### PR TITLE
fix(selfhost): finish typeName→typeRepr migration in inspect/lint

### DIFF
--- a/toolchain/inspect.osty
+++ b/toolchain/inspect.osty
@@ -34,8 +34,8 @@
 //   - ❌ Hint propagation (`hintName`) is still empty. Go reconstructs
 //        the hint by re-walking the AST with expected-type threading.
 //        Porting needs a small type-string parser on top of
-//        `FrontCheckedNode.typeName` (since the self-host path only
-//        exposes types as rendered strings, not structured `types.Type`).
+//        `FrontCheckedNode.typeRepr` (rendered via `frontTypeReprToString`
+//        for the legacy string-based hint helpers).
 //
 // Entry points:
 //
@@ -237,7 +237,7 @@ fn inspectTypeNameByNode(arena: AstArena, checked: FrontCheckResult) -> List<Str
     }
     for tn in checked.typedNodes {
         if tn.node >= 0 && tn.node < n {
-            out[tn.node] = tn.typeName
+            out[tn.node] = frontTypeReprToString(tn.typeRepr)
         }
     }
     out
@@ -367,7 +367,7 @@ fn inspectThreadHintsThroughContainers(
         }
         let declNode = arena.nodes[sym.node]
         if sym.kind == "fn" {
-            let sig = hintFnSignature(sym.typeName)
+            let sig = hintFnSignature(frontTypeReprToString(sym.typeRepr))
             if !sig.ok || sig.returnType == "" {
                 continue
             }
@@ -375,11 +375,12 @@ fn inspectThreadHintsThroughContainers(
                 inspectThreadHint(arena, declNode.right, sig.returnType, hints)
             }
         } else if sym.kind == "let" {
-            if sym.typeName == "" {
+            let typeStr = frontTypeReprToString(sym.typeRepr)
+            if typeStr == "" {
                 continue
             }
             if (declNode.kind == AstNLet || declNode.kind == AstNLetDecl) && declNode.right >= 0 {
-                inspectThreadHint(arena, declNode.right, sym.typeName, hints)
+                inspectThreadHint(arena, declNode.right, typeStr, hints)
             }
         }
     }
@@ -406,7 +407,7 @@ fn inspectThreadHintsThroughContainers(
 fn inspectBindingTypeByPattern(checked: FrontCheckResult) -> List<InspectBindingEntry> {
     let mut out: List<InspectBindingEntry> = []
     for bnd in checked.bindings {
-        out.push(InspectBindingEntry { node: bnd.node, typeName: bnd.typeName })
+        out.push(InspectBindingEntry { node: bnd.node, typeName: frontTypeReprToString(bnd.typeRepr) })
     }
     out
 }
@@ -500,7 +501,7 @@ fn inspectBuildRecords(
             end: tn.end,
             nodeKind: tn.kind,
             rule,
-            typeName: tn.typeName,
+            typeName: frontTypeReprToString(tn.typeRepr),
             hintName: hint,
             notes: [],
         })
@@ -522,7 +523,7 @@ fn inspectBuildRecords(
             end: sym.end,
             nodeKind: inspectNodeKindForSymbolKind(sym.kind),
             rule,
-            typeName: sym.typeName,
+            typeName: frontTypeReprToString(sym.typeRepr),
             hintName: "",
             notes,
         })
@@ -544,7 +545,7 @@ fn inspectBuildRecords(
             end: bnd.end,
             nodeKind,
             rule,
-            typeName: bnd.typeName,
+            typeName: frontTypeReprToString(bnd.typeRepr),
             hintName: "",
             notes,
         })

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -2881,7 +2881,7 @@ fn selfLintTypeHintsFromChecked(checked: FrontCheckResult) -> SelfLintTypeHints 
     let mut types: List<String> = []
     for tn in checked.typedNodes {
         nodes.push(tn.node)
-        types.push(tn.typeName)
+        types.push(frontTypeReprToString(tn.typeRepr))
     }
     SelfLintTypeHints { enabled: true, nodes, types }
 }


### PR DESCRIPTION
## Summary

- PR #892 renamed `typeName: String` → `typeRepr: FrontTypeRepr` on `FrontCheckedNode` / `FrontCheckedSymbol` / `FrontCheckedBinding` (`toolchain/check.osty:149-180`) but missed 9 consumer sites in `toolchain/inspect.osty` and `toolchain/lint.osty`, producing `E0702` errors on `osty check toolchain`.
- Each consumer read goes through `frontTypeReprToString(.typeRepr)` (the existing renderer at `toolchain/check.osty:110`) so the `String`-shaped consumer contracts (`InspectRecord.typeName`, `InspectBindingEntry.typeName`, `SelfLintTypeHints.types`) are preserved unchanged. Note that `InspectRecord` / `InspectBindingEntry` keep their own `typeName: String` field — those are the FFI bridge contract and should not be migrated.
- In `inspectThreadHintsThroughContainers` the render is pushed inside each kind arm. The majority of `FrontCheckedSymbol` entries (`struct` / `enum` / `field` / `variant` / `use`) wouldn't consume `typeStr` at all — only `fn` and `let` do — so a hoisted render would do recursive work for nothing.

## Sites migrated

- `toolchain/inspect.osty:240` — `inspectTypeNameByNode`
- `toolchain/inspect.osty:369–388` — `inspectThreadHintsThroughContainers` (render moved into `fn` and `let` arms)
- `toolchain/inspect.osty:410` — `inspectBindingTypeByPattern`
- `toolchain/inspect.osty:504` / `:526` / `:548` — `inspectBuildRecords` typed-node / symbol / binding constructors
- `toolchain/lint.osty:2884` — `selfLintTypeHintsFromChecked`
- Stale doc reference at `toolchain/inspect.osty:34-38` updated.

## Out of scope

The 2 remaining `E0708` `MirSwitchCase` errors on `osty check toolchain` are tracked separately.

## Test plan

- [x] `.bin/osty check toolchain` → 9 `E0702`s gone; only the 2 unrelated `MirSwitchCase` `E0708`s remain
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)