### PR TITLE
perf(mir): hoist non-escaping String.split out of loop bodies

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -5098,6 +5098,50 @@ void *osty_rt_strings_Split(const char *value, const char *sep) {
     return out;
 }
 
+/* osty_rt_strings_SplitInto reuses an existing List<String> as the
+ * destination instead of allocating a fresh one each call. The MIR
+ * `hoistNonEscapingSplitInLoops` pass rewrites tight-loop calls of the
+ * shape `let parts = row.split(",")` (where `parts` doesn't escape the
+ * loop body) into a hoisted `out = list_new()` at the preheader plus a
+ * per-iteration `SplitInto(out, row, ",")` here. The list backing array
+ * stabilises after the first iteration so subsequent calls only allocate
+ * the per-piece strings. csv_parse-style 100k×5-piece splits drop ~100k
+ * `osty_rt_list_new` allocs and the early `realloc` grows. */
+void osty_rt_strings_SplitInto(void *raw_out, const char *value, const char *sep) {
+    osty_rt_list *out;
+    const char *cursor;
+    const char *next;
+    size_t sep_len;
+
+    if (raw_out == NULL) {
+        osty_rt_abort("split_into out is null");
+    }
+    out = (osty_rt_list *)raw_out;
+    /* Preserve the previously-stamped layout (elem_size = sizeof(ptr),
+     * trace_elem = osty_gc_mark_slot_v1) by replaying push_ptr through
+     * osty_rt_list_clear then push. clear() leaves data/cap untouched. */
+    osty_rt_list_clear(out);
+    if (value == NULL) {
+        return;
+    }
+    if (sep == NULL || sep[0] == '\0') {
+        while (*value != '\0') {
+            char *piece = osty_rt_string_dup_range(value, 1);
+            osty_rt_list_push_ptr(out, piece);
+            value += 1;
+        }
+        return;
+    }
+    sep_len = strlen(sep);
+    cursor = value;
+    while ((next = strstr(cursor, sep)) != NULL) {
+        char *piece = osty_rt_string_dup_range(cursor, (size_t)(next - cursor));
+        osty_rt_list_push_ptr(out, piece);
+        cursor = next + sep_len;
+    }
+    osty_rt_list_push_ptr(out, osty_rt_string_dup_range(cursor, strlen(cursor)));
+}
+
 // osty_rt_strings_SplitN caps the output at `n` pieces, matching the
 // pure-Osty body in internal/stdlib/modules/strings.osty:
 //   n == 0 → empty list

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1199,6 +1199,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringSplitInto,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
@@ -4549,6 +4550,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringSplitInto,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -6314,6 +6316,9 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 // MIR `{i64 disc, i64 payload}` Result layout after validating the
 // parse at the runtime boundary.
 func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
+	if i.Kind == mir.IntrinsicStringSplitInto {
+		return g.emitStringSplitInto(i)
+	}
 	if i.Kind == mir.IntrinsicStringConcat {
 		if len(i.Args) == 0 {
 			return unsupported("mir-mvp", "string_concat with no args")
@@ -6674,6 +6679,44 @@ func (g *mirGen) emitStringSplit(i *mir.IntrinsicInstr, strReg string) error {
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}, {typ: "ptr", name: sepReg}})
 	g.flushOstyEmitter(em)
 	return g.storeIntrinsicResult(i, result)
+}
+
+// emitStringSplitInto lowers the void-returning in-place split form
+// produced by the `hoistNonEscapingSplitInLoops` MIR pass. Args are
+// `[out_list, value, sep]` — the runtime clears `out_list` then
+// refills it with the pieces, reusing the previously-grown backing
+// array. Dest must be nil (the side effect is the only result).
+func (g *mirGen) emitStringSplitInto(i *mir.IntrinsicInstr) error {
+	if len(i.Args) != 3 {
+		return unsupported("mir-mvp", "string_split_into arity")
+	}
+	if i.Dest != nil {
+		return unsupported("mir-mvp", "string_split_into has Dest")
+	}
+	outReg, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	if !isStringLLVMType(i.Args[1].Type()) {
+		return unsupported("mir-mvp", fmt.Sprintf("string_split_into value type %s", mirTypeString(i.Args[1].Type())))
+	}
+	valReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+	if err != nil {
+		return err
+	}
+	if !isStringLLVMType(i.Args[2].Type()) {
+		return unsupported("mir-mvp", fmt.Sprintf("string_split_into sep type %s", mirTypeString(i.Args[2].Type())))
+	}
+	sepReg, err := g.evalOperand(i.Args[2], i.Args[2].Type())
+	if err != nil {
+		return err
+	}
+	sym := "osty_rt_strings_SplitInto"
+	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, ptr)")
+	em := g.ostyEmitter()
+	em.body = append(em.body, fmt.Sprintf("  call void @%s(ptr %s, ptr %s, ptr %s)", sym, outReg, valReg, sepReg))
+	g.flushOstyEmitter(em)
+	return nil
 }
 
 // emitStringBinaryBoolIntrinsic dispatches `.startsWith(s)` /

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -4062,6 +4062,139 @@ func TestGenerateFromMIRBytesLastIndexOf(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRSplitInLoopHoistsToSplitInto — end-to-end check
+// that a `for row in rows { let parts = row.split(",") ... }` shape
+// survives `mir.Lower → mir.Optimize → GenerateFromMIR` and emits the
+// in-place `osty_rt_strings_SplitInto` call rather than the per-iter
+// allocating `osty_rt_strings_Split`. Composes the unit tests for the
+// MIR escape pass (internal/mir) and the SplitInto codegen below.
+func TestGenerateFromMIRSplitInLoopHoistsToSplitInto(t *testing.T) {
+	listStrT := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "rowParts",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "rows", Type: listStrT}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name:  "total",
+					Type:  ir.TInt,
+					Mut:   true,
+					Value: &ir.IntLit{Text: "0", T: ir.TInt},
+				},
+				&ir.ForStmt{
+					Kind: ir.ForIn,
+					Var:  "row",
+					Iter: &ir.Ident{Name: "rows", Kind: ir.IdentParam, T: listStrT},
+					Body: &ir.Block{
+						Stmts: []ir.Stmt{
+							&ir.LetStmt{
+								Name: "parts",
+								Type: listStrT,
+								Value: &ir.MethodCall{
+									Receiver: &ir.Ident{Name: "row", Kind: ir.IdentLocal, T: ir.TString},
+									Name:     "split",
+									Args:     []ir.Arg{{Value: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: ","}}}}},
+									T:        listStrT,
+								},
+							},
+							&ir.AssignStmt{
+								Op:      ir.AssignEq,
+								Targets: []ir.Expr{&ir.Ident{Name: "total", Kind: ir.IdentLocal, T: ir.TInt}},
+								Value: &ir.BinaryExpr{
+									Op:   ir.BinAdd,
+									Left: &ir.Ident{Name: "total", Kind: ir.IdentLocal, T: ir.TInt},
+									Right: &ir.MethodCall{
+										Receiver: &ir.Ident{Name: "parts", Kind: ir.IdentLocal, T: listStrT},
+										Name:     "len",
+										T:        ir.TInt,
+									},
+									T: ir.TInt,
+								},
+							},
+						},
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "total", Kind: ir.IdentLocal, T: ir.TInt},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	mir.Optimize(m)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/split_in_loop.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare void @osty_rt_strings_SplitInto(ptr, ptr, ptr)",
+		"call void @osty_rt_strings_SplitInto(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The per-iter allocating `osty_rt_strings_Split` call must be gone
+	// — the escape pass replaced it. (The declare line for the symbol
+	// may still appear if some other code-path declares it; the
+	// load-bearing assertion is the absence of the call site in the
+	// rewritten loop body.)
+	if strings.Contains(got, "call ptr @osty_rt_strings_Split(") {
+		t.Fatalf("hoist did not remove per-iter osty_rt_strings_Split call:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIRStringSplitInto — the void-returning in-place
+// split form synthesised by the `hoistNonEscapingSplitInLoops` MIR
+// pass must lower to `call void @osty_rt_strings_SplitInto(ptr, ptr,
+// ptr)`. Codegen-level smoke; the pass itself has unit tests in
+// internal/mir/escape_split_test.go.
+func TestGenerateFromMIRStringSplitInto(t *testing.T) {
+	listStrT := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+	fn := &mir.Function{
+		Name:       "split_inplace",
+		ReturnType: ir.TUnit,
+	}
+	fn.ReturnLocal = fn.NewLocal("_return", ir.TUnit, false, mir.Span{})
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	out := fn.NewLocal("out", listStrT, true, mir.Span{})
+	val := fn.NewLocal("v", ir.TString, false, mir.Span{})
+	sep := fn.NewLocal("s", ir.TString, false, mir.Span{})
+	fn.Locals[out].IsParam = true
+	fn.Locals[val].IsParam = true
+	fn.Locals[sep].IsParam = true
+	fn.Params = []mir.LocalID{out, val, sep}
+	entry := fn.NewBlock(mir.Span{})
+	fn.Entry = entry
+	bb := fn.Block(entry)
+	bb.Instrs = append(bb.Instrs, &mir.IntrinsicInstr{
+		Kind: mir.IntrinsicStringSplitInto,
+		Args: []mir.Operand{
+			&mir.CopyOp{Place: mir.Place{Local: out}, T: listStrT},
+			&mir.CopyOp{Place: mir.Place{Local: val}, T: ir.TString},
+			&mir.CopyOp{Place: mir.Place{Local: sep}, T: ir.TString},
+		},
+	})
+	bb.SetTerminator(&mir.ReturnTerm{})
+	m := &mir.Module{
+		Functions: []*mir.Function{fn},
+	}
+	gen, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/split_into.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(gen)
+	for _, want := range []string{
+		"declare void @osty_rt_strings_SplitInto(ptr, ptr, ptr)",
+		"call void @osty_rt_strings_SplitInto(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestGenerateFromMIRBytesSplit(t *testing.T) {
 	listBytes := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TBytes}, Builtin: true}
 	fn := &ir.FnDecl{

--- a/internal/mir/escape_split.go
+++ b/internal/mir/escape_split.go
@@ -1,0 +1,419 @@
+package mir
+
+import "fmt"
+
+// hoistNonEscapingSplitInLoops moves `IntrinsicStringSplit` allocations
+// out of loop bodies when the result list does not escape the iteration.
+//
+// Pattern (csv_parse, record_pipeline-style hot loops):
+//
+//	for row in rows {
+//	    let parts = row.split(",")
+//	    use parts[0], parts[1], parts.len()
+//	}
+//
+// Each iteration today calls `osty_rt_strings_Split` which allocates a
+// fresh `osty_rt_list` plus grows the backing array on the first few
+// pushes. After the transform, one persistent buffer is allocated in the
+// loop preheader, and each iteration calls `osty_rt_strings_SplitInto`
+// which clears and refills the buffer in place. Per-iteration cost drops
+// from `1 list_new + 1-2 realloc + N piece dups` to `N piece dups` once
+// the backing array has stabilised.
+//
+// Safety conditions (all must hold):
+//   - The split call lives in a natural loop (reachable from a back-edge
+//     header and reaching the back-edge source).
+//   - The result local L's only writes are the split call we're
+//     rewriting; reads of L only ever produce a derived scalar
+//     (`parts[i]` element via IndexProj, `parts.len()` via LenRV) or
+//     a Storage{Live,Dead} marker. Any read that yields the bare list
+//     pointer — return, call argument, aggregate field, alias copy,
+//     `&parts` — is treated as escape and bails the transform.
+//   - The loop has a unique preheader (a single predecessor of the
+//     header outside the loop body). MVP bails on multiple preheaders
+//     instead of synthesising one.
+//
+// Returns true when any function block was rewritten.
+func hoistNonEscapingSplitInLoops(fn *Function) bool {
+	if fn == nil || fn.IsExternal || fn.IsIntrinsic || len(fn.Blocks) == 0 {
+		return false
+	}
+	backEdges := findBackEdges(fn)
+	if len(backEdges) == 0 {
+		return false
+	}
+	preds := Predecessors(fn)
+	changed := false
+	for _, edge := range backEdges {
+		body := loopBodyBlocks(fn, edge.header, edge.from, preds)
+		if len(body) == 0 {
+			continue
+		}
+		preheader, ok := uniquePreheader(edge.header, body, preds)
+		if !ok {
+			continue
+		}
+		for _, bid := range body {
+			bb := fn.Block(bid)
+			if bb == nil {
+				continue
+			}
+			for instrIdx := 0; instrIdx < len(bb.Instrs); instrIdx++ {
+				ii, isIntr := bb.Instrs[instrIdx].(*IntrinsicInstr)
+				if !isIntr || ii.Kind != IntrinsicStringSplit {
+					continue
+				}
+				if ii.Dest == nil || ii.Dest.HasProjections() {
+					continue
+				}
+				if len(ii.Args) != 2 {
+					continue
+				}
+				destL := ii.Dest.Local
+				if !splitDestEscapeSafe(fn, destL, ii) {
+					continue
+				}
+				bufType := fn.Locals[destL].Type
+				bufID := fn.NewLocal(fmt.Sprintf("_split_buf_%d", destL), bufType, true, fn.Locals[destL].SpanV)
+				phBB := fn.Block(preheader)
+				phBB.Instrs = append(phBB.Instrs,
+					&StorageLiveInstr{Local: bufID, SpanV: phBB.SpanV},
+					&AssignInstr{
+						Dest:  Place{Local: bufID},
+						Src:   &AggregateRV{Kind: AggList, Fields: nil, T: bufType},
+						SpanV: phBB.SpanV,
+					},
+				)
+				splitInto := &IntrinsicInstr{
+					Kind: IntrinsicStringSplitInto,
+					Args: []Operand{
+						&CopyOp{Place: Place{Local: bufID}, T: bufType},
+						ii.Args[0], ii.Args[1],
+					},
+					SpanV: ii.SpanV,
+				}
+				aliasAssign := &AssignInstr{
+					Dest:  Place{Local: destL},
+					Src:   &UseRV{Op: &CopyOp{Place: Place{Local: bufID}, T: bufType}},
+					SpanV: ii.SpanV,
+				}
+				rewritten := make([]Instr, 0, len(bb.Instrs)+1)
+				rewritten = append(rewritten, bb.Instrs[:instrIdx]...)
+				rewritten = append(rewritten, splitInto, aliasAssign)
+				rewritten = append(rewritten, bb.Instrs[instrIdx+1:]...)
+				bb.Instrs = rewritten
+				changed = true
+				instrIdx++ // skip the appended alias on the next iteration
+			}
+		}
+	}
+	return changed
+}
+
+// backEdge captures one back-edge in the CFG: from → header where
+// header is an ancestor of from in the DFS tree from fn.Entry.
+type backEdge struct {
+	from   BlockID
+	header BlockID
+}
+
+// findBackEdges runs an iterative DFS from fn.Entry and reports every
+// edge whose terminator successor is gray when visited.
+func findBackEdges(fn *Function) []backEdge {
+	if fn == nil || len(fn.Blocks) == 0 {
+		return nil
+	}
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make([]int, len(fn.Blocks))
+	type frame struct {
+		bid       BlockID
+		successors []BlockID
+		nextIdx   int
+	}
+	push := func(stack []frame, b BlockID) []frame {
+		if int(b) < 0 || int(b) >= len(fn.Blocks) || color[b] != white {
+			return stack
+		}
+		color[b] = gray
+		bb := fn.Blocks[b]
+		var succ []BlockID
+		if bb != nil {
+			succ = Successors(bb.Term)
+		}
+		return append(stack, frame{bid: b, successors: succ})
+	}
+	var edges []backEdge
+	stack := push(nil, fn.Entry)
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.nextIdx >= len(top.successors) {
+			color[top.bid] = black
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		next := top.successors[top.nextIdx]
+		top.nextIdx++
+		if int(next) < 0 || int(next) >= len(fn.Blocks) {
+			continue
+		}
+		switch color[next] {
+		case white:
+			stack = push(stack, next)
+		case gray:
+			edges = append(edges, backEdge{from: top.bid, header: next})
+		}
+	}
+	return edges
+}
+
+// loopBodyBlocks returns the natural loop induced by a back edge
+// (backSrc → header): blocks reachable from header that can also reach
+// backSrc. Both header and backSrc are included.
+func loopBodyBlocks(fn *Function, header, backSrc BlockID, preds map[BlockID][]BlockID) []BlockID {
+	forward := map[BlockID]bool{header: true}
+	stack := []BlockID{header}
+	for len(stack) > 0 {
+		b := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		bb := fn.Block(b)
+		if bb == nil {
+			continue
+		}
+		for _, succ := range Successors(bb.Term) {
+			if forward[succ] {
+				continue
+			}
+			forward[succ] = true
+			stack = append(stack, succ)
+		}
+	}
+	if !forward[backSrc] {
+		return nil
+	}
+	backward := map[BlockID]bool{backSrc: true, header: true}
+	stack = append(stack[:0], backSrc)
+	for len(stack) > 0 {
+		b := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, pred := range preds[b] {
+			if backward[pred] {
+				continue
+			}
+			backward[pred] = true
+			stack = append(stack, pred)
+		}
+	}
+	var body []BlockID
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		if forward[bb.ID] && backward[bb.ID] {
+			body = append(body, bb.ID)
+		}
+	}
+	return body
+}
+
+// uniquePreheader returns the sole predecessor of header that lies
+// outside the loop body. Returns false when zero or multiple such
+// predecessors exist — MVP doesn't synthesise a preheader.
+func uniquePreheader(header BlockID, body []BlockID, preds map[BlockID][]BlockID) (BlockID, bool) {
+	inBody := map[BlockID]bool{}
+	for _, b := range body {
+		inBody[b] = true
+	}
+	found := BlockID(-1)
+	for _, p := range preds[header] {
+		if inBody[p] {
+			continue
+		}
+		if found != -1 {
+			return -1, false
+		}
+		found = p
+	}
+	if found == -1 {
+		return -1, false
+	}
+	return found, true
+}
+
+// splitDestEscapeSafe verifies that destL is only written by srcCall
+// and that every read of destL across the function either yields a
+// derived scalar (IndexProj element, LenRV) or is a Storage marker.
+// Any read that surfaces the bare list pointer is treated as escape.
+func splitDestEscapeSafe(fn *Function, destL LocalID, srcCall *IntrinsicInstr) bool {
+	if int(destL) < 0 || int(destL) >= len(fn.Locals) {
+		return false
+	}
+	if fn.Locals[destL].IsParam || fn.Locals[destL].IsReturn {
+		return false
+	}
+	if fn.ReturnLocal == destL {
+		return false
+	}
+	writes := 0
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, instr := range bb.Instrs {
+			switch x := instr.(type) {
+			case *AssignInstr:
+				if x.Dest.Local == destL {
+					if x.Dest.HasProjections() {
+						return false
+					}
+					return false // unrelated direct write — bail
+				}
+				if rvalueLeaksLocal(x.Src, destL) {
+					return false
+				}
+			case *CallInstr:
+				if x.Dest != nil && x.Dest.Local == destL {
+					return false
+				}
+				for _, op := range x.Args {
+					if operandLeaksLocal(op, destL) {
+						return false
+					}
+				}
+				if ind, ok := x.Callee.(*IndirectCall); ok {
+					if operandLeaksLocal(ind.Callee, destL) {
+						return false
+					}
+				}
+			case *IntrinsicInstr:
+				if x == srcCall {
+					writes++
+					continue
+				}
+				if x.Dest != nil && x.Dest.Local == destL {
+					return false
+				}
+				// Read-only list query intrinsics receive the bare list
+				// pointer as Args[0] but do not retain it past the call —
+				// safe to pass even though placeLeaksRoot would otherwise
+				// flag the bare CopyOp. Mutating intrinsics
+				// (push/insert/clear/pop) are deliberately *not* on this
+				// list; the buf reuse model only holds when nothing
+				// modifies the list between the SplitInto and the next
+				// iteration.
+				if len(x.Args) >= 1 && operandLeaksLocal(x.Args[0], destL) && readOnlyListQueryIntrinsic(x.Kind) {
+					// Args[0] is the receiver — fine for query intrinsics.
+					// Check the rest don't leak.
+					for _, op := range x.Args[1:] {
+						if operandLeaksLocal(op, destL) {
+							return false
+						}
+					}
+					continue
+				}
+				for _, op := range x.Args {
+					if operandLeaksLocal(op, destL) {
+						return false
+					}
+				}
+			case *StorageLiveInstr, *StorageDeadInstr:
+				// markers — fine.
+			}
+		}
+		switch t := bb.Term.(type) {
+		case *BranchTerm:
+			if operandLeaksLocal(t.Cond, destL) {
+				return false
+			}
+		case *SwitchIntTerm:
+			if operandLeaksLocal(t.Scrutinee, destL) {
+				return false
+			}
+		}
+	}
+	return writes == 1
+}
+
+// rvalueLeaksLocal reports whether evaluating rv yields a value that
+// contains destL's bare list pointer (and could therefore alias it
+// outside the loop). LenRV / DiscriminantRV produce scalars and never
+// leak. IndexProj reads under any operand produce element values, not
+// the list itself, so they are also safe.
+func rvalueLeaksLocal(rv RValue, destL LocalID) bool {
+	switch x := rv.(type) {
+	case *UseRV:
+		return operandLeaksLocal(x.Op, destL)
+	case *UnaryRV:
+		return operandLeaksLocal(x.Arg, destL)
+	case *BinaryRV:
+		return operandLeaksLocal(x.Left, destL) || operandLeaksLocal(x.Right, destL)
+	case *AggregateRV:
+		for _, f := range x.Fields {
+			if operandLeaksLocal(f, destL) {
+				return true
+			}
+		}
+		return false
+	case *CastRV:
+		return operandLeaksLocal(x.Arg, destL)
+	case *DiscriminantRV, *LenRV:
+		return false
+	case *AddressOfRV:
+		return x.Place.Local == destL
+	case *RefRV:
+		return x.Place.Local == destL
+	case *NullaryRV, *GlobalRefRV:
+		return false
+	}
+	return true // unknown rv — be conservative
+}
+
+// operandLeaksLocal returns true for a CopyOp/MoveOp whose Place would
+// surface the bare list pointer (root local destL with no projections,
+// or with a non-IndexProj first projection).
+func operandLeaksLocal(op Operand, destL LocalID) bool {
+	if op == nil {
+		return false
+	}
+	switch x := op.(type) {
+	case *CopyOp:
+		return placeLeaksRoot(x.Place, destL)
+	case *MoveOp:
+		return placeLeaksRoot(x.Place, destL)
+	}
+	return false
+}
+
+// placeLeaksRoot reports whether reading place yields the bare list
+// pointer of destL. Element reads (`destL[i]`, `destL[i].field`) do
+// not — IndexProj decomposes the list. Field/tuple/variant projections
+// before any IndexProj would not appear on a List<T>, so we treat them
+// conservatively as escape.
+func placeLeaksRoot(p Place, destL LocalID) bool {
+	if p.Local != destL {
+		return false
+	}
+	if len(p.Projections) == 0 {
+		return true
+	}
+	_, isIndex := p.Projections[0].(*IndexProj)
+	return !isIndex
+}
+
+// readOnlyListQueryIntrinsic enumerates the IntrinsicKind values that
+// take a List receiver as Args[0] and observe but never retain the list
+// past the call. Mutating list intrinsics (push, insert, clear, pop,
+// etc.) are deliberately excluded — the SplitInto reuse model assumes
+// nothing else changes the buffer between iterations.
+func readOnlyListQueryIntrinsic(k IntrinsicKind) bool {
+	switch k {
+	case IntrinsicListLen, IntrinsicListIsEmpty, IntrinsicListGet,
+		IntrinsicListContains, IntrinsicListFirst, IntrinsicListLast,
+		IntrinsicListIndexOf, IntrinsicListSorted, IntrinsicListSlice:
+		return true
+	}
+	return false
+}

--- a/internal/mir/escape_split_test.go
+++ b/internal/mir/escape_split_test.go
@@ -1,0 +1,279 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// listOfStringT is the MIR type used by the lowerer for `List<String>`
+// — a builtin NamedType `List` parameterised by `String`. The escape
+// pass keys off the dest local's type when synthesising the hoisted
+// buffer's AggregateRV, so it must round-trip through this exact
+// shape.
+func listOfStringT() Type {
+	return &ir.NamedType{Name: "List", Args: []ir.Type{TString}, Builtin: true}
+}
+
+// buildSplitInLoopFn synthesises a function with the structure produced
+// by `for row in rows { let parts = row.split(",") ... }`:
+//
+//	entry → header → body → step → header
+//	header → exit (loop break)
+//
+// Returns the function plus the body block ID so individual tests can
+// pin extra instructions into the body to exercise positive / negative
+// shapes.
+func buildSplitInLoopFn(t *testing.T) (*Function, BlockID, LocalID) {
+	t.Helper()
+	fn, _ := newTestFunction("split_loop", TInt)
+	rowsT := listOfStringT()
+	rowsL := fn.NewLocal("rows", rowsT, false, Span{})
+	fn.Locals[rowsL].IsParam = true
+	fn.Params = []LocalID{rowsL}
+	idx := fn.NewLocal("idx", TInt, true, Span{})
+	row := fn.NewLocal("row", TString, false, Span{})
+	parts := fn.NewLocal("parts", listOfStringT(), false, Span{})
+
+	header := fn.NewBlock(Span{})
+	body := fn.NewBlock(Span{})
+	step := fn.NewBlock(Span{})
+	exit := fn.NewBlock(Span{})
+
+	// entry block already exists (BlockID 0). Wire entry → header.
+	entry := fn.Block(fn.Entry)
+	entry.Instrs = append(entry.Instrs,
+		&StorageLiveInstr{Local: idx},
+		&AssignInstr{
+			Dest: Place{Local: idx},
+			Src:  &UseRV{Op: &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt}},
+		},
+	)
+	entry.SetTerminator(&GotoTerm{Target: header})
+
+	// header: branch idx<len ? body : exit
+	headerBB := fn.Block(header)
+	headerBB.SetTerminator(&BranchTerm{
+		Cond: &ConstOp{Const: &BoolConst{Value: true}, T: TBool},
+		Then: body,
+		Else: exit,
+	})
+
+	// body: row = rows[idx]; parts = row.split(",")
+	bodyBB := fn.Block(body)
+	bodyBB.Instrs = append(bodyBB.Instrs,
+		&StorageLiveInstr{Local: row},
+		&AssignInstr{
+			Dest: Place{Local: row},
+			Src: &UseRV{Op: &CopyOp{
+				Place: Place{Local: rowsL, Projections: []Projection{
+					&IndexProj{Index: &CopyOp{Place: Place{Local: idx}, T: TInt}, ElemType: TString},
+				}},
+				T: TString,
+			}},
+		},
+		&StorageLiveInstr{Local: parts},
+		&IntrinsicInstr{
+			Kind: IntrinsicStringSplit,
+			Dest: &Place{Local: parts},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: row}, T: TString},
+				&ConstOp{Const: &StringConst{Value: ","}, T: TString},
+			},
+		},
+	)
+	bodyBB.SetTerminator(&GotoTerm{Target: step})
+
+	// step: idx += 1; goto header (back edge)
+	stepBB := fn.Block(step)
+	stepBB.Instrs = append(stepBB.Instrs,
+		&AssignInstr{
+			Dest: Place{Local: idx},
+			Src: &BinaryRV{
+				Op:    BinAdd,
+				Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+				Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+				T:     TInt,
+			},
+		},
+	)
+	stepBB.SetTerminator(&GotoTerm{Target: header})
+
+	// exit: ReturnTerm
+	exitBB := fn.Block(exit)
+	exitBB.SetTerminator(&ReturnTerm{})
+
+	return fn, body, parts
+}
+
+// findIntrinsic walks the block for a single intrinsic of kind k and
+// returns it (or nil + the count when zero or multiple).
+func findIntrinsic(bb *BasicBlock, k IntrinsicKind) (*IntrinsicInstr, int) {
+	var hits []*IntrinsicInstr
+	for _, ins := range bb.Instrs {
+		if ii, ok := ins.(*IntrinsicInstr); ok && ii.Kind == k {
+			hits = append(hits, ii)
+		}
+	}
+	if len(hits) == 1 {
+		return hits[0], 1
+	}
+	return nil, len(hits)
+}
+
+func TestHoistSplit_PositiveBareUseAsIndex(t *testing.T) {
+	fn, bodyID, parts := buildSplitInLoopFn(t)
+	bodyBB := fn.Block(bodyID)
+	// Read parts[0] into a sink (still in the body, before goto step).
+	sink := fn.NewLocal("first", TString, false, Span{})
+	bodyBB.Instrs = append(bodyBB.Instrs[:len(bodyBB.Instrs)],
+		&StorageLiveInstr{Local: sink},
+		&AssignInstr{
+			Dest: Place{Local: sink},
+			Src: &UseRV{Op: &CopyOp{
+				Place: Place{Local: parts, Projections: []Projection{
+					&IndexProj{
+						Index:    &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt},
+						ElemType: TString,
+					},
+				}},
+				T: TString,
+			}},
+		},
+	)
+	// Re-hook terminator after splice.
+	bodyBB.SetTerminator(bodyBB.Term)
+
+	if !hoistNonEscapingSplitInLoops(fn) {
+		t.Fatalf("expected transform to apply")
+	}
+	if _, n := findIntrinsic(bodyBB, IntrinsicStringSplit); n != 0 {
+		t.Fatalf("expected IntrinsicStringSplit to be removed from body, got %d remaining", n)
+	}
+	splitInto, n := findIntrinsic(bodyBB, IntrinsicStringSplitInto)
+	if n != 1 {
+		t.Fatalf("expected exactly 1 IntrinsicStringSplitInto in body, got %d", n)
+	}
+	if len(splitInto.Args) != 3 {
+		t.Fatalf("expected SplitInto to have 3 args, got %d", len(splitInto.Args))
+	}
+	if splitInto.Dest != nil {
+		t.Fatalf("expected SplitInto Dest=nil (void result)")
+	}
+	// Preheader is the entry block (only non-loop predecessor of header).
+	entry := fn.Block(fn.Entry)
+	hasNew := false
+	for _, ins := range entry.Instrs {
+		if a, ok := ins.(*AssignInstr); ok {
+			if agg, ok := a.Src.(*AggregateRV); ok && agg.Kind == AggList && len(agg.Fields) == 0 {
+				hasNew = true
+			}
+		}
+	}
+	if !hasNew {
+		t.Fatalf("expected hoisted AggregateRV{AggList, []} in entry/preheader")
+	}
+}
+
+func TestHoistSplit_NegativeReturnEscapes(t *testing.T) {
+	fn, bodyID, parts := buildSplitInLoopFn(t)
+	bodyBB := fn.Block(bodyID)
+	// Make parts the return value (escape via ReturnLocal assignment).
+	bodyBB.Instrs = append(bodyBB.Instrs,
+		&AssignInstr{
+			Dest: Place{Local: fn.ReturnLocal},
+			Src: &UseRV{Op: &CopyOp{
+				Place: Place{Local: parts},
+				T:     listOfStringT(),
+			}},
+		},
+	)
+	bodyBB.SetTerminator(bodyBB.Term)
+	// fn.ReturnLocal is TInt in the test helper but the test only cares
+	// that the transform refuses to fire when the bare list pointer is
+	// captured into another local — type mismatch is irrelevant here.
+
+	if hoistNonEscapingSplitInLoops(fn) {
+		t.Fatalf("expected transform to refuse: parts is captured by return-local assignment")
+	}
+}
+
+func TestHoistSplit_NegativeCallArgEscapes(t *testing.T) {
+	fn, bodyID, parts := buildSplitInLoopFn(t)
+	bodyBB := fn.Block(bodyID)
+	// Pass parts as a call argument → escape.
+	bodyBB.Instrs = append(bodyBB.Instrs,
+		&CallInstr{
+			Callee: &FnRef{Symbol: "consume_parts", Type: nil},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: parts}, T: listOfStringT()},
+			},
+		},
+	)
+	bodyBB.SetTerminator(bodyBB.Term)
+
+	if hoistNonEscapingSplitInLoops(fn) {
+		t.Fatalf("expected transform to refuse: parts passed as call argument")
+	}
+}
+
+func TestHoistSplit_NegativeAggregateFieldEscapes(t *testing.T) {
+	fn, bodyID, parts := buildSplitInLoopFn(t)
+	bodyBB := fn.Block(bodyID)
+	// Box parts into a tuple → escape.
+	tupleT := &ir.TupleType{Elems: []ir.Type{listOfStringT()}}
+	tupleL := fn.NewLocal("box", tupleT, false, Span{})
+	bodyBB.Instrs = append(bodyBB.Instrs,
+		&StorageLiveInstr{Local: tupleL},
+		&AssignInstr{
+			Dest: Place{Local: tupleL},
+			Src: &AggregateRV{
+				Kind:   AggTuple,
+				Fields: []Operand{&CopyOp{Place: Place{Local: parts}, T: listOfStringT()}},
+				T:      tupleT,
+			},
+		},
+	)
+	bodyBB.SetTerminator(bodyBB.Term)
+
+	if hoistNonEscapingSplitInLoops(fn) {
+		t.Fatalf("expected transform to refuse: parts captured into tuple aggregate")
+	}
+}
+
+func TestHoistSplit_NegativeNoLoop(t *testing.T) {
+	fn, _ := newTestFunction("flat", TInt)
+	row := fn.NewLocal("row", TString, false, Span{})
+	parts := fn.NewLocal("parts", listOfStringT(), false, Span{})
+	entry := fn.Block(fn.Entry)
+	entry.Instrs = append(entry.Instrs,
+		&StorageLiveInstr{Local: row},
+		&AssignInstr{
+			Dest: Place{Local: row},
+			Src:  &UseRV{Op: &ConstOp{Const: &StringConst{Value: "a,b"}, T: TString}},
+		},
+		&StorageLiveInstr{Local: parts},
+		&IntrinsicInstr{
+			Kind: IntrinsicStringSplit,
+			Dest: &Place{Local: parts},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: row}, T: TString},
+				&ConstOp{Const: &StringConst{Value: ","}, T: TString},
+			},
+		},
+	)
+
+	if hoistNonEscapingSplitInLoops(fn) {
+		t.Fatalf("expected transform to refuse: split is not inside any loop")
+	}
+}
+
+func TestHoistSplit_PrintMIRRendersOpcode(t *testing.T) {
+	// Quick sanity that the new IntrinsicKind round-trips through the
+	// printer so debug dumps don't surface "invalid".
+	got := IntrinsicStringSplitInto.String()
+	if !strings.Contains(got, "split_into") {
+		t.Fatalf("expected printer to render new opcode, got %q", got)
+	}
+}

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -706,6 +706,16 @@ const (
 	// materialising an Option<V> struct and immediately unwrapping
 	// it, which `m.get(k) ?? d` would otherwise do.
 	IntrinsicMapGetOr
+
+	// IntrinsicStringSplitInto reuses an existing List<String> as the
+	// split destination instead of allocating a fresh one. Void result
+	// (Dest must be nil). Args: [out_list, value, sep]. Synthesised by
+	// the `hoistNonEscapingSplitInLoops` MIR pass when a loop-body
+	// `let parts = expr.split(sep)` does not escape — the pass moves
+	// the list allocation to the loop preheader and switches the
+	// per-iteration call to this in-place form. Lowers to
+	// `osty_rt_strings_SplitInto(out, value, sep)`.
+	IntrinsicStringSplitInto
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1688,6 +1698,8 @@ func (k IntrinsicKind) String() string {
 		return "list_slice"
 	case IntrinsicMapGetOr:
 		return "map_get_or"
+	case IntrinsicStringSplitInto:
+		return "string_split_into"
 	}
 	return "invalid"
 }

--- a/internal/mir/optimize.go
+++ b/internal/mir/optimize.go
@@ -49,6 +49,10 @@ func optimizeFunction(fn *Function) {
 	if fn == nil || fn.IsExternal || fn.IsIntrinsic {
 		return
 	}
+	// Structural rewrite — runs once before the peephole fixed point so
+	// the alias copy / new buffer local feed copy-prop / dead-assign
+	// elimination on the same Optimize call.
+	hoistNonEscapingSplitInLoops(fn)
 	const maxIters = 16
 	for i := 0; i < maxIters; i++ {
 		changed := false


### PR DESCRIPTION
## Summary

- Adds a MIR optimization pass that detects `for row in rows { let parts = row.split(\",\") ... }` shapes and rewrites them to a single hoisted `List<String>` allocated in the loop preheader plus a per-iteration in-place `osty_rt_strings_SplitInto(buf, value, sep)` call.
- New runtime helper `osty_rt_strings_SplitInto` mirrors `Split` but reuses the destination list — `osty_rt_list_clear` keeps the elem-layout stamp, then refills via the same `osty_rt_string_dup_range + osty_rt_list_push_ptr` path.
- New MIR opcode `IntrinsicStringSplitInto` (void result; args `[out_list, value, sep]`) plus codegen wiring.

## Why

Per-iter savings on csv_parse-style 5-piece splits: 1 list_new GC alloc + 1-2 backing-array realloc gone per row; only the 5 piece dups remain. Over 100k iterations that's ~300k allocations dropped before any other hot-path work.

Item from the bench-perf backlog (originally framed as escape analysis based stack-list optimization): hoist the split allocation when the result list does not escape the iteration.

## How

**Escape safety conditions** (all must hold or the rewrite bails):

- The split lives in a natural loop reachable from a back-edge header that can also reach the back-edge source.
- The result local's only writes are the split call we're rewriting; reads only ever produce a derived scalar — IndexProj element, `LenRV`, or a read-only list query intrinsic (`Len`/`IsEmpty`/`Get`/`Contains`/`First`/`Last`/`IndexOf`/`Sorted`/`Slice`). Anything that surfaces the bare list pointer (return, call argument, aggregate field, alias copy, `AddressOf`/`Ref`) is treated as escape.
- The loop has a unique preheader (a single predecessor of the header outside the loop body). MVP doesn't synthesise one; multi-preheader loops just bail.

**Pass implementation** ([internal/mir/escape_split.go](internal/mir/escape_split.go)):

- DFS gray/black to find back edges.
- Forward∩backward reachability for the natural loop body.
- Whole-function walk of every read/write of the dest local against the safety whitelist.
- Allocate `_split_buf_N = []` (`AggregateRV{AggList, []}`) at the preheader's tail; rewrite the split call to `IntrinsicStringSplitInto(buf, ...) ; parts = copy buf`.
- Wired into `optimizeFunction` as a one-shot before the peephole fixed point so copy-prop / dead-assign-elim can clean up the alias.

## Test plan

- [x] `internal/mir/escape_split_test.go` — positive (index reads), negatives (return / call arg / tuple aggregate field / no-loop).
- [x] `internal/llvmgen/mir_generator_test.go` — synthetic SplitInto codegen smoke + end-to-end HIR `for ... split ... len` going through `mir.Lower → mir.Optimize → GenerateFromMIR`, asserting `osty_rt_strings_SplitInto` appears and `osty_rt_strings_Split` per-iter call is gone.
- [x] `just front` — green.
- [x] `internal/mir` + `internal/llvmgen` `-short` — green.
- [ ] Pre-existing `TestParseSnapshot` and `TestNativeToolchainMergedMIRErrTypeFloor` failures — confirmed unrelated by re-running on clean origin/main; tracked separately.

## Reviewer notes

- Mutating list intrinsics (`push`/`insert`/`clear`/`pop`) are deliberately **not** on the read-only whitelist — the buffer-reuse model only holds when nothing else mutates the list between the SplitInto and the next iteration. If a future caller wants in-place mutation of split output, the safety rule needs revisiting.
- The pass is gated by `OSTY_MIR_OPTIMIZE` like every other MIR pass — set to `0`/`false`/`off` to bisect.
- Future work: same shape applies to `Bytes.split`, `string.chars()`, `string.bytes()`, `strings.Fields()`. Out of scope here; the runtime + MIR opcode + escape pass scaffolding generalises cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)