### PR TITLE
fix(mir,ir,toolchain): close substitution-cache <error> MIR-path wall + nil-guard StringLit

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1275,9 +1275,19 @@ func (l *lowerer) lowerStringLit(s *ast.StringLit) Expr {
 	for _, p := range s.Parts {
 		if p.IsLit {
 			out.Parts = append(out.Parts, StringPart{IsLit: true, Lit: p.Lit})
-		} else {
-			out.Parts = append(out.Parts, StringPart{Expr: l.lowerExpr(p.Expr)})
+			continue
 		}
+		// A non-literal part with a nil expression is produced by the
+		// parser's error-recovery path when a `{...}` interpolation
+		// slot couldn't be parsed cleanly. Downstream consumers
+		// (mir.Lower, the MIR emitter) assume every non-lit part has
+		// a real Expr, so treat the hole as an empty string literal
+		// here rather than letting lowerExpr crash on a nil switch.
+		if p.Expr == nil {
+			out.Parts = append(out.Parts, StringPart{IsLit: true, Lit: ""})
+			continue
+		}
+		out.Parts = append(out.Parts, StringPart{Expr: l.lowerExpr(p.Expr)})
 	}
 	return out
 }

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -758,6 +758,16 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	t := let.Type
 	if isPoisonType(t) && let.Value != nil {
 		t = let.Value.Type()
+		// Same IR→MIR seam recovery lowerExprAsOperand uses for
+		// `"{f(...)}"` interpolations: when `let x = f(...)` is
+		// dropped by the checker, recover the initializer type off
+		// the fn signature / stdlib intrinsic table so the binding's
+		// local doesn't carry ErrType into every downstream use.
+		if isPoisonType(t) {
+			if rt := bs.recoverOperandType(let.Value); rt != nil && !isPoisonType(rt) {
+				t = rt
+			}
+		}
 	}
 	if t == nil {
 		t = ir.ErrTypeVal
@@ -1965,9 +1975,242 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 	if t == nil {
 		t = ir.ErrTypeVal
 	}
+	// The IR→MIR seam leaks `<error>` typed temps whenever a CallExpr
+	// reaches this point without a per-node type (the checker skips
+	// expressions nested inside string interpolations, match arms, and
+	// a handful of other suppressed contexts). The MIR emitter later
+	// rejects any local with ErrType — `unsupported local type <error>
+	// in <fn>` — masking what is really a type-propagation gap. Recover
+	// the return type off the module's own fn signature table (preferred)
+	// or the callee's FnType (fallback) so every downstream temp has a
+	// concrete width.
+	if t == ir.ErrTypeVal {
+		if rt := bs.recoverOperandType(e); rt != nil && rt != ir.ErrTypeVal {
+			t = rt
+		}
+	}
 	tmp := bs.freshTemp(t, exprSpan(e))
 	bs.lowerExprInto(e, tmp, t)
 	return &CopyOp{Place: Place{Local: tmp}, T: t}
+}
+
+// recoverOperandType patches the subset of expression shapes that reach
+// lowerExprAsOperand's generic fallback with ErrType. Today that's
+// dominated by CallExpr inside `"{f(...)}"` interpolations where the
+// checker/native-checker pair skips the call node; lifting the return
+// type off the module's own signature table keeps the MIR temp typed
+// so the emitter doesn't wall on `unsupported local type <error>`.
+func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
+	if e == nil {
+		return nil
+	}
+	switch x := e.(type) {
+	case *ir.CallExpr:
+		if x.Callee == nil {
+			return nil
+		}
+		// Preferred path: free-fn call by bare identifier. The MIR
+		// lowerer's pass-1 signature table carries the declared return
+		// type off the IR FnDecl, which survives even when per-node
+		// checker annotations are missing.
+		if id, ok := x.Callee.(*ir.Ident); ok {
+			if sig := bs.l.signatureForFn(id.Name); sig != nil && sig.retType != nil && sig.retType != ir.ErrTypeVal {
+				return sig.retType
+			}
+		}
+		// Qualified call through a `use X as alias` — `alias.fn(...)`.
+		// When the checker/native-checker pair skips the call node and
+		// neither the UseDecl body nor the resolved package surface has
+		// the fn's return type, fall back to the stdlib intrinsic table
+		// (std.strings.*) which is the dispatch path the MIR emitter
+		// already uses for these calls at lowerCallExprInto.
+		if fx, ok := x.Callee.(*ir.FieldExpr); ok {
+			if use := bs.l.useAliasFor(fx.X); use != nil {
+				if rt := stdlibFreeFnReturnType(qualifierOf(use), fx.Name); rt != nil {
+					return rt
+				}
+				// Also accept Path-based match: RawPath may be empty
+				// for alias-only imports; fall back to "std.strings"
+				// via Path joined.
+				if rt := stdlibFreeFnReturnType(pathQualifier(use), fx.Name); rt != nil {
+					return rt
+				}
+			}
+			// Otherwise rely on whatever FnType the FieldExpr carries.
+			if ct := fx.Type(); ct != nil && ct != ir.ErrTypeVal {
+				if f, ok := ct.(*ir.FnType); ok && f.Return != nil {
+					return f.Return
+				}
+			}
+		}
+		// Fallback: the callee may still carry a concrete FnType (for
+		// fn-typed locals / params with a declared signature).
+		ct := x.Callee.Type()
+		if ct == nil || ct == ir.ErrTypeVal {
+			return nil
+		}
+		if f, ok := ct.(*ir.FnType); ok && f.Return != nil {
+			return f.Return
+		}
+	case *ir.MethodCall:
+		// Method calls show up inside interpolations whenever the
+		// checker skipped the call site (e.g. `"{xs.len()}"`). Recover
+		// via the method-signature table keyed on the receiver's type
+		// name. Receivers that resolve to a generic builtin (String,
+		// List<T>, Map<K, V>) go through the hardcoded intrinsic
+		// return-type table since they never appear in the user's
+		// signatures map.
+		if x.Receiver == nil {
+			return nil
+		}
+		// Package-qualified MethodCall: HIR lowers `strings.join(xs, s)`
+		// as MethodCall{Receiver: Ident("strings"), Name: "join"}. The
+		// receiver is a use alias, not a value, so look up via the alias
+		// table instead of x.Receiver.Type().
+		if use := bs.l.useAliasFor(x.Receiver); use != nil {
+			if rt := stdlibFreeFnReturnType(qualifierOf(use), x.Name); rt != nil {
+				return rt
+			}
+			if rt := stdlibFreeFnReturnType(pathQualifier(use), x.Name); rt != nil {
+				return rt
+			}
+		}
+		recvT := x.Receiver.Type()
+		if rt := builtinMethodReturnType(recvT, x.Name); rt != nil {
+			return rt
+		}
+		if recvT == nil || recvT == ir.ErrTypeVal {
+			return nil
+		}
+		if nt, ok := recvT.(*ir.NamedType); ok && nt.Name != "" {
+			if sig := bs.l.signatureForMethod(nt.Name, x.Name); sig != nil && sig.retType != nil && sig.retType != ir.ErrTypeVal {
+				return sig.retType
+			}
+		}
+	case *ir.IndexExpr:
+		// `xs[i]` in interp position ends up here when the checker
+		// dropped the element type. Peel the collection type off the
+		// receiver.
+		if x.X == nil {
+			return nil
+		}
+		xT := x.X.Type()
+		if xT == nil || xT == ir.ErrTypeVal {
+			return nil
+		}
+		if nt, ok := xT.(*ir.NamedType); ok && len(nt.Args) > 0 {
+			switch nt.Name {
+			case "List":
+				return nt.Args[0]
+			case "Map":
+				if len(nt.Args) >= 2 {
+					return nt.Args[1]
+				}
+			}
+		}
+	case *ir.BinaryExpr:
+		// Binary ops in interp position: integer arithmetic is the
+		// dominant case. Recover from operand types.
+		lt := x.Left.Type()
+		rt := x.Right.Type()
+		if lt != nil && lt != ir.ErrTypeVal {
+			return lt
+		}
+		if rt != nil && rt != ir.ErrTypeVal {
+			return rt
+		}
+	}
+	return nil
+}
+
+// builtinMethodReturnType returns the declared return type for the
+// subset of receiver-method calls that the MIR emitter dispatches
+// through a runtime intrinsic rather than a user-defined FnDecl. Used
+// as a last-resort fallback in recoverOperandType.
+func builtinMethodReturnType(recvT ir.Type, method string) ir.Type {
+	if recvT == nil {
+		return nil
+	}
+	// String.* method returns.
+	if isStringReceiver(recvT) {
+		switch method {
+		case "len", "indexOf":
+			return ir.TInt
+		case "isEmpty", "contains", "hasPrefix", "startsWith", "hasSuffix", "endsWith":
+			return ir.TBool
+		case "substring", "slice", "trim", "toUpper", "toLower", "replace", "toString":
+			return ir.TString
+		case "chars":
+			return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TChar}, Builtin: true}
+		case "bytes":
+			return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TByte}, Builtin: true}
+		}
+	}
+	// List<T>.* method returns — we only need the ones that appear
+	// inside `"{...}"` interpolations in the toolchain, which is the
+	// `.len()` / `.isEmpty()` pair. Element-typed returns (pop, first,
+	// last) rarely hit this path because the checker tracks them.
+	if nt, ok := recvT.(*ir.NamedType); ok && nt.Builtin {
+		switch nt.Name {
+		case "List", "Map", "Set":
+			switch method {
+			case "len":
+				return ir.TInt
+			case "isEmpty":
+				return ir.TBool
+			}
+		}
+	}
+	return nil
+}
+
+// isStringReceiver reports whether a receiver type is String — either
+// via the primitive (TString) or a NamedType tagged "String".
+func isStringReceiver(t ir.Type) bool {
+	if t == ir.TString {
+		return true
+	}
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "String"
+	}
+	return false
+}
+
+// pathQualifier returns the "." joined Path of a UseDecl, so
+// `use std.strings as strings` yields "std.strings" even when RawPath
+// is empty (path-only imports).
+func pathQualifier(use *ir.UseDecl) string {
+	if use == nil || len(use.Path) == 0 {
+		return ""
+	}
+	return strings.Join(use.Path, ".")
+}
+
+// stdlibFreeFnReturnType reports the declared return type for the
+// subset of `std.strings.*` free-function calls that the MIR emitter
+// dispatches through an intrinsic. Used as the last-resort fallback in
+// recoverOperandType when the checker/native-checker pair has dropped
+// the call site's per-node type and neither the UseDecl body nor the
+// resolved package surface carries the fn signature.
+func stdlibFreeFnReturnType(qualifier, name string) ir.Type {
+	if qualifier != "std.strings" {
+		return nil
+	}
+	switch name {
+	case "len", "indexOf":
+		return ir.TInt
+	case "isEmpty", "contains", "hasPrefix", "startsWith", "hasSuffix", "endsWith":
+		return ir.TBool
+	case "join", "substring", "slice", "trim", "toUpper", "toLower", "replace":
+		return ir.TString
+	case "split":
+		return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+	case "chars":
+		return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TChar}, Builtin: true}
+	case "bytes":
+		return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TByte}, Builtin: true}
+	}
+	return nil
 }
 
 // lowerExprToRValue lowers a non-control-flow expression into an
@@ -2892,6 +3135,21 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 		}
 		if kind := runtimeIntrinsicForFree(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
 			bs.emitRuntimeIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+			return
+		}
+		// Route `std.strings.fn(x, ...)` to the equivalent String-method
+		// intrinsic — mirrors the CallExpr+FieldExpr path in
+		// lowerCallExprInto. The HIR pipeline may lower `pkg.fn(...)` as
+		// a MethodCall with the package alias as the receiver; without
+		// this branch the merged native-toolchain MIR probe would emit a
+		// CallInstr targeting `std.strings.join` whose result temp stays
+		// at ErrType because the checker skipped the call node.
+		if kind := stdlibStringFreeFnToIntrinsic(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
+			bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+			return
+		}
+		if kind := stdlibStringFreeFnToIntrinsic(pathQualifier(use), mc.Name); kind != IntrinsicInvalid {
+			bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
 			return
 		}
 		args := make([]Operand, len(mc.Args))

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -934,7 +934,15 @@ fn checkSubstCacheSet(env: CheckEnv, ty: Int, generics: List<String>, args: List
 }
 
 fn checkSubstCacheKey(ty: Int, generics: List<String>, args: List<Int>) -> String {
-    "{ty}\u{1f}{checkStringKey(generics)}\u{1f}{checkIntKey(args)}"
+    // Materialize the two helper results into typed `String` locals
+    // before splicing them into the interpolation. Inlining the calls
+    // directly leaves a synthetic interp temp at `<error>` type under
+    // MIR lowering, tripping `unsupported local type <error> in
+    // checkSubstCacheKey` in mir_generator.go — same shape as the
+    // `let v: Int = xs[i]` workaround in `checkIntKey` below.
+    let gKey: String = checkStringKey(generics)
+    let aKey: String = checkIntKey(args)
+    "{ty}\u{1f}{gKey}\u{1f}{aKey}"
 }
 
 // ---------------------------------------------------------------------

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -315,6 +315,13 @@ fn isPodType(arena: AstArena, typeIdx: Int, podStructs: List<String>, podGeneric
 }
 
 fn formatTypeForDiag(arena: AstArena, typeIdx: Int) -> String {
+    // Every recursive `formatTypeForDiag(...)` result is hoisted into a
+    // typed `String` local before being spliced into the enclosing
+    // interpolation. Inlining the call directly inside `"{...}"`
+    // leaves a synthetic interp temp at `<error>` type under MIR
+    // lowering, tripping `unsupported local type <error> in
+    // formatTypeForDiag` — same workaround shape as
+    // `checkSubstCacheKey` / `checkIntKey`.
     if typeIdx < 0 {
         return "?"
     }
@@ -323,7 +330,8 @@ fn formatTypeForDiag(arena: AstArena, typeIdx: Int) -> String {
         return "?"
     }
     if node.text == "optional" {
-        return "{formatTypeForDiag(arena, node.left)}?"
+        let inner: String = formatTypeForDiag(arena, node.left)
+        return "{inner}?"
     }
     if node.text == "tuple" {
         let mut out = "("
@@ -334,7 +342,8 @@ fn formatTypeForDiag(arena: AstArena, typeIdx: Int) -> String {
             } else {
                 out = "{out}, "
             }
-            out = "{out}{formatTypeForDiag(arena, elIdx)}"
+            let part: String = formatTypeForDiag(arena, elIdx)
+            out = "{out}{part}"
         }
         return "{out})"
     }
@@ -347,11 +356,13 @@ fn formatTypeForDiag(arena: AstArena, typeIdx: Int) -> String {
             } else {
                 out = "{out}, "
             }
-            out = "{out}{formatTypeForDiag(arena, pIdx)}"
+            let part: String = formatTypeForDiag(arena, pIdx)
+            out = "{out}{part}"
         }
         out = "{out})"
         if node.right >= 0 {
-            out = "{out} -> {formatTypeForDiag(arena, node.right)}"
+            let ret: String = formatTypeForDiag(arena, node.right)
+            out = "{out} -> {ret}"
         }
         return out
     }
@@ -367,7 +378,8 @@ fn formatTypeForDiag(arena: AstArena, typeIdx: Int) -> String {
         } else {
             out = "{out}, "
         }
-        out = "{out}{formatTypeForDiag(arena, argIdx)}"
+        let part: String = formatTypeForDiag(arena, argIdx)
+        out = "{out}{part}"
     }
     "{out}>"
 }


### PR DESCRIPTION
## Summary
- Close the MIR-path wall `unsupported local type <error> in checkSubstCacheKey` (user-named "substitution cache `<error>` 타입") by (a) hoisting recursive / qualified call results into typed `String` locals inside the interpolation splice in `checkSubstCacheKey` and `formatTypeForDiag`, and (b) adding systemic structural recovery in `internal/mir/lower.go` so `lowerExprAsOperand` / `lowerLet` patch `ErrType` temps for `CallExpr` / `MethodCall` / `IndexExpr` / `BinaryExpr` and std.strings-qualified dispatches (also routed through `lowerMethodCallInto`'s stdlib intrinsic path so MethodCall-shaped qualified calls no longer emit a `CallInstr` whose result temp stays at ErrType).
- Nil-guard in `ir.Lower`'s `lowerStringLit` so a parser-recovery nil `p.Expr` inside a `{...}` slot degrades to an empty literal part instead of crashing the MIR probe. This was masking the substitution-cache wall as a runtime panic instead of a diagnostic.

## Test plan
- [x] `go test ./internal/ir/ ./internal/mir/` clean
- [x] `TestProbeWholeToolchainMerged` / `TestProbeNativeToolchainMerged` pass — first wall is `LLVM012` final-`*ast.ForStmt` (separate structural shape, out of scope here)
- [x] `TestProbeNativeToolchainMergedMIR` passes — first wall moved past the substitution-cache chain (`checkSubstCacheKey` → `formatTypeForDiag` → `corePrintModule` → `corePrintList`) onto `selfDocAddRefsFromText` (`let units = strings.split(...)` that needs the same recovery to flow through `let`-binding types; tracked as a follow-up)
- [x] Rebased on top of latest main (`6f15a31c` Phase 1c.1) — kept upstream's `hirPrintEscapeChar(value: Int) -> "{value}"` resolution of the AST-path Char/Int width wall
- [x] `TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes` failure pre-exists on main (verified with `git stash`); unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)