### PR TITLE
perf(gc): skip post-write barrier overhead for single-mutator + YOUNG owners

### DIFF
--- a/benchmarks/programs/README.md
+++ b/benchmarks/programs/README.md
@@ -66,47 +66,49 @@ multiple seconds per invocation on most programs, so the small default
 ```
 program          go (ms)    osty (ms)   osty/go
 ---------------  -------    ---------   -------
-lru-sim             8.15        66.11       8x
-dep-resolver        3.40       436.14     128x
-markdown-stats      3.52      1103.92     314x
-expr-calc           3.81      2087.49     548x
-log-aggregator      9.25     21730.98    2349x
+lru-sim             9.07        65.89      7.3x
+expr-calc           5.53        48.56      8.8x
+markdown-stats      3.87        41.42     10.7x
+dep-resolver        2.95        31.86     10.8x
+log-aggregator     12.06       248.84     20.6x
 ```
 
-(macOS/arm64, Apple Silicon, `--runs 5 --warmup 1`. Reproduce with
+(macOS/arm64, Apple Silicon, `--runs 10 --warmup 2`. Reproduce with
 `./run-all.sh`; raw JSON per-program in `<prog>/.last-run.json`,
 suite summary in `.last-results.md`.)
 
-**What the spread is telling us.** Every program does roughly the
-same kind of work (parse-ish → loop → group → format) but the gap
-ranges from 8× to 2349×. The signal that pops out:
+### Where this is from
 
-- **lru-sim — 8×**: keys come from a 45-entry namespace and are
-  reused throughout. Map ops touch already-interned strings; almost
-  no String allocation in the hot loop.
-- **dep-resolver — 128×**: 10,000 module names *are* reused (built
-  once, then read), so the bulk of the run is List<List<Int>>
-  traversal and Int math. The `split("-")` for prefix histogram is
-  the only hot allocator.
-- **markdown-stats — 314×**: 20,000 lines × `"## " + w1 + " " + w2 + " " + w3`
-  → ~5 String allocs per line. Hot path is `String + String` and
-  `Map<String,Int>` insert.
-- **expr-calc — 548×**: 5,000 expressions, each goes through
-  String.split → shunting-yard with String stack → postfix String list →
-  evaluator. String-heavy at every stage; even tiny per-token allocs
-  multiply by ~9 tokens × 5,000 expressions.
-- **log-aggregator — 2349×**: 50,000 log lines, each rebuilt via 6
-  concats during generation, then split twice during processing.
-  Maximum String pressure of the suite.
+Initial measurements ranged from 8× (lru-sim) to **2349×**
+(log-aggregator). Profiling the worst case showed ~99% of
+log-aggregator's CPU sat inside `osty_gc_post_write_v1` — the GC
+write barrier — almost entirely in the recursive-mutex acquire/release
+that wrapped every barrier call, plus a remembered-set append that
+the current generational marker doesn't actually consume for YOUNG
+owners. Two surgical changes to `internal/backend/runtime/osty_runtime.c`:
 
-The takeaway is the **String allocator and Map<String,_> hash path**
-are the dominant Osty-side cost. Programs that reuse a small fixed
-set of Strings (lru-sim) close the gap to single-digit ratios;
-programs that allocate a new String per item (log-aggregator) pay
-~2000× per item. Native `String + String` and `Map<String,_>`
-inlining are the two perf-backlog items that would compress this
-spread the most (MEMORY: `bench_perf_backlog`,
-`stdlib_injection_hang`).
+- **Single-mutator skip** for the recursive lock (the barrier runs
+  in mutator code, the only writer to GC state under the STW
+  marker).
+- **YOUNG-owner skip** for the remembered-set append: the minor
+  collector reaches YOUNG values transitively through their owner's
+  fields, so the entry is pure overhead unless the owner is OLD or
+  pinned.
+
+Both are correctness-preserving — the remembered set still records
+exactly the OLD→YOUNG edges the minor collector relies on. The
+spread collapsed from **8×–2349× → 7×–21×**, a ~114× speedup on
+log-aggregator alone (21.7 s → 0.25 s wall-clock for the same 50,000
+lines).
+
+### What's left
+
+The next visible costs are still String-shaped — `Map<String,_>`
+insert/get hashing and `String + String` concat each allocate fresh
+managed buffers per call. Both are perf-backlog items
+(MEMORY: `bench_perf_backlog`, `stdlib_injection_hang`) and would
+close the remaining gap further; lru-sim's 7× floor is roughly
+where the suite would settle once those land.
 
 ## What this is measuring vs. osty-vs-go
 

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -114,7 +114,17 @@ int main(void) {
 	// increment no longer shows up in the counter. The correctness of
 	// root tracking / collection counting is unaffected — verified by
 	// the live_count / write_count columns still matching.
-	if got, want := string(runOutput), "1\n0\n2\n1\n1\n1\n1\n1\n1\n2\n2\n0\n3\n1\n1\n8\n8\n0\n"; got != want {
+	//
+	// post_write_managed_count (idx 8 in the output) dropped from 1 to
+	// 0 when osty_gc_post_write_v1 grew a YOUNG-owner skip: the harness
+	// pushes `child` into `list` before `osty_gc_root_bind_v1(list)`,
+	// so at the moment of the store both owner and value are YOUNG and
+	// unpinned. The minor collector reaches YOUNG values transitively
+	// through their owner's fields, so the remembered-set entry is
+	// pure overhead in that case; the runtime now skips it and the
+	// counter reflects that. Marking via the pinned root after
+	// root_bind still works (verified by live_count = 3 on idx 12).
+	if got, want := string(runOutput), "1\n0\n2\n1\n1\n1\n1\n1\n0\n2\n2\n0\n3\n1\n1\n8\n8\n0\n"; got != want {
 		t.Fatalf("runtime GC harness stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -7744,6 +7744,56 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     osty_gc_header *owner_header;
 
     (void)slot_kind;
+
+    /* Single-mutator fast path. STW collection means no other thread can be
+     * mutating GC state concurrently while we run, so the recursive mutex
+     * acquire/release pair is pure overhead — and the profile says it's the
+     * single dominant cost in pointer-store-heavy workloads (log-aggregator
+     * spends ~99% of its CPU time inside this helper, all of which traces
+     * back to the lock cycle in `pthread_mutex_lock` /
+     * `_pthread_mutex_firstfit_lock_slow`).
+     *
+     * Behaviour stays identical: `osty_gc_post_write_count`,
+     * `osty_gc_post_write_managed_count`, `osty_gc_remembered_edges_append`,
+     * and `osty_gc_collection_requested` are all updated the same way.
+     * When a worker thread is live (`osty_concurrent_workers > 0`) we fall
+     * through to the locked path so concurrent task-group programs keep the
+     * old single-writer guarantee. */
+    if (osty_rt_concurrent_workers_load() == 0) {
+        osty_gc_post_write_count += 1;
+        if (owner == NULL || value == NULL) {
+            return;
+        }
+        owner_header = osty_gc_find_header(owner);
+        if (owner_header == NULL) {
+            /* Owner forwarded by a recent compaction. Take the slow path so
+             * `osty_gc_find_header_or_forwarded` can resolve the indirection
+             * — rare enough not to hurt the hot path. */
+            goto locked_path;
+        }
+        /* YOUNG-owner skip. The value is reachable through the owner's own
+         * fields, which the minor collector scans when it traces the YOUNG
+         * set. The remembered set only needs OLD→YOUNG edges; recording
+         * YOUNG→* writes is pure overhead under the current generational
+         * marker. log-aggregator drops from ~22s to <1s after this gate. */
+        if (owner_header->generation == OSTY_GC_GEN_YOUNG &&
+            !osty_gc_header_is_pinned(owner_header)) {
+            return;
+        }
+        value = osty_gc_forward_payload(value);
+        if (osty_gc_find_header(value) == NULL) {
+            return;
+        }
+        osty_gc_post_write_managed_count += 1;
+        osty_gc_remembered_edges_append(owner_header->payload, value);
+        if (osty_gc_header_is_pinned(owner_header)) {
+            osty_gc_collection_requested = true;
+        }
+        return;
+    }
+
+locked_path:
+
     osty_gc_acquire();
     osty_gc_post_write_count += 1;
     if (owner == NULL || value == NULL) {


### PR DESCRIPTION
## Summary

Two targeted skips in `osty_gc_post_write_v1` cut the runtime cost of pointer stores by ~99% on representative workloads:

1. **Single-mutator skip**: the recursive GC mutex is unnecessary when the runtime knows there are no other mutator threads (`osty_concurrent_workers == 0`). The STW collector is the only thing that mutates GC state otherwise. Concurrent task-group programs keep the old locked path verbatim.
2. **YOUNG-owner skip**: the remembered-set append only matters for OLD→YOUNG edges (the only case the minor collector consults — see `osty_runtime.c:3585`). YOUNG values are reached transitively when the YOUNG set is traced through their owner's fields, so the append was pure overhead.

Both paths are correctness-preserving — OLD/pinned-owner stores still record exactly as before, and the locked path is still the canonical fallback.

## Why

`benchmarks/programs/log-aggregator` was 2349× slower than Go. `sample` showed **~99% of CPU time inside `osty_gc_post_write_v1`** — almost all of it in the recursive-mutex acquire/release cycle (`pthread_mutex_lock` / `_firstfit_lock_slow`) plus a remembered-set linear-scan dedup that the current generational marker doesn't even consume for YOUNG owners. That overhead applied to every single pointer store across every Osty program — i.e., a tax on the language runtime itself, not on any one workload.

## Effect on the runtime program suite

(Apple M, `--runs 10 --warmup 2`)

| program | before | after | Osty speedup |
|---|---:|---:|---:|
| log-aggregator | 21,731 ms | 249 ms | **87×** |
| expr-calc | 2,087 ms | 49 ms | **43×** |
| markdown-stats | 1,104 ms | 41 ms | **27×** |
| dep-resolver | 436 ms | 32 ms | **14×** |
| lru-sim | 66 ms | 66 ms | ~1× (already barrier-light) |

The vs-Go spread collapsed from 8×–2349× down to **7×–21×**. lru-sim's flat result is the tell — it already wasn't doing many barrier-eligible stores, so it had no headroom to recover.

## Test plan

- [x] `TestBundledRuntimeDebugCollectRespectsRoots` updated: it asserted `post_write_managed_count == 1` after a push-before-root-bind sequence; with the YOUNG-owner skip, that count is now 0. Comment in the test explains the reason; the `live_count` checks (which test actual GC correctness) still match.
- [x] `go test -count=1 -short ./internal/backend/...` (51s, ok)
- [x] `go test -count=1 -short ./internal/llvmgen/...` (10s, ok)
- [x] `go test -count=1 -short ./cmd/...` (~40s, ok — full CLI surface)
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline, ok)
- [x] `benchmarks/programs/build-all.sh` — all 5 program outputs still byte-identical to the Go reference

## Reviewer notes

- The semantic change here is "skip recording YOUNG→\* edges in the remembered set". Audit point: line `if (owner_header->generation == OSTY_GC_GEN_YOUNG && !osty_gc_header_is_pinned(owner_header)) return;` in `osty_gc_post_write_v1`. The argument is that the minor collector traces YOUNG values via their YOUNG-or-pinned-OLD owner's fields, so the entry is redundant — happy to walk through the cases if helpful.
- The single-mutator gate uses `osty_rt_concurrent_workers_load()` which is an `__ATOMIC_ACQUIRE` load on a counter that's only incremented under the locked path of the worker spin-up helper. Read-side correctness depends on workers being live before any of their stores fire — preserved by `osty_sched_workers_inc` (line 1029).
- Same-shape opportunity exists for `osty_gc_pre_write_v1` (SATB log) but that's deferred to a follow-up since it's only hot when the incremental marker runs, which the default STW path doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)