### PR TITLE
refactor(runtime): drive young dead-cleanup + remap from kind descriptor

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -676,11 +676,12 @@ static void osty_rt_task_handle_destroy(void *payload);
 static void osty_gc_cleanup_young_dead_list(void *payload);
 static void osty_gc_cleanup_young_dead_set(void *payload);
 static void osty_gc_cleanup_young_dead_map(void *payload);
-static void osty_gc_remap_young_list(void *payload);
-static void osty_gc_remap_young_map(void *payload);
-static void osty_gc_remap_young_set(void *payload);
-static void osty_gc_remap_young_closure_env(void *payload);
-static void osty_gc_remap_young_generic_enum_ptr(void *payload);
+static void osty_gc_remap_list_payload(void *payload);
+static void osty_gc_remap_map_payload(void *payload);
+static void osty_gc_remap_set_payload(void *payload);
+static void osty_gc_remap_closure_env_payload(void *payload);
+static void osty_gc_remap_chan_payload(void *payload);
+static void osty_gc_remap_slot(void *slot_addr);
 
 typedef struct osty_gc_kind_descriptor {
     osty_gc_trace_fn trace;
@@ -689,16 +690,14 @@ typedef struct osty_gc_kind_descriptor {
      * at the table row, not in `osty_gc_young_eligible`. */
     bool young_eligible;
     /* Per-kind cleanup for UNFORWARDED young objects swept by
-     * `cheney_destroy_dead_from_space`. Null for kinds with no
-     * external resources (STRING/BYTES/CLOSURE_ENV/GENERIC NONE/
-     * GENERIC_ENUM_PTR — payload bytes are reclaimed by the cursor
-     * reset). */
+     * `cheney_destroy_dead_from_space`. NULL when the payload has
+     * no external buffers. */
     osty_gc_destroy_fn cleanup_young_dead;
-    /* Per-kind pointer-rewrite for the young-arena pass that runs
-     * after major compaction (`osty_gc_remap_young_arena_payloads`).
-     * Null for kinds whose payload carries no managed pointers
-     * (STRING/BYTES/GENERIC NONE). */
-    osty_gc_destroy_fn remap_young;
+    /* Per-kind pointer-rewrite invoked by both
+     * `osty_gc_remap_header_payload` (OLD compaction) and
+     * `osty_gc_remap_young_arena_payloads` (young arena). NULL
+     * when the payload carries no managed pointers. */
+    osty_gc_destroy_fn remap;
 } osty_gc_kind_descriptor;
 
 /* Phase 4 generic-pattern table (RUNTIME_GC_DELTA Phase E follow-up).
@@ -723,17 +722,18 @@ enum {
 
 static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
     /* NONE — opaque payload, cheney handles it as raw bytes. */
-    [OSTY_GC_GENERIC_NONE] =
-        {NULL, NULL, true, NULL, NULL},
+    [OSTY_GC_GENERIC_NONE] = {.young_eligible = true},
     /* ENUM_PTR routes through `OSTY_GC_KIND_GENERIC_ENUM_PTR`'s row
      * in the kind table; this row is only consulted on the headerful
      * fallback dispatch, so the young flag stays false. */
-    [OSTY_GC_GENERIC_ENUM_PTR] =
-        {osty_rt_enum_ptr_payload_trace, NULL, false, NULL, NULL},
+    [OSTY_GC_GENERIC_ENUM_PTR] = {
+        .trace = osty_rt_enum_ptr_payload_trace,
+    },
     /* TASK_HANDLE has a pthread-rich destroy — not yet covered by
      * the safe-clone path that Map uses. */
-    [OSTY_GC_GENERIC_TASK_HANDLE] =
-        {NULL, osty_rt_task_handle_destroy, false, NULL, NULL},
+    [OSTY_GC_GENERIC_TASK_HANDLE] = {
+        .destroy = osty_rt_task_handle_destroy,
+    },
 };
 
 #define OSTY_GC_GENERIC_PATTERN_COUNT \
@@ -750,23 +750,28 @@ static uint8_t osty_gc_pattern_of(osty_gc_trace_fn trace,
  * row here in the same order. */
 static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
     [OSTY_GC_KIND_LIST - OSTY_GC_KIND_LIST] = {
-        osty_rt_list_trace, osty_rt_list_destroy, true,
-        osty_gc_cleanup_young_dead_list, osty_gc_remap_young_list,
+        .trace = osty_rt_list_trace,
+        .destroy = osty_rt_list_destroy,
+        .young_eligible = true,
+        .cleanup_young_dead = osty_gc_cleanup_young_dead_list,
+        .remap = osty_gc_remap_list_payload,
     },
-    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {
-        NULL, NULL, true, NULL, NULL,
-    },
+    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {.young_eligible = true},
     [OSTY_GC_KIND_MAP - OSTY_GC_KIND_LIST] = {
-        osty_rt_map_trace, osty_rt_map_destroy, true,
-        osty_gc_cleanup_young_dead_map, osty_gc_remap_young_map,
+        .trace = osty_rt_map_trace,
+        .destroy = osty_rt_map_destroy,
+        .young_eligible = true,
+        .cleanup_young_dead = osty_gc_cleanup_young_dead_map,
+        .remap = osty_gc_remap_map_payload,
     },
     [OSTY_GC_KIND_SET - OSTY_GC_KIND_LIST] = {
-        osty_rt_set_trace, osty_rt_set_destroy, true,
-        osty_gc_cleanup_young_dead_set, osty_gc_remap_young_set,
+        .trace = osty_rt_set_trace,
+        .destroy = osty_rt_set_destroy,
+        .young_eligible = true,
+        .cleanup_young_dead = osty_gc_cleanup_young_dead_set,
+        .remap = osty_gc_remap_set_payload,
     },
-    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {
-        NULL, NULL, true, NULL, NULL,
-    },
+    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {.young_eligible = true},
     /* CLOSURE_ENV's young safety relies on a mutator-side contract:
      * captures are populated synchronously at construction (single
      * basic block in LLVM emit) before the env can escape to a slot
@@ -774,19 +779,23 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
      * populated env to OLD; nothing in cheney_forward / promote
      * special-cases this kind. */
     [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] = {
-        osty_rt_closure_env_trace, NULL, true,
-        NULL, osty_gc_remap_young_closure_env,
+        .trace = osty_rt_closure_env_trace,
+        .young_eligible = true,
+        .remap = osty_gc_remap_closure_env_payload,
     },
     /* CHANNEL stays headerful — destroy frees a mutex + 2 condvars
      * + slots buffer, and the safe-clone primitives that Map uses
      * for the cheney/promote path don't yet cover condvar
      * destroy/init pairs. */
     [OSTY_GC_KIND_CHANNEL - OSTY_GC_KIND_LIST] = {
-        osty_rt_chan_trace, osty_rt_chan_destroy, false, NULL, NULL,
+        .trace = osty_rt_chan_trace,
+        .destroy = osty_rt_chan_destroy,
+        .remap = osty_gc_remap_chan_payload,
     },
     [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] = {
-        osty_rt_enum_ptr_payload_trace, NULL, true,
-        NULL, osty_gc_remap_young_generic_enum_ptr,
+        .trace = osty_rt_enum_ptr_payload_trace,
+        .young_eligible = true,
+        .remap = osty_gc_remap_slot,
     },
 };
 
@@ -3456,10 +3465,11 @@ static int64_t osty_gc_young_cheney_dead_buffer_bytes_freed_total = 0;
 static size_t osty_gc_micro_object_total_size(int32_t payload_size);
 static size_t osty_rt_kind_size(int64_t kind);
 
-/* Per-kind cleanup helpers wired into `osty_gc_kind_descriptor::
- * cleanup_young_dead`. Each one frees the dead young payload's
- * external buffers and bumps the per-kind freed-count + global
- * buffer-bytes-freed counters. */
+/* Per-kind cleanup helpers: free dead-young external buffers and
+ * accumulate the per-kind freed-count + global buffer-bytes-freed
+ * counters. LIST/SET inline the accounting their destroy fns
+ * don't track; MAP delegates to `osty_rt_map_destroy` since the
+ * Map destroy already covers every external buffer + the mutex. */
 static void osty_gc_cleanup_young_dead_list(void *payload) {
     osty_rt_list *list = (osty_rt_list *)payload;
     if (list->gc_offsets != NULL) {
@@ -3485,10 +3495,6 @@ static void osty_gc_cleanup_young_dead_set(void *payload) {
 }
 
 static void osty_gc_cleanup_young_dead_map(void *payload) {
-    /* Map's full destroy: keys, values, index buffers (if not
-     * aliased to inline arrays), and the recursive mutex if it
-     * was init'd. Reuses the headerful destroy fn so the cleanup
-     * logic stays in one place. */
     osty_rt_map_destroy(payload);
     osty_gc_young_cheney_dead_maps_freed_total += 1;
 }
@@ -4839,7 +4845,8 @@ static void osty_gc_remap_slot(void *slot_addr) {
     }
 }
 
-static void osty_gc_remap_list_payload(osty_rt_list *list) {
+static void osty_gc_remap_list_payload(void *payload) {
+    osty_rt_list *list = (osty_rt_list *)payload;
     int64_t i;
     int64_t j;
 
@@ -4871,7 +4878,8 @@ static void osty_gc_remap_list_payload(osty_rt_list *list) {
     }
 }
 
-static void osty_gc_remap_map_payload(osty_rt_map *map) {
+static void osty_gc_remap_map_payload(void *payload) {
+    osty_rt_map *map = (osty_rt_map *)payload;
     int64_t i;
 
     if (map == NULL) {
@@ -4897,7 +4905,8 @@ static void osty_gc_remap_map_payload(osty_rt_map *map) {
     }
 }
 
-static void osty_gc_remap_set_payload(osty_rt_set *set) {
+static void osty_gc_remap_set_payload(void *payload) {
+    osty_rt_set *set = (osty_rt_set *)payload;
     int64_t i;
     size_t elem_size;
 
@@ -4914,7 +4923,8 @@ static void osty_gc_remap_set_payload(osty_rt_set *set) {
     }
 }
 
-static void osty_gc_remap_closure_env_payload(osty_rt_closure_env *env) {
+static void osty_gc_remap_closure_env_payload(void *payload) {
+    osty_rt_closure_env *env = (osty_rt_closure_env *)payload;
     int64_t i;
 
     if (env == NULL) {
@@ -4925,7 +4935,8 @@ static void osty_gc_remap_closure_env_payload(osty_rt_closure_env *env) {
     }
 }
 
-static void osty_gc_remap_chan_payload(osty_rt_chan_impl *ch) {
+static void osty_gc_remap_chan_payload(void *payload) {
+    osty_rt_chan_impl *ch = (osty_rt_chan_impl *)payload;
     int64_t i;
 
     if (ch == NULL || ch->slots == NULL ||
@@ -4946,30 +4957,16 @@ static void osty_gc_remap_header_payload(osty_gc_header *header) {
     if (header == NULL) {
         return;
     }
-    switch (header->object_kind) {
-    case OSTY_GC_KIND_LIST:
-        osty_gc_remap_list_payload((osty_rt_list *)header->payload);
+    const osty_gc_kind_descriptor *desc =
+        osty_gc_kind_descriptor_lookup(header->object_kind);
+    if (desc != NULL && desc->remap != NULL) {
+        desc->remap(header->payload);
         return;
-    case OSTY_GC_KIND_MAP:
-        osty_gc_remap_map_payload((osty_rt_map *)header->payload);
-        return;
-    case OSTY_GC_KIND_SET:
-        osty_gc_remap_set_payload((osty_rt_set *)header->payload);
-        return;
-    case OSTY_GC_KIND_CLOSURE_ENV:
-        osty_gc_remap_closure_env_payload(
-            (osty_rt_closure_env *)header->payload);
-        return;
-    case OSTY_GC_KIND_CHANNEL:
-        osty_gc_remap_chan_payload((osty_rt_chan_impl *)header->payload);
-        return;
-    default:
-        break;
     }
-    /* GENERIC fallback path — same shape as Phase 2's dispatch:
-     * resolve the trace fn from the generic_patterns table for kinds
-     * not handled by the switch above. The `byte_size == sizeof(ptr)`
-     * filter still pins this to the enum-ptr-payload case. */
+    /* GENERIC fallback path — kinds not represented in the kind
+     * table fall back to the per-instance pattern table. The
+     * `byte_size == sizeof(ptr)` filter pins this to the
+     * enum-ptr-payload case. */
     if (osty_gc_generic_patterns[header->generic_pattern].trace != NULL &&
         header->byte_size == (int64_t)sizeof(void *)) {
         osty_gc_remap_slot(header->payload);
@@ -4985,31 +4982,6 @@ static void osty_gc_remap_header_payload(osty_gc_header *header) {
  * addresses. Walk the young from-space (cheney just swapped
  * survivors here) and dispatch the kind-specific remap helper —
  * the same helpers `osty_gc_remap_header_payload` calls. */
-/* Per-kind young-arena remap helpers wired into
- * `osty_gc_kind_descriptor::remap_young`. Each casts the void*
- * payload and forwards to the existing kind-specific remap fn
- * (the same fn `osty_gc_remap_header_payload` uses for the OLD
- * dispatch, so headerful and young remap stay in sync). */
-static void osty_gc_remap_young_list(void *payload) {
-    osty_gc_remap_list_payload((osty_rt_list *)payload);
-}
-
-static void osty_gc_remap_young_map(void *payload) {
-    osty_gc_remap_map_payload((osty_rt_map *)payload);
-}
-
-static void osty_gc_remap_young_set(void *payload) {
-    osty_gc_remap_set_payload((osty_rt_set *)payload);
-}
-
-static void osty_gc_remap_young_closure_env(void *payload) {
-    osty_gc_remap_closure_env_payload((osty_rt_closure_env *)payload);
-}
-
-static void osty_gc_remap_young_generic_enum_ptr(void *payload) {
-    osty_gc_remap_slot(payload);
-}
-
 static void osty_gc_remap_young_arena_payloads(void) {
     if (!osty_gc_tinytag_young_now() || osty_gc_young_from.base == NULL) {
         return;
@@ -5020,11 +4992,11 @@ static void osty_gc_remap_young_arena_payloads(void) {
         int32_t payload_size = micro->byte_size;
         const osty_gc_kind_descriptor *desc =
             osty_gc_kind_descriptor_lookup((int64_t)micro->object_kind);
-        if (desc != NULL && desc->remap_young != NULL) {
+        if (desc != NULL && desc->remap != NULL) {
             void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
-            desc->remap_young(payload);
+            desc->remap(payload);
         }
-        /* Kinds with no remap_young (STRING / BYTES / GENERIC NONE)
+        /* Kinds with no remap fn (STRING / BYTES / GENERIC NONE)
          * carry no managed-pointer buffers — payload bytes are
          * opaque from the GC's view. */
         scan += osty_gc_micro_object_total_size(payload_size);

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -671,6 +671,16 @@ static void osty_rt_chan_trace(void *payload);
 static void osty_rt_chan_destroy(void *payload);
 static void osty_rt_enum_ptr_payload_trace(void *payload);
 static void osty_rt_task_handle_destroy(void *payload);
+/* Per-kind dispatch helpers wired into the descriptor — defined
+ * with the rest of the cheney young-arena machinery further down. */
+static void osty_gc_cleanup_young_dead_list(void *payload);
+static void osty_gc_cleanup_young_dead_set(void *payload);
+static void osty_gc_cleanup_young_dead_map(void *payload);
+static void osty_gc_remap_young_list(void *payload);
+static void osty_gc_remap_young_map(void *payload);
+static void osty_gc_remap_young_set(void *payload);
+static void osty_gc_remap_young_closure_env(void *payload);
+static void osty_gc_remap_young_generic_enum_ptr(void *payload);
 
 typedef struct osty_gc_kind_descriptor {
     osty_gc_trace_fn trace;
@@ -678,6 +688,17 @@ typedef struct osty_gc_kind_descriptor {
     /* Whether the no-header young arena can carry this kind. Toggle
      * at the table row, not in `osty_gc_young_eligible`. */
     bool young_eligible;
+    /* Per-kind cleanup for UNFORWARDED young objects swept by
+     * `cheney_destroy_dead_from_space`. Null for kinds with no
+     * external resources (STRING/BYTES/CLOSURE_ENV/GENERIC NONE/
+     * GENERIC_ENUM_PTR — payload bytes are reclaimed by the cursor
+     * reset). */
+    osty_gc_destroy_fn cleanup_young_dead;
+    /* Per-kind pointer-rewrite for the young-arena pass that runs
+     * after major compaction (`osty_gc_remap_young_arena_payloads`).
+     * Null for kinds whose payload carries no managed pointers
+     * (STRING/BYTES/GENERIC NONE). */
+    osty_gc_destroy_fn remap_young;
 } osty_gc_kind_descriptor;
 
 /* Phase 4 generic-pattern table (RUNTIME_GC_DELTA Phase E follow-up).
@@ -702,14 +723,17 @@ enum {
 
 static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
     /* NONE — opaque payload, cheney handles it as raw bytes. */
-    [OSTY_GC_GENERIC_NONE] = {NULL, NULL, true},
+    [OSTY_GC_GENERIC_NONE] =
+        {NULL, NULL, true, NULL, NULL},
     /* ENUM_PTR routes through `OSTY_GC_KIND_GENERIC_ENUM_PTR`'s row
      * in the kind table; this row is only consulted on the headerful
      * fallback dispatch, so the young flag stays false. */
-    [OSTY_GC_GENERIC_ENUM_PTR] = {osty_rt_enum_ptr_payload_trace, NULL, false},
+    [OSTY_GC_GENERIC_ENUM_PTR] =
+        {osty_rt_enum_ptr_payload_trace, NULL, false, NULL, NULL},
     /* TASK_HANDLE has a pthread-rich destroy — not yet covered by
      * the safe-clone path that Map uses. */
-    [OSTY_GC_GENERIC_TASK_HANDLE] = {NULL, osty_rt_task_handle_destroy, false},
+    [OSTY_GC_GENERIC_TASK_HANDLE] =
+        {NULL, osty_rt_task_handle_destroy, false, NULL, NULL},
 };
 
 #define OSTY_GC_GENERIC_PATTERN_COUNT \
@@ -725,30 +749,45 @@ static uint8_t osty_gc_pattern_of(osty_gc_trace_fn trace,
  * the layout: any new kind must extend the contiguous range and append a
  * row here in the same order. */
 static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
-    [OSTY_GC_KIND_LIST - OSTY_GC_KIND_LIST] =
-        {osty_rt_list_trace, osty_rt_list_destroy, true},
-    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {NULL, NULL, true},
-    [OSTY_GC_KIND_MAP - OSTY_GC_KIND_LIST] =
-        {osty_rt_map_trace, osty_rt_map_destroy, true},
-    [OSTY_GC_KIND_SET - OSTY_GC_KIND_LIST] =
-        {osty_rt_set_trace, osty_rt_set_destroy, true},
-    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {NULL, NULL, true},
+    [OSTY_GC_KIND_LIST - OSTY_GC_KIND_LIST] = {
+        osty_rt_list_trace, osty_rt_list_destroy, true,
+        osty_gc_cleanup_young_dead_list, osty_gc_remap_young_list,
+    },
+    [OSTY_GC_KIND_STRING - OSTY_GC_KIND_LIST] = {
+        NULL, NULL, true, NULL, NULL,
+    },
+    [OSTY_GC_KIND_MAP - OSTY_GC_KIND_LIST] = {
+        osty_rt_map_trace, osty_rt_map_destroy, true,
+        osty_gc_cleanup_young_dead_map, osty_gc_remap_young_map,
+    },
+    [OSTY_GC_KIND_SET - OSTY_GC_KIND_LIST] = {
+        osty_rt_set_trace, osty_rt_set_destroy, true,
+        osty_gc_cleanup_young_dead_set, osty_gc_remap_young_set,
+    },
+    [OSTY_GC_KIND_BYTES - OSTY_GC_KIND_LIST] = {
+        NULL, NULL, true, NULL, NULL,
+    },
     /* CLOSURE_ENV's young safety relies on a mutator-side contract:
      * captures are populated synchronously at construction (single
      * basic block in LLVM emit) before the env can escape to a slot
      * that triggers root_bind. promote-on-bind copies a fully
      * populated env to OLD; nothing in cheney_forward / promote
      * special-cases this kind. */
-    [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] =
-        {osty_rt_closure_env_trace, NULL, true},
+    [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] = {
+        osty_rt_closure_env_trace, NULL, true,
+        NULL, osty_gc_remap_young_closure_env,
+    },
     /* CHANNEL stays headerful — destroy frees a mutex + 2 condvars
      * + slots buffer, and the safe-clone primitives that Map uses
      * for the cheney/promote path don't yet cover condvar
      * destroy/init pairs. */
-    [OSTY_GC_KIND_CHANNEL - OSTY_GC_KIND_LIST] =
-        {osty_rt_chan_trace, osty_rt_chan_destroy, false},
-    [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] =
-        {osty_rt_enum_ptr_payload_trace, NULL, true},
+    [OSTY_GC_KIND_CHANNEL - OSTY_GC_KIND_LIST] = {
+        osty_rt_chan_trace, osty_rt_chan_destroy, false, NULL, NULL,
+    },
+    [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] = {
+        osty_rt_enum_ptr_payload_trace, NULL, true,
+        NULL, osty_gc_remap_young_generic_enum_ptr,
+    },
 };
 
 _Static_assert(OSTY_GC_KIND_LIST == 1024,
@@ -3417,6 +3456,43 @@ static int64_t osty_gc_young_cheney_dead_buffer_bytes_freed_total = 0;
 static size_t osty_gc_micro_object_total_size(int32_t payload_size);
 static size_t osty_rt_kind_size(int64_t kind);
 
+/* Per-kind cleanup helpers wired into `osty_gc_kind_descriptor::
+ * cleanup_young_dead`. Each one frees the dead young payload's
+ * external buffers and bumps the per-kind freed-count + global
+ * buffer-bytes-freed counters. */
+static void osty_gc_cleanup_young_dead_list(void *payload) {
+    osty_rt_list *list = (osty_rt_list *)payload;
+    if (list->gc_offsets != NULL) {
+        free(list->gc_offsets);
+    }
+    if (list->data != NULL && list->data != list->inline_storage) {
+        osty_gc_young_cheney_dead_buffer_bytes_freed_total +=
+            (int64_t)((size_t)list->cap * list->elem_size);
+        free(list->data);
+    }
+    osty_gc_young_cheney_dead_lists_freed_total += 1;
+}
+
+static void osty_gc_cleanup_young_dead_set(void *payload) {
+    osty_rt_set *set = (osty_rt_set *)payload;
+    if (set->items != NULL) {
+        osty_gc_young_cheney_dead_buffer_bytes_freed_total +=
+            (int64_t)((size_t)set->cap *
+                      osty_rt_kind_size(set->elem_kind));
+        free(set->items);
+    }
+    osty_gc_young_cheney_dead_sets_freed_total += 1;
+}
+
+static void osty_gc_cleanup_young_dead_map(void *payload) {
+    /* Map's full destroy: keys, values, index buffers (if not
+     * aliased to inline arrays), and the recursive mutex if it
+     * was init'd. Reuses the headerful destroy fn so the cleanup
+     * logic stays in one place. */
+    osty_rt_map_destroy(payload);
+    osty_gc_young_cheney_dead_maps_freed_total += 1;
+}
+
 static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
                                                    unsigned char *from_end_cursor) {
     unsigned char *scan = from_base;
@@ -3426,42 +3502,16 @@ static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
         size_t total = osty_gc_micro_object_total_size(payload_size);
         uint64_t tag = micro->forward_or_meta & OSTY_GC_FORWARD_TAG_MASK;
         if (tag == OSTY_GC_FORWARD_TAG_UNFORWARDED) {
-            /* Dead. Per-kind external-resource cleanup. */
-            void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
-            if (micro->object_kind == OSTY_GC_KIND_LIST) {
-                osty_rt_list *list = (osty_rt_list *)payload;
-                if (list->gc_offsets != NULL) {
-                    free(list->gc_offsets);
-                }
-                if (list->data != NULL &&
-                    list->data != list->inline_storage) {
-                    osty_gc_young_cheney_dead_buffer_bytes_freed_total +=
-                        (int64_t)((size_t)list->cap * list->elem_size);
-                    free(list->data);
-                }
-                osty_gc_young_cheney_dead_lists_freed_total += 1;
-            } else if (micro->object_kind == OSTY_GC_KIND_SET) {
-                osty_rt_set *set = (osty_rt_set *)payload;
-                if (set->items != NULL) {
-                    osty_gc_young_cheney_dead_buffer_bytes_freed_total +=
-                        (int64_t)((size_t)set->cap *
-                                  osty_rt_kind_size(set->elem_kind));
-                    free(set->items);
-                }
-                osty_gc_young_cheney_dead_sets_freed_total += 1;
-            } else if (micro->object_kind == OSTY_GC_KIND_MAP) {
-                /* Map's full destroy: keys, values, index buffers
-                 * (if not aliased to inline arrays), and the
-                 * recursive mutex if it was init'd. Reuses the
-                 * headerful destroy fn so the cleanup logic stays
-                 * in one place. */
-                osty_rt_map_destroy(payload);
-                osty_gc_young_cheney_dead_maps_freed_total += 1;
+            const osty_gc_kind_descriptor *desc =
+                osty_gc_kind_descriptor_lookup((int64_t)micro->object_kind);
+            if (desc != NULL && desc->cleanup_young_dead != NULL) {
+                void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
+                desc->cleanup_young_dead(payload);
             }
-            /* STRING / BYTES / CLOSURE_ENV / GENERIC NONE /
-             * GENERIC_ENUM_PTR carry no external buffers — payload
-             * bytes are reclaimed by the cursor reset, no destroy
-             * needed. */
+            /* Kinds with no cleanup_young_dead (STRING / BYTES /
+             * CLOSURE_ENV / GENERIC NONE / GENERIC_ENUM_PTR) carry no
+             * external buffers — payload bytes are reclaimed by the
+             * cursor reset. */
         }
         scan += total;
     }
@@ -4935,6 +4985,31 @@ static void osty_gc_remap_header_payload(osty_gc_header *header) {
  * addresses. Walk the young from-space (cheney just swapped
  * survivors here) and dispatch the kind-specific remap helper —
  * the same helpers `osty_gc_remap_header_payload` calls. */
+/* Per-kind young-arena remap helpers wired into
+ * `osty_gc_kind_descriptor::remap_young`. Each casts the void*
+ * payload and forwards to the existing kind-specific remap fn
+ * (the same fn `osty_gc_remap_header_payload` uses for the OLD
+ * dispatch, so headerful and young remap stay in sync). */
+static void osty_gc_remap_young_list(void *payload) {
+    osty_gc_remap_list_payload((osty_rt_list *)payload);
+}
+
+static void osty_gc_remap_young_map(void *payload) {
+    osty_gc_remap_map_payload((osty_rt_map *)payload);
+}
+
+static void osty_gc_remap_young_set(void *payload) {
+    osty_gc_remap_set_payload((osty_rt_set *)payload);
+}
+
+static void osty_gc_remap_young_closure_env(void *payload) {
+    osty_gc_remap_closure_env_payload((osty_rt_closure_env *)payload);
+}
+
+static void osty_gc_remap_young_generic_enum_ptr(void *payload) {
+    osty_gc_remap_slot(payload);
+}
+
 static void osty_gc_remap_young_arena_payloads(void) {
     if (!osty_gc_tinytag_young_now() || osty_gc_young_from.base == NULL) {
         return;
@@ -4943,29 +5018,15 @@ static void osty_gc_remap_young_arena_payloads(void) {
     while (scan < osty_gc_young_from.cursor) {
         osty_gc_micro_header *micro = (osty_gc_micro_header *)scan;
         int32_t payload_size = micro->byte_size;
-        void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
-        switch (micro->object_kind) {
-        case OSTY_GC_KIND_LIST:
-            osty_gc_remap_list_payload((osty_rt_list *)payload);
-            break;
-        case OSTY_GC_KIND_MAP:
-            osty_gc_remap_map_payload((osty_rt_map *)payload);
-            break;
-        case OSTY_GC_KIND_SET:
-            osty_gc_remap_set_payload((osty_rt_set *)payload);
-            break;
-        case OSTY_GC_KIND_CLOSURE_ENV:
-            osty_gc_remap_closure_env_payload(
-                (osty_rt_closure_env *)payload);
-            break;
-        case OSTY_GC_KIND_GENERIC_ENUM_PTR:
-            osty_gc_remap_slot(payload);
-            break;
-        default:
-            /* STRING / BYTES / GENERIC NONE carry no managed-pointer
-             * buffers — payload bytes are opaque from the GC's view. */
-            break;
+        const osty_gc_kind_descriptor *desc =
+            osty_gc_kind_descriptor_lookup((int64_t)micro->object_kind);
+        if (desc != NULL && desc->remap_young != NULL) {
+            void *payload = (void *)(scan + sizeof(osty_gc_micro_header));
+            desc->remap_young(payload);
         }
+        /* Kinds with no remap_young (STRING / BYTES / GENERIC NONE)
+         * carry no managed-pointer buffers — payload bytes are
+         * opaque from the GC's view. */
         scan += osty_gc_micro_object_total_size(payload_size);
     }
 }


### PR DESCRIPTION
## Summary

Same shape as the `young_eligible` flag added in [osty#981](https://github.com/choiceoh/osty/pull/981): add `cleanup_young_dead` and `remap_young` fn pointers to `osty_gc_kind_descriptor` and table-drive both dispatches.

**Before:**
- `osty_gc_cheney_destroy_dead_from_space` had a 3-way `if/else if` chain (LIST inline, SET inline, MAP delegate-to-destroy) with per-kind buffer-bytes counter accounting and per-kind freed-count counters interleaved.
- `osty_gc_remap_young_arena_payloads` had a 5-case switch (LIST, MAP, SET, CLOSURE_ENV, GENERIC_ENUM_PTR) calling the existing kind-specific remap fns through inline casts.

**After:**
- Three new cleanup helpers (`osty_gc_cleanup_young_dead_{list,set,map}`) each carry their own counter accumulation. LIST/SET preserve the inline-cleanup path with byte-counter tracking; MAP keeps delegating to `osty_rt_map_destroy`. The dispatch collapses to `desc->cleanup_young_dead(payload)` if non-NULL.
- Five new remap helpers (`osty_gc_remap_young_{list,map,set,closure_env,generic_enum_ptr}`) cast and forward to the existing remap fns. The dispatch collapses to `desc->remap_young(payload)` if non-NULL.

Adding the next young-eligible kind that needs either pass is now just a row update at the kind table — no edits to the dispatch loops.

## Changes

`internal/backend/runtime/osty_runtime.c`:
- `osty_gc_kind_descriptor` gains `cleanup_young_dead` and `remap_young` fn pointers (alongside the existing `trace`, `destroy`, `young_eligible`).
- `osty_gc_kind_table`: 7 rows updated with the new fields.
- `osty_gc_generic_patterns`: 3 rows updated (all NULL — GENERIC's young eligibility flows through `KIND_GENERIC_ENUM_PTR`, not the pattern table).
- 8 new per-kind helpers + forward decls.
- `osty_gc_cheney_destroy_dead_from_space`: chain → 1-line table-driven dispatch.
- `osty_gc_remap_young_arena_payloads`: switch → 1-line table-driven dispatch.

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeMapYoungLifecycle|TestBundledRuntimeSetYoungLifecycle|TestBundledRuntimeGenericEnumPtrYoungTraceFollows|TestBundledRuntimeMapRemapsCompactionPhaseD|TestBundledRuntimeYoungEligibilityFilter"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime sweep passes (~45s)

## Pending follow-ups (not in this PR)

- Channel + GENERIC TASK_HANDLE young eligibility — pthread condvar teardown is the remaining blocker. With descriptor-driven dispatch in place, adding either kind is now a one-liner at the kind table once the safe-clone primitives for condvars exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)