### PR TITLE
perf(runtime): make Set young-eligible (cheney covers items buffer cleanup)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -6278,20 +6278,9 @@ int main(void) {
 // (flag off / GENERIC / has-destroy / oversized / zero-size) keep
 // behaving as designed even when no production caller uses it yet.
 //
-// Allowed kinds today: STRING, BYTES (immutable byte payloads),
-// LIST (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list
-// scan), CLOSURE_ENV (captures populated synchronously at
-// construction before the env escapes; promote-on-bind copies a
-// fully-populated env to OLD), GENERIC NONE pattern (NULL trace +
-// NULL destroy — opaque payload, nothing for cheney to follow), SET
-// (cheney_destroy_dead_from_space frees the `items` heap buffer for
-// UNFORWARDED young Sets). The debug entry assumes NONE for
-// GENERIC; the production allocator also rejects ENUM_PTR /
-// TASK_HANDLE because the per-instance pattern can't be recovered
-// from the 16-byte micro-header.
-// Rejected: MAP/CHANNEL (destroy frees pthread sync state in
-// addition to backing arrays — larger surface, less perf payoff
-// since these are typically long-lived), humongous (size > threshold).
+// Per-kind eligibility verdicts and rationale live next to
+// `osty_gc_young_eligible` in the runtime — this test pins the
+// verdicts (one row per kind), not the reasoning.
 func TestBundledRuntimeYoungEligibilityFilter(t *testing.T) {
 	parallelClangBackendTest(t)
 
@@ -6646,9 +6635,6 @@ int main(void) {
 // the inserted items survive a forced collect, and the items heap
 // buffer is freed (not leaked) when an UNFORWARDED young Set is
 // reclaimed by `osty_gc_cheney_destroy_dead_from_space`.
-//
-// This is the dual of the LIST young test (#960): same dead-buffer
-// scan, no self-ref fixup since Set has no inline-storage union.
 func TestBundledRuntimeSetYoungLifecycle(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -6283,12 +6283,15 @@ int main(void) {
 // scan), CLOSURE_ENV (captures populated synchronously at
 // construction before the env escapes; promote-on-bind copies a
 // fully-populated env to OLD), GENERIC NONE pattern (NULL trace +
-// NULL destroy — opaque payload, nothing for cheney to follow). The
-// debug entry assumes NONE for GENERIC; the production allocator
-// also rejects ENUM_PTR / TASK_HANDLE because the per-instance
-// pattern can't be recovered from the 16-byte micro-header.
-// Rejected: MAP/SET/CHANNEL (have destroy callbacks Cheney can't
-// invoke), humongous (size > threshold).
+// NULL destroy — opaque payload, nothing for cheney to follow), SET
+// (cheney_destroy_dead_from_space frees the `items` heap buffer for
+// UNFORWARDED young Sets). The debug entry assumes NONE for
+// GENERIC; the production allocator also rejects ENUM_PTR /
+// TASK_HANDLE because the per-instance pattern can't be recovered
+// from the 16-byte micro-header.
+// Rejected: MAP/CHANNEL (destroy frees pthread sync state in
+// addition to backing arrays — larger surface, less perf payoff
+// since these are typically long-lived), humongous (size > threshold).
 func TestBundledRuntimeYoungEligibilityFilter(t *testing.T) {
 	parallelClangBackendTest(t)
 
@@ -6375,8 +6378,8 @@ int main(void) {
 				"1 1 1",    // GENERIC: eligible under NONE pattern (debug entry assumes NULL trace/destroy)
 				"1024 1 1", // LIST: eligible (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list scan)
 				"1025 1 1", // STRING: eligible
-				"1026 0 0", // MAP: has destroy (free's keys/values arrays — needs typed sweep)
-				"1027 0 0", // SET: has destroy
+				"1026 0 0", // MAP: has destroy (frees pthread state + key/value arrays — needs typed sweep)
+				"1027 1 1", // SET: eligible (dead-from-space scan frees items buffer; no inline-storage union)
 				"1028 1 1", // BYTES: eligible
 				"1029 1 1", // CLOSURE_ENV: eligible (captures populated synchronously before escape)
 				"1030 0 0", // CHANNEL: has destroy
@@ -6633,6 +6636,128 @@ int main(void) {
 	}, "\n")
 	if got := string(runOutput); got != want {
 		t.Fatalf("generic-none harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestBundledRuntimeSetYoungLifecycle covers the SET young
+// eligibility addition: a fresh `osty_rt_set_new` lands in the young
+// arena, `set_insert_*` keeps working through `osty_gc_load_v1`'s
+// PROMOTED follow after `root_bind` promotes the young Set to OLD,
+// the inserted items survive a forced collect, and the items heap
+// buffer is freed (not leaked) when an UNFORWARDED young Set is
+// reclaimed by `osty_gc_cheney_destroy_dead_from_space`.
+//
+// This is the dual of the LIST young test (#960): same dead-buffer
+// scan, no self-ref fixup since Set has no inline-storage union.
+func TestBundledRuntimeSetYoungLifecycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_set_young_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_set_young_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_rt_set_new(int64_t elem_kind);
+int64_t osty_rt_set_len(void *raw_set);
+int osty_rt_set_insert_i64(void *raw_set, int64_t item);
+int osty_rt_set_contains_i64(void *raw_set, int64_t item);
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+int64_t osty_gc_debug_arena_is_young_page(void *payload);
+int64_t osty_gc_debug_young_forward_tag(void *from_payload);
+int64_t osty_gc_debug_young_cheney_dead_sets_freed_total(void);
+void osty_gc_debug_collect(void);
+
+#define ABI_I64 1
+
+int main(void) {
+    /* Fresh Set goes young. Inserts before root_bind populate the
+     * heap items buffer through the still-young set pointer. */
+    void *raw = osty_rt_set_new(ABI_I64);
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(raw));
+
+    osty_rt_set_insert_i64(raw, 10);
+    osty_rt_set_insert_i64(raw, 20);
+    osty_rt_set_insert_i64(raw, 30);
+
+    /* root_bind promotes the young Set to OLD. The OLD copy carries
+     * the same items pointer (memcpy of payload bytes). */
+    osty_gc_root_bind_v1(raw);
+    printf("%lld\n", (long long)osty_gc_debug_young_forward_tag(raw));
+
+    /* Inserts via the stale young handle work because the typed
+     * insert macros run through osty_rt_set_cast then osty_gc_load_v1,
+     * which follows the PROMOTED tag. Verify the OLD copy got the
+     * write. */
+    osty_rt_set_insert_i64(raw, 40);
+    printf("%lld\n", (long long)osty_rt_set_len(raw));
+    printf("%d %d %d %d\n",
+        osty_rt_set_contains_i64(raw, 10),
+        osty_rt_set_contains_i64(raw, 20),
+        osty_rt_set_contains_i64(raw, 30),
+        osty_rt_set_contains_i64(raw, 40));
+
+    /* Forced collect: cheney_minor processes the (PROMOTED) young
+     * Set, the major mark keeps OLD alive via the root binding, and
+     * the items buffer survives because the OLD copy still owns it. */
+    osty_gc_debug_collect();
+    printf("%lld\n", (long long)osty_rt_set_len(raw));
+
+    /* Allocate + drop a fresh young Set to exercise the dead-Set
+     * cleanup path: insert one item to force items-buffer
+     * allocation, then never root the Set so the next collect
+     * reclaims it as UNFORWARDED. The cleanup counter increments
+     * iff cheney_destroy_dead_from_space ran the SET branch. */
+    int64_t freed_before = osty_gc_debug_young_cheney_dead_sets_freed_total();
+    void *transient = osty_rt_set_new(ABI_I64);
+    osty_rt_set_insert_i64(transient, 99);
+    osty_gc_debug_collect();
+    int64_t freed_after = osty_gc_debug_young_cheney_dead_sets_freed_total();
+    printf("%lld\n", (long long)(freed_after - freed_before));
+
+    /* Release the rooted Set. The OLD copy's destroy fires on the
+     * subsequent collect, freeing items via the headerful destroy
+     * path (not the young dead-Set scan). */
+    osty_gc_root_release_v1(raw);
+    osty_gc_debug_collect();
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"1",         // fresh Set landed in young arena
+		"2",         // forward tag = PROMOTED after root_bind
+		"4",         // post-promote insert via stale young handle worked (load_v1 follow)
+		"1 1 1 1",   // all four items contained
+		"4",         // items survived forced collect (still rooted)
+		"1",         // dead-Set cleanup fired on the unrooted transient
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("set-young harness output mismatch\n got: %q\nwant: %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3100,8 +3100,8 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      dormant and every alloc takes the headerful path, preserving
  *      pre-Phase-5 behaviour exactly.
  *   2. The kind must be one of the young-safe kinds — STRING, BYTES,
- *      LIST, CLOSURE_ENV, or GENERIC with the NONE pattern (NULL
- *      trace + NULL destroy). STRING/BYTES are immutable byte
+ *      LIST, CLOSURE_ENV, SET, or GENERIC with the NONE pattern
+ *      (NULL trace + NULL destroy). STRING/BYTES are immutable byte
  *      payloads. LIST has a destroy callback (frees spilled `data` +
  *      `gc_offsets`), but Phase E follow-up adds a from-space
  *      dead-list scan in cheney_minor that runs the destroy work just
@@ -3125,11 +3125,18 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      per-instance pattern to be recoverable at cheney scan time —
  *      not yet possible since the micro-header has no
  *      `generic_pattern` byte — so they stay headerful.
+ *      SET has a destroy callback (frees the `items` heap buffer).
+ *      It rides the same dead-from-space scan as LIST: the cheney
+ *      pass calls `free(set->items)` on UNFORWARDED young Sets
+ *      before the arena swap reclaims their micro-header bytes.
+ *      No self-ref fixup needed — Set has no inline-storage union;
+ *      `items` is always a separate heap allocation.
  *
  *      Why not the other kinds:
- *        - MAP/SET/CHANNEL: destroy frees pthread sync state and
- *          backing arrays — typed-allocator surface is larger and
- *          these are typically long-lived.
+ *        - MAP/CHANNEL: destroy frees pthread sync state in addition
+ *          to backing arrays — the recursive-mutex teardown +
+ *          pthread_cond_destroy surface is larger and these are
+ *          typically long-lived, so the perf payoff is smaller.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being
@@ -3155,7 +3162,8 @@ static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size,
     } else if (object_kind != OSTY_GC_KIND_STRING &&
                object_kind != OSTY_GC_KIND_BYTES &&
                object_kind != OSTY_GC_KIND_LIST &&
-               object_kind != OSTY_GC_KIND_CLOSURE_ENV) {
+               object_kind != OSTY_GC_KIND_CLOSURE_ENV &&
+               object_kind != OSTY_GC_KIND_SET) {
         return false;
     }
     if (payload_size == 0 ||
@@ -3291,23 +3299,29 @@ static void osty_gc_cheney_swap_arenas(void) {
  * objects.
  *
  * Cheney's normal "reclamation = cursor reset" is fine for objects
- * whose only memory is the payload bytes themselves (STRING/BYTES).
- * `osty_rt_list`, however, may hold a heap-allocated `data` buffer
- * (when the list spilled past inline storage) or a heap-allocated
- * `gc_offsets` array (struct-element lists). Without an explicit
- * destroy pass these external buffers leak when their owning list
+ * whose only memory is the payload bytes themselves (STRING/BYTES /
+ * GENERIC NONE / CLOSURE_ENV). `osty_rt_list`, however, may hold a
+ * heap-allocated `data` buffer (when the list spilled past inline
+ * storage) or a heap-allocated `gc_offsets` array (struct-element
+ * lists). `osty_rt_set` always holds a heap-allocated `items`
+ * buffer (no inline-storage union). Without an explicit destroy
+ * pass these external buffers leak when their owning collection
  * becomes unreachable in young.
  *
  * The scan walks from-space from base to the recorded pre-swap
  * cursor. Forwarded objects (`FORWARDED` / `PROMOTED` tag) are
- * skipped — their external resources moved with them. Unforwarded
+ * skipped — their external resources moved with them (the to-space
+ * or OLD copy carries the same `items`/`data` pointer; freeing here
+ * would double-free when that copy is later destroyed). Unforwarded
  * (UNFORWARDED tag) objects are dead; for kinds that own external
  * memory we run a per-kind cleanup before the swap reclaims the
  * arena bytes. */
 static int64_t osty_gc_young_cheney_dead_lists_freed_total = 0;
+static int64_t osty_gc_young_cheney_dead_sets_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_buffer_bytes_freed_total = 0;
 
 static size_t osty_gc_micro_object_total_size(int32_t payload_size);
+static size_t osty_rt_kind_size(int64_t kind);
 
 static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
                                                    unsigned char *from_end_cursor) {
@@ -3332,9 +3346,19 @@ static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
                     free(list->data);
                 }
                 osty_gc_young_cheney_dead_lists_freed_total += 1;
+            } else if (micro->object_kind == OSTY_GC_KIND_SET) {
+                osty_rt_set *set = (osty_rt_set *)payload;
+                if (set->items != NULL) {
+                    osty_gc_young_cheney_dead_buffer_bytes_freed_total +=
+                        (int64_t)((size_t)set->cap *
+                                  osty_rt_kind_size(set->elem_kind));
+                    free(set->items);
+                }
+                osty_gc_young_cheney_dead_sets_freed_total += 1;
             }
-            /* STRING / BYTES carry no external buffers — payload bytes
-             * are reclaimed by the cursor reset, no destroy needed. */
+            /* STRING / BYTES / CLOSURE_ENV / GENERIC NONE carry no
+             * external buffers — payload bytes are reclaimed by the
+             * cursor reset, no destroy needed. */
         }
         scan += total;
     }
@@ -10879,6 +10903,18 @@ int64_t osty_gc_debug_young_cheney_forwarded_bytes_total(void) {
 
 int64_t osty_gc_debug_young_cheney_swap_count_total(void) {
     return osty_gc_young_cheney_swap_count_total;
+}
+
+int64_t osty_gc_debug_young_cheney_dead_lists_freed_total(void) {
+    return osty_gc_young_cheney_dead_lists_freed_total;
+}
+
+int64_t osty_gc_debug_young_cheney_dead_sets_freed_total(void) {
+    return osty_gc_young_cheney_dead_sets_freed_total;
+}
+
+int64_t osty_gc_debug_young_cheney_dead_buffer_bytes_freed_total(void) {
+    return osty_gc_young_cheney_dead_buffer_bytes_freed_total;
 }
 
 /* Decode the forwarding tag for testing. Returns the tag value

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4053,7 +4053,6 @@ static void *osty_gc_allocate_pinned_managed(size_t byte_size,
 }
 
 static void osty_gc_mark_payload(void *payload);
-static size_t osty_rt_kind_size(int64_t kind);
 static void osty_rt_chan_sync_init_or_abort(osty_rt_chan_impl *ch,
                                             const char *op);
 static void osty_rt_chan_ensure_elem_kind(osty_rt_chan_impl *ch,


### PR DESCRIPTION
## Summary

Set joins LIST in the no-header young arena. Same shape as the LIST work ([osty#960](https://github.com/choiceoh/osty/pull/960)): the typed insert macros already funnel through `osty_rt_set_cast` → `osty_gc_load_v1`, which follows the PROMOTED tag, so post-promote inserts via a stale young pointer correctly land on the OLD copy. The new piece is dead-Set cleanup: when an UNFORWARDED young Set is reclaimed by cheney_minor's arena swap, the `items` heap buffer would otherwise leak. `cheney_destroy_dead_from_space` now runs `free(set->items)` for the SET branch (mirroring the LIST branch), gated on UNFORWARDED so PROMOTED / FORWARDED Sets — whose items pointer was inherited by the OLD or to-space copy — don't double-free.

No self-ref fixup needed (Set has no inline-storage union — `items` is always a separate heap allocation).

## Changes

`internal/backend/runtime/osty_runtime.c`:
- `osty_gc_young_eligible` admits `OSTY_GC_KIND_SET`.
- `osty_gc_cheney_destroy_dead_from_space` adds the SET case + counter.
- New debug accessors: `osty_gc_debug_young_cheney_dead_lists/sets/buffer_bytes_freed_total` (the LIST counters were already unobservable — exposing them in the same pass keeps the cleanup pass instrumentable).
- Forward-decl `osty_rt_kind_size` near the dead-from-space scan since the SET branch needs it before its definition.

`internal/backend/llvm_runtime_gc_test.go`:
- `TestBundledRuntimeYoungEligibilityFilter`: SET row flips `"1027 0 0"` → `"1027 1 1"`.
- New `TestBundledRuntimeSetYoungLifecycle`: alloc young Set, insert pre-promote, `root_bind` (verify PROMOTED tag), insert post-promote via stale handle (verify `load_v1` follow), forced collect (verify items survive), allocate + drop a transient Set (verify dead-from-space scan freed its items buffer via the new counter).

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeSetYoungLifecycle|TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime suite passes
- [x] `go test ./internal/backend/ -run "Gc|GC|Cheney|Young|Promote|Closure|Generic|Set"` — all GC + Set tests pass

## Pending follow-ups (not in this PR)

- Map (mutex + 4 buffers + self-ref fixup for keys/values arrays)
- Channel + GENERIC TASK_HANDLE (pthread sync teardown)
- GENERIC ENUM_PTR / TASK_HANDLE: needs a `generic_pattern` byte in the micro-header (or kind-enum split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)