### PR TITLE
perf(selfhost): defer lexer diagnostics on native run path

### DIFF
--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -93,8 +93,6 @@ func runFrontend(src []byte, adaptTokens bool) *FrontendRun {
 	run := &FrontendRun{text: text, rt: rt, stream: stream, parser: p}
 	if adaptTokens {
 		run.ensureLexAdapted()
-	} else {
-		run.lexDiags = lexDiagnosticsFromFacts(rt, stream, run.facts())
 	}
 	return run
 }

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -61,11 +61,17 @@ func TestRunDefersLexAdaptationUntilTokensRequested(t *testing.T) {
 	if run.adapted {
 		t.Fatal("Run eagerly adapted lex surfaces")
 	}
+	if run.lexDiags != nil {
+		t.Fatal("Run eagerly adapted lexer diagnostics")
+	}
 	if diags := run.Diagnostics(); len(diags) != 0 {
 		t.Fatalf("Diagnostics = %#v, want none", diags)
 	}
 	if run.adapted {
 		t.Fatal("Diagnostics() should not force token/comment adaptation")
+	}
+	if run.lexDiags == nil {
+		t.Fatal("Diagnostics() should populate lexer diagnostics lazily")
 	}
 	if toks := run.Tokens(); len(toks) == 0 {
 		t.Fatal("Tokens() returned no tokens")


### PR DESCRIPTION
## Summary
- defer lexer diagnostics materialization for `selfhost.Run` native fast paths until diagnostics are actually requested
- extend the lazy-run regression test to pin the new `lexDiags` behavior
- keep the existing token/comment adaptation lazy path unchanged

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestRunDefersLexAdaptationUntilTokensRequested|TestCheckStructuredFromRun|TestCheckFromSource|TestCheckSourceStructuredIsAstbridgeFree'`
- `go test -count=1 -vet=off ./internal/parser ./internal/resolve ./internal/lsp`

## Bench Notes
- `BenchmarkRunDiagnostics`: `55376 ns/op` -> `52089 ns/op`
- `BenchmarkCheckStructuredFromRun`: `349612 ns/op` -> `338625 ns/op`, `5850 allocs/op` -> `5784 allocs/op`