### PR TITLE
refactor(selfhost): source-bytes entry for single-file check/resolve

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1219,9 +1219,7 @@ func findOwningFile(files []selfhost.PackageCheckFile, offset int) int {
 // line/column span and the inferred type. Zero astbridge lowerings
 // on the happy path (same counter invariant as runCheckFileNative).
 func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
-	run := parser.ParseRun(src)
-	parseDiags := run.Diagnostics()
-	checked := selfhost.CheckStructuredFromRun(run)
+	parseDiags, checked := selfhost.CheckFromSource(src)
 	checkDiags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
 	for _, d := range checkDiags {
 		if d != nil && d.File == "" {
@@ -1399,9 +1397,7 @@ func runTypecheckFileLegacy(path string, src []byte, formatter *diag.Formatter, 
 // subcommand's exit code (0 clean / 1 on any error-severity
 // diagnostic).
 func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
-	run := parser.ParseRun(src)
-	parseDiags := run.Diagnostics()
-	checked := selfhost.CheckStructuredFromRun(run)
+	parseDiags, checked := selfhost.CheckFromSource(src)
 	checkDiags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
 	for _, d := range checkDiags {
 		if d != nil && d.File == "" {
@@ -1418,15 +1414,15 @@ func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flag
 }
 
 func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
-	run := parser.ParseRun(src)
-	parseDiags := run.Diagnostics()
+	parseDiags, resolved := selfhost.ResolveFromSource(src, path)
 	var (
 		res  *resolve.Result
 		file *ast.File
 	)
 	ensureLoweredFile := func() *ast.File {
 		if file == nil {
-			file = run.File()
+			parsed, _ := parser.ParseDiagnostics(src)
+			file = parsed
 		}
 		return file
 	}
@@ -1437,10 +1433,10 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 		return res
 	}
 	all := append([]*diag.Diagnostic{}, parseDiags...)
-	nativeDiags := nativeResolveFromRunDiagnostics(run, src, path)
+	nativeDiags := nativeResolveDiagnosticsFromResolved(resolved, src, path)
 	all = append(all, nativeDiags...)
 	printDiags(formatter, all, flags)
-	if rows := nativeResolveFromRunRows(run, src, path); len(rows) > 0 {
+	if rows := nativeResolveRowsFromResolved(resolved, src, path); len(rows) > 0 {
 		printNativeResolutionRows(rows)
 	} else {
 		// Native pass produced no rows — fall back to the Go

--- a/cmd/osty/resolve_native.go
+++ b/cmd/osty/resolve_native.go
@@ -24,16 +24,11 @@ func printNativeResolutionRows(rows []resolve.NativeResolutionRow) {
 	}
 }
 
-// nativeResolveFromRunRows is the astbridge-free single-file resolve
-// row builder. Given a parsed FrontendRun and the raw source, it runs
-// the native resolver directly on the parser arena (no *ast.File
-// round-trip) and formats the result into the same
-// resolve.NativeResolutionRow shape printNativeResolutionRows expects.
-func nativeResolveFromRunRows(run *selfhost.FrontendRun, src []byte, path string) []resolve.NativeResolutionRow {
-	if run == nil {
-		return nil
-	}
-	resolved := selfhost.ResolveStructuredFromRunForPath(run, path)
+// nativeResolveRowsFromResolved formats an already-produced native
+// resolve result into printNativeResolutionRows input. Pair with
+// selfhost.ResolveFromSource so the caller never threads a
+// *selfhost.FrontendRun through the CLI layer.
+func nativeResolveRowsFromResolved(resolved selfhost.ResolveResult, src []byte, path string) []resolve.NativeResolutionRow {
 	lineStarts := computeLineStartsBytes(src)
 	kindByNode := map[int]string{}
 	for _, sym := range resolved.Symbols {
@@ -78,15 +73,11 @@ func nativeResolveFromRunRows(run *selfhost.FrontendRun, src []byte, path string
 	return rows
 }
 
-// nativeResolveFromRunDiagnostics converts the native resolver's
-// structured diagnostics into *diag.Diagnostic, preserving the code +
-// primary span + hint shape callers expect. Pair with ParseRun to keep
-// the resolve pass free of the astbridge *ast.File lowering.
-func nativeResolveFromRunDiagnostics(run *selfhost.FrontendRun, src []byte, path string) []*diag.Diagnostic {
-	if run == nil {
-		return nil
-	}
-	resolved := selfhost.ResolveStructuredFromRunForPath(run, path)
+// nativeResolveDiagnosticsFromResolved converts an already-produced
+// native resolver's structured diagnostics into *diag.Diagnostic,
+// preserving the code + primary span + hint shape callers expect.
+// Pair with selfhost.ResolveFromSource for the astbridge-free path.
+func nativeResolveDiagnosticsFromResolved(resolved selfhost.ResolveResult, src []byte, path string) []*diag.Diagnostic {
 	lineStarts := computeLineStartsBytes(src)
 	out := make([]*diag.Diagnostic, 0, len(resolved.Diagnostics))
 	for _, record := range resolved.Diagnostics {

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -1,5 +1,7 @@
 package selfhost
 
+import "github.com/osty/osty/internal/diag"
+
 // CheckSummary is the exported Go shape for the bootstrapped Osty checker.
 //
 // The self-hosted checker is authoritative for mainstream checker diagnostics
@@ -104,6 +106,20 @@ func CheckSourceStructured(src []byte) CheckResult {
 	result := adaptCheckResult(checked, lexed)
 	selfhostAppendIntrinsicBodyGateForSource(&result, src)
 	return result
+}
+
+// CheckFromSource parses src, runs the bootstrapped Osty checker, and
+// returns parse-level diagnostics plus the structured check result in
+// one pass. Callers that previously threaded a *FrontendRun through
+// their CLI layer should prefer this entry point: it keeps the
+// FrontendRun internal so cmd/osty does not need the selfhost type to
+// cross its call boundary.
+func CheckFromSource(src []byte) ([]*diag.Diagnostic, CheckResult) {
+	run := Run(src)
+	if run == nil {
+		return nil, CheckResult{}
+	}
+	return run.Diagnostics(), CheckStructuredFromRun(run)
 }
 
 // CheckStructuredFromRun runs the bootstrapped Osty checker directly

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -1,6 +1,10 @@
 package selfhost
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/osty/osty/internal/diag"
+)
 
 // PackageResolveFile is the per-file input shape accepted by the structured
 // self-host resolve adapter.
@@ -255,6 +259,18 @@ func ResolveStructuredFromRun(run *FrontendRun) ResolveResult {
 			return checkNodeOffsets(rt, stream, start, end)
 		},
 	)
+}
+
+// ResolveFromSource parses src once and returns the parse diagnostics
+// together with the structured resolve result annotated with path.
+// Keeps the internal FrontendRun hidden from callers that only need
+// source-in / result-out, which is the subprocess-compatible shape.
+func ResolveFromSource(src []byte, path string) ([]*diag.Diagnostic, ResolveResult) {
+	run := Run(src)
+	if run == nil {
+		return nil, ResolveResult{}
+	}
+	return run.Diagnostics(), ResolveStructuredFromRunForPath(run, path)
 }
 
 // ResolveStructuredFromRunForPath is ResolveStructuredFromRun plus


### PR DESCRIPTION
## Summary

- `*selfhost.FrontendRun`이 cmd/osty 경계를 넘나들지 않도록 source-bytes 진입점을 추가하고 단일 파일 check/resolve 러너를 그쪽으로 재배선. subprocess 디스패치 가능한 모양을 만드는 첫 번째 wedge.
- 새 API: `selfhost.CheckFromSource(src) ([]*diag.Diagnostic, CheckResult)` / `selfhost.ResolveFromSource(src, path) ([]*diag.Diagnostic, ResolveResult)` — 내부에서 FrontendRun을 한 번만 돌리고 parse 진단과 구조화 결과를 같이 반환.
- 교체된 cmd/osty 러너: `runTypecheckFileNative`, `runCheckFileNative`, `runResolveFile` + `nativeResolveRowsFromResolved` / `nativeResolveDiagnosticsFromResolved` 헬퍼.

## Why

`cmd/osty`에서 `internal/selfhost/generated.go` 링크를 결국 떼어내려면 호출 API가 serializable해야 함 (서브프로세스/JSON RPC 경계 대비). 포인터 threaded `*FrontendRun`이 유일한 non-serializable 구조였음. 이 PR은 그 한 가지만 정리.

## Notes for reviewer

- **범위 제한**: 워크스페이스 체크는 이미 `CheckPackageStructured(input)`로 source-bytes shape였기에 변경 없음.
- **Fallback 경로**: `runResolveFile`의 Go-resolver fallback은 `parser.ParseDiagnostics(src)`로 재-파싱. 이 fallback은 비어있거나 resolver-disagreement 케이스에만 발화하므로 핫 패스 regress 없음.
- **남은 경로**: cmd/osty는 여전히 `CheckResult`/`ResolveResult`/`PackageCheckInput` 등 타입과 `CheckPackageStructured`/`CheckDiagnosticsAsDiag` 함수로 selfhost를 import. 따라서 Go 링커는 여전히 generated.go를 cmd/osty 바이너리에 포함. 실제 "generated.go 제거"는 subprocess dispatch가 필요 — 후속 PR에서.
- 테스트의 `AstbridgeLowerCount` 관찰자 6개 파일은 in-process 전제라 그대로 유지. subprocess 이행 시 재설계 대상.

## Test plan

- [x] `go build ./...` 전체 빌드 통과
- [x] `go test ./cmd/osty/ -run 'TestResolve|TestRunResolve|TestCheckFileNative|TestRunCheckFileNative|TestTypecheckFileNative|Astbridge' -count=1` 통과
- [x] `go test ./internal/selfhost/ -count=1` 통과
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)