### PR TITLE
fix(mir): recompile match decision tree dropped by monomorph clone

### DIFF
--- a/internal/backend/llvm_match_decision_tree_test.go
+++ b/internal/backend/llvm_match_decision_tree_test.go
@@ -1,0 +1,123 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsResultMatchPayloadBinding exercises the MIR
+// regression where `match result { Ok(v) -> …, Err(e) -> … }` lost its
+// decision tree after monomorph-clone (cloneMatchStmt intentionally
+// drops Tree so backends recompile on demand). The MIR lowerer's
+// fallback path unconditionally gotoed armBlocks[0], which caused two
+// visible symptoms:
+//
+//   - the Err arm was unreachable (always printed the Ok case)
+//   - the payload binding `v` resolved to a const fn reference
+//     ("const fn v" in MIR; `@v` at LLVM level → global-ref clang error)
+//
+// The fix recompiles the decision tree in lowerMatch when it's nil.
+// This end-to-end test confirms the binary actually dispatches on the
+// discriminant and binds the Ok payload as an SSA register.
+func TestLLVMBackendBinaryRunsResultMatchPayloadBinding(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn tryParse(s: String) -> Result<Int, Error> {
+    Ok(s.toInt()?)
+}
+
+fn main() {
+    match tryParse("42") {
+        Ok(v) -> println(v),
+        Err(e) -> println(-1),
+    }
+    match tryParse("bad") {
+        Ok(v) -> println(v),
+        Err(e) -> println(-1),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n-1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsPrimitiveLiteralMatch covers the same
+// monomorph-drops-Tree regression on a primitive-literal `match x { 1
+// -> …, 2 -> …, _ -> … }`. Before the fix, every iteration printed
+// arm 0's body (the fallback's unconditional goto armBlocks[0]),
+// collapsing the switch to a no-op.
+func TestLLVMBackendBinaryRunsPrimitiveLiteralMatch(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    for x in [1, 2, 3] {
+        match x {
+            1 -> println(10),
+            2 -> println(20),
+            _ -> println(0),
+        }
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "10\n20\n0\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsCharLiteralMatch covers the Char (i32)
+// scrutinee case for the same regression — before the fix the MIR
+// emitter walled on "match scrutinee type i32, want enum tag" via the
+// legacy fallback, and the MIR path silently took arm 0.
+func TestLLVMBackendBinaryRunsCharLiteralMatch(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn classify(c: Char) -> Int {
+    match c {
+        'a' -> 1,
+        'z' -> 2,
+        _ -> 0,
+    }
+}
+
+fn main() {
+    println(classify('a'))
+    println(classify('m'))
+    println(classify('z'))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n0\n2\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1547,6 +1547,15 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 		_ = arm
 	}
 
+	// Monomorph clones drop Tree (cloneMatchStmt / cloneMatchExpr leave
+	// it nil) — recompile on demand so the post-mono MIR path still sees
+	// a specialised decision tree instead of the goto-armBlocks[0]
+	// fallback, which silently collapses every match on Result / enum
+	// payload bindings to "always take arm 0".
+	if tree == nil && scrutinee.Type() != nil {
+		tree = ir.CompileDecisionTree(scrutinee.Type(), arms)
+	}
+
 	// If we have a decision tree, use it.
 	if tree != nil {
 		ctx := &matchContext{


### PR DESCRIPTION
## Summary

- `cloneMatchStmt` / `cloneMatchExpr` intentionally leave `Tree` nil on the clone, expecting backends to recompile — MIR's `lowerMatch` never did, collapsing to an unconditional `goto armBlocks[0]`
- Recompile the decision tree via `ir.CompileDecisionTree` when it's nil, same as the HIR lowerer does on first lowering
- Single change fixes 3 separate user-visible gaps: Result-match payload binding (`@v` global-ref clang error), primitive literal match (always takes arm 0), and Char literal match (`i32` scrutinee wall)

## Repro (pre-fix)

```osty
fn tryParse(s: String) -> Result<Int, Error> { Ok(s.toInt()?) }
fn main() {
    match tryParse("42") {
        Ok(v) -> println(v),
        Err(e) -> println(-1),
    }
}
```

Pre-fix:
```
/tmp/.../main.ll:74: error: global variable reference must have pointer type
  call i32 (ptr, ...) @printf(ptr @.str.2, i64 @v)
                                               ^
```

Post-fix: prints `42`.

Same bug caused:

```osty
match x { 1 -> 10, 2 -> 20, _ -> 0 }   // for x in [1,2,3] printed 10,10,10 instead of 10,20,0
match c { 'a' -> 1, 'z' -> 2, _ -> 0 } // always took arm 0
```

## Root cause

`internal/ir/clone.go:560` `cloneMatchStmt` comments this behavior explicitly:

```go
// Decision tree carries backend-specific bookkeeping; leaving it
// nil here forces the monomorphised body to be recompiled on demand
// by backends that rely on arm-by-arm fallback.
```

The HIR lowerer runs `CompileDecisionTree(scrutinee.Type(), arms)` at AST→IR time. When monomorph clones for specialisation, it strips the tree. MIR's `lowerMatch` ([internal/mir/lower.go:1550](internal/mir/lower.go:1550)) had a fallback:

```go
if tree != nil {
    ctx.lowerTree(tree)
} else {
    bs.l.noteIssue("match without decision tree not lowered to MIR")
    if len(armBlocks) > 0 {
        bs.terminate(&GotoTerm{Target: armBlocks[0], SpanV: sp})
    }
}
```

That fallback unconditionally routes to arm 0 — no discriminant check, no payload bindings, every arm past 0 unreachable. Verified by dumping post-mono MIR:

```
bb0:
    _1 = call tryParse(const "42")
    goto -> bb2                  ← unconditional, no switch
bb2:
    _2 = intrinsic println(const fn v)   ← "const fn v" = FnConst fallback
```

Fix is a 3-line guard in `lowerMatch`: recompile when nil.

## Test plan

- [x] 3 new end-to-end binary-run tests (Result / Int-literal / Char-literal) — all pass with fix, all fail without it with the exact pre-fix symptoms
- [x] `go test ./internal/mir/` — green
- [x] `just front` — all 8 frontend packages green
- [x] `TestNativeToolchainMergedMIRErrTypeFloor` — ErrType count improves from 127 → 124 (floor 40; test still fails pre-existing, this is a partial recovery)
- [x] Pre-existing failures in `internal/backend/`, `internal/llvmgen/`, `internal/ir/` unchanged — same set before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)