### PR TITLE
feat(llvmgen): implement List.{reverse,reversed,removeAt,indexOf}

### DIFF
--- a/internal/backend/llvm_list_ops_batch_test.go
+++ b/internal/backend/llvm_list_ops_batch_test.go
@@ -1,0 +1,135 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestLLVMBackendBinaryRunsListReverseInPlace covers `xs.reverse()` —
+// an in-place reverse that returns Unit. Routed through the new
+// `IntrinsicListReverse` → `osty_rt_list_reverse` runtime helper
+// (generic byte-swap using list->elem_size, so one C function covers
+// every element type).
+func TestLLVMBackendBinaryRunsListReverseInPlace(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut xs: List<Int> = [1, 2, 3, 4, 5]
+    xs.reverse()
+    for x in xs { println(x) }
+    println(xs.len())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "5\n4\n3\n2\n1\n5\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListReversedNewList covers `xs.reversed()`
+// — returns a freshly allocated List<T> with reversed elements while
+// leaving the original unchanged. The new list inherits the source's
+// elem_size + trace callback so GC bookkeeping stays intact.
+func TestLLVMBackendBinaryRunsListReversedNewList(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let orig: List<Int> = [10, 20, 30]
+    let rev = orig.reversed()
+    for x in rev { println(x) }
+    // Verify source untouched.
+    for x in orig { println(x) }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "30\n20\n10\n10\n20\n30\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListRemoveAt covers `xs.removeAt(i) -> T`
+// (abort-on-OOB). Emitter reads the element via `list_get_<kind>`
+// BEFORE calling `osty_rt_list_remove_at_discard` so the captured
+// value stays valid after the shift.
+func TestLLVMBackendBinaryRunsListRemoveAt(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut xs: List<Int> = [10, 20, 30, 40]
+    let r = xs.removeAt(1)
+    println(r)
+    for x in xs { println(x) }
+    println(xs.len())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "20\n10\n30\n40\n3\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsListIndexOf covers `xs.indexOf(x) -> Int?`
+// — inline linear scan. Found case yields Some(i), not-found yields
+// None. String elements route through the string-equal runtime
+// helper; other scalars use plain icmp / fcmp.
+func TestLLVMBackendBinaryRunsListIndexOf(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let ys: List<Int> = [5, 10, 15, 20, 25]
+    println(ys.indexOf(5) ?? -1)
+    println(ys.indexOf(15) ?? -1)
+    println(ys.indexOf(25) ?? -1)
+    println(ys.indexOf(99) ?? -1)
+
+    let ss: List<String> = ["apple", "banana", "cherry"]
+    println(ss.indexOf("banana") ?? -1)
+    println(ss.indexOf("grape") ?? -1)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	// 5@0, 15@2, 25@4, 99 missing, "banana"@1, "grape" missing.
+	want := "0\n2\n4\n-1\n1\n-1\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4269,6 +4269,96 @@ void osty_rt_list_insert_ptr(void *raw_list, int64_t index, void *value) {
     osty_gc_post_write_v1(raw_list, value, OSTY_GC_KIND_LIST);
 }
 
+// osty_rt_list_remove_at_discard shifts list[index+1..len] left by one slot
+// and decrements len. Aborts on out-of-range (matches stdlib
+// `removeAt(i) -> T` semantics — the caller reads the element first via
+// a typed get, then invokes this helper to splice the slot out).
+// Element-type-agnostic: operates in terms of list->elem_size.
+void osty_rt_list_remove_at_discard(void *raw_list, int64_t index) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (list == NULL) {
+        osty_rt_abort("list.removeAt on nil receiver");
+    }
+    if (index < 0 || index >= list->len) {
+        osty_rt_abort("list.removeAt index out of range");
+    }
+    size_t elem_size = list->elem_size;
+    if (index + 1 < list->len) {
+        memmove(list->data + (size_t)index * elem_size,
+                list->data + (size_t)(index + 1) * elem_size,
+                (size_t)(list->len - index - 1) * elem_size);
+    }
+    list->len -= 1;
+}
+
+// osty_rt_list_reverse reverses the list in place. Byte-level swap
+// using the list's own elem_size — no per-element type dispatch needed.
+// The GC trace bookkeeping survives because we swap entire slots
+// (including any embedded ptrs or gc_offsets roots); no slot ever
+// holds a half-written intermediate value visible to a GC safepoint
+// because the whole swap is inline within a single C call.
+void osty_rt_list_reverse(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (list == NULL) {
+        osty_rt_abort("list.reverse on nil receiver");
+    }
+    if (list->len <= 1) {
+        return;
+    }
+    size_t elem_size = list->elem_size;
+    if (elem_size == 0) {
+        return;
+    }
+    // Stack buffer for small slots; heap buffer for larger ones.
+    unsigned char small[64];
+    unsigned char *tmp = small;
+    unsigned char *heap = NULL;
+    if (elem_size > sizeof(small)) {
+        heap = (unsigned char *)malloc(elem_size);
+        if (heap == NULL) {
+            osty_rt_abort("list.reverse: out of memory");
+        }
+        tmp = heap;
+    }
+    int64_t lo = 0, hi = list->len - 1;
+    while (lo < hi) {
+        unsigned char *a = list->data + (size_t)lo * elem_size;
+        unsigned char *b = list->data + (size_t)hi * elem_size;
+        memcpy(tmp, a, elem_size);
+        memcpy(a, b, elem_size);
+        memcpy(b, tmp, elem_size);
+        lo++;
+        hi--;
+    }
+    if (heap != NULL) {
+        free(heap);
+    }
+}
+
+// osty_rt_list_reversed returns a freshly allocated list holding the
+// receiver's elements in reverse order. The new list inherits the
+// source's elem_size + trace callback so GC bookkeeping stays intact.
+void *osty_rt_list_reversed(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (list == NULL) {
+        osty_rt_abort("list.reversed on nil receiver");
+    }
+    osty_rt_list *out = (osty_rt_list *)osty_rt_list_new();
+    if (list->len == 0) {
+        return out;
+    }
+    size_t elem_size = list->elem_size;
+    osty_rt_list_ensure_layout(out, elem_size, list->trace_elem);
+    osty_rt_list_reserve(out, list->len);
+    // Copy elements from end → start into the new list's data buffer.
+    for (int64_t i = 0; i < list->len; i++) {
+        const unsigned char *src = list->data + (size_t)(list->len - 1 - i) * elem_size;
+        memcpy(out->data + (size_t)i * elem_size, src, elem_size);
+    }
+    out->len = list->len;
+    return out;
+}
+
 void osty_rt_list_push_i1(void *raw_list, bool value) {
     osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1075,7 +1075,9 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
-		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast:
+		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
+		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
+		mir.IntrinsicListIndexOf:
 		return true
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -4213,7 +4215,9 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStdIoWriteIntrinsic(i, "eprintln")
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
-		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast:
+		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
+		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
+		mir.IntrinsicListIndexOf:
 		return g.emitListIntrinsic(i)
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -4461,6 +4465,127 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
 		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
 		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		return nil
+	case mir.IntrinsicListReverse:
+		// In-place reverse. Runtime walks elem_size-sized slots byte by
+		// byte so the call is element-type agnostic.
+		sym := "osty_rt_list_reverse"
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", sym, listReg)
+		return nil
+	case mir.IntrinsicListReversed:
+		// Returns a freshly allocated reversed copy. Same elem_size/
+		// trace handling inside the runtime; GC roots remain valid
+		// across the allocation because the source list stays
+		// reachable through the caller's local.
+		sym := "osty_rt_list_reversed"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicListRemoveAt:
+		// `removeAt(i) -> T` — aborts on OOB (matching stdlib spec).
+		// Compute the return value via `list_get_<kind>` BEFORE the
+		// runtime splice so the captured element is still valid.
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "list_remove_at arity")
+		}
+		if !listUsesTypedRuntime(elemLLVM) {
+			return unsupported("mir-mvp", fmt.Sprintf("list_remove_at on composite element type %s", elemLLVM))
+		}
+		idxOp := i.Args[1]
+		idxReg, err := g.evalOperand(idxOp, idxOp.Type())
+		if err != nil {
+			return err
+		}
+		getSym := listRuntimeGetSymbol(elemLLVM)
+		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		spliceSym := "osty_rt_list_remove_at_discard"
+		g.declareRuntime(spliceSym, "declare void @"+spliceSym+"(ptr, i64)")
+		elemReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
+		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s, i64 %s)\n", spliceSym, listReg, idxReg)
+		return g.storeIntrinsicResult(i, &LlvmValue{typ: elemLLVM, name: elemReg})
+	case mir.IntrinsicListIndexOf:
+		// `indexOf(x) -> Int?` — linear scan. Emit inline loop so we
+		// don't need per-elem-type runtime helpers. Dest is Option<Int>
+		// with i64 payload.
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "list_index_of arity")
+		}
+		if !listUsesTypedRuntime(elemLLVM) {
+			return unsupported("mir-mvp", fmt.Sprintf("list_index_of on composite element type %s", elemLLVM))
+		}
+		if i.Dest == nil {
+			return unsupported("mir-mvp", "list_index_of without destination")
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return unsupported("mir-mvp", "list_index_of dest into unknown local")
+		}
+		destLLVM := g.llvmType(destLoc.Type)
+		destSlot := g.localSlots[i.Dest.Local]
+		needleOp := i.Args[1]
+		needleReg, err := g.evalOperand(needleOp, needleOp.Type())
+		if err != nil {
+			return err
+		}
+		lenSym := listRuntimeLenSymbol()
+		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		getSym := listRuntimeGetSymbol(elemLLVM)
+		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		stringEq := ""
+		if isStringLLVMType(needleOp.Type()) {
+			// String equality must go through the runtime — raw ptr
+			// compare would reject equal-content separate allocations.
+			stringEq = llvmStringRuntimeEqualSymbol()
+			g.declareRuntime(stringEq, "declare i1 @"+stringEq+"(ptr, ptr) nounwind willreturn memory(read)")
+		}
+		lenReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+		// Pre-store None; overwritten with Some(idx) on match.
+		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
+		iSlot := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = alloca i64\n", iSlot)
+		fmt.Fprintf(&g.fnBuf, "  store i64 0, ptr %s\n", iSlot)
+		headLabel := g.freshLabel("list.indexof.head")
+		bodyLabel := g.freshLabel("list.indexof.body")
+		matchLabel := g.freshLabel("list.indexof.match")
+		contLabel := g.freshLabel("list.indexof.cont")
+		endLabel := g.freshLabel("list.indexof.end")
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", headLabel)
+		iReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = load i64, ptr %s\n", iReg, iSlot)
+		cont := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = icmp slt i64 %s, %s\n", cont, iReg, lenReg)
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", cont, bodyLabel, endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", bodyLabel)
+		elemReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, iReg)
+		eqReg := g.fresh()
+		if stringEq != "" {
+			fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, ptr %s)\n", eqReg, stringEq, elemReg, needleReg)
+		} else if elemLLVM == "double" {
+			fmt.Fprintf(&g.fnBuf, "  %s = fcmp oeq double %s, %s\n", eqReg, elemReg, needleReg)
+		} else {
+			fmt.Fprintf(&g.fnBuf, "  %s = icmp eq %s %s, %s\n", eqReg, elemLLVM, elemReg, needleReg)
+		}
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", eqReg, matchLabel, contLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", matchLabel)
+		tagged := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		filled := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, iReg)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", contLabel)
+		next := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = add i64 %s, 1\n", next, iReg)
+		fmt.Fprintf(&g.fnBuf, "  store i64 %s, ptr %s\n", next, iSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
 		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
 		return nil
 	case mir.IntrinsicListPop:

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3805,6 +3805,12 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 			return IntrinsicListIndexOf
 		case "toSet":
 			return IntrinsicListToSet
+		case "removeAt":
+			return IntrinsicListRemoveAt
+		case "reverse":
+			return IntrinsicListReverse
+		case "reversed":
+			return IntrinsicListReversed
 		}
 	case "Map":
 		switch name {

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -484,6 +484,15 @@ const (
 	IntrinsicListIndexOf
 	// IntrinsicListToSet constructs a Set<T> from a List<T>. Args: [list].
 	IntrinsicListToSet
+	// IntrinsicListRemoveAt removes the element at the given index and
+	// returns it. Aborts on out-of-range. Args: [list, idx]. Dest is T.
+	IntrinsicListRemoveAt
+	// IntrinsicListReverse reverses a List<T> in place. Args: [list].
+	// Dest nil.
+	IntrinsicListReverse
+	// IntrinsicListReversed returns a freshly allocated copy of the list
+	// with elements in reverse order. Args: [list]. Dest is List<T>.
+	IntrinsicListReversed
 
 	// ---- stdlib collections: Map<K, V> ----
 
@@ -1517,6 +1526,12 @@ func (k IntrinsicKind) String() string {
 		return "list_index_of"
 	case IntrinsicListToSet:
 		return "list_to_set"
+	case IntrinsicListRemoveAt:
+		return "list_remove_at"
+	case IntrinsicListReverse:
+		return "list_reverse"
+	case IntrinsicListReversed:
+		return "list_reversed"
 	case IntrinsicMapNew:
 		return "map_new"
 	case IntrinsicMapGet:


### PR DESCRIPTION
## Summary

Four `List<T>` methods were registered in the native checker's intrinsic table but had no path through the MIR emitter. Every user call fell back to the legacy AST path and tripped `LLVM015 call: call target *ast.TurbofishExpr`. One PR, four methods:

| method | signature | runtime / emit |
|---|---|---|
| `reverse()` | `-> ()` | `osty_rt_list_reverse` (byte-swap via elem_size) |
| `reversed()` | `-> List<T>` | `osty_rt_list_reversed` (fresh copy) |
| `removeAt(i)` | `-> T` (abort on OOB) | `get(i)` + `osty_rt_list_remove_at_discard(i)` |
| `indexOf(x)` | `-> Int?` | inline linear scan, Some(i) / None |

## Repro (pre-fix)

```osty
fn main() {
    let mut xs: List<Int> = [1, 2, 3]
    xs.reverse()
    for x in xs { println(x) }
}
```

Pre-fix:
```
; unsupported: LLVM015 call: call target *ast.TurbofishExpr
```

Post-fix: prints `3\n2\n1\n`.

## Changes

- **`internal/mir/mir.go`**: 3 new IntrinsicKind variants (`IntrinsicListRemoveAt` / `IntrinsicListReverse` / `IntrinsicListReversed`) + label strings
- **`internal/mir/lower.go`**: HIR→MIR routing for the 3 new method names (`indexOf` already had a kind, just wasn't backed by emit)
- **`internal/backend/runtime/osty_runtime.c`**: 3 new C helpers — `remove_at_discard`, `reverse`, `reversed`. All element-type agnostic via `list->elem_size`; reverse uses a stack/heap scratch buffer sized to `elem_size`; reversed inherits source's `elem_size` + `trace_elem` so GC bookkeeping survives the fresh allocation
- **`internal/llvmgen/mir_generator.go`**: emit cases for all 4; `isSupportedIntrinsic` + dispatch switch updated. IndexOf keeps the runtime footprint small by emitting the linear-scan loop inline — String elements route through `osty_rt_strings_Equal` (content-eq), doubles use `fcmp oeq`, others use `icmp eq`

## Coverage / scope

- Scalar element types only (i64 / i1 / f64 / ptr / string). Composite elements return `unsupported "mir-mvp"` — the raw-get + Option-wrap shape would need a bytes-v1 slot integration and wasn't in scope for this batch.
- RemoveAt: captures the return element via `list_get_<kind>` BEFORE the splice, matching the pattern used by `List.pop` (#793).
- IndexOf: pre-stores None, overwrites with Some(idx) on the match branch — same Option-slot layout (`{i64 tag, i64 value}`) as the rest of the family.

## Test plan

- [x] `TestLLVMBackendBinaryRunsListReverseInPlace` — `[1..5].reverse()` → `5\n4\n3\n2\n1\n5\n`
- [x] `TestLLVMBackendBinaryRunsListReversedNewList` — `.reversed()` produces reversed copy, leaves source untouched
- [x] `TestLLVMBackendBinaryRunsListRemoveAt` — `removeAt(1)` on `[10,20,30,40]` returns 20, leaves `[10,30,40]`
- [x] `TestLLVMBackendBinaryRunsListIndexOf` — found at `0/2/4`, not-found returns -1, String case works via runtime equality
- [x] `just front` — 8 frontend packages green
- [x] `go test ./internal/mir/` + `./internal/backend/ -run TestBundledRuntime` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)