### PR TITLE
fix(toolchain): Char/String type confusion in mir_lower.osty numeric parsing

### DIFF
--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2604,14 +2604,13 @@ pub fn mirLowerParseIntLit(text: String) -> Int {
 }
 
 fn mirLowerStripUnderscores(text: String) -> String {
-    let mut buf: List<String> = []
-    let chars = text.chars()
-    for ch in chars {
-        if ch != "_" {
-            buf.push(ch)
-        }
-    }
-    strings.join(buf, "")
+    // Spec §1.6.1 numeric separators: `_` between digits is lexically
+    // elided when computing the literal value. String.replace runs in
+    // a single pass and keeps the Char/String boundaries aligned with
+    // the backend — previously this loop wrote `if ch != "_"` where
+    // `ch: Char` met a String literal, walling the merged AST probe
+    // with LLVM011 "compare type mismatch i32/ptr".
+    text.replace("_", "")
 }
 
 fn mirLowerStripSign(text: String) -> String {
@@ -2654,24 +2653,29 @@ fn mirLowerParseRadix(text: String, radix: Int) -> Int {
     acc
 }
 
-fn mirLowerCharToDigit(ch: String) -> Int {
+// mirLowerCharToDigit takes a Char (i32 Unicode scalar) because the
+// caller iterates `text.chars()` which returns `List<Char>` per the
+// String primitive contract — earlier this took `String` and matched
+// against "0"/"a"/…, but that passed a Char where a String was
+// expected, walling the merged probe with LLVM011 type mismatch.
+fn mirLowerCharToDigit(ch: Char) -> Int {
     match ch {
-        "0" -> 0,
-        "1" -> 1,
-        "2" -> 2,
-        "3" -> 3,
-        "4" -> 4,
-        "5" -> 5,
-        "6" -> 6,
-        "7" -> 7,
-        "8" -> 8,
-        "9" -> 9,
-        "a" -> 10, "A" -> 10,
-        "b" -> 11, "B" -> 11,
-        "c" -> 12, "C" -> 12,
-        "d" -> 13, "D" -> 13,
-        "e" -> 14, "E" -> 14,
-        "f" -> 15, "F" -> 15,
+        '0' -> 0,
+        '1' -> 1,
+        '2' -> 2,
+        '3' -> 3,
+        '4' -> 4,
+        '5' -> 5,
+        '6' -> 6,
+        '7' -> 7,
+        '8' -> 8,
+        '9' -> 9,
+        'a' -> 10, 'A' -> 10,
+        'b' -> 11, 'B' -> 11,
+        'c' -> 12, 'C' -> 12,
+        'd' -> 13, 'D' -> 13,
+        'e' -> 14, 'E' -> 14,
+        'f' -> 15, 'F' -> 15,
         _ -> -1,
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `LLVM011 compare type mismatch i32/ptr` wall that both merged-toolchain probes hit after the empty-list sibling-hint fix (#702). Two adjacent helpers in `toolchain/mir_lower.osty` treated `text.chars()` as if it returned `List<String>`, but the String primitive contract ([`internal/stdlib/primitives/string.osty:34`](internal/stdlib/primitives/string.osty)) says `chars() -> List<Char>`.

## Root cause

1. `mirLowerStripUnderscores` — `ch != "_"` compared `Char` (i32) with a `String` literal (ptr). **Direct source of i32/ptr mismatch.**
2. `mirLowerCharToDigit(ch: String)` — parameter declared `String` with `match ch { "0" -> 0, ... }`, but the only caller (`mirLowerParseRadix`) fed it `Char` values from `text.chars()`. Same Char-for-String substitution, one wall deeper.

## Fix

- `mirLowerStripUnderscores` → `text.replace("_", "")`. Spec §1.6.1 elides `_` between digits lexically during value computation, so a single-pass replacement produces the same result without crossing the Char/String boundary or needing `strings.join` to reassemble.
- `mirLowerCharToDigit(ch: Char) -> Int`. Signature flipped to `Char`; every match arm literal rewritten from String (`"0"`, `"a"`, …) to Char (`'0'`, `'a'`, …). The caller now passes the exact type the signature declares.

Callers and return types unchanged — no ripple effects.

## Probe deltas

| Probe | Before | After |
|---|---|---|
| `TestProbeWholeToolchainMerged` | `LLVM011 compare type mismatch i32/ptr at mir_lower.osty:2610` | `LLVM015 call target *ast.FieldExpr (text.substring)` |
| `TestProbeNativeToolchainMerged` | same | same |
| `TestNativeToolchainMergedMIRPipelineIsClean` | FAIL (i32/ptr) | FAIL (LLVM015 text.substring — separate legacy-emitter gap) |

The new LLVM015 wall is unrelated to this fix — it's the legacy AST emitter's missing support for method calls against chained field/method receivers. Will be tackled separately.

## Why not a backend-side Char-auto-coerce?

The source was wrong. `text.chars()` explicitly returns `List<Char>` in the stdlib surface, and the spec treats Char and String as distinct types (Char is a `u32` Unicode scalar, not a 1-char string). Making the backend silently coerce would hide real type errors elsewhere. The source bug belongs at the source.

## Test plan

- [x] `TestProbeWholeToolchainMerged` / `TestProbeNativeToolchainMerged` advance past the i32/ptr wall
- [x] `just front` — no new failures (pre-existing `TestLexAsQuestionSingleToken` + `TestResolve{Undefined,Shadow}LoopLabel` verified unchanged via stash)
- [x] Selfhost tests — no new failures (pre-existing `TestResolveSourceStructuredResolvesBreakValue` verified unchanged)

## Stacked on

Doesn't depend on #702 (empty-list hint), but without #702 the probe wouldn't have reached the i32/ptr wall to expose this bug. Both PRs move the probe forward independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)