### PR TITLE
[codex] Implement std.io readLine runtime bridge

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -1020,6 +1020,35 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryStdIoReadLine(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.io as io
+
+fn main() {
+    let first = io.readLine()
+    let second = io.readLine()
+    println(first)
+    println(second)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Stdin = strings.NewReader("alpha\nbeta\n")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "alpha\nbeta\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinaryStdEnvGetReadsProcessEnv(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -11855,6 +11855,35 @@ void osty_rt_io_write(const char *text, bool newline, bool to_stderr) {
     fflush(out);
 }
 
+void *osty_rt_io_read_line(void) {
+    size_t cap = 128;
+    size_t len = 0;
+    char *buf = (char *)osty_rt_xmalloc(cap, "runtime.io.read_line.buf");
+    for (;;) {
+        int ch = fgetc(stdin);
+        if (ch == EOF || ch == '\n') {
+            break;
+        }
+        if (len + 1 >= cap) {
+            size_t next_cap = cap * 2;
+            char *grown = (char *)realloc(buf, next_cap);
+            if (grown == NULL) {
+                free(buf);
+                osty_rt_abort("runtime.io.read_line: realloc failed");
+            }
+            buf = grown;
+            cap = next_cap;
+        }
+        buf[len++] = (char)ch;
+    }
+    if (len > 0 && buf[len - 1] == '\r') {
+        len--;
+    }
+    void *out = osty_rt_string_dup_site(buf, len, "runtime.io.read_line");
+    free(buf);
+    return out;
+}
+
 /* std.env command-line argument surface.
  *
  * The emitter (see internal/llvmgen/stdlib_env_shim.go) routes the Osty

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -6975,6 +6975,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdIoCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitPtrBackedErrorCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -2020,6 +2020,19 @@ func nativeStdIoCallStmtFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) 
 	}, true
 }
 
+func nativeStdIoExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeExpr, bool) {
+	alias, name, ok := nativeQualifiedAliasCall(call)
+	if !ok || ctx == nil || !ctx.stdIoAliases[alias] || name != "readLine" || len(call.Args) != 0 {
+		return nil, false
+	}
+	ctx.addRuntimeDecl("declare ptr @" + ostyRtIOReadLineSymbol + "()")
+	return &llvmNativeExpr{
+		kind:     llvmNativeExprCall,
+		llvmType: "ptr",
+		name:     ostyRtIOReadLineSymbol,
+	}, true
+}
+
 func nativeStdIoIntrinsicExpr(ctx *nativeProjectionCtx, e *ostyir.IntrinsicCall) (*llvmNativeExpr, bool) {
 	if ctx == nil || e == nil || len(e.Args) != 1 || e.Args[0].IsKeyword() || e.Args[0].Value == nil {
 		return nil, false
@@ -3336,6 +3349,9 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 			childExprs:          []*llvmNativeExpr{left, right},
 		}, true
 	case *ostyir.CallExpr:
+		if stdIoExpr, ok := nativeStdIoExprFromIR(ctx, e); ok {
+			return stdIoExpr, true
+		}
 		if testingExpr, ok := nativeTestingResultExprFromIR(ctx, e); ok {
 			return testingExpr, true
 		}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2832,6 +2832,9 @@ func (g *mirGen) emitStdTestingCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, e
 
 func (g *mirGen) emitStdIoCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	method := strings.TrimPrefix(fnRef.Symbol, "std.io.")
+	if method == "readLine" {
+		return true, g.emitStdIoReadLineMIR(c)
+	}
 	if !isStdIoOutputMethod(method) {
 		return false, nil
 	}
@@ -2839,6 +2842,14 @@ func (g *mirGen) emitStdIoCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 		return true, err
 	}
 	return true, g.storeUnitDestIfAny(c)
+}
+
+func (g *mirGen) emitStdIoReadLineMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 0 {
+		return unsupported("mir-mvp", "std.io.readLine requires no arguments")
+	}
+	g.declareRuntime(ostyRtIOReadLineSymbol, "declare ptr @"+ostyRtIOReadLineSymbol+"()")
+	return g.emitCallSiteByName(c, ostyRtIOReadLineSymbol, "ptr", nil)
 }
 
 func (g *mirGen) emitStdIoWriteIntrinsic(i *mir.IntrinsicInstr, method string) error {

--- a/internal/llvmgen/stdlib_io_shim.go
+++ b/internal/llvmgen/stdlib_io_shim.go
@@ -3,6 +3,7 @@ package llvmgen
 import "github.com/osty/osty/internal/ast"
 
 const ostyRtIOWriteSymbol = "osty_rt_io_write"
+const ostyRtIOReadLineSymbol = "osty_rt_io_read_line"
 
 func collectStdIoAliases(file *ast.File) map[string]bool {
 	out := map[string]bool{}
@@ -50,15 +51,23 @@ func stdIoWriteFlags(name string) (newline bool, toStderr bool, ok bool) {
 }
 
 func (g *generator) stdIoCallMethod(call *ast.CallExpr) (string, bool) {
-	field, ok := fieldExprOfCallFn(call)
-	if !ok || field.IsOptional {
-		return "", false
-	}
-	alias, ok := field.X.(*ast.Ident)
-	if !ok || alias == nil || !g.stdIoAliases[alias.Name] || !isStdIoOutputMethod(field.Name) {
+	field, ok := g.stdIoCallField(call)
+	if !ok || !isStdIoOutputMethod(field.Name) {
 		return "", false
 	}
 	return field.Name, true
+}
+
+func (g *generator) stdIoCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || alias == nil || !g.stdIoAliases[alias.Name] {
+		return nil, false
+	}
+	return field, true
 }
 
 func stdIoBareCallName(call *ast.CallExpr) (string, bool) {
@@ -81,6 +90,15 @@ func (g *generator) emitStdIoCallStmt(call *ast.CallExpr) (bool, error) {
 		}
 	}
 	return true, g.emitStdIoWriteCall(call, method)
+}
+
+func (g *generator) emitStdIoCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdIoCallField(call)
+	if !ok || field.Name != "readLine" {
+		return value{}, false, nil
+	}
+	v, err := g.emitStdIoReadLineCall(call)
+	return v, true, err
 }
 
 func (g *generator) emitStdIoWriteCall(call *ast.CallExpr, method string) error {
@@ -108,6 +126,24 @@ func (g *generator) emitStdIoWriteCall(call *ast.CallExpr, method string) error 
 	})
 	g.takeOstyEmitter(emitter)
 	return nil
+}
+
+func (g *generator) emitStdIoReadLineCall(call *ast.CallExpr) (value, error) {
+	field, ok := g.stdIoCallField(call)
+	if !ok || field.Name != "readLine" {
+		return value{}, unsupported("call", "std.io.readLine requires a std.io alias receiver")
+	}
+	if len(call.Args) != 0 {
+		return value{}, unsupported("call", "std.io.readLine requires no arguments")
+	}
+	g.declareRuntimeSymbol(ostyRtIOReadLineSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", ostyRtIOReadLineSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	text := fromOstyValue(out)
+	text.gcManaged = true
+	text.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return text, nil
 }
 
 func llvmStdIoBoolValue(v bool) *LlvmValue {

--- a/internal/llvmgen/stdlib_io_shim_test.go
+++ b/internal/llvmgen/stdlib_io_shim_test.go
@@ -41,6 +41,32 @@ fn main() {
 	}
 }
 
+func TestStdIoReadLineRoutesToRuntimeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.io as io
+
+fn main() {
+    let line = io.readLine()
+    println(line)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_io_readline_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_io_read_line()",
+		"call ptr @osty_rt_io_read_line()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
 func TestStdIoOutputCallsRouteToRuntimeWriteInMIR(t *testing.T) {
 	mod := lowerSrcLLVM(t, `use std.io as io
 
@@ -74,6 +100,33 @@ fn main() {
 	}
 	if gotCalls := strings.Count(got, "call void @osty_rt_io_write("); gotCalls != 4 {
 		t.Fatalf("osty_rt_io_write call count = %d, want 4\n%s", gotCalls, got)
+	}
+}
+
+func TestStdIoReadLineRoutesToRuntimeInMIR(t *testing.T) {
+	mod := lowerSrcLLVM(t, `use std.io as io
+
+fn main() {
+    let line = io.readLine()
+    println(line)
+}
+`)
+	mirMod := buildMIRModuleFromHIR(t, mod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_io_readline_mir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_io_read_line()",
+		"call ptr @osty_rt_io_read_line()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
 	}
 }
 
@@ -113,5 +166,34 @@ fn main() {
 	}
 	if gotCalls := strings.Count(got, "call void @osty_rt_io_write("); gotCalls != 4 {
 		t.Fatalf("osty_rt_io_write call count = %d, want 4\n%s", gotCalls, got)
+	}
+}
+
+func TestStdIoReadLineRoutesToRuntimeInNativeOwnedEntry(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `use std.io as io
+
+fn main() {
+    let line = io.readLine()
+    println(line)
+}
+`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_io_readline_native.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_io_read_line()",
+		"call ptr @osty_rt_io_read_line()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
 	}
 }

--- a/internal/stdlib/modules/io.osty
+++ b/internal/stdlib/modules/io.osty
@@ -1,10 +1,9 @@
 // std.io — console I/O.
 //
 // `print`, `println`, `eprint`, `eprintln`, `readLine` are the full
-// Tier 1 surface. The four output helpers are backend-owned
-// declarations; `readLine` still keeps its placeholder body until the
-// stdin runtime lands. All five except `readLine` are prelude-aliased
-// so user code can call them unqualified.
+// Tier 1 surface. All five are backend-owned declarations; the output
+// helpers are prelude-aliased while `readLine` is module-qualified.
+// The LLVM lowering routes them to the runtime stdio helpers.
 
 pub fn print(s: String)
 
@@ -14,6 +13,4 @@ pub fn eprint(s: String)
 
 pub fn eprintln(s: String)
 
-pub fn readLine() -> String {
-    ""
-}
+pub fn readLine() -> String


### PR DESCRIPTION
## Summary
- make `std.io.readLine()` declaration-only and route it through a new runtime helper
- lower alias-qualified `io.readLine()` across the AST bridge, MIR backend, and native-owned entry path
- add llvmgen and backend regressions that cover both IR lowering and real stdin-backed binary execution

## Validation
- go test -count=1 -vet=off ./internal/llvmgen -run 'Test(StdIo(OutputCallsRouteToRuntimeWriteIn(AST|MIR|NativeOwnedEntry)|ReadLineRoutesToRuntimeIn(AST|MIR|NativeOwnedEntry))|GenerateFromMIRPrintln)$'
- go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinary(RunsBundledRuntime|StdIoOutputFamily|StdIoReadLine)$'
