### PR TITLE
refactor(llvmgen): port 28 §3 / §6 builders + drain *all* inline declareRuntime strings

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -381,6 +381,33 @@ list keeps new Osty clean of known landmines.
 | `mirAllocaI64ZeroSlot` | `(slot: String) -> String` | §6 | Canonical "fresh i64 counter slot initialised to zero" preamble for linear-scan loops |
 | `mirAllocaI1FalseSlot` | `(slot: String) -> String` | §6 | Canonical "fresh i1 result slot initialised to false" preamble for IntrinsicListContains |
 | `mirStoreI1TrueLine` | `(slot: String) -> String` | §6 | `store i1 true, ptr <slot>` — IntrinsicListContains match arm flip |
+| `mirRuntimeDeclarePtrFromTwoPtrLine` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, ptr)` — two-ptr ABI shape (string-pair runtimes: Concat / Replace / Split, etc.) |
+| `mirRuntimeDeclareI64FromTwoPtrLine` | `(sym: String) -> String` | §3 | `declare i64 @<sym>(ptr, ptr)` — i64-from-two-ptr ABI (strings.Compare, bytes.IndexOf) |
+| `mirRuntimeDeclareI1FromTwoPtrLine` | `(sym: String) -> String` | §3 | `declare i1 @<sym>(ptr, ptr)` — i1-from-two-ptr predicate (strings.Equal, bytes.starts_with/ends_with) |
+| `mirRuntimeDeclarePtrFromPtrI64I64Line` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, i64, i64)` — slice-like ABI shape (strings.Substring, list.slice) |
+| `mirRuntimeDeclarePtrFromThreePtrLine` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, ptr, ptr)` — three-ptr ABI (strings.Replace) |
+| `mirRuntimeDeclarePtrFromPtrPtrI64Line` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, ptr, i64)` — (ptr, ptr, i64) ABI (strings.ReplaceN) |
+| `mirRuntimeDeclarePtrFromPtrI64PtrLine` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, i64, ptr)` — (ptr, i64, ptr) ABI |
+| `mirRuntimeDeclarePtrFromPtrI64Line` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(ptr, i64)` — (ptr, i64) ABI (list_primitive_to_string) |
+| `mirRuntimeDeclarePtrFromI64Line` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(i64)` — int-derived constructor shape |
+| `mirRuntimeDeclarePtrFromI64PtrLine` | `(sym: String) -> String` | §3 | `declare ptr @<sym>(i64, ptr)` — handle-with-context constructor |
+| `mirRuntimeDeclareEnumLayoutFromPtrLine` | `(sym: String) -> String` | §3 | `declare { i64, i64 } @<sym>(ptr)` — Option/Result-returning runtime (chan-recv) |
+| `mirRuntimeDeclareEnumLayoutNoArgsLine` | `(sym: String) -> String` | §3 | `declare { i64, i64 } @<sym>()` — zero-arg Option/Result-returning runtime (cancel-check) |
+| `mirRuntimeDeclareBytesV1GetLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr, i64, ptr, i64)` — bytes-v1 list-get/insert |
+| `mirRuntimeDeclareBytesV1PushLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr, ptr, i64)` — bytes-v1 list-push |
+| `mirRuntimeDeclareBytesV1SetWithBarrierLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr, i64, ptr, i64, ptr)` — bytes-v1 list-set + GC barrier |
+| `mirRuntimeDeclareThreePtrVoidLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr, ptr, ptr)` — used by `osty_rt_test_snapshot` |
+| `mirRuntimeDeclareTaskGroupSplitLine` | `(sym: String) -> String` | §3 | `declare void @<sym>(ptr, ptr, ptr, i64, ptr)` — task-group spawn 5-arg ABI |
+| `mirSubI64MinusOneLine` | `(reg: String, lenReg: String) -> String` | §6 | `<reg> = sub i64 <len>, 1` — len-1 step for IntrinsicListLast / IntrinsicListPop |
+| `mirAddI64PlusOneLine` | `(reg: String, iReg: String) -> String` | §6 | `<reg> = add i64 <i>, 1` — increment for linear-scan loop tails |
+| `mirLenGuardLines` | `(lenReg, isEmpty, lenSym, listReg) -> String` | §6 | "Is the list non-empty?" preamble: len call + eq-zero check (2-line block) |
+| `mirCallVoidPtrLine` | `(sym: String, ptr: String) -> String` | §6 | `call void @<sym>(ptr <ptr>)` — single-ptr-arg side-effect call |
+| `mirCallValueI64FromPtrLine` | `(reg, sym, ptr) -> String` | §6 | `<reg> = call i64 @<sym>(ptr <ptr>)` — single-handle scalar probe |
+| `mirCallValuePtrFromPtrLine` | `(reg, sym, ptr) -> String` | §6 | `<reg> = call ptr @<sym>(ptr <ptr>)` — single-handle ptr-returning call |
+| `mirCallValueI1FromPtrLine` | `(reg, sym, ptr) -> String` | §6 | `<reg> = call i1 @<sym>(ptr <ptr>)` — single-handle predicate call |
+| `mirRuntimeDeclareI8FromPtrI64Line` | `(sym: String) -> String` | §3 | `declare i8 @<sym>(ptr, i64)` — byte-typed list/bytes element-get shape |
+| `mirCallValueI8FromPtrI64Line` | `(reg, sym, ptr, idx) -> String` | §6 | `<reg> = call i8 @<sym>(ptr <ptr>, i64 <idx>)` — paired with i8 declare |
+| `mirCallValueElemFromPtrI64Line` | `(reg, elemLLVM, sym, ptr, idx) -> String` | §6 | Generalises i8 form for any element type — typed-element list-get runtime call |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2364,7 +2364,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 				}
 			}
 			sym := "osty_rt_list_set_" + listRuntimeSymbolSuffix(elemLLVM)
-			g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, "+elemLLVM+")")
+			g.declareRuntime(sym, mirRuntimeDeclareListSetSimpleLine(sym, elemLLVM))
 			g.fnBuf.WriteString(mirCallVoidLine(sym,
 				"ptr "+contReg+", i64 "+idxReg+", "+elemLLVM+" "+valReg))
 			return nil
@@ -2378,7 +2378,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 		g.flushOstyEmitter(em)
 		sizeReg := g.emitSizeOf(elemLLVM)
 		sym := "osty_rt_list_set_bytes_v1"
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareBytesV1SetWithBarrierLine(sym))
 		g.fnBuf.WriteString(mirCallVoidLine(sym,
 			"ptr "+contReg+", i64 "+idxReg+
 				", ptr "+valSlot.name+
@@ -2401,7 +2401,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 			return err
 		}
 		sym := mapRuntimeInsertSymbol(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareMapInsertLine(sym, keyLLVM))
 		em := g.ostyEmitter()
 		valSlot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: vReg})
 		llvmMapInsert(em,
@@ -2786,7 +2786,7 @@ func (g *mirGen) emitStdIoReadLineMIR(c *mir.CallInstr) error {
 	if len(c.Args) != 0 {
 		return unsupported("mir-mvp", "std.io.readLine requires no arguments")
 	}
-	g.declareRuntime(ostyRtIOReadLineSymbol, "declare ptr @"+ostyRtIOReadLineSymbol+"()")
+	g.declareRuntime(ostyRtIOReadLineSymbol, mirRuntimeDeclareLine("ptr", ostyRtIOReadLineSymbol, ""))
 	return g.emitCallSiteByName(c, ostyRtIOReadLineSymbol, "ptr", nil)
 }
 
@@ -2806,7 +2806,7 @@ func (g *mirGen) emitStdIoWriteArgsMIR(args []mir.Operand, method string) error 
 	if !ok {
 		return unsupported("mir-mvp", "unsupported std.io method "+method)
 	}
-	g.declareRuntime(ostyRtIOWriteSymbol, "declare void @"+ostyRtIOWriteSymbol+"(ptr, i1, i1)")
+	g.declareRuntime(ostyRtIOWriteSymbol, mirRuntimeDeclareLine("void", ostyRtIOWriteSymbol, "ptr, i1, i1"))
 	g.fnBuf.WriteString(mirCallVoidLine(ostyRtIOWriteSymbol,
 		"ptr "+text+", i1 "+llvmStdIoI1Text(newline)+", i1 "+llvmStdIoI1Text(toStderr)))
 	return nil
@@ -3211,7 +3211,7 @@ func testingListPrimitiveKind(t mir.Type) int {
 }
 
 func (g *mirGen) emitRuntimeListPrimitiveToStringMIR(reg string, kind int) (*LlvmValue, error) {
-	g.declareRuntime("osty_rt_list_primitive_to_string", "declare ptr @osty_rt_list_primitive_to_string(ptr, i64)")
+	g.declareRuntime("osty_rt_list_primitive_to_string", mirRuntimeDeclarePtrFromPtrI64Line("osty_rt_list_primitive_to_string"))
 	em := g.ostyEmitter()
 	out := llvmCall(em, "ptr", "osty_rt_list_primitive_to_string", []*LlvmValue{
 		{typ: "ptr", name: reg},
@@ -3222,7 +3222,7 @@ func (g *mirGen) emitRuntimeListPrimitiveToStringMIR(reg string, kind int) (*Llv
 }
 
 func (g *mirGen) emitRuntimeStringDiffMIR(left, right *LlvmValue) (*LlvmValue, error) {
-	g.declareRuntime("osty_rt_strings_DiffLines", "declare ptr @osty_rt_strings_DiffLines(ptr, ptr)")
+	g.declareRuntime("osty_rt_strings_DiffLines", mirRuntimeDeclarePtrFromTwoPtrLine("osty_rt_strings_DiffLines"))
 	em := g.ostyEmitter()
 	out := llvmCall(em, "ptr", "osty_rt_strings_DiffLines", []*LlvmValue{left, right})
 	g.flushOstyEmitter(em)
@@ -3291,7 +3291,7 @@ func (g *mirGen) emitTestingSnapshotMIR(c *mir.CallInstr) error {
 	if err != nil {
 		return err
 	}
-	g.declareRuntime("osty_rt_test_snapshot", "declare void @osty_rt_test_snapshot(ptr, ptr, ptr)")
+	g.declareRuntime("osty_rt_test_snapshot", mirRuntimeDeclareThreePtrVoidLine("osty_rt_test_snapshot"))
 	sourceSym := g.stringLiteral(g.source)
 	g.fnBuf.WriteString(mirCallVoidLine("osty_rt_test_snapshot",
 		"ptr "+name+", ptr "+output+", ptr "+sourceSym))
@@ -4095,23 +4095,21 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// `mir*Line` builders so the LLVM-text shapes line up with the
 		// streq port's call style. SSA / label numbering unchanged.
 		lenReg := g.fresh()
-		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		isEmpty := g.fresh()
-		g.fnBuf.WriteString(mirICmpEqI64Line(isEmpty, lenReg, "0"))
+		g.fnBuf.WriteString(mirLenGuardLines(lenReg, isEmpty, lenSym, listReg))
 		someLabel := g.freshLabel("list.opt.some")
 		noneLabel := g.freshLabel("list.opt.none")
 		endLabel := g.freshLabel("list.opt.end")
 		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(destLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		var idxRef string
 		if i.Kind == mir.IntrinsicListFirst {
 			idxRef = "0"
 		} else {
 			idxRef = g.fresh()
-			g.fnBuf.WriteString(mirSubI64Line(idxRef, lenReg, "1"))
+			g.fnBuf.WriteString(mirSubI64MinusOneLine(idxRef, lenReg))
 		}
 		elemReg, err := g.emitListLoadElement(listReg, idxRef, elemLLVM)
 		if err != nil {
@@ -4162,7 +4160,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := listRuntimeSliceSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrI64I64Line(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: listReg},
@@ -4184,7 +4182,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		spliceSym := "osty_rt_list_remove_at_discard"
-		g.declareRuntime(spliceSym, "declare void @"+spliceSym+"(ptr, i64)")
+		g.declareRuntime(spliceSym, mirRuntimeDeclareLine("void", spliceSym, "ptr, i64"))
 		elemReg, err := g.emitListLoadElement(listReg, idxReg, elemLLVM)
 		if err != nil {
 			return err
@@ -4229,7 +4227,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// Linear-scan loop emission via Osty-sourced builders. Pre-store
 		// None into dest; iterate, on first match overwrite with Some(idx).
 		lenReg := g.fresh()
-		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirCallValueI64FromPtrLine(lenReg, lenSym, listReg))
 		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
 		iSlot := g.fresh()
 		g.fnBuf.WriteString(mirAllocaI64ZeroSlot(iSlot))
@@ -4239,12 +4237,9 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		contLabel := g.freshLabel("list.indexof.cont")
 		endLabel := g.freshLabel("list.indexof.end")
 		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
-		g.fnBuf.WriteString(mirLabelLine(headLabel))
 		iReg := g.fresh()
-		g.fnBuf.WriteString(mirLoadLine(iReg, "i64", iSlot))
 		cont := g.fresh()
-		g.fnBuf.WriteString(mirICmpLine(cont, "slt", "i64", iReg, lenReg))
-		g.fnBuf.WriteString(mirBrCondLine(cont, bodyLabel, endLabel))
+		g.fnBuf.WriteString(mirLinearScanLoopHeadLines(headLabel, iReg, iSlot, cont, lenReg, bodyLabel, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(bodyLabel))
 		elemReg := g.fresh()
 		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
@@ -4301,7 +4296,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// false into dest; iterate, on first match overwrite with true
 		// and break to end.
 		lenReg := g.fresh()
-		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirCallValueI64FromPtrLine(lenReg, lenSym, listReg))
 		g.fnBuf.WriteString(mirStoreLine("i1", "false", destSlot))
 		iSlot := g.fresh()
 		g.fnBuf.WriteString(mirAllocaI64ZeroSlot(iSlot))
@@ -4311,12 +4306,9 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		contLabel := g.freshLabel("list.contains.cont")
 		endLabel := g.freshLabel("list.contains.end")
 		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
-		g.fnBuf.WriteString(mirLabelLine(headLabel))
 		iReg := g.fresh()
-		g.fnBuf.WriteString(mirLoadLine(iReg, "i64", iSlot))
 		cont := g.fresh()
-		g.fnBuf.WriteString(mirICmpLine(cont, "slt", "i64", iReg, lenReg))
-		g.fnBuf.WriteString(mirBrCondLine(cont, bodyLabel, endLabel))
+		g.fnBuf.WriteString(mirLinearScanLoopHeadLines(headLabel, iReg, iSlot, cont, lenReg, bodyLabel, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(bodyLabel))
 		elemReg := g.fresh()
 		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
@@ -4330,13 +4322,10 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		g.fnBuf.WriteString(mirBrCondLine(eqReg, matchLabel, contLabel))
 		g.fnBuf.WriteString(mirLabelLine(matchLabel))
-		g.fnBuf.WriteString(mirStoreLine("i1", "true", destSlot))
+		g.fnBuf.WriteString(mirStoreI1TrueLine(destSlot))
 		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
-		g.fnBuf.WriteString(mirLabelLine(contLabel))
 		next := g.fresh()
-		g.fnBuf.WriteString(mirAddI64Line(next, iReg, "1"))
-		g.fnBuf.WriteString(mirStoreLine("i64", next, iSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(headLabel))
+		g.fnBuf.WriteString(mirLinearScanLoopTailLines(contLabel, next, iReg, iSlot, headLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicListPop:
@@ -4347,16 +4336,16 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// returned value via `list_get_<kind>(list, len-1)` before the
 		// discard so the element is captured.
 		discardSym := "osty_rt_list_pop_discard"
-		g.declareRuntime(discardSym, "declare void @"+discardSym+"(ptr)")
+		g.declareRuntime(discardSym, mirRuntimeDeclareVoidFromPtrLine(discardSym))
 		if i.Dest == nil {
 			// Statement-position `xs.pop()` with no dest: fall back
 			// to the classic discard-and-abort path.
-			g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
+			g.fnBuf.WriteString(mirCallVoidPtrLine(discardSym, listReg))
 			return nil
 		}
 		destLoc := g.fn.Local(i.Dest.Local)
 		if destLoc == nil {
-			g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
+			g.fnBuf.WriteString(mirCallVoidPtrLine(discardSym, listReg))
 			return nil
 		}
 		destLLVM := g.llvmType(destLoc.Type)
@@ -4364,24 +4353,22 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		lenSym := listRuntimeLenSymbol()
 		g.declareRuntime(lenSym, mirRuntimeDeclareMemoryRead("i64", lenSym, "ptr"))
 		lenReg := g.fresh()
-		g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
 		isEmpty := g.fresh()
-		g.fnBuf.WriteString(mirICmpEqI64Line(isEmpty, lenReg, "0"))
+		g.fnBuf.WriteString(mirLenGuardLines(lenReg, isEmpty, lenSym, listReg))
 		someLabel := g.freshLabel("list.pop.some")
 		noneLabel := g.freshLabel("list.pop.none")
 		endLabel := g.freshLabel("list.pop.end")
 		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
-		g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(destLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		lastIdx := g.fresh()
-		g.fnBuf.WriteString(mirSubI64Line(lastIdx, lenReg, "1"))
+		g.fnBuf.WriteString(mirSubI64MinusOneLine(lastIdx, lenReg))
 		elemReg, err := g.emitListLoadElement(listReg, lastIdx, elemLLVM)
 		if err != nil {
 			return err
 		}
-		g.fnBuf.WriteString(mirCallVoidLine(discardSym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirCallVoidPtrLine(discardSym, listReg))
 		payloadReg, err := g.listOptionalPayloadToI64(elemReg, elemLLVM, elemT)
 		if err != nil {
 			return unsupported("mir-mvp", fmt.Sprintf("list_pop payload widen unsupported for %s", elemLLVM))
@@ -4407,7 +4394,7 @@ func (g *mirGen) emitListLoadElement(listReg, idxReg string, elemLLVM string) (s
 	g.fnBuf.WriteString(mirAllocaLine(slot, elemLLVM))
 	sizeReg := g.emitSizeOf(elemLLVM)
 	sym := listRuntimeGetBytesV1Symbol()
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+	g.declareRuntime(sym, mirRuntimeDeclareBytesV1GetLine(sym))
 	g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg+", i64 "+idxReg+", ptr "+slot+", i64 "+sizeReg))
 	elemReg := g.fresh()
 	g.fnBuf.WriteString(mirLoadLine(elemReg, elemLLVM, slot))
@@ -4469,7 +4456,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", fmt.Sprintf("map_new unsupported value type %s", valLLVM))
 		}
 		sym := "osty_rt_map_new"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i64, i64, i64, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("ptr", sym, "i64, i64, i64, ptr"))
 		args := []string{
 			fmt.Sprintf("i64 %d", keyKind),
 			fmt.Sprintf("i64 %d", valKind),
@@ -4513,7 +4500,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := mapRuntimeContainsSymbol(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+keyLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareMapContainsLine(sym, keyLLVM))
 		em := g.ostyEmitter()
 		result := llvmMapContains(em,
 			&LlvmValue{typ: "ptr", name: mapReg},
@@ -4642,7 +4629,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		vLLVM := g.llvmType(vOp.Type())
 		sym := mapRuntimeInsertSymbol(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareMapInsertLine(sym, keyLLVM))
 		// Spill the value into a stack slot so the runtime can memcpy
 		// value_size bytes from it. This replaces the old inttoptr
 		// widening shim, which was semantically wrong for primitives
@@ -4678,7 +4665,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := mapRuntimeIncrI64Symbol(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, "+keyLLVM+", i64)")
+		g.declareRuntime(sym, mirRuntimeDeclareMapIncrLine(sym, keyLLVM))
 		tmp := g.fresh()
 		g.fnBuf.WriteString(mirCallI64MapKeyDeltaLine(tmp, sym, mapReg, keyLLVM, kReg, dReg))
 		if i.Dest != nil {
@@ -4697,7 +4684,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		// Runtime returns i1 (true = was present); MIR ignores it — the
 		// temp fall-through to DCE is fine but the decl must match the
 		// C runtime so the verifier accepts the call.
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+keyLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareMapContainsLine(sym, keyLLVM))
 		em := g.ostyEmitter()
 		_ = llvmMapRemove(em,
 			&LlvmValue{typ: "ptr", name: mapReg},
@@ -4718,7 +4705,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		sym := "osty_rt_map_keys_sorted_" + suffix
 		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		tmp := g.fresh()
-		g.fnBuf.WriteString(mirCallValueLine(tmp, "ptr", sym, "ptr "+mapReg))
+		g.fnBuf.WriteString(mirCallValuePtrFromPtrLine(tmp, sym, mapReg))
 		if i.Dest != nil {
 			g.fnBuf.WriteString(mirStorePtrLine(tmp, g.localSlots[i.Dest.Local]))
 		}
@@ -4739,7 +4726,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 // `m.get(k)` and `m[k]` can't drift in ABI.
 func (g *mirGen) emitMapGetOrAbort(mapReg, keyReg, keyLLVM string, keyString bool, valLLVM, outSlot string) string {
 	sym := mapRuntimeGetOrAbortSymbol(keyLLVM, keyString)
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclareMapInsertLine(sym, keyLLVM))
 	em := g.ostyEmitter()
 	var slot *LlvmValue
 	ownsSlot := outSlot == ""
@@ -4771,7 +4758,7 @@ func (g *mirGen) emitMapGetOrAbort(mapReg, keyReg, keyLLVM string, keyString boo
 // ABI (mirrors the `emitMapGetOrAbort` sharing rationale).
 func (g *mirGen) emitMapGetProbe(mapReg, keyReg, keyLLVM string, keyString bool, valLLVM string) (present, slot string) {
 	getSym := mapRuntimeGetSymbol(keyLLVM, keyString)
-	g.declareRuntime(getSym, "declare i1 @"+getSym+"(ptr, "+keyLLVM+", ptr)")
+	g.declareRuntime(getSym, mirRuntimeDeclareMapGetLine(getSym, keyLLVM))
 	slot = g.fresh()
 	g.fnBuf.WriteString(mirAllocaLine(slot, valLLVM))
 	present = g.fresh()
@@ -4828,7 +4815,7 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := setRuntimeContainsSymbol(elemLLVM, elemString)
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("i1", sym, "ptr, "+elemLLVM))
 		em := g.ostyEmitter()
 		result := llvmSetContains(em,
 			&LlvmValue{typ: "ptr", name: setReg},
@@ -4848,7 +4835,7 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 		// Runtime returns i1 (true = newly added); MIR discards the
 		// result when this intrinsic is used as a statement. Decl must
 		// match the C runtime — the temp ends up DCE'd.
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("i1", sym, "ptr, "+elemLLVM))
 		em := g.ostyEmitter()
 		_ = llvmSetInsert(em,
 			&LlvmValue{typ: "ptr", name: setReg},
@@ -4865,7 +4852,7 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := setRuntimeRemoveSymbol(elemLLVM, elemString)
-		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("i1", sym, "ptr, "+elemLLVM))
 		em := g.ostyEmitter()
 		result := llvmSetRemove(em,
 			&LlvmValue{typ: "ptr", name: setReg},
@@ -4926,8 +4913,8 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		lenSym := "osty_rt_bytes_len"
 		getSym := "osty_rt_bytes_get"
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr)")
-		g.declareRuntime(getSym, "declare i8 @"+getSym+"(ptr, i64)")
+		g.declareRuntime(lenSym, mirRuntimeDeclareI64FromPtrLine(lenSym))
+		g.declareRuntime(getSym, mirRuntimeDeclareLine("i8", getSym, "ptr, i64"))
 		em := g.ostyEmitter()
 		length := llvmCall(em, "i64", lenSym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
 		nonNegative := llvmCompare(em, "sge", &LlvmValue{typ: "i64", name: idxReg}, llvmIntLiteral(0))
@@ -4975,7 +4962,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_index_of"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		index := llvmCall(em, "i64", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -4993,7 +4980,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_index_of"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		index := llvmCall(em, "i64", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5012,8 +4999,8 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		lastSym := "osty_rt_bytes_last_index_of"
 		lenSym := "osty_rt_bytes_len"
-		g.declareRuntime(lastSym, "declare i64 @"+lastSym+"(ptr, ptr)")
-		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr)")
+		g.declareRuntime(lastSym, mirRuntimeDeclareI64FromTwoPtrLine(lastSym))
+		g.declareRuntime(lenSym, mirRuntimeDeclareI64FromPtrLine(lenSym))
 		em := g.ostyEmitter()
 		index := llvmCall(em, "i64", lastSym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5048,7 +5035,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_index_of"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		index := llvmCall(em, "i64", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5101,7 +5088,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_last_index_of"
-		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		index := llvmCall(em, "i64", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5143,7 +5130,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_split"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5160,7 +5147,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_join"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: partsReg},
@@ -5177,7 +5164,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_concat"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5194,7 +5181,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_repeat"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrI64Line(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5215,7 +5202,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_replace"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromThreePtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5237,7 +5224,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_replace_all"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromThreePtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5255,7 +5242,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_trim_left"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5272,7 +5259,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_trim_right"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5289,7 +5276,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_trim"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5358,7 +5345,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_bytes_slice"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrI64I64Line(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{
 			{typ: "ptr", name: bytesReg},
@@ -5427,7 +5414,7 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		if len(parts) == 2 {
 			sym := llvmStringRuntimeConcatSymbol()
-			g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+			g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 			em := g.ostyEmitter()
 			out := llvmStringConcat(em, parts[0], parts[1])
 			g.flushOstyEmitter(em)
@@ -5533,7 +5520,7 @@ func (g *mirGen) emitStringIndexOf(i *mir.IntrinsicInstr, strReg string) error {
 		return err
 	}
 	sym := llvmStringRuntimeIndexOfSymbol()
-	g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
 	em := g.ostyEmitter()
 	index := llvmCall(em, "i64", sym, []*LlvmValue{
 		{typ: "ptr", name: strReg},
@@ -5599,7 +5586,7 @@ func (g *mirGen) emitStringSubstring(i *mir.IntrinsicInstr, strReg string) error
 		return err
 	}
 	sym := "osty_rt_strings_Slice"
-	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+	g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrI64I64Line(sym))
 	em := g.ostyEmitter()
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{
 		{typ: "ptr", name: strReg},
@@ -5627,7 +5614,7 @@ func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
 		return err
 	}
 	sym := llvmStringRuntimeJoinSymbol()
-	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 	em := g.ostyEmitter()
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: partsReg}, {typ: "ptr", name: sepReg}})
 	g.flushOstyEmitter(em)
@@ -5636,7 +5623,7 @@ func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
 
 func (g *mirGen) emitStringConcatN(parts []*LlvmValue) *LlvmValue {
 	sym := "osty_rt_strings_ConcatN"
-	g.declareRuntime(sym, "declare ptr @"+sym+"(i64, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclarePtrFromI64PtrLine(sym))
 	em := g.ostyEmitter()
 	arr := llvmNextTemp(em)
 	em.body = append(em.body, fmt.Sprintf("  %s = alloca [%d x ptr]", arr, len(parts)))
@@ -5674,7 +5661,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 			return nil, err
 		}
 		sym := llvmIntRuntimeToStringSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromI64Line(sym))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i64", name: reg}})
 		g.flushOstyEmitter(em)
@@ -5685,7 +5672,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 			return nil, err
 		}
 		sym := "osty_rt_char_to_string"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i32)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "i32"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i32", name: reg}})
 		g.flushOstyEmitter(em)
@@ -5696,7 +5683,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 			return nil, err
 		}
 		sym := "osty_rt_byte_to_string"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i8)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "i8"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i8", name: reg}})
 		g.flushOstyEmitter(em)
@@ -5707,7 +5694,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 			return nil, err
 		}
 		sym := llvmBoolRuntimeToStringSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i1)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "i1"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i1", name: reg}})
 		g.flushOstyEmitter(em)
@@ -5718,7 +5705,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 			return nil, err
 		}
 		sym := llvmFloatRuntimeToStringSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(double)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "double"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "double", name: reg}})
 		g.flushOstyEmitter(em)
@@ -5744,7 +5731,7 @@ func (g *mirGen) emitStringSplit(i *mir.IntrinsicInstr, strReg string) error {
 		return err
 	}
 	sym := llvmStringRuntimeSplitSymbol()
-	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclarePtrFromTwoPtrLine(sym))
 	em := g.ostyEmitter()
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}, {typ: "ptr", name: sepReg}})
 	g.flushOstyEmitter(em)
@@ -5782,7 +5769,7 @@ func (g *mirGen) emitStringSplitInto(i *mir.IntrinsicInstr) error {
 		return err
 	}
 	sym := "osty_rt_strings_SplitInto"
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclareThreePtrVoidLine(sym))
 	em := g.ostyEmitter()
 	em.body = append(em.body, fmt.Sprintf("  call void @%s(ptr %s, ptr %s, ptr %s)", sym, outReg, valReg, sepReg))
 	g.flushOstyEmitter(em)
@@ -5818,7 +5805,7 @@ func (g *mirGen) emitStringNthSegment(i *mir.IntrinsicInstr) error {
 		return err
 	}
 	sym := "osty_rt_strings_NthSegment"
-	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr, i64)")
+	g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrPtrI64Line(sym))
 	em := g.ostyEmitter()
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{
 		{typ: "ptr", name: valReg},
@@ -5847,7 +5834,7 @@ func (g *mirGen) emitStringBinaryBoolIntrinsic(i *mir.IntrinsicInstr, strReg, sy
 	if err != nil {
 		return err
 	}
-	g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclareI1FromTwoPtrLine(sym))
 	em := g.ostyEmitter()
 	result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: strReg}, {typ: "ptr", name: argReg}})
 	g.flushOstyEmitter(em)
@@ -5867,8 +5854,8 @@ func (g *mirGen) emitStringParseResultIntrinsic(i *mir.IntrinsicInstr, strReg, v
 		return unsupported("mir-mvp", "string parse dest is not Result")
 	}
 	resultLLVM := g.llvmType(destLoc.Type)
-	g.declareRuntime(validateSym, "declare i1 @"+validateSym+"(ptr)")
-	g.declareRuntime(parseSym, "declare "+parseLLVM+" @"+parseSym+"(ptr)")
+	g.declareRuntime(validateSym, mirRuntimeDeclareI1FromPtrLine(validateSym))
+	g.declareRuntime(parseSym, mirRuntimeDeclareLine(parseLLVM, parseSym, "ptr"))
 
 	em := g.ostyEmitter()
 	valid := llvmCall(em, "i1", validateSym, []*LlvmValue{{typ: "ptr", name: strReg}})
@@ -5932,7 +5919,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := llvmChanRuntimeMakeSymbol()
-		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromI64Line(sym))
 		em := g.ostyEmitter()
 		result := llvmChanMake(em, &LlvmValue{typ: "i64", name: capReg})
 		g.flushOstyEmitter(em)
@@ -5959,7 +5946,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 		chanVal := &LlvmValue{typ: "ptr", name: chReg}
 		if listUsesTypedRuntime(elemLLVM) {
 			sym := llvmChanRuntimeSendSymbol(llvmListElementSuffix(elemLLVM))
-			g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
+			g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, "ptr, "+elemLLVM))
 			em := g.ostyEmitter()
 			llvmChanSend(em, chanVal, &LlvmValue{typ: elemLLVM, name: valReg})
 			g.flushOstyEmitter(em)
@@ -5967,7 +5954,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		// Composite element — bytes fallback.
 		sym := llvmChanRuntimeSendBytesSymbol()
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
+		g.declareRuntime(sym, mirRuntimeDeclareBytesV1PushLine(sym))
 		em := g.ostyEmitter()
 		slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: valReg})
 		size := llvmSizeOf(em, elemLLVM)
@@ -5992,7 +5979,7 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		elemLLVM := g.llvmType(elemT)
 		sym := llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemLLVM))
-		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareEnumLayoutFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmChanRecv(em, &LlvmValue{typ: "ptr", name: chReg}, elemLLVM)
 		if i.Dest == nil {
@@ -6076,7 +6063,7 @@ func (g *mirGen) emitTaskIntrinsic(i *mir.IntrinsicInstr) error {
 			}
 		}
 		sym := "osty_rt_task_group"
-		g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareLine(retLLVM, sym, "ptr"))
 		return g.emitSimpleCall(i, sym, retLLVM, []string{"ptr " + arg})
 	case mir.IntrinsicSpawn:
 		// One-arg form: detached spawn(body). Two-arg form:
@@ -6117,7 +6104,7 @@ func (g *mirGen) emitTaskIntrinsic(i *mir.IntrinsicInstr) error {
 			}
 		}
 		sym := "osty_rt_task_handle_join"
-		g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareLine(retLLVM, sym, "ptr"))
 		return g.emitSimpleCall(i, sym, retLLVM, []string{"ptr " + handle})
 	case mir.IntrinsicGroupCancel:
 		if len(i.Args) != 1 {
@@ -6198,7 +6185,7 @@ func (g *mirGen) emitSelectSend(i *mir.IntrinsicInstr) error {
 	if listUsesTypedRuntime(elemLLVM) {
 		suffix := llvmListElementSuffix(elemLLVM)
 		sym := "osty_rt_select_send_" + suffix
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, "+elemLLVM+", ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, "ptr, ptr, "+elemLLVM+", ptr"))
 		g.fnBuf.WriteString(mirCallVoidLine(sym,
 			"ptr "+builderReg+", ptr "+chReg+
 				", "+elemLLVM+" "+valReg+", ptr "+armReg))
@@ -6207,7 +6194,7 @@ func (g *mirGen) emitSelectSend(i *mir.IntrinsicInstr) error {
 	// Composite element — bytes_v1 route. Spill value to a stack slot,
 	// hand the runtime a (ptr, size) pair; it copies into GC storage.
 	sym := "osty_rt_select_send_bytes_v1"
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, ptr, i64, ptr)")
+	g.declareRuntime(sym, mirRuntimeDeclareTaskGroupSplitLine(sym))
 	em := g.ostyEmitter()
 	slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: valReg})
 	size := llvmSizeOf(em, elemLLVM)
@@ -6226,13 +6213,13 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicIsCancelled:
 		sym := "osty_rt_cancel_is_cancelled"
-		g.declareRuntime(sym, "declare i1 @"+sym+"()")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("i1", sym, ""))
 		return g.emitSimpleCall(i, sym, "i1", nil)
 	case mir.IntrinsicCheckCancelled:
 		// Returns Result<(), Error> — runtime uses the `{i64, i64}`
 		// enum layout like chan_recv.
 		sym := "osty_rt_cancel_check_cancelled"
-		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"()")
+		g.declareRuntime(sym, mirRuntimeDeclareEnumLayoutNoArgsLine(sym))
 		if i.Dest == nil {
 			g.fnBuf.WriteString(mirCallStmtNoArgsLine("{ i64, i64 }", sym))
 			return nil
@@ -6243,7 +6230,7 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 		return nil
 	case mir.IntrinsicYield:
 		sym := "osty_rt_thread_yield"
-		g.declareRuntime(sym, "declare void @"+sym+"()")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, ""))
 		g.fnBuf.WriteString(mirCallVoidNoArgsLine(sym))
 		return nil
 	case mir.IntrinsicSleep:
@@ -6285,7 +6272,7 @@ func (g *mirGen) emitConcurrencyHelperIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_parallel"
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrI64PtrLine(sym))
 		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + items, "i64 " + conc, "ptr " + f})
 	case mir.IntrinsicRace:
 		// Returns Result<T, Error> — runtime uses the `{i64, i64}` enum
@@ -6298,7 +6285,7 @@ func (g *mirGen) emitConcurrencyHelperIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		sym := "osty_rt_task_race"
-		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"(ptr)")
+		g.declareRuntime(sym, mirRuntimeDeclareEnumLayoutFromPtrLine(sym))
 		argList := "ptr " + body
 		if i.Dest == nil {
 			g.fnBuf.WriteString(mirCallStmtLine("{ i64, i64 }", sym, argList))
@@ -6334,7 +6321,7 @@ func (g *mirGen) emitSimpleConcurrencyCall(i *mir.IntrinsicInstr, sym, retLLVM s
 	for idx := range paramParts {
 		paramParts[idx] = "ptr"
 	}
-	g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"("+strings.Join(paramParts, ", ")+")")
+	g.declareRuntime(sym, mirRuntimeDeclareLine(retLLVM, sym, strings.Join(paramParts, ", ")))
 	return g.emitSimpleCall(i, sym, retLLVM, argParts)
 }
 
@@ -6345,7 +6332,7 @@ func (g *mirGen) emitRuntimeVoidCall(i *mir.IntrinsicInstr, sym, argLLVM string)
 	if err != nil {
 		return err
 	}
-	g.declareRuntime(sym, "declare void @"+sym+"("+argLLVM+")")
+	g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, argLLVM))
 	g.fnBuf.WriteString(mirCallVoidLine(sym, argLLVM+" "+val))
 	return nil
 }
@@ -7117,7 +7104,7 @@ func (g *mirGen) emitListLiteral(rv *mir.AggregateRV, aggT mir.Type) (string, er
 	if elemT == nil {
 		return "", unsupported("mir-mvp", "list literal: missing element type")
 	}
-	g.declareRuntime(listRuntimeNewSymbol(), "declare ptr @"+listRuntimeNewSymbol()+"()")
+	g.declareRuntime(listRuntimeNewSymbol(), mirRuntimeDeclareLine("ptr", listRuntimeNewSymbol(), ""))
 	em := g.ostyEmitter()
 	listVal := llvmListNew(em)
 	g.flushOstyEmitter(em)
@@ -7140,7 +7127,7 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 	elemLLVM := g.llvmType(elemT)
 	if listUsesTypedRuntime(elemLLVM) {
 		sym := listRuntimePushSymbol(elemLLVM)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
+		g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, "ptr, "+elemLLVM))
 		em := g.ostyEmitter()
 		llvmListPush(em,
 			&LlvmValue{typ: "ptr", name: listReg, pointer: false},
@@ -7152,7 +7139,7 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 	// compute the size via the `getelementptr null, 1` idiom, and
 	// call the bytes helper.
 	sym := listRuntimePushBytesV1Symbol()
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
+	g.declareRuntime(sym, mirRuntimeDeclareBytesV1PushLine(sym))
 	em := g.ostyEmitter()
 	slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: val})
 	size := llvmSizeOf(em, elemLLVM)
@@ -7183,7 +7170,7 @@ func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLV
 	getSym := listRuntimeGetSymbol(elemLLVM)
 	g.declareRuntime(getSym, mirRuntimeDeclareMemoryRead(elemLLVM, getSym, "ptr, i64"))
 	lenReg := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg))
+	g.fnBuf.WriteString(mirCallValueI64FromPtrLine(lenReg, lenSym, listReg))
 	nonNeg := g.fresh()
 	g.fnBuf.WriteString(mirICmpLine(nonNeg, "sge", "i64", idxReg, "0"))
 	inUpper := g.fresh()
@@ -7228,7 +7215,7 @@ func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLV
 func (g *mirGen) emitListGetBytes(i *mir.IntrinsicInstr, listReg, idxReg string, elemT mir.Type) error {
 	elemLLVM := g.llvmType(elemT)
 	sym := listRuntimeGetBytesV1Symbol()
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+	g.declareRuntime(sym, mirRuntimeDeclareBytesV1GetLine(sym))
 	em := g.ostyEmitter()
 	slot := llvmAllocaSlot(em, elemLLVM)
 	size := llvmSizeOf(em, elemLLVM)
@@ -7520,7 +7507,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 					}
 				}
 				sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
-				g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
+				g.declareRuntime(sym, mirRuntimeDeclareLine(elemLLVM, sym, "ptr, i64"))
 				next := g.fresh()
 				g.fnBuf.WriteString(mirCallValueLine(next, elemLLVM, sym,
 					"ptr "+curReg+", i64 "+idxVal))
@@ -7534,7 +7521,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 			g.fnBuf.WriteString(mirAllocaLine(slot, elemLLVM))
 			sizeReg := g.emitSizeOf(elemLLVM)
 			sym := "osty_rt_list_get_bytes_v1"
-			g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+			g.declareRuntime(sym, mirRuntimeDeclareBytesV1GetLine(sym))
 			g.fnBuf.WriteString(mirCallVoidLine(sym,
 				"ptr "+curReg+", i64 "+idxVal+", ptr "+slot+", i64 "+sizeReg))
 			loaded := g.fresh()

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -2827,3 +2827,175 @@ func mirAllocaI1FalseSlot(slot string) string {
 func mirStoreI1TrueLine(slot string) string {
 	return mirStoreLine("i1", "true", slot)
 }
+
+// §3 runtime-declare canonical-shape builders (continued).
+
+// mirRuntimeDeclarePtrFromTwoPtrLine renders `declare ptr @<sym>(ptr, ptr)`.
+// Osty: mirRuntimeDeclarePtrFromTwoPtrLine
+func mirRuntimeDeclarePtrFromTwoPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, ptr")
+}
+
+// mirRuntimeDeclareI64FromTwoPtrLine renders `declare i64 @<sym>(ptr, ptr)`.
+// Osty: mirRuntimeDeclareI64FromTwoPtrLine
+func mirRuntimeDeclareI64FromTwoPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("i64", sym, "ptr, ptr")
+}
+
+// mirRuntimeDeclareI1FromTwoPtrLine renders `declare i1 @<sym>(ptr, ptr)`.
+// Osty: mirRuntimeDeclareI1FromTwoPtrLine
+func mirRuntimeDeclareI1FromTwoPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("i1", sym, "ptr, ptr")
+}
+
+// mirRuntimeDeclarePtrFromPtrI64I64Line renders `declare ptr @<sym>(ptr, i64, i64)`.
+// Osty: mirRuntimeDeclarePtrFromPtrI64I64Line
+func mirRuntimeDeclarePtrFromPtrI64I64Line(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, i64, i64")
+}
+
+// mirRuntimeDeclarePtrFromThreePtrLine renders `declare ptr @<sym>(ptr, ptr, ptr)`.
+// Osty: mirRuntimeDeclarePtrFromThreePtrLine
+func mirRuntimeDeclarePtrFromThreePtrLine(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, ptr, ptr")
+}
+
+// mirRuntimeDeclarePtrFromPtrPtrI64Line renders `declare ptr @<sym>(ptr, ptr, i64)`.
+// Osty: mirRuntimeDeclarePtrFromPtrPtrI64Line
+func mirRuntimeDeclarePtrFromPtrPtrI64Line(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, ptr, i64")
+}
+
+// mirRuntimeDeclarePtrFromPtrI64PtrLine renders `declare ptr @<sym>(ptr, i64, ptr)`.
+// Osty: mirRuntimeDeclarePtrFromPtrI64PtrLine
+func mirRuntimeDeclarePtrFromPtrI64PtrLine(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, i64, ptr")
+}
+
+// mirRuntimeDeclarePtrFromPtrI64Line renders `declare ptr @<sym>(ptr, i64)`.
+// Osty: mirRuntimeDeclarePtrFromPtrI64Line
+func mirRuntimeDeclarePtrFromPtrI64Line(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "ptr, i64")
+}
+
+// mirRuntimeDeclarePtrFromI64Line renders `declare ptr @<sym>(i64)`.
+// Osty: mirRuntimeDeclarePtrFromI64Line
+func mirRuntimeDeclarePtrFromI64Line(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "i64")
+}
+
+// mirRuntimeDeclarePtrFromI64PtrLine renders `declare ptr @<sym>(i64, ptr)`.
+// Osty: mirRuntimeDeclarePtrFromI64PtrLine
+func mirRuntimeDeclarePtrFromI64PtrLine(sym string) string {
+	return mirRuntimeDeclareLine("ptr", sym, "i64, ptr")
+}
+
+// mirRuntimeDeclareEnumLayoutFromPtrLine renders `declare { i64, i64 } @<sym>(ptr)`.
+// Osty: mirRuntimeDeclareEnumLayoutFromPtrLine
+func mirRuntimeDeclareEnumLayoutFromPtrLine(sym string) string {
+	return mirRuntimeDeclareLine("{ i64, i64 }", sym, "ptr")
+}
+
+// mirRuntimeDeclareEnumLayoutNoArgsLine renders `declare { i64, i64 } @<sym>()`.
+// Osty: mirRuntimeDeclareEnumLayoutNoArgsLine
+func mirRuntimeDeclareEnumLayoutNoArgsLine(sym string) string {
+	return mirRuntimeDeclareLine("{ i64, i64 }", sym, "")
+}
+
+// mirRuntimeDeclareBytesV1GetLine renders the bytes-v1 list-get
+// runtime decl `void @<sym>(ptr, i64, ptr, i64)`.
+// Osty: mirRuntimeDeclareBytesV1GetLine
+func mirRuntimeDeclareBytesV1GetLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, i64, ptr, i64")
+}
+
+// mirRuntimeDeclareBytesV1PushLine renders the bytes-v1 list-push
+// runtime decl `void @<sym>(ptr, ptr, i64)`.
+// Osty: mirRuntimeDeclareBytesV1PushLine
+func mirRuntimeDeclareBytesV1PushLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, ptr, i64")
+}
+
+// mirRuntimeDeclareBytesV1SetWithBarrierLine renders
+// `declare void @<sym>(ptr, i64, ptr, i64, ptr)`.
+// Osty: mirRuntimeDeclareBytesV1SetWithBarrierLine
+func mirRuntimeDeclareBytesV1SetWithBarrierLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, i64, ptr, i64, ptr")
+}
+
+// mirRuntimeDeclareThreePtrVoidLine renders `declare void @<sym>(ptr, ptr, ptr)`.
+// Osty: mirRuntimeDeclareThreePtrVoidLine
+func mirRuntimeDeclareThreePtrVoidLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr")
+}
+
+// mirRuntimeDeclareTaskGroupSplitLine renders the task-group spawn
+// 5-arg ABI `void @<sym>(ptr, ptr, ptr, i64, ptr)`.
+// Osty: mirRuntimeDeclareTaskGroupSplitLine
+func mirRuntimeDeclareTaskGroupSplitLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr, i64, ptr")
+}
+
+// §6 list-pop / list-front read-projection helpers.
+
+// mirSubI64MinusOneLine renders `<reg> = sub i64 <lenReg>, 1`.
+// Osty: mirSubI64MinusOneLine
+func mirSubI64MinusOneLine(reg, lenReg string) string {
+	return mirSubI64Line(reg, lenReg, "1")
+}
+
+// mirAddI64PlusOneLine renders `<reg> = add i64 <iReg>, 1`.
+// Osty: mirAddI64PlusOneLine
+func mirAddI64PlusOneLine(reg, iReg string) string {
+	return mirAddI64Line(reg, iReg, "1")
+}
+
+// mirLenGuardLines renders the canonical "is non-empty?" preamble
+// used by every list intrinsic that returns Option<T>.
+// Osty: mirLenGuardLines
+func mirLenGuardLines(lenReg, isEmpty, lenSym, listReg string) string {
+	return mirCallValueLine(lenReg, "i64", lenSym, "ptr "+listReg) +
+		mirICmpEqI64Line(isEmpty, lenReg, "0")
+}
+
+// mirCallVoidPtrLine renders `call void @<sym>(ptr <ptr>)`.
+// Osty: mirCallVoidPtrLine
+func mirCallVoidPtrLine(sym, ptr string) string {
+	return mirCallVoidLine(sym, "ptr "+ptr)
+}
+
+// mirCallValueI64FromPtrLine renders `<reg> = call i64 @<sym>(ptr <ptr>)`.
+// Osty: mirCallValueI64FromPtrLine
+func mirCallValueI64FromPtrLine(reg, sym, ptr string) string {
+	return mirCallValueLine(reg, "i64", sym, "ptr "+ptr)
+}
+
+// mirCallValuePtrFromPtrLine renders `<reg> = call ptr @<sym>(ptr <ptr>)`.
+// Osty: mirCallValuePtrFromPtrLine
+func mirCallValuePtrFromPtrLine(reg, sym, ptr string) string {
+	return mirCallValueLine(reg, "ptr", sym, "ptr "+ptr)
+}
+
+// mirCallValueI1FromPtrLine renders `<reg> = call i1 @<sym>(ptr <ptr>)`.
+// Osty: mirCallValueI1FromPtrLine
+func mirCallValueI1FromPtrLine(reg, sym, ptr string) string {
+	return mirCallValueLine(reg, "i1", sym, "ptr "+ptr)
+}
+
+// mirRuntimeDeclareI8FromPtrI64Line renders `declare i8 @<sym>(ptr, i64)`.
+// Osty: mirRuntimeDeclareI8FromPtrI64Line
+func mirRuntimeDeclareI8FromPtrI64Line(sym string) string {
+	return mirRuntimeDeclareLine("i8", sym, "ptr, i64")
+}
+
+// mirCallValueI8FromPtrI64Line renders `<reg> = call i8 @<sym>(ptr <ptr>, i64 <idx>)`.
+// Osty: mirCallValueI8FromPtrI64Line
+func mirCallValueI8FromPtrI64Line(reg, sym, ptr, idx string) string {
+	return mirCallValueLine(reg, "i8", sym, "ptr "+ptr+", i64 "+idx)
+}
+
+// mirCallValueElemFromPtrI64Line renders typed-element list-get runtime call.
+// Osty: mirCallValueElemFromPtrI64Line
+func mirCallValueElemFromPtrI64Line(reg, elemLLVM, sym, ptr, idx string) string {
+	return mirCallValueLine(reg, elemLLVM, sym, "ptr "+ptr+", i64 "+idx)
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -3734,3 +3734,248 @@ pub fn mirAllocaI1FalseSlot(slot: String) -> String {
 pub fn mirStoreI1TrueLine(slot: String) -> String {
     mirStoreLine("i1", "true", slot)
 }
+
+/// §3 runtime-declare canonical-shape builders (continued) — drain
+/// the remaining common `(ret, argList)` shapes still inlined as
+/// string-concat at call sites.
+
+/// mirRuntimeDeclarePtrFromTwoPtrLine renders `declare ptr @<sym>(ptr, ptr)`
+/// — the two-ptr ABI shape for string-pair runtimes
+/// (`osty_rt_strings_Concat`, `*_Replace`, `*_Split`, etc.). The
+/// literal `mirRuntimeDeclareStringConcat` covers the named exact
+/// shape; this builder is the abstract-symbol form for the same
+/// arity.
+pub fn mirRuntimeDeclarePtrFromTwoPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, ptr")
+}
+
+/// mirRuntimeDeclareI64FromTwoPtrLine renders `declare i64 @<sym>(ptr, ptr)`
+/// — the i64-from-two-ptr ABI shape. Used by `osty_rt_strings_Compare`
+/// (the lexicographic compare runtime), `osty_rt_bytes_index_of`, and
+/// other two-pointer scalar-returning probes.
+pub fn mirRuntimeDeclareI64FromTwoPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("i64", sym, "ptr, ptr")
+}
+
+/// mirRuntimeDeclareI1FromTwoPtrLine renders `declare i1 @<sym>(ptr, ptr)`
+/// — the i1-from-two-ptr predicate shape: `osty_rt_strings_Equal`,
+/// `osty_rt_bytes_starts_with`, `osty_rt_bytes_ends_with`. Sibling
+/// of `mirRuntimeDeclareI64FromTwoPtrLine` for the boolean-returning
+/// case.
+pub fn mirRuntimeDeclareI1FromTwoPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("i1", sym, "ptr, ptr")
+}
+
+/// mirRuntimeDeclarePtrFromPtrI64I64Line renders
+///   `declare ptr @<sym>(ptr, i64, i64)`
+/// — the slice-like ABI shape used by `osty_rt_strings_Substring`,
+/// `osty_rt_list_slice`, `osty_rt_bytes_substring`. Three-arg form
+/// where the first ptr is the input handle and the trailing pair
+/// is `(start, end)` byte / element offsets.
+pub fn mirRuntimeDeclarePtrFromPtrI64I64Line(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, i64, i64")
+}
+
+/// mirRuntimeDeclarePtrFromThreePtrLine renders
+///   `declare ptr @<sym>(ptr, ptr, ptr)`
+/// — the three-ptr ABI shape used by `osty_rt_strings_Replace`
+/// (input + needle + replacement → new string).
+pub fn mirRuntimeDeclarePtrFromThreePtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, ptr, ptr")
+}
+
+/// mirRuntimeDeclarePtrFromPtrPtrI64Line renders
+///   `declare ptr @<sym>(ptr, ptr, i64)`
+/// — the (ptr, ptr, i64) ABI shape used by `osty_rt_strings_ReplaceN`
+/// (input + needle + max_count → new string).
+pub fn mirRuntimeDeclarePtrFromPtrPtrI64Line(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, ptr, i64")
+}
+
+/// mirRuntimeDeclarePtrFromPtrI64PtrLine renders
+///   `declare ptr @<sym>(ptr, i64, ptr)`
+/// — the (ptr, i64, ptr) ABI shape used by some list intrinsic
+/// helpers (e.g. `osty_rt_list_slice_with_ctx`).
+pub fn mirRuntimeDeclarePtrFromPtrI64PtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, i64, ptr")
+}
+
+/// mirRuntimeDeclarePtrFromPtrI64Line renders
+///   `declare ptr @<sym>(ptr, i64)`
+/// — the (ptr, i64) ABI shape used by indexed-getter runtimes
+/// (`osty_rt_list_primitive_to_string` (ptr + count form)).
+pub fn mirRuntimeDeclarePtrFromPtrI64Line(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "ptr, i64")
+}
+
+/// mirRuntimeDeclarePtrFromI64Line renders `declare ptr @<sym>(i64)`
+/// — used by some int-derived constructors (e.g. allocator-like
+/// helpers that take a size and return a fresh handle).
+pub fn mirRuntimeDeclarePtrFromI64Line(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "i64")
+}
+
+/// mirRuntimeDeclarePtrFromI64PtrLine renders
+///   `declare ptr @<sym>(i64, ptr)`
+/// — used by handle-with-context constructors (some chan helpers).
+pub fn mirRuntimeDeclarePtrFromI64PtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("ptr", sym, "i64, ptr")
+}
+
+/// mirRuntimeDeclareEnumLayoutFromPtrLine renders the enum-layout
+/// runtime decl shape:
+///   `declare { i64, i64 } @<sym>(ptr)`
+/// Used by runtimes that return Option<T> / Result<T, E> directly
+/// (channel-recv, cancel-check, etc.). The fixed `{ i64, i64 }`
+/// matches the MIR/LLVM enum layout convention.
+pub fn mirRuntimeDeclareEnumLayoutFromPtrLine(sym: String) -> String {
+    mirRuntimeDeclareLine("\{ i64, i64 \}", sym, "ptr")
+}
+
+/// mirRuntimeDeclareEnumLayoutNoArgsLine renders the no-arg enum-
+/// layout runtime decl shape:
+///   `declare { i64, i64 } @<sym>()`
+/// Used by `osty_rt_cancel_check_cancelled` and other zero-arg
+/// Option/Result-returning runtimes.
+pub fn mirRuntimeDeclareEnumLayoutNoArgsLine(sym: String) -> String {
+    mirRuntimeDeclareLine("\{ i64, i64 \}", sym, "")
+}
+
+/// mirRuntimeDeclareBytesV1GetLine renders the bytes-v1 list-get
+/// runtime decl, which is `void @<sym>(ptr, i64, ptr, i64)`. Three
+/// sites (list-set / list-get / list-insert) produce the same shape.
+/// Specialisation of `mirRuntimeDeclareLine` for the four-arg
+/// (ptr, i64, ptr, i64) signature.
+pub fn mirRuntimeDeclareBytesV1GetLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, i64, ptr, i64")
+}
+
+/// mirRuntimeDeclareBytesV1PushLine renders the bytes-v1 list-push
+/// runtime decl: `void @<sym>(ptr, ptr, i64)`. Used at the
+/// IntrinsicListPush composite-element site and the chan-send-
+/// bytes runtime decl.
+pub fn mirRuntimeDeclareBytesV1PushLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, ptr, i64")
+}
+
+/// mirRuntimeDeclareBytesV1SetWithBarrierLine renders
+///   `declare void @<sym>(ptr, i64, ptr, i64, ptr)`
+/// — the bytes-v1 list-set ABI with trailing GC write-barrier slot.
+/// One inline site at `emitIndexedWrite` for composite list-set.
+pub fn mirRuntimeDeclareBytesV1SetWithBarrierLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, i64, ptr, i64, ptr")
+}
+
+/// mirRuntimeDeclareThreePtrVoidLine renders `declare void @<sym>(ptr, ptr, ptr)`
+/// — used by `osty_rt_test_snapshot(name, expected, actual)`.
+pub fn mirRuntimeDeclareThreePtrVoidLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr")
+}
+
+/// mirRuntimeDeclareTaskGroupSplitLine renders the special 5-arg
+/// task-group spawn ABI:
+///   `declare void @<sym>(ptr, ptr, ptr, i64, ptr)`
+/// Used by `osty_rt_task_group_spawn_with_args`. The longest
+/// runtime-decl shape; centralised so the param tuple stays in
+/// lockstep between decl + call.
+pub fn mirRuntimeDeclareTaskGroupSplitLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr, i64, ptr")
+}
+
+/// §6 list-pop / list-front read-projection helpers — drain the
+/// repeating "len-guarded read of last/first element" body.
+
+/// mirSubI64MinusOneLine renders the `len - 1` step used by
+/// `IntrinsicListLast` and `IntrinsicListPop` to compute the last
+/// element index:
+///   `  <reg> = sub i64 <lenReg>, 1\n`
+/// Specialisation of `mirSubI64Line` for the `lenReg, "1"` operand
+/// pair; reads cleaner than the general form because the constant
+/// is the same at every call site.
+pub fn mirSubI64MinusOneLine(reg: String, lenReg: String) -> String {
+    mirSubI64Line(reg, lenReg, "1")
+}
+
+/// mirAddI64PlusOneLine renders the `i + 1` step used by every
+/// linear-scan loop's tail:
+///   `  <reg> = add i64 <iReg>, 1\n`
+/// Specialisation of `mirAddI64Line` mirroring `mirSubI64MinusOneLine`
+/// for the increment side. Companion to `mirLinearScanLoopTailLines`
+/// which already inlines this pattern.
+pub fn mirAddI64PlusOneLine(reg: String, iReg: String) -> String {
+    mirAddI64Line(reg, iReg, "1")
+}
+
+/// mirLenGuardLines renders the canonical "is the list non-empty?"
+/// preamble used by every list intrinsic that returns Option<T>
+/// (first/last/pop/safe_get/index_of):
+///   `  <lenReg> = call i64 @<lenSym>(ptr <listReg>)\n`
+///   `  <isEmpty> = icmp eq i64 <lenReg>, 0\n`
+/// Two-line block. Caller threads the runtime symbol; the helper
+/// produces the canonical len-then-eq probe pair so call sites
+/// don't need to remember the eq-on-i64 specialisation.
+pub fn mirLenGuardLines(lenReg: String, isEmpty: String, lenSym: String, listReg: String) -> String {
+    mirCallValueLine(lenReg, "i64", lenSym, "ptr " + listReg) +
+    mirICmpEqI64Line(isEmpty, lenReg, "0")
+}
+
+/// mirCallVoidPtrLine renders `  call void @<sym>(ptr <ptr>)\n` —
+/// the single-ptr-arg side-effect runtime call. Used by
+/// `osty_rt_list_clear`, `osty_rt_list_reverse`, `osty_rt_chan_close`,
+/// `osty_rt_list_pop_discard`, etc. Sibling of the existing
+/// `mirCallVoidLine` for the specific 1-ptr-arg case so callers
+/// don't thread the literal "ptr " prefix at every site.
+pub fn mirCallVoidPtrLine(sym: String, ptr: String) -> String {
+    mirCallVoidLine(sym, "ptr " + ptr)
+}
+
+/// mirCallValueI64FromPtrLine renders the canonical i64-from-ptr
+/// probe call: `  <reg> = call i64 @<sym>(ptr <ptr>)\n`. Used by
+/// `osty_rt_list_len`, `osty_rt_set_len`, `osty_rt_map_len` — the
+/// single-handle scalar probe shape that's inlined as
+/// `mirCallValueLine(reg, "i64", sym, "ptr "+listReg)` at every
+/// call site today.
+pub fn mirCallValueI64FromPtrLine(reg: String, sym: String, ptr: String) -> String {
+    mirCallValueLine(reg, "i64", sym, "ptr " + ptr)
+}
+
+/// mirCallValuePtrFromPtrLine renders the canonical ptr-from-ptr
+/// runtime call: `  <reg> = call ptr @<sym>(ptr <ptr>)\n`. Used by
+/// `osty_rt_list_keys`, `osty_rt_set_to_list`, `osty_rt_list_data_*`,
+/// etc. Mirror of `mirCallValueI64FromPtrLine` for the ptr-returning
+/// case.
+pub fn mirCallValuePtrFromPtrLine(reg: String, sym: String, ptr: String) -> String {
+    mirCallValueLine(reg, "ptr", sym, "ptr " + ptr)
+}
+
+/// mirCallValueI1FromPtrLine renders the canonical i1-from-ptr
+/// predicate call: `  <reg> = call i1 @<sym>(ptr <ptr>)\n`. Used by
+/// `osty_rt_list_is_empty`, `osty_rt_chan_is_closed`,
+/// `osty_rt_cancel_is_cancelled`, etc. Boolean-returning probe.
+pub fn mirCallValueI1FromPtrLine(reg: String, sym: String, ptr: String) -> String {
+    mirCallValueLine(reg, "i1", sym, "ptr " + ptr)
+}
+
+/// mirRuntimeDeclareI8FromPtrI64Line renders `declare i8 @<sym>(ptr, i64)`
+/// — the byte-typed list/bytes element-get shape used by
+/// `osty_rt_bytes_get` and `osty_rt_list_get_i8`. Sibling of
+/// `mirCallValueI64FromPtrLine` for the i8 element width.
+pub fn mirRuntimeDeclareI8FromPtrI64Line(sym: String) -> String {
+    mirRuntimeDeclareLine("i8", sym, "ptr, i64")
+}
+
+/// mirCallValueI8FromPtrI64Line renders `<reg> = call i8 @<sym>(ptr <ptr>, i64 <idx>)`
+/// — paired with `mirRuntimeDeclareI8FromPtrI64Line` at every byte
+/// list/string element-get site.
+pub fn mirCallValueI8FromPtrI64Line(reg: String, sym: String, ptr: String, idx: String) -> String {
+    mirCallValueLine(reg, "i8", sym, "ptr " + ptr + ", i64 " + idx)
+}
+
+/// mirCallValueElemFromPtrI64Line renders the typed-element list-get
+/// runtime call `<reg> = call <elemLLVM> @<sym>(ptr <list>, i64
+/// <idx>)`. Generalises `mirCallValueI8FromPtrI64Line` for any
+/// element type. Used at every IntrinsicListGet / inline list-get
+/// site that goes through the typed-element fast path.
+pub fn mirCallValueElemFromPtrI64Line(reg: String, elemLLVM: String, sym: String, ptr: String, idx: String) -> String {
+    mirCallValueLine(reg, elemLLVM, sym, "ptr " + ptr + ", i64 " + idx)
+}


### PR DESCRIPTION
## Summary

- Adds 28 new line-builders to `toolchain/mir_generator.osty` covering the remaining `declareRuntime(sym, \"declare <ret> @\"+sym+\"(<args>)\")` inline string-concat shapes plus the most common runtime-call shapes
- **After this slice, zero inline `\"declare ...\"` literals remain in `mir_generator.go`**
- §3 runtime-declare builders (17): `mirRuntimeDeclarePtrFromTwoPtrLine` (~9 sites), `mirRuntimeDeclareI64FromTwoPtrLine` (5 sites), `mirRuntimeDeclareI1FromTwoPtrLine`, `mirRuntimeDeclarePtrFromPtrI64I64Line` (3 sites), `mirRuntimeDeclarePtrFromThreePtrLine`, `mirRuntimeDeclarePtrFromPtrPtrI64Line`, `mirRuntimeDeclarePtrFromPtrI64{,Ptr}Line`, `mirRuntimeDeclarePtrFromI64{,Ptr}Line`, `mirRuntimeDeclareEnumLayout{FromPtr,NoArgs}Line` (chan-recv / cancel-check), `mirRuntimeDeclareBytesV1{Get,Push,SetWithBarrier}Line`, `mirRuntimeDeclareThreePtrVoidLine` (test_snapshot), `mirRuntimeDeclareTaskGroupSplitLine` (5-arg spawn), `mirRuntimeDeclareI8FromPtrI64Line`
- §6 list-pop / linear-scan / runtime-call helpers (11): `mirSubI64MinusOneLine` / `mirAddI64PlusOneLine`, `mirLenGuardLines` (canonical "is non-empty?" 2-line preamble), `mirCallVoidPtrLine` / `mirCallValue{I64,Ptr,I1}FromPtrLine`, `mirCallValueI8FromPtrI64Line` / `mirCallValueElemFromPtrI64Line`

## Drain sites

| Site | Before | After |
|------|--------|-------|
| ~40 `declareRuntime` sites | inline `"declare <ret> @"+sym+"(<args>)"` string-concat | canonical-shape builders (zero inline strings remaining) |
| `IntrinsicListFirst` / `Last` / `Pop` | inline call + icmp_eq + cond br + zero-init store | `mirLenGuardLines` + `mirNoneStoreThenJumpLines` |
| `IntrinsicListIndexOf` / `IntrinsicListContains` | inline label + load + icmp slt + cond-br | `mirLinearScanLoopHeadLines` |
| len-1 step sites | `mirSubI64Line(reg, lenReg, "1")` | `mirSubI64MinusOneLine(reg, lenReg)` |

## Diffstat

**538 insertions / 107 deletions** across 4 files.

## Test plan

- [x] `go build ./internal/llvmgen/...` clean
- [x] `go vet ./internal/llvmgen/...` clean
- [x] Byte-stable golden parity: pre/post `go test ./internal/llvmgen/...` reports identical 6-failure set (zero inline `"declare ..."` literals remaining is a structural milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)