### PR TITLE
perf(gc): elide allocate_managed's redundant zero-stores

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -361,6 +361,15 @@ enum {
     OSTY_GC_COLOR_BLACK = 2,
 };
 
+/* `osty_gc_allocate_managed`'s hot path elides explicit zero-stores
+ * to header->color and header->generation, relying on the fact that
+ * the chunk is zero-initialized at this point and both default
+ * values are zero. Lock the assumption with a build-time check so
+ * a future enum-value reshuffle doesn't silently miscolour fresh
+ * allocations. */
+_Static_assert(OSTY_GC_COLOR_WHITE == 0,
+               "alloc fast path assumes WHITE is the zero color");
+
 /* Phase B generation tags (RUNTIME_GC_DELTA §5.1-5.5).
  *
  * Every managed allocation is born YOUNG. A minor collection promotes
@@ -378,6 +387,10 @@ enum {
     OSTY_GC_GEN_YOUNG = 0,
     OSTY_GC_GEN_OLD = 1,
 };
+
+_Static_assert(OSTY_GC_GEN_YOUNG == 0,
+               "alloc fast path assumes YOUNG is the zero generation");
+
 #define OSTY_GC_PROMOTE_AGE_DEFAULT 3
 #define OSTY_GC_PROMOTE_AGE_ENV "OSTY_GC_PROMOTE_AGE"
 #define OSTY_GC_NURSERY_LIMIT_ENV "OSTY_GC_NURSERY_BYTES"
@@ -2576,19 +2589,27 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
     header->site = site;
     header->payload = (void *)(header + 1);
     header->storage_kind = storage_kind;
-    /* Phase B: every new allocation enters the nursery. Promotion to
-     * OLD happens inside a minor collection after
-     * `osty_gc_promote_age` survivals. */
-    header->generation = OSTY_GC_GEN_YOUNG;
-    header->age = 0;
-    /* Phase C: header starts WHITE. An incremental major in
-     * progress will NOT retroactively colour this allocation — it was
-     * born after the mark snapshot and stays white until the cycle
-     * ends, at which point sweep reclaims it if still unrooted. SATB
-     * plus mutator assist together keep the grey queue draining so
-     * this is a bounded pressure, not an allocation floodgate. */
-    header->color = OSTY_GC_COLOR_WHITE;
-    header->marked = false;
+    /* generation / age / color / marked are NOT explicitly stored:
+     * the freshly-acquired chunk is zero-initialized regardless of
+     * source — TLAB blocks come out of mmap'd arena pages (kernel-
+     * zeroed on first touch), heap fallback uses calloc, and the
+     * free-list path memsets the chunk to zero on reuse (line above).
+     * The four values we'd write are all zero anyway:
+     *   - OSTY_GC_GEN_YOUNG  = 0
+     *   - age                = 0
+     *   - OSTY_GC_COLOR_WHITE = 0
+     *   - marked / false     = 0
+     * Eliding the redundant stores trims four cache-line touches off
+     * the allocate_managed hot path; on log-aggregator's 50K-alloc
+     * × 100-iter stress run that's ~20M dropped writes.
+     *
+     * Phase B intent: every new allocation enters the nursery.
+     * Promotion to OLD happens inside a minor collection after
+     * `osty_gc_promote_age` survivals. Phase C intent: header starts
+     * WHITE; an incremental major in progress will NOT retroactively
+     * colour this allocation — it was born after the mark snapshot
+     * and stays white until the cycle ends, at which point sweep
+     * reclaims it if still unrooted. */
     if (!single_threaded) osty_gc_acquire();
     if (humongous) {
         osty_gc_humongous_alloc_count_total += 1;


### PR DESCRIPTION
## Summary

`osty_gc_allocate_managed` unconditionally stored zero into four header fields whose default value is also zero, on every allocation:

```c
header->generation = OSTY_GC_GEN_YOUNG;   /* 0 */
header->age        = 0;
header->color      = OSTY_GC_COLOR_WHITE; /* 0 */
header->marked     = false;               /* 0 */
```

The chunk is zero-initialized at this point regardless of source:
- TLAB blocks come from mmap'd arena pages (kernel-zeroed on first touch since #881),
- Heap fallback uses `calloc`,
- The free-list reuse path memsets the chunk to zero on take.

So the four stores were writing zero over zero — no behavioural effect, just unnecessary cache traffic on a hot path that runs millions of times per program.

## Fix

Drop the four explicit zero-stores. The fields are still initialized to the same value, just by upstream zeroing rather than explicit assignment.

Two `_Static_assert`s on `OSTY_GC_COLOR_WHITE == 0` and `OSTY_GC_GEN_YOUNG == 0` lock the assumption — a future enum-value reshuffle that puts a non-zero default for these fields would otherwise silently miscolour fresh allocations.

## Effect

On log-aggregator's 50K-alloc × 100-iter stress run that's ~20M elided writes. The per-call delta is sub-nanosecond, but it's the kind of micro-overhead that accumulates against `osty_gc_allocate_managed`'s 611-sample profile share post-#882. Wall-time delta on this measurement run was within noise (Go side moved alongside Osty side); the change matters more for the architectural cleanup than the immediate microbench delta.

## Test plan

- [x] `go test -count=1 -short ./internal/backend/...` (55s, ok)
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline, ok)
- [x] `benchmarks/programs/build-all.sh` — all 5 outputs byte-identical to Go reference

## Reviewer notes

- The `_Static_assert`s catch the obvious failure mode: someone reshuffles the enum (`OSTY_GC_COLOR_WHITE = 1, OSTY_GC_COLOR_GREY = 0` for some reason) and silently corrupts every fresh allocation's color. The build fails instead.
- The Phase-B / Phase-C intent comments that previously sat next to the explicit stores are preserved in the elide-comment block — they explain *why* the values are what they are, even though we no longer write them explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)