### PR TITLE
fix(llvmgen): match-arm empty list literal inherits sibling List<T> hint

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1652,6 +1652,14 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 	if len(expr.Arms) == 0 {
 		return value{}, unsupported("expression", "match with no arms")
 	}
+	// Pre-scan arms for a typed List<T> source so a sibling bare `[]` arm
+	// body inherits the element type instead of walling on LLVM013. Push
+	// once here and every sub-emitter (tag / payload / result / optional /
+	// guarded) inherits the hint through g.matchArmListHints.
+	if hint, ok := g.inferMatchArmsListHint(expr.Arms); ok {
+		g.pushMatchArmListHint(hint)
+		defer g.popMatchArmListHint()
+	}
 	scrutinee, err := g.emitExpr(expr.Scrutinee)
 	if err != nil {
 		return value{}, err
@@ -6626,6 +6634,64 @@ func (g *generator) matchPayloadEnumPattern(info *enumInfo, pattern ast.Pattern)
 	}
 }
 
+// listElemHint carries the LLVM-level element type + String-pointer flag
+// for a List<T> shape inferred from surrounding context. Pushed on
+// g.matchArmListHints during match-expression arm emission so a bare
+// empty-list arm body can pick up its element type from a sibling arm
+// (or from an outer expected-type hint), instead of walling on LLVM013
+// "empty list literal requires explicit List<T>".
+type listElemHint struct {
+	elemTyp    string
+	elemString bool
+}
+
+func (g *generator) pushMatchArmListHint(hint listElemHint) {
+	g.matchArmListHints = append(g.matchArmListHints, hint)
+}
+
+func (g *generator) popMatchArmListHint() {
+	if n := len(g.matchArmListHints); n > 0 {
+		g.matchArmListHints = g.matchArmListHints[:n-1]
+	}
+}
+
+func (g *generator) currentMatchArmListHint() (listElemHint, bool) {
+	if n := len(g.matchArmListHints); n > 0 {
+		h := g.matchArmListHints[n-1]
+		if h.elemTyp == "" {
+			return listElemHint{}, false
+		}
+		return h, true
+	}
+	return listElemHint{}, false
+}
+
+// inferMatchArmsListHint scans arm bodies for a ListExpr whose source
+// type resolves to `List<T>` with a known element IR type. Returns the
+// first hint found; siblings with bare `[]` can then adopt it via
+// pushMatchArmListHint on the surrounding match-expr emitter.
+func (g *generator) inferMatchArmsListHint(arms []*ast.MatchArm) (listElemHint, bool) {
+	for _, arm := range arms {
+		if arm == nil {
+			continue
+		}
+		body := arm.Body
+		if block, ok := body.(*ast.Block); ok && len(block.Stmts) > 0 {
+			if tail, ok := block.Stmts[len(block.Stmts)-1].(*ast.ExprStmt); ok && tail != nil {
+				body = tail.X
+			}
+		}
+		src, ok := g.staticExprSourceType(body)
+		if !ok || src == nil {
+			continue
+		}
+		if elemTyp, elemString, ok, err := llvmListElementInfo(src, g.typeEnv()); err == nil && ok && elemTyp != "" {
+			return listElemHint{elemTyp: elemTyp, elemString: elemString}, true
+		}
+	}
+	return listElemHint{}, false
+}
+
 func (g *generator) emitMatchArmBodyValue(expr ast.Expr) (value, error) {
 	switch e := expr.(type) {
 	case *ast.Block:
@@ -6633,6 +6699,14 @@ func (g *generator) emitMatchArmBodyValue(expr ast.Expr) (value, error) {
 		defer g.popScope()
 		return g.emitBlockValue(e)
 	default:
+		// Empty-list arm body: adopt the sibling hint (if a push has been
+		// done by the enclosing match-expr emitter) so the LLVM013 wall
+		// on `_ -> []` against a typed List<T> arm stays closed.
+		if list, ok := expr.(*ast.ListExpr); ok && len(list.Elems) == 0 {
+			if hint, ok := g.currentMatchArmListHint(); ok {
+				return g.emitListExprWithHint(list, nil, hint.elemTyp, hint.elemString)
+			}
+		}
 		return g.emitExpr(expr)
 	}
 }

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -83,6 +83,12 @@ type generator struct {
 	currentReachable     bool
 	resultContexts       []builtinResultContext
 	optionContexts       []builtinOptionContext
+	// matchArmListHints is the push/pop stack of list-element hints active
+	// during match-expression arm emission. Sibling arms that return a
+	// typed list (e.g. `rhsT.tupleElems: List<HirType>`) seed the hint so
+	// a bare `[]` in another arm picks up the same element type instead of
+	// walling on LLVM013 "empty list literal requires explicit List<T>".
+	matchArmListHints []listElemHint
 
 	needsGCRuntime bool
 	gcRootSlots    []value
@@ -210,6 +216,7 @@ func (g *generator) beginFunction() {
 	g.loopStack = nil
 	g.resultContexts = nil
 	g.optionContexts = nil
+	g.matchArmListHints = nil
 	g.deferStack = [][]*ast.DeferStmt{nil}
 	g.vectorizeHint = false
 	g.vectorizeWidth = 0

--- a/internal/llvmgen/match_arm_empty_list_test.go
+++ b/internal/llvmgen/match_arm_empty_list_test.go
@@ -1,0 +1,82 @@
+package llvmgen
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestMatchArmEmptyListInheritsSiblingHint verifies the sibling-arm list
+// element hint propagation added to emitMatchExprValue. Before the fix,
+// a match expression like
+//
+//	let xs = match tag {
+//	    Tuple -> typedList,
+//	    _     -> [],
+//	}
+//
+// walled on LLVM013 "empty list literal requires an explicit List<T>
+// type" because emitMatchArmBodyValue emitted the `_ -> []` arm with no
+// hint. The fix pre-scans arms in emitMatchExprValue, pushes the
+// inferred List<T> element onto g.matchArmListHints, and the empty-arm
+// body reads it back off the stack.
+//
+// This is the exact shape that toolchain/mir_lower.osty:2369 produces
+// and that tripped the merged-toolchain AST probe on main at
+// 4eccfe8.
+func TestMatchArmEmptyListInheritsSiblingHint(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "int_list_sibling",
+			src: `pub struct Holder { pub xs: List<Int> }
+pub fn pick(tag: Int, src: Holder) -> List<Int> {
+    match tag {
+        0 -> src.xs,
+        _ -> [],
+    }
+}
+fn main() {}
+`,
+		},
+		{
+			name: "string_list_sibling",
+			src: `pub struct Holder { pub xs: List<String> }
+pub fn pick(tag: Int, src: Holder) -> List<String> {
+    match tag {
+        0 -> src.xs,
+        _ -> [],
+    }
+}
+fn main() {}
+`,
+		},
+		{
+			name: "let_binding_no_annotation",
+			src: `pub struct Holder { pub xs: List<Int> }
+pub fn pick(tag: Int, src: Holder) -> Int {
+    let xs = match tag {
+        0 -> src.xs,
+        _ -> [],
+    }
+    xs.len()
+}
+fn main() {}
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			file, diags := parser.ParseDiagnostics([]byte(c.src))
+			if len(diags) > 0 {
+				t.Fatalf("parse: %v", diags[0])
+			}
+			_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/" + c.name + ".osty"})
+			if err != nil {
+				t.Fatalf("expected clean lowering, got wall: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a sibling-arm list-element hint propagation pass to `emitMatchExprValue` so a bare `_ -> []` arm body stops walling on LLVM013 when another arm returns a typed list.
- Closes the merged-probe first wall at `toolchain/mir_lower.osty:2369` (offset 1495048) — `let elemTs = match rhsT.kind { HirTypeTuple -> rhsT.tupleElems, _ -> [] }`.
- Ratchets the fix with a 3-case regression test covering `List<Int>` / `List<String>` siblings and a no-annotation let binding.

## Why

The `let elemTs = ...` binding carries no type annotation, so the AST emitter has no external hint for the empty arm. The checker's inferred `List<HirType>` never reaches the AST emitter (that info lives in `check.Result`, which `generateFromAST` doesn't read). Bridge the gap via the sibling arm that DOES have a static source type.

## How

New push/pop stack on `generator`:

- `matchArmListHints []listElemHint` — follows the `resultContexts` / `optionContexts` pattern
- `emitMatchExprValue` pre-scans arms once via `inferMatchArmsListHint`, pushes the hint, defers pop
- Every sub-emitter (tag / payload / result / optional / guarded) inherits the hint through the stack
- `emitMatchArmBodyValue`: on empty `*ast.ListExpr` body, route through `emitListExprWithHint` using the top hint

The scan unwraps trailing `Block` expressions so `_ -> { xs }` arms also contribute their source type.

## Probe deltas

| Probe | Before | After |
|---|---|---|
| `TestProbeWholeToolchainMerged` | `LLVM013 empty list literal at 46251:14` | `LLVM011 compare type mismatch i32/ptr` (new pre-existing wall exposed) |
| `TestProbeNativeToolchainMerged` | same | same |
| `TestNativeToolchainMergedMIRPipelineIsClean` | FAIL (empty list) | FAIL (i32/ptr compare — different root cause) |

The MIR fast-path still refuses — it trips on a sibling-arm issue that the new AST hint doesn't help with — but the legacy fallback now reaches further before failing.

## Out of scope

- `i32/ptr` compare wall: distinct type-confusion bug.
- MIR-direct empty-list hint propagation: separate fix that should mirror this one inside `toolchain/mir_lower.osty` / `internal/mir/lower.go`.

## Test plan

- [x] `TestMatchArmEmptyListInheritsSiblingHint` (new, 3 sub-cases) — passes
- [x] `TestProbeWholeToolchainMerged` / `TestProbeNativeToolchainMerged` advance past the empty-list wall
- [x] Front-end (`just front`) — lexer/resolve `TestResolve{UndefinedLoopLabel,LoopLabelShadow}` failures pre-exist on main (stash-verified, tied to `#664` G24 label work), unrelated to this PR
- [x] Regression site at `toolchain/mir_lower.osty:2369` lowers cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)