### PR TITLE
fix(mir): remove OptionalType from isScalarPayload so Some(v) narrows

### DIFF
--- a/internal/backend/llvm_match_option_scrutinee_test.go
+++ b/internal/backend/llvm_match_option_scrutinee_test.go
@@ -1,0 +1,70 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsMatchOptionScrutineeBindsPayload covers a
+// subtle MIR projection bug where `match <scrut>: T? { Some(v) -> ... }`
+// typed the `v` binding as `T?` instead of `T`. The failure surfaced
+// downstream as "println of non-primitive Int?" because `v` flowed
+// into `println` with the wrong LLVM aggregate type.
+//
+// Root cause: `isScalarPayload` classified `*ir.OptionalType` as
+// scalar, so the short-circuit in `variantLookupPayloadType`
+// (`isScalarPayload(scrutT) && idx == 0 → return scrutT`) fired on
+// the FIRST ProjVariant(Some) against an `Int?` scrutinee — before
+// the variant-container → payload narrowing could run. The bind then
+// inherited the unnarrowed Option<Int> type.
+//
+// The short-circuit's original purpose is "ProjVariantN(0) after
+// ProjVariant already narrowed to a scalar is redundant" — that
+// semantic only applies when the value is genuinely scalar-leaf
+// (PrimType / FnType), not when it's still a variant container like
+// OptionalType. Removing OptionalType from the classifier lets
+// projectionResultType / projectionToPlace correctly narrow through
+// the Some-variant step.
+//
+// Patterns covered:
+//   - List<Int>.first() scrutinee → Some(v: Int)
+//   - empty list → None arm reached
+//   - List<String>.last() → Some(s: String) with String payload
+func TestLLVMBackendBinaryRunsMatchOptionScrutineeBindsPayload(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    match xs.first() {
+        Some(v) -> println(v),
+        None -> println(-1),
+    }
+
+    let empty: List<Int> = []
+    match empty.first() {
+        Some(v) -> println(v),
+        None -> println(-999),
+    }
+
+    let strs: List<String> = ["hello", "world"]
+    match strs.last() {
+        Some(s) -> println(s),
+        None -> println("empty"),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "10\n-999\nworld\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4548,11 +4548,20 @@ func channelElementType(t ir.Type) Type {
 // that already represents a variant's single payload element. Used to
 // detect redundant ProjVariantN steps after a ProjVariant has already
 // descended into a scalar payload.
+// isScalarPayload reports whether `t` is already a "leaf" payload
+// type from a variant projection's perspective — i.e. `ProjVariantN(0)`
+// against it is redundant because there's no further variant
+// structure to narrow through.
+//
+// OptionalType is NOT scalar: it's a variant container
+// (`Some(T) | None`), and `variantLookupPayloadType` needs to actually
+// narrow through it. Including OptionalType here used to short-circuit
+// the first ProjVariant(Some) on an `Int?` scrutinee, so the bound
+// name in `match xs.first() { Some(v) -> … }` got typed `Int?`
+// instead of `Int`.
 func isScalarPayload(t ir.Type) bool {
 	switch t.(type) {
 	case *ir.PrimType:
-		return true
-	case *ir.OptionalType:
 		return true
 	case *ir.FnType:
 		return true


### PR DESCRIPTION
## Summary

- `match <scrut>: T? { Some(v) -> …, None -> … }` typed the `v` binding as `T?` instead of `T`; downstream uses tripped e.g. `println of non-primitive Int?` at the MIR fallback gate
- Root cause: `isScalarPayload` classified `*ir.OptionalType` as scalar, so the short-circuit in `variantLookupPayloadType` fired on the first `ProjVariant(Some)` against a `T?` scrutinee — returning the unnarrowed container before the proper `OptionalType → Inner` narrowing could run
- Fix is a 1-line classifier change; existing OptionalType fallback already handles the `Some → Inner` case correctly for both first-layer and nested patterns

## Repro (pre-fix)

```osty
fn main() {
    let xs: List<Int> = [10, 20, 30]
    match xs.first() {
        Some(v) -> println(v),   // v typed as Int? instead of Int
        None -> println(-1),
    }
}
```

Pre-fix trace (`OSTY_TRACE_MIR_FALLBACK=1`):
```
osty-mir-fallback: /tmp/.../main.osty: LLVM000 unsupported-source: println of non-primitive Int?
```

Post-fix: prints `10`.

## Root cause

[internal/mir/lower.go:4420](internal/mir/lower.go:4420) `variantLookupPayloadType` has an optimization short-circuit:

```go
if isScalarPayload(scrutT) && idx == 0 {
    return scrutT
}
```

Its purpose: "if a prior `ProjVariant` already descended past the payload tuple boundary into a scalar-leaf type, a following `ProjVariantN(0)` is redundant — skip the extra projection".

That semantic only applies when the value is genuinely a scalar leaf (PrimType / FnType). `OptionalType` is still a variant container (`Some(T) | None`) — variant projections need to actually narrow through it. But the classifier included OptionalType:

```go
case *ir.OptionalType:
    return true    // ← wrong
```

So the very first `ProjVariant(Some)` against `Int?` took the short-circuit and returned `Int?` unchanged, never reaching the `if ot, ok := scrutT.(*OptionalType); ok: return ot.Inner` fallback below.

The bound-name's local then carried the wrong type through `newLocal("v", Int?, …)` → MIR emitter rejected downstream uses that wanted a scalar.

## Nested case

`Some(Some(x))` on `Option<Option<Int>>` also benefits:
- outer `ProjVariant(Some)`: narrows to `Option<Int>`
- inner `ProjVariantN(Some, 0)`: now narrows to `Int` (previously short-circuited back to `Option<Int>`)

## Test plan

- [x] `TestLLVMBackendBinaryRunsMatchOptionScrutineeBindsPayload` — three shapes:
  - `xs.first()` on `[10, 20, 30]` → Some arm: prints `10`
  - empty list → None arm reached: prints `-999`
  - `strs.last()` on `["hello", "world"]` → Some(String) payload: prints `world`
- [x] `just front` — 8 frontend packages green
- [x] `go test ./internal/mir/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)