### PR TITLE
refactor(llvmgen): rename rendering MirSwitchCase → MirGenSwitchCase

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -6620,9 +6620,9 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 			return err
 		}
 		llvmT := g.llvmType(scrutT)
-		cases := make([]MirSwitchCase, len(x.Cases))
+		cases := make([]MirGenSwitchCase, len(x.Cases))
 		for i, c := range x.Cases {
-			cases[i] = MirSwitchCase{
+			cases[i] = MirGenSwitchCase{
 				ValueText:   strconv.FormatInt(c.Value, 10),
 				TargetLabel: g.blockLabels[c.Target],
 			}

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -1793,8 +1793,8 @@ func mirTerminatorBranchConditional(condReg, thenLabel, elseLabel, loopMDRef str
 	return head + "\n"
 }
 
-// Osty: MirSwitchCase
-type MirSwitchCase struct {
+// Osty: MirGenSwitchCase
+type MirGenSwitchCase struct {
 	ValueText   string
 	TargetLabel string
 }
@@ -1805,7 +1805,7 @@ type MirSwitchCase struct {
 // `out += ...` shape the Osty source uses literally — large enum
 // dispatches with hundreds of cases would otherwise be O(n²) on the
 // Go side. The emitted bytes are identical.
-func mirTerminatorSwitchInt(llvmType, scrutReg, defaultLabel string, cases []MirSwitchCase) string {
+func mirTerminatorSwitchInt(llvmType, scrutReg, defaultLabel string, cases []MirGenSwitchCase) string {
 	var b llvmStrings.Builder
 	b.WriteString("  switch ")
 	b.WriteString(llvmType)

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2140,11 +2140,14 @@ pub struct MirLayoutCache {
 /// templates skip the `, !llvm.loop !N` suffix in that case so the
 /// caller doesn't have to fork on the predicate themselves.
 ///
-/// `MirSwitchCase` represents one (value, target-label) pair of a
+/// `MirGenSwitchCase` represents one (value, target-label) pair of a
 /// `switch i<N>` terminator. The value text is pre-formatted by the
 /// Go caller because `mir.SwitchIntCase.Value` is `int64` and Osty's
 /// `Int` ↔ Go `int` bridge prefers narrow scalars at the boundary —
 /// `strconv.FormatInt(c.Value, 10)` happens once on the Go side.
+/// Distinct from `mir.MirSwitchCase` (the MIR-level case carrying the
+/// raw Int value + block-index target); this rendering mirror only
+/// holds pre-resolved strings.
 
 /// mirTerminatorBranchUnconditional renders an unconditional
 /// `br label %<target>` terminator. When `loopMDRef` is non-empty
@@ -2177,12 +2180,12 @@ pub fn mirTerminatorBranchConditional(
     head + "\n"
 }
 
-/// MirSwitchCase carries one case row of a `switch i<N>` terminator
+/// MirGenSwitchCase carries one case row of a `switch i<N>` terminator
 /// in the form already rendered for IR emission — `valueText` is the
 /// pre-formatted decimal value (the Go caller produces it via
 /// `strconv.FormatInt(c.Value, 10)`), `targetLabel` is the resolved
 /// basic-block label.
-pub struct MirSwitchCase {
+pub struct MirGenSwitchCase {
     pub valueText: String,
     pub targetLabel: String,
 }
@@ -2197,7 +2200,7 @@ pub fn mirTerminatorSwitchInt(
     llvmType: String,
     scrutReg: String,
     defaultLabel: String,
-    cases: List<MirSwitchCase>,
+    cases: List<MirGenSwitchCase>,
 ) -> String {
     let mut out = "  switch " + llvmType + " " + scrutReg +
         ", label %" + defaultLabel + " [\n"


### PR DESCRIPTION
## Summary

- Two `pub struct MirSwitchCase` declarations existed in the same `toolchain/` package — `mir.osty:888` (MIR core: `value: Int, target: Int, label: String`) and `mir_generator.osty:2185` (LLVM rendering mirror: `valueText: String, targetLabel: String`). Same name, different abstractions.
- This failed the partial-decl checker (E0708) and walled the merged-toolchain LLVM probe at `LLVM010 duplicate struct "MirSwitchCase"`.
- Renamed the rendering-only mirror → `MirGenSwitchCase`. Kept `MirSwitchCase` as the MIR core type (used by `mir_lower`, `mir_optimize`, `mir_test`).
- Updated `mirTerminatorSwitchInt` signature, the Go snapshot in `mir_generator_snapshot.go`, and the single constructor at `mir_generator.go:6623`. Added a section-header note documenting why the two types coexist so future readers don't try to merge them again.

## Verification

- `.bin/osty check toolchain` — both `E0708` duplicate-decl errors gone (the 9 unrelated `typeName` errors are a separate issue, untouched).
- `go test ./internal/llvmgen -run TestProbeWholeToolchainMerged -count=1` — wall advanced from `LLVM010 duplicate struct "MirSwitchCase"` to `LLVM011 type-system: struct "CheckFnSig" field "hasReceiver" has a default value` (the next layout-blocker down the merge list).
- `go build ./internal/llvmgen` — clean.

## Test plan

- [ ] `just front` (frontend including spec corpus) passes
- [ ] `go test ./internal/llvmgen/... -count=1` stays green
- [ ] `.bin/osty check toolchain` shows 0 `E0708` errors
- [ ] No remaining references to old name outside `mir.osty` core type: `rg 'MirSwitchCase'` shows only `mir.osty`, `mir_lower.osty`, `mir_optimize.osty`, `mir_test.osty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)