### PR TITLE
port(llvmgen): move §11/§15 pure predicates onto mir_generator.osty

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -57,11 +57,11 @@ untouched.
 | 8 | concurrency intrinsics | 6762–7472 | ~20 | MEDIUM | Go-only |
 | 9 | terminators | 7473–7595 | ~5 | LOW | Go-only |
 | 10 | rvalue / operand | 7596–8937 | ~25 | HIGH | Go-only |
-| 11 | operators | 8938–9196 | ~12 | LOW | Partial — `isHeapEqualityType`, `isStringPrimType` ported |
+| 11 | operators | 8938–9196 | ~12 | LOW | Partial — `isHeapEqualityType`, `isStringPrimType`, `isStringOrderingBinOp`, `stringOrderingPredicate` ported |
 | 12 | strings | 9197–9284 | ~7 | LOW | Partial — `encodeLLVMString` / `earliestAfter` ported |
 | 13 | type mapping | 9285–9375 | ~8 | LOW | **Ported** (primitive + opaque-named + head-name + optional-surface) |
 | 14 | enum layout helpers | 9376–9575 | ~10 | LOW | Go-only |
-| 15 | helpers | 9576–9616 | ~5 | LOW | Partial — `firstNonEmpty`, `isUnitType`, `isFloatType` ported |
+| 15 | helpers | 9576–9616 | ~5 | LOW | Partial — `firstNonEmpty`, `isUnitType`, `isFloatType`, `isScalarLLVMType`, `llvmStdIoI1Text` ported |
 
 ## Phased plan
 
@@ -70,13 +70,15 @@ functions that have no `g.*` state dependency. Ship one section per PR
 with the compile-gate generator enforcing correctness.
 
 - ✅ §13 type mapping — first PR.
-- ⏳ §11 operators — predicates in, emit* bodies deferred (need state).
+- ⏳ §11 operators — pure predicates in (`isStringOrderingBinOp`,
+  `stringOrderingPredicate` delegate through `op.String()`); `emit*`
+  bodies deferred (need `g.fresh` / `g.fnBuf`).
 - ⏳ §12 strings — `encodeLLVMString` / `earliestAfter` in, `stringLiteral`
   / `emitStringPool` deferred (touch `g.strings`).
-- ⏳ §15 helpers — pure-side done (`firstNonEmpty`, unit/float predicates);
-  state-touching (`fresh`, `freshLabel`, `ostyEmitter`,
-  `flushOstyEmitter`, `storeIntrinsicResult`, `emitRuntimeRawNull`)
-  deferred to Phase B.
+- ⏳ §15 helpers — pure-side done (`firstNonEmpty`, unit/float/scalar
+  predicates, `llvmStdIoI1Text`); state-touching (`fresh`, `freshLabel`,
+  `ostyEmitter`, `flushOstyEmitter`, `storeIntrinsicResult`,
+  `emitRuntimeRawNull`) deferred to Phase B.
 - ⏳ §9 terminators — small (~120 LOC), single `emitTerm` switch. Cross-
   calls into §5 safepoint + §1 metadata — port after Phase B state.
 
@@ -147,8 +149,12 @@ list keeps new Osty clean of known landmines.
 | `mirLlvmTypeIsOptionalSurface` | `(typeText: String) -> Bool` | §13 | trailing-`?` + bracket-depth guard |
 | `mirIsHeapEqualityType` | `(typeText: String) -> Bool` | §11 | String/Bytes route to runtime equal |
 | `mirIsStringPrimTypeText` | `(typeText: String) -> Bool` | §11 | String-only ordering routing |
+| `mirIsStringOrderingSymbol` | `(symbol: String) -> Bool` | §11 | `<` / `<=` / `>` / `>=` symbol gate |
+| `mirStringOrderingPredicate` | `(symbol: String) -> String` | §11 | symbol → `slt` / `sle` / `sgt` / `sge` |
 | `mirIsUnitTypeText` | `(typeText: String) -> Bool` | §15 | Unit / `()` / Never |
 | `mirIsFloatTypeText` | `(typeText: String) -> Bool` | §15 | spec surface + LLVM text forms |
+| `mirIsScalarLLVMType` | `(t: String) -> Bool` | §15 | single-register LLVM scalar gate |
+| `mirLlvmI1Text` | `(v: Bool) -> String` | §15 | `true`/`false` i1 literal shim |
 | `mirFirstNonEmpty` | `(vals: List<String>) -> String` | §1 | variadic-erased first-non-empty |
 | `mirEarliestAfter` | `(input: String, needle: String) -> Int` | §12 | wrapper around `llvmStrings.Index` |
 | `mirEncodeLLVMString` | `(s: String) -> String` | §12 | printable-ASCII LLVM literal escaper |

--- a/internal/llvmgen/gen_mir_generator_snapshot.go
+++ b/internal/llvmgen/gen_mir_generator_snapshot.go
@@ -29,7 +29,7 @@ var (
 	mirGenContainsRE        = regexp.MustCompile("(?s)// Osty: .*\\nfunc ostyStringsContains\\(s string, substr string\\) bool \\{\\n\\treturn llvmStrings\\.Contains\\(s, substr\\)\\n\\}\\n\\n")
 	mirGenPrefixRE          = regexp.MustCompile("(?s)// Osty: .*\\nfunc ostyStringsHasPrefix\\(s string, prefix string\\) bool \\{\\n\\treturn llvmStrings\\.HasPrefix\\(s, prefix\\)\\n\\}\\n\\n")
 	mirGenSuffixRE          = regexp.MustCompile("(?s)// Osty: .*\\nfunc ostyStringsHasSuffix\\(s string, suffix string\\) bool \\{\\n\\treturn llvmStrings\\.HasSuffix\\(s, suffix\\)\\n\\}\\n\\n")
-	mirGenMergedCommentRE   = regexp.MustCompile(`// Osty: .*?/merged\.osty:(\d+):(\d+)`)
+	mirGenMergedCommentRE   = regexp.MustCompile(`// Osty: .*?[\\/]merged\.osty:(\d+):(\d+)`)
 )
 
 func main() {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3238,16 +3238,12 @@ func (g *mirGen) emitHintBlackBoxMIR(c *mir.CallInstr) error {
 	return nil
 }
 
-// isScalarLLVMType reports whether the given llvmType string names a
-// scalar LLVM type that fits a single register — the set the `=r,0`
-// asm constraint can tie to. Conservative; struct / array / composite
-// types return false.
+// isScalarLLVMType delegates to the Osty-sourced `mirIsScalarLLVMType`
+// predicate (`toolchain/mir_generator.osty`). The set the `=r,0` asm
+// constraint can tie to stays a single source of truth on the Osty
+// side; composite types (struct / array) fall through to the safe path.
 func isScalarLLVMType(t string) bool {
-	switch t {
-	case "i1", "i8", "i16", "i32", "i64", "float", "double", "ptr":
-		return true
-	}
-	return false
+	return mirIsScalarLLVMType(t)
 }
 
 // emitStdTestingCall dispatches `std.testing.*` call symbols at MIR
@@ -3334,11 +3330,11 @@ func (g *mirGen) emitStdIoWriteArgsMIR(args []mir.Operand, method string) error 
 	return nil
 }
 
+// llvmStdIoI1Text delegates to the Osty-sourced `mirLlvmI1Text`
+// (`toolchain/mir_generator.osty`) — the `bool` → `"true"` / `"false"`
+// shim is shared with any other site that needs an LLVM i1 literal.
 func llvmStdIoI1Text(v bool) string {
-	if v {
-		return "true"
-	}
-	return "false"
+	return mirLlvmI1Text(v)
 }
 
 func (g *mirGen) emitStdIoStringOperandMIR(op mir.Operand, method string) (string, error) {
@@ -9143,12 +9139,12 @@ func isStringPrimType(t mir.Type) bool {
 	return mirIsStringPrimTypeText(p.String())
 }
 
+// isStringOrderingBinOp delegates to the Osty-sourced
+// `mirIsStringOrderingSymbol` predicate (`toolchain/mir_generator.osty`).
+// The Go wrapper hands over the `mir.BinaryOp.String()` form so the
+// symbol-matching stays as a single source of truth on the Osty side.
 func isStringOrderingBinOp(op mir.BinaryOp) bool {
-	switch op {
-	case mir.BinLt, mir.BinLeq, mir.BinGt, mir.BinGeq:
-		return true
-	}
-	return false
+	return mirIsStringOrderingSymbol(op.String())
 }
 
 // emitStringOrdering lowers `<` / `<=` / `>` / `>=` on String values to
@@ -9181,18 +9177,12 @@ func (g *mirGen) emitStringOrdering(op mir.BinaryOp, left, right string) (string
 	return out, nil
 }
 
+// stringOrderingPredicate delegates to the Osty-sourced
+// `mirStringOrderingPredicate` helper (`toolchain/mir_generator.osty`).
+// Callers guard with `isStringOrderingBinOp` first, so the empty
+// fallthrough never reaches an emitter site.
 func stringOrderingPredicate(op mir.BinaryOp) string {
-	switch op {
-	case mir.BinLt:
-		return "slt"
-	case mir.BinLeq:
-		return "sle"
-	case mir.BinGt:
-		return "sgt"
-	case mir.BinGeq:
-		return "sge"
-	}
-	return ""
+	return mirStringOrderingPredicate(op.String())
 }
 
 // ==== strings ====

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -204,34 +204,79 @@ func mirIsStringPrimTypeText(typeText string) bool {
 }
 
 // Osty: toolchain/mir_generator.osty:182:5
+func mirIsStringOrderingSymbol(symbol string) bool {
+	return symbol == "<" || symbol == "<=" || symbol == ">" || symbol == ">="
+}
+
+// Osty: toolchain/mir_generator.osty:192:5
+func mirStringOrderingPredicate(symbol string) string {
+	// Osty: toolchain/mir_generator.osty:193:5
+	if symbol == "<" {
+		// Osty: toolchain/mir_generator.osty:194:9
+		return "slt"
+	}
+	// Osty: toolchain/mir_generator.osty:196:5
+	if symbol == "<=" {
+		// Osty: toolchain/mir_generator.osty:197:9
+		return "sle"
+	}
+	// Osty: toolchain/mir_generator.osty:199:5
+	if symbol == ">" {
+		// Osty: toolchain/mir_generator.osty:200:9
+		return "sgt"
+	}
+	// Osty: toolchain/mir_generator.osty:202:5
+	if symbol == ">=" {
+		// Osty: toolchain/mir_generator.osty:203:9
+		return "sge"
+	}
+	return ""
+}
+
+// Osty: toolchain/mir_generator.osty:215:5
 func mirIsUnitTypeText(typeText string) bool {
 	return typeText == "Unit" || typeText == "()" || typeText == "Never"
 }
 
-// Osty: toolchain/mir_generator.osty:192:5
+// Osty: toolchain/mir_generator.osty:225:5
 func mirIsFloatTypeText(typeText string) bool {
 	return typeText == "Float" || typeText == "Float32" || typeText == "Float64" || typeText == "double" || typeText == "float"
 }
 
-// Osty: toolchain/mir_generator.osty:203:5
+// Osty: toolchain/mir_generator.osty:236:5
+func mirIsScalarLLVMType(t string) bool {
+	return t == "i1" || t == "i8" || t == "i16" || t == "i32" || t == "i64" || t == "float" || t == "double" || t == "ptr"
+}
+
+// Osty: toolchain/mir_generator.osty:246:5
+func mirLlvmI1Text(v bool) string {
+	// Osty: toolchain/mir_generator.osty:247:5
+	if v {
+		// Osty: toolchain/mir_generator.osty:248:9
+		return "true"
+	}
+	return "false"
+}
+
+// Osty: toolchain/mir_generator.osty:259:5
 func mirFirstNonEmpty(vals []string) string {
-	// Osty: toolchain/mir_generator.osty:204:5
+	// Osty: toolchain/mir_generator.osty:260:5
 	n := len(vals)
 	_ = n
-	// Osty: toolchain/mir_generator.osty:205:5
+	// Osty: toolchain/mir_generator.osty:261:5
 	i := 0
 	_ = i
-	// Osty: toolchain/mir_generator.osty:206:5
+	// Osty: toolchain/mir_generator.osty:262:5
 	for i < n {
-		// Osty: toolchain/mir_generator.osty:207:9
+		// Osty: toolchain/mir_generator.osty:263:9
 		x := vals[i]
 		_ = x
-		// Osty: toolchain/mir_generator.osty:208:9
+		// Osty: toolchain/mir_generator.osty:264:9
 		if x != "" {
-			// Osty: toolchain/mir_generator.osty:209:13
+			// Osty: toolchain/mir_generator.osty:265:13
 			return x
 		}
-		// Osty: toolchain/mir_generator.osty:211:9
+		// Osty: toolchain/mir_generator.osty:267:9
 		func() {
 			var _cur7 int = i
 			var _rhs8 int = 1
@@ -247,51 +292,51 @@ func mirFirstNonEmpty(vals []string) string {
 	return ""
 }
 
-// Osty: toolchain/mir_generator.osty:223:5
+// Osty: toolchain/mir_generator.osty:279:5
 func mirEarliestAfter(input string, needle string) int {
 	return llvmStrings.Index(input, needle)
 }
 
-// Osty: toolchain/mir_generator.osty:248:5
+// Osty: toolchain/mir_generator.osty:304:5
 func mirEncodeLLVMString(s string) string {
-	// Osty: toolchain/mir_generator.osty:258:5
+	// Osty: toolchain/mir_generator.osty:314:5
 	printable := " !#$%&'()*+,-./0123456789:;<=" + ">?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 	_ = printable
-	// Osty: toolchain/mir_generator.osty:259:5
+	// Osty: toolchain/mir_generator.osty:315:5
 	out := ""
 	_ = out
-	// Osty: toolchain/mir_generator.osty:260:5
+	// Osty: toolchain/mir_generator.osty:316:5
 	n := len(s)
 	_ = n
-	// Osty: toolchain/mir_generator.osty:261:5
+	// Osty: toolchain/mir_generator.osty:317:5
 	i := 0
 	_ = i
-	// Osty: toolchain/mir_generator.osty:262:5
+	// Osty: toolchain/mir_generator.osty:318:5
 	for i < n {
-		// Osty: toolchain/mir_generator.osty:263:9
+		// Osty: toolchain/mir_generator.osty:319:9
 		ch := s[i:(i + 1)]
 		_ = ch
-		// Osty: toolchain/mir_generator.osty:264:9
+		// Osty: toolchain/mir_generator.osty:320:9
 		if ch == "\\" {
-			// Osty: toolchain/mir_generator.osty:265:13
+			// Osty: toolchain/mir_generator.osty:321:13
 			out = out + "\\\\"
 		} else if ch == "\"" {
-			// Osty: toolchain/mir_generator.osty:267:13
+			// Osty: toolchain/mir_generator.osty:323:13
 			out = out + "\\22"
 		} else if llvmStrings.Contains(printable, ch) {
-			// Osty: toolchain/mir_generator.osty:269:13
+			// Osty: toolchain/mir_generator.osty:325:13
 			out = out + ch
 		} else {
-			// Osty: toolchain/mir_generator.osty:274:13
+			// Osty: toolchain/mir_generator.osty:330:13
 			plen := len(printable)
 			_ = plen
-			// Osty: toolchain/mir_generator.osty:275:13
+			// Osty: toolchain/mir_generator.osty:331:13
 			trap := printable[(plen + 1):(plen + 2)]
 			_ = trap
-			// Osty: toolchain/mir_generator.osty:276:13
+			// Osty: toolchain/mir_generator.osty:332:13
 			return trap
 		}
-		// Osty: toolchain/mir_generator.osty:278:9
+		// Osty: toolchain/mir_generator.osty:334:9
 		func() {
 			var _cur9 int = i
 			var _rhs10 int = 1

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -163,6 +163,39 @@ pub fn mirIsStringPrimTypeText(typeText: String) -> Bool {
     typeText == "String"
 }
 
+/// mirIsStringOrderingSymbol reports whether the given operator symbol
+/// (the `mir.BinaryOp.String()` form — `"<"` / `"<="` / `">"` / `">="`)
+/// names one of the ordering comparisons that routes through
+/// `osty_rt_strings_Compare` when the operand type is `String`. Mirrors
+/// `isStringOrderingBinOp` in `internal/llvmgen/mir_generator.go`; the
+/// Go wrapper forwards `op.String()` so we keep the symbol-matching as a
+/// single source of truth here.
+pub fn mirIsStringOrderingSymbol(symbol: String) -> Bool {
+    symbol == "<" || symbol == "<=" || symbol == ">" || symbol == ">="
+}
+
+/// mirStringOrderingPredicate maps the operator symbol form of a MIR
+/// ordering binop (`"<"` / `"<="` / `">"` / `">="`) to the corresponding
+/// signed-integer LLVM icmp predicate (`"slt"` / `"sle"` / `"sgt"` /
+/// `"sge"`). Any other symbol returns `""` — callers that guard with
+/// `mirIsStringOrderingSymbol` first will never see the empty branch.
+/// Mirrors `stringOrderingPredicate` in `internal/llvmgen/mir_generator.go`.
+pub fn mirStringOrderingPredicate(symbol: String) -> String {
+    if symbol == "<" {
+        return "slt"
+    }
+    if symbol == "<=" {
+        return "sle"
+    }
+    if symbol == ">" {
+        return "sgt"
+    }
+    if symbol == ">=" {
+        return "sge"
+    }
+    ""
+}
+
 /// mirIsUnitTypeText reports whether the hir-style type text names the
 /// `Unit` / `()` / `Never` "no-value" types. Mirrors `isUnitType` in
 /// `internal/llvmgen/mir_generator.go` but operates on the textual
@@ -183,6 +216,29 @@ pub fn mirIsUnitTypeText(typeText: String) -> Bool {
 pub fn mirIsFloatTypeText(typeText: String) -> Bool {
     typeText == "Float" || typeText == "Float32" || typeText == "Float64" ||
         typeText == "double" || typeText == "float"
+}
+
+/// mirIsScalarLLVMType reports whether the given LLVM type name refers
+/// to a single-register scalar (`i1` / `i8` / `i16` / `i32` / `i64` /
+/// `float` / `double` / `ptr`). Mirrors `isScalarLLVMType` in
+/// `internal/llvmgen/mir_generator.go`. Used by the inline-asm shim to
+/// gate the `=r,0` tie constraint — composite types (structs, arrays)
+/// must return false so the emitter falls back to the safe path.
+pub fn mirIsScalarLLVMType(t: String) -> Bool {
+    t == "i1" || t == "i8" || t == "i16" || t == "i32" || t == "i64" ||
+        t == "float" || t == "double" || t == "ptr"
+}
+
+/// mirLlvmI1Text renders a Bool as its LLVM `i1` literal form —
+/// `"true"` or `"false"`. Mirrors `llvmStdIoI1Text` in
+/// `internal/llvmgen/mir_generator.go`. Extracted as a pure helper so
+/// callers that assemble `i1` operands (std.io writes, option disc
+/// stores, etc.) share the same stringification.
+pub fn mirLlvmI1Text(v: Bool) -> String {
+    if v {
+        return "true"
+    }
+    "false"
 }
 
 /// mirFirstNonEmpty returns the first non-empty entry in `vals`, or the


### PR DESCRIPTION
## Summary

Continues the MIR-emitter selfhost port tracked in [MIR_EMITTER_PORT.md](MIR_EMITTER_PORT.md). Four more stateless helpers from `internal/llvmgen/mir_generator.go` move onto the Osty source; the Go-side wrappers now delegate through the generated snapshot instead of owning the dispatch table.

- **§11 operators** — `isStringOrderingBinOp`, `stringOrderingPredicate` forward the `mir.BinaryOp.String()` symbol to Osty helpers `mirIsStringOrderingSymbol` / `mirStringOrderingPredicate`. The set of symbols routed through `osty_rt_strings_Compare` and their LLVM predicate names (`slt`/`sle`/`sgt`/`sge`) stay a single source of truth in `toolchain/mir_generator.osty`.
- **§15 helpers** — `isScalarLLVMType` (inline-asm `=r,0` tie gate) and `llvmStdIoI1Text` (`bool` → `"true"`/`"false"`) collapse into one-liner Go wrappers calling `mirIsScalarLLVMType` / `mirLlvmI1Text`.

Also fixes a Windows-only bug in `gen_mir_generator_snapshot.go`: the postprocess regex that rewrites `/tmp/.../merged.osty:L:C` back to `toolchain/mir_generator.osty:L:C` only matched forward slashes, so snapshots regenerated on Windows leaked the host temp-dir path into every Osty origin comment. The regex now accepts either separator.

## Why

`MIR_EMITTER_PORT.md` Phase A — keep shifting pure leaves onto the selfhost surface so the hand-written `mir_generator.go` shrinks one section at a time without losing either byte stability or the MIR-first / HIR-fallback dispatch contract.

## Test plan

- [x] `just front` clean (lexer / parser / resolve / check / diag / format / lint / pipeline).
- [x] `go test -run TestGenerateFromMIRStringOrdering ./internal/llvmgen` — all four lt/leq/gt/geq subcases pass; `call i64 @osty_rt_strings_Compare` and `icmp s{lt,le,gt,ge} i64` both present.
- [x] Broader `go test -run TestGenerateFromMIR ./internal/llvmgen` sweep pass.
- [x] `TestNativeToolchainMergedMIRErrTypeFloor` + `TestProbeNativeToolchainMergedMIR` gates green (MIR-first pipeline unaffected).
- [x] `go run ./internal/llvmgen/gen_mir_generator_snapshot.go` runs the full transpile + compile-gate cycle without rollback.
- [ ] Pre-existing `TestNativeToolchainMergedMIRPipelineIsClean` (legacy-fallback `AstPackage` type surface) and `TestGenerateCoalesceFullPipeline` failures are present on `main`, confirmed unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)