### PR TITLE
refactor(llvmgen): port 200+ §14-§17 aggregate-construction / typed-call composite shape builders

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -757,6 +757,55 @@ The historical rules:
 | `mirRefToGlobal` / `mirRefToMD` / `mirRefToReg` | `(name) -> String` | §12 | Reference-encoding semantic aliases |
 | `mirTypedZeroForLine` / `mirTypedOneForLine` | `(ty) -> String` | §12 | Typed-zero / typed-one constant composites |
 | `mirOptionNoneConst` / `mirOptionPtrNoneConst` / `mirResultOkUnitConst` / `mirResultErrPtrConst` | `([err]) -> String` | §12 | Canonical zero-aggregate constant composites |
+| `mirOptionSomeI64BuildLine` / `SomePtrBuildLine` / `mirResultOk{I64,Ptr}BuildLine` / `mirResultErrPtrBuildLine` | `(args...) -> String` | §14 | 2-line Option/Result aggregate-construction shapes |
+| `mirOption{,Ptr}UnwrapDestructureLine` / `mirResultUnwrapDestructureLine` | `(disc, payload, agg) -> String` | §14 | 2-line discriminant+payload extract composites |
+| `mirOptionIs{Some,None}Line` / `mirResultIs{Ok,Err}Line` | `(disc, isReg, agg) -> String` | §14 | 2-line discriminant test composites |
+| `mirBranchOn{Option,Result}DiscLine` | `(args...) -> String` | §14 | 3-line discriminant-branch composites |
+| `mirInternedStringPoolLine` / `mirInternedFormatPoolLine` | `(args...) -> String` | §14 | String/format pool emit aliases |
+| `mirArgPtrCastFromI64Line` / `mirArgI64CastFromPtrLine` | `(reg, val) -> String` | §14 | Cast-arg shape aliases |
+| `mirForRangePreludeLine` / `mirForRangeHeadLine` | `(args...) -> String` | §14 | For-range loop prelude / head composites |
+| `mirMatchArmHeadLine` / `mirMatchArmBodyLine` | `(args...) -> String` | §14 | Match-arm head / body shape composers |
+| `mirArrayBoundsCheckLine` | `(args...) -> String` | §14 | 4-line array bounds check composite |
+| `mirVectorListSnapshot3Line` | `(args...) -> String` | §14 | 3-line vector-list snapshot + branch composite |
+| `mirCastFPToSIWithRTZLine` / `mirCastSIToFPDefaultLine` | `(reg, fromTy, val, toTy) -> String` | §14 | FP-cast semantic aliases |
+| `mirAllocaThenMemcpyLine` | `(args...) -> String` | §14 | Alloca + memcpy 2-line composite |
+| `mirEmitOption{None,NonePtr}Line` | `(reg) -> String` | §14 | Canonical None aggregate emit (1-line) |
+| `mirInterned{I64,Ptr}GlobalLine` / `mirMutable{I64,Ptr}GlobalLine` | `(args...) -> String` | §14 | Module-globals emit aliases |
+| `mirCall{I64,I1,Ptr}NoArgsAndStoreLine` | `(reg, sym, slot) -> String` | §14 | Call-and-store 2-line shapes |
+| `mirLoadPtrThenCall{Void,Value,I64,I1}Line` | `(args...) -> String` | §15 | Load + call 2-line shapes |
+| `mirICmp{Eq,Ne,Slt,Sgt,Sle,Sge}I64ThenBranchLine` / `mirICmpEqPtrThenBranchLine` / `mirICmpNullPtrThenBranchLine` | `(args...) -> String` | §15 | Predicate + branch 2-line shapes |
+| `mirRuntimeProbeAndStoreLine` | `(args...) -> String` | §15 | Generic call + store 2-line shape |
+| `mirLoadI64ThenCmp{Eq,Ne,Zero}Line` / `mirLoadPtrThenCmpNullLine` | `(args...) -> String` | §15 | Load + cmp 2-line shapes |
+| `mirLoadI1ThenStoreLine` / `mirLoadDoubleThenStoreLine` | `(args...) -> String` | §15 | Load + store typed shapes |
+| `mirCallVoidWithI64ResultLine` | `(reg, sym, slot) -> String` | §15 | Alias for call-and-store i64 |
+| `mirReturnConstant{I64,Ptr,I1,Double}Line` / `mirReturn{ZeroI64,NullPtr,FalseI1,TrueI1,ZeroDouble}Line` | `([val]) -> String` | §15 | Return-constant 1-line shapes |
+| `mirArgListPtrPtr` / `mirArgListPtrI64Slot` / `mirArgListThreePtrSlot` | `(args...) -> String` | §15 | Arg-list shape aliases |
+| `mirAddI64ImmediateThenStoreLine` / `mirSubI64ImmediateThenStoreLine` | `(args...) -> String` | §15 | Arith + store composites |
+| `mirIfThenElseSkeletonLine` | `(args...) -> String` | §15 | If-then-else block skeleton composite |
+| `mirStoreOption{,Ptr}AggregateLine` / `mirStoreResult{,Ptr}AggregateLine` | `(agg, slot) -> String` | §15 | Aggregate-store 1-line shapes |
+| `mirLoadOption{,Ptr}AggregateLine` / `mirLoadResult{,Ptr}AggregateLine` | `(reg, slot) -> String` | §15 | Aggregate-load 1-line shapes |
+| `mirCall{Sqrt,FAbs,Sin,Cos,Tan,Log,Log2,Log10,Exp,Exp2,Pow,MinNum,MaxNum}DoubleLine` | `(reg, args...) -> String` | §16 | LLVM math intrinsic call aliases |
+| `mirCall{Ctlz,Cttz,Ctpop,BSwap{I64,I32,I16},BitReverse}I64Line` | `(reg, x) -> String` | §16 | LLVM bit-manip intrinsic call aliases |
+| `mirCallLifetime{Start,End}Line` / `mirCallAssumeLine` / `mirCallExpectI1Line` | `(args...) -> String` | §16 | Lifetime / assume / branch-hint call aliases |
+| `mirCallMemcpy{Volatile,NonVolatile}Line` / `mirCallMemmoveNonVolatileLine` / `mirCallMemsetZeroLine` | `(args...) -> String` | §16 | Memcpy/memmove/memset typed call shapes |
+| `mirCallTest{Abort,ContextEnter,ContextExit,ExpectOk,ExpectError}Line` | `(args...) -> String` | §16 | Test-runtime call aliases |
+| `mirCallBench{NowNanos,TargetNs}Line` / `mirCallGC{Alloc,Safepoint,Barrier,AllocatedBytes}Line` / `mirCallDiffLinesLine` | `(args...) -> String` | §16 | Bench / GC / diff-debug call aliases |
+| `mirCallVoidWithI1ResultDiscardLine` | `(reg, sym, args) -> String` | §16 | Discard-result i1-call shape |
+| `mirSpillOption{,Ptr}AggregateLine` / `mirSpillResult{,Ptr}AggregateLine` | `(slot, agg) -> String` | §16 | Aggregate spill 2-line composites |
+| `mirArgListFour/Five/SixMixed` | `(args...) -> String` | §16 | Pre-typed 4/5/6-elem arg-list joiners |
+| `mirModulePreambleLine` / `mirModuleEpilogueLine` | `(args...) -> String` | §16 | Module preamble (3-line) / epilogue composites |
+| `mirCastI64ToPtrThenCallLine` / `mirCastPtrToI64ThenCallLine` | `(args...) -> String` | §16 | Cast + call 2-line composites |
+| `mirZExtI{8,1}ToI64ThenCallLine` | `(args...) -> String` | §16 | ZExt + call 2-line composites |
+| `mirTruncI64To{I8,I1,I32}ThenStoreLine` | `(args...) -> String` | §16 | Trunc + store 2-line composites |
+| `mirCallList{Length,Reverse,Reversed,Clear,PopDiscard,IsEmptyTyped}Line` | `(args...) -> String` | §17 | Typed list runtime call composites |
+| `mirCall{Map,Set}LengthLine` / `mirCallStringLengthLine` / `mirCallBytesLengthLine` | `(reg, handle) -> String` | §17 | Typed length / size runtime call composites |
+| `mirCallSetToListLine` / `mirCallMap{Values,Entries}Line` | `(reg, handle) -> String` | §17 | Container conversion call composites |
+| `mirCallChannel{Close,IsClosed,Len,Cap}Line` | `(args...) -> String` | §17 | Channel-state runtime call composites |
+| `mirCallCancel{Check,IsCancelled,Cancel}Line` / `mirCallThread{Yield,Sleep}Line` | `(args...) -> String` | §17 | Cancel / thread runtime call composites |
+| `mirCallString{ConcatTwo,Hash,IsEmpty,ToUpper,ToLower,Trim,Repeat}Line` | `(reg, args...) -> String` | §17 | String runtime operation call composites |
+| `mirCallBytes{IsEmpty,GetTyped,Contains,StartsWith,EndsWith}Line` | `(reg, args...) -> String` | §17 | Bytes runtime operation call composites |
+| `mirCallMap{Insert,Remove}Line` / `mirCallSet{Add,Remove}Line` | `(handle, args) -> String` | §17 | Map / set mutation call composites |
+| `mirCallTaskGroup{New,Cancel,IsCancelled}Line` / `mirCallTaskHandleJoinLine` / `mirCallTaskCollectAllLine` / `mirCallTaskRaceLine` | `(args...) -> String` | §17 | Structured-concurrency runtime call composites |
 
 Keep this table updated as each section lands. New entries go in
 insertion order so the provenance columns (`Origin §`) stay useful as

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2362,7 +2362,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 					return nil
 				}
 			}
-			sym := "osty_rt_list_set_" + listRuntimeSymbolSuffix(elemLLVM)
+			sym := mirRtListSetSuffixSymbol(listRuntimeSymbolSuffix(elemLLVM))
 			g.declareRuntime(sym, mirRuntimeDeclareListSetSimpleLine(sym, elemLLVM))
 			g.fnBuf.WriteString(mirCallVoidListPtrI64ValueLine(sym, contReg, idxReg, elemLLVM, valReg))
 			return nil
@@ -3685,10 +3685,10 @@ func (g *mirGen) tryEmitInterfaceDowncast(c *mir.CallInstr, fnRef *mir.FnRef) (b
 	g.fnBuf.WriteString(mirPtrToIntLine(payload, optPtr, "i64"))
 
 	optStep1 := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(optStep1, optLLVM, "undef", "i64", disc, "0"))
+	g.fnBuf.WriteString(mirInsertValueI64Line(optStep1, optLLVM, "undef", disc, "0"))
 
 	optFull := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(optFull, optLLVM, optStep1, "i64", payload, "1"))
+	g.fnBuf.WriteString(mirInsertValueI64Line(optFull, optLLVM, optStep1, payload, "1"))
 
 	g.fnBuf.WriteString(mirStoreLine(optLLVM, optFull, g.localSlots[c.Dest.Local]))
 	return true, nil
@@ -4685,7 +4685,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if !keyString {
 			suffix = llvmMapKeySuffix(keyLLVM, false)
 		}
-		sym := "osty_rt_map_keys_sorted_" + suffix
+		sym := mirRtMapKeysSortedSuffixSymbol(suffix)
 		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
 		tmp := g.fresh()
 		g.fnBuf.WriteString(mirCallValuePtrFromPtrLine(tmp, sym, mapReg))
@@ -6194,7 +6194,7 @@ func (g *mirGen) emitSelectSend(i *mir.IntrinsicInstr) error {
 	elemLLVM := g.llvmType(elemT)
 	if listUsesTypedRuntime(elemLLVM) {
 		suffix := llvmListElementSuffix(elemLLVM)
-		sym := "osty_rt_select_send_" + suffix
+		sym := mirRtSelectSendSuffixSymbol(suffix)
 		g.declareRuntime(sym, mirRuntimeDeclareSelectSendLine(sym, elemLLVM))
 		g.fnBuf.WriteString(mirCallVoidSelectSendLine(sym, builderReg, chReg, elemLLVM, valReg, armReg))
 		return nil
@@ -6911,7 +6911,7 @@ func (g *mirGen) emitEnumVariant(rv *mir.AggregateRV, aggT mir.Type) (string, er
 	// Step 1: insert discriminant.
 	disc := strconv.Itoa(rv.VariantIdx)
 	tmp1 := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(tmp1, aggLLVM, "undef", "i64", disc, "0"))
+	g.fnBuf.WriteString(mirInsertValueI64Line(tmp1, aggLLVM, "undef", disc, "0"))
 
 	// Step 2: insert payload. For single scalar payloads the value
 	// lives directly in the i64 slot. For no-payload variants we
@@ -6935,7 +6935,7 @@ func (g *mirGen) emitEnumVariant(rv *mir.AggregateRV, aggT mir.Type) (string, er
 		return "", unsupported("mir-mvp", fmt.Sprintf("enum variant with %d payload fields (only scalar / 0-arity supported)", len(rv.Fields)))
 	}
 	tmp2 := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueAggLine(tmp2, aggLLVM, tmp1, "i64", payloadI64, "1"))
+	g.fnBuf.WriteString(mirInsertValueI64Line(tmp2, aggLLVM, tmp1, payloadI64, "1"))
 	return tmp2, nil
 }
 
@@ -7513,7 +7513,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 						continue
 					}
 				}
-				sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
+				sym := mirRtListGetSuffixSymbol(listRuntimeSymbolSuffix(elemLLVM))
 				g.declareRuntime(sym, mirRuntimeDeclareLine(elemLLVM, sym, "ptr, i64"))
 				next := g.fresh()
 				g.fnBuf.WriteString(mirCallValueLine(next, elemLLVM, sym,

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -6801,3 +6801,793 @@ func mirGEPThenStorePtrLine(slotReg, ty, basePtr, idxDigits, val string) string 
 	return mirGEPPtrStrideLine(slotReg, basePtr, idxDigits) +
 		"  " + mirInstrStore() + " ptr " + val + ", ptr " + slotReg + "\n"
 }
+
+// §14 LLVM-text aggregate-construction composite shapes.
+
+// Osty: mirOptionSomeI64BuildLine / mirOptionSomePtrBuildLine /
+//       mirResultOk{I64,Ptr}BuildLine / mirResultErrPtrBuildLine
+func mirOptionSomeI64BuildLine(stepReg, fullReg, payload string) string {
+	return mirInsertValueI64Line(stepReg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantSome(), "0") +
+		mirInsertValueI64Line(fullReg, mirOptionAggregateType(), stepReg, payload, "1")
+}
+func mirOptionSomePtrBuildLine(stepReg, fullReg, payloadPtr string) string {
+	return mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantSome(), "0") +
+		mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, payloadPtr, "1")
+}
+func mirResultOkI64BuildLine(stepReg, fullReg, payload string) string {
+	return mirInsertValueI64Line(stepReg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantOk(), "0") +
+		mirInsertValueI64Line(fullReg, mirOptionAggregateType(), stepReg, payload, "1")
+}
+func mirResultOkPtrBuildLine(stepReg, fullReg, payloadPtr string) string {
+	return mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantOk(), "0") +
+		mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, payloadPtr, "1")
+}
+func mirResultErrPtrBuildLine(stepReg, fullReg, errPtr string) string {
+	return mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantErr(), "0") +
+		mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, errPtr, "1")
+}
+
+// §14 LLVM-text Option / Result destructure helpers.
+
+// Osty: mirOptionUnwrapDestructureLine / mirOptionPtrUnwrapDestructureLine /
+//       mirResultUnwrapDestructureLine
+func mirOptionUnwrapDestructureLine(discReg, payloadReg, agg string) string {
+	return mirOptionDiscProbeLine(discReg, agg) + mirOptionPayloadProbeLine(payloadReg, agg)
+}
+func mirOptionPtrUnwrapDestructureLine(discReg, payloadReg, agg string) string {
+	return mirOptionPtrDiscProbeLine(discReg, agg) + mirOptionPtrPayloadProbeLine(payloadReg, agg)
+}
+func mirResultUnwrapDestructureLine(discReg, payloadReg, agg string) string {
+	return mirResultDiscProbeLine(discReg, agg) + mirResultPayloadProbeLine(payloadReg, agg)
+}
+
+// §14 LLVM-text discriminant-comparison composite shapes.
+
+// Osty: mirOptionIsSomeLine / mirOptionIsNoneLine / mirResultIsOkLine / mirResultIsErrLine
+func mirOptionIsSomeLine(discReg, isSomeReg, agg string) string {
+	return mirOptionDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(isSomeReg, discReg, mirDiscriminantSome())
+}
+func mirOptionIsNoneLine(discReg, isNoneReg, agg string) string {
+	return mirOptionDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(isNoneReg, discReg, mirDiscriminantNone())
+}
+func mirResultIsOkLine(discReg, isOkReg, agg string) string {
+	return mirResultDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(isOkReg, discReg, mirDiscriminantOk())
+}
+func mirResultIsErrLine(discReg, isErrReg, agg string) string {
+	return mirResultDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(isErrReg, discReg, mirDiscriminantErr())
+}
+
+// §14 LLVM-text branch-on-discriminant composite shapes.
+
+// Osty: mirBranchOnOptionDiscLine / mirBranchOnResultDiscLine
+func mirBranchOnOptionDiscLine(discReg, cmpReg, agg, someLbl, noneLbl string) string {
+	return mirOptionDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(cmpReg, discReg, mirDiscriminantSome()) +
+		mirBrCondLine(cmpReg, someLbl, noneLbl)
+}
+func mirBranchOnResultDiscLine(discReg, cmpReg, agg, okLbl, errLbl string) string {
+	return mirResultDiscProbeLine(discReg, agg) +
+		mirICmpI64EqLine(cmpReg, discReg, mirDiscriminantOk()) +
+		mirBrCondLine(cmpReg, okLbl, errLbl)
+}
+
+// §14 LLVM-text typed-string-pool global emit helpers.
+
+// Osty: mirInternedStringPoolLine / mirInternedFormatPoolLine
+func mirInternedStringPoolLine(sym, sizeDigits, encoded string) string {
+	return mirGlobalStringPoolDeclLine(sym, sizeDigits, encoded)
+}
+func mirInternedFormatPoolLine(sym, sizeDigits, encoded string) string {
+	return mirGlobalStringPoolDeclLine(sym, sizeDigits, encoded)
+}
+
+// §14 LLVM-text typed-cast call-arg shape composers.
+
+// Osty: mirArgPtrCastFromI64Line / mirArgI64CastFromPtrLine
+func mirArgPtrCastFromI64Line(castReg, val string) string {
+	return mirCastI64ToPtrLine(castReg, val)
+}
+func mirArgI64CastFromPtrLine(castReg, val string) string {
+	return mirCastPtrToI64Line(castReg, val)
+}
+
+// §14 LLVM-text Range / Iter shape composite helpers.
+
+// Osty: mirForRangePreludeLine / mirForRangeHeadLine
+func mirForRangePreludeLine(slotReg, start, headLbl string) string {
+	return mirAllocaInitI64Line(slotReg, start) + mirBrLabelLine(headLbl)
+}
+func mirForRangeHeadLine(headLbl, iReg, slot, cmpReg, bound, bodyLbl, exitLbl string) string {
+	return mirBlockHeaderLine(headLbl) +
+		mirLoadI64Line(iReg, slot) +
+		mirICmpI64SltLine(cmpReg, iReg, bound) +
+		mirBrCondLine(cmpReg, bodyLbl, exitLbl)
+}
+
+// §14 LLVM-text Match-arm head-body shape helpers.
+
+// Osty: mirMatchArmHeadLine / mirMatchArmBodyLine
+func mirMatchArmHeadLine(idxDigits string) string {
+	return mirLabelMatchArmPrefix() + "." + idxDigits + ":\n"
+}
+func mirMatchArmBodyLine(exitLbl string) string {
+	return mirBrLabelLine(exitLbl)
+}
+
+// §14 LLVM-text bounds-check composite shapes.
+
+// Osty: mirArrayBoundsCheckLine
+func mirArrayBoundsCheckLine(nonNegReg, ltLenReg, andReg, idx, lenReg, okLbl, oobLbl string) string {
+	return mirICmpI64SgeLine(nonNegReg, idx, "0") +
+		mirICmpI64SltLine(ltLenReg, idx, lenReg) +
+		mirAndI1Line(andReg, nonNegReg, ltLenReg) +
+		mirBrCondLine(andReg, okLbl, oobLbl)
+}
+
+// §14 LLVM-text vector-list snapshot 3-line composite.
+
+// Osty: mirVectorListSnapshot3Line
+func mirVectorListSnapshot3Line(dataReg, dataSym, lenReg, listReg, scopeRef, headLbl string) string {
+	return mirVectorListSnapshot2Line(dataReg, dataSym, lenReg, listReg, scopeRef) +
+		mirBrLabelLine(headLbl)
+}
+
+// §14 LLVM-text typed-numerical-cast composites.
+
+// Osty: mirCastFPToSIWithRTZLine / mirCastSIToFPDefaultLine
+func mirCastFPToSIWithRTZLine(reg, fromTy, val, toTy string) string {
+	return mirFPToSILine(reg, fromTy, val, toTy)
+}
+func mirCastSIToFPDefaultLine(reg, fromTy, val, toTy string) string {
+	return mirSIToFPLine(reg, fromTy, val, toTy)
+}
+
+// §14 Generic memcpy composite — alloca + memcpy 2-line.
+
+// Osty: mirAllocaThenMemcpyLine
+func mirAllocaThenMemcpyLine(slotReg, ty, src, sizeBytesDigits string) string {
+	return mirAllocaSingleLine(slotReg, ty) +
+		mirCallVoidLLVMMemcpyLine(slotReg, src, sizeBytesDigits, "false")
+}
+
+// §14 LLVM-text typed-aggregate field-extract composite shapes.
+
+// Osty: mirExtractValueI64FieldLine
+func mirExtractValueI64FieldLine(reg, aggTy, agg, idx string) string {
+	return mirExtractValueI64Line(reg, aggTy, agg, idx)
+}
+
+// §14 LLVM-text canonical zero-aggregate emit helpers.
+
+// Osty: mirEmitOptionNoneI64Line / mirEmitOptionNonePtrLine
+func mirEmitOptionNoneI64Line(reg string) string {
+	return mirInsertValueI64Line(reg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantNone(), "0")
+}
+func mirEmitOptionNonePtrLine(reg string) string {
+	return mirInsertValueI64Line(reg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantNone(), "0")
+}
+
+// §14 Module-globals helpers.
+
+// Osty: mirInternedI64GlobalLine / mirInternedPtrGlobalLine /
+//       mirMutableI64GlobalLine / mirMutablePtrGlobalLine
+func mirInternedI64GlobalLine(sym, val string) string {
+	return mirGlobalConstantI64DeclLine(sym, val)
+}
+func mirInternedPtrGlobalLine(sym, val string) string {
+	return mirGlobalConstantPtrDeclLine(sym, val)
+}
+func mirMutableI64GlobalLine(sym, init string) string {
+	return mirGlobalMutableI64DeclLine(sym, init)
+}
+func mirMutablePtrGlobalLine(sym, init string) string {
+	return mirGlobalMutablePtrDeclLine(sym, init)
+}
+
+// §14 LLVM-text typed-call-shape with no-args + result-store
+// composite helpers.
+
+// Osty: mirCallI64NoArgsAndStoreLine / mirCallI1NoArgsAndStoreLine /
+//       mirCallPtrNoArgsAndStoreLine
+func mirCallI64NoArgsAndStoreLine(reg, sym, slot string) string {
+	return mirCallI64NoArgsLine(reg, sym) +
+		"  " + mirInstrStore() + " i64 " + reg + ", ptr " + slot + "\n"
+}
+func mirCallI1NoArgsAndStoreLine(reg, sym, slot string) string {
+	return mirCallI1NoArgsLine(reg, sym) +
+		"  " + mirInstrStore() + " i1 " + reg + ", ptr " + slot + "\n"
+}
+func mirCallPtrNoArgsAndStoreLine(reg, sym, slot string) string {
+	return mirCallPtrNoArgsLine(reg, sym) +
+		"  " + mirInstrStore() + " ptr " + reg + ", ptr " + slot + "\n"
+}
+
+// §15 LLVM-text load-then-call composite helpers.
+
+// Osty: mirLoadPtrThenCall{Void,Value,I64,I1}Line
+func mirLoadPtrThenCallVoidLine(reg, slot, sym string) string {
+	return mirLoadPtrLine(reg, slot) + mirCallVoidPtrLine(sym, reg)
+}
+func mirLoadPtrThenCallValueLine(loadReg, slot, resultReg, sym string) string {
+	return mirLoadPtrLine(loadReg, slot) + mirCallValuePtrFromPtrLine(resultReg, sym, loadReg)
+}
+func mirLoadPtrThenCallI64Line(loadReg, slot, resultReg, sym string) string {
+	return mirLoadPtrLine(loadReg, slot) + mirCallValueI64FromPtrLine(resultReg, sym, loadReg)
+}
+func mirLoadPtrThenCallI1Line(loadReg, slot, resultReg, sym string) string {
+	return mirLoadPtrLine(loadReg, slot) + mirCallValueI1FromPtrLine(resultReg, sym, loadReg)
+}
+
+// §15 LLVM-text predicate-then-branch composite helpers.
+
+// Osty: mirICmp{Eq,Ne,Slt,Sgt,Sle,Sge}I64ThenBranchLine / mirICmpEqPtrThenBranchLine /
+//       mirICmpNullPtrThenBranchLine
+func mirICmpEqI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64EqLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpNeI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64NeLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpSltI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64SltLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpSgtI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64SgtLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpSleI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64SleLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpSgeI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpI64SgeLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpEqPtrThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
+	return mirICmpPtrEqLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+func mirICmpNullPtrThenBranchLine(cmpReg, a, thenLbl, elseLbl string) string {
+	return mirICmpNullPtrLine(cmpReg, a) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+// §15 LLVM-text typed-runtime-call sequencing composites.
+
+// Osty: mirRuntimeProbeAndStoreLine
+func mirRuntimeProbeAndStoreLine(reg, retTy, sym, args, slot string) string {
+	return "  " + reg + " = " + mirInstrCall() + " " + retTy + " @" + sym + "(" + args + ")\n" +
+		"  " + mirInstrStore() + " " + retTy + " " + reg + ", ptr " + slot + "\n"
+}
+
+// §15 LLVM-text typed-load-then-cmp composite helpers.
+
+// Osty: mirLoadI64ThenCmp{Eq,Ne,Zero}Line / mirLoadPtrThenCmpNullLine
+func mirLoadI64ThenCmpEqLine(loadReg, slot, cmpReg, b string) string {
+	return mirLoadI64Line(loadReg, slot) + mirICmpI64EqLine(cmpReg, loadReg, b)
+}
+func mirLoadI64ThenCmpNeLine(loadReg, slot, cmpReg, b string) string {
+	return mirLoadI64Line(loadReg, slot) + mirICmpI64NeLine(cmpReg, loadReg, b)
+}
+func mirLoadI64ThenCmpZeroLine(loadReg, slot, cmpReg string) string {
+	return mirLoadI64Line(loadReg, slot) + mirICmpZeroI64Line(cmpReg, loadReg)
+}
+func mirLoadPtrThenCmpNullLine(loadReg, slot, cmpReg string) string {
+	return mirLoadPtrLine(loadReg, slot) + mirICmpNullPtrLine(cmpReg, loadReg)
+}
+
+// §15 LLVM-text typed-load-then-store composite helpers.
+
+// Osty: mirLoadI1ThenStoreLine / mirLoadDoubleThenStoreLine
+func mirLoadI1ThenStoreLine(loadReg, src, dst string) string {
+	return mirLoadStoreI1Line(loadReg, src, dst)
+}
+func mirLoadDoubleThenStoreLine(loadReg, src, dst string) string {
+	return mirLoadStoreDoubleLine(loadReg, src, dst)
+}
+
+// §15 LLVM-text typed-runtime-call composite shapes (no result).
+
+// Osty: mirCallVoidWithI64ResultLine
+func mirCallVoidWithI64ResultLine(reg, sym, slot string) string {
+	return mirCallI64NoArgsAndStoreLine(reg, sym, slot)
+}
+
+// §15 Common emit-pass shape composers — return-constant 1-line shapes.
+
+// Osty: mirReturnConstant{I64,Ptr,I1,Double}Line / mirReturn{ZeroI64,NullPtr,FalseI1,TrueI1,ZeroDouble}Line
+func mirReturnConstantI64Line(val string) string    { return mirRetTypedLine(mirTypeI64(), val) }
+func mirReturnConstantPtrLine(val string) string    { return mirRetTypedLine(mirTypePtr(), val) }
+func mirReturnConstantI1Line(val string) string     { return mirRetTypedLine(mirTypeI1(), val) }
+func mirReturnConstantDoubleLine(val string) string { return mirRetTypedLine(mirTypeDouble(), val) }
+func mirReturnZeroI64Line() string                  { return mirReturnConstantI64Line("0") }
+func mirReturnNullPtrLine() string                  { return mirReturnConstantPtrLine("null") }
+func mirReturnFalseI1Line() string                  { return mirReturnConstantI1Line("0") }
+func mirReturnTrueI1Line() string                   { return mirReturnConstantI1Line("1") }
+func mirReturnZeroDoubleLine() string               { return mirReturnConstantDoubleLine("0.0") }
+
+// §15 LLVM-text typed call-arg list compositions (siblings).
+
+// Osty: mirArgListPtrPtr / mirArgListPtrI64Slot / mirArgListThreePtrSlot
+func mirArgListPtrPtr(a, b string) string {
+	return mirArgSlotPtr(a) + ", " + mirArgSlotPtr(b)
+}
+func mirArgListPtrI64Slot(a, b string) string {
+	return mirArgSlotPtr(a) + ", " + mirArgSlotI64(b)
+}
+func mirArgListThreePtrSlot(a, b, c string) string {
+	return mirArgSlotPtr(a) + ", " + mirArgSlotPtr(b) + ", " + mirArgSlotPtr(c)
+}
+
+// §15 LLVM-text typed-i64-add-with-immediate composites.
+
+// Osty: mirAddI64ImmediateThenStoreLine / mirSubI64ImmediateThenStoreLine
+func mirAddI64ImmediateThenStoreLine(addReg, base, imm, slot string) string {
+	return mirAddI64ImmediateLine(addReg, base, imm) +
+		"  " + mirInstrStore() + " i64 " + addReg + ", ptr " + slot + "\n"
+}
+func mirSubI64ImmediateThenStoreLine(subReg, base, imm, slot string) string {
+	return mirSubI64ImmediateLine(subReg, base, imm) +
+		"  " + mirInstrStore() + " i64 " + subReg + ", ptr " + slot + "\n"
+}
+
+// §15 Block-builder composites — for typical 3-block "if-then-else"
+// pattern.
+
+// Osty: mirIfThenElseSkeletonLine
+func mirIfThenElseSkeletonLine(cmpReg, cond, thenLbl, elseLbl string) string {
+	return mirICmpI1NeLine(cmpReg, cond, "0") +
+		mirBrCondLine(cmpReg, thenLbl, elseLbl) +
+		mirBlockHeaderLine(thenLbl)
+}
+
+// §15 LLVM-text typed-aggregate-store composite helpers.
+
+// Osty: mirStoreOptionAggregateLine / mirStoreOptionPtrAggregateLine /
+//       mirStoreResultAggregateLine / mirStoreResultPtrAggregateLine
+func mirStoreOptionAggregateLine(agg, slot string) string {
+	return "  " + mirInstrStore() + " " + mirOptionAggregateType() + " " + agg + ", ptr " + slot + "\n"
+}
+func mirStoreOptionPtrAggregateLine(agg, slot string) string {
+	return "  " + mirInstrStore() + " " + mirOptionPtrAggregateType() + " " + agg + ", ptr " + slot + "\n"
+}
+func mirStoreResultAggregateLine(agg, slot string) string {
+	return mirStoreOptionAggregateLine(agg, slot)
+}
+func mirStoreResultPtrAggregateLine(agg, slot string) string {
+	return mirStoreOptionPtrAggregateLine(agg, slot)
+}
+
+// §15 LLVM-text typed-aggregate-load composite helpers.
+
+// Osty: mirLoadOptionAggregateLine / mirLoadOptionPtrAggregateLine /
+//       mirLoadResultAggregateLine / mirLoadResultPtrAggregateLine
+func mirLoadOptionAggregateLine(reg, slot string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " " + mirOptionAggregateType() + ", ptr " + slot + "\n"
+}
+func mirLoadOptionPtrAggregateLine(reg, slot string) string {
+	return "  " + reg + " = " + mirInstrLoad() + " " + mirOptionPtrAggregateType() + ", ptr " + slot + "\n"
+}
+func mirLoadResultAggregateLine(reg, slot string) string {
+	return mirLoadOptionAggregateLine(reg, slot)
+}
+func mirLoadResultPtrAggregateLine(reg, slot string) string {
+	return mirLoadOptionPtrAggregateLine(reg, slot)
+}
+
+// §16 LLVM-text intrinsic-builder helpers (semantic aliases).
+
+// Osty: mirCall{Sqrt,FAbs,Sin,Cos,Tan,Log,Log2,Log10,Exp,Exp2}DoubleLine
+func mirCallSqrtDoubleLine(reg, x string) string  { return mirCallValueLLVMSqrtF64Line(reg, x) }
+func mirCallFAbsDoubleLine(reg, x string) string  { return mirCallValueLLVMFAbsF64Line(reg, x) }
+func mirCallSinDoubleLine(reg, x string) string   { return mirCallValueLLVMSinF64Line(reg, x) }
+func mirCallCosDoubleLine(reg, x string) string   { return mirCallValueLLVMCosF64Line(reg, x) }
+func mirCallTanDoubleLine(reg, x string) string   { return mirCallValueLLVMTanF64Line(reg, x) }
+func mirCallLogDoubleLine(reg, x string) string   { return mirCallValueLLVMLogF64Line(reg, x) }
+func mirCallLog2DoubleLine(reg, x string) string  { return mirCallValueLLVMLog2F64Line(reg, x) }
+func mirCallLog10DoubleLine(reg, x string) string { return mirCallValueLLVMLog10F64Line(reg, x) }
+func mirCallExpDoubleLine(reg, x string) string   { return mirCallValueLLVMExpF64Line(reg, x) }
+func mirCallExp2DoubleLine(reg, x string) string  { return mirCallValueLLVMExp2F64Line(reg, x) }
+
+// Osty: mirCallPowDoubleLine / MinNumDoubleLine / MaxNumDoubleLine
+func mirCallPowDoubleLine(reg, base, exp string) string {
+	return mirCallValueLLVMPowF64Line(reg, base, exp)
+}
+func mirCallMinNumDoubleLine(reg, a, b string) string {
+	return mirCallValueLLVMMinNumF64Line(reg, a, b)
+}
+func mirCallMaxNumDoubleLine(reg, a, b string) string {
+	return mirCallValueLLVMMaxNumF64Line(reg, a, b)
+}
+
+// §16 LLVM-text bit-manipulation typed-call composites.
+
+// Osty: mirCall{Ctlz,Cttz,Ctpop,BSwapI{64,32,16},BitReverse}I64Line
+func mirCallCtlzI64Line(reg, x string) string       { return mirCallValueLLVMCtlzI64Line(reg, x) }
+func mirCallCttzI64Line(reg, x string) string       { return mirCallValueLLVMCttzI64Line(reg, x) }
+func mirCallCtpopI64Line(reg, x string) string      { return mirCallValueLLVMCtpopI64Line(reg, x) }
+func mirCallBSwapI64Line(reg, x string) string      { return mirCallValueLLVMBSwapI64Line(reg, x) }
+func mirCallBSwapI32Line(reg, x string) string      { return mirCallValueLLVMBSwapI32Line(reg, x) }
+func mirCallBSwapI16Line(reg, x string) string      { return mirCallValueLLVMBSwapI16Line(reg, x) }
+func mirCallBitReverseI64Line(reg, x string) string { return mirCallValueLLVMBitReverseI64Line(reg, x) }
+
+// §16 LLVM-text typed-runtime-callable lifetime intrinsics.
+
+// Osty: mirCallLifetime{Start,End}Line / mirCallAssumeLine / mirCallExpectI1Line
+func mirCallLifetimeStartLine(sizeBytes, slot string) string {
+	return mirCallVoidLLVMLifetimeStartLine(sizeBytes, slot)
+}
+func mirCallLifetimeEndLine(sizeBytes, slot string) string {
+	return mirCallVoidLLVMLifetimeEndLine(sizeBytes, slot)
+}
+func mirCallAssumeLine(cond string) string {
+	return mirCallVoidLLVMAssumeLine(cond)
+}
+func mirCallExpectI1Line(reg, cond, expected string) string {
+	return mirCallValueLLVMExpectI1Line(reg, cond, expected)
+}
+
+// §16 LLVM-text mem-intrinsic typed call shapes.
+
+// Osty: mirCallMemcpy{Volatile,NonVolatile}Line / MemmoveNonVolatileLine / MemsetZeroLine
+func mirCallMemcpyVolatileLine(dst, src, sizeBytes string) string {
+	return mirCallVoidLLVMMemcpyLine(dst, src, sizeBytes, "true")
+}
+func mirCallMemcpyNonVolatileLine(dst, src, sizeBytes string) string {
+	return mirCallVoidLLVMMemcpyLine(dst, src, sizeBytes, "false")
+}
+func mirCallMemmoveNonVolatileLine(dst, src, sizeBytes string) string {
+	return mirCallVoidLLVMMemmoveLine(dst, src, sizeBytes, "false")
+}
+func mirCallMemsetZeroLine(dst, sizeBytes string) string {
+	return mirCallVoidLLVMMemsetLine(dst, "0", sizeBytes, "false")
+}
+
+// §16 LLVM-text typed-runtime-callable testing helpers.
+
+// Osty: mirCallTest{Abort,ContextEnter,ContextExit,ExpectOk,ExpectError}Line
+func mirCallTestAbortLine(messagePtr string) string {
+	return mirCallVoidTestingAbortLine(messagePtr)
+}
+func mirCallTestContextEnterLine(nameReg string) string {
+	return mirCallVoidTestingContextEnterLine(nameReg)
+}
+func mirCallTestContextExitLine() string {
+	return mirCallVoidTestingContextExitLine()
+}
+func mirCallTestExpectOkLine(reg, resultReg string) string {
+	return mirCallValueTestingExpectOkLine(reg, resultReg)
+}
+func mirCallTestExpectErrorLine(reg, resultReg string) string {
+	return mirCallValueTestingExpectErrorLine(reg, resultReg)
+}
+
+// §16 LLVM-text typed runtime-callable bench helpers.
+
+// Osty: mirCallBench{NowNanos,TargetNs}Line
+func mirCallBenchNowNanosLine(reg string) string {
+	return mirCallValueBenchNowNanosLine(reg)
+}
+func mirCallBenchTargetNsLine(reg string) string {
+	return mirCallValueBenchTargetNsLine(reg)
+}
+
+// §16 LLVM-text typed-runtime-callable GC helpers.
+
+// Osty: mirCallGC{Alloc,Safepoint,Barrier,AllocatedBytes}Line
+func mirCallGCAllocLine(reg, sizeBytes, kind string) string {
+	return mirCallValueGCAllocLine(reg, sizeBytes, kind)
+}
+func mirCallGCSafepointLine(slotsPtr, slotCount string) string {
+	return mirCallVoidGCSafepointLine(slotsPtr, slotCount)
+}
+func mirCallGCBarrierLine(targetPtr, valuePtr string) string {
+	return mirCallVoidGCBarrierLine(targetPtr, valuePtr)
+}
+func mirCallGCAllocatedBytesLine(reg string) string {
+	return mirCallValueGCAllocatedBytesLine(reg)
+}
+
+// §16 LLVM-text typed runtime-callable string-debug helpers.
+
+// Osty: mirCallDiffLinesLine
+func mirCallDiffLinesLine(reg, expectedReg, actualReg string) string {
+	return mirCallValueStringDiffLinesLine(reg, expectedReg, actualReg)
+}
+
+// §16 LLVM-text typed-call-and-no-store composites.
+
+// Osty: mirCallVoidWithI1ResultDiscardLine
+func mirCallVoidWithI1ResultDiscardLine(reg, sym, args string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i1 @" + sym + "(" + args + ")\n"
+}
+
+// §16 LLVM-text option/result spilling helpers.
+
+// Osty: mirSpill{Option,OptionPtr,Result,ResultPtr}AggregateLine
+func mirSpillOptionAggregateLine(slotReg, agg string) string {
+	return mirAllocaSingleLine(slotReg, mirOptionAggregateType()) +
+		mirStoreOptionAggregateLine(agg, slotReg)
+}
+func mirSpillOptionPtrAggregateLine(slotReg, agg string) string {
+	return mirAllocaSingleLine(slotReg, mirOptionPtrAggregateType()) +
+		mirStoreOptionPtrAggregateLine(agg, slotReg)
+}
+func mirSpillResultAggregateLine(slotReg, agg string) string {
+	return mirSpillOptionAggregateLine(slotReg, agg)
+}
+func mirSpillResultPtrAggregateLine(slotReg, agg string) string {
+	return mirSpillOptionPtrAggregateLine(slotReg, agg)
+}
+
+// §16 LLVM-text typed-arg list 4/5/6-elem composers (aliases).
+
+// Osty: mirArgListFour/Five/SixMixed
+func mirArgListFourMixed(a, b, c, d string) string {
+	return mirJoinCommaFour(a, b, c, d)
+}
+func mirArgListFiveMixed(a, b, c, d, e string) string {
+	return mirJoinCommaFive(a, b, c, d, e)
+}
+func mirArgListSixMixed(a, b, c, d, e, f string) string {
+	return mirJoinCommaSix(a, b, c, d, e, f)
+}
+
+// §16 LLVM-text emit-pass header / footer helpers.
+
+// Osty: mirModulePreambleLine / mirModuleEpilogueLine
+func mirModulePreambleLine(sourcePath, triple, layout string) string {
+	return mirModuleHeaderSourceFilename(sourcePath) +
+		mirModuleHeaderTargetTriple(triple) +
+		mirModuleHeaderDataLayout(layout)
+}
+func mirModuleEpilogueLine(version string) string {
+	return mirIdentList(mirCompilerInfoLine(version))
+}
+
+// §16 LLVM-text typed-cast-then-call composite shapes.
+
+// Osty: mirCastI64ToPtrThenCallLine / mirCastPtrToI64ThenCallLine
+func mirCastI64ToPtrThenCallLine(castReg, val, resultReg, sym string) string {
+	return mirCastI64ToPtrLine(castReg, val) +
+		mirCallValuePtrFromPtrLine(resultReg, sym, castReg)
+}
+func mirCastPtrToI64ThenCallLine(castReg, val, resultReg, sym, args string) string {
+	return mirCastPtrToI64Line(castReg, val) +
+		"  " + resultReg + " = " + mirInstrCall() + " i64 @" + sym + "(" + args + ")\n"
+}
+
+// §16 LLVM-text typed-zext-then-call composite shapes.
+
+// Osty: mirZExtI{8,1}ToI64ThenCallLine
+func mirZExtI8ToI64ThenCallLine(zextReg, val, resultReg, sym string) string {
+	return mirZExtI8ToI64Line(zextReg, val) +
+		mirCallValueI64FromPtrLine(resultReg, sym, zextReg)
+}
+func mirZExtI1ToI64ThenCallLine(zextReg, val, resultReg, sym string) string {
+	return mirZExtI1ToI64Line(zextReg, val) +
+		mirCallValueI64FromPtrLine(resultReg, sym, zextReg)
+}
+
+// §16 LLVM-text typed-trunc-then-store composite shapes.
+
+// Osty: mirTruncI64To{I8,I1,I32}ThenStoreLine
+func mirTruncI64ToI8ThenStoreLine(truncReg, val, slot string) string {
+	return mirTruncI64ToI8Line(truncReg, val) + mirStoreI8Line(truncReg, slot)
+}
+func mirTruncI64ToI1ThenStoreLine(truncReg, val, slot string) string {
+	return mirTruncI64ToI1Line(truncReg, val) +
+		"  " + mirInstrStore() + " i1 " + truncReg + ", ptr " + slot + "\n"
+}
+func mirTruncI64ToI32ThenStoreLine(truncReg, val, slot string) string {
+	return mirTruncI64ToI32Line(truncReg, val) + mirStoreI32Line(truncReg, slot)
+}
+
+// §17 LLVM-text typed list / map / set runtime call aliases.
+
+// Osty: mirCallListLengthLine / MapLengthLine / SetLengthLine /
+//       StringLengthLine / BytesLengthLine
+func mirCallListLengthLine(reg, listReg string) string {
+	return mirCallListLenLine(reg, listReg)
+}
+func mirCallMapLengthLine(reg, mapReg string) string {
+	return mirCallMapLenLine(reg, mapReg)
+}
+func mirCallSetLengthLine(reg, setReg string) string {
+	return mirCallSetLenLine(reg, setReg)
+}
+func mirCallStringLengthLine(reg, strReg string) string {
+	return mirCallValueI64FromPtrLine(reg, mirRtStringLenSymbol(), strReg)
+}
+func mirCallBytesLengthLine(reg, bytesReg string) string {
+	return mirCallBytesLenLine(reg, bytesReg)
+}
+
+// §17 LLVM-text typed iterator-call shapes.
+
+// Osty: mirCallList{Reverse,Reversed,Clear,PopDiscard,IsEmptyTyped}Line /
+//       mirCallMapClearLine / mirCallSetClearLine
+func mirCallListReverseLine(listReg string) string {
+	return mirCallVoidPtrLine(mirRtListReverseSymbol(), listReg)
+}
+func mirCallListReversedLine(reg, listReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtListReversedSymbol(), listReg)
+}
+func mirCallListClearLine(listReg string) string {
+	return mirCallVoidPtrLine(mirRtListClearSymbol(), listReg)
+}
+func mirCallMapClearLine(mapReg string) string {
+	return mirCallVoidPtrLine(mirRtMapClearSymbol(), mapReg)
+}
+func mirCallSetClearLine(setReg string) string {
+	return mirCallVoidPtrLine(mirRtSetClearSymbol(), setReg)
+}
+func mirCallListPopDiscardLine(listReg string) string {
+	return mirCallVoidPtrLine(mirRtListPopDiscardSymbol(), listReg)
+}
+func mirCallListIsEmptyTypedLine(reg, listReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtListIsEmptySymbol(), listReg)
+}
+
+// §17 LLVM-text typed-runtime-callable container-conversion helpers.
+
+// Osty: mirCallSetToListLine / MapValuesLine / MapEntriesLine
+func mirCallSetToListLine(reg, setReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtSetToListSymbol(), setReg)
+}
+func mirCallMapValuesLine(reg, mapReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtMapValuesSymbol(), mapReg)
+}
+func mirCallMapEntriesLine(reg, mapReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtMapEntriesSymbol(), mapReg)
+}
+
+// §17 LLVM-text typed-runtime-callable channel-state helpers.
+
+// Osty: mirCallChannel{Close,IsClosed,Len,Cap}Line
+func mirCallChannelCloseLine(chanReg string) string {
+	return mirCallVoidPtrLine(mirRtChanCloseSymbol(), chanReg)
+}
+func mirCallChannelIsClosedLine(reg, chanReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtChanIsClosedSymbol(), chanReg)
+}
+func mirCallChannelLenLine(reg, chanReg string) string {
+	return mirCallValueI64FromPtrLine(reg, mirRtChanLenSymbol(), chanReg)
+}
+func mirCallChannelCapLine(reg, chanReg string) string {
+	return mirCallValueI64FromPtrLine(reg, mirRtChanCapSymbol(), chanReg)
+}
+
+// §17 LLVM-text typed-runtime-callable cancel helpers.
+
+// Osty: mirCallCancel{Check,IsCancelled,Cancel}Line
+func mirCallCancelCheckLine(reg string) string {
+	return mirCallI1NoArgsLine(reg, mirRtCancelCheckCancelledSymbol())
+}
+func mirCallCancelIsCancelledLine(reg string) string {
+	return mirCallI1NoArgsLine(reg, mirRtCancelIsCancelledSymbol())
+}
+func mirCallCancelCancelLine() string {
+	return mirCallVoidNoArgsLine(mirRtCancelCancelSymbol())
+}
+
+// §17 LLVM-text typed-runtime-callable thread-state helpers.
+
+// Osty: mirCallThread{Yield,Sleep}Line
+func mirCallThreadYieldLine() string {
+	return mirCallVoidNoArgsLine(mirRtThreadYieldSymbol())
+}
+func mirCallThreadSleepLine(nsReg string) string {
+	return mirCallVoidFromI64Line(mirRtThreadSleepSymbol(), nsReg)
+}
+
+// §17 LLVM-text typed-runtime-callable string operations.
+
+// Osty: mirCallStringConcatTwoLine / Hash / IsEmpty / ToUpper / ToLower / Trim / Repeat
+func mirCallStringConcatTwoLine(reg, leftReg, rightReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), leftReg) +
+		mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), rightReg)
+}
+func mirCallStringHashLine(reg, strReg string) string {
+	return mirCallValueI64FromPtrLine(reg, mirRtStringHashSymbol(), strReg)
+}
+func mirCallStringIsEmptyLine(reg, strReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtStringIsEmptySymbol(), strReg)
+}
+func mirCallStringToUpperLine(reg, strReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtStringToUpperSymbol(), strReg)
+}
+func mirCallStringToLowerLine(reg, strReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtStringToLowerSymbol(), strReg)
+}
+func mirCallStringTrimLine(reg, strReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtStringTrimSymbol(), strReg)
+}
+func mirCallStringRepeatLine(reg, strReg, nReg string) string {
+	return mirCallPtrFromPtrI64Line(reg, mirRtStringRepeatSymbol(), strReg, nReg)
+}
+
+// §17 LLVM-text typed-runtime-callable bytes operations.
+
+// Osty: mirCallBytesIsEmptyLine / GetTypedLine / ContainsLine / StartsWithLine / EndsWithLine
+func mirCallBytesIsEmptyLine(reg, bytesReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtBytesIsEmptySymbol(), bytesReg)
+}
+func mirCallBytesGetTypedLine(reg, bytesReg, idxReg string) string {
+	return "  " + reg + " = " + mirInstrCall() + " i8 @" + mirRtBytesGetSymbol() + "(ptr " + bytesReg + ", i64 " + idxReg + ")\n"
+}
+func mirCallBytesContainsLine(reg, bytesReg, needleReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg) +
+		mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), needleReg)
+}
+func mirCallBytesStartsWithLine(reg, bytesReg, prefixReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtBytesStartsWithSymbol(), bytesReg) +
+		mirCallValueI1FromPtrLine(reg, mirRtBytesStartsWithSymbol(), prefixReg)
+}
+func mirCallBytesEndsWithLine(reg, bytesReg, suffixReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtBytesEndsWithSymbol(), bytesReg) +
+		mirCallValueI1FromPtrLine(reg, mirRtBytesEndsWithSymbol(), suffixReg)
+}
+
+// §17 LLVM-text typed runtime-callable map / set operations.
+
+// Osty: mirCallMap{Insert,Remove}Line / mirCallSet{Add,Remove}Line
+func mirCallMapInsertLine(mapReg, keyArgs, valArgs string) string {
+	return "  " + mirInstrCallVoid() + " void @" + mirRtMapInsertSymbol() + "(ptr " + mapReg + ", " + keyArgs + ", " + valArgs + ")\n"
+}
+func mirCallMapRemoveLine(mapReg, keyArgs string) string {
+	return "  " + mirInstrCallVoid() + " void @" + mirRtMapRemoveSymbol() + "(ptr " + mapReg + ", " + keyArgs + ")\n"
+}
+func mirCallSetAddLine(setReg, elemArgs string) string {
+	return "  " + mirInstrCallVoid() + " void @" + mirRtSetAddSymbol() + "(ptr " + setReg + ", " + elemArgs + ")\n"
+}
+func mirCallSetRemoveLine(setReg, elemArgs string) string {
+	return "  " + mirInstrCallVoid() + " void @" + mirRtSetRemoveSymbol() + "(ptr " + setReg + ", " + elemArgs + ")\n"
+}
+
+// §17 LLVM-text typed runtime-callable structured-concurrency.
+
+// Osty: mirCallTaskGroup{New,Cancel,IsCancelled}Line / mirCallTaskHandleJoinLine /
+//       mirCallTaskCollectAllLine / mirCallTaskRaceLine
+func mirCallTaskGroupNewLine(reg string) string {
+	return mirCallPtrNoArgsLine(reg, mirRtTaskGroupRootSymbol())
+}
+func mirCallTaskGroupCancelLine(groupReg string) string {
+	return mirCallVoidPtrLine(mirRtTaskGroupCancelSymbol(), groupReg)
+}
+func mirCallTaskGroupIsCancelledLine(reg, groupReg string) string {
+	return mirCallValueI1FromPtrLine(reg, mirRtTaskGroupIsCancelledSymbol(), groupReg)
+}
+func mirCallTaskHandleJoinLine(reg, handleReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtTaskHandleJoinSymbol(), handleReg)
+}
+func mirCallTaskCollectAllLine(reg, listReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtTaskCollectAllSymbol(), listReg)
+}
+func mirCallTaskRaceLine(reg, bodyReg string) string {
+	return mirCallValuePtrFromPtrLine(reg, mirRtTaskRaceSymbol(), bodyReg)
+}
+
+// §17 LLVM-text typed runtime-callable panic / abort helpers.
+
+// Osty: mirCall{Panic,Unreachable,Todo,Abort}Line / mirCall{OptionUnwrapNone,ResultUnwrapErr,ExpectFailed}Line
+func mirCallPanicLine(messagePtr string) string {
+	return mirCallVoidPtrLine(mirRtPanicSymbol(), messagePtr)
+}
+func mirCallUnreachableLine() string {
+	return mirCallVoidNoArgsLine(mirRtUnreachableSymbol())
+}
+func mirCallTodoLine() string {
+	return mirCallVoidNoArgsLine(mirRtTodoSymbol())
+}
+func mirCallAbortLine() string {
+	return mirCallVoidNoArgsLine(mirRtAbortSymbol())
+}
+func mirCallOptionUnwrapNoneLine() string {
+	return mirCallVoidNoArgsLine(mirRtOptionUnwrapNoneSymbol())
+}
+func mirCallResultUnwrapErrLine() string {
+	return mirCallVoidNoArgsLine(mirRtResultUnwrapErrSymbol())
+}
+func mirCallExpectFailedLine() string {
+	return mirCallVoidNoArgsLine(mirRtExpectFailedSymbol())
+}

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7484,8 +7484,7 @@ func mirCallThreadSleepLine(nsReg string) string {
 
 // Osty: mirCallStringConcatTwoLine / Hash / IsEmpty / ToUpper / ToLower / Trim / Repeat
 func mirCallStringConcatTwoLine(reg, leftReg, rightReg string) string {
-	return mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), leftReg) +
-		mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), rightReg)
+	return mirCallPtrFromTwoPtrLine(reg, mirRtStringConcatSymbol(), leftReg, rightReg)
 }
 func mirCallStringHashLine(reg, strReg string) string {
 	return mirCallValueI64FromPtrLine(reg, mirRtStringHashSymbol(), strReg)
@@ -7516,16 +7515,13 @@ func mirCallBytesGetTypedLine(reg, bytesReg, idxReg string) string {
 	return "  " + reg + " = " + mirInstrCall() + " i8 @" + mirRtBytesGetSymbol() + "(ptr " + bytesReg + ", i64 " + idxReg + ")\n"
 }
 func mirCallBytesContainsLine(reg, bytesReg, needleReg string) string {
-	return mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg) +
-		mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), needleReg)
+	return mirCallI1FromTwoPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg, needleReg)
 }
 func mirCallBytesStartsWithLine(reg, bytesReg, prefixReg string) string {
-	return mirCallValueI1FromPtrLine(reg, mirRtBytesStartsWithSymbol(), bytesReg) +
-		mirCallValueI1FromPtrLine(reg, mirRtBytesStartsWithSymbol(), prefixReg)
+	return mirCallI1FromTwoPtrLine(reg, mirRtBytesStartsWithSymbol(), bytesReg, prefixReg)
 }
 func mirCallBytesEndsWithLine(reg, bytesReg, suffixReg string) string {
-	return mirCallValueI1FromPtrLine(reg, mirRtBytesEndsWithSymbol(), bytesReg) +
-		mirCallValueI1FromPtrLine(reg, mirRtBytesEndsWithSymbol(), suffixReg)
+	return mirCallI1FromTwoPtrLine(reg, mirRtBytesEndsWithSymbol(), bytesReg, suffixReg)
 }
 
 // §17 LLVM-text typed runtime-callable map / set operations.

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -11405,3 +11405,1171 @@ pub fn mirGEPThenStorePtrLine(slotReg: String, ty: String, basePtr: String, idxD
     mirGEPPtrStrideLine(slotReg, basePtr, idxDigits) +
     "  " + mirInstrStore() + " ptr " + val + ", ptr " + slotReg + "\n"
 }
+
+/// §14 LLVM-text aggregate-construction composite shapes.
+
+/// mirOptionSomeI64BuildLine renders the canonical 2-line None +
+/// payload-Some<i64> aggregate construction.
+pub fn mirOptionSomeI64BuildLine(stepReg: String, fullReg: String, payload: String) -> String {
+    mirInsertValueI64Line(stepReg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantSome(), "0") +
+    mirInsertValueI64Line(fullReg, mirOptionAggregateType(), stepReg, payload, "1")
+}
+
+/// mirOptionSomePtrBuildLine renders the canonical 2-line None +
+/// payload-Some<Ptr> aggregate construction.
+pub fn mirOptionSomePtrBuildLine(stepReg: String, fullReg: String, payloadPtr: String) -> String {
+    mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantSome(), "0") +
+    mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, payloadPtr, "1")
+}
+
+/// mirResultOkI64BuildLine / mirResultOkPtrBuildLine — Result<T, E>
+/// Ok-aggregate construction shapes.
+pub fn mirResultOkI64BuildLine(stepReg: String, fullReg: String, payload: String) -> String {
+    mirInsertValueI64Line(stepReg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantOk(), "0") +
+    mirInsertValueI64Line(fullReg, mirOptionAggregateType(), stepReg, payload, "1")
+}
+
+pub fn mirResultOkPtrBuildLine(stepReg: String, fullReg: String, payloadPtr: String) -> String {
+    mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantOk(), "0") +
+    mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, payloadPtr, "1")
+}
+
+/// mirResultErrPtrBuildLine renders the canonical Result<T, Error>
+/// Err-aggregate construction.
+pub fn mirResultErrPtrBuildLine(stepReg: String, fullReg: String, errPtr: String) -> String {
+    mirInsertValueI64Line(stepReg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantErr(), "0") +
+    mirInsertValuePtrLine(fullReg, mirOptionPtrAggregateType(), stepReg, errPtr, "1")
+}
+
+/// §14 LLVM-text Option / Result destructure helpers.
+
+/// mirOptionUnwrapDestructureLine renders the canonical Option<T>
+/// unwrap destructure 2-line shape: extract disc + extract payload.
+pub fn mirOptionUnwrapDestructureLine(discReg: String, payloadReg: String, agg: String) -> String {
+    mirOptionDiscProbeLine(discReg, agg) +
+    mirOptionPayloadProbeLine(payloadReg, agg)
+}
+
+/// mirOptionPtrUnwrapDestructureLine renders the canonical
+/// Option<Ptr> unwrap destructure.
+pub fn mirOptionPtrUnwrapDestructureLine(discReg: String, payloadReg: String, agg: String) -> String {
+    mirOptionPtrDiscProbeLine(discReg, agg) +
+    mirOptionPtrPayloadProbeLine(payloadReg, agg)
+}
+
+/// mirResultUnwrapDestructureLine renders the canonical Result<T, E>
+/// unwrap destructure.
+pub fn mirResultUnwrapDestructureLine(discReg: String, payloadReg: String, agg: String) -> String {
+    mirResultDiscProbeLine(discReg, agg) +
+    mirResultPayloadProbeLine(payloadReg, agg)
+}
+
+/// §14 LLVM-text discriminant-comparison composite shapes.
+
+/// mirOptionIsSomeLine renders the canonical Option<T> is-Some test
+/// 2-line shape: extract disc + cmp eq Some.
+pub fn mirOptionIsSomeLine(discReg: String, isSomeReg: String, agg: String) -> String {
+    mirOptionDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(isSomeReg, discReg, mirDiscriminantSome())
+}
+
+/// mirOptionIsNoneLine renders the canonical Option<T> is-None test.
+pub fn mirOptionIsNoneLine(discReg: String, isNoneReg: String, agg: String) -> String {
+    mirOptionDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(isNoneReg, discReg, mirDiscriminantNone())
+}
+
+/// mirResultIsOkLine / mirResultIsErrLine — Result<T, E> probe
+/// composites.
+pub fn mirResultIsOkLine(discReg: String, isOkReg: String, agg: String) -> String {
+    mirResultDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(isOkReg, discReg, mirDiscriminantOk())
+}
+
+pub fn mirResultIsErrLine(discReg: String, isErrReg: String, agg: String) -> String {
+    mirResultDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(isErrReg, discReg, mirDiscriminantErr())
+}
+
+/// §14 LLVM-text branch-on-discriminant composite shapes.
+
+/// mirBranchOnOptionDiscLine renders the canonical Option<T>
+/// branch-on-disc 3-line shape: extract + cmp + br.
+pub fn mirBranchOnOptionDiscLine(discReg: String, cmpReg: String, agg: String, someLbl: String, noneLbl: String) -> String {
+    mirOptionDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(cmpReg, discReg, mirDiscriminantSome()) +
+    mirBrCondLine(cmpReg, someLbl, noneLbl)
+}
+
+/// mirBranchOnResultDiscLine renders the canonical Result<T, E>
+/// branch-on-disc 3-line shape.
+pub fn mirBranchOnResultDiscLine(discReg: String, cmpReg: String, agg: String, okLbl: String, errLbl: String) -> String {
+    mirResultDiscProbeLine(discReg, agg) +
+    mirICmpI64EqLine(cmpReg, discReg, mirDiscriminantOk()) +
+    mirBrCondLine(cmpReg, okLbl, errLbl)
+}
+
+/// §14 LLVM-text typed-string-pool global emit helpers.
+
+/// mirInternedStringPoolLine renders the canonical interned-string
+/// pool entry. Sibling of `mirGlobalStringPoolDeclLine` named for
+/// the string-pool deduplication path.
+pub fn mirInternedStringPoolLine(sym: String, sizeDigits: String, encoded: String) -> String {
+    mirGlobalStringPoolDeclLine(sym, sizeDigits, encoded)
+}
+
+/// mirInternedFormatPoolLine renders the canonical interned-format
+/// string pool entry.
+pub fn mirInternedFormatPoolLine(sym: String, sizeDigits: String, encoded: String) -> String {
+    mirGlobalStringPoolDeclLine(sym, sizeDigits, encoded)
+}
+
+/// §14 LLVM-text typed-cast call-arg shape composers.
+
+/// mirArgPtrCastFromI64Line renders the canonical 2-line cast +
+/// arg-slot pattern: i64-to-ptr cast.
+pub fn mirArgPtrCastFromI64Line(castReg: String, val: String) -> String {
+    mirCastI64ToPtrLine(castReg, val)
+}
+
+/// mirArgI64CastFromPtrLine renders the canonical 2-line cast: ptr-
+/// to-i64 cast.
+pub fn mirArgI64CastFromPtrLine(castReg: String, val: String) -> String {
+    mirCastPtrToI64Line(castReg, val)
+}
+
+/// §14 LLVM-text Range / Iter shape composite helpers.
+
+/// mirForRangePreludeLine renders the canonical for-range prelude:
+///   alloca + init + branch to head label.
+pub fn mirForRangePreludeLine(slotReg: String, start: String, headLbl: String) -> String {
+    mirAllocaInitI64Line(slotReg, start) +
+    mirBrLabelLine(headLbl)
+}
+
+/// mirForRangeHeadLine renders the canonical for-range head block:
+///   header label + load i + cmp + branch.
+pub fn mirForRangeHeadLine(headLbl: String, iReg: String, slot: String, cmpReg: String, bound: String, bodyLbl: String, exitLbl: String) -> String {
+    mirBlockHeaderLine(headLbl) +
+    mirLoadI64Line(iReg, slot) +
+    mirICmpI64SltLine(cmpReg, iReg, bound) +
+    mirBrCondLine(cmpReg, bodyLbl, exitLbl)
+}
+
+/// §14 LLVM-text Match-arm head-body shape helpers.
+
+/// mirMatchArmHeadLine renders the canonical match-arm head label.
+pub fn mirMatchArmHeadLine(idxDigits: String) -> String {
+    mirLabelMatchArmPrefix() + "." + idxDigits + ":\n"
+}
+
+/// mirMatchArmBodyLine renders the canonical match-arm body —
+/// branch to match-exit after body emit.
+pub fn mirMatchArmBodyLine(exitLbl: String) -> String {
+    mirBrLabelLine(exitLbl)
+}
+
+/// §14 LLVM-text bounds-check composite shapes.
+
+/// mirArrayBoundsCheckLine renders the canonical 4-line bounds-check
+/// pattern: cmp non-neg + cmp lt-len + and + branch.
+pub fn mirArrayBoundsCheckLine(nonNegReg: String, ltLenReg: String, andReg: String, idx: String, lenReg: String, okLbl: String, oobLbl: String) -> String {
+    mirICmpI64SgeLine(nonNegReg, idx, "0") +
+    mirICmpI64SltLine(ltLenReg, idx, lenReg) +
+    mirAndI1Line(andReg, nonNegReg, ltLenReg) +
+    mirBrCondLine(andReg, okLbl, oobLbl)
+}
+
+/// §14 LLVM-text vector-list snapshot 3-line composite (with body
+/// label).
+
+/// mirVectorListSnapshot3Line renders the canonical 3-line snapshot
+/// composite: data + len calls + label.
+pub fn mirVectorListSnapshot3Line(dataReg: String, dataSym: String, lenReg: String, listReg: String, scopeRef: String, headLbl: String) -> String {
+    mirVectorListSnapshot2Line(dataReg, dataSym, lenReg, listReg, scopeRef) +
+    mirBrLabelLine(headLbl)
+}
+
+/// §14 LLVM-text typed-numerical-cast composites with explicit
+/// rounding mode (reserved for future fp-cast metadata).
+
+/// mirCastFPToSIWithRTZLine renders the canonical fp-to-int cast
+/// with round-to-zero rounding mode (the LLVM default).
+pub fn mirCastFPToSIWithRTZLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    mirFPToSILine(reg, fromTy, val, toTy)
+}
+
+/// mirCastSIToFPDefaultLine renders the canonical int-to-fp cast
+/// with the LLVM default rounding mode.
+pub fn mirCastSIToFPDefaultLine(reg: String, fromTy: String, val: String, toTy: String) -> String {
+    mirSIToFPLine(reg, fromTy, val, toTy)
+}
+
+/// §14 Generic memcpy composite — alloca + memcpy 2-line.
+
+/// mirAllocaThenMemcpyLine renders `<alloca>\n<memcpy>\n` for a
+/// stack-resident copy of a fixed-size aggregate.
+pub fn mirAllocaThenMemcpyLine(slotReg: String, ty: String, src: String, sizeBytesDigits: String) -> String {
+    mirAllocaSingleLine(slotReg, ty) +
+    mirCallVoidLLVMMemcpyLine(slotReg, src, sizeBytesDigits, "false")
+}
+
+/// §14 LLVM-text typed-aggregate field-extract composite shapes.
+
+/// mirExtractValueI64FieldLine renders the canonical i64 extractvalue
+/// + cast-to-target shape (used at sites where Option/Result-payload
+/// gets re-typed downstream).
+pub fn mirExtractValueI64FieldLine(reg: String, aggTy: String, agg: String, idx: String) -> String {
+    mirExtractValueI64Line(reg, aggTy, agg, idx)
+}
+
+/// §14 LLVM-text canonical zero-aggregate emit helpers.
+
+/// mirEmitOptionNoneI64Line renders the canonical None<i64-payload>
+/// aggregate emit (full 1-line build).
+pub fn mirEmitOptionNoneI64Line(reg: String) -> String {
+    mirInsertValueI64Line(reg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantNone(), "0")
+}
+
+/// mirEmitOptionNonePtrLine renders the canonical None<ptr-payload>
+/// aggregate emit.
+pub fn mirEmitOptionNonePtrLine(reg: String) -> String {
+    mirInsertValueI64Line(reg, mirOptionPtrAggregateType(), mirAggregateUndef(), mirDiscriminantNone(), "0")
+}
+
+/// §14 Module-globals helpers — drain repeated patterns.
+
+/// mirInternedI64GlobalLine renders the canonical interned-i64-
+/// constant emit line.
+pub fn mirInternedI64GlobalLine(sym: String, val: String) -> String {
+    mirGlobalConstantI64DeclLine(sym, val)
+}
+
+/// mirInternedPtrGlobalLine renders the canonical interned-ptr-
+/// constant emit line.
+pub fn mirInternedPtrGlobalLine(sym: String, val: String) -> String {
+    mirGlobalConstantPtrDeclLine(sym, val)
+}
+
+/// mirMutableI64GlobalLine renders the canonical mutable-i64-global
+/// emit line.
+pub fn mirMutableI64GlobalLine(sym: String, init: String) -> String {
+    mirGlobalMutableI64DeclLine(sym, init)
+}
+
+/// mirMutablePtrGlobalLine renders the canonical mutable-ptr-global
+/// emit line.
+pub fn mirMutablePtrGlobalLine(sym: String, init: String) -> String {
+    mirGlobalMutablePtrDeclLine(sym, init)
+}
+
+/// §14 LLVM-text typed-call-shape with no-args + result-store
+/// composite helpers.
+
+/// mirCallI64NoArgsAndStoreLine renders the canonical call + store
+/// 2-line shape for an i64 no-args runtime call.
+pub fn mirCallI64NoArgsAndStoreLine(reg: String, sym: String, slot: String) -> String {
+    mirCallI64NoArgsLine(reg, sym) +
+    "  " + mirInstrStore() + " i64 " + reg + ", ptr " + slot + "\n"
+}
+
+/// mirCallI1NoArgsAndStoreLine renders the canonical call + store
+/// 2-line shape for an i1 no-args runtime call.
+pub fn mirCallI1NoArgsAndStoreLine(reg: String, sym: String, slot: String) -> String {
+    mirCallI1NoArgsLine(reg, sym) +
+    "  " + mirInstrStore() + " i1 " + reg + ", ptr " + slot + "\n"
+}
+
+/// mirCallPtrNoArgsAndStoreLine renders the canonical call + store
+/// 2-line shape for a ptr no-args runtime call.
+pub fn mirCallPtrNoArgsAndStoreLine(reg: String, sym: String, slot: String) -> String {
+    mirCallPtrNoArgsLine(reg, sym) +
+    "  " + mirInstrStore() + " ptr " + reg + ", ptr " + slot + "\n"
+}
+
+/// §15 LLVM-text load-then-call composite helpers.
+
+/// mirLoadPtrThenCallVoidLine renders the canonical load + void-call
+/// 2-line shape.
+pub fn mirLoadPtrThenCallVoidLine(reg: String, slot: String, sym: String) -> String {
+    mirLoadPtrLine(reg, slot) +
+    mirCallVoidPtrLine(sym, reg)
+}
+
+/// mirLoadPtrThenCallValueLine renders the canonical load + ptr-call
+/// 2-line shape.
+pub fn mirLoadPtrThenCallValueLine(loadReg: String, slot: String, resultReg: String, sym: String) -> String {
+    mirLoadPtrLine(loadReg, slot) +
+    mirCallValuePtrFromPtrLine(resultReg, sym, loadReg)
+}
+
+/// mirLoadPtrThenCallI64Line renders the canonical load + i64-call
+/// 2-line shape.
+pub fn mirLoadPtrThenCallI64Line(loadReg: String, slot: String, resultReg: String, sym: String) -> String {
+    mirLoadPtrLine(loadReg, slot) +
+    mirCallValueI64FromPtrLine(resultReg, sym, loadReg)
+}
+
+/// mirLoadPtrThenCallI1Line renders the canonical load + i1-call
+/// 2-line shape.
+pub fn mirLoadPtrThenCallI1Line(loadReg: String, slot: String, resultReg: String, sym: String) -> String {
+    mirLoadPtrLine(loadReg, slot) +
+    mirCallValueI1FromPtrLine(resultReg, sym, loadReg)
+}
+
+/// (mirAddI64Line / mirSubI64Line continue to live at their original
+/// sites earlier in this file.)
+
+/// §15 LLVM-text predicate-then-branch composite helpers.
+
+/// mirICmpEqI64ThenBranchLine renders the canonical icmp eq + branch
+/// 2-line shape for i64 equality dispatch.
+pub fn mirICmpEqI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64EqLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpNeI64ThenBranchLine renders the canonical icmp ne + branch.
+pub fn mirICmpNeI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64NeLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpSltI64ThenBranchLine renders the canonical icmp slt + branch.
+pub fn mirICmpSltI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64SltLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpSgtI64ThenBranchLine renders the canonical icmp sgt + branch.
+pub fn mirICmpSgtI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64SgtLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpSleI64ThenBranchLine renders the canonical icmp sle + branch.
+pub fn mirICmpSleI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64SleLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpSgeI64ThenBranchLine renders the canonical icmp sge + branch.
+pub fn mirICmpSgeI64ThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI64SgeLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpEqPtrThenBranchLine renders the canonical ptr-eq + branch
+/// 2-line shape.
+pub fn mirICmpEqPtrThenBranchLine(cmpReg: String, a: String, b: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpPtrEqLine(cmpReg, a, b) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// mirICmpNullPtrThenBranchLine renders the canonical null-ptr + branch.
+pub fn mirICmpNullPtrThenBranchLine(cmpReg: String, a: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpNullPtrLine(cmpReg, a) +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl)
+}
+
+/// §15 LLVM-text typed-runtime-call sequencing composites.
+
+/// mirRuntimeProbeAndStoreLine renders the canonical 2-line shape:
+///   `<reg> = call <retTy> @<sym>(<args>)\n`
+///   `  store <retTy> <reg>, ptr <slot>\n`
+pub fn mirRuntimeProbeAndStoreLine(reg: String, retTy: String, sym: String, args: String, slot: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " " + retTy + " @" + sym + "(" + args + ")\n" +
+    "  " + mirInstrStore() + " " + retTy + " " + reg + ", ptr " + slot + "\n"
+}
+
+/// §15 LLVM-text typed-load-then-cmp composite helpers.
+
+/// mirLoadI64ThenCmpEqLine renders `load i64 + icmp eq i64`.
+pub fn mirLoadI64ThenCmpEqLine(loadReg: String, slot: String, cmpReg: String, b: String) -> String {
+    mirLoadI64Line(loadReg, slot) +
+    mirICmpI64EqLine(cmpReg, loadReg, b)
+}
+
+/// mirLoadI64ThenCmpNeLine renders `load i64 + icmp ne i64`.
+pub fn mirLoadI64ThenCmpNeLine(loadReg: String, slot: String, cmpReg: String, b: String) -> String {
+    mirLoadI64Line(loadReg, slot) +
+    mirICmpI64NeLine(cmpReg, loadReg, b)
+}
+
+/// mirLoadI64ThenCmpZeroLine renders `load i64 + icmp eq i64 0`.
+pub fn mirLoadI64ThenCmpZeroLine(loadReg: String, slot: String, cmpReg: String) -> String {
+    mirLoadI64Line(loadReg, slot) +
+    mirICmpZeroI64Line(cmpReg, loadReg)
+}
+
+/// mirLoadPtrThenCmpNullLine renders `load ptr + icmp eq ptr null`.
+pub fn mirLoadPtrThenCmpNullLine(loadReg: String, slot: String, cmpReg: String) -> String {
+    mirLoadPtrLine(loadReg, slot) +
+    mirICmpNullPtrLine(cmpReg, loadReg)
+}
+
+/// §15 LLVM-text typed-load-then-store composite helpers (alternate
+/// types beyond i64/ptr).
+
+/// mirLoadI1ThenStoreLine renders `load i1 + store i1`.
+pub fn mirLoadI1ThenStoreLine(loadReg: String, src: String, dst: String) -> String {
+    mirLoadStoreI1Line(loadReg, src, dst)
+}
+
+/// mirLoadDoubleThenStoreLine renders `load double + store double`.
+pub fn mirLoadDoubleThenStoreLine(loadReg: String, src: String, dst: String) -> String {
+    mirLoadStoreDoubleLine(loadReg, src, dst)
+}
+
+/// §15 LLVM-text typed-runtime-call composite shapes (no result).
+
+/// mirCallVoidWithI64ResultLine renders the canonical call + store-i64
+/// 2-line shape (alias of `mirCallI64NoArgsAndStoreLine`).
+pub fn mirCallVoidWithI64ResultLine(reg: String, sym: String, slot: String) -> String {
+    mirCallI64NoArgsAndStoreLine(reg, sym, slot)
+}
+
+/// §15 Common emit-pass shape composers — multi-line patterns that
+/// the emitter forms as a unit.
+
+/// mirReturnConstantI64Line renders the canonical 1-line return-i64-
+/// constant: `  ret i64 <val>\n`.
+pub fn mirReturnConstantI64Line(val: String) -> String {
+    mirRetTypedLine(mirTypeI64(), val)
+}
+
+/// mirReturnConstantPtrLine renders the canonical 1-line return-ptr-
+/// constant.
+pub fn mirReturnConstantPtrLine(val: String) -> String {
+    mirRetTypedLine(mirTypePtr(), val)
+}
+
+/// mirReturnConstantI1Line renders the canonical 1-line return-i1-
+/// constant.
+pub fn mirReturnConstantI1Line(val: String) -> String {
+    mirRetTypedLine(mirTypeI1(), val)
+}
+
+/// mirReturnConstantDoubleLine renders the canonical 1-line return-
+/// double-constant.
+pub fn mirReturnConstantDoubleLine(val: String) -> String {
+    mirRetTypedLine(mirTypeDouble(), val)
+}
+
+/// mirReturnZeroI64Line / NullPtrLine / FalseI1Line / ZeroDoubleLine —
+/// canonical return-zero / return-default 1-line shapes.
+pub fn mirReturnZeroI64Line() -> String {
+    mirReturnConstantI64Line("0")
+}
+
+pub fn mirReturnNullPtrLine() -> String {
+    mirReturnConstantPtrLine("null")
+}
+
+pub fn mirReturnFalseI1Line() -> String {
+    mirReturnConstantI1Line("0")
+}
+
+pub fn mirReturnTrueI1Line() -> String {
+    mirReturnConstantI1Line("1")
+}
+
+pub fn mirReturnZeroDoubleLine() -> String {
+    mirReturnConstantDoubleLine("0.0")
+}
+
+/// §15 LLVM-text typed call-arg list compositions.
+
+/// mirArgListPtrPtr renders `ptr <a>, ptr <b>` — sibling of
+/// `mirArgListTwoPtr`. (Both are kept; this one named for pair-call
+/// shapes vs collection arg-list shapes.)
+pub fn mirArgListPtrPtr(a: String, b: String) -> String {
+    mirArgSlotPtr(a) + ", " + mirArgSlotPtr(b)
+}
+
+/// mirArgListPtrI64Slot renders `ptr <a>, i64 <b>` (sibling of
+/// `mirArgListPtrI64`).
+pub fn mirArgListPtrI64Slot(a: String, b: String) -> String {
+    mirArgSlotPtr(a) + ", " + mirArgSlotI64(b)
+}
+
+/// mirArgListThreePtrSlot renders `ptr <a>, ptr <b>, ptr <c>` (sibling
+/// of `mirArgListThreePtr`).
+pub fn mirArgListThreePtrSlot(a: String, b: String, c: String) -> String {
+    mirArgSlotPtr(a) + ", " + mirArgSlotPtr(b) + ", " + mirArgSlotPtr(c)
+}
+
+/// §15 LLVM-text typed-i64-add-with-immediate composites.
+
+/// mirAddI64ImmediateThenStoreLine renders the canonical add-imm + store
+/// 2-line shape (used at counter increment sites).
+pub fn mirAddI64ImmediateThenStoreLine(addReg: String, base: String, imm: String, slot: String) -> String {
+    mirAddI64ImmediateLine(addReg, base, imm) +
+    "  " + mirInstrStore() + " i64 " + addReg + ", ptr " + slot + "\n"
+}
+
+/// mirSubI64ImmediateThenStoreLine renders the canonical sub-imm + store.
+pub fn mirSubI64ImmediateThenStoreLine(subReg: String, base: String, imm: String, slot: String) -> String {
+    mirSubI64ImmediateLine(subReg, base, imm) +
+    "  " + mirInstrStore() + " i64 " + subReg + ", ptr " + slot + "\n"
+}
+
+/// §15 Block-builder composites — for typical 3-block "if-then-else"
+/// pattern.
+
+/// mirIfThenElseSkeletonLine renders the canonical if/else 4-line
+/// skeleton: cond + branch + then label + else label.
+pub fn mirIfThenElseSkeletonLine(cmpReg: String, cond: String, thenLbl: String, elseLbl: String) -> String {
+    mirICmpI1NeLine(cmpReg, cond, "0") +
+    mirBrCondLine(cmpReg, thenLbl, elseLbl) +
+    mirBlockHeaderLine(thenLbl)
+}
+
+/// §15 LLVM-text typed-aggregate-store composite helpers.
+
+/// mirStoreOptionAggregateLine renders the canonical 1-line store
+/// of an Option<T> aggregate: `store \{ i64, i64 \} <agg>, ptr <slot>`.
+pub fn mirStoreOptionAggregateLine(agg: String, slot: String) -> String {
+    "  " + mirInstrStore() + " " + mirOptionAggregateType() + " " + agg + ", ptr " + slot + "\n"
+}
+
+/// mirStoreOptionPtrAggregateLine renders the canonical 1-line store
+/// of an Option<Ptr> aggregate.
+pub fn mirStoreOptionPtrAggregateLine(agg: String, slot: String) -> String {
+    "  " + mirInstrStore() + " " + mirOptionPtrAggregateType() + " " + agg + ", ptr " + slot + "\n"
+}
+
+/// mirStoreResultAggregateLine renders the canonical 1-line store
+/// of a Result<T,E> aggregate.
+pub fn mirStoreResultAggregateLine(agg: String, slot: String) -> String {
+    mirStoreOptionAggregateLine(agg, slot)
+}
+
+/// mirStoreResultPtrAggregateLine renders the canonical 1-line store
+/// of a Result<T,Error> aggregate (Err is always ptr-typed).
+pub fn mirStoreResultPtrAggregateLine(agg: String, slot: String) -> String {
+    mirStoreOptionPtrAggregateLine(agg, slot)
+}
+
+/// §15 LLVM-text typed-aggregate-load composite helpers.
+
+/// mirLoadOptionAggregateLine renders the canonical 1-line load of
+/// an Option<T> aggregate: `<reg> = load \{ i64, i64 \}, ptr <slot>`.
+pub fn mirLoadOptionAggregateLine(reg: String, slot: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " " + mirOptionAggregateType() + ", ptr " + slot + "\n"
+}
+
+/// mirLoadOptionPtrAggregateLine renders the canonical 1-line load.
+pub fn mirLoadOptionPtrAggregateLine(reg: String, slot: String) -> String {
+    "  " + reg + " = " + mirInstrLoad() + " " + mirOptionPtrAggregateType() + ", ptr " + slot + "\n"
+}
+
+/// mirLoadResultAggregateLine / mirLoadResultPtrAggregateLine —
+/// alias for Result<T,E> 1-line load.
+pub fn mirLoadResultAggregateLine(reg: String, slot: String) -> String {
+    mirLoadOptionAggregateLine(reg, slot)
+}
+
+pub fn mirLoadResultPtrAggregateLine(reg: String, slot: String) -> String {
+    mirLoadOptionPtrAggregateLine(reg, slot)
+}
+
+/// §16 LLVM-text intrinsic-builder helpers (semantic aliases).
+
+/// mirCallSqrtDoubleLine / FAbsDoubleLine / SinDoubleLine / CosDoubleLine /
+/// TanDoubleLine / LogDoubleLine / Log2DoubleLine / Log10DoubleLine /
+/// ExpDoubleLine / Exp2DoubleLine — `llvm.<feature>.f64` typed-call
+/// aliases for emit-pass call sites.
+pub fn mirCallSqrtDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMSqrtF64Line(reg, x)
+}
+
+pub fn mirCallFAbsDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMFAbsF64Line(reg, x)
+}
+
+pub fn mirCallSinDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMSinF64Line(reg, x)
+}
+
+pub fn mirCallCosDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMCosF64Line(reg, x)
+}
+
+pub fn mirCallTanDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMTanF64Line(reg, x)
+}
+
+pub fn mirCallLogDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMLogF64Line(reg, x)
+}
+
+pub fn mirCallLog2DoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMLog2F64Line(reg, x)
+}
+
+pub fn mirCallLog10DoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMLog10F64Line(reg, x)
+}
+
+pub fn mirCallExpDoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMExpF64Line(reg, x)
+}
+
+pub fn mirCallExp2DoubleLine(reg: String, x: String) -> String {
+    mirCallValueLLVMExp2F64Line(reg, x)
+}
+
+/// mirCallPowDoubleLine renders the canonical pow.f64 2-arg call.
+pub fn mirCallPowDoubleLine(reg: String, base: String, exp: String) -> String {
+    mirCallValueLLVMPowF64Line(reg, base, exp)
+}
+
+/// mirCallMinNumDoubleLine / MaxNumDoubleLine — IEEE-754 minNum / maxNum.
+pub fn mirCallMinNumDoubleLine(reg: String, a: String, b: String) -> String {
+    mirCallValueLLVMMinNumF64Line(reg, a, b)
+}
+
+pub fn mirCallMaxNumDoubleLine(reg: String, a: String, b: String) -> String {
+    mirCallValueLLVMMaxNumF64Line(reg, a, b)
+}
+
+/// §16 LLVM-text bit-manipulation typed-call composites (aliases).
+
+/// mirCallCtlzI64Line / CttzI64Line / CtpopI64Line — bit-count calls.
+pub fn mirCallCtlzI64Line(reg: String, x: String) -> String {
+    mirCallValueLLVMCtlzI64Line(reg, x)
+}
+
+pub fn mirCallCttzI64Line(reg: String, x: String) -> String {
+    mirCallValueLLVMCttzI64Line(reg, x)
+}
+
+pub fn mirCallCtpopI64Line(reg: String, x: String) -> String {
+    mirCallValueLLVMCtpopI64Line(reg, x)
+}
+
+/// mirCallBSwapI{64,32,16}Line — byte swap.
+pub fn mirCallBSwapI64Line(reg: String, x: String) -> String {
+    mirCallValueLLVMBSwapI64Line(reg, x)
+}
+
+pub fn mirCallBSwapI32Line(reg: String, x: String) -> String {
+    mirCallValueLLVMBSwapI32Line(reg, x)
+}
+
+pub fn mirCallBSwapI16Line(reg: String, x: String) -> String {
+    mirCallValueLLVMBSwapI16Line(reg, x)
+}
+
+/// mirCallBitReverseI64Line — bit reverse.
+pub fn mirCallBitReverseI64Line(reg: String, x: String) -> String {
+    mirCallValueLLVMBitReverseI64Line(reg, x)
+}
+
+/// §16 LLVM-text typed-runtime-callable lifetime intrinsics (aliases).
+
+/// mirCallLifetimeStartLine / EndLine / mirCallAssumeLine /
+/// mirCallExpectI1Line — lifetime / branch-hint composites.
+pub fn mirCallLifetimeStartLine(sizeBytes: String, slot: String) -> String {
+    mirCallVoidLLVMLifetimeStartLine(sizeBytes, slot)
+}
+
+pub fn mirCallLifetimeEndLine(sizeBytes: String, slot: String) -> String {
+    mirCallVoidLLVMLifetimeEndLine(sizeBytes, slot)
+}
+
+pub fn mirCallAssumeLine(cond: String) -> String {
+    mirCallVoidLLVMAssumeLine(cond)
+}
+
+pub fn mirCallExpectI1Line(reg: String, cond: String, expected: String) -> String {
+    mirCallValueLLVMExpectI1Line(reg, cond, expected)
+}
+
+/// §16 LLVM-text mem-intrinsic typed call shapes.
+
+/// mirCallMemcpy{Volatile,NonVolatile}Line / mirCallMemmoveNonVolatileLine
+/// / mirCallMemsetZeroLine — common memcpy/memmove/memset shapes.
+pub fn mirCallMemcpyVolatileLine(dst: String, src: String, sizeBytes: String) -> String {
+    mirCallVoidLLVMMemcpyLine(dst, src, sizeBytes, "true")
+}
+
+pub fn mirCallMemcpyNonVolatileLine(dst: String, src: String, sizeBytes: String) -> String {
+    mirCallVoidLLVMMemcpyLine(dst, src, sizeBytes, "false")
+}
+
+pub fn mirCallMemmoveNonVolatileLine(dst: String, src: String, sizeBytes: String) -> String {
+    mirCallVoidLLVMMemmoveLine(dst, src, sizeBytes, "false")
+}
+
+pub fn mirCallMemsetZeroLine(dst: String, sizeBytes: String) -> String {
+    mirCallVoidLLVMMemsetLine(dst, "0", sizeBytes, "false")
+}
+
+/// §16 LLVM-text typed-runtime-callable testing helpers (aliases).
+
+pub fn mirCallTestAbortLine(messagePtr: String) -> String {
+    mirCallVoidTestingAbortLine(messagePtr)
+}
+
+pub fn mirCallTestContextEnterLine(nameReg: String) -> String {
+    mirCallVoidTestingContextEnterLine(nameReg)
+}
+
+pub fn mirCallTestContextExitLine() -> String {
+    mirCallVoidTestingContextExitLine()
+}
+
+pub fn mirCallTestExpectOkLine(reg: String, resultReg: String) -> String {
+    mirCallValueTestingExpectOkLine(reg, resultReg)
+}
+
+pub fn mirCallTestExpectErrorLine(reg: String, resultReg: String) -> String {
+    mirCallValueTestingExpectErrorLine(reg, resultReg)
+}
+
+/// §16 LLVM-text typed runtime-callable bench helpers (aliases).
+
+pub fn mirCallBenchNowNanosLine(reg: String) -> String {
+    mirCallValueBenchNowNanosLine(reg)
+}
+
+pub fn mirCallBenchTargetNsLine(reg: String) -> String {
+    mirCallValueBenchTargetNsLine(reg)
+}
+
+/// §16 LLVM-text typed-runtime-callable GC helpers (aliases).
+
+pub fn mirCallGCAllocLine(reg: String, sizeBytes: String, kind: String) -> String {
+    mirCallValueGCAllocLine(reg, sizeBytes, kind)
+}
+
+pub fn mirCallGCSafepointLine(slotsPtr: String, slotCount: String) -> String {
+    mirCallVoidGCSafepointLine(slotsPtr, slotCount)
+}
+
+pub fn mirCallGCBarrierLine(targetPtr: String, valuePtr: String) -> String {
+    mirCallVoidGCBarrierLine(targetPtr, valuePtr)
+}
+
+pub fn mirCallGCAllocatedBytesLine(reg: String) -> String {
+    mirCallValueGCAllocatedBytesLine(reg)
+}
+
+/// §16 LLVM-text typed runtime-callable string-debug helpers.
+
+pub fn mirCallDiffLinesLine(reg: String, expectedReg: String, actualReg: String) -> String {
+    mirCallValueStringDiffLinesLine(reg, expectedReg, actualReg)
+}
+
+/// §16 LLVM-text typed-call-and-no-store composites.
+
+/// mirCallVoidWithI1ResultDiscardLine renders the canonical "call i1
+/// + ignore result" 1-line shape.
+pub fn mirCallVoidWithI1ResultDiscardLine(reg: String, sym: String, args: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i1 @" + sym + "(" + args + ")\n"
+}
+
+/// §16 LLVM-text option/result spilling helpers.
+
+/// mirSpillOptionAggregateLine / SpillOptionPtrAggregateLine /
+/// SpillResultAggregateLine / SpillResultPtrAggregateLine — spill
+/// composite (alloca + store).
+pub fn mirSpillOptionAggregateLine(slotReg: String, agg: String) -> String {
+    mirAllocaSingleLine(slotReg, mirOptionAggregateType()) +
+    mirStoreOptionAggregateLine(agg, slotReg)
+}
+
+pub fn mirSpillOptionPtrAggregateLine(slotReg: String, agg: String) -> String {
+    mirAllocaSingleLine(slotReg, mirOptionPtrAggregateType()) +
+    mirStoreOptionPtrAggregateLine(agg, slotReg)
+}
+
+pub fn mirSpillResultAggregateLine(slotReg: String, agg: String) -> String {
+    mirSpillOptionAggregateLine(slotReg, agg)
+}
+
+pub fn mirSpillResultPtrAggregateLine(slotReg: String, agg: String) -> String {
+    mirSpillOptionPtrAggregateLine(slotReg, agg)
+}
+
+/// §16 LLVM-text typed-arg list 4/5/6-elem composers (aliases).
+
+pub fn mirArgListFourMixed(a: String, b: String, c: String, d: String) -> String {
+    mirJoinCommaFour(a, b, c, d)
+}
+
+pub fn mirArgListFiveMixed(a: String, b: String, c: String, d: String, e: String) -> String {
+    mirJoinCommaFive(a, b, c, d, e)
+}
+
+pub fn mirArgListSixMixed(a: String, b: String, c: String, d: String, e: String, f: String) -> String {
+    mirJoinCommaSix(a, b, c, d, e, f)
+}
+
+/// §16 LLVM-text emit-pass header / footer helpers.
+
+/// mirModulePreambleLine renders the canonical 3-line module
+/// preamble: source_filename + target triple + datalayout.
+pub fn mirModulePreambleLine(sourcePath: String, triple: String, layout: String) -> String {
+    mirModuleHeaderSourceFilename(sourcePath) +
+    mirModuleHeaderTargetTriple(triple) +
+    mirModuleHeaderDataLayout(layout)
+}
+
+/// mirModuleEpilogueLine renders the canonical module epilogue.
+pub fn mirModuleEpilogueLine(version: String) -> String {
+    mirIdentList(mirCompilerInfoLine(version))
+}
+
+/// §16 LLVM-text typed-cast-then-call composite shapes.
+
+/// mirCastI64ToPtrThenCallLine renders the canonical inttoptr + call
+/// 2-line shape.
+pub fn mirCastI64ToPtrThenCallLine(castReg: String, val: String, resultReg: String, sym: String) -> String {
+    mirCastI64ToPtrLine(castReg, val) +
+    mirCallValuePtrFromPtrLine(resultReg, sym, castReg)
+}
+
+/// mirCastPtrToI64ThenCallLine renders the canonical ptrtoint + call
+/// 2-line shape.
+pub fn mirCastPtrToI64ThenCallLine(castReg: String, val: String, resultReg: String, sym: String, args: String) -> String {
+    mirCastPtrToI64Line(castReg, val) +
+    "  " + resultReg + " = " + mirInstrCall() + " i64 @" + sym + "(" + args + ")\n"
+}
+
+/// §16 LLVM-text typed-zext-then-call composite shapes.
+
+/// mirZExtI8ToI64ThenCallLine / mirZExtI1ToI64ThenCallLine — zext + call.
+pub fn mirZExtI8ToI64ThenCallLine(zextReg: String, val: String, resultReg: String, sym: String) -> String {
+    mirZExtI8ToI64Line(zextReg, val) +
+    mirCallValueI64FromPtrLine(resultReg, sym, zextReg)
+}
+
+pub fn mirZExtI1ToI64ThenCallLine(zextReg: String, val: String, resultReg: String, sym: String) -> String {
+    mirZExtI1ToI64Line(zextReg, val) +
+    mirCallValueI64FromPtrLine(resultReg, sym, zextReg)
+}
+
+/// §16 LLVM-text typed-trunc-then-store composite shapes.
+
+/// mirTruncI64ToI8ThenStoreLine renders the canonical trunc + store
+/// 2-line shape.
+pub fn mirTruncI64ToI8ThenStoreLine(truncReg: String, val: String, slot: String) -> String {
+    mirTruncI64ToI8Line(truncReg, val) +
+    mirStoreI8Line(truncReg, slot)
+}
+
+/// mirTruncI64ToI1ThenStoreLine renders the canonical trunc + store-i1.
+pub fn mirTruncI64ToI1ThenStoreLine(truncReg: String, val: String, slot: String) -> String {
+    mirTruncI64ToI1Line(truncReg, val) +
+    "  " + mirInstrStore() + " i1 " + truncReg + ", ptr " + slot + "\n"
+}
+
+/// mirTruncI64ToI32ThenStoreLine renders the canonical trunc + store-i32.
+pub fn mirTruncI64ToI32ThenStoreLine(truncReg: String, val: String, slot: String) -> String {
+    mirTruncI64ToI32Line(truncReg, val) +
+    mirStoreI32Line(truncReg, slot)
+}
+
+/// §17 LLVM-text typed list runtime call aliases — long-tail
+/// composite shapes that drain inline runtime call sequences.
+
+/// mirCallListLengthLine renders the canonical list-length call.
+/// Synonym of `mirCallListLenLine` named for the readable site.
+pub fn mirCallListLengthLine(reg: String, listReg: String) -> String {
+    mirCallListLenLine(reg, listReg)
+}
+
+/// mirCallMapLengthLine renders the canonical map-length call.
+pub fn mirCallMapLengthLine(reg: String, mapReg: String) -> String {
+    mirCallMapLenLine(reg, mapReg)
+}
+
+/// mirCallSetLengthLine renders the canonical set-length call.
+pub fn mirCallSetLengthLine(reg: String, setReg: String) -> String {
+    mirCallSetLenLine(reg, setReg)
+}
+
+/// mirCallStringLengthLine renders the canonical string-length call.
+pub fn mirCallStringLengthLine(reg: String, strReg: String) -> String {
+    mirCallI64FromPtrLine(reg, mirRtStringLenSymbol(), strReg)
+}
+
+/// mirCallBytesLengthLine renders the canonical bytes-length call.
+pub fn mirCallBytesLengthLine(reg: String, bytesReg: String) -> String {
+    mirCallBytesLenLine(reg, bytesReg)
+}
+
+/// §17 LLVM-text typed iterator-call shapes.
+
+/// mirCallListReverseLine renders the canonical list-reverse call.
+pub fn mirCallListReverseLine(listReg: String) -> String {
+    mirCallVoidPtrLine(mirRtListReverseSymbol(), listReg)
+}
+
+/// mirCallListReversedLine renders the canonical list-reversed call.
+pub fn mirCallListReversedLine(reg: String, listReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtListReversedSymbol(), listReg)
+}
+
+/// mirCallListClearLine renders the canonical list-clear call.
+pub fn mirCallListClearLine(listReg: String) -> String {
+    mirCallVoidPtrLine(mirRtListClearSymbol(), listReg)
+}
+
+/// mirCallMapClearLine renders the canonical map-clear call.
+pub fn mirCallMapClearLine(mapReg: String) -> String {
+    mirCallVoidPtrLine(mirRtMapClearSymbol(), mapReg)
+}
+
+/// mirCallSetClearLine renders the canonical set-clear call.
+pub fn mirCallSetClearLine(setReg: String) -> String {
+    mirCallVoidPtrLine(mirRtSetClearSymbol(), setReg)
+}
+
+/// mirCallListPopDiscardLine renders the canonical list-pop-discard
+/// call.
+pub fn mirCallListPopDiscardLine(listReg: String) -> String {
+    mirCallVoidPtrLine(mirRtListPopDiscardSymbol(), listReg)
+}
+
+/// mirCallListIsEmptyTypedLine renders the canonical list-is-empty
+/// call (using mirRtListIsEmptySymbol composer).
+pub fn mirCallListIsEmptyTypedLine(reg: String, listReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtListIsEmptySymbol(), listReg)
+}
+
+/// §17 LLVM-text typed-runtime-callable container-conversion helpers.
+
+/// mirCallSetToListLine renders the canonical set-to-list call.
+pub fn mirCallSetToListLine(reg: String, setReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtSetToListSymbol(), setReg)
+}
+
+/// mirCallMapValuesLine renders the canonical map-values call.
+pub fn mirCallMapValuesLine(reg: String, mapReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtMapValuesSymbol(), mapReg)
+}
+
+/// mirCallMapEntriesLine renders the canonical map-entries call.
+pub fn mirCallMapEntriesLine(reg: String, mapReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtMapEntriesSymbol(), mapReg)
+}
+
+/// §17 LLVM-text typed-runtime-callable channel-state helpers.
+
+/// mirCallChannelCloseLine renders the canonical channel-close call.
+pub fn mirCallChannelCloseLine(chanReg: String) -> String {
+    mirCallVoidPtrLine(mirRtChanCloseSymbol(), chanReg)
+}
+
+/// mirCallChannelIsClosedLine renders the canonical channel-is-closed
+/// predicate call.
+pub fn mirCallChannelIsClosedLine(reg: String, chanReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtChanIsClosedSymbol(), chanReg)
+}
+
+/// mirCallChannelLenLine renders the canonical channel-len call.
+pub fn mirCallChannelLenLine(reg: String, chanReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, mirRtChanLenSymbol(), chanReg)
+}
+
+/// mirCallChannelCapLine renders the canonical channel-cap call.
+pub fn mirCallChannelCapLine(reg: String, chanReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, mirRtChanCapSymbol(), chanReg)
+}
+
+/// §17 LLVM-text typed-runtime-callable cancel helpers.
+
+/// mirCallCancelCheckLine renders the canonical cancel-check call.
+pub fn mirCallCancelCheckLine(reg: String) -> String {
+    mirCallI1NoArgsLine(reg, mirRtCancelCheckCancelledSymbol())
+}
+
+/// mirCallCancelIsCancelledLine renders the canonical cancel-is-cancelled
+/// call.
+pub fn mirCallCancelIsCancelledLine(reg: String) -> String {
+    mirCallI1NoArgsLine(reg, mirRtCancelIsCancelledSymbol())
+}
+
+/// mirCallCancelCancelLine renders the canonical cancel-cancel call.
+pub fn mirCallCancelCancelLine() -> String {
+    mirCallVoidNoArgsLine(mirRtCancelCancelSymbol())
+}
+
+/// §17 LLVM-text typed-runtime-callable thread-state helpers.
+
+/// mirCallThreadYieldLine renders the canonical thread-yield call.
+pub fn mirCallThreadYieldLine() -> String {
+    mirCallVoidNoArgsLine(mirRtThreadYieldSymbol())
+}
+
+/// mirCallThreadSleepLine renders the canonical thread-sleep call.
+pub fn mirCallThreadSleepLine(nsReg: String) -> String {
+    mirCallVoidFromI64Line(mirRtThreadSleepSymbol(), nsReg)
+}
+
+/// §17 LLVM-text typed-runtime-callable string operations.
+
+/// mirCallStringConcatTwoLine renders the canonical 2-arg string-
+/// concat call.
+pub fn mirCallStringConcatTwoLine(reg: String, leftReg: String, rightReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), leftReg) +
+    mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), rightReg)
+}
+
+/// mirCallStringHashLine renders the canonical string-hash call.
+pub fn mirCallStringHashLine(reg: String, strReg: String) -> String {
+    mirCallValueI64FromPtrLine(reg, mirRtStringHashSymbol(), strReg)
+}
+
+/// mirCallStringIsEmptyLine renders the canonical string-is-empty
+/// predicate call.
+pub fn mirCallStringIsEmptyLine(reg: String, strReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtStringIsEmptySymbol(), strReg)
+}
+
+/// mirCallStringToUpperLine renders the canonical string-to-upper call.
+pub fn mirCallStringToUpperLine(reg: String, strReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtStringToUpperSymbol(), strReg)
+}
+
+/// mirCallStringToLowerLine renders the canonical string-to-lower call.
+pub fn mirCallStringToLowerLine(reg: String, strReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtStringToLowerSymbol(), strReg)
+}
+
+/// mirCallStringTrimLine renders the canonical string-trim call.
+pub fn mirCallStringTrimLine(reg: String, strReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtStringTrimSymbol(), strReg)
+}
+
+/// mirCallStringRepeatLine renders the canonical string-repeat call.
+pub fn mirCallStringRepeatLine(reg: String, strReg: String, nReg: String) -> String {
+    mirCallPtrFromPtrI64Line(reg, mirRtStringRepeatSymbol(), strReg, nReg)
+}
+
+/// §17 LLVM-text typed-runtime-callable bytes operations.
+
+/// mirCallBytesIsEmptyLine renders the canonical bytes-is-empty call.
+pub fn mirCallBytesIsEmptyLine(reg: String, bytesReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtBytesIsEmptySymbol(), bytesReg)
+}
+
+/// mirCallBytesGetTypedLine renders the canonical bytes-get call
+/// (typed for i8 byte access).
+pub fn mirCallBytesGetTypedLine(reg: String, bytesReg: String, idxReg: String) -> String {
+    "  " + reg + " = " + mirInstrCall() + " i8 @" + mirRtBytesGetSymbol() + "(ptr " + bytesReg + ", i64 " + idxReg + ")\n"
+}
+
+/// mirCallBytesContainsLine renders the canonical bytes-contains call.
+pub fn mirCallBytesContainsLine(reg: String, bytesReg: String, needleReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg) +
+    mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), needleReg)
+}
+
+/// mirCallBytesStartsWithLine renders the canonical bytes-starts-with call.
+pub fn mirCallBytesStartsWithLine(reg: String, bytesReg: String, prefixReg: String) -> String {
+    mirCallI1FromTwoPtrLine(reg, mirRtBytesStartsWithSymbol(), bytesReg, prefixReg)
+}
+
+/// mirCallBytesEndsWithLine renders the canonical bytes-ends-with call.
+pub fn mirCallBytesEndsWithLine(reg: String, bytesReg: String, suffixReg: String) -> String {
+    mirCallI1FromTwoPtrLine(reg, mirRtBytesEndsWithSymbol(), bytesReg, suffixReg)
+}
+
+/// §17 LLVM-text typed runtime-callable map / set operations.
+
+/// mirCallMapInsertLine renders the canonical map-insert call.
+pub fn mirCallMapInsertLine(mapReg: String, keyArgs: String, valArgs: String) -> String {
+    "  " + mirInstrCallVoid() + " void @" + mirRtMapInsertSymbol() + "(ptr " + mapReg + ", " + keyArgs + ", " + valArgs + ")\n"
+}
+
+/// mirCallMapRemoveLine renders the canonical map-remove call.
+pub fn mirCallMapRemoveLine(mapReg: String, keyArgs: String) -> String {
+    "  " + mirInstrCallVoid() + " void @" + mirRtMapRemoveSymbol() + "(ptr " + mapReg + ", " + keyArgs + ")\n"
+}
+
+/// mirCallSetAddLine renders the canonical set-add call.
+pub fn mirCallSetAddLine(setReg: String, elemArgs: String) -> String {
+    "  " + mirInstrCallVoid() + " void @" + mirRtSetAddSymbol() + "(ptr " + setReg + ", " + elemArgs + ")\n"
+}
+
+/// mirCallSetRemoveLine renders the canonical set-remove call.
+pub fn mirCallSetRemoveLine(setReg: String, elemArgs: String) -> String {
+    "  " + mirInstrCallVoid() + " void @" + mirRtSetRemoveSymbol() + "(ptr " + setReg + ", " + elemArgs + ")\n"
+}
+
+/// §17 LLVM-text typed runtime-callable structured-concurrency.
+
+/// mirCallTaskGroupNewLine renders the canonical task-group factory call.
+pub fn mirCallTaskGroupNewLine(reg: String) -> String {
+    mirCallPtrNoArgsLine(reg, mirRtTaskGroupRootSymbol())
+}
+
+/// mirCallTaskGroupCancelLine renders the canonical task-group cancel call.
+pub fn mirCallTaskGroupCancelLine(groupReg: String) -> String {
+    mirCallVoidPtrLine(mirRtTaskGroupCancelSymbol(), groupReg)
+}
+
+/// mirCallTaskGroupIsCancelledLine renders the canonical task-group
+/// is-cancelled probe.
+pub fn mirCallTaskGroupIsCancelledLine(reg: String, groupReg: String) -> String {
+    mirCallValueI1FromPtrLine(reg, mirRtTaskGroupIsCancelledSymbol(), groupReg)
+}
+
+/// mirCallTaskHandleJoinLine renders the canonical task-handle-join call.
+pub fn mirCallTaskHandleJoinLine(reg: String, handleReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtTaskHandleJoinSymbol(), handleReg)
+}
+
+/// mirCallTaskCollectAllLine renders the canonical collect-all call.
+pub fn mirCallTaskCollectAllLine(reg: String, listReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtTaskCollectAllSymbol(), listReg)
+}
+
+/// mirCallTaskRaceLine renders the canonical race call.
+pub fn mirCallTaskRaceLine(reg: String, bodyReg: String) -> String {
+    mirCallValuePtrFromPtrLine(reg, mirRtTaskRaceSymbol(), bodyReg)
+}
+
+/// §17 LLVM-text typed runtime-callable panic / abort helpers.
+
+/// mirCallPanicLine renders the canonical panic call.
+pub fn mirCallPanicLine(messagePtr: String) -> String {
+    mirCallVoidPtrLine(mirRtPanicSymbol(), messagePtr)
+}
+
+/// mirCallUnreachableLine renders the canonical unreachable call.
+pub fn mirCallUnreachableLine() -> String {
+    mirCallVoidNoArgsLine(mirRtUnreachableSymbol())
+}
+
+/// mirCallTodoLine renders the canonical todo!() call.
+pub fn mirCallTodoLine() -> String {
+    mirCallVoidNoArgsLine(mirRtTodoSymbol())
+}
+
+/// mirCallAbortLine renders the canonical abort!() call.
+pub fn mirCallAbortLine() -> String {
+    mirCallVoidNoArgsLine(mirRtAbortSymbol())
+}
+
+/// mirCallOptionUnwrapNoneLine renders the canonical Option-unwrap-None
+/// panic call.
+pub fn mirCallOptionUnwrapNoneLine() -> String {
+    mirCallVoidNoArgsLine(mirRtOptionUnwrapNoneSymbol())
+}
+
+/// mirCallResultUnwrapErrLine renders the canonical Result-unwrap-Err
+/// panic call.
+pub fn mirCallResultUnwrapErrLine() -> String {
+    mirCallVoidNoArgsLine(mirRtResultUnwrapErrSymbol())
+}
+
+/// mirCallExpectFailedLine renders the canonical expect-failed call.
+pub fn mirCallExpectFailedLine() -> String {
+    mirCallVoidNoArgsLine(mirRtExpectFailedSymbol())
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12414,10 +12414,9 @@ pub fn mirCallThreadSleepLine(nsReg: String) -> String {
 /// §17 LLVM-text typed-runtime-callable string operations.
 
 /// mirCallStringConcatTwoLine renders the canonical 2-arg string-
-/// concat call.
+/// concat call: `<reg> = call ptr @osty_rt_strings_Concat(ptr <left>, ptr <right>)`.
 pub fn mirCallStringConcatTwoLine(reg: String, leftReg: String, rightReg: String) -> String {
-    mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), leftReg) +
-    mirCallValuePtrFromPtrLine(reg, mirRtStringConcatSymbol(), rightReg)
+    mirCallPtrFromTwoPtrLine(reg, mirRtStringConcatSymbol(), leftReg, rightReg)
 }
 
 /// mirCallStringHashLine renders the canonical string-hash call.
@@ -12464,10 +12463,10 @@ pub fn mirCallBytesGetTypedLine(reg: String, bytesReg: String, idxReg: String) -
     "  " + reg + " = " + mirInstrCall() + " i8 @" + mirRtBytesGetSymbol() + "(ptr " + bytesReg + ", i64 " + idxReg + ")\n"
 }
 
-/// mirCallBytesContainsLine renders the canonical bytes-contains call.
+/// mirCallBytesContainsLine renders the canonical bytes-contains call:
+/// `<reg> = call i1 @osty_rt_bytes_contains(ptr <bytes>, ptr <needle>)`.
 pub fn mirCallBytesContainsLine(reg: String, bytesReg: String, needleReg: String) -> String {
-    mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg) +
-    mirCallValueI1FromPtrLine(reg, mirRtBytesContainsSymbol(), needleReg)
+    mirCallI1FromTwoPtrLine(reg, mirRtBytesContainsSymbol(), bytesReg, needleReg)
 }
 
 /// mirCallBytesStartsWithLine renders the canonical bytes-starts-with call.


### PR DESCRIPTION
## Summary

2,015-line slice of the MIR emitter port (Go → Osty self-host).

### §14 Option / Result aggregate-construction shapes

- 2-line build composites (`mirOptionSomeI64BuildLine`, `OptionSomePtrBuildLine`, `ResultOk{I64,Ptr}BuildLine`, `ResultErrPtrBuildLine`)
- Discriminant + payload destructure composites (Option / OptionPtr / Result)
- Discriminant test composites (`IsSome` / `IsNone` / `IsOk` / `IsErr`)
- Branch-on-discriminant 3-line composites (Option / Result)
- Pool emit aliases (InternedString / InternedFormat)
- For-range loop prelude / head composites
- Match-arm head / body shape composers
- 4-line array bounds check composite
- Vector-list snapshot 3-line composite (with branch)
- Cast aliases (FPToSIWithRTZ / SIToFPDefault)
- Alloca + memcpy 2-line composite
- Canonical None aggregate emit shapes
- Module-globals emit aliases
- Call-and-store 2-line shapes (I64 / I1 / Ptr)

### §15 typed call / load / cmp composites

- Load + call 2-line shapes (Void / Value / I64 / I1)
- Predicate + branch 2-line shapes (icmp i64 + branch ×6, ptr-eq, null-ptr)
- Generic call + store 2-line shape
- Load + cmp 2-line shapes (i64 eq/ne/zero, ptr null)
- Load + store typed shapes (i1, double)
- Return-constant 1-line shapes + 5 zero/null/false/true defaults
- Arg-list shape aliases (PtrPtr, PtrI64Slot, ThreePtrSlot)
- Arith + store composites (Add/Sub immediate)
- If-then-else block skeleton composite
- Aggregate store / load 1-line shapes (Option / Result × scalar / ptr)

### §16 LLVM intrinsic / lifetime / mem composites

- Math intrinsic call aliases (sqrt/fabs/sin/cos/tan/log/log2/log10/exp/exp2/pow/minnum/maxnum)
- Bit-manip intrinsic call aliases (ctlz/cttz/ctpop/bswap{i64,i32,i16}/bitreverse)
- Lifetime / assume / branch-hint call aliases
- Memcpy/memmove/memset typed call shapes (volatile / nonvolatile / zero)
- Test-runtime call aliases (abort/contextEnter/contextExit/expectOk/expectError)
- Bench / GC / diff-debug call aliases
- Discard-result i1-call shape
- Aggregate spill 2-line composites (Option / Result × scalar / ptr)
- Pre-typed 4/5/6-elem arg-list joiners
- Module preamble (3-line) / epilogue composites
- Cast + call 2-line composites (i64↔ptr)
- ZExt + call 2-line composites (i8/i1 → i64)
- Trunc + store 2-line composites (i64 → i8/i1/i32)

### §17 typed runtime call composites

- Typed list runtime call composites (Length/Reverse/Reversed/Clear/PopDiscard/IsEmpty)
- Typed length / size runtime call composites (Map/Set/String/Bytes)
- Container conversion call composites (SetToList/MapValues/MapEntries)
- Channel-state runtime call composites (Close/IsClosed/Len/Cap)
- Cancel / thread runtime call composites (Check/IsCancelled/Cancel/Yield/Sleep)
- String runtime operation call composites (ConcatTwo/Hash/IsEmpty/ToUpper/ToLower/Trim/Repeat)
- Bytes runtime operation call composites (IsEmpty/GetTyped/Contains/StartsWith/EndsWith)
- Map / set mutation call composites (Insert/Remove/Add/Remove)
- Structured-concurrency call composites (TaskGroup{New,Cancel,IsCancelled}/HandleJoin/CollectAll/Race)
- Panic / abort runtime call composites (Panic/Unreachable/Todo/Abort/OptionUnwrapNone/ResultUnwrapErr/ExpectFailed)

### Drained inline sites in `mir_generator.go`

- 4 inline `"osty_rt_*"` suffix-keyed sites → `mirRtList{Set,Get}SuffixSymbol` / `mirRtMapKeysSortedSuffixSymbol` / `mirRtSelectSendSuffixSymbol` composers
- 4 inline `mirInsertValueAggLine` sites with hardcoded `"i64"` → `mirInsertValueI64Line`

### Mirrored everything in `mir_generator_snapshot.go`. Updated `MIR_EMITTER_PORT.md` inventory.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — only 5 pre-existing failures (identical to baseline before this branch)