### PR TITLE
perf(mir,ir): broaden ErrType recovery on iflet/coalesce/q/opt + partial-struct field lookup

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -117,6 +117,12 @@ type lowerer struct {
 	// to its IdentPat and looking up the type the lowerer recorded
 	// when it processed the LetStmt earlier in the same function.
 	bindingPatTypes map[*ast.IdentPat]Type
+
+	// fieldTypeCache memoises (typeName, fieldName) → field IR Type
+	// resolutions for `recoverFieldType`. Without the memo, every
+	// field access on a partial struct re-walks the file's decls
+	// looking for the matching StructDecl.
+	fieldTypeCache map[fieldKey]Type
 }
 
 // ==== Top level ====
@@ -2718,9 +2724,10 @@ func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
 
 // recoverFieldType resolves a field access `receiverType.fieldName`
 // back to the declared field type by consulting the resolver's type
-// decl for receiverType. Only handles user structs today —
-// enums/interfaces/tuples use different access shapes that do not
-// flow through lowerFieldExpr in the same way.
+// decl for receiverType. Handles partial struct declarations (multiple
+// `pub struct X { ... }` blocks across the same package) by walking
+// `l.file.Decls` for any StructDecl with the same head name when the
+// resolver-anchored decl doesn't carry the requested field.
 func (l *lowerer) recoverFieldType(receiverType Type, fieldName string) Type {
 	if receiverType == nil || receiverType == ErrTypeVal {
 		return nil
@@ -2729,27 +2736,64 @@ func (l *lowerer) recoverFieldType(receiverType Type, fieldName string) Type {
 	if !ok || nt.Builtin {
 		return nil
 	}
-	if l.res == nil {
+	return l.lookupStructFieldType(nt.Name, fieldName)
+}
+
+// lookupStructFieldType returns the declared type of a field on a
+// (possibly partial) struct. Memoised per (typeName, fieldName) so the
+// merged-toolchain hot path doesn't re-walk file decls per access.
+func (l *lowerer) lookupStructFieldType(typeName, fieldName string) Type {
+	if l.fieldTypeCache != nil {
+		if v, ok := l.fieldTypeCache[fieldKey{typeName, fieldName}]; ok {
+			return v
+		}
+	}
+	t := l.lookupStructFieldTypeUncached(typeName, fieldName)
+	if l.fieldTypeCache == nil {
+		l.fieldTypeCache = map[fieldKey]Type{}
+	}
+	l.fieldTypeCache[fieldKey{typeName, fieldName}] = t
+	return t
+}
+
+func (l *lowerer) lookupStructFieldTypeUncached(typeName, fieldName string) Type {
+	if l.res != nil {
+		if sym := l.res.FileScope.Lookup(typeName); sym != nil && sym.Decl != nil {
+			if sd, ok := sym.Decl.(*ast.StructDecl); ok && sd != nil {
+				if t := structFieldType(sd, fieldName); t != nil {
+					return l.lowerType(t)
+				}
+			}
+		}
+	}
+	if l.file == nil {
 		return nil
 	}
-	sym := l.res.FileScope.Lookup(nt.Name)
-	if sym == nil || sym.Decl == nil {
-		return nil
+	for _, d := range l.file.Decls {
+		sd, ok := d.(*ast.StructDecl)
+		if !ok || sd == nil || sd.Name != typeName {
+			continue
+		}
+		if t := structFieldType(sd, fieldName); t != nil {
+			return l.lowerType(t)
+		}
 	}
-	sd, ok := sym.Decl.(*ast.StructDecl)
-	if !ok || sd == nil {
-		return nil
-	}
+	return nil
+}
+
+func structFieldType(sd *ast.StructDecl, fieldName string) ast.Type {
 	for _, f := range sd.Fields {
 		if f == nil || f.Name != fieldName {
 			continue
 		}
-		if f.Type == nil {
-			return nil
-		}
-		return l.lowerType(f.Type)
+		return f.Type
 	}
 	return nil
+}
+
+type fieldKey struct {
+	typeName  string
+	fieldName string
 }
 
 // tupleIndex parses a field name like "0" or "12" as a tuple index.

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2947,6 +2947,11 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 	bs.pushScope()
 	scrut := ife.Scrutinee
 	scrutT := scrut.Type()
+	if isPoisonType(scrutT) {
+		if rt := bs.recoverOperandType(scrut); rt != nil && !isPoisonType(rt) {
+			scrutT = rt
+		}
+	}
 	scrutLocal := bs.newLocal("_iflet", scrutT, false, ife.SpanV)
 	bs.emit(&StorageLiveInstr{Local: scrutLocal, SpanV: ife.SpanV})
 	bs.lowerExprInto(scrut, scrutLocal, scrutT)
@@ -3049,6 +3054,11 @@ func (bs *bodyState) lowerMatchExprIntoPlace(m *ir.MatchExpr, dest Place, destT 
 func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Type) {
 	bs.pushScope()
 	leftT := c.Left.Type()
+	if isPoisonType(leftT) {
+		if rt := bs.recoverOperandType(c.Left); rt != nil && !isPoisonType(rt) {
+			leftT = rt
+		}
+	}
 	leftLocal := bs.newLocal("_coalesce", leftT, false, c.SpanV)
 	bs.emit(&StorageLiveInstr{Local: leftLocal, SpanV: c.SpanV})
 	bs.lowerExprInto(c.Left, leftLocal, leftT)
@@ -3095,6 +3105,11 @@ func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Typ
 func (bs *bodyState) lowerQuestionInto(q *ir.QuestionExpr, dest Place, destT Type) {
 	bs.pushScope()
 	xT := q.X.Type()
+	if isPoisonType(xT) {
+		if rt := bs.recoverOperandType(q.X); rt != nil && !isPoisonType(rt) {
+			xT = rt
+		}
+	}
 	tmp := bs.newLocal("_q", xT, false, q.SpanV)
 	bs.emit(&StorageLiveInstr{Local: tmp, SpanV: q.SpanV})
 	bs.lowerExprInto(q.X, tmp, xT)
@@ -3242,6 +3257,11 @@ func typesMatch(a, b Type) bool {
 // lowerOptionalFieldInto handles `x?.field`.
 func (bs *bodyState) lowerOptionalFieldInto(fe *ir.FieldExpr, dest Place, destT Type) {
 	recvT := fe.X.Type()
+	if isPoisonType(recvT) {
+		if rt := bs.recoverOperandType(fe.X); rt != nil && !isPoisonType(rt) {
+			recvT = rt
+		}
+	}
 	recvLocal := bs.newLocal("_opt", recvT, false, fe.SpanV)
 	bs.emit(&StorageLiveInstr{Local: recvLocal, SpanV: fe.SpanV})
 	bs.lowerExprInto(fe.X, recvLocal, recvT)


### PR DESCRIPTION
## Summary

- Extends the `recoverOperandType` pattern that #942 introduced for `match` scrutinees to four sibling lowerers that materialise a `_xxx` local seeded from a possibly-poisoned operand: `lowerIfLetExprInto` (`_iflet`), `lowerCoalesceInto` (`_coalesce`), `lowerQuestionInto` (`_q`), `lowerOptionalFieldInto` (`_opt`). Each was unconditionally `newLocal`'ing with the raw HIR type, so a checker-skipped `CallExpr` / `FieldExpr` / `IndexExpr` scrutinee leaked `ErrType` into the local and then cascaded through projection chains.
- Extends `internal/ir/lower.go::recoverFieldType` to walk `l.file.Decls` for any `*ast.StructDecl` matching the receiver type name when the resolver-anchored decl doesn't carry the field — the former code only consulted `FileScope.Lookup`, missing fields declared in a sibling partial-struct block. Memoised per `(typeName, fieldName)` so the merged-toolchain hot path doesn't re-walk file decls per access.

## Why

Both are correctness improvements that close holes in the existing operand-based ErrType recovery. The toolchain ErrType floor is unchanged at 395 (no partials in the merged toolchain today; iflet/coalesce/q/opt scrutinees in the toolchain happen to already be typed), so this is defensive — it prevents future regressions when other corpora exercise these shapes.

The remaining 395 → 40 floor gap is dominated by a separate `CheckFnSig` misidentification root cause — `typeNameOf` returning the wrong `NamedType.Name` for various MIR-side receivers (likely a monomorph or `fromCheckerType` Sym.Name issue). That needs its own investigation session.

## Test plan
- [x] `go build ./...`
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) → green
- [x] `osty check toolchain` → 0 errors
- [x] `TestNativeToolchainMergedMIRErrTypeFloor` → 395 (no regression vs main baseline)
- [ ] Verify smoke + AST-only probes still pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)