### PR TITLE
fix(llvmgen): List.get(i) Option<T> dest emits len-guarded Some/None

### DIFF
--- a/internal/backend/llvm_list_get_safe_test.go
+++ b/internal/backend/llvm_list_get_safe_test.go
@@ -1,0 +1,89 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsListSafeGetOption covers the
+// `list.get(i) -> T?` ABI mismatch: the MIR `IntrinsicListGet` is
+// documented as "Dest is T" (matching `list[i]` indexing, aborts on
+// OOB) but `list.get(i)` returns `T?` and expects the Option
+// aggregate. The emitter was calling `osty_rt_list_get_<kind>`
+// (returns raw T) and storing the raw scalar into an `%Option.T`
+// slot — clang rejected with:
+//
+//   '%tN' defined with type 'i64' but expected '%Option.i64'
+//
+// Fix detects `i.Dest` typed as OptionalType and routes through a
+// bounds-guarded len-check + Some/None wrap (same pattern as
+// emitListIntrinsic for First/Last in #783). Scalar elements widen
+// to i64 before insertvalue to match the fixed Option slot width.
+//
+// OOB semantics: both negative idx and idx >= len yield None (matches
+// the stdlib spec for `.get`, distinct from `list[i]` which aborts).
+func TestLLVMBackendBinaryRunsListSafeGetOption(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    println(xs.get(0) ?? -1)
+    println(xs.get(2) ?? -1)
+    println(xs.get(5) ?? -99)
+    println(xs.get(-1) ?? -99)
+
+    let strs: List<String> = ["a", "b", "c"]
+    println(strs.get(0) ?? "none")
+    println(strs.get(9) ?? "none")
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "10\n30\n-99\n-99\na\nnone\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListSafeGetMatch exercises the match-arm
+// form of the same pattern — ensures the Option aggregate produced
+// by safe-get flows through the match-scrutinee binding path and
+// the Some/None arms type-check cleanly.
+func TestLLVMBackendBinaryRunsListSafeGetMatch(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    match xs.get(1) {
+        Some(v) -> println(v),
+        None -> println(-1),
+    }
+    match xs.get(99) {
+        Some(v) -> println(v),
+        None -> println(-1),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "20\n-1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -4333,6 +4333,19 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
+		// `list[i]` and `list.get(i)` both map to IntrinsicListGet, but
+		// the stdlib sig for `.get` is `T?` (safe, returns None on OOB)
+		// while `list[i]` is the abort-on-OOB form (T). Detect the
+		// Option<T> dest and emit the len-guarded Some/None wrap
+		// instead of a raw typed-get that would type-mismatch when
+		// stored into the Option slot.
+		if i.Dest != nil && listUsesTypedRuntime(elemLLVM) {
+			if destLoc := g.fn.Local(i.Dest.Local); destLoc != nil {
+				if _, optDest := destLoc.Type.(*ir.OptionalType); optDest {
+					return g.emitListSafeGet(i, listReg, idxReg, elemLLVM, destLoc.Type)
+				}
+			}
+		}
 		if listUsesTypedRuntime(elemLLVM) {
 			if local, ok := mirOperandRootLocal(listOp); ok && listUsesRawDataFastPath(elemLLVM) {
 				if fast, ok := g.emitVectorListFastLoad(local, idxReg, elemLLVM); ok {
@@ -7452,6 +7465,65 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 // runtime helper. Allocates a stack slot sized to the element type,
 // asks the runtime to write into it, loads back, and stores into
 // the intrinsic's optional destination.
+// emitListSafeGet lowers `list.get(i)` where the dest is `Option<T>`.
+// The runtime `osty_rt_list_get_<kind>` aborts on OOB, so we gate the
+// call behind an in-bounds check and materialise None for the OOB
+// branch. Pattern mirrors emitListIntrinsic(IntrinsicListFirst/Last).
+// Scalar elements only — composite element types go through the
+// existing bytes-v1 path and aren't rewrapped here.
+func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLVM string, destT mir.Type) error {
+	destLLVM := g.llvmType(destT)
+	destSlot := g.localSlots[i.Dest.Local]
+	lenSym := listRuntimeLenSymbol()
+	g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+	getSym := listRuntimeGetSymbol(elemLLVM)
+	g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+	lenReg := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+	nonNeg := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = icmp sge i64 %s, 0\n", nonNeg, idxReg)
+	inUpper := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = icmp slt i64 %s, %s\n", inUpper, idxReg, lenReg)
+	inBounds := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = and i1 %s, %s\n", inBounds, nonNeg, inUpper)
+	someLabel := g.freshLabel("list.safeget.some")
+	noneLabel := g.freshLabel("list.safeget.none")
+	endLabel := g.freshLabel("list.safeget.end")
+	fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", inBounds, someLabel, noneLabel)
+	fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+	fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
+	fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+	fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+	elemReg := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
+	payloadReg := elemReg
+	switch elemLLVM {
+	case "i64":
+	case "i1", "i8", "i16", "i32":
+		widened := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
+		payloadReg = widened
+	case "double":
+		cast := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
+		payloadReg = cast
+	case "ptr":
+		cast := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
+		payloadReg = cast
+	default:
+		return unsupported("mir-mvp", fmt.Sprintf("list_get safe payload widen unsupported for %s", elemLLVM))
+	}
+	tagged := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+	filled := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
+	fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
+	fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+	fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+	return nil
+}
+
 func (g *mirGen) emitListGetBytes(i *mir.IntrinsicInstr, listReg, idxReg string, elemT mir.Type) error {
 	elemLLVM := g.llvmType(elemT)
 	sym := listRuntimeGetBytesV1Symbol()


### PR DESCRIPTION
## Summary

- `list.get(i) -> T?` (safe, returns None on OOB) shares the MIR `IntrinsicListGet` shape with `list[i]` (aborts on OOB, Dest=T), so the emitter called `osty_rt_list_get_<kind>` — returning raw scalar — and stored it into the Option slot, tripping clang's type mismatch
- Detects `i.Dest` typed `*ir.OptionalType` and routes through a bounds-guarded `Some/None` wrap, same pattern as #783's List.first/last

## Repro (pre-fix)

```osty
fn main() {
    let xs: List<Int> = [10, 20, 30]
    println(xs.get(0) ?? -1)
}
```

Pre-fix:
```
/tmp/.../main.ll: '%t2' defined with type 'i64' but expected '%Option.i64 = type { i64, i64 }'
  store %Option.i64 %t2, ptr %l2
                    ^
```

Post-fix: prints `10`.

## OOB semantics

Safe-get (this PR) returns `None` on negative idx and idx ≥ len, matching the stdlib spec. The abort-on-OOB `list[i]` form is unchanged — `IntrinsicListGet` with a raw `T` dest still hits the typed-get path.

## Widening

Scalar elem types widen to i64 before `insertvalue` so the Option's fixed-width payload slot stays consistent:

| elem LLVM | coercion |
|---|---|
| i64 | no-op |
| i1/i8/i16/i32 | zext |
| double | bitcast |
| ptr | ptrtoint |

Composite elements still route through `emitListGetBytes` (no change).

## Test plan

- [x] `TestLLVMBackendBinaryRunsListSafeGetOption` — `?? fallback` form over Int + String lists, in-bounds / over-index / negative-index
- [x] `TestLLVMBackendBinaryRunsListSafeGetMatch` — match-arm form, Some(v) / None both reached
- [x] `just front` — 8 frontend packages green
- [x] Pre-fix: both tests trip the clang type mismatch. Post-fix: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)