### PR TITLE
feat(llvmgen): allow struct field defaults + drain sibling lookupExpr/lookupCall O(N²)

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -830,12 +830,41 @@ type selfhostSpanIndex struct {
 	// equally large scopes map; the previous full-map scan was effectively
 	// O(N²) and timed the pipeline-clean test out at 5 minutes.
 	scopeQueries map[selfhostSpanKey]*resolve.Scope
+
+	// exprSpans is `exprKeys` sorted by exprKey.start asc, materialised
+	// lazily on the first lookupExpr fallback. Same shape as scopeSpans
+	// (sibling slow-path defence). exprQueries memoises results keyed by
+	// (key, kind) so repeated misses don't re-walk.
+	exprSpans   []exprSpanEntry
+	exprQueries map[exprQueryKey]ast.Expr
+
+	// callSpans / callQueries mirror exprSpans / exprQueries for
+	// lookupCall — same O(N²) fallback used to dominate the merged
+	// toolchain probe alongside scopeFor.
+	callSpans   []callSpanEntry
+	callQueries map[selfhostSpanKey]*ast.CallExpr
 }
 
 // scopeSpanEntry is one row of the sorted scope candidate list.
 type scopeSpanEntry struct {
 	span  selfhostSpanKey
 	scope *resolve.Scope
+}
+
+type exprSpanEntry struct {
+	span selfhostSpanKey
+	expr ast.Expr
+	kind string
+}
+
+type callSpanEntry struct {
+	span selfhostSpanKey
+	call *ast.CallExpr
+}
+
+type exprQueryKey struct {
+	span selfhostSpanKey
+	kind string
 }
 
 func (idx *selfhostSpanIndex) bindNode(key selfhostNameSpanKey, n ast.Node) {
@@ -1319,7 +1348,9 @@ func lookupLocalDeclSymbol(scope *resolve.Scope, name string, decl ast.Node) *re
 
 func (idx *selfhostSpanIndex) lookupExpr(key selfhostSpanKey, kind string) ast.Expr {
 	if expr := idx.exprs[key]; expr != nil {
-		return expr
+		if kind == "" || selfhostExprKind(expr) == kind {
+			return expr
+		}
 	}
 	var best ast.Expr
 	bestSize := int(^uint(0) >> 1)
@@ -1340,20 +1371,58 @@ func (idx *selfhostSpanIndex) lookupExpr(key selfhostSpanKey, kind string) ast.E
 	if best != nil {
 		return best
 	}
-	for expr, exprKey := range idx.exprKeys {
-		if kind != "" && selfhostExprKind(expr) != kind {
+	cacheKey := exprQueryKey{span: key, kind: kind}
+	if cached, ok := idx.exprQueries[cacheKey]; ok {
+		return cached
+	}
+	idx.ensureExprSpans()
+
+	list := idx.exprSpans
+	lo, hi := 0, len(list)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if list[mid].span.start <= key.start {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	for i := 0; i < lo; i++ {
+		e := list[i]
+		if kind != "" && e.kind != kind {
 			continue
 		}
-		if exprKey.start > key.start || exprKey.end < key.end {
+		if e.span.end < key.end {
 			continue
 		}
-		size := exprKey.end - exprKey.start
+		size := e.span.end - e.span.start
 		if size < bestSize {
-			best = expr
+			best = e.expr
 			bestSize = size
 		}
 	}
+	if idx.exprQueries == nil {
+		idx.exprQueries = map[exprQueryKey]ast.Expr{}
+	}
+	idx.exprQueries[cacheKey] = best
 	return best
+}
+
+func (idx *selfhostSpanIndex) ensureExprSpans() {
+	if idx.exprSpans != nil {
+		return
+	}
+	list := make([]exprSpanEntry, 0, len(idx.exprKeys))
+	for expr, span := range idx.exprKeys {
+		list = append(list, exprSpanEntry{span: span, expr: expr, kind: selfhostExprKind(expr)})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].span.start < list[j].span.start
+	})
+	if list == nil {
+		list = []exprSpanEntry{}
+	}
+	idx.exprSpans = list
 }
 
 func (idx *selfhostSpanIndex) lookupCall(key selfhostSpanKey) *ast.CallExpr {
@@ -1376,17 +1445,54 @@ func (idx *selfhostSpanIndex) lookupCall(key selfhostSpanKey) *ast.CallExpr {
 	if best != nil {
 		return best
 	}
-	for call, callKey := range idx.callKeys {
-		if callKey.start > key.start || callKey.end < key.end {
+	if cached, ok := idx.callQueries[key]; ok {
+		return cached
+	}
+	idx.ensureCallSpans()
+
+	list := idx.callSpans
+	lo, hi := 0, len(list)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if list[mid].span.start <= key.start {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	for i := 0; i < lo; i++ {
+		e := list[i]
+		if e.span.end < key.end {
 			continue
 		}
-		size := callKey.end - callKey.start
+		size := e.span.end - e.span.start
 		if size < bestSize {
-			best = call
+			best = e.call
 			bestSize = size
 		}
 	}
+	if idx.callQueries == nil {
+		idx.callQueries = map[selfhostSpanKey]*ast.CallExpr{}
+	}
+	idx.callQueries[key] = best
 	return best
+}
+
+func (idx *selfhostSpanIndex) ensureCallSpans() {
+	if idx.callSpans != nil {
+		return
+	}
+	list := make([]callSpanEntry, 0, len(idx.callKeys))
+	for call, span := range idx.callKeys {
+		list = append(list, callSpanEntry{span: span, call: call})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].span.start < list[j].span.start
+	})
+	if list == nil {
+		list = []callSpanEntry{}
+	}
+	idx.callSpans = list
 }
 
 func selfhostExprKind(expr ast.Expr) string {

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2770,9 +2770,11 @@ func tupleIndex(name string) (int, bool) {
 
 func (l *lowerer) lowerStructLit(s *ast.StructLit) Expr {
 	name := ""
+	var headIdent *ast.Ident
 	switch h := s.Type.(type) {
 	case *ast.Ident:
 		name = h.Name
+		headIdent = h
 	case *ast.FieldExpr:
 		// `pkg.Type { ... }` — keep the trailing name; the IR doesn't
 		// model packages yet.
@@ -2783,6 +2785,7 @@ func (l *lowerer) lowerStructLit(s *ast.StructLit) Expr {
 		T:        l.exprType(s),
 		SpanV:    nodeSpan(s),
 	}
+	explicit := map[string]bool{}
 	for _, f := range s.Fields {
 		field := StructLitField{
 			Name:  f.Name,
@@ -2792,9 +2795,32 @@ func (l *lowerer) lowerStructLit(s *ast.StructLit) Expr {
 			field.Value = l.lowerExpr(f.Value)
 		}
 		out.Fields = append(out.Fields, field)
+		explicit[f.Name] = true
 	}
 	if s.Spread != nil {
 		out.Spread = l.lowerExpr(s.Spread)
+	}
+	// Inject defaults for unspecified fields when no spread is present.
+	// With a spread, missing fields come from the spread base — defaults
+	// are only relevant on the bare `T { explicit, ... }` shape. Defaults
+	// are pure literals per spec (§3.4: literal-only default values), so
+	// `lowerExpr` produces a self-contained IR Expr per construction site.
+	if s.Spread == nil && headIdent != nil {
+		if sd := l.structDeclByIdent(headIdent); sd != nil {
+			for _, df := range sd.Fields {
+				if df == nil || df.Default == nil || df.Name == "" {
+					continue
+				}
+				if explicit[df.Name] {
+					continue
+				}
+				out.Fields = append(out.Fields, StructLitField{
+					Name:  df.Name,
+					Value: l.lowerExpr(df.Default),
+					SpanV: nodeSpan(s),
+				})
+			}
+		}
 	}
 	return out
 }

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -1037,7 +1037,13 @@ func collectStructFields(info *structInfo, env typeEnv) error {
 		if field == nil {
 			return unsupportedf("source-layout", "struct %q has nil field", info.name)
 		}
-		if diag := llvmStructFieldDiagnostic(info.name, field.Name, llvmIsIdent(field.Name), field.Default != nil, false, false, ""); diag.kind != "" {
+		// Field-level default values do not affect struct layout (the
+		// type sits unchanged); they only matter at construction time
+		// where lowerStructLit injects them for unspecified fields. So
+		// pass `hasDefault=false` to the diagnostic check — the layout
+		// pass should not reject decls that the construction-site path
+		// already handles.
+		if diag := llvmStructFieldDiagnostic(info.name, field.Name, llvmIsIdent(field.Name), false, false, false, ""); diag.kind != "" {
 			return unsupported(diag.kind, diag.message)
 		}
 		if _, exists := info.byName[field.Name]; exists {

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -1285,9 +1285,13 @@ func nativePopulateStructDecl(ctx *nativeProjectionCtx, decl *ostyir.StructDecl)
 		return info != nil
 	}
 	for i, field := range decl.Fields {
-		if field == nil || field.Name == "" || field.Default != nil {
+		if field == nil || field.Name == "" {
 			return false
 		}
+		// Defaults are construction-site concerns (lowerStructLit injects
+		// them); the native projection only needs the field's name + type
+		// for layout. Skipping the default-bail keeps fields like
+		// `CheckFnSig.hasReceiver: Bool = false` projectable.
 		if _, exists := info.byName[field.Name]; exists {
 			return false
 		}


### PR DESCRIPTION
**Re-open of #943** — that PR's base was set to PR #932's branch instead of `main`, so its changes never landed on `main` even though GitHub marked it merged. This PR carries the same content rebased onto current `main`.

## Summary

Two distinct but related fixes that together drop the merged-toolchain MIR pipeline gate from a 5-minute timeout to **~30 seconds**:

### 1. Struct field defaults work at the LLVM layer

Allow LLVM lowering of structs whose fields carry literal defaults (e.g. `pub hasReceiver: Bool = false` on `CheckFnSig`). Layout was always default-independent; the rejection was a placeholder while the construction-site path was missing.

- [internal/ir/lower.go::lowerStructLit](internal/ir/lower.go) now resolves the head ident to its `*ast.StructDecl` and, when no spread is present, appends `StructLitField` entries for every default-bearing field the literal omits. Spread-bearing literals (`{ ..base, ... }`) are left alone — missing fields come from the base.
- [internal/llvmgen/decl.go::collectStructFields](internal/llvmgen/decl.go) and [internal/llvmgen/ir_native_entry.go::nativePopulateStructDecl](internal/llvmgen/ir_native_entry.go) no longer reject struct decls with default-bearing fields.

### 2. lookupExpr / lookupCall sorted+memoize

Same shape as PR #932's scopeFor fix — these were the next-tier blocker once scopeFor stopped dominating. Lazily-built sorted slice (by `span.start` asc) + binary-search candidate prefix + memoize results. Fast paths (exact-key map hit, `…ByFrom[start]` filtered walk) are kept; only the full-map fallback is replaced.

## Verification

| Check | Pre-#932 | After #932 | After this PR |
|---|---|---|---|
| `osty check toolchain` smoke | 11 errors | EXIT=0 | EXIT=0 |
| `just front` (8 packages) | green | green | green |
| `TestProbe*` merged probes | LLVM010 wall | pass (~280s) | pass (~60s) |
| `TestNativeToolchainMergedMIRPipelineIsClean` | 5min+ timeout | 246s, LLVM011 wall | **31s, LLVM016 wall** |
| `TestNativeToolchainMergedMIRErrTypeFloor` | 274s, 474 ErrType | 242s, 426 | **27s, 395** |

The 8× / 9× perf wins come from the lookupExpr / lookupCall fix unblocking another hot path that was hidden behind scopeFor's larger timeout. The struct-default change unblocks LLVM011 specifically. ErrType further dropped 426 → 395 thanks to PR #942's lowerMatch scrutinee recovery in main, which composes cleanly here.

## Remaining walls

- **LLVM016 `unknown identifier "None"`** — the legacy const-expr path needs ptr-backed Option support in `constEnumVariantIdent`. Separate Phase 3 follow-up.
- **395 ErrType locals (floor=40)** — needs `ir.Lower` / `ir.Monomorphize` recovery extension to generic-call sites in the merged-single-file context.

## Test plan

- [ ] CI: `just front` green
- [ ] CI: `go test ./internal/check/...` green
- [ ] CI: `go test ./internal/ir/...` green
- [ ] CI: `go test ./internal/llvmgen/...` no new failures (LLVM016 / ErrType=395 are pre-existing on main)
- [ ] Manual: `osty check toolchain` returns EXIT=0
- [ ] Manual: `go test ./internal/llvmgen -run TestNativeToolchainMergedMIRPipelineIsClean -timeout 600s` finishes in <60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)