### PR TITLE
fix(mir): fuse_split_nth — bail on non-const-index + extend to multi-index canonical pattern

### DIFF
--- a/internal/mir/fuse_split_nth.go
+++ b/internal/mir/fuse_split_nth.go
@@ -1,40 +1,69 @@
 package mir
 
-// fuseNonEscapingSplitNth detects the `expr.split(sep)[K]` pattern and
-// replaces it with a single `IntrinsicStringNthSegment` call. The full
-// `Split` materialises a `List<String>` with N pieces; when only one
-// constant index is consumed, the list itself is dead — eliminate it
-// and dup just the segment we care about.
+import "sort"
+
+// fuseNonEscapingSplitNth detects the `expr.split(sep)[K]` pattern (and
+// its multi-index sibling, `let parts = expr.split(sep); parts[K0];
+// parts[K1]; …`) and replaces each indexed read with a single
+// `IntrinsicStringNthSegment` call. The full `Split` materialises a
+// `List<String>` with N pieces; when only constant indices are
+// consumed, the list itself is dead — eliminate it and dup just the
+// segments we care about.
 //
-// Pattern (markdown-stats `classify(line)` shape):
+// Single-index pattern (markdown-stats `classify(line)` shape):
 //
 //	let parts = value.split(sep)        // IntrinsicStringSplit, dest=L
 //	let first = parts[0]                // AssignInstr with IndexProj on L
 //	// `parts` otherwise unused
 //
-// After the transform:
+// After:
 //
-//	let first = NthSegment(value, sep, 0)   // IntrinsicStringNthSegment, dest=M
+//	let first = NthSegment(value, sep, 0)   // dest=M
 //	// list-typed local L is dead; deadAssignElim removes the
 //	// now-unreachable Split call and storage markers.
 //
+// Multi-index pattern (log-aggregator's per-line parse — `let parts =
+// line.split(" "); let ts = parts[0]; let level = parts[1]`, hot enough
+// to dominate the 50 K-line loop):
+//
+//	let parts = line.split(" ")
+//	let ts    = parts[0]
+//	let level = parts[1]
+//
+// After:
+//
+//	let ts    = NthSegment(line, " ", 0)
+//	let level = NthSegment(line, " ", 1)
+//
+// We re-walk the input string for each index, so the fusion is a win
+// only when the saved per-piece allocation work + parts-list alloc
+// exceeds the cost of the extra walks. For typical
+// `parts[0..K_small]` patterns over short inputs that's overwhelmingly
+// true: each saved piece avoids one `osty_gc_allocate_managed(STRING)`
+// + `osty_rt_string_dup_range` (heap or SSO), and the parts list
+// itself dodges its `osty_rt_list_new` + N `list_push_ptr` chain.
+//
 // Safety conditions (all must hold):
 //   - The split call's Dest local L has a single IntrinsicStringSplit
-//     write and no other writes (same shape `splitDestEscapeSafe`
-//     enforces for the loop variant).
-//   - L's only read produces an IndexProj with a non-negative i64
-//     IntConst index (no `parts.len()`, no `for x in parts`, no second
-//     `parts[i]`). Other read shapes leave the unfused Split path
-//     intact — the heuristic isn't trying to be exhaustive.
-//   - The index read happens in an AssignInstr whose RValue is
-//     `UseRV{Op: CopyOp{Place: parts[K]}}` — the canonical lowering
-//     for `let first = parts[K]`. Other RValue shapes on top of an
-//     IndexProj (e.g. `BinaryRV{IndexProj, …}`) bail to keep the
-//     pass narrow.
+//     write and no other writes.
+//   - L's reads are EXCLUSIVELY canonical IndexProj reads with non-
+//     negative i64 IntConst indices — no `parts.len()`, no
+//     `for x in parts`, no second indirect index `parts[i]`. ANY
+//     other read shape (rvalue leak, call arg, branch operand)
+//     leaves the Split path intact. The single-index variant is the
+//     existing pre-extension shape; multi-index simply lifts the
+//     `matches == 1` constraint.
+//   - Each indexed read happens in an `AssignInstr{Src: UseRV{Op:
+//     CopyOp{Place: parts[K]}}}`. Other RValue shapes (binary,
+//     compound assign) bail.
+//   - The set of (BB, idx) replacements is processed bottom-up
+//     within each block so earlier replacements don't shift the
+//     index of later ones we still need to find.
 //
-// Fires before `hoistNonEscapingSplitInLoops` so the `[K]`-only
+// Fires before `hoistNonEscapingSplitInLoops` so the constant-index
 // pattern wins over the loop-hoist transform — the hoist still
-// allocates one List and dups all pieces, which we can avoid here.
+// allocates one List per outer iteration and dups all pieces, which
+// we can avoid here.
 func fuseNonEscapingSplitNth(fn *Function) bool {
 	if fn == nil || fn.IsExternal || fn.IsIntrinsic || len(fn.Blocks) == 0 {
 		return false
@@ -56,42 +85,53 @@ func fuseNonEscapingSplitNth(fn *Function) bool {
 				continue
 			}
 			destL := ii.Dest.Local
-			indexLocal, indexValue, indexAssignBB, indexAssignIdx, ok :=
-				findSingleIndexProjUseFn(fn, destL, ii)
+			matches, ok := findIndexProjUsesFn(fn, destL, ii)
 			if !ok {
 				continue
 			}
-			// Build the replacement: IntrinsicStringNthSegment
-			// targeting the original index-read destination.
-			indexConst := &ConstOp{
-				Const: &IntConst{Value: indexValue, T: TInt},
-				T:     TInt,
+			// Group replacements by block so we can splice-out from
+			// each block bottom-up — modifying ab.Instrs[idx] in
+			// place doesn't shift indices, but if a later
+			// replacement and the Split call live in the same BB,
+			// removing the Split first would invalidate later idx
+			// values. We do replacements first (in-place), then
+			// remove the Split call last.
+			for _, m := range matches {
+				ab := fn.Block(m.bb)
+				if ab == nil {
+					ok = false
+					break
+				}
+				indexConst := &ConstOp{
+					Const: &IntConst{Value: m.constIdx, T: TInt},
+					T:     TInt,
+				}
+				ab.Instrs[m.idx] = &IntrinsicInstr{
+					Kind: IntrinsicStringNthSegment,
+					Dest: &Place{Local: m.destLoc},
+					Args: []Operand{
+						ii.Args[0], // value
+						ii.Args[1], // sep
+						indexConst,
+					},
+					SpanV: ii.SpanV,
+				}
 			}
-			fused := &IntrinsicInstr{
-				Kind: IntrinsicStringNthSegment,
-				Dest: &Place{Local: indexLocal},
-				Args: []Operand{
-					ii.Args[0], // value
-					ii.Args[1], // sep
-					indexConst,
-				},
-				SpanV: ii.SpanV,
+			if !ok {
+				// Bail mid-stream: at least one match's BB resolved
+				// to nil, which shouldn't happen for a well-formed
+				// function but we don't want a partial rewrite.
+				continue
 			}
-			// Apply both edits in a defined order: the index-read
-			// might be in the same BB as the Split (the typical
-			// straight-line case) or in a successor block. Compute
-			// the adjusted index first, splice out the Split, then
-			// install the fused intrinsic at the adjusted position.
-			// Split is pure side-effect-wise (no abort, no IO,
-			// only allocation), so removing the unused result
-			// removes nothing observable.
-			ab := fn.Block(indexAssignBB)
-			adjustedIdx := indexAssignIdx
-			if indexAssignBB == bb.ID && indexAssignIdx > instrIdx {
-				adjustedIdx = indexAssignIdx - 1
-			}
+			// Now remove the originating Split. After all the
+			// in-place rewrites above the Split call still sits at
+			// `bb.Instrs[instrIdx]`; splicing it out is safe even
+			// when one of the rewritten instrs lived in the same
+			// BB at a higher index because we never inserted, only
+			// replaced. The remaining `bb.Instrs[idx]`-style
+			// references would shift by one, but at this point we
+			// don't need them.
 			bb.Instrs = append(bb.Instrs[:instrIdx], bb.Instrs[instrIdx+1:]...)
-			ab.Instrs[adjustedIdx] = fused
 			changed = true
 			instrIdx-- // re-examine the slot we deleted from
 		}
@@ -99,29 +139,38 @@ func fuseNonEscapingSplitNth(fn *Function) bool {
 	return changed
 }
 
-// findSingleIndexProjUseFn returns (indexAssignDestLocal, K, BB, idx,
-// true) when destL has exactly one read across the function and that
-// read is an `AssignInstr{Src: UseRV{Op: CopyOp{Place: destL[K_const]}}}`
-// with K_const a non-negative IntConst. Otherwise returns
-// `(_, _, _, _, false)`. Any read shape other than the canonical
-// IndexProj-into-Use path counts as "not the simple pattern" and
-// disables the fusion for that local. Storage markers and the
-// originating split call are excluded from the read tally.
-func findSingleIndexProjUseFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (LocalID, int64, BlockID, int, bool) {
+// indexUseMatch records one canonical `parts[K_const]` read of the
+// originating Split's destination local. Stored as a slice so the
+// multi-index lift can rewrite each of `parts[0]`, `parts[1]`, …
+// independently.
+type indexUseMatch struct {
+	bb       BlockID
+	idx      int
+	destLoc  LocalID
+	constIdx int64
+}
+
+// findIndexProjUsesFn returns the set of canonical index reads of
+// `destL` (and `true`) when EVERY non-storage read of `destL` is the
+// `AssignInstr{Src: UseRV{Op: CopyOp{Place: destL[K_const]}}}` shape.
+// Any other read shape (rvalue leak, call arg, branch/switch operand,
+// non-const index, `parts.len()` etc.) makes the function return
+// `(_, false)` — the unfused Split path stays intact.
+//
+// `srcCall` is the originating Split intrinsic; it's the one allowed
+// write of `destL` and is excluded from the read tally.
+//
+// Returned matches are sorted by (BlockID asc, instrIdx asc) so the
+// caller can splice the originating Split last without disturbing
+// earlier replacement indices.
+func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) ([]indexUseMatch, bool) {
 	if int(destL) < 0 || int(destL) >= len(fn.Locals) {
-		return 0, 0, 0, 0, false
+		return nil, false
 	}
 	if fn.Locals[destL].IsParam || fn.Locals[destL].IsReturn || fn.ReturnLocal == destL {
-		return 0, 0, 0, 0, false
+		return nil, false
 	}
-	type indexUse struct {
-		bb       BlockID
-		idx      int
-		destLoc  LocalID
-		constIdx int64
-	}
-	var match indexUse
-	matches := 0
+	matches := make([]indexUseMatch, 0, 4)
 	otherReads := 0
 	writes := 0
 	for _, bb := range fn.Blocks {
@@ -133,17 +182,30 @@ func findSingleIndexProjUseFn(fn *Function, destL LocalID, srcCall *IntrinsicIns
 			case *AssignInstr:
 				if x.Dest.Local == destL {
 					if x.Dest.HasProjections() {
-						return 0, 0, 0, 0, false
+						return nil, false
 					}
-					return 0, 0, 0, 0, false // unrelated direct write — bail
+					return nil, false // unrelated direct write — bail
 				}
 				if u, ok := x.Src.(*UseRV); ok {
 					if cu, ok := u.Op.(*CopyOp); ok && cu.Place.Local == destL {
 						if k, isConstIdx := singleConstIndexProjection(cu.Place); isConstIdx && !x.Dest.HasProjections() {
-							match = indexUse{bb: bb.ID, idx: j, destLoc: x.Dest.Local, constIdx: k}
-							matches++
+							matches = append(matches, indexUseMatch{
+								bb: bb.ID, idx: j,
+								destLoc: x.Dest.Local, constIdx: k,
+							})
 							continue
 						}
+						// `parts[X]` where X isn't a non-negative
+						// IntConst, or the dest carries its own
+						// projections. `rvalueLeaksLocal` won't
+						// flag this — `placeLeaksRoot` deliberately
+						// treats `IndexProj`-led reads as element
+						// access, not bare-pointer leaks. Without
+						// the explicit bail we'd approve fusion,
+						// rewrite the const-index reads, drop the
+						// originating Split, and orphan the
+						// non-const-index read on a now-dead local.
+						return nil, false
 					}
 				}
 				if rvalueLeaksLocal(x.Src, destL) {
@@ -151,7 +213,7 @@ func findSingleIndexProjUseFn(fn *Function, destL LocalID, srcCall *IntrinsicIns
 				}
 			case *CallInstr:
 				if x.Dest != nil && x.Dest.Local == destL {
-					return 0, 0, 0, 0, false
+					return nil, false
 				}
 				for _, op := range x.Args {
 					if operandLeaksLocal(op, destL) {
@@ -169,7 +231,7 @@ func findSingleIndexProjUseFn(fn *Function, destL LocalID, srcCall *IntrinsicIns
 					continue
 				}
 				if x.Dest != nil && x.Dest.Local == destL {
-					return 0, 0, 0, 0, false
+					return nil, false
 				}
 				for _, op := range x.Args {
 					if operandLeaksLocal(op, destL) {
@@ -191,10 +253,19 @@ func findSingleIndexProjUseFn(fn *Function, destL LocalID, srcCall *IntrinsicIns
 			}
 		}
 	}
-	if writes != 1 || matches != 1 || otherReads != 0 {
-		return 0, 0, 0, 0, false
+	if writes != 1 || len(matches) < 1 || otherReads != 0 {
+		return nil, false
 	}
-	return match.destLoc, match.constIdx, match.bb, match.idx, true
+	// Sort by (bb, idx) ascending. Stable order makes the rewrite
+	// loop deterministic and avoids surprising index-shift bugs if
+	// the caller ever needs to mutate Instrs alongside the matches.
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].bb != matches[j].bb {
+			return matches[i].bb < matches[j].bb
+		}
+		return matches[i].idx < matches[j].idx
+	})
+	return matches, true
 }
 
 // singleConstIndexProjection reports whether place's projections are

--- a/internal/mir/fuse_split_nth_test.go
+++ b/internal/mir/fuse_split_nth_test.go
@@ -1,0 +1,273 @@
+package mir
+
+import (
+	"testing"
+)
+
+// fuseNonEscapingSplitNth has two flavours:
+//
+//   1. Single-index (markdown-stats): one `parts[K]` read, fuse to a
+//      single NthSegment call.
+//   2. Multi-index (log-aggregator): N reads `parts[K0..KM]`, fuse
+//      each to its own NthSegment call sharing the same underlying
+//      string + separator.
+//
+// Either flavour relies on the originating Split being entirely dead
+// after rewrite (tracked via the now-unused list local). These tests
+// drive each shape and the relevant bail cases.
+
+// buildStraightLineSplitFn synthesises a simple straight-line function
+// that:
+//
+//   parts = value.split(sep)
+//   ... callers append `parts[K]`-style reads here
+//
+// Returns the function, its only block, the value local, the sep
+// local (filled in from a string literal), and the parts local for
+// downstream tests to add reads against.
+func buildStraightLineSplitFn(t *testing.T) (*Function, *BasicBlock, LocalID) {
+	t.Helper()
+	fn, bb := newTestFunction("split_nth", TString)
+	value := fn.NewLocal("value", TString, false, Span{})
+	fn.Locals[value].IsParam = true
+	fn.Params = []LocalID{value}
+	parts := fn.NewLocal("parts", listOfStringT(), false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: parts},
+		&IntrinsicInstr{
+			Kind: IntrinsicStringSplit,
+			Dest: &Place{Local: parts},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: value}, T: TString},
+				&ConstOp{Const: &StringConst{Value: ","}, T: TString},
+			},
+		},
+	)
+	return fn, bb, parts
+}
+
+// addPartsKRead appends `let dest = parts[k]` to bb. Returns the
+// new dest local so the caller can inspect it (or hand it back into
+// the function as the return value to keep the read alive for
+// liveness analysis).
+func addPartsKRead(fn *Function, bb *BasicBlock, parts LocalID, k int64) LocalID {
+	dest := fn.NewLocal("part", TString, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: dest},
+		&AssignInstr{
+			Dest: Place{Local: dest},
+			Src: &UseRV{Op: &CopyOp{
+				Place: Place{Local: parts, Projections: []Projection{
+					&IndexProj{
+						Index:    &ConstOp{Const: &IntConst{Value: k, T: TInt}, T: TInt},
+						ElemType: TString,
+					},
+				}},
+				T: TString,
+			}},
+		},
+	)
+	return dest
+}
+
+// findAllIntrinsics returns every intrinsic of kind k in bb. Used by
+// the multi-index test to count fused calls.
+func findAllIntrinsics(bb *BasicBlock, k IntrinsicKind) []*IntrinsicInstr {
+	var hits []*IntrinsicInstr
+	for _, ins := range bb.Instrs {
+		if ii, ok := ins.(*IntrinsicInstr); ok && ii.Kind == k {
+			hits = append(hits, ii)
+		}
+	}
+	return hits
+}
+
+func TestFuseSplitNth_SingleIndex_StillFuses(t *testing.T) {
+	// Regression: the existing markdown-stats `parts[0]` shape must
+	// keep firing after the multi-index lift.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	_ = addPartsKRead(fn, bb, parts, 0)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected transform to apply")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 0 {
+		t.Fatalf("Split should be removed; %d remaining", n)
+	}
+	hits := findAllIntrinsics(bb, IntrinsicStringNthSegment)
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 NthSegment, got %d", len(hits))
+	}
+	if k, ok := constArgK(hits[0]); !ok || k != 0 {
+		t.Fatalf("expected K=0, got %d ok=%v", k, ok)
+	}
+}
+
+func TestFuseSplitNth_MultiIndex_FusesEachRead(t *testing.T) {
+	// log-aggregator's `let ts = parts[0]; let level = parts[1]`
+	// must produce TWO NthSegment calls — one per index — and the
+	// originating Split must still be removed.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	_ = addPartsKRead(fn, bb, parts, 0)
+	_ = addPartsKRead(fn, bb, parts, 1)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected transform to apply")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 0 {
+		t.Fatalf("Split should be removed after multi-index fuse; %d remaining", n)
+	}
+	hits := findAllIntrinsics(bb, IntrinsicStringNthSegment)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 NthSegment calls, got %d", len(hits))
+	}
+	// Index ordering: matches sorted by (BB, idx) ascending. The
+	// parts[0] read was inserted first, so its NthSegment lives at
+	// the lower instruction index — which means K=0 then K=1.
+	k0, ok0 := constArgK(hits[0])
+	k1, ok1 := constArgK(hits[1])
+	if !ok0 || !ok1 || k0 != 0 || k1 != 1 {
+		t.Fatalf("expected NthSegment indices [0, 1], got [%d, %d] (ok=%v %v)", k0, k1, ok0, ok1)
+	}
+}
+
+func TestFuseSplitNth_MultiIndex_NonContiguousIndices(t *testing.T) {
+	// User code might do `parts[0]; parts[2]; parts[5]` — sparse
+	// indices. Each read is independent; the fusion should rewrite
+	// every one regardless of gaps in the K values.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	addPartsKRead(fn, bb, parts, 0)
+	addPartsKRead(fn, bb, parts, 2)
+	_ = addPartsKRead(fn, bb, parts, 5)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected transform to apply")
+	}
+	hits := findAllIntrinsics(bb, IntrinsicStringNthSegment)
+	if len(hits) != 3 {
+		t.Fatalf("expected 3 NthSegment calls, got %d", len(hits))
+	}
+	want := []int64{0, 2, 5}
+	for i, want := range want {
+		got, ok := constArgK(hits[i])
+		if !ok || got != want {
+			t.Fatalf("expected K=%d at position %d, got %d (ok=%v)", want, i, got, ok)
+		}
+	}
+}
+
+func TestFuseSplitNth_BailsOnRepeatedIndex(t *testing.T) {
+	// Two reads of `parts[0]` is technically two valid fuse targets
+	// but downstream IR consumers don't expect a single source local
+	// to be written twice. The pass treats every canonical read as a
+	// separate replacement target — confirm the rewrite still
+	// produces two NthSegment calls so dead-code elim can drop one
+	// later if both dest locals turn out to be identical use chains.
+	// (Not strictly a bail, but pinning the behaviour so a future
+	// change doesn't accidentally collapse them into a single call.)
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	_ = addPartsKRead(fn, bb, parts, 0)
+	_ = addPartsKRead(fn, bb, parts, 0)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected transform to apply for repeated K=0 reads")
+	}
+	hits := findAllIntrinsics(bb, IntrinsicStringNthSegment)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 NthSegment calls (one per read), got %d", len(hits))
+	}
+}
+
+func TestFuseSplitNth_BailsOnPartsLen(t *testing.T) {
+	// `parts.len()` lowers to an IntrinsicInstr that takes `parts`
+	// as an argument — that's a non-IndexProj read, which the
+	// safety check counts as `otherReads` and forces the unfused
+	// Split path to remain.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	addPartsKRead(fn, bb, parts, 0)
+	lenLocal := fn.NewLocal("count", TInt, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: lenLocal},
+		&IntrinsicInstr{
+			Kind: IntrinsicListLen,
+			Dest: &Place{Local: lenLocal},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: parts}, T: listOfStringT()},
+			},
+		},
+	)
+	bb.SetTerminator(&ReturnTerm{})
+
+	// Note: the test function returns String per newTestFunction,
+	// but ReturnTerm.Value carries an Int. The pass under test
+	// doesn't validate types, only structure; this is fine for
+	// driving the read-shape analysis.
+	if fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected NO transform — parts.len() should disable fusion")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 1 {
+		t.Fatalf("Split should remain; got %d", n)
+	}
+}
+
+func TestFuseSplitNth_BailsOnNonConstIndex(t *testing.T) {
+	// `parts[i]` with a non-const index forces the unfused path
+	// because the runtime intrinsic takes a constant K. Even if
+	// other reads are canonical, the presence of one variable-index
+	// read means we can't safely drop the parts list.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	addPartsKRead(fn, bb, parts, 0)
+	i := fn.NewLocal("i", TInt, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: i},
+		&AssignInstr{
+			Dest: Place{Local: i},
+			Src:  &UseRV{Op: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt}},
+		},
+	)
+	dyn := fn.NewLocal("dyn", TString, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: dyn},
+		&AssignInstr{
+			Dest: Place{Local: dyn},
+			Src: &UseRV{Op: &CopyOp{
+				Place: Place{Local: parts, Projections: []Projection{
+					&IndexProj{
+						Index:    &CopyOp{Place: Place{Local: i}, T: TInt},
+						ElemType: TString,
+					},
+				}},
+				T: TString,
+			}},
+		},
+	)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected NO transform — non-const index should disable fusion")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 1 {
+		t.Fatalf("Split should remain when non-const index is present; got %d", n)
+	}
+}
+
+// constArgK extracts the trailing IntConst K argument of a
+// fused IntrinsicStringNthSegment call: NthSegment(value, sep, K).
+func constArgK(ii *IntrinsicInstr) (int64, bool) {
+	if ii == nil || len(ii.Args) != 3 {
+		return 0, false
+	}
+	co, ok := ii.Args[2].(*ConstOp)
+	if !ok {
+		return 0, false
+	}
+	ic, ok := co.Const.(*IntConst)
+	if !ok {
+		return 0, false
+	}
+	return ic.Value, true
+}


### PR DESCRIPTION
## Summary

Two changes to `fuseNonEscapingSplitNth` shipped together:

### 1. Bug fix: bail on `parts[X]` when X isn't a non-negative IntConst

The pre-existing single-index pass had a latent silent-orphan hazard. When `parts[K_const]` (canonical) and `parts[i]` (non-const) coexist on the same Split, the non-const read fell through the canonical-match branch, then `rvalueLeaksLocal` left `otherReads == 0` because `placeLeaksRoot` deliberately treats `IndexProj`-led places as element access (not bare-pointer leaks).

That combination satisfied the `matches == 1, otherReads == 0` gate even though the IR contained a *second* live read of `parts`. The fusion would then rewrite the const-index read, splice out the originating Split, and leave `parts[i]` referencing a now-dead local — observable as a load from uninitialised memory once the backend lowered it.

No current workload triggers it, but the regression test `TestFuseSplitNth_BailsOnNonConstIndex` reproduces it directly. Fix: explicit `return nil, false` when the IndexProj's index isn't a non-negative IntConst.

### 2. Multi-index canonical pattern (capability extension)

The existing pass enforced `matches == 1`, locking out:

```osty
let parts = line.split(" ")
let ts    = parts[0]
let level = parts[1]
```

Lifted to `len(matches) >= 1`, with each canonical IndexProj read rewritten to its own `IntrinsicStringNthSegment(value, sep, K)` call. Originating Split removed last so in-place rewrites don't deal with shifting indices.

## Why no benchmark perf delta yet

Every direct multi-index user in the codebase (log-aggregator's `parts.len() < 3 { continue }; let ts = parts[0]; let level = parts[1]`) also calls `parts.len()`, which the analysis correctly flags as non-canonical. Replacing with NthSegment would let malformed lines fall through with empty-string parts — observable output change.

Latent capability for:
- Synthetic CSV/TSV parsers reading fixed columns without length checks
- Stdlib helpers that internalise bounds checks separately from column reads
- A future `strings.splitN(s, sep, n)` runtime helper

## Tests

Six unit tests in `fuse_split_nth_test.go`:

- `SingleIndex_StillFuses` — regression for existing `parts[K]` shape
- `MultiIndex_FusesEachRead` — `parts[0]; parts[1]` produces two
- `MultiIndex_NonContiguousIndices` — sparse indices `[0, 2, 5]`
- `BailsOnRepeatedIndex` — `parts[0]; parts[0]` produces two (DCE may collapse)
- `BailsOnPartsLen` — `parts.len()` blocks fusion
- `BailsOnNonConstIndex` — the bug-fix regression

## Test plan

- [x] `go test ./internal/mir` — green
- [x] `go test ./internal/llvmgen -run "TestBundled|TestRuntime|TestList|TestMap|TestGC"` — green
- [x] `benchmarks/programs/build-all.sh` — all 7 programs byte-equal
- [x] NthSegment IR count unchanged on existing benchmarks (sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)