### PR TITLE
[codex] Speed up string ordering comparisons

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -2545,10 +2545,6 @@ static inline size_t osty_rt_string_hash(const char *value) {
 }
 
 static int osty_rt_string_compare_bytes(const char *left, const char *right) {
-    size_t left_len = 0;
-    size_t right_len = 0;
-    size_t common = 0;
-    int cmp = 0;
     if (left == right) {
         return 0;
     }
@@ -2558,22 +2554,7 @@ static int osty_rt_string_compare_bytes(const char *left, const char *right) {
     if (right == NULL) {
         return 1;
     }
-    osty_rt_string_measure(left, &left_len, NULL);
-    osty_rt_string_measure(right, &right_len, NULL);
-    common = (left_len < right_len) ? left_len : right_len;
-    if (common != 0) {
-        cmp = memcmp(left, right, common);
-        if (cmp != 0) {
-            return cmp;
-        }
-    }
-    if (left_len < right_len) {
-        return -1;
-    }
-    if (left_len > right_len) {
-        return 1;
-    }
-    return 0;
+    return strcmp(left, right);
 }
 
 static size_t osty_rt_map_key_hash(int64_t kind, const void *key) {


### PR DESCRIPTION
## Summary
- simplify runtime string ordering comparisons to use `strcmp`
- remove the extra length-measure + prefix `memcmp` path from the shared compare helper

## Why
The runtime string ordering helper is used by `List<String>.sorted()` and `strings.compare`. The old path measured both strings up front, compared the common prefix with `memcmp`, then only decided on length after that. For the benchmark workloads we care about, especially sorted map-key passes, that was more work than necessary in the common mismatch case.

## Impact
This keeps the semantics but lets the runtime hand the whole ordering decision to `strcmp`, which is a better fit for hot string-key sorting paths.

On the latest pre-change runtime state with the same `--benchtime 400ms`:
- `record_pipeline`: `26705ns -> 25167ns`
- `word_freq`: `19704ns -> 16476ns`

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntimeStringsHelpersPreserveSemantics'`
- `go build -o .bin/osty ./cmd/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/record_pipeline/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/word_freq/osty`