### PR TITLE
feat(selfhost): port emitUnary + string-pool line + metadata templates

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -53,7 +53,7 @@ untouched.
 
 | § | Section | Lines | Funcs | Risk | Status |
 | - | ------- | ----- | ----- | ---- | ------ |
-| 1 | generator state | 100–472 | ~10 | LOW | Partial — `firstNonEmpty`, `formatFnAttrs`, `loopHintsActive`, + loop-metadata constant templates ported (`mirFormatFnAttrs`, `mirLoopHintsActive`, `mirLoopMDVectorizeEnable`/`Scalable`/`Predicate`/`Width`, `mirLoopMDUnrollEnable`/`Count`, `mirLoopMDParallelAccesses`); state-touching (`nextLoopMD` body, `listAliasScopeRef`, `nextAccessGroupMD`) deferred to Phase B |
+| 1 | generator state | 100–472 | ~10 | LOW | Partial — `firstNonEmpty`, `formatFnAttrs`, `loopHintsActive`, loop-metadata + alias-scope + access-group templates ported (`mirFormatFnAttrs`, `mirLoopHintsActive`, `mirLoopMDVectorizeEnable`/`Scalable`/`Predicate`/`Width`, `mirLoopMDUnrollEnable`/`Count`, `mirLoopMDParallelAccesses`, `mirAliasScopeDomainLine`/`ScopeLine`/`ListLine`, `mirAccessGroupLine`); `nextLoopMD` body + `g.loopMDDefs` indexing stays on Go (state) |
 | 2 | support check | 473–1364 | ~20 | MEDIUM | Go-only |
 | 3 | header + runtime declares | 1365–1641 | ~8 | LOW | Go-only |
 | 4 | function emission | 1642–2384 | ~18 | MEDIUM | Go-only |
@@ -63,8 +63,8 @@ untouched.
 | 8 | concurrency intrinsics | 6762–7472 | ~20 | MEDIUM | Go-only |
 | 9 | terminators | 7473–7595 | ~5 | LOW | Go-only |
 | 10 | rvalue / operand | 7596–8937 | ~25 | HIGH | Go-only |
-| 11 | operators | 8938–9196 | ~12 | LOW | Partial — predicates + `emitBinary` opcode table ported (`isHeapEqualityType`, `isStringPrimType`, `isStringOrderingBinOp`, `stringOrderingPredicate`, `mirBinaryOpcode`, `mirBinaryForcesI1Type`); `emitUnary` / `emitInlineStringEqLiteral` deferred (touch `g.fresh` / `g.fnBuf`) |
-| 12 | strings | 9197–9284 | ~7 | LOW | Partial — `encodeLLVMString` / `earliestAfter` ported |
+| 11 | operators | 8938–9196 | ~12 | LOW | Partial — predicates + `emitBinary` opcode table + `emitUnary` instruction body ported (`isHeapEqualityType`, `isStringPrimType`, `isStringOrderingBinOp`, `stringOrderingPredicate`, `mirBinaryOpcode`, `mirBinaryForcesI1Type`, `mirUnaryIsIdentity`, `mirUnaryInstruction`); `emitInlineStringEqLiteral` deferred (needs `g.freshLabel` / `g.fnBuf`) |
+| 12 | strings | 9197–9284 | ~7 | LOW | Partial — `encodeLLVMString`, `earliestAfter`, and the string-pool line template ported (`mirEncodeLLVMString`, `mirEarliestAfter`, `mirStringPoolLine`); `stringLiteral` interning + `emitStringPool` orchestration stay on Go (touch `g.strings` / `g.out`) |
 | 13 | type mapping | 9285–9375 | ~8 | LOW | **Ported** (primitive + opaque-named + head-name + optional-surface) |
 | 14 | enum layout helpers | 9376–9575 | ~10 | LOW | Partial — `llvmTypeForTupleTag` Prim / Named branches + Optional / Option / Result / Tuple name-mangling ported (`mirTupleTagForPrim`, `mirTupleTagForNamed`, `mirOptionalTypeName`, `mirOptionTypeName`, `mirResultTypeName`, `mirTupleTypeNameFromTags`); `registerEnumLayout` + `g.tupleDefs` caches deferred to Phase B |
 | 15 | helpers | 9576–9616 | ~5 | LOW | Partial — `firstNonEmpty`, `isUnitType`, `isFloatType`, `isScalarLLVMType`, `llvmStdIoI1Text` ported |
@@ -181,6 +181,13 @@ list keeps new Osty clean of known landmines.
 | `mirLoopMDUnrollCount` | `(countDigits: String) -> String` | §1 | `!{!"llvm.loop.unroll.count", i32 <digits>}` body — caller pre-formats the Int |
 | `mirLoopMDParallelAccesses` | `(accessGroupRef: String) -> String` | §1 | `!{!"llvm.loop.parallel_accesses", <ref>}` body — A6 group reference |
 | `mirFormatFnAttrs` | `(inlineMode: Int, hot: Bool, cold: Bool, pureFn: Bool, targetFeatures: List<String>) -> String` | §1 | Space-joined v0.6 A8/A9/A10/A13 fn-attr string — `inlinehint`/`alwaysinline`/`noinline` + `hot`/`cold`/`readnone` + `"target-features"="+f1,+f2"` |
+| `mirUnaryIsIdentity` | `(symbol: String) -> Bool` | §11 | True for unary `+`, the identity op — caller short-circuits to reuse the operand register |
+| `mirUnaryInstruction` | `(symbol: String, argReg: String, llvmTy: String, isFloat: Bool) -> String` | §11 | LLVM instruction body for `-` / `!` / `~` — spliced between `%tmp = ` and `\n`; returns `""` on miss so caller stays on the unsupported diagnostic |
+| `mirStringPoolLine` | `(sym: String, sizeDigits: String, encoded: String) -> String` | §12 | One constant line of the string pool — `@.str.N = private unnamed_addr constant [<size> x i8] c"<encoded>"\n`; `sizeDigits` is pre-formatted by the Go caller |
+| `mirAliasScopeDomainLine` | `(ref: String) -> String` | §1 | `!N = distinct !{!"osty.list.metadata.domain"}` — root of the list-alias-scope chain |
+| `mirAliasScopeScopeLine` | `(ref: String, domainRef: String) -> String` | §1 | `!N = distinct !{!"osty.list.metadata.scope", !Domain}` — middle node of the chain |
+| `mirAliasScopeListLine` | `(ref: String, scopeRef: String) -> String` | §1 | `!N = !{!Scope}` — the one-element scope list attached via `!alias.scope`/`!noalias` |
+| `mirAccessGroupLine` | `(ref: String) -> String` | §1 | `!N = distinct !{}` — A6 parallel-access group root |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -390,14 +390,11 @@ func (g *mirGen) listAliasScopeRef() string {
 		return g.listMetaScopeList
 	}
 	domainRef := fmt.Sprintf("!%d", len(g.loopMDDefs))
-	g.loopMDDefs = append(g.loopMDDefs,
-		fmt.Sprintf(`%s = distinct !{!"osty.list.metadata.domain"}`, domainRef))
+	g.loopMDDefs = append(g.loopMDDefs, mirAliasScopeDomainLine(domainRef))
 	scopeRef := fmt.Sprintf("!%d", len(g.loopMDDefs))
-	g.loopMDDefs = append(g.loopMDDefs,
-		fmt.Sprintf(`%s = distinct !{!"osty.list.metadata.scope", %s}`, scopeRef, domainRef))
+	g.loopMDDefs = append(g.loopMDDefs, mirAliasScopeScopeLine(scopeRef, domainRef))
 	listRef := fmt.Sprintf("!%d", len(g.loopMDDefs))
-	g.loopMDDefs = append(g.loopMDDefs,
-		fmt.Sprintf("%s = !{%s}", listRef, scopeRef))
+	g.loopMDDefs = append(g.loopMDDefs, mirAliasScopeListLine(listRef, scopeRef))
 	g.listMetaScopeList = listRef
 	return listRef
 }
@@ -410,7 +407,7 @@ func (g *mirGen) listAliasScopeRef() string {
 // inside each loop's `llvm.loop.parallel_accesses` property.
 func (g *mirGen) nextAccessGroupMD() string {
 	ref := fmt.Sprintf("!%d", len(g.loopMDDefs))
-	g.loopMDDefs = append(g.loopMDDefs, fmt.Sprintf("%s = distinct !{}", ref))
+	g.loopMDDefs = append(g.loopMDDefs, mirAccessGroupLine(ref))
 	return ref
 }
 
@@ -9107,49 +9104,21 @@ func (g *mirGen) renderConst(c mir.Const, hintT mir.Type) (string, error) {
 // ==== operators ====
 
 func (g *mirGen) emitUnary(op mir.UnaryOp, arg string, t mir.Type) (string, error) {
-	llvmT := g.llvmType(t)
-	tmp := g.fresh()
-	switch op {
-	case mir.UnNeg:
-		if isFloatType(t) {
-			g.fnBuf.WriteString("  ")
-			g.fnBuf.WriteString(tmp)
-			g.fnBuf.WriteString(" = fneg ")
-			g.fnBuf.WriteString(llvmT)
-			g.fnBuf.WriteByte(' ')
-			g.fnBuf.WriteString(arg)
-			g.fnBuf.WriteByte('\n')
-			return tmp, nil
-		}
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(" = sub ")
-		g.fnBuf.WriteString(llvmT)
-		g.fnBuf.WriteString(" 0, ")
-		g.fnBuf.WriteString(arg)
-		g.fnBuf.WriteByte('\n')
-		return tmp, nil
-	case mir.UnPlus:
-		// identity
+	sym := op.String()
+	if mirUnaryIsIdentity(sym) {
 		return arg, nil
-	case mir.UnNot:
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(" = xor i1 ")
-		g.fnBuf.WriteString(arg)
-		g.fnBuf.WriteString(", 1\n")
-		return tmp, nil
-	case mir.UnBitNot:
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(" = xor ")
-		g.fnBuf.WriteString(llvmT)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(arg)
-		g.fnBuf.WriteString(", -1\n")
-		return tmp, nil
 	}
-	return "", unsupported("mir-mvp", fmt.Sprintf("unary op %d", op))
+	instr := mirUnaryInstruction(sym, arg, g.llvmType(t), isFloatType(t))
+	if instr == "" {
+		return "", unsupported("mir-mvp", fmt.Sprintf("unary op %d", op))
+	}
+	tmp := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(tmp)
+	g.fnBuf.WriteString(" = ")
+	g.fnBuf.WriteString(instr)
+	g.fnBuf.WriteByte('\n')
+	return tmp, nil
 }
 
 func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.Type) (string, error) {
@@ -9465,12 +9434,7 @@ func (g *mirGen) emitStringPool() {
 	for _, s := range g.stringOrder {
 		sym := g.strings[s]
 		encoded, size := encodeLLVMString(s)
-		pool.WriteString(sym)
-		pool.WriteString(" = private unnamed_addr constant [")
-		pool.WriteString(strconv.Itoa(size))
-		pool.WriteString(" x i8] c\"")
-		pool.WriteString(encoded)
-		pool.WriteString("\"\n")
+		pool.WriteString(mirStringPoolLine(sym, strconv.Itoa(size), encoded))
 	}
 	pool.WriteByte('\n')
 	// Inject before the first "define " or "declare " line, whichever

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -363,6 +363,28 @@ func mirBinaryForcesI1Type(symbol string) bool {
 	return symbol == "&&" || symbol == "||"
 }
 
+// Osty: toolchain/mir_generator.osty:307:5
+func mirUnaryIsIdentity(symbol string) bool {
+	return symbol == "+"
+}
+
+// Osty: toolchain/mir_generator.osty:323:5
+func mirUnaryInstruction(symbol string, argReg string, llvmTy string, isFloat bool) string {
+	if symbol == "-" {
+		if isFloat {
+			return "fneg " + llvmTy + " " + argReg
+		}
+		return "sub " + llvmTy + " 0, " + argReg
+	}
+	if symbol == "!" {
+		return "xor i1 " + argReg + ", 1"
+	}
+	if symbol == "~" {
+		return "xor " + llvmTy + " " + argReg + ", -1"
+	}
+	return ""
+}
+
 // Osty: toolchain/mir_generator.osty:318:5
 func mirLoopHintsActive(vectorizeHint bool, parallelHint bool, unrollHint bool) bool {
 	return vectorizeHint || parallelHint || unrollHint
@@ -401,6 +423,31 @@ func mirLoopMDUnrollCount(countDigits string) string {
 // Osty: toolchain/mir_generator.osty:375:5
 func mirLoopMDParallelAccesses(accessGroupRef string) string {
 	return "!{!\"llvm.loop.parallel_accesses\", " + accessGroupRef + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:354:5
+func mirStringPoolLine(sym string, sizeDigits string, encoded string) string {
+	return sym + " = private unnamed_addr constant [" + sizeDigits + " x i8] c\"" + encoded + "\"\n"
+}
+
+// Osty: toolchain/mir_generator.osty:362:5
+func mirAliasScopeDomainLine(ref string) string {
+	return ref + " = distinct !{!\"osty.list.metadata.domain\"}"
+}
+
+// Osty: toolchain/mir_generator.osty:369:5
+func mirAliasScopeScopeLine(ref string, domainRef string) string {
+	return ref + " = distinct !{!\"osty.list.metadata.scope\", " + domainRef + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:377:5
+func mirAliasScopeListLine(ref string, scopeRef string) string {
+	return ref + " = !{" + scopeRef + "}"
+}
+
+// Osty: toolchain/mir_generator.osty:385:5
+func mirAccessGroupLine(ref string) string {
+	return ref + " = distinct !{}"
 }
 
 // Osty: toolchain/mir_generator.osty:393:5

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -300,6 +300,92 @@ pub fn mirBinaryForcesI1Type(symbol: String) -> Bool {
     symbol == "&&" || symbol == "||"
 }
 
+/// mirUnaryIsIdentity reports whether a unary operator symbol is the
+/// no-op (unary-plus) form. The caller short-circuits before
+/// requesting an instruction body — unary plus emits nothing and just
+/// reuses the operand register.
+pub fn mirUnaryIsIdentity(symbol: String) -> Bool {
+    symbol == "+"
+}
+
+/// mirUnaryInstruction returns the LLVM instruction body for a unary
+/// operator, suitable for splicing between `<tmp> = ` and `\n`. Handles
+/// the four non-identity MIR unary ops with their distinct LLVM shapes:
+///   `-`  (float)  → `fneg <ty> <arg>`
+///   `-`  (int)    → `sub <ty> 0, <arg>`
+///   `!`           → `xor i1 <arg>, 1`
+///   `~`           → `xor <ty> <arg>, -1`
+/// The `argReg` and `llvmTy` come from the caller's existing register
+/// / type plumbing. Returns `""` when the symbol is unrecognised or is
+/// the identity `+` — the caller MUST guard with `mirUnaryIsIdentity`
+/// first so the empty string signals "unknown" unambiguously and maps
+/// to the `unsupported` diagnostic path.
+pub fn mirUnaryInstruction(
+    symbol: String,
+    argReg: String,
+    llvmTy: String,
+    isFloat: Bool,
+) -> String {
+    if symbol == "-" {
+        if isFloat {
+            return "fneg " + llvmTy + " " + argReg
+        }
+        return "sub " + llvmTy + " 0, " + argReg
+    }
+    // Boolean `!` always emits on i1 regardless of argument LLVM type —
+    // MIR guarantees the operand is already i1 at this point.
+    if symbol == "!" {
+        return "xor i1 " + argReg + ", 1"
+    }
+    // Bitwise `~` uses the operand's LLVM width; XOR with all-ones
+    // (`-1`) flips every bit at that width.
+    if symbol == "~" {
+        return "xor " + llvmTy + " " + argReg + ", -1"
+    }
+    ""
+}
+
+/// mirStringPoolLine returns one line of the LLVM string-pool section,
+/// suitable for appending to the emitter's module-tail buffer. The
+/// `sizeDigits` argument is the already-formatted decimal form of the
+/// array length (Go caller uses `strconv.Itoa` — Osty helpers stay on
+/// printable-ASCII string composition). The trailing `\n` matches the
+/// Go source's byte-for-byte output so the pool stays format-stable.
+pub fn mirStringPoolLine(sym: String, sizeDigits: String, encoded: String) -> String {
+    sym + " = private unnamed_addr constant [" + sizeDigits + " x i8] c\"" + encoded + "\"\n"
+}
+
+/// mirAliasScopeDomainLine renders the `!llvm.alias.scope`-domain
+/// metadata definition line used to tag list-snapshot reads. Pair with
+/// `mirAliasScopeScopeLine` and `mirAliasScopeListLine` to emit the
+/// three-node chain the Go source allocates in `listAliasScopeRef`.
+pub fn mirAliasScopeDomainLine(ref: String) -> String {
+    ref + " = distinct !\{!\"osty.list.metadata.domain\"\}"
+}
+
+/// mirAliasScopeScopeLine renders the `scope` node of the alias-scope
+/// chain: `!N = distinct !{!"...scope", !Domain}`. `domainRef` is the
+/// `!M` handle returned by `mirAliasScopeDomainLine`'s caller.
+pub fn mirAliasScopeScopeLine(ref: String, domainRef: String) -> String {
+    ref + " = distinct !\{!\"osty.list.metadata.scope\", " + domainRef + "\}"
+}
+
+/// mirAliasScopeListLine renders the one-element scope list node
+/// (`!N = !{!Scope}`) that loads/stores reference via
+/// `!alias.scope !N` / `!noalias !N`. Mirrors the last allocation in
+/// `listAliasScopeRef`.
+pub fn mirAliasScopeListLine(ref: String, scopeRef: String) -> String {
+    ref + " = !\{" + scopeRef + "\}"
+}
+
+/// mirAccessGroupLine renders the bare `!llvm.access.group` node
+/// `!N = distinct !{}` used once per `#[parallel]` function. Attached
+/// to individual loads/stores as `!llvm.access !N` and referenced from
+/// the loop property `!"llvm.loop.parallel_accesses", !N`.
+pub fn mirAccessGroupLine(ref: String) -> String {
+    ref + " = distinct !\{\}"
+}
+
 /// mirLoopHintsActive reports whether any v0.6 loop annotation is
 /// set for the current function — i.e. whether the loop-metadata
 /// emitter should attach an `!llvm.loop !N` reference to this


### PR DESCRIPTION
## Summary

Second Phase-A batch for the MIR emitter selfhost port. 7 new helpers in `toolchain/mir_generator.osty` replace ~54 lines of hand-written Go in `mir_generator.go`.

### §11 operators — emitUnary body
- `mirUnaryIsIdentity` — short-circuit for unary `+`
- `mirUnaryInstruction` — LLVM instruction body for `-` / `!` / `~` covering the 4 distinct shapes (fneg / `sub 0,arg` / `xor i1 arg,1` / `xor ty arg,-1`). Go `emitUnary` switch collapses 45 → 15 lines.

### §12 strings — emitStringPool line template
- `mirStringPoolLine` — one `@.str.N = private unnamed_addr constant [N x i8] c"..."\n` line. Go caller pre-formats the decimal size via `strconv.Itoa` so the Osty helper stays on printable-ASCII string composition.

### §1 generator state — metadata node templates
- `mirAliasScopeDomainLine` / `ScopeLine` / `ListLine` — the three consecutive `!llvm.alias.scope` chain definitions that `listAliasScopeRef` emits lazily.
- `mirAccessGroupLine` — the bare `distinct !{}` access-group node for `#[parallel]` functions.

### Snapshot-pipeline note
Post #854 the Osty→Go transpiler is retired, so `mir_generator_snapshot.go` is now a **frozen committed seed** — new helpers land as hand-patched Go mirrors next to the Osty source of truth. The `// Osty: toolchain/...` comments still point callers at the authoritative `.osty` definition.

### Section status
- §1  Partial (9) → **Partial (13)**
- §11 Partial (6) → **Partial (8)**
- §12 Partial (2) → **Partial (3)**

## Test plan

- [x] `just front` — green
- [x] `go build ./internal/llvmgen/...` — clean
- [x] `go test -run 'TestUnary|TestEmitUnary|TestNegation|TestStringPool|TestAliasScope|TestAccessGroup|TestVector|TestLoop|TestMIR' -timeout 240s ./internal/llvmgen/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)