### PR TITLE
feat(runtime): closure env per-capture pointer bitmap (§2.4)

### DIFF
--- a/RUNTIME_GC_DELTA.md
+++ b/RUNTIME_GC_DELTA.md
@@ -174,7 +174,7 @@ A5–A6는 safepoint ABI 주변 분류·가드.
   C 스택 안전. Sweep이 marked를 clear해 "outside collection == no marks"
   invariant 성립. 테스트 `TestBundledRuntimeMarkWorkQueueDeepGraph`.
 - ✅ **§2.4 A4 Closure env kind 예약** — `OSTY_GC_KIND_CLOSURE_ENV = 1029`.
-  Phase 1 closure env는 dedicated allocator `osty.rt.closure_env_alloc_v1`
+  Phase 1 closure env는 dedicated allocator `osty.rt.closure_env_alloc_v2`
   경유로 생성되고, heap dump와 `osty_gc_stats`에서 일반
   `osty.gc.alloc_v1` 객체와 분리 추적된다. Phase 4 capture 랜딩 시 이
   kind 태그로 분기하여 per-capture trace를 등록한다. 호출 지점:
@@ -206,16 +206,25 @@ A5–A6는 safepoint ABI 주변 분류·가드.
   유지, 초기 cap 128, tombstone 기반 삭제). deep-mark 테스트 28s → <1s.
   capacity / count / tombstones / find_ops 관측.
   `TestBundledRuntimeFindHeaderHashIndex`.
-- **A4 심화** — Phase 1 태그 swap을 넘어 `osty.rt.closure_env_alloc_v1`
+- **A4 심화** — Phase 1 태그 swap을 넘어 `osty.rt.closure_env_alloc_v2`
   전용 allocator + `osty_rt_closure_env_trace` 콜백을 런타임에 구현.
-  capture slot array를 직접 순회하는 self-describing 레이아웃
-  (`{ ptr fn, i64 capture_count, ptr captures[] }`). llvmgen
-  `emitFnValueEnv`가 dedicated 엔트리로 전환. Phase 4 capture lift는
-  `closure_lift.go`에서 scalar (Int / Bool / Char / Byte / Float) + 관리
-  포인터 (String / Bytes / List / Map / Set) capture를 env slot에 기록하며
-  runtime trace가 이를 walk한다. 3개 캡처 보유한 env로 trace 경로 검증:
-  `TestBundledRuntimeClosureEnvTracesCaptures`. E2E capture lift는
-  `TestClosureLiftCapturingIntLocal` / `TestClosureLiftCapturingStringLocal`.
+  self-describing 레이아웃 `{ ptr fn, i64 capture_count, i64
+  pointer_bitmap, ptr captures[] }` — `pointer_bitmap` 비트 i 가 1
+  iff `captures[i]`가 managed pointer. tracer는 비트맵을 참조해 scalar
+  slot을 unconditional하게 건너뛰므로, scalar bit pattern 이 live
+  payload 주소와 우연히 겹쳐도 false-retention 이 **구조적으로**
+  불가능하다 (v1 시절의 확률적 보장을 대체). llvmgen
+  `emitFnValueEnv` / `emitClosureMakerCall`이 dedicated 엔트리로 전환.
+  Phase 4 capture lift는 `closure_lift.go`에서 scalar (Int / Bool /
+  Char / Byte / Float) + 관리 포인터 (String / Bytes / List / Map /
+  Set) capture를 env slot에 기록하고 `pointerBitmapForCaptures`가
+  비트맵을 계산한다. runtime trace가 이를 walk한다. 캡처 개수는
+  비트맵 폭(64)에 맞춰 64 로 제한. Trace 경로 검증:
+  `TestBundledRuntimeClosureEnvTracesCaptures` + false-retention 구조적
+  보장 `TestBundledRuntimeClosureEnvBitmapSkipsScalarSlots`. E2E
+  capture lift는 `TestClosureLiftCapturingIntLocal` /
+  `TestClosureLiftCapturingStringLocal` /
+  `TestClosureLiftCapturingMixedScalarAndPointerEncodesBitmap`.
 - **A5 심화** — E2E 테스트 `TestGenerateFromASTSafepointKindMixCallAndLoop`:
   legacy 에미터가 lower한 IR을 정규식으로 파싱해 kind 분포를 복원,
   CALL + LOOP 존재와 UNSPECIFIED 부재를 검증. MIR 측 ENTRY + LOOP는

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -1539,10 +1539,11 @@ int main(void) {
 }
 
 // TestBundledRuntimeClosureEnvTracesCaptures covers the A4 depth
-// follow-up — `osty.rt.closure_env_alloc_v1` builds a self-describing
-// env with a capture array, the runtime registers
-// `osty_rt_closure_env_trace` at construction, and managed pointers
-// stored in captures stay reachable across GC.
+// follow-up — `osty.rt.closure_env_alloc_v2` builds a self-describing
+// env with a capture array + per-capture pointer bitmap, the runtime
+// registers `osty_rt_closure_env_trace` at construction, and managed
+// pointers stored in captures whose bitmap bit is set stay reachable
+// across GC.
 //
 // This exercises the allocation ABI that Phase 4's capture lowering
 // will emit. Today's llvmgen still materialises 0-capture envs via the
@@ -1570,11 +1571,12 @@ func TestBundledRuntimeClosureEnvTracesCaptures(t *testing.T) {
 typedef struct osty_rt_closure_env {
     void *fn_ptr;
     int64_t capture_count;
+    uint64_t pointer_bitmap;
     void *captures[];
 } osty_rt_closure_env;
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
-void *osty_rt_closure_env_alloc_v1(int64_t capture_count, const char *site) __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v1"));
+void *osty_rt_closure_env_alloc_v2(int64_t capture_count, const char *site, uint64_t pointer_bitmap) __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v2"));
 void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
 void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
 
@@ -1582,18 +1584,19 @@ void osty_gc_debug_collect(void);
 int64_t osty_gc_debug_live_count(void);
 
 int main(void) {
-    /* Phase 1 shape: zero captures. Env still allocates and is
-     * collectable. */
-    void *env0 = osty_rt_closure_env_alloc_v1(0, "env0");
+    /* Phase 1 shape: zero captures, bitmap zero. Env still allocates
+     * and is collectable. */
+    void *env0 = osty_rt_closure_env_alloc_v2(0, "env0", 0);
     osty_gc_root_bind_v1(env0);
     osty_gc_debug_collect();
     printf("%d\n", env0 != 0);
 
-    /* Phase 4 shape preview: 3 captures. Allocate three managed
-     * payloads and store them into the capture slots. They are NOT
-     * root-bound — their only liveness path is through the env's
-     * trace. If the trace is not wired, they're swept. */
-    osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v1(3, "env3");
+    /* Phase 4 shape preview: 3 pointer captures (bitmap 0b111).
+     * Allocate three managed payloads and store them into capture
+     * slots. They are NOT root-bound — their only liveness path is
+     * through the env's trace. If the trace is not wired, they're
+     * swept. */
+    osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(3, "env3", 0x7ULL);
     osty_gc_root_bind_v1(env);
     void *cap0 = osty_gc_alloc_v1(7, 32, "cap0");
     void *cap1 = osty_gc_alloc_v1(7, 32, "cap1");
@@ -1630,6 +1633,102 @@ int main(void) {
 	}
 	if got, want := string(runOutput), "1\n5 5\n1 1 1\n"; got != want {
 		t.Fatalf("closure-env harness stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBundledRuntimeClosureEnvBitmapSkipsScalarSlots covers the §2.4
+// structural guarantee: a scalar capture whose 8-byte bit pattern
+// happens to collide with a live payload address must NOT keep that
+// payload alive through the closure env. The v1 layout gave only a
+// probabilistic guarantee (find_header filtering); v2's pointer bitmap
+// makes the tracer skip scalar slots unconditionally.
+//
+// Harness: allocate a payload P, root-bind it briefly to get its
+// address, unbind it, then store P's address (as a raw integer bit
+// pattern) into the scalar capture slot of a rooted closure env with
+// bitmap bit 0 cleared. After collect, P must be swept — if the tracer
+// honored the scalar slot, P would survive and the live count stays at
+// 2 (env + P) instead of the expected 1 (env only).
+func TestBundledRuntimeClosureEnvBitmapSkipsScalarSlots(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_closure_bitmap_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_closure_bitmap_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+typedef struct osty_rt_closure_env {
+    void *fn_ptr;
+    int64_t capture_count;
+    uint64_t pointer_bitmap;
+    void *captures[];
+} osty_rt_closure_env;
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void *osty_rt_closure_env_alloc_v2(int64_t capture_count, const char *site, uint64_t pointer_bitmap) __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v2"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+
+void osty_gc_debug_collect(void);
+int64_t osty_gc_debug_live_count(void);
+
+int main(void) {
+    /* Two captures: slot 0 scalar (bit 0 cleared), slot 1 pointer
+     * (bit 1 set). Bitmap = 0b10 = 0x2. */
+    osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(2, "env2", 0x2ULL);
+    osty_gc_root_bind_v1(env);
+
+    /* Payload P: allocate but do not root. Its only potential
+     * liveness path is through env's scalar capture slot. */
+    void *p = osty_gc_alloc_v1(7, 32, "scalar_victim");
+
+    /* Store P's address into the scalar slot as a raw bit pattern.
+     * Semantically this is a scalar (an Int that happens to equal
+     * a valid heap address). Under v1 conservative scan, find_header
+     * would identify P as reachable and keep it alive. Under v2 the
+     * bitmap bit is 0 so the tracer skips this slot unconditionally
+     * — P must be swept. */
+    env->captures[0] = p;
+
+    /* Payload Q: stored in the pointer slot with bitmap bit 1 set.
+     * Must survive collection. */
+    void *q = osty_gc_alloc_v1(7, 32, "pointer_capture");
+    env->captures[1] = q;
+
+    int64_t live_before = osty_gc_debug_live_count();
+    osty_gc_debug_collect();
+    int64_t live_after = osty_gc_debug_live_count();
+
+    /* live_before: env + P + Q = 3.
+     * live_after:  env + Q     = 2  (structural guarantee).
+     * If the tracer ignored the bitmap, live_after would be 3. */
+    printf("%lld %lld\n", (long long)live_before, (long long)live_after);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "3 2\n"; got != want {
+		t.Fatalf("closure-bitmap harness stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -483,7 +483,7 @@ enum {
      * callback (`osty_rt_closure_env_trace`) that walks the capture
      * slots so any managed pointer captured by a closure stays
      * reachable across GC cycles. Layout below in `osty_rt_closure_env`.
-    * Allocation is dedicated: `osty.rt.closure_env_alloc_v1` rather
+    * Allocation is dedicated: `osty.rt.closure_env_alloc_v2` rather
      * than the generic `osty.gc.alloc_v1`, so the trace is installed
      * at construction and not as a post-alloc mutation. Phase 1 still
      * emits envs with `capture_count = 0`, exercising the allocation
@@ -502,16 +502,25 @@ enum {
 
 /* Closure environment payload. The thunk ABI is preserved — the LLVM
  * call site still does `load ptr, ptr %env` — because `fn_ptr` stays
- * at offset 0. `capture_count` and `captures[]` follow so the trace
- * callback can iterate without any side metadata.
+ * at offset 0. `capture_count` and `pointer_bitmap` follow so the
+ * trace callback can iterate without any side metadata.
  *
- * Capture slots hold `void *`, always through managed-pointer
- * semantics. Non-pointer captures (scalar values boxed by the Osty
- * frontend) would still go here as tagged managed values; the
- * frontend is responsible for boxing. */
+ * `pointer_bitmap` (RUNTIME_GC §2.4): bit i is 1 iff `captures[i]`
+ * holds a managed pointer that the tracer must mark. Scalar captures
+ * set bit i to 0 so the tracer skips them entirely — a structural
+ * guarantee that a scalar bit pattern aliasing a live payload address
+ * cannot false-retain that payload. Bitmap width caps capture count
+ * at 64 per env (enforced at alloc time); closures in practice never
+ * approach this limit.
+ *
+ * Capture slots hold `void *` bit patterns. For pointer slots the
+ * value is a managed payload pointer; for scalar slots the 8-byte
+ * pattern is the raw IEEE-754 double / sign-extended integer / bool
+ * the frontend stored — the GC never dereferences it. */
 typedef struct osty_rt_closure_env {
     void *fn_ptr;
     int64_t capture_count;
+    uint64_t pointer_bitmap;
     void *captures[];
 } osty_rt_closure_env;
 
@@ -7369,32 +7378,33 @@ static void osty_rt_enum_ptr_payload_trace(void *payload) {
  * closure capture survives GC while the env itself is reachable.
  *
  * The env layout is self-describing (see `osty_rt_closure_env`) so the
- * trace needs no external descriptor — it reads `capture_count`, then
- * passes each slot address to `osty_gc_mark_slot_v1`. Non-managed
- * capture values (scalars that the Osty frontend stores as raw bits
- * inside the slot) are handled transparently because `mark_slot_v1`
- * filters through `find_header`.
+ * trace needs no external descriptor — it reads `capture_count` and
+ * `pointer_bitmap`, then calls `osty_gc_mark_slot_v1` only for slots
+ * whose bitmap bit is set.
  *
- * Correctness caveat: `find_header` identifies real heap payloads by
- * pointer, so a scalar capture whose 8-byte bit pattern happens to
- * collide with a live payload address will be treated as a reachable
- * pointer and keep that object alive for one extra cycle. On a 64-bit
- * host typical IEEE-754 doubles and small integers do not alias heap
- * addresses (heap sits in the high half of user space; small doubles
- * have exponent bits 0x3F…, small ints sit below 0x0001…), so the
- * collision probability is effectively zero in practice — but the
- * guarantee is probabilistic, not structural. A follow-up that stores
- * a per-capture kind bitmap would close this to a structural
- * guarantee; today's code chooses the simpler self-describing layout.
+ * This is a structural guarantee against scalar false-retention: the
+ * frontend records which capture slots hold managed pointers at alloc
+ * time (`osty_rt_closure_env_alloc_v2`), so scalar bit patterns that
+ * happen to alias a live payload address can never keep that payload
+ * alive through a closure env. This closes the probabilistic caveat
+ * the v1 layout carried (find_header would have safely skipped
+ * invalid pointers, but the guarantee was statistical, not
+ * structural).
  */
 static void osty_rt_closure_env_trace(void *payload) {
     osty_rt_closure_env *env = (osty_rt_closure_env *)payload;
+    uint64_t bitmap;
+    int64_t n;
     int64_t i;
     if (env == NULL || env->capture_count <= 0) {
         return;
     }
-    for (i = 0; i < env->capture_count; i++) {
-        osty_gc_mark_slot_v1((void *)&env->captures[i]);
+    bitmap = env->pointer_bitmap;
+    n = env->capture_count;
+    for (i = 0; i < n; i++) {
+        if ((bitmap >> (uint64_t)i) & 1ULL) {
+            osty_gc_mark_slot_v1((void *)&env->captures[i]);
+        }
     }
 }
 
@@ -7403,19 +7413,29 @@ static void osty_rt_closure_env_trace(void *payload) {
  * together — there is no post-alloc mutation window where a
  * collection could see an env without its trace installed.
  *
- * Exported as `osty.rt.closure_env_alloc_v1` so the LLVM emitter can
- * call it with a single `call ptr @osty.rt.closure_env_alloc_v1(i64 N,
- * ptr %site)` at the fn-value materialisation site.
+ * `pointer_bitmap` (RUNTIME_GC §2.4): bit i is 1 iff capture slot i
+ * holds a managed pointer. Scalar slots leave the bit clear so the
+ * tracer skips them entirely, giving a structural (not probabilistic)
+ * guarantee against scalar false-retention. The bitmap is 64 bits
+ * wide so capture_count is capped at 64 — closures in practice never
+ * approach this limit.
+ *
+ * Exported as `osty.rt.closure_env_alloc_v2` so the LLVM emitter can
+ * call it with a single `call ptr @osty.rt.closure_env_alloc_v2(i64 N,
+ * ptr %site, i64 %bitmap)` at the fn-value materialisation site.
  */
-void *osty_rt_closure_env_alloc_v1(int64_t capture_count, const char *site)
-    __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v1"));
+void *osty_rt_closure_env_alloc_v2(int64_t capture_count, const char *site, uint64_t pointer_bitmap)
+    __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v2"));
 
-void *osty_rt_closure_env_alloc_v1(int64_t capture_count, const char *site) {
+void *osty_rt_closure_env_alloc_v2(int64_t capture_count, const char *site, uint64_t pointer_bitmap) {
     size_t byte_size;
     osty_rt_closure_env *env;
 
     if (capture_count < 0) {
         osty_rt_abort("negative closure env capture count");
+    }
+    if (capture_count > 64) {
+        osty_rt_abort("closure env capture count exceeds bitmap width (max 64)");
     }
     if ((size_t)capture_count > (SIZE_MAX - sizeof(osty_rt_closure_env)) / sizeof(void *)) {
         osty_rt_abort("closure env capture count overflow");
@@ -7425,6 +7445,7 @@ void *osty_rt_closure_env_alloc_v1(int64_t capture_count, const char *site) {
         byte_size, OSTY_GC_KIND_CLOSURE_ENV, site,
         osty_rt_closure_env_trace, NULL);
     env->capture_count = capture_count;
+    env->pointer_bitmap = pointer_bitmap;
     return env;
 }
 

--- a/internal/llvmgen/closure_lift.go
+++ b/internal/llvmgen/closure_lift.go
@@ -27,13 +27,15 @@
 // Capture support covers scalar IR primitives (Int / Bool / Char /
 // Byte / Float and their typed cousins) that fit in a single machine
 // word, plus managed pointer-typed captures (String / Bytes / List /
-// Map / Set) that lower to `ptr`. The runtime side is already set up
-// for this: `osty.rt.closure_env_alloc_v1` installs
-// `osty_rt_closure_env_trace`, which walks every capture slot via
-// `osty_gc_mark_slot_v1` — that helper filters through `find_header`,
-// so scalar bit patterns in a slot are safely skipped and real managed
-// pointers get marked. User struct captures and other ptr-by-value
-// shapes still fall through to the existing LLVM013 wall.
+// Map / Set) that lower to `ptr`. The emitter computes a per-env
+// pointer bitmap (bit i = 1 iff captures[i] is a managed pointer) and
+// passes it to `osty.rt.closure_env_alloc_v2`; the tracer
+// (`osty_rt_closure_env_trace`) consults the bitmap to mark only
+// pointer slots, giving a structural (not probabilistic) guarantee
+// that a scalar bit pattern aliasing a live heap address cannot
+// false-retain that payload (RUNTIME_GC §2.4). User struct captures
+// and other ptr-by-value shapes still fall through to the existing
+// LLVM013 wall.
 package llvmgen
 
 import (
@@ -63,6 +65,23 @@ type closureCapture struct {
 	name    string
 	llvmTyp string
 	astTyp  ast.Type
+}
+
+// pointerBitmapForCaptures encodes which capture slots hold managed
+// pointers as a 64-bit bitmap (bit i = 1 iff captures[i].llvmTyp is
+// "ptr"). The runtime tracer (`osty_rt_closure_env_trace`) consults
+// the bitmap to skip scalar slots unconditionally — a structural
+// guarantee against scalar false-retention (RUNTIME_GC §2.4).
+//
+// Caller must ensure len(captures) <= 64 (enforced at emit time).
+func pointerBitmapForCaptures(captures []closureCapture) uint64 {
+	var bitmap uint64
+	for i, c := range captures {
+		if c.llvmTyp == "ptr" {
+			bitmap |= uint64(1) << uint(i)
+		}
+	}
+	return bitmap
 }
 
 // liftedClosure is the per-closure record produced by the lift pass.

--- a/internal/llvmgen/closure_lift_test.go
+++ b/internal/llvmgen/closure_lift_test.go
@@ -68,7 +68,7 @@ fn main() {
 		// The lifted closure landed as a top-level def.
 		"@__osty_closure_",
 		// And the call site reaches it via the fn-value Env helper.
-		"@osty.rt.closure_env_alloc_v1",
+		"@osty.rt.closure_env_alloc_v2",
 		"@apply",
 	} {
 		if !strings.Contains(got, want) {
@@ -110,11 +110,11 @@ fn main() {
 // Locks the round-trip end-to-end:
 //
 //   - lifted fn signature appends the capture as `outer: Int`
-//   - capturing thunk emits `getelementptr i8, ptr %env, i64 16` +
+//   - capturing thunk emits `getelementptr i8, ptr %env, i64 24` +
 //     `load i64, ptr %cap0_slot` and calls the lifted fn with
 //     `(orig_args..., cap0)`
 //   - maker call site stores the thunk symbol at env slot 0 and
-//     the captured value at offset 16
+//     the captured value at offset 24
 func TestClosureLiftCapturingIntLocal(t *testing.T) {
 	src := `fn apply(f: fn(Int) -> Int, x: Int) -> Int {
     f(x)
@@ -137,13 +137,14 @@ fn main() {
 	for _, want := range []string{
 		// Lifted fn appends `outer` after the original `n` param.
 		"(i64 %n, i64 %outer)",
-		// Capturing thunk loads the capture from env at offset 16
-		// and reorders args.
-		"%cap0_slot = getelementptr i8, ptr %env, i64 16",
+		// Capturing thunk loads the capture from env at offset 24
+		// (after fn_ptr + capture_count + pointer_bitmap) and
+		// reorders args.
+		"%cap0_slot = getelementptr i8, ptr %env, i64 24",
 		"%cap0 = load i64",
 		"call i64 @__osty_closure_",
 		// Maker call site allocates env, stores thunk + capture.
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 1",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 1",
 		"store ptr @__osty_closure_thunk___osty_closure_",
 		"store i64 ", // capture value store
 	} {
@@ -161,15 +162,19 @@ fn main() {
 }
 
 // A closure capturing a managed pointer (String) survives GC because
-// the env's trace callback (`osty_rt_closure_env_trace`) walks every
-// capture slot through `mark_slot_v1`, which filters to live heap
-// headers. The lifter now lowers String/Bytes/List/Map/Set captures
-// as `ptr` — the runtime side was already prepared during Phase A4.
+// the env's trace callback (`osty_rt_closure_env_trace`) consults the
+// per-capture pointer bitmap and marks every slot whose bit is set.
+// The lifter lowers String/Bytes/List/Map/Set captures as `ptr` and
+// emits bitmap bit i = 1 for each; the scalar-false-retention
+// guarantee (RUNTIME_GC §2.4) depends on bitmap bit i = 0 for scalars
+// so the tracer skips them unconditionally.
 //
 // Locks:
 //   - lifted fn signature appends `msg: String` after the `n` param
 //   - capturing thunk loads the capture as `ptr` (not `i64`)
-//   - maker call site stores `ptr` into the env slot at offset 16
+//   - maker call site stores `ptr` into the env slot at offset 24
+//   - maker call site passes `i64 1` for the bitmap (bit 0 set for
+//     the single pointer capture)
 func TestClosureLiftCapturingStringLocal(t *testing.T) {
 	src := `fn apply(f: fn(Int) -> String, x: Int) -> String {
     f(x)
@@ -189,23 +194,24 @@ fn main() {
 	for _, want := range []string{
 		// Lifted fn appends `msg` after `n`. LLVM String lowers to `ptr`.
 		"(i64 %n, ptr %msg)",
-		// Capturing thunk loads the capture as ptr from offset 16.
-		"%cap0_slot = getelementptr i8, ptr %env, i64 16",
+		// Capturing thunk loads the capture as ptr from offset 24.
+		"%cap0_slot = getelementptr i8, ptr %env, i64 24",
 		"%cap0 = load ptr",
-		// Maker call site allocates env with capture_count=1, stores
-		// the thunk at slot 0 and a ptr capture at offset 16.
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 1",
+		// Maker call site allocates env with capture_count=1 and
+		// bitmap=1 (bit 0 set for the single pointer capture),
+		// stores the thunk at slot 0 and a ptr capture at offset 24.
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 1",
 		"store ptr @__osty_closure_thunk___osty_closure_",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("string-capturing closure missing %q in IR:\n%s", want, got)
 		}
 	}
-	// Locate the slot at offset 16 and check the store that lands
+	// Locate the slot at offset 24 and check the store that lands
 	// there is a `store ptr`, not a `store i64` (which would leave
 	// the upper 4 bytes of a managed pointer undefined). This is the
 	// invariant that makes GC tracing correct for pointer captures.
-	if !strings.Contains(got, "store ptr %") || !strings.Contains(got, "= getelementptr i8, ptr %env, i64 16") {
+	if !strings.Contains(got, "store ptr %") || !strings.Contains(got, "= getelementptr i8, ptr %env, i64 24") {
 		t.Fatalf("expected `store ptr %%…` into env slot, got:\n%s", got)
 	}
 }
@@ -230,13 +236,53 @@ fn main() {
 		t.Fatalf("multi-capture closure errored: %v", err)
 	}
 	got := string(ir)
-	// Two capture loads at offsets 16 and 24.
+	// Two capture loads at offsets 24 and 32 (v2 header is 24 bytes:
+	// fn_ptr + capture_count + pointer_bitmap).
 	for _, want := range []string{
-		"= getelementptr i8, ptr %env, i64 16",
 		"= getelementptr i8, ptr %env, i64 24",
+		"= getelementptr i8, ptr %env, i64 32",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("multi-capture closure missing %q in IR:\n%s", want, got)
 		}
+	}
+}
+
+// A closure capturing both a scalar (Int) and a pointer (String) must
+// encode the bitmap with bit i set iff captures[i] is a pointer. This
+// is the codegen-side anchor for RUNTIME_GC §2.4 — the runtime tracer
+// consults this bitmap to skip scalar slots and close the scalar-
+// false-retention window structurally.
+//
+// The IR lowerer decides capture order, so the test accepts either
+// `i64 1` (pointer first) or `i64 2` (scalar first) — both encode
+// exactly one pointer in a two-slot env. Bitmap 0 (both scalars) or
+// 3 (both pointers) would be wrong.
+func TestClosureLiftCapturingMixedScalarAndPointerEncodesBitmap(t *testing.T) {
+	src := `fn apply(f: fn(Int) -> String, x: Int) -> String {
+    f(x)
+}
+
+fn main() {
+    let outerInt = 10
+    let outerStr = "hi"
+    let _ = apply(|n| if n > outerInt { outerStr } else { outerStr }, 5)
+}
+`
+	mod := lowerSrcLLVM(t, src)
+	ir, err := GenerateModule(mod, Options{PackageName: "main", SourcePath: "/tmp/closure_lift_mixed.osty"})
+	if err != nil {
+		t.Fatalf("mixed-capture closure errored: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, "call ptr @osty.rt.closure_env_alloc_v2(i64 2") {
+		t.Fatalf("mixed-capture closure missing 2-capture v2 alloc:\n%s", got)
+	}
+	// Grab the bitmap arg. Accept either ordering. Must NOT be 0
+	// (both scalars) or 3 (both pointers).
+	hasBitmap1 := strings.Contains(got, "closure_env_alloc_v2(i64 2, ptr @") && strings.Contains(got, ", i64 1)")
+	hasBitmap2 := strings.Contains(got, "closure_env_alloc_v2(i64 2, ptr @") && strings.Contains(got, ", i64 2)")
+	if !hasBitmap1 && !hasBitmap2 {
+		t.Fatalf("expected bitmap `i64 1)` or `i64 2)` for one-pointer-one-scalar env, got:\n%s", got)
 	}
 }

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -357,7 +357,7 @@ fn main() {
 		// closure allocator (RUNTIME_GC_DELTA §2.4), so the trace
 		// callback for captures is installed at construction even
 		// though Phase 1 passes 0 captures.
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		"store ptr @__osty_closure_thunk_identity, ptr",
 		// Indirect call at the use site: load fn ptr from env[0],
 		// invoke through the loaded ptr with env as implicit arg 0.
@@ -443,7 +443,7 @@ fn main() {
 	for _, want := range []string{
 		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
 		"define private i64 @__osty_closure_thunk_dec(ptr %env, i64 %arg0)",
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		"= phi ptr [",
 		"= load ptr, ptr",
 		"= call i64 (ptr, i64)",
@@ -1156,7 +1156,7 @@ fn main() {
 		// the dedicated runtime allocator so its capture-tracing
 		// callback is installed at construction. Phase 1 passes 0
 		// captures; Phase 4 will grow the count.
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		// The FieldExpr call path loads the fn ptr from env and
 		// dispatches through it.
 		"= call i64 (ptr, i64)",
@@ -1196,7 +1196,7 @@ fn main() {
 	got := string(ir)
 	for _, want := range []string{
 		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		"= load ptr, ptr",
 		"= call i64 (ptr, i64)",
 	} {
@@ -1280,7 +1280,7 @@ fn main() {
 		"= call i64 (ptr, i64)",
 		// main materialises a GC-heap env for inc and passes it to
 		// apply via the Phase A4 closure-dedicated allocator.
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
 	} {
 		if !strings.Contains(got, want) {
@@ -1318,7 +1318,7 @@ fn main() {
 	for _, want := range []string{
 		"define void @apply2(ptr %f)",
 		"call void (ptr, i64, i64)",
-		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr",
 		"define private void @__osty_closure_thunk_printPair(ptr %env, i64 %arg0, i64 %arg1)",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -64,17 +64,20 @@ var fnValuePhase1CaptureCount = llvmClosureEnvPhase1CaptureCount()
 // fnSigRef so a subsequent call site can do indirect dispatch with
 // the correct signature.
 //
-// Allocation goes through `osty.rt.closure_env_alloc_v1` (Phase A4
+// Allocation goes through `osty.rt.closure_env_alloc_v2` (Phase A4
 // dedicated entry, RUNTIME_GC_DELTA §2.4). That helper attaches the
 // capture-tracing callback at construction so any managed pointers
 // placed in capture slots by a Phase 4 lowering are immediately
 // reachable from GC mark without revisiting the emit site.
 //
-// The env layout is `{ ptr fn, i64 capture_count, ptr captures[] }`.
-// `fn` at offset 0 is unchanged from the Phase 1 ABI, so existing
-// thunk call sites (`load ptr, ptr %env`) continue to work. For
-// Phase 1 the capture count is zero — the bulge only grows when the
-// capture-aware lowering lands.
+// The env layout is `{ ptr fn, i64 capture_count, i64 pointer_bitmap,
+// ptr captures[] }`. `fn` at offset 0 is unchanged from the Phase 1
+// ABI, so existing thunk call sites (`load ptr, ptr %env`) continue
+// to work. For Phase 1 the capture count is zero — bitmap is zero
+// too, and the env is a shell whose only job is to carry the thunk
+// pointer. Bit i of `pointer_bitmap` is 1 iff capture slot i holds a
+// managed pointer; the tracer consults it so scalar bit patterns can
+// never false-retain a live payload they happen to alias.
 //
 // Callers must already be inside a function — there is no
 // module-level fn-value literal path (globals would need a separate
@@ -85,13 +88,16 @@ func (g *generator) emitFnValueEnv(sig *fnSig) (value, error) {
 		return value{}, unsupportedf("call", "fn-value env for nil signature")
 	}
 	thunk := g.ensureFnValueThunk(sig)
-	g.declareRuntimeSymbol("osty.rt.closure_env_alloc_v1", "ptr", []paramInfo{
+	g.declareRuntimeSymbol("osty.rt.closure_env_alloc_v2", "ptr", []paramInfo{
 		{typ: "i64"},
 		{typ: "ptr"},
+		{typ: "i64"},
 	})
 	emitter := g.toOstyEmitter()
 	site := llvmStringLiteral(emitter, "runtime.closure.env.ptr")
-	env := llvmEmitClosureEnvAllocRuntime(emitter, fnValuePhase1CaptureCount, site.name, thunk)
+	// No captures, so bitmap is zero — the env carries only the thunk
+	// pointer at slot 0 and the tracer has nothing to mark.
+	env := llvmEmitClosureEnvAllocRuntime(emitter, fnValuePhase1CaptureCount, site.name, thunk, 0)
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
 	return value{
@@ -247,8 +253,10 @@ func requireFnValueSignature(v value, label string) (*fnSig, error) {
 //   - register a Phase 4 capturing thunk for the lifted fn that
 //     loads each capture from env at runtime and reorders args
 //     before calling the lifted fn
-//   - allocate env via `osty.rt.closure_env_alloc_v1(N, site, thunk)`;
-//     the helper writes the supplied symbol at slot 0
+//   - allocate env via `osty.rt.closure_env_alloc_v2(N, site, bitmap)`;
+//     the helper writes the supplied symbol at slot 0. `bitmap` bit i
+//     is 1 iff capture slot i holds a managed pointer — the tracer
+//     uses it to skip scalar slots unconditionally
 //   - eval each capture in the call site's lexical scope and
 //     store the result at env's capture slot i+1
 //
@@ -320,22 +328,27 @@ func (g *generator) emitClosureMakerCall(call *ast.CallExpr) (value, bool, error
 		captureVals[i] = loaded
 	}
 	thunkSym := g.ensureCapturingClosureThunk(rec, origParamCount, sig)
-	g.declareRuntimeSymbol("osty.rt.closure_env_alloc_v1", "ptr", []paramInfo{
+	if len(rec.captures) > 64 {
+		return value{}, true, unsupportedf("call", "closure %q captures %d values; pointer bitmap caps this at 64", rec.name, len(rec.captures))
+	}
+	bitmap := pointerBitmapForCaptures(rec.captures)
+	g.declareRuntimeSymbol("osty.rt.closure_env_alloc_v2", "ptr", []paramInfo{
 		{typ: "i64"},
 		{typ: "ptr"},
+		{typ: "i64"},
 	})
 	emitter := g.toOstyEmitter()
 	site := llvmStringLiteral(emitter, "runtime.closure.env.captures")
-	env := llvmEmitClosureEnvAllocRuntime(emitter, len(rec.captures), site.name, thunkSym)
+	env := llvmEmitClosureEnvAllocRuntime(emitter, len(rec.captures), site.name, thunkSym, bitmap)
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
-	// Store each capture at offset 16 + i*8. Header is
-	// `{ ptr fn, i64 cap_count }` (16 bytes); captures payload
-	// follows. The 8-byte stride keeps slot indexing uniform across
-	// scalar widths.
+	// Store each capture at `closureEnvCapturesOffset + i*8`. Header is
+	// `{ ptr fn, i64 cap_count, i64 pointer_bitmap }` (24 bytes);
+	// captures payload follows. The 8-byte stride keeps slot indexing
+	// uniform across scalar widths.
 	emitter = g.toOstyEmitter()
 	for i, cv := range captureVals {
-		offset := 16 + i*8
+		offset := llvmClosureEnvCapturesOffset() + i*8
 		slotPtr := llvmNextTemp(emitter)
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", slotPtr, env.name, offset))
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", cv.typ, cv.ref, slotPtr))
@@ -353,7 +366,7 @@ func (g *generator) emitClosureMakerCall(call *ast.CallExpr) (value, bool, error
 // for the lifted fn `sig.irName` and returns its symbol name.
 //
 //	define private RET @__osty_closure_thunk_<sym>(ptr %env, P0 %arg0, ...) {
-//	  %cap0_slot = getelementptr i8, ptr %env, i64 16
+//	  %cap0_slot = getelementptr i8, ptr %env, i64 24
 //	  %cap0 = load <CT0>, ptr %cap0_slot
 //	  ...
 //	  (%ret = )? call RET @<sym>(P0 %arg0, ..., <CT0> %cap0, ...)
@@ -409,7 +422,7 @@ func llvmCapturingClosureThunkDefinition(symbol string, returnType string, origP
 	}
 	captureArgParts := make([]string, 0, len(captureTypes))
 	for i, ct := range captureTypes {
-		offset := 16 + i*8
+		offset := llvmClosureEnvCapturesOffset() + i*8
 		slotName := fmt.Sprintf("%%cap%d_slot", i)
 		valName := fmt.Sprintf("%%cap%d", i)
 		lines = append(lines, fmt.Sprintf("  %s = getelementptr i8, ptr %%env, i64 %d", slotName, offset))

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -54,10 +54,10 @@ type nativeTupleInfo struct {
 // appended after the original closure params on the lifted fn -
 // the thunk loads them from env slots and forwards everything.
 //
-// Env layout: `ptr` fn slot at offset 0, `ptr` GC-trace slot at
-// offset 8, captures in declaration order at offset 16 + i*8 (each
-// capture occupies one 8-byte slot, even when the LLVM type is
-// smaller - matches legacy emit).
+// Env layout: `ptr fn` slot at offset 0, `i64 capture_count` at
+// offset 8, `i64 pointer_bitmap` at offset 16, captures in
+// declaration order at offset 24 + i*8 (each capture occupies one
+// 8-byte slot, even when the LLVM type is smaller).
 type nativeClosureInfo struct {
 	id           int
 	liftedName   string
@@ -4269,9 +4269,10 @@ func nativeEmitLiftedClosures(ctx *nativeProjectionCtx, out *llvmNativeModule) b
 // appendNativeClosureThunks appends one trampoline fn per
 // registered closure to the emitted LLVM IR text. The thunk ABI
 // is `(ptr env, <orig_params>)`; the body loads each capture from
-// env at offset 16 + i*8, then calls the lifted fn with
-// `(orig_args..., cap0, cap1, ...)`. Also emits a top-level
-// `declare` for the env-alloc helper (no-op if already present).
+// env at offset `closureEnvCapturesOffset + i*8`, then calls the
+// lifted fn with `(orig_args..., cap0, cap1, ...)`. Also emits a
+// top-level `declare` for the env-alloc helper (no-op if already
+// present).
 func appendNativeClosureThunks(out []byte, ctx *nativeProjectionCtx) []byte {
 	if ctx == nil || len(ctx.closuresByID) == 0 {
 		return out
@@ -4279,7 +4280,7 @@ func appendNativeClosureThunks(out []byte, ctx *nativeProjectionCtx) []byte {
 	if len(out) > 0 && out[len(out)-1] != '\n' {
 		out = append(out, '\n')
 	}
-	out = append(out, "declare ptr @osty.rt.closure_env_alloc_v1(i64, ptr)\n"...)
+	out = append(out, "declare ptr @osty.rt.closure_env_alloc_v2(i64, ptr, i64)\n"...)
 	for _, info := range ctx.closuresByID {
 		var b strings.Builder
 		b.WriteString("define private ")
@@ -4294,9 +4295,9 @@ func appendNativeClosureThunks(out []byte, ctx *nativeProjectionCtx) []byte {
 			b.WriteString(strconv.Itoa(i))
 		}
 		b.WriteString(") {\nentry:\n")
-		// Load each capture from env at offset 16 + i*8.
+		// Load each capture from env at offset `closureEnvCapturesOffset + i*8`.
 		for i, capType := range info.captureLLVMs {
-			b.WriteString(fmt.Sprintf("  %%cap%d_slot = getelementptr i8, ptr %%env, i64 %d\n", i, 16+i*8))
+			b.WriteString(fmt.Sprintf("  %%cap%d_slot = getelementptr i8, ptr %%env, i64 %d\n", i, llvmClosureEnvCapturesOffset()+i*8))
 			b.WriteString(fmt.Sprintf("  %%cap%d = load %s, ptr %%cap%d_slot\n", i, capType, i))
 		}
 		// Call the lifted fn: (orig_args..., cap0, cap1, ...). Env

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -48,7 +48,7 @@ const (
 	// a no-capture closure literal:
 	//
 	//   %site = <string literal ptr>
-	//   %env  = call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr %site)
+	//   %env  = call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr %site, i64 0)
 	//   store ptr <thunk_sym>, ptr %env
 	//
 	// `name` carries the thunk symbol (e.g. "@__osty_closure_thunk___osty_closure_1"),
@@ -1197,19 +1197,21 @@ func llvmNativeEvalInterfaceCall(emitter *LlvmEmitter, expr *llvmNativeExpr) *Ll
 
 // llvmNativeEvalClosureEnvAlloc emits the env-alloc + store-thunk
 // sequence used by a closure literal, plus (for capturing closures)
-// per-capture stores into env slots at offset 16 + i*8.
+// per-capture stores into env slots at offset
+// `closureEnvCapturesOffset + i*8`.
 //
 //	%site = <ptr to string literal>
-//	%env  = call ptr @osty.rt.closure_env_alloc_v1(i64 <N>, ptr %site)
+//	%env  = call ptr @osty.rt.closure_env_alloc_v2(i64 <N>, ptr %site, i64 <bitmap>)
 //	store ptr <thunkSym>, ptr %env
 //	; for each capture i:
-//	%cap<i>_slot = getelementptr i8, ptr %env, i64 <16 + i*8>
+//	%cap<i>_slot = getelementptr i8, ptr %env, i64 <closureEnvCapturesOffset + i*8>
 //	store <capType> <capVal>, ptr %cap<i>_slot
 //
 // `expr.text` has shape "<site>;<capType0>,<capType1>,..." — the
 // site label up to the first semicolon, then comma-separated
 // capture LLVM types (empty for no-capture). The capture values
-// are `expr.childExprs` in declaration order.
+// are `expr.childExprs` in declaration order. Bit i of the pointer
+// bitmap is set iff `capTypes[i] == "ptr"` (RUNTIME_GC §2.4).
 func llvmNativeEvalClosureEnvAlloc(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
 	if emitter == nil || expr == nil {
 		return llvmNativeZeroValue("ptr")
@@ -1220,11 +1222,18 @@ func llvmNativeEvalClosureEnvAlloc(emitter *LlvmEmitter, expr *llvmNativeExpr) *
 		capTypesRaw = expr.text[idx+1:]
 	}
 	capTypes := splitArgTypes(capTypesRaw)
+	var bitmap uint64
+	for i, t := range capTypes {
+		if t == "ptr" {
+			bitmap |= uint64(1) << uint(i)
+		}
+	}
 	site := llvmStringLiteral(emitter, siteLabel)
 	env := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)", env, len(capTypes), site.name))
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v2(i64 %d, ptr %s, i64 %d)", env, len(capTypes), site.name, bitmap))
 	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", expr.name, env))
-	// Store each capture value into its env slot at offset 16 + i*8.
+	// Store each capture value into its env slot at offset
+	// `closureEnvCapturesOffset + i*8`.
 	for i, child := range expr.childExprs {
 		val := llvmNativeEvalExpr(emitter, child)
 		typ := "i64"
@@ -1233,7 +1242,7 @@ func llvmNativeEvalClosureEnvAlloc(emitter *LlvmEmitter, expr *llvmNativeExpr) *
 		}
 		slot := fmt.Sprintf("%%cap%d_slot", i)
 		// Use raw-named slot (matches legacy shape so tests can lock it).
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", slot, env, 16+i*8))
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", slot, env, llvmClosureEnvCapturesOffset()+i*8))
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", typ, val.name, slot))
 	}
 	return &LlvmValue{typ: "ptr", name: env}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -744,14 +744,22 @@ func llvmClosureEnvPhase1CaptureCount() int {
 	return 0
 }
 
+// Byte offset where capture slots begin in a closure env: `ptr fn` (0) +
+// `i64 capture_count` (8) + `i64 pointer_bitmap` (16) + `captures[]` (24).
+// RUNTIME_GC §2.4 — the bitmap gives a structural guarantee against scalar
+// false-retention during trace.
+func llvmClosureEnvCapturesOffset() int {
+	return 24
+}
+
 // Osty: toolchain/llvmgen.osty:569:5
-func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
+func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string, pointerBitmap uint64) *LlvmValue {
 	// Osty: toolchain/llvmgen.osty:575:5
 	envTemp := llvmNextTemp(emitter)
 	_ = envTemp
 	// Osty: toolchain/llvmgen.osty:576:5
 	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %s, ptr %s)", ostyToString(envTemp), ostyToString(captureCount), ostyToString(siteName)))
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v2(i64 %s, ptr %s, i64 %d)", ostyToString(envTemp), ostyToString(captureCount), ostyToString(siteName), pointerBitmap))
 		return struct{}{}
 	}()
 	// Osty: toolchain/llvmgen.osty:579:5

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -557,7 +557,7 @@ pub fn llvmPlanSafepointChunks(
 ///
 /// Points at the dedicated `OSTY_GC_KIND_CLOSURE_ENV = 1029`
 /// reservation in the runtime. The closure allocation path itself
-/// uses `osty.rt.closure_env_alloc_v1`, which installs the
+/// uses `osty.rt.closure_env_alloc_v2`, which installs the
 /// capture-tracing callback at construction; this constant is
 /// retained for heap-dump / `osty_gc_stats` categorisation and as
 /// the pivot for any direct `osty.gc.alloc_v1` caller that wants to
@@ -571,11 +571,18 @@ pub fn llvmClosureEnvGcKind() -> Int { 1029 }
 /// capture-aware lowering lands.
 pub fn llvmClosureEnvPhase1CaptureCount() -> Int { 0 }
 
+/// Byte offset where capture slots begin in a closure env. Layout:
+/// `ptr fn` (0) + `i64 capture_count` (8) + `i64 pointer_bitmap` (16)
+/// + `captures[]` (24). Bumped from 16 when the bitmap field landed
+/// (RUNTIME_GC §2.4 — structural guarantee against scalar
+/// false-retention).
+pub fn llvmClosureEnvCapturesOffset() -> Int { 24 }
+
 /// Phase A4 closure env allocation + thunk install. Calls
-/// `osty.rt.closure_env_alloc_v1` with the supplied capture count
-/// (currently always `llvmClosureEnvPhase1CaptureCount()`) and a
-/// diagnostic site, then stores the thunk symbol at slot 0 so
-/// subsequent indirect calls can dispatch through the env. Returns
+/// `osty.rt.closure_env_alloc_v2` with the supplied capture count, a
+/// diagnostic site, and the pointer bitmap (bit i = 1 iff capture slot
+/// i holds a managed pointer), then stores the thunk symbol at slot 0
+/// so subsequent indirect calls can dispatch through the env. Returns
 /// the env pointer as a `ptr`-typed LlvmValue. The runtime helper
 /// attaches the capture-tracing GC callback at construction so any
 /// managed pointers a Phase 4 lowering drops into capture slots are
@@ -585,10 +592,11 @@ pub fn llvmEmitClosureEnvAllocRuntime(
     captureCount: Int,
     siteName: String,
     thunkSymbol: String,
+    pointerBitmap: Int,
 ) -> LlvmValue {
     let envTemp = llvmNextTemp(emitter)
     emitter.body.push(
-        "  {envTemp} = call ptr @osty.rt.closure_env_alloc_v1(i64 {captureCount}, ptr {siteName})",
+        "  {envTemp} = call ptr @osty.rt.closure_env_alloc_v2(i64 {captureCount}, ptr {siteName}, i64 {pointerBitmap})",
     )
     emitter.body.push("  store ptr @{thunkSymbol}, ptr {envTemp}")
     LlvmValue { typ: "ptr", name: envTemp, pointer: false }

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -1479,11 +1479,11 @@ fn testLlvmEmitSafepointWithRootsIsOstyOwned() {
 
 fn testLlvmEmitClosureEnvAllocRuntimeIsOstyOwned() {
     let emitter = llvmEmitter()
-    let env = llvmEmitClosureEnvAllocRuntime(emitter, 0, "@.str0", "__osty_closure_thunk_foo")
+    let env = llvmEmitClosureEnvAllocRuntime(emitter, 0, "@.str0", "__osty_closure_thunk_foo", 0)
     let ir = llvmTestStrings.join(emitter.body, "\n")
 
     testing.assertEq(env.typ, "ptr")
     testing.assertEq(env.name, "%t0")
-    assertLlvmContains(ir, "%t0 = call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr @.str0)")
+    assertLlvmContains(ir, "%t0 = call ptr @osty.rt.closure_env_alloc_v2(i64 0, ptr @.str0, i64 0)")
     assertLlvmContains(ir, "store ptr @__osty_closure_thunk_foo, ptr %t0")
 }


### PR DESCRIPTION
## Summary

- Replaces the probabilistic scalar-skipping closure-env trace with a **per-env pointer bitmap** so scalar bit patterns that alias a live heap address can no longer false-retain that payload through the env (RUNTIME_GC §2.4 — the structural-guarantee follow-up called out in the v1 comment).
- ABI bump: \`osty.rt.closure_env_alloc_v1(count, site)\` → \`osty.rt.closure_env_alloc_v2(count, site, bitmap)\`. Env layout grows by 8 bytes: \`{ ptr fn, i64 capture_count, i64 pointer_bitmap, ptr captures[] }\`.
- Capture slot offsets shift 16→24. Capture count now capped at 64 (bitmap width); exceeding aborts at alloc.

## Why

The v1 trace called \`mark_slot_v1\` on every capture slot, relying on \`find_header\` to reject invalid pointers. For scalars this is statistically fine on a 64-bit host but not structural — a scalar whose 8-byte bit pattern happens to equal a valid heap address would keep that payload alive for one extra cycle. Under v2 the frontend records which slots are managed pointers at alloc time and the tracer skips scalar slots unconditionally.

## What changed

- **Runtime** (\`internal/backend/runtime/osty_runtime.c\`): new \`osty_rt_closure_env_alloc_v2\`, \`pointer_bitmap\` field, trace consults bit i.
- **Codegen** (\`internal/llvmgen/fn_value.go\`, \`closure_lift.go\`, \`ir_native_entry.go\`, \`native_entry_snapshot.go\`): \`pointerBitmapForCaptures\` helper computes bitmap from capture LLVM types (\`ptr\` → bit set, scalars → bit clear). Slot offsets use new \`llvmClosureEnvCapturesOffset()\` (= 24).
- **Toolchain** (\`toolchain/llvmgen.osty\` + \`internal/llvmgen/support_snapshot.go\`): Osty source + Go snapshot kept in sync.
- **Docs** (\`RUNTIME_GC_DELTA.md\`): §2.4 entry updated to reflect the structural guarantee.

## Test plan

- [x] \`TestBundledRuntimeClosureEnvTracesCaptures\` — updated for v2 ABI; confirms pointer captures still survive GC via the bitmap.
- [x] \`TestBundledRuntimeClosureEnvBitmapSkipsScalarSlots\` (new) — stores a live payload's raw address into a scalar capture slot, asserts it is swept after collect. **This is the structural guarantee**: under v1 the payload would survive; under v2 it dies.
- [x] \`TestClosureLiftCapturingMixedScalarAndPointerEncodesBitmap\` (new) — locks the codegen-side bitmap encoding for a mixed Int + String closure.
- [x] Existing \`TestClosureLift*\` / \`TestField*\` / \`TestFnValue*\` assertions updated for the v2 symbol name + new offsets. All pass.
- [x] \`go build ./...\` / \`go vet ./...\` clean.
- Two pre-existing test failures on \`main\` (\`TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes\`, \`TestToolchainHasNoPhantomRangeExpr\`, \`TestLexAsQuestionSingleToken\`, \`TestResolveUndefinedLoopLabel\`) are unrelated to this change and reproduce on \`bc2a6407\` with the diff stashed.

## Reviewer notes

- The 64-capture cap is a hard runtime abort. Closures never approach this in practice, and the diagnostic is explicit (\"closure env capture count exceeds bitmap width (max 64)\"). If the cap ever matters, the layout can swap the inline bitmap for a shape-descriptor pointer without touching the tracer semantics.
- The write to \`env->captures[i]\` in the test harness doesn't go through a write barrier — intentional, because the harness uses \`osty_gc_debug_collect\` which is a full STW cycle where the tracer walks the env's slot list fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)