### PR TITLE
refactor(llvmgen): port ostyEmitter + 19 LLVM-line builders + §7 chain refactors

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -250,6 +250,24 @@ list keeps new Osty clean of known landmines.
 | `mirStoreZeroinitLine` | `(ty: String, slot: String) -> String` | §6 | `  store <ty> zeroinitializer, ptr <slot>\n` — None-branch slot zeroing for Option<T> in `IntrinsicListFirst`/`IntrinsicListLast`/`IntrinsicMapGet` |
 | `mirInsertValueAggLine` | `(reg: String, aggTy: String, baseVal: String, fieldTy: String, val: String, idxDigits: String) -> String` | §6 | `  <reg> = insertvalue <aggTy> <baseVal>, <fieldTy> <val>, <idxDigits>\n` — field-by-field aggregate construction (Some payload, tuple, Result) |
 | `mirSubI64Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i64 subtraction `  <reg> = sub i64 <lhs>, <rhs>\n` — len-1 / byte-offset hot uses; other widths route through `mirBinaryOpcode` |
+| `mirAddI64Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i64 addition `  <reg> = add i64 <lhs>, <rhs>\n` — sibling of sub; used by linear-scan loops for the `i = i + 1` step |
+| `mirFCmpLine` | `(reg: String, pred: String, ty: String, lhs: String, rhs: String) -> String` | §6 | General floating-point compare `  <reg> = fcmp <pred> <ty> <lhs>, <rhs>\n` — used by typed list scans on Float/Float64 elements |
+| `mirGEPInboundsLine` | `(reg: String, baseTy: String, basePtr: String, idxTy: String, idx: String) -> String` | §6 | General single-index GEP — supersedes the over-specialised `mirGEPInboundsI8Line` (which stays as a thin wrapper for hot byte-stride sites) |
+| `mirGEPStructFieldLine` | `(reg: String, structTy: String, basePtr: String, fieldDigits: String) -> String` | §6 | Two-index struct-field GEP `  <reg> = getelementptr inbounds <T>, ptr <p>, i32 0, i32 <N>\n` — canonical "field N of aggregate at p" |
+| `mirICmpLine` | `(reg: String, pred: String, ty: String, lhs: String, rhs: String) -> String` | §6 | General icmp with arbitrary predicate (`eq`/`ne`/`slt`/`sle`/...). The eq-only `mirICmpEqLine` stays for streq/length probes |
+| `mirAllocaLine` | `(reg: String, ty: String) -> String` | §3 | Function-preamble slot allocation `  <reg> = alloca <ty>\n` |
+| `mirRetLine` | `(ty: String, val: String) -> String` | §9 | Value return `  ret <ty> <val>\n` |
+| `mirRetVoidLine` | `() -> String` | §9 | Void return `  ret void\n` |
+| `mirSelectLine` | `(reg: String, ty: String, cond: String, lhs: String, rhs: String) -> String` | §6 | i1 select `  <reg> = select i1 <c>, <ty> <l>, <ty> <r>\n` |
+| `mirSExtLine` / `mirZExtLine` / `mirTruncLine` | `(reg, fromTy, val, toTy) -> String` | §6 | Width conversions: sign-extend / zero-extend / truncate |
+| `mirPtrToIntLine` / `mirIntToPtrLine` | various | §6 | Pointer↔int conversions used by Option<T*> payload narrows / widens |
+| `mirCommentLine` | `(text: String) -> String` | §6 | LLVM IR comment line `  ; <text>\n` |
+| `mirExtractValueLine` | `(reg: String, aggTy: String, aggVal: String, idxDigits: String) -> String` | §6 | Aggregate field projection `  <reg> = extractvalue <aggTy> <aggVal>, <idx>\n` — Option/Result disc + payload reads |
+| `mirBitcastLine` | `(reg: String, fromTy: String, val: String, toTy: String) -> String` | §6 | Same-width type reinterpretation — `i64`↔`double` Option payload narrows |
+| `mirPhiTwoLine` | `(reg: String, ty: String, val1: String, label1: String, val2: String, label2: String) -> String` | §6 | General two-arm phi `  <reg> = phi <ty> [ <v1>, %<l1> ], [ <v2>, %<l2> ]\n` — Option unwrap-or merges, conditional value joins |
+| `mirCallVoidNoArgsLine` | `(sym: String) -> String` | §6 | `  call void @<sym>()\n` — argumentless action call (unwrap abort, runtime hooks) |
+| `mirUnreachableLine` | `() -> String` | §9 | LLVM `  unreachable\n` terminator after `noreturn` calls |
+| `MirSeq.ostyEmitter` | `(self) -> LlvmEmitter` | §15 | Constructs a fresh `LlvmEmitter` seeded from `tempSeq`. Replaces the inline `&LlvmEmitter{temp:...,body:nil}` Go shim — drift fix added two missing fields (`nativeListData`, `nativeListLens`) to the Osty `LlvmEmitter` struct so the snapshot mirror compiles |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -4568,16 +4568,16 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		return err
 	}
 	discReg := g.fresh()
-	fmt.Fprintf(&g.fnBuf, "  %s = extractvalue %s %s, 0\n", discReg, optLLVM, optVal)
+	g.fnBuf.WriteString(mirExtractValueLine(discReg, optLLVM, optVal, "0"))
 
 	switch i.Kind {
 	case mir.IntrinsicOptionIsSome:
 		res := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp ne i64 %s, 0\n", res, discReg)
+		g.fnBuf.WriteString(mirICmpLine(res, "ne", "i64", discReg, "0"))
 		return g.storeIntrinsicResult(i, &LlvmValue{typ: "i1", name: res})
 	case mir.IntrinsicOptionIsNone:
 		res := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", res, discReg)
+		g.fnBuf.WriteString(mirICmpEqLine(res, "i64", discReg, "0"))
 		return g.storeIntrinsicResult(i, &LlvmValue{typ: "i1", name: res})
 	case mir.IntrinsicOptionUnwrap:
 		if i.Dest == nil {
@@ -4590,23 +4590,23 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
 		isNone := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isNone, discReg)
+		g.fnBuf.WriteString(mirICmpEqLine(isNone, "i64", discReg, "0"))
 		noneLabel := g.freshLabel("opt.unwrap.none")
 		someLabel := g.freshLabel("opt.unwrap.some")
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isNone, noneLabel, someLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+		g.fnBuf.WriteString(mirBrCondLine(isNone, noneLabel, someLabel))
+		g.fnBuf.WriteString(mirLabelLine(noneLabel))
 		abortSym := "osty_rt_option_unwrap_none"
 		g.declareRuntime(abortSym, mirRuntimeDeclareNoReturn("void", abortSym, "", false))
-		fmt.Fprintf(&g.fnBuf, "  call void @%s()\n", abortSym)
-		g.fnBuf.WriteString("  unreachable\n")
-		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		g.fnBuf.WriteString(mirCallVoidNoArgsLine(abortSym))
+		g.fnBuf.WriteString(mirUnreachableLine())
+		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		payload := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = extractvalue %s %s, 1\n", payload, optLLVM, optVal)
+		g.fnBuf.WriteString(mirExtractValueLine(payload, optLLVM, optVal, "1"))
 		narrowed, err := g.narrowOptionPayload(payload, destLLVM)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, narrowed, destSlot)
+		g.fnBuf.WriteString(mirStoreLine(destLLVM, narrowed, destSlot))
 		return nil
 	case mir.IntrinsicOptionUnwrapOr:
 		if len(i.Args) != 2 {
@@ -4622,33 +4622,32 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		destLLVM := g.llvmType(destLoc.Type)
 		destSlot := g.localSlots[i.Dest.Local]
 		isNone := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isNone, discReg)
+		g.fnBuf.WriteString(mirICmpEqLine(isNone, "i64", discReg, "0"))
 		noneLabel := g.freshLabel("opt.unwrapor.none")
 		someLabel := g.freshLabel("opt.unwrapor.some")
 		endLabel := g.freshLabel("opt.unwrapor.end")
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isNone, noneLabel, someLabel)
+		g.fnBuf.WriteString(mirBrCondLine(isNone, noneLabel, someLabel))
 		// None arm: evaluate and propagate fallback.
-		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
+		g.fnBuf.WriteString(mirLabelLine(noneLabel))
 		fallback, err := g.evalOperand(i.Args[1], destLoc.Type)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
 		// Some arm: extract and narrow payload.
-		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		payload := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = extractvalue %s %s, 1\n", payload, optLLVM, optVal)
+		g.fnBuf.WriteString(mirExtractValueLine(payload, optLLVM, optVal, "1"))
 		narrowed, err := g.narrowOptionPayload(payload, destLLVM)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
 		// Join.
-		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		merged := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]\n",
-			merged, destLLVM, fallback, noneLabel, narrowed, someLabel)
-		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, merged, destSlot)
+		g.fnBuf.WriteString(mirPhiTwoLine(merged, destLLVM, fallback, noneLabel, narrowed, someLabel))
+		g.fnBuf.WriteString(mirStoreLine(destLLVM, merged, destSlot))
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("option intrinsic kind %d", i.Kind))
@@ -4658,21 +4657,23 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 // Maybe constructors use at insertvalue time (see emitListIntrinsic's
 // IntrinsicListFirst/Last arm). Payload is always stored as i64; on
 // extraction we truncate / bitcast back to the caller's concrete T.
+// Uses the Osty-sourced cast builders (`mirTruncLine`, `mirBitcastLine`,
+// `mirIntToPtrLine`).
 func (g *mirGen) narrowOptionPayload(payloadI64, destLLVM string) (string, error) {
 	switch destLLVM {
 	case "i64":
 		return payloadI64, nil
 	case "i1", "i8", "i16", "i32":
 		narrow := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = trunc i64 %s to %s\n", narrow, payloadI64, destLLVM)
+		g.fnBuf.WriteString(mirTruncLine(narrow, "i64", payloadI64, destLLVM))
 		return narrow, nil
 	case "double":
 		narrow := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = bitcast i64 %s to double\n", narrow, payloadI64)
+		g.fnBuf.WriteString(mirBitcastLine(narrow, "i64", payloadI64, "double"))
 		return narrow, nil
 	case "ptr":
 		narrow := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = inttoptr i64 %s to ptr\n", narrow, payloadI64)
+		g.fnBuf.WriteString(mirIntToPtrLine(narrow, "i64", payloadI64))
 		return narrow, nil
 	}
 	return "", unsupported("mir-mvp", "option payload narrow unsupported for "+destLLVM)
@@ -4966,50 +4967,51 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			stringEq = llvmStringRuntimeEqualSymbol()
 			g.declareRuntime(stringEq, mirRuntimeDeclareMemoryRead("i1", stringEq, "ptr, ptr"))
 		}
+		// Linear-scan loop emission via Osty-sourced builders. Pre-store
+		// None into dest; iterate, on first match overwrite with Some(idx).
 		lenReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
-		// Pre-store None; overwritten with Some(idx) on match.
-		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
+		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
 		iSlot := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = alloca i64\n", iSlot)
-		fmt.Fprintf(&g.fnBuf, "  store i64 0, ptr %s\n", iSlot)
+		g.fnBuf.WriteString(mirAllocaLine(iSlot, "i64"))
+		g.fnBuf.WriteString(mirStoreLine("i64", "0", iSlot))
 		headLabel := g.freshLabel("list.indexof.head")
 		bodyLabel := g.freshLabel("list.indexof.body")
 		matchLabel := g.freshLabel("list.indexof.match")
 		contLabel := g.freshLabel("list.indexof.cont")
 		endLabel := g.freshLabel("list.indexof.end")
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", headLabel)
+		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLabelLine(headLabel))
 		iReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = load i64, ptr %s\n", iReg, iSlot)
+		g.fnBuf.WriteString(mirLoadLine(iReg, "i64", iSlot))
 		cont := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp slt i64 %s, %s\n", cont, iReg, lenReg)
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", cont, bodyLabel, endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", bodyLabel)
+		g.fnBuf.WriteString(mirICmpLine(cont, "slt", "i64", iReg, lenReg))
+		g.fnBuf.WriteString(mirBrCondLine(cont, bodyLabel, endLabel))
+		g.fnBuf.WriteString(mirLabelLine(bodyLabel))
 		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, iReg)
+		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
 		eqReg := g.fresh()
 		if stringEq != "" {
-			fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, ptr %s)\n", eqReg, stringEq, elemReg, needleReg)
+			g.fnBuf.WriteString(mirCallValueLine(eqReg, "i1", stringEq, "ptr "+elemReg+", ptr "+needleReg))
 		} else if elemLLVM == "double" {
-			fmt.Fprintf(&g.fnBuf, "  %s = fcmp oeq double %s, %s\n", eqReg, elemReg, needleReg)
+			g.fnBuf.WriteString(mirFCmpLine(eqReg, "oeq", "double", elemReg, needleReg))
 		} else {
-			fmt.Fprintf(&g.fnBuf, "  %s = icmp eq %s %s, %s\n", eqReg, elemLLVM, elemReg, needleReg)
+			g.fnBuf.WriteString(mirICmpEqLine(eqReg, elemLLVM, elemReg, needleReg))
 		}
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", eqReg, matchLabel, contLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", matchLabel)
+		g.fnBuf.WriteString(mirBrCondLine(eqReg, matchLabel, contLabel))
+		g.fnBuf.WriteString(mirLabelLine(matchLabel))
 		tagged := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, iReg)
-		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", contLabel)
+		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", iReg, "1"))
+		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(contLabel))
 		next := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = add i64 %s, 1\n", next, iReg)
-		fmt.Fprintf(&g.fnBuf, "  store i64 %s, ptr %s\n", next, iSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		g.fnBuf.WriteString(mirAddI64Line(next, iReg, "1"))
+		g.fnBuf.WriteString(mirStoreLine("i64", next, iSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListContains:
 		// `contains(x) -> Bool` — inline linear scan. Same shape as
@@ -5043,46 +5045,48 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			stringEq = llvmStringRuntimeEqualSymbol()
 			g.declareRuntime(stringEq, mirRuntimeDeclareMemoryRead("i1", stringEq, "ptr, ptr"))
 		}
+		// Linear-scan loop emission via Osty-sourced builders. Pre-store
+		// false into dest; iterate, on first match overwrite with true
+		// and break to end.
 		lenReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
-		// Pre-store false; overwrite with true on first match.
-		fmt.Fprintf(&g.fnBuf, "  store i1 false, ptr %s\n", destSlot)
+		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirStoreLine("i1", "false", destSlot))
 		iSlot := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = alloca i64\n", iSlot)
-		fmt.Fprintf(&g.fnBuf, "  store i64 0, ptr %s\n", iSlot)
+		g.fnBuf.WriteString(mirAllocaLine(iSlot, "i64"))
+		g.fnBuf.WriteString(mirStoreLine("i64", "0", iSlot))
 		headLabel := g.freshLabel("list.contains.head")
 		bodyLabel := g.freshLabel("list.contains.body")
 		matchLabel := g.freshLabel("list.contains.match")
 		contLabel := g.freshLabel("list.contains.cont")
 		endLabel := g.freshLabel("list.contains.end")
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", headLabel)
+		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLabelLine(headLabel))
 		iReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = load i64, ptr %s\n", iReg, iSlot)
+		g.fnBuf.WriteString(mirLoadLine(iReg, "i64", iSlot))
 		cont := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp slt i64 %s, %s\n", cont, iReg, lenReg)
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", cont, bodyLabel, endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", bodyLabel)
+		g.fnBuf.WriteString(mirICmpLine(cont, "slt", "i64", iReg, lenReg))
+		g.fnBuf.WriteString(mirBrCondLine(cont, bodyLabel, endLabel))
+		g.fnBuf.WriteString(mirLabelLine(bodyLabel))
 		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, iReg)
+		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
 		eqReg := g.fresh()
 		if stringEq != "" {
-			fmt.Fprintf(&g.fnBuf, "  %s = call i1 @%s(ptr %s, ptr %s)\n", eqReg, stringEq, elemReg, needleReg)
+			g.fnBuf.WriteString(mirCallValueLine(eqReg, "i1", stringEq, "ptr "+elemReg+", ptr "+needleReg))
 		} else if elemLLVM == "double" {
-			fmt.Fprintf(&g.fnBuf, "  %s = fcmp oeq double %s, %s\n", eqReg, elemReg, needleReg)
+			g.fnBuf.WriteString(mirFCmpLine(eqReg, "oeq", "double", elemReg, needleReg))
 		} else {
-			fmt.Fprintf(&g.fnBuf, "  %s = icmp eq %s %s, %s\n", eqReg, elemLLVM, elemReg, needleReg)
+			g.fnBuf.WriteString(mirICmpEqLine(eqReg, elemLLVM, elemReg, needleReg))
 		}
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", eqReg, matchLabel, contLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", matchLabel)
-		fmt.Fprintf(&g.fnBuf, "  store i1 true, ptr %s\n", destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", contLabel)
+		g.fnBuf.WriteString(mirBrCondLine(eqReg, matchLabel, contLabel))
+		g.fnBuf.WriteString(mirLabelLine(matchLabel))
+		g.fnBuf.WriteString(mirStoreLine("i1", "true", destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(contLabel))
 		next := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = add i64 %s, 1\n", next, iReg)
-		fmt.Fprintf(&g.fnBuf, "  store i64 %s, ptr %s\n", next, iSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", headLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		g.fnBuf.WriteString(mirAddI64Line(next, iReg, "1"))
+		g.fnBuf.WriteString(mirStoreLine("i64", next, iSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListPop:
 		// `xs.pop()` returns `Option<T>` — the last element wrapped in
@@ -5096,12 +5100,12 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if i.Dest == nil {
 			// Statement-position `xs.pop()` with no dest: fall back
 			// to the classic discard-and-abort path.
-			fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
+			g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
 			return nil
 		}
 		destLoc := g.fn.Local(i.Dest.Local)
 		if destLoc == nil {
-			fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
+			g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
 			return nil
 		}
 		destLLVM := g.llvmType(destLoc.Type)
@@ -5109,35 +5113,35 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		lenSym := listRuntimeLenSymbol()
 		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		lenReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call i64 @%s(ptr %s)\n", lenReg, lenSym, listReg)
+		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		isEmpty := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = icmp eq i64 %s, 0\n", isEmpty, lenReg)
+		g.fnBuf.WriteString(mirICmpEqLine(isEmpty, "i64", lenReg, "0"))
 		someLabel := g.freshLabel("list.pop.some")
 		noneLabel := g.freshLabel("list.pop.none")
 		endLabel := g.freshLabel("list.pop.end")
-		fmt.Fprintf(&g.fnBuf, "  br i1 %s, label %%%s, label %%%s\n", isEmpty, noneLabel, someLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", noneLabel)
-		fmt.Fprintf(&g.fnBuf, "  store %s zeroinitializer, ptr %s\n", destLLVM, destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", someLabel)
+		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
+		g.fnBuf.WriteString(mirLabelLine(noneLabel))
+		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		lastIdx := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = sub i64 %s, 1\n", lastIdx, lenReg)
+		g.fnBuf.WriteString(mirSubI64Line(lastIdx, lenReg, "1"))
 		elemReg, err := g.emitListLoadElement(listReg, lastIdx, elemLLVM)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s)\n", discardSym, listReg)
+		g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
 		payloadReg, err := g.listOptionalPayloadToI64(elemReg, elemLLVM, elemT)
 		if err != nil {
 			return unsupported("mir-mvp", fmt.Sprintf("list_pop payload widen unsupported for %s", elemLLVM))
 		}
 		tagged := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s undef, i64 1, 0\n", tagged, destLLVM)
+		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = insertvalue %s %s, i64 %s, 1\n", filled, destLLVM, tagged, payloadReg)
-		fmt.Fprintf(&g.fnBuf, "  store %s %s, ptr %s\n", destLLVM, filled, destSlot)
-		fmt.Fprintf(&g.fnBuf, "  br label %%%s\n", endLabel)
-		fmt.Fprintf(&g.fnBuf, "%s:\n", endLabel)
+		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", payloadReg, "1"))
+		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
+		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("list intrinsic kind %d", i.Kind))
@@ -5148,15 +5152,15 @@ func (g *mirGen) emitListLoadElement(listReg, idxReg string, elemLLVM string) (s
 		getSym := listRuntimeGetSymbol(elemLLVM)
 		g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 		elemReg := g.fresh()
-		fmt.Fprintf(&g.fnBuf, "  %s = call %s @%s(ptr %s, i64 %s)\n", elemReg, elemLLVM, getSym, listReg, idxReg)
+		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+idxReg))
 		return elemReg, nil
 	}
 	slot := g.fresh()
-	fmt.Fprintf(&g.fnBuf, "  %s = alloca %s\n", slot, elemLLVM)
+	g.fnBuf.WriteString(mirAllocaLine(slot, elemLLVM))
 	sizeReg := g.emitSizeOf(elemLLVM)
 	sym := listRuntimeGetBytesV1Symbol()
 	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
-	fmt.Fprintf(&g.fnBuf, "  call void @%s(ptr %s, i64 %s, ptr %s, i64 %s)\n", sym, listReg, idxReg, slot, sizeReg)
+	g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg+", i64 "+idxReg+", ptr "+slot+", i64 "+sizeReg))
 	elemReg := g.fresh()
 	fmt.Fprintf(&g.fnBuf, "  %s = load %s, ptr %s\n", elemReg, elemLLVM, slot)
 	return elemReg, nil
@@ -9498,9 +9502,15 @@ func (g *mirGen) freshLabel(prefix string) string {
 // llvmListPush, …) against the returned emitter, then splice the
 // accumulated body into g.fnBuf via flushOstyEmitter. This is the
 // adapter that lets mir_generator.go delegate actual LLVM text to
-// toolchain/llvmgen.osty without double-counting temps.
+// toolchain/llvmgen.osty without double-counting temps. Now delegates
+// to the Osty-sourced `MirSeq.ostyEmitter`
+// (`toolchain/mir_generator.osty`) so the seeding logic lives in one
+// place. The Go LlvmEmitter has fields the Osty struct doesn't model
+// (nextLoopMD / loopMDDefs / vectorize hints) — those are the native-
+// owned-function emission state, separate from the MIR ostyEmitter
+// path; they stay zero-init.
 func (g *mirGen) ostyEmitter() *LlvmEmitter {
-	return &LlvmEmitter{temp: g.seq.TempSeq, body: nil}
+	return g.seq.OstyEmitter()
 }
 
 // flushOstyEmitter writes the emitter's body lines into g.fnBuf and

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -1269,6 +1269,31 @@ func (s *MirSeq) AbsorbOstyEmitter(em *LlvmEmitter) {
 	s.FnBuf = append(s.FnBuf, em.body...)
 }
 
+// OstyEmitter constructs a fresh LlvmEmitter seeded from the current
+// TempSeq. The Go bridge `func (g *mirGen) ostyEmitter` now delegates
+// here so the seeding logic lives in one place. The Go LlvmEmitter
+// has fields the Osty source struct doesn't model (nextLoopMD,
+// loopMDDefs, vectorizeHint, parallelAccessHint, parallelAccessGroupRef)
+// — those are native-owned-function emission state, separate from the
+// MIR ostyEmitter path. They zero-init here, matching the original
+// `&LlvmEmitter{temp: g.seq.TempSeq, body: nil}` semantics.
+//
+// Osty: MirSeq.ostyEmitter
+func (s *MirSeq) OstyEmitter() *LlvmEmitter {
+	return &LlvmEmitter{
+		temp:              s.TempSeq,
+		label:             0,
+		stringId:          0,
+		body:              nil,
+		locals:            nil,
+		stringGlobals:     nil,
+		nativeBoundedLens: nil,
+		nativeSafeIndices: nil,
+		nativeListData:    nil,
+		nativeListLens:    nil,
+	}
+}
+
 // LLVM-line builders. Each helper produces one fully-formed function-
 // body line ending with `\n`. Osty: toolchain/mir_generator.osty.
 
@@ -1370,4 +1395,135 @@ func mirInsertValueAggLine(reg string, aggTy string, baseVal string, fieldTy str
 // Osty: mirSubI64Line
 func mirSubI64Line(reg string, lhs string, rhs string) string {
 	return "  " + reg + " = sub i64 " + lhs + ", " + rhs + "\n"
+}
+
+// mirAddI64Line renders i64 addition `  <reg> = add i64 <lhs>, <rhs>\n`.
+// Osty: mirAddI64Line
+func mirAddI64Line(reg string, lhs string, rhs string) string {
+	return "  " + reg + " = add i64 " + lhs + ", " + rhs + "\n"
+}
+
+// mirFCmpLine renders the general floating-point compare shape
+// `  <reg> = fcmp <pred> <ty> <lhs>, <rhs>\n`.
+// Osty: mirFCmpLine
+func mirFCmpLine(reg string, pred string, ty string, lhs string, rhs string) string {
+	return "  " + reg + " = fcmp " + pred + " " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+// Generalised line builders — fixes the over-specialisation of the
+// first slice. Specialised builders above stay as compat callers.
+
+// mirGEPInboundsLine renders the general single-index GEP shape.
+// Osty: mirGEPInboundsLine
+func mirGEPInboundsLine(reg string, baseTy string, basePtr string, idxTy string, idx string) string {
+	return "  " + reg + " = getelementptr inbounds " + baseTy +
+		", ptr " + basePtr + ", " + idxTy + " " + idx + "\n"
+}
+
+// mirGEPStructFieldLine renders the two-index struct-field GEP form.
+// Osty: mirGEPStructFieldLine
+func mirGEPStructFieldLine(reg string, structTy string, basePtr string, fieldDigits string) string {
+	return "  " + reg + " = getelementptr inbounds " + structTy +
+		", ptr " + basePtr +
+		", i32 0, i32 " + fieldDigits + "\n"
+}
+
+// mirICmpLine renders the general icmp shape with arbitrary predicate.
+// Osty: mirICmpLine
+func mirICmpLine(reg string, pred string, ty string, lhs string, rhs string) string {
+	return "  " + reg + " = icmp " + pred + " " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+// mirAllocaLine renders `  <reg> = alloca <ty>\n`.
+// Osty: mirAllocaLine
+func mirAllocaLine(reg string, ty string) string {
+	return "  " + reg + " = alloca " + ty + "\n"
+}
+
+// mirRetLine renders `  ret <ty> <val>\n`.
+// Osty: mirRetLine
+func mirRetLine(ty string, val string) string {
+	return "  ret " + ty + " " + val + "\n"
+}
+
+// mirRetVoidLine renders `  ret void\n`.
+// Osty: mirRetVoidLine
+func mirRetVoidLine() string {
+	return "  ret void\n"
+}
+
+// mirSelectLine renders the i1 select form.
+// Osty: mirSelectLine
+func mirSelectLine(reg string, ty string, cond string, lhs string, rhs string) string {
+	return "  " + reg + " = select i1 " + cond +
+		", " + ty + " " + lhs +
+		", " + ty + " " + rhs + "\n"
+}
+
+// mirSExtLine renders sign-extension.
+// Osty: mirSExtLine
+func mirSExtLine(reg string, fromTy string, val string, toTy string) string {
+	return "  " + reg + " = sext " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+// mirZExtLine renders zero-extension.
+// Osty: mirZExtLine
+func mirZExtLine(reg string, fromTy string, val string, toTy string) string {
+	return "  " + reg + " = zext " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+// mirTruncLine renders truncation.
+// Osty: mirTruncLine
+func mirTruncLine(reg string, fromTy string, val string, toTy string) string {
+	return "  " + reg + " = trunc " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+// mirPtrToIntLine renders ptr→int conversion.
+// Osty: mirPtrToIntLine
+func mirPtrToIntLine(reg string, val string, toTy string) string {
+	return "  " + reg + " = ptrtoint ptr " + val + " to " + toTy + "\n"
+}
+
+// mirIntToPtrLine renders int→ptr conversion.
+// Osty: mirIntToPtrLine
+func mirIntToPtrLine(reg string, fromTy string, val string) string {
+	return "  " + reg + " = inttoptr " + fromTy + " " + val + " to ptr\n"
+}
+
+// mirCommentLine renders `  ; <text>\n`.
+// Osty: mirCommentLine
+func mirCommentLine(text string) string {
+	return "  ; " + text + "\n"
+}
+
+// mirExtractValueLine renders `  <reg> = extractvalue <aggTy> <aggVal>, <idxDigits>\n`.
+// Osty: mirExtractValueLine
+func mirExtractValueLine(reg string, aggTy string, aggVal string, idxDigits string) string {
+	return "  " + reg + " = extractvalue " + aggTy + " " + aggVal + ", " + idxDigits + "\n"
+}
+
+// mirBitcastLine renders `  <reg> = bitcast <fromTy> <val> to <toTy>\n`.
+// Osty: mirBitcastLine
+func mirBitcastLine(reg string, fromTy string, val string, toTy string) string {
+	return "  " + reg + " = bitcast " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+// mirPhiTwoLine renders the two-incoming-edge phi.
+// Osty: mirPhiTwoLine
+func mirPhiTwoLine(reg string, ty string, val1 string, label1 string, val2 string, label2 string) string {
+	return "  " + reg + " = phi " + ty +
+		" [ " + val1 + ", %" + label1 +
+		" ], [ " + val2 + ", %" + label2 + " ]\n"
+}
+
+// mirCallVoidNoArgsLine renders `  call void @<sym>()\n`.
+// Osty: mirCallVoidNoArgsLine
+func mirCallVoidNoArgsLine(sym string) string {
+	return "  call void @" + sym + "()\n"
+}
+
+// mirUnreachableLine renders `  unreachable\n`.
+// Osty: mirUnreachableLine
+func mirUnreachableLine() string {
+	return "  unreachable\n"
 }

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -63,6 +63,19 @@ pub struct LlvmEmitter {
     /// consults this to skip the runtime bounds-check branch — that
     /// branch's slow-path call is what blocks LLVM's LoopVectorizer.
     pub nativeSafeIndices: Map<String, Map<String, Int>>,
+    /// nativeListData caches the `data` snapshot register for each
+    /// list parameter that the native module-entry slice has already
+    /// hoisted. Keyed by the list-param's source name (e.g. `"xs"`);
+    /// the value is the SSA register holding the `osty_rt_list_data_<T>`
+    /// result. Mirrors the `emitter.nativeListData` slot used by
+    /// `internal/llvmgen/native_entry_snapshot.go` — adding here so
+    /// the Osty struct shape matches what the snapshot accesses.
+    pub nativeListData: Map<String, LlvmValue>,
+    /// nativeListLens caches the `len` snapshot register for the same
+    /// hoisted list params as `nativeListData`. Stored as
+    /// `Map<String, LlvmValue>` so consumers can copy the typed handle
+    /// out without re-allocating.
+    pub nativeListLens: Map<String, LlvmValue>,
 }
 
 pub struct LlvmIfLabels {
@@ -102,6 +115,8 @@ pub fn llvmEmitter() -> LlvmEmitter {
         stringGlobals: [],
         nativeBoundedLens: {:},
         nativeSafeIndices: {:},
+        nativeListData: {:},
+        nativeListLens: {:},
     }
 }
 

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -1119,6 +1119,28 @@ pub struct MirSeq {
         }
     }
 
+    /// ostyEmitter constructs a fresh LlvmEmitter seeded from the
+    /// current `tempSeq`. The Go bridge `func (g *mirGen) ostyEmitter`
+    /// now delegates here so the seeding logic lives in one place.
+    /// All other counter / accumulator fields start fresh — the Osty
+    /// `llvm*` helpers don't read them through the call boundary; the
+    /// Go side maintains the persistent state on `mirGen` across the
+    /// many short-lived emitter scopes.
+    pub fn ostyEmitter(self) -> LlvmEmitter {
+        LlvmEmitter {
+            temp: self.tempSeq,
+            label: 0,
+            stringId: 0,
+            body: [],
+            locals: [],
+            stringGlobals: [],
+            nativeBoundedLens: {:},
+            nativeSafeIndices: {:},
+            nativeListData: {:},
+            nativeListLens: {:},
+        }
+    }
+
     /// emitInlineStringEqLiteral builds the byte-by-byte string-
     /// equality switch the legacy emitter inlined directly into
     /// `g.fnBuf`. `litBytes` is the per-byte integer view of the
@@ -1555,12 +1577,195 @@ pub fn mirInsertValueAggLine(
         ", " + idxDigits + "\n"
 }
 
-/// mirSubLine renders the i64 subtraction
+/// mirSubI64Line renders the i64 subtraction
 /// `  <reg> = sub i64 <lhs>, <rhs>\n`. Specialised to i64 because the
 /// hot uses (computing `len - 1` for `IntrinsicListLast`, byte offsets
 /// in iteration) all operate at i64 width — other widths use
 /// `mirBinaryOpcode`'s general path.
 pub fn mirSubI64Line(reg: String, lhs: String, rhs: String) -> String {
     "  " + reg + " = sub i64 " + lhs + ", " + rhs + "\n"
+}
+
+/// mirAddI64Line renders the i64 addition
+/// `  <reg> = add i64 <lhs>, <rhs>\n`. Sibling of `mirSubI64Line` —
+/// used by linear-scan loops (`IntrinsicListIndexOf`, `IntrinsicListContains`)
+/// for the `i = i + 1` step.
+pub fn mirAddI64Line(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = add i64 " + lhs + ", " + rhs + "\n"
+}
+
+/// mirFCmpLine renders the general floating-point compare shape
+/// `  <reg> = fcmp <pred> <ty> <lhs>, <rhs>\n`. `pred` is the LLVM
+/// FP predicate (`oeq` / `one` / `olt` / `ole` / `ogt` / `oge` /
+/// `ueq` / `une` / `ord` / `uno`). Used by typed list scans where
+/// the element type is `Float`/`Float64`.
+pub fn mirFCmpLine(reg: String, pred: String, ty: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fcmp " + pred + " " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+// ============================================================
+// Generalised line builders (Phase B: fixes the over-specialisation
+// of the first slice). Specialised builders above stay as one-liner
+// wrappers so existing call sites don't churn.
+// ============================================================
+
+/// mirGEPInboundsLine renders the general
+/// `  <reg> = getelementptr inbounds <baseTy>, ptr <basePtr>, <idxTy> <idx>\n`
+/// shape. Use for arbitrary single-index GEPs; multi-index struct-field
+/// access goes through `mirGEPStructFieldLine`. The byte-stride form
+/// (`mirGEPInboundsI8Line`) stays as a thin wrapper so hot paths read
+/// at a glance.
+pub fn mirGEPInboundsLine(
+    reg: String,
+    baseTy: String,
+    basePtr: String,
+    idxTy: String,
+    idx: String,
+) -> String {
+    "  " + reg + " = getelementptr inbounds " + baseTy +
+        ", ptr " + basePtr + ", " + idxTy + " " + idx + "\n"
+}
+
+/// mirGEPStructFieldLine renders the two-index struct-field GEP
+/// `  <reg> = getelementptr inbounds <structTy>, ptr <basePtr>, i32 0, i32 <fieldDigits>\n`
+/// — the canonical "field N of aggregate at p" pattern. `fieldDigits`
+/// is the already-formatted decimal field index.
+pub fn mirGEPStructFieldLine(
+    reg: String,
+    structTy: String,
+    basePtr: String,
+    fieldDigits: String,
+) -> String {
+    "  " + reg + " = getelementptr inbounds " + structTy +
+        ", ptr " + basePtr +
+        ", i32 0, i32 " + fieldDigits + "\n"
+}
+
+/// mirICmpLine renders the general icmp shape
+/// `  <reg> = icmp <pred> <ty> <lhs>, <rhs>\n`. `pred` is the LLVM
+/// predicate keyword (`eq`, `ne`, `slt`, `sle`, `sgt`, `sge`, `ult`,
+/// `ule`, `ugt`, `uge`). The eq-only `mirICmpEqLine` stays for
+/// readability at hot sites (streq, length probes).
+pub fn mirICmpLine(reg: String, pred: String, ty: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp " + pred + " " + ty + " " + lhs + ", " + rhs + "\n"
+}
+
+/// mirAllocaLine renders `  <reg> = alloca <ty>\n` — the function-
+/// preamble slot allocation form. No `align N` / addrspace tuning;
+/// LLVM's natural alignment from the type is sufficient for the
+/// shapes the MIR emitter produces.
+pub fn mirAllocaLine(reg: String, ty: String) -> String {
+    "  " + reg + " = alloca " + ty + "\n"
+}
+
+/// mirRetLine renders `  ret <ty> <val>\n` — value return.
+pub fn mirRetLine(ty: String, val: String) -> String {
+    "  ret " + ty + " " + val + "\n"
+}
+
+/// mirRetVoidLine renders `  ret void\n`.
+pub fn mirRetVoidLine() -> String {
+    "  ret void\n"
+}
+
+/// mirSelectLine renders the i1 select
+/// `  <reg> = select i1 <cond>, <ty> <lhs>, <ty> <rhs>\n`. The two
+/// arms share a type because that's the only shape the emitter
+/// produces (mismatched arms would have already been coerced earlier).
+pub fn mirSelectLine(
+    reg: String,
+    ty: String,
+    cond: String,
+    lhs: String,
+    rhs: String,
+) -> String {
+    "  " + reg + " = select i1 " + cond +
+        ", " + ty + " " + lhs +
+        ", " + ty + " " + rhs + "\n"
+}
+
+/// mirSExtLine renders sign-extension `  <reg> = sext <fromTy> <val> to <toTy>\n`.
+pub fn mirSExtLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    "  " + reg + " = sext " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+/// mirZExtLine renders zero-extension `  <reg> = zext <fromTy> <val> to <toTy>\n`.
+pub fn mirZExtLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    "  " + reg + " = zext " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+/// mirTruncLine renders truncation `  <reg> = trunc <fromTy> <val> to <toTy>\n`.
+pub fn mirTruncLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    "  " + reg + " = trunc " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+/// mirPtrToIntLine renders `  <reg> = ptrtoint ptr <val> to <toTy>\n`
+/// — the pointer-payload upcast used to widen `Option<T*>` payloads
+/// into the i64 enum slot.
+pub fn mirPtrToIntLine(reg: String, val: String, toTy: String) -> String {
+    "  " + reg + " = ptrtoint ptr " + val + " to " + toTy + "\n"
+}
+
+/// mirIntToPtrLine renders `  <reg> = inttoptr <fromTy> <val> to ptr\n`
+/// — the inverse of `mirPtrToIntLine`, used when reading a pointer
+/// payload back out of the i64 enum slot.
+pub fn mirIntToPtrLine(reg: String, fromTy: String, val: String) -> String {
+    "  " + reg + " = inttoptr " + fromTy + " " + val + " to ptr\n"
+}
+
+/// mirCommentLine renders `  ; <text>\n` — an LLVM IR comment line at
+/// the per-instruction indent. Used by debug / annotation paths to
+/// mark optimization boundaries without emitting actual instructions.
+pub fn mirCommentLine(text: String) -> String {
+    "  ; " + text + "\n"
+}
+
+/// mirExtractValueLine renders `  <reg> = extractvalue <aggTy> <aggVal>, <idxDigits>\n`.
+/// The single-index field projection used to read Option<T> /
+/// Result<T,E> discriminants and payloads out of their aggregate
+/// values.
+pub fn mirExtractValueLine(reg: String, aggTy: String, aggVal: String, idxDigits: String) -> String {
+    "  " + reg + " = extractvalue " + aggTy + " " + aggVal + ", " + idxDigits + "\n"
+}
+
+/// mirBitcastLine renders `  <reg> = bitcast <fromTy> <val> to <toTy>\n`.
+/// Same-width type reinterpretation — used for `i64`↔`double` Option
+/// payload narrows and pointer aggregate field reads.
+pub fn mirBitcastLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    "  " + reg + " = bitcast " + fromTy + " " + val + " to " + toTy + "\n"
+}
+
+/// mirPhiTwoLine renders the two-incoming-edge phi
+/// `  <reg> = phi <ty> [ <val1>, %<label1> ], [ <val2>, %<label2> ]\n`.
+/// General-purpose two-arm phi for Option<T> unwrap-or merges,
+/// conditional value joins, etc. The i1-specialised
+/// `mirPhiI1FromTwoLine` (with `[true, ...]` / `[false, ...]` baked
+/// in) stays as a streq-readability shortcut.
+pub fn mirPhiTwoLine(
+    reg: String,
+    ty: String,
+    val1: String,
+    label1: String,
+    val2: String,
+    label2: String,
+) -> String {
+    "  " + reg + " = phi " + ty +
+        " [ " + val1 + ", %" + label1 +
+        " ], [ " + val2 + ", %" + label2 + " ]\n"
+}
+
+/// mirCallVoidNoArgsLine renders `  call void @<sym>()\n` — the
+/// argumentless action call (Option-unwrap abort, runtime init/teardown
+/// hooks). `mirCallVoidLine` requires the caller to pass `""` as
+/// `argList`; this variant skips that round-trip.
+pub fn mirCallVoidNoArgsLine(sym: String) -> String {
+    "  call void @" + sym + "()\n"
+}
+
+/// mirUnreachableLine renders `  unreachable\n` — the LLVM terminator
+/// emitted after a `noreturn` call or in dead-code paths the optimizer
+/// proves can't be entered.
+pub fn mirUnreachableLine() -> String {
+    "  unreachable\n"
 }
 


### PR DESCRIPTION
## Summary

Continues [MIR_EMITTER_PORT.md](MIR_EMITTER_PORT.md) past the §15
fnBuf mirror. Addresses the three weaknesses I called out in the
previous slice's self-eval:

1. **\`ostyEmitter\` constructor port** (drift fix on \`LlvmEmitter\`
   struct).
2. **Generalised over-specialised builders** from the streq port.
3. **Aggressive call-site refactor** across §7 list intrinsics.

Builds on #884 (streq + 9 helpers) and #887 (§15 fnBuf + 14 builders).

## What landed

**\`MirSeq.ostyEmitter\` constructor port + drift fix**
- Adds the missing \`nativeListData\` / \`nativeListLens\` fields to
  Osty \`LlvmEmitter\` (\`toolchain/llvmgen.osty\`). These were already
  used by \`internal/llvmgen/native_entry_snapshot.go\` — the Osty
  source had drifted out of sync, which is what blocked the
  ostyEmitter port in the §15 slice.
- \`func (g *mirGen) ostyEmitter()\` now delegates to
  \`g.seq.OstyEmitter()\` with the seeding logic in one place.

**19 LLVM-line builders**

11 generalised forms:
\`mirGEPInboundsLine\`, \`mirGEPStructFieldLine\`, \`mirICmpLine\`,
\`mirAllocaLine\`, \`mirRetLine\`, \`mirRetVoidLine\`, \`mirSelectLine\`,
\`mirSExtLine\`, \`mirZExtLine\`, \`mirTruncLine\`, \`mirPtrToIntLine\`,
\`mirIntToPtrLine\`.

4 aggregate / control-flow shapes:
\`mirExtractValueLine\`, \`mirBitcastLine\`, \`mirPhiTwoLine\`,
\`mirCommentLine\`, \`mirCallVoidNoArgsLine\`, \`mirUnreachableLine\`.

2 arithmetic siblings:
\`mirAddI64Line\`, \`mirFCmpLine\`.

The over-specialised \`mirGEPInboundsI8Line\` / \`mirICmpEqLine\` from
the previous slice stay as compat callers for streq readability.

**§7 chain refactor — ~80 \`fmt.Fprintf\` lines collapsed**
- \`IntrinsicOption{IsSome,IsNone,Unwrap,UnwrapOr}\` +
  \`narrowOptionPayload\`
- \`IntrinsicListIndexOf\` + \`IntrinsicListContains\` +
  \`IntrinsicListPop\` + \`emitListLoadElement\`

Each densely-emitting branch now reads as a sequence of named
\`mirXxxLine\` calls instead of formatted-string-arithmetic.

## Behavior parity

- All builders produce the exact byte sequence the legacy emitter
  wrote (same indent, same separators, same trailing newline).
- \`TestGenerateFromMIRStringEquality\` + \`InlineLiteral\` golden
  checks pass.

## Test plan

- [x] \`go build ./internal/llvmgen/\` clean
- [x] \`go test -short ./internal/llvmgen/\` pass (10.5s)
- [x] \`go test -short ./internal/backend/...\` pass (50.7s)
- [ ] CI \`just prepush\` gate
- [ ] Spot-check MIR_EMITTER_PORT.md inventory rows match the 19 new
      line builders + \`MirSeq.ostyEmitter\` entry

## Stats

\`501 insertions(+) / 97 deletions(-)\` across 5 files.
\`mir_generator.go\` loses ~80 lines of \`fmt.Fprintf\` noise; the
snapshot grows correspondingly because the source of truth is moving
to Osty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)