### PR TITLE
fix(parser): G26 — allow fields after `..spread` in struct literal

### DIFF
--- a/internal/parser/struct_lit_spread_test.go
+++ b/internal/parser/struct_lit_spread_test.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// TestParseStructLitSpreadWithFields pins G26 spread-update semantics
+// (LANG_SPEC_v0.5 / OSTY_GRAMMAR_v0.5 §R5: `..expr` in a struct literal
+// is a spread-update, may appear at most once, and may freely combine
+// with explicit fields). Until #935 the parser broke out of the field
+// loop the moment it consumed a spread, silently rejecting every
+// `T { ..x, field: v }` shape — including the canonical example the
+// spec uses.
+func TestParseStructLitSpreadWithFields(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		src  string
+	}{
+		{"spread_then_field", "struct P { x: Int, y: Int }\nfn f(p: P) -> P { P { ..p, x: 1 } }\n"},
+		{"spread_then_two_fields", "struct P { x: Int, y: Int, z: Int }\nfn f(p: P) -> P { P { ..p, x: 1, y: 2 } }\n"},
+		{"field_then_spread", "struct P { x: Int, y: Int }\nfn f(p: P) -> P { P { x: 1, ..p } }\n"},
+		{"spread_only", "struct P { x: Int }\nfn f(p: P) -> P { P { ..p } }\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := ParseDiagnostics([]byte(tt.src))
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			lit := findStructLit(file)
+			if lit == nil {
+				t.Fatal("no StructLit in parsed file")
+			}
+			if lit.Spread == nil {
+				t.Errorf("Spread = nil, want non-nil")
+			}
+		})
+	}
+}
+
+// TestParseStructLitDuplicateSpread enforces the "max one spread" rule
+// from §R5. Two `..` operands in the same literal should surface E0204
+// with an explicit "remove the duplicate spread" hint.
+func TestParseStructLitDuplicateSpread(t *testing.T) {
+	src := []byte("struct P { x: Int }\nfn f(p: P, q: P) -> P { P { ..p, ..q } }\n")
+	_, diags := ParseDiagnostics(src)
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for duplicate spread, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Code == "E0204" && strings.Contains(d.Message, "at most one") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected E0204 'at most one' diagnostic, got: %v", diags)
+	}
+}
+
+// findStructLit returns the first StructLit it finds reachable from
+// the file body. The G26 fixtures always shape the source so the
+// literal is the only expression of the only function — descending
+// the FnDecl → Block → ExprStmt chain is enough.
+func findStructLit(file *ast.File) *ast.StructLit {
+	if file == nil {
+		return nil
+	}
+	for _, d := range file.Decls {
+		fn, ok := d.(*ast.FnDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		for _, stmt := range fn.Body.Stmts {
+			es, ok := stmt.(*ast.ExprStmt)
+			if !ok {
+				continue
+			}
+			if lit, ok := es.X.(*ast.StructLit); ok {
+				return lit
+			}
+		}
+	}
+	return nil
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -21127,16 +21127,20 @@ func opParseStructLit(p *OstyParser, name int) int {
 	for !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontRBrace{}))) && !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontEOF{}))) {
 		// Osty: /tmp/selfhost_merged.osty:8144:9
 		if opAt(p, FrontTokenKind(&FrontTokenKind_FrontDotDot{})) {
-			// Osty: /tmp/selfhost_merged.osty:8145:13
+			// Osty: toolchain/parser.osty:1288 (G26 hand-port: allow spread + fields)
 			_ = opAdvance(p)
-			// Osty: /tmp/selfhost_merged.osty:8146:13
-			spreadIdx = opParseExpr(p)
-			// Osty: /tmp/selfhost_merged.osty:8147:13
+			exprIdx := opParseExpr(p)
+			if spreadIdx >= 0 {
+				opErrorFull(p, "struct literal allows at most one `..` spread", "remove the duplicate spread", "spec R5: `..` in a struct literal is a spread-update and may appear at most once", "E0204")
+			} else {
+				spreadIdx = exprIdx
+			}
 			opSkipNewlines(p)
-			// Osty: /tmp/selfhost_merged.osty:8148:13
-			_ = opEat(p, FrontTokenKind(&FrontTokenKind_FrontComma{}))
-			// Osty: /tmp/selfhost_merged.osty:8149:13
-			break
+			if !(opEat(p, FrontTokenKind(&FrontTokenKind_FrontComma{}))) {
+				break
+			}
+			opSkipNewlines(p)
+			continue
 		}
 		// Osty: /tmp/selfhost_merged.osty:8151:9
 		fs := p.pos

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -1286,10 +1286,16 @@ fn opParseStructLit(p: OstyParser, name: Int) -> Int {
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
         if opAt(p, FrontDotDot) {
             let _ = opAdvance(p)
-            spreadIdx = opParseExpr(p)
+            let exprIdx = opParseExpr(p)
+            if spreadIdx >= 0 {
+                opErrorFull(p, "struct literal allows at most one `..` spread", "remove the duplicate spread", "spec R5: `..` in a struct literal is a spread-update and may appear at most once", "E0204")
+            } else {
+                spreadIdx = exprIdx
+            }
             opSkipNewlines(p)
-            let _ = opEat(p, FrontComma)
-            break
+            if !(opEat(p, FrontComma)) { break }
+            opSkipNewlines(p)
+            continue
         }
         let fs = p.pos
         let fn_ = opAdvance(p).text


### PR DESCRIPTION
## Summary

`LANG_SPEC_v0.5` / `OSTY_GRAMMAR_v0.5.md` §R5 declares struct-literal spread-update as a single `..expr` operand that may freely combine with explicit fields:

```osty
P { ..p, x: p.x + 1 }
```

The downstream pipeline (typechecker `elabInferStructLit`, HIR lowerer `hirLowerAssembleStructLit`) was already prepared for this shape — `node.right` carries the spread expression and explicit fields are expected to override its values at runtime. The parser broke ranks: `opParseStructLit` consumed the `..` operand and then unconditionally `break`'d out of the field loop, so every literal shaped `T { ..x, field: v }` died at the parser with `expected }, got IDENT` — including the example the spec uses to introduce the rule and the canonical CLAUDE.md A.2 sample.

Surfaced as a blocker while writing the Osty TOML parser ([osty#935](https://github.com/choiceoh/osty/pull/935)); every struct-update path there had to be unrolled into explicit field-by-field listing because of this.

## What changed

| File | Change |
|---|---|
| [toolchain/parser.osty:1287](toolchain/parser.osty:1287) | Replace the `break` with a continue path that re-enters the field loop. Track multiple spreads and emit `E0204` when §R5's "max once" rule is violated. |
| [internal/selfhost/generated.go:21129](internal/selfhost/generated.go:21129) | Same fix hand-ported into the frozen Go snapshot. The transpiler retired in #854 means the snapshot is the runtime source of truth until that path is restored; cite is `// Osty: toolchain/parser.osty:1288 (G26 hand-port)` so the link is explicit. |
| [internal/parser/struct_lit_spread_test.go](internal/parser/struct_lit_spread_test.go) | New `TestParseStructLitSpreadWithFields` (4 positions: spread-only, spread→field, spread→multi-field, field→spread) and `TestParseStructLitDuplicateSpread` pinning the E0204 path. |

## Test plan

- [x] `go test ./internal/parser/ -run TestParseStructLit -v` — all 5 subtests pass
- [x] `osty parse` on the spec canonical example `P { ..p, x: p.x + 1 }` — parses cleanly
- [x] `osty check` on the CLAUDE.md A.2 sample (`User { ..self, age: self.age + 1 }`) — clean
- [x] `osty parse` on duplicate-spread `P { ..p, ..q }` — surfaces E0204 with "remove the duplicate spread" hint
- [x] `just front` — 8/8 packages green (no regressions)
- [x] `just spec` — positive + negative corpora unchanged

## Reviewer notes

- The spec gap was discovered during the work in [osty#935](https://github.com/choiceoh/osty/pull/935) (Osty TOML parser); that PR worked around the missing G26 by listing every field explicitly. With this in, the same code can be rewritten to use `..` updates idiomatically — happy to follow up.
- `toolchain/elab_test.osty` already carries `testElabStructSpreadOverrideSingleField` etc. as test fixtures inside `r"""..."""` raw strings. Those exercises run through `frontendCheckSourceStructured`, which calls the same `opParseStructLit` we just fixed — so they were silently failing before this change for anyone who actually executed the toolchain test suite. Couldn't find a Go-side runner that wires `_test.osty` execution into CI today; flagging in case it's relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)