### PR TITLE
refactor(selfhost,resolver): unify native-resolver JSON shapes via api package

### DIFF
--- a/cmd/osty-native-checker/main.go
+++ b/cmd/osty-native-checker/main.go
@@ -7,75 +7,8 @@ import (
 	"os"
 
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
-
-type checkRequest struct {
-	Source  string                      `json:"source,omitempty"`
-	Package *selfhost.PackageCheckInput `json:"package,omitempty"`
-}
-
-type checkSummary struct {
-	Assignments     int                       `json:"assignments"`
-	Accepted        int                       `json:"accepted"`
-	Errors          int                       `json:"errors"`
-	ErrorsByContext map[string]int            `json:"errorsByContext,omitempty"`
-	ErrorDetails    map[string]map[string]int `json:"errorDetails,omitempty"`
-}
-
-type checkedNode struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type checkedBinding struct {
-	Node     int    `json:"node"`
-	Name     string `json:"name"`
-	TypeName string `json:"typeName"`
-	Mutable  bool   `json:"mutable"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type checkedSymbol struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	Name     string `json:"name"`
-	Owner    string `json:"owner"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type checkInstantiation struct {
-	Node       int      `json:"node"`
-	Callee     string   `json:"callee"`
-	TypeArgs   []string `json:"typeArgs"`
-	ResultType string   `json:"resultType"`
-	Start      int      `json:"start"`
-	End        int      `json:"end"`
-}
-
-type checkDiagnostic struct {
-	Code     string   `json:"code"`
-	Severity string   `json:"severity"`
-	Message  string   `json:"message"`
-	Start    int      `json:"start"`
-	End      int      `json:"end"`
-	File     string   `json:"file,omitempty"`
-	Notes    []string `json:"notes,omitempty"`
-}
-
-type checkResponse struct {
-	Summary        checkSummary         `json:"summary"`
-	TypedNodes     []checkedNode        `json:"typedNodes"`
-	Bindings       []checkedBinding     `json:"bindings"`
-	Symbols        []checkedSymbol      `json:"symbols"`
-	Instantiations []checkInstantiation `json:"instantiations"`
-	Diagnostics    []checkDiagnostic    `json:"diagnostics,omitempty"`
-}
 
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
@@ -85,12 +18,12 @@ func main() {
 }
 
 func run(stdin io.Reader, stdout io.Writer) error {
-	var req checkRequest
+	var req api.CheckRequest
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode checker request: %w", err)
 	}
 	var (
-		checked selfhost.CheckResult
+		checked api.CheckResult
 		err     error
 	)
 	if req.Package != nil {
@@ -101,73 +34,5 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	} else {
 		checked = selfhost.CheckSourceStructured([]byte(req.Source))
 	}
-	resp := checkResponse{
-		Summary: checkSummary{
-			Assignments:     checked.Summary.Assignments,
-			Accepted:        checked.Summary.Accepted,
-			Errors:          checked.Summary.Errors,
-			ErrorsByContext: checked.Summary.ErrorsByContext,
-			ErrorDetails:    checked.Summary.ErrorDetails,
-		},
-		TypedNodes:     make([]checkedNode, 0, len(checked.TypedNodes)),
-		Bindings:       make([]checkedBinding, 0, len(checked.Bindings)),
-		Symbols:        make([]checkedSymbol, 0, len(checked.Symbols)),
-		Instantiations: make([]checkInstantiation, 0, len(checked.Instantiations)),
-	}
-	for _, node := range checked.TypedNodes {
-		resp.TypedNodes = append(resp.TypedNodes, checkedNode{
-			Node:     node.Node,
-			Kind:     node.Kind,
-			TypeName: node.TypeName,
-			Start:    node.Start,
-			End:      node.End,
-		})
-	}
-	for _, binding := range checked.Bindings {
-		resp.Bindings = append(resp.Bindings, checkedBinding{
-			Node:     binding.Node,
-			Name:     binding.Name,
-			TypeName: binding.TypeName,
-			Mutable:  binding.Mutable,
-			Start:    binding.Start,
-			End:      binding.End,
-		})
-	}
-	for _, symbol := range checked.Symbols {
-		resp.Symbols = append(resp.Symbols, checkedSymbol{
-			Node:     symbol.Node,
-			Kind:     symbol.Kind,
-			Name:     symbol.Name,
-			Owner:    symbol.Owner,
-			TypeName: symbol.TypeName,
-			Start:    symbol.Start,
-			End:      symbol.End,
-		})
-	}
-	for _, inst := range checked.Instantiations {
-		resp.Instantiations = append(resp.Instantiations, checkInstantiation{
-			Node:       inst.Node,
-			Callee:     inst.Callee,
-			TypeArgs:   append([]string(nil), inst.TypeArgs...),
-			ResultType: inst.ResultType,
-			Start:      inst.Start,
-			End:        inst.End,
-		})
-	}
-	if len(checked.Diagnostics) > 0 {
-		resp.Diagnostics = make([]checkDiagnostic, 0, len(checked.Diagnostics))
-		for _, d := range checked.Diagnostics {
-			resp.Diagnostics = append(resp.Diagnostics, checkDiagnostic{
-				Code:     d.Code,
-				Severity: d.Severity,
-				Message:  d.Message,
-				Start:    d.Start,
-				End:      d.End,
-				File:     d.File,
-				Notes:    append([]string(nil), d.Notes...),
-			})
-		}
-	}
-	enc := json.NewEncoder(stdout)
-	return enc.Encode(resp)
+	return json.NewEncoder(stdout).Encode(checked)
 }

--- a/cmd/osty-native-checker/main_test.go
+++ b/cmd/osty-native-checker/main_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 func TestRunEmitsStructuredCheckResult(t *testing.T) {
@@ -15,7 +15,7 @@ func TestRunEmitsStructuredCheckResult(t *testing.T) {
 	if err := run(stdin, &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	var resp checkResponse
+	var resp api.CheckResult
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestRunChecksGenericBoundsAndInterfaceExtends(t *testing.T) {
 	if err := run(goodIn, &goodOut); err != nil {
 		t.Fatalf("run good error: %v", err)
 	}
-	var goodResp checkResponse
+	var goodResp api.CheckResult
 	if err := json.Unmarshal(goodOut.Bytes(), &goodResp); err != nil {
 		t.Fatalf("decode good response: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestRunChecksGenericBoundsAndInterfaceExtends(t *testing.T) {
 	if err := run(badIn, &badOut); err != nil {
 		t.Fatalf("run bad error: %v", err)
 	}
-	var badResp checkResponse
+	var badResp api.CheckResult
 	if err := json.Unmarshal(badOut.Bytes(), &badResp); err != nil {
 		t.Fatalf("decode bad response: %v", err)
 	}
@@ -78,9 +78,9 @@ func TestRunChecksGenericBoundsAndInterfaceExtends(t *testing.T) {
 func TestRunChecksPackageStructuredRequest(t *testing.T) {
 	fileA := []byte("fn helper() -> Int { 1 }\n")
 	fileB := []byte("fn main() { let value = helper() }\n")
-	reqBody, err := json.Marshal(checkRequest{
-		Package: &selfhost.PackageCheckInput{
-			Files: []selfhost.PackageCheckFile{
+	reqBody, err := json.Marshal(api.CheckRequest{
+		Package: &api.PackageCheckInput{
+			Files: []api.PackageCheckFile{
 				{Source: fileA, Base: 0, Name: "a.osty"},
 				{Source: fileB, Base: len(fileA) + 1, Name: "b.osty"},
 			},
@@ -94,7 +94,7 @@ func TestRunChecksPackageStructuredRequest(t *testing.T) {
 	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	var resp checkResponse
+	var resp api.CheckResult
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}

--- a/cmd/osty-native-resolver/main.go
+++ b/cmd/osty-native-resolver/main.go
@@ -7,75 +7,8 @@ import (
 	"os"
 
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
-
-type resolveRequest struct {
-	Source  string                        `json:"source,omitempty"`
-	Package *selfhost.PackageResolveInput `json:"package,omitempty"`
-}
-
-type resolveSummary struct {
-	Symbols           int            `json:"symbols"`
-	Refs              int            `json:"refs"`
-	TypeRefs          int            `json:"typeRefs"`
-	Diagnostics       int            `json:"diagnostics"`
-	Unresolved        int            `json:"unresolved"`
-	Duplicates        int            `json:"duplicates"`
-	SymbolsByKind     map[string]int `json:"symbolsByKind,omitempty"`
-	DiagnosticsByCode map[string]int `json:"diagnosticsByCode,omitempty"`
-}
-
-type resolvedSymbol struct {
-	Node     int    `json:"node"`
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
-	TypeName string `json:"typeName"`
-	Arity    int    `json:"arity"`
-	Depth    int    `json:"depth"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Public   bool   `json:"public"`
-	File     string `json:"file,omitempty"`
-}
-
-type resolvedRef struct {
-	Name        string `json:"name"`
-	Node        int    `json:"node"`
-	Start       int    `json:"start"`
-	End         int    `json:"end"`
-	File        string `json:"file,omitempty"`
-	TargetNode  int    `json:"targetNode"`
-	TargetStart int    `json:"targetStart"`
-	TargetEnd   int    `json:"targetEnd"`
-	TargetFile  string `json:"targetFile,omitempty"`
-}
-
-type resolvedTypeRef struct {
-	Name  string `json:"name"`
-	Node  int    `json:"node"`
-	Start int    `json:"start"`
-	End   int    `json:"end"`
-	File  string `json:"file,omitempty"`
-}
-
-type resolveDiagnostic struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Name    string `json:"name,omitempty"`
-	Hint    string `json:"hint,omitempty"`
-	Node    int    `json:"node"`
-	Start   int    `json:"start"`
-	End     int    `json:"end"`
-	File    string `json:"file,omitempty"`
-}
-
-type resolveResponse struct {
-	Summary     resolveSummary      `json:"summary"`
-	Symbols     []resolvedSymbol    `json:"symbols"`
-	Refs        []resolvedRef       `json:"refs"`
-	TypeRefs    []resolvedTypeRef   `json:"typeRefs"`
-	Diagnostics []resolveDiagnostic `json:"diagnostics,omitempty"`
-}
 
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
@@ -85,12 +18,12 @@ func main() {
 }
 
 func run(stdin io.Reader, stdout io.Writer) error {
-	var req resolveRequest
+	var req api.ResolveRequest
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode resolver request: %w", err)
 	}
 	var (
-		resolved selfhost.ResolveResult
+		resolved api.ResolveResult
 		err      error
 	)
 	if req.Package != nil {
@@ -101,71 +34,5 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	} else {
 		resolved = selfhost.ResolveSourceStructured([]byte(req.Source))
 	}
-	resp := resolveResponse{
-		Summary: resolveSummary{
-			Symbols:           resolved.Summary.Symbols,
-			Refs:              resolved.Summary.Refs,
-			TypeRefs:          resolved.Summary.TypeRefs,
-			Diagnostics:       resolved.Summary.Diagnostics,
-			Unresolved:        resolved.Summary.Unresolved,
-			Duplicates:        resolved.Summary.Duplicates,
-			SymbolsByKind:     resolved.Summary.SymbolsByKind,
-			DiagnosticsByCode: resolved.Summary.DiagnosticsByCode,
-		},
-		Symbols:  make([]resolvedSymbol, 0, len(resolved.Symbols)),
-		Refs:     make([]resolvedRef, 0, len(resolved.Refs)),
-		TypeRefs: make([]resolvedTypeRef, 0, len(resolved.TypeRefs)),
-	}
-	for _, sym := range resolved.Symbols {
-		resp.Symbols = append(resp.Symbols, resolvedSymbol{
-			Node:     sym.Node,
-			Name:     sym.Name,
-			Kind:     sym.Kind,
-			TypeName: sym.TypeName,
-			Arity:    sym.Arity,
-			Depth:    sym.Depth,
-			Start:    sym.Start,
-			End:      sym.End,
-			Public:   sym.Public,
-			File:     sym.File,
-		})
-	}
-	for _, ref := range resolved.Refs {
-		resp.Refs = append(resp.Refs, resolvedRef{
-			Name:        ref.Name,
-			Node:        ref.Node,
-			Start:       ref.Start,
-			End:         ref.End,
-			File:        ref.File,
-			TargetNode:  ref.TargetNode,
-			TargetStart: ref.TargetStart,
-			TargetEnd:   ref.TargetEnd,
-			TargetFile:  ref.TargetFile,
-		})
-	}
-	for _, ref := range resolved.TypeRefs {
-		resp.TypeRefs = append(resp.TypeRefs, resolvedTypeRef{
-			Name:  ref.Name,
-			Node:  ref.Node,
-			Start: ref.Start,
-			End:   ref.End,
-			File:  ref.File,
-		})
-	}
-	if len(resolved.Diagnostics) > 0 {
-		resp.Diagnostics = make([]resolveDiagnostic, 0, len(resolved.Diagnostics))
-		for _, d := range resolved.Diagnostics {
-			resp.Diagnostics = append(resp.Diagnostics, resolveDiagnostic{
-				Code:    d.Code,
-				Message: d.Message,
-				Name:    d.Name,
-				Hint:    d.Hint,
-				Node:    d.Node,
-				Start:   d.Start,
-				End:     d.End,
-				File:    d.File,
-			})
-		}
-	}
-	return json.NewEncoder(stdout).Encode(resp)
+	return json.NewEncoder(stdout).Encode(resolved)
 }

--- a/cmd/osty-native-resolver/main_test.go
+++ b/cmd/osty-native-resolver/main_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 func TestRunEmitsStructuredResolveResult(t *testing.T) {
@@ -16,7 +16,7 @@ func TestRunEmitsStructuredResolveResult(t *testing.T) {
 	if err := run(stdin, &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	var resp resolveResponse
+	var resp api.ResolveResult
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -46,9 +46,9 @@ func TestRunResolvesPackageStructuredRequest(t *testing.T) {
 	dir := t.TempDir()
 	fileA := []byte("pub fn helper() -> Int { 1 }\n")
 	fileB := []byte("fn main() { let value = helper() }\n")
-	reqBody, err := json.Marshal(resolveRequest{
-		Package: &selfhost.PackageResolveInput{
-			Files: []selfhost.PackageResolveFile{
+	reqBody, err := json.Marshal(api.ResolveRequest{
+		Package: &api.PackageResolveInput{
+			Files: []api.PackageResolveFile{
 				{Source: fileA, Base: 0, Name: "a.osty", Path: filepath.Join(dir, "a.osty")},
 				{Source: fileB, Base: len(fileA) + 1, Name: "b.osty", Path: filepath.Join(dir, "b.osty")},
 			},
@@ -62,7 +62,7 @@ func TestRunResolvesPackageStructuredRequest(t *testing.T) {
 	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	var resp resolveResponse
+	var resp api.ResolveResult
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -19,6 +19,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -29,98 +30,34 @@ const nativeCheckerEnv = "OSTY_NATIVE_CHECKER_BIN"
 // The checker targets an Osty-native request/response boundary. The default
 // host implementation uses the embedded selfhost checker in-process; callers
 // can opt into an external executable by setting OSTY_NATIVE_CHECKER_BIN.
+//
+// The result and request types are api.CheckResult / api.CheckRequest so the
+// in-process embedded path and the subprocess exec path speak identical
+// shapes with no adapter layer in between.
 type nativeChecker interface {
-	CheckSourceStructured([]byte) (nativeCheckResult, error)
+	CheckSourceStructured([]byte) (api.CheckResult, error)
 }
 
 type nativePackageChecker interface {
-	CheckPackageStructured(selfhost.PackageCheckInput) (nativeCheckResult, error)
-}
-
-type nativeCheckRequest struct {
-	Source  string                      `json:"source,omitempty"`
-	Package *selfhost.PackageCheckInput `json:"package,omitempty"`
-}
-
-type nativeCheckSummary struct {
-	Assignments     int                       `json:"assignments"`
-	Accepted        int                       `json:"accepted"`
-	Errors          int                       `json:"errors"`
-	ErrorsByContext map[string]int            `json:"errorsByContext,omitempty"`
-	ErrorDetails    map[string]map[string]int `json:"errorDetails,omitempty"`
-}
-
-type nativeCheckedNode struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type nativeCheckedBinding struct {
-	Node     int    `json:"node"`
-	Name     string `json:"name"`
-	TypeName string `json:"typeName"`
-	Mutable  bool   `json:"mutable"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type nativeCheckedSymbol struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	Name     string `json:"name"`
-	Owner    string `json:"owner"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-}
-
-type nativeCheckInstantiation struct {
-	Node       int      `json:"node"`
-	Callee     string   `json:"callee"`
-	TypeArgs   []string `json:"typeArgs"`
-	ResultType string   `json:"resultType"`
-	Start      int      `json:"start"`
-	End        int      `json:"end"`
-}
-
-type nativeCheckDiagnostic struct {
-	Code     string   `json:"code"`
-	Severity string   `json:"severity"`
-	Message  string   `json:"message"`
-	Start    int      `json:"start"`
-	End      int      `json:"end"`
-	File     string   `json:"file,omitempty"`
-	Notes    []string `json:"notes,omitempty"`
-}
-
-type nativeCheckResult struct {
-	Summary        nativeCheckSummary         `json:"summary"`
-	TypedNodes     []nativeCheckedNode        `json:"typedNodes"`
-	Bindings       []nativeCheckedBinding     `json:"bindings"`
-	Symbols        []nativeCheckedSymbol      `json:"symbols"`
-	Instantiations []nativeCheckInstantiation `json:"instantiations"`
-	Diagnostics    []nativeCheckDiagnostic    `json:"diagnostics,omitempty"`
+	CheckPackageStructured(api.PackageCheckInput) (api.CheckResult, error)
 }
 
 type nativeCheckerExec struct {
 	path string
 }
 
-func (e nativeCheckerExec) CheckSourceStructured(src []byte) (nativeCheckResult, error) {
-	return e.run(nativeCheckRequest{Source: string(src)})
+func (e nativeCheckerExec) CheckSourceStructured(src []byte) (api.CheckResult, error) {
+	return e.run(api.CheckRequest{Source: string(src)})
 }
 
-func (e nativeCheckerExec) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
-	return e.run(nativeCheckRequest{Package: &input})
+func (e nativeCheckerExec) CheckPackageStructured(input api.PackageCheckInput) (api.CheckResult, error) {
+	return e.run(api.CheckRequest{Package: &input})
 }
 
-func (e nativeCheckerExec) run(req nativeCheckRequest) (nativeCheckResult, error) {
+func (e nativeCheckerExec) run(req api.CheckRequest) (api.CheckResult, error) {
 	payload, err := json.Marshal(req)
 	if err != nil {
-		return nativeCheckResult{}, fmt.Errorf("marshal native checker request: %w", err)
+		return api.CheckResult{}, fmt.Errorf("marshal native checker request: %w", err)
 	}
 	cmd := exec.Command(e.path)
 	cmd.Stdin = bytes.NewReader(payload)
@@ -130,99 +67,23 @@ func (e nativeCheckerExec) run(req nativeCheckRequest) (nativeCheckResult, error
 		if msg == "" {
 			msg = "<no output>"
 		}
-		return nativeCheckResult{}, fmt.Errorf("exec %s: %w (%s)", e.path, err, msg)
+		return api.CheckResult{}, fmt.Errorf("exec %s: %w (%s)", e.path, err, msg)
 	}
-	var checked nativeCheckResult
+	var checked api.CheckResult
 	if err := json.Unmarshal(out, &checked); err != nil {
-		return nativeCheckResult{}, fmt.Errorf("decode native checker response: %w", err)
+		return api.CheckResult{}, fmt.Errorf("decode native checker response: %w", err)
 	}
 	return checked, nil
 }
 
 type embeddedNativeChecker struct{}
 
-func (embeddedNativeChecker) CheckSourceStructured(src []byte) (nativeCheckResult, error) {
-	checked := selfhost.CheckSourceStructured(src)
-	return adaptEmbeddedCheckResult(checked), nil
+func (embeddedNativeChecker) CheckSourceStructured(src []byte) (api.CheckResult, error) {
+	return selfhost.CheckSourceStructured(src), nil
 }
 
-func (embeddedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
-	checked, err := selfhost.CheckPackageStructured(input)
-	if err != nil {
-		return nativeCheckResult{}, err
-	}
-	return adaptEmbeddedCheckResult(checked), nil
-}
-
-func adaptEmbeddedCheckResult(checked selfhost.CheckResult) nativeCheckResult {
-	result := nativeCheckResult{
-		Summary: nativeCheckSummary{
-			Assignments:     checked.Summary.Assignments,
-			Accepted:        checked.Summary.Accepted,
-			Errors:          checked.Summary.Errors,
-			ErrorsByContext: cloneStringIntMap(checked.Summary.ErrorsByContext),
-			ErrorDetails:    cloneErrorDetailMap(checked.Summary.ErrorDetails),
-		},
-		TypedNodes:     make([]nativeCheckedNode, 0, len(checked.TypedNodes)),
-		Bindings:       make([]nativeCheckedBinding, 0, len(checked.Bindings)),
-		Symbols:        make([]nativeCheckedSymbol, 0, len(checked.Symbols)),
-		Instantiations: make([]nativeCheckInstantiation, 0, len(checked.Instantiations)),
-	}
-	for _, node := range checked.TypedNodes {
-		result.TypedNodes = append(result.TypedNodes, nativeCheckedNode{
-			Node:     node.Node,
-			Kind:     node.Kind,
-			TypeName: node.TypeName,
-			Start:    node.Start,
-			End:      node.End,
-		})
-	}
-	for _, binding := range checked.Bindings {
-		result.Bindings = append(result.Bindings, nativeCheckedBinding{
-			Node:     binding.Node,
-			Name:     binding.Name,
-			TypeName: binding.TypeName,
-			Mutable:  binding.Mutable,
-			Start:    binding.Start,
-			End:      binding.End,
-		})
-	}
-	for _, symbol := range checked.Symbols {
-		result.Symbols = append(result.Symbols, nativeCheckedSymbol{
-			Node:     symbol.Node,
-			Kind:     symbol.Kind,
-			Name:     symbol.Name,
-			Owner:    symbol.Owner,
-			TypeName: symbol.TypeName,
-			Start:    symbol.Start,
-			End:      symbol.End,
-		})
-	}
-	for _, inst := range checked.Instantiations {
-		result.Instantiations = append(result.Instantiations, nativeCheckInstantiation{
-			Node:       inst.Node,
-			Callee:     inst.Callee,
-			TypeArgs:   append([]string(nil), inst.TypeArgs...),
-			ResultType: inst.ResultType,
-			Start:      inst.Start,
-			End:        inst.End,
-		})
-	}
-	if len(checked.Diagnostics) > 0 {
-		result.Diagnostics = make([]nativeCheckDiagnostic, 0, len(checked.Diagnostics))
-		for _, d := range checked.Diagnostics {
-			result.Diagnostics = append(result.Diagnostics, nativeCheckDiagnostic{
-				Code:     d.Code,
-				Severity: d.Severity,
-				Message:  d.Message,
-				Start:    d.Start,
-				End:      d.End,
-				File:     d.File,
-				Notes:    append([]string(nil), d.Notes...),
-			})
-		}
-	}
-	return result
+func (embeddedNativeChecker) CheckPackageStructured(input api.PackageCheckInput) (api.CheckResult, error) {
+	return selfhost.CheckPackageStructured(input)
 }
 
 var nativeCheckerFactory = defaultNativeChecker
@@ -254,7 +115,7 @@ func UseEmbeddedNativeChecker() {
 // cacheDir is created on demand. A misformatted cache entry is silently
 // rebuilt. The cache is plain JSON so it is trivially introspectable
 // with `cat`; no schema migration is attempted, so bump validity if the
-// nativeCheckResult shape changes.
+// api.CheckResult shape changes.
 func UseCachedEmbeddedNativeChecker(cacheDir, validity string) {
 	checker := cachedNativeChecker{
 		backing:  embeddedNativeChecker{},
@@ -341,7 +202,7 @@ type cachedNativeChecker struct {
 	validity string
 }
 
-func (c cachedNativeChecker) CheckSourceStructured(src []byte) (nativeCheckResult, error) {
+func (c cachedNativeChecker) CheckSourceStructured(src []byte) (api.CheckResult, error) {
 	key := cachedEmbeddedKey("src", src)
 	if res, ok := c.read(key); ok {
 		return res, nil
@@ -353,7 +214,7 @@ func (c cachedNativeChecker) CheckSourceStructured(src []byte) (nativeCheckResul
 	return res, err
 }
 
-func (c cachedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
+func (c cachedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (api.CheckResult, error) {
 	// Key on the raw source + a stable subset of the import surface.
 	// Hashing the full PackageCheckInput through json.Marshal would
 	// traverse the entire parsed AST — multi-second for the regen
@@ -369,7 +230,7 @@ func (c cachedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckI
 	// falls through to the single-source entry. We pick the package
 	// path explicitly so the subprocess round-trip isn't bypassed.
 	var (
-		res nativeCheckResult
+		res api.CheckResult
 		err error
 	)
 	if pc, ok := c.backing.(nativePackageChecker); ok {
@@ -429,19 +290,19 @@ func packageCheckFingerprint(input selfhost.PackageCheckInput) []byte {
 	return sum[:]
 }
 
-func (c cachedNativeChecker) read(key string) (nativeCheckResult, bool) {
+func (c cachedNativeChecker) read(key string) (api.CheckResult, bool) {
 	data, err := os.ReadFile(filepath.Join(c.dir, key+".json"))
 	if err != nil {
-		return nativeCheckResult{}, false
+		return api.CheckResult{}, false
 	}
-	var res nativeCheckResult
+	var res api.CheckResult
 	if err := json.Unmarshal(data, &res); err != nil {
-		return nativeCheckResult{}, false
+		return api.CheckResult{}, false
 	}
 	return res, true
 }
 
-func (c cachedNativeChecker) write(key string, res nativeCheckResult) {
+func (c cachedNativeChecker) write(key string, res api.CheckResult) {
 	data, err := json.Marshal(res)
 	if err != nil {
 		return
@@ -525,7 +386,7 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		return
 	}
 	var (
-		checked    nativeCheckResult
+		checked    api.CheckResult
 		checkedSrc selfhostCheckedSource
 		err        error
 	)
@@ -590,7 +451,7 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 		return
 	}
 	var (
-		checked nativeCheckResult
+		checked api.CheckResult
 		err     error
 	)
 	input := selfhostPackageCheckInput(pkg, ws, stdlib, src)
@@ -723,7 +584,7 @@ func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, ws *re
 		return
 	}
 	var (
-		checked nativeCheckResult
+		checked api.CheckResult
 		err     error
 	)
 	input := selfhostPackageCheckInput(pkg, ws, stdlib, src)
@@ -758,7 +619,7 @@ type nativeDiagPolicy struct {
 	privileged bool
 }
 
-func nativeCheckerTelemetry(checked nativeCheckResult, policy nativeDiagPolicy) *NativeCheckerTelemetry {
+func nativeCheckerTelemetry(checked api.CheckResult, policy nativeDiagPolicy) *NativeCheckerTelemetry {
 	summary := filteredNativeSummary(checked, policy)
 	if summary.Assignments == 0 && summary.Errors == 0 && len(summary.ErrorsByContext) == 0 {
 		return nil
@@ -794,7 +655,7 @@ func cloneStringIntMap(src map[string]int) map[string]int {
 	return out
 }
 
-func nativeCheckerDiags(src []byte, checked nativeCheckResult, policy nativeDiagPolicy) []*diag.Diagnostic {
+func nativeCheckerDiags(src []byte, checked api.CheckResult, policy nativeDiagPolicy) []*diag.Diagnostic {
 	out := make([]*diag.Diagnostic, 0, len(checked.Diagnostics))
 	for _, d := range checked.Diagnostics {
 		if shouldSuppressNativeDiag(d, policy) {
@@ -826,7 +687,7 @@ func nativeCheckerDiags(src []byte, checked nativeCheckResult, policy nativeDiag
 	return out
 }
 
-func filteredNativeSummary(checked nativeCheckResult, policy nativeDiagPolicy) nativeCheckSummary {
+func filteredNativeSummary(checked api.CheckResult, policy nativeDiagPolicy) api.CheckSummary {
 	summary := checked.Summary
 	if !policy.privileged {
 		return summary
@@ -862,11 +723,11 @@ func filteredNativeSummary(checked nativeCheckResult, policy nativeDiagPolicy) n
 	return summary
 }
 
-func shouldSuppressNativeDiag(d nativeCheckDiagnostic, policy nativeDiagPolicy) bool {
+func shouldSuppressNativeDiag(d api.CheckDiagnosticRecord, policy nativeDiagPolicy) bool {
 	return policy.privileged && d.Code == diag.CodeRuntimePrivilegeViolation
 }
 
-func nativeDiagIsError(d nativeCheckDiagnostic) bool {
+func nativeDiagIsError(d api.CheckDiagnosticRecord) bool {
 	switch strings.ToLower(strings.TrimSpace(d.Severity)) {
 	case "warning", "warn", "lint":
 		return false
@@ -884,7 +745,7 @@ func nativeDiagIsError(d nativeCheckDiagnostic) bool {
 // reported line/column may diverge from the user's file by a fixed
 // offset. Downstream consumers still get the structured code + message
 // + notes, which is what the migrated gates (§19.6 E0773, ...) rely on.
-func convertNativeDiag(src []byte, d nativeCheckDiagnostic) *diag.Diagnostic {
+func convertNativeDiag(src []byte, d api.CheckDiagnosticRecord) *diag.Diagnostic {
 	if d.Code == "" && d.Message == "" {
 		return nil
 	}
@@ -979,7 +840,7 @@ func (idx *selfhostSpanIndex) bindNode(key selfhostNameSpanKey, n ast.Node) {
 	idx.bindings[key] = n
 }
 
-func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked nativeCheckResult) {
+func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked api.CheckResult) {
 	if result == nil {
 		return
 	}

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -12,36 +12,37 @@ import (
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
 )
 
 type fakeNativeChecker struct {
-	result nativeCheckResult
+	result api.CheckResult
 	err    error
 }
 
-func (f fakeNativeChecker) CheckSourceStructured([]byte) (nativeCheckResult, error) {
+func (f fakeNativeChecker) CheckSourceStructured([]byte) (api.CheckResult, error) {
 	return f.result, f.err
 }
 
 type fakeNativePackageChecker struct {
 	t            *testing.T
-	result       nativeCheckResult
+	result       api.CheckResult
 	err          error
 	sourceCalls  int
 	packageCalls int
 	imports      []selfhost.PackageCheckImport
 }
 
-func (f *fakeNativePackageChecker) CheckSourceStructured([]byte) (nativeCheckResult, error) {
+func (f *fakeNativePackageChecker) CheckSourceStructured([]byte) (api.CheckResult, error) {
 	f.sourceCalls++
 	if f.t != nil {
 		f.t.Fatalf("file-mode checker unexpectedly used raw source path")
 	}
-	return nativeCheckResult{}, fmt.Errorf("unexpected raw source path")
+	return api.CheckResult{}, fmt.Errorf("unexpected raw source path")
 }
 
-func (f *fakeNativePackageChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
+func (f *fakeNativePackageChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (api.CheckResult, error) {
 	f.packageCalls++
 	f.imports = append([]selfhost.PackageCheckImport(nil), input.Imports...)
 	return f.result, f.err
@@ -57,9 +58,9 @@ func TestNativeBoundaryPrefersStructuredPackageCheckerForFileMode(t *testing.T) 
 
 	fake := &fakeNativePackageChecker{
 		t: t,
-		result: nativeCheckResult{
-			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
-			Bindings: []nativeCheckedBinding{{
+		result: api.CheckResult{
+			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			Bindings: []api.CheckedBinding{{
 				Name:     "value",
 				TypeName: "UntypedInt",
 				Start:    letStmt.Pattern.Pos().Offset,
@@ -131,19 +132,19 @@ fn main() {
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
-			TypedNodes: []nativeCheckedNode{
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			TypedNodes: []api.CheckedNode{
 				{Kind: "Call", TypeName: "Int", Start: call.Pos().Offset, End: call.End().Offset},
 				{Kind: "IntLit", TypeName: "Int", Start: lit.Pos().Offset, End: lit.End().Offset},
 			},
-			Bindings: []nativeCheckedBinding{
+			Bindings: []api.CheckedBinding{
 				{Name: "answer", TypeName: "Int", Start: letStmt.Pattern.Pos().Offset, End: letStmt.Pattern.End().Offset},
 			},
-			Symbols: []nativeCheckedSymbol{
+			Symbols: []api.CheckedSymbol{
 				{Name: "id", Kind: "fn", TypeName: "fn(T) -> T", Start: idDecl.Pos().Offset, End: idDecl.End().Offset},
 			},
-			Instantiations: []nativeCheckInstantiation{
+			Instantiations: []api.CheckInstantiation{
 				{Callee: "id", TypeArgs: []string{"Int"}, Start: call.Pos().Offset, End: call.End().Offset},
 			},
 		}}, ""
@@ -190,8 +191,8 @@ fn main() {}
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{Assignments: 0, Accepted: 0, Errors: 0},
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{Assignments: 0, Accepted: 0, Errors: 0},
 		}}, ""
 	}
 	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
@@ -236,12 +237,12 @@ fn main() {}
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
-			Bindings: []nativeCheckedBinding{
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			Bindings: []api.CheckedBinding{
 				{Name: "value", TypeName: "Int", Start: param.Pos().Offset, End: param.End().Offset},
 			},
-			Symbols: []nativeCheckedSymbol{
+			Symbols: []api.CheckedSymbol{
 				{Name: "unused", Kind: "fn", TypeName: "fn(Int) -> Int", Start: unusedDecl.Pos().Offset, End: unusedDecl.End().Offset},
 			},
 		}}, ""
@@ -265,7 +266,7 @@ fn main() {}
 }
 
 func TestConvertNativeDiagPreservesFile(t *testing.T) {
-	got := convertNativeDiag([]byte("fn main() {}\n"), nativeCheckDiagnostic{
+	got := convertNativeDiag([]byte("fn main() {}\n"), api.CheckDiagnosticRecord{
 		Code:     diag.CodeIntrinsicNonEmptyBody,
 		Severity: "error",
 		Message:  "`#[intrinsic]` function `violator` must have an empty body",
@@ -290,9 +291,9 @@ pub fn raw_null() -> Int { 0 }
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{},
-			Diagnostics: []nativeCheckDiagnostic{
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{},
+			Diagnostics: []api.CheckDiagnosticRecord{
 				{
 					Code:     diag.CodeIntrinsicNonEmptyBody,
 					Severity: "error",
@@ -326,8 +327,8 @@ pub fn raw_null() -> Int { }
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{
 				Assignments:     1,
 				Accepted:        1,
 				Errors:          1,
@@ -338,7 +339,7 @@ pub fn raw_null() -> Int { }
 					},
 				},
 			},
-			Diagnostics: []nativeCheckDiagnostic{
+			Diagnostics: []api.CheckDiagnosticRecord{
 				{
 					Code:     diag.CodeRuntimePrivilegeViolation,
 					Severity: "error",
@@ -386,9 +387,9 @@ func TestNativeBoundaryOverlaysCanonicalSourceSpansBackToOriginalAST(t *testing.
 
 	oldFactory := nativeCheckerFactory
 	nativeCheckerFactory = func() (nativeChecker, string) {
-		return fakeNativeChecker{result: nativeCheckResult{
-			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
-			TypedNodes: []nativeCheckedNode{
+		return fakeNativeChecker{result: api.CheckResult{
+			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			TypedNodes: []api.CheckedNode{
 				{Kind: "Call", TypeName: "Int", Start: start, End: end},
 			},
 		}}, ""

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -108,73 +108,85 @@ type CheckRequest struct {
 
 // ResolveSummary is the exported Go summary for the bootstrapped Osty
 // resolver.
+//
+// JSON tags mirror the cmd/osty-native-resolver wire format so the
+// struct travels both in-process and across the subprocess edge
+// without a translation layer.
 type ResolveSummary struct {
-	Symbols           int
-	Refs              int
-	TypeRefs          int
-	Diagnostics       int
-	Unresolved        int
-	Duplicates        int
-	SymbolsByKind     map[string]int
-	DiagnosticsByCode map[string]int
+	Symbols           int            `json:"symbols"`
+	Refs              int            `json:"refs"`
+	TypeRefs          int            `json:"typeRefs"`
+	Diagnostics       int            `json:"diagnostics"`
+	Unresolved        int            `json:"unresolved"`
+	Duplicates        int            `json:"duplicates"`
+	SymbolsByKind     map[string]int `json:"symbolsByKind,omitempty"`
+	DiagnosticsByCode map[string]int `json:"diagnosticsByCode,omitempty"`
 }
 
 // ResolvedSymbol records one symbol declared by the self-host resolver.
 type ResolvedSymbol struct {
-	Node     int
-	Name     string
-	Kind     string
-	TypeName string
-	Arity    int
-	Depth    int
-	Start    int
-	End      int
-	Public   bool
-	File     string
+	Node     int    `json:"node"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	TypeName string `json:"typeName"`
+	Arity    int    `json:"arity"`
+	Depth    int    `json:"depth"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Public   bool   `json:"public"`
+	File     string `json:"file,omitempty"`
 }
 
 // ResolvedRef records one value/name reference plus its resolved target span
 // when available.
 type ResolvedRef struct {
-	Name        string
-	Node        int
-	Start       int
-	End         int
-	File        string
-	TargetNode  int
-	TargetStart int
-	TargetEnd   int
-	TargetFile  string
+	Name        string `json:"name"`
+	Node        int    `json:"node"`
+	Start       int    `json:"start"`
+	End         int    `json:"end"`
+	File        string `json:"file,omitempty"`
+	TargetNode  int    `json:"targetNode"`
+	TargetStart int    `json:"targetStart"`
+	TargetEnd   int    `json:"targetEnd"`
+	TargetFile  string `json:"targetFile,omitempty"`
 }
 
 // ResolvedTypeRef records one resolved type-name reference.
 type ResolvedTypeRef struct {
-	Name  string
-	Node  int
-	Start int
-	End   int
-	File  string
+	Name  string `json:"name"`
+	Node  int    `json:"node"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+	File  string `json:"file,omitempty"`
 }
 
 // ResolveDiagnosticRecord is one structured diagnostic produced by the
 // self-host resolver.
 type ResolveDiagnosticRecord struct {
-	Code    string
-	Message string
-	Name    string
-	Hint    string
-	Node    int
-	Start   int
-	End     int
-	File    string
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Name    string `json:"name,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+	Node    int    `json:"node"`
+	Start   int    `json:"start"`
+	End     int    `json:"end"`
+	File    string `json:"file,omitempty"`
 }
 
 // ResolveResult is the structured Go-facing surface for the bootstrapped
 // resolver.
 type ResolveResult struct {
-	Summary     ResolveSummary
-	Symbols     []ResolvedSymbol
-	Refs        []ResolvedRef
-	TypeRefs    []ResolvedTypeRef
-	Diagnostics []ResolveDiagnosticRecord
+	Summary     ResolveSummary            `json:"summary"`
+	Symbols     []ResolvedSymbol          `json:"symbols"`
+	Refs        []ResolvedRef             `json:"refs"`
+	TypeRefs    []ResolvedTypeRef         `json:"typeRefs"`
+	Diagnostics []ResolveDiagnosticRecord `json:"diagnostics,omitempty"`
+}
+
+// ResolveRequest is the wire shape consumed by the
+// cmd/osty-native-resolver subprocess entry point. Exactly one of
+// Source / Package should be set.
+type ResolveRequest struct {
+	Source  string               `json:"source,omitempty"`
+	Package *PackageResolveInput `json:"package,omitempty"`
 }

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -12,59 +12,63 @@ package api
 // The self-hosted checker is authoritative for mainstream checker diagnostics
 // and supplies structured expression, binding, declaration-symbol, and
 // instantiation facts to the Go check.Result bridge.
+//
+// JSON tags mirror the wire contract used by cmd/osty-native-checker and
+// internal/check's host-boundary exec path so the same struct can travel
+// both in-process and across the subprocess edge.
 type CheckSummary struct {
-	Assignments int
-	Accepted    int
-	Errors      int
+	Assignments int `json:"assignments"`
+	Accepted    int `json:"accepted"`
+	Errors      int `json:"errors"`
 	// ErrorsByContext buckets error-severity diagnostics by the native
 	// checker's stable bucket key. For the typed checker this is usually
 	// the diagnostic code (for example E0700); consumed by
 	// `osty check --dump-native-diags`.
-	ErrorsByContext map[string]int
+	ErrorsByContext map[string]int `json:"errorsByContext,omitempty"`
 	// ErrorDetails optionally holds a second-level split under a given
 	// bucket. For the typed checker this is the rendered diagnostic
 	// message histogram underneath a code bucket.
-	ErrorDetails map[string]map[string]int
+	ErrorDetails map[string]map[string]int `json:"errorDetails,omitempty"`
 }
 
 // CheckedNode records a checked expression node and its inferred type name.
 type CheckedNode struct {
-	Node     int
-	Kind     string
-	TypeName string
-	Start    int
-	End      int
+	Node     int    `json:"node"`
+	Kind     string `json:"kind"`
+	TypeName string `json:"typeName"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
 }
 
 // CheckedBinding records a local binding that the bootstrapped checker typed.
 type CheckedBinding struct {
-	Node     int
-	Name     string
-	TypeName string
-	Mutable  bool
-	Start    int
-	End      int
+	Node     int    `json:"node"`
+	Name     string `json:"name"`
+	TypeName string `json:"typeName"`
+	Mutable  bool   `json:"mutable"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
 }
 
 // CheckedSymbol records a declaration collected by the bootstrapped checker.
 type CheckedSymbol struct {
-	Node     int
-	Kind     string
-	Name     string
-	Owner    string
-	TypeName string
-	Start    int
-	End      int
+	Node     int    `json:"node"`
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Owner    string `json:"owner"`
+	TypeName string `json:"typeName"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
 }
 
 // CheckInstantiation records a generic function or method instantiation.
 type CheckInstantiation struct {
-	Node       int
-	Callee     string
-	TypeArgs   []string
-	ResultType string
-	Start      int
-	End        int
+	Node       int      `json:"node"`
+	Callee     string   `json:"callee"`
+	TypeArgs   []string `json:"typeArgs"`
+	ResultType string   `json:"resultType"`
+	Start      int      `json:"start"`
+	End        int      `json:"end"`
 }
 
 // CheckDiagnosticRecord is a structured diagnostic produced by the
@@ -74,23 +78,32 @@ type CheckInstantiation struct {
 // channel. Start/End are token indices; the Go bridge converts to byte
 // offsets via the lex stream.
 type CheckDiagnosticRecord struct {
-	Code     string
-	Severity string
-	Message  string
-	Start    int
-	End      int
-	File     string
-	Notes    []string
+	Code     string   `json:"code"`
+	Severity string   `json:"severity"`
+	Message  string   `json:"message"`
+	Start    int      `json:"start"`
+	End      int      `json:"end"`
+	File     string   `json:"file,omitempty"`
+	Notes    []string `json:"notes,omitempty"`
 }
 
 // CheckResult is the structured Go-facing surface for the bootstrapped checker.
 type CheckResult struct {
-	Summary        CheckSummary
-	TypedNodes     []CheckedNode
-	Bindings       []CheckedBinding
-	Symbols        []CheckedSymbol
-	Instantiations []CheckInstantiation
-	Diagnostics    []CheckDiagnosticRecord
+	Summary        CheckSummary          `json:"summary"`
+	TypedNodes     []CheckedNode         `json:"typedNodes"`
+	Bindings       []CheckedBinding      `json:"bindings"`
+	Symbols        []CheckedSymbol       `json:"symbols"`
+	Instantiations []CheckInstantiation  `json:"instantiations"`
+	Diagnostics    []CheckDiagnosticRecord `json:"diagnostics,omitempty"`
+}
+
+// CheckRequest is the wire shape consumed by the cmd/osty-native-checker
+// subprocess entry point. Exactly one of Source / Package should be set.
+// Included in api so host callers and the native-checker binary share the
+// same struct declaration.
+type CheckRequest struct {
+	Source  string             `json:"source,omitempty"`
+	Package *PackageCheckInput `json:"package,omitempty"`
 }
 
 // ResolveSummary is the exported Go summary for the bootstrapped Osty


### PR DESCRIPTION
## Summary

Mirror of #774's check-side consolidation for the resolver binary. \`cmd/osty-native-resolver\` declared its own \`resolveRequest\` / \`resolveResponse\` plus per-record structs (\`resolveSummary\`, \`resolvedSymbol\`, \`resolvedRef\`, ...) that were shape-identical to \`selfhost.ResolveResult\` and friends. Add JSON tags to the api resolve types, introduce \`api.ResolveRequest\`, and have the binary serialize \`api.ResolveResult\` directly — dropping the field-by-field response copy.

Net: **-188 / +67 lines**.

## Changes

- **\`internal/selfhost/api/types.go\`**: add JSON tags to \`ResolveSummary\`, \`ResolvedSymbol\`, \`ResolvedRef\`, \`ResolvedTypeRef\`, \`ResolveDiagnosticRecord\`, \`ResolveResult\` matching the existing wire format. New \`api.ResolveRequest { Source, *PackageResolveInput }\`.
- **\`cmd/osty-native-resolver/main.go\`**: drop the local \`resolveSummary\` / \`resolved*\` / \`resolveDiagnostic\` / \`resolveResponse\` declarations and the response copy loop. \`json.Encoder\` handles \`api.ResolveResult\` directly via tags.
- **\`cmd/osty-native-resolver/main_test.go\`**: mechanical rename to \`api.ResolveResult\` / \`api.ResolveRequest\`.

## Why

Same rationale as #774: the shapes were already aligned by convention; only the local type declarations differed. Removing them reduces duplication that had to be hand-synced and gives the resolver subprocess an explicit shared contract. No host-side \`nativeResolveResult\` equivalent existed (the exec path was only on the check side), so this PR is scoped to the binary.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./cmd/osty-native-resolver/ -count=1\`
- [x] \`go test ./internal/selfhost/... -count=1 -short\`
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)