### PR TITLE
[codex] Add std.env directory operations

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1123,6 +1124,116 @@ fn main() {
 	}
 	if got, want := string(output), "environment variable not set: OSTY_ENV_REQUIRE_TEST\nnone\n"; got != want {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdEnvCurrentDirReadsProcessWorkingDir(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    match env.currentDir() {
+        Ok(dir) -> println(dir),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	wantDir := filepath.Clean(t.TempDir())
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Dir = wantDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	got := string(output)
+	want := wantDir + "\n"
+	if got == want {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(wantDir); err == nil && got == filepath.Clean(resolved)+"\n" {
+		return
+	}
+	t.Fatalf("binary stdout = %q, want %q (or symlink-resolved equivalent)", got, want)
+}
+
+func TestLLVMBackendBinaryStdEnvSetCurrentDirChangesProcessWorkingDir(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(%q): %v", targetDir, err)
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, fmt.Sprintf(`use std.env
+
+fn main() {
+    match env.setCurrentDir(%q) {
+        Ok(_) -> {
+            match env.currentDir() {
+                Ok(dir) -> println(dir),
+                Err(err) -> println(err.message()),
+            }
+        },
+        Err(err) -> println(err.message()),
+    }
+}
+`, targetDir))
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	got := string(output)
+	want := filepath.Clean(targetDir) + "\n"
+	if got == want {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(targetDir); err == nil && got == filepath.Clean(resolved)+"\n" {
+		return
+	}
+	t.Fatalf("binary stdout = %q, want %q (or symlink-resolved equivalent)", got, want)
+}
+
+func TestLLVMBackendBinaryStdEnvSetCurrentDirReportsMissingPath(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	missingDir := filepath.Join(t.TempDir(), "missing")
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, fmt.Sprintf(`use std.env
+
+fn main() {
+    match env.setCurrentDir(%q) {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`, missingDir))
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	got := string(output)
+	if !strings.HasPrefix(got, "failed to set current directory: ") {
+		t.Fatalf("binary stdout = %q, want prefix %q", got, "failed to set current directory: ")
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -47,6 +47,7 @@
 #else
 #  include <sys/stat.h>
 #  include <sys/types.h>
+#  include <unistd.h>
 #  define OSTY_RT_MKDIR_ONE(path) mkdir((path), 0755)
 #endif
 
@@ -9104,9 +9105,6 @@ done:
  * ABI pass.
  * ====================================================================== */
 
-#if !defined(OSTY_RT_PLATFORM_WIN32)
-#  include <unistd.h>    /* sysconf(_SC_NPROCESSORS_ONLN) */
-#endif
 #if defined(__APPLE__)
 /* Forward-declare the sysctl entry we need instead of pulling in
  * <sys/sysctl.h>, which on macOS transitively requires BSD types
@@ -11851,9 +11849,11 @@ void osty_rt_test_snapshot(const char *name, const char *output, const char *sou
  *
  * The emitter (see internal/llvmgen/stdlib_env_shim.go) routes the Osty
  * call `env.args()` to `osty_rt_env_args`, `env.get(name)` to
- * `osty_rt_env_get`, `env.vars()` to `osty_rt_env_vars`, and when a
- * script/binary's package imports `std.env` the generated `main` is
- * widened to (i32 argc, ptr argv) and begins with a call to
+ * `osty_rt_env_get`, `env.vars()` to `osty_rt_env_vars`,
+ * `env.currentDir()` to `osty_rt_env_current_dir`,
+ * `env.setCurrentDir(path)` to `osty_rt_env_set_current_dir`, and
+ * when a script/binary's package imports `std.env` the generated
+ * `main` is widened to (i32 argc, ptr argv) and begins with a call to
  * `osty_rt_env_args_init`.
  *
  * The init call hands us the raw C argv; each `env.args()` invocation
@@ -11869,9 +11869,36 @@ void osty_rt_test_snapshot(const char *name, const char *output, const char *sou
  * `env.vars()` snapshots the current environment into a fresh
  * `Map<String, String>`. Keys beginning with '=' are skipped on
  * Windows to avoid the drive-current-directory pseudo-entries the CRT
- * exposes through GetEnvironmentStringsA. */
+ * exposes through GetEnvironmentStringsA.
+ *
+ * `env.currentDir()` duplicates the process working directory into a
+ * fresh managed String on success. On failure the helper returns NULL
+ * and leaves the platform error intact so `osty_rt_env_current_dir_error`
+ * can materialize a human-readable Error message.
+ *
+ * `env.setCurrentDir(path)` returns NULL on success and a freshly
+ * allocated error String on failure so the emitter can materialize
+ * `Result<(), Error>` without relying on process-global errno state
+ * after the runtime call returns. */
 static int64_t osty_rt_env_stored_argc = 0;
 static char *const *osty_rt_env_stored_argv = NULL;
+
+static void *osty_rt_env_error_message(const char *prefix, const char *detail, const char *site) {
+    const char *lhs = prefix == NULL ? "environment error" : prefix;
+    const char *rhs = (detail != NULL && detail[0] != '\0') ? detail : "unknown error";
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
+    size_t total = lhs_len + 2 + rhs_len;
+    char *buf = (char *)osty_rt_xmalloc(total + 1, site);
+    memcpy(buf, lhs, lhs_len);
+    buf[lhs_len] = ':';
+    buf[lhs_len + 1] = ' ';
+    memcpy(buf + lhs_len + 2, rhs, rhs_len);
+    buf[total] = '\0';
+    void *out = osty_rt_string_dup_site(buf, total, site);
+    free(buf);
+    return out;
+}
 
 void osty_rt_env_args_init(int64_t argc, void *argv) {
     osty_rt_env_stored_argc = argc < 0 ? 0 : argc;
@@ -11984,4 +12011,100 @@ void *osty_rt_env_vars(void) {
 #endif
     osty_gc_root_release_v1(out);
     return out;
+}
+
+void *osty_rt_env_current_dir(void) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    DWORD need = GetCurrentDirectoryA(0, NULL);
+    if (need == 0) {
+        return NULL;
+    }
+    char *buf = (char *)osty_rt_xmalloc((size_t)need + 1, "runtime.env.current_dir.buf");
+    DWORD written = GetCurrentDirectoryA(need + 1, buf);
+    if (written == 0 || written > need) {
+        DWORD code = GetLastError();
+        free(buf);
+        SetLastError(code);
+        return NULL;
+    }
+    void *out = osty_rt_string_dup_site(buf, (size_t)written, "runtime.env.current_dir");
+    free(buf);
+    return out;
+#else
+    size_t cap = 256;
+    for (;;) {
+        char *buf = (char *)osty_rt_xmalloc(cap, "runtime.env.current_dir.buf");
+        errno = 0;
+        if (getcwd(buf, cap) != NULL) {
+            void *out = osty_rt_string_dup_site(buf, strlen(buf), "runtime.env.current_dir");
+            free(buf);
+            return out;
+        }
+        int err = errno;
+        free(buf);
+        if (err != ERANGE) {
+            errno = err;
+            return NULL;
+        }
+        if (cap > ((size_t)-1) / 2) {
+            errno = ERANGE;
+            return NULL;
+        }
+        cap *= 2;
+    }
+#endif
+}
+
+void *osty_rt_env_current_dir_error(void) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    DWORD code = GetLastError();
+    char buf[96];
+    int written;
+    if (code == 0) {
+        return osty_rt_env_error_message("failed to get current directory", "unknown error", "runtime.env.current_dir.error");
+    }
+    written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+    if (written < 0) {
+        return osty_rt_env_error_message("failed to get current directory", "win32 error", "runtime.env.current_dir.error");
+    }
+    return osty_rt_env_error_message("failed to get current directory", buf, "runtime.env.current_dir.error");
+#else
+    int err = errno;
+    if (err == 0) {
+        return osty_rt_env_error_message("failed to get current directory", "unknown error", "runtime.env.current_dir.error");
+    }
+    return osty_rt_env_error_message("failed to get current directory", strerror(err), "runtime.env.current_dir.error");
+#endif
+}
+
+void *osty_rt_env_set_current_dir(const char *path) {
+    if (path == NULL) {
+        return osty_rt_env_error_message("failed to set current directory", "path is null", "runtime.env.set_current_dir.error");
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    if (SetCurrentDirectoryA(path)) {
+        return NULL;
+    }
+    DWORD code = GetLastError();
+    char buf[96];
+    int written;
+    if (code == 0) {
+        return osty_rt_env_error_message("failed to set current directory", "unknown error", "runtime.env.set_current_dir.error");
+    }
+    written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+    if (written < 0) {
+        return osty_rt_env_error_message("failed to set current directory", "win32 error", "runtime.env.set_current_dir.error");
+    }
+    return osty_rt_env_error_message("failed to set current directory", buf, "runtime.env.set_current_dir.error");
+#else
+    errno = 0;
+    if (chdir(path) == 0) {
+        return NULL;
+    }
+    int err = errno;
+    if (err == 0) {
+        return osty_rt_env_error_message("failed to set current directory", "unknown error", "runtime.env.set_current_dir.error");
+    }
+    return osty_rt_env_error_message("failed to set current directory", strerror(err), "runtime.env.set_current_dir.error");
+#endif
 }

--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -3,8 +3,9 @@
 // The pure-Osty stdlib body in internal/stdlib/modules/env.osty is a
 // placeholder returning an empty list; this shim bypasses it so real
 // process environment reaches the program. `env.args()`,
-// `env.get(name)`, `env.require(name)`, and `env.vars()` are covered; the
-// remaining std.env surface (currentDir, setCurrentDir, set, unset, …)
+// `env.get(name)`, `env.require(name)`, `env.vars()`,
+// `env.currentDir()`, and `env.setCurrentDir(path)` are covered; the
+// remaining std.env surface (set, unset, …)
 // still falls through to LLVM015 and needs its own runtime helper + switch arm.
 package llvmgen
 
@@ -16,6 +17,9 @@ const ostyRtEnvArgsSymbol = "osty_rt_env_args"
 const ostyRtEnvArgsInitSymbol = "osty_rt_env_args_init"
 const ostyRtEnvGetSymbol = "osty_rt_env_get"
 const ostyRtEnvVarsSymbol = "osty_rt_env_vars"
+const ostyRtEnvCurrentDirSymbol = "osty_rt_env_current_dir"
+const ostyRtEnvCurrentDirErrorSymbol = "osty_rt_env_current_dir_error"
+const ostyRtEnvSetCurrentDirSymbol = "osty_rt_env_set_current_dir"
 
 // Shared across every env.args() call site so type inference doesn't
 // re-allocate an identical `List<String>` AST tree per reference.
@@ -32,6 +36,16 @@ var stdEnvRequireResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
 	Args: []ast.Type{
 		&ast.NamedType{Path: []string{"String"}},
+		errorSourceTypeSingleton,
+	},
+}
+
+var unitTupleSourceTypeSingleton ast.Type = &ast.TupleType{}
+
+var stdEnvSetCurrentDirResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		unitTupleSourceTypeSingleton,
 		errorSourceTypeSingleton,
 	},
 }
@@ -79,6 +93,10 @@ func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdEnvRequireCall(call)
 	case "vars":
 		return g.emitStdEnvVarsCall(call)
+	case "currentDir":
+		return g.emitStdEnvCurrentDirCall(call)
+	case "setCurrentDir":
+		return g.emitStdEnvSetCurrentDirCall(call)
 	default:
 		return value{}, false, nil
 	}
@@ -122,6 +140,24 @@ func (g *generator) stdEnvCallStaticResult(call *ast.CallExpr) (value, bool) {
 			mapKeyString: true,
 			sourceType:   stdEnvVarsSourceTypeSingleton,
 		}, true
+	case "currentDir":
+		info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdEnvRequireResultSourceTypeSingleton,
+		}, true
+	case "setCurrentDir":
+		info, ok := builtinResultTypeFromAST(stdEnvSetCurrentDirResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdEnvSetCurrentDirResultSourceTypeSingleton,
+		}, true
 	default:
 		return value{}, false
 	}
@@ -144,6 +180,10 @@ func (g *generator) staticStdEnvCallSourceType(call *ast.CallExpr) (ast.Type, bo
 		return stdEnvRequireResultSourceTypeSingleton, true
 	case "vars":
 		return stdEnvVarsSourceTypeSingleton, true
+	case "currentDir":
+		return stdEnvRequireResultSourceTypeSingleton, true
+	case "setCurrentDir":
+		return stdEnvSetCurrentDirResultSourceTypeSingleton, true
 	default:
 		return nil, false
 	}
@@ -286,6 +326,133 @@ func (g *generator) emitStdEnvVarsCall(call *ast.CallExpr) (value, bool, error) 
 	v.mapValueTyp = "ptr"
 	v.mapKeyString = true
 	v.sourceType = stdEnvVarsSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdEnvCurrentDirCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "env.currentDir takes no arguments, got %d", len(call.Args))
+	}
+	info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "env.currentDir Result<String, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != "ptr" || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.currentDir currently needs ptr-backed Result<String, Error>, got ok=%s err=%s", info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(ostyRtEnvCurrentDirSymbol, "ptr", nil)
+	g.declareRuntimeSymbol(ostyRtEnvCurrentDirErrorSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	dir := llvmCall(emitter, "ptr", ostyRtEnvCurrentDirSymbol, nil)
+	missing := llvmCompare(emitter, "eq", dir, toOstyValue(value{typ: "ptr", ref: "null"}))
+	missingLabel := llvmNextLabel(emitter, "env.current_dir.err")
+	okLabel := llvmNextLabel(emitter, "env.current_dir.ok")
+	contLabel := llvmNextLabel(emitter, "env.current_dir.cont")
+	emitter.body = append(emitter.body, "  br i1 "+missing.name+", label %"+missingLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, missingLabel+":")
+	errText := llvmCall(emitter, "ptr", ostyRtEnvCurrentDirErrorSymbol, nil)
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		dir,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+missingLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: stdEnvRequireResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdEnvSetCurrentDirCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "env.setCurrentDir expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, true, unsupported("call", "env.setCurrentDir requires one positional String argument")
+	}
+	unitInfo := g.registerTupleType(nil, nil)
+	info, ok := builtinResultTypeFromAST(stdEnvSetCurrentDirResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "env.setCurrentDir Result<(), Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != unitInfo.typ || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.setCurrentDir currently needs Result<%s, ptr>, got ok=%s err=%s", unitInfo.typ, info.okTyp, info.errTyp)
+	}
+	path, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	path = g.protectManagedTemporary("env.setCurrentDir.path", path)
+	path, err = g.loadIfPointer(path)
+	if err != nil {
+		return value{}, true, err
+	}
+	if path.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.setCurrentDir arg 1 type %s, want String", path.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtEnvSetCurrentDirSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	errText := llvmCall(emitter, "ptr", ostyRtEnvSetCurrentDirSymbol, []*LlvmValue{toOstyValue(path)})
+	failed := llvmCompare(emitter, "ne", errText, toOstyValue(value{typ: "ptr", ref: "null"}))
+	errLabel := llvmNextLabel(emitter, "env.set_current_dir.err")
+	okLabel := llvmNextLabel(emitter, "env.set_current_dir.ok")
+	contLabel := llvmNextLabel(emitter, "env.set_current_dir.cont")
+	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, errLabel+":")
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: stdEnvSetCurrentDirResultSourceTypeSingleton,
+	}
 	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil
 }

--- a/internal/llvmgen/stdlib_env_shim_test.go
+++ b/internal/llvmgen/stdlib_env_shim_test.go
@@ -159,3 +159,69 @@ fn main() {
 		}
 	}
 }
+
+// `env.currentDir()` should lower to the runtime helpers and preserve
+// the Result<String, Error> source type so `match` keeps compiling.
+func TestStdEnvCurrentDirRoutesToRuntimeAndKeepsResultSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    match osenv.currentDir() {
+        Ok(dir) -> println(dir),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_current_dir.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_current_dir()",
+		"call ptr @osty_rt_env_current_dir()",
+		"declare ptr @osty_rt_env_current_dir_error()",
+		"call ptr @osty_rt_env_current_dir_error()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// `env.setCurrentDir(path)` should lower to the runtime helper and
+// preserve the Result<(), Error> source type so `match` keeps compiling.
+func TestStdEnvSetCurrentDirRoutesToRuntimeAndKeepsResultSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    match osenv.setCurrentDir("/tmp") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_set_current_dir.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_set_current_dir(ptr)",
+		"call ptr @osty_rt_env_set_current_dir(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add LLVM lowering for `std.env.currentDir()` and `std.env.setCurrentDir(path)`
- add runtime helpers for reading and mutating the process working directory with platform-specific error messages
- cover the new directory operations with IR-level and binary-level regression tests

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestStdEnv(ArgsRoutesToRuntime|GetRoutesToRuntimeAndKeepsOptionalSourceType|RequireRoutesToRuntimeAndKeepsErrorMessageFallback|VarsRoutesToRuntimeAndKeepsMapSourceType|CurrentDirRoutesToRuntimeAndKeepsResultSourceType|SetCurrentDirRoutesToRuntimeAndKeepsResultSourceType|MainSignatureStableWithoutStdEnv)$'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryStdEnv(GetReadsProcessEnv|RequireReadsProcessEnv|RequireReportsMissingKey|VarsReadsProcessEnv|CurrentDirReadsProcessWorkingDir|SetCurrentDirChangesProcessWorkingDir|SetCurrentDirReportsMissingPath)$'`