### PR TITLE
bench: add id-tracker (Map<Int, Int>-heavy program) for i64 key path

### DIFF
--- a/benchmarks/programs/id-tracker/go/go.mod
+++ b/benchmarks/programs/id-tracker/go/go.mod
@@ -1,0 +1,3 @@
+module osty/benchmarks/id-tracker
+
+go 1.22

--- a/benchmarks/programs/id-tracker/go/main.go
+++ b/benchmarks/programs/id-tracker/go/main.go
@@ -1,0 +1,96 @@
+// id-tracker — Go side of the end-to-end runtime program benchmark.
+//
+// Mirrors the Osty implementation byte-for-byte (deterministic LCG
+// generator, identical aggregation, identical output format) so
+// hyperfine can compare wall-clock cost on a Map<int64, V>-heavy
+// workload: each iteration does containsKey + getOr + insert on
+// Map<int64, int64> for the count and sum aggregations, then a
+// sort + top-K format pass.
+//
+// No I/O — the event stream is generated in-process from the LCG
+// state seeded the same on both sides.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+const N = 50000
+
+func generateEvents(n int) []int64 {
+	out := make([]int64, n)
+	state := int64(1)
+	for i := 0; i < n; i++ {
+		state = (state*1103515245 + 12345) % 2147483648
+		out[i] = state
+	}
+	return out
+}
+
+func main() {
+	events := generateEvents(N)
+	// id space: 256 distinct ids. Skewed: hot-id is selected ~70% of
+	// the time, cold ids the rest. id is `state % hotKeySpace` for
+	// hot, `hotKeySpace + (state / 8) % coldKeySpace` for cold.
+	const hotKeys = 32
+	const coldKeys = 224
+	counts := map[int64]int64{}
+	sums := map[int64]int64{}
+	firstSeen := map[int64]int64{}
+
+	for i, ev := range events {
+		var id int64
+		if ev%100 < 70 {
+			id = ev % hotKeys
+		} else {
+			id = hotKeys + (ev/8)%coldKeys
+		}
+		value := (ev / 1024) % 1000
+		counts[id] = counts[id] + 1
+		sums[id] = sums[id] + value
+		if _, ok := firstSeen[id]; !ok {
+			firstSeen[id] = int64(i)
+		}
+	}
+
+	// Top 10 ids by count desc, id asc tiebreak.
+	ids := make([]int64, 0, len(counts))
+	for k := range counts {
+		ids = append(ids, k)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		ci := counts[ids[i]]
+		cj := counts[ids[j]]
+		if ci != cj {
+			return ci > cj
+		}
+		return ids[i] < ids[j]
+	})
+	topK := 10
+	if len(ids) < topK {
+		topK = len(ids)
+	}
+
+	// Aggregate totals as a sanity column the verifier diffs.
+	var totalCount int64
+	var totalSum int64
+	for _, c := range counts {
+		totalCount += c
+	}
+	for _, s := range sums {
+		totalSum += s
+	}
+
+	fmt.Printf("events: %d\n", len(events))
+	fmt.Printf("distinct: %d\n", len(counts))
+	fmt.Printf("total_count: %d\n", totalCount)
+	fmt.Printf("total_sum: %d\n", totalSum)
+	fmt.Println("top:")
+	for i := 0; i < topK; i++ {
+		id := ids[i]
+		fmt.Printf("  id=%d count=%d sum=%d first=%d\n",
+			id, counts[id], sums[id], firstSeen[id])
+	}
+}

--- a/benchmarks/programs/id-tracker/osty/main.osty
+++ b/benchmarks/programs/id-tracker/osty/main.osty
@@ -1,0 +1,140 @@
+// id-tracker — Osty side of the end-to-end runtime program benchmark.
+//
+// Mirrors benchmarks/programs/id-tracker/go/main.go byte-for-byte
+// (same deterministic LCG, same id partitioning, same output
+// format) so hyperfine can compare wall-clock cost on a
+// Map<Int, Int>-heavy workload — each iteration does 3 Map ops on
+// i64-keyed maps. Companion to the String-keyed log-aggregator /
+// lru-sim / markdown-stats benches; this one exercises the i64
+// key intrinsic path.
+//
+// Backend constraints:
+//   * No `Int.toString()` / Int interpolation — local `intToStr`.
+//   * Only intrinsic Map<Int, Int> ops (insert/get/getOr/keys/containsKey).
+//   * Insertion sort for top-K so we don't need a comparator-bearing
+//     `sorted` for List<Int>.
+
+fn intToStr(n: Int) -> String {
+    let digits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+    if n == 0 {
+        return "0"
+    }
+    let mut x = n
+    let mut neg = false
+    if x < 0 {
+        neg = true
+        x = 0 - x
+    }
+    let mut chunks: List<String> = []
+    for x > 0 {
+        chunks.push(digits[x % 10])
+        x = x / 10
+    }
+    let mut out = ""
+    if neg {
+        out = "-"
+    }
+    let mut i = chunks.len()
+    for i > 0 {
+        i = i - 1
+        out = out + chunks[i]
+    }
+    out
+}
+
+fn generateEvents(n: Int) -> List<Int> {
+    let mut out: List<Int> = []
+    let mut state = 1
+    let mut i = 0
+    for i < n {
+        state = (state * 1103515245 + 12345) % 2147483648
+        out.push(state)
+        i = i + 1
+    }
+    out
+}
+
+fn main() {
+    let n = 50000
+    let events = generateEvents(n)
+    // 256 distinct ids; ~70% bias toward hot bucket.
+    let hotKeys = 32
+    let coldKeys = 224
+    let mut counts: Map<Int, Int> = {:}
+    let mut sums: Map<Int, Int> = {:}
+    let mut firstSeen: Map<Int, Int> = {:}
+
+    let mut idx = 0
+    for idx < events.len() {
+        let ev = events[idx]
+        let mut id = 0
+        if ev % 100 < 70 {
+            id = ev % hotKeys
+        } else {
+            id = hotKeys + (ev / 8) % coldKeys
+        }
+        let value = (ev / 1024) % 1000
+        counts.insert(id, counts.getOr(id, 0) + 1)
+        sums.insert(id, sums.getOr(id, 0) + value)
+        if !firstSeen.containsKey(id) {
+            firstSeen.insert(id, idx)
+        }
+        idx = idx + 1
+    }
+
+    // Aggregate totals (verifier sanity columns).
+    let mut totalCount = 0
+    let mut totalSum = 0
+    let allIds = counts.keys()
+    let mut k = 0
+    for k < allIds.len() {
+        totalCount = totalCount + counts.getOr(allIds[k], 0)
+        totalSum = totalSum + sums.getOr(allIds[k], 0)
+        k = k + 1
+    }
+
+    // Top 10 by count desc, id asc tiebreak.
+    // First build present-id list in id-asc order so insertion sort
+    // by count desc preserves id-asc on ties.
+    let mut ids: List<Int> = []
+    let totalKeys = hotKeys + coldKeys
+    let mut bid = 0
+    for bid < totalKeys {
+        if counts.containsKey(bid) {
+            ids.push(bid)
+        }
+        bid = bid + 1
+    }
+    let mut i2 = 1
+    for i2 < ids.len() {
+        let mut j = i2
+        for j > 0 {
+            let prev = ids[j - 1]
+            let cur = ids[j]
+            if counts.getOr(prev, 0) < counts.getOr(cur, 0) {
+                ids[j - 1] = cur
+                ids[j] = prev
+                j = j - 1
+            } else {
+                break
+            }
+        }
+        i2 = i2 + 1
+    }
+    let topK = if ids.len() < 10 { ids.len() } else { 10 }
+
+    println("events: " + intToStr(n))
+    println("distinct: " + intToStr(allIds.len()))
+    println("total_count: " + intToStr(totalCount))
+    println("total_sum: " + intToStr(totalSum))
+    println("top:")
+    let mut t = 0
+    for t < topK {
+        let id = ids[t]
+        let c = counts.getOr(id, 0)
+        let s = sums.getOr(id, 0)
+        let f = firstSeen.getOr(id, 0)
+        println("  id=" + intToStr(id) + " count=" + intToStr(c) + " sum=" + intToStr(s) + " first=" + intToStr(f))
+        t = t + 1
+    }
+}

--- a/benchmarks/programs/id-tracker/osty/osty.toml
+++ b/benchmarks/programs/id-tracker/osty/osty.toml
@@ -1,0 +1,17 @@
+# id-tracker — Osty side of the end-to-end runtime program benchmark.
+# Mirrors benchmarks/programs/id-tracker/go/main.go.
+#
+# Map<Int, Int>-heavy workload: each event does 3 Map ops on i64-keyed
+# maps (counts / sums / firstSeen). Designed to exercise the i64 key
+# Map intrinsic path the way log-aggregator/lru-sim/markdown-stats
+# exercise the String key path.
+#
+#     osty build
+#     osty run
+
+[package]
+name = "id-tracker"
+version = "0.1.0"
+edition = "0.4"
+
+[dependencies]


### PR DESCRIPTION
## Summary

Adds a 6th program to `benchmarks/programs/` that exercises the **i64 key** Map intrinsic path. Companion to log-aggregator / lru-sim / markdown-stats (which all use String keys).

Each iteration does 3 Map ops on `Map<Int, Int>` (counts, sums, firstSeen) over a 50000-event stream with 256 distinct ids partitioned 70/30 hot/cold, then sorts by count desc for top-K format.

## Confirms i64 wrapper inlining from #898

The `OSTY_HOT_INLINE` + `-import-instr-limit=500` work in #898 was applied via the `OSTY_RT_DEFINE_MAP_KEY_OPS` macro (which generates wrappers for all key suffixes — `i64`, `i1`, `f64`, `ptr`, `string`), so i64 was already covered. This benchmark verifies it empirically:

- `nm` shows no `osty_rt_map_get_i64` / `_insert_i64` / `_contains_i64` symbols in the binary
- `otool -tV` shows zero `bl _osty_rt_map_get_i64` instructions in the hot loop

## Perf vs Go (hyperfine 30 runs / 5 warmup)

| | mean ± σ |
|---|---:|
| go | 3.7 ms ± 0.2 ms |
| osty | 4.8 ms ± 0.2 ms |
| osty/go | **1.3x** |

Second-best ratio in the suite (after dep-resolver at 1.2x). i64 keys outperform String keys because:
- Hash: `mix64` single multiply vs FNV byte-walk + SSO decode
- Value-equality: i64 `==` vs strcmp with SSO tag dispatch
- Probe loop: no decode buffer, no tag check

## Suite snapshot (6 programs)

| program | osty (ms) | osty/go |
|---|---:|:---:|
| dep-resolver | 2.9 | 1.2x |
| **id-tracker** | **4.8** | **1.3x** ← new |
| expr-calc | 5.5 | 1.7x |
| log-aggregator | 19.2 | 1.9x |
| lru-sim | 19.1 | 2.1x |
| markdown-stats | 7.3 | 2.1x |

The remaining 1.9-2.1x gap is concentrated on String-key Map workloads — inlining-orthogonal alloc / cache-locality issues for follow-up work.

## Test plan

- [x] Go and Osty produce byte-equal output (verified via build-all.sh parity check)
- [x] Auto-discovered by `benchmarks/programs/build-all.sh` (uses go/ + osty/ subdir convention)
- [x] Auto-discovered by `benchmarks/programs/run-all.sh`
- [x] i64 wrapper inlining empirically confirmed (`nm` + `otool` post-build)
- [x] Acts as an early-warning signal if a future runtime change ever bumps a Map wrapper body past the 500-instr ThinLTO budget — the wrapper would reappear as a `bl` and the 1.3x ratio would degrade visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)