### PR TITLE
refactor(llvmgen): port mirFunctionDefineFooter + drain emitFunction body / GC safepoint / closure call chains

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -281,6 +281,7 @@ list keeps new Osty clean of known landmines.
 | `mirBlockLabelName` | `(isEntry: Bool, blockIDDigits: String) -> String` | §4 | `"entry"` for the function's entry block, `"bb<N>"` otherwise. Used by `emitFunction`'s block-label allocation loop |
 | `mirExternalDeclareLine` | `(cconv, retLLVM, name, paramListJoined, attrs) -> String` | §4 | `declare` line for an external (non-defined) function. Trailing `\n\n` matches legacy spacing — one blank line before the next `define`/`declare` |
 | `mirFunctionDefineHeader` | `(cconv, retLLVM, name, paramListJoined, attrs) -> String` | §4 | Opening line of a function definition — `define [cconv]<retLLVM> @<name>(<params>) [attrs] {\n`. The `{` is included; body / closing `}` come from caller |
+| `mirFunctionDefineFooter` | `() -> String` | §4 | Closing `}\n\n` of a function definition. Pair with `mirFunctionDefineHeader` to bookend every emitted function body |
 | `mirAndI1Line` | `(reg: String, lhs: String, rhs: String) -> String` | §6 | i1 logical-and `  <reg> = and i1 <lhs>, <rhs>\n` — used by bounds-check `nonNeg && inUpper` pattern in `emitListSafeGet` |
 | `mirCallValueWithAliasScopeLine` | `(reg, retTy, sym, argList, scopeRef) -> String` | §1 | Snapshot-call form with `!alias.scope` metadata: `  <reg> = call <retTy> @<sym>(<args>), !alias.scope <ref>\n`. Unlocks LICM of `osty_rt_list_data_*` / `osty_rt_list_len` snapshot reads |
 | `mirLoadWithNoAliasLine` | `(reg: String, ty: String, ptr: String, scopeRef: String) -> String` | §1 | Load tagged with `!noalias` metadata — vector-list fast-path read |

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1590,8 +1590,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 			continue
 		}
 		if bb.ID != fn.Entry {
-			g.fnBuf.WriteString(g.blockLabels[bb.ID])
-			g.fnBuf.WriteString(":\n")
+			g.fnBuf.WriteString(mirLabelLine(g.blockLabels[bb.ID]))
 		}
 		g.curBlockID = bb.ID
 		for _, inst := range bb.Instrs {
@@ -1604,7 +1603,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 		}
 	}
 
-	g.fnBuf.WriteString("}\n\n")
+	g.fnBuf.WriteString(mirFunctionDefineFooter())
 
 	// v0.6 A6: if `#[parallel]` is in effect, annotate every load/store
 	// we just emitted inside this function body with `!llvm.access.group
@@ -2187,13 +2186,10 @@ func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 	g.nextSafepoint += len(plan)
 	for i, chunk := range plan {
 		rootChunk := g.gcRootChunks[i]
-		g.fnBuf.WriteString("  call void @osty.gc.safepoint_v1(i64 ")
-		g.fnBuf.WriteString(strconv.Itoa(chunk.id))
-		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(rootChunk.slotsPtr)
-		g.fnBuf.WriteString(", i64 ")
-		g.fnBuf.WriteString(strconv.Itoa(rootChunk.count))
-		g.fnBuf.WriteString(")\n")
+		g.fnBuf.WriteString(mirCallVoidLine("osty.gc.safepoint_v1",
+			"i64 "+strconv.Itoa(chunk.id)+
+				", ptr "+rootChunk.slotsPtr+
+				", i64 "+strconv.Itoa(rootChunk.count)))
 	}
 }
 
@@ -3685,37 +3681,17 @@ func (g *mirGen) emitBenchErrorCheck(retRef, prefix string) {
 	errFmt := g.stringLiteral("bench `?` propagated failure at %s\n")
 	pathSym := g.stringLiteral(g.source)
 	tag := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(tag)
-	g.fnBuf.WriteString(" = extractvalue %Result.unit.Error ")
-	g.fnBuf.WriteString(retRef)
-	g.fnBuf.WriteString(", 0\n")
+	g.fnBuf.WriteString(mirExtractValueLine(tag, "%Result.unit.Error", retRef, "0"))
 	isErr := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(isErr)
-	g.fnBuf.WriteString(" = icmp eq i64 ")
-	g.fnBuf.WriteString(tag)
-	g.fnBuf.WriteString(", 0\n")
+	g.fnBuf.WriteString(mirICmpEqLine(isErr, "i64", tag, "0"))
 	errLabel := g.freshLabel(prefix + ".err")
 	okLabel := g.freshLabel(prefix + ".ok")
-	g.fnBuf.WriteString("  br i1 ")
-	g.fnBuf.WriteString(isErr)
-	g.fnBuf.WriteString(", label %")
-	g.fnBuf.WriteString(errLabel)
-	g.fnBuf.WriteString(", label %")
-	g.fnBuf.WriteString(okLabel)
-	g.fnBuf.WriteByte('\n')
-	g.fnBuf.WriteString(errLabel)
-	g.fnBuf.WriteString(":\n")
-	g.fnBuf.WriteString("  call i32 (ptr, ...) @printf(ptr ")
-	g.fnBuf.WriteString(errFmt)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(pathSym)
-	g.fnBuf.WriteString(")\n")
-	g.fnBuf.WriteString("  call void @exit(i32 1)\n")
-	g.fnBuf.WriteString("  unreachable\n")
-	g.fnBuf.WriteString(okLabel)
-	g.fnBuf.WriteString(":\n")
+	g.fnBuf.WriteString(mirBrCondLine(isErr, errLabel, okLabel))
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	g.fnBuf.WriteString("  call i32 (ptr, ...) @printf(ptr " + errFmt + ", ptr " + pathSym + ")\n")
+	g.fnBuf.WriteString(mirCallVoidLine("exit", "i32 1"))
+	g.fnBuf.WriteString(mirUnreachableLine())
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
 }
 
 // invokeClosureOperand calls a closure value through its env pointer
@@ -3739,32 +3715,14 @@ func (g *mirGen) invokeClosureOperand(op mir.Operand) error {
 		}
 	}
 	fnPtr := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(fnPtr)
-	g.fnBuf.WriteString(" = load ptr, ptr ")
-	g.fnBuf.WriteString(envPtr)
-	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString(mirLoadLine(fnPtr, "ptr", envPtr))
 	callType := retLLVM + " (" + strings.Join(paramParts, ", ") + ")"
 	if retLLVM == "void" {
-		g.fnBuf.WriteString("  call ")
-		g.fnBuf.WriteString(callType)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(fnPtr)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(envPtr)
-		g.fnBuf.WriteString(")\n")
+		g.fnBuf.WriteString("  call " + callType + " " + fnPtr + "(ptr " + envPtr + ")\n")
 		return nil
 	}
 	tmp := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(tmp)
-	g.fnBuf.WriteString(" = call ")
-	g.fnBuf.WriteString(callType)
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(fnPtr)
-	g.fnBuf.WriteString("(ptr ")
-	g.fnBuf.WriteString(envPtr)
-	g.fnBuf.WriteString(")\n")
+	g.fnBuf.WriteString("  " + tmp + " = call " + callType + " " + fnPtr + "(ptr " + envPtr + ")\n")
 	return nil
 }
 

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -2046,3 +2046,10 @@ func mirFunctionDefineHeader(cconv string, retLLVM string, name string, paramLis
 	}
 	return "define " + cconv + retLLVM + " @" + name + "(" + paramListJoined + ")" + attrSuffix + " {\n"
 }
+
+// mirFunctionDefineFooter renders the closing `}\n\n` of a function
+// definition.
+// Osty: mirFunctionDefineFooter
+func mirFunctionDefineFooter() string {
+	return "}\n\n"
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2563,3 +2563,12 @@ pub fn mirFunctionDefineHeader(
     let attrSuffix = if attrs == "" { "" } else { " " + attrs }
     "define " + cconv + retLLVM + " @" + name + "(" + paramListJoined + ")" + attrSuffix + " {\n"
 }
+
+/// mirFunctionDefineFooter renders the closing of a function
+/// definition: `}\n\n`. Pair with `mirFunctionDefineHeader` to
+/// bookend every emitted function body. The trailing two
+/// newlines match the legacy emitter's spacing — one blank line
+/// between consecutive definitions in the module out buffer.
+pub fn mirFunctionDefineFooter() -> String {
+    "}\n\n"
+}


### PR DESCRIPTION
## Summary

Continues §4 work from #904. Adds the function-define footer builder,
refactors the \`emitFunction\` block-emission loop +
GC-safepoint-with-roots emission + \`invokeClosureOperand\` +
\`emitBenchErrorCheck\` — collapsing another batch of inline
\`g.fnBuf.WriteString\` chains into named builder calls.

## What landed

**1 new builder**

\`mirFunctionDefineFooter()\` → \`}\n\n\` — pairs with
\`mirFunctionDefineHeader\` (#904) to bookend every emitted function
body.

**Refactors**

- \`emitFunction\` per-block label header → \`mirLabelLine\`
- \`emitFunction\` closing → \`mirFunctionDefineFooter\`
- \`emitGCSafepointKind\` per-chunk safepoint call → \`mirCallVoidLine\`
- \`emitBenchErrorCheck\`: extractvalue / icmp / br / label / printf-call /
  exit-call / unreachable / label all use existing builders
- \`invokeClosureOperand\` load fnptr → \`mirLoadLine\`; callType-typed
  call lines collapse to single-string concat

## Behavior parity

- All builders produce the exact byte sequence the legacy emitter
  wrote.
- llvmgen test failure count unchanged (25 vs main's 25)
- backend test failure count unchanged (10 vs main's 10)

## Test plan

- [x] \`go build ./internal/llvmgen/\` clean
- [x] \`go test -short ./internal/llvmgen/\` no new failures
- [x] \`go test -short ./internal/backend/...\` no new failures
- [ ] CI \`just prepush\` gate

## Stats

\`34 insertions(+) / 59 deletions(-)\` across 4 files. Net -26 LOC —
mostly the inline chains collapsing. The new \`mirFunctionDefineFooter\`
is trivial (3 lines) but completes the header/footer pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)