### PR TITLE
refactor(llvmgen): port 40 §3 / §6 builders + drain concurrency / container-runtime call shapes

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -425,6 +425,29 @@ list keeps new Osty clean of known landmines.
 | `mirCallListNewLine` / `mirCallMapNewLine` / `mirCallSetNewLine` | `(reg, ...) -> String` | §6 | Constructor calls for `[]` / `{:}` / `{}` literals |
 | `mirSizeOfDoubleLine` / `mirSizeOfI64Line` / `mirSizeOfI32Line` / `mirSizeOfI8Line` / `mirSizeOfPtrLine` / `mirSizeOfI1Line` | `() -> String` | §6 | Canonical sizeof literal returns — centralise the byte-width constants |
 
+| `mirCallVoidPtrI64Line` | `(sym, ptr, idx) -> String` | §6 | `call void @<sym>(ptr <ptr>, i64 <i>)` — (ptr, i64) side-effect call shape (list_pop_n, list_splice_at) |
+| `mirCallValuePtrI64Line` | `(reg, retTy, sym, ptr, idx) -> String` | §6 | Typed-return sibling of `mirCallVoidPtrI64Line` |
+| `mirCallVoidSelectSendLine` | `(sym, builder, ch, elemLLVM, val, arm) -> String` | §6 | Typed-element select-send call (5-arg shape) |
+| `mirCallVoidSelectSendBytesLine` | `(sym, builder, ch, slot, size, arm) -> String` | §6 | Bytes-v1 select-send call (5-arg shape with size) |
+| `mirRuntimeDeclareSelectSendLine` | `(sym, elemLLVM) -> String` | §3 | `declare void @<sym>(ptr, ptr, <elem>, ptr)` — typed select-send decl |
+| `mirRuntimeDeclareSelectSendBytesLine` | `(sym) -> String` | §3 | `declare void @<sym>(ptr, ptr, ptr, i64, ptr)` — bytes-v1 select-send decl |
+| `mirCallVoidArgValueLine` | `(sym, argLLVM, val) -> String` | §6 | `call void @<sym>(<argLLVM> <val>)` — single-typed-arg side-effect call |
+| `mirRuntimeDeclareVoidSingleArgLine` | `(sym, argLLVM) -> String` | §3 | Matching decl for single-typed-arg side-effect call |
+| `mirCallValueListLenLine` / `mirCallValueMapLenLine` / `mirCallValueSetLenLine` | `(reg, handle) -> String` | §6 | Canonical container-len call specialisations (literal symbol per container kind) |
+| `mirCallValueChanRecvLine` | `(reg, sym, ch) -> String` | §6 | Typed `{ i64, i64 }` chan-recv call shape |
+| `mirCallValueCancelCheckLine` | `(reg) -> String` | §6 | `osty_rt_cancel_check_cancelled()` — `?`-style cancellation propagation |
+| `mirCallValueCancelIsCancelledLine` | `(reg) -> String` | §6 | `osty_rt_cancel_is_cancelled()` — boolean predicate |
+| `mirSpillThenSizeOfLines` | `(slot, ty, val, gepReg, sizeReg) -> String` | §6 | spill + sizeof preamble (4-line block) |
+| `mirCallValueListSortedLine` / `mirCallValueMapKeysSortedLine` | `(reg, sym, handle) -> String` | §6 | Sorted-allocator call specialisations |
+| `mirCallVoidListPushTypedLine` | `(sym, list, elemLLVM, val) -> String` | §6 | Typed-element list-push call |
+| `mirRuntimeDeclareListPushTypedLine` | `(sym, elemLLVM) -> String` | §3 | Typed-element list-push decl |
+| `mirCallVoidChanCloseLine` | `(ch) -> String` | §6 | `osty_rt_chan_close` literal-symbol specialisation |
+| `mirCallVoidCancelCancelLine` / `mirCallVoidYieldLine` | `() -> String` | §6 | No-arg concurrency runtime calls |
+| `mirCallValueListReversedLine` / `mirCallVoidListReverseLine` | `(reg, list)/(list) -> String` | §6 | List reverse: allocator vs in-place |
+| `mirCallVoidListClearLine` / `mirCallVoidMapClearLine` / `mirCallVoidSetClearLine` | `(handle) -> String` | §6 | Container clear specialisations |
+| `mirCallVoidPopDiscardLine` | `(list) -> String` | §6 | `osty_rt_list_pop_discard` literal-symbol specialisation |
+| `mirCallValueIsEmptyLine` | `(reg, sym, handle) -> String` | §6 | Generic is-empty predicate probe |
+
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as
 the file grows.

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2167,10 +2167,8 @@ func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 	g.nextSafepoint += len(plan)
 	for i, chunk := range plan {
 		rootChunk := g.gcRootChunks[i]
-		g.fnBuf.WriteString(mirCallVoidLine("osty.gc.safepoint_v1",
-			"i64 "+strconv.Itoa(chunk.id)+
-				", ptr "+rootChunk.slotsPtr+
-				", i64 "+strconv.Itoa(rootChunk.count)))
+		g.fnBuf.WriteString(mirCallVoidI64TagAndPtrLine("osty.gc.safepoint_v1",
+			strconv.Itoa(chunk.id), rootChunk.slotsPtr, strconv.Itoa(rootChunk.count)))
 	}
 }
 
@@ -2365,8 +2363,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 			}
 			sym := "osty_rt_list_set_" + listRuntimeSymbolSuffix(elemLLVM)
 			g.declareRuntime(sym, mirRuntimeDeclareListSetSimpleLine(sym, elemLLVM))
-			g.fnBuf.WriteString(mirCallVoidLine(sym,
-				"ptr "+contReg+", i64 "+idxReg+", "+elemLLVM+" "+valReg))
+			g.fnBuf.WriteString(mirCallVoidListPtrI64ValueLine(sym, contReg, idxReg, elemLLVM, valReg))
 			return nil
 		}
 		// Composite element path — spill the value to a stack slot
@@ -2379,11 +2376,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 		sizeReg := g.emitSizeOf(elemLLVM)
 		sym := "osty_rt_list_set_bytes_v1"
 		g.declareRuntime(sym, mirRuntimeDeclareBytesV1SetWithBarrierLine(sym))
-		g.fnBuf.WriteString(mirCallVoidLine(sym,
-			"ptr "+contReg+", i64 "+idxReg+
-				", ptr "+valSlot.name+
-				", i64 "+sizeReg+
-				", ptr null"))
+		g.fnBuf.WriteString(mirCallVoidListBytesV1SetWithBarrierLine(sym, contReg, idxReg, valSlot.name, sizeReg, "null"))
 		return nil
 	case isMapPtrType(localT):
 		keyT, _ := mapKeyValueTypes(localT)
@@ -4120,7 +4113,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// byte so the call is element-type agnostic.
 		sym := "osty_rt_list_reverse"
 		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
-		g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg))
+		g.fnBuf.WriteString(mirCallVoidPtrLine(sym, listReg))
 		return nil
 	case mir.IntrinsicListReversed:
 		// Returns a freshly allocated reversed copy. Same elem_size/
@@ -4178,7 +4171,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		g.fnBuf.WriteString(mirCallVoidLine(spliceSym, "ptr "+listReg+", i64 "+idxReg))
+		g.fnBuf.WriteString(mirCallVoidPtrI64Line(spliceSym, listReg, idxReg))
 		return g.storeIntrinsicResult(i, &LlvmValue{typ: elemLLVM, name: elemReg})
 	case mir.IntrinsicListIndexOf:
 		// `indexOf(x) -> Int?` — linear scan. Emit inline loop so we
@@ -4385,7 +4378,7 @@ func (g *mirGen) emitListLoadElement(listReg, idxReg string, elemLLVM string) (s
 	sizeReg := g.emitSizeOf(elemLLVM)
 	sym := listRuntimeGetBytesV1Symbol()
 	g.declareRuntime(sym, mirRuntimeDeclareBytesV1GetLine(sym))
-	g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+listReg+", i64 "+idxReg+", ptr "+slot+", i64 "+sizeReg))
+	g.fnBuf.WriteString(mirCallVoidListBytesV1GetLine(sym, listReg, idxReg, slot, sizeReg))
 	elemReg := g.fresh()
 	g.fnBuf.WriteString(mirLoadLine(elemReg, elemLLVM, slot))
 	return elemReg, nil
@@ -6174,24 +6167,19 @@ func (g *mirGen) emitSelectSend(i *mir.IntrinsicInstr) error {
 	if listUsesTypedRuntime(elemLLVM) {
 		suffix := llvmListElementSuffix(elemLLVM)
 		sym := "osty_rt_select_send_" + suffix
-		g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, "ptr, ptr, "+elemLLVM+", ptr"))
-		g.fnBuf.WriteString(mirCallVoidLine(sym,
-			"ptr "+builderReg+", ptr "+chReg+
-				", "+elemLLVM+" "+valReg+", ptr "+armReg))
+		g.declareRuntime(sym, mirRuntimeDeclareSelectSendLine(sym, elemLLVM))
+		g.fnBuf.WriteString(mirCallVoidSelectSendLine(sym, builderReg, chReg, elemLLVM, valReg, armReg))
 		return nil
 	}
 	// Composite element — bytes_v1 route. Spill value to a stack slot,
 	// hand the runtime a (ptr, size) pair; it copies into GC storage.
 	sym := "osty_rt_select_send_bytes_v1"
-	g.declareRuntime(sym, mirRuntimeDeclareTaskGroupSplitLine(sym))
+	g.declareRuntime(sym, mirRuntimeDeclareSelectSendBytesLine(sym))
 	em := g.ostyEmitter()
 	slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: valReg})
 	size := llvmSizeOf(em, elemLLVM)
 	g.flushOstyEmitter(em)
-	g.fnBuf.WriteString(mirCallVoidLine(sym,
-		"ptr "+builderReg+", ptr "+chReg+
-			", ptr "+slot.name+", i64 "+size.name+
-			", ptr "+armReg))
+	g.fnBuf.WriteString(mirCallVoidSelectSendBytesLine(sym, builderReg, chReg, slot.name, size.name, armReg))
 	return nil
 }
 
@@ -6232,7 +6220,7 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		sym := "osty_rt_thread_sleep"
 		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
-		g.fnBuf.WriteString(mirCallVoidLine(sym, "ptr "+dur))
+		g.fnBuf.WriteString(mirCallVoidPtrLine(sym, dur))
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("cancel intrinsic kind %d", i.Kind))

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -3186,3 +3186,253 @@ func mirSizeOfPtrLine() string { return "8" }
 
 // Osty: mirSizeOfI1Line
 func mirSizeOfI1Line() string { return "1" }
+
+// §6 concurrency-shape and additional emit-shape builders.
+
+// mirCallVoidPtrI64Line — call void @<sym>(ptr, i64).
+// Osty: mirCallVoidPtrI64Line
+func mirCallVoidPtrI64Line(sym, ptr, idx string) string {
+	return mirCallVoidLine(sym, "ptr "+ptr+", i64 "+idx)
+}
+
+// mirCallValuePtrI64Line — typed-return sibling.
+// Osty: mirCallValuePtrI64Line
+func mirCallValuePtrI64Line(reg, retTy, sym, ptr, idx string) string {
+	return mirCallValueLine(reg, retTy, sym, "ptr "+ptr+", i64 "+idx)
+}
+
+// mirCallVoidSelectSendLine — typed select-send call shape.
+// Osty: mirCallVoidSelectSendLine
+func mirCallVoidSelectSendLine(sym, builderReg, chReg, elemLLVM, valReg, armReg string) string {
+	return mirCallVoidLine(sym, "ptr "+builderReg+", ptr "+chReg+", "+elemLLVM+" "+valReg+", ptr "+armReg)
+}
+
+// mirCallVoidSelectSendBytesLine — bytes-v1 select-send call.
+// Osty: mirCallVoidSelectSendBytesLine
+func mirCallVoidSelectSendBytesLine(sym, builderReg, chReg, slot, size, armReg string) string {
+	return mirCallVoidLine(sym, "ptr "+builderReg+", ptr "+chReg+", ptr "+slot+", i64 "+size+", ptr "+armReg)
+}
+
+// mirRuntimeDeclareSelectSendLine — declare void @<sym>(ptr, ptr, <elem>, ptr).
+// Osty: mirRuntimeDeclareSelectSendLine
+func mirRuntimeDeclareSelectSendLine(sym, elemLLVM string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, ptr, "+elemLLVM+", ptr")
+}
+
+// mirRuntimeDeclareSelectSendBytesLine — bytes-v1 select-send decl.
+// Osty: mirRuntimeDeclareSelectSendBytesLine
+func mirRuntimeDeclareSelectSendBytesLine(sym string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr, i64, ptr")
+}
+
+// mirCallVoidArgValueLine — call void @<sym>(<argLLVM> <val>).
+// Osty: mirCallVoidArgValueLine
+func mirCallVoidArgValueLine(sym, argLLVM, val string) string {
+	return mirCallVoidLine(sym, argLLVM+" "+val)
+}
+
+// mirRuntimeDeclareVoidSingleArgLine — declare void @<sym>(<argLLVM>).
+// Osty: mirRuntimeDeclareVoidSingleArgLine
+func mirRuntimeDeclareVoidSingleArgLine(sym, argLLVM string) string {
+	return mirRuntimeDeclareLine("void", sym, argLLVM)
+}
+
+// mirCallValueListLenLine / MapLenLine / SetLenLine — canonical
+// container-len call specialisations.
+// Osty: mirCallValueListLenLine
+func mirCallValueListLenLine(reg, listReg string) string {
+	return mirCallValueI64FromPtrLine(reg, "osty_rt_list_len", listReg)
+}
+
+// Osty: mirCallValueMapLenLine
+func mirCallValueMapLenLine(reg, mapReg string) string {
+	return mirCallValueI64FromPtrLine(reg, "osty_rt_map_len", mapReg)
+}
+
+// Osty: mirCallValueSetLenLine
+func mirCallValueSetLenLine(reg, setReg string) string {
+	return mirCallValueI64FromPtrLine(reg, "osty_rt_set_len", setReg)
+}
+
+// mirCallValueChanRecvLine — typed `{ i64, i64 }` chan-recv call.
+// Osty: mirCallValueChanRecvLine
+func mirCallValueChanRecvLine(reg, sym, chReg string) string {
+	return mirCallValueLine(reg, "{ i64, i64 }", sym, "ptr "+chReg)
+}
+
+// mirCallValueCancelCheckLine — osty_rt_cancel_check_cancelled() call.
+// Osty: mirCallValueCancelCheckLine
+func mirCallValueCancelCheckLine(reg string) string {
+	return mirCallValueNoArgsLine(reg, "{ i64, i64 }", "osty_rt_cancel_check_cancelled")
+}
+
+// mirCallValueCancelIsCancelledLine — osty_rt_cancel_is_cancelled() call.
+// Osty: mirCallValueCancelIsCancelledLine
+func mirCallValueCancelIsCancelledLine(reg string) string {
+	return mirCallValueNoArgsLine(reg, "i1", "osty_rt_cancel_is_cancelled")
+}
+
+// mirSpillThenSizeOfLines — spill + sizeof preamble.
+// Osty: mirSpillThenSizeOfLines
+func mirSpillThenSizeOfLines(slot, ty, val, gepReg, sizeReg string) string {
+	return mirAllocaSpillStoreLine(slot, ty, val) + mirSizeOfLines(gepReg, sizeReg, ty)
+}
+
+// mirCallValueListSortedLine — osty_rt_list_sorted_<elem>(list) call.
+// Osty: mirCallValueListSortedLine
+func mirCallValueListSortedLine(reg, sym, listReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, sym, listReg)
+}
+
+// mirCallValueMapKeysSortedLine — fused map.keys().sorted() call.
+// Osty: mirCallValueMapKeysSortedLine
+func mirCallValueMapKeysSortedLine(reg, sym, mapReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, sym, mapReg)
+}
+
+// mirCallVoidListPushTypedLine — typed-element list-push call.
+// Osty: mirCallVoidListPushTypedLine
+func mirCallVoidListPushTypedLine(sym, listReg, elemLLVM, valReg string) string {
+	return mirCallVoidLine(sym, "ptr "+listReg+", "+elemLLVM+" "+valReg)
+}
+
+// mirRuntimeDeclareListPushTypedLine — typed-element list-push decl.
+// Osty: mirRuntimeDeclareListPushTypedLine
+func mirRuntimeDeclareListPushTypedLine(sym, elemLLVM string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, "+elemLLVM)
+}
+
+// mirCallVoidChanCloseLine — osty_rt_chan_close specialisation.
+// Osty: mirCallVoidChanCloseLine
+func mirCallVoidChanCloseLine(chReg string) string {
+	return mirCallVoidPtrLine("osty_rt_chan_close", chReg)
+}
+
+// mirCallVoidCancelCancelLine — osty_rt_cancel_cancel call.
+// Osty: mirCallVoidCancelCancelLine
+func mirCallVoidCancelCancelLine() string {
+	return mirCallVoidNoArgsLine("osty_rt_cancel_cancel")
+}
+
+// mirCallVoidYieldLine — osty_rt_task_yield call.
+// Osty: mirCallVoidYieldLine
+func mirCallVoidYieldLine() string {
+	return mirCallVoidNoArgsLine("osty_rt_task_yield")
+}
+
+// mirCallValueListReversedLine — osty_rt_list_reversed allocator call.
+// Osty: mirCallValueListReversedLine
+func mirCallValueListReversedLine(reg, listReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, "osty_rt_list_reversed", listReg)
+}
+
+// mirCallVoidListReverseLine — in-place osty_rt_list_reverse call.
+// Osty: mirCallVoidListReverseLine
+func mirCallVoidListReverseLine(listReg string) string {
+	return mirCallVoidPtrLine("osty_rt_list_reverse", listReg)
+}
+
+// mirCallVoidListClearLine / MapClearLine / SetClearLine.
+// Osty: mirCallVoidListClearLine
+func mirCallVoidListClearLine(listReg string) string {
+	return mirCallVoidPtrLine("osty_rt_list_clear", listReg)
+}
+
+// Osty: mirCallVoidMapClearLine
+func mirCallVoidMapClearLine(mapReg string) string {
+	return mirCallVoidPtrLine("osty_rt_map_clear", mapReg)
+}
+
+// Osty: mirCallVoidSetClearLine
+func mirCallVoidSetClearLine(setReg string) string {
+	return mirCallVoidPtrLine("osty_rt_set_clear", setReg)
+}
+
+// mirCallVoidPopDiscardLine — osty_rt_list_pop_discard call.
+// Osty: mirCallVoidPopDiscardLine
+func mirCallVoidPopDiscardLine(listReg string) string {
+	return mirCallVoidPtrLine("osty_rt_list_pop_discard", listReg)
+}
+
+// mirCallValueIsEmptyLine — generic is-empty probe.
+// Osty: mirCallValueIsEmptyLine
+func mirCallValueIsEmptyLine(reg, sym, handleReg string) string {
+	return mirCallValueI1FromPtrLine(reg, sym, handleReg)
+}
+
+// mirCallI1MapKeyLine renders `<reg> = call i1 @<sym>(ptr <map>, <keyLLVM> <key>)`.
+// Osty: mirCallI1MapKeyLine
+func mirCallI1MapKeyLine(reg, sym, mapReg, keyLLVM, keyReg string) string {
+	return mirCallValueLine(reg, "i1", sym, "ptr "+mapReg+", "+keyLLVM+" "+keyReg)
+}
+
+// mirCallI1SetElemLine renders `<reg> = call i1 @<sym>(ptr <set>, <elemLLVM> <elem>)`.
+// Osty: mirCallI1SetElemLine
+func mirCallI1SetElemLine(reg, sym, setReg, elemLLVM, elemReg string) string {
+	return mirCallValueLine(reg, "i1", sym, "ptr "+setReg+", "+elemLLVM+" "+elemReg)
+}
+
+// mirCallVoidSetElemLine renders `call void @<sym>(ptr <set>, <elemLLVM> <elem>)`.
+// Osty: mirCallVoidSetElemLine
+func mirCallVoidSetElemLine(sym, setReg, elemLLVM, elemReg string) string {
+	return mirCallVoidLine(sym, "ptr "+setReg+", "+elemLLVM+" "+elemReg)
+}
+
+// mirRuntimeDeclareI1FromPtrAndElemLine — declare i1 @<sym>(ptr, <elem>).
+// Osty: mirRuntimeDeclareI1FromPtrAndElemLine
+func mirRuntimeDeclareI1FromPtrAndElemLine(sym, elemLLVM string) string {
+	return mirRuntimeDeclareLine("i1", sym, "ptr, "+elemLLVM)
+}
+
+// mirRuntimeDeclareVoidFromPtrAndElemLine — declare void @<sym>(ptr, <elem>).
+// Osty: mirRuntimeDeclareVoidFromPtrAndElemLine
+func mirRuntimeDeclareVoidFromPtrAndElemLine(sym, elemLLVM string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, "+elemLLVM)
+}
+
+// mirCallValueElemFromPtrAndElemLine — typed-return sibling of mirCallVoidSetElemLine.
+// Osty: mirCallValueElemFromPtrAndElemLine
+func mirCallValueElemFromPtrAndElemLine(reg, retTy, sym, handleReg, elemLLVM, elemReg string) string {
+	return mirCallValueLine(reg, retTy, sym, "ptr "+handleReg+", "+elemLLVM+" "+elemReg)
+}
+
+// mirCallVoidChanSendLine — typed chan-send call.
+// Osty: mirCallVoidChanSendLine
+func mirCallVoidChanSendLine(sym, chReg, elemLLVM, valReg string) string {
+	return mirCallVoidLine(sym, "ptr "+chReg+", "+elemLLVM+" "+valReg)
+}
+
+// mirRuntimeDeclareChanSendLine — declare void @<sym>(ptr, <elem>).
+// Osty: mirRuntimeDeclareChanSendLine
+func mirRuntimeDeclareChanSendLine(sym, elemLLVM string) string {
+	return mirRuntimeDeclareLine("void", sym, "ptr, "+elemLLVM)
+}
+
+// mirCallVoidChanSendBytesLine — bytes-v1 chan-send call.
+// Osty: mirCallVoidChanSendBytesLine
+func mirCallVoidChanSendBytesLine(sym, chReg, slot, size string) string {
+	return mirCallVoidLine(sym, "ptr "+chReg+", ptr "+slot+", i64 "+size)
+}
+
+// mirCallVoidIntrinsicArgsLine / mirCallValueIntrinsicArgsLine — re-exports.
+// Osty: mirCallVoidIntrinsicArgsLine
+func mirCallVoidIntrinsicArgsLine(sym, argList string) string {
+	return mirCallVoidLine(sym, argList)
+}
+
+// Osty: mirCallValueIntrinsicArgsLine
+func mirCallValueIntrinsicArgsLine(reg, retTy, sym, argList string) string {
+	return mirCallValueLine(reg, retTy, sym, argList)
+}
+
+// mirCallGcAllocV1Line — osty.gc.alloc_v1 specialisation.
+// Osty: mirCallGcAllocV1Line
+func mirCallGcAllocV1Line(reg, kind, size, site string) string {
+	return mirCallValueLine(reg, "ptr", "osty.gc.alloc_v1", "i64 "+kind+", i64 "+size+", ptr "+site)
+}
+
+// mirCallSafepointLine — osty.gc.safepoint_v1 specialisation.
+// Osty: mirCallSafepointLine
+func mirCallSafepointLine(tag, slots, count string) string {
+	return mirCallVoidI64TagAndPtrLine("osty.gc.safepoint_v1", tag, slots, count)
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -4275,3 +4275,304 @@ pub fn mirSizeOfPtrLine() -> String { "8" }
 /// mirSizeOfI1Line returns the canonical sizeof(i1)-as-i8 literal "1"
 /// (LLVM materialises i1 in a byte-wide slot for storage).
 pub fn mirSizeOfI1Line() -> String { "1" }
+
+/// §6 concurrency-shape and additional emit-shape builders — drain
+/// the remaining `mirCallVoidLine(sym, "ptr "+x+...)` and
+/// `mirCallValueLine(reg, ty, sym, "ptr "+x+...)` inline patterns
+/// at sites where the call signature fits a small number of fixed
+/// shapes.
+
+/// mirCallVoidPtrI64Line renders `call void @<sym>(ptr <ptr>, i64 <i>)`
+/// — the (ptr, i64) side-effect call shape used by `osty_rt_list_pop_n`,
+/// `osty_rt_list_splice_at`, and similar one-handle + index runtimes.
+pub fn mirCallVoidPtrI64Line(sym: String, ptr: String, idx: String) -> String {
+    mirCallVoidLine(sym, "ptr " + ptr + ", i64 " + idx)
+}
+
+/// mirCallValuePtrI64Line renders `<reg> = call <retTy> @<sym>(ptr <ptr>, i64 <i>)`
+/// — the typed-return sibling of `mirCallVoidPtrI64Line`. Used by
+/// `osty_rt_list_get_<elem>` and other typed-element list-get
+/// runtimes (which `mirCallValueElemFromPtrI64Line` already covers
+/// for the elem-typed case; this is the abstract form).
+pub fn mirCallValuePtrI64Line(reg: String, retTy: String, sym: String, ptr: String, idx: String) -> String {
+    mirCallValueLine(reg, retTy, sym, "ptr " + ptr + ", i64 " + idx)
+}
+
+/// mirCallVoidSelectSendLine renders the typed-element select-send
+/// runtime call: `call void @<sym>(ptr <builder>, ptr <chan>, <elemLLVM> <val>, ptr <arm>)`.
+/// Used at the IntrinsicSelectSend typed-element fast path.
+pub fn mirCallVoidSelectSendLine(sym: String, builderReg: String, chReg: String, elemLLVM: String, valReg: String, armReg: String) -> String {
+    mirCallVoidLine(sym, "ptr " + builderReg + ", ptr " + chReg + ", " + elemLLVM + " " + valReg + ", ptr " + armReg)
+}
+
+/// mirCallVoidSelectSendBytesLine renders the bytes-v1 select-send
+/// runtime call: `call void @<sym>(ptr <builder>, ptr <chan>, ptr <slot>, i64 <size>, ptr <arm>)`.
+/// Used at the IntrinsicSelectSend composite-element path.
+pub fn mirCallVoidSelectSendBytesLine(sym: String, builderReg: String, chReg: String, slot: String, size: String, armReg: String) -> String {
+    mirCallVoidLine(sym, "ptr " + builderReg + ", ptr " + chReg + ", ptr " + slot + ", i64 " + size + ", ptr " + armReg)
+}
+
+/// mirRuntimeDeclareSelectSendLine renders the canonical select-
+/// send decl shape: `declare void @<sym>(ptr, ptr, <elemLLVM>, ptr)`.
+pub fn mirRuntimeDeclareSelectSendLine(sym: String, elemLLVM: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, ptr, " + elemLLVM + ", ptr")
+}
+
+/// mirRuntimeDeclareSelectSendBytesLine renders the canonical
+/// bytes-v1 select-send decl: `declare void @<sym>(ptr, ptr, ptr, i64, ptr)`.
+pub fn mirRuntimeDeclareSelectSendBytesLine(sym: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, ptr, ptr, i64, ptr")
+}
+
+/// mirCallVoidArgValueLine renders `call void @<sym>(<argLLVM> <val>)`
+/// — the single-typed-arg side-effect call. Used by
+/// `emitRuntimeVoidCall` for one-arg runtime hooks (e.g.
+/// thread.sleep(duration)).
+pub fn mirCallVoidArgValueLine(sym: String, argLLVM: String, val: String) -> String {
+    mirCallVoidLine(sym, argLLVM + " " + val)
+}
+
+/// mirRuntimeDeclareVoidSingleArgLine renders `declare void @<sym>(<argLLVM>)`
+/// — the matching decl for `mirCallVoidArgValueLine`.
+pub fn mirRuntimeDeclareVoidSingleArgLine(sym: String, argLLVM: String) -> String {
+    mirRuntimeDeclareLine("void", sym, argLLVM)
+}
+
+/// mirCallValueListLenLine renders the canonical list-len call:
+///   `<reg> = call i64 @osty_rt_list_len(ptr <list>)`
+/// Specialisation of `mirCallValueI64FromPtrLine` for the literal
+/// `osty_rt_list_len` symbol — every IntrinsicListLen / .len() probe
+/// site reaches for this.
+pub fn mirCallValueListLenLine(reg: String, listReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, "osty_rt_list_len", listReg)
+}
+
+/// mirCallValueMapLenLine renders the canonical map-len call:
+///   `<reg> = call i64 @osty_rt_map_len(ptr <map>)`
+pub fn mirCallValueMapLenLine(reg: String, mapReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, "osty_rt_map_len", mapReg)
+}
+
+/// mirCallValueSetLenLine renders the canonical set-len call:
+///   `<reg> = call i64 @osty_rt_set_len(ptr <set>)`
+pub fn mirCallValueSetLenLine(reg: String, setReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, "osty_rt_set_len", setReg)
+}
+
+/// mirCallValueChanRecvLine renders the canonical chan-recv call:
+///   `<reg> = call { i64, i64 } @<sym>(ptr <chan>)`
+/// Used by IntrinsicChanRecv / IntrinsicSelectRecv. The runtime
+/// returns Option<T>-shaped `{i64, i64}` tuple matching the MIR
+/// enum layout convention.
+pub fn mirCallValueChanRecvLine(reg: String, sym: String, chReg: String) -> String {
+    mirCallValueLine(reg, "\{ i64, i64 \}", sym, "ptr " + chReg)
+}
+
+/// mirCallValueCancelCheckLine renders the canonical cancel-check
+/// call: `<reg> = call { i64, i64 } @osty_rt_cancel_check_cancelled()`.
+/// Used at every `?`-style cancellation propagation site.
+pub fn mirCallValueCancelCheckLine(reg: String) -> String {
+    mirCallValueNoArgsLine(reg, "\{ i64, i64 \}", "osty_rt_cancel_check_cancelled")
+}
+
+/// mirCallValueCancelIsCancelledLine renders the canonical
+/// is-cancelled probe: `<reg> = call i1 @osty_rt_cancel_is_cancelled()`.
+pub fn mirCallValueCancelIsCancelledLine(reg: String) -> String {
+    mirCallValueNoArgsLine(reg, "i1", "osty_rt_cancel_is_cancelled")
+}
+
+/// mirSpillThenSizeOfLines renders the canonical "spill an SSA
+/// value into a stack slot then compute its sizeof" preamble:
+///   `  <slot> = alloca <ty>\n`
+///   `  store <ty> <val>, ptr <slot>\n`
+///   `  <gepReg> = getelementptr <ty>, ptr null, i32 1\n`
+///   `  <sizeReg> = ptrtoint ptr <gepReg> to i64\n`
+/// Four-line block. Sibling of `mirAllocaSpillStoreLine` +
+/// `mirSizeOfLines` chained, but exposed as one builder so the four
+/// fresh registers are passed up-front and the order stays stable.
+pub fn mirSpillThenSizeOfLines(slot: String, ty: String, val: String, gepReg: String, sizeReg: String) -> String {
+    mirAllocaSpillStoreLine(slot, ty, val) + mirSizeOfLines(gepReg, sizeReg, ty)
+}
+
+/// mirCallValueListSortedLine renders the canonical list-sorted
+/// call: `<reg> = call ptr @<sym>(ptr <list>)`. The runtime returns
+/// a freshly-allocated sorted copy. Specialisation of
+/// `mirCallValuePtrFromPtrLine` for the literal sorted-helper
+/// symbols (osty_rt_list_sorted_i64 / _string / etc.).
+pub fn mirCallValueListSortedLine(reg: String, sym: String, listReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, sym, listReg)
+}
+
+/// mirCallValueMapKeysSortedLine renders the canonical fused
+/// `map.keys().sorted()` call: `<reg> = call ptr @<sym>(ptr <map>)`.
+pub fn mirCallValueMapKeysSortedLine(reg: String, sym: String, mapReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, sym, mapReg)
+}
+
+/// mirCallVoidListPushTypedLine renders the typed-element list-push
+/// call: `call void @<sym>(ptr <list>, <elemLLVM> <val>)`. Used at
+/// every IntrinsicListPush typed-element fast path.
+pub fn mirCallVoidListPushTypedLine(sym: String, listReg: String, elemLLVM: String, valReg: String) -> String {
+    mirCallVoidLine(sym, "ptr " + listReg + ", " + elemLLVM + " " + valReg)
+}
+
+/// mirRuntimeDeclareListPushTypedLine renders the canonical
+/// typed-element list-push decl: `declare void @<sym>(ptr, <elemLLVM>)`.
+pub fn mirRuntimeDeclareListPushTypedLine(sym: String, elemLLVM: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, " + elemLLVM)
+}
+
+/// mirCallVoidChanCloseLine renders the canonical chan-close call:
+///   `call void @osty_rt_chan_close(ptr <chan>)`
+/// Specialisation of `mirCallVoidPtrLine` for the literal
+/// `osty_rt_chan_close` symbol used at every IntrinsicChanClose /
+/// `ch.close()` site.
+pub fn mirCallVoidChanCloseLine(chReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_chan_close", chReg)
+}
+
+/// mirCallVoidCancelCancelLine renders the canonical group-cancel
+/// call: `call void @osty_rt_cancel_cancel()`.
+pub fn mirCallVoidCancelCancelLine() -> String {
+    mirCallVoidNoArgsLine("osty_rt_cancel_cancel")
+}
+
+/// mirCallVoidYieldLine renders the canonical task-yield call:
+///   `call void @osty_rt_task_yield()`.
+pub fn mirCallVoidYieldLine() -> String {
+    mirCallVoidNoArgsLine("osty_rt_task_yield")
+}
+
+/// mirCallValueListReversedLine renders the canonical list-reversed
+/// allocator call: `<reg> = call ptr @osty_rt_list_reversed(ptr <list>)`.
+pub fn mirCallValueListReversedLine(reg: String, listReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, "osty_rt_list_reversed", listReg)
+}
+
+/// mirCallVoidListReverseLine renders the canonical in-place
+/// list-reverse call: `call void @osty_rt_list_reverse(ptr <list>)`.
+pub fn mirCallVoidListReverseLine(listReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_list_reverse", listReg)
+}
+
+/// mirCallVoidListClearLine / MapClearLine / SetClearLine —
+/// canonical clear-helpers per container. All share the one-ptr-arg
+/// void call shape.
+pub fn mirCallVoidListClearLine(listReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_list_clear", listReg)
+}
+
+pub fn mirCallVoidMapClearLine(mapReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_map_clear", mapReg)
+}
+
+pub fn mirCallVoidSetClearLine(setReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_set_clear", setReg)
+}
+
+/// mirCallVoidPopDiscardLine renders the canonical list-pop-discard
+/// call: `call void @osty_rt_list_pop_discard(ptr <list>)`.
+/// Used by IntrinsicListPop's no-dest path and by the `pop` arm
+/// inside the dest-bearing path after the element has been read.
+pub fn mirCallVoidPopDiscardLine(listReg: String) -> String {
+    mirCallVoidPtrLine("osty_rt_list_pop_discard", listReg)
+}
+
+/// mirCallValueIsEmptyLine renders the canonical is-empty probe:
+///   `<reg> = call i1 @<sym>(ptr <handle>)`
+/// Used by IntrinsicListIsEmpty, IntrinsicMapIsEmpty,
+/// IntrinsicSetIsEmpty, IntrinsicChanIsClosed, etc.
+pub fn mirCallValueIsEmptyLine(reg: String, sym: String, handleReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, sym, handleReg)
+}
+
+/// mirCallI1MapKeyLine renders `<reg> = call i1 @<sym>(ptr <map>, <keyLLVM> <key>)`
+/// — the map-contains / map-remove call shape used by IntrinsicMapContains
+/// / IntrinsicMapRemove.
+pub fn mirCallI1MapKeyLine(reg: String, sym: String, mapReg: String, keyLLVM: String, keyReg: String) -> String {
+    mirCallValueLine(reg, "i1", sym, "ptr " + mapReg + ", " + keyLLVM + " " + keyReg)
+}
+
+/// mirCallI1SetElemLine renders `<reg> = call i1 @<sym>(ptr <set>, <elemLLVM> <elem>)`
+/// — the set-contains / set-add probe shape (sibling of
+/// `mirCallI1MapKeyLine` for set's single-arg key surface).
+pub fn mirCallI1SetElemLine(reg: String, sym: String, setReg: String, elemLLVM: String, elemReg: String) -> String {
+    mirCallValueLine(reg, "i1", sym, "ptr " + setReg + ", " + elemLLVM + " " + elemReg)
+}
+
+/// mirCallVoidSetElemLine renders `call void @<sym>(ptr <set>, <elemLLVM> <elem>)`
+/// — the set-add / set-remove side-effect shape.
+pub fn mirCallVoidSetElemLine(sym: String, setReg: String, elemLLVM: String, elemReg: String) -> String {
+    mirCallVoidLine(sym, "ptr " + setReg + ", " + elemLLVM + " " + elemReg)
+}
+
+/// mirRuntimeDeclareI1FromPtrAndElemLine renders `declare i1 @<sym>(ptr, <elemLLVM>)`
+/// — used by set-contains / set-add probes, map-contains, etc.
+pub fn mirRuntimeDeclareI1FromPtrAndElemLine(sym: String, elemLLVM: String) -> String {
+    mirRuntimeDeclareLine("i1", sym, "ptr, " + elemLLVM)
+}
+
+/// mirRuntimeDeclareVoidFromPtrAndElemLine renders
+///   `declare void @<sym>(ptr, <elemLLVM>)`
+/// — set-add / set-remove side-effect shape.
+pub fn mirRuntimeDeclareVoidFromPtrAndElemLine(sym: String, elemLLVM: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, " + elemLLVM)
+}
+
+/// mirCallValueElemFromPtrAndElemLine renders
+///   `<reg> = call <retTy> @<sym>(ptr <handle>, <elemLLVM> <elem>)`
+/// — the typed-return sibling of `mirCallVoidSetElemLine`.
+pub fn mirCallValueElemFromPtrAndElemLine(reg: String, retTy: String, sym: String, handleReg: String, elemLLVM: String, elemReg: String) -> String {
+    mirCallValueLine(reg, retTy, sym, "ptr " + handleReg + ", " + elemLLVM + " " + elemReg)
+}
+
+/// mirCallValueChanSendLine / mirCallVoidChanSendLine — typed
+/// chan-send shape `[ptr <ch>, <elemLLVM> <val>]`. Send is void-
+/// returning today; the value form is reserved for future ABI
+/// changes that surface back-pressure as a return value.
+pub fn mirCallVoidChanSendLine(sym: String, chReg: String, elemLLVM: String, valReg: String) -> String {
+    mirCallVoidLine(sym, "ptr " + chReg + ", " + elemLLVM + " " + valReg)
+}
+
+/// mirRuntimeDeclareChanSendLine renders the canonical chan-send decl:
+///   `declare void @<sym>(ptr, <elemLLVM>)`
+pub fn mirRuntimeDeclareChanSendLine(sym: String, elemLLVM: String) -> String {
+    mirRuntimeDeclareLine("void", sym, "ptr, " + elemLLVM)
+}
+
+/// mirCallVoidChanSendBytesLine renders the bytes-v1 chan-send call:
+///   `call void @<sym>(ptr <ch>, ptr <slot>, i64 <size>)`
+pub fn mirCallVoidChanSendBytesLine(sym: String, chReg: String, slot: String, size: String) -> String {
+    mirCallVoidLine(sym, "ptr " + chReg + ", ptr " + slot + ", i64 " + size)
+}
+
+/// mirCallVoidIntrinsicArgsLine renders a void runtime call where
+/// the arg list is pre-joined (one or more args). Thin re-export of
+/// `mirCallVoidLine` for consistency with the typed-return surface
+/// — names the call style at the call site so refactors that swap
+/// shapes only have to edit one builder.
+pub fn mirCallVoidIntrinsicArgsLine(sym: String, argList: String) -> String {
+    mirCallVoidLine(sym, argList)
+}
+
+/// mirCallValueIntrinsicArgsLine — typed-return sibling.
+pub fn mirCallValueIntrinsicArgsLine(reg: String, retTy: String, sym: String, argList: String) -> String {
+    mirCallValueLine(reg, retTy, sym, argList)
+}
+
+/// mirCallVoidGcAllocLine renders the canonical gc-alloc call:
+///   `<reg> = call ptr @osty.gc.alloc_v1(i64 <kind>, i64 <size>, ptr <site>)`
+/// Specialisation of `mirCallValueLine` for the literal allocator
+/// symbol — every site that boxes a payload onto the GC heap reaches
+/// for this.
+pub fn mirCallGcAllocV1Line(reg: String, kind: String, size: String, site: String) -> String {
+    mirCallValueLine(reg, "ptr", "osty.gc.alloc_v1", "i64 " + kind + ", i64 " + size + ", ptr " + site)
+}
+
+/// mirCallSafepointLine renders the canonical safepoint chunk call:
+///   `call void @osty.gc.safepoint_v1(i64 <tag>, ptr <slots>, i64 <count>)`
+/// Specialisation of `mirCallVoidI64TagAndPtrLine` for the literal
+/// safepoint symbol — the GC's main probe entry point.
+pub fn mirCallSafepointLine(tag: String, slots: String, count: String) -> String {
+    mirCallVoidI64TagAndPtrLine("osty.gc.safepoint_v1", tag, slots, count)
+}


### PR DESCRIPTION
## Summary

- Adds 40 new line-builders to `toolchain/mir_generator.osty` covering the remaining concurrency / container-runtime call shapes plus literal-symbol specialisations for the most-called container helpers
- §6 ptr-and-i64 / ptr-and-elem call shapes (10): `mirCallVoidPtrI64Line` / `mirCallValuePtrI64Line` (list_pop_n / list_splice_at), `mirCallVoidSelectSend{,Bytes}Line` (typed + bytes-v1 select-send), `mirCallVoidArgValueLine` (single-typed-arg side-effect), `mirCallI1Map{Key,Elem}Line` / `mirCallVoidSetElemLine` / `mirCallValueElemFromPtrAndElemLine`
- §3 runtime-declare canonical shapes (6): `mirRuntimeDeclareSelectSend{,Bytes}Line`, `mirRuntimeDeclareVoidSingleArgLine`, `mirRuntimeDeclareI1/VoidFromPtrAndElemLine`, `mirRuntimeDeclareChanSendLine`
- §6 literal-symbol container call specialisations (15): list/map/set len, chan-recv, cancel-check, list/map keys-sorted, list-push typed, chan-close / cancel-cancel / yield, list-reversed/reverse, list/map/set clear, pop-discard, is-empty probe
- §6 GC + chan-send + intrinsic wrappers (9): `mirSpillThenSizeOfLines` (4-line spill+sizeof preamble), `mirCallVoidChanSend{,Bytes}Line`, `mirRuntimeDeclareListPushTypedLine`, intrinsic args wrappers, `mirCallGcAllocV1Line`, `mirCallSafepointLine`

## Drain sites

| Site | Before | After |
|------|--------|-------|
| `emitGCSafepointKind` chunk-call | inline `i64 ...+ptr ...+i64 ...` 4-arg concat | `mirCallVoidI64TagAndPtrLine` 1-call |
| `IntrinsicListSet` typed path | inline 5-arg `mirCallVoidLine(sym, "ptr "+x+", i64 "+i+", "+T+" "+v)` | `mirCallVoidListPtrI64ValueLine` 1-call |
| `IntrinsicListSet` bytes-v1 path | inline 5-arg with trailing `, ptr null` | `mirCallVoidListBytesV1SetWithBarrierLine` 1-call |
| `emitSelectSend` typed + bytes-v1 paths | inline 5-arg call shapes | `mirCallVoidSelectSendLine` / `mirCallVoidSelectSendBytesLine` |

## Diffstat

**586 insertions / 24 deletions** across 4 files.

## Test plan

- [x] `go build ./internal/llvmgen/...` clean
- [x] `go vet ./internal/llvmgen/...` clean
- [x] Byte-stable golden parity confirmed: pre/post `go test ./internal/llvmgen/...` reports identical 6-failure set

🤖 Generated with [Claude Code](https://claude.com/claude-code)