### PR TITLE
fix(mir): recover ErrType for Ident and IfExpr in recoverOperandType

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2185,6 +2185,56 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		case *ir.FloatLit:
 			return ir.TFloat64
 		}
+	case *ir.Ident:
+		// Ident whose carrier type is poisoned — if it resolves to a
+		// MIR local we've already created (common after lowerLet's
+		// own valueType recovery), surface the local's type instead
+		// of the poisoned annotation on the IR node.
+		if id, ok := bs.lookup(x.Name); ok {
+			if loc := bs.fn.Local(id); loc != nil && !isPoisonType(loc.Type) {
+				return loc.Type
+			}
+		}
+	case *ir.IfExpr:
+		// `let x = if ... { a } else { b }` with a poisoned IfExpr
+		// carrier: recover from whichever arm's tail expression still
+		// carries a concrete type. Both arms produce the same type by
+		// exhaustiveness, so either is fine.
+		if rt := recoverBlockTailType(bs, x.Then); rt != nil {
+			return rt
+		}
+		if rt := recoverBlockTailType(bs, x.Else); rt != nil {
+			return rt
+		}
+	}
+	return nil
+}
+
+// recoverBlockTailType returns the recovered type of a Block's tail
+// expression. When b.Result is nil — common after a checker bailout,
+// since ir/lower.go's lowerBlock only promotes the last stmt to
+// Result when the checker tagged it with a non-unit type — fall back
+// to the final statement when it's an ExprStmt. Named to distinguish
+// it from ir.blockResultType, which is the authoritative non-recovery
+// version on the IR side.
+func recoverBlockTailType(bs *bodyState, b *ir.Block) ir.Type {
+	if b == nil {
+		return nil
+	}
+	tail := b.Result
+	if tail == nil && len(b.Stmts) > 0 {
+		if es, ok := b.Stmts[len(b.Stmts)-1].(*ir.ExprStmt); ok {
+			tail = es.X
+		}
+	}
+	if tail == nil {
+		return nil
+	}
+	if t := tail.Type(); !isPoisonType(t) {
+		return t
+	}
+	if rt := bs.recoverOperandType(tail); !isPoisonType(rt) {
+		return rt
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Continuation of the MIR-path recovery work (#758, #767, #777). Closes the
`collectFnDecl` wall pair at `toolchain/check.osty:704–705` by extending
`recoverOperandType` with two new cases.

## What changed

- **Ident case**: when an identifier's carrier type is poisoned, consult
  the MIR local table. `lowerLet` runs its own valueType recovery, so the
  MIR local has the right type even when the IR node doesn't. Combined
  with main's `fieldExprType` (added in #777), `paramNode.text` now
  resolves cleanly — the Ident recovery un-poisons the receiver, and the
  existing struct-field table walk fills in the FieldExpr.

- **IfExpr case**: recover `let x = if ... { a } else { b }` by lifting
  the type from whichever arm's tail expression still carries a concrete
  type (both arms produce the same type by exhaustiveness).

- **New helper `recoverBlockTailType`**: checker bailouts leave
  `Block.Result` nil because `ir/lower.go`'s `lowerBlock` only promotes
  the last stmt to `Result` when the checker tagged it non-unit. The
  helper falls back to the final `ExprStmt.X`. Named to distinguish from
  the authoritative `ir.blockResultType`.

## Probe advancement

```
Before: collectFnDecl rawName  id=24 src=UseRV at 800:27
After:  collectFnDecl <temp>   id=27 (next wall — separate follow-up)
```

ErrType floor: 2279 → 1873 (-406, ~18%).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/mir/ ./internal/ir/`
- [x] `go test ./internal/llvmgen/ -run TestProbeNativeToolchainMergedMIR -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)