### PR TITLE
fix(llvmgen): hoist alloca instructions to function entry block

### DIFF
--- a/internal/llvmgen/alloca_hoist.go
+++ b/internal/llvmgen/alloca_hoist.go
@@ -1,0 +1,119 @@
+package llvmgen
+
+import "strings"
+
+// hoistAllocasToEntry rewrites a function body so every `alloca`
+// instruction lives in the entry block.
+//
+// Background: the legacy support_snapshot codegen emits `alloca` lines
+// straight into emitter.body wherever the current emit cursor sits. When
+// `let s = expr()` is inlined into a loop body, the alloca lands inside
+// the loop's basic block instead of the entry block. Each loop iteration
+// then re-executes that alloca, growing the C stack by `sizeof(slot)`
+// bytes per iteration without ever freeing — a 200K-iteration loop
+// accumulates ~1.6 MB of dead stack frames, which the GC has to walk on
+// every safepoint scan, turning per-iter cost into O(N) and the whole
+// loop into O(N²).
+//
+// LLVM's mem2reg / SROA passes promote allocas to SSA registers when
+// they're in the entry block, and on -O3 they'd normally hoist single-
+// use stack slots. The slots we emit fail the "single use" precondition
+// because the alloca's address is captured (passed to runtime helpers,
+// stored as a GC root), so promotion is blocked. Hoisting the alloca
+// itself to entry doesn't unlock promotion, but it does eliminate the
+// per-iter stack growth — the same alloca pointer is reused every
+// iteration, the store overwrites the slot in place, and stack-walk cost
+// stays O(1) regardless of loop trip count.
+//
+// Algorithm:
+//
+//  1. Find the index of the first `br` line (terminator of the entry
+//     block — every emitted function has one because emit always falls
+//     through to a label like `for.cond0:` or returns directly).
+//  2. Scan all subsequent lines. Any line of the form
+//     `  %name = alloca <ty>...` gets removed from its current position
+//     and queued for hoist.
+//  3. Insert the hoisted lines just before the entry-block terminator,
+//     preserving their original relative order.
+//
+// Edge cases:
+//
+//   - No `br` in body (e.g. `define void @f() { ret void }` style):
+//     all lines are already in the entry block; nothing to hoist.
+//   - Allocas already in the entry block (before the first `br`):
+//     left untouched.
+//   - Lines that LOOK like alloca but are inside a comment or string:
+//     emitted body lines never embed allocas in arbitrary text — every
+//     alloca emitter writes via fmt.Sprintf("  %s = alloca ...") with
+//     a leading two-space indent — so the prefix check is unambiguous.
+//   - Multiple basic blocks past entry: irrelevant. We move every
+//     alloca to entry regardless of which block it lived in.
+//
+// The function is idempotent: running it on already-hoisted IR leaves
+// the body unchanged because there are no allocas past the first `br`.
+func hoistAllocasToEntry(body []string) []string {
+	firstBr := -1
+	for i, line := range body {
+		if isBrTerminator(line) {
+			firstBr = i
+			break
+		}
+	}
+	if firstBr < 0 {
+		return body
+	}
+
+	// Walk body[firstBr+1:] once, collecting alloca lines into `hoisted`
+	// and the rest into `kept`.
+	hoisted := make([]string, 0)
+	kept := make([]string, 0, len(body)-firstBr-1)
+	for _, line := range body[firstBr+1:] {
+		if isAllocaLine(line) {
+			hoisted = append(hoisted, line)
+		} else {
+			kept = append(kept, line)
+		}
+	}
+	if len(hoisted) == 0 {
+		return body
+	}
+
+	// Reassemble: entry-block instructions, then hoisted allocas, then
+	// the entry-block `br`, then everything after.
+	out := make([]string, 0, len(body))
+	out = append(out, body[:firstBr]...)
+	out = append(out, hoisted...)
+	out = append(out, body[firstBr])
+	out = append(out, kept...)
+	return out
+}
+
+// isAllocaLine reports whether `line` is an LLVM `alloca` instruction
+// emitted by the snapshot helpers. They all write the form
+// `"  %<name> = alloca <ty>..."` via fmt.Sprintf with a leading two-
+// space indent. We match that prefix conservatively: leading two
+// spaces, a `%`-named SSA value, an `=`, and the literal token
+// `alloca` separated by spaces.
+func isAllocaLine(line string) bool {
+	const prefix = "  %"
+	if !strings.HasPrefix(line, prefix) {
+		return false
+	}
+	rest := line[len(prefix):]
+	eq := strings.Index(rest, " = ")
+	if eq < 0 {
+		return false
+	}
+	tail := rest[eq+len(" = "):]
+	return strings.HasPrefix(tail, "alloca ") || tail == "alloca"
+}
+
+// isBrTerminator reports whether `line` is the unconditional or
+// conditional `br` instruction that terminates a basic block. Used to
+// locate the entry block's boundary so hoisted allocas land just
+// before the terminator (LLVM requires terminators to be the last
+// instruction in their block).
+func isBrTerminator(line string) bool {
+	const prefix = "  br "
+	return strings.HasPrefix(line, prefix)
+}

--- a/internal/llvmgen/alloca_hoist_test.go
+++ b/internal/llvmgen/alloca_hoist_test.go
@@ -1,0 +1,186 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// hoistAllocasToEntry's job is to move any `alloca` line that landed in
+// a non-entry basic block to just before the entry block's terminator.
+// These tests drive each shape we expect to encounter from the legacy
+// snapshot codegen path.
+
+func TestHoistAllocasToEntry_SimpleLoopBody(t *testing.T) {
+	// Mirrors the IR pattern that triggered the O(N²) bug in big-map:
+	// `let s = i.toString()` inside `for i < n` emits the alloca into
+	// %for.body1 instead of entry.
+	body := []string{
+		"  %t0 = alloca i64",
+		"  store i64 0, ptr %t0",
+		"  br label %for.cond0",
+		"for.cond0:",
+		"  %t1 = load i64, ptr %t0",
+		"  %t2 = icmp slt i64 %t1, 100",
+		"  br i1 %t2, label %for.body1, label %for.end",
+		"for.body1:",
+		"  %t3 = load i64, ptr %t0",
+		"  %t4 = call ptr @osty_rt_int_to_string(i64 %t3)",
+		"  %t5 = alloca ptr",
+		"  store ptr %t4, ptr %t5",
+		"  br label %for.cond0",
+		"for.end:",
+		"  ret i32 0",
+	}
+	got := hoistAllocasToEntry(body)
+	want := []string{
+		"  %t0 = alloca i64",
+		"  store i64 0, ptr %t0",
+		"  %t5 = alloca ptr",
+		"  br label %for.cond0",
+		"for.cond0:",
+		"  %t1 = load i64, ptr %t0",
+		"  %t2 = icmp slt i64 %t1, 100",
+		"  br i1 %t2, label %for.body1, label %for.end",
+		"for.body1:",
+		"  %t3 = load i64, ptr %t0",
+		"  %t4 = call ptr @osty_rt_int_to_string(i64 %t3)",
+		"  store ptr %t4, ptr %t5",
+		"  br label %for.cond0",
+		"for.end:",
+		"  ret i32 0",
+	}
+	assertSameLines(t, got, want)
+}
+
+func TestHoistAllocasToEntry_NoAllocas_ReturnsUnchanged(t *testing.T) {
+	body := []string{
+		"  br label %for.cond0",
+		"for.cond0:",
+		"  ret i32 0",
+	}
+	got := hoistAllocasToEntry(body)
+	assertSameLines(t, got, body)
+}
+
+func TestHoistAllocasToEntry_AllocasAlreadyInEntry_LeftAlone(t *testing.T) {
+	body := []string{
+		"  %t0 = alloca i64",
+		"  %t1 = alloca ptr",
+		"  store i64 0, ptr %t0",
+		"  br label %for.cond0",
+		"for.cond0:",
+		"  ret i32 0",
+	}
+	got := hoistAllocasToEntry(body)
+	assertSameLines(t, got, body)
+}
+
+func TestHoistAllocasToEntry_NoBranch_ReturnsUnchanged(t *testing.T) {
+	// Single-block function (no `br` terminator): every line is in
+	// the entry block by definition; nothing to hoist.
+	body := []string{
+		"  %t0 = alloca i64",
+		"  store i64 42, ptr %t0",
+		"  %t1 = load i64, ptr %t0",
+		"  ret i64 %t1",
+	}
+	got := hoistAllocasToEntry(body)
+	assertSameLines(t, got, body)
+}
+
+func TestHoistAllocasToEntry_MultipleAllocasInLoop_PreservesOrder(t *testing.T) {
+	// When several `let`s appear in the same loop body, their allocas
+	// should hoist together AND retain their original relative order so
+	// any dependency between later store-into-slot lines and the slot
+	// pointer they reference still resolves.
+	body := []string{
+		"  br label %loop",
+		"loop:",
+		"  %t0 = alloca ptr",
+		"  store ptr null, ptr %t0",
+		"  %t1 = alloca i64",
+		"  store i64 0, ptr %t1",
+		"  %t2 = alloca double",
+		"  store double 0.0, ptr %t2",
+		"  br label %loop",
+	}
+	got := hoistAllocasToEntry(body)
+	want := []string{
+		"  %t0 = alloca ptr",
+		"  %t1 = alloca i64",
+		"  %t2 = alloca double",
+		"  br label %loop",
+		"loop:",
+		"  store ptr null, ptr %t0",
+		"  store i64 0, ptr %t1",
+		"  store double 0.0, ptr %t2",
+		"  br label %loop",
+	}
+	assertSameLines(t, got, want)
+}
+
+func TestHoistAllocasToEntry_Idempotent(t *testing.T) {
+	// Running the hoist twice must produce the same body as running it
+	// once — there should be no alloca past the entry's `br` after the
+	// first pass, so the second pass is a no-op.
+	body := []string{
+		"  %t0 = alloca ptr",
+		"  br label %loop",
+		"loop:",
+		"  %t1 = alloca i64",
+		"  br label %loop",
+	}
+	once := hoistAllocasToEntry(body)
+	twice := hoistAllocasToEntry(once)
+	assertSameLines(t, once, twice)
+}
+
+func TestHoistAllocasToEntry_AllocaArrayShape(t *testing.T) {
+	// `expr.go:247` emits `alloca [N x ptr]` for ConcatN's stack
+	// arg vector. The hoist matcher must accept this shape too.
+	body := []string{
+		"  br label %loop",
+		"loop:",
+		"  %arr = alloca [4 x ptr]",
+		"  store ptr @.str0, ptr %arr",
+		"  br label %loop",
+	}
+	got := hoistAllocasToEntry(body)
+	want := []string{
+		"  %arr = alloca [4 x ptr]",
+		"  br label %loop",
+		"loop:",
+		"  store ptr @.str0, ptr %arr",
+		"  br label %loop",
+	}
+	assertSameLines(t, got, want)
+}
+
+func TestHoistAllocasToEntry_DoesNotMatchUnrelatedLines(t *testing.T) {
+	// Lines that mention "alloca" inside other contexts (function calls,
+	// metadata) must not be rewritten. The matcher only fires on the
+	// canonical `  %name = alloca ...` form.
+	body := []string{
+		"  br label %loop",
+		"loop:",
+		"  %t0 = call ptr @some_alloca_lookalike()",
+		"  call void @osty.gc.alloca_track(ptr %t0)",
+		"  br label %loop",
+	}
+	got := hoistAllocasToEntry(body)
+	assertSameLines(t, got, body)
+}
+
+func assertSameLines(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("line count mismatch: got %d, want %d\ngot:\n%s\nwant:\n%s",
+			len(got), len(want),
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -585,6 +585,11 @@ func llvmNativeFnAttrString(fn *llvmNativeFunction) string {
 // list's closing paren and the opening brace. `fnAttrs == ""` produces
 // output byte-identical to `llvmRenderFunction`.
 func llvmRenderFunctionWithAttrs(ret string, name string, params []*LlvmParam, fnAttrs string, body []string) string {
+	// See llvmRenderFunction / alloca_hoist.go: emitter writes `alloca`
+	// straight into emitter.body at whatever cursor position is current,
+	// so loop-body lets accumulate stack slots per iteration. Hoisting
+	// to the entry block makes the slot reusable.
+	body = hoistAllocasToEntry(body)
 	var header string
 	if fnAttrs == "" {
 		header = fmt.Sprintf("define %s @%s(%s) {", ret, name, llvmParams(params))

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1473,6 +1473,11 @@ func llvmRenderSkeleton(packageName string, sourcePath string, emit string, targ
 
 // Osty: toolchain/llvmgen.osty:1107:5
 func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []string) string {
+	// `body` may contain `alloca` lines emitted into non-entry basic
+	// blocks (loop bodies, conditional branches). Hoist them to the
+	// entry block so each iteration reuses the same stack slot — see
+	// alloca_hoist.go for the rationale and the O(N²) bug it fixes.
+	body = hoistAllocasToEntry(body)
 	// Osty: toolchain/llvmgen.osty:1113:5
 	lines := []string{fmt.Sprintf("define %s @%s(%s) {", ostyToString(ret), ostyToString(name), ostyToString(llvmParams(params))), "entry:"}
 	_ = lines


### PR DESCRIPTION
## Summary

The legacy `support_snapshot` codegen path (used for toolchain helpers, primitive-method dispatch, and fallback codegen for shapes the MIR pipeline doesn't yet handle) emits `alloca` lines straight into `emitter.body` at whatever the current emit cursor is. When `let s = expr()` lands inside a loop body, the alloca is generated *as part of that loop body*:

```llvm
for.body1:
  %t6 = call ptr @osty_rt_int_to_string(i64 %t5)
  %t7 = alloca ptr           ; <-- BUG: re-executes every iteration
  store ptr %t6, ptr %t7
  ...
  br label %for.cond0
```

Each loop iteration re-executes the alloca and grows the C stack by `sizeof(slot)` bytes that LLVM never reclaims (only entry-block allocas get folded into the function prologue). LLVM mem2reg can't promote them either because the slot's address escapes via GC root binds and runtime-helper byref args.

Concrete observation: a 200K-iter `for { let s = i.toString() }` loop accumulates ~1.6 MB of stack. The GC's safepoint scanner walks every stack root each collection — O(N) sweep × O(log N) collections = effectively O(N²) GC time. The same micro-benchmark went from "runs for minutes" to **0.35s** after this fix.

## Implementation

`hoistAllocasToEntry` in `alloca_hoist.go` post-processes the function body before rendering: every `  %name = alloca ...` line emitted past the entry-block's terminating `br` is moved to just before that `br`. Both render functions (`llvmRenderFunction` legacy + `llvmRenderFunctionWithAttrs` native-owned) call it.

The pass is idempotent and preserves order — hoisted allocas keep their relative position so dependent stores in the original block still see the same `%name`.

## Why mem2reg isn't enough

mem2reg requires every use to be a load or a store with the alloca pointer (no address escape). Our slots fail that:

- GC roots: `osty.gc.root_bind_v1(ptr %slot)` captures the address
- Runtime helpers like `osty_rt_map_insert_string(map, key_ptr, val_slot)` take the slot pointer to memcpy the value out

So even after hoisting, the alloca stays a real stack slot — but it's allocated *once* in the prologue instead of once per iteration. Same address, in-place rewritten by each `store`. Stack-walk cost stops growing with loop trip count.

## Why the legacy codegen emits this shape

The MIR-based path (`mir_generator.go`) already routes allocas to a per-function entry buffer. The legacy snapshot path shares one `emitter.body` for allocas + control flow, so position is wherever the cursor was at emit time. A more invasive fix would split the snapshot emitter into entry + body buffers (symmetric to mir_generator). The post-process hoist gets the same observable IR with one Go file and zero changes to the snapshot-generated helpers.

## Test plan

- [x] 8 unit tests in `alloca_hoist_test.go`: simple loop body, no allocas, allocas already in entry, no branch, multiple allocas in loop (order preservation), idempotence, alloca array shape, doesn't match unrelated lines
- [x] `go test ./internal/llvmgen -run "TestBundled|TestRuntime|TestList|TestMap|TestGC"` — pass
- [x] `go test ./internal/llvmgen` (full package) — pass
- [x] `just front` — all front-end packages pass
- [x] `benchmarks/programs/build-all.sh` — all 6 programs byte-equal output to Go reference
- [x] `for { let s = i.toString() }` micro-benchmark: N=100K in 0.35s (was: minutes / hangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)