### PR TITLE
feat(llvmgen): lower xs[r] where r is a Range<Int> value

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -768,6 +768,9 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 	if err != nil {
 		return value{}, err
 	}
+	if info, ok := g.rangeTypes[index.typ]; ok {
+		return g.emitSliceIndexByRangeValue(expr, base, index, info)
+	}
 	switch {
 	case base.listElemTyp != "":
 		if index.typ != "i64" {
@@ -840,17 +843,8 @@ func (g *generator) emitSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr) (val
 	if base.listElemTyp != "" {
 		return g.emitListSliceIndex(expr, rng, base)
 	}
-	if base.typ != "ptr" {
-		return value{}, unsupportedf("type-system", "slice indexing on %s, want String (ptr) or List<T>", base.typ)
-	}
-	baseIsString := false
-	if sourceType, ok := g.staticExprSourceType(expr.X); ok {
-		if resolved, resErr := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{}); resErr == nil {
-			baseIsString = llvmNamedTypeIsString(resolved)
-		}
-	}
-	if !baseIsString {
-		return value{}, unsupported("type-system", "slice indexing is only supported on String or List<T> receivers")
+	if err := g.requireStringSliceBase(expr.X, base); err != nil {
+		return value{}, err
 	}
 	base, err = g.loadIfPointer(base)
 	if err != nil {
@@ -966,6 +960,104 @@ func (g *generator) emitListSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr, 
 	sliced.sourceType = base.sourceType
 	sliced.rootPaths = g.rootPathsForType(base.listElemTyp)
 	return sliced, nil
+}
+
+// Range aggregate layout — kept in lockstep with the struct def emitted
+// at generator.go (fields: elemTyp, elemTyp, i1, i1, i1). If the layout
+// ever gains a field, update builtinRangeFieldInfo in type.go and the
+// type def site together.
+const (
+	rangeFieldStart     = 0
+	rangeFieldStop      = 1
+	rangeFieldHasStart  = 2
+	rangeFieldHasStop   = 3
+	rangeFieldInclusive = 4
+)
+
+// emitSliceIndexByRangeValue lowers `base[r]` where `r` is a Range<T>
+// value (param, let binding, or expression result) rather than an inline
+// range literal. The Range aggregate is destructured at runtime and fed
+// to the same osty_rt_list_slice / osty_rt_strings_Slice helpers as the
+// literal path. Element type is restricted to i64 (Range<Int>) to match
+// the literal slicer's bound constraints.
+func (g *generator) emitSliceIndexByRangeValue(expr *ast.IndexExpr, base value, rangeVal value, info builtinRangeType) (value, error) {
+	if info.elemTyp != "i64" {
+		return value{}, unsupportedf("type-system", "slice range element type %s, want i64", info.elemTyp)
+	}
+
+	isList := base.listElemTyp != ""
+	if !isList {
+		if err := g.requireStringSliceBase(expr.X, base); err != nil {
+			return value{}, err
+		}
+	}
+	baseLoaded, err := g.loadIfPointer(base)
+	if err != nil {
+		return value{}, err
+	}
+
+	var lenSym, sliceSym string
+	if isList {
+		lenSym = listRuntimeLenSymbol()
+		sliceSym = listRuntimeSliceSymbol()
+	} else {
+		lenSym = llvmStringRuntimeByteLenSymbol()
+		sliceSym = llvmStringRuntimeSliceSymbol()
+	}
+	g.declareRuntimeSymbol(lenSym, "i64", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(sliceSym, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+
+	emitter := g.toOstyEmitter()
+	startRaw := llvmExtractValue(emitter, toOstyValue(rangeVal), "i64", rangeFieldStart)
+	stopRaw := llvmExtractValue(emitter, toOstyValue(rangeVal), "i64", rangeFieldStop)
+	hasStart := llvmExtractValue(emitter, toOstyValue(rangeVal), "i1", rangeFieldHasStart)
+	hasStop := llvmExtractValue(emitter, toOstyValue(rangeVal), "i1", rangeFieldHasStop)
+	inclusive := llvmExtractValue(emitter, toOstyValue(rangeVal), "i1", rangeFieldInclusive)
+
+	startSel := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 0", startSel, hasStart.name, startRaw.name))
+	stopPlus := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", stopPlus, stopRaw.name))
+	stopIncl := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 %s", stopIncl, inclusive.name, stopPlus, stopRaw.name))
+
+	lenVal := llvmCall(emitter, "i64", lenSym, []*LlvmValue{toOstyValue(baseLoaded)})
+	endSel := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 %s", endSel, hasStop.name, stopIncl, lenVal.name))
+
+	startVal := value{typ: "i64", ref: startSel}
+	endVal := value{typ: "i64", ref: endSel}
+	out := llvmCall(emitter, "ptr", sliceSym, []*LlvmValue{toOstyValue(baseLoaded), toOstyValue(startVal), toOstyValue(endVal)})
+	g.takeOstyEmitter(emitter)
+
+	sliced := fromOstyValue(out)
+	sliced.gcManaged = true
+	if isList {
+		sliced.listElemTyp = base.listElemTyp
+		sliced.listElemString = base.listElemString
+		sliced.sourceType = base.sourceType
+		sliced.rootPaths = g.rootPathsForType(base.listElemTyp)
+	} else {
+		sliced.sourceType = &ast.NamedType{Path: []string{"String"}}
+	}
+	return sliced, nil
+}
+
+// requireStringSliceBase rejects non-String ptr receivers at the slice
+// index site. Shared between literal-range and range-value slice paths
+// so the diagnostic phrasing stays identical.
+func (g *generator) requireStringSliceBase(x ast.Expr, base value) error {
+	if base.typ != "ptr" {
+		return unsupportedf("type-system", "slice indexing on %s, want String (ptr) or List<T>", base.typ)
+	}
+	if sourceType, ok := g.staticExprSourceType(x); ok {
+		if resolved, resErr := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{}); resErr == nil {
+			if llvmNamedTypeIsString(resolved) {
+				return nil
+			}
+		}
+	}
+	return unsupported("type-system", "slice indexing is only supported on String or List<T> receivers")
 }
 
 func (g *generator) enumVariantValue(expr *ast.FieldExpr) (value, bool, error) {

--- a/internal/llvmgen/list_slice_test.go
+++ b/internal/llvmgen/list_slice_test.go
@@ -109,3 +109,115 @@ fn main() {
 		t.Fatalf("list<string> slice did not call runtime slice:\n%s", got)
 	}
 }
+
+// List indexing by a bound Range value routes through osty_rt_list_slice
+// — same runtime as the literal-range path. The aggregate is destructured
+// at runtime so hasStart/hasStop/inclusive stay live.
+func TestListSliceByLetRangeValue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let xs = [10, 20, 30, 40]
+    let n = xs.len()
+    let r = 0..n
+    let ys = xs[r]
+    println(ys.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_let_range.osty"})
+	if err != nil {
+		t.Fatalf("let-range list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"@osty_rt_list_len",
+		"extractvalue %Range.i64",
+		"select i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("let-range list slice missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Range passed as a parameter also routes through the slice runtime.
+// Covers `fn f(xs, r) { xs[r] }` where the function body has no static
+// view of the range's start/stop — everything is pulled out of the
+// aggregate at runtime.
+func TestListSliceByRangeParam(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn take(xs: List<Int>, r: Range<Int>) -> List<Int> {
+    xs[r]
+}
+
+fn main() {
+    let xs = [10, 20, 30]
+    println(take(xs, 0..2).len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_range_param.osty"})
+	if err != nil {
+		t.Fatalf("range-param list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"extractvalue %Range.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("range-param list slice missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Open-ended range values (`..n`, `n..`, `..`) must fall back to 0 for
+// start and list.len for stop, matching the literal slicer. Validated
+// here by storing an open-low range in a let and confirming the IR
+// still emits the hasStart/hasStop select guards.
+func TestListSliceByOpenRangeValue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let xs = [10, 20, 30, 40]
+    let r = ..3
+    let ys = xs[r]
+    println(ys.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_open_range.osty"})
+	if err != nil {
+		t.Fatalf("open-low range list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"extractvalue %Range.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("open-low range list slice missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Inclusive range values (`a..=b`) must add 1 to the stop bound at
+// runtime. The select on the `inclusive` field lets the same IR handle
+// both exclusive and inclusive ranges without branching.
+func TestListSliceByInclusiveRangeValue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let xs = [10, 20, 30]
+    let r = 0..=1
+    let ys = xs[r]
+    println(ys.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_incl_range.osty"})
+	if err != nil {
+		t.Fatalf("inclusive range-value list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"add i64",
+		"select i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("inclusive range-value list slice missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/string_slice_test.go
+++ b/internal/llvmgen/string_slice_test.go
@@ -81,6 +81,31 @@ fn main() {
 	}
 }
 
+// String indexing by a bound Range value routes through
+// osty_rt_strings_Slice — same runtime as the literal-range path.
+func TestStringSliceByRangeValue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let s = "hello"
+    let n = s.len()
+    let r = 1..n
+    println(s[r])
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_slice_let_range.osty"})
+	if err != nil {
+		t.Fatalf("string range-value slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_Slice",
+		"extractvalue %Range.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("string range-value slice missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStringSubstringMethodCall(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn stripPrefix(text: String) -> String {
     if text.startsWith("0x") {


### PR DESCRIPTION
## Summary

- `emitIndexExpr` only dispatched to the slice runtime when the index was an inline `*ast.RangeExpr`. Storing the range in a let binding or passing it as a parameter — `let r = 0..n; xs[r]` or `fn f(xs, r: Range<Int>) { xs[r] }` — fell through to the scalar index path and tripped `LLVM011 type-system: list index type %Range.i64, want i64`. This blocks quicksort and similar benches from hoisting a slice range into a named variable.
- Add `emitSliceIndexByRangeValue`: destructures the Range aggregate at runtime (`extractvalue` on start/stop/hasStart/hasStop/inclusive), folds the `hasStart`/`hasStop`/`inclusive` semantics with `select`, and routes to the same `osty_rt_list_slice` / `osty_rt_strings_Slice` helpers as the literal path.
- Element type restricted to `i64` to match the literal slicer's bound constraints.
- Shared the String-receiver guard (`base.typ == "ptr"` + static-source-type + `llvmNamedTypeIsString`) between literal and range-value paths as `requireStringSliceBase` so the diagnostic phrasing stays identical.
- Named constants for the Range aggregate field indices (`rangeFieldStart`..`Inclusive`), pinned to the struct def emitted in `generator.go`.

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestListSlice|TestStringSlice'` — 12/12 pass, including 5 new cases:
  - `TestListSliceByLetRangeValue` — `let r = 0..n; xs[r]`
  - `TestListSliceByRangeParam` — `Range<Int>` as fn param
  - `TestListSliceByOpenRangeValue` — `let r = ..3; xs[r]`
  - `TestListSliceByInclusiveRangeValue` — `let r = 0..=1; xs[r]`
  - `TestStringSliceByRangeValue` — String receiver with bound Range
- [x] `go test ./internal/llvmgen/ -short` failure set identical to `main` (no new failures introduced; 6 pre-existing failures unchanged).
- [x] `just front` — all frontend packages pass.
- [x] `go vet ./internal/llvmgen/` clean.

## Notes for reviewer

- The inline-`RangeExpr` fast path is untouched — `xs[0..n]` still lowers via `emitSliceIndex` / `emitListSliceIndex` with no runtime selects. The new code only engages when the index is a stored Range value.
- LLVM folds the `select`/`add` guards to the inline IR when the Range's bounds are compile-time constants (`mem2reg` + SROA + `instcombine`), so hot-path codegen parity with the literal path is preserved after `-O2`.
- `osty_rt_list_len` is always declared `memory(read)` ([support_snapshot.go:2389](../blob/main/internal/llvmgen/support_snapshot.go#L2389)) so the unconditional call in the `hasStop` select path is DCE'd when the `hasStop` branch is resolved at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)