### PR TITLE
fix(selfhost): close 2 toolchain/ parity gaps (String.split + seedgen interp List.len)

### DIFF
--- a/internal/bootstrap/gen/decl.go
+++ b/internal/bootstrap/gen/decl.go
@@ -100,14 +100,27 @@ func (g *gen) emitFnDeclBody(fn *ast.FnDecl, name string) {
 
 	prevRet := g.currentRetType
 	prevRetGo := g.currentRetGo
+	prevParams := g.currentFnParams
 	g.currentRetType = fn.ReturnType
 	g.currentRetGo = ""
 	if fn.ReturnType != nil {
 		g.currentRetGo = g.goTypeExpr(fn.ReturnType)
 	}
+	if len(fn.Params) > 0 {
+		params := make(map[string]ast.Type, len(fn.Params))
+		for _, p := range fn.Params {
+			if p.Name != "" && p.Type != nil {
+				params[p.Name] = p.Type
+			}
+		}
+		g.currentFnParams = params
+	} else {
+		g.currentFnParams = nil
+	}
 	defer func() {
 		g.currentRetType = prevRet
 		g.currentRetGo = prevRetGo
+		g.currentFnParams = prevParams
 	}()
 
 	g.emitBlockAsReturn(fn.Body, fn.ReturnType != nil)

--- a/internal/bootstrap/gen/expr.go
+++ b/internal/bootstrap/gen/expr.go
@@ -2064,6 +2064,9 @@ func (g *gen) syntacticTypeSeen(e ast.Expr, seen map[ast.Node]bool) ast.Type {
 	case *ast.Ident:
 		sym := g.symbolFor(e)
 		if sym == nil {
+			if t, ok := g.currentFnParams[e.Name]; ok && t != nil {
+				return t
+			}
 			return nil
 		}
 		switch d := sym.Decl.(type) {

--- a/internal/bootstrap/gen/gen.go
+++ b/internal/bootstrap/gen/gen.go
@@ -228,6 +228,16 @@ type gen struct {
 	// rather than an explicit AST annotation.
 	currentRetGo string
 
+	// currentFnParams maps the enclosing fn's parameter names to their
+	// declared AST type. Populated on every fn body entry and restored on
+	// exit. Used by syntacticType as a last-resort fallback when the
+	// resolver did not stamp a NodeID on an Ident (e.g. inside a string
+	// interpolation segment — the self-host parser stores interp as raw
+	// text and re-parses lazily, producing nodes the resolver may see
+	// without a NodeID, so lookups by NodeID miss even though the name
+	// binds to a known parameter).
+	currentFnParams map[string]ast.Type
+
 	// retHintType / retHintGo carry the enclosing function's return type
 	// as a *tail-position* hint. Set by emitReturn and the tail of
 	// emitBlockAsReturn; consumed (and cleared) by emitMatch and the

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -650,7 +650,7 @@ pub fn hirLowerAnnotationStringLit(e: HirExpr) -> HirLowerStringParse {
 // ---- Internal digit helpers --------------------------------------
 
 fn hirLowerStripUnderscores(text: String) -> String {
-    strings.join(text.split("_"), "")
+    strings.join(strings.split(text, "_"), "")
 }
 
 fn hirLowerStripSign(text: String) -> String {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2609,7 +2609,7 @@ pub fn mirLowerParseIntLit(text: String) -> Int {
 }
 
 fn mirLowerStripUnderscores(text: String) -> String {
-    strings.join(text.split("_"), "")
+    strings.join(strings.split(text, "_"), "")
 }
 
 fn mirLowerStripSign(text: String) -> String {


### PR DESCRIPTION
## Summary
- **Gap 1 — `String.split` method form (E0703)**: `hir_lower.osty` and `mir_lower.osty` used `text.split("_")`; native checker only exposes `strings.split(text, "_")`. Fixed both call sites. After fix, `osty build toolchain/` exits 0 (previously 2 E0703 errors, 51,102/51,102 native-checker assertions already accepted).
- **Gap 2 — seedgen misses `List.len` inside string interpolation**: `"...{typeArgs.len()}..."` emitted `typeArgs.len()` as literal Go instead of `len(typeArgs)`. Root cause: interp-embedded `Ident` can miss `RefsByID[id.ID]`, so `symbolFor` → nil → `syntacticType` → `emitListMethodBySyntax` bails, and `emitCall` falls through to the generic path. Fix is contained to `internal/bootstrap/gen`: add a `currentFnParams` stack populated on fn body entry, consulted by `syntacticType` as a last-resort fallback for bare-Ident receivers.

## Why
`osty build toolchain/` (Go-built osty compiling its own self-hosted toolchain source) needed to be parity-green against the Go snapshots. These were the only two gaps in the frontend + bootstrap-transpile parity surface.

## Test plan
- [x] `osty build toolchain/` exits 0 (was 1; 2 E0703 → 0)
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) — 8/8 ok
- [x] `just verify-selfhost` — 2/2 ok (CoreSnapshotParity, PolicySnapshotParity)
- [x] Bootstrap transpile smokes — now **6/6 green** (was 3/6):
  - `TestToolchainHirSourcesTranspile` ✅ (was FAIL)
  - `TestToolchainMirSourcesTranspile` ✅ (was FAIL)
  - `TestMirSourcesBootstrapSmoke` ✅ (was FAIL)
  - `TestToolchainCheckerSourcesTranspile` ✅ (still)
  - `TestToolchainLLVMGenSourcesTranspile` ✅ (still)
  - `TestToolchainLlvmgenSupportSourcesTranspile` ✅ (still)
- [x] `internal/bootstrap/gen` unit tests — ok

## Reviewer notes
- Fix 2 stays in `internal/bootstrap/gen` (the Osty→Go bootstrap transpiler, isolated per CLAUDE.md — no new features, just a fallback that widens an existing semantic-miss path). No changes to resolver/checker or to the ID-stamping contract.
- The deeper fix (parser stamping NodeIDs on interp-embedded idents consistently, or resolver registering them post-reparse) is orthogonal and would let this fallback be dead code; leaving as-is for now since the fallback is cheap (`map[string]ast.Type` lookup) and matches the existing `letStmtForIdentPat` / `structFieldTypes` escape-hatch pattern in the same file.
- Gap 3 in the session summary (LLVM native-link codegen: `Int/Float/Char.toString`, generic closures) is **not** touched here — it's tracked multi-phase work in `LLVM_MIGRATION_PLAN.md` / memory `project_llvm_backend_limits.md`, and doesn't block toolchain/ since toolchain is a library (no `[[bin]]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)