### PR TITLE
fix(check): register Set<T> arity so receiver-only methods infer T

### DIFF
--- a/internal/check/native_checker_set_generic_test.go
+++ b/internal/check/native_checker_set_generic_test.go
@@ -1,0 +1,62 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestNativeBoundaryExecRecognizesSetGenericIntrinsics covers a
+// registration gap where the `Set` type itself was never declared via
+// `checkRegisterType(name: "Set", generics: ["T"])` — only its methods
+// were. The arity-unknown owner made `instSeedOwnerArgs` skip the
+// receiver→generic unification, leaving T unbound on every call whose
+// signature has no value argument to seed T from. The visible symptom
+// was `s.len()` / `s.isEmpty()` / `s.clear()` tripping
+// E0748 "cannot infer type parameter `T` of `len`" even though
+// `s.contains(x)` worked (because the arg provides a second path to
+// seed T).
+//
+// List and Map were both registered correctly; Set was the lone
+// omission in the ` stdlib types that carry generics` block.
+func TestNativeBoundaryExecRecognizesSetGenericIntrinsics(t *testing.T) {
+	src := []byte(`fn main() {
+    let xs: List<Int> = [1, 2, 3, 2, 1]
+    let s: Set<Int> = xs.toSet()
+    let size = s.len()
+    let empty = s.isEmpty()
+    let has = s.contains(2)
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[0].(*ast.FnDecl)
+	sizeLet := mainDecl.Body.Stmts[2].(*ast.LetStmt)
+	emptyLet := mainDecl.Body.Stmts[3].(*ast.LetStmt)
+	hasLet := mainDecl.Body.Stmts[4].(*ast.LetStmt)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	for _, tc := range []struct {
+		name     string
+		stmt     *ast.LetStmt
+		wantType string
+	}{
+		{"len", sizeLet, "Int"},
+		{"isEmpty", emptyLet, "Bool"},
+		{"contains", hasLet, "Bool"},
+	} {
+		if got := chk.LetTypes[tc.stmt]; got == nil || got.String() != tc.wantType {
+			t.Errorf("%s binding type = %v, want %s", tc.name, got, tc.wantType)
+		}
+	}
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36065,6 +36065,7 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterType(env, &CheckTypeSig{name: "List", generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "struct"})
 	// Osty: /tmp/selfhost_merged.osty:15894:5
 	checkRegisterType(env, &CheckTypeSig{name: "Map", generics: []string{"K", "V"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "struct"})
+	checkRegisterType(env, &CheckTypeSig{name: "Set", generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "struct"})
 	// Osty: /tmp/selfhost_merged.osty:15895:5
 	checkRegisterType(env, &CheckTypeSig{name: "Option", generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "enum"})
 	// Osty: /tmp/selfhost_merged.osty:15896:5

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1797,6 +1797,7 @@ pub fn checkInstallPrelude(env: CheckEnv) {
     // type entry so type-qualified calls can resolve the owner name.
     checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Set", generics: ["T"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], genericBounds: [], kind: "enum" })
     checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], genericBounds: [], kind: "enum" })
     checkRegisterType(env, CheckTypeSig { name: "Range", generics: ["T"], genericBounds: [], kind: "struct" })


### PR DESCRIPTION
## Summary

- `Set<T>.len()` / `.isEmpty()` / `.clear()` tripped E0748 "cannot infer type parameter `T`" even though `Set<T>.contains(x)` worked on the same value
- Root cause: Set was the lone omission from the stdlib arity-registration block in `checkInstallBuiltinMethods`. Without `checkRegisterType(name: "Set", generics: ["T"])`, `instSeedOwnerArgs` skipped the receiver→generic unification and T stayed unbound
- Methods that take a T-typed argument (like `contains(x)`) side-stepped the bug because the value-argument path seeded T separately

## Repro (pre-fix)

```osty
fn main() {
    let xs: List<Int> = [1, 2, 3]
    let s: Set<Int> = xs.toSet()
    println(s.contains(2))   // true  ✓
    println(s.len())         // E0748: cannot infer type parameter `T` of `len`
}
```

Post-fix: prints `true / 3`.

## Root cause

[toolchain/check_env.osty:1798-1803](toolchain/check_env.osty:1798) registers the stdlib types that carry generics so arity/substitution code can find the parameter names:

```osty
checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], ... })
checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], ... })
// "Set" missing here
checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], ... })
checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], ... })
```

Without that entry, [elab.osty:2031 `instSeedOwnerArgs`](toolchain/elab.osty:2031) gets `ownerGenerics = []` (from empty `checkLookupType("Set").generics`) but `ownerArgs = [Int]` (from the receiver's concrete type args). Arity mismatch → early return → T never unified with Int → E0748 at the final `isFullyResolved` check.

Fix is a single additional line in the type-registration block.

## Test plan

- [x] `go test ./internal/check -run TestNativeBoundaryExecRecognizesSetGenericIntrinsics` — builds native-checker binary, exercises Set.len / isEmpty / contains. Without fix: 2× E0748. With fix: all three bindings type correctly (Int / Bool / Bool)
- [x] `just front` — 8 frontend packages green
- [x] End-to-end: `osty run --backend=llvm` on a full Set<Int> + Set<String> program works

🤖 Generated with [Claude Code](https://claude.com/claude-code)