### PR TITLE
perf(runtime): make GENERIC NONE pattern young-eligible

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -6282,10 +6282,13 @@ int main(void) {
 // LIST (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list
 // scan), CLOSURE_ENV (captures populated synchronously at
 // construction before the env escapes; promote-on-bind copies a
-// fully-populated env to OLD).
+// fully-populated env to OLD), GENERIC NONE pattern (NULL trace +
+// NULL destroy — opaque payload, nothing for cheney to follow). The
+// debug entry assumes NONE for GENERIC; the production allocator
+// also rejects ENUM_PTR / TASK_HANDLE because the per-instance
+// pattern can't be recovered from the 16-byte micro-header.
 // Rejected: MAP/SET/CHANNEL (have destroy callbacks Cheney can't
-// invoke), GENERIC (per-instance callbacks not on the micro-header),
-// humongous (size > threshold).
+// invoke), humongous (size > threshold).
 func TestBundledRuntimeYoungEligibilityFilter(t *testing.T) {
 	parallelClangBackendTest(t)
 
@@ -6363,13 +6366,13 @@ int main(void) {
 			},
 		},
 		{
-			// Default (Phase 8 step 2 cutover): STRING/BYTES route
-			// to young. Map<String, _> works because cheney_minor
-			// traces OLD reachability transitively.
+			// Default routing: cheney_minor traces OLD reachability
+			// transitively, so Map<String, _> still works even with
+			// young String keys.
 			name: "default",
 			env:  nil,
 			wantRows: []string{
-				"1 0 0",    // GENERIC: no descriptor
+				"1 1 1",    // GENERIC: eligible under NONE pattern (debug entry assumes NULL trace/destroy)
 				"1024 1 1", // LIST: eligible (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list scan)
 				"1025 1 1", // STRING: eligible
 				"1026 0 0", // MAP: has destroy (free's keys/values arrays — needs typed sweep)
@@ -6527,6 +6530,112 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeGenericNoneYoungRoundTrip covers the GENERIC
+// young-eligibility addition: an `osty.gc.alloc_v1(KIND_GENERIC, …)`
+// with implicit NULL trace + NULL destroy lands in the young arena,
+// promotes cleanly to OLD on root_bind (where headerful would carry
+// `generic_pattern == OSTY_GC_GENERIC_NONE`), survives a forced
+// collect, and unbinds without underflowing find_header. Before the
+// runtime change, promote_young_to_old aborted with "kind missing
+// descriptor" because GENERIC isn't in `osty_gc_kind_table` — this
+// test pins the new descriptor-less promotion path.
+func TestBundledRuntimeGenericNoneYoungRoundTrip(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_generic_none_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_generic_none_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+int64_t osty_gc_debug_arena_is_young_page(void *payload);
+int64_t osty_gc_debug_young_forward_tag(void *from_payload);
+int64_t osty_gc_debug_generic_pattern_of(void *payload);
+int64_t osty_gc_debug_live_count(void);
+void osty_gc_debug_collect(void);
+
+#define KIND_GENERIC 1
+
+int main(void) {
+    /* GENERIC NONE pattern: alloc_v1 routes to NULL trace + NULL
+     * destroy, which is the only GENERIC pattern the eligibility
+     * filter admits. Should land in young. */
+    void *young = osty_gc_alloc_v1(KIND_GENERIC, 16, "scalar.enum");
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(young));
+
+    /* Stash a recognizable bit pattern so we can confirm the bytes
+     * survive promotion (memcpy young → OLD) and the subsequent
+     * collect. Cast through uint64_t to avoid strict-aliasing UB. */
+    *(uint64_t *)young = 0xDEADBEEFCAFEBABEULL;
+
+    /* root_bind → promote_young_to_old. Pre-fix, this aborted on
+     * GENERIC because kind_descriptor_lookup returned NULL. */
+    osty_gc_root_bind_v1(young);
+    printf("%lld\n", (long long)osty_gc_debug_young_forward_tag(young));
+
+    /* Resolve the OLD copy via PROMOTED tag follow and inspect its
+     * generic_pattern. Promotion picks NULL trace + NULL destroy →
+     * OSTY_GC_GENERIC_NONE (= 0). */
+    void *old = osty_gc_load_v1(young);
+    printf("%lld\n", (long long)osty_gc_debug_generic_pattern_of(old));
+    printf("%llx\n", (unsigned long long)*(uint64_t *)old);
+
+    /* Forced collect: cheney processes the (PROMOTED) young, the
+     * major sweep keeps OLD alive via the root binding. */
+    int64_t live_before = osty_gc_debug_live_count();
+    osty_gc_debug_collect();
+    int64_t live_after = osty_gc_debug_live_count();
+    printf("%lld %lld\n", (long long)live_before, (long long)live_after);
+
+    /* Release: root_count drops to 0, next collect sweeps the OLD
+     * copy. find_header following the PROMOTED tag is what makes
+     * release-with-stale-young-addr work. */
+    osty_gc_root_release_v1(young);
+    osty_gc_debug_collect();
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"1",            // young alloc landed in young arena
+		"2",            // forward tag = PROMOTED after root_bind
+		"0",            // OLD copy carries OSTY_GC_GENERIC_NONE
+		"deadbeefcafebabe", // payload bytes survived young → OLD memcpy
+		"1 1",          // collect kept the rooted OLD copy alive
+		"0",            // release + collect reclaimed the OLD copy
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("generic-none harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // Phase 8 step 1 of the tiny-tag young-space landing: end-to-end
 // routing. With the feature flag on, the production allocator entry
 // `osty.gc.alloc_v1` should pick the young arena for eligible kinds
@@ -6616,12 +6725,15 @@ int main(void) {
 			wantClass: [6]string{"0", "0", "0", "0", "0", "0"},
 		},
 		{
-			// Default routing: STRING + BYTES + LIST + CLOSURE_ENV →
-			// young arena; GENERIC / MAP / CHANNEL stay headerful.
+			// Default routing: STRING + BYTES + LIST + CLOSURE_ENV +
+			// GENERIC NONE → young arena; MAP / CHANNEL stay headerful
+			// (GENERIC ENUM_PTR / TASK_HANDLE patterns also stay
+			// headerful, but `osty_gc_alloc_v1(1, …)` constructs the
+			// NONE pattern via NULL trace + NULL destroy).
 			name:      "default",
 			env:       nil,
-			wantDelta: "4",
-			wantClass: [6]string{"1", "1", "1", "1", "0", "0"},
+			wantDelta: "5",
+			wantClass: [6]string{"1", "1", "1", "1", "0", "1"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3100,8 +3100,9 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      dormant and every alloc takes the headerful path, preserving
  *      pre-Phase-5 behaviour exactly.
  *   2. The kind must be one of the young-safe kinds — STRING, BYTES,
- *      LIST, CLOSURE_ENV. STRING/BYTES are immutable byte payloads.
- *      LIST has a destroy callback (frees spilled `data` +
+ *      LIST, CLOSURE_ENV, or GENERIC with the NONE pattern (NULL
+ *      trace + NULL destroy). STRING/BYTES are immutable byte
+ *      payloads. LIST has a destroy callback (frees spilled `data` +
  *      `gc_offsets`), but Phase E follow-up adds a from-space
  *      dead-list scan in cheney_minor that runs the destroy work just
  *      before the arena swap reclaims the bytes — making LIST safe to
@@ -3116,25 +3117,45 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      could trigger root_bind — so promote-on-bind copies a fully
  *      populated env to OLD and post-promote stale-pointer writes
  *      do not occur in production.
+ *      GENERIC NONE pattern (e.g. `osty_rt_enum_alloc_scalar_v1` —
+ *      unboxed enum scalar payload) has no trace or destroy, so the
+ *      micro-header carries everything cheney needs (opaque copy +
+ *      no destroy on dead-from-space). The other GENERIC patterns
+ *      (ENUM_PTR has trace, TASK_HANDLE has destroy) need their
+ *      per-instance pattern to be recoverable at cheney scan time —
+ *      not yet possible since the micro-header has no
+ *      `generic_pattern` byte — so they stay headerful.
  *
  *      Why not the other kinds:
- *        - GENERIC: per-instance trace/destroy callbacks not on the
- *          micro-header.
  *        - MAP/SET/CHANNEL: destroy frees pthread sync state and
  *          backing arrays — typed-allocator surface is larger and
  *          these are typically long-lived.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being
- *      bump-allocated. */
-static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size) {
+ *      bump-allocated.
+ *
+ * `trace` and `destroy` are passed through so the GENERIC-pattern
+ * filter can reject ENUM_PTR (non-NULL trace) and TASK_HANDLE
+ * (non-NULL destroy). For non-GENERIC kinds the pair is determined
+ * by `osty_gc_kind_table` so the params are ignored. */
+static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size,
+                                   osty_gc_trace_fn trace,
+                                   osty_gc_destroy_fn destroy) {
     if (!osty_gc_tinytag_young_now()) {
         return false;
     }
-    if (object_kind != OSTY_GC_KIND_STRING &&
-        object_kind != OSTY_GC_KIND_BYTES &&
-        object_kind != OSTY_GC_KIND_LIST &&
-        object_kind != OSTY_GC_KIND_CLOSURE_ENV) {
+    if (object_kind == OSTY_GC_KIND_GENERIC) {
+        /* Only the NONE pattern (no trace, no destroy) is young-safe;
+         * ENUM_PTR / TASK_HANDLE need the per-instance pattern at
+         * cheney time, which the 16-byte micro-header doesn't carry. */
+        if (trace != NULL || destroy != NULL) {
+            return false;
+        }
+    } else if (object_kind != OSTY_GC_KIND_STRING &&
+               object_kind != OSTY_GC_KIND_BYTES &&
+               object_kind != OSTY_GC_KIND_LIST &&
+               object_kind != OSTY_GC_KIND_CLOSURE_ENV) {
         return false;
     }
     if (payload_size == 0 ||
@@ -3148,10 +3169,15 @@ static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size) {
  * (Phase 8 cutover) consult before falling through to the headerful
  * path. Returns NULL when the kind/size combination is ineligible
  * or when the young arena is exhausted, signalling the caller to
- * use the headerful allocator. */
+ * use the headerful allocator.
+ *
+ * `trace` and `destroy` are forwarded to `osty_gc_young_eligible` so
+ * the GENERIC-pattern filter can reject ENUM_PTR / TASK_HANDLE. */
 static void *osty_gc_allocate_young_if_eligible(size_t byte_size,
-                                                int64_t object_kind) {
-    if (!osty_gc_young_eligible(object_kind, byte_size)) {
+                                                int64_t object_kind,
+                                                osty_gc_trace_fn trace,
+                                                osty_gc_destroy_fn destroy) {
+    if (!osty_gc_young_eligible(object_kind, byte_size, trace, destroy)) {
         return NULL;
     }
     return osty_gc_allocate_young(byte_size, object_kind);
@@ -3402,11 +3428,18 @@ static void *osty_gc_promote_young_to_old(void *young_payload) {
     object_kind = (int64_t)micro->object_kind;
     payload_size = (size_t)micro->byte_size;
     desc = osty_gc_kind_descriptor_lookup(object_kind);
-    if (desc == NULL) {
-        /* Eligibility filter (Phase 7 step 1) keeps GENERIC out of
-         * young, so any young payload's kind has a descriptor. If
-         * this fires, something allocated young directly without
-         * going through `_if_eligible`. */
+    osty_gc_trace_fn promote_trace;
+    osty_gc_destroy_fn promote_destroy;
+    if (desc != NULL) {
+        promote_trace = desc->trace;
+        promote_destroy = desc->destroy;
+    } else if (object_kind == OSTY_GC_KIND_GENERIC) {
+        /* GENERIC is not in `osty_gc_kind_table`; the eligibility
+         * filter only admits the NONE pattern (NULL trace + NULL
+         * destroy), so promotion lands a NONE-pattern OLD copy. */
+        promote_trace = NULL;
+        promote_destroy = NULL;
+    } else {
         osty_rt_abort("promote_young_to_old: kind missing descriptor");
     }
     /* Bypass the Phase 8 young-routing wrapper: promotion exists
@@ -3416,7 +3449,7 @@ static void *osty_gc_promote_young_to_old(void *young_payload) {
      * make persistent). */
     new_payload = osty_gc_allocate_managed_headerful(
         payload_size, object_kind, "runtime.gc.promote_young",
-        desc->trace, desc->destroy);
+        promote_trace, promote_destroy);
     memcpy(new_payload, young_payload, payload_size);
     /* Same self-referential `data` fixup as cheney_forward —
      * a promoted inline list still points its `data` at the source
@@ -3909,11 +3942,10 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind,
     void *young_payload;
 
     osty_gc_kind_descriptor_assert_parity(object_kind, trace, destroy);
-    young_payload = osty_gc_allocate_young_if_eligible(byte_size, object_kind);
+    young_payload = osty_gc_allocate_young_if_eligible(byte_size, object_kind,
+                                                       trace, destroy);
     if (young_payload != NULL) {
         (void)site;
-        (void)trace;
-        (void)destroy;
         return young_payload;
     }
     return osty_gc_allocate_managed_headerful(byte_size, object_kind, site,
@@ -10904,7 +10936,12 @@ int64_t osty_gc_debug_young_eligible(int64_t byte_size, int64_t object_kind) {
     if (byte_size < 0) {
         return 0;
     }
-    return osty_gc_young_eligible(object_kind, (size_t)byte_size) ? 1 : 0;
+    /* Debug entry assumes the GENERIC NONE pattern (NULL trace +
+     * NULL destroy) — the per-instance trace/destroy aren't part of
+     * this filter's surface, and NONE is the only GENERIC pattern
+     * the eligibility filter can admit. */
+    return osty_gc_young_eligible(object_kind, (size_t)byte_size, NULL, NULL)
+               ? 1 : 0;
 }
 
 void *osty_gc_debug_allocate_young_if_eligible(int64_t byte_size,
@@ -10912,7 +10949,8 @@ void *osty_gc_debug_allocate_young_if_eligible(int64_t byte_size,
     if (byte_size < 0) {
         return NULL;
     }
-    return osty_gc_allocate_young_if_eligible((size_t)byte_size, object_kind);
+    return osty_gc_allocate_young_if_eligible((size_t)byte_size, object_kind,
+                                              NULL, NULL);
 }
 
 /* Phase 7 step 2 accessors. The promote path is exercised via the


### PR DESCRIPTION
## Summary

GENERIC objects with NULL trace + NULL destroy (the NONE pattern — `osty_rt_enum_alloc_scalar_v1` and any `osty_gc_alloc_v1` that doesn't supply trace/destroy) now route to the no-header young arena.

The other two GENERIC patterns stay headerful: ENUM_PTR has a trace fn (`osty_rt_enum_ptr_payload_trace`) and TASK_HANDLE has a destroy fn — recovering the per-instance pattern at cheney scan time would need a `generic_pattern` byte in the 16-byte micro-header that we don't have. The eligibility filter rejects them by inspecting the (trace, destroy) pair the caller passed.

## Changes

`internal/backend/runtime/osty_runtime.c`:
- `osty_gc_young_eligible` now takes (trace, destroy) so it can admit GENERIC NONE and reject ENUM_PTR / TASK_HANDLE.
- `osty_gc_allocate_young_if_eligible` + `osty_gc_allocate_managed` forward the pair through.
- `osty_gc_promote_young_to_old`: when kind is GENERIC, look up the NULL/NULL pair instead of aborting on a missing `osty_gc_kind_table` descriptor. The promoted OLD copy carries `generic_pattern == OSTY_GC_GENERIC_NONE`.
- Debug entries (`osty_gc_debug_young_eligible`, `osty_gc_debug_allocate_young_if_eligible`) keep their pre-existing (size, kind) signature and pass NULL/NULL — they document the GENERIC-row meaning as "NONE pattern assumed".

`internal/backend/llvm_runtime_gc_test.go`:
- `TestBundledRuntimeYoungEligibilityFilter`: GENERIC row flips `"1 0 0"` → `"1 1 1"` (debug entry assumes NONE).
- `TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn`: default delta becomes 5 (S/B/L/E/G), classification slot 5 (g) flips to `"1"`.
- New `TestBundledRuntimeGenericNoneYoungRoundTrip`: alloc young GENERIC, write a recognisable bit pattern, root_bind (must NOT abort on missing descriptor), promote, verify OLD copy carries `generic_pattern == NONE`, payload bytes survived the memcpy, forced collect keeps it alive, release + collect reclaims it.

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn|TestBundledRuntimeGenericNone"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime suite passes
- [x] `go test ./internal/backend/ -run "Gc|GC|Cheney|Young|Promote|Closure|Generic"` — all GC + closure tests pass

## Pending follow-ups (not in this PR)

- GENERIC ENUM_PTR / TASK_HANDLE: needs a `generic_pattern` byte in the micro-header (or a kind-enum split) so cheney can recover per-instance trace/destroy. Tracked separately.
- Set / Map / Channel young eligibility (next phase per the rolling roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)