### PR TITLE
fix(parser,check): move E0604 emit from parser to resolver/elab (fixes for-in tuple wildcard false positive)

### DIFF
--- a/internal/docgen/generated.go
+++ b/internal/docgen/generated.go
@@ -10479,8 +10479,8 @@ func opParsePrimary(p *OstyParser) int {
 	}
 	// Osty: /tmp/docgen_merged.osty:7200:5
 	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontUnderscore{})) {
-		// Osty: /tmp/docgen_merged.osty:7201:5
-		opErrorFull(p, "`_` can only be used as a pattern", "for ignored bindings, write `let _ = expr`", "", "E0604")
+		// Accept `_` at the token level and defer E0604 to the resolver
+		// (see toolchain/parser.osty). docgen's parser shares this branch.
 		// Osty: /tmp/docgen_merged.osty:7202:5
 		opAdvance(p)
 		// Osty: /tmp/docgen_merged.osty:7203:5

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -19870,8 +19870,11 @@ func opParsePrimary(p *OstyParser) int {
 	}
 	// Osty: /tmp/selfhost_merged.osty:7562:5
 	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontUnderscore{})) {
-		// Osty: /tmp/selfhost_merged.osty:7563:5
-		opErrorFull(p, "`_` can only be used as a pattern", "for ignored bindings, write `let _ = expr`", "", "E0604")
+		// Accept `_` at the token level and defer E0604 to the resolver.
+		// See toolchain/parser.osty for the rationale — for-in tuple
+		// destructures (`for (_, item) in xs`) parse the tuple as an
+		// expression first, then rewrite into a pattern. Eager parse-
+		// time emission fires on the rewritten pattern's wildcard.
 		// Osty: /tmp/selfhost_merged.osty:7564:5
 		opAdvance(p)
 		// Osty: /tmp/selfhost_merged.osty:7565:5
@@ -27635,6 +27638,13 @@ func diagUnknownField(owner string, name string, start int, end int) *CheckDiagn
 // receiver did not resolve to an Option type.
 func diagOptionalChainOnNon(owner string, start int, end int) *CheckDiagnostic {
 	return checkDiag(checkCodeOptionalChainOnNon(), fmt.Sprintf("`?.` operator applied to non-optional type `%s`; use `.` for direct field access", ostyToString(owner)), start, end)
+}
+
+// kept in sync with toolchain/check_diag.osty — mirrors
+// srWildcardInExprAtNode so elab emits the same E0604 payload the
+// resolver produces for a `_` used as a value.
+func diagWildcardInExpr(start int, end int) *CheckDiagnostic {
+	return checkDiag("E0604", "`_` is only valid as a pattern wildcard, not as an expression", start, end)
 }
 
 // Osty: /tmp/selfhost_merged.osty:10943:5
@@ -37933,6 +37943,15 @@ func elabCheckFloatLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 
 // Osty: /tmp/selfhost_merged.osty:17834:1
 func elabInferIdent(cx *ElabCx, node *AstNode) *ElabResult {
+	// `_` at expression position is spec-level invalid. Emit E0604
+	// here so the parser's now-deferred E0604 still reaches the user
+	// through the check pipeline (resolve emits it for `osty resolve`,
+	// elab emits it for `osty check`). Kept in sync with
+	// toolchain/elab.osty::elabInferIdent.
+	if node.text == "_" {
+		cx.env.diagnostics = append(cx.env.diagnostics, diagWildcardInExpr(node.start, node.end))
+		return elabPoisonResult(cx, node.start, node.end)
+	}
 	// Osty: /tmp/selfhost_merged.osty:17835:5
 	ty := checkLookup(cx.env, node.text)
 	_ = ty

--- a/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
+++ b/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
@@ -32,7 +32,6 @@ error E0205 "expected closure parameter" ^[100:19-100:22] hint="use an identifie
 error E0301 "expected pattern" ^[104:33-104:34] hint="supply a literal, variant, struct, tuple, or `_` pattern"
 error E0600 "`break` outside of loop" ^[132:16-132:17] hint="move inside a `for` loop"
 error E0601 "`continue` outside of loop" ^[136:19-136:20] hint="move inside a `for` loop"
-error E0604 "`_` can only be used as a pattern" ^[140:18-140:19] hint="for ignored bindings, write `let _ = expr`"
 error E0607 "annotation on the wrong kind of declaration" ^[163:1-163:4] hint="annotations are not permitted on `use` statements"
 error E0608 "`defer` is not allowed at the top level of a script" ^[168:1-168:6] hint="move this `defer` inside a function body — it binds to the enclosing function's return"
 error E0202 "`as?` must be written without whitespace between `as` and `?`" ^[260:9-260:11] hint="write `as?` as a single token (no space)" note="OSTY_GRAMMAR_v0.5 §28"

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -189,6 +189,18 @@ pub fn diagOptionalChainOnNon(owner: String, start: Int, end: Int) -> CheckDiagn
     )
 }
 
+pub fn diagWildcardInExpr(start: Int, end: Int) -> CheckDiagnostic {
+    // Mirrors `srWildcardInExprAtNode` in toolchain/resolve.osty so the
+    // elab and resolve pipelines emit the same E0604 payload for a `_`
+    // used as a value.
+    checkDiag(
+        "E0604",
+        "`_` is only valid as a pattern wildcard, not as an expression",
+        start,
+        end,
+    )
+}
+
 pub fn diagUnknownMethod(owner: String, name: String, start: Int, end: Int) -> CheckDiagnostic {
     checkDiag(
         checkCodeUnknownMethod(),

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -314,6 +314,17 @@ fn elabCheckFloatLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
 // ---------------------------------------------------------------------
 
 fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
+    // `_` in expression position is spec-level invalid (§4 pattern
+    // wildcard only). The parser accepts it as an AstNIdent so for-in
+    // tuple destructures like `for (_, item) in xs` — which parse the
+    // LHS as an expression first and then convert to AstNPattern —
+    // do not bleed E0604 from that conversion site. Emit the dedicated
+    // E0604 here before the ordinary unknown-name fallback kicks in,
+    // matching toolchain/resolve.osty::srResolveOneAstIdent's contract.
+    if node.text == "_" {
+        cx.env.diagnostics.push(diagWildcardInExpr(node.start, node.end))
+        return elabPoisonResult(cx, node.start, node.end)
+    }
     let ty = checkLookup(cx.env, node.text)
     if ty >= 0 {
         let coreIdx = coreIdent(cx.core, node.text, IkLocal, ty, node.start, node.end)

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -703,7 +703,16 @@ fn opParsePrimary(p: OstyParser) -> Int {
     if tok.kind == FrontMatch { return opParseMatchExpr(p) }
     if tok.kind == FrontBitOr || tok.kind == FrontOr { return opParseClosure(p) }
     if tok.kind == FrontUnderscore {
-    opErrorFull(p, "`_` can only be used as a pattern", "for ignored bindings, write `let _ = expr`", "", "E0604")
+    // Accept `_` at the token level and defer the E0604 diagnostic
+    // to the resolver (`srResolveOneAstIdent` → `srWildcardInExprAtNode`).
+    // The parser has no way to tell whether this `_` will later be
+    // rewritten into a pattern wildcard — e.g. `for (_, item) in xs`
+    // parses the tuple as an expression and then `opExprToForPattern`
+    // converts it to an AstNPattern, at which point the `_` is in
+    // pattern position and must NOT carry a lingering E0604. Emitting
+    // lazily from the resolver keeps the legitimate `let x = _` case
+    // covered (resolver sees AstNIdent in expr-value context) while
+    // unblocking for-in tuple destructures.
     opAdvance(p)
     let mut n = emptyAstNode(AstNIdent)
     n.text = "_"


### PR DESCRIPTION
## Summary

`TestRunDiagnosticsAllowDiscardInForInHead` in [internal/selfhost/check_adapter_test.go](internal/selfhost/check_adapter_test.go) expected `for (_, item) in enumerate(items)` to parse without E0604, but the parser emitted it eagerly for every `FrontUnderscore` in expression position. The test had been red on `origin/main` for a while — long enough that `git stash` + rebuild reproduced the failure without this PR's changes.

## Root cause

The for-in LHS is grammar-ambiguous until the `in` keyword appears. The parser first parses `(_, item)` as an expression tuple, then [`opExprToForPattern`](toolchain/parser.osty) rewrites the tuple into an AstNPattern with ident-kind children. The eager E0604 fires during the expression-tuple phase, before `_` ever gets a chance to be reclassified as a pattern wildcard.

## What changed

Move E0604 emission out of the parser and into the semantic layer where the context is actually known:

- **[toolchain/parser.osty](toolchain/parser.osty)**: accept `FrontUnderscore` at the token level as an ordinary `AstNIdent "_"`. No diagnostic.
- **[toolchain/elab.osty::elabInferIdent](toolchain/elab.osty)**: emit E0604 via a new `diagWildcardInExpr` helper before falling through to the unknown-name path. Guards `osty check` — which pipes through elab — against losing the diagnostic when the parser stops emitting it.
- **[toolchain/resolve.osty::srResolveOneAstIdent](toolchain/resolve.osty)** already emits E0604 via `srWildcardInExprAtNode`; `osty resolve` coverage is unchanged.
- **[toolchain/check_diag.osty](toolchain/check_diag.osty)**: new `diagWildcardInExpr(start, end)` returning the canonical E0604 payload so the two emit sites (resolver + elab) produce byte-identical records.
- **[internal/selfhost/generated.go](internal/selfhost/generated.go)** + **[internal/docgen/generated.go](internal/docgen/generated.go)**: lockstep hand-sync of the parser drop, the elab guard, and the new diag helper.
- **[internal/selfhost/testdata/parse_snapshots/…reject.txt](internal/selfhost/testdata/parse_snapshots)**: snapshot refreshed (one E0604 line drops from the parse-time batch — it still appears in the resolver-time batch, matching the full-pipeline contract).

## Test plan

Coverage map after the move:

- [x] `osty resolve /tmp/x.osty` on `let x = _` → E0604 (resolver, unchanged)
- [x] `osty check /tmp/x.osty` on `let x = _` → E0604 (elab, new guard)
- [x] `for (_, item) in enumerate(items)` → no E0604 at parse time — `TestRunDiagnosticsAllowDiscardInForInHead` now passes
- [x] Spec corpus negative CASE `E0604 === \`_\` in expression position` still fires through the full pipeline (resolver emits) — `TestSpecNegative` green
- [x] `go test -count=1 -short ./internal/check/... ./internal/selfhost/... ./internal/resolve/... ./internal/speccorpus/...` — all PASS
- [x] Parser snapshot (`TestParseSnapshot/testdata_spec_negative_reject`) refreshed with `UPDATE_SNAPSHOT=1` — one expected E0604 line drops from the parse batch, matching the new emission policy

## Impact

- **Net LoC**: +56 / -6 across 6 files (3 `.osty` sources + 2 generated Go files + 1 parse-snapshot golden)
- **Behaviour**: eliminates a spurious E0604 on any legal for-in tuple destructure that names `_`. All legitimate `let x = _` usage still reports the same E0604 through the check/resolve pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)