### PR TITLE
feat(selfhost): HIR lowerer annotation extractors + builder classifier (Stage 5b)

### DIFF
--- a/toolchain/hir.osty
+++ b/toolchain/hir.osty
@@ -3423,3 +3423,83 @@ pub fn hirProjectionKindName(k: HirProjectionKind) -> String {
         HirProjVariantN -> "variantN",
     }
 }
+
+// ====================================================================
+// Annotation bridge types (for hir_lower.osty extraction helpers)
+// ====================================================================
+//
+// HIR nodes themselves never carry `HirAnnotation` values — AST-level
+// annotations (`#[vectorize(...)]`, `#[json(...)]`, `#[export("…")]`
+// etc.) are extracted into concrete fields on the decl during
+// AST→HIR lowering (FnDecl.Vectorize, Field.JSONKey, …).
+//
+// `HirAnnotation` + `HirAnnotationArg` exist as a shared bridge
+// type: the AST→HIR lowerer builds a `List<HirAnnotation>` from its
+// input (whatever the Osty front-end's annotation representation is)
+// and hands it to the extractors below. Keeping the extractors
+// independent of the specific AST arena shape lets them be unit-
+// tested in isolation and reused as the front-end evolves.
+
+/// HirAnnotation is a single `#[name(args)]` attribute. `name` is
+/// the bare identifier (e.g. `"vectorize"`, `"export"`).
+pub struct HirAnnotation {
+    pub name: String,
+    pub args: List<HirAnnotationArg>,
+    pub span: HirSpan,
+}
+
+pub fn hirAnnotation(name: String, span: HirSpan) -> HirAnnotation {
+    HirAnnotation { name, args: [], span }
+}
+
+/// HirAnnotationArg is one argument of an annotation. Three shapes
+/// appear in practice:
+///
+///   - bare identifier: `scalable` / `predicate` / `always` — `key`
+///     is the identifier text, `hasValue` is false
+///   - key = value: `width = 4` / `count = 8` / `key = "…"` — `key`
+///     is the LHS identifier, `hasValue` is true with the RHS in
+///     `value`
+///   - positional literal: `"name"` in `#[export("name")]` — `key`
+///     is empty, `hasValue` is true with the literal in `value`
+///
+/// `value` is a `HirExpr` so annotation-argument literals reuse the
+/// existing HIR literal nodes; malformed values (resolver should
+/// have rejected them) fall through as `HirExprInvalid`.
+pub struct HirAnnotationArg {
+    pub key: String,
+    pub hasValue: Bool,
+    pub value: HirExpr,
+    pub span: HirSpan,
+}
+
+pub fn hirAnnotationArgFlag(key: String, span: HirSpan) -> HirAnnotationArg {
+    HirAnnotationArg {
+        key,
+        hasValue: false,
+        value: hirExprInvalid(),
+        span,
+    }
+}
+
+pub fn hirAnnotationArgKeyValue(
+    key: String,
+    value: HirExpr,
+    span: HirSpan,
+) -> HirAnnotationArg {
+    HirAnnotationArg {
+        key,
+        hasValue: true,
+        value,
+        span,
+    }
+}
+
+pub fn hirAnnotationArgPositional(value: HirExpr, span: HirSpan) -> HirAnnotationArg {
+    HirAnnotationArg {
+        key: "",
+        hasValue: true,
+        value,
+        span,
+    }
+}

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -310,3 +310,428 @@ pub fn hirLowerLast(xs: List<String>) -> String {
     }
     xs[xs.len() - 1]
 }
+
+// ====================================================================
+// Annotation extraction (Stage 5b)
+// ====================================================================
+//
+// These mirror Go `lower.go` helpers verbatim. Each reads a
+// `List<HirAnnotation>` and returns the concrete-field form that
+// HirFnDecl / HirField / HirVariant / HirStructDecl already carries
+// (Vectorize: Bool, VectorizeWidth: Int, ExportSymbol: String,
+// JSONKey: String etc.).
+//
+// Callers get these by walking the AST's annotation list once into
+// `List<HirAnnotation>` and then invoking the relevant extractors.
+
+/// hirLowerHasNamedAnnotation reports whether the list contains a
+/// `#[name]` annotation. Used for bare-flag shapes (c_abi / no_alloc
+/// / intrinsic / parallel / pure / hot / cold / no_vectorize).
+pub fn hirLowerHasNamedAnnotation(annots: List<HirAnnotation>, name: String) -> Bool {
+    for a in annots {
+        if a.name == name {
+            return true
+        }
+    }
+    false
+}
+
+/// hirLowerExtractInlineMode resolves the v0.6 A8 `#[inline]`
+/// family:
+///   - no annotation            → HirInlineNone
+///   - `#[inline]`              → HirInlineSoft
+///   - `#[inline(always)]`      → HirInlineAlways
+///   - `#[inline(never)]`       → HirInlineNever
+///
+/// Mirrors Go's `extractInlineMode`. The resolver is the
+/// authoritative validator for malformed arg shapes; we only read
+/// well-formed cases here.
+pub fn hirLowerExtractInlineMode(annots: List<HirAnnotation>) -> HirInlineMode {
+    for a in annots {
+        if a.name == "inline" {
+            if a.args.len() == 0 {
+                return HirInlineSoft
+            }
+            for arg in a.args {
+                if arg.key == "always" {
+                    return HirInlineAlways
+                }
+                if arg.key == "never" {
+                    return HirInlineNever
+                }
+            }
+            return HirInlineSoft
+        }
+    }
+    HirInlineNone
+}
+
+/// hirLowerExtractNoaliasArgs reads `#[noalias]` / `#[noalias(p1,
+/// p2)]` and returns (allParams, names):
+///   - absent              → (false, [])
+///   - `#[noalias]`        → (true, [])
+///   - `#[noalias(p, q)]`  → (false, [p, q])
+///
+/// Bool is emitted first in the returned struct so callers can
+/// match the Go signature order.
+pub struct HirLowerNoaliasInfo {
+    pub all: Bool,
+    pub names: List<String>,
+}
+
+pub fn hirLowerExtractNoaliasArgs(annots: List<HirAnnotation>) -> HirLowerNoaliasInfo {
+    for a in annots {
+        if a.name == "noalias" {
+            if a.args.len() == 0 {
+                return HirLowerNoaliasInfo { all: true, names: [] }
+            }
+            let mut names: List<String> = []
+            for arg in a.args {
+                if arg.key != "" {
+                    names.push(arg.key)
+                }
+            }
+            return HirLowerNoaliasInfo { all: false, names }
+        }
+    }
+    HirLowerNoaliasInfo { all: false, names: [] }
+}
+
+/// hirLowerExtractTargetFeatures reads every bare-identifier
+/// argument from the `#[target_feature(...)]` annotations and
+/// returns them in source order. Empty keys are skipped (the
+/// resolver rejects malformed names).
+pub fn hirLowerExtractTargetFeatures(annots: List<HirAnnotation>) -> List<String> {
+    let mut out: List<String> = []
+    for a in annots {
+        if a.name == "target_feature" {
+            for arg in a.args {
+                if arg.key != "" {
+                    out.push(arg.key)
+                }
+            }
+        }
+    }
+    out
+}
+
+/// hirLowerExtractVectorizeArgs reads `#[vectorize(...)]` metadata
+/// and returns (enable, width, scalable, predicate). `enable` tracks
+/// presence; three flags come from the arg list. Matches Go's
+/// `extractVectorizeArgs`.
+pub struct HirLowerVectorizeInfo {
+    pub enable: Bool,
+    pub width: Int,
+    pub scalable: Bool,
+    pub predicate: Bool,
+}
+
+pub fn hirLowerExtractVectorizeArgs(annots: List<HirAnnotation>) -> HirLowerVectorizeInfo {
+    let mut out = HirLowerVectorizeInfo {
+        enable: false,
+        width: 0,
+        scalable: false,
+        predicate: false,
+    }
+    for a in annots {
+        if a.name == "vectorize" {
+            out.enable = true
+            for arg in a.args {
+                if arg.key == "scalable" {
+                    out.scalable = true
+                } else if arg.key == "predicate" {
+                    out.predicate = true
+                } else if arg.key == "width" {
+                    if arg.hasValue {
+                        let parsed = hirLowerParseAnnotationInt(arg.value)
+                        if parsed.ok && parsed.value >= 0 {
+                            out.width = parsed.value
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// hirLowerExtractUnrollArgs reads `#[unroll]` / `#[unroll(count =
+/// N)]` and returns (enable, count). `count == 0` marks the bare
+/// form; a positive value is the fixed factor.
+pub struct HirLowerUnrollInfo {
+    pub enable: Bool,
+    pub count: Int,
+}
+
+pub fn hirLowerExtractUnrollArgs(annots: List<HirAnnotation>) -> HirLowerUnrollInfo {
+    let mut out = HirLowerUnrollInfo { enable: false, count: 0 }
+    for a in annots {
+        if a.name == "unroll" {
+            out.enable = true
+            for arg in a.args {
+                if arg.key == "count" && arg.hasValue {
+                    let parsed = hirLowerParseAnnotationInt(arg.value)
+                    if parsed.ok && parsed.value >= 0 {
+                        out.count = parsed.value
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// hirLowerExtractExportSymbol reads the `#[export("name")]`
+/// annotation and returns the literal string. Empty for missing /
+/// malformed (malformed cases are already rejected by the resolver;
+/// we only pick up well-formed shapes).
+pub fn hirLowerExtractExportSymbol(annots: List<HirAnnotation>) -> String {
+    for a in annots {
+        if a.name == "export" && a.args.len() == 1 {
+            let arg = a.args[0]
+            if arg.key == "" && arg.hasValue {
+                let parsed = hirLowerAnnotationStringLit(arg.value)
+                if parsed.ok {
+                    return parsed.value
+                }
+            }
+        }
+    }
+    ""
+}
+
+// ---- json(...) options -------------------------------------------
+
+/// HirLowerJsonFieldInfo carries the extracted `#[json(...)]` flags
+/// for a struct field: `key = "..."` override, `skip` flag, and
+/// `optional` flag.
+pub struct HirLowerJsonFieldInfo {
+    pub key: String,
+    pub skip: Bool,
+    pub optional: Bool,
+}
+
+pub fn hirLowerJsonFieldOptions(annots: List<HirAnnotation>) -> HirLowerJsonFieldInfo {
+    let mut out = HirLowerJsonFieldInfo { key: "", skip: false, optional: false }
+    for a in annots {
+        if a.name == "json" {
+            for arg in a.args {
+                if arg.key == "skip" {
+                    out.skip = true
+                } else if arg.key == "optional" {
+                    out.optional = true
+                } else if arg.key == "key" && arg.hasValue {
+                    let parsed = hirLowerAnnotationStringLit(arg.value)
+                    if parsed.ok {
+                        out.key = parsed.value
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// HirLowerJsonVariantInfo carries the extracted `#[json(...)]`
+/// flags for an enum variant: discriminator `tag` override via
+/// `key = "..."`, and `skip` flag.
+pub struct HirLowerJsonVariantInfo {
+    pub tag: String,
+    pub skip: Bool,
+}
+
+pub fn hirLowerJsonVariantOptions(annots: List<HirAnnotation>) -> HirLowerJsonVariantInfo {
+    let mut out = HirLowerJsonVariantInfo { tag: "", skip: false }
+    for a in annots {
+        if a.name == "json" {
+            for arg in a.args {
+                if arg.key == "skip" {
+                    out.skip = true
+                } else if arg.key == "key" && arg.hasValue {
+                    let parsed = hirLowerAnnotationStringLit(arg.value)
+                    if parsed.ok {
+                        out.tag = parsed.value
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+// ---- Literal parsing helpers -------------------------------------
+
+/// HirLowerIntParse is a (value, ok) pair. Osty doesn't yet have
+/// tuple returns in our convention, so we use a small struct.
+pub struct HirLowerIntParse {
+    pub value: Int,
+    pub ok: Bool,
+}
+
+/// hirLowerParseAnnotationInt consumes an IntLit-shaped HirExpr
+/// and returns a (value, ok) pair. Supports the full Osty numeric
+/// grammar (decimal, hex, binary, octal, underscores). Returns
+/// `ok=false` for non-IntLit expressions or unparseable text.
+pub fn hirLowerParseAnnotationInt(e: HirExpr) -> HirLowerIntParse {
+    let isIntLit = match e.kind {
+        HirExprIntLit -> true,
+        _ -> false,
+    }
+    if !isIntLit {
+        return HirLowerIntParse { value: 0, ok: false }
+    }
+    let stripped = hirLowerStripUnderscores(e.numText)
+    if stripped.len() == 0 {
+        return HirLowerIntParse { value: 0, ok: false }
+    }
+    let text = hirLowerStripSign(stripped)
+    let negative = stripped.startsWith("-")
+    if text.len() == 0 {
+        return HirLowerIntParse { value: 0, ok: false }
+    }
+    let mut body = text
+    let mut base = 10
+    if text.startsWith("0x") || text.startsWith("0X") {
+        base = 16
+        body = text.substring(2, text.len())
+    } else if text.startsWith("0o") || text.startsWith("0O") {
+        base = 8
+        body = text.substring(2, text.len())
+    } else if text.startsWith("0b") || text.startsWith("0B") {
+        base = 2
+        body = text.substring(2, text.len())
+    }
+    if body.len() == 0 {
+        return HirLowerIntParse { value: 0, ok: false }
+    }
+    let mut acc = 0
+    let chars = body.chars()
+    for ch in chars {
+        let d = hirLowerCharToDigit(ch)
+        if d < 0 || d >= base {
+            return HirLowerIntParse { value: 0, ok: false }
+        }
+        acc = acc * base + d
+    }
+    if negative {
+        acc = 0 - acc
+    }
+    HirLowerIntParse { value: acc, ok: true }
+}
+
+/// HirLowerStringParse is a (value, ok) pair for literal-only
+/// StringLit extraction.
+pub struct HirLowerStringParse {
+    pub value: String,
+    pub ok: Bool,
+}
+
+/// hirLowerAnnotationStringLit extracts a simple (non-interpolated)
+/// String literal from an annotation arg value. Interpolated forms
+/// are rejected — annotation args must be literals.
+pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
+    let isStringLit = match e.kind {
+        HirExprStringLit -> true,
+        _ -> false,
+    }
+    if !isStringLit {
+        return HirLowerStringParse { value: "", ok: false }
+    }
+    let mut buf: List<String> = []
+    for part in e.strParts {
+        if !part.isLit {
+            return HirLowerStringParse { value: "", ok: false }
+        }
+        buf.push(part.lit)
+    }
+    HirLowerStringParse { value: strings.join(buf, ""), ok: true }
+}
+
+// ---- Internal digit helpers --------------------------------------
+
+fn hirLowerStripUnderscores(text: String) -> String {
+    let mut buf: List<String> = []
+    let chars = text.chars()
+    for ch in chars {
+        if ch != "_" {
+            buf.push(ch)
+        }
+    }
+    strings.join(buf, "")
+}
+
+fn hirLowerStripSign(text: String) -> String {
+    if text.startsWith("+") || text.startsWith("-") {
+        text.substring(1, text.len())
+    } else {
+        text
+    }
+}
+
+fn hirLowerCharToDigit(ch: String) -> Int {
+    match ch {
+        "0" -> 0, "1" -> 1, "2" -> 2, "3" -> 3, "4" -> 4,
+        "5" -> 5, "6" -> 6, "7" -> 7, "8" -> 8, "9" -> 9,
+        "a" -> 10, "A" -> 10,
+        "b" -> 11, "B" -> 11,
+        "c" -> 12, "C" -> 12,
+        "d" -> 13, "D" -> 13,
+        "e" -> 14, "E" -> 14,
+        "f" -> 15, "F" -> 15,
+        _ -> -1,
+    }
+}
+
+// ====================================================================
+// Builder-derive classification
+// ====================================================================
+
+/// HirLowerBuilderInfo is the result of classifying whether a struct
+/// qualifies for auto-derived builder codegen (LANG_SPEC §3.3).
+///
+/// `derivable` is true only when every non-pub field has a default —
+/// the builder chain lets callers omit non-pub fields, so they must
+/// have a default to fall back on. `required` lists the names of
+/// `pub` fields without a default, in source order — callers use
+/// this list for the compile-time error when `.build()` is called
+/// with missing fields (G9).
+pub struct HirLowerBuilderInfo {
+    pub derivable: Bool,
+    pub required: List<String>,
+}
+
+/// hirLowerClassifyBuilderDerive inspects a struct's field list and
+/// produces (derivable, requiredPubFields). Mirrors Go's
+/// `classifyBuilderDerive`.
+///
+/// Takes a parallel list of (name, exported, hasDefault) tuples
+/// rather than `List<HirField>` to avoid assuming the field's HIR
+/// Expr default is lowered yet — the classifier runs before body
+/// lowering completes. Callers build the input by walking their
+/// struct's AST-level field list.
+pub fn hirLowerClassifyBuilderDerive(
+    names: List<String>,
+    exported: List<Bool>,
+    hasDefaults: List<Bool>,
+) -> HirLowerBuilderInfo {
+    let n = names.len()
+    if n != exported.len() || n != hasDefaults.len() {
+        return HirLowerBuilderInfo { derivable: false, required: [] }
+    }
+    let mut derivable = true
+    let mut required: List<String> = []
+    let mut i = 0
+    for i < n {
+        let isPub = exported[i]
+        let hasDefault = hasDefaults[i]
+        if !isPub && !hasDefault {
+            // Private field without a default — builder can't emit.
+            derivable = false
+        }
+        if isPub && !hasDefault {
+            required.push(names[i])
+        }
+        i = i + 1
+    }
+    HirLowerBuilderInfo { derivable, required }
+}


### PR DESCRIPTION
## Summary

Second chunk of the `internal/ir/lower.go` port. Adds the annotation-extraction helpers + builder-derive classifier that Stage 5c's decl lowerers will consume.

File deltas:
- [toolchain/hir.osty](toolchain/hir.osty): +83 lines (HirAnnotation data model)
- [toolchain/hir_lower.osty](toolchain/hir_lower.osty): +422 lines (extractors + helpers)

## HirAnnotation data model

Added to `hir.osty`:
- `HirAnnotation` — name + args + span
- `HirAnnotationArg` — `key` (identifier) + `hasValue` + `value: HirExpr` + span. Covers three arg shapes:
  - bare identifier (`scalable` / `predicate` / `always`)
  - key = value (`width = 4` / `count = 8` / `key = "…"`)
  - positional literal (`"name"` in `#[export("name")]`)
- Constructors: `hirAnnotation`, `hirAnnotationArgFlag`, `hirAnnotationArgKeyValue`, `hirAnnotationArgPositional`

HIR nodes never carry `HirAnnotation` values themselves — annotations lower into concrete fields on decls (FnDecl.Vectorize, Field.JSONKey etc.). HirAnnotation is a shared bridge type the AST→HIR lowerer builds and hands to the extractors.

## Annotation extractors

Full set ported from `lower.go`:

| Extractor | Input | Output |
|---|---|---|
| `hirLowerHasNamedAnnotation` | list + name | Bool (bare-flag presence) |
| `hirLowerExtractInlineMode` | list | `HirInlineMode` (None/Soft/Always/Never) |
| `hirLowerExtractNoaliasArgs` | list | `{ all, names }` |
| `hirLowerExtractTargetFeatures` | list | `List<String>` in source order |
| `hirLowerExtractVectorizeArgs` | list | `{ enable, width, scalable, predicate }` |
| `hirLowerExtractUnrollArgs` | list | `{ enable, count }` |
| `hirLowerExtractExportSymbol` | list | `String` |

## JSON option extractors

- `hirLowerJsonFieldOptions` — struct-field `#[json(...)]` → `{ key, skip, optional }`
- `hirLowerJsonVariantOptions` — enum-variant `#[json(...)]` → `{ tag, skip }`

## Literal parsing

- `hirLowerParseAnnotationInt` — IntLit HirExpr → `{ value, ok }`. Handles decimal / 0x / 0b / 0o + underscores + optional leading sign
- `hirLowerAnnotationStringLit` — StringLit HirExpr → `{ value, ok }`. Interpolated forms rejected

## Builder-derive classifier

`hirLowerClassifyBuilderDerive` — "can this struct get an auto-derived builder?" (LANG_SPEC §3.3). Takes parallel `(name, exported, hasDefault)` lists rather than `List<HirField>` so callers can drive it from AST field lists before HIR field defaults are lowered.

Returns `{ derivable, required }`:
- `derivable: false` iff any non-pub field lacks a default
- `required`: ordered list of pub field names without defaults — the G9 "missing field on `.build()`" error list

## Verification

- `osty parse toolchain/hir.osty` → exit 0
- `osty parse toolchain/hir_lower.osty` → exit 0
- `osty check toolchain/hir_lower.osty` → zero errors

## Remaining

| Stage | Scope |
|---|---|
| 5c | Decl shell lowerers (FnDecl / StructDecl / EnumDecl / LetDecl / UseDecl / InterfaceDecl / TypeAliasDecl) |
| 5d | Stmt lowering |
| 5e | Expr lowering |
| 5f | `pmCompileDecisionTree` integration into MatchStmt / MatchExpr |

🤖 Generated with [Claude Code](https://claude.com/claude-code)