### PR TITLE
perf(bench): fix quicksort aliasing + shrink hot-path allocations

### DIFF
--- a/benchmarks/osty-vs-go/csv_parse/osty/csv_parse.osty
+++ b/benchmarks/osty-vs-go/csv_parse/osty/csv_parse.osty
@@ -1,18 +1,5 @@
 fn buildCSV(n: Int) -> List<String> {
-    let samples = [
-        "us,free,alice,search,ok",
-        "eu,pro,bob,report,ok",
-        "apac,enterprise,carol,search,fail",
-        "sa,free,dave,export,ok",
-        "us,pro,eve,report,fail",
-        "eu,enterprise,frank,search,ok",
-        "apac,free,grace,export,ok",
-        "sa,pro,heidi,report,fail",
-        "us,enterprise,ivan,search,ok",
-        "eu,free,judy,export,ok",
-        "apac,pro,ken,report,ok",
-        "sa,enterprise,leo,search,fail",
-    ]
+    let samples = ["us,free,alice,search,ok", "eu,pro,bob,report,ok", "apac,enterprise,carol,search,fail", "sa,free,dave,export,ok", "us,pro,eve,report,fail", "eu,enterprise,frank,search,ok", "apac,free,grace,export,ok", "sa,pro,heidi,report,fail", "us,enterprise,ivan,search,ok", "eu,free,judy,export,ok", "apac,pro,ken,report,ok", "sa,enterprise,leo,search,fail"]
     let mut out: List<String> = []
     let mut i = 0
     for i < n {
@@ -21,7 +8,6 @@ fn buildCSV(n: Int) -> List<String> {
     }
     out
 }
-
 fn regionWeight(s: String) -> Int {
     if s == "us" {
         1
@@ -35,7 +21,6 @@ fn regionWeight(s: String) -> Int {
         0
     }
 }
-
 fn tierWeight(s: String) -> Int {
     if s == "free" {
         1
@@ -47,7 +32,6 @@ fn tierWeight(s: String) -> Int {
         0
     }
 }
-
 #[inline(never)]
 pub fn csvSum(rows: List<String>) -> Int {
     let mut counts: Map<String, Int> = {:}
@@ -55,18 +39,13 @@ pub fn csvSum(rows: List<String>) -> Int {
     for row in rows {
         let parts = row.split(",")
         let key = "{parts[0]}/{parts[1]}"
-        let next = if counts.containsKey(key) {
-            counts.getOr(key, 0) + 1
-        } else {
-            1
-        }
+        let next = counts.getOr(key, 0) + 1
         counts.insert(key, next)
         total = total + regionWeight(parts[0]) * tierWeight(parts[1])
         if parts[4] == "ok" {
             total = total + 1
         }
     }
-    // Fold the map so the GROUP BY cost participates in the checksum.
     let keys = counts.keys().sorted()
     for k in keys {
         total = total + counts.getOr(k, 0) * k.len()

--- a/benchmarks/osty-vs-go/log_scan/osty/log_scan.osty
+++ b/benchmarks/osty-vs-go/log_scan/osty/log_scan.osty
@@ -1,14 +1,7 @@
 fn buildLogLines(n: Int) -> List<String> {
     let levels = ["INFO", "WARN", "ERROR", "DEBUG", "INFO", "WARN", "INFO"]
     let services = ["auth", "api", "db", "cache", "worker"]
-    let messages = [
-        "request completed",
-        "connection closed",
-        "retry scheduled",
-        "cache miss",
-        "query executed",
-        "timeout reached",
-    ]
+    let messages = ["request completed", "connection closed", "retry scheduled", "cache miss", "query executed", "timeout reached"]
     let mut out: List<String> = []
     let mut i = 0
     for i < n {
@@ -20,22 +13,17 @@ fn buildLogLines(n: Int) -> List<String> {
     }
     out
 }
-
 #[inline(never)]
 pub fn logScan(lines: List<String>) -> Int {
     let mut counts: Map<String, Int> = {:}
     for line in lines {
-        let parts = line.split(" ")
-        // Sample lines all have >=4 tokens so we can index directly.
-        // parts.len() on List<String> hits LLVM015 on current backends;
-        // skipping the guard trades defensive correctness for
-        // compatibility on the hot path. The fixture is controlled.
-        let level = parts[1]
-        let next = if counts.containsKey(level) {
-            counts.getOr(level, 0) + 1
-        } else {
-            1
-        }
+        // Mirror Go's IndexByte + subslice: locate the level between the
+        // first two spaces without allocating a full List<String>.
+        let first = line.indexOf(" ").unwrap()
+        let rest = line[(first + 1)..line.len()]
+        let second = rest.indexOf(" ").unwrap()
+        let level = rest[0..second]
+        let next = counts.getOr(level, 0) + 1
         counts.insert(level, next)
     }
     let mut checksum = 0

--- a/benchmarks/osty-vs-go/matmul/osty/matmul.osty
+++ b/benchmarks/osty-vs-go/matmul/osty/matmul.osty
@@ -7,30 +7,28 @@ fn buildMatrix(n: Int, seed: Int) -> List<Int> {
     }
     m
 }
-
 #[inline(never)]
 pub fn matmulChecksum(a: List<Int>, b: List<Int>, n: Int) -> Int {
     let mut c: List<Int> = []
     for _i in 0..(n * n) {
         c.push(0)
     }
-
     let mut i = 0
     for i < n {
+        let iBase = i * n
         let mut j = 0
         for j < n {
             let mut sum = 0
             let mut k = 0
             for k < n {
-                sum = sum + a[i * n + k] * b[k * n + j]
+                sum = sum + a[iBase + k] * b[k * n + j]
                 k = k + 1
             }
-            c[i * n + j] = sum
+            c[iBase + j] = sum
             j = j + 1
         }
         i = i + 1
     }
-
     let mut checksum = 0
     let mut idx = 0
     for idx < c.len() {

--- a/benchmarks/osty-vs-go/quicksort/osty/quicksort.osty
+++ b/benchmarks/osty-vs-go/quicksort/osty/quicksort.osty
@@ -7,18 +7,17 @@ fn buildInts(n: Int) -> List<Int> {
     }
     xs
 }
-
 #[inline(never)]
 pub fn quicksortChecksum(src: List<Int>) -> Int {
-    let mut xs = src
-    let n = xs.len()
+    let n = src.len()
     if n <= 1 {
         return 0
     }
 
-    // Iterative quicksort: Lists are pass-by-value in Osty so a recursive
-    // in-place sort would need to thread the full array through every call
-    // frame. Manual stack of (lo, hi) pairs keeps one owner of `xs`.
+    // List has reference semantics (LANG_SPEC §2.8); copy so each call sorts
+    // a fresh buffer — Lomuto is O(n²) on already-sorted input.
+    let mut xs = src[0..n]
+
     let stackCap = 512
     let mut stack: List<Int> = []
     for _i in 0..stackCap {
@@ -27,7 +26,6 @@ pub fn quicksortChecksum(src: List<Int>) -> Int {
     stack[0] = 0
     stack[1] = n - 1
     let mut sp = 2
-
     for sp > 0 {
         sp = sp - 1
         let hi = stack[sp]
@@ -36,7 +34,6 @@ pub fn quicksortChecksum(src: List<Int>) -> Int {
         if lo >= hi {
             continue
         }
-
         let pivot = xs[hi]
         let mut i = lo - 1
         let mut j = lo
@@ -53,7 +50,6 @@ pub fn quicksortChecksum(src: List<Int>) -> Int {
         xs[i + 1] = xs[hi]
         xs[hi] = t
         let p = i + 1
-
         stack[sp] = lo
         sp = sp + 1
         stack[sp] = p - 1
@@ -63,7 +59,6 @@ pub fn quicksortChecksum(src: List<Int>) -> Int {
         stack[sp] = hi
         sp = sp + 1
     }
-
     let mut sum = 0
     let mut k = 0
     for k < xs.len() {


### PR DESCRIPTION
## Summary

User-reported geomean offenders from `osty-vs-go`: log_scan **48502x** (outlier, suspected bug), quicksort **135.9x**, matmul **27.5x**, csv_parse **20.1x**. All four osty benchmark bodies got targeted, apples-to-apples rewrites.

- **quicksort** — Aliasing bug. `let mut xs = src` shared the caller's buffer because `List<T>` has reference semantics (LANG_SPEC §2.8). `testing.benchmark` iteration 2+ therefore ran Lomuto partition on an already-sorted list (`pivot = xs[hi]` → O(n²) worst case), which dominated the measured time. Fix: `let mut xs = src[0..n]` — lowers to `osty_rt_list_slice` (bulk memcpy runtime intrinsic), mirroring Go's `make + copy`.
- **log_scan** — `line.split(" ")` allocated a full `List<String>` per line and kept only `parts[1]`. Replaced with `line.indexOf(" ")` + `s[a..b]`, mirroring Go's `IndexByte + subslice` — two short-lived strings per line instead of a list of six.
- **csv_parse / log_scan** — Dropped the redundant `containsKey` branch; `getOr(k, 0) + 1` handles the absent-key case in one lookup.
- **matmul** — Hoisted `i * n` out of both inner loops (64³ = 262 144 iterations per call).

## Verification

- `osty check` / `osty pipeline` pass on all four benchmarks (0 errors, pre-existing lint warnings only).
- Runtime intrinsic for `xs[0..n]` confirmed via [internal/backend/runtime/osty_runtime.c:4679](internal/backend/runtime/osty_runtime.c:4679) (`osty_rt_list_slice` does a GC-rooted bulk copy).
- Reference semantics finding cross-checked against [LANG_SPEC_v0.5/02-type-system.md:440](LANG_SPEC_v0.5/02-type-system.md:440).

## Test plan

- [ ] `just build && go run ./cmd/osty-vs-go --benchtime 500ms --osty-count 3 --label "slow4-fix"` and confirm quicksort/log_scan/csv_parse/matmul ratios drop vs. the prior baseline.
- [ ] Spot-check that the checksum output of each bench is unchanged (sanity — all four changes preserve semantics; quicksort sort is idempotent on sorted input so output was already correct pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)