### PR TITLE
[codex] support native dump-native-diags

### DIFF
--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -60,34 +60,76 @@ fn bad() -> Int {
 	}
 }
 
-// TestCheckCLINativeRejectsInspectAndDumpFlags pins the flag
-// compatibility contract. --inspect / --dump-native-diags both probe
-// the Go check.Result shape, which --native never materializes, so
-// combining them is explicitly rejected at the dispatch site with
-// exit code 2.
-func TestCheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
+// TestCheckCLINativeRejectsInspectFlag pins the remaining flag
+// compatibility contract. --inspect still probes the Go check.Result
+// shape, which --native never materializes, so combining them is
+// explicitly rejected at the dispatch site with exit code 2.
+func TestCheckCLINativeRejectsInspectFlag(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
 	if err := os.WriteFile(path, []byte(`fn main() {}
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	// --inspect and --dump-native-diags are declared as global flags
-	// in parseFlags(), so Go's flag package only recognizes them
+	// --inspect is declared as a global flag in parseFlags(), so Go's
+	// flag package only recognizes it
 	// before the subcommand. Pre-subcommand placement is the normal
 	// user ergonomic for those flags; combining them with --native
 	// must still be rejected at the dispatch site.
-	for _, incompatible := range []string{"--inspect", "--dump-native-diags"} {
-		incompatible := incompatible
-		t.Run(incompatible, func(t *testing.T) {
-			got := runOstyCLI(t, incompatible, "check", "--native", path)
-			if got.exit != 2 {
-				t.Fatalf("exit = %d, want 2 (flag-incompatibility rejection)\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
-			}
-			if !strings.Contains(got.stderr, "incompatible") {
-				t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
-			}
-		})
+	got := runOstyCLI(t, "--inspect", "check", "--native", path)
+	if got.exit != 2 {
+		t.Fatalf("exit = %d, want 2 (flag-incompatibility rejection)\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "incompatible") {
+		t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
+	}
+}
+
+func TestRunCheckFileNativeDumpNativeDiagsPrintsSummary(t *testing.T) {
+	src := []byte(`fn id(n: Int) -> Int {
+    n
+}
+
+fn main() {
+    let y = id(1)
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true, native: true, dumpNativeDiags: true}
+	formatter := newFormatter(path, src, flags)
+
+	origStderr := os.Stderr
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = werr
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runCheckFileNative(path, src, formatter, flags)
+	_ = werr.Close()
+	stderrBytes, err := io.ReadAll(rerr)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	stderr := string(stderrBytes)
+
+	if exit != 0 {
+		t.Fatalf("runCheckFileNative exit = %d, want 0\nstderr:\n%s", exit, stderr)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after dump-native-diags native check = %d, want 0", got)
+	}
+	if !strings.Contains(stderr, "native checker telemetry: "+path) {
+		t.Fatalf("stderr missing telemetry header:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "assignments:") {
+		t.Fatalf("stderr missing assignments row:\n%s", stderr)
 	}
 }
 

--- a/cmd/osty/dump_native_diags.go
+++ b/cmd/osty/dump_native_diags.go
@@ -18,7 +18,16 @@ import (
 	"sort"
 
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/selfhost"
 )
+
+type nativeDiagTelemetry struct {
+	Assignments     int
+	Accepted        int
+	Errors          int
+	ErrorsByContext map[string]int
+	ErrorDetails    map[string]map[string]int
+}
 
 // dumpNativeDiagsFor prints the native checker's per-context histogram
 // for one already-checked scope (file, package, or workspace entry) to
@@ -30,6 +39,29 @@ func dumpNativeDiagsFor(label string, chk *check.Result) {
 		return
 	}
 	t := chk.NativeCheckerTelemetry
+	dumpNativeDiagTelemetry(label, nativeDiagTelemetry{
+		Assignments:     t.Assignments,
+		Accepted:        t.Accepted,
+		Errors:          t.Errors,
+		ErrorsByContext: t.ErrorsByContext,
+		ErrorDetails:    t.ErrorDetails,
+	})
+}
+
+// dumpNativeDiagsForSummary is the native CLI-path sibling of
+// dumpNativeDiagsFor: it reads the already-materialized self-host
+// summary directly instead of going through check.Result.
+func dumpNativeDiagsForSummary(label string, summary selfhost.CheckSummary) {
+	dumpNativeDiagTelemetry(label, nativeDiagTelemetry{
+		Assignments:     summary.Assignments,
+		Accepted:        summary.Accepted,
+		Errors:          summary.Errors,
+		ErrorsByContext: summary.ErrorsByContext,
+		ErrorDetails:    summary.ErrorDetails,
+	})
+}
+
+func dumpNativeDiagTelemetry(label string, t nativeDiagTelemetry) {
 	if t.Errors == 0 && t.Assignments == 0 {
 		return
 	}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -88,18 +88,18 @@ type cliFlags struct {
 	aiMode     airepair.Mode
 	// dumpNativeDiags prints the native checker's per-context error
 	// histogram (assignments/accepted/errors + breakdown) to stderr after
-	// a `check` / `typecheck` run. Populated from `internal/check.Result`
-	// once the native-checker boundary has been invoked. Off by default;
-	// nil-safe when the native checker was unavailable.
+	// a `check` / `typecheck` run. Legacy paths read it from
+	// `internal/check.Result`; self-host native CLI paths read the same
+	// counters directly from `selfhost.CheckSummary`. Off by default.
 	dumpNativeDiags bool
 	// native routes `check` through the self-host arena pipeline
 	// (selfhost.CheckFromSource) instead of the Go-hosted resolve +
 	// check.File pair. The happy path never materializes *ast.File,
 	// so selfhost.AstbridgeLowerCount stays at 0 for the whole
-	// subcommand. Incompatible with --inspect / --dump-native-diags,
-	// which both probe the Go check.Result shape. Production default
-	// as of Phase 1c.1 (SELFHOST_PORT_MATRIX.md); `--legacy` opts back
-	// to the Go-hosted pair until the dual-track is retired.
+	// subcommand. Incompatible with --inspect, which still probes the
+	// Go check.Result shape. Production default as of Phase 1c.1
+	// (SELFHOST_PORT_MATRIX.md); `--legacy` opts back to the Go-hosted
+	// pair until the dual-track is retired.
 	native bool
 	// legacy routes `check` / `typecheck` back through the Go-hosted
 	// resolve + check.File pair. Escape hatch for the 1c.1 default
@@ -411,8 +411,8 @@ func main() {
 					"osty: typecheck --legacy does not accept a directory (expected a file)\n")
 				os.Exit(2)
 			}
-			if flags.inspect || flags.dumpNativeDiags {
-				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+			if flags.inspect {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect\n")
 				os.Exit(2)
 			}
 			if root, ok, abort := nativeWorkspaceRoot(path, flags); abort {
@@ -539,8 +539,8 @@ func main() {
 		}
 	case "check":
 		if flags.native {
-			if flags.inspect || flags.dumpNativeDiags {
-				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+			if flags.inspect {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect\n")
 				os.Exit(2)
 			}
 			if runCheckFileNative(path, src, formatter, flags) != 0 {
@@ -553,8 +553,8 @@ func main() {
 		}
 	case "typecheck":
 		if flags.native {
-			if flags.inspect || flags.dumpNativeDiags {
-				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+			if flags.inspect {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect\n")
 				os.Exit(2)
 			}
 			if runTypecheckFileNative(path, src, formatter, flags) != 0 {
@@ -606,8 +606,8 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.trace, "trace", false, "stream per-phase timing to stderr (single-file front-end commands)")
 	flag.BoolVar(&f.explain, "explain", false, "after diagnostics, print the `osty explain CODE` text for each unique code")
 	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.5/02a-type-inference.md)")
-	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check: after the run, print the native checker's per-context error histogram to stderr")
-	flag.BoolVar(&f.native, "native", true, "check/typecheck: route through the self-host arena pipeline (astbridge-free; production default). Incompatible with --inspect and --dump-native-diags; redundant with the default but accepted for backwards compatibility")
+	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check/typecheck: after the run, print the native checker's per-context error histogram to stderr")
+	flag.BoolVar(&f.native, "native", true, "check/typecheck: route through the self-host arena pipeline (astbridge-free; production default). Incompatible with --inspect; redundant with the default but accepted for backwards compatibility")
 	flag.BoolVar(&f.legacy, "legacy", false, "check/typecheck: route through the Go-hosted resolve + check.File pair (pre-1c.1 default). Escape hatch while the selfhost checker coverage tail finishes; will be removed once dual-track is retired")
 	flag.Usage = usage
 	flag.Parse()
@@ -632,8 +632,8 @@ func parseFlags() cliFlags {
 // snippets point at the right lines even when spanning packages.
 func runCheckPackage(dir string, flags cliFlags) {
 	if flags.native {
-		if flags.inspect || flags.dumpNativeDiags {
-			fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+		if flags.inspect {
+			fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect\n")
 			os.Exit(2)
 		}
 		if root, ok, abort := nativeWorkspaceRoot(dir, flags); abort {
@@ -1005,6 +1005,9 @@ func runTypecheckPackageNative(dir string, flags cliFlags) int {
 	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
 	printPackageDiags(pkg, diags, flags)
 	printNativePackageTypes(checked, input.Files)
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsForSummary(dir, checked.Summary)
+	}
 	if hasError(diags) {
 		return 1
 	}
@@ -1076,6 +1079,9 @@ func runCheckPackageNative(dir string, flags cliFlags) int {
 	diags := packageParseDiags(pkg)
 	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
 	printPackageDiags(pkg, diags, flags)
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsForSummary(dir, checked.Summary)
+	}
 	if hasError(diags) {
 		return 1
 	}
@@ -1109,6 +1115,9 @@ func runNativeWorkspaceCheck(dir, mode string, flags cliFlags, emitTypes bool) i
 		printPackageDiags(pkg, diags, flags)
 		if emitTypes {
 			printNativePackageTypes(checked, input.Files)
+		}
+		if flags.dumpNativeDiags {
+			dumpNativeDiagsForSummary(path, checked.Summary)
 		}
 		if hasError(diags) {
 			anyErr = true
@@ -1257,6 +1266,9 @@ func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, 
 	all = append(all, checkDiags...)
 	printDiags(formatter, all, flags)
 	printNativeTypes(src, checked)
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsForSummary(path, checked.Summary)
+	}
 	if hasError(all) {
 		return 1
 	}
@@ -1434,6 +1446,9 @@ func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flag
 	all := append([]*diag.Diagnostic{}, parseDiags...)
 	all = append(all, checkDiags...)
 	printDiags(formatter, all, flags)
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsForSummary(path, checked.Summary)
+	}
 	if hasError(all) {
 		return 1
 	}

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -60,27 +60,86 @@ func TestTypecheckCLINativeSurfacesTypeError(t *testing.T) {
 	}
 }
 
-// TestTypecheckCLINativeRejectsInspectAndDumpFlags mirrors the check
-// path incompatibility contract: --inspect / --dump-native-diags both
-// probe the Go check.Result shape, which --native never materializes.
-func TestTypecheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
+// TestTypecheckCLINativeRejectsInspectFlag mirrors the check-path
+// incompatibility contract: --inspect still probes the Go
+// check.Result shape, which --native never materializes.
+func TestTypecheckCLINativeRejectsInspectFlag(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
 	if err := os.WriteFile(path, []byte(`fn main() {}
 `), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	for _, incompatible := range []string{"--inspect", "--dump-native-diags"} {
-		incompatible := incompatible
-		t.Run(incompatible, func(t *testing.T) {
-			got := runOstyCLI(t, incompatible, "typecheck", "--native", path)
-			if got.exit != 2 {
-				t.Fatalf("exit = %d, want 2\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
-			}
-			if !strings.Contains(got.stderr, "incompatible") {
-				t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
-			}
-		})
+	got := runOstyCLI(t, "--inspect", "typecheck", "--native", path)
+	if got.exit != 2 {
+		t.Fatalf("exit = %d, want 2\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "incompatible") {
+		t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
+	}
+}
+
+func TestRunTypecheckFileNativeDumpNativeDiagsPrintsSummary(t *testing.T) {
+	src := []byte(`fn id(n: Int) -> Int {
+    n
+}
+
+fn main() {
+    let y = id(1)
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true, native: true, dumpNativeDiags: true}
+	formatter := newFormatter(path, src, flags)
+
+	origStdout := os.Stdout
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = wout
+	t.Cleanup(func() { os.Stdout = origStdout })
+	origStderr := os.Stderr
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = werr
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runTypecheckFileNative(path, src, formatter, flags)
+	_ = wout.Close()
+	_ = werr.Close()
+	stdoutBytes, err := io.ReadAll(rout)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	stderrBytes, err := io.ReadAll(rerr)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	stdout := string(stdoutBytes)
+	stderr := string(stderrBytes)
+
+	if exit != 0 {
+		t.Fatalf("runTypecheckFileNative exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exit, stdout, stderr)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after dump-native-diags native typecheck = %d, want 0", got)
+	}
+	if !strings.Contains(stderr, "native checker telemetry: "+path) {
+		t.Fatalf("stderr missing telemetry header:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "assignments:") {
+		t.Fatalf("stderr missing assignments row:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "Int") {
+		t.Fatalf("stdout missing Int type row:\n%s", stdout)
 	}
 }
 


### PR DESCRIPTION
## What changed
- enabled `--dump-native-diags` on the self-host native `check` and `typecheck` paths instead of rejecting it with `--native`
- added a shared telemetry dumper that can read either legacy `check.Result` telemetry or direct `selfhost.CheckSummary` output
- updated native-path tests to keep `--inspect` rejected while covering the new dump-native-diags behavior

## Why
The CLI already defaults `check` and `typecheck` to the self-host native path, but `--dump-native-diags` was still treated like a legacy-only feature because it depended on the Go `check.Result` shape. That made the default path reject a flag whose data was already available in the native summary.

## Impact
- `osty check --native --dump-native-diags ...` now prints native checker telemetry
- `osty typecheck --native --dump-native-diags ...` now prints telemetry and still emits native type rows
- `--inspect` remains blocked on native until the inspect bridge is finished

## Validation
- `go test ./cmd/osty -run 'Test(CheckCLINativeRejectsInspectFlag|RunCheckFileNativeDumpNativeDiagsPrintsSummary|TypecheckCLINativeRejectsInspectFlag|RunTypecheckFileNativeDumpNativeDiagsPrintsSummary)$' -count=1`
- `go test ./cmd/osty -count=1`
- `just verify-selfhost`
