### PR TITLE
refactor(llvmgen): port is{List,Map,Set}PtrType built-in name predicates to osty

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -858,34 +858,36 @@ func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx st
 }
 
 // isListPtrType reports whether t is a `List<T>` builtin (which
-// lowers to a ptr at the LLVM boundary).
+// lowers to a ptr at the LLVM boundary). The host-boundary
+// `*ir.NamedType` type assertion stays Go-side; the name-and-Builtin
+// policy delegates to `mirIsBuiltinList` (`toolchain/mir_generator.osty`).
 func isListPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return nt.Name == "List" && nt.Builtin
+		return mirIsBuiltinList(nt.Name, nt.Builtin)
 	}
 	return false
 }
 
-// isMapPtrType reports whether t is a `Map<K, V>` builtin (which
-// lowers to a ptr at the LLVM boundary). Used by the IndexProj read
-// path to dispatch to the map_get_or_abort runtime when the base is
-// a map rather than a list.
+// isMapPtrType reports whether t is a `Map<K, V>` builtin. Delegates
+// to `mirIsBuiltinMap`.
 func isMapPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return nt.Name == "Map" && nt.Builtin
+		return mirIsBuiltinMap(nt.Name, nt.Builtin)
 	}
 	return false
 }
 
+// isSetPtrType reports whether t is a `Set<T>` builtin. Delegates to
+// `mirIsBuiltinSet`.
 func isSetPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return nt.Name == "Set" && nt.Builtin
+		return mirIsBuiltinSet(nt.Name, nt.Builtin)
 	}
 	return false
 }
 
 func vectorListElemType(t mir.Type) mir.Type {
-	if nt, ok := t.(*ir.NamedType); ok && nt.Name == "List" && nt.Builtin && len(nt.Args) > 0 {
+	if nt, ok := t.(*ir.NamedType); ok && mirIsBuiltinList(nt.Name, nt.Builtin) && len(nt.Args) > 0 {
 		return nt.Args[0]
 	}
 	return nil

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7623,3 +7623,22 @@ func mirIntrinsicKindFallbackLabel(kindDigits string) string {
 
 // (mirChannelRecvSuffix / mirElemSizeBytes are not added — mirChanRecvSuffix /
 // mirMapValueSizeBytes already serve the same role; aliases would shadow them.)
+
+// §18 (cont'd) — built-in named-type predicates ported from
+// is{List,Map,Set}PtrType in mir_generator.go.
+
+// Osty: mirIsBuiltinNamedType
+func mirIsBuiltinNamedType(name string, isBuiltin bool, expected string) bool {
+	return name == expected && isBuiltin
+}
+
+// Osty: mirIsBuiltin{List,Map,Set}
+func mirIsBuiltinList(name string, isBuiltin bool) bool {
+	return mirIsBuiltinNamedType(name, isBuiltin, "List")
+}
+func mirIsBuiltinMap(name string, isBuiltin bool) bool {
+	return mirIsBuiltinNamedType(name, isBuiltin, "Map")
+}
+func mirIsBuiltinSet(name string, isBuiltin bool) bool {
+	return mirIsBuiltinNamedType(name, isBuiltin, "Set")
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12612,3 +12612,36 @@ pub fn mirIntrinsicKindFallbackLabel(kindDigits: String) -> String {
 /// (mirChannelRecvSuffix / mirElemSizeBytes are not added — the
 /// existing mirChanRecvSuffix / mirMapValueSizeBytes already serve
 /// the same role; aliases would just shadow them.)
+
+/// §18 (cont'd) — built-in named-type predicates ported from
+/// `is{List,Map,Set}PtrType` in `internal/llvmgen/mir_generator.go`.
+/// Caller (Go side) keeps the `*ir.NamedType` type assertion since
+/// `ir.Type` is a Go interface tree that doesn't cross the host
+/// boundary; the name-and-Builtin policy moves to Osty.
+
+/// mirIsBuiltinNamedType returns true when a named type is the named
+/// builtin `expected` (e.g. `"List"`, `"Map"`, `"Set"`). Both the
+/// `name` match and the `isBuiltin` flag must hold — user-defined
+/// types named `List` (e.g. in a custom module) are explicitly NOT
+/// matched.
+pub fn mirIsBuiltinNamedType(name: String, isBuiltin: Bool, expected: String) -> Bool {
+    name == expected && isBuiltin
+}
+
+/// mirIsBuiltinList returns true when (name, isBuiltin) names the
+/// built-in `List<T>`.
+pub fn mirIsBuiltinList(name: String, isBuiltin: Bool) -> Bool {
+    mirIsBuiltinNamedType(name, isBuiltin, "List")
+}
+
+/// mirIsBuiltinMap returns true when (name, isBuiltin) names the
+/// built-in `Map<K, V>`.
+pub fn mirIsBuiltinMap(name: String, isBuiltin: Bool) -> Bool {
+    mirIsBuiltinNamedType(name, isBuiltin, "Map")
+}
+
+/// mirIsBuiltinSet returns true when (name, isBuiltin) names the
+/// built-in `Set<T>`.
+pub fn mirIsBuiltinSet(name: String, isBuiltin: Bool) -> Bool {
+    mirIsBuiltinNamedType(name, isBuiltin, "Set")
+}


### PR DESCRIPTION
## Phase 2 — second function port

Three sibling helpers in `mir_generator.go` encoded the same
`name == \"X\" && Builtin` policy inline. Ported to osty:

```osty
pub fn mirIsBuiltinNamedType(name: String, isBuiltin: Bool, expected: String) -> Bool {
    name == expected && isBuiltin
}

pub fn mirIsBuiltinList(name: String, isBuiltin: Bool) -> Bool { mirIsBuiltinNamedType(name, isBuiltin, "List") }
pub fn mirIsBuiltinMap(name: String, isBuiltin: Bool) -> Bool { mirIsBuiltinNamedType(name, isBuiltin, "Map") }
pub fn mirIsBuiltinSet(name: String, isBuiltin: Bool) -> Bool { mirIsBuiltinNamedType(name, isBuiltin, "Set") }
```

The host-boundary `*ir.NamedType` type assertion stays Go-side
(`ir.Type` is a Go interface tree that doesn't cross to Osty).
The name-and-Builtin policy moves to Osty.

### Drained 4 call sites in `mir_generator.go`

- `isListPtrType` / `isMapPtrType` / `isSetPtrType` — each delegate
  to the corresponding `mirIsBuiltin{List,Map,Set}`
- `vectorListElemType` — same Builtin-checked predicate; now uses
  `mirIsBuiltinList`

```go
func isListPtrType(t mir.Type) bool {
    if nt, ok := t.(*ir.NamedType); ok {
        return mirIsBuiltinList(nt.Name, nt.Builtin)
    }
    return false
}
```

### Left alone

Other inline `nt.Name == \"...\"` sites in `mir_generator.go` —
`mapKeyValueTypes`, `setElemType`, `listElemType` — use loose name
checks WITHOUT the Builtin filter. Different semantics; not the
right fit for the new predicates.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (verified via stash-rerun)