### PR TITLE
perf(runtime): prefetch keys[slot] in Map probe (1.31× big-map)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -7066,8 +7066,37 @@ static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_indexed(osty_rt_map *map, 
             return -1;
         }
         slot = entry - 1;
-        if (slot >= 0 && slot < map->len &&
-            map->index_hashes[idx] == key_fingerprint &&
+        if (slot < 0 || slot >= map->len) {
+            /* Stale slot index (e.g., post-remove compaction left a
+             * dangling entry). Keep walking; fingerprint match is the
+             * load-bearing guard. */
+            idx = (idx + 1) & mask;
+            continue;
+        }
+        /* Prefetch the candidate key BEFORE the fingerprint compare.
+         *
+         * `slot` lands at a hash-derived position in `keys[]` — NOT
+         * sequential with `idx` — so this load is a likely L2/L3 miss
+         * on every fresh probe. Issuing the prefetch here overlaps
+         * the cache fill with the cheap `index_hashes[idx] == fp`
+         * register compare and the conditional branch, so by the time
+         * `osty_rt_value_equals` actually dereferences `keys[slot]`
+         * (1-2 cycles later) the line is in L1.
+         *
+         * Locality `3` (T0 / keep-in-L1) because every fingerprint
+         * match consumes the line in the very next call frame —
+         * `osty_rt_value_equals` issues a memcpy on it, and for
+         * STRING/PTR kinds an `osty_gc_load_v1` plus the pointed-to
+         * payload follow. Lower temporal hints would route to L2 and
+         * force a re-fetch on the consume.
+         *
+         * Wasted on the rare fingerprint-mismatch path (~0.01% on a
+         * 32-bit fingerprint with low collision rate) — at one
+         * hardware prefetch per iteration this stays well under the
+         * LSU's outstanding-load budget on Apple Silicon and any
+         * current x86_64. */
+        __builtin_prefetch(osty_rt_map_key_slot(map, slot), 0, 3);
+        if (map->index_hashes[idx] == key_fingerprint &&
             osty_rt_value_equals(osty_rt_map_key_slot(map, slot), key, key_size, map->key_kind)) {
             return slot;
         }


### PR DESCRIPTION
## Summary

Add `__builtin_prefetch(keys + slot * key_size, 0, 3)` in `osty_rt_map_find_index_indexed` right after the slot is decoded. The cache fill overlaps with the fingerprint compare and conditional branch, so by the time `osty_rt_value_equals` dereferences `keys[slot]` (1-2 cycles later) the line is in L1.

## Why this is the right load to prefetch

Three array loads in the probe, very different cache behaviour:

- `index_slots[idx]` — 8 entries per cache line, sequential across collisions. Cold on first probe, warm thereafter.
- `index_hashes[idx]` — same shape, parallel array.
- `keys[slot]` — `slot` is hash-derived, NOT sequential with `idx`. Every match finds a fresh cold line.

The keys[slot] load is the dominant uncovered miss on ~100% of matches and ~0.01% of mismatches (32-bit fingerprint false-positive rate). Prefetching it turns that latency into hidden bandwidth.

Locality `3` (T0 / keep-in-L1) because the consumer (`osty_rt_value_equals`) executes 1-2 cycles after the prefetch — lower hints would route to L2 and force a re-fetch.

## Empirical (hyperfine -N --warmup 5+ --runs 30+, A/B same machine)

```
benchmark         result
big-map           prefetch 1.31 ± 0.25× faster   ✓✓
markdown-stats    prefetch 1.09 ± 0.10× faster   ✓
log-aggregator    prefetch 1.04 ± 0.07× faster   ✓
dep-resolver      prefetch 1.02 ± 0.07× faster   tied
id-tracker        prefetch 1.02 ± 0.07× faster   tied
expr-calc         base 1.00 ± 0.04× faster       tied
lru-sim           base 1.00 ± 0.09× faster       tied
```

big-map (200K Map<String,Int> + 1M lookups) — designed to exercise the cold keys[] line on every probe — drops from ~5.6× to ~4.3× vs Go. Win compounds with the SSO `int_to_string` change (#940).

## Side cleanup

Lifted the slot-bounds check out of the && short-circuit into an explicit guard. Functionally identical; makes the prefetch site conditional on a valid slot without duplicating the bounds check.

## Test plan

- [x] `benchmarks/programs/build-all.sh` — all 7 programs byte-equal to Go reference
- [x] `go test ./internal/llvmgen -run "TestBundled|TestRuntime|TestList|TestMap|TestGC"` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)