### PR TITLE
feat: self-host format + lint wired into production path

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1307,7 +1307,7 @@ func runLintFileLegacy(path string, src []byte, formatter *diag.Formatter, flags
 	file, parseDiags := parsed.File, parsed.Diagnostics
 	res := resolveFile(file)
 	chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
-	lr := runLintEngine(file, res, chk)
+	lr := runLintEngine(file, src, res, chk)
 	if cfg, ok := loadLintConfigNear(path); ok {
 		lr = cfg.Apply(lr)
 	}
@@ -1906,8 +1906,8 @@ func resolveFile(file *ast.File) *resolve.Result {
 	return resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 }
 
-func runLintEngine(file *ast.File, res *resolve.Result, chk *check.Result) *lint.Result {
-	return lint.File(file, res, chk)
+func runLintEngine(file *ast.File, src []byte, res *resolve.Result, chk *check.Result) *lint.Result {
+	return lint.File(file, src, res, chk)
 }
 
 // checkOpts builds the check.Opts every subcommand passes to the type

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lexer"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
 )
@@ -34,29 +35,40 @@ const cacheLevels = 16
 
 var indentCache = strings.Repeat(Indent, cacheLevels)
 
-// Source formats the given Osty source bytes. It returns the formatted
-// output, any parse diagnostics produced along the way, and an error
-// only when the input cannot be parsed (i.e. diagnostics contain at
-// least one Error-severity entry).
+// Source formats the given Osty source bytes. It delegates to the
+// self-hosted Osty formatter compiled from toolchain/formatter_ast.osty;
+// the surviving Go printer below is used as the fallback when the
+// self-host formatter reports a failure.
+//
+// Returns the formatted output, any parse diagnostics produced along
+// the way, and an error only when the input cannot be parsed (i.e.
+// diagnostics contain at least one Error-severity entry).
 //
 // Warnings do not block formatting — the formatter works on a
 // best-effort AST when possible. Callers that want "format only clean
 // files" should inspect the returned diagnostics themselves.
 func Source(src []byte) ([]byte, []*diag.Diagnostic, error) {
-	// Keep one lexer pass for comments; parsing itself is handled by the
-	// self-hosted front end through parser.ParseDiagnostics.
-	l := lexer.New(src)
-	_ = l.Lex()
-	file, diags := parser.ParseDiagnostics(src)
+	_, diags := parser.ParseDiagnostics(src)
 	for _, d := range diags {
 		if d.Severity == diag.Error {
 			return nil, diags, fmt.Errorf("cannot format file with parse errors")
 		}
 	}
+	out, _, err := selfhost.FormatSource(src)
+	if err == nil {
+		return out, diags, nil
+	}
+	return goPrinterFallback(src, diags)
+}
+
+// goPrinterFallback renders src with the legacy Go printer. It exists
+// so the self-host formatter can fall back without losing the parse
+// diagnostics or changing the public Source error contract.
+func goPrinterFallback(src []byte, diags []*diag.Diagnostic) ([]byte, []*diag.Diagnostic, error) {
+	l := lexer.New(src)
+	_ = l.Lex()
+	file, _ := parser.ParseDiagnostics(src)
 	p := newPrinter(l.Comments(), nil)
-	// Formatted output is within ~10% of input size for well-written
-	// code; preallocating avoids ~log2(N) buffer reallocations on large
-	// files.
 	p.buf.Grow(len(src))
 	p.printFile(file)
 	return p.bytes(), diags, nil

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -42,9 +43,12 @@ type Result struct {
 //
 // rr must be the resolver's output for f. chk is optional — when non-nil,
 // rules that need type information (Never-call dead code, ignored
-// Result/Option) are enabled. The lint pass is read-only over all inputs:
-// it never mutates the AST, symbol tables, or checker state.
-func File(f *ast.File, rr *resolve.Result, chk *check.Result) *Result {
+// Result/Option) are enabled. src carries the original source bytes; the
+// self-hosted linter runs over them in parallel and its findings are merged
+// into the returned result, so selfhost-authored rules (toolchain/lint.osty)
+// are part of the CLI output. The lint pass is read-only over all inputs: it
+// never mutates the AST, symbol tables, or checker state.
+func File(f *ast.File, src []byte, rr *resolve.Result, chk *check.Result) *Result {
 	if f == nil {
 		return &Result{}
 	}
@@ -69,7 +73,49 @@ func File(f *ast.File, rr *resolve.Result, chk *check.Result) *Result {
 	l.lintComplexity()
 	l.lintDocs()
 	l.filterSuppressed()
+	mergeSelfhostLint(l.result, src)
 	return l.result
+}
+
+// mergeSelfhostLint appends diagnostics from the Osty-authored lint pass
+// (toolchain/lint.osty) that the Go pass did not already emit at the same
+// code + position. Dedupe is by (Code, start offset) because the two
+// implementations occasionally phrase the same finding differently.
+func mergeSelfhostLint(result *Result, src []byte) {
+	if result == nil || len(src) == 0 {
+		return
+	}
+	seen := map[selfhostLintKey]bool{}
+	for _, d := range result.Diags {
+		seen[selfhostLintKeyOf(d)] = true
+	}
+	for _, d := range selfhost.LintDiagnostics(src) {
+		if d == nil {
+			continue
+		}
+		k := selfhostLintKeyOf(d)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		result.Diags = append(result.Diags, d)
+	}
+}
+
+type selfhostLintKey struct {
+	code  string
+	start int
+}
+
+func selfhostLintKeyOf(d *diag.Diagnostic) selfhostLintKey {
+	if d == nil {
+		return selfhostLintKey{}
+	}
+	key := selfhostLintKey{code: d.Code}
+	if len(d.Spans) > 0 {
+		key.start = d.Spans[0].Span.Start.Offset
+	}
+	return key
 }
 
 // Package runs lint over every file in pkg as one analysis unit.
@@ -148,6 +194,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 		l.lintNaming()
 		l.lintSimplify()
 		l.filterSuppressed()
+		mergeSelfhostLint(local, pf.Source)
 		diag.StampFile(local.Diags, pf.Path)
 		res.Diags = append(res.Diags, local.Diags...)
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -682,7 +682,7 @@ func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 	res := resolve.File(parsed.File, s.prelude)
 	canonicalSrc, _ := canonical.SourceWithMap(src, parsed.File)
 	chk := check.File(parsed.File, res, lspCheckOpts(canonicalSrc))
-	lr := lint.File(parsed.File, res, chk)
+	lr := lint.File(parsed.File, src, res, chk)
 	all := make([]*diag.Diagnostic, 0,
 		len(parsed.Diagnostics)+len(res.Diags)+len(chk.Diags)+len(lr.Diags))
 	all = append(all, parsed.Diagnostics...)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -505,7 +505,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 
 	// --- lint ---
 	t0 = time.Now()
-	lr := lint.File(file, res, chk)
+	lr := lint.File(file, src, res, chk)
 	r.Lint = lr
 	r.AllDiags = append(r.AllDiags, lr.Diags...)
 	emit(Stage{
@@ -688,7 +688,7 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 			TypeRefIdents: pf.TypeRefIdents,
 			FileScope:     pf.FileScope,
 		}
-		lr := lint.File(pf.File, fileRes, chk)
+		lr := lint.File(pf.File, pf.Source, fileRes, chk)
 		lintDiags = append(lintDiags, lr.Diags...)
 	}
 	r.AllDiags = append(r.AllDiags, lintDiags...)
@@ -914,7 +914,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 				TypeRefIdents: pf.TypeRefIdents,
 				FileScope:     pf.FileScope,
 			}
-			lr := lint.File(pf.File, fileRes, cr)
+			lr := lint.File(pf.File, pf.Source, fileRes, cr)
 			lintDiags = append(lintDiags, lr.Diags...)
 		}
 	}

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -246,7 +246,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			}
 			rr := qs.ResolveFile.Fetch(ctx, path)
 			chk := qs.CheckFile.Fetch(ctx, path)
-			return lint.File(pr.File, rr, chk)
+			return lint.File(pr.File, pr.Source, rr, chk)
 		},
 		hashLintResult,
 	)


### PR DESCRIPTION
## Summary

Wire the Osty-authored formatter and linter (compiled from `toolchain/formatter_ast.osty` and `toolchain/lint.osty` via bootstrap/gen) into the production CLI/LSP/CI path. Moves the self-host frontend count from **lex + parse + check** to **lex + parse + check + format + lint (partial)** — toolchain/*.osty is now authoritative for formatting, and selfhost lint findings show up in `osty lint` / LSP diagnostics.

## Why

Audited the repo and found that while `toolchain/formatter_ast.osty` (745줄) and `toolchain/lint.osty` (3957줄) exist in the selfhost bundle and compile cleanly into `internal/selfhost/generated.go`, none of their entry points were called from production. [internal/format/osty.go:20](internal/format/osty.go:20) explicitly documented the Osty formatter as drift-guard-only, and [internal/lsp/references.go](internal/lsp/references.go) / [cmd/osty/main.go:1305](cmd/osty/main.go:1305) ran the Go `internal/lint` implementation without ever invoking `selfhost.LintDiagnostics`. This PR flips those switches with minimal disruption.

## Commits

1. **feat(format): delegate Source to self-hosted Osty formatter** — `internal/format.Source` now routes through `selfhost.FormatSource`; the Go printer survives as `goPrinterFallback` for cases where the self-host formatter errors. Parse diagnostics are preserved via a separate `parser.ParseDiagnostics` pass so the public error contract (`error` only on parse errors, warnings still returned) stays intact.

2. **feat(lint): merge self-hosted lint diagnostics into lint.File output** — After the Go lint pass, `lint.File` now calls `selfhost.LintDiagnostics(src)` and appends any diagnostics the Go pass didn't already emit at the same `(Code, start offset)`. `lint.Package` does the same per file via `pf.Source`. Rather than swap wholesale (which would regress rules the Osty linter doesn't yet implement), this merges — so toolchain/lint.osty rules are live in production output, and we can tighten the Go side independently as Osty catches up.

## Call-site updates

- `lint.File` signature gained `src []byte`. Updated callers:
  - [internal/pipeline/pipeline.go](internal/pipeline/pipeline.go) (3 sites)
  - [cmd/osty/main.go](cmd/osty/main.go) (runLintEngine + runLintFileLegacy)
  - [internal/lsp/server.go](internal/lsp/server.go) (analyzeSingleFile)
  - [internal/query/osty/queries.go](internal/query/osty/queries.go) (LintFile query)
- `lint.Package` signature unchanged (uses `pf.Source` internally).
- `format.Source` / `format.OstySource` signatures unchanged.

## Test plan

- [x] `just front` — lexer, parser, resolve, check, diag, format, lint, pipeline all green.
- [x] `just short` — green except pre-existing E0757 `as?` waivers (parallel work on main, unrelated).
- [x] Existing drift-guard tests (`TestFormatSourceMatchesHostFormatter` in `internal/selfhost`) guard against format divergence; if the self-host formatter drifts, these fail first.
- [x] `AstbridgeLowerCount` sharing check in [cmd/osty/lint_legacy_baseline_test.go](cmd/osty/lint_legacy_baseline_test.go) still passes — lint still walks the existing `*ast.File`, doesn't trigger a second bridge lowering.

## Notes

- The lint merge strategy (append, dedupe by code+offset) is a deliberate choice over wholesale swap: a full swap would drop Go-only rules like type-info-dependent `lintIgnoredResult` / `lintDeadCode` expansions. Merging lets Osty lint contribute additively without regressing coverage. When `toolchain/lint.osty` reaches parity, the Go side can be deleted.
- Format full swap is safer because the two implementations were already proven equivalent by `TestFormatSourceMatchesHostFormatter`.
- Not in scope: the resolve swap (would require reshaping `selfhost.ResolveResult` flat arrays into `resolve.Result` scope tree + NodeID maps that downstream passes depend on — separate port, not a switch flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)