### PR TITLE
feat(selfhost): port §1/§11/§14 pure helpers from mir_generator.go

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -53,7 +53,7 @@ untouched.
 
 | § | Section | Lines | Funcs | Risk | Status |
 | - | ------- | ----- | ----- | ---- | ------ |
-| 1 | generator state | 100–472 | ~10 | LOW | Go-only — partial helpers (`firstNonEmpty`) ported |
+| 1 | generator state | 100–472 | ~10 | LOW | Partial — `firstNonEmpty`, `formatFnAttrs`, `loopHintsActive`, + loop-metadata constant templates ported (`mirFormatFnAttrs`, `mirLoopHintsActive`, `mirLoopMDVectorizeEnable`/`Scalable`/`Predicate`/`Width`, `mirLoopMDUnrollEnable`/`Count`, `mirLoopMDParallelAccesses`); state-touching (`nextLoopMD` body, `listAliasScopeRef`, `nextAccessGroupMD`) deferred to Phase B |
 | 2 | support check | 473–1364 | ~20 | MEDIUM | Go-only |
 | 3 | header + runtime declares | 1365–1641 | ~8 | LOW | Go-only |
 | 4 | function emission | 1642–2384 | ~18 | MEDIUM | Go-only |
@@ -63,10 +63,10 @@ untouched.
 | 8 | concurrency intrinsics | 6762–7472 | ~20 | MEDIUM | Go-only |
 | 9 | terminators | 7473–7595 | ~5 | LOW | Go-only |
 | 10 | rvalue / operand | 7596–8937 | ~25 | HIGH | Go-only |
-| 11 | operators | 8938–9196 | ~12 | LOW | Partial — `isHeapEqualityType`, `isStringPrimType`, `isStringOrderingBinOp`, `stringOrderingPredicate` ported |
+| 11 | operators | 8938–9196 | ~12 | LOW | Partial — predicates + `emitBinary` opcode table ported (`isHeapEqualityType`, `isStringPrimType`, `isStringOrderingBinOp`, `stringOrderingPredicate`, `mirBinaryOpcode`, `mirBinaryForcesI1Type`); `emitUnary` / `emitInlineStringEqLiteral` deferred (touch `g.fresh` / `g.fnBuf`) |
 | 12 | strings | 9197–9284 | ~7 | LOW | Partial — `encodeLLVMString` / `earliestAfter` ported |
 | 13 | type mapping | 9285–9375 | ~8 | LOW | **Ported** (primitive + opaque-named + head-name + optional-surface) |
-| 14 | enum layout helpers | 9376–9575 | ~10 | LOW | Go-only |
+| 14 | enum layout helpers | 9376–9575 | ~10 | LOW | Partial — `llvmTypeForTupleTag` Prim / Named branches + Optional / Option / Result / Tuple name-mangling ported (`mirTupleTagForPrim`, `mirTupleTagForNamed`, `mirOptionalTypeName`, `mirOptionTypeName`, `mirResultTypeName`, `mirTupleTypeNameFromTags`); `registerEnumLayout` + `g.tupleDefs` caches deferred to Phase B |
 | 15 | helpers | 9576–9616 | ~5 | LOW | Partial — `firstNonEmpty`, `isUnitType`, `isFloatType`, `isScalarLLVMType`, `llvmStdIoI1Text` ported |
 
 ## Phased plan
@@ -164,6 +164,23 @@ list keeps new Osty clean of known landmines.
 | `mirFirstNonEmpty` | `(vals: List<String>) -> String` | §1 | variadic-erased first-non-empty |
 | `mirEarliestAfter` | `(input: String, needle: String) -> Int` | §12 | wrapper around `llvmStrings.Index` |
 | `mirEncodeLLVMString` | `(s: String) -> String` | §12 | printable-ASCII LLVM literal escaper |
+| `mirTupleTagForPrim` | `(name: String) -> String` | §14 | Prim branch of `llvmTypeForTupleTag` — `"Float64"` → `"f64"`, `"String"` → `"string"`, `"()"` → `"unit"`; returns `""` for unknown kinds so caller falls through to `"opaque"` |
+| `mirTupleTagForNamed` | `(name: String, builtin: Bool) -> String` | §14 | NamedType branch — collapses builtin collection handles + concurrency runtime types to `"ptr"`, otherwise preserves the declared name |
+| `mirOptionalTypeName` | `(innerTag: String) -> String` | §14 | `"Option." + innerTag` — surface-`T?` mangled name |
+| `mirOptionTypeName` | `(innerTag: String) -> String` | §14 | Named `Option<T>` — `""` tag means bare `"Option"`, otherwise mirrors `mirOptionalTypeName` |
+| `mirResultTypeName` | `(okTag: String, errTag: String) -> String` | §14 | `Result` / `Result.<Ok>` / `Result.<Ok>.<Err>` — empty tags drop trailing components |
+| `mirTupleTypeNameFromTags` | `(tags: List<String>) -> String` | §14 | `"Tuple." + tags.join(".")` — matches the Go source byte-for-byte including the `"Tuple."` trailing-dot on an empty tuple |
+| `mirBinaryOpcode` | `(symbol: String, isFloat: Bool) -> String` | §11 | 19-branch opcode + icmp/fcmp predicate table keyed on `BinaryOp.String()`; returns `""` on miss so caller stays on the unsupported diagnostic |
+| `mirBinaryForcesI1Type` | `(symbol: String) -> Bool` | §11 | `&&` / `\|\|` force operand type to `"i1"` instead of argLLVM — complement to `mirBinaryOpcode` |
+| `mirLoopHintsActive` | `(vectorizeHint: Bool, parallelHint: Bool, unrollHint: Bool) -> Bool` | §1 | OR of the v0.6 loop annotation flags |
+| `mirLoopMDVectorizeEnable` | `() -> String` | §1 | `!{!"llvm.loop.vectorize.enable", i1 true}` body — A5 opt-in literal |
+| `mirLoopMDVectorizeScalable` | `() -> String` | §1 | `!{!"llvm.loop.vectorize.scalable.enable", i1 true}` body — A5.1 SVE toggle |
+| `mirLoopMDVectorizePredicate` | `() -> String` | §1 | `!{!"llvm.loop.vectorize.predicate.enable", i1 true}` body — A5.1 tail-folding toggle |
+| `mirLoopMDUnrollEnable` | `() -> String` | §1 | `!{!"llvm.loop.unroll.enable", i1 true}` body — bare `#[unroll]` |
+| `mirLoopMDVectorizeWidth` | `(widthDigits: String) -> String` | §1 | `!{!"llvm.loop.vectorize.width", i32 <digits>}` body — caller pre-formats the Int |
+| `mirLoopMDUnrollCount` | `(countDigits: String) -> String` | §1 | `!{!"llvm.loop.unroll.count", i32 <digits>}` body — caller pre-formats the Int |
+| `mirLoopMDParallelAccesses` | `(accessGroupRef: String) -> String` | §1 | `!{!"llvm.loop.parallel_accesses", <ref>}` body — A6 group reference |
+| `mirFormatFnAttrs` | `(inlineMode: Int, hot: Bool, cold: Bool, pureFn: Bool, targetFeatures: List<String>) -> String` | §1 | Space-joined v0.6 A8/A9/A10/A13 fn-attr string — `inlinehint`/`alwaysinline`/`noinline` + `hot`/`cold`/`readnone` + `"target-features"="+f1,+f2"` |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -264,43 +264,11 @@ func newMIRGen(m *mir.Module, opts Options) *mirGen {
 //
 // The set handled here is the exact mirror of the IR FnDecl fields
 // ir.Lower populates from annotations — InlineMode, Hot, Cold,
-// TargetFeatures. Shared across MIR and HIR emitters via the legacy
-// bridge's reified annotation list on the HIR side.
+// Pure, TargetFeatures. Delegates to the Osty-sourced
+// `mirFormatFnAttrs` helper (`toolchain/mir_generator.osty`) so the
+// attribute-name table has a single source of truth.
 func formatFnAttrs(fn *mir.Function) string {
-	parts := make([]string, 0, 5)
-	switch fn.InlineMode {
-	case 1: // InlineSoft
-		parts = append(parts, "inlinehint")
-	case 2: // InlineAlways
-		parts = append(parts, "alwaysinline")
-	case 3: // InlineNever
-		parts = append(parts, "noinline")
-	}
-	if fn.Hot {
-		parts = append(parts, "hot")
-	}
-	if fn.Cold {
-		parts = append(parts, "cold")
-	}
-	if fn.Pure {
-		// v0.6 A13 `#[pure]` → LLVM `readnone`: function reads no
-		// memory and has no side effects. Enables caller-side CSE.
-		parts = append(parts, "readnone")
-	}
-	if len(fn.TargetFeatures) > 0 {
-		prefixed := make([]string, len(fn.TargetFeatures))
-		for i, f := range fn.TargetFeatures {
-			// LLVM's target-features string expects each feature
-			// prefixed with `+` for enable or `-` for disable. The
-			// v0.6 annotation set only supports enable, so we
-			// always prepend `+`. Features the user typed with a
-			// leading `+` are tolerated by stripping it first.
-			prefixed[i] = "+" + strings.TrimPrefix(f, "+")
-		}
-		parts = append(parts,
-			fmt.Sprintf(`"target-features"="%s"`, strings.Join(prefixed, ",")))
-	}
-	return strings.Join(parts, " ")
+	return mirFormatFnAttrs(fn.InlineMode, fn.Hot, fn.Cold, fn.Pure, fn.TargetFeatures)
 }
 
 // noaliasNameSet builds a lookup set of parameter names that should
@@ -374,28 +342,28 @@ func (g *mirGen) nextLoopMD() string {
 	}
 
 	if g.vectorizeHint {
-		propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.enable", i1 true}`))
+		propRefs = append(propRefs, alloc(mirLoopMDVectorizeEnable()))
 		if g.vectorizeWidth > 0 {
 			propRefs = append(propRefs, alloc(
-				fmt.Sprintf(`!{!"llvm.loop.vectorize.width", i32 %d}`, g.vectorizeWidth)))
+				mirLoopMDVectorizeWidth(strconv.Itoa(g.vectorizeWidth))))
 		}
 		if g.vectorizeScalable {
-			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.scalable.enable", i1 true}`))
+			propRefs = append(propRefs, alloc(mirLoopMDVectorizeScalable()))
 		}
 		if g.vectorizePredicate {
-			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.predicate.enable", i1 true}`))
+			propRefs = append(propRefs, alloc(mirLoopMDVectorizePredicate()))
 		}
 	}
 	if g.parallelHint && g.parallelAccessGroupRef != "" {
 		propRefs = append(propRefs, alloc(
-			fmt.Sprintf(`!{!"llvm.loop.parallel_accesses", %s}`, g.parallelAccessGroupRef)))
+			mirLoopMDParallelAccesses(g.parallelAccessGroupRef)))
 	}
 	if g.unrollHint {
 		if g.unrollCount > 0 {
 			propRefs = append(propRefs, alloc(
-				fmt.Sprintf(`!{!"llvm.loop.unroll.count", i32 %d}`, g.unrollCount)))
+				mirLoopMDUnrollCount(strconv.Itoa(g.unrollCount))))
 		} else {
-			propRefs = append(propRefs, alloc(`!{!"llvm.loop.unroll.enable", i1 true}`))
+			propRefs = append(propRefs, alloc(mirLoopMDUnrollEnable()))
 		}
 	}
 	if len(propRefs) == 0 {
@@ -451,7 +419,7 @@ func (g *mirGen) nextAccessGroupMD() string {
 // back-edges. Covers vectorize/parallel/unroll without re-listing the
 // individual field names at every call site.
 func (g *mirGen) loopHintsActive() bool {
-	return g.vectorizeHint || g.parallelHint || g.unrollHint
+	return mirLoopHintsActive(g.vectorizeHint, g.parallelHint, g.unrollHint)
 }
 
 // emitLoopMetadata appends every `!llvm.loop` node + vectorize-enable
@@ -9199,98 +9167,30 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 		return g.emitStringOrdering(op, left, right)
 	}
 	argLLVM := g.llvmType(argT)
-	resLLVM := g.llvmType(resT)
+	_ = g.llvmType(resT)
 	isFloat := isFloatType(argT)
+	sym := op.String()
+	opcode := mirBinaryOpcode(sym, isFloat)
+	if opcode == "" {
+		return "", unsupported("mir-mvp", fmt.Sprintf("binary op %d", op))
+	}
+	ty := argLLVM
+	if mirBinaryForcesI1Type(sym) {
+		ty = "i1"
+	}
 	tmp := g.fresh()
-
-	render := func(opStr string, ty string) (string, error) {
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(" = ")
-		g.fnBuf.WriteString(opStr)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(ty)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(left)
-		g.fnBuf.WriteString(", ")
-		g.fnBuf.WriteString(right)
-		g.fnBuf.WriteByte('\n')
-		return tmp, nil
-	}
-
-	switch op {
-	case mir.BinAdd:
-		if isFloat {
-			return render("fadd", argLLVM)
-		}
-		return render("add", argLLVM)
-	case mir.BinSub:
-		if isFloat {
-			return render("fsub", argLLVM)
-		}
-		return render("sub", argLLVM)
-	case mir.BinMul:
-		if isFloat {
-			return render("fmul", argLLVM)
-		}
-		return render("mul", argLLVM)
-	case mir.BinDiv:
-		if isFloat {
-			return render("fdiv", argLLVM)
-		}
-		return render("sdiv", argLLVM)
-	case mir.BinMod:
-		if isFloat {
-			return render("frem", argLLVM)
-		}
-		return render("srem", argLLVM)
-	case mir.BinEq:
-		if isFloat {
-			return render("fcmp oeq", argLLVM)
-		}
-		return render("icmp eq", argLLVM)
-	case mir.BinNeq:
-		if isFloat {
-			return render("fcmp one", argLLVM)
-		}
-		return render("icmp ne", argLLVM)
-	case mir.BinLt:
-		if isFloat {
-			return render("fcmp olt", argLLVM)
-		}
-		return render("icmp slt", argLLVM)
-	case mir.BinLeq:
-		if isFloat {
-			return render("fcmp ole", argLLVM)
-		}
-		return render("icmp sle", argLLVM)
-	case mir.BinGt:
-		if isFloat {
-			return render("fcmp ogt", argLLVM)
-		}
-		return render("icmp sgt", argLLVM)
-	case mir.BinGeq:
-		if isFloat {
-			return render("fcmp oge", argLLVM)
-		}
-		return render("icmp sge", argLLVM)
-	case mir.BinAnd:
-		return render("and", "i1")
-	case mir.BinOr:
-		return render("or", "i1")
-	case mir.BinBitAnd:
-		return render("and", argLLVM)
-	case mir.BinBitOr:
-		return render("or", argLLVM)
-	case mir.BinBitXor:
-		return render("xor", argLLVM)
-	case mir.BinShl:
-		return render("shl", argLLVM)
-	case mir.BinShr:
-		return render("ashr", argLLVM)
-	}
-	_ = resLLVM
-	return "", unsupported("mir-mvp", fmt.Sprintf("binary op %d", op))
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(tmp)
+	g.fnBuf.WriteString(" = ")
+	g.fnBuf.WriteString(opcode)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(ty)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(left)
+	g.fnBuf.WriteString(", ")
+	g.fnBuf.WriteString(right)
+	g.fnBuf.WriteByte('\n')
+	return tmp, nil
 }
 
 // isHeapEqualityType reports whether MIR `==` / `!=` on values of type t
@@ -9709,23 +9609,23 @@ func (g *mirGen) llvmType(t mir.Type) string {
 // ==== enum layout helpers ====
 
 // optionalTypeName returns a mangled `Option.<T>` name for a surface
-// `T?` optional. The layout is always `{ i64 disc, <payload> }` where
-// payload is the inner's LLVM type promoted to a slot-sized value.
+// `T?` optional. The pure mangling step delegates to the Osty-sourced
+// `mirOptionalTypeName`; `registerEnumLayout` stays on Go because it
+// mutates `g.enumLayouts` module state.
 func (g *mirGen) optionalTypeName(t *ir.OptionalType) string {
-	name := "Option." + g.llvmTypeForTupleTag(t.Inner)
+	name := mirOptionalTypeName(g.llvmTypeForTupleTag(t.Inner))
 	g.registerEnumLayout(name, t.Inner)
 	return name
 }
 
 func (g *mirGen) optionTypeName(t *ir.NamedType) string {
 	inner := mir.Type(nil)
+	innerTag := ""
 	if len(t.Args) > 0 {
 		inner = t.Args[0]
+		innerTag = g.llvmTypeForTupleTag(inner)
 	}
-	name := "Option"
-	if inner != nil {
-		name = "Option." + g.llvmTypeForTupleTag(inner)
-	}
+	name := mirOptionTypeName(innerTag)
 	g.registerEnumLayout(name, inner)
 	return name
 }
@@ -9734,15 +9634,16 @@ func (g *mirGen) optionTypeName(t *ir.NamedType) string {
 // i64 width and Err payload (usually an Error ptr) reuses it via
 // bitcast — matching the legacy emitter's `%Result.T.E` convention.
 func (g *mirGen) resultTypeName(t *ir.NamedType) string {
-	name := "Result"
 	var inner mir.Type
+	okTag, errTag := "", ""
 	if len(t.Args) >= 1 {
 		inner = t.Args[0]
-		name = "Result." + g.llvmTypeForTupleTag(t.Args[0])
+		okTag = g.llvmTypeForTupleTag(t.Args[0])
 		if len(t.Args) >= 2 {
-			name += "." + g.llvmTypeForTupleTag(t.Args[1])
+			errTag = g.llvmTypeForTupleTag(t.Args[1])
 		}
 	}
+	name := mirResultTypeName(okTag, errTag)
 	g.registerEnumLayout(name, inner)
 	return name
 }
@@ -9763,14 +9664,15 @@ func (g *mirGen) registerEnumLayout(name string, inner mir.Type) {
 
 // tupleName returns the mangled LLVM type name for a tuple and
 // ensures its type definition is emitted at least once per module.
-// Keeping the naming scheme in sync with the legacy emitter
-// (`Tuple.<elem1>.<elem2>.…`) makes it easier to cross-check output.
+// The mangling step delegates to the Osty-sourced
+// `mirTupleTypeNameFromTags`; tuple layout registration stays on Go
+// because it mutates `g.tupleDefs` / `g.tupleOrder` module state.
 func (g *mirGen) tupleName(t *ir.TupleType) string {
-	var parts []string
+	tags := make([]string, 0, len(t.Elems))
 	for _, e := range t.Elems {
-		parts = append(parts, g.llvmTypeForTupleTag(e))
+		tags = append(tags, g.llvmTypeForTupleTag(e))
 	}
-	name := "Tuple." + strings.Join(parts, ".")
+	name := mirTupleTypeNameFromTags(tags)
 	if _, ok := g.tupleDefs[name]; !ok {
 		// Defer the actual `%Tuple.* = type { ... }` line until the
 		// emitter flushes its type pool so the order is stable.
@@ -9782,47 +9684,20 @@ func (g *mirGen) tupleName(t *ir.TupleType) string {
 
 // llvmTypeForTupleTag renders a type in the compact mangled form used
 // inside a tuple type name (dots instead of LLVM keywords). Matches
-// the legacy naming (`i64.string.f64.Tuple.i64.i64`).
+// the legacy naming (`i64.string.f64.Tuple.i64.i64`). The PrimType
+// and NamedType branches delegate to the Osty-sourced
+// `mirTupleTagForPrim` / `mirTupleTagForNamed` helpers
+// (`toolchain/mir_generator.osty`) so the tag table has a single
+// source of truth; tuple recursion stays here because it touches
+// `g.tupleDefs` module state.
 func (g *mirGen) llvmTypeForTupleTag(t mir.Type) string {
 	switch x := t.(type) {
 	case *ir.PrimType:
-		switch x.Kind {
-		case ir.PrimInt, ir.PrimInt64, ir.PrimUInt64:
-			return "i64"
-		case ir.PrimInt32, ir.PrimUInt32, ir.PrimChar:
-			return "i32"
-		case ir.PrimInt16, ir.PrimUInt16:
-			return "i16"
-		case ir.PrimInt8, ir.PrimUInt8, ir.PrimByte:
-			return "i8"
-		case ir.PrimBool:
-			return "i1"
-		case ir.PrimFloat, ir.PrimFloat64:
-			return "f64"
-		case ir.PrimFloat32:
-			return "f32"
-		case ir.PrimString:
-			return "string"
-		case ir.PrimBytes:
-			return "bytes"
-		case ir.PrimUnit:
-			return "unit"
+		if tag := mirTupleTagForPrim(x.String()); tag != "" {
+			return tag
 		}
 	case *ir.NamedType:
-		// Builtin types that flow as `ptr` at the LLVM boundary are
-		// tagged as "ptr" so mangled names like `ClosureEnv.ptr.i64`
-		// stay readable. User named types keep their declared name.
-		if x.Builtin {
-			switch x.Name {
-			case "List", "Map", "Set", "Bytes", "ClosureEnv":
-				return "ptr"
-			}
-		}
-		switch x.Name {
-		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration":
-			return "ptr"
-		}
-		return x.Name
+		return mirTupleTagForNamed(x.Name, x.Builtin)
 	case *ir.TupleType:
 		return g.tupleName(x)
 	case *ir.FnType:

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -91,12 +91,410 @@ func mirLlvmTypeForOpaqueNamed(name string) string {
 	return ""
 }
 
-// Osty: toolchain/mir_generator.osty:101:5
-func mirLlvmTypeHeadName(typeText string) string {
+// Osty: toolchain/mir_generator.osty:104:5
+func mirTupleTagForPrim(name string) string {
 	// Osty: toolchain/mir_generator.osty:105:5
+	if name == "Int" || name == "Int64" || name == "UInt64" {
+		// Osty: toolchain/mir_generator.osty:106:9
+		return "i64"
+	}
+	// Osty: toolchain/mir_generator.osty:108:5
+	if name == "Int32" || name == "UInt32" || name == "Char" {
+		// Osty: toolchain/mir_generator.osty:109:9
+		return "i32"
+	}
+	// Osty: toolchain/mir_generator.osty:111:5
+	if name == "Int16" || name == "UInt16" {
+		// Osty: toolchain/mir_generator.osty:112:9
+		return "i16"
+	}
+	// Osty: toolchain/mir_generator.osty:114:5
+	if name == "Int8" || name == "UInt8" || name == "Byte" {
+		// Osty: toolchain/mir_generator.osty:115:9
+		return "i8"
+	}
+	// Osty: toolchain/mir_generator.osty:117:5
+	if name == "Bool" {
+		// Osty: toolchain/mir_generator.osty:118:9
+		return "i1"
+	}
+	// Osty: toolchain/mir_generator.osty:120:5
+	if name == "Float" || name == "Float64" {
+		// Osty: toolchain/mir_generator.osty:121:9
+		return "f64"
+	}
+	// Osty: toolchain/mir_generator.osty:123:5
+	if name == "Float32" {
+		// Osty: toolchain/mir_generator.osty:124:9
+		return "f32"
+	}
+	// Osty: toolchain/mir_generator.osty:126:5
+	if name == "String" {
+		// Osty: toolchain/mir_generator.osty:127:9
+		return "string"
+	}
+	// Osty: toolchain/mir_generator.osty:129:5
+	if name == "Bytes" {
+		// Osty: toolchain/mir_generator.osty:130:9
+		return "bytes"
+	}
+	// Osty: toolchain/mir_generator.osty:135:5
+	if name == "Unit" || name == "()" {
+		// Osty: toolchain/mir_generator.osty:136:9
+		return "unit"
+	}
+	return ""
+}
+
+// Osty: toolchain/mir_generator.osty:147:5
+func mirTupleTagForNamed(name string, builtin bool) string {
+	// Osty: toolchain/mir_generator.osty:151:5
+	if builtin {
+		// Osty: toolchain/mir_generator.osty:152:9
+		if name == "List" || name == "Map" || name == "Set" || name == "Bytes" || name == "ClosureEnv" {
+			// Osty: toolchain/mir_generator.osty:154:13
+			return "ptr"
+		}
+	}
+	// Osty: toolchain/mir_generator.osty:160:5
+	if name == "Channel" || name == "Handle" || name == "Group" || name == "TaskGroup" || name == "Select" || name == "Duration" {
+		// Osty: toolchain/mir_generator.osty:162:9
+		return "ptr"
+	}
+	return name
+}
+
+// Osty: toolchain/mir_generator.osty:173:5
+func mirOptionalTypeName(innerTag string) string {
+	return "Option." + innerTag
+}
+
+// Osty: toolchain/mir_generator.osty:182:5
+func mirOptionTypeName(innerTag string) string {
+	// Osty: toolchain/mir_generator.osty:183:5
+	if innerTag == "" {
+		// Osty: toolchain/mir_generator.osty:184:9
+		return "Option"
+	}
+	return "Option." + innerTag
+}
+
+// Osty: toolchain/mir_generator.osty:193:5
+func mirResultTypeName(okTag string, errTag string) string {
+	// Osty: toolchain/mir_generator.osty:194:5
+	if okTag == "" {
+		// Osty: toolchain/mir_generator.osty:195:9
+		return "Result"
+	}
+	// Osty: toolchain/mir_generator.osty:197:5
+	if errTag == "" {
+		// Osty: toolchain/mir_generator.osty:198:9
+		return "Result." + okTag
+	}
+	return "Result." + okTag + "." + errTag
+}
+
+// Osty: toolchain/mir_generator.osty:214:5
+func mirTupleTypeNameFromTags(tags []string) string {
+	// Osty: toolchain/mir_generator.osty:215:5
+	joined := ""
+	_ = joined
+	// Osty: toolchain/mir_generator.osty:216:5
+	first := true
+	_ = first
+	// Osty: toolchain/mir_generator.osty:217:5
+	for _, tag := range tags {
+		// Osty: toolchain/mir_generator.osty:218:9
+		if first {
+			// Osty: toolchain/mir_generator.osty:219:13
+			joined = tag
+			// Osty: toolchain/mir_generator.osty:220:13
+			first = false
+		} else {
+			// Osty: toolchain/mir_generator.osty:222:13
+			joined = joined + "." + tag
+		}
+	}
+	return "Tuple." + joined
+}
+
+// Osty: toolchain/mir_generator.osty:236:5
+func mirBinaryOpcode(symbol string, isFloat bool) string {
+	// Osty: toolchain/mir_generator.osty:237:5
+	if symbol == "+" {
+		// Osty: toolchain/mir_generator.osty:238:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:238:22
+			return "fadd"
+		}
+		// Osty: toolchain/mir_generator.osty:239:9
+		return "add"
+	}
+	// Osty: toolchain/mir_generator.osty:241:5
+	if symbol == "-" {
+		// Osty: toolchain/mir_generator.osty:242:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:242:22
+			return "fsub"
+		}
+		// Osty: toolchain/mir_generator.osty:243:9
+		return "sub"
+	}
+	// Osty: toolchain/mir_generator.osty:245:5
+	if symbol == "*" {
+		// Osty: toolchain/mir_generator.osty:246:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:246:22
+			return "fmul"
+		}
+		// Osty: toolchain/mir_generator.osty:247:9
+		return "mul"
+	}
+	// Osty: toolchain/mir_generator.osty:249:5
+	if symbol == "/" {
+		// Osty: toolchain/mir_generator.osty:250:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:250:22
+			return "fdiv"
+		}
+		// Osty: toolchain/mir_generator.osty:251:9
+		return "sdiv"
+	}
+	// Osty: toolchain/mir_generator.osty:253:5
+	if symbol == "%" {
+		// Osty: toolchain/mir_generator.osty:254:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:254:22
+			return "frem"
+		}
+		// Osty: toolchain/mir_generator.osty:255:9
+		return "srem"
+	}
+	// Osty: toolchain/mir_generator.osty:257:5
+	if symbol == "==" {
+		// Osty: toolchain/mir_generator.osty:258:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:258:22
+			return "fcmp oeq"
+		}
+		// Osty: toolchain/mir_generator.osty:259:9
+		return "icmp eq"
+	}
+	// Osty: toolchain/mir_generator.osty:261:5
+	if symbol == "!=" {
+		// Osty: toolchain/mir_generator.osty:262:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:262:22
+			return "fcmp one"
+		}
+		// Osty: toolchain/mir_generator.osty:263:9
+		return "icmp ne"
+	}
+	// Osty: toolchain/mir_generator.osty:265:5
+	if symbol == "<" {
+		// Osty: toolchain/mir_generator.osty:266:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:266:22
+			return "fcmp olt"
+		}
+		// Osty: toolchain/mir_generator.osty:267:9
+		return "icmp slt"
+	}
+	// Osty: toolchain/mir_generator.osty:269:5
+	if symbol == "<=" {
+		// Osty: toolchain/mir_generator.osty:270:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:270:22
+			return "fcmp ole"
+		}
+		// Osty: toolchain/mir_generator.osty:271:9
+		return "icmp sle"
+	}
+	// Osty: toolchain/mir_generator.osty:273:5
+	if symbol == ">" {
+		// Osty: toolchain/mir_generator.osty:274:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:274:22
+			return "fcmp ogt"
+		}
+		// Osty: toolchain/mir_generator.osty:275:9
+		return "icmp sgt"
+	}
+	// Osty: toolchain/mir_generator.osty:277:5
+	if symbol == ">=" {
+		// Osty: toolchain/mir_generator.osty:278:9
+		if isFloat {
+			// Osty: toolchain/mir_generator.osty:278:22
+			return "fcmp oge"
+		}
+		// Osty: toolchain/mir_generator.osty:279:9
+		return "icmp sge"
+	}
+	// Osty: toolchain/mir_generator.osty:284:5
+	if symbol == "&&" || symbol == "&" {
+		// Osty: toolchain/mir_generator.osty:285:9
+		return "and"
+	}
+	// Osty: toolchain/mir_generator.osty:287:5
+	if symbol == "||" || symbol == "|" {
+		// Osty: toolchain/mir_generator.osty:288:9
+		return "or"
+	}
+	// Osty: toolchain/mir_generator.osty:290:5
+	if symbol == "^" {
+		// Osty: toolchain/mir_generator.osty:291:9
+		return "xor"
+	}
+	// Osty: toolchain/mir_generator.osty:293:5
+	if symbol == "<<" {
+		// Osty: toolchain/mir_generator.osty:294:9
+		return "shl"
+	}
+	// Osty: toolchain/mir_generator.osty:296:5
+	if symbol == ">>" {
+		// Osty: toolchain/mir_generator.osty:297:9
+		return "ashr"
+	}
+	return ""
+}
+
+// Osty: toolchain/mir_generator.osty:308:5
+func mirBinaryForcesI1Type(symbol string) bool {
+	return symbol == "&&" || symbol == "||"
+}
+
+// Osty: toolchain/mir_generator.osty:318:5
+func mirLoopHintsActive(vectorizeHint bool, parallelHint bool, unrollHint bool) bool {
+	return vectorizeHint || parallelHint || unrollHint
+}
+
+// Osty: toolchain/mir_generator.osty:326:5
+func mirLoopMDVectorizeEnable() string {
+	return "!{!\"llvm.loop.vectorize.enable\", i1 true}"
+}
+
+// Osty: toolchain/mir_generator.osty:333:5
+func mirLoopMDVectorizeScalable() string {
+	return "!{!\"llvm.loop.vectorize.scalable.enable\", i1 true}"
+}
+
+// Osty: toolchain/mir_generator.osty:340:5
+func mirLoopMDVectorizePredicate() string {
+	return "!{!\"llvm.loop.vectorize.predicate.enable\", i1 true}"
+}
+
+// Osty: toolchain/mir_generator.osty:349:5
+func mirLoopMDUnrollEnable() string {
+	return "!{!\"llvm.loop.unroll.enable\", i1 true}"
+}
+
+// Osty: toolchain/mir_generator.osty:359:5
+func mirLoopMDVectorizeWidth(widthDigits string) string {
+	return "!{!\"llvm.loop.vectorize.width\", i32 " + widthDigits + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:367:5
+func mirLoopMDUnrollCount(countDigits string) string {
+	return "!{!\"llvm.loop.unroll.count\", i32 " + countDigits + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:375:5
+func mirLoopMDParallelAccesses(accessGroupRef string) string {
+	return "!{!\"llvm.loop.parallel_accesses\", " + accessGroupRef + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:393:5
+func mirFormatFnAttrs(inlineMode int, hot bool, cold bool, pureFn bool, targetFeatures []string) string {
+	// Osty: toolchain/mir_generator.osty:400:5
+	var parts []string = make([]string, 0, 1)
+	_ = parts
+	// Osty: toolchain/mir_generator.osty:401:5
+	if inlineMode == 1 {
+		// Osty: toolchain/mir_generator.osty:402:9
+		func() struct{} { parts = append(parts, "inlinehint"); return struct{}{} }()
+	} else if inlineMode == 2 {
+		// Osty: toolchain/mir_generator.osty:404:9
+		func() struct{} { parts = append(parts, "alwaysinline"); return struct{}{} }()
+	} else if inlineMode == 3 {
+		// Osty: toolchain/mir_generator.osty:406:9
+		func() struct{} { parts = append(parts, "noinline"); return struct{}{} }()
+	}
+	// Osty: toolchain/mir_generator.osty:408:5
+	if hot {
+		// Osty: toolchain/mir_generator.osty:409:9
+		func() struct{} { parts = append(parts, "hot"); return struct{}{} }()
+	}
+	// Osty: toolchain/mir_generator.osty:411:5
+	if cold {
+		// Osty: toolchain/mir_generator.osty:412:9
+		func() struct{} { parts = append(parts, "cold"); return struct{}{} }()
+	}
+	// Osty: toolchain/mir_generator.osty:416:5
+	if pureFn {
+		// Osty: toolchain/mir_generator.osty:417:9
+		func() struct{} { parts = append(parts, "readnone"); return struct{}{} }()
+	}
+	// Osty: toolchain/mir_generator.osty:419:5
+	if !(len(targetFeatures) == 0) {
+		// Osty: toolchain/mir_generator.osty:423:9
+		joined := ""
+		_ = joined
+		// Osty: toolchain/mir_generator.osty:424:9
+		first := true
+		_ = first
+		// Osty: toolchain/mir_generator.osty:425:9
+		for _, f := range targetFeatures {
+			// Osty: toolchain/mir_generator.osty:426:13
+			stripped := func() string {
+				if llvmStrings.HasPrefix(f, "+") {
+					return f[1:len(f)]
+				} else {
+					return f
+				}
+			}()
+			_ = stripped
+			// Osty: toolchain/mir_generator.osty:431:13
+			if first {
+				// Osty: toolchain/mir_generator.osty:432:17
+				joined = "+" + stripped
+				// Osty: toolchain/mir_generator.osty:433:17
+				first = false
+			} else {
+				// Osty: toolchain/mir_generator.osty:435:17
+				joined = joined + ",+" + stripped
+			}
+		}
+		// Osty: toolchain/mir_generator.osty:438:9
+		func() struct{} { parts = append(parts, "\"target-features\"=\""+joined+"\""); return struct{}{} }()
+	}
+	// Osty: toolchain/mir_generator.osty:442:5
+	out := ""
+	_ = out
+	// Osty: toolchain/mir_generator.osty:443:5
+	first := true
+	_ = first
+	// Osty: toolchain/mir_generator.osty:444:5
+	for _, p := range parts {
+		// Osty: toolchain/mir_generator.osty:445:9
+		if first {
+			// Osty: toolchain/mir_generator.osty:446:13
+			out = p
+			// Osty: toolchain/mir_generator.osty:447:13
+			first = false
+		} else {
+			// Osty: toolchain/mir_generator.osty:449:13
+			out = out + " " + p
+		}
+	}
+	return out
+}
+
+// Osty: toolchain/mir_generator.osty:461:5
+func mirLlvmTypeHeadName(typeText string) string {
+	// Osty: toolchain/mir_generator.osty:465:5
 	ltIdx := llvmStrings.Index(typeText, "<")
 	_ = ltIdx
-	// Osty: toolchain/mir_generator.osty:106:5
+	// Osty: toolchain/mir_generator.osty:466:5
 	stripped := func() string {
 		if ltIdx >= 0 {
 			return typeText[0:ltIdx]
@@ -105,7 +503,7 @@ func mirLlvmTypeHeadName(typeText string) string {
 		}
 	}()
 	_ = stripped
-	// Osty: toolchain/mir_generator.osty:111:5
+	// Osty: toolchain/mir_generator.osty:471:5
 	dotIdx := llvmStrings.Index(stripped, ".")
 	_ = dotIdx
 	return func() string {
@@ -117,41 +515,41 @@ func mirLlvmTypeHeadName(typeText string) string {
 	}()
 }
 
-// Osty: toolchain/mir_generator.osty:125:5
+// Osty: toolchain/mir_generator.osty:485:5
 func mirLlvmTypeIsOptionalSurface(typeText string) bool {
-	// Osty: toolchain/mir_generator.osty:126:5
+	// Osty: toolchain/mir_generator.osty:486:5
 	n := len(typeText)
 	_ = n
-	// Osty: toolchain/mir_generator.osty:127:5
+	// Osty: toolchain/mir_generator.osty:487:5
 	if n == 0 {
-		// Osty: toolchain/mir_generator.osty:128:9
+		// Osty: toolchain/mir_generator.osty:488:9
 		return false
 	}
-	// Osty: toolchain/mir_generator.osty:130:5
+	// Osty: toolchain/mir_generator.osty:490:5
 	if !llvmStrings.HasSuffix(typeText, "?") {
-		// Osty: toolchain/mir_generator.osty:131:9
+		// Osty: toolchain/mir_generator.osty:491:9
 		return false
 	}
-	// Osty: toolchain/mir_generator.osty:135:5
+	// Osty: toolchain/mir_generator.osty:495:5
 	depth := 0
 	_ = depth
-	// Osty: toolchain/mir_generator.osty:136:5
+	// Osty: toolchain/mir_generator.osty:496:5
 	i := 0
 	_ = i
-	// Osty: toolchain/mir_generator.osty:137:5
+	// Osty: toolchain/mir_generator.osty:497:5
 	prefix := typeText[0:(n - 1)]
 	_ = prefix
-	// Osty: toolchain/mir_generator.osty:138:5
+	// Osty: toolchain/mir_generator.osty:498:5
 	plen := len(prefix)
 	_ = plen
-	// Osty: toolchain/mir_generator.osty:139:5
+	// Osty: toolchain/mir_generator.osty:499:5
 	for i < plen {
-		// Osty: toolchain/mir_generator.osty:140:9
+		// Osty: toolchain/mir_generator.osty:500:9
 		ch := prefix[i:(i + 1)]
 		_ = ch
-		// Osty: toolchain/mir_generator.osty:141:9
+		// Osty: toolchain/mir_generator.osty:501:9
 		if ch == "<" || ch == "(" {
-			// Osty: toolchain/mir_generator.osty:142:13
+			// Osty: toolchain/mir_generator.osty:502:13
 			func() {
 				var _cur1 int = depth
 				var _rhs2 int = 1
@@ -164,7 +562,7 @@ func mirLlvmTypeIsOptionalSurface(typeText string) bool {
 				depth = _cur1 + _rhs2
 			}()
 		} else if ch == ">" || ch == ")" {
-			// Osty: toolchain/mir_generator.osty:144:13
+			// Osty: toolchain/mir_generator.osty:504:13
 			func() {
 				var _cur3 int = depth
 				var _rhs4 int = 1
@@ -177,7 +575,7 @@ func mirLlvmTypeIsOptionalSurface(typeText string) bool {
 				depth = _cur3 - _rhs4
 			}()
 		}
-		// Osty: toolchain/mir_generator.osty:146:9
+		// Osty: toolchain/mir_generator.osty:506:9
 		func() {
 			var _cur5 int = i
 			var _rhs6 int = 1
@@ -193,90 +591,90 @@ func mirLlvmTypeIsOptionalSurface(typeText string) bool {
 	return depth == 0
 }
 
-// Osty: toolchain/mir_generator.osty:161:5
+// Osty: toolchain/mir_generator.osty:521:5
 func mirIsHeapEqualityType(typeText string) bool {
 	return typeText == "String" || typeText == "Bytes"
 }
 
-// Osty: toolchain/mir_generator.osty:171:5
+// Osty: toolchain/mir_generator.osty:531:5
 func mirIsStringPrimTypeText(typeText string) bool {
 	return typeText == "String"
 }
 
-// Osty: toolchain/mir_generator.osty:182:5
+// Osty: toolchain/mir_generator.osty:542:5
 func mirIsStringOrderingSymbol(symbol string) bool {
 	return symbol == "<" || symbol == "<=" || symbol == ">" || symbol == ">="
 }
 
-// Osty: toolchain/mir_generator.osty:192:5
+// Osty: toolchain/mir_generator.osty:552:5
 func mirStringOrderingPredicate(symbol string) string {
-	// Osty: toolchain/mir_generator.osty:193:5
+	// Osty: toolchain/mir_generator.osty:553:5
 	if symbol == "<" {
-		// Osty: toolchain/mir_generator.osty:194:9
+		// Osty: toolchain/mir_generator.osty:554:9
 		return "slt"
 	}
-	// Osty: toolchain/mir_generator.osty:196:5
+	// Osty: toolchain/mir_generator.osty:556:5
 	if symbol == "<=" {
-		// Osty: toolchain/mir_generator.osty:197:9
+		// Osty: toolchain/mir_generator.osty:557:9
 		return "sle"
 	}
-	// Osty: toolchain/mir_generator.osty:199:5
+	// Osty: toolchain/mir_generator.osty:559:5
 	if symbol == ">" {
-		// Osty: toolchain/mir_generator.osty:200:9
+		// Osty: toolchain/mir_generator.osty:560:9
 		return "sgt"
 	}
-	// Osty: toolchain/mir_generator.osty:202:5
+	// Osty: toolchain/mir_generator.osty:562:5
 	if symbol == ">=" {
-		// Osty: toolchain/mir_generator.osty:203:9
+		// Osty: toolchain/mir_generator.osty:563:9
 		return "sge"
 	}
 	return ""
 }
 
-// Osty: toolchain/mir_generator.osty:215:5
+// Osty: toolchain/mir_generator.osty:575:5
 func mirIsUnitTypeText(typeText string) bool {
 	return typeText == "Unit" || typeText == "()" || typeText == "Never"
 }
 
-// Osty: toolchain/mir_generator.osty:225:5
+// Osty: toolchain/mir_generator.osty:585:5
 func mirIsFloatTypeText(typeText string) bool {
 	return typeText == "Float" || typeText == "Float32" || typeText == "Float64" || typeText == "double" || typeText == "float"
 }
 
-// Osty: toolchain/mir_generator.osty:236:5
+// Osty: toolchain/mir_generator.osty:596:5
 func mirIsScalarLLVMType(t string) bool {
 	return t == "i1" || t == "i8" || t == "i16" || t == "i32" || t == "i64" || t == "float" || t == "double" || t == "ptr"
 }
 
-// Osty: toolchain/mir_generator.osty:246:5
+// Osty: toolchain/mir_generator.osty:606:5
 func mirLlvmI1Text(v bool) string {
-	// Osty: toolchain/mir_generator.osty:247:5
+	// Osty: toolchain/mir_generator.osty:607:5
 	if v {
-		// Osty: toolchain/mir_generator.osty:248:9
+		// Osty: toolchain/mir_generator.osty:608:9
 		return "true"
 	}
 	return "false"
 }
 
-// Osty: toolchain/mir_generator.osty:259:5
+// Osty: toolchain/mir_generator.osty:619:5
 func mirFirstNonEmpty(vals []string) string {
-	// Osty: toolchain/mir_generator.osty:260:5
+	// Osty: toolchain/mir_generator.osty:620:5
 	n := len(vals)
 	_ = n
-	// Osty: toolchain/mir_generator.osty:261:5
+	// Osty: toolchain/mir_generator.osty:621:5
 	i := 0
 	_ = i
-	// Osty: toolchain/mir_generator.osty:262:5
+	// Osty: toolchain/mir_generator.osty:622:5
 	for i < n {
-		// Osty: toolchain/mir_generator.osty:263:9
+		// Osty: toolchain/mir_generator.osty:623:9
 		x := vals[i]
 		_ = x
-		// Osty: toolchain/mir_generator.osty:264:9
+		// Osty: toolchain/mir_generator.osty:624:9
 		if x != "" {
-			// Osty: toolchain/mir_generator.osty:265:13
+			// Osty: toolchain/mir_generator.osty:625:13
 			return x
 		}
-		// Osty: toolchain/mir_generator.osty:267:9
+		// Osty: toolchain/mir_generator.osty:627:9
 		func() {
 			var _cur7 int = i
 			var _rhs8 int = 1
@@ -292,51 +690,51 @@ func mirFirstNonEmpty(vals []string) string {
 	return ""
 }
 
-// Osty: toolchain/mir_generator.osty:279:5
+// Osty: toolchain/mir_generator.osty:639:5
 func mirEarliestAfter(input string, needle string) int {
 	return llvmStrings.Index(input, needle)
 }
 
-// Osty: toolchain/mir_generator.osty:304:5
+// Osty: toolchain/mir_generator.osty:664:5
 func mirEncodeLLVMString(s string) string {
-	// Osty: toolchain/mir_generator.osty:314:5
+	// Osty: toolchain/mir_generator.osty:674:5
 	printable := " !#$%&'()*+,-./0123456789:;<=" + ">?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 	_ = printable
-	// Osty: toolchain/mir_generator.osty:315:5
+	// Osty: toolchain/mir_generator.osty:675:5
 	out := ""
 	_ = out
-	// Osty: toolchain/mir_generator.osty:316:5
+	// Osty: toolchain/mir_generator.osty:676:5
 	n := len(s)
 	_ = n
-	// Osty: toolchain/mir_generator.osty:317:5
+	// Osty: toolchain/mir_generator.osty:677:5
 	i := 0
 	_ = i
-	// Osty: toolchain/mir_generator.osty:318:5
+	// Osty: toolchain/mir_generator.osty:678:5
 	for i < n {
-		// Osty: toolchain/mir_generator.osty:319:9
+		// Osty: toolchain/mir_generator.osty:679:9
 		ch := s[i:(i + 1)]
 		_ = ch
-		// Osty: toolchain/mir_generator.osty:320:9
+		// Osty: toolchain/mir_generator.osty:680:9
 		if ch == "\\" {
-			// Osty: toolchain/mir_generator.osty:321:13
+			// Osty: toolchain/mir_generator.osty:681:13
 			out = out + "\\\\"
 		} else if ch == "\"" {
-			// Osty: toolchain/mir_generator.osty:323:13
+			// Osty: toolchain/mir_generator.osty:683:13
 			out = out + "\\22"
 		} else if llvmStrings.Contains(printable, ch) {
-			// Osty: toolchain/mir_generator.osty:325:13
+			// Osty: toolchain/mir_generator.osty:685:13
 			out = out + ch
 		} else {
-			// Osty: toolchain/mir_generator.osty:330:13
+			// Osty: toolchain/mir_generator.osty:690:13
 			plen := len(printable)
 			_ = plen
-			// Osty: toolchain/mir_generator.osty:331:13
+			// Osty: toolchain/mir_generator.osty:691:13
 			trap := printable[(plen + 1):(plen + 2)]
 			_ = trap
-			// Osty: toolchain/mir_generator.osty:332:13
+			// Osty: toolchain/mir_generator.osty:692:13
 			return trap
 		}
-		// Osty: toolchain/mir_generator.osty:334:9
+		// Osty: toolchain/mir_generator.osty:694:9
 		func() {
 			var _cur9 int = i
 			var _rhs10 int = 1

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -83,6 +83,366 @@ pub fn mirLlvmTypeForOpaqueNamed(name: String) -> String {
     ""
 }
 
+/// mirTupleTagForPrim returns the mangled tag fragment used when a
+/// primitive type appears inside a tuple / enum / result type name.
+/// Mirrors the `*ir.PrimType` branch of `llvmTypeForTupleTag` in
+/// `internal/llvmgen/mir_generator.go`. The tag form differs from
+/// `mirLlvmTypeForPrim` — floats are `f64`/`f32` (not `double`/`float`),
+/// String / Bytes keep their spec names (not `ptr`), and Unit is
+/// `unit` (not `void`). Returns `""` when the caller should fall
+/// through to the generic `"opaque"` tag — matches the Go switch's
+/// implicit default.
+pub fn mirTupleTagForPrim(name: String) -> String {
+    if name == "Int" || name == "Int64" || name == "UInt64" {
+        return "i64"
+    }
+    if name == "Int32" || name == "UInt32" || name == "Char" {
+        return "i32"
+    }
+    if name == "Int16" || name == "UInt16" {
+        return "i16"
+    }
+    if name == "Int8" || name == "UInt8" || name == "Byte" {
+        return "i8"
+    }
+    if name == "Bool" {
+        return "i1"
+    }
+    if name == "Float" || name == "Float64" {
+        return "f64"
+    }
+    if name == "Float32" {
+        return "f32"
+    }
+    if name == "String" {
+        return "string"
+    }
+    if name == "Bytes" {
+        return "bytes"
+    }
+    // `PrimType.String()` renders PrimUnit as `"()"`; keep `"Unit"`
+    // too for symmetry with `mirLlvmTypeForPrim` even though no Go
+    // stringifier produces it.
+    if name == "Unit" || name == "()" {
+        return "unit"
+    }
+    ""
+}
+
+/// mirTupleTagForNamed returns the mangled tag fragment used when a
+/// named type appears inside a tuple / enum / result type name.
+/// Mirrors the `*ir.NamedType` branch of `llvmTypeForTupleTag`:
+/// builtin collection handles and the concurrency runtime types
+/// collapse to `"ptr"`, everything else keeps its declared name so
+/// mangled strings stay human-readable (`Tuple.i64.Event`).
+pub fn mirTupleTagForNamed(name: String, builtin: Bool) -> String {
+    // Builtin collection / closure-env handles share the opaque-ptr
+    // LLVM form. The `builtin` guard preserves user names that
+    // happen to collide with builtin identifiers.
+    if builtin {
+        if name == "List" || name == "Map" || name == "Set" ||
+           name == "Bytes" || name == "ClosureEnv" {
+            return "ptr"
+        }
+    }
+    // Concurrency runtime handle types are always opaque pointers,
+    // regardless of the Builtin flag — the Go source also skips the
+    // guard here, so we keep the same relaxation.
+    if name == "Channel" || name == "Handle" || name == "Group" ||
+       name == "TaskGroup" || name == "Select" || name == "Duration" {
+        return "ptr"
+    }
+    name
+}
+
+/// mirOptionalTypeName returns the mangled LLVM type name for a
+/// surface `T?` optional. Matches `optionalTypeName` in
+/// `internal/llvmgen/mir_generator.go` — always a two-word mangling
+/// since `Option` needs an inner tag to disambiguate payload slot
+/// width. Caller passes `innerTag` already computed via
+/// `mirTupleTagForPrim` / `mirTupleTagForNamed` / tuple recursion.
+pub fn mirOptionalTypeName(innerTag: String) -> String {
+    "Option." + innerTag
+}
+
+/// mirOptionTypeName returns the mangled name for a `Option<T>`
+/// *named* type (as distinct from the surface `T?` form). When the
+/// caller has no inner tag (bare `Option`), the result is just
+/// `"Option"` — the Go source emits this when the named type has no
+/// type args. Otherwise the suffix mirrors `mirOptionalTypeName`.
+pub fn mirOptionTypeName(innerTag: String) -> String {
+    if innerTag == "" {
+        return "Option"
+    }
+    "Option." + innerTag
+}
+
+/// mirResultTypeName returns the mangled name for `Result<T, E>`.
+/// Matches `resultTypeName` — one-arg drops the `E` suffix, no-arg
+/// falls back to bare `"Result"`. Empty-string tags signal "skip"
+/// so the caller doesn't have to duplicate the arg-count branching.
+pub fn mirResultTypeName(okTag: String, errTag: String) -> String {
+    if okTag == "" {
+        return "Result"
+    }
+    if errTag == "" {
+        return "Result." + okTag
+    }
+    "Result." + okTag + "." + errTag
+}
+
+/// mirTupleTypeNameFromTags returns the mangled name for a tuple
+/// type given its element tags (already computed via
+/// `mirTupleTagForPrim` / `mirTupleTagForNamed` / nested
+/// `mirTupleTypeNameFromTags`). The element tags are joined with
+/// `.` separators so the name stays printable and collision-free
+/// (`Tuple.i64.string.f64`). Mirrors `tupleName` in the Go source
+/// — the Go version was literally
+/// `"Tuple." + strings.Join(tags, ".")`, so an empty tag list
+/// produces the trailing-dot form `"Tuple."`. The Go version also
+/// registers the tuple layout in `g.tupleDefs`, which stays on the
+/// caller since it's module state.
+pub fn mirTupleTypeNameFromTags(tags: List<String>) -> String {
+    let mut joined = ""
+    let mut first = true
+    for tag in tags {
+        if first {
+            joined = tag
+            first = false
+        } else {
+            joined = joined + "." + tag
+        }
+    }
+    "Tuple." + joined
+}
+
+/// mirBinaryOpcode returns the LLVM opcode (and `icmp`/`fcmp`
+/// predicate) for the MIR binary operator whose `BinaryOp.String()`
+/// form matches `symbol`. The `isFloat` flag selects the
+/// floating-point family for arithmetic + comparison symbols. Logical
+/// (`&&` / `||`) and bitwise (`&` / `|` / `^` / `<<` / `>>`)
+/// operators ignore `isFloat` — the Go source also never reaches
+/// those branches with a float operand. Returns `""` when no match
+/// so the caller can fall through to the `unsupported` diagnostic.
+pub fn mirBinaryOpcode(symbol: String, isFloat: Bool) -> String {
+    if symbol == "+" {
+        if isFloat { return "fadd" }
+        return "add"
+    }
+    if symbol == "-" {
+        if isFloat { return "fsub" }
+        return "sub"
+    }
+    if symbol == "*" {
+        if isFloat { return "fmul" }
+        return "mul"
+    }
+    if symbol == "/" {
+        if isFloat { return "fdiv" }
+        return "sdiv"
+    }
+    if symbol == "%" {
+        if isFloat { return "frem" }
+        return "srem"
+    }
+    if symbol == "==" {
+        if isFloat { return "fcmp oeq" }
+        return "icmp eq"
+    }
+    if symbol == "!=" {
+        if isFloat { return "fcmp one" }
+        return "icmp ne"
+    }
+    if symbol == "<" {
+        if isFloat { return "fcmp olt" }
+        return "icmp slt"
+    }
+    if symbol == "<=" {
+        if isFloat { return "fcmp ole" }
+        return "icmp sle"
+    }
+    if symbol == ">" {
+        if isFloat { return "fcmp ogt" }
+        return "icmp sgt"
+    }
+    if symbol == ">=" {
+        if isFloat { return "fcmp oge" }
+        return "icmp sge"
+    }
+    // Logical-and / bitwise-and share the `and` opcode; the operand
+    // type is what differs — `i1` for logical, operand LLVM type
+    // for bitwise. Callers discriminate via `mirBinaryForcesI1Type`.
+    if symbol == "&&" || symbol == "&" {
+        return "and"
+    }
+    if symbol == "||" || symbol == "|" {
+        return "or"
+    }
+    if symbol == "^" {
+        return "xor"
+    }
+    if symbol == "<<" {
+        return "shl"
+    }
+    if symbol == ">>" {
+        return "ashr"
+    }
+    ""
+}
+
+/// mirBinaryForcesI1Type reports whether the operand type emitted
+/// alongside the opcode should be `"i1"` regardless of the argument
+/// type the caller would otherwise use. True for logical `&&` / `||`
+/// only — bitwise `&` / `|` / `^` shift on the operand width.
+/// Complements `mirBinaryOpcode` so the caller never has to repeat
+/// the opcode switch.
+pub fn mirBinaryForcesI1Type(symbol: String) -> Bool {
+    symbol == "&&" || symbol == "||"
+}
+
+/// mirLoopHintsActive reports whether any v0.6 loop annotation is
+/// set for the current function — i.e. whether the loop-metadata
+/// emitter should attach an `!llvm.loop !N` reference to this
+/// function's back-edge terminators. Mirrors the Go predicate of
+/// the same name; the Boolean OR lives here so the Go caller only
+/// keeps the state-owning flag fields.
+pub fn mirLoopHintsActive(vectorizeHint: Bool, parallelHint: Bool, unrollHint: Bool) -> Bool {
+    vectorizeHint || parallelHint || unrollHint
+}
+
+/// mirLoopMDVectorizeEnable returns the literal body of the
+/// `!llvm.loop.vectorize.enable` metadata node. Always
+/// `i1 true` — `#[vectorize]` has no "disable" form; the absence
+/// of the annotation is what signals disable.
+pub fn mirLoopMDVectorizeEnable() -> String {
+    "!\{!\"llvm.loop.vectorize.enable\", i1 true\}"
+}
+
+/// mirLoopMDVectorizeScalable returns the literal body of the
+/// `!llvm.loop.vectorize.scalable.enable` node — the SVE/RVV
+/// scalable-vector toggle produced by `#[vectorize(scalable)]`.
+pub fn mirLoopMDVectorizeScalable() -> String {
+    "!\{!\"llvm.loop.vectorize.scalable.enable\", i1 true\}"
+}
+
+/// mirLoopMDVectorizePredicate returns the literal body of the
+/// `!llvm.loop.vectorize.predicate.enable` node — the tail-folding
+/// toggle produced by `#[vectorize(predicate)]`.
+pub fn mirLoopMDVectorizePredicate() -> String {
+    "!\{!\"llvm.loop.vectorize.predicate.enable\", i1 true\}"
+}
+
+/// mirLoopMDUnrollEnable returns the literal body of the
+/// `!llvm.loop.unroll.enable` node — bare `#[unroll]` without a
+/// `count = N` argument. The count form has dynamic content and is
+/// built by the Go caller from the (already-formatted) count digit
+/// string via `mirLoopMDUnrollCount`.
+pub fn mirLoopMDUnrollEnable() -> String {
+    "!\{!\"llvm.loop.unroll.enable\", i1 true\}"
+}
+
+/// mirLoopMDVectorizeWidth returns the body of the
+/// `!llvm.loop.vectorize.width` metadata node for a `width = N`
+/// argument. `widthDigits` must be the already-formatted decimal
+/// form (the bootstrap transpiler doesn't lower Go-style
+/// `fmt.Sprintf("%d", n)`, so the Go caller handles the Int-to-
+/// String conversion).
+pub fn mirLoopMDVectorizeWidth(widthDigits: String) -> String {
+    "!\{!\"llvm.loop.vectorize.width\", i32 " + widthDigits + "\}"
+}
+
+/// mirLoopMDUnrollCount returns the body of the
+/// `!llvm.loop.unroll.count` metadata node for `#[unroll(count =
+/// N)]`. As with width, `countDigits` is pre-formatted by the
+/// caller.
+pub fn mirLoopMDUnrollCount(countDigits: String) -> String {
+    "!\{!\"llvm.loop.unroll.count\", i32 " + countDigits + "\}"
+}
+
+/// mirLoopMDParallelAccesses returns the body of the
+/// `!llvm.loop.parallel_accesses` metadata node for `#[parallel]`.
+/// `accessGroupRef` is the already-allocated `!N` reference string
+/// pointing at the function's `!llvm.access.group` node.
+pub fn mirLoopMDParallelAccesses(accessGroupRef: String) -> String {
+    "!\{!\"llvm.loop.parallel_accesses\", " + accessGroupRef + "\}"
+}
+
+/// mirFormatFnAttrs renders the v0.6 A8/A9/A10/A13 function-level
+/// LLVM attribute string spliced between the parameter list and the
+/// body brace of a `define`/`declare` line. Returns `""` when no
+/// attribute applies so the caller emits the attribute-free form.
+///
+/// Inputs mirror the `mir.Function` shape the Go source reads:
+/// `inlineMode` uses the v0.6 A8 discriminant (0 none / 1 soft /
+/// 2 always / 3 never — see `ir.FnDecl.InlineMode`), `hot` / `cold`
+/// / `pureFn` toggle the corresponding LLVM fn-attrs, and
+/// `targetFeatures` lists the A10 feature names that get
+/// `+`-prefixed and joined for the `"target-features"` attr.
+/// Matches `formatFnAttrs` in `internal/llvmgen/mir_generator.go`
+/// byte-for-byte (including the `hot` + `cold` both-set relaxation:
+/// callers filter that upstream).
+pub fn mirFormatFnAttrs(
+    inlineMode: Int,
+    hot: Bool,
+    cold: Bool,
+    pureFn: Bool,
+    targetFeatures: List<String>,
+) -> String {
+    let mut parts: List<String> = []
+    if inlineMode == 1 {
+        parts.push("inlinehint")
+    } else if inlineMode == 2 {
+        parts.push("alwaysinline")
+    } else if inlineMode == 3 {
+        parts.push("noinline")
+    }
+    if hot {
+        parts.push("hot")
+    }
+    if cold {
+        parts.push("cold")
+    }
+    // v0.6 A13 `#[pure]` → LLVM `readnone`: function reads no
+    // memory and has no side effects. Enables caller-side CSE.
+    if pureFn {
+        parts.push("readnone")
+    }
+    if !targetFeatures.isEmpty() {
+        // LLVM's target-features string expects each feature prefixed
+        // with `+` for enable. v0.6 surface only supports enable, so
+        // we always prepend `+` after stripping any user-typed `+`.
+        let mut joined = ""
+        let mut first = true
+        for f in targetFeatures {
+            let stripped = if llvmStrings.HasPrefix(f, "+") {
+                f[1..f.len()]
+            } else {
+                f
+            }
+            if first {
+                joined = "+" + stripped
+                first = false
+            } else {
+                joined = joined + ",+" + stripped
+            }
+        }
+        parts.push("\"target-features\"=\"" + joined + "\"")
+    }
+    // Space-join the parts list. Empty list → "" so caller emits
+    // the attribute-free define/declare shape.
+    let mut out = ""
+    let mut first = true
+    for p in parts {
+        if first {
+            out = p
+            first = false
+        } else {
+            out = out + " " + p
+        }
+    }
+    out
+}
+
 /// mirLlvmTypeHeadName strips the optional `pkg.` prefix and the
 /// `<...>` argument list from a hirTypeString-style named type
 /// text, returning just the head identifier. For `Map<String, Int>`


### PR DESCRIPTION
## Summary

Phase A of the MIR emitter selfhost port: move 17 new pure helpers from hand-written Go (`internal/llvmgen/mir_generator.go`) into `toolchain/mir_generator.osty` as the single source of truth. Net −125 LOC in the hand-written Go emitter; 360 new LOC of Osty.

### §1 generator state (9 helpers)
- `mirFormatFnAttrs` — v0.6 A8/A9/A10/A13 fn-attr string builder (`InlineMode` / `Hot` / `Cold` / `Pure` / `TargetFeatures`). Go `formatFnAttrs` collapses 35 → 3 lines.
- `mirLoopHintsActive` — vectorize | parallel | unroll OR predicate.
- `mirLoopMDVectorizeEnable` / `Scalable` / `Predicate` / `UnrollEnable` — constant loop-metadata templates.
- `mirLoopMDVectorizeWidth` / `UnrollCount` / `ParallelAccesses` — templates taking pre-formatted digits / access-group refs. Go-side uses `strconv.Itoa` for the Int formatting.

### §11 operators (2 helpers)
- `mirBinaryOpcode` — 19-branch opcode + `icmp`/`fcmp` predicate table keyed on `BinaryOp.String()`. Go `emitBinary` switch collapses 90 → 20 lines.
- `mirBinaryForcesI1Type` — true for `&&` / `||` so operand type is `"i1"` instead of `argLLVM`.

### §14 enum layout (6 helpers)
- `mirTupleTagForPrim` — Prim branch of `llvmTypeForTupleTag` (Float64→f64, String→string, ()→unit).
- `mirTupleTagForNamed` — NamedType branch (builtin collections + concurrency handles → ptr, otherwise declared name).
- `mirOptionalTypeName` / `mirOptionTypeName` / `mirResultTypeName` / `mirTupleTypeNameFromTags` — pure name-mangling. Layout registration (`registerEnumLayout`, `g.tupleDefs` cache) stays on Go since it mutates module state.

### Section status (MIR_EMITTER_PORT.md)
- §1  Go-only → **Partial** (9 helpers)
- §11 Partial (4) → **Partial** (6)
- §14 Go-only → **Partial** (6)

### Regen pipeline
Used `go run internal/llvmgen/gen_mir_generator_snapshot.go` directly. The umbrella `go generate ./internal/llvmgen` is blocked on a pre-existing `support_snapshot` field-drift issue (see `SELFHOST_PORT_MATRIX.md §1c.5`); the MIR emitter snapshot regen runs independently and compile-gates cleanly.

## Test plan

- [x] `just front` — green (lexer/parser/resolve/check/diag/format/lint/pipeline)
- [x] `go test -run 'TestFormatFnAttrs|TestBinary|TestTuple|TestOption|TestResult|TestVector|TestLoop|TestMetadata|TestMIR' -timeout 240s ./internal/llvmgen/` — green
- [x] `go build ./internal/llvmgen/...` — clean
- [x] Pre-existing failures reproduce on `main` (confirmed via `git stash` baseline):
  - `TestGoGenerateSupportSnapshotIsFixedPoint` — fails on main too (support_snapshot drift)
  - `TestNativeToolchainMergedMIRPipelineIsClean` — fails on main too (`LLVM011 struct default value`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)