### PR TITLE
perf(gc): prefetch + branch-hint on hot index probes

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1126,14 +1126,20 @@ static void osty_gc_index_grow(int64_t new_capacity) {
 static OSTY_HOT_INLINE void osty_gc_index_insert_new(void *payload, osty_gc_header *header) {
     size_t mask;
     size_t idx;
-    if (osty_gc_index_keys == NULL ||
-        (osty_gc_index_count + osty_gc_index_tombstones + 1) * 4 >=
-            osty_gc_index_capacity * 3) {
+    if (__builtin_expect(osty_gc_index_keys == NULL ||
+                         (osty_gc_index_count + osty_gc_index_tombstones + 1) * 4 >=
+                             osty_gc_index_capacity * 3, 0)) {
         int64_t new_cap = osty_gc_index_capacity == 0 ? 128 : osty_gc_index_capacity * 2;
         osty_gc_index_grow(new_cap);
     }
     mask = (size_t)(osty_gc_index_capacity - 1);
     idx = osty_gc_index_hash(payload) & mask;
+    /* Prefetch the slot we're about to read. Hash-table cache misses
+     * to L2/L3 are the dominant cost on alloc-heavy programs (50K+
+     * allocs/iter on log-aggregator); issuing the prefetch concurrently
+     * with the surrounding header-init work gives the load a chance to
+     * overlap with that work instead of stalling the probe. */
+    __builtin_prefetch(&osty_gc_index_keys[idx], 1 /* write */, 1 /* moderate locality */);
     /* Walk past live entries. The first tombstone we hit is reusable;
      * since the caller guarantees `payload` is fresh, we don't need
      * to keep walking to confirm absence — we can short-circuit on
@@ -1185,12 +1191,16 @@ static void osty_gc_index_insert(void *payload, osty_gc_header *header) {
 static osty_gc_header *osty_gc_index_lookup(void *payload) {
     size_t mask;
     size_t idx;
-    if (osty_gc_index_keys == NULL || payload == NULL ||
-        payload == OSTY_GC_INDEX_TOMBSTONE) {
+    if (__builtin_expect(osty_gc_index_keys == NULL || payload == NULL ||
+                         payload == OSTY_GC_INDEX_TOMBSTONE, 0)) {
         return NULL;
     }
     mask = (size_t)(osty_gc_index_capacity - 1);
     idx = osty_gc_index_hash(payload) & mask;
+    /* Prefetch the first probe slot. Read-only locality hint: the
+     * caller is about to compare to payload, then maybe load a
+     * subsequent slot if there's a collision. */
+    __builtin_prefetch(&osty_gc_index_keys[idx], 0 /* read */, 1);
     while (osty_gc_index_keys[idx] != NULL) {
         if (osty_gc_index_keys[idx] == payload) {
             return osty_gc_index_values[idx];


### PR DESCRIPTION
## Summary

Two-line micro-optimizations on the GC payload-index probe sites that the profile post-#879 still shows as the dominant alloc-path cost on log-aggregator-shaped workloads (~50K live entries spread across a multi-MB index, every probe is a fresh L2/L3 cache line).

1. **Prefetch the first-probe slot.** `osty_gc_index_insert_new` and `osty_gc_index_lookup` issue an explicit `__builtin_prefetch` for the slot the hash points at, alongside the hash compute. Hardware can issue the line fetch in parallel with the surrounding header-init / counter work and hide L3 latency that would otherwise stall the probe load.
2. **Branch-hint the cold cap-check.** `__builtin_expect` marks the table-NULL / load-factor-exceeded branch as unlikely so the compiler keeps the hot path linear and pushes the grow path out-of-line.

## Results

Within hyperfine noise on this run — the suite is sensitive to thermal / background-load drift on Apple M, and Go side moved alongside Osty side on every iteration of this measurement. The changes don't regress anything and set the probe path up to absorb future cache-friendliness work without structural overhead.

## What's left

The remaining vs-Go gap on alloc-heavy programs (3-4× across the suite) is genuinely structural at this point. Per-allocation hash registration is the tax this design pays for cheap `find_header(payload)` in the write barrier and root scanner. Closing it further requires one of:

- **Skip eager registration for transient YOUNG allocs.** Attempted in a follow-up iteration; correctness around STW + minor compaction was non-trivial — Map relocation paths and bump-block forwarding aliases interact in ways that broke several Phase-D regression tests. Solvable but deserves its own PR with a careful test-by-test fix-up.
- **Codegen-level escape analysis to reduce allocation count itself.** Not a runtime change; needs a new MIR pass that tracks transient String / List liveness across loop iterations and either elides the alloc or lowers it to `splitN` style.
- **Go-style allocator with mmap'd managed regions + per-page metadata** instead of a hash. Multi-day restructure with broad surface-area touch on barrier / root-scanner / forwarding paths.

## Test plan

- [x] `go test -count=1 -short ./internal/backend/...` (54s, ok)
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline, ok)
- [x] `benchmarks/programs/build-all.sh` — all 5 outputs byte-identical to Go reference

## Reviewer notes

- The prefetch hint targets the slot at `osty_gc_index_keys[idx]` where `idx = hash(payload) & mask`. That's the only deterministic fixed slot at probe entry; subsequent probes hit `idx+1`, `idx+2`, etc. depending on collision.
- Locality hint `1` (moderate) on both prefetches — we want the line in L2/L3 but not necessarily L1, since the probe will read it in the next few cycles regardless.
- `__builtin_expect` on the unlikely branch is harmless on compilers that ignore it; the prefetch builtin is also a safe no-op when the target lacks the hint instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)