### PR TITLE
refactor(llvmgen): port 32 §6 builders + drain abort-trap / Option-branch / two-ptr call shapes

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -408,6 +408,22 @@ list keeps new Osty clean of known landmines.
 | `mirRuntimeDeclareI8FromPtrI64Line` | `(sym: String) -> String` | §3 | `declare i8 @<sym>(ptr, i64)` — byte-typed list/bytes element-get shape |
 | `mirCallValueI8FromPtrI64Line` | `(reg, sym, ptr, idx) -> String` | §6 | `<reg> = call i8 @<sym>(ptr <ptr>, i64 <idx>)` — paired with i8 declare |
 | `mirCallValueElemFromPtrI64Line` | `(reg, elemLLVM, sym, ptr, idx) -> String` | §6 | Generalises i8 form for any element type — typed-element list-get runtime call |
+| `mirAbortPrintfExitLines` | `(fmtSym, messagePtr, nextLabel) -> String` | §6 | Canonical "printf+exit+unreachable+next-label" 4-line block — drains every testing-abort / bench-error error-trap body |
+| `mirBranchToErrorTrapLines` | `(isErr, errLabel, okLabel) -> String` | §6 | Result-Err gate: cond-br + err-label header — pairs with `mirAbortPrintfExitLines` |
+| `mirNoneBranchLines` | `(noneLabel, optLLVM, destSlot, endLabel) -> String` | §6 | Option-miss branch (label + zeroinit + br) — 3-line block |
+| `mirSomeBranchLines` | `(someLabel, taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel) -> String` | §6 | Option-hit branch (label + Some + store + br) — 5-line block |
+| `mirSomeNoneJoinLines` | `(endLabel) -> String` | §6 | Convergence-label pass-through (named for grep-ability) |
+| `mirCallExitOneLine` / `mirCallExitZeroLine` | `() -> String` | §6 | Canonical exit(1) / exit(0) line specialisations |
+| `mirAbortBlockLines` | `(errLabel, fmtSym, messagePtr, nextLabel) -> String` | §6 | Full abort block (label + printf + exit + unreachable + next-label) — 5-line block |
+| `mirCallI64FromTwoPtrLine` / `mirCallI1FromTwoPtrLine` / `mirCallPtrFromTwoPtrLine` / `mirCallVoidFromTwoPtrLine` | `(reg?, sym, left, right) -> String` | §6 | Two-ptr-arg runtime call shapes (Compare / Equal / Concat / void-side-effect) |
+| `mirCallVoidFromThreePtrLine` | `(sym, a, b, c) -> String` | §6 | Three-ptr-arg side-effect call (test_snapshot) |
+| `mirInsertValueI64IndexLine` / `mirExtractValueI64IndexLine` | `(reg, aggTy, base, val, idx) -> String` | §6 | i64-typed insertvalue/extractvalue specialisations for Option/Result disc + payload |
+| `mirCallVoidI64Line` / `mirCallVoidI32Line` | `(sym, arg) -> String` | §6 | Single-scalar-arg side-effect calls |
+| `mirGEPInboundsI64IdxLine` | `(reg, elemTy, basePtr, idx) -> String` | §6 | i64-indexed inbounds GEP — vector-list per-element load/store |
+| `mirZExtToI64Line` / `mirSExtToI64Line` / `mirBitcastToI64Line` / `mirPtrToInt64Line` | `(reg, fromTy?, val) -> String` | §6 | i64-payload widen specialisations for Option/Result aggregate construction |
+| `mirCallStringConcatLine` / `mirCallStringEqualLine` / `mirCallStringCompareLine` / `mirCallStringSubstringLine` | `(reg, left, right, ...) -> String` | §6 | Literal-symbol specialisations for the String runtime ABI most-called sites |
+| `mirCallListNewLine` / `mirCallMapNewLine` / `mirCallSetNewLine` | `(reg, ...) -> String` | §6 | Constructor calls for `[]` / `{:}` / `{}` literals |
+| `mirSizeOfDoubleLine` / `mirSizeOfI64Line` / `mirSizeOfI32Line` / `mirSizeOfI8Line` / `mirSizeOfPtrLine` / `mirSizeOfI1Line` | `() -> String` | §6 | Canonical sizeof literal returns — centralise the byte-width constants |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2990,10 +2990,7 @@ func (g *mirGen) emitTestingAbortString(message *LlvmValue, nextLabel string) {
 	g.declareRuntime("printf", mirRuntimeDeclarePrintf())
 	g.declareRuntime("exit", mirRuntimeDeclareExit())
 	fmtPtr := g.stringLiteral("%s\n")
-	g.fnBuf.WriteString(mirCallVarargPrintfPathLine(fmtPtr, message.name))
-	g.fnBuf.WriteString(mirCallExitLine("1"))
-	g.fnBuf.WriteString(mirUnreachableLine())
-	g.fnBuf.WriteString(mirLabelLine(nextLabel))
+	g.fnBuf.WriteString(mirAbortPrintfExitLines(fmtPtr, message.name, nextLabel))
 }
 
 func (g *mirGen) testingFailureMessage(line int, method string) string {
@@ -3293,8 +3290,7 @@ func (g *mirGen) emitTestingSnapshotMIR(c *mir.CallInstr) error {
 	}
 	g.declareRuntime("osty_rt_test_snapshot", mirRuntimeDeclareThreePtrVoidLine("osty_rt_test_snapshot"))
 	sourceSym := g.stringLiteral(g.source)
-	g.fnBuf.WriteString(mirCallVoidLine("osty_rt_test_snapshot",
-		"ptr "+name+", ptr "+output+", ptr "+sourceSym))
+	g.fnBuf.WriteString(mirCallVoidFromThreePtrLine("osty_rt_test_snapshot", name, output, sourceSym))
 	return g.storeUnitDestIfAny(c)
 }
 
@@ -3542,12 +3538,8 @@ func (g *mirGen) emitBenchErrorCheck(retRef, prefix string) {
 	g.fnBuf.WriteString(mirICmpEqI64Line(isErr, tag, "0"))
 	errLabel := g.freshLabel(prefix + ".err")
 	okLabel := g.freshLabel(prefix + ".ok")
-	g.fnBuf.WriteString(mirBrCondLine(isErr, errLabel, okLabel))
-	g.fnBuf.WriteString(mirLabelLine(errLabel))
-	g.fnBuf.WriteString(mirCallVarargPrintfPathLine(errFmt, pathSym))
-	g.fnBuf.WriteString(mirCallExitLine("1"))
-	g.fnBuf.WriteString(mirUnreachableLine())
-	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	g.fnBuf.WriteString(mirBranchToErrorTrapLines(isErr, errLabel, okLabel))
+	g.fnBuf.WriteString(mirAbortPrintfExitLines(errFmt, pathSym, okLabel))
 }
 
 // invokeClosureOperand calls a closure value through its env pointer
@@ -4101,8 +4093,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		noneLabel := g.freshLabel("list.opt.none")
 		endLabel := g.freshLabel("list.opt.end")
 		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
-		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(destLLVM, destSlot, endLabel))
+		g.fnBuf.WriteString(mirNoneBranchLines(noneLabel, destLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		var idxRef string
 		if i.Kind == mir.IntrinsicListFirst {
@@ -4245,7 +4236,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
 		eqReg := g.fresh()
 		if stringEq != "" {
-			g.fnBuf.WriteString(mirCallValueLine(eqReg, "i1", stringEq, "ptr "+elemReg+", ptr "+needleReg))
+			g.fnBuf.WriteString(mirCallI1FromTwoPtrLine(eqReg, stringEq, elemReg, needleReg))
 		} else if elemLLVM == "double" {
 			g.fnBuf.WriteString(mirFCmpLine(eqReg, "oeq", "double", elemReg, needleReg))
 		} else {
@@ -4314,7 +4305,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+iReg))
 		eqReg := g.fresh()
 		if stringEq != "" {
-			g.fnBuf.WriteString(mirCallValueLine(eqReg, "i1", stringEq, "ptr "+elemReg+", ptr "+needleReg))
+			g.fnBuf.WriteString(mirCallI1FromTwoPtrLine(eqReg, stringEq, elemReg, needleReg))
 		} else if elemLLVM == "double" {
 			g.fnBuf.WriteString(mirFCmpLine(eqReg, "oeq", "double", elemReg, needleReg))
 		} else {
@@ -4359,8 +4350,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		noneLabel := g.freshLabel("list.pop.none")
 		endLabel := g.freshLabel("list.pop.end")
 		g.fnBuf.WriteString(mirBrCondLine(isEmpty, noneLabel, someLabel))
-		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(destLLVM, destSlot, endLabel))
+		g.fnBuf.WriteString(mirNoneBranchLines(noneLabel, destLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		lastIdx := g.fresh()
 		g.fnBuf.WriteString(mirSubI64MinusOneLine(lastIdx, lenReg))
@@ -4556,8 +4546,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		someStep := g.fresh()
 		someValue := g.fresh()
 		g.fnBuf.WriteString(mirSomeStoreThenJumpLines(someStep, someValue, optLLVM, payloadI64, destSlot, endLabel))
-		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		g.fnBuf.WriteString(mirNoneStoreThenJumpLines(optLLVM, destSlot, endLabel))
+		g.fnBuf.WriteString(mirNoneBranchLines(noneLabel, optLLVM, destSlot, endLabel))
 		g.fnBuf.WriteString(mirLabelLine(endLabel))
 		return nil
 	case mir.IntrinsicMapGetOr:
@@ -7181,9 +7170,7 @@ func (g *mirGen) emitListSafeGet(i *mir.IntrinsicInstr, listReg, idxReg, elemLLV
 	noneLabel := g.freshLabel("list.safeget.none")
 	endLabel := g.freshLabel("list.safeget.end")
 	g.fnBuf.WriteString(mirBrCondLine(inBounds, someLabel, noneLabel))
-	g.fnBuf.WriteString(mirLabelLine(noneLabel))
-	g.fnBuf.WriteString(mirStoreZeroinitLine(destLLVM, destSlot))
-	g.fnBuf.WriteString(mirBrUncondLine(endLabel))
+	g.fnBuf.WriteString(mirNoneBranchLines(noneLabel, destLLVM, destSlot, endLabel))
 	g.fnBuf.WriteString(mirLabelLine(someLabel))
 	elemReg := g.fresh()
 	g.fnBuf.WriteString(mirCallValueLine(elemReg, elemLLVM, getSym, "ptr "+listReg+", i64 "+idxReg))
@@ -7748,7 +7735,7 @@ func (g *mirGen) emitHeapEquality(op mir.BinaryOp, left, right string) (string, 
 	sym := llvmStringRuntimeEqualSymbol()
 	g.declareRuntime(sym, fmt.Sprintf("declare i1 @%s(ptr, ptr)", sym))
 	eq := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(eq, "i1", sym, "ptr "+left+", ptr "+right))
+	g.fnBuf.WriteString(mirCallI1FromTwoPtrLine(eq, sym, left, right))
 	if op == mir.BinEq {
 		return eq, nil
 	}
@@ -7847,7 +7834,7 @@ func (g *mirGen) emitStringOrdering(op mir.BinaryOp, left, right string) (string
 	sym := llvmStringRuntimeCompareSymbol()
 	g.declareRuntime(sym, fmt.Sprintf("declare i64 @%s(ptr, ptr)", sym))
 	cmp := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(cmp, "i64", sym, "ptr "+left+", ptr "+right))
+	g.fnBuf.WriteString(mirCallI64FromTwoPtrLine(cmp, sym, left, right))
 	pred := stringOrderingPredicate(op)
 	out := g.fresh()
 	g.fnBuf.WriteString(mirICmpLine(out, pred, "i64", cmp, "0"))

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -2999,3 +2999,190 @@ func mirCallValueI8FromPtrI64Line(reg, sym, ptr, idx string) string {
 func mirCallValueElemFromPtrI64Line(reg, elemLLVM, sym, ptr, idx string) string {
 	return mirCallValueLine(reg, elemLLVM, sym, "ptr "+ptr+", i64 "+idx)
 }
+
+// §6 abort-and-exit shape builders.
+
+// mirAbortPrintfExitLines renders printf+exit+unreachable+nextLabel.
+// Osty: mirAbortPrintfExitLines
+func mirAbortPrintfExitLines(fmtSym, messagePtr, nextLabel string) string {
+	return mirCallVarargPrintfPathLine(fmtSym, messagePtr) +
+		mirCallExitLine("1") +
+		mirUnreachableLine() +
+		mirLabelLine(nextLabel)
+}
+
+// mirBranchToErrorTrapLines renders `br i1 <isErr> + errLabel:`.
+// Osty: mirBranchToErrorTrapLines
+func mirBranchToErrorTrapLines(isErr, errLabel, okLabel string) string {
+	return mirBrCondLine(isErr, errLabel, okLabel) + mirLabelLine(errLabel)
+}
+
+// mirNoneBranchLines renders Option-miss branch (label + zeroinit + br).
+// Osty: mirNoneBranchLines
+func mirNoneBranchLines(noneLabel, optLLVM, destSlot, endLabel string) string {
+	return mirLabelLine(noneLabel) + mirNoneStoreThenJumpLines(optLLVM, destSlot, endLabel)
+}
+
+// mirSomeBranchLines renders Option-hit branch (label + Some + store + br).
+// Osty: mirSomeBranchLines
+func mirSomeBranchLines(someLabel, taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel string) string {
+	return mirLabelLine(someLabel) + mirSomeStoreThenJumpLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel)
+}
+
+// mirSomeNoneJoinLines renders the convergence label.
+// Osty: mirSomeNoneJoinLines
+func mirSomeNoneJoinLines(endLabel string) string {
+	return mirLabelLine(endLabel)
+}
+
+// mirCallExitOneLine returns canonical `call void @exit(i32 1)`.
+// Osty: mirCallExitOneLine
+func mirCallExitOneLine() string {
+	return mirCallExitLine("1")
+}
+
+// mirCallExitZeroLine returns canonical `call void @exit(i32 0)`.
+// Osty: mirCallExitZeroLine
+func mirCallExitZeroLine() string {
+	return mirCallExitLine("0")
+}
+
+// mirAbortBlockLines renders the full abort block.
+// Osty: mirAbortBlockLines
+func mirAbortBlockLines(errLabel, fmtSym, messagePtr, nextLabel string) string {
+	return mirLabelLine(errLabel) + mirAbortPrintfExitLines(fmtSym, messagePtr, nextLabel)
+}
+
+// mirCallI64FromTwoPtrLine renders `<reg> = call i64 @<sym>(ptr, ptr)`.
+// Osty: mirCallI64FromTwoPtrLine
+func mirCallI64FromTwoPtrLine(reg, sym, left, right string) string {
+	return mirCallValueLine(reg, "i64", sym, "ptr "+left+", ptr "+right)
+}
+
+// mirCallI1FromTwoPtrLine renders `<reg> = call i1 @<sym>(ptr, ptr)`.
+// Osty: mirCallI1FromTwoPtrLine
+func mirCallI1FromTwoPtrLine(reg, sym, left, right string) string {
+	return mirCallValueLine(reg, "i1", sym, "ptr "+left+", ptr "+right)
+}
+
+// mirCallPtrFromTwoPtrLine renders `<reg> = call ptr @<sym>(ptr, ptr)`.
+// Osty: mirCallPtrFromTwoPtrLine
+func mirCallPtrFromTwoPtrLine(reg, sym, left, right string) string {
+	return mirCallValueLine(reg, "ptr", sym, "ptr "+left+", ptr "+right)
+}
+
+// mirCallVoidFromTwoPtrLine renders `call void @<sym>(ptr, ptr)`.
+// Osty: mirCallVoidFromTwoPtrLine
+func mirCallVoidFromTwoPtrLine(sym, left, right string) string {
+	return mirCallVoidLine(sym, "ptr "+left+", ptr "+right)
+}
+
+// mirCallVoidFromThreePtrLine renders `call void @<sym>(ptr, ptr, ptr)`.
+// Osty: mirCallVoidFromThreePtrLine
+func mirCallVoidFromThreePtrLine(sym, a, b, c string) string {
+	return mirCallVoidLine(sym, "ptr "+a+", ptr "+b+", ptr "+c)
+}
+
+// mirInsertValueI64IndexLine renders `<reg> = insertvalue <aggTy> <base>, i64 <val>, <idx>`.
+// Osty: mirInsertValueI64IndexLine
+func mirInsertValueI64IndexLine(reg, aggTy, baseVal, val, idxDigits string) string {
+	return mirInsertValueAggLine(reg, aggTy, baseVal, "i64", val, idxDigits)
+}
+
+// mirExtractValueI64IndexLine renders `<reg> = extractvalue <aggTy> <agg>, <idx>`.
+// Osty: mirExtractValueI64IndexLine
+func mirExtractValueI64IndexLine(reg, aggTy, aggVal, idxDigits string) string {
+	return "  " + reg + " = extractvalue " + aggTy + " " + aggVal + ", " + idxDigits + "\n"
+}
+
+// mirCallVoidI64Line renders `call void @<sym>(i64 <arg>)`.
+// Osty: mirCallVoidI64Line
+func mirCallVoidI64Line(sym, arg string) string {
+	return mirCallVoidLine(sym, "i64 "+arg)
+}
+
+// mirCallVoidI32Line renders `call void @<sym>(i32 <arg>)`.
+// Osty: mirCallVoidI32Line
+func mirCallVoidI32Line(sym, arg string) string {
+	return mirCallVoidLine(sym, "i32 "+arg)
+}
+
+// mirGEPInboundsI64IdxLine renders i64-indexed inbounds GEP.
+// Osty: mirGEPInboundsI64IdxLine
+func mirGEPInboundsI64IdxLine(reg, elemTy, basePtr, idx string) string {
+	return "  " + reg + " = getelementptr inbounds " + elemTy + ", ptr " + basePtr + ", i64 " + idx + "\n"
+}
+
+// mirZExtToI64Line / mirSExtToI64Line / mirBitcastToI64Line / mirPtrToInt64Line — i64-payload widen specializations.
+// Osty: mirZExtToI64Line
+func mirZExtToI64Line(reg, fromTy, val string) string { return mirZExtLine(reg, fromTy, val, "i64") }
+
+// Osty: mirSExtToI64Line
+func mirSExtToI64Line(reg, fromTy, val string) string { return mirSExtLine(reg, fromTy, val, "i64") }
+
+// Osty: mirBitcastToI64Line
+func mirBitcastToI64Line(reg, val string) string { return mirBitcastLine(reg, "double", val, "i64") }
+
+// Osty: mirPtrToInt64Line
+func mirPtrToInt64Line(reg, val string) string { return mirPtrToIntLine(reg, val, "i64") }
+
+// mirCallStringConcatLine specialisation for osty_rt_strings_Concat.
+// Osty: mirCallStringConcatLine
+func mirCallStringConcatLine(reg, left, right string) string {
+	return mirCallPtrFromTwoPtrLine(reg, "osty_rt_strings_Concat", left, right)
+}
+
+// mirCallStringEqualLine specialisation for osty_rt_strings_Equal.
+// Osty: mirCallStringEqualLine
+func mirCallStringEqualLine(reg, left, right string) string {
+	return mirCallI1FromTwoPtrLine(reg, "osty_rt_strings_Equal", left, right)
+}
+
+// mirCallStringCompareLine specialisation for osty_rt_strings_Compare.
+// Osty: mirCallStringCompareLine
+func mirCallStringCompareLine(reg, left, right string) string {
+	return mirCallI64FromTwoPtrLine(reg, "osty_rt_strings_Compare", left, right)
+}
+
+// mirCallStringSubstringLine specialisation for osty_rt_strings_Substring.
+// Osty: mirCallStringSubstringLine
+func mirCallStringSubstringLine(reg, src, startIdx, endIdx string) string {
+	return mirCallValueLine(reg, "ptr", "osty_rt_strings_Substring", "ptr "+src+", i64 "+startIdx+", i64 "+endIdx)
+}
+
+// mirCallListNewLine renders osty_rt_list_new() call.
+// Osty: mirCallListNewLine
+func mirCallListNewLine(reg string) string {
+	return mirCallValueNoArgsLine(reg, "ptr", "osty_rt_list_new")
+}
+
+// mirCallMapNewLine renders osty_rt_map_new(...) call.
+// Osty: mirCallMapNewLine
+func mirCallMapNewLine(reg, keyKind, valKind, valSize string) string {
+	return mirCallValueLine(reg, "ptr", "osty_rt_map_new", "i64 "+keyKind+", i64 "+valKind+", i64 "+valSize+", ptr null")
+}
+
+// mirCallSetNewLine renders osty_rt_set_new(elemKind) call.
+// Osty: mirCallSetNewLine
+func mirCallSetNewLine(reg, elemKind string) string {
+	return mirCallValueLine(reg, "ptr", "osty_rt_set_new", "i64 "+elemKind)
+}
+
+// mirSizeOf*Line — canonical sizeof literals.
+// Osty: mirSizeOfDoubleLine
+func mirSizeOfDoubleLine() string { return "8" }
+
+// Osty: mirSizeOfI64Line
+func mirSizeOfI64Line() string { return "8" }
+
+// Osty: mirSizeOfI32Line
+func mirSizeOfI32Line() string { return "4" }
+
+// Osty: mirSizeOfI8Line
+func mirSizeOfI8Line() string { return "1" }
+
+// Osty: mirSizeOfPtrLine
+func mirSizeOfPtrLine() string { return "8" }
+
+// Osty: mirSizeOfI1Line
+func mirSizeOfI1Line() string { return "1" }

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -3979,3 +3979,299 @@ pub fn mirCallValueI8FromPtrI64Line(reg: String, sym: String, ptr: String, idx: 
 pub fn mirCallValueElemFromPtrI64Line(reg: String, elemLLVM: String, sym: String, ptr: String, idx: String) -> String {
     mirCallValueLine(reg, elemLLVM, sym, "ptr " + ptr + ", i64 " + idx)
 }
+
+/// §6 abort-and-exit shape builders — drain the canonical
+/// "print error message, exit, unreachable, then continue at next
+/// label" sequence used by every testing-abort and bench-error
+/// site. Keeps the four-line block as one builder so the order
+/// stays stable across refactors.
+
+/// mirAbortPrintfExitLines renders the canonical abort sequence
+/// after the abort branch has been entered:
+///   `  call i32 (ptr, ...) @printf(ptr <fmt>, ptr <message>)\n`
+///   `  call void @exit(i32 1)\n`
+///   `  unreachable\n`
+///   `<nextLabel>:\n`
+/// Four-line block. Used by `emitTestingAbortString`,
+/// `emitBenchErrorCheck`, and any future panic-helper emitter.
+/// `fmtSym` is the format-string literal symbol; `messagePtr` is
+/// the SSA register or symbol holding the message ptr; `nextLabel`
+/// is the post-abort continuation label (typically a fresh
+/// `test.dead` / `bench.ok` label).
+pub fn mirAbortPrintfExitLines(fmtSym: String, messagePtr: String, nextLabel: String) -> String {
+    mirCallVarargPrintfPathLine(fmtSym, messagePtr) +
+    mirCallExitLine("1") +
+    mirUnreachableLine() +
+    mirLabelLine(nextLabel)
+}
+
+/// mirBranchToErrorTrapLines renders the gate that routes Result
+/// `Err` into an abort:
+///   `  br i1 <isErr>, label %<errLabel>, label %<okLabel>\n`
+///   `<errLabel>:\n`
+/// Two-line block. Caller chains it with `mirAbortPrintfExitLines`
+/// (or its equivalent) to build the full error-trap path. Sibling
+/// of `mirNoneBranchLines` for the Result rather than Option case.
+pub fn mirBranchToErrorTrapLines(isErr: String, errLabel: String, okLabel: String) -> String {
+    mirBrCondLine(isErr, errLabel, okLabel) +
+    mirLabelLine(errLabel)
+}
+
+/// mirNoneBranchLines renders the canonical Option-miss branch:
+///   `<noneLabel>:\n`
+///   `  store <optTy> zeroinitializer, ptr <destSlot>\n`
+///   `  br label %<endLabel>\n`
+/// Three-line block. Caller pairs it with `mirSomeBranchLines` for
+/// the hit path. Drains the label+store+br pattern repeated at
+/// every list/map probe site that produces Option<T>.
+pub fn mirNoneBranchLines(noneLabel: String, optLLVM: String, destSlot: String, endLabel: String) -> String {
+    mirLabelLine(noneLabel) +
+    mirNoneStoreThenJumpLines(optLLVM, destSlot, endLabel)
+}
+
+/// mirSomeBranchLines renders the canonical Option-hit branch:
+///   `<someLabel>:\n`
+///   `  <tagged> = insertvalue <optTy> undef, i64 1, 0\n`
+///   `  <filled> = insertvalue <optTy> <tagged>, i64 <payload>, 1\n`
+///   `  store <optTy> <filled>, ptr <destSlot>\n`
+///   `  br label %<endLabel>\n`
+/// Five-line block. Combines the Some-aggregate construction with
+/// the canonical store+jump pattern. Sibling of
+/// `mirNoneBranchLines` for the hit path.
+pub fn mirSomeBranchLines(someLabel: String, taggedReg: String, filledReg: String, optLLVM: String, payloadI64: String, destSlot: String, endLabel: String) -> String {
+    mirLabelLine(someLabel) +
+    mirSomeStoreThenJumpLines(taggedReg, filledReg, optLLVM, payloadI64, destSlot, endLabel)
+}
+
+/// mirSomeNoneJoinLines renders the convergence label of an
+/// Option probe — the join block that both Some and None paths
+/// branch to:
+///   `<endLabel>:\n`
+/// One-line block. Trivial pass-through to `mirLabelLine`, named
+/// for readability so callers can grep for the join site separately
+/// from the dozens of other label emissions.
+pub fn mirSomeNoneJoinLines(endLabel: String) -> String {
+    mirLabelLine(endLabel)
+}
+
+/// mirCallExitOneLine returns the canonical `call void @exit(i32 1)`
+/// line — the most common call-exit pattern (testing-abort,
+/// bench-error, panic-helper). Specialisation of `mirCallExitLine`
+/// for the literal exit code "1" so callers don't thread the digit
+/// through every call site.
+pub fn mirCallExitOneLine() -> String {
+    mirCallExitLine("1")
+}
+
+/// mirCallExitZeroLine returns the canonical `call void @exit(i32
+/// 0)` line — the success-exit pattern used by the bench summary's
+/// final exit. Sibling of `mirCallExitOneLine` for the success
+/// case.
+pub fn mirCallExitZeroLine() -> String {
+    mirCallExitLine("0")
+}
+
+/// mirAbortBlockLines renders the full abort block as one helper:
+///   `<errLabel>:\n`
+///   `  call i32 (ptr, ...) @printf(ptr <fmt>, ptr <message>)\n`
+///   `  call void @exit(i32 1)\n`
+///   `  unreachable\n`
+///   `<nextLabel>:\n`
+/// Five-line block. Combines `mirLabelLine(errLabel)` with
+/// `mirAbortPrintfExitLines`. Drains the entire error-trap body
+/// at sites that already bail with cond-br to errLabel.
+pub fn mirAbortBlockLines(errLabel: String, fmtSym: String, messagePtr: String, nextLabel: String) -> String {
+    mirLabelLine(errLabel) +
+    mirAbortPrintfExitLines(fmtSym, messagePtr, nextLabel)
+}
+
+/// mirCallI64FromTwoPtrLine renders the canonical i64-from-two-ptr
+/// runtime call: `<reg> = call i64 @<sym>(ptr <left>, ptr <right>)`.
+/// Used by `osty_rt_strings_Compare`'s ordering call and similar
+/// two-pointer scalar-returning probes. Sibling of
+/// `mirCallValueI64FromPtrLine` for the two-arg case.
+pub fn mirCallI64FromTwoPtrLine(reg: String, sym: String, left: String, right: String) -> String {
+    mirCallValueLine(reg, "i64", sym, "ptr " + left + ", ptr " + right)
+}
+
+/// mirCallI1FromTwoPtrLine renders the canonical i1-from-two-ptr
+/// runtime call: `<reg> = call i1 @<sym>(ptr <left>, ptr <right>)`.
+/// Used by `osty_rt_strings_Equal` / `osty_rt_bytes_starts_with` /
+/// `osty_rt_bytes_ends_with` and the inline string-equality
+/// runtime hook. Sibling of `mirCallI64FromTwoPtrLine` for the
+/// boolean-returning case.
+pub fn mirCallI1FromTwoPtrLine(reg: String, sym: String, left: String, right: String) -> String {
+    mirCallValueLine(reg, "i1", sym, "ptr " + left + ", ptr " + right)
+}
+
+/// mirCallPtrFromTwoPtrLine renders the canonical ptr-from-two-ptr
+/// runtime call: `<reg> = call ptr @<sym>(ptr <left>, ptr <right>)`.
+/// Used by `osty_rt_strings_Concat`, `osty_rt_strings_DiffLines`,
+/// and other two-string runtime constructors.
+pub fn mirCallPtrFromTwoPtrLine(reg: String, sym: String, left: String, right: String) -> String {
+    mirCallValueLine(reg, "ptr", sym, "ptr " + left + ", ptr " + right)
+}
+
+/// mirCallVoidFromTwoPtrLine renders the canonical void-from-two-
+/// ptr runtime call: `call void @<sym>(ptr <left>, ptr <right>)`.
+/// Used by side-effect runtimes that operate on a pair of handles.
+pub fn mirCallVoidFromTwoPtrLine(sym: String, left: String, right: String) -> String {
+    mirCallVoidLine(sym, "ptr " + left + ", ptr " + right)
+}
+
+/// mirCallVoidFromThreePtrLine renders `call void @<sym>(ptr, ptr, ptr)`
+/// — the three-pointer side-effect ABI used by
+/// `osty_rt_test_snapshot(name, expected, actual)`.
+pub fn mirCallVoidFromThreePtrLine(sym: String, a: String, b: String, c: String) -> String {
+    mirCallVoidLine(sym, "ptr " + a + ", ptr " + b + ", ptr " + c)
+}
+
+/// mirInsertValueI64IndexLine renders an insertvalue specialised
+/// for the `i64` field type — the most common shape inside
+/// Option/Result aggregate construction:
+///   `  <reg> = insertvalue <aggTy> <baseVal>, i64 <val>, <idxDigits>\n`
+/// Companion to `mirInsertValueAggLine` for the i64-typed case
+/// (which is every disc + payload slot for Option/Result).
+pub fn mirInsertValueI64IndexLine(reg: String, aggTy: String, baseVal: String, val: String, idxDigits: String) -> String {
+    mirInsertValueAggLine(reg, aggTy, baseVal, "i64", val, idxDigits)
+}
+
+/// mirExtractValueI64IndexLine renders an extractvalue specialised
+/// for the `i64` field type — used by every Option / Result
+/// discriminant + payload read.
+pub fn mirExtractValueI64IndexLine(reg: String, aggTy: String, aggVal: String, idxDigits: String) -> String {
+    "  " + reg + " = extractvalue " + aggTy + " " + aggVal + ", " + idxDigits + "\n"
+}
+
+/// mirCallVoidI64Line renders `  call void @<sym>(i64 <arg>)\n`
+/// — the single-i64-arg side-effect call, mirroring the
+/// `call void @exit(i32 1)` shape but for i64 callees. Used by
+/// some debug / runtime hooks that take a single i64 token.
+pub fn mirCallVoidI64Line(sym: String, arg: String) -> String {
+    mirCallVoidLine(sym, "i64 " + arg)
+}
+
+/// mirCallVoidI32Line renders `  call void @<sym>(i32 <arg>)\n`
+/// — the i32-typed sibling of `mirCallVoidI64Line`. The literal
+/// `mirCallExitLine` covers the exact `@exit` symbol; this builder
+/// is the abstract form for any i32-arg side-effect call.
+pub fn mirCallVoidI32Line(sym: String, arg: String) -> String {
+    mirCallVoidLine(sym, "i32 " + arg)
+}
+
+/// mirGEPInboundsI64IdxLine renders the i64-indexed inbounds GEP
+/// shape used by per-element list iteration:
+///   `  <reg> = getelementptr inbounds <elemTy>, ptr <basePtr>, i64 <idx>\n`
+/// The MIR emitter's vector-list fast path currently spells this out
+/// inline at every load/store site. Combining the type tag with the
+/// i64-stride convention keeps the GEP shape stable across refactors.
+pub fn mirGEPInboundsI64IdxLine(reg: String, elemTy: String, basePtr: String, idx: String) -> String {
+    "  " + reg + " = getelementptr inbounds " + elemTy + ", ptr " + basePtr + ", i64 " + idx + "\n"
+}
+
+/// mirZExtToI64Line / mirSExtToI64Line render the canonical "widen
+/// to i64 payload slot" shape used by Option / Result aggregate
+/// construction:
+///   `  <reg> = zext <fromTy> <val> to i64\n`
+///   `  <reg> = sext <fromTy> <val> to i64\n`
+/// Specialise `mirZExtLine` / `mirSExtLine` for the common destination
+/// width — every payload-slot widen lands at i64, so the helper saves
+/// the trailing `"i64"` thread at every call site.
+pub fn mirZExtToI64Line(reg: String, fromTy: String, val: String) -> String {
+    mirZExtLine(reg, fromTy, val, "i64")
+}
+
+pub fn mirSExtToI64Line(reg: String, fromTy: String, val: String) -> String {
+    mirSExtLine(reg, fromTy, val, "i64")
+}
+
+/// mirBitcastToI64Line / mirPtrToInt64Line render canonical "narrow
+/// to i64 payload slot" shapes for double / ptr payloads:
+///   `  <reg> = bitcast double <val> to i64\n`
+///   `  <reg> = ptrtoint ptr <val> to i64\n`
+pub fn mirBitcastToI64Line(reg: String, val: String) -> String {
+    mirBitcastLine(reg, "double", val, "i64")
+}
+
+pub fn mirPtrToInt64Line(reg: String, val: String) -> String {
+    mirPtrToIntLine(reg, val, "i64")
+}
+
+/// mirCallStringConcatLine renders the canonical String concat call
+/// shape: `<reg> = call ptr @osty_rt_strings_Concat(ptr <left>, ptr <right>)`.
+/// Specialisation of `mirCallPtrFromTwoPtrLine` for the literal
+/// `osty_rt_strings_Concat` symbol — the most-called runtime symbol
+/// in a typical program (every `+` on String, every interpolation
+/// segment chain).
+pub fn mirCallStringConcatLine(reg: String, left: String, right: String) -> String {
+    mirCallPtrFromTwoPtrLine(reg, "osty_rt_strings_Concat", left, right)
+}
+
+/// mirCallStringEqualLine renders the canonical String equal call
+/// shape: `<reg> = call i1 @osty_rt_strings_Equal(ptr <left>, ptr <right>)`.
+/// Specialisation of `mirCallI1FromTwoPtrLine` for the
+/// `osty_rt_strings_Equal` symbol used by `==` on String.
+pub fn mirCallStringEqualLine(reg: String, left: String, right: String) -> String {
+    mirCallI1FromTwoPtrLine(reg, "osty_rt_strings_Equal", left, right)
+}
+
+/// mirCallStringCompareLine renders the canonical String lex-compare
+/// call: `<reg> = call i64 @osty_rt_strings_Compare(ptr <left>, ptr <right>)`.
+/// Returns negative / zero / positive in the libc strcmp convention.
+/// Used by `<` / `<=` / `>` / `>=` on String.
+pub fn mirCallStringCompareLine(reg: String, left: String, right: String) -> String {
+    mirCallI64FromTwoPtrLine(reg, "osty_rt_strings_Compare", left, right)
+}
+
+/// mirCallStringSubstringLine renders the canonical String substring
+/// call: `<reg> = call ptr @osty_rt_strings_Substring(ptr <s>, i64 <start>, i64 <end>)`.
+/// Specialisation for the slice-shape ABI.
+pub fn mirCallStringSubstringLine(reg: String, src: String, startIdx: String, endIdx: String) -> String {
+    mirCallValueLine(reg, "ptr", "osty_rt_strings_Substring", "ptr " + src + ", i64 " + startIdx + ", i64 " + endIdx)
+}
+
+/// mirCallListNewLine renders `<reg> = call ptr @osty_rt_list_new()`
+/// — the no-arg list constructor used at every `[]` literal /
+/// IntrinsicListNew site. Specialisation of
+/// `mirCallValueNoArgsLine` for the literal symbol.
+pub fn mirCallListNewLine(reg: String) -> String {
+    mirCallValueNoArgsLine(reg, "ptr", "osty_rt_list_new")
+}
+
+/// mirCallMapNewLine renders the canonical map constructor call:
+///   `<reg> = call ptr @osty_rt_map_new(i64 <keyKind>, i64 <valKind>, i64 <valSize>, ptr null)`
+/// Used by `{:}` literal / IntrinsicMapNew site. The fourth `ptr null`
+/// is the optional GC site-token.
+pub fn mirCallMapNewLine(reg: String, keyKind: String, valKind: String, valSize: String) -> String {
+    mirCallValueLine(reg, "ptr", "osty_rt_map_new", "i64 " + keyKind + ", i64 " + valKind + ", i64 " + valSize + ", ptr null")
+}
+
+/// mirCallSetNewLine renders the canonical set constructor call:
+///   `<reg> = call ptr @osty_rt_set_new(i64 <elemKind>)`
+/// One-arg version for set; the runtime infers element layout from
+/// the kind tag.
+pub fn mirCallSetNewLine(reg: String, elemKind: String) -> String {
+    mirCallValueLine(reg, "ptr", "osty_rt_set_new", "i64 " + elemKind)
+}
+
+/// mirSizeOfDoubleLine returns the canonical sizeof(double) literal
+/// "8" — the constant that bench's `bytes_total / safeN` divisor and
+/// other sites use directly. Centralised so a future ABI change
+/// (e.g. f128 elements) only touches one site.
+pub fn mirSizeOfDoubleLine() -> String { "8" }
+
+/// mirSizeOfI64Line returns the canonical sizeof(i64) literal "8".
+pub fn mirSizeOfI64Line() -> String { "8" }
+
+/// mirSizeOfI32Line returns the canonical sizeof(i32) literal "4".
+pub fn mirSizeOfI32Line() -> String { "4" }
+
+/// mirSizeOfI8Line returns the canonical sizeof(i8) literal "1".
+pub fn mirSizeOfI8Line() -> String { "1" }
+
+/// mirSizeOfPtrLine returns the canonical sizeof(ptr) literal "8".
+pub fn mirSizeOfPtrLine() -> String { "8" }
+
+/// mirSizeOfI1Line returns the canonical sizeof(i1)-as-i8 literal "1"
+/// (LLVM materialises i1 in a byte-wide slot for storage).
+pub fn mirSizeOfI1Line() -> String { "1" }


### PR DESCRIPTION
## Summary

- Adds 32 new line-builders to `toolchain/mir_generator.osty` covering the canonical abort-and-exit sequences, Option-arm branch blocks, two-ptr runtime calls, i64-payload widen specialisations, and literal-symbol runtime call shapes
- §6 abort-and-exit (5): `mirAbortPrintfExitLines` (4-line block), `mirBranchToErrorTrapLines` (2-line block), `mirAbortBlockLines` (5-line block), `mirCallExitOneLine`, `mirCallExitZeroLine`
- §6 Option-branch (3): `mirNoneBranchLines` (3-line block: label + zeroinit + br), `mirSomeBranchLines` (5-line block: label + Some-aggregate + store + br), `mirSomeNoneJoinLines`
- §6 two/three-ptr runtime calls (5): `mirCallI64FromTwoPtrLine`, `mirCallI1FromTwoPtrLine`, `mirCallPtrFromTwoPtrLine`, `mirCallVoidFromTwoPtrLine`, `mirCallVoidFromThreePtrLine`
- §6 i64-payload widen specialisations (4): `mirZExtToI64Line`, `mirSExtToI64Line`, `mirBitcastToI64Line`, `mirPtrToInt64Line`
- §6 literal-symbol runtime call shapes (4): `mirCallStringConcatLine`, `mirCallStringEqualLine`, `mirCallStringCompareLine`, `mirCallStringSubstringLine`
- §6 constructor + sizeof helpers (8): `mirCallListNewLine`, `mirCallMapNewLine`, `mirCallSetNewLine`, `mirSizeOf{Double,I64,I32,I8,Ptr,I1}Line`
- §6 misc (3): `mirCallVoidI64Line` / `mirCallVoidI32Line`, `mirGEPInboundsI64IdxLine`, `mirInsertValueI64IndexLine` / `mirExtractValueI64IndexLine`

## Drain sites

| Site | Before | After |
|------|--------|-------|
| `emitTestingAbortString` | 4-line printf+exit+unreachable+label | `mirAbortPrintfExitLines` 1-call |
| `emitBenchErrorCheck` | 5-line cond-br+label+printf+exit+unreachable+label | `mirBranchToErrorTrapLines` + `mirAbortPrintfExitLines` (2 calls) |
| 5 `IntrinsicList{First,Last,Pop,SafeGet}` / `IntrinsicMapGet` None-arm bodies | label + zeroinit + br (3 calls) | `mirNoneBranchLines` 1-call |
| `emitTestingSnapshotMIR` | `mirCallVoidLine(sym, "ptr "+a+", ptr "+b+", ptr "+c)` | `mirCallVoidFromThreePtrLine` 1-call |
| All 2-ptr `mirCallValueLine(_, "i1"|"i64", _, "ptr "+left+", ptr "+right)` sites | inline 4-arg call | `mirCallI1FromTwoPtrLine` / `mirCallI64FromTwoPtrLine` |

## Diffstat

**511 insertions / 25 deletions** across 4 files.

## Test plan

- [x] `go build ./internal/llvmgen/...` clean
- [x] `go vet ./internal/llvmgen/...` clean
- [x] Byte-stable golden parity: pre/post `go test ./internal/llvmgen/...` reports identical 6-failure set (empty diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)