### PR TITLE
perf(runtime): make CLOSURE_ENV young-eligible (cheney covers it end-to-end)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -1661,13 +1661,8 @@ int main(void) {
      * through the env's trace. If the trace is not wired, they're
      * swept.
      *
-     * Order matters: captures are populated BEFORE root_bind. This
-     * matches the production LLVM-emit order (alloc + store thunk +
-     * store captures land in a single basic block before the env
-     * ever escapes to a slot that triggers root_bind). On young
-     * eligibility, root_bind auto-promotes the young env to OLD via
-     * memcpy — captures populated beforehand survive the copy; later
-     * writes via the now-stale young pointer would not propagate. */
+     * Captures populated BEFORE root_bind — see osty_gc_young_eligible
+     * in osty_runtime.c for the contract. */
     osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(3, "env3", 0x7ULL);
     void *cap0 = osty_gc_alloc_v1(7, 32, "cap0");
     void *cap1 = osty_gc_alloc_v1(7, 32, "cap1");
@@ -1764,12 +1759,8 @@ int main(void) {
     /* Two captures: slot 0 scalar (bit 0 cleared), slot 1 pointer
      * (bit 1 set). Bitmap = 0b10 = 0x2.
      *
-     * Order matters (matches production LLVM-emit order): captures
-     * are populated BEFORE root_bind. With CLOSURE_ENV young
-     * eligibility, root_bind auto-promotes the env to OLD via
-     * memcpy — populating captures beforehand keeps them in the
-     * promoted copy; writes via a stale young pointer afterward
-     * would not propagate. */
+     * Captures populated BEFORE root_bind — see osty_gc_young_eligible
+     * in osty_runtime.c for the contract. */
     osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(2, "env2", 0x2ULL);
 
     /* Payload P: allocate but do not root. Its only potential
@@ -6625,9 +6616,8 @@ int main(void) {
 			wantClass: [6]string{"0", "0", "0", "0", "0", "0"},
 		},
 		{
-			// Default (Phase 8 step 2 cutover + Phase E follow-up):
-			// STRING + BYTES + LIST + CLOSURE_ENV route to young arena.
-			// GENERIC / MAP / CHANNEL stay headerful.
+			// Default routing: STRING + BYTES + LIST + CLOSURE_ENV →
+			// young arena; GENERIC / MAP / CHANNEL stay headerful.
 			name:      "default",
 			env:       nil,
 			wantDelta: "4",

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -1659,15 +1659,23 @@ int main(void) {
      * Allocate three managed payloads and store them into capture
      * slots. They are NOT root-bound — their only liveness path is
      * through the env's trace. If the trace is not wired, they're
-     * swept. */
+     * swept.
+     *
+     * Order matters: captures are populated BEFORE root_bind. This
+     * matches the production LLVM-emit order (alloc + store thunk +
+     * store captures land in a single basic block before the env
+     * ever escapes to a slot that triggers root_bind). On young
+     * eligibility, root_bind auto-promotes the young env to OLD via
+     * memcpy — captures populated beforehand survive the copy; later
+     * writes via the now-stale young pointer would not propagate. */
     osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(3, "env3", 0x7ULL);
-    osty_gc_root_bind_v1(env);
     void *cap0 = osty_gc_alloc_v1(7, 32, "cap0");
     void *cap1 = osty_gc_alloc_v1(7, 32, "cap1");
     void *cap2 = osty_gc_alloc_v1(7, 32, "cap2");
     env->captures[0] = cap0;
     env->captures[1] = cap1;
     env->captures[2] = cap2;
+    osty_gc_root_bind_v1(env);
 
     int64_t live_before = osty_gc_debug_live_count();
     osty_gc_debug_collect();
@@ -1677,10 +1685,16 @@ int main(void) {
      * After collect: env0 and env still rooted, captures survive via
      * trace → same count. Would drop by 3 if trace were broken. */
     printf("%lld %lld\n", (long long)live_before, (long long)live_after);
+    /* Refresh env via load_v1 to follow the PROMOTED tag (root_bind
+     * promoted the young env to OLD; the local env handle is now
+     * stale). Both sides use load_v1 so the comparison stays valid
+     * even when major compaction has relocated the OLD capture
+     * targets. */
+    osty_rt_closure_env *live_env = (osty_rt_closure_env *)osty_gc_load_v1(env);
     printf("%d %d %d\n",
-        env->captures[0] == osty_gc_load_v1(cap0),
-        env->captures[1] == osty_gc_load_v1(cap1),
-        env->captures[2] == osty_gc_load_v1(cap2));
+        live_env->captures[0] == osty_gc_load_v1(cap0),
+        live_env->captures[1] == osty_gc_load_v1(cap1),
+        live_env->captures[2] == osty_gc_load_v1(cap2));
     return 0;
 }
 `), 0o644); err != nil {
@@ -1748,9 +1762,15 @@ int64_t osty_gc_debug_live_count(void);
 
 int main(void) {
     /* Two captures: slot 0 scalar (bit 0 cleared), slot 1 pointer
-     * (bit 1 set). Bitmap = 0b10 = 0x2. */
+     * (bit 1 set). Bitmap = 0b10 = 0x2.
+     *
+     * Order matters (matches production LLVM-emit order): captures
+     * are populated BEFORE root_bind. With CLOSURE_ENV young
+     * eligibility, root_bind auto-promotes the env to OLD via
+     * memcpy — populating captures beforehand keeps them in the
+     * promoted copy; writes via a stale young pointer afterward
+     * would not propagate. */
     osty_rt_closure_env *env = (osty_rt_closure_env *)osty_rt_closure_env_alloc_v2(2, "env2", 0x2ULL);
-    osty_gc_root_bind_v1(env);
 
     /* Payload P: allocate but do not root. Its only potential
      * liveness path is through env's scalar capture slot. */
@@ -1768,6 +1788,8 @@ int main(void) {
      * Must survive collection. */
     void *q = osty_gc_alloc_v1(7, 32, "pointer_capture");
     env->captures[1] = q;
+
+    osty_gc_root_bind_v1(env);
 
     int64_t live_before = osty_gc_debug_live_count();
     osty_gc_debug_collect();
@@ -6265,11 +6287,14 @@ int main(void) {
 // (flag off / GENERIC / has-destroy / oversized / zero-size) keep
 // behaving as designed even when no production caller uses it yet.
 //
-// Allowed kinds today: STRING, BYTES (immutable byte payloads).
-// Rejected: CLOSURE_ENV (callers mutate captures after alloc, breaks
-// auto-promote-on-pin), LIST/MAP/SET/CHANNEL (have destroy callbacks
-// Cheney can't invoke), GENERIC (per-instance callbacks not on the
-// micro-header), humongous (size > threshold).
+// Allowed kinds today: STRING, BYTES (immutable byte payloads),
+// LIST (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list
+// scan), CLOSURE_ENV (captures populated synchronously at
+// construction before the env escapes; promote-on-bind copies a
+// fully-populated env to OLD).
+// Rejected: MAP/SET/CHANNEL (have destroy callbacks Cheney can't
+// invoke), GENERIC (per-instance callbacks not on the micro-header),
+// humongous (size > threshold).
 func TestBundledRuntimeYoungEligibilityFilter(t *testing.T) {
 	parallelClangBackendTest(t)
 
@@ -6359,7 +6384,7 @@ int main(void) {
 				"1026 0 0", // MAP: has destroy (free's keys/values arrays — needs typed sweep)
 				"1027 0 0", // SET: has destroy
 				"1028 1 1", // BYTES: eligible
-				"1029 0 0", // CLOSURE_ENV: post-alloc captures mutation breaks auto-promote
+				"1029 1 1", // CLOSURE_ENV: eligible (captures populated synchronously before escape)
 				"1030 0 0", // CHANNEL: has destroy
 			},
 		},
@@ -6601,12 +6626,12 @@ int main(void) {
 		},
 		{
 			// Default (Phase 8 step 2 cutover + Phase E follow-up):
-			// STRING + BYTES + LIST route to young arena.
-			// CLOSURE_ENV / GENERIC / MAP / CHANNEL stay headerful.
+			// STRING + BYTES + LIST + CLOSURE_ENV route to young arena.
+			// GENERIC / MAP / CHANNEL stay headerful.
 			name:      "default",
 			env:       nil,
-			wantDelta: "3",
-			wantClass: [6]string{"1", "1", "0", "1", "0", "0"},
+			wantDelta: "4",
+			wantClass: [6]string{"1", "1", "1", "1", "0", "0"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3100,19 +3100,24 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      dormant and every alloc takes the headerful path, preserving
  *      pre-Phase-5 behaviour exactly.
  *   2. The kind must be one of the young-safe kinds — STRING, BYTES,
- *      LIST. STRING/BYTES are immutable byte payloads. LIST has a
- *      destroy callback (frees spilled `data` + `gc_offsets`), but
- *      Phase E follow-up adds a from-space dead-list scan in
- *      cheney_minor that runs the destroy work just before the
- *      arena swap reclaims the bytes — making LIST safe to route
- *      through the no-header path despite the external resource.
- *      The scan also handles the self-referential `data` ptr
- *      fixup on the to-space copy when a forwarded List was inline.
+ *      LIST, CLOSURE_ENV. STRING/BYTES are immutable byte payloads.
+ *      LIST has a destroy callback (frees spilled `data` +
+ *      `gc_offsets`), but Phase E follow-up adds a from-space
+ *      dead-list scan in cheney_minor that runs the destroy work just
+ *      before the arena swap reclaims the bytes — making LIST safe to
+ *      route through the no-header path despite the external resource.
+ *      The scan also handles the self-referential `data` ptr fixup on
+ *      the to-space copy when a forwarded List was inline.
+ *      CLOSURE_ENV has no destroy callback (captures live inline in
+ *      the flexible array) and trace just walks `captures[]` under
+ *      the `pointer_bitmap`. The mutator contract is that captures
+ *      are populated synchronously at construction (single basic
+ *      block in LLVM emit) before the env escapes to a slot that
+ *      could trigger root_bind — so promote-on-bind copies a fully
+ *      populated env to OLD and post-promote stale-pointer writes
+ *      do not occur in production.
  *
  *      Why not the other no-destroy kinds:
- *        - CLOSURE_ENV: callers populate `captures[i]` after alloc
- *          and root-bind the env. Auto-promote would land on the
- *          dead young addr while the OLD copy holds zero captures.
  *        - GENERIC: per-instance trace/destroy callbacks not on the
  *          micro-header.
  *        - MAP/SET/CHANNEL: destroy frees pthread sync state,
@@ -3130,7 +3135,8 @@ static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size) {
     }
     if (object_kind != OSTY_GC_KIND_STRING &&
         object_kind != OSTY_GC_KIND_BYTES &&
-        object_kind != OSTY_GC_KIND_LIST) {
+        object_kind != OSTY_GC_KIND_LIST &&
+        object_kind != OSTY_GC_KIND_CLOSURE_ENV) {
         return false;
     }
     if (payload_size == 0 ||

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3117,14 +3117,12 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      populated env to OLD and post-promote stale-pointer writes
  *      do not occur in production.
  *
- *      Why not the other no-destroy kinds:
+ *      Why not the other kinds:
  *        - GENERIC: per-instance trace/destroy callbacks not on the
  *          micro-header.
- *        - MAP/SET/CHANNEL: destroy frees pthread sync state,
- *          backing arrays, etc. Same dead-from-space scan path
- *          could handle them but the typed-allocator surface is
- *          larger and the perf payoff smaller (these are typically
- *          long-lived).
+ *        - MAP/SET/CHANNEL: destroy frees pthread sync state and
+ *          backing arrays — typed-allocator surface is larger and
+ *          these are typically long-lived.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being


### PR DESCRIPTION
## Summary

CLOSURE_ENV joins STRING / BYTES / LIST in the no-header young arena. The trace fn (`osty_rt_closure_env_trace`) already walks `captures[]` under `pointer_bitmap` with no destroy callback, so cheney covers it end-to-end without extra work.

The mutator contract: captures must be populated synchronously at construction (single basic block in LLVM emit) before the env escapes to a slot that could trigger `root_bind`. `promote_young_to_old` then copies the fully-populated env to OLD via memcpy, so post-promote stale-pointer writes do not occur in production code.

## Changes

- `internal/backend/runtime/osty_runtime.c`: add `OSTY_GC_KIND_CLOSURE_ENV` to `osty_gc_young_eligible`; refresh the surrounding doc comment so it documents the four young-eligible kinds (S/B/L/E) and the contract.
- `internal/backend/llvm_runtime_gc_test.go`:
  - `TestBundledRuntimeClosureEnvTracesCaptures` and `TestBundledRuntimeClosureEnvBitmapSkipsScalarSlots`: reorder so captures are populated before `root_bind` (matches production ordering); refresh `env` via `osty_gc_load_v1` before the equality comparisons so the post-collect read follows the PROMOTED tag and major-compaction-relocated capture targets stay matchable.
  - `TestBundledRuntimeYoungEligibilityFilter`: CLOSURE_ENV row flips to `"1029 1 1"`.
  - `TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn`: default delta becomes 4 (S/B/L/E), classification slot 3 flips to `1`.

## Test plan

- [x] `go test ./internal/backend/ -run TestBundledRuntimeClosureEnv` — both pass
- [x] `go test ./internal/backend/ -run TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn` — both pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — entire bundled-runtime suite passes
- [x] `go test ./internal/backend/ -run "Gc|GC|Cheney|Young|Promote|Closure"` — all GC + closure tests pass
- [x] `go test ./internal/llvmgen/ -run "Closure|ClosureEnv|FnValue"` — closure-related llvmgen tests pass
- [x] Confirmed remaining `internal/backend` / `internal/llvmgen` / `cmd/osty` failures (`TestPhase2gUpdateUserCallsiteKeepsLockedLowering`, `TestNativeToolchainMergedMIRPipelineIsClean`, etc.) reproduce on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)