### PR TITLE
refactor(llvmgen): port 28 §3 / §6 builders + drain runtime-decl + Some/None/Ok/Err aggregate sites

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -354,6 +354,33 @@ list keeps new Osty clean of known landmines.
 | `mirCallVarargPrintfTwoArgLine` | `(fmtSym, arg1, arg2) -> String` | §6 | printf with two variadic args. Used by testing-summary `(seed 0x%x)` lines |
 | `mirCallVarargPrintfThreeArgLine` | `(fmtSym, arg1, arg2, arg3) -> String` | §6 | printf with three variadic args. Used by bench summary preludes |
 | `mirAllocaSpillStoreLine` | `(slot, ty, val) -> String` | §6 | `alloca <ty>` + `store <ty> <val>, ptr <slot>` — canonical "spill an SSA value into a stack slot" preamble before bytes-v1 runtime calls |
+| `mirRuntimeDeclarePrintf` | `() -> String` | §3 | `declare i32 @printf(ptr, ...)` — drains the literal printf decl at testing-abort, bench-summary, and println-like emit sites |
+| `mirRuntimeDeclareExit` | `() -> String` | §3 | `declare void @exit(i32)` — drains the literal exit decl at testing-abort, bench-error, panic-helper sites |
+| `mirRuntimeDeclarePtrFromPtrLine` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr)` — the most common runtime ABI shape (~22 sites: list_keys/data, set_to_list, etc.) |
+| `mirRuntimeDeclareI1FromPtrLine` | `(sym: String) -> String` | §3 | `declare i1 @<sym>(ptr)` — predicate runtime shape (is_empty/is_closed/pop_check) |
+| `mirRuntimeDeclareVoidFromPtrLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr)` — side-effect runtime shape (clear/reverse/close/pop_discard) |
+| `mirRuntimeDeclareI64FromPtrLine` | `(sym: String) -> String` | §3 | `declare i64 @<sym>(ptr)` — scalar-returning ptr-handle probe shape (plain, no LICM attrs). Distinct from `mirRuntimeDeclareMemoryRead` |
+| `mirRuntimeDeclarePtrFromScalarLine` | `(sym, scalarLLVM) -> String` | §3 | `declare ptr @<sym>(<scalar>)` — scalar-to-string family (int_to_string/float_to_string/bool/char/byte) |
+| `mirRuntimeDeclareI64NoArgsLine` | `(sym: String) -> String` | §3 | `declare i64 @<sym>()` — zero-arg scalar probe (bench clock reads, GC-debug allocators) |
+| `mirRuntimeDeclareVoidI32Line` | `(sym: String) -> String` | §3 | `declare void @<sym>(i32)` — abstract-symbol form for noreturn exit-like helpers |
+| `mirRuntimeDeclareSafepointV1` | `() -> String` | §3 | `declare void @osty.gc.safepoint_v1(i64, ptr, i64)` — GC safepoint runtime ABI canonical decl |
+| `mirRuntimeDeclareGcAllocV1` | `() -> String` | §3 | `declare ptr @osty.gc.alloc_v1(i64, i64, ptr)` — GC allocator runtime ABI canonical decl |
+| `mirRuntimeDeclareStringConcat` | `() -> String` | §3 | `declare ptr @osty_rt_strings_Concat(ptr, ptr)` — String concat runtime ABI canonical decl |
+| `mirSomeAggregateLines` | `(taggedReg, filledReg, optLLVM, payloadI64) -> String` | §6 | Canonical Some(payload) two-insertvalue construction. Drains the 7-site repetition at IntrinsicListFirst/Last/Pop/IndexOf/Contains/MapGet/ListSafeGet |
+| `mirSomeStoreLines` | `(taggedReg, filledReg, optLLVM, payloadI64, destSlot) -> String` | §6 | Some-aggregate construction + store into dest slot — 3-line block |
+| `mirSomeStoreThenJumpLines` | `(taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel) -> String` | §6 | Full Some-arm body: aggregate + store + br to join — 4-line block |
+| `mirNoneStoreThenJumpLines` | `(optLLVM, destSlot, endLabel) -> String` | §6 | None-arm body: zeroinitializer store + br to join — 2-line block |
+| `mirNoneAggregateLines` | `(stepReg, valueReg, optLLVM) -> String` | §6 | Canonical None two-insertvalue (disc=0, payload=0) for phi-merge sites |
+| `mirOkAggregateLines` | `(stepReg, valueReg, resultLLVM, payloadI64) -> String` | §6 | Canonical Ok(payload) two-insertvalue for `Result<Ok, Err>` |
+| `mirErrAggregateLines` | `(stepReg, valueReg, resultLLVM, payloadI64) -> String` | §6 | Canonical Err(payload) two-insertvalue for `Result<Ok, Err>` (disc=0) |
+| `mirICmpSltI64Line` | `(reg, lhs, rhs) -> String` | §6 | Loop-bound check `icmp slt i64` — hot-path predicate for linear scans |
+| `mirICmpSgeI64Line` | `(reg, lhs, rhs) -> String` | §6 | Lower-bound check `icmp sge i64` for negative-index detection |
+| `mirLinearScanLoopHeadLines` | `(headLabel, iReg, iSlot, cont, lenReg, bodyLabel, endLabel) -> String` | §6 | Loop-head block of the linear-scan idiom (label + load + slt + cond-br) — 4-line block |
+| `mirLinearScanLoopTailLines` | `(contLabel, nextReg, iReg, iSlot, headLabel) -> String` | §6 | Loop-tail block of the linear-scan idiom (cont label + add + store + jump) — 4-line block |
+| `mirCallVoidI64TagAndPtrLine` | `(sym, tag, slot, count) -> String` | §6 | `call void @<sym>(i64, ptr, i64)` — safepoint chunk-call shape |
+| `mirAllocaI64ZeroSlot` | `(slot: String) -> String` | §6 | Canonical "fresh i64 counter slot initialised to zero" preamble for linear-scan loops |
+| `mirAllocaI1FalseSlot` | `(slot: String) -> String` | §6 | Canonical "fresh i1 result slot initialised to false" preamble for IntrinsicListContains |
+| `mirStoreI1TrueLine` | `(slot: String) -> String` | §6 | `store i1 true, ptr <slot>` — IntrinsicListContains match arm flip |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2204,7 +2204,7 @@ func (g *mirGen) emitLoopSafepointKind() {
 // the explicit-root machinery so pointer-free functions don't pull in
 // any unused GC declarations.
 func (g *mirGen) declareSafepoint() {
-	g.declareRuntime("osty.gc.safepoint_v1", "declare void @osty.gc.safepoint_v1(i64, ptr, i64)")
+	g.declareRuntime("osty.gc.safepoint_v1", mirRuntimeDeclareSafepointV1())
 }
 
 // ==== instructions ====
@@ -2987,8 +2987,8 @@ func (g *mirGen) emitTestingFailureCheck(cond string, failWhenTrue bool, buildMe
 }
 
 func (g *mirGen) emitTestingAbortString(message *LlvmValue, nextLabel string) {
-	g.declareRuntime("printf", "declare i32 @printf(ptr, ...)")
-	g.declareRuntime("exit", "declare void @exit(i32)")
+	g.declareRuntime("printf", mirRuntimeDeclarePrintf())
+	g.declareRuntime("exit", mirRuntimeDeclareExit())
 	fmtPtr := g.stringLiteral("%s\n")
 	g.fnBuf.WriteString(mirCallVarargPrintfPathLine(fmtPtr, message.name))
 	g.fnBuf.WriteString(mirCallExitLine("1"))
@@ -3132,31 +3132,31 @@ func (g *mirGen) emitAssertValueToStringMIR(reg string, t mir.Type) (*LlvmValue,
 	llvmT := g.llvmType(t)
 	switch llvmT {
 	case "i64":
-		g.declareRuntime("osty_rt_int_to_string", "declare ptr @osty_rt_int_to_string(i64)")
+		g.declareRuntime("osty_rt_int_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_int_to_string", "i64"))
 		em := g.ostyEmitter()
 		out := llvmIntRuntimeToString(em, &LlvmValue{typ: "i64", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "double":
-		g.declareRuntime("osty_rt_float_to_string", "declare ptr @osty_rt_float_to_string(double)")
+		g.declareRuntime("osty_rt_float_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_float_to_string", "double"))
 		em := g.ostyEmitter()
 		out := llvmFloatRuntimeToString(em, &LlvmValue{typ: "double", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i1":
-		g.declareRuntime("osty_rt_bool_to_string", "declare ptr @osty_rt_bool_to_string(i1)")
+		g.declareRuntime("osty_rt_bool_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_bool_to_string", "i1"))
 		em := g.ostyEmitter()
 		out := llvmBoolRuntimeToString(em, &LlvmValue{typ: "i1", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i32":
-		g.declareRuntime("osty_rt_char_to_string", "declare ptr @osty_rt_char_to_string(i32)")
+		g.declareRuntime("osty_rt_char_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_char_to_string", "i32"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", "osty_rt_char_to_string", []*LlvmValue{{typ: "i32", name: reg}})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i8":
-		g.declareRuntime("osty_rt_byte_to_string", "declare ptr @osty_rt_byte_to_string(i8)")
+		g.declareRuntime("osty_rt_byte_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_byte_to_string", "i8"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", "osty_rt_byte_to_string", []*LlvmValue{{typ: "i8", name: reg}})
 		g.flushOstyEmitter(em)
@@ -3319,10 +3319,10 @@ func (g *mirGen) emitTestingBenchmarkMIR(c *mir.CallInstr) error {
 	}
 	// Declare the runtime helpers we'll call. These are idempotent — a
 	// later benchmark in the same module reuses the same declare lines.
-	g.declareRuntime("osty_rt_bench_now_nanos", "declare i64 @osty_rt_bench_now_nanos()")
-	g.declareRuntime("osty_rt_bench_target_ns", "declare i64 @osty_rt_bench_target_ns()")
-	g.declareRuntime("osty_gc_debug_allocated_bytes_total", "declare i64 @osty_gc_debug_allocated_bytes_total()")
-	g.declareRuntime("printf", "declare i32 @printf(ptr, ...)")
+	g.declareRuntime("osty_rt_bench_now_nanos", mirRuntimeDeclareI64NoArgsLine("osty_rt_bench_now_nanos"))
+	g.declareRuntime("osty_rt_bench_target_ns", mirRuntimeDeclareI64NoArgsLine("osty_rt_bench_target_ns"))
+	g.declareRuntime("osty_gc_debug_allocated_bytes_total", mirRuntimeDeclareI64NoArgsLine("osty_gc_debug_allocated_bytes_total"))
+	g.declareRuntime("printf", mirRuntimeDeclarePrintf())
 
 	// `@.bench_fmt` is the summary format string. Extended with
 	// `bytes/op=%ld` so the osty-vs-go runner can surface per-iter GC
@@ -3533,7 +3533,7 @@ func (g *mirGen) emitBenchCountedLoopMIR(closureOp mir.Operand, itersRef, prefix
 // failure at <path>:<line>\n" line and exits 1. Emitted inline so the
 // counted-loop doesn't need its own error return.
 func (g *mirGen) emitBenchErrorCheck(retRef, prefix string) {
-	g.declareRuntime("exit", "declare void @exit(i32)")
+	g.declareRuntime("exit", mirRuntimeDeclareExit())
 	errFmt := g.stringLiteral("bench `?` propagated failure at %s\n")
 	pathSym := g.stringLiteral(g.source)
 	tag := g.fresh()
@@ -4009,7 +4009,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListIsEmpty:
 		sym := "osty_rt_list_is_empty"
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + listReg})
 	case mir.IntrinsicListGet:
 		if len(i.Args) != 2 {
@@ -4060,7 +4060,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if sym == "" {
 			return unsupported("mir-mvp", "list_sorted on element type "+elemLLVM)
 		}
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
 		g.flushOstyEmitter(em)
@@ -4071,7 +4071,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if sym == "" {
 			return unsupported("mir-mvp", "list_to_set on element type "+elemLLVM)
 		}
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
 		g.flushOstyEmitter(em)
@@ -4122,18 +4122,15 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", fmt.Sprintf("list_%s payload widen unsupported for %s", mirIntrinsicLabel(i.Kind), elemLLVM))
 		}
 		tagged := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", payloadReg, "1"))
-		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirSomeStoreThenJumpLines(tagged, filled, destLLVM, payloadReg, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListReverse:
 		// In-place reverse. Runtime walks elem_size-sized slots byte by
 		// byte so the call is element-type agnostic.
 		sym := "osty_rt_list_reverse"
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg))
 		return nil
 	case mir.IntrinsicListReversed:
@@ -4142,7 +4139,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// across the allocation because the source list stays
 		// reachable through the caller's local.
 		sym := "osty_rt_list_reversed"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
 		g.flushOstyEmitter(em)
@@ -4235,8 +4232,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
 		iSlot := g.fresh()
-		g.fnBuf.WriteString(mirAllocaLine(iSlot, "i64"))
-		g.fnBuf.WriteString(mirStoreLine("i64", "0", iSlot))
+		g.fnBuf.WriteString(mirAllocaI64ZeroSlot(iSlot))
 		headLabel := g.freshLabel("list.indexof.head")
 		bodyLabel := g.freshLabel("list.indexof.body")
 		matchLabel := g.freshLabel("list.indexof.match")
@@ -4263,16 +4259,10 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirBrCondLine(eqReg, matchLabel, contLabel))
 		g.fnBuf.WriteString(mirLabelLine(matchLabel))
 		tagged := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", iReg, "1"))
-		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
-		g.fnBuf.WriteString(mirLabelLine(contLabel))
+		g.fnBuf.WriteString(mirSomeStoreThenJumpLines(tagged, filled, destLLVM, iReg, destSlot, endLabel))
 		next := g.fresh()
-		g.fnBuf.WriteString(mirAddI64Line(next, iReg, "1"))
-		g.fnBuf.WriteString(mirStoreLine("i64", next, iSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLinearScanLoopTailLines(contLabel, next, iReg, iSlot, headLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListContains:
@@ -4314,8 +4304,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		g.fnBuf.WriteString(mirStoreLine("i1", "false", destSlot))
 		iSlot := g.fresh()
-		g.fnBuf.WriteString(mirAllocaLine(iSlot, "i64"))
-		g.fnBuf.WriteString(mirStoreLine("i64", "0", iSlot))
+		g.fnBuf.WriteString(mirAllocaI64ZeroSlot(iSlot))
 		headLabel := g.freshLabel("list.contains.head")
 		bodyLabel := g.freshLabel("list.contains.body")
 		matchLabel := g.freshLabel("list.contains.match")
@@ -4398,11 +4387,8 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", fmt.Sprintf("list_pop payload widen unsupported for %s", elemLLVM))
 		}
 		tagged := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 		filled := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", payloadReg, "1"))
-		g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirSomeStoreThenJumpLines(tagged, filled, destLLVM, payloadReg, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	}
@@ -4506,14 +4492,14 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicMapLen:
 		sym := llvmMapRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmMapLen(em, &LlvmValue{typ: "ptr", name: mapReg})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicMapKeys:
 		sym := mapRuntimeKeysSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmMapKeys(em, &LlvmValue{typ: "ptr", name: mapReg})
 		g.flushOstyEmitter(em)
@@ -4581,14 +4567,10 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupportedf("mir-mvp", "map_get payload widen unsupported for %s", vLLVM)
 		}
 		someStep := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someStep, optLLVM, "undef", "i64", "1", "0"))
 		someValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someValue, optLLVM, someStep, "i64", payloadI64, "1"))
-		g.fnBuf.WriteString(mirStoreLine(optLLVM, someValue, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirSomeStoreThenJumpLines(someStep, someValue, optLLVM, payloadI64, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirStoreZeroinitLine(optLLVM, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(optLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicMapGetOr:
@@ -4734,7 +4716,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			suffix = llvmMapKeySuffix(keyLLVM, false)
 		}
 		sym := "osty_rt_map_keys_sorted_" + suffix
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		tmp := g.fresh()
 		g.fnBuf.WriteString(mirCallValueLine(tmp, "ptr", sym, "ptr "+mapReg))
 		if i.Dest != nil {
@@ -4825,14 +4807,14 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicSetLen:
 		sym := setRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmSetLen(em, &LlvmValue{typ: "ptr", name: setReg})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicSetToList:
 		sym := setRuntimeToListSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmSetToList(em, &LlvmValue{typ: "ptr", name: setReg})
 		g.flushOstyEmitter(em)
@@ -4911,14 +4893,14 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicBytesLen:
 		sym := "osty_rt_bytes_len"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicBytesIsEmpty:
 		sym := "osty_rt_bytes_is_empty"
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
 		g.flushOstyEmitter(em)
@@ -4969,16 +4951,14 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		someStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someStep1, optLLVM, "undef", "i64", "1", "0"))
 		someValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someValue, optLLVM, someStep1, "i64", payload, "1"))
+		g.fnBuf.WriteString(mirSomeAggregateLines(someStep1, someValue, optLLVM, payload))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
 		noneStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneStep1, optLLVM, "undef", "i64", "0", "0"))
 		noneValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneValue, optLLVM, noneStep1, "i64", "0", "1"))
+		g.fnBuf.WriteString(mirNoneAggregateLines(noneStep1, noneValue, optLLVM))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(mergeLabel))
@@ -5086,16 +5066,14 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		someStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someStep1, optLLVM, "undef", "i64", "1", "0"))
 		someValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someValue, optLLVM, someStep1, "i64", index.name, "1"))
+		g.fnBuf.WriteString(mirSomeAggregateLines(someStep1, someValue, optLLVM, index.name))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
 		noneStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneStep1, optLLVM, "undef", "i64", "0", "0"))
 		noneValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneValue, optLLVM, noneStep1, "i64", "0", "1"))
+		g.fnBuf.WriteString(mirNoneAggregateLines(noneStep1, noneValue, optLLVM))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(mergeLabel))
@@ -5141,16 +5119,14 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		someStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someStep1, optLLVM, "undef", "i64", "1", "0"))
 		someValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(someValue, optLLVM, someStep1, "i64", index.name, "1"))
+		g.fnBuf.WriteString(mirSomeAggregateLines(someStep1, someValue, optLLVM, index.name))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
 		noneStep1 := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneStep1, optLLVM, "undef", "i64", "0", "0"))
 		noneValue := g.fresh()
-		g.fnBuf.WriteString(mirInsertValueAggLine(noneValue, optLLVM, noneStep1, "i64", "0", "1"))
+		g.fnBuf.WriteString(mirNoneAggregateLines(noneStep1, noneValue, optLLVM))
 		g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 		g.fnBuf.WriteString(mirLabelLine(mergeLabel))
@@ -5326,7 +5302,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "bytes_trim_space arity")
 		}
 		sym := "osty_rt_bytes_trim_space"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5338,7 +5314,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "bytes_to_upper arity")
 		}
 		sym := "osty_rt_bytes_to_upper"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5350,7 +5326,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "bytes_to_lower arity")
 		}
 		sym := "osty_rt_bytes_to_lower"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5362,7 +5338,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "bytes_to_hex arity")
 		}
 		sym := "osty_rt_bytes_to_hex"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5471,21 +5447,21 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicStringChars:
 		sym := "osty_rt_strings_Chars"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringBytes:
 		sym := "osty_rt_strings_Bytes"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringLen:
 		sym := "osty_rt_strings_ByteLen"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		g.flushOstyEmitter(em)
@@ -5494,7 +5470,7 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		// Runtime has no `_IsEmpty`; reuse `ByteLen` and emit an eq-0
 		// compare, matching the legacy emitter's shape.
 		sym := "osty_rt_strings_ByteLen"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		size := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		result := llvmCompare(em, "eq", size, llvmIntLiteral(0))
@@ -5502,21 +5478,21 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringTrim:
 		sym := llvmStringRuntimeTrimSpaceSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmStringRuntimeTrimSpace(em, &LlvmValue{typ: "ptr", name: strReg})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringToUpper:
 		sym := "osty_rt_strings_ToUpper"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicStringToLower:
 		sym := "osty_rt_strings_ToLower"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
 		g.flushOstyEmitter(em)
@@ -5588,16 +5564,14 @@ func (g *mirGen) storeOptionalIntFromNegativeOneIndex(i *mir.IntrinsicInstr, opt
 
 	g.fnBuf.WriteString(mirLabelLine(someLabel))
 	someStep := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(someStep, optLLVM, "undef", "i64", "1", "0"))
 	someValue := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(someValue, optLLVM, someStep, "i64", indexReg, "1"))
+	g.fnBuf.WriteString(mirSomeAggregateLines(someStep, someValue, optLLVM, indexReg))
 	g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 	g.fnBuf.WriteString(mirLabelLine(noneLabel))
 	noneStep := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(noneStep, optLLVM, "undef", "i64", "0", "0"))
 	noneValue := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(noneValue, optLLVM, noneStep, "i64", "0", "1"))
+	g.fnBuf.WriteString(mirNoneAggregateLines(noneStep, noneValue, optLLVM))
 	g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 	g.fnBuf.WriteString(mirLabelLine(mergeLabel))
@@ -5914,16 +5888,14 @@ func (g *mirGen) emitStringParseResultIntrinsic(i *mir.IntrinsicInstr, strReg, v
 		return err
 	}
 	okStep1 := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(okStep1, resultLLVM, "undef", "i64", "1", "0"))
 	okValue := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(okValue, resultLLVM, okStep1, "i64", payload, "1"))
+	g.fnBuf.WriteString(mirOkAggregateLines(okStep1, okValue, resultLLVM, payload))
 	g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 	g.fnBuf.WriteString(mirLabelLine(errLabel))
 	errStep1 := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(errStep1, resultLLVM, "undef", "i64", "0", "0"))
 	errValue := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(errValue, resultLLVM, errStep1, "i64", "0", "1"))
+	g.fnBuf.WriteString(mirErrAggregateLines(errStep1, errValue, resultLLVM, "0"))
 	g.fnBuf.WriteString(mirBrUncondLine(mergeLabel))
 
 	g.fnBuf.WriteString(mirLabelLine(mergeLabel))
@@ -6044,7 +6016,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := llvmChanRuntimeCloseSymbol()
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		em := g.ostyEmitter()
 		llvmChanClose(em, &LlvmValue{typ: "ptr", name: chReg})
 		g.flushOstyEmitter(em)
@@ -6058,7 +6030,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := llvmChanRuntimeIsClosedSymbol()
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmChanIsClosed(em, &LlvmValue{typ: "ptr", name: chReg})
 		g.flushOstyEmitter(em)
@@ -6162,7 +6134,7 @@ func (g *mirGen) emitTaskIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_task_group_is_cancelled"
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + group})
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("task intrinsic kind %d", i.Kind))
@@ -6283,7 +6255,7 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_thread_sleep"
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+dur))
 		return nil
 	}
@@ -6538,7 +6510,7 @@ func (g *mirGen) emitPrintlnLike(op mir.Operand, newline bool) error {
 		callArg = tmp
 		callT = "double"
 	}
-	g.declareRuntime("printf", "declare i32 @printf(ptr, ...)")
+	g.declareRuntime("printf", mirRuntimeDeclarePrintf())
 	g.fnBuf.WriteString(mirCallVarargPrintfLine(fmtSym, callT+" "+callArg))
 	return nil
 }
@@ -6760,31 +6732,31 @@ func (g *mirGen) emitLenRV(rv *mir.LenRV) (string, error) {
 	switch {
 	case isListPtrType(placeT):
 		sym := listRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmListLen(em, &LlvmValue{typ: "ptr", name: valueReg})
 		g.flushOstyEmitter(em)
 		return result.name, nil
 	case isMapPtrType(placeT):
 		sym := mapRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmMapLen(em, &LlvmValue{typ: "ptr", name: valueReg})
 		g.flushOstyEmitter(em)
 		return result.name, nil
 	case isSetPtrType(placeT):
 		sym := setRuntimeLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmSetLen(em, &LlvmValue{typ: "ptr", name: valueReg})
 		g.flushOstyEmitter(em)
 		return result.name, nil
 	case isStringLLVMType(placeT):
 		sym := llvmStringRuntimeByteLenSymbol()
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmStringByteLen(em, &LlvmValue{typ: "ptr", name: valueReg})
 		g.flushOstyEmitter(em)
 		return result.name, nil
 	case isBytesType(placeT):
 		sym := "osty_rt_bytes_len"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: valueReg}})
 		g.flushOstyEmitter(em)
 		return result.name, nil
@@ -7013,7 +6985,7 @@ func (g *mirGen) toI64Slot(val string, t mir.Type) (string, error) {
 	// inttoptr + load. Heap (not stack) because Result/Option can
 	// escape the constructing frame via returns / stores.
 	if strings.HasPrefix(llvmT, "%") {
-		g.declareRuntime("osty.gc.alloc_v1", "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)")
+		g.declareRuntime("osty.gc.alloc_v1", mirRuntimeDeclareGcAllocV1())
 		size := g.emitSizeOf(llvmT)
 		site := g.stringLiteral("mir.enum.box." + strings.TrimPrefix(llvmT, "%"))
 		box := g.fresh()
@@ -7247,11 +7219,8 @@ func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLV
 		return unsupported("mir-mvp", fmt.Sprintf("list_get safe payload widen unsupported for %s", elemLLVM))
 	}
 	tagged := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(tagged, destLLVM, "undef", "i64", "1", "0"))
 	filled := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(filled, destLLVM, tagged, "i64", payloadReg, "1"))
-	g.fnBuf.WriteString(mirStoreLine(destLLVM, filled, destSlot))
-	g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+	g.fnBuf.WriteString(mirSomeStoreThenJumpLines(tagged, filled, destLLVM, payloadReg, destSlot, endLabel))
 	g.fnBuf.WriteString(mirLabelLine(endLabel))
 	return nil
 }
@@ -7742,7 +7711,7 @@ func (g *mirGen) emitUnary(op mir.UnaryOp, arg string, t mir.Type) (string, erro
 
 func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.Type) (string, error) {
 	if op == mir.BinAdd && isStringPrimType(argT) {
-		g.declareRuntime("osty_rt_strings_Concat", "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+		g.declareRuntime("osty_rt_strings_Concat", mirRuntimeDeclareStringConcat())
 		em := g.ostyEmitter()
 		out := llvmStringConcat(em, &LlvmValue{typ: "ptr", name: left}, &LlvmValue{typ: "ptr", name: right})
 		g.flushOstyEmitter(em)

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -2636,3 +2636,194 @@ func mirRuntimeDeclareMapRemoveLine(sym, keyLLVM string) string {
 func mirRuntimeDeclareListSetSimpleLine(sym, elemLLVM string) string {
 	return mirRuntimeDeclareLine("void", sym, "ptr, i64, "+elemLLVM)
 }
+
+// §3 runtime-declare canonical-shape builders — drain the
+// `"declare <ret> @"+sym+"(<args>)"` string-concat pattern at every
+// call site in `mir_generator.go`. Each helper covers one common
+// (ret, args) shape.
+
+// mirRuntimeDeclarePrintf returns `declare i32 @printf(ptr, ...)`.
+// Osty: mirRuntimeDeclarePrintf
+func mirRuntimeDeclarePrintf() string {
+	return "declare i32 @printf(ptr, ...)"
+}
+
+// mirRuntimeDeclareExit returns `declare void @exit(i32)`.
+// Osty: mirRuntimeDeclareExit
+func mirRuntimeDeclareExit() string {
+	return "declare void @exit(i32)"
+}
+
+// mirRuntimeDeclarePtrFromPtrLine renders `declare ptr @<sym>(ptr)`.
+// Osty: mirRuntimeDeclarePtrFromPtrLine
+func mirRuntimeDeclarePtrFromPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr")
+}
+
+// mirRuntimeDeclareI1FromPtrLine renders `declare i1 @<sym>(ptr)`.
+// Osty: mirRuntimeDeclareI1FromPtrLine
+func mirRuntimeDeclareI1FromPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("i1", sym, "ptr")
+}
+
+// mirRuntimeDeclareVoidFromPtrLine renders `declare void @<sym>(ptr)`.
+// Osty: mirRuntimeDeclareVoidFromPtrLine
+func mirRuntimeDeclareVoidFromPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr")
+}
+
+// mirRuntimeDeclareI64FromPtrLine renders `declare i64 @<sym>(ptr)`.
+// Osty: mirRuntimeDeclareI64FromPtrLine
+func mirRuntimeDeclareI64FromPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("i64", sym, "ptr")
+}
+
+// mirRuntimeDeclarePtrFromScalarLine renders `declare ptr @<sym>(<scalar>)`.
+// Osty: mirRuntimeDeclarePtrFromScalarLine
+func mirRuntimeDeclarePtrFromScalarLine(sym, scalarLLVM string) string {
+	return mirRuntimeDeclareLine("ptr", sym, scalarLLVM)
+}
+
+// mirRuntimeDeclareI64NoArgsLine renders `declare i64 @<sym>()`.
+// Osty: mirRuntimeDeclareI64NoArgsLine
+func mirRuntimeDeclareI64NoArgsLine(sym string) string {
+	return mirRuntimeDeclareLine("i64", sym, "")
+}
+
+// mirRuntimeDeclareVoidI32Line renders `declare void @<sym>(i32)`.
+// Osty: mirRuntimeDeclareVoidI32Line
+func mirRuntimeDeclareVoidI32Line(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "i32")
+}
+
+// mirRuntimeDeclareSafepointV1 returns the GC safepoint decl shape.
+// Osty: mirRuntimeDeclareSafepointV1
+func mirRuntimeDeclareSafepointV1() string {
+	return "declare void @osty.gc.safepoint_v1(i64, ptr, i64)"
+}
+
+// mirRuntimeDeclareGcAllocV1 returns the GC allocator decl shape.
+// Osty: mirRuntimeDeclareGcAllocV1
+func mirRuntimeDeclareGcAllocV1() string {
+	return "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)"
+}
+
+// mirRuntimeDeclareStringConcat returns the String concat decl shape.
+// Osty: mirRuntimeDeclareStringConcat
+func mirRuntimeDeclareStringConcat() string {
+	return "declare ptr @osty_rt_strings_Concat(ptr, ptr)"
+}
+
+// §6 Some-aggregate builders — repeating the Some(payload) two-
+// insertvalue construction.
+
+// mirSomeAggregateLines renders the canonical Some(payload) two-
+// insertvalue pair into one block.
+// Osty: mirSomeAggregateLines
+func mirSomeAggregateLines(taggedReg, filledReg, optLLVM, payloadI64 string) string {
+	return mirInsertValueAggLine(taggedReg, optLLVM, "undef", "i64", "1", "0") +
+		mirInsertValueAggLine(filledReg, optLLVM, taggedReg, "i64", payloadI64, "1")
+}
+
+// mirSomeStoreLines renders Some-aggregate construction + store.
+// Osty: mirSomeStoreLines
+func mirSomeStoreLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot string) string {
+	return mirSomeAggregateLines(taggedReg, filledReg, optLLVM, payloadI64) +
+		mirStoreLine(optLLVM, filledReg, destSlot)
+}
+
+// mirSomeStoreThenJumpLines renders Some-arm body: aggregate +
+// store + br to join label.
+// Osty: mirSomeStoreThenJumpLines
+func mirSomeStoreThenJumpLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel string) string {
+	return mirSomeStoreLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot) +
+		mirBrUncondLine(endLabel)
+}
+
+// mirNoneStoreThenJumpLines renders None-arm body: store
+// zeroinitializer + br to join label.
+// Osty: mirNoneStoreThenJumpLines
+func mirNoneStoreThenJumpLines(optLLVM, destSlot, endLabel string) string {
+	return mirStoreZeroinitLine(optLLVM, destSlot) + mirBrUncondLine(endLabel)
+}
+
+// mirICmpSltI64Line renders the loop-bound check `icmp slt i64`.
+// Osty: mirICmpSltI64Line
+func mirICmpSltI64Line(reg, lhs, rhs string) string {
+	return mirICmpLine(reg, "slt", "i64", lhs, rhs)
+}
+
+// mirICmpSgeI64Line renders the lower-bound check `icmp sge i64`.
+// Osty: mirICmpSgeI64Line
+func mirICmpSgeI64Line(reg, lhs, rhs string) string {
+	return mirICmpLine(reg, "sge", "i64", lhs, rhs)
+}
+
+// mirLinearScanLoopHeadLines renders the loop-head block of the
+// linear-scan idiom: label + load + slt + cond-br.
+// Osty: mirLinearScanLoopHeadLines
+func mirLinearScanLoopHeadLines(headLabel, iReg, iSlot, cont, lenReg, bodyLabel, endLabel string) string {
+	return mirLabelLine(headLabel) +
+		mirLoadLine(iReg, "i64", iSlot) +
+		mirICmpSltI64Line(cont, iReg, lenReg) +
+		mirBrCondLine(cont, bodyLabel, endLabel)
+}
+
+// mirLinearScanLoopTailLines renders the loop-tail block: cont
+// label + add + store + jump to head.
+// Osty: mirLinearScanLoopTailLines
+func mirLinearScanLoopTailLines(contLabel, nextReg, iReg, iSlot, headLabel string) string {
+	return mirLabelLine(contLabel) +
+		mirAddI64Line(nextReg, iReg, "1") +
+		mirStoreLine("i64", nextReg, iSlot) +
+		mirBrUncondLine(headLabel)
+}
+
+// mirNoneAggregateLines renders the canonical None two-insertvalue
+// construction.
+// Osty: mirNoneAggregateLines
+func mirNoneAggregateLines(stepReg, valueReg, optLLVM string) string {
+	return mirInsertValueAggLine(stepReg, optLLVM, "undef", "i64", "0", "0") +
+		mirInsertValueAggLine(valueReg, optLLVM, stepReg, "i64", "0", "1")
+}
+
+// mirOkAggregateLines renders the canonical Ok(payload) two-
+// insertvalue construction.
+// Osty: mirOkAggregateLines
+func mirOkAggregateLines(stepReg, valueReg, resultLLVM, payloadI64 string) string {
+	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "1", "0") +
+		mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
+}
+
+// mirErrAggregateLines renders the canonical Err(payload) two-
+// insertvalue construction.
+// Osty: mirErrAggregateLines
+func mirErrAggregateLines(stepReg, valueReg, resultLLVM, payloadI64 string) string {
+	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "0", "0") +
+		mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
+}
+
+// mirCallVoidI64TagAndPtrLine renders the safepoint chunk-call
+// shape `call void @<sym>(i64, ptr, i64)`.
+// Osty: mirCallVoidI64TagAndPtrLine
+func mirCallVoidI64TagAndPtrLine(sym, tag, slot, count string) string {
+	return mirCallVoidLine(sym, "i64 "+tag+", ptr "+slot+", i64 "+count)
+}
+
+// mirAllocaI64ZeroSlot renders alloca i64 + store i64 0.
+// Osty: mirAllocaI64ZeroSlot
+func mirAllocaI64ZeroSlot(slot string) string {
+	return mirAllocaWithStoreLine(slot, "i64", "0")
+}
+
+// mirAllocaI1FalseSlot renders alloca i1 + store i1 false.
+// Osty: mirAllocaI1FalseSlot
+func mirAllocaI1FalseSlot(slot string) string {
+	return mirAllocaWithStoreLine(slot, "i1", "false")
+}
+
+// mirStoreI1TrueLine renders `store i1 true, ptr <slot>`.
+// Osty: mirStoreI1TrueLine
+func mirStoreI1TrueLine(slot string) string {
+	return mirStoreLine("i1", "true", slot)
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -3431,3 +3431,306 @@ pub fn mirRuntimeDeclareMapRemoveLine(sym: String, keyLLVM: String) -> String {
 pub fn mirRuntimeDeclareListSetSimpleLine(sym: String, elemLLVM: String) -> String {
     mirRuntimeDeclareLine("void", sym, "ptr, i64, " + elemLLVM)
 }
+
+/// §3 runtime-declare canonical-shape builders — drain the `"declare
+/// <ret> @"+sym+"(<args>)"` string-concat pattern at every call site
+/// in `mir_generator.go`. Each helper covers one common (ret, args)
+/// shape and produces the exact bytes the existing inline form
+/// generated, so the swap is byte-stable.
+
+/// mirRuntimeDeclarePrintf returns the canonical printf decl shape:
+///   `declare i32 @printf(ptr, ...)`
+/// Centralised so every printf-emitting site uses the same shape.
+pub fn mirRuntimeDeclarePrintf() -> String {
+    "declare i32 @printf(ptr, ...)"
+}
+
+/// mirRuntimeDeclareExit returns the canonical exit decl shape:
+///   `declare void @exit(i32)`
+/// Centralised so the noreturn-emitting sites (testing-abort,
+/// bench-error, panic-helper) all reach for the same builder.
+pub fn mirRuntimeDeclareExit() -> String {
+    "declare void @exit(i32)"
+}
+
+/// mirRuntimeDeclarePtrFromPtrLine renders `declare ptr @<sym>(ptr)` —
+/// the most common runtime ABI shape (~22 sites): `osty_rt_list_keys`,
+/// `osty_rt_list_data_*`, `osty_rt_set_to_list`, etc. Single ptr arg
+/// returning a ptr handle.
+pub fn mirRuntimeDeclarePtrFromPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr")
+}
+
+/// mirRuntimeDeclareI1FromPtrLine renders `declare i1 @<sym>(ptr)` —
+/// the predicate runtime shape used by `is_empty`, `is_closed`,
+/// `is_cancelled`, `osty_rt_list_pop_check`, etc.
+pub fn mirRuntimeDeclareI1FromPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("i1", sym, "ptr")
+}
+
+/// mirRuntimeDeclareVoidFromPtrLine renders `declare void @<sym>(ptr)` —
+/// the side-effect runtime shape used by `osty_rt_list_clear`,
+/// `osty_rt_list_reverse`, `osty_rt_chan_close`, `*_pop_discard`,
+/// etc. The list/map/chan/set runtimes that act on a handle in-
+/// place all reach for this shape.
+pub fn mirRuntimeDeclareVoidFromPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr")
+}
+
+/// mirRuntimeDeclareI64FromPtrLine renders `declare i64 @<sym>(ptr)` —
+/// scalar-returning ptr-handle probe shape for `osty_rt_list_len`,
+/// `osty_rt_map_len`, `osty_rt_set_len`, etc. Distinct from
+/// `mirRuntimeDeclareMemoryRead` (which adds the `nounwind willreturn
+/// memory(read)` attribute combo for snapshot-LICM); this is the
+/// plain shape used at sites where the LICM hoist isn't desired.
+pub fn mirRuntimeDeclareI64FromPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("i64", sym, "ptr")
+}
+
+/// mirRuntimeDeclarePtrFromScalarLine renders `declare ptr @<sym>(<scalar>)`
+/// — the scalar-to-string family: `osty_rt_int_to_string(i64)`,
+/// `osty_rt_float_to_string(double)`, `osty_rt_bool_to_string(i1)`,
+/// `osty_rt_char_to_string(i32)`, `osty_rt_byte_to_string(i8)`. All
+/// take a single scalar param and return an interned String ptr.
+pub fn mirRuntimeDeclarePtrFromScalarLine(sym: String, scalarLLVM: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, scalarLLVM)
+}
+
+/// mirRuntimeDeclareI64NoArgsLine renders `declare i64 @<sym>()` —
+/// the zero-arg scalar probe used by the bench harness clock reads
+/// (`osty_rt_bench_now_nanos`, `osty_rt_bench_target_ns`,
+/// `osty_gc_debug_allocated_bytes_total`).
+pub fn mirRuntimeDeclareI64NoArgsLine(sym: String) -> String {
+    mirRuntimeDeclareLine("i64", sym, "")
+}
+
+/// mirRuntimeDeclareVoidI32Line renders `declare void @<sym>(i32)` —
+/// shape exemplified by the libc `exit(i32)` decl. `mirRuntimeDeclareExit`
+/// covers the literal `@exit` symbol; this builder is the
+/// abstract-symbol form for any noreturn exit-like helper.
+pub fn mirRuntimeDeclareVoidI32Line(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "i32")
+}
+
+/// mirRuntimeDeclareSafepointV1 returns the canonical decl for the
+/// GC safepoint runtime ABI:
+///   `declare void @osty.gc.safepoint_v1(i64, ptr, i64)`
+/// Tag + slots-array + count. The MIR emitter's safepoint chunker
+/// passes the per-chunk slots-array slot through this hook; the C
+/// runtime walks it to trace the live root set without pinning.
+pub fn mirRuntimeDeclareSafepointV1() -> String {
+    "declare void @osty.gc.safepoint_v1(i64, ptr, i64)"
+}
+
+/// mirRuntimeDeclareGcAllocV1 returns the canonical decl for the
+/// GC allocator runtime ABI:
+///   `declare ptr @osty.gc.alloc_v1(i64, i64, ptr)`
+/// Trace-kind + size + site-token. Used by the stack-spill heap-box
+/// path inside `toI64Slot` for aggregate-payload Option/Result
+/// constructions where the payload exceeds the i64 inline budget.
+pub fn mirRuntimeDeclareGcAllocV1() -> String {
+    "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)"
+}
+
+/// mirRuntimeDeclareStringConcat returns the canonical decl for the
+/// String concat runtime ABI:
+///   `declare ptr @osty_rt_strings_Concat(ptr, ptr)`
+/// Two ptr-typed strings → joined String ptr. The most-called
+/// runtime symbol in a typical program (every `+` on String, every
+/// interpolation segment chain).
+pub fn mirRuntimeDeclareStringConcat() -> String {
+    "declare ptr @osty_rt_strings_Concat(ptr, ptr)"
+}
+
+/// §6 Some-aggregate builders — repeating the `Some(payload)` two-
+/// insertvalue construction that appears at every list/map probe
+/// site. Centralising the pair keeps the disc=1 / payload=val order
+/// stable and produces a four-line block (two insertvalues + store +
+/// store-zero-on-miss) that downstream readers can spot as a unit.
+
+/// mirSomeAggregateLines renders the canonical Some(payload)
+/// aggregate construction:
+///   `  <tagged> = insertvalue <optTy> undef, i64 1, 0\n`
+///   `  <filled> = insertvalue <optTy> <tagged>, i64 <payload>, 1\n`
+/// Caller passes freshly-allocated SSA registers for both
+/// intermediates and the i64-widened payload value. The returned
+/// 2-line block goes into `g.fnBuf` ahead of the `store <opt>
+/// <filled>, ptr <slot>` terminator. Drains the two-`mirInsertValueAggLine`
+/// pattern repeated at IntrinsicListFirst / IntrinsicListLast /
+/// IntrinsicListPop / IntrinsicListIndexOf / IntrinsicListContains
+/// / IntrinsicMapGet / IntrinsicListSafeGet sites.
+pub fn mirSomeAggregateLines(taggedReg: String, filledReg: String, optLLVM: String, payloadI64: String) -> String {
+    mirInsertValueAggLine(taggedReg, optLLVM, "undef", "i64", "1", "0") +
+    mirInsertValueAggLine(filledReg, optLLVM, taggedReg, "i64", payloadI64, "1")
+}
+
+/// mirSomeStoreLines renders the Some-aggregate construction
+/// followed by the store into the destination slot:
+///   `  <tagged> = insertvalue <optTy> undef, i64 1, 0\n`
+///   `  <filled> = insertvalue <optTy> <tagged>, i64 <payload>, 1\n`
+///   `  store <optTy> <filled>, ptr <destSlot>\n`
+/// Three-line block. Wraps `mirSomeAggregateLines` with the trailing
+/// store via `mirStoreLine`. The destSlot is the function-local
+/// alloca for the Option<T>-typed dest; the i64-widened payload is
+/// produced by the caller via `listOptionalPayloadToI64`.
+pub fn mirSomeStoreLines(taggedReg: String, filledReg: String, optLLVM: String, payloadI64: String, destSlot: String) -> String {
+    mirSomeAggregateLines(taggedReg, filledReg, optLLVM, payloadI64) +
+    mirStoreLine(optLLVM, filledReg, destSlot)
+}
+
+/// mirSomeStoreThenJumpLines renders the full Some-arm body of a
+/// list/map probe match: aggregate construction + dest store + br
+/// to the join label.
+///   `  <tagged> = insertvalue <optTy> undef, i64 1, 0\n`
+///   `  <filled> = insertvalue <optTy> <tagged>, i64 <payload>, 1\n`
+///   `  store <optTy> <filled>, ptr <destSlot>\n`
+///   `  br label %<endLabel>\n`
+/// Four-line block. Drains the canonical "Some-arm exit" sequence
+/// at the seven sites listed under `mirSomeAggregateLines`. The br
+/// is unconditional because the Some-arm's match has already been
+/// proved by an earlier conditional.
+pub fn mirSomeStoreThenJumpLines(taggedReg: String, filledReg: String, optLLVM: String, payloadI64: String, destSlot: String, endLabel: String) -> String {
+    mirSomeStoreLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot) +
+    mirBrUncondLine(endLabel)
+}
+
+/// mirNoneStoreThenJumpLines renders the canonical "None-arm exit"
+/// sequence: write zeroinitializer into the dest slot then jump to
+/// the join label.
+///   `  store <optTy> zeroinitializer, ptr <destSlot>\n`
+///   `  br label %<endLabel>\n`
+/// Two-line block. Sibling of `mirSomeStoreThenJumpLines` for the
+/// miss / empty / oob branch where None is the payload.
+pub fn mirNoneStoreThenJumpLines(optLLVM: String, destSlot: String, endLabel: String) -> String {
+    mirStoreZeroinitLine(optLLVM, destSlot) +
+    mirBrUncondLine(endLabel)
+}
+
+/// mirICmpSltI64Line renders the loop-bound check that drives every
+/// inline list/string scan loop:
+///   `  <reg> = icmp slt i64 <iReg>, <lenReg>\n`
+/// Specialised because `slt`-on-i64 is the hot-path predicate for
+/// linear scans. The general `mirICmpLine(reg, "slt", "i64", lhs,
+/// rhs)` form covers other widths; this is the typed shorthand.
+pub fn mirICmpSltI64Line(reg: String, lhs: String, rhs: String) -> String {
+    mirICmpLine(reg, "slt", "i64", lhs, rhs)
+}
+
+/// mirICmpSgeI64Line renders the lower-bound check for negative-
+/// index detection in `safe_get` / `index_of` style intrinsics:
+///   `  <reg> = icmp sge i64 <iReg>, 0\n`
+/// Sibling of `mirICmpSltI64Line` — `nonNeg && inUpper` is the
+/// canonical bounds check that gates the typed-element fast path.
+pub fn mirICmpSgeI64Line(reg: String, lhs: String, rhs: String) -> String {
+    mirICmpLine(reg, "sge", "i64", lhs, rhs)
+}
+
+/// mirLinearScanLoopHeadLines renders the loop-head block of the
+/// linear-scan idiom used by `IntrinsicListIndexOf` /
+/// `IntrinsicListContains`:
+///   `<headLabel>:\n`
+///   `  <iReg> = load i64, ptr <iSlot>\n`
+///   `  <cont> = icmp slt i64 <iReg>, <lenReg>\n`
+///   `  br i1 <cont>, label %<bodyLabel>, label %<endLabel>\n`
+/// Four-line block. Caller pre-allocates <iReg> and <cont>; the
+/// helper threads the labels and slot together. The `iSlot` was
+/// initialised to 0 in the preamble; the `<endLabel>` is the
+/// scan's exit block.
+pub fn mirLinearScanLoopHeadLines(headLabel: String, iReg: String, iSlot: String, cont: String, lenReg: String, bodyLabel: String, endLabel: String) -> String {
+    mirLabelLine(headLabel) +
+    mirLoadLine(iReg, "i64", iSlot) +
+    mirICmpSltI64Line(cont, iReg, lenReg) +
+    mirBrCondLine(cont, bodyLabel, endLabel)
+}
+
+/// mirLinearScanLoopTailLines renders the loop-tail block of the
+/// linear-scan idiom: continue-label header, increment, store back,
+/// jump to head.
+///   `<contLabel>:\n`
+///   `  <next> = add i64 <iReg>, 1\n`
+///   `  store i64 <next>, ptr <iSlot>\n`
+///   `  br label %<headLabel>\n`
+/// Four-line block. The `<contLabel>` is the post-match-fail
+/// fall-through that every iteration takes when the body's match
+/// missed.
+pub fn mirLinearScanLoopTailLines(contLabel: String, nextReg: String, iReg: String, iSlot: String, headLabel: String) -> String {
+    mirLabelLine(contLabel) +
+    mirAddI64Line(nextReg, iReg, "1") +
+    mirStoreLine("i64", nextReg, iSlot) +
+    mirBrUncondLine(headLabel)
+}
+
+/// mirNoneAggregateLines renders the canonical None two-insertvalue
+/// construction:
+///   `  <step> = insertvalue <optTy> undef, i64 0, 0\n`
+///   `  <value> = insertvalue <optTy> <step>, i64 0, 1\n`
+/// Two-line block. Sibling of `mirSomeAggregateLines` for the
+/// "build a None value" surface — `bytes.get` / `list.find` /
+/// `map.get` phi-merge sites where the two arms produce the value
+/// shape (Some/None) rather than storing into a slot directly. The
+/// caller phi-merges Some/None into a single Option<T>.
+pub fn mirNoneAggregateLines(stepReg: String, valueReg: String, optLLVM: String) -> String {
+    mirInsertValueAggLine(stepReg, optLLVM, "undef", "i64", "0", "0") +
+    mirInsertValueAggLine(valueReg, optLLVM, stepReg, "i64", "0", "1")
+}
+
+/// mirOkAggregateLines renders the canonical Ok(payload) two-
+/// insertvalue construction:
+///   `  <step> = insertvalue <resultTy> undef, i64 1, 0\n`
+///   `  <value> = insertvalue <resultTy> <step>, i64 <payload>, 1\n`
+/// Sibling of `mirSomeAggregateLines` but for `Result<Ok, Err>`
+/// where `Ok` shares the disc=1 tag with Some. Used by the bench
+/// harness `Ok(())` synthesis and the `?` propagation Ok-arm.
+pub fn mirOkAggregateLines(stepReg: String, valueReg: String, resultLLVM: String, payloadI64: String) -> String {
+    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "1", "0") +
+    mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
+}
+
+/// mirErrAggregateLines renders the canonical Err(payload) two-
+/// insertvalue construction:
+///   `  <step> = insertvalue <resultTy> undef, i64 0, 0\n`
+///   `  <value> = insertvalue <resultTy> <step>, i64 <payload>, 1\n`
+/// Sibling of `mirOkAggregateLines` for the Err arm of Result.
+/// Note that for Result, disc=0 is Err (not None as in Option) —
+/// the discriminant convention is shared between Result and Option
+/// at the i64-tag level but the variant assignment differs.
+pub fn mirErrAggregateLines(stepReg: String, valueReg: String, resultLLVM: String, payloadI64: String) -> String {
+    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "0", "0") +
+    mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
+}
+
+/// mirCallVoidI64TagAndPtrLine renders `call void @<sym>(i64 <tag>,
+/// ptr <slot>, i64 <count>)\n` — the safepoint chunk-call shape.
+/// Used by `emitGCSafepointKind` to invoke the runtime safepoint
+/// hook with a per-chunk slots array.
+pub fn mirCallVoidI64TagAndPtrLine(sym: String, tag: String, slot: String, count: String) -> String {
+    mirCallVoidLine(sym, "i64 " + tag + ", ptr " + slot + ", i64 " + count)
+}
+
+/// mirAllocaI64ZeroSlot renders the canonical "fresh i64 counter
+/// slot initialised to zero" preamble used by linear-scan loops:
+///   `  <slot> = alloca i64\n`
+///   `  store i64 0, ptr <slot>\n`
+/// Two-line block. Companion to the existing `mirAllocaWithStoreLine`
+/// but specialised for the (i64, "0") init case so call sites can
+/// grep for the "scan-counter slot" idiom.
+pub fn mirAllocaI64ZeroSlot(slot: String) -> String {
+    mirAllocaWithStoreLine(slot, "i64", "0")
+}
+
+/// mirAllocaI1FalseSlot renders the canonical "fresh i1 result
+/// slot initialised to false" preamble used by `IntrinsicListContains`:
+///   `  <slot> = alloca i1\n`
+///   `  store i1 false, ptr <slot>\n`
+/// Two-line block. Used so the contains scan can pre-store false
+/// and only flip to true on the first match without needing a phi.
+pub fn mirAllocaI1FalseSlot(slot: String) -> String {
+    mirAllocaWithStoreLine(slot, "i1", "false")
+}
+
+/// mirStoreI1TrueLine renders the literal "store i1 true" — used
+/// by `IntrinsicListContains`'s match arm to flip the result slot
+/// to true without recomputing.
+pub fn mirStoreI1TrueLine(slot: String) -> String {
+    mirStoreLine("i1", "true", slot)
+}


### PR DESCRIPTION
## Summary

- Adds 28 new line-builders to `toolchain/mir_generator.osty` covering runtime-declare canonical shapes (12) plus the repeating Some/None/Ok/Err two-insertvalue aggregate construction (8) plus loop-scaffold helpers (8)
- §3 runtime-declare builders: `mirRuntimeDeclarePrintf` / `mirRuntimeDeclareExit` / `mirRuntimeDeclareSafepointV1` / `mirRuntimeDeclareGcAllocV1` / `mirRuntimeDeclareStringConcat` (5 fixed-shape) + `mirRuntimeDeclare{Ptr,I1,Void,I64}FromPtrLine` (4 by-arity) + `mirRuntimeDeclarePtrFromScalarLine` / `mirRuntimeDeclareI64NoArgsLine` / `mirRuntimeDeclareVoidI32Line` (3 abstract-symbol)
- §6 aggregate builders: `mirSomeAggregateLines` / `mirSomeStoreLines` / `mirSomeStoreThenJumpLines` / `mirNoneStoreThenJumpLines` / `mirNoneAggregateLines` / `mirOkAggregateLines` / `mirErrAggregateLines` / `mirCallVoidI64TagAndPtrLine`
- §6 loop-scaffold: `mirICmpSltI64Line` / `mirICmpSgeI64Line` / `mirLinearScanLoopHeadLines` / `mirLinearScanLoopTailLines` / `mirAllocaI64ZeroSlot` / `mirAllocaI1FalseSlot` / `mirStoreI1TrueLine`

## Drain sites

| Site | Before | After |
|------|--------|-------|
| 32 `declareRuntime` sites | inline `"declare <ret> @"+sym+"(<args>)"` string-concat | one of 12 canonical-shape builders |
| 7 IntrinsicList* / IntrinsicMapGet probe sites | 5-call insertvalue+store+br repetition | 1-call `mirSomeStoreThenJumpLines` / `mirNoneStoreThenJumpLines` |
| IntrinsicBytesGet / IntrinsicBytesIndexOf phi-merge | 4-call aggregate construction in each arm | 1-call `mirSomeAggregateLines` / `mirNoneAggregateLines` |
| `emitStringParseResult` | inline Ok/Err aggregate | `mirOkAggregateLines` / `mirErrAggregateLines` |
| 2 linear-scan loop preambles | alloca + store i64 0 | `mirAllocaI64ZeroSlot` |

## Diffstat

**588 insertions / 98 deletions** across 4 files.

## Test plan

- [x] `go build ./internal/llvmgen/...` clean
- [x] `go vet ./internal/llvmgen/...` clean
- [x] Byte-stable golden parity confirmed: `go test ./internal/llvmgen/...` pre/post diff is empty (same 6 pre-existing native-owned coverage gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)