### PR TITLE
fix(mir): IntrinsicMapGet returns Option<V>, not abort-on-miss

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -5430,6 +5430,17 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicMapGet:
+		// `m.get(k) -> V?` — the stdlib signature is Option-returning
+		// (collections.osty §Map). Emits the present-flag runtime
+		// `osty_rt_map_get_<K>(map, key, out) -> i1` and constructs an
+		// `%Option.V = { i64 disc, i64 payload }` struct: miss → disc=0
+		// (zeroinitializer), hit → disc=1 with the loaded payload
+		// widened to i64. No GC box — Option<V> stays on the stack.
+		//
+		// `m[k]` (IndexExpr on a Map) is a separate lowering path: it
+		// goes through IndexProj and aborts on miss via
+		// `emitMapGetOrAbort`. The two have different language-level
+		// semantics (§10: `m[k]` aborts, `m.get(k)` returns V?).
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "map_get arity")
 		}
@@ -5438,35 +5449,41 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		vLLVM := g.llvmType(valT)
-		// When the destination local's LLVM type matches the map's
-		// value type exactly, hand the runtime the dest slot itself —
-		// the runtime will memcpy straight into it, skipping the
-		// fresh-alloca + load + store we'd otherwise need.
-		if i.Dest != nil {
-			destLoc := g.fn.Local(i.Dest.Local)
-			if destLoc == nil {
-				return fmt.Errorf("mir-mvp: map_get into unknown local %d", i.Dest.Local)
-			}
-			if g.llvmType(destLoc.Type) == vLLVM {
-				g.emitMapGetOrAbort(mapReg, kReg, keyLLVM, keyString, vLLVM, g.localSlots[i.Dest.Local])
-				return nil
-			}
-			// Type mismatch (a future coercion shape): fall through
-			// to the alloca-load path so the store retains its
-			// declared type width.
-			loaded := g.emitMapGetOrAbort(mapReg, kReg, keyLLVM, keyString, vLLVM, "")
-			g.fnBuf.WriteString("  store ")
-			g.fnBuf.WriteString(g.llvmType(destLoc.Type))
-			g.fnBuf.WriteByte(' ')
-			g.fnBuf.WriteString(loaded)
-			g.fnBuf.WriteString(", ptr ")
-			g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
-			g.fnBuf.WriteByte('\n')
+		if i.Dest == nil {
 			return nil
 		}
-		// No destination — still perform the call for its side
-		// effects (abort-on-miss).
-		g.emitMapGetOrAbort(mapReg, kReg, keyLLVM, keyString, vLLVM, "")
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: map_get into unknown local %d", i.Dest.Local)
+		}
+		optT, ok := destLoc.Type.(*ir.OptionalType)
+		if !ok {
+			return unsupportedf("mir-mvp", "map_get dest type %s, expected Optional<V>", mirTypeString(destLoc.Type))
+		}
+		optLLVM := g.llvmType(optT)
+		destSlot := g.localSlots[i.Dest.Local]
+		present, slot := g.emitMapGetProbe(mapReg, kReg, keyLLVM, keyString, vLLVM)
+		someLabel := g.freshLabel("map.get.some")
+		noneLabel := g.freshLabel("map.get.none")
+		endLabel := g.freshLabel("map.get.end")
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", present, someLabel, noneLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		loaded := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = load %s, ptr %s\n", loaded, vLLVM, slot)
+		payloadI64, err := g.listOptionalPayloadToI64(loaded, vLLVM, valT)
+		if err != nil {
+			return unsupportedf("mir-mvp", "map_get payload widen unsupported for %s", vLLVM)
+		}
+		someStep := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", someStep, optLLVM)
+		someValue := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", someValue, optLLVM, someStep, payloadI64)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", optLLVM, someValue, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", optLLVM, destSlot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
 		return nil
 	case mir.IntrinsicMapGetOr:
 		// `m.getOr(k, d) -> V` lowered without allocating an Option
@@ -5498,13 +5515,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if destLLVM != vLLVM {
 			return unsupportedf("mir-mvp", "map_getOr dest type %s does not match value type %s", destLLVM, vLLVM)
 		}
-		getSym := mapRuntimeGetSymbol(keyLLVM, keyString)
-		g.declareRuntime(getSym, "declare i1 @"+getSym+"(ptr, "+keyLLVM+", ptr)")
-		slot := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, vLLVM)
-		present := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, %s %s, ptr %s)\n",
-			present, getSym, mapReg, keyLLVM, kReg, slot)
+		present, slot := g.emitMapGetProbe(mapReg, kReg, keyLLVM, keyString, vLLVM)
 		hitLabel := g.freshLabel("map.getOr.hit")
 		missLabel := g.freshLabel("map.getOr.miss")
 		endLabel := g.freshLabel("map.getOr.end")
@@ -5644,6 +5655,24 @@ func (g *mirGen) emitMapGetOrAbort(mapReg, keyReg, keyLLVM string, keyString boo
 	loaded := llvmLoadFromSlot(em, slot, valLLVM)
 	g.flushOstyEmitter(em)
 	return loaded.name
+}
+
+// emitMapGetProbe emits the shared prologue of `m.get(k)` /
+// `m.getOr(k, d)`: declares the present-flag runtime helper,
+// allocates an out-slot sized for `valLLVM`, and calls
+// `osty_rt_map_get_<suffix>(map, key, out) -> i1`. Returns the SSA
+// register holding the i1 present flag and the slot the runtime
+// writes into on hit. Shared so the two call sites can't drift in
+// ABI (mirrors the `emitMapGetOrAbort` sharing rationale).
+func (g *mirGen) emitMapGetProbe(mapReg, keyReg, keyLLVM string, keyString bool, valLLVM string) (present, slot string) {
+	getSym := mapRuntimeGetSymbol(keyLLVM, keyString)
+	g.declareRuntime(getSym, "declare i1 @"+getSym+"(ptr, "+keyLLVM+", ptr)")
+	slot = g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, valLLVM)
+	present = g.fresh()
+	fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, %s %s, ptr %s)\n",
+		present, getSym, mapReg, keyLLVM, keyReg, slot)
+	return present, slot
 }
 
 // spillToSlot materialises `val` (an SSA register of `llvmType`) in

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1274,11 +1274,11 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
 		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
-		mir.IntrinsicListIndexOf, mir.IntrinsicListContains:
+		mir.IntrinsicListIndexOf, mir.IntrinsicListContains, mir.IntrinsicListSlice:
 		return true
-	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
-		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
+	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
+		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
+		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -4663,11 +4663,11 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
 		mir.IntrinsicListRemoveAt, mir.IntrinsicListReverse, mir.IntrinsicListReversed,
-		mir.IntrinsicListIndexOf, mir.IntrinsicListContains:
+		mir.IntrinsicListIndexOf, mir.IntrinsicListContains, mir.IntrinsicListSlice:
 		return g.emitListIntrinsic(i)
-	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
-		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
-		mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
+	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
+		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
+		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted:
 		return g.emitMapIntrinsic(i)
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -5042,6 +5042,33 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicListSlice:
+		// `list[a..b]` / `list[a..=b]` — elem_size-agnostic half-open
+		// copy. Inclusive ranges are pre-normalised at lowering time
+		// so this path always sees [start, end) operands.
+		if len(i.Args) != 3 {
+			return unsupported("mir-mvp", "list_slice arity")
+		}
+		startOp := i.Args[1]
+		startReg, err := g.evalOperand(startOp, startOp.Type())
+		if err != nil {
+			return err
+		}
+		endOp := i.Args[2]
+		endReg, err := g.evalOperand(endOp, endOp.Type())
+		if err != nil {
+			return err
+		}
+		sym := listRuntimeSliceSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "ptr", name: listReg},
+			{typ: "i64", name: startReg},
+			{typ: "i64", name: endReg},
+		})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListRemoveAt:
@@ -5440,6 +5467,67 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		// No destination — still perform the call for its side
 		// effects (abort-on-miss).
 		g.emitMapGetOrAbort(mapReg, kReg, keyLLVM, keyString, vLLVM, "")
+		return nil
+	case mir.IntrinsicMapGetOr:
+		// `m.getOr(k, d) -> V` lowered without allocating an Option
+		// box. Uses the present-flag runtime helper
+		// `osty_rt_map_get_<suffix>(map, key, out) -> i1`: on hit the
+		// runtime memcpys into `out` and returns true, on miss it
+		// returns false and leaves `out` untouched. We branch on the
+		// flag, load the out-slot in the hit arm, evaluate `default`
+		// in the miss arm, phi-merge both into V, and store into the
+		// dest slot. This keeps the whole operation on the stack —
+		// the legacy `m.get(k) ?? d` AST path went through
+		// `emitMapGet` which allocates a scalar Option box per call.
+		if len(i.Args) != 3 {
+			return unsupported("mir-mvp", "map_getOr arity")
+		}
+		if i.Dest == nil {
+			return unsupported("mir-mvp", "map_getOr without destination")
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return unsupported("mir-mvp", "map_getOr dest into unknown local")
+		}
+		kReg, err := g.evalOperand(i.Args[1], keyT)
+		if err != nil {
+			return err
+		}
+		vLLVM := g.llvmType(valT)
+		destLLVM := g.llvmType(destLoc.Type)
+		if destLLVM != vLLVM {
+			return unsupportedf("mir-mvp", "map_getOr dest type %s does not match value type %s", destLLVM, vLLVM)
+		}
+		getSym := mapRuntimeGetSymbol(keyLLVM, keyString)
+		g.declareRuntime(getSym, "declare i1 @"+getSym+"(ptr, "+keyLLVM+", ptr)")
+		slot := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, vLLVM)
+		present := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, %s %s, ptr %s)\n",
+			present, getSym, mapReg, keyLLVM, kReg, slot)
+		hitLabel := g.freshLabel("map.getOr.hit")
+		missLabel := g.freshLabel("map.getOr.miss")
+		endLabel := g.freshLabel("map.getOr.end")
+		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", present, hitLabel, missLabel)
+		// Hit: load payload from the out-slot the runtime filled.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", hitLabel)
+		loaded := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = load %s, ptr %s\n", loaded, vLLVM, slot)
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		// Miss: evaluate the default operand. Deferred until this arm
+		// so it isn't computed on a hit path.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", missLabel)
+		fallback, err := g.evalOperand(i.Args[2], destLoc.Type)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		// Join.
+		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		merged := g.fresh()
+		fmt.Fprintf(&g.fnBuf, "  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]\n",
+			merged, vLLVM, loaded, hitLabel, fallback, missLabel)
+		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", vLLVM, merged, g.localSlots[i.Dest.Local])
 		return nil
 	case mir.IntrinsicMapSet:
 		if len(i.Args) != 3 {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1435,41 +1435,35 @@ func TestGenerateFromMIRMapPrimitiveGet(t *testing.T) {
 	}
 }
 
-// TestGenerateFromMIRMapGetMethodDestSlotFastPath — `let v = m.get(k)`
-// lowers to an IntrinsicMapGet with a known Dest local. When the
-// destination slot's LLVM type matches the value type, the emitter
-// hands the dest slot directly to the runtime — no extra alloca +
-// load + store pair. Locks in the fast path extracted during the
-// Stage 3.12 refactor.
-func TestGenerateFromMIRMapGetMethodDestSlotFastPath(t *testing.T) {
-	// fn lookup(m: Map<String, Int>, k: String) -> Int {
-	//     let v = m.get(k)
-	//     v
+// TestGenerateFromMIRMapGetMethod — `let v: Int? = m.get(k)` lowers
+// to the present-flag runtime `osty_rt_map_get_<K>(map, key, out)`
+// plus `%Option.i64` struct construction. Miss → disc=0 via a
+// zeroinitializer store; hit → disc=1 with the loaded payload.
+// Locks in the Option-returning ABI that matches the stdlib
+// signature `Map.get(self, key: K) -> V?` and guards against
+// regressing to the abort-variant runtime used by `m[k]`.
+func TestGenerateFromMIRMapGetMethod(t *testing.T) {
+	// fn lookup(m: Map<String, Int>, k: String) -> Int? {
+	//     m.get(k)
 	// }
 	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, ir.TInt}, Builtin: true}
+	optIntT := &ir.OptionalType{Inner: ir.TInt}
 	fn := &ir.FnDecl{
 		Name:   "lookup",
-		Return: ir.TInt,
+		Return: optIntT,
 		Params: []*ir.Param{
 			{Name: "m", Type: mapT},
 			{Name: "k", Type: ir.TString},
 		},
 		Body: &ir.Block{
-			Stmts: []ir.Stmt{
-				&ir.LetStmt{
-					Name: "v",
-					Type: ir.TInt,
-					Value: &ir.MethodCall{
-						Receiver: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
-						Name:     "get",
-						Args: []ir.Arg{
-							{Value: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString}},
-						},
-						T: ir.TInt,
-					},
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+				Name:     "get",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString}},
 				},
+				T: optIntT,
 			},
-			Result: &ir.Ident{Name: "v", Kind: ir.IdentLocal, T: ir.TInt},
 		},
 	}
 	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
@@ -1479,17 +1473,31 @@ func TestGenerateFromMIRMapGetMethodDestSlotFastPath(t *testing.T) {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
 	got := string(out)
-	// The runtime call's 3rd argument is the dest local's alloca
-	// slot (`%lN`) rather than a fresh emitter temp (`%tN`). That's
-	// the signal that the fast path skipped the extra alloca +
-	// load + store a separate out-slot would require.
-	if !strings.Contains(got, "call void @osty_rt_map_get_or_abort_string(ptr %t0, ptr %t1, ptr %l") {
-		t.Fatalf("expected runtime call to use dest local slot directly:\n%s", got)
+	for _, want := range []string{
+		// Present-flag runtime — NOT the abort variant.
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"call i1 @osty_rt_map_get_string(",
+		// Both arms + join label.
+		"map.get.some",
+		"map.get.none",
+		"map.get.end",
+		// Option struct construction on hit.
+		"insertvalue %Option.i64 undef, i64 1, 0",
+		"insertvalue %Option.i64 ",
+		// None arm writes disc=0 via zeroinitializer.
+		"store %Option.i64 zeroinitializer, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
 	}
-	// Fresh-temp out-slot would look like `call ... ptr %t<N>)` at
-	// the 3rd arg — guard against it.
-	if strings.Contains(got, "call void @osty_rt_map_get_or_abort_string(ptr %t0, ptr %t1, ptr %t") {
-		t.Fatalf("dest-slot fast path regressed to fresh-temp out-slot:\n%s", got)
+	// Abort variant must not appear — that would be the `m[k]` path.
+	if strings.Contains(got, "osty_rt_map_get_or_abort_") {
+		t.Fatalf("map.get regressed to abort runtime:\n%s", got)
+	}
+	// No GC box for Option<Int> — struct stays on the stack.
+	if strings.Contains(got, "osty.gc.alloc_v1") {
+		t.Fatalf("map.get allocated a GC box (stack path regressed):\n%s", got)
 	}
 }
 

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1493,6 +1493,67 @@ func TestGenerateFromMIRMapGetMethodDestSlotFastPath(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRMapGetOr — `m.getOr(k, d) -> V` lowers to the
+// present-flag runtime call `osty_rt_map_get_<K>` plus a phi that
+// merges the loaded payload with the default operand. Guards against
+// regressing back to the Option-box path (`m.get(k) ?? d`) that went
+// through the abort-variant runtime + a GC-allocated scalar box.
+func TestGenerateFromMIRMapGetOr(t *testing.T) {
+	// fn lookup(m: Map<String, Int>, k: String, d: Int) -> Int {
+	//     m.getOr(k, d)
+	// }
+	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "lookup",
+		Return: ir.TInt,
+		Params: []*ir.Param{
+			{Name: "m", Type: mapT},
+			{Name: "k", Type: ir.TString},
+			{Name: "d", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+				Name:     "getOr",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString}},
+					{Value: &ir.Ident{Name: "d", Kind: ir.IdentParam, T: ir.TInt}},
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/map_getor.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"call i1 @osty_rt_map_get_string(",
+		"map.getOr.hit",
+		"map.getOr.miss",
+		"map.getOr.end",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Must NOT route through the abort variant — that's the
+	// `m.get(k)`/unwrap path, not getOr.
+	if strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("getOr regressed to abort runtime:\n%s", got)
+	}
+	// Must NOT heap-allocate a scalar Option box — the whole point
+	// of the MIR path is to keep the value on the stack.
+	if strings.Contains(got, "osty.gc.alloc_v1") {
+		t.Fatalf("getOr allocated a GC box (stack path regressed):\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRSetContains(t *testing.T) {
 	setT := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}
 	fn := &ir.FnDecl{
@@ -4037,6 +4098,101 @@ func TestGenerateFromMIRBytesConcat(t *testing.T) {
 	for _, want := range []string{
 		"declare ptr @osty_rt_bytes_concat(ptr, ptr)",
 		"call ptr @osty_rt_bytes_concat(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRListSlice verifies `list[a..b]` on a List<T>
+// receiver lowers through the MIR IntrinsicListSlice path to
+// `osty_rt_list_slice(ptr, i64, i64) -> ptr`. Regression guard on
+// the quicksort-unblocking lowering (Range-typed IndexExpr operand
+// previously reached the backend as `osty_rt_list_get_ptr(ptr, i64)`
+// with a Range<i64> register mismatch).
+func TestGenerateFromMIRListSlice(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "window",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "xs", Type: listInt},
+			{Name: "a", Type: ir.TInt},
+			{Name: "b", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.RangeLit{
+					Start: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					End:   &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TInt},
+					T:     &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: listInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_slice.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_slice(ptr, i64, i64)",
+		"call ptr @osty_rt_list_slice(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The failure mode this guards against — a typed get helper landing
+	// here because the Range reached the generic IndexProj path.
+	if strings.Contains(got, "osty_rt_list_get_ptr") {
+		t.Fatalf("regressed to osty_rt_list_get_ptr on a range index:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIRListSliceInclusive — `list[a..=b]` normalises to
+// a half-open `[a, b+1)` slice at lowering time, so the runtime call
+// still sees the element-agnostic `osty_rt_list_slice` shape.
+func TestGenerateFromMIRListSliceInclusive(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "window",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "xs", Type: listInt},
+			{Name: "a", Type: ir.TInt},
+			{Name: "b", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.RangeLit{
+					Start:     &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					End:       &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TInt},
+					Inclusive: true,
+					T:         &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: listInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_slice_incl.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_slice(ptr, i64, i64)",
+		"call ptr @osty_rt_list_slice(",
+		// +1 normalisation evidence.
+		"add i64",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2479,9 +2479,16 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		// at runtime with "invalid bounds". Handle the common slice
 		// shape by pulling start/end operands straight out of the
 		// RangeLit's Start/End exprs and emitting a proper intrinsic.
-		if rng, ok := x.Index.(*ir.RangeLit); ok && isStringReceiverType(x.X.Type()) {
-			if rv, handled := bs.lowerStringSliceRValue(x, rng); handled {
-				return rv
+		if rng, ok := x.Index.(*ir.RangeLit); ok {
+			switch {
+			case isStringReceiverType(x.X.Type()):
+				if rv, handled := bs.lowerStringSliceRValue(x, rng); handled {
+					return rv
+				}
+			case isListType(x.X.Type()):
+				if rv, handled := bs.lowerListSliceRValue(x, rng); handled {
+					return rv
+				}
 			}
 		}
 		recvPlace, ok := bs.lowerExprToPlace(x.X)
@@ -2561,8 +2568,10 @@ func (bs *bodyState) lowerExprToPlace(e ir.Expr) (Place, bool) {
 		// path can model that. Bail out here so callers use the RValue
 		// form instead (lowerExprAsRValue catches the string-slice
 		// pattern and emits the intrinsic directly).
-		if _, ok := x.Index.(*ir.RangeLit); ok && isStringReceiverType(x.X.Type()) {
-			return Place{}, false
+		if _, ok := x.Index.(*ir.RangeLit); ok {
+			if isStringReceiverType(x.X.Type()) || isListType(x.X.Type()) {
+				return Place{}, false
+			}
 		}
 		recv, ok := bs.lowerExprToPlace(x.X)
 		if !ok {
@@ -4017,9 +4026,15 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 		switch name {
 		case "get":
 			return IntrinsicMapGet
-		case "set":
+		case "getOr":
+			return IntrinsicMapGetOr
+		// Stdlib's Map defines `.insert(k, v)` as the canonical
+		// insert method (see collections.osty §pub struct Map). The
+		// older `.set` alias is kept so existing bench / test
+		// sources that hand-wrote `.set` still route here.
+		case "insert", "set":
 			return IntrinsicMapSet
-		case "contains":
+		case "contains", "containsKey":
 			return IntrinsicMapContains
 		case "len":
 			return IntrinsicMapLen
@@ -4243,7 +4258,7 @@ func isStringReceiverType(t ir.Type) bool {
 // mean bumping `end` by one byte which conflicts with the multi-byte
 // char boundary invariant the runtime enforces.
 func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
-	if rng == nil || rng.Start == nil || rng.End == nil || rng.Inclusive {
+	if rng.Start == nil || rng.End == nil || rng.Inclusive {
 		return nil, false
 	}
 	recvOp := bs.lowerExprAsOperand(x.X)
@@ -4257,6 +4272,46 @@ func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (
 		SpanV: exprSpan(x),
 	})
 	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: ir.TString}}, true
+}
+
+// lowerListSliceRValue emits `list[a..b]` / `list[a..=b]` as an
+// IntrinsicListSlice call, returning the RValue that reads the
+// freshly-allocated List<T>. Requires both bounds to be concrete
+// exprs; open-ended ranges are unsupported (MIR has no Range
+// first-class value). Inclusive `..=` ranges are normalised to a
+// half-open `[start, end+1)` at lowering time — unlike the String
+// path, lists have no multi-byte boundary concerns so the +1 is
+// unambiguous.
+func (bs *bodyState) lowerListSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
+	if rng.Start == nil || rng.End == nil {
+		return nil, false
+	}
+	recvOp := bs.lowerExprAsOperand(x.X)
+	startOp := bs.lowerExprAsOperand(rng.Start)
+	endOp := bs.lowerExprAsOperand(rng.End)
+	if rng.Inclusive {
+		endTmp := bs.freshTemp(ir.TInt, exprSpan(rng))
+		bs.emit(&AssignInstr{
+			Dest: Place{Local: endTmp},
+			Src: &BinaryRV{
+				Op:    BinAdd,
+				Left:  endOp,
+				Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+				T:     TInt,
+			},
+			SpanV: exprSpan(rng),
+		})
+		endOp = &CopyOp{Place: Place{Local: endTmp}, T: TInt}
+	}
+	listT := x.X.Type()
+	tmp := bs.freshTemp(listT, exprSpan(x))
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: tmp},
+		Kind:  IntrinsicListSlice,
+		Args:  []Operand{recvOp, startOp, endOp},
+		SpanV: exprSpan(x),
+	})
+	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: listT}}, true
 }
 
 // emitStringFreeFnIntrinsic lowers each arg in source order and

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -686,6 +686,25 @@ const (
 	// get the code point in numeric context. Lowers to
 	// `zext i32 to i64`.
 	IntrinsicCharToInt
+
+	// IntrinsicListSlice returns the half-open slice `list[start..end)`
+	// as a freshly allocated List<T>. Args: [list, start, end]. Routed
+	// by the `list[a..b]` / `list[a..=b]` index-expr sugar when the
+	// base is List<T>; the runtime `osty_rt_list_slice` is
+	// element-agnostic (byte-level memcpy off the elem_size header),
+	// so a single intrinsic kind covers every T. Inclusive ranges are
+	// pre-normalised at lowering time by adding 1 to `end`.
+	IntrinsicListSlice
+
+	// IntrinsicMapGetOr implements `map.getOr(key, default) -> V`.
+	// Args: [map, key, default]. Lowers to the present-flag variant
+	// of the runtime map_get helper (`get_<suffix>` returns bool and
+	// writes the value into an out slot), branching to the default
+	// operand on miss. Present directly as an intrinsic rather than
+	// as `map.get(key) ?? default` because the existing
+	// IntrinsicMapGet path emits the abort-on-miss runtime and a `??`
+	// over it would never see the default operand.
+	IntrinsicMapGetOr
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1664,6 +1683,10 @@ func (k IntrinsicKind) String() string {
 		return "byte_to_int"
 	case IntrinsicCharToInt:
 		return "char_to_int"
+	case IntrinsicListSlice:
+		return "list_slice"
+	case IntrinsicMapGetOr:
+		return "map_get_or"
 	}
 	return "invalid"
 }

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -701,9 +701,10 @@ const (
 	// of the runtime map_get helper (`get_<suffix>` returns bool and
 	// writes the value into an out slot), branching to the default
 	// operand on miss. Present directly as an intrinsic rather than
-	// as `map.get(key) ?? default` because the existing
-	// IntrinsicMapGet path emits the abort-on-miss runtime and a `??`
-	// over it would never see the default operand.
+	// as `map.get(key) ?? default` so the default operand is visible
+	// to the emitter without a separate `??` pass — this also avoids
+	// materialising an Option<V> struct and immediately unwrapping
+	// it, which `m.get(k) ?? d` would otherwise do.
 	IntrinsicMapGetOr
 )
 


### PR DESCRIPTION
## Summary

- `m.get(k)` in stdlib is `Map.get(self, key: K) -> V?`, but `IntrinsicMapGet` was lowering to `osty_rt_map_get_or_abort_<K>` — which aborts on miss. Latent bug uncovered by [#847](https://github.com/choiceoh/osty/pull/847): once MIR started lowering `m.get` (instead of punting to the AST HIR emitter), `m.get(k) ?? d` would have aborted on miss instead of returning `d`.
- Rewrite the emission to use the present-flag runtime `osty_rt_map_get_<K>(map, key, out) -> i1` and construct the `%Option.V = { i64 disc, i64 payload }` struct in-place — disc=0 via zeroinitializer on miss, disc=1 with the payload widened via `listOptionalPayloadToI64` on hit. No GC box; Option<V> stays on the stack.
- `m[k]` (IndexExpr) keeps the abort-on-miss path via `emitMapGetOrAbort` — different language-level semantics (§10: `m[k]` aborts, `m.get(k)` returns V?).
- Extract `emitMapGetProbe` — the `declareRuntime` + `alloca` + `call` + i1-present-flag prologue is shared byte-for-byte between `IntrinsicMapGet` and `IntrinsicMapGetOr`. Mirrors the existing `emitMapGetOrAbort` sharing precedent.

## Why

Without this fix, once the AST fallback path is removed (or any existing caller routes through MIR), `m.get(k) ?? d` becomes a miscompilation: the `??` default is unreachable because the program already aborted inside `IntrinsicMapGet`. The latent bug was flagged in [`project_bench_perf_backlog.md`](https://github.com/choiceoh/osty/blob/main/.claude/skills/bench/bench_perf_backlog.md) when #847 landed.

## Test plan

- [x] `TestGenerateFromMIRMapGetMethod` asserts the Option construction pattern (declare `i1`, some/none/end labels, `insertvalue %Option.i64 undef, i64 1, 0`, `store %Option.i64 zeroinitializer`), forbids the abort-variant runtime, and forbids `osty.gc.alloc_v1`.
- [x] `go test -short ./internal/llvmgen/ ./internal/mir/` green.
- [x] Smoke test: `m.get(k) ?? fallback` + `m.get(k).isSome()` through real `osty gen` pipeline confirmed correct IR emission, zero abort-variant calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)