### PR TITLE
refactor(llvmgen): port MirVtableRefs struct (§3 vtable reference set mirror)

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -270,6 +270,11 @@ list keeps new Osty clean of known landmines.
 | `MirThunkDefs.body` | `(self, symbol: String) -> String` | §4 | Looks up the IR for an already-registered thunk; returns `""` when not present |
 | `MirThunkDefs.orderedBodies` | `(self) -> List<String>` | §4 | Insertion-ordered thunk IR strings — `emitThunks` concatenates these directly (each body already ends with `}\n\n`) |
 | `MirThunkDefs.isEmpty` | `(self) -> Bool` | §4 | Early-exit gate for `emitThunks` — modules without closure-converted top-level fns emit no thunk block |
+| `MirVtableRefs` (struct) | `{ seen: Map<String, Bool>, order: List<String> }` | §3 | Vtable reference set (downcast support). Owns the dedup + insertion-order side of the emitter's `@osty.vtable.<impl>__<iface>` external constant declarations. Replaces `mirGen.vtableRefs + vtableRefOrder` Go fields. Fifth (and capping) member of the dedup-with-order family alongside `MirLayoutCache`, `MirRuntimeDecls`, `MirStringPool`, `MirThunkDefs` |
+| `MirVtableRefs.register` | `(mut self, symbol: String) -> Bool` | §3 | Adds `symbol` to the set; returns true when newly added, false when already seen |
+| `MirVtableRefs.contains` | `(self, symbol: String) -> Bool` | §3 | Read-only check; sibling of `MirThunkDefs.contains` so cross-cache code reads uniformly |
+| `MirVtableRefs.orderedSymbols` | `(self) -> List<String>` | §3 | Insertion-ordered list of registered symbols — drives `emitTypeDefs`'s walk over the external-constant block |
+| `MirVtableRefs.isEmpty` | `(self) -> Bool` | §3 | Early-exit signal for callers that gate the `@osty.vtable.* = external constant [0 x ptr]` block on presence of any downcast site |
 | `mirAndI1Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i1 logical-and `  <reg> = and i1 <lhs>, <rhs>\n` — used by bounds-check `nonNeg && inUpper` pattern in `emitListSafeGet` |
 | `mirCallValueWithAliasScopeLine` | `(reg, retTy, sym, argList, scopeRef) -> String` | §1 | Snapshot-call form with `!alias.scope` metadata: `  <reg> = call <retTy> @<sym>(<args>), !alias.scope <ref>\n`. Unlocks LICM of `osty_rt_list_data_*` / `osty_rt_list_len` snapshot reads |
 | `mirLoadWithNoAliasLine` | `(reg: String, ty: String, ptr: String, scopeRef: String) -> String` | §1 | Load tagged with `!noalias` metadata — vector-list fast-path read |

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -185,9 +185,13 @@ type mirGen struct {
 	// call sites; each becomes an external constant declaration so the
 	// emitted module stays self-describing even before the MIR path
 	// grows full vtable-body emission.
-	ifaceTouched   bool
-	vtableRefs     map[string]struct{}
-	vtableRefOrder []string
+	ifaceTouched bool
+	// vtableRefs owns the downcast vtable-reference set —
+	// dedup + insertion-order, mirrored from
+	// `toolchain/mir_generator.osty: MirVtableRefs`. Replaces
+	// the previous `vtableRefs map[string]struct{} +
+	// vtableRefOrder []string` pair fields.
+	vtables MirVtableRefs
 
 	// v0.6 A5/A5.1/A6/A7: per-function loop-optimization hints,
 	// captured at `emitFunction` entry and cleared between functions.
@@ -256,7 +260,6 @@ func newMIRGen(m *mir.Module, opts Options) *mirGen {
 		src:           append([]byte(nil), opts.Source...),
 		functionTypes: map[string]mirFnSig{},
 		tupleDefs:     map[string][]mir.Type{},
-		vtableRefs:    map[string]struct{}{},
 	}
 }
 
@@ -1480,7 +1483,7 @@ func (g *mirGen) emitTypeDefs() {
 	// not yet emitted by the MIR path; the downcast-compare lowering
 	// only needs the symbol to exist so the `icmp eq ptr` is a legal
 	// reference.
-	for _, sym := range g.vtableRefOrder {
+	for _, sym := range g.vtables.OrderedSymbols() {
 		block.WriteString(mirLlvmVtableDeclLine(sym))
 	}
 	block.WriteByte('\n')
@@ -3908,10 +3911,7 @@ func (g *mirGen) tryEmitInterfaceDowncast(c *mir.CallInstr, fnRef *mir.FnRef) (b
 		return true, unsupportedf("mir-mvp",
 			"interface downcast target %q does not implement interface %q", targetT.Name, ifaceName)
 	}
-	if _, exists := g.vtableRefs[vtableSym]; !exists {
-		g.vtableRefs[vtableSym] = struct{}{}
-		g.vtableRefOrder = append(g.vtableRefOrder, vtableSym)
-	}
+	g.vtables.Register(vtableSym)
 	g.ifaceTouched = true
 
 	recvVal, err := g.evalOperand(c.Args[0], c.Args[0].Type())

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -1913,3 +1913,50 @@ func (t *MirThunkDefs) OrderedBodies() []string {
 func (t *MirThunkDefs) IsEmpty() bool {
 	return len(t.Order) == 0
 }
+
+// §3 vtable reference set (downcast support).
+//
+// MirVtableRefs mirrors `toolchain/mir_generator.osty: MirVtableRefs`.
+// Owns the dedup + insertion-order side of the emitter's vtable-symbol
+// pool. Replaces the `mirGen.vtableRefs map[string]struct{} +
+// vtableRefOrder []string` pair fields. Fifth member of the
+// dedup-with-order family alongside `MirLayoutCache`, `MirRuntimeDecls`,
+// `MirStringPool`, and `MirThunkDefs`.
+
+// Osty: MirVtableRefs
+type MirVtableRefs struct {
+	Seen  map[string]bool
+	Order []string
+}
+
+// Osty: MirVtableRefs.register
+func (v *MirVtableRefs) Register(symbol string) bool {
+	if v.Seen == nil {
+		v.Seen = map[string]bool{}
+	}
+	if _, ok := v.Seen[symbol]; ok {
+		return false
+	}
+	v.Seen[symbol] = true
+	v.Order = append(v.Order, symbol)
+	return true
+}
+
+// Osty: MirVtableRefs.contains
+func (v *MirVtableRefs) Contains(symbol string) bool {
+	if v.Seen == nil {
+		return false
+	}
+	_, ok := v.Seen[symbol]
+	return ok
+}
+
+// Osty: MirVtableRefs.orderedSymbols
+func (v *MirVtableRefs) OrderedSymbols() []string {
+	return v.Order
+}
+
+// Osty: MirVtableRefs.isEmpty
+func (v *MirVtableRefs) IsEmpty() bool {
+	return len(v.Order) == 0
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2353,3 +2353,77 @@ pub struct MirThunkDefs {
         self.order.isEmpty()
     }
 }
+
+/// §3 vtable reference set (downcast support).
+///
+/// MirVtableRefs owns the dedup + insertion-order side of the
+/// emitter's vtable-symbol pool — the `@osty.vtable.<impl>__<iface>`
+/// external constant declarations that must precede any
+/// `icmp eq ptr` downcast-compare callsite. Mirrors the
+/// `mirGen.vtableRefs map[string]struct{} + vtableRefOrder []string`
+/// Go fields. Fifth member of the dedup-with-order family alongside
+/// `MirLayoutCache` (#888), `MirRuntimeDecls` (#897), `MirStringPool`
+/// (#899), and `MirThunkDefs` (#900).
+///
+/// Why a struct: vtable refs are recorded once per distinct
+/// `<impl>__<iface>` pair across the whole module (one entry even
+/// if 1000 downcast sites mention it). The set form (no value
+/// payload, just presence) is what distinguishes this from the
+/// other four caches — no `body` / `signature` / `bodies`
+/// equivalent. The cache emits one `external constant [0 x ptr]`
+/// declaration per ref at the same module-tail injection point as
+/// type defs.
+pub struct MirVtableRefs {
+    /// seen tracks distinct `@osty.vtable.<impl>__<iface>` symbols
+    /// already recorded. The map's value type is `Bool` (always
+    /// `true`) — it's a presence-only set; the Bool slot exists
+    /// only because Osty's `Map<K, V>` doesn't have a parameterless
+    /// `Set<K>` form yet.
+    pub seen: Map<String, Bool>,
+    /// order is the insertion-ordered list of vtable symbols —
+    /// walked by `emitTypeDefs` when injecting the
+    /// `<sym> = external constant [0 x ptr]` declarations into
+    /// the module out buffer.
+    pub order: List<String>,
+
+    /// register adds `symbol` to the set if not already present.
+    /// Returns true when newly added, false when already seen —
+    /// caller can use the return to gate per-symbol side effects
+    /// (e.g. logging the first vtable touch). The Go side
+    /// (`tryEmitInterfaceDowncast`) flips `ifaceTouched`
+    /// unconditionally on any downcast emission, so the boolean
+    /// stays available for future tightening rather than being
+    /// load-bearing today.
+    pub fn register(mut self, symbol: String) -> Bool {
+        if self.seen.containsKey(symbol) {
+            return false
+        }
+        self.seen.insert(symbol, true)
+        self.order.push(symbol)
+        true
+    }
+
+    /// contains reports whether `symbol` has been registered.
+    /// Read-only check; `register` does the mutating add. Sibling
+    /// of `MirThunkDefs.contains` so cross-cache code reads
+    /// uniformly.
+    pub fn contains(self, symbol: String) -> Bool {
+        self.seen.containsKey(symbol)
+    }
+
+    /// orderedSymbols returns the registered vtable symbols in
+    /// insertion order. Used by `emitTypeDefs` to walk the set
+    /// deterministically when assembling the external-constant
+    /// block.
+    pub fn orderedSymbols(self) -> List<String> {
+        self.order
+    }
+
+    /// isEmpty reports whether the set holds no vtable refs — the
+    /// early-exit signal for callers that gate the
+    /// `@osty.vtable.* = external constant [0 x ptr]` block on
+    /// presence of any downcast site.
+    pub fn isEmpty(self) -> Bool {
+        self.order.isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`MirVtableRefs\` to \`toolchain/mir_generator.osty\` — fifth
(and capping) member of the dedup-with-order family alongside
\`MirLayoutCache\` (#888), \`MirRuntimeDecls\` (#897),
\`MirStringPool\` (#899), and \`MirThunkDefs\` (#900). Replaces the
\`mirGen.vtableRefs + vtableRefOrder\` Go fields with a single
\`vtables MirVtableRefs\` field.

## What landed

**\`MirVtableRefs\` struct + 4 methods**

\`\`\`osty
pub struct MirVtableRefs {
    pub seen: Map<String, Bool>,
    pub order: List<String>,

    pub fn register(mut self, symbol: String) -> Bool { ... }
    pub fn contains(self, symbol: String) -> Bool { ... }
    pub fn orderedSymbols(self) -> List<String> { ... }
    pub fn isEmpty(self) -> Bool { ... }
}
\`\`\`

**Go-side wiring**

- \`mirGen\` field replacement: \`vtableRefs\` + \`vtableRefOrder\` →
  \`vtables MirVtableRefs\`.
- \`tryEmitInterfaceDowncast\` uses \`Register\` (idempotent — boolean
  return ignored at the existing site, available for future
  per-symbol side effects).
- \`emitTypeDefs\` walks \`OrderedSymbols()\` when injecting the
  external-constant block.

## Why

The presence-only set form is what distinguishes this from the
other four caches — no \`body\` / \`signature\` / \`bodies\`
equivalent. Caller registers a symbol, walks the ordered list at
emission time, and that's it.

## Behavior parity

- Same dedup semantics: first downcast registers, subsequent ones
  are no-ops.
- Insertion order preserved.
- \`emitTypeDefs\` output unchanged byte-for-byte.

## Test plan

- [x] \`go build ./internal/llvmgen/\` clean
- [x] \`go test -short -run "TestGenerateFromMIRStringEquality|InlineLiteral"\` pass
- [x] llvmgen test failure count unchanged (25 vs main's 25 — all
      pre-existing failures, none caused by this refactor)
- [ ] CI \`just prepush\` gate

## Stats

\`135 insertions(+) / 9 deletions(-)\` across 4 files. Net +126 LOC —
mostly the new struct + 4 methods + Go mirror; the Go field
declaration collapses from 2 named fields to 1.

## dedup-with-order family is now complete

| Cache | Slice | Replaces |
|-------|-------|----------|
| MirLayoutCache | #888 | enum/tuple layout |
| MirRuntimeDecls | #897 | runtime declares |
| MirStringPool | #899 | string literals |
| MirThunkDefs | #900 | closure thunks |
| **MirVtableRefs** | **this** | **vtable refs** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)