### PR TITLE
[codex] propagate native vectorization loop metadata

### DIFF
--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -288,6 +288,7 @@ func TryGenerateNativeOwnedModule(mod *ostyir.Module, opts Options) ([]byte, boo
 	if err := prepareModuleGeneration(mod); err != nil {
 		return nil, false, err
 	}
+	opts.Target = CanonicalLLVMTarget(opts.Target)
 	out, ok, err := tryNativeOwnedModule(mod, opts)
 	if err != nil || !ok {
 		return out, ok, err
@@ -305,6 +306,7 @@ func tryNativeOwnedModule(mod *ostyir.Module, opts Options) ([]byte, bool, error
 		return nil, false, nil
 	}
 	out := []byte(llvmNativeEmitModule(nativeMod))
+	out = withDataLayout(out, nativeMod.target)
 	out = appendNativeInterfaceSurface(out, mod, nativeMod)
 	out = appendNativeClosureThunks(out, nativeMod.projectionCtx)
 	return out, true, nil
@@ -314,6 +316,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	if mod == nil {
 		return nil, false
 	}
+	opts.Target = CanonicalLLVMTarget(opts.Target)
 	ctx := &nativeProjectionCtx{
 		structsByName:     map[string]*nativeStructInfo{},
 		enumsByName:       map[string]*nativeEnumInfo{},

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -32,6 +32,71 @@ func lowerNativeEntryModule(t *testing.T, src string) *ostyir.Module {
 	return mod
 }
 
+func renderNativeOwnedModuleText(nativeMod *llvmNativeModule) string {
+	if nativeMod == nil {
+		return ""
+	}
+	out := []byte(llvmNativeEmitModule(nativeMod))
+	return string(withDataLayout(out, nativeMod.target))
+}
+
+func TestTryGenerateNativeOwnedModuleAddsHostTargetHeader(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `fn main() { println(1) }`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_entry_host_target.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported for primitive main")
+	}
+	wantTarget := CanonicalLLVMTarget("")
+	got := string(out)
+	if !strings.Contains(got, `target triple = "`+wantTarget+`"`) {
+		t.Fatalf("native-owned IR missing canonical host target %q:\n%s", wantTarget, got)
+	}
+	if !strings.Contains(got, `target datalayout = "`) {
+		t.Fatalf("native-owned IR missing target datalayout:\n%s", got)
+	}
+}
+
+func TestNativeOwnedModuleVectorizedScalarListLoopEmitsLoopMetadata(t *testing.T) {
+	src := `#[vectorize]
+fn sum(xs: List<Int>) -> Int {
+    let mut out = 0
+    for i in 0..xs.len() {
+        out = out + xs[i]
+    }
+    out
+}
+
+fn main() {
+    println(sum([1, 2, 3, 4]))
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	nativeMod, ok := nativeModuleFromIR(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_entry_vector_loop.osty",
+	})
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for vectorized scalar list loop")
+	}
+	got := renderNativeOwnedModuleText(nativeMod)
+	for _, want := range []string{
+		"!llvm.loop !",
+		`!"llvm.loop.vectorize.enable", i1 true`,
+		`!"llvm.loop.parallel_accesses",`,
+		`!llvm.access.group !`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned loop IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestNativeOwnedModuleEntryPrimitiveSlice(t *testing.T) {
 	src := `fn pick(flag: Bool) -> Int {
     if flag {
@@ -57,7 +122,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for primitive slice")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @pick(i1 %flag)",
 		"phi i64",
@@ -138,7 +203,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for plain struct slice")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Pair = type { i64, i64 }",
 		"insertvalue %Pair",
@@ -178,7 +243,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for plain struct method slice")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @Pair__total(%Pair %self)",
 		"call i64 @Pair__total(%Pair",
@@ -218,7 +283,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for mut self method slice")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define void @Counter__bump(ptr %self)",
 		"call void @Counter__bump(ptr",
@@ -263,7 +328,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for projected local mut self receiver")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"alloca %Counter",
 		"call void @Counter__bump(ptr",
@@ -307,7 +372,7 @@ fn run(mut box: Box) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for projected param mut self receiver")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define void @run(%Box %box)",
 		"alloca %Box",
@@ -385,7 +450,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for local struct field assignment")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Pair = type { i64, i64 }",
 		"store %Pair",
@@ -421,7 +486,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for nested local struct field assignment")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	if strings.Count(direct, "extractvalue") < 2 {
 		t.Fatalf("native-owned nested field-assign IR missing chained extractvalue ops:\n%s", direct)
 	}
@@ -451,7 +516,7 @@ fn bump(mut pair: Pair) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for param struct field assignment")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define void @bump(%Pair %pair)",
 		"alloca %Pair",
@@ -488,7 +553,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for global struct field assignment")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"@osty_global_ORIGIN = internal global %Point { i64 1, i64 2 }",
 		"load %Point, ptr @osty_global_ORIGIN",
@@ -525,7 +590,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for top-level global let")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"@osty_global_MAX_USERS = internal constant i64 10000",
 		"define i64 @limit()",
@@ -557,7 +622,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for top-level global string let")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"@osty_global_DEFAULT_ERROR = internal constant ptr @.str0",
 		"load ptr, ptr @osty_global_DEFAULT_ERROR",
@@ -591,7 +656,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for top-level global struct let")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Point = type { i64, i64 }",
 		"@osty_global_ORIGIN = internal constant %Point { i64 0, i64 0 }",
@@ -631,7 +696,7 @@ func TestNativeOwnedModuleEntryStringMethodBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for string method batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @describe(ptr %s)",
 		"declare ptr @osty_rt_strings_TrimSpace(ptr)",
@@ -673,7 +738,7 @@ func TestNativeOwnedModuleEntryListSetMethodBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for list/set method batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @touch(ptr %words)",
 		"declare ptr @osty_rt_list_to_set_string(ptr)",
@@ -710,7 +775,7 @@ func TestNativeOwnedModuleEntryListPushInsertBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for list push/insert batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @build(ptr %xs)",
 		"declare void @osty_rt_list_push_i64(ptr, i64)",
@@ -752,7 +817,7 @@ func TestNativeOwnedModuleEntryMapMethodBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for map method batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @touch(ptr %counts)",
 		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
@@ -788,7 +853,7 @@ func TestNativeOwnedModuleEntryListLiteralAndIndexBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for list literal/index batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @build()",
 		"declare ptr @osty_rt_list_new()",
@@ -825,7 +890,7 @@ fn build() -> Int {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for list struct bytes batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Point = type { i64, i64 }",
 		"declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)",
@@ -859,7 +924,7 @@ func TestNativeOwnedModuleEntryMapIndexBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for map index batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @lookup(ptr %counts)",
 		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
@@ -892,7 +957,7 @@ func TestNativeOwnedModuleEntryTupleBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for tuple batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Tuple.i64.i64 = type { i64, i64 }",
 		"insertvalue %Tuple.i64.i64 undef, i64 1, 0",
@@ -922,7 +987,7 @@ func TestNativeOwnedModuleEntryTupleParamBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for tuple param batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Tuple.i64.ptr = type { i64, ptr }",
 		"define i64 @first(%Tuple.i64.ptr %p)",
@@ -955,7 +1020,7 @@ fn build() -> Int {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for map literal struct batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Point = type { i64, i64 }",
 		"declare ptr @osty_rt_map_new()",
@@ -1006,7 +1071,7 @@ fn main() {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for projected global mut self receiver")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"@osty_global_STATE = internal global %Box",
 		"load %Box, ptr @osty_global_STATE",
@@ -1163,7 +1228,7 @@ func TestNativeOwnedModuleEntryOptionalMethodBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional method batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i1 @flags(ptr %name)",
 		"icmp ne ptr",
@@ -1194,7 +1259,7 @@ func TestNativeOwnedModuleEntryOptionalCoalesceStringBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional string coalesce batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define ptr @display(ptr %name)",
 		"icmp eq ptr",
@@ -1225,7 +1290,7 @@ func TestNativeOwnedModuleEntryOptionalCoalesceScalarBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional scalar coalesce batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define i64 @score(ptr %value)",
 		"icmp eq ptr",
@@ -1258,7 +1323,7 @@ func TestNativeOwnedModuleEntryOptionalQuestionScalarBatch(t *testing.T) {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional scalar question batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"define ptr @requireScore(ptr %score)",
 		"ret ptr null",
@@ -1292,7 +1357,7 @@ fn requireName(profile: Profile?) -> String? {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional struct question batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Profile = type { ptr }",
 		"define ptr @requireName(ptr %profile)",
@@ -1326,7 +1391,7 @@ fn maybeName(profile: Profile?) -> String? {
 	if !ok {
 		t.Fatal("nativeModuleFromIR returned unsupported for optional field batch")
 	}
-	direct := llvmNativeEmitModule(nativeMod)
+	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
 		"%Profile = type { ptr }",
 		"define ptr @maybeName(ptr %profile)",

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -219,6 +219,8 @@ type llvmNativeRenderedFunction struct {
 	definition    string
 	stringGlobals []*LlvmStringGlobal
 	nextStringID  int
+	loopMDDefs    []string
+	nextLoopMD    int
 }
 
 type llvmNativeMaybeValue struct {
@@ -234,6 +236,8 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 	definitions := make([]string, 0, len(mod.globals)+len(mod.functions))
 	stringGlobals := append([]*LlvmStringGlobal(nil), mod.stringGlobals...)
 	nextStringID := len(stringGlobals)
+	loopMDDefs := make([]string, 0, len(mod.functions))
+	nextLoopMD := 0
 	for _, st := range mod.structs {
 		if st == nil {
 			continue
@@ -261,11 +265,14 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 		definitions = append(definitions, global.irName+" = internal "+kind+" "+global.llvmType+" "+global.init)
 	}
 	for _, fn := range mod.functions {
-		rendered := llvmNativeEmitFunction(fn, mod.globals, nextStringID)
+		rendered := llvmNativeEmitFunction(fn, mod.globals, nextStringID, nextLoopMD)
 		nextStringID = rendered.nextStringID
+		nextLoopMD = rendered.nextLoopMD
 		definitions = append(definitions, rendered.definition)
 		stringGlobals = append(stringGlobals, rendered.stringGlobals...)
+		loopMDDefs = append(loopMDDefs, rendered.loopMDDefs...)
 	}
+	definitions = append(definitions, loopMDDefs...)
 	return llvmRenderModuleWithRuntimeDeclarations(
 		mod.sourcePath,
 		mod.target,
@@ -425,7 +432,11 @@ func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName, idxName stri
 		elemPtr := llvmNextTemp(emitter)
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i64 %s", elemPtr, elemLLVM, data.name, index.name))
 		fastValue := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", fastValue, elemLLVM, elemPtr))
+		loadLine := fmt.Sprintf("  %s = load %s, ptr %s", fastValue, elemLLVM, elemPtr)
+		if emitter.parallelAccessHint && emitter.parallelAccessGroupRef != "" {
+			loadLine += fmt.Sprintf(", !llvm.access.group %s", emitter.parallelAccessGroupRef)
+		}
+		emitter.body = append(emitter.body, loadLine)
 		return &LlvmValue{typ: elemLLVM, name: fastValue, pointer: false}
 	}
 	nonNegative := llvmCompare(emitter, "sge", index, llvmIntLiteral(0))
@@ -450,11 +461,17 @@ func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName, idxName stri
 	return &LlvmValue{typ: elemLLVM, name: phi, pointer: false}
 }
 
-func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal, startStringID int) llvmNativeRenderedFunction {
+func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal, startStringID int, startLoopMD int) llvmNativeRenderedFunction {
 	emitter := llvmEmitter()
 	emitter.stringId = startStringID
+	emitter.nextLoopMD = startLoopMD
+	emitter.vectorizeHint = fn != nil && fn.vectorize
 	llvmNativeBindGlobals(emitter, globals)
 	eligibleScalarListParams := llvmNativeEligibleScalarListParams(fn)
+	if emitter.vectorizeHint && len(eligibleScalarListParams) > 0 {
+		emitter.parallelAccessHint = true
+		emitter.parallelAccessGroupRef = llvmNextAccessGroupRef(emitter)
+	}
 	params := make([]*LlvmParam, 0, len(fn.params))
 	for _, param := range fn.params {
 		paramIRType := param.llvmType
@@ -500,6 +517,8 @@ func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal,
 		definition:    llvmRenderFunction(retType, fn.name, params, emitter.body),
 		stringGlobals: append([]*LlvmStringGlobal(nil), emitter.stringGlobals...),
 		nextStringID:  emitter.stringId,
+		loopMDDefs:    append([]string(nil), emitter.loopMDDefs...),
+		nextLoopMD:    emitter.nextLoopMD,
 	}
 }
 

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -98,6 +98,19 @@ type LlvmEmitter struct {
 	// for any constant `addend` in `[0, k]`. Cleared on loop-body
 	// exit.
 	nativeSafeIndices map[string]map[string]int
+	// loopMDDefs accumulates module-scope loop metadata definitions
+	// for native-owned function emission. nextLoopMD keeps the `!N`
+	// namespace monotonically increasing across functions.
+	nextLoopMD int
+	loopMDDefs []string
+	// vectorizeHint mirrors the source-level vectorize bit for the
+	// current native-owned function. parallelAccessHint is the
+	// auto-enabled read-only scalar-list fast-path analogue of
+	// `#[parallel]`: when proven-safe raw-buffer loads are emitted,
+	// we attach one access-group and reference it from loop metadata.
+	vectorizeHint          bool
+	parallelAccessHint     bool
+	parallelAccessGroupRef string
 }
 
 // Osty: toolchain/llvmgen.osty:56:5
@@ -144,7 +157,54 @@ func llvmEmitter() *LlvmEmitter {
 		nativeListLens:    map[string]*LlvmValue{},
 		nativeBoundedLens: map[string]map[string]int{},
 		nativeSafeIndices: map[string]map[string]int{},
+		loopMDDefs:        make([]string, 0, 1),
 	}
+}
+
+func llvmLoopHintsActive(emitter *LlvmEmitter) bool {
+	if emitter == nil {
+		return false
+	}
+	return emitter.vectorizeHint || emitter.parallelAccessHint
+}
+
+func llvmNextLoopMetadataRef(emitter *LlvmEmitter, line string) string {
+	if emitter == nil {
+		return ""
+	}
+	ref := fmt.Sprintf("!%d", emitter.nextLoopMD)
+	emitter.nextLoopMD++
+	emitter.loopMDDefs = append(emitter.loopMDDefs, fmt.Sprintf("%s = %s", ref, line))
+	return ref
+}
+
+func llvmNextAccessGroupRef(emitter *LlvmEmitter) string {
+	return llvmNextLoopMetadataRef(emitter, "distinct !{}")
+}
+
+func llvmNextRangeLoopRef(emitter *LlvmEmitter) string {
+	if !llvmLoopHintsActive(emitter) {
+		return ""
+	}
+	props := make([]string, 0, 2)
+	if emitter.vectorizeHint {
+		props = append(props, llvmNextLoopMetadataRef(emitter, `!{!"llvm.loop.vectorize.enable", i1 true}`))
+	}
+	if emitter.parallelAccessHint && emitter.parallelAccessGroupRef != "" {
+		props = append(props, llvmNextLoopMetadataRef(emitter,
+			fmt.Sprintf(`!{!"llvm.loop.parallel_accesses", %s}`, emitter.parallelAccessGroupRef)))
+		props = append(props, llvmNextLoopMetadataRef(emitter,
+			`!{!"llvm.loop.unroll.count", i32 4}`))
+	}
+	if len(props) == 0 {
+		return ""
+	}
+	ref := fmt.Sprintf("!%d", emitter.nextLoopMD)
+	emitter.nextLoopMD++
+	children := append([]string{ref}, props...)
+	emitter.loopMDDefs = append(emitter.loopMDDefs,
+		fmt.Sprintf("%s = distinct !{%s}", ref, llvmStrings.Join(children, ", ")))
+	return ref
 }
 
 // Osty: toolchain/llvmgen.osty:94:5
@@ -1189,7 +1249,11 @@ func llvmRangeEnd(emitter *LlvmEmitter, loop *LlvmRangeLoop) {
 	}()
 	// Osty: toolchain/llvmgen.osty:868:5
 	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
+		line := fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel))
+		if loopMD := llvmNextRangeLoopRef(emitter); loopMD != "" {
+			line += fmt.Sprintf(", !llvm.loop %s", ostyToString(loopMD))
+		}
+		emitter.body = append(emitter.body, line)
 		return struct{}{}
 	}()
 	// Osty: toolchain/llvmgen.osty:869:5


### PR DESCRIPTION
## Summary
- canonicalize the native-owned LLVM target and emit the matching datalayout header
- preserve loop metadata for native-owned `#[vectorize]` scalar-list fast paths, including access groups and loop unroll hints
- add regression coverage for host target headers and vectorized native-owned loop metadata

## Why
`simd_stats`-style native-owned LLVM paths were dropping target and loop-hint information that the regular pipeline keeps, which left vectorized scalar-list loops under-optimized on x64 hosts.

## Impact
This gives native-owned vectorized loops enough target and loop metadata for LLVM to generate materially better code in SIMD-heavy workloads without changing user source.

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'Test(TryGenerateNativeOwnedModuleAddsHostTargetHeader|NativeOwnedModuleVectorizedScalarListLoopEmitsLoopMetadata|NativeOwnedModuleEntryPrimitiveSlice|TryGenerateNativeOwnedModulePrimitiveSlice|NativeOwnedModuleEntryListLiteralAndIndexBatch|NativeOwnedModuleEntryMapIndexBatch)$'`
- `go build -o .bin/osty ./cmd/osty`