### PR TITLE
[codex] Fix native package stdlib import surfaces

### DIFF
--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -120,6 +120,27 @@ func TestCheckCLINativePackageCleanSourceExitsZero(t *testing.T) {
 	}
 }
 
+func TestCheckCLINativePackageLoadsStdlibImportSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`use std.strings as strings
+
+fn main() {
+    let parts = strings.fields("alpha beta")
+    parts
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "check", "--native", dir)
+	if got.exit != 0 {
+		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[E0703]") {
+		t.Fatalf("stderr retained missing-method E0703 for std.strings surface:\n%s", got.stderr)
+	}
+}
+
 // TestCheckCLINativePackageSurfacesPerFileIntrinsic confirms the
 // per-file diagnostic bucketing: an `#[intrinsic]` violation in the
 // second file must surface with E0773 and a span whose rendered path

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1163,6 +1163,9 @@ func nativePackageCheckInput(pkg *resolve.Package, imports []selfhost.PackageChe
 	input := selfhost.PackageCheckInput{
 		Files: make([]selfhost.PackageCheckFile, 0, len(pkg.Files)),
 	}
+	if len(imports) == 0 {
+		imports = check.PackageImportSurfacesForSelfhost(pkg, nil, nativeLazyStdlibProvider{})
+	}
 	if len(imports) > 0 {
 		input.Imports = append([]selfhost.PackageCheckImport(nil), imports...)
 	}

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -118,6 +118,30 @@ func TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes(t *testing.T) {
 	}
 }
 
+func TestTypecheckCLINativePackageLoadsStdlibImportSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`use std.strings as strings
+
+fn main() {
+    let parts = strings.fields("alpha beta")
+    parts
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "typecheck", "--native", dir)
+	if got.exit != 0 {
+		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[E0703]") {
+		t.Fatalf("stderr retained missing-method E0703 for std.strings surface:\n%s", got.stderr)
+	}
+	if !strings.Contains(got.stdout, "List<String>") {
+		t.Fatalf("stdout missing List<String> type row:\n%s", got.stdout)
+	}
+}
+
 // TestTypecheckCLILegacyPackageRejected pins the legacy contract
 // that survives the 1c.1 flip: `osty typecheck --legacy DIR` is
 // still rejected with exit 2, because only the native path has DIR


### PR DESCRIPTION
## What changed
- populate stdlib import surfaces for native single-package DIR checks/typechecks when no explicit imports are passed into `nativePackageCheckInput`
- add CLI regression tests covering `strings.fields(...)` in both `check --native DIR` and `typecheck --native DIR`

## Why
`osty check toolchain` was still failing with `E0703: no method 'fields' on type 'strings'` at `toolchain/manifest_validation.osty:427`.

The root cause was that the native workspace path already populated import surfaces for the selfhost checker, but the native single-package DIR path passed `imports=nil`. That meant stdlib methods like `std.strings.fields` existed in the implementation but were never registered in the checker environment for `osty check DIR` / `osty typecheck DIR`.

## Impact
- fixes the package-native checker/typechecker surface mismatch
- allows `std.strings.fields` to resolve under native DIR mode
- unblocks `OSTY_NATIVE_CHECKER_BIN="$PWD/.osty/bin/osty-native-checker" ./.bin/osty check toolchain`

## Validation
- `go test -count=1 -vet=off ./cmd/osty -run 'TestCheckCLINativePackageLoadsStdlibImportSurfaces|TestTypecheckCLINativePackageLoadsStdlibImportSurfaces'`
- `go build -o ./.bin/osty ./cmd/osty`
- `OSTY_NATIVE_CHECKER_BIN="$PWD/.osty/bin/osty-native-checker" ./.bin/osty check toolchain`