### PR TITLE
perf(mir): fuse_split_nth handles parts.len() via Count + 1 rewrite

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1187,6 +1187,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
 		mir.IntrinsicStringSplitInto, mir.IntrinsicStringNthSegment,
+		mir.IntrinsicStringCount,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
@@ -3772,6 +3773,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringIndexOf, mir.IntrinsicStringSplit,
 		mir.IntrinsicStringSplitInto, mir.IntrinsicStringNthSegment,
+		mir.IntrinsicStringCount,
 		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -5475,6 +5477,8 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeHasSuffixSymbol())
 	case mir.IntrinsicStringContains:
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeContainsSymbol())
+	case mir.IntrinsicStringCount:
+		return g.emitStringCount(i, strReg)
 	case mir.IntrinsicStringIndexOf:
 		return g.emitStringIndexOf(i, strReg)
 	case mir.IntrinsicStringSplit:
@@ -5519,6 +5523,31 @@ func (g *mirGen) emitStringIndexOf(i *mir.IntrinsicInstr, strReg string) error {
 		return g.storeOptionalIntFromNegativeOneIndex(i, optT, index.name, "string.index_of")
 	}
 	return g.storeIntrinsicResult(i, index)
+}
+
+// emitStringCount lowers `IntrinsicStringCount(value, needle)` to a
+// direct `osty_rt_strings_Count(value, needle)` runtime call returning
+// i64. Synthesised by `fuseNonEscapingSplitNth` to replace
+// `parts.len()` reads when the originating Split is being eliminated;
+// the rewrite path emits an `Add 1` after this call so callers see the
+// same `len(Split(value, sep))` value.
+func (g *mirGen) emitStringCount(i *mir.IntrinsicInstr, strReg string) error {
+	if len(i.Args) != 2 {
+		return unsupported("mir-mvp", "string_count arity")
+	}
+	needleReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+	if err != nil {
+		return err
+	}
+	sym := "osty_rt_strings_Count"
+	g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrLine(sym))
+	em := g.ostyEmitter()
+	count := llvmCall(em, "i64", sym, []*LlvmValue{
+		{typ: "ptr", name: strReg},
+		{typ: "ptr", name: needleReg},
+	})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, count)
 }
 
 func (g *mirGen) storeOptionalIntFromNegativeOneIndex(i *mir.IntrinsicInstr, optT *ir.OptionalType, indexReg, labelPrefix string) error {

--- a/internal/mir/fuse_split_nth.go
+++ b/internal/mir/fuse_split_nth.go
@@ -35,6 +35,32 @@ import "sort"
 //	let ts    = NthSegment(line, " ", 0)
 //	let level = NthSegment(line, " ", 1)
 //
+// `parts.len()` extension (defensive-bounds-check shape from log-
+// aggregator-style parsers):
+//
+//	let parts = line.split(" ")
+//	if parts.len() < 3 { continue }
+//	let ts    = parts[0]
+//	let level = parts[1]
+//
+// Naively, the `parts.len()` read disqualified fusion — it's a non-
+// canonical use of the parts list. But for any non-empty separator,
+// `len(Split(value, sep)) == Count(value, sep) + 1` exactly (the
+// runtime always pushes the trailing piece), so the read can be
+// rewritten to a runtime `Count` plus a `+1`. After the rewrite the
+// parts list is unused and the originating Split disappears with
+// the rest of the pattern:
+//
+//	if Count(line, " ") + 1 < 3 { continue }
+//	let ts    = NthSegment(line, " ", 0)
+//	let level = NthSegment(line, " ", 1)
+//
+// The empty-separator case is excluded — Split on an empty separator
+// performs byte-level expansion returning N pieces while Count
+// returns N+1, so the rewrite would be off by one. The fusion pass
+// requires the Split's separator argument to be a non-empty
+// StringConst literal, which covers every realistic call site.
+//
 // We re-walk the input string for each index, so the fusion is a win
 // only when the saved per-piece allocation work + parts-list alloc
 // exceeds the cost of the extra walks. For typical
@@ -46,19 +72,17 @@ import "sort"
 // Safety conditions (all must hold):
 //   - The split call's Dest local L has a single IntrinsicStringSplit
 //     write and no other writes.
-//   - L's reads are EXCLUSIVELY canonical IndexProj reads with non-
-//     negative i64 IntConst indices — no `parts.len()`, no
-//     `for x in parts`, no second indirect index `parts[i]`. ANY
-//     other read shape (rvalue leak, call arg, branch operand)
-//     leaves the Split path intact. The single-index variant is the
-//     existing pre-extension shape; multi-index simply lifts the
-//     `matches == 1` constraint.
+//   - L's reads are EXCLUSIVELY canonical IndexProj reads OR bare-
+//     local `parts.len()` reads. No `for x in parts`, no second
+//     indirect index `parts[i]`, no escapes via call args / branch
+//     operands. ANY other read shape leaves the unfused Split path
+//     intact.
 //   - Each indexed read happens in an `AssignInstr{Src: UseRV{Op:
 //     CopyOp{Place: parts[K]}}}`. Other RValue shapes (binary,
 //     compound assign) bail.
-//   - The set of (BB, idx) replacements is processed bottom-up
-//     within each block so earlier replacements don't shift the
-//     index of later ones we still need to find.
+//   - When at least one `parts.len()` read is present, the Split's
+//     separator argument MUST be a non-empty StringConst literal.
+//     The `Count + 1` rewrite is exact only for that shape.
 //
 // Fires before `hoistNonEscapingSplitInLoops` so the constant-index
 // pattern wins over the loop-hoist transform — the hoist still
@@ -85,17 +109,26 @@ func fuseNonEscapingSplitNth(fn *Function) bool {
 				continue
 			}
 			destL := ii.Dest.Local
-			matches, ok := findIndexProjUsesFn(fn, destL, ii)
+			matches, lenReads, ok := findIndexProjUsesFn(fn, destL, ii)
 			if !ok {
 				continue
 			}
-			// Group replacements by block so we can splice-out from
-			// each block bottom-up — modifying ab.Instrs[idx] in
-			// place doesn't shift indices, but if a later
-			// replacement and the Split call live in the same BB,
-			// removing the Split first would invalidate later idx
-			// values. We do replacements first (in-place), then
-			// remove the Split call last.
+			// `len`-rewrite requires a non-empty StringConst separator
+			// (see top-of-file rationale: empty-sep Split returns N
+			// pieces while Count returns N+1). If we have any len reads
+			// but the separator isn't a non-empty literal, leave the
+			// pattern alone rather than fuse half of it.
+			if len(lenReads) > 0 && !isNonEmptyStringConst(ii.Args[1]) {
+				continue
+			}
+			// Per-block splicing strategy: replace canonical IndexProj
+			// reads in-place (no index shift), then for `parts.len()`
+			// reads emit a 2-instruction sequence in place of the
+			// original ListLen — replacing the existing slot with the
+			// Count call and inserting the `+1` AssignInstr just after.
+			// We process len rewrites in REVERSE block order so the
+			// inserted instructions don't shift indices we still need
+			// to find for siblings in the same block.
 			for _, m := range matches {
 				ab := fn.Block(m.bb)
 				if ab == nil {
@@ -118,19 +151,60 @@ func fuseNonEscapingSplitNth(fn *Function) bool {
 				}
 			}
 			if !ok {
-				// Bail mid-stream: at least one match's BB resolved
-				// to nil, which shouldn't happen for a well-formed
-				// function but we don't want a partial rewrite.
+				continue
+			}
+			// `parts.len()` rewrites: for each one, replace the
+			// IntrinsicListLen with `tmp = Count(value, sep)` (writing
+			// a fresh local) and insert `AssignInstr{Dest: original,
+			// Src: tmp + 1}` right after. Sort by (BB desc, idx desc)
+			// so insertion in one slot doesn't shift indices of later
+			// rewrites in the same block.
+			sortLenReadsForRewrite(lenReads)
+			for _, lr := range lenReads {
+				ab := fn.Block(lr.bb)
+				if ab == nil {
+					ok = false
+					break
+				}
+				tmp := fn.NewLocal("split_nth_count_tmp", TInt, false, ii.SpanV)
+				ab.Instrs[lr.idx] = &IntrinsicInstr{
+					Kind: IntrinsicStringCount,
+					Dest: &Place{Local: tmp},
+					Args: []Operand{
+						ii.Args[0], // value
+						ii.Args[1], // sep
+					},
+					SpanV: ii.SpanV,
+				}
+				addOne := &AssignInstr{
+					Dest: Place{Local: lr.destLoc},
+					Src: &BinaryRV{
+						Op:    BinAdd,
+						Left:  &CopyOp{Place: Place{Local: tmp}, T: TInt},
+						Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+						T:     TInt,
+					},
+					SpanV: ii.SpanV,
+				}
+				// Splice insert at lr.idx+1.
+				ab.Instrs = append(ab.Instrs, nil)
+				copy(ab.Instrs[lr.idx+2:], ab.Instrs[lr.idx+1:])
+				ab.Instrs[lr.idx+1] = addOne
+				// Same-block bookkeeping: if the Split call we're about
+				// to remove sits at a higher index in the same block,
+				// the insert just shifted it by one. Track the shift
+				// so the splice-out below targets the correct slot.
+				if lr.bb == bb.ID && lr.idx <= instrIdx {
+					instrIdx++
+				}
+			}
+			if !ok {
 				continue
 			}
 			// Now remove the originating Split. After all the
 			// in-place rewrites above the Split call still sits at
-			// `bb.Instrs[instrIdx]`; splicing it out is safe even
-			// when one of the rewritten instrs lived in the same
-			// BB at a higher index because we never inserted, only
-			// replaced. The remaining `bb.Instrs[idx]`-style
-			// references would shift by one, but at this point we
-			// don't need them.
+			// `bb.Instrs[instrIdx]` (adjusted for any same-block
+			// inserts above).
 			bb.Instrs = append(bb.Instrs[:instrIdx], bb.Instrs[instrIdx+1:]...)
 			changed = true
 			instrIdx-- // re-examine the slot we deleted from
@@ -150,27 +224,94 @@ type indexUseMatch struct {
 	constIdx int64
 }
 
+// lenUseMatch records one `parts.len()` read of the originating
+// Split's destination local. The rewrite path replaces the
+// IntrinsicListLen with a 2-instruction sequence:
+//
+//	tmp = IntrinsicStringCount(value, sep)
+//	dest = tmp + 1
+//
+// so the original `dest` local sees the same value as before.
+type lenUseMatch struct {
+	bb      BlockID
+	idx     int
+	destLoc LocalID
+}
+
+// isNonEmptyStringConst returns true when `op` is a non-empty
+// StringConst literal. Used to gate the `parts.len() → Count(value,
+// sep) + 1` rewrite: an empty separator triggers different runtime
+// semantics (byte-level expansion in Split, value-len + 1 in Count)
+// and would make the rewrite off by one.
+func isNonEmptyStringConst(op Operand) bool {
+	co, ok := op.(*ConstOp)
+	if !ok {
+		return false
+	}
+	sc, ok := co.Const.(*StringConst)
+	if !ok {
+		return false
+	}
+	return len(sc.Value) > 0
+}
+
+// argReadsBareLocal reports whether `op` is `CopyOp{Place: bare-local
+// destL}` — i.e., reads the entire list as a single value (no
+// projections). Used to detect `parts.len()` and similar full-list
+// reads where the receiver is just `parts` with nothing after.
+func argReadsBareLocal(op Operand, destL LocalID) bool {
+	cu, ok := op.(*CopyOp)
+	if !ok {
+		return false
+	}
+	return cu.Place.Local == destL && len(cu.Place.Projections) == 0
+}
+
+// sortLenReadsForRewrite orders len rewrites bottom-up within each
+// block (highest BlockID first, then highest instrIdx first). The
+// rewrite inserts an extra instruction per len read; processing
+// bottom-up means earlier-block / earlier-idx rewrites still find
+// the right offsets when their turn comes.
+func sortLenReadsForRewrite(lr []lenUseMatch) {
+	sort.SliceStable(lr, func(i, j int) bool {
+		if lr[i].bb != lr[j].bb {
+			return lr[i].bb > lr[j].bb
+		}
+		return lr[i].idx > lr[j].idx
+	})
+}
+
 // findIndexProjUsesFn returns the set of canonical index reads of
-// `destL` (and `true`) when EVERY non-storage read of `destL` is the
-// `AssignInstr{Src: UseRV{Op: CopyOp{Place: destL[K_const]}}}` shape.
+// `destL` and the set of `parts.len()` reads (plus `true`) when
+// EVERY non-storage read of `destL` is one of:
+//
+//   - `AssignInstr{Src: UseRV{Op: CopyOp{Place: destL[K_const]}}}`
+//     (canonical IndexProj — gets fused to NthSegment)
+//   - `IntrinsicInstr{Kind: IntrinsicListLen, Args: [CopyOp{destL}]}`
+//     (parts.len() — gets rewritten to Count + 1, but only when the
+//     originating Split's separator is a non-empty StringConst)
+//
 // Any other read shape (rvalue leak, call arg, branch/switch operand,
-// non-const index, `parts.len()` etc.) makes the function return
-// `(_, false)` — the unfused Split path stays intact.
+// non-const index, `for x in parts`, etc.) makes the function return
+// `(_, _, false)` — the unfused Split path stays intact.
 //
 // `srcCall` is the originating Split intrinsic; it's the one allowed
 // write of `destL` and is excluded from the read tally.
 //
 // Returned matches are sorted by (BlockID asc, instrIdx asc) so the
 // caller can splice the originating Split last without disturbing
-// earlier replacement indices.
-func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) ([]indexUseMatch, bool) {
+// earlier replacement indices. lenReads have a separate sort step
+// (sortLenReadsForRewrite) since their rewrite inserts new
+// instructions and needs to process bottom-up.
+func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) ([]indexUseMatch, []lenUseMatch, bool) {
 	if int(destL) < 0 || int(destL) >= len(fn.Locals) {
-		return nil, false
+		return nil, nil, false
 	}
 	if fn.Locals[destL].IsParam || fn.Locals[destL].IsReturn || fn.ReturnLocal == destL {
-		return nil, false
+		return nil, nil, false
 	}
 	matches := make([]indexUseMatch, 0, 4)
+	lenReads := make([]lenUseMatch, 0, 2)
 	otherReads := 0
 	writes := 0
 	for _, bb := range fn.Blocks {
@@ -182,9 +323,9 @@ func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (
 			case *AssignInstr:
 				if x.Dest.Local == destL {
 					if x.Dest.HasProjections() {
-						return nil, false
+						return nil, nil, false
 					}
-					return nil, false // unrelated direct write — bail
+					return nil, nil, false // unrelated direct write — bail
 				}
 				if u, ok := x.Src.(*UseRV); ok {
 					if cu, ok := u.Op.(*CopyOp); ok && cu.Place.Local == destL {
@@ -205,7 +346,7 @@ func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (
 						// rewrite the const-index reads, drop the
 						// originating Split, and orphan the
 						// non-const-index read on a now-dead local.
-						return nil, false
+						return nil, nil, false
 					}
 				}
 				if rvalueLeaksLocal(x.Src, destL) {
@@ -213,7 +354,7 @@ func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (
 				}
 			case *CallInstr:
 				if x.Dest != nil && x.Dest.Local == destL {
-					return nil, false
+					return nil, nil, false
 				}
 				for _, op := range x.Args {
 					if operandLeaksLocal(op, destL) {
@@ -231,7 +372,23 @@ func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (
 					continue
 				}
 				if x.Dest != nil && x.Dest.Local == destL {
-					return nil, false
+					return nil, nil, false
+				}
+				// `parts.len()` — IntrinsicListLen with `parts` as
+				// Args[0] and a Dest that isn't `parts` itself. The
+				// rewrite path can replace this with `Count(value,
+				// sep) + 1` when the originating Split's separator
+				// is a non-empty literal. Track separately so the
+				// caller can gate on the separator shape after
+				// collecting.
+				if x.Kind == IntrinsicListLen && x.Dest != nil &&
+					!x.Dest.HasProjections() && x.Dest.Local != destL &&
+					len(x.Args) == 1 && argReadsBareLocal(x.Args[0], destL) {
+					lenReads = append(lenReads, lenUseMatch{
+						bb: bb.ID, idx: j,
+						destLoc: x.Dest.Local,
+					})
+					continue
 				}
 				for _, op := range x.Args {
 					if operandLeaksLocal(op, destL) {
@@ -254,18 +411,19 @@ func findIndexProjUsesFn(fn *Function, destL LocalID, srcCall *IntrinsicInstr) (
 		}
 	}
 	if writes != 1 || len(matches) < 1 || otherReads != 0 {
-		return nil, false
+		return nil, nil, false
 	}
-	// Sort by (bb, idx) ascending. Stable order makes the rewrite
-	// loop deterministic and avoids surprising index-shift bugs if
-	// the caller ever needs to mutate Instrs alongside the matches.
+	// Sort canonical matches by (bb, idx) ascending. Stable order
+	// makes the rewrite loop deterministic and avoids surprising
+	// index-shift bugs if the caller ever needs to mutate Instrs
+	// alongside the matches.
 	sort.SliceStable(matches, func(i, j int) bool {
 		if matches[i].bb != matches[j].bb {
 			return matches[i].bb < matches[j].bb
 		}
 		return matches[i].idx < matches[j].idx
 	})
-	return matches, true
+	return matches, lenReads, true
 }
 
 // singleConstIndexProjection reports whether place's projections are

--- a/internal/mir/fuse_split_nth_test.go
+++ b/internal/mir/fuse_split_nth_test.go
@@ -182,11 +182,17 @@ func TestFuseSplitNth_BailsOnRepeatedIndex(t *testing.T) {
 	}
 }
 
-func TestFuseSplitNth_BailsOnPartsLen(t *testing.T) {
-	// `parts.len()` lowers to an IntrinsicInstr that takes `parts`
-	// as an argument — that's a non-IndexProj read, which the
-	// safety check counts as `otherReads` and forces the unfused
-	// Split path to remain.
+func TestFuseSplitNth_PartsLen_FusesViaCountPlusOne(t *testing.T) {
+	// log-aggregator's defensive-bounds-check shape:
+	//   let parts = line.split(",")
+	//   if parts.len() < 3 { continue }
+	//   let p0 = parts[0]
+	//
+	// The pass should rewrite `parts.len()` into `Count(value, sep)
+	// + 1` (a 2-instruction sequence: IntrinsicStringCount writing
+	// a fresh tmp local, then AssignInstr adding 1 to that tmp into
+	// the original len destination), AND fuse the `parts[0]` read
+	// into a NthSegment call. The originating Split disappears.
 	fn, bb, parts := buildStraightLineSplitFn(t)
 	addPartsKRead(fn, bb, parts, 0)
 	lenLocal := fn.NewLocal("count", TInt, false, Span{})
@@ -202,15 +208,113 @@ func TestFuseSplitNth_BailsOnPartsLen(t *testing.T) {
 	)
 	bb.SetTerminator(&ReturnTerm{})
 
-	// Note: the test function returns String per newTestFunction,
-	// but ReturnTerm.Value carries an Int. The pass under test
-	// doesn't validate types, only structure; this is fine for
-	// driving the read-shape analysis.
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected fusion to apply — parts.len() with non-empty StringConst sep")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 0 {
+		t.Fatalf("Split should be removed; %d remaining", n)
+	}
+	nths := findAllIntrinsics(bb, IntrinsicStringNthSegment)
+	if len(nths) != 1 {
+		t.Fatalf("expected 1 NthSegment, got %d", len(nths))
+	}
+	counts := findAllIntrinsics(bb, IntrinsicStringCount)
+	if len(counts) != 1 {
+		t.Fatalf("expected 1 StringCount, got %d", len(counts))
+	}
+	// Verify the AssignInstr `+1` was inserted right after the
+	// StringCount call, and writes back into the original len local.
+	var sawAddOne bool
+	for _, instr := range bb.Instrs {
+		if a, ok := instr.(*AssignInstr); ok && a.Dest.Local == lenLocal {
+			if br, ok := a.Src.(*BinaryRV); ok && br.Op == BinAdd {
+				if rco, ok := br.Right.(*ConstOp); ok {
+					if ic, ok := rco.Const.(*IntConst); ok && ic.Value == 1 {
+						sawAddOne = true
+					}
+				}
+			}
+		}
+	}
+	if !sawAddOne {
+		t.Fatalf("expected AssignInstr writing `tmp + 1` into the original len local")
+	}
+}
+
+func TestFuseSplitNth_BailsOnPartsLenWithEmptySep(t *testing.T) {
+	// Empty separator: Split returns N pieces (byte-level expansion)
+	// while Count returns N+1, so the rewrite would be off by one.
+	// Fusion must bail and leave the original Split + ListLen intact.
+	fn, bb := newTestFunction("split_nth_empty_sep", TString)
+	value := fn.NewLocal("value", TString, false, Span{})
+	fn.Locals[value].IsParam = true
+	fn.Params = []LocalID{value}
+	parts := fn.NewLocal("parts", listOfStringT(), false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: parts},
+		&IntrinsicInstr{
+			Kind: IntrinsicStringSplit,
+			Dest: &Place{Local: parts},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: value}, T: TString},
+				&ConstOp{Const: &StringConst{Value: ""}, T: TString}, // EMPTY sep
+			},
+		},
+	)
+	addPartsKRead(fn, bb, parts, 0)
+	lenLocal := fn.NewLocal("count", TInt, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: lenLocal},
+		&IntrinsicInstr{
+			Kind: IntrinsicListLen,
+			Dest: &Place{Local: lenLocal},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: parts}, T: listOfStringT()},
+			},
+		},
+	)
+	bb.SetTerminator(&ReturnTerm{})
+
 	if fuseNonEscapingSplitNth(fn) {
-		t.Fatalf("expected NO transform — parts.len() should disable fusion")
+		t.Fatalf("expected NO transform — empty separator disables Count+1 rewrite")
 	}
 	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 1 {
-		t.Fatalf("Split should remain; got %d", n)
+		t.Fatalf("Split should remain when sep is empty; got %d", n)
+	}
+}
+
+func TestFuseSplitNth_PartsLen_MultiIndex(t *testing.T) {
+	// log-aggregator's actual shape: `parts.len() < 3 { continue };
+	// parts[0]; parts[1]`. All three reads should be handled in a
+	// single fusion: 2 NthSegment calls, 1 StringCount + AssignInstr,
+	// originating Split gone.
+	fn, bb, parts := buildStraightLineSplitFn(t)
+	addPartsKRead(fn, bb, parts, 0)
+	addPartsKRead(fn, bb, parts, 1)
+	lenLocal := fn.NewLocal("count", TInt, false, Span{})
+	bb.Instrs = append(bb.Instrs,
+		&StorageLiveInstr{Local: lenLocal},
+		&IntrinsicInstr{
+			Kind: IntrinsicListLen,
+			Dest: &Place{Local: lenLocal},
+			Args: []Operand{
+				&CopyOp{Place: Place{Local: parts}, T: listOfStringT()},
+			},
+		},
+	)
+	bb.SetTerminator(&ReturnTerm{})
+
+	if !fuseNonEscapingSplitNth(fn) {
+		t.Fatalf("expected fusion to apply for multi-index + parts.len() shape")
+	}
+	if _, n := findIntrinsic(bb, IntrinsicStringSplit); n != 0 {
+		t.Fatalf("Split should be removed; %d remaining", n)
+	}
+	if got := len(findAllIntrinsics(bb, IntrinsicStringNthSegment)); got != 2 {
+		t.Fatalf("expected 2 NthSegment, got %d", got)
+	}
+	if got := len(findAllIntrinsics(bb, IntrinsicStringCount)); got != 1 {
+		t.Fatalf("expected 1 StringCount, got %d", got)
 	}
 }
 

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -547,6 +547,17 @@ const (
 	IntrinsicStringIsEmpty
 	// IntrinsicStringContains returns Bool. Args: [string, needle].
 	IntrinsicStringContains
+	// IntrinsicStringCount returns Int — non-overlapping occurrences
+	// of `needle` within `string`. Args: [string, needle].
+	//
+	// Synthesised by the `fuseNonEscapingSplitNth` MIR pass to replace
+	// `parts.len()` reads when fusing `let parts = X.split(sep);
+	// parts[K0]; parts[K1]; ... parts.len()` patterns: a list len of a
+	// freshly-split list equals `Count(value, sep) + 1` for every
+	// non-empty separator (the only shape the fusion targets — empty
+	// separators take a different path in the runtime). Lowers to
+	// `osty_rt_strings_Count(value, needle)`.
+	IntrinsicStringCount
 	// IntrinsicStringStartsWith returns Bool. Args: [string, prefix].
 	IntrinsicStringStartsWith
 	// IntrinsicStringEndsWith returns Bool. Args: [string, suffix].
@@ -1628,6 +1639,8 @@ func (k IntrinsicKind) String() string {
 		return "string_is_empty"
 	case IntrinsicStringContains:
 		return "string_contains"
+	case IntrinsicStringCount:
+		return "string_count"
 	case IntrinsicStringStartsWith:
 		return "string_starts_with"
 	case IntrinsicStringEndsWith:


### PR DESCRIPTION
## Summary

Extends `fuseNonEscapingSplitNth` to fire on the defensive-bounds-check shape:

```osty
let parts = line.split(" ")
if parts.len() < 3 { continue }   // ← previously blocked fusion
let ts    = parts[0]
let level = parts[1]
```

Pre-extension, `parts.len()` was a non-canonical read that disabled fusion. Now the analysis recognises it as known-handlable: the rewrite emits `Count(value, sep) + 1` in its place. For any non-empty separator, `len(Split(value, sep)) == Count(value, sep) + 1` exactly (Split always pushes the trailing piece), so the rewrite is semantics-preserving.

After fusion:

```
if Count(line, " ") + 1 < 3 { continue }
let ts    = NthSegment(line, " ", 0)
let level = NthSegment(line, " ", 1)
```

Originating Split call disappears. List allocation, 4 piece dups, push_ptr chain — all gone.

## Mechanism

1. **`IntrinsicStringCount`** added to MIR enum + dispatch tables (`mir.go`, `mir_generator.go`). Lowers to `osty_rt_strings_Count(value, needle)` runtime call (the runtime function predates this PR, used for `strings.count(s, substr)` via the legacy stdlib shim).

2. **`findIndexProjUsesFn`** now also collects `parts.len()` reads — `IntrinsicListLen` calls with a bare-local read of the split destination. Returns alongside canonical IndexProj matches.

3. **Empty-sep gate**: the rewrite requires a non-empty `StringConst` separator. Empty seps trigger different semantics in Split (byte-level expansion → N pieces) vs Count (→ N+1), so `Count + 1` would be off by one.

4. **2-instruction sequence per parts.len() read**: replaces `IntrinsicListLen` with `tmp = StringCount(value, sep)` and inserts `dest = tmp + 1` right after. Processed bottom-up within each block so insertions don't shift later indices.

## Empirical

```
log-aggregator (N=50K, defensive check kept):
  fused 1.07–1.43× faster, ±0.31–0.74 CI (system noisy)
```

Wide CI hides exact effect size, but IR-level proof is deterministic: log-aggregator's IR Split count drops 1 → 0, NthSegment 2 → 4, StringCount 0 → 2. Per-iteration: ~6 fewer allocations (1 list + 4 pieces, minus 2 fused pieces) plus the saved push_ptr chain.

## Test plan

- [x] 8 unit tests pass — three new for parts.len() shape:
  - `PartsLen_FusesViaCountPlusOne` — single-index + parts.len()
  - `PartsLen_MultiIndex` — `parts[0]; parts[1]; parts.len()`
  - `BailsOnPartsLenWithEmptySep` — empty sep disables rewrite
- [x] `go test ./internal/mir` clean
- [x] `go test ./internal/llvmgen -run "TestBundled|TestRuntime|TestList|TestMap|TestGC"` clean
- [x] `benchmarks/programs/build-all.sh` — all 7 programs byte-equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)