### PR TITLE
[codex] refactor(lsp): route single-file analysis through native seam

### DIFF
--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // LSP code-action kind strings (LSP 3.17 §codeActionKind). Only the
@@ -369,8 +370,8 @@ func airepairFixAllEdit(doc *document) *TextEdit {
 		return nil
 	}
 	repaired := result.Repaired
-	if parsed := parser.ParseDetailed(repaired); parsed.File != nil {
-		if canonicalRepaired := canonical.Source(repaired, parsed.File); len(canonicalRepaired) > 0 {
+	if file := selfhost.LowerPublicFileFromRun(parser.ParseRun(repaired)); file != nil {
+		if canonicalRepaired := canonical.Source(repaired, file); len(canonicalRepaired) > 0 {
 			repaired = canonicalRepaired
 		}
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -701,21 +701,22 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 // repeated edits of the same buffer benefit from the incremental
 // cache and early cutoff.
 func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
-	parsed := parser.ParseDetailed(src)
-	res := resolve.File(parsed.File, s.prelude)
-	canonicalSrc, _ := canonical.SourceWithMap(src, parsed.File)
-	chk := check.File(parsed.File, res, lspCheckOpts(canonicalSrc))
-	lr := lint.File(parsed.File, src, res, chk)
+	run := parser.ParseRun(src)
+	file := selfhost.LowerPublicFileFromRun(run)
+	parseDiags := run.Diagnostics()
+	canonicalSrc, _ := canonical.SourceWithMap(src, file)
+	res := resolve.File(file, s.prelude)
+	chk := check.File(file, res, lspCheckOpts(canonicalSrc))
+	lr := lint.File(file, src, res, chk)
 	all := make([]*diag.Diagnostic, 0,
-		len(parsed.Diagnostics)+len(res.Diags)+len(chk.Diags)+len(lr.Diags))
-	all = append(all, parsed.Diagnostics...)
+		len(parseDiags)+len(res.Diags)+len(chk.Diags)+len(lr.Diags))
+	all = append(all, parseDiags...)
 	all = append(all, res.Diags...)
 	all = append(all, chk.Diags...)
 	all = append(all, lr.Diags...)
 	return &docAnalysis{
 		lines:      newLineIndex(src),
-		file:       parsed.File,
-		provenance: parsed.Provenance,
+		file:       file,
 		canonical:  canonicalSrc,
 		resolve:    res,
 		check:      chk,

--- a/internal/lsp/server_native_test.go
+++ b/internal/lsp/server_native_test.go
@@ -40,6 +40,23 @@ func TestAnalyzePackageContainingUsesNativeCompatibilityPath(t *testing.T) {
 	}
 }
 
+func TestAnalyzeSingleFileUsesNativeCompatibilityPath(t *testing.T) {
+	src := []byte("pub fn fresh() {}\n")
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	selfhost.ResetAstbridgeLowerCount()
+	a := s.analyzeSingleFile(src)
+	if a == nil {
+		t.Fatal("analyzeSingleFile returned nil")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after single-file analyze = %d, want 0", got)
+	}
+	if got := lspFirstFnName(a.file); got != "fresh" {
+		t.Fatalf("first function = %q, want %q", got, "fresh")
+	}
+}
+
 func TestAnalyzeWorkspaceUsesNativeCompatibilityPath(t *testing.T) {
 	root := t.TempDir()
 	appDir := filepath.Join(root, "app")


### PR DESCRIPTION
## Summary
- route legacy LSP single-file analysis through `parser.ParseRun` plus `selfhost.LowerPublicFileFromRun`
- keep parser provenance handling only where `source.fixAll` still needs parser-owned canonicalization
- add a native-compat regression test covering the single-file path

## Why
Package and workspace analysis were already on the native compatibility seam, but the legacy single-file path still forced a direct `parser.ParseDetailed` lowering. This keeps the remaining compatibility surface smaller and makes the single-file path match the rest of the LSP analysis pipeline more closely.

## Validation
- `go test -count=1 -vet=off ./internal/lsp`