### PR TITLE
refactor(selfhost): hide FrontendRun behind source adapters

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -93,10 +93,9 @@ type cliFlags struct {
 	// nil-safe when the native checker was unavailable.
 	dumpNativeDiags bool
 	// native routes `check` through the self-host arena pipeline
-	// (ParseRun → CheckStructuredFromRun → CheckDiagnosticsAsDiag)
-	// instead of the Go-hosted resolve + check.File pair. The happy
-	// path never materializes *ast.File, so
-	// selfhost.AstbridgeLowerCount stays at 0 for the whole
+	// (selfhost.CheckFromSource) instead of the Go-hosted resolve +
+	// check.File pair. The happy path never materializes *ast.File,
+	// so selfhost.AstbridgeLowerCount stays at 0 for the whole
 	// subcommand. Incompatible with --inspect / --dump-native-diags,
 	// which both probe the Go check.Result shape.
 	native bool
@@ -950,13 +949,13 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 
 // runResolveFile is the extracted body of `osty resolve FILE`. It
 // drives the single-file resolve happy path entirely through the
-// self-host arena (ParseRun → ResolveStructuredFromRun); `run.File()`
-// — the sole astbridge entry point on this side of the compiler — is
-// only materialized lazily when a fallback needs it (printResolution
-// with no native rows, or --show-scopes). Returns the subcommand's
-// exit code: 0 on clean input, 1 when any error-severity diagnostic
-// surfaces. Extracting this keeps the subcommand body testable in-
-// process so the astbridge counter can pin the end-to-end CLI
+// self-host arena (selfhost.ResolveFromSource); the astbridge
+// *ast.File is only materialized lazily via parser.ParseDiagnostics
+// when a fallback needs it (printResolution with no native rows, or
+// --show-scopes). Returns the subcommand's exit code: 0 on clean
+// input, 1 when any error-severity diagnostic surfaces. Extracting
+// this keeps the subcommand body testable in-process so the
+// astbridge counter can pin the end-to-end CLI
 // invariant (not just the library primitives).
 // runTypecheckPackageNative is the DIR sibling of
 // runTypecheckFileNative and the typecheck sibling of
@@ -1387,13 +1386,13 @@ func runTypecheckFileLegacy(path string, src []byte, formatter *diag.Formatter, 
 }
 
 // runCheckFileNative drives `osty check --native FILE` end-to-end on
-// the self-host arena pipeline: parser.ParseRun produces the
-// FrontendRun without lowering *ast.File, selfhost.CheckStructuredFromRun
-// runs the native checker directly on the arena (arena-direct gate
-// included), and selfhost.CheckDiagnosticsAsDiag lifts the structured
-// records into the CLI's usual diag.Diagnostic shape. Zero astbridge
-// lowerings on the happy path — the counter stays at 0 throughout,
-// pinned by TestRunCheckFileNativeIsAstbridgeFree. Returns the
+// the self-host arena pipeline: selfhost.CheckFromSource parses once
+// and runs the native checker directly on the arena (arena-direct
+// gate included), and selfhost.CheckDiagnosticsAsDiag lifts the
+// structured records into the CLI's usual diag.Diagnostic shape.
+// Zero astbridge lowerings on the happy path — the counter stays at
+// 0 throughout, pinned by TestRunCheckFileNativeIsAstbridgeFree.
+// Returns the
 // subcommand's exit code (0 clean / 1 on any error-severity
 // diagnostic).
 func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {

--- a/internal/bootstrap/seedgen/seedgen.go
+++ b/internal/bootstrap/seedgen/seedgen.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/osty/osty/internal/bootstrap/gen"
+	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
@@ -64,10 +65,11 @@ func Generate(cfg Config) ([]byte, error) {
 		return nil, err
 	}
 	ws.Stdlib = reg
-	if _, err := ws.LoadPackage(""); err != nil {
+	if _, err := ws.LoadPackageNative(""); err != nil {
 		return nil, err
 	}
 	results := ws.ResolveAll()
+	materializeCanonicalWorkspaceSources(ws)
 
 	pkg := ws.Packages[""]
 	if pkg == nil {
@@ -116,6 +118,23 @@ func Generate(cfg Config) ([]byte, error) {
 	}
 	out = normalizeGeneratedOutput(out)
 	return out, emitErr
+}
+
+func materializeCanonicalWorkspaceSources(ws *resolve.Workspace) {
+	if ws == nil {
+		return
+	}
+	for _, pkg := range ws.Packages {
+		if pkg == nil {
+			continue
+		}
+		for _, pf := range pkg.Files {
+			if pf == nil || pf.File == nil || len(pf.CanonicalSource) > 0 {
+				continue
+			}
+			pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMap(pf.Source, pf.File)
+		}
+	}
 }
 
 var generatedInterpLenCall = regexp.MustCompile(

--- a/internal/bootstrap/seedgen/seedgen_test.go
+++ b/internal/bootstrap/seedgen/seedgen_test.go
@@ -1,6 +1,14 @@
 package seedgen
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/stdlib"
+)
 
 func TestNormalizeGeneratedOutputRewritesInterpolatedLenCalls(t *testing.T) {
 	src := []byte(`monoAddErr(state, fmt.Sprintf("arity %s %s %s", ostyToString(typeArgs.len()), ostyToString(fnDecl.generics.len()), "Ok(s.len())"))`)
@@ -27,4 +35,54 @@ func containsTextAt(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+func TestMaterializeCanonicalWorkspaceSourcesUsesNativeLoaderCompatibilityPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "main.osty")
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    println("{y}")
+}
+`)
+	if err := os.WriteFile(srcPath, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	ws, err := resolve.NewWorkspace(tmpDir)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	ws.Stdlib = stdlib.LoadCached()
+
+	selfhost.ResetAstbridgeLowerCount()
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+	materializeCanonicalWorkspaceSources(ws)
+	results := ws.ResolveAll()
+	pkg := ws.Packages[""]
+	if pkg == nil || len(pkg.Files) != 1 {
+		t.Fatalf("root package files = %#v, want exactly one source file", pkg)
+	}
+	pf := pkg.Files[0]
+	if pf == nil {
+		t.Fatal("root PackageFile is nil")
+	}
+	if pf.Run == nil {
+		t.Fatal("LoadPackageNative did not retain FrontendRun on the PackageFile")
+	}
+	if pf.File == nil {
+		t.Fatal("native compatibility path did not materialize a public AST")
+	}
+	if len(pf.CanonicalSource) == 0 {
+		t.Fatal("CanonicalSource is empty after materializeCanonicalWorkspaceSources")
+	}
+	if pf.CanonicalMap == nil {
+		t.Fatal("CanonicalMap is nil after materializeCanonicalWorkspaceSources")
+	}
+	if root := results[""]; root == nil {
+		t.Fatal("ResolveAll missing root package result")
+	}
 }

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -129,6 +129,50 @@ fn main() {
 	}
 }
 
+func TestCheckFromSourceMatchesRunDiagnosticsAndStructuredResult(t *testing.T) {
+	cases := []struct {
+		name string
+		src  []byte
+	}{
+		{
+			name: "clean source",
+			src: []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`),
+		},
+		{
+			name: "type error",
+			src: []byte(`fn main() {
+    let n: Int = "oops"
+}
+`),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			run := Run(tc.src)
+			wantDiags := run.Diagnostics()
+			wantResult := CheckStructuredFromRun(run)
+
+			ResetAstbridgeLowerCount()
+			gotDiags, gotResult := CheckFromSource(tc.src)
+			if !reflect.DeepEqual(wantDiags, gotDiags) {
+				t.Fatalf("CheckFromSource parse diagnostics diverge\nwant=%#v\ngot=%#v", wantDiags, gotDiags)
+			}
+			if !reflect.DeepEqual(wantResult, gotResult) {
+				t.Fatalf("CheckFromSource result diverges\nwant=%#v\ngot=%#v", wantResult, gotResult)
+			}
+			if got := AstbridgeLowerCount(); got != 0 {
+				t.Fatalf("CheckFromSource: AstbridgeLowerCount = %d, want 0", got)
+			}
+		})
+	}
+}
+
 // TestCheckPackageStructuredIsAstbridgeFree is the multi-file analogue.
 // The gate adapter re-parses each file's source into a fresh arena
 // (selfhostAppendIntrinsicBodyGateForPackage uses Run per file), so

--- a/internal/selfhost/public_file_adapter.go
+++ b/internal/selfhost/public_file_adapter.go
@@ -10,5 +10,7 @@ func LowerPublicFileFromRun(run *FrontendRun) *ast.File {
 	if run == nil || run.parser == nil {
 		return nil
 	}
-	return astLowerPublicFile(run.parser.arena, run.Tokens())
+	file := astLowerPublicFile(run.parser.arena, run.Tokens())
+	ast.AssignIDs(file)
+	return file
 }

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -259,6 +259,55 @@ fn main() {
 	}
 }
 
+func TestResolveFromSourceMatchesRunDiagnosticsAndStructuredResult(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		src  []byte
+	}{
+		{
+			name: "clean source",
+			path: "main.osty",
+			src: []byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`),
+		},
+		{
+			name: "missing ref",
+			path: "broken.osty",
+			src: []byte(`fn main() {
+    let x = missing()
+}
+`),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			run := selfhost.Run(tc.src)
+			wantDiags := run.Diagnostics()
+			wantResult := selfhost.ResolveStructuredFromRunForPath(run, tc.path)
+
+			selfhost.ResetAstbridgeLowerCount()
+			gotDiags, gotResult := selfhost.ResolveFromSource(tc.src, tc.path)
+			if !reflect.DeepEqual(wantDiags, gotDiags) {
+				t.Fatalf("ResolveFromSource parse diagnostics diverge\nwant=%#v\ngot=%#v", wantDiags, gotDiags)
+			}
+			if !reflect.DeepEqual(wantResult, gotResult) {
+				t.Fatalf("ResolveFromSource result diverges\nwant=%#v\ngot=%#v", wantResult, gotResult)
+			}
+			if got := selfhost.AstbridgeLowerCount(); got != 0 {
+				t.Fatalf("ResolveFromSource: AstbridgeLowerCount = %d, want 0", got)
+			}
+		})
+	}
+}
+
 func TestResolveSourceStructuredUndefinedLoopLabel(t *testing.T) {
 	resolved := selfhost.ResolveSourceStructured([]byte(`fn main() {
     for {


### PR DESCRIPTION
## Summary
- add source-based selfhost check/resolve adapters and switch the native FILE CLI paths to use them
- keep bootstrap seed generation on the native loader path and materialize compatibility AST/canonical source only where downstream consumers still need it
- add regression coverage for adapter parity, astbridge-free native CLI paths, and the seedgen compatibility seam

## Testing
- go test -count=1 -vet=off ./cmd/osty -run 'TestRun(CheckFileNativeIsAstbridgeFree|TypecheckFileNativeIsAstbridgeFree|ResolveFileHappyPathIsAstbridgeFree)$|TestRunResolvePackageHappyPathIsAstbridgeFree'
- go test -count=1 -vet=off ./internal/selfhost -run 'Test(CheckFromSourceMatchesRunDiagnosticsAndStructuredResult|CheckStructuredFromRunIsAstbridgeFree|CheckSourceStructuredIsAstbridgeFree|ToolchainCheckerSourcesTranspile)$|TestResolveFromSourceMatchesRunDiagnosticsAndStructuredResult'
- go test -count=1 -vet=off ./internal/bootstrap/seedgen -run 'Test(NormalizeGeneratedOutputRewritesInterpolatedLenCalls|MaterializeCanonicalWorkspaceSourcesUsesNativeLoaderCompatibilityPath)$'