### PR TITLE
refactor(llvmgen): port isSpecializedBuiltinStructName + llvmBuiltinAggregatePart to osty

### DIFF
--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -827,8 +827,10 @@ func legacyStructDeclFromIR(sd *ostyir.StructDecl) (*ast.StructDecl, error) {
 // keep their source name unless explicitly specialized via the same
 // mangler, and in that case they are equally free of bodyless
 // methods (user structs don't carry intrinsic placeholders).
+// isSpecializedBuiltinStructName delegates to the Osty-sourced
+// `mirIsSpecializedBuiltinStructName` (`toolchain/mir_generator.osty`).
 func isSpecializedBuiltinStructName(name string) bool {
-	return strings.HasPrefix(name, "_ZTS")
+	return mirIsSpecializedBuiltinStructName(name)
 }
 
 func legacyFieldFromIR(field *ostyir.Field) (*ast.Field, error) {

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7916,3 +7916,36 @@ func mirLLVMTripleFor(arch, osName string) string {
 	}
 	return mirLinuxArch(arch) + "-unknown-" + osName
 }
+
+// §18 (cont'd) — specialized-builtin name predicate ported from
+// internal/llvmgen/ir_module.go.
+
+// Osty: mirIsSpecializedBuiltinStructName
+func mirIsSpecializedBuiltinStructName(name string) bool {
+	return llvmStrings.HasPrefix(name, "_ZTS")
+}
+
+// §18 (cont'd) — LLVM aggregate name-part sanitizer ported from
+// internal/llvmgen/type.go.
+
+// Osty: mirLLVMBuiltinAggregatePart
+func mirLLVMBuiltinAggregatePart(part string) string {
+	if part == "" {
+		return "void"
+	}
+	var b llvmStrings.Builder
+	sawValid := false
+	for i := 0; i < len(part); i++ {
+		c := part[i]
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
+			b.WriteByte(c)
+			sawValid = true
+			continue
+		}
+		b.WriteByte('_')
+	}
+	if !sawValid {
+		return "value"
+	}
+	return b.String()
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -32,23 +32,11 @@ func llvmBuiltinAggregateName(prefix string, parts ...string) string {
 	return "%" + strings.Join(names, ".")
 }
 
+// llvmBuiltinAggregatePart folds a type-name fragment into the LLVM
+// identifier alphabet. Delegates to the Osty-sourced
+// `mirLLVMBuiltinAggregatePart` (`toolchain/mir_generator.osty`).
 func llvmBuiltinAggregatePart(part string) string {
-	if part == "" {
-		return "void"
-	}
-	var b strings.Builder
-	for i := 0; i < len(part); i++ {
-		c := part[i]
-		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
-			b.WriteByte(c)
-			continue
-		}
-		b.WriteByte('_')
-	}
-	if b.Len() == 0 {
-		return "value"
-	}
-	return b.String()
+	return mirLLVMBuiltinAggregatePart(part)
 }
 
 func llvmResultTypeName(okTyp, errTyp string) string {

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12958,3 +12958,46 @@ pub fn mirLLVMTripleFor(arch: String, osName: String) -> String {
     if osName == "js" { return "wasm32-unknown-emscripten" }
     mirLinuxArch(arch) + "-unknown-" + osName
 }
+
+/// §18 (cont'd) — specialized-builtin name predicate ported from
+/// `isSpecializedBuiltinStructName` in `internal/llvmgen/ir_module.go`.
+///
+/// Reports whether a struct name is the `_ZTS`-prefixed Itanium
+/// type-info form used for stdlib built-in template specialisations
+/// (Map, List, Set, Option, Result). User struct names keep their
+/// source spelling.
+pub fn mirIsSpecializedBuiltinStructName(name: String) -> Bool {
+    llvmStrings.HasPrefix(name, "_ZTS")
+}
+
+/// §18 (cont'd) — LLVM aggregate name-part sanitizer ported from
+/// `llvmBuiltinAggregatePart` in `internal/llvmgen/type.go`.
+///
+/// Folds a single Osty type-name fragment into the LLVM identifier
+/// alphabet ([A-Za-z0-9_]) for use as a piece of an aggregate
+/// type-name (e.g. `%Range_i64`, `%Result_i64_String`). Non-alnum
+/// characters become `_`; an empty input becomes `void`; an all-
+/// non-alnum input collapses to `value`.
+pub fn mirLLVMBuiltinAggregatePart(part: String) -> String {
+    if part == "" { return "void" }
+    let mut buf = ""
+    let mut sawValid = false
+    let mut i = 0
+    let n = part.len()
+    for i < n {
+        let c = part[i]
+        let isUnderscore = c == "_"
+        let isLower = c >= "a" && c <= "z"
+        let isUpper = c >= "A" && c <= "Z"
+        let isDigit = c >= "0" && c <= "9"
+        if isUnderscore || isLower || isUpper || isDigit {
+            buf = buf + c
+            sawValid = true
+        } else {
+            buf = buf + "_"
+        }
+        i = i + 1
+    }
+    if !sawValid { return "value" }
+    buf
+}


### PR DESCRIPTION
## Phase 2 — sixth function port

Two pure string helpers moved to `toolchain/mir_generator.osty`:

### 1. `isSpecializedBuiltinStructName` → `mirIsSpecializedBuiltinStructName`

Trivial 1-line \`_ZTS\` prefix check. Distinguishes Itanium-mangled stdlib built-in template specialisations from user struct names.

```osty
pub fn mirIsSpecializedBuiltinStructName(name: String) -> Bool {
    llvmStrings.HasPrefix(name, "_ZTS")
}
```

### 2. `llvmBuiltinAggregatePart` → `mirLLVMBuiltinAggregatePart`

Char-level sanitizer that folds an Osty type-name fragment into the LLVM identifier alphabet ([A-Za-z0-9_]). Used to assemble aggregate type names (`%Range_i64`, `%Result_i64_String` etc.). Empty input → `void`; all-non-alnum input → `value`.

```osty
pub fn mirLLVMBuiltinAggregatePart(part: String) -> String {
    if part == "" { return "void" }
    let mut buf = ""
    let mut sawValid = false
    let mut i = 0
    let n = part.len()
    for i < n {
        let c = part[i]
        let isUnderscore = c == "_"
        let isLower = c >= "a" && c <= "z"
        let isUpper = c >= "A" && c <= "Z"
        let isDigit = c >= "0" && c <= "9"
        if isUnderscore || isLower || isUpper || isDigit {
            buf = buf + c
            sawValid = true
        } else {
            buf = buf + "_"
        }
        i = i + 1
    }
    if !sawValid { return "value" }
    buf
}
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (baseline)