### PR TITLE
refactor(llvmgen): port listUsesRawDataFastPath + isAllocaLine + isBrTerminator to osty

### DIFF
--- a/internal/llvmgen/alloca_hoist.go
+++ b/internal/llvmgen/alloca_hoist.go
@@ -1,7 +1,5 @@
 package llvmgen
 
-import "strings"
-
 // hoistAllocasToEntry rewrites a function body so every `alloca`
 // instruction lives in the entry block.
 //
@@ -91,29 +89,15 @@ func hoistAllocasToEntry(body []string) []string {
 // isAllocaLine reports whether `line` is an LLVM `alloca` instruction
 // emitted by the snapshot helpers. They all write the form
 // `"  %<name> = alloca <ty>..."` via fmt.Sprintf with a leading two-
-// space indent. We match that prefix conservatively: leading two
-// spaces, a `%`-named SSA value, an `=`, and the literal token
-// `alloca` separated by spaces.
+// space indent. Delegates to the Osty-sourced `mirIsAllocaLine`
+// (`toolchain/mir_generator.osty`).
 func isAllocaLine(line string) bool {
-	const prefix = "  %"
-	if !strings.HasPrefix(line, prefix) {
-		return false
-	}
-	rest := line[len(prefix):]
-	eq := strings.Index(rest, " = ")
-	if eq < 0 {
-		return false
-	}
-	tail := rest[eq+len(" = "):]
-	return strings.HasPrefix(tail, "alloca ") || tail == "alloca"
+	return mirIsAllocaLine(line)
 }
 
 // isBrTerminator reports whether `line` is the unconditional or
-// conditional `br` instruction that terminates a basic block. Used to
-// locate the entry block's boundary so hoisted allocas land just
-// before the terminator (LLVM requires terminators to be the last
-// instruction in their block).
+// conditional `br` instruction that terminates a basic block.
+// Delegates to `mirIsBrTerminatorLine`.
 func isBrTerminator(line string) bool {
-	const prefix = "  br "
-	return strings.HasPrefix(line, prefix)
+	return mirIsBrTerminatorLine(line)
 }

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7642,3 +7642,35 @@ func mirIsBuiltinMap(name string, isBuiltin bool) bool {
 func mirIsBuiltinSet(name string, isBuiltin bool) bool {
 	return mirIsBuiltinNamedType(name, isBuiltin, "Set")
 }
+
+// §18 (cont'd) — typed-list runtime fast-path predicate ported from
+// listUsesRawDataFastPath in runtime_ffi.go.
+
+// Osty: mirListUsesRawDataFastPath
+func mirListUsesRawDataFastPath(elemLLVM string) bool {
+	return elemLLVM == "i64" || elemLLVM == "i1" || elemLLVM == "double"
+}
+
+// §18 (cont'd) — alloca-hoist scanner predicates ported from
+// alloca_hoist.go.
+
+// Osty: mirIsBrTerminatorLine
+func mirIsBrTerminatorLine(line string) bool {
+	return llvmStrings.HasPrefix(line, "  br ")
+}
+
+// Osty: mirIsAllocaLine
+func mirIsAllocaLine(line string) bool {
+	const prefix = "  %"
+	if !llvmStrings.HasPrefix(line, prefix) {
+		return false
+	}
+	rest := line[len(prefix):]
+	eq := llvmStrings.Index(rest, " = ")
+	if eq < 0 {
+		return false
+	}
+	const separator = " = "
+	tail := rest[eq+len(separator):]
+	return llvmStrings.HasPrefix(tail, "alloca ") || tail == "alloca"
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -482,13 +482,12 @@ func listUsesTypedRuntime(elemTyp string) bool {
 	return llvmListUsesTypedRuntime(elemTyp)
 }
 
+// listUsesRawDataFastPath delegates to the Osty-sourced
+// `mirListUsesRawDataFastPath` (`toolchain/mir_generator.osty`). The
+// fast set (i64 / i1 / double) is the same source-of-truth for both
+// the snapshot read path and the typed-runtime dispatch.
 func listUsesRawDataFastPath(elemTyp string) bool {
-	switch elemTyp {
-	case "i64", "i1", "double":
-		return true
-	default:
-		return false
-	}
+	return mirListUsesRawDataFastPath(elemTyp)
 }
 
 func listRuntimeSymbolSuffix(typ string) string {

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12645,3 +12645,53 @@ pub fn mirIsBuiltinMap(name: String, isBuiltin: Bool) -> Bool {
 pub fn mirIsBuiltinSet(name: String, isBuiltin: Bool) -> Bool {
     mirIsBuiltinNamedType(name, isBuiltin, "Set")
 }
+
+/// §18 (cont'd) — typed-list runtime fast-path predicate ported from
+/// `listUsesRawDataFastPath` in `internal/llvmgen/runtime_ffi.go`.
+///
+/// Returns true when the List<elem> element type can use the raw-
+/// data fast path (direct GEP into the backing buffer, no bytes-v1
+/// out-pointer ABI). The fast set is i64 / i1 / double — fixed-width
+/// scalars whose stride is power-of-two and whose snapshot doesn't
+/// need a per-element copy.
+///
+/// Distinct from `mirListUsesTypedRuntime` (the existing predicate at
+/// `toolchain/llvmgen.osty`) which adds `ptr` to the typed runtime
+/// set — pointers go through a typed `osty_rt_list_*_ptr` runtime
+/// shape but cannot use the raw-data fast path because of GC
+/// barriers on the backing pointer reads.
+pub fn mirListUsesRawDataFastPath(elemLLVM: String) -> Bool {
+    elemLLVM == "i64" || elemLLVM == "i1" || elemLLVM == "double"
+}
+
+/// §18 (cont'd) — alloca-hoist scanner predicates ported from
+/// `isAllocaLine` / `isBrTerminator` in
+/// `internal/llvmgen/alloca_hoist.go`. Pure string scanners that
+/// classify pre-formatted LLVM-text lines emitted by the emit pass.
+
+/// mirIsBrTerminatorLine reports whether `line` is an unconditional
+/// or conditional `br` terminator. Used by the alloca-hoist pass to
+/// locate the entry-block boundary so hoisted allocas land just
+/// before the terminator.
+pub fn mirIsBrTerminatorLine(line: String) -> Bool {
+    llvmStrings.HasPrefix(line, "  br ")
+}
+
+/// mirIsAllocaLine reports whether `line` is an `alloca`-shaped
+/// instruction (the prefix is `  %<name> = alloca`). Used by the
+/// alloca-hoist pass to find candidates to lift to the entry block.
+///
+/// Accepts both `alloca <ty>` (with a trailing token) and the
+/// degenerate bare `alloca` form (no type — currently unreachable
+/// from the emit pass but left in for parser-symmetry).
+pub fn mirIsAllocaLine(line: String) -> Bool {
+    let prefix = "  %"
+    if !llvmStrings.HasPrefix(line, prefix) { return false }
+    let rest = line[prefix.len()..line.len()]
+    let eq = llvmStrings.Index(rest, " = ")
+    if eq < 0 { return false }
+    let separator = " = "
+    let tailStart = eq + separator.len()
+    let tail = rest[tailStart..rest.len()]
+    llvmStrings.HasPrefix(tail, "alloca ") || tail == "alloca"
+}


### PR DESCRIPTION
## Phase 2 — third function port

Three pure string predicates moved from `internal/llvmgen/` to
`toolchain/mir_generator.osty`:

### 1. `listUsesRawDataFastPath` (runtime_ffi.go)

Element types eligible for the raw-data list fast path: `i64` / `i1` / `double` (no `ptr` — that goes through the typed `osty_rt_list_*_ptr` shape with GC barriers).

```osty
pub fn mirListUsesRawDataFastPath(elemLLVM: String) -> Bool {
    elemLLVM == "i64" || elemLLVM == "i1" || elemLLVM == "double"
}
```

### 2. `isBrTerminator` (alloca_hoist.go)

Detects `  br ...` line prefix used by the alloca-hoist pass.

```osty
pub fn mirIsBrTerminatorLine(line: String) -> Bool {
    llvmStrings.HasPrefix(line, "  br ")
}
```

### 3. `isAllocaLine` (alloca_hoist.go)

Detects `  %<name> = alloca ...` line shape with leading-2-space indent. Handles both the typed (`alloca i64`) and degenerate bare `alloca` forms.

```osty
pub fn mirIsAllocaLine(line: String) -> Bool {
    let prefix = "  %"
    if !llvmStrings.HasPrefix(line, prefix) { return false }
    let rest = line[prefix.len()..line.len()]
    let eq = llvmStrings.Index(rest, " = ")
    if eq < 0 { return false }
    let separator = " = "
    let tailStart = eq + separator.len()
    let tail = rest[tailStart..rest.len()]
    llvmStrings.HasPrefix(tail, "alloca ") || tail == "alloca"
}
```

### Cleanup

Removed `"strings"` import from `alloca_hoist.go` — only callers were the two ported predicates. The `strings` package now flows through the `llvmStrings` alias used inside snapshot.go.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing