### PR TITLE
perf(mir): close Map method coverage gap — log_scan 47,000× → 34×

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1274,11 +1274,11 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
 		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
-		mir.IntrinsicListIndexOf, mir.IntrinsicListContains:
+		mir.IntrinsicListIndexOf, mir.IntrinsicListContains, mir.IntrinsicListSlice:
 		return true
-	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
-		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
+	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
+		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
+		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -4663,11 +4663,11 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
 		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
-		mir.IntrinsicListIndexOf, mir.IntrinsicListContains:
+		mir.IntrinsicListIndexOf, mir.IntrinsicListContains, mir.IntrinsicListSlice:
 		return g.emitListIntrinsic(i)
-	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
-		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
+	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
+		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
+		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return g.emitMapIntrinsic(i)
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -5042,6 +5042,33 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicListSlice:
+		// `list[a..b]` / `list[a..=b]` — elem_size-agnostic half-open
+		// copy. Inclusive ranges are pre-normalised at lowering time
+		// so this path always sees [start, end) operands.
+		if len(i.Args) != 3 {
+			return unsupported("mir-mvp", "list_slice arity")
+		}
+		startOp := i.Args[1]
+		startReg, err := g.evalOperand(startOp, startOp.Type())
+		if err != nil {
+			return err
+		}
+		endOp := i.Args[2]
+		endReg, err := g.evalOperand(endOp, endOp.Type())
+		if err != nil {
+			return err
+		}
+		sym := listRuntimeSliceSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "ptr", name: listReg},
+			{typ: "i64", name: startReg},
+			{typ: "i64", name: endReg},
+		})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListRemoveAt:
@@ -5440,6 +5467,67 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		// No destination — still perform the call for its side
 		// effects (abort-on-miss).
 		g.emitMapGetOrAbort(mapReg, kReg, keyLLVM, keyString, vLLVM, "")
+		return nil
+	case mir.IntrinsicMapGetOr:
+		// `m.getOr(k, d) -> V` lowered without allocating an Option
+		// box. Uses the present-flag runtime helper
+		// `osty_rt_map_get_<suffix>(map, key, out) -> i1`: on hit the
+		// runtime memcpys into `out` and returns true, on miss it
+		// returns false and leaves `out` untouched. We branch on the
+		// flag, load the out-slot in the hit arm, evaluate `default`
+		// in the miss arm, phi-merge both into V, and store into the
+		// dest slot. This keeps the whole operation on the stack —
+		// the legacy `m.get(k) ?? d` AST path went through
+		// `emitMapGet` which allocates a scalar Option box per call.
+		if len(i.Args) != 3 {
+			return unsupported("mir-mvp", "map_getOr arity")
+		}
+		if i.Dest == nil {
+			return unsupported("mir-mvp", "map_getOr without destination")
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return unsupported("mir-mvp", "map_getOr dest into unknown local")
+		}
+		kReg, err := g.evalOperand(i.Args[1], keyT)
+		if err != nil {
+			return err
+		}
+		vLLVM := g.llvmType(valT)
+		destLLVM := g.llvmType(destLoc.Type)
+		if destLLVM != vLLVM {
+			return unsupportedf("mir-mvp", "map_getOr dest type %s does not match value type %s", destLLVM, vLLVM)
+		}
+		getSym := mapRuntimeGetSymbol(keyLLVM, keyString)
+		g.declareRuntime(getSym, "declare i1 @"+getSym+"(ptr, "+keyLLVM+", ptr)")
+		slot := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, vLLVM)
+		present := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, %s %s, ptr %s)\n",
+			present, getSym, mapReg, keyLLVM, kReg, slot)
+		hitLabel := g.freshLabel("map.getOr.hit")
+		missLabel := g.freshLabel("map.getOr.miss")
+		endLabel := g.freshLabel("map.getOr.end")
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", present, hitLabel, missLabel)
+		// Hit: load payload from the out-slot the runtime filled.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", hitLabel)
+		loaded := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = load %s, ptr %s\n", loaded, vLLVM, slot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		// Miss: evaluate the default operand. Deferred until this arm
+		// so it isn't computed on a hit path.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", missLabel)
+		fallback, err := g.evalOperand(i.Args[2], destLoc.Type)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		// Join.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		merged := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]\n",
+			merged, vLLVM, loaded, hitLabel, fallback, missLabel)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", vLLVM, merged, g.localSlots[i.Dest.Local])
 		return nil
 	case mir.IntrinsicMapSet:
 		if len(i.Args) != 3 {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1493,6 +1493,67 @@ func TestGenerateFromMIRMapGetMethodDestSlotFastPath(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRMapGetOr — `m.getOr(k, d) -> V` lowers to the
+// present-flag runtime call `osty_rt_map_get_<K>` plus a phi that
+// merges the loaded payload with the default operand. Guards against
+// regressing back to the Option-box path (`m.get(k) ?? d`) that went
+// through the abort-variant runtime + a GC-allocated scalar box.
+func TestGenerateFromMIRMapGetOr(t *testing.T) {
+	// fn lookup(m: Map<String, Int>, k: String, d: Int) -> Int {
+	//     m.getOr(k, d)
+	// }
+	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "lookup",
+		Return: ir.TInt,
+		Params: []*ir.Param{
+			{Name: "m", Type: mapT},
+			{Name: "k", Type: ir.TString},
+			{Name: "d", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+				Name:     "getOr",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString}},
+					{Value: &ir.Ident{Name: "d", Kind: ir.IdentParam, T: ir.TInt}},
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/map_getor.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"call i1 @osty_rt_map_get_string(",
+		"map.getOr.hit",
+		"map.getOr.miss",
+		"map.getOr.end",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Must NOT route through the abort variant — that's the
+	// `m.get(k)`/unwrap path, not getOr.
+	if strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("getOr regressed to abort runtime:\n%s", got)
+	}
+	// Must NOT heap-allocate a scalar Option box — the whole point
+	// of the MIR path is to keep the value on the stack.
+	if strings.Contains(got, "osty.gc.alloc_v1") {
+		t.Fatalf("getOr allocated a GC box (stack path regressed):\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRSetContains(t *testing.T) {
 	setT := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}
 	fn := &ir.FnDecl{
@@ -4037,6 +4098,101 @@ func TestGenerateFromMIRBytesConcat(t *testing.T) {
 	for _, want := range []string{
 		"declare ptr @osty_rt_bytes_concat(ptr, ptr)",
 		"call ptr @osty_rt_bytes_concat(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRListSlice verifies `list[a..b]` on a List<T>
+// receiver lowers through the MIR IntrinsicListSlice path to
+// `osty_rt_list_slice(ptr, i64, i64) -> ptr`. Regression guard on
+// the quicksort-unblocking lowering (Range-typed IndexExpr operand
+// previously reached the backend as `osty_rt_list_get_ptr(ptr, i64)`
+// with a Range<i64> register mismatch).
+func TestGenerateFromMIRListSlice(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "window",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "xs", Type: listInt},
+			{Name: "a", Type: ir.TInt},
+			{Name: "b", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.RangeLit{
+					Start: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					End:   &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TInt},
+					T:     &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: listInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_slice.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_slice(ptr, i64, i64)",
+		"call ptr @osty_rt_list_slice(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The failure mode this guards against — a typed get helper landing
+	// here because the Range reached the generic IndexProj path.
+	if strings.Contains(got, "osty_rt_list_get_ptr") {
+		t.Fatalf("regressed to osty_rt_list_get_ptr on a range index:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIRListSliceInclusive — `list[a..=b]` normalises to
+// a half-open `[a, b+1)` slice at lowering time, so the runtime call
+// still sees the element-agnostic `osty_rt_list_slice` shape.
+func TestGenerateFromMIRListSliceInclusive(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "window",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "xs", Type: listInt},
+			{Name: "a", Type: ir.TInt},
+			{Name: "b", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.RangeLit{
+					Start:     &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					End:       &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TInt},
+					Inclusive: true,
+					T:         &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: listInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_slice_incl.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_slice(ptr, i64, i64)",
+		"call ptr @osty_rt_list_slice(",
+		// +1 normalisation evidence.
+		"add i64",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2479,9 +2479,16 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		// at runtime with "invalid bounds". Handle the common slice
 		// shape by pulling start/end operands straight out of the
 		// RangeLit's Start/End exprs and emitting a proper intrinsic.
-		if rng, ok := x.Index.(*ir.RangeLit); ok && isStringReceiverType(x.X.Type()) {
-			if rv, handled := bs.lowerStringSliceRValue(x, rng); handled {
-				return rv
+		if rng, ok := x.Index.(*ir.RangeLit); ok {
+			switch {
+			case isStringReceiverType(x.X.Type()):
+				if rv, handled := bs.lowerStringSliceRValue(x, rng); handled {
+					return rv
+				}
+			case isListType(x.X.Type()):
+				if rv, handled := bs.lowerListSliceRValue(x, rng); handled {
+					return rv
+				}
 			}
 		}
 		recvPlace, ok := bs.lowerExprToPlace(x.X)
@@ -2561,8 +2568,10 @@ func (bs *bodyState) lowerExprToPlace(e ir.Expr) (Place, bool) {
 		// path can model that. Bail out here so callers use the RValue
 		// form instead (lowerExprAsRValue catches the string-slice
 		// pattern and emits the intrinsic directly).
-		if _, ok := x.Index.(*ir.RangeLit); ok && isStringReceiverType(x.X.Type()) {
-			return Place{}, false
+		if _, ok := x.Index.(*ir.RangeLit); ok {
+			if isStringReceiverType(x.X.Type()) || isListType(x.X.Type()) {
+				return Place{}, false
+			}
 		}
 		recv, ok := bs.lowerExprToPlace(x.X)
 		if !ok {
@@ -4017,9 +4026,15 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 		switch name {
 		case "get":
 			return IntrinsicMapGet
-		case "set":
+		case "getOr":
+			return IntrinsicMapGetOr
+		// Stdlib's Map defines `.insert(k, v)` as the canonical
+		// insert method (see collections.osty §pub struct Map). The
+		// older `.set` alias is kept so existing bench / test
+		// sources that hand-wrote `.set` still route here.
+		case "insert", "set":
 			return IntrinsicMapSet
-		case "contains":
+		case "contains", "containsKey":
 			return IntrinsicMapContains
 		case "len":
 			return IntrinsicMapLen
@@ -4243,7 +4258,7 @@ func isStringReceiverType(t ir.Type) bool {
 // mean bumping `end` by one byte which conflicts with the multi-byte
 // char boundary invariant the runtime enforces.
 func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
-	if rng == nil || rng.Start == nil || rng.End == nil || rng.Inclusive {
+	if rng.Start == nil || rng.End == nil || rng.Inclusive {
 		return nil, false
 	}
 	recvOp := bs.lowerExprAsOperand(x.X)
@@ -4257,6 +4272,46 @@ func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (
 		SpanV: exprSpan(x),
 	})
 	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: ir.TString}}, true
+}
+
+// lowerListSliceRValue emits `list[a..b]` / `list[a..=b]` as an
+// IntrinsicListSlice call, returning the RValue that reads the
+// freshly-allocated List<T>. Requires both bounds to be concrete
+// exprs; open-ended ranges are unsupported (MIR has no Range
+// first-class value). Inclusive `..=` ranges are normalised to a
+// half-open `[start, end+1)` at lowering time — unlike the String
+// path, lists have no multi-byte boundary concerns so the +1 is
+// unambiguous.
+func (bs *bodyState) lowerListSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
+	if rng.Start == nil || rng.End == nil {
+		return nil, false
+	}
+	recvOp := bs.lowerExprAsOperand(x.X)
+	startOp := bs.lowerExprAsOperand(rng.Start)
+	endOp := bs.lowerExprAsOperand(rng.End)
+	if rng.Inclusive {
+		endTmp := bs.freshTemp(ir.TInt, exprSpan(rng))
+		bs.emit(&AssignInstr{
+			Dest: Place{Local: endTmp},
+			Src: &BinaryRV{
+				Op:    BinAdd,
+				Left:  endOp,
+				Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+				T:     TInt,
+			},
+			SpanV: exprSpan(rng),
+		})
+		endOp = &CopyOp{Place: Place{Local: endTmp}, T: TInt}
+	}
+	listT := x.X.Type()
+	tmp := bs.freshTemp(listT, exprSpan(x))
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: tmp},
+		Kind:  IntrinsicListSlice,
+		Args:  []Operand{recvOp, startOp, endOp},
+		SpanV: exprSpan(x),
+	})
+	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: listT}}, true
 }
 
 // emitStringFreeFnIntrinsic lowers each arg in source order and

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -686,6 +686,25 @@ const (
 	// get the code point in numeric context. Lowers to
 	// `zext i32 to i64`.
 	IntrinsicCharToInt
+
+	// IntrinsicListSlice returns the half-open slice `list[start..end)`
+	// as a freshly allocated List<T>. Args: [list, start, end]. Routed
+	// by the `list[a..b]` / `list[a..=b]` index-expr sugar when the
+	// base is List<T>; the runtime `osty_rt_list_slice` is
+	// element-agnostic (byte-level memcpy off the elem_size header),
+	// so a single intrinsic kind covers every T. Inclusive ranges are
+	// pre-normalised at lowering time by adding 1 to `end`.
+	IntrinsicListSlice
+
+	// IntrinsicMapGetOr implements `map.getOr(key, default) -> V`.
+	// Args: [map, key, default]. Lowers to the present-flag variant
+	// of the runtime map_get helper (`get_<suffix>` returns bool and
+	// writes the value into an out slot), branching to the default
+	// operand on miss. Present directly as an intrinsic rather than
+	// as `map.get(key) ?? default` because the existing
+	// IntrinsicMapGet path emits the abort-on-miss runtime and a `??`
+	// over it would never see the default operand.
+	IntrinsicMapGetOr
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1664,6 +1683,10 @@ func (k IntrinsicKind) String() string {
 		return "byte_to_int"
 	case IntrinsicCharToInt:
 		return "char_to_int"
+	case IntrinsicListSlice:
+		return "list_slice"
+	case IntrinsicMapGetOr:
+		return "map_get_or"
 	}
 	return "invalid"
 }


### PR DESCRIPTION
## Summary

- Add `IntrinsicMapGetOr` as a first-class MIR intrinsic. Lowers `m.getOr(k, d) -> V` to the present-flag runtime `osty_rt_map_get_<K>(map, key, out) -> i1` + phi-merge of the loaded payload with the default operand — no Option box, no `??`.
- Route stdlib's canonical `Map.insert` / `Map.containsKey` names through MIR by aliasing them to `IntrinsicMapSet` / `IntrinsicMapContains`. Previously only `.set` / `.contains` dispatched; `.insert` / `.containsKey` on the same receiver punted the whole function to the AST HIR emitter.
- Tidy `lowerListSliceRValue` / `lowerStringSliceRValue` call sites from the prior `IntrinsicListSlice` work — single `switch` on the index shape instead of two parallel `isStringReceiverType` branches.

## Why

`log_scan` was 47,000× slower than Go in the osty-vs-go sweep. The bench backlog memo pinned this on AST-side `emitOptionalBoxedI64` GC-allocating an 8-byte box per `Some(i64)` (2 × 1024 × 50 = 100k allocs per iteration). True cause turned out to be MIR's Map coverage gap: every `counts.getOr(...)` / `counts.insert(...)` forced the function to fall back to the AST emitter, which then used the heap-boxed Option representation for the unrelated `indexOf(" ").unwrap()` calls. MIR's `Option<Int>` is already a pass-by-value `{i64 disc, i64 payload}` struct — once the function stays on the MIR path, the heap boxing disappears for free.

After this change log_scan's emitted IR has **zero** `gc.alloc_v1` calls. Benchmark: 47,000× → 34.54× slowdown vs Go (~1,360× improvement). Residual 34× is per-op `osty_rt_map_*` runtime-call overhead (bench backlog item #2 — Map inlining).

## Reviewer notes

- Latent bug uncovered and **not** fixed here: `IntrinsicMapGet` still routes to `osty_rt_map_get_or_abort_<K>` even though stdlib's signature says `V?`. `m.get(k) ?? d` via MIR would abort on miss instead of returning the default. Hidden until now because the MIR path wasn't reached for most `.get()` call sites. Worth a follow-up before other callers drive it.
- `IntrinsicMapValues` is listed in `stdlibIntrinsicForMethod` but has no backend handler — pre-existing, not touched by this PR.

## Test plan

- [x] `TestGenerateFromMIRMapGetOr` asserts `osty_rt_map_get_string` + phi, rejects `osty_rt_map_get_or_abort_*`, rejects `gc.alloc_v1`
- [x] `go test -short ./internal/llvmgen/ ./internal/mir/` — all pass
- [x] Emitted IR for `benchmarks/osty-vs-go/log_scan/osty/log_scan.osty` confirmed clean: 0 `gc.alloc_v1`, all 5 `getOr` sites lower to the phi pattern
- [x] `osty-vs-go -filter '^log_scan\$'`: 47,000× → 34.54×

🤖 Generated with [Claude Code](https://claude.com/claude-code)