### PR TITLE
refactor(llvmgen): port MirThunkDefs struct (§4 closure-thunk cache mirror)

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -264,6 +264,12 @@ list keeps new Osty clean of known landmines.
 | `MirStringPool.symbol` | `(self, content: String) -> String` | §12 | Looks up the symbol for an already-interned content; returns `""` when not present |
 | `MirStringPool.orderedKeys` | `(self) -> List<String>` | §12 | Insertion-ordered list of literal contents — drives `emitStringPool`'s deterministic walk over the pool |
 | `MirStringPool.isEmpty` | `(self) -> Bool` | §12 | Early-exit gate for `emitStringPool` — modules without string constants emit no pool block |
+| `MirThunkDefs` (struct) | `{ bodies: Map<String, String>, order: List<String> }` | §4 | Closure-thunk definition cache. Owns the dedup + insertion-order side of the emitter's `define private <ret> @__osty_closure_thunk_<sym>(ptr env, ...)` shim functions. Replaces `mirGen.thunkDefs + thunkOrder` Go fields. Fourth member of the dedup-with-order family alongside `MirLayoutCache`, `MirRuntimeDecls`, `MirStringPool` |
+| `MirThunkDefs.contains` | `(self, symbol: String) -> Bool` | §4 | Reports whether a thunk for `symbol` has already been generated. Used by `ensureThunk` as an early-exit gate before doing the (non-trivial) work of formatting the thunk's IR body |
+| `MirThunkDefs.register` | `(mut self, symbol: String, body: String) -> Bool` | §4 | Records a freshly-generated thunk body. Returns true when newly added, false when already present |
+| `MirThunkDefs.body` | `(self, symbol: String) -> String` | §4 | Looks up the IR for an already-registered thunk; returns `""` when not present |
+| `MirThunkDefs.orderedBodies` | `(self) -> List<String>` | §4 | Insertion-ordered thunk IR strings — `emitThunks` concatenates these directly (each body already ends with `}\n\n`) |
+| `MirThunkDefs.isEmpty` | `(self) -> Bool` | §4 | Early-exit gate for `emitThunks` — modules without closure-converted top-level fns emit no thunk block |
 | `mirAndI1Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i1 logical-and `  <reg> = and i1 <lhs>, <rhs>\n` — used by bounds-check `nonNeg && inUpper` pattern in `emitListSafeGet` |
 | `mirCallValueWithAliasScopeLine` | `(reg, retTy, sym, argList, scopeRef) -> String` | §1 | Snapshot-call form with `!alias.scope` metadata: `  <reg> = call <retTy> @<sym>(<args>), !alias.scope <ref>\n`. Unlocks LICM of `osty_rt_list_data_*` / `osty_rt_list_len` snapshot reads |
 | `mirLoadWithNoAliasLine` | `(reg: String, ty: String, ptr: String, scopeRef: String) -> String` | §1 | Load tagged with `!noalias` metadata — vector-list fast-path read |

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -170,8 +170,12 @@ type mirGen struct {
 	// Under the uniform env ABI every closure call takes an env as
 	// implicit first arg; top-level fns have no env, so the thunk
 	// ignores env and delegates to the real fn.
-	thunkDefs  map[string]string // symbol → full thunk IR
-	thunkOrder []string
+	// thunkDefs owns the closure-thunk definition pool — dedup +
+	// insertion-order, mirrored from
+	// `toolchain/mir_generator.osty: MirThunkDefs`. Replaces the
+	// previous `thunkDefs map[string]string + thunkOrder []string`
+	// pair fields.
+	thunks MirThunkDefs
 
 	// Interface-related state. `ifaceTouched` is flipped when any code
 	// path emits a value typed as `%osty.iface` — either a parameter
@@ -251,7 +255,6 @@ func newMIRGen(m *mir.Module, opts Options) *mirGen {
 		source:        filepath.ToSlash(firstNonEmpty(opts.SourcePath, "<unknown>")),
 		src:           append([]byte(nil), opts.Source...),
 		functionTypes: map[string]mirFnSig{},
-		thunkDefs:     map[string]string{},
 		tupleDefs:     map[string][]mir.Type{},
 		vtableRefs:    map[string]struct{}{},
 	}
@@ -1367,12 +1370,14 @@ func (g *mirGen) emitGlobalVars() {
 // emitThunks appends any closure thunks generated during function
 // emission. Thunks live below the normal user function definitions so
 // the output reads top-down: user fns first, then closure shims.
+// Delegates to the Osty-sourced `MirThunkDefs.IsEmpty` /
+// `OrderedBodies` (`toolchain/mir_generator.osty`).
 func (g *mirGen) emitThunks() {
-	if len(g.thunkOrder) == 0 {
+	if g.thunks.IsEmpty() {
 		return
 	}
-	for _, sym := range g.thunkOrder {
-		g.out.WriteString(g.thunkDefs[sym])
+	for _, body := range g.thunks.OrderedBodies() {
+		g.out.WriteString(body)
 	}
 }
 
@@ -8157,9 +8162,11 @@ func (g *mirGen) emitFnValueWrapper(symbol string, fnT mir.Type) (string, error)
 
 // ensureThunk generates (once per symbol) a thunk function with
 // signature `ret (ptr env, user_params...) -> ret`. The body
-// discards env and tail-calls the real symbol.
+// discards env and tail-calls the real symbol. Dedup gate routes
+// through the Osty-sourced `MirThunkDefs.Contains`
+// (`toolchain/mir_generator.osty`).
 func (g *mirGen) ensureThunk(symbol string, fnT *ir.FnType) {
-	if _, ok := g.thunkDefs[symbol]; ok {
+	if g.thunks.Contains(symbol) {
 		return
 	}
 	retLLVM := "void"
@@ -8205,8 +8212,7 @@ func (g *mirGen) ensureThunk(symbol string, fnT *ir.FnType) {
 		b.WriteString(" %ret\n")
 	}
 	b.WriteString("}\n\n")
-	g.thunkDefs[symbol] = b.String()
-	g.thunkOrder = append(g.thunkOrder, symbol)
+	g.thunks.Register(symbol, b.String())
 }
 
 // thunkName builds the closure-thunk LLVM symbol name. Delegates to

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -1855,3 +1855,61 @@ func (p *MirStringPool) OrderedKeys() []string {
 func (p *MirStringPool) IsEmpty() bool {
 	return len(p.Order) == 0
 }
+
+// §4 closure-thunk definition cache.
+//
+// MirThunkDefs mirrors `toolchain/mir_generator.osty: MirThunkDefs`.
+// Owns the dedup + insertion-order side of the emitter's closure-thunk
+// pool. Replaces the `mirGen.thunkDefs map[string]string + thunkOrder
+// []string` pair fields. Fourth member of the dedup-with-order family
+// alongside `MirLayoutCache`, `MirRuntimeDecls`, and `MirStringPool`.
+
+// Osty: MirThunkDefs
+type MirThunkDefs struct {
+	Bodies map[string]string
+	Order  []string
+}
+
+// Osty: MirThunkDefs.contains
+func (t *MirThunkDefs) Contains(symbol string) bool {
+	if t.Bodies == nil {
+		return false
+	}
+	_, ok := t.Bodies[symbol]
+	return ok
+}
+
+// Osty: MirThunkDefs.register
+func (t *MirThunkDefs) Register(symbol string, body string) bool {
+	if t.Bodies == nil {
+		t.Bodies = map[string]string{}
+	}
+	if _, ok := t.Bodies[symbol]; ok {
+		return false
+	}
+	t.Bodies[symbol] = body
+	t.Order = append(t.Order, symbol)
+	return true
+}
+
+// Osty: MirThunkDefs.body
+func (t *MirThunkDefs) Body(symbol string) string {
+	if t.Bodies == nil {
+		return ""
+	}
+	return t.Bodies[symbol]
+}
+
+// Osty: MirThunkDefs.orderedBodies
+func (t *MirThunkDefs) OrderedBodies() []string {
+	out := make([]string, 0, len(t.Order))
+	for _, sym := range t.Order {
+		out = append(out, t.Body(sym))
+	}
+	return out
+}
+
+// Osty: MirThunkDefs.isEmpty
+func (t *MirThunkDefs) IsEmpty() bool {
+	return len(t.Order) == 0
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2273,3 +2273,83 @@ pub struct MirStringPool {
         self.order.isEmpty()
     }
 }
+
+/// §4 closure-thunk definition cache.
+///
+/// MirThunkDefs owns the dedup + insertion-order side of the
+/// emitter's closure-thunk pool — the `define private <ret>
+/// @__osty_closure_thunk_<sym>(ptr env, <user_params>...)` shim
+/// functions that adapt a top-level function symbol to the
+/// uniform-env closure ABI. Mirrors the `mirGen.thunkDefs
+/// map[string]string + thunkOrder []string` Go fields. Fourth
+/// member of the dedup-with-order family alongside
+/// `MirLayoutCache` (#888), `MirRuntimeDecls`, and `MirStringPool`.
+///
+/// Why a struct: thunks are generated lazily (one per
+/// closure-converted top-level fn referenced as a value) and the
+/// dedup check at call time (`contains(symbol)`) is on the hot
+/// `evalClosureFnConst` path. Centralising the cache makes the
+/// "have I seen this thunk?" check a named method instead of a
+/// raw map probe.
+pub struct MirThunkDefs {
+    /// bodies maps the user-fn symbol (e.g. `main_renderReport`)
+    /// to its complete thunk IR — the full `define private ... { ... }`
+    /// block ready to be appended to `g.out` by `emitThunks`. The
+    /// IR string ends with `}\n\n` so concatenation with the next
+    /// thunk's IR produces well-spaced output.
+    pub bodies: Map<String, String>,
+    /// order is the insertion-ordered list of user-fn symbols —
+    /// the keys of `bodies` in the order the thunks were
+    /// generated. Walked by `emitThunks` to append the thunk pool
+    /// deterministically regardless of map iteration order.
+    pub order: List<String>,
+
+    /// contains reports whether a thunk for `symbol` has already
+    /// been generated. Used by `ensureThunk` as an early-exit gate
+    /// before doing the (non-trivial) work of formatting the
+    /// thunk's IR body.
+    pub fn contains(self, symbol: String) -> Bool {
+        self.bodies.containsKey(symbol)
+    }
+
+    /// register records a freshly-generated thunk body for
+    /// `symbol`. Returns true when newly added, false when the
+    /// symbol already had a thunk (the caller's body work is
+    /// then discarded — `ensureThunk` instead pre-checks via
+    /// `contains` to skip the work entirely).
+    pub fn register(mut self, symbol: String, body: String) -> Bool {
+        if self.bodies.containsKey(symbol) {
+            return false
+        }
+        self.bodies.insert(symbol, body)
+        self.order.push(symbol)
+        true
+    }
+
+    /// body looks up the IR for an already-registered thunk;
+    /// returns `""` when not present. Used by `emitThunks` to
+    /// recover each entry's IR without re-registering.
+    pub fn body(self, symbol: String) -> String {
+        self.bodies.get(symbol) ?? ""
+    }
+
+    /// orderedBodies returns the thunk IR strings in insertion
+    /// order — `emitThunks` concatenates these directly to
+    /// `g.out` (each body already ends with `}\n\n` so no
+    /// separator is needed).
+    pub fn orderedBodies(self) -> List<String> {
+        let mut out: List<String> = []
+        for sym in self.order {
+            out.push(self.body(sym))
+        }
+        out
+    }
+
+    /// isEmpty reports whether the cache holds no thunks —
+    /// the early-exit gate in `emitThunks` so modules that
+    /// don't pass any top-level functions as closures emit no
+    /// thunk block.
+    pub fn isEmpty(self) -> Bool {
+        self.order.isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`MirThunkDefs\` to \`toolchain/mir_generator.osty\` — fourth
member of the dedup-with-order family alongside \`MirLayoutCache\`
(#888), \`MirRuntimeDecls\` (#897), and \`MirStringPool\` (#899).
Replaces the \`mirGen.thunkDefs + thunkOrder\` Go fields with a
single \`thunks MirThunkDefs\` field that lives in the snapshot
mirror.

## What landed

**\`MirThunkDefs\` struct + 5 methods**

\`\`\`osty
pub struct MirThunkDefs {
    pub bodies: Map<String, String>,  // symbol -> full thunk IR
    pub order: List<String>,

    pub fn contains(self, symbol: String) -> Bool { ... }
    pub fn register(mut self, symbol: String, body: String) -> Bool { ... }
    pub fn body(self, symbol: String) -> String { ... }
    pub fn orderedBodies(self) -> List<String> { ... }
    pub fn isEmpty(self) -> Bool { ... }
}
\`\`\`

**Go-side wiring**

- \`mirGen\` field replacement: \`thunkDefs\` + \`thunkOrder\` →
  \`thunks MirThunkDefs\`.
- \`ensureThunk\` uses \`Contains\` for the early-exit gate,
  \`Register\` after building the body.
- \`emitThunks\` uses \`IsEmpty\` + \`OrderedBodies\`.

## Why

The Osty-side API splits into \`contains\` (read-only check) and
\`register\` (insert) so \`ensureThunk\` can short-circuit BEFORE
doing the (non-trivial) work of building the thunk's IR body.
Doing the work + discarding via \`register\`'s \`false\` return
would waste effort on every repeat reference.

## Behavior parity

- Same dedup semantics: first reference generates + stores, all
  subsequent references skip via the contains check.
- Insertion order preserved.
- \`emitThunks\` output unchanged byte-for-byte.

## Test plan

- [x] \`go build ./internal/llvmgen/\` clean
- [x] \`go test -short -run "TestGenerateFromMIRStringEquality|InlineLiteral"\` pass
- [x] llvmgen test failure count unchanged (25 vs main's 25 — all
      pre-existing failures, none caused by this refactor)
- [ ] CI \`just prepush\` gate

## Stats

\`160 insertions(+) / 10 deletions(-)\` across 4 files. Net +150 LOC —
mostly the new struct + 5 methods + Go mirror; the Go field
declaration collapses from 2 named fields to 1.

## dedup-with-order family progress

| Cache | Slice | Replaces |
|-------|-------|----------|
| MirLayoutCache | #888 | \`enumLayouts\`/\`enumLayoutOrder\` + \`tupleDefs\`/\`tupleOrder\` |
| MirRuntimeDecls | #897 | \`declares\` + \`declareOrder\` |
| MirStringPool | #899 | \`strings\` + \`stringOrder\` |
| **MirThunkDefs** | **this** | \`thunkDefs\` + \`thunkOrder\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)