### PR TITLE
perf(gc): short-circuit load_v1 when no compaction has occurred

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -7904,12 +7904,34 @@ locked_path:
 void *osty_gc_load_v1(void *value) {
     void *out = value;
 
-    /* Single-mutator fast path, mirroring `osty_gc_post_write_v1`.
-     * Hash lookup + forwarding-table lookup don't need the recursive
-     * mutex when no worker thread is live: STW collection never overlaps
-     * mutator execution, so the tables can be read lock-free. The
-     * counter increments stay in lock-step with the locked path so
-     * test observability is preserved. */
+    /* Pre-compaction fast path. The only thing the slow path can do
+     * differently from "return value" is route forwarded payloads to
+     * their relocated header, which can only fire after a major
+     * compaction has actually moved at least one object — i.e., when
+     * `osty_gc_forwarding_count > 0`. Until then every load resolves
+     * to its input verbatim, so the hash + forwarding-table probes
+     * are pure overhead. log-aggregator-style code (read-heavy lists,
+     * no compaction) spent ~10% of CPU here post-#872 just hashing
+     * pointers to confirm "yes, that's the address you already had".
+     *
+     * Counters: load_count still steps every call (test observability).
+     * load_managed_count was previously "value resolved to a managed
+     * header"; with the fast path it counts non-NULL loads instead,
+     * which equals the previous semantic on every test program in
+     * the suite (none of them mix unmanaged sentinels into pointer
+     * fields the GC sees). The slow path keeps the original
+     * accounting for forwarded loads. */
+    if (osty_rt_concurrent_workers_load() == 0 &&
+        osty_gc_forwarding_count == 0) {
+        osty_gc_load_count += 1;
+        if (value != NULL) {
+            osty_gc_load_managed_count += 1;
+        }
+        return value;
+    }
+
+    /* Single-mutator path with forwarding active: skip the lock but
+     * keep the full hash + forwarding lookup. */
     if (osty_rt_concurrent_workers_load() == 0) {
         osty_gc_load_count += 1;
         if (osty_gc_find_header(value) != NULL) {


### PR DESCRIPTION
## Summary

Continues the runtime-perf series after #867 / #870 / #872 / #873. Profile post-#873 showed `osty.gc.load_v1` was the next-largest runtime cost — ~10% of CPU on lru-sim, ~5% on log-aggregator — driven by the hash + forwarding-table probes inside the load barrier.

## Problem

`osty_gc_load_v1`'s only job is to remap forwarded payloads to their relocated header. Forwarding only happens **after** a major compaction has actually moved at least one object, signalled by `osty_gc_forwarding_count > 0`. Until that point, every load resolves to its input verbatim — but the function still walked the hash + forwarding tables on every pointer load through `osty_rt_list_get_ptr` and friends, just round-tripping pointers for a counter side-effect.

For programs that never trigger a compaction (which is essentially every short-lived CLI / request-handler workload), this is pure overhead on every pointer load.

## Fix

Three-tier dispatch in `osty_gc_load_v1`:

1. **Single-mutator + `osty_gc_forwarding_count == 0`** → return `value` immediately. `osty_gc_load_count` still steps every call; `osty_gc_load_managed_count` bumps on non-NULL inputs (matches the previous semantic on every test program — none mix unmanaged sentinels into pointer fields).
2. **Single-mutator + forwarding active** → keep the unlocked hash + forwarding lookup path from #872.
3. **Multi-mutator** → original locked path unchanged.

## Effect on the runtime program suite

(Apple M, `--runs 15 --warmup 3`)

| program | before (#873) | after | speedup |
|---|---:|---:|---:|
| lru-sim | 39.30 ms | **20.45 ms** | **1.92×** |
| expr-calc | 13.47 ms | **9.57 ms** | 1.41× |
| markdown-stats | 18.04 ms | **13.18 ms** | 1.37× |
| log-aggregator | 51.83 ms | **41.10 ms** | 1.26× |
| dep-resolver | 6.49 ms | **5.18 ms** | 1.25× |

vs-Go ratio drops from 3×–5× to **2×–4×**. lru-sim gets the biggest win because its hot path is `cache[i]` accesses — `osty_rt_list_get_ptr` calls `load_v1` once per access.

## Cumulative effect since #867

| program | before #867 | after this PR | total |
|---|---:|---:|---:|
| log-aggregator | 21,731 ms | 41.10 ms | **528×** |
| expr-calc | 2,087 ms | 9.57 ms | 218× |
| markdown-stats | 1,104 ms | 13.18 ms | 84× |
| dep-resolver | 436 ms | 5.18 ms | 84× |
| lru-sim | 66 ms | 20.45 ms | 3.2× |

All on the runtime side — no user-code changes. Every Osty program with pointer loads through GC-managed lists or maps benefits immediately.

## Test plan

- [x] `go test -count=1 -short ./internal/backend/...` (49s, ok — the `osty_gc_debug_load_managed_count` assertions in the existing harnesses still hold because every loaded pointer in those tests IS a non-NULL managed payload, which is what the fast-path counts)
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline, ok)
- [x] `benchmarks/programs/build-all.sh` — all 5 outputs byte-identical to Go reference

## Reviewer notes

- Audit point: the new top-of-function block in `osty_gc_load_v1`. The semantic change is "load_managed_count counts non-NULL loads instead of resolved-managed loads when no compaction is pending". The two are equal whenever pointer fields don't store unmanaged values, which holds for every program in the test suite.
- The slow path is reached only after a major compaction has moved at least one object. If the system later goes back to "no forwarded entries" (compaction completes and entries are GC'd), the fast path resumes — `osty_gc_forwarding_count` is the live counter, not a one-way latch.
- The same single-mutator gate from #867 / #872 applies — concurrent task-group programs fall through to the locked path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)