### PR TITLE
fix: resolve 17 checker errors after rebase + wire as? lexer token

### DIFF
--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -512,6 +512,8 @@ func mapTokenKind(k FrontTokenKind) token.Kind {
 		return token.QDOT
 	case *FrontTokenKind_FrontQQ:
 		return token.QQ
+	case *FrontTokenKind_FrontAsQuestion:
+		return token.ASQUESTION
 	case *FrontTokenKind_FrontDotDot:
 		return token.DOTDOT
 	case *FrontTokenKind_FrontDotDotEq:

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -593,13 +593,13 @@ pub fn hirLowerParseAnnotationInt(e: HirExpr) -> HirLowerIntParse {
     let mut base = 10
     if text.startsWith("0x") || text.startsWith("0X") {
         base = 16
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     } else if text.startsWith("0o") || text.startsWith("0O") {
         base = 8
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     } else if text.startsWith("0b") || text.startsWith("0B") {
         base = 2
-        body = text.substring(2, text.len())
+        body = strings.slice(text, 2, text.len())
     }
     if body.len() == 0 {
         return HirLowerIntParse { value: 0, ok: false }
@@ -650,34 +650,28 @@ pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
 // ---- Internal digit helpers --------------------------------------
 
 fn hirLowerStripUnderscores(text: String) -> String {
-    let mut buf: List<String> = []
-    let chars = text.chars()
-    for ch in chars {
-        if ch != "_" {
-            buf.push(ch)
-        }
-    }
-    strings.join(buf, "")
+    // §1.6.1 numeric separators
+    strings.replaceAll(text, "_", "")
 }
 
 fn hirLowerStripSign(text: String) -> String {
     if text.startsWith("+") || text.startsWith("-") {
-        text.substring(1, text.len())
+        strings.slice(text, 1, text.len())
     } else {
         text
     }
 }
 
-fn hirLowerCharToDigit(ch: String) -> Int {
+fn hirLowerCharToDigit(ch: Char) -> Int {
     match ch {
-        "0" -> 0, "1" -> 1, "2" -> 2, "3" -> 3, "4" -> 4,
-        "5" -> 5, "6" -> 6, "7" -> 7, "8" -> 8, "9" -> 9,
-        "a" -> 10, "A" -> 10,
-        "b" -> 11, "B" -> 11,
-        "c" -> 12, "C" -> 12,
-        "d" -> 13, "D" -> 13,
-        "e" -> 14, "E" -> 14,
-        "f" -> 15, "F" -> 15,
+        '0' -> 0, '1' -> 1, '2' -> 2, '3' -> 3, '4' -> 4,
+        '5' -> 5, '6' -> 6, '7' -> 7, '8' -> 8, '9' -> 9,
+        'a' -> 10, 'A' -> 10,
+        'b' -> 11, 'B' -> 11,
+        'c' -> 12, 'C' -> 12,
+        'd' -> 13, 'D' -> 13,
+        'e' -> 14, 'E' -> 14,
+        'f' -> 15, 'F' -> 15,
         _ -> -1,
     }
 }
@@ -1821,14 +1815,7 @@ pub fn hirLowerNormalizeIntText(text: String) -> String {
     if text.len() == 0 {
         return ""
     }
-    let mut buf: List<String> = []
-    let chars = text.chars()
-    for ch in chars {
-        if ch != "_" {
-            buf.push(ch)
-        }
-    }
-    strings.join(buf, "")
+    strings.replaceAll(text, "_", "")
 }
 
 /// hirLowerNormalizeFloatText shares the same underscore-stripping

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2609,18 +2609,13 @@ pub fn mirLowerParseIntLit(text: String) -> Int {
 }
 
 fn mirLowerStripUnderscores(text: String) -> String {
-    // Spec §1.6.1 numeric separators: `_` between digits is lexically
-    // elided when computing the literal value. String.replace runs in
-    // a single pass and keeps the Char/String boundaries aligned with
-    // the backend — previously this loop wrote `if ch != "_"` where
-    // `ch: Char` met a String literal, walling the merged AST probe
-    // with LLVM011 "compare type mismatch i32/ptr".
-    text.replace("_", "")
+    // §1.6.1 numeric separators
+    strings.replaceAll(text, "_", "")
 }
 
 fn mirLowerStripSign(text: String) -> String {
     if text.startsWith("+") || text.startsWith("-") {
-        text.substring(1, text.len())
+        strings.slice(text, 1, text.len())
     } else {
         text
     }
@@ -2631,13 +2626,13 @@ fn mirLowerParseIntDigits(text: String) -> Int {
         return 0
     }
     if text.startsWith("0x") || text.startsWith("0X") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 16)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 16)
     }
     if text.startsWith("0b") || text.startsWith("0B") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 2)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 2)
     }
     if text.startsWith("0o") || text.startsWith("0O") {
-        return mirLowerParseRadix(text.substring(2, text.len()), 8)
+        return mirLowerParseRadix(strings.slice(text, 2, text.len()), 8)
     }
     mirLowerParseRadix(text, 10)
 }

--- a/toolchain/monomorph_pass.osty
+++ b/toolchain/monomorph_pass.osty
@@ -350,7 +350,6 @@ pub fn hirTypeEqual(a: HirType, b: HirType) -> Bool {
         HirTypeVar -> a.varName == b.varName && a.varOwner == b.varOwner,
         HirTypeErr -> true,
         HirTypeInvalid -> true,
-        _ -> false,
     }
 }
 

--- a/toolchain/package_entry.osty
+++ b/toolchain/package_entry.osty
@@ -5,7 +5,7 @@ use runtime.path.filepath as filepath {
 
 /// PackageEntryKind is the self-hosting-facing shape of one package file.
 pub enum PackageEntryKind {
-    Manifest,
+    ManifestFile,
     Lockfile,
     Source,
     Support,
@@ -16,33 +16,33 @@ pub enum PackageEntryKind {
 pub fn packageEntryKind(rel: String) -> PackageEntryKind {
     let base = filepath.Base(rel)
     if base == ".osty" || base == ".git" || base == ".hg" || base == ".svn" || base == ".DS_Store" {
-        Ignored
+        PackageEntryKind.Ignored
     } else if base == "osty.toml" {
-        Manifest
+        PackageEntryKind.ManifestFile
     } else if base == "osty.lock" {
-        Lockfile
+        PackageEntryKind.Lockfile
     } else if filepath.Ext(base) == ".osty" {
-        Source
+        PackageEntryKind.Source
     } else {
-        Support
+        PackageEntryKind.Support
     }
 }
 
 /// packageEntryKindName returns a stable label for reports and snapshots.
 pub fn packageEntryKindName(kind: PackageEntryKind) -> String {
     match kind {
-        Manifest -> "manifest",
-        Lockfile -> "lockfile",
-        Source -> "source",
-        Support -> "support",
-        Ignored -> "ignored",
+        PackageEntryKind.ManifestFile -> "manifest",
+        PackageEntryKind.Lockfile -> "lockfile",
+        PackageEntryKind.Source -> "source",
+        PackageEntryKind.Support -> "support",
+        PackageEntryKind.Ignored -> "ignored",
     }
 }
 
 /// shouldHashPackageEntry mirrors the package-manager rule for cache metadata.
 pub fn shouldHashPackageEntry(rel: String) -> Bool {
     match packageEntryKind(rel) {
-        Ignored -> false,
+        PackageEntryKind.Ignored -> false,
         _ -> true,
     }
 }
@@ -50,7 +50,7 @@ pub fn shouldHashPackageEntry(rel: String) -> Bool {
 /// isOstySourceEntry reports whether a package path is authored Osty code.
 pub fn isOstySourceEntry(rel: String) -> Bool {
     match packageEntryKind(rel) {
-        Source -> true,
+        PackageEntryKind.Source -> true,
         _ -> false,
     }
 }


### PR DESCRIPTION
## Summary

- **Toolchain checker: 17 errors → 0** after the recent rebase regressed the toolchain-on-toolchain check
- **TestLexAsQuestionSingleToken: now passing** — `as?` was being scanned by the front-end but the Go-facing token bridge had no mapping for it, so callers saw `ILLEGAL("as?")`

## Errors fixed

| Code | Count | Fix |
|---|---|---|
| `E0501` `Manifest` duplicate | 1 | Renamed `PackageEntryKind.Manifest` → `ManifestFile` (the variant collided with `struct Manifest {}` — the Go FFI handle in `ci.osty`). All call sites qualified to `PackageEntryKind.X`. |
| `E0703` `no method substring on String` | 8 | Replaced `text.substring(s, e)` with `strings.slice(text, s, e)` in `hir_lower.osty` and `mir_lower.osty` — `substring` was never an intrinsic. |
| `E0703` `no method replace on String` | 1 | Replaced `text.replace("_", "")` with `strings.replaceAll(text, "_", "")` (intrinsic only does first-occurrence). |
| `E0700` Char ↔ String mismatch | 5 | `text.chars()` returns `List<Char>`, not `List<String>`. Replaced two hand-rolled char-strip loops in `hir_lower.osty` with `strings.replaceAll`, and changed `hirLowerCharToDigit(ch: String)` → `(ch: Char)` with Char-literal arms (mirrors the existing fix in `mir_lower.osty`). |
| `E0740` unreachable pattern | 1 | `hirTypeEqual` in `monomorph_pass.osty` exhaustively matches all 8 `HirTypeKind` variants — removed the dead `_ -> false` arm. |

## TestLexAsQuestionSingleToken

The front-end (`toolchain/frontend.osty`) already scans `as?` into `FrontAsQuestion`, but `internal/selfhost/adapter.go`'s `mapTokenKind` switch was missing the case, falling through to `token.ILLEGAL`. Added the one-line case returning `token.ASQUESTION`.

## Notes for reviewer

- The `ManifestFile` variant name is asymmetric next to siblings `Lockfile`/`Source`/`Support`/`Ignored`. The cleaner alternative — renaming the FFI struct to `ManifestHandle` — was considered but rejected: it cascades through the Go bridge type alias (`internal/cihost/host.go`), 14 signatures in `ci.osty`, and `LoadResult.Manifest`/`CiRunnerState.Manifest` field names. Out of scope for an error-fix PR; flagged as a follow-up candidate.
- Two helper duplications surfaced during review (`hirLowerStripSign`/`mirLowerStripSign` and `hirLowerCharToDigit`/`mirLowerCharToDigit` are byte-identical) — left for a separate refactor PR.

## Test plan

- [x] `osty check toolchain` exits 0 (was: 17 errors)
- [x] `just front` passes (lexer/parser/resolve/check/diag/format/lint/pipeline all green)
- [x] `TestLexAsQuestionSingleToken` passes individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)