### PR TITLE
fix(ast_lower): Char/Byte literal 'b' decoded to U+FFFD

### DIFF
--- a/internal/parser/char_byte_literal_test.go
+++ b/internal/parser/char_byte_literal_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// TestParseCharLiteralAllAsciiLetters guards against a regression where
+// `'b'` (the ASCII letter b as a Char literal) decoded to U+FFFD.
+// Root cause: astLowerDecodedLiteral unconditionally trimmed a leading
+// "b" from the already-decoded token value, which collapsed the single
+// character "b" to "" before firstRune ran. The fix requires the prefix
+// to be followed by `'` so only byte-literal source (`b'A'`) is trimmed.
+func TestParseCharLiteralAllAsciiLetters(t *testing.T) {
+	for r := 'a'; r <= 'z'; r++ {
+		r := r
+		t.Run(fmt.Sprintf("lower_%c", r), func(t *testing.T) {
+			got := parseCharLitValue(t, fmt.Sprintf("pub let c: Char = '%c'\n", r))
+			if got != r {
+				t.Fatalf("CharLit('%c') = U+%04X, want U+%04X", r, got, r)
+			}
+		})
+	}
+	for r := 'A'; r <= 'Z'; r++ {
+		r := r
+		t.Run(fmt.Sprintf("upper_%c", r), func(t *testing.T) {
+			got := parseCharLitValue(t, fmt.Sprintf("pub let c: Char = '%c'\n", r))
+			if got != r {
+				t.Fatalf("CharLit('%c') = U+%04X, want U+%04X", r, got, r)
+			}
+		})
+	}
+}
+
+func TestParseByteLiteralAllAsciiLetters(t *testing.T) {
+	for r := 'a'; r <= 'z'; r++ {
+		r := r
+		t.Run(fmt.Sprintf("lower_%c", r), func(t *testing.T) {
+			got := parseByteLitValue(t, fmt.Sprintf("pub let c: Byte = b'%c'\n", r))
+			if got != byte(r) {
+				t.Fatalf("ByteLit(b'%c') = %d, want %d", r, got, byte(r))
+			}
+		})
+	}
+}
+
+func parseCharLitValue(t *testing.T, src string) rune {
+	t.Helper()
+	lit, ok := firstLetValue(t, src).(*ast.CharLit)
+	if !ok {
+		t.Fatalf("let value %T, want *ast.CharLit", firstLetValue(t, src))
+	}
+	return lit.Value
+}
+
+func parseByteLitValue(t *testing.T, src string) byte {
+	t.Helper()
+	lit, ok := firstLetValue(t, src).(*ast.ByteLit)
+	if !ok {
+		t.Fatalf("let value %T, want *ast.ByteLit", firstLetValue(t, src))
+	}
+	return lit.Value
+}
+
+func firstLetValue(t *testing.T, src string) ast.Expr {
+	t.Helper()
+	file, diags := ParseDiagnostics([]byte(src))
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags[0])
+	}
+	if file == nil || len(file.Decls) == 0 {
+		t.Fatalf("no decls parsed from %q", src)
+	}
+	let, ok := file.Decls[0].(*ast.LetDecl)
+	if !ok {
+		t.Fatalf("decl %T, want *ast.LetDecl", file.Decls[0])
+	}
+	return let.Value
+}

--- a/internal/selfhost/ast_lower.osty
+++ b/internal/selfhost/ast_lower.osty
@@ -702,7 +702,7 @@ fn astLowerStringContent(s: String) -> String {
 
 fn astLowerDecodedLiteral(s: String) -> String {
     let mut raw = s
-    if strings.HasPrefix(raw, "b") {
+    if strings.HasPrefix(raw, "b'") {
         raw = strings.TrimPrefix(raw, "b")
     }
     if strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'") {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -63585,7 +63585,7 @@ func astLowerDecodedLiteral(s string) string {
 	raw := s
 	_ = raw
 	// Osty: /tmp/selfhost_merged.osty:33664:5
-	if strings.HasPrefix(raw, "b") {
+	if strings.HasPrefix(raw, "b'") {
 		// Osty: /tmp/selfhost_merged.osty:33665:9
 		raw = strings.TrimPrefix(raw, "b")
 	}


### PR DESCRIPTION
## Summary

Replacement for #734 (closed due to rebase conflict state). Clean rebase onto current main.

- `'b'` (and `b'b'`) were silently decoded to U+FFFD / 0 because `astLowerDecodedLiteral` blindly trimmed a leading `"b"` from an already-decoded token value, collapsing the single character `b` to the empty string
- Fix narrows the trim to the actual byte-literal prefix shape `b'…'` so only real byte-literal source is stripped
- 78 ASCII letter regression tests (52 Char + 26 Byte); without fix only `_b` subtests fail, confirming single-character trigger

## Repro (pre-fix)

```osty
fn main() {
    let a: Char = 'a'
    let b: Char = 'b'
    let c: Char = 'c'
    println(a.toInt())   // 97   ✓
    println(b.toInt())   // 65533 ✗ (expected 98)
    println(c.toInt())   // 99   ✓
}
```

Byte literals were also affected — `b'b'` → 0 via `firstByte("")`.

## Root cause

The front-end has two layers that both want to strip the byte-literal wrapper:

- `internal/selfhost/adapter.go` `decodeChar` / `decodeByte` already strips `b'…'` → `…` at lex time
- `internal/selfhost/ast_lower.osty` `astLowerDecodedLiteral` was doing it again, unconditionally, via `HasPrefix(raw, "b")`. When the token value was the single letter `b`, this collapsed it to `""`; `firstRune("")` then returned `RuneError` = 0xFFFD and `firstByte("")` returned 0.

Guarding the second strip with `HasPrefix(raw, "b'")` makes it only fire for raw-source paths that still carry the byte-literal wrapper, and leaves already-decoded tokens alone.

## Why generated.go is patched in place

`generated.go` is transpiled from `ast_lower.osty` via `go run ./internal/selfhost/gen_selfhost.go`, but a fresh regen would churn ~19k unrelated lines due to bootstrap-gen drift accumulated since the last regen. Applied a surgical patch to keep the PR focused on the bug fix; the next full regen will absorb this naturally.

## Test plan

- [x] `go test ./internal/parser -run 'TestParseCharLiteralAllAsciiLetters|TestParseByteLiteralAllAsciiLetters'` — 78 subtests pass with fix; `_b` subtests fail without
- [x] `just front` — all 8 frontend packages green
- [x] End-to-end: `osty run --backend=llvm` on a program printing `.toInt()` for every ASCII letter

🤖 Generated with [Claude Code](https://claude.com/claude-code)