### PR TITLE
[codex] expand native-owned llvm coverage

### DIFF
--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -127,7 +127,7 @@ func TestRunEmitsNativeOwnedLLVMIRForListIndex(t *testing.T) {
 	}
 }
 
-func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
+func TestRunReportsCoveredForOptionalCoalesceSource(t *testing.T) {
 	var stdout bytes.Buffer
 	stdin := strings.NewReader(`{"path":"main.osty","source":"fn resolve(name: String?) -> String {\n    name ?? \"anonymous\"\n}\n\nfn main() {}\n"}`)
 	if err := run(stdin, &stdout); err != nil {
@@ -137,11 +137,18 @@ func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.Covered {
-		t.Fatalf("covered = true, want false\nllvmIr:\n%s", resp.LLVMIR)
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
 	}
-	if resp.LLVMIR != "" {
-		t.Fatalf("llvmIr = %q, want empty output for uncovered source", resp.LLVMIR)
+	for _, want := range []string{
+		"define ptr @resolve(ptr %name)",
+		"coalesce.some",
+		"coalesce.none",
+		"phi ptr",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
 	}
 }
 

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -343,13 +343,22 @@ func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
 	}
 }
 
-func TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule(t *testing.T) {
+func TestEmitGenArtifactFallsBackForStdTestingMIRBackend(t *testing.T) {
 	dir := t.TempDir()
-	target := writeGenTestFile(t, dir, "main.osty", `fn resolve(name: String?) -> String {
-    name ?? "anonymous"
+	target := writeGenTestFile(t, dir, "main.osty", `use std.testing
+
+enum CalcError {
+    DivideByZero,
+}
+
+fn div(a: Int, b: Int) -> Result<Int, CalcError> {
+    if b == 0 { Err(DivideByZero) } else { Ok(a / b) }
 }
 
 fn main() {
+    let q = testing.expectOk(div(10, 2))
+    testing.assertEq(q, 5)
+    testing.expectError(div(1, 0))
 }
 `)
 
@@ -369,7 +378,7 @@ fn main() {
 	if _, ok, _, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered coalesce fallback")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered std.testing fallback")
 	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
@@ -379,8 +388,16 @@ fn main() {
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
-		t.Fatalf("fallback llvm-ir missing coalesce shape:\n%s", got)
+	for _, want := range []string{
+		"declare void @exit(i32)",
+		"extractvalue %Result.",
+		"testing.expectOk failed",
+		"testing.expectError failed",
+		"testing.assertEq failed",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("fallback llvm-ir missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -686,51 +686,77 @@ func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForListIndex(t *testing.
 	}
 }
 
-func TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+func TestEmitLLVMIRTextFallsBackForStdTestingMIRBackend(t *testing.T) {
 	t.Parallel()
 
-	req := newBackendRequest(t, EmitLLVMIR, `fn resolve(name: String?) -> String {
-    name ?? "anonymous"
+	req := newBackendRequest(t, EmitLLVMIR, `use std.testing
+
+enum CalcError {
+    DivideByZero,
+}
+
+fn div(a: Int, b: Int) -> Result<Int, CalcError> {
+    if b == 0 { Err(DivideByZero) } else { Ok(a / b) }
 }
 
 fn main() {
+    let q = testing.expectOk(div(10, 2))
+    testing.assertEq(q, 5)
+    testing.expectError(div(1, 0))
 }
 `)
 
 	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered coalesce fallback")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered std.testing fallback")
 	}
 	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
-	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
-		t.Fatalf("EmitLLVMIRText fallback IR missing coalesce shape:\n%s", got)
+	for _, want := range []string{
+		"declare void @exit(i32)",
+		"extractvalue %Result.",
+		"testing.expectOk failed",
+		"testing.expectError failed",
+		"testing.assertEq failed",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("EmitLLVMIRText fallback IR missing %q:\n%s", want, got)
+		}
 	}
 	if len(warnings) != len(req.Entry.IRIssues) {
 		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
 	}
 }
 
-func TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+func TestLLVMBackendEmitBinaryFallsBackForStdTestingMIRBackend(t *testing.T) {
 	t.Parallel()
 
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
-	req := newBackendRequest(t, EmitBinary, `fn resolve(name: String?) -> String {
-    name ?? "anonymous"
+	req := newBackendRequest(t, EmitBinary, `use std.testing
+
+enum CalcError {
+    DivideByZero,
+}
+
+fn div(a: Int, b: Int) -> Result<Int, CalcError> {
+    if b == 0 { Err(DivideByZero) } else { Ok(a / b) }
 }
 
 fn main() {
+    let q = testing.expectOk(div(10, 2))
+    testing.assertEq(q, 5)
+    testing.expectError(div(1, 0))
 }
 `)
 
 	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered coalesce fallback")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered std.testing fallback")
 	}
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
@@ -740,8 +766,16 @@ fn main() {
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
 	}
-	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
-		t.Fatalf("Emit binary fallback IR missing coalesce shape:\n%s", got)
+	for _, want := range []string{
+		"declare void @exit(i32)",
+		"extractvalue %Result.",
+		"testing.expectOk failed",
+		"testing.expectError failed",
+		"testing.assertEq failed",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("Emit binary fallback IR missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -1929,22 +1929,21 @@ func nativeStdIoCallMethod(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (str
 }
 
 func nativeStdIoStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeExpr, bool) {
-	if ctx == nil || expr == nil || expr.Type() == nil {
-		return nil, false
-	}
-	if nativeTypeIsString(expr.Type()) {
-		return nativeExprFromIR(ctx, expr)
-	}
-	prim, ok := expr.Type().(*ostyir.PrimType)
-	if !ok {
+	if ctx == nil || expr == nil {
 		return nil, false
 	}
 	value, ok := nativeExprFromIR(ctx, expr)
 	if !ok {
 		return nil, false
 	}
-	switch prim.Kind {
-	case ostyir.PrimInt, ostyir.PrimInt64:
+	if info, ok := nativeExprTypeInfo(ctx, expr); ok && info.kind == nativeExprInfoString {
+		return value, true
+	}
+	if expr.Type() != nil && nativeTypeIsString(expr.Type()) {
+		return value, true
+	}
+	switch value.llvmType {
+	case "i64":
 		ctx.addRuntimeDecl("declare ptr @osty_rt_int_to_string(i64)")
 		return &llvmNativeExpr{
 			kind:       llvmNativeExprCall,
@@ -1952,7 +1951,7 @@ func nativeStdIoStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNat
 			name:       llvmIntRuntimeToStringSymbol(),
 			childExprs: []*llvmNativeExpr{value},
 		}, true
-	case ostyir.PrimFloat, ostyir.PrimFloat64:
+	case "double":
 		ctx.addRuntimeDecl("declare ptr @osty_rt_float_to_string(double)")
 		return &llvmNativeExpr{
 			kind:       llvmNativeExprCall,
@@ -1960,7 +1959,7 @@ func nativeStdIoStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNat
 			name:       llvmFloatRuntimeToStringSymbol(),
 			childExprs: []*llvmNativeExpr{value},
 		}, true
-	case ostyir.PrimBool:
+	case "i1":
 		ctx.addRuntimeDecl("declare ptr @osty_rt_bool_to_string(i1)")
 		return &llvmNativeExpr{
 			kind:       llvmNativeExprCall,
@@ -1968,7 +1967,7 @@ func nativeStdIoStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNat
 			name:       llvmBoolRuntimeToStringSymbol(),
 			childExprs: []*llvmNativeExpr{value},
 		}, true
-	case ostyir.PrimChar:
+	case "i32":
 		ctx.addRuntimeDecl("declare ptr @osty_rt_char_to_string(i32)")
 		return &llvmNativeExpr{
 			kind:       llvmNativeExprCall,
@@ -1976,7 +1975,7 @@ func nativeStdIoStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNat
 			name:       "osty_rt_char_to_string",
 			childExprs: []*llvmNativeExpr{value},
 		}, true
-	case ostyir.PrimByte:
+	case "i8":
 		ctx.addRuntimeDecl("declare ptr @osty_rt_byte_to_string(i8)")
 		return &llvmNativeExpr{
 			kind:       llvmNativeExprCall,

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -1328,7 +1328,8 @@ func TestNativeOwnedModuleEntryOptionalQuestionScalarBatch(t *testing.T) {
 		"define ptr @requireScore(ptr %score)",
 		"ret ptr null",
 		"load i64, ptr %t",
-		"call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64",
+		"call ptr @osty_rt_int_to_string(i64",
+		"call void @osty_rt_io_write(ptr",
 	} {
 		if !strings.Contains(direct, want) {
 			t.Fatalf("native-owned optional-scalar-question IR missing %q:\n%s", want, direct)

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2958,8 +2958,15 @@ func TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
-	if strings.Count(string(out), "call ptr @osty_rt_strings_Concat(") != 2 {
-		t.Fatalf("expected two concat calls in:\n%s", out)
+	got := string(out)
+	if !strings.Contains(got, "declare ptr @osty_rt_strings_ConcatN(i64, ptr)") {
+		t.Fatalf("missing concat_n decl in:\n%s", got)
+	}
+	if strings.Count(got, "call ptr @osty_rt_strings_ConcatN(") != 1 {
+		t.Fatalf("expected one concat_n call in:\n%s", got)
+	}
+	if strings.Contains(got, "call ptr @osty_rt_strings_Concat(") {
+		t.Fatalf("did not expect chained concat calls in:\n%s", got)
 	}
 }
 

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -305,19 +305,29 @@ func llvmNativeRuntimeDeclarations(mod *llvmNativeModule) []string {
 		return nil
 	}
 	out := make([]string, 0, 32)
+	seen := map[string]bool{}
+	appendUnique := func(decls []string) {
+		for _, decl := range decls {
+			if decl == "" || seen[decl] {
+				continue
+			}
+			seen[decl] = true
+			out = append(out, decl)
+		}
+	}
 	if mod.needsListRuntime {
-		out = append(out, llvmListRuntimeDeclarations()...)
+		appendUnique(llvmListRuntimeDeclarations())
 	}
 	if mod.needsMapRuntime {
-		out = append(out, llvmMapRuntimeDeclarations()...)
+		appendUnique(llvmMapRuntimeDeclarations())
 	}
 	if mod.needsSetRuntime {
-		out = append(out, llvmSetRuntimeDeclarations()...)
+		appendUnique(llvmSetRuntimeDeclarations())
 	}
 	if mod.needsStringRuntime {
-		out = append(out, llvmStringRuntimeDeclarations()...)
+		appendUnique(llvmStringRuntimeDeclarations())
 	}
-	out = append(out, mod.extraRuntimeDecls...)
+	appendUnique(mod.extraRuntimeDecls)
 	return out
 }
 


### PR DESCRIPTION
## Summary
- route more native-owned LLVM cases through the new path instead of treating them as uncovered
- make native stdio stringification rely on lowered LLVM/native expr info so `ErrType`-tagged expressions like `join`, `score?`, and `if let` payload bindings still print correctly
- dedupe native runtime declarations at final emission so string runtime helpers such as `osty_rt_int_to_string` are not emitted twice
- update fallback and coverage tests to match the current MIR/native split and `ConcatN` lowering

## Why
The native-owned path had regressed in a few places while the AST-era expectations were being retired:
- optional coalesce was still tested as uncovered even though the new path now covers it
- native `println(...)` rejected some otherwise-lowerable expressions because it trusted surface IR types too much
- backend binary tests could fail at clang time due to duplicated runtime declarations

## Validation
- `go test -count=1 -vet=off ./cmd/osty -run 'TestEmitGenArtifactFallsBackForStdTestingMIRBackend'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestEmitLLVMIRTextFallsBackForStdTestingMIRBackend|TestLLVMBackendEmitBinaryFallsBackForStdTestingMIRBackend|TestLLVMBackendBinaryAutoCollectsOnPressure|TestLLVMBackendBinaryPtrBackedListToSetAndBoolPrint|TestLLVMBackendBinarySafepointsKeepManagedRootsAlive|TestLLVMBackendBinaryManagedTemporaryCallArgSurvivesPressure|TestLLVMBackendBinaryLetStructPatternDestructuring'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes|TestNativeOwnedModuleEntryStringMethodBatch|TestNativeOwnedModuleEntryOptionalQuestionScalarBatch|TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybe|TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybeNone'`
- `go test -count=1 -vet=off ./cmd/osty-native-llvmgen -run 'TestRunReportsCoveredForOptionalCoalesceSource'`