### PR TITLE
feat(airepair): 학습 루프 prepush/CI 결합 + osty pipeline 와이어 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,19 @@ jobs:
         run: |
           while IFS= read -r file; do
             case "$file" in
-              testdata/spec/negative/*) continue ;;
+              testdata/spec/negative/*|internal/airepair/testdata/corpus/*.input.osty) continue ;;
             esac
             "$OSTY_BIN" repair --check "$file"
           done < <(git ls-files '*.osty')
+
+      - name: Osty airepair backlog
+        if: always()
+        run: |
+          bash scripts/airepair-update-backlog.sh "$OSTY_BIN" "$RUNNER_TEMP/airepair-cases" /tmp/todo-airepair.md
+          if ! diff -q todo-airepair.md /tmp/todo-airepair.md >/dev/null 2>&1; then
+            echo "::warning::todo-airepair.md is stale — run \`just airepair-capture\` and commit the result"
+            diff -u todo-airepair.md /tmp/todo-airepair.md || true
+          fi
 
       - name: Osty CI
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/.osty/
 .profiles/
 .direnv/
+tmp/
 
 # VS Code extension dependencies and packages
 node_modules/

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -334,7 +334,7 @@ func main() {
 	// timing/output table (or JSON). Has its own flag parser for
 	// --json and --trace.
 	if cmd == "pipeline" {
-		runPipeline(args[1:])
+		runPipeline(args[1:], flags)
 		return
 	}
 	// Build-profile / target / feature / cache inspection commands.

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -37,7 +37,7 @@ import (
 // the full pipeline; memprofile is captured once the pipeline completes
 // (with one explicit `runtime.GC()` first so the snapshot reflects live
 // allocations rather than transient garbage).
-func runPipeline(args []string) {
+func runPipeline(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("pipeline", flag.ExitOnError)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr,
@@ -103,10 +103,11 @@ func runPipeline(args []string) {
 		stream = os.Stderr
 	}
 	cfg := pipeline.Config{
-		PerDecl:    perDecl,
-		RunGen:     runGen,
-		GenBackend: backendID,
-		GenEmit:    emitMode,
+		PerDecl:         perDecl,
+		RunGen:          runGen,
+		GenBackend:      backendID,
+		GenEmit:         emitMode,
+		SourceTransform: aiRepairSourceTransform(aiRepairPrefix("pipeline"), os.Stderr, flags),
 	}
 
 	info, err := os.Stat(target)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -170,6 +170,12 @@ type Config struct {
 
 	// GenSourcePath is used for generated source anchors in single-file mode.
 	GenSourcePath string
+
+	// SourceTransform rewrites raw source bytes before parsing. The CLI sets
+	// this so directory/workspace pipeline runs go through the same airepair
+	// pre-pass as `osty check|build|run|test|lint` (Phase 1c arena flip).
+	// Nil keeps the historical raw-source loader.
+	SourceTransform resolve.SourceTransform
 }
 
 func genPackageName(cfgName, fallback string) string {
@@ -563,7 +569,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 // CLI can decide whether to abort. Uses the arena-first loader
 // (Phase 1c.2) so parse keeps the astbridge counter low.
 func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
-	pkg, err := resolve.LoadPackageArenaFirst(dir)
+	pkg, err := resolve.LoadPackageArenaFirstWithTransform(dir, cfg.SourceTransform)
 	if err != nil {
 		return Result{}, err
 	}
@@ -768,6 +774,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 		return r, err
 	}
 	ws.Stdlib = stdlib.LoadCached()
+	ws.SourceTransform = cfg.SourceTransform
 	for _, p := range resolve.WorkspacePackagePaths(dir) {
 		_, _ = ws.LoadPackageArenaFirst(p)
 	}

--- a/internal/runner/airepair_policy.go
+++ b/internal/runner/airepair_policy.go
@@ -65,7 +65,7 @@ func ParseAiRepairCaptureMode(value string) AiRepairCaptureModeResult {
 // Osty: toolchain/airepair_flags.osty:71
 func UsesFrontEndAIRepair(cmd string) bool {
 	switch cmd {
-	case "check", "typecheck", "resolve", "lint":
+	case "check", "typecheck", "resolve", "lint", "pipeline":
 		return true
 	default:
 		return false

--- a/internal/runner/airepair_policy_test.go
+++ b/internal/runner/airepair_policy_test.go
@@ -61,13 +61,13 @@ func TestParseAiRepairCaptureModeRejectsUnknown(t *testing.T) {
 }
 
 func TestUsesFrontEndAIRepair(t *testing.T) {
-	enabled := []string{"check", "typecheck", "resolve", "lint"}
+	enabled := []string{"check", "typecheck", "resolve", "lint", "pipeline"}
 	for _, cmd := range enabled {
 		if !UsesFrontEndAIRepair(cmd) {
 			t.Errorf("UsesFrontEndAIRepair(%q) = false, want true", cmd)
 		}
 	}
-	disabled := []string{"run", "build", "test", "gen", "pipeline", ""}
+	disabled := []string{"run", "build", "test", "gen", ""}
 	for _, cmd := range disabled {
 		if UsesFrontEndAIRepair(cmd) {
 			t.Errorf("UsesFrontEndAIRepair(%q) = true, want false", cmd)

--- a/justfile
+++ b/justfile
@@ -96,6 +96,11 @@ diag test=".":
 repair-check: build
     while IFS= read -r file; do case "$file" in testdata/spec/negative/*|internal/airepair/testdata/corpus/*.input.osty) continue ;; esac; {{bin}} repair --check "$file"; done < <(git ls-files '*.osty')
 
+# Capture residual airepair cases into tmp/airepair-cases/ and rewrite
+# todo-airepair.md with the ranked learning backlog. Non-blocking.
+airepair-capture: build
+    bash scripts/airepair-update-backlog.sh {{bin}}
+
 ci: build
     {{bin}} ci .
 
@@ -104,7 +109,7 @@ verify-selfhost:
 
 check: fmt-check vet front
 
-prepush: fmt-check vet repair-check ci
+prepush: fmt-check vet repair-check airepair-capture ci
 
 pipe target:
     test -x {{bin}} || just build

--- a/scripts/airepair-update-backlog.sh
+++ b/scripts/airepair-update-backlog.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Refresh tmp/airepair-cases/ + rewrite todo-airepair.md.
+# Used by `just airepair-capture` and the CI workflow so both
+# emit the same backlog format.
+#
+# Args: $1 = osty binary (default .bin/osty)
+#       $2 = capture dir (default tmp/airepair-cases)
+#       $3 = output markdown (default todo-airepair.md)
+
+set -u
+
+osty="${1:-.bin/osty}"
+captures="${2:-tmp/airepair-cases}"
+out="${3:-todo-airepair.md}"
+
+mkdir -p "$captures"
+
+scanned=0
+while IFS= read -r file; do
+	case "$file" in
+	testdata/spec/negative/* | internal/airepair/testdata/corpus/*.input.osty)
+		continue
+		;;
+	esac
+	"$osty" airepair --capture-dir "$captures" --capture-if residual "$file" >/dev/null 2>&1 || true
+	scanned=$((scanned + 1))
+done < <(git ls-files '*.osty')
+
+captured=$(find "$captures" -maxdepth 1 -name '*.input.osty' 2>/dev/null | wc -l | tr -d ' ')
+promoted=$(find internal/airepair/testdata/corpus -maxdepth 1 -name '*.input.osty' 2>/dev/null | wc -l | tr -d ' ')
+
+# Split signal from noise:
+#   changed=true  → airepair actually rewrote something = real AI-slip backlog
+#   changed=false → airepair left it untouched, residuals are toolchain
+#                   self-host / LLVM backend gaps (not learning fodder)
+#
+# Mirror the AI-slip cases into a sibling dir so `osty airepair learn`
+# only ranks signal, not noise.
+ai_dir="${captures}-ai-slips"
+rm -rf "$ai_dir"
+mkdir -p "$ai_dir"
+ai_slips=0
+domain_errs=0
+if [ "$captured" -gt 0 ]; then
+	for report in "$captures"/*.report.json; do
+		[ -f "$report" ] || continue
+		base="$(basename "$report" .report.json)"
+		if grep -q '"changed": true' "$report"; then
+			ai_slips=$((ai_slips + 1))
+			cp "$captures/$base.report.json" "$ai_dir/" 2>/dev/null || true
+			[ -f "$captures/$base.input.osty" ] && cp "$captures/$base.input.osty" "$ai_dir/"
+			[ -f "$captures/$base.expected.osty" ] && cp "$captures/$base.expected.osty" "$ai_dir/"
+		else
+			domain_errs=$((domain_errs + 1))
+		fi
+	done
+fi
+
+{
+	echo "# AI Repair Backlog"
+	echo
+	echo "_Auto-generated. Refresh with \`just airepair-capture\` (or rerun in CI)._"
+	echo
+	echo "**Scanned:** ${scanned} \`.osty\` file(s)  "
+	echo "**Captured:** ${captured} residual case(s) — **${ai_slips}** AI-slip(s) airepair rewrote, **${domain_errs}** untouched (toolchain self-host / backend gap, not airepair's job)  "
+	echo "**Corpus coverage:** ${promoted} promoted case(s)"
+	echo
+	echo "## AI-slip backlog (changed=true)"
+	echo
+	if [ "$ai_slips" -gt 0 ]; then
+		echo '```'
+		"$osty" airepair learn --top 10 --corpus internal/airepair/testdata/corpus "$ai_dir" 2>/dev/null |
+			sed -n '/^learning priorities:/,$p'
+		echo '```'
+	else
+		echo "_No new AI slips this run — airepair didn't need to rewrite anything._"
+		echo
+		echo "If \`Captured\` is non-zero above, it's domain code that fails the checker for unrelated reasons (self-host / backend coverage)."
+	fi
+	echo
+	echo "## Workflow"
+	echo
+	echo "1. \`just airepair-capture\` refreshes \`${captures}/\` and rewrites this file."
+	echo "2. For an AI-slip group above: \`${osty} airepair triage ${captures}/\` for detail, then \`${osty} airepair promote ${captures}/<case>\` to add to \`internal/airepair/testdata/corpus/\`."
+	echo "3. The untouched-residual count is a separate signal — it tracks how many \`.osty\` files in the repo currently fail the checker for non-AI-slip reasons."
+} >"$out"
+
+echo "airepair: captured ${captured} (AI-slips: ${ai_slips}, domain: ${domain_errs}) over ${scanned} files → ${out}"

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -1,0 +1,19 @@
+# AI Repair Backlog
+
+_Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
+
+**Scanned:** 315 `.osty` file(s)  
+**Captured:** 148 residual case(s) — **0** AI-slip(s) airepair rewrote, **148** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Corpus coverage:** 16 promoted case(s)
+
+## AI-slip backlog (changed=true)
+
+_No new AI slips this run — airepair didn't need to rewrite anything._
+
+If `Captured` is non-zero above, it's domain code that fails the checker for unrelated reasons (self-host / backend coverage).
+
+## Workflow
+
+1. `just airepair-capture` refreshes `tmp/airepair-cases/` and rewrites this file.
+2. For an AI-slip group above: `.bin/osty airepair triage tmp/airepair-cases/` for detail, then `.bin/osty airepair promote tmp/airepair-cases/<case>` to add to `internal/airepair/testdata/corpus/`.
+3. The untouched-residual count is a separate signal — it tracks how many `.osty` files in the repo currently fail the checker for non-AI-slip reasons.

--- a/toolchain/airepair_flags.osty
+++ b/toolchain/airepair_flags.osty
@@ -62,12 +62,12 @@ pub fn parseAiRepairCaptureMode(value: String) -> AiRepairCaptureModeResult {
 /// trigger AI-repair against the front-end diagnostics (parse +
 /// resolve + check) rather than just the parse/lex layer.
 ///
-/// check / typecheck / resolve / lint all surface the full
-/// front-end error set to the user, so they benefit from repairs
-/// that fix resolution-stage symptoms; run/build/test care only
-/// about the parser rewrite.
+/// check / typecheck / resolve / lint / pipeline all surface the
+/// full front-end error set to the user, so they benefit from
+/// repairs that fix resolution-stage symptoms; run/build/test
+/// care only about the parser rewrite.
 pub fn usesFrontEndAIRepair(cmd: String) -> Bool {
-    cmd == "check" || cmd == "typecheck" || cmd == "resolve" || cmd == "lint"
+    cmd == "check" || cmd == "typecheck" || cmd == "resolve" || cmd == "lint" || cmd == "pipeline"
 }
 
 /// shouldCaptureAiRepair decides whether an airepair run warrants

--- a/toolchain/airepair_flags_test.osty
+++ b/toolchain/airepair_flags_test.osty
@@ -46,6 +46,7 @@ fn testUsesFrontEndAIRepairCoversCheckerCommands() {
     testing.assert(usesFrontEndAIRepair("typecheck"))
     testing.assert(usesFrontEndAIRepair("resolve"))
     testing.assert(usesFrontEndAIRepair("lint"))
+    testing.assert(usesFrontEndAIRepair("pipeline"))
 }
 
 fn testUsesFrontEndAIRepairRejectsOtherCommands() {


### PR DESCRIPTION
## Summary

- airepair 학습 루프(capture → learn → backlog)를 prepush와 CI에 결합. 결과를 `todo-airepair.md`에 누적해 PR diff로 가시화
- 학습 ranking은 `changed=true`(실제 airepair가 수정한 AI-slip)만 포함하도록 신호/노이즈 분리 — `changed=false`는 toolchain 셀프호스팅/백엔드 갭이라 별도 카운트로만 표시
- `osty pipeline`의 깨진 airepair 와이어 fix (`RunPackage`/`RunWorkspace`에 `SourceTransform` 옵션 + `usesFrontEndAIRepair`에 `"pipeline"` 추가)

## Why

학습 루프 인프라(`triage`/`learn`/`promote`)는 #221~#242 시기에 만들어졌지만 시드 batch 1회(2026-04-16/17, 16건 코퍼스) 후 정지 상태였습니다. capture를 prepush/CI에 결합해 새 AI-slip이 들어오면 자동으로 backlog에 표시되도록 활성화합니다.

`osty pipeline`은 Phase 1c arena flip 이후 다른 명령들과 달리 `aiRepairSourceTransform`을 거치지 않아 AI-syntax가 그대로 fail. self-host 정책(`toolchain/airepair_flags.osty`)에 추가하고 Go 정책 동기화.

## End-to-end 검증

합성 AI-slip(`range(xs.length)` + 미존재 심볼) → capture → 분류 → learn ranking에 정확히 priority 1번으로 등장 확인 완료. 그 다음 cleanup → baseline 회복.

```
airepair: captured 148 (AI-slips: 0, domain: 148) over 315 files → todo-airepair.md
```

## Test plan

- [x] `just front` 통과
- [x] `internal/runner` 통과 (정책에 pipeline 추가, 테스트 동기화)
- [x] `internal/pipeline` 통과 (SourceTransform 와이어)
- [x] `cmd/osty` 통과
- [x] `bash scripts/airepair-update-backlog.sh .bin/osty` 로컬 실행 → todo-airepair.md baseline 갱신 확인
- [ ] CI에서 backlog freshness 워닝 step 정상 동작
- [ ] 후속: `osty fmt`의 `repair` vs `airepair` 문서/구현 불일치는 별도 task로 분리됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)