### PR TITLE
fix(mir): lower bare None ident as Option aggregate, not FnConst

### DIFF
--- a/internal/backend/llvm_none_as_arg_test.go
+++ b/internal/backend/llvm_none_as_arg_test.go
@@ -1,0 +1,78 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsBareNoneAsCallArg covers a MIR lowering gap
+// for the bare `None` identifier in expression position. The resolver
+// tags `None` as `SymBuiltin` (see internal/resolve/prelude.go:56),
+// which HIR then lifts to `IdentBuiltin`. The MIR `lowerIdent` switch
+// only handled `IdentFn` / `IdentGlobal` / `IdentVariant`, so
+// `IdentBuiltin` fell through to the "unknown identifier" fallback
+// that emits a `FnConst{Symbol: "None"}`. At LLVM level that renders
+// as `@None` — a reference to an undeclared global, failing with
+// "global variable reference must have pointer type" at clang link
+// time.
+//
+// The fix materialises `None` as a NullaryRV with the ident's
+// checker-resolved type, matching the existing `?` propagation path
+// for Option<T> error arms (see emitQuestionExprOption in lower.go).
+func TestLLVMBackendBinaryRunsBareNoneAsCallArg(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn plus(n: Int?) -> Int { n ?? -1 }
+
+fn main() {
+    println(plus(None))
+    println(plus(Some(5)))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "-1\n5\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsBareNoneInListLiteral makes sure the same
+// fix works for `None` inside a typed `List<Int?>` literal — another
+// position where the checker seeds id.T from the list element type
+// and the MIR emitter then asks lowerIdent to produce a proper
+// Option aggregate.
+func TestLLVMBackendBinaryRunsBareNoneInListLiteral(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int?> = [None, Some(10), None, Some(20)]
+    let mut sum = 0
+    for x in xs {
+        sum = sum + (x ?? 0)
+    }
+    println(sum)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "30\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2380,6 +2380,28 @@ func (bs *bodyState) lowerExprToPlace(e ir.Expr) (Place, bool) {
 
 // lowerIdent turns an Ident into an operand.
 func (bs *bodyState) lowerIdent(id *ir.Ident) Operand {
+	// Bare `None` (no payload, no call) reaches here as an Ident with
+	// Kind=IdentBuiltin because prelude.go tags it as SymBuiltin. Without
+	// explicit handling it would fall through to the FnConst fallback
+	// below and emit as `@None` — an undefined global at LLVM level. The
+	// LLVM runtime shape for every Option<T>::None is `{0, 0}`, so
+	// materialise a NullaryNone with the ident's checker-resolved type.
+	// Callers that want type-directed coercion (e.g. plus(None) where
+	// the checker seeded id.T from the signature) already get it for
+	// free because id.T is Option<Int> by the time this fires.
+	if id.Name == "None" && id.Kind != ir.IdentLocal && id.Kind != ir.IdentParam {
+		t := id.T
+		if t == nil {
+			t = ir.ErrTypeVal
+		}
+		tmp := bs.freshTemp(t, id.SpanV)
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: tmp},
+			Src:   &NullaryRV{Kind: NullaryNone, T: t},
+			SpanV: id.SpanV,
+		})
+		return &CopyOp{Place: Place{Local: tmp}, T: t}
+	}
 	switch id.Kind {
 	case ir.IdentFn:
 		fnType := id.T


### PR DESCRIPTION
## Summary

- Bare `None` in expression position (call arg, list element, …) was emitted as `@None` — an undeclared LLVM global — making any program that passed `None` fail clang link with `global variable reference must have pointer type`
- Root cause: the resolver tags `None` as `SymBuiltin`, which HIR lifts to `IdentBuiltin`. MIR's `lowerIdent` switch only covered `IdentFn` / `IdentGlobal` / `IdentVariant`, so `IdentBuiltin` fell through to the "unknown identifier" fallback that emits `FnConst{Symbol: "None"}`
- Fix: materialise bare `None` as a `NullaryRV{Kind: NullaryNone}`, matching the shape the `?` propagation path has used for "produce a None of type T" since Phase 74

## Repro (pre-fix)

```osty
fn plus(n: Int?) -> Int { n ?? -1 }
fn main() {
    println(plus(None))
}
```

Pre-fix:
```
/tmp/.../main.ll:41: error: global variable reference must have pointer type
  %t0 = call i64 @plus(%Option.i64 @None)
                                   ^
```

Post-fix: prints `-1`.

## Why only the bare Ident form

- `Some(x)` / `Ok(x)` / `Err(x)` go through `CallExpr` (they always carry a payload arg) so their lowering path builds the aggregate correctly from the arg.
- `None` is the only one with no payload, so it appears as a bare `*ast.Ident` and the resolver hands it `SymBuiltin` tags.
- `let x: Int? = None` already works because `LetStmt` lowering sees the type annotation and emits the aggregate directly; the problem only shows up in sub-expression positions where lowerIdent is invoked.

The fix lowers bare `None` idents as NullaryRV, identical to the `?` propagation path. Checker already seeds `id.T` from the surrounding context for this to work in the common case (positional call arg, typed list element, typed let).

## Kind-guard

The conditional excludes `IdentLocal` / `IdentParam` so a user-named local variable called `None` (legal — `None` is not a keyword per spec §1.4) still binds through the locals table.

## Test plan

- [x] `TestLLVMBackendBinaryRunsBareNoneAsCallArg` — `plus(None)` / `plus(Some(5))` prints `-1 / 5`. Pre-fix: clang link failure.
- [x] `TestLLVMBackendBinaryRunsBareNoneInListLiteral` — `[None, Some(10), None, Some(20)]` folded through `?? 0` sums to `30`. Pre-fix: same clang link failure.
- [x] `just front` — 8 frontend packages green
- [x] `go test ./internal/mir/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)