### PR TITLE
[codex] close selfhost MIR backend gaps

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1291,10 +1291,11 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	// object/binary emission instead of falling back.
 	case mir.IntrinsicStringConcat, mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty,
+		mir.IntrinsicStringTrim,
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
@@ -4675,10 +4676,11 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitBytesIntrinsic(i)
 	case mir.IntrinsicStringConcat, mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty,
+		mir.IntrinsicStringTrim,
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -4977,13 +4979,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicListFirst, mir.IntrinsicListLast:
 		// `.first()` / `.last()` return `T?`. Runtime has no bespoke
 		// symbol — lower as `len == 0 ? None : Some(get(idx))` where
-		// idx is 0 for first and len-1 for last. Scalar elems use the
-		// typed get_<kind> symbol; composite elements (structs / lists
-		// / maps) aren't supported yet because the raw scalar-return
-		// contract above doesn't match their aggregate shape.
-		if !listUsesTypedRuntime(elemLLVM) {
-			return unsupported("mir-mvp", fmt.Sprintf("list_%s on composite element type %s", mirIntrinsicLabel(i.Kind), elemLLVM))
-		}
+		// idx is 0 for first and len-1 for last.
 		if i.Dest == nil {
 			return unsupported("mir-mvp", fmt.Sprintf("%s without destination", mirIntrinsicLabel(i.Kind)))
 		}
@@ -4995,8 +4991,6 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		destSlot := g.localSlots[i.Dest.Local]
 		lenSym := listRuntimeLenSymbol()
 		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
-		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
 		isEmpty := g.fresh()
@@ -5016,28 +5010,12 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			idxRef = g.fresh()
 			fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", idxRef, lenReg)
 		}
-		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxRef)
-		// Option<T> slot-1 is i64-wide by layout convention (see
-		// support_snapshot.go / emitNullaryRV). For non-i64 scalars we
-		// must widen/bitcast to i64 before insertvalue.
-		payloadReg := elemReg
-		switch elemLLVM {
-		case "i64":
-			// no-op
-		case "i1", "i8", "i16", "i32":
-			widened := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
-			payloadReg = widened
-		case "double":
-			cast := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
-			payloadReg = cast
-		case "ptr":
-			cast := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
-			payloadReg = cast
-		default:
+		elemReg, err := g.emitListLoadElement(listReg, idxRef, elemLLVM)
+		if err != nil {
+			return err
+		}
+		payloadReg, err := g.listOptionalPayloadToI64(elemReg, elemLLVM, elemT)
+		if err != nil {
 			return unsupported("mir-mvp", fmt.Sprintf("list_%s payload widen unsupported for %s", mirIntrinsicLabel(i.Kind), elemLLVM))
 		}
 		tagged := g.fresh()
@@ -5073,20 +5051,17 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "list_remove_at arity")
 		}
-		if !listUsesTypedRuntime(elemLLVM) {
-			return unsupported("mir-mvp", fmt.Sprintf("list_remove_at on composite element type %s", elemLLVM))
-		}
 		idxOp := i.Args[1]
 		idxReg, err := g.evalOperand(idxOp, idxOp.Type())
 		if err != nil {
 			return err
 		}
-		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
 		spliceSym := "osty_rt_list_remove_at_discard"
 		g.declareRuntime(spliceSym, "declare void @"+spliceSym+"(ptr, i64)")
-		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
+		elemReg, err := g.emitListLoadElement(listReg, idxReg, elemLLVM)
+		if err != nil {
+			return err
+		}
 		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s, i64 %s)\n", spliceSym, listReg, idxReg)
 		return g.storeIntrinsicResult(i, &LlvmValue{typ: elemLLVM, name: elemReg})
 	case mir.IntrinsicListIndexOf:
@@ -5262,15 +5237,10 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
 			return nil
 		}
-		if !listUsesTypedRuntime(elemLLVM) {
-			return unsupported("mir-mvp", fmt.Sprintf("list_pop on composite element type %s", elemLLVM))
-		}
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
 		lenSym := listRuntimeLenSymbol()
 		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
-		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
 		isEmpty := g.fresh()
@@ -5285,25 +5255,13 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
 		lastIdx := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", lastIdx, lenReg)
-		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, lastIdx)
+		elemReg, err := g.emitListLoadElement(listReg, lastIdx, elemLLVM)
+		if err != nil {
+			return err
+		}
 		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
-		payloadReg := elemReg
-		switch elemLLVM {
-		case "i64":
-		case "i1", "i8", "i16", "i32":
-			widened := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
-			payloadReg = widened
-		case "double":
-			cast := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
-			payloadReg = cast
-		case "ptr":
-			cast := g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
-			payloadReg = cast
-		default:
+		payloadReg, err := g.listOptionalPayloadToI64(elemReg, elemLLVM, elemT)
+		if err != nil {
 			return unsupported("mir-mvp", fmt.Sprintf("list_pop payload widen unsupported for %s", elemLLVM))
 		}
 		tagged := g.fresh()
@@ -5316,6 +5274,49 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("list intrinsic kind %d", i.Kind))
+}
+
+func (g *mirGen) emitListLoadElement(listReg, idxReg string, elemLLVM string) (string, error) {
+	if listUsesTypedRuntime(elemLLVM) {
+		getSym := listRuntimeGetSymbol(elemLLVM)
+		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		elemReg := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
+		return elemReg, nil
+	}
+	slot := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, elemLLVM)
+	sizeReg := g.emitSizeOf(elemLLVM)
+	sym := listRuntimeGetBytesV1Symbol()
+	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+	fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s, i64 %s, ptr %s, i64 %s)\n", sym, listReg, idxReg, slot, sizeReg)
+	elemReg := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = load %s, ptr %s\n", elemReg, elemLLVM, slot)
+	return elemReg, nil
+}
+
+func (g *mirGen) listOptionalPayloadToI64(elemReg, elemLLVM string, elemT mir.Type) (string, error) {
+	switch elemLLVM {
+	case "i64":
+		return elemReg, nil
+	case "i1", "i8", "i16", "i32":
+		widened := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = zext %s %s to i64\n", widened, elemLLVM, elemReg)
+		return widened, nil
+	case "double":
+		cast := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = bitcast double %s to i64\n", cast, elemReg)
+		return cast, nil
+	case "ptr":
+		cast := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = ptrtoint ptr %s to i64\n", cast, elemReg)
+		return cast, nil
+	default:
+		if strings.HasPrefix(elemLLVM, "%") {
+			return g.toI64Slot(elemReg, elemT)
+		}
+	}
+	return "", unsupported("mir-mvp", "list optional payload widen unsupported for "+elemLLVM)
 }
 
 // emitMapIntrinsic dispatches map intrinsics to runtime symbols. Key
@@ -6413,6 +6414,13 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		result := llvmCompare(em, "eq", size, llvmIntLiteral(0))
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicStringTrim:
+		sym := llvmStringRuntimeTrimSpaceSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmStringRuntimeTrimSpace(em, &LlvmValue{typ: "ptr", name: strReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringToUpper:
 		sym := "osty_rt_strings_ToUpper"
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
@@ -6437,6 +6445,8 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeHasSuffixSymbol())
 	case mir.IntrinsicStringContains:
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeContainsSymbol())
+	case mir.IntrinsicStringIndexOf:
+		return g.emitStringIndexOf(i, strReg)
 	case mir.IntrinsicStringSplit:
 		return g.emitStringSplit(i, strReg)
 	case mir.IntrinsicStringJoin:
@@ -6450,6 +6460,65 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringSubstring(i, strReg)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+func (g *mirGen) emitStringIndexOf(i *mir.IntrinsicInstr, strReg string) error {
+	if len(i.Args) != 2 {
+		return unsupported("mir-mvp", "string_index_of arity")
+	}
+	needleReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+	if err != nil {
+		return err
+	}
+	sym := llvmStringRuntimeIndexOfSymbol()
+	g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+	em := g.ostyEmitter()
+	index := llvmCall(em, "i64", sym, []*LlvmValue{
+		{typ: "ptr", name: strReg},
+		{typ: "ptr", name: needleReg},
+	})
+	g.flushOstyEmitter(em)
+	if i.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(i.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: string_index_of dest %d", i.Dest.Local)
+	}
+	if optT, ok := destLoc.Type.(*ir.OptionalType); ok {
+		return g.storeOptionalIntFromNegativeOneIndex(i, optT, index.name, "string.index_of")
+	}
+	return g.storeIntrinsicResult(i, index)
+}
+
+func (g *mirGen) storeOptionalIntFromNegativeOneIndex(i *mir.IntrinsicInstr, optT *ir.OptionalType, indexReg, labelPrefix string) error {
+	optLLVM := g.llvmType(optT)
+	present := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = icmp sge i64 %s, 0\n", present, indexReg)
+	someLabel := g.freshLabel(labelPrefix + ".some")
+	noneLabel := g.freshLabel(labelPrefix + ".none")
+	mergeLabel := g.freshLabel(labelPrefix + ".merge")
+	fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", present, someLabel, noneLabel)
+
+	fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+	someStep := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", someStep, optLLVM)
+	someValue := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", someValue, optLLVM, someStep, indexReg)
+	fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", mergeLabel)
+
+	fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+	noneStep := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 0, 0\n", noneStep, optLLVM)
+	noneValue := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 0, 1\n", noneValue, optLLVM, noneStep)
+	fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", mergeLabel)
+
+	fmt.Fprintf(&g.fnBuf, "%s:\n", mergeLabel)
+	result := g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]\n", result, optLLVM, someValue, someLabel, noneValue, noneLabel)
+	fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", optLLVM, result, g.localSlots[i.Dest.Local])
+	return nil
 }
 
 // emitStringSubstring emits `s.substring(start, end)` / `s[a..b]`

--- a/internal/llvmgen/multifile_probe_helper_test.go
+++ b/internal/llvmgen/multifile_probe_helper_test.go
@@ -21,8 +21,15 @@ func TestIsBootstrapOnlyOstyFile(t *testing.T) {
 		}
 	})
 
+	t.Run("detects real runtime cihost ffi", func(t *testing.T) {
+		src := []byte("use runtime.cihost as host {\n    pub fn LoadRunnerState(root: String) -> Bool\n}\n")
+		if !isBootstrapOnlyOstyFile(src) {
+			t.Fatalf("expected runtime.cihost file to be classified as bootstrap-only")
+		}
+	})
+
 	t.Run("ignores comments mentioning bootstrap syntax", func(t *testing.T) {
-		src := []byte("// `use go \"...\" { ... }` stays in comments only.\n// `use runtime.golegacy.foo` is also documentation here.\npub fn keep() -> Int { 1 }\n")
+		src := []byte("// `use go \"...\" { ... }` stays in comments only.\n// `use runtime.golegacy.foo` is also documentation here.\n// `use runtime.cihost as host` too.\npub fn keep() -> Int { 1 }\n")
 		if isBootstrapOnlyOstyFile(src) {
 			t.Fatalf("expected comment-only mentions to stay in the native merged set")
 		}

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -173,7 +173,8 @@ func TestProbeWholeToolchainMerged(t *testing.T) {
 // isBootstrapOnlyOstyFile reports whether the source is a
 // host-boundary bootstrap adapter — i.e., whether it declares either
 //
-//   - a `use runtime.golegacy.*` FFI (the legacy Go AST bridge), or
+//   - a `use runtime.golegacy.*` FFI (the legacy Go AST bridge),
+//   - a `use runtime.cihost` FFI (the CI runner's Go host adapter), or
 //   - a `use go "..."` FFI (arbitrary Go package host binding)
 //
 // Both forms require the Osty compiler to be running under the
@@ -188,6 +189,7 @@ func isBootstrapOnlyOstyFile(src []byte) bool {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "use runtime.golegacy.") ||
+			strings.HasPrefix(trimmed, "use runtime.cihost") ||
 			strings.HasPrefix(trimmed, "use go \"") {
 			return true
 		}
@@ -245,9 +247,8 @@ func TestProbeNativeToolchainMerged(t *testing.T) {
 // GenerateFromMIR pipeline and reports the first stage that walls
 // (along with its message). Info-only.
 //
-// NOTE: the toolchain currently has ~949 checker errors, so ir.Lower /
-// Monomorphize will produce issues; the probe logs the count and keeps
-// going so we can see where the MIR emitter itself walls.
+// The probe logs checker/lowering counts and keeps going so we can see
+// where the MIR emitter itself walls.
 func TestProbeNativeToolchainMergedMIR(t *testing.T) {
 	if testing.Short() {
 		t.Skip("info-only; slow; skipped in -short")
@@ -272,7 +273,7 @@ func TestProbeNativeToolchainMergedMIR(t *testing.T) {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/selfhost_mir_gaps_test.go
+++ b/internal/llvmgen/selfhost_mir_gaps_test.go
@@ -1,0 +1,534 @@
+package llvmgen
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestSelfhostDocgenAddRefsFromTextMIRDirect(t *testing.T) {
+	src := `use std.strings as strings
+
+struct SelfDocRef {
+    name: String,
+    anchor: String,
+}
+
+fn selfDocStringListCount(xs: List<String>) -> Int { xs.len() }
+fn selfDocIdentStart(unit: String) -> Bool { unit == "_" || (unit >= "a" && unit <= "z") || (unit >= "A" && unit <= "Z") }
+fn selfDocIdentCont(unit: String) -> Bool { selfDocIdentStart(unit) || (unit >= "0" && unit <= "9") }
+fn selfDocIndexAnchor(refs: List<SelfDocRef>, name: String) -> String { "" }
+fn listContainsString(xs: List<String>, needle: String) -> Bool { false }
+
+fn selfDocAddRefsFromText(
+    existing: List<String>,
+    text: String,
+    refs: List<SelfDocRef>,
+    exclude: String,
+) -> List<String> {
+    let mut out = existing
+    let units = strings.split(text, "")
+    let mut idx = 0
+    let count = selfDocStringListCount(units)
+    for idx < count {
+        let unit = units[idx]
+        if selfDocIdentStart(unit) {
+            let mut word = unit
+            idx = idx + 1
+            for idx < count && selfDocIdentCont(units[idx]) {
+                word = "{word}{units[idx]}"
+                idx = idx + 1
+            }
+            let anchor = selfDocIndexAnchor(refs, word)
+            if anchor != "" && word != exclude && !(listContainsString(out, word)) {
+                out.push(word)
+            }
+        } else {
+            idx = idx + 1
+        }
+    }
+    out
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	poisonSelfhostDocgenInterpolationIndexTypes(t, mono)
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("selfDocAddRefsFromText")
+	if fn == nil {
+		t.Fatal("missing selfDocAddRefsFromText")
+	}
+	for _, loc := range fn.Locals {
+		if loc == nil {
+			continue
+		}
+		if _, ok := loc.Type.(*ir.ErrType); ok {
+			t.Fatalf("selfhost MIR local stayed poisoned: id=%d name=%s\n%s", loc.ID, loc.Name, mir.PrintFunction(fn))
+		}
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_docgen_add_refs.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost docgen path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define ptr @selfDocAddRefsFromText(",
+		"call ptr @osty_rt_strings_Split(",
+		"call ptr @osty_rt_strings_Concat(",
+		"call void @osty_rt_list_push_ptr(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelfhostHirOptimizeCharToDigitMIRDirect(t *testing.T) {
+	src := `fn hirOptimizeCharToDigit(ch: Char) -> Int {
+    match ch {
+        '0' -> 0,
+        '1' -> 1,
+        '2' -> 2,
+        '3' -> 3,
+        '4' -> 4,
+        '5' -> 5,
+        '6' -> 6,
+        '7' -> 7,
+        '8' -> 8,
+        '9' -> 9,
+        'a' -> 10,
+        'b' -> 11,
+        'c' -> 12,
+        'd' -> 13,
+        'e' -> 14,
+        'f' -> 15,
+        'A' -> 10,
+        'B' -> 11,
+        'C' -> 12,
+        'D' -> 13,
+        'E' -> 14,
+        'F' -> 15,
+        _ -> -1,
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("hirOptimizeCharToDigit")
+	if fn == nil {
+		t.Fatal("missing hirOptimizeCharToDigit")
+	}
+	for _, bb := range fn.Blocks {
+		if bb != nil && bb.Term == nil {
+			t.Fatalf("hirOptimizeCharToDigit MIR block missing terminator:\n%s", mir.PrintFunction(fn))
+		}
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_hir_optimize_char_digit.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost char digit path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define i64 @hirOptimizeCharToDigit(",
+		"icmp eq i32",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelfhostHintListElemTrimMIRDirect(t *testing.T) {
+	src := `fn hintListElem(hint: String) -> String {
+    if !hint.startsWith("List<") {
+        return ""
+    }
+    if !hint.endsWith(">") {
+        return ""
+    }
+    let n = hint.len()
+    if n <= 6 {
+        return ""
+    }
+    hint[5..n - 1].trim()
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("hintListElem")
+	if fn == nil {
+		t.Fatal("missing hintListElem")
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_hint_list_elem.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost hintListElem path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define ptr @hintListElem(",
+		"call ptr @osty_rt_strings_Slice(",
+		"call ptr @osty_rt_strings_TrimSpace(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelfhostMirLlvmTypeHeadNameIndexMIRDirect(t *testing.T) {
+	src := `use std.strings as llvmStrings
+
+fn mirLlvmTypeHeadName(typeText: String) -> String {
+    let ltIdx = llvmStrings.Index(typeText, "<")
+    let stripped = if ltIdx >= 0 {
+        typeText[0..ltIdx]
+    } else {
+        typeText
+    }
+    let dotIdx = llvmStrings.Index(stripped, ".")
+    if dotIdx >= 0 {
+        stripped[(dotIdx + 1)..stripped.len()]
+    } else {
+        stripped
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("mirLlvmTypeHeadName")
+	if fn == nil {
+		t.Fatal("missing mirLlvmTypeHeadName")
+	}
+	for _, loc := range fn.Locals {
+		if loc == nil {
+			continue
+		}
+		if _, ok := loc.Type.(*ir.ErrType); ok {
+			t.Fatalf("mirLlvmTypeHeadName MIR local stayed poisoned: id=%d name=%s\n%s", loc.ID, loc.Name, mir.PrintFunction(fn))
+		}
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_mir_type_head.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost mirLlvmTypeHeadName path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define ptr @mirLlvmTypeHeadName(",
+		"call i64 @osty_rt_strings_IndexOf(",
+		"call ptr @osty_rt_strings_Slice(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelfhostCheckDiagRenderFieldInterpolationMIRDirect(t *testing.T) {
+	src := `struct CheckDiagnostic {
+    code: String,
+    message: String,
+}
+
+fn checkDiagRender(d: CheckDiagnostic) -> String {
+    let prefix = "error"
+    if d.code == "" {
+        return "{prefix}: {d.message}"
+    }
+    "{prefix}[{d.code}]: {d.message}"
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	poisonSelfhostCheckDiagFieldInterpolationTypes(t, mono)
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("checkDiagRender")
+	if fn == nil {
+		t.Fatal("missing checkDiagRender")
+	}
+	assertStringConcatArgsTyped(t, fn)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_check_diag_render.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost checkDiagRender path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define ptr @checkDiagRender(",
+		"call ptr @osty_rt_strings_ConcatN(",
+		"extractvalue %CheckDiagnostic",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelfhostCompositeListPopMIRDirect(t *testing.T) {
+	src := `struct CheckBinding {
+    name: String,
+    depth: Int,
+}
+
+fn popBinding(xs: List<CheckBinding>) -> CheckBinding? {
+    xs.pop()
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	mono, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(mono)
+	fn := mirMod.LookupFunction("popBinding")
+	if fn == nil {
+		t.Fatal("missing popBinding")
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/selfhost_composite_list_pop.osty",
+	})
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MIR-direct selfhost composite list pop path unsupported: %v\n%s", err, mir.PrintFunction(fn))
+		}
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"define %Option.CheckBinding @popBinding(",
+		"call void @osty_rt_list_get_bytes_v1(",
+		"call void @osty_rt_list_pop_discard(",
+		"call ptr @osty.gc.alloc_v1(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func poisonSelfhostDocgenInterpolationIndexTypes(t *testing.T, mod *ir.Module) {
+	t.Helper()
+	var fn *ir.FnDecl
+	for _, decl := range mod.Decls {
+		if f, ok := decl.(*ir.FnDecl); ok && f.Name == "selfDocAddRefsFromText" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("missing IR selfDocAddRefsFromText")
+	}
+	poisoned := 0
+	ir.Inspect(fn.Body, func(n ir.Node) bool {
+		lit, ok := n.(*ir.StringLit)
+		if !ok {
+			return true
+		}
+		for _, part := range lit.Parts {
+			idx, ok := part.Expr.(*ir.IndexExpr)
+			if !ok {
+				continue
+			}
+			base, ok := idx.X.(*ir.Ident)
+			if !ok || base.Name != "units" {
+				continue
+			}
+			base.T = &ir.TypeVar{Name: "T", Owner: "selfDocAddRefsFromText"}
+			idx.T = &ir.ErrType{}
+			poisoned++
+		}
+		return true
+	})
+	if poisoned == 0 {
+		t.Fatal("did not find docgen interpolation index to poison")
+	}
+}
+
+func poisonSelfhostCheckDiagFieldInterpolationTypes(t *testing.T, mod *ir.Module) {
+	t.Helper()
+	var fn *ir.FnDecl
+	for _, decl := range mod.Decls {
+		if f, ok := decl.(*ir.FnDecl); ok && f.Name == "checkDiagRender" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("missing IR checkDiagRender")
+	}
+	poisoned := 0
+	ir.Inspect(fn.Body, func(n ir.Node) bool {
+		lit, ok := n.(*ir.StringLit)
+		if !ok {
+			return true
+		}
+		for _, part := range lit.Parts {
+			field, ok := part.Expr.(*ir.FieldExpr)
+			if !ok {
+				continue
+			}
+			base, ok := field.X.(*ir.Ident)
+			if !ok || base.Name != "d" {
+				continue
+			}
+			field.T = &ir.ErrType{}
+			poisoned++
+		}
+		return true
+	})
+	if poisoned == 0 {
+		t.Fatal("did not find checkDiagRender interpolation fields to poison")
+	}
+}
+
+func assertStringConcatArgsTyped(t *testing.T, fn *mir.Function) {
+	t.Helper()
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, instr := range bb.Instrs {
+			in, ok := instr.(*mir.IntrinsicInstr)
+			if !ok || in.Kind != mir.IntrinsicStringConcat {
+				continue
+			}
+			for idx, arg := range in.Args {
+				if _, ok := arg.Type().(*ir.ErrType); ok {
+					t.Fatalf("string_concat arg %d stayed poisoned:\n%s", idx, mir.PrintFunction(fn))
+				}
+			}
+		}
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1899,17 +1899,17 @@ func (mc *matchContext) lowerSwitch(sw *ir.DecisionSwitch) {
 			return
 		}
 		// Mixed / non-integer literal chain.
-		var defTarget BlockID
-		if sw.Default != nil {
-			defTarget = bs.newBlock(mc.sp)
-		} else {
-			defTarget = bs.newBlock(mc.sp)
+		defTarget := bs.newBlock(mc.sp)
+		if len(sw.Cases) == 0 {
+			bs.terminate(&GotoTerm{Target: defTarget, SpanV: mc.sp})
+			bs.cur = defTarget
 		}
-		next := defTarget
-		for i := len(sw.Cases) - 1; i >= 0; i-- {
-			c := sw.Cases[i]
+		for i, c := range sw.Cases {
 			caseBB := bs.newBlock(mc.sp)
-			testBB := bs.newBlock(mc.sp)
+			elseBB := defTarget
+			if i < len(sw.Cases)-1 {
+				elseBB = bs.newBlock(mc.sp)
+			}
 			// Lower the literal into an operand.
 			rhs := bs.lowerExprAsOperand(c.Lit)
 			cmp := bs.freshTemp(TBool, mc.sp)
@@ -1926,13 +1926,12 @@ func (mc *matchContext) lowerSwitch(sw *ir.DecisionSwitch) {
 			bs.terminate(&BranchTerm{
 				Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
 				Then:  caseBB,
-				Else:  next,
+				Else:  elseBB,
 				SpanV: mc.sp,
 			})
 			bs.cur = caseBB
 			mc.lowerTree(c.Body)
-			bs.cur = testBB
-			next = testBB
+			bs.cur = elseBB
 		}
 		bs.cur = defTarget
 		if sw.Default != nil {
@@ -2077,8 +2076,8 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 	// the return type off the module's own fn signature table (preferred)
 	// or the callee's FnType (fallback) so every downstream temp has a
 	// concrete width.
-	if t == ir.ErrTypeVal {
-		if rt := bs.recoverOperandType(e); rt != nil && rt != ir.ErrTypeVal {
+	if isPoisonType(t) {
+		if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) {
 			t = rt
 		}
 	}
@@ -2113,10 +2112,10 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 // `f(x).field` where the checker dropped the call's return type.
 func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 	t := e.Type()
-	if t != nil && t != ir.ErrTypeVal {
+	if !isPoisonType(t) {
 		return t
 	}
-	if rt := bs.recoverOperandType(e); rt != nil && rt != ir.ErrTypeVal {
+	if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) {
 		return rt
 	}
 	return t
@@ -2142,7 +2141,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// type off the IR FnDecl, which survives even when per-node
 		// checker annotations are missing.
 		if id, ok := x.Callee.(*ir.Ident); ok {
-			if sig := bs.l.signatureForFn(id.Name); sig != nil && sig.retType != nil && sig.retType != ir.ErrTypeVal {
+			if sig := bs.l.signatureForFn(id.Name); sig != nil && !isPoisonType(sig.retType) {
 				return sig.retType
 			}
 		}
@@ -2165,7 +2164,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 				}
 			}
 			// Otherwise rely on whatever FnType the FieldExpr carries.
-			if ct := fx.Type(); ct != nil && ct != ir.ErrTypeVal {
+			if ct := fx.Type(); !isPoisonType(ct) {
 				if f, ok := ct.(*ir.FnType); ok && f.Return != nil {
 					return f.Return
 				}
@@ -2174,7 +2173,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// Fallback: the callee may still carry a concrete FnType (for
 		// fn-typed locals / params with a declared signature).
 		ct := x.Callee.Type()
-		if ct == nil || ct == ir.ErrTypeVal {
+		if isPoisonType(ct) {
 			return nil
 		}
 		if f, ok := ct.(*ir.FnType); ok && f.Return != nil {
@@ -2207,11 +2206,11 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		if rt := builtinMethodReturnType(recvT, x.Name); rt != nil {
 			return rt
 		}
-		if recvT == nil || recvT == ir.ErrTypeVal {
+		if isPoisonType(recvT) {
 			return nil
 		}
 		if nt, ok := recvT.(*ir.NamedType); ok && nt.Name != "" {
-			if sig := bs.l.signatureForMethod(nt.Name, x.Name); sig != nil && sig.retType != nil && sig.retType != ir.ErrTypeVal {
+			if sig := bs.l.signatureForMethod(nt.Name, x.Name); sig != nil && !isPoisonType(sig.retType) {
 				return sig.retType
 			}
 		}
@@ -2223,7 +2222,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// `xs[i]` in interp position ends up here when the checker
 		// dropped the element type. Peel the collection type off the
 		// receiver.
-		if elemT := bs.indexExprType(x); elemT != nil && elemT != ir.ErrTypeVal {
+		if elemT := bs.indexExprType(x); !isPoisonType(elemT) {
 			return elemT
 		}
 	case *ir.BinaryExpr:
@@ -2239,10 +2238,10 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// carries a concrete type.
 		lt := x.Left.Type()
 		rt := x.Right.Type()
-		if lt != nil && lt != ir.ErrTypeVal {
+		if !isPoisonType(lt) {
 			return lt
 		}
-		if rt != nil && rt != ir.ErrTypeVal {
+		if !isPoisonType(rt) {
 			return rt
 		}
 	case *ir.StructLit:
@@ -2264,10 +2263,10 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		if x.X == nil {
 			return nil
 		}
-		if ot := x.X.Type(); ot != nil && ot != ir.ErrTypeVal {
+		if ot := x.X.Type(); !isPoisonType(ot) {
 			return ot
 		}
-		if rt := bs.recoverOperandType(x.X); rt != nil && rt != ir.ErrTypeVal {
+		if rt := bs.recoverOperandType(x.X); !isPoisonType(rt) {
 			return rt
 		}
 		switch x.X.(type) {
@@ -2404,9 +2403,9 @@ func stdlibFreeFnReturnType(qualifier, name string) ir.Type {
 		return nil
 	}
 	switch name {
-	case "len", "indexOf":
+	case "len", "indexOf", "Index":
 		return ir.TInt
-	case "isEmpty", "contains", "hasPrefix", "startsWith", "hasSuffix", "endsWith":
+	case "isEmpty", "contains", "Contains", "hasPrefix", "HasPrefix", "startsWith", "hasSuffix", "HasSuffix", "endsWith":
 		return ir.TBool
 	case "join", "substring", "slice", "trim", "toUpper", "toLower", "replace":
 		return ir.TString
@@ -2526,7 +2525,7 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
 	}
 	// Fallback: lower as operand and wrap in UseRV.
-	return &UseRV{Op: bs.lowerExprAsOperand(e)}
+	return &UseRV{Op: bs.lowerExprAsOperandHint(e, hint)}
 }
 
 // lowerExprToPlace tries to describe e as a Place without materialising
@@ -2630,7 +2629,7 @@ func (bs *bodyState) lowerIdent(id *ir.Ident) Operand {
 	case ir.IdentVariant:
 		// bare variant → aggregate with no payload.
 		t := id.T
-		if t == nil || t == ir.ErrTypeVal {
+		if isPoisonType(t) {
 			if enumName := bs.l.enumForVariant(id.Name); enumName != "" {
 				t = &ir.NamedType{Name: enumName}
 			} else if t == nil {
@@ -2690,8 +2689,7 @@ func (bs *bodyState) lowerStringLit(s *ir.StringLit) Operand {
 			args = append(args, &ConstOp{Const: &StringConst{Value: p.Lit}, T: TString})
 			continue
 		}
-		op := bs.lowerExprAsOperand(p.Expr)
-		args = append(args, op)
+		args = append(args, bs.lowerStringInterpolationOperand(p.Expr))
 	}
 	tmp := bs.freshTemp(TString, s.SpanV)
 	bs.emit(&IntrinsicInstr{
@@ -2701,6 +2699,126 @@ func (bs *bodyState) lowerStringLit(s *ir.StringLit) Operand {
 		SpanV: s.SpanV,
 	})
 	return &CopyOp{Place: Place{Local: tmp}, T: TString}
+}
+
+func (bs *bodyState) lowerStringInterpolationOperand(e ir.Expr) Operand {
+	op := bs.lowerExprAsOperand(e)
+	if !isPoisonType(op.Type()) {
+		return op
+	}
+	if rt := bs.recoverOperandType(e); !isPoisonType(rt) {
+		return retagOperandType(op, rt)
+	}
+	if rt := bs.recoverOperandStorageType(op); !isPoisonType(rt) {
+		return retagOperandType(op, rt)
+	}
+	return op
+}
+
+func (bs *bodyState) recoverOperandStorageType(op Operand) Type {
+	var place Place
+	switch x := op.(type) {
+	case *CopyOp:
+		place = x.Place
+	case *MoveOp:
+		place = x.Place
+	default:
+		return nil
+	}
+	loc := bs.fn.Local(place.Local)
+	if loc == nil || isPoisonType(loc.Type) {
+		return nil
+	}
+	cur := loc.Type
+	for _, proj := range place.Projections {
+		if pt := mirProjectionType(proj); !isPoisonType(pt) {
+			cur = pt
+			continue
+		}
+		switch p := proj.(type) {
+		case *FieldProj:
+			cur = bs.l.fieldType(bs.l.structFromType(cur, ""), p.Name)
+		case *TupleProj:
+			cur = elementTypeAt(tupleElementTypes(cur), p.Index)
+		case *VariantProj:
+			cur = variantLookupPayloadType(bs.l, cur, p.Name, p.FieldIdx)
+		case *IndexProj:
+			cur = indexElementType(cur)
+		case *DerefProj:
+			cur = p.Type
+		}
+		if isPoisonType(cur) {
+			return nil
+		}
+	}
+	return cur
+}
+
+func mirProjectionType(p Projection) Type {
+	switch x := p.(type) {
+	case *FieldProj:
+		return x.Type
+	case *TupleProj:
+		return x.Type
+	case *VariantProj:
+		return x.Type
+	case *IndexProj:
+		return x.ElemType
+	case *DerefProj:
+		return x.Type
+	}
+	return nil
+}
+
+func retagOperandType(op Operand, t Type) Operand {
+	switch x := op.(type) {
+	case *CopyOp:
+		return &CopyOp{Place: retagPlaceType(x.Place, t), T: t}
+	case *MoveOp:
+		return &MoveOp{Place: retagPlaceType(x.Place, t), T: t}
+	case *ConstOp:
+		return &ConstOp{Const: x.Const, T: t}
+	}
+	return op
+}
+
+func retagPlaceType(p Place, t Type) Place {
+	if len(p.Projections) == 0 {
+		return p
+	}
+	projs := append([]Projection(nil), p.Projections...)
+	last := len(projs) - 1
+	if isPoisonType(mirProjectionType(projs[last])) {
+		projs[last] = retagProjectionType(projs[last], t)
+	}
+	p.Projections = projs
+	return p
+}
+
+func retagProjectionType(p Projection, t Type) Projection {
+	switch x := p.(type) {
+	case *FieldProj:
+		cp := *x
+		cp.Type = t
+		return &cp
+	case *TupleProj:
+		cp := *x
+		cp.Type = t
+		return &cp
+	case *VariantProj:
+		cp := *x
+		cp.Type = t
+		return &cp
+	case *IndexProj:
+		cp := *x
+		cp.ElemType = t
+		return &cp
+	case *DerefProj:
+		cp := *x
+		cp.Type = t
+		return &cp
+	}
+	return p
 }
 
 // lowerIfExprInto lowers an IfExpr by reusing the stmt-form lowering
@@ -4074,13 +4192,13 @@ func stdlibStringFreeFnToIntrinsic(qualifier, name string) IntrinsicKind {
 		return IntrinsicStringLen
 	case "isEmpty":
 		return IntrinsicStringIsEmpty
-	case "contains":
+	case "contains", "Contains":
 		return IntrinsicStringContains
-	case "hasPrefix", "startsWith":
+	case "hasPrefix", "HasPrefix", "startsWith":
 		return IntrinsicStringStartsWith
-	case "hasSuffix", "endsWith":
+	case "hasSuffix", "HasSuffix", "endsWith":
 		return IntrinsicStringEndsWith
-	case "indexOf":
+	case "indexOf", "Index":
 		return IntrinsicStringIndexOf
 	case "split":
 		return IntrinsicStringSplit
@@ -4404,7 +4522,8 @@ func (bs *bodyState) finishNoReturn() {
 // ==== helpers that bridge HIR-level knowledge to layouts ====
 
 type lookupStruct struct {
-	decl *ir.StructDecl
+	decl   *ir.StructDecl
+	layout *StructLayout
 }
 
 func (l *lowerer) structFromType(t ir.Type, fallbackName string) *lookupStruct {
@@ -4415,45 +4534,80 @@ func (l *lowerer) structFromType(t ir.Type, fallbackName string) *lookupStruct {
 	if name == "" {
 		return &lookupStruct{}
 	}
+	var layout *StructLayout
+	if l.out != nil && l.out.Layouts != nil {
+		layout = l.out.Layouts.Structs[name]
+	}
 	if d, ok := l.structs[name]; ok {
-		return &lookupStruct{decl: d}
+		return &lookupStruct{decl: d, layout: layout}
+	}
+	if layout != nil {
+		return &lookupStruct{layout: layout}
 	}
 	return &lookupStruct{}
 }
 
 func (l *lowerer) fieldType(info *lookupStruct, name string) Type {
-	if info == nil || info.decl == nil {
+	if info == nil {
 		return ir.ErrTypeVal
 	}
-	for _, f := range info.decl.Fields {
-		if f.Name == name {
-			return f.Type
+	if info.decl != nil {
+		for _, f := range info.decl.Fields {
+			if f.Name == name && !isPoisonType(f.Type) {
+				return f.Type
+			}
+		}
+	}
+	if info.layout != nil {
+		for _, f := range info.layout.Fields {
+			if f.Name == name {
+				return f.Type
+			}
 		}
 	}
 	return ir.ErrTypeVal
 }
 
 func (l *lowerer) fieldIndex(info *lookupStruct, name string) int {
-	if info == nil || info.decl == nil {
+	if info == nil {
 		return 0
 	}
-	for i, f := range info.decl.Fields {
-		if f.Name == name {
-			return i
+	if info.decl != nil {
+		for i, f := range info.decl.Fields {
+			if f.Name == name {
+				return i
+			}
+		}
+	}
+	if info.layout != nil {
+		for _, f := range info.layout.Fields {
+			if f.Name == name {
+				return f.Index
+			}
 		}
 	}
 	return 0
 }
 
 func (l *lowerer) fieldNames(info *lookupStruct) []string {
-	if info == nil || info.decl == nil {
+	if info == nil {
 		return nil
 	}
-	out := make([]string, len(info.decl.Fields))
-	for i, f := range info.decl.Fields {
-		out[i] = f.Name
+	if info.decl != nil {
+		out := make([]string, len(info.decl.Fields))
+		for i, f := range info.decl.Fields {
+			out[i] = f.Name
+		}
+		return out
 	}
-	return out
+	if info.layout != nil {
+		out := make([]string, len(info.layout.Fields))
+		for i, f := range info.layout.Fields {
+			out[i] = f.Name
+		}
+		return out
+	}
+	return nil
 }
 
 type variantInfo struct {
@@ -4841,10 +4995,19 @@ func (bs *bodyState) indexExprType(x *ir.IndexExpr) Type {
 	if x.X == nil {
 		return x.T
 	}
-	switch baseT := bs.recoveredTypeOf(x.X).(type) {
+	for _, baseT := range []Type{bs.recoveredTypeOf(x.X), bs.recoverOperandType(x.X)} {
+		if elemT := indexElementType(baseT); !isPoisonType(elemT) {
+			return elemT
+		}
+	}
+	return x.T
+}
+
+func indexElementType(base Type) Type {
+	switch baseT := base.(type) {
 	case *ir.NamedType:
 		if len(baseT.Args) == 0 {
-			return x.T
+			return ir.ErrTypeVal
 		}
 		switch baseT.Name {
 		case "List":
@@ -4862,7 +5025,7 @@ func (bs *bodyState) indexExprType(x *ir.IndexExpr) Type {
 			return ir.TChar
 		}
 	}
-	return x.T
+	return ir.ErrTypeVal
 }
 
 func mapUnaryOp(op ir.UnOp) UnaryOp {

--- a/internal/stdlib/modules/strings.osty
+++ b/internal/stdlib/modules/strings.osty
@@ -1004,6 +1004,13 @@ pub fn contains(s: String, substr: String) -> Bool {
     indexOfChars(s.chars(), substr.chars()) >= 0
 }
 
+// Bootstrap aliases for self-hosted MIR→LLVM snapshot sources. These
+// mirror Go's strings package names where the snapshot transpiler
+// deliberately routes directly to Go helpers.
+pub fn Contains(s: String, substr: String) -> Bool {
+    contains(s, substr)
+}
+
 pub fn indexOf(s: String, substr: String) -> Int? {
     let at = indexOfChars(s.chars(), substr.chars())
     if at < 0 {
@@ -1011,6 +1018,10 @@ pub fn indexOf(s: String, substr: String) -> Int? {
     } else {
         Some(at)
     }
+}
+
+pub fn Index(s: String, substr: String) -> Int {
+    indexOfChars(s.chars(), substr.chars())
 }
 
 pub fn lastIndexOf(s: String, substr: String) -> Int? {
@@ -1049,6 +1060,10 @@ pub fn hasPrefix(s: String, prefix: String) -> Bool {
     startsWith(s, prefix)
 }
 
+pub fn HasPrefix(s: String, prefix: String) -> Bool {
+    hasPrefix(s, prefix)
+}
+
 pub fn endsWith(s: String, suffix: String) -> Bool {
     let chars = s.chars()
     let needle = suffix.chars()
@@ -1057,6 +1072,10 @@ pub fn endsWith(s: String, suffix: String) -> Bool {
 
 pub fn hasSuffix(s: String, suffix: String) -> Bool {
     endsWith(s, suffix)
+}
+
+pub fn HasSuffix(s: String, suffix: String) -> Bool {
+    hasSuffix(s, suffix)
 }
 
 pub fn trim(s: String) -> String {

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -331,8 +331,20 @@ fn registerStdStringsAliasFns(env: CheckEnv, alias: String) {
         paramNames: ["s", "substr"], paramTys: [tString_, tString_],
         generics: emptyGenerics, genericBounds: emptyBounds,
     })
+    // Bootstrap MIR-LLVM helpers use Go-style stdlib names so the
+    // snapshot transpiler can route them straight to Go's strings package.
+    checkRegisterFn(env, CheckFnSig {
+        name: "Contains", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
     checkRegisterFn(env, CheckFnSig {
         name: "indexOf", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tOptInt,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "Index", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tInt_,
         paramNames: ["s", "substr"], paramTys: [tString_, tString_],
         generics: emptyGenerics, genericBounds: emptyBounds,
     })
@@ -357,12 +369,22 @@ fn registerStdStringsAliasFns(env: CheckEnv, alias: String) {
         generics: emptyGenerics, genericBounds: emptyBounds,
     })
     checkRegisterFn(env, CheckFnSig {
+        name: "HasPrefix", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
+        paramNames: ["s", "prefix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
         name: "endsWith", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
         paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
         generics: emptyGenerics, genericBounds: emptyBounds,
     })
     checkRegisterFn(env, CheckFnSig {
         name: "hasSuffix", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
+        paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "HasSuffix", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
         paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
         generics: emptyGenerics, genericBounds: emptyBounds,
     })

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -34,7 +34,7 @@ pub struct CheckFnSig {
     pub name: String,
     pub owner: String,
     pub receiverTy: Int,        // -1 when free function
-    pub hasReceiver: Bool,
+    pub hasReceiver: Bool = false,
     pub retTy: Int,
     pub paramNames: List<String>,
     pub paramTys: List<Int>,
@@ -46,7 +46,7 @@ pub struct CheckFieldSig {
     pub owner: String,
     pub name: String,
     pub ty: Int,
-    pub exported: Bool,
+    pub exported: Bool = false,
     pub hasDefault: Bool,
 }
 

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -2401,7 +2401,7 @@ fn hirLowerStructDecl(
     )
 }
 
-fn hirLowerFnDeclHasNoReceiver(ast: AstPackage, idx: Int) -> Bool {
+fn hirLowerFnDeclHasNoReceiver(ast: AstFile, idx: Int) -> Bool {
     let node = astArenaNodeAt(ast.arena, idx)
     if node.kind != AstNFnDecl {
         return true


### PR DESCRIPTION
## Summary

- Fix selfhost checker model drift by adding missing `CheckFnSig.hasReceiver` and `CheckFieldSig.exported` defaults, plus Go-style `std.strings` aliases used by toolchain code.
- Recover MIR operand types for poisoned field/index interpolation paths so selfhost string concatenation no longer reaches LLVM with `<error>` operands.
- Lower composite `List<T>` `first`/`last`/`removeAt`/`pop` through bytes-v1 element loads and aggregate option boxing instead of rejecting struct elements.
- Classify `runtime.cihost` as a bootstrap/host-boundary adapter for native selfhost probes.

## Root Cause

The selfhost path was mixing several unrelated walls: stale checker signatures, recoverable MIR type poison, composite list runtime gaps, and Go-hosted CI adapter calls. This separates the host boundary and fixes the selfhost-core backend gaps that were masking the next real wall.

After this change, `TestProbeNativeToolchainMergedMIR` reports `check: 0 diag(s)` and advances to the next remaining core issue: `indirect call on non-function type LlvmValue`.

## Validation

- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestIsBootstrapOnlyOstyFile|TestSelfhost(CheckDiagRenderFieldInterpolation|CompositeListPop|DocgenAddRefsFromText|HirOptimizeCharToDigit|HintListElemTrim|MirLlvmTypeHeadNameIndex)MIRDirect|TestGenerate(DiscardedListPop|ExprStmtListPop)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsListPop(ReturnsRealValue|String)' -v`
- `go test -count=1 -vet=off ./internal/llvmgen -run TestProbeNativeToolchainMergedMIR -v`