### PR TITLE
feat(selfhost): port §3 type-def + runtime-declare templates

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -55,7 +55,7 @@ untouched.
 | - | ------- | ----- | ----- | ---- | ------ |
 | 1 | generator state | 100–472 | ~10 | LOW | Partial — `firstNonEmpty`, `formatFnAttrs`, `loopHintsActive`, loop-metadata + alias-scope + access-group templates ported (`mirFormatFnAttrs`, `mirLoopHintsActive`, `mirLoopMDVectorizeEnable`/`Scalable`/`Predicate`/`Width`, `mirLoopMDUnrollEnable`/`Count`, `mirLoopMDParallelAccesses`, `mirAliasScopeDomainLine`/`ScopeLine`/`ListLine`, `mirAccessGroupLine`); `nextLoopMD` body + `g.loopMDDefs` indexing stays on Go (state) |
 | 2 | support check | 473–1364 | ~20 | MEDIUM | Go-only |
-| 3 | header + runtime declares | 1365–1641 | ~8 | LOW | Go-only |
+| 3 | header + runtime declares | 1365–1641 | ~8 | LOW | Partial — global-var, ctor, iface/struct/enum/tuple/vtable type-def lines + three runtime-declare shapes ported (`mirLlvmGlobalVarLine`, `mirLlvmIfaceTypeDefLine`, `mirLlvmStructTypeDefLine`, `mirLlvmEnumLayoutTypeDefLine`, `mirLlvmVtableDeclLine`, `mirGlobalCtorsRegistration`, `mirInitGlobalsCtorHeader`/`Footer`/`StoreSequence`, `mirRuntimeDeclareLine`, `mirRuntimeDeclareMemoryRead`, `mirRuntimeDeclareNoReturn`); orchestration (`emitGlobalVars`/`emitTypeDefs`/`emitRuntimeDeclarations`) + state (`g.declares`/`g.out`) stays on Go |
 | 4 | function emission | 1642–2384 | ~18 | MEDIUM | Go-only |
 | 5 | GC instrumentation | 2385–2614 | ~8 | LOW | Go-only |
 | 6 | instructions | 2615–4873 | ~35 | HIGH | Go-only |
@@ -188,6 +188,18 @@ list keeps new Osty clean of known landmines.
 | `mirAliasScopeScopeLine` | `(ref: String, domainRef: String) -> String` | §1 | `!N = distinct !{!"osty.list.metadata.scope", !Domain}` — middle node of the chain |
 | `mirAliasScopeListLine` | `(ref: String, scopeRef: String) -> String` | §1 | `!N = !{!Scope}` — the one-element scope list attached via `!alias.scope`/`!noalias` |
 | `mirAccessGroupLine` | `(ref: String) -> String` | §1 | `!N = distinct !{}` — A6 parallel-access group root |
+| `mirLlvmGlobalVarLine` | `(name: String, llvmType: String) -> String` | §3 | `@<name> = global <T> zeroinitializer\n` — module-scope global backing; value filled by `@__osty_init_globals` ctor |
+| `mirLlvmIfaceTypeDefLine` | `() -> String` | §3 | `%osty.iface = type { ptr, ptr }\n` — fat-pointer type-def, emitted once when any interface reference lands in the module |
+| `mirLlvmStructTypeDefLine` | `(name: String, fieldsJoined: String) -> String` | §3 | `%<name> = type { <fields> }\n` — used for both user structs and tuple type-defs (shape is identical; caller joins field types first) |
+| `mirLlvmEnumLayoutTypeDefLine` | `(name: String) -> String` | §3 | `%<name> = type { i64, i64 }\n` — fixed 2-word enum layout for Option / Result / user enums |
+| `mirLlvmVtableDeclLine` | `(symbol: String) -> String` | §3 | `<sym> = external constant [0 x ptr]\n` — downcast-site vtable reference (body deferred) |
+| `mirGlobalCtorsRegistration` | `() -> String` | §3 | Constant `@llvm.global_ctors` appending-array that wires `@__osty_init_globals` at priority 65535 |
+| `mirInitGlobalsCtorHeader` | `() -> String` | §3 | `define private void @__osty_init_globals() {\nentry:\n` — ctor prelude |
+| `mirInitGlobalsCtorFooter` | `() -> String` | §3 | `  ret void\n}\n\n` — ctor epilogue with the two-newline separator before the ctors registration line |
+| `mirInitGlobalsCtorStoreSequence` | `(globName: String, retLLVM: String, initName: String) -> String` | §3 | One `%vName = call <T> @<init>() ; store <T> %vName, ptr @<glob>` pair inside the ctor body |
+| `mirRuntimeDeclareLine` | `(retTy: String, sym: String, argList: String) -> String` | §3 | Plain `declare <ret> @<sym>(<args>)` — no LLVM-attribute tuning |
+| `mirRuntimeDeclareMemoryRead` | `(retTy: String, sym: String, argList: String) -> String` | §3 | `declare ... ) nounwind willreturn memory(read)` — the attribute combo that unlocks LICM / CSE of snapshot calls (list-data / list-len / slow-path getters) |
+| `mirRuntimeDeclareNoReturn` | `(retTy: String, sym: String, argList: String, cold: Bool) -> String` | §3 | `declare ... ) noreturn` + optional ` cold nounwind` for bounds-check traps |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1398,45 +1398,23 @@ func (g *mirGen) emitGlobalVars() {
 		if glob == nil {
 			continue
 		}
-		block.WriteByte('@')
-		block.WriteString(glob.Name)
-		block.WriteString(" = global ")
-		block.WriteString(g.llvmType(glob.Type))
-		block.WriteString(" zeroinitializer\n")
+		block.WriteString(mirLlvmGlobalVarLine(glob.Name, g.llvmType(glob.Type)))
 	}
 	block.WriteByte('\n')
 	// Ctor function: `@__osty_init_globals() { call <Ti> @_init_xxx();
 	// store <Ti> %tmp, ptr @xxx; ... ret void }`.
-	block.WriteString("define private void @__osty_init_globals() {\n")
-	block.WriteString("entry:\n")
+	block.WriteString(mirInitGlobalsCtorHeader())
 	for _, glob := range g.mod.Globals {
 		if glob == nil || glob.Init == nil {
 			continue
 		}
-		initName := glob.Init.Name
-		retLLVM := g.llvmType(glob.Type)
-		tmp := "%v" + glob.Name
-		block.WriteString("  ")
-		block.WriteString(tmp)
-		block.WriteString(" = call ")
-		block.WriteString(retLLVM)
-		block.WriteString(" @")
-		block.WriteString(initName)
-		block.WriteString("()\n")
-		block.WriteString("  store ")
-		block.WriteString(retLLVM)
-		block.WriteByte(' ')
-		block.WriteString(tmp)
-		block.WriteString(", ptr @")
-		block.WriteString(glob.Name)
-		block.WriteByte('\n')
+		block.WriteString(mirInitGlobalsCtorStoreSequence(glob.Name, g.llvmType(glob.Type), glob.Init.Name))
 	}
-	block.WriteString("  ret void\n")
-	block.WriteString("}\n\n")
+	block.WriteString(mirInitGlobalsCtorFooter())
 	// LLVM ctor registration. Priority 65535 runs last among ctors
 	// so anything with lower priority (runtime setup) has already
 	// executed.
-	block.WriteString("@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__osty_init_globals, ptr null }]\n\n")
+	block.WriteString(mirGlobalCtorsRegistration())
 
 	// Inject the block before the first `define ` / `declare ` line
 	// so the `@<name>` globals and the ctor sit alongside type defs.
@@ -1533,7 +1511,7 @@ func (g *mirGen) emitTypeDefs() {
 		// Interface fat-pointer type def must precede any `%osty.iface`
 		// use inside struct / tuple layouts. Ordering is conservative —
 		// emit once at the top of the type-def block.
-		block.WriteString("%osty.iface = type { ptr, ptr }\n")
+		block.WriteString(mirLlvmIfaceTypeDefLine())
 	}
 	for _, name := range g.structOrder {
 		sl := g.mod.Layouts.Structs[name]
@@ -1544,16 +1522,10 @@ func (g *mirGen) emitTypeDefs() {
 		for i, f := range sl.Fields {
 			parts[i] = g.llvmType(f.Type)
 		}
-		block.WriteByte('%')
-		block.WriteString(name)
-		block.WriteString(" = type { ")
-		block.WriteString(strings.Join(parts, ", "))
-		block.WriteString(" }\n")
+		block.WriteString(mirLlvmStructTypeDefLine(name, strings.Join(parts, ", ")))
 	}
 	for _, name := range g.enumLayoutOrder {
-		block.WriteByte('%')
-		block.WriteString(name)
-		block.WriteString(" = type { i64, i64 }\n")
+		block.WriteString(mirLlvmEnumLayoutTypeDefLine(name))
 	}
 	for _, name := range g.tupleOrder {
 		elems := g.tupleDefs[name]
@@ -1561,11 +1533,7 @@ func (g *mirGen) emitTypeDefs() {
 		for i, e := range elems {
 			parts[i] = g.llvmType(e)
 		}
-		block.WriteByte('%')
-		block.WriteString(name)
-		block.WriteString(" = type { ")
-		block.WriteString(strings.Join(parts, ", "))
-		block.WriteString(" }\n")
+		block.WriteString(mirLlvmStructTypeDefLine(name, strings.Join(parts, ", ")))
 	}
 	// Vtable declarations for every `@osty.vtable.<impl>__<iface>`
 	// referenced from a downcast call site. Declared as external
@@ -1574,10 +1542,7 @@ func (g *mirGen) emitTypeDefs() {
 	// only needs the symbol to exist so the `icmp eq ptr` is a legal
 	// reference.
 	for _, sym := range g.vtableRefOrder {
-		// `<sym> = external constant [0 x ptr]` — `@`-prefixed symbol
-		// already present in `sym`.
-		block.WriteString(sym)
-		block.WriteString(" = external constant [0 x ptr]\n")
+		block.WriteString(mirLlvmVtableDeclLine(sym))
 	}
 	block.WriteByte('\n')
 
@@ -2077,7 +2042,7 @@ func (g *mirGen) snapshotVectorListLocal(local mir.LocalID, elemLLVM string) {
 	scopeList := g.listAliasScopeRef()
 
 	dataSym := listRuntimeDataSymbol(elemLLVM)
-	g.declareRuntime(dataSym, "declare ptr @"+dataSym+"(ptr) nounwind willreturn memory(read)")
+	g.declareRuntime(dataSym, mirRuntimeDeclareMemoryRead("ptr", dataSym, "ptr"))
 	dataReg := g.fresh()
 	g.fnBuf.WriteString("  ")
 	g.fnBuf.WriteString(dataReg)
@@ -2091,7 +2056,7 @@ func (g *mirGen) snapshotVectorListLocal(local mir.LocalID, elemLLVM string) {
 	g.vectorListData[local] = dataReg
 
 	lenSym := listRuntimeLenSymbol()
-	g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+	g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 	lenReg := g.fresh()
 	g.fnBuf.WriteString("  ")
 	g.fnBuf.WriteString(lenReg)
@@ -2192,7 +2157,7 @@ func (g *mirGen) emitVectorListFastLoad(local mir.LocalID, idxVal, elemLLVM stri
 	// readonly lets LLVM reason across the fast/slow branch and keep
 	// the loop vectorizable even when the slow path is theoretically
 	// reachable for OOB indices.
-	g.declareRuntime(slowSym, "declare "+elemLLVM+" @"+slowSym+"(ptr, i64) nounwind willreturn memory(read)")
+	g.declareRuntime(slowSym, mirRuntimeDeclareMemoryRead(elemLLVM, slowSym, "ptr, i64"))
 	g.fnBuf.WriteString(slowLabel)
 	g.fnBuf.WriteString(":\n")
 	listReg := g.fresh()
@@ -2333,7 +2298,7 @@ func (g *mirGen) emitVectorListFastStore(local mir.LocalID, idxVal, valReg, elem
 	// as a memory writer) is what unlocks the in-loop LICM win on
 	// matmul and quicksort's partition step.
 	const oobSym = "osty_rt_list_oob_abort_v1"
-	g.declareRuntime(oobSym, "declare void @"+oobSym+"() noreturn cold nounwind")
+	g.declareRuntime(oobSym, mirRuntimeDeclareNoReturn("void", oobSym, "", true))
 	g.fnBuf.WriteString(slowLabel)
 	g.fnBuf.WriteString(":\n")
 	g.fnBuf.WriteString("  call void @")
@@ -4724,7 +4689,7 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isNone, noneLabel, someLabel)
 		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
 		abortSym := "osty_rt_option_unwrap_none"
-		g.declareRuntime(abortSym, "declare void @"+abortSym+"() noreturn")
+		g.declareRuntime(abortSym, mirRuntimeDeclareNoReturn("void", abortSym, "", false))
 		fmt.Fprintf(&g.fnBuf, "  call void @%s()\n", abortSym)
 		g.fnBuf.WriteString("  unreachable\n")
 		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
@@ -4867,7 +4832,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			}
 		}
 		sym := listRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr) nounwind willreturn memory(read)")
+		g.declareRuntime(sym, mirRuntimeDeclareMemoryRead("i64", sym, "ptr"))
 		em := g.ostyEmitter()
 		result := llvmListLen(em, &LlvmValue{typ: "ptr", name: listReg})
 		g.flushOstyEmitter(em)
@@ -4905,7 +4870,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 				}
 			}
 			sym := listRuntimeGetSymbol(elemLLVM)
-			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64) nounwind willreturn memory(read)")
+			g.declareRuntime(sym, mirRuntimeDeclareMemoryRead(elemLLVM, sym, "ptr, i64"))
 			em := g.ostyEmitter()
 			result := llvmListGet(em,
 				&LlvmValue{typ: "ptr", name: listReg},
@@ -4955,7 +4920,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
 		lenSym := listRuntimeLenSymbol()
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
 		isEmpty := g.fresh()
@@ -5081,15 +5046,15 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		lenSym := listRuntimeLenSymbol()
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 		stringEq := ""
 		if isStringLLVMType(needleOp.Type()) {
 			// String equality must go through the runtime — raw ptr
 			// compare would reject equal-content separate allocations.
 			stringEq = llvmStringRuntimeEqualSymbol()
-			g.declareRuntime(stringEq, "declare i1 @"+stringEq+"(ptr, ptr) nounwind willreturn memory(read)")
+			g.declareRuntime(stringEq, mirRuntimeDeclareMemoryRead("i1", stringEq, "ptr, ptr"))
 		}
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
@@ -5160,13 +5125,13 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		lenSym := listRuntimeLenSymbol()
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 		stringEq := ""
 		if isStringLLVMType(needleOp.Type()) {
 			stringEq = llvmStringRuntimeEqualSymbol()
-			g.declareRuntime(stringEq, "declare i1 @"+stringEq+"(ptr, ptr) nounwind willreturn memory(read)")
+			g.declareRuntime(stringEq, mirRuntimeDeclareMemoryRead("i1", stringEq, "ptr, ptr"))
 		}
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
@@ -5232,7 +5197,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
 		lenSym := listRuntimeLenSymbol()
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		lenReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
 		isEmpty := g.fresh()
@@ -5271,7 +5236,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 func (g *mirGen) emitListLoadElement(listReg, idxReg string, elemLLVM string) (string, error) {
 	if listUsesTypedRuntime(elemLLVM) {
 		getSym := listRuntimeGetSymbol(elemLLVM)
-		g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+		g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 		elemReg := g.fresh()
 		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
 		return elemReg, nil
@@ -8496,9 +8461,9 @@ func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLV
 	destLLVM := g.llvmType(destT)
 	destSlot := g.localSlots[i.Dest.Local]
 	lenSym := listRuntimeLenSymbol()
-	g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr) nounwind willreturn memory(read)")
+	g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 	getSym := listRuntimeGetSymbol(elemLLVM)
-	g.declareRuntime(getSym, "declare "+elemLLVM+" @"+getSym+"(ptr, i64) nounwind willreturn memory(read)")
+	g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 	lenReg := g.fresh()
 	fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
 	nonNeg := g.fresh()

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -796,3 +796,69 @@ func mirEncodeLLVMString(s string) string {
 	}
 	return out + "\\00"
 }
+
+// Osty: toolchain/mir_generator.osty:781:5
+func mirLlvmGlobalVarLine(name string, llvmType string) string {
+	return "@" + name + " = global " + llvmType + " zeroinitializer\n"
+}
+
+// Osty: toolchain/mir_generator.osty:789:5
+func mirLlvmIfaceTypeDefLine() string {
+	return "%osty.iface = type { ptr, ptr }\n"
+}
+
+// Osty: toolchain/mir_generator.osty:796:5
+func mirLlvmStructTypeDefLine(name string, fieldsJoined string) string {
+	return "%" + name + " = type { " + fieldsJoined + " }\n"
+}
+
+// Osty: toolchain/mir_generator.osty:806:5
+func mirLlvmEnumLayoutTypeDefLine(name string) string {
+	return "%" + name + " = type { i64, i64 }\n"
+}
+
+// Osty: toolchain/mir_generator.osty:815:5
+func mirLlvmVtableDeclLine(symbol string) string {
+	return symbol + " = external constant [0 x ptr]\n"
+}
+
+// Osty: toolchain/mir_generator.osty:823:5
+func mirGlobalCtorsRegistration() string {
+	return "@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__osty_init_globals, ptr null }]\n\n"
+}
+
+// Osty: toolchain/mir_generator.osty:831:5
+func mirInitGlobalsCtorHeader() string {
+	return "define private void @__osty_init_globals() {\nentry:\n"
+}
+
+// Osty: toolchain/mir_generator.osty:838:5
+func mirInitGlobalsCtorFooter() string {
+	return "  ret void\n}\n\n"
+}
+
+// Osty: toolchain/mir_generator.osty:848:5
+func mirInitGlobalsCtorStoreSequence(globName string, retLLVM string, initName string) string {
+	tmp := "%v" + globName
+	return "  " + tmp + " = call " + retLLVM + " @" + initName + "()\n" +
+		"  store " + retLLVM + " " + tmp + ", ptr @" + globName + "\n"
+}
+
+// Osty: toolchain/mir_generator.osty:858:5
+func mirRuntimeDeclareLine(retTy string, sym string, argList string) string {
+	return "declare " + retTy + " @" + sym + "(" + argList + ")"
+}
+
+// Osty: toolchain/mir_generator.osty:868:5
+func mirRuntimeDeclareMemoryRead(retTy string, sym string, argList string) string {
+	return "declare " + retTy + " @" + sym + "(" + argList + ") nounwind willreturn memory(read)"
+}
+
+// Osty: toolchain/mir_generator.osty:876:5
+func mirRuntimeDeclareNoReturn(retTy string, sym string, argList string, cold bool) string {
+	prefix := "declare " + retTy + " @" + sym + "(" + argList + ") noreturn"
+	if cold {
+		return prefix + " cold nounwind"
+	}
+	return prefix
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -761,3 +761,111 @@ pub fn mirEncodeLLVMString(s: String) -> String {
     }
     out + "\\00"
 }
+
+/// mirLlvmGlobalVarLine renders `@<name> = global <ty> zeroinitializer\n`
+/// — one top-level global definition for each module Global. Used by
+/// `emitGlobalVars` in `internal/llvmgen/mir_generator.go`; the init
+/// expression is deferred into the `__osty_init_globals` ctor so the
+/// static allocation always starts zeroed.
+pub fn mirLlvmGlobalVarLine(name: String, llvmType: String) -> String {
+    "@" + name + " = global " + llvmType + " zeroinitializer\n"
+}
+
+/// mirLlvmIfaceTypeDefLine is the constant fat-pointer type
+/// definition `%osty.iface = type { ptr, ptr }\n` that must precede
+/// any `%osty.iface` use inside struct / tuple layouts. `ifaceTouched`
+/// gates emission on the Go side.
+pub fn mirLlvmIfaceTypeDefLine() -> String {
+    "%osty.iface = type \{ ptr, ptr \}\n"
+}
+
+/// mirLlvmStructTypeDefLine renders the `%<name> = type { <fields> }\n`
+/// line for a user struct or a tuple (both share the same shape; the
+/// Go caller joins the LLVM field types with `", "` first).
+pub fn mirLlvmStructTypeDefLine(name: String, fieldsJoined: String) -> String {
+    "%" + name + " = type \{ " + fieldsJoined + " \}\n"
+}
+
+/// mirLlvmEnumLayoutTypeDefLine renders the fixed 2-word enum layout
+/// `%<name> = type { i64, i64 }\n` — matches the MIR emitter's
+/// convention where Option / Result / user enums always use
+/// `{ i64 disc, i64 payload }` regardless of payload type (payloads
+/// narrower than i64 are upcast at construction, pointer payloads go
+/// through ptrtoint).
+pub fn mirLlvmEnumLayoutTypeDefLine(name: String) -> String {
+    "%" + name + " = type \{ i64, i64 \}\n"
+}
+
+/// mirLlvmVtableDeclLine renders `<sym> = external constant [0 x ptr]\n`
+/// for every `@osty.vtable.<impl>__<iface>` symbol referenced from a
+/// downcast compare site. `symbol` already includes the leading `@`.
+/// The vtable body itself isn't emitted by the MIR path yet — the
+/// declaration just makes the `icmp eq ptr` reference legal.
+pub fn mirLlvmVtableDeclLine(symbol: String) -> String {
+    symbol + " = external constant [0 x ptr]\n"
+}
+
+/// mirGlobalCtorsRegistration returns the constant
+/// `@llvm.global_ctors` appending-array line that wires
+/// `@__osty_init_globals` into LLVM's priority-ordered ctor queue at
+/// priority 65535 (runs last). Constant — no callsite-specific state.
+pub fn mirGlobalCtorsRegistration() -> String {
+    "@llvm.global_ctors = appending global [1 x \{ i32, ptr, ptr \}] [\{ i32, ptr, ptr \} \{ i32 65535, ptr @__osty_init_globals, ptr null \}]\n\n"
+}
+
+/// mirInitGlobalsCtorHeader is the `define private void
+/// @__osty_init_globals() \{\nentry:\n` prelude that opens the ctor
+/// body. Pair with `mirInitGlobalsCtorFooter` to bookend the per-global
+/// call+store sequences built by `mirInitGlobalsCtorStoreSequence`.
+pub fn mirInitGlobalsCtorHeader() -> String {
+    "define private void @__osty_init_globals() \{\nentry:\n"
+}
+
+/// mirInitGlobalsCtorFooter closes the ctor with `ret void` + `}` plus
+/// the trailing two newlines that separate the ctor from the
+/// following `@llvm.global_ctors` registration line.
+pub fn mirInitGlobalsCtorFooter() -> String {
+    "  ret void\n\}\n\n"
+}
+
+/// mirInitGlobalsCtorStoreSequence renders one global's
+/// `%vName = call <retLLVM> @<initName>()` +
+/// `store <retLLVM> %vName, ptr @<globName>` pair inside the
+/// `@__osty_init_globals` ctor body. The `%v<globName>` temp name
+/// scheme mirrors the Go source's per-global SSA naming — stable
+/// even if module-level init reordering changes later.
+pub fn mirInitGlobalsCtorStoreSequence(globName: String, retLLVM: String, initName: String) -> String {
+    let tmp = "%v" + globName
+    "  " + tmp + " = call " + retLLVM + " @" + initName + "()\n" +
+    "  store " + retLLVM + " " + tmp + ", ptr @" + globName + "\n"
+}
+
+/// mirRuntimeDeclareLine renders the plain-shape runtime declaration
+/// `declare <ret> @<sym>(<argList>)`. `argList` is already joined with
+/// `", "` by the caller — empty-arg functions pass `""`. Used for
+/// runtime intrinsics that don't need LLVM attribute tuning.
+pub fn mirRuntimeDeclareLine(retTy: String, sym: String, argList: String) -> String {
+    "declare " + retTy + " @" + sym + "(" + argList + ")"
+}
+
+/// mirRuntimeDeclareMemoryRead renders a read-only runtime intrinsic
+/// declare suffixed with `nounwind willreturn memory(read)`. The
+/// attribute trio is what unlocks LLVM's LICM / CSE of snapshot
+/// calls like `osty_rt_list_data_*` / `osty_rt_list_len` out of
+/// hot loops. Use for helpers whose result depends only on the
+/// pointed-to contents (no side effects, no trapping).
+pub fn mirRuntimeDeclareMemoryRead(retTy: String, sym: String, argList: String) -> String {
+    "declare " + retTy + " @" + sym + "(" + argList + ") nounwind willreturn memory(read)"
+}
+
+/// mirRuntimeDeclareNoReturn renders an abort-kind runtime declare
+/// with the `noreturn` attribute. The `cold` flag additionally
+/// appends `cold nounwind` — used for bounds-check traps and similar
+/// unlikely-taken paths so LLVM tilts block placement away from them.
+pub fn mirRuntimeDeclareNoReturn(retTy: String, sym: String, argList: String, cold: Bool) -> String {
+    let prefix = "declare " + retTy + " @" + sym + "(" + argList + ") noreturn"
+    if cold {
+        return prefix + " cold nounwind"
+    }
+    prefix
+}


### PR DESCRIPTION
## Summary

Third Phase-A batch for the MIR emitter selfhost port. 12 new helpers in `toolchain/mir_generator.osty` replace ~64 lines of hand-written Go (−64 / +27 in `mir_generator.go`).

### §3 — type-def line templates
Consumed by `emitGlobalVars` / `emitTypeDefs`:
- `mirLlvmGlobalVarLine` — `@<name> = global <T> zeroinitializer\n`
- `mirLlvmIfaceTypeDefLine` — constant `%osty.iface = type { ptr, ptr }\n`
- `mirLlvmStructTypeDefLine` — `%<name> = type { <fields> }\n` (used for structs + tuples; shape is identical)
- `mirLlvmEnumLayoutTypeDefLine` — fixed 2-word `%<name> = type { i64, i64 }\n` for Option / Result / user enums
- `mirLlvmVtableDeclLine` — downcast-site external constant reference

### §3 — ctor bookends + store sequence
- `mirGlobalCtorsRegistration` — constant `@llvm.global_ctors` appending-array line wiring `@__osty_init_globals` at priority 65535
- `mirInitGlobalsCtorHeader` / `Footer` — `define private void @__osty_init_globals() { ... ret void }` bookends
- `mirInitGlobalsCtorStoreSequence` — one per-global `%vN = call <T> @<init>() ; store <T> %vN, ptr @<glob>` pair

### §3 — runtime-declare shapes
Consumed by 18 `g.declareRuntime` callsites:
- `mirRuntimeDeclareLine` — plain `declare <ret> @<sym>(<args>)`
- `mirRuntimeDeclareMemoryRead` — adds `nounwind willreturn memory(read)` attribute trio that unlocks LLVM LICM / CSE of snapshot calls (list-data / list-len / slow-path getters). **16 callsites rewired.**
- `mirRuntimeDeclareNoReturn` — `... ) noreturn` plus optional ` cold nounwind` for bounds-check traps. **2 callsites rewired.**

### Section status
- §3 Go-only → **Partial** (12 helpers)

### Snapshot-pipeline reminder
Post #854 `mir_generator_snapshot.go` is a frozen committed seed; new helpers land as hand-patched Go mirrors next to the Osty source of truth.

## Test plan

- [x] `just front` — green
- [x] `go build ./internal/llvmgen/...` — clean
- [x] `go test -run 'TestGlobal|TestTypeDef|TestRuntimeDeclare|TestEnum|TestStruct|TestVtable|TestMIR' -timeout 240s ./internal/llvmgen/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)