### PR TITLE
[codex] Lower MIR string interpolation via ConcatN

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -433,10 +433,10 @@ func (g *mirGen) checkSupported() error {
 			}
 			if !g.typeSupported(loc.Type) {
 				hint := localDefiningSiteHint(fn, loc.ID)
-			if hint != "" {
-				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint))
-			}
-			return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID))
+				if hint != "" {
+					return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint))
+				}
+				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID))
 			}
 		}
 		if fn.ReturnType != nil && !g.typeSupported(fn.ReturnType) {
@@ -4116,9 +4116,7 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		if len(i.Args) == 0 {
 			return unsupported("mir-mvp", "string_concat with no args")
 		}
-		sym := llvmStringRuntimeConcatSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
-		var acc *LlvmValue
+		parts := make([]*LlvmValue, 0, len(i.Args))
 		for idx, op := range i.Args {
 			if !isStringLLVMType(op.Type()) {
 				// String interpolation embeds non-String values
@@ -4133,31 +4131,30 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 				if boxed == nil {
 					return unsupported("mir-mvp", fmt.Sprintf("string_concat arg %d type %s", idx+1, mirTypeString(op.Type())))
 				}
-				if acc == nil {
-					acc = boxed
-					continue
-				}
-				em := g.ostyEmitter()
-				acc = llvmStringConcat(em, acc, boxed)
-				g.flushOstyEmitter(em)
+				parts = append(parts, boxed)
 				continue
 			}
 			partReg, err := g.evalOperand(op, op.Type())
 			if err != nil {
 				return err
 			}
-			part := &LlvmValue{typ: "ptr", name: partReg}
-			if acc == nil {
-				acc = part
-				continue
-			}
-			em := g.ostyEmitter()
-			acc = llvmStringConcat(em, acc, part)
-			g.flushOstyEmitter(em)
+			parts = append(parts, &LlvmValue{typ: "ptr", name: partReg})
 		}
-		if acc == nil {
+		if len(parts) == 0 {
 			return unsupported("mir-mvp", "string_concat produced no value")
 		}
+		if len(parts) >= 3 {
+			return g.storeIntrinsicResult(i, g.emitStringConcatN(parts))
+		}
+		if len(parts) == 2 {
+			sym := llvmStringRuntimeConcatSymbol()
+			g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+			em := g.ostyEmitter()
+			out := llvmStringConcat(em, parts[0], parts[1])
+			g.flushOstyEmitter(em)
+			return g.storeIntrinsicResult(i, out)
+		}
+		acc := parts[0]
 		return g.storeIntrinsicResult(i, acc)
 	}
 	if len(i.Args) < 1 {
@@ -4290,6 +4287,23 @@ func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: partsReg}, {typ: "ptr", name: sepReg}})
 	g.flushOstyEmitter(em)
 	return g.storeIntrinsicResult(i, result)
+}
+
+func (g *mirGen) emitStringConcatN(parts []*LlvmValue) *LlvmValue {
+	sym := "osty_rt_strings_ConcatN"
+	g.declareRuntime(sym, "declare ptr @"+sym+"(i64, ptr)")
+	em := g.ostyEmitter()
+	arr := llvmNextTemp(em)
+	em.body = append(em.body, fmt.Sprintf("  %s = alloca [%d x ptr]", arr, len(parts)))
+	for i, part := range parts {
+		slot := llvmNextTemp(em)
+		em.body = append(em.body, fmt.Sprintf("  %s = getelementptr [%d x ptr], ptr %s, i64 0, i64 %d", slot, len(parts), arr, i))
+		em.body = append(em.body, fmt.Sprintf("  store ptr %s, ptr %s", part.name, slot))
+	}
+	out := llvmNextTemp(em)
+	em.body = append(em.body, fmt.Sprintf("  %s = call ptr @%s(i64 %d, ptr %s)", out, sym, len(parts), arr))
+	g.flushOstyEmitter(em)
+	return &LlvmValue{typ: "ptr", name: out}
 }
 
 // emitStringConcatBoxed converts a non-String operand into a String

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2773,11 +2773,55 @@ func TestGenerateFromMIRStringInterpolationConcat(t *testing.T) {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
 	got := string(out)
-	if !strings.Contains(got, "declare ptr @osty_rt_strings_Concat(ptr, ptr)") {
-		t.Fatalf("missing string concat runtime decl in:\n%s", got)
+	if !strings.Contains(got, "declare ptr @osty_rt_strings_ConcatN(i64, ptr)") {
+		t.Fatalf("missing string concat_n runtime decl in:\n%s", got)
 	}
-	if strings.Count(got, "call ptr @osty_rt_strings_Concat(") != 2 {
-		t.Fatalf("expected two concat calls in:\n%s", got)
+	if strings.Count(got, "call ptr @osty_rt_strings_ConcatN(") != 1 {
+		t.Fatalf("expected one concat_n call in:\n%s", got)
+	}
+	if strings.Contains(got, "call ptr @osty_rt_strings_Concat(") {
+		t.Fatalf("did not expect chained concat calls in:\n%s", got)
+	}
+}
+
+func TestGenerateFromMIRStringInterpolationConcatBoxesScalars(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "render",
+		Return: ir.TString,
+		Params: []*ir.Param{
+			{Name: "n", Type: ir.TInt},
+			{Name: "ok", Type: ir.TBool},
+		},
+		Body: &ir.Block{
+			Result: &ir.StringLit{
+				Parts: []ir.StringPart{
+					{Expr: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt}},
+					{IsLit: true, Lit: ":"},
+					{Expr: &ir.Ident{Name: "ok", Kind: ir.IdentParam, T: ir.TBool}},
+				},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_concat_scalars.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare ptr @osty_rt_bool_to_string(i1)",
+		"call ptr @osty_rt_int_to_string(",
+		"call ptr @osty_rt_bool_to_string(",
+		"call ptr @osty_rt_strings_ConcatN(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "call ptr @osty_rt_strings_Concat(") {
+		t.Fatalf("did not expect chained concat calls in:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- lower MIR `string_concat` with 3 or more parts through `osty_rt_strings_ConcatN`
- keep two-part concatenations on the existing `Concat` helper
- add MIR regression tests for both pure-string and scalar-boxing interpolation paths

## Why
The AST llvmgen path already lowered multi-part string interpolation to a single `ConcatN` call, but the MIR path still emitted chained two-arg `Concat` calls. That meant extra intermediate string allocations on hot interpolation sites even after the runtime had a one-shot concat helper.

## Impact
This makes MIR-generated code use the same one-allocation concat strategy for 3+ part interpolations. On a clean `main`-based validation worktree with `--benchtime 400ms`:
- `record_pipeline`: `30943ns -> 29919ns`
- `word_freq`: `22366ns -> 21304ns`

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIRStringInterpolationConcat|TestGenerateFromMIRStringInterpolationConcatBoxesScalars'`
- `go build -o .bin/osty ./cmd/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/record_pipeline/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/word_freq/osty`