### PR TITLE
Advance native-merged MIR pipeline walls

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1028,7 +1028,11 @@ func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
 	}
 	if llvmIsCompareOp(e.Op.String()) {
 		isString := g.staticExprIsString(e.Left) || g.staticExprIsString(e.Right)
-		return g.emitCompare(e.Op, left, right, isString)
+		v, err := g.emitCompare(e.Op, left, right, isString)
+		if err != nil {
+			return v, fmt.Errorf("%s at %s", err.Error(), exprPosLabel(e))
+		}
+		return v, nil
 	}
 	if e.Op == token.AND || e.Op == token.OR {
 		return g.emitLogical(e.Op, left, right)
@@ -1471,7 +1475,7 @@ func (g *generator) emitIfExprValue(expr *ast.IfExpr) (value, error) {
 		return value{}, unsupported("control-flow", "if expression has no then block")
 	}
 	if expr.Else == nil {
-		return value{}, unsupported("control-flow", "if expression has no else branch")
+		return value{}, unsupportedf("control-flow", "if expression has no else branch %s", exprPosLabel(expr))
 	}
 	cond, err := g.emitExpr(expr.Cond)
 	if err != nil {
@@ -1514,7 +1518,7 @@ func (g *generator) emitIfLetExprValue(expr *ast.IfExpr) (value, error) {
 		return value{}, unsupported("control-flow", "if expression has no then block")
 	}
 	if expr.Else == nil {
-		return value{}, unsupported("control-flow", "if expression has no else branch")
+		return value{}, unsupportedf("control-flow", "if expression has no else branch %s", exprPosLabel(expr))
 	}
 	scrutinee, err := g.emitExpr(expr.Cond)
 	if err != nil {
@@ -1625,7 +1629,7 @@ func (g *generator) emitBlockValue(block *ast.Block) (value, error) {
 		}
 		exprStmt, ok := stmt.(*ast.ExprStmt)
 		if !ok {
-			return value{}, unsupportedf("statement", "final block statement %T", stmt)
+			return value{}, unsupportedf("statement", "final block statement %T %s", stmt, exprPosLabel(stmt))
 		}
 		return g.emitExpr(exprStmt.X)
 	}
@@ -2161,7 +2165,7 @@ func (g *generator) emitTagEnumMatchSelectValue(scrutinee value, arms []*ast.Mat
 			return value{}, err
 		}
 		if !ok {
-			return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s)", debugPatternShape(arm.Pattern))
+			return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s) %s", debugPatternShape(arm.Pattern), exprPosLabel(arm.Pattern))
 		}
 		armValue, err := g.emitMatchArmBodyValue(arm.Body)
 		if err != nil {
@@ -2203,7 +2207,7 @@ func (g *generator) emitTagEnumMatchChainValue(scrutinee value, arms []*ast.Matc
 			if _, ok, err := g.matchEnumTag(arm.Pattern); err != nil {
 				return value{}, err
 			} else if !ok {
-				return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s)", debugPatternShape(arm.Pattern))
+				return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s) %s", debugPatternShape(arm.Pattern), exprPosLabel(arm.Pattern))
 			}
 		}
 		return g.emitMatchArmBodyValue(arm.Body)

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1094,7 +1094,8 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
-		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
+		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring,
+		mir.IntrinsicStringReplace:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -2982,7 +2983,8 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
-		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
+		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring,
+		mir.IntrinsicStringReplace:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -4232,8 +4234,38 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringJoin(i, strReg)
 	case mir.IntrinsicStringSubstring:
 		return g.emitStringSubstring(i, strReg)
+	case mir.IntrinsicStringReplace:
+		return g.emitStringReplaceAll(i, strReg)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+// emitStringReplaceAll emits `s.replace(old, new)` as a call to the
+// runtime helper `osty_rt_strings_ReplaceAll`, matching the spec's
+// always-replace-all semantics for the `String.replace` method. Args:
+// [s, old, new].
+func (g *mirGen) emitStringReplaceAll(i *mir.IntrinsicInstr, strReg string) error {
+	if len(i.Args) < 3 {
+		return unsupported("mir-mvp", "string_replace arity")
+	}
+	oldReg, err := g.evalOperand(i.Args[1], mir.TString)
+	if err != nil {
+		return err
+	}
+	newReg, err := g.evalOperand(i.Args[2], mir.TString)
+	if err != nil {
+		return err
+	}
+	sym := "osty_rt_strings_ReplaceAll"
+	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr, ptr)")
+	em := g.ostyEmitter()
+	result := llvmCall(em, "ptr", sym, []*LlvmValue{
+		{typ: "ptr", name: strReg},
+		{typ: "ptr", name: oldReg},
+		{typ: "ptr", name: newReg},
+	})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, result)
 }
 
 // emitStringSubstring emits `s.substring(start, end)` / `s[a..b]`

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1102,7 +1102,7 @@ func (g *generator) emitReturn(stmt *ast.ReturnStmt) error {
 func (g *generator) emitExprStmt(expr ast.Expr) error {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
-		return unsupportedf("statement", "expression statement %T is not a call; only println and similar side-effect calls are supported as expression statements", expr)
+		return unsupportedf("statement", "expression statement %T %s is not a call; only println and similar side-effect calls are supported as expression statements", expr, exprPosLabel(expr))
 	}
 	if emitted, err := g.emitTestingCallStmt(call); emitted || err != nil {
 		return err

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -593,13 +593,13 @@ pub fn hirLowerParseAnnotationInt(e: HirExpr) -> HirLowerIntParse {
     let mut base = 10
     if text.startsWith("0x") || text.startsWith("0X") {
         base = 16
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     } else if text.startsWith("0o") || text.startsWith("0O") {
         base = 8
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     } else if text.startsWith("0b") || text.startsWith("0B") {
         base = 2
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     }
     if body.len() == 0 {
         return HirLowerIntParse { value: 0, ok: false }
@@ -650,35 +650,39 @@ pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
 // ---- Internal digit helpers --------------------------------------
 
 fn hirLowerStripUnderscores(text: String) -> String {
-    let mut buf: List<String> = []
-    let chars = text.chars()
-    for ch in chars {
-        if ch != "_" {
-            buf.push(ch)
-        }
-    }
-    strings.join(buf, "")
+    // Same shape as mir_lower.osty's mirLowerStripUnderscores post-#706.
+    // `text.chars()` yields `List<Char>`, so the per-char `!= "_"` test
+    // compared Char to a String literal — LLVM011 i32/ptr mismatch on
+    // the legacy fallback. A single-pass replace skips the Char surface.
+    text.replace("_", "")
 }
 
 fn hirLowerStripSign(text: String) -> String {
+    // strings.slice (free fn) rather than `text.substring()` (method call
+    // on FieldExpr receiver) — the legacy LLVM emitter rejects the
+    // latter with LLVM015.
     if text.startsWith("+") || text.startsWith("-") {
-        text.substring(1, text.len())
+        strings.slice(text, 1, text.len())
     } else {
         text
     }
 }
 
-fn hirLowerCharToDigit(ch: String) -> Int {
-    match ch {
-        "0" -> 0, "1" -> 1, "2" -> 2, "3" -> 3, "4" -> 4,
-        "5" -> 5, "6" -> 6, "7" -> 7, "8" -> 8, "9" -> 9,
-        "a" -> 10, "A" -> 10,
-        "b" -> 11, "B" -> 11,
-        "c" -> 12, "C" -> 12,
-        "d" -> 13, "D" -> 13,
-        "e" -> 14, "E" -> 14,
-        "f" -> 15, "F" -> 15,
-        _ -> -1,
+// hirLowerCharToDigit takes a Char — the caller iterates `body.chars()`
+// which returns `List<Char>`. Folding to Int via `ch.toInt()` keeps
+// the legacy LLVM fallback out of its "match scrutinee type i32, want
+// enum tag" wall; plain Int comparisons in an if/else-if chain carry
+// the same mapping.
+fn hirLowerCharToDigit(ch: Char) -> Int {
+    let n = ch.toInt()
+    if n >= 48 && n <= 57 {
+        n - 48
+    } else if n >= 97 && n <= 102 {
+        n - 97 + 10
+    } else if n >= 65 && n <= 70 {
+        n - 65 + 10
+    } else {
+        -1
     }
 }
 
@@ -1596,12 +1600,12 @@ pub fn hirLowerIsPreludeVariantName(name: String) -> Bool {
 /// hirLowerIsPrim reports whether `t` is a primitive HirType with
 /// the given PrimKind. Mirrors Go's `isPrim`.
 pub fn hirLowerIsPrim(t: HirType, pk: HirPrimKind) -> Bool {
+    // Plain field read + helper rather than a nested identity match —
+    // the inner `pkMatched -> …` identifier-bind arm walls the legacy
+    // LLVM emitter (LLVM013 "match arm must be a payload-free enum
+    // variant"), and the indirection adds no information.
     match t.kind {
-        HirTypePrim -> {
-            match t.primKind {
-                pkMatched -> hirLowerPrimKindEq(pkMatched, pk),
-            }
-        },
+        HirTypePrim -> hirLowerPrimKindEq(t.primKind, pk),
         _ -> false,
     }
 }
@@ -1821,14 +1825,8 @@ pub fn hirLowerNormalizeIntText(text: String) -> String {
     if text.len() == 0 {
         return ""
     }
-    let mut buf: List<String> = []
-    let chars = text.chars()
-    for ch in chars {
-        if ch != "_" {
-            buf.push(ch)
-        }
-    }
-    strings.join(buf, "")
+    // Same Char-vs-String fix pattern as hirLowerStripUnderscores.
+    text.replace("_", "")
 }
 
 /// hirLowerNormalizeFloatText shares the same underscore-stripping

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2363,11 +2363,14 @@ fn mirLowerMultiAssign(bs: MirLowerBodyState, s: HirStmt) {
     let scratch = mirLowerNewLocal(bs, "_mtuple", rhsT, false, span)
     mirLowerEmitInstr(bs, mirStorageLiveInstr(scratch, span))
     mirLowerExprInto(bs, s.assignValue, scratch, rhsT)
-    // Tuple element types: pull from the HIR tuple type when present.
-    let elemTs = match rhsT.kind {
-        HirTypeTuple -> rhsT.tupleElems,
-        _ -> [],
-    }
+    // Tuple element types: pull from the HIR tuple field unconditionally
+    // — HirType constructors set `tupleElems: []` for every kind (see
+    // hirTypeInvalid / hirTypePrim in hir.osty), so non-tuple values
+    // already yield the empty list the `i < elemTs.len()` guard below
+    // expects. Avoiding a `_ -> []` match arm sidesteps the legacy LLVM
+    // emitter's LLVM013 "empty list literal requires explicit List<T>"
+    // wall on the HIR→AST fallback path.
+    let elemTs: List<HirType> = rhsT.tupleElems
     let mut i = 0
     for target in s.assignTargets {
         let dst = mirLowerExprToPlace(bs, target)
@@ -2614,8 +2617,12 @@ fn mirLowerStripUnderscores(text: String) -> String {
 }
 
 fn mirLowerStripSign(text: String) -> String {
+    // Use strings.slice rather than `text.substring()` — the legacy
+    // LLVM emitter's AST-fallback path doesn't route String method
+    // calls through the substring intrinsic (LLVM015 "call target
+    // *ast.FieldExpr"), but accepts the package-level free function.
     if text.startsWith("+") || text.startsWith("-") {
-        text.substring(1, text.len())
+        strings.slice(text, 1, text.len())
     } else {
         text
     }
@@ -2626,13 +2633,13 @@ fn mirLowerParseIntDigits(text: String) -> Int {
         return 0
     }
     if text.startsWith("0x") || text.startsWith("0X") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 16)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 16)
     }
     if text.startsWith("0b") || text.startsWith("0B") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 2)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 2)
     }
     if text.startsWith("0o") || text.startsWith("0O") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 8)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 8)
     }
     mirLowerParseRadix(text, 10)
 }
@@ -2655,28 +2662,20 @@ fn mirLowerParseRadix(text: String, radix: Int) -> Int {
 
 // mirLowerCharToDigit takes a Char (i32 Unicode scalar) because the
 // caller iterates `text.chars()` which returns `List<Char>` per the
-// String primitive contract — earlier this took `String` and matched
-// against "0"/"a"/…, but that passed a Char where a String was
-// expected, walling the merged probe with LLVM011 type mismatch.
+// String primitive contract. Folding to Int via `ch.toInt()` keeps
+// the merged-probe legacy fallback from walling — a Char scrutinee on
+// the `match` form triggers LLVM011 "match scrutinee type i32, want
+// enum tag", so we branch in Int-space instead.
 fn mirLowerCharToDigit(ch: Char) -> Int {
-    match ch {
-        '0' -> 0,
-        '1' -> 1,
-        '2' -> 2,
-        '3' -> 3,
-        '4' -> 4,
-        '5' -> 5,
-        '6' -> 6,
-        '7' -> 7,
-        '8' -> 8,
-        '9' -> 9,
-        'a' -> 10, 'A' -> 10,
-        'b' -> 11, 'B' -> 11,
-        'c' -> 12, 'C' -> 12,
-        'd' -> 13, 'D' -> 13,
-        'e' -> 14, 'E' -> 14,
-        'f' -> 15, 'F' -> 15,
-        _ -> -1,
+    let n = ch.toInt()
+    if n >= 48 && n <= 57 {
+        n - 48
+    } else if n >= 97 && n <= 102 {
+        n - 97 + 10
+    } else if n >= 65 && n <= 70 {
+        n - 65 + 10
+    } else {
+        -1
     }
 }
 

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -2376,16 +2376,19 @@ fn opParseScopedUseDecl(p: OstyParser, start: Int, basePath: String, isPub: Bool
 }
 
 fn opStripUseCQuotes(raw: String) -> String {
+    // strings.slice (free fn) rather than `raw[a..b]` Range indexing —
+    // the legacy LLVM emitter rejects a `*ast.RangeExpr` in value
+    // position (LLVM013), but the package-level slice helper is fine.
     let n = raw.len()
     if n < 2 {
         return raw
     }
-    let first = raw[0..1]
-    if first == "\"" && raw[n - 1..n] == "\"" {
-        return raw[1..n - 1]
+    let first = strings.slice(raw, 0, 1)
+    if first == "\"" && strings.slice(raw, n - 1, n) == "\"" {
+        return strings.slice(raw, 1, n - 1)
     }
-    if first == "r" && n >= 3 && raw[1..2] == "\"" && raw[n - 1..n] == "\"" {
-        return raw[2..n - 1]
+    if first == "r" && n >= 3 && strings.slice(raw, 1, 2) == "\"" && strings.slice(raw, n - 1, n) == "\"" {
+        return strings.slice(raw, 2, n - 1)
     }
     raw
 }

--- a/toolchain/pkgmgr_sat.osty
+++ b/toolchain/pkgmgr_sat.osty
@@ -169,20 +169,30 @@ fn satHighInclusiveRank(b: SatBound) -> Int {
 
 /// satIntervalContains reports whether `v` lies inside interval `iv`.
 pub fn satIntervalContains(iv: SatInterval, v: SemVersion) -> Bool {
+    // Flat chain of `if <cond> { return false }` guards. The original
+    // `match iv.low.kind { SatUnbounded -> true, SatInclusive -> if cmp < 0 { return false }, ... }`
+    // walled the legacy LLVM emitter twice: LLVM012 bare BoolLit
+    // expression-statement on the `-> true` arm, and LLVM012 final
+    // block statement ReturnStmt on any nested `if { return false }`
+    // block when the outer if/else-if chain gets treated as an
+    // expression. Guard-style statements keep every block terminating
+    // on a non-expression-statement without nesting.
     if !(satBoundIsUnbounded(iv.low)) {
         let cmp = compareSemVersion(v, iv.low.version)
-        match iv.low.kind {
-            SatUnbounded -> true,
-            SatInclusive -> if cmp < 0 { return false },
-            SatExclusive -> if cmp <= 0 { return false },
+        if iv.low.kind == SatInclusive && cmp < 0 {
+            return false
+        }
+        if iv.low.kind == SatExclusive && cmp <= 0 {
+            return false
         }
     }
     if !(satBoundIsUnbounded(iv.high)) {
         let cmp = compareSemVersion(v, iv.high.version)
-        match iv.high.kind {
-            SatUnbounded -> true,
-            SatInclusive -> if cmp > 0 { return false },
-            SatExclusive -> if cmp >= 0 { return false },
+        if iv.high.kind == SatInclusive && cmp > 0 {
+            return false
+        }
+        if iv.high.kind == SatExclusive && cmp >= 0 {
+            return false
         }
     }
     true

--- a/toolchain/pmcompile.osty
+++ b/toolchain/pmcompile.osty
@@ -225,11 +225,16 @@ pub fn pmTryCompileLitSwitch(
         let arm = arms[i]
         match arm.pattern.kind {
             HirPatLit -> {
-                let litValue = if arm.pattern.litValue.len() > 0 {
-                    arm.pattern.litValue[0]
-                } else {
+                // Guard first, bind after — the legacy LLVM emitter
+                // walls on a `let x = if cond { value } else { return ... }`
+                // shape (LLVM012 "final block statement *ast.ReturnStmt")
+                // because the else-arm of an if-expression isn't allowed
+                // to diverge. A plain if-statement for the early return
+                // keeps the binding unconditional.
+                if arm.pattern.litValue.len() == 0 {
                     return hirDecisionInvalid()
                 }
+                let litValue = arm.pattern.litValue[0]
                 let k = pmSwitchKindOfLit(litValue)
                 let kIsUnknown = match k {
                     HirSwitchUnknown -> true,
@@ -381,7 +386,11 @@ pub fn pmLitLabel(e: HirExpr) -> String {
                 if part.isLit {
                     buf.push(part.lit)
                 } else {
-                    buf.push("{...}")
+                    // Escape the curlies — a bare `"{...}"` is parsed
+                    // as an interpolation slot whose expression is a
+                    // malformed `..`, which cascades into a phantom
+                    // RangeExpr node that walls the LLVM backend.
+                    buf.push("\{...\}")
                 }
             }
             buf.push("\"")


### PR DESCRIPTION
## Summary

Picks up where PR #706 / #702 left off. Combines source-level rewrites across `toolchain/*.osty` with one new MIR intrinsic and four diagnostic-quality improvements to move `TestNativeToolchainMergedMIRPipelineIsClean` past ~10 distinct legacy-emitter wall classes.

**The pipeline test is not fully green** — it now fails on a separate LLVM011 `ptr/ptr` bitwise-or stemming from a self-host checker return-type inference bug in `resolve.osty`'s annotation-target helpers. That's a checker-level issue, out of scope for this source+emitter PR.

## Source fixes

| File | Function | Wall closed |
|---|---|---|
| `mir_lower.osty` | `mirLowerExprAssignTuple` | LLVM013 empty-list match arm |
| `mir_lower.osty` | `mirLowerCharToDigit` | LLVM011 Char match scrutinee |
| `mir_lower.osty` | `mirLowerParseIntDigits` / `mirLowerStripSign` | LLVM015 `text.substring` |
| `hir_lower.osty` | Stage 5a-5e digit helpers (Underscores/Sign/CharToDigit/NormalizeIntText) | Same four walls |
| `hir_lower.osty` | `hirLowerIsPrim` | LLVM013 nested identity match |
| `pmcompile.osty` | `pmLitLabel` | Phantom RangeExpr (unescaped `{...}` in literal) — `TestToolchainHasNoPhantomRangeExpr` now passes |
| `pmcompile.osty` | Switch-kind arm lit bind | LLVM012 final-block ReturnStmt in if-expression else |
| `pkgmgr_sat.osty` | `satIntervalContains` | LLVM012 BoolLit expression-statement + final-block-return |
| `parser.osty` | `opStripUseCQuotes` | LLVM013 `raw[a..b]` RangeExpr in IndexExpr |

## MIR emitter

- `IntrinsicStringReplace` (kind 65) wired through `emitStringIntrinsic`, calling `osty_rt_strings_ReplaceAll` with three `ptr` args. Without this the MIR-direct path refuses every source that uses `String.replace(...)`, forcing an unnecessary legacy fallback.

## Diagnostics

Four emitter walls now carry `exprPosLabel` (line:col + byte offset):
- LLVM011 compare
- LLVM012 expression-statement
- LLVM012 final-block-statement
- LLVM013 match-arm

Merged-toolchain probes can pinpoint offending expressions in a single run.

## Test plan

- [x] PR #693 gates (`TestMIRDirectCoversFormerFallbackWalls`, `TestNativeToolchainMergedMIRErrTypeFloor`) stay green
- [x] `TestToolchainHasNoPhantomRangeExpr` now passes (was red on main)
- [x] `go test ./internal/llvmgen/ ./internal/mir/ ./internal/ir/ -count=1 -short` — clean
- [ ] `TestNativeToolchainMergedMIRPipelineIsClean` — not fully green; advances past ~10 walls, now red on a separate checker-level `ptr/ptr` bug in `resolve.osty`. Tracking as remaining follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)