### PR TITLE
[codex] advance llvm toolchain probe blockers

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3470,6 +3470,26 @@ func (g *generator) emitStringMethodCall(call *ast.CallExpr) (value, bool, error
 		v.gcManaged = true
 		v.sourceType = &ast.NamedType{Path: []string{"String"}}
 		return v, true, nil
+	case "substring", "slice":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "String.%s requires two positional arguments", field.Name)
+		}
+		start, err := g.emitStdStringsIntArg(call.Args[0], field.Name, 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		end, err := g.emitStdStringsIntArg(call.Args[1], field.Name, 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeSliceSymbol(), "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+		emitter := g.toOstyEmitter()
+		out := llvmStringRuntimeSlice(emitter, toOstyValue(base), toOstyValue(start), toOstyValue(end))
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.sourceType = &ast.NamedType{Path: []string{"String"}}
+		return v, true, nil
 	case "toUpper":
 		if len(call.Args) != 0 {
 			return value{}, true, unsupported("call", "String.toUpper requires no arguments")

--- a/internal/llvmgen/string_slice_test.go
+++ b/internal/llvmgen/string_slice_test.go
@@ -80,3 +80,31 @@ fn main() {
 		}
 	}
 }
+
+func TestStringSubstringMethodCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn stripPrefix(text: String) -> String {
+    if text.startsWith("0x") {
+        return text.substring(2, text.len())
+    }
+    text
+}
+
+fn main() {
+    println(stripPrefix("0xff"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_substring_method.osty"})
+	if err != nil {
+		t.Fatalf("substring method errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_Slice",
+		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
+		"call ptr @osty_rt_strings_Slice",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -1308,7 +1308,7 @@ func (g *generator) staticStringMethodSourceType(call *ast.CallExpr) (ast.Type, 
 		return stringToFloatResultSourceType(), true
 	case "toBytes":
 		return &ast.NamedType{Path: []string{"Bytes"}}, true
-	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat", "toUpper", "toLower":
+	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat", "substring", "slice", "toUpper", "toLower":
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case "chars":
 		return &ast.NamedType{
@@ -1432,7 +1432,7 @@ func (g *generator) staticStringMethodResult(call *ast.CallExpr) (value, bool) {
 		return value{}, false
 	case "toBytes":
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
-	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat", "toUpper", "toLower":
+	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat", "substring", "slice", "toUpper", "toLower":
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
 	case "chars":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "i32"}, true
@@ -1461,7 +1461,7 @@ func (g *generator) stringMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) 
 		"indexOf",
 		"get",
 		"trimStart", "trimEnd", "trimPrefix", "trimSuffix",
-		"split", "lines", "join", "trim", "replace", "repeat", "toUpper", "toLower", "toInt", "toFloat", "toString", "chars", "bytes", "toBytes":
+		"split", "lines", "join", "trim", "replace", "repeat", "substring", "slice", "toUpper", "toLower", "toInt", "toFloat", "toString", "chars", "bytes", "toBytes":
 		return field, true
 	default:
 		return nil, false

--- a/toolchain/airepair_flags.osty
+++ b/toolchain/airepair_flags.osty
@@ -84,10 +84,10 @@ pub fn usesFrontEndAIRepair(cmd: String) -> Bool {
 /// captures unconditionally (for corpus collection).
 pub fn shouldCaptureAiRepair(captureMode: String, changed: Bool, totalErrorsAfter: Int) -> Bool {
     if captureMode == "always" {
-        return true
+        true
+    } else if captureMode == "changed" {
+        changed
+    } else {
+        totalErrorsAfter > 0
     }
-    if captureMode == "changed" {
-        return changed
-    }
-    totalErrorsAfter > 0
 }

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -137,16 +137,24 @@ pub fn elabFile(cx: ElabCx) {
 fn collectDecls(cx: ElabCx) {
     for declIdx in cx.ast.arena.decls {
         let node = astArenaNodeAt(cx.ast.arena, declIdx)
-        match node.kind {
-            AstNFnDecl -> collectFnDecl(cx, declIdx, node, "", [], []),
-            AstNStructDecl -> collectStructDecl(cx, declIdx, node),
-            AstNEnumDecl -> collectEnumDecl(cx, declIdx, node),
-            AstNInterfaceDecl -> collectInterfaceDecl(cx, declIdx, node),
-            AstNTypeAlias -> collectTypeAlias(cx, declIdx, node),
-            AstNLet -> collectLetDecl(cx, declIdx, node),
-            AstNLetDecl -> collectLetDecl(cx, declIdx, node),
-            AstNUseDecl -> collectUseDecl(cx, declIdx, node),
-            _ -> {},
+        if node.kind == AstNFnDecl {
+            collectFnDecl(cx, declIdx, node, "", [], [])
+        } else if node.kind == AstNStructDecl {
+            collectStructDecl(cx, declIdx, node)
+        } else if node.kind == AstNEnumDecl {
+            collectEnumDecl(cx, declIdx, node)
+        } else if node.kind == AstNInterfaceDecl {
+            collectInterfaceDecl(cx, declIdx, node)
+        } else if node.kind == AstNTypeAlias {
+            collectTypeAlias(cx, declIdx, node)
+        } else if node.kind == AstNLet {
+            collectLetDecl(cx, declIdx, node)
+        } else if node.kind == AstNLetDecl {
+            collectLetDecl(cx, declIdx, node)
+        } else if node.kind == AstNUseDecl {
+            collectUseDecl(cx, declIdx, node)
+        } else {
+            let _ = declIdx
         }
     }
 }
@@ -168,49 +176,52 @@ fn collectDecls(cx: ElabCx) {
 fn collectUseDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
     let alias = useDeclAliasName(cx, node)
     if alias == "" {
-        return
-    }
-    let env = cx.env
-    // Register a binding so bare `X` in expression position has a
-    // type; the head name is what `checkLookupMethod` keys off.
-    let moduleTy = tyNamed(env.tys, alias, [])
-    checkBindSpan(env, alias, moduleTy, false, node.start, node.end)
-    checkRecordSymbol(env, declIdx, "use", alias, "", moduleTy, node.start, node.end)
+        let _ = alias
+    } else {
+        let env = cx.env
+        // Register a binding so bare `X` in expression position has a
+        // type; the head name is what `checkLookupMethod` keys off.
+        let moduleTy = tyNamed(env.tys, alias, [])
+        checkBindSpan(env, alias, moduleTy, false, node.start, node.end)
+        checkRecordSymbol(env, declIdx, "use", alias, "", moduleTy, node.start, node.end)
 
-    for bodyIdx in node.children {
-        let body = astArenaNodeAt(cx.ast.arena, bodyIdx)
-        match body.kind {
-            AstNFnDecl -> collectFnDecl(cx, bodyIdx, body, alias, [], []),
-            AstNStructDecl -> collectUseDeclTypeBody(cx, bodyIdx, body, alias),
-            AstNEnumDecl -> collectUseDeclTypeBody(cx, bodyIdx, body, alias),
-            AstNInterfaceDecl -> collectUseDeclTypeBody(cx, bodyIdx, body, alias),
-            AstNTypeAlias -> collectUseDeclTypeBody(cx, bodyIdx, body, alias),
-            _ -> {},
+        for bodyIdx in node.children {
+            let body = astArenaNodeAt(cx.ast.arena, bodyIdx)
+            if body.kind == AstNFnDecl {
+                collectFnDecl(cx, bodyIdx, body, alias, [], [])
+            } else if body.kind == AstNStructDecl {
+                collectUseDeclTypeBody(cx, bodyIdx, body, alias)
+            } else if body.kind == AstNEnumDecl {
+                collectUseDeclTypeBody(cx, bodyIdx, body, alias)
+            } else if body.kind == AstNInterfaceDecl {
+                collectUseDeclTypeBody(cx, bodyIdx, body, alias)
+            } else if body.kind == AstNTypeAlias {
+                collectUseDeclTypeBody(cx, bodyIdx, body, alias)
+            } else {
+                let _ = bodyIdx
+            }
         }
-    }
 
-    // `use std.strings as X` (no body) — pull the std.strings surface
-    // under the alias. Toolchain code routinely spells this as
-    // `strings`, `ciStrings`, `pkgStrings`, `llvmStrings`, etc.
-    if node.text == "std.strings" {
-        registerStdStringsAliasFns(env, alias)
-    }
-    // `use std.testing` (examples use this without an explicit alias,
-    // so the alias defaults to "testing" via useDeclAliasName).
-    if node.text == "std.testing" {
-        registerStdTestingAliasFns(env, alias)
-    }
-    if node.text == "std.fs" {
-        registerStdFsAliasFns(env, alias)
-    }
-    if node.text == "std.debug" {
-        registerStdDebugAliasFns(env, alias)
-    }
-    if node.text == "std.thread" {
-        registerStdThreadAliasFns(env, alias)
-    }
-    if node.text == "std.io" {
-        registerStdIoAliasFns(env, alias)
+        // `use std.strings as X` (no body) — pull the std.strings surface
+        // under the alias. Toolchain code routinely spells this as
+        // `strings`, `ciStrings`, `pkgStrings`, `llvmStrings`, etc.
+        if node.text == "std.strings" {
+            registerStdStringsAliasFns(env, alias)
+        } else if node.text == "std.testing" {
+            // `use std.testing` (examples use this without an explicit alias,
+            // so the alias defaults to "testing" via useDeclAliasName).
+            registerStdTestingAliasFns(env, alias)
+        } else if node.text == "std.fs" {
+            registerStdFsAliasFns(env, alias)
+        } else if node.text == "std.debug" {
+            registerStdDebugAliasFns(env, alias)
+        } else if node.text == "std.thread" {
+            registerStdThreadAliasFns(env, alias)
+        } else if node.text == "std.io" {
+            registerStdIoAliasFns(env, alias)
+        } else {
+            let _ = env
+        }
     }
 }
 
@@ -233,20 +244,22 @@ fn collectUseDeclTypeBody(cx: ElabCx, declIdx: Int, node: AstNode, alias: String
 fn registerUseDeclQualifiedTypeAlias(cx: ElabCx, alias: String, name: String, generics: List<String>) {
     let qualified = useDeclQualifiedTypeName(alias, name)
     if qualified == "" || qualified == name {
-        return
+        let _ = qualified
+    } else {
+        checkRegisterAlias(cx.env, CheckAliasSig {
+            name: qualified,
+            ty: tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics)),
+            generics,
+        })
     }
-    checkRegisterAlias(cx.env, CheckAliasSig {
-        name: qualified,
-        ty: tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics)),
-        generics,
-    })
 }
 
 fn useDeclQualifiedTypeName(alias: String, name: String) -> String {
     if alias == "" || name == "" {
-        return ""
+        ""
+    } else {
+        "{alias}.{name}"
     }
-    "{alias}.{name}"
 }
 
 /// registerStdStringsAliasFns registers the hot subset of std.strings
@@ -496,11 +509,16 @@ fn useDeclAliasName(cx: ElabCx, node: AstNode) -> String {
         if aliasIdx >= 0 {
             let aliasNode = astArenaNodeAt(cx.ast.arena, aliasIdx)
             if aliasNode.kind == AstNIdent && aliasNode.text != "" {
-                return aliasNode.text
+                aliasNode.text
+            } else {
+                useDeclLastSegment(node.text)
             }
+        } else {
+            useDeclLastSegment(node.text)
         }
+    } else {
+        useDeclLastSegment(node.text)
     }
-    useDeclLastSegment(node.text)
 }
 
 /// registerStdFsAliasFns — hot subset of std.fs.
@@ -614,43 +632,44 @@ fn registerStdIoAliasFns(env: CheckEnv, alias: String) {
 /// bare `core` → "core"; empty → empty.
 fn useDeclLastSegment(path: String) -> String {
     if path == "" {
-        return ""
+        ""
+    } else {
+        // Walk the bytes manually so this helper stays free of the
+        // `std.strings` import tax (check.osty would need one otherwise).
+        let afterSlash = useDeclTailAfter(path, "/")
+        useDeclTailAfter(afterSlash, ".")
     }
-    // Walk the bytes manually so this helper stays free of the
-    // `std.strings` import tax (check.osty would need one otherwise).
-    let afterSlash = useDeclTailAfter(path, "/")
-    useDeclTailAfter(afterSlash, ".")
 }
 
 fn useDeclTailAfter(s: String, sep: String) -> String {
     let mut out = s
-    let mut i = 0
-    for unit in strings.split(s, "") {
-        let _ = unit
-        i = i + 1
-    }
     // Scan from end to find last occurrence of `sep` (single char).
     let mut idx = -1
     let mut j = 0
     for unit in strings.split(s, "") {
         if unit == sep {
             idx = j
+        } else {
+            let _ = unit
         }
         j = j + 1
     }
     if idx < 0 {
-        return out
-    }
-    // Collect units after idx.
-    out = ""
-    let mut k = 0
-    for unit in strings.split(s, "") {
-        if k > idx {
-            out = "{out}{unit}"
+        out
+    } else {
+        // Collect units after idx.
+        out = ""
+        let mut k = 0
+        for unit in strings.split(s, "") {
+            if k > idx {
+                out = "{out}{unit}"
+            } else {
+                let _ = unit
+            }
+            k = k + 1
         }
-        k = k + 1
+        out
     }
-    out
 }
 
 
@@ -673,21 +692,21 @@ fn collectFnDecl(
     for paramIdx in node.children {
         let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
         if paramNode.kind != AstNParam {
-            continue
+            let _ = paramIdx
+        } else if paramNode.text == "self" {
+            let _ = paramNode
+        } else {
+            // Prefix default-carrying params with "?" so the arity check
+            // (see paramDefaultCount in elab.osty) can count trailing
+            // defaults without threading a parallel List<Bool> through
+            // every CheckFnSig constructor.
+            let hasDefault = paramNode.left >= 0
+            let rawName = paramNode.text
+            let storedName = if hasDefault { "?" + rawName } else { rawName }
+            paramNames.push(storedName)
+            let declared = astTypeToTyInCollect(cx, paramNode.right)
+            paramTys.push(if declared >= 0 { declared } else { tErr(cx.env.tys) })
         }
-        if paramNode.text == "self" {
-            continue
-        }
-        // Prefix default-carrying params with "?" so the arity check
-        // (see paramDefaultCount in elab.osty) can count trailing
-        // defaults without threading a parallel List<Bool> through
-        // every CheckFnSig constructor.
-        let hasDefault = paramNode.left >= 0
-        let rawName = paramNode.text
-        let storedName = if hasDefault { "?" + rawName } else { rawName }
-        paramNames.push(storedName)
-        let declared = astTypeToTyInCollect(cx, paramNode.right)
-        paramTys.push(if declared >= 0 { declared } else { tErr(cx.env.tys) })
     }
 
     let retTy = astTypeToTyInCollect(cx, node.left)
@@ -712,6 +731,8 @@ fn collectFnDecl(
     checkRegisterFn(cx.env, sig)
     if node.right >= 0 {
         checkMarkFnHasBody(cx.env, name, owner)
+    } else {
+        let _ = node
     }
 
     // Record a symbol for the Go-bridge summary.
@@ -777,6 +798,8 @@ fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
                     }
                     if ty >= 0 {
                         fieldTys.push(ty)
+                    } else {
+                        let _ = fIdx
                     }
                 }
                 checkRegisterVariant(cx.env, CheckVariantSig {
@@ -809,6 +832,8 @@ fn collectInterfaceDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
             let ifaceTy = astTypeToTyInCollect(cx, memberIdx)
             if ifaceTy >= 0 {
                 checkRegisterInterfaceExtends(cx.env, CheckInterfaceExt { owner: name, ifaceTy })
+            } else {
+                let _ = memberIdx
             }
         }
     }
@@ -895,6 +920,8 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
     if node.right >= 0 {
         // Fn body is stored in node.right as a block (AstNBlock).
         let _ = elabCheck(cx, node.right, sig.retTy)
+    } else {
+        let _ = sig
     }
 
     cx.env.returnTy = prevReturn
@@ -909,6 +936,8 @@ fn elaborateStructMethods(cx: ElabCx, node: AstNode) {
         let member = astArenaNodeAt(cx.ast.arena, memberIdx)
         if member.kind == AstNFnDecl {
             elaborateFnBody(cx, member, owner)
+        } else {
+            let _ = memberIdx
         }
     }
 }
@@ -919,6 +948,8 @@ fn elaborateEnumMethods(cx: ElabCx, node: AstNode) {
         let member = astArenaNodeAt(cx.ast.arena, memberIdx)
         if member.kind == AstNFnDecl {
             elaborateFnBody(cx, member, owner)
+        } else {
+            let _ = memberIdx
         }
     }
 }

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -650,8 +650,7 @@ pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
 // ---- Internal digit helpers --------------------------------------
 
 fn hirLowerStripUnderscores(text: String) -> String {
-    // §1.6.1 numeric separators
-    strings.replaceAll(text, "_", "")
+    strings.join(text.split("_"), "")
 }
 
 fn hirLowerStripSign(text: String) -> String {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2609,8 +2609,7 @@ pub fn mirLowerParseIntLit(text: String) -> Int {
 }
 
 fn mirLowerStripUnderscores(text: String) -> String {
-    // §1.6.1 numeric separators
-    strings.replaceAll(text, "_", "")
+    strings.join(text.split("_"), "")
 }
 
 fn mirLowerStripSign(text: String) -> String {


### PR DESCRIPTION
## What changed
- taught the legacy LLVM path to lower `String.substring` / `String.slice` method calls and added regression coverage
- rewrote several toolchain helpers in `airepair_flags.osty` and `check.osty` into LLVM-friendly `if/else` shapes so the merged toolchain probes advance past earlier control-flow and match blockers
- changed `hirLowerStripUnderscores` and `mirLowerStripUnderscores` to avoid `Char.toString()` / `String.replace()` and use a backend-friendly separator-elision path instead
- aligned the `hir_lower` digit helper with the MIR-first path so the native MIR probe moves past the numeric-separator helper cluster

## Why
The self-hosted LLVM migration was still stalling on small source-shape incompatibilities in the checked-in toolchain sources. In practice that meant the probes were getting stuck before reaching the next real backend gaps.

## Impact
- the native MIR probe no longer stops in `hirLowerStripUnderscores`
- the current MIR first wall moves forward to `pmLitLabel`
- the merged whole/native probes also move, with the current head wall now being the `match` scrutinee `i32` issue rather than the previous no-else/helper blockers

## Validation
- `go test ./internal/llvmgen -run 'TestStringSlice|TestStringSubstringMethodCall' -count=1`
- `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMergedMIR' -count=1 -v`
- `go test ./internal/llvmgen -run 'TestProbeWholeToolchainMerged|TestProbeNativeToolchainMerged$' -count=1 -v`
