### PR TITLE
refactor(runtime): drive young eligibility from kind-descriptor flag

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -665,15 +665,8 @@ static void osty_rt_task_handle_destroy(void *payload);
 typedef struct osty_gc_kind_descriptor {
     osty_gc_trace_fn trace;
     osty_gc_destroy_fn destroy;
-    /* Whether the no-header young arena can carry this kind. Each
-     * young-eligible row also requires the supporting cheney work
-     * to be in place (self-ref fixup in cheney_forward / promote,
-     * dead-from-space cleanup, young-arena remap dispatch). The
-     * per-PR doc comment on `osty_gc_young_eligible` explains the
-     * specific arrangement for each kind. Replaces the explicit
-     * `kind != X && kind != Y && ...` whitelist that grew with
-     * every PR; new young-eligible kinds set this to true here
-     * instead of editing the predicate. */
+    /* Whether the no-header young arena can carry this kind. Toggle
+     * at the table row, not in `osty_gc_young_eligible`. */
     bool young_eligible;
 } osty_gc_kind_descriptor;
 
@@ -698,12 +691,11 @@ enum {
 };
 
 static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
-    /* GENERIC NONE — opaque payload, cheney handles it as raw bytes. */
+    /* NONE — opaque payload, cheney handles it as raw bytes. */
     [OSTY_GC_GENERIC_NONE] = {NULL, NULL, true},
-    /* ENUM_PTR has its own dedicated kind (KIND_GENERIC_ENUM_PTR) for
-     * the young path, so this row is parity-only — the headerful
-     * fallback dispatch still consults it but young eligibility is
-     * driven by the kind table, not this entry. */
+    /* ENUM_PTR routes through `OSTY_GC_KIND_GENERIC_ENUM_PTR`'s row
+     * in the kind table; this row is only consulted on the headerful
+     * fallback dispatch, so the young flag stays false. */
     [OSTY_GC_GENERIC_ENUM_PTR] = {osty_rt_enum_ptr_payload_trace, NULL, false},
     /* TASK_HANDLE has a pthread-rich destroy — not yet covered by
      * the safe-clone path that Map uses. */
@@ -731,6 +723,12 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
     [OSTY_GC_KIND_SET - OSTY_GC_KIND_LIST] =
         {osty_rt_set_trace, osty_rt_set_destroy, true},
     [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {NULL, NULL, true},
+    /* CLOSURE_ENV's young safety relies on a mutator-side contract:
+     * captures are populated synchronously at construction (single
+     * basic block in LLVM emit) before the env can escape to a slot
+     * that triggers root_bind. promote-on-bind copies a fully
+     * populated env to OLD; nothing in cheney_forward / promote
+     * special-cases this kind. */
     [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] =
         {osty_rt_closure_env_trace, NULL, true},
     /* CHANNEL stays headerful — destroy frees a mutex + 2 condvars

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -665,6 +665,16 @@ static void osty_rt_task_handle_destroy(void *payload);
 typedef struct osty_gc_kind_descriptor {
     osty_gc_trace_fn trace;
     osty_gc_destroy_fn destroy;
+    /* Whether the no-header young arena can carry this kind. Each
+     * young-eligible row also requires the supporting cheney work
+     * to be in place (self-ref fixup in cheney_forward / promote,
+     * dead-from-space cleanup, young-arena remap dispatch). The
+     * per-PR doc comment on `osty_gc_young_eligible` explains the
+     * specific arrangement for each kind. Replaces the explicit
+     * `kind != X && kind != Y && ...` whitelist that grew with
+     * every PR; new young-eligible kinds set this to true here
+     * instead of editing the predicate. */
+    bool young_eligible;
 } osty_gc_kind_descriptor;
 
 /* Phase 4 generic-pattern table (RUNTIME_GC_DELTA Phase E follow-up).
@@ -688,9 +698,16 @@ enum {
 };
 
 static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
-    [OSTY_GC_GENERIC_NONE] = {NULL, NULL},
-    [OSTY_GC_GENERIC_ENUM_PTR] = {osty_rt_enum_ptr_payload_trace, NULL},
-    [OSTY_GC_GENERIC_TASK_HANDLE] = {NULL, osty_rt_task_handle_destroy},
+    /* GENERIC NONE — opaque payload, cheney handles it as raw bytes. */
+    [OSTY_GC_GENERIC_NONE] = {NULL, NULL, true},
+    /* ENUM_PTR has its own dedicated kind (KIND_GENERIC_ENUM_PTR) for
+     * the young path, so this row is parity-only — the headerful
+     * fallback dispatch still consults it but young eligibility is
+     * driven by the kind table, not this entry. */
+    [OSTY_GC_GENERIC_ENUM_PTR] = {osty_rt_enum_ptr_payload_trace, NULL, false},
+    /* TASK_HANDLE has a pthread-rich destroy — not yet covered by
+     * the safe-clone path that Map uses. */
+    [OSTY_GC_GENERIC_TASK_HANDLE] = {NULL, osty_rt_task_handle_destroy, false},
 };
 
 #define OSTY_GC_GENERIC_PATTERN_COUNT \
@@ -707,19 +724,23 @@ static uint8_t osty_gc_pattern_of(osty_gc_trace_fn trace,
  * row here in the same order. */
 static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
     [OSTY_GC_KIND_LIST - OSTY_GC_KIND_LIST] =
-        {osty_rt_list_trace, osty_rt_list_destroy},
-    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {NULL, NULL},
+        {osty_rt_list_trace, osty_rt_list_destroy, true},
+    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {NULL, NULL, true},
     [OSTY_GC_KIND_MAP - OSTY_GC_KIND_LIST] =
-        {osty_rt_map_trace, osty_rt_map_destroy},
+        {osty_rt_map_trace, osty_rt_map_destroy, true},
     [OSTY_GC_KIND_SET - OSTY_GC_KIND_LIST] =
-        {osty_rt_set_trace, osty_rt_set_destroy},
-    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {NULL, NULL},
+        {osty_rt_set_trace, osty_rt_set_destroy, true},
+    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {NULL, NULL, true},
     [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] =
-        {osty_rt_closure_env_trace, NULL},
+        {osty_rt_closure_env_trace, NULL, true},
+    /* CHANNEL stays headerful — destroy frees a mutex + 2 condvars
+     * + slots buffer, and the safe-clone primitives that Map uses
+     * for the cheney/promote path don't yet cover condvar
+     * destroy/init pairs. */
     [OSTY_GC_KIND_CHANNEL - OSTY_GC_KIND_LIST] =
-        {osty_rt_chan_trace, osty_rt_chan_destroy},
+        {osty_rt_chan_trace, osty_rt_chan_destroy, false},
     [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] =
-        {osty_rt_enum_ptr_payload_trace, NULL},
+        {osty_rt_enum_ptr_payload_trace, NULL, true},
 };
 
 _Static_assert(OSTY_GC_KIND_LIST == 1024,
@@ -3151,75 +3172,35 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
     return (void *)((unsigned char *)slot + sizeof(osty_gc_micro_header));
 }
 
-/* Phase 7 step 1: which kinds are safe to live in the young arena
- * without a headerful header.
+/* Whether a (kind, payload_size, trace, destroy) tuple may live in
+ * the no-header young arena.
  *
- * Rules (in order — first failure short-circuits):
- *   1. Feature flag must be on. With the flag off the young arena is
- *      dormant and every alloc takes the headerful path, preserving
- *      pre-Phase-5 behaviour exactly.
- *   2. The kind must be one of the young-safe kinds — STRING, BYTES,
- *      LIST, CLOSURE_ENV, SET, or GENERIC with the NONE pattern
- *      (NULL trace + NULL destroy). STRING/BYTES are immutable byte
- *      payloads. LIST has a destroy callback (frees spilled `data` +
- *      `gc_offsets`), but Phase E follow-up adds a from-space
- *      dead-list scan in cheney_minor that runs the destroy work just
- *      before the arena swap reclaims the bytes — making LIST safe to
- *      route through the no-header path despite the external resource.
- *      The scan also handles the self-referential `data` ptr fixup on
- *      the to-space copy when a forwarded List was inline.
- *      CLOSURE_ENV has no destroy callback (captures live inline in
- *      the flexible array) and trace just walks `captures[]` under
- *      the `pointer_bitmap`. The mutator contract is that captures
- *      are populated synchronously at construction (single basic
- *      block in LLVM emit) before the env escapes to a slot that
- *      could trigger root_bind — so promote-on-bind copies a fully
- *      populated env to OLD and post-promote stale-pointer writes
- *      do not occur in production.
- *      GENERIC NONE pattern (e.g. `osty_rt_enum_alloc_scalar_v1` —
- *      unboxed enum scalar payload) has no trace or destroy, so the
- *      micro-header carries everything cheney needs (opaque copy +
- *      no destroy on dead-from-space).
- *      GENERIC_ENUM_PTR (boxed enum payload — `Option<ptr>` /
- *      `Result<ptr, _>`) has its own dedicated kind so the trace
- *      (`osty_rt_enum_ptr_payload_trace`) is reachable from
- *      `osty_gc_kind_table` at cheney scan time. No destroy. The
- *      remaining GENERIC pattern (TASK_HANDLE) keeps using
- *      OSTY_GC_KIND_GENERIC; same pthread-teardown rationale as
- *      Map/Channel below.
- *      SET has a destroy callback (frees the `items` heap buffer).
- *      It rides the same dead-from-space scan as LIST: the cheney
- *      pass calls `free(set->items)` on UNFORWARDED young Sets
- *      before the arena swap reclaims their micro-header bytes.
- *      No self-ref fixup needed — Set has no inline-storage union;
- *      `items` is always a separate heap allocation.
- *      MAP has a destroy callback (frees keys/values/index buffers
- *      and the recursive mutex). Its memcpy-on-promote is normally
- *      UB for the embedded `pthread_mutex_t`, so cheney_forward and
- *      promote_young_to_old both special-case MAP: they re-init the
- *      destination's mutex and destroy the source's, mirroring
- *      `osty_gc_clone_map_header_to_bump_region`. They also fix up
- *      the inline-index self-refs and null the source's
- *      keys/values/index pointers so dead-from-space's free path
- *      can't double-free a forwarded Map's buffers. The
- *      dead-from-space scan calls `osty_rt_map_destroy` directly on
- *      UNFORWARDED young Maps.
- *
- *      Why not the other kinds:
- *        - CHANNEL: destroy frees mutex + 2 condvars + slot buffer.
- *          Same pthread-teardown family as Map but the safe-clone
- *          surface is larger (cond_destroy doesn't have an
- *          equivalent re-init helper) and channels are typically
- *          long-lived, so the perf payoff is smaller.
+ * Rules (first failure short-circuits):
+ *   1. Feature flag (`OSTY_GC_TINYTAG_YOUNG`) must be on.
+ *   2. Kind eligibility:
+ *        - For non-GENERIC kinds, look up `young_eligible` on the
+ *          kind descriptor (`osty_gc_kind_table`). Each row carries
+ *          its own bit; new young-eligible kinds set this true at
+ *          their table row instead of editing this predicate.
+ *        - For OSTY_GC_KIND_GENERIC, look up the matching pattern
+ *          row in `osty_gc_generic_patterns` via (trace, destroy).
+ *          The NONE pattern (NULL/NULL) is young-eligible; ENUM_PTR
+ *          uses its own dedicated kind (KIND_GENERIC_ENUM_PTR) and
+ *          TASK_HANDLE has a pthread-rich destroy that the young
+ *          arena's safe-clone primitives don't yet cover.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being
  *      bump-allocated.
  *
- * `trace` and `destroy` are passed through so the GENERIC-pattern
- * filter can reject ENUM_PTR (non-NULL trace) and TASK_HANDLE
- * (non-NULL destroy). For non-GENERIC kinds the pair is determined
- * by `osty_gc_kind_table` so the params are ignored. */
+ * `trace` and `destroy` are passed through so the GENERIC arm can
+ * resolve the per-instance pattern. For non-GENERIC kinds the pair
+ * is determined by the kind table and the params are ignored.
+ *
+ * Why each currently-eligible kind is safe — see the kind-table
+ * comment block and the matching cheney_forward / promote /
+ * dead-from-space special cases for the per-kind safe-clone +
+ * cleanup invariants. */
 static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size,
                                    osty_gc_trace_fn trace,
                                    osty_gc_destroy_fn destroy) {
@@ -3227,20 +3208,16 @@ static bool osty_gc_young_eligible(int64_t object_kind, size_t payload_size,
         return false;
     }
     if (object_kind == OSTY_GC_KIND_GENERIC) {
-        /* Only the NONE pattern (no trace, no destroy) is young-safe;
-         * ENUM_PTR / TASK_HANDLE need the per-instance pattern at
-         * cheney time, which the 16-byte micro-header doesn't carry. */
-        if (trace != NULL || destroy != NULL) {
+        uint8_t pattern = osty_gc_pattern_of(trace, destroy);
+        if (!osty_gc_generic_patterns[pattern].young_eligible) {
             return false;
         }
-    } else if (object_kind != OSTY_GC_KIND_STRING &&
-               object_kind != OSTY_GC_KIND_BYTES &&
-               object_kind != OSTY_GC_KIND_LIST &&
-               object_kind != OSTY_GC_KIND_CLOSURE_ENV &&
-               object_kind != OSTY_GC_KIND_SET &&
-               object_kind != OSTY_GC_KIND_GENERIC_ENUM_PTR &&
-               object_kind != OSTY_GC_KIND_MAP) {
-        return false;
+    } else {
+        const osty_gc_kind_descriptor *desc =
+            osty_gc_kind_descriptor_lookup(object_kind);
+        if (desc == NULL || !desc->young_eligible) {
+            return false;
+        }
     }
     if (payload_size == 0 ||
         payload_size > (size_t)OSTY_GC_HUMONGOUS_THRESHOLD_BYTES) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -2963,6 +2963,17 @@ typedef struct osty_gc_micro_header {
 _Static_assert(sizeof(osty_gc_micro_header) == 16,
                "tiny-tag young micro-header must stay at 16 bytes");
 
+/* Map's payload + micro-header must stay below the humongous
+ * threshold so it remains young-arena eligible. The struct is
+ * large (~900 B with the inline-index arrays + the embedded
+ * pthread_mutex_t) and pthread_mutex_t size varies by platform —
+ * a single new field could push it over and silently disable the
+ * young path. This guard fails at compile time before that
+ * happens. */
+_Static_assert(sizeof(osty_rt_map) + sizeof(osty_gc_micro_header) <=
+                   (size_t)OSTY_GC_HUMONGOUS_THRESHOLD_BYTES,
+               "osty_rt_map outgrew the young arena humongous threshold");
+
 enum {
     OSTY_GC_FORWARD_TAG_UNFORWARDED = 0,
     OSTY_GC_FORWARD_TAG_FORWARDED = 1,
@@ -3256,11 +3267,11 @@ static void *osty_gc_allocate_young_if_eligible(size_t byte_size,
     return osty_gc_allocate_young(byte_size, object_kind);
 }
 
-/* Forward decls for Map's safe-clone path used by `cheney_forward`,
- * `promote_young_to_old`, and `cheney_destroy_dead_from_space` —
- * defined further down with the rest of the Map runtime. */
-static void osty_rt_map_mutex_init_or_abort(osty_rt_map *map);
-static void osty_rt_map_destroy(void *payload);
+/* Forward decl for Map's safe-clone helper — used by
+ * `cheney_forward`, `promote_young_to_old`, and
+ * `osty_gc_clone_map_header_to_bump_region`. Defined further down
+ * with the rest of the Map runtime. */
+static void osty_gc_map_safe_handoff(osty_rt_map *src, osty_rt_map *dst);
 
 /* Phase 6 step 1: Cheney semi-space copy mechanic.
  *
@@ -3346,41 +3357,11 @@ static void *osty_gc_cheney_forward(void *from_payload) {
             dst_list->data = dst_list->inline_storage;
         }
     } else if (object_kind == OSTY_GC_KIND_MAP) {
-        /* Map carries a `pthread_mutex_t` inline. Bit-copying it via
-         * memcpy is UB (the kernel-tracked state is keyed on the
-         * mutex address; aliased copies would race the destroy
-         * sequence). Re-init the to-space mutex from scratch and
-         * destroy the from-space original — same handoff
-         * `osty_gc_clone_map_header_to_bump_region` uses for
-         * headerful compaction.
-         *
-         * The inline-index self-refs (`index_inline[]` /
-         * `index_hashes_inline[]`) need the same re-anchoring as
-         * List's `inline_storage`: a forwarded inline-mode Map's
-         * `index_slots` would otherwise point at the from-space
-         * inline region (about to be reclaimed by the arena swap).
-         *
-         * Null the from-space's owned-buffer pointers so that any
-         * later traversal of from-space (today only the
-         * dead-from-space scan, which already filters by tag) can
-         * never reach a buffer the to-space copy still owns. */
-        osty_rt_map *src_map = (osty_rt_map *)from_payload;
-        osty_rt_map *dst_map = (osty_rt_map *)to_payload;
-        if (dst_map->index_slots == src_map->index_inline) {
-            dst_map->index_slots = dst_map->index_inline;
-        }
-        if (dst_map->index_hashes == src_map->index_hashes_inline) {
-            dst_map->index_hashes = dst_map->index_hashes_inline;
-        }
-        if (src_map->mu_init) {
-            osty_rt_map_mutex_init_or_abort(dst_map);
-            osty_rt_rmu_destroy(&src_map->mu);
-            src_map->mu_init = 0;
-        }
-        src_map->keys = NULL;
-        src_map->values = NULL;
-        src_map->index_slots = NULL;
-        src_map->index_hashes = NULL;
+        /* Bit-copying the embedded pthread_mutex_t is UB — see
+         * osty_gc_map_safe_handoff for the destroy/re-init dance
+         * and inline-index self-ref re-anchoring. */
+        osty_gc_map_safe_handoff((osty_rt_map *)from_payload,
+                                 (osty_rt_map *)to_payload);
     }
     src->forward_or_meta = (uint64_t)(uintptr_t)to_payload |
                            OSTY_GC_FORWARD_TAG_FORWARDED;
@@ -3614,29 +3595,9 @@ static void *osty_gc_promote_young_to_old(void *young_payload) {
             dst_list->data = dst_list->inline_storage;
         }
     } else if (object_kind == OSTY_GC_KIND_MAP) {
-        /* Same safe-clone Map handoff as cheney_forward (see comment
-         * there for rationale): re-anchor inline-index self-refs,
-         * destroy the from-space mutex + init the OLD copy's, null
-         * the source's owned-buffer pointers so the from-space
-         * payload can be reclaimed without double-freeing what the
-         * OLD copy now owns. */
-        osty_rt_map *src_map = (osty_rt_map *)young_payload;
-        osty_rt_map *dst_map = (osty_rt_map *)new_payload;
-        if (dst_map->index_slots == src_map->index_inline) {
-            dst_map->index_slots = dst_map->index_inline;
-        }
-        if (dst_map->index_hashes == src_map->index_hashes_inline) {
-            dst_map->index_hashes = dst_map->index_hashes_inline;
-        }
-        if (src_map->mu_init) {
-            osty_rt_map_mutex_init_or_abort(dst_map);
-            osty_rt_rmu_destroy(&src_map->mu);
-            src_map->mu_init = 0;
-        }
-        src_map->keys = NULL;
-        src_map->values = NULL;
-        src_map->index_slots = NULL;
-        src_map->index_hashes = NULL;
+        /* Same handoff as cheney_forward — see osty_gc_map_safe_handoff. */
+        osty_gc_map_safe_handoff((osty_rt_map *)young_payload,
+                                 (osty_rt_map *)new_payload);
     }
     micro->forward_or_meta = (uint64_t)(uintptr_t)new_payload |
                              OSTY_GC_FORWARD_TAG_PROMOTED;
@@ -4327,6 +4288,42 @@ static void osty_rt_map_mutex_init_or_abort(osty_rt_map *map) {
         osty_rt_abort("map lock: mutex_init failed");
     }
     map->mu_init = 1;
+}
+
+/* Move Map ownership from `src` to `dst` after a bit-copy of the
+ * payload bytes. Used by cheney_forward (young → young) and
+ * promote_young_to_old (young → OLD). Constraints handled here:
+ *   - The embedded pthread_mutex_t can't be byte-copied (the kernel
+ *     state is keyed on the mutex address). Init a fresh mutex on
+ *     `dst` and destroy `src`'s.
+ *   - `index_slots` / `index_hashes` may alias the inline arrays
+ *     (`index_inline[]` / `index_hashes_inline[]`). After memcpy,
+ *     `dst`'s aliased pointers still point at `src`'s inline region;
+ *     re-anchor to `dst`'s own.
+ *   - Null `src`'s owned-buffer pointers so the from-space copy
+ *     can't be reached by any later traversal that would double-free
+ *     buffers `dst` now owns.
+ *
+ * The headerful compactor's `osty_gc_clone_map_header_to_bump_region`
+ * does field-by-field copy (not memcpy) and relies on `src`'s
+ * destroy freeing its non-stolen index buffers — so it can't share
+ * this helper without changing those semantics. */
+static void osty_gc_map_safe_handoff(osty_rt_map *src, osty_rt_map *dst) {
+    if (dst->index_slots == src->index_inline) {
+        dst->index_slots = dst->index_inline;
+    }
+    if (dst->index_hashes == src->index_hashes_inline) {
+        dst->index_hashes = dst->index_hashes_inline;
+    }
+    if (src->mu_init) {
+        osty_rt_map_mutex_init_or_abort(dst);
+        osty_rt_rmu_destroy(&src->mu);
+        src->mu_init = 0;
+    }
+    src->keys = NULL;
+    src->values = NULL;
+    src->index_slots = NULL;
+    src->index_hashes = NULL;
 }
 
 /* OSTY_HOT_INLINE: called from every Map probe iteration after the


### PR DESCRIPTION
## Summary

Three prior simplify reviews (in [osty#971](https://github.com/choiceoh/osty/pull/971), [osty#974](https://github.com/choiceoh/osty/pull/974), [osty#977](https://github.com/choiceoh/osty/pull/977)) flagged the `else if` chain in `osty_gc_young_eligible` as accumulating one entry per young-PR (STRING/BYTES/LIST/CLOSURE_ENV/SET/GENERIC_ENUM_PTR/MAP — now 7 explicit names). Each row in the existing `osty_gc_kind_table` descriptor was the natural place for the bit; this PR adds it.

## Changes

- Add `bool young_eligible` to `osty_gc_kind_descriptor`.
- Populate per row in `osty_gc_kind_table` (LIST/STRING/MAP/SET/BYTES/CLOSURE_ENV/GENERIC_ENUM_PTR `true`; CHANNEL `false`) and in `osty_gc_generic_patterns` (NONE `true`; ENUM_PTR `false` since it has its own dedicated kind for the young path; TASK_HANDLE `false` because pthread teardown isn't covered).
- `osty_gc_young_eligible` collapses the `!= ... && != ...` chain to a single descriptor lookup (`desc->young_eligible`) for non-GENERIC kinds and a `pattern_of(trace, destroy)` lookup through `osty_gc_generic_patterns` for GENERIC. Doc comment trims from ~70 lines of per-kind prose to a 15-line decision tree pointing at the kind table for the per-kind rationale.

Adding the next young-eligible kind is now a one-line change at the kind-table row instead of editing the predicate.

**No behavior change** — every existing eligibility verdict matches the previous chain (regression-tested via the full bundled-runtime suite + the per-kind eligibility filter test).

## Folded in

PR [osty#977](https://github.com/choiceoh/osty/pull/977)'s simplify cleanup commit (`2a97efce`) didn't make it into the squash merge — pushed after auto-merge fired. Cherry-picked here:
- Drop redundant `osty_rt_map_destroy` forward decl.
- `_Static_assert` for `sizeof(osty_rt_map) + sizeof(osty_gc_micro_header) <= OSTY_GC_HUMONGOUS_THRESHOLD_BYTES`.
- Extract `osty_gc_map_safe_handoff` helper covering the Map mutex + inline-index re-anchor + null-source-pointers dance shared by `cheney_forward` and `promote_young_to_old`.

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn|TestBundledRuntimeMapYoungLifecycle|TestBundledRuntimeSetYoungLifecycle|TestBundledRuntimeGenericNoneYoungRoundTrip|TestBundledRuntimeGenericEnumPtrYoungTraceFollows|TestBundledRuntimeClosureEnv"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime sweep passes (~50s)

## Pending follow-ups (not in this PR)

- Same descriptor pattern for `cleanup_young_dead` (replaces the `if/else if` chain in `osty_gc_cheney_destroy_dead_from_space` — currently 3 cases inline) and `remap_young` (replaces the switch in `osty_gc_remap_young_arena_payloads` — currently 5 cases). Both have the same shape as `young_eligible` but with extra wrinkles (per-kind byte counters for cleanup, GENERIC_ENUM_PTR's `osty_gc_remap_slot` direct call). Worth doing once Channel + GENERIC TASK_HANDLE land so all kinds get the same treatment.
- Channel + GENERIC TASK_HANDLE young eligibility — pthread condvar teardown is the remaining blocker; condvar destroy/init helpers exist (`osty_rt_cond_init` / `osty_rt_cond_destroy`) but Channel/TASK_HANDLE are typically long-lived so the perf payoff is smaller than Map's was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)