### PR TITLE
refactor(llvmgen): port 200+ §7-§9 emit-pass / fixed-symbol / label / metadata builders

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -675,6 +675,55 @@ The historical rules:
 | `mirDiscriminant{None,Some,Ok,Err}` / `mirBoolTrueLiteral` / `mirBoolFalseLiteral` / `mirBoolFromOsty` | `(args...) -> String` | §6 | Discriminant / boolean-literal tokens |
 | `mirGEPI64FieldZeroLine` / `mirGEPDoubleIndexLine` / `mirGEPNamedFieldLine` | `(args...) -> String` | §6 | Common GEP shape composers (zero-index / double-index / named-field) |
 | `mirRtSymbol` / `mirRtListSymbol` / `mirRtMapSymbol` / `mirRtSetSymbol` / `mirRtStringSymbol` / `mirRtBytesSymbol` / `mirRtChanSymbol` / `mirRtTaskGroupSymbol` / `mirRtGCSymbol` / `mirRtTestSymbol` / `mirRtMathSymbol` / `mirRtRandomSymbol` / `mirRtCancelSymbol` | `(suffix) -> String` | §6 | Runtime-symbol prefix composers (centralise `osty_rt_*` namespace) |
+| `mirBlockSeparatorComment` / `mirBlockTraceLine` / `mirInstrTraceLine` | `(args...) -> String` | §7 | Per-block / per-instruction trace comment helpers |
+| `mirPredI64Eq` / `Ne` / `mirPredPtrEq` / `Ne` / `mirPredI1Eq` | `(a, b) -> String` | §7 | Predicate-value composers (no leading SSA assignment) |
+| `mirStore{I64,Double,Ptr}WithAliasScopeLine` / `mirLoad{I64,Double,Ptr}WithAliasScopeLine` | `(args...) -> String` | §7 | Alias-scope-tagged store / load shapes |
+| `mirStore{I64,Ptr}WithNoAliasLine` / `mirLoad{I64,Ptr}WithNoAliasLine` | `(args...) -> String` | §7 | Noalias-tagged store / load shapes |
+| `mirLLVMAccessGroupRef` / `mirStore{I64,Double}WithAccessGroupLine` / `mirLoad{I64,Double}WithAccessGroupLine` | `(args...) -> String` | §7 | Access-group metadata-tagged shapes |
+| `mirRtList{OOBAbort,PopDiscard,IsEmpty,LenSymbolName,Reverse,Reversed,Clear,RemoveAtDiscard}Symbol` | `() -> String` | §7 | Fixed List-runtime symbol composers |
+| `mirRtMap{New,Clear,LenSymbolName,Values,Entries,MergeWith}Symbol` | `() -> String` | §7 | Fixed Map-runtime symbol composers |
+| `mirRtSet{Clear,LenSymbolName,ToList}Symbol` | `() -> String` | §7 | Fixed Set-runtime symbol composers |
+| `mirRtBytes{LenSymbolName,IsEmpty,Get}Symbol` | `() -> String` | §7 | Fixed Bytes-runtime symbol composers |
+| `mirRtString{Concat,ConcatN,DiffLines}Symbol` | `() -> String` | §7 | Fixed String-runtime symbol composers |
+| `mirRtCancel{CheckCancelled,IsCancelled,Cancel}Symbol` | `() -> String` | §7 | Fixed cancel-runtime symbol composers |
+| `mirRtChan{Close,Recv,SendSymbolName}Symbol` | `() -> String` | §7 | Fixed channel-runtime symbol composers |
+| `mirRtThread{Yield,Sleep,Spawn}Symbol` | `() -> String` | §7 | Fixed thread-runtime symbol composers |
+| `mirRtBench{NowNanos,TargetNs}Symbol` | `() -> String` | §7 | Fixed bench-runtime symbol composers |
+| `mirRtTest{Snapshot,Abort,ContextEnter,ContextExit,ExpectOk,ExpectError}Symbol` | `() -> String` | §7 | Fixed test-runtime symbol composers |
+| `mirRt{Panic,Unreachable,Todo,Abort}Symbol` / `mirRt{OptionUnwrapNone,ResultUnwrapErr,ExpectFailed}Symbol` / `mirRt{Int,Float,Bool,Char,Byte}ToStringSymbol` / `mirRt{Parallel,Race,TaskGroupRoot}Symbol` | `() -> String` | §7 | Fixed bare runtime symbol composers |
+| `mirListTypeText` / `mirMapTypeText` / `mirSetTypeText` / `mirOptionTypeText{Scalar,Ptr}` / `mirResultTypeText{Scalar,Ptr}` | `() -> String` | §7 | LLVM-text type-text composers (semantic aliases) |
+| `mirOption{Disc,Payload}ProbeLine` / `mirOptionPtr{Disc,Payload}ProbeLine` / `mirResult{Disc,Payload}ProbeLine` | `(reg, agg) -> String` | §7 | Option / Result discriminant-extract / payload-extract shapes |
+| `mirOption{None,SomeDisc,SomePayload}AggregateLine` / `mirResult{Ok,Err}DiscAggregateLine` | `(args...) -> String` | §7 | Option / Result aggregate-construction shapes |
+| `mirPanicTrapLine` / `mirAbortTrapLine` | `(sym, [msg]) -> String` | §7 | Canonical 2-line panic / abort trap composers |
+| `mirConditionalBranch3Line` | `(cmp, ty, a, b, then, else) -> String` | §7 | 3-line guard pattern composer |
+| `mirLoop{Header,Body,Exit,Latch}BlockLine` | `(name) -> String` | §7 | Loop-prelude block-label aliases |
+| `mirRangeLoopInitLine` / `mirRangeLoopBoundLine` | `(reg, val) -> String` | §7 | Range-loop init / bound preamble shapes |
+| `mirVectorListSnapshot2Line` | `(args...) -> String` | §7 | 2-line vector-list snapshot composite |
+| `mirMonomorphKey` / `mirGenericInstanceKey` / `mirClosureSignatureKey` | `(args...) -> String` | §8 | Monomorphisation / generic-instance / closure-sig key composers |
+| `mirFnSignatureType` / `mirFnPointerTypeWithEnv` | `(retTy, params) -> String` | §8 | LLVM fn-signature / fn-pointer-type composers |
+| `mirParamSlot{Ptr,I64,I32,I1,I8,Double}` / `mirParamListEnvPtr{,AndOne,AndTwo,AndThree}` | `(args...) -> String` | §8 | LLVM param-list shape helpers |
+| `mirOstyFnName` / `mirOstyMethodName` / `mirOstyClosureName` / `mirOstyVTableName` / `mirOstyStringPoolName` / `mirOstyFormatPoolName` | `(args...) -> String` | §8 | Osty-side fn / method / vtable / pool symbol-name composers |
+| `mirLocalSlotName` / `mirParamSlotName` / `mirTempRegName` | `(idDigits) -> String` | §8 | Canonical SSA-local slot / param / temp register name composers |
+| `mirAliasScopeMetadataNode` / `mirAliasScopeListMetadataNode` / `mirAliasScopeReference` / `mirNoAliasReference` | `(args...) -> String` | §8 | Alias-scope metadata-node body / reference helpers |
+| `mirJoinCommaList` / `mirJoinSpaceList` | `(parts) -> String` | §8 | Comma / space joiner for variadic parts |
+| `mirConstantArrayBody` / `OfList` / `mirConstantStructBody` / `OfList` | `(args...) -> String` | §8 | LLVM constant-array / constant-struct body composers |
+| `mirTypedConstFragment` / `I64` / `I1` / `Ptr` / `Double` | `(args...) -> String` | §8 | Typed constant-fragment composers |
+| `mirComment{Safepoint,NoSafepoint,Vectorize,NoVectorize,Parallel,Inline,NoInline,Hot,Cold}` | `() -> String` | §8 | Annotation-purpose comment helpers |
+| `mirParamBinding{Ptr,I64,I1,Double}` | `(slot, name) -> String` | §8 | 2-line typed param-binding (alloca + store) shapes |
+| `mirGCRootSlotsAllocaWithCommentLine` / `mirGCRootSafepointWithCommentLine` | `(args...) -> String` | §8 | GC-root setup with comment annotation composites |
+| `mirBuildLines{2,3,4,5}` | `(args...) -> String` | §8 | N-line concatenation helpers |
+| `mirTypeAliasLine` / `mirNamedAggregateType` | `(args...) -> String` | §8 | LLVM type-alias emit / reference composers |
+| `mirEmitVoidCallStmt` / `mirEmitValueCallStmt` | `(args...) -> String` | §8 | Call-instruction stmt composers |
+| `mirCallNoReturnVoidLine` / `mirCallNoReturnVoidNoArgsAttrLine` | `(args...) -> String` | §8 | Noreturn-tagged void-call shapes |
+| `mirNamedMDTuple` / `mirNamedMDDistinctTuple` / `mirAnonymousMDTuple` | `(args...) -> String` | §8 | Named / distinct / anonymous metadata-tuple emit shapes |
+| `mirSection{Declares,Globals,Functions,Metadata,Prelude,Epilogue}` | `() -> String` | §9 | Emit-pass section-marker comment helpers |
+| `mirGlobalRef` / `mirRegRef` / `mirMDRef` | `(name) -> String` | §9 | LLVM-text reference encoders (`@`, `%`, `!` prefixed names) |
+| `mirLabelHeaderLine` / `mirJumpToLabelLine` | `(name) -> String` | §9 | Label-emit aliases for terminator-block usage path |
+| `mirAppendArg{Ptr,I64,I1,Double,I8,I32}` | `(prev, reg) -> String` | §9 | Incremental typed-arg list extension helpers |
+| `mirCall{List,Map,Set,Bytes}LenLine` / `mirCallListIsEmptyLine` | `(reg, handle) -> String` | §9 | Container-len / isEmpty common shape composers |
+| `mirIncrementLoopCounterLine` / `mirDecrementLoopCounterLine` | `(reg, iReg) -> String` | §9 | Loop-counter increment / decrement aliases |
+| `mirLoadStoreLine` / `I64Line` / `I1Line` / `PtrLine` / `DoubleLine` | `(args...) -> String` | §9 | 2-line typed load + store (read-modify-write) shapes |
+| `mirLabel{Ok,Err,Done,LoopHead,LoopBody,LoopExit,LoopLatch,MatchArmPrefix,MatchExit,IfThen,IfElse,IfEnd,OptionSome,OptionNone,ResultOk,ResultErr}` | `() -> String` | §9 | Canonical label-name tokens (centralise for future renaming) |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2020,7 +2020,7 @@ func (g *mirGen) emitVectorListFastStore(local mir.LocalID, idxVal, valReg, elem
 	// previous slow-path `osty_rt_list_set_*` call (which was declared
 	// as a memory writer) is what unlocks the in-loop LICM win on
 	// matmul and quicksort's partition step.
-	const oobSym = "osty_rt_list_oob_abort_v1"
+	oobSym := mirRtListOOBAbortSymbol()
 	g.declareRuntime(oobSym, mirRuntimeDeclareNoReturn("void", oobSym, "", true))
 	g.fnBuf.WriteString(mirLabelLine(slowLabel))
 	g.fnBuf.WriteString(mirCallVoidNoReturnNoArgsLine(oobSym))
@@ -3122,33 +3122,33 @@ func (g *mirGen) emitAssertValueToStringMIR(reg string, t mir.Type) (*LlvmValue,
 	llvmT := g.llvmType(t)
 	switch llvmT {
 	case "i64":
-		g.declareRuntime("osty_rt_int_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_int_to_string", "i64"))
+		g.declareRuntime(mirRtIntToStringSymbol(), mirRuntimeDeclarePtrFromScalarLine(mirRtIntToStringSymbol(), "i64"))
 		em := g.ostyEmitter()
 		out := llvmIntRuntimeToString(em, &LlvmValue{typ: "i64", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "double":
-		g.declareRuntime("osty_rt_float_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_float_to_string", "double"))
+		g.declareRuntime(mirRtFloatToStringSymbol(), mirRuntimeDeclarePtrFromScalarLine(mirRtFloatToStringSymbol(), "double"))
 		em := g.ostyEmitter()
 		out := llvmFloatRuntimeToString(em, &LlvmValue{typ: "double", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i1":
-		g.declareRuntime("osty_rt_bool_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_bool_to_string", "i1"))
+		g.declareRuntime(mirRtBoolToStringSymbol(), mirRuntimeDeclarePtrFromScalarLine(mirRtBoolToStringSymbol(), "i1"))
 		em := g.ostyEmitter()
 		out := llvmBoolRuntimeToString(em, &LlvmValue{typ: "i1", name: reg})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i32":
-		g.declareRuntime("osty_rt_char_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_char_to_string", "i32"))
+		g.declareRuntime(mirRtCharToStringSymbol(), mirRuntimeDeclarePtrFromScalarLine(mirRtCharToStringSymbol(), "i32"))
 		em := g.ostyEmitter()
-		out := llvmCall(em, "ptr", "osty_rt_char_to_string", []*LlvmValue{{typ: "i32", name: reg}})
+		out := llvmCall(em, "ptr", mirRtCharToStringSymbol(), []*LlvmValue{{typ: "i32", name: reg}})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "i8":
-		g.declareRuntime("osty_rt_byte_to_string", mirRuntimeDeclarePtrFromScalarLine("osty_rt_byte_to_string", "i8"))
+		g.declareRuntime(mirRtByteToStringSymbol(), mirRuntimeDeclarePtrFromScalarLine(mirRtByteToStringSymbol(), "i8"))
 		em := g.ostyEmitter()
-		out := llvmCall(em, "ptr", "osty_rt_byte_to_string", []*LlvmValue{{typ: "i8", name: reg}})
+		out := llvmCall(em, "ptr", mirRtByteToStringSymbol(), []*LlvmValue{{typ: "i8", name: reg}})
 		g.flushOstyEmitter(em)
 		return out, true, nil
 	case "ptr":
@@ -3201,9 +3201,9 @@ func testingListPrimitiveKind(t mir.Type) int {
 }
 
 func (g *mirGen) emitRuntimeListPrimitiveToStringMIR(reg string, kind int) (*LlvmValue, error) {
-	g.declareRuntime("osty_rt_list_primitive_to_string", mirRuntimeDeclarePtrFromPtrI64Line("osty_rt_list_primitive_to_string"))
+	g.declareRuntime(mirRtListPrimitiveToStringSymbol(), mirRuntimeDeclarePtrFromPtrI64Line(mirRtListPrimitiveToStringSymbol()))
 	em := g.ostyEmitter()
-	out := llvmCall(em, "ptr", "osty_rt_list_primitive_to_string", []*LlvmValue{
+	out := llvmCall(em, "ptr", mirRtListPrimitiveToStringSymbol(), []*LlvmValue{
 		{typ: "ptr", name: reg},
 		llvmIntLiteral(kind),
 	})
@@ -3212,9 +3212,9 @@ func (g *mirGen) emitRuntimeListPrimitiveToStringMIR(reg string, kind int) (*Llv
 }
 
 func (g *mirGen) emitRuntimeStringDiffMIR(left, right *LlvmValue) (*LlvmValue, error) {
-	g.declareRuntime("osty_rt_strings_DiffLines", mirRuntimeDeclarePtrFromTwoPtrLine("osty_rt_strings_DiffLines"))
+	g.declareRuntime(mirRtStringDiffLinesSymbol(), mirRuntimeDeclarePtrFromTwoPtrLine(mirRtStringDiffLinesSymbol()))
 	em := g.ostyEmitter()
-	out := llvmCall(em, "ptr", "osty_rt_strings_DiffLines", []*LlvmValue{left, right})
+	out := llvmCall(em, "ptr", mirRtStringDiffLinesSymbol(), []*LlvmValue{left, right})
 	g.flushOstyEmitter(em)
 	return out, nil
 }
@@ -3281,9 +3281,9 @@ func (g *mirGen) emitTestingSnapshotMIR(c *mir.CallInstr) error {
 	if err != nil {
 		return err
 	}
-	g.declareRuntime("osty_rt_test_snapshot", mirRuntimeDeclareThreePtrVoidLine("osty_rt_test_snapshot"))
+	g.declareRuntime(mirRtTestSnapshotSymbol(), mirRuntimeDeclareThreePtrVoidLine(mirRtTestSnapshotSymbol()))
 	sourceSym := g.stringLiteral(g.source)
-	g.fnBuf.WriteString(mirCallVoidFromThreePtrLine("osty_rt_test_snapshot", name, output, sourceSym))
+	g.fnBuf.WriteString(mirCallVoidFromThreePtrLine(mirRtTestSnapshotSymbol(), name, output, sourceSym))
 	return g.storeUnitDestIfAny(c)
 }
 
@@ -3308,8 +3308,8 @@ func (g *mirGen) emitTestingBenchmarkMIR(c *mir.CallInstr) error {
 	}
 	// Declare the runtime helpers we'll call. These are idempotent — a
 	// later benchmark in the same module reuses the same declare lines.
-	g.declareRuntime("osty_rt_bench_now_nanos", mirRuntimeDeclareI64NoArgsLine("osty_rt_bench_now_nanos"))
-	g.declareRuntime("osty_rt_bench_target_ns", mirRuntimeDeclareI64NoArgsLine("osty_rt_bench_target_ns"))
+	g.declareRuntime(mirRtBenchNowNanosSymbol(), mirRuntimeDeclareI64NoArgsLine(mirRtBenchNowNanosSymbol()))
+	g.declareRuntime(mirRtBenchTargetNsSymbol(), mirRuntimeDeclareI64NoArgsLine(mirRtBenchTargetNsSymbol()))
 	g.declareRuntime("osty_gc_debug_allocated_bytes_total", mirRuntimeDeclareI64NoArgsLine("osty_gc_debug_allocated_bytes_total"))
 	g.declareRuntime("printf", mirRuntimeDeclarePrintf())
 
@@ -3849,7 +3849,7 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		someLabel := g.freshLabel("opt.unwrap.some")
 		g.fnBuf.WriteString(mirBrCondLine(isNone, noneLabel, someLabel))
 		g.fnBuf.WriteString(mirLabelLine(noneLabel))
-		abortSym := "osty_rt_option_unwrap_none"
+		abortSym := mirRtOptionUnwrapNoneSymbol()
 		g.declareRuntime(abortSym, mirRuntimeDeclareNoReturn("void", abortSym, "", false))
 		g.fnBuf.WriteString(mirCallVoidNoArgsLine(abortSym))
 		g.fnBuf.WriteString(mirUnreachableLine())
@@ -3992,7 +3992,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListIsEmpty:
-		sym := "osty_rt_list_is_empty"
+		sym := mirRtListIsEmptySymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + listReg})
 	case mir.IntrinsicListGet:
@@ -4110,7 +4110,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicListReverse:
 		// In-place reverse. Runtime walks elem_size-sized slots byte by
 		// byte so the call is element-type agnostic.
-		sym := "osty_rt_list_reverse"
+		sym := mirRtListReverseSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		g.fnBuf.WriteString(mirCallVoidPtrLine(sym, listReg))
 		return nil
@@ -4119,7 +4119,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// trace handling inside the runtime; GC roots remain valid
 		// across the allocation because the source list stays
 		// reachable through the caller's local.
-		sym := "osty_rt_list_reversed"
+		sym := mirRtListReversedSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
@@ -4164,7 +4164,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		spliceSym := "osty_rt_list_remove_at_discard"
+		spliceSym := mirRtListRemoveAtDiscardSymbol()
 		g.declareRuntime(spliceSym, mirRuntimeDeclareVoidFromPtrI64Line(spliceSym))
 		elemReg, err := g.emitListLoadElement(listReg, idxReg, elemLLVM)
 		if err != nil {
@@ -4318,7 +4318,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		// empty, so we gate it behind a `len > 0` check and compute the
 		// returned value via `list_get_<kind>(list, len-1)` before the
 		// discard so the element is captured.
-		discardSym := "osty_rt_list_pop_discard"
+		discardSym := mirRtListPopDiscardSymbol()
 		g.declareRuntime(discardSym, mirRuntimeDeclareVoidFromPtrLine(discardSym))
 		if i.Dest == nil {
 			// Statement-position `xs.pop()` with no dest: fall back
@@ -4437,7 +4437,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if valueSize <= 0 {
 			return unsupported("mir-mvp", fmt.Sprintf("map_new unsupported value type %s", valLLVM))
 		}
-		sym := "osty_rt_map_new"
+		sym := mirRtMapNewSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareLine("ptr", sym, "i64, i64, i64, ptr"))
 		args := []string{
 			mirIntLiteralI64(strconv.Itoa(keyKind)),
@@ -4860,14 +4860,14 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 	}
 	switch i.Kind {
 	case mir.IntrinsicBytesLen:
-		sym := "osty_rt_bytes_len"
+		sym := mirRtBytesLenSymbolName()
 		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicBytesIsEmpty:
-		sym := "osty_rt_bytes_is_empty"
+		sym := mirRtBytesIsEmptySymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
@@ -4892,8 +4892,8 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		lenSym := "osty_rt_bytes_len"
-		getSym := "osty_rt_bytes_get"
+		lenSym := mirRtBytesLenSymbolName()
+		getSym := mirRtBytesGetSymbol()
 		g.declareRuntime(lenSym, mirRuntimeDeclareI64FromPtrLine(lenSym))
 		g.declareRuntime(getSym, mirRuntimeDeclareLine("i8", getSym, "ptr, i64"))
 		em := g.ostyEmitter()
@@ -4979,7 +4979,7 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		lastSym := "osty_rt_bytes_last_index_of"
-		lenSym := "osty_rt_bytes_len"
+		lenSym := mirRtBytesLenSymbolName()
 		g.declareRuntime(lastSym, mirRuntimeDeclareI64FromTwoPtrLine(lastSym))
 		g.declareRuntime(lenSym, mirRuntimeDeclareI64FromPtrLine(lenSym))
 		em := g.ostyEmitter()
@@ -5603,7 +5603,7 @@ func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
 }
 
 func (g *mirGen) emitStringConcatN(parts []*LlvmValue) *LlvmValue {
-	sym := "osty_rt_strings_ConcatN"
+	sym := mirRtStringConcatNSymbol()
 	g.declareRuntime(sym, mirRuntimeDeclarePtrFromI64PtrLine(sym))
 	em := g.ostyEmitter()
 	arr := llvmNextTemp(em)
@@ -5652,7 +5652,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 		if err != nil {
 			return nil, err
 		}
-		sym := "osty_rt_char_to_string"
+		sym := mirRtCharToStringSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "i32"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i32", name: reg}})
@@ -5663,7 +5663,7 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 		if err != nil {
 			return nil, err
 		}
-		sym := "osty_rt_byte_to_string"
+		sym := mirRtByteToStringSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclarePtrFromScalarLine(sym, "i8"))
 		em := g.ostyEmitter()
 		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i8", name: reg}})
@@ -6188,13 +6188,13 @@ func (g *mirGen) emitSelectSend(i *mir.IntrinsicInstr) error {
 func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicIsCancelled:
-		sym := "osty_rt_cancel_is_cancelled"
+		sym := mirRtCancelIsCancelledSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareI1NoArgsLine(sym))
 		return g.emitSimpleCall(i, sym, "i1", nil)
 	case mir.IntrinsicCheckCancelled:
 		// Returns Result<(), Error> — runtime uses the `{i64, i64}`
 		// enum layout like chan_recv.
-		sym := "osty_rt_cancel_check_cancelled"
+		sym := mirRtCancelCheckCancelledSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareEnumLayoutNoArgsLine(sym))
 		if i.Dest == nil {
 			g.fnBuf.WriteString(mirCallStmtNoArgsLine("{ i64, i64 }", sym))
@@ -6205,7 +6205,7 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirStoreLine("{ i64, i64 }", tmp, g.localSlots[i.Dest.Local]))
 		return nil
 	case mir.IntrinsicYield:
-		sym := "osty_rt_thread_yield"
+		sym := mirRtThreadYieldSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, ""))
 		g.fnBuf.WriteString(mirCallVoidNoArgsLine(sym))
 		return nil
@@ -6217,7 +6217,7 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_thread_sleep"
+		sym := mirRtThreadSleepSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		g.fnBuf.WriteString(mirCallVoidPtrLine(sym, dur))
 		return nil
@@ -6722,7 +6722,7 @@ func (g *mirGen) emitLenRV(rv *mir.LenRV) (string, error) {
 		g.flushOstyEmitter(em)
 		return result.name, nil
 	case isBytesType(placeT):
-		sym := "osty_rt_bytes_len"
+		sym := mirRtBytesLenSymbolName()
 		g.declareRuntime(sym, mirRuntimeDeclareI64FromPtrLine(sym))
 		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: valueReg}})
 		g.flushOstyEmitter(em)
@@ -7676,7 +7676,7 @@ func (g *mirGen) emitUnary(op mir.UnaryOp, arg string, t mir.Type) (string, erro
 
 func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.Type) (string, error) {
 	if op == mir.BinAdd && isStringPrimType(argT) {
-		g.declareRuntime("osty_rt_strings_Concat", mirRuntimeDeclareStringConcat())
+		g.declareRuntime(mirRtStringConcatSymbol(), mirRuntimeDeclareStringConcat())
 		em := g.ostyEmitter()
 		out := llvmStringConcat(em, &LlvmValue{typ: "ptr", name: left}, &LlvmValue{typ: "ptr", name: right})
 		g.flushOstyEmitter(em)

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -5496,3 +5496,674 @@ func mirRtBenchSymbol(suffix string) string     { return "osty_rt_bench_" + suff
 func mirRtIOSymbol(suffix string) string        { return "osty_rt_io_" + suffix }
 func mirRtJsonSymbol(suffix string) string      { return "osty_rt_json_" + suffix }
 func mirRtFmtSymbol(suffix string) string       { return "osty_rt_fmt_" + suffix }
+
+// §7 emit-pass per-block helpers.
+
+// Osty: mirBlockSeparatorComment / mirBlockTraceLine / mirInstrTraceLine
+func mirBlockSeparatorComment() string { return "; ---- next block ----\n" }
+func mirBlockTraceLine(blockId, kind string) string {
+	return "; block " + blockId + " (" + kind + ")\n"
+}
+func mirInstrTraceLine(kind, line, col string) string {
+	return "; " + kind + " at " + line + ":" + col + "\n"
+}
+
+// §7 LLVM-text predicate composers.
+
+// Osty: mirPredI64Eq / Ne / mirPredPtrEq / Ne / mirPredI1Eq
+func mirPredI64Eq(a, b string) string {
+	return mirInstrICmp() + " " + mirICmpEq() + " " + mirTypeI64() + " " + a + ", " + b
+}
+func mirPredI64Ne(a, b string) string {
+	return mirInstrICmp() + " " + mirICmpNe() + " " + mirTypeI64() + " " + a + ", " + b
+}
+func mirPredPtrEq(a, b string) string {
+	return mirInstrICmp() + " " + mirICmpEq() + " " + mirTypePtr() + " " + a + ", " + b
+}
+func mirPredPtrNe(a, b string) string {
+	return mirInstrICmp() + " " + mirICmpNe() + " " + mirTypePtr() + " " + a + ", " + b
+}
+func mirPredI1Eq(a, b string) string {
+	return mirInstrICmp() + " " + mirICmpEq() + " " + mirTypeI1() + " " + a + ", " + b
+}
+
+// §7 typed-store / typed-load shapes with !alias.scope metadata.
+
+// Osty: mirStoreI64WithAliasScopeLine / DoubleWithAliasScopeLine / PtrWithAliasScopeLine /
+//       LoadI64WithAliasScopeLine / DoubleWithAliasScopeLine / PtrWithAliasScopeLine
+func mirStoreI64WithAliasScopeLine(val, slot, scopeRef string) string {
+	return "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+func mirStoreDoubleWithAliasScopeLine(val, slot, scopeRef string) string {
+	return "  " + mirInstrStore() + " double " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+func mirStorePtrWithAliasScopeLine(val, slot, scopeRef string) string {
+	return "  " + mirInstrStore() + " ptr " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+func mirLoadI64WithAliasScopeLine(reg, slot, scopeRef string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+func mirLoadDoubleWithAliasScopeLine(reg, slot, scopeRef string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " double, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+func mirLoadPtrWithAliasScopeLine(reg, slot, scopeRef string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " ptr, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+// §7 typed-store / typed-load shapes with !noalias metadata.
+
+// Osty: mirStoreI64WithNoAliasLine / PtrWithNoAliasLine / LoadI64WithNoAliasLine / PtrWithNoAliasLine
+func mirStoreI64WithNoAliasLine(val, slot, ref string) string {
+	return "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !noalias " + ref + "\n"
+}
+func mirStorePtrWithNoAliasLine(val, slot, ref string) string {
+	return "  " + mirInstrStore() + " ptr " + val + ", ptr " + slot + ", !noalias " + ref + "\n"
+}
+func mirLoadI64WithNoAliasLine(reg, slot, ref string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !noalias " + ref + "\n"
+}
+func mirLoadPtrWithNoAliasLine(reg, slot, ref string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " ptr, ptr " + slot + ", !noalias " + ref + "\n"
+}
+
+// §7 LLVM access-group metadata helpers.
+
+// Osty: mirLLVMAccessGroupRef / mirStoreI64WithAccessGroupLine /
+//       DoubleWithAccessGroupLine / LoadI64WithAccessGroupLine /
+//       DoubleWithAccessGroupLine
+func mirLLVMAccessGroupRef(ref string) string {
+	return "!access_group " + ref
+}
+func mirStoreI64WithAccessGroupLine(val, slot, ref string) string {
+	return "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !access_group " + ref + "\n"
+}
+func mirStoreDoubleWithAccessGroupLine(val, slot, ref string) string {
+	return "  " + mirInstrStore() + " double " + val + ", ptr " + slot + ", !access_group " + ref + "\n"
+}
+func mirLoadI64WithAccessGroupLine(reg, slot, ref string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !access_group " + ref + "\n"
+}
+func mirLoadDoubleWithAccessGroupLine(reg, slot, ref string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " double, ptr " + slot + ", !access_group " + ref + "\n"
+}
+
+// §7 fixed-symbol composers.
+
+// Osty: mirRtList* fixed-symbols
+func mirRtListOOBAbortSymbol() string        { return mirRtListSymbol("oob_abort_v1") }
+func mirRtListPopDiscardSymbol() string      { return mirRtListSymbol("pop_discard") }
+func mirRtListIsEmptySymbol() string         { return mirRtListSymbol("is_empty") }
+func mirRtListLenSymbolName() string         { return mirRtListSymbol("len") }
+func mirRtListReverseSymbol() string         { return mirRtListSymbol("reverse") }
+func mirRtListReversedSymbol() string        { return mirRtListSymbol("reversed") }
+func mirRtListClearSymbol() string           { return mirRtListSymbol("clear") }
+func mirRtListRemoveAtDiscardSymbol() string { return mirRtListSymbol("remove_at_discard") }
+
+// Osty: mirRtMap* fixed-symbols
+func mirRtMapNewSymbol() string       { return mirRtMapSymbol("new") }
+func mirRtMapClearSymbol() string     { return mirRtMapSymbol("clear") }
+func mirRtMapLenSymbolName() string   { return mirRtMapSymbol("len") }
+func mirRtMapValuesSymbol() string    { return mirRtMapSymbol("values") }
+func mirRtMapEntriesSymbol() string   { return mirRtMapSymbol("entries") }
+func mirRtMapMergeWithSymbol() string { return mirRtMapSymbol("merge_with") }
+
+// Osty: mirRtSet* fixed-symbols
+func mirRtSetClearSymbol() string   { return mirRtSetSymbol("clear") }
+func mirRtSetLenSymbolName() string { return mirRtSetSymbol("len") }
+func mirRtSetToListSymbol() string  { return mirRtSetSymbol("to_list") }
+
+// Osty: mirRtBytes* fixed-symbols
+func mirRtBytesLenSymbolName() string { return mirRtBytesSymbol("len") }
+func mirRtBytesIsEmptySymbol() string { return mirRtBytesSymbol("is_empty") }
+func mirRtBytesGetSymbol() string     { return mirRtBytesSymbol("get") }
+
+// Osty: mirRtString* fixed-symbols
+func mirRtStringConcatSymbol() string    { return mirRtStringSymbol("Concat") }
+func mirRtStringConcatNSymbol() string   { return mirRtStringSymbol("ConcatN") }
+func mirRtStringDiffLinesSymbol() string { return mirRtStringSymbol("DiffLines") }
+
+// Osty: mirRtCancel* fixed-symbols
+func mirRtCancelCheckCancelledSymbol() string { return mirRtCancelSymbol("check_cancelled") }
+func mirRtCancelIsCancelledSymbol() string    { return mirRtCancelSymbol("is_cancelled") }
+func mirRtCancelCancelSymbol() string         { return mirRtCancelSymbol("cancel") }
+
+// Osty: mirRtChan* fixed-symbols
+func mirRtChanCloseSymbol() string    { return mirRtChanSymbol("close") }
+func mirRtChanRecvSymbol() string     { return mirRtChanSymbol("recv") }
+func mirRtChanSendSymbolName() string { return mirRtChanSymbol("send") }
+
+// Osty: mirRtThread* fixed-symbols
+func mirRtThreadYieldSymbol() string { return mirRtThreadSymbol("yield") }
+func mirRtThreadSleepSymbol() string { return mirRtThreadSymbol("sleep") }
+func mirRtThreadSpawnSymbol() string { return mirRtThreadSymbol("spawn") }
+
+// Osty: mirRtBench* fixed-symbols
+func mirRtBenchNowNanosSymbol() string { return mirRtBenchSymbol("now_nanos") }
+func mirRtBenchTargetNsSymbol() string { return mirRtBenchSymbol("target_ns") }
+
+// Osty: mirRtTest* fixed-symbols
+func mirRtTestSnapshotSymbol() string     { return mirRtTestSymbol("snapshot") }
+func mirRtTestAbortSymbol() string        { return mirRtTestSymbol("abort") }
+func mirRtTestContextEnterSymbol() string { return mirRtTestSymbol("context_enter") }
+func mirRtTestContextExitSymbol() string  { return mirRtTestSymbol("context_exit") }
+func mirRtTestExpectOkSymbol() string     { return mirRtTestSymbol("expect_ok") }
+func mirRtTestExpectErrorSymbol() string  { return mirRtTestSymbol("expect_error") }
+
+// Osty: bare runtime symbols
+func mirRtPanicSymbol() string       { return mirRtSymbol("panic") }
+func mirRtUnreachableSymbol() string { return mirRtSymbol("unreachable") }
+func mirRtTodoSymbol() string        { return mirRtSymbol("todo") }
+func mirRtAbortSymbol() string       { return mirRtSymbol("abort") }
+
+// Osty: option / result panic-helper symbols
+func mirRtOptionUnwrapNoneSymbol() string { return mirRtSymbol("option_unwrap_none") }
+func mirRtResultUnwrapErrSymbol() string  { return mirRtSymbol("result_unwrap_err") }
+func mirRtExpectFailedSymbol() string     { return mirRtSymbol("expect_failed") }
+
+// Osty: to-string runtime symbols
+func mirRtIntToStringSymbol() string           { return mirRtSymbol("int_to_string") }
+func mirRtFloatToStringSymbol() string         { return mirRtSymbol("float_to_string") }
+func mirRtBoolToStringSymbol() string          { return mirRtSymbol("bool_to_string") }
+func mirRtCharToStringSymbol() string          { return mirRtSymbol("char_to_string") }
+func mirRtByteToStringSymbol() string          { return mirRtSymbol("byte_to_string") }
+func mirRtListPrimitiveToStringSymbol() string { return mirRtListSymbol("primitive_to_string") }
+
+// Osty: structured-concurrency runtime symbols
+func mirRtParallelSymbol() string      { return mirRtSymbol("parallel") }
+func mirRtRaceSymbol() string          { return mirRtSymbol("race") }
+func mirRtTaskGroupRootSymbol() string { return mirRtSymbol("task_group") }
+
+// §7 LLVM-text type-text composers.
+
+// Osty: mirListTypeText / MapTypeText / SetTypeText / mirOptionTypeTextScalar /
+//       OptionTypeTextPtr / mirResultTypeTextScalar / ResultTypeTextPtr
+func mirListTypeText() string         { return mirTypePtr() }
+func mirMapTypeText() string          { return mirTypePtr() }
+func mirSetTypeText() string          { return mirTypePtr() }
+func mirOptionTypeTextScalar() string { return mirOptionAggregateType() }
+func mirOptionTypeTextPtr() string    { return mirOptionPtrAggregateType() }
+func mirResultTypeTextScalar() string { return mirOptionAggregateType() }
+func mirResultTypeTextPtr() string    { return mirOptionPtrAggregateType() }
+
+// §7 LLVM-text discriminant probe / payload-extract shapes.
+
+// Osty: mirOptionDiscProbeLine / PayloadProbeLine / mirOptionPtrDiscProbeLine /
+//       PtrPayloadProbeLine / mirResultDiscProbeLine / PayloadProbeLine
+func mirOptionDiscProbeLine(reg, aggReg string) string {
+	return mirExtractValueLine(reg, mirOptionAggregateType(), aggReg, "0")
+}
+func mirOptionPayloadProbeLine(reg, aggReg string) string {
+	return mirExtractValueLine(reg, mirOptionAggregateType(), aggReg, "1")
+}
+func mirOptionPtrDiscProbeLine(reg, aggReg string) string {
+	return mirExtractValueLine(reg, mirOptionPtrAggregateType(), aggReg, "0")
+}
+func mirOptionPtrPayloadProbeLine(reg, aggReg string) string {
+	return mirExtractValueLine(reg, mirOptionPtrAggregateType(), aggReg, "1")
+}
+func mirResultDiscProbeLine(reg, aggReg string) string {
+	return mirOptionDiscProbeLine(reg, aggReg)
+}
+func mirResultPayloadProbeLine(reg, aggReg string) string {
+	return mirOptionPayloadProbeLine(reg, aggReg)
+}
+
+// §7 LLVM-text Option / Result aggregate-construction shapes.
+
+// Osty: mirOptionNoneAggregateLine / SomeDiscAggregateLine / SomePayloadAggregateLine /
+//       mirResultOkDiscAggregateLine / ErrDiscAggregateLine
+func mirOptionNoneAggregateLine(reg string) string {
+	return mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantNone(), "0")
+}
+func mirOptionSomeDiscAggregateLine(reg string) string {
+	return mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantSome(), "0")
+}
+func mirOptionSomePayloadAggregateLine(reg, prev, payload string) string {
+	return mirInsertValueAggLine(reg, mirOptionAggregateType(), prev, mirTypeI64(), payload, "1")
+}
+func mirResultOkDiscAggregateLine(reg string) string {
+	return mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantOk(), "0")
+}
+func mirResultErrDiscAggregateLine(reg string) string {
+	return mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantErr(), "0")
+}
+
+// §7 LLVM-text panic-trap shape composers.
+
+// Osty: mirPanicTrapLine / mirAbortTrapLine
+func mirPanicTrapLine(sym, messagePtr string) string {
+	return mirCallVoidPtrLine(sym, messagePtr) + mirUnreachableLine()
+}
+func mirAbortTrapLine(sym string) string {
+	return mirCallVoidNoArgsLine(sym) + mirUnreachableLine()
+}
+
+// §7 LLVM-text Cond-branch shape composers.
+
+// Osty: mirConditionalBranch3Line
+func mirConditionalBranch3Line(cmpReg, ty, a, b, thenLbl, elseLbl string) string {
+	return mirICmpLine(cmpReg, mirICmpEq(), ty, a, b) +
+		mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+// §7 LLVM-text loop-prelude shape helpers.
+
+// Osty: mirLoopHeaderBlockLine / mirLoopBodyBlockLine / mirLoopExitBlockLine /
+//       mirLoopLatchBlockLine
+func mirLoopHeaderBlockLine(head string) string { return mirBlockHeaderLine(head) }
+func mirLoopBodyBlockLine(body string) string   { return mirBlockHeaderLine(body) }
+func mirLoopExitBlockLine(exit string) string   { return mirBlockHeaderLine(exit) }
+func mirLoopLatchBlockLine(latch string) string { return mirBlockHeaderLine(latch) }
+
+// §7 LLVM-text typed-Range-loop preamble helpers.
+
+// Osty: mirRangeLoopInitLine / mirRangeLoopBoundLine
+func mirRangeLoopInitLine(initReg, start string) string {
+	return mirAddIntLine(initReg, mirTypeI64(), start, "0")
+}
+func mirRangeLoopBoundLine(boundReg, end string) string {
+	return mirAddIntLine(boundReg, mirTypeI64(), end, "0")
+}
+
+// §7 vector-list snapshot composite helper.
+
+// Osty: mirVectorListSnapshot2Line
+func mirVectorListSnapshot2Line(dataReg, dataSym, lenReg, listReg, scopeRef string) string {
+	return mirCallValueListDataNoAliasLine(dataReg, dataSym, listReg, scopeRef) +
+		mirCallValueListLenWithScopeLine(lenReg, listReg, scopeRef)
+}
+
+// §8 monomorphisation key / sig composers.
+
+// Osty: mirMonomorphKey / mirGenericInstanceKey / mirClosureSignatureKey
+func mirMonomorphKey(base string, typeArgs []string) string {
+	if len(typeArgs) == 0 {
+		return base
+	}
+	parts := base + "::"
+	first := true
+	for _, a := range typeArgs {
+		if !first {
+			parts = parts + ","
+		}
+		parts = parts + a
+		first = false
+	}
+	return parts
+}
+func mirGenericInstanceKey(base string, typeArgs []string) string {
+	if len(typeArgs) == 0 {
+		return base
+	}
+	parts := base + "["
+	first := true
+	for _, a := range typeArgs {
+		if !first {
+			parts = parts + ","
+		}
+		parts = parts + a
+		first = false
+	}
+	return parts + "]"
+}
+func mirClosureSignatureKey(retTy string, paramTypes []string) string {
+	parts := "closure[" + retTy + "]("
+	first := true
+	for _, p := range paramTypes {
+		if !first {
+			parts = parts + ", "
+		}
+		parts = parts + p
+		first = false
+	}
+	return parts + ")"
+}
+
+// §8 LLVM-text fn-signature composers.
+
+// Osty: mirFnSignatureType / mirFnPointerTypeWithEnv
+func mirFnSignatureType(retTy string, paramTypes []string) string {
+	parts := retTy + " ("
+	first := true
+	for _, p := range paramTypes {
+		if !first {
+			parts = parts + ", "
+		}
+		parts = parts + p
+		first = false
+	}
+	return parts + ")"
+}
+func mirFnPointerTypeWithEnv(retTy string, restParamTypes []string) string {
+	parts := retTy + " (ptr"
+	for _, p := range restParamTypes {
+		parts = parts + ", " + p
+	}
+	return parts + ")"
+}
+
+// §8 LLVM-text param-list shape helpers.
+
+// Osty: mirParamSlot{Ptr,I64,I32,I1,I8,Double}
+func mirParamSlotPtr(name string) string    { return "ptr %" + name }
+func mirParamSlotI64(name string) string    { return "i64 %" + name }
+func mirParamSlotI32(name string) string    { return "i32 %" + name }
+func mirParamSlotI1(name string) string     { return "i1 %" + name }
+func mirParamSlotI8(name string) string     { return "i8 %" + name }
+func mirParamSlotDouble(name string) string { return "double %" + name }
+
+// §8 LLVM-text typed-parameter list composers.
+
+// Osty: mirParamListEnvPtr / EnvPtrAndOne / Two / Three
+func mirParamListEnvPtr() string { return "ptr %env" }
+func mirParamListEnvPtrAndOne(p1 string) string {
+	return mirParamListEnvPtr() + ", " + p1
+}
+func mirParamListEnvPtrAndTwo(p1, p2 string) string {
+	return mirParamListEnvPtr() + ", " + p1 + ", " + p2
+}
+func mirParamListEnvPtrAndThree(p1, p2, p3 string) string {
+	return mirParamListEnvPtr() + ", " + p1 + ", " + p2 + ", " + p3
+}
+
+// §8 LLVM-text fn-name composers.
+
+// Osty: mirOstyFnName / MethodName / ClosureName / VTableName / StringPoolName / FormatPoolName
+func mirOstyFnName(packageName, fnName string) string {
+	return "osty_" + packageName + "_" + fnName
+}
+func mirOstyMethodName(packageName, typeName, methodName string) string {
+	return "osty_" + packageName + "_" + typeName + "_" + methodName
+}
+func mirOstyClosureName(idDigits string) string {
+	return "osty_closure_" + idDigits
+}
+func mirOstyVTableName(typeName, interfaceName string) string {
+	return "osty_vt_" + typeName + "__" + interfaceName
+}
+func mirOstyStringPoolName(idDigits string) string { return "@.str" + idDigits }
+func mirOstyFormatPoolName(idDigits string) string { return "@.fmt" + idDigits }
+
+// §8 LLVM-text local-name composers.
+
+// Osty: mirLocalSlotName / ParamSlotName / TempRegName / BlockLabelName
+// (mirBlockLabelName continues to live at its original site earlier in this file.)
+func mirLocalSlotName(idDigits string) string { return "%l" + idDigits }
+func mirParamSlotName(idDigits string) string { return "%p" + idDigits }
+func mirTempRegName(idDigits string) string   { return "%t" + idDigits }
+
+// §8 LLVM-text alias-scope metadata helpers.
+
+// Osty: mirAliasScopeMetadataNode / ListMetadataNode / Reference / mirNoAliasReference
+func mirAliasScopeMetadataNode(scopeRef string) string {
+	return "!{!" + scopeRef + "}"
+}
+func mirAliasScopeListMetadataNode(refs string) string {
+	return "!{" + refs + "}"
+}
+func mirAliasScopeReference(ref string) string {
+	return "!alias.scope " + ref
+}
+func mirNoAliasReference(ref string) string {
+	return "!noalias " + ref
+}
+
+// §8 LLVM-text comma-joined / space-joined list helpers.
+
+// Osty: mirJoinCommaList / mirJoinSpaceList
+func mirJoinCommaList(parts []string) string {
+	joined := ""
+	first := true
+	for _, p := range parts {
+		if !first {
+			joined = joined + ", "
+		}
+		joined = joined + p
+		first = false
+	}
+	return joined
+}
+func mirJoinSpaceList(parts []string) string {
+	joined := ""
+	first := true
+	for _, p := range parts {
+		if !first {
+			joined = joined + " "
+		}
+		joined = joined + p
+		first = false
+	}
+	return joined
+}
+
+// §8 LLVM-text constant-array body composers.
+
+// Osty: mirConstantArrayBody / OfList / mirConstantStructBody / OfList
+func mirConstantArrayBody(entries string) string {
+	return "[" + entries + "]"
+}
+func mirConstantArrayBodyOfList(entries []string) string {
+	return "[" + mirJoinCommaList(entries) + "]"
+}
+func mirConstantStructBody(fields string) string {
+	return "{" + fields + "}"
+}
+func mirConstantStructBodyOfList(fields []string) string {
+	return "{" + mirJoinCommaList(fields) + "}"
+}
+
+// §8 LLVM-text typed-constant fragment helpers.
+
+// Osty: mirTypedConstFragment / I64 / I1 / Ptr / Double
+func mirTypedConstFragment(ty, val string) string {
+	return ty + " " + val
+}
+func mirTypedConstFragmentI64(val string) string {
+	return mirTypedConstFragment(mirTypeI64(), val)
+}
+func mirTypedConstFragmentI1(val string) string {
+	return mirTypedConstFragment(mirTypeI1(), val)
+}
+func mirTypedConstFragmentPtr(val string) string {
+	return mirTypedConstFragment(mirTypePtr(), val)
+}
+func mirTypedConstFragmentDouble(val string) string {
+	return mirTypedConstFragment(mirTypeDouble(), val)
+}
+
+// §8 LLVM-text comments-by-purpose helpers.
+
+// Osty: mirComment{Safepoint,NoSafepoint,Vectorize,NoVectorize,Parallel,Inline,NoInline,Hot,Cold}
+func mirCommentSafepoint() string   { return "  ; safepoint\n" }
+func mirCommentNoSafepoint() string { return "  ; no-safepoint\n" }
+func mirCommentVectorize() string   { return "  ; vectorize-eligible\n" }
+func mirCommentNoVectorize() string { return "  ; no-vectorize\n" }
+func mirCommentParallel() string    { return "  ; parallel\n" }
+func mirCommentInline() string      { return "  ; inline-hint\n" }
+func mirCommentNoInline() string    { return "  ; no-inline\n" }
+func mirCommentHot() string         { return "  ; hot\n" }
+func mirCommentCold() string        { return "  ; cold\n" }
+
+// §8 LLVM-text parameter-binding helpers.
+
+// Osty: mirParamBinding{Ptr,I64,I1,Double}
+func mirParamBindingPtr(paramSlot, argName string) string {
+	return mirAllocaPtrLine(paramSlot) +
+		"  " + mirInstrStore() + " ptr " + argName + ", ptr " + paramSlot + "\n"
+}
+func mirParamBindingI64(paramSlot, argName string) string {
+	return mirAllocaI64Line(paramSlot) +
+		"  " + mirInstrStore() + " i64 " + argName + ", ptr " + paramSlot + "\n"
+}
+func mirParamBindingI1(paramSlot, argName string) string {
+	return mirAllocaI1Line(paramSlot) +
+		"  " + mirInstrStore() + " i1 " + argName + ", ptr " + paramSlot + "\n"
+}
+func mirParamBindingDouble(paramSlot, argName string) string {
+	return mirAllocaDoubleLine(paramSlot) +
+		"  " + mirInstrStore() + " double " + argName + ", ptr " + paramSlot + "\n"
+}
+
+// §8 GC root array setup composite helpers.
+
+// Osty: mirGCRootSlotsAllocaWithCommentLine / mirGCRootSafepointWithCommentLine
+func mirGCRootSlotsAllocaWithCommentLine(slotsPtr, countDigits string) string {
+	return "  ; gc roots\n" + mirGCRootSlotsAllocaLine(slotsPtr, countDigits)
+}
+func mirGCRootSafepointWithCommentLine(slotsPtr, slotCount string) string {
+	return mirCommentSafepoint() + mirCallVoidGCSafepointLine(slotsPtr, slotCount)
+}
+
+// §8 LLVM-text builder-buffer helpers.
+
+// Osty: mirBuildLines{2,3,4,5}
+func mirBuildLines2(a, b string) string             { return a + b }
+func mirBuildLines3(a, b, c string) string          { return a + b + c }
+func mirBuildLines4(a, b, c, d string) string       { return a + b + c + d }
+func mirBuildLines5(a, b, c, d, e string) string    { return a + b + c + d + e }
+
+// §8 LLVM-text type alias helpers.
+
+// Osty: mirTypeAliasLine / mirNamedAggregateType
+func mirTypeAliasLine(name, body string) string {
+	return "%" + name + " = type " + body + "\n"
+}
+func mirNamedAggregateType(name string) string {
+	return "%" + name
+}
+
+// §8 LLVM-text emit-pass abbreviation helpers.
+
+// Osty: mirEmitVoidCallStmt / mirEmitValueCallStmt
+func mirEmitVoidCallStmt(sym, args string) string {
+	return mirInstrCallVoid() + " void @" + sym + "(" + args + ")"
+}
+func mirEmitValueCallStmt(reg, retTy, sym, args string) string {
+	return reg + " = " + mirInstrCall() + " " + retTy + " @" + sym + "(" + args + ")"
+}
+
+// §8 LLVM-text noreturn-call shape helpers.
+
+// Osty: mirCallNoReturnVoidLine / NoArgsAttrLine
+func mirCallNoReturnVoidLine(sym, args string) string {
+	return "  " + mirEmitVoidCallStmt(sym, args) + " #1\n"
+}
+func mirCallNoReturnVoidNoArgsAttrLine(sym string) string {
+	return "  " + mirInstrCallVoid() + " void @" + sym + "() #1\n"
+}
+
+// §8 LLVM-text named-md-tuple helpers.
+
+// Osty: mirNamedMDTuple / mirNamedMDDistinctTuple / mirAnonymousMDTuple
+func mirNamedMDTuple(name, entries string) string {
+	return "!" + name + " = !{" + entries + "}\n"
+}
+func mirNamedMDDistinctTuple(name, entries string) string {
+	return "!" + name + " = distinct !{" + entries + "}\n"
+}
+func mirAnonymousMDTuple(entries string) string {
+	return "!{" + entries + "}"
+}
+
+// §9 LLVM-text emit-pass section markers.
+
+// Osty: mirSection{Declares,Globals,Functions,Metadata,Prelude,Epilogue}
+func mirSectionDeclares() string  { return "; declares\n" }
+func mirSectionGlobals() string   { return "; globals\n" }
+func mirSectionFunctions() string { return "; functions\n" }
+func mirSectionMetadata() string  { return "; metadata\n" }
+func mirSectionPrelude() string   { return "; prelude\n" }
+func mirSectionEpilogue() string  { return "; epilogue\n" }
+
+// §9 LLVM-text reference-encoding helpers.
+
+// Osty: mirGlobalRef / mirRegRef / mirMDRef
+func mirGlobalRef(sym string) string { return "@" + sym }
+func mirRegRef(name string) string   { return "%" + name }
+func mirMDRef(name string) string    { return "!" + name }
+
+// §9 LLVM-text label-emit shape helpers.
+
+// Osty: mirLabelHeaderLine / mirJumpToLabelLine
+func mirLabelHeaderLine(name string) string { return name + ":\n" }
+func mirJumpToLabelLine(dst string) string  { return mirBrLabelLine(dst) }
+
+// §9 LLVM-text typed-arg list extension helpers.
+
+// Osty: mirAppendArg{Ptr,I64,I1,Double,I8,I32}
+func mirAppendArgPtr(prev, reg string) string    { return prev + ", ptr " + reg }
+func mirAppendArgI64(prev, reg string) string    { return prev + ", i64 " + reg }
+func mirAppendArgI1(prev, reg string) string     { return prev + ", i1 " + reg }
+func mirAppendArgDouble(prev, reg string) string { return prev + ", double " + reg }
+func mirAppendArgI8(prev, reg string) string     { return prev + ", i8 " + reg }
+func mirAppendArgI32(prev, reg string) string    { return prev + ", i32 " + reg }
+
+// §9 LLVM-text list-len / list-isEmpty common shape composers.
+
+// Osty: mirCallListLenLine / mirCallListIsEmptyLine / mirCallMapLenLine /
+//       mirCallSetLenLine / mirCallBytesLenLine
+func mirCallListLenLine(reg, listReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtListLenSymbolName() + "(ptr " + listReg + ")\n"
+}
+func mirCallListIsEmptyLine(reg, listReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i1 @" + mirRtListIsEmptySymbol() + "(ptr " + listReg + ")\n"
+}
+func mirCallMapLenLine(reg, mapReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtMapLenSymbolName() + "(ptr " + mapReg + ")\n"
+}
+func mirCallSetLenLine(reg, setReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtSetLenSymbolName() + "(ptr " + setReg + ")\n"
+}
+func mirCallBytesLenLine(reg, bytesReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtBytesLenSymbolName() + "(ptr " + bytesReg + ")\n"
+}
+
+// §9 LLVM-text loop-iter increment shape helpers.
+
+// Osty: mirIncrementLoopCounterLine / mirDecrementLoopCounterLine
+func mirIncrementLoopCounterLine(nextReg, iReg string) string {
+	return mirAddIntLine(nextReg, mirTypeI64(), iReg, "1")
+}
+func mirDecrementLoopCounterLine(nextReg, iReg string) string {
+	return mirSubIntLine(nextReg, mirTypeI64(), iReg, "1")
+}
+
+// §9 LLVM-text typed-load-store with align tag composite helpers.
+
+// Osty: mirLoadStoreLine / I64Line / I1Line / PtrLine / DoubleLine
+func mirLoadStoreLine(tmpReg, ty, src, dst string) string {
+	return "  " + tmpReg + " = " + mirInstrLoad() + " " + ty + ", ptr " + src + "\n" +
+		"  " + mirInstrStore() + " " + ty + " " + tmpReg + ", ptr " + dst + "\n"
+}
+func mirLoadStoreI64Line(tmpReg, src, dst string) string {
+	return mirLoadStoreLine(tmpReg, mirTypeI64(), src, dst)
+}
+func mirLoadStoreI1Line(tmpReg, src, dst string) string {
+	return mirLoadStoreLine(tmpReg, mirTypeI1(), src, dst)
+}
+func mirLoadStorePtrLine(tmpReg, src, dst string) string {
+	return mirLoadStoreLine(tmpReg, mirTypePtr(), src, dst)
+}
+func mirLoadStoreDoubleLine(tmpReg, src, dst string) string {
+	return mirLoadStoreLine(tmpReg, mirTypeDouble(), src, dst)
+}
+
+// §9 LLVM-text label-helper specialisations.
+
+// Osty: mirLabel{Ok,Err,Done,LoopHead,LoopBody,LoopExit,LoopLatch,MatchArmPrefix,MatchExit,IfThen,IfElse,IfEnd,OptionSome,OptionNone,ResultOk,ResultErr}
+func mirLabelOk() string             { return "ok" }
+func mirLabelErr() string            { return "err" }
+func mirLabelDone() string           { return "done" }
+func mirLabelLoopHead() string       { return "loop.head" }
+func mirLabelLoopBody() string       { return "loop.body" }
+func mirLabelLoopExit() string       { return "loop.exit" }
+func mirLabelLoopLatch() string      { return "loop.latch" }
+func mirLabelMatchArmPrefix() string { return "match.arm" }
+func mirLabelMatchExit() string      { return "match.exit" }
+func mirLabelIfThen() string         { return "if.then" }
+func mirLabelIfElse() string         { return "if.else" }
+func mirLabelIfEnd() string          { return "if.end" }
+func mirLabelOptionSome() string     { return "option.some" }
+func mirLabelOptionNone() string     { return "option.none" }
+func mirLabelResultOk() string       { return "result.ok" }
+func mirLabelResultErr() string      { return "result.err" }

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -8715,3 +8715,1329 @@ pub fn mirRtJsonSymbol(suffix: String) -> String {
 pub fn mirRtFmtSymbol(suffix: String) -> String {
     "osty_rt_fmt_" + suffix
 }
+
+/// §7 emit-pass per-block helpers — the pieces of code that the
+/// mid-level emitter writes once per basic-block.
+
+/// mirBlockSeparatorComment renders a canonical inter-block divider
+/// comment: `; ---- next block ----\n`.
+pub fn mirBlockSeparatorComment() -> String {
+    "; ---- next block ----\n"
+}
+
+/// mirBlockTraceLine renders a per-block trace comment.
+pub fn mirBlockTraceLine(blockId: String, kind: String) -> String {
+    "; block " + blockId + " (" + kind + ")\n"
+}
+
+/// mirInstrTraceLine renders a per-instruction trace comment.
+pub fn mirInstrTraceLine(kind: String, line: String, col: String) -> String {
+    "; " + kind + " at " + line + ":" + col + "\n"
+}
+
+/// §7 LLVM-text predicate composers (without leading indent / SSA
+/// assignment — used at sites that thread the predicate as a value
+/// into a select / extract chain).
+
+/// mirPredI64Eq composes `icmp eq i64 <a>, <b>`.
+pub fn mirPredI64Eq(a: String, b: String) -> String {
+    mirInstrICmp() + " " + mirICmpEq() + " " + mirTypeI64() + " " + a + ", " + b
+}
+
+/// mirPredI64Ne composes the inequality predicate.
+pub fn mirPredI64Ne(a: String, b: String) -> String {
+    mirInstrICmp() + " " + mirICmpNe() + " " + mirTypeI64() + " " + a + ", " + b
+}
+
+/// mirPredPtrEq composes the ptr-typed equality predicate.
+pub fn mirPredPtrEq(a: String, b: String) -> String {
+    mirInstrICmp() + " " + mirICmpEq() + " " + mirTypePtr() + " " + a + ", " + b
+}
+
+/// mirPredPtrNe composes the ptr-typed inequality predicate.
+pub fn mirPredPtrNe(a: String, b: String) -> String {
+    mirInstrICmp() + " " + mirICmpNe() + " " + mirTypePtr() + " " + a + ", " + b
+}
+
+/// mirPredI1Eq composes the i1 equality predicate.
+pub fn mirPredI1Eq(a: String, b: String) -> String {
+    mirInstrICmp() + " " + mirICmpEq() + " " + mirTypeI1() + " " + a + ", " + b
+}
+
+/// §7 typed-store / typed-load shapes with `!alias.scope` metadata.
+
+/// mirStoreI64WithAliasScopeLine renders the alias-scope-tagged i64
+/// store.
+pub fn mirStoreI64WithAliasScopeLine(val: String, slot: String, scopeRef: String) -> String {
+    "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// mirStoreDoubleWithAliasScopeLine renders the alias-scope-tagged
+/// double store.
+pub fn mirStoreDoubleWithAliasScopeLine(val: String, slot: String, scopeRef: String) -> String {
+    "  " + mirInstrStore() + " double " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// mirStorePtrWithAliasScopeLine renders the alias-scope-tagged ptr
+/// store.
+pub fn mirStorePtrWithAliasScopeLine(val: String, slot: String, scopeRef: String) -> String {
+    "  " + mirInstrStore() + " ptr " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// mirLoadI64WithAliasScopeLine renders the alias-scope-tagged i64
+/// load.
+pub fn mirLoadI64WithAliasScopeLine(reg: String, slot: String, scopeRef: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// mirLoadDoubleWithAliasScopeLine renders the alias-scope-tagged
+/// double load.
+pub fn mirLoadDoubleWithAliasScopeLine(reg: String, slot: String, scopeRef: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " double, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// mirLoadPtrWithAliasScopeLine renders the alias-scope-tagged ptr
+/// load.
+pub fn mirLoadPtrWithAliasScopeLine(reg: String, slot: String, scopeRef: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " ptr, ptr " + slot + ", !alias.scope " + scopeRef + "\n"
+}
+
+/// §7 typed-store / typed-load shapes with `!noalias` metadata.
+
+/// mirStoreI64WithNoAliasLine renders the noalias-tagged i64 store.
+pub fn mirStoreI64WithNoAliasLine(val: String, slot: String, ref: String) -> String {
+    "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !noalias " + ref + "\n"
+}
+
+/// mirStorePtrWithNoAliasLine renders the noalias-tagged ptr store.
+pub fn mirStorePtrWithNoAliasLine(val: String, slot: String, ref: String) -> String {
+    "  " + mirInstrStore() + " ptr " + val + ", ptr " + slot + ", !noalias " + ref + "\n"
+}
+
+/// mirLoadI64WithNoAliasLine renders the noalias-tagged i64 load.
+pub fn mirLoadI64WithNoAliasLine(reg: String, slot: String, ref: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !noalias " + ref + "\n"
+}
+
+/// mirLoadPtrWithNoAliasLine renders the noalias-tagged ptr load.
+pub fn mirLoadPtrWithNoAliasLine(reg: String, slot: String, ref: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " ptr, ptr " + slot + ", !noalias " + ref + "\n"
+}
+
+/// §7 LLVM `!llvm.access.group` — composite metadata for parallel
+/// loops (per v0.6 A6 `#[parallel]`).
+
+/// mirLLVMAccessGroupRef renders the canonical `!access_group <ref>`
+/// metadata attachment.
+pub fn mirLLVMAccessGroupRef(ref: String) -> String {
+    "!access_group " + ref
+}
+
+/// mirStoreI64WithAccessGroupLine renders the access-group-tagged
+/// i64 store.
+pub fn mirStoreI64WithAccessGroupLine(val: String, slot: String, ref: String) -> String {
+    "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !access_group " + ref + "\n"
+}
+
+/// mirStoreDoubleWithAccessGroupLine renders the access-group-tagged
+/// double store.
+pub fn mirStoreDoubleWithAccessGroupLine(val: String, slot: String, ref: String) -> String {
+    "  " + mirInstrStore() + " double " + val + ", ptr " + slot + ", !access_group " + ref + "\n"
+}
+
+/// mirLoadI64WithAccessGroupLine renders the access-group-tagged i64
+/// load.
+pub fn mirLoadI64WithAccessGroupLine(reg: String, slot: String, ref: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " i64, ptr " + slot + ", !access_group " + ref + "\n"
+}
+
+/// mirLoadDoubleWithAccessGroupLine renders the access-group-tagged
+/// double load.
+pub fn mirLoadDoubleWithAccessGroupLine(reg: String, slot: String, ref: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " double, ptr " + slot + ", !access_group " + ref + "\n"
+}
+
+/// §7 fixed-symbol composers — drain the inline `"osty_rt_*"` literal
+/// references at runtime-symbol declaration sites.
+
+/// mirRtListOOBAbortSymbol returns `osty_rt_list_oob_abort_v1`.
+pub fn mirRtListOOBAbortSymbol() -> String {
+    mirRtListSymbol("oob_abort_v1")
+}
+
+/// mirRtListPopDiscardSymbol returns `osty_rt_list_pop_discard`.
+pub fn mirRtListPopDiscardSymbol() -> String {
+    mirRtListSymbol("pop_discard")
+}
+
+/// mirRtListIsEmptySymbol returns `osty_rt_list_is_empty`.
+pub fn mirRtListIsEmptySymbol() -> String {
+    mirRtListSymbol("is_empty")
+}
+
+/// mirRtListLenSymbolName returns `osty_rt_list_len`.
+pub fn mirRtListLenSymbolName() -> String {
+    mirRtListSymbol("len")
+}
+
+/// mirRtListReverseSymbol / ReversedSymbol return the reverse-runtime
+/// symbol names.
+pub fn mirRtListReverseSymbol() -> String {
+    mirRtListSymbol("reverse")
+}
+
+pub fn mirRtListReversedSymbol() -> String {
+    mirRtListSymbol("reversed")
+}
+
+/// mirRtListClearSymbol returns `osty_rt_list_clear`.
+pub fn mirRtListClearSymbol() -> String {
+    mirRtListSymbol("clear")
+}
+
+/// mirRtListRemoveAtDiscardSymbol returns `osty_rt_list_remove_at_discard`.
+pub fn mirRtListRemoveAtDiscardSymbol() -> String {
+    mirRtListSymbol("remove_at_discard")
+}
+
+/// mirRtMapNewSymbol returns `osty_rt_map_new`.
+pub fn mirRtMapNewSymbol() -> String {
+    mirRtMapSymbol("new")
+}
+
+/// mirRtMapClearSymbol returns `osty_rt_map_clear`.
+pub fn mirRtMapClearSymbol() -> String {
+    mirRtMapSymbol("clear")
+}
+
+/// mirRtMapLenSymbolName returns `osty_rt_map_len`.
+pub fn mirRtMapLenSymbolName() -> String {
+    mirRtMapSymbol("len")
+}
+
+/// mirRtMapValuesSymbol / EntriesSymbol / MergeWithSymbol — iteration
+/// / merge entry-point names.
+pub fn mirRtMapValuesSymbol() -> String {
+    mirRtMapSymbol("values")
+}
+
+pub fn mirRtMapEntriesSymbol() -> String {
+    mirRtMapSymbol("entries")
+}
+
+pub fn mirRtMapMergeWithSymbol() -> String {
+    mirRtMapSymbol("merge_with")
+}
+
+/// mirRtSetClearSymbol / LenSymbolName / ToListSymbol — Set-runtime
+/// symbol names.
+pub fn mirRtSetClearSymbol() -> String {
+    mirRtSetSymbol("clear")
+}
+
+pub fn mirRtSetLenSymbolName() -> String {
+    mirRtSetSymbol("len")
+}
+
+pub fn mirRtSetToListSymbol() -> String {
+    mirRtSetSymbol("to_list")
+}
+
+/// mirRtBytesLenSymbolName / IsEmptySymbol / GetSymbol — Bytes-runtime
+/// symbol names.
+pub fn mirRtBytesLenSymbolName() -> String {
+    mirRtBytesSymbol("len")
+}
+
+pub fn mirRtBytesIsEmptySymbol() -> String {
+    mirRtBytesSymbol("is_empty")
+}
+
+pub fn mirRtBytesGetSymbol() -> String {
+    mirRtBytesSymbol("get")
+}
+
+/// mirRtStringConcatSymbol / ConcatNSymbol / DiffLinesSymbol —
+/// String-runtime symbol names.
+pub fn mirRtStringConcatSymbol() -> String {
+    mirRtStringSymbol("Concat")
+}
+
+pub fn mirRtStringConcatNSymbol() -> String {
+    mirRtStringSymbol("ConcatN")
+}
+
+pub fn mirRtStringDiffLinesSymbol() -> String {
+    mirRtStringSymbol("DiffLines")
+}
+
+/// mirRtCancelCheckCancelledSymbol / IsCancelledSymbol / CancelSymbol
+/// — cancellation runtime symbol names.
+pub fn mirRtCancelCheckCancelledSymbol() -> String {
+    mirRtCancelSymbol("check_cancelled")
+}
+
+pub fn mirRtCancelIsCancelledSymbol() -> String {
+    mirRtCancelSymbol("is_cancelled")
+}
+
+pub fn mirRtCancelCancelSymbol() -> String {
+    mirRtCancelSymbol("cancel")
+}
+
+/// mirRtChanCloseSymbol / RecvSymbol / SendSymbolName — channel
+/// runtime symbol names.
+pub fn mirRtChanCloseSymbol() -> String {
+    mirRtChanSymbol("close")
+}
+
+pub fn mirRtChanRecvSymbol() -> String {
+    mirRtChanSymbol("recv")
+}
+
+pub fn mirRtChanSendSymbolName() -> String {
+    mirRtChanSymbol("send")
+}
+
+/// mirRtThreadYieldSymbol / SleepSymbol / SpawnSymbol — thread-
+/// runtime symbol names.
+pub fn mirRtThreadYieldSymbol() -> String {
+    mirRtThreadSymbol("yield")
+}
+
+pub fn mirRtThreadSleepSymbol() -> String {
+    mirRtThreadSymbol("sleep")
+}
+
+pub fn mirRtThreadSpawnSymbol() -> String {
+    mirRtThreadSymbol("spawn")
+}
+
+/// mirRtBenchNowNanosSymbol / TargetNsSymbol — bench-harness runtime
+/// symbol names.
+pub fn mirRtBenchNowNanosSymbol() -> String {
+    mirRtBenchSymbol("now_nanos")
+}
+
+pub fn mirRtBenchTargetNsSymbol() -> String {
+    mirRtBenchSymbol("target_ns")
+}
+
+/// mirRtTestSnapshotSymbol / AbortSymbol / ContextEnterSymbol /
+/// ContextExitSymbol / ExpectOkSymbol / ExpectErrorSymbol — test-
+/// harness runtime symbol names.
+pub fn mirRtTestSnapshotSymbol() -> String {
+    mirRtTestSymbol("snapshot")
+}
+
+pub fn mirRtTestAbortSymbol() -> String {
+    mirRtTestSymbol("abort")
+}
+
+pub fn mirRtTestContextEnterSymbol() -> String {
+    mirRtTestSymbol("context_enter")
+}
+
+pub fn mirRtTestContextExitSymbol() -> String {
+    mirRtTestSymbol("context_exit")
+}
+
+pub fn mirRtTestExpectOkSymbol() -> String {
+    mirRtTestSymbol("expect_ok")
+}
+
+pub fn mirRtTestExpectErrorSymbol() -> String {
+    mirRtTestSymbol("expect_error")
+}
+
+/// mirRtPanicSymbol / mirRtUnreachableSymbol / mirRtTodoSymbol /
+/// mirRtAbortSymbol — bare runtime symbols.
+pub fn mirRtPanicSymbol() -> String {
+    mirRtSymbol("panic")
+}
+
+pub fn mirRtUnreachableSymbol() -> String {
+    mirRtSymbol("unreachable")
+}
+
+pub fn mirRtTodoSymbol() -> String {
+    mirRtSymbol("todo")
+}
+
+pub fn mirRtAbortSymbol() -> String {
+    mirRtSymbol("abort")
+}
+
+/// mirRtOptionUnwrapNoneSymbol / mirRtResultUnwrapErrSymbol /
+/// mirRtExpectFailedSymbol — option / result panic-helper symbols.
+pub fn mirRtOptionUnwrapNoneSymbol() -> String {
+    mirRtSymbol("option_unwrap_none")
+}
+
+pub fn mirRtResultUnwrapErrSymbol() -> String {
+    mirRtSymbol("result_unwrap_err")
+}
+
+pub fn mirRtExpectFailedSymbol() -> String {
+    mirRtSymbol("expect_failed")
+}
+
+/// mirRtIntToStringSymbol / FloatToStringSymbol / BoolToStringSymbol /
+/// CharToStringSymbol / ByteToStringSymbol / ListPrimitiveToStringSymbol
+/// — to-string runtime symbol names.
+pub fn mirRtIntToStringSymbol() -> String {
+    mirRtSymbol("int_to_string")
+}
+
+pub fn mirRtFloatToStringSymbol() -> String {
+    mirRtSymbol("float_to_string")
+}
+
+pub fn mirRtBoolToStringSymbol() -> String {
+    mirRtSymbol("bool_to_string")
+}
+
+pub fn mirRtCharToStringSymbol() -> String {
+    mirRtSymbol("char_to_string")
+}
+
+pub fn mirRtByteToStringSymbol() -> String {
+    mirRtSymbol("byte_to_string")
+}
+
+pub fn mirRtListPrimitiveToStringSymbol() -> String {
+    mirRtListSymbol("primitive_to_string")
+}
+
+/// mirRtParallelSymbol / RaceSymbol — structured-concurrency runtime
+/// symbol names.
+pub fn mirRtParallelSymbol() -> String {
+    mirRtSymbol("parallel")
+}
+
+pub fn mirRtRaceSymbol() -> String {
+    mirRtSymbol("race")
+}
+
+/// mirRtTaskGroupRootSymbol returns `osty_rt_task_group` — the
+/// canonical task-group factory symbol (different from the
+/// namespace-prefixed `mirRtTaskGroupSymbol(suffix)` composer).
+pub fn mirRtTaskGroupRootSymbol() -> String {
+    mirRtSymbol("task_group")
+}
+
+/// §7 LLVM-text type-text composers (semantic aliases for the
+/// existing aggregate-type tokens; named for the call-site context).
+
+/// mirListTypeText composes the LLVM-text List<T> handle type.
+pub fn mirListTypeText() -> String {
+    mirTypePtr()
+}
+
+/// mirMapTypeText composes the LLVM-text Map<K,V> handle type.
+pub fn mirMapTypeText() -> String {
+    mirTypePtr()
+}
+
+/// mirSetTypeText composes the LLVM-text Set<T> handle type.
+pub fn mirSetTypeText() -> String {
+    mirTypePtr()
+}
+
+/// mirOptionTypeTextScalar / mirOptionTypeTextPtr — Option aggregate
+/// variant aliases.
+pub fn mirOptionTypeTextScalar() -> String {
+    mirOptionAggregateType()
+}
+
+pub fn mirOptionTypeTextPtr() -> String {
+    mirOptionPtrAggregateType()
+}
+
+/// mirResultTypeTextScalar / mirResultTypeTextPtr — Result aggregate
+/// variant aliases.
+pub fn mirResultTypeTextScalar() -> String {
+    mirOptionAggregateType()
+}
+
+pub fn mirResultTypeTextPtr() -> String {
+    mirOptionPtrAggregateType()
+}
+
+/// §7 LLVM-text discriminant probe / payload-extract shapes.
+
+/// mirOptionDiscProbeLine renders the canonical Option discriminant
+/// extract.
+pub fn mirOptionDiscProbeLine(reg: String, aggReg: String) -> String {
+    mirExtractValueLine(reg, mirOptionAggregateType(), aggReg, "0")
+}
+
+/// mirOptionPayloadProbeLine renders the canonical Option payload
+/// extract.
+pub fn mirOptionPayloadProbeLine(reg: String, aggReg: String) -> String {
+    mirExtractValueLine(reg, mirOptionAggregateType(), aggReg, "1")
+}
+
+/// mirOptionPtrDiscProbeLine / PayloadProbeLine — Option<Ptr>
+/// variant.
+pub fn mirOptionPtrDiscProbeLine(reg: String, aggReg: String) -> String {
+    mirExtractValueLine(reg, mirOptionPtrAggregateType(), aggReg, "0")
+}
+
+pub fn mirOptionPtrPayloadProbeLine(reg: String, aggReg: String) -> String {
+    mirExtractValueLine(reg, mirOptionPtrAggregateType(), aggReg, "1")
+}
+
+/// mirResultDiscProbeLine / PayloadProbeLine — Result variant.
+pub fn mirResultDiscProbeLine(reg: String, aggReg: String) -> String {
+    mirOptionDiscProbeLine(reg, aggReg)
+}
+
+pub fn mirResultPayloadProbeLine(reg: String, aggReg: String) -> String {
+    mirOptionPayloadProbeLine(reg, aggReg)
+}
+
+/// §7 LLVM-text Option / Result aggregate-construction shapes.
+
+/// mirOptionNoneAggregateLine renders the canonical None-aggregate
+/// construction.
+pub fn mirOptionNoneAggregateLine(reg: String) -> String {
+    mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantNone(), "0")
+}
+
+/// mirOptionSomeDiscAggregateLine renders the canonical Some-disc
+/// step.
+pub fn mirOptionSomeDiscAggregateLine(reg: String) -> String {
+    mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantSome(), "0")
+}
+
+/// mirOptionSomePayloadAggregateLine renders the Some-payload step.
+pub fn mirOptionSomePayloadAggregateLine(reg: String, prev: String, payload: String) -> String {
+    mirInsertValueAggLine(reg, mirOptionAggregateType(), prev, mirTypeI64(), payload, "1")
+}
+
+/// mirResultOkDiscAggregateLine / mirResultErrDiscAggregateLine —
+/// Result-aggregate construction.
+pub fn mirResultOkDiscAggregateLine(reg: String) -> String {
+    mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantOk(), "0")
+}
+
+pub fn mirResultErrDiscAggregateLine(reg: String) -> String {
+    mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantErr(), "0")
+}
+
+/// §7 LLVM-text panic-trap shape composers.
+
+/// mirPanicTrapLine renders the canonical 2-line panic trap:
+/// `call void @<sym>(ptr <message>)\n  unreachable\n`.
+pub fn mirPanicTrapLine(sym: String, messagePtr: String) -> String {
+    mirCallVoidPtrLine(sym, messagePtr) + mirUnreachableLine()
+}
+
+/// mirAbortTrapLine renders the canonical no-arg abort trap:
+/// `call void @<sym>()\n  unreachable\n`.
+pub fn mirAbortTrapLine(sym: String) -> String {
+    mirCallVoidNoArgsLine(sym) + mirUnreachableLine()
+}
+
+/// §7 LLVM-text Cond-branch shape composers.
+
+/// mirConditionalBranch3Line renders a 3-line guard pattern: cmp +
+/// branch.
+pub fn mirConditionalBranch3Line(cmpReg: String, ty: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpLine(cmpReg, mirICmpEq(), ty, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// §7 LLVM-text loop-prelude shape helpers.
+
+/// mirLoopHeaderBlockLine renders the canonical loop-header block
+/// label.
+pub fn mirLoopHeaderBlockLine(head: String) -> String {
+    mirBlockHeaderLine(head)
+}
+
+/// mirLoopBodyBlockLine / ExitBlockLine / LatchBlockLine — loop block
+/// labels at the well-known prelude positions.
+pub fn mirLoopBodyBlockLine(body: String) -> String {
+    mirBlockHeaderLine(body)
+}
+
+pub fn mirLoopExitBlockLine(exit: String) -> String {
+    mirBlockHeaderLine(exit)
+}
+
+pub fn mirLoopLatchBlockLine(latch: String) -> String {
+    mirBlockHeaderLine(latch)
+}
+
+/// §7 LLVM-text typed-Range-loop preamble helpers.
+
+/// mirRangeLoopInitLine renders the canonical range-loop init step.
+pub fn mirRangeLoopInitLine(initReg: String, start: String) -> String {
+    mirAddIntLine(initReg, mirTypeI64(), start, "0")
+}
+
+/// mirRangeLoopBoundLine renders the canonical range-loop bound
+/// computation.
+pub fn mirRangeLoopBoundLine(boundReg: String, end: String) -> String {
+    mirAddIntLine(boundReg, mirTypeI64(), end, "0")
+}
+
+/// §7 vector-list snapshot composite helper.
+
+/// mirVectorListSnapshot2Line renders the canonical 2-line vector-
+/// list snapshot prelude: data + len calls.
+pub fn mirVectorListSnapshot2Line(dataReg: String, dataSym: String, lenReg: String, listReg: String, scopeRef: String) -> String {
+    mirCallValueListDataNoAliasLine(dataReg, dataSym, listReg, scopeRef) +
+    mirCallValueListLenWithScopeLine(lenReg, listReg, scopeRef)
+}
+
+/// §8 monomorphisation key / sig composers — drain remaining
+/// inline patterns where the emitter forms canonical Osty-side
+/// keys for monomorphised entries.
+
+/// mirMonomorphKey composes the canonical monomorphised-fn key:
+///   `<base>::<ty1>,<ty2>,...`
+/// Used at every `<T> -> Concrete<T>` lookup site that wants a
+/// stable string for cache hashing.
+pub fn mirMonomorphKey(base: String, typeArgs: List<String>) -> String {
+    if typeArgs.isEmpty() { return base }
+    let mut parts = base + "::"
+    let mut first = true
+    for a in typeArgs {
+        if !first { parts = parts + "," }
+        parts = parts + a
+        first = false
+    }
+    parts
+}
+
+/// mirGenericInstanceKey composes a key for a generic-struct /
+/// enum instance: `<base>[<ty1>,<ty2>,...]`. Sibling of
+/// `mirMonomorphKey` named for the type-instance path.
+pub fn mirGenericInstanceKey(base: String, typeArgs: List<String>) -> String {
+    if typeArgs.isEmpty() { return base }
+    let mut parts = base + "["
+    let mut first = true
+    for a in typeArgs {
+        if !first { parts = parts + "," }
+        parts = parts + a
+        first = false
+    }
+    parts + "]"
+}
+
+/// mirClosureSignatureKey composes the canonical closure-signature
+/// key: `closure[<retTy>](<paramTypes>)`. Used at the closure-table
+/// dedup pass.
+pub fn mirClosureSignatureKey(retTy: String, paramTypes: List<String>) -> String {
+    let mut parts = "closure[" + retTy + "]("
+    let mut first = true
+    for p in paramTypes {
+        if !first { parts = parts + ", " }
+        parts = parts + p
+        first = false
+    }
+    parts + ")"
+}
+
+/// §8 LLVM-text fn-signature composers.
+
+/// mirFnSignatureType composes the canonical LLVM function-pointer
+/// type: `<retTy> (<paramTypes>)`. Used at every fn-pointer typing
+/// site (closure call, vtable method, indirect call).
+pub fn mirFnSignatureType(retTy: String, paramTypes: List<String>) -> String {
+    let mut parts = retTy + " ("
+    let mut first = true
+    for p in paramTypes {
+        if !first { parts = parts + ", " }
+        parts = parts + p
+        first = false
+    }
+    parts + ")"
+}
+
+/// mirFnPointerTypeWithEnv composes `<retTy> (ptr, <restParams>)` —
+/// the canonical closure fn-pointer type that prepends the env
+/// pointer. Sibling of `mirClosureCallTypeLine` exposed as a value.
+pub fn mirFnPointerTypeWithEnv(retTy: String, restParamTypes: List<String>) -> String {
+    let mut parts = retTy + " (ptr"
+    for p in restParamTypes {
+        parts = parts + ", " + p
+    }
+    parts + ")"
+}
+
+/// §8 LLVM-text param-list shape helpers.
+
+/// mirParamSlotPtr renders `ptr %<name>` — the canonical ptr-typed
+/// parameter slot in a function-define header. Sibling of
+/// `mirArgSlotPtr` for the param-list (vs arg-list) usage.
+pub fn mirParamSlotPtr(name: String) -> String {
+    "ptr %" + name
+}
+
+/// mirParamSlotI64 / I32 / I1 / I8 / Double — typed-parameter slots.
+pub fn mirParamSlotI64(name: String) -> String {
+    "i64 %" + name
+}
+
+pub fn mirParamSlotI32(name: String) -> String {
+    "i32 %" + name
+}
+
+pub fn mirParamSlotI1(name: String) -> String {
+    "i1 %" + name
+}
+
+pub fn mirParamSlotI8(name: String) -> String {
+    "i8 %" + name
+}
+
+pub fn mirParamSlotDouble(name: String) -> String {
+    "double %" + name
+}
+
+/// §8 LLVM-text typed-parameter list composers.
+
+/// mirParamListEnvPtr renders the canonical closure-env-only param
+/// list: `ptr %env`. Used at every closure define's first param.
+pub fn mirParamListEnvPtr() -> String {
+    "ptr %env"
+}
+
+/// mirParamListEnvPtrAndOne / Two / Three — composed env-prefixed
+/// param lists.
+pub fn mirParamListEnvPtrAndOne(p1: String) -> String {
+    mirParamListEnvPtr() + ", " + p1
+}
+
+pub fn mirParamListEnvPtrAndTwo(p1: String, p2: String) -> String {
+    mirParamListEnvPtr() + ", " + p1 + ", " + p2
+}
+
+pub fn mirParamListEnvPtrAndThree(p1: String, p2: String, p3: String) -> String {
+    mirParamListEnvPtr() + ", " + p1 + ", " + p2 + ", " + p3
+}
+
+/// §8 LLVM-text fn-name composers.
+
+/// mirOstyFnName composes the canonical Osty-side fn name:
+///   `osty_<package>_<fnname>`
+/// Used at every Osty fn definition / call site.
+pub fn mirOstyFnName(packageName: String, fnName: String) -> String {
+    "osty_" + packageName + "_" + fnName
+}
+
+/// mirOstyMethodName composes `osty_<package>_<typename>_<methodname>`.
+/// Used at every Osty method definition / call site.
+pub fn mirOstyMethodName(packageName: String, typeName: String, methodName: String) -> String {
+    "osty_" + packageName + "_" + typeName + "_" + methodName
+}
+
+/// mirOstyClosureName composes `osty_closure_<id>` — the canonical
+/// closure-implementation symbol name.
+pub fn mirOstyClosureName(idDigits: String) -> String {
+    "osty_closure_" + idDigits
+}
+
+/// mirOstyVTableName composes `osty_vt_<typename>__<interfacename>` —
+/// the canonical vtable-symbol name.
+pub fn mirOstyVTableName(typeName: String, interfaceName: String) -> String {
+    "osty_vt_" + typeName + "__" + interfaceName
+}
+
+/// mirOstyStringPoolName composes the canonical string-pool entry
+/// name: `@.str<idDigits>`.
+pub fn mirOstyStringPoolName(idDigits: String) -> String {
+    "@.str" + idDigits
+}
+
+/// mirOstyFormatPoolName composes `@.fmt<idDigits>` — the format-
+/// string pool entry name.
+pub fn mirOstyFormatPoolName(idDigits: String) -> String {
+    "@.fmt" + idDigits
+}
+
+/// §8 LLVM-text local-name composers.
+
+/// mirLocalSlotName composes the canonical local slot name:
+///   `%l<idDigits>`. Sibling of the existing emit pattern.
+pub fn mirLocalSlotName(idDigits: String) -> String {
+    "%l" + idDigits
+}
+
+/// mirParamSlotName composes `%p<idDigits>` — the canonical param
+/// slot name.
+pub fn mirParamSlotName(idDigits: String) -> String {
+    "%p" + idDigits
+}
+
+/// mirTempRegName composes `%t<idDigits>` — the canonical temporary
+/// register name.
+pub fn mirTempRegName(idDigits: String) -> String {
+    "%t" + idDigits
+}
+
+/// (mirBlockLabelName continues to live at its original site
+/// earlier in this file.)
+
+/// §8 LLVM-text alias-scope metadata helpers.
+
+/// mirAliasScopeMetadataNode renders the canonical alias-scope-
+/// list metadata-node body:
+///   `!\{!<scopeRef>\}` (single-element scope list)
+pub fn mirAliasScopeMetadataNode(scopeRef: String) -> String {
+    "!\{!" + scopeRef + "\}"
+}
+
+/// mirAliasScopeListMetadataNode renders an alias-scope-list with
+/// multiple scopes. Caller comma-joins the refs.
+pub fn mirAliasScopeListMetadataNode(refs: String) -> String {
+    "!\{" + refs + "\}"
+}
+
+/// mirAliasScopeReference renders the canonical scope-attachment:
+///   `!alias.scope <ref>`
+/// Used inside instruction metadata-attachment lists.
+pub fn mirAliasScopeReference(ref: String) -> String {
+    "!alias.scope " + ref
+}
+
+/// mirNoAliasReference renders the canonical noalias attachment.
+pub fn mirNoAliasReference(ref: String) -> String {
+    "!noalias " + ref
+}
+
+/// §8 LLVM-text comma-joined list helpers — for runtime call arg
+/// list formation.
+
+/// mirJoinCommaList joins a list of strings with `, ` separator.
+/// Sibling of `mirJoinCommaTwo/Three/Four/Five/Six` for variadic
+/// arg lists.
+pub fn mirJoinCommaList(parts: List<String>) -> String {
+    let mut joined = ""
+    let mut first = true
+    for p in parts {
+        if !first { joined = joined + ", " }
+        joined = joined + p
+        first = false
+    }
+    joined
+}
+
+/// mirJoinSpaceList joins a list of strings with ` ` separator.
+/// Used at sites that build attribute strings (e.g. `inlinehint hot`).
+pub fn mirJoinSpaceList(parts: List<String>) -> String {
+    let mut joined = ""
+    let mut first = true
+    for p in parts {
+        if !first { joined = joined + " " }
+        joined = joined + p
+        first = false
+    }
+    joined
+}
+
+/// §8 LLVM-text constant-array body composers.
+
+/// mirConstantArrayBody composes the canonical `[<entries>]` body
+/// of an array-constant initializer. Caller threads the entries
+/// already-comma-joined.
+pub fn mirConstantArrayBody(entries: String) -> String {
+    "[" + entries + "]"
+}
+
+/// mirConstantArrayBodyOfList joins the entry list and wraps in
+/// brackets.
+pub fn mirConstantArrayBodyOfList(entries: List<String>) -> String {
+    "[" + mirJoinCommaList(entries) + "]"
+}
+
+/// mirConstantStructBody composes `\{<fields>\}` — the struct-
+/// constant initializer body.
+pub fn mirConstantStructBody(fields: String) -> String {
+    "\{" + fields + "\}"
+}
+
+/// mirConstantStructBodyOfList joins the field list and wraps in
+/// braces.
+pub fn mirConstantStructBodyOfList(fields: List<String>) -> String {
+    "\{" + mirJoinCommaList(fields) + "\}"
+}
+
+/// §8 LLVM-text typed-constant fragment helpers.
+
+/// mirTypedConstFragment composes `<ty> <val>` — the canonical
+/// typed-const fragment. Sibling of `mirArgSlot*` for the
+/// constant-context (vs runtime register).
+pub fn mirTypedConstFragment(ty: String, val: String) -> String {
+    ty + " " + val
+}
+
+/// mirTypedConstFragmentI64 composes `i64 <val>`.
+pub fn mirTypedConstFragmentI64(val: String) -> String {
+    mirTypedConstFragment(mirTypeI64(), val)
+}
+
+/// mirTypedConstFragmentI1 composes `i1 <val>`.
+pub fn mirTypedConstFragmentI1(val: String) -> String {
+    mirTypedConstFragment(mirTypeI1(), val)
+}
+
+/// mirTypedConstFragmentPtr composes `ptr <val>`.
+pub fn mirTypedConstFragmentPtr(val: String) -> String {
+    mirTypedConstFragment(mirTypePtr(), val)
+}
+
+/// mirTypedConstFragmentDouble composes `double <val>`.
+pub fn mirTypedConstFragmentDouble(val: String) -> String {
+    mirTypedConstFragment(mirTypeDouble(), val)
+}
+
+/// §8 LLVM-text comments-by-purpose helpers.
+
+/// mirCommentSafepoint renders the canonical safepoint annotation
+/// comment.
+pub fn mirCommentSafepoint() -> String {
+    "  ; safepoint\n"
+}
+
+/// mirCommentNoSafepoint renders the canonical no-safepoint annotation.
+pub fn mirCommentNoSafepoint() -> String {
+    "  ; no-safepoint\n"
+}
+
+/// mirCommentVectorize renders the canonical vectorize-eligible
+/// annotation.
+pub fn mirCommentVectorize() -> String {
+    "  ; vectorize-eligible\n"
+}
+
+/// mirCommentNoVectorize renders the canonical no-vectorize annotation.
+pub fn mirCommentNoVectorize() -> String {
+    "  ; no-vectorize\n"
+}
+
+/// mirCommentParallel renders the canonical parallel annotation.
+pub fn mirCommentParallel() -> String {
+    "  ; parallel\n"
+}
+
+/// mirCommentInline renders the canonical inline-hint annotation.
+pub fn mirCommentInline() -> String {
+    "  ; inline-hint\n"
+}
+
+/// mirCommentNoInline renders the canonical no-inline annotation.
+pub fn mirCommentNoInline() -> String {
+    "  ; no-inline\n"
+}
+
+/// mirCommentHot renders the canonical hot-path annotation.
+pub fn mirCommentHot() -> String {
+    "  ; hot\n"
+}
+
+/// mirCommentCold renders the canonical cold-path annotation.
+pub fn mirCommentCold() -> String {
+    "  ; cold\n"
+}
+
+/// §8 LLVM-text parameter-binding helpers.
+
+/// mirParamBindingPtr renders `<paramSlot> = alloca ptr\n  store ptr <argName>, ptr <paramSlot>\n`.
+/// The 2-line param-binding pattern the emitter uses for every ptr-
+/// typed function parameter.
+pub fn mirParamBindingPtr(paramSlot: String, argName: String) -> String {
+    mirAllocaPtrLine(paramSlot) +
+    "  " + mirInstrStore() + " ptr " + argName + ", ptr " + paramSlot + "\n"
+}
+
+/// mirParamBindingI64 renders the i64-typed param-binding 2-line
+/// pattern.
+pub fn mirParamBindingI64(paramSlot: String, argName: String) -> String {
+    mirAllocaI64Line(paramSlot) +
+    "  " + mirInstrStore() + " i64 " + argName + ", ptr " + paramSlot + "\n"
+}
+
+/// mirParamBindingI1 renders the i1-typed param-binding 2-line
+/// pattern.
+pub fn mirParamBindingI1(paramSlot: String, argName: String) -> String {
+    mirAllocaI1Line(paramSlot) +
+    "  " + mirInstrStore() + " i1 " + argName + ", ptr " + paramSlot + "\n"
+}
+
+/// mirParamBindingDouble renders the double-typed param-binding
+/// 2-line pattern.
+pub fn mirParamBindingDouble(paramSlot: String, argName: String) -> String {
+    mirAllocaDoubleLine(paramSlot) +
+    "  " + mirInstrStore() + " double " + argName + ", ptr " + paramSlot + "\n"
+}
+
+/// §8 GC root array setup composite helpers.
+
+/// mirGCRootSlotsAllocaWithCommentLine renders the canonical
+/// root-slots alloca prefixed by a `; gc roots` comment.
+pub fn mirGCRootSlotsAllocaWithCommentLine(slotsPtr: String, countDigits: String) -> String {
+    "  ; gc roots\n" + mirGCRootSlotsAllocaLine(slotsPtr, countDigits)
+}
+
+/// mirGCRootSafepointWithCommentLine renders the canonical
+/// safepoint-call line prefixed by a `; safepoint` comment.
+pub fn mirGCRootSafepointWithCommentLine(slotsPtr: String, slotCount: String) -> String {
+    mirCommentSafepoint() + mirCallVoidGCSafepointLine(slotsPtr, slotCount)
+}
+
+/// §8 LLVM-text builder-buffer helpers.
+
+/// mirBuildLines2 concatenates two lines into a single string. Used
+/// at sites that batch a 2-line emit into one string for less
+/// fnBuf flushing.
+pub fn mirBuildLines2(a: String, b: String) -> String {
+    a + b
+}
+
+/// mirBuildLines3 concatenates three lines.
+pub fn mirBuildLines3(a: String, b: String, c: String) -> String {
+    a + b + c
+}
+
+/// mirBuildLines4 concatenates four lines.
+pub fn mirBuildLines4(a: String, b: String, c: String, d: String) -> String {
+    a + b + c + d
+}
+
+/// mirBuildLines5 concatenates five lines.
+pub fn mirBuildLines5(a: String, b: String, c: String, d: String, e: String) -> String {
+    a + b + c + d + e
+}
+
+/// §8 LLVM-text type alias helpers.
+
+/// mirTypeAliasLine renders the canonical type-alias emit line:
+///   `%<name> = type <body>\n`
+/// Used at sites that name aggregate types for legibility (e.g.
+/// vtable struct types).
+pub fn mirTypeAliasLine(name: String, body: String) -> String {
+    "%" + name + " = type " + body + "\n"
+}
+
+/// mirNamedAggregateType composes `%<name>` — a reference to a
+/// previously-named aggregate type. Used at sites that thread the
+/// alias through fn signatures / GEP instructions.
+pub fn mirNamedAggregateType(name: String) -> String {
+    "%" + name
+}
+
+/// §8 LLVM-text emit-pass abbreviation helpers.
+
+/// mirEmitVoidCallStmt composes the canonical void-call statement:
+///   `call void @<sym>(<args>)`
+/// (No leading indent, no trailing newline — for sites that compose
+/// the line manually.)
+pub fn mirEmitVoidCallStmt(sym: String, args: String) -> String {
+    mirInstrCallVoid() + " void @" + sym + "(" + args + ")"
+}
+
+/// mirEmitValueCallStmt composes `<reg> = call <retTy> @<sym>(<args>)`.
+pub fn mirEmitValueCallStmt(reg: String, retTy: String, sym: String, args: String) -> String {
+    reg + " = " + mirInstrCall() + " " + retTy + " @" + sym + "(" + args + ")"
+}
+
+/// §8 LLVM-text noreturn-call shape helpers.
+
+/// mirCallNoReturnVoidLine renders the canonical noreturn-tagged
+/// void call: `call void @<sym>(<args>) #<attrId>\n`. The `#<attrId>`
+/// is a per-decl noreturn attribute group; we use `#1` by emitter
+/// convention for cold/noreturn helpers.
+pub fn mirCallNoReturnVoidLine(sym: String, args: String) -> String {
+    "  " + mirEmitVoidCallStmt(sym, args) + " #1\n"
+}
+
+/// mirCallNoReturnVoidNoArgsAttrLine renders the canonical noreturn-
+/// tagged no-arg void call.
+pub fn mirCallNoReturnVoidNoArgsAttrLine(sym: String) -> String {
+    "  " + mirInstrCallVoid() + " void @" + sym + "() #1\n"
+}
+
+/// §8 LLVM-text named-md-tuple helpers.
+
+/// mirNamedMDTuple renders the canonical named-MD-tuple emit line:
+///   `!<name> = !\{<entries>\}\n`
+/// Used at sites that emit module-level metadata (e.g. compile-unit
+/// reference, named subprogram list).
+pub fn mirNamedMDTuple(name: String, entries: String) -> String {
+    "!" + name + " = !\{" + entries + "\}\n"
+}
+
+/// mirNamedMDDistinctTuple renders `!<name> = distinct !\{<entries>\}\n`.
+pub fn mirNamedMDDistinctTuple(name: String, entries: String) -> String {
+    "!" + name + " = distinct !\{" + entries + "\}\n"
+}
+
+/// mirAnonymousMDTuple renders the canonical anonymous-MD-tuple ref:
+///   `!\{<entries>\}` (no leading `!<name> =`, no trailing newline)
+pub fn mirAnonymousMDTuple(entries: String) -> String {
+    "!\{" + entries + "\}"
+}
+
+/// §9 LLVM-text emit-pass section markers.
+
+/// mirSectionDeclares renders the canonical "; declares" header.
+pub fn mirSectionDeclares() -> String {
+    "; declares\n"
+}
+
+/// mirSectionGlobals renders the canonical "; globals" header.
+pub fn mirSectionGlobals() -> String {
+    "; globals\n"
+}
+
+/// mirSectionFunctions renders the canonical "; functions" header.
+pub fn mirSectionFunctions() -> String {
+    "; functions\n"
+}
+
+/// mirSectionMetadata renders the canonical "; metadata" header.
+pub fn mirSectionMetadata() -> String {
+    "; metadata\n"
+}
+
+/// mirSectionPrelude renders the canonical "; prelude" header.
+pub fn mirSectionPrelude() -> String {
+    "; prelude\n"
+}
+
+/// mirSectionEpilogue renders the canonical "; epilogue" header.
+pub fn mirSectionEpilogue() -> String {
+    "; epilogue\n"
+}
+
+/// §9 LLVM-text reference-encoding helpers.
+
+/// mirGlobalRef renders the canonical address-of-global expression
+/// without type prefix: `@<sym>`. Sibling of `mirArgSlotPtr` /
+/// `mirAddrOfGlobal` for the no-type-prefix usage path.
+pub fn mirGlobalRef(sym: String) -> String {
+    "@" + sym
+}
+
+/// mirRegRef renders `%<name>` — the canonical local-register
+/// reference (no type prefix).
+pub fn mirRegRef(name: String) -> String {
+    "%" + name
+}
+
+/// mirMDRef renders `!<name>` — the canonical metadata reference.
+pub fn mirMDRef(name: String) -> String {
+    "!" + name
+}
+
+/// §9 LLVM-text label-emit shape helpers.
+
+/// mirLabelHeaderLine renders `<name>:\n` — the canonical block
+/// header. Sibling of `mirBlockHeaderLine` named for the
+/// terminator-end-of-block usage.
+pub fn mirLabelHeaderLine(name: String) -> String {
+    name + ":\n"
+}
+
+/// mirJumpToLabelLine renders `  br label %<dst>\n` — the
+/// canonical unconditional jump. Sibling of `mirBrLabelLine`.
+pub fn mirJumpToLabelLine(dst: String) -> String {
+    mirBrLabelLine(dst)
+}
+
+/// §9 LLVM-text typed-arg list extension helpers — for arg lists
+/// the emitter forms incrementally.
+
+/// mirAppendArgPtr appends `, ptr <reg>` to an existing arg list.
+pub fn mirAppendArgPtr(prev: String, reg: String) -> String {
+    prev + ", ptr " + reg
+}
+
+/// mirAppendArgI64 appends `, i64 <reg>` to an existing arg list.
+pub fn mirAppendArgI64(prev: String, reg: String) -> String {
+    prev + ", i64 " + reg
+}
+
+/// mirAppendArgI1 appends `, i1 <reg>` to an existing arg list.
+pub fn mirAppendArgI1(prev: String, reg: String) -> String {
+    prev + ", i1 " + reg
+}
+
+/// mirAppendArgDouble appends `, double <reg>` to an existing arg
+/// list.
+pub fn mirAppendArgDouble(prev: String, reg: String) -> String {
+    prev + ", double " + reg
+}
+
+/// mirAppendArgI8 appends `, i8 <reg>` to an existing arg list.
+pub fn mirAppendArgI8(prev: String, reg: String) -> String {
+    prev + ", i8 " + reg
+}
+
+/// mirAppendArgI32 appends `, i32 <reg>` to an existing arg list.
+pub fn mirAppendArgI32(prev: String, reg: String) -> String {
+    prev + ", i32 " + reg
+}
+
+/// §9 LLVM-text list-len / list-isEmpty common shape composers.
+
+/// mirCallListLenLine renders the canonical list-len call:
+///   `<reg> = call i64 @osty_rt_list_len(ptr <list>)`
+/// Specialisation of `mirCallValueListLenLine` named for the
+/// value-only call (no alias-scope tag).
+pub fn mirCallListLenLine(reg: String, listReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtListLenSymbolName() + "(ptr " + listReg + ")\n"
+}
+
+/// mirCallListIsEmptyLine renders the canonical list-isEmpty call.
+pub fn mirCallListIsEmptyLine(reg: String, listReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i1 @" + mirRtListIsEmptySymbol() + "(ptr " + listReg + ")\n"
+}
+
+/// mirCallMapLenLine renders the canonical map-len call.
+pub fn mirCallMapLenLine(reg: String, mapReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtMapLenSymbolName() + "(ptr " + mapReg + ")\n"
+}
+
+/// mirCallSetLenLine renders the canonical set-len call.
+pub fn mirCallSetLenLine(reg: String, setReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtSetLenSymbolName() + "(ptr " + setReg + ")\n"
+}
+
+/// mirCallBytesLenLine renders the canonical bytes-len call.
+pub fn mirCallBytesLenLine(reg: String, bytesReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtBytesLenSymbolName() + "(ptr " + bytesReg + ")\n"
+}
+
+/// §9 LLVM-text loop-iter increment shape helpers.
+
+/// mirIncrementLoopCounterLine renders `<next> = add i64 <i>, 1\n`
+/// — the canonical loop-counter increment. Sibling of
+/// `mirIncrementI64Line` named for the loop-counter usage path.
+pub fn mirIncrementLoopCounterLine(nextReg: String, iReg: String) -> String {
+    mirAddIntLine(nextReg, mirTypeI64(), iReg, "1")
+}
+
+/// mirDecrementLoopCounterLine renders the canonical loop-counter
+/// decrement.
+pub fn mirDecrementLoopCounterLine(nextReg: String, iReg: String) -> String {
+    mirSubIntLine(nextReg, mirTypeI64(), iReg, "1")
+}
+
+/// §9 LLVM-text typed-load-store with align tag composite helpers.
+
+/// mirLoadStoreLine renders the canonical load + store 2-line
+/// pattern (read-modify-write style):
+///   `<tmpReg> = load <ty>, ptr <src>\n  store <ty> <tmpReg>, ptr <dst>\n`
+pub fn mirLoadStoreLine(tmpReg: String, ty: String, src: String, dst: String) -> String {
+    "  " + tmpReg + " = " + mirInstrLoad() + " " + ty + ", ptr " + src + "\n" +
+    "  " + mirInstrStore() + " " + ty + " " + tmpReg + ", ptr " + dst + "\n"
+}
+
+/// mirLoadStoreI64Line / I1Line / PtrLine / DoubleLine — typed
+/// load+store specialisations.
+pub fn mirLoadStoreI64Line(tmpReg: String, src: String, dst: String) -> String {
+    mirLoadStoreLine(tmpReg, mirTypeI64(), src, dst)
+}
+
+pub fn mirLoadStoreI1Line(tmpReg: String, src: String, dst: String) -> String {
+    mirLoadStoreLine(tmpReg, mirTypeI1(), src, dst)
+}
+
+pub fn mirLoadStorePtrLine(tmpReg: String, src: String, dst: String) -> String {
+    mirLoadStoreLine(tmpReg, mirTypePtr(), src, dst)
+}
+
+pub fn mirLoadStoreDoubleLine(tmpReg: String, src: String, dst: String) -> String {
+    mirLoadStoreLine(tmpReg, mirTypeDouble(), src, dst)
+}
+
+/// §9 LLVM-text label-helper specialisations — for the canonical
+/// label names the emitter uses.
+
+/// mirLabelOk renders the canonical "ok" label name (e.g. for a
+/// match-arm exit).
+pub fn mirLabelOk() -> String {
+    "ok"
+}
+
+/// mirLabelErr renders the canonical "err" label name.
+pub fn mirLabelErr() -> String {
+    "err"
+}
+
+/// mirLabelDone renders the canonical "done" label name.
+pub fn mirLabelDone() -> String {
+    "done"
+}
+
+/// mirLabelLoopHead renders the canonical "loop.head" label name.
+pub fn mirLabelLoopHead() -> String {
+    "loop.head"
+}
+
+/// mirLabelLoopBody renders the canonical "loop.body" label name.
+pub fn mirLabelLoopBody() -> String {
+    "loop.body"
+}
+
+/// mirLabelLoopExit renders the canonical "loop.exit" label name.
+pub fn mirLabelLoopExit() -> String {
+    "loop.exit"
+}
+
+/// mirLabelLoopLatch renders the canonical "loop.latch" label name.
+pub fn mirLabelLoopLatch() -> String {
+    "loop.latch"
+}
+
+/// mirLabelMatchArm renders the canonical "match.arm" label name
+/// prefix (caller appends the arm index).
+pub fn mirLabelMatchArmPrefix() -> String {
+    "match.arm"
+}
+
+/// mirLabelMatchExit renders the canonical "match.exit" label name.
+pub fn mirLabelMatchExit() -> String {
+    "match.exit"
+}
+
+/// mirLabelIfThen renders the canonical "if.then" label name.
+pub fn mirLabelIfThen() -> String {
+    "if.then"
+}
+
+/// mirLabelIfElse renders the canonical "if.else" label name.
+pub fn mirLabelIfElse() -> String {
+    "if.else"
+}
+
+/// mirLabelIfEnd renders the canonical "if.end" label name.
+pub fn mirLabelIfEnd() -> String {
+    "if.end"
+}
+
+/// mirLabelOptionSome renders the canonical "option.some" label name.
+pub fn mirLabelOptionSome() -> String {
+    "option.some"
+}
+
+/// mirLabelOptionNone renders the canonical "option.none" label name.
+pub fn mirLabelOptionNone() -> String {
+    "option.none"
+}
+
+/// mirLabelResultOk renders the canonical "result.ok" label name.
+pub fn mirLabelResultOk() -> String {
+    "result.ok"
+}
+
+/// mirLabelResultErr renders the canonical "result.err" label name.
+pub fn mirLabelResultErr() -> String {
+    "result.err"
+}


### PR DESCRIPTION
## Summary

2,083-line slice of the MIR emitter port (Go → Osty self-host).

### §7 emit-pass / lowering helpers

- Per-block + per-instruction trace comment helpers
- Predicate-value composers (icmp/fcmp without leading SSA assign)
- Alias-scope / noalias / access-group metadata-tagged store/load shapes
- **Fixed-symbol composers** — drain inline `"osty_rt_*"` literals across List/Map/Set/Bytes/String/Cancel/Chan/Thread/Bench/Test namespaces + bare `panic`/`abort`/`unwrap`/to-string/`parallel`/`race`/`task_group`
- Type-text composers (List/Map/Set/Option/Result aggregate aliases)
- Option / Result discriminant + payload extract / aggregate-construction shapes
- Panic / abort 2-line trap composers
- 3-line conditional-branch guard pattern
- Loop-prelude block-label aliases (Header/Body/Exit/Latch)
- Range-loop init / bound preamble shapes
- Vector-list snapshot 2-line composite

### §8 monomorphisation / signature / param-list / metadata helpers

- Monomorph / generic-instance / closure-sig key composers
- LLVM fn-signature / fn-pointer-type composers
- Param-list shape helpers + env-prefixed param-list composites
- Osty-side fn/method/closure/vtable/pool symbol-name composers
- Local SSA / param / temp / block-label name composers
- Alias-scope metadata-node body / reference helpers
- Comma / space joiner for variadic parts
- Constant-array / constant-struct body composers
- Typed constant-fragment composers
- Annotation-purpose comment helpers (safepoint/vectorize/parallel/inline/hot/cold)
- Typed param-binding (alloca + store) 2-line shapes
- GC-root setup composite helpers
- N-line concatenation helpers (mirBuildLines2-5)
- LLVM type-alias emit / reference composers
- Call-instruction stmt composers (no indent/newline)
- Noreturn-tagged void-call shapes
- Named / distinct / anonymous metadata-tuple emit shapes

### §9 emit-pass section markers / label-name tokens

- Section-marker comment helpers (declares/globals/functions/metadata/prelude/epilogue)
- LLVM-text reference encoders (`@`, `%`, `!` prefixed)
- Label-emit aliases for terminator-block usage
- Incremental typed-arg list extension helpers
- Container-len / isEmpty common shape composers
- Loop-counter increment / decrement aliases
- 2-line typed load+store (read-modify-write) shapes
- Canonical label-name tokens (ok/err/done/loop.\*/match.\*/if.\*/option.\*/result.\*)

### Drained inline sites in `mir_generator.go`

- `osty_rt_list_oob_abort_v1` → `mirRtListOOBAbortSymbol()`
- `osty_rt_option_unwrap_none` → `mirRtOptionUnwrapNoneSymbol()`
- `osty_rt_list_{is_empty,reverse,reversed,remove_at_discard,pop_discard}` → `mirRtList*Symbol()`
- `osty_rt_map_new` → `mirRtMapNewSymbol()`
- `osty_rt_bytes_{len,is_empty,get}` → `mirRtBytes*Symbol()`
- `osty_rt_cancel_{is_cancelled,check_cancelled}` → `mirRtCancel*Symbol()`
- `osty_rt_thread_{yield,sleep}` → `mirRtThread*Symbol()`
- `osty_rt_strings_{DiffLines,Concat,ConcatN}` → `mirRtString*Symbol()`
- `osty_rt_test_snapshot` → `mirRtTestSnapshotSymbol()`
- `osty_rt_{int,float,bool,char,byte}_to_string` → `mirRt*ToStringSymbol()`
- `osty_rt_list_primitive_to_string` → `mirRtListPrimitiveToStringSymbol()`
- `osty_rt_bench_{now_nanos,target_ns}` → `mirRtBench*Symbol()`

### Mirrored everything in `mir_generator_snapshot.go`. Updated `MIR_EMITTER_PORT.md` inventory.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — only 5 pre-existing failures (identical to baseline before this branch)