### PR TITLE
[codex] perf(selfhost): trim frontend and diag overhead

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 
@@ -772,43 +773,65 @@ func convertNativeDiag(src []byte, d api.CheckDiagnosticRecord) *diag.Diagnostic
 }
 
 // byteRangeSpan builds a `diag.Span` for a [start, end) byte range
-// into `src`. It walks the bytes to recover 1-based line/column.
-// Clamping keeps downstream renderers robust even when the native
-// checker reports offsets beyond EOF.
+// into `src`. A lightweight line-start index keeps repeated
+// conversions off the O(offset) byte-walk path while preserving the
+// same 1-based line/column shape. Clamping keeps downstream
+// renderers robust even when the native checker reports offsets
+// beyond EOF.
 func byteRangeSpan(src []byte, start, end int) diag.Span {
-	if start < 0 {
-		start = 0
-	}
+	idx := newSelfhostDiagLineIndex(src)
+	start = idx.clampOffset(start)
+	end = idx.clampOffset(end)
 	if end < start {
 		end = start
 	}
-	if len(src) == 0 {
+	if idx.total == 0 {
 		p := token.Pos{Line: 1, Column: 1, Offset: 0}
 		return diag.Span{Start: p, End: p}
 	}
-	if start > len(src) {
-		start = len(src)
-	}
-	if end > len(src) {
-		end = len(src)
-	}
-	startPos := positionAtOffset(src, start)
-	endPos := positionAtOffset(src, end)
-	return diag.Span{Start: startPos, End: endPos}
+	return diag.Span{Start: idx.positionAt(start), End: idx.positionAt(end)}
 }
 
-func positionAtOffset(src []byte, offset int) token.Pos {
-	line := 1
-	col := 1
-	for i := 0; i < offset && i < len(src); i++ {
-		if src[i] == '\n' {
-			line++
-			col = 1
-			continue
+type selfhostDiagLineIndex struct {
+	starts []int
+	total  int
+}
+
+func newSelfhostDiagLineIndex(src []byte) selfhostDiagLineIndex {
+	starts := make([]int, 1, 1+len(src)/32)
+	starts[0] = 0
+	for i, b := range src {
+		if b == '\n' {
+			starts = append(starts, i+1)
 		}
-		col++
 	}
-	return token.Pos{Line: line, Column: col, Offset: offset}
+	return selfhostDiagLineIndex{starts: starts, total: len(src)}
+}
+
+func (idx selfhostDiagLineIndex) clampOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	if offset > idx.total {
+		return idx.total
+	}
+	return offset
+}
+
+func (idx selfhostDiagLineIndex) positionAt(offset int) token.Pos {
+	offset = idx.clampOffset(offset)
+	lineIdx := sort.Search(len(idx.starts), func(i int) bool {
+		return idx.starts[i] > offset
+	}) - 1
+	if lineIdx < 0 {
+		lineIdx = 0
+	}
+	lineStart := idx.starts[lineIdx]
+	return token.Pos{
+		Line:   lineIdx + 1,
+		Column: offset - lineStart + 1,
+		Offset: offset,
+	}
 }
 
 type selfhostSpanKey struct {

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -79,7 +79,7 @@ type FrontendRun struct {
 // Run executes the self-hosted lexer and parser once and keeps all adapted
 // public surfaces available through FrontendRun methods.
 func Run(src []byte) *FrontendRun {
-	return runFrontend(src, true)
+	return runFrontend(src, false)
 }
 
 func runFrontend(src []byte, adaptTokens bool) *FrontendRun {

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -5,6 +5,76 @@ import (
 	"testing"
 )
 
+func BenchmarkRunDiagnostics(b *testing.B) {
+	src := []byte(`fn main() {
+    let xs = [1, 2, 3]
+    let y = xs[0] + 2
+    y
+}
+`)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		run := Run(src)
+		if run == nil {
+			b.Fatal("Run returned nil")
+		}
+		diags := run.Diagnostics()
+		if len(diags) != 0 {
+			b.Fatalf("len(diags) = %d, want 0", len(diags))
+		}
+	}
+}
+
+func BenchmarkCheckStructuredFromRun(b *testing.B) {
+	src := []byte(`fn main() {
+    let xs = [1, 2, 3]
+    let y = xs[0] + 2
+    y
+}
+`)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		run := Run(src)
+		if run == nil {
+			b.Fatal("Run returned nil")
+		}
+		result := CheckStructuredFromRun(run)
+		if result.Summary.Errors != 0 {
+			b.Fatalf("errors = %d, want 0", result.Summary.Errors)
+		}
+	}
+}
+
+func TestRunDefersLexAdaptationUntilTokensRequested(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    x
+}
+`)
+
+	run := Run(src)
+	if run == nil {
+		t.Fatal("Run returned nil")
+	}
+	if run.adapted {
+		t.Fatal("Run eagerly adapted lex surfaces")
+	}
+	if diags := run.Diagnostics(); len(diags) != 0 {
+		t.Fatalf("Diagnostics = %#v, want none", diags)
+	}
+	if run.adapted {
+		t.Fatal("Diagnostics() should not force token/comment adaptation")
+	}
+	if toks := run.Tokens(); len(toks) == 0 {
+		t.Fatal("Tokens() returned no tokens")
+	}
+	if !run.adapted {
+		t.Fatal("Tokens() should force token/comment adaptation")
+	}
+}
+
 // TestCheckStructuredFromRunMatchesCheckSourceStructured pins the
 // invariant that feeds the check-path astbridge wedge: running the
 // native checker on an existing FrontendRun's parser arena must

--- a/internal/selfhost/check_diag_convert.go
+++ b/internal/selfhost/check_diag_convert.go
@@ -1,6 +1,7 @@
 package selfhost
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/diag"
@@ -20,9 +21,10 @@ import (
 // Callers that want per-record control should use
 // CheckDiagnosticRecordAsDiag instead and filter before conversion.
 func CheckDiagnosticsAsDiag(src []byte, records []CheckDiagnosticRecord) []*diag.Diagnostic {
+	index := newDiagLineIndex(src)
 	out := make([]*diag.Diagnostic, 0, len(records))
 	for _, rec := range records {
-		if converted := CheckDiagnosticRecordAsDiag(src, rec); converted != nil {
+		if converted := checkDiagnosticRecordAsDiagWithIndex(src, index, rec); converted != nil {
 			out = append(out, converted)
 		}
 	}
@@ -37,9 +39,13 @@ func CheckDiagnosticsAsDiag(src []byte, records []CheckDiagnosticRecord) []*diag
 // native checker occasionally reports a past-EOF end when the
 // originating token is the trailing EOF marker, and we'd rather emit
 // a clamped span than drop the diagnostic. Line/column come from a
-// single linear scan of src (no rune table needed; the native
-// checker's offsets are already byte-accurate).
+// lightweight line-start index over src (no rune table needed; the
+// native checker's offsets are already byte-accurate).
 func CheckDiagnosticRecordAsDiag(src []byte, rec CheckDiagnosticRecord) *diag.Diagnostic {
+	return checkDiagnosticRecordAsDiagWithIndex(src, newDiagLineIndex(src), rec)
+}
+
+func checkDiagnosticRecordAsDiagWithIndex(src []byte, index diagLineIndex, rec CheckDiagnosticRecord) *diag.Diagnostic {
 	if rec.Code == "" && rec.Message == "" {
 		return nil
 	}
@@ -55,7 +61,7 @@ func CheckDiagnosticRecordAsDiag(src []byte, rec CheckDiagnosticRecord) *diag.Di
 	if rec.File != "" {
 		b = b.File(rec.File)
 	}
-	b = b.Primary(byteRangeSpanForDiag(src, rec.Start, rec.End), "")
+	b = b.Primary(index.byteRangeSpan(rec.Start, rec.End), "")
 	for _, note := range rec.Notes {
 		if strings.TrimSpace(note) == "" {
 			continue
@@ -65,43 +71,60 @@ func CheckDiagnosticRecordAsDiag(src []byte, rec CheckDiagnosticRecord) *diag.Di
 	return b.Build()
 }
 
-// byteRangeSpanForDiag builds a diag.Span over the [start, end) byte
-// range in src. Mirrors internal/check/host_boundary.go:byteRangeSpan
-// so both entry points produce identical spans for equivalent input
-// — keep the two in sync.
-func byteRangeSpanForDiag(src []byte, start, end int) diag.Span {
-	if start < 0 {
-		start = 0
+type diagLineIndex struct {
+	starts []int
+	total  int
+}
+
+func newDiagLineIndex(src []byte) diagLineIndex {
+	starts := make([]int, 1, 1+len(src)/32)
+	starts[0] = 0
+	for i, b := range src {
+		if b == '\n' {
+			starts = append(starts, i+1)
+		}
 	}
+	return diagLineIndex{starts: starts, total: len(src)}
+}
+
+func (idx diagLineIndex) byteRangeSpan(start, end int) diag.Span {
+	start = idx.clampOffset(start)
+	end = idx.clampOffset(end)
 	if end < start {
 		end = start
 	}
-	if len(src) == 0 {
+	if idx.total == 0 {
 		p := token.Pos{Line: 1, Column: 1, Offset: 0}
 		return diag.Span{Start: p, End: p}
 	}
-	if start > len(src) {
-		start = len(src)
-	}
-	if end > len(src) {
-		end = len(src)
-	}
 	return diag.Span{
-		Start: positionAtOffsetForDiag(src, start),
-		End:   positionAtOffsetForDiag(src, end),
+		Start: idx.positionAt(start),
+		End:   idx.positionAt(end),
 	}
 }
 
-func positionAtOffsetForDiag(src []byte, offset int) token.Pos {
-	line := 1
-	col := 1
-	for i := 0; i < offset && i < len(src); i++ {
-		if src[i] == '\n' {
-			line++
-			col = 1
-			continue
-		}
-		col++
+func (idx diagLineIndex) clampOffset(offset int) int {
+	if offset < 0 {
+		return 0
 	}
-	return token.Pos{Line: line, Column: col, Offset: offset}
+	if offset > idx.total {
+		return idx.total
+	}
+	return offset
+}
+
+func (idx diagLineIndex) positionAt(offset int) token.Pos {
+	offset = idx.clampOffset(offset)
+	lineIdx := sort.Search(len(idx.starts), func(i int) bool {
+		return idx.starts[i] > offset
+	}) - 1
+	if lineIdx < 0 {
+		lineIdx = 0
+	}
+	lineStart := idx.starts[lineIdx]
+	return token.Pos{
+		Line:   lineIdx + 1,
+		Column: offset - lineStart + 1,
+		Offset: offset,
+	}
 }

--- a/internal/selfhost/check_diag_convert_test.go
+++ b/internal/selfhost/check_diag_convert_test.go
@@ -1,6 +1,7 @@
 package selfhost_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/diag"
@@ -116,7 +117,7 @@ func TestCheckDiagnosticRecordAsDiagSeverityMapping(t *testing.T) {
 		{"warning", diag.Warning},
 		{"warn", diag.Warning},
 		{"WARN", diag.Warning},
-		{"", diag.Error},    // default
+		{"", diag.Error},     // default
 		{"info", diag.Error}, // unrecognized → default to Error (not silently downgraded)
 	}
 	for _, tc := range cases {
@@ -136,5 +137,58 @@ func TestCheckDiagnosticRecordAsDiagSeverityMapping(t *testing.T) {
 				t.Fatalf("severity for %q = %v, want %v", tc.severity, got.Severity, tc.want)
 			}
 		})
+	}
+}
+
+func TestCheckDiagnosticRecordAsDiagPreservesOffsetMapping(t *testing.T) {
+	src := []byte("alpha\nbeta\ngamma\n")
+	got := selfhost.CheckDiagnosticRecordAsDiag(src, selfhost.CheckDiagnosticRecord{
+		Code:    "Eline",
+		Message: "mapped",
+		Start:   strings.Index(string(src), "beta"),
+		End:     strings.Index(string(src), "gamma"),
+	})
+	if got == nil {
+		t.Fatal("nil diagnostic")
+	}
+	if len(got.Spans) == 0 {
+		t.Fatal("missing primary span")
+	}
+	span := got.Spans[0].Span
+	if span.Start.Line != 2 || span.Start.Column != 1 {
+		t.Fatalf("start = %d:%d, want 2:1", span.Start.Line, span.Start.Column)
+	}
+	if span.End.Line != 3 || span.End.Column != 1 {
+		t.Fatalf("end = %d:%d, want 3:1", span.End.Line, span.End.Column)
+	}
+}
+
+func BenchmarkCheckDiagnosticsAsDiag(b *testing.B) {
+	var src strings.Builder
+	src.Grow(32 * 256)
+	records := make([]selfhost.CheckDiagnosticRecord, 0, 256)
+	offset := 0
+	for i := 0; i < 256; i++ {
+		line := "let value = 1234567890\n"
+		start := offset + len("let ")
+		end := start + len("value")
+		src.WriteString(line)
+		offset += len(line)
+		records = append(records, selfhost.CheckDiagnosticRecord{
+			Code:     "Ebench",
+			Message:  "bench",
+			Severity: "error",
+			Start:    start,
+			End:      end,
+		})
+	}
+	data := []byte(src.String())
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		diags := selfhost.CheckDiagnosticsAsDiag(data, records)
+		if len(diags) != len(records) {
+			b.Fatalf("len(diags) = %d, want %d", len(diags), len(records))
+		}
 	}
 }

--- a/internal/selfhost/gate_adapter.go
+++ b/internal/selfhost/gate_adapter.go
@@ -31,7 +31,7 @@ func IntrinsicBodyDiagsForSource(src []byte, path string) []*diag.Diagnostic {
 	if run == nil || run.parser == nil || run.parser.arena == nil {
 		return nil
 	}
-	if selfhostHasErrorDiagnostics(run.Diagnostics()) {
+	if selfhostRunHasErrorDiagnostics(run) {
 		return nil
 	}
 	records := selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, path)
@@ -43,10 +43,7 @@ func selfhostAppendIntrinsicBodyGateForSource(result *CheckResult, src []byte) {
 		return
 	}
 	run := Run(src)
-	if selfhostHasErrorDiagnostics(run.Diagnostics()) {
-		return
-	}
-	if run.parser == nil || run.parser.arena == nil {
+	if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
 		return
 	}
 	records := selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
@@ -63,11 +60,7 @@ func selfhostAppendIntrinsicBodyGateForRun(result *CheckResult, run *FrontendRun
 	if result == nil || run == nil {
 		return
 	}
-	diags := run.Diagnostics()
-	if selfhostHasErrorDiagnostics(diags) {
-		return
-	}
-	if run.parser == nil || run.parser.arena == nil {
+	if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
 		return
 	}
 	records := selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
@@ -215,15 +208,22 @@ func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input Packag
 			continue
 		}
 		run := Run(file.Source)
-		if selfhostHasErrorDiagnostics(run.Diagnostics()) {
-			continue
-		}
-		if run.parser == nil || run.parser.arena == nil {
+		if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
 			continue
 		}
 		records = append(records, selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, file.Base, file.Path)...)
 	}
 	selfhostMergeDiagnosticRecords(result, records...)
+}
+
+func selfhostRunHasErrorDiagnostics(run *FrontendRun) bool {
+	if run == nil {
+		return false
+	}
+	if run.stream != nil && len(run.stream.diagnostics) > 0 {
+		return true
+	}
+	return run.parser != nil && run.parser.arena != nil && len(run.parser.arena.errors) > 0
 }
 
 func selfhostHasErrorDiagnostics(diags []*diag.Diagnostic) bool {


### PR DESCRIPTION
## Summary
- make `selfhost.Run` keep lex token/comment adaptation lazy so arena-direct callers only pay for it on demand
- reuse a lightweight line-start index when converting native check diagnostics into `*diag.Diagnostic`
- let the intrinsic-body gate fast-fail on raw lexer/parser error state instead of materializing full diagnostic slices

## Why
The selfhost-native fast path still had a few avoidable costs in hot code paths:
- `Run` eagerly adapted public lex surfaces even when native callers only needed the parser arena or parse diagnostics
- diagnostic conversion rebuilt line/column positions with repeated linear scans over the source
- the intrinsic-body gate asked for full diagnostic shaping just to answer "did lex/parse produce any errors?"

Together these costs showed up in the native selfhost path and in repeated CLI/LSP-style file analysis.

## Impact
Native parse/check/resolve entry points now stay cheaper on the common happy path, with lower allocation pressure and less redundant work before the caller asks for public tokens or shaped diagnostics.

## Benchmarks
On the local Apple M5 dev machine:
- `BenchmarkRunDiagnostics`: `47600 ns/op` -> `38282 ns/op`, `20264 B/op` -> `16168 B/op`
- `BenchmarkCheckStructuredFromRun`: `318795 ns/op` -> `225095 ns/op`, `165684 B/op` -> `161589 B/op`
- `BenchmarkCheckDiagnosticsAsDiag`: `1001615 ns/op` -> `132948 ns/op` in the earlier batch-sized harness, then `76392 ns/op` -> `45662 ns/op` in the rebased small-record harness

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestRunDefersLexAdaptationUntilTokensRequested|TestCheckStructuredFromRun|TestCheckFromSource|TestCheckSourceStructuredIsAstbridgeFree'`
- `go test -count=1 -vet=off ./internal/parser ./internal/resolve ./internal/lsp`
- `go test -count=1 -vet=off ./internal/selfhost -run '^$' -bench 'BenchmarkRunDiagnostics|BenchmarkCheckStructuredFromRun|BenchmarkCheckDiagnosticsAsDiag' -benchmem`