### PR TITLE
perf(runtime): make Map young-eligible (safe-clone mutex + young-arena remap)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3583,7 +3583,12 @@ int main(void) {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
 	runCmd := exec.Command(binaryPath)
-	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	/* Opt out of young arena: this test pins Phase D's headerful
+	 * compaction + remap path for Map. With Map young-eligible, the
+	 * Map alloc lands young instead and the headerful forwarded count
+	 * drops by one (Map goes through cheney_forward, not compaction). */
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_THRESHOLD_BYTES=1", "OSTY_GC_TINYTAG_YOUNG=0")
 	runOutput, err := runCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
@@ -3687,7 +3692,10 @@ int main(void) {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
 	runCmd := exec.Command(binaryPath)
-	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	/* Same opt-out as TestBundledRuntimeMapRemapsCompactionPhaseD —
+	 * pin the headerful compaction + remap path. */
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_THRESHOLD_BYTES=1", "OSTY_GC_TINYTAG_YOUNG=0")
 	runOutput, err := runCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
@@ -5693,9 +5701,11 @@ int main(void) {
      * var or doesn't. */
     printf("%lld\n", (long long)osty_gc_debug_tinytag_young_enabled());
 
-    /* Map is reliably headerful (KIND_MAP has destroy → ineligible
-     * for young arena regardless of flag state). The predicate must
-     * classify it as not-young in both default and envOff modes. */
+    /* Map alloc — KIND_MAP is young-eligible when the flag is on
+     * (the safe-clone Map handoff in cheney_forward + promote
+     * destroys/re-inits the embedded mutex), headerful otherwise.
+     * The predicate's young/old classification of the local handle
+     * tracks the flag. */
     void *map = osty_rt_map_new(1, 1, 8, 0);
     osty_gc_root_bind_v1(map);
     printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(map));
@@ -5724,7 +5734,11 @@ int main(void) {
 	}{
 		// Default is on (Phase 8 step 2 cutover). Opt out via
 		// `OSTY_GC_TINYTAG_YOUNG=0`.
-		{name: "default", env: nil, wantFlag: "1", wantYoung: "0"},
+		// Default-on: Map alloc lands young; the local handle stays
+		// pointing at the young address even after root_bind promotes
+		// it (root_bind takes the pointer by value, doesn't rewrite
+		// the caller's slot), so the predicate reports 1.
+		{name: "default", env: nil, wantFlag: "1", wantYoung: "1"},
 		{name: "envOff", env: []string{"OSTY_GC_TINYTAG_YOUNG=0"}, wantFlag: "0", wantYoung: "0"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -5795,16 +5809,18 @@ int64_t osty_gc_debug_young_header_object_kind(void *payload);
 int64_t osty_gc_debug_young_header_byte_size(void *payload);
 int64_t osty_gc_debug_young_header_generation(void *payload);
 
-void *osty_rt_map_new(int64_t k, int64_t v, int64_t vsz, void *vt);
+void *osty_rt_thread_chan_make(int64_t capacity);
 
 #define KIND_LIST 1024
 #define KIND_STRING 1025
 
 int main(void) {
-    /* OLD-arena Map should not be classified as a young-arena page
-     * (KIND_MAP has destroy → ineligible regardless of flag). */
-    void *map = osty_rt_map_new(1, 1, 8, 0);
-    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(map));
+    /* Channel stays headerful (KIND_CHANNEL has a pthread-rich
+     * destroy that the dead-from-space scan doesn't yet cover), so
+     * the predicate must classify it as not-young regardless of
+     * flag state. Picked over Map because Map is now young-eligible. */
+    void *chan = osty_rt_thread_chan_make(1);
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(chan));
 
     /* Direct young alloc (Phase 6 will route real allocators here). */
     void *young = osty_gc_debug_allocate_young(48, KIND_STRING);
@@ -6371,7 +6387,7 @@ int main(void) {
 				"1 1 1",    // GENERIC: eligible under NONE pattern (debug entry assumes NULL trace/destroy)
 				"1024 1 1", // LIST: eligible (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list scan)
 				"1025 1 1", // STRING: eligible
-				"1026 0 0", // MAP: has destroy (frees pthread state + key/value arrays — needs typed sweep)
+				"1026 1 1", // MAP: eligible (cheney_forward + promote re-init mutex; dead-from-space calls map_destroy)
 				"1027 1 1", // SET: eligible (dead-from-space scan frees items buffer; no inline-storage union)
 				"1028 1 1", // BYTES: eligible
 				"1029 1 1", // CLOSURE_ENV: eligible (captures populated synchronously before escape)
@@ -6752,6 +6768,133 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeMapYoungLifecycle covers the MAP young addition:
+// a fresh `osty_rt_map_new` lands in the young arena, insert/get
+// follow the PROMOTED tag via `osty_gc_load_v1` after `root_bind`
+// promotes it, and the items + recursive mutex are reclaimed cleanly
+// when an UNFORWARDED young Map is swept by
+// `osty_gc_cheney_destroy_dead_from_space`.
+//
+// The mutex memcpy concern is covered by the safe-clone path in
+// `osty_gc_promote_young_to_old`: the source mutex is destroyed and
+// the destination's is freshly initialised, so no two live mutex
+// copies share kernel-tracked state.
+func TestBundledRuntimeMapYoungLifecycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_map_young_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_map_young_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, void *value_trace);
+int64_t osty_rt_map_len(void *raw_map);
+void osty_rt_map_insert_i64(void *raw_map, int64_t key, const void *value);
+void osty_rt_map_get_or_abort_i64(void *raw_map, int64_t key, void *out_value);
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+int64_t osty_gc_debug_arena_is_young_page(void *payload);
+int64_t osty_gc_debug_young_forward_tag(void *from_payload);
+int64_t osty_gc_debug_young_cheney_dead_maps_freed_total(void);
+void osty_gc_debug_collect(void);
+
+#define ABI_I64 1
+
+int main(void) {
+    /* Fresh Map goes young: KIND_MAP is now in the eligibility list,
+     * sizeof(osty_rt_map) sits well under the humongous threshold. */
+    void *raw = osty_rt_map_new(ABI_I64, ABI_I64, (int64_t)sizeof(int64_t), 0);
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(raw));
+
+    /* Inserts before root_bind populate the heap-owned keys/values
+     * buffers through the still-young map handle. */
+    int64_t v100 = 100, v200 = 200, v300 = 300;
+    osty_rt_map_insert_i64(raw, 1, &v100);
+    osty_rt_map_insert_i64(raw, 2, &v200);
+
+    /* root_bind promotes the young Map to OLD. The safe-clone path
+     * destroys the source mutex + re-inits the OLD copy's, then
+     * steals keys/values/index pointers so dead-from-space can't
+     * double-free what the OLD copy now owns. */
+    osty_gc_root_bind_v1(raw);
+    printf("%lld\n", (long long)osty_gc_debug_young_forward_tag(raw));
+
+    /* Inserts via the stale young handle work because the typed
+     * insert macros run through osty_rt_map_cast then osty_gc_load_v1,
+     * which follows the PROMOTED tag. */
+    osty_rt_map_insert_i64(raw, 3, &v300);
+    printf("%lld\n", (long long)osty_rt_map_len(raw));
+    int64_t got1 = 0, got2 = 0, got3 = 0;
+    osty_rt_map_get_or_abort_i64(raw, 1, &got1);
+    osty_rt_map_get_or_abort_i64(raw, 2, &got2);
+    osty_rt_map_get_or_abort_i64(raw, 3, &got3);
+    printf("%lld %lld %lld\n", (long long)got1, (long long)got2, (long long)got3);
+
+    /* Forced collect: cheney processes the (PROMOTED) young Map, the
+     * major sweep keeps OLD alive, the keys/values heap buffers
+     * survive because the OLD copy still owns them. */
+    osty_gc_debug_collect();
+    printf("%lld\n", (long long)osty_rt_map_len(raw));
+
+    /* Allocate + drop a fresh young Map to exercise the dead-Map
+     * cleanup path: insert one entry to force reservation, then
+     * never root the Map so the next collect reclaims it as
+     * UNFORWARDED. The cleanup counter increments iff
+     * cheney_destroy_dead_from_space ran the MAP branch (which
+     * delegates to osty_rt_map_destroy — frees keys + values + the
+     * inline-or-heap index buffers + destroys the mutex). */
+    int64_t freed_before = osty_gc_debug_young_cheney_dead_maps_freed_total();
+    void *transient = osty_rt_map_new(ABI_I64, ABI_I64, (int64_t)sizeof(int64_t), 0);
+    int64_t v9900 = 9900;
+    osty_rt_map_insert_i64(transient, 99, &v9900);
+    osty_gc_debug_collect();
+    int64_t freed_after = osty_gc_debug_young_cheney_dead_maps_freed_total();
+    printf("%lld\n", (long long)(freed_after - freed_before));
+
+    /* Release the rooted Map. Subsequent collect sweeps the OLD copy
+     * via the headerful destroy path. */
+    osty_gc_root_release_v1(raw);
+    osty_gc_debug_collect();
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"1",           // fresh Map landed in young arena
+		"2",           // forward tag = PROMOTED after root_bind
+		"3",           // post-promote insert via stale young handle worked (load_v1 follow)
+		"100 200 300", // all three values readable
+		"3",           // values survived forced collect (still rooted)
+		"1",           // dead-Map cleanup fired on the unrooted transient
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("map-young harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestBundledRuntimeGenericEnumPtrYoungTraceFollows covers the
 // KIND_GENERIC_ENUM_PTR young addition: an `osty_rt_enum_alloc_ptr_v1`
 // box lands young, and during cheney_minor the kind_table descriptor
@@ -6956,14 +7099,14 @@ int main(void) {
 		},
 		{
 			// Default routing: STRING + BYTES + LIST + CLOSURE_ENV +
-			// GENERIC NONE → young arena; MAP / CHANNEL stay headerful
+			// GENERIC NONE + MAP → young arena; CHANNEL stays headerful
 			// (GENERIC ENUM_PTR / TASK_HANDLE patterns also stay
-			// headerful, but `osty_gc_alloc_v1(1, …)` constructs the
-			// NONE pattern via NULL trace + NULL destroy).
+			// headerful via `osty_gc_alloc_v1(1, …)`'s NONE pattern
+			// with NULL trace + NULL destroy).
 			name:      "default",
 			env:       nil,
-			wantDelta: "5",
-			wantClass: [6]string{"1", "1", "1", "1", "0", "1"},
+			wantDelta: "6",
+			wantClass: [6]string{"1", "1", "1", "1", "1", "1"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3182,12 +3182,24 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *      before the arena swap reclaims their micro-header bytes.
  *      No self-ref fixup needed — Set has no inline-storage union;
  *      `items` is always a separate heap allocation.
+ *      MAP has a destroy callback (frees keys/values/index buffers
+ *      and the recursive mutex). Its memcpy-on-promote is normally
+ *      UB for the embedded `pthread_mutex_t`, so cheney_forward and
+ *      promote_young_to_old both special-case MAP: they re-init the
+ *      destination's mutex and destroy the source's, mirroring
+ *      `osty_gc_clone_map_header_to_bump_region`. They also fix up
+ *      the inline-index self-refs and null the source's
+ *      keys/values/index pointers so dead-from-space's free path
+ *      can't double-free a forwarded Map's buffers. The
+ *      dead-from-space scan calls `osty_rt_map_destroy` directly on
+ *      UNFORWARDED young Maps.
  *
  *      Why not the other kinds:
- *        - MAP/CHANNEL: destroy frees pthread sync state in addition
- *          to backing arrays — the recursive-mutex teardown +
- *          pthread_cond_destroy surface is larger and these are
- *          typically long-lived, so the perf payoff is smaller.
+ *        - CHANNEL: destroy frees mutex + 2 condvars + slot buffer.
+ *          Same pthread-teardown family as Map but the safe-clone
+ *          surface is larger (cond_destroy doesn't have an
+ *          equivalent re-init helper) and channels are typically
+ *          long-lived, so the perf payoff is smaller.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being
@@ -3215,7 +3227,8 @@ static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size,
                object_kind != OSTY_GC_KIND_LIST &&
                object_kind != OSTY_GC_KIND_CLOSURE_ENV &&
                object_kind != OSTY_GC_KIND_SET &&
-               object_kind != OSTY_GC_KIND_GENERIC_ENUM_PTR) {
+               object_kind != OSTY_GC_KIND_GENERIC_ENUM_PTR &&
+               object_kind != OSTY_GC_KIND_MAP) {
         return false;
     }
     if (payload_size == 0 ||
@@ -3242,6 +3255,12 @@ static void *osty_gc_allocate_young_if_eligible(size_t byte_size,
     }
     return osty_gc_allocate_young(byte_size, object_kind);
 }
+
+/* Forward decls for Map's safe-clone path used by `cheney_forward`,
+ * `promote_young_to_old`, and `cheney_destroy_dead_from_space` —
+ * defined further down with the rest of the Map runtime. */
+static void osty_rt_map_mutex_init_or_abort(osty_rt_map *map);
+static void osty_rt_map_destroy(void *payload);
 
 /* Phase 6 step 1: Cheney semi-space copy mechanic.
  *
@@ -3326,6 +3345,42 @@ static void *osty_gc_cheney_forward(void *from_payload) {
         if (dst_list->data == src_list->inline_storage) {
             dst_list->data = dst_list->inline_storage;
         }
+    } else if (object_kind == OSTY_GC_KIND_MAP) {
+        /* Map carries a `pthread_mutex_t` inline. Bit-copying it via
+         * memcpy is UB (the kernel-tracked state is keyed on the
+         * mutex address; aliased copies would race the destroy
+         * sequence). Re-init the to-space mutex from scratch and
+         * destroy the from-space original — same handoff
+         * `osty_gc_clone_map_header_to_bump_region` uses for
+         * headerful compaction.
+         *
+         * The inline-index self-refs (`index_inline[]` /
+         * `index_hashes_inline[]`) need the same re-anchoring as
+         * List's `inline_storage`: a forwarded inline-mode Map's
+         * `index_slots` would otherwise point at the from-space
+         * inline region (about to be reclaimed by the arena swap).
+         *
+         * Null the from-space's owned-buffer pointers so that any
+         * later traversal of from-space (today only the
+         * dead-from-space scan, which already filters by tag) can
+         * never reach a buffer the to-space copy still owns. */
+        osty_rt_map *src_map = (osty_rt_map *)from_payload;
+        osty_rt_map *dst_map = (osty_rt_map *)to_payload;
+        if (dst_map->index_slots == src_map->index_inline) {
+            dst_map->index_slots = dst_map->index_inline;
+        }
+        if (dst_map->index_hashes == src_map->index_hashes_inline) {
+            dst_map->index_hashes = dst_map->index_hashes_inline;
+        }
+        if (src_map->mu_init) {
+            osty_rt_map_mutex_init_or_abort(dst_map);
+            osty_rt_rmu_destroy(&src_map->mu);
+            src_map->mu_init = 0;
+        }
+        src_map->keys = NULL;
+        src_map->values = NULL;
+        src_map->index_slots = NULL;
+        src_map->index_hashes = NULL;
     }
     src->forward_or_meta = (uint64_t)(uintptr_t)to_payload |
                            OSTY_GC_FORWARD_TAG_FORWARDED;
@@ -3381,6 +3436,7 @@ static void osty_gc_cheney_swap_arenas(void) {
  * arena bytes. */
 static int64_t osty_gc_young_cheney_dead_lists_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_sets_freed_total = 0;
+static int64_t osty_gc_young_cheney_dead_maps_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_buffer_bytes_freed_total = 0;
 
 static size_t osty_gc_micro_object_total_size(int32_t payload_size);
@@ -3418,10 +3474,19 @@ static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
                     free(set->items);
                 }
                 osty_gc_young_cheney_dead_sets_freed_total += 1;
+            } else if (micro->object_kind == OSTY_GC_KIND_MAP) {
+                /* Map's full destroy: keys, values, index buffers
+                 * (if not aliased to inline arrays), and the
+                 * recursive mutex if it was init'd. Reuses the
+                 * headerful destroy fn so the cleanup logic stays
+                 * in one place. */
+                osty_rt_map_destroy(payload);
+                osty_gc_young_cheney_dead_maps_freed_total += 1;
             }
-            /* STRING / BYTES / CLOSURE_ENV / GENERIC NONE carry no
-             * external buffers — payload bytes are reclaimed by the
-             * cursor reset, no destroy needed. */
+            /* STRING / BYTES / CLOSURE_ENV / GENERIC NONE /
+             * GENERIC_ENUM_PTR carry no external buffers — payload
+             * bytes are reclaimed by the cursor reset, no destroy
+             * needed. */
         }
         scan += total;
     }
@@ -3548,6 +3613,30 @@ static void *osty_gc_promote_young_to_old(void *young_payload) {
         if (dst_list->data == src_list->inline_storage) {
             dst_list->data = dst_list->inline_storage;
         }
+    } else if (object_kind == OSTY_GC_KIND_MAP) {
+        /* Same safe-clone Map handoff as cheney_forward (see comment
+         * there for rationale): re-anchor inline-index self-refs,
+         * destroy the from-space mutex + init the OLD copy's, null
+         * the source's owned-buffer pointers so the from-space
+         * payload can be reclaimed without double-freeing what the
+         * OLD copy now owns. */
+        osty_rt_map *src_map = (osty_rt_map *)young_payload;
+        osty_rt_map *dst_map = (osty_rt_map *)new_payload;
+        if (dst_map->index_slots == src_map->index_inline) {
+            dst_map->index_slots = dst_map->index_inline;
+        }
+        if (dst_map->index_hashes == src_map->index_hashes_inline) {
+            dst_map->index_hashes = dst_map->index_hashes_inline;
+        }
+        if (src_map->mu_init) {
+            osty_rt_map_mutex_init_or_abort(dst_map);
+            osty_rt_rmu_destroy(&src_map->mu);
+            src_map->mu_init = 0;
+        }
+        src_map->keys = NULL;
+        src_map->values = NULL;
+        src_map->index_slots = NULL;
+        src_map->index_hashes = NULL;
     }
     micro->forward_or_meta = (uint64_t)(uintptr_t)new_payload |
                              OSTY_GC_FORWARD_TAG_PROMOTED;
@@ -4846,6 +4935,50 @@ static void osty_gc_remap_header_payload(osty_gc_header *header) {
     }
 }
 
+/* Phase E follow-up: live young objects also hold OLD pointers
+ * (e.g. a young Map<String, _> with OLD String values; a young
+ * GENERIC_ENUM_PTR box pointing at an OLD enum payload). The
+ * headerful remap loops in `osty_gc_compact_*_with_stack_roots`
+ * only walk `osty_gc_objects`, so without this pass the young
+ * survivors' buffer entries would still reference pre-compact
+ * addresses. Walk the young from-space (cheney just swapped
+ * survivors here) and dispatch the kind-specific remap helper —
+ * the same helpers `osty_gc_remap_header_payload` calls. */
+static void osty_gc_remap_young_arena_payloads(void) {
+    if (!osty_gc_tinytag_young_now() || osty_gc_young_from.base == NULL) {
+        return;
+    }
+    unsigned char *scan = osty_gc_young_from.base;
+    while (scan < osty_gc_young_from.cursor) {
+        osty_gc_micro_header *micro = (osty_gc_micro_header *)scan;
+        int32_t payload_size = micro->byte_size;
+        void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
+        switch (micro->object_kind) {
+        case OSTY_GC_KIND_LIST:
+            osty_gc_remap_list_payload((osty_rt_list *)payload);
+            break;
+        case OSTY_GC_KIND_MAP:
+            osty_gc_remap_map_payload((osty_rt_map *)payload);
+            break;
+        case OSTY_GC_KIND_SET:
+            osty_gc_remap_set_payload((osty_rt_set *)payload);
+            break;
+        case OSTY_GC_KIND_CLOSURE_ENV:
+            osty_gc_remap_closure_env_payload(
+                (osty_rt_closure_env *)payload);
+            break;
+        case OSTY_GC_KIND_GENERIC_ENUM_PTR:
+            osty_gc_remap_slot(payload);
+            break;
+        default:
+            /* STRING / BYTES / GENERIC NONE carry no managed-pointer
+             * buffers — payload bytes are opaque from the GC's view. */
+            break;
+        }
+        scan += osty_gc_micro_object_total_size(payload_size);
+    }
+}
+
 static osty_gc_header *osty_gc_clone_header_storage_to_bump_region(
     osty_gc_header *header,
     uint8_t storage_kind,
@@ -5166,6 +5299,7 @@ static int64_t osty_gc_compact_major_with_stack_roots(
         osty_gc_remap_header_payload(current);
         header = header->next;
     }
+    osty_gc_remap_young_arena_payloads();
 
     header = osty_gc_objects;
     while (header != NULL) {
@@ -5303,6 +5437,7 @@ static int64_t osty_gc_compact_minor_with_stack_roots(
         osty_gc_remap_header_payload(current);
         header = header->next;
     }
+    osty_gc_remap_young_arena_payloads();
 
     header = osty_gc_objects;
     while (header != NULL) {
@@ -11081,6 +11216,10 @@ int64_t osty_gc_debug_young_cheney_dead_lists_freed_total(void) {
 
 int64_t osty_gc_debug_young_cheney_dead_sets_freed_total(void) {
     return osty_gc_young_cheney_dead_sets_freed_total;
+}
+
+int64_t osty_gc_debug_young_cheney_dead_maps_freed_total(void) {
+    return osty_gc_young_cheney_dead_maps_freed_total;
 }
 
 int64_t osty_gc_debug_young_cheney_dead_buffer_bytes_freed_total(void) {


### PR DESCRIPTION
## Summary

Map joins LIST/SET/CLOSURE_ENV/STRING/BYTES/GENERIC NONE/GENERIC_ENUM_PTR in the no-header young arena. The pthread mutex embedded in `osty_rt_map` is the central blocker — bit-copying a live mutex via memcpy is UB — so `cheney_forward` and `promote_young_to_old` both special-case MAP with a safe-clone handoff: re-init the destination's mutex, destroy the source's, re-anchor inline-index self-refs, and null the source's keys/values/index pointers so the from-space copy can't double-free buffers the destination now owns. The pattern mirrors the existing `osty_gc_clone_map_header_to_bump_region` used by headerful compaction.

The dead-from-space scan delegates to `osty_rt_map_destroy` for UNFORWARDED young Maps — frees keys + values + index buffers (if not aliased to the inline arrays) + destroys the mutex.

## Major remap pass extension

The headerful remap loop in `osty_gc_compact_*_with_stack_roots` only walked `osty_gc_objects`, so a young Map (or List/Set/CLOSURE_ENV/GENERIC_ENUM_PTR) holding OLD references would carry stale pointers after compaction. Added `osty_gc_remap_young_arena_payloads` which walks the young from-space and dispatches the kind-specific remap helper — fixes correctness for the hybrid case (young collection containing OLD elements that compaction relocated).

This was a latent bug that would have bitten LIST/SET too, but the existing test corpus didn't exercise it. Map's compaction tests (which were headerful) caught it on the first run.

## Changes

`internal/backend/runtime/osty_runtime.c`:
- `osty_gc_young_eligible` admits `OSTY_GC_KIND_MAP`.
- `osty_gc_cheney_forward` special-cases MAP for the safe clone.
- `osty_gc_promote_young_to_old` mirrors the same safe clone.
- `osty_gc_cheney_destroy_dead_from_space` adds MAP branch (calls `osty_rt_map_destroy`).
- New `osty_gc_remap_young_arena_payloads` helper, called from both the major and minor compactors after the headerful remap.
- New counter + debug accessor `_dead_maps_freed_total`.
- Forward decls for `osty_rt_map_mutex_init_or_abort` / `osty_rt_map_destroy` near `cheney_forward`.

`internal/backend/llvm_runtime_gc_test.go`:
- `TestBundledRuntimeYoungEligibilityFilter`: MAP row flips `"1026 0 0"` → `"1026 1 1"`.
- `TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn`: default delta becomes 6 (S/B/L/E/G/M), classification slot 4 (m) flips to `"1"`.
- `TestBundledRuntimeMapRemapsCompactionPhaseD` + `TestBundledRuntimeMapCompositeValueRemapsCompactionPhaseD`: opt out of young arena via `OSTY_GC_TINYTAG_YOUNG=0` — these tests pin the headerful Phase-D compaction + remap path, which Map no longer takes by default.
- `TestBundledRuntimeFindHeaderBranchingParity`: default-on expectation flips (Map IS young now); doc comment updated.
- `TestBundledRuntimeYoungArenaAllocAndShimReconstructs`: switch the "non-young example" from Map to Channel (Channel still has pthread teardown → ineligible).
- New `TestBundledRuntimeMapYoungLifecycle`: alloc young Map, insert pre-promote, `root_bind` (verify PROMOTED tag), insert post-promote via stale handle (verify `load_v1` follow), forced collect (verify entries survive), allocate + drop a transient Map (verify dead-Map cleanup counter via the new accessor).

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeMapYoungLifecycle|TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn|TestBundledRuntimeMapRemapsCompactionPhaseD|TestBundledRuntimeMapCompositeValueRemapsCompactionPhaseD|TestBundledRuntimeFindHeaderBranchingParity|TestBundledRuntimeYoungArenaAllocAndShimReconstructs"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime suite passes
- [x] `go test ./internal/backend/ -run "Gc|GC|Cheney|Young|Promote|Closure|Generic|Set|Enum|Map"` — all GC + Map tests pass

## Pending follow-ups (not in this PR)

- Channel + GENERIC TASK_HANDLE: Channel has the same pthread blocker but with two condvars in addition to the mutex. The condvar destroy/init helpers exist (`osty_rt_cond_init` / `osty_rt_cond_destroy`) but Channel is typically long-lived, so the perf payoff is smaller. TASK_HANDLE has the same shape as Channel.
- Per-kind cleanup descriptor refactor (per [osty#971](https://github.com/choiceoh/osty/pull/971)/[osty#974](https://github.com/choiceoh/osty/pull/974)'s simplify findings): the eligibility `!=` chain (now 7 explicit kind names) and the `if/else if` chain in `cheney_destroy_dead_from_space` (3 cases) are at the inflection point where a `young_eligible` bit + `cleanup_young_dead` fn pointer on `osty_gc_kind_descriptor` would scale better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)