### PR TITLE
feat(llvmgen): wire v0.6 A8 #[inline] through native-owned emit path

### DIFF
--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -1351,6 +1351,7 @@ func nativeFunctionFromIR(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (*llvmNat
 		returnType: retType,
 		params:     make([]*llvmNativeParam, 0, len(fn.Params)),
 		vectorize:  fn.Vectorize,
+		inlineMode: fn.InlineMode,
 	}
 	for _, param := range fn.Params {
 		if param == nil || param.IsDestructured() || param.Default != nil {
@@ -1421,7 +1422,8 @@ func nativeMethodFunctionFromIR(
 			irType:   llvmMethodReceiverIRType(ownerInfo.def.llvmType, fn.ReceiverMut),
 			byRef:    fn.ReceiverMut,
 		}},
-		vectorize: fn.Vectorize,
+		vectorize:  fn.Vectorize,
+		inlineMode: fn.InlineMode,
 	}
 	ctx.bindScopeName("self", nativeExprInfo{
 		kind:       nativeExprInfoStruct,

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -195,6 +195,7 @@ type llvmNativeFunction struct {
 	params     []*llvmNativeParam
 	body       *llvmNativeBlock
 	vectorize  bool
+	inlineMode int
 }
 
 type llvmNativeModule struct {
@@ -542,12 +543,58 @@ func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal,
 		retType = "void"
 	}
 	return llvmNativeRenderedFunction{
-		definition:    llvmRenderFunction(retType, fn.name, params, emitter.body),
+		definition:    llvmRenderFunctionWithAttrs(retType, fn.name, params, llvmNativeFnAttrString(fn), emitter.body),
 		stringGlobals: append([]*LlvmStringGlobal(nil), emitter.stringGlobals...),
 		nextStringID:  emitter.stringId,
 		loopMDDefs:    append([]string(nil), emitter.loopMDDefs...),
 		nextLoopMD:    emitter.nextLoopMD,
 	}
+}
+
+// llvmNativeInlineAttrKeyword mirrors toolchain/llvmgen.osty's
+// `llvmNativeInlineAttrKeyword`. Maps the v0.6 A8 `#[inline]` family
+// discriminant to the matching LLVM fn-attribute keyword; unknown
+// modes fall through to the empty string so the renderer produces the
+// attribute-free `define ... (...) {` shape.
+func llvmNativeInlineAttrKeyword(mode int) string {
+	switch mode {
+	case 1:
+		return "inlinehint"
+	case 2:
+		return "alwaysinline"
+	case 3:
+		return "noinline"
+	default:
+		return ""
+	}
+}
+
+// llvmNativeFnAttrString mirrors toolchain/llvmgen.osty's
+// `llvmNativeFnAttrString`. Assembles the fn-attribute string spliced
+// between `)` and `{` on a `llvmNativeFunction`'s `define` line.
+func llvmNativeFnAttrString(fn *llvmNativeFunction) string {
+	if fn == nil {
+		return ""
+	}
+	return llvmNativeInlineAttrKeyword(fn.inlineMode)
+}
+
+// llvmRenderFunctionWithAttrs mirrors toolchain/llvmgen.osty's
+// `llvmRenderFunctionWithAttrs`. Renders a function `define` line
+// with an optional fn-attribute string spliced between the parameter
+// list's closing paren and the opening brace. `fnAttrs == ""` produces
+// output byte-identical to `llvmRenderFunction`.
+func llvmRenderFunctionWithAttrs(ret string, name string, params []*LlvmParam, fnAttrs string, body []string) string {
+	var header string
+	if fnAttrs == "" {
+		header = fmt.Sprintf("define %s @%s(%s) {", ret, name, llvmParams(params))
+	} else {
+		header = fmt.Sprintf("define %s @%s(%s) %s {", ret, name, llvmParams(params), fnAttrs)
+	}
+	lines := []string{header, "entry:"}
+	lines = append(lines, body...)
+	lines = append(lines, "}")
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func llvmNativeBindGlobals(emitter *LlvmEmitter, globals []*llvmNativeGlobal) {

--- a/internal/llvmgen/native_inline_attr_test.go
+++ b/internal/llvmgen/native_inline_attr_test.go
@@ -1,0 +1,79 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNativeOwnedModuleInlineAlwaysAttrOnDefineLine pins the v0.6 A8
+// `#[inline(always)]` emission on the IR → MIR → native projection
+// path. The HIR-based emitter is covered by fn_attrs_test.go; this
+// test ensures the native slice (toolchain/llvmgen.osty +
+// native_entry_snapshot.go) picks up the same discriminant from
+// `FnDecl.InlineMode` and splices `alwaysinline` into the `define`
+// line produced by `llvmRenderFunctionWithAttrs`.
+func TestNativeOwnedModuleInlineAlwaysAttrOnDefineLine(t *testing.T) {
+	src := `#[inline(always)]
+fn tiny(n: Int) -> Int { n + 1 }
+
+fn main() {
+    let _ = tiny(42)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	nativeMod, ok := nativeModuleFromIR(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_inline_always.osty",
+	})
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for #[inline(always)] tiny()")
+	}
+	got := renderNativeOwnedModuleText(nativeMod)
+	idx := strings.Index(got, "define i64 @tiny(")
+	if idx < 0 {
+		t.Fatalf("define line for tiny not found in native IR:\n%s", got)
+	}
+	lineEnd := strings.IndexByte(got[idx:], '\n')
+	if lineEnd < 0 {
+		t.Fatalf("define line has no newline terminator:\n%s", got[idx:])
+	}
+	defineLine := got[idx : idx+lineEnd]
+	if !strings.Contains(defineLine, "alwaysinline") {
+		t.Fatalf("native-path tiny define line missing `alwaysinline`:\n  %s", defineLine)
+	}
+}
+
+// TestNativeOwnedModuleInlineNoneStaysClean is the negative control:
+// a fn without any inline annotation must produce the attribute-free
+// `define ... (...) {` shape on the native path — confirms the
+// fnAttrs == "" branch of `llvmRenderFunctionWithAttrs` byte-matches
+// legacy output.
+func TestNativeOwnedModuleInlineNoneStaysClean(t *testing.T) {
+	src := `fn plain(n: Int) -> Int { n + 1 }
+
+fn main() {
+    let _ = plain(42)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	nativeMod, ok := nativeModuleFromIR(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_inline_none.osty",
+	})
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for plain()")
+	}
+	got := renderNativeOwnedModuleText(nativeMod)
+	idx := strings.Index(got, "define i64 @plain(")
+	if idx < 0 {
+		t.Fatalf("define line for plain not found in native IR:\n%s", got)
+	}
+	lineEnd := strings.IndexByte(got[idx:], '\n')
+	if lineEnd < 0 {
+		t.Fatalf("define line has no newline terminator:\n%s", got[idx:])
+	}
+	defineLine := got[idx : idx+lineEnd]
+	if !strings.HasSuffix(defineLine, ") {") {
+		t.Fatalf("unannotated plain() define line should end `) {` (no attrs), got:\n  %s", defineLine)
+	}
+}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1280,6 +1280,62 @@ pub struct LlvmNativeFunction {
     pub returnType: String,
     pub params: List<LlvmNativeParam>,
     pub body: LlvmNativeBlock,
+    /// v0.6 A8 `#[inline]` family: 0=none, 1=inlinehint, 2=alwaysinline,
+    /// 3=noinline. Mirrors `ir.FnDecl.InlineMode` in the Go HIR.
+    pub inlineMode: Int,
+}
+
+/// Translate a `LlvmNativeFunction.inlineMode` discriminant into the
+/// corresponding LLVM fn-attribute keyword. Mirrors the HIR emitter's
+/// `formatFnAttrs` switch — values here are the authoritative v0.6 A8
+/// mapping (`InlineSoft`/`InlineAlways`/`InlineNever`). Unknown modes
+/// fall through to the empty string so the renderer produces the
+/// attribute-free `define ... (...) \{` shape.
+pub fn llvmNativeInlineAttrKeyword(mode: Int) -> String {
+    if mode == 1 {
+        "inlinehint"
+    } else if mode == 2 {
+        "alwaysinline"
+    } else if mode == 3 {
+        "noinline"
+    } else {
+        ""
+    }
+}
+
+/// Assemble the fn-attribute string spliced between `)` and `\{` on a
+/// `LlvmNativeFunction`'s `define` line. Currently only the A8 inline
+/// family contributes; future v0.6 annotations (hot/cold/pure/target
+/// features/noalias) land in this helper as they gain Osty-emitter
+/// coverage so all callers stay on one call shape.
+pub fn llvmNativeFnAttrString(function: LlvmNativeFunction) -> String {
+    llvmNativeInlineAttrKeyword(function.inlineMode)
+}
+
+/// Variant of `llvmRenderFunction` that splices a fn-attribute string
+/// (e.g. `"alwaysinline"`, `"readnone"`) between the parameter list's
+/// closing paren and the body-opening brace. `fnAttrs == ""` produces
+/// output byte-identical to `llvmRenderFunction` so the attribute-free
+/// path stays on a stable shape. Lives inside the native-owned entry
+/// slice because only the IR-projected emitter consumes it today.
+pub fn llvmRenderFunctionWithAttrs(
+    ret: String,
+    name: String,
+    params: List<LlvmParam>,
+    fnAttrs: String,
+    body: List<String>,
+) -> String {
+    let header = if fnAttrs == "" {
+        "define {ret} @{name}({llvmParams(params)}) \{"
+    } else {
+        "define {ret} @{name}({llvmParams(params)}) {fnAttrs} \{"
+    }
+    let mut lines = [header, "entry:"]
+    for line in body {
+        lines.push(line)
+    }
+    lines.push("\}")
+    llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
 }
 
 pub struct LlvmNativeModule {
@@ -1410,10 +1466,11 @@ pub fn llvmNativeEmitFunction(
             }
         }
         return LlvmNativeRenderedFunction {
-            definition: llvmRenderFunction(
+            definition: llvmRenderFunctionWithAttrs(
                 if function.returnType == "" { "void" } else { function.returnType },
                 function.name,
                 [],
+                llvmNativeFnAttrString(function),
                 emitter.body,
             ),
             stringGlobals: emitter.stringGlobals,
@@ -1481,10 +1538,11 @@ pub fn llvmNativeEmitFunction(
         }
     }
     return LlvmNativeRenderedFunction {
-        definition: llvmRenderFunction(
+        definition: llvmRenderFunctionWithAttrs(
             if function.returnType == "" { "void" } else { function.returnType },
             function.name,
             params,
+            llvmNativeFnAttrString(function),
             emitter.body,
         ),
         stringGlobals: emitter.stringGlobals,


### PR DESCRIPTION
## Summary

- Native-owned emitter (`toolchain/llvmgen.osty` + the `native_entry_snapshot.go` hand-mirror) now honors the v0.6 A8 `#[inline]` family on the IR→MIR→native path, matching what the HIR emitter already does for the Go-owned path.
- Functions routed through the native projection previously dropped `FnDecl.InlineMode`, so `#[inline(always)]`, `#[inline]`, `#[inline(never)]` were silently no-ops for covered shapes; this closes that gap.

## What changed

- **`toolchain/llvmgen.osty`**
  - `LlvmNativeFunction` carries `inlineMode: Int` (mirrors `ir.FnDecl.InlineMode`).
  - New `llvmNativeInlineAttrKeyword` / `llvmNativeFnAttrString` / `llvmRenderFunctionWithAttrs` placed **inside the native-owned stripped slice** so the support-snapshot transpiler doesn't chase `LlvmNativeFunction` across stripped/non-stripped regions.
  - `llvmRenderFunction` stays self-contained (4-arg) — 90+ legacy test call sites untouched.
  - Production `llvmNativeEmitFunction` paths splice `llvmNativeFnAttrString(function)` into the `define` line via `llvmRenderFunctionWithAttrs`.
- **`internal/llvmgen/native_entry_snapshot.go`**: hand-mirrors the three new Osty helpers; `llvmNativeEmitFunction` rewired to the attr-aware render call.
- **`internal/llvmgen/ir_native_entry.go`**: projector wires `out.inlineMode = fn.InlineMode` in both `nativeFunctionFromIR` and `nativeMethodFunctionFromIR`.
- **`internal/llvmgen/native_inline_attr_test.go`** (new): pins `alwaysinline` on the `define` line for `#[inline(always)] fn tiny()` on the native path; negative control asserts unannotated fns still end `) {` (byte-identical to legacy shape).

## Why this placement

`llvmRenderFunctionWithAttrs` could have lived in the non-stripped region alongside `llvmRenderFunction`, but it's only consumed by the IR-projected emitter. Placing it inside the stripped slice keeps the support-snapshot regen clean of a helper that would never be called from the generated bundle, and avoids a cross-region type reference (`LlvmNativeFunction` only exists inside the stripped slice).

## Not in this PR

- Hot/cold, target-feature, noalias, pure, unroll, parallel on the native path. Same wiring pattern will apply, scoped to a follow-up PR per attribute family to keep diffs reviewable.
- The pre-existing `TestGoGenerateSupportSnapshotIsFixedPoint` regen drift — confirmed independent of this change (re-ran regen on a clean stash: same failure, unrelated symbols).

## Test plan

- [x] `go test ./internal/llvmgen/ -short -count=1` — pass (13s).
- [x] `just front` — all 8 packages pass.
- [x] New `TestNativeOwnedModuleInlineAlwaysAttrOnDefineLine` + `TestNativeOwnedModuleInlineNoneStaysClean` — pass.
- [x] Existing HIR-path `TestInlineAlwaysEmitsAttr` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)