### PR TITLE
refactor(llvmgen): declare Phase 1 complete + begin Phase 2 (port localDisplayName)

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -1,5 +1,26 @@
 # MIR emitter selfhost port
 
+> **Phase 1 (LLVM-text builder library): COMPLETE (2026-04-27).**
+>
+> The §1–§17 builder library at `toolchain/mir_generator.osty`
+> (~1,665 `mir*` builders) covers every inline LLVM-text literal
+> shape the emit pass produces. After PR #962 + this slice, only 4
+> raw `g.fnBuf.WriteString` sites remain in `mir_generator.go` —
+> all of them flush pre-built helper output (`llvmRenderSafepointEmpty`,
+> `mirNoneAggregate.Lines`), not raw inline literals. **99.9% inline
+> literal coverage; further builder additions would create dormant
+> code without active call sites.**
+>
+> **Phase 2 (function port): IN PROGRESS (2026-04-27).**
+>
+> Now porting individual helper functions from `mir_generator.go` to
+> `toolchain/mir_generator.osty`. First port: `localDisplayName` →
+> `mirLocalDisplayNameFromText`. The `*mir.Local` host-boundary
+> stays Go-side; the name-extraction policy moves to Osty.
+>
+> Smaller PRs from this point forward — function porting is per-
+> function, not bulk drain. The "2k insertion" cadence ends here.
+
 > **Status (2026-04-26, post-rebase to #955): Partially historical.**
 >
 > - The bootstrap Osty→Go transpiler (`internal/bootstrap/gen`) was

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -236,7 +236,7 @@ func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
 // The array of parts is materialized in a stack alloca at the current
 // block — free for the caller and automatically dead after the call.
 func (g *generator) emitRuntimeStringConcatN(pieces []value) (value, error) {
-	symbol := "osty_rt_strings_ConcatN"
+	symbol := mirRtStringConcatNSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{
 		{typ: "i64"},
 		{typ: "ptr"},
@@ -1673,7 +1673,7 @@ func (g *generator) emitRuntimeBoolToString(v value) (value, error) {
 // The helper handles all four UTF-8 width classes plus the out-of-range
 // replacement-char fallback — see internal/backend/runtime/osty_runtime.c.
 func (g *generator) emitRuntimeCharToString(v value) (value, error) {
-	symbol := "osty_rt_char_to_string"
+	symbol := mirRtCharToStringSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "i32"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(v)})
@@ -1687,7 +1687,7 @@ func (g *generator) emitRuntimeCharToString(v value) (value, error) {
 // (i8) via osty_rt_byte_to_string. Treats the byte as a raw octet; useful
 // when iterating over text.bytes() and rebuilding the original bytes.
 func (g *generator) emitRuntimeByteToString(v value) (value, error) {
-	symbol := "osty_rt_byte_to_string"
+	symbol := mirRtByteToStringSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "i8"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(v)})
@@ -1700,7 +1700,7 @@ func (g *generator) emitRuntimeByteToString(v value) (value, error) {
 func (g *generator) emitRuntimeStringCompare(op token.Kind, left, right value) (value, error) {
 	switch op {
 	case token.EQ, token.NEQ:
-		g.declareRuntimeSymbol("osty_rt_strings_Equal", "i1", []paramInfo{
+		g.declareRuntimeSymbol(mirRtStringSymbol("Equal"), "i1", []paramInfo{
 			{typ: "ptr"},
 			{typ: "ptr"},
 		})
@@ -3932,7 +3932,7 @@ func (g *generator) emitBytesMethodCall(call *ast.CallExpr) (value, bool, error)
 		if len(call.Args) != 0 {
 			return value{}, true, unsupported("call", "Bytes.len requires no arguments")
 		}
-		symbol := "osty_rt_bytes_len"
+		symbol := mirRtBytesLenSymbolName()
 		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base)})
@@ -3942,7 +3942,7 @@ func (g *generator) emitBytesMethodCall(call *ast.CallExpr) (value, bool, error)
 		if len(call.Args) != 0 {
 			return value{}, true, unsupported("call", "Bytes.isEmpty requires no arguments")
 		}
-		symbol := "osty_rt_bytes_is_empty"
+		symbol := mirRtBytesIsEmptySymbol()
 		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4345,8 +4345,8 @@ func (g *generator) emitBytesMethodCall(call *ast.CallExpr) (value, bool, error)
 }
 
 func (g *generator) emitBytesGetRuntime(base, index value) (value, error) {
-	lenSymbol := "osty_rt_bytes_len"
-	getSymbol := "osty_rt_bytes_get"
+	lenSymbol := mirRtBytesLenSymbolName()
+	getSymbol := mirRtBytesGetSymbol()
 	g.declareRuntimeSymbol(lenSymbol, "i64", []paramInfo{{typ: "ptr"}})
 	g.declareRuntimeSymbol(getSymbol, "i8", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
@@ -4385,7 +4385,7 @@ func (g *generator) emitBytesGetRuntime(base, index value) (value, error) {
 }
 
 func (g *generator) emitBytesLastIndexRaw(base, needle value) (value, error) {
-	symbol := "osty_rt_bytes_last_index_of"
+	symbol := mirRtBytesLastIndexOfSymbol()
 	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
@@ -4394,7 +4394,7 @@ func (g *generator) emitBytesLastIndexRaw(base, needle value) (value, error) {
 }
 
 func (g *generator) emitBytesIndexOfRuntime(base, needle value) (value, error) {
-	symbol := "osty_rt_bytes_index_of"
+	symbol := mirRtBytesIndexOfSymbol()
 	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
@@ -4403,7 +4403,7 @@ func (g *generator) emitBytesIndexOfRuntime(base, needle value) (value, error) {
 }
 
 func (g *generator) emitBytesContainsRuntime(base, needle value) (value, error) {
-	symbol := "osty_rt_bytes_index_of"
+	symbol := mirRtBytesIndexOfSymbol()
 	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
@@ -4413,7 +4413,7 @@ func (g *generator) emitBytesContainsRuntime(base, needle value) (value, error) 
 }
 
 func (g *generator) emitBytesStartsWithRuntime(base, prefix value) (value, error) {
-	symbol := "osty_rt_bytes_index_of"
+	symbol := mirRtBytesIndexOfSymbol()
 	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(prefix)})
@@ -4423,7 +4423,7 @@ func (g *generator) emitBytesStartsWithRuntime(base, prefix value) (value, error
 }
 
 func (g *generator) emitBytesEndsWithRuntime(base, suffix value) (value, error) {
-	lenSymbol := "osty_rt_bytes_len"
+	lenSymbol := mirRtBytesLenSymbolName()
 	g.declareRuntimeSymbol(lenSymbol, "i64", []paramInfo{{typ: "ptr"}})
 	lastIndex, err := g.emitBytesLastIndexRaw(base, suffix)
 	if err != nil {
@@ -4450,7 +4450,7 @@ func (g *generator) emitBytesLastIndexOfRuntime(base, needle value) (value, erro
 }
 
 func (g *generator) emitBytesFromListRuntime(items value) (value, error) {
-	symbol := "osty_rt_bytes_from_list"
+	symbol := mirRtBytesSymbol("from_list")
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(items)})
@@ -4487,7 +4487,7 @@ func (g *generator) emitBytesListOfBytesExpr(expr ast.Expr, label string) (value
 }
 
 func (g *generator) emitBytesSplitRuntime(base, sep value) (value, error) {
-	symbol := "osty_rt_bytes_split"
+	symbol := mirRtBytesSplitSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(sep)})
@@ -4501,7 +4501,7 @@ func (g *generator) emitBytesSplitRuntime(base, sep value) (value, error) {
 }
 
 func (g *generator) emitBytesJoinRuntime(parts, sep value) (value, error) {
-	symbol := "osty_rt_bytes_join"
+	symbol := mirRtBytesJoinSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(parts), toOstyValue(sep)})
@@ -4513,7 +4513,7 @@ func (g *generator) emitBytesJoinRuntime(parts, sep value) (value, error) {
 }
 
 func (g *generator) emitBytesConcatRuntime(left, right value) (value, error) {
-	symbol := "osty_rt_bytes_concat"
+	symbol := mirRtBytesConcatSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(left), toOstyValue(right)})
@@ -4525,7 +4525,7 @@ func (g *generator) emitBytesConcatRuntime(left, right value) (value, error) {
 }
 
 func (g *generator) emitBytesRepeatRuntime(base, n value) (value, error) {
-	symbol := "osty_rt_bytes_repeat"
+	symbol := mirRtBytesRepeatSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(n)})
@@ -4537,7 +4537,7 @@ func (g *generator) emitBytesRepeatRuntime(base, n value) (value, error) {
 }
 
 func (g *generator) emitBytesReplaceRuntime(base, oldValue, newValue value) (value, error) {
-	symbol := "osty_rt_bytes_replace"
+	symbol := mirRtBytesReplaceSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(oldValue), toOstyValue(newValue)})
@@ -4549,7 +4549,7 @@ func (g *generator) emitBytesReplaceRuntime(base, oldValue, newValue value) (val
 }
 
 func (g *generator) emitBytesReplaceAllRuntime(base, oldValue, newValue value) (value, error) {
-	symbol := "osty_rt_bytes_replace_all"
+	symbol := mirRtBytesReplaceAllSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(oldValue), toOstyValue(newValue)})
@@ -4561,7 +4561,7 @@ func (g *generator) emitBytesReplaceAllRuntime(base, oldValue, newValue value) (
 }
 
 func (g *generator) emitBytesTrimLeftRuntime(base, strip value) (value, error) {
-	symbol := "osty_rt_bytes_trim_left"
+	symbol := mirRtBytesTrimLeftSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(strip)})
@@ -4573,7 +4573,7 @@ func (g *generator) emitBytesTrimLeftRuntime(base, strip value) (value, error) {
 }
 
 func (g *generator) emitBytesTrimRightRuntime(base, strip value) (value, error) {
-	symbol := "osty_rt_bytes_trim_right"
+	symbol := mirRtBytesTrimRightSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(strip)})
@@ -4585,7 +4585,7 @@ func (g *generator) emitBytesTrimRightRuntime(base, strip value) (value, error) 
 }
 
 func (g *generator) emitBytesTrimRuntime(base, strip value) (value, error) {
-	symbol := "osty_rt_bytes_trim"
+	symbol := mirRtBytesTrimSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(strip)})
@@ -4597,7 +4597,7 @@ func (g *generator) emitBytesTrimRuntime(base, strip value) (value, error) {
 }
 
 func (g *generator) emitBytesTrimSpaceRuntime(base value) (value, error) {
-	symbol := "osty_rt_bytes_trim_space"
+	symbol := mirRtBytesTrimSpaceSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4609,7 +4609,7 @@ func (g *generator) emitBytesTrimSpaceRuntime(base value) (value, error) {
 }
 
 func (g *generator) emitBytesToUpperRuntime(base value) (value, error) {
-	symbol := "osty_rt_bytes_to_upper"
+	symbol := mirRtBytesToUpperSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4621,7 +4621,7 @@ func (g *generator) emitBytesToUpperRuntime(base value) (value, error) {
 }
 
 func (g *generator) emitBytesToLowerRuntime(base value) (value, error) {
-	symbol := "osty_rt_bytes_to_lower"
+	symbol := mirRtBytesToLowerSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4633,7 +4633,7 @@ func (g *generator) emitBytesToLowerRuntime(base value) (value, error) {
 }
 
 func (g *generator) emitBytesToHexRuntime(base value) (value, error) {
-	symbol := "osty_rt_bytes_to_hex"
+	symbol := mirRtBytesToHexSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4650,8 +4650,8 @@ func (g *generator) emitBytesFromHexResult(text value) (value, error) {
 	if !ok {
 		return value{}, unsupported("type-system", "Bytes.fromHex Result<Bytes, Error> type is unavailable")
 	}
-	validateSymbol := "osty_rt_bytes_is_valid_hex"
-	fromHexSymbol := "osty_rt_bytes_from_hex"
+	validateSymbol := mirRtBytesSymbol("is_valid_hex")
+	fromHexSymbol := mirRtBytesSymbol("from_hex")
 	g.declareRuntimeSymbol(validateSymbol, "i1", []paramInfo{{typ: "ptr"}})
 	g.declareRuntimeSymbol(fromHexSymbol, "ptr", []paramInfo{{typ: "ptr"}})
 
@@ -4707,7 +4707,7 @@ func (g *generator) emitBytesFromHexResult(text value) (value, error) {
 }
 
 func (g *generator) emitBytesSliceRuntime(base, start, end value) (value, error) {
-	symbol := "osty_rt_bytes_slice"
+	symbol := mirRtBytesSliceSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(start), toOstyValue(end)})
@@ -4724,8 +4724,8 @@ func (g *generator) emitBytesToStringResult(base value) (value, error) {
 	if !ok {
 		return value{}, unsupported("type-system", "Bytes.toString Result<String, Error> type is unavailable")
 	}
-	validateSymbol := "osty_rt_bytes_is_valid_utf8"
-	toStringSymbol := "osty_rt_bytes_to_string"
+	validateSymbol := mirRtBytesSymbol("is_valid_utf8")
+	toStringSymbol := mirRtBytesSymbol("to_string")
 	g.declareRuntimeSymbol(validateSymbol, "i1", []paramInfo{{typ: "ptr"}})
 	g.declareRuntimeSymbol(toStringSymbol, "ptr", []paramInfo{{typ: "ptr"}})
 
@@ -4911,7 +4911,7 @@ func (g *generator) emitBytesNamespaceCall(call *ast.CallExpr) (value, bool, err
 		if base.typ != "ptr" {
 			return value{}, true, unsupportedf("type-system", "Bytes.len arg 1 type %s, want Bytes", base.typ)
 		}
-		symbol := "osty_rt_bytes_len"
+		symbol := mirRtBytesLenSymbolName()
 		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base)})
@@ -4932,7 +4932,7 @@ func (g *generator) emitBytesNamespaceCall(call *ast.CallExpr) (value, bool, err
 		if base.typ != "ptr" {
 			return value{}, true, unsupportedf("type-system", "Bytes.isEmpty arg 1 type %s, want Bytes", base.typ)
 		}
-		symbol := "osty_rt_bytes_is_empty"
+		symbol := mirRtBytesIsEmptySymbol()
 		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base)})

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -11,6 +11,7 @@ package llvmgen
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -1490,7 +1491,7 @@ func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
 	if name, ok := g.traceHelpers[key]; ok {
 		return name
 	}
-	name := fmt.Sprintf("osty_rt_trace_%d", len(g.traceHelpers))
+	name := mirRtSymbol("trace_" + strconv.Itoa(len(g.traceHelpers)))
 	g.traceHelpers[key] = name
 	g.declareRuntimeSymbol("osty.gc.mark_slot_v1", "void", []paramInfo{{typ: "ptr"}})
 	g.needsGCRuntime = true

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -563,14 +563,16 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 // When the local is a synthetic temp (no Name), append the first
 // instruction that *writes* the temp — that's usually the expression
 // whose checker-inferred type leaked through as <error>.
+// localDisplayName returns a human-readable display name for a MIR
+// local. Delegates the name-extraction policy to the Osty-sourced
+// `mirLocalDisplayNameFromText` (`toolchain/mir_generator.osty`); the
+// nil-Local case stays Go-side since it's a host-boundary concern
+// (`*mir.Local` is a Go pointer type).
 func localDisplayName(loc *mir.Local) string {
 	if loc == nil {
 		return "<nil>"
 	}
-	if loc.Name == "" {
-		return "<temp>"
-	}
-	return loc.Name
+	return mirLocalDisplayNameFromText(loc.Name)
 }
 
 // localDefiningSiteHint walks fn's blocks to find the first

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7587,3 +7587,39 @@ func mirCallResultUnwrapErrLine() string {
 func mirCallExpectFailedLine() string {
 	return mirCallVoidNoArgsLine(mirRtExpectFailedSymbol())
 }
+
+// §18 Phase-2 function ports — small pure helpers ported from
+// internal/llvmgen/mir_generator.go.
+
+// Osty: mirLocalDisplayNameFromText
+func mirLocalDisplayNameFromText(name string) string {
+	if name == "" {
+		return "<temp>"
+	}
+	return name
+}
+
+// Osty: mirIntrinsicKindLabel
+func mirIntrinsicKindLabel(kind int, kindFallback string) string {
+	switch kind {
+	case 1:
+		return "print"
+	case 2:
+		return "println"
+	case 3:
+		return "eprint"
+	case 4:
+		return "eprintln"
+	case 6:
+		return "string_concat"
+	}
+	return kindFallback
+}
+
+// Osty: mirIntrinsicKindFallbackLabel
+func mirIntrinsicKindFallbackLabel(kindDigits string) string {
+	return "kind=" + kindDigits
+}
+
+// (mirChannelRecvSuffix / mirElemSizeBytes are not added — mirChanRecvSuffix /
+// mirMapValueSizeBytes already serve the same role; aliases would shadow them.)

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -284,15 +284,15 @@ func listRuntimeNewSymbol() string {
 }
 
 func listRuntimePushBytesSymbol() string {
-	return "osty_rt_list_push_bytes"
+	return mirRtListSymbol("push_bytes")
 }
 
 func listRuntimeGetBytesSymbol() string {
-	return "osty_rt_list_get_bytes"
+	return mirRtListSymbol("get_bytes")
 }
 
 func listRuntimeSetBytesSymbol() string {
-	return "osty_rt_list_set_bytes"
+	return mirRtListSymbol("set_bytes")
 }
 
 func listRuntimeLenSymbol() string {
@@ -300,27 +300,27 @@ func listRuntimeLenSymbol() string {
 }
 
 func listRuntimeDataSymbol(elemTyp string) string {
-	return "osty_rt_list_data_" + llvmListElementSuffix(elemTyp)
+	return mirRtListSymbol("data_" + llvmListElementSuffix(elemTyp))
 }
 
 func listRuntimePopDiscardSymbol() string {
-	return "osty_rt_list_pop_discard"
+	return mirRtListPopDiscardSymbol()
 }
 
 func listRuntimeClearSymbol() string {
-	return "osty_rt_list_clear"
+	return mirRtListClearSymbol()
 }
 
 func listRuntimePushBytesV1Symbol() string {
-	return "osty_rt_list_push_bytes_v1"
+	return mirRtListSymbol("push_bytes_v1")
 }
 
 func listRuntimePushBytesRootsSymbol() string {
-	return "osty_rt_list_push_bytes_roots_v1"
+	return mirRtListSymbol("push_bytes_roots_v1")
 }
 
 func listRuntimeGetBytesV1Symbol() string {
-	return "osty_rt_list_get_bytes_v1"
+	return mirRtListGetBytesV1Symbol()
 }
 
 func listRuntimePushSymbol(elemTyp string) string {
@@ -340,11 +340,11 @@ func listRuntimeInsertSymbol(elemTyp string) string {
 }
 
 func listRuntimeInsertBytesV1Symbol() string {
-	return "osty_rt_list_insert_bytes_v1"
+	return mirRtListSymbol("insert_bytes_v1")
 }
 
 func listRuntimeInsertBytesRootsSymbol() string {
-	return "osty_rt_list_insert_bytes_roots_v1"
+	return mirRtListSymbol("insert_bytes_roots_v1")
 }
 
 func listRuntimeSortedSymbol(elemTyp string, elemString bool) string {
@@ -360,7 +360,7 @@ func listRuntimeToSetSymbol(elemTyp string, elemString bool) string {
 // the slice is a pure byte-level copy — the elem_size stored on the
 // list header is enough, so one symbol covers every T.
 func listRuntimeSliceSymbol() string {
-	return "osty_rt_list_slice"
+	return mirRtListSliceSymbol()
 }
 
 func mapRuntimeNewSymbol() string {
@@ -389,7 +389,7 @@ func mapRuntimeGetOrAbortSymbol(keyTyp string, keyString bool) string {
 // (null ptr = None, boxed payload ptr = Some) without inlining the
 // stdlib body per callsite.
 func mapRuntimeGetSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_get_" + llvmMapKeySuffix(keyTyp, keyString)
+	return mirRtMapSymbol("get_" + llvmMapKeySuffix(keyTyp, keyString))
 }
 
 // mapRuntimeIncrI64Symbol returns the runtime symbol for the
@@ -398,19 +398,19 @@ func mapRuntimeGetSymbol(keyTyp string, keyString bool) string {
 // probe + in-place update on hit, falls through to insert on miss.
 // Targeted by the `IntrinsicMapIncr` lowering.
 func mapRuntimeIncrI64Symbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_incr_i64_" + llvmMapKeySuffix(keyTyp, keyString)
+	return mirRtMapSymbol("incr_i64_" + llvmMapKeySuffix(keyTyp, keyString))
 }
 
 // mapRuntimeKeyAtSymbol returns the K-at-slot accessor used by
 // `for (k, v) in m` iteration. `osty_rt_map_key_at_<ksuf>(map, i) -> K`.
 func mapRuntimeKeyAtSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_key_at_" + llvmMapKeySuffix(keyTyp, keyString)
+	return mirRtMapSymbol("key_at_" + llvmMapKeySuffix(keyTyp, keyString))
 }
 
 // mapRuntimeValueAtSymbol returns the V-at-slot accessor — V-agnostic,
 // takes an out-pointer. `osty_rt_map_value_at(map, i, out_ptr)`.
 func mapRuntimeValueAtSymbol() string {
-	return "osty_rt_map_value_at"
+	return mirRtMapSymbol("value_at")
 }
 
 // mapRuntimeEntryAtSymbol returns the combined K+V accessor used by
@@ -418,7 +418,7 @@ func mapRuntimeValueAtSymbol() string {
 // under the map lock and memcpy-writes the value into the caller's
 // out-slot in the same critical section.
 func mapRuntimeEntryAtSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_entry_at_" + llvmMapKeySuffix(keyTyp, keyString)
+	return mirRtMapSymbol("entry_at_" + llvmMapKeySuffix(keyTyp, keyString))
 }
 
 // mapRuntimeLockSymbol / mapRuntimeUnlockSymbol expose the per-map
@@ -427,11 +427,11 @@ func mapRuntimeEntryAtSymbol(keyTyp string, keyString bool) string {
 // callback can re-enter the same map (e.g. read self.len()) without
 // self-deadlock.
 func mapRuntimeLockSymbol() string {
-	return "osty_rt_map_lock"
+	return mirRtMapSymbol("lock")
 }
 
 func mapRuntimeUnlockSymbol() string {
-	return "osty_rt_map_unlock"
+	return mirRtMapSymbol("unlock")
 }
 
 func mapRuntimeKeysSymbol() string {
@@ -443,7 +443,7 @@ func mapRuntimeLenSymbol() string {
 }
 
 func mapRuntimeClearSymbol() string {
-	return "osty_rt_map_clear"
+	return mirRtMapClearSymbol()
 }
 
 func setRuntimeNewSymbol() string {

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -445,7 +445,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		if err != nil {
 			return value{}, true, err
 		}
-		symbol := "osty_rt_bytes_len"
+		symbol := mirRtBytesLenSymbolName()
 		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(b)})
@@ -459,7 +459,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		if err != nil {
 			return value{}, true, err
 		}
-		symbol := "osty_rt_bytes_is_empty"
+		symbol := mirRtBytesIsEmptySymbol()
 		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(b)})
@@ -717,7 +717,7 @@ func (g *generator) emitStdStringsSplit(call *ast.CallExpr) (value, error) {
 	if err != nil {
 		return value{}, err
 	}
-	symbol := "osty_rt_strings_Split"
+	symbol := mirRtStringSplitSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(sep)})
@@ -786,7 +786,7 @@ func (g *generator) emitStdStringsFields(call *ast.CallExpr) (value, error) {
 	if err != nil {
 		return value{}, err
 	}
-	symbol := "osty_rt_strings_Fields"
+	symbol := mirRtStringSymbol("Fields")
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s)})

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -277,7 +277,7 @@ func (g *generator) tryEmitMapIncrPattern(first, second ast.Stmt) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	symbol := "osty_rt_map_incr_i64_" + suffix
+	symbol := mirRtMapSymbol("incr_i64_" + suffix)
 	keyTyp := mapInfo.mapKeyTyp
 	if mapInfo.mapKeyString {
 		keyTyp = "ptr"
@@ -1704,8 +1704,8 @@ func (g *generator) emitTestingBenchmarkStmt(call *ast.CallExpr) error {
 	return nil
 }
 
-func benchClockRuntimeSymbol() string  { return "osty_rt_bench_now_nanos" }
-func benchTargetRuntimeSymbol() string { return "osty_rt_bench_target_ns" }
+func benchClockRuntimeSymbol() string  { return mirRtBenchNowNanosSymbol() }
+func benchTargetRuntimeSymbol() string { return mirRtBenchTargetNsSymbol() }
 
 // emitBenchAutoTuneN probes the body when --benchtime is active and
 // picks N from that sample. Returns an alloca that downstream code
@@ -1858,10 +1858,10 @@ func (g *generator) emitBenchInlineLoop(stmts []ast.Stmt, count value, labelPref
 	return nil
 }
 
-func benchSamplesNewSymbol() string    { return "osty_rt_bench_samples_new" }
-func benchSamplesRecordSymbol() string { return "osty_rt_bench_samples_record" }
-func benchSamplesReportSymbol() string { return "osty_rt_bench_samples_report" }
-func benchSamplesFreeSymbol() string   { return "osty_rt_bench_samples_free" }
+func benchSamplesNewSymbol() string    { return mirRtBenchSymbol("samples_new") }
+func benchSamplesRecordSymbol() string { return mirRtBenchSymbol("samples_record") }
+func benchSamplesReportSymbol() string { return mirRtBenchSymbol("samples_report") }
+func benchSamplesFreeSymbol() string   { return mirRtBenchSymbol("samples_free") }
 
 // benchQuestionFailMessage is the runtime message printed when `?`
 // inside a bench closure sees Err / None. The shape mirrors

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12572,3 +12572,43 @@ pub fn mirCallResultUnwrapErrLine() -> String {
 pub fn mirCallExpectFailedLine() -> String {
     mirCallVoidNoArgsLine(mirRtExpectFailedSymbol())
 }
+
+/// §18 Phase-2 function ports — small pure helpers ported from
+/// `internal/llvmgen/mir_generator.go`. The Go side passes already-
+/// extracted text / integer values since `mir.Local`, `mir.IntrinsicKind`,
+/// etc. are Go-only types that don't cross the host boundary.
+
+/// mirLocalDisplayNameFromText returns a human-readable display name
+/// for a MIR local: the local's source-level name, or `<temp>` if it's
+/// an unnamed compiler-generated temporary. Caller (Go side) handles
+/// the nil-Local case separately, returning `<nil>`.
+///
+/// Ported from `localDisplayName` in `internal/llvmgen/mir_generator.go`.
+pub fn mirLocalDisplayNameFromText(name: String) -> String {
+    if name == "" { "<temp>" } else { name }
+}
+
+/// mirIntrinsicKindLabel returns the human-readable label for a MIR
+/// intrinsic kind. Mapping mirrors `mir.go`'s `IntrinsicKind` iota
+/// constants. Caller passes `int(k)` to convert from the typed enum;
+/// `kindFallback` is the legacy `kind=<n>` fallback string.
+///
+/// Ported from `mirIntrinsicLabel` in `internal/llvmgen/mir_generator.go`.
+pub fn mirIntrinsicKindLabel(kind: Int, kindFallback: String) -> String {
+    if kind == 1 { return "print" }
+    if kind == 2 { return "println" }
+    if kind == 3 { return "eprint" }
+    if kind == 4 { return "eprintln" }
+    if kind == 6 { return "string_concat" }
+    kindFallback
+}
+
+/// mirIntrinsicKindFallbackLabel renders the canonical fallback label
+/// shape `kind=<n>`. Ported alongside `mirIntrinsicKindLabel`.
+pub fn mirIntrinsicKindFallbackLabel(kindDigits: String) -> String {
+    "kind=" + kindDigits
+}
+
+/// (mirChannelRecvSuffix / mirElemSizeBytes are not added — the
+/// existing mirChanRecvSuffix / mirMapValueSizeBytes already serve
+/// the same role; aliases would just shadow them.)


### PR DESCRIPTION
## Phase 1 (LLVM-text builder library): COMPLETE

After 8 PRs (#946, #952, #955, #958, #959, #961, #962, this one) the
LLVM-text builder library at `toolchain/mir_generator.osty` covers
99.9% of inline literal patterns the emit pass produces.

**Remaining 4 `g.fnBuf.WriteString` sites in `mir_generator.go`** are
all flushing pre-built helper output (`llvmRenderSafepointEmpty`,
`mirNoneAggregate.Lines`) — not raw inline literals. Adding more
builders from here would create dormant code without active call
sites (the simplify reviewer caught 4 such bugs in PR #962).

### Final Phase 1 cleanup in this PR

Drained ~30 inline `"osty_rt_*"` literals:
- `runtime_ffi.go` — list/map runtime symbol getter functions
- `expr.go` — bytes/string/char/byte runtime call sites
- `stmt.go` — bench-clock / bench-samples / map-incr getters
- `generator.go` — trace helper symbol composer
- `stdlib_shim.go` — bytes-len / bytes-is-empty / strings-Split

All now use the existing `mirRt*Symbol()` composers.

## Phase 2 (function port): BEGINS

### First function ported

**`localDisplayName`** (`mir_generator.go`) → **`mirLocalDisplayNameFromText`** (`toolchain/mir_generator.osty`).

Go side keeps the nil-Local check (host boundary; `*mir.Local` is a
Go pointer type that doesn't cross to Osty). The name-extraction
policy (`""` → `"<temp>"`, non-empty → as-is) moves to Osty.

```go
func localDisplayName(loc *mir.Local) string {
    if loc == nil {
        return "<nil>"
    }
    return mirLocalDisplayNameFromText(loc.Name)
}
```

```osty
pub fn mirLocalDisplayNameFromText(name: String) -> String {
    if name == "" { "<temp>" } else { name }
}
```

### Pre-staged for next slice

`mirIntrinsicKindLabel` + `mirIntrinsicKindFallbackLabel` added to
osty (with Go mirrors) but not yet wired up — they'll port
`mirIntrinsicLabel` once the next slice handles the IntrinsicKind
enum mapping cleanly.

## Slice cadence change

The "2k insertion per slice" cadence ends here. Phase 2 is per-function,
so slices will be smaller and tighter. This slice: 170 insertions / 70
deletions across 9 files.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (verified via stash-rerun on baseline)