### PR TITLE
fix(fmt): wire osty fmt through airepair instead of conservative repair

### DIFF
--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -86,6 +86,31 @@ func TestFmtAIRepairFlagAliasesDisableAutomaticFixes(t *testing.T) {
 	}
 }
 
+func TestFmtRunsSemanticAIRepairBeforeFormatting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	source := "fn main() {\n    let items = [1, 2]\n    println(items.length)\n}\n"
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "fmt", "--write", path)
+	if got.exit != 0 {
+		t.Fatalf("fmt --write exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read formatted source: %v", err)
+	}
+	if strings.Contains(string(out), ".length") {
+		t.Fatalf("fmt left `.length` in source = %q; airepair semantic phase did not run", string(out))
+	}
+	if !strings.Contains(string(out), ".len()") {
+		t.Fatalf("fmt did not rewrite `.length` to `.len()`; source = %q", string(out))
+	}
+}
+
 func TestUsageOutputUsesCanonicalAIRepairNames(t *testing.T) {
 	t.Run("top-level", func(t *testing.T) {
 		got := runOstyCLI(t)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -2190,8 +2190,14 @@ func runFmt(args []string) {
 	formatSrc := src
 	var repairs repair.Result
 	if repairMode {
-		repairs = repair.Source(src)
-		formatSrc = repairs.Source
+		result := airepair.Analyze(airepair.Request{
+			Source:   src,
+			Filename: path,
+		})
+		if result.Accepted {
+			formatSrc = result.Repaired
+			repairs = result.Repair
+		}
 	}
 	parserCanonical, parserCanonicalChanged := parserCanonicalFmtSource(formatSrc)
 	if parserCanonicalChanged {


### PR DESCRIPTION
## Summary

- `runFmt` was calling `repair.Source(src)` (token-only lexical pass) while every other front-end command (`check`/`lint`/`build`/`run`/`gen`/`test`/`pipeline`) goes through `airepair.Analyze`
- Commit bf4d7af9 renamed the flag from `--no-repair` to `--no-airepair` and rebranded the doc strings to say "AI repair," but never replaced the body — README:293 + 332-333 documented the intended behavior, the wiring just didn't follow
- Switch `runFmt` to `airepair.Analyze` (default `ModeAutoAssist`); when airepair accepts, `formatSrc` becomes the repaired source and `repairs` carries the merged `repair.Result` for the existing `--check` summary path
- The downstream `parserCanonicalFmtSource` call stays — it's the lenient version that runs even when airepair's strict parser-canonical phase bailed on parse errors
- Add `TestFmtRunsSemanticAIRepairBeforeFormatting` as a regression guard: `items.length` requires the type-aware semantic phase that only airepair runs, so a regression to `repair.Source` immediately fails

## Test plan

- [x] `just cmd "TestFmt"` — new test + existing `TestFmtAIRepairFlagAliasesDisableAutomaticFixes` pass
- [x] `just cmd "TestCheckWithAIRepair|TestCheckWithoutAIRepair|TestAIRepair"` — all airepair-adjacent CLI coverage green
- [x] `just front` — lexer/parser/resolve/check/diag/format/lint/pipeline all green
- [x] `go test ./internal/airepair ./internal/repair` — package tests green

## Reviewer notes

- README left untouched per the original task instruction — it was already accurate, only the implementation lagged
- The `--airepair` / `--no-airepair` flag names on `osty fmt` are now correctly named (they actually toggle airepair, not the conservative pass)
- One known behavioral change worth surfacing: `osty fmt` now runs the full multi-phase semantic probe pipeline on every invocation. Editors invoking fmt on save will see slower latency than before. If that becomes a problem, a fmt-specific `ModeRewriteOnly` (skip diagnostic probes) would be the natural follow-up; out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)