### PR TITLE
fix(toolchain): resolve 9 type-check errors in osty check toolchain

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36916,6 +36916,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "Char", receiverTy: tChar(tys), retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17165:5
 	checkRegisterFn(env, &CheckFnSig{name: "toByte", owner: "Char", receiverTy: tChar(tys), retTy: tByte(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "toString", owner: "Char", receiverTy: tChar(tys), retTy: tString_, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17170:5
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "Byte", receiverTy: tByte(tys), retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17175:5

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -2963,6 +2963,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         generics: [], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
+        name: "toString", owner: "Char", receiverTy: tChar(tys), hasReceiver: true, retTy: tString_,
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
         name: "toInt", owner: "Byte", receiverTy: tByte(tys), hasReceiver: true, retTy: tInt(tys),
         paramNames: [], paramTys: [],
         generics: [], genericBounds: [],

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -12487,7 +12487,7 @@ pub fn mirCallSetLengthLine(reg: String, setReg: String) -> String {
 
 /// mirCallStringLengthLine renders the canonical string-length call.
 pub fn mirCallStringLengthLine(reg: String, strReg: String) -> String {
-    mirCallI64FromPtrLine(reg, mirRtStringLenSymbol(), strReg)
+    mirCallValueI64FromPtrLine(reg, mirRtStringLenSymbol(), strReg)
 }
 
 /// mirCallBytesLengthLine renders the canonical bytes-length call.
@@ -12986,12 +12986,12 @@ pub fn mirLLVMBuiltinAggregatePart(part: String) -> String {
     let n = part.len()
     for i < n {
         let c = part[i]
-        let isUnderscore = c == "_"
-        let isLower = c >= "a" && c <= "z"
-        let isUpper = c >= "A" && c <= "Z"
-        let isDigit = c >= "0" && c <= "9"
+        let isUnderscore = c == '_'
+        let isLower = c >= 'a' && c <= 'z'
+        let isUpper = c >= 'A' && c <= 'Z'
+        let isDigit = c >= '0' && c <= '9'
         if isUnderscore || isLower || isUpper || isDigit {
-            buf = buf + c
+            buf = buf + c.toString()
             sawValid = true
         } else {
             buf = buf + "_"


### PR DESCRIPTION
## Summary
- Replace non-existent `mirCallI64FromPtrLine` with existing `mirCallValueI64FromPtrLine` (same semantics, correct name)
- Fix Char vs String literal mismatches in `mirLLVMBuiltinAggregatePart` — `"a"` → `'a'`, `"_"` → `'_'`, etc.
- Fix `String + Char` concatenation by calling `c.toString()` (Char → String conversion)
- Register `Char.toString()` intrinsic method in both `check_env.osty` and `generated.go`

## Test plan
- [x] `go build ./...` passes
- [x] `osty check toolchain` exits 0 (was 9 errors)