### PR TITLE
[codex] Add std.env mutation helpers

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -1237,6 +1237,78 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryStdEnvSetMutatesProcessEnv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    match env.set("OSTY_ENV_SET_TEST", "configured") {
+        Ok(_) -> println(env.get("OSTY_ENV_SET_TEST") ?? "missing"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	filteredEnv := []string{}
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "OSTY_ENV_SET_TEST=") {
+			continue
+		}
+		filteredEnv = append(filteredEnv, entry)
+	}
+	cmd.Env = filteredEnv
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "configured\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdEnvUnsetMutatesProcessEnv(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.env
+
+fn main() {
+    match env.unset("OSTY_ENV_UNSET_TEST") {
+        Ok(_) -> println(env.get("OSTY_ENV_UNSET_TEST") ?? "missing"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	filteredEnv := []string{}
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "OSTY_ENV_UNSET_TEST=") {
+			continue
+		}
+		filteredEnv = append(filteredEnv, entry)
+	}
+	cmd.Env = append(filteredEnv, "OSTY_ENV_UNSET_TEST=configured")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "missing\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinarySafepointsKeepManagedRootsAlive(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -11871,6 +11871,10 @@ void osty_rt_test_snapshot(const char *name, const char *output, const char *sou
  * Windows to avoid the drive-current-directory pseudo-entries the CRT
  * exposes through GetEnvironmentStringsA.
  *
+ * `env.set(name, value)` / `env.unset(name)` return NULL on success
+ * and a freshly allocated error String on failure, matching the
+ * `Result<(), Error>` lowering used for directory mutations too.
+ *
  * `env.currentDir()` duplicates the process working directory into a
  * fresh managed String on success. On failure the helper returns NULL
  * and leaves the platform error intact so `osty_rt_env_current_dir_error`
@@ -12011,6 +12015,71 @@ void *osty_rt_env_vars(void) {
 #endif
     osty_gc_root_release_v1(out);
     return out;
+}
+
+void *osty_rt_env_set(const char *name, const char *value) {
+    if (name == NULL) {
+        return osty_rt_env_error_message("failed to set environment variable", "name is null", "runtime.env.set.error");
+    }
+    if (value == NULL) {
+        return osty_rt_env_error_message("failed to set environment variable", "value is null", "runtime.env.set.error");
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    if (SetEnvironmentVariableA(name, value)) {
+        return NULL;
+    }
+    DWORD code = GetLastError();
+    char buf[96];
+    int written;
+    if (code == 0) {
+        return osty_rt_env_error_message("failed to set environment variable", "unknown error", "runtime.env.set.error");
+    }
+    written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+    if (written < 0) {
+        return osty_rt_env_error_message("failed to set environment variable", "win32 error", "runtime.env.set.error");
+    }
+    return osty_rt_env_error_message("failed to set environment variable", buf, "runtime.env.set.error");
+#else
+    errno = 0;
+    if (setenv(name, value, 1) == 0) {
+        return NULL;
+    }
+    if (errno == 0) {
+        return osty_rt_env_error_message("failed to set environment variable", "unknown error", "runtime.env.set.error");
+    }
+    return osty_rt_env_error_message("failed to set environment variable", strerror(errno), "runtime.env.set.error");
+#endif
+}
+
+void *osty_rt_env_unset(const char *name) {
+    if (name == NULL) {
+        return osty_rt_env_error_message("failed to unset environment variable", "name is null", "runtime.env.unset.error");
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    if (SetEnvironmentVariableA(name, NULL)) {
+        return NULL;
+    }
+    DWORD code = GetLastError();
+    char buf[96];
+    int written;
+    if (code == 0) {
+        return osty_rt_env_error_message("failed to unset environment variable", "unknown error", "runtime.env.unset.error");
+    }
+    written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+    if (written < 0) {
+        return osty_rt_env_error_message("failed to unset environment variable", "win32 error", "runtime.env.unset.error");
+    }
+    return osty_rt_env_error_message("failed to unset environment variable", buf, "runtime.env.unset.error");
+#else
+    errno = 0;
+    if (unsetenv(name) == 0) {
+        return NULL;
+    }
+    if (errno == 0) {
+        return osty_rt_env_error_message("failed to unset environment variable", "unknown error", "runtime.env.unset.error");
+    }
+    return osty_rt_env_error_message("failed to unset environment variable", strerror(errno), "runtime.env.unset.error");
+#endif
 }
 
 void *osty_rt_env_current_dir(void) {

--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -4,8 +4,8 @@
 // placeholder returning an empty list; this shim bypasses it so real
 // process environment reaches the program. `env.args()`,
 // `env.get(name)`, `env.require(name)`, `env.vars()`,
-// `env.currentDir()`, and `env.setCurrentDir(path)` are covered; the
-// remaining std.env surface (set, unset, …)
+// `env.currentDir()`, `env.setCurrentDir(path)`, `env.set(name, value)`,
+// and `env.unset(name)` are covered.
 // still falls through to LLVM015 and needs its own runtime helper + switch arm.
 package llvmgen
 
@@ -20,6 +20,8 @@ const ostyRtEnvVarsSymbol = "osty_rt_env_vars"
 const ostyRtEnvCurrentDirSymbol = "osty_rt_env_current_dir"
 const ostyRtEnvCurrentDirErrorSymbol = "osty_rt_env_current_dir_error"
 const ostyRtEnvSetCurrentDirSymbol = "osty_rt_env_set_current_dir"
+const ostyRtEnvSetSymbol = "osty_rt_env_set"
+const ostyRtEnvUnsetSymbol = "osty_rt_env_unset"
 
 // Shared across every env.args() call site so type inference doesn't
 // re-allocate an identical `List<String>` AST tree per reference.
@@ -42,7 +44,7 @@ var stdEnvRequireResultSourceTypeSingleton ast.Type = &ast.NamedType{
 
 var unitTupleSourceTypeSingleton ast.Type = &ast.TupleType{}
 
-var stdEnvSetCurrentDirResultSourceTypeSingleton ast.Type = &ast.NamedType{
+var stdEnvUnitErrorResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
 	Args: []ast.Type{
 		unitTupleSourceTypeSingleton,
@@ -97,6 +99,10 @@ func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdEnvCurrentDirCall(call)
 	case "setCurrentDir":
 		return g.emitStdEnvSetCurrentDirCall(call)
+	case "set":
+		return g.emitStdEnvSetCall(call)
+	case "unset":
+		return g.emitStdEnvUnsetCall(call)
 	default:
 		return value{}, false, nil
 	}
@@ -150,13 +156,31 @@ func (g *generator) stdEnvCallStaticResult(call *ast.CallExpr) (value, bool) {
 			sourceType: stdEnvRequireResultSourceTypeSingleton,
 		}, true
 	case "setCurrentDir":
-		info, ok := builtinResultTypeFromAST(stdEnvSetCurrentDirResultSourceTypeSingleton, g.typeEnv())
+		info, ok := builtinResultTypeFromAST(stdEnvUnitErrorResultSourceTypeSingleton, g.typeEnv())
 		if !ok {
 			return value{}, false
 		}
 		return value{
 			typ:        info.typ,
-			sourceType: stdEnvSetCurrentDirResultSourceTypeSingleton,
+			sourceType: stdEnvUnitErrorResultSourceTypeSingleton,
+		}, true
+	case "set":
+		info, ok := builtinResultTypeFromAST(stdEnvUnitErrorResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdEnvUnitErrorResultSourceTypeSingleton,
+		}, true
+	case "unset":
+		info, ok := builtinResultTypeFromAST(stdEnvUnitErrorResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdEnvUnitErrorResultSourceTypeSingleton,
 		}, true
 	default:
 		return value{}, false
@@ -183,7 +207,11 @@ func (g *generator) staticStdEnvCallSourceType(call *ast.CallExpr) (ast.Type, bo
 	case "currentDir":
 		return stdEnvRequireResultSourceTypeSingleton, true
 	case "setCurrentDir":
-		return stdEnvSetCurrentDirResultSourceTypeSingleton, true
+		return stdEnvUnitErrorResultSourceTypeSingleton, true
+	case "set":
+		return stdEnvUnitErrorResultSourceTypeSingleton, true
+	case "unset":
+		return stdEnvUnitErrorResultSourceTypeSingleton, true
 	default:
 		return nil, false
 	}
@@ -395,7 +423,7 @@ func (g *generator) emitStdEnvSetCurrentDirCall(call *ast.CallExpr) (value, bool
 		return value{}, true, unsupported("call", "env.setCurrentDir requires one positional String argument")
 	}
 	unitInfo := g.registerTupleType(nil, nil)
-	info, ok := builtinResultTypeFromAST(stdEnvSetCurrentDirResultSourceTypeSingleton, g.typeEnv())
+	info, ok := builtinResultTypeFromAST(stdEnvUnitErrorResultSourceTypeSingleton, g.typeEnv())
 	if !ok {
 		return value{}, true, unsupported("type-system", "env.setCurrentDir Result<(), Error> type is unavailable")
 	}
@@ -451,7 +479,130 @@ func (g *generator) emitStdEnvSetCurrentDirCall(call *ast.CallExpr) (value, bool
 	v := value{
 		typ:        info.typ,
 		ref:        phi,
-		sourceType: stdEnvSetCurrentDirResultSourceTypeSingleton,
+		sourceType: stdEnvUnitErrorResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdEnvSetCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "env.set expects 2 arguments, got %d", len(call.Args))
+	}
+	first := call.Args[0]
+	second := call.Args[1]
+	if first == nil || first.Name != "" || first.Value == nil || second == nil || second.Name != "" || second.Value == nil {
+		return value{}, true, unsupported("call", "env.set requires two positional String arguments")
+	}
+	name, err := g.emitExpr(first.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	name = g.protectManagedTemporary("env.set.name", name)
+	name, err = g.loadIfPointer(name)
+	if err != nil {
+		return value{}, true, err
+	}
+	if name.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.set arg 1 type %s, want String", name.typ)
+	}
+	valueArg, err := g.emitExpr(second.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	valueArg = g.protectManagedTemporary("env.set.value", valueArg)
+	valueArg, err = g.loadIfPointer(valueArg)
+	if err != nil {
+		return value{}, true, err
+	}
+	if valueArg.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.set arg 2 type %s, want String", valueArg.typ)
+	}
+	return g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"env.set",
+		stdEnvUnitErrorResultSourceTypeSingleton,
+		ostyRtEnvSetSymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(name), toOstyValue(valueArg)},
+	)
+}
+
+func (g *generator) emitStdEnvUnsetCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "env.unset expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, true, unsupported("call", "env.unset requires one positional String argument")
+	}
+	name, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	name = g.protectManagedTemporary("env.unset.name", name)
+	name, err = g.loadIfPointer(name)
+	if err != nil {
+		return value{}, true, err
+	}
+	if name.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "env.unset arg 1 type %s, want String", name.typ)
+	}
+	return g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"env.unset",
+		stdEnvUnitErrorResultSourceTypeSingleton,
+		ostyRtEnvUnsetSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(name)},
+	)
+}
+
+func (g *generator) emitStdEnvUnitErrorResultFromRuntimeCall(prefix string, sourceType ast.Type, symbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+	unitInfo := g.registerTupleType(nil, nil)
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupportedf("type-system", "%s Result<(), Error> type is unavailable", prefix)
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != unitInfo.typ || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "%s currently needs Result<%s, ptr>, got ok=%s err=%s", prefix, unitInfo.typ, info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(symbol, "ptr", params)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	errText := llvmCall(emitter, "ptr", symbol, args)
+	failed := llvmCompare(emitter, "ne", errText, toOstyValue(value{typ: "ptr", ref: "null"}))
+	errLabel := llvmNextLabel(emitter, llvmBuiltinAggregatePart(prefix)+".err")
+	okLabel := llvmNextLabel(emitter, llvmBuiltinAggregatePart(prefix)+".ok")
+	contLabel := llvmNextLabel(emitter, llvmBuiltinAggregatePart(prefix)+".cont")
+	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, errLabel+":")
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: sourceType,
 	}
 	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil

--- a/internal/llvmgen/stdlib_env_shim_test.go
+++ b/internal/llvmgen/stdlib_env_shim_test.go
@@ -225,3 +225,67 @@ fn main() {
 		}
 	}
 }
+
+// `env.set(name, value)` should lower to the runtime helper and
+// preserve the Result<(), Error> source type so `match` keeps compiling.
+func TestStdEnvSetRoutesToRuntimeAndKeepsResultSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    match osenv.set("HOME", "/tmp/demo") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_set.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_set(ptr, ptr)",
+		"call ptr @osty_rt_env_set(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// `env.unset(name)` should lower to the runtime helper and preserve
+// the Result<(), Error> source type so `match` keeps compiling.
+func TestStdEnvUnsetRoutesToRuntimeAndKeepsResultSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env as osenv
+
+fn main() {
+    match osenv.unset("HOME") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_unset.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_unset(ptr)",
+		"call ptr @osty_rt_env_unset(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add LLVM lowering for `std.env.set(name, value)` and `std.env.unset(name)`
- add runtime helpers that mutate the process environment and surface platform-specific error strings
- cover the new environment mutation paths with IR-level and binary-level regression tests

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestStdEnv(ArgsRoutesToRuntime|GetRoutesToRuntimeAndKeepsOptionalSourceType|RequireRoutesToRuntimeAndKeepsErrorMessageFallback|VarsRoutesToRuntimeAndKeepsMapSourceType|CurrentDirRoutesToRuntimeAndKeepsResultSourceType|SetCurrentDirRoutesToRuntimeAndKeepsResultSourceType|SetRoutesToRuntimeAndKeepsResultSourceType|UnsetRoutesToRuntimeAndKeepsResultSourceType|MainSignatureStableWithoutStdEnv)$'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryStdEnv(GetReadsProcessEnv|RequireReadsProcessEnv|RequireReportsMissingKey|VarsReadsProcessEnv|CurrentDirReadsProcessWorkingDir|SetCurrentDirChangesProcessWorkingDir|SetCurrentDirReportsMissingPath|SetMutatesProcessEnv|UnsetMutatesProcessEnv)$'`