### PR TITLE
refactor(resolve): Phase 1c.5 warm-up — delete unused resolve.File helper

### DIFF
--- a/internal/resolve/loop_label_test.go
+++ b/internal/resolve/loop_label_test.go
@@ -18,7 +18,7 @@ func TestResolveUndefinedLoopLabel(t *testing.T) {
 	if len(parseDiags) > 0 {
 		t.Fatalf("parse diagnostics = %v", parseDiags)
 	}
-	res := File(file, NewPrelude())
+	res := FileWithStdlib(file, NewPrelude(), nil)
 	if !hasResolveCode(res.Diags, "E0763") {
 		t.Fatalf("expected E0763, got %#v", res.Diags)
 	}
@@ -37,7 +37,7 @@ func TestResolveLoopLabelShadow(t *testing.T) {
 	if len(parseDiags) > 0 {
 		t.Fatalf("parse diagnostics = %v", parseDiags)
 	}
-	res := File(file, NewPrelude())
+	res := FileWithStdlib(file, NewPrelude(), nil)
 	if !hasResolveCode(res.Diags, "E0764") {
 		t.Fatalf("expected E0764, got %#v", res.Diags)
 	}
@@ -55,7 +55,7 @@ func TestResolveBreakValueExpression(t *testing.T) {
 	if len(parseDiags) > 0 {
 		t.Fatalf("parse diagnostics = %v", parseDiags)
 	}
-	res := File(file, NewPrelude())
+	res := FileWithStdlib(file, NewPrelude(), nil)
 	if len(res.Diags) != 0 {
 		t.Fatalf("unexpected resolve diagnostics: %#v", res.Diags)
 	}

--- a/internal/resolve/refs_by_id_test.go
+++ b/internal/resolve/refs_by_id_test.go
@@ -26,7 +26,7 @@ fn main() {
 	if file == nil {
 		t.Fatal("parse failed")
 	}
-	res := File(file, NewPrelude())
+	res := FileWithStdlib(file, NewPrelude(), nil)
 
 	if res.RefsByID == nil || res.TypeRefsByID == nil {
 		t.Fatal("RefsByID / TypeRefsByID not populated")

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -36,15 +36,8 @@ type Result struct {
 	Diags []*diag.Diagnostic
 }
 
-// File runs name resolution over a single parsed source file. It is a
-// thin convenience wrapper around ResolvePackage that treats the input
-// as a one-file package. Use ResolvePackage directly when working with
-// a real on-disk directory.
-func File(file *ast.File, prelude *Scope) *Result {
-	return FileWithStdlib(file, prelude, nil)
-}
-
-// FileWithStdlib is File plus a StdlibProvider: `use std.*` imports in
+// FileWithStdlib runs name resolution over a single parsed source file
+// with an optional StdlibProvider: `use std.*` imports in
 // the source resolve through the provider before falling back to the
 // opaque-stub behavior. Passing a nil provider is equivalent to File.
 func FileWithStdlib(file *ast.File, prelude *Scope, stdlib StdlibProvider) *Result {

--- a/internal/resolve/runtime_annot_test.go
+++ b/internal/resolve/runtime_annot_test.go
@@ -18,7 +18,7 @@ func runAnnotArgs(t *testing.T, src string) []*diag.Diagnostic {
 	if len(parseDiags) != 0 {
 		t.Fatalf("parse diagnostics: %v", parseDiags)
 	}
-	res := File(file, NewPrelude())
+	res := FileWithStdlib(file, NewPrelude(), nil)
 	return res.Diags
 }
 


### PR DESCRIPTION
## Summary
\`resolve.File(file, prelude)\` was a one-line wrapper around \`FileWithStdlib(file, prelude, nil)\`. Post-1c.4, **no production code** calls it — only five in-package tests did. Removes the wrapper and updates the tests to call \`FileWithStdlib(..., nil)\` directly.

First tangible Phase 1c.5 step: shrinks the Go resolver's external API surface by one symbol.

## What's in here
- \`internal/resolve/resolve.go\`: deletes the \`File\` function (6 LOC) and merges its doc into \`FileWithStdlib\`.
- \`internal/resolve/loop_label_test.go\` (×3), \`refs_by_id_test.go\` (×1), \`runtime_annot_test.go\` (×1): swap to \`FileWithStdlib(..., nil)\`.

## What comes next in 1c.5
The larger 1c.5 work depends on migrating 30+ production + test call sites across \`cmd/osty\`, \`internal/pipeline\`, \`internal/bootstrap/{seedgen,gen}\`, \`internal/cihost\`, and backend/llvmgen test suites off the Go-native resolver entrypoints (\`ResolveAll\`, \`LoadPackage\`, \`FileWithStdlib\`, \`ResolvePackage\`) onto the selfhost arena-first loader (\`LoadPackageArenaFirst\` + \`CheckStructuredFromRun\`).

Each migration is a per-site refactor; there's no single-PR path to delete the whole Go-native resolver. Expect a series of small incremental PRs.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`just front\` green (including \`internal/resolve\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)