### PR TITLE
[codex] Expand std.env LLVM lowering

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -991,6 +991,141 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryStdEnvGetReadsProcessEnv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    println(env.get("OSTY_ENV_GET_TEST") ?? "missing")
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Env = append(os.Environ(), "OSTY_ENV_GET_TEST=configured")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "configured\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdEnvVarsReadsProcessEnv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    let vars = env.vars()
+    println(vars.containsKey("OSTY_ENV_VARS_TEST"))
+    println(vars.get("OSTY_ENV_VARS_TEST") ?? "missing")
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Env = append(os.Environ(),
+		"OSTY_ENV_VARS_TEST=configured",
+		"OSTY_GC_THRESHOLD_BYTES=1",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "true\nconfigured\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdEnvRequireReadsProcessEnv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    match env.require("OSTY_ENV_REQUIRE_TEST") {
+        Ok(value) -> println(value),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	filteredEnv := []string{}
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "OSTY_ENV_REQUIRE_TEST=") {
+			continue
+		}
+		filteredEnv = append(filteredEnv, entry)
+	}
+	cmd.Env = append(filteredEnv, "OSTY_ENV_REQUIRE_TEST=configured")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "configured\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdEnvRequireReportsMissingKey(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    match env.require("OSTY_ENV_REQUIRE_TEST") {
+        Ok(value) -> println(value),
+        Err(err) -> {
+            println(err.message())
+            match err.source() {
+                Some(inner) -> println(inner.message()),
+                None -> println("none"),
+            }
+        },
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	filteredEnv := []string{}
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "OSTY_ENV_REQUIRE_TEST=") {
+			continue
+		}
+		filteredEnv = append(filteredEnv, entry)
+	}
+	cmd.Env = filteredEnv
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "environment variable not set: OSTY_ENV_REQUIRE_TEST\nnone\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinarySafepointsKeepManagedRootsAlive(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -87,6 +87,9 @@ typedef INIT_ONCE          osty_rt_once_t;
 #  include <pthread.h>
 #  include <sched.h>
 #  include <signal.h>
+#  if defined(__APPLE__)
+#    include <crt_externs.h>
+#  endif
 #  if defined(__STDC_NO_THREADS__) || defined(__APPLE__)
 #    define OSTY_RT_TLS __thread
 #  else
@@ -11847,14 +11850,26 @@ void osty_rt_test_snapshot(const char *name, const char *output, const char *sou
 /* std.env command-line argument surface.
  *
  * The emitter (see internal/llvmgen/stdlib_env_shim.go) routes the Osty
- * call `env.args()` to `osty_rt_env_args`, and when a script/binary's
- * package imports `std.env` the generated `main` is widened to
- * (i32 argc, ptr argv) and begins with a call to `osty_rt_env_args_init`.
+ * call `env.args()` to `osty_rt_env_args`, `env.get(name)` to
+ * `osty_rt_env_get`, `env.vars()` to `osty_rt_env_vars`, and when a
+ * script/binary's package imports `std.env` the generated `main` is
+ * widened to (i32 argc, ptr argv) and begins with a call to
+ * `osty_rt_env_args_init`.
+ *
  * The init call hands us the raw C argv; each `env.args()` invocation
  * materializes a fresh GC-managed List<String> by duplicating every
  * argv entry through the string allocator. Freshness matters because
  * the returned list is mutable from Osty and must not alias process
- * argv storage. */
+ * argv storage.
+ *
+ * `env.get(name)` similarly duplicates the C library getenv result so
+ * the returned Osty String owns its own managed storage. Missing keys
+ * surface as NULL, matching the ptr-backed `String?` lowering.
+ *
+ * `env.vars()` snapshots the current environment into a fresh
+ * `Map<String, String>`. Keys beginning with '=' are skipped on
+ * Windows to avoid the drive-current-directory pseudo-entries the CRT
+ * exposes through GetEnvironmentStringsA. */
 static int64_t osty_rt_env_stored_argc = 0;
 static char *const *osty_rt_env_stored_argv = NULL;
 
@@ -11876,5 +11891,97 @@ void *osty_rt_env_args(void) {
         char *copy = osty_rt_string_dup_site(raw, strlen(raw), "runtime.env.args.entry");
         osty_rt_list_push_ptr(out, copy);
     }
+    return out;
+}
+
+void *osty_rt_env_get(const char *name) {
+    const char *raw;
+    if (name == NULL) {
+        return NULL;
+    }
+    raw = getenv(name);
+    if (raw == NULL) {
+        return NULL;
+    }
+    return osty_rt_string_dup_site(raw, strlen(raw), "runtime.env.get");
+}
+
+#if defined(OSTY_RT_PLATFORM_WIN32)
+static LPCH osty_rt_env_entries_block(void) {
+    return GetEnvironmentStringsA();
+}
+#else
+static char *const *osty_rt_env_entries_posix(void) {
+#  if defined(__APPLE__)
+    char ***envp = _NSGetEnviron();
+    return envp == NULL ? NULL : (char *const *)(*envp);
+#  else
+    extern char **environ;
+    return (char *const *)environ;
+#  endif
+}
+#endif
+
+void *osty_rt_env_vars(void) {
+    void *out = osty_rt_map_new(OSTY_RT_ABI_STRING, OSTY_RT_ABI_PTR,
+                                (int64_t)sizeof(void *), NULL);
+    osty_gc_root_bind_v1(out);
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    LPCH block = osty_rt_env_entries_block();
+    LPCH cursor;
+    if (block != NULL) {
+        for (cursor = block; cursor[0] != '\0'; cursor += strlen(cursor) + 1) {
+            const char *entry = (const char *)cursor;
+            const char *eq = strchr(entry, '=');
+            size_t key_len;
+            const char *value_text;
+            char *key_copy;
+            char *value_copy;
+            if (eq == NULL || eq == entry) {
+                continue;
+            }
+            key_len = (size_t)(eq - entry);
+            value_text = eq + 1;
+            key_copy = osty_rt_string_dup_site(entry, key_len, "runtime.env.vars.key");
+            osty_gc_root_bind_v1(key_copy);
+            value_copy = osty_rt_string_dup_site(value_text, strlen(value_text), "runtime.env.vars.value");
+            osty_gc_root_bind_v1(value_copy);
+            osty_rt_map_insert_string(out, key_copy, &value_copy);
+            osty_gc_root_release_v1(value_copy);
+            osty_gc_root_release_v1(key_copy);
+        }
+        FreeEnvironmentStringsA(block);
+    }
+#else
+    char *const *entries = osty_rt_env_entries_posix();
+    if (entries != NULL) {
+        char *const *cursor;
+        for (cursor = entries; *cursor != NULL; cursor++) {
+            const char *entry = *cursor;
+            const char *eq;
+            size_t key_len;
+            const char *value_text;
+            char *key_copy;
+            char *value_copy;
+            if (entry == NULL) {
+                continue;
+            }
+            eq = strchr(entry, '=');
+            if (eq == NULL || eq == entry) {
+                continue;
+            }
+            key_len = (size_t)(eq - entry);
+            value_text = eq + 1;
+            key_copy = osty_rt_string_dup_site(entry, key_len, "runtime.env.vars.key");
+            osty_gc_root_bind_v1(key_copy);
+            value_copy = osty_rt_string_dup_site(value_text, strlen(value_text), "runtime.env.vars.value");
+            osty_gc_root_bind_v1(value_copy);
+            osty_rt_map_insert_string(out, key_copy, &value_copy);
+            osty_gc_root_release_v1(value_copy);
+            osty_gc_root_release_v1(key_copy);
+        }
+    }
+#endif
+    osty_gc_root_release_v1(out);
     return out;
 }

--- a/internal/llvmgen/error_fallback.go
+++ b/internal/llvmgen/error_fallback.go
@@ -1,0 +1,142 @@
+package llvmgen
+
+import (
+	"github.com/osty/osty/internal/ast"
+)
+
+var errorSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Error"},
+}
+
+var optionalErrorSourceTypeSingleton ast.Type = &ast.OptionalType{
+	Inner: errorSourceTypeSingleton,
+}
+
+func (g *generator) usesPtrBackedErrorFallback() bool {
+	return g.interfacesByName["Error"] == nil
+}
+
+func isErrorConstructorReceiver(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e != nil && e.Name == "Error"
+	case *ast.FieldExpr:
+		return e != nil && e.Name == "Error"
+	default:
+		return false
+	}
+}
+
+func (g *generator) staticPtrBackedErrorCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	if !g.usesPtrBackedErrorFallback() {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field == nil || field.IsOptional {
+		return nil, false
+	}
+	switch field.Name {
+	case "new":
+		if isErrorConstructorReceiver(field.X) {
+			return errorSourceTypeSingleton, true
+		}
+	case "message":
+		src, ok := g.staticExprSourceType(field.X)
+		if ok && namedTypeSingleSegment(src) == "Error" {
+			return &ast.NamedType{Path: []string{"String"}}, true
+		}
+	case "source":
+		src, ok := g.staticExprSourceType(field.X)
+		if ok && namedTypeSingleSegment(src) == "Error" {
+			return optionalErrorSourceTypeSingleton, true
+		}
+	}
+	return nil, false
+}
+
+func (g *generator) emitPtrBackedErrorCall(call *ast.CallExpr) (value, bool, error) {
+	if !g.usesPtrBackedErrorFallback() {
+		return value{}, false, nil
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field == nil || field.IsOptional {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "new":
+		if !isErrorConstructorReceiver(field.X) {
+			return value{}, false, nil
+		}
+		return g.emitPtrBackedErrorNewCall(call)
+	case "message":
+		src, ok := g.staticExprSourceType(field.X)
+		if !ok || namedTypeSingleSegment(src) != "Error" {
+			return value{}, false, nil
+		}
+		return g.emitPtrBackedErrorMessageCall(call)
+	case "source":
+		src, ok := g.staticExprSourceType(field.X)
+		if !ok || namedTypeSingleSegment(src) != "Error" {
+			return value{}, false, nil
+		}
+		return g.emitPtrBackedErrorSourceCall(call)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) emitPtrBackedErrorNewCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupportedf("call", "Error.new requires one positional String argument")
+	}
+	msg, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	msg = g.protectManagedTemporary("error.new.message", msg)
+	msg, err = g.loadIfPointer(msg)
+	if err != nil {
+		return value{}, true, err
+	}
+	if msg.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Error.new arg 1 type %s, want String", msg.typ)
+	}
+	msg.sourceType = errorSourceTypeSingleton
+	msg.gcManaged = true
+	msg.rootPaths = g.rootPathsForType(msg.typ)
+	return msg, true, nil
+}
+
+func (g *generator) emitPtrBackedErrorMessageCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "Error.message takes no arguments, got %d", len(call.Args))
+	}
+	field := call.Fn.(*ast.FieldExpr)
+	recv, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	recv = g.protectManagedTemporary("error.message.self", recv)
+	recv, err = g.loadIfPointer(recv)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Error.message receiver type %s, want Error", recv.typ)
+	}
+	recv.sourceType = &ast.NamedType{Path: []string{"String"}}
+	recv.gcManaged = true
+	recv.rootPaths = g.rootPathsForType(recv.typ)
+	return recv, true, nil
+}
+
+func (g *generator) emitPtrBackedErrorSourceCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "Error.source takes no arguments, got %d", len(call.Args))
+	}
+	return value{
+		typ:        "ptr",
+		ref:        "null",
+		sourceType: optionalErrorSourceTypeSingleton,
+	}, true, nil
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -6975,6 +6975,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitPtrBackedErrorCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitRuntimeFFICall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -2,9 +2,10 @@
 //
 // The pure-Osty stdlib body in internal/stdlib/modules/env.osty is a
 // placeholder returning an empty list; this shim bypasses it so real
-// argv reaches the program. Only `env.args()` is covered — other
-// std.env surface (get, require, vars, currentDir, …) still falls
-// through to LLVM015 and needs its own runtime helper + switch arm.
+// process environment reaches the program. `env.args()`,
+// `env.get(name)`, `env.require(name)`, and `env.vars()` are covered; the
+// remaining std.env surface (currentDir, setCurrentDir, set, unset, …)
+// still falls through to LLVM015 and needs its own runtime helper + switch arm.
 package llvmgen
 
 import (
@@ -13,12 +14,34 @@ import (
 
 const ostyRtEnvArgsSymbol = "osty_rt_env_args"
 const ostyRtEnvArgsInitSymbol = "osty_rt_env_args_init"
+const ostyRtEnvGetSymbol = "osty_rt_env_get"
+const ostyRtEnvVarsSymbol = "osty_rt_env_vars"
 
 // Shared across every env.args() call site so type inference doesn't
 // re-allocate an identical `List<String>` AST tree per reference.
 var stdEnvArgsSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"List"},
 	Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+}
+
+var stdEnvGetSourceTypeSingleton ast.Type = &ast.OptionalType{
+	Inner: &ast.NamedType{Path: []string{"String"}},
+}
+
+var stdEnvRequireResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		&ast.NamedType{Path: []string{"String"}},
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdEnvVarsSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Map"},
+	Args: []ast.Type{
+		&ast.NamedType{Path: []string{"String"}},
+		&ast.NamedType{Path: []string{"String"}},
+	},
 }
 
 func collectStdEnvAliases(file *ast.File) map[string]bool {
@@ -43,9 +66,90 @@ func collectStdEnvAliases(file *ast.File) map[string]bool {
 }
 
 func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
-	if !g.isStdEnvArgsCall(call) {
+	field, ok := g.stdEnvCallField(call)
+	if !ok {
 		return value{}, false, nil
 	}
+	switch field.Name {
+	case "args":
+		return g.emitStdEnvArgsCall(call)
+	case "get":
+		return g.emitStdEnvGetCall(call)
+	case "require":
+		return g.emitStdEnvRequireCall(call)
+	case "vars":
+		return g.emitStdEnvVarsCall(call)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdEnvCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdEnvCallField(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "args":
+		return value{
+			typ:            "ptr",
+			gcManaged:      true,
+			listElemTyp:    "ptr",
+			listElemString: true,
+			sourceType:     stdEnvArgsSourceTypeSingleton,
+		}, true
+	case "get":
+		return value{
+			typ:        "ptr",
+			gcManaged:  true,
+			sourceType: stdEnvGetSourceTypeSingleton,
+		}, true
+	case "require":
+		info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdEnvRequireResultSourceTypeSingleton,
+		}, true
+	case "vars":
+		return value{
+			typ:          "ptr",
+			gcManaged:    true,
+			mapKeyTyp:    "ptr",
+			mapValueTyp:  "ptr",
+			mapKeyString: true,
+			sourceType:   stdEnvVarsSourceTypeSingleton,
+		}, true
+	default:
+		return value{}, false
+	}
+}
+
+// staticStdEnvCallSourceType recovers the source-level env call result
+// so downstream Optional/List-aware emitters (`??`, `.get(i)`, …) can
+// keep threading the right source type.
+func (g *generator) staticStdEnvCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdEnvCallField(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "args":
+		return stdEnvArgsSourceTypeSingleton, true
+	case "get":
+		return stdEnvGetSourceTypeSingleton, true
+	case "require":
+		return stdEnvRequireResultSourceTypeSingleton, true
+	case "vars":
+		return stdEnvVarsSourceTypeSingleton, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) emitStdEnvArgsCall(call *ast.CallExpr) (value, bool, error) {
 	if len(call.Args) != 0 {
 		return value{}, true, unsupportedf("call", "env.args takes no arguments, got %d", len(call.Args))
 	}
@@ -63,41 +167,140 @@ func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
 	return v, true, nil
 }
 
-func (g *generator) stdEnvCallStaticResult(call *ast.CallExpr) (value, bool) {
-	if !g.isStdEnvArgsCall(call) {
-		return value{}, false
+func (g *generator) emitStdEnvGetCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "env.get expects 1 argument, got %d", len(call.Args))
 	}
-	return value{
-		typ:            "ptr",
-		gcManaged:      true,
-		listElemTyp:    "ptr",
-		listElemString: true,
-		sourceType:     stdEnvArgsSourceTypeSingleton,
-	}, true
+	arg := call.Args[0]
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, true, unsupported("call", "env.get requires one positional String argument")
+	}
+	name, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	name, err = g.loadIfPointer(name)
+	if err != nil {
+		return value{}, true, err
+	}
+	if name.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.get arg 1 type %s, want String", name.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtEnvGetSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtEnvGetSymbol, []*LlvmValue{toOstyValue(name)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = stdEnvGetSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
 }
 
-// staticStdEnvCallSourceType recovers the source-level `List<String>`
-// so `args.get(i) ?? "x"` reaches the Option<String> the `??` emitter
-// demands. Without it the coalesce path bails with
-// "?? left source type unknown".
-func (g *generator) staticStdEnvCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
-	if !g.isStdEnvArgsCall(call) {
+func (g *generator) emitStdEnvRequireCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "env.require expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, true, unsupported("call", "env.require requires one positional String argument")
+	}
+	info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "env.require Result<String, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != "ptr" || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.require currently needs ptr-backed Result<String, Error>, got ok=%s err=%s", info.okTyp, info.errTyp)
+	}
+	name, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	name = g.protectManagedTemporary("env.require.name", name)
+	name, err = g.loadIfPointer(name)
+	if err != nil {
+		return value{}, true, err
+	}
+	if name.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.require arg 1 type %s, want String", name.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtEnvGetSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(llvmStringRuntimeConcatSymbol(), "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	found := llvmCall(emitter, "ptr", ostyRtEnvGetSymbol, []*LlvmValue{toOstyValue(name)})
+	missing := llvmCompare(emitter, "eq", found, toOstyValue(value{typ: "ptr", ref: "null"}))
+	missingLabel := llvmNextLabel(emitter, "env.require.missing")
+	okLabel := llvmNextLabel(emitter, "env.require.ok")
+	contLabel := llvmNextLabel(emitter, "env.require.cont")
+	emitter.body = append(emitter.body, "  br i1 "+missing.name+", label %"+missingLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, missingLabel+":")
+	prefix := llvmStringLiteral(emitter, "environment variable not set: ")
+	message := llvmStringConcat(emitter, prefix, toOstyValue(name))
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		message,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		found,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+missingLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: stdEnvRequireResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdEnvVarsCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "env.vars takes no arguments, got %d", len(call.Args))
+	}
+	g.declareRuntimeSymbol(ostyRtEnvVarsSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtEnvVarsSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.mapKeyTyp = "ptr"
+	v.mapValueTyp = "ptr"
+	v.mapKeyString = true
+	v.sourceType = stdEnvVarsSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) stdEnvCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdEnvAliases) == 0 {
 		return nil, false
 	}
-	return stdEnvArgsSourceTypeSingleton, true
-}
-
-func (g *generator) isStdEnvArgsCall(call *ast.CallExpr) bool {
-	if call == nil || len(g.stdEnvAliases) == 0 {
-		return false
-	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok {
-		return false
+		return nil, false
 	}
 	alias, ok := field.X.(*ast.Ident)
 	if !ok || !g.stdEnvAliases[alias.Name] {
-		return false
+		return nil, false
 	}
-	return field.Name == "args"
+	return field, true
 }

--- a/internal/llvmgen/stdlib_env_shim_test.go
+++ b/internal/llvmgen/stdlib_env_shim_test.go
@@ -64,3 +64,98 @@ func TestMainSignatureStableWithoutStdEnv(t *testing.T) {
 		t.Fatalf("unexpected env init prologue in main without std.env:\n%s", got)
 	}
 }
+
+// `env.get(name)` should lower to the runtime helper and preserve the
+// Optional<String> source type so `??` keeps compiling on top.
+func TestStdEnvGetRoutesToRuntimeAndKeepsOptionalSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    let home = osenv.get("HOME") ?? "fallback"
+    println(home)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_get.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_get(ptr)",
+		"call ptr @osty_rt_env_get(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// `env.vars()` should lower to the runtime helper and preserve the
+// Map<String, String> source type so map methods keep compiling.
+func TestStdEnvVarsRoutesToRuntimeAndKeepsMapSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    let home = osenv.vars().get("HOME") ?? "fallback"
+    println(home)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_vars.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_vars()",
+		"call ptr @osty_rt_env_vars()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// `env.require(name)` should lower through env.get, materialize a
+// Result<String, Error>, and keep ptr-backed `Error.message()` usable
+// on the Err arm without needing std.error type injection.
+func TestStdEnvRequireRoutesToRuntimeAndKeepsErrorMessageFallback(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    match osenv.require("HOME") {
+        Ok(home) -> println(home),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_require.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_get(ptr)",
+		"call ptr @osty_rt_env_get(ptr",
+		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"call ptr @osty_rt_strings_Concat(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2491,6 +2491,9 @@ func (g *generator) bindResultMatchPayload(scrutinee value, info resultPatternIn
 	payloadValue := fromOstyValue(payload)
 	payloadValue.gcManaged = info.payloadType == "ptr"
 	payloadValue.rootPaths = g.rootPathsForType(info.payloadType)
+	if err := g.decorateValueFromSourceType(&payloadValue, builtinResultPayloadSourceType(scrutinee.sourceType, resultVariantName(info.tag))); err != nil {
+		return err
+	}
 	g.bindNamedLocal(info.payloadName, payloadValue, false)
 	return nil
 }

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -450,6 +450,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdEnvCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticPtrBackedErrorCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticCollectionMethodSourceType(e); ok {
 			return src, true
 		}


### PR DESCRIPTION
## Summary
- add LLVM lowering for `std.env.require(name)` alongside the existing `args/get/vars` paths
- add ptr-backed `Error` fallback support for `message()` and `source()` on the LLVM path
- preserve Result payload source types for statement-position `match` bindings so `Err(err)` method calls resolve correctly

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestStdEnv(ArgsRoutesToRuntime|GetRoutesToRuntimeAndKeepsOptionalSourceType|RequireRoutesToRuntimeAndKeepsErrorMessageFallback|VarsRoutesToRuntimeAndKeepsMapSourceType|MainSignatureStableWithoutStdEnv)$'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryStdEnv(GetReadsProcessEnv|RequireReadsProcessEnv|RequireReportsMissingKey|VarsReadsProcessEnv)$'`