### PR TITLE
refactor(selfhost): move Package/Resolve/CfgEnv types to selfhost/api

### DIFF
--- a/internal/selfhost/api/package.go
+++ b/internal/selfhost/api/package.go
@@ -1,0 +1,169 @@
+package api
+
+// PackageCheckFile is the per-file input accepted by the structured
+// self-host check / resolve adapters.
+type PackageCheckFile struct {
+	Source []byte `json:"source,omitempty"`
+	Base   int    `json:"base,omitempty"`
+	// Name is the display filename surfaced in diagnostic telemetry (typically
+	// a basename like `user.osty`). Empty when unknown; the telemetry suffix
+	// falls back to `@Lnn:Cnn` without a filename prefix in that case.
+	Name string `json:"name,omitempty"`
+	// Path is the owning source path when known. Package-mode diagnostics carry
+	// this through the native checker boundary so multi-file callers do not
+	// need to guess which file owned a given span.
+	Path string `json:"path,omitempty"`
+}
+
+// PackageCheckGenericBound describes one `<T: Iface>` constraint on a
+// generic decl surfaced from an imported package.
+type PackageCheckGenericBound struct {
+	TyParam       string `json:"tyParam,omitempty"`
+	InterfaceType string `json:"interfaceType,omitempty"`
+}
+
+// PackageCheckFn describes one function or method declared in an
+// imported package surface.
+type PackageCheckFn struct {
+	Name          string                     `json:"name,omitempty"`
+	Owner         string                     `json:"owner,omitempty"`
+	ReceiverType  string                     `json:"receiverType,omitempty"`
+	ReturnType    string                     `json:"returnType,omitempty"`
+	HasBody       bool                       `json:"hasBody,omitempty"`
+	ParamNames    []string                   `json:"paramNames,omitempty"`
+	ParamTypes    []string                   `json:"paramTypes,omitempty"`
+	ParamDefaults []bool                     `json:"paramDefaults,omitempty"`
+	Generics      []string                   `json:"generics,omitempty"`
+	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
+}
+
+// PackageCheckField describes one struct field exported by an imported
+// package.
+type PackageCheckField struct {
+	Owner      string `json:"owner,omitempty"`
+	Name       string `json:"name,omitempty"`
+	TypeName   string `json:"typeName,omitempty"`
+	HasDefault bool   `json:"hasDefault,omitempty"`
+}
+
+// PackageCheckVariant describes one enum variant exported by an
+// imported package.
+type PackageCheckVariant struct {
+	Owner      string   `json:"owner,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	FieldTypes []string `json:"fieldTypes,omitempty"`
+	Generics   []string `json:"generics,omitempty"`
+}
+
+// PackageCheckAlias describes one `type Alias = Target` declaration
+// exported by an imported package.
+type PackageCheckAlias struct {
+	Name     string   `json:"name,omitempty"`
+	Target   string   `json:"target,omitempty"`
+	Generics []string `json:"generics,omitempty"`
+}
+
+// PackageCheckType describes one struct / enum / interface declaration
+// exported by an imported package.
+type PackageCheckType struct {
+	Name          string                     `json:"name,omitempty"`
+	Kind          string                     `json:"kind,omitempty"`
+	Generics      []string                   `json:"generics,omitempty"`
+	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
+}
+
+// PackageCheckInterfaceExt records one interface extension
+// (`impl Iface for T`) coming from an imported package.
+type PackageCheckInterfaceExt struct {
+	Owner         string `json:"owner,omitempty"`
+	InterfaceType string `json:"interfaceType,omitempty"`
+}
+
+// PackageCheckImport is the surface of one imported package: its
+// exported fns, fields, variants, aliases, type decls, interface
+// extensions, and the set of interface types it satisfies via
+// structural `register_as_iface` declarations.
+type PackageCheckImport struct {
+	Alias           string                     `json:"alias,omitempty"`
+	Functions       []PackageCheckFn           `json:"functions,omitempty"`
+	Fields          []PackageCheckField        `json:"fields,omitempty"`
+	Variants        []PackageCheckVariant      `json:"variants,omitempty"`
+	Aliases         []PackageCheckAlias        `json:"aliases,omitempty"`
+	TypeDecls       []PackageCheckType         `json:"typeDecls,omitempty"`
+	InterfaceExts   []PackageCheckInterfaceExt `json:"interfaceExts,omitempty"`
+	RegisterAsIface []string                   `json:"registerAsIface,omitempty"`
+}
+
+// PackageCheckInput batches one or more source files plus their
+// imported package surfaces into the structured self-host check call.
+type PackageCheckInput struct {
+	Files   []PackageCheckFile   `json:"files,omitempty"`
+	Imports []PackageCheckImport `json:"imports,omitempty"`
+}
+
+// PackageResolveFile is the per-file input shape accepted by the
+// structured self-host resolve adapter. Aliases PackageCheckFile so
+// the checker and resolver can share file shape.
+type PackageResolveFile = PackageCheckFile
+
+// PackageResolveInput batches one or more source files into a
+// synthetic package so the self-host resolver can see one shared
+// top-level namespace.
+type PackageResolveInput struct {
+	Files []PackageResolveFile `json:"files,omitempty"`
+	// Cfg, when non-nil, activates the `#[cfg(key = "value")]`
+	// pre-resolve filter per LANG_SPEC v0.5 §5 / G29. A nil Cfg leaves
+	// every decl alive (cfg shape validation still emits E0405/E0739
+	// either way).
+	Cfg *CfgEnv `json:"cfg,omitempty"`
+}
+
+// CfgEnv carries the values that `#[cfg(...)]` predicates compare
+// against. Mirrors toolchain/resolve.osty::SelfResolveCfgEnv and the
+// internal/resolve Go-side CfgEnv — kept as a separate type so the
+// selfhost package has no cycle with internal/resolve.
+type CfgEnv struct {
+	OS       string   `json:"os,omitempty"`
+	Arch     string   `json:"arch,omitempty"`
+	Target   string   `json:"target,omitempty"`
+	Features []string `json:"features,omitempty"`
+}
+
+// UseEdge is one `use <target>` edge in the workspace import graph.
+// Pos / EndPos are source offsets pointing at the use site; callers
+// render them into line/column via their own source-map when emitting
+// diagnostics.
+type UseEdge struct {
+	Target string
+	Pos    int
+	EndPos int
+	File   string
+}
+
+// PackageUses groups every non-FFI use edge emitted by one package.
+// Path is the dotted package key (same format as
+// internal/resolve::UseKey).
+type PackageUses struct {
+	Path string
+	Uses []UseEdge
+}
+
+// WorkspaceUses is the cross-package input accepted by
+// DetectImportCycles. Callers should sort Packages lexicographically
+// by Path so the diagnostic emission order stays deterministic — the
+// detector respects the given order verbatim.
+type WorkspaceUses struct {
+	Packages []PackageUses
+}
+
+// CycleDiag is one cyclic-import diagnostic record carrying the edge
+// that closed the cycle. Callers convert this to a rich
+// diag.Diagnostic by rendering Pos / EndPos through their source map.
+type CycleDiag struct {
+	Importer string
+	Target   string
+	Pos      int
+	EndPos   int
+	File     string
+	Message  string
+}

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -2,86 +2,24 @@ package selfhost
 
 import (
 	"fmt"
+
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
-type PackageCheckFile struct {
-	Source []byte `json:"source,omitempty"`
-	Base   int    `json:"base,omitempty"`
-	// Name is the display filename surfaced in diagnostic telemetry (typically
-	// a basename like `user.osty`). Empty when unknown; the telemetry suffix
-	// falls back to `@Lnn:Cnn` without a filename prefix in that case.
-	Name string `json:"name,omitempty"`
-	// Path is the owning source path when known. Package-mode diagnostics carry
-	// this through the native checker boundary so multi-file callers do not
-	// need to guess which file owned a given span.
-	Path string `json:"path,omitempty"`
-}
-
-type PackageCheckGenericBound struct {
-	TyParam       string `json:"tyParam,omitempty"`
-	InterfaceType string `json:"interfaceType,omitempty"`
-}
-
-type PackageCheckFn struct {
-	Name          string                     `json:"name,omitempty"`
-	Owner         string                     `json:"owner,omitempty"`
-	ReceiverType  string                     `json:"receiverType,omitempty"`
-	ReturnType    string                     `json:"returnType,omitempty"`
-	HasBody       bool                       `json:"hasBody,omitempty"`
-	ParamNames    []string                   `json:"paramNames,omitempty"`
-	ParamTypes    []string                   `json:"paramTypes,omitempty"`
-	ParamDefaults []bool                     `json:"paramDefaults,omitempty"`
-	Generics      []string                   `json:"generics,omitempty"`
-	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
-}
-
-type PackageCheckField struct {
-	Owner      string `json:"owner,omitempty"`
-	Name       string `json:"name,omitempty"`
-	TypeName   string `json:"typeName,omitempty"`
-	HasDefault bool   `json:"hasDefault,omitempty"`
-}
-
-type PackageCheckVariant struct {
-	Owner      string   `json:"owner,omitempty"`
-	Name       string   `json:"name,omitempty"`
-	FieldTypes []string `json:"fieldTypes,omitempty"`
-	Generics   []string `json:"generics,omitempty"`
-}
-
-type PackageCheckAlias struct {
-	Name     string   `json:"name,omitempty"`
-	Target   string   `json:"target,omitempty"`
-	Generics []string `json:"generics,omitempty"`
-}
-
-type PackageCheckType struct {
-	Name          string                     `json:"name,omitempty"`
-	Kind          string                     `json:"kind,omitempty"`
-	Generics      []string                   `json:"generics,omitempty"`
-	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
-}
-
-type PackageCheckInterfaceExt struct {
-	Owner         string `json:"owner,omitempty"`
-	InterfaceType string `json:"interfaceType,omitempty"`
-}
-
-type PackageCheckImport struct {
-	Alias           string                     `json:"alias,omitempty"`
-	Functions       []PackageCheckFn           `json:"functions,omitempty"`
-	Fields          []PackageCheckField        `json:"fields,omitempty"`
-	Variants        []PackageCheckVariant      `json:"variants,omitempty"`
-	Aliases         []PackageCheckAlias        `json:"aliases,omitempty"`
-	TypeDecls       []PackageCheckType         `json:"typeDecls,omitempty"`
-	InterfaceExts   []PackageCheckInterfaceExt `json:"interfaceExts,omitempty"`
-	RegisterAsIface []string                   `json:"registerAsIface,omitempty"`
-}
-
-type PackageCheckInput struct {
-	Files   []PackageCheckFile   `json:"files,omitempty"`
-	Imports []PackageCheckImport `json:"imports,omitempty"`
-}
+// Package-level type aliases re-export the shared boundary shapes from
+// internal/selfhost/api. See selfhost/api/package.go for definitions.
+type (
+	PackageCheckFile         = api.PackageCheckFile
+	PackageCheckGenericBound = api.PackageCheckGenericBound
+	PackageCheckFn           = api.PackageCheckFn
+	PackageCheckField        = api.PackageCheckField
+	PackageCheckVariant      = api.PackageCheckVariant
+	PackageCheckAlias        = api.PackageCheckAlias
+	PackageCheckType         = api.PackageCheckType
+	PackageCheckInterfaceExt = api.PackageCheckInterfaceExt
+	PackageCheckImport       = api.PackageCheckImport
+	PackageCheckInput        = api.PackageCheckInput
+)
 
 // CheckPackageStructured re-parses each input file via the self-host
 // lexer + parser, merges the per-file AstArenas into a synthetic package

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -5,58 +5,16 @@ import (
 	"github.com/osty/osty/internal/selfhost/api"
 )
 
-// PackageResolveFile is the per-file input shape accepted by the structured
-// self-host resolve adapter.
-type PackageResolveFile = PackageCheckFile
-
-// PackageResolveInput batches one or more source files into a synthetic package
-// so the self-host resolver can see one shared top-level namespace.
-type PackageResolveInput struct {
-	Files []PackageResolveFile `json:"files,omitempty"`
-	// Cfg, when non-nil, activates the `#[cfg(key = "value")]` pre-resolve
-	// filter per LANG_SPEC v0.5 §5 / G29. A nil Cfg leaves every decl
-	// alive (cfg shape validation still emits E0405/E0739 either way).
-	Cfg *CfgEnv `json:"cfg,omitempty"`
-}
-
-// UseEdge is one `use <target>` edge in the workspace import graph.
-// Pos / EndPos are source offsets pointing at the use site; callers
-// render them into line/column via their own source-map when emitting
-// diagnostics.
-type UseEdge struct {
-	Target string
-	Pos    int
-	EndPos int
-	File   string
-}
-
-// PackageUses groups every non-FFI use edge emitted by one package.
-// Path is the dotted package key (same format as
-// internal/resolve::UseKey).
-type PackageUses struct {
-	Path string
-	Uses []UseEdge
-}
-
-// WorkspaceUses is the cross-package input accepted by
-// DetectImportCycles. Callers should sort Packages lexicographically
-// by Path so the diagnostic emission order stays deterministic — the
-// detector respects the given order verbatim.
-type WorkspaceUses struct {
-	Packages []PackageUses
-}
-
-// CycleDiag is one cyclic-import diagnostic record carrying the edge
-// that closed the cycle. Callers convert this to a rich
-// diag.Diagnostic by rendering Pos / EndPos through their source map.
-type CycleDiag struct {
-	Importer string
-	Target   string
-	Pos      int
-	EndPos   int
-	File     string
-	Message  string
-}
+// Resolve-side types re-exported from internal/selfhost/api. See
+// selfhost/api/package.go for definitions.
+type (
+	PackageResolveFile  = api.PackageResolveFile
+	PackageResolveInput = api.PackageResolveInput
+	UseEdge             = api.UseEdge
+	PackageUses         = api.PackageUses
+	WorkspaceUses       = api.WorkspaceUses
+	CycleDiag           = api.CycleDiag
+)
 
 // DetectImportCycles walks the given workspace graph and returns one
 // CycleDiag per edge that completes a cycle. Targets absent from
@@ -102,21 +60,15 @@ func toSelfWorkspaceUses(w WorkspaceUses) *SelfWorkspaceUses {
 	return &SelfWorkspaceUses{packages: packages}
 }
 
-// CfgEnv carries the values that `#[cfg(...)]` predicates compare against.
-// Mirrors toolchain/resolve.osty::SelfResolveCfgEnv and the internal/resolve
-// Go-side CfgEnv — kept as a separate type so the selfhost package has no
-// cycle with internal/resolve.
-type CfgEnv struct {
-	OS       string   `json:"os,omitempty"`
-	Arch     string   `json:"arch,omitempty"`
-	Target   string   `json:"target,omitempty"`
-	Features []string `json:"features,omitempty"`
-}
+// CfgEnv is re-exported from internal/selfhost/api. See
+// selfhost/api/package.go for the definition.
+type CfgEnv = api.CfgEnv
 
-// toSelf converts the external CfgEnv into the selfhost-generated struct the
-// Osty resolver consumes. A nil receiver maps to the disabled sentinel so
-// the walk behaves identically to callers that never passed an env.
-func (c *CfgEnv) toSelf() *SelfResolveCfgEnv {
+// cfgEnvToSelf converts the external CfgEnv into the selfhost-
+// generated struct the Osty resolver consumes. A nil env maps to the
+// disabled sentinel so the walk behaves identically to callers that
+// never passed one.
+func cfgEnvToSelf(c *CfgEnv) *SelfResolveCfgEnv {
 	if c == nil {
 		return selfResolveCfgDisabled()
 	}
@@ -164,7 +116,7 @@ func ResolveSourceStructuredWithCfg(src []byte, cfg *CfgEnv) ResolveResult {
 	}
 	rt := newRuneTable(lexed.source)
 	return adaptResolveResult(
-		selfResolveAstFileWithCfg(file, cfg.toSelf()),
+		selfResolveAstFileWithCfg(file, cfgEnvToSelf(cfg)),
 		file,
 		func(start, end int) (int, int) {
 			return checkNodeOffsets(rt, lexed.stream, start, end)
@@ -246,7 +198,7 @@ func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResul
 // Source text is the sole AST ingress — no *ast.File round-trip. Cfg
 // filtering activates when input.Cfg is non-nil.
 func ResolvePackageStructured(input PackageResolveInput) (ResolveResult, error) {
-	cfg := input.Cfg.toSelf()
+	cfg := cfgEnvToSelf(input.Cfg)
 	file, layout, err := selfhostBuildPackageAst(input.Files)
 	if err != nil {
 		return ResolveResult{}, err


### PR DESCRIPTION
## Summary

Follow-up to #761 (Check/Resolve types extracted). Moves the remaining cross-boundary data types into `internal/selfhost/api` so the whole public-type surface now lives in one subpackage.

## Moved

- **Package surface types**: `PackageCheckFile`, `PackageCheckGenericBound`, `PackageCheckFn`, `PackageCheckField`, `PackageCheckVariant`, `PackageCheckAlias`, `PackageCheckType`, `PackageCheckInterfaceExt`, `PackageCheckImport`, `PackageCheckInput`
- **Resolve surface types**: `PackageResolveFile` (alias of `PackageCheckFile`), `PackageResolveInput`
- **Import-cycle graph types**: `UseEdge`, `PackageUses`, `WorkspaceUses`, `CycleDiag`
- **Cfg env**: `CfgEnv` — its receiver method `(*CfgEnv).toSelf()` became a free function `cfgEnvToSelf(c *CfgEnv) *SelfResolveCfgEnv` so the type has no selfhost-internal references.

## Why

After #753 (source-bytes API) and #761 (Check/Resolve types in api), this completes the types-only split. Downstream consumers that eventually move to subprocess dispatch can import `internal/selfhost/api` alone without dragging in the generated bootstrap core. No call-site churn — selfhost re-exports each type via a Go type alias.

## Notes for reviewer

- Pure refactor: no behavior change.
- `PackageCheckFile` keeps the main-branch shape (no `File *ast.File` / `SourceMap *sourcemap.Map`) — #769 already stripped those, and the rebase adopted that version.
- api pkg has zero selfhost-internal imports. `import \"github.com/osty/osty/internal/selfhost/api\"` is safe from anywhere that wants just the shapes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/selfhost/ -count=1 -short`
- [x] `go test ./cmd/osty/ -run 'TestResolve|TestRunResolve|TestCheckFileNative|TestRunCheckFileNative|TestTypecheckFileNative|Astbridge|TestCfg|TestPackage' -count=1`
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)