### PR TITLE
[codex] complete self-host HIR lowering

### DIFF
--- a/internal/selfhost/bundle/hir_bundle.go
+++ b/internal/selfhost/bundle/hir_bundle.go
@@ -16,8 +16,9 @@ package bundle
 // checker bundle to make the HIR tier transpile cleanly. `hir.osty`
 // defines the HIR node algebra; `hir_clone.osty` supplies deep-clone
 // helpers; `monomorph_pass.osty` provides the `hirCloneType` /
-// `hirCloneTypeList` primitives the clone layer calls; `hir_lower.osty`
-// is the AST → HIR lowerer plus annotation extractors.
+// `hirCloneTypeList` primitives the clone layer calls; `pmcompile.osty`
+// provides the match decision-tree compiler used by `hir_lower.osty`;
+// `hir_lower.osty` is the AST → HIR lowerer plus annotation extractors.
 //
 // `ty.osty` (the arena-based type surface HIR lowering consumes) is
 // already in the checker bundle, so we don't re-declare it here — the
@@ -28,6 +29,7 @@ var hirExtensionFiles = []string{
 	"toolchain/monomorph.osty",
 	"toolchain/monomorph_rewrite.osty",
 	"toolchain/monomorph_pass.osty",
+	"toolchain/pmcompile.osty",
 	"toolchain/hir_lower.osty",
 }
 

--- a/internal/selfhost/bundle/hir_bundle_test.go
+++ b/internal/selfhost/bundle/hir_bundle_test.go
@@ -18,6 +18,7 @@ func TestToolchainHirBundleIncludesHirLower(t *testing.T) {
 		"toolchain/hir.osty",
 		"toolchain/hir_clone.osty",
 		"toolchain/monomorph_pass.osty",
+		"toolchain/pmcompile.osty",
 		"toolchain/hir_lower.osty",
 	}
 	seen := make(map[string]bool)

--- a/internal/selfhost/hir_gen_test.go
+++ b/internal/selfhost/hir_gen_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 // TestToolchainHirSourcesTranspile verifies the HIR bundle (ty +
-// hir + hir_clone + hir_lower) goes through the bootstrap seedgen
-// transpiler and the resulting Go compiles. Mirrors the llvmgen
-// smoke test so regressions in any HIR file surface here.
+// hir + hir_clone + pmcompile + hir_lower) goes through the bootstrap
+// seedgen transpiler and the resulting Go compiles. Mirrors the
+// llvmgen smoke test so regressions in any HIR file surface here.
 func TestToolchainHirSourcesTranspile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping self-host hir transpile smoke test in short mode")

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -56,6 +56,11 @@ pub struct ElabCx {
     pub ast: AstFile,
     pub core: CoreArena,
     pub env: CheckEnv,
+    pub typedExprNodes: List<Int>,
+    pub typedExprCoreNodes: List<Int>,
+    pub typedExprTypes: List<Int>,
+    pub typedStmtNodes: List<Int>,
+    pub typedStmtCoreNodes: List<Int>,
 }
 
 pub struct InstSession {
@@ -71,6 +76,11 @@ pub fn newElabCx(ast: AstFile, tys: TyArena) -> ElabCx {
         ast,
         core: emptyCoreArena(),
         env,
+        typedExprNodes: [],
+        typedExprCoreNodes: [],
+        typedExprTypes: [],
+        typedStmtNodes: [],
+        typedStmtCoreNodes: [],
     }
 }
 
@@ -672,7 +682,7 @@ pub fn elabStmt(cx: ElabCx, idx: Int) -> Int {
         return -1
     }
     let node = astArenaNodeAt(cx.ast.arena, idx)
-    match node.kind {
+    let out = match node.kind {
         AstNLet -> elabLetStmt(cx, node),
         AstNAssign -> elabAssignStmt(cx, node),
         AstNReturn -> elabReturnStmt(cx, node),
@@ -684,6 +694,8 @@ pub fn elabStmt(cx: ElabCx, idx: Int) -> Int {
         AstNContinue -> coreContinueStmt(cx.core, node.start, node.end),
         _ -> elabExprAsStmt(cx, idx, node),
     }
+    elabRecordTypedStmt(cx, idx, out)
+    out
 }
 
 fn elabExprAsStmt(cx: ElabCx, idx: Int, node: AstNode) -> Int {
@@ -1043,7 +1055,51 @@ fn elabRecordTypedExpr(cx: ElabCx, idx: Int, out: ElabResult) {
     if idx < 0 || out.node < 0 || tyIsBad(cx.env.tys, out.ty) {
         return
     }
+    cx.typedExprNodes.push(idx)
+    cx.typedExprCoreNodes.push(out.node)
+    cx.typedExprTypes.push(out.ty)
     coreSetOrigin(cx.core, out.node, idx)
+}
+
+fn elabRecordTypedStmt(cx: ElabCx, idx: Int, coreIdx: Int) {
+    if idx < 0 || coreIdx < 0 {
+        return
+    }
+    cx.typedStmtNodes.push(idx)
+    cx.typedStmtCoreNodes.push(coreIdx)
+}
+
+pub fn elabTypedExprCoreAt(cx: ElabCx, idx: Int) -> Int {
+    let mut i = cx.typedExprNodes.len() - 1
+    for i >= 0 {
+        if cx.typedExprNodes[i] == idx {
+            return cx.typedExprCoreNodes[i]
+        }
+        i = i - 1
+    }
+    -1
+}
+
+pub fn elabTypedExprTyAt(cx: ElabCx, idx: Int) -> Int {
+    let mut i = cx.typedExprNodes.len() - 1
+    for i >= 0 {
+        if cx.typedExprNodes[i] == idx {
+            return cx.typedExprTypes[i]
+        }
+        i = i - 1
+    }
+    -1
+}
+
+pub fn elabTypedStmtCoreAt(cx: ElabCx, idx: Int) -> Int {
+    let mut i = cx.typedStmtNodes.len() - 1
+    for i >= 0 {
+        if cx.typedStmtNodes[i] == idx {
+            return cx.typedStmtCoreNodes[i]
+        }
+        i = i - 1
+    }
+    -1
 }
 
 /// astTypeToTy materialises an AST type node into the typed arena.

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -1,32 +1,27 @@
-// hir_lower.osty — self-hosted AST → HIR lowerer (Stage 5a scaffold).
+// hir_lower.osty — self-hosted AST → HIR lowerer.
 //
-// Osty port of `internal/ir/lower.go`. The Go side is 2625 lines
-// depending on four separate packages (ast / resolve / check /
-// types); porting it as a single blob isn't practical, so this
-// stage lands the plumbing first:
+// Self-hosted port of `internal/ir/lower.go`, adapted to the Osty
+// frontend pipeline:
 //
-//   - HirLowerer state struct (mirrors Go's `lowerer`)
-//   - Issue/diagnostic note buffer
-//   - TyArena → HirType bridge (equivalent of Go's
-//     `fromCheckerType` — the authoritative path for expression
-//     types, since the checker already typed every expression)
-//   - Primitive name / PrimKind → HirType helpers
-//     (`primitiveByName` / `primitiveByKind` equivalents)
-//   - joinDottedPath utility
-//   - hirLowerModule entry that seeds an empty HirModule
+//   - source is parsed into the arena-based `AstFile`
+//   - `elab.osty` provides typed Core nodes + `TyArena` types
+//   - `selfResolveAstFile` provides the name-resolution side tables
+//   - this file rebuilds typed `HirDecl` / `HirStmt` / `HirExpr`
+//     nodes from that combined view
 //
-// Stage 5b+ fills in AST-walking decl / stmt / expr lowerers once
-// the toolchain's AST / resolver shape is threaded into the bridge.
-// In the Osty self-host the "AST" input is the arena-based
-// `FrontParseTree` from `lexer.osty` / `parser.osty`, and the
-// "checker result" is `elab.osty` + `ty.osty`'s `TyArena`, so the
-// straight 1:1 port isn't meaningful — the real task is building
-// an adapter from those Osty-native shapes to `HirType` / `HirExpr`
-// / `HirStmt` nodes defined in `hir.osty`. That adapter is the
-// subject of Stage 5b/5c/5d.
+// The port is intentionally hybrid:
+//
+//   - declarations, blocks, patterns, annotations, and surface-only
+//     constructs come from AST so we keep source shape and spans
+//   - expression types come from `TyArena`
+//   - most expression lowering comes from typed Core so overload
+//     resolution and operator lowering match the checker
+//   - a few source-only details (for example optional field access,
+//     struct-literal shorthand/spread, and some match-arm shape) are
+//     recovered from AST origins recorded on Core nodes
 //
 // Relation to Go:
-//   - Go `lowerer`                        ↔ HirLowerer
+//   - Go `lowerer`                        ↔ HirLowerer / HirLowerContext
 //   - Go `fromCheckerType(t types.Type)`  ↔ hirLowerTyToHirType(arena, idx)
 //   - Go `primitiveByName(name)`          ↔ hirLowerPrimByName(name)
 //   - Go `primitiveByKind(k)`             ↔ hirLowerPrimByPk(pk)
@@ -72,17 +67,110 @@ pub fn hirLowerFinish(l: HirLowerer) -> HirModule {
     l.out
 }
 
-/// hirLowerModule is the entry public signature future stages will
-/// fill in. For Stage 5a it seeds an empty HirModule carrying the
-/// package name and any pre-registered issues — Stage 5b+ will thread
-/// the AST / resolver / checker inputs through and populate decls.
+pub struct HirLowerContext {
+    pub l: HirLowerer,
+    pub ast: AstFile,
+    pub elab: ElabCx,
+    pub resolved: SelfResolveResult,
+}
+
+pub struct HirLowerTypeScope {
+    pub genericNames: List<String>,
+    pub genericOwners: List<String>,
+    pub selfOwner: String,
+}
+
+pub struct HirLowerStmtScope {
+    pub loopResultName: String,
+    pub loopResultType: HirType,
+}
+
+fn hirLowerTypeScope(selfOwner: String) -> HirLowerTypeScope {
+    HirLowerTypeScope {
+        genericNames: [],
+        genericOwners: [],
+        selfOwner,
+    }
+}
+
+fn hirLowerStmtScope() -> HirLowerStmtScope {
+    HirLowerStmtScope {
+        loopResultName: "",
+        loopResultType: hirTypeInvalid(),
+    }
+}
+
+/// hirLowerModule remains as the zero-input wrapper used by the
+/// self-host transpile smoke tests. Real lowering flows through
+/// `hirLowerSource` / `hirLowerAstFile`.
 pub fn hirLowerModule(packageName: String) -> HirModule {
-    let l = hirLowerer(packageName)
-    hirLowerNote(
-        l,
-        "hir_lower Stage 5a scaffold: AST → HIR lowering not yet implemented",
-    )
-    hirLowerFinish(l)
+    hirLowerAstFile(packageName, astParse(""))
+}
+
+pub fn hirLowerSource(packageName: String, source: String) -> HirModule {
+    hirLowerAstFile(packageName, astParse(source))
+}
+
+pub fn hirLowerAstFile(packageName: String, ast: AstFile) -> HirModule {
+    let tys = emptyTyArena()
+    let elab = newElabCx(ast, tys)
+    elabFile(elab)
+    let resolved = selfResolveAstFile(ast)
+    let cx = HirLowerContext {
+        l: hirLowerer(packageName),
+        ast,
+        elab,
+        resolved,
+    }
+    hirLowerSeedModuleSpan(cx)
+    hirLowerCollectDiagnostics(cx)
+    for declIdx in cx.ast.arena.decls {
+        hirLowerTopLevel(cx, declIdx, hirLowerTypeScope(""))
+    }
+    hirLowerFinish(cx.l)
+}
+
+fn hirLowerSeedModuleSpan(cx: HirLowerContext) {
+    let decls = cx.ast.arena.decls
+    if decls.len() == 0 {
+        return
+    }
+    let firstIdx = decls[0]
+    let lastIdx = decls[decls.len() - 1]
+    let first = astArenaNodeAt(cx.ast.arena, firstIdx)
+    let last = astArenaNodeAt(cx.ast.arena, lastIdx)
+    cx.l.out.span = hirSpanFromOffsets(first.start, last.end)
+}
+
+fn hirLowerCollectDiagnostics(cx: HirLowerContext) {
+    for e in cx.ast.arena.errors {
+        let mut msg = if e.code != "" {
+            "parse[" + e.code + "] " + e.message
+        } else {
+            "parse: " + e.message
+        }
+        if e.note != "" {
+            msg = msg + " — note: " + e.note
+        }
+        if e.hint != "" {
+            msg = msg + " — hint: " + e.hint
+        }
+        hirLowerNote(cx.l, msg)
+    }
+    for d in cx.resolved.diagnostics {
+        let mut msg = if d.code != "" {
+            "resolve[" + d.code + "] " + d.message
+        } else {
+            "resolve: " + d.message
+        }
+        if d.hint != "" {
+            msg = msg + " — hint: " + d.hint
+        }
+        hirLowerNote(cx.l, msg)
+    }
+    for d in cx.elab.env.diagnostics {
+        hirLowerNote(cx.l, checkDiagRender(d))
+    }
 }
 
 // ====================================================================
@@ -2232,4 +2320,1999 @@ pub fn hirLowerAssembleErrorExpr(
 
 pub fn hirLowerAssembleErrorStmt(note: String, span: HirSpan) -> HirStmt {
     hirErrorStmt(note, span)
+}
+
+// ====================================================================
+// AST -> HIR lowering
+// ====================================================================
+
+fn hirLowerTopLevel(cx: HirLowerContext, idx: Int, typeScope: HirLowerTypeScope) {
+    if idx < 0 {
+        return
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind == AstNUseDecl {
+        hirLowerTopLevelUse(cx, idx, typeScope)
+        return
+    }
+    if node.kind == AstNFnDecl {
+        hirLowerAddFnDecl(cx.l, hirLowerFnDecl(cx, idx, "", typeScope))
+        return
+    }
+    if node.kind == AstNStructDecl {
+        hirLowerAddStructDecl(cx.l, hirLowerStructDecl(cx, idx, typeScope))
+        return
+    }
+    if node.kind == AstNEnumDecl {
+        hirLowerAddEnumDecl(cx.l, hirLowerEnumDecl(cx, idx, typeScope))
+        return
+    }
+    if node.kind == AstNInterfaceDecl {
+        hirLowerAddInterfaceDecl(cx.l, hirLowerInterfaceDecl(cx, idx, typeScope))
+        return
+    }
+    if node.kind == AstNTypeAlias {
+        hirLowerAddTypeAliasDecl(cx.l, hirLowerTypeAliasDecl(cx, idx, typeScope))
+        return
+    }
+    if node.kind == AstNLet || node.kind == AstNLetDecl {
+        let decl = hirLowerTopLevelLetDecl(cx, idx, typeScope)
+        if decl.name != "" {
+            hirLowerAddLetDecl(cx.l, decl)
+        }
+        return
+    }
+    let stmt = hirLowerStmt(cx, idx, hirLowerStmtScope(), typeScope)
+    if stmt.kind != HirStmtInvalid {
+        cx.l.out.script.push(stmt)
+    }
+}
+
+fn hirLowerTopLevelUse(cx: HirLowerContext, idx: Int, typeScope: HirLowerTypeScope) {
+    let _ = typeScope
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if astUseDeclIsGroup(node) {
+        for childIdx in node.children {
+            hirLowerTopLevelUse(cx, childIdx, hirLowerTypeScope(""))
+        }
+        return
+    }
+    hirLowerAddUseDecl(cx.l, hirLowerUseDecl(cx, idx))
+}
+
+fn hirLowerFnDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    owner: String,
+    parentScope: HirLowerTypeScope,
+) -> HirFnDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let genericScope = hirLowerTypeScopeWithGenerics(
+        cx.ast,
+        node.children2,
+        node.text,
+        parentScope.selfOwner,
+        parentScope,
+    )
+    let generics = hirLowerGenericParams(cx, node.children2, genericScope)
+    let annotations = hirLowerAnnotations(cx, node.extra, genericScope)
+    let mut params: List<HirParam> = []
+    let mut receiverMut = false
+    let mut i = 0
+    for paramIdx in node.children {
+        let param = astArenaNodeAt(cx.ast.arena, paramIdx)
+        if owner != "" && i == 0 && param.text == "self" && param.left < 0 {
+            receiverMut = param.flags == 1
+        } else {
+            params.push(hirLowerParam(cx, paramIdx, genericScope))
+        }
+        i = i + 1
+    }
+    let ret = hirLowerTypeFromAst(cx.ast, node.left, genericScope)
+    let body = if node.right >= 0 {
+        hirLowerBlockLike(cx, node.right, hirLowerStmtScope(), genericScope)
+    } else {
+        hirBlock(span)
+    }
+    hirLowerAssembleFnDecl(
+        node.text,
+        params,
+        ret,
+        generics,
+        body,
+        annotations,
+        receiverMut,
+        node.flags == 1,
+        span,
+    )
+}
+
+fn hirLowerStructDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    parentScope: HirLowerTypeScope,
+) -> HirStructDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let scope = hirLowerTypeScopeWithGenerics(cx.ast, node.children2, node.text, node.text, parentScope)
+    let generics = hirLowerGenericParams(cx, node.children2, scope)
+    let annotations = hirLowerAnnotations(cx, node.extra, scope)
+    let mut fields: List<HirField> = []
+    let mut methods: List<HirFnDecl> = []
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNField_ {
+            fields.push(hirLowerStructFieldDecl(cx, memberIdx, scope))
+        } else if member.kind == AstNFnDecl {
+            methods.push(hirLowerFnDecl(cx, memberIdx, node.text, scope))
+        }
+    }
+    hirLowerAssembleStructDecl(
+        node.text,
+        fields,
+        methods,
+        generics,
+        node.flags == 1,
+        annotations,
+        span,
+    )
+}
+
+fn hirLowerEnumDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    parentScope: HirLowerTypeScope,
+) -> HirEnumDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let scope = hirLowerTypeScopeWithGenerics(cx.ast, node.children2, node.text, node.text, parentScope)
+    let generics = hirLowerGenericParams(cx, node.children2, scope)
+    let mut variants: List<HirVariant> = []
+    let mut methods: List<HirFnDecl> = []
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNVariant {
+            variants.push(hirLowerEnumVariantDecl(cx, memberIdx, scope))
+        } else if member.kind == AstNFnDecl {
+            methods.push(hirLowerFnDecl(cx, memberIdx, node.text, scope))
+        }
+    }
+    hirLowerAssembleEnumDecl(
+        node.text,
+        variants,
+        methods,
+        generics,
+        node.flags == 1,
+        span,
+    )
+}
+
+fn hirLowerInterfaceDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    parentScope: HirLowerTypeScope,
+) -> HirInterfaceDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let scope = hirLowerTypeScopeWithGenerics(cx.ast, node.children2, node.text, node.text, parentScope)
+    let generics = hirLowerGenericParams(cx, node.children2, scope)
+    let mut methods: List<HirFnDecl> = []
+    let mut extends: List<HirType> = []
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            methods.push(hirLowerFnDecl(cx, memberIdx, node.text, scope))
+        } else if member.kind == AstNType {
+            extends.push(hirLowerTypeFromAst(cx.ast, memberIdx, scope))
+        }
+    }
+    hirLowerAssembleInterfaceDecl(
+        node.text,
+        methods,
+        extends,
+        generics,
+        node.flags == 1,
+        span,
+    )
+}
+
+fn hirLowerTypeAliasDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    parentScope: HirLowerTypeScope,
+) -> HirTypeAliasDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let scope = hirLowerTypeScopeWithGenerics(
+        cx.ast,
+        node.children,
+        node.text,
+        parentScope.selfOwner,
+        parentScope,
+    )
+    let generics = hirLowerGenericParams(cx, node.children, scope)
+    let target = hirLowerTypeFromAst(cx.ast, node.left, scope)
+    hirLowerAssembleTypeAliasDecl(
+        node.text,
+        target,
+        generics,
+        node.flags == 1,
+        span,
+    )
+}
+
+fn hirLowerTopLevelLetDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirLetDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let name = hirLowerTopLevelLetName(cx.ast, node.left)
+    if name == "" {
+        hirLowerNote(
+            cx.l,
+            "hir_lower: unsupported top-level destructuring let at " + hirLowerSpanText(span),
+        )
+        return hirLetDecl("", hirTypeInvalid(), span)
+    }
+    let typeIdx = hirLowerAstFirst(node.children)
+    let typ = hirLowerTypeFromAst(cx.ast, typeIdx, typeScope)
+    let hasValue = node.right >= 0
+    let value = if hasValue {
+        hirLowerExpr(cx, node.right, typeScope)
+    } else {
+        hirExprInvalid()
+    }
+    hirLowerAssembleLetDecl(name, typ, hasValue, value, node.flags == 1, false, span)
+}
+
+fn hirLowerUseDecl(cx: HirLowerContext, idx: Int) -> HirUseDecl {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let alias = hirLowerUseAlias(cx.ast, node)
+    if astUseDeclIsGo(node) {
+        let mut fns: List<HirFnDecl> = []
+        for bodyIdx in node.children {
+            let body = astArenaNodeAt(cx.ast.arena, bodyIdx)
+            if body.kind == AstNFnDecl {
+                fns.push(hirLowerFnDecl(cx, bodyIdx, "", hirLowerTypeScope("")))
+            } else {
+                hirLowerNote(
+                    cx.l,
+                    "hir_lower: use go body item not representable in HIR use decl: "
+                        + astNodeKindName(body.kind),
+                )
+            }
+        }
+        return hirLowerAssembleUseDeclGo(
+            alias,
+            node.text,
+            hirLowerDecodeStringToken(node.text).body,
+            fns,
+            span,
+        )
+    }
+    if hirLowerPathStartsWithRuntime(node.text) {
+        return hirLowerAssembleUseDeclRuntime(alias, node.text, node.text, span)
+    }
+    hirLowerAssembleUseDecl(hirLowerUsePathSegments(node.text), alias, node.text, span)
+}
+
+fn hirLowerStructFieldDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirField {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let annotations = hirLowerAnnotations(cx, node.extra, typeScope)
+    let typ = hirLowerTypeFromAst(cx.ast, node.right, typeScope)
+    let hasDefault = node.left >= 0
+    let defaultValue = if hasDefault {
+        hirLowerExpr(cx, node.left, typeScope)
+    } else {
+        hirExprInvalid()
+    }
+    hirLowerAssembleField(
+        node.text,
+        typ,
+        hasDefault,
+        defaultValue,
+        node.flags == 1,
+        annotations,
+        span,
+    )
+}
+
+fn hirLowerEnumVariantDecl(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirVariant {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let annotations = hirLowerAnnotations(cx, node.extra, typeScope)
+    let mut payload: List<HirType> = []
+    for childIdx in node.children {
+        payload.push(hirLowerTypeFromAst(cx.ast, childIdx, typeScope))
+    }
+    hirLowerAssembleVariant(node.text, payload, annotations, span)
+}
+
+fn hirLowerParam(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirParam {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let typ = if node.right >= 0 {
+        hirLowerTypeFromAst(cx.ast, node.right, typeScope)
+    } else {
+        hirTypeErr()
+    }
+    let hasDefault = node.left >= 0 && node.text != ""
+    let defaultValue = if hasDefault {
+        hirLowerExpr(cx, node.left, typeScope)
+    } else {
+        hirExprInvalid()
+    }
+    if node.text != "" {
+        return hirLowerAssembleParam(node.text, typ, hasDefault, defaultValue, span)
+    }
+    let pattern = if node.left >= 0 {
+        hirLowerPattern(cx, node.left, typeScope)
+    } else {
+        hirPatternInvalid()
+    }
+    hirLowerAssembleParamDestructured(pattern, typ, span)
+}
+
+fn hirLowerClosureParam(
+    cx: HirLowerContext,
+    idx: Int,
+    closureTy: HirType,
+    paramPos: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirParam {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let inferred = hirLowerFnParamTypeAt(closureTy, paramPos)
+    let typ = if node.right >= 0 {
+        hirLowerTypeFromAst(cx.ast, node.right, typeScope)
+    } else {
+        inferred
+    }
+    let span = hirLowerSpanFromNode(node)
+    if node.text != "" {
+        return hirLowerAssembleParam(node.text, typ, false, hirExprInvalid(), span)
+    }
+    let pattern = hirLowerPattern(cx, node.left, typeScope)
+    hirLowerAssembleParamDestructured(pattern, typ, span)
+}
+
+fn hirLowerStmt(
+    cx: HirLowerContext,
+    idx: Int,
+    stmtScope: HirLowerStmtScope,
+    typeScope: HirLowerTypeScope,
+) -> HirStmt {
+    if idx < 0 {
+        return hirStmtInvalid()
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.kind == AstNLet {
+        let pattern = hirLowerPattern(cx, node.left, typeScope)
+        let typ = hirLowerTypeFromAst(cx.ast, hirLowerAstFirst(node.children), typeScope)
+        let hasValue = node.right >= 0
+        let value = if hasValue {
+            hirLowerExpr(cx, node.right, typeScope)
+        } else {
+            hirExprInvalid()
+        }
+        return hirLowerAssembleLetStmt(pattern, typ, hasValue, value, node.flags == 1, span)
+    }
+    if node.kind == AstNAssign {
+        let target = hirLowerExpr(cx, node.left, typeScope)
+        let value = hirLowerExpr(cx, node.right, typeScope)
+        return hirLowerAssembleAssignStmt(
+            hirLowerAssignOpFromFrontToken(node.op),
+            [target],
+            value,
+            span,
+        )
+    }
+    if node.kind == AstNReturn {
+        if node.left >= 0 {
+            return hirReturnStmt(hirLowerExpr(cx, node.left, typeScope), span)
+        }
+        return hirReturnStmtUnit(span)
+    }
+    if node.kind == AstNBreak {
+        if node.extra >= 0 {
+            hirLowerNote(cx.l, "hir_lower: labeled break lowered as unlabeled break")
+        }
+        if node.left >= 0 {
+            if stmtScope.loopResultName != "" {
+                let mut block = hirBlock(span)
+                let target = hirIdent(
+                    stmtScope.loopResultName,
+                    HirIdentLocal,
+                    stmtScope.loopResultType,
+                    span,
+                )
+                let assign = hirAssignStmt(
+                    HirAssignEq,
+                    target,
+                    hirLowerExpr(cx, node.left, typeScope),
+                    span,
+                )
+                hirBlockAppend(block, assign)
+                hirBlockAppend(block, hirBreakStmt(span))
+                return hirBlockStmt(block, span)
+            }
+            hirLowerNote(cx.l, "hir_lower: break with value is not representable in HIR statement form")
+            return hirLowerAssembleErrorStmt("break with value is unsupported here", span)
+        }
+        return hirBreakStmt(span)
+    }
+    if node.kind == AstNContinue {
+        if node.extra >= 0 {
+            hirLowerNote(cx.l, "hir_lower: labeled continue lowered as unlabeled continue")
+        }
+        return hirContinueStmt(span)
+    }
+    if node.kind == AstNDefer {
+        return hirDeferStmt(
+            hirLowerDeferredBlock(cx, node.left, typeScope),
+            span,
+        )
+    }
+    if node.kind == AstNFor {
+        return hirLowerForStmt(cx, idx, stmtScope, typeScope)
+    }
+    if node.kind == AstNChanSend {
+        return hirChanSendStmt(
+            hirLowerExpr(cx, node.left, typeScope),
+            hirLowerExpr(cx, node.right, typeScope),
+            span,
+        )
+    }
+    if node.kind == AstNExprStmt {
+        let e = hirLowerExpr(cx, node.left, typeScope)
+        if e.kind == HirExprBlock && e.blockBody.len() > 0 {
+            return hirBlockStmt(e.blockBody[0], span)
+        }
+        let ifStmt = hirLowerPromoteIfExprToStmt(e)
+        if ifStmt.promoted {
+            return ifStmt.stmt
+        }
+        let matchStmt = hirLowerPromoteMatchExprToStmt(e)
+        if matchStmt.promoted {
+            return matchStmt.stmt
+        }
+        return hirExprStmt(e, span)
+    }
+    if node.kind == AstNBlock {
+        return hirBlockStmt(hirLowerBlockFromAst(cx, idx, stmtScope, typeScope), span)
+    }
+    hirExprStmt(hirLowerExpr(cx, idx, typeScope), span)
+}
+
+fn hirLowerForStmt(
+    cx: HirLowerContext,
+    idx: Int,
+    stmtScope: HirLowerStmtScope,
+    typeScope: HirLowerTypeScope,
+) -> HirStmt {
+    let _ = stmtScope
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.extra >= 0 {
+        hirLowerNote(cx.l, "hir_lower: loop labels are not preserved in HIR")
+    }
+    let patIdx = hirLowerAstChildAt(node.children, 0)
+    let iterIdx = hirLowerAstChildAt(node.children, 1)
+    let body = hirLowerBlockFromAst(cx, node.right, hirLowerStmtScope(), typeScope)
+    if node.text == "infinite" {
+        return hirForInfiniteStmt(body, span)
+    }
+    if node.text == "cond" {
+        return hirForWhileStmt(hirLowerExpr(cx, node.left, typeScope), body, span)
+    }
+    if node.text == "forlet" {
+        let pattern = hirLowerPattern(cx, patIdx, typeScope)
+        let scrutinee = hirLowerExpr(cx, node.left, typeScope)
+        let mut elseBlock = hirBlock(span)
+        hirBlockAppend(elseBlock, hirBreakStmt(span))
+        let ifLetExpr = hirLowerAssembleIfLetExpr(
+            pattern,
+            scrutinee,
+            body,
+            true,
+            elseBlock,
+            hirTUnit(),
+            span,
+        )
+        let mut loopBody = hirBlock(span)
+        hirBlockAppend(loopBody, hirExprStmt(ifLetExpr, span))
+        return hirForInfiniteStmt(loopBody, span)
+    }
+    if node.text == "forin" {
+        let pattern = hirLowerPattern(cx, patIdx, typeScope)
+        if iterIdx >= 0 {
+            let iterNode = astArenaNodeAt(cx.ast.arena, iterIdx)
+            if iterNode.kind == AstNRange {
+                if hirLowerAstRangeHasStep(iterNode) {
+                    hirLowerNote(cx.l, "hir_lower: range step is not representable in HIR and will be ignored")
+                }
+                let start = if iterNode.left >= 0 {
+                    hirLowerExpr(cx, iterNode.left, typeScope)
+                } else {
+                    hirExprInvalid()
+                }
+                let end = if iterNode.right >= 0 {
+                    hirLowerExpr(cx, iterNode.right, typeScope)
+                } else {
+                    hirExprInvalid()
+                }
+                return hirLowerAssembleForStmt(
+                    true,
+                    pattern,
+                    false,
+                    hirExprInvalid(),
+                    false,
+                    hirExprInvalid(),
+                    true,
+                    start,
+                    end,
+                    hirLowerAstRangeInclusive(iterNode),
+                    body,
+                    span,
+                )
+            }
+        }
+        let iter = hirLowerExpr(cx, iterIdx, typeScope)
+        return hirLowerAssembleForStmt(
+            true,
+            pattern,
+            false,
+            hirExprInvalid(),
+            true,
+            iter,
+            false,
+            hirExprInvalid(),
+            hirExprInvalid(),
+            false,
+            body,
+            span,
+        )
+    }
+    hirForInfiniteStmt(body, span)
+}
+
+fn hirLowerBlockFromAst(
+    cx: HirLowerContext,
+    idx: Int,
+    stmtScope: HirLowerStmtScope,
+    typeScope: HirLowerTypeScope,
+) -> HirBlock {
+    if idx < 0 {
+        return hirBlock(hirNoSpan())
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.kind != AstNBlock {
+        return hirLowerBlockLike(cx, idx, stmtScope, typeScope)
+    }
+    let mut out = hirBlock(span)
+    let lastIdx = if node.children.len() > 0 {
+        node.children[node.children.len() - 1]
+    } else {
+        -1
+    }
+    for stmtIdx in node.children {
+        let stmt = astArenaNodeAt(cx.ast.arena, stmtIdx)
+        if stmtIdx == lastIdx && stmt.kind == AstNExprStmt {
+            hirBlockSetResult(out, hirLowerExpr(cx, stmt.left, typeScope))
+        } else {
+            hirBlockAppend(out, hirLowerStmt(cx, stmtIdx, stmtScope, typeScope))
+        }
+    }
+    out
+}
+
+fn hirLowerBlockLike(
+    cx: HirLowerContext,
+    idx: Int,
+    stmtScope: HirLowerStmtScope,
+    typeScope: HirLowerTypeScope,
+) -> HirBlock {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind == AstNBlock {
+        return hirLowerBlockFromAst(cx, idx, stmtScope, typeScope)
+    }
+    let mut out = hirBlock(hirLowerSpanFromNode(node))
+    hirBlockSetResult(out, hirLowerExpr(cx, idx, typeScope))
+    out
+}
+
+fn hirLowerDeferredBlock(
+    cx: HirLowerContext,
+    exprIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirBlock {
+    let span = hirLowerSpanFromAst(cx.ast, exprIdx)
+    let node = astArenaNodeAt(cx.ast.arena, exprIdx)
+    if node.kind == AstNBlock {
+        return hirLowerBlockFromAst(cx, exprIdx, hirLowerStmtScope(), typeScope)
+    }
+    let mut block = hirBlock(span)
+    let e = hirLowerExpr(cx, exprIdx, typeScope)
+    let ifStmt = hirLowerPromoteIfExprToStmt(e)
+    if ifStmt.promoted {
+        hirBlockAppend(block, ifStmt.stmt)
+        return block
+    }
+    let matchStmt = hirLowerPromoteMatchExprToStmt(e)
+    if matchStmt.promoted {
+        hirBlockAppend(block, matchStmt.stmt)
+        return block
+    }
+    hirBlockAppend(block, hirExprStmt(e, span))
+    block
+}
+
+fn hirLowerExpr(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    if idx < 0 {
+        return hirExprInvalid()
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind == AstNParen {
+        return hirLowerExpr(cx, node.left, typeScope)
+    }
+    if node.kind == AstNClosure {
+        return hirLowerClosureExpr(cx, idx, typeScope)
+    }
+    if node.kind == AstNFor && node.text == "loopexpr" {
+        return hirLowerLoopExpr(cx, idx, typeScope)
+    }
+    let coreIdx = hirLowerExprCoreIdx(cx, idx)
+    if coreIdx < 0 {
+        let span = hirLowerSpanFromNode(node)
+        hirLowerNote(
+            cx.l,
+            "hir_lower: expression did not elaborate to Core: " + astNodeKindName(node.kind),
+        )
+        return hirLowerAssembleErrorExpr("expression did not elaborate", hirTypeErr(), span)
+    }
+    hirLowerExprFromCore(cx, coreIdx, typeScope)
+}
+
+fn hirLowerLoopExpr(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let loopTy = hirLowerExprType(cx, idx)
+    let mut outer = hirBlock(span)
+    let resultName = "__loop_result_" + hirLowerIntToString(idx)
+    let stmtScope = HirLowerStmtScope {
+        loopResultName: resultName,
+        loopResultType: loopTy,
+    }
+    if !hirTypeIsNever(loopTy) {
+        hirBlockAppend(outer, hirLetStmtNoValue(resultName, loopTy, true, span))
+    }
+    let loopBody = hirLowerBlockFromAst(cx, node.right, stmtScope, typeScope)
+    hirBlockAppend(outer, hirForInfiniteStmt(loopBody, span))
+    if !hirTypeIsNever(loopTy) {
+        hirBlockSetResult(
+            outer,
+            hirIdent(resultName, HirIdentLocal, loopTy, span),
+        )
+    }
+    hirLowerAssembleBlockExpr(outer, loopTy, span)
+}
+
+fn hirLowerClosureExpr(
+    cx: HirLowerContext,
+    idx: Int,
+    parentScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let closureTy = hirLowerExprType(cx, idx)
+    let scope = parentScope
+    let mut params: List<HirParam> = []
+    let mut i = 0
+    for paramIdx in node.children {
+        params.push(hirLowerClosureParam(cx, paramIdx, closureTy, i, scope))
+        i = i + 1
+    }
+    let returnType = if node.right >= 0 {
+        hirLowerTypeFromAst(cx.ast, node.right, scope)
+    } else {
+        hirLowerFnReturnType(closureTy)
+    }
+    let body = hirLowerBlockLike(cx, node.left, hirLowerStmtScope(), scope)
+    let captures = hirLowerClosureCaptures(cx, idx)
+    hirLowerAssembleClosure(params, returnType, body, captures, closureTy, span)
+}
+
+fn hirLowerClosureCaptures(
+    cx: HirLowerContext,
+    closureIdx: Int,
+) -> List<HirCapture> {
+    let node = astArenaNodeAt(cx.ast.arena, closureIdx)
+    let mut names: List<String> = []
+    let mut out: List<HirCapture> = []
+    let mut i = 0
+    for refNode in cx.resolved.refNodes {
+        let target = hirLowerIntListAt(cx.resolved.refTargets, i)
+        let name = hirLowerStringListAt(cx.resolved.refNames, i)
+        if !(hirLowerNodeInsideClosure(cx.ast, closureIdx, refNode, true)) {
+            i = i + 1
+            continue
+        }
+        if target >= 0 && hirLowerNodeInsideClosure(cx.ast, closureIdx, target, false) {
+            i = i + 1
+            continue
+        }
+        let coreIdx = hirLowerExprCoreIdx(cx, refNode)
+        let identKind = hirLowerCoreIdentCaptureKind(cx, coreIdx, name)
+        let shouldCapture = match identKind {
+            HirCaptureLocal -> true,
+            HirCaptureParam -> true,
+            HirCaptureSelf -> true,
+            _ -> false,
+        }
+        if shouldCapture && !(hirLowerContainsString(names, name)) {
+            names.push(name)
+            let typ = if refNode >= 0 {
+                hirLowerExprType(cx, refNode)
+            } else {
+                hirTypeErr()
+            }
+            let targetNode = if target >= 0 {
+                astArenaNodeAt(cx.ast.arena, target)
+            } else {
+                node
+            }
+            out.push(
+                hirLowerAssembleCapture(
+                    name,
+                    identKind,
+                    typ,
+                    hirLowerBindingMutable(targetNode),
+                    hirLowerSpanFromAst(cx.ast, refNode),
+                ),
+            )
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn hirLowerExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let span = hirLowerSpanFromCore(cx.elab.core, coreIdx)
+    let typ = hirLowerTyToHirType(cx.elab.env.tys, node.ty)
+    let origin = node.originAst
+    if node.kind == CkIntLit {
+        return hirIntLit(hirLowerNormalizeIntText(node.text), typ, span)
+    }
+    if node.kind == CkFloatLit {
+        return hirFloatLit(hirLowerNormalizeFloatText(node.text), typ, span)
+    }
+    if node.kind == CkBoolLit {
+        return hirBoolLit(coreBoolLitValueAt(cx.elab.core, coreIdx), span)
+    }
+    if node.kind == CkCharLit {
+        return hirCharLit(node.value, span)
+    }
+    if node.kind == CkByteLit {
+        return hirByteLit(node.value, span)
+    }
+    if node.kind == CkStringLit {
+        return hirLowerStringExprFromCore(cx, coreIdx, span)
+    }
+    if node.kind == CkUnitLit {
+        return hirUnitLit(span)
+    }
+    if node.kind == CkIdent {
+        return hirIdent(node.text, hirLowerIdentKindFromCore(coreIdentKindAt(cx.elab.core, coreIdx)), typ, span)
+    }
+    if node.kind == CkUnary {
+        return hirUnary(
+            hirLowerUnaryOpFromCore(coreUnaryOpAt(cx.elab.core, coreIdx)),
+            hirLowerExprFromCore(cx, node.left, typeScope),
+            typ,
+            span,
+        )
+    }
+    if node.kind == CkBinary {
+        return hirBinary(
+            hirLowerBinaryOpFromCore(coreBinaryOpAt(cx.elab.core, coreIdx)),
+            hirLowerExprFromCore(cx, node.left, typeScope),
+            hirLowerExprFromCore(cx, node.right, typeScope),
+            typ,
+            span,
+        )
+    }
+    if node.kind == CkCoalesce {
+        return hirCoalesce(
+            hirLowerExprFromCore(cx, node.left, typeScope),
+            hirLowerExprFromCore(cx, node.right, typeScope),
+            typ,
+            span,
+        )
+    }
+    if node.kind == CkQuestion {
+        return hirQuestion(hirLowerExprFromCore(cx, node.left, typeScope), typ, span)
+    }
+    if node.kind == CkCall {
+        return hirLowerCallExprFromCore(cx, coreIdx, typeScope)
+    }
+    if node.kind == CkMethodCall {
+        return hirLowerMethodCallExprFromCore(cx, coreIdx, typeScope)
+    }
+    if node.kind == CkIntrinsic {
+        return hirLowerIntrinsicExprFromCore(cx, coreIdx, typeScope)
+    }
+    if node.kind == CkVariantLit {
+        return hirLowerVariantExprFromCore(cx, coreIdx, typeScope)
+    }
+    if node.kind == CkField {
+        let target = hirLowerExprFromCore(cx, node.left, typeScope)
+        if origin >= 0 {
+            let ast = astArenaNodeAt(cx.ast.arena, origin)
+            if ast.flags == 1 {
+                return hirFieldExprOptional(target, node.text, typ, span)
+            }
+        }
+        return hirFieldExpr(target, node.text, typ, span)
+    }
+    if node.kind == CkTupleAccess {
+        return hirTupleAccess(
+            hirLowerExprFromCore(cx, node.left, typeScope),
+            node.value,
+            typ,
+            span,
+        )
+    }
+    if node.kind == CkIndex {
+        return hirIndexExpr(
+            hirLowerExprFromCore(cx, node.left, typeScope),
+            hirLowerExprFromCore(cx, node.right, typeScope),
+            typ,
+            span,
+        )
+    }
+    if node.kind == CkList {
+        return hirLowerListExprFromCore(cx, coreIdx, typeScope, typ, span)
+    }
+    if node.kind == CkMap {
+        return hirLowerMapExprFromCore(cx, coreIdx, typeScope, typ, span)
+    }
+    if node.kind == CkTuple {
+        let mut elems: List<HirExpr> = []
+        for childIdx in node.children {
+            elems.push(hirLowerExprFromCore(cx, childIdx, typeScope))
+        }
+        return hirTupleLit(elems, typ, span)
+    }
+    if node.kind == CkStruct {
+        if origin >= 0 {
+            return hirLowerStructExprFromAst(cx, origin, typeScope, typ)
+        }
+    }
+    if node.kind == CkRange {
+        if origin >= 0 {
+            let ast = astArenaNodeAt(cx.ast.arena, origin)
+            if hirLowerAstRangeHasStep(ast) {
+                hirLowerNote(cx.l, "hir_lower: range step is not representable in HIR and will be ignored")
+            }
+        }
+        let hasStart = node.left >= 0
+        let hasEnd = node.right >= 0
+        let start = if hasStart {
+            hirLowerExprFromCore(cx, node.left, typeScope)
+        } else {
+            hirExprInvalid()
+        }
+        let end = if hasEnd {
+            hirLowerExprFromCore(cx, node.right, typeScope)
+        } else {
+            hirExprInvalid()
+        }
+        let inclusive = node.flags == 1
+        let shape = hirLowerClassifyRange(hasStart, hasEnd)
+        if shape == HirRangeShapeBounded {
+            return hirRangeLitBounded(start, end, inclusive, typ, span)
+        }
+        if shape == HirRangeShapeFrom {
+            return hirRangeLitFrom(start, typ, span)
+        }
+        if shape == HirRangeShapeTo {
+            return hirRangeLitTo(end, inclusive, typ, span)
+        }
+        hirLowerNote(cx.l, "hir_lower: empty range expression is invalid")
+        return hirLowerAssembleErrorExpr("empty range", typ, span)
+    }
+    if node.kind == CkBlock {
+        if origin >= 0 {
+            return hirLowerAssembleBlockExpr(
+                hirLowerBlockFromAst(cx, origin, hirLowerStmtScope(), typeScope),
+                typ,
+                span,
+            )
+        }
+        hirLowerNote(cx.l, "hir_lower: synthetic Core block without AST origin")
+        return hirLowerAssembleBlockExpr(hirBlock(span), typ, span)
+    }
+    if node.kind == CkIf {
+        return hirLowerIfExprFromAst(cx, origin, typeScope, typ, span)
+    }
+    if node.kind == CkIfLet {
+        return hirLowerIfLetExprFromAst(cx, origin, typeScope, typ, span)
+    }
+    if node.kind == CkMatch {
+        return hirLowerMatchExprFromAst(cx, origin, typeScope, typ, span)
+    }
+    if node.kind == CkErr {
+        return hirLowerAssembleErrorExpr("poisoned expression", typ, span)
+    }
+    hirLowerNote(
+        cx.l,
+        "hir_lower: unsupported Core expr kind " + coreKindName(node.kind),
+    )
+    hirLowerAssembleErrorExpr("unsupported Core expr", typ, span)
+}
+
+fn hirLowerIfExprFromAst(
+    cx: HirLowerContext,
+    origin: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+    span: HirSpan,
+) -> HirExpr {
+    if origin < 0 {
+        return hirLowerAssembleErrorExpr("if expression lost AST origin", typ, span)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, origin)
+    let cond = hirLowerExpr(cx, node.left, typeScope)
+    let thenBlock = hirLowerBlockFromAst(cx, node.right, hirLowerStmtScope(), typeScope)
+    let elseIdx = hirLowerAstChildAt(node.children, 0)
+    let elseBlock = if elseIdx >= 0 {
+        hirLowerBlockLike(cx, elseIdx, hirLowerStmtScope(), typeScope)
+    } else {
+        hirBlock(span)
+    }
+    hirLowerAssembleIfExpr(cond, thenBlock, elseBlock, typ, span)
+}
+
+fn hirLowerIfLetExprFromAst(
+    cx: HirLowerContext,
+    origin: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+    span: HirSpan,
+) -> HirExpr {
+    if origin < 0 {
+        return hirLowerAssembleErrorExpr("if-let expression lost AST origin", typ, span)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, origin)
+    let patternIdx = hirLowerAstChildAt(node.children, 1)
+    let pattern = hirLowerPattern(cx, patternIdx, typeScope)
+    let scrutinee = hirLowerExpr(cx, node.left, typeScope)
+    let thenBlock = hirLowerBlockFromAst(cx, node.right, hirLowerStmtScope(), typeScope)
+    let elseIdx = hirLowerAstChildAt(node.children, 0)
+    if elseIdx >= 0 {
+        return hirLowerAssembleIfLetExpr(
+            pattern,
+            scrutinee,
+            thenBlock,
+            true,
+            hirLowerBlockLike(cx, elseIdx, hirLowerStmtScope(), typeScope),
+            typ,
+            span,
+        )
+    }
+    hirLowerAssembleIfLetExpr(pattern, scrutinee, thenBlock, false, hirBlock(span), typ, span)
+}
+
+fn hirLowerMatchExprFromAst(
+    cx: HirLowerContext,
+    origin: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+    span: HirSpan,
+) -> HirExpr {
+    if origin < 0 {
+        return hirLowerAssembleErrorExpr("match expression lost AST origin", typ, span)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, origin)
+    let scrutinee = hirLowerExpr(cx, node.left, typeScope)
+    let mut arms: List<HirMatchArm> = []
+    for armIdx in node.children {
+        arms.push(hirLowerMatchArmFromAst(cx, armIdx, typeScope))
+    }
+    let tree = if hirTypeIsValid(scrutinee.typ) {
+        pmCompileDecisionTree(scrutinee.typ, arms)
+    } else {
+        hirDecisionInvalid()
+    }
+    hirLowerAssembleMatchExpr(scrutinee, arms, tree, typ, span)
+}
+
+fn hirLowerMatchArmFromAst(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirMatchArm {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let pattern = hirLowerPattern(cx, node.left, typeScope)
+    let guardIdx = hirLowerAstChildAt(node.children, 0)
+    let hasGuard = guardIdx >= 0
+    let guard = if hasGuard {
+        hirLowerExpr(cx, guardIdx, typeScope)
+    } else {
+        hirExprInvalid()
+    }
+    let body = hirLowerBlockLike(cx, node.right, hirLowerStmtScope(), typeScope)
+    hirLowerAssembleMatchArm(pattern, hasGuard, guard, body, span)
+}
+
+fn hirLowerCallExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let span = hirLowerSpanFromCore(cx.elab.core, coreIdx)
+    let typ = hirLowerTyToHirType(cx.elab.env.tys, node.ty)
+    let callee = hirLowerExprFromCore(cx, node.left, typeScope)
+    let mut args: List<HirArg> = []
+    for argIdx in node.children {
+        args.push(hirArg(hirLowerExprFromCore(cx, argIdx, typeScope), hirLowerSpanFromCore(cx.elab.core, argIdx)))
+    }
+    let typeArgs = hirLowerTypeArgs(cx.elab.env.tys, node.typeArgs)
+    hirLowerAssembleCall(callee, typeArgs, args, typ, span)
+}
+
+fn hirLowerMethodCallExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let span = hirLowerSpanFromCore(cx.elab.core, coreIdx)
+    let typ = hirLowerTyToHirType(cx.elab.env.tys, node.ty)
+    let recv = hirLowerExprFromCore(cx, node.left, typeScope)
+    let mut args: List<HirArg> = []
+    for argIdx in node.children {
+        args.push(hirArg(hirLowerExprFromCore(cx, argIdx, typeScope), hirLowerSpanFromCore(cx.elab.core, argIdx)))
+    }
+    let typeArgs = hirLowerTypeArgs(cx.elab.env.tys, node.typeArgs)
+    hirLowerAssembleMethodCall(recv, node.name, typeArgs, args, typ, span)
+}
+
+fn hirLowerIntrinsicExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let span = hirLowerSpanFromCore(cx.elab.core, coreIdx)
+    let kind = hirLowerIntrinsicFromIdent(node.name)
+    let mut args: List<HirArg> = []
+    for argIdx in node.children {
+        args.push(hirArg(hirLowerExprFromCore(cx, argIdx, typeScope), hirLowerSpanFromCore(cx.elab.core, argIdx)))
+    }
+    hirLowerAssembleIntrinsicCall(kind, args, span)
+}
+
+fn hirLowerVariantExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let span = hirLowerSpanFromCore(cx.elab.core, coreIdx)
+    let typ = hirLowerTyToHirType(cx.elab.env.tys, node.ty)
+    let mut args: List<HirArg> = []
+    for argIdx in node.children {
+        args.push(hirArg(hirLowerExprFromCore(cx, argIdx, typeScope), hirLowerSpanFromCore(cx.elab.core, argIdx)))
+    }
+    hirLowerAssembleVariantLit(node.owner, node.name, args, typ, span)
+}
+
+fn hirLowerStructExprFromAst(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+) -> HirExpr {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    let mut fields: List<HirStructLitField> = []
+    for fieldIdx in node.children {
+        let field = astArenaNodeAt(cx.ast.arena, fieldIdx)
+        let fieldSpan = hirLowerSpanFromNode(field)
+        if field.left >= 0 {
+            fields.push(hirStructLitField(field.text, hirLowerExpr(cx, field.left, typeScope), fieldSpan))
+        } else {
+            fields.push(hirStructLitFieldShorthand(field.text, fieldSpan))
+        }
+    }
+    let typeName = hirLowerStructLitTypeName(cx.ast, node, typ)
+    let hasSpread = node.right >= 0
+    let spread = if hasSpread {
+        hirLowerExpr(cx, node.right, typeScope)
+    } else {
+        hirExprInvalid()
+    }
+    hirLowerAssembleStructLit(typeName, fields, hasSpread, spread, typ, span)
+}
+
+fn hirLowerStringExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    span: HirSpan,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let decoded = hirLowerDecodeStringToken(node.text)
+    let parts = [hirStringPartLit(decoded.body)]
+    hirLowerAssembleStringLit(parts, decoded.raw, decoded.triple, span)
+}
+
+fn hirLowerListExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+    span: HirSpan,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let mut elems: List<HirExpr> = []
+    for childIdx in node.children {
+        elems.push(hirLowerExprFromCore(cx, childIdx, typeScope))
+    }
+    let elemT = hirLowerListElemType(typ, elems)
+    hirListLit(elems, elemT, span)
+}
+
+fn hirLowerMapExprFromCore(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    typeScope: HirLowerTypeScope,
+    typ: HirType,
+    span: HirSpan,
+) -> HirExpr {
+    let node = coreArenaNodeAt(cx.elab.core, coreIdx)
+    let kv = hirLowerMapTypes(typ)
+    let mut entries: List<HirMapEntry> = []
+    for entryIdx in node.children {
+        let entry = coreArenaNodeAt(cx.elab.core, entryIdx)
+        entries.push(
+            hirMapEntry(
+                hirLowerExprFromCore(cx, entry.left, typeScope),
+                hirLowerExprFromCore(cx, entry.right, typeScope),
+                hirLowerSpanFromCore(cx.elab.core, entryIdx),
+            ),
+        )
+    }
+    hirMapLit(entries, kv.keyT, kv.valT, span)
+}
+
+fn hirLowerPattern(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirPattern {
+    if idx < 0 {
+        return hirPatternInvalid()
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.kind != AstNPattern {
+        return hirErrorPat("non-pattern node", span)
+    }
+    if node.extra == astPatternWildcardKind() {
+        return hirWildPat(span)
+    }
+    if node.extra == astPatternLiteralKind() {
+        return hirLitPat(hirLowerPatternLiteralExpr(cx, idx, typeScope), span)
+    }
+    if node.extra == astPatternIdentKind() {
+        return hirLowerAssemblePatternIdent(node.text, false, span)
+    }
+    if node.extra == astPatternTupleKind() {
+        let mut elems: List<HirPattern> = []
+        for childIdx in node.children {
+            elems.push(hirLowerPattern(cx, childIdx, typeScope))
+        }
+        return hirTuplePat(elems, span)
+    }
+    if node.extra == astPatternStructKind() {
+        let mut fields: List<HirStructPatField> = []
+        for childIdx in node.children {
+            let child = astArenaNodeAt(cx.ast.arena, childIdx)
+            if child.kind == AstNPattern && child.extra == astPatternFieldKind() {
+                let hasPattern = child.left >= 0
+                let pattern = if hasPattern {
+                    hirLowerPattern(cx, child.left, typeScope)
+                } else {
+                    hirPatternInvalid()
+                }
+                fields.push(hirLowerAssemblePatternStructField(child.text, hasPattern, pattern, hirLowerSpanFromNode(child)))
+            }
+        }
+        return hirLowerAssemblePatternStruct(node.text, fields, node.flags == 1, span)
+    }
+    if node.extra == astPatternVariantKind() {
+        let split = hirLowerSplitQualifiedName(node.text)
+        let mut args: List<HirPattern> = []
+        for childIdx in node.children {
+            args.push(hirLowerPattern(cx, childIdx, typeScope))
+        }
+        return hirVariantPat(split.owner, split.leaf, args, span)
+    }
+    if node.extra == astPatternRangeKind() {
+        let low = if node.left >= 0 {
+            hirLowerPatternLiteralExpr(cx, node.left, typeScope)
+        } else {
+            hirExprInvalid()
+        }
+        let high = if node.right >= 0 {
+            hirLowerPatternLiteralExpr(cx, node.right, typeScope)
+        } else {
+            hirExprInvalid()
+        }
+        return hirLowerAssemblePatternRange(
+            node.left >= 0,
+            low,
+            node.right >= 0,
+            high,
+            node.flags == 1,
+            span,
+        )
+    }
+    if node.extra == astPatternOrKind() {
+        let mut alts: List<HirPattern> = []
+        if node.left >= 0 {
+            alts.push(hirLowerPattern(cx, node.left, typeScope))
+        }
+        if node.right >= 0 {
+            alts.push(hirLowerPattern(cx, node.right, typeScope))
+        }
+        for childIdx in node.children {
+            alts.push(hirLowerPattern(cx, childIdx, typeScope))
+        }
+        return hirOrPat(alts, span)
+    }
+    if node.extra == astPatternBindingKind() {
+        return hirBindingPat(node.text, hirLowerPattern(cx, node.left, typeScope), span)
+    }
+    if node.extra == astPatternErrorKind() {
+        return hirErrorPat("invalid pattern", span)
+    }
+    hirErrorPat("unsupported pattern", span)
+}
+
+fn hirLowerPatternLiteralExpr(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirExpr {
+    if idx < 0 {
+        return hirExprInvalid()
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.kind == AstNIntLit {
+        return hirIntLit(hirLowerNormalizeIntText(node.text), hirLowerExprType(cx, idx), span)
+    }
+    if node.kind == AstNFloatLit {
+        return hirFloatLit(hirLowerNormalizeFloatText(node.text), hirLowerExprType(cx, idx), span)
+    }
+    if node.kind == AstNStringLit {
+        let decoded = hirLowerDecodeStringToken(node.text)
+        return hirLowerAssembleStringLit([hirStringPartLit(decoded.body)], decoded.raw, decoded.triple, span)
+    }
+    if node.kind == AstNBoolLit {
+        return hirBoolLit(node.text == "true", span)
+    }
+    if node.kind == AstNCharLit {
+        return hirCharLit(hirLowerCharValue(node.text), span)
+    }
+    if node.kind == AstNByteLit {
+        return hirByteLit(hirLowerByteValue(node.text), span)
+    }
+    if node.kind == AstNPattern {
+        if node.extra == astPatternLiteralKind() {
+            if node.text == "-" && node.left >= 0 {
+                let inner = hirLowerPatternLiteralExpr(cx, node.left, typeScope)
+                if inner.kind == HirExprIntLit {
+                    return hirIntLit("-" + inner.numText, inner.typ, span)
+                }
+                if inner.kind == HirExprFloatLit {
+                    return hirFloatLit("-" + inner.numText, inner.typ, span)
+                }
+            }
+            let mut fake = node
+            if fake.op == FrontIdent && (fake.text == "true" || fake.text == "false") {
+                return hirBoolLit(fake.text == "true", span)
+            }
+            if fake.op == FrontInt {
+                return hirIntLit(hirLowerNormalizeIntText(fake.text), hirTInt(), span)
+            }
+            if fake.op == FrontFloat {
+                return hirFloatLit(hirLowerNormalizeFloatText(fake.text), hirTFloat(), span)
+            }
+            if fake.op == FrontString || fake.op == FrontRawString {
+                let decoded = hirLowerDecodeStringToken(fake.text)
+                return hirLowerAssembleStringLit([hirStringPartLit(decoded.body)], decoded.raw, decoded.triple, span)
+            }
+            if fake.op == FrontChar {
+                return hirCharLit(hirLowerCharValue(fake.text), span)
+            }
+            if fake.op == FrontByte {
+                return hirByteLit(hirLowerByteValue(fake.text), span)
+            }
+        }
+        if node.extra == astPatternRangeKind() {
+            return hirExprInvalid()
+        }
+    }
+    hirLowerExpr(cx, idx, typeScope)
+}
+
+fn hirLowerAnnotations(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> List<HirAnnotation> {
+    let mut out: List<HirAnnotation> = []
+    if idx < 0 {
+        return out
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind == AstNAnnotation && node.text == "__group" {
+        for childIdx in node.children {
+            out.push(hirLowerOneAnnotation(cx, childIdx, typeScope))
+        }
+        return out
+    }
+    out.push(hirLowerOneAnnotation(cx, idx, typeScope))
+    out
+}
+
+fn hirLowerOneAnnotation(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirAnnotation {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let mut ann = hirAnnotation(node.text, hirLowerSpanFromNode(node))
+    for argIdx in node.children {
+        ann.args.push(hirLowerAnnotationArg(cx, argIdx, typeScope))
+    }
+    ann
+}
+
+fn hirLowerAnnotationArg(
+    cx: HirLowerContext,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirAnnotationArg {
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    let span = hirLowerSpanFromNode(node)
+    if node.kind == AstNField_ {
+        return hirAnnotationArgKeyValue(node.text, hirLowerExpr(cx, node.left, typeScope), span)
+    }
+    if node.kind == AstNIdent {
+        return hirAnnotationArgFlag(node.text, span)
+    }
+    hirAnnotationArgPositional(hirLowerExpr(cx, idx, typeScope), span)
+}
+
+fn hirLowerTypeScopeWithGenerics(
+    ast: AstFile,
+    genericIdxs: List<Int>,
+    genericOwner: String,
+    selfOwner: String,
+    parent: HirLowerTypeScope,
+) -> HirLowerTypeScope {
+    let mut out = parent
+    if selfOwner != "" {
+        out.selfOwner = selfOwner
+    }
+    for genericIdx in genericIdxs {
+        let node = astArenaNodeAt(ast.arena, genericIdx)
+        if node.kind == AstNGenericParam {
+            out.genericNames.push(node.text)
+            out.genericOwners.push(genericOwner)
+        }
+    }
+    out
+}
+
+fn hirLowerGenericParams(
+    cx: HirLowerContext,
+    idxs: List<Int>,
+    typeScope: HirLowerTypeScope,
+) -> List<HirTypeParam> {
+    let mut out: List<HirTypeParam> = []
+    for idx in idxs {
+        let node = astArenaNodeAt(cx.ast.arena, idx)
+        if node.kind != AstNGenericParam {
+            continue
+        }
+        let mut bounds: List<HirType> = []
+        for boundIdx in node.children {
+            bounds.push(hirLowerTypeFromAst(cx.ast, boundIdx, typeScope))
+        }
+        out.push(hirLowerAssembleTypeParam(node.text, bounds, hirLowerSpanFromNode(node)))
+    }
+    out
+}
+
+fn hirLowerTypeFromAst(
+    ast: AstFile,
+    idx: Int,
+    typeScope: HirLowerTypeScope,
+) -> HirType {
+    if idx < 0 {
+        return hirTypeInvalid()
+    }
+    let node = astArenaNodeAt(ast.arena, idx)
+    if node.kind != AstNType {
+        return hirTypeInvalid()
+    }
+    if node.text == "optional" {
+        return hirTypeOptional(hirLowerTypeFromAst(ast, node.left, typeScope))
+    }
+    if node.text == "tuple" {
+        let mut elems: List<HirType> = []
+        for childIdx in node.children {
+            elems.push(hirLowerTypeFromAst(ast, childIdx, typeScope))
+        }
+        return hirTypeTuple(elems)
+    }
+    if node.text == "fn" {
+        let mut params: List<HirType> = []
+        for childIdx in node.children {
+            params.push(hirLowerTypeFromAst(ast, childIdx, typeScope))
+        }
+        let ret = if node.right >= 0 {
+            hirLowerTypeFromAst(ast, node.right, typeScope)
+        } else {
+            hirTUnit()
+        }
+        return hirTypeFn(params, ret)
+    }
+    if node.text == "Self" && typeScope.selfOwner != "" {
+        return hirTypeVar("Self", typeScope.selfOwner)
+    }
+    let genericOwner = hirLowerTypeScopeLookup(typeScope, node.text)
+    if genericOwner != "" {
+        return hirTypeVar(node.text, genericOwner)
+    }
+    let mut args: List<HirType> = []
+    for childIdx in node.children {
+        args.push(hirLowerTypeFromAst(ast, childIdx, typeScope))
+    }
+    if args.len() == 0 {
+        let prim = hirLowerPrimByName(node.text)
+        let isPrim = match prim.kind {
+            HirTypeInvalid -> false,
+            _ -> true,
+        }
+        if isPrim {
+            return prim
+        }
+    }
+    if hirLowerIsBuiltinGenericName(node.text) {
+        return hirTypeBuiltin(node.text, args)
+    }
+    let parts = strings.split(node.text, ".")
+    if parts.len() > 1 {
+        let pkg = hirLowerJoinDottedPath(hirLowerDropLast(parts))
+        let leaf = hirLowerLast(parts)
+        return hirTypeNamedQualified(pkg, leaf, args)
+    }
+    hirTypeNamed(node.text, args)
+}
+
+fn hirLowerTypeScopeLookup(scope: HirLowerTypeScope, name: String) -> String {
+    let mut i = scope.genericNames.len() - 1
+    for i >= 0 {
+        if scope.genericNames[i] == name {
+            return scope.genericOwners[i]
+        }
+        i = i - 1
+    }
+    ""
+}
+
+fn hirLowerTypeArgs(tys: TyArena, idxs: List<Int>) -> List<HirType> {
+    let mut out: List<HirType> = []
+    for idx in idxs {
+        out.push(hirLowerTyToHirType(tys, idx))
+    }
+    out
+}
+
+fn hirLowerSpanFromNode(node: AstNode) -> HirSpan {
+    hirSpanFromOffsets(node.start, node.end)
+}
+
+fn hirLowerSpanFromAst(ast: AstFile, idx: Int) -> HirSpan {
+    if idx < 0 {
+        return hirNoSpan()
+    }
+    hirLowerSpanFromNode(astArenaNodeAt(ast.arena, idx))
+}
+
+fn hirLowerSpanFromCore(core: CoreArena, idx: Int) -> HirSpan {
+    if idx < 0 {
+        return hirNoSpan()
+    }
+    hirSpanFromOffsets(coreStartAt(core, idx), coreEndAt(core, idx))
+}
+
+fn hirLowerSpanText(span: HirSpan) -> String {
+    hirLowerIntToString(span.start.offset) + ".." + hirLowerIntToString(span.end.offset)
+}
+
+fn hirLowerExprCoreIdx(cx: HirLowerContext, idx: Int) -> Int {
+    let mapped = elabTypedExprCoreAt(cx.elab, idx)
+    if mapped >= 0 {
+        return mapped
+    }
+    if idx < 0 {
+        return -1
+    }
+    elabInfer(cx.elab, idx).node
+}
+
+fn hirLowerExprType(cx: HirLowerContext, idx: Int) -> HirType {
+    let mapped = elabTypedExprTyAt(cx.elab, idx)
+    if mapped >= 0 {
+        return hirLowerTyToHirType(cx.elab.env.tys, mapped)
+    }
+    if idx < 0 {
+        return hirTypeErr()
+    }
+    let r = elabInfer(cx.elab, idx)
+    hirLowerTyToHirType(cx.elab.env.tys, r.ty)
+}
+
+fn hirLowerUseAlias(ast: AstFile, node: AstNode) -> String {
+    let aliasIdx = hirLowerAstChildAt(node.children2, 0)
+    if aliasIdx >= 0 {
+        let alias = astArenaNodeAt(ast.arena, aliasIdx)
+        if alias.text != "" {
+            return alias.text
+        }
+    }
+    hirLowerPathLastSegment(node.text)
+}
+
+fn hirLowerUsePathSegments(path: String) -> List<String> {
+    let raw = hirLowerDecodeStringToken(path).body
+    let source = if raw != "" { raw } else { path }
+    let mut out: List<String> = []
+    for slash in strings.split(source, "/") {
+        for dot in strings.split(slash, ".") {
+            for colon in strings.split(dot, ":") {
+                if colon != "" {
+                    out.push(colon)
+                }
+            }
+        }
+    }
+    out
+}
+
+fn hirLowerPathLastSegment(path: String) -> String {
+    let parts = hirLowerUsePathSegments(path)
+    hirLowerLast(parts)
+}
+
+fn hirLowerPathStartsWithRuntime(path: String) -> Bool {
+    path.startsWith("runtime.") || path.startsWith("runtime/") || path.startsWith("runtime:")
+}
+
+pub struct HirLowerDecodedString {
+    pub body: String,
+    pub raw: Bool,
+    pub triple: Bool,
+}
+
+fn hirLowerDecodeStringToken(text: String) -> HirLowerDecodedString {
+    let n = text.len()
+    if n >= 7 && text[0..4] == "r\"\"\"" && text[n - 3..n] == "\"\"\"" {
+        return HirLowerDecodedString {
+            body: text[4..n - 3],
+            raw: true,
+            triple: true,
+        }
+    }
+    if n >= 6 && text[0..3] == "\"\"\"" && text[n - 3..n] == "\"\"\"" {
+        return HirLowerDecodedString {
+            body: text[3..n - 3],
+            raw: false,
+            triple: true,
+        }
+    }
+    if n >= 3 && text[0..2] == "r\"" && text[n - 1..n] == "\"" {
+        return HirLowerDecodedString {
+            body: text[2..n - 1],
+            raw: true,
+            triple: false,
+        }
+    }
+    if n >= 2 && text[0..1] == "\"" && text[n - 1..n] == "\"" {
+        return HirLowerDecodedString {
+            body: text[1..n - 1],
+            raw: false,
+            triple: false,
+        }
+    }
+    HirLowerDecodedString { body: text, raw: false, triple: false }
+}
+
+pub struct HirLowerQualifiedName {
+    pub owner: String,
+    pub leaf: String,
+}
+
+fn hirLowerSplitQualifiedName(name: String) -> HirLowerQualifiedName {
+    let parts = strings.split(name, ".")
+    if parts.len() <= 1 {
+        return HirLowerQualifiedName { owner: "", leaf: name }
+    }
+    HirLowerQualifiedName {
+        owner: hirLowerJoinDottedPath(hirLowerDropLast(parts)),
+        leaf: hirLowerLast(parts),
+    }
+}
+
+fn hirLowerStructLitTypeName(ast: AstFile, node: AstNode, typ: HirType) -> String {
+    if node.flags == 1 {
+        return hirTypeString(typ)
+    }
+    if node.left >= 0 {
+        return astArenaNodeAt(ast.arena, node.left).text
+    }
+    hirTypeString(typ)
+}
+
+fn hirLowerTopLevelLetName(ast: AstFile, patIdx: Int) -> String {
+    if patIdx < 0 {
+        return ""
+    }
+    let node = astArenaNodeAt(ast.arena, patIdx)
+    if node.kind != AstNPattern {
+        return ""
+    }
+    if node.extra == astPatternIdentKind() || node.extra == astPatternBindingKind() {
+        return node.text
+    }
+    ""
+}
+
+fn hirLowerFnParamTypeAt(fnTy: HirType, idx: Int) -> HirType {
+    if fnTy.kind != HirTypeFn {
+        return hirTypeErr()
+    }
+    if idx < 0 || idx >= fnTy.fnParams.len() {
+        return hirTypeErr()
+    }
+    fnTy.fnParams[idx]
+}
+
+fn hirLowerFnReturnType(fnTy: HirType) -> HirType {
+    if fnTy.kind != HirTypeFn || fnTy.fnReturn.len() == 0 {
+        return hirTypeErr()
+    }
+    fnTy.fnReturn[0]
+}
+
+fn hirLowerListElemType(typ: HirType, elems: List<HirExpr>) -> HirType {
+    if typ.kind == HirTypeNamed && typ.namedName == "List" && typ.namedArgs.len() > 0 {
+        return typ.namedArgs[0]
+    }
+    if elems.len() > 0 {
+        return elems[0].typ
+    }
+    hirTypeErr()
+}
+
+pub struct HirLowerMapTypeInfo {
+    pub keyT: HirType,
+    pub valT: HirType,
+}
+
+fn hirLowerMapTypes(typ: HirType) -> HirLowerMapTypeInfo {
+    if typ.kind == HirTypeNamed && typ.namedName == "Map" && typ.namedArgs.len() >= 2 {
+        return HirLowerMapTypeInfo {
+            keyT: typ.namedArgs[0],
+            valT: typ.namedArgs[1],
+        }
+    }
+    HirLowerMapTypeInfo { keyT: hirTypeErr(), valT: hirTypeErr() }
+}
+
+fn hirLowerAstFirst(xs: List<Int>) -> Int {
+    if xs.len() == 0 {
+        return -1
+    }
+    xs[0]
+}
+
+fn hirLowerAstChildAt(xs: List<Int>, idx: Int) -> Int {
+    if idx < 0 || idx >= xs.len() {
+        return -1
+    }
+    xs[idx]
+}
+
+fn hirLowerStringListAt(xs: List<String>, idx: Int) -> String {
+    if idx < 0 || idx >= xs.len() {
+        return ""
+    }
+    xs[idx]
+}
+
+fn hirLowerIntListAt(xs: List<Int>, idx: Int) -> Int {
+    if idx < 0 || idx >= xs.len() {
+        return -1
+    }
+    xs[idx]
+}
+
+fn hirLowerContainsString(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn hirLowerAssignOpFromFrontToken(op: FrontTokenKind) -> HirAssignOp {
+    if op == FrontAssign { return HirAssignEq }
+    if op == FrontPlusEq { return HirAssignAdd }
+    if op == FrontMinusEq { return HirAssignSub }
+    if op == FrontStarEq { return HirAssignMul }
+    if op == FrontSlashEq { return HirAssignDiv }
+    if op == FrontPercentEq { return HirAssignMod }
+    if op == FrontBitAndEq { return HirAssignAnd }
+    if op == FrontBitOrEq { return HirAssignOr }
+    if op == FrontBitXorEq { return HirAssignXor }
+    if op == FrontShlEq { return HirAssignShl }
+    if op == FrontShrEq { return HirAssignShr }
+    HirAssignInvalid
+}
+
+fn hirLowerUnaryOpFromCore(op: UnOp) -> HirUnOp {
+    match op {
+        UoNeg -> HirUnNeg,
+        UoPlus -> HirUnPlus,
+        UoNot -> HirUnNot,
+        UoBitNot -> HirUnBitNot,
+        _ -> HirUnInvalid,
+    }
+}
+
+fn hirLowerBinaryOpFromCore(op: BinOp) -> HirBinOp {
+    match op {
+        BoAdd -> HirBinAdd,
+        BoSub -> HirBinSub,
+        BoMul -> HirBinMul,
+        BoDiv -> HirBinDiv,
+        BoMod -> HirBinMod,
+        BoEq -> HirBinEq,
+        BoNe -> HirBinNeq,
+        BoLt -> HirBinLt,
+        BoLe -> HirBinLeq,
+        BoGt -> HirBinGt,
+        BoGe -> HirBinGeq,
+        BoAnd -> HirBinAnd,
+        BoOr -> HirBinOr,
+        BoBitAnd -> HirBinBitAnd,
+        BoBitOr -> HirBinBitOr,
+        BoBitXor -> HirBinBitXor,
+        BoShl -> HirBinShl,
+        BoShr -> HirBinShr,
+        _ -> HirBinInvalid,
+    }
+}
+
+fn hirLowerIdentKindFromCore(kind: IdentKind) -> HirIdentKind {
+    match kind {
+        IkLocal -> HirIdentLocal,
+        IkParam -> HirIdentParam,
+        IkFn -> HirIdentFn,
+        IkVariant -> HirIdentVariant,
+        IkTypeName -> HirIdentTypeName,
+        IkGlobal -> HirIdentGlobal,
+        IkBuiltin -> HirIdentBuiltin,
+        _ -> HirIdentUnknown,
+    }
+}
+
+fn hirLowerCoreIdentCaptureKind(
+    cx: HirLowerContext,
+    coreIdx: Int,
+    name: String,
+) -> HirCaptureKind {
+    let _ = cx
+    if name == "self" {
+        return HirCaptureSelf
+    }
+    if coreIdx < 0 {
+        return HirCaptureUnknown
+    }
+    match coreIdentKindAt(cx.elab.core, coreIdx) {
+        IkLocal -> HirCaptureLocal,
+        IkParam -> HirCaptureParam,
+        IkFn -> HirCaptureFn,
+        IkGlobal -> HirCaptureGlobal,
+        _ -> HirCaptureUnknown,
+    }
+}
+
+fn hirLowerBindingMutable(node: AstNode) -> Bool {
+    if node.kind == AstNLet {
+        return node.flags == 1
+    }
+    if node.kind == AstNParam {
+        return node.flags == 1
+    }
+    if node.kind == AstNPattern && node.extra == astPatternIdentKind() {
+        return false
+    }
+    false
+}
+
+fn hirLowerNodeInsideClosure(
+    ast: AstFile,
+    closureIdx: Int,
+    targetIdx: Int,
+    skipNestedClosures: Bool,
+) -> Bool {
+    if closureIdx < 0 || targetIdx < 0 {
+        return false
+    }
+    let closure = astArenaNodeAt(ast.arena, closureIdx)
+    for paramIdx in closure.children {
+        if hirLowerNodeInsideAstSubtree(ast, paramIdx, targetIdx, skipNestedClosures, false) {
+            return true
+        }
+    }
+    hirLowerNodeInsideAstSubtree(ast, closure.left, targetIdx, skipNestedClosures, false)
+}
+
+fn hirLowerNodeInsideAstSubtree(
+    ast: AstFile,
+    rootIdx: Int,
+    targetIdx: Int,
+    skipNestedClosures: Bool,
+    nested: Bool,
+) -> Bool {
+    if rootIdx < 0 {
+        return false
+    }
+    if rootIdx == targetIdx {
+        return true
+    }
+    let node = astArenaNodeAt(ast.arena, rootIdx)
+    let nextNested = nested || (node.kind == AstNClosure)
+    if nextNested && skipNestedClosures && rootIdx != targetIdx && nested {
+        return false
+    }
+    if hirLowerNodeInsideAstSubtree(ast, node.left, targetIdx, skipNestedClosures, nextNested) {
+        return true
+    }
+    if hirLowerNodeInsideAstSubtree(ast, node.right, targetIdx, skipNestedClosures, nextNested) {
+        return true
+    }
+    if hirLowerNodeInsideAstSubtree(ast, node.extra, targetIdx, skipNestedClosures, nextNested) {
+        return true
+    }
+    for childIdx in node.children {
+        if hirLowerNodeInsideAstSubtree(ast, childIdx, targetIdx, skipNestedClosures, nextNested) {
+            return true
+        }
+    }
+    for childIdx in node.children2 {
+        if hirLowerNodeInsideAstSubtree(ast, childIdx, targetIdx, skipNestedClosures, nextNested) {
+            return true
+        }
+    }
+    false
+}
+
+fn hirLowerAstRangeInclusive(node: AstNode) -> Bool {
+    node.flags == 1 || node.flags == 3
+}
+
+fn hirLowerAstRangeHasStep(node: AstNode) -> Bool {
+    node.flags == 2 || node.flags == 3 || node.children.len() > 0
+}
+
+fn hirLowerIntToString(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let negative = n < 0
+    let mut value = if negative { 0 - n } else { n }
+    let mut digits: List<String> = []
+    for value > 0 {
+        let digit = value % 10
+        digits.push(hirLowerDigitText(digit))
+        value = value / 10
+    }
+    let mut out = ""
+    let mut i = digits.len() - 1
+    for i >= 0 {
+        out = out + digits[i]
+        i = i - 1
+    }
+    if negative {
+        return "-" + out
+    }
+    out
+}
+
+fn hirLowerDigitText(d: Int) -> String {
+    if d == 0 { return "0" }
+    if d == 1 { return "1" }
+    if d == 2 { return "2" }
+    if d == 3 { return "3" }
+    if d == 4 { return "4" }
+    if d == 5 { return "5" }
+    if d == 6 { return "6" }
+    if d == 7 { return "7" }
+    if d == 8 { return "8" }
+    if d == 9 { return "9" }
+    "0"
+}
+
+fn hirLowerCharValue(text: String) -> Int {
+    if text.len() >= 3 {
+        let inner = text[1..text.len() - 1]
+        if inner.len() == 1 {
+            return inner.chars()[0].toInt()
+        }
+    }
+    0
+}
+
+fn hirLowerByteValue(text: String) -> Int {
+    if text.startsWith("b'") && text.len() >= 4 {
+        let inner = text[2..text.len() - 1]
+        if inner.len() == 1 {
+            return inner.chars()[0].toInt()
+        }
+    }
+    0
 }

--- a/toolchain/hir_optimize.osty
+++ b/toolchain/hir_optimize.osty
@@ -1,0 +1,788 @@
+use std.strings as strings
+
+// hir_optimize.osty — conservative cleanup passes for self-hosted HIR.
+//
+// Counterpart to `internal/ir/optimize.go`. The optimiser mutates the module in
+// place and returns it for chaining.
+
+pub struct HirOptimizeOptions {
+    pub disableConstFold: Bool,
+    pub disableDeadCode: Bool,
+    pub disableBranch: Bool,
+    pub disableSimplify: Bool,
+}
+
+pub fn hirOptimizeOptions() -> HirOptimizeOptions {
+    HirOptimizeOptions {
+        disableConstFold: false,
+        disableDeadCode: false,
+        disableBranch: false,
+        disableSimplify: false,
+    }
+}
+
+pub fn hirOptimize(m: HirModule, opts: HirOptimizeOptions) -> HirModule {
+    let o = hirOptimizer(opts)
+    hirOptimizeVisitModule(o, m)
+    m
+}
+
+struct HirOptimizer {
+    opts: HirOptimizeOptions,
+}
+
+fn hirOptimizer(opts: HirOptimizeOptions) -> HirOptimizer {
+    HirOptimizer { opts }
+}
+
+fn hirOptimizeVisitModule(o: HirOptimizer, m: HirModule) {
+    let fnCount = m.fns.len()
+    for i in 0..fnCount {
+        let decl = m.fns[i]
+        hirOptimizeVisitBlock(o, decl.body)
+    }
+    let structCount = m.structs.len()
+    for i in 0..structCount {
+        let decl = m.structs[i]
+        let fieldCount = decl.fields.len()
+        for j in 0..fieldCount {
+            let field = decl.fields[j]
+            if field.hasDefault {
+                field.defaultValue = hirOptimizeVisitExpr(o, field.defaultValue)
+            }
+        }
+        let methodCount = decl.methods.len()
+        for j in 0..methodCount {
+            let method = decl.methods[j]
+            hirOptimizeVisitBlock(o, method.body)
+        }
+    }
+    let enumCount = m.enums.len()
+    for i in 0..enumCount {
+        let decl = m.enums[i]
+        let methodCount = decl.methods.len()
+        for j in 0..methodCount {
+            let method = decl.methods[j]
+            hirOptimizeVisitBlock(o, method.body)
+        }
+    }
+    let ifaceCount = m.interfaces.len()
+    for i in 0..ifaceCount {
+        let decl = m.interfaces[i]
+        let methodCount = decl.methods.len()
+        for j in 0..methodCount {
+            let method = decl.methods[j]
+            hirOptimizeVisitBlock(o, method.body)
+        }
+    }
+    let letCount = m.lets.len()
+    for i in 0..letCount {
+        let decl = m.lets[i]
+        if decl.hasValue {
+            decl.value = hirOptimizeVisitExpr(o, decl.value)
+        }
+    }
+    let scriptCount = m.script.len()
+    for i in 0..scriptCount {
+        m.script[i] = hirOptimizeVisitStmt(o, m.script[i])
+    }
+    m.script = hirOptimizeSimplifyStmts(o, m.script)
+}
+
+fn hirOptimizeVisitBlock(o: HirOptimizer, b: HirBlock) {
+    let stmtCount = b.stmts.len()
+    for i in 0..stmtCount {
+        b.stmts[i] = hirOptimizeVisitStmt(o, b.stmts[i])
+    }
+    if b.hasResult {
+        b.result = hirOptimizeVisitExpr(o, b.result)
+    }
+    b.stmts = hirOptimizeSimplifyStmts(o, b.stmts)
+}
+
+fn hirOptimizeSimplifyStmts(o: HirOptimizer, stmts: List<HirStmt>) -> List<HirStmt> {
+    if o.opts.disableDeadCode {
+        return stmts
+    }
+    let mut out: List<HirStmt> = []
+    for s in stmts {
+        out.push(s)
+        if hirOptimizeIsTerminator(s) {
+            return out
+        }
+    }
+    out
+}
+
+fn hirOptimizeIsTerminator(s: HirStmt) -> Bool {
+    match s.kind {
+        HirStmtReturn -> true,
+        HirStmtBreak -> true,
+        HirStmtContinue -> true,
+        _ -> false,
+    }
+}
+
+fn hirOptimizeVisitStmt(o: HirOptimizer, s: HirStmt) -> HirStmt {
+    match s.kind {
+        HirStmtInvalid -> s,
+        HirStmtBlock -> {
+            hirOptimizeVisitBlock(o, s.block)
+            s
+        },
+        HirStmtLet -> {
+            if s.letHasValue {
+                s.letValue = hirOptimizeVisitExpr(o, s.letValue)
+            }
+            s
+        },
+        HirStmtExpr -> {
+            s.exprValue = hirOptimizeVisitExpr(o, s.exprValue)
+            s
+        },
+        HirStmtAssign -> {
+            let targetCount = s.assignTargets.len()
+            for i in 0..targetCount {
+                s.assignTargets[i] = hirOptimizeVisitExpr(o, s.assignTargets[i])
+            }
+            s.assignValue = hirOptimizeVisitExpr(o, s.assignValue)
+            s
+        },
+        HirStmtReturn -> {
+            if s.returnHasValue {
+                s.returnValue = hirOptimizeVisitExpr(o, s.returnValue)
+            }
+            s
+        },
+        HirStmtIf -> {
+            s.ifCond = hirOptimizeVisitExpr(o, s.ifCond)
+            hirOptimizeVisitBlock(o, s.ifThen)
+            if s.ifHasElse {
+                hirOptimizeVisitBlock(o, s.ifElse)
+            }
+            if !(o.opts.disableBranch) && s.ifCond.kind == HirExprBoolLit {
+                if s.ifCond.boolValue {
+                    return hirBlockStmt(s.ifThen, s.span)
+                }
+                if s.ifHasElse {
+                    return hirBlockStmt(s.ifElse, s.span)
+                }
+                return hirBlockStmt(hirBlock(s.span), s.span)
+            }
+            s
+        },
+        HirStmtFor -> {
+            if s.forHasCond {
+                s.forCond = hirOptimizeVisitExpr(o, s.forCond)
+            }
+            if s.forHasIter {
+                s.forIter = hirOptimizeVisitExpr(o, s.forIter)
+            }
+            if s.forHasStart {
+                s.forStart = hirOptimizeVisitExpr(o, s.forStart)
+            }
+            if s.forHasEnd {
+                s.forEnd = hirOptimizeVisitExpr(o, s.forEnd)
+            }
+            hirOptimizeVisitBlock(o, s.forBody)
+            s
+        },
+        HirStmtDefer -> {
+            hirOptimizeVisitBlock(o, s.deferBody)
+            s
+        },
+        HirStmtChanSend -> {
+            s.chanChannel = hirOptimizeVisitExpr(o, s.chanChannel)
+            s.chanValue = hirOptimizeVisitExpr(o, s.chanValue)
+            s
+        },
+        HirStmtMatch -> {
+            s.matchScrutinee = hirOptimizeVisitExpr(o, s.matchScrutinee)
+            let armCount = s.matchArms.len()
+            for i in 0..armCount {
+                hirOptimizeVisitMatchArm(o, s.matchArms[i])
+            }
+            s
+        },
+        _ -> s,
+    }
+}
+
+fn hirOptimizeVisitMatchArm(o: HirOptimizer, arm: HirMatchArm) {
+    if arm.hasGuard {
+        arm.guard = hirOptimizeVisitExpr(o, arm.guard)
+    }
+    hirOptimizeVisitBlock(o, arm.body)
+}
+
+fn hirOptimizeVisitExpr(o: HirOptimizer, e: HirExpr) -> HirExpr {
+    match e.kind {
+        HirExprUnary -> {
+            if e.unaryChild.len() > 0 {
+                e.unaryChild[0] = hirOptimizeVisitExpr(o, e.unaryChild[0])
+            }
+            let folded = hirOptimizeFoldUnary(o, e)
+            if folded.kind != HirExprInvalid {
+                return folded
+            }
+            e
+        },
+        HirExprBinary -> {
+            if e.binaryLeft.len() > 0 {
+                e.binaryLeft[0] = hirOptimizeVisitExpr(o, e.binaryLeft[0])
+            }
+            if e.binaryRight.len() > 0 {
+                e.binaryRight[0] = hirOptimizeVisitExpr(o, e.binaryRight[0])
+            }
+            let folded = hirOptimizeFoldBinary(o, e)
+            if folded.kind != HirExprInvalid {
+                return folded
+            }
+            let simplified = hirOptimizeSimplifyBinary(o, e)
+            if simplified.kind != HirExprInvalid {
+                return simplified
+            }
+            e
+        },
+        HirExprCall -> {
+            if e.callCallee.len() > 0 {
+                e.callCallee[0] = hirOptimizeVisitExpr(o, e.callCallee[0])
+            }
+            let argCount = e.callArgs.len()
+            for i in 0..argCount {
+                e.callArgs[i].value = hirOptimizeVisitExpr(o, e.callArgs[i].value)
+            }
+            e
+        },
+        HirExprIntrinsic -> {
+            let argCount = e.intrinsicArgs.len()
+            for i in 0..argCount {
+                e.intrinsicArgs[i].value = hirOptimizeVisitExpr(o, e.intrinsicArgs[i].value)
+            }
+            e
+        },
+        HirExprMethod -> {
+            if e.methodReceiver.len() > 0 {
+                e.methodReceiver[0] = hirOptimizeVisitExpr(o, e.methodReceiver[0])
+            }
+            let argCount = e.methodArgs.len()
+            for i in 0..argCount {
+                e.methodArgs[i].value = hirOptimizeVisitExpr(o, e.methodArgs[i].value)
+            }
+            e
+        },
+        HirExprList -> {
+            let elemCount = e.listElems.len()
+            for i in 0..elemCount {
+                e.listElems[i] = hirOptimizeVisitExpr(o, e.listElems[i])
+            }
+            e
+        },
+        HirExprMapLit -> {
+            let entryCount = e.mapEntries.len()
+            for i in 0..entryCount {
+                e.mapEntries[i].key = hirOptimizeVisitExpr(o, e.mapEntries[i].key)
+                e.mapEntries[i].value = hirOptimizeVisitExpr(o, e.mapEntries[i].value)
+            }
+            e
+        },
+        HirExprTupleLit -> {
+            let elemCount = e.tupleElems.len()
+            for i in 0..elemCount {
+                e.tupleElems[i] = hirOptimizeVisitExpr(o, e.tupleElems[i])
+            }
+            e
+        },
+        HirExprStructLit -> {
+            let fieldCount = e.structFields.len()
+            for i in 0..fieldCount {
+                if e.structFields[i].hasValue {
+                    e.structFields[i].value = hirOptimizeVisitExpr(o, e.structFields[i].value)
+                }
+            }
+            if e.structHasSpread && e.structSpread.len() > 0 {
+                e.structSpread[0] = hirOptimizeVisitExpr(o, e.structSpread[0])
+            }
+            e
+        },
+        HirExprRange -> {
+            if e.rangeStart.len() > 0 {
+                e.rangeStart[0] = hirOptimizeVisitExpr(o, e.rangeStart[0])
+            }
+            if e.rangeEnd.len() > 0 {
+                e.rangeEnd[0] = hirOptimizeVisitExpr(o, e.rangeEnd[0])
+            }
+            e
+        },
+        HirExprQuestion -> {
+            if e.questionChild.len() > 0 {
+                e.questionChild[0] = hirOptimizeVisitExpr(o, e.questionChild[0])
+            }
+            e
+        },
+        HirExprCoalesce -> {
+            if e.coalesceLeft.len() > 0 {
+                e.coalesceLeft[0] = hirOptimizeVisitExpr(o, e.coalesceLeft[0])
+            }
+            if e.coalesceRight.len() > 0 {
+                e.coalesceRight[0] = hirOptimizeVisitExpr(o, e.coalesceRight[0])
+            }
+            e
+        },
+        HirExprField -> {
+            if e.fieldTarget.len() > 0 {
+                e.fieldTarget[0] = hirOptimizeVisitExpr(o, e.fieldTarget[0])
+            }
+            e
+        },
+        HirExprTupleAccess -> {
+            if e.tupleAccessTarget.len() > 0 {
+                e.tupleAccessTarget[0] = hirOptimizeVisitExpr(o, e.tupleAccessTarget[0])
+                if !(o.opts.disableSimplify) {
+                    let base = e.tupleAccessTarget[0]
+                    if base.kind == HirExprTupleLit
+                        && e.tupleAccessIndex >= 0
+                        && e.tupleAccessIndex < base.tupleElems.len() {
+                        return base.tupleElems[e.tupleAccessIndex]
+                    }
+                }
+            }
+            e
+        },
+        HirExprIndex -> {
+            if e.indexTarget.len() > 0 {
+                e.indexTarget[0] = hirOptimizeVisitExpr(o, e.indexTarget[0])
+            }
+            if e.indexIndex.len() > 0 {
+                e.indexIndex[0] = hirOptimizeVisitExpr(o, e.indexIndex[0])
+            }
+            e
+        },
+        HirExprClosure -> {
+            let paramCount = e.closureParams.len()
+            for i in 0..paramCount {
+                if e.closureParams[i].hasDefault {
+                    e.closureParams[i].defaultValue = hirOptimizeVisitExpr(o, e.closureParams[i].defaultValue)
+                }
+            }
+            if e.closureBody.len() > 0 {
+                hirOptimizeVisitBlock(o, e.closureBody[0])
+            }
+            e
+        },
+        HirExprVariantLit -> {
+            let argCount = e.variantArgs.len()
+            for i in 0..argCount {
+                e.variantArgs[i].value = hirOptimizeVisitExpr(o, e.variantArgs[i].value)
+            }
+            e
+        },
+        HirExprBlock -> {
+            if e.blockBody.len() > 0 {
+                hirOptimizeVisitBlock(o, e.blockBody[0])
+                if !(o.opts.disableSimplify) && e.blockBody[0].stmts.len() == 0 && e.blockBody[0].hasResult {
+                    return e.blockBody[0].result
+                }
+            }
+            e
+        },
+        HirExprIf -> {
+            if e.ifExprCond.len() > 0 {
+                e.ifExprCond[0] = hirOptimizeVisitExpr(o, e.ifExprCond[0])
+            }
+            if e.ifExprThen.len() > 0 {
+                hirOptimizeVisitBlock(o, e.ifExprThen[0])
+            }
+            if e.ifExprElse.len() > 0 {
+                hirOptimizeVisitBlock(o, e.ifExprElse[0])
+            }
+            if !(o.opts.disableBranch)
+                && e.ifExprCond.len() > 0
+                && e.ifExprCond[0].kind == HirExprBoolLit {
+                if e.ifExprCond[0].boolValue {
+                    return hirOptimizeBlockResult(hirOptimizeFirstBlock(e.ifExprThen), e.typ, e.span)
+                }
+                return hirOptimizeBlockResult(hirOptimizeFirstBlock(e.ifExprElse), e.typ, e.span)
+            }
+            e
+        },
+        HirExprIfLet -> {
+            if e.ifLetScrutinee.len() > 0 {
+                e.ifLetScrutinee[0] = hirOptimizeVisitExpr(o, e.ifLetScrutinee[0])
+            }
+            if e.ifLetThen.len() > 0 {
+                hirOptimizeVisitBlock(o, e.ifLetThen[0])
+            }
+            if e.ifLetElse.len() > 0 {
+                hirOptimizeVisitBlock(o, e.ifLetElse[0])
+            }
+            e
+        },
+        HirExprMatch -> {
+            if e.matchExprScrutinee.len() > 0 {
+                e.matchExprScrutinee[0] = hirOptimizeVisitExpr(o, e.matchExprScrutinee[0])
+            }
+            let armCount = e.matchExprArms.len()
+            for i in 0..armCount {
+                hirOptimizeVisitMatchArm(o, e.matchExprArms[i])
+            }
+            e
+        },
+        HirExprStringLit -> {
+            let partCount = e.strParts.len()
+            for i in 0..partCount {
+                if !(e.strParts[i].isLit) && e.strParts[i].expr.len() > 0 {
+                    e.strParts[i].expr[0] = hirOptimizeVisitExpr(o, e.strParts[i].expr[0])
+                }
+            }
+            e
+        },
+        _ -> e,
+    }
+}
+
+fn hirOptimizeBlockResult(b: HirBlock, t: HirType, span: HirSpan) -> HirExpr {
+    if b.stmts.len() == 0 {
+        if b.hasResult {
+            return b.result
+        }
+        return hirUnitLit(span)
+    }
+    hirBlockExpr(b, t, span)
+}
+
+// ====================================================================
+// Constant folding
+// ====================================================================
+
+fn hirOptimizeFoldUnary(o: HirOptimizer, e: HirExpr) -> HirExpr {
+    if o.opts.disableConstFold {
+        return hirExprInvalid()
+    }
+    if e.unaryChild.len() == 0 {
+        return hirExprInvalid()
+    }
+    let child = e.unaryChild[0]
+    match e.unaryOp {
+        HirUnNeg -> {
+            if child.kind == HirExprIntLit {
+                let v = 0 - hirOptimizeParseIntLit(child.numText)
+                return hirIntLit(hirOptimizeIntToString(v), e.typ, e.span)
+            }
+        },
+        HirUnPlus -> {
+            if child.kind == HirExprIntLit || child.kind == HirExprFloatLit {
+                return child
+            }
+        },
+        HirUnNot -> {
+            if child.kind == HirExprBoolLit {
+                return hirBoolLit(!(child.boolValue), e.span)
+            }
+        },
+        HirUnBitNot -> {
+            if child.kind == HirExprIntLit {
+                let v = hirOptimizeParseIntLit(child.numText)
+                return hirIntLit(hirOptimizeIntToString(~v), e.typ, e.span)
+            }
+        },
+        _ -> {},
+    }
+    hirExprInvalid()
+}
+
+fn hirOptimizeFoldBinary(o: HirOptimizer, e: HirExpr) -> HirExpr {
+    if o.opts.disableConstFold || e.binaryLeft.len() == 0 || e.binaryRight.len() == 0 {
+        return hirExprInvalid()
+    }
+    let left = e.binaryLeft[0]
+    let right = e.binaryRight[0]
+    if left.kind == HirExprIntLit && right.kind == HirExprIntLit {
+        let lv = hirOptimizeParseIntLit(left.numText)
+        let rv = hirOptimizeParseIntLit(right.numText)
+        return hirOptimizeFoldIntBinary(e, lv, rv)
+    }
+    if left.kind == HirExprBoolLit && right.kind == HirExprBoolLit {
+        return hirOptimizeFoldBoolBinary(e, left.boolValue, right.boolValue)
+    }
+    if e.binaryOp == HirBinAnd && left.kind == HirExprBoolLit {
+        if !(left.boolValue) {
+            return hirBoolLit(false, e.span)
+        }
+        return right
+    }
+    if e.binaryOp == HirBinOr && left.kind == HirExprBoolLit {
+        if left.boolValue {
+            return hirBoolLit(true, e.span)
+        }
+        return right
+    }
+    if e.binaryOp == HirBinAdd
+        && hirOptimizePureStringLit(left)
+        && hirOptimizePureStringLit(right) {
+        let parts = [hirStringPartLit(hirOptimizeStringText(left) + hirOptimizeStringText(right))]
+        let mut out = hirStringLit(parts, e.span)
+        out.strIsRaw = left.strIsRaw && right.strIsRaw
+        out.strIsTriple = false
+        return out
+    }
+    hirExprInvalid()
+}
+
+fn hirOptimizeSimplifyBinary(o: HirOptimizer, e: HirExpr) -> HirExpr {
+    if o.opts.disableSimplify || e.binaryLeft.len() == 0 || e.binaryRight.len() == 0 {
+        return hirExprInvalid()
+    }
+    let left = e.binaryLeft[0]
+    let right = e.binaryRight[0]
+    if e.binaryOp == HirBinAdd {
+        if hirOptimizeIsIntLiteralZero(right) {
+            return left
+        }
+        if hirOptimizeIsIntLiteralZero(left) {
+            return right
+        }
+    }
+    if e.binaryOp == HirBinSub && hirOptimizeIsIntLiteralZero(right) {
+        return left
+    }
+    if e.binaryOp == HirBinMul {
+        if hirOptimizeIsIntLiteralOne(right) {
+            return left
+        }
+        if hirOptimizeIsIntLiteralOne(left) {
+            return right
+        }
+        if hirOptimizeIsIntLiteralZero(right) || hirOptimizeIsIntLiteralZero(left) {
+            return hirIntLit("0", e.typ, e.span)
+        }
+    }
+    if e.binaryOp == HirBinDiv && hirOptimizeIsIntLiteralOne(right) {
+        return left
+    }
+    hirExprInvalid()
+}
+
+fn hirOptimizeFoldIntBinary(e: HirExpr, lv: Int, rv: Int) -> HirExpr {
+    match e.binaryOp {
+        HirBinAdd -> hirIntLit(hirOptimizeIntToString(lv + rv), e.typ, e.span),
+        HirBinSub -> hirIntLit(hirOptimizeIntToString(lv - rv), e.typ, e.span),
+        HirBinMul -> hirIntLit(hirOptimizeIntToString(lv * rv), e.typ, e.span),
+        HirBinDiv -> {
+            if rv == 0 {
+                return hirExprInvalid()
+            }
+            hirIntLit(hirOptimizeIntToString(lv / rv), e.typ, e.span)
+        },
+        HirBinMod -> {
+            if rv == 0 {
+                return hirExprInvalid()
+            }
+            hirIntLit(hirOptimizeIntToString(lv % rv), e.typ, e.span)
+        },
+        HirBinBitAnd -> hirIntLit(hirOptimizeIntToString(lv & rv), e.typ, e.span),
+        HirBinBitOr -> hirIntLit(hirOptimizeIntToString(lv | rv), e.typ, e.span),
+        HirBinBitXor -> hirIntLit(hirOptimizeIntToString(lv ^ rv), e.typ, e.span),
+        HirBinShl -> {
+            if rv < 0 || rv > 1024 {
+                return hirExprInvalid()
+            }
+            hirIntLit(hirOptimizeIntToString(lv << rv), e.typ, e.span)
+        },
+        HirBinShr -> {
+            if rv < 0 || rv > 1024 {
+                return hirExprInvalid()
+            }
+            hirIntLit(hirOptimizeIntToString(lv >> rv), e.typ, e.span)
+        },
+        HirBinEq -> hirBoolLit(lv == rv, e.span),
+        HirBinNeq -> hirBoolLit(lv != rv, e.span),
+        HirBinLt -> hirBoolLit(lv < rv, e.span),
+        HirBinLeq -> hirBoolLit(lv <= rv, e.span),
+        HirBinGt -> hirBoolLit(lv > rv, e.span),
+        HirBinGeq -> hirBoolLit(lv >= rv, e.span),
+        _ -> hirExprInvalid(),
+    }
+}
+
+fn hirOptimizeFoldBoolBinary(e: HirExpr, left: Bool, right: Bool) -> HirExpr {
+    match e.binaryOp {
+        HirBinAnd -> hirBoolLit(left && right, e.span),
+        HirBinOr -> hirBoolLit(left || right, e.span),
+        HirBinEq -> hirBoolLit(left == right, e.span),
+        HirBinNeq -> hirBoolLit(left != right, e.span),
+        _ -> hirExprInvalid(),
+    }
+}
+
+fn hirOptimizeIsIntLiteralZero(e: HirExpr) -> Bool {
+    e.kind == HirExprIntLit && hirOptimizeParseIntLit(e.numText) == 0
+}
+
+fn hirOptimizeIsIntLiteralOne(e: HirExpr) -> Bool {
+    e.kind == HirExprIntLit && hirOptimizeParseIntLit(e.numText) == 1
+}
+
+fn hirOptimizePureStringLit(e: HirExpr) -> Bool {
+    if e.kind != HirExprStringLit {
+        return false
+    }
+    for p in e.strParts {
+        if !(p.isLit) {
+            return false
+        }
+    }
+    true
+}
+
+fn hirOptimizeStringText(e: HirExpr) -> String {
+    let mut out = ""
+    for p in e.strParts {
+        if p.isLit {
+            out = out + p.lit
+        }
+    }
+    out
+}
+
+// ====================================================================
+// Integer literal parsing
+// ====================================================================
+
+fn hirOptimizeParseIntLit(text: String) -> Int {
+    let stripped = strings.replaceAll(text, "_", "")
+    let trimmed = hirOptimizeStripSign(stripped)
+    let negative = stripped.len() > 0 && stripped.startsWith("-")
+    let value = hirOptimizeParseIntDigits(trimmed)
+    if negative {
+        0 - value
+    } else {
+        value
+    }
+}
+
+fn hirOptimizeStripSign(text: String) -> String {
+    if text.startsWith("+") || text.startsWith("-") {
+        strings.slice(text, 1, text.len())
+    } else {
+        text
+    }
+}
+
+fn hirOptimizeParseIntDigits(text: String) -> Int {
+    if text.len() == 0 {
+        return 0
+    }
+    if text.startsWith("0x") || text.startsWith("0X") {
+        return hirOptimizeParseRadix(strings.slice(text, 2, text.len()), 16)
+    }
+    if text.startsWith("0b") || text.startsWith("0B") {
+        return hirOptimizeParseRadix(strings.slice(text, 2, text.len()), 2)
+    }
+    if text.startsWith("0o") || text.startsWith("0O") {
+        return hirOptimizeParseRadix(strings.slice(text, 2, text.len()), 8)
+    }
+    hirOptimizeParseRadix(text, 10)
+}
+
+fn hirOptimizeParseRadix(text: String, radix: Int) -> Int {
+    let mut acc = 0
+    let chars = text.chars()
+    for ch in chars {
+        let d = hirOptimizeCharToDigit(ch)
+        if d < 0 || d >= radix {
+            return acc
+        }
+        acc = acc * radix + d
+    }
+    acc
+}
+
+fn hirOptimizeCharToDigit(ch: Char) -> Int {
+    match ch {
+        '0' -> 0,
+        '1' -> 1,
+        '2' -> 2,
+        '3' -> 3,
+        '4' -> 4,
+        '5' -> 5,
+        '6' -> 6,
+        '7' -> 7,
+        '8' -> 8,
+        '9' -> 9,
+        'a' -> 10,
+        'b' -> 11,
+        'c' -> 12,
+        'd' -> 13,
+        'e' -> 14,
+        'f' -> 15,
+        'A' -> 10,
+        'B' -> 11,
+        'C' -> 12,
+        'D' -> 13,
+        'E' -> 14,
+        'F' -> 15,
+        _ -> -1,
+    }
+}
+
+// ====================================================================
+// Misc helpers
+// ====================================================================
+
+fn hirOptimizeFirstBlock(xs: List<HirBlock>) -> HirBlock {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirBlock(hirNoSpan())
+    }
+}
+
+fn hirOptimizeIntToString(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let mut value = n
+    let mut negative = false
+    if value < 0 {
+        negative = true
+        value = -value
+    }
+    let mut digits: List<Int> = []
+    for _d in 0..40 {
+        if value == 0 {
+            break
+        }
+        digits.push(value % 10)
+        value = value / 10
+    }
+    let mut out = ""
+    if negative {
+        out = "-"
+    }
+    let mut i = digits.len() - 1
+    for _j in 0..digits.len() {
+        if i < 0 {
+            break
+        }
+        out = out + hirOptimizeDigitChar(digits[i])
+        i = i - 1
+    }
+    out
+}
+
+fn hirOptimizeDigitChar(d: Int) -> String {
+    match d {
+        0 -> "0",
+        1 -> "1",
+        2 -> "2",
+        3 -> "3",
+        4 -> "4",
+        5 -> "5",
+        6 -> "6",
+        7 -> "7",
+        8 -> "8",
+        9 -> "9",
+        _ -> "?",
+    }
+}

--- a/toolchain/hir_port_test.osty
+++ b/toolchain/hir_port_test.osty
@@ -1,0 +1,283 @@
+use std.testing
+
+// ==== Helpers =======================================================
+
+fn hirPortSpan() -> HirSpan {
+    hirNoSpan()
+}
+
+fn hirPortInt(text: String) -> HirExpr {
+    hirIntLit(text, hirTInt(), hirPortSpan())
+}
+
+fn hirPortStr(text: String) -> HirExpr {
+    hirStringLit([hirStringPartLit(text)], hirPortSpan())
+}
+
+fn hirPortModuleWithExpr(e: HirExpr) -> HirModule {
+    let m = hirModule("main")
+    m.script.push(hirExprStmt(e, hirPortSpan()))
+    m
+}
+
+fn hirPortFindQualified(xs: List<HirQualifiedRef>, qualifier: String, name: String) -> Bool {
+    for x in xs {
+        if x.qualifier == qualifier && x.name == name {
+            return true
+        }
+    }
+    false
+}
+
+fn hirPortFindMethod(xs: List<HirMethodRef>, module: String, typeName: String, method: String) -> Bool {
+    for x in xs {
+        if x.module == module && x.typeName == typeName && x.method == method {
+            return true
+        }
+    }
+    false
+}
+
+fn hirPortStringContains(haystack: String, needle: String) -> Bool {
+    let hLen = haystack.len()
+    let nLen = needle.len()
+    if nLen == 0 {
+        return true
+    }
+    if nLen > hLen {
+        return false
+    }
+    let last = hLen - nLen
+    for start in 0..(last + 1) {
+        let mut matched = true
+        for offset in 0..nLen {
+            if haystack[start + offset] != needle[offset] {
+                matched = false
+                break
+            }
+        }
+        if matched {
+            return true
+        }
+    }
+    false
+}
+
+// ==== Printing ======================================================
+
+fn testHirPrintModuleHeaderAndBody() {
+    let body = hirBlock(hirPortSpan())
+    hirBlockSetResult(body, hirPortInt("1"))
+    let fn_ = hirFnDecl("addOne", hirTInt(), hirPortSpan())
+    fn_.params.push(hirParam("x", hirTInt(), hirPortSpan()))
+    fn_.body = body
+
+    let m = hirModule("pkg")
+    m.fns.push(fn_)
+
+    let rendered = hirPrintModule(m)
+    testing.assert(hirPortStringContains(rendered, "(module \"pkg\""))
+    testing.assert(hirPortStringContains(rendered, "(fn addOne"))
+    testing.assert(hirPortStringContains(rendered, "(result 1)"))
+}
+
+fn testHirPatternStringVariant() {
+    let pat = hirVariantPat("Option", "Some", [hirIdentPat("x", hirPortSpan())], hirPortSpan())
+    testing.assertEq(hirPatternString(pat), "Option.Some(x)")
+}
+
+fn testHirWalkCollectsPreorderNodes() {
+    let body = hirBlock(hirPortSpan())
+    let expr = hirBinary(HirBinAdd, hirPortInt("1"), hirPortInt("2"), hirTInt(), hirPortSpan())
+    hirBlockAppend(body, hirExprStmt(expr, hirPortSpan()))
+    let fn_ = hirFnDecl("f", hirTUnit(), hirPortSpan())
+    fn_.body = body
+    let m = hirModule("main")
+    m.fns.push(fn_)
+
+    let walk = hirWalkModule(m)
+    testing.assertEq(walk.fns.len(), 1)
+    testing.assertEq(walk.blocks.len(), 1)
+    testing.assertEq(walk.stmts.len(), 1)
+    testing.assertEq(walk.exprs.len(), 3)
+    testing.assert(walk.exprs[0].kind == HirExprBinary)
+    testing.assert(walk.exprs[1].kind == HirExprIntLit)
+    testing.assert(walk.exprs[2].kind == HirExprIntLit)
+}
+
+// ==== Reach =========================================================
+
+fn testHirReachCollectsQualifiedCall() {
+    let callee = hirFieldExpr(
+        hirIdent("strings", HirIdentUnknown, hirTypeNamed("Strings", []), hirPortSpan()),
+        "compare",
+        hirTypeFn([hirTInt(), hirTInt()], hirTInt()),
+        hirPortSpan(),
+    )
+    let call = hirCall(
+        callee,
+        [hirArg(hirIdent("a", HirIdentLocal, hirTInt(), hirPortSpan()), hirPortSpan()),
+            hirArg(hirIdent("b", HirIdentLocal, hirTInt(), hirPortSpan()), hirPortSpan())],
+        hirTInt(),
+        hirPortSpan(),
+    )
+    let refs = hirReach(hirPortModuleWithExpr(call))
+    testing.assertEq(refs.len(), 1)
+    testing.assert(hirPortFindQualified(refs, "strings", "compare"))
+}
+
+fn testHirReachDedupesRepeatedCalls() {
+    let mk = hirCall(
+        hirFieldExpr(
+            hirIdent("strings", HirIdentUnknown, hirTypeNamed("Strings", []), hirPortSpan()),
+            "compare",
+            hirTypeFn([hirTInt(), hirTInt()], hirTInt()),
+            hirPortSpan(),
+        ),
+        [hirArg(hirPortInt("1"), hirPortSpan())],
+        hirTInt(),
+        hirPortSpan(),
+    )
+    let m = hirModule("main")
+    m.script.push(hirExprStmt(mk, hirPortSpan()))
+    m.script.push(hirExprStmt(mk, hirPortSpan()))
+
+    let refs = hirReach(m)
+    testing.assertEq(refs.len(), 1)
+}
+
+fn testHirReachMethodsCollectsStdlibReceiverMethod() {
+    let hexT = hirTypeNamedQualified("encoding", "Hex", [])
+    let recv = hirIdent("h", HirIdentLocal, hexT, hirPortSpan())
+    let call = hirMethodCall(recv, "encode", [hirArg(hirPortStr("data"), hirPortSpan())], hirTString(), hirPortSpan())
+
+    let refs = hirReachMethods(hirPortModuleWithExpr(call))
+    testing.assertEq(refs.len(), 1)
+    testing.assert(hirPortFindMethod(refs, "encoding", "Hex", "encode"))
+}
+
+fn testHirReachMethodsSkipsUserTypes() {
+    let userT = hirTypeNamed("MyType", [])
+    let recv = hirIdent("v", HirIdentLocal, userT, hirPortSpan())
+    let call = hirMethodCall(recv, "doThing", [], hirTUnit(), hirPortSpan())
+    let refs = hirReachMethods(hirPortModuleWithExpr(call))
+    testing.assertEq(refs.len(), 0)
+}
+
+// ==== Validate ======================================================
+
+fn testHirValidateAcceptsWellFormedModule() {
+    let body = hirBlock(hirPortSpan())
+    hirBlockSetResult(body, hirPortInt("1"))
+    let fn_ = hirFnDecl("f", hirTInt(), hirPortSpan())
+    fn_.body = body
+    let m = hirModule("main")
+    m.fns.push(fn_)
+
+    let errs = hirValidateModule(m)
+    testing.assertEq(errs.len(), 0)
+}
+
+fn testHirValidateRejectsLetWithoutBinding() {
+    let m = hirModule("main")
+    let mut bad = hirStmtInvalid()
+    bad.kind = HirStmtLet
+    bad.letHasValue = true
+    bad.letValue = hirPortInt("1")
+    bad.span = hirPortSpan()
+    m.script.push(bad)
+
+    let errs = hirValidateModule(m)
+    testing.assert(errs.len() >= 1)
+}
+
+fn testHirValidateDecisionTreeRejectsOutOfRangeLeaf() {
+    let errs = hirValidateDecisionTree(hirDecisionLeaf(99), 2)
+    testing.assert(errs.len() >= 1)
+}
+
+// ==== Optimize ======================================================
+
+fn testHirOptimizeFoldsIntArithmetic() {
+    let e = hirBinary(
+        HirBinMul,
+        hirBinary(HirBinAdd, hirPortInt("1"), hirPortInt("2"), hirTInt(), hirPortSpan()),
+        hirPortInt("3"),
+        hirTInt(),
+        hirPortSpan(),
+    )
+    let m = hirPortModuleWithExpr(e)
+    hirOptimize(m, hirOptimizeOptions())
+
+    let got = m.script[0].exprValue
+    testing.assert(got.kind == HirExprIntLit)
+    testing.assertEq(got.numText, "9")
+}
+
+fn testHirOptimizeFoldsBoolLogic() {
+    let e = hirBinary(HirBinAnd, hirBoolLit(true, hirPortSpan()), hirBoolLit(false, hirPortSpan()), hirTBool(), hirPortSpan())
+    let m = hirPortModuleWithExpr(e)
+    hirOptimize(m, hirOptimizeOptions())
+
+    let got = m.script[0].exprValue
+    testing.assert(got.kind == HirExprBoolLit)
+    testing.assert(!(got.boolValue))
+}
+
+fn testHirOptimizeSimplifiesIdentity() {
+    let e = hirBinary(
+        HirBinAdd,
+        hirIdent("x", HirIdentLocal, hirTInt(), hirPortSpan()),
+        hirPortInt("0"),
+        hirTInt(),
+        hirPortSpan(),
+    )
+    let m = hirPortModuleWithExpr(e)
+    hirOptimize(m, hirOptimizeOptions())
+
+    let got = m.script[0].exprValue
+    testing.assert(got.kind == HirExprIdent)
+    testing.assertEq(got.identName, "x")
+}
+
+fn testHirOptimizeDeadCodeAfterReturn() {
+    let body = hirBlock(hirPortSpan())
+    hirBlockAppend(body, hirReturnStmt(hirPortInt("1"), hirPortSpan()))
+    hirBlockAppend(body, hirExprStmt(hirPortInt("2"), hirPortSpan()))
+    hirBlockAppend(body, hirExprStmt(hirPortInt("3"), hirPortSpan()))
+
+    let fn_ = hirFnDecl("f", hirTInt(), hirPortSpan())
+    fn_.body = body
+    let m = hirModule("main")
+    m.fns.push(fn_)
+
+    hirOptimize(m, hirOptimizeOptions())
+    testing.assertEq(m.fns[0].body.stmts.len(), 1)
+    testing.assert(m.fns[0].body.stmts[0].kind == HirStmtReturn)
+}
+
+fn testHirOptimizeFoldsConstantIfExpr() {
+    let thenB = hirBlock(hirPortSpan())
+    hirBlockSetResult(thenB, hirPortInt("1"))
+    let elseB = hirBlock(hirPortSpan())
+    hirBlockSetResult(elseB, hirPortInt("2"))
+    let e = hirIfExpr(hirBoolLit(true, hirPortSpan()), thenB, elseB, hirTInt(), hirPortSpan())
+
+    let m = hirPortModuleWithExpr(e)
+    hirOptimize(m, hirOptimizeOptions())
+
+    let got = m.script[0].exprValue
+    testing.assert(got.kind == HirExprIntLit)
+    testing.assertEq(got.numText, "1")
+}
+
+fn testHirOptimizeRespectsDisableConstFold() {
+    let e = hirBinary(HirBinAdd, hirPortInt("1"), hirPortInt("2"), hirTInt(), hirPortSpan())
+    let m = hirPortModuleWithExpr(e)
+    let opts = hirOptimizeOptions()
+    opts.disableConstFold = true
+    hirOptimize(m, opts)
+
+    let got = m.script[0].exprValue
+    testing.assert(got.kind == HirExprBinary)
+}

--- a/toolchain/hir_print.osty
+++ b/toolchain/hir_print.osty
@@ -1,0 +1,984 @@
+use std.strings as strings
+
+// hir_print.osty — stable debug rendering helpers for self-hosted HIR.
+//
+// This is the HIR-side counterpart to `internal/ir/print.go` plus
+// `internal/ir/pattern.go`'s PatternString helper. HIR is not interface-
+// based like Go IR, so the entry points are per-shape (`hirPrintModule`,
+// `hirPrintStmt`, `hirPrintExpr`, `hirPatternString`) rather than a single
+// `PrintNode(any)` API.
+
+// ====================================================================
+// Public entry points
+// ====================================================================
+
+pub fn hirPrintModule(m: HirModule) -> String {
+    let mut parts: List<String> = []
+    parts.push("(module \"{hirPrintEscapeString(m.packageName)}\"")
+
+    for decl in m.fns {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintFnDecl(decl, 1))
+    }
+    for decl in m.structs {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintStructDecl(decl, 1))
+    }
+    for decl in m.enums {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintEnumDecl(decl, 1))
+    }
+    for decl in m.interfaces {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintInterfaceDecl(decl, 1))
+    }
+    for decl in m.aliases {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintTypeAliasDecl(decl))
+    }
+    for decl in m.lets {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintLetDecl(decl))
+    }
+    for decl in m.uses {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push(hirPrintUseDecl(decl))
+    }
+
+    if m.script.len() > 0 {
+        parts.push("\n")
+        parts.push(hirPrintIndent(1))
+        parts.push("(script")
+        for stmt in m.script {
+            parts.push("\n")
+            parts.push(hirPrintIndent(2))
+            parts.push(hirPrintStmt(stmt, 2))
+        }
+        parts.push(")")
+    }
+
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+pub fn hirPrintBlock(b: HirBlock, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(block")
+    for stmt in b.stmts {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintStmt(stmt, indent + 1))
+    }
+    if b.hasResult {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("(result ")
+        parts.push(hirPrintExpr(b.result, indent + 1))
+        parts.push(")")
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+pub fn hirPrintStmt(s: HirStmt, indent: Int) -> String {
+    match s.kind {
+        HirStmtInvalid -> "(stmt <invalid>)",
+        HirStmtBlock -> hirPrintBlock(s.block, indent),
+        HirStmtLet -> hirPrintLetStmt(s, indent),
+        HirStmtExpr -> "(stmt " + hirPrintExpr(s.exprValue, indent) + ")",
+        HirStmtAssign -> hirPrintAssignStmt(s, indent),
+        HirStmtReturn -> hirPrintReturnStmt(s, indent),
+        HirStmtBreak -> "(break)",
+        HirStmtContinue -> "(continue)",
+        HirStmtIf -> hirPrintIfStmt(s, indent),
+        HirStmtFor -> hirPrintForStmt(s, indent),
+        HirStmtMatch -> hirPrintMatchStmt(s, indent),
+        HirStmtDefer -> "(defer " + hirPrintBlock(s.deferBody, indent) + ")",
+        HirStmtChanSend -> "(send " + hirPrintExpr(s.chanChannel, indent) + " "
+            + hirPrintExpr(s.chanValue, indent) + ")",
+        HirStmtError -> "(err-stmt \"" + hirPrintEscapeString(s.errorNote) + "\")",
+    }
+}
+
+pub fn hirPrintExpr(e: HirExpr, indent: Int) -> String {
+    match e.kind {
+        HirExprInvalid -> "nil",
+        HirExprIntLit -> e.numText,
+        HirExprFloatLit -> e.numText,
+        HirExprBoolLit -> if e.boolValue { "true" } else { "false" },
+        HirExprCharLit -> "'" + hirPrintEscapeChar(e.charValue) + "'",
+        HirExprByteLit -> "b" + hirPrintIntToString(e.byteValue),
+        HirExprStringLit -> hirPrintStringLit(e),
+        HirExprUnitLit -> "()",
+        HirExprIdent -> hirPrintIdentExpr(e),
+        HirExprUnary -> "(" + hirUnOpName(e.unaryOp) + " "
+            + hirPrintExpr(hirPrintFirstExpr(e.unaryChild), indent) + ")",
+        HirExprBinary -> "(" + hirBinOpName(e.binaryOp) + " "
+            + hirPrintExpr(hirPrintFirstExpr(e.binaryLeft), indent) + " "
+            + hirPrintExpr(hirPrintFirstExpr(e.binaryRight), indent) + ")",
+        HirExprCall -> hirPrintCallExpr(e, indent),
+        HirExprIntrinsic -> hirPrintIntrinsicExpr(e, indent),
+        HirExprList -> hirPrintListExpr(e, indent),
+        HirExprBlock -> hirPrintBlock(hirPrintFirstBlock(e.blockBody), indent),
+        HirExprIf -> hirPrintIfExpr(e, indent),
+        HirExprField -> "(" + if e.fieldOptional { "?." } else { "." } + " "
+            + hirPrintExpr(hirPrintFirstExpr(e.fieldTarget), indent) + " "
+            + e.fieldName + ")",
+        HirExprIndex -> "(idx " + hirPrintExpr(hirPrintFirstExpr(e.indexTarget), indent)
+            + " " + hirPrintExpr(hirPrintFirstExpr(e.indexIndex), indent) + ")",
+        HirExprMethod -> hirPrintMethodExpr(e, indent),
+        HirExprStructLit -> hirPrintStructLitExpr(e, indent),
+        HirExprTupleLit -> hirPrintTupleExpr(e, indent),
+        HirExprMapLit -> hirPrintMapExpr(e, indent),
+        HirExprRange -> hirPrintRangeExpr(e, indent),
+        HirExprQuestion -> "(? " + hirPrintExpr(hirPrintFirstExpr(e.questionChild), indent) + ")",
+        HirExprCoalesce -> "(?? " + hirPrintExpr(hirPrintFirstExpr(e.coalesceLeft), indent)
+            + " " + hirPrintExpr(hirPrintFirstExpr(e.coalesceRight), indent) + ")",
+        HirExprClosure -> hirPrintClosureExpr(e, indent),
+        HirExprVariantLit -> hirPrintVariantLitExpr(e, indent),
+        HirExprMatch -> hirPrintMatchExpr(e, indent),
+        HirExprIfLet -> hirPrintIfLetExpr(e, indent),
+        HirExprTupleAccess -> "(." + hirPrintIntToString(e.tupleAccessIndex) + " "
+            + hirPrintExpr(hirPrintFirstExpr(e.tupleAccessTarget), indent) + ")",
+        HirExprError -> "(err \"" + hirPrintEscapeString(e.errorNote) + "\")",
+    }
+}
+
+pub fn hirPatternString(p: HirPattern) -> String {
+    match p.kind {
+        HirPatInvalid -> "<nil>",
+        HirPatWild -> "_",
+        HirPatIdent -> {
+            if p.identMut {
+                "mut " + p.identName
+            } else {
+                p.identName
+            }
+        },
+        HirPatLit -> hirExprLiteralText(hirPrintFirstExpr(p.litValue)),
+        HirPatTuple -> hirPrintTuplePattern(p),
+        HirPatStruct -> hirPrintStructPattern(p),
+        HirPatVariant -> hirPrintVariantPattern(p),
+        HirPatRange -> hirPrintRangePattern(p),
+        HirPatOr -> hirPrintOrPattern(p),
+        HirPatBinding -> p.bindingName + " @ " + hirPatternString(hirPrintFirstPattern(p.bindingChild)),
+        HirPatError -> "<error:" + p.errorNote + ">",
+    }
+}
+
+// ====================================================================
+// Decl printers
+// ====================================================================
+
+fn hirPrintFnDecl(d: HirFnDecl, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(fn ")
+    parts.push(d.name)
+    if d.exported {
+        parts.push(" pub")
+    }
+    if d.generics.len() > 0 {
+        parts.push(" [")
+        let mut i = 0
+        for g in d.generics {
+            if i > 0 {
+                parts.push(" ")
+            }
+            parts.push(g.name)
+            i = i + 1
+        }
+        parts.push("]")
+    }
+    parts.push(" (")
+    let mut i = 0
+    for pm in d.params {
+        if i > 0 {
+            parts.push(" ")
+        }
+        parts.push(hirPrintParam(pm))
+        i = i + 1
+    }
+    parts.push(") -> ")
+    parts.push(hirTypeString(d.ret))
+    parts.push("\n")
+    parts.push(hirPrintIndent(indent + 1))
+    parts.push(hirPrintBlock(d.body, indent + 1))
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintStructDecl(d: HirStructDecl, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(struct ")
+    parts.push(d.name)
+    if d.exported {
+        parts.push(" pub")
+    }
+    if d.builderDerivable {
+        parts.push(" builder-derivable")
+    }
+    if d.builderRequiredFields.len() > 0 {
+        parts.push(" builder-required=[")
+        let mut i = 0
+        for name in d.builderRequiredFields {
+            if i > 0 {
+                parts.push(",")
+            }
+            parts.push(name)
+            i = i + 1
+        }
+        parts.push("]")
+    }
+    for field in d.fields {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("(field ")
+        parts.push(field.name)
+        parts.push(" ")
+        parts.push(hirTypeString(field.typ))
+        if field.jsonKey != "" {
+            parts.push(" json-key=\"")
+            parts.push(hirPrintEscapeString(field.jsonKey))
+            parts.push("\"")
+        }
+        if field.jsonSkip {
+            parts.push(" json-skip")
+        }
+        if field.jsonOptional {
+            parts.push(" json-optional")
+        }
+        parts.push(")")
+    }
+    for method in d.methods {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintFnDecl(method, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintEnumDecl(d: HirEnumDecl, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(enum ")
+    parts.push(d.name)
+    for vr in d.variants {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("(variant ")
+        parts.push(vr.name)
+        for pl in vr.payload {
+            parts.push(" ")
+            parts.push(hirTypeString(pl))
+        }
+        if vr.jsonTag != "" {
+            parts.push(" json-tag=\"")
+            parts.push(hirPrintEscapeString(vr.jsonTag))
+            parts.push("\"")
+        }
+        if vr.jsonSkip {
+            parts.push(" json-skip")
+        }
+        parts.push(")")
+    }
+    for method in d.methods {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintFnDecl(method, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintInterfaceDecl(d: HirInterfaceDecl, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(interface ")
+    parts.push(d.name)
+    for method in d.methods {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintFnDecl(method, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintTypeAliasDecl(d: HirTypeAliasDecl) -> String {
+    "(alias " + d.name + " " + hirTypeString(d.target) + ")"
+}
+
+fn hirPrintLetDecl(d: HirLetDecl) -> String {
+    let mut out = "(let " + d.name + " " + hirTypeString(d.typ) + " "
+    if d.hasValue {
+        out = out + hirPrintExpr(d.value, 0)
+    } else {
+        out = out + "nil"
+    }
+    out + ")"
+}
+
+fn hirPrintUseDecl(d: HirUseDecl) -> String {
+    let path = if d.isGoFFI {
+        d.goPath
+    } else if d.isRuntimeFFI {
+        d.runtimePath
+    } else {
+        strings.join(d.path, ".")
+    }
+    let mut out = "(use " + path
+    if d.alias != "" && (d.path.len() == 0 || d.alias != d.path[d.path.len() - 1]) {
+        out = out + " as=" + d.alias
+    }
+    out + ")"
+}
+
+// ====================================================================
+// Statement printers
+// ====================================================================
+
+fn hirPrintLetStmt(s: HirStmt, indent: Int) -> String {
+    let mut out = ""
+    if s.letHasPattern {
+        out = "(let-pat " + hirPatternString(s.letPattern) + " "
+    } else {
+        out = "(let " + s.letName + " "
+    }
+    if s.letHasType {
+        out = out + hirTypeString(s.letTyp) + " "
+    } else {
+        out = out + "<nil> "
+    }
+    if s.letHasValue {
+        out = out + hirPrintExpr(s.letValue, indent)
+    } else {
+        out = out + "nil"
+    }
+    out + ")"
+}
+
+fn hirPrintAssignStmt(s: HirStmt, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(assign ")
+    parts.push(hirAssignOpName(s.assignOp))
+    for t in s.assignTargets {
+        parts.push(" ")
+        parts.push(hirPrintExpr(t, indent))
+    }
+    parts.push(" := ")
+    parts.push(hirPrintExpr(s.assignValue, indent))
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintReturnStmt(s: HirStmt, indent: Int) -> String {
+    let mut out = "(return"
+    if s.returnHasValue {
+        out = out + " " + hirPrintExpr(s.returnValue, indent)
+    }
+    out + ")"
+}
+
+fn hirPrintIfStmt(s: HirStmt, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(if ")
+    parts.push(hirPrintExpr(s.ifCond, indent))
+    parts.push("\n")
+    parts.push(hirPrintIndent(indent + 1))
+    parts.push(hirPrintBlock(s.ifThen, indent + 1))
+    if s.ifHasElse {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("else ")
+        parts.push(hirPrintBlock(s.ifElse, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintForStmt(s: HirStmt, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(for ")
+    parts.push(hirForKindName(s.forKind))
+    if s.forVar != "" {
+        parts.push(" ")
+        parts.push(s.forVar)
+    } else if s.forHasPattern {
+        parts.push(" ")
+        parts.push(hirPatternString(s.forPattern))
+    }
+    if s.forHasCond {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("cond=")
+        parts.push(hirPrintExpr(s.forCond, indent + 1))
+    }
+    if s.forHasIter {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("iter=")
+        parts.push(hirPrintExpr(s.forIter, indent + 1))
+    }
+    if s.forHasStart {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("start=")
+        parts.push(hirPrintExpr(s.forStart, indent + 1))
+    }
+    if s.forHasEnd {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push("end=")
+        parts.push(hirPrintExpr(s.forEnd, indent + 1))
+    }
+    parts.push("\n")
+    parts.push(hirPrintIndent(indent + 1))
+    parts.push(hirPrintBlock(s.forBody, indent + 1))
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintMatchStmt(s: HirStmt, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(match-stmt ")
+    parts.push(hirPrintExpr(s.matchScrutinee, indent))
+    for arm in s.matchArms {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintMatchArm(arm, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+// ====================================================================
+// Expression printers
+// ====================================================================
+
+fn hirPrintIdentExpr(e: HirExpr) -> String {
+    let mut out = e.identName
+    if e.identKind != HirIdentUnknown {
+        out = out + "#" + hirIdentKindName(e.identKind)
+    }
+    if e.identTypeArgs.len() > 0 {
+        out = out + "::<"
+        let mut i = 0
+        for ta in e.identTypeArgs {
+            if i > 0 {
+                out = out + ","
+            }
+            out = out + hirTypeString(ta)
+            i = i + 1
+        }
+        out = out + ">"
+    }
+    out
+}
+
+fn hirPrintCallExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(call ")
+    parts.push(hirPrintExpr(hirPrintFirstExpr(e.callCallee), indent))
+    if e.callTypeArgs.len() > 0 {
+        parts.push(" ::<")
+        let mut i = 0
+        for ta in e.callTypeArgs {
+            if i > 0 {
+                parts.push(",")
+            }
+            parts.push(hirTypeString(ta))
+            i = i + 1
+        }
+        parts.push(">")
+    }
+    for a in e.callArgs {
+        parts.push(" ")
+        parts.push(hirPrintArg(a, indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintIntrinsicExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(intrinsic ")
+    parts.push(hirIntrinsicKindName(e.intrinsicKind))
+    for a in e.intrinsicArgs {
+        parts.push(" ")
+        parts.push(hirPrintArg(a, indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintMethodExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(mcall ")
+    parts.push(hirPrintExpr(hirPrintFirstExpr(e.methodReceiver), indent))
+    parts.push(" ")
+    parts.push(e.methodName)
+    if e.methodTypeArgs.len() > 0 {
+        parts.push(" ::<")
+        let mut i = 0
+        for ta in e.methodTypeArgs {
+            if i > 0 {
+                parts.push(",")
+            }
+            parts.push(hirTypeString(ta))
+            i = i + 1
+        }
+        parts.push(">")
+    }
+    for a in e.methodArgs {
+        parts.push(" ")
+        parts.push(hirPrintArg(a, indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintListExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("[")
+    let mut i = 0
+    for el in e.listElems {
+        if i > 0 {
+            parts.push(" ")
+        }
+        parts.push(hirPrintExpr(el, indent))
+        i = i + 1
+    }
+    parts.push("]")
+    strings.join(parts, "")
+}
+
+fn hirPrintTupleExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(")
+    let mut i = 0
+    for el in e.tupleElems {
+        if i > 0 {
+            parts.push(", ")
+        }
+        parts.push(hirPrintExpr(el, indent))
+        i = i + 1
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintMapExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("{")
+    let mut i = 0
+    for en in e.mapEntries {
+        if i > 0 {
+            parts.push(", ")
+        }
+        parts.push(hirPrintExpr(en.key, indent))
+        parts.push(":")
+        parts.push(hirPrintExpr(en.value, indent))
+        i = i + 1
+    }
+    parts.push("}")
+    strings.join(parts, "")
+}
+
+fn hirPrintStructLitExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(")
+    parts.push(e.structTypeName)
+    parts.push(" {")
+    let mut i = 0
+    for f in e.structFields {
+        if i > 0 {
+            parts.push(", ")
+        }
+        parts.push(f.name)
+        parts.push(":")
+        if f.hasValue {
+            parts.push(hirPrintExpr(f.value, indent))
+        } else {
+            parts.push(f.name)
+        }
+        i = i + 1
+    }
+    if e.structHasSpread && e.structSpread.len() > 0 {
+        parts.push(" ..")
+        parts.push(hirPrintExpr(e.structSpread[0], indent))
+    }
+    parts.push("})")
+    strings.join(parts, "")
+}
+
+fn hirPrintRangeExpr(e: HirExpr, indent: Int) -> String {
+    let mut out = ""
+    if e.rangeStart.len() > 0 {
+        out = out + hirPrintExpr(e.rangeStart[0], indent)
+    }
+    if e.rangeInclusive {
+        out = out + "..="
+    } else {
+        out = out + ".."
+    }
+    if e.rangeEnd.len() > 0 {
+        out = out + hirPrintExpr(e.rangeEnd[0], indent)
+    }
+    out
+}
+
+fn hirPrintClosureExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(\\(")
+    let mut i = 0
+    for pm in e.closureParams {
+        if i > 0 {
+            parts.push(" ")
+        }
+        parts.push(hirPrintParam(pm))
+        i = i + 1
+    }
+    parts.push(") -> ")
+    parts.push(hirTypeString(e.closureReturn))
+    if e.closureCaptures.len() > 0 {
+        parts.push(" captures=[")
+        let mut j = 0
+        for c in e.closureCaptures {
+            if j > 0 {
+                parts.push(" ")
+            }
+            parts.push(c.name)
+            parts.push(":")
+            parts.push(hirTypeString(c.typ))
+            j = j + 1
+        }
+        parts.push("]")
+    }
+    parts.push(" ")
+    parts.push(hirPrintBlock(hirPrintFirstBlock(e.closureBody), indent))
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintVariantLitExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(")
+    if e.variantEnum != "" {
+        parts.push(e.variantEnum)
+        parts.push(".")
+    }
+    parts.push(e.variantName)
+    for a in e.variantArgs {
+        parts.push(" ")
+        parts.push(hirPrintArg(a, indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintIfExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(if-expr ")
+    parts.push(hirPrintExpr(hirPrintFirstExpr(e.ifExprCond), indent))
+    parts.push(" ")
+    parts.push(hirPrintBlock(hirPrintFirstBlock(e.ifExprThen), indent))
+    if e.ifExprElse.len() > 0 {
+        parts.push(" else ")
+        parts.push(hirPrintBlock(hirPrintFirstBlock(e.ifExprElse), indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintIfLetExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(if-let ")
+    parts.push(hirPatternString(e.ifLetPattern))
+    parts.push(" ")
+    parts.push(hirPrintExpr(hirPrintFirstExpr(e.ifLetScrutinee), indent))
+    parts.push(" ")
+    parts.push(hirPrintBlock(hirPrintFirstBlock(e.ifLetThen), indent))
+    if e.ifLetHasElse && e.ifLetElse.len() > 0 {
+        parts.push(" else ")
+        parts.push(hirPrintBlock(hirPrintFirstBlock(e.ifLetElse), indent))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintMatchExpr(e: HirExpr, indent: Int) -> String {
+    let mut parts: List<String> = []
+    parts.push("(match ")
+    parts.push(hirPrintExpr(hirPrintFirstExpr(e.matchExprScrutinee), indent))
+    for arm in e.matchExprArms {
+        parts.push("\n")
+        parts.push(hirPrintIndent(indent + 1))
+        parts.push(hirPrintMatchArm(arm, indent + 1))
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintStringLit(e: HirExpr) -> String {
+    let mut out = "\""
+    for part in e.strParts {
+        if part.isLit {
+            out = out + hirPrintEscapeString(part.lit)
+        } else if part.expr.len() > 0 {
+            out = out + "{"
+            out = out + hirPrintExpr(part.expr[0], 0)
+            out = out + "}"
+        }
+    }
+    out + "\""
+}
+
+// ====================================================================
+// Shared leaf printers
+// ====================================================================
+
+fn hirPrintParam(pm: HirParam) -> String {
+    if hirParamIsDestructured(pm) {
+        hirPatternString(pm.pattern) + ":" + hirTypeString(pm.typ)
+    } else {
+        pm.name + ":" + hirTypeString(pm.typ)
+    }
+}
+
+fn hirPrintArg(a: HirArg, indent: Int) -> String {
+    if a.name != "" {
+        a.name + ":" + hirPrintExpr(a.value, indent)
+    } else {
+        hirPrintExpr(a.value, indent)
+    }
+}
+
+fn hirPrintMatchArm(a: HirMatchArm, indent: Int) -> String {
+    let mut out = "(arm " + hirPatternString(a.pattern)
+    if a.hasGuard {
+        out = out + " if=" + hirPrintExpr(a.guard, indent)
+    }
+    out = out + " " + hirPrintBlock(a.body, indent)
+    out + ")"
+}
+
+fn hirPrintTuplePattern(p: HirPattern) -> String {
+    let mut parts: List<String> = []
+    parts.push("(")
+    let mut i = 0
+    for el in p.tupleElems {
+        if i > 0 {
+            parts.push(", ")
+        }
+        parts.push(hirPatternString(el))
+        i = i + 1
+    }
+    parts.push(")")
+    strings.join(parts, "")
+}
+
+fn hirPrintStructPattern(p: HirPattern) -> String {
+    let mut parts: List<String> = []
+    parts.push(p.structTypeName)
+    parts.push(" { ")
+    let mut i = 0
+    for f in p.structFields {
+        if i > 0 {
+            parts.push(", ")
+        }
+        parts.push(f.name)
+        if f.hasPattern {
+            parts.push(": ")
+            parts.push(hirPatternString(f.pattern))
+        }
+        i = i + 1
+    }
+    if p.structRest {
+        if p.structFields.len() > 0 {
+            parts.push(", ")
+        }
+        parts.push("..")
+    }
+    parts.push(" }")
+    strings.join(parts, "")
+}
+
+fn hirPrintVariantPattern(p: HirPattern) -> String {
+    let mut parts: List<String> = []
+    if p.variantEnum != "" {
+        parts.push(p.variantEnum)
+        parts.push(".")
+    }
+    parts.push(p.variantName)
+    if p.variantArgs.len() > 0 {
+        parts.push("(")
+        let mut i = 0
+        for a in p.variantArgs {
+            if i > 0 {
+                parts.push(", ")
+            }
+            parts.push(hirPatternString(a))
+            i = i + 1
+        }
+        parts.push(")")
+    }
+    strings.join(parts, "")
+}
+
+fn hirPrintRangePattern(p: HirPattern) -> String {
+    let mut out = ""
+    if p.rangeLow.len() > 0 {
+        out = out + hirExprLiteralText(p.rangeLow[0])
+    }
+    if p.rangeInclusive {
+        out = out + "..="
+    } else {
+        out = out + ".."
+    }
+    if p.rangeHigh.len() > 0 {
+        out = out + hirExprLiteralText(p.rangeHigh[0])
+    }
+    out
+}
+
+fn hirPrintOrPattern(p: HirPattern) -> String {
+    let mut parts: List<String> = []
+    let mut i = 0
+    for a in p.orAlts {
+        if i > 0 {
+            parts.push(" | ")
+        }
+        parts.push(hirPatternString(a))
+        i = i + 1
+    }
+    strings.join(parts, "")
+}
+
+fn hirExprLiteralText(e: HirExpr) -> String {
+    match e.kind {
+        HirExprIntLit -> e.numText,
+        HirExprFloatLit -> e.numText,
+        HirExprBoolLit -> if e.boolValue { "true" } else { "false" },
+        HirExprCharLit -> "'" + hirPrintEscapeChar(e.charValue) + "'",
+        HirExprByteLit -> "b" + hirPrintIntToString(e.byteValue),
+        HirExprStringLit -> {
+            let mut out = "\""
+            for part in e.strParts {
+                if part.isLit {
+                    out = out + part.lit
+                } else {
+                    out = out + "{expr}"
+                }
+            }
+            out + "\""
+        },
+        HirExprIdent -> e.identName,
+        _ -> "<expr>",
+    }
+}
+
+// ====================================================================
+// Small helpers
+// ====================================================================
+
+fn hirPrintFirstExpr(xs: List<HirExpr>) -> HirExpr {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirExprInvalid()
+    }
+}
+
+fn hirPrintFirstBlock(xs: List<HirBlock>) -> HirBlock {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirBlock(hirNoSpan())
+    }
+}
+
+fn hirPrintFirstPattern(xs: List<HirPattern>) -> HirPattern {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirPatternInvalid()
+    }
+}
+
+fn hirPrintEscapeString(text: String) -> String {
+    let slash = strings.replaceAll(text, "\\", "\\\\")
+    let quote = strings.replaceAll(slash, "\"", "\\\"")
+    let newline = strings.replaceAll(quote, "\n", "\\n")
+    strings.replaceAll(newline, "\t", "\\t")
+}
+
+fn hirPrintEscapeChar(value: Char) -> String {
+    if value == '\'' {
+        "\\'"
+    } else {
+        "{value}"
+    }
+}
+
+fn hirPrintIndent(depth: Int) -> String {
+    let mut out = ""
+    for _i in 0..depth {
+        out = out + "  "
+    }
+    out
+}
+
+fn hirPrintIntToString(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let mut value = n
+    let mut negative = false
+    if value < 0 {
+        negative = true
+        value = -value
+    }
+    let mut digits: List<Int> = []
+    for _d in 0..40 {
+        if value == 0 {
+            break
+        }
+        digits.push(value % 10)
+        value = value / 10
+    }
+    let mut out = ""
+    if negative {
+        out = "-"
+    }
+    let mut i = digits.len() - 1
+    for _j in 0..digits.len() {
+        if i < 0 {
+            break
+        }
+        out = out + hirPrintDigitChar(digits[i])
+        i = i - 1
+    }
+    out
+}
+
+fn hirPrintDigitChar(d: Int) -> String {
+    match d {
+        0 -> "0",
+        1 -> "1",
+        2 -> "2",
+        3 -> "3",
+        4 -> "4",
+        5 -> "5",
+        6 -> "6",
+        7 -> "7",
+        8 -> "8",
+        9 -> "9",
+        _ -> "?",
+    }
+}

--- a/toolchain/hir_reach.osty
+++ b/toolchain/hir_reach.osty
@@ -1,0 +1,680 @@
+// hir_reach.osty — reachability scans over self-hosted HIR.
+//
+// Counterpart to `internal/ir/reach.go`. HIR uses flat structs instead of
+// interface-based nodes, so the public result is a deduplicated List rather
+// than a Go map-set keyed by struct values.
+
+pub struct HirQualifiedRef {
+    pub qualifier: String,
+    pub name: String,
+}
+
+pub fn hirQualifiedRef(qualifier: String, name: String) -> HirQualifiedRef {
+    HirQualifiedRef { qualifier, name }
+}
+
+pub struct HirMethodRef {
+    pub module: String,
+    pub typeName: String,
+    pub method: String,
+}
+
+pub fn hirMethodRef(module: String, typeName: String, method: String) -> HirMethodRef {
+    HirMethodRef { module, typeName, method }
+}
+
+pub fn hirReach(m: HirModule) -> List<HirQualifiedRef> {
+    let mut out: List<HirQualifiedRef> = []
+    hirReachModule(out, m)
+    out
+}
+
+pub fn hirReachMethods(m: HirModule) -> List<HirMethodRef> {
+    let mut out: List<HirMethodRef> = []
+    hirReachMethodsModule(out, m)
+    out
+}
+
+// ====================================================================
+// Reach: free-function / module-qualified calls
+// ====================================================================
+
+fn hirReachModule(out: List<HirQualifiedRef>, m: HirModule) {
+    for d in m.fns {
+        hirReachBlock(out, d.body)
+    }
+    for d in m.structs {
+        for field in d.fields {
+            if field.hasDefault {
+                hirReachExpr(out, field.defaultValue)
+            }
+        }
+        for method in d.methods {
+            hirReachBlock(out, method.body)
+        }
+    }
+    for d in m.enums {
+        for method in d.methods {
+            hirReachBlock(out, method.body)
+        }
+    }
+    for d in m.interfaces {
+        for method in d.methods {
+            hirReachBlock(out, method.body)
+        }
+    }
+    for d in m.lets {
+        if d.hasValue {
+            hirReachExpr(out, d.value)
+        }
+    }
+    for d in m.uses {
+        for bodyFn in d.goBodyFns {
+            hirReachBlock(out, bodyFn.body)
+        }
+    }
+    for s in m.script {
+        hirReachStmt(out, s)
+    }
+}
+
+fn hirReachBlock(out: List<HirQualifiedRef>, b: HirBlock) {
+    for s in b.stmts {
+        hirReachStmt(out, s)
+    }
+    if b.hasResult {
+        hirReachExpr(out, b.result)
+    }
+}
+
+fn hirReachStmt(out: List<HirQualifiedRef>, s: HirStmt) {
+    match s.kind {
+        HirStmtBlock -> hirReachBlock(out, s.block),
+        HirStmtLet -> {
+            if s.letHasPattern {
+                hirReachPattern(out, s.letPattern)
+            }
+            if s.letHasValue {
+                hirReachExpr(out, s.letValue)
+            }
+        },
+        HirStmtExpr -> hirReachExpr(out, s.exprValue),
+        HirStmtAssign -> {
+            for t in s.assignTargets {
+                hirReachExpr(out, t)
+            }
+            hirReachExpr(out, s.assignValue)
+        },
+        HirStmtReturn -> {
+            if s.returnHasValue {
+                hirReachExpr(out, s.returnValue)
+            }
+        },
+        HirStmtIf -> {
+            hirReachExpr(out, s.ifCond)
+            hirReachBlock(out, s.ifThen)
+            if s.ifHasElse {
+                hirReachBlock(out, s.ifElse)
+            }
+        },
+        HirStmtFor -> {
+            if s.forHasPattern {
+                hirReachPattern(out, s.forPattern)
+            }
+            if s.forHasCond {
+                hirReachExpr(out, s.forCond)
+            }
+            if s.forHasIter {
+                hirReachExpr(out, s.forIter)
+            }
+            if s.forHasStart {
+                hirReachExpr(out, s.forStart)
+            }
+            if s.forHasEnd {
+                hirReachExpr(out, s.forEnd)
+            }
+            hirReachBlock(out, s.forBody)
+        },
+        HirStmtMatch -> {
+            hirReachExpr(out, s.matchScrutinee)
+            for arm in s.matchArms {
+                hirReachMatchArm(out, arm)
+            }
+            if s.matchHasTree {
+                hirReachDecision(out, s.matchTree)
+            }
+        },
+        HirStmtDefer -> hirReachBlock(out, s.deferBody),
+        HirStmtChanSend -> {
+            hirReachExpr(out, s.chanChannel)
+            hirReachExpr(out, s.chanValue)
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachExpr(out: List<HirQualifiedRef>, e: HirExpr) {
+    match e.kind {
+        HirExprCall -> {
+            if e.callCallee.len() > 0 {
+                let callee = e.callCallee[0]
+                if callee.kind == HirExprField && callee.fieldTarget.len() > 0 {
+                    let recv = callee.fieldTarget[0]
+                    if recv.kind == HirExprIdent && recv.identName != "" && callee.fieldName != "" {
+                        hirReachAdd(out, hirQualifiedRef(recv.identName, callee.fieldName))
+                    }
+                }
+                hirReachExpr(out, callee)
+            }
+            for a in e.callArgs {
+                hirReachExpr(out, a.value)
+            }
+        },
+        HirExprMethod -> {
+            if e.methodReceiver.len() > 0 {
+                let recv = e.methodReceiver[0]
+                if recv.kind == HirExprIdent && recv.identName != "" && e.methodName != "" {
+                    hirReachAdd(out, hirQualifiedRef(recv.identName, e.methodName))
+                }
+                hirReachExpr(out, recv)
+            }
+            for a in e.methodArgs {
+                hirReachExpr(out, a.value)
+            }
+        },
+        HirExprIntrinsic -> {
+            for a in e.intrinsicArgs {
+                hirReachExpr(out, a.value)
+            }
+        },
+        HirExprUnary -> hirReachExpr(out, hirReachFirstExpr(e.unaryChild)),
+        HirExprBinary -> {
+            hirReachExpr(out, hirReachFirstExpr(e.binaryLeft))
+            hirReachExpr(out, hirReachFirstExpr(e.binaryRight))
+        },
+        HirExprList -> {
+            for el in e.listElems {
+                hirReachExpr(out, el)
+            }
+        },
+        HirExprBlock -> hirReachBlock(out, hirReachFirstBlock(e.blockBody)),
+        HirExprIf -> {
+            hirReachExpr(out, hirReachFirstExpr(e.ifExprCond))
+            hirReachBlock(out, hirReachFirstBlock(e.ifExprThen))
+            if e.ifExprElse.len() > 0 {
+                hirReachBlock(out, e.ifExprElse[0])
+            }
+        },
+        HirExprField -> hirReachExpr(out, hirReachFirstExpr(e.fieldTarget)),
+        HirExprIndex -> {
+            hirReachExpr(out, hirReachFirstExpr(e.indexTarget))
+            hirReachExpr(out, hirReachFirstExpr(e.indexIndex))
+        },
+        HirExprStructLit -> {
+            for f in e.structFields {
+                if f.hasValue {
+                    hirReachExpr(out, f.value)
+                }
+            }
+            if e.structHasSpread && e.structSpread.len() > 0 {
+                hirReachExpr(out, e.structSpread[0])
+            }
+        },
+        HirExprTupleLit -> {
+            for el in e.tupleElems {
+                hirReachExpr(out, el)
+            }
+        },
+        HirExprMapLit -> {
+            for entry in e.mapEntries {
+                hirReachExpr(out, entry.key)
+                hirReachExpr(out, entry.value)
+            }
+        },
+        HirExprRange -> {
+            if e.rangeStart.len() > 0 {
+                hirReachExpr(out, e.rangeStart[0])
+            }
+            if e.rangeEnd.len() > 0 {
+                hirReachExpr(out, e.rangeEnd[0])
+            }
+        },
+        HirExprQuestion -> hirReachExpr(out, hirReachFirstExpr(e.questionChild)),
+        HirExprCoalesce -> {
+            hirReachExpr(out, hirReachFirstExpr(e.coalesceLeft))
+            hirReachExpr(out, hirReachFirstExpr(e.coalesceRight))
+        },
+        HirExprClosure -> {
+            for pm in e.closureParams {
+                if hirParamIsDestructured(pm) {
+                    hirReachPattern(out, pm.pattern)
+                }
+                if pm.hasDefault {
+                    hirReachExpr(out, pm.defaultValue)
+                }
+            }
+            if e.closureBody.len() > 0 {
+                hirReachBlock(out, e.closureBody[0])
+            }
+        },
+        HirExprVariantLit -> {
+            for a in e.variantArgs {
+                hirReachExpr(out, a.value)
+            }
+        },
+        HirExprMatch -> {
+            hirReachExpr(out, hirReachFirstExpr(e.matchExprScrutinee))
+            for arm in e.matchExprArms {
+                hirReachMatchArm(out, arm)
+            }
+            if e.matchExprHasTree {
+                hirReachDecision(out, e.matchExprTree)
+            }
+        },
+        HirExprIfLet -> {
+            hirReachPattern(out, e.ifLetPattern)
+            hirReachExpr(out, hirReachFirstExpr(e.ifLetScrutinee))
+            hirReachBlock(out, hirReachFirstBlock(e.ifLetThen))
+            if e.ifLetHasElse && e.ifLetElse.len() > 0 {
+                hirReachBlock(out, e.ifLetElse[0])
+            }
+        },
+        HirExprTupleAccess -> hirReachExpr(out, hirReachFirstExpr(e.tupleAccessTarget)),
+        HirExprStringLit -> {
+            for part in e.strParts {
+                if !(part.isLit) && part.expr.len() > 0 {
+                    hirReachExpr(out, part.expr[0])
+                }
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachPattern(out: List<HirQualifiedRef>, p: HirPattern) {
+    match p.kind {
+        HirPatLit -> {
+            if p.litValue.len() > 0 {
+                hirReachExpr(out, p.litValue[0])
+            }
+        },
+        HirPatTuple -> {
+            for el in p.tupleElems {
+                hirReachPattern(out, el)
+            }
+        },
+        HirPatStruct -> {
+            for f in p.structFields {
+                if f.hasPattern {
+                    hirReachPattern(out, f.pattern)
+                }
+            }
+        },
+        HirPatVariant -> {
+            for arg in p.variantArgs {
+                hirReachPattern(out, arg)
+            }
+        },
+        HirPatRange -> {
+            if p.rangeLow.len() > 0 {
+                hirReachExpr(out, p.rangeLow[0])
+            }
+            if p.rangeHigh.len() > 0 {
+                hirReachExpr(out, p.rangeHigh[0])
+            }
+        },
+        HirPatOr -> {
+            for alt in p.orAlts {
+                hirReachPattern(out, alt)
+            }
+        },
+        HirPatBinding -> {
+            if p.bindingChild.len() > 0 {
+                hirReachPattern(out, p.bindingChild[0])
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachMatchArm(out: List<HirQualifiedRef>, arm: HirMatchArm) {
+    hirReachPattern(out, arm.pattern)
+    if arm.hasGuard {
+        hirReachExpr(out, arm.guard)
+    }
+    hirReachBlock(out, arm.body)
+}
+
+fn hirReachDecision(out: List<HirQualifiedRef>, n: HirDecisionNode) {
+    match n.kind {
+        HirDecisionBind -> {
+            if n.bindHasProj {
+                hirReachProjection(out, n.bindProj)
+            }
+            if n.bindNext.len() > 0 {
+                hirReachDecision(out, n.bindNext[0])
+            }
+        },
+        HirDecisionGuard -> {
+            hirReachExpr(out, n.guardCond)
+            if n.guardThen.len() > 0 {
+                hirReachDecision(out, n.guardThen[0])
+            }
+            if n.guardElse.len() > 0 {
+                hirReachDecision(out, n.guardElse[0])
+            }
+        },
+        HirDecisionSwitch -> {
+            hirReachProjection(out, n.switchProj)
+            for c in n.switchCases {
+                if c.hasLit {
+                    hirReachExpr(out, c.lit)
+                }
+                hirReachDecision(out, c.body)
+            }
+            if n.switchDefault.len() > 0 {
+                hirReachDecision(out, n.switchDefault[0])
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachProjection(out: List<HirQualifiedRef>, p: HirProjection) {
+    if p.base.len() > 0 {
+        hirReachProjection(out, p.base[0])
+    }
+}
+
+fn hirReachAdd(out: List<HirQualifiedRef>, ref: HirQualifiedRef) {
+    if hirReachContains(out, ref) {
+        return
+    }
+    out.push(ref)
+}
+
+fn hirReachContains(xs: List<HirQualifiedRef>, target: HirQualifiedRef) -> Bool {
+    for x in xs {
+        if x.qualifier == target.qualifier && x.name == target.name {
+            return true
+        }
+    }
+    false
+}
+
+// ====================================================================
+// ReachMethods: stdlib-owned receiver method calls
+// ====================================================================
+
+fn hirReachMethodsModule(out: List<HirMethodRef>, m: HirModule) {
+    for d in m.fns {
+        hirReachMethodsBlock(out, d.body)
+    }
+    for d in m.structs {
+        for field in d.fields {
+            if field.hasDefault {
+                hirReachMethodsExpr(out, field.defaultValue)
+            }
+        }
+        for method in d.methods {
+            hirReachMethodsBlock(out, method.body)
+        }
+    }
+    for d in m.enums {
+        for method in d.methods {
+            hirReachMethodsBlock(out, method.body)
+        }
+    }
+    for d in m.interfaces {
+        for method in d.methods {
+            hirReachMethodsBlock(out, method.body)
+        }
+    }
+    for d in m.lets {
+        if d.hasValue {
+            hirReachMethodsExpr(out, d.value)
+        }
+    }
+    for d in m.uses {
+        for bodyFn in d.goBodyFns {
+            hirReachMethodsBlock(out, bodyFn.body)
+        }
+    }
+    for s in m.script {
+        hirReachMethodsStmt(out, s)
+    }
+}
+
+fn hirReachMethodsBlock(out: List<HirMethodRef>, b: HirBlock) {
+    for s in b.stmts {
+        hirReachMethodsStmt(out, s)
+    }
+    if b.hasResult {
+        hirReachMethodsExpr(out, b.result)
+    }
+}
+
+fn hirReachMethodsStmt(out: List<HirMethodRef>, s: HirStmt) {
+    match s.kind {
+        HirStmtBlock -> hirReachMethodsBlock(out, s.block),
+        HirStmtLet -> {
+            if s.letHasValue {
+                hirReachMethodsExpr(out, s.letValue)
+            }
+        },
+        HirStmtExpr -> hirReachMethodsExpr(out, s.exprValue),
+        HirStmtAssign -> {
+            for t in s.assignTargets {
+                hirReachMethodsExpr(out, t)
+            }
+            hirReachMethodsExpr(out, s.assignValue)
+        },
+        HirStmtReturn -> {
+            if s.returnHasValue {
+                hirReachMethodsExpr(out, s.returnValue)
+            }
+        },
+        HirStmtIf -> {
+            hirReachMethodsExpr(out, s.ifCond)
+            hirReachMethodsBlock(out, s.ifThen)
+            if s.ifHasElse {
+                hirReachMethodsBlock(out, s.ifElse)
+            }
+        },
+        HirStmtFor -> {
+            if s.forHasCond {
+                hirReachMethodsExpr(out, s.forCond)
+            }
+            if s.forHasIter {
+                hirReachMethodsExpr(out, s.forIter)
+            }
+            if s.forHasStart {
+                hirReachMethodsExpr(out, s.forStart)
+            }
+            if s.forHasEnd {
+                hirReachMethodsExpr(out, s.forEnd)
+            }
+            hirReachMethodsBlock(out, s.forBody)
+        },
+        HirStmtMatch -> {
+            hirReachMethodsExpr(out, s.matchScrutinee)
+            for arm in s.matchArms {
+                hirReachMethodsMatchArm(out, arm)
+            }
+        },
+        HirStmtDefer -> hirReachMethodsBlock(out, s.deferBody),
+        HirStmtChanSend -> {
+            hirReachMethodsExpr(out, s.chanChannel)
+            hirReachMethodsExpr(out, s.chanValue)
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachMethodsExpr(out: List<HirMethodRef>, e: HirExpr) {
+    if e.kind == HirExprMethod && e.methodReceiver.len() > 0 && e.methodName != "" {
+        let recv = e.methodReceiver[0]
+        let recvT = recv.typ
+        if recvT.kind == HirTypeNamed && recvT.namedPkg != "" && recvT.namedName != "" {
+            hirReachMethodsAdd(out, hirMethodRef(recvT.namedPkg, recvT.namedName, e.methodName))
+        }
+    }
+    hirReachExprAsMethods(out, e)
+}
+
+fn hirReachExprAsMethods(out: List<HirMethodRef>, e: HirExpr) {
+    match e.kind {
+        HirExprUnary -> hirReachMethodsExpr(out, hirReachFirstExpr(e.unaryChild)),
+        HirExprBinary -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.binaryLeft))
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.binaryRight))
+        },
+        HirExprCall -> {
+            if e.callCallee.len() > 0 {
+                hirReachMethodsExpr(out, e.callCallee[0])
+            }
+            for a in e.callArgs {
+                hirReachMethodsExpr(out, a.value)
+            }
+        },
+        HirExprIntrinsic -> {
+            for a in e.intrinsicArgs {
+                hirReachMethodsExpr(out, a.value)
+            }
+        },
+        HirExprMethod -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.methodReceiver))
+            for a in e.methodArgs {
+                hirReachMethodsExpr(out, a.value)
+            }
+        },
+        HirExprList -> {
+            for el in e.listElems {
+                hirReachMethodsExpr(out, el)
+            }
+        },
+        HirExprBlock -> hirReachMethodsBlock(out, hirReachFirstBlock(e.blockBody)),
+        HirExprIf -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.ifExprCond))
+            hirReachMethodsBlock(out, hirReachFirstBlock(e.ifExprThen))
+            if e.ifExprElse.len() > 0 {
+                hirReachMethodsBlock(out, e.ifExprElse[0])
+            }
+        },
+        HirExprField -> hirReachMethodsExpr(out, hirReachFirstExpr(e.fieldTarget)),
+        HirExprIndex -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.indexTarget))
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.indexIndex))
+        },
+        HirExprStructLit -> {
+            for f in e.structFields {
+                if f.hasValue {
+                    hirReachMethodsExpr(out, f.value)
+                }
+            }
+            if e.structHasSpread && e.structSpread.len() > 0 {
+                hirReachMethodsExpr(out, e.structSpread[0])
+            }
+        },
+        HirExprTupleLit -> {
+            for el in e.tupleElems {
+                hirReachMethodsExpr(out, el)
+            }
+        },
+        HirExprMapLit -> {
+            for en in e.mapEntries {
+                hirReachMethodsExpr(out, en.key)
+                hirReachMethodsExpr(out, en.value)
+            }
+        },
+        HirExprRange -> {
+            if e.rangeStart.len() > 0 {
+                hirReachMethodsExpr(out, e.rangeStart[0])
+            }
+            if e.rangeEnd.len() > 0 {
+                hirReachMethodsExpr(out, e.rangeEnd[0])
+            }
+        },
+        HirExprQuestion -> hirReachMethodsExpr(out, hirReachFirstExpr(e.questionChild)),
+        HirExprCoalesce -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.coalesceLeft))
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.coalesceRight))
+        },
+        HirExprClosure -> {
+            for pm in e.closureParams {
+                if pm.hasDefault {
+                    hirReachMethodsExpr(out, pm.defaultValue)
+                }
+            }
+            if e.closureBody.len() > 0 {
+                hirReachMethodsBlock(out, e.closureBody[0])
+            }
+        },
+        HirExprVariantLit -> {
+            for a in e.variantArgs {
+                hirReachMethodsExpr(out, a.value)
+            }
+        },
+        HirExprMatch -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.matchExprScrutinee))
+            for arm in e.matchExprArms {
+                hirReachMethodsMatchArm(out, arm)
+            }
+        },
+        HirExprIfLet -> {
+            hirReachMethodsExpr(out, hirReachFirstExpr(e.ifLetScrutinee))
+            hirReachMethodsBlock(out, hirReachFirstBlock(e.ifLetThen))
+            if e.ifLetHasElse && e.ifLetElse.len() > 0 {
+                hirReachMethodsBlock(out, e.ifLetElse[0])
+            }
+        },
+        HirExprTupleAccess -> hirReachMethodsExpr(out, hirReachFirstExpr(e.tupleAccessTarget)),
+        HirExprStringLit -> {
+            for part in e.strParts {
+                if !(part.isLit) && part.expr.len() > 0 {
+                    hirReachMethodsExpr(out, part.expr[0])
+                }
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirReachMethodsMatchArm(out: List<HirMethodRef>, arm: HirMatchArm) {
+    if arm.hasGuard {
+        hirReachMethodsExpr(out, arm.guard)
+    }
+    hirReachMethodsBlock(out, arm.body)
+}
+
+fn hirReachMethodsAdd(out: List<HirMethodRef>, ref: HirMethodRef) {
+    if hirReachMethodsContains(out, ref) {
+        return
+    }
+    out.push(ref)
+}
+
+fn hirReachMethodsContains(xs: List<HirMethodRef>, target: HirMethodRef) -> Bool {
+    for x in xs {
+        if x.module == target.module && x.typeName == target.typeName && x.method == target.method {
+            return true
+        }
+    }
+    false
+}
+
+fn hirReachFirstExpr(xs: List<HirExpr>) -> HirExpr {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirExprInvalid()
+    }
+}
+
+fn hirReachFirstBlock(xs: List<HirBlock>) -> HirBlock {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirBlock(hirNoSpan())
+    }
+}

--- a/toolchain/hir_validate.osty
+++ b/toolchain/hir_validate.osty
@@ -1,0 +1,781 @@
+// hir_validate.osty — structural validation for self-hosted HIR.
+//
+// Counterpart to `internal/ir/validate.go`. HIR's flat structs mean the
+// validation surface is "invalid kind / missing child list / empty required
+// field" rather than Go IR's nil pointers, but the public contract is the same:
+// catch internal lowering/rewriting bugs without re-running type checking.
+
+pub fn hirValidateModule(m: HirModule) -> List<String> {
+    let v = hirValidator()
+    hirValidateWalkModule(v, m)
+    v.errs
+}
+
+pub fn hirValidateDecisionTree(n: HirDecisionNode, armCount: Int) -> List<String> {
+    let v = hirDecisionValidator(armCount)
+    hirValidateWalkDecision(v, n)
+    v.errs
+}
+
+struct HirValidator {
+    errs: List<String>,
+    inInterface: Bool,
+}
+
+fn hirValidator() -> HirValidator {
+    HirValidator { errs: [], inInterface: false }
+}
+
+fn hirValidateAdd(v: HirValidator, msg: String) {
+    v.errs.push(msg)
+}
+
+fn hirValidateWalkModule(v: HirValidator, m: HirModule) {
+    if m.packageName == "" {
+        hirValidateAdd(v, "module: empty packageName")
+    }
+    for decl in m.fns {
+        hirValidateFnDecl(v, decl, false)
+    }
+    for decl in m.structs {
+        hirValidateStructDecl(v, decl)
+    }
+    for decl in m.enums {
+        hirValidateEnumDecl(v, decl)
+    }
+    for decl in m.interfaces {
+        hirValidateInterfaceDecl(v, decl)
+    }
+    for decl in m.aliases {
+        hirValidateTypeAliasDecl(v, decl)
+    }
+    for decl in m.lets {
+        hirValidateLetDecl(v, decl)
+    }
+    for decl in m.uses {
+        hirValidateUseDecl(v, decl)
+    }
+    let mut i = 0
+    for stmt in m.script {
+        hirValidateStmt(v, stmt, "script[" + hirValidateIntToString(i) + "]")
+        i = i + 1
+    }
+}
+
+fn hirValidateFnDecl(v: HirValidator, fn_: HirFnDecl, allowNoBody: Bool) {
+    if fn_.name == "" {
+        hirValidateAdd(v, "fn: empty name")
+    }
+    hirValidateType(fn_.ret, "fn " + fn_.name + " return", v)
+    hirValidateTypeParams(v, "fn " + fn_.name, fn_.generics)
+    let mut i = 0
+    for p in fn_.params {
+        hirValidateParam(v, p, "fn " + fn_.name + " param[" + hirValidateIntToString(i) + "]")
+        i = i + 1
+    }
+    if !(allowNoBody) || fn_.body.stmts.len() > 0 || fn_.body.hasResult {
+        hirValidateBlock(v, fn_.body, "fn " + fn_.name + " body")
+    }
+}
+
+fn hirValidateStructDecl(v: HirValidator, decl: HirStructDecl) {
+    hirValidateTypeParams(v, "struct " + decl.name, decl.generics)
+    let mut i = 0
+    for f in decl.fields {
+        if f.name == "" {
+            hirValidateAdd(v, "struct " + decl.name + ": field[" + hirValidateIntToString(i) + "] empty name")
+        }
+        hirValidateType(f.typ, "struct " + decl.name + " field " + f.name, v)
+        if f.hasDefault {
+            hirValidateExpr(v, f.defaultValue, "struct " + decl.name + " field " + f.name + " default")
+        }
+        i = i + 1
+    }
+    for method in decl.methods {
+        hirValidateFnDecl(v, method, decl.builtinSource != "")
+    }
+}
+
+fn hirValidateEnumDecl(v: HirValidator, decl: HirEnumDecl) {
+    hirValidateTypeParams(v, "enum " + decl.name, decl.generics)
+    let mut seen: List<String> = []
+    let mut i = 0
+    for vr in decl.variants {
+        if vr.name == "" {
+            hirValidateAdd(v, "enum " + decl.name + ": variant[" + hirValidateIntToString(i) + "] empty name")
+        }
+        if hirValidateListContainsString(seen, vr.name) {
+            hirValidateAdd(v, "enum " + decl.name + ": duplicate variant " + vr.name)
+        } else {
+            seen.push(vr.name)
+        }
+        let mut j = 0
+        for p in vr.payload {
+            hirValidateType(
+                p,
+                "enum " + decl.name + " variant " + vr.name + " payload[" + hirValidateIntToString(j) + "]",
+                v,
+            )
+            j = j + 1
+        }
+        i = i + 1
+    }
+    for method in decl.methods {
+        hirValidateFnDecl(v, method, decl.builtinSource != "")
+    }
+}
+
+fn hirValidateInterfaceDecl(v: HirValidator, decl: HirInterfaceDecl) {
+    hirValidateTypeParams(v, "interface " + decl.name, decl.generics)
+    let mut i = 0
+    for ext in decl.extends {
+        hirValidateType(ext, "interface " + decl.name + " extends[" + hirValidateIntToString(i) + "]", v)
+        i = i + 1
+    }
+    let old = v.inInterface
+    v.inInterface = true
+    for method in decl.methods {
+        hirValidateFnDecl(v, method, true)
+    }
+    v.inInterface = old
+}
+
+fn hirValidateTypeAliasDecl(v: HirValidator, decl: HirTypeAliasDecl) {
+    hirValidateTypeParams(v, "alias " + decl.name, decl.generics)
+    hirValidateType(decl.target, "alias " + decl.name, v)
+}
+
+fn hirValidateLetDecl(v: HirValidator, decl: HirLetDecl) {
+    if decl.name == "" {
+        hirValidateAdd(v, "top-level let: empty name")
+    }
+    hirValidateType(decl.typ, "top-level let " + decl.name, v)
+    if !(decl.hasValue) {
+        hirValidateAdd(v, "top-level let " + decl.name + ": missing value")
+        return
+    }
+    hirValidateExpr(v, decl.value, "top-level let " + decl.name + " value")
+}
+
+fn hirValidateUseDecl(v: HirValidator, decl: HirUseDecl) {
+    if !(hirUseIsFFI(decl)) && decl.alias == "" {
+        hirValidateAdd(v, "use: empty alias")
+    }
+    for bodyFn in decl.goBodyFns {
+        hirValidateFnDecl(v, bodyFn, false)
+    }
+}
+
+fn hirValidateBlock(v: HirValidator, b: HirBlock, where: String) {
+    let mut i = 0
+    for s in b.stmts {
+        hirValidateStmt(v, s, where + " stmt[" + hirValidateIntToString(i) + "]")
+        i = i + 1
+    }
+    if b.hasResult {
+        hirValidateExpr(v, b.result, where + " result")
+    }
+}
+
+fn hirValidateStmt(v: HirValidator, s: HirStmt, where: String) {
+    match s.kind {
+        HirStmtInvalid -> hirValidateAdd(v, where + ": invalid stmt"),
+        HirStmtBlock -> hirValidateBlock(v, s.block, where + " block"),
+        HirStmtLet -> {
+            if s.letName == "" && !(s.letHasPattern) {
+                hirValidateAdd(v, where + ": let has neither name nor pattern")
+            }
+            if s.letHasPattern {
+                hirValidatePattern(v, s.letPattern, where + " pattern")
+            }
+            if s.letHasType {
+                hirValidateType(s.letTyp, where + " type", v)
+            }
+            if s.letHasValue {
+                hirValidateExpr(v, s.letValue, where + " value")
+            }
+        },
+        HirStmtExpr -> hirValidateExpr(v, s.exprValue, where + " expr"),
+        HirStmtAssign -> {
+            if s.assignTargets.len() == 0 {
+                hirValidateAdd(v, where + ": assign has no targets")
+            }
+            let mut i = 0
+            for t in s.assignTargets {
+                hirValidateExpr(v, t, where + " target[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+            hirValidateExpr(v, s.assignValue, where + " value")
+        },
+        HirStmtReturn -> {
+            if s.returnHasValue {
+                hirValidateExpr(v, s.returnValue, where + " return")
+            }
+        },
+        HirStmtBreak -> {},
+        HirStmtContinue -> {},
+        HirStmtIf -> {
+            hirValidateExpr(v, s.ifCond, where + " cond")
+            hirValidateBlock(v, s.ifThen, where + " then")
+            if s.ifHasElse {
+                hirValidateBlock(v, s.ifElse, where + " else")
+            }
+        },
+        HirStmtFor -> {
+            if s.forVar != "" && s.forHasPattern {
+                hirValidateAdd(v, where + ": for has both var and pattern")
+            }
+            if s.forHasPattern {
+                hirValidatePattern(v, s.forPattern, where + " for-pattern")
+            }
+            hirValidateBlock(v, s.forBody, where + " body")
+            match s.forKind {
+                HirForInfinite -> {},
+                HirForWhile -> {
+                    if !(s.forHasCond) {
+                        hirValidateAdd(v, where + ": while-for missing cond")
+                    } else {
+                        hirValidateExpr(v, s.forCond, where + " cond")
+                    }
+                },
+                HirForIn -> {
+                    if !(s.forHasIter) {
+                        hirValidateAdd(v, where + ": in-for missing iter")
+                    } else {
+                        hirValidateExpr(v, s.forIter, where + " iter")
+                    }
+                    if s.forVar == "" && !(s.forHasPattern) {
+                        hirValidateAdd(v, where + ": in-for missing binding")
+                    }
+                },
+                HirForRange -> {
+                    if s.forHasStart {
+                        hirValidateExpr(v, s.forStart, where + " start")
+                    }
+                    if s.forHasEnd {
+                        hirValidateExpr(v, s.forEnd, where + " end")
+                    }
+                    if !(s.forHasStart) && !(s.forHasEnd) {
+                        hirValidateAdd(v, where + ": range-for missing both start and end")
+                    }
+                    if s.forVar == "" && !(s.forHasPattern) {
+                        hirValidateAdd(v, where + ": range-for missing binding")
+                    }
+                },
+                HirForInvalid -> hirValidateAdd(v, where + ": invalid for kind"),
+            }
+        },
+        HirStmtMatch -> {
+            hirValidateExpr(v, s.matchScrutinee, where + " scrutinee")
+            let mut i = 0
+            for arm in s.matchArms {
+                hirValidateMatchArm(v, arm, where + " arm[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+            if s.matchHasTree {
+                let errs = hirValidateDecisionTree(s.matchTree, s.matchArms.len())
+                for err in errs {
+                    hirValidateAdd(v, where + " tree: " + err)
+                }
+            }
+        },
+        HirStmtDefer -> hirValidateBlock(v, s.deferBody, where + " defer"),
+        HirStmtChanSend -> {
+            hirValidateExpr(v, s.chanChannel, where + " channel")
+            hirValidateExpr(v, s.chanValue, where + " value")
+        },
+        HirStmtError -> {},
+    }
+}
+
+fn hirValidateExpr(v: HirValidator, e: HirExpr, where: String) {
+    if e.kind == HirExprInvalid {
+        hirValidateAdd(v, where + ": invalid expr")
+        return
+    }
+    hirValidateType(e.typ, where + " type", v)
+    match e.kind {
+        HirExprUnary -> hirValidateExpr(v, hirValidateFirstExpr(e.unaryChild), where + " unary"),
+        HirExprBinary -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.binaryLeft), where + " left")
+            hirValidateExpr(v, hirValidateFirstExpr(e.binaryRight), where + " right")
+        },
+        HirExprIdent -> {
+            let mut i = 0
+            for ta in e.identTypeArgs {
+                hirValidateType(ta, where + " typeArg[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+        },
+        HirExprCall -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.callCallee), where + " callee")
+            let mut i = 0
+            for ta in e.callTypeArgs {
+                hirValidateType(ta, where + " typeArg[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+            hirValidateArgs(v, e.callArgs, where)
+        },
+        HirExprIntrinsic -> hirValidateArgs(v, e.intrinsicArgs, where),
+        HirExprMethod -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.methodReceiver), where + " receiver")
+            if e.methodName == "" {
+                hirValidateAdd(v, where + ": empty method name")
+            }
+            let mut i = 0
+            for ta in e.methodTypeArgs {
+                hirValidateType(ta, where + " typeArg[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+            hirValidateArgs(v, e.methodArgs, where)
+        },
+        HirExprList -> {
+            hirValidateType(e.listElem, where + " listElem", v)
+            let mut i = 0
+            for el in e.listElems {
+                hirValidateExpr(v, el, where + " elem[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+        },
+        HirExprMapLit -> {
+            hirValidateType(e.mapKeyT, where + " mapKeyT", v)
+            hirValidateType(e.mapValT, where + " mapValT", v)
+            let mut i = 0
+            for en in e.mapEntries {
+                hirValidateExpr(v, en.key, where + " entry[" + hirValidateIntToString(i) + "].key")
+                hirValidateExpr(v, en.value, where + " entry[" + hirValidateIntToString(i) + "].value")
+                i = i + 1
+            }
+        },
+        HirExprTupleLit -> {
+            let mut i = 0
+            for el in e.tupleElems {
+                hirValidateExpr(v, el, where + " elem[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+        },
+        HirExprStructLit -> {
+            if e.structTypeName == "" {
+                hirValidateAdd(v, where + ": empty structTypeName")
+            }
+            let mut i = 0
+            for f in e.structFields {
+                if f.name == "" {
+                    hirValidateAdd(v, where + ": field[" + hirValidateIntToString(i) + "] empty name")
+                }
+                if f.hasValue {
+                    hirValidateExpr(v, f.value, where + " field[" + hirValidateIntToString(i) + "]")
+                }
+                i = i + 1
+            }
+            if e.structHasSpread {
+                hirValidateExpr(v, hirValidateFirstExpr(e.structSpread), where + " spread")
+            }
+        },
+        HirExprRange -> {
+            if e.rangeStart.len() > 0 {
+                hirValidateExpr(v, e.rangeStart[0], where + " start")
+            }
+            if e.rangeEnd.len() > 0 {
+                hirValidateExpr(v, e.rangeEnd[0], where + " end")
+            }
+        },
+        HirExprQuestion -> hirValidateExpr(v, hirValidateFirstExpr(e.questionChild), where + " question"),
+        HirExprCoalesce -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.coalesceLeft), where + " left")
+            hirValidateExpr(v, hirValidateFirstExpr(e.coalesceRight), where + " right")
+        },
+        HirExprField -> hirValidateExpr(v, hirValidateFirstExpr(e.fieldTarget), where + " field-target"),
+        HirExprTupleAccess -> hirValidateExpr(v, hirValidateFirstExpr(e.tupleAccessTarget), where + " tuple-target"),
+        HirExprIndex -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.indexTarget), where + " index-target")
+            hirValidateExpr(v, hirValidateFirstExpr(e.indexIndex), where + " index")
+        },
+        HirExprClosure -> {
+            hirValidateType(e.closureReturn, where + " closureReturn", v)
+            let mut i = 0
+            for c in e.closureCaptures {
+                if c.name == "" {
+                    hirValidateAdd(v, where + ": capture[" + hirValidateIntToString(i) + "] empty name")
+                }
+                hirValidateType(c.typ, where + " capture[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+            let mut j = 0
+            for p in e.closureParams {
+                hirValidateParam(v, p, where + " param[" + hirValidateIntToString(j) + "]")
+                j = j + 1
+            }
+            hirValidateBlock(v, hirValidateFirstBlock(e.closureBody), where + " body")
+        },
+        HirExprVariantLit -> {
+            if e.variantName == "" {
+                hirValidateAdd(v, where + ": empty variantName")
+            }
+            hirValidateArgs(v, e.variantArgs, where)
+        },
+        HirExprBlock -> hirValidateBlock(v, hirValidateFirstBlock(e.blockBody), where + " block"),
+        HirExprIf -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.ifExprCond), where + " cond")
+            hirValidateBlock(v, hirValidateFirstBlock(e.ifExprThen), where + " then")
+            if e.ifExprElse.len() == 0 {
+                hirValidateAdd(v, where + ": if-expr missing else")
+            } else {
+                hirValidateBlock(v, e.ifExprElse[0], where + " else")
+            }
+        },
+        HirExprIfLet -> {
+            hirValidatePattern(v, e.ifLetPattern, where + " pattern")
+            hirValidateExpr(v, hirValidateFirstExpr(e.ifLetScrutinee), where + " scrutinee")
+            hirValidateBlock(v, hirValidateFirstBlock(e.ifLetThen), where + " then")
+            if e.ifLetHasElse {
+                hirValidateBlock(v, hirValidateFirstBlock(e.ifLetElse), where + " else")
+            }
+        },
+        HirExprMatch -> {
+            hirValidateExpr(v, hirValidateFirstExpr(e.matchExprScrutinee), where + " scrutinee")
+            let mut i = 0
+            for arm in e.matchExprArms {
+                hirValidateMatchArm(v, arm, where + " arm[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+            if e.matchExprHasTree {
+                let errs = hirValidateDecisionTree(e.matchExprTree, e.matchExprArms.len())
+                for err in errs {
+                    hirValidateAdd(v, where + " tree: " + err)
+                }
+            }
+        },
+        HirExprStringLit -> {
+            let mut i = 0
+            for part in e.strParts {
+                if !(part.isLit) {
+                    hirValidateExpr(v, hirValidateFirstExpr(part.expr), where + " part[" + hirValidateIntToString(i) + "]")
+                }
+                i = i + 1
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirValidateParam(v: HirValidator, p: HirParam, where: String) {
+    hirValidateType(p.typ, where + " type", v)
+    let destructured = hirParamIsDestructured(p)
+    if p.name == "" && !(destructured) {
+        hirValidateAdd(v, where + ": param has neither name nor pattern")
+    }
+    if p.name != "" && destructured {
+        hirValidateAdd(v, where + ": param has both name and pattern")
+    }
+    if destructured {
+        hirValidatePattern(v, p.pattern, where + " pattern")
+    }
+    if p.hasDefault {
+        hirValidateExpr(v, p.defaultValue, where + " default")
+    }
+}
+
+fn hirValidateArgs(v: HirValidator, args: List<HirArg>, where: String) {
+    let mut i = 0
+    for a in args {
+        hirValidateExpr(v, a.value, where + " arg[" + hirValidateIntToString(i) + "]")
+        i = i + 1
+    }
+}
+
+fn hirValidatePattern(v: HirValidator, p: HirPattern, where: String) {
+    if p.kind == HirPatInvalid {
+        hirValidateAdd(v, where + ": invalid pattern")
+        return
+    }
+    match p.kind {
+        HirPatLit -> hirValidateExpr(v, hirValidateFirstExpr(p.litValue), where + " lit"),
+        HirPatTuple -> {
+            let mut i = 0
+            for el in p.tupleElems {
+                hirValidatePattern(v, el, where + " elem[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+        },
+        HirPatStruct -> {
+            if p.structTypeName == "" {
+                hirValidateAdd(v, where + ": empty structTypeName")
+            }
+            let mut i = 0
+            for f in p.structFields {
+                if f.name == "" {
+                    hirValidateAdd(v, where + ": field[" + hirValidateIntToString(i) + "] empty name")
+                }
+                if f.hasPattern {
+                    hirValidatePattern(v, f.pattern, where + " field[" + hirValidateIntToString(i) + "]")
+                }
+                i = i + 1
+            }
+        },
+        HirPatVariant -> {
+            if p.variantName == "" {
+                hirValidateAdd(v, where + ": empty variantName")
+            }
+            let mut i = 0
+            for arg in p.variantArgs {
+                hirValidatePattern(v, arg, where + " arg[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+        },
+        HirPatRange -> {
+            if p.rangeLow.len() > 0 {
+                hirValidateExpr(v, p.rangeLow[0], where + " low")
+            }
+            if p.rangeHigh.len() > 0 {
+                hirValidateExpr(v, p.rangeHigh[0], where + " high")
+            }
+        },
+        HirPatOr -> {
+            let mut i = 0
+            for alt in p.orAlts {
+                hirValidatePattern(v, alt, where + " alt[" + hirValidateIntToString(i) + "]")
+                i = i + 1
+            }
+        },
+        HirPatBinding -> hirValidatePattern(v, hirValidateFirstPattern(p.bindingChild), where + " binding"),
+        _ -> {},
+    }
+}
+
+fn hirValidateTypeParams(v: HirValidator, owner: String, params: List<HirTypeParam>) {
+    let mut seen: List<String> = []
+    let mut i = 0
+    for p in params {
+        if p.name == "" {
+            hirValidateAdd(v, owner + ": generic[" + hirValidateIntToString(i) + "] empty name")
+        } else if hirValidateListContainsString(seen, p.name) {
+            hirValidateAdd(v, owner + ": duplicate generic " + p.name)
+        } else {
+            seen.push(p.name)
+        }
+        let mut j = 0
+        for b in p.bounds {
+            hirValidateType(
+                b,
+                owner + " generic " + p.name + " bound[" + hirValidateIntToString(j) + "]",
+                v,
+            )
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+fn hirValidateType(t: HirType, where: String, v: HirValidator) {
+    match t.kind {
+        HirTypeInvalid -> hirValidateAdd(v, where + ": invalid type"),
+        HirTypePrim -> {
+            if t.primKind == HirPrimInvalid {
+                hirValidateAdd(v, where + ": invalid primitive type")
+            }
+        },
+        HirTypeNamed -> {
+            if t.namedName == "" {
+                hirValidateAdd(v, where + ": named type empty name")
+            }
+            let mut i = 0
+            for a in t.namedArgs {
+                hirValidateType(a, where + " arg[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+        },
+        HirTypeOptional -> {
+            if t.optionalInner.len() == 0 {
+                hirValidateAdd(v, where + ": optional type missing inner")
+            } else {
+                hirValidateType(t.optionalInner[0], where + " inner", v)
+            }
+        },
+        HirTypeTuple -> {
+            let mut i = 0
+            for e in t.tupleElems {
+                hirValidateType(e, where + " elem[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+        },
+        HirTypeFn -> {
+            let mut i = 0
+            for p in t.fnParams {
+                hirValidateType(p, where + " param[" + hirValidateIntToString(i) + "]", v)
+                i = i + 1
+            }
+            if t.fnReturn.len() > 0 {
+                hirValidateType(t.fnReturn[0], where + " return", v)
+            }
+        },
+        HirTypeVar -> {
+            if t.varName == "" {
+                hirValidateAdd(v, where + ": type var empty name")
+            }
+        },
+        HirTypeErr -> {},
+    }
+}
+
+fn hirValidateMatchArm(v: HirValidator, arm: HirMatchArm, where: String) {
+    hirValidatePattern(v, arm.pattern, where + " pattern")
+    if arm.hasGuard {
+        hirValidateExpr(v, arm.guard, where + " guard")
+    }
+    hirValidateBlock(v, arm.body, where + " body")
+}
+
+// ====================================================================
+// Decision tree validator
+// ====================================================================
+
+struct HirDecisionValidator {
+    armCount: Int,
+    errs: List<String>,
+}
+
+fn hirDecisionValidator(armCount: Int) -> HirDecisionValidator {
+    HirDecisionValidator { armCount, errs: [] }
+}
+
+fn hirValidateDecisionAdd(v: HirDecisionValidator, msg: String) {
+    v.errs.push(msg)
+}
+
+fn hirValidateWalkDecision(v: HirDecisionValidator, n: HirDecisionNode) {
+    match n.kind {
+        HirDecisionInvalid -> hirValidateDecisionAdd(v, "invalid node"),
+        HirDecisionLeaf -> {
+            if n.leafArm < 0 || n.leafArm >= v.armCount {
+                hirValidateDecisionAdd(
+                    v,
+                    "leaf: arm " + hirValidateIntToString(n.leafArm)
+                        + " out of range [0," + hirValidateIntToString(v.armCount) + ")",
+                )
+            }
+        },
+        HirDecisionFail -> {},
+        HirDecisionBind -> {
+            if n.bindNext.len() == 0 {
+                hirValidateDecisionAdd(v, "bind: missing next")
+            } else {
+                hirValidateWalkDecision(v, n.bindNext[0])
+            }
+        },
+        HirDecisionGuard -> {
+            if n.guardThen.len() == 0 {
+                hirValidateDecisionAdd(v, "guard: missing then")
+            } else {
+                hirValidateWalkDecision(v, n.guardThen[0])
+            }
+            if n.guardElse.len() == 0 {
+                hirValidateDecisionAdd(v, "guard: missing else")
+            } else {
+                hirValidateWalkDecision(v, n.guardElse[0])
+            }
+        },
+        HirDecisionSwitch -> {
+            if n.switchDefault.len() == 0 {
+                hirValidateDecisionAdd(v, "switch: missing default")
+            } else {
+                hirValidateWalkDecision(v, n.switchDefault[0])
+            }
+            let mut i = 0
+            for c in n.switchCases {
+                if c.body.kind == HirDecisionInvalid {
+                    hirValidateDecisionAdd(v, "switch: case[" + hirValidateIntToString(i) + "] invalid body")
+                } else {
+                    hirValidateWalkDecision(v, c.body)
+                }
+                i = i + 1
+            }
+        },
+    }
+}
+
+// ====================================================================
+// Small helpers
+// ====================================================================
+
+fn hirValidateFirstExpr(xs: List<HirExpr>) -> HirExpr {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirExprInvalid()
+    }
+}
+
+fn hirValidateFirstBlock(xs: List<HirBlock>) -> HirBlock {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirBlock(hirNoSpan())
+    }
+}
+
+fn hirValidateFirstPattern(xs: List<HirPattern>) -> HirPattern {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirPatternInvalid()
+    }
+}
+
+fn hirValidateListContainsString(xs: List<String>, target: String) -> Bool {
+    for x in xs {
+        if x == target {
+            return true
+        }
+    }
+    false
+}
+
+fn hirValidateIntToString(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let mut value = n
+    let mut negative = false
+    if value < 0 {
+        negative = true
+        value = -value
+    }
+    let mut digits: List<Int> = []
+    for _d in 0..40 {
+        if value == 0 {
+            break
+        }
+        digits.push(value % 10)
+        value = value / 10
+    }
+    let mut out = ""
+    if negative {
+        out = "-"
+    }
+    let mut i = digits.len() - 1
+    for _j in 0..digits.len() {
+        if i < 0 {
+            break
+        }
+        out = out + hirValidateDigitChar(digits[i])
+        i = i - 1
+    }
+    out
+}
+
+fn hirValidateDigitChar(d: Int) -> String {
+    match d {
+        0 -> "0",
+        1 -> "1",
+        2 -> "2",
+        3 -> "3",
+        4 -> "4",
+        5 -> "5",
+        6 -> "6",
+        7 -> "7",
+        8 -> "8",
+        9 -> "9",
+        _ -> "?",
+    }
+}

--- a/toolchain/hir_walk.osty
+++ b/toolchain/hir_walk.osty
@@ -1,0 +1,432 @@
+// hir_walk.osty — preorder traversal helpers for self-hosted HIR.
+//
+// Go IR exposes `Walk(v, n)` with an interface-based visitor. Self-hosted HIR
+// is flat-struct based, so the portable utility here is a collector that records
+// nodes in preorder by category. Consumers that just need "visit every expr /
+// stmt / pattern in source order" can reuse this without inventing their own
+// recursive descent.
+
+pub struct HirWalkOrder {
+    pub fns: List<HirFnDecl>,
+    pub structs: List<HirStructDecl>,
+    pub enums: List<HirEnumDecl>,
+    pub lets: List<HirLetDecl>,
+    pub uses: List<HirUseDecl>,
+    pub interfaces: List<HirInterfaceDecl>,
+    pub aliases: List<HirTypeAliasDecl>,
+    pub params: List<HirParam>,
+    pub fields: List<HirField>,
+    pub variants: List<HirVariant>,
+    pub blocks: List<HirBlock>,
+    pub stmts: List<HirStmt>,
+    pub exprs: List<HirExpr>,
+    pub patterns: List<HirPattern>,
+    pub matchArms: List<HirMatchArm>,
+    pub typeParams: List<HirTypeParam>,
+    pub captures: List<HirCapture>,
+}
+
+pub fn hirWalkModule(m: HirModule) -> HirWalkOrder {
+    let out = hirWalkOrder()
+    hirWalkVisitModule(out, m)
+    out
+}
+
+fn hirWalkOrder() -> HirWalkOrder {
+    HirWalkOrder {
+        fns: [],
+        structs: [],
+        enums: [],
+        lets: [],
+        uses: [],
+        interfaces: [],
+        aliases: [],
+        params: [],
+        fields: [],
+        variants: [],
+        blocks: [],
+        stmts: [],
+        exprs: [],
+        patterns: [],
+        matchArms: [],
+        typeParams: [],
+        captures: [],
+    }
+}
+
+fn hirWalkVisitModule(out: HirWalkOrder, m: HirModule) {
+    for d in m.fns {
+        hirWalkVisitFn(out, d)
+    }
+    for d in m.structs {
+        hirWalkVisitStruct(out, d)
+    }
+    for d in m.enums {
+        hirWalkVisitEnum(out, d)
+    }
+    for d in m.lets {
+        hirWalkVisitLetDecl(out, d)
+    }
+    for d in m.uses {
+        hirWalkVisitUseDecl(out, d)
+    }
+    for d in m.interfaces {
+        hirWalkVisitInterface(out, d)
+    }
+    for d in m.aliases {
+        hirWalkVisitAlias(out, d)
+    }
+    for s in m.script {
+        hirWalkVisitStmt(out, s)
+    }
+}
+
+fn hirWalkVisitFn(out: HirWalkOrder, d: HirFnDecl) {
+    out.fns.push(d)
+    for tp in d.generics {
+        out.typeParams.push(tp)
+    }
+    for p in d.params {
+        hirWalkVisitParam(out, p)
+    }
+    hirWalkVisitBlock(out, d.body)
+}
+
+fn hirWalkVisitStruct(out: HirWalkOrder, d: HirStructDecl) {
+    out.structs.push(d)
+    for tp in d.generics {
+        out.typeParams.push(tp)
+    }
+    for f in d.fields {
+        hirWalkVisitField(out, f)
+    }
+    for m in d.methods {
+        hirWalkVisitFn(out, m)
+    }
+}
+
+fn hirWalkVisitEnum(out: HirWalkOrder, d: HirEnumDecl) {
+    out.enums.push(d)
+    for tp in d.generics {
+        out.typeParams.push(tp)
+    }
+    for vr in d.variants {
+        out.variants.push(vr)
+    }
+    for m in d.methods {
+        hirWalkVisitFn(out, m)
+    }
+}
+
+fn hirWalkVisitLetDecl(out: HirWalkOrder, d: HirLetDecl) {
+    out.lets.push(d)
+    if d.hasValue {
+        hirWalkVisitExpr(out, d.value)
+    }
+}
+
+fn hirWalkVisitUseDecl(out: HirWalkOrder, d: HirUseDecl) {
+    out.uses.push(d)
+    for bodyFn in d.goBodyFns {
+        hirWalkVisitFn(out, bodyFn)
+    }
+}
+
+fn hirWalkVisitInterface(out: HirWalkOrder, d: HirInterfaceDecl) {
+    out.interfaces.push(d)
+    for tp in d.generics {
+        out.typeParams.push(tp)
+    }
+    for m in d.methods {
+        hirWalkVisitFn(out, m)
+    }
+}
+
+fn hirWalkVisitAlias(out: HirWalkOrder, d: HirTypeAliasDecl) {
+    out.aliases.push(d)
+    for tp in d.generics {
+        out.typeParams.push(tp)
+    }
+}
+
+fn hirWalkVisitParam(out: HirWalkOrder, p: HirParam) {
+    out.params.push(p)
+    if hirParamIsDestructured(p) {
+        hirWalkVisitPattern(out, p.pattern)
+    }
+    if p.hasDefault {
+        hirWalkVisitExpr(out, p.defaultValue)
+    }
+}
+
+fn hirWalkVisitField(out: HirWalkOrder, f: HirField) {
+    out.fields.push(f)
+    if f.hasDefault {
+        hirWalkVisitExpr(out, f.defaultValue)
+    }
+}
+
+fn hirWalkVisitBlock(out: HirWalkOrder, b: HirBlock) {
+    out.blocks.push(b)
+    for s in b.stmts {
+        hirWalkVisitStmt(out, s)
+    }
+    if b.hasResult {
+        hirWalkVisitExpr(out, b.result)
+    }
+}
+
+fn hirWalkVisitStmt(out: HirWalkOrder, s: HirStmt) {
+    out.stmts.push(s)
+    match s.kind {
+        HirStmtBlock -> hirWalkVisitBlock(out, s.block),
+        HirStmtLet -> {
+            if s.letHasPattern {
+                hirWalkVisitPattern(out, s.letPattern)
+            }
+            if s.letHasValue {
+                hirWalkVisitExpr(out, s.letValue)
+            }
+        },
+        HirStmtExpr -> hirWalkVisitExpr(out, s.exprValue),
+        HirStmtAssign -> {
+            for t in s.assignTargets {
+                hirWalkVisitExpr(out, t)
+            }
+            hirWalkVisitExpr(out, s.assignValue)
+        },
+        HirStmtReturn -> {
+            if s.returnHasValue {
+                hirWalkVisitExpr(out, s.returnValue)
+            }
+        },
+        HirStmtIf -> {
+            hirWalkVisitExpr(out, s.ifCond)
+            hirWalkVisitBlock(out, s.ifThen)
+            if s.ifHasElse {
+                hirWalkVisitBlock(out, s.ifElse)
+            }
+        },
+        HirStmtFor -> {
+            if s.forHasPattern {
+                hirWalkVisitPattern(out, s.forPattern)
+            }
+            if s.forHasCond {
+                hirWalkVisitExpr(out, s.forCond)
+            }
+            if s.forHasIter {
+                hirWalkVisitExpr(out, s.forIter)
+            }
+            if s.forHasStart {
+                hirWalkVisitExpr(out, s.forStart)
+            }
+            if s.forHasEnd {
+                hirWalkVisitExpr(out, s.forEnd)
+            }
+            hirWalkVisitBlock(out, s.forBody)
+        },
+        HirStmtMatch -> {
+            hirWalkVisitExpr(out, s.matchScrutinee)
+            for arm in s.matchArms {
+                hirWalkVisitMatchArm(out, arm)
+            }
+        },
+        HirStmtDefer -> hirWalkVisitBlock(out, s.deferBody),
+        HirStmtChanSend -> {
+            hirWalkVisitExpr(out, s.chanChannel)
+            hirWalkVisitExpr(out, s.chanValue)
+        },
+        _ -> {},
+    }
+}
+
+fn hirWalkVisitExpr(out: HirWalkOrder, e: HirExpr) {
+    out.exprs.push(e)
+    match e.kind {
+        HirExprUnary -> hirWalkVisitExpr(out, hirWalkFirstExpr(e.unaryChild)),
+        HirExprBinary -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.binaryLeft))
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.binaryRight))
+        },
+        HirExprCall -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.callCallee))
+            for a in e.callArgs {
+                hirWalkVisitExpr(out, a.value)
+            }
+        },
+        HirExprIntrinsic -> {
+            for a in e.intrinsicArgs {
+                hirWalkVisitExpr(out, a.value)
+            }
+        },
+        HirExprList -> {
+            for el in e.listElems {
+                hirWalkVisitExpr(out, el)
+            }
+        },
+        HirExprBlock -> hirWalkVisitBlock(out, hirWalkFirstBlock(e.blockBody)),
+        HirExprIf -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.ifExprCond))
+            hirWalkVisitBlock(out, hirWalkFirstBlock(e.ifExprThen))
+            if e.ifExprElse.len() > 0 {
+                hirWalkVisitBlock(out, e.ifExprElse[0])
+            }
+        },
+        HirExprField -> hirWalkVisitExpr(out, hirWalkFirstExpr(e.fieldTarget)),
+        HirExprIndex -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.indexTarget))
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.indexIndex))
+        },
+        HirExprMethod -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.methodReceiver))
+            for a in e.methodArgs {
+                hirWalkVisitExpr(out, a.value)
+            }
+        },
+        HirExprStructLit -> {
+            for f in e.structFields {
+                if f.hasValue {
+                    hirWalkVisitExpr(out, f.value)
+                }
+            }
+            if e.structHasSpread && e.structSpread.len() > 0 {
+                hirWalkVisitExpr(out, e.structSpread[0])
+            }
+        },
+        HirExprTupleLit -> {
+            for el in e.tupleElems {
+                hirWalkVisitExpr(out, el)
+            }
+        },
+        HirExprMapLit -> {
+            for en in e.mapEntries {
+                hirWalkVisitExpr(out, en.key)
+                hirWalkVisitExpr(out, en.value)
+            }
+        },
+        HirExprRange -> {
+            if e.rangeStart.len() > 0 {
+                hirWalkVisitExpr(out, e.rangeStart[0])
+            }
+            if e.rangeEnd.len() > 0 {
+                hirWalkVisitExpr(out, e.rangeEnd[0])
+            }
+        },
+        HirExprQuestion -> hirWalkVisitExpr(out, hirWalkFirstExpr(e.questionChild)),
+        HirExprCoalesce -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.coalesceLeft))
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.coalesceRight))
+        },
+        HirExprClosure -> {
+            for p in e.closureParams {
+                hirWalkVisitParam(out, p)
+            }
+            for c in e.closureCaptures {
+                out.captures.push(c)
+            }
+            if e.closureBody.len() > 0 {
+                hirWalkVisitBlock(out, e.closureBody[0])
+            }
+        },
+        HirExprVariantLit -> {
+            for a in e.variantArgs {
+                hirWalkVisitExpr(out, a.value)
+            }
+        },
+        HirExprMatch -> {
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.matchExprScrutinee))
+            for arm in e.matchExprArms {
+                hirWalkVisitMatchArm(out, arm)
+            }
+        },
+        HirExprIfLet -> {
+            hirWalkVisitPattern(out, e.ifLetPattern)
+            hirWalkVisitExpr(out, hirWalkFirstExpr(e.ifLetScrutinee))
+            hirWalkVisitBlock(out, hirWalkFirstBlock(e.ifLetThen))
+            if e.ifLetHasElse && e.ifLetElse.len() > 0 {
+                hirWalkVisitBlock(out, e.ifLetElse[0])
+            }
+        },
+        HirExprTupleAccess -> hirWalkVisitExpr(out, hirWalkFirstExpr(e.tupleAccessTarget)),
+        HirExprStringLit -> {
+            for part in e.strParts {
+                if !(part.isLit) && part.expr.len() > 0 {
+                    hirWalkVisitExpr(out, part.expr[0])
+                }
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirWalkVisitPattern(out: HirWalkOrder, p: HirPattern) {
+    out.patterns.push(p)
+    match p.kind {
+        HirPatLit -> {
+            if p.litValue.len() > 0 {
+                hirWalkVisitExpr(out, p.litValue[0])
+            }
+        },
+        HirPatTuple -> {
+            for el in p.tupleElems {
+                hirWalkVisitPattern(out, el)
+            }
+        },
+        HirPatStruct -> {
+            for f in p.structFields {
+                if f.hasPattern {
+                    hirWalkVisitPattern(out, f.pattern)
+                }
+            }
+        },
+        HirPatVariant -> {
+            for arg in p.variantArgs {
+                hirWalkVisitPattern(out, arg)
+            }
+        },
+        HirPatRange -> {
+            if p.rangeLow.len() > 0 {
+                hirWalkVisitExpr(out, p.rangeLow[0])
+            }
+            if p.rangeHigh.len() > 0 {
+                hirWalkVisitExpr(out, p.rangeHigh[0])
+            }
+        },
+        HirPatOr -> {
+            for alt in p.orAlts {
+                hirWalkVisitPattern(out, alt)
+            }
+        },
+        HirPatBinding -> {
+            if p.bindingChild.len() > 0 {
+                hirWalkVisitPattern(out, p.bindingChild[0])
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn hirWalkVisitMatchArm(out: HirWalkOrder, arm: HirMatchArm) {
+    out.matchArms.push(arm)
+    hirWalkVisitPattern(out, arm.pattern)
+    if arm.hasGuard {
+        hirWalkVisitExpr(out, arm.guard)
+    }
+    hirWalkVisitBlock(out, arm.body)
+}
+
+fn hirWalkFirstExpr(xs: List<HirExpr>) -> HirExpr {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirExprInvalid()
+    }
+}
+
+fn hirWalkFirstBlock(xs: List<HirBlock>) -> HirBlock {
+    if xs.len() > 0 {
+        xs[0]
+    } else {
+        hirBlock(hirNoSpan())
+    }
+}

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -574,7 +574,8 @@ pub fn mirLowerEmitDeclarations(l: MirLowerer) {
 /// as the body of a synthetic `main()`. Matches Go's `emitScript`
 /// policy — backends conventionally do the same thing.
 pub fn mirLowerEmitScript(l: MirLowerer) {
-    if l.src.script.len() == 0 {
+    let script = l.src.script
+    if script.len() == 0 {
         return
     }
     let span = mirSpanFromHir(l.src.span)
@@ -585,7 +586,7 @@ pub fn mirLowerEmitScript(l: MirLowerer) {
     // simple stmt kinds land instructions; unsupported kinds record
     // an issue and fall through to an implicit unit return.
     let bs = mirLowerBodyState(l, main, hirTUnit())
-    for s in l.src.script {
+    for s in script {
         mirLowerStmt(bs, s)
     }
     mirLowerFinishNoReturn(bs, span)
@@ -711,7 +712,8 @@ fn mirLowerSelfOwnerName(decl: HirFnDecl) -> String {
 /// therefore should emit as an external stub. FFI-sourced fns arrive
 /// with empty bodies after the collector.
 fn mirLowerFunctionIsExternal(decl: HirFnDecl) -> Bool {
-    decl.body.stmts.len() == 0 && !decl.body.hasResult
+    let stmts = decl.body.stmts
+    stmts.len() == 0 && !decl.body.hasResult
 }
 
 /// mirLowerCopyFnAnnotations copies HIR annotation metadata onto the

--- a/toolchain/mir_optimize.osty
+++ b/toolchain/mir_optimize.osty
@@ -725,7 +725,8 @@ fn mirCollapseBlockEdges(bb: MirBasicBlock, func: MirFunction) -> Bool {
             }
         },
         MirTermSwitchInt -> {
-            let nCases = bb.term.cases.len()
+            let cases = bb.term.cases
+            let nCases = cases.len()
             let mut ci = 0
             for _iter in 0..nCases {
                 let curTarget = bb.term.cases[ci].target

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -104,7 +104,8 @@ pub fn mirValidateFunction(func: MirFunction) -> List<String> {
     let mut pi = 0
     for pid in func.params {
         if pid < 0 || pid >= func.locals.len() {
-            errs.push("function \"{func.name}\": params[{pi}]={pid} out of range (locals={func.locals.len()})")
+            let localCount = func.locals.len()
+            errs.push("function \"{func.name}\": params[{pi}]={pid} out of range (locals={localCount})")
             pi = pi + 1
             continue
         }
@@ -159,7 +160,8 @@ pub fn mirValidateFunction(func: MirFunction) -> List<String> {
         return errs
     }
     if func.entry < 0 || func.entry >= func.blocks.len() {
-        errs.push("function \"{func.name}\": entry={func.entry} out of range (blocks={func.blocks.len()})")
+        let blockCount = func.blocks.len()
+        errs.push("function \"{func.name}\": entry={func.entry} out of range (blocks={blockCount})")
     }
 
     let mut bi = 0
@@ -574,7 +576,8 @@ fn mirValidateBlockRef(
 ) -> List<String> {
     let mut errs: List<String> = []
     if target < 0 || target >= func.blocks.len() {
-        errs.push("function \"{func.name}\" bb{bb.id} {ctx}: target bb{target} out of range (blocks={func.blocks.len()})")
+        let blockCount = func.blocks.len()
+        errs.push("function \"{func.name}\" bb{bb.id} {ctx}: target bb{target} out of range (blocks={blockCount})")
     }
     errs
 }

--- a/toolchain/monomorph_pass.osty
+++ b/toolchain/monomorph_pass.osty
@@ -761,8 +761,10 @@ pub fn hirTypeCodeList(ts: List<HirType>, pkg: String) -> List<String> {
 /// into the call expression's callee — Stage C's scanner does that.
 /// Stage B only guarantees enqueue + mangling + dedup.
 pub fn monoRequestFn(state: MonoState, fnDecl: HirFnDecl, typeArgs: List<HirType>) -> String {
-    if !monomorphShouldInstantiate(typeArgs.len(), fnDecl.generics.len()) {
-        monoAddErr(state, "monomorph: arity mismatch for {fnDecl.name}: {typeArgs.len()} type args vs {fnDecl.generics.len()} generics")
+    let typeArgCount = typeArgs.len()
+    let genericCount = fnDecl.generics.len()
+    if !monomorphShouldInstantiate(typeArgCount, genericCount) {
+        monoAddErr(state, "monomorph: arity mismatch for {fnDecl.name}: {typeArgCount} type args vs {genericCount} generics")
         return ""
     }
     if monoCheckConcreteArgs(state, "fn", fnDecl.name, typeArgs) {
@@ -809,8 +811,10 @@ pub fn monoRequestFn(state: MonoState, fnDecl: HirFnDecl, typeArgs: List<HirType
 /// Phase 4 method rewriting that runs before the struct is emitted
 /// still resolves the template.
 pub fn monoRequestStructType(state: MonoState, decl: HirStructDecl, typeArgs: List<HirType>) -> String {
-    if !monomorphShouldInstantiate(typeArgs.len(), decl.generics.len()) {
-        monoAddErr(state, "monomorph: arity mismatch for struct {decl.name}: {typeArgs.len()} type args vs {decl.generics.len()} generics")
+    let typeArgCount = typeArgs.len()
+    let genericCount = decl.generics.len()
+    if !monomorphShouldInstantiate(typeArgCount, genericCount) {
+        monoAddErr(state, "monomorph: arity mismatch for struct {decl.name}: {typeArgCount} type args vs {genericCount} generics")
         return ""
     }
     if monoCheckConcreteArgs(state, "struct", decl.name, typeArgs) {
@@ -849,8 +853,10 @@ pub fn monoRequestStructType(state: MonoState, decl: HirStructDecl, typeArgs: Li
 
 /// monoRequestEnumType is the enum counterpart of monoRequestStructType.
 pub fn monoRequestEnumType(state: MonoState, decl: HirEnumDecl, typeArgs: List<HirType>) -> String {
-    if !monomorphShouldInstantiate(typeArgs.len(), decl.generics.len()) {
-        monoAddErr(state, "monomorph: arity mismatch for enum {decl.name}: {typeArgs.len()} type args vs {decl.generics.len()} generics")
+    let typeArgCount = typeArgs.len()
+    let genericCount = decl.generics.len()
+    if !monomorphShouldInstantiate(typeArgCount, genericCount) {
+        monoAddErr(state, "monomorph: arity mismatch for enum {decl.name}: {typeArgCount} type args vs {genericCount} generics")
         return ""
     }
     if monoCheckConcreteArgs(state, "enum", decl.name, typeArgs) {
@@ -888,8 +894,10 @@ pub fn monoRequestEnumType(state: MonoState, decl: HirEnumDecl, typeArgs: List<H
 /// interfaces have no instance-method dispatch site to route, so Phase
 /// 4 bookkeeping skips them.
 pub fn monoRequestInterfaceType(state: MonoState, decl: HirInterfaceDecl, typeArgs: List<HirType>) -> String {
-    if !monomorphShouldInstantiate(typeArgs.len(), decl.generics.len()) {
-        monoAddErr(state, "monomorph: arity mismatch for interface {decl.name}: {typeArgs.len()} type args vs {decl.generics.len()} generics")
+    let typeArgCount = typeArgs.len()
+    let genericCount = decl.generics.len()
+    if !monomorphShouldInstantiate(typeArgCount, genericCount) {
+        monoAddErr(state, "monomorph: arity mismatch for interface {decl.name}: {typeArgCount} type args vs {genericCount} generics")
         return ""
     }
     if monoCheckConcreteArgs(state, "interface", decl.name, typeArgs) {
@@ -939,8 +947,10 @@ pub fn monoRequestMethodSpecialization(
     method: HirFnDecl,
     typeArgs: List<HirType>,
 ) -> String {
-    if !monomorphShouldInstantiate(typeArgs.len(), method.generics.len()) {
-        monoAddErr(state, "monomorph: arity mismatch for method {ownerMangled}.{method.name}: {typeArgs.len()} type args vs {method.generics.len()} generics")
+    let typeArgCount = typeArgs.len()
+    let genericCount = method.generics.len()
+    if !monomorphShouldInstantiate(typeArgCount, genericCount) {
+        monoAddErr(state, "monomorph: arity mismatch for method {ownerMangled}.{method.name}: {typeArgCount} type args vs {genericCount} generics")
         return ""
     }
     if monoCheckConcreteArgs(state, "method", method.name, typeArgs) {
@@ -1028,7 +1038,10 @@ pub fn monoDrain(state: MonoState) {
         monoDrainTypeQueue(state)
         monoDrainMethodQueue(state)
     }
-    monoAddErr(state, "monomorph: drain exceeded {maxPasses} passes; likely an emitter is enqueuing without discharging (current queue sizes: fn={state.queue.len()}, type={state.typeQueue.len()}, method={state.methodQueue.len()})")
+    let fnQueueLen = state.queue.len()
+    let typeQueueLen = state.typeQueue.len()
+    let methodQueueLen = state.methodQueue.len()
+    monoAddErr(state, "monomorph: drain exceeded {maxPasses} passes; likely an emitter is enqueuing without discharging (current queue sizes: fn={fnQueueLen}, type={typeQueueLen}, method={methodQueueLen})")
 }
 
 /// monoDrainFnQueue pops every currently-queued free-fn specialization

--- a/toolchain/pmcompile.osty
+++ b/toolchain/pmcompile.osty
@@ -225,11 +225,11 @@ pub fn pmTryCompileLitSwitch(
         let arm = arms[i]
         match arm.pattern.kind {
             HirPatLit -> {
-                let litValue = if arm.pattern.litValue.len() > 0 {
-                    arm.pattern.litValue[0]
-                } else {
+                let litValues = arm.pattern.litValue
+                if litValues.len() == 0 {
                     return hirDecisionInvalid()
                 }
+                let litValue = litValues[0]
                 let k = pmSwitchKindOfLit(litValue)
                 let kIsUnknown = match k {
                     HirSwitchUnknown -> true,
@@ -411,6 +411,9 @@ fn pmAsciiChar(cp: Int) -> String {
     // manually unrolled table keeps this free of intrinsic
     // dependencies. Only printable ASCII (0x20..0x7E) is populated;
     // outside that range pmCodePointChar already routed to "...".
+    if cp == 123 { return "\{" }
+    if cp == 124 { return "|" }
+    if cp == 125 { return "\}" }
     match cp {
         32 -> " ", 33 -> "!", 34 -> "\"", 35 -> "#", 36 -> "$",
         37 -> "%", 38 -> "&", 39 -> "'", 40 -> "(", 41 -> ")",
@@ -430,7 +433,7 @@ fn pmAsciiChar(cp: Int) -> String {
         107 -> "k", 108 -> "l", 109 -> "m", 110 -> "n", 111 -> "o",
         112 -> "p", 113 -> "q", 114 -> "r", 115 -> "s", 116 -> "t",
         117 -> "u", 118 -> "v", 119 -> "w", 120 -> "x", 121 -> "y",
-        122 -> "z", 123 -> "{", 124 -> "|", 125 -> "}", 126 -> "~",
+        122 -> "z", 126 -> "~",
         _ -> "?",
     }
 }


### PR DESCRIPTION
## Summary
- complete the self-hosted `hir_lower.osty` AST->HIR lowering path, including decl/stmt/expr lowering for closures, match expressions, and loop-result handling
- add the remaining self-host HIR utility layers (`hir_print`, `hir_walk`, `hir_reach`, `hir_validate`, `hir_optimize`) plus regression coverage in `hir_port_test.osty`
- wire typed AST->Core lookup helpers through `elab.osty` and include `pmcompile.osty` in the HIR bundle, with small self-host compatibility fixes in monomorph/MIR helpers

## Why
The self-host toolchain still had a partial HIR lowerer and several missing HIR-side utility passes. That left the self-host pipeline incomplete and kept the HIR/MIR transpile smoke path from exercising the full AST->HIR bridge.

## Impact
This moves the self-host pipeline closer to parity with the Go implementation, gives the HIR tier its missing utility surface, and makes the merged HIR/MIR bundles transpile and compile through the bootstrap smoke tests.

## Validation
- `just front`
- `go test -count=1 -vet=off -run 'TestToolchainHirSourcesTranspile|TestToolchainMirSourcesTranspile' ./internal/selfhost`
- `just short` still fails for a pre-existing unrelated issue in `internal/ir/lower_test.go` because `resolve.Result` no longer has a `Refs` field