### PR TITLE
[codex] default checker to embedded path

### DIFF
--- a/cmd/osty/checker_cache.go
+++ b/cmd/osty/checker_cache.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/osty/osty/internal/check"
-	"github.com/osty/osty/internal/toolchain"
 )
 
 // enableCheckerCacheForRoot activates the on-disk native-checker cache
@@ -21,10 +20,10 @@ import (
 //
 // The cache lives at `<root>/.osty/cache/checker/<validity>/` so it is
 // trivially inspectable (`cat`, `ls`) and trivially invalidated (`rm
-// -rf .osty/cache/checker/`). The validity segment binds entries to a
-// specific checker binary so upgrading the managed checker (new
-// `.osty/toolchain/<ver>/osty-native-checker`) transparently
-// invalidates every record without requiring a manual purge.
+// -rf .osty/cache/checker/`). The validity segment binds entries to the
+// embedded checker sources by default, so regenerating
+// `internal/selfhost/generated.go` transparently invalidates every record
+// without requiring a manual purge.
 //
 // No-op when OSTY_CHECKER_CACHE=0. Idempotent: safe to call multiple
 // times in a process — once overrides take, subsequent calls just
@@ -37,34 +36,25 @@ func enableCheckerCacheForRoot(root string) {
 		return
 	}
 	cacheDir := filepath.Join(root, ".osty", "cache", "checker")
-	validity := checkerCacheValidity()
+	validity := checkerCacheValidity(root)
 	check.UseCachedDefaultNativeChecker(cacheDir, validity)
 }
 
-// checkerCacheValidity returns a stable identifier for the current
-// checker binary. The cache invalidates whenever this changes, so the
-// implementation must capture every way the checker's behavior can
-// shift: binary content (via path + size + mtime), or — when the
-// managed checker isn't present — the embedded selfhost checker's
-// version.
+// checkerCacheValidity returns a stable identifier for the default checker
+// backend. When the embedded selfhost checker sources are readable from root,
+// they define the cache namespace; otherwise we fall back to a coarser tool
+// version token so callers still get a deterministic cache directory.
 //
-// We compute lazily and memoize: the validity only depends on process-
-// lifetime immutables (tool version, managed checker path) so a
-// single cache dir name suffices per run.
-func checkerCacheValidity() string {
+// We compute lazily and memoize: the validity only depends on process-lifetime
+// immutables for a single repo checkout, so one cache dir name suffices per run.
+func checkerCacheValidity(root string) string {
 	validityOnce.Do(func() {
+		if fp := check.EmbeddedCheckerFingerprint(root); fp != "" {
+			validity = fp
+			return
+		}
 		h := sha256.New()
 		fmt.Fprintf(h, "tool=%s\n", toolVersion())
-		// Managed-checker binary stamp: path + size + mtime. If the
-		// binary can't be located (dev host without it, or shutdown
-		// race), the hash still carries tool version so entries are
-		// validity-scoped within the process.
-		if path, err := toolchain.EnsureNativeChecker("."); err == nil {
-			if info, err := os.Stat(path); err == nil {
-				fmt.Fprintf(h, "checker=%s size=%d mtime=%d\n",
-					path, info.Size(), info.ModTime().UnixNano())
-			}
-		}
 		validity = hex.EncodeToString(h.Sum(nil))[:16]
 	})
 	return validity

--- a/cmd/osty/checker_cache_test.go
+++ b/cmd/osty/checker_cache_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+)
+
+func TestCheckerCacheValidityUsesEmbeddedCheckerFingerprint(t *testing.T) {
+	root := t.TempDir()
+	writeCheckerCacheTestFile(t, filepath.Join(root, "internal/selfhost/generated.go"), "package selfhost\n\nconst generated = 1\n")
+	writeCheckerCacheTestFile(t, filepath.Join(root, "internal/selfhost/astbridge/generated.go"), "package astbridge\n\nconst generated = 1\n")
+
+	resetCheckerCacheValidityForTest()
+	got := checkerCacheValidity(root)
+	want := check.EmbeddedCheckerFingerprint(root)
+	if want == "" {
+		t.Fatal("EmbeddedCheckerFingerprint returned empty fingerprint")
+	}
+	if got != want {
+		t.Fatalf("checkerCacheValidity = %q, want %q", got, want)
+	}
+
+	writeCheckerCacheTestFile(t, filepath.Join(root, "internal/selfhost/generated.go"), "package selfhost\n\nconst generated = 2\n")
+
+	resetCheckerCacheValidityForTest()
+	got2 := checkerCacheValidity(root)
+	want2 := check.EmbeddedCheckerFingerprint(root)
+	if got2 != want2 {
+		t.Fatalf("checkerCacheValidity after edit = %q, want %q", got2, want2)
+	}
+	if got2 == got {
+		t.Fatalf("checkerCacheValidity did not change after embedded checker edit: %q", got2)
+	}
+}
+
+func resetCheckerCacheValidityForTest() {
+	validityOnce = sync.Once{}
+	validity = ""
+}
+
+func writeCheckerCacheTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -21,15 +21,14 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
-	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/types"
 )
 
 const nativeCheckerEnv = "OSTY_NATIVE_CHECKER_BIN"
 
-// The checker targets an Osty-native request/response boundary. The preferred
-// path uses an external executable, and the default host implementation falls
-// back to the embedded selfhost checker when that binary is unavailable.
+// The checker targets an Osty-native request/response boundary. The default
+// host implementation uses the embedded selfhost checker in-process; callers
+// can opt into an external executable by setting OSTY_NATIVE_CHECKER_BIN.
 type nativeChecker interface {
 	CheckSourceStructured([]byte) (nativeCheckResult, error)
 }
@@ -227,9 +226,6 @@ func adaptEmbeddedCheckResult(checked selfhost.CheckResult) nativeCheckResult {
 }
 
 var nativeCheckerFactory = defaultNativeChecker
-var ensureManagedNativeChecker = func() (string, error) {
-	return toolchain.EnsureNativeChecker(".")
-}
 
 // UseEmbeddedNativeChecker forces the in-process selfhost checker for the
 // remainder of the process. Use only in developer tooling (bootstrap-gen)
@@ -270,8 +266,32 @@ func UseCachedEmbeddedNativeChecker(cacheDir, validity string) {
 	}
 }
 
+// EmbeddedCheckerFingerprint returns a cache-stable identifier for the Go
+// sources compiled into the embedded selfhost checker rooted at repoRoot. When
+// the bundled generated sources are unavailable it returns the empty string so
+// callers can fall back to a coarser validity token.
+func EmbeddedCheckerFingerprint(repoRoot string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "go=%s\nos=%s\narch=%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	files := []string{
+		"internal/selfhost/generated.go",
+		"internal/selfhost/astbridge/generated.go",
+	}
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(rel)))
+		if err != nil {
+			return ""
+		}
+		fmt.Fprintf(h, "%s=%d\n", rel, len(data))
+		h.Write(data)
+	}
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:12])
+}
+
 // UseCachedDefaultNativeChecker wraps whichever checker `defaultNativeChecker`
-// would return (managed subprocess, or embedded fallback) in the on-disk
+// would return (embedded by default, or an explicit subprocess override) in
+// the on-disk
 // cache layer. First-time builds pay the full check cost; second-and-later
 // builds with unchanged package inputs short-circuit to a JSON read
 // (~microseconds) instead of re-running the checker. Unchanged-package
@@ -286,7 +306,8 @@ func UseCachedDefaultNativeChecker(cacheDir, validity string) {
 	backing, note := defaultNativeChecker()
 	if backing == nil {
 		// Preserve the error note so callers see the same diagnostic as
-		// the uncached path when the managed checker can't start.
+		// the uncached path when an explicitly configured checker can't
+		// start.
 		nativeCheckerFactory = func() (nativeChecker, string) {
 			return nil, note
 		}
@@ -463,15 +484,7 @@ func defaultNativeChecker() (nativeChecker, string) {
 		}
 		return nativeCheckerExec{path: resolved}, ""
 	}
-	managedPath, err := ensureManagedNativeChecker()
-	if err != nil {
-		return embeddedNativeChecker{}, fmt.Sprintf(
-			"%s is not set and the managed toolchain checker could not be prepared: %v; falling back to the embedded checker",
-			nativeCheckerEnv,
-			err,
-		)
-	}
-	return nativeCheckerExec{path: managedPath}, ""
+	return embeddedNativeChecker{}, ""
 }
 
 type selfhostCheckedSource struct {

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -404,7 +404,7 @@ func TestNativeBoundaryOverlaysCanonicalSourceSpansBackToOriginalAST(t *testing.
 	}
 }
 
-func TestFileFallsBackToEmbeddedCheckerWhenManagedArtifactUnavailable(t *testing.T) {
+func TestFileUsesEmbeddedCheckerByDefaultWhenEnvUnset(t *testing.T) {
 	src := []byte(`fn id<T>(value: T) -> T { value }
 
 fn main() {
@@ -417,12 +417,6 @@ fn main() {
 	call := letStmt.Value.(*ast.CallExpr)
 
 	t.Setenv(nativeCheckerEnv, "")
-
-	oldEnsure := ensureManagedNativeChecker
-	ensureManagedNativeChecker = func() (string, error) {
-		return "", fmt.Errorf("boom")
-	}
-	t.Cleanup(func() { ensureManagedNativeChecker = oldEnsure })
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = defaultNativeChecker

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,45 +49,15 @@ fn main() {
 	}
 }
 
-func TestDefaultNativeCheckerUsesManagedArtifactWhenEnvUnset(t *testing.T) {
+func TestDefaultNativeCheckerUsesEmbeddedCheckerWhenEnvUnset(t *testing.T) {
 	t.Setenv(nativeCheckerEnv, "")
-	bin := buildRepoNativeChecker(t)
-
-	oldEnsure := ensureManagedNativeChecker
-	ensureManagedNativeChecker = func() (string, error) { return bin, nil }
-	t.Cleanup(func() { ensureManagedNativeChecker = oldEnsure })
 
 	runner, note := defaultNativeChecker()
 	if runner == nil {
 		t.Fatalf("defaultNativeChecker returned nil runner: %s", note)
 	}
-	checked, err := runner.CheckSourceStructured([]byte("fn main() { let answer = 1 }\n"))
-	if err != nil {
-		t.Fatalf("CheckSourceStructured error: %v", err)
-	}
-	if checked.Summary.Errors != 0 {
-		t.Fatalf("summary errors = %d, want 0", checked.Summary.Errors)
-	}
-	if len(checked.TypedNodes) == 0 {
-		t.Fatalf("typed nodes = %#v, want non-empty result", checked.TypedNodes)
-	}
-}
-
-func TestDefaultNativeCheckerFallsBackToEmbeddedCheckerWhenManagedArtifactUnavailable(t *testing.T) {
-	t.Setenv(nativeCheckerEnv, "")
-
-	oldEnsure := ensureManagedNativeChecker
-	ensureManagedNativeChecker = func() (string, error) {
-		return "", fmt.Errorf("boom")
-	}
-	t.Cleanup(func() { ensureManagedNativeChecker = oldEnsure })
-
-	runner, note := defaultNativeChecker()
-	if runner == nil {
-		t.Fatalf("defaultNativeChecker returned nil runner: %s", note)
-	}
-	if note == "" || note == "boom" {
-		t.Fatalf("fallback note = %q, want fallback explanation", note)
+	if _, ok := runner.(embeddedNativeChecker); !ok {
+		t.Fatalf("defaultNativeChecker runner = %T, want embeddedNativeChecker", runner)
 	}
 	checked, err := runner.CheckSourceStructured([]byte("fn main() { let answer = 1 }\n"))
 	if err != nil {

--- a/internal/selfhost/toolchain_checker_probe_test.go
+++ b/internal/selfhost/toolchain_checker_probe_test.go
@@ -152,6 +152,10 @@ func toolchainSubsetOutcome(t *testing.T, root, checker string, files []string, 
 	return toolchainProbeOutcome{duration: dur, timedOut: false}
 }
 
+// ensureNativeCheckerBinary is probe-only instrumentation. Production checker
+// selection now defaults to the embedded selfhost path; the toolchain bisect and
+// timeout probes opt into the managed subprocess explicitly so they can keep
+// measuring the exec-boundary behavior in isolation.
 func ensureNativeCheckerBinary(t *testing.T, start string) string {
 	t.Helper()
 	path, err := toolchainbin.EnsureNativeChecker(start)


### PR DESCRIPTION
## Summary
- switch the default native checker path to the embedded in-process checker
- key CLI checker cache validity off the embedded checker sources instead of the managed checker artifact
- keep external checker probes as explicit dev instrumentation instead of the production default path

## Why
The checker path still smelled like it depended on the managed `osty-native-checker` binary even though the embedded checker already handled the real production path. This change makes the default runtime behavior match the intended selfhost direction and avoids touching the managed checker just to compute cache validity.

## Impact
- `osty check`, `osty build`, and `osty typecheck` now use the embedded checker by default unless `OSTY_NATIVE_CHECKER_BIN` is explicitly set.
- cache invalidation follows embedded checker source changes (`internal/selfhost/generated.go` and `internal/selfhost/astbridge/generated.go`).
- toolchain bisect/probe helpers still use the managed checker, but only as opt-in instrumentation.

## Validation
- `go test -count=1 -vet=off ./internal/check -run 'DefaultNativeChecker|NativeBoundary|FileUsesEmbeddedCheckerByDefaultWhenEnvUnset'`
- `go test -count=1 -vet=off ./cmd/osty -run 'CheckerCache|Run(Resolve|Check|Typecheck).*(AstbridgeFree)'`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestToolchainCheckerFileBisect'`