### PR TITLE
fix(check): route FrontQQ through elabCoalesce + accept TkOptional

### DIFF
--- a/internal/backend/llvm_closure_coalesce_test.go
+++ b/internal/backend/llvm_closure_coalesce_test.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsClosureCoalesceInferredReturn covers the
+// canonical `map.update(k, |n| (n ?? 0) + 1)` pattern from
+// CLAUDE.md §B.9.1 which was silently blocked at the native checker:
+//
+//   - `tokenToBinOp(FrontQQ)` returned `BoInvalid` (no matching variant)
+//   - `binOpIsCoalesce(BoInvalid)` returned false (stub)
+//   - `elabInferBinary` fell into the default path with `op=BoInvalid`
+//   - `binOpResultType(BoInvalid, ...)` returned `tErr`
+//   - Closure inferred return type became `<error>`, tripping LLVM011
+//     "function return type: type `<error>`" at backend emit
+//
+// The fix routes `FrontQQ` directly to `elabCoalesce` regardless of
+// `tokenToBinOp` (which has no BinOp variant for `?? `), and
+// `elabCoalesce` now also accepts `TkOptional` receivers (the shape
+// `|n: Int?|` produces) in addition to the `TkNamed "Option"` shape.
+func TestLLVMBackendBinaryRunsClosureCoalesceInferredReturn(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let f = |n: Int?| n ?? 0
+    println(f(Some(5)))
+    println(f(None))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "5\n0\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsMapUpdateCanonicalPattern exercises the
+// CLAUDE.md §B.9.1 canonical counting pattern end-to-end:
+//
+//	counts.update(word, |n: Int?| (n ?? 0) + 1)
+//
+// This needs the closure return type to infer through `(n ?? 0) + 1`
+// as `Int` — the same coalesce-in-closure-body fix the previous test
+// covers, but additionally driving Map.update's closure-taking
+// combinator path all the way through monomorph + codegen.
+func TestLLVMBackendBinaryRunsMapUpdateCanonicalPattern(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut counts: Map<String, Int> = {:}
+    for word in ["the", "quick", "brown", "fox", "the", "quick"] {
+        counts.update(word, |n: Int?| (n ?? 0) + 1)
+    }
+    println(counts.len())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "4\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -38099,6 +38099,12 @@ func unOpBitNot(env *CheckEnv, inner int, start int, end int) int {
 
 // Osty: /tmp/selfhost_merged.osty:17949:1
 func elabInferBinary(cx *ElabCx, node *AstNode) *ElabResult {
+	// `??` is a binary-shaped AST node but has Option-specific inference
+	// rules — detect it directly off the source token before
+	// tokenToBinOp collapses it to BoInvalid (no matching BinOp variant).
+	if _, ok := node.op.(*FrontTokenKind_FrontQQ); ok {
+		return elabCoalesce(cx, node)
+	}
 	// Osty: /tmp/selfhost_merged.osty:17950:5
 	op := tokenToBinOp(node.op)
 	_ = op
@@ -38353,22 +38359,21 @@ func elabCoalesce(cx *ElabCx, node *AstNode) *ElabResult {
 	tys := cx.env.tys
 	_ = tys
 	// Osty: /tmp/selfhost_merged.osty:18079:5
+	// `T?` surface syntax lowers to TkOptional; `Option<T>` qualified
+	// form lowers to TkNamed. Both are the same type per §7 spec.
+	inner := -1
 	if tyIsNamedHead(tys, leftTy, "Option") {
-		// Osty: /tmp/selfhost_merged.osty:18080:9
-		inner := func() int {
-			if checkIntListLenHelper(tyArgsAt(tys, leftTy)) > 0 {
-				return tyArgsAt(tys, leftTy)[0]
-			} else {
-				return tErr(tys)
-			}
-		}()
-		_ = inner
-		// Osty: /tmp/selfhost_merged.osty:18085:9
+		if checkIntListLenHelper(tyArgsAt(tys, leftTy)) > 0 {
+			inner = tyArgsAt(tys, leftTy)[0]
+		} else {
+			inner = tErr(tys)
+		}
+	} else if _, ok := tyKindAt(tys, leftTy).(*TyKind_TkOptional); ok {
+		inner = tyInnerAt(tys, leftTy)
+	}
+	if inner >= 0 {
 		_ = checkExpectAssignable(cx.env, inner, right.ty, node.start, node.end)
-		// Osty: /tmp/selfhost_merged.osty:18086:9
 		coreIdx := coreCoalesce(cx.core, left.node, right.node, inner, node.start, node.end)
-		_ = coreIdx
-		// Osty: /tmp/selfhost_merged.osty:18087:9
 		return &ElabResult{node: coreIdx, ty: inner}
 	}
 	// Osty: /tmp/selfhost_merged.osty:18089:5

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -438,6 +438,16 @@ fn unOpBitNot(env: CheckEnv, inner: Int, start: Int, end: Int) -> Int {
 // ---------------------------------------------------------------------
 
 fn elabInferBinary(cx: ElabCx, node: AstNode) -> ElabResult {
+    // `??` is a binary-shaped AST node but has Option-specific
+    // inference rules — detect it directly off the source token
+    // before tokenToBinOp collapses it to BoInvalid (there is no
+    // matching BinOp variant). Without this early route the coalesce
+    // falls through to `binOpResultType(op=BoInvalid, ...)` which
+    // returns tErr, poisoning any closure body that uses `?? `
+    // (e.g. `|n: Int?| n ?? 0` became `fn(Int?) -> <error>`).
+    if node.op == FrontQQ {
+        return elabCoalesce(cx, node)
+    }
     let op = tokenToBinOp(node.op)
     // `??` has special checking for Option unwrap.
     if binOpIsCoalesce(op) {
@@ -567,12 +577,22 @@ fn elabCoalesce(cx: ElabCx, node: AstNode) -> ElabResult {
     let right = elabInfer(cx, node.right)
     let leftTy = checkResolveAliasDeep(cx.env, left.ty)
     let tys = cx.env.tys
+    // `T?` surface syntax lowers to TkOptional; `Option<T>` qualified
+    // form lowers to TkNamed. Both are the same type per §7 spec, so
+    // accept either representation — closure params use `|n: Int?|`
+    // which went through astTypeToTy → tyOptional, never reaching the
+    // TkNamed branch.
+    let mut inner = -1
     if tyIsNamedHead(tys, leftTy, "Option") {
-        let inner = if checkIntListLenHelper(tyArgsAt(tys, leftTy)) > 0 {
+        inner = if checkIntListLenHelper(tyArgsAt(tys, leftTy)) > 0 {
             tyArgsAt(tys, leftTy)[0]
         } else {
             tErr(tys)
         }
+    } else if tyKindAt(tys, leftTy) == TkOptional {
+        inner = tyInnerAt(tys, leftTy)
+    }
+    if inner >= 0 {
         let _ = checkExpectAssignable(cx.env, inner, right.ty, node.start, node.end)
         let coreIdx = coreCoalesce(cx.core, left.node, right.node, inner, node.start, node.end)
         return ElabResult { node: coreIdx, ty: inner }


### PR DESCRIPTION
## Summary

- `|n: Int?| n ?? 0` inferred return type `<error>`, tripping LLVM011 "function return type: type \`<error>\`" at backend emit
- CLAUDE.md §B.9.1's canonical `counts.update(word, |n: Int?| (n ?? 0) + 1)` pattern was blocked end-to-end — every user program following the canonical docs hit it
- Two-line root cause: `tokenToBinOp(FrontQQ) = BoInvalid` + `binOpIsCoalesce` stub always returns false, so `?? ` fell through to the default binary path and returned `tErr`

## Repro (pre-fix)

```osty
fn main() {
    let f = |n: Int?| n ?? 0   // closure return type inferred as <error>
    println(f(Some(5)))
}
```

Pre-fix: `osty run` prints the LLVM skeleton with
```
; unsupported: LLVM011 type-system: function "__osty_closure_1" return type: type "<error>"
```

Post-fix: prints `5`.

The `let x: Int? = Some(5); println(x ?? 0)` form worked through a different Go-side `check.File` code path — which masked the native-checker gap and made the closure failure look like a closure-specific bug when it was really a token-dispatch gap.

## Root cause

[toolchain/elab.osty:441-444](toolchain/elab.osty:441) `elabInferBinary`:

```osty
let op = tokenToBinOp(node.op)         // FrontQQ → BoInvalid
if binOpIsCoalesce(op) {               // stub: always false
    return elabCoalesce(cx, node)
}
// falls through to binOpResultType(op=BoInvalid, ...) → tErr
```

`tokenToBinOp` has no case for `FrontQQ` (no matching BinOp enum variant), and `binOpIsCoalesce` is stubbed `_ -> false` with a "placeholder that will fire in Phase 7 once the AST carries a distinct token" comment. So the elabCoalesce branch is unreachable.

Additional issue: `elabCoalesce` only accepted `TkNamed "Option"` receivers, but `|n: Int?|` produces `TkOptional` (via `astTypeToTy → tyOptional`). These are the same type per §7 but needed an explicit kind branch.

## Fix

Two minimal changes in [toolchain/elab.osty](toolchain/elab.osty):

1. `elabInferBinary`: early-return on `node.op == FrontQQ` before `tokenToBinOp`. Keeps the `binOpIsCoalesce` stub's "phase 7" story intact; we just stop depending on it.
2. `elabCoalesce`: accept `TkOptional` kind as equivalent to `TkNamed "Option"`.

generated.go patched in place (consistent with PR #746 / #748 / #766).

## Test plan

- [x] `TestLLVMBackendBinaryRunsClosureCoalesceInferredReturn` — `|n: Int?| n ?? 0` infers `fn(Int?) -> Int`. Pre-fix: LLVM skeleton with `<error>` return type.
- [x] `TestLLVMBackendBinaryRunsMapUpdateCanonicalPattern` — `Map.update(word, |n: Int?| (n ?? 0) + 1)` runs end-to-end over 6 words and returns the 4 unique-key count.
- [x] `just front` — 7 of 8 packages green; `internal/check` build failure is pre-existing on main (unrelated `runIntrinsicBodyChecks` undefined symbol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)