### PR TITLE
[codex] Port stableLowerer fixups to selfhost parser

### DIFF
--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -777,20 +777,14 @@ func TestCheckWithoutAIRepairPassesStableParserAliases(t *testing.T) {
 func TestCheckWithoutAIRepairPassesParserLoweredEnumerateLoop(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
-	source := "fn main() {\n    let items = [1, 2]\n    for (i, item) in enumerate(items) {\n        println(i)\n        println(item)\n    }\n}\n"
+	source := "fn main() {\n    let items = [1, 2]\n    for (i, item) in enumerate(items) {\n        println(i)\n        println(item)\n    }\n    for (_, item) in enumerate(items) {\n        println(item)\n    }\n}\n"
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
 
-	// Parser-owned enumerate/len/append lowerings live in
-	// internal/parser/lower.go's stableLowerer, which ParseDetailed
-	// runs but ParseRun (the selfhost arena path) does not. Until the
-	// selfhost parser grows an equivalent fixup pass (tracked on
-	// SELFHOST_PORT_MATRIX.md as a 1c follow-up), these surface
-	// rewrites are available only on `--legacy`.
-	got := runOstyCLI(t, "check", "--legacy", "--no-airepair", path)
+	got := runOstyCLI(t, "check", "--no-airepair", path)
 	if got.exit != 0 {
-		t.Fatalf("check --legacy --no-airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("check --no-airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 }
 
@@ -800,16 +794,14 @@ func TestCheckWithoutAIRepairPassesParserLoweredSemanticHelpers(t *testing.T) {
 	// Only the truly parser-owned helpers (`len(list)` → `list.len()`,
 	// `append(list, x)` → `list.push(x)`) — `.length` is airepair-only
 	// after 182f819, so it belongs in TestCheckWithAIRepairPassesSemanticForeignHelpers.
-	source := "fn main() {\n    let mut items = [1, 2]\n    let count = len(items)\n    items = append(items, count)\n    println(items)\n}\n"
+	source := "fn main() {\n    let mut items = [1, 2]\n    let count = len(items)\n    items = append(items, count)\n    let more = append(items, count)\n    println(items)\n    println(more)\n}\n"
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
 
-	// Parser-owned len/append lowerings: see the enumerate variant
-	// above for the same --legacy rationale.
-	got := runOstyCLI(t, "check", "--legacy", "--no-airepair", path)
+	got := runOstyCLI(t, "check", "--no-airepair", path)
 	if got.exit != 0 {
-		t.Fatalf("check --legacy --no-airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+		t.Fatalf("check --no-airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 	}
 }
 

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -71,6 +71,7 @@ type FrontendRun struct {
 	toks     []token.Token
 	comments []token.Comment
 	file     *ast.File
+	semantic *AstFile
 	lexDiags []*diag.Diagnostic
 	diags    []*diag.Diagnostic
 	adapted  bool
@@ -226,6 +227,17 @@ func (r *FrontendRun) astFile() *AstFile {
 		return nil
 	}
 	return &AstFile{arena: r.parser.arena}
+}
+
+func (r *FrontendRun) semanticAstFile() *AstFile {
+	if r == nil {
+		return nil
+	}
+	if r.semantic != nil {
+		return r.semantic
+	}
+	r.semantic = selfhostSemanticAstFile(r.astFile())
+	return r.semantic
 }
 
 // LexDiagnostics returns lexer-only diagnostics.

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -30,7 +30,14 @@ func CheckSource(src []byte) CheckSummary {
 // structured result consumed by the Go check.Result bridge.
 func CheckSourceStructured(src []byte) CheckResult {
 	lexed := ostyLexSource(string(src))
-	checked := frontendCheckLexedSourceStructured(lexed)
+	if lexed == nil {
+		return CheckResult{}
+	}
+	file := selfhostSemanticAstFile(astParseLexedSource(lexed))
+	if file == nil {
+		return CheckResult{}
+	}
+	checked := frontendCheckAstStructured(file)
 	if checked == nil {
 		return CheckResult{}
 	}
@@ -69,7 +76,7 @@ func CheckStructuredFromRun(run *FrontendRun) CheckResult {
 	if run == nil {
 		return CheckResult{}
 	}
-	file := run.astFile()
+	file := run.semanticAstFile()
 	if file == nil {
 		return CheckResult{}
 	}

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -115,6 +115,19 @@ fn main() {
 }
 `),
 		},
+		{
+			name: "stable helper lowerings",
+			src: []byte(`fn main() {
+    let mut items = [1, 2]
+    let count = len(items)
+    items = append(items, count)
+    let more = append(items, count)
+    for (_, item) in enumerate(more) {
+        println(item)
+    }
+}
+`),
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -125,6 +138,22 @@ fn main() {
 				t.Fatalf("CheckStructuredFromRun diverges from CheckSourceStructured\nlegacy=%#v\nfresh=%#v", legacy, fresh)
 			}
 		})
+	}
+}
+
+func TestRunDiagnosticsAllowDiscardInForInHead(t *testing.T) {
+	src := []byte(`fn main() {
+    let items = ["a", "b"]
+    for (_, item) in enumerate(items) {
+        println(item)
+    }
+}
+`)
+	run := Run(src)
+	for _, d := range run.Diagnostics() {
+		if d != nil && d.Code == "E0604" {
+			t.Fatalf("unexpected wildcard parse diagnostic in for-in head: %#v", d)
+		}
 	}
 }
 

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -18712,19 +18712,20 @@ func astArenaNodeAt(arena *AstArena, idx int) *AstNode {
 
 // Osty: /tmp/selfhost_merged.osty:7032:5
 type OstyParser struct {
-	tokens        []*FrontToken
-	count         int
-	pos           int
-	arena         *AstArena
-	noStructLit   bool
-	inLoop        bool
-	typeGtDebt    int
-	pendingAssign bool
+	tokens            []*FrontToken
+	count             int
+	pos               int
+	arena             *AstArena
+	noStructLit       bool
+	allowExprWildcard bool
+	inLoop            bool
+	typeGtDebt        int
+	pendingAssign     bool
 }
 
 // Osty: /tmp/selfhost_merged.osty:7043:5
 func newOstyParser(tokens []*FrontToken) *OstyParser {
-	return &OstyParser{tokens: tokens, count: frontTokenListCount(tokens), pos: 0, arena: emptyAstArena(), noStructLit: false, inLoop: false, typeGtDebt: 0, pendingAssign: false}
+	return &OstyParser{tokens: tokens, count: frontTokenListCount(tokens), pos: 0, arena: emptyAstArena(), noStructLit: false, allowExprWildcard: false, inLoop: false, typeGtDebt: 0, pendingAssign: false}
 }
 
 // Osty: /tmp/selfhost_merged.osty:7055:1
@@ -19871,7 +19872,9 @@ func opParsePrimary(p *OstyParser) int {
 	// Osty: /tmp/selfhost_merged.osty:7562:5
 	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontUnderscore{})) {
 		// Osty: /tmp/selfhost_merged.osty:7563:5
-		opErrorFull(p, "`_` can only be used as a pattern", "for ignored bindings, write `let _ = expr`", "", "E0604")
+		if !(p.allowExprWildcard) {
+			opErrorFull(p, "`_` can only be used as a pattern", "for ignored bindings, write `let _ = expr`", "", "E0604")
+		}
 		// Osty: /tmp/selfhost_merged.osty:7564:5
 		opAdvance(p)
 		// Osty: /tmp/selfhost_merged.osty:7565:5
@@ -21556,7 +21559,11 @@ func opExprToForPattern(p *OstyParser, exprIdx int) int {
 		pat := emptyAstNode(AstNodeKind(&AstNodeKind_AstNPattern{}))
 		_ = pat
 		// Osty: /tmp/selfhost_merged.osty:8337:12
-		pat.extra = astPatternIdentKind()
+		if node.text == "_" {
+			pat.extra = astPatternWildcardKind()
+		} else {
+			pat.extra = astPatternIdentKind()
+		}
 		// Osty: /tmp/selfhost_merged.osty:8338:12
 		pat.text = node.text
 		// Osty: /tmp/selfhost_merged.osty:8339:12
@@ -21669,13 +21676,17 @@ func opParseForStmt(p *OstyParser, labelIdx int) int {
 		// Osty: /tmp/selfhost_merged.osty:8396:9
 		pv := p.noStructLit
 		_ = pv
+		prevAllowExprWildcard := p.allowExprWildcard
+		_ = prevAllowExprWildcard
 		// Osty: /tmp/selfhost_merged.osty:8397:10
 		p.noStructLit = true
+		p.allowExprWildcard = true
 		// Osty: /tmp/selfhost_merged.osty:8398:9
 		expr := opParseExpr(p)
 		_ = expr
 		// Osty: /tmp/selfhost_merged.osty:8399:10
 		p.noStructLit = pv
+		p.allowExprWildcard = prevAllowExprWildcard
 		// Osty: /tmp/selfhost_merged.osty:8400:9
 		if opAt(p, FrontTokenKind(&FrontTokenKind_FrontIdent{})) && opPeek(p).text == "in" {
 			// Osty: /tmp/selfhost_merged.osty:8401:13

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -70,6 +70,7 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 		if len(parsed.arena.errors) > 0 {
 			return nil, nil, fmt.Errorf("selfhost package adapter: parse errors: %s", astFormatErrors(parsed))
 		}
+		parsed = selfhostSemanticAstFile(parsed)
 		tokenBase := len(layout.starts)
 		fileIdx := -1
 		if file.Name != "" {

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -110,7 +110,7 @@ func ResolveSourceStructuredWithCfg(src []byte, cfg *CfgEnv) ResolveResult {
 	if lexed == nil {
 		return ResolveResult{}
 	}
-	file := astParseLexedSource(lexed)
+	file := selfhostSemanticAstFile(astParseLexedSource(lexed))
 	if file == nil {
 		return ResolveResult{}
 	}
@@ -135,7 +135,7 @@ func ResolveStructuredFromRun(run *FrontendRun) ResolveResult {
 	if run == nil {
 		return ResolveResult{}
 	}
-	file := run.astFile()
+	file := run.semanticAstFile()
 	if file == nil {
 		return ResolveResult{}
 	}

--- a/internal/selfhost/stable_lower.go
+++ b/internal/selfhost/stable_lower.go
@@ -1,0 +1,604 @@
+package selfhost
+
+import "fmt"
+
+// selfhostSemanticAstFile clones the raw parser arena and applies the
+// parser-owned helper lowerings that the arena-native check/resolve path
+// still needs for parity with internal/parser's stableLowerer.
+func selfhostSemanticAstFile(file *AstFile) *AstFile {
+	if file == nil || file.arena == nil {
+		return file
+	}
+	cloned := &AstFile{arena: selfhostCloneAstArena(file.arena)}
+	l := &selfhostStableLowerer{arena: cloned.arena}
+	for i, idx := range cloned.arena.decls {
+		cloned.arena.decls[i] = l.lowerDecl(idx)
+	}
+	return cloned
+}
+
+func selfhostCloneAstArena(src *AstArena) *AstArena {
+	if src == nil {
+		return nil
+	}
+	dst := &AstArena{
+		nodes: make([]*AstNode, len(src.nodes)),
+		decls: append([]int(nil), src.decls...),
+		errors: func() []*AstParseError {
+			out := make([]*AstParseError, len(src.errors))
+			for i, err := range src.errors {
+				if err == nil {
+					continue
+				}
+				copy := *err
+				out[i] = &copy
+			}
+			return out
+		}(),
+	}
+	for i, node := range src.nodes {
+		if node == nil {
+			continue
+		}
+		copy := *node
+		copy.children = append([]int(nil), node.children...)
+		copy.children2 = append([]int(nil), node.children2...)
+		dst.nodes[i] = &copy
+	}
+	return dst
+}
+
+type selfhostStableLowerer struct {
+	arena   *AstArena
+	counter int
+}
+
+func (l *selfhostStableLowerer) nextTemp(prefix string) string {
+	name := fmt.Sprintf("_osty_%s%d", prefix, l.counter)
+	l.counter++
+	return name
+}
+
+func (l *selfhostStableLowerer) lowerDecl(idx int) int {
+	n := l.node(idx)
+	if n == nil {
+		return idx
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNFnDecl:
+		n.right = l.lowerBlock(n.right)
+	case *AstNodeKind_AstNStructDecl, *AstNodeKind_AstNEnumDecl, *AstNodeKind_AstNInterfaceDecl:
+		for _, child := range n.children {
+			cn := l.node(child)
+			if cn == nil {
+				continue
+			}
+			if _, ok := cn.kind.(*AstNodeKind_AstNFnDecl); ok {
+				cn.right = l.lowerBlock(cn.right)
+			}
+		}
+	case *AstNodeKind_AstNLet:
+		n.right = l.lowerExpr(n.right)
+	}
+	return idx
+}
+
+func (l *selfhostStableLowerer) lowerBlock(idx int) int {
+	n := l.node(idx)
+	if n == nil {
+		return idx
+	}
+	n.children = l.lowerStmtList(n.children)
+	return idx
+}
+
+func (l *selfhostStableLowerer) lowerStmtList(stmts []int) []int {
+	if len(stmts) == 0 {
+		return stmts
+	}
+	out := make([]int, 0, len(stmts))
+	for _, idx := range stmts {
+		out = append(out, l.lowerStmt(idx)...)
+	}
+	return out
+}
+
+func (l *selfhostStableLowerer) lowerStmt(idx int) []int {
+	n := l.node(idx)
+	if n == nil {
+		return []int{idx}
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNBlock:
+		n.children = l.lowerStmtList(n.children)
+		return []int{idx}
+	case *AstNodeKind_AstNLet:
+		n.right = l.lowerExpr(n.right)
+		if push, ok := l.lowerAppendLetStmt(n); ok {
+			return []int{idx, push}
+		}
+		return []int{idx}
+	case *AstNodeKind_AstNExprStmt:
+		n.left = l.lowerExpr(n.left)
+		if l.lowerAppendExprStmt(n) {
+			return []int{idx}
+		}
+		return []int{idx}
+	case *AstNodeKind_AstNAssign:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerExpr(n.right)
+		if l.lowerAppendAssignStmt(n) {
+			return []int{idx}
+		}
+		return []int{idx}
+	case *AstNodeKind_AstNReturn, *AstNodeKind_AstNDefer:
+		n.left = l.lowerExpr(n.left)
+		return []int{idx}
+	case *AstNodeKind_AstNFor:
+		if len(n.children) > 1 {
+			n.children[1] = l.lowerExpr(n.children[1])
+		}
+		n.right = l.lowerBlock(n.right)
+		if temp, ok := l.lowerEnumerateForStmt(n); ok {
+			return []int{temp, idx}
+		}
+		return []int{idx}
+	case *AstNodeKind_AstNChanSend:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerExpr(n.right)
+		return []int{idx}
+	default:
+		return []int{idx}
+	}
+}
+
+func (l *selfhostStableLowerer) lowerExpr(idx int) int {
+	n := l.node(idx)
+	if n == nil {
+		return idx
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNBlock:
+		n.children = l.lowerStmtList(n.children)
+		return idx
+	case *AstNodeKind_AstNUnary, *AstNodeKind_AstNQuestion, *AstNodeKind_AstNParen:
+		n.left = l.lowerExpr(n.left)
+		return idx
+	case *AstNodeKind_AstNBinary, *AstNodeKind_AstNIndex:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerExpr(n.right)
+		return idx
+	case *AstNodeKind_AstNCall:
+		n.left = l.lowerExpr(n.left)
+		for i, child := range n.children {
+			n.children[i] = l.lowerExpr(child)
+		}
+		l.lowerBuiltinLenCall(n)
+		return idx
+	case *AstNodeKind_AstNField:
+		n.left = l.lowerExpr(n.left)
+		return idx
+	case *AstNodeKind_AstNTurbofish:
+		n.left = l.lowerExpr(n.left)
+		return idx
+	case *AstNodeKind_AstNRange:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerExpr(n.right)
+		for i, child := range n.children {
+			n.children[i] = l.lowerExpr(child)
+		}
+		return idx
+	case *AstNodeKind_AstNTuple, *AstNodeKind_AstNList:
+		for i, child := range n.children {
+			n.children[i] = l.lowerExpr(child)
+		}
+		return idx
+	case *AstNodeKind_AstNMap:
+		for i, child := range n.children {
+			n.children[i] = l.lowerExpr(child)
+		}
+		for i, child := range n.children2 {
+			n.children2[i] = l.lowerExpr(child)
+		}
+		return idx
+	case *AstNodeKind_AstNStructLit:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerExpr(n.right)
+		for _, child := range n.children {
+			cn := l.node(child)
+			if cn != nil {
+				cn.left = l.lowerExpr(cn.left)
+			}
+		}
+		return idx
+	case *AstNodeKind_AstNIf:
+		n.left = l.lowerExpr(n.left)
+		n.right = l.lowerBlock(n.right)
+		if len(n.children) > 0 {
+			n.children[0] = l.lowerExpr(n.children[0])
+		}
+		return idx
+	case *AstNodeKind_AstNMatch:
+		n.left = l.lowerExpr(n.left)
+		for _, child := range n.children {
+			arm := l.node(child)
+			if arm == nil {
+				continue
+			}
+			if len(arm.children) > 0 {
+				arm.children[0] = l.lowerExpr(arm.children[0])
+			}
+			arm.right = l.lowerExpr(arm.right)
+		}
+		return idx
+	case *AstNodeKind_AstNClosure:
+		n.left = l.lowerExpr(n.left)
+		return idx
+	default:
+		return idx
+	}
+}
+
+func (l *selfhostStableLowerer) lowerBuiltinLenCall(call *AstNode) bool {
+	if call == nil || !l.isCall(call) || len(call.children) != 1 {
+		return false
+	}
+	if !l.isIdentNamed(call.left, "len") {
+		return false
+	}
+	target := call.children[0]
+	field := emptyAstNode(AstNodeKind(&AstNodeKind_AstNField{}))
+	field.left = target
+	field.text = "len"
+	field.start = call.start
+	field.end = call.end
+	call.left = astArenaAdd(l.arena, field)
+	call.children = call.children[:0]
+	return true
+}
+
+func (l *selfhostStableLowerer) lowerAppendAssignStmt(assign *AstNode) bool {
+	if assign == nil || !l.isAppendCall(assign.right) {
+		return false
+	}
+	targetName, ok := l.identName(assign.left)
+	if !ok {
+		return false
+	}
+	base, item, ok := l.appendCallParts(assign.right)
+	if !ok {
+		return false
+	}
+	baseName, ok := l.identName(base)
+	if !ok || baseName != targetName {
+		return false
+	}
+	assign.kind = AstNodeKind(&AstNodeKind_AstNExprStmt{})
+	assign.left = l.pushCallExpr(base, item, assign.start, assign.end)
+	assign.right = -1
+	assign.op = FrontTokenKind(&FrontTokenKind_FrontEOF{})
+	return true
+}
+
+func (l *selfhostStableLowerer) lowerAppendExprStmt(stmt *AstNode) bool {
+	if stmt == nil || !l.isAppendCall(stmt.left) {
+		return false
+	}
+	base, item, ok := l.appendCallParts(stmt.left)
+	if !ok {
+		return false
+	}
+	if _, ok := l.identName(base); !ok {
+		return false
+	}
+	stmt.left = l.pushCallExpr(base, item, stmt.start, stmt.end)
+	return true
+}
+
+func (l *selfhostStableLowerer) lowerAppendLetStmt(stmt *AstNode) (int, bool) {
+	if stmt == nil {
+		return 0, false
+	}
+	name, ok := l.simpleIdentPatternName(stmt.left)
+	if !ok || !l.isAppendCall(stmt.right) {
+		return 0, false
+	}
+	base, item, ok := l.appendCallParts(stmt.right)
+	if !ok {
+		return 0, false
+	}
+	baseName, ok := l.identName(base)
+	if !ok || baseName == name {
+		return 0, false
+	}
+	stmt.flags = 1
+	stmt.right = base
+	return l.pushExprStmt(base, item, stmt.start, stmt.end), true
+}
+
+func (l *selfhostStableLowerer) lowerEnumerateForStmt(loop *AstNode) (int, bool) {
+	if loop == nil || !l.isForIn(loop) {
+		return 0, false
+	}
+	pattern, iterExpr, ok := l.enumerateLoopParts(loop)
+	if !ok {
+		return 0, false
+	}
+	indexPattern, valuePattern, ok := l.tuplePatternElems(pattern)
+	if !ok {
+		return 0, false
+	}
+	loopPattern, indexExpr, ok := l.enumerateIndexPattern(indexPattern, loop.start, loop.end)
+	if !ok {
+		return 0, false
+	}
+
+	tempName := l.nextTemp("enumerate")
+	tempPat := l.identPattern(tempName, loop.start, loop.end)
+	tempLet := emptyAstNode(AstNodeKind(&AstNodeKind_AstNLet{}))
+	tempLet.left = tempPat
+	tempLet.right = iterExpr
+	tempLet.children = []int{-1}
+	tempLet.start = loop.start
+	tempLet.end = loop.end
+	tempIdx := astArenaAdd(l.arena, tempLet)
+
+	tempRef := l.identExpr(tempName, loop.start, loop.end)
+	indexNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNIndex{}))
+	indexNode.left = tempRef
+	indexNode.right = indexExpr
+	indexNode.start = loop.start
+	indexNode.end = loop.end
+	indexIdx := astArenaAdd(l.arena, indexNode)
+
+	prelude := emptyAstNode(AstNodeKind(&AstNodeKind_AstNLet{}))
+	prelude.left = valuePattern
+	prelude.right = indexIdx
+	prelude.children = []int{-1}
+	prelude.start = loop.start
+	prelude.end = loop.end
+	preludeIdx := astArenaAdd(l.arena, prelude)
+
+	body := l.node(loop.right)
+	if body == nil {
+		body = emptyAstNode(AstNodeKind(&AstNodeKind_AstNBlock{}))
+		body.start = loop.start
+		body.end = loop.end
+		loop.right = astArenaAdd(l.arena, body)
+	}
+	body.children = append([]int{preludeIdx}, body.children...)
+
+	rangeStart := emptyAstNode(AstNodeKind(&AstNodeKind_AstNIntLit{}))
+	rangeStart.text = "0"
+	rangeStart.start = loop.start
+	rangeStart.end = loop.start
+	rangeStartIdx := astArenaAdd(l.arena, rangeStart)
+
+	tempLen := l.zeroArgMethodCall(tempName, "len", loop.start, loop.end)
+	rangeNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNRange{}))
+	rangeNode.left = rangeStartIdx
+	rangeNode.right = tempLen
+	rangeNode.start = loop.start
+	rangeNode.end = loop.end
+	rangeIdx := astArenaAdd(l.arena, rangeNode)
+
+	loop.children = []int{loopPattern, rangeIdx}
+	return tempIdx, true
+}
+
+func (l *selfhostStableLowerer) enumerateLoopParts(loop *AstNode) (pattern int, iterExpr int, ok bool) {
+	if loop == nil || len(loop.children) < 2 {
+		return 0, 0, false
+	}
+	pattern = loop.children[0]
+	iter := loop.children[1]
+	call := l.node(iter)
+	if call == nil || !l.isCall(call) {
+		return 0, 0, false
+	}
+	if l.isIdentNamed(call.left, "enumerate") && len(call.children) == 1 {
+		return pattern, call.children[0], true
+	}
+	fn := l.node(call.left)
+	if fn == nil || !l.isFieldNamed(fn, "enumerate") || len(call.children) != 0 {
+		return 0, 0, false
+	}
+	return pattern, fn.left, true
+}
+
+func (l *selfhostStableLowerer) enumerateIndexPattern(idx int, start, end int) (pattern int, expr int, ok bool) {
+	if l.isWildcardPattern(idx) {
+		name := l.nextTemp("index")
+		return l.identPattern(name, start, end), l.identExpr(name, start, end), true
+	}
+	if name, ok := l.simpleIdentPatternName(idx); ok {
+		return idx, l.identExpr(name, start, end), true
+	}
+	return 0, 0, false
+}
+
+func (l *selfhostStableLowerer) appendCallParts(idx int) (base int, item int, ok bool) {
+	call := l.node(idx)
+	if call == nil || !l.isCall(call) || !l.isIdentNamed(call.left, "append") || len(call.children) != 2 {
+		return 0, 0, false
+	}
+	return call.children[0], call.children[1], true
+}
+
+func (l *selfhostStableLowerer) tuplePatternElems(idx int) (first int, second int, ok bool) {
+	n := l.node(idx)
+	if n == nil {
+		return 0, 0, false
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNPattern:
+		if n.extra != astPatternTupleKind() || len(n.children) != 2 {
+			return 0, 0, false
+		}
+		return n.children[0], n.children[1], true
+	case *AstNodeKind_AstNTuple:
+		if len(n.children) != 2 {
+			return 0, 0, false
+		}
+		return n.children[0], n.children[1], true
+	default:
+		return 0, 0, false
+	}
+}
+
+func (l *selfhostStableLowerer) pushExprStmt(base int, item int, start, end int) int {
+	stmt := emptyAstNode(AstNodeKind(&AstNodeKind_AstNExprStmt{}))
+	stmt.left = l.pushCallExpr(base, item, start, end)
+	stmt.start = start
+	stmt.end = end
+	return astArenaAdd(l.arena, stmt)
+}
+
+func (l *selfhostStableLowerer) pushCallExpr(base int, item int, start, end int) int {
+	name, ok := l.identName(base)
+	if !ok {
+		name = ""
+	}
+	field := emptyAstNode(AstNodeKind(&AstNodeKind_AstNField{}))
+	field.left = l.identExpr(name, start, end)
+	field.text = "push"
+	field.start = start
+	field.end = end
+	fieldIdx := astArenaAdd(l.arena, field)
+
+	call := emptyAstNode(AstNodeKind(&AstNodeKind_AstNCall{}))
+	call.left = fieldIdx
+	call.children = []int{item}
+	call.start = start
+	call.end = end
+	return astArenaAdd(l.arena, call)
+}
+
+func (l *selfhostStableLowerer) zeroArgMethodCall(receiver, method string, start, end int) int {
+	field := emptyAstNode(AstNodeKind(&AstNodeKind_AstNField{}))
+	field.left = l.identExpr(receiver, start, end)
+	field.text = method
+	field.start = start
+	field.end = end
+	fieldIdx := astArenaAdd(l.arena, field)
+
+	call := emptyAstNode(AstNodeKind(&AstNodeKind_AstNCall{}))
+	call.left = fieldIdx
+	call.start = start
+	call.end = end
+	return astArenaAdd(l.arena, call)
+}
+
+func (l *selfhostStableLowerer) identExpr(name string, start, end int) int {
+	n := emptyAstNode(AstNodeKind(&AstNodeKind_AstNIdent{}))
+	n.text = name
+	n.start = start
+	n.end = end
+	return astArenaAdd(l.arena, n)
+}
+
+func (l *selfhostStableLowerer) identPattern(name string, start, end int) int {
+	n := emptyAstNode(AstNodeKind(&AstNodeKind_AstNPattern{}))
+	n.text = name
+	n.extra = astPatternIdentKind()
+	n.start = start
+	n.end = end
+	return astArenaAdd(l.arena, n)
+}
+
+func (l *selfhostStableLowerer) simpleIdentPatternName(idx int) (string, bool) {
+	n := l.node(idx)
+	if n == nil {
+		return "", false
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNPattern:
+		if n.extra == astPatternIdentKind() && n.text != "" && n.text != "_" {
+			return n.text, true
+		}
+	case *AstNodeKind_AstNIdent:
+		if n.text != "" && n.text != "_" {
+			return n.text, true
+		}
+	}
+	return "", false
+}
+
+func (l *selfhostStableLowerer) isWildcardPattern(idx int) bool {
+	n := l.node(idx)
+	if n == nil {
+		return false
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNPattern:
+		// opExprToForPattern currently preserves `_` as an ident-pattern when a
+		// for-in binding starts from an expression tuple, so accept that shape
+		// here for parity with the Go parser's enumerate lowering.
+		return n.extra == astPatternWildcardKind() || n.text == "_" || n.text == "wildcard"
+	case *AstNodeKind_AstNIdent:
+		return n.text == "_"
+	default:
+		return false
+	}
+}
+
+func (l *selfhostStableLowerer) identName(idx int) (string, bool) {
+	n := l.node(idx)
+	if n == nil {
+		return "", false
+	}
+	if _, ok := n.kind.(*AstNodeKind_AstNIdent); !ok {
+		return "", false
+	}
+	if n.text == "" {
+		return "", false
+	}
+	return n.text, true
+}
+
+func (l *selfhostStableLowerer) isAppendCall(idx int) bool {
+	_, _, ok := l.appendCallParts(idx)
+	return ok
+}
+
+func (l *selfhostStableLowerer) isForIn(n *AstNode) bool {
+	return n != nil && l.isFor(n) && n.text == "forin"
+}
+
+func (l *selfhostStableLowerer) isFor(n *AstNode) bool {
+	if n == nil {
+		return false
+	}
+	_, ok := n.kind.(*AstNodeKind_AstNFor)
+	return ok
+}
+
+func (l *selfhostStableLowerer) isCall(n *AstNode) bool {
+	if n == nil {
+		return false
+	}
+	_, ok := n.kind.(*AstNodeKind_AstNCall)
+	return ok
+}
+
+func (l *selfhostStableLowerer) isIdentNamed(idx int, name string) bool {
+	got, ok := l.identName(idx)
+	return ok && got == name
+}
+
+func (l *selfhostStableLowerer) isFieldNamed(n *AstNode, name string) bool {
+	if n == nil {
+		return false
+	}
+	if _, ok := n.kind.(*AstNodeKind_AstNField); !ok {
+		return false
+	}
+	return n.text == name
+}
+
+func (l *selfhostStableLowerer) node(idx int) *AstNode {
+	if l == nil || l.arena == nil || idx < 0 || idx >= len(l.arena.nodes) {
+		return nil
+	}
+	return l.arena.nodes[idx]
+}


### PR DESCRIPTION
## What changed
- ported parser-owned `stableLowerer` helper rewrites into the selfhost semantic AST path used by selfhost check/resolve/package flows
- added a new selfhost lowering pass for `len`, `append`, and `enumerate` tuple-loop desugaring parity
- taught the selfhost parser's `for` head expr-to-pattern path to accept discard `_` without emitting the stray `E0604` parse diagnostic
- updated CLI and selfhost regression tests to cover `enumerate`, wildcard tuple bindings, and semantic helper lowerings on the default selfhost path

## Why
The selfhost parser/check pipeline was still missing a parser-owned lowering that the Go parser's `stableLowerer` already applies. That gap left default selfhost flows unable to accept inputs like `for (_, item) in enumerate(items)` and helper calls in the same regression family as issue #755.

## Impact
Default selfhost `check --no-airepair` now accepts the affected helper/desugared forms without needing the legacy parser path, and the parser no longer emits the false `_ can only be used as a pattern` diagnostic in `for` heads.

## Validation
- `go test -count=1 -vet=off ./cmd/osty -run 'TestCheckWithoutAIRepairPassesParserLoweredEnumerateLoop|TestCheckWithoutAIRepairPassesParserLoweredSemanticHelpers' -v`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestCheckStructuredFromRunMatchesCheckSourceStructured|TestRunDiagnosticsAllowDiscardInForInHead|TestCheckSourceStructuredIsAstbridgeFree|TestCheckPackageStructuredIsAstbridgeFree' -v`