### PR TITLE
Advance llvmgen native probe coverage

### DIFF
--- a/internal/llvmgen/char_byte_lowering_test.go
+++ b/internal/llvmgen/char_byte_lowering_test.go
@@ -229,6 +229,43 @@ fn main() {
 	}
 }
 
+// hirLowerParseRadix-style loop: iterate `text.chars()` (List<Char>),
+// pass each char to a helper, and match on char literals. This is the
+// exact family of shapes that first-walled the merged AST probe when
+// the helper still expected String.
+func TestCharsLoopFeedsCharMatchHelper(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn charToDigit(ch: Char) -> Int {
+    match ch {
+        '0' -> 0,
+        '1' -> 1,
+        'a' -> 10, 'A' -> 10,
+        _ -> -1,
+    }
+}
+
+fn parseHead(text: String) -> Int {
+    let mut acc = 0
+    let chars = text.chars()
+    for ch in chars {
+        let d = charToDigit(ch)
+        if d < 0 {
+            return acc
+        }
+        acc = acc * 16 + d
+    }
+    acc
+}
+
+fn main() {
+    println(parseHead("1A"))
+}
+`)
+	_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/chars_digit_loop.osty"})
+	if err != nil {
+		t.Fatalf("chars loop + char match helper still errors: %v", err)
+	}
+}
+
 // Byte.toString() calls the osty_rt_byte_to_string runtime helper to
 // materialise a single-byte String. Useful for raw-byte display paths.
 func TestByteToStringCallsRuntimeHelper(t *testing.T) {

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -308,6 +308,11 @@ type builtinResultType struct {
 	errTyp string
 }
 
+type builtinRangeType struct {
+	typ     string
+	elemTyp string
+}
+
 func builtinResultTypeFromAST(t ast.Type, env typeEnv) (builtinResultType, bool) {
 	named, ok := t.(*ast.NamedType)
 	if !ok || len(named.Path) != 1 || named.Path[0] != "Result" || len(named.Args) != 2 {
@@ -325,6 +330,25 @@ func builtinResultTypeFromAST(t ast.Type, env typeEnv) (builtinResultType, bool)
 		typ:    llvmResultTypeName(okTyp, errTyp),
 		okTyp:  okTyp,
 		errTyp: errTyp,
+	}, true
+}
+
+func llvmRangeTypeName(elemTyp string) string {
+	return llvmBuiltinAggregateName("Range", elemTyp)
+}
+
+func builtinRangeTypeFromAST(t ast.Type, env typeEnv) (builtinRangeType, bool) {
+	named, ok := t.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "Range" || len(named.Args) != 1 {
+		return builtinRangeType{}, false
+	}
+	elemTyp, err := llvmType(named.Args[0], env)
+	if err != nil {
+		return builtinRangeType{}, false
+	}
+	return builtinRangeType{
+		typ:     llvmRangeTypeName(elemTyp),
+		elemTyp: elemTyp,
 	}, true
 }
 
@@ -529,6 +553,58 @@ func collectBuiltinResultTypes(file *ast.File, env typeEnv) map[string]builtinRe
 	}
 	for _, stmt := range file.Stmts {
 		collectBuiltinResultTypesFromStmt(out, stmt, env)
+	}
+	return out
+}
+
+func collectBuiltinRangeTypes(file *ast.File, env typeEnv) map[string]builtinRangeType {
+	out := map[string]builtinRangeType{}
+	if file == nil {
+		return out
+	}
+	collectFn := func(fn *ast.FnDecl) {
+		if fn == nil {
+			return
+		}
+		for _, param := range fn.Params {
+			if param == nil {
+				continue
+			}
+			collectBuiltinRangeTypeFromAST(out, param.Type, env)
+		}
+		collectBuiltinRangeTypeFromAST(out, fn.ReturnType, env)
+	}
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FnDecl:
+			collectFn(d)
+		case *ast.StructDecl:
+			for _, field := range d.Fields {
+				if field == nil {
+					continue
+				}
+				collectBuiltinRangeTypeFromAST(out, field.Type, env)
+			}
+			for _, method := range d.Methods {
+				collectFn(method)
+			}
+		case *ast.EnumDecl:
+			for _, variant := range d.Variants {
+				if variant == nil {
+					continue
+				}
+				for _, field := range variant.Fields {
+					collectBuiltinRangeTypeFromAST(out, field, env)
+				}
+			}
+			for _, method := range d.Methods {
+				collectFn(method)
+			}
+		case *ast.LetDecl:
+			collectBuiltinRangeTypeFromAST(out, d.Type, env)
+		case *ast.TypeAliasDecl:
+			collectBuiltinRangeTypeFromAST(out, d.Target, env)
+		}
 	}
 	return out
 }
@@ -784,6 +860,32 @@ func collectBuiltinResultTypeFromAST(out map[string]builtinResultType, t ast.Typ
 			collectBuiltinResultTypeFromAST(out, param, env)
 		}
 		collectBuiltinResultTypeFromAST(out, tt.ReturnType, env)
+	}
+}
+
+func collectBuiltinRangeTypeFromAST(out map[string]builtinRangeType, t ast.Type, env typeEnv) {
+	if out == nil || t == nil {
+		return
+	}
+	switch tt := t.(type) {
+	case *ast.NamedType:
+		if info, ok := builtinRangeTypeFromAST(tt, env); ok {
+			out[info.typ] = info
+		}
+		for _, arg := range tt.Args {
+			collectBuiltinRangeTypeFromAST(out, arg, env)
+		}
+	case *ast.OptionalType:
+		collectBuiltinRangeTypeFromAST(out, tt.Inner, env)
+	case *ast.TupleType:
+		for _, elem := range tt.Elems {
+			collectBuiltinRangeTypeFromAST(out, elem, env)
+		}
+	case *ast.FnType:
+		for _, param := range tt.Params {
+			collectBuiltinRangeTypeFromAST(out, param, env)
+		}
+		collectBuiltinRangeTypeFromAST(out, tt.ReturnType, env)
 	}
 }
 

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -29,6 +29,21 @@ func (g *generator) ifLetCondition(pattern ast.Pattern, scrutinee value) (*LlvmV
 	if _, ok := pattern.(*ast.WildcardPat); ok {
 		return toOstyValue(value{typ: "i1", ref: "true"}), func() error { return nil }, nil
 	}
+	if p, ok := pattern.(*ast.BindingPat); ok {
+		cond, bind, err := g.ifLetCondition(p.Pattern, scrutinee)
+		if err != nil {
+			return nil, nil, err
+		}
+		return cond, func() error {
+			if err := g.bindLetPattern(&ast.IdentPat{Name: p.Name}, scrutinee, false); err != nil {
+				return err
+			}
+			if bind != nil {
+				return bind()
+			}
+			return nil
+		}, nil
+	}
 	if info := g.enumsByType[scrutinee.typ]; info != nil && info.hasPayload {
 		matched, ok, err := g.matchPayloadEnumPattern(info, pattern)
 		if err != nil {
@@ -45,17 +60,79 @@ func (g *generator) ifLetCondition(pattern ast.Pattern, scrutinee value) (*LlvmV
 			return g.bindPayloadEnumPattern(scrutinee, matched)
 		}, nil
 	}
+	if litPat, ok := pattern.(*ast.LiteralPat); ok && litPat.Literal != nil && isPrimitiveLiteralMatchScrutineeType(scrutinee.typ) {
+		litValue, err := g.emitExpr(litPat.Literal)
+		if err != nil {
+			return nil, nil, err
+		}
+		if litValue.typ != scrutinee.typ {
+			return nil, nil, unsupportedf("type-system", "match literal type %s, want %s", litValue.typ, scrutinee.typ)
+		}
+		emitter := g.toOstyEmitter()
+		cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(litValue))
+		g.takeOstyEmitter(emitter)
+		return cond, func() error { return nil }, nil
+	}
 	tag, ok, err := g.matchEnumTag(pattern)
 	if err != nil {
 		return nil, nil, err
 	}
 	if !ok {
+		if _, ok := pattern.(*ast.IdentPat); ok {
+			return toOstyValue(value{typ: "i1", ref: "true"}), func() error {
+				return g.bindLetPattern(pattern, scrutinee, false)
+			}, nil
+		}
 		return nil, nil, unsupported("control-flow", "if-let pattern must be an enum variant")
 	}
 	emitter := g.toOstyEmitter()
 	cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(value{typ: "i64", ref: strconv.Itoa(tag)}))
 	g.takeOstyEmitter(emitter)
 	return cond, func() error { return nil }, nil
+}
+
+func (g *generator) matchNeedsGenericConditionPath(scrutinee value, arms []*ast.MatchArm) bool {
+	if len(arms) == 0 {
+		return false
+	}
+	payloadInfo := g.enumsByType[scrutinee.typ]
+	if payloadInfo != nil && payloadInfo.hasPayload {
+		for _, arm := range arms {
+			if arm == nil || arm.Pattern == nil {
+				continue
+			}
+			switch pat := arm.Pattern.(type) {
+			case *ast.BindingPat:
+				return true
+			case *ast.IdentPat:
+				if _, ok, err := g.matchPayloadEnumPattern(payloadInfo, pat); err == nil && !ok {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	if scrutinee.typ == "i64" || isPrimitiveLiteralMatchScrutineeType(scrutinee.typ) {
+		literalSetOnly := isPrimitiveLiteralMatchArms(arms)
+		for _, arm := range arms {
+			if arm == nil || arm.Pattern == nil {
+				continue
+			}
+			switch pat := arm.Pattern.(type) {
+			case *ast.BindingPat:
+				return true
+			case *ast.IdentPat:
+				if _, ok, err := g.matchEnumTag(pat); err == nil && !ok {
+					return true
+				}
+			case *ast.LiteralPat:
+				if !literalSetOnly {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (g *generator) emitStringLiteral(lit *ast.StringLit) (value, error) {
@@ -253,6 +330,8 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 		return g.emitListExprWithHint(e, nil, "", false)
 	case *ast.MapExpr:
 		return g.emitMapExprWithHint(e, nil, nil, "", "", false)
+	case *ast.RangeExpr:
+		return g.emitRangeExpr(e)
 	case *ast.StructLit:
 		return g.emitStructLit(e)
 	case *ast.IfExpr:
@@ -262,6 +341,64 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 	default:
 		return value{}, unsupportedf("expression", "expression %T %s", expr, exprPosLabel(expr))
 	}
+}
+
+func (g *generator) emitRangeExpr(expr *ast.RangeExpr) (value, error) {
+	if expr == nil {
+		return value{}, unsupported("expression", "nil range literal")
+	}
+	if expr.Step != nil {
+		return value{}, unsupported("expression", "range literal with step is not supported yet")
+	}
+	sourceType, _ := g.staticRangeExprSourceType(expr)
+	info, ok := builtinRangeTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		info = builtinRangeType{
+			typ:     llvmRangeTypeName("i64"),
+			elemTyp: "i64",
+		}
+		sourceType = &ast.NamedType{Path: []string{"Range"}, Args: []ast.Type{&ast.NamedType{Path: []string{"Int"}}}}
+	}
+	if g.rangeTypes == nil {
+		g.rangeTypes = map[string]builtinRangeType{}
+	}
+	g.rangeTypes[info.typ] = info
+
+	emitBound := func(bound ast.Expr) (value, bool, error) {
+		if bound == nil {
+			return value{typ: info.elemTyp, ref: llvmZeroLiteral(info.elemTyp)}, false, nil
+		}
+		v, err := g.emitExpr(bound)
+		if err != nil {
+			return value{}, false, err
+		}
+		if v.typ != info.elemTyp {
+			return value{}, false, unsupportedf("type-system", "range bound type %s, want %s", v.typ, info.elemTyp)
+		}
+		return v, true, nil
+	}
+
+	startVal, hasStart, err := emitBound(expr.Start)
+	if err != nil {
+		return value{}, err
+	}
+	stopVal, hasStop, err := emitBound(expr.Stop)
+	if err != nil {
+		return value{}, err
+	}
+
+	emitter := g.toOstyEmitter()
+	out := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(startVal),
+		toOstyValue(stopVal),
+		toOstyValue(value{typ: "i1", ref: strconv.FormatBool(hasStart)}),
+		toOstyValue(value{typ: "i1", ref: strconv.FormatBool(hasStop)}),
+		toOstyValue(value{typ: "i1", ref: strconv.FormatBool(expr.Inclusive)}),
+	})
+	g.takeOstyEmitter(emitter)
+	loaded := fromOstyValue(out)
+	loaded.sourceType = sourceType
+	return loaded, nil
 }
 
 // exprPosLabel formats the AST node's source line/column and byte
@@ -505,9 +642,26 @@ func (g *generator) emitFieldExpr(expr *ast.FieldExpr) (value, error) {
 	if err != nil {
 		return value{}, err
 	}
+	rangeSource := base.sourceType
+	if rangeSource == nil {
+		rangeSource, _ = g.staticExprSourceType(expr.X)
+	}
+	if field, ok := g.builtinRangeFieldInfo(rangeSource, expr.Name); ok {
+		emitter := g.toOstyEmitter()
+		out := llvmExtractValue(emitter, toOstyValue(base), field.typ, field.index)
+		g.takeOstyEmitter(emitter)
+		loaded := fromOstyValue(out)
+		loaded.sourceType = field.sourceType
+		if err := g.decorateValueFromSourceType(&loaded, field.sourceType); err != nil {
+			return value{}, err
+		}
+		loaded.gcManaged = valueNeedsManagedRoot(loaded)
+		loaded.rootPaths = g.rootPathsForType(field.typ)
+		return loaded, nil
+	}
 	info := g.structsByType[base.typ]
 	if info == nil {
-		return value{}, unsupportedf("type-system", "field access on %s", base.typ)
+		return value{}, unsupportedf("type-system", "field %q access on %s %s", expr.Name, base.typ, exprPosLabel(expr))
 	}
 	field, ok := info.byName[expr.Name]
 	if !ok {
@@ -1623,6 +1777,12 @@ func (g *generator) emitBlockValue(block *ast.Block) (value, error) {
 			}
 			continue
 		}
+		if ret, ok := stmt.(*ast.ReturnStmt); ok {
+			if err := g.emitReturn(ret); err != nil {
+				return value{}, err
+			}
+			return value{typ: "void", ref: "undef"}, nil
+		}
 		exprStmt, ok := stmt.(*ast.ExprStmt)
 		if !ok {
 			return value{}, unsupportedf("statement", "final block statement %T", stmt)
@@ -1676,6 +1836,12 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 	if hasGuard {
 		return g.emitGuardedMatchExprValue(scrutinee, expr.Arms)
 	}
+	if g.matchNeedsGenericConditionPath(scrutinee, expr.Arms) {
+		return g.emitGuardedMatchExprValue(scrutinee, expr.Arms)
+	}
+	if isPrimitiveLiteralMatchScrutineeType(scrutinee.typ) && isPrimitiveLiteralMatchArms(expr.Arms) {
+		return g.emitPrimitiveLiteralMatchExprValue(scrutinee, expr.Arms)
+	}
 	if scrutinee.typ == "i64" {
 		// `match n { 0 -> ..., 1 -> ..., _ -> ... }` on a plain Int
 		// scrutinee falls into the same i64 dispatch as a payload-free
@@ -1683,9 +1849,6 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 		// variant idents, so emitTagEnumMatchExprValue's matchEnumTag
 		// returns false on every arm. Detect the literal-pattern shape
 		// up front and route to the dedicated primitive lowering.
-		if isPrimitiveLiteralMatchArms(expr.Arms) {
-			return g.emitPrimitiveLiteralMatchExprValue(scrutinee, expr.Arms)
-		}
 		return g.emitTagEnumMatchExprValue(scrutinee, expr.Arms)
 	}
 	if info := g.enumsByType[scrutinee.typ]; info != nil && info.hasPayload {
@@ -1999,6 +2162,15 @@ func isPrimitiveLiteralMatchArms(arms []*ast.MatchArm) bool {
 		}
 	}
 	return sawLiteral
+}
+
+func isPrimitiveLiteralMatchScrutineeType(typ string) bool {
+	switch typ {
+	case "i64", "i32", "i8", "i1":
+		return true
+	default:
+		return false
+	}
 }
 
 // emitPrimitiveLiteralMatchExprValue lowers `match n { 0 -> A, 1 -> B,

--- a/internal/llvmgen/expr_pos_label_test.go
+++ b/internal/llvmgen/expr_pos_label_test.go
@@ -3,42 +3,32 @@ package llvmgen
 import (
 	"strings"
 	"testing"
-
-	"github.com/osty/osty/internal/parser"
 )
 
-// TestEmitExprDefaultWallCarriesSourcePos locks in that the emitExpr
-// fallthrough wall (LLVM013 "expression: expression %T") is tagged
-// with the offending node's line:col. The native-toolchain probe
-// (TestProbeNativeToolchainMerged) relies on this tag to point
-// investigators at the exact Tier A blocker in the merged buffer
-// without re-running a second diagnostic pass.
-//
-// Positive-position reproduction: a value-position RangeExpr. For
-// the synthetic source below the RangeExpr literal starts at line 2,
-// column 13 (`0..10`), so the wall must include `at 2:13` and the
-// corresponding byte offset.
-func TestEmitExprDefaultWallCarriesSourcePos(t *testing.T) {
-	src := []byte("fn main() {\n    let r = 0..10\n    println(r)\n}\n")
-	file, _ := parser.ParseDiagnostics(src)
-	if file == nil {
-		t.Fatalf("parse returned nil file")
+// TestRangeExprValuePositionLowers locks the fix for the
+// value-position `RangeExpr` wall that used to stop the merged
+// toolchain probe at LLVM013. The exact shape mirrors the probe's
+// motivating formatter case: an `if` expression on the left of `..`.
+func TestRangeExprValuePositionLowers(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn build(ok: Bool) -> Range<Int> {
+    if ok { 0 } else { 1 }..10
+}
+
+fn main() {
+    let _ = build(true)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/range_expr_value.osty"})
+	if err != nil {
+		t.Fatalf("range value lowering errored: %v", err)
 	}
-	_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/pos_probe.osty"})
-	if err == nil {
-		t.Fatalf("expected LLVM013 wall for value-position RangeExpr; got nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "LLVM013") {
-		t.Fatalf("expected LLVM013 wall; got: %s", msg)
-	}
-	if !strings.Contains(msg, "*ast.RangeExpr") {
-		t.Fatalf("expected wall to mention *ast.RangeExpr; got: %s", msg)
-	}
-	if !strings.Contains(msg, "at 2:13") {
-		t.Fatalf("expected wall to pin `at 2:13`; got: %s", msg)
-	}
-	if !strings.Contains(msg, "offset ") {
-		t.Fatalf("expected wall to include byte offset; got: %s", msg)
+	got := string(ir)
+	for _, want := range []string{
+		"%Range.i64 = type { i64, i64, i1, i1, i1 }",
+		"insertvalue %Range.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/llvmgen/expr_stmt_test.go
+++ b/internal/llvmgen/expr_stmt_test.go
@@ -1,0 +1,22 @@
+package llvmgen
+
+import "testing"
+
+func TestBoolLiteralExpressionStatementIsIgnored(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn run(flag: Bool) {
+    if flag {
+        true
+    } else {
+        false
+    }
+}
+`)
+
+	_, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/bool_expr_stmt.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -44,6 +44,7 @@ type generator struct {
 	globalConsts      map[string]constValue
 	tupleTypes        map[string]tupleTypeInfo
 	resultTypes       map[string]builtinResultType
+	rangeTypes        map[string]builtinRangeType
 	runtimeFFI        map[string]map[string]*runtimeFFIFunction
 	runtimeFFIPaths   map[string]string
 	testingAliases    map[string]bool
@@ -513,7 +514,7 @@ func (g *generator) render(defs []string) []byte {
 	allDefs := make([]string, 0, len(g.globalDefs)+len(defs))
 	allDefs = append(allDefs, g.globalDefs...)
 	allDefs = append(allDefs, defs...)
-	typeDefs := make([]string, 0, len(g.structs)+len(g.enumsByType)+len(g.tupleTypes)+len(g.resultTypes))
+	typeDefs := make([]string, 0, len(g.structs)+len(g.enumsByType)+len(g.tupleTypes)+len(g.resultTypes)+len(g.rangeTypes))
 	for _, info := range g.structs {
 		fieldTypes := make([]string, 0, len(info.fields))
 		for _, field := range info.fields {
@@ -568,6 +569,17 @@ func (g *generator) render(defs []string) []byte {
 		for _, name := range names {
 			info := g.resultTypes[name]
 			typeDefs = append(typeDefs, llvmStructTypeDef(strings.TrimPrefix(info.typ, "%"), []string{"i64", info.okTyp, info.errTyp}))
+		}
+	}
+	if len(g.rangeTypes) != 0 {
+		names := make([]string, 0, len(g.rangeTypes))
+		for name := range g.rangeTypes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			info := g.rangeTypes[name]
+			typeDefs = append(typeDefs, llvmStructTypeDef(strings.TrimPrefix(info.typ, "%"), []string{info.elemTyp, info.elemTyp, "i1", "i1", "i1"}))
 		}
 	}
 	// Phase 6a: interface fat-pointer type + per (impl, interface) vtable
@@ -1617,6 +1629,35 @@ func (g *generator) lookupLocal(name string) (value, bool) {
 		}
 	}
 	return value{}, false
+}
+
+func (g *generator) lookupLocalScope(name string) (int, value, bool) {
+	for i := len(g.locals) - 1; i >= 0; i-- {
+		if v, ok := g.locals[i][name]; ok {
+			return i, v, true
+		}
+	}
+	return -1, value{}, false
+}
+
+func (g *generator) materializeAddressableLocalBinding(name string) (value, bool, error) {
+	scope, current, ok := g.lookupLocalScope(name)
+	if !ok {
+		return value{}, false, nil
+	}
+	if current.ptr {
+		return current, true, nil
+	}
+	emitter := g.toOstyEmitter()
+	slot := llvmMutableLetSlot(emitter, name, toOstyValue(current))
+	slotValue := fromOstyValue(slot)
+	copyContainerMetadata(&slotValue, current)
+	slotValue.mutable = current.mutable
+	slotValue.rootPaths = cloneRootPaths(current.rootPaths)
+	g.bindGCRootIfManagedPointer(emitter, slotValue)
+	g.takeOstyEmitter(emitter)
+	g.locals[scope][name] = slotValue
+	return slotValue, true, nil
 }
 
 func (g *generator) bindLetPattern(pattern ast.Pattern, v value, mutable bool) error {

--- a/internal/llvmgen/if_expr_return_test.go
+++ b/internal/llvmgen/if_expr_return_test.go
@@ -1,0 +1,23 @@
+package llvmgen
+
+import "testing"
+
+func TestIfExpressionBranchMayReturnEarly(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn choose(flag: Bool) -> Int {
+    let x = if flag {
+        return 1
+    } else {
+        2
+    }
+    x
+}
+`)
+
+	_, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/if_expr_return.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+}

--- a/internal/llvmgen/indexed_field_assign_test.go
+++ b/internal/llvmgen/indexed_field_assign_test.go
@@ -1,0 +1,43 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIndexedFieldAssignOnListElement(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Instr {
+    hasDest: Bool,
+    dest: Int,
+}
+
+fn main() {
+    let mut instrs: List<Instr> = [Instr { hasDest: true, dest: 1 }]
+    instrs[0].hasDest = false
+    if instrs[0].hasDest {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/indexed_field_assign.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"call void @osty_rt_list_get_bytes",
+		"call void @osty_rt_list_set_bytes",
+		"insertvalue %Instr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -256,6 +256,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		traceHelpers:    map[string]string{},
 		tupleTypes:      map[string]tupleTypeInfo{},
 		resultTypes:     map[string]builtinResultType{},
+		rangeTypes:      map[string]builtinRangeType{},
 	}
 	if len(file.Stmts) > 0 {
 		if len(file.Decls) > 0 {
@@ -266,6 +267,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.runtimeFFI = collectRuntimeFFI(file, env)
 		g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
 		g.resultTypes = collectBuiltinResultTypes(file, env)
+		g.rangeTypes = collectBuiltinRangeTypes(file, env)
 		g.testingAliases = collectStdTestingAliases(file)
 		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
@@ -294,6 +296,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.globalConsts = map[string]constValue{}
 	g.tupleTypes = collectTupleTypes(file, g.typeEnv())
 	g.resultTypes = collectBuiltinResultTypes(file, g.typeEnv())
+	g.rangeTypes = collectBuiltinRangeTypes(file, g.typeEnv())
 	g.runtimeFFI = collectRuntimeFFI(file, g.typeEnv())
 	g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
 	g.testingAliases = collectStdTestingAliases(file)

--- a/internal/llvmgen/match_binding_test.go
+++ b/internal/llvmgen/match_binding_test.go
@@ -1,0 +1,67 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateTagEnumBindingMatchExpression(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Kind {
+    Ready,
+    Waiting,
+}
+
+fn keep(kind: Kind) -> Kind {
+    match kind {
+        matched -> matched,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/match_binding_tag.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @keep(i64 %kind)",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGeneratePrimitiveLiteralAndBindingMatchExpression(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn classify(n: Int) -> Int {
+    match n {
+        0 -> 0,
+        rest -> rest,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/match_binding_primitive.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @classify(i64 %n)",
+		"icmp eq i64 %n, 0",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/multifile_probe_helper_test.go
+++ b/internal/llvmgen/multifile_probe_helper_test.go
@@ -1,6 +1,10 @@
 package llvmgen
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestIsBootstrapOnlyOstyFile(t *testing.T) {
 	t.Run("detects real use go ffi", func(t *testing.T) {
@@ -23,4 +27,34 @@ func TestIsBootstrapOnlyOstyFile(t *testing.T) {
 			t.Fatalf("expected comment-only mentions to stay in the native merged set")
 		}
 	})
+}
+
+func TestCollectToolchainProbeFilesSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".osty"), 0o755); err != nil {
+		t.Fatalf("mkdir .osty: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "alpha.osty"), []byte("pub fn alpha() -> Int { 1 }\n"), 0o644); err != nil {
+		t.Fatalf("write alpha.osty: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "beta_test.osty"), []byte("pub fn beta() -> Int { 2 }\n"), 0o644); err != nil {
+		t.Fatalf("write beta_test.osty: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore\n"), 0o644); err != nil {
+		t.Fatalf("write notes.txt: %v", err)
+	}
+
+	files, skipped, err := collectToolchainProbeFiles(dir, false)
+	if err != nil {
+		t.Fatalf("collectToolchainProbeFiles: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipBootstrapOnly=false unexpectedly skipped files: %v", skipped)
+	}
+	if got, want := len(files), 1; got != want {
+		t.Fatalf("len(files) = %d, want %d (%v)", got, want, files)
+	}
+	if got, want := files[0], "alpha.osty"; got != want {
+		t.Fatalf("files[0] = %q, want %q", got, want)
+	}
 }

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -14,6 +14,38 @@ import (
 	"github.com/osty/osty/internal/stdlib"
 )
 
+func collectToolchainProbeFiles(dir string, skipBootstrapOnly bool) ([]string, []string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	var files []string
+	var skipped []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		if !skipBootstrapOnly {
+			files = append(files, name)
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		if isBootstrapOnlyOstyFile(src) {
+			skipped = append(skipped, name)
+			continue
+		}
+		files = append(files, name)
+	}
+	return files, skipped, nil
+}
+
 // mergeToolchainSources concatenates toolchain files in order into a
 // single source buffer. The parser tolerates duplicate
 // `use std.strings as strings` stanzas, so repeats across files are
@@ -125,17 +157,9 @@ func TestProbeWholeToolchainMerged(t *testing.T) {
 		t.Fatalf("abs root: %v", err)
 	}
 	dir := filepath.Join(root, "toolchain")
-	entries, err := os.ReadDir(dir)
+	files, _, err := collectToolchainProbeFiles(dir, false)
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
-	}
-	var files []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		files = append(files, name)
 	}
 	merged := mergeToolchainSources(t, root, files)
 	file, _ := parser.ParseDiagnostics(merged)
@@ -190,26 +214,9 @@ func TestProbeNativeToolchainMerged(t *testing.T) {
 		t.Fatalf("abs root: %v", err)
 	}
 	dir := filepath.Join(root, "toolchain")
-	entries, err := os.ReadDir(dir)
+	files, skipped, err := collectToolchainProbeFiles(dir, true)
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
-	}
-	var files []string
-	var skipped []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			continue
-		}
-		if isBootstrapOnlyOstyFile(src) {
-			skipped = append(skipped, name)
-			continue
-		}
-		files = append(files, name)
 	}
 	if len(skipped) == 0 {
 		t.Logf("no bootstrap-only files detected; this probe is equivalent to TestProbeWholeToolchainMerged")
@@ -250,26 +257,9 @@ func TestProbeNativeToolchainMergedMIR(t *testing.T) {
 		t.Fatalf("abs root: %v", err)
 	}
 	dir := filepath.Join(root, "toolchain")
-	entries, err := os.ReadDir(dir)
+	files, skipped, err := collectToolchainProbeFiles(dir, true)
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
-	}
-	var files []string
-	var skipped []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			continue
-		}
-		if isBootstrapOnlyOstyFile(src) {
-			skipped = append(skipped, name)
-			continue
-		}
-		files = append(files, name)
 	}
 	if len(skipped) > 0 {
 		t.Logf("bootstrap-only files skipped (%d): %s", len(skipped), strings.Join(skipped, ", "))

--- a/internal/llvmgen/non_addressable_field_assign_test.go
+++ b/internal/llvmgen/non_addressable_field_assign_test.go
@@ -1,0 +1,38 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFieldAssignMaterializesNonAddressableLocalBinding(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Decl {
+    name: String,
+    arity: Int,
+}
+
+fn rewrite(decl: Decl) -> Int {
+    decl.arity = 7
+    decl.arity
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/non_addressable_field_assign.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"alloca %Decl",
+		"insertvalue %Decl",
+		"store %Decl",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/phantom_range_decl_test.go
+++ b/internal/llvmgen/phantom_range_decl_test.go
@@ -13,11 +13,11 @@ import (
 
 // TestToolchainHasNoPhantomRangeExpr locks the fix for the "LLVM013
 // *ast.RangeExpr at 1:16" wall that TestProbeNativeToolchainMerged
-// hit before. Root cause: `llvmUnsupportedDiagnostic`'s hint strings
-// carried unescaped `{ ... }` which the Osty lexer treats as
-// interpolation. The reparsed interpolation expression (` .. `) came
-// back as a RangeExpr with position 1:16 (offset 15) in the local
-// reparse buffer, which then surfaced as the backend's first wall.
+// hit before. Root cause: unescaped `{ ... }` in string literals,
+// which the Osty lexer treats as interpolation. Reparsing those
+// placeholders can synthesize phantom nodes (historically RangeExpr,
+// later an empty-name FieldExpr) at 1:16 in the local reparse buffer,
+// which then surface as the backend's first wall.
 //
 // Regression shape: any top-level toolchain declaration that contains
 // a *ast.RangeExpr whose reported line is BEFORE the declaration's
@@ -51,6 +51,12 @@ func TestToolchainHasNoPhantomRangeExpr(t *testing.T) {
 			walkPhantomRange(reflect.ValueOf(decl), func(line, col, off int) {
 				if line < declPos.Line {
 					t.Errorf("%s: decl %q (line %d) has phantom RangeExpr at %d:%d (offset %d) — likely an unescaped `{ ... }` in a string literal",
+						name, declLabel(decl), declPos.Line, line, col, off)
+				}
+			})
+			walkPhantomEmptyField(reflect.ValueOf(decl), func(line, col, off int) {
+				if line < declPos.Line {
+					t.Errorf("%s: decl %q (line %d) has phantom empty FieldExpr at %d:%d (offset %d) — likely an unescaped `{ ... }` in a string literal",
 						name, declLabel(decl), declPos.Line, line, col, off)
 				}
 			})
@@ -111,6 +117,34 @@ func walkPhantomRange(v reflect.Value, visit func(line, col, off int)) {
 	case reflect.Slice:
 		for i := 0; i < v.Len(); i++ {
 			walkPhantomRange(v.Index(i), visit)
+		}
+	}
+}
+
+func walkPhantomEmptyField(v reflect.Value, visit func(line, col, off int)) {
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Struct:
+		if v.Type().Name() == "FieldExpr" {
+			name := v.FieldByName("Name")
+			if name.IsValid() && name.Kind() == reflect.String && name.Len() == 0 {
+				p := v.FieldByName("PosV")
+				visit(int(p.FieldByName("Line").Int()),
+					int(p.FieldByName("Column").Int()),
+					int(p.FieldByName("Offset").Int()))
+			}
+		}
+		for i := 0; i < v.NumField(); i++ {
+			walkPhantomEmptyField(v.Field(i), visit)
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			walkPhantomEmptyField(v.Index(i), visit)
 		}
 	}
 }

--- a/internal/llvmgen/primitive_literal_match_test.go
+++ b/internal/llvmgen/primitive_literal_match_test.go
@@ -128,3 +128,39 @@ func TestGenerateIntLiteralMatchNonSelectSafeUsesIfPhi(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateCharLiteralMatchExpression(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn digit(ch: Char) -> Int {
+    match ch {
+        '0' -> 0,
+        '1' -> 1,
+        _ -> -1,
+    }
+}
+
+fn main() {
+    println(digit('1'))
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/char_literal_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @digit(i32",
+		"icmp eq i32",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "LLVM013") {
+		t.Fatalf("emitted LLVM013 unsupported diagnostic where char-literal match lowering should fire:\n%s", got)
+	}
+}

--- a/internal/llvmgen/range_expr_test.go
+++ b/internal/llvmgen/range_expr_test.go
@@ -1,0 +1,39 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRangeExprInferredLetCompiles(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let r = 0..10
+    let _ = r
+}
+`)
+	if _, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/range_expr_let.osty"}); err != nil {
+		t.Fatalf("inferred range let errored: %v", err)
+	}
+}
+
+func TestRangeExprFieldAccessLowers(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let r = 0..10
+    println(r.hasStart)
+    println(r.start)
+    println(r.inclusive)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/range_expr_fields.osty"})
+	if err != nil {
+		t.Fatalf("range field access errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"extractvalue %Range.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -674,16 +674,33 @@ func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
 		}
 		break
 	}
-	baseIdent, ok := cur.X.(*ast.Ident)
-	if !ok {
+	switch base := cur.X.(type) {
+	case *ast.Ident:
+		return g.emitBindingFieldAssign(base, fields, rhs)
+	case *ast.IndexExpr:
+		return g.emitIndexedFieldAssign(base, fields, rhs)
+	default:
 		return unsupportedf("statement", "field assignment base %T", cur.X)
+	}
+}
+
+func (g *generator) emitBindingFieldAssign(baseIdent *ast.Ident, fields []string, rhs ast.Expr) error {
+	if baseIdent == nil {
+		return unsupported("statement", "nil field assignment base")
 	}
 	slot, ok := g.lookupBinding(baseIdent.Name)
 	if !ok {
 		return unsupportedf("name", "assignment to unknown identifier %q", baseIdent.Name)
 	}
 	if !slot.ptr {
-		return unsupportedf("statement", "field assignment on non-addressable binding %q", baseIdent.Name)
+		materialized, ok, err := g.materializeAddressableLocalBinding(baseIdent.Name)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return unsupportedf("statement", "field assignment on non-addressable binding %q", baseIdent.Name)
+		}
+		slot = materialized
 	}
 	// NB: we deliberately do not gate on `slot.mutable` here. Osty's
 	// checker accepts field-through-param writes for managed context
@@ -741,6 +758,61 @@ func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
 	return nil
 }
 
+func (g *generator) emitIndexedFieldAssign(target *ast.IndexExpr, fields []string, rhs ast.Expr) error {
+	if target == nil {
+		return unsupported("statement", "nil indexed field assignment target")
+	}
+	base, err := g.emitExpr(target.X)
+	if err != nil {
+		return err
+	}
+	index, err := g.emitExpr(target.Index)
+	if err != nil {
+		return err
+	}
+	root, err := g.emitListElementValue(base, index)
+	if err != nil {
+		return err
+	}
+	steps := make([]fieldInfo, len(fields))
+	curTyp := root.typ
+	for i, name := range fields {
+		info := g.structsByType[curTyp]
+		if info == nil {
+			return unsupportedf("type-system", "field assignment on %s", curTyp)
+		}
+		field, ok := info.byName[name]
+		if !ok {
+			return unsupportedf("expression", "struct %q has no field %q", info.name, name)
+		}
+		steps[i] = field
+		curTyp = field.typ
+	}
+	innermost := steps[len(steps)-1]
+	v, err := g.emitExprWithHintAndSourceType(rhs, innermost.sourceType, innermost.listElemTyp, innermost.listElemString, innermost.mapKeyTyp, innermost.mapValueTyp, innermost.mapKeyString, innermost.setElemTyp, innermost.setElemString)
+	if err != nil {
+		return err
+	}
+	if v.typ != innermost.typ {
+		return unsupportedf("type-system", "field assignment index.%s type %s, value %s", strings.Join(fields, "."), innermost.typ, v.typ)
+	}
+	emitter := g.toOstyEmitter()
+	levels := make([]value, len(steps))
+	levels[0] = root
+	for i := 1; i < len(steps); i++ {
+		prev := levels[i-1]
+		extracted := llvmExtractValue(emitter, toOstyValue(prev), steps[i-1].typ, steps[i-1].index)
+		levels[i] = fromOstyValue(extracted)
+	}
+	next := v
+	for i := len(steps) - 1; i >= 0; i-- {
+		rebuilt := llvmInsertValue(emitter, toOstyValue(levels[i]), toOstyValue(next), steps[i].index)
+		next = fromOstyValue(rebuilt)
+	}
+	g.takeOstyEmitter(emitter)
+	return g.emitListAssignValue(base, index, next)
+}
+
 func (g *generator) emitIndexAssign(target *ast.IndexExpr, rhs ast.Expr) error {
 	if target == nil {
 		return unsupported("statement", "nil index assignment target")
@@ -770,6 +842,19 @@ func (g *generator) emitIndexAssign(target *ast.IndexExpr, rhs ast.Expr) error {
 	if err != nil {
 		return err
 	}
+	return g.emitListAssignValue(base, index, loaded)
+}
+
+func (g *generator) emitListAssignValue(base, index, v value) error {
+	if base.listElemTyp == "" {
+		return unsupported("statement", "list assignment currently supports lists only")
+	}
+	if index.typ != "i64" {
+		return unsupportedf("type-system", "list index type %s, want i64", index.typ)
+	}
+	if v.typ != base.listElemTyp {
+		return unsupportedf("type-system", "list assignment value type %s, want %s", v.typ, base.listElemTyp)
+	}
 	emitter := g.toOstyEmitter()
 	if listUsesTypedRuntime(base.listElemTyp) {
 		symbol := listRuntimeSetSymbol(base.listElemTyp)
@@ -777,11 +862,11 @@ func (g *generator) emitIndexAssign(target *ast.IndexExpr, rhs ast.Expr) error {
 		emitter.body = append(emitter.body, fmt.Sprintf(
 			"  call void @%s(%s)",
 			symbol,
-			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), toOstyValue(loaded)}),
+			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), toOstyValue(v)}),
 		))
 	} else {
 		traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
-		addr := g.spillValueAddress(emitter, "list.set", loaded)
+		addr := g.spillValueAddress(emitter, "list.set", v)
 		sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
 		g.declareRuntimeSymbol(listRuntimeSetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
 		emitter.body = append(emitter.body, fmt.Sprintf(
@@ -792,6 +877,41 @@ func (g *generator) emitIndexAssign(target *ast.IndexExpr, rhs ast.Expr) error {
 	}
 	g.takeOstyEmitter(emitter)
 	return nil
+}
+
+func (g *generator) emitListElementValue(base, index value) (value, error) {
+	if base.listElemTyp == "" {
+		return value{}, unsupported("expression", "index expression on non-list base")
+	}
+	if index.typ != "i64" {
+		return value{}, unsupportedf("type-system", "list index type %s, want i64", index.typ)
+	}
+	if listUsesTypedRuntime(base.listElemTyp) {
+		symbol := listRuntimeGetSymbol(base.listElemTyp)
+		g.declareRuntimeSymbol(symbol, base.listElemTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, base.listElemTyp, symbol, []*LlvmValue{toOstyValue(base), toOstyValue(index)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = base.listElemTyp == "ptr"
+		v.rootPaths = g.rootPathsForType(base.listElemTyp)
+		return v, nil
+	}
+	traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
+	emitter := g.toOstyEmitter()
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.listElemTyp))
+	sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
+	g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  call void @%s(%s)",
+		listRuntimeGetBytesSymbol(),
+		llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
+	))
+	loaded := g.loadValueFromAddress(emitter, base.listElemTyp, slot)
+	g.takeOstyEmitter(emitter)
+	loaded.rootPaths = g.rootPathsForType(base.listElemTyp)
+	return loaded, nil
 }
 
 func (g *generator) emitFor(stmt *ast.ForStmt) error {
@@ -1102,7 +1222,11 @@ func (g *generator) emitReturn(stmt *ast.ReturnStmt) error {
 func (g *generator) emitExprStmt(expr ast.Expr) error {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
-		return unsupportedf("statement", "expression statement %T is not a call; only println and similar side-effect calls are supported as expression statements", expr)
+		if block, ok := expr.(*ast.Block); ok {
+			return g.emitScopedStmtBlock(block.Stmts)
+		}
+		_, err := g.emitExpr(expr)
+		return err
 	}
 	if emitted, err := g.emitTestingCallStmt(call); emitted || err != nil {
 		return err
@@ -2263,6 +2387,9 @@ func (g *generator) emitMatchStmt(expr *ast.MatchExpr) error {
 	if info, ok := g.resultTypes[scrutinee.typ]; ok {
 		return g.emitResultMatchStmt(scrutinee, info, expr.Arms)
 	}
+	if isPrimitiveLiteralMatchScrutineeType(scrutinee.typ) && isPrimitiveLiteralMatchArms(expr.Arms) {
+		return g.emitPrimitiveLiteralMatchStmt(scrutinee, expr.Arms)
+	}
 	if scrutinee.typ != "i64" {
 		return unsupportedf("statement", "match statement scrutinee type %s (only tag-enum i64 supported as statement for now)", scrutinee.typ)
 	}
@@ -2614,6 +2741,87 @@ func (g *generator) emitTagEnumMatchStmt(scrutinee value, arms []*ast.MatchArm) 
 		anyReached = true
 	}
 
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+	g.currentReachable = anyReached
+	return nil
+}
+
+func (g *generator) emitPrimitiveLiteralMatchStmt(scrutinee value, arms []*ast.MatchArm) error {
+	emitter := g.toOstyEmitter()
+	endLabel := llvmNextLabel(emitter, "match.end")
+	g.takeOstyEmitter(emitter)
+
+	anyReached := false
+	for i, arm := range arms {
+		if arm == nil {
+			return unsupported("statement", "nil match arm")
+		}
+		if arm.Guard != nil {
+			return unsupported("statement", "guarded primitive match arms are not yet supported as statements")
+		}
+		_, isWildcard := arm.Pattern.(*ast.WildcardPat)
+		isLast := i == len(arms)-1
+
+		if isWildcard {
+			if !isLast {
+				return unsupported("statement", "wildcard match arm must be last")
+			}
+			baseState := g.captureScopeState()
+			if err := g.emitMatchArmBodyAsStmt(arm.Body); err != nil {
+				return err
+			}
+			if g.currentReachable {
+				g.branchTo(endLabel)
+				anyReached = true
+			}
+			g.restoreScopeState(baseState)
+			continue
+		}
+
+		litPat, ok := arm.Pattern.(*ast.LiteralPat)
+		if !ok || litPat.Literal == nil {
+			return unsupportedf("statement", "primitive match arm must be a literal pattern or wildcard, got %T", arm.Pattern)
+		}
+		litValue, err := g.emitExpr(litPat.Literal)
+		if err != nil {
+			return err
+		}
+		if litValue.typ != scrutinee.typ {
+			return unsupportedf("type-system", "match literal type %s does not match scrutinee %s", litValue.typ, scrutinee.typ)
+		}
+
+		emitter := g.toOstyEmitter()
+		cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(litValue))
+		armLabel := llvmNextLabel(emitter, "match.arm")
+		nextLabel := llvmNextLabel(emitter, "match.next")
+		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, armLabel, nextLabel))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(armLabel)
+
+		baseState := g.captureScopeState()
+		if err := g.emitMatchArmBodyAsStmt(arm.Body); err != nil {
+			return err
+		}
+		if g.currentReachable {
+			g.branchTo(endLabel)
+			anyReached = true
+		}
+		g.restoreScopeState(baseState)
+
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(nextLabel)
+	}
+
+	if g.currentReachable {
+		g.branchTo(endLabel)
+		anyReached = true
+	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
 	g.takeOstyEmitter(emitter)

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -69,6 +69,9 @@ func llvmRuntimeABIType(t ast.Type, env typeEnv) (string, error) {
 	case nil:
 		return "void", nil
 	case *ast.NamedType:
+		if info, ok := builtinRangeTypeFromAST(tt, env); ok {
+			return info.typ, nil
+		}
 		name := ""
 		structType := ""
 		enumType := ""
@@ -420,6 +423,8 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		return g.staticListLiteralSourceType(e)
 	case *ast.MapExpr:
 		return g.staticMapLiteralSourceType(e)
+	case *ast.RangeExpr:
+		return g.staticRangeExprSourceType(e)
 	case *ast.QuestionExpr:
 		src, ok := g.staticExprSourceType(e.X)
 		if !ok {
@@ -490,6 +495,12 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if !ok {
 			return nil, false
 		}
+		if field, ok := g.builtinRangeFieldInfo(baseSource, e.Name); ok {
+			if e.IsOptional {
+				return wrapOptionalSourceType(field.sourceType), true
+			}
+			return field.sourceType, true
+		}
 		ownerSource := baseSource
 		if e.IsOptional {
 			var hasInner bool
@@ -535,6 +546,73 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (g *generator) staticRangeExprSourceType(expr *ast.RangeExpr) (ast.Type, bool) {
+	if expr == nil {
+		return nil, false
+	}
+	elem := ast.Type(&ast.NamedType{Path: []string{"Int"}})
+	var candidates []ast.Type
+	for _, part := range []ast.Expr{expr.Start, expr.Stop, expr.Step} {
+		if part == nil {
+			continue
+		}
+		src, ok := g.staticExprSourceType(part)
+		if !ok || src == nil {
+			continue
+		}
+		candidates = append(candidates, src)
+	}
+	if len(candidates) > 0 {
+		elem = candidates[0]
+		for _, candidate := range candidates[1:] {
+			if sameSourceType(elem, candidate) {
+				continue
+			}
+			elem = &ast.NamedType{Path: []string{"Int"}}
+			break
+		}
+	}
+	return &ast.NamedType{Path: []string{"Range"}, Args: []ast.Type{elem}}, true
+}
+
+type builtinRangeField struct {
+	index      int
+	typ        string
+	sourceType ast.Type
+}
+
+func (g *generator) builtinRangeFieldInfo(sourceType ast.Type, name string) (builtinRangeField, bool) {
+	if sourceType == nil {
+		return builtinRangeField{}, false
+	}
+	resolved, err := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{})
+	if err != nil {
+		return builtinRangeField{}, false
+	}
+	named, ok := resolved.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "Range" || len(named.Args) != 1 {
+		return builtinRangeField{}, false
+	}
+	info, ok := builtinRangeTypeFromAST(named, g.typeEnv())
+	if !ok {
+		return builtinRangeField{}, false
+	}
+	switch name {
+	case "start":
+		return builtinRangeField{index: 0, typ: info.elemTyp, sourceType: named.Args[0]}, true
+	case "stop":
+		return builtinRangeField{index: 1, typ: info.elemTyp, sourceType: named.Args[0]}, true
+	case "hasStart":
+		return builtinRangeField{index: 2, typ: "i1", sourceType: &ast.NamedType{Path: []string{"Bool"}}}, true
+	case "hasStop":
+		return builtinRangeField{index: 3, typ: "i1", sourceType: &ast.NamedType{Path: []string{"Bool"}}}, true
+	case "inclusive":
+		return builtinRangeField{index: 4, typ: "i1", sourceType: &ast.NamedType{Path: []string{"Bool"}}}, true
+	default:
+		return builtinRangeField{}, false
+	}
 }
 
 func fnSourceTypeFromSignature(sig *fnSig) ast.Type {
@@ -783,6 +861,16 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		}
 	case *ast.MapExpr:
 		return value{}, false
+	case *ast.RangeExpr:
+		sourceType, ok := g.staticRangeExprSourceType(e)
+		if !ok {
+			return value{}, false
+		}
+		info, ok := builtinRangeTypeFromAST(sourceType, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: sourceType}, true
 	case *ast.CallExpr:
 		if out, ok := g.staticStringMethodResult(e); ok {
 			return out, true
@@ -851,6 +939,12 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 	case *ast.FieldExpr:
 		if e.IsOptional {
 			return value{}, false
+		}
+		if baseSource, ok := g.staticExprSourceType(e.X); ok {
+			if field, ok := g.builtinRangeFieldInfo(baseSource, e.Name); ok {
+				out := value{typ: field.typ, sourceType: field.sourceType}
+				return g.decorateStaticValueFromSourceType(out, e), true
+			}
 		}
 		baseInfo, ok := g.staticExprInfo(e.X)
 		if !ok {
@@ -1816,6 +1910,9 @@ func llvmType(t ast.Type, env typeEnv) (string, error) {
 	t = resolved
 	switch tt := t.(type) {
 	case *ast.NamedType:
+		if info, ok := builtinRangeTypeFromAST(tt, env); ok {
+			return info.typ, nil
+		}
 		if len(tt.Path) == 1 && tt.Path[0] == "Result" && len(tt.Args) == 2 {
 			okTyp, err := llvmType(tt.Args[0], env)
 			if err != nil {

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -661,6 +661,11 @@ fn hirLowerStripSign(text: String) -> String {
     }
 }
 
+// hirLowerCharToDigit takes a Char (i32 Unicode scalar) because the
+// caller iterates `text.chars()` which returns `List<Char>` per the
+// String primitive contract. Earlier this took `String` and matched
+// against "0"/"a"/…, which passed a Char where a String was expected
+// and first-walled the merged AST probe with LLVM011.
 fn hirLowerCharToDigit(ch: Char) -> Int {
     match ch {
         '0' -> 0, '1' -> 1, '2' -> 2, '3' -> 3, '4' -> 4,

--- a/toolchain/pmcompile.osty
+++ b/toolchain/pmcompile.osty
@@ -381,7 +381,7 @@ pub fn pmLitLabel(e: HirExpr) -> String {
                 if part.isLit {
                     buf.push(part.lit)
                 } else {
-                    buf.push("{...}")
+                    buf.push("\{...\}")
                 }
             }
             buf.push("\"")


### PR DESCRIPTION
## Summary
- extend the native llvmgen probe path with binding/literal match lowering, indexed field assignment, non-addressable aggregate materialization, expression-statement discards, and block-tail returns
- add builtin `Range<T>` lowering plus field access support so value-position ranges no longer wall the merged toolchain probe
- fix the phantom `"{...}"` interpolation regression in `pmcompile.osty` and broaden llvmgen regressions around the probe frontier

## Testing
- `go test -count=1 -vet=off ./internal/llvmgen -run 'Test(IfExpressionBranchMayReturnEarly|BoolLiteralExpressionStatementIsIgnored|FieldAssignMaterializesNonAddressableLocalBinding|IndexedFieldAssignOnListElement|GenerateTagEnumBindingMatchExpression|GeneratePrimitiveLiteralAndBindingMatchExpression|CharsLoopFeedsCharMatchHelper|GenerateCharLiteralMatchExpression|StringSubstringMethodCall|RangeExprValuePositionLowers|RangeExprInferredLetCompiles|RangeExprFieldAccessLowers|ToolchainHasNoPhantomRangeExpr|ProbeWholeToolchainMerged|ProbeNativeToolchainMerged)$' -v`