### PR TITLE
fix(llvmgen): implement IntrinsicListFirst/Last in MIR emitter

### DIFF
--- a/internal/backend/llvm_list_first_last_test.go
+++ b/internal/backend/llvm_list_first_last_test.go
@@ -1,0 +1,75 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsListFirstLastInt covers List<Int>.first() /
+// .last() which were parsed + checked but the MIR→LLVM emitter simply
+// didn't have cases for IntrinsicListFirst / IntrinsicListLast — the
+// `isSupportedIntrinsic` gate also filtered them out, so `xs.first()`
+// on any program fell back to the legacy AST path and tripped
+// LLVM015 "call: call target *ast.TurbofishExpr".
+//
+// The fix materialises them as `len == 0 ? None : Some(get(idx))` on
+// the typed-runtime list (i64/i1/f64/ptr/string). The Option slot-1
+// is i64-wide by layout, so non-i64 scalars widen via zext /
+// ptrtoint / bitcast before insertvalue.
+func TestLLVMBackendBinaryRunsListFirstLastInt(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    println(xs.first() ?? -1)
+    println(xs.last() ?? -1)
+    let empty: List<Int> = []
+    println(empty.first() ?? 99)
+    println(empty.last() ?? 99)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "10\n30\n99\n99\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListFirstLastString covers the String /
+// ptr-slot case where the Option<String> aggregate's second field is
+// still i64 by layout, so the emitted insertvalue must ptrtoint the
+// runtime get result to i64 before inserting.
+func TestLLVMBackendBinaryRunsListFirstLastString(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let strs: List<String> = ["hello", "world"]
+    println(strs.first() ?? "empty")
+    println(strs.last() ?? "empty")
+    let empty: List<String> = []
+    println(empty.first() ?? "none")
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "hello\nworld\nnone\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1075,7 +1075,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
-		mir.IntrinsicListPop:
+		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast:
 		return true
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -4213,7 +4213,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStdIoWriteIntrinsic(i, "eprintln")
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
-		mir.IntrinsicListPop:
+		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast:
 		return g.emitListIntrinsic(i)
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -4376,6 +4376,80 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicListFirst, mir.IntrinsicListLast:
+		// `.first()` / `.last()` return `T?`. Runtime has no bespoke
+		// symbol — lower as `len == 0 ? None : Some(get(idx))` where
+		// idx is 0 for first and len-1 for last. Scalar elems use the
+		// typed get_<kind> symbol; composite elements (structs / lists
+		// / maps) aren't supported yet because the raw scalar-return
+		// contract above doesn't match their aggregate shape.
+		if !listUsesTypedRuntime(elemLLVM) {
+			return unsupported("mir-mvp", fmt.Sprintf("list_%s on composite element type %s", mirIntrinsicLabel(i.Kind), elemLLVM))
+		}
+		if i.Dest == nil {
+			return unsupported("mir-mvp", fmt.Sprintf("%s without destination", mirIntrinsicLabel(i.Kind)))
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return unsupported("mir-mvp", fmt.Sprintf("%s dest into unknown local", mirIntrinsicLabel(i.Kind)))
+		}
+		destLLVM := g.llvmType(destLoc.Type)
+		destSlot := g.localSlots[i.Dest.Local]
+		lenSym := listRuntimeLenSymbol()
+		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		getSym := listRuntimeGetSymbol(elemLLVM)
+		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		lenReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+		isEmpty := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isEmpty, lenReg)
+		someLabel := g.freshLabel("list.opt.some")
+		noneLabel := g.freshLabel("list.opt.none")
+		endLabel := g.freshLabel("list.opt.end")
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isEmpty, noneLabel, someLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		var idxRef string
+		if i.Kind == mir.IntrinsicListFirst {
+			idxRef = "0"
+		} else {
+			idxRef = g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", idxRef, lenReg)
+		}
+		elemReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxRef)
+		// Option<T> slot-1 is i64-wide by layout convention (see
+		// support_snapshot.go / emitNullaryRV). For non-i64 scalars we
+		// must widen/bitcast to i64 before insertvalue.
+		payloadReg := elemReg
+		switch elemLLVM {
+		case "i64":
+			// no-op
+		case "i1", "i8", "i16", "i32":
+			widened := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
+			payloadReg = widened
+		case "double":
+			cast := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
+			payloadReg = cast
+		case "ptr":
+			cast := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
+			payloadReg = cast
+		default:
+			return unsupported("mir-mvp", fmt.Sprintf("list_%s payload widen unsupported for %s", mirIntrinsicLabel(i.Kind), elemLLVM))
+		}
+		tagged := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		filled := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		return nil
 	case mir.IntrinsicListPop:
 		// Runtime exposes `osty_rt_list_pop_discard` — drops the last
 		// element without returning it. All toolchain uses of


### PR DESCRIPTION
## Summary

- `List<T>.first()` / `.last()` returned `T?` per stdlib, had MIR intrinsic definitions (`IntrinsicListFirst` / `IntrinsicListLast`), and a live HIR→MIR routing path — but the LLVM emitter had no case for either, and the `isSupportedIntrinsic` gate filtered them out so the whole MIR module was rejected
- Any `xs.first()` / `xs.last()` fell back to the legacy AST emitter and walled on `LLVM015 call: call target *ast.TurbofishExpr`
- Fix: emit `len == 0 ? None : Some(get(idx))` — `idx = 0` for first, `len - 1` for last. Scalar elems widen/bitcast to i64 for the fixed-size Option payload slot

## Repro (pre-fix)

```osty
fn main() {
    let xs: List<Int> = [10, 20, 30]
    println(xs.first() ?? -1)
}
```

Pre-fix: LLVM skeleton with
```
; unsupported: LLVM015 call: call target *ast.TurbofishExpr
```
(MIR path: `intrinsic kind=33 not yet supported` visible via `OSTY_TRACE_MIR_FALLBACK=1`)

Post-fix: prints `10`.

## Option slot widening

The `Option<T>` aggregate layout is `{ i64 tag, i64 value }` universally — see `emitNullaryRV` for the matching `None = {0, 0}` shape. Non-i64 element types must widen/bitcast the runtime-get result before `insertvalue`:

| elem LLVM type | coercion |
|---|---|
| `i64` | no-op |
| `i1`/`i8`/`i16`/`i32` | zext |
| `double` | bitcast |
| `ptr` | ptrtoint |

Composite elements (structs / nested aggregates) return `unsupported` — those go through a different `emitListGetBytes` path that would need a wider rework.

## Scope

Intentionally narrow: the `match xs.first() { Some(v) -> …, None -> … }` form still walls on an unrelated TurbofishExpr issue in the match scrutinee lowering. The `xs.first() ?? fallback` form works end-to-end, so the regression tests pick that shape.

## Test plan

- [x] `TestLLVMBackendBinaryRunsListFirstLastInt` — `[10,20,30].first()/last()` + empty list, prints `10\n30\n99\n99\n`
- [x] `TestLLVMBackendBinaryRunsListFirstLastString` — `["hello","world"].first()/last()` + empty list, prints `hello\nworld\nnone\n`
- [x] `just front` — 8 frontend packages green
- [x] No regressions in existing List / MIR backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)