### PR TITLE
[codex] Fix hir_print brace escaping

### DIFF
--- a/internal/llvmgen/phantom_range_decl_test.go
+++ b/internal/llvmgen/phantom_range_decl_test.go
@@ -64,6 +64,41 @@ func TestToolchainHasNoPhantomRangeExpr(t *testing.T) {
 	}
 }
 
+// TestToolchainFilesParseWithoutDiagnostics closes the simpler failure
+// mode behind the phantom-node regression above: an unescaped `\{` /
+// `\}` omission in a toolchain string literal can fail the initial
+// parse outright, which then later surfaces as confusing downstream
+// parser/checker walls such as "expected ), got let".
+func TestToolchainFilesParseWithoutDiagnostics(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !ostyToolchainSource(name) {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		file, diags := parser.ParseDiagnostics(src)
+		if len(diags) > 0 {
+			t.Errorf("%s: ParseDiagnostics returned %d diagnostics; first=%v", name, len(diags), diags[0])
+			continue
+		}
+		if file == nil {
+			t.Errorf("%s: ParseDiagnostics returned nil file without diagnostics", name)
+		}
+	}
+}
+
 func ostyToolchainSource(name string) bool {
 	if !hasSuffix(name, ".osty") {
 		return false

--- a/toolchain/hir_print.osty
+++ b/toolchain/hir_print.osty
@@ -575,7 +575,7 @@ fn hirPrintTupleExpr(e: HirExpr, indent: Int) -> String {
 
 fn hirPrintMapExpr(e: HirExpr, indent: Int) -> String {
     let mut parts: List<String> = []
-    parts.push("{")
+    parts.push("\{")
     let mut i = 0
     for en in e.mapEntries {
         if i > 0 {
@@ -586,7 +586,7 @@ fn hirPrintMapExpr(e: HirExpr, indent: Int) -> String {
         parts.push(hirPrintExpr(en.value, indent))
         i = i + 1
     }
-    parts.push("}")
+    parts.push("\}")
     strings.join(parts, "")
 }
 
@@ -594,7 +594,7 @@ fn hirPrintStructLitExpr(e: HirExpr, indent: Int) -> String {
     let mut parts: List<String> = []
     parts.push("(")
     parts.push(e.structTypeName)
-    parts.push(" {")
+    parts.push(" \{")
     let mut i = 0
     for f in e.structFields {
         if i > 0 {
@@ -613,7 +613,7 @@ fn hirPrintStructLitExpr(e: HirExpr, indent: Int) -> String {
         parts.push(" ..")
         parts.push(hirPrintExpr(e.structSpread[0], indent))
     }
-    parts.push("})")
+    parts.push("\})")
     strings.join(parts, "")
 }
 
@@ -731,9 +731,9 @@ fn hirPrintStringLit(e: HirExpr) -> String {
         if part.isLit {
             out = out + hirPrintEscapeString(part.lit)
         } else if part.expr.len() > 0 {
-            out = out + "{"
+            out = out + "\{"
             out = out + hirPrintExpr(part.expr[0], 0)
-            out = out + "}"
+            out = out + "\}"
         }
     }
     out + "\""
@@ -786,7 +786,7 @@ fn hirPrintTuplePattern(p: HirPattern) -> String {
 fn hirPrintStructPattern(p: HirPattern) -> String {
     let mut parts: List<String> = []
     parts.push(p.structTypeName)
-    parts.push(" { ")
+    parts.push(" \{ ")
     let mut i = 0
     for f in p.structFields {
         if i > 0 {
@@ -805,7 +805,7 @@ fn hirPrintStructPattern(p: HirPattern) -> String {
         }
         parts.push("..")
     }
-    parts.push(" }")
+    parts.push(" \}")
     strings.join(parts, "")
 }
 


### PR DESCRIPTION
## What changed
- escape literal `{` / `}` output in `toolchain/hir_print.osty` so selfhost string parsing does not treat them as interpolation markers
- add a regression test that every non-test `toolchain/*.osty` file parses without diagnostics

## Why
The native selfhost path was failing with `E0204: expected ), got let`, but the real root cause was earlier string parsing failure in `hir_print.osty`: bare braces inside string literals were being lexed as interpolation starts. Once the string parse broke, the next `let` tokens surfaced as misleading downstream parser errors.

## Impact
- removes the old `E0204` parser wall at the previous token sites
- `osty check toolchain` now advances to a separate existing issue: `E0703` at `toolchain/manifest_validation.osty:427`

## Validation
- `./.bin/osty parse toolchain/hir_print.osty`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestToolchainFilesParseWithoutDiagnostics|TestToolchainHasNoPhantomRangeExpr'`
- `OSTY_NATIVE_CHECKER_BIN="$PWD/.osty/bin/osty-native-checker" ./.bin/osty check toolchain`