### PR TITLE
[codex] Fix manifest lowering and optional None typing

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -598,6 +598,64 @@ func TestGenerateFromMIRStructLiteralAndFieldRead(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRStructLiteralSeedsOptionalFieldNoneType(t *testing.T) {
+	src := `struct Runner {
+    manifest: Int?
+    workspace: String?
+}
+
+fn newRunner() -> Runner {
+    Runner {
+        manifest: None,
+        workspace: None,
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	hirMod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ir.Monomorphize(hirMod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize: %v", monoErrs)
+	}
+	if errs := ir.Validate(monoMod); len(errs) != 0 {
+		t.Fatalf("ir.Validate: %v", errs)
+	}
+	mirMod := mir.Lower(monoMod)
+	if mirMod == nil {
+		t.Fatalf("mir.Lower returned nil")
+	}
+	if errs := mir.Validate(mirMod); len(errs) != 0 {
+		t.Fatalf("mir.Validate: %v", errs)
+	}
+	out, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/struct_none_fields.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Runner = type { %Option.i64, %Option.string }",
+		"insertvalue %Option.i64 undef, i64 0, 0",
+		"insertvalue %Option.string undef, i64 0, 0",
+		"ret %Runner",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestGenerateFromMIRTupleLiteralAndElementRead(t *testing.T) {
 	// fn pack() -> Int { let t = (1, 2); t.0 + t.1 }
 	tupT := &ir.TupleType{Elems: []ir.Type{ir.TInt, ir.TInt}}
@@ -1013,6 +1071,59 @@ func TestGenerateFromMIROptionIsSomeLowers(t *testing.T) {
 	for _, want := range []string{
 		"extractvalue %Option.i64",
 		"icmp ne i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRQuestionRebuildsOptionalReturnNone(t *testing.T) {
+	// fn widen(x: Int?) -> Bool? {
+	//   let n = x?
+	//   Some(n > 0)
+	// }
+	intOpt := &ir.OptionalType{Inner: ir.TInt}
+	boolOpt := &ir.OptionalType{Inner: ir.TBool}
+	fn := &ir.FnDecl{
+		Name:   "widen",
+		Return: boolOpt,
+		Params: []*ir.Param{{Name: "x", Type: intOpt}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "n",
+					Type: ir.TInt,
+					Value: &ir.QuestionExpr{
+						X: &ir.Ident{Name: "x", Kind: ir.IdentParam, T: intOpt},
+						T: ir.TInt,
+					},
+				},
+			},
+			Result: &ir.VariantLit{
+				Enum:    "Option",
+				Variant: "Some",
+				Args: []ir.Arg{{Value: &ir.BinaryExpr{
+					Op:    ir.BinGt,
+					Left:  &ir.Ident{Name: "n", Kind: ir.IdentLocal, T: ir.TInt},
+					Right: &ir.IntLit{Text: "0", T: ir.TInt},
+					T:     ir.TBool,
+				}}},
+				T: boolOpt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/opt_question_bool.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Option.i1 = type { i64, i64 }",
+		"insertvalue %Option.i1 undef, i64 0, 0",
+		"ret %Option.i1",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)

--- a/internal/llvmgen/toolchain_lower_probe_test.go
+++ b/internal/llvmgen/toolchain_lower_probe_test.go
@@ -23,6 +23,7 @@ func TestProbeToolchainSemverAndDiagPolicyLower(t *testing.T) {
 	cases := []string{
 		"toolchain/semver.osty",
 		"toolchain/diag_policy.osty",
+		"toolchain/manifest_validation.osty",
 	}
 	for _, rel := range cases {
 		path := filepath.Join(root, rel)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -824,6 +824,50 @@ func isPoisonType(t Type) bool {
 	return ok
 }
 
+func containsTypeVar(t Type) bool {
+	switch x := t.(type) {
+	case nil:
+		return false
+	case *ir.TypeVar:
+		return true
+	case *ir.NamedType:
+		for _, a := range x.Args {
+			if containsTypeVar(a) {
+				return true
+			}
+		}
+		return false
+	case *ir.OptionalType:
+		return containsTypeVar(x.Inner)
+	case *ir.TupleType:
+		for _, e := range x.Elems {
+			if containsTypeVar(e) {
+				return true
+			}
+		}
+		return false
+	case *ir.FnType:
+		for _, p := range x.Params {
+			if containsTypeVar(p) {
+				return true
+			}
+		}
+		return containsTypeVar(x.Return)
+	default:
+		return false
+	}
+}
+
+func shouldPreferHintType(actual, hint Type) bool {
+	if hint == nil || isPoisonType(hint) {
+		return false
+	}
+	if actual == nil || isPoisonType(actual) {
+		return true
+	}
+	return containsTypeVar(actual) && !containsTypeVar(hint)
+}
+
 func (bs *bodyState) lowerLetPattern(pat ir.Pattern, value ir.Expr, valueType Type, sp Span) {
 	// Wildcard-only binding has nothing to store, so skip the scratch
 	// local and evaluate `value` for side effects — otherwise a
@@ -2041,6 +2085,24 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 	tmp := bs.freshTemp(t, exprSpan(e))
 	bs.lowerExprInto(e, tmp, t)
 	return &CopyOp{Place: Place{Local: tmp}, T: t}
+}
+
+func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
+	if !shouldPreferHintType(e.Type(), hint) {
+		return bs.lowerExprAsOperand(e)
+	}
+	if id, ok := e.(*ir.Ident); ok {
+		if id.Name == "None" && id.Kind != ir.IdentLocal && id.Kind != ir.IdentParam {
+			tmp := bs.freshTemp(hint, id.SpanV)
+			bs.emit(&AssignInstr{
+				Dest:  Place{Local: tmp},
+				Src:   &NullaryRV{Kind: NullaryNone, T: hint},
+				SpanV: id.SpanV,
+			})
+			return &CopyOp{Place: Place{Local: tmp}, T: hint}
+		}
+	}
+	return bs.lowerExprAsOperand(e)
 }
 
 // recoveredTypeOf returns e.Type() when it's populated, otherwise
@@ -3548,7 +3610,7 @@ func (bs *bodyState) lowerStructLit(sl *ir.StructLit, hint Type) RValue {
 				continue
 			}
 		} else {
-			fields[i] = bs.lowerExprAsOperand(f.Value)
+			fields[i] = bs.lowerExprAsOperandHint(f.Value, bs.l.fieldType(info, f.Name))
 			filled[i] = true
 		}
 	}

--- a/toolchain/hir_print.osty
+++ b/toolchain/hir_print.osty
@@ -873,7 +873,7 @@ fn hirExprLiteralText(e: HirExpr) -> String {
                 if part.isLit {
                     out = out + part.lit
                 } else {
-                    out = out + "{expr}"
+                    out = out + "\{expr\}"
                 }
             }
             out + "\""

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -4594,7 +4594,7 @@ pub fn mirLowerStdlibStringFreeFnToIntrinsic(
     qualifier: String,
     name: String,
 ) -> MirIntrinsicKind {
-    if qualifier != "std.strings" {
+    if qualifier != "std.strings" && qualifier != "strings" {
         return MirIntrinsicInvalid
     }
     // Accept the Go-level aliases first so they don't drop into the


### PR DESCRIPTION
## What changed
- accept alias-qualified `strings.fields(...)` in MIR stdlib intrinsic lowering
- escape the `"{expr}"` placeholder in HIR literal printing so it stays literal text
- seed struct literal field lowering with concrete optional field types so bare `None` does not leak generic `T?` into MIR/LLVM
- add regressions for the optional return rebuild path and the manifest validation probe

## Why
A few toolchain paths were failing for separate but related lowering reasons:
- module free functions under the `strings` alias were being resolved like methods instead of stdlib intrinsics
- the LLVM bridge tripped on a literal placeholder that was parsed as interpolation
- bare `None` inside struct literals could keep an unconstrained optional type variable and surface as `NullaryRV` with `T?`

## Impact
- `toolchain/manifest_validation.osty` now lowers past the previous `strings.fields` failure
- the LLVM generator no longer fails on the literal `expr` placeholder path
- `NewRunner`-style struct literals no longer emit generic optional temps for bare `None`

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIROptionalNoneConstruction|TestGenerateFromMIRQuestionRebuildsOptionalReturnNone|TestGenerateFromMIRStructLiteralSeedsOptionalFieldNoneType' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsBareNoneAsCallArg|TestLLVMBackendBinaryRunsBareNoneInListLiteral' -v`
- `go test -count=1 -vet=off ./internal/mir -run 'TestLowerQuestionOperatorNoneForOption|TestLowerQuestionOperatorRebuildsErrorForResult' -v`
- `go test -count=1 -vet=off ./internal/llvmgen -run TestProbeToolchainSemverAndDiagPolicyLower -v`
- `go test -count=1 -vet=off ./internal/llvmgen -run '^TestProbeNativeToolchainMergedMIR$' -v`
- `go test -count=1 -vet=off ./internal/llvmgen -run TestNativeToolchainMergedMIRPipelineIsClean -v`