### PR TITLE
refactor(resolve): Phase 1c.5 — migrate LoadPackage test callers to arena-first

### DIFF
--- a/internal/bootstrap/gen/error_runtime_test.go
+++ b/internal/bootstrap/gen/error_runtime_test.go
@@ -73,7 +73,7 @@ func bootstrapGeneratedSource(t *testing.T, path string) string {
 		t.Fatalf("NewWorkspace: %v", err)
 	}
 	ws.Stdlib = reg
-	if _, err := ws.LoadPackage(""); err != nil {
+	if _, err := ws.LoadPackageArenaFirst(""); err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}
 	results := ws.ResolveAll()

--- a/internal/check/diag_file_attrib_test.go
+++ b/internal/check/diag_file_attrib_test.go
@@ -28,7 +28,7 @@ pub fn violator() -> Int { 42 }
 		t.Fatal(err)
 	}
 
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}

--- a/internal/check/workspace_parallel_test.go
+++ b/internal/check/workspace_parallel_test.go
@@ -69,7 +69,7 @@ pub struct Pair%d {
 	}
 	ws.Stdlib = stdlib.LoadCached()
 	for i := 0; i < n; i++ {
-		if _, err := ws.LoadPackage(fmt.Sprintf("pkg%d", i)); err != nil {
+		if _, err := ws.LoadPackageArenaFirst(fmt.Sprintf("pkg%d", i)); err != nil {
 			tb.Fatalf("load pkg%d: %v", i, err)
 		}
 	}

--- a/internal/lint/diag_file_attrib_test.go
+++ b/internal/lint/diag_file_attrib_test.go
@@ -29,7 +29,7 @@ func TestLintPackageStampsPerFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}

--- a/internal/pipeline/pipeline_gen_test.go
+++ b/internal/pipeline/pipeline_gen_test.go
@@ -14,7 +14,7 @@ func TestRunLoadedPackageGenUsesPackageLoweringForSiblingFiles(t *testing.T) {
 	writePipelineTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
 	writePipelineTestFile(t, dir, "b.osty", "fn main() { println(helper()) }\n")
 
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage() error = %v", err)
 	}
@@ -72,7 +72,7 @@ func TestRunLoadedPackageGenUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
 	writePipelineTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
 	writePipelineTestFile(t, dir, "b.osty", "fn main() { println(helper()) }\n")
 
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage() error = %v", err)
 	}
@@ -102,7 +102,7 @@ func TestRunLoadedPackageGenSingleFileUsesManagedNativeLLVMGen(t *testing.T) {
 	dir := t.TempDir()
 	writePipelineTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
 
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage() error = %v", err)
 	}

--- a/internal/resolve/cycle_detection_test.go
+++ b/internal/resolve/cycle_detection_test.go
@@ -43,7 +43,7 @@ pub fn world() -> Int { 1 }
 		t.Fatalf("NewWorkspace: %v", err)
 	}
 	for _, p := range WorkspacePackagePaths(root) {
-		if _, err := ws.LoadPackage(p); err != nil {
+		if _, err := ws.LoadPackageArenaFirst(p); err != nil {
 			t.Fatalf("LoadPackage %s: %v", p, err)
 		}
 	}
@@ -101,7 +101,7 @@ func TestWorkspaceDetectsCyclicImportThreePackage(t *testing.T) {
 		t.Fatalf("NewWorkspace: %v", err)
 	}
 	for _, p := range WorkspacePackagePaths(root) {
-		if _, err := ws.LoadPackage(p); err != nil {
+		if _, err := ws.LoadPackageArenaFirst(p); err != nil {
 			t.Fatalf("LoadPackage %s: %v", p, err)
 		}
 	}
@@ -151,7 +151,7 @@ func TestWorkspaceNoCycleOnDAG(t *testing.T) {
 		t.Fatalf("NewWorkspace: %v", err)
 	}
 	for _, p := range WorkspacePackagePaths(root) {
-		if _, err := ws.LoadPackage(p); err != nil {
+		if _, err := ws.LoadPackageArenaFirst(p); err != nil {
 			t.Fatalf("LoadPackage %s: %v", p, err)
 		}
 	}

--- a/internal/resolve/diag_file_attrib_test.go
+++ b/internal/resolve/diag_file_attrib_test.go
@@ -25,7 +25,7 @@ func TestPackageDiagsCarryOwningFilePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}

--- a/internal/resolve/diag_file_attrib_workspace_test.go
+++ b/internal/resolve/diag_file_attrib_workspace_test.go
@@ -37,7 +37,7 @@ func TestWorkspaceDiagsCarryFilePathAcrossPackages(t *testing.T) {
 		t.Fatalf("NewWorkspace: %v", err)
 	}
 	for _, p := range WorkspacePackagePaths(root) {
-		if _, err := ws.LoadPackage(p); err != nil {
+		if _, err := ws.LoadPackageArenaFirst(p); err != nil {
 			t.Fatalf("LoadPackage %s: %v", p, err)
 		}
 	}

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -17,20 +17,21 @@ import (
 // parser sees them. nil preserves the on-disk bytes.
 type SourceTransform func(path string, src []byte) []byte
 
-// LoadPackage discovers and parses every `.osty` file directly under
-// dir (non-recursive) and returns them as a single Package ready for
-// ResolvePackage. Test files (`*_test.osty`) are excluded per v0.4 §11
-// so production builds don't drag test-only declarations into scope.
+// LoadPackageWithTransform discovers and parses every `.osty` file
+// directly under dir (non-recursive) and returns them as a single
+// Package ready for ResolvePackage. Test files (`*_test.osty`) are
+// excluded per v0.4 §11 so production builds don't drag test-only
+// declarations into scope. Accepts an optional pre-parse source
+// transform — callers can normalize foreign syntax or inject generated
+// source before diagnostics are computed.
 //
 // The returned Package has Files sorted lexicographically by path for
 // deterministic diagnostic ordering.
-func LoadPackage(dir string) (*Package, error) {
-	return LoadPackageWithTransform(dir, nil)
-}
-
-// LoadPackageWithTransform is LoadPackage plus an optional pre-parse
-// source transform. The callback can normalize foreign syntax or inject
-// generated source before diagnostics are computed.
+//
+// Public callers should prefer LoadPackageArenaFirst, which routes
+// through the selfhost arena-first loader. This function is retained
+// as the internal primitive workspace.go uses for its own loading
+// machinery.
 func LoadPackageWithTransform(dir string, transform SourceTransform) (*Package, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {

--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -101,7 +101,7 @@ func TestNativeResolutionRowsCrossFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}
@@ -136,7 +136,7 @@ fn main() {
 		t.Fatal(err)
 	}
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestNativeDiagnosticsSingleFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageArenaFirst(dir)
 	if err != nil {
 		t.Fatalf("LoadPackage: %v", err)
 	}


### PR DESCRIPTION
## Summary
Migrates 13 call sites of \`resolve.LoadPackage\` / \`Workspace.LoadPackage\` to the arena-first variants (\`LoadPackageArenaFirst\`). Deletes the top-level \`resolve.LoadPackage\` wrapper; \`LoadPackageWithTransform\` stays as the internal primitive for \`Workspace\`'s own loading.

## Call sites migrated
| File | Count |
|---|---|
| \`internal/pipeline/pipeline_gen_test.go\` | 3 |
| \`internal/resolve/native_adapter_test.go\` | 3 |
| \`internal/resolve/cycle_detection_test.go\` | 3 |
| \`internal/resolve/diag_file_attrib_test.go\` | 1 |
| \`internal/resolve/diag_file_attrib_workspace_test.go\` | 1 |
| \`internal/check/diag_file_attrib_test.go\` | 1 |
| \`internal/check/workspace_parallel_test.go\` | 1 |
| \`internal/lint/diag_file_attrib_test.go\` | 1 |
| \`internal/bootstrap/gen/error_runtime_test.go\` | 1 |

## What this leaves
- \`LoadPackageWithTransform\` kept — used internally by \`workspace.go:243,304\` to load external deps.
- \`Workspace.LoadPackage\` method still used by \`workspace.go\` self-recursion (\`:273,:325,:600\`). Removing it needs a refactor of the Workspace loader's DFS.
- \`Workspace.ResolveAll\` — still has 20+ production callers (cmd/osty/\*, pipeline, cihost, bootstrap). Separate migration chain.
- \`resolve.FileWithStdlib\` / \`ResolvePackage\` — still called from 15+ sites. Separate chain.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`just front\` green
- [x] \`go test ./internal/bootstrap/...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)