### PR TITLE
perf(mir): fuse map.keys().sorted() into single runtime call

### DIFF
--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -177,6 +177,15 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	if opts.UseMIR && entry.MIR != nil {
 		irOut, genErr = llvmgen.GenerateFromMIR(entry.MIR, opts)
 		if genErr != nil && errors.Is(genErr, llvmgen.ErrUnsupported) {
+			// OSTY_TRACE_MIR_FALLBACK is the probe env flag that prints
+			// which shape made the MIR emitter refuse. Off by default
+			// so user-facing `osty test` / `osty build` stays quiet —
+			// wire it on when extending MIR coverage to see the
+			// specific unsupported symbol/type hint the emitter
+			// surfaces.
+			if os.Getenv("OSTY_TRACE_MIR_FALLBACK") != "" {
+				fmt.Fprintf(os.Stderr, "osty-mir-fallback: %s: %v\n", entry.SourcePath, genErr)
+			}
 			// MIR emitter refused — fall back to the HIR path.
 			opts.UseMIR = false
 			irOut, genErr = llvmgen.GenerateModule(entry.IR, opts)

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -6080,6 +6080,34 @@ void *osty_rt_map_keys(void *raw_map) {
     return out;
 }
 
+/* osty_rt_map_keys_sorted_<suffix> — `map.keys()` + `list.sorted()`
+ * fused into one allocation. The unfused sequence creates the keys
+ * list, then allocates a *second* list inside sorted() and copies
+ * into it before qsort. Fusing saves the second list allocation —
+ * we qsort the freshly-built keys buffer in place before the caller
+ * ever sees it. Matches the `.keys().sorted()` shape every
+ * Map-aggregation bench (word_freq, record_pipeline, csv_parse) ends
+ * with. One variant per key suffix to route through the right
+ * comparator; i64 and string are wired because those are the key
+ * kinds the osty-vs-go sweep exercises. */
+void *osty_rt_map_keys_sorted_string(void *raw_map) {
+    void *keys = osty_rt_map_keys(raw_map);
+    osty_rt_list *list = osty_rt_list_cast(keys);
+    if (list->len > 1) {
+        qsort(list->data, (size_t)list->len, sizeof(void *), osty_rt_compare_string_ascending);
+    }
+    return keys;
+}
+
+void *osty_rt_map_keys_sorted_i64(void *raw_map) {
+    void *keys = osty_rt_map_keys(raw_map);
+    osty_rt_list *list = osty_rt_list_cast(keys);
+    if (list->len > 1) {
+        qsort(list->data, (size_t)list->len, sizeof(int64_t), osty_rt_compare_i64_ascending);
+    }
+    return keys;
+}
+
 // Every public keyed op takes the per-map lock, runs the raw op, and
 // releases. Recursive so that `update`'s outer lock + a re-entrant op
 // from a user callback (e.g. counts.len() inside f) don't deadlock.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4404,14 +4404,20 @@ void *osty_rt_list_get_ptr(void *raw_list, int64_t index) {
     return osty_gc_load_v1(value);
 }
 
-void osty_rt_list_get_bytes(void *raw_list, int64_t index, void *out_value, int64_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+OSTY_HOT_INLINE void osty_rt_list_get_bytes(void *raw_list, int64_t index, void *out_value, int64_t elem_size, osty_rt_trace_slot_fn trace_elem) {
     if (out_value == NULL || elem_size < 0) {
         osty_rt_abort("invalid list get_bytes call");
     }
     memcpy(out_value, osty_rt_list_get_raw(raw_list, index, (size_t)elem_size, trace_elem), (size_t)elem_size);
 }
 
-void osty_rt_list_get_bytes_v1(void *raw_list, int64_t index, void *out, int64_t elem_size) {
+/* Hot path for struct-element list iteration (`for row in rows` where
+ * rows: List<Record>). Inlined so LTO can see the memcpy against a
+ * fixed-size struct and let SROA split the per-iter alloca + load into
+ * direct per-field loads — record_pipeline's analyzeRecordPipeline
+ * reads 3 struct fields per row × 192 rows, so the memcpy-round-trip
+ * overhead compounds quickly without this. */
+OSTY_HOT_INLINE void osty_rt_list_get_bytes_v1(void *raw_list, int64_t index, void *out, int64_t elem_size) {
     if (out == NULL) {
         osty_rt_abort("list output buffer is null");
     }

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1079,7 +1079,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove:
+		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -4217,7 +4217,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitListIntrinsic(i)
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove:
+		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return g.emitMapIntrinsic(i)
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -4581,6 +4581,34 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			&LlvmValue{typ: keyLLVM, name: kReg},
 			keyString)
 		g.flushOstyEmitter(em)
+		return nil
+	case mir.IntrinsicMapKeysSorted:
+		// Fused `map.keys().sorted()` → single runtime call. Saves the
+		// extra list allocation the unfused form does inside
+		// `osty_rt_list_sorted_<suffix>`. Key-type dispatched: the HIR
+		// matcher only emits this when the key has a registered
+		// comparator (i64 / string), so we just pick the symbol.
+		suffix := "string"
+		if !keyString {
+			suffix = llvmMapKeySuffix(keyLLVM, false)
+		}
+		sym := "osty_rt_map_keys_sorted_" + suffix
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		tmp := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(" = call ptr @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(mapReg)
+		g.fnBuf.WriteString(")\n")
+		if i.Dest != nil {
+			g.fnBuf.WriteString("  store ptr ")
+			g.fnBuf.WriteString(tmp)
+			g.fnBuf.WriteString(", ptr ")
+			g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+			g.fnBuf.WriteByte('\n')
+		}
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("map intrinsic kind %d", i.Kind))

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -754,6 +754,35 @@ func (bs *bodyState) lowerBlockStmt(b *ir.Block) {
 	bs.popScope()
 }
 
+// mapKVFromMapType peels a Map<K, V> named type into its (K, V) type
+// args. Returns (nil, nil) for anything else. Used by the HIR-level
+// peephole matchers that fuse common Map access patterns before
+// reaching MIR emit.
+func mapKVFromMapType(t ir.Type) (ir.Type, ir.Type) {
+	named, ok := t.(*ir.NamedType)
+	if !ok || named.Name != "Map" || len(named.Args) != 2 {
+		return nil, nil
+	}
+	return named.Args[0], named.Args[1]
+}
+
+// mapKeyHasRuntimeSort reports whether `osty_rt_map_keys_sorted_<suf>`
+// exists for this key type. Only i64 and string are currently
+// implemented — floats would need a NaN-stable comparator and bools
+// don't benefit from sorting in practice.
+func mapKeyHasRuntimeSort(t ir.Type) bool {
+	if pt, ok := t.(*ir.PrimType); ok {
+		switch pt.Kind {
+		case ir.PrimInt, ir.PrimInt64, ir.PrimString:
+			return true
+		}
+	}
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "Int" || nt.Name == "String"
+	}
+	return false
+}
+
 func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	t := let.Type
 	if isPoisonType(t) && let.Value != nil {
@@ -3254,6 +3283,36 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 			SpanV: mc.SpanV,
 		})
 		return
+	}
+
+	// Peephole: `map.keys().sorted()` fuses to a single
+	// IntrinsicMapKeysSorted runtime call, saving the intermediate
+	// unsorted-keys-list allocation. Every Map-aggregation bench
+	// (word_freq, record_pipeline, csv_parse) ends with a
+	// `totals.keys().sorted()` to fold the map into a stable
+	// checksum, so the saved allocation compounds across iterations.
+	// The rewrite is strict: only fires when the receiver is itself a
+	// MethodCall(.keys) on a Map<K, V> with a registered key
+	// comparator (i64 / string). Anything else falls through to the
+	// unfused lowering.
+	if mc.Name == "sorted" && len(mc.Args) == 0 {
+		if inner, ok := mc.Receiver.(*ir.MethodCall); ok &&
+			inner.Name == "keys" && len(inner.Args) == 0 {
+			if kT, _ := mapKVFromMapType(inner.Receiver.Type()); kT != nil && mapKeyHasRuntimeSort(kT) {
+				mapOp := bs.lowerExprAsOperand(inner.Receiver)
+				destPtr := &dest
+				if isUnit(destT) {
+					destPtr = nil
+				}
+				bs.emit(&IntrinsicInstr{
+					Dest:  destPtr,
+					Kind:  IntrinsicMapKeysSorted,
+					Args:  []Operand{mapOp},
+					SpanV: mc.SpanV,
+				})
+				return
+			}
+		}
 	}
 
 	// Stdlib-intrinsic fast path: List / Map / Set / String / Bytes /

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -505,6 +505,14 @@ const (
 	IntrinsicMapValues
 	// IntrinsicMapRemove deletes a key. Args: [map, key]. Dest nil.
 	IntrinsicMapRemove
+	// IntrinsicMapKeysSorted fuses `map.keys().sorted()` into a single
+	// runtime call, saving the intermediate unsorted-keys-list
+	// allocation that the unfused two-call sequence produces. Args:
+	// [map]. Dest receives `List<K>` (the sorted key list). Currently
+	// limited to maps whose key type has a runtime comparator
+	// registered (i64 / string); the HIR pattern matcher that emits
+	// this rejects other keys and falls back to the unfused lowering.
+	IntrinsicMapKeysSorted
 
 	// ---- stdlib collections: Set<T> ----
 
@@ -1525,6 +1533,8 @@ func (k IntrinsicKind) String() string {
 		return "map_values"
 	case IntrinsicMapRemove:
 		return "map_remove"
+	case IntrinsicMapKeysSorted:
+		return "map_keys_sorted"
 	case IntrinsicSetNew:
 		return "set_new"
 	case IntrinsicSetInsert:


### PR DESCRIPTION
## Why

Every Map-aggregation bench (word_freq, record_pipeline, csv_parse) ends with a `totals.keys().sorted()` to fold the map into a stable checksum. The unfused lowering:

1. `map.keys()` → \`osty_rt_map_keys\` allocates \`List<K>\` and copies keys in.
2. `.sorted()` → \`osty_rt_list_sorted_<suffix>\` allocates a **second** list, copies the keys across, then qsorts the copy.

Two allocations per aggregation step, with the second being pure overhead — qsort doesn't need a fresh buffer.

## Change

- **Runtime**: new `osty_rt_map_keys_sorted_<suffix>(map) -> List<K>` (string, i64) — calls the existing \`osty_rt_map_keys\` and qsorts the freshly-built key buffer in place before returning. One allocation instead of two.
- **MIR intrinsic**: new \`IntrinsicMapKeysSorted\` (Args: \`[map]\`, Dest: \`List<K>\`).
- **HIR matcher**: inside \`lowerMethodCallInto\`, when the method is \`sorted()\` and the receiver is itself \`keys()\` on a \`Map<K, V>\` with a registered key comparator (i64 / string), emit \`IntrinsicMapKeysSorted(map)\` directly. Falls through to the standalone intrinsic chain on anything else — float keys, missing comparator, non-Map receiver, arguments passed to \`sorted()\`.
- **MIR emit**: dispatches \`IntrinsicMapKeysSorted\` to the right \`osty_rt_map_keys_sorted_<suffix>\` symbol based on the receiver map's key LLVM type.

## Reach

The fusion is wired end-to-end but its current impact on the osty-vs-go sweep is limited — record_pipeline and the other Map-aggregation benches still bail to the AST emitter on \`Map.containsKey\` + \`Map.insert\` (kept out of MIR after #768 to avoid an individual-op regression). So the fusion will only fire once MIR covers those shapes too. The runtime helpers land unconditionally though, so an AST-side matcher is a cheap follow-up if the MIR coverage isn't unblocked first.

## Test plan

- [x] \`go test ./cmd/osty-vs-go ./cmd/osty -run Bench\` — passes
- [x] \`go test -short ./internal/mir\` — passes
- [x] Runtime builds clean; no changes to existing \`osty_rt_map_keys\` or \`osty_rt_list_sorted_*\` call sites
- [x] HIR matcher rejects unsupported key types (float, pointer, bool) and non-zero-arg \`.sorted()\` calls — falls through to standalone intrinsics

🤖 Generated with [Claude Code](https://claude.com/claude-code)