### PR TITLE
[codex] fix native-owned llvm parity

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4797,7 +4797,6 @@ const char *osty_rt_byte_to_string(int8_t value) {
 
 const char *osty_rt_float_to_string(double value) {
     char buffer[64];
-    int precision;
 
     if (isnan(value)) {
         return osty_rt_string_dup_site("NaN", 3, "runtime.float.to_string");
@@ -4809,18 +4808,8 @@ const char *osty_rt_float_to_string(double value) {
         return osty_rt_string_dup_site("+Inf", 4, "runtime.float.to_string");
     }
 
-    buffer[0] = '\0';
-    for (precision = 1; precision <= 17; precision++) {
-        char *end = NULL;
-        double parsed;
-
-        if (snprintf(buffer, sizeof(buffer), "%.*g", precision, value) < 0) {
-            osty_rt_abort("failed to format Float as String");
-        }
-        parsed = strtod(buffer, &end);
-        if (end != NULL && *end == '\0' && osty_rt_f64_same_bits(parsed, value)) {
-            break;
-        }
+    if (snprintf(buffer, sizeof(buffer), "%.6f", value) < 0) {
+        osty_rt_abort("failed to format Float as String");
     }
     return osty_rt_string_dup_site(buffer, strlen(buffer), "runtime.float.to_string");
 }

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -308,7 +308,6 @@ func tryNativeOwnedModule(mod *ostyir.Module, opts Options) ([]byte, bool, error
 	}
 	out := []byte(llvmNativeEmitModule(nativeMod))
 	out = withDataLayout(out, nativeMod.target)
-	out = appendNativeInterfaceSurface(out, mod, nativeMod)
 	out = appendNativeClosureThunks(out, nativeMod.projectionCtx)
 	return out, true, nil
 }
@@ -533,6 +532,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	out.needsMapRuntime = ctx.needsMapRT
 	out.needsSetRuntime = ctx.needsSetRT
 	out.needsStringRuntime = ctx.needsStringRT
+	out.interfaceImpls = collectNativeInterfaceImpls(mod)
 	out.projectionCtx = ctx
 	out.extraRuntimeDecls = append(out.extraRuntimeDecls, ctx.runtimeDecls...)
 	return out, true
@@ -2822,6 +2822,15 @@ func nativeConstFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (nativeConstV
 				return nativeConstValue{llvmType: "i1", init: strconv.FormatBool(value.init != "true")}, true
 			}
 			return nativeConstValue{}, false
+		case "~":
+			if value.llvmType != "i64" {
+				return nativeConstValue{}, false
+			}
+			n, err := strconv.ParseInt(value.init, 10, 64)
+			if err != nil {
+				return nativeConstValue{}, false
+			}
+			return nativeConstValue{llvmType: "i64", init: strconv.FormatInt(^n, 10)}, true
 		default:
 			return nativeConstValue{}, false
 		}
@@ -5474,6 +5483,8 @@ func nativeUnaryOpString(op ostyir.UnOp) string {
 		return "+"
 	case ostyir.UnNot:
 		return "!"
+	case ostyir.UnBitNot:
+		return "~"
 	default:
 		return ""
 	}

--- a/internal/llvmgen/ir_native_interface_test.go
+++ b/internal/llvmgen/ir_native_interface_test.go
@@ -142,7 +142,7 @@ fn main() {
 		"@osty.vtable.Vec__Sized",
 		"alloca %Vec",
 		"store %Vec",
-		"insertvalue %osty.iface undef, ptr",
+		"insertvalue %osty.iface zeroinitializer, ptr",
 		"insertvalue %osty.iface",
 		"ptr @osty.vtable.Vec__Sized, 1",
 		"extractvalue %osty.iface",
@@ -151,6 +151,33 @@ fn main() {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTryGenerateNativeOwnedModuleCoversBitwiseUnaryNot(t *testing.T) {
+	src := `fn main() {
+    println(~-43)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_bitnot.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for bitwise unary not")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"xor i64",
+		"-1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned bitwise-not IR missing %q:\n%s", want, got)
 		}
 	}
 }

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -203,6 +203,7 @@ type llvmNativeModule struct {
 	globals            []*llvmNativeGlobal
 	structs            []*llvmNativeStruct
 	enums              []*llvmNativeEnum
+	interfaceImpls     []nativeInterfaceImpl
 	stringGlobals      []*LlvmStringGlobal
 	functions          []*llvmNativeFunction
 	needsListRuntime   bool
@@ -234,12 +235,15 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 	if mod == nil {
 		return llvmRenderModule("", "", nil)
 	}
-	typeDefs := make([]string, 0, len(mod.structs))
+	typeDefs := make([]string, 0, len(mod.structs)+1)
 	definitions := make([]string, 0, len(mod.globals)+len(mod.functions))
 	stringGlobals := append([]*LlvmStringGlobal(nil), mod.stringGlobals...)
 	nextStringID := len(stringGlobals)
 	loopMDDefs := make([]string, 0, len(mod.functions))
 	nextLoopMD := 0
+	if len(mod.interfaceImpls) != 0 {
+		typeDefs = append(typeDefs, "%osty.iface = type { ptr, ptr }")
+	}
 	for _, st := range mod.structs {
 		if st == nil {
 			continue
@@ -266,6 +270,11 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 		}
 		definitions = append(definitions, global.irName+" = internal "+kind+" "+global.llvmType+" "+global.init)
 	}
+	for _, impl := range mod.interfaceImpls {
+		if ir := strings.TrimSpace(string(emitNativeInterfaceVtable(impl))); ir != "" {
+			definitions = append(definitions, ir)
+		}
+	}
 	for _, fn := range mod.functions {
 		rendered := llvmNativeEmitFunction(fn, mod.globals, nextStringID, nextLoopMD)
 		nextStringID = rendered.nextStringID
@@ -273,6 +282,13 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 		definitions = append(definitions, rendered.definition)
 		stringGlobals = append(stringGlobals, rendered.stringGlobals...)
 		loopMDDefs = append(loopMDDefs, rendered.loopMDDefs...)
+	}
+	for _, impl := range mod.interfaceImpls {
+		for _, method := range impl.methods {
+			if ir := strings.TrimSpace(string(emitNativeInterfaceShim(impl, method))); ir != "" {
+				definitions = append(definitions, ir)
+			}
+		}
 	}
 	definitions = append(definitions, loopMDDefs...)
 	return llvmRenderModuleWithRuntimeDeclarations(
@@ -1132,7 +1148,7 @@ func llvmNativeEvalExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
 //
 //	<slot> = alloca %<S>
 //	store %<S> <concrete>, ptr <slot>
-//	<t1> = insertvalue %osty.iface undef, ptr <slot>, 0
+//	<t1> = insertvalue %osty.iface zeroinitializer, ptr <slot>, 0
 //	<t2> = insertvalue %osty.iface <t1>, ptr <vtable_sym>, 1
 //
 // and returns a value pointing at %osty.iface. `expr.name` carries
@@ -1145,7 +1161,7 @@ func llvmNativeEvalInterfaceBox(emitter *LlvmEmitter, expr *llvmNativeExpr) *Llv
 	concrete := llvmNativeEvalExpr(emitter, expr.childExprs[0])
 	slot := llvmSpillToSlot(emitter, concrete)
 	step1 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface undef, ptr %s, 0", step1, slot.name))
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface zeroinitializer, ptr %s, 0", step1, slot.name))
 	step2 := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface %s, ptr %s, 1", step2, step1, expr.name))
 	return &LlvmValue{typ: "%osty.iface", name: step2}
@@ -1423,6 +1439,8 @@ func llvmNativeEvalUnary(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue 
 		return value
 	case "!":
 		return llvmNotI1(emitter, value)
+	case "~":
+		return llvmBinaryI64(emitter, "xor", value, llvmIntLiteral(-1))
 	default:
 		if expr.llvmType == "double" {
 			return llvmBinaryF64(emitter, llvmFloatBinaryInstruction("-"), llvmNativeZeroValue("double"), value)

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -515,7 +515,7 @@ func (g *generator) boxInterfaceValue(ifaceType ast.Type, v value) (value, error
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, v.typ))
 	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", v.typ, v.ref, slot))
 	step1 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface undef, ptr %s, 0", step1, slot))
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface zeroinitializer, ptr %s, 0", step1, slot))
 	step2 := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface %s, ptr %s, 1", step2, step1, vtableSym))
 	g.takeOstyEmitter(emitter)


### PR DESCRIPTION
## Summary
- fix native-owned interface boxing so `%osty.iface` is emitted as a proper module-level surface and boxed values use a valid aggregate initializer
- restore native unary bitwise-not lowering and constant handling so `~x` no longer regresses to unary minus in the new path
- align runtime float stringification with the backend's expected fixed six-decimal display format
- add/update native-owned regression tests covering interface boxing and bitwise-not

## Why
The native-owned path was close, but not yet parity-complete:
- interface boxing emitted invalid LLVM IR and failed at clang time
- native unary `~` was being lowered as `-x`
- float printing still diverged from existing backend output expectations

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestTryGenerateNativeOwnedModuleCoversInterfaceBoxingDispatch|TestTryGenerateNativeOwnedModuleCoversBitwiseUnaryNot|TestGenerateBitwiseIntOps|TestGenerateModuleInterfaceBoxingDispatch|TestGenerateModuleInterfaceDispatchWithArgs'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsInterfaceBoxingDispatch|TestLLVMBackendBinaryRunsBitwiseIntOps|TestLLVMBackendBinaryExtendedListSortedAndToSet|TestLLVMBackendBinaryPtrBackedListToSetAndBoolPrint'`