### PR TITLE
[codex] Optimize IR len method chains

### DIFF
--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -143,6 +143,7 @@ func finalizeEntryModule(entry Entry, mod *ir.Module) (Entry, error) {
 		mod = monoMod
 		entry.IRIssues = append(entry.IRIssues, monoErrs...)
 	}
+	mod = ir.Optimize(mod, ir.OptimizeOptions{})
 	entry.IR = mod
 	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
 		entry.IRIssues = append(entry.IRIssues, validateErrs...)

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -1576,6 +1576,39 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendIRElidesMapKeysSortedLenChain(t *testing.T) {
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitLLVMIR, `fn sortedCount(words: List<String>) -> Int {
+    let mut index: Map<String, Int> = {:}
+    for word in words {
+        index.insert(word, 1)
+    }
+    index.keys().sorted().len()
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	out, err := os.ReadFile(result.Artifacts.LLVMIR)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) failed: %v", result.Artifacts.LLVMIR, err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "call i64 @osty_rt_map_len(") {
+		t.Fatalf("optimized llvm-ir missing map.len call:\n%s", got)
+	}
+	for _, unwanted := range []string{
+		"call ptr @osty_rt_map_keys(",
+		"call ptr @osty_rt_list_sorted_string(",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("optimized llvm-ir unexpectedly kept %q:\n%s", unwanted, got)
+		}
+	}
+}
+
 func TestLLVMBackendBinaryForInOverTemporaryManagedListSurvivesPressure(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -9,10 +9,10 @@ import (
 func TestOptimizeFoldsIntArithmetic(t *testing.T) {
 	// (1 + 2) * 3
 	e := &BinaryExpr{
-		Op:   BinMul,
-		Left: &BinaryExpr{Op: BinAdd, Left: intLit("1"), Right: intLit("2"), T: TInt},
+		Op:    BinMul,
+		Left:  &BinaryExpr{Op: BinAdd, Left: intLit("1"), Right: intLit("2"), T: TInt},
 		Right: intLit("3"),
-		T:    TInt,
+		T:     TInt,
 	}
 	m := moduleWithExpr(e)
 	Optimize(m, OptimizeOptions{})
@@ -128,6 +128,118 @@ func TestOptimizeRespectsDisableFlags(t *testing.T) {
 	got := m.Script[0].(*ExprStmt).X
 	if _, ok := got.(*BinaryExpr); !ok {
 		t.Fatalf("expected BinaryExpr preserved with DisableConstFold, got %T", got)
+	}
+}
+
+func TestOptimizeSimplifiesListSortedLen(t *testing.T) {
+	list := &Ident{
+		Name: "xs",
+		Kind: IdentLocal,
+		T:    &NamedType{Name: "List", Args: []Type{TInt}, Builtin: true},
+	}
+	e := &MethodCall{
+		Receiver: &MethodCall{
+			Receiver: list,
+			Name:     "sorted",
+			T:        list.T,
+		},
+		Name: "len",
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	assertOptimizedLenReceiverIdent(t, m.Script[0].(*ExprStmt).X, "xs")
+}
+
+func TestOptimizeSimplifiesMapKeysLen(t *testing.T) {
+	index := &Ident{
+		Name: "index",
+		Kind: IdentLocal,
+		T:    &NamedType{Name: "Map", Args: []Type{TString, TInt}, Builtin: true},
+	}
+	e := &MethodCall{
+		Receiver: &MethodCall{
+			Receiver: index,
+			Name:     "keys",
+			T:        &NamedType{Name: "List", Args: []Type{TString}, Builtin: true},
+		},
+		Name: "len",
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	assertOptimizedLenReceiverIdent(t, m.Script[0].(*ExprStmt).X, "index")
+}
+
+func TestOptimizeSimplifiesMapKeysSortedLen(t *testing.T) {
+	index := &Ident{
+		Name: "index",
+		Kind: IdentLocal,
+		T:    &NamedType{Name: "Map", Args: []Type{TString, TInt}, Builtin: true},
+	}
+	e := &MethodCall{
+		Receiver: &MethodCall{
+			Receiver: &MethodCall{
+				Receiver: index,
+				Name:     "keys",
+			},
+			Name: "sorted",
+		},
+		Name: "len",
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	assertOptimizedLenReceiverIdent(t, m.Script[0].(*ExprStmt).X, "index")
+}
+
+func TestOptimizeSimplifiesSetToListSortedLen(t *testing.T) {
+	seen := &Ident{
+		Name: "seen",
+		Kind: IdentLocal,
+		T:    &NamedType{Name: "Set", Args: []Type{TString}, Builtin: true},
+	}
+	e := &MethodCall{
+		Receiver: &MethodCall{
+			Receiver: &MethodCall{
+				Receiver: seen,
+				Name:     "toList",
+			},
+			Name: "sorted",
+		},
+		Name: "len",
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	assertOptimizedLenReceiverIdent(t, m.Script[0].(*ExprStmt).X, "seen")
+}
+
+func TestOptimizeDoesNotSimplifyUserDefinedListSortedLen(t *testing.T) {
+	list := &Ident{
+		Name: "xs",
+		Kind: IdentLocal,
+		T:    &NamedType{Name: "List", Args: []Type{TInt}},
+	}
+	e := &MethodCall{
+		Receiver: &MethodCall{
+			Receiver: list,
+			Name:     "sorted",
+			T:        list.T,
+		},
+		Name: "len",
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	lenCall, ok := got.(*MethodCall)
+	if !ok {
+		t.Fatalf("expected MethodCall preserved, got %T", got)
+	}
+	sortedCall, ok := lenCall.Receiver.(*MethodCall)
+	if !ok || sortedCall.Name != "sorted" {
+		t.Fatalf("expected sorted().len() preserved, got %T (%v)", lenCall.Receiver, lenCall.Receiver)
 	}
 }
 
@@ -403,5 +515,19 @@ func moduleWithExpr(e Expr) *Module {
 	}
 }
 
-func intLit(text string) *IntLit  { return &IntLit{Text: text, T: TInt} }
-func strLit(s string) *StringLit  { return &StringLit{Parts: []StringPart{{IsLit: true, Lit: s}}} }
+func assertOptimizedLenReceiverIdent(t *testing.T, got Expr, want string) {
+	t.Helper()
+	lenCall, ok := got.(*MethodCall)
+	if !ok {
+		t.Fatalf("expected MethodCall after optimization, got %T", got)
+	}
+	if lenCall.Name != "len" {
+		t.Fatalf("expected len call, got %q", lenCall.Name)
+	}
+	if recv, ok := lenCall.Receiver.(*Ident); !ok || recv.Name != want {
+		t.Fatalf("expected len receiver %q, got %T (%v)", want, lenCall.Receiver, lenCall.Receiver)
+	}
+}
+
+func intLit(text string) *IntLit { return &IntLit{Text: text, T: TInt} }
+func strLit(s string) *StringLit { return &StringLit{Parts: []StringPart{{IsLit: true, Lit: s}}} }

--- a/internal/ir/optimize.go
+++ b/internal/ir/optimize.go
@@ -240,6 +240,9 @@ func (o *optimizer) visitExpr(e Expr) Expr {
 		for i := range e.Args {
 			e.Args[i].Value = o.visitExpr(e.Args[i].Value)
 		}
+		if simplified, ok := o.simplifyMethodCall(e); ok {
+			return simplified
+		}
 		return e
 	case *ListLit:
 		for i, el := range e.Elems {
@@ -479,6 +482,84 @@ func (o *optimizer) simplifyBinary(e *BinaryExpr) (Expr, bool) {
 		return e.Left, true
 	}
 	return nil, false
+}
+
+func (o *optimizer) simplifyMethodCall(e *MethodCall) (Expr, bool) {
+	if o.opts.DisableSimplify {
+		return nil, false
+	}
+	current := e
+	changed := false
+	for {
+		next, ok := simplifyLenMethodChainStep(current)
+		if !ok {
+			break
+		}
+		current = next
+		changed = true
+	}
+	if !changed {
+		return nil, false
+	}
+	return current, true
+}
+
+func simplifyLenMethodChainStep(e *MethodCall) (*MethodCall, bool) {
+	if e == nil || e.Name != "len" || len(e.Args) != 0 || len(e.TypeArgs) != 0 {
+		return nil, false
+	}
+	recvCall, ok := e.Receiver.(*MethodCall)
+	if !ok || len(recvCall.Args) != 0 || len(recvCall.TypeArgs) != 0 {
+		return nil, false
+	}
+	switch recvCall.Name {
+	case "sorted":
+		if !isBuiltinListLikeExpr(recvCall.Receiver) {
+			return nil, false
+		}
+	case "keys":
+		if !isBuiltinNamedType(recvCall.Receiver.Type(), "Map", 2) {
+			return nil, false
+		}
+	case "toList":
+		if !isBuiltinNamedType(recvCall.Receiver.Type(), "Set", 1) {
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+	return &MethodCall{
+		Receiver: recvCall.Receiver,
+		Name:     "len",
+		T:        e.T,
+		SpanV:    e.SpanV,
+	}, true
+}
+
+func isBuiltinNamedType(t Type, name string, argCount int) bool {
+	n, ok := t.(*NamedType)
+	if !ok {
+		return false
+	}
+	return n.Builtin && n.Package == "" && n.Name == name && len(n.Args) == argCount
+}
+
+func isBuiltinListLikeExpr(e Expr) bool {
+	if isBuiltinNamedType(e.Type(), "List", 1) {
+		return true
+	}
+	m, ok := e.(*MethodCall)
+	if !ok || len(m.Args) != 0 || len(m.TypeArgs) != 0 {
+		return false
+	}
+	switch m.Name {
+	case "keys":
+		return isBuiltinNamedType(m.Receiver.Type(), "Map", 2)
+	case "toList":
+		return isBuiltinNamedType(m.Receiver.Type(), "Set", 1)
+	default:
+		return false
+	}
 }
 
 func foldIntBinary(e *BinaryExpr, l, r *IntLit) (Expr, bool) {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -22,6 +22,7 @@ import (
 // is unexported. Once the emitter consumes IR directly end-to-end, the
 // fallback bridge and the AST helper both go away.
 func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
+	mod = ostyir.Optimize(mod, ostyir.OptimizeOptions{})
 	if out, ok, err := TryGenerateNativeOwnedModule(mod, opts); err != nil {
 		return nil, err
 	} else if ok {


### PR DESCRIPTION
## Summary
- add an IR peephole that folds `sorted().len()`, `keys().sorted().len()`, and `toList().sorted().len()` into direct `len()` calls for builtin collections
- run that IR optimization in the real backend and direct LLVM generation pipelines
- add backend coverage that asserts emitted LLVM IR now uses direct `map.len()` lowering instead of materializing intermediate key/sorted lists

## Why
These chained collection method shapes were paying for unnecessary intermediate runtime work in the emitted program even though the final result only needed the collection length.

## Validation
- `go test -count=1 -vet=off ./internal/ir`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestNativeOwnedModuleEntryListSetMethodBatch|TestNativeOwnedModuleEntryListPushInsertBatch'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendIRElidesMapKeysSortedLenChain|TestLLVMBackendBinaryKeepsMapKeysSortedAliveUnderGC'`