### PR TITLE
[codex] Make std.testing core helpers declaration-only

### DIFF
--- a/internal/llvmgen/mir_direct_4walls_gate_test.go
+++ b/internal/llvmgen/mir_direct_4walls_gate_test.go
@@ -13,17 +13,22 @@ import (
 )
 
 // TestMIRDirectCoversFormerFallbackWalls is the regression gate for
-// four MIR-direct walls that previously forced GenerateFromMIR to
+// five MIR-direct walls that previously forced GenerateFromMIR to
 // surface ErrUnsupported and delegate to the legacy HIR→AST emitter:
 //
 //   - Downcast        : `recv.downcast::<T>()` on an interface value
-//                       — rejected with "unsupported local type <Iface>".
+//     — rejected with "unsupported local type <Iface>".
 //   - EnumWiden       : a user enum used as `Result<_, E>` Err payload
-//                       — rejected with "cannot widen %<Enum> to i64".
+//     — rejected with "cannot widen %<Enum> to i64".
 //   - TestingContext  : `std.testing.context(label, closure)`
-//                       — rejected with "unresolved symbol std.testing.*".
+//     — rejected with "unresolved symbol std.testing.*".
 //   - TestingBenchmark: `std.testing.benchmark(n, closure)` with `Ok(())`
-//                       — rejected with "tuple aggregate type ()".
+//     — rejected with "tuple aggregate type ()".
+//   - TestingSnapshot : `std.testing.snapshot(name, output)` —
+//     previously fell through to an unresolved
+//     `std.testing.*` symbol because the MIR
+//     dispatcher did not forward it to the runtime
+//     helper.
 //
 // Each sub-test calls GenerateFromMIR ONLY (no legacy fallback) and
 // asserts that the MIR emitter now produces the shape-critical IR
@@ -94,6 +99,19 @@ fn main() {
 `,
 			want: []string{
 				"call i64 @add(i64 1, i64 2)",
+			},
+		},
+		{
+			name: "TestingSnapshot",
+			src: `use std.testing as testing
+fn main() {
+    testing.snapshot("golden", "hello\nworld\n")
+}
+`,
+			want: []string{
+				"declare void @osty_rt_test_snapshot(ptr, ptr, ptr)",
+				"call void @osty_rt_test_snapshot(",
+				"/tmp/probe_4walls.osty",
 			},
 		},
 	}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2561,7 +2561,8 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 	// mirrors that dispatch in-place instead of trying to resolve the
 	// symbol as an ordinary user function. Scope stays narrow: only the
 	// shapes the LLVM compat tests exercise (assertEq/assertNe/assert/
-	// assertTrue/assertFalse/fail/context/benchmark/expectOk/expectError).
+	// assertTrue/assertFalse/fail/context/benchmark/expectOk/expectError/
+	// snapshot).
 	if strings.HasPrefix(fnRef.Symbol, "std.testing.") {
 		if handled, err := g.emitStdTestingCall(c, fnRef); handled {
 			return err
@@ -2818,6 +2819,8 @@ func (g *mirGen) emitStdTestingCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, e
 		return true, g.emitTestingContextMIR(c)
 	case "benchmark":
 		return true, g.emitTestingBenchmarkMIR(c)
+	case "snapshot":
+		return true, g.emitTestingSnapshotMIR(c)
 	}
 	return false, nil
 }
@@ -2864,6 +2867,42 @@ func (g *mirGen) emitTestingContextMIR(c *mir.CallInstr) error {
 	if err := g.invokeClosureOperand(c.Args[1]); err != nil {
 		return err
 	}
+	return g.storeUnitDestIfAny(c)
+}
+
+// emitTestingSnapshotMIR lowers `testing.snapshot(name, output)` to the
+// same runtime helper the legacy AST path uses. `g.source` carries the
+// compile-time source path so snapshot lookup stays independent of the
+// process working directory.
+func (g *mirGen) emitTestingSnapshotMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.testing.snapshot requires (name, output)")
+	}
+	nameT := c.Args[0].Type()
+	if g.llvmType(nameT) != "ptr" {
+		return unsupportedf("mir-mvp", "std.testing.snapshot name type %s, want String", mirTypeString(nameT))
+	}
+	name, err := g.evalOperand(c.Args[0], nameT)
+	if err != nil {
+		return err
+	}
+	outputT := c.Args[1].Type()
+	if g.llvmType(outputT) != "ptr" {
+		return unsupportedf("mir-mvp", "std.testing.snapshot output type %s, want String", mirTypeString(outputT))
+	}
+	output, err := g.evalOperand(c.Args[1], outputT)
+	if err != nil {
+		return err
+	}
+	g.declareRuntime("osty_rt_test_snapshot", "declare void @osty_rt_test_snapshot(ptr, ptr, ptr)")
+	sourceSym := g.stringLiteral(g.source)
+	g.fnBuf.WriteString("  call void @osty_rt_test_snapshot(ptr ")
+	g.fnBuf.WriteString(name)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(output)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(sourceSym)
+	g.fnBuf.WriteString(")\n")
 	return g.storeUnitDestIfAny(c)
 }
 

--- a/internal/stdlib/modules/testing.osty
+++ b/internal/stdlib/modules/testing.osty
@@ -5,46 +5,29 @@
 // take no arguments are discovered and run by `osty test`; functions
 // whose names begin with `bench` are benchmarks (§11.4).
 //
-// Bodies below are placeholders sized to satisfy the type checker. The
-// `osty test` runner supplies real behavior at run time — assertion
-// failures are converted into recorded test results via panic / recover
-// in the generated Go harness, so these stubs are never actually called
-// in the happy path of a passing test.
+// Core assertion/runner helpers are declaration-only: both LLVM codegen
+// paths intercept these call sites and lower them to the real test
+// runtime / harness behavior.
 
-pub fn assert(cond: Bool) {
-}
+pub fn assert(cond: Bool)
 
-pub fn assertTrue(cond: Bool) {
-}
+pub fn assertTrue(cond: Bool)
 
-pub fn assertFalse(cond: Bool) {
-}
+pub fn assertFalse(cond: Bool)
 
-pub fn assertEq<T: Equal>(actual: T, expected: T) {
-}
+pub fn assertEq<T: Equal>(actual: T, expected: T)
 
-pub fn assertNe<T: Equal>(actual: T, expected: T) {
-}
+pub fn assertNe<T: Equal>(actual: T, expected: T)
 
-pub fn expectOk<T, E>(result: Result<T, E>) -> T {
-    result.unwrap()
-}
+pub fn expectOk<T, E>(result: Result<T, E>) -> T
 
-pub fn expectError<T, E>(result: Result<T, E>) -> E {
-    result.unwrapErr()
-}
+pub fn expectError<T, E>(result: Result<T, E>) -> E
 
-pub fn fail(msg: String) -> Never {
-    fail(msg)
-}
+pub fn fail(msg: String) -> Never
 
-pub fn context(msg: String, body: fn() -> ()) {
-    body()
-}
+pub fn context(msg: String, body: fn() -> ())
 
-pub fn benchmark(iterations: Int, body: fn() -> Result<(), Error>) {
-    body()
-}
+pub fn benchmark(iterations: Int, body: fn() -> Result<(), Error>)
 
 /// `snapshot(name, output)` compares `output` against a golden file
 /// stored at `<source_dir>/__snapshots__/<sanitize(name)>.snap`.
@@ -58,13 +41,9 @@ pub fn benchmark(iterations: Int, body: fn() -> Result<(), Error>) {
 ///
 /// Re-run `osty test --update-snapshots` (or set
 /// `OSTY_UPDATE_SNAPSHOTS=1`) to accept the new output and overwrite
-/// every golden in the run. The LLVM backend intercepts this call
-/// and emits a direct runtime helper — the stub body below exists
-/// only to satisfy the type checker.
-pub fn snapshot(name: String, output: String) {
-    let _ = name
-    let _ = output
-}
+/// every golden in the run. Both LLVM codegen paths intercept this
+/// call and emit a direct runtime helper.
+pub fn snapshot(name: String, output: String)
 
 // ---------- property-based testing (v0.5 G33) ----------
 


### PR DESCRIPTION
## Summary
- make the core `std.testing` helpers declaration-only instead of keeping placeholder bodies
- add MIR lowering for `testing.snapshot(...)` so both LLVM paths intercept the same surface
- extend the former fallback-wall regression gate with a `TestingSnapshot` case

## Validation
- go test -count=1 -vet=off ./internal/llvmgen -run 'Test(TestingSnapshotLowersToRuntimeHelper|TestingAssertEqStringsEmitsStructuralDiff|TestingAssertEqListIntEmitsStructuralDiff|TestingAssertEqIntegersSkipsDiff|MIRDirectCoversFormerFallbackWalls)$'
- go test -count=1 -vet=off ./internal/backend -run 'Test(PreparePackageMergesMultiFileDecls|PreparePackageSingleFileKeepsEntryFileAndDecl|PreparePackageNilPackage|PreparePackagePicksFirstNonNilFileWhenEntryUnset)$'
