### PR TITLE
refactor(lsp): value-typed view boundary for hover/completion/refactor (Phase 0)

### DIFF
--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -358,6 +358,39 @@ type** 을 소비하기 때문에 단순 포팅이 아니라 identity-model migr
 - `symbolDoc` 의 AST decl → doc comment switch 를 `ast_lower.osty` 에 쌍둥이로 이관하고 Go 는 1-line delegator 로 축소
 - orchestration-layer identity 전환 (arena NodeID) 가 선행되면 `organizeImportsAction` / `completionItemFromSym` 전체 이관 검토
 
+**2026-04-26 Phase 0 착륙 — value-typed view boundary**:
+`generated.go` frozen seed 제약 때문에 정책을 lsp.osty 로 더 옮겨도 Go LSP
+런타임에 닿지 않는다 (PR #854). 대신 **leaf consumer 함수의 pointer-arg 표면을
+value-typed view 로 깎아 내** orchestration 자체를 LLVM self-host LSP 가
+catch up 할 때 trivial-portable 하게 만드는 경로로 전환.
+
+`selfhost/lsp_policy.go` 에 두 개의 view 타입 신설:
+- `LSPSymbolView{Name, Kind, TypeText, DocText, HasSym}` — hover/completion 공용.
+- `LSPUseDeclView{PosOffset, EndOffset, Path, RawPath, Alias, IsFFI, FFIPath}` —
+  organize-imports / refactor 공용.
+
+착륙한 phase:
+
+| phase | 파일 | 변경 |
+|---|---|---|
+| 0a | `internal/lsp/handlers.go` | `hoverForSymbol` → `hoverSymbolView` extractor + `selfhost.LSPHoverMarkdown(view)`. `writeSymSignature` 삭제. |
+| 0b | `internal/lsp/completion.go` | `completionItemFromSym` → `completionSymbolView` + `completionItemFromView`. 모든 정책 (Kind/Detail/SortText) 가 view 통과. |
+| 0d | `internal/lsp/refactor.go` | `keyedUse.u *ast.UseDecl` → `keyedUse.view LSPUseDeclView`. `unusedUseSet map[*ast.UseDecl]bool` → `unusedUseOffsets map[int]bool`. `useGroup`/`useKey`/`useSourceText`/`endOfLineOffset`/`hasTriviaBetweenUses`/`keyWithAlias` 1-line shim 6 종 삭제 — 모두 `LSP*` 직접 호출. `useDeclViews([]*ast.UseDecl) []LSPUseDeclView` 가 유일 pointer-touch site. |
+
+평가 결과 보류 (별도 design 필요):
+
+- **0c (signature.go)**: 단일 `symbolDoc` call 외에는 `*types.FnType` /
+  `*ast.FnDecl` 포인터에 직접 의존. extraction layer 를 추가해도 가치 낮음.
+- **0e (references.go)**: `if refs[id.ID] != target` 의 **포인터 동등 비교가
+  알고리즘 그 자체**. value-typed view 로 깎을 수 없고 `SymbolID`
+  (`internal/resolve/symbolid.go`) 또는 NodeID 기반 identity 모델을 도입해야
+  한다. `containsNode` 의 `ast.Node(d) == decl` 도 같은 종류. 별도 PR.
+
+후속 항목:
+- `references.go` SymbolID identity 도입 (별도 design 문서 선행 권장)
+- `signature.go::buildSignatureInfo` 는 `LSPBuildSignatureText` 가 이미
+  selfhost 라 추가 작업 가치 낮음 — close as won't-fix 후보
+
 ---
 
 ## 3. Hidden hazards

--- a/benchmarks/programs/big-map/go/main.go
+++ b/benchmarks/programs/big-map/go/main.go
@@ -4,28 +4,28 @@ import "fmt"
 import "strconv"
 
 func main() {
-    n := 200000
-    lookups := 1000000
+	n := 200000
+	lookups := 1000000
 
-    m := make(map[string]int, n)
-    for i := 0; i < n; i++ {
-        m["key:"+strconv.Itoa(i)] = i
-    }
+	m := make(map[string]int, n)
+	for i := 0; i < n; i++ {
+		m["key:"+strconv.Itoa(i)] = i
+	}
 
-    state := 1
-    sum := 0
-    hits := 0
-    for j := 0; j < lookups; j++ {
-        state = (state*1103515245 + 12345) % 2147483648
-        target := state % n
-        key := "key:" + strconv.Itoa(target)
-        if _, ok := m[key]; ok {
-            hits++
-            sum += state % 7
-        }
-    }
+	state := 1
+	sum := 0
+	hits := 0
+	for j := 0; j < lookups; j++ {
+		state = (state*1103515245 + 12345) % 2147483648
+		target := state % n
+		key := "key:" + strconv.Itoa(target)
+		if _, ok := m[key]; ok {
+			hits++
+			sum += state % 7
+		}
+	}
 
-    fmt.Println("size:", len(m))
-    fmt.Println("hits:", hits)
-    fmt.Println("sum:", sum)
+	fmt.Println("size:", len(m))
+	fmt.Println("hits:", hits)
+	fmt.Println("sum:", sum)
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // handleCompletion answers `textDocument/completion`. Behavior splits
@@ -143,24 +144,49 @@ func sortCompletionItems(in []CompletionItem) []CompletionItem {
 }
 
 // completionItemFromSym maps a resolver Symbol to a user-facing
-// CompletionItem. Kind, detail (type signature), and documentation
-// (doc comment) are all pulled from check.Result + ast decl nodes.
+// CompletionItem. The pointer-typed extraction lives in
+// completionSymbolView; the assembly itself runs off the value-typed
+// LSPSymbolView so the policy is portable.
 func completionItemFromSym(label string, sym *resolve.Symbol, r *check.Result) CompletionItem {
-	item := CompletionItem{
-		Label: label,
-		Kind:  CompletionItemKind(LSPCompletionKindForSymbolKind(sym.Kind.String())),
-	}
+	return completionItemFromView(completionSymbolView(label, sym, r))
+}
+
+// completionSymbolView projects a resolver Symbol into the
+// value-typed view consumed by completionItemFromView.
+func completionSymbolView(label string, sym *resolve.Symbol, r *check.Result) selfhost.LSPSymbolView {
+	typeText := ""
 	if r != nil {
 		if t := r.LookupSymType(sym); t != nil {
-			item.Detail = LSPCompletionDetail(sym.Kind.String(), label, t.String())
+			typeText = t.String()
 		}
 	}
-	if doc := symbolDoc(sym); doc != "" {
+	return selfhost.LSPSymbolView{
+		Name:     label,
+		Kind:     sym.Kind.String(),
+		TypeText: typeText,
+		DocText:  symbolDoc(sym),
+		HasSym:   true,
+	}
+}
+
+// completionItemFromView assembles a CompletionItem from a
+// pre-extracted view. Kind/Detail/SortText delegate to the
+// self-hosted policy; the markdown documentation flows through as a
+// raw doc string.
+func completionItemFromView(view selfhost.LSPSymbolView) CompletionItem {
+	item := CompletionItem{
+		Label:    view.Name,
+		Kind:     CompletionItemKind(LSPCompletionKindForSymbolKind(view.Kind)),
+		SortText: LSPCompletionSortTextForSymbolKind(view.Kind, view.Name),
+	}
+	if view.TypeText != "" {
+		item.Detail = LSPCompletionDetail(view.Kind, view.Name, view.TypeText)
+	}
+	if view.DocText != "" {
 		item.Documentation = &MarkupContent{
 			Kind:  MarkupKindMarkdown,
-			Value: doc,
+			Value: view.DocText,
 		}
 	}
-	item.SortText = LSPCompletionSortTextForSymbolKind(sym.Kind.String(), label)
 	return item
 }

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -3,8 +3,6 @@ package lsp
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
@@ -12,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/format"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -251,39 +250,39 @@ func (s *Server) handleHover(req *rpcRequest) {
 	replyJSON(s.conn, req.ID, h)
 }
 
-// hoverForSymbol formats the markdown block shown on hover. When sym
-// is nil we fall back to nameFallback (the raw identifier text) so
-// unresolved references still get a minimal popup.
+// hoverForSymbol formats the markdown block shown on hover. The
+// pointer-typed extraction is contained in hoverSymbolView; the
+// markdown rendering itself goes through the value-typed
+// selfhost.LSPHoverMarkdown so the policy stays portable.
 func hoverForSymbol(sym *resolve.Symbol, nameFallback string, r *check.Result) *Hover {
-	var b strings.Builder
-	b.WriteString("```osty\n")
-	if sym != nil {
-		writeSymSignature(&b, sym, r)
-	} else {
-		fmt.Fprintf(&b, "%s\n", nameFallback)
-	}
-	b.WriteString("```")
-	if sym != nil {
-		if doc := symbolDoc(sym); doc != "" {
-			b.WriteString("\n\n")
-			b.WriteString(doc)
-		}
-	}
-	return &Hover{Contents: MarkupContent{Kind: MarkupKindMarkdown, Value: b.String()}}
+	view := hoverSymbolView(sym, nameFallback, r)
+	return &Hover{Contents: MarkupContent{
+		Kind:  MarkupKindMarkdown,
+		Value: selfhost.LSPHoverMarkdown(view),
+	}}
 }
 
-// writeSymSignature emits a one-line declaration-shaped summary for
-// a symbol. For values (let/param/fn) the checker's type is shown;
-// for types (struct/enum/interface) we lead with the keyword.
-func writeSymSignature(b *strings.Builder, sym *resolve.Symbol, r *check.Result) {
+// hoverSymbolView projects a *resolve.Symbol (plus its type from the
+// checker result) into the value-typed view consumed by the markdown
+// formatter. nameFallback is shown when sym is nil so unresolved
+// references still get a minimal popup.
+func hoverSymbolView(sym *resolve.Symbol, nameFallback string, r *check.Result) selfhost.LSPSymbolView {
+	if sym == nil {
+		return selfhost.LSPSymbolView{Name: nameFallback}
+	}
 	typeText := ""
 	if r != nil {
 		if t := r.LookupSymType(sym); t != nil {
 			typeText = t.String()
 		}
 	}
-	b.WriteString(LSPHoverSignatureLine(sym.Kind.String(), sym.Name, typeText))
-	b.WriteByte('\n')
+	return selfhost.LSPSymbolView{
+		Name:     sym.Name,
+		Kind:     sym.Kind.String(),
+		TypeText: typeText,
+		DocText:  symbolDoc(sym),
+		HasSym:   true,
+	}
 }
 
 // symbolDoc extracts the leading `///` comment from a symbol's

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -25,7 +25,7 @@ const (
 )
 
 type keyedUse struct {
-	u     *ast.UseDecl
+	view  selfhost.LSPUseDeclView
 	group int
 	key   string
 	text  string
@@ -61,41 +61,41 @@ func organizeImportsAction(doc *document) *CodeAction {
 	if a == nil || a.file == nil || len(a.file.Uses) == 0 {
 		return nil
 	}
-	uses := a.file.Uses
+	views := useDeclViews(a.file.Uses)
+	if len(views) == 0 {
+		return nil
+	}
 	// Bail out if any meaningful trivia sits between consecutive use
 	// decls — line comments, doc comments, or annotations that the
 	// AST doesn't attach to the UseDecl itself. Rewriting the block
 	// would silently relocate or delete those bytes. The user can
 	// still delete unused imports via the per-diagnostic quick fix,
 	// so organizing is just unavailable, not broken.
-	if hasTriviaBetweenUses(doc.src, uses) {
+	if hasTriviaBetweenUseViews(doc.src, views) {
 		return nil
 	}
-	unused := unusedUseSet(doc)
+	unused := unusedUseOffsets(doc)
 
-	kept := make([]keyedUse, 0, len(uses))
-	seen := make(map[string]bool, len(uses))
-	for _, u := range uses {
-		if u == nil {
+	kept := make([]keyedUse, 0, len(views))
+	seen := make(map[string]bool, len(views))
+	for _, v := range views {
+		if unused[v.PosOffset] {
 			continue
 		}
-		if unused[u] {
-			continue
-		}
-		text := useSourceText(doc.src, u)
+		text := LSPUseSourceText(doc.src, v.PosOffset, v.EndOffset)
 		if text == "" {
 			continue
 		}
-		group := useGroup(u)
-		key := useKey(u)
+		group := LSPUseGroup(v.IsFFI, v.Path)
+		key := LSPUseKey(v.IsFFI, v.FFIPath, v.RawPath, v.Path)
 		// Dedup by (group, key, alias) — two identical `use` lines
 		// collapse to one.
-		dedupKey := keyWithAlias(group, key, u.Alias)
+		dedupKey := LSPKeyWithAlias(group, key, v.Alias)
 		if seen[dedupKey] {
 			continue
 		}
 		seen[dedupKey] = true
-		kept = append(kept, keyedUse{u: u, group: group, key: key, text: text})
+		kept = append(kept, keyedUse{view: v, group: group, key: key, text: text})
 	}
 	kept = sortImportEntries(kept)
 
@@ -117,8 +117,8 @@ func organizeImportsAction(doc *document) *CodeAction {
 	// use's start to just past the last use's terminating newline. We
 	// must NOT swallow a blank line that belongs to the subsequent
 	// decl, so we stop at the newline of the last use's line.
-	startOff := uses[0].PosV.Offset
-	endOff := endOfLineOffset(doc.src, uses[len(uses)-1].EndV.Offset)
+	startOff := views[0].PosOffset
+	endOff := LSPEndOfLineOffset(doc.src, views[len(views)-1].EndOffset)
 	oldText := string(doc.src[startOff:endOff])
 	if newText == oldText {
 		return nil
@@ -136,6 +136,29 @@ func organizeImportsAction(doc *document) *CodeAction {
 	}
 }
 
+// useDeclViews projects a slice of *ast.UseDecl into value-typed
+// views, dropping nil entries so downstream code never has to nil-check.
+// This is the only function that touches *ast.UseDecl pointers in
+// the organize-imports path.
+func useDeclViews(uses []*ast.UseDecl) []selfhost.LSPUseDeclView {
+	out := make([]selfhost.LSPUseDeclView, 0, len(uses))
+	for _, u := range uses {
+		if u == nil {
+			continue
+		}
+		out = append(out, selfhost.LSPUseDeclView{
+			PosOffset: u.PosV.Offset,
+			EndOffset: u.EndV.Offset,
+			Path:      u.Path,
+			RawPath:   u.RawPath,
+			Alias:     u.Alias,
+			IsFFI:     u.IsFFI(),
+			FFIPath:   u.FFIPath(),
+		})
+	}
+	return out
+}
+
 func sortImportEntries(in []keyedUse) []keyedUse {
 	if len(in) <= 1 {
 		return in
@@ -145,7 +168,7 @@ func sortImportEntries(in []keyedUse) []keyedUse {
 		keys = append(keys, LSPImportSortKey{
 			Group: item.group,
 			Key:   item.key,
-			Alias: item.u.Alias,
+			Alias: item.view.Alias,
 		})
 	}
 	indexes := SortLSPImportIndexes(keys)
@@ -159,59 +182,17 @@ func sortImportEntries(in []keyedUse) []keyedUse {
 	return out
 }
 
-// useGroup classifies a use decl into the canonical group ordering.
-// Kept in sync with format.useGroupOrder — duplicating instead of
-// importing to avoid pulling the formatter into the lsp package just
-// for a three-way switch.
-func useGroup(u *ast.UseDecl) int {
-	return LSPUseGroup(u.IsFFI(), u.Path)
-}
-
-// useKey is the intra-group sort key.
-func useKey(u *ast.UseDecl) string {
-	return LSPUseKey(u.IsFFI(), u.FFIPath(), u.RawPath, u.Path)
-}
-
-// keyWithAlias combines the sort key with the alias so `use foo` and
-// `use foo as bar` don't dedupe into one entry.
-func keyWithAlias(group int, key, alias string) string {
-	return LSPKeyWithAlias(group, key, alias)
-}
-
-// useSourceText extracts the exact source text of a single-line use
-// decl. Multi-line FFI blocks (whose body spans several lines) are
-// returned verbatim including the `{ ... }` block.
-func useSourceText(src []byte, u *ast.UseDecl) string {
-	return LSPUseSourceText(src, u.PosV.Offset, u.EndV.Offset)
-}
-
-// endOfLineOffset advances from `off` over any trailing whitespace
-// plus exactly one line terminator, returning the offset of the first
-// byte of the next line (or len(src) if we hit EOF first). Trailing
-// blank lines the user inserted between the last `use` and the next
-// decl are preserved — we stop after consuming the first newline.
-func endOfLineOffset(src []byte, off int) int {
-	return LSPEndOfLineOffset(src, off)
-}
-
-// hasTriviaBetweenUses reports whether non-whitespace bytes appear
-// between the end of one UseDecl's line and the start of the next.
-// Osty's parser strips comments before handing the token stream to
-// the AST builder, so a `// ...` line between two `use` decls has no
-// AST node — it only shows up when we scan the raw source. Finding
-// ANY non-whitespace / non-`use` byte in that gap tells us there's
-// trivia we shouldn't stomp.
-//
-// The scan runs from each use's end-of-line to the next use's
-// PosV.Offset. If it sees anything other than ASCII whitespace or a
-// second `use` keyword, we treat the block as too risky to rewrite.
-func hasTriviaBetweenUses(src []byte, uses []*ast.UseDecl) bool {
-	for i := 0; i+1 < len(uses); i++ {
-		if uses[i] == nil || uses[i+1] == nil {
-			continue
-		}
-		gapStart := uses[i].EndV.Offset
-		gapEnd := uses[i+1].PosV.Offset
+// hasTriviaBetweenUseViews reports whether non-whitespace bytes
+// appear between the end of one UseDecl's line and the start of the
+// next. Osty's parser strips comments before handing the token
+// stream to the AST builder, so a `// ...` line between two `use`
+// decls has no AST node — it only shows up when we scan the raw
+// source. Finding ANY non-whitespace / non-`use` byte in that gap
+// tells us there's trivia we shouldn't stomp.
+func hasTriviaBetweenUseViews(src []byte, views []selfhost.LSPUseDeclView) bool {
+	for i := 0; i+1 < len(views); i++ {
+		gapStart := views[i].EndOffset
+		gapEnd := views[i+1].PosOffset
 		if gapStart < 0 || gapEnd > len(src) || gapStart >= gapEnd {
 			continue
 		}
@@ -222,33 +203,22 @@ func hasTriviaBetweenUses(src []byte, uses []*ast.UseDecl) bool {
 	return false
 }
 
-// unusedUseSet returns the set of UseDecl nodes flagged L0003
-// ("unused import") by the analysis pipeline's lint pass. Uses the
-// cached result on doc.analysis so organizing imports costs one diag
-// scan, not another full lint walk.
-func unusedUseSet(doc *document) map[*ast.UseDecl]bool {
-	out := map[*ast.UseDecl]bool{}
+// unusedUseOffsets returns the set of UseDecl source offsets flagged
+// L0003 ("unused import") by the analysis pipeline's lint pass. Keyed
+// on the decl's PosV.Offset so callers can match against an
+// LSPUseDeclView without holding the original AST pointer.
+func unusedUseOffsets(doc *document) map[int]bool {
+	out := map[int]bool{}
 	a := doc.analysis
-	if a == nil || a.file == nil || a.lint == nil {
+	if a == nil || a.lint == nil {
 		return out
-	}
-	// Build a by-offset index of every use decl so we can map lint
-	// diagnostics (which carry positions, not AST pointers) back to
-	// the node they concern.
-	byOffset := make(map[int]*ast.UseDecl, len(a.file.Uses))
-	for _, u := range a.file.Uses {
-		if u != nil {
-			byOffset[u.PosV.Offset] = u
-		}
 	}
 	for _, d := range a.lint.Diags {
 		if d.Code != diag.CodeUnusedImport {
 			continue
 		}
 		for _, sp := range d.Spans {
-			if u := byOffset[sp.Span.Start.Offset]; u != nil {
-				out[u] = true
-			}
+			out[sp.Span.Start.Offset] = true
 		}
 	}
 	return out

--- a/internal/lsp/selfhost_policy_test.go
+++ b/internal/lsp/selfhost_policy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -89,9 +90,7 @@ func TestWantsKindUsesSelfHostedPrefixPolicy(t *testing.T) {
 }
 
 func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
-	var b strings.Builder
-	writeSymSignature(&b, &resolve.Symbol{Name: "User", Kind: resolve.SymStruct}, nil)
-	if got := b.String(); got != "struct User\n" {
+	if got := LSPHoverSignatureLine("struct", "User", ""); got != "struct User" {
 		t.Fatalf("hover signature = %q", got)
 	}
 	if got := LSPHoverSignatureLine("binding", "value", "Int"); got != "let value: Int" {
@@ -99,6 +98,22 @@ func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got := LSPCompletionDetail("function", "map", "fn(Int) -> String"); got != "fn map(Int) -> String" {
 		t.Fatalf("completion detail = %q", got)
+	}
+}
+
+func TestHoverMarkdownWrapsSelfHostedPolicy(t *testing.T) {
+	view := hoverSymbolView(&resolve.Symbol{Name: "User", Kind: resolve.SymStruct}, "", nil)
+	if !view.HasSym || view.Kind != "struct" || view.Name != "User" {
+		t.Fatalf("view = %+v", view)
+	}
+	got := selfhost.LSPHoverMarkdown(view)
+	if want := "```osty\nstruct User\n```"; got != want {
+		t.Fatalf("hover markdown = %q, want %q", got, want)
+	}
+
+	fallback := selfhost.LSPHoverMarkdown(hoverSymbolView(nil, "raw", nil))
+	if want := "```osty\nraw\n```"; fallback != want {
+		t.Fatalf("fallback markdown = %q, want %q", fallback, want)
 	}
 }
 
@@ -479,56 +494,63 @@ func TestDiagnosticPayloadUsesSelfHostedPolicy(t *testing.T) {
 }
 
 func TestImportOrganizeHelpersUseSelfHost(t *testing.T) {
-	std := &ast.UseDecl{Path: []string{"std", "fmt"}, PosV: token.Pos{Offset: 0}, EndV: token.Pos{Offset: len("use std.fmt  \n")}}
+	stdSrc := []byte("use std.fmt  \n")
+	std := &ast.UseDecl{Path: []string{"std", "fmt"}, PosV: token.Pos{Offset: 0}, EndV: token.Pos{Offset: len(stdSrc)}}
 	raw := &ast.UseDecl{RawPath: "github.com/acme/pkg"}
 	goFFI := &ast.UseDecl{IsGoFFI: true, GoPath: "net/http"}
+	views := useDeclViews([]*ast.UseDecl{std, raw, goFFI})
+	if len(views) != 3 {
+		t.Fatalf("view count = %d, want 3", len(views))
+	}
 
-	if got := useGroup(std); got != 0 {
+	if got := LSPUseGroup(views[0].IsFFI, views[0].Path); got != 0 {
 		t.Fatalf("std group = %d, want 0", got)
 	}
-	if got := useGroup(raw); got != 1 {
+	if got := LSPUseGroup(views[1].IsFFI, views[1].Path); got != 1 {
 		t.Fatalf("external group = %d, want 1", got)
 	}
-	if got := useGroup(goFFI); got != 2 {
+	if got := LSPUseGroup(views[2].IsFFI, views[2].Path); got != 2 {
 		t.Fatalf("go group = %d, want 2", got)
 	}
-	if got := useKey(std); got != "std.fmt" {
+	if got := LSPUseKey(views[0].IsFFI, views[0].FFIPath, views[0].RawPath, views[0].Path); got != "std.fmt" {
 		t.Fatalf("std key = %q", got)
 	}
-	if got := useKey(raw); got != "github.com/acme/pkg" {
+	if got := LSPUseKey(views[1].IsFFI, views[1].FFIPath, views[1].RawPath, views[1].Path); got != "github.com/acme/pkg" {
 		t.Fatalf("raw key = %q", got)
 	}
-	if got := useKey(goFFI); got != "net/http" {
+	if got := LSPUseKey(views[2].IsFFI, views[2].FFIPath, views[2].RawPath, views[2].Path); got != "net/http" {
 		t.Fatalf("go key = %q", got)
 	}
-	if got := keyWithAlias(1, "pkg", "alias"); got != "1|pkg|alias" {
+	if got := LSPKeyWithAlias(1, "pkg", "alias"); got != "1|pkg|alias" {
 		t.Fatalf("dedup key = %q", got)
 	}
 	sorted := sortImportEntries([]keyedUse{
-		{u: &ast.UseDecl{}, group: 1, key: "zeta"},
-		{u: &ast.UseDecl{}, group: 0, key: "fmt"},
-		{u: &ast.UseDecl{Alias: "b"}, group: 1, key: "alpha"},
-		{u: &ast.UseDecl{Alias: "a"}, group: 1, key: "alpha"},
+		{view: selfhost.LSPUseDeclView{}, group: 1, key: "zeta"},
+		{view: selfhost.LSPUseDeclView{}, group: 0, key: "fmt"},
+		{view: selfhost.LSPUseDeclView{Alias: "b"}, group: 1, key: "alpha"},
+		{view: selfhost.LSPUseDeclView{Alias: "a"}, group: 1, key: "alpha"},
 	})
-	if got := []string{sorted[0].key, sorted[1].u.Alias, sorted[2].u.Alias, sorted[3].key}; !reflect.DeepEqual(got, []string{"fmt", "a", "b", "zeta"}) {
+	if got := []string{sorted[0].key, sorted[1].view.Alias, sorted[2].view.Alias, sorted[3].key}; !reflect.DeepEqual(got, []string{"fmt", "a", "b", "zeta"}) {
 		t.Fatalf("import order = %#v", got)
 	}
-	if got := useSourceText([]byte("use std.fmt  \n"), std); got != "use std.fmt" {
+	if got := LSPUseSourceText(stdSrc, views[0].PosOffset, views[0].EndOffset); got != "use std.fmt" {
 		t.Fatalf("source text = %q", got)
 	}
-	if got := endOfLineOffset([]byte("use a  \r\nnext"), 5); got != 9 {
+	if got := LSPEndOfLineOffset([]byte("use a  \r\nnext"), 5); got != 9 {
 		t.Fatalf("line end = %d, want 9", got)
 	}
-	if hasTriviaBetweenUses([]byte("use a\n\nuse b"), []*ast.UseDecl{
-		{EndV: token.Pos{Offset: 5}},
-		{PosV: token.Pos{Offset: 7}},
-	}) {
+	gapOK := []selfhost.LSPUseDeclView{
+		{EndOffset: 5},
+		{PosOffset: 7},
+	}
+	if hasTriviaBetweenUseViews([]byte("use a\n\nuse b"), gapOK) {
 		t.Fatal("blank line gap should be safe")
 	}
-	if !hasTriviaBetweenUses([]byte("use a\n// note\nuse b"), []*ast.UseDecl{
-		{EndV: token.Pos{Offset: 5}},
-		{PosV: token.Pos{Offset: 13}},
-	}) {
+	gapBad := []selfhost.LSPUseDeclView{
+		{EndOffset: 5},
+		{PosOffset: 13},
+	}
+	if !hasTriviaBetweenUseViews([]byte("use a\n// note\nuse b"), gapBad) {
 		t.Fatal("comment gap should be treated as trivia")
 	}
 }

--- a/internal/mir/fuse_map_incr.go
+++ b/internal/mir/fuse_map_incr.go
@@ -14,7 +14,7 @@ package mir
 //   - lru-sim: `accessed.insert(key, accessed.getOr(key, 0) + 1)`
 //   - log-aggregator: `levelCounts.insert(level, levelCounts.getOr(level, 0) + 1)`
 //   - markdown-stats: `counts.insert(kind, counts.getOr(kind, 0) + 1)`
-//                     `chars.insert("heading", chars.getOr("heading", 0) + n)`
+//     `chars.insert("heading", chars.getOr("heading", 0) + n)`
 //
 // At the MIR level the user expression lowers to three instructions
 // in the same basic block, with two intermediate locals threading

--- a/internal/selfhost/lsp_policy.go
+++ b/internal/selfhost/lsp_policy.go
@@ -1,6 +1,9 @@
 package selfhost
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 type LSPSemanticToken struct {
 	Line      int
@@ -57,6 +60,35 @@ type LSPDiagnosticPayload struct {
 	Message  string
 }
 
+// LSPSymbolView is the value-typed snapshot the LSP policy layer
+// consumes when rendering hover / signature / completion text. The
+// extractor at the LSP boundary (which still holds *resolve.Symbol)
+// projects into this struct exactly once; every downstream formatter
+// stays pointer-free, which keeps the policy a candidate for
+// migration to toolchain/lsp.osty when the LLVM self-host LSP lands.
+type LSPSymbolView struct {
+	Name     string
+	Kind     string
+	TypeText string
+	DocText  string
+	HasSym   bool
+}
+
+// LSPUseDeclView is the value-typed projection of an *ast.UseDecl
+// the refactor / organize-imports policy consumes. PosOffset and
+// EndOffset cover the source range; the rest mirror the fields the
+// existing selfhost helpers (LSPUseGroup / LSPUseKey / LSPUseSourceText)
+// already accept as plain values.
+type LSPUseDeclView struct {
+	PosOffset int
+	EndOffset int
+	Path      []string
+	RawPath   string
+	Alias     string
+	IsFFI     bool
+	FFIPath   string
+}
+
 type LSPPosition struct {
 	Line      int
 	Character int
@@ -97,6 +129,26 @@ func LSPCompletionDetail(kind, label, typeText string) string {
 
 func LSPHoverSignatureLine(kind, name, typeText string) string {
 	return lspHoverSignatureLine(kind, name, typeText)
+}
+
+// LSPHoverMarkdown renders the markdown body shown on hover from a
+// pre-extracted symbol view. Wraps the signature line in an `osty`
+// fenced block and appends the doc comment when present; the no-sym
+// path emits the fallback identifier text alone.
+func LSPHoverMarkdown(view LSPSymbolView) string {
+	var b strings.Builder
+	b.WriteString("```osty\n")
+	if view.HasSym {
+		b.WriteString(LSPHoverSignatureLine(view.Kind, view.Name, view.TypeText))
+	} else {
+		b.WriteString(view.Name)
+	}
+	b.WriteString("\n```")
+	if view.HasSym && view.DocText != "" {
+		b.WriteString("\n\n")
+		b.WriteString(view.DocText)
+	}
+	return b.String()
 }
 
 func LSPPathToURI(path string) string {


### PR DESCRIPTION
## Summary

LSP self-host port Phase 0 — strip `*resolve.Symbol` / `*ast.UseDecl` pointer args from leaf consumer functions so the orchestration becomes trivially Osty-portable when the LLVM self-host LSP catches up. Adding more policy to `toolchain/lsp.osty` is unreachable for the Go LSP since #854 froze `internal/selfhost/generated.go`.

- **Phase 0a** (`handlers.go`): `hoverForSymbol` extracts via `hoverSymbolView` once; downstream is `selfhost.LSPHoverMarkdown(view)` value call. `writeSymSignature` deleted.
- **Phase 0b** (`completion.go`): `completionItemFromSym` splits into `completionSymbolView` + `completionItemFromView`. All policy (Kind/Detail/SortText/Documentation) goes through view.
- **Phase 0d** (`refactor.go`): `keyedUse.u *ast.UseDecl` → `keyedUse.view LSPUseDeclView`; `unusedUseSet map[*ast.UseDecl]bool` → `unusedUseOffsets map[int]bool`; 6 one-line shims removed in favor of direct `selfhost.LSP*` calls; `useDeclViews()` is the sole pointer-touch site.
- **`selfhost/lsp_policy.go`**: New `LSPSymbolView` + `LSPUseDeclView` value types, `LSPHoverMarkdown` formatter (signature line still delegates to existing Osty-backed `LSPHoverSignatureLine`).

Evaluated, deferred (separate design needed):
- `signature.go`: single `symbolDoc` call + `*types.FnType` / `*ast.FnDecl` pointer dependencies — refactor value low.
- `references.go`: `refs[id.ID] != target` pointer-identity comparison **is** the algorithm. Needs `SymbolID` or NodeID-based identity migration. `containsNode` `ast.Node(d) == decl` same family.

Also includes a **drive-by `gofmt -w`** on `benchmarks/programs/big-map/go/main.go` + `internal/mir/fuse_map_incr.go` (separate commit) — both files had landed on `origin/main` with 4-space indentation, breaking baseline `just prepush` fmt-check.

`SELFHOST_PORT_MATRIX.md` LSP section updated with phase landings + deferred items.

## Test plan
- [x] `just prepush` 로컬 통과 (fmt-check + vet + repair-check + ci)
- [x] `go test ./internal/lsp/ ./internal/selfhost/ -count=1` green
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) green
- [x] `TestHoverMarkdownWrapsSelfHostedPolicy` 추가
- [x] `TestImportOrganizeHelpersUseSelfHost` view 기반 재작성
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)