### PR TITLE
perf(runtime): SSO output for int/bool/char/byte/float to_string (1.10-1.13× big-map / log-aggregator)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -5531,7 +5531,30 @@ const char *osty_rt_int_to_string(int64_t value) {
     if (written < 0) {
         osty_rt_abort("failed to format Int as String");
     }
-    return osty_rt_string_dup_site(buffer, (size_t)written, "runtime.int.to_string");
+    /* SSO output: ≤7-byte results pack into the pointer tag bits and
+     * skip the GC alloc entirely. That covers most realistic ranges:
+     * unsigned 0..9999999 (7 digits), signed -999999..9999999, and
+     * 6-digit-bounded counters typical for IDs / row indices /
+     * timestamp seconds-since-launch. Larger magnitudes (≥ 10⁷ unsigned,
+     * negative ≥ 10⁶) fall back to the heap path automatically.
+     *
+     * The output flows safely into every existing caller because every
+     * String consumer in the runtime is SSO-aware: `osty_rt_io_write`
+     * decodes via `osty_rt_string_decode_to_buf_if_inline` before
+     * `fputs`, `osty_rt_strings_Concat`/`ConcatN` use
+     * `osty_rt_string_copy_bytes` which branches on the SSO tag,
+     * `osty_rt_string_hash`/`_compare_bytes`/`_measure` all decode SSO,
+     * and Map/Set String key paths read through the same `_measure` /
+     * `_equal_bytes` helpers. Only direct `fputs(p)` / `printf("%s", p)`
+     * with the raw pointer would crash, and the runtime emits no such
+     * site (everything routes through `osty_rt_io_write`).
+     *
+     * Hot win: big-map's per-iteration `m.insert("key:" + i.toString(), i)`
+     * was paying one `osty_gc_allocate_managed(...STRING)` per
+     * Int.toString call — at 200K inserts + 1M lookups that's 1.2M
+     * allocations now skipped. The Concat call still allocates the
+     * combined `"key:N"` string, but the per-toString alloc is gone. */
+    return osty_rt_string_dup_site_sso(buffer, (size_t)written, "runtime.int.to_string");
 }
 
 /* Monotonic-clock sample in nanoseconds, exported for the benchmark
@@ -5633,10 +5656,14 @@ int64_t osty_rt_bench_target_ns(void) {
 }
 
 const char *osty_rt_bool_to_string(bool value) {
+    /* "true" (4 bytes) and "false" (5 bytes) both fit in the 7-byte
+     * SSO budget. Sibling rationale to `osty_rt_int_to_string`: every
+     * runtime caller is SSO-aware, no libc-direct sites exist, the
+     * pointer tag carries the bytes inline so the GC alloc disappears. */
     if (value) {
-        return osty_rt_string_dup_site("true", 4, "runtime.bool.to_string");
+        return osty_rt_string_dup_site_sso("true", 4, "runtime.bool.to_string");
     }
-    return osty_rt_string_dup_site("false", 5, "runtime.bool.to_string");
+    return osty_rt_string_dup_site_sso("false", 5, "runtime.bool.to_string");
 }
 
 const char *osty_rt_char_to_string(int32_t codepoint) {
@@ -5668,31 +5695,43 @@ const char *osty_rt_char_to_string(int32_t codepoint) {
         buffer[2] = 0xBDU;
         len = 3;
     }
-    return osty_rt_string_dup_site((const char *)buffer, len, "runtime.char.to_string");
+    /* Char.toString output is always 1-4 UTF-8 bytes (REPLACEMENT
+     * CHAR is 3 bytes), well within the 7-byte SSO budget. Same SSO
+     * safety story as `osty_rt_int_to_string`: every consumer of the
+     * returned String routes through SSO-aware decoders. */
+    return osty_rt_string_dup_site_sso((const char *)buffer, len, "runtime.char.to_string");
 }
 
 const char *osty_rt_byte_to_string(int8_t value) {
     unsigned char byte = (unsigned char)value;
-    return osty_rt_string_dup_site((const char *)&byte, 1, "runtime.byte.to_string");
+    /* 1-byte payload — trivially SSO-eligible. */
+    return osty_rt_string_dup_site_sso((const char *)&byte, 1, "runtime.byte.to_string");
 }
 
 const char *osty_rt_float_to_string(double value) {
     char buffer[64];
 
+    /* Sentinel strings ("NaN", "-Inf", "+Inf") all fit in SSO. */
     if (isnan(value)) {
-        return osty_rt_string_dup_site("NaN", 3, "runtime.float.to_string");
+        return osty_rt_string_dup_site_sso("NaN", 3, "runtime.float.to_string");
     }
     if (isinf(value)) {
         if (value < 0) {
-            return osty_rt_string_dup_site("-Inf", 4, "runtime.float.to_string");
+            return osty_rt_string_dup_site_sso("-Inf", 4, "runtime.float.to_string");
         }
-        return osty_rt_string_dup_site("+Inf", 4, "runtime.float.to_string");
+        return osty_rt_string_dup_site_sso("+Inf", 4, "runtime.float.to_string");
     }
 
     if (snprintf(buffer, sizeof(buffer), "%.6f", value) < 0) {
         osty_rt_abort("failed to format Float as String");
     }
-    return osty_rt_string_dup_site(buffer, strlen(buffer), "runtime.float.to_string");
+    /* `%.6f` for typical values produces 8+ chars (e.g. "0.000000",
+     * "1.234567"), which exceeds the 7-byte SSO budget. `_sso` handles
+     * that gracefully by falling back to the heap path; the no-cost
+     * branch only triggers for tiny outputs (currently unreachable
+     * with `%.6f` but cheap insurance against future format changes
+     * like compact "1e3" / "0" representations). */
+    return osty_rt_string_dup_site_sso(buffer, strlen(buffer), "runtime.float.to_string");
 }
 
 int64_t osty_rt_strings_Compare(const char *left, const char *right) {


### PR DESCRIPTION
## Summary

Switch the five primitive `to_string` runtime helpers from `osty_rt_string_dup_site` (always heap-alloc) to `osty_rt_string_dup_site_sso` (pack ≤7-byte results into the pointer-tagged inline form). Almost all real outputs fit:

- `Int.toString`: 1-7 chars covers `0..9999999` and `-999999..9999999`
- `Bool.toString`: "true" (4) / "false" (5) — both fit
- `Char.toString`: 1-4 UTF-8 bytes — all fit
- `Byte.toString`: 1 byte — trivially fits
- `Float.toString`: `%.6f` outputs 8+ chars (heap fallback), but NaN/+Inf/-Inf sentinels SSO

That's one fewer GC alloc per call. For big-map's `m.insert("key:" + i.toString(), i)` × 1.2M call sites, that's 1.2M allocations skipped.

## Empirical (hyperfine -N --warmup 5+ --runs 30+, A/B same machine)

```
benchmark         result
big-map           SSO 1.13 ± 0.18× faster   ✓
log-aggregator    SSO 1.10 ± 0.14× faster   ✓
lru-sim           SSO 1.10 ± 0.27× faster
dep-resolver      SSO 1.07 ± 0.26× faster
expr-calc         base 1.03 ± 0.13× faster  tied
id-tracker        base 1.01 ± 0.16× faster  tied
markdown-stats    base 1.17 ± 0.50× faster  tied (CI ±0.50)
```

Strongest wins on Map<String, Int>-heavy benchmarks (big-map, log-aggregator) — exactly where the GC pressure from short-string allocs was visible in earlier profiles.

## Why this is safe

The `_sso` variant returns a tagged inline-pointer for `len <= 7`. Every existing String consumer in the runtime is SSO-aware:

- `osty_rt_io_write` decodes via `osty_rt_string_decode_to_buf_if_inline` before `fputs`/`fputc`
- `osty_rt_strings_Concat` / `_ConcatN` use `osty_rt_string_copy_bytes` which branches on the SSO tag
- `osty_rt_string_hash` / `_compare_bytes` / `_measure` decode SSO
- Map/Set String key paths read through the same `_measure`/`_equals` helpers

The runtime emits zero direct `fputs(p)` / `printf("%s", p)` sites with raw pointers — every IO write routes through `osty_rt_io_write`. The previous comment on `_dup_site_sso` flagged a hypothetical libc hand-off, but no such site exists today.

## Bonus: safer for Map<String, _> keys under GC moves

SSO Strings stored as Map keys are *safer* than heap Strings: the bytes are inline in the pointer itself, so there's no "forwarded reference becomes stale" failure mode if a tracer doesn't update its slot. (See PR #930 review — that exact failure mode bit `osty_rt_int_to_string` heap allocations under tinytag young space. SSO output sidesteps it entirely.)

## Test plan

- [x] `benchmarks/programs/build-all.sh` — all 7 programs byte-equal output to Go reference
- [x] `just front` — all front-end packages pass
- [x] `go test ./internal/llvmgen -run "TestBundled|TestRuntime|TestList|TestMap|TestGC"` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)