### PR TITLE
fix(mir): recover ErrType for let _, for-in elem, and unary expr

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -796,6 +796,21 @@ func isPoisonType(t Type) bool {
 }
 
 func (bs *bodyState) lowerLetPattern(pat ir.Pattern, value ir.Expr, valueType Type, sp Span) {
+	// Wildcard-only binding has nothing to store, so skip the scratch
+	// local and evaluate `value` for side effects — otherwise a
+	// `let _ = x` with a poisoned `x.Type()` materialises an ErrType
+	// scratch that survives into MIR.
+	if _, ok := pat.(*ir.WildPat); ok {
+		if value != nil {
+			_ = bs.lowerExprAsOperand(value)
+		}
+		return
+	}
+	if isPoisonType(valueType) && value != nil {
+		if rt := bs.recoverOperandType(value); rt != nil && !isPoisonType(rt) {
+			valueType = rt
+		}
+	}
 	scratch := bs.newLocal("_scratch", valueType, false, sp)
 	bs.emit(&StorageLiveInstr{Local: scratch, SpanV: sp})
 	if value != nil {
@@ -1358,8 +1373,13 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		return
 	}
 	elemT := listElementType(iterT)
-	if elemT == nil {
-		elemT = ir.ErrTypeVal
+	if elemT == nil || isPoisonType(elemT) {
+		// List<?> with a poisoned element type would propagate ErrType
+		// to the `_elem` copy and surface as `unsupported local type
+		// <error>` downstream. Drop the for-in, same as the
+		// non-List/Channel fallback above.
+		bs.l.noteIssue("for-in over List with unresolved element type is not lowered to MIR yet")
+		return
 	}
 	// capture iterable into a temp so we can re-read length and index
 	iter := bs.newLocal("_iter", iterT, false, f.SpanV)
@@ -2152,6 +2172,28 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 			if _, ok := bs.l.structs[x.TypeName]; ok {
 				return &ir.NamedType{Name: x.TypeName}
 			}
+		}
+	case *ir.UnaryExpr:
+		// `!x` is Bool unconditionally; `-x` / `+x` / `~x` propagate
+		// the operand's type, falling back to numeric-literal defaults
+		// when the operand itself lost its annotation.
+		if x.Op == ir.UnNot {
+			return ir.TBool
+		}
+		if x.X == nil {
+			return nil
+		}
+		if ot := x.X.Type(); ot != nil && ot != ir.ErrTypeVal {
+			return ot
+		}
+		if rt := bs.recoverOperandType(x.X); rt != nil && rt != ir.ErrTypeVal {
+			return rt
+		}
+		switch x.X.(type) {
+		case *ir.IntLit:
+			return ir.TInt
+		case *ir.FloatLit:
+			return ir.TFloat64
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Three MIR-lowering recovery paths that unblock the merged native-toolchain probe (`TestProbeNativeToolchainMergedMIR`) when the checker bails out and leaves ErrType on expression nodes:

- **`lowerLetPattern`**: short-circuit wildcard bindings (no scratch local materialised), and recover the scratch type via `recoverOperandType(value)` when the incoming `valueType` is poisoned.
- **`lowerForIn`**: drop the for-in entirely when the list element type resolves to `nil` / `ErrType`, matching the existing non-List/Channel fallback above. Avoids emitting an `_elem` copy whose Dest has `ErrType`.
- **`recoverOperandType`**: new `*ir.UnaryExpr` case — `Bool` for `!x`, propagate the operand's type for `-x` / `+x` / `~x`, fall back to `Int` / `Float64` for bare numeric-literal operands.

## Impact

Probe wall advances past three stops:
- `collectDecls` `_scratch id=34` (wildcard pattern bypass)
- `registerStdStringsAliasFns` `UnaryRV(op=1, T=<error>)` at `receiverTy: -1` (UnaryExpr case)
- `registerStdFsAliasFns` `_elem id=42` (for-in elem skip)

Now blocked on `collectFnDecl` `rawName id=24` — separate follow-up PR.

ErrType local count on the merged probe: **3211 → 2279** (−932, 29% reduction).

## Test plan

- [x] `go test ./internal/mir/` — passes
- [x] `go test ./internal/ir/` — passes
- [x] `go test ./internal/llvmgen/ -run TestProbeNativeToolchainMergedMIR` — passes, new wall reported
- [x] No new regressions in `./internal/llvmgen/` (8 pre-existing failures on main unchanged)
- [x] `TestNativeToolchainMergedMIRErrTypeFloor` count drops from 3211 → 2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)