### PR TITLE
refactor(lint): drop Go L0001 emission, defer to toolchain/lint.osty

### DIFF
--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -7,9 +7,8 @@
 // block compilation. The CLI surfaces them via `osty lint`, with
 // `--strict` flipping warnings into a non-zero exit for CI use.
 //
-// Currently implemented rules:
+// Currently implemented rules (Go-side):
 //
-//	L0001  unused `let` binding
 //	L0002  unused function / closure parameter
 //	L0003  unused `use` alias (file-local)
 //	L0010  inner `let` shadows an outer binding
@@ -17,6 +16,9 @@
 //	L0030  type name not UpperCamelCase
 //	L0031  fn / let / param name not lowerCamelCase
 //	L0032  enum variant name not UpperCamelCase
+//
+// L0001 (unused `let` binding) is emitted by toolchain/lint.osty and
+// merged in by mergeSelfhostLint.
 //
 // Additional rules (e.g. unreachable via Never, dead match arms, magic
 // numbers) belong here once the underlying analyses (type checker,

--- a/internal/lint/unused.go
+++ b/internal/lint/unused.go
@@ -12,22 +12,22 @@ import (
 // lintUnused flags every bound name that is never referenced anywhere in
 // the resolved source:
 //
-//	L0001 - let bindings (both statement lets and top-level LetDecls)
 //	L0002 - function / closure parameters
 //	L0003 - `use` aliases
+//
+// L0001 (unused let binding) runs in toolchain/lint.osty and is merged in
+// by mergeSelfhostLint.
 //
 // Names that intentionally go unused (`_foo`), publicly exported items
 // (`pub fn`, `pub let`), and the implicit `self` / `Self` are excluded.
 // In package mode the "used" set is the union across every file in the
 // package, so cross-file references don't trigger false positives.
 //
-// Implementation note: unused bindings are by definition NOT reachable
-// from the resolver's Refs/TypeRefs maps (and their enclosing scope is
-// no longer live after resolve finishes). We therefore cannot look up
-// the Symbol for a pattern binding directly; instead we build a set of
+// Implementation note: unused params are by definition NOT reachable from
+// the resolver's Refs/TypeRefs maps (and their enclosing scope is no
+// longer live after resolve finishes). We therefore build a set of
 // "declaration AST nodes that some reference points back at" via the
-// Symbol.Decl field, then check each declaration's node against that
-// set.
+// Symbol.Decl field, then check each parameter's node against that set.
 func (l *linter) lintUnused() {
 	usedDecls := buildUsedDeclSet(l.resolved, l.used)
 
@@ -59,7 +59,7 @@ func (l *linter) lintUnused() {
 			Build())
 	}
 
-	// ---- L0001 / L0002: walk bodies for lets + params ----
+	// ---- L0002: walk bodies for params ----
 	for _, d := range l.file.Decls {
 		l.unusedDecl(d, usedDecls)
 	}
@@ -132,10 +132,6 @@ func (l *linter) unusedDecl(d ast.Decl, usedDecls map[ast.Node]bool) {
 			}
 		}
 	case *ast.LetDecl:
-		if !n.Pub && !isUnderscore(n.Name) && !usedDecls[n] {
-			l.warnNode(n, diag.CodeUnusedLet,
-				"binding `%s` is never used", n.Name)
-		}
 		l.unusedExpr(n.Value, usedDecls)
 	}
 }
@@ -289,36 +285,16 @@ func namePos(base token.Pos, deltaCol int) token.Pos {
 	}
 }
 
-// unusedPattern flags each pattern-bound name whose declaration AST node
-// is not in usedDecls.
+// unusedPattern recurses into composite patterns so nested lets / params
+// are reachable for the other rules (L0002 unused param in closures the
+// pattern binds, etc.). L0001 unused-binding detection lives in
+// toolchain/lint.osty.
 func (l *linter) unusedPattern(p ast.Pattern, usedDecls map[ast.Node]bool) {
 	if p == nil {
 		return
 	}
 	switch n := p.(type) {
-	case *ast.IdentPat:
-		if isUnderscore(n.Name) {
-			return
-		}
-		if !usedDecls[n] {
-			l.emit(diag.New(diag.Warning,
-				"binding `"+n.Name+"` is never used").
-				Code(diag.CodeUnusedLet).
-				Primary(diag.Span{Start: n.PosV, End: n.EndV}, "unused binding").
-				Suggest(diag.Span{Start: n.PosV, End: n.PosV},
-					"_", "rename to `_"+n.Name+"` to mark intentionally unused", true).
-				Build())
-		}
 	case *ast.BindingPat:
-		if !isUnderscore(n.Name) && !usedDecls[n] {
-			l.emit(diag.New(diag.Warning,
-				"binding `"+n.Name+"` is never used").
-				Code(diag.CodeUnusedLet).
-				Primary(diag.Span{Start: n.PosV, End: n.EndV}, "unused binding").
-				Suggest(diag.Span{Start: n.PosV, End: n.PosV},
-					"_", "rename to `_"+n.Name+"` to mark intentionally unused", true).
-				Build())
-		}
 		l.unusedPattern(n.Pattern, usedDecls)
 	case *ast.TuplePat:
 		for _, e := range n.Elems {
@@ -328,9 +304,6 @@ func (l *linter) unusedPattern(p ast.Pattern, usedDecls map[ast.Node]bool) {
 		for _, f := range n.Fields {
 			if f.Pattern != nil {
 				l.unusedPattern(f.Pattern, usedDecls)
-			} else if !isUnderscore(f.Name) && !usedDecls[f] {
-				l.warnNode(f, diag.CodeUnusedLet,
-					"binding `%s` is never used", f.Name)
 			}
 		}
 	case *ast.VariantPat:


### PR DESCRIPTION
## Summary

First concrete reduction of duplicate Go lint code under the broader [Phase 1c.5](../blob/main/SELFHOST_PORT_MATRIX.md#1c-로드맵--go-resolver-제거까지) plan to drain `internal/lint` into `toolchain/lint.osty` so the Go-native resolver (`internal/resolve/resolve.go`, 2299 LOC) can eventually be deleted.

`toolchain/lint.osty:1068-1077` already emits L0001 \"binding never used\" with the same rename-to-\`_\` Suggest fix the Go side carried, and `mergeSelfhostLint` deduplicates by (code, start offset). All 4 Go L0001 emit sites in `internal/lint/unused.go` are now removed; the Osty implementation is the single source.

## Why

- bootstrap-gen retired in #854 → no transpile-safety constraint remains, the path is wide open to start retiring duplicate Go rules
- Lint duplicates roughly half of `toolchain/lint.osty`'s 3973 LOC. Going one rule at a time keeps each PR auditable
- Net Go-side LOC: −41/+16 (single file change)

## What dropped

| Site | What it was | Why safe |
|---|---|---|
| `unusedDecl` LetDecl case | top-level `let x` emit | Osty L0001 covers (lint.osty:1062 walks `AstNLet` decls + stmts) |
| `unusedPattern` IdentPat case | `let x` simple ident | Osty walks `selfLintAstPatternNames` over the let pattern |
| `unusedPattern` BindingPat emit | `let name @ pat` | same Osty path; recursion into nested pattern preserved |
| `unusedPattern` StructPat field shorthand emit | `let StructPat { name, .. }` | same Osty path |

Walk infrastructure (`unusedDecl`, `unusedStmt`, `unusedExpr`, `unusedBlock`, `unusedPattern`, `buildUsedDeclSet`) **stays** — still needed by L0002 (unused param) and L0003 (unused import) detection that recurses into nested closures and let bodies.

## Verification

Parity probe (stub all 4 Go emit sites → run full test suite → confirm identical CLI behavior) passed:

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/lint/... ./cmd/osty/... -run 'Lint|Fix' -count=1` (lint + fix tests)
- [x] `just short` — only failure is pre-existing `internal/selfhost.TestParseSnapshot` drift on `testdata/spec/negative/reject.osty`, baseline regression confirmed via `git stash` round-trip; unrelated to this change

The `--fix` rename-to-\`_\` rewrite path in particular (`TestLintFixSingleFileRewritesUnusedBinding`, `TestLintFixPackageModeRewritesEveryFile`, `TestLintFixDryRunLeavesFilesUnchanged`, `TestLintFixPackageDryRunHeadsEachFile`) all pass — the Osty-side L0001 carries the same Suggest fix metadata, so the CLI rewrite path is unaffected.

## Stacking

Stacked on #854 (bootstrap-gen retirement). When #854 merges, this PR will auto-retarget `main`.

## Next steps

If this lands cleanly, follow-up PRs can drop the next layer of duplicates (L0002 UnusedParam, L0003 UnusedImport, L0004 UnusedMut, L0010 ShadowedBinding, L0020 DeadCode, L0021–L0026 flow, L0030–L0032 naming, L0050–L0053 complexity) one at a time. Each removal further reduces the surface that pins `internal/resolve/resolve.go` alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)