### PR TITLE
fix(llvmgen,ir): Char/Byte MIR dispatch + generic closure param backfill

### DIFF
--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -15,16 +15,17 @@ func TestLowerClassifiesTopLevelLetRefsAsGlobal(t *testing.T) {
 		Name:  "g",
 		Value: &ast.IntLit{Text: "1"},
 	}
-	ref := &ast.Ident{Name: "g"}
+	ref := &ast.Ident{ID: 1, Name: "g"}
 	closure := &ast.ClosureExpr{Body: ref}
 	file := &ast.File{
 		Decls: []ast.Decl{global},
 		Stmts: []ast.Stmt{&ast.ExprStmt{X: closure}},
 	}
 	res := &resolve.Result{
-		Refs: map[*ast.Ident]*resolve.Symbol{
-			ref: {Name: "g", Kind: resolve.SymLet, Decl: global},
+		RefsByID: map[ast.NodeID]*resolve.Symbol{
+			ref.ID: {Name: "g", Kind: resolve.SymLet, Decl: global},
 		},
+		RefIdents: []*ast.Ident{ref},
 	}
 
 	mod, issues := Lower("main", file, res, nil)
@@ -56,7 +57,7 @@ func TestLowerClassifiesTopLevelLetRefsAsGlobal(t *testing.T) {
 }
 
 func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
-	some := &ast.Ident{Name: "Some"}
+	some := &ast.Ident{ID: 1, Name: "Some"}
 	call := &ast.CallExpr{
 		Fn: some,
 		Args: []*ast.Arg{{
@@ -67,9 +68,10 @@ func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
 		Stmts: []ast.Stmt{&ast.ExprStmt{X: call}},
 	}
 	res := &resolve.Result{
-		Refs: map[*ast.Ident]*resolve.Symbol{
-			some: {Name: "Some", Kind: resolve.SymBuiltin, Pub: true},
+		RefsByID: map[ast.NodeID]*resolve.Symbol{
+			some.ID: {Name: "Some", Kind: resolve.SymBuiltin, Pub: true},
 		},
+		RefIdents: []*ast.Ident{some},
 	}
 
 	mod, issues := Lower("main", file, res, nil)

--- a/internal/ir/subst.go
+++ b/internal/ir/subst.go
@@ -377,6 +377,23 @@ func subst(n Node, env SubstEnv) {
 		for _, p := range n.Params {
 			subst(p, env)
 		}
+		// Closure params whose Type was already nil before substitution
+		// (lowerClosure backfill missed them — e.g., when a generic
+		// fn is monomorphized and its inner closure's inferred FnType
+		// uses TypeVars that are tracked only on Closure.T, not on
+		// each Param.Type) would leave validator tripping on
+		// "Closure: param[i] nil Type". Re-run the same backfill that
+		// lowerClosure does, now that Closure.T has been substituted
+		// — so the FnType's substituted param slots are the source of
+		// truth.
+		if fnT, ok := n.T.(*FnType); ok && fnT != nil {
+			for i, p := range n.Params {
+				if p == nil || p.Type != nil || i >= len(fnT.Params) {
+					continue
+				}
+				p.Type = fnT.Params[i]
+			}
+		}
 		for _, c := range n.Captures {
 			c.T = substType(c.T, env)
 		}

--- a/internal/ir/subst_test.go
+++ b/internal/ir/subst_test.go
@@ -95,6 +95,41 @@ func TestSubstituteTypesReachesFnDeclParamsAndBody(t *testing.T) {
 	}
 }
 
+// A Closure whose Params were never type-backfilled (p.Type == nil)
+// is legitimate mid-pipeline input when an outer specialization carries
+// TypeVars through the closure's inferred FnType (Closure.T) but hadn't
+// had lowerClosure's backfill run. After substitution, the Closure case
+// must re-run the same backfill so validator's
+// "Closure: param[i] nil Type" wall is not reintroduced. Without this,
+// ≥2 test files in a package importing a generic fn with an inner
+// closure (e.g. fmt.joinWith<T>) trip the validator at IR merge time.
+func TestSubstituteClosureBackfillsNilParamTypesFromSubstitutedFnType(t *testing.T) {
+	// Closure with nil param Type; inferred FnType on Closure.T uses
+	// TypeVar T that substitution will resolve to Int.
+	ft := &FnType{Params: []Type{&TypeVar{Name: "T"}}, Return: TString}
+	closure := &Closure{
+		T:      ft,
+		Return: TString,
+		Params: []*Param{{Name: "n", Type: nil}},
+		Body:   &Block{Result: &StringLit{Parts: []StringPart{{IsLit: true, Lit: ""}}}},
+	}
+	fn := &FnDecl{
+		Name:   "takeClosure",
+		Return: TUnit,
+		Body:   &Block{Result: closure},
+	}
+	SubstituteTypes(fn, SubstEnv{"T": TInt})
+	if closure.Params[0].Type == nil {
+		t.Fatalf("closure param Type still nil after substitution backfill")
+	}
+	if closure.Params[0].Type != TInt {
+		t.Fatalf("closure param Type not substituted: got %T (%v)", closure.Params[0].Type, closure.Params[0].Type)
+	}
+	if errs := Validate(&Module{Package: "main", Decls: []Decl{fn}}); len(errs) != 0 {
+		t.Fatalf("Validate failed after backfill: %v", errs)
+	}
+}
+
 func TestSubstituteTypesRewritesCallExprTypeArgs(t *testing.T) {
 	// A generic call inside a specialization body needs its TypeArgs
 	// rewritten before the outer worklist picks them up. The call's own

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -5023,8 +5023,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 	}
 	switch prim.Kind {
 	case ir.PrimInt, ir.PrimInt8, ir.PrimInt16, ir.PrimInt32, ir.PrimInt64,
-		ir.PrimUInt8, ir.PrimUInt16, ir.PrimUInt32, ir.PrimUInt64,
-		ir.PrimByte, ir.PrimChar:
+		ir.PrimUInt8, ir.PrimUInt16, ir.PrimUInt32, ir.PrimUInt64:
 		reg, err := g.evalOperand(op, t)
 		if err != nil {
 			return nil, err
@@ -5033,6 +5032,28 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i64", name: reg}})
+		g.flushOstyEmitter(em)
+		return out, nil
+	case ir.PrimChar:
+		reg, err := g.evalOperand(op, t)
+		if err != nil {
+			return nil, err
+		}
+		sym := "osty_rt_char_to_string"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(i32)")
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i32", name: reg}})
+		g.flushOstyEmitter(em)
+		return out, nil
+	case ir.PrimByte:
+		reg, err := g.evalOperand(op, t)
+		if err != nil {
+			return nil, err
+		}
+		sym := "osty_rt_byte_to_string"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(i8)")
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i8", name: reg}})
 		g.flushOstyEmitter(em)
 		return out, nil
 	case ir.PrimBool:

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2825,6 +2825,51 @@ func TestGenerateFromMIRStringInterpolationConcatBoxesScalars(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRStringInterpolationBoxesCharAndByte pins the
+// Char (i32) and Byte (i8) dispatch in emitStringConcatBoxed so they
+// call osty_rt_char_to_string / osty_rt_byte_to_string instead of
+// being misrouted through osty_rt_int_to_string(i64) (which produces
+// malformed LLVM IR on width mismatch).
+func TestGenerateFromMIRStringInterpolationBoxesCharAndByte(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "render",
+		Return: ir.TString,
+		Params: []*ir.Param{
+			{Name: "c", Type: ir.TChar},
+			{Name: "b", Type: ir.TByte},
+		},
+		Body: &ir.Block{
+			Result: &ir.StringLit{
+				Parts: []ir.StringPart{
+					{Expr: &ir.Ident{Name: "c", Kind: ir.IdentParam, T: ir.TChar}},
+					{IsLit: true, Lit: "="},
+					{Expr: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TByte}},
+				},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/char_byte_concat.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_char_to_string(i32)",
+		"declare ptr @osty_rt_byte_to_string(i8)",
+		"call ptr @osty_rt_char_to_string(",
+		"call ptr @osty_rt_byte_to_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "@osty_rt_int_to_string") {
+		t.Fatalf("Char/Byte should not route through osty_rt_int_to_string:\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes(t *testing.T) {
 	diagT := &ir.NamedType{Name: "Diag"}
 	fn := &ir.FnDecl{


### PR DESCRIPTION
## Summary

Two narrow LLVM-backend fixes, each with focused regression coverage. Both surfaced while auditing Tier-A self-hosting blockers against the authoritative `docs/toolchain_llvm_status.md` (which turned out to be several commits ahead of `LLVM_MIGRATION_PLAN.md`'s Tier-A table).

### 1. MIR `emitStringConcatBoxed` Char/Byte width bug

`internal/llvmgen/mir_generator.go`'s string-interpolation box emitter was grouping `PrimChar` and `PrimByte` with the integer kinds, emitting `osty_rt_int_to_string(i64)` against registers that `evalOperand` produced as i32 / i8. On the MIR path that's malformed IR at the call site. Split into dedicated arms calling `osty_rt_char_to_string(i32)` and `osty_rt_byte_to_string(i8)` — the same runtime helpers the AST path has been using since PR #486.

The AST path (`emitPrimitiveToStringCall` + `emitInterpolationStringPiece`) was already correct; this only affects the MIR-direct emitter that opt-in builds take when `Options.UseMIR = true`.

### 2. Generic closure param Type lost through substitution

`internal/ir/subst.go`'s Closure case walked each Param with `substType(n.Type, env)` — but `substType(nil)` returns `nil`. So any closure whose `lowerClosure` backfill hadn't populated `param.Type` (an inner closure whose inferred `FnType` lived on `Closure.T` but whose per-param types weren't copied down) stayed nil after monomorphization. The IR validator then tripped with `Closure: param[i] nil Type` — visible today as "the first wall every fmt test hits whenever ≥2 test files in the package import `std.fmt`" (see the header comment in `examples/fmt_e2e/fmt_test.osty`).

Fix is a post-subst backfill using the same logic `lowerClosure` already has: if `p.Type == nil` and the substituted `Closure.T` is an `FnType` with matching arity, copy `fnT.Params[i]` into `p.Type`. The nil path is legitimate mid-pipeline input; the validator wall catches it only after monomorphization cloning, so the same defensive backfill belongs there too.

### 3. `internal/ir/lower_test.go` identity-model update

Two tests were constructing `resolve.Result{Refs: map[*ast.Ident]*Symbol{...}}`, which is the pre-transition pointer-identity shape. `Result` now uses `RefsByID: map[ast.NodeID]*Symbol` + `RefIdents []*ast.Ident` (the identity-model transition tracked in the self-host blocker memory). Tests updated to assign explicit `ID`s and use the new field names so `./internal/ir/...` builds again.

## Regression coverage

- `TestGenerateFromMIRStringInterpolationBoxesCharAndByte` — asserts the MIR path now emits both `osty_rt_char_to_string(i32)` and `osty_rt_byte_to_string(i8)` declarations and explicitly rejects routing through `osty_rt_int_to_string`.
- `TestSubstituteClosureBackfillsNilParamTypesFromSubstitutedFnType` — constructs a Closure with nil param Type and a `TypeVar T` on `Closure.T`, runs `SubstituteTypes{"T": TInt}`, asserts both that the param Type becomes `TInt` and that `Validate` succeeds on the enclosing module.

## What this does NOT include

While scoping the rest of the Tier-A backlog I measured two larger blockers that looked "Small" on first read but turned out to require dedicated PRs — flagging them here so they don't get picked up on the assumption they're in the same scope:

- **`OSTY_STDLIB_BODY_LOWER=1` as default**: flipping the gate turned 5 baseline backend failures into 16. Many tests assert shim-based emission patterns (`@osty_rt_strings_Concat` callsites) and there's a literal `TestStdlibBodyLoweringEnabledDefaultOff`. A real retirement needs flag flip + ≥16 test updates + shim deletion + perf measurement. Revert confirmed baseline-identical.
- **`toolchain/ci.osty` `use go "internal/cihost"` → `runtime.cabi.*`**: the last non-bootstrap `use go` in the toolchain. Scoping showed ~32 functions across 8 opaque types; needs a new C ABI wrapper layer (cgo ↔ C ↔ Osty) plus Osty-side opaque handle workarounds. Out of single-session scope; tracking separately.

## Test plan

- [x] `just front` passes.
- [x] `go test ./internal/ir/...` passes (including the new subst + restored lower tests).
- [x] `go test ./internal/llvmgen -run TestGenerateFromMIRStringInterpolation` — 3 of 4 pass; the 4th (`RecoversFieldExprTypes`) fails on `origin/main` without this patch and is unrelated.
- [x] `go test ./internal/backend/...` failure count unchanged from baseline (5 preexisting, none introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)