### PR TITLE
fix(llvmgen): List.pop() returns real Some(T), not zeroed placeholder

### DIFF
--- a/internal/backend/llvm_list_pop_option_test.go
+++ b/internal/backend/llvm_list_pop_option_test.go
@@ -1,0 +1,88 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsListPopReturnsRealValue covers the MIR
+// emitter bug where `xs.pop()` — which the stdlib declares as
+// `-> T?` — silently returned a zero-initialised `Option<T>` (i.e.
+// always `None`) and called `osty_rt_list_pop_discard` separately.
+// The MIR IntrinsicListPop comment admitted the shortcut: "A future
+// typed-pop runtime family can replace this with real Some(T)
+// returns."
+//
+// This PR implements the real `Some(T)` return by computing
+// `list[len-1]` via `osty_rt_list_get_<kind>` BEFORE the discard,
+// wrapping in `Some` for the non-empty branch and `None` for the
+// empty branch. The dest-less form (`xs.pop()` as a statement, or
+// `let _ = xs.pop()`) still routes through the raw `pop_discard`
+// call — matching the existing AST-path behaviour exercised by
+// TestGenerateDiscardedListPopNoLongerTripsLLVM015.
+func TestLLVMBackendBinaryRunsListPopReturnsRealValue(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut xs: List<Int> = [1, 2, 3, 4, 5]
+    match xs.pop() {
+        Some(v) -> println(v),
+        None -> println(-1),
+    }
+    println(xs.pop() ?? -1)
+    println(xs.len())
+
+    let mut empty: List<Int> = []
+    match empty.pop() {
+        Some(v) -> println(v),
+        None -> println(-99),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	// Drain order: 5 (from [1..5]), then 4, leaving len 3. Empty list
+	// pop reaches the None arm.
+	if got, want := string(output), "5\n4\n3\n-99\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListPopString verifies the ptr-slot widening
+// path — Option<String> stores the popped pointer as i64 through
+// ptrtoint, matching the layout convention used by List.first/last and
+// the new List.get safe-get path.
+func TestLLVMBackendBinaryRunsListPopString(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut strs: List<String> = ["a", "b", "c"]
+    println(strs.pop() ?? "none")
+    println(strs.pop() ?? "none")
+    println(strs.pop() ?? "none")
+    println(strs.pop() ?? "none")
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "c\nb\na\nnone\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -4464,34 +4464,76 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
 		return nil
 	case mir.IntrinsicListPop:
-		// Runtime exposes `osty_rt_list_pop_discard` — drops the last
-		// element without returning it. All toolchain uses of
-		// `xs.pop()` currently discard the result (`let _ = xs.pop()`
-		// or bare-statement form), so the dest gets a zero-initialized
-		// Option<T> placeholder. A future typed-pop runtime family can
-		// replace this with real Some(T) returns.
-		sym := "osty_rt_list_pop_discard"
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(listReg)
-		g.fnBuf.WriteString(")\n")
+		// `xs.pop()` returns `Option<T>` — the last element wrapped in
+		// Some, or None for an empty list. The runtime's
+		// `osty_rt_list_pop_discard` drops the tail but aborts on
+		// empty, so we gate it behind a `len > 0` check and compute the
+		// returned value via `list_get_<kind>(list, len-1)` before the
+		// discard so the element is captured.
+		discardSym := "osty_rt_list_pop_discard"
+		g.declareRuntime(discardSym, "declare void @"+discardSym+"(ptr)")
 		if i.Dest == nil {
+			// Statement-position `xs.pop()` with no dest: fall back
+			// to the classic discard-and-abort path.
+			fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
 			return nil
 		}
-		// Zero-init the dest (None for Option<T>).
 		destLoc := g.fn.Local(i.Dest.Local)
 		if destLoc == nil {
+			fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
 			return nil
+		}
+		if !listUsesTypedRuntime(elemLLVM) {
+			return unsupported("mir-mvp", fmt.Sprintf("list_pop on composite element type %s", elemLLVM))
 		}
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
-		g.fnBuf.WriteString("  store ")
-		g.fnBuf.WriteString(destLLVM)
-		g.fnBuf.WriteString(" zeroinitializer, ptr ")
-		g.fnBuf.WriteString(destSlot)
-		g.fnBuf.WriteByte('\n')
+		lenSym := listRuntimeLenSymbol()
+		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		getSym := listRuntimeGetSymbol(elemLLVM)
+		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		lenReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+		isEmpty := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isEmpty, lenReg)
+		someLabel := g.freshLabel("list.pop.some")
+		noneLabel := g.freshLabel("list.pop.none")
+		endLabel := g.freshLabel("list.pop.end")
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isEmpty, noneLabel, someLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		lastIdx := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", lastIdx, lenReg)
+		elemReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, lastIdx)
+		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
+		payloadReg := elemReg
+		switch elemLLVM {
+		case "i64":
+		case "i1", "i8", "i16", "i32":
+			widened := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
+			payloadReg = widened
+		case "double":
+			cast := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
+			payloadReg = cast
+		case "ptr":
+			cast := g.fresh()
+			fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
+			payloadReg = cast
+		default:
+			return unsupported("mir-mvp", fmt.Sprintf("list_pop payload widen unsupported for %s", elemLLVM))
+		}
+		tagged := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		filled := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("list intrinsic kind %d", i.Kind))


### PR DESCRIPTION
## Summary

- `xs.pop()` returns `Option<T>` per stdlib, but the MIR emitter had a TODO in its `IntrinsicListPop` handler: it called `osty_rt_list_pop_discard` for the mutation but zero-initialised the Option dest — so expression-position uses always saw `None` even when a real value was popped
- Fix: compute `list[len-1]` via `osty_rt_list_get_<kind>` BEFORE the discard, wrap in Some for non-empty, None for empty. Pattern matches the len-guarded Some/None wraps in #783 (first/last) and #790 (safe-get)

## Repro (pre-fix)

```osty
fn main() {
    let mut xs: List<Int> = [1, 2, 3]
    match xs.pop() {
        Some(v) -> println(v),
        None -> println(-1),
    }
    println(xs.len())
}
```

Pre-fix: prints `-1 / 2` — pop always hits None arm even though list mutated correctly.
Post-fix: prints `3 / 2` — real popped value surfaces.

## Emission shape

```llvm
%len      = call i64 @osty_rt_list_len(%list)
%is_empty = icmp eq i64 %len, 0
br i1 %is_empty, label %none, label %some
none:
  store %Option.<T> zeroinitializer, ptr %destSlot
  br label %end
some:
  %last = sub i64 %len, 1
  %elem = call <T> @osty_rt_list_get_<kind>(%list, %last)
  call void @osty_rt_list_pop_discard(%list)
  %pay  = <widen %elem to i64>
  %tag  = insertvalue %Option.<T> undef, i64 1, 0
  %wrap = insertvalue %Option.<T> %tag, i64 %pay, 1
  store %Option.<T> %wrap, ptr %destSlot
  br label %end
```

Widening matches the existing Option-slot layout (`{i64 tag, i64 value}`) — i1/i8/i16/i32 zext, double bitcast, ptr ptrtoint.

## Dest-less form unchanged

Statement form (`xs.pop()`) and `let _ = xs.pop()` still route through the plain `pop_discard` path, preserving the existing AST-path behaviour exercised by `TestGenerateDiscardedListPopNoLongerTripsLLVM015` and `TestGenerateExprStmtListPopNoLongerTripsLLVM015`.

## Test plan

- [x] `TestLLVMBackendBinaryRunsListPopReturnsRealValue` — drain [1,2,3,4,5] via match + `??`, empty list reaches None arm
- [x] `TestLLVMBackendBinaryRunsListPopString` — ptr-backed List<String> drained to empty
- [x] `just front` — 8 frontend packages green
- [x] Existing `ListPop` tests pass unchanged (AST-path discard semantics preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)