### PR TITLE
refactor(llvmgen): port dataLayoutFor to osty (Phase 2 slice 7)

### DIFF
--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7949,3 +7949,34 @@ func mirLLVMBuiltinAggregatePart(part string) string {
 	}
 	return b.String()
 }
+
+// §18 (cont'd) — LLVM datalayout mapping ported from
+// internal/llvmgen/target.go.
+
+// Osty: mirDataLayoutFor
+func mirDataLayoutFor(target string) string {
+	isWindows := llvmStrings.Contains(target, "-windows-msvc") || llvmStrings.Contains(target, "-pc-windows-msvc")
+	if isWindows {
+		if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
+			return "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
+		}
+		return "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+	}
+	isApple := llvmStrings.Contains(target, "-apple-darwin") || llvmStrings.Contains(target, "-apple-macos")
+	if isApple {
+		if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
+			return "e-m:o-i64:64-i128:128-n32:64-S128"
+		}
+		return "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+	}
+	isLinux := llvmStrings.Contains(target, "-linux-gnu") || llvmStrings.Contains(target, "-linux-musl")
+	if isLinux {
+		if llvmStrings.HasPrefix(target, "aarch64") {
+			return "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+		}
+		if llvmStrings.HasPrefix(target, "x86_64") {
+			return "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+		}
+	}
+	return ""
+}

--- a/internal/llvmgen/target.go
+++ b/internal/llvmgen/target.go
@@ -62,35 +62,10 @@ func CanonicalLLVMTarget(target string) string {
 
 // dataLayoutFor returns the LLVM datalayout string matching target.
 // Returns "" when no bundled mapping covers the triple; callers should
-// skip emission in that case rather than guess.
-//
-// Datalayouts are lifted verbatim from clang's
-// `llvm::TargetMachine::createDataLayout` output for the corresponding
-// triple so they round-trip cleanly through `llc`, `opt`, and `clang`.
+// skip emission in that case rather than guess. Delegates to the
+// Osty-sourced `mirDataLayoutFor` (`toolchain/mir_generator.osty`).
 func dataLayoutFor(target string) string {
-	switch {
-	case strings.Contains(target, "-windows-msvc"),
-		strings.Contains(target, "-pc-windows-msvc"):
-		if strings.HasPrefix(target, "aarch64") || strings.HasPrefix(target, "arm64") {
-			return "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
-		}
-		return "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-	case strings.Contains(target, "-apple-darwin"),
-		strings.Contains(target, "-apple-macos"):
-		if strings.HasPrefix(target, "aarch64") || strings.HasPrefix(target, "arm64") {
-			return "e-m:o-i64:64-i128:128-n32:64-S128"
-		}
-		return "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-	case strings.Contains(target, "-linux-gnu"),
-		strings.Contains(target, "-linux-musl"):
-		switch {
-		case strings.HasPrefix(target, "aarch64"):
-			return "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-		case strings.HasPrefix(target, "x86_64"):
-			return "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-		}
-	}
-	return ""
+	return mirDataLayoutFor(target)
 }
 
 // withDataLayout injects a `target datalayout = ...` directive

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -13001,3 +13001,45 @@ pub fn mirLLVMBuiltinAggregatePart(part: String) -> String {
     if !sawValid { return "value" }
     buf
 }
+
+/// §18 (cont'd) — LLVM datalayout mapping ported from
+/// `dataLayoutFor` in `internal/llvmgen/target.go`.
+///
+/// Returns the standard LLVM datalayout string matching `target`, or
+/// `""` when no bundled mapping covers the triple. Datalayouts are
+/// lifted verbatim from clang's `llvm::TargetMachine::createDataLayout`
+/// output so they round-trip cleanly through `llc`, `opt`, and `clang`.
+///
+/// Coverage:
+///   - Windows (MSVC ABI): aarch64/arm64, x86_64
+///   - Apple (darwin / macos): aarch64/arm64, x86_64
+///   - Linux (gnu / musl): aarch64, x86_64
+///
+/// Other triples return `""` — caller should skip datalayout emission
+/// rather than guess.
+pub fn mirDataLayoutFor(target: String) -> String {
+    let isWindows = llvmStrings.Contains(target, "-windows-msvc") || llvmStrings.Contains(target, "-pc-windows-msvc")
+    if isWindows {
+        if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
+            return "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
+        }
+        return "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+    }
+    let isApple = llvmStrings.Contains(target, "-apple-darwin") || llvmStrings.Contains(target, "-apple-macos")
+    if isApple {
+        if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
+            return "e-m:o-i64:64-i128:128-n32:64-S128"
+        }
+        return "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+    }
+    let isLinux = llvmStrings.Contains(target, "-linux-gnu") || llvmStrings.Contains(target, "-linux-musl")
+    if isLinux {
+        if llvmStrings.HasPrefix(target, "aarch64") {
+            return "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+        }
+        if llvmStrings.HasPrefix(target, "x86_64") {
+            return "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+        }
+    }
+    ""
+}


### PR DESCRIPTION
## Phase 2 — seventh function port

Larger pure helper from `internal/llvmgen/target.go` moved to `toolchain/mir_generator.osty`:

### `dataLayoutFor` → `mirDataLayoutFor`

Returns the standard LLVM datalayout string for a given target triple. Datalayouts are lifted verbatim from clang's `llvm::TargetMachine::createDataLayout` output so they round-trip cleanly through llc/opt/clang.

**Coverage:**
- Windows (MSVC ABI): aarch64/arm64, x86_64
- Apple (darwin / macos): aarch64/arm64, x86_64
- Linux (gnu / musl): aarch64, x86_64

Other triples return `""` — caller skips datalayout emission.

```osty
pub fn mirDataLayoutFor(target: String) -> String {
    let isWindows = llvmStrings.Contains(target, "-windows-msvc") || llvmStrings.Contains(target, "-pc-windows-msvc")
    if isWindows {
        if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
            return "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
        }
        return "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
    }
    let isApple = llvmStrings.Contains(target, "-apple-darwin") || llvmStrings.Contains(target, "-apple-macos")
    if isApple {
        if llvmStrings.HasPrefix(target, "aarch64") || llvmStrings.HasPrefix(target, "arm64") {
            return "e-m:o-i64:64-i128:128-n32:64-S128"
        }
        return "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
    }
    let isLinux = llvmStrings.Contains(target, "-linux-gnu") || llvmStrings.Contains(target, "-linux-musl")
    if isLinux {
        if llvmStrings.HasPrefix(target, "aarch64") {
            return "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
        }
        if llvmStrings.HasPrefix(target, "x86_64") {
            return "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
        }
    }
    ""
}
```

### target.go: pure-mapping port now COMPLETE

After PRs #975 + this PR, all the pure (string→string) mapping helpers in `target.go` delegate to osty: `linuxArch`, `darwinArch`, `llvmTripleFor`, `dataLayoutFor`. Only the `runtime.GOOS`/`runtime.GOARCH` host probe in `CanonicalLLVMTarget` / `hostLLVMTriple` stays Go-side per the package doc note about host-boundary I/O.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `gofmt -l` clean
- [x] `just front` — all front-end packages pass
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes
- [x] `go test -count=1 -short ./internal/llvmgen/` — 6 failures, all pre-existing (baseline)