### PR TITLE
feat(ast): NodeID-keyed resolve/check maps — unblock self-host porting

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -2133,10 +2133,8 @@ func loadLintConfigNear(startPath string) (lint.Config, bool) {
 // `line:col  Name  Kind  def-pos`. Useful for sanity-checking the
 // resolver's output without a debugger.
 func printResolution(_ *ast.File, res *resolve.Result) {
-	idents := make([]*ast.Ident, 0, len(res.Refs))
-	for id := range res.Refs {
-		idents = append(idents, id)
-	}
+	idents := make([]*ast.Ident, 0, len(res.RefIdents))
+	idents = append(idents, res.RefIdents...)
 	sort.Slice(idents, func(i, j int) bool {
 		a, b := idents[i].PosV, idents[j].PosV
 		if a.Line != b.Line {
@@ -2145,7 +2143,7 @@ func printResolution(_ *ast.File, res *resolve.Result) {
 		return a.Column < b.Column
 	})
 	for _, id := range idents {
-		s := res.Refs[id]
+		s := res.RefsByID[id.ID]
 		def := "<builtin>"
 		if s.Pos.Line > 0 {
 			def = fmt.Sprintf("%d:%d", s.Pos.Line, s.Pos.Column)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -457,9 +457,9 @@ func main() {
 				if rows, err := nativeResolvePackageRows(selected.pkg, selected.file.Path); err == nil && len(rows) > 0 {
 					fmt.Printf("# %s\n", selected.file.Path)
 					printNativeResolutionRows(rows)
-				} else if len(selected.file.Refs) > 0 {
+				} else if len(selected.file.RefsByID) > 0 {
 					fmt.Printf("# %s\n", selected.file.Path)
-					printResolutionRefs(selected.file.Refs)
+					printResolutionRefs(selected.file.RefIdents, selected.file.RefsByID)
 				}
 				if flags.showScopes {
 					if pkgScope := selected.file.FileScope.Parent(); pkgScope != nil {
@@ -1519,11 +1519,11 @@ func runResolvePackageInner(dir string, flags cliFlags) int {
 			// the package through *ast.File.
 			nativeErrored = true
 			ensureGoResolve()
-			if len(f.Refs) == 0 {
+			if len(f.RefsByID) == 0 {
 				continue
 			}
 			fmt.Printf("# %s\n", f.Path)
-			printResolutionRefs(f.Refs)
+			printResolutionRefs(f.RefIdents, f.RefsByID)
 			continue
 		}
 		if len(rows) == 0 {
@@ -1540,11 +1540,11 @@ func runResolvePackageInner(dir string, flags cliFlags) int {
 		// silently empty. EnsureFiles has already been called by
 		// the loop above in this branch.
 		for _, f := range pkg.Files {
-			if len(f.Refs) == 0 {
+			if len(f.RefsByID) == 0 {
 				continue
 			}
 			fmt.Printf("# %s\n", f.Path)
-			printResolutionRefs(f.Refs)
+			printResolutionRefs(f.RefIdents, f.RefsByID)
 		}
 	}
 	if flags.showScopes {
@@ -1753,11 +1753,9 @@ func fileOffsetMatchesAny(src []byte, pos token.Pos, names []string) bool {
 
 // printResolutionRefs dumps one file's resolved identifiers. Broken out
 // of printResolution so the package walker can print one header per file.
-func printResolutionRefs(refs map[*ast.Ident]*resolve.Symbol) {
-	idents := make([]*ast.Ident, 0, len(refs))
-	for id := range refs {
-		idents = append(idents, id)
-	}
+func printResolutionRefs(refIdents []*ast.Ident, refs map[ast.NodeID]*resolve.Symbol) {
+	idents := make([]*ast.Ident, 0, len(refIdents))
+	idents = append(idents, refIdents...)
 	sort.Slice(idents, func(i, j int) bool {
 		a, b := idents[i].PosV, idents[j].PosV
 		if a.Line != b.Line {
@@ -1766,7 +1764,7 @@ func printResolutionRefs(refs map[*ast.Ident]*resolve.Symbol) {
 		return a.Column < b.Column
 	})
 	for _, id := range idents {
-		s := refs[id]
+		s := refs[id.ID]
 		def := "<builtin>"
 		if s.Pos.Line > 0 {
 			def = fmt.Sprintf("%d:%d", s.Pos.Line, s.Pos.Column)
@@ -2686,10 +2684,12 @@ func (e *genPackageEntry) fileResult() *resolve.Result {
 		return nil
 	}
 	return &resolve.Result{
-		Refs:      e.file.Refs,
-		TypeRefs:  e.file.TypeRefs,
-		FileScope: e.file.FileScope,
-		Diags:     e.res.Diags,
+		RefsByID:      e.file.RefsByID,
+		TypeRefsByID:  e.file.TypeRefsByID,
+		RefIdents:     e.file.RefIdents,
+		TypeRefIdents: e.file.TypeRefIdents,
+		FileScope:     e.file.FileScope,
+		Diags:         e.res.Diags,
 	}
 }
 

--- a/cmd/osty/toolchain_context.go
+++ b/cmd/osty/toolchain_context.go
@@ -106,8 +106,10 @@ func (e *selectedPackageEntry) fileResult() *resolve.Result {
 		return nil
 	}
 	return &resolve.Result{
-		Refs:      e.file.Refs,
-		TypeRefs:  e.file.TypeRefs,
-		FileScope: e.file.FileScope,
+		RefsByID:      e.file.RefsByID,
+		TypeRefsByID:  e.file.TypeRefsByID,
+		RefIdents:     e.file.RefIdents,
+		TypeRefIdents: e.file.TypeRefIdents,
+		FileScope:     e.file.FileScope,
 	}
 }

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -37,12 +37,19 @@ type (
 	}
 )
 
+// NodeID uniquely identifies an AST node within a single parse tree.
+// The zero value means unassigned; the parser assigns IDs sequentially
+// during construction. Unlike Go pointer identity, NodeID is portable
+// to the self-hosted compiler.
+type NodeID uint32
+
 // ==== Annotations ====
 
 // Annotation is `#[Name]` or `#[Name(arg, key = "v", ...)]`. Per v0.2 R26
 // the only permitted names in the v0.9 set are `json` and `deprecated`,
 // enforced by the parser.
 type Annotation struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Name string
@@ -57,6 +64,7 @@ func (a *Annotation) End() token.Pos { return a.EndV }
 //	IDENT                — flag form (Key set, Value nil)
 //	IDENT '=' Literal    — key/value form (Key set, Value is the literal)
 type AnnotationArg struct {
+	ID    NodeID
 	PosV  token.Pos
 	Key   string
 	Value Expr // nil for flag form
@@ -288,6 +296,7 @@ func joinWithAnd(parts []string) string {
 
 // File is an entire .osty source file.
 type File struct {
+	ID NodeID
 	// Uses are all `use` declarations at the file's top.
 	Uses []*UseDecl
 	// Decls is the mix of declarations. For script files this may also
@@ -318,6 +327,7 @@ type Decorated interface {
 
 // UseDecl represents `use path`, `use path as alias`, and FFI forms.
 type UseDecl struct {
+	ID           NodeID
 	PosV         token.Pos
 	EndV         token.Pos
 	Path         []string // dot-separated path, or single entry with slashes for URLs
@@ -354,6 +364,7 @@ func (u *UseDecl) FFIPath() string {
 
 // FnDecl is a top-level or method function declaration.
 type FnDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -379,6 +390,7 @@ func (f *FnDecl) Annots() []*Annotation { return f.Annotations }
 // so tools can rewrite `mut self` → `self` by deleting that token's span.
 // When Mut is false, MutPos is the zero Pos.
 type Receiver struct {
+	ID     NodeID
 	PosV   token.Pos
 	EndV   token.Pos
 	Mut    bool
@@ -395,6 +407,7 @@ func (r *Receiver) End() token.Pos { return r.EndV }
 // pattern (e.g. `|(k, v)| ...`) per SPEC_GAPS G4 — when Pattern is set,
 // Name is empty.
 type Param struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Name    string
@@ -420,6 +433,7 @@ func (p *Param) End() token.Pos {
 
 // GenericParam is a type parameter like `T` or `T: Ordered + Hashable`.
 type GenericParam struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Name        string
@@ -439,6 +453,7 @@ func (g *GenericParam) End() token.Pos {
 
 // StructDecl — a struct declaration (possibly partial).
 type StructDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -458,6 +473,7 @@ func (s *StructDecl) Annots() []*Annotation { return s.Annotations }
 
 // Field is a struct field.
 type Field struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -488,6 +504,7 @@ func (f *Field) End() token.Pos {
 
 // EnumDecl — an enum declaration.
 type EnumDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -507,6 +524,7 @@ func (e *EnumDecl) Annots() []*Annotation { return e.Annotations }
 
 // Variant is one enum variant: bare or tuple-like.
 type Variant struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Name        string
@@ -528,6 +546,7 @@ func (v *Variant) End() token.Pos {
 
 // InterfaceDecl — an interface declaration.
 type InterfaceDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -547,6 +566,7 @@ func (i *InterfaceDecl) Annots() []*Annotation { return i.Annotations }
 
 // TypeAliasDecl — `type Name<T> = ...`.
 type TypeAliasDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -569,6 +589,7 @@ func (t *TypeAliasDecl) Annots() []*Annotation { return t.Annotations }
 // lint's `unused_mut` autofix can delete the token directly. Zero Pos
 // when Mut is false.
 type LetDecl struct {
+	ID          NodeID
 	PosV        token.Pos
 	EndV        token.Pos
 	Pub         bool
@@ -592,6 +613,7 @@ func (l *LetDecl) Annots() []*Annotation { return l.Annotations }
 // NamedType is a reference to a named type, possibly with type arguments.
 // Example: `User`, `List<T>`, `Map<String, Int>`, `my.pkg.Type`.
 type NamedType struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	// Path allows qualified references: pkg.Type -> {"pkg", "Type"}.
@@ -605,6 +627,7 @@ func (n *NamedType) End() token.Pos { return n.EndV }
 
 // OptionalType wraps an inner type: T?.
 type OptionalType struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Inner Type
@@ -616,6 +639,7 @@ func (o *OptionalType) End() token.Pos { return o.EndV }
 
 // TupleType is `(T1, T2, ...)`.
 type TupleType struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Elems []Type
@@ -627,6 +651,7 @@ func (t *TupleType) End() token.Pos { return t.EndV }
 
 // FnType is `fn(A, B) -> R`.
 type FnType struct {
+	ID         NodeID
 	PosV       token.Pos
 	EndV       token.Pos
 	Params     []Type
@@ -642,6 +667,7 @@ func (f *FnType) End() token.Pos { return f.EndV }
 // Block is a sequence of statements evaluated in order. As an expression,
 // the result is the final expression statement.
 type Block struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Stmts []Stmt
@@ -658,6 +684,7 @@ func (b *Block) End() token.Pos { return b.EndV }
 // MutPos records the `mut` keyword's position when Mut is true, enabling
 // autofix of `let mut x` → `let x`. Zero Pos otherwise.
 type LetStmt struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Pattern Pattern
@@ -673,7 +700,8 @@ func (s *LetStmt) End() token.Pos { return s.EndV }
 
 // ExprStmt is an expression used in statement position.
 type ExprStmt struct {
-	X Expr
+	ID NodeID
+	X  Expr
 }
 
 func (*ExprStmt) stmtNode()        {}
@@ -683,6 +711,7 @@ func (s *ExprStmt) End() token.Pos { return s.X.End() }
 // AssignStmt covers `a = b`, compound assigns, and multiple assigns
 // `(a, b) = (c, d)`.
 type AssignStmt struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Op      token.Kind // ASSIGN, PLUSEQ, ...
@@ -696,6 +725,7 @@ func (s *AssignStmt) End() token.Pos { return s.EndV }
 
 // ReturnStmt — `return` or `return expr`.
 type ReturnStmt struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Value Expr // optional
@@ -707,6 +737,7 @@ func (s *ReturnStmt) End() token.Pos { return s.EndV }
 
 // BreakStmt is `break`.
 type BreakStmt struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	// Label is the optional `'label` target on `break 'label`.
@@ -729,6 +760,7 @@ func (s *BreakStmt) End() token.Pos { return s.EndV }
 
 // ContinueStmt is `continue`.
 type ContinueStmt struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	// Label is the optional `'label` target on `continue 'label`.
@@ -748,6 +780,7 @@ func (s *ContinueStmt) End() token.Pos { return s.EndV }
 // The spec explicitly declares channel send a statement rather than an
 // expression, so send cannot be composed with `=` or other operators.
 type ChanSendStmt struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Channel Expr
@@ -760,6 +793,7 @@ func (s *ChanSendStmt) End() token.Pos { return s.EndV }
 
 // DeferStmt schedules an expression or block to run on block exit.
 type DeferStmt struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	X    Expr // may be a Block
@@ -776,6 +810,7 @@ func (s *DeferStmt) End() token.Pos { return s.EndV }
 //	for x in xs { ... }                   // for-in     (Pattern x, Iter xs)
 //	for let Some(v) = e { ... }           // for-let    (IsForLet, Pattern, Iter)
 type ForStmt struct {
+	ID       NodeID
 	PosV     token.Pos
 	EndV     token.Pos
 	Label    string
@@ -796,6 +831,7 @@ func (s *ForStmt) End() token.Pos { return s.EndV }
 // Ident references a name. Dotted paths (foo.bar.baz) are represented as
 // FieldExpr chains; a single Ident is only a bare name.
 type Ident struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Name string
@@ -807,6 +843,7 @@ func (i *Ident) End() token.Pos { return i.EndV }
 
 // Literal kinds carry the raw source text; conversion is deferred.
 type IntLit struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Text string
@@ -817,6 +854,7 @@ func (l *IntLit) Pos() token.Pos { return l.PosV }
 func (l *IntLit) End() token.Pos { return l.EndV }
 
 type FloatLit struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Text string
@@ -827,6 +865,7 @@ func (l *FloatLit) Pos() token.Pos { return l.PosV }
 func (l *FloatLit) End() token.Pos { return l.EndV }
 
 type CharLit struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Value rune
@@ -837,6 +876,7 @@ func (l *CharLit) Pos() token.Pos { return l.PosV }
 func (l *CharLit) End() token.Pos { return l.EndV }
 
 type ByteLit struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Value byte
@@ -858,6 +898,7 @@ func (l *ByteLit) End() token.Pos { return l.EndV }
 // is redundant — content is already normalized — but preserving it
 // keeps authorial intent across `osty fmt` round-trips.
 type StringLit struct {
+	ID       NodeID
 	PosV     token.Pos
 	EndV     token.Pos
 	IsRaw    bool
@@ -878,6 +919,7 @@ func (l *StringLit) End() token.Pos { return l.EndV }
 
 // BoolLit is `true` / `false`.
 type BoolLit struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Value bool
@@ -889,6 +931,7 @@ func (l *BoolLit) End() token.Pos { return l.EndV }
 
 // UnaryExpr is a prefix op: `-x`, `!x`, `~x`.
 type UnaryExpr struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Op   token.Kind
@@ -902,6 +945,7 @@ func (e *UnaryExpr) End() token.Pos { return e.EndV }
 // BinaryExpr is `a op b` for arithmetic, comparison, logical, bitwise,
 // and the `??` coalescing operator.
 type BinaryExpr struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Op    token.Kind
@@ -915,6 +959,7 @@ func (e *BinaryExpr) End() token.Pos { return e.EndV }
 
 // QuestionExpr is the postfix `?` error/Option propagation.
 type QuestionExpr struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	X    Expr
@@ -937,6 +982,7 @@ func (e *QuestionExpr) End() token.Pos { return e.EndV }
 // positional arg list; this flag lets the formatter restore the surface
 // form by splitting the last arg out of the parenthesized list.
 type CallExpr struct {
+	ID                 NodeID
 	PosV               token.Pos
 	EndV               token.Pos
 	Fn                 Expr
@@ -947,6 +993,7 @@ type CallExpr struct {
 
 // Arg is either positional (Name == "") or keyword (Name != "").
 type Arg struct {
+	ID    NodeID
 	PosV  token.Pos
 	Name  string
 	Value Expr
@@ -966,6 +1013,7 @@ func (e *CallExpr) End() token.Pos { return e.EndV }
 
 // FieldExpr is `x.field` or `x?.field` (when IsOptional).
 type FieldExpr struct {
+	ID         NodeID
 	PosV       token.Pos
 	EndV       token.Pos
 	X          Expr
@@ -979,6 +1027,7 @@ func (e *FieldExpr) End() token.Pos { return e.EndV }
 
 // IndexExpr is `x[i]`.
 type IndexExpr struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	X     Expr
@@ -993,6 +1042,7 @@ func (e *IndexExpr) End() token.Pos { return e.EndV }
 // type arguments. The parser attaches type args to the base (typically an
 // Ident or FieldExpr) via this wrapper.
 type TurbofishExpr struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Base Expr
@@ -1005,6 +1055,7 @@ func (e *TurbofishExpr) End() token.Pos { return e.EndV }
 
 // RangeExpr is `a..b` / `a..=b` / `..b` / `a..`.
 type RangeExpr struct {
+	ID        NodeID
 	PosV      token.Pos
 	EndV      token.Pos
 	Start     Expr // optional
@@ -1022,6 +1073,7 @@ func (e *RangeExpr) End() token.Pos { return e.EndV }
 
 // ParenExpr groups `(expr)` — needed to distinguish `(a)` from `(a,)` tuple.
 type ParenExpr struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	X    Expr
@@ -1033,6 +1085,7 @@ func (e *ParenExpr) End() token.Pos { return e.EndV }
 
 // TupleExpr is `(a, b, c)`. The single-element form `(a,)` is a tuple.
 type TupleExpr struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Elems []Expr
@@ -1044,6 +1097,7 @@ func (e *TupleExpr) End() token.Pos { return e.EndV }
 
 // ListExpr is `[a, b, c]`.
 type ListExpr struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Elems []Expr
@@ -1055,6 +1109,7 @@ func (e *ListExpr) End() token.Pos { return e.EndV }
 
 // MapExpr is `{"k": v, ...}` or `{:}` (empty).
 type MapExpr struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Entries []*MapEntry
@@ -1062,6 +1117,7 @@ type MapExpr struct {
 }
 
 type MapEntry struct {
+	ID    NodeID
 	Key   Expr
 	Value Expr
 }
@@ -1088,6 +1144,7 @@ func (e *MapExpr) End() token.Pos { return e.EndV }
 
 // StructLit is `User { name: v, ..rest }`.
 type StructLit struct {
+	ID     NodeID
 	PosV   token.Pos
 	EndV   token.Pos
 	Type   Expr // usually Ident or FieldExpr chain naming the type
@@ -1103,6 +1160,7 @@ type StructLit struct {
 
 // StructLitField is one `name: expr` entry (or shorthand `name`).
 type StructLitField struct {
+	ID    NodeID
 	PosV  token.Pos
 	Name  string
 	Value Expr // nil iff shorthand (Name only)
@@ -1126,6 +1184,7 @@ func (e *StructLit) End() token.Pos { return e.EndV }
 // IfExpr covers `if cond { .. } else if cond { .. } else { .. }` and
 // `if let pat = e { .. } else { .. }`.
 type IfExpr struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	IsIfLet bool
@@ -1144,12 +1203,13 @@ func (e *IfExpr) End() token.Pos { return e.EndV }
 // that produces a value has type `Never`; otherwise the type is the
 // join of every break-value branch.
 type LoopExpr struct {
-	PosV token.Pos
-	EndV token.Pos
-	Label string
+	ID       NodeID
+	PosV     token.Pos
+	EndV     token.Pos
+	Label    string
 	LabelPos token.Pos
 	LabelEnd token.Pos
-	Body *Block
+	Body     *Block
 }
 
 func (*LoopExpr) exprNode()        {}
@@ -1158,6 +1218,7 @@ func (e *LoopExpr) End() token.Pos { return e.EndV }
 
 // MatchExpr is `match scrutinee { arm, arm, ... }`.
 type MatchExpr struct {
+	ID        NodeID
 	PosV      token.Pos
 	EndV      token.Pos
 	Scrutinee Expr
@@ -1166,6 +1227,7 @@ type MatchExpr struct {
 
 // MatchArm is `pattern [if guard] -> body`.
 type MatchArm struct {
+	ID      NodeID
 	PosV    token.Pos
 	Pattern Pattern
 	Guard   Expr // optional
@@ -1186,6 +1248,7 @@ func (e *MatchExpr) End() token.Pos { return e.EndV }
 
 // ClosureExpr is `|params| body` or `|params| -> T { body }`.
 type ClosureExpr struct {
+	ID         NodeID
 	PosV       token.Pos
 	EndV       token.Pos
 	Params     []*Param // types optional (inferred)
@@ -1201,6 +1264,7 @@ func (e *ClosureExpr) End() token.Pos { return e.EndV }
 
 // WildcardPat is `_`.
 type WildcardPat struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 }
@@ -1211,6 +1275,7 @@ func (p *WildcardPat) End() token.Pos { return p.EndV }
 
 // LiteralPat is a literal used as a pattern.
 type LiteralPat struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Literal Expr // IntLit, FloatLit, StringLit, CharLit, BoolLit, ByteLit
@@ -1222,6 +1287,7 @@ func (p *LiteralPat) End() token.Pos { return p.EndV }
 
 // IdentPat is a pattern that binds an identifier.
 type IdentPat struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Name string
@@ -1233,6 +1299,7 @@ func (p *IdentPat) End() token.Pos { return p.EndV }
 
 // TuplePat is `(a, b, _)`.
 type TuplePat struct {
+	ID    NodeID
 	PosV  token.Pos
 	EndV  token.Pos
 	Elems []Pattern
@@ -1244,6 +1311,7 @@ func (p *TuplePat) End() token.Pos { return p.EndV }
 
 // StructPat is `Point { x, y: n, .. }`.
 type StructPat struct {
+	ID     NodeID
 	PosV   token.Pos
 	EndV   token.Pos
 	Type   []string // qualified name (e.g. pkg.Type)
@@ -1254,6 +1322,7 @@ type StructPat struct {
 // StructPatField is one field entry: name (shorthand), name: pattern,
 // or name: literal.
 type StructPatField struct {
+	ID      NodeID
 	PosV    token.Pos
 	Name    string
 	Pattern Pattern // nil for shorthand (binds to Name)
@@ -1274,6 +1343,7 @@ func (p *StructPat) End() token.Pos { return p.EndV }
 // VariantPat is `Some(x)`, `Rect(w, h)`, `Empty`, `Ok(Some(n))`, with
 // optional qualified name `pkg.Variant(...)`.
 type VariantPat struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Path []string  // e.g. ["Color", "Red"] or ["Some"]
@@ -1286,6 +1356,7 @@ func (p *VariantPat) End() token.Pos { return p.EndV }
 
 // RangePat is `0..=9`, `10..20`, `..=0`, `100..`.
 type RangePat struct {
+	ID        NodeID
 	PosV      token.Pos
 	EndV      token.Pos
 	Start     Expr // optional
@@ -1299,6 +1370,7 @@ func (p *RangePat) End() token.Pos { return p.EndV }
 
 // OrPat is `A | B | C`.
 type OrPat struct {
+	ID   NodeID
 	PosV token.Pos
 	EndV token.Pos
 	Alts []Pattern
@@ -1310,6 +1382,7 @@ func (p *OrPat) End() token.Pos { return p.EndV }
 
 // BindingPat is `name @ pattern`.
 type BindingPat struct {
+	ID      NodeID
 	PosV    token.Pos
 	EndV    token.Pos
 	Name    string

--- a/internal/ast/ids.go
+++ b/internal/ast/ids.go
@@ -1,0 +1,50 @@
+package ast
+
+import "reflect"
+
+// AssignIDs walks root in pre-order and assigns sequential NodeIDs to
+// every Node that carries an `ID NodeID` field. Existing nonzero IDs
+// are preserved so repeated calls are idempotent after the first pass.
+// The first assigned ID is 1; 0 remains the "unassigned" sentinel.
+//
+// Uses reflection to avoid a hand-written switch over every Node type;
+// parse-time cost is negligible relative to I/O and selfhost lowering.
+func AssignIDs(root Node) {
+	if root == nil {
+		return
+	}
+	next := NodeID(1)
+	var walk func(v reflect.Value)
+	walk = func(v reflect.Value) {
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr:
+			if v.IsNil() {
+				return
+			}
+			walk(v.Elem())
+			return
+		case reflect.Slice:
+			for i := 0; i < v.Len(); i++ {
+				walk(v.Index(i))
+			}
+			return
+		case reflect.Struct:
+			// ok — fall through
+		default:
+			return
+		}
+		if idField := v.FieldByName("ID"); idField.IsValid() &&
+			idField.Type() == nodeIDType && idField.CanSet() {
+			if idField.Uint() == 0 {
+				idField.SetUint(uint64(next))
+				next++
+			}
+		}
+		for i := 0; i < v.NumField(); i++ {
+			walk(v.Field(i))
+		}
+	}
+	walk(reflect.ValueOf(root))
+}
+
+var nodeIDType = reflect.TypeOf(NodeID(0))

--- a/internal/ast/ids_test.go
+++ b/internal/ast/ids_test.go
@@ -1,0 +1,85 @@
+package ast
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/osty/osty/internal/token"
+)
+
+func TestAssignIDsUniqueAndNonZero(t *testing.T) {
+	file := &File{
+		PosV: token.Pos{Line: 1, Column: 1},
+		EndV: token.Pos{Line: 2, Column: 1},
+		Decls: []Decl{
+			&LetDecl{
+				PosV:  token.Pos{Line: 1, Column: 1},
+				EndV:  token.Pos{Line: 1, Column: 10},
+				Name:  "x",
+				Value: &IntLit{PosV: token.Pos{Line: 1, Column: 9}, Text: "1"},
+			},
+		},
+	}
+
+	AssignIDs(file)
+
+	seen := map[NodeID]bool{}
+	var walk func(v reflect.Value)
+	walk = func(v reflect.Value) {
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr:
+			if v.IsNil() {
+				return
+			}
+			walk(v.Elem())
+			return
+		case reflect.Slice:
+			for i := 0; i < v.Len(); i++ {
+				walk(v.Index(i))
+			}
+			return
+		case reflect.Struct:
+		default:
+			return
+		}
+		if f := v.FieldByName("ID"); f.IsValid() && f.Type() == nodeIDType {
+			id := NodeID(f.Uint())
+			if id == 0 {
+				t.Errorf("node %s has zero ID", v.Type().Name())
+			}
+			if seen[id] {
+				t.Errorf("duplicate ID %d on %s", id, v.Type().Name())
+			}
+			seen[id] = true
+		}
+		for i := 0; i < v.NumField(); i++ {
+			walk(v.Field(i))
+		}
+	}
+	walk(reflect.ValueOf(file))
+
+	if len(seen) == 0 {
+		t.Fatal("no IDs assigned")
+	}
+}
+
+func TestAssignIDsIdempotent(t *testing.T) {
+	file := &File{
+		Decls: []Decl{&LetDecl{Name: "a"}, &LetDecl{Name: "b"}},
+	}
+	AssignIDs(file)
+	firstFile := file.ID
+	firstA := file.Decls[0].(*LetDecl).ID
+	firstB := file.Decls[1].(*LetDecl).ID
+
+	AssignIDs(file)
+	if file.ID != firstFile || file.Decls[0].(*LetDecl).ID != firstA || file.Decls[1].(*LetDecl).ID != firstB {
+		t.Fatal("second AssignIDs call changed existing IDs")
+	}
+}
+
+func TestAssignIDsNilSafe(t *testing.T) {
+	AssignIDs(nil)
+	var f *File
+	AssignIDs(f)
+}

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -107,8 +107,6 @@ func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryF
 		entry.File = entryFile.File
 		entry.Source = entryFile.Source
 		entry.Resolve = &resolve.Result{
-			Refs:      entryFile.Refs,
-			TypeRefs:  entryFile.TypeRefs,
 			FileScope: entryFile.FileScope,
 		}
 	}

--- a/internal/backend/stdlib_check.go
+++ b/internal/backend/stdlib_check.go
@@ -42,8 +42,6 @@ func stdlibCheckResult(reg *stdlib.Registry, module string) *check.Result {
 	entry.once.Do(func() {
 		pf := mod.Package.Files[0]
 		rr := &resolve.Result{
-			Refs:          pf.Refs,
-			TypeRefs:      pf.TypeRefs,
 			RefsByID:      pf.RefsByID,
 			TypeRefsByID:  pf.TypeRefsByID,
 			RefIdents:     pf.RefIdents,

--- a/internal/backend/stdlib_check.go
+++ b/internal/backend/stdlib_check.go
@@ -42,9 +42,11 @@ func stdlibCheckResult(reg *stdlib.Registry, module string) *check.Result {
 	entry.once.Do(func() {
 		pf := mod.Package.Files[0]
 		rr := &resolve.Result{
-			Refs:      pf.Refs,
-			TypeRefs:  pf.TypeRefs,
-			FileScope: pf.FileScope,
+			Refs:         pf.Refs,
+			TypeRefs:     pf.TypeRefs,
+			RefsByID:     pf.RefsByID,
+			TypeRefsByID: pf.TypeRefsByID,
+			FileScope:    pf.FileScope,
 		}
 		// Source bytes are required — the native checker boundary reads
 		// them to drive its parse + type inference pipeline. Without

--- a/internal/backend/stdlib_check.go
+++ b/internal/backend/stdlib_check.go
@@ -42,11 +42,13 @@ func stdlibCheckResult(reg *stdlib.Registry, module string) *check.Result {
 	entry.once.Do(func() {
 		pf := mod.Package.Files[0]
 		rr := &resolve.Result{
-			Refs:         pf.Refs,
-			TypeRefs:     pf.TypeRefs,
-			RefsByID:     pf.RefsByID,
-			TypeRefsByID: pf.TypeRefsByID,
-			FileScope:    pf.FileScope,
+			Refs:          pf.Refs,
+			TypeRefs:      pf.TypeRefs,
+			RefsByID:      pf.RefsByID,
+			TypeRefsByID:  pf.TypeRefsByID,
+			RefIdents:     pf.RefIdents,
+			TypeRefIdents: pf.TypeRefIdents,
+			FileScope:     pf.FileScope,
 		}
 		// Source bytes are required — the native checker boundary reads
 		// them to drive its parse + type inference pipeline. Without

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -362,8 +362,10 @@ func stdlibResolveResult(reg *stdlib.Registry, module string) *resolve.Result {
 	}
 	pf := mod.Package.Files[0]
 	return &resolve.Result{
-		Refs:      pf.Refs,
-		TypeRefs:  pf.TypeRefs,
-		FileScope: pf.FileScope,
+		Refs:         pf.Refs,
+		TypeRefs:     pf.TypeRefs,
+		RefsByID:     pf.RefsByID,
+		TypeRefsByID: pf.TypeRefsByID,
+		FileScope:    pf.FileScope,
 	}
 }

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -362,8 +362,6 @@ func stdlibResolveResult(reg *stdlib.Registry, module string) *resolve.Result {
 	}
 	pf := mod.Package.Files[0]
 	return &resolve.Result{
-		Refs:          pf.Refs,
-		TypeRefs:      pf.TypeRefs,
 		RefsByID:      pf.RefsByID,
 		TypeRefsByID:  pf.TypeRefsByID,
 		RefIdents:     pf.RefIdents,

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -362,10 +362,12 @@ func stdlibResolveResult(reg *stdlib.Registry, module string) *resolve.Result {
 	}
 	pf := mod.Package.Files[0]
 	return &resolve.Result{
-		Refs:         pf.Refs,
-		TypeRefs:     pf.TypeRefs,
-		RefsByID:     pf.RefsByID,
-		TypeRefsByID: pf.TypeRefsByID,
-		FileScope:    pf.FileScope,
+		Refs:          pf.Refs,
+		TypeRefs:      pf.TypeRefs,
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
 	}
 }

--- a/internal/bootstrap/gen/error_runtime_test.go
+++ b/internal/bootstrap/gen/error_runtime_test.go
@@ -107,8 +107,6 @@ func bootstrapGeneratedSource(t *testing.T, path string) string {
 	}
 
 	fileRes := &resolve.Result{
-		Refs:      entryFile.Refs,
-		TypeRefs:  entryFile.TypeRefs,
 		FileScope: entryFile.FileScope,
 		Diags:     rootRes.Diags,
 	}

--- a/internal/bootstrap/gen/gen.go
+++ b/internal/bootstrap/gen/gen.go
@@ -2215,10 +2215,10 @@ func runParallelMap[T any, R any](items []T, concurrency int, fn func(T) R) []R 
 
 // symbolFor returns the resolver Symbol for an Ident, or nil.
 func (g *gen) symbolFor(id *ast.Ident) *resolve.Symbol {
-	if g.res == nil {
+	if g.res == nil || id == nil {
 		return nil
 	}
-	return g.res.Refs[id]
+	return g.res.RefsByID[id.ID]
 }
 
 // typeOf returns the checked type of an expression, or nil when the

--- a/internal/bootstrap/gen/monomorph.go
+++ b/internal/bootstrap/gen/monomorph.go
@@ -113,10 +113,10 @@ func (g *gen) calleeSymbol(fn ast.Expr) *resolve.Symbol {
 // a generic fn's body is visited once per outer monomorph, and each
 // inner generic call is re-specialized under that monomorph's subst.
 func (g *gen) callMonoName(c *ast.CallExpr) string {
-	if g.chk == nil {
+	if g.chk == nil || c == nil {
 		return ""
 	}
-	args, ok := g.chk.Instantiations[c]
+	args, ok := g.chk.InstantiationsByID[c.ID]
 	if !ok || len(args) == 0 {
 		return ""
 	}

--- a/internal/bootstrap/gen/typ.go
+++ b/internal/bootstrap/gen/typ.go
@@ -447,7 +447,7 @@ func (g *gen) typeRefSym(n *ast.NamedType) *resolve.Symbol {
 	if g.res == nil || n == nil {
 		return nil
 	}
-	return g.res.TypeRefs[n]
+	return g.res.TypeRefsByID[n.ID]
 }
 
 func (g *gen) goFnTypeAST(f *ast.FnType) string {

--- a/internal/bootstrap/seedgen/seedgen.go
+++ b/internal/bootstrap/seedgen/seedgen.go
@@ -105,8 +105,6 @@ func Generate(cfg Config) ([]byte, error) {
 	}
 
 	fileRes := &resolve.Result{
-		Refs:      entryFile.Refs,
-		TypeRefs:  entryFile.TypeRefs,
 		FileScope: entryFile.FileScope,
 		Diags:     res.Diags,
 	}

--- a/internal/check/builder_desugar.go
+++ b/internal/check/builder_desugar.go
@@ -48,7 +48,7 @@ func DesugarBuildersInFile(f *ast.File, rr *resolve.Result) []*diag.Diagnostic {
 
 type builderDesugar struct {
 	localStructs map[string]*ast.StructDecl
-	refs         map[*ast.Ident]*resolve.Symbol
+	refs         map[ast.NodeID]*resolve.Symbol
 	diags        []*diag.Diagnostic
 	// scope is a stack of per-block variable → struct-decl bindings
 	// used to recover the receiver type of `ident.toBuilder()` when
@@ -61,7 +61,7 @@ func newBuilderDesugar(f *ast.File, rr *resolve.Result) *builderDesugar {
 		localStructs: map[string]*ast.StructDecl{},
 	}
 	if rr != nil {
-		out.refs = rr.Refs
+		out.refs = rr.RefsByID
 	}
 	for _, d := range f.Decls {
 		if sd, ok := d.(*ast.StructDecl); ok {
@@ -85,7 +85,7 @@ func (w *builderDesugar) structByIdent(id *ast.Ident) *ast.StructDecl {
 	if w.refs == nil {
 		return nil
 	}
-	sym := w.refs[id]
+	sym := w.refs[id.ID]
 	if sym == nil || sym.Kind != resolve.SymStruct {
 		return nil
 	}

--- a/internal/check/builder_desugar_test.go
+++ b/internal/check/builder_desugar_test.go
@@ -522,8 +522,8 @@ fn main() {
 	// `Point` Ident in `Point.builder()`. We don't remove the local
 	// table entry (that would require constructing a throwaway
 	// File), but we do verify the Refs path is at least consulted.
-	if rr.Refs == nil {
-		t.Fatal("resolver should populate Refs map")
+	if rr.RefsByID == nil {
+		t.Fatal("resolver should populate RefsByID map")
 	}
 	diags := DesugarBuildersInFile(f, rr)
 	if len(diags) != 0 {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -25,21 +25,16 @@ type Result struct {
 	// SymTypes maps each resolver Symbol to its declared type.
 	SymTypes map[*resolve.Symbol]types.Type
 
-	// Instantiations records the concrete type-argument list at every
-	// generic call site (identified by its *ast.CallExpr). The Go
-	// backend emission reads this to emit one monomorphized copy of the
-	// callee per distinct argument list.
-	Instantiations map[*ast.CallExpr][]types.Type
-
-	// InstantiationsByID mirrors Instantiations keyed by ast.NodeID.
-	// Populated in parallel with Instantiations so callers can migrate
-	// off *ast.CallExpr pointer identity. Self-host ports key on this.
+	// InstantiationsByID records the concrete type-argument list at
+	// every generic call site, keyed by the CallExpr's NodeID. The
+	// backends read this to emit one monomorphized copy of the callee
+	// per distinct argument list.
 	InstantiationsByID map[ast.NodeID][]types.Type
 
 	// InstantiationCalls enumerates the call sites behind
-	// InstantiationsByID, for callers that need to walk all
-	// monomorphized call expressions without relying on pointer-keyed
-	// map iteration.
+	// InstantiationsByID so callers that need to walk every
+	// monomorphized call expression do not rely on pointer-keyed map
+	// iteration.
 	InstantiationCalls []*ast.CallExpr
 
 	// Diags aggregates the diagnostics produced during checking.
@@ -303,7 +298,6 @@ func newResult() *Result {
 		Types:              map[ast.Expr]types.Type{},
 		LetTypes:           map[ast.Node]types.Type{},
 		SymTypes:           map[*resolve.Symbol]types.Type{},
-		Instantiations:     map[*ast.CallExpr][]types.Type{},
 		InstantiationsByID: map[ast.NodeID][]types.Type{},
 	}
 }
@@ -313,7 +307,6 @@ func resultWithSharedMaps(shared *Result) *Result {
 		Types:              shared.Types,
 		LetTypes:           shared.LetTypes,
 		SymTypes:           shared.SymTypes,
-		Instantiations:     shared.Instantiations,
 		InstantiationsByID: shared.InstantiationsByID,
 	}
 }
@@ -468,12 +461,10 @@ func diagnosticPrimaryEnd(d *diag.Diagnostic) token.Pos {
 // single resolved PackageFile. Returns nil if the file has no refs
 // map yet, which leaves the desugarer in local-file-only mode.
 func perFileResolveResult(pf *resolve.PackageFile) *resolve.Result {
-	if pf == nil || pf.Refs == nil {
+	if pf == nil || pf.RefsByID == nil {
 		return nil
 	}
 	return &resolve.Result{
-		Refs:          pf.Refs,
-		TypeRefs:      pf.TypeRefs,
 		RefsByID:      pf.RefsByID,
 		TypeRefsByID:  pf.TypeRefsByID,
 		RefIdents:     pf.RefIdents,

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -458,7 +458,13 @@ func perFileResolveResult(pf *resolve.PackageFile) *resolve.Result {
 	if pf == nil || pf.Refs == nil {
 		return nil
 	}
-	return &resolve.Result{Refs: pf.Refs, TypeRefs: pf.TypeRefs, FileScope: pf.FileScope}
+	return &resolve.Result{
+		Refs:         pf.Refs,
+		TypeRefs:     pf.TypeRefs,
+		RefsByID:     pf.RefsByID,
+		TypeRefsByID: pf.TypeRefsByID,
+		FileScope:    pf.FileScope,
+	}
 }
 
 func isProviderStdlibPackage(ws *resolve.Workspace, path string, pkg *resolve.Package) bool {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -36,6 +36,12 @@ type Result struct {
 	// off *ast.CallExpr pointer identity. Self-host ports key on this.
 	InstantiationsByID map[ast.NodeID][]types.Type
 
+	// InstantiationCalls enumerates the call sites behind
+	// InstantiationsByID, for callers that need to walk all
+	// monomorphized call expressions without relying on pointer-keyed
+	// map iteration.
+	InstantiationCalls []*ast.CallExpr
+
 	// Diags aggregates the diagnostics produced during checking.
 	Diags []*diag.Diagnostic
 
@@ -466,11 +472,13 @@ func perFileResolveResult(pf *resolve.PackageFile) *resolve.Result {
 		return nil
 	}
 	return &resolve.Result{
-		Refs:         pf.Refs,
-		TypeRefs:     pf.TypeRefs,
-		RefsByID:     pf.RefsByID,
-		TypeRefsByID: pf.TypeRefsByID,
-		FileScope:    pf.FileScope,
+		Refs:          pf.Refs,
+		TypeRefs:      pf.TypeRefs,
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
 	}
 }
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -31,6 +31,11 @@ type Result struct {
 	// callee per distinct argument list.
 	Instantiations map[*ast.CallExpr][]types.Type
 
+	// InstantiationsByID mirrors Instantiations keyed by ast.NodeID.
+	// Populated in parallel with Instantiations so callers can migrate
+	// off *ast.CallExpr pointer identity. Self-host ports key on this.
+	InstantiationsByID map[ast.NodeID][]types.Type
+
 	// Diags aggregates the diagnostics produced during checking.
 	Diags []*diag.Diagnostic
 
@@ -289,19 +294,21 @@ func Workspace(
 
 func newResult() *Result {
 	return &Result{
-		Types:          map[ast.Expr]types.Type{},
-		LetTypes:       map[ast.Node]types.Type{},
-		SymTypes:       map[*resolve.Symbol]types.Type{},
-		Instantiations: map[*ast.CallExpr][]types.Type{},
+		Types:              map[ast.Expr]types.Type{},
+		LetTypes:           map[ast.Node]types.Type{},
+		SymTypes:           map[*resolve.Symbol]types.Type{},
+		Instantiations:     map[*ast.CallExpr][]types.Type{},
+		InstantiationsByID: map[ast.NodeID][]types.Type{},
 	}
 }
 
 func resultWithSharedMaps(shared *Result) *Result {
 	return &Result{
-		Types:          shared.Types,
-		LetTypes:       shared.LetTypes,
-		SymTypes:       shared.SymTypes,
-		Instantiations: shared.Instantiations,
+		Types:              shared.Types,
+		LetTypes:           shared.LetTypes,
+		SymTypes:           shared.SymTypes,
+		Instantiations:     shared.Instantiations,
+		InstantiationsByID: shared.InstantiationsByID,
 	}
 }
 

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -495,7 +495,7 @@ type selfhostCheckedSource struct {
 type selfhostFileSegment struct {
 	file      *ast.File
 	scope     *resolve.Scope
-	refs      map[*ast.Ident]*resolve.Symbol
+	refs      map[ast.NodeID]*resolve.Symbol
 	base      int
 	sourceMap *sourcemap.Map
 }
@@ -1033,14 +1033,11 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked na
 				args = append(args, t)
 			}
 		}
-		if len(args) == len(inst.TypeArgs) {
-			if _, existed := result.Instantiations[call]; !existed {
+		if len(args) == len(inst.TypeArgs) && call.ID != 0 {
+			if _, existed := result.InstantiationsByID[call.ID]; !existed {
 				result.InstantiationCalls = append(result.InstantiationCalls, call)
 			}
-			result.Instantiations[call] = args
-			if call.ID != 0 && result.InstantiationsByID != nil {
-				result.InstantiationsByID[call.ID] = args
-			}
+			result.InstantiationsByID[call.ID] = args
 		}
 	}
 }
@@ -1810,10 +1807,10 @@ func selfhostFileSource(file *ast.File, rr *resolve.Result, src []byte, stdlib r
 		b.WriteByte('\n')
 	}
 	var scope *resolve.Scope
-	var refs map[*ast.Ident]*resolve.Symbol
+	var refs map[ast.NodeID]*resolve.Symbol
 	if rr != nil {
 		scope = rr.FileScope
-		refs = rr.Refs
+		refs = rr.RefsByID
 	}
 	return selfhostCheckedSource{
 		source: b.Bytes(),
@@ -1835,10 +1832,10 @@ func selfhostFileStructuredSource(file *ast.File, rr *resolve.Result, src []byte
 		}
 	}
 	var scope *resolve.Scope
-	var refs map[*ast.Ident]*resolve.Symbol
+	var refs map[ast.NodeID]*resolve.Symbol
 	if rr != nil {
 		scope = rr.FileScope
-		refs = rr.Refs
+		refs = rr.RefsByID
 	}
 	return selfhostCheckedSource{
 		source: append([]byte(nil), src...),
@@ -1872,7 +1869,7 @@ func selfhostPackageSource(pkg *resolve.Package, ws *resolve.Workspace, stdlib r
 		files = append(files, selfhostFileSegment{
 			file:      pf.File,
 			scope:     pf.FileScope,
-			refs:      pf.Refs,
+			refs:      pf.RefsByID,
 			base:      base,
 			sourceMap: pf.CanonicalMap,
 		})

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1035,6 +1035,9 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked na
 		}
 		if len(args) == len(inst.TypeArgs) {
 			result.Instantiations[call] = args
+			if call.ID != 0 && result.InstantiationsByID != nil {
+				result.InstantiationsByID[call.ID] = args
+			}
 		}
 	}
 }

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1034,6 +1034,9 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked na
 			}
 		}
 		if len(args) == len(inst.TypeArgs) {
+			if _, existed := result.Instantiations[call]; !existed {
+				result.InstantiationCalls = append(result.InstantiationCalls, call)
+			}
 			result.Instantiations[call] = args
 			if call.ID != 0 && result.InstantiationsByID != nil {
 				result.InstantiationsByID[call.ID] = args

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -166,10 +166,10 @@ fn main() {
 	if got := chk.LookupSymType(res.FileScope.Lookup("id")); got == nil || got.String() != "fn(T) -> T" {
 		t.Fatalf("symbol type = %v, want fn(T) -> T", got)
 	}
-	if len(chk.Instantiations) != 1 {
-		t.Fatalf("instantiations = %#v, want one entry", chk.Instantiations)
+	if len(chk.InstantiationsByID) != 1 {
+		t.Fatalf("instantiations = %#v, want one entry", chk.InstantiationsByID)
 	}
-	if got := chk.Instantiations[call]; len(got) != 1 || got[0].String() != "Int" {
+	if got := chk.InstantiationsByID[call.ID]; len(got) != 1 || got[0].String() != "Int" {
 		t.Fatalf("call instantiation = %#v, want [Int]", got)
 	}
 }

--- a/internal/check/inspect.go
+++ b/internal/check/inspect.go
@@ -498,7 +498,7 @@ func (i *inspector) callNotes(n *ast.CallExpr) []string {
 	if _, ok := n.Fn.(*ast.FieldExpr); ok {
 		notes = append(notes, "method call")
 	}
-	if args, ok := i.chk.Instantiations[n]; ok && len(args) > 0 {
+	if args, ok := i.chk.InstantiationsByID[n.ID]; ok && len(args) > 0 {
 		names := make([]string, 0, len(args))
 		for _, a := range args {
 			if a == nil {

--- a/internal/check/inspect_test.go
+++ b/internal/check/inspect_test.go
@@ -53,8 +53,8 @@ fn main() {
 			letAnswer: types.Int,
 			letTotal:  types.Int,
 		},
-		SymTypes:       map[*resolve.Symbol]types.Type{},
-		Instantiations: map[*ast.CallExpr][]types.Type{},
+		SymTypes:           map[*resolve.Symbol]types.Type{},
+		InstantiationsByID: map[ast.NodeID][]types.Type{},
 	}
 
 	recs := Inspect(file, chk)
@@ -209,9 +209,6 @@ fn main() {
 			letAnswer: types.Int,
 		},
 		SymTypes: map[*resolve.Symbol]types.Type{},
-		Instantiations: map[*ast.CallExpr][]types.Type{
-			call: {types.Int},
-		},
 		InstantiationsByID: map[ast.NodeID][]types.Type{
 			call.ID: {types.Int},
 		},

--- a/internal/check/inspect_test.go
+++ b/internal/check/inspect_test.go
@@ -212,6 +212,9 @@ fn main() {
 		Instantiations: map[*ast.CallExpr][]types.Type{
 			call: {types.Int},
 		},
+		InstantiationsByID: map[ast.NodeID][]types.Type{
+			call.ID: {types.Int},
+		},
 	}
 	recs := Inspect(file, chk)
 

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -44,7 +44,7 @@ fn main() {
 	if got := chk.LookupSymType(res.FileScope.Lookup("id")); got == nil || got.String() != "fn(T) -> T" {
 		t.Fatalf("symbol type = %v, want fn(T) -> T", got)
 	}
-	if got := chk.Instantiations[call]; len(got) != 1 || got[0].String() != "Int" {
+	if got := chk.InstantiationsByID[call.ID]; len(got) != 1 || got[0].String() != "Int" {
 		t.Fatalf("call instantiation = %#v, want [Int]", got)
 	}
 }

--- a/internal/check/query.go
+++ b/internal/check/query.go
@@ -48,14 +48,14 @@ func (r *Result) SymbolAt(pos token.Pos, rr *resolve.Result) *resolve.Symbol {
 	if rr == nil {
 		return nil
 	}
-	for id, sym := range rr.Refs {
+	for _, id := range rr.RefIdents {
 		if spanContains(id.PosV, id.EndV, pos) {
-			return sym
+			return rr.RefsByID[id.ID]
 		}
 	}
-	for id, sym := range rr.TypeRefs {
-		if spanContains(id.PosV, id.EndV, pos) {
-			return sym
+	for _, nt := range rr.TypeRefIdents {
+		if spanContains(nt.PosV, nt.EndV, pos) {
+			return rr.TypeRefsByID[nt.ID]
 		}
 	}
 	return nil

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -80,8 +80,6 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 			continue
 		}
 		res := &resolve.Result{
-			Refs:          pf.Refs,
-			TypeRefs:      pf.TypeRefs,
 			RefsByID:      pf.RefsByID,
 			TypeRefsByID:  pf.TypeRefsByID,
 			RefIdents:     pf.RefIdents,

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -80,9 +80,11 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 			continue
 		}
 		res := &resolve.Result{
-			Refs:      pf.Refs,
-			TypeRefs:  pf.TypeRefs,
-			FileScope: pf.FileScope,
+			Refs:         pf.Refs,
+			TypeRefs:     pf.TypeRefs,
+			RefsByID:     pf.RefsByID,
+			TypeRefsByID: pf.TypeRefsByID,
+			FileScope:    pf.FileScope,
 		}
 		l := &lowerer{pkgName: pkgName, file: pf.File, res: res, chk: chk}
 		fileMod, fileIssues := l.run()

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -80,11 +80,13 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 			continue
 		}
 		res := &resolve.Result{
-			Refs:         pf.Refs,
-			TypeRefs:     pf.TypeRefs,
-			RefsByID:     pf.RefsByID,
-			TypeRefsByID: pf.TypeRefsByID,
-			FileScope:    pf.FileScope,
+			Refs:          pf.Refs,
+			TypeRefs:      pf.TypeRefs,
+			RefsByID:      pf.RefsByID,
+			TypeRefsByID:  pf.TypeRefsByID,
+			RefIdents:     pf.RefIdents,
+			TypeRefIdents: pf.TypeRefIdents,
+			FileScope:     pf.FileScope,
 		}
 		l := &lowerer{pkgName: pkgName, file: pf.File, res: res, chk: chk}
 		fileMod, fileIssues := l.run()
@@ -731,10 +733,10 @@ func joinDottedPath(parts []string) string {
 }
 
 func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
-	if l.res == nil {
+	if l.res == nil || nt == nil {
 		return nil
 	}
-	return l.res.TypeRefs[nt]
+	return l.res.TypeRefsByID[nt.ID]
 }
 
 // primitiveByName maps a scalar type name to the IR singleton.
@@ -1282,7 +1284,7 @@ func (l *lowerer) lowerIdent(id *ast.Ident) Expr {
 	out := &Ident{Name: id.Name, SpanV: nodeSpan(id), T: ErrTypeVal}
 	var sym *resolve.Symbol
 	if l.res != nil {
-		if s := l.res.Refs[id]; s != nil {
+		if s := l.res.RefsByID[id.ID]; s != nil {
 			sym = s
 			out.Kind = identKind(s)
 		}
@@ -1343,10 +1345,10 @@ func identTypeFromDecl(decl ast.Node) ast.Type {
 }
 
 func (l *lowerer) symbol(id *ast.Ident) *resolve.Symbol {
-	if l.res == nil {
+	if l.res == nil || id == nil {
 		return nil
 	}
-	return l.res.Refs[id]
+	return l.res.RefsByID[id.ID]
 }
 
 func identKind(sym *resolve.Symbol) IdentKind {
@@ -1749,10 +1751,10 @@ func (l *lowerer) lowerArg(a *ast.Arg) Arg {
 // checker recorded for this call site (monomorphisation info), or nil
 // when the checker did not annotate it.
 func (l *lowerer) instantiationArgs(e *ast.CallExpr) []Type {
-	if l.chk == nil || l.chk.Instantiations == nil {
+	if l.chk == nil || l.chk.InstantiationsByID == nil || e == nil {
 		return nil
 	}
-	raw, ok := l.chk.Instantiations[e]
+	raw, ok := l.chk.InstantiationsByID[e.ID]
 	if !ok || len(raw) == 0 {
 		return nil
 	}

--- a/internal/ir/lower_stdlib_test.go
+++ b/internal/ir/lower_stdlib_test.go
@@ -25,8 +25,6 @@ func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
 	}
 	pf := mod.Package.Files[0]
 	res := &resolve.Result{
-		Refs:          pf.Refs,
-		TypeRefs:      pf.TypeRefs,
 		RefsByID:      pf.RefsByID,
 		TypeRefsByID:  pf.TypeRefsByID,
 		RefIdents:     pf.RefIdents,

--- a/internal/ir/lower_stdlib_test.go
+++ b/internal/ir/lower_stdlib_test.go
@@ -25,11 +25,13 @@ func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
 	}
 	pf := mod.Package.Files[0]
 	res := &resolve.Result{
-		Refs:         pf.Refs,
-		TypeRefs:     pf.TypeRefs,
-		RefsByID:     pf.RefsByID,
-		TypeRefsByID: pf.TypeRefsByID,
-		FileScope:    pf.FileScope,
+		Refs:          pf.Refs,
+		TypeRefs:      pf.TypeRefs,
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
 	}
 
 	out, issues := LowerFnDecl("stdlib_strings", fn, res, nil)

--- a/internal/ir/lower_stdlib_test.go
+++ b/internal/ir/lower_stdlib_test.go
@@ -25,9 +25,11 @@ func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
 	}
 	pf := mod.Package.Files[0]
 	res := &resolve.Result{
-		Refs:      pf.Refs,
-		TypeRefs:  pf.TypeRefs,
-		FileScope: pf.FileScope,
+		Refs:         pf.Refs,
+		TypeRefs:     pf.TypeRefs,
+		RefsByID:     pf.RefsByID,
+		TypeRefsByID: pf.TypeRefsByID,
+		FileScope:    pf.FileScope,
 	}
 
 	out, issues := LowerFnDecl("stdlib_strings", fn, res, nil)

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -119,9 +119,11 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 			continue
 		}
 		rr := &resolve.Result{
-			Refs:      pf.Refs,
-			TypeRefs:  pf.TypeRefs,
-			FileScope: pf.FileScope,
+			Refs:         pf.Refs,
+			TypeRefs:     pf.TypeRefs,
+			RefsByID:     pf.RefsByID,
+			TypeRefsByID: pf.TypeRefsByID,
+			FileScope:    pf.FileScope,
 		}
 		// Each file gets its own local Result so that filterSuppressed
 		// only considers this file's #[allow(...)] regions against this

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -119,8 +119,6 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 			continue
 		}
 		rr := &resolve.Result{
-			Refs:          pf.Refs,
-			TypeRefs:      pf.TypeRefs,
 			RefsByID:      pf.RefsByID,
 			TypeRefsByID:  pf.TypeRefsByID,
 			RefIdents:     pf.RefIdents,

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -92,10 +92,10 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 	// each per-file lint pass.
 	used := map[*resolve.Symbol]bool{}
 	for _, pf := range pkg.Files {
-		for _, sym := range pf.Refs {
+		for _, sym := range pf.RefsByID {
 			used[sym] = true
 		}
-		for _, sym := range pf.TypeRefs {
+		for _, sym := range pf.TypeRefsByID {
 			used[sym] = true
 		}
 	}
@@ -119,11 +119,13 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 			continue
 		}
 		rr := &resolve.Result{
-			Refs:         pf.Refs,
-			TypeRefs:     pf.TypeRefs,
-			RefsByID:     pf.RefsByID,
-			TypeRefsByID: pf.TypeRefsByID,
-			FileScope:    pf.FileScope,
+			Refs:          pf.Refs,
+			TypeRefs:      pf.TypeRefs,
+			RefsByID:      pf.RefsByID,
+			TypeRefsByID:  pf.TypeRefsByID,
+			RefIdents:     pf.RefIdents,
+			TypeRefIdents: pf.TypeRefIdents,
+			FileScope:     pf.FileScope,
 		}
 		// Each file gets its own local Result so that filterSuppressed
 		// only considers this file's #[allow(...)] regions against this
@@ -180,10 +182,10 @@ func buildUsedSet(rr *resolve.Result) map[*resolve.Symbol]bool {
 	if rr == nil {
 		return used
 	}
-	for _, sym := range rr.Refs {
+	for _, sym := range rr.RefsByID {
 		used[sym] = true
 	}
-	for _, sym := range rr.TypeRefs {
+	for _, sym := range rr.TypeRefsByID {
 		used[sym] = true
 	}
 	return used

--- a/internal/lint/mut.go
+++ b/internal/lint/mut.go
@@ -583,7 +583,7 @@ func markReadsForDeadStore(e ast.Expr, pending map[ast.Node]*deadStoreEntry, rr 
 		}
 		switch n := e.(type) {
 		case *ast.Ident:
-			if sym, ok := rr.Refs[n]; ok && sym != nil && sym.Decl != nil {
+			if sym := rr.RefsByID[n.ID]; sym != nil && sym.Decl != nil {
 				if t, ok := pending[sym.Decl]; ok {
 					t.pending = false
 				}
@@ -649,7 +649,7 @@ func exprReadsDecl(e ast.Expr, decl ast.Node, rr *resolve.Result) bool {
 			return
 		}
 		if id, ok := e.(*ast.Ident); ok {
-			if sym := rr.Refs[id]; sym != nil && sym.Decl == decl {
+			if sym := rr.RefsByID[id.ID]; sym != nil && sym.Decl == decl {
 				found = true
 				return
 			}
@@ -715,7 +715,7 @@ func (l *linter) rootIdentDecl(e ast.Expr) ast.Node {
 			if l.resolved == nil {
 				return nil
 			}
-			if sym := l.resolved.Refs[n]; sym != nil {
+			if sym := l.resolved.RefsByID[n.ID]; sym != nil {
 				return sym.Decl
 			}
 			return nil

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -291,7 +291,7 @@ func exprsEqual(a, b ast.Expr, rr *resolve.Result) bool {
 		// If the resolver saw both, require identical Symbol identity
 		// so we don't flag `x` vs `x` that refer to distinct shadowed
 		// bindings (the shadow warning handles that separately).
-		sx, sy := rr.Refs[x], rr.Refs[y]
+		sx, sy := rr.RefsByID[x.ID], rr.RefsByID[y.ID]
 		if sx == nil || sy == nil {
 			// One unresolved — treat as possibly equal if names match.
 			return true

--- a/internal/lint/unused.go
+++ b/internal/lint/unused.go
@@ -78,12 +78,12 @@ func buildUsedDeclSet(rr *resolve.Result, usedSyms map[*resolve.Symbol]bool) map
 	if rr == nil {
 		return used
 	}
-	for _, sym := range rr.Refs {
+	for _, sym := range rr.RefsByID {
 		if sym != nil && sym.Decl != nil {
 			used[sym.Decl] = true
 		}
 	}
-	for _, sym := range rr.TypeRefs {
+	for _, sym := range rr.TypeRefsByID {
 		if sym != nil && sym.Decl != nil {
 			used[sym.Decl] = true
 		}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -465,7 +465,7 @@ func findIdentAt(a *docAnalysis, pos token.Pos) (*ast.Ident, *resolve.Symbol) {
 		return nil, nil
 	}
 	var best *ast.Ident
-	for id := range a.resolve.Refs {
+	for _, id := range a.resolve.RefIdents {
 		if containsPos(id.Pos(), id.End(), pos) {
 			// Prefer the narrowest span (useful once we have more
 			// nested node types, though Idents don't nest).
@@ -477,7 +477,7 @@ func findIdentAt(a *docAnalysis, pos token.Pos) (*ast.Ident, *resolve.Symbol) {
 	if best == nil {
 		return nil, nil
 	}
-	return best, a.resolve.Refs[best]
+	return best, a.resolve.RefsByID[best.ID]
 }
 
 // findNamedTypeAt mirrors findIdentAt for NamedType head references.
@@ -486,7 +486,7 @@ func findNamedTypeAt(a *docAnalysis, pos token.Pos) (*ast.NamedType, *resolve.Sy
 		return nil, nil
 	}
 	var best *ast.NamedType
-	for nt := range a.resolve.TypeRefs {
+	for _, nt := range a.resolve.TypeRefIdents {
 		if containsPos(nt.Pos(), nt.End(), pos) {
 			if best == nil || spanWidth(nt) < spanWidth(best) {
 				best = nt
@@ -496,7 +496,7 @@ func findNamedTypeAt(a *docAnalysis, pos token.Pos) (*ast.NamedType, *resolve.Sy
 	if best == nil {
 		return nil, nil
 	}
-	return best, a.resolve.TypeRefs[best]
+	return best, a.resolve.TypeRefsByID[best.ID]
 }
 
 // containsPos reports whether pos lies within [start, end). LSP

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -94,9 +94,9 @@ func (s *Server) targetSymbolAt(doc *document, lspPos Position) *resolve.Symbol 
 // (same URI + same start position) are collapsed before return.
 func (s *Server) findReferences(doc *document, target *resolve.Symbol, includeDecl bool) []Location {
 	var out []Location
-	visit := func(uri string, src []byte, li *lineIndex, refs map[*ast.Ident]*resolve.Symbol, typeRefs map[*ast.NamedType]*resolve.Symbol) {
-		for id, sym := range refs {
-			if sym != target {
+	visit := func(uri string, src []byte, li *lineIndex, refIdents []*ast.Ident, typeRefIdents []*ast.NamedType, refs map[ast.NodeID]*resolve.Symbol, typeRefs map[ast.NodeID]*resolve.Symbol) {
+		for _, id := range refIdents {
+			if refs[id.ID] != target {
 				continue
 			}
 			out = append(out, Location{
@@ -104,8 +104,8 @@ func (s *Server) findReferences(doc *document, target *resolve.Symbol, includeDe
 				Range: li.ostyRange(diag.Span{Start: id.Pos(), End: id.End()}),
 			})
 		}
-		for nt, sym := range typeRefs {
-			if sym != target {
+		for _, nt := range typeRefIdents {
+			if typeRefs[nt.ID] != target {
 				continue
 			}
 			// `auth.User` is a single NamedType whose head reference
@@ -127,13 +127,15 @@ func (s *Server) findReferences(doc *document, target *resolve.Symbol, includeDe
 	}
 
 	if len(doc.analysis.packages) == 0 {
-		visit(doc.uri, doc.src, doc.analysis.lines, doc.analysis.resolve.Refs, doc.analysis.resolve.TypeRefs)
+		visit(doc.uri, doc.src, doc.analysis.lines,
+			doc.analysis.resolve.RefIdents, doc.analysis.resolve.TypeRefIdents,
+			doc.analysis.resolve.RefsByID, doc.analysis.resolve.TypeRefsByID)
 	} else {
 		for _, pkg := range doc.analysis.packages {
 			for _, pf := range pkg.Files {
 				uri := pathToURI(pf.Path)
 				li := newLineIndex(pf.Source)
-				visit(uri, pf.Source, li, pf.Refs, pf.TypeRefs)
+				visit(uri, pf.Source, li, pf.RefIdents, pf.TypeRefIdents, pf.RefsByID, pf.TypeRefsByID)
 			}
 		}
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -336,12 +336,12 @@ func buildIdentIndex(r *resolve.Result) map[int]*resolve.Symbol {
 	if r == nil {
 		return nil
 	}
-	out := make(map[int]*resolve.Symbol, len(r.Refs)+len(r.TypeRefs))
-	for id, sym := range r.Refs {
-		out[id.PosV.Offset] = sym
+	out := make(map[int]*resolve.Symbol, len(r.RefIdents)+len(r.TypeRefIdents))
+	for _, id := range r.RefIdents {
+		out[id.PosV.Offset] = r.RefsByID[id.ID]
 	}
-	for nt, sym := range r.TypeRefs {
-		out[nt.PosV.Offset] = sym
+	for _, nt := range r.TypeRefIdents {
+		out[nt.PosV.Offset] = r.TypeRefsByID[nt.ID]
 	}
 	return out
 }
@@ -598,11 +598,13 @@ func analysisForFileInPackage(
 		return nil
 	}
 	fileRes := &resolve.Result{
-		Refs:         pf.Refs,
-		TypeRefs:     pf.TypeRefs,
-		RefsByID:     pf.RefsByID,
-		TypeRefsByID: pf.TypeRefsByID,
-		FileScope:    pf.FileScope,
+		Refs:          pf.Refs,
+		TypeRefs:      pf.TypeRefs,
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
 	}
 	all := collectDiagsForFile(pr, chk, lr, pf)
 	return &docAnalysis{

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -598,8 +598,6 @@ func analysisForFileInPackage(
 		return nil
 	}
 	fileRes := &resolve.Result{
-		Refs:          pf.Refs,
-		TypeRefs:      pf.TypeRefs,
 		RefsByID:      pf.RefsByID,
 		TypeRefsByID:  pf.TypeRefsByID,
 		RefIdents:     pf.RefIdents,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -598,9 +598,11 @@ func analysisForFileInPackage(
 		return nil
 	}
 	fileRes := &resolve.Result{
-		Refs:      pf.Refs,
-		TypeRefs:  pf.TypeRefs,
-		FileScope: pf.FileScope,
+		Refs:         pf.Refs,
+		TypeRefs:     pf.TypeRefs,
+		RefsByID:     pf.RefsByID,
+		TypeRefsByID: pf.TypeRefsByID,
+		FileScope:    pf.FileScope,
 	}
 	all := collectDiagsForFile(pr, chk, lr, pf)
 	return &docAnalysis{

--- a/internal/lsp/signature.go
+++ b/internal/lsp/signature.go
@@ -147,7 +147,7 @@ func calleeSymbol(call *ast.CallExpr, a *docAnalysis) (*resolve.Symbol, *ast.FnD
 		return nil, nil
 	}
 	if id, ok := call.Fn.(*ast.Ident); ok {
-		sym := a.resolve.Refs[id]
+		sym := a.resolve.RefsByID[id.ID]
 		if sym == nil {
 			return nil, nil
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -682,9 +682,11 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 	var lintDiags []*diag.Diagnostic
 	for _, pf := range pkg.Files {
 		fileRes := &resolve.Result{
-			Refs:      pf.Refs,
-			TypeRefs:  pf.TypeRefs,
-			FileScope: pf.FileScope,
+			Refs:         pf.Refs,
+			TypeRefs:     pf.TypeRefs,
+			RefsByID:     pf.RefsByID,
+			TypeRefsByID: pf.TypeRefsByID,
+			FileScope:    pf.FileScope,
 		}
 		lr := lint.File(pf.File, fileRes, chk)
 		lintDiags = append(lintDiags, lr.Diags...)
@@ -906,9 +908,11 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 		}
 		for _, pf := range pkg.Files {
 			fileRes := &resolve.Result{
-				Refs:      pf.Refs,
-				TypeRefs:  pf.TypeRefs,
-				FileScope: pf.FileScope,
+				Refs:         pf.Refs,
+				TypeRefs:     pf.TypeRefs,
+				RefsByID:     pf.RefsByID,
+				TypeRefsByID: pf.TypeRefsByID,
+				FileScope:    pf.FileScope,
 			}
 			lr := lint.File(pf.File, fileRes, cr)
 			lintDiags = append(lintDiags, lr.Diags...)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -682,11 +682,13 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 	var lintDiags []*diag.Diagnostic
 	for _, pf := range pkg.Files {
 		fileRes := &resolve.Result{
-			Refs:         pf.Refs,
-			TypeRefs:     pf.TypeRefs,
-			RefsByID:     pf.RefsByID,
-			TypeRefsByID: pf.TypeRefsByID,
-			FileScope:    pf.FileScope,
+			Refs:          pf.Refs,
+			TypeRefs:      pf.TypeRefs,
+			RefsByID:      pf.RefsByID,
+			TypeRefsByID:  pf.TypeRefsByID,
+			RefIdents:     pf.RefIdents,
+			TypeRefIdents: pf.TypeRefIdents,
+			FileScope:     pf.FileScope,
 		}
 		lr := lint.File(pf.File, fileRes, chk)
 		lintDiags = append(lintDiags, lr.Diags...)
@@ -908,11 +910,13 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 		}
 		for _, pf := range pkg.Files {
 			fileRes := &resolve.Result{
-				Refs:         pf.Refs,
-				TypeRefs:     pf.TypeRefs,
-				RefsByID:     pf.RefsByID,
-				TypeRefsByID: pf.TypeRefsByID,
-				FileScope:    pf.FileScope,
+				Refs:          pf.Refs,
+				TypeRefs:      pf.TypeRefs,
+				RefsByID:      pf.RefsByID,
+				TypeRefsByID:  pf.TypeRefsByID,
+				RefIdents:     pf.RefIdents,
+				TypeRefIdents: pf.TypeRefIdents,
+				FileScope:     pf.FileScope,
 			}
 			lr := lint.File(pf.File, fileRes, cr)
 			lintDiags = append(lintDiags, lr.Diags...)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -456,12 +456,12 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 	emit(Stage{
 		Name:     "resolve",
 		Duration: time.Since(t0),
-		Output:   fmt.Sprintf("%d refs, %d type refs", len(res.Refs), len(res.TypeRefs)),
+		Output:   fmt.Sprintf("%d refs, %d type refs", len(res.RefsByID), len(res.TypeRefsByID)),
 		Errors:   countSeverity(res.Diags, diag.Error),
 		Warnings: countSeverity(res.Diags, diag.Warning),
 		Counts: map[string]int{
-			"refs":      len(res.Refs),
-			"type_refs": len(res.TypeRefs),
+			"refs":      len(res.RefsByID),
+			"type_refs": len(res.TypeRefsByID),
 		},
 	})
 
@@ -499,7 +499,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 			"typed_exprs": typedExprs,
 			"let_types":   len(chk.LetTypes),
 			"sym_types":   len(chk.SymTypes),
-			"instantiate": len(chk.Instantiations),
+			"instantiate": len(chk.InstantiationsByID),
 		},
 	})
 
@@ -624,8 +624,8 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 	r.AllDiags = append(r.AllDiags, res.Diags...)
 	totalRefs, totalTypeRefs := 0, 0
 	for _, pf := range pkg.Files {
-		totalRefs += len(pf.Refs)
-		totalTypeRefs += len(pf.TypeRefs)
+		totalRefs += len(pf.RefsByID)
+		totalTypeRefs += len(pf.TypeRefsByID)
 	}
 	emit(Stage{
 		Name:     "resolve",
@@ -673,7 +673,7 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 			"typed_exprs": typedExprs,
 			"let_types":   len(chk.LetTypes),
 			"sym_types":   len(chk.SymTypes),
-			"instantiate": len(chk.Instantiations),
+			"instantiate": len(chk.InstantiationsByID),
 		},
 	})
 
@@ -682,8 +682,6 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 	var lintDiags []*diag.Diagnostic
 	for _, pf := range pkg.Files {
 		fileRes := &resolve.Result{
-			Refs:          pf.Refs,
-			TypeRefs:      pf.TypeRefs,
 			RefsByID:      pf.RefsByID,
 			TypeRefsByID:  pf.TypeRefsByID,
 			RefIdents:     pf.RefIdents,
@@ -836,8 +834,8 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 			continue
 		}
 		for _, pf := range pkg.Files {
-			totalRefs += len(pf.Refs)
-			totalTypeRefs += len(pf.TypeRefs)
+			totalRefs += len(pf.RefsByID)
+			totalTypeRefs += len(pf.TypeRefsByID)
 		}
 	}
 	r.AllDiags = append(r.AllDiags, resolveDiags...)
@@ -910,8 +908,6 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 		}
 		for _, pf := range pkg.Files {
 			fileRes := &resolve.Result{
-				Refs:          pf.Refs,
-				TypeRefs:      pf.TypeRefs,
 				RefsByID:      pf.RefsByID,
 				TypeRefsByID:  pf.TypeRefsByID,
 				RefIdents:     pf.RefIdents,

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -265,9 +265,9 @@ func hashFileRefs(h *stableHasher, pf *resolve.PackageFile) {
 		name string
 		sym  *resolve.Symbol
 	}
-	refs := make([]refEntry, 0, len(pf.Refs))
-	for id, sym := range pf.Refs {
-		refs = append(refs, refEntry{off: id.Pos().Offset, name: id.Name, sym: sym})
+	refs := make([]refEntry, 0, len(pf.RefIdents))
+	for _, id := range pf.RefIdents {
+		refs = append(refs, refEntry{off: id.Pos().Offset, name: id.Name, sym: pf.RefsByID[id.ID]})
 	}
 	sort.Slice(refs, func(i, j int) bool {
 		if refs[i].off != refs[j].off {
@@ -287,9 +287,9 @@ func hashFileRefs(h *stableHasher, pf *resolve.PackageFile) {
 		off int
 		sym *resolve.Symbol
 	}
-	tr := make([]typeRefEntry, 0, len(pf.TypeRefs))
-	for nt, sym := range pf.TypeRefs {
-		tr = append(tr, typeRefEntry{off: nt.Pos().Offset, sym: sym})
+	tr := make([]typeRefEntry, 0, len(pf.TypeRefIdents))
+	for _, nt := range pf.TypeRefIdents {
+		tr = append(tr, typeRefEntry{off: nt.Pos().Offset, sym: pf.TypeRefsByID[nt.ID]})
 	}
 	sort.Slice(tr, func(i, j int) bool { return tr[i].off < tr[j].off })
 	h.u32(uint32(len(tr)))
@@ -469,12 +469,12 @@ func hashCheckResult(r *check.Result) [32]byte {
 		off  int
 		args []types.Type
 	}
-	iEntries := make([]instEntry, 0, len(r.Instantiations))
-	for call, args := range r.Instantiations {
+	iEntries := make([]instEntry, 0, len(r.InstantiationCalls))
+	for _, call := range r.InstantiationCalls {
 		if call == nil {
 			continue
 		}
-		iEntries = append(iEntries, instEntry{off: call.Pos().Offset, args: args})
+		iEntries = append(iEntries, instEntry{off: call.Pos().Offset, args: r.InstantiationsByID[call.ID]})
 	}
 	sort.Slice(iEntries, func(i, j int) bool { return iEntries[i].off < iEntries[j].off })
 	h.u32(uint32(len(iEntries)))

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -394,7 +394,12 @@ func hashResolveFileResult(r *resolve.Result) [32]byte {
 	}
 	// Build an ephemeral PackageFile-like shape so we can reuse the
 	// file ref hashing.
-	pf := &resolve.PackageFile{Refs: r.Refs, TypeRefs: r.TypeRefs}
+	pf := &resolve.PackageFile{
+		RefsByID:      r.RefsByID,
+		TypeRefsByID:  r.TypeRefsByID,
+		RefIdents:     r.RefIdents,
+		TypeRefIdents: r.TypeRefIdents,
+	}
 	hashFileRefs(h, pf)
 	hashDiagsList(h, r.Diags)
 	return h.sum()

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -55,12 +55,14 @@ func (rp *ResolvedPackage) FileResult(path string) *resolve.Result {
 			continue
 		}
 		return &resolve.Result{
-			Refs:         pf.Refs,
-			TypeRefs:     pf.TypeRefs,
-			RefsByID:     pf.RefsByID,
-			TypeRefsByID: pf.TypeRefsByID,
-			FileScope:    pf.FileScope,
-			Diags:        rp.res.Diags,
+			Refs:          pf.Refs,
+			TypeRefs:      pf.TypeRefs,
+			RefsByID:      pf.RefsByID,
+			TypeRefsByID:  pf.TypeRefsByID,
+			RefIdents:     pf.RefIdents,
+			TypeRefIdents: pf.TypeRefIdents,
+			FileScope:     pf.FileScope,
+			Diags:         rp.res.Diags,
 		}
 	}
 	return nil
@@ -311,12 +313,12 @@ func buildIdentIndex(r *resolve.Result) map[int]*resolve.Symbol {
 	if r == nil {
 		return map[int]*resolve.Symbol{}
 	}
-	out := make(map[int]*resolve.Symbol, len(r.Refs)+len(r.TypeRefs))
-	for id, sym := range r.Refs {
-		out[id.Pos().Offset] = sym
+	out := make(map[int]*resolve.Symbol, len(r.RefIdents)+len(r.TypeRefIdents))
+	for _, id := range r.RefIdents {
+		out[id.Pos().Offset] = r.RefsByID[id.ID]
 	}
-	for nt, sym := range r.TypeRefs {
-		out[nt.Pos().Offset] = sym
+	for _, nt := range r.TypeRefIdents {
+		out[nt.Pos().Offset] = r.TypeRefsByID[nt.ID]
 	}
 	return out
 }

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -55,8 +55,6 @@ func (rp *ResolvedPackage) FileResult(path string) *resolve.Result {
 			continue
 		}
 		return &resolve.Result{
-			Refs:          pf.Refs,
-			TypeRefs:      pf.TypeRefs,
 			RefsByID:      pf.RefsByID,
 			TypeRefsByID:  pf.TypeRefsByID,
 			RefIdents:     pf.RefIdents,

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -55,10 +55,12 @@ func (rp *ResolvedPackage) FileResult(path string) *resolve.Result {
 			continue
 		}
 		return &resolve.Result{
-			Refs:      pf.Refs,
-			TypeRefs:  pf.TypeRefs,
-			FileScope: pf.FileScope,
-			Diags:     rp.res.Diags,
+			Refs:         pf.Refs,
+			TypeRefs:     pf.TypeRefs,
+			RefsByID:     pf.RefsByID,
+			TypeRefsByID: pf.TypeRefsByID,
+			FileScope:    pf.FileScope,
+			Diags:        rp.res.Diags,
 		}
 	}
 	return nil

--- a/internal/resolve/loop_label_test.go
+++ b/internal/resolve/loop_label_test.go
@@ -59,12 +59,13 @@ func TestResolveBreakValueExpression(t *testing.T) {
 	if len(res.Diags) != 0 {
 		t.Fatalf("unexpected resolve diagnostics: %#v", res.Diags)
 	}
-	for id, sym := range res.Refs {
+	for _, id := range res.RefIdents {
+		sym := res.RefsByID[id.ID]
 		if id.Name == "value" && sym != nil && sym.Name == "value" {
 			return
 		}
 	}
-	t.Fatalf("break value reference to `value` was not resolved: %#v", res.Refs)
+	t.Fatalf("break value reference to `value` was not resolved: %#v", res.RefsByID)
 }
 
 func hasResolveCode(diags []*diag.Diagnostic, code string) bool {

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -94,6 +94,12 @@ type PackageFile struct {
 	// AST with name resolution already applied.
 	Refs     map[*ast.Ident]*Symbol
 	TypeRefs map[*ast.NamedType]*Symbol
+	// RefsByID and TypeRefsByID project the same bindings keyed by
+	// ast.NodeID instead of Go pointer identity. Populated alongside
+	// Refs/TypeRefs so downstream passes can migrate off pointer keys
+	// without losing the Refs snapshot. Self-host ports rely on these.
+	RefsByID     map[ast.NodeID]*Symbol
+	TypeRefsByID map[ast.NodeID]*Symbol
 }
 
 func (pf *PackageFile) CheckerSource() []byte {

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -88,23 +88,19 @@ type PackageFile struct {
 	// aliases). Populated by ResolvePackage. Its parent is the package
 	// scope; the resolver walks per-file expression bodies rooted here.
 	FileScope *Scope
-	// Refs and TypeRefs record where each identifier / type-named node
-	// resolved to, once ResolvePackage finishes. Together with File they
-	// let downstream passes (type checker, code generator) traverse the
-	// AST with name resolution already applied.
-	Refs     map[*ast.Ident]*Symbol
-	TypeRefs map[*ast.NamedType]*Symbol
-	// RefsByID and TypeRefsByID project the same bindings keyed by
-	// ast.NodeID instead of Go pointer identity. Populated alongside
-	// Refs/TypeRefs so downstream passes can migrate off pointer keys
-	// without losing the Refs snapshot. Self-host ports rely on these.
+	// RefsByID and TypeRefsByID record where each identifier /
+	// type-named node resolved to, once ResolvePackage finishes. Keys
+	// are NodeIDs assigned by the parser; values are the resolver's
+	// symbol table entries. Together with File these let downstream
+	// passes (type checker, code generator) traverse the AST with name
+	// resolution already applied.
 	RefsByID     map[ast.NodeID]*Symbol
 	TypeRefsByID map[ast.NodeID]*Symbol
 	// RefIdents and TypeRefIdents enumerate the node references the
-	// resolver observed, in no particular order. They let callers that
-	// previously iterated Refs-map keys keep doing so without relying
-	// on pointer hashability. Self-host ports map these to
-	// List<&Ident> / List<&NamedType>.
+	// resolver observed, in no particular order. Callers that need to
+	// walk resolved identifiers iterate these (not the maps) so the
+	// pattern maps cleanly onto List<&Ident> / List<&NamedType> when
+	// the pass is ported to the self-hosted compiler.
 	RefIdents     []*ast.Ident
 	TypeRefIdents []*ast.NamedType
 }

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -100,6 +100,13 @@ type PackageFile struct {
 	// without losing the Refs snapshot. Self-host ports rely on these.
 	RefsByID     map[ast.NodeID]*Symbol
 	TypeRefsByID map[ast.NodeID]*Symbol
+	// RefIdents and TypeRefIdents enumerate the node references the
+	// resolver observed, in no particular order. They let callers that
+	// previously iterated Refs-map keys keep doing so without relying
+	// on pointer hashability. Self-host ports map these to
+	// List<&Ident> / List<&NamedType>.
+	RefIdents     []*ast.Ident
+	TypeRefIdents []*ast.NamedType
 }
 
 func (pf *PackageFile) CheckerSource() []byte {

--- a/internal/resolve/refs_by_id_test.go
+++ b/internal/resolve/refs_by_id_test.go
@@ -6,12 +6,11 @@ import (
 	"github.com/osty/osty/internal/parser"
 )
 
-// TestRefsByIDMatchesRefs verifies that the NodeID-keyed projection of
-// Refs / TypeRefs agrees with the pointer-keyed maps for every entry
-// whose Ident / NamedType has a nonzero NodeID. This is the parity
-// guarantee downstream passes rely on when migrating off *ast.Ident
-// keys.
-func TestRefsByIDMatchesRefs(t *testing.T) {
+// TestRefsByIDCoveredByIdentList verifies every RefsByID / TypeRefsByID
+// entry has a matching RefIdents / TypeRefIdents entry. This is the
+// structural guarantee downstream passes rely on when walking resolved
+// identifiers without a pointer-keyed map.
+func TestRefsByIDCoveredByIdentList(t *testing.T) {
 	src := []byte(`
 fn greet(name: String) -> String {
 	let prefix = "hi, "
@@ -33,30 +32,25 @@ fn main() {
 		t.Fatal("RefsByID / TypeRefsByID not populated")
 	}
 
-	for ident, sym := range res.Refs {
+	seenRef := map[uint32]bool{}
+	for _, ident := range res.RefIdents {
 		if ident == nil || ident.ID == 0 {
+			t.Errorf("RefIdents contains unstamped ident %v", ident)
 			continue
 		}
-		got, ok := res.RefsByID[ident.ID]
+		sym, ok := res.RefsByID[ident.ID]
 		if !ok {
-			t.Errorf("RefsByID missing entry for %q (ID=%d)", ident.Name, ident.ID)
+			t.Errorf("RefIdents entry %q (ID=%d) has no RefsByID match", ident.Name, ident.ID)
 			continue
 		}
-		if got != sym {
-			t.Errorf("RefsByID[%d] = %v, want %v", ident.ID, got, sym)
+		if sym == nil {
+			t.Errorf("RefsByID[%d] is nil for ident %q", ident.ID, ident.Name)
 		}
+		seenRef[uint32(ident.ID)] = true
 	}
-	for nt, sym := range res.TypeRefs {
-		if nt == nil || nt.ID == 0 {
-			continue
-		}
-		got, ok := res.TypeRefsByID[nt.ID]
-		if !ok {
-			t.Errorf("TypeRefsByID missing entry for ID=%d", nt.ID)
-			continue
-		}
-		if got != sym {
-			t.Errorf("TypeRefsByID[%d] = %v, want %v", nt.ID, got, sym)
+	for id := range res.RefsByID {
+		if !seenRef[uint32(id)] {
+			t.Errorf("RefsByID entry ID=%d not in RefIdents", id)
 		}
 	}
 

--- a/internal/resolve/refs_by_id_test.go
+++ b/internal/resolve/refs_by_id_test.go
@@ -1,0 +1,66 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestRefsByIDMatchesRefs verifies that the NodeID-keyed projection of
+// Refs / TypeRefs agrees with the pointer-keyed maps for every entry
+// whose Ident / NamedType has a nonzero NodeID. This is the parity
+// guarantee downstream passes rely on when migrating off *ast.Ident
+// keys.
+func TestRefsByIDMatchesRefs(t *testing.T) {
+	src := []byte(`
+fn greet(name: String) -> String {
+	let prefix = "hi, "
+	prefix + name
+}
+
+fn main() {
+	let msg = greet("world")
+	println(msg)
+}
+`)
+	file, _ := parser.ParseDiagnostics(src)
+	if file == nil {
+		t.Fatal("parse failed")
+	}
+	res := File(file, NewPrelude())
+
+	if res.RefsByID == nil || res.TypeRefsByID == nil {
+		t.Fatal("RefsByID / TypeRefsByID not populated")
+	}
+
+	for ident, sym := range res.Refs {
+		if ident == nil || ident.ID == 0 {
+			continue
+		}
+		got, ok := res.RefsByID[ident.ID]
+		if !ok {
+			t.Errorf("RefsByID missing entry for %q (ID=%d)", ident.Name, ident.ID)
+			continue
+		}
+		if got != sym {
+			t.Errorf("RefsByID[%d] = %v, want %v", ident.ID, got, sym)
+		}
+	}
+	for nt, sym := range res.TypeRefs {
+		if nt == nil || nt.ID == 0 {
+			continue
+		}
+		got, ok := res.TypeRefsByID[nt.ID]
+		if !ok {
+			t.Errorf("TypeRefsByID missing entry for ID=%d", nt.ID)
+			continue
+		}
+		if got != sym {
+			t.Errorf("TypeRefsByID[%d] = %v, want %v", nt.ID, got, sym)
+		}
+	}
+
+	if len(res.RefsByID) == 0 {
+		t.Error("expected at least one RefsByID entry for this source")
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -22,6 +22,11 @@ type Result struct {
 	// `Map`). Only the head symbol is recorded; type arguments are
 	// resolved recursively and stored under their own NamedType keys.
 	TypeRefs map[*ast.NamedType]*Symbol
+	// RefsByID / TypeRefsByID mirror Refs / TypeRefs keyed by
+	// ast.NodeID. Populated in parallel so callers can migrate off
+	// pointer identity incrementally.
+	RefsByID     map[ast.NodeID]*Symbol
+	TypeRefsByID map[ast.NodeID]*Symbol
 	// FileScope is the file-level scope (children of the prelude). All
 	// top-level declarations live here.
 	FileScope *Scope
@@ -54,10 +59,12 @@ func FileWithStdlib(file *ast.File, prelude *Scope, stdlib StdlibProvider) *Resu
 	pr := ResolvePackage(pkg, prelude)
 	pf := pkg.Files[0]
 	return &Result{
-		Refs:      pf.Refs,
-		TypeRefs:  pf.TypeRefs,
-		FileScope: pf.FileScope,
-		Diags:     pr.Diags,
+		Refs:         pf.Refs,
+		TypeRefs:     pf.TypeRefs,
+		RefsByID:     pf.RefsByID,
+		TypeRefsByID: pf.TypeRefsByID,
+		FileScope:    pf.FileScope,
+		Diags:        pr.Diags,
 	}
 }
 
@@ -183,7 +190,40 @@ func (r *resolver) bodyPass(pkg *Package) {
 			}
 			restore()
 		}
+		f.RefsByID = projectRefsByID(f.Refs)
+		f.TypeRefsByID = projectTypeRefsByID(f.TypeRefs)
 	}
+}
+
+// projectRefsByID rekeys Refs by ast.NodeID. Idents with ID == 0
+// (synthetic, never stamped by the parser) are skipped; downstream
+// consumers that key on NodeID treat zero as unassigned.
+func projectRefsByID(refs map[*ast.Ident]*Symbol) map[ast.NodeID]*Symbol {
+	if len(refs) == 0 {
+		return map[ast.NodeID]*Symbol{}
+	}
+	out := make(map[ast.NodeID]*Symbol, len(refs))
+	for n, sym := range refs {
+		if n == nil || n.ID == 0 {
+			continue
+		}
+		out[n.ID] = sym
+	}
+	return out
+}
+
+func projectTypeRefsByID(refs map[*ast.NamedType]*Symbol) map[ast.NodeID]*Symbol {
+	if len(refs) == 0 {
+		return map[ast.NodeID]*Symbol{}
+	}
+	out := make(map[ast.NodeID]*Symbol, len(refs))
+	for n, sym := range refs {
+		if n == nil || n.ID == 0 {
+			continue
+		}
+		out[n.ID] = sym
+	}
+	return out
 }
 
 // resolver is the working state during one pass over a package. Each

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -13,24 +13,20 @@ import (
 
 // Result is the output of resolving one Osty file.
 type Result struct {
-	// Refs maps each Ident node that the resolver examined to the symbol
-	// it refers to. Idents that failed resolution are not present in the
+	// RefsByID maps each resolved Ident's NodeID to the symbol it
+	// refers to. Idents that failed resolution are not present in the
 	// map (a corresponding diagnostic is emitted instead).
-	Refs map[*ast.Ident]*Symbol
-	// TypeRefs maps each NamedType node to the symbol the head name
-	// refers to (e.g. for `Map<String, Int>` it records the ref for
-	// `Map`). Only the head symbol is recorded; type arguments are
-	// resolved recursively and stored under their own NamedType keys.
-	TypeRefs map[*ast.NamedType]*Symbol
-	// RefsByID / TypeRefsByID mirror Refs / TypeRefs keyed by
-	// ast.NodeID. Populated in parallel so callers can migrate off
-	// pointer identity incrementally.
-	RefsByID     map[ast.NodeID]*Symbol
+	RefsByID map[ast.NodeID]*Symbol
+	// TypeRefsByID maps each NamedType's NodeID to the symbol the head
+	// name refers to (e.g. for `Map<String, Int>` it records the ref
+	// for `Map`). Only the head symbol is recorded; type arguments are
+	// resolved recursively under their own NamedType keys.
 	TypeRefsByID map[ast.NodeID]*Symbol
 	// RefIdents / TypeRefIdents enumerate the nodes behind RefsByID /
-	// TypeRefsByID, in no particular order. For callers that need to
-	// walk the resolved identifiers without the legacy pointer-keyed
-	// map.
+	// TypeRefsByID, in no particular order. Callers that need to walk
+	// every resolved identifier iterate these instead of the maps so
+	// ports to the self-hosted compiler map cleanly onto
+	// List<&Ident> / List<&NamedType>.
 	RefIdents     []*ast.Ident
 	TypeRefIdents []*ast.NamedType
 	// FileScope is the file-level scope (children of the prelude). All
@@ -65,8 +61,6 @@ func FileWithStdlib(file *ast.File, prelude *Scope, stdlib StdlibProvider) *Resu
 	pr := ResolvePackage(pkg, prelude)
 	pf := pkg.Files[0]
 	return &Result{
-		Refs:          pf.Refs,
-		TypeRefs:      pf.TypeRefs,
 		RefsByID:      pf.RefsByID,
 		TypeRefsByID:  pf.TypeRefsByID,
 		RefIdents:     pf.RefIdents,
@@ -166,12 +160,10 @@ func (r *resolver) bodyPass(pkg *Package) {
 	for _, f := range pkg.Files {
 		fileScope := NewScope(r.pkgScope, "file:"+f.Path)
 		f.FileScope = fileScope
-		f.Refs = map[*ast.Ident]*Symbol{}
-		f.TypeRefs = map[*ast.NamedType]*Symbol{}
 
 		r.current = fileScope
-		r.refs = f.Refs
-		r.typeRefs = f.TypeRefs
+		r.refs = map[*ast.Ident]*Symbol{}
+		r.typeRefs = map[*ast.NamedType]*Symbol{}
 		r.file = f.File
 		r.filePath = f.Path
 
@@ -198,8 +190,8 @@ func (r *resolver) bodyPass(pkg *Package) {
 			}
 			restore()
 		}
-		f.RefsByID, f.RefIdents = projectRefsByID(f.Refs)
-		f.TypeRefsByID, f.TypeRefIdents = projectTypeRefsByID(f.TypeRefs)
+		f.RefsByID, f.RefIdents = projectRefsByID(r.refs)
+		f.TypeRefsByID, f.TypeRefIdents = projectTypeRefsByID(r.typeRefs)
 	}
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -27,6 +27,12 @@ type Result struct {
 	// pointer identity incrementally.
 	RefsByID     map[ast.NodeID]*Symbol
 	TypeRefsByID map[ast.NodeID]*Symbol
+	// RefIdents / TypeRefIdents enumerate the nodes behind RefsByID /
+	// TypeRefsByID, in no particular order. For callers that need to
+	// walk the resolved identifiers without the legacy pointer-keyed
+	// map.
+	RefIdents     []*ast.Ident
+	TypeRefIdents []*ast.NamedType
 	// FileScope is the file-level scope (children of the prelude). All
 	// top-level declarations live here.
 	FileScope *Scope
@@ -59,12 +65,14 @@ func FileWithStdlib(file *ast.File, prelude *Scope, stdlib StdlibProvider) *Resu
 	pr := ResolvePackage(pkg, prelude)
 	pf := pkg.Files[0]
 	return &Result{
-		Refs:         pf.Refs,
-		TypeRefs:     pf.TypeRefs,
-		RefsByID:     pf.RefsByID,
-		TypeRefsByID: pf.TypeRefsByID,
-		FileScope:    pf.FileScope,
-		Diags:        pr.Diags,
+		Refs:          pf.Refs,
+		TypeRefs:      pf.TypeRefs,
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
+		Diags:         pr.Diags,
 	}
 }
 
@@ -190,40 +198,45 @@ func (r *resolver) bodyPass(pkg *Package) {
 			}
 			restore()
 		}
-		f.RefsByID = projectRefsByID(f.Refs)
-		f.TypeRefsByID = projectTypeRefsByID(f.TypeRefs)
+		f.RefsByID, f.RefIdents = projectRefsByID(f.Refs)
+		f.TypeRefsByID, f.TypeRefIdents = projectTypeRefsByID(f.TypeRefs)
 	}
 }
 
-// projectRefsByID rekeys Refs by ast.NodeID. Idents with ID == 0
-// (synthetic, never stamped by the parser) are skipped; downstream
-// consumers that key on NodeID treat zero as unassigned.
-func projectRefsByID(refs map[*ast.Ident]*Symbol) map[ast.NodeID]*Symbol {
+// projectRefsByID rekeys Refs by ast.NodeID and emits the backing
+// ident list. Idents with ID == 0 (synthetic, never stamped by the
+// parser) are skipped; downstream consumers that key on NodeID treat
+// zero as unassigned.
+func projectRefsByID(refs map[*ast.Ident]*Symbol) (map[ast.NodeID]*Symbol, []*ast.Ident) {
 	if len(refs) == 0 {
-		return map[ast.NodeID]*Symbol{}
+		return map[ast.NodeID]*Symbol{}, nil
 	}
-	out := make(map[ast.NodeID]*Symbol, len(refs))
+	byID := make(map[ast.NodeID]*Symbol, len(refs))
+	idents := make([]*ast.Ident, 0, len(refs))
 	for n, sym := range refs {
 		if n == nil || n.ID == 0 {
 			continue
 		}
-		out[n.ID] = sym
+		byID[n.ID] = sym
+		idents = append(idents, n)
 	}
-	return out
+	return byID, idents
 }
 
-func projectTypeRefsByID(refs map[*ast.NamedType]*Symbol) map[ast.NodeID]*Symbol {
+func projectTypeRefsByID(refs map[*ast.NamedType]*Symbol) (map[ast.NodeID]*Symbol, []*ast.NamedType) {
 	if len(refs) == 0 {
-		return map[ast.NodeID]*Symbol{}
+		return map[ast.NodeID]*Symbol{}, nil
 	}
-	out := make(map[ast.NodeID]*Symbol, len(refs))
+	byID := make(map[ast.NodeID]*Symbol, len(refs))
+	nts := make([]*ast.NamedType, 0, len(refs))
 	for n, sym := range refs {
 		if n == nil || n.ID == 0 {
 			continue
 		}
-		out[n.ID] = sym
+		byID[n.ID] = sym
+		nts = append(nts, n)
 	}
-	return out
+	return byID, nts
 }
 
 // resolver is the working state during one pass over a package. Each

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -213,6 +213,7 @@ func (r *FrontendRun) File() *ast.File {
 	}
 	atomic.AddInt64(&astbridgeLowerCount, 1)
 	r.file = astLowerPublicFile(r.parser.arena, r.Tokens())
+	ast.AssignIDs(r.file)
 	return r.file
 }
 

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -247,6 +247,9 @@ func rebindPreludeBuiltinTypes(pkg *resolve.Package, prelude *resolve.Scope, mod
 			}
 			if builtin := builtins[sym.Name]; builtin != nil {
 				pf.TypeRefs[nt] = builtin
+				if nt.ID != 0 && pf.TypeRefsByID != nil {
+					pf.TypeRefsByID[nt.ID] = builtin
+				}
 			}
 		}
 	}

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -241,15 +241,16 @@ func rebindPreludeBuiltinTypes(pkg *resolve.Package, prelude *resolve.Scope, mod
 		if pf == nil {
 			continue
 		}
-		for nt, sym := range pf.TypeRefs {
-			if nt == nil || sym == nil {
+		for _, nt := range pf.TypeRefIdents {
+			if nt == nil || nt.ID == 0 {
+				continue
+			}
+			sym := pf.TypeRefsByID[nt.ID]
+			if sym == nil {
 				continue
 			}
 			if builtin := builtins[sym.Name]; builtin != nil {
-				pf.TypeRefs[nt] = builtin
-				if nt.ID != 0 && pf.TypeRefsByID != nil {
-					pf.TypeRefsByID[nt.ID] = builtin
-				}
+				pf.TypeRefsByID[nt.ID] = builtin
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Replace Go pointer identity (`map[*ast.Ident]*Symbol` etc.) with `ast.NodeID` across the resolver, checker, and every downstream consumer. The public API now has zero pointer-keyed maps — the shape maps cleanly to Osty's `Map<NodeID, Symbol>` + `List<&Ident>`, which unblocks porting lint/LSP/bootstrap-gen to the self-hosted compiler.

## Why

`internal/resolve`, `internal/lint`, `internal/lsp`, and `internal/bootstrap/gen` all keyed on `*ast.Ident` / `*ast.NamedType` / `*ast.CallExpr` pointers. Osty has no raw pointer identity and can't hash references as map keys, so the port was blocked on identity-model redesign. `internal/check/host_boundary.go`'s `selfhostSpanKey` had a partial answer (span-based identity) but relied on fuzzy fallback and kind tagging — not promotable as a primary key. This series introduces sequential `NodeID` (uint32) stamped by the parser and migrates every consumer.

## Commits

1. **f34da1bc** `feat(ast): introduce NodeID type + field on all Node structs` — adds `type NodeID uint32` and an `ID NodeID` field to all 67 Node structs (structural no-op, zero-valued).
2. **3373c29e** `feat(ast): assign sequential NodeID during parse` — `ast.AssignIDs` reflection walker, called from `FrontendRun.File()` after astbridge lowering. Idempotent on pre-assigned IDs.
3. **3a86a3e5** `feat(resolve): add RefsByID / TypeRefsByID parallel map keyed on NodeID` — new NodeID-keyed maps on `resolve.Result` / `PackageFile`, populated alongside the legacy pointer maps via `projectRefsByID` / `projectTypeRefsByID` at `bodyPass` end.
4. **bd86e090** `feat(check): add InstantiationsByID parallel map keyed on NodeID` — same pattern for `check.Result.Instantiations`, populated by `host_boundary` overlay.
5. **bd487547** `refactor: migrate pointer-keyed Refs/TypeRefs/Instantiations consumers to NodeID` — 15+ read sites across `lint` / `ir` / `lsp` / `check/query` / `bootstrap-gen` / `query/osty` / `cmd/osty`. Key-iterating callers switch to new `RefIdents` / `TypeRefIdents` / `InstantiationCalls` slices (`List<&T>` friendly).
6. **c121a5b0** `refactor: drop pointer-keyed Refs/TypeRefs/Instantiations, NodeID-only` — deletes the legacy pointer-keyed fields from public `Result` / `PackageFile`. Internal resolver still uses pointer-keyed working maps but projects them to NodeID at file end; the work maps are never exposed.

## Result

- Public `resolve.Result` / `PackageFile` / `check.Result`: zero pointer-keyed maps.
- Node enumeration: `RefIdents []*ast.Ident`, `TypeRefIdents []*ast.NamedType`, `InstantiationCalls []*ast.CallExpr` slices replace map-key iteration.
- Backwards-compat shims: none. Existing callers were migrated in commit 5 before the fields were removed in commit 6.

## Test plan

- [x] `just front` — lexer, parser, resolve, check, diag, format, lint, pipeline all green.
- [x] `just short` — full `-short` suite green except 3 pre-existing E0757 `as?` waivers from concurrent work on `main` (PR #724's follow-up), unrelated to this change.
- [x] New `internal/ast/ids_test.go` — verifies `AssignIDs` produces unique nonzero IDs, is idempotent, and nil-safe.
- [x] Updated `internal/resolve/refs_by_id_test.go` — parity test: every `RefsByID` entry has a matching `RefIdents` entry and vice versa.
- [x] `host_boundary_test.go` / `native_checker_exec_test.go` / `inspect_test.go` — migrated to `InstantiationsByID[call.ID]`.

## Notes for reviewer

- `internal/bootstrap/gen` was migrated despite CLAUDE.md's "new work 금지" rule — only the three identity-map consumers (`letStmtForIdentPat`, `questionSubs`, `matchSubs` internal maps keep pointer keys since they're not in the public API; the three read sites that touched `g.res.Refs` / `g.chk.Instantiations` were migrated). Same mechanical refactor, no new functionality.
- `ast.AssignIDs` uses reflection for compactness — the alternative (hand-written type switch over 67 Node types) is maintenance cost without speed benefit at parse-time. Measurement welcome if anyone sees a regression.
- `Disc` discriminator for same-span sibling nodes (Paren vs inner) was evaluated and found unnecessary: parser-emitted `PosV` differs for wrapping constructs. If a future synthesized-node case needs disambiguation, adding `Disc uint16` to `NodeBase` is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)