### PR TITLE
chore: add /osty-ship skill for automated ship workflow

### DIFF
--- a/.claude/skills/osty-ship/SKILL.md
+++ b/.claude/skills/osty-ship/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: osty-ship
+description: Osty 프로젝트 전용 ship 워크플로우. `just prepush` 게이트 통과 후 commit/push/draft PR 생성 + auto-merge 활성화. Stop 훅으로 자동 호출되거나 수동 `/osty-ship`으로 실행. 변경사항 없으면 조용히 skip.
+---
+
+# /osty-ship — Osty 프로젝트 ship 워크플로우
+
+Osty 레포 컨벤션(`CLAUDE.md` §커밋 메시지, §테스트 규칙)에 맞춘 ship 자동화.
+사용자가 "매번 치기 귀찮다"고 한 플로우 — 기본적으로 autonomous 진행.
+
+## 중단 조건 (사전 체크)
+
+다음 중 하나라도 해당하면 **즉시 종료** (에러 아님, 그냥 아무것도 안 함):
+
+1. `git status --porcelain` 결과 비어있음 AND `git log @{u}..HEAD` 비어있음 → 보낼 게 없음
+2. 현재 브랜치가 `main` 또는 `master` → feature branch 에서만 ship
+3. diff에 `.env`, `*.key`, `*.pem`, `credentials*`, `*secret*` 포함 → 시크릿 차단
+4. 변경사항이 `internal/selfhost/generated.go` 뿐이고 `osty-bootstrap-gen` 실행 흔적 없음 → 수동 재생성 필요한 파일이므로 보류
+
+## 1단계: 게이트
+
+```
+just prepush
+```
+
+- fmt-check + vet + repair-check + ci 전부 통과해야 함
+- 실패 시: 출력을 사용자에게 보여주고 **중단**. 자동 수정 시도 금지.
+- 성공 시에만 다음 단계로.
+
+## 2단계: Commit
+
+**파일 stage**:
+- `git status --porcelain` 으로 변경 파일 목록 추출
+- 명시적으로 `git add <file1> <file2> ...` (절대 `-A` / `.` 사용 금지)
+- 바이너리/대용량 파일(`*.pprof`, `.profiles/`, `*.broken`, `graphify-out/`) 있으면 제외 + 경고
+
+**메시지**:
+- prefix: `feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `perf:` 중 하나
+- diff 스코프로 prefix 결정:
+  - 새 기능 → `feat:`
+  - 버그 픽스 → `fix:`
+  - 의존성/설정 → `chore:`
+  - 문서 → `docs:`
+  - 코드 구조 변경(동작 동일) → `refactor:`
+  - 테스트 추가/수정만 → `test:`
+  - 성능 → `perf:`
+- 한국어 또는 영어, **간결하게** (본 레포 최근 커밋 스타일 참조)
+- trailer: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+
+**실행** (HEREDOC으로):
+```bash
+git commit -m "$(cat <<'EOF'
+<prefix>: <간결 설명>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Pre-commit hook 실패 시: 원인 파악 후 수정 → 재스테이지 → **새 커밋** (amend 금지).
+
+## 3단계: Push
+
+```
+git push -u origin <current-branch>
+```
+
+- force push 절대 금지
+- 실패하면 (upstream drift 등) 중단하고 사용자에게 보고
+
+## 4단계: Draft PR
+
+```bash
+gh pr create --draft --base main --title "<70자 이하>" --body "$(cat <<'EOF'
+## Summary
+- <1–3 bullets, diff 기반>
+
+## Test plan
+- [x] `just prepush` 로컬 통과
+- [ ] CI 그린 확인
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- title: 커밋 prefix + 요약 (70자 제한)
+- body: Summary + Test plan 섹션
+- 항상 `--draft` + `--base main`
+
+## 5단계: Auto-merge (가능하면)
+
+```bash
+PR_NUMBER=$(gh pr view --json number -q .number)
+gh pr ready "$PR_NUMBER"
+gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+```
+
+**실패 케이스별 처리**:
+- branch protection/review 필요 → draft 로 되돌림 (`gh pr ready --undo`), PR URL + 이유 보고
+- auto-merge 미활성 저장소 → "auto-merge 설정 없음" 보고, PR URL 남김
+- 어떤 경우에도 force merge 시도 금지
+
+## 6단계: 리포트
+
+사용자에게 한 줄로:
+- `✓ shipped: <PR-URL> (auto-merge enabled)`
+- 또는 `⚠ PR created (draft): <PR-URL> — <실패 사유>`
+
+## 중요 원칙
+
+- `just prepush` 실패하면 절대 push/PR 진행 안 함
+- 커밋 메시지는 **확인 없이** 진행 (자동화가 목적)
+- 한 번의 stop 훅에서 1회만 실행 (sentinel)
+- auto-merge 는 "가능하면" — 실패는 사용자에게 알리되 fatal 취급 안 함
+- 스코프 벗어난 정리 작업 추가 금지 (diff 그대로 ship)

--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -715,17 +715,17 @@ func renderEntry(b *strings.Builder, e codeEntry) {
 // Headings that share a family prefix (e.g. "Manifest — TOML syntax."
 // vs "Manifest — schema.") are matched by prefix via headingToFamily.
 var headingFamily = map[string]string{
-	"Lexical":                  "FamilyLexical",
+	"Lexical":                   "FamilyLexical",
 	"Declarations & statements": "FamilyDeclaration",
-	"Expressions":              "FamilyExpression",
-	"Types & patterns":         "FamilyTypePattern",
-	"Annotations":              "FamilyAnnotation",
-	"Name resolution":          "FamilyResolution",
-	"Control flow / context":   "FamilyControlFlow",
-	"Type checking":            "FamilyTypeChecking",
-	"Deprecation warning":      "FamilyWarning",
-	"Runtime sublanguage":      "FamilyTypeChecking", // TODO: dedicated FamilyRuntime once generated.go accommodates it
-	"Scaffolding":              "FamilyScaffold",
+	"Expressions":               "FamilyExpression",
+	"Types & patterns":          "FamilyTypePattern",
+	"Annotations":               "FamilyAnnotation",
+	"Name resolution":           "FamilyResolution",
+	"Control flow / context":    "FamilyControlFlow",
+	"Type checking":             "FamilyTypeChecking",
+	"Deprecation warning":       "FamilyWarning",
+	"Runtime sublanguage":       "FamilyTypeChecking", // TODO: dedicated FamilyRuntime once generated.go accommodates it
+	"Scaffolding":               "FamilyScaffold",
 }
 
 // headingPrefixFamily matches headings by prefix when multiple

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -71,7 +71,7 @@ func prepareSourceEntry(req llvmgenRequest) (backend.Entry, error) {
 	reg := stdlib.LoadCached()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -107,8 +107,8 @@ func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
 	}
 	results := ws.ResolveAll()
 	checks := check.Workspace(ws, results, check.Opts{
-		
-		Stdlib:      ws.Stdlib,
+
+		Stdlib: ws.Stdlib,
 	})
 	pkg := ws.Packages[""]
 	if pkg == nil {

--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -478,7 +478,7 @@ func compareFrontEndAssist(before, after ProbeStats) int {
 func checkOptsForSource(src []byte) check.Opts {
 	reg := stdlib.LoadCached()
 	return check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/airepair/corpus_test.go
+++ b/internal/airepair/corpus_test.go
@@ -127,7 +127,7 @@ func TestAnalyzeCorpus(t *testing.T) {
 			// else_if_keyword → python_else_if_block path the Go-legacy
 			// checker triggered. Final repaired source is identical
 			// (expected fixture unchanged; wantAfterTotalErrs stays 0).
-			wantChangeKinds:    []string{"python_if_block", "python_elif_block", "python_else_block"},
+			wantChangeKinds: []string{"python_if_block", "python_elif_block", "python_else_block"},
 		},
 		{
 			name:               "js_for_of_loop",

--- a/internal/backend/llvm_list_get_safe_test.go
+++ b/internal/backend/llvm_list_get_safe_test.go
@@ -14,7 +14,7 @@ import (
 // (returns raw T) and storing the raw scalar into an `%Option.T`
 // slot — clang rejected with:
 //
-//   '%tN' defined with type 'i64' but expected '%Option.i64'
+//	'%tN' defined with type 'i64' but expected '%Option.i64'
 //
 // Fix detects `i.Dest` typed as OptionalType and routes through a
 // bounds-guarded len-check + Some/None wrap (same pattern as

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -74,7 +74,7 @@ func parseBackendFile(t *testing.T, src string) (*ast.File, *resolve.Result, *ch
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/backend/stdlib_type_inject_test.go
+++ b/internal/backend/stdlib_type_inject_test.go
@@ -14,12 +14,12 @@ import (
 // TestInjectedMapTypeMonomorphizes drives the Option B Phase 1
 // pipeline end-to-end at the IR layer:
 //
-//   1. User code references `Map<String, Int>` in a function signature
-//      and calls `m.containsKey(k)` inside the body.
-//   2. injectReachableStdlibTypes appends Map's generic StructDecl to
-//      the module.
-//   3. ir.Monomorphize specializes Map<K, V> → Map$String$Int with its
-//      methods (containsKey, getOr, update, …) pre-substituted.
+//  1. User code references `Map<String, Int>` in a function signature
+//     and calls `m.containsKey(k)` inside the body.
+//  2. injectReachableStdlibTypes appends Map's generic StructDecl to
+//     the module.
+//  3. ir.Monomorphize specializes Map<K, V> → Map$String$Int with its
+//     methods (containsKey, getOr, update, …) pre-substituted.
 //
 // The assertion: the output IR module contains a specialized struct
 // for Map<String, Int>, and its Methods list includes the bodied

--- a/internal/bootstrap/gen/error_runtime_test.go
+++ b/internal/bootstrap/gen/error_runtime_test.go
@@ -62,7 +62,7 @@ func bootstrapGeneratedSource(t *testing.T, path string) string {
 
 	reg := stdlib.LoadCached()
 	opts := check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/bootstrap/gen/stdlib_inline.go
+++ b/internal/bootstrap/gen/stdlib_inline.go
@@ -56,7 +56,7 @@ func (g *gen) emitStdlibOstyModule(module string) {
 
 	res := resolve.FileWithStdlib(mod.File, resolve.NewPrelude(), reg)
 	chk := check.SelfhostFile(mod.File, res, check.Opts{
-		
+
 		Source:        mod.Source,
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,

--- a/internal/bootstrap/seedgen/seedgen.go
+++ b/internal/bootstrap/seedgen/seedgen.go
@@ -54,7 +54,7 @@ func Generate(cfg Config) ([]byte, error) {
 
 	reg := stdlib.LoadCached()
 	opts := check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -86,7 +86,6 @@ func (r *Result) LookupType(e ast.Expr) types.Type {
 // Opts bundles optional inputs to File / Package / Workspace.
 type Opts struct {
 
-
 	// Source is the raw source for File. Package and Workspace read
 	// sources from resolve.PackageFile.
 	Source []byte

--- a/internal/check/inspect_format.go
+++ b/internal/check/inspect_format.go
@@ -72,15 +72,15 @@ func FormatInspectJSON(w io.Writer, recs []InspectRecord) error {
 	enc := json.NewEncoder(w)
 	for _, r := range recs {
 		if err := enc.Encode(inspectRecordJSON{
-			PosLine:    r.Pos.Line,
-			PosColumn:  r.Pos.Column,
-			EndLine:    r.End.Line,
-			EndColumn:  r.End.Column,
-			NodeKind:   r.NodeKind,
-			Rule:       r.Rule,
-			Type:       typeString(r.Type),
-			Hint:       typeString(r.Hint),
-			Notes:      r.Notes,
+			PosLine:   r.Pos.Line,
+			PosColumn: r.Pos.Column,
+			EndLine:   r.End.Line,
+			EndColumn: r.End.Column,
+			NodeKind:  r.NodeKind,
+			Rule:      r.Rule,
+			Type:      typeString(r.Type),
+			Hint:      typeString(r.Hint),
+			Notes:     r.Notes,
 		}); err != nil {
 			return err
 		}

--- a/internal/cst/green.go
+++ b/internal/cst/green.go
@@ -19,9 +19,9 @@ type GreenKind int
 const (
 	// ---- Meta ----
 
-	GkNone GreenKind = iota // unused sentinel
-	GkToken                 // a terminal with text + trivia
-	GkTrivia                // a trivia leaf (rarely used; trivia usually lives on tokens)
+	GkNone   GreenKind = iota // unused sentinel
+	GkToken                   // a terminal with text + trivia
+	GkTrivia                  // a trivia leaf (rarely used; trivia usually lives on tokens)
 
 	// ---- File / entry points ----
 
@@ -85,7 +85,7 @@ const (
 	GkBoolLit
 	GkCharLit
 	GkByteLit
-	GkStringPart // one text segment of a STRING/RAWSTRING
+	GkStringPart   // one text segment of a STRING/RAWSTRING
 	GkStringInterp // one {expr} interpolation
 
 	// ---- Expressions: operators ----
@@ -278,7 +278,7 @@ var greenKindNames = map[GreenKind]string{
 // source extent (TotalWidth) while consumers that only care about the token
 // text can still use Width:
 //
-//   TotalWidth = LeadingWidth + Width + TrailingWidth
+//	TotalWidth = LeadingWidth + Width + TrailingWidth
 //
 // Structural sharing: two GreenTokens with identical fields dedupe to a
 // single id in the arena, saving memory for common keyword/punctuation

--- a/internal/cst/green_arena.go
+++ b/internal/cst/green_arena.go
@@ -189,4 +189,3 @@ func (b *GreenBuilder) Finish() (arena *GreenArena, rootID int) {
 	}
 	return b.arena, b.root
 }
-

--- a/internal/cst/red.go
+++ b/internal/cst/red.go
@@ -17,8 +17,8 @@ type Red struct {
 	absoluteOffset int
 	// green identifies the underlying green entry. We keep both the tag
 	// and the id so the node / token dispatch is straightforward.
-	tag  GreenChildTag // GctNode or GctToken
-	id   int           // arena id
+	tag GreenChildTag // GctNode or GctToken
+	id  int           // arena id
 }
 
 // Tree couples a Green arena with a Red side-table. The side-table caches

--- a/internal/cst/trivia.go
+++ b/internal/cst/trivia.go
@@ -15,15 +15,15 @@ import (
 type TriviaKind int
 
 const (
-	_                             TriviaKind = iota
-	TriviaWhitespace                         // runs of ' ' or '\t'
-	TriviaNewline                            // one or more '\n' (source is normalized)
-	TriviaLineComment                        // `// ...` up to end-of-line (exclusive of '\n')
-	TriviaBlockComment                       // `/* ... */`, possibly multi-line
-	TriviaDocComment                         // `/// ...` up to end-of-line
-	TriviaShebang                            // `#!...` on the first line only
-	TriviaBom                                // U+FEFF at offset 0 only
-	TriviaUnterminatedBlockComment           // `/* ...` with no closing `*/`
+	_                              TriviaKind = iota
+	TriviaWhitespace                          // runs of ' ' or '\t'
+	TriviaNewline                             // one or more '\n' (source is normalized)
+	TriviaLineComment                         // `// ...` up to end-of-line (exclusive of '\n')
+	TriviaBlockComment                        // `/* ... */`, possibly multi-line
+	TriviaDocComment                          // `/// ...` up to end-of-line
+	TriviaShebang                             // `#!...` on the first line only
+	TriviaBom                                 // U+FEFF at offset 0 only
+	TriviaUnterminatedBlockComment            // `/* ...` with no closing `*/`
 )
 
 // String returns a short, stable label for snapshot and log output.

--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -215,12 +215,12 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		return nil
 	}
 	out := &FnDecl{
-		Name:         fn.Name,
-		Return:       CloneType(fn.Return),
-		Body:         cloneBlockOrNil(fn.Body),
-		ReceiverMut:  fn.ReceiverMut,
-		Exported:     fn.Exported,
-		SpanV:        fn.SpanV,
+		Name:               fn.Name,
+		Return:             CloneType(fn.Return),
+		Body:               cloneBlockOrNil(fn.Body),
+		ReceiverMut:        fn.ReceiverMut,
+		Exported:           fn.Exported,
+		SpanV:              fn.SpanV,
 		ExportSymbol:       fn.ExportSymbol,
 		CABI:               fn.CABI,
 		IsIntrinsic:        fn.IsIntrinsic,

--- a/internal/ir/decision.go
+++ b/internal/ir/decision.go
@@ -36,7 +36,7 @@ type DecisionLeaf struct {
 	ArmIndex int
 }
 
-func (*DecisionLeaf) decisionNode()   {}
+func (*DecisionLeaf) decisionNode()    {}
 func (l *DecisionLeaf) String() string { return fmt.Sprintf("leaf(arm=%d)", l.ArmIndex) }
 
 // DecisionFail is reached only when no arm matches. For a match proven
@@ -44,7 +44,7 @@ func (l *DecisionLeaf) String() string { return fmt.Sprintf("leaf(arm=%d)", l.Ar
 // backends must still emit a safe trap (e.g. a runtime abort).
 type DecisionFail struct{}
 
-func (*DecisionFail) decisionNode()   {}
+func (*DecisionFail) decisionNode()  {}
 func (*DecisionFail) String() string { return "fail" }
 
 // DecisionBind adds one pattern binding (`name = projection`) to the

--- a/internal/ir/doc.go
+++ b/internal/ir/doc.go
@@ -42,7 +42,7 @@
 //     IntrinsicCall, MethodCall, VariantLit, FieldExpr, TupleAccess,
 //     IndexExpr, ListLit, MapLit, TupleLit, StructLit, RangeLit,
 //     Closure (Captures), BlockExpr, IfExpr, IfLetExpr, MatchExpr (arms
-//     + optional DecisionTree), ErrorExpr.
+//   - optional DecisionTree), ErrorExpr.
 //   - Patterns: WildPat, IdentPat, LitPat, TuplePat, StructPat,
 //     VariantPat, RangePat, OrPat, BindingPat, ErrorPat.
 //   - Types: PrimType (with canonical singletons), NamedType (Package

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -179,7 +179,7 @@ fn probe(p: Printable) -> Note? {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -254,7 +254,7 @@ func TestLowerUseDeclRecoversBuiltinGenericTypesWithoutResolverTypeRefs(t *testi
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/ir/runtime_annot_propagation_test.go
+++ b/internal/ir/runtime_annot_propagation_test.go
@@ -21,7 +21,7 @@ func lowerSrc(t *testing.T, src string) *Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/lexer/lexer_fuzz_test.go
+++ b/internal/lexer/lexer_fuzz_test.go
@@ -32,44 +32,44 @@ func FuzzLex(f *testing.F) {
 	// tripped the parser fuzzer, and a handful of truncated inputs that
 	// exercise the unterminated-* code paths.
 	seeds := []string{
-		"",                   // empty
-		"\x00",               // lone NUL
-		"\xff\xfe\xfd",       // invalid UTF-8 sequence
-		"#",                  // lone hash (historic parser hang)
+		"",             // empty
+		"\x00",         // lone NUL
+		"\xff\xfe\xfd", // invalid UTF-8 sequence
+		"#",            // lone hash (historic parser hang)
 		"#!/usr/bin/env osty\n",
 		"\ufeffpub fn main() {}",
-		"let s = \"hello",    // E0001 unterminated
+		"let s = \"hello", // E0001 unterminated
 		"let s = \"hi\n",
-		"let n = 0X1F",        // E0002
-		"let c = '\\u{D800}'", // E0003 surrogate
-		"let c = '\\q'",       // E0003 unknown escape
-		"/* never closes",     // E0004
-		"let x = ⚡",           // E0005
-		"let s = \"\"\"oops\"\"\"", // E0006 missing leading newline
-		"match 0 { 0 => 1 }",  // E0007 fat arrow
-		"let a = 1_",          // E0008
-		"let a = 0x_FF",       // E0008
-		"let a = 1__000",      // E0008
-		"let a = ''",          // E0009 empty char
-		"let a = b''",         // E0009 empty byte
-		"let cast = err as? FsError", // fused postfix token
+		"let n = 0X1F",                    // E0002
+		"let c = '\\u{D800}'",             // E0003 surrogate
+		"let c = '\\q'",                   // E0003 unknown escape
+		"/* never closes",                 // E0004
+		"let x = ⚡",                       // E0005
+		"let s = \"\"\"oops\"\"\"",        // E0006 missing leading newline
+		"match 0 { 0 => 1 }",              // E0007 fat arrow
+		"let a = 1_",                      // E0008
+		"let a = 0x_FF",                   // E0008
+		"let a = 1__000",                  // E0008
+		"let a = ''",                      // E0009 empty char
+		"let a = b''",                     // E0009 empty byte
+		"let cast = err as? FsError",      // fused postfix token
 		"'outer: for { continue 'outer }", // label token + labeled control flow
-		"let s = \"a {f({g: 1})} b\"", // nested interpolation
+		"let s = \"a {f({g: 1})} b\"",     // nested interpolation
 		"let s = \"\"\"\n    line1\n    line2\n    \"\"\"", // triple valid
-		"let s = r\"raw \\n\"",  // raw string
-		"let s = b\"bytes\"",    // byte string
-		"let c = '\\u{1F600}'",  // valid unicode escape
-		"let x = 길 + 🦀",        // multi-byte UTF-8 identifiers (invalid, but no panic)
-		"0x",                    // truncated base literal
+		"let s = r\"raw \\n\"",                             // raw string
+		"let s = b\"bytes\"",                               // byte string
+		"let c = '\\u{1F600}'",                             // valid unicode escape
+		"let x = 길 + 🦀",                                    // multi-byte UTF-8 identifiers (invalid, but no panic)
+		"0x",                                               // truncated base literal
 		"0b",
 		"0o",
-		"\"",                    // lone quote
-		"\"\"\"",                // lone triple
-		"'",                     // lone apostrophe
+		"\"",     // lone quote
+		"\"\"\"", // lone triple
+		"'",      // lone apostrophe
 		"b'",
 		"r\"",
-		"\\u{",                  // truncated unicode escape
-		"{",                     // lone brace
+		"\\u{", // truncated unicode escape
+		"{",    // lone brace
 		"fn f() {\n    return 1\n}",
 		// ASI suppression landmines: binary op at EOL + leading dot.
 		"let x = 1 +\n    2\n",

--- a/internal/llvmgen/c_abi_codegen_test.go
+++ b/internal/llvmgen/c_abi_codegen_test.go
@@ -114,7 +114,7 @@ fn main() {}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/char_predicate_test.go
+++ b/internal/llvmgen/char_predicate_test.go
@@ -31,8 +31,8 @@ fn main() {
 	}
 	got := string(ir)
 	for _, want := range []string{
-		"sub i32 ",  // c - '0'
-		"icmp ult i32 ",  // <u 10
+		"sub i32 ",      // c - '0'
+		"icmp ult i32 ", // <u 10
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Char.isDigit missing %q in IR:\n%s", want, got)

--- a/internal/llvmgen/closure_lift_test.go
+++ b/internal/llvmgen/closure_lift_test.go
@@ -24,7 +24,7 @@ func lowerSrcLLVM(t *testing.T, src string) *ostyir.Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/export_codegen_test.go
+++ b/internal/llvmgen/export_codegen_test.go
@@ -128,7 +128,7 @@ fn main() {}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/iface_downcast.go
+++ b/internal/llvmgen/iface_downcast.go
@@ -87,11 +87,11 @@ func (g *generator) emitIfaceDowncastIR(ifaceVal value, targetVtableSym string) 
 //
 // Recognition walks:
 //
-//   CallExpr
-//     Fn: TurbofishExpr
-//       Base: FieldExpr { Name: "downcast", X: <recv> }
-//       Args: [ NamedType{ Path: ["T"] } ]
-//     Args: []                       // no value args
+//	CallExpr
+//	  Fn: TurbofishExpr
+//	    Base: FieldExpr { Name: "downcast", X: <recv> }
+//	    Args: [ NamedType{ Path: ["T"] } ]
+//	  Args: []                       // no value args
 //
 // The receiver's static type must resolve to %osty.iface (any
 // interface — downcast is Error-specific in the spec but the

--- a/internal/llvmgen/iface_downcast_test.go
+++ b/internal/llvmgen/iface_downcast_test.go
@@ -193,7 +193,7 @@ fn main() {}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/intrinsic_propagation_test.go
+++ b/internal/llvmgen/intrinsic_propagation_test.go
@@ -33,7 +33,7 @@ fn main() {}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -88,7 +88,7 @@ fn main() {}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -16,7 +16,7 @@ func lowerNativeEntryModule(t *testing.T, src string) *ostyir.Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/ir_native_enum_test.go
+++ b/internal/llvmgen/ir_native_enum_test.go
@@ -138,7 +138,7 @@ fn main() {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -196,7 +196,7 @@ fn main() {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/ir_native_result_test.go
+++ b/internal/llvmgen/ir_native_result_test.go
@@ -85,7 +85,7 @@ func lowerResultNativeEntryModule(t *testing.T, src string) *ostyir.Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/ir_native_tuple_destructure_test.go
+++ b/internal/llvmgen/ir_native_tuple_destructure_test.go
@@ -115,7 +115,7 @@ fn main() {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/legacy_export_alias_test.go
+++ b/internal/llvmgen/legacy_export_alias_test.go
@@ -147,7 +147,7 @@ func buildLegacyIRResult(t *testing.T, src string) ([]byte, error) {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -437,7 +437,7 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -615,7 +615,7 @@ fn newRunner() -> Runner {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -1737,7 +1737,7 @@ func TestGenerateFromMIRVectorizedScalarListParamUsesRawDataFastPath(t *testing.
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/native_toolchain_mir_pipeline_test.go
+++ b/internal/llvmgen/native_toolchain_mir_pipeline_test.go
@@ -71,7 +71,7 @@ func TestNativeToolchainMergedMIRPipelineIsClean(t *testing.T) {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,
@@ -169,7 +169,7 @@ func TestNativeToolchainMergedMIRErrTypeFloor(t *testing.T) {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/runtime_intrinsic_codegen_test.go
+++ b/internal/llvmgen/runtime_intrinsic_codegen_test.go
@@ -39,7 +39,7 @@ func lowerPrivilegedToMIR(t *testing.T, src string) *mir.Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/runtime_intrinsic_typing_test.go
+++ b/internal/llvmgen/runtime_intrinsic_typing_test.go
@@ -98,7 +98,7 @@ func lowerPrivileged(t *testing.T, src string) *ir.Module {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/stdlib_method_lookup.go
+++ b/internal/llvmgen/stdlib_method_lookup.go
@@ -61,14 +61,14 @@
 //
 // # What's usable today
 //
-// - `LookupStructMethod` / `LookupEnumMethod` — return the cached
-//   stdlib AST FnDecl for a built-in method. Callers get a read-only
-//   view; cloning is the caller's responsibility (use
-//   `internal/ir/clone.go` once converted to IR).
+//   - `LookupStructMethod` / `LookupEnumMethod` — return the cached
+//     stdlib AST FnDecl for a built-in method. Callers get a read-only
+//     view; cloning is the caller's responsibility (use
+//     `internal/ir/clone.go` once converted to IR).
 //
-// - `MapCanonicalHelperNames` — the §B.9.1.64 canonical set. Useful
-//   for the future dispatcher that decides whether a given callsite
-//   should route to monomorphization or intrinsic.
+//   - `MapCanonicalHelperNames` — the §B.9.1.64 canonical set. Useful
+//     for the future dispatcher that decides whether a given callsite
+//     should route to monomorphization or intrinsic.
 //
 // Tests in `stdlib_method_lookup_test.go` pin the registry has all
 // six Map canonical helpers plus Option's isSome/isNone, so a stdlib

--- a/internal/llvmgen/testing_property_codegen_test.go
+++ b/internal/llvmgen/testing_property_codegen_test.go
@@ -90,7 +90,7 @@ fn main() {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/unsupported_diag_parity_test.go
+++ b/internal/llvmgen/unsupported_diag_parity_test.go
@@ -95,7 +95,7 @@ func TestUnsupportedDiagnosticOstySnapshotParity(t *testing.T) {
 }
 
 var (
-	ostyKindBranchRE = regexp.MustCompile(`if kind == "([^"]+)"`)
+	ostyKindBranchRE      = regexp.MustCompile(`if kind == "([^"]+)"`)
 	ostyUnsupportedCallRE = regexp.MustCompile(
 		`llvmUnsupportedDiagnosticWith\(\s*"(LLVM\d{3})"\s*,\s*kind\s*,\s*detail\s*,\s*"((?:[^"\\]|\\.)*)"`,
 	)
@@ -108,12 +108,12 @@ var (
 // llvmUnsupportedDiagnostic. Two branch shapes are recognized:
 //
 //   - uniform helper call:
-//       return llvmUnsupportedDiagnosticWith("LLVMNNN", kind, detail, "hint")
+//     return llvmUnsupportedDiagnosticWith("LLVMNNN", kind, detail, "hint")
 //   - field-literal return (LLVM001 / LLVM002, which decorate the kind
 //     they emit so they can't reuse the helper):
-//       return LlvmUnsupportedDiagnostic {
-//         code: "LLVMNNN", ..., hint: "hint", ...,
-//       }
+//     return LlvmUnsupportedDiagnostic {
+//     code: "LLVMNNN", ..., hint: "hint", ...,
+//     }
 //
 // Each branch is bounded to the source slice between its kind anchor
 // and the next branch's anchor, so a field-literal hint pattern from

--- a/internal/llvmgen/vectorize_real_simd_test.go
+++ b/internal/llvmgen/vectorize_real_simd_test.go
@@ -26,7 +26,7 @@ func lowerThroughMIR(t *testing.T, src string) string {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/llvmgen/vectorize_test.go
+++ b/internal/llvmgen/vectorize_test.go
@@ -241,7 +241,7 @@ fn main() {
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
 	reg := stdlib.LoadCached()
 	chk := check.SelfhostFile(file, res, check.Opts{
-		
+
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,
 		ResultMethods: reg.ResultMethods,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -752,7 +752,7 @@ func engineKeyForURI(uri string) string {
 func lspCheckOpts(src []byte) check.Opts {
 	reg := stdlib.LoadCached()
 	return check.Opts{
-		
+
 		Source:        src,
 		Stdlib:        reg,
 		Primitives:    reg.Primitives,

--- a/internal/parser/parser_fuzz_test.go
+++ b/internal/parser/parser_fuzz_test.go
@@ -75,7 +75,7 @@ func truncate(src []byte) string {
 // BenchmarkParseBaseline measures parse time on a representative file.
 // Useful for the Phase 5 perf budget (Green parse within 1.4x of baseline).
 //
-//   go test ./internal/parser -bench=BenchmarkParseBaseline -benchtime=3s
+//	go test ./internal/parser -bench=BenchmarkParseBaseline -benchtime=3s
 func BenchmarkParseBaseline(b *testing.B) {
 	src, err := os.ReadFile(filepath.Join("..", "..", "word_freq.osty"))
 	if err != nil {

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -37,7 +37,6 @@ func newHasher() *stableHasher {
 	return s
 }
 
-
 // sum returns the accumulated hash and returns the hasher to the
 // pool. Callers use this once per top-level hashFn (and once per
 // intermediate hash in helpers like the SymTypes symbol-hashing
@@ -571,4 +570,3 @@ func hashStringSlice(ss []string) [32]byte {
 	}
 	return h.sum()
 }
-

--- a/internal/runner/airepair_policy_test.go
+++ b/internal/runner/airepair_policy_test.go
@@ -77,11 +77,11 @@ func TestUsesFrontEndAIRepair(t *testing.T) {
 
 func TestShouldCaptureAiRepair(t *testing.T) {
 	cases := []struct {
-		name         string
-		mode         string
-		changed      bool
-		totalErrors  int
-		want         bool
+		name        string
+		mode        string
+		changed     bool
+		totalErrors int
+		want        bool
 	}{
 		{"always-no-changes-no-errors", "always", false, 0, true},
 		{"always-changed-errors", "always", true, 5, true},

--- a/internal/runner/diag_policy_test.go
+++ b/internal/runner/diag_policy_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestIsDeferredGenCheckDiag(t *testing.T) {
 	cases := []struct {
-		name             string
-		severity, msg    string
-		want             bool
+		name          string
+		severity, msg string
+		want          bool
 	}{
 		{"error-with-marker-prefix", "error", "type checking unavailable for /tmp/foo.osty", true},
 		{"warning-even-with-marker", "warning", "type checking unavailable for /tmp/foo.osty", false},

--- a/internal/runner/policy_test.go
+++ b/internal/runner/policy_test.go
@@ -36,7 +36,7 @@ func TestBinaryNameForAppliesExeOnWindows(t *testing.T) {
 
 func TestBuildBinaryName(t *testing.T) {
 	cases := []struct {
-		name                                        string
+		name                                       string
 		bin, pkg, triple, targetOS, hostGoos, want string
 	}{
 		{"host-linux", "cli", "pkg", "", "", "linux", "cli"},

--- a/internal/runner/test_runner_policy_test.go
+++ b/internal/runner/test_runner_policy_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestResolveTestWorkers(t *testing.T) {
 	cases := []struct {
-		name                              string
-		serial                            bool
+		name                            string
+		serial                          bool
 		jobs, cpuCount, testCount, want int
 	}{
 		{"serial-wins", true, 8, 16, 100, 1},

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -89,11 +89,11 @@ type CheckDiagnosticRecord struct {
 
 // CheckResult is the structured Go-facing surface for the bootstrapped checker.
 type CheckResult struct {
-	Summary        CheckSummary          `json:"summary"`
-	TypedNodes     []CheckedNode         `json:"typedNodes"`
-	Bindings       []CheckedBinding      `json:"bindings"`
-	Symbols        []CheckedSymbol       `json:"symbols"`
-	Instantiations []CheckInstantiation  `json:"instantiations"`
+	Summary        CheckSummary            `json:"summary"`
+	TypedNodes     []CheckedNode           `json:"typedNodes"`
+	Bindings       []CheckedBinding        `json:"bindings"`
+	Symbols        []CheckedSymbol         `json:"symbols"`
+	Instantiations []CheckInstantiation    `json:"instantiations"`
 	Diagnostics    []CheckDiagnosticRecord `json:"diagnostics,omitempty"`
 }
 

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -94,10 +94,10 @@ const (
 	SHLEQ     // <<=
 	SHREQ     // >>=
 
-	QUESTION // ?
+	QUESTION   // ?
 	ASQUESTION // as?
-	QDOT     // ?.
-	QQ       // ??
+	QDOT       // ?.
+	QQ         // ??
 
 	DOTDOT   // ..
 	DOTDOTEQ // ..=


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/osty-ship/SKILL.md` — project-scoped ship automation
- Flow: `just prepush` gate → commit (Osty convention prefix) → push → draft PR → `--auto --squash` merge
- Invoked by Stop hook (personal `.claude/settings.local.json`, not in this PR) so manual `/osty-ship` typing is skipped

## Test plan
- [x] `just prepush` passes locally
- [x] First real run (this PR) exposed pre-existing `$$(...)` gofmt drift — fixed in #841
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)