### PR TITLE
refactor(llvmgen): port 3 pure switch helpers to osty (Phase 2 slice 4)

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2265,13 +2265,12 @@ func isPrimitiveLiteralMatchArms(arms []*ast.MatchArm) bool {
 	return sawLiteral
 }
 
+// isPrimitiveLiteralMatchScrutineeType reports whether a match
+// scrutinee LLVM type can use the literal-dispatch fast path.
+// Delegates to the Osty-sourced `mirIsPrimitiveLiteralMatchScrutineeType`
+// (`toolchain/mir_generator.osty`).
 func isPrimitiveLiteralMatchScrutineeType(typ string) bool {
-	switch typ {
-	case "i64", "i32", "i8", "i1":
-		return true
-	default:
-		return false
-	}
+	return mirIsPrimitiveLiteralMatchScrutineeType(typ)
 }
 
 // emitPrimitiveLiteralMatchExprValue lowers `match n { 0 -> A, 1 -> B,

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7674,3 +7674,33 @@ func mirIsAllocaLine(line string) bool {
 	tail := rest[eq+len(separator):]
 	return llvmStrings.HasPrefix(tail, "alloca ") || tail == "alloca"
 }
+
+// §18 (cont'd) — primitive scrutinee / std.io output / list-primitive
+// kind helpers ported from expr.go / stdlib_io_shim.go / stmt.go.
+
+// Osty: mirIsPrimitiveLiteralMatchScrutineeType
+func mirIsPrimitiveLiteralMatchScrutineeType(typ string) bool {
+	return typ == "i64" || typ == "i32" || typ == "i8" || typ == "i1"
+}
+
+// Osty: mirIsStdIoOutputMethod
+func mirIsStdIoOutputMethod(name string) bool {
+	return name == "print" || name == "println" || name == "eprint" || name == "eprintln"
+}
+
+// Osty: mirListPrimitiveKindID
+func mirListPrimitiveKindID(elemTyp string, elemIsString bool) int {
+	switch elemTyp {
+	case "i64":
+		return 1
+	case "double":
+		return 2
+	case "i1":
+		return 3
+	case "ptr":
+		if elemIsString {
+			return 4
+		}
+	}
+	return 0
+}

--- a/internal/llvmgen/stdlib_io_shim.go
+++ b/internal/llvmgen/stdlib_io_shim.go
@@ -26,13 +26,11 @@ func collectStdIoAliases(file *ast.File) map[string]bool {
 	return out
 }
 
+// isStdIoOutputMethod reports whether `name` is one of the four
+// std.io output methods. Delegates to the Osty-sourced
+// `mirIsStdIoOutputMethod` (`toolchain/mir_generator.osty`).
 func isStdIoOutputMethod(name string) bool {
-	switch name {
-	case "print", "println", "eprint", "eprintln":
-		return true
-	default:
-		return false
-	}
+	return mirIsStdIoOutputMethod(name)
 }
 
 func stdIoWriteFlags(name string) (newline bool, toStderr bool, ok bool) {

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2016,22 +2016,11 @@ func (g *generator) buildAssertCompareMessage(call *ast.CallExpr, name, leftText
 
 // listPrimitiveKindID maps an LLVM element type to the elem_kind
 // argument accepted by osty_rt_list_primitive_to_string. Returns 0
-// when the element type is not a supported primitive (struct, enum,
-// Map payload, nested list) — caller falls back to no-diff rendering.
+// when the element type is not a supported primitive — caller falls
+// back to no-diff rendering. Delegates to the Osty-sourced
+// `mirListPrimitiveKindID` (`toolchain/mir_generator.osty`).
 func listPrimitiveKindID(elemTyp string, elemIsString bool) int {
-	switch elemTyp {
-	case "i64":
-		return 1
-	case "double":
-		return 2
-	case "i1":
-		return 3
-	case "ptr":
-		if elemIsString {
-			return 4
-		}
-	}
-	return 0
+	return mirListPrimitiveKindID(elemTyp, elemIsString)
 }
 
 // stringifyForStructuralDiff returns (leftStr, rightStr, true) when

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12695,3 +12695,35 @@ pub fn mirIsAllocaLine(line: String) -> Bool {
     let tail = rest[tailStart..rest.len()]
     llvmStrings.HasPrefix(tail, "alloca ") || tail == "alloca"
 }
+
+/// §18 (cont'd) — primitive scrutinee predicate ported from
+/// `isPrimitiveLiteralMatchScrutineeType` in
+/// `internal/llvmgen/expr.go`. Reports whether a match scrutinee
+/// LLVM type can use the literal-dispatch fast path (i64 / i32 / i8
+/// / i1 — the integer family that fits the `select`-chain shape).
+pub fn mirIsPrimitiveLiteralMatchScrutineeType(typ: String) -> Bool {
+    typ == "i64" || typ == "i32" || typ == "i8" || typ == "i1"
+}
+
+/// §18 (cont'd) — std.io output-method predicate ported from
+/// `isStdIoOutputMethod` in `internal/llvmgen/stdlib_io_shim.go`.
+/// Recognises the four `print` / `println` / `eprint` / `eprintln`
+/// std.io output methods.
+pub fn mirIsStdIoOutputMethod(name: String) -> Bool {
+    name == "print" || name == "println" || name == "eprint" || name == "eprintln"
+}
+
+/// §18 (cont'd) — list-primitive kind ID ported from
+/// `listPrimitiveKindID` in `internal/llvmgen/stmt.go`.
+///
+/// Returns the runtime-side kind ID for `osty_rt_list_primitive_to_string`
+/// — 1=Int, 2=Float, 3=Bool, 4=String. Returns 0 when the element type
+/// is not a supported primitive (struct, enum, Map payload, nested
+/// list); caller falls back to no-diff rendering.
+pub fn mirListPrimitiveKindID(elemTyp: String, elemIsString: Bool) -> Int {
+    if elemTyp == "i64" { return 1 }
+    if elemTyp == "double" { return 2 }
+    if elemTyp == "i1" { return 3 }
+    if elemTyp == "ptr" && elemIsString { return 4 }
+    0
+}


### PR DESCRIPTION
## Phase 2 — fourth function port

Three pure switch-on-string predicates moved from `internal/llvmgen/` to `toolchain/mir_generator.osty`:

### 1. `isPrimitiveLiteralMatchScrutineeType` (expr.go)

```osty
pub fn mirIsPrimitiveLiteralMatchScrutineeType(typ: String) -> Bool {
    typ == "i64" || typ == "i32" || typ == "i8" || typ == "i1"
}
```

Recognises i64/i32/i8/i1 — the integer family eligible for the match-literal-dispatch select-chain shape.

### 2. `isStdIoOutputMethod` (stdlib_io_shim.go)

```osty
pub fn mirIsStdIoOutputMethod(name: String) -> Bool {
    name == "print" || name == "println" || name == "eprint" || name == "eprintln"
}
```

### 3. `listPrimitiveKindID` (stmt.go)

```osty
pub fn mirListPrimitiveKindID(elemTyp: String, elemIsString: Bool) -> Int {
    if elemTyp == "i64" { return 1 }
    if elemTyp == "double" { return 2 }
    if elemTyp == "i1" { return 3 }
    if elemTyp == "ptr" && elemIsString { return 4 }
    0
}
```

Returns runtime kind ID for `osty_rt_list_primitive_to_string` (1=Int, 2=Float, 3=Bool, 4=String, 0=unsupported — caller falls back to no-diff rendering).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (baseline)