### PR TITLE
feat(selfhost): wire HIR/MIR bundles + transpile smoke tests

### DIFF
--- a/internal/selfhost/bundle/hir_bundle.go
+++ b/internal/selfhost/bundle/hir_bundle.go
@@ -1,0 +1,93 @@
+package bundle
+
+// Bundles for the Osty-authored HIR / MIR tiers of the toolchain. These
+// mirror `MergeToolchainLLVMGen` (see llvmgen_bundle.go) but cover the
+// AST → HIR lowerer and the HIR → MIR lowerer that live in
+// `toolchain/hir*.osty` and `toolchain/mir*.osty`.
+//
+// Both tiers share the checker bundle's `MergeFiles` plumbing (full
+// stdlib-strings prelude + std-call normalization + while→for loop
+// sugar), so they currently transpile under the same bootstrap rules
+// as the checker. The smoke tests under `internal/selfhost/hir_gen_test.go`
+// and `mir_gen_test.go` exercise these bundles end-to-end through
+// `seedgen.Generate` → `go test`.
+
+// hirExtensionFiles are the Osty-authored files layered on top of the
+// checker bundle to make the HIR tier transpile cleanly. `hir.osty`
+// defines the HIR node algebra; `hir_clone.osty` supplies deep-clone
+// helpers; `monomorph_pass.osty` provides the `hirCloneType` /
+// `hirCloneTypeList` primitives the clone layer calls; `hir_lower.osty`
+// is the AST → HIR lowerer plus annotation extractors.
+//
+// `ty.osty` (the arena-based type surface HIR lowering consumes) is
+// already in the checker bundle, so we don't re-declare it here — the
+// HIR bundle starts from `ToolchainCheckerFiles()` and appends.
+var hirExtensionFiles = []string{
+	"toolchain/hir.osty",
+	"toolchain/hir_clone.osty",
+	"toolchain/monomorph.osty",
+	"toolchain/monomorph_rewrite.osty",
+	"toolchain/monomorph_pass.osty",
+	"toolchain/hir_lower.osty",
+}
+
+// mirExtensionFiles layers the MIR tier on top of the HIR bundle. MIR
+// lowering consumes HIR as input, so `hir*` must precede these files
+// in the merge order.
+var mirExtensionFiles = []string{
+	"toolchain/mir.osty",
+	"toolchain/mir_lower.osty",
+	"toolchain/mir_optimize.osty",
+	"toolchain/mir_validator.osty",
+}
+
+func toolchainHirFiles() []string {
+	// Drop `ast_lower.osty` from the checker bundle — HIR lowering
+	// does not consume the Osty-side AST bridge (it works off the
+	// elab `TyArena`), and removing it means the merged source
+	// transpiles to Go that does not import `astbridge`, letting the
+	// smoke test compile with a fresh `go.mod`.
+	base := ToolchainCheckerFiles()
+	filtered := make([]string, 0, len(base)+len(hirExtensionFiles))
+	for _, f := range base {
+		if f == "internal/selfhost/ast_lower.osty" {
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+	return append(filtered, hirExtensionFiles...)
+}
+
+func toolchainMirFiles() []string {
+	base := toolchainHirFiles()
+	return append(base, mirExtensionFiles...)
+}
+
+// ToolchainHirFiles returns the HIR bundle members in dependency order:
+// the checker bundle followed by the HIR-extension files.
+func ToolchainHirFiles() []string {
+	return toolchainHirFiles()
+}
+
+// ToolchainMirFiles returns the MIR bundle members in dependency order:
+// the HIR bundle followed by the MIR-extension files.
+func ToolchainMirFiles() []string {
+	return toolchainMirFiles()
+}
+
+// MergeToolchainHir concatenates the HIR bundle through the shared
+// `MergeFiles` path so it inherits the checker bundle's stdlib-strings
+// prelude + call normalizer + while→for sugar lowering. Returns the
+// merged source as a `[]byte` ready to be handed to `seedgen.Generate`.
+func MergeToolchainHir(root string) ([]byte, error) {
+	return MergeFiles(root, toolchainHirFiles())
+}
+
+// MergeToolchainMir concatenates the MIR bundle (HIR surface + MIR
+// lowerer + passes) through `MergeFiles`. The resulting merged source
+// can transpile with the bootstrap seedgen as long as every pattern
+// exercised is already supported upstream — the companion smoke test
+// pins that guarantee.
+func MergeToolchainMir(root string) ([]byte, error) {
+	return MergeFiles(root, toolchainMirFiles())
+}

--- a/internal/selfhost/bundle/hir_bundle_test.go
+++ b/internal/selfhost/bundle/hir_bundle_test.go
@@ -1,0 +1,123 @@
+package bundle
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestToolchainHirBundleIncludesHirLower(t *testing.T) {
+	files := ToolchainHirFiles()
+	if len(files) == 0 {
+		t.Fatal("ToolchainHirFiles() returned empty list")
+	}
+	expected := []string{
+		"toolchain/ty.osty",
+		"toolchain/hir.osty",
+		"toolchain/hir_clone.osty",
+		"toolchain/monomorph_pass.osty",
+		"toolchain/hir_lower.osty",
+	}
+	seen := make(map[string]bool)
+	for _, f := range files {
+		seen[f] = true
+	}
+	for _, want := range expected {
+		if !seen[want] {
+			t.Errorf("ToolchainHirFiles() missing %q", want)
+		}
+	}
+}
+
+func TestToolchainMirBundleIncludesMirLower(t *testing.T) {
+	files := ToolchainMirFiles()
+	expected := []string{
+		"toolchain/hir.osty",
+		"toolchain/hir_lower.osty",
+		"toolchain/mir.osty",
+		"toolchain/mir_lower.osty",
+		"toolchain/mir_optimize.osty",
+		"toolchain/mir_validator.osty",
+	}
+	seen := make(map[string]bool)
+	for _, f := range files {
+		seen[f] = true
+	}
+	for _, want := range expected {
+		if !seen[want] {
+			t.Errorf("ToolchainMirFiles() missing %q", want)
+		}
+	}
+}
+
+func TestMergeToolchainHirContainsSignatures(t *testing.T) {
+	root := repoRoot(t)
+	merged, err := MergeToolchainHir(root)
+	if err != nil {
+		t.Fatalf("MergeToolchainHir() error = %v", err)
+	}
+	if len(merged) == 0 {
+		t.Fatal("MergeToolchainHir() returned empty output")
+	}
+	// Spot-check that the HIR lowerer's public surface landed in the
+	// merged source — if the bundle file list accidentally loses
+	// hir_lower.osty, these checks trip.
+	mustContain(t, merged, "pub fn hirLowerer(")
+	mustContain(t, merged, "pub fn hirLowerModule(")
+	mustContain(t, merged, "pub fn hirLowerExtractInlineMode(")
+	mustContain(t, merged, "pub fn hirLowerExtractVectorizeArgs(")
+	// HIR data model should also be in scope.
+	mustContain(t, merged, "pub struct HirModule")
+	// The merged output must have been scrubbed of `use std.strings`
+	// imports by the shared merger.
+	if bytes.Contains(merged, []byte("\nuse std.strings")) {
+		t.Fatal("merged HIR bundle still contains `use std.strings` imports")
+	}
+}
+
+func TestMergeToolchainMirContainsSignatures(t *testing.T) {
+	root := repoRoot(t)
+	merged, err := MergeToolchainMir(root)
+	if err != nil {
+		t.Fatalf("MergeToolchainMir() error = %v", err)
+	}
+	if len(merged) == 0 {
+		t.Fatal("MergeToolchainMir() returned empty output")
+	}
+	mustContain(t, merged, "pub fn mirLowerModule(")
+	mustContain(t, merged, "pub fn mirLowerStmt(")
+	mustContain(t, merged, "pub fn mirLowerExprToRValue(")
+	mustContain(t, merged, "pub struct MirModule")
+	if bytes.Contains(merged, []byte("\nuse std.strings")) {
+		t.Fatal("merged MIR bundle still contains `use std.strings` imports")
+	}
+}
+
+func mustContain(t *testing.T, haystack []byte, needle string) {
+	t.Helper()
+	if !bytes.Contains(haystack, []byte(needle)) {
+		t.Errorf("merged bundle missing expected text %q", needle)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// Locate the repo root by walking up until we find go.mod — tests
+	// run with the package dir as cwd, so the relative path varies.
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod above %s", strings.TrimSpace(dir))
+		}
+		dir = parent
+	}
+}

--- a/internal/selfhost/hir_gen_test.go
+++ b/internal/selfhost/hir_gen_test.go
@@ -1,0 +1,138 @@
+package selfhost_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/bootstrap/seedgen"
+	"github.com/osty/osty/internal/selfhost/bundle"
+)
+
+// TestToolchainHirSourcesTranspile verifies the HIR bundle (ty +
+// hir + hir_clone + hir_lower) goes through the bootstrap seedgen
+// transpiler and the resulting Go compiles. Mirrors the llvmgen
+// smoke test so regressions in any HIR file surface here.
+func TestToolchainHirSourcesTranspile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping self-host hir transpile smoke test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+	merged, err := bundle.MergeToolchainHir(repoRoot)
+	if err != nil {
+		t.Fatalf("merge toolchain hir sources: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	mergedPath := filepath.Join(tmpDir, "toolchain_hir_merged.osty")
+	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
+		t.Fatalf("write merged source: %v", err)
+	}
+	generatedPath := filepath.Join(tmpDir, "toolchain_hir_generated.go")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+
+	generated, err := seedgen.Generate(seedgen.Config{
+		SourcePath:  mergedPath,
+		PackageName: "hirselfhostsmoke",
+		RepoRoot:    repoRoot,
+	})
+	if err != nil {
+		t.Fatalf("transpile merged toolchain hir: %v", err)
+	}
+	if err := os.WriteFile(generatedPath, generated, 0o644); err != nil {
+		t.Fatalf("write generated file: %v", err)
+	}
+	if len(generated) == 0 {
+		t.Fatal("generated file is empty")
+	}
+	// Spot-check the HIR lowerer entry points and annotation extractors
+	// made it through transpile.
+	for _, needle := range []string{
+		"func hirLowerer(",
+		"func hirLowerModule(",
+		"func hirLowerTyToHirType(",
+		"func hirLowerExtractInlineMode(",
+		"func hirLowerExtractVectorizeArgs(",
+		"func hirLowerParseAnnotationInt(",
+	} {
+		if !bytes.Contains(generated, []byte(needle)) {
+			t.Errorf("generated hir bridge missing %q", needle)
+		}
+	}
+
+	if err := os.WriteFile(goModPath, []byte("module hirselfhostsmoke\n\ngo 1.20\n"), 0o644); err != nil {
+		t.Fatalf("write temp go.mod: %v", err)
+	}
+	buildCmd := exec.Command("go", "test", ".")
+	buildCmd.Dir = tmpDir
+	buildOut, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile generated hir smoke bridge: %v\n%s", err, bytes.TrimSpace(buildOut))
+	}
+}
+
+// TestToolchainMirSourcesTranspile verifies the MIR bundle (HIR
+// surface + mir + mir_lower + mir_optimize + mir_validator) goes
+// through the bootstrap seedgen transpiler and compiles as Go.
+func TestToolchainMirSourcesTranspile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping self-host mir transpile smoke test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+	merged, err := bundle.MergeToolchainMir(repoRoot)
+	if err != nil {
+		t.Fatalf("merge toolchain mir sources: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	mergedPath := filepath.Join(tmpDir, "toolchain_mir_merged.osty")
+	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
+		t.Fatalf("write merged source: %v", err)
+	}
+	generatedPath := filepath.Join(tmpDir, "toolchain_mir_generated.go")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+
+	generated, err := seedgen.Generate(seedgen.Config{
+		SourcePath:  mergedPath,
+		PackageName: "mirselfhostsmoke",
+		RepoRoot:    repoRoot,
+	})
+	if err != nil {
+		t.Fatalf("transpile merged toolchain mir: %v", err)
+	}
+	if err := os.WriteFile(generatedPath, generated, 0o644); err != nil {
+		t.Fatalf("write generated file: %v", err)
+	}
+	if dump := os.Getenv("DUMP_MIR_GENERATED"); dump != "" {
+		if err := os.WriteFile(dump, generated, 0o644); err != nil {
+			t.Logf("dump write failed: %v", err)
+		}
+	}
+	if len(generated) == 0 {
+		t.Fatal("generated file is empty")
+	}
+	for _, needle := range []string{
+		"func mirLowerModule(",
+		"func mirLowerStmt(",
+		"func mirLowerExprToRValue(",
+		"func mirLowerMatchStmt(",
+	} {
+		if !bytes.Contains(generated, []byte(needle)) {
+			t.Errorf("generated mir bridge missing %q", needle)
+		}
+	}
+
+	if err := os.WriteFile(goModPath, []byte("module mirselfhostsmoke\n\ngo 1.20\n"), 0o644); err != nil {
+		t.Fatalf("write temp go.mod: %v", err)
+	}
+	buildCmd := exec.Command("go", "test", ".")
+	buildCmd.Dir = tmpDir
+	buildOut, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile generated mir smoke bridge: %v\n%s", err, bytes.TrimSpace(buildOut))
+	}
+}

--- a/toolchain/hir_lower_annotations_test.osty
+++ b/toolchain/hir_lower_annotations_test.osty
@@ -1,0 +1,421 @@
+// hir_lower_annotations_test.osty — Phase 1a: unit coverage for the
+// annotation extractors already defined in hir_lower.osty (Stage 5a
+// landed them alongside the TyArena bridge). Before Stage 5b consumes
+// these helpers from decl / struct / enum lowering, we want them
+// exercised end-to-end on synthetic `List<HirAnnotation>` inputs so
+// regressions surface as focused test failures rather than obscure
+// HIR layout drifts.
+//
+// Exercises:
+//   - hirLowerHasNamedAnnotation
+//   - hirLowerExtractInlineMode
+//   - hirLowerExtractNoaliasArgs      (-> HirLowerNoaliasInfo)
+//   - hirLowerExtractTargetFeatures
+//   - hirLowerExtractVectorizeArgs    (-> HirLowerVectorizeInfo)
+//   - hirLowerExtractUnrollArgs       (-> HirLowerUnrollInfo)
+//   - hirLowerExtractExportSymbol
+//   - hirLowerJsonFieldOptions        (-> HirLowerJsonFieldInfo)
+//   - hirLowerJsonVariantOptions      (-> HirLowerJsonVariantInfo)
+//   - hirLowerParseAnnotationInt      (-> HirLowerIntParse)
+//   - hirLowerAnnotationStringLit     (-> HirLowerStringParse)
+
+use std.testing
+
+// ==== Test fixtures ===================================================
+
+fn sp() -> HirSpan { hirNoSpan() }
+
+/// mkFlag builds a bare-flag annotation `#[name]` (e.g. `#[pure]`,
+/// `#[cold]`, `#[parallel]`).
+fn mkFlag(name: String) -> HirAnnotation {
+    hirAnnotation(name, sp())
+}
+
+/// mkIntArg constructs a key=IntLit annotation arg (e.g. `width = 4`,
+/// `count = 8`).
+fn mkIntArg(key: String, text: String) -> HirAnnotationArg {
+    let lit = hirIntLit(text, hirTInt(), sp())
+    hirAnnotationArgKeyValue(key, lit, sp())
+}
+
+/// mkStringArgPositional constructs a positional StringLit arg used
+/// by `#[export("name")]`.
+fn mkStringArgPositional(text: String) -> HirAnnotationArg {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit(text))
+    let lit = hirStringLit(parts, sp())
+    hirAnnotationArgPositional(lit, sp())
+}
+
+/// mkStringArgKeyValue constructs a key="str" arg used by
+/// `#[json(key = "user_id")]`.
+fn mkStringArgKeyValue(key: String, text: String) -> HirAnnotationArg {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit(text))
+    let lit = hirStringLit(parts, sp())
+    hirAnnotationArgKeyValue(key, lit, sp())
+}
+
+/// mkBareKey constructs a bare-identifier arg (e.g. `scalable`,
+/// `predicate`, `always`, `never`, `skip`, `optional`, or a param
+/// name for `#[noalias(p1, p2)]`).
+fn mkBareKey(key: String) -> HirAnnotationArg {
+    hirAnnotationArgFlag(key, sp())
+}
+
+// ==== hirLowerHasNamedAnnotation =====================================
+
+fn testHasNamedAnnotationAbsent() {
+    let annots: List<HirAnnotation> = []
+    testing.assert(!hirLowerHasNamedAnnotation(annots, "pure"))
+}
+
+fn testHasNamedAnnotationPresent() {
+    let mut annots: List<HirAnnotation> = []
+    annots.push(mkFlag("pure"))
+    annots.push(mkFlag("cold"))
+    testing.assert(hirLowerHasNamedAnnotation(annots, "pure"))
+    testing.assert(hirLowerHasNamedAnnotation(annots, "cold"))
+    testing.assert(!hirLowerHasNamedAnnotation(annots, "hot"))
+}
+
+// ==== hirLowerExtractVectorizeArgs ===================================
+
+fn testExtractVectorizeAbsent() {
+    let annots: List<HirAnnotation> = []
+    let v = hirLowerExtractVectorizeArgs(annots)
+    testing.assert(!v.enable)
+    testing.assertEq(v.width, 0)
+    testing.assert(!v.scalable)
+    testing.assert(!v.predicate)
+}
+
+fn testExtractVectorizeBareEnables() {
+    let mut annots: List<HirAnnotation> = []
+    annots.push(mkFlag("vectorize"))
+    let v = hirLowerExtractVectorizeArgs(annots)
+    testing.assert(v.enable)
+    testing.assertEq(v.width, 0)
+    testing.assert(!v.scalable)
+    testing.assert(!v.predicate)
+}
+
+fn testExtractVectorizeFullArgs() {
+    let mut ann = hirAnnotation("vectorize", sp())
+    ann.args.push(mkBareKey("scalable"))
+    ann.args.push(mkBareKey("predicate"))
+    ann.args.push(mkIntArg("width", "8"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let v = hirLowerExtractVectorizeArgs(annots)
+    testing.assert(v.enable)
+    testing.assert(v.scalable)
+    testing.assert(v.predicate)
+    testing.assertEq(v.width, 8)
+}
+
+fn testExtractVectorizeWidthUnderscoreAndHex() {
+    let mut ann = hirAnnotation("vectorize", sp())
+    ann.args.push(mkIntArg("width", "0x10_0"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let v = hirLowerExtractVectorizeArgs(annots)
+    testing.assertEq(v.width, 256)
+}
+
+fn testExtractVectorizeIgnoresUnknownKeys() {
+    let mut ann = hirAnnotation("vectorize", sp())
+    ann.args.push(mkBareKey("bogus"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let v = hirLowerExtractVectorizeArgs(annots)
+    testing.assert(v.enable)
+    testing.assertEq(v.width, 0)
+}
+
+// ==== hirLowerExtractUnrollArgs ======================================
+
+fn testExtractUnrollBare() {
+    let mut annots: List<HirAnnotation> = []
+    annots.push(mkFlag("unroll"))
+    let u = hirLowerExtractUnrollArgs(annots)
+    testing.assert(u.enable)
+    testing.assertEq(u.count, 0)
+}
+
+fn testExtractUnrollCount() {
+    let mut ann = hirAnnotation("unroll", sp())
+    ann.args.push(mkIntArg("count", "4"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let u = hirLowerExtractUnrollArgs(annots)
+    testing.assert(u.enable)
+    testing.assertEq(u.count, 4)
+}
+
+fn testExtractUnrollAbsent() {
+    let annots: List<HirAnnotation> = []
+    let u = hirLowerExtractUnrollArgs(annots)
+    testing.assert(!u.enable)
+    testing.assertEq(u.count, 0)
+}
+
+// ==== hirLowerExtractInlineMode ======================================
+
+fn testExtractInlineNone() {
+    let annots: List<HirAnnotation> = []
+    testing.assert(hirLowerExtractInlineMode(annots) == HirInlineNone)
+}
+
+fn testExtractInlineSoft() {
+    let mut annots: List<HirAnnotation> = []
+    annots.push(mkFlag("inline"))
+    testing.assert(hirLowerExtractInlineMode(annots) == HirInlineSoft)
+}
+
+fn testExtractInlineAlways() {
+    let mut ann = hirAnnotation("inline", sp())
+    ann.args.push(mkBareKey("always"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    testing.assert(hirLowerExtractInlineMode(annots) == HirInlineAlways)
+}
+
+fn testExtractInlineNever() {
+    let mut ann = hirAnnotation("inline", sp())
+    ann.args.push(mkBareKey("never"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    testing.assert(hirLowerExtractInlineMode(annots) == HirInlineNever)
+}
+
+// ==== hirLowerExtractNoaliasArgs =====================================
+
+fn testExtractNoaliasAbsent() {
+    let annots: List<HirAnnotation> = []
+    let n = hirLowerExtractNoaliasArgs(annots)
+    testing.assert(!n.all)
+    testing.assertEq(n.names.len(), 0)
+}
+
+fn testExtractNoaliasBare() {
+    let mut annots: List<HirAnnotation> = []
+    annots.push(mkFlag("noalias"))
+    let n = hirLowerExtractNoaliasArgs(annots)
+    testing.assert(n.all)
+    testing.assertEq(n.names.len(), 0)
+}
+
+fn testExtractNoaliasParams() {
+    let mut ann = hirAnnotation("noalias", sp())
+    ann.args.push(mkBareKey("p1"))
+    ann.args.push(mkBareKey("p2"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let n = hirLowerExtractNoaliasArgs(annots)
+    testing.assert(!n.all)
+    testing.assertEq(n.names.len(), 2)
+    testing.assertEq(n.names[0], "p1")
+    testing.assertEq(n.names[1], "p2")
+}
+
+// ==== hirLowerExtractTargetFeatures ==================================
+
+fn testExtractTargetFeaturesEmpty() {
+    let annots: List<HirAnnotation> = []
+    let f = hirLowerExtractTargetFeatures(annots)
+    testing.assertEq(f.len(), 0)
+}
+
+fn testExtractTargetFeaturesOrderPreserved() {
+    let mut ann = hirAnnotation("target_feature", sp())
+    ann.args.push(mkBareKey("avx512f"))
+    ann.args.push(mkBareKey("avx512bw"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let f = hirLowerExtractTargetFeatures(annots)
+    testing.assertEq(f.len(), 2)
+    testing.assertEq(f[0], "avx512f")
+    testing.assertEq(f[1], "avx512bw")
+}
+
+// ==== hirLowerExtractExportSymbol ====================================
+
+fn testExtractExportSymbolAbsent() {
+    let annots: List<HirAnnotation> = []
+    testing.assertEq(hirLowerExtractExportSymbol(annots), "")
+}
+
+fn testExtractExportSymbolLiteral() {
+    let mut ann = hirAnnotation("export", sp())
+    ann.args.push(mkStringArgPositional("osty_sum"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    testing.assertEq(hirLowerExtractExportSymbol(annots), "osty_sum")
+}
+
+fn testExtractExportSymbolRejectsKeyArg() {
+    // Keyed `#[export(name = "x")]` is malformed (resolver rejects),
+    // but guard the extractor anyway — `key != ""` must disqualify.
+    let mut ann = hirAnnotation("export", sp())
+    ann.args.push(mkStringArgKeyValue("name", "x"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    testing.assertEq(hirLowerExtractExportSymbol(annots), "")
+}
+
+// ==== hirLowerJsonFieldOptions =======================================
+
+fn testJsonFieldOptionsAbsent() {
+    let annots: List<HirAnnotation> = []
+    let opts = hirLowerJsonFieldOptions(annots)
+    testing.assertEq(opts.key, "")
+    testing.assert(!opts.skip)
+    testing.assert(!opts.optional)
+}
+
+fn testJsonFieldOptionsKeyAndSkip() {
+    let mut ann = hirAnnotation("json", sp())
+    ann.args.push(mkStringArgKeyValue("key", "user_id"))
+    ann.args.push(mkBareKey("skip"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let opts = hirLowerJsonFieldOptions(annots)
+    testing.assertEq(opts.key, "user_id")
+    testing.assert(opts.skip)
+    testing.assert(!opts.optional)
+}
+
+fn testJsonFieldOptionsOptional() {
+    let mut ann = hirAnnotation("json", sp())
+    ann.args.push(mkBareKey("optional"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let opts = hirLowerJsonFieldOptions(annots)
+    testing.assert(opts.optional)
+}
+
+// ==== hirLowerJsonVariantOptions =====================================
+
+fn testJsonVariantOptionsAbsent() {
+    let annots: List<HirAnnotation> = []
+    let opts = hirLowerJsonVariantOptions(annots)
+    testing.assertEq(opts.tag, "")
+    testing.assert(!opts.skip)
+}
+
+fn testJsonVariantOptionsKeyAndSkip() {
+    let mut ann = hirAnnotation("json", sp())
+    ann.args.push(mkStringArgKeyValue("key", "click"))
+    ann.args.push(mkBareKey("skip"))
+    let mut annots: List<HirAnnotation> = []
+    annots.push(ann)
+    let opts = hirLowerJsonVariantOptions(annots)
+    testing.assertEq(opts.tag, "click")
+    testing.assert(opts.skip)
+}
+
+// ==== hirLowerParseAnnotationInt =====================================
+
+fn parseIntFromText(text: String) -> HirLowerIntParse {
+    let lit = hirIntLit(text, hirTInt(), sp())
+    hirLowerParseAnnotationInt(lit)
+}
+
+fn testParseIntDecimal() {
+    let r = parseIntFromText("42")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 42)
+}
+
+fn testParseIntUnderscore() {
+    let r = parseIntFromText("1_000_000")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 1000000)
+}
+
+fn testParseIntHex() {
+    let r = parseIntFromText("0xFF")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 255)
+    let r2 = parseIntFromText("0Xff_ff")
+    testing.assert(r2.ok)
+    testing.assertEq(r2.value, 65535)
+}
+
+fn testParseIntOctal() {
+    let r = parseIntFromText("0o777")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 511)
+}
+
+fn testParseIntBinary() {
+    let r = parseIntFromText("0b1010_0101")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 165)
+}
+
+fn testParseIntZero() {
+    let r = parseIntFromText("0")
+    testing.assert(r.ok)
+    testing.assertEq(r.value, 0)
+}
+
+fn testParseIntEmptyAfterPrefixRejected() {
+    // "0x" alone (no digits) is invalid.
+    let r = parseIntFromText("0x")
+    testing.assert(!r.ok)
+}
+
+fn testParseIntDigitOutOfBaseRejected() {
+    let r = parseIntFromText("0b102")
+    testing.assert(!r.ok)
+    let r2 = parseIntFromText("0o89")
+    testing.assert(!r2.ok)
+    let r3 = parseIntFromText("0xGG")
+    testing.assert(!r3.ok)
+}
+
+fn testParseIntRejectsNonIntExpr() {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit("42"))
+    let e = hirStringLit(parts, sp())
+    let r = hirLowerParseAnnotationInt(e)
+    testing.assert(!r.ok)
+}
+
+// ==== hirLowerAnnotationStringLit ====================================
+
+fn testAnnotationStringLitPlain() {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit("hello"))
+    let e = hirStringLit(parts, sp())
+    let r = hirLowerAnnotationStringLit(e)
+    testing.assert(r.ok)
+    testing.assertEq(r.value, "hello")
+}
+
+fn testAnnotationStringLitMultiPart() {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit("osty_"))
+    parts.push(hirStringPartLit("sum"))
+    let e = hirStringLit(parts, sp())
+    let r = hirLowerAnnotationStringLit(e)
+    testing.assert(r.ok)
+    testing.assertEq(r.value, "osty_sum")
+}
+
+fn testAnnotationStringLitRejectsInterpolated() {
+    let mut parts: List<HirStringPart> = []
+    parts.push(hirStringPartLit("prefix_"))
+    parts.push(hirStringPartExpr(hirIntLit("1", hirTInt(), sp())))
+    let e = hirStringLit(parts, sp())
+    let r = hirLowerAnnotationStringLit(e)
+    testing.assert(!r.ok)
+}
+
+fn testAnnotationStringLitRejectsNonString() {
+    let e = hirIntLit("42", hirTInt(), sp())
+    let r = hirLowerAnnotationStringLit(e)
+    testing.assert(!r.ok)
+}

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -5084,9 +5084,15 @@ fn mirLowerSwitchVariant(mc: MirLowerMatchContext, node: HirDecisionNode) {
     let discRV = mirRVDiscriminant(projPlace, "Int")
     mirLowerEmitInstr(mc.bs, mirAssignInstr(mirPlace(disc), discRV, mc.span))
 
-    // Allocate one block per case + a default block.
+    // Allocate one block per case + a default block. Iterate by
+    // index (binding `i` in the loop header itself satisfies the
+    // bootstrap transpiler's "declared and used" check for the
+    // generated Go counterpart) instead of `for _c in …`, which
+    // lowers to a named-but-unused `_c` in Go.
     let mut caseBlocks: List<Int> = []
-    for _c in node.switchCases {
+    let caseCount = node.switchCases.len()
+    for i in 0..caseCount {
+        let _ = i
         caseBlocks.push(mirLowerNewBlock(mc.bs, mc.span))
     }
     let defaultBB = mirLowerNewBlock(mc.bs, mc.span)


### PR DESCRIPTION
## Summary
- Add `MergeToolchainHir` / `MergeToolchainMir` to `internal/selfhost/bundle` so the Osty-authored HIR and MIR tiers travel through the bootstrap `seedgen.Generate` transpiler and the resulting Go compiles cleanly — mirrors the existing `MergeToolchainLLVMGen` wiring.
- Add `TestToolchainHirSourcesTranspile` / `TestToolchainMirSourcesTranspile` smoke tests that pin the full transpile → `go test` compile loop for both bundles.
- Add `toolchain/hir_lower_annotations_test.osty` — unit coverage for the 11 annotation extractors already shipping in `hir_lower.osty` (previously untested).
- Fix `toolchain/mir_lower.osty:5090` — `for _c in node.switchCases` became a named-unused `_c` binding once the bootstrap transpiler lowered it to Go; switched to an index-based loop over `0..caseCount` so the loop counter stays referenced in the header.

## Why
`toolchain/hir.osty` (3.5K LOC), `toolchain/hir_lower.osty` (2.2K LOC), `toolchain/mir.osty` (1.9K LOC), `toolchain/mir_lower.osty` (5.5K LOC), plus the monomorph passes already ship the self-hosted HIR/MIR port (data model + assemble helpers + 144 + 105 public symbols across the two tiers) but none of them were reachable through the bundle layer — only `llvmgen.osty` was wired. That meant:

- No CI gate catches regressions where a HIR/MIR file stops transpiling through the bootstrap seedgen.
- The annotation extractors in `hir_lower.osty` had zero unit coverage.

This PR closes that gap. The bundles reuse the shared `MergeFiles` path so they inherit the same `std.strings` prelude, call normalizer, and `while→for` sugar lowering as the checker bundle.

## HIR bundle construction notes

The HIR bundle derives from `ToolchainCheckerFiles()` minus `internal/selfhost/ast_lower.osty`, then appends the HIR / monomorph / hir_lower extensions. Dropping `ast_lower.osty` matters because HIR lowering consumes the elab `TyArena` rather than the Osty-side AST bridge — keeping it in would pull `astbridge` into the generated smoke module and force the tmp `go.mod` to replace-stitch the real `internal/selfhost/astbridge` package, which the checker and llvmgen smoke tests both avoid.

The MIR bundle extends HIR with `mir.osty`, `mir_lower.osty`, `mir_optimize.osty`, `mir_validator.osty` (no further checker deletions required).

## Test plan
- [x] `go test ./internal/selfhost/ -run 'TestToolchain(LLVMGen|Hir|Mir)SourcesTranspile' -count=1` — all green (13.1s)
- [x] `go test ./internal/selfhost/bundle/ -count=1` — all green (0.9s)
- [x] Spot-check generated Go contains the expected entry points (`hirLowerer`, `mirLowerModule`, `mirLowerStmt`, …) and that no unlowered `use std.strings` imports or `strings.xxx` calls leak through.

## Follow-up
The `internal/selfhost/bundle` package itself is still Go. Per CLAUDE.md that sits at the explicitly-allowed "Osty 자체를 부트스트랩하는 self-host seed 경로" boundary, so matching the existing shape here was the right call for this PR — but a follow-up should narrow the Go shim so the file-list filter + path construction can move to Osty. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)