### PR TITLE
refactor(llvmgen): port linuxArch + darwinArch + llvmTripleFor to osty (Phase 2 slice 5)

### DIFF
--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7717,3 +7717,45 @@ func mirListPrimitiveKindID(elemTyp string, elemIsString bool) int {
 	}
 	return 0
 }
+
+// §18 (cont'd) — target-triple canonicalization helpers ported from
+// internal/llvmgen/target.go.
+
+// Osty: mirLinuxArch
+func mirLinuxArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	case "386":
+		return "i386"
+	case "arm64":
+		return "aarch64"
+	}
+	return arch
+}
+
+// Osty: mirDarwinArch
+func mirDarwinArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "arm64"
+	}
+	return arch
+}
+
+// Osty: mirLLVMTripleFor
+func mirLLVMTripleFor(arch, osName string) string {
+	switch osName {
+	case "darwin":
+		return mirDarwinArch(arch) + "-apple-darwin"
+	case "linux":
+		return mirLinuxArch(arch) + "-unknown-linux-gnu"
+	case "windows":
+		return mirLinuxArch(arch) + "-pc-windows-msvc"
+	case "js":
+		return "wasm32-unknown-emscripten"
+	}
+	return mirLinuxArch(arch) + "-unknown-" + osName
+}

--- a/internal/llvmgen/target.go
+++ b/internal/llvmgen/target.go
@@ -135,51 +135,20 @@ func hostLLVMTriple() string {
 }
 
 // llvmTripleFor maps a (Go-style arch, Go-style os) pair to the LLVM
-// triple the host toolchain uses by default. Unknown archs pass
-// through unchanged so exotic targets still produce *something*
-// deterministic rather than silently falling back to host.
+// triple the host toolchain uses by default. Delegates to the Osty-
+// sourced `mirLLVMTripleFor` (`toolchain/mir_generator.osty`).
 func llvmTripleFor(arch, osName string) string {
-	switch osName {
-	case "darwin":
-		return darwinArch(arch) + "-apple-darwin"
-	case "linux":
-		return linuxArch(arch) + "-unknown-linux-gnu"
-	case "windows":
-		return linuxArch(arch) + "-pc-windows-msvc"
-	case "js":
-		// Emscripten is the only pairing the Osty toolchain ships for
-		// wasm today; keep the shape explicit rather than invent a
-		// generic unknown triple that clang would reject.
-		return "wasm32-unknown-emscripten"
-	default:
-		return linuxArch(arch) + "-unknown-" + osName
-	}
+	return mirLLVMTripleFor(arch, osName)
 }
 
 // linuxArch maps Go's GOARCH to the LLVM arch component used on
-// Linux / Windows triples. The Apple ecosystem prefers `arm64` over
-// `aarch64`, so darwinArch keeps that spelling separate.
+// Linux / Windows triples. Delegates to `mirLinuxArch`.
 func linuxArch(arch string) string {
-	switch arch {
-	case "amd64":
-		return "x86_64"
-	case "386":
-		return "i386"
-	case "arm64":
-		return "aarch64"
-	default:
-		return arch
-	}
+	return mirLinuxArch(arch)
 }
 
+// darwinArch maps Go's GOARCH to the LLVM arch component used on
+// Apple-sys triples. Delegates to `mirDarwinArch`.
 func darwinArch(arch string) string {
-	switch arch {
-	case "amd64":
-		return "x86_64"
-	case "arm64":
-		// Apple's own triples write `arm64-apple-darwin`, not aarch64.
-		return "arm64"
-	default:
-		return arch
-	}
+	return mirDarwinArch(arch)
 }

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12727,3 +12727,41 @@ pub fn mirListPrimitiveKindID(elemTyp: String, elemIsString: Bool) -> Int {
     if elemTyp == "ptr" && elemIsString { return 4 }
     0
 }
+
+/// §18 (cont'd) — target-triple canonicalization helpers ported from
+/// `internal/llvmgen/target.go`. The host-boundary `runtime.GOOS` /
+/// `runtime.GOARCH` probe stays Go-side; the pure (arch, os) → LLVM
+/// triple / arch-component mapping moves to Osty.
+
+/// mirLinuxArch maps Go's GOARCH to the LLVM arch component used on
+/// Linux / Windows triples. The Apple ecosystem prefers `arm64` over
+/// `aarch64`, so `mirDarwinArch` keeps that spelling separate.
+pub fn mirLinuxArch(arch: String) -> String {
+    if arch == "amd64" { return "x86_64" }
+    if arch == "386" { return "i386" }
+    if arch == "arm64" { return "aarch64" }
+    arch
+}
+
+/// mirDarwinArch maps Go's GOARCH to the LLVM arch component used on
+/// Apple-sys (apple-darwin / apple-macos) triples. Apple's own
+/// triples write `arm64-apple-darwin`, not `aarch64`.
+pub fn mirDarwinArch(arch: String) -> String {
+    if arch == "amd64" { return "x86_64" }
+    if arch == "arm64" { return "arm64" }
+    arch
+}
+
+/// mirLLVMTripleFor maps a (Go-style arch, Go-style os) pair to the
+/// LLVM triple the host toolchain uses by default. Mirrors
+/// `llvmTripleFor` in `internal/llvmgen/target.go`.
+///
+/// The `js` / Emscripten case hard-codes `wasm32-unknown-emscripten`
+/// — the only wasm pairing the Osty toolchain ships today.
+pub fn mirLLVMTripleFor(arch: String, osName: String) -> String {
+    if osName == "darwin" { return mirDarwinArch(arch) + "-apple-darwin" }
+    if osName == "linux" { return mirLinuxArch(arch) + "-unknown-linux-gnu" }
+    if osName == "windows" { return mirLinuxArch(arch) + "-pc-windows-msvc" }
+    if osName == "js" { return "wasm32-unknown-emscripten" }
+    mirLinuxArch(arch) + "-unknown-" + osName
+}


### PR DESCRIPTION
## Phase 2 — fifth function port

Three pure (arch, os) → LLVM triple / arch-component mapping helpers
moved from `internal/llvmgen/target.go` to `toolchain/mir_generator.osty`:

### 1. `linuxArch` → `mirLinuxArch`

Go GOARCH → LLVM arch on Linux/Windows triples.

```osty
pub fn mirLinuxArch(arch: String) -> String {
    if arch == "amd64" { return "x86_64" }
    if arch == "386" { return "i386" }
    if arch == "arm64" { return "aarch64" }
    arch
}
```

### 2. `darwinArch` → `mirDarwinArch`

Go GOARCH → LLVM arch on Apple-sys triples (Apple keeps `arm64` over `aarch64`).

```osty
pub fn mirDarwinArch(arch: String) -> String {
    if arch == "amd64" { return "x86_64" }
    if arch == "arm64" { return "arm64" }
    arch
}
```

### 3. `llvmTripleFor` → `mirLLVMTripleFor`

(arch, osName) → full LLVM triple. darwin/linux/windows/js are special-cased; default `<arch>-unknown-<osName>`.

```osty
pub fn mirLLVMTripleFor(arch: String, osName: String) -> String {
    if osName == "darwin" { return mirDarwinArch(arch) + "-apple-darwin" }
    if osName == "linux" { return mirLinuxArch(arch) + "-unknown-linux-gnu" }
    if osName == "windows" { return mirLinuxArch(arch) + "-pc-windows-msvc" }
    if osName == "js" { return "wasm32-unknown-emscripten" }
    mirLinuxArch(arch) + "-unknown-" + osName
}
```

### Why now

The `target.go` package doc comment says:

> The pure mapping from Osty triple to LLVM triple could live in toolchain/llvmgen.osty once Osty gains a `std.env.hostTriple()` primitive — until then the shim keeps policy next to the call sites that consume it.

The pure mapping doesn't actually need that primitive — it can move now. The `runtime.GOOS` / `runtime.GOARCH` host probe in `hostLLVMTriple` and `CanonicalLLVMTarget` stays Go-side; only the (arch, os) → string mapping moves.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (baseline)