### PR TITLE
perf(mir): recover scrutinee type in lowerMatch — ErrType floor 426→374

### DIFF
--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -52,10 +52,13 @@ Pipeline-Clean timeout 도 풀렸다 (5분+ → 246s 정상 종료, 다음 wall 
   fallback 경로에서 발생. struct field 의 default value 가 LLVM runtime type
   surface 미지원. surface 확장 또는 default 제거 필요. `LLVM_BACKEND_CORPUS.md`
   에 LLVM011 추적 항목.
-- **426 ErrType locals (floor=40)** — Phase 0 가 PR #921 의 12개 type-error 중
-  11개를 제거했지만 (474 → 426, -48), 잔여 ~386 leaks 는 **checker 가 통과한
+- **374 ErrType locals (floor=40)** — Phase 0 가 PR #921 의 12개 type-error
+  중 11개를 제거하고 (474 → 426), Phase 3a 가 추가로 -52 (426 → 374,
+  `lowerMatch` scrutinee recovery). 잔여 ~334 leaks 는 **checker 가 통과한
   소스인데 ir.Lower / ir.Monomorphize 에서 타입을 못 잡는 사이트** 다 (`osty
-  check toolchain` 자체는 EXIT=0). 분포 (probe 결과 상위 10개):
+  check toolchain` 자체는 EXIT=0).
+
+  Phase 3a 분포 (probe 결과 상위 10개, 167 functions affected):
 
   | count | function |
   |---:|---|
@@ -64,17 +67,30 @@ Pipeline-Clean timeout 도 풀렸다 (5분+ → 246s 정상 종료, 다음 wall 
   | 12 | `llvmNativeEmitStmt` |
   | 10 | `hirOptimizeVisitModule` |
   | 9  | `hirReachExpr` |
-  | 8  | `pmTryCompileLitSwitch` |
-  | 7  | `hirReachExprAsMethods` |
   | 7  | `llvmNativeEmitFieldAssign` |
-  | 6  | `hirWalkVisitExpr` (×2 — same name in different scopes) |
+  | 7  | `hirReachExprAsMethods` |
+  | 6  | `mirDeadAssignElimBlock` |
+  | 6  | `hirWalkVisitExpr` |
   | 6  | `monoScanRoots` |
 
-  공통 패턴: 큰 `match expr.kind` 디스패치에서 매 arm 의 local binding (`let
-  folded = ...`) 이 ErrType 으로 떨어진다. 단일 파일 머지가 만드는 generic
-  instantiation context 에서 monomorph 이 inference 를 못 하는 케이스로 추정.
-  실제 multi-file 컴파일에서는 발생 안 함. 후속 fix 는 ir/mir lowering 의
-  recovery helper 를 generic-call site 에 확장하는 작업.
+  공통 패턴: 큰 `match expr.kind` 디스패치에서 `let folded = call(...)` 또는
+  `let kind = e.field` 이 ErrType 으로 떨어진다. Phase 3a (`lowerMatch`
+  scrutinee recovery) 가 cascade 의 seed (`_scrut` local) 를 차단했지만,
+  arm 안의 사용자 정의 enum variant ident 와 chained field/index access 의
+  recovery 는 아직 미흡. 단일 파일 머지가 만드는 generic instantiation
+  context 에서 monomorph 이 inference 를 못 하는 케이스로 추정. 실제
+  multi-file 컴파일에서는 발생 안 함.
+
+  Phase 3b 후보 (추가 진입 비용 낮음):
+  - `identTypeFromDecl` (`internal/ir/lower.go`) 에 `*ast.Variant` case 추가
+    — 현재 nil 반환 → 부모 enum 이름으로 `&ast.NamedType` 합성. 변수
+    `let mut kind = HirSwitchUnknown` 같은 bare variant ident 가 ErrType
+    으로 안 떨어지게 된다. (resolver 가 Variant Symbol 에 부모 enum 백포인터
+    를 안 보존하므로 lookup 헬퍼 신설 필요.)
+  - `bindingTypeFromAST` (`internal/ir/lower.go`) 가 `StructLit/ParenExpr`
+    만 처리 — `CallExpr` (recoverFnDeclReturnType 재사용), `IfExpr` (양쪽
+    branch 결과 type), `FieldExpr` (recoverFieldType 재사용), `IndexExpr`
+    (List<T>[i]→T) 추가.
 
 이 두 wall 은 현재 Phase 1 (E0553) 또는 1c.5 (Go resolver 삭제) 와는 독립이라
 별도 트랙으로 추적.

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1636,6 +1636,16 @@ func (bs *bodyState) lowerMatchExprInto(m *ir.MatchExpr, dest LocalID, destT Typ
 func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.DecisionNode, sp Span, dest *LocalID, destT Type) {
 	bs.pushScope()
 	scrutT := scrutinee.Type()
+	// Recover when the scrutinee carries an ErrType — same recovery
+	// chain that lowerLet uses. Otherwise `_scrut` becomes the seed of
+	// the cascade in `match e.kind { ... }` (the dominant pattern in
+	// the merged toolchain probe), and every arm-pattern binding
+	// inherits ErrType via UseRV propagation.
+	if isPoisonType(scrutT) {
+		if rt := bs.recoverOperandType(scrutinee); rt != nil && !isPoisonType(rt) {
+			scrutT = rt
+		}
+	}
 	if scrutT == nil {
 		scrutT = ir.ErrTypeVal
 	}


### PR DESCRIPTION
## Summary

Phase 3a of the [SELFHOST_PORT_MATRIX.md](SELFHOST_PORT_MATRIX.md) ErrType floor cleanup. Picks up where #932 left off (Phase 0 a/b/c).

`lowerMatch` previously took `scrutinee.Type()` directly into the `_scrut` local without recovery. When the scrutinee carried an ErrType — the dominant shape in the merged-toolchain probe, `match e.kind { ... }` over a HIR walker's parameter — `_scrut` became the seed of a cascade through every arm-pattern binding via `UseRV` propagation.

Routed through the same `recoverOperandType` chain that `lowerLet` already uses. This covers `FieldExpr` (via `bs.fieldExprType` → `bs.fieldExprInfo` → `bs.l.structFromType`), `Ident`-local lookup, `IfExpr` branches, etc.

**Measured impact** (`TestNativeToolchainMergedMIRErrTypeFloor`): **426 → 374 (−52)**. 167 functions still affected.

## Phase 3b candidates (follow-up, documented in matrix)

- `identTypeFromDecl` Variant case — `let mut kind = HirSwitchUnknown` reaches MIR with ErrType because `lowerIdent` recovery only handles `Param/LetStmt/LetDecl` decls. Variant Symbols don't carry parent-enum back-pointer, so need a small lookup helper.
- `bindingTypeFromAST` expansion — currently only handles `StructLit/ParenExpr`. Add `CallExpr` (recoverFnDeclReturnType reuse), `IfExpr`, `FieldExpr`, `IndexExpr`.

## Test plan

- [x] just prepush 로컬 통과 (fmt-check + vet + repair-check + ci)
- [x] go test -count=1 -short ./internal/mir/ green
- [x] TestNativeToolchainMergedMIRErrTypeFloor 측정 결과 426 → 374
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)