### PR TITLE
feat(llvmgen): extend vectorize fast-path to local scalar Lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -830,7 +830,7 @@ fn parseTokens(tokens: List<Token>) -> Result<Config, Error> { ... }
 | 61 | `#[json(...)]` | struct field / variant |
 | 62 | `#[deprecated(...)]` | W0750 |
 | 63 | 값 = 리터럴 전용 | 검증 용이 |
-| 63.1 | **기본 ON** + `#[vectorize(scalable, predicate, width = N)]` + `#[no_vectorize]` | v0.6 A5/A5.1/A5.2. 기본은 모든 함수에서 `vectorize.enable` + safepoint 스킵. tuning args 로 strategy 지정; opt-out 은 `#[no_vectorize]`. |
+| 63.1 | **기본 ON** + `#[vectorize(scalable, predicate, width = N)]` + `#[no_vectorize]` | v0.6 A5/A5.1/A5.2. 기본은 모든 함수에서 `vectorize.enable` + safepoint 스킵. tuning args 로 strategy 지정; opt-out 은 `#[no_vectorize]`. 스칼라 `List<T>` (i64/i1/double) subscript 는 param 이든 local 이든 MIR lazy snapshot 으로 fast path 진입 — CFG forward reachability 로 뮤테이션 도달 가능하면 slow call 로 fallback (`mir_generator.go:snapshotVectorListLocal` / `mirLocalMutationReachableFrom`). `osty_rt_list_data_* / len / get_*` 는 `memory(read)` 로 선언되어 LLVM LICM 이 hoist 가능. |
 | 63.2 | `#[parallel]` | v0.6 A6. `!llvm.access.group` + `loop.parallel_accesses` 로 alias analysis 우회. soundness는 프로그래머 책임. |
 | 63.3 | `#[unroll]` / `#[unroll(count = N)]` | v0.6 A7. `loop.unroll.enable` 또는 `loop.unroll.count`. vectorize와 독립적. |
 | 63.4 | `#[inline]` / `#[inline(always)]` / `#[inline(never)]` | v0.6 A8. LLVM `inlinehint` / `alwaysinline` / `noinline` fn attr. |

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -29,6 +29,20 @@ AVX-512 cost model 우회 문서화.
    루프가 bracketed 되어 GC liveness 는 유지. 실측: XOR reduction 1M
    × 200 iterations — scalar 0.28s vs vectorized 0.06s = **4.7× 속도
    향상**, ARM NEON `eor.16b` / `add.2d` emission 확인.
+1a. ~~**Local scalar List subscript fast path.**~~ **해소됨.** 이전에는
+   `emitVectorListPreamble` 이 함수 entry 에서 파라미터만 snapshot 해서
+   `let mut xs: List<Int> = []; push…; for i in 0..xs.len() { xs[i] }`
+   같은 "build-then-read" 패턴의 read 루프가 매 iteration 에서
+   `@osty_rt_list_get_i64` 를 호출했고, LLVM vectorizer 가 "call
+   instruction cannot be vectorized" 로 bail 했다. 해소 경로는
+   `emitVectorListFastLoad` 에 lazy snapshot 을 추가하고 forward-CFG
+   reachability gate (`mirLocalMutationReachableFrom`) 로 뮤테이션이
+   snapshot site 로부터 도달 가능하면 slow call 로 fallback — realloc
+   으로 인한 stale data ptr 캐싱을 막는다. 동시에 런타임 data / len /
+   get 선언에 `memory(read)` 를 부여해 LLVM LICM 이 snapshot call 을
+   hoist 할 수 있게 한다. 회귀 테스트는 `vectorize_real_simd_test.go`
+   의 `TestVectorizeAppliesToListLocalReadLoop` (happy path) 와
+   `TestVectorizeLazySnapshotRespectsInLoopMutation` (soundness gate).
 2. **Iterator-protocol loops.** `for x in iter` (iter 가 `List<T>` /
    range / `Map<K, V>` 가 아닌 경우) 는 callback-driven shape 로
    lower 되어 LLVM 이 trip count 를 볼 수 없다. 해결 경로는

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1712,48 +1712,188 @@ func (g *mirGen) emitVectorListPreamble(fn *mir.Function) {
 	for _, rawID := range ids {
 		pid := mir.LocalID(rawID)
 		elemLLVM := eligible[pid]
-		slot := g.localSlots[pid]
-		if slot == "" {
-			continue
-		}
-		listReg := g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(listReg)
-		g.fnBuf.WriteString(" = load ptr, ptr ")
-		g.fnBuf.WriteString(slot)
-		g.fnBuf.WriteByte('\n')
-
-		dataSym := listRuntimeDataSymbol(elemLLVM)
-		g.declareRuntime(dataSym, "declare ptr @"+dataSym+"(ptr)")
-		dataReg := g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(dataReg)
-		g.fnBuf.WriteString(" = call ptr @")
-		g.fnBuf.WriteString(dataSym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(listReg)
-		g.fnBuf.WriteString(")\n")
-		g.vectorListData[pid] = dataReg
-
-		lenSym := listRuntimeLenSymbol()
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr)")
-		lenReg := g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(lenReg)
-		g.fnBuf.WriteString(" = call i64 @")
-		g.fnBuf.WriteString(lenSym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(listReg)
-		g.fnBuf.WriteString(")\n")
-		g.vectorListLens[pid] = lenReg
+		g.snapshotVectorListLocal(pid, elemLLVM)
 	}
 }
 
+// mirBlockSuccessors returns the out-edges of a MIR block — the set of
+// block IDs control can transfer to from the terminator. Used by
+// mirLocalMutationReachableFrom for forward-CFG analysis.
+func mirBlockSuccessors(bb *mir.BasicBlock) []mir.BlockID {
+	if bb == nil {
+		return nil
+	}
+	switch t := bb.Term.(type) {
+	case *mir.GotoTerm:
+		return []mir.BlockID{t.Target}
+	case *mir.BranchTerm:
+		return []mir.BlockID{t.Then, t.Else}
+	case *mir.SwitchIntTerm:
+		out := make([]mir.BlockID, 0, len(t.Cases)+1)
+		for _, c := range t.Cases {
+			out = append(out, c.Target)
+		}
+		out = append(out, t.Default)
+		return out
+	}
+	return nil
+}
+
+// mirLocalIsMutatedIn returns true if any instruction in `bb` mutates
+// `local` — i.e., passes it to an unsafe call/intrinsic, or reassigns
+// it via an AssignInstr. Mirrors the bailout rules in
+// eligibleVectorListParams but scoped to a single block and a single
+// local.
+func mirLocalIsMutatedIn(bb *mir.BasicBlock, local mir.LocalID) bool {
+	if bb == nil {
+		return false
+	}
+	touchesLocal := func(operands []mir.Operand) bool {
+		for _, op := range operands {
+			if id, ok := mirOperandRootLocal(op); ok && id == local {
+				return true
+			}
+		}
+		return false
+	}
+	for _, inst := range bb.Instrs {
+		switch x := inst.(type) {
+		case *mir.CallInstr:
+			if touchesLocal(x.Args) {
+				return true
+			}
+		case *mir.IntrinsicInstr:
+			if mirIntrinsicSafeForVectorListFastPath(x.Kind) {
+				continue
+			}
+			if touchesLocal(x.Args) {
+				return true
+			}
+		case *mir.AssignInstr:
+			if x.Dest.Local == local {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mirLocalMutationReachableFrom returns true if, starting from block
+// `fromBB` and walking the forward CFG, any reachable block mutates
+// `local`. "Reaches itself" counts — so a loop body that contains both
+// the snapshot site and a push is correctly rejected. This is the
+// soundness gate that keeps the lazy snapshot path from caching a stale
+// `data` pointer past a reallocation.
+func mirLocalMutationReachableFrom(fn *mir.Function, fromBB mir.BlockID, local mir.LocalID) bool {
+	if fn == nil {
+		return false
+	}
+	visited := make(map[mir.BlockID]bool, len(fn.Blocks))
+	stack := []mir.BlockID{fromBB}
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if visited[id] {
+			continue
+		}
+		visited[id] = true
+		bb := fn.Block(id)
+		if bb == nil {
+			continue
+		}
+		if mirLocalIsMutatedIn(bb, local) {
+			return true
+		}
+		for _, s := range mirBlockSuccessors(bb) {
+			if !visited[s] {
+				stack = append(stack, s)
+			}
+		}
+	}
+	return false
+}
+
+// snapshotVectorListLocal emits a one-shot `data`/`len` capture for the
+// given scalar-List local (param or plain local) and records the result
+// registers in `vectorListData` / `vectorListLens`. Callers must have
+// already ensured the local has a stored value by the time this runs;
+// emitting too early (before the backing `osty_rt_list_*` object is
+// assigned) would capture an uninitialised slot. The helper is a no-op
+// when a snapshot already exists or the element type isn't fast-path
+// eligible (i64 / i1 / double).
+//
+// The data/len runtime symbols are declared with `memory(read)` so
+// LLVM's LICM can hoist the snapshot out of any loop that doesn't
+// mutate the list — which is what lets this path deliver real-world
+// SIMD speedups for plain `for i in 0..xs.len() { acc ^= xs[i] }`
+// patterns on locals (not just params).
+func (g *mirGen) snapshotVectorListLocal(local mir.LocalID, elemLLVM string) {
+	if !listUsesRawDataFastPath(elemLLVM) {
+		return
+	}
+	slot := g.localSlots[local]
+	if slot == "" {
+		return
+	}
+	if g.vectorListData[local] != "" && g.vectorListLens[local] != "" {
+		return
+	}
+	listReg := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(" = load ptr, ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteByte('\n')
+
+	dataSym := listRuntimeDataSymbol(elemLLVM)
+	g.declareRuntime(dataSym, "declare ptr @"+dataSym+"(ptr) nounwind willreturn memory(read)")
+	dataReg := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(dataReg)
+	g.fnBuf.WriteString(" = call ptr @")
+	g.fnBuf.WriteString(dataSym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(")\n")
+	g.vectorListData[local] = dataReg
+
+	lenSym := listRuntimeLenSymbol()
+	g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+	lenReg := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(lenReg)
+	g.fnBuf.WriteString(" = call i64 @")
+	g.fnBuf.WriteString(lenSym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(")\n")
+	g.vectorListLens[local] = lenReg
+}
+
 func (g *mirGen) emitVectorListFastLoad(local mir.LocalID, idxVal, elemLLVM string) (string, bool) {
+	slot := g.localSlots[local]
+	if slot == "" {
+		return "", false
+	}
+	// Lazy snapshot: when a local scalar List wasn't captured at
+	// function entry (i.e., it isn't an eligible param) but is about
+	// to be subscripted, emit the data/len capture here — provided no
+	// mutation of this local is forward-reachable in the CFG. The
+	// reachability gate is the correctness anchor: without it, a later
+	// push could reallocate the list's backing buffer and the cached
+	// `dataReg` would dangle. With it, LLVM's LICM still hoists the
+	// memory(read) snapshot calls out of non-mutating loops, so the
+	// resulting fast/slow branch matches the preamble shape that
+	// already vectorizes for params.
+	if g.vectorListData[local] == "" || g.vectorListLens[local] == "" {
+		if mirLocalMutationReachableFrom(g.fn, g.curBlockID, local) {
+			return "", false
+		}
+		g.snapshotVectorListLocal(local, elemLLVM)
+	}
 	dataReg := g.vectorListData[local]
 	lenReg := g.vectorListLens[local]
-	slot := g.localSlots[local]
-	if dataReg == "" || lenReg == "" || slot == "" {
+	if dataReg == "" || lenReg == "" {
 		return "", false
 	}
 	inBounds := g.fresh()
@@ -1801,7 +1941,12 @@ func (g *mirGen) emitVectorListFastLoad(local mir.LocalID, idxVal, elemLLVM stri
 	g.fnBuf.WriteByte('\n')
 
 	slowSym := listRuntimeGetSymbol(elemLLVM)
-	g.declareRuntime(slowSym, "declare "+elemLLVM+" @"+slowSym+"(ptr, i64)")
+	// memory(read): the typed slow-path read is semantically pure
+	// (modulo an idempotent first-call layout init). Marking it
+	// readonly lets LLVM reason across the fast/slow branch and keep
+	// the loop vectorizable even when the slow path is theoretically
+	// reachable for OOB indices.
+	g.declareRuntime(slowSym, "declare "+elemLLVM+" @"+slowSym+"(ptr, i64) nounwind willreturn memory(read)")
 	g.fnBuf.WriteString(slowLabel)
 	g.fnBuf.WriteString(":\n")
 	listReg := g.fresh()
@@ -3067,7 +3212,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			}
 		}
 		sym := listRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr) nounwind willreturn memory(read)")
 		em := g.ostyEmitter()
 		result := llvmListLen(em, &LlvmValue{typ: "ptr", name: listReg})
 		g.flushOstyEmitter(em)
@@ -3092,7 +3237,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 				}
 			}
 			sym := listRuntimeGetSymbol(elemLLVM)
-			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
+			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64) nounwind willreturn memory(read)")
 			em := g.ostyEmitter()
 			result := llvmListGet(em,
 				&LlvmValue{typ: "ptr", name: listReg},

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2366,15 +2366,14 @@ func llvmListElementSuffix(typ string) string {
 
 // Osty: toolchain/llvmgen.osty:1819:5
 func llvmListRuntimeDeclarations() []string {
-	// List runtime ops. `osty_rt_list_len` is a pure read of the
-	// list's `len` field — annotated `memory(read)` so LLVM LICMs
-	// the call and CSEs repeated reads on the same list.
-	//
-	// Mutating ops (push / insert / set / sorted / to_set / get_*
-	// / data_*) are marked `nounwind willreturn` — they may write
-	// but never throw and always return. That's enough for LLVM to
-	// speculate around them and simplify control flow, without
-	// claiming they're pure.
+	// List runtime ops. `osty_rt_list_len` / typed `get_*` / typed
+	// `data_*` are pure reads of the list header — annotated
+	// `memory(read)` so LLVM's LICM can hoist them out of non-mutating
+	// loops and LoopVectorizer can keep scalar reduction loops
+	// vectorizable. The `ensure_layout` side effect inside these is
+	// idempotent after first call, so CSE/hoist/elim are semantically
+	// safe. Mutating ops (push / insert / set / sorted / to_set) stay
+	// on `nounwind willreturn` — they may realloc the backing buffer.
 	return []string{
 		"declare ptr @osty_rt_list_new() nounwind willreturn",
 		"declare i64 @osty_rt_list_len(ptr) nounwind willreturn memory(read)",
@@ -2387,13 +2386,13 @@ func llvmListRuntimeDeclarations() []string {
 		"declare void @osty_rt_list_insert_i1(ptr, i64, i1) nounwind willreturn",
 		"declare void @osty_rt_list_insert_f64(ptr, i64, double) nounwind willreturn",
 		"declare void @osty_rt_list_insert_ptr(ptr, i64, ptr) nounwind willreturn",
-		"declare i64 @osty_rt_list_get_i64(ptr, i64) nounwind willreturn",
-		"declare i1 @osty_rt_list_get_i1(ptr, i64) nounwind willreturn",
-		"declare double @osty_rt_list_get_f64(ptr, i64) nounwind willreturn",
-		"declare ptr @osty_rt_list_get_ptr(ptr, i64) nounwind willreturn",
-		"declare ptr @osty_rt_list_data_i64(ptr) nounwind willreturn",
-		"declare ptr @osty_rt_list_data_i1(ptr) nounwind willreturn",
-		"declare ptr @osty_rt_list_data_f64(ptr) nounwind willreturn",
+		"declare i64 @osty_rt_list_get_i64(ptr, i64) nounwind willreturn memory(read)",
+		"declare i1 @osty_rt_list_get_i1(ptr, i64) nounwind willreturn memory(read)",
+		"declare double @osty_rt_list_get_f64(ptr, i64) nounwind willreturn memory(read)",
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64) nounwind willreturn memory(read)",
+		"declare ptr @osty_rt_list_data_i64(ptr) nounwind willreturn memory(read)",
+		"declare ptr @osty_rt_list_data_i1(ptr) nounwind willreturn memory(read)",
+		"declare ptr @osty_rt_list_data_f64(ptr) nounwind willreturn memory(read)",
 		"declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64) nounwind willreturn",
 		"declare void @osty_rt_list_set_i64(ptr, i64, i64) nounwind willreturn",
 		"declare void @osty_rt_list_set_i1(ptr, i64, i1) nounwind willreturn",

--- a/internal/llvmgen/vectorize_real_simd_test.go
+++ b/internal/llvmgen/vectorize_real_simd_test.go
@@ -6,7 +6,47 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
+
+// lowerThroughMIR runs the same full pipeline as `osty build --backend
+// llvm`: parse → resolve → check → ir.Lower → Monomorphize → mir.Lower
+// → GenerateFromMIR. Tests that want to assert on the IR the native
+// dispatcher actually selects must go through this path; `generateFromAST`
+// is the legacy HIR emitter and doesn't reach the MIR-only fast-path
+// machinery.
+func lowerThroughMIR(t *testing.T, src string) string {
+	t.Helper()
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower: %v", issues)
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/vectorize_mir_probe.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	return string(out)
+}
 
 // TestVectorizeFunctionBodyIsCallFree pins the GC-contract side of the
 // v0.6 A5 delivery: inside a `#[vectorize]` function the lowered loop
@@ -142,6 +182,108 @@ fn main() {
 		t.Fatalf("clang -O3 on annotated IR did not vectorize the loop; "+
 			"expected a `remark: vectorized loop` line. Full output:\n%s",
 			remarks)
+	}
+}
+
+// TestVectorizeAppliesToListLocalReadLoop pins the "plain everyday code
+// should SIMD" promise of the default-on vectorize flip: build a local
+// `List<Int>`, then run a read-only XOR reduction over it. The MIR
+// emitter has long had a fast-path for *parameter* lists, but before
+// the lazy snapshot was added the caller had no way to cover locals —
+// so the reduction loop kept calling `@osty_rt_list_get_i64` per
+// iteration and LLVM's vectorizer bailed ("call instruction cannot be
+// vectorized"). This test is the regression oracle for that gap:
+// without the MIR-side snapshot + `memory(read)` attributes on the
+// list runtime surface, it fails at the clang remark check.
+func TestVectorizeAppliesToListLocalReadLoop(t *testing.T) {
+	clangPath, err := exec.LookPath("clang")
+	if err != nil {
+		t.Skip("clang not on PATH — skipping integration oracle")
+	}
+
+	src := `fn computeXor(n: Int) -> Int {
+    let mut xs: List<Int> = []
+    let mut k = 0
+    while k < n {
+        xs.push(k)
+        k = k + 1
+    }
+    let mut acc = 0
+    for j in 0..xs.len() {
+        acc = acc ^ xs[j]
+    }
+    acc
+}
+
+fn main() {
+    let _ = computeXor(64)
+}
+`
+	ir := lowerThroughMIR(t, src)
+
+	irPath := filepath.Join(t.TempDir(), "module.ll")
+	if err := writeBytes(irPath, []byte(ir)); err != nil {
+		t.Fatalf("write ir: %v", err)
+	}
+	cmd := exec.Command(clangPath,
+		"-x", "ir",
+		"-O3",
+		"-S",
+		"-o", filepath.Join(t.TempDir(), "module.s"),
+		"-Rpass=loop-vectorize",
+		irPath,
+	)
+	out, runErr := cmd.CombinedOutput()
+	remarks := string(out)
+	if runErr != nil {
+		t.Fatalf("clang -O3 on list-local IR failed: %v\n%s", runErr, remarks)
+	}
+	if !strings.Contains(remarks, "vectorized loop") {
+		fnBody, _ := extractFunctionBody(ir, "computeXor")
+		t.Fatalf("clang -O3 did not vectorize a read-only loop over a local "+
+			"List<Int>; default-on vectorize is effectively a no-op on "+
+			"everyday code. Remarks:\n%s\n\ncomputeXor body:\n%s",
+			remarks, fnBody)
+	}
+}
+
+// TestVectorizeLazySnapshotRespectsInLoopMutation is the soundness
+// oracle for the lazy-snapshot fast path: when a subscript read shares
+// a loop body with a mutation (push/set/insert) on the same local,
+// caching `data`/`len` across iterations would hand out stale pointers
+// after a reallocation. The CFG reachability gate must detect this and
+// fall back to the typed slow-path runtime call — we pin that by
+// asserting the emitted IR does NOT grow a `list.fast.*` branch inside
+// the mixed loop, and the slow-path `@osty_rt_list_get_i64` call stays
+// in the loop body.
+func TestVectorizeLazySnapshotRespectsInLoopMutation(t *testing.T) {
+	src := `fn mixed(n: Int) -> Int {
+    let mut xs: List<Int> = []
+    let mut acc = 0
+    for i in 0..n {
+        xs.push(i)
+        acc = acc ^ xs[0]
+    }
+    acc
+}
+
+fn main() {
+    let _ = mixed(8)
+}
+`
+	ir := lowerThroughMIR(t, src)
+	body, ok := extractFunctionBody(ir, "mixed")
+	if !ok {
+		t.Fatalf("mixed function not found:\n%s", ir)
+	}
+	if strings.Contains(body, "list.fast.") {
+		t.Fatalf("lazy fast path fired for a local that is mutated in "+
+			"the same loop as the read — would cache a stale data ptr "+
+			"across a realloc. Body:\n%s", body)
+	}
+	if !strings.Contains(body, "@osty_rt_list_get_i64") {
+		t.Fatalf("expected the typed slow-path call to still be present "+
+			"in the mixed loop (soundness fallback). Body:\n%s", body)
 	}
 }
 

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2726,37 +2726,52 @@ pub fn llvmListElementSuffix(typ: String) -> String {
 /// LLVM forward declarations for the `osty_rt_list_*` C runtime surface
 /// used by the scalar List<T> codegen path. The native backend emits
 /// these once per module that touches typed lists.
+///
+/// Attribute conventions:
+/// - `memory(read)` on len / typed get / typed data — pure reads of the
+///   list header. `ensure_layout` is idempotent after first call, so
+///   LLVM is free to CSE / hoist / eliminate these across iterations.
+///   This is what lets the LoopVectorizer keep scalar List<T> reduction
+///   loops vectorizable even when the typed slow-path call is the only
+///   branch that stays live. See internal/llvmgen/mir_generator.go
+///   `snapshotVectorListLocal` + `emitVectorListFastLoad` for the
+///   lazy-snapshot consumer of these attributes.
+/// - Mutating ops (push / insert / set / sorted / to_set) stay on just
+///   `nounwind willreturn` — they may realloc the backing buffer.
 pub fn llvmListRuntimeDeclarations() -> List<String> {
     [
-        "declare ptr @osty_rt_list_new()",
-        "declare i64 @osty_rt_list_len(ptr)",
-        "declare void @osty_rt_list_push_i64(ptr, i64)",
-        "declare void @osty_rt_list_push_i1(ptr, i1)",
-        "declare void @osty_rt_list_push_f64(ptr, double)",
-        "declare void @osty_rt_list_push_ptr(ptr, ptr)",
-        "declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)",
-        "declare void @osty_rt_list_insert_i64(ptr, i64, i64)",
-        "declare void @osty_rt_list_insert_i1(ptr, i64, i1)",
-        "declare void @osty_rt_list_insert_f64(ptr, i64, double)",
-        "declare void @osty_rt_list_insert_ptr(ptr, i64, ptr)",
-        "declare i64 @osty_rt_list_get_i64(ptr, i64)",
-        "declare i1 @osty_rt_list_get_i1(ptr, i64)",
-        "declare double @osty_rt_list_get_f64(ptr, i64)",
-        "declare ptr @osty_rt_list_get_ptr(ptr, i64)",
-        "declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)",
-        "declare void @osty_rt_list_set_i64(ptr, i64, i64)",
-        "declare void @osty_rt_list_set_i1(ptr, i64, i1)",
-        "declare void @osty_rt_list_set_f64(ptr, i64, double)",
-        "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
-        "declare ptr @osty_rt_list_sorted_i64(ptr)",
-        "declare ptr @osty_rt_list_sorted_i1(ptr)",
-        "declare ptr @osty_rt_list_sorted_f64(ptr)",
-        "declare ptr @osty_rt_list_sorted_string(ptr)",
-        "declare ptr @osty_rt_list_to_set_i64(ptr)",
-        "declare ptr @osty_rt_list_to_set_i1(ptr)",
-        "declare ptr @osty_rt_list_to_set_f64(ptr)",
-        "declare ptr @osty_rt_list_to_set_ptr(ptr)",
-        "declare ptr @osty_rt_list_to_set_string(ptr)",
+        "declare ptr @osty_rt_list_new() nounwind willreturn",
+        "declare i64 @osty_rt_list_len(ptr) nounwind willreturn memory(read)",
+        "declare void @osty_rt_list_push_i64(ptr, i64) nounwind willreturn",
+        "declare void @osty_rt_list_push_i1(ptr, i1) nounwind willreturn",
+        "declare void @osty_rt_list_push_f64(ptr, double) nounwind willreturn",
+        "declare void @osty_rt_list_push_ptr(ptr, ptr) nounwind willreturn",
+        "declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64) nounwind willreturn",
+        "declare void @osty_rt_list_insert_i64(ptr, i64, i64) nounwind willreturn",
+        "declare void @osty_rt_list_insert_i1(ptr, i64, i1) nounwind willreturn",
+        "declare void @osty_rt_list_insert_f64(ptr, i64, double) nounwind willreturn",
+        "declare void @osty_rt_list_insert_ptr(ptr, i64, ptr) nounwind willreturn",
+        "declare i64 @osty_rt_list_get_i64(ptr, i64) nounwind willreturn memory(read)",
+        "declare i1 @osty_rt_list_get_i1(ptr, i64) nounwind willreturn memory(read)",
+        "declare double @osty_rt_list_get_f64(ptr, i64) nounwind willreturn memory(read)",
+        "declare ptr @osty_rt_list_get_ptr(ptr, i64) nounwind willreturn memory(read)",
+        "declare ptr @osty_rt_list_data_i64(ptr) nounwind willreturn memory(read)",
+        "declare ptr @osty_rt_list_data_i1(ptr) nounwind willreturn memory(read)",
+        "declare ptr @osty_rt_list_data_f64(ptr) nounwind willreturn memory(read)",
+        "declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64) nounwind willreturn",
+        "declare void @osty_rt_list_set_i64(ptr, i64, i64) nounwind willreturn",
+        "declare void @osty_rt_list_set_i1(ptr, i64, i1) nounwind willreturn",
+        "declare void @osty_rt_list_set_f64(ptr, i64, double) nounwind willreturn",
+        "declare void @osty_rt_list_set_ptr(ptr, i64, ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_sorted_i64(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_sorted_i1(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_sorted_f64(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_sorted_string(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_to_set_i64(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_to_set_i1(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_to_set_f64(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_to_set_ptr(ptr) nounwind willreturn",
+        "declare ptr @osty_rt_list_to_set_string(ptr) nounwind willreturn",
     ]
 }
 


### PR DESCRIPTION
## Summary

- **Lazy snapshot for local scalar Lists in the MIR emitter.** Before this PR the vectorize preamble only captured `data`/`len` for eligible *parameter* lists, so build-then-read patterns on a local (`let mut xs: List<Int> = []; push…; for i in 0..xs.len() { xs[i] }`) kept `@osty_rt_list_get_i64` inside the loop and LLVM bailed with "call instruction cannot be vectorized". The default-on vectorize flip (v0.6 A5.2) was effectively a no-op on that shape.
- **CFG forward-reachability gate for correctness.** The new `mirLocalMutationReachableFrom` rejects a lazy snapshot when a push/insert/set is forward-reachable from the capture site, preventing stale-pointer caching across a realloc — same soundness envelope the existing param path relies on.
- **`memory(read)` on `osty_rt_list_data_*` / `_len` / `_get_*`.** The `ensure_layout` side-effect is idempotent, so marking these readonly lets LICM hoist the snapshot calls out of non-mutating loops. Synced into both `toolchain/llvmgen.osty` and `internal/llvmgen/support_snapshot.go`.

## Why

User reported that even with vectorize defaulting ON, everyday list-reduction code saw no real SIMD. Probes via clang `-Rpass=loop-vectorize` confirmed: param `List<Int>` sums already vectorized, but a `let` local with push-then-read still bailed. This PR closes that gap on the self-hosting MIR path (legacy AST emitter is out of scope — tracked as a separate concern).

## Coverage verified

| pattern | before | after |
|---|---|---|
| `List<Int>` param, `for i in 0..xs.len() { xs[i] }` | vectorizes | vectorizes |
| `List<Int>` local, build-then-read | bails | **vectorizes** (width 2, interleave 4) |
| `List<Float64>` param reduction | vectorizes | vectorizes |
| `List<Bool>` param reduction | vectorizes | vectorizes (width 32) |
| `List<Int>` local, mutation + read in same loop | n/a | **slow path** (soundness gate) |

`#[parallel]` (A6) was investigated as a companion gap but is already fully wired — `tagParallelAccesses` emits `!llvm.access.group` on every load/store and loop metadata carries `llvm.loop.parallel_accesses`. No change needed; `TestParallelAccessGroupTagsLoadsAndStores` + `TestParallelDoesNotLeakToSiblingFunction` already assert it.

## Files

- `internal/llvmgen/mir_generator.go` — `snapshotVectorListLocal` helper (shared by preamble + lazy path), `emitVectorListFastLoad` lazy registration, `mirBlockSuccessors` / `mirLocalIsMutatedIn` / `mirLocalMutationReachableFrom` CFG helpers, `memory(read)` attributes on runtime decls.
- `internal/llvmgen/vectorize_real_simd_test.go` — `lowerThroughMIR` helper, `TestVectorizeAppliesToListLocalReadLoop` (happy path), `TestVectorizeLazySnapshotRespectsInLoopMutation` (soundness).
- `internal/llvmgen/support_snapshot.go` — runtime decl attrs synced.
- `toolchain/llvmgen.osty` — Osty source decl attrs synced (regen-safe).
- `CLAUDE.md` — 부록 B.8 63.1 entry mentions the lazy snapshot + reachability gate.
- `SPEC_GAPS.md` — `vectorize-hint` section gets resolved item 1a documenting the fix and correctness anchor.

## Reviewer notes

- All 11 `TestVectorize*` + 2 `TestParallel*` tests pass. `gofmt` / `go vet` clean.
- 4 pre-existing `./internal/llvmgen` failures (`TestNativeToolchainMergedMIRPipelineIsClean`, `TestToolchainHasNoPhantomRangeExpr`, `TestGoGenerateSupportSnapshotIsFixedPoint`, `TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes`) are unchanged — verified via `git stash` that they fail on the branch tip without these edits.
- The correctness argument rides on the same assumption the existing param path makes: the `osty_rt_list_data_*` / `_get_*` calls' `ensure_layout` side-effect is idempotent after first call, so CSE/hoist/elim of the readonly-annotated calls are observationally equivalent to keeping them.
- The soundness gate is conservative — it rejects the fast path on *any* forward-reachable mutation, which means functions that mutate a local in one loop and read it in a later loop still vectorize (the read loop doesn't reach the build loop in the forward CFG), but a function that mixes read and mutation in the same loop body correctly falls back to the typed slow-path call.

## Test plan

- [x] `go test -run "TestVectorize|TestParallel" ./internal/llvmgen/` — all pass
- [x] `gofmt -l` / `go vet ./internal/llvmgen/` — clean
- [x] Clang `-Rpass=loop-vectorize` oracle confirms "vectorized loop" remark on the new local-list pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)