### PR TITLE
refactor(llvmgen): port §15 stateful + Phase B fnBuf mirror + 14 LLVM-line builders

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -67,7 +67,7 @@ untouched.
 | 12 | strings | 9197–9284 | ~7 | LOW | Partial — `encodeLLVMString`, `earliestAfter` (single + multi-needle: `mirEarliestAfter` + `mirEarliestAfterAny`), `mirInjectBeforeFirstFn` inject orchestration, and the string-pool line template ported (`mirEncodeLLVMString`, `mirStringPoolLine`); `stringLiteral` interning stays on Go (touches `g.strings`). `emitStringPool` / `emitGlobalVars` inject step now delegates through `mirInjectBeforeFirstFn`. |
 | 13 | type mapping | 9285–9375 | ~8 | LOW | **Ported** (primitive + opaque-named + head-name + optional-surface) |
 | 14 | enum layout helpers | 9376–9575 | ~10 | LOW | Partial — `llvmTypeForTupleTag` Prim / Named branches + Optional / Option / Result / Tuple name-mangling ported (`mirTupleTagForPrim`, `mirTupleTagForNamed`, `mirOptionalTypeName`, `mirOptionTypeName`, `mirResultTypeName`, `mirTupleTypeNameFromTags`); `registerEnumLayout` + `g.tupleDefs` caches deferred to Phase B |
-| 15 | helpers | 9576–9616 | ~5 | LOW | Partial — pure (`firstNonEmpty`, `isUnitType`, `isFloatType`, `isScalarLLVMType`, `llvmStdIoI1Text`) + state-bearing (`MirSeq.fresh` / `MirSeq.freshLabel` / `MirSeq.reset`) ported. Phase B start: `tempSeq` field migrated from `mirGen` into Osty `MirSeq` struct mirror. `ostyEmitter` / `flushOstyEmitter` / `storeIntrinsicResult` / `emitRuntimeRawNull` still touch other state; landing as the mirror grows |
+| 15 | helpers | 9576–9616 | ~5 | LOW | Partial — pure (`firstNonEmpty`, `isUnitType`, `isFloatType`, `isScalarLLVMType`, `llvmStdIoI1Text`) + state-bearing leaves (`MirSeq.fresh` / `MirSeq.freshLabel` / `MirSeq.reset`) + Phase B fnBuf mirror (`MirSeq.fnBuf`, `MirSeq.appendFnLine`, `MirSeq.flushFnBuf`, `MirSeq.absorbOstyEmitter`) ported. `flushOstyEmitter` Go bridge now routes through `MirSeq.absorbOstyEmitter` (Osty drains `em.body` into `seq.fnBuf`; Go drains back to `g.fnBuf`). `storeIntrinsicResult` Go body now uses the Osty `mirStoreLine` builder. `ostyEmitter` constructor stays on Go (Go `LlvmEmitter` has fields the Osty struct doesn't model — `nativeListData`/`nativeListLens`). `emitRuntimeRawNull` is mir-internal routing, no Osty change. |
 
 ## Phased plan
 
@@ -85,10 +85,12 @@ with the compile-gate generator enforcing correctness.
   inject-before-first-fn orchestration in (`mirEarliestAfterAny`,
   `mirInjectBeforeFirstFn`); `stringLiteral` interning still touches
   `g.strings` and stays on Go.
-- ⏳ §15 helpers — pure-side done (`firstNonEmpty`, unit/float/scalar
-  predicates, `llvmStdIoI1Text`); state-touching (`fresh`, `freshLabel`,
-  `ostyEmitter`, `flushOstyEmitter`, `storeIntrinsicResult`,
-  `emitRuntimeRawNull`) deferred to Phase B.
+- ✅ §15 helpers — pure-side + state-bearing leaves (`fresh`,
+  `freshLabel`, `reset`) + Phase B fnBuf mirror (`fnBuf`,
+  `appendFnLine`, `flushFnBuf`, `absorbOstyEmitter`) done.
+  `flushOstyEmitter` routes through `MirSeq.absorbOstyEmitter`;
+  `storeIntrinsicResult` uses the Osty `mirStoreLine` builder.
+  `ostyEmitter` constructor stays on Go (Go-only LlvmEmitter fields).
 - ⏳ §9 terminators — small (~120 LOC), single `emitTerm` switch. Cross-
   calls into §5 safepoint + §1 metadata — port after Phase B state.
 
@@ -228,7 +230,26 @@ list keeps new Osty clean of known landmines.
 | `mirInjectBeforeFirstFn` | `(body: String, block: String) -> String` | §3 | Splices `block` into `body` before the first `define ` / `declare ` line; appends at the end when neither marker is present. Replaces the inline rewrite-buffer pattern in `emitGlobalVars` / `emitStringPool` |
 | `mirJoinDeclareLines` | `(orderedDecls: List<String>) -> String` | §3 | Concatenates ordered `declare ...` strings with trailing newlines into one block ready for `mirInjectBeforeFirstFn`. Caller still owns the dedupe / ordering map |
 | `MirInlineStringEqResult` (struct) | `{ finalReg: String, lines: List<String> }` | §11 | Value/code split returned by `MirSeq.emitInlineStringEqLiteral`. Caller iterates `lines` (each already including leading 2-space indent + trailing newline) into `g.fnBuf`, then uses `finalReg` as the i1 result |
-| `MirSeq.emitInlineStringEqLiteral` | `(mut self, opIsEq: Bool, dynReg: String, litSym: String, litBytes: List<Int>) -> MirInlineStringEqResult` | §11 | Byte-by-byte string-equality switch with pointer-equality fast path + per-byte compare + terminating NUL check. `litBytes` is the per-byte int view of the literal (Go converts via `int(lit[i])`). Every `freshLabel` / `fresh` call mirrors the legacy emitter so `tempSeq` advances byte-stably across the port |
+| `MirSeq.emitInlineStringEqLiteral` | `(mut self, opIsEq: Bool, dynReg: String, litSym: String, litBytes: List<Int>) -> MirInlineStringEqResult` | §11 | Byte-by-byte string-equality switch with pointer-equality fast path + per-byte compare + terminating NUL check. Now expressed in terms of the small `mir*Line` builders (`mirICmpEqLine`, `mirBrCondLine`, `mirGEPInboundsI8Line`, `mirLoadLine`, `mirLabelLine`, `mirLabelHeadWithBranch`, `mirPhiI1FromTwoLine`, `mirXorI1NegLine`); SSA / label numbering still byte-stable with the legacy stream |
+| `MirSeq.fnBuf` (field) | `List<String>` | §15 | Per-function body accumulator. Phase B foundation — Osty-side mirror of `g.fnBuf strings.Builder`. Populated by `appendFnLine` / `absorbOstyEmitter`; drained by `flushFnBuf` |
+| `MirSeq.appendFnLine` | `(mut self, line: String) -> ()` | §15 | Push one fully-formed line (including indent + trailing newline) onto `fnBuf`. Mirrors `g.fnBuf.WriteString(line)` |
+| `MirSeq.flushFnBuf` | `(mut self) -> List<String>` | §15 | Return the accumulated lines and clear the buffer in one move; caller drains into `g.fnBuf` so the existing flush-to-`g.out` path stays unchanged |
+| `MirSeq.absorbOstyEmitter` | `(mut self, em: LlvmEmitter) -> ()` | §15 | Sync a Go-driven LlvmEmitter scope back into MirSeq — bumps `tempSeq` to `em.temp` and drains `em.body` into `fnBuf`. The `flushOstyEmitter` Go bridge routes through here |
+| `mirStoreLine` | `(ty: String, val: String, slot: String) -> String` | §6 | `  store <ty> <val>, ptr <slot>\n` — the most common emit shape across `mir_generator.go`. `storeIntrinsicResult` now delegates here |
+| `mirCallVoidLine` | `(sym: String, argList: String) -> String` | §6 | `  call void @<sym>(<argList>)\n` — runtime-action call (push/pop/clear/etc.); caller pre-joins `argList` |
+| `mirCallValueLine` | `(reg: String, retTy: String, sym: String, argList: String) -> String` | §6 | `  <reg> = call <retTy> @<sym>(<argList>)\n` — runtime helper that returns a scalar |
+| `mirGEPInboundsI8Line` | `(reg: String, basePtr: String, offDigits: String) -> String` | §6 | Byte-stride GEP form `  <reg> = getelementptr inbounds i8, ptr <basePtr>, i64 <offDigits>\n`; `offDigits` pre-formatted decimal |
+| `mirLoadLine` | `(reg: String, ty: String, ptr: String) -> String` | §6 | Plain load `  <reg> = load <ty>, ptr <ptr>\n` (no `align` / `!nontemporal` hints) |
+| `mirICmpEqLine` | `(reg: String, ty: String, lhs: String, rhs: String) -> String` | §6 | `  <reg> = icmp eq <ty> <lhs>, <rhs>\n` — eq-only specialisation; other predicates use `mirBinaryOpcode` |
+| `mirBrCondLine` | `(cond: String, trueLabel: String, falseLabel: String) -> String` | §9 | Conditional branch `  br i1 <cond>, label %<trueLabel>, label %<falseLabel>\n`; labels are bare names |
+| `mirBrUncondLine` | `(label: String) -> String` | §9 | Unconditional branch `  br label %<label>\n` |
+| `mirLabelLine` | `(name: String) -> String` | §9 | Basic-block header `<name>:\n`; bare label name input |
+| `mirLabelHeadWithBranch` | `(name: String, target: String) -> String` | §9 | Combined head-of-block + tail-branch `<name>:\n  br label %<target>\n` — match / nomatch joinpoint shape |
+| `mirPhiI1FromTwoLine` | `(reg: String, trueLabel: String, falseLabel: String) -> String` | §6 | Two-incoming-edge i1 phi `  <reg> = phi i1 [true, %<trueLabel>], [false, %<falseLabel>]\n` — boolean joinpoint |
+| `mirXorI1NegLine` | `(reg: String, src: String) -> String` | §6 | i1 negation `  <reg> = xor i1 <src>, true\n` — used by streq for the `!=` form |
+| `mirStoreZeroinitLine` | `(ty: String, slot: String) -> String` | §6 | `  store <ty> zeroinitializer, ptr <slot>\n` — None-branch slot zeroing for Option<T> in `IntrinsicListFirst`/`IntrinsicListLast`/`IntrinsicMapGet` |
+| `mirInsertValueAggLine` | `(reg: String, aggTy: String, baseVal: String, fieldTy: String, val: String, idxDigits: String) -> String` | §6 | `  <reg> = insertvalue <aggTy> <baseVal>, <fieldTy> <val>, <idxDigits>\n` — field-by-field aggregate construction (Some payload, tuple, Result) |
+| `mirSubI64Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i64 subtraction `  <reg> = sub i64 <lhs>, <rhs>\n` — len-1 / byte-offset hot uses; other widths route through `mirBinaryOpcode` |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -4828,24 +4828,27 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		destSlot := g.localSlots[i.Dest.Local]
 		lenSym := listRuntimeLenSymbol()
 		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
+		// len-guarded Some/None wrap; uses the new Osty-sourced
+		// `mir*Line` builders so the LLVM-text shapes line up with the
+		// streq port's call style. SSA / label numbering unchanged.
 		lenReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		isEmpty := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isEmpty, lenReg)
+		g.fnBuf.WriteString(mirICmpEqLine(isEmpty, "i64", lenReg, "0"))
 		someLabel := g.freshLabel("list.opt.some")
 		noneLabel := g.freshLabel("list.opt.none")
 		endLabel := g.freshLabel("list.opt.end")
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isEmpty, noneLabel, someLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
-		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
+		g.fnBuf.WriteString(mirLabelLine(noneLabel))
+		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		var idxRef string
 		if i.Kind == mir.IntrinsicListFirst {
 			idxRef = "0"
 		} else {
 			idxRef = g.fresh()
-			fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", idxRef, lenReg)
+			g.fnBuf.WriteString(mirSubI64Line(idxRef, lenReg, "1"))
 		}
 		elemReg, err := g.emitListLoadElement(listReg, idxRef, elemLLVM)
 		if err != nil {
@@ -4856,19 +4859,19 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", fmt.Sprintf("list_%s payload widen unsupported for %s", mirIntrinsicLabel(i.Kind), elemLLVM))
 		}
 		tagged := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
-		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", payloadReg, "1"))
+		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListReverse:
 		// In-place reverse. Runtime walks elem_size-sized slots byte by
 		// byte so the call is element-type agnostic.
 		sym := "osty_rt_list_reverse"
 		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
-		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", sym, listReg)
+		g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg))
 		return nil
 	case mir.IntrinsicListReversed:
 		// Returns a freshly allocated reversed copy. Same elem_size/
@@ -4926,7 +4929,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s, i64 %s)\n", spliceSym, listReg, idxReg)
+		g.fnBuf.WriteString(mirCallVoidLine(spliceSym, "ptr "+listReg+", i64 "+idxReg))
 		return g.storeIntrinsicResult(i, &LlvmValue{typ: elemLLVM, name: elemReg})
 	case mir.IntrinsicListIndexOf:
 		// `indexOf(x) -> Int?` — linear scan. Emit inline loop so we
@@ -9501,12 +9504,17 @@ func (g *mirGen) ostyEmitter() *LlvmEmitter {
 }
 
 // flushOstyEmitter writes the emitter's body lines into g.fnBuf and
-// syncs the temp counter back. Every Osty helper output line already
-// carries its leading 2-space indent — we only need to add the
-// trailing newline.
+// syncs the temp counter back. Routes through `MirSeq.AbsorbOstyEmitter`
+// (`toolchain/mir_generator.osty`) which bumps `TempSeq` and stages the
+// lines on `seq.FnBuf`; we then drain that buffer into `g.fnBuf` so the
+// existing flush-to-`g.out` path stays unchanged. The legacy LlvmEmitter
+// contract is "line WITHOUT trailing newline" — `g.fnBuf` adds the `\n`
+// here so existing `llvm*` helpers in `toolchain/llvmgen.osty` keep
+// working unchanged. New `mir*Line` builders bake the `\n` in and
+// should bypass this path (push directly via AppendFnLine).
 func (g *mirGen) flushOstyEmitter(em *LlvmEmitter) {
-	g.seq.TempSeq = em.temp
-	for _, line := range em.body {
+	g.seq.AbsorbOstyEmitter(em)
+	for _, line := range g.seq.FlushFnBuf() {
 		g.fnBuf.WriteString(line)
 		g.fnBuf.WriteByte('\n')
 	}
@@ -9516,7 +9524,9 @@ func (g *mirGen) flushOstyEmitter(em *LlvmEmitter) {
 // old emitSimpleCall path after an Osty-authored helper has produced
 // the value-returning call. Returns nil when the intrinsic has no
 // destination (call result discarded); coerces scalar widths when the
-// dest local's type differs from what the runtime returned.
+// dest local's type differs from what the runtime returned. The
+// final store-line is rendered via the Osty-sourced `mirStoreLine`
+// (`toolchain/mir_generator.osty`).
 func (g *mirGen) storeIntrinsicResult(i *mir.IntrinsicInstr, result *LlvmValue) error {
 	if i.Dest == nil {
 		return nil
@@ -9532,13 +9542,7 @@ func (g *mirGen) storeIntrinsicResult(i *mir.IntrinsicInstr, result *LlvmValue) 
 			stored = widened
 		}
 	}
-	g.fnBuf.WriteString("  store ")
-	g.fnBuf.WriteString(destLLVM)
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(stored)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
-	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString(mirStoreLine(destLLVM, stored, g.localSlots[i.Dest.Local]))
 	return nil
 }
 

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -899,6 +899,11 @@ type MirSeq struct {
 	TempSeq           int
 	LoopMDDefs        []string
 	ListMetaScopeList string
+	// FnBuf is the per-function body accumulator. Mirrors the Osty
+	// MirSeq.fnBuf field added in the §15 stateful slice. Populated by
+	// AppendFnLine / AbsorbOstyEmitter; drained by FlushFnBuf at
+	// function-emission boundaries.
+	FnBuf []string
 }
 
 // MirLoopHints mirrors
@@ -1178,71 +1183,191 @@ func (s *MirSeq) EmitInlineStringEqLiteral(
 	nomatchLabel := s.FreshLabel("streq.nomatch")
 	doneLabel := s.FreshLabel("streq.done")
 
+	// Pointer-equality fast path.
 	ptrEq := s.Fresh()
-	lines = append(lines, "  "+ptrEq+" = icmp eq ptr "+dynReg+", "+litSym+"\n")
+	lines = append(lines, mirICmpEqLine(ptrEq, "ptr", dynReg, litSym))
 
 	n := len(litBytes)
 	byteLabels := make([]string, 0, n+1)
 	for k := 0; k <= n; k++ {
 		byteLabels = append(byteLabels, s.FreshLabel("streq.b"+strconv.Itoa(k)))
 	}
-	lines = append(lines,
-		"  br i1 "+ptrEq+
-			", label %"+matchLabel+
-			", label %"+byteLabels[0]+"\n",
-	)
+	lines = append(lines, mirBrCondLine(ptrEq, matchLabel, byteLabels[0]))
 
+	// Per-byte compare.
 	for i := 0; i <= n; i++ {
-		lines = append(lines, byteLabels[i]+":\n")
+		lines = append(lines, mirLabelLine(byteLabels[i]))
 		ptrReg := dynReg
 		if i > 0 {
 			ptrReg = s.Fresh()
-			lines = append(lines,
-				"  "+ptrReg+
-					" = getelementptr inbounds i8, ptr "+dynReg+
-					", i64 "+strconv.Itoa(i)+"\n",
-			)
+			lines = append(lines, mirGEPInboundsI8Line(ptrReg, dynReg, strconv.Itoa(i)))
 		}
 		byteReg := s.Fresh()
-		lines = append(lines, "  "+byteReg+" = load i8, ptr "+ptrReg+"\n")
+		lines = append(lines, mirLoadLine(byteReg, "i8", ptrReg))
 
 		expected := 0
 		if i < n {
 			expected = litBytes[i]
 		}
 		matchReg := s.Fresh()
-		lines = append(lines,
-			"  "+matchReg+
-				" = icmp eq i8 "+byteReg+
-				", "+strconv.Itoa(expected)+"\n",
-		)
+		lines = append(lines, mirICmpEqLine(matchReg, "i8", byteReg, strconv.Itoa(expected)))
 
 		nextLabel := matchLabel
 		if i < n {
 			nextLabel = byteLabels[i+1]
 		}
-		lines = append(lines,
-			"  br i1 "+matchReg+
-				", label %"+nextLabel+
-				", label %"+nomatchLabel+"\n",
-		)
+		lines = append(lines, mirBrCondLine(matchReg, nextLabel, nomatchLabel))
 	}
 
-	lines = append(lines, matchLabel+":\n  br label %"+doneLabel+"\n")
-	lines = append(lines, nomatchLabel+":\n  br label %"+doneLabel+"\n")
-	lines = append(lines, doneLabel+":\n")
+	// Joinpoint + i1 phi.
+	lines = append(lines, mirLabelHeadWithBranch(matchLabel, doneLabel))
+	lines = append(lines, mirLabelHeadWithBranch(nomatchLabel, doneLabel))
+	lines = append(lines, mirLabelLine(doneLabel))
 
 	eq := s.Fresh()
-	lines = append(lines,
-		"  "+eq+
-			" = phi i1 [true, %"+matchLabel+
-			"], [false, %"+nomatchLabel+"]\n",
-	)
+	lines = append(lines, mirPhiI1FromTwoLine(eq, matchLabel, nomatchLabel))
 
 	if opIsEq {
 		return MirInlineStringEqResult{FinalReg: eq, Lines: lines}
 	}
 	neq := s.Fresh()
-	lines = append(lines, "  "+neq+" = xor i1 "+eq+", true\n")
+	lines = append(lines, mirXorI1NegLine(neq, eq))
 	return MirInlineStringEqResult{FinalReg: neq, Lines: lines}
+}
+
+// AppendFnLine pushes a fully-formed line (including any leading
+// indent and trailing newline) onto MirSeq.FnBuf — the per-function
+// body accumulator. Mirrors `g.fnBuf.WriteString(line)` semantics on
+// the legacy Go path. Phase B foundation: future Osty-side state-
+// bearing emit methods push their lines here so callers don't have
+// to thread a Go strings.Builder through the call.
+//
+// Osty: MirSeq.appendFnLine
+func (s *MirSeq) AppendFnLine(line string) {
+	s.FnBuf = append(s.FnBuf, line)
+}
+
+// FlushFnBuf returns the accumulated function-body lines and clears
+// the buffer in one move. Caller drains into `g.fnBuf` so the
+// existing flush-to-`g.out` path stays unchanged.
+//
+// Osty: MirSeq.flushFnBuf
+func (s *MirSeq) FlushFnBuf() []string {
+	drained := s.FnBuf
+	s.FnBuf = nil
+	return drained
+}
+
+// AbsorbOstyEmitter syncs a Go-driven LlvmEmitter scope back into
+// MirSeq. Bumps TempSeq to the emitter's final value and drains
+// `em.body` into FnBuf — matches `func (g *mirGen) flushOstyEmitter`
+// byte-for-byte (modulo the destination buffer).
+//
+// Osty: MirSeq.absorbOstyEmitter
+func (s *MirSeq) AbsorbOstyEmitter(em *LlvmEmitter) {
+	s.TempSeq = em.temp
+	s.FnBuf = append(s.FnBuf, em.body...)
+}
+
+// LLVM-line builders. Each helper produces one fully-formed function-
+// body line ending with `\n`. Osty: toolchain/mir_generator.osty.
+
+// mirStoreLine renders `  store <ty> <val>, ptr <slot>\n`.
+// Osty: mirStoreLine
+func mirStoreLine(ty string, val string, slot string) string {
+	return "  store " + ty + " " + val + ", ptr " + slot + "\n"
+}
+
+// mirCallVoidLine renders `  call void @<sym>(<argList>)\n`.
+// Osty: mirCallVoidLine
+func mirCallVoidLine(sym string, argList string) string {
+	return "  call void @" + sym + "(" + argList + ")\n"
+}
+
+// mirCallValueLine renders `  <reg> = call <retTy> @<sym>(<argList>)\n`.
+// Osty: mirCallValueLine
+func mirCallValueLine(reg string, retTy string, sym string, argList string) string {
+	return "  " + reg + " = call " + retTy + " @" + sym + "(" + argList + ")\n"
+}
+
+// mirGEPInboundsI8Line renders the byte-stride GEP form:
+// `  <reg> = getelementptr inbounds i8, ptr <basePtr>, i64 <offDigits>\n`.
+// Osty: mirGEPInboundsI8Line
+func mirGEPInboundsI8Line(reg string, basePtr string, offDigits string) string {
+	return "  " + reg + " = getelementptr inbounds i8, ptr " + basePtr +
+		", i64 " + offDigits + "\n"
+}
+
+// mirLoadLine renders `  <reg> = load <ty>, ptr <ptr>\n`.
+// Osty: mirLoadLine
+func mirLoadLine(reg string, ty string, ptr string) string {
+	return "  " + reg + " = load " + ty + ", ptr " + ptr + "\n"
+}
+
+// mirICmpEqLine renders `  <reg> = icmp eq <ty> <lhs>, <rhs>\n`.
+// Osty: mirICmpEqLine
+func mirICmpEqLine(reg string, ty string, lhs string, rhs string) string {
+	return "  " + reg + " = icmp eq " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+// mirBrCondLine renders the conditional branch
+// `  br i1 <cond>, label %<trueLabel>, label %<falseLabel>\n`.
+// Osty: mirBrCondLine
+func mirBrCondLine(cond string, trueLabel string, falseLabel string) string {
+	return "  br i1 " + cond + ", label %" + trueLabel + ", label %" + falseLabel + "\n"
+}
+
+// mirBrUncondLine renders `  br label %<label>\n`.
+// Osty: mirBrUncondLine
+func mirBrUncondLine(label string) string {
+	return "  br label %" + label + "\n"
+}
+
+// mirLabelLine renders `<name>:\n`.
+// Osty: mirLabelLine
+func mirLabelLine(name string) string {
+	return name + ":\n"
+}
+
+// mirLabelHeadWithBranch renders `<name>:\n  br label %<target>\n` —
+// the head-of-block + tail-branch shape used at streq match /
+// nomatch sites.
+// Osty: mirLabelHeadWithBranch
+func mirLabelHeadWithBranch(name string, target string) string {
+	return name + ":\n  br label %" + target + "\n"
+}
+
+// mirPhiI1FromTwoLine renders the two-incoming-edge phi
+// `  <reg> = phi i1 [true, %<trueLabel>], [false, %<falseLabel>]\n`.
+// Osty: mirPhiI1FromTwoLine
+func mirPhiI1FromTwoLine(reg string, trueLabel string, falseLabel string) string {
+	return "  " + reg + " = phi i1 [true, %" + trueLabel +
+		"], [false, %" + falseLabel + "]\n"
+}
+
+// mirXorI1NegLine renders the i1 negation `  <reg> = xor i1 <src>, true\n`.
+// Osty: mirXorI1NegLine
+func mirXorI1NegLine(reg string, src string) string {
+	return "  " + reg + " = xor i1 " + src + ", true\n"
+}
+
+// mirStoreZeroinitLine renders `  store <ty> zeroinitializer, ptr <slot>\n`.
+// Osty: mirStoreZeroinitLine
+func mirStoreZeroinitLine(ty string, slot string) string {
+	return "  store " + ty + " zeroinitializer, ptr " + slot + "\n"
+}
+
+// mirInsertValueAggLine renders the insertvalue shape:
+// `  <reg> = insertvalue <aggTy> <baseVal>, <fieldTy> <val>, <idxDigits>\n`.
+// Osty: mirInsertValueAggLine
+func mirInsertValueAggLine(reg string, aggTy string, baseVal string, fieldTy string, val string, idxDigits string) string {
+	return "  " + reg + " = insertvalue " + aggTy + " " + baseVal +
+		", " + fieldTy + " " + val +
+		", " + idxDigits + "\n"
+}
+
+// mirSubI64Line renders i64 subtraction `  <reg> = sub i64 <lhs>, <rhs>\n`.
+// Osty: mirSubI64Line
+func mirSubI64Line(reg string, lhs string, rhs string) string {
+	return "  " + reg + " = sub i64 " + lhs + ", " + rhs + "\n"
 }

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -941,6 +941,17 @@ pub struct MirSeq {
     /// 3-node domain/scope/list chain. Empty string means "not yet
     /// allocated" — the singleton convention matches Go.
     pub listMetaScopeList: String,
+    /// fnBuf is the per-function body accumulator. Mirrors `g.fnBuf
+    /// strings.Builder` on the Go side. Populated by the new
+    /// `appendFnLine` method and by `absorbOstyEmitter` when a Go-
+    /// driven LlvmEmitter scope drains its body lines into the
+    /// MirSeq accumulator. `flushFnBuf` returns the lines and
+    /// clears the buffer — paired with `g.out.WriteString` on the
+    /// Go side at function-emission boundaries. Phase B foundation:
+    /// future Osty-side state-bearing emit methods (`emitTerm`,
+    /// instruction lowering, etc.) push their lines here without
+    /// having to thread a Go strings.Builder through the call.
+    pub fnBuf: List<String>,
 
     /// fresh issues a fresh `%tN` SSA register name and bumps the
     /// counter. Mirrors `func (g *mirGen) fresh()` in the Go source —
@@ -1076,6 +1087,38 @@ pub struct MirSeq {
         ref
     }
 
+    /// appendFnLine pushes a fully-formed line (including any leading
+    /// indent and trailing newline) onto the per-function body
+    /// accumulator. Mirrors the legacy `g.fnBuf.WriteString(line)`
+    /// pattern. The Go bridge drains `fnBuf` into `g.fnBuf` at the
+    /// function-emission boundary via `flushFnBuf`.
+    pub fn appendFnLine(mut self, line: String) {
+        self.fnBuf.push(line)
+    }
+
+    /// flushFnBuf returns the accumulated function-body lines and
+    /// clears the buffer in one move. Caller (Go bridge) writes the
+    /// returned list to its own `g.fnBuf` strings.Builder so the
+    /// existing flush-to-`g.out` path stays unchanged.
+    pub fn flushFnBuf(mut self) -> List<String> {
+        let drained = self.fnBuf
+        self.fnBuf = []
+        drained
+    }
+
+    /// absorbOstyEmitter syncs a Go-driven `LlvmEmitter` scope back
+    /// into MirSeq. The Go pattern is: build emitter (seeded from
+    /// `seq.tempSeq`), call Osty `llvm*` helpers that push to
+    /// `em.body`, then absorb the result here. Bumps `tempSeq` to
+    /// the emitter's final value and drains `em.body` into `fnBuf`,
+    /// matching `func (g *mirGen) flushOstyEmitter` byte-for-byte.
+    pub fn absorbOstyEmitter(mut self, em: LlvmEmitter) {
+        self.tempSeq = em.temp
+        for line in em.body {
+            self.fnBuf.push(line)
+        }
+    }
+
     /// emitInlineStringEqLiteral builds the byte-by-byte string-
     /// equality switch the legacy emitter inlined directly into
     /// `g.fnBuf`. `litBytes` is the per-byte integer view of the
@@ -1106,8 +1149,10 @@ pub struct MirSeq {
         let nomatchLabel = self.freshLabel("streq.nomatch")
         let doneLabel = self.freshLabel("streq.done")
 
+        // Pointer-equality fast path: if both Strings hold the same
+        // global symbol, skip the byte-by-byte walk entirely.
         let ptrEq = self.fresh()
-        lines.push("  " + ptrEq + " = icmp eq ptr " + dynReg + ", " + litSym + "\n")
+        lines.push(mirICmpEqLine(ptrEq, "ptr", dynReg, litSym))
 
         let n = litBytes.len()
         let mut byteLabels: List<String> = []
@@ -1116,66 +1161,50 @@ pub struct MirSeq {
             byteLabels.push(self.freshLabel("streq.b" + mirGenIntToString(k)))
             k = k + 1
         }
-        lines.push(
-            "  br i1 " + ptrEq +
-                ", label %" + matchLabel +
-                ", label %" + byteLabels[0] + "\n",
-        )
+        lines.push(mirBrCondLine(ptrEq, matchLabel, byteLabels[0]))
 
+        // Per-byte compare: byteLabels[i] holds the load + compare for
+        // litBytes[i] (or the trailing NUL when i == n).
         let mut i = 0
         for i <= n {
-            lines.push(byteLabels[i] + ":\n")
+            lines.push(mirLabelLine(byteLabels[i]))
             let mut ptrReg = dynReg
             if i > 0 {
                 ptrReg = self.fresh()
-                lines.push(
-                    "  " + ptrReg +
-                        " = getelementptr inbounds i8, ptr " + dynReg +
-                        ", i64 " + mirGenIntToString(i) + "\n",
-                )
+                lines.push(mirGEPInboundsI8Line(ptrReg, dynReg, mirGenIntToString(i)))
             }
             let byteReg = self.fresh()
-            lines.push("  " + byteReg + " = load i8, ptr " + ptrReg + "\n")
+            lines.push(mirLoadLine(byteReg, "i8", ptrReg))
 
             let mut expected = 0
             if i < n {
                 expected = litBytes[i]
             }
             let matchReg = self.fresh()
-            lines.push(
-                "  " + matchReg +
-                    " = icmp eq i8 " + byteReg +
-                    ", " + mirGenIntToString(expected) + "\n",
-            )
+            lines.push(mirICmpEqLine(matchReg, "i8", byteReg, mirGenIntToString(expected)))
 
             let mut nextLabel = matchLabel
             if i < n {
                 nextLabel = byteLabels[i + 1]
             }
-            lines.push(
-                "  br i1 " + matchReg +
-                    ", label %" + nextLabel +
-                    ", label %" + nomatchLabel + "\n",
-            )
+            lines.push(mirBrCondLine(matchReg, nextLabel, nomatchLabel))
             i = i + 1
         }
 
-        lines.push(matchLabel + ":\n  br label %" + doneLabel + "\n")
-        lines.push(nomatchLabel + ":\n  br label %" + doneLabel + "\n")
-        lines.push(doneLabel + ":\n")
+        // Joinpoint: matchLabel/nomatchLabel each branch to doneLabel,
+        // then a phi node selects the i1 result.
+        lines.push(mirLabelHeadWithBranch(matchLabel, doneLabel))
+        lines.push(mirLabelHeadWithBranch(nomatchLabel, doneLabel))
+        lines.push(mirLabelLine(doneLabel))
 
         let eq = self.fresh()
-        lines.push(
-            "  " + eq +
-                " = phi i1 [true, %" + matchLabel +
-                "], [false, %" + nomatchLabel + "]\n",
-        )
+        lines.push(mirPhiI1FromTwoLine(eq, matchLabel, nomatchLabel))
 
         if opIsEq {
             return MirInlineStringEqResult { finalReg: eq, lines }
         }
         let neq = self.fresh()
-        lines.push("  " + neq + " = xor i1 " + eq + ", true\n")
+        lines.push(mirXorI1NegLine(neq, eq))
         MirInlineStringEqResult { finalReg: neq, lines }
     }
 }
@@ -1386,5 +1415,152 @@ pub fn mirJoinDeclareLines(orderedDecls: List<String>) -> String {
 pub struct MirInlineStringEqResult {
     pub finalReg: String,
     pub lines: List<String>,
+}
+
+// ============================================================
+// LLVM-line builders (small pure templates).
+//
+// Each helper produces one fully-formed function-body line ending
+// with `\n`, including the leading 2-space indent the legacy
+// emitter writes via `g.fnBuf.WriteString("  ")`. Pair with
+// `MirSeq.appendFnLine` (Phase B) or splice directly into a
+// `List<String>` accumulator (the streq path).
+// ============================================================
+
+/// mirStoreLine renders `  store <ty> <val>, ptr <slot>\n`. Mirrors
+/// the most common emit shape across `mir_generator.go` —
+/// intrinsic-result stores, alloca initialisations, optional-payload
+/// writes. `slot` already includes its `%` / `@` sigil.
+pub fn mirStoreLine(ty: String, val: String, slot: String) -> String {
+    "  store " + ty + " " + val + ", ptr " + slot + "\n"
+}
+
+/// mirCallVoidLine renders `  call void @<sym>(<argList>)\n`.
+/// `argList` is pre-joined by the caller (e.g. `"ptr %list, i64 5"`).
+/// The void return shape is the runtime-action call (push/pop/clear/
+/// reverse/etc.) — caller typically discards the result.
+pub fn mirCallVoidLine(sym: String, argList: String) -> String {
+    "  call void @" + sym + "(" + argList + ")\n"
+}
+
+/// mirCallValueLine renders `  <reg> = call <retTy> @<sym>(<argList>)\n`.
+/// `reg` is the SSA register name (already `%`-prefixed). Used for
+/// runtime helpers that return a scalar — `osty_rt_list_len`,
+/// `osty_rt_strings_Compare`, etc.
+pub fn mirCallValueLine(reg: String, retTy: String, sym: String, argList: String) -> String {
+    "  " + reg + " = call " + retTy + " @" + sym + "(" + argList + ")\n"
+}
+
+/// mirGEPInboundsI8Line renders the byte-stride GEP form that hot
+/// loops use to index into a list's data area:
+///   `  <reg> = getelementptr inbounds i8, ptr <basePtr>, i64 <offDigits>\n`
+/// `offDigits` is the already-formatted decimal byte offset.
+pub fn mirGEPInboundsI8Line(reg: String, basePtr: String, offDigits: String) -> String {
+    "  " + reg + " = getelementptr inbounds i8, ptr " + basePtr +
+        ", i64 " + offDigits + "\n"
+}
+
+/// mirLoadLine renders `  <reg> = load <ty>, ptr <ptr>\n`. The plain
+/// `load` form (no `align` / `!nontemporal` / metadata hints) — the
+/// LLVM optimizer inserts the alignment from the pointer-defining
+/// instruction.
+pub fn mirLoadLine(reg: String, ty: String, ptr: String) -> String {
+    "  " + reg + " = load " + ty + ", ptr " + ptr + "\n"
+}
+
+/// mirICmpEqLine renders `  <reg> = icmp eq <ty> <lhs>, <rhs>\n`.
+/// Specialised to the `eq` predicate because that's the dominant
+/// shape (pointer equality, byte-by-byte compare in streq, etc.);
+/// other predicates use `mirBinaryOpcode`.
+pub fn mirICmpEqLine(reg: String, ty: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp eq " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+/// mirBrCondLine renders the conditional branch
+/// `  br i1 <cond>, label %<trueLabel>, label %<falseLabel>\n`.
+/// `cond` is the i1 SSA register. Labels are bare names (no leading
+/// `%`); the helper adds the `label %` prefix.
+pub fn mirBrCondLine(cond: String, trueLabel: String, falseLabel: String) -> String {
+    "  br i1 " + cond + ", label %" + trueLabel + ", label %" + falseLabel + "\n"
+}
+
+/// mirBrUncondLine renders the unconditional branch
+/// `  br label %<label>\n`. Caller passes a bare label name.
+pub fn mirBrUncondLine(label: String) -> String {
+    "  br label %" + label + "\n"
+}
+
+/// mirLabelLine renders `<name>:\n` — the basic-block header. Caller
+/// passes the bare label name (no leading `%`); the helper adds the
+/// trailing `:` and newline.
+pub fn mirLabelLine(name: String) -> String {
+    name + ":\n"
+}
+
+/// mirLabelHeadWithBranch renders the combined head-of-block + tail-
+/// branch shape used at the matchLabel / nomatchLabel sites of the
+/// streq lowering: `<name>:\n  br label %<target>\n`. Single helper
+/// because the legacy emitter writes both pieces in one
+/// `WriteString(":\n  br label %")` chain — mirroring the byte
+/// sequence keeps SSA / label numbering stable.
+pub fn mirLabelHeadWithBranch(name: String, target: String) -> String {
+    name + ":\n  br label %" + target + "\n"
+}
+
+/// mirPhiI1FromTwoLine renders the two-incoming-edge phi node
+/// `  <reg> = phi i1 [true, %<trueLabel>], [false, %<falseLabel>]\n`.
+/// Specialised for the i1 streq result; the constants are baked in
+/// because every site that wants this exact phi shape passes
+/// `[true, falseLabel]` and `[false, falseLabel]` (the boolean
+/// joinpoint pattern).
+pub fn mirPhiI1FromTwoLine(reg: String, trueLabel: String, falseLabel: String) -> String {
+    "  " + reg + " = phi i1 [true, %" + trueLabel +
+        "], [false, %" + falseLabel + "]\n"
+}
+
+/// mirXorI1NegLine renders the i1 negation `  <reg> = xor i1 <src>, true\n`.
+/// Used by the streq lowering to flip the equality result for the
+/// `!=` form. `src` is the SSA register holding the i1 value.
+pub fn mirXorI1NegLine(reg: String, src: String) -> String {
+    "  " + reg + " = xor i1 " + src + ", true\n"
+}
+
+/// mirStoreZeroinitLine renders `  store <ty> zeroinitializer, ptr <slot>\n`.
+/// The "zero out a slot" shape used heavily by the None / default
+/// branches in `IntrinsicListFirst` / `IntrinsicListLast` /
+/// `IntrinsicMapGet` (Option<T> result with payload zero-initialised).
+/// `ty` is the destination's full LLVM aggregate type (e.g.
+/// `%Option.i64`); `slot` is the alloca / GEP target.
+pub fn mirStoreZeroinitLine(ty: String, slot: String) -> String {
+    "  store " + ty + " zeroinitializer, ptr " + slot + "\n"
+}
+
+/// mirInsertValueAggLine renders the LLVM `insertvalue` shape used to
+/// build a struct/aggregate value field-by-field:
+///   `  <reg> = insertvalue <aggTy> <baseVal>, <fieldTy> <val>, <idxDigits>\n`
+/// `idxDigits` is the already-formatted decimal field index; `baseVal`
+/// is either `undef` for the first insert or the previous insertvalue's
+/// result register. Used to assemble Option<T> Some payloads, tuple
+/// constructions, and Result<Ok,Err> aggregates.
+pub fn mirInsertValueAggLine(
+    reg: String,
+    aggTy: String,
+    baseVal: String,
+    fieldTy: String,
+    val: String,
+    idxDigits: String,
+) -> String {
+    "  " + reg + " = insertvalue " + aggTy + " " + baseVal +
+        ", " + fieldTy + " " + val +
+        ", " + idxDigits + "\n"
+}
+
+/// mirSubLine renders the i64 subtraction
+/// `  <reg> = sub i64 <lhs>, <rhs>\n`. Specialised to i64 because the
+/// hot uses (computing `len - 1` for `IntrinsicListLast`, byte offsets
+/// in iteration) all operate at i64 width — other widths use
+/// `mirBinaryOpcode`'s general path.
+pub fn mirSubI64Line(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = sub i64 " + lhs + ", " + rhs + "\n"
 }
 


### PR DESCRIPTION
## Summary

Continues [MIR_EMITTER_PORT.md](MIR_EMITTER_PORT.md) past §11. The §15
stateful helpers (\`flushOstyEmitter\` / \`storeIntrinsicResult\`) now route
through Osty, \`MirSeq\` gains a \`fnBuf\` mirror as Phase B foundation,
and 14 small LLVM-line builders land for future state-bearing ports
to compose against.

Builds on #884 (squash-merged streq inliner + 9 pure helpers).

## What landed

**Phase B foundation — \`MirSeq.fnBuf\` mirror**
- Adds \`MirSeq.fnBuf: List<String>\` field with \`AppendFnLine\` /
  \`FlushFnBuf\` / \`AbsorbOstyEmitter\` methods. Future state-bearing
  Osty methods push their lines here so callers don't have to thread
  a Go \`strings.Builder\` through the call.
- The \`flushOstyEmitter\` Go bridge routes through
  \`MirSeq.AbsorbOstyEmitter\` (Osty drains \`em.body\` into \`seq.fnBuf\`,
  Go drains back to \`g.fnBuf\`).

**14 LLVM-line builders**

\`mirStoreLine\`, \`mirCallVoidLine\`, \`mirCallValueLine\`,
\`mirGEPInboundsI8Line\`, \`mirLoadLine\`, \`mirICmpEqLine\`,
\`mirBrCondLine\`, \`mirBrUncondLine\`, \`mirLabelLine\`,
\`mirLabelHeadWithBranch\`, \`mirPhiI1FromTwoLine\`, \`mirXorI1NegLine\`,
\`mirStoreZeroinitLine\`, \`mirInsertValueAggLine\`, \`mirSubI64Line\`.

Each helper produces one fully-formed function-body line with the
legacy 2-space indent and trailing newline.

**Refactors using the builders**
- \`MirSeq.emitInlineStringEqLiteral\` — every \`fnBuf.WriteString(...)\`
  inline concatenation collapsed to one builder call. SSA / label
  numbering remains byte-stable (same \`fresh\` / \`freshLabel\` order).
- \`storeIntrinsicResult\` Go body uses \`mirStoreLine\`.
- §7 \`IntrinsicListFirst\` / \`IntrinsicListLast\` /
  \`IntrinsicListReverse\` / \`IntrinsicListRemoveAt\` switched from
  \`fmt.Fprintf\` chains to builder calls.

## Behavior parity

- streq SSA / label numbering byte-stable
  (\`TestGenerateFromMIRStringEqualityInlineLiteral\` passes).
- \`ostyEmitter\` constructor stays on Go: the Go \`LlvmEmitter\` struct
  has fields the Osty source doesn't model
  (\`nativeListData\` / \`nativeListLens\`). Documented in
  MIR_EMITTER_PORT.md §15 row.
- \`emitRuntimeRawNull\` is mir-internal routing — no Osty change.

## Test plan

- [x] \`go build ./internal/llvmgen/\` clean
- [x] \`go test -short ./internal/llvmgen/\` pass (10s)
- [x] \`TestGenerateFromMIRStringEquality\` +
      \`TestGenerateFromMIRStringEqualityInlineLiteral\` golden checks
- [ ] CI \`just prepush\` gate
- [ ] Spot-check MIR_EMITTER_PORT.md inventory rows match the 18 new
      entries (1 field + 3 MirSeq methods + 14 line builders)

## Stats

\`424 insertions(+) / 98 deletions(-)\` across 4 files.
MIR_EMITTER_PORT.md inventory updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)