### PR TITLE
refactor(lsp): use native compatibility seam

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/osty/osty/internal/parser"
 	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -471,14 +472,14 @@ func dirHasOstySiblings(dir, selfPath string) bool {
 // as one package. The file whose URI the client opened is substituted
 // with `src` so unsaved edits are honored.
 func (s *Server) analyzePackage(pkgDir, path string, src []byte) *docAnalysis {
-	pkg, err := resolve.LoadPackage(pkgDir)
+	pkg, err := resolve.LoadPackageForNativeWithTransform(pkgDir, lspSourceOverrideTransform(path, src))
 	if err != nil {
 		return nil
 	}
 	if pkg == nil || len(pkg.Files) == 0 {
 		return nil
 	}
-	substituteFileSource(pkg, path, src)
+	lspMaterializeNativePackageFiles(pkg)
 	pr := resolve.ResolvePackage(pkg, s.prelude)
 	chk := check.Package(pkg, pr, lspCheckOpts(nil))
 	lr := lint.Package(pkg, pr, chk)
@@ -497,17 +498,11 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 	if err != nil {
 		return nil
 	}
+	ws.SourceTransform = lspSourceOverrideTransform(path, src)
 	// Seed the root package (if any) and every immediate subdir that
 	// has `.osty` files; LoadPackage chases `use` edges from there.
 	seedWorkspace(ws, root)
-	// Swap in the client's buffer for the currently-open file. Only
-	// one package owns it; stop once substituteFileSource reports a
-	// hit so the remaining packages don't pay for a useless walk.
-	for _, pkg := range ws.Packages {
-		if substituteFileSource(pkg, path, src) {
-			break
-		}
-	}
+	lspMaterializeNativeWorkspace(ws)
 	resolved := ws.ResolveAll()
 	checks := check.Workspace(ws, resolved, lspCheckOpts(nil))
 	// Collect every loaded package for cross-file handlers.
@@ -549,31 +544,59 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 // Delegates to the shared helper so CLI and LSP don't drift.
 func seedWorkspace(ws *resolve.Workspace, root string) {
 	for _, p := range resolve.WorkspacePackagePaths(root) {
-		_, _ = ws.LoadPackage(p)
+		_, _ = ws.LoadPackageNative(p)
 	}
 }
 
-// substituteFileSource overwrites the parsed state of the file at
-// `path` with a fresh parse of `src`. Returns true when a matching
-// file was found so callers can stop scanning additional packages.
-// Used so the LSP analyzes the client's unsaved buffer even when
-// on-disk content is stale.
-func substituteFileSource(pkg *resolve.Package, path string, src []byte) bool {
+func lspSourceOverrideTransform(path string, src []byte) resolve.SourceTransform {
+	if path == "" {
+		return nil
+	}
+	return func(candidate string, original []byte) []byte {
+		if candidate != path {
+			return original
+		}
+		return append([]byte(nil), src...)
+	}
+}
+
+func lspSourceOverrideMapTransform(overrides map[string][]byte) resolve.SourceTransform {
+	if len(overrides) == 0 {
+		return nil
+	}
+	return func(candidate string, original []byte) []byte {
+		src, ok := overrides[candidate]
+		if !ok {
+			return original
+		}
+		return append([]byte(nil), src...)
+	}
+}
+
+func lspMaterializeNativeWorkspace(ws *resolve.Workspace) {
+	if ws == nil {
+		return
+	}
+	for _, pkg := range ws.Packages {
+		lspMaterializeNativePackageFiles(pkg)
+	}
+}
+
+func lspMaterializeNativePackageFiles(pkg *resolve.Package) {
+	if pkg == nil {
+		return
+	}
 	for _, pf := range pkg.Files {
-		if pf.Path != path {
+		if pf == nil {
 			continue
 		}
-		parsed := parser.ParseDetailed(src)
-		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
-		pf.Source = src
-		pf.CanonicalSource = canonicalSrc
-		pf.CanonicalMap = canonicalMap
-		pf.File = parsed.File
-		pf.ParseDiags = parsed.Diagnostics
-		pf.ParseProvenance = parsed.Provenance
-		return true
+		if pf.File == nil && pf.Run != nil {
+			pf.File = selfhost.LowerPublicFileFromRun(pf.Run)
+		}
+		if len(pf.CanonicalSource) == 0 && pf.File != nil {
+			pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMap(pf.Source, pf.File)
+		}
 	}
-	return false
 }
 
 // analysisForFileInPackage builds a docAnalysis that carries the
@@ -803,7 +826,6 @@ func (s *Server) ensureWorkspaceIndex(root string) []*resolve.Package {
 	if err != nil {
 		return nil
 	}
-	seedWorkspace(ws, root)
 	// Substitute in every open document's current buffer so the
 	// index reflects unsaved edits, not stale disk contents.
 	s.docs.mu.Lock()
@@ -814,11 +836,10 @@ func (s *Server) ensureWorkspaceIndex(root string) []*resolve.Package {
 		}
 	}
 	s.docs.mu.Unlock()
-	for _, pkg := range ws.Packages {
-		for path, src := range openBufs {
-			substituteFileSource(pkg, path, src)
-		}
-	}
+	ws.SourceTransform = lspSourceOverrideMapTransform(openBufs)
+	ws.Packages = map[string]*resolve.Package{}
+	seedWorkspace(ws, root)
+	lspMaterializeNativeWorkspace(ws)
 	_ = ws.ResolveAll()
 	pkgs := make([]*resolve.Package, 0, len(ws.Packages))
 	for _, pkg := range ws.Packages {

--- a/internal/lsp/server_native_test.go
+++ b/internal/lsp/server_native_test.go
@@ -1,0 +1,92 @@
+package lsp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestAnalyzePackageContainingUsesNativeCompatibilityPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	helperPath := filepath.Join(dir, "helper.osty")
+	if err := os.WriteFile(path, []byte("pub fn stale() {}\n"), 0o644); err != nil {
+		t.Fatalf("write main.osty: %v", err)
+	}
+	if err := os.WriteFile(helperPath, []byte("pub fn helper() -> Int { 1 }\n"), 0o644); err != nil {
+		t.Fatalf("write helper.osty: %v", err)
+	}
+
+	src := []byte("pub fn fresh() {}\n")
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	selfhost.ResetAstbridgeLowerCount()
+	a := s.analyzePackageContaining(path, src)
+	if a == nil {
+		t.Fatal("analyzePackageContaining returned nil")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after package analyze = %d, want 0", got)
+	}
+	if len(a.packages) != 1 {
+		t.Fatalf("packages = %d, want 1", len(a.packages))
+	}
+	if got := lspFirstFnName(a.file); got != "fresh" {
+		t.Fatalf("first function = %q, want %q", got, "fresh")
+	}
+}
+
+func TestAnalyzeWorkspaceUsesNativeCompatibilityPath(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	libDir := filepath.Join(root, "lib")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("mkdir app: %v", err)
+	}
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+
+	path := filepath.Join(appDir, "main.osty")
+	libPath := filepath.Join(libDir, "util.osty")
+	if err := os.WriteFile(path, []byte("pub fn stale() {}\n"), 0o644); err != nil {
+		t.Fatalf("write app/main.osty: %v", err)
+	}
+	if err := os.WriteFile(libPath, []byte("pub fn helper() -> Int { 1 }\n"), 0o644); err != nil {
+		t.Fatalf("write lib/util.osty: %v", err)
+	}
+
+	src := []byte("pub fn fresh() {}\n")
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	selfhost.ResetAstbridgeLowerCount()
+	a := s.analyzePackageContaining(path, src)
+	if a == nil {
+		t.Fatal("analyzePackageContaining returned nil")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after workspace analyze = %d, want 0", got)
+	}
+	if len(a.packages) != 2 {
+		t.Fatalf("packages = %d, want 2", len(a.packages))
+	}
+	if got := lspFirstFnName(a.file); got != "fresh" {
+		t.Fatalf("first function = %q, want %q", got, "fresh")
+	}
+}
+
+func lspFirstFnName(file *ast.File) string {
+	if file == nil {
+		return ""
+	}
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FnDecl); ok {
+			return fn.Name
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- route LSP package/workspace analysis through native package loaders plus a compatibility lowering seam
- keep unsaved-buffer overrides on the native loader path for package, workspace, and workspace-symbol indexing
- add LSP regression tests that pin zero astbridge bumps for package/workspace analysis

## Testing
- go test -count=1 -vet=off ./internal/lsp