### PR TITLE
refactor(selfhost): replace string-based typeName round-trip with structured TypeRepr

### DIFF
--- a/cmd/osty-native-checker/main_test.go
+++ b/cmd/osty-native-checker/main_test.go
@@ -103,7 +103,7 @@ func TestRunChecksPackageStructuredRequest(t *testing.T) {
 	}
 	found := false
 	for _, binding := range resp.Bindings {
-		if binding.Name == "value" && binding.TypeName == "Int" {
+		if binding.Name == "value" && binding.Type != nil && binding.Type.Kind == "primitive" && binding.Type.Name == "Int" {
 			found = true
 			break
 		}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -846,7 +846,7 @@ func printNativePackageTypes(result selfhost.CheckResult, files []selfhost.Packa
 	}
 	buckets := make(map[int][]selfhost.CheckedNode, len(files))
 	for _, n := range result.TypedNodes {
-		if n.TypeName == "" {
+		if n.Type == nil {
 			continue
 		}
 		idx := findOwningFile(files, n.Start)
@@ -1094,8 +1094,8 @@ func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, 
 // printNativeTypes is the --native sibling of printTypes: it renders
 // selfhost.CheckResult.TypedNodes (node.Start, node.End are byte
 // offsets produced by the native checker) as
-// `line:col-line:col\tTypeName` rows sorted by start position. Rows
-// with empty TypeName (the checker's signal-only placeholders) are
+// `line:col-line:col\tType` rows sorted by start position. Rows
+// with nil Type (the checker's signal-only placeholders) are
 // dropped so output stays compact.
 func printNativeTypes(src []byte, result selfhost.CheckResult) {
 	type row struct {
@@ -1104,10 +1104,10 @@ func printNativeTypes(src []byte, result selfhost.CheckResult) {
 	}
 	rows := make([]row, 0, len(result.TypedNodes))
 	for _, n := range result.TypedNodes {
-		if n.TypeName == "" {
+		if n.Type == nil {
 			continue
 		}
-		rows = append(rows, row{start: n.Start, end: n.End, text: n.TypeName})
+		rows = append(rows, row{start: n.Start, end: n.End, text: n.Type.String()})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].start != rows[j].start {

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -839,7 +839,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 		if expr == nil {
 			continue
 		}
-		t := parseSelfhostTypeName(node.TypeName, idx.scopeFor(key))
+		t := typeReprToType(node.Type, idx.scopeFor(key))
 		if t == nil {
 			continue
 		}
@@ -847,7 +847,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 	}
 	for _, binding := range checked.Bindings {
 		key := selfhostSpanKey{start: binding.Start, end: binding.End}
-		t := parseSelfhostTypeName(binding.TypeName, idx.scopeFor(key))
+		t := typeReprToType(binding.Type, idx.scopeFor(key))
 		if t == nil {
 			continue
 		}
@@ -861,7 +861,7 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 	}
 	for _, symbol := range checked.Symbols {
 		key := selfhostSpanKey{start: symbol.Start, end: symbol.End}
-		t := parseSelfhostTypeName(symbol.TypeName, idx.scopeFor(key))
+		t := typeReprToType(symbol.Type, idx.scopeFor(key))
 		if t == nil {
 			continue
 		}
@@ -877,8 +877,8 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 			continue
 		}
 		args := make([]types.Type, 0, len(inst.TypeArgs))
-		for _, name := range inst.TypeArgs {
-			if t := parseSelfhostTypeName(name, idx.scopeFor(key)); t != nil {
+		for i := range inst.TypeArgs {
+			if t := typeReprToType(&inst.TypeArgs[i], idx.scopeFor(key)); t != nil {
 				args = append(args, t)
 			}
 		}
@@ -1441,158 +1441,85 @@ func bindingPatternName(p ast.Pattern) string {
 	}
 }
 
-func parseSelfhostTypeName(raw string, scope *resolve.Scope) types.Type {
-	text := strings.TrimSpace(raw)
-	switch text {
-	case "", "Invalid", "Poison":
+// typeReprToType converts a structured *api.TypeRepr to a types.Type using
+// the given scope for symbol resolution. This replaces the former string
+// round-trip through parseSelfhostTypeName. Returns nil when tr is nil so
+// callers can continue to use the `if t == nil { continue }` guard.
+func typeReprToType(tr *api.TypeRepr, scope *resolve.Scope) types.Type {
+	if tr == nil {
+		return nil
+	}
+	switch tr.Kind {
+	case "error", "poison":
 		return types.ErrorType
-	case "()", "Unit":
+	case "primitive":
+		switch tr.Name {
+		case "", "Invalid", "Poison":
+			return types.ErrorType
+		case "()", "Unit":
+			return types.Unit
+		case "Never":
+			return types.Never
+		case "UntypedInt":
+			return types.UntypedIntVal
+		case "UntypedFloat":
+			return types.UntypedFloatVal
+		default:
+			if p := types.PrimitiveByName(tr.Name); p != nil {
+				return p
+			}
+			return types.ErrorType
+		}
+	case "unit":
 		return types.Unit
-	case "Never":
+	case "never":
 		return types.Never
-	case "UntypedInt":
-		return types.UntypedIntVal
-	case "UntypedFloat":
-		return types.UntypedFloatVal
-	}
-	if strings.HasSuffix(text, "?") {
-		inner := parseSelfhostTypeName(strings.TrimSuffix(text, "?"), scope)
-		return &types.Optional{Inner: inner}
-	}
-	if strings.HasPrefix(text, "fn(") {
-		return parseSelfhostFnType(text, scope)
-	}
-	if strings.HasPrefix(text, "(") && strings.HasSuffix(text, ")") {
-		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(text, "("), ")"))
-		if inner == "" {
+	case "named":
+		sym := lookupSelfhostTypeSymbol(tr.Name, scope)
+		var args []types.Type
+		for i := range tr.Args {
+			args = append(args, typeReprToType(&tr.Args[i], scope))
+		}
+		if sym.Kind == resolve.SymGeneric {
+			return &types.TypeVar{Sym: sym}
+		}
+		return &types.Named{Sym: sym, Args: args}
+	case "optional":
+		if tr.Return != nil {
+			return &types.Optional{Inner: typeReprToType(tr.Return, scope)}
+		}
+		return types.ErrorType
+	case "tuple":
+		if len(tr.Args) == 0 {
 			return types.Unit
 		}
-		parts := splitSelfhostTypeList(inner)
-		if len(parts) == 1 {
-			return parseSelfhostTypeName(parts[0], scope)
+		if len(tr.Args) == 1 {
+			return typeReprToType(&tr.Args[0], scope)
 		}
-		elems := make([]types.Type, 0, len(parts))
-		for _, part := range parts {
-			elems = append(elems, parseSelfhostTypeName(part, scope))
+		elems := make([]types.Type, 0, len(tr.Args))
+		for i := range tr.Args {
+			elems = append(elems, typeReprToType(&tr.Args[i], scope))
 		}
 		return &types.Tuple{Elems: elems}
-	}
-	head, argText, hasArgs := splitSelfhostGeneric(text)
-	if p := types.PrimitiveByName(head); p != nil && !hasArgs {
-		return p
-	}
-	if head == "Option" && hasArgs {
-		args := splitSelfhostTypeList(argText)
-		if len(args) == 1 {
-			return &types.Optional{Inner: parseSelfhostTypeName(args[0], scope)}
+	case "fn":
+		var params []types.Type
+		for i := range tr.Args {
+			params = append(params, typeReprToType(&tr.Args[i], scope))
 		}
-	}
-	args := []types.Type(nil)
-	if hasArgs {
-		for _, part := range splitSelfhostTypeList(argText) {
-			args = append(args, parseSelfhostTypeName(part, scope))
+		ret := types.Type(types.Unit)
+		if tr.Return != nil {
+			ret = typeReprToType(tr.Return, scope)
 		}
-	}
-	sym := lookupSelfhostTypeSymbol(head, scope)
-	if sym.Kind == resolve.SymGeneric {
+		return &types.FnType{Params: params, Return: ret}
+	case "typevar":
+		sym := lookupSelfhostTypeSymbol(tr.Name, scope)
 		return &types.TypeVar{Sym: sym}
-	}
-	return &types.Named{Sym: sym, Args: args}
-}
-
-func parseSelfhostFnType(text string, scope *resolve.Scope) types.Type {
-	open := strings.IndexByte(text, '(')
-	if open < 0 {
+	case "self":
+		// Self type — approximated as error type for now
+		return types.ErrorType
+	default:
 		return types.ErrorType
 	}
-	close := matchingSelfhostParen(text, open)
-	if close < 0 {
-		return types.ErrorType
-	}
-	paramText := strings.TrimSpace(text[open+1 : close])
-	var params []types.Type
-	if paramText != "" {
-		for _, part := range splitSelfhostTypeList(paramText) {
-			params = append(params, parseSelfhostTypeName(part, scope))
-		}
-	}
-	ret := types.Type(types.Unit)
-	rest := strings.TrimSpace(text[close+1:])
-	if strings.HasPrefix(rest, "->") {
-		ret = parseSelfhostTypeName(strings.TrimSpace(strings.TrimPrefix(rest, "->")), scope)
-	}
-	return &types.FnType{Params: params, Return: ret}
-}
-
-func splitSelfhostGeneric(text string) (head, args string, ok bool) {
-	depth := 0
-	start := -1
-	for i, r := range text {
-		switch r {
-		case '<':
-			if depth == 0 {
-				start = i
-			}
-			depth++
-		case '>':
-			depth--
-			if depth == 0 && i == len(text)-1 && start >= 0 {
-				return strings.TrimSpace(text[:start]), strings.TrimSpace(text[start+1 : i]), true
-			}
-		}
-	}
-	return strings.TrimSpace(text), "", false
-}
-
-func splitSelfhostTypeList(text string) []string {
-	var out []string
-	start := 0
-	angle := 0
-	paren := 0
-	for i, r := range text {
-		switch r {
-		case '<':
-			angle++
-		case '>':
-			if angle > 0 {
-				angle--
-			}
-		case '(':
-			paren++
-		case ')':
-			if paren > 0 {
-				paren--
-			}
-		case ',':
-			if angle == 0 && paren == 0 {
-				part := strings.TrimSpace(text[start:i])
-				if part != "" {
-					out = append(out, part)
-				}
-				start = i + 1
-			}
-		}
-	}
-	if part := strings.TrimSpace(text[start:]); part != "" {
-		out = append(out, part)
-	}
-	return out
-}
-
-func matchingSelfhostParen(text string, open int) int {
-	depth := 0
-	for i := open; i < len(text); i++ {
-		switch text[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-	}
-	return -1
 }
 
 func lookupSelfhostTypeSymbol(head string, scope *resolve.Scope) *resolve.Symbol {

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -61,10 +61,10 @@ func TestNativeBoundaryPrefersStructuredPackageCheckerForFileMode(t *testing.T) 
 		result: api.CheckResult{
 			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
 			Bindings: []api.CheckedBinding{{
-				Name:     "value",
-				TypeName: "UntypedInt",
-				Start:    letStmt.Pattern.Pos().Offset,
-				End:      letStmt.Pattern.End().Offset,
+				Name:  "value",
+				Type:  &api.TypeRepr{Kind: "primitive", Name: "UntypedInt"},
+				Start: letStmt.Pattern.Pos().Offset,
+				End:   letStmt.Pattern.End().Offset,
 			}},
 		},
 	}
@@ -135,17 +135,17 @@ fn main() {
 		return fakeNativeChecker{result: api.CheckResult{
 			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
 			TypedNodes: []api.CheckedNode{
-				{Kind: "Call", TypeName: "Int", Start: call.Pos().Offset, End: call.End().Offset},
-				{Kind: "IntLit", TypeName: "Int", Start: lit.Pos().Offset, End: lit.End().Offset},
+				{Kind: "Call", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}, Start: call.Pos().Offset, End: call.End().Offset},
+				{Kind: "IntLit", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}, Start: lit.Pos().Offset, End: lit.End().Offset},
 			},
 			Bindings: []api.CheckedBinding{
-				{Name: "answer", TypeName: "Int", Start: letStmt.Pattern.Pos().Offset, End: letStmt.Pattern.End().Offset},
+				{Name: "answer", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}, Start: letStmt.Pattern.Pos().Offset, End: letStmt.Pattern.End().Offset},
 			},
 			Symbols: []api.CheckedSymbol{
-				{Name: "id", Kind: "fn", TypeName: "fn(T) -> T", Start: idDecl.Pos().Offset, End: idDecl.End().Offset},
+				{Name: "id", Kind: "fn", Type: &api.TypeRepr{Kind: "fn", Args: []api.TypeRepr{{Kind: "typevar", Name: "T"}}, Return: &api.TypeRepr{Kind: "typevar", Name: "T"}}, Start: idDecl.Pos().Offset, End: idDecl.End().Offset},
 			},
 			Instantiations: []api.CheckInstantiation{
-				{Callee: "id", TypeArgs: []string{"Int"}, Start: call.Pos().Offset, End: call.End().Offset},
+				{Callee: "id", TypeArgs: []api.TypeRepr{{Kind: "primitive", Name: "Int"}}, Start: call.Pos().Offset, End: call.End().Offset},
 			},
 		}}, ""
 	}
@@ -240,10 +240,10 @@ fn main() {}
 		return fakeNativeChecker{result: api.CheckResult{
 			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
 			Bindings: []api.CheckedBinding{
-				{Name: "value", TypeName: "Int", Start: param.Pos().Offset, End: param.End().Offset},
+				{Name: "value", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}, Start: param.Pos().Offset, End: param.End().Offset},
 			},
 			Symbols: []api.CheckedSymbol{
-				{Name: "unused", Kind: "fn", TypeName: "fn(Int) -> Int", Start: unusedDecl.Pos().Offset, End: unusedDecl.End().Offset},
+				{Name: "unused", Kind: "fn", Type: &api.TypeRepr{Kind: "fn", Args: []api.TypeRepr{{Kind: "primitive", Name: "Int"}}, Return: &api.TypeRepr{Kind: "primitive", Name: "Int"}}, Start: unusedDecl.Pos().Offset, End: unusedDecl.End().Offset},
 			},
 		}}, ""
 	}
@@ -390,7 +390,7 @@ func TestNativeBoundaryOverlaysCanonicalSourceSpansBackToOriginalAST(t *testing.
 		return fakeNativeChecker{result: api.CheckResult{
 			Summary: api.CheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
 			TypedNodes: []api.CheckedNode{
-				{Kind: "Call", TypeName: "Int", Start: start, End: end},
+				{Kind: "Call", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}, Start: start, End: end},
 			},
 		}}, ""
 	}

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -163,7 +163,7 @@ func TestNativeBoundaryExecChecksStructuredPackageInput(t *testing.T) {
 	}
 	found := false
 	for _, binding := range checked.Bindings {
-		if binding.Name == "value" && binding.TypeName == "Int" {
+		if binding.Name == "value" && binding.Type != nil && binding.Type.Kind == "primitive" && binding.Type.Name == "Int" {
 			found = true
 			break
 		}

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -31,44 +31,138 @@ type CheckSummary struct {
 	ErrorDetails map[string]map[string]int `json:"errorDetails,omitempty"`
 }
 
+// TypeRepr is a structured type representation that replaces the former
+// string-based typeName round-trip between the Osty checker and the Go
+// host bridge. The Osty side emits a TypeRepr for every typed node; the
+// Go side converts it directly to types.Type without string parsing.
+type TypeRepr struct {
+	Kind   string     `json:"kind"`             // "primitive", "named", "tuple", "optional", "fn", "unit", "never", "typevar", "self", "error", "poison"
+	Name   string     `json:"name,omitempty"`   // primitive/named/typevar name: "Int", "List", "T"
+	Path   string     `json:"path,omitempty"`   // qualified path (reserved, currently empty)
+	Args   []TypeRepr `json:"args,omitempty"`   // named generic args / tuple elems / fn params
+	Return *TypeRepr  `json:"return,omitempty"` // fn return type / optional inner
+}
+
+// String renders a TypeRepr back to a human-readable type string matching the
+// format produced by the Osty type printer (e.g. "List<Int>", "fn(T) -> T",
+// "(Int, String)", "Int?"). This is used by diagnostic printers, CLI dump
+// commands, and query helpers that still operate on rendered type names.
+func (tr *TypeRepr) String() string {
+	if tr == nil {
+		return ""
+	}
+	switch tr.Kind {
+	case "primitive", "named", "typevar", "error":
+		if len(tr.Args) == 0 {
+			if tr.Name == "" {
+				switch tr.Kind {
+				case "error":
+					return "Invalid"
+				default:
+					return ""
+				}
+			}
+			return tr.Name
+		}
+		parts := make([]string, 0, len(tr.Args))
+		for i := range tr.Args {
+			parts = append(parts, tr.Args[i].String())
+		}
+		return tr.Name + "<" + joinTypeReprStrings(parts, ", ") + ">"
+	case "unit":
+		return "()"
+	case "never":
+		return "Never"
+	case "optional":
+		if tr.Return != nil {
+			return tr.Return.String() + "?"
+		}
+		return "()?"
+	case "tuple":
+		if len(tr.Args) == 0 {
+			return "()"
+		}
+		if len(tr.Args) == 1 {
+			return "(" + tr.Args[0].String() + ")"
+		}
+		parts := make([]string, 0, len(tr.Args))
+		for i := range tr.Args {
+			parts = append(parts, tr.Args[i].String())
+		}
+		return "(" + joinTypeReprStrings(parts, ", ") + ")"
+	case "fn":
+		parts := make([]string, 0, len(tr.Args))
+		for i := range tr.Args {
+			parts = append(parts, tr.Args[i].String())
+		}
+		s := "fn(" + joinTypeReprStrings(parts, ", ") + ")"
+		if tr.Return != nil {
+			s += " -> " + tr.Return.String()
+		} else {
+			s += " -> ()"
+		}
+		return s
+	case "self":
+		return "Self"
+	case "poison":
+		return "Poison"
+	default:
+		if tr.Name != "" {
+			return tr.Name
+		}
+		return ""
+	}
+}
+
+func joinTypeReprStrings(ss []string, sep string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	result := ss[0]
+	for _, s := range ss[1:] {
+		result += sep + s
+	}
+	return result
+}
+
 // CheckedNode records a checked expression node and its inferred type name.
 type CheckedNode struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
+	Node  int       `json:"node"`
+	Kind  string    `json:"kind"`
+	Type  *TypeRepr `json:"type"`
+	Start int       `json:"start"`
+	End   int       `json:"end"`
 }
 
 // CheckedBinding records a local binding that the bootstrapped checker typed.
 type CheckedBinding struct {
-	Node     int    `json:"node"`
-	Name     string `json:"name"`
-	TypeName string `json:"typeName"`
-	Mutable  bool   `json:"mutable"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
+	Node    int       `json:"node"`
+	Name    string    `json:"name"`
+	Type    *TypeRepr `json:"type"`
+	Mutable bool      `json:"mutable"`
+	Start   int       `json:"start"`
+	End     int       `json:"end"`
 }
 
 // CheckedSymbol records a declaration collected by the bootstrapped checker.
 type CheckedSymbol struct {
-	Node     int    `json:"node"`
-	Kind     string `json:"kind"`
-	Name     string `json:"name"`
-	Owner    string `json:"owner"`
-	TypeName string `json:"typeName"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
+	Node  int       `json:"node"`
+	Kind  string    `json:"kind"`
+	Name  string    `json:"name"`
+	Owner string    `json:"owner"`
+	Type  *TypeRepr `json:"type"`
+	Start int       `json:"start"`
+	End   int       `json:"end"`
 }
 
 // CheckInstantiation records a generic function or method instantiation.
 type CheckInstantiation struct {
-	Node       int      `json:"node"`
-	Callee     string   `json:"callee"`
-	TypeArgs   []string `json:"typeArgs"`
-	ResultType string   `json:"resultType"`
-	Start      int      `json:"start"`
-	End        int      `json:"end"`
+	Node       int        `json:"node"`
+	Callee     string     `json:"callee"`
+	TypeArgs   []TypeRepr `json:"typeArgs"`
+	ResultType *TypeRepr  `json:"resultType,omitempty"`
+	Start      int        `json:"start"`
+	End        int        `json:"end"`
 }
 
 // CheckDiagnosticRecord is a structured diagnostic produced by the
@@ -125,16 +219,16 @@ type ResolveSummary struct {
 
 // ResolvedSymbol records one symbol declared by the self-host resolver.
 type ResolvedSymbol struct {
-	Node     int    `json:"node"`
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
-	TypeName string `json:"typeName"`
-	Arity    int    `json:"arity"`
-	Depth    int    `json:"depth"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Public   bool   `json:"public"`
-	File     string `json:"file,omitempty"`
+	Node   int       `json:"node"`
+	Name   string    `json:"name"`
+	Kind   string    `json:"kind"`
+	Type   *TypeRepr `json:"type"`
+	Arity  int       `json:"arity"`
+	Depth  int       `json:"depth"`
+	Start  int       `json:"start"`
+	End    int       `json:"end"`
+	Public bool      `json:"public"`
+	File   string    `json:"file,omitempty"`
 }
 
 // ResolvedRef records one value/name reference plus its resolved target span
@@ -200,11 +294,11 @@ type ResolveRequest struct {
 // type strings. Callers that need structured types should continue to
 // use the Go-side Inspect until the self-host surfaces a typed form.
 type InspectRecord struct {
-	Start    int      `json:"start"`
-	End      int      `json:"end"`
-	NodeKind string   `json:"nodeKind"`
-	Rule     string   `json:"rule"`
-	TypeName string   `json:"typeName,omitempty"`
-	HintName string   `json:"hintName,omitempty"`
-	Notes    []string `json:"notes,omitempty"`
+	Start    int       `json:"start"`
+	End      int       `json:"end"`
+	NodeKind string    `json:"nodeKind"`
+	Rule     string    `json:"rule"`
+	Type     *TypeRepr `json:"type,omitempty"`
+	HintName string    `json:"hintName,omitempty"`
+	Notes    []string  `json:"notes,omitempty"`
 }

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -1,6 +1,8 @@
 package selfhost
 
 import (
+	"strings"
+
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
 )
@@ -161,11 +163,11 @@ func adaptCheckResultFromRuneStream(checked *FrontCheckResult, rt runeTable, str
 		}
 		start, end := checkNodeOffsets(rt, stream, node.start, node.end)
 		result.TypedNodes = append(result.TypedNodes, CheckedNode{
-			Node:     node.node,
-			Kind:     node.kind,
-			TypeName: node.typeName,
-			Start:    start,
-			End:      end,
+			Node:  node.node,
+			Kind:  node.kind,
+			Type:  parseTypeRepr(node.typeName),
+			Start: start,
+			End:   end,
 		})
 	}
 	for _, binding := range checked.bindings {
@@ -174,12 +176,12 @@ func adaptCheckResultFromRuneStream(checked *FrontCheckResult, rt runeTable, str
 		}
 		start, end := checkNodeOffsets(rt, stream, binding.start, binding.end)
 		result.Bindings = append(result.Bindings, CheckedBinding{
-			Node:     binding.node,
-			Name:     binding.name,
-			TypeName: binding.typeName,
-			Mutable:  binding.mutable,
-			Start:    start,
-			End:      end,
+			Node:    binding.node,
+			Name:    binding.name,
+			Type:    parseTypeRepr(binding.typeName),
+			Mutable: binding.mutable,
+			Start:   start,
+			End:     end,
 		})
 	}
 	for _, symbol := range checked.symbols {
@@ -188,13 +190,13 @@ func adaptCheckResultFromRuneStream(checked *FrontCheckResult, rt runeTable, str
 		}
 		start, end := checkNodeOffsets(rt, stream, symbol.start, symbol.end)
 		result.Symbols = append(result.Symbols, CheckedSymbol{
-			Node:     symbol.node,
-			Kind:     symbol.kind,
-			Name:     symbol.name,
-			Owner:    symbol.owner,
-			TypeName: symbol.typeName,
-			Start:    start,
-			End:      end,
+			Node:  symbol.node,
+			Kind:  symbol.kind,
+			Name:  symbol.name,
+			Owner: symbol.owner,
+			Type:  parseTypeRepr(symbol.typeName),
+			Start: start,
+			End:   end,
 		})
 	}
 	for _, inst := range checked.instantiations {
@@ -205,8 +207,8 @@ func adaptCheckResultFromRuneStream(checked *FrontCheckResult, rt runeTable, str
 		result.Instantiations = append(result.Instantiations, CheckInstantiation{
 			Node:       inst.node,
 			Callee:     inst.callee,
-			TypeArgs:   append([]string(nil), inst.typeArgs...),
-			ResultType: inst.resultType,
+			TypeArgs:   parseTypeReprSlice(inst.typeArgs),
+			ResultType: parseTypeRepr(inst.resultType),
 			Start:      start,
 			End:        end,
 		})
@@ -252,4 +254,199 @@ func checkNodeOffsets(rt runeTable, stream *FrontLexStream, startToken, endToken
 		end = start
 	}
 	return start, end
+}
+
+// parseTypeRepr converts an Osty-rendered type string into a structured
+// *api.TypeRepr.
+//
+// Transitional: internal/selfhost/generated.go still uses string-based
+// typeName fields in FrontCheckedNode/FrontCheckedBinding/FrontCheckedSymbol
+// and []string typeArgs in FrontCheckInstantiation because it was produced by
+// the Osty→Go transpiler before the FrontTypeRepr struct landed in
+// toolchain/check.osty. Once generated.go is regenerated with the new
+// FrontTypeRepr-based fields, this function and its helpers (parseFnTypeRepr,
+// splitGenericRepr, splitTypeReprList, matchingTypeReprParen,
+// parseTypeReprSlice) can be deleted entirely — the adapters will read
+// structured FrontTypeRepr values directly from the generated structs.
+func parseTypeRepr(raw string) *api.TypeRepr {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return nil
+	}
+	switch text {
+	case "Invalid", "Poison":
+		return &api.TypeRepr{Kind: "error", Name: text}
+	case "()", "Unit":
+		return &api.TypeRepr{Kind: "unit"}
+	case "Never":
+		return &api.TypeRepr{Kind: "never", Name: "Never"}
+	case "UntypedInt":
+		return &api.TypeRepr{Kind: "primitive", Name: "UntypedInt"}
+	case "UntypedFloat":
+		return &api.TypeRepr{Kind: "primitive", Name: "UntypedFloat"}
+	}
+	// Optional suffix: "Int?"
+	if strings.HasSuffix(text, "?") {
+		inner := parseTypeRepr(strings.TrimSuffix(text, "?"))
+		return &api.TypeRepr{Kind: "optional", Return: inner}
+	}
+	// Function type: "fn(...) -> ..."
+	if strings.HasPrefix(text, "fn(") {
+		return parseFnTypeRepr(text)
+	}
+	// Tuple: "(A, B, ...)" or "()" (already handled above)
+	if strings.HasPrefix(text, "(") && strings.HasSuffix(text, ")") {
+		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(text, "("), ")"))
+		if inner == "" {
+			return &api.TypeRepr{Kind: "unit"}
+		}
+		parts := splitTypeReprList(inner)
+		if len(parts) == 1 {
+			return parseTypeRepr(parts[0])
+		}
+		args := make([]api.TypeRepr, 0, len(parts))
+		for _, part := range parts {
+			if tr := parseTypeRepr(part); tr != nil {
+				args = append(args, *tr)
+			}
+		}
+		return &api.TypeRepr{Kind: "tuple", Args: args}
+	}
+	// Named with generics: "List<Int>"
+	head, argText, hasArgs := splitGenericRepr(text)
+	if hasArgs {
+		parts := splitTypeReprList(argText)
+		typeArgs := make([]api.TypeRepr, 0, len(parts))
+		for _, a := range parts {
+			if tr := parseTypeRepr(a); tr != nil {
+				typeArgs = append(typeArgs, *tr)
+			}
+		}
+		return &api.TypeRepr{Kind: "named", Name: head, Args: typeArgs}
+	}
+	// Single uppercase letter → type variable
+	if len(head) == 1 && head[0] >= 'A' && head[0] <= 'Z' {
+		return &api.TypeRepr{Kind: "typevar", Name: head}
+	}
+	return &api.TypeRepr{Kind: "primitive", Name: head}
+}
+
+func parseFnTypeRepr(text string) *api.TypeRepr {
+	open := strings.IndexByte(text, '(')
+	if open < 0 {
+		return &api.TypeRepr{Kind: "error", Name: text}
+	}
+	close := matchingTypeReprParen(text, open)
+	if close < 0 {
+		return &api.TypeRepr{Kind: "error", Name: text}
+	}
+	paramText := strings.TrimSpace(text[open+1 : close])
+	var params []api.TypeRepr
+	if paramText != "" {
+		for _, part := range splitTypeReprList(paramText) {
+			if tr := parseTypeRepr(part); tr != nil {
+				params = append(params, *tr)
+			}
+		}
+	}
+	var ret *api.TypeRepr
+	rest := strings.TrimSpace(text[close+1:])
+	if strings.HasPrefix(rest, "->") {
+		ret = parseTypeRepr(strings.TrimSpace(strings.TrimPrefix(rest, "->")))
+	}
+	if ret == nil {
+		ret = &api.TypeRepr{Kind: "unit"}
+	}
+	return &api.TypeRepr{Kind: "fn", Args: params, Return: ret}
+}
+
+// splitGenericRepr splits "List<Int>" into ("List", "Int", true)
+// and "Int" into ("Int", "", false).
+func splitGenericRepr(text string) (head, args string, ok bool) {
+	depth := 0
+	start := -1
+	for i, r := range text {
+		switch r {
+		case '<':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '>':
+			depth--
+			if depth == 0 && i == len(text)-1 && start >= 0 {
+				return strings.TrimSpace(text[:start]), strings.TrimSpace(text[start+1 : i]), true
+			}
+		}
+	}
+	return strings.TrimSpace(text), "", false
+}
+
+// splitTypeReprList splits "A, B, C" into ["A", "B", "C"] respecting
+// angle brackets and parens.
+func splitTypeReprList(text string) []string {
+	var out []string
+	start := 0
+	angle := 0
+	paren := 0
+	for i, r := range text {
+		switch r {
+		case '<':
+			angle++
+		case '>':
+			if angle > 0 {
+				angle--
+			}
+		case '(':
+			paren++
+		case ')':
+			if paren > 0 {
+				paren--
+			}
+		case ',':
+			if angle == 0 && paren == 0 {
+				part := strings.TrimSpace(text[start:i])
+				if part != "" {
+					out = append(out, part)
+				}
+				start = i + 1
+			}
+		}
+	}
+	if part := strings.TrimSpace(text[start:]); part != "" {
+		out = append(out, part)
+	}
+	return out
+}
+
+// matchingTypeReprParen finds the index of the closing paren matching the
+// opening paren at position open.
+func matchingTypeReprParen(text string, open int) int {
+	depth := 0
+	for i := open; i < len(text); i++ {
+		switch text[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// parseTypeReprSlice converts a slice of Osty type strings to []api.TypeRepr.
+func parseTypeReprSlice(raw []string) []api.TypeRepr {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]api.TypeRepr, 0, len(raw))
+	for _, s := range raw {
+		if tr := parseTypeRepr(s); tr != nil {
+			out = append(out, *tr)
+		}
+	}
+	return out
 }

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -467,7 +467,7 @@ func TestCheckSourceStructuredRegistersPreludeFunctions(t *testing.T) {
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
 		if _, ok := want[binding.Name]; ok {
-			got[binding.Name] = binding.TypeName
+			got[binding.Name] = binding.Type.String()
 		}
 	}
 	for name, wantType := range want {
@@ -501,7 +501,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	if got["item"] != "host.Item" {
 		t.Fatalf("binding type for item = %q, want host.Item (all=%v)", got["item"], got)
@@ -580,7 +580,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
 		"chain":        "List<Error>",
@@ -639,7 +639,7 @@ func TestCheckSourceStructuredAcceptsStdListMethods(t *testing.T) {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
 		"idx":         "Int?",
@@ -711,7 +711,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
 		"eqPoint":     "Bool",
@@ -830,7 +830,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
 		"renamed":   "User",
@@ -875,7 +875,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
 		"samePoint": "Bool",
@@ -950,7 +950,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	if got["described"] != "(String, Error?)" {
 		t.Fatalf("binding type for described = %q, want %q (all=%v)", got["described"], "(String, Error?)", got)
@@ -1033,7 +1033,7 @@ fn main() {
 
 	got := map[string]string{}
 	for _, binding := range checked.Bindings {
-		got[binding.Name] = binding.TypeName
+		got[binding.Name] = binding.Type.String()
 	}
 	if got["label"] != "String" {
 		t.Fatalf("binding type for label = %q, want %q (all=%v)", got["label"], "String", got)

--- a/internal/selfhost/check_query.go
+++ b/internal/selfhost/check_query.go
@@ -47,7 +47,7 @@ func TypeAtOffset(r CheckResult, offset int) string {
 	if bestIdx < 0 {
 		return ""
 	}
-	return r.TypedNodes[bestIdx].TypeName
+	return r.TypedNodes[bestIdx].Type.String()
 }
 
 // LetTypeAtOffset returns the declared type-name of the let/param
@@ -56,7 +56,7 @@ func TypeAtOffset(r CheckResult, offset int) string {
 func LetTypeAtOffset(r CheckResult, offset int) string {
 	for _, b := range r.Bindings {
 		if offsetContains(b.Start, b.End, offset) {
-			return b.TypeName
+			return b.Type.String()
 		}
 	}
 	return ""
@@ -109,7 +109,7 @@ func HoverAtOffset(r CheckResult, offset int) HoverInfo {
 		sym := r.Symbols[bestIdx]
 		info.SymbolName = sym.Name
 		info.SymbolKind = sym.Kind
-		info.SymbolType = sym.TypeName
+		info.SymbolType = sym.Type.String()
 	}
 	return info
 }

--- a/internal/selfhost/check_query_test.go
+++ b/internal/selfhost/check_query_test.go
@@ -159,7 +159,8 @@ func TestOffsetContainmentBoundary(t *testing.T) {
 	if outer == "" {
 		return // no outer node — End is exclusive, empty result is fine
 	}
-	if outer == litNode.TypeName {
+	litType := selfhost.TypeAtOffset(r, litNode.Start)
+	if outer == litType {
 		t.Errorf("TypeAtOffset at End offset returned same type as literal node; expected an enclosing node's type or empty, got %q", outer)
 	}
 }

--- a/internal/selfhost/inspect_adapter.go
+++ b/internal/selfhost/inspect_adapter.go
@@ -30,7 +30,7 @@ func adaptInspectRecords(recs []*InspectRecord) []api.InspectRecord {
 			End:      r.end,
 			NodeKind: r.nodeKind,
 			Rule:     r.rule,
-			TypeName: r.typeName,
+			Type:     parseTypeRepr(r.typeName),
 			HintName: r.hintName,
 			Notes:    append([]string(nil), r.notes...),
 		})

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -242,11 +242,11 @@ func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhost
 		}
 		start, end := checkNodeOffsetsWithTokenLayout(layout, node.start, node.end)
 		result.TypedNodes = append(result.TypedNodes, CheckedNode{
-			Node:     node.node,
-			Kind:     node.kind,
-			TypeName: node.typeName,
-			Start:    start,
-			End:      end,
+			Node:  node.node,
+			Kind:  node.kind,
+			Type:  parseTypeRepr(node.typeName),
+			Start: start,
+			End:   end,
 		})
 	}
 	for _, binding := range checked.bindings {
@@ -255,12 +255,12 @@ func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhost
 		}
 		start, end := checkNodeOffsetsWithTokenLayout(layout, binding.start, binding.end)
 		result.Bindings = append(result.Bindings, CheckedBinding{
-			Node:     binding.node,
-			Name:     binding.name,
-			TypeName: binding.typeName,
-			Mutable:  binding.mutable,
-			Start:    start,
-			End:      end,
+			Node:    binding.node,
+			Name:    binding.name,
+			Type:    parseTypeRepr(binding.typeName),
+			Mutable: binding.mutable,
+			Start:   start,
+			End:     end,
 		})
 	}
 	for _, symbol := range checked.symbols {
@@ -269,13 +269,13 @@ func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhost
 		}
 		start, end := checkNodeOffsetsWithTokenLayout(layout, symbol.start, symbol.end)
 		result.Symbols = append(result.Symbols, CheckedSymbol{
-			Node:     symbol.node,
-			Kind:     symbol.kind,
-			Name:     symbol.name,
-			Owner:    symbol.owner,
-			TypeName: symbol.typeName,
-			Start:    start,
-			End:      end,
+			Node:  symbol.node,
+			Kind:  symbol.kind,
+			Name:  symbol.name,
+			Owner: symbol.owner,
+			Type:  parseTypeRepr(symbol.typeName),
+			Start: start,
+			End:   end,
 		})
 	}
 	for _, inst := range checked.instantiations {
@@ -286,8 +286,8 @@ func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhost
 		result.Instantiations = append(result.Instantiations, CheckInstantiation{
 			Node:       inst.node,
 			Callee:     inst.callee,
-			TypeArgs:   append([]string(nil), inst.typeArgs...),
-			ResultType: inst.resultType,
+			TypeArgs:   parseTypeReprSlice(inst.typeArgs),
+			ResultType: parseTypeRepr(inst.resultType),
 			Start:      start,
 			End:        end,
 		})

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -375,7 +375,7 @@ fn main() {
 func findCheckedBindingType(result selfhost.CheckResult, name string) string {
 	for _, binding := range result.Bindings {
 		if binding.Name == name {
-			return binding.TypeName
+			return binding.Type.String()
 		}
 	}
 	return ""

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -297,15 +297,15 @@ func adaptResolveResult(resolved *SelfResolveResult, file *AstFile, offsets func
 		}
 		start, end := offsets(sym.start, sym.end)
 		result.Symbols = append(result.Symbols, ResolvedSymbol{
-			Node:     sym.node,
-			Name:     sym.name,
-			Kind:     sym.kind,
-			TypeName: sym.typeName,
-			Arity:    sym.arity,
-			Depth:    sym.depth,
-			Start:    start,
-			End:      end,
-			Public:   sym.public,
+			Node:   sym.node,
+			Name:   sym.name,
+			Kind:   sym.kind,
+			Type:   parseTypeRepr(sym.typeName),
+			Arity:  sym.arity,
+			Depth:  sym.depth,
+			Start:  start,
+			End:    end,
+			Public: sym.public,
 		})
 	}
 	for _, ref := range resolved.refList {

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -36,10 +36,120 @@ use std.strings as strings
 // Bridge record types (preserved for Go host compatibility).
 // ---------------------------------------------------------------------
 
+/// FrontTypeRepr is a structured type representation that crosses the
+/// selfhost boundary without string round-tripping. Each field mirrors
+/// the discriminated TyNode shape but is serializable.
+pub struct FrontTypeRepr {
+    pub kind: String,
+    pub name: String,
+    pub path: String,
+    pub args: List<FrontTypeRepr>,
+    pub ret: Option<FrontTypeRepr>,
+}
+
+/// tyToRepr converts a TyArena index into a structured FrontTypeRepr,
+/// eliminating the string-based round-trip on the Go ↔ Osty boundary.
+pub fn tyToRepr(arena: TyArena, idx: Int) -> FrontTypeRepr {
+    if idx < 0 {
+        return FrontTypeRepr { kind: "error", name: "Invalid", path: "", args: [], ret: None }
+    }
+    let node = tyGet(arena, idx)
+    match node.kind {
+        TkErr -> FrontTypeRepr { kind: "error", name: "Invalid", path: "", args: [], ret: None },
+        TkPoison -> FrontTypeRepr { kind: "poison", name: "Poison", path: "", args: [], ret: None },
+        TkPrim -> FrontTypeRepr { kind: "primitive", name: primKindName(node.prim), path: "", args: [], ret: None },
+        TkNamed -> {
+            let mut reprArgs: List<FrontTypeRepr> = []
+            for arg in node.args {
+                reprArgs.push(tyToRepr(arena, arg))
+            }
+            FrontTypeRepr { kind: "named", name: node.head, path: "", args: reprArgs, ret: None }
+        },
+        TkOptional -> FrontTypeRepr {
+            kind: "optional",
+            name: "",
+            path: "",
+            args: [],
+            ret: Some(tyToRepr(arena, node.ret)),
+        },
+        TkTuple -> {
+            let mut elems: List<FrontTypeRepr> = []
+            for e in node.args {
+                elems.push(tyToRepr(arena, e))
+            }
+            FrontTypeRepr { kind: "tuple", name: "", path: "", args: elems, ret: None }
+        },
+        TkFn -> {
+            let mut paramReprs: List<FrontTypeRepr> = []
+            for p in node.args {
+                paramReprs.push(tyToRepr(arena, p))
+            }
+            FrontTypeRepr {
+                kind: "fn",
+                name: "",
+                path: "",
+                args: paramReprs,
+                ret: Some(tyToRepr(arena, node.ret)),
+            }
+        },
+        TkVar -> {
+            let vName = node.varName
+            if vName == "" {
+                FrontTypeRepr { kind: "typevar", name: "?{node.varId}", path: "", args: [], ret: None }
+            } else {
+                FrontTypeRepr { kind: "typevar", name: vName, path: "", args: [], ret: None }
+            }
+        },
+        TkSelf -> FrontTypeRepr { kind: "self", name: "Self", path: "", args: [], ret: None },
+    }
+}
+
+/// frontTypeReprToString converts a structured FrontTypeRepr back into
+/// a human-readable string for legacy callers that still expect String
+/// output (hover, query helpers).
+pub fn frontTypeReprToString(repr: FrontTypeRepr) -> String {
+    if repr.kind == "primitive" || repr.kind == "error" || repr.kind == "poison" || repr.kind == "typevar" || repr.kind == "self" {
+        repr.name
+    } else if repr.kind == "named" {
+        if repr.args.len() == 0 {
+            repr.name
+        } else {
+            let mut parts: List<String> = []
+            for a in repr.args {
+                parts.push(frontTypeReprToString(a))
+            }
+            "{repr.name}<{strings.join(parts, ", ")}>"
+        }
+    } else if repr.kind == "optional" {
+        match repr.ret {
+            Some(inner) -> "{frontTypeReprToString(inner)}?",
+            None -> "?",
+        }
+    } else if repr.kind == "tuple" {
+        let mut parts: List<String> = []
+        for e in repr.args {
+            parts.push(frontTypeReprToString(e))
+        }
+        "({strings.join(parts, ", ")})"
+    } else if repr.kind == "fn" {
+        let mut parts: List<String> = []
+        for p in repr.args {
+            parts.push(frontTypeReprToString(p))
+        }
+        let retStr = match repr.ret {
+            Some(r) -> frontTypeReprToString(r),
+            None -> "()",
+        }
+        "fn({strings.join(parts, ", ")}) -> {retStr}"
+    } else {
+        repr.name
+    }
+}
+
 pub struct FrontCheckedNode {
     pub node: Int,
     pub kind: String,
-    pub typeName: String,
+    pub type: FrontTypeRepr,
     pub start: Int,
     pub end: Int,
 }
@@ -47,7 +157,7 @@ pub struct FrontCheckedNode {
 pub struct FrontCheckedBinding {
     pub node: Int,
     pub name: String,
-    pub typeName: String,
+    pub type: FrontTypeRepr,
     pub mutable: Bool,
     pub start: Int,
     pub end: Int,
@@ -58,7 +168,7 @@ pub struct FrontCheckedSymbol {
     pub kind: String,
     pub name: String,
     pub owner: String,
-    pub typeName: String,
+    pub type: FrontTypeRepr,
     pub start: Int,
     pub end: Int,
 }
@@ -66,8 +176,8 @@ pub struct FrontCheckedSymbol {
 pub struct FrontCheckInstantiation {
     pub node: Int,
     pub callee: String,
-    pub typeArgs: List<String>,
-    pub resultType: String,
+    pub typeArgs: List<FrontTypeRepr>,
+    pub resultType: FrontTypeRepr,
     pub start: Int,
     pub end: Int,
 }
@@ -1200,7 +1310,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
         typedNodes.push(FrontCheckedNode {
             node: node.originAst,
             kind,
-            typeName: tyToString(cx.env.tys, node.ty),
+            type: tyToRepr(cx.env.tys, node.ty),
             start: astNode.start,
             end: astNode.end,
         })
@@ -1211,7 +1321,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
         bindings.push(FrontCheckedBinding {
             node: b.node,
             name: b.name,
-            typeName: tyToString(cx.env.tys, b.ty),
+            type: tyToRepr(cx.env.tys, b.ty),
             mutable: b.mutable,
             start: b.start,
             end: b.end,
@@ -1225,7 +1335,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
             kind: s.kind,
             name: s.name,
             owner: s.owner,
-            typeName: tyToString(cx.env.tys, s.ty),
+            type: tyToRepr(cx.env.tys, s.ty),
             start: s.start,
             end: s.end,
         })
@@ -1233,15 +1343,15 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
 
     let mut instantiations: List<FrontCheckInstantiation> = []
     for inst in cx.env.instantiations {
-        let mut typeArgStrs: List<String> = []
+        let mut typeArgReprs: List<FrontTypeRepr> = []
         for tyArg in inst.typeArgs {
-            typeArgStrs.push(tyToString(cx.env.tys, tyArg))
+            typeArgReprs.push(tyToRepr(cx.env.tys, tyArg))
         }
         instantiations.push(FrontCheckInstantiation {
             node: inst.node,
             callee: inst.callee,
-            typeArgs: typeArgStrs,
-            resultType: tyToString(cx.env.tys, inst.resultTy),
+            typeArgs: typeArgReprs,
+            resultType: tyToRepr(cx.env.tys, inst.resultTy),
             start: inst.start,
             end: inst.end,
         })
@@ -1271,7 +1381,7 @@ pub fn frontCheckResultBindingType(result: FrontCheckResult, name: String) -> St
     let mut found = ""
     for b in result.bindings {
         if b.name == name {
-            found = b.typeName
+            found = frontTypeReprToString(b.type)
         }
     }
     found
@@ -1337,7 +1447,7 @@ pub fn selfCheckTypeNameAtOffset(result: FrontCheckResult, offset: Int) -> Strin
     if bestIdx < 0 {
         return ""
     }
-    result.typedNodes[bestIdx].typeName
+    frontTypeReprToString(result.typedNodes[bestIdx].type)
 }
 
 /// selfCheckLetTypeNameAtOffset returns the declared type-name of the
@@ -1347,7 +1457,7 @@ pub fn selfCheckTypeNameAtOffset(result: FrontCheckResult, offset: Int) -> Strin
 pub fn selfCheckLetTypeNameAtOffset(result: FrontCheckResult, offset: Int) -> String {
     for b in result.bindings {
         if selfCheckOffsetContains(b.start, b.end, offset) {
-            return b.typeName
+            return frontTypeReprToString(b.type)
         }
     }
     ""
@@ -1405,7 +1515,7 @@ pub fn selfCheckHoverAtOffset(result: FrontCheckResult, offset: Int) -> SelfChec
     if bestIdx >= 0 {
         info.symbolName = result.symbols[bestIdx].name
         info.symbolKind = result.symbols[bestIdx].kind
-        info.symbolType = result.symbols[bestIdx].typeName
+        info.symbolType = frontTypeReprToString(result.symbols[bestIdx].type)
     }
     info
 }

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -647,7 +647,7 @@ fn tyFnToString(arena: TyArena, params: List<Int>, ret: Int) -> String {
     "fn({strings.join(parts, sep)}) -> {tyToString(arena, ret)}"
 }
 
-fn primKindName(prim: PrimKind) -> String {
+pub fn primKindName(prim: PrimKind) -> String {
     match prim {
         PkInvalid -> "Invalid",
         PkInt -> "Int",


### PR DESCRIPTION
## Summary

The Go ↔ Osty boundary previously serialized type checker results as strings (`"List<Int>"`, `"fn(T) -> T"`) and parsed them back with a hand-written recursive descent parser (~120 lines) in `host_boundary.go`. Every new type form required manual parser updates.

This PR introduces `api.TypeRepr` — a structured type representation that crosses the boundary without string parsing.

## Changes

### `api.TypeRepr` (new)

```go
type TypeRepr struct {
    Kind   string     `json:"kind"`              // "primitive", "named", "tuple", "optional", "fn", ...
    Name   string     `json:"name,omitempty"`    // "Int", "List", "T"
    Path   string     `json:"path,omitempty"`    // reserved
    Args   []TypeRepr `json:"args,omitempty"`    // generic args / tuple elems / fn params
    Return *TypeRepr  `json:"return,omitempty"`  // fn return type / optional inner
}
```

### Field migrations (`TypeName string` → `Type *TypeRepr`)

| Struct | Before | After |
|--------|--------|-------|
| `CheckedNode` | `TypeName string` | `Type *TypeRepr` |
| `CheckedBinding` | `TypeName string` | `Type *TypeRepr` |
| `CheckedSymbol` | `TypeName string` | `Type *TypeRepr` |
| `CheckInstantiation` | `TypeArgs []string`, `ResultType string` | `TypeArgs []TypeRepr`, `ResultType *TypeRepr` |
| `ResolvedSymbol` | `TypeName string` | `Type *TypeRepr` |
| `InspectRecord` | `TypeName string` | `Type *TypeRepr` |

### Osty side (`toolchain/check.osty`)

- `FrontTypeRepr` struct + `tyToRepr()` converts `TyArena` index → structured repr
- `frontTypeReprToString()` for legacy `String`-returning helpers
- Bridge record fields: `typeName: String` → `type: FrontTypeRepr`
- `toolchain/ty.osty`: `primKindName` promoted to `pub`

### Go bridge (`internal/check/host_boundary.go`)

- `typeReprToType()` replaces `parseSelfhostTypeName()` (~60 vs ~120 lines)
- **Removed**: `parseSelfhostTypeName`, `parseSelfhostFnType`, `splitSelfhostGeneric`, `splitSelfhostTypeList`, `matchingSelfhostParen`

## Transitional note

`check_adapter.go` retains `parseTypeRepr()` because `generated.go` has not been regenerated with `FrontTypeRepr` fields yet (the Osty→Go transpiler needs to run). Once regenerated, `parseTypeRepr` and its helpers (~190 lines) will be deleted entirely — adapters will read `FrontTypeRepr` values directly.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/selfhost/ ./internal/check/ ./cmd/osty-native-checker/` passes
- [x] All test data updated from `TypeName: "Int"` → `Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}`