### PR TITLE
refactor(llvmgen): port 8 pure helpers + add 125 Text builders + drain 282 inline IR sites (slices 8-9)

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -244,14 +244,15 @@ func (g *generator) emitRuntimeStringConcatN(pieces []value) (value, error) {
 	emitter := g.toOstyEmitter()
 	// Stack-allocate `[N x ptr]` and store each piece into the slot.
 	arr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca [%d x ptr]", arr, len(pieces)))
+	piecesN := strconv.Itoa(len(pieces))
+	emitter.body = append(emitter.body, mirAllocaArrayPtrText(arr, piecesN))
 	for i, piece := range pieces {
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr [%d x ptr], ptr %s, i64 0, i64 %d", slot, len(pieces), arr, i))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", piece.ref, slot))
+		emitter.body = append(emitter.body, mirGEPArrayElementText(slot, piecesN, arr, strconv.Itoa(i)))
+		emitter.body = append(emitter.body, mirStorePtrText(piece.ref, slot))
 	}
 	out := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @%s(i64 %d, ptr %s)", out, symbol, len(pieces), arr))
+	emitter.body = append(emitter.body, mirCallRuntimePtrI64PtrText(out, symbol, piecesN, arr))
 	g.takeOstyEmitter(emitter)
 	joined := value{typ: "ptr", ref: out, gcManaged: true}
 	return joined, nil
@@ -457,7 +458,7 @@ func (g *generator) loadTypedPointerValue(addr value, typ string) (value, error)
 	}
 	emitter := g.toOstyEmitter()
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, typ, addr.ref))
+	emitter.body = append(emitter.body, mirLoadText(tmp, typ, addr.ref))
 	g.takeOstyEmitter(emitter)
 	out := value{typ: typ, ref: tmp}
 	out.rootPaths = g.rootPathsForType(typ)
@@ -473,8 +474,8 @@ func (g *generator) emitOptionalPtrExpr(base value, then func() (value, error)) 
 	thenLabel := llvmNextLabel(emitter, "optional.then")
 	nilLabel := llvmNextLabel(emitter, "optional.nil")
 	endLabel := llvmNextLabel(emitter, "optional.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, nilLabel, thenLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", thenLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isNil.name, nilLabel, thenLabel))
+	emitter.body = append(emitter.body, mirLabelText(thenLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(thenLabel)
 
@@ -491,11 +492,11 @@ func (g *generator) emitOptionalPtrExpr(base value, then func() (value, error)) 
 	}
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nilLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(nilLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ null, %%%s ]", tmp, thenValue.ref, thenPred, nilLabel))
+	emitter.body = append(emitter.body, mirPhiPtrFromValueOrNullText(tmp, thenValue.ref, thenPred, nilLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 
@@ -515,8 +516,8 @@ func (g *generator) emitOptionalPtrStmt(base value, then func() error) error {
 	thenLabel := llvmNextLabel(emitter, "optional.then")
 	nilLabel := llvmNextLabel(emitter, "optional.nil")
 	endLabel := llvmNextLabel(emitter, "optional.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, nilLabel, thenLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", thenLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isNil.name, nilLabel, thenLabel))
+	emitter.body = append(emitter.body, mirLabelText(thenLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(thenLabel)
 	if err := then(); err != nil {
@@ -526,9 +527,9 @@ func (g *generator) emitOptionalPtrStmt(base value, then func() error) error {
 		g.branchTo(endLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nilLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(nilLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	return nil
@@ -790,11 +791,10 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 		traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
 		emitter := g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.listElemTyp))
+		emitter.body = append(emitter.body, mirAllocaText(slot, base.listElemTyp))
 		sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
 		g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeGetBytesSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 		))
@@ -814,9 +814,8 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 		g.declareRuntimeSymbol(symbol, "void", []paramInfo{{typ: "ptr"}, {typ: base.mapKeyTyp}, {typ: "ptr"}})
 		emitter := g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.mapValueTyp))
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirAllocaText(slot, base.mapValueTyp))
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			symbol,
 			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(loadedKey), {typ: "ptr", name: slot}}),
 		))
@@ -884,7 +883,7 @@ func (g *generator) emitSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr) (val
 		if rng.Inclusive {
 			emitter := g.toOstyEmitter()
 			tmp := llvmNextTemp(emitter)
-			emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", tmp, endVal.ref))
+			emitter.body = append(emitter.body, mirAddI64OneText(tmp, endVal.ref))
 			g.takeOstyEmitter(emitter)
 			endVal = value{typ: "i64", ref: tmp}
 		}
@@ -943,7 +942,7 @@ func (g *generator) emitListSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr, 
 		if rng.Inclusive {
 			emitter := g.toOstyEmitter()
 			tmp := llvmNextTemp(emitter)
-			emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", tmp, endVal.ref))
+			emitter.body = append(emitter.body, mirAddI64OneText(tmp, endVal.ref))
 			g.takeOstyEmitter(emitter)
 			endVal = value{typ: "i64", ref: tmp}
 		}
@@ -1015,15 +1014,15 @@ func (g *generator) emitSliceIndexByRangeValue(expr *ast.IndexExpr, base value, 
 	inclusive := llvmExtractValue(emitter, toOstyValue(rangeVal), "i1", rangeFieldInclusive)
 
 	startSel := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 0", startSel, hasStart.name, startRaw.name))
+	emitter.body = append(emitter.body, mirSelectI64LiteralRhsText(startSel, hasStart.name, startRaw.name, "0"))
 	stopPlus := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", stopPlus, stopRaw.name))
+	emitter.body = append(emitter.body, mirAddI64OneText(stopPlus, stopRaw.name))
 	stopIncl := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 %s", stopIncl, inclusive.name, stopPlus, stopRaw.name))
+	emitter.body = append(emitter.body, mirSelectI64Text(stopIncl, inclusive.name, stopPlus, stopRaw.name))
 
 	lenVal := llvmCall(emitter, "i64", lenSym, []*LlvmValue{toOstyValue(baseLoaded)})
 	endSel := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 %s", endSel, hasStop.name, stopIncl, lenVal.name))
+	emitter.body = append(emitter.body, mirSelectI64Text(endSel, hasStop.name, stopIncl, lenVal.name))
 
 	startVal := value{typ: "i64", ref: startSel}
 	endVal := value{typ: "i64", ref: endSel}
@@ -1148,8 +1147,8 @@ func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, 
 			heapPtr := llvmGcAlloc(emitter, 1, byteSize, site)
 			for i, p := range payloads {
 				gep := llvmNextTemp(emitter)
-				emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", gep, heapPtr.name, i*8))
-				emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", p.typ, p.ref, gep))
+				emitter.body = append(emitter.body, mirGEPInboundsI8Text(gep, heapPtr.name, strconv.Itoa(i*8)))
+				emitter.body = append(emitter.body, mirStoreText(p.typ, p.ref, gep))
 			}
 			out := llvmStructLiteral(emitter, info.typ, []*LlvmValue{llvmEnumVariant(info.typ, variant.tag), heapPtr})
 			g.takeOstyEmitter(emitter)
@@ -1365,8 +1364,8 @@ func (g *generator) emitCoalesce(e *ast.BinaryExpr) (value, error) {
 	someLabel := llvmNextLabel(emitter, "coalesce.some")
 	noneLabel := llvmNextLabel(emitter, "coalesce.none")
 	endLabel := llvmNextLabel(emitter, "coalesce.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, noneLabel, someLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isNil.name, noneLabel, someLabel))
+	emitter.body = append(emitter.body, mirLabelText(someLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(someLabel)
 
@@ -1386,7 +1385,7 @@ func (g *generator) emitCoalesce(e *ast.BinaryExpr) (value, error) {
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	emitter.body = append(emitter.body, mirLabelText(noneLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(noneLabel)
 
@@ -1401,12 +1400,9 @@ func (g *generator) emitCoalesce(e *ast.BinaryExpr) (value, error) {
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]",
-		tmp, innerTyp, leftUnwrapped.ref, somePred, right.ref, nonePred,
-	))
+	emitter.body = append(emitter.body, mirPhiTypedTwoEdgeText(tmp, innerTyp, leftUnwrapped.ref, somePred, right.ref, nonePred))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 
@@ -1529,14 +1525,14 @@ func (g *generator) emitQuestionExpr(expr *ast.QuestionExpr) (value, error) {
 	isNil := llvmCompare(emitter, "eq", toOstyValue(base), toOstyValue(value{typ: "ptr", ref: "null"}))
 	nilLabel := llvmNextLabel(emitter, "optional.return")
 	contLabel := llvmNextLabel(emitter, "optional.cont")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, nilLabel, contLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nilLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isNil.name, nilLabel, contLabel))
+	emitter.body = append(emitter.body, mirLabelText(nilLabel))
 	if inBench {
 		g.emitTestingAbortWithEmitter(emitter, g.benchQuestionFailMessage(expr), contLabel)
 	} else {
 		g.releaseGCRoots(emitter)
 		emitter.body = append(emitter.body, "  ret ptr null")
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", contLabel))
+		emitter.body = append(emitter.body, mirLabelText(contLabel))
 	}
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(contLabel)
@@ -1584,9 +1580,9 @@ func (g *generator) emitQuestionExprResult(expr *ast.QuestionExpr, info builtinR
 	isErr := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: "1"}))
 	errLabel := llvmNextLabel(emitter, "result.err")
 	okLabel := llvmNextLabel(emitter, "result.ok")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isErr.name, errLabel, okLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isErr.name, errLabel, okLabel))
 
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", errLabel))
+	emitter.body = append(emitter.body, mirLabelText(errLabel))
 	if inBench {
 		g.emitTestingAbortWithEmitter(emitter, g.benchQuestionFailMessage(expr), okLabel)
 	} else {
@@ -1601,8 +1597,8 @@ func (g *generator) emitQuestionExprResult(expr *ast.QuestionExpr, info builtinR
 		}
 		retStruct := llvmStructLiteral(emitter, returnInfo.typ, retFields)
 		g.releaseGCRoots(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  ret %s %s", returnInfo.typ, retStruct.name))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", okLabel))
+		emitter.body = append(emitter.body, mirRetText(returnInfo.typ, retStruct.name))
+		emitter.body = append(emitter.body, mirLabelText(okLabel))
 	}
 	okSlot := llvmExtractValue(emitter, toOstyValue(base), info.okTyp, 1)
 	g.takeOstyEmitter(emitter)
@@ -1831,18 +1827,10 @@ func (g *generator) emitIfExprPhi(labels *LlvmIfLabels, thenPred, elsePred strin
 		return value{}, unsupportedf("type-system", "if expression branch types %s/%s", thenValue.typ, elseValue.typ)
 	}
 	emitter := g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(labels.endLabel))
+	emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]",
-		tmp,
-		thenValue.typ,
-		thenValue.ref,
-		thenPred,
-		elseValue.ref,
-		elsePred,
-	))
+	emitter.body = append(emitter.body, mirPhiTypedTwoEdgeText(tmp, thenValue.typ, thenValue.ref, thenPred, elseValue.ref, elsePred))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = labels.endLabel
 	out := value{typ: thenValue.typ, ref: tmp}
@@ -2056,7 +2044,7 @@ func (g *generator) emitOptionalMatchExprValue(scrutinee value, innerSource ast.
 
 	emitter := g.toOstyEmitter()
 	isNil := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, scrutinee.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNil, scrutinee.ref))
 	// `cond=true` selects the then-label per llvmIfExprStart; isNil=true
 	// → the None arm runs in `then`, the Some arm in `else`.
 	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
@@ -2680,7 +2668,7 @@ func (g *generator) emitSelectValue(cond *LlvmValue, thenValue, elseValue value)
 	}
 	emitter := g.toOstyEmitter()
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, %s %s, %s %s", tmp, cond.name, thenValue.typ, thenValue.ref, elseValue.typ, elseValue.ref))
+	emitter.body = append(emitter.body, mirSelectTypedText(tmp, thenValue.typ, cond.name, thenValue.ref, elseValue.ref))
 	g.takeOstyEmitter(emitter)
 	out := value{typ: thenValue.typ, ref: tmp}
 	mergeContainerMetadata(&out, thenValue, elseValue)
@@ -2860,16 +2848,16 @@ func (g *generator) usesAggregateListABI(elemTyp string) bool {
 
 func (g *generator) emitAggregateByteSize(emitter *LlvmEmitter, typ string) value {
 	sizePtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", sizePtr, typ))
+	emitter.body = append(emitter.body, mirGEPSizeofText(sizePtr, typ))
 	size := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", size, sizePtr))
+	emitter.body = append(emitter.body, mirPtrToIntI64Text(size, sizePtr))
 	return value{typ: "i64", ref: size}
 }
 
 func (g *generator) emitAggregateScratchSlot(emitter *LlvmEmitter, typ, initial string) value {
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, typ))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", typ, initial, slot))
+	emitter.body = append(emitter.body, mirAllocaText(slot, typ))
+	emitter.body = append(emitter.body, mirStoreText(typ, initial, slot))
 	return value{typ: typ, ref: slot, ptr: true}
 }
 
@@ -2880,23 +2868,18 @@ func (g *generator) emitAggregateRootOffsets(emitter *LlvmEmitter, typ string) (
 	}
 	arrayTyp := fmt.Sprintf("[%d x i64]", len(paths))
 	arrayPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", arrayPtr, arrayTyp))
+	emitter.body = append(emitter.body, mirAllocaText(arrayPtr, arrayTyp))
 	for i, path := range paths {
 		offsetPtr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  %s = getelementptr inbounds %s, ptr null, %s",
-			offsetPtr,
-			typ,
-			llvmAggregatePathIndices(path),
-		))
+		emitter.body = append(emitter.body, mirGEPInboundsNullRawIndicesText(offsetPtr, typ, llvmAggregatePathIndices(path)))
 		offsetValue := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", offsetValue, offsetPtr))
+		emitter.body = append(emitter.body, mirPtrToIntI64Text(offsetValue, offsetPtr))
 		slotPtr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d", slotPtr, arrayTyp, arrayPtr, i))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", offsetValue, slotPtr))
+		emitter.body = append(emitter.body, mirGEPInboundsFieldText(slotPtr, arrayTyp, arrayPtr, strconv.Itoa(i)))
+		emitter.body = append(emitter.body, mirStoreI64Text(offsetValue, slotPtr))
 	}
 	firstPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", firstPtr, arrayTyp, arrayPtr))
+	emitter.body = append(emitter.body, mirGEPInboundsZeroText(firstPtr, arrayTyp, arrayPtr))
 	return value{typ: "ptr", ref: firstPtr}, len(paths), nil
 }
 
@@ -2910,15 +2893,13 @@ func (g *generator) emitListAggregatePush(listValue, elem value) error {
 	}
 	if offsetCount == 0 {
 		g.declareRuntimeSymbol(listRuntimePushBytesV1Symbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimePushBytesV1Symbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
 		))
 	} else {
 		g.declareRuntimeSymbol(listRuntimePushBytesRootsSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimePushBytesRootsSymbol(),
 			llvmCallArgs([]*LlvmValue{
 				toOstyValue(listValue),
@@ -2947,15 +2928,13 @@ func (g *generator) emitListAggregateInsert(listValue, idx, elem value) error {
 	}
 	if offsetCount == 0 {
 		g.declareRuntimeSymbol(listRuntimeInsertBytesV1Symbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeInsertBytesV1Symbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(idx), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
 		))
 	} else {
 		g.declareRuntimeSymbol(listRuntimeInsertBytesRootsSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeInsertBytesRootsSymbol(),
 			llvmCallArgs([]*LlvmValue{
 				toOstyValue(listValue),
@@ -2976,8 +2955,7 @@ func (g *generator) emitListAggregateGet(listValue value, index value, elemTyp s
 	emitter := g.toOstyEmitter()
 	slot := g.emitAggregateScratchSlot(emitter, elemTyp, "zeroinitializer")
 	size := g.emitAggregateByteSize(emitter, elemTyp)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 		listRuntimeGetBytesV1Symbol(),
 		llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(index), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
 	))
@@ -3061,8 +3039,7 @@ func (g *generator) emitListExprWithHint(expr *ast.ListExpr, elemSource ast.Type
 		if listUsesTypedRuntime(elemTyp) {
 			pushSymbol := listRuntimePushSymbol(elemTyp)
 			g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
-			emitter.body = append(emitter.body, fmt.Sprintf(
-				"  call void @%s(%s)",
+			emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 				pushSymbol,
 				llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(loaded)}),
 			))
@@ -3070,8 +3047,7 @@ func (g *generator) emitListExprWithHint(expr *ast.ListExpr, elemSource ast.Type
 			addr := g.spillValueAddress(emitter, "list.elem", loaded)
 			sizeValue := g.emitTypeSize(emitter, elemTyp)
 			g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-			emitter.body = append(emitter.body, fmt.Sprintf(
-				"  call void @%s(%s)",
+			emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 				listRuntimePushBytesSymbol(),
 				llvmCallArgs([]*LlvmValue{
 					toOstyValue(listValue),
@@ -3178,8 +3154,7 @@ func (g *generator) emitMapInsert(base, key, val value) error {
 	emitter := g.toOstyEmitter()
 	valAddr := g.spillValueAddress(emitter, "map.insert.value", valLoaded)
 	g.declareRuntimeSymbol(insertSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: base.mapKeyTyp}, {typ: "ptr"}})
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 		insertSymbol,
 		llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(keyLoaded), {typ: "ptr", name: valAddr}}),
 	))
@@ -3225,15 +3200,15 @@ func (g *generator) emitCharByteConversionCall(call *ast.CallExpr) (value, bool,
 	tmp := llvmNextTemp(emitter)
 	switch {
 	case field.Name == "toInt" && base.typ == "i32":
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = zext i32 %s to i64", tmp, base.ref))
+		emitter.body = append(emitter.body, mirZExtI32ToI64Text(tmp, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i64", ref: tmp}, true, nil
 	case field.Name == "toInt" && base.typ == "i8":
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = zext i8 %s to i64", tmp, base.ref))
+		emitter.body = append(emitter.body, mirZExtI8ToI64Text(tmp, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i64", ref: tmp}, true, nil
 	case field.Name == "toChar" && base.typ == "i64":
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = trunc i64 %s to i32", tmp, base.ref))
+		emitter.body = append(emitter.body, mirTruncI64ToI32Text(tmp, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i32", ref: tmp}, true, nil
 	case field.Name == "toByte" && base.typ == "i64":
@@ -3243,14 +3218,14 @@ func (g *generator) emitCharByteConversionCall(call *ast.CallExpr) (value, bool,
 		// Lower as plain `trunc i64 to i8` so the comparisons that
 		// follow (`b == '\\'.toInt().toByte()`) type-check against the
 		// Byte receiver without an extra `.unwrap()` layer.
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = trunc i64 %s to i8", tmp, base.ref))
+		emitter.body = append(emitter.body, mirTruncI64ToI8Text(tmp, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i8", ref: tmp}, true, nil
 	case field.Name == "toChar" && base.typ == "i8":
 		// Byte → Char widens a u8 to a Char code point via zero extend.
 		// `b.toChar().toString()` in the llvmgen C-string escape loop
 		// materialises a one-byte UTF-8 string for printable ASCII.
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = zext i8 %s to i32", tmp, base.ref))
+		emitter.body = append(emitter.body, mirZExtI8ToI32Text(tmp, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i32", ref: tmp}, true, nil
 	}
@@ -3321,7 +3296,7 @@ func (g *generator) emitCharPredicateCall(call *ast.CallExpr) (value, bool, erro
 		up := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
 		lo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
 		out := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, up, lo))
+		emitter.body = append(emitter.body, mirOrI1Text(out, up, lo))
 		return value{typ: "i1", ref: out}, true, nil
 	case "isAlphanumeric":
 		// isDigit || isUpper || isLower
@@ -3329,9 +3304,9 @@ func (g *generator) emitCharPredicateCall(call *ast.CallExpr) (value, bool, erro
 		up := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
 		lo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
 		al := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", al, up, lo))
+		emitter.body = append(emitter.body, mirOrI1Text(al, up, lo))
 		out := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, dg, al))
+		emitter.body = append(emitter.body, mirOrI1Text(out, dg, al))
 		return value{typ: "i1", ref: out}, true, nil
 	case "isWhitespace":
 		// Spec-relevant ASCII whitespace: SPACE / TAB / LF / CR.
@@ -3339,35 +3314,35 @@ func (g *generator) emitCharPredicateCall(call *ast.CallExpr) (value, bool, erro
 		// any current stdlib body and matching libc isspace() too
 		// closely is a Unicode follow-up concern.)
 		eqSp := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 32", eqSp, base.ref))
+		emitter.body = append(emitter.body, mirICmpEqI32LiteralText(eqSp, base.ref, "32"))
 		eqTab := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 9", eqTab, base.ref))
+		emitter.body = append(emitter.body, mirICmpEqI32LiteralText(eqTab, base.ref, "9"))
 		eqLf := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 10", eqLf, base.ref))
+		emitter.body = append(emitter.body, mirICmpEqI32LiteralText(eqLf, base.ref, "10"))
 		eqCr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 13", eqCr, base.ref))
+		emitter.body = append(emitter.body, mirICmpEqI32LiteralText(eqCr, base.ref, "13"))
 		o1 := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", o1, eqSp, eqTab))
+		emitter.body = append(emitter.body, mirOrI1Text(o1, eqSp, eqTab))
 		o2 := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", o2, eqLf, eqCr))
+		emitter.body = append(emitter.body, mirOrI1Text(o2, eqLf, eqCr))
 		out := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, o1, o2))
+		emitter.body = append(emitter.body, mirOrI1Text(out, o1, o2))
 		return value{typ: "i1", ref: out}, true, nil
 	case "toLower":
 		// if c is ASCII upper, c + 32; else c. select form keeps it
 		// branch-free (downstream phi avoidance).
 		isUp := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
 		shifted := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i32 %s, 32", shifted, base.ref))
+		emitter.body = append(emitter.body, mirAddI32LiteralText(shifted, base.ref, "32"))
 		out := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i32 %s, i32 %s", out, isUp, shifted, base.ref))
+		emitter.body = append(emitter.body, mirSelectI32Text(out, isUp, shifted, base.ref))
 		return value{typ: "i32", ref: out}, true, nil
 	case "toUpper":
 		isLo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
 		shifted := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i32 %s, 32", shifted, base.ref))
+		emitter.body = append(emitter.body, mirSubI32LiteralText(shifted, base.ref, "32"))
 		out := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i32 %s, i32 %s", out, isLo, shifted, base.ref))
+		emitter.body = append(emitter.body, mirSelectI32Text(out, isLo, shifted, base.ref))
 		return value{typ: "i32", ref: out}, true, nil
 	}
 	return value{}, false, nil
@@ -3378,9 +3353,9 @@ func (g *generator) emitCharPredicateCall(call *ast.CallExpr) (value, bool, erro
 // compare against the count. Returns the i1 temp name.
 func llvmCharAsciiRangeCheck(emitter *LlvmEmitter, charRef string, low int, count int) string {
 	shifted := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i32 %s, %d", shifted, charRef, low))
+	emitter.body = append(emitter.body, mirSubI32LiteralText(shifted, charRef, strconv.Itoa(low)))
 	cmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp ult i32 %s, %d", cmp, shifted, count))
+	emitter.body = append(emitter.body, mirICmpULTI32LiteralText(cmp, shifted, strconv.Itoa(count)))
 	return cmp
 }
 
@@ -3564,7 +3539,7 @@ func (g *generator) emitStringMethodCall(call *ast.CallExpr) (value, bool, error
 		emitter = g.toOstyEmitter()
 		item := llvmCall(emitter, "i8", getSym, []*LlvmValue{bytes, toOstyValue(index)})
 		box := llvmGcAlloc(emitter, 1, 1, "string.get.byte")
-		emitter.body = append(emitter.body, fmt.Sprintf("  store i8 %s, ptr %s", item.name, box.name))
+		emitter.body = append(emitter.body, mirStoreI8Text(item.name, box.name))
 		g.takeOstyEmitter(emitter)
 		g.needsGCRuntime = true
 		someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
@@ -3861,7 +3836,7 @@ func (g *generator) emitOptionalBoxedI64(index value, site string) (value, error
 
 	emitter = g.toOstyEmitter()
 	box := llvmGcAlloc(emitter, 1, 8, site)
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", index.ref, box.name))
+	emitter.body = append(emitter.body, mirStoreI64Text(index.ref, box.name))
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
 	someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
@@ -4357,7 +4332,7 @@ func (g *generator) emitBytesGetRuntime(base, index value) (value, error) {
 	emitter = g.toOstyEmitter()
 	item := llvmCall(emitter, "i8", getSymbol, []*LlvmValue{toOstyValue(base), toOstyValue(index)})
 	box := llvmGcAlloc(emitter, 1, 1, "bytes.get.byte")
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i8 %s, ptr %s", item.name, box.name))
+	emitter.body = append(emitter.body, mirStoreI8Text(item.name, box.name))
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
 	someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
@@ -4429,7 +4404,7 @@ func (g *generator) emitBytesEndsWithRuntime(base, suffix value) (value, error) 
 	baseLen := llvmCall(emitter, "i64", lenSymbol, []*LlvmValue{toOstyValue(base)})
 	suffixLen := llvmCall(emitter, "i64", lenSymbol, []*LlvmValue{toOstyValue(suffix)})
 	expectedName := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i64 %s, %s", expectedName, baseLen.name, suffixLen.name))
+	emitter.body = append(emitter.body, mirSubI64Text(expectedName, baseLen.name, suffixLen.name))
 	found := llvmCompare(emitter, "sge", toOstyValue(lastIndex), llvmIntLiteral(0))
 	atEnd := llvmCompare(emitter, "eq", toOstyValue(lastIndex), &LlvmValue{typ: "i64", name: expectedName})
 	out := llvmLogicalI1(emitter, "and", found, atEnd)
@@ -5595,7 +5570,7 @@ func (g *generator) emitListMethodCall(call *ast.CallExpr) (value, bool, error) 
 		emitter := g.toOstyEmitter()
 		lenVal := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 		cmp := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		emitter.body = append(emitter.body, mirICmpEqI64LiteralText(cmp, lenVal.name, "0"))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i1", ref: cmp}, true, nil
 	case "sorted":
@@ -5686,18 +5661,18 @@ func (g *generator) emitListGetCall(call *ast.CallExpr, base value, elemTyp stri
 	emitter := g.toOstyEmitter()
 	lenVal := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 	geq0 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sge i64 %s, 0", geq0, idx.ref))
+	emitter.body = append(emitter.body, mirICmpSGEI64ZeroText(geq0, idx.ref))
 	ltlen := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp slt i64 %s, %s", ltlen, idx.ref, lenVal.name))
+	emitter.body = append(emitter.body, mirICmpSLTI64Text(ltlen, idx.ref, lenVal.name))
 	inBounds := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = and i1 %s, %s", inBounds, geq0, ltlen))
+	emitter.body = append(emitter.body, mirAndI1Text(inBounds, geq0, ltlen))
 
 	inLabel := llvmNextLabel(emitter, "list.get.in")
 	outLabel := llvmNextLabel(emitter, "list.get.out")
 	endLabel := llvmNextLabel(emitter, "list.get.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", inBounds, inLabel, outLabel))
+	emitter.body = append(emitter.body, mirBrCondText(inBounds, inLabel, outLabel))
 
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", inLabel))
+	emitter.body = append(emitter.body, mirLabelText(inLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(inLabel)
 
@@ -5710,7 +5685,7 @@ func (g *generator) emitListGetCall(call *ast.CallExpr, base value, elemTyp stri
 		got := llvmCall(emitter, elemTyp, getSym, []*LlvmValue{toOstyValue(base), toOstyValue(idx)})
 		site := "list.get.box." + elemTyp
 		box := llvmGcAlloc(emitter, 1, byteSize, site)
-		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", elemTyp, got.name, box.name))
+		emitter.body = append(emitter.body, mirStoreText(elemTyp, got.name, box.name))
 		someRef = box.name
 		g.needsGCRuntime = true
 	} else {
@@ -5719,12 +5694,12 @@ func (g *generator) emitListGetCall(call *ast.CallExpr, base value, elemTyp stri
 		someRef = got.name
 	}
 	inPred := g.currentBlock
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", outLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(outLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ null, %%%s ]", tmp, someRef, inPred, outLabel))
+	emitter.body = append(emitter.body, mirPhiPtrFromValueOrNullText(tmp, someRef, inPred, outLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 
@@ -5789,7 +5764,7 @@ func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
 		emitter := g.toOstyEmitter()
 		lenVal := llvmCall(emitter, "i64", mapRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 		cmp := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		emitter.body = append(emitter.body, mirICmpEqI64LiteralText(cmp, lenVal.name, "0"))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i1", ref: cmp}, true, nil
 	case "get":
@@ -5937,10 +5912,9 @@ func (g *generator) emitMapGetCore(base value, loadedKey value, keyTyp string, k
 		// ptr (= Some). No branch needed.
 		emitter := g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr", slot))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr null, ptr %s", slot))
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  %s = call i1 @%s(%s)",
+		emitter.body = append(emitter.body, mirAllocaPtrText(slot))
+		emitter.body = append(emitter.body, mirStorePtrNullText(slot))
+		emitter.body = append(emitter.body, mirCallI1FromArgsText(
 			llvmNextTemp(emitter),
 			getSym,
 			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(loadedKey), {typ: "ptr", name: slot}}),
@@ -5968,7 +5942,7 @@ func (g *generator) emitMapGetCore(base value, loadedKey value, keyTyp string, k
 	// unchanged by ?? / match / .isSome().
 	emitter := g.toOstyEmitter()
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, valTyp))
+	emitter.body = append(emitter.body, mirAllocaText(slot, valTyp))
 	present := llvmCall(emitter, "i1", getSym, []*LlvmValue{
 		toOstyValue(base),
 		toOstyValue(loadedKey),
@@ -5982,7 +5956,7 @@ func (g *generator) emitMapGetCore(base value, loadedKey value, keyTyp string, k
 	emitter = g.toOstyEmitter()
 	box := llvmGcAlloc(emitter, 1, byteSize, "map.get.box."+valTyp)
 	payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: slot, pointer: true})
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", valTyp, payload.name, box.name))
+	emitter.body = append(emitter.body, mirStoreText(valTyp, payload.name, box.name))
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
 	someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
@@ -6086,7 +6060,7 @@ func (g *generator) emitMapIterate(mapVal value, keyTyp, valTyp string, keyStrin
 	// if opt is null → skip; else → unwrap and run body.
 	emitter = g.toOstyEmitter()
 	isNil := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, optV.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNil, optV.ref))
 	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
 	g.takeOstyEmitter(emitter)
 	// then = none (skip)
@@ -6115,8 +6089,8 @@ func (g *generator) emitMapIterate(mapVal value, keyTyp, valTyp string, keyStrin
 
 	// Merge branches at labels.endLabel.
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(labels.endLabel))
+	emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = labels.endLabel
 
@@ -6125,7 +6099,7 @@ func (g *generator) emitMapIterate(mapVal value, keyTyp, valTyp string, keyStrin
 		g.branchTo(cont)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont))
+	emitter.body = append(emitter.body, mirLabelText(cont))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
@@ -6217,7 +6191,7 @@ func (g *generator) emitMapMergeWith(call *ast.CallExpr, base value, keyTyp stri
 		// branch on opt null-ness
 		emitter := g.toOstyEmitter()
 		isNil := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, existingOpt.ref))
+		emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNil, existingOpt.ref))
 		labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
 		g.takeOstyEmitter(emitter)
 
@@ -6252,8 +6226,8 @@ func (g *generator) emitMapMergeWith(call *ast.CallExpr, base value, keyTyp stri
 			return err
 		}
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		emitter.body = append(emitter.body, mirBrUncondText(labels.endLabel))
+		emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 		g.takeOstyEmitter(emitter)
 		g.currentBlock = labels.endLabel
 		return nil
@@ -6361,7 +6335,7 @@ func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, 
 
 		emitter := g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, valTyp))
+		emitter.body = append(emitter.body, mirAllocaText(slot, valTyp))
 		present := llvmCall(emitter, "i1", getSym, []*LlvmValue{
 			toOstyValue(base),
 			toOstyValue(loadedKey),
@@ -6400,7 +6374,7 @@ func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, 
 
 	emitter := g.toOstyEmitter()
 	isNil := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, optVal.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNil, optVal.ref))
 	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
 	g.takeOstyEmitter(emitter)
 
@@ -6486,7 +6460,7 @@ func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error
 	if field.Name == "isNone" {
 		op = "eq"
 	}
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s ptr %s, null", cmp, op, base.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrText(cmp, op, base.ref))
 	g.takeOstyEmitter(emitter)
 	return value{typ: "i1", ref: cmp}, true, nil
 }
@@ -6545,11 +6519,11 @@ func (g *generator) emitResultAbortCall(call *ast.CallExpr) (value, error) {
 func (g *generator) emitOptionUnwrap(base value, optType *ast.OptionalType, call *ast.CallExpr) (value, bool, error) {
 	emitter := g.toOstyEmitter()
 	isNone := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNone, base.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNone, base.ref))
 	someLabel := llvmNextLabel(emitter, "unwrap.some")
 	noneLabel := llvmNextLabel(emitter, "unwrap.none")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNone, noneLabel, someLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	emitter.body = append(emitter.body, mirBrCondText(isNone, noneLabel, someLabel))
+	emitter.body = append(emitter.body, mirLabelText(noneLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(noneLabel)
 
@@ -6560,7 +6534,7 @@ func (g *generator) emitOptionUnwrap(base value, optType *ast.OptionalType, call
 	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
 	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
 	emitter.body = append(emitter.body, "  unreachable")
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	emitter.body = append(emitter.body, mirLabelText(someLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(someLabel)
 
@@ -6575,7 +6549,7 @@ func (g *generator) emitOptionUnwrap(base value, optType *ast.OptionalType, call
 	if innerLLVM, ok := scalarLLVMTypeForOptionInner(inner); ok {
 		emitter = g.toOstyEmitter()
 		loaded := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", loaded, innerLLVM, base.ref))
+		emitter.body = append(emitter.body, mirLoadText(loaded, innerLLVM, base.ref))
 		g.takeOstyEmitter(emitter)
 		return value{typ: innerLLVM, ref: loaded, sourceType: inner}, true, nil
 	}
@@ -6638,7 +6612,7 @@ func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {
 		emitter := g.toOstyEmitter()
 		lenVal := llvmCall(emitter, "i64", setRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 		cmp := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		emitter.body = append(emitter.body, mirICmpEqI64LiteralText(cmp, lenVal.name, "0"))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i1", ref: cmp}, true, nil
 	case "contains", "remove":
@@ -6810,9 +6784,9 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 					continue
 				}
 				gep := llvmNextTemp(emitter)
-				emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", gep, heapPtr.name, i*8))
+				emitter.body = append(emitter.body, mirGEPInboundsI8Text(gep, heapPtr.name, strconv.Itoa(i*8)))
 				loadTmp := llvmNextTemp(emitter)
-				emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", loadTmp, b.typ, gep))
+				emitter.body = append(emitter.body, mirLoadText(loadTmp, b.typ, gep))
 				payloadValue := value{typ: b.typ, ref: loadTmp}
 				payloadValue.rootPaths = g.rootPathsForType(b.typ)
 				if err := decoratePayload(i, &payloadValue); err != nil {
@@ -7795,25 +7769,19 @@ func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, er
 	}
 	emitter := g.toOstyEmitter()
 	dataPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %%osty.iface %s, 0", dataPtr, recv.ref))
+	emitter.body = append(emitter.body, mirExtractValueIfacePtrText(dataPtr, recv.ref))
 	vtable := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %%osty.iface %s, 1", vtable, recv.ref))
+	emitter.body = append(emitter.body, mirExtractValueIfaceVtableText(vtable, recv.ref))
 	fnPtrSlot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = getelementptr [%d x ptr], ptr %s, i64 0, i64 %d",
-		fnPtrSlot, len(iface.methods), vtable, slot,
-	))
+	emitter.body = append(emitter.body, mirGEPArrayElementText(fnPtrSlot, strconv.Itoa(len(iface.methods)), vtable, strconv.Itoa(slot)))
 	fnPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, fnPtrSlot))
+	emitter.body = append(emitter.body, mirLoadPtrText(fnPtr, fnPtrSlot))
 	callArgList := fmt.Sprintf("ptr %s", dataPtr)
 	for _, p := range argPairs {
 		callArgList += fmt.Sprintf(", %s %s", p[0], p[1])
 	}
 	ret := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = call %s %s(%s)",
-		ret, retTyp, fnPtr, callArgList,
-	))
+	emitter.body = append(emitter.body, mirCallTypedFnPtrText(ret, retTyp, fnPtr, callArgList))
 	g.takeOstyEmitter(emitter)
 	return value{typ: retTyp, ref: ret}, true, nil
 }

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2105,10 +2105,7 @@ type resultPatternInfo struct {
 }
 
 func resultVariantName(tag int) string {
-	if tag == 1 {
-		return "Err"
-	}
-	return "Ok"
+	return mirResultVariantName(tag)
 }
 
 func (g *generator) matchResultPattern(info builtinResultType, pattern ast.Pattern) (resultPatternInfo, bool, error) {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -457,8 +457,8 @@ func (g *generator) allocLoopSafepointCounter(emitter *LlvmEmitter) string {
 		return ""
 	}
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", slot))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 0, ptr %s", slot))
+	emitter.body = append(emitter.body, mirAllocaI64Text(slot))
+	emitter.body = append(emitter.body, mirStoreI64ZeroText(slot))
 	return slot
 }
 
@@ -474,21 +474,21 @@ func (g *generator) emitLoopSafepoint(emitter *LlvmEmitter, counterSlot string) 
 		return
 	}
 	count := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", count, counterSlot))
+	emitter.body = append(emitter.body, mirLoadI64Text(count, counterSlot))
 	next := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", next, count))
+	emitter.body = append(emitter.body, mirAddI64OneText(next, count))
 	shouldPoll := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, %d", shouldPoll, next, loopSafepointStride))
+	emitter.body = append(emitter.body, mirICmpEqI64LiteralText(shouldPoll, next, strconv.FormatInt(loopSafepointStride, 10)))
 	stored := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 0, i64 %s", stored, shouldPoll, next))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", stored, counterSlot))
+	emitter.body = append(emitter.body, mirSelectI64LiteralLhsText(stored, shouldPoll, "0", next))
+	emitter.body = append(emitter.body, mirStoreI64Text(stored, counterSlot))
 	pollLabel := llvmNextLabel(emitter, "gc.loop.poll")
 	afterLabel := llvmNextLabel(emitter, "gc.loop.after")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", shouldPoll, pollLabel, afterLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", pollLabel))
+	emitter.body = append(emitter.body, mirBrCondText(shouldPoll, pollLabel, afterLabel))
+	emitter.body = append(emitter.body, mirLabelText(pollLabel))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", afterLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", afterLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(afterLabel))
+	emitter.body = append(emitter.body, mirLabelText(afterLabel))
 }
 
 func llvmZeroValue(typ string) value {
@@ -1034,7 +1034,7 @@ func (g *generator) leaveBlock() {
 
 func (g *generator) branchTo(label string) {
 	emitter := g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", label))
+	emitter.body = append(emitter.body, mirBrUncondText(label))
 	g.takeOstyEmitter(emitter)
 	g.leaveBlock()
 }
@@ -1455,13 +1455,7 @@ func (g *generator) safepointRootAddress(emitter *LlvmEmitter, root gcSafepointR
 	currentType := root.slot.typ
 	for _, index := range root.path {
 		fieldPtr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d",
-			fieldPtr,
-			currentType,
-			addr,
-			index,
-		))
+		emitter.body = append(emitter.body, mirGEPInboundsFieldText(fieldPtr, currentType, addr, strconv.Itoa(index)))
 		nextType, ok := g.aggregateFieldType(currentType, index)
 		if !ok {
 			return addr
@@ -1499,13 +1493,7 @@ func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
 		currentType = typ
 		for _, index := range path {
 			fieldPtr := fmt.Sprintf("%%trace.field.%d.%d", len(body), index)
-			body = append(body, fmt.Sprintf(
-				"  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d",
-				fieldPtr,
-				currentType,
-				addr,
-				index,
-			))
+			body = append(body, mirGEPInboundsFieldText(fieldPtr, currentType, addr, strconv.Itoa(index)))
 			nextType, ok := g.aggregateFieldType(currentType, index)
 			if !ok {
 				currentType = ""
@@ -1517,7 +1505,7 @@ func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
 		if currentType == "" {
 			continue
 		}
-		body = append(body, fmt.Sprintf("  call void @osty.gc.mark_slot_v1(ptr %s)", addr))
+		body = append(body, mirGCMarkSlotText(addr))
 	}
 	body = append(body, "  ret void")
 	g.traceHelperDefs = append(g.traceHelperDefs, llvmRenderFunction("void", name, []*LlvmParam{llvmParam("value.addr", "ptr")}, body))
@@ -1526,8 +1514,8 @@ func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
 
 func (g *generator) spillValueAddress(emitter *LlvmEmitter, prefix string, v value) string {
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, v.typ))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", v.typ, v.ref, slot))
+	emitter.body = append(emitter.body, mirAllocaText(slot, v.typ))
+	emitter.body = append(emitter.body, mirStoreText(v.typ, v.ref, slot))
 	return slot
 }
 
@@ -1544,9 +1532,9 @@ func (g *generator) emitTypeSize(emitter *LlvmEmitter, typ string) *LlvmValue {
 		return llvmI64("1")
 	}
 	ptr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", ptr, typ))
+	emitter.body = append(emitter.body, mirGEPSizeofText(ptr, typ))
 	out := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", out, ptr))
+	emitter.body = append(emitter.body, mirPtrToIntI64Text(out, ptr))
 	return llvmI64(out)
 }
 

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -1408,10 +1408,7 @@ func prependRootIndex(index int, paths [][]int) [][]int {
 }
 
 func llvmPointerOperand(name string) string {
-	if name == "" || name == "null" || strings.HasPrefix(name, "@") || strings.HasPrefix(name, "%") {
-		return name
-	}
-	return "@" + name
+	return mirLlvmPointerOperand(name)
 }
 
 func (g *generator) visibleSafepointRoots() []gcSafepointRoot {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -2158,10 +2158,7 @@ func legacyTypeExpr(name string, start, end token.Pos) ast.Expr {
 }
 
 func splitQualifiedName(name string) []string {
-	if name == "" {
-		return nil
-	}
-	return strings.Split(name, ".")
+	return mirSplitQualifiedName(name)
 }
 
 func legacySpan(span ostyir.Span) (token.Pos, token.Pos) {

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -7980,3 +7980,97 @@ func mirDataLayoutFor(target string) string {
 	}
 	return ""
 }
+
+// §19 — pure string helpers ported from
+// internal/llvmgen/{expr,generator,ir_module,stdlib_shim,stmt,type}.go.
+
+// Osty: mirResultVariantName
+func mirResultVariantName(tag int) string {
+	if tag == 1 {
+		return "Err"
+	}
+	return "Ok"
+}
+
+// Osty: mirLlvmPointerOperand
+func mirLlvmPointerOperand(name string) string {
+	if name == "" || name == "null" {
+		return name
+	}
+	if llvmStrings.HasPrefix(name, "@") || llvmStrings.HasPrefix(name, "%") {
+		return name
+	}
+	return "@" + name
+}
+
+// Osty: mirSplitQualifiedName
+func mirSplitQualifiedName(name string) []string {
+	if name == "" {
+		return nil
+	}
+	return llvmStrings.Split(name, ".")
+}
+
+// Osty: mirScalarSomeBoxByteSize
+func mirScalarSomeBoxByteSize(typ string) int {
+	if typ == "i64" || typ == "double" {
+		return 8
+	}
+	if typ == "i32" {
+		return 4
+	}
+	if typ == "i8" || typ == "i1" {
+		return 1
+	}
+	return 0
+}
+
+// Osty: mirLlvmBuiltinAggregateName
+func mirLlvmBuiltinAggregateName(prefix string, parts []string) string {
+	names := make([]string, 0, len(parts)+1)
+	names = append(names, prefix)
+	for _, p := range parts {
+		names = append(names, mirLLVMBuiltinAggregatePart(p))
+	}
+	return "%" + llvmStrings.Join(names, ".")
+}
+
+// Osty: mirLlvmResultTypeName
+func mirLlvmResultTypeName(okTyp, errTyp string) string {
+	return mirLlvmBuiltinAggregateName("Result", []string{okTyp, errTyp})
+}
+
+// Osty: mirLlvmTupleTypeName
+func mirLlvmTupleTypeName(elemTypes []string) string {
+	return mirLlvmBuiltinAggregateName("Tuple", elemTypes)
+}
+
+// Osty: mirNormalizeAssertExprText
+func mirNormalizeAssertExprText(text string) string {
+	var buf llvmStrings.Builder
+	prevSpace := false
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+		if ch == '\n' || ch == '\r' || ch == '\t' {
+			ch = ' '
+		}
+		if ch == ' ' {
+			if prevSpace {
+				continue
+			}
+			prevSpace = true
+		} else {
+			prevSpace = false
+		}
+		buf.WriteByte(ch)
+	}
+	out := buf.String()
+	lo, hi := 0, len(out)
+	if hi > 0 && out[0] == ' ' {
+		lo = 1
+	}
+	if hi > lo && out[hi-1] == ' ' {
+		hi--
+	}
+	return out[lo:hi]
+}

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -8074,3 +8074,548 @@ func mirNormalizeAssertExprText(text string) string {
 	}
 	return out[lo:hi]
 }
+
+// §20 — Text variants of common Line builders, for `body []string`
+// callers that join entries on "\n". Same shapes as the Line builders
+// minus the trailing "\n"; lets emitter sites in expr.go / stmt.go /
+// generator.go drop fmt.Sprintf("  %s = ...") in favor of named
+// helpers without flipping the surrounding append-then-join idiom.
+
+// Osty: mirAllocaText
+func mirAllocaText(reg, ty string) string {
+	return "  " + reg + " = alloca " + ty
+}
+
+// Osty: mirAllocaI64Text
+func mirAllocaI64Text(reg string) string {
+	return "  " + reg + " = alloca i64"
+}
+
+// Osty: mirAllocaPtrText
+func mirAllocaPtrText(reg string) string {
+	return "  " + reg + " = alloca ptr"
+}
+
+// Osty: mirAllocaArrayPtrText
+func mirAllocaArrayPtrText(reg, n string) string {
+	return "  " + reg + " = alloca [" + n + " x ptr]"
+}
+
+// Osty: mirLoadText
+func mirLoadText(reg, ty, ptr string) string {
+	return "  " + reg + " = load " + ty + ", ptr " + ptr
+}
+
+// Osty: mirLoadI64Text
+func mirLoadI64Text(reg, ptr string) string {
+	return "  " + reg + " = load i64, ptr " + ptr
+}
+
+// Osty: mirLoadPtrText
+func mirLoadPtrText(reg, slot string) string {
+	return "  " + reg + " = load ptr, ptr " + slot
+}
+
+// Osty: mirStoreText
+func mirStoreText(ty, val, slot string) string {
+	return "  store " + ty + " " + val + ", ptr " + slot
+}
+
+// Osty: mirStoreI64Text
+func mirStoreI64Text(val, slot string) string {
+	return "  store i64 " + val + ", ptr " + slot
+}
+
+// Osty: mirStoreI8Text
+func mirStoreI8Text(val, slot string) string {
+	return "  store i8 " + val + ", ptr " + slot
+}
+
+// Osty: mirStorePtrText
+func mirStorePtrText(val, slot string) string {
+	return "  store ptr " + val + ", ptr " + slot
+}
+
+// Osty: mirStorePtrNullText
+func mirStorePtrNullText(slot string) string {
+	return "  store ptr null, ptr " + slot
+}
+
+// Osty: mirStoreI64ZeroText
+func mirStoreI64ZeroText(slot string) string {
+	return "  store i64 0, ptr " + slot
+}
+
+// Osty: mirBrCondText
+func mirBrCondText(cond, trueLabel, falseLabel string) string {
+	return "  br i1 " + cond + ", label %" + trueLabel + ", label %" + falseLabel
+}
+
+// Osty: mirBrUncondText
+func mirBrUncondText(label string) string {
+	return "  br label %" + label
+}
+
+// Osty: mirLabelText
+func mirLabelText(name string) string {
+	return name + ":"
+}
+
+// Osty: mirRetText
+func mirRetText(ty, val string) string {
+	return "  ret " + ty + " " + val
+}
+
+// Osty: mirRetVoidText
+func mirRetVoidText() string {
+	return "  ret void"
+}
+
+// Osty: mirICmpEqText
+func mirICmpEqText(reg, ty, lhs, rhs string) string {
+	return "  " + reg + " = icmp eq " + ty + " " + lhs + ", " + rhs
+}
+
+// Osty: mirICmpEqI64Text
+func mirICmpEqI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = icmp eq i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirICmpEqPtrNullText
+func mirICmpEqPtrNullText(reg, ptr string) string {
+	return "  " + reg + " = icmp eq ptr " + ptr + ", null"
+}
+
+// Osty: mirICmpText
+func mirICmpText(reg, pred, ty, lhs, rhs string) string {
+	return "  " + reg + " = icmp " + pred + " " + ty + " " + lhs + ", " + rhs
+}
+
+// Osty: mirICmpSGTI64ZeroText
+func mirICmpSGTI64ZeroText(reg, lhs string) string {
+	return "  " + reg + " = icmp sgt i64 " + lhs + ", 0"
+}
+
+// Osty: mirICmpSLTI64Text
+func mirICmpSLTI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = icmp slt i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirICmpSGEI64ZeroText
+func mirICmpSGEI64ZeroText(reg, lhs string) string {
+	return "  " + reg + " = icmp sge i64 " + lhs + ", 0"
+}
+
+// Osty: mirICmpSLTI64LiteralText
+func mirICmpSLTI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = icmp slt i64 " + lhs + ", " + lit
+}
+
+// Osty: mirICmpSGTI64LiteralText
+func mirICmpSGTI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = icmp sgt i64 " + lhs + ", " + lit
+}
+
+// Osty: mirICmpEqI64LiteralText
+func mirICmpEqI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = icmp eq i64 " + lhs + ", " + lit
+}
+
+// Osty: mirICmpEqI32LiteralText
+func mirICmpEqI32LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = icmp eq i32 " + lhs + ", " + lit
+}
+
+// Osty: mirICmpULTI32LiteralText
+func mirICmpULTI32LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = icmp ult i32 " + lhs + ", " + lit
+}
+
+// Osty: mirICmpEqPtrText
+func mirICmpEqPtrText(reg, pred, lhs string) string {
+	return "  " + reg + " = icmp " + pred + " ptr " + lhs + ", null"
+}
+
+// Osty: mirAddI64OneText
+func mirAddI64OneText(reg, lhs string) string {
+	return "  " + reg + " = add i64 " + lhs + ", 1"
+}
+
+// Osty: mirAddI64Text
+func mirAddI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = add i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirAddI32LiteralText
+func mirAddI32LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = add i32 " + lhs + ", " + lit
+}
+
+// Osty: mirSubI64Text
+func mirSubI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = sub i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirSubI32LiteralText
+func mirSubI32LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = sub i32 " + lhs + ", " + lit
+}
+
+// Osty: mirMulI64Text
+func mirMulI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = mul i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirMulI64LiteralText
+func mirMulI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = mul i64 " + lhs + ", " + lit
+}
+
+// Osty: mirSDivI64Text
+func mirSDivI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = sdiv i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirSDivI64LiteralText
+func mirSDivI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = sdiv i64 " + lhs + ", " + lit
+}
+
+// Osty: mirOrI1Text
+func mirOrI1Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = or i1 " + lhs + ", " + rhs
+}
+
+// Osty: mirAndI1Text
+func mirAndI1Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = and i1 " + lhs + ", " + rhs
+}
+
+// Osty: mirXorI1NegText
+func mirXorI1NegText(reg, src string) string {
+	return "  " + reg + " = xor i1 " + src + ", true"
+}
+
+// Osty: mirSelectI64Text
+func mirSelectI64Text(reg, cond, lhs, rhs string) string {
+	return "  " + reg + " = select i1 " + cond + ", i64 " + lhs + ", i64 " + rhs
+}
+
+// Osty: mirSelectI32Text
+func mirSelectI32Text(reg, cond, lhs, rhs string) string {
+	return "  " + reg + " = select i1 " + cond + ", i32 " + lhs + ", i32 " + rhs
+}
+
+// Osty: mirSelectI64LiteralRhsText
+func mirSelectI64LiteralRhsText(reg, cond, lhs, lit string) string {
+	return "  " + reg + " = select i1 " + cond + ", i64 " + lhs + ", i64 " + lit
+}
+
+// Osty: mirSelectI64LiteralLhsText
+func mirSelectI64LiteralLhsText(reg, cond, lit, rhs string) string {
+	return "  " + reg + " = select i1 " + cond + ", i64 " + lit + ", i64 " + rhs
+}
+
+// Osty: mirSelectTypedText
+func mirSelectTypedText(reg, ty, cond, lhs, rhs string) string {
+	return "  " + reg + " = select i1 " + cond + ", " + ty + " " + lhs + ", " + ty + " " + rhs
+}
+
+// Osty: mirZExtI8ToI32Text
+func mirZExtI8ToI32Text(reg, src string) string {
+	return "  " + reg + " = zext i8 " + src + " to i32"
+}
+
+// Osty: mirZExtI8ToI64Text
+func mirZExtI8ToI64Text(reg, src string) string {
+	return "  " + reg + " = zext i8 " + src + " to i64"
+}
+
+// Osty: mirZExtI32ToI64Text
+func mirZExtI32ToI64Text(reg, src string) string {
+	return "  " + reg + " = zext i32 " + src + " to i64"
+}
+
+// Osty: mirTruncI64ToI8Text
+func mirTruncI64ToI8Text(reg, src string) string {
+	return "  " + reg + " = trunc i64 " + src + " to i8"
+}
+
+// Osty: mirTruncI64ToI32Text
+func mirTruncI64ToI32Text(reg, src string) string {
+	return "  " + reg + " = trunc i64 " + src + " to i32"
+}
+
+// Osty: mirPtrToIntI64Text
+func mirPtrToIntI64Text(reg, ptr string) string {
+	return "  " + reg + " = ptrtoint ptr " + ptr + " to i64"
+}
+
+// Osty: mirGEPInboundsZeroText
+func mirGEPInboundsZeroText(reg, ty, basePtr string) string {
+	return "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr + ", i32 0, i32 0"
+}
+
+// Osty: mirGEPInboundsFieldText
+func mirGEPInboundsFieldText(reg, ty, basePtr, idx string) string {
+	return "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr + ", i32 0, i32 " + idx
+}
+
+// Osty: mirGEPInboundsI8Text
+func mirGEPInboundsI8Text(reg, basePtr, offDigits string) string {
+	return "  " + reg + " = getelementptr i8, ptr " + basePtr + ", i64 " + offDigits
+}
+
+// Osty: mirGEPSizeofText
+func mirGEPSizeofText(reg, ty string) string {
+	return "  " + reg + " = getelementptr " + ty + ", ptr null, i32 1"
+}
+
+// Osty: mirGEPArrayElementText
+func mirGEPArrayElementText(reg, n, arr, idx string) string {
+	return "  " + reg + " = getelementptr [" + n + " x ptr], ptr " + arr + ", i64 0, i64 " + idx
+}
+
+// Osty: mirCallRuntimeI64NoArgsText
+func mirCallRuntimeI64NoArgsText(reg, symbol string) string {
+	return "  " + reg + " = call i64 @" + symbol + "()"
+}
+
+// Osty: mirCallRuntimeVoidOneArgText
+func mirCallRuntimeVoidOneArgText(symbol, arg string) string {
+	return "  call void @" + symbol + "(" + arg + ")"
+}
+
+// Osty: mirCallRuntimeVoidPtrText
+func mirCallRuntimeVoidPtrText(symbol, arg string) string {
+	return "  call void @" + symbol + "(ptr " + arg + ")"
+}
+
+// Osty: mirCallRuntimeVoidPtrI64Text
+func mirCallRuntimeVoidPtrI64Text(symbol, a, n string) string {
+	return "  call void @" + symbol + "(ptr " + a + ", i64 " + n + ")"
+}
+
+// Osty: mirCallRuntimeVoidPtrI64I64Text
+func mirCallRuntimeVoidPtrI64I64Text(symbol, a, n, m string) string {
+	return "  call void @" + symbol + "(ptr " + a + ", i64 " + n + ", i64 " + m + ")"
+}
+
+// Osty: mirCallRuntimePtrI64Text
+func mirCallRuntimePtrI64Text(reg, symbol, n string) string {
+	return "  " + reg + " = call ptr @" + symbol + "(i64 " + n + ")"
+}
+
+// Osty: mirCallRuntimePtrI64PtrText
+func mirCallRuntimePtrI64PtrText(reg, symbol, n, p string) string {
+	return "  " + reg + " = call ptr @" + symbol + "(i64 " + n + ", ptr " + p + ")"
+}
+
+// Osty: mirGCMarkSlotText
+func mirGCMarkSlotText(addr string) string {
+	return "  call void @osty.gc.mark_slot_v1(ptr " + addr + ")"
+}
+
+// Osty: mirInsertValueIfaceCtorText
+func mirInsertValueIfaceCtorText(reg, slot string) string {
+	return "  " + reg + " = insertvalue %osty.iface zeroinitializer, ptr " + slot + ", 0"
+}
+
+// Osty: mirInsertValueIfaceVtableText
+func mirInsertValueIfaceVtableText(reg, iface, vtable string) string {
+	return "  " + reg + " = insertvalue %osty.iface " + iface + ", ptr " + vtable + ", 1"
+}
+
+// Osty: mirExtractValueIfacePtrText
+func mirExtractValueIfacePtrText(reg, iface string) string {
+	return "  " + reg + " = extractvalue %osty.iface " + iface + ", 0"
+}
+
+// Osty: mirExtractValueIfaceVtableText
+func mirExtractValueIfaceVtableText(reg, iface string) string {
+	return "  " + reg + " = extractvalue %osty.iface " + iface + ", 1"
+}
+
+// Osty: mirPhiPtrFromValueOrNullText
+func mirPhiPtrFromValueOrNullText(reg, val, valLabel, nullLabel string) string {
+	return "  " + reg + " = phi ptr [ " + val + ", %" + valLabel +
+		" ], [ null, %" + nullLabel + " ]"
+}
+
+// Osty: mirPhiI64FromValueOrZeroText
+func mirPhiI64FromValueOrZeroText(reg, val, valLabel, zeroLabel string) string {
+	return "  " + reg + " = phi i64 [ " + val + ", %" + valLabel +
+		" ], [ 0, %" + zeroLabel + " ]"
+}
+
+// Osty: mirPhiTypedTwoEdgeText
+func mirPhiTypedTwoEdgeText(reg, ty, a, la, b, lb string) string {
+	return "  " + reg + " = phi " + ty + " [ " + a + ", %" + la +
+		" ], [ " + b + ", %" + lb + " ]"
+}
+
+// Osty: mirGEPInboundsRawIndicesText
+func mirGEPInboundsRawIndicesText(reg, ty, basePtr, indices string) string {
+	return "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr +
+		", " + indices
+}
+
+// Osty: mirGEPInboundsNullRawIndicesText
+func mirGEPInboundsNullRawIndicesText(reg, ty, indices string) string {
+	return "  " + reg + " = getelementptr inbounds " + ty + ", ptr null, " + indices
+}
+
+// Osty: mirCallTypedFnPtrText
+func mirCallTypedFnPtrText(reg, retTyp, fnPtr, argList string) string {
+	return "  " + reg + " = call " + retTyp + " " + fnPtr + "(" + argList + ")"
+}
+
+// Osty: mirCallI1FromArgsText
+func mirCallI1FromArgsText(reg, symbol, argList string) string {
+	return "  " + reg + " = call i1 @" + symbol + "(" + argList + ")"
+}
+
+// Osty: mirCallTypedFromArgsText
+func mirCallTypedFromArgsText(reg, retTyp, symbol, argList string) string {
+	return "  " + reg + " = call " + retTyp + " @" + symbol + "(" + argList + ")"
+}
+
+// Osty: mirICmpEqI32ZeroText
+func mirICmpEqI32ZeroText(reg, lhs string) string {
+	return "  " + reg + " = icmp eq i32 " + lhs + ", 0"
+}
+
+// Osty: mirICmpNEI64ZeroText
+func mirICmpNEI64ZeroText(reg, lhs string) string {
+	return "  " + reg + " = icmp ne i64 " + lhs + ", 0"
+}
+
+// Osty: mirICmpEqI1Text
+func mirICmpEqI1Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = icmp eq i1 " + lhs + ", " + rhs
+}
+
+// Osty: mirAddI64LiteralText
+func mirAddI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = add i64 " + lhs + ", " + lit
+}
+
+// Osty: mirSubI64LiteralText
+func mirSubI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = sub i64 " + lhs + ", " + lit
+}
+
+// Osty: mirSubI64OneText
+func mirSubI64OneText(reg, lhs string) string {
+	return "  " + reg + " = sub i64 " + lhs + ", 1"
+}
+
+// Osty: mirShlI64Text
+func mirShlI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = shl i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirShlI64LiteralText
+func mirShlI64LiteralText(reg, lhs, lit string) string {
+	return "  " + reg + " = shl i64 " + lhs + ", " + lit
+}
+
+// Osty: mirLShrI64Text
+func mirLShrI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = lshr i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirAShrI64Text
+func mirAShrI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = ashr i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirAndI64Text
+func mirAndI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = and i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirOrI64Text
+func mirOrI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = or i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirXorI64Text
+func mirXorI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = xor i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirSremI64Text
+func mirSremI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = srem i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirURemI64Text
+func mirURemI64Text(reg, lhs, rhs string) string {
+	return "  " + reg + " = urem i64 " + lhs + ", " + rhs
+}
+
+// Osty: mirFAddText
+func mirFAddText(reg, lhs, rhs string) string {
+	return "  " + reg + " = fadd double " + lhs + ", " + rhs
+}
+
+// Osty: mirFSubText
+func mirFSubText(reg, lhs, rhs string) string {
+	return "  " + reg + " = fsub double " + lhs + ", " + rhs
+}
+
+// Osty: mirFMulText
+func mirFMulText(reg, lhs, rhs string) string {
+	return "  " + reg + " = fmul double " + lhs + ", " + rhs
+}
+
+// Osty: mirFDivText
+func mirFDivText(reg, lhs, rhs string) string {
+	return "  " + reg + " = fdiv double " + lhs + ", " + rhs
+}
+
+// Osty: mirFCmpOEqText
+func mirFCmpOEqText(reg, lhs, rhs string) string {
+	return "  " + reg + " = fcmp oeq double " + lhs + ", " + rhs
+}
+
+// Osty: mirFCmpText
+func mirFCmpText(reg, pred, lhs, rhs string) string {
+	return "  " + reg + " = fcmp " + pred + " double " + lhs + ", " + rhs
+}
+
+// Osty: mirSIToFPText
+func mirSIToFPText(reg, src string) string {
+	return "  " + reg + " = sitofp i64 " + src + " to double"
+}
+
+// Osty: mirFPToSIText
+func mirFPToSIText(reg, src string) string {
+	return "  " + reg + " = fptosi double " + src + " to i64"
+}
+
+// Osty: mirAllocaI8Text
+func mirAllocaI8Text(reg string) string {
+	return "  " + reg + " = alloca i8"
+}
+
+// Osty: mirAllocaDoubleText
+func mirAllocaDoubleText(reg string) string {
+	return "  " + reg + " = alloca double"
+}
+
+// Osty: mirLoadDoubleText
+func mirLoadDoubleText(reg, slot string) string {
+	return "  " + reg + " = load double, ptr " + slot
+}
+
+// Osty: mirLoadI8Text
+func mirLoadI8Text(reg, slot string) string {
+	return "  " + reg + " = load i8, ptr " + slot
+}
+
+// Osty: mirStoreDoubleText
+func mirStoreDoubleText(val, slot string) string {
+	return "  store double " + val + ", ptr " + slot
+}

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -1266,13 +1266,6 @@ func (g *generator) emitBuiltinOptionSomeCall(call *ast.CallExpr) (value, bool, 
 // payload, or (0, false) when the type is not a recognized primitive
 // the backend already materializes at this width.
 func scalarSomeBoxByteSize(typ string) (int, bool) {
-	switch typ {
-	case "i64", "double":
-		return 8, true
-	case "i32":
-		return 4, true
-	case "i8", "i1":
-		return 1, true
-	}
-	return 0, false
+	size := mirScalarSomeBoxByteSize(typ)
+	return size, size > 0
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -512,12 +512,12 @@ func (g *generator) boxInterfaceValue(ifaceType ast.Type, v value) (value, error
 	}
 	emitter := g.toOstyEmitter()
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, v.typ))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", v.typ, v.ref, slot))
+	emitter.body = append(emitter.body, mirAllocaText(slot, v.typ))
+	emitter.body = append(emitter.body, mirStoreText(v.typ, v.ref, slot))
 	step1 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface zeroinitializer, ptr %s, 0", step1, slot))
+	emitter.body = append(emitter.body, mirInsertValueIfaceCtorText(step1, slot))
 	step2 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface %s, ptr %s, 1", step2, step1, vtableSym))
+	emitter.body = append(emitter.body, mirInsertValueIfaceVtableText(step2, step1, vtableSym))
 	g.takeOstyEmitter(emitter)
 	// Phase 6e: tag the boxed value with its interface AST type so
 	// downstream slots (e.g. `let mut s: Iface = …`) remember the
@@ -906,8 +906,7 @@ func (g *generator) emitListAssignValue(base, index, v value) error {
 	if listUsesTypedRuntime(base.listElemTyp) {
 		symbol := listRuntimeSetSymbol(base.listElemTyp)
 		g.declareRuntimeSymbol(symbol, "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: base.listElemTyp}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			symbol,
 			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), toOstyValue(v)}),
 		))
@@ -916,8 +915,7 @@ func (g *generator) emitListAssignValue(base, index, v value) error {
 		addr := g.spillValueAddress(emitter, "list.set", v)
 		sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
 		g.declareRuntimeSymbol(listRuntimeSetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeSetBytesSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: addr}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 		))
@@ -947,11 +945,10 @@ func (g *generator) emitListElementValue(base, index value) (value, error) {
 	traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
 	emitter := g.toOstyEmitter()
 	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.listElemTyp))
+	emitter.body = append(emitter.body, mirAllocaText(slot, base.listElemTyp))
 	sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
 	g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 		listRuntimeGetBytesSymbol(),
 		llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 	))
@@ -1052,7 +1049,7 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	llvmRangeEnd(emitter, loop)
 	g.attachVectorizeMD(emitter, loop.condLabel)
@@ -1068,15 +1065,15 @@ func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
 	bodyLabel := llvmNextLabel(emitter, "for.body")
 	continueLabel := llvmNextLabel(emitter, "for.cont")
 	endLabel := llvmNextLabel(emitter, "for.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", condLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(condLabel))
+	emitter.body = append(emitter.body, mirLabelText(condLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(condLabel)
 
 	if stmt.Iter == nil {
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", bodyLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+		emitter.body = append(emitter.body, mirBrUncondText(bodyLabel))
+		emitter.body = append(emitter.body, mirLabelText(bodyLabel))
 		g.takeOstyEmitter(emitter)
 	} else {
 		cond, err := g.emitExpr(stmt.Iter)
@@ -1087,13 +1084,8 @@ func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
 			return unsupportedf("type-system", "for condition type %s, want i1", cond.typ)
 		}
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  br i1 %s, label %%%s, label %%%s",
-			toOstyValue(cond).name,
-			bodyLabel,
-			endLabel,
-		))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+		emitter.body = append(emitter.body, mirBrCondText(toOstyValue(cond).name, bodyLabel, endLabel))
+		emitter.body = append(emitter.body, mirLabelText(bodyLabel))
 		g.takeOstyEmitter(emitter)
 	}
 	g.enterBlock(bodyLabel)
@@ -1121,14 +1113,14 @@ func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
 	}
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(continueLabel)
 	emitter = g.toOstyEmitter()
 	g.emitLoopSafepoint(emitter, loopSafepointSlot)
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(condLabel))
 	g.attachVectorizeMD(emitter, condLabel)
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	return nil
@@ -1150,8 +1142,8 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 	bodyLabel := llvmNextLabel(emitter, "for.body")
 	continueLabel := llvmNextLabel(emitter, "for.cont")
 	endLabel := llvmNextLabel(emitter, "for.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", condLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(condLabel))
+	emitter.body = append(emitter.body, mirLabelText(condLabel))
 	g.takeOstyEmitter(emitter)
 
 	scrutinee, err := g.emitExpr(stmt.Iter)
@@ -1163,8 +1155,8 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 		return err
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, bodyLabel, endLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.name, bodyLabel, endLabel))
+	emitter.body = append(emitter.body, mirLabelText(bodyLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(bodyLabel)
 
@@ -1200,14 +1192,14 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 	}
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(continueLabel)
 	emitter = g.toOstyEmitter()
 	g.emitLoopSafepoint(emitter, loopSafepointSlot)
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(condLabel))
 	g.attachVectorizeMD(emitter, condLabel)
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	return nil
@@ -1499,8 +1491,8 @@ func (g *generator) emitTestingExpect(call *ast.CallExpr, wantErr bool) (value, 
 	cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: wantTag}))
 	okLabel := llvmNextLabel(emitter, "test.expect.ok")
 	failLabel := llvmNextLabel(emitter, "test.expect.fail")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, okLabel, failLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", failLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.name, okLabel, failLabel))
+	emitter.body = append(emitter.body, mirLabelText(failLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = failLabel
 	exprText := g.sourceSpanText(call.Args[0].Value)
@@ -1513,7 +1505,7 @@ func (g *generator) emitTestingExpect(call *ast.CallExpr, wantErr bool) (value, 
 	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
 	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
 	emitter.body = append(emitter.body, "  unreachable")
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", okLabel))
+	emitter.body = append(emitter.body, mirLabelText(okLabel))
 	payload := llvmExtractValue(emitter, toOstyValue(result), payloadType, payloadIndex)
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = okLabel
@@ -1602,19 +1594,19 @@ func (g *generator) emitTestingBenchmarkStmt(call *ast.CallExpr) error {
 
 	emitter := g.toOstyEmitter()
 	effectiveN := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", effectiveN, nslot))
+	emitter.body = append(emitter.body, mirLoadI64Text(effectiveN, nslot))
 	// Warmup: clamp(N/10, 1, 1000). Cold-cache / branch-predictor misses
 	// get amortized before the first clock sample.
 	warmupDiv := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sdiv i64 %s, 10", warmupDiv, effectiveN))
+	emitter.body = append(emitter.body, mirSDivI64LiteralText(warmupDiv, effectiveN, "10"))
 	warmupGE1Cond := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sgt i64 %s, 0", warmupGE1Cond, warmupDiv))
+	emitter.body = append(emitter.body, mirICmpSGTI64ZeroText(warmupGE1Cond, warmupDiv))
 	warmupGE1 := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 1", warmupGE1, warmupGE1Cond, warmupDiv))
+	emitter.body = append(emitter.body, mirSelectI64LiteralRhsText(warmupGE1, warmupGE1Cond, warmupDiv, "1"))
 	warmupCapCond := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp slt i64 %s, 1000", warmupCapCond, warmupGE1))
+	emitter.body = append(emitter.body, mirICmpSLTI64LiteralText(warmupCapCond, warmupGE1, "1000"))
 	warmupTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 1000", warmupTemp, warmupCapCond, warmupGE1))
+	emitter.body = append(emitter.body, mirSelectI64LiteralRhsText(warmupTemp, warmupCapCond, warmupGE1, "1000"))
 	g.takeOstyEmitter(emitter)
 
 	if err := g.emitBenchInlineLoop(stmts, value{typ: "i64", ref: warmupTemp}, "bench.warm", ""); err != nil {
@@ -1630,11 +1622,11 @@ func (g *generator) emitTestingBenchmarkStmt(call *ast.CallExpr) error {
 	g.declareRuntimeSymbol(benchSamplesFreeSymbol(), "void", []paramInfo{{typ: "ptr"}})
 	emitter = g.toOstyEmitter()
 	finalN := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", finalN, nslot))
+	emitter.body = append(emitter.body, mirLoadI64Text(finalN, nslot))
 	samplesPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @%s(i64 %s)", samplesPtr, benchSamplesNewSymbol(), finalN))
+	emitter.body = append(emitter.body, mirCallRuntimePtrI64Text(samplesPtr, benchSamplesNewSymbol(), finalN))
 	startTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", startTemp, benchClockRuntimeSymbol()))
+	emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(startTemp, benchClockRuntimeSymbol()))
 	g.takeOstyEmitter(emitter)
 
 	if err := g.emitBenchInlineLoop(stmts, value{typ: "i64", ref: finalN}, "bench.run", samplesPtr); err != nil {
@@ -1643,26 +1635,26 @@ func (g *generator) emitTestingBenchmarkStmt(call *ast.CallExpr) error {
 
 	emitter = g.toOstyEmitter()
 	endTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", endTemp, benchClockRuntimeSymbol()))
+	emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(endTemp, benchClockRuntimeSymbol()))
 	totalTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i64 %s, %s", totalTemp, endTemp, startTemp))
+	emitter.body = append(emitter.body, mirSubI64Text(totalTemp, endTemp, startTemp))
 	finalNReload := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", finalNReload, nslot))
+	emitter.body = append(emitter.body, mirLoadI64Text(finalNReload, nslot))
 	nonZero := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sgt i64 %s, 0", nonZero, finalNReload))
+	emitter.body = append(emitter.body, mirICmpSGTI64ZeroText(nonZero, finalNReload))
 	divLabel := llvmNextLabel(emitter, "bench.div")
 	skipLabel := llvmNextLabel(emitter, "bench.skip")
 	joinLabel := llvmNextLabel(emitter, "bench.join")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", nonZero, divLabel, skipLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", divLabel))
+	emitter.body = append(emitter.body, mirBrCondText(nonZero, divLabel, skipLabel))
+	emitter.body = append(emitter.body, mirLabelText(divLabel))
 	divTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sdiv i64 %s, %s", divTemp, totalTemp, finalNReload))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", joinLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", skipLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", joinLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", joinLabel))
+	emitter.body = append(emitter.body, mirSDivI64Text(divTemp, totalTemp, finalNReload))
+	emitter.body = append(emitter.body, mirBrUncondText(joinLabel))
+	emitter.body = append(emitter.body, mirLabelText(skipLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(joinLabel))
+	emitter.body = append(emitter.body, mirLabelText(joinLabel))
 	avgTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi i64 [ %s, %%%s ], [ 0, %%%s ]", avgTemp, divTemp, divLabel, skipLabel))
+	emitter.body = append(emitter.body, mirPhiI64FromValueOrZeroText(avgTemp, divTemp, divLabel, skipLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = joinLabel
 	g.currentReachable = true
@@ -1698,8 +1690,8 @@ func (g *generator) emitTestingBenchmarkStmt(call *ast.CallExpr) error {
 	}
 	emitter = g.toOstyEmitter()
 	llvmPrintlnString(emitter, toOstyValue(msg))
-	emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(ptr %s, i64 %s)", benchSamplesReportSymbol(), samplesPtr, finalNReload))
-	emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(ptr %s)", benchSamplesFreeSymbol(), samplesPtr))
+	emitter.body = append(emitter.body, mirCallRuntimeVoidPtrI64Text(benchSamplesReportSymbol(), samplesPtr, finalNReload))
+	emitter.body = append(emitter.body, mirCallRuntimeVoidPtrText(benchSamplesFreeSymbol(), samplesPtr))
 	g.takeOstyEmitter(emitter)
 	return nil
 }
@@ -1727,18 +1719,18 @@ func benchTargetRuntimeSymbol() string { return mirRtBenchTargetNsSymbol() }
 func (g *generator) emitBenchAutoTuneN(stmts []ast.Stmt, declaredN string) (string, error) {
 	emitter := g.toOstyEmitter()
 	nslot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", nslot))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", declaredN, nslot))
+	emitter.body = append(emitter.body, mirAllocaI64Text(nslot))
+	emitter.body = append(emitter.body, mirStoreI64Text(declaredN, nslot))
 	target := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", target, benchTargetRuntimeSymbol()))
+	emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(target, benchTargetRuntimeSymbol()))
 	autoCond := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sgt i64 %s, 0", autoCond, target))
+	emitter.body = append(emitter.body, mirICmpSGTI64ZeroText(autoCond, target))
 	probeLabel := llvmNextLabel(emitter, "bench.probe")
 	afterLabel := llvmNextLabel(emitter, "bench.after_probe")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", autoCond, probeLabel, afterLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", probeLabel))
+	emitter.body = append(emitter.body, mirBrCondText(autoCond, probeLabel, afterLabel))
+	emitter.body = append(emitter.body, mirLabelText(probeLabel))
 	probeStart := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", probeStart, benchClockRuntimeSymbol()))
+	emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(probeStart, benchClockRuntimeSymbol()))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = probeLabel
 
@@ -1750,34 +1742,34 @@ func (g *generator) emitBenchAutoTuneN(stmts []ast.Stmt, declaredN string) (stri
 
 	emitter = g.toOstyEmitter()
 	probeEnd := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", probeEnd, benchClockRuntimeSymbol()))
+	emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(probeEnd, benchClockRuntimeSymbol()))
 	probeElapsed := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i64 %s, %s", probeElapsed, probeEnd, probeStart))
+	emitter.body = append(emitter.body, mirSubI64Text(probeElapsed, probeEnd, probeStart))
 	// Guard against 0-ns elapsed (clock resolution floor): treat as 1ns
 	// so the subsequent sdiv can't trap or explode.
 	elapsedPos := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sgt i64 %s, 0", elapsedPos, probeElapsed))
+	emitter.body = append(emitter.body, mirICmpSGTI64ZeroText(elapsedPos, probeElapsed))
 	elapsedSafe := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 1", elapsedSafe, elapsedPos, probeElapsed))
+	emitter.body = append(emitter.body, mirSelectI64LiteralRhsText(elapsedSafe, elapsedPos, probeElapsed, "1"))
 	targetScaled := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = mul i64 %s, %d", targetScaled, target, probeIters))
+	emitter.body = append(emitter.body, mirMulI64LiteralText(targetScaled, target, strconv.FormatInt(probeIters, 10)))
 	estRaw := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sdiv i64 %s, %s", estRaw, targetScaled, elapsedSafe))
+	emitter.body = append(emitter.body, mirSDivI64Text(estRaw, targetScaled, elapsedSafe))
 	estHead := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = mul i64 %s, 6", estHead, estRaw))
+	emitter.body = append(emitter.body, mirMulI64LiteralText(estHead, estRaw, "6"))
 	estAdj := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sdiv i64 %s, 5", estAdj, estHead))
+	emitter.body = append(emitter.body, mirSDivI64LiteralText(estAdj, estHead, "5"))
 	estFloorCond := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp slt i64 %s, 10", estFloorCond, estAdj))
+	emitter.body = append(emitter.body, mirICmpSLTI64LiteralText(estFloorCond, estAdj, "10"))
 	estFloored := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 10, i64 %s", estFloored, estFloorCond, estAdj))
+	emitter.body = append(emitter.body, mirSelectI64LiteralLhsText(estFloored, estFloorCond, "10", estAdj))
 	estCapCond := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp sgt i64 %s, 100000000", estCapCond, estFloored))
+	emitter.body = append(emitter.body, mirICmpSGTI64LiteralText(estCapCond, estFloored, "100000000"))
 	estFinal := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 100000000, i64 %s", estFinal, estCapCond, estFloored))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", estFinal, nslot))
-	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", afterLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", afterLabel))
+	emitter.body = append(emitter.body, mirSelectI64LiteralLhsText(estFinal, estCapCond, "100000000", estFloored))
+	emitter.body = append(emitter.body, mirStoreI64Text(estFinal, nslot))
+	emitter.body = append(emitter.body, mirBrUncondText(afterLabel))
+	emitter.body = append(emitter.body, mirLabelText(afterLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = afterLabel
 	g.currentReachable = true
@@ -1801,15 +1793,15 @@ func (g *generator) emitBenchInlineLoop(stmts []ast.Stmt, count value, labelPref
 		// the loop body — LLVM treats alloca-in-loop as an explicit
 		// stack-growing op and mem2reg won't promote it.
 		iterStartSlot = llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", iterStartSlot))
+		emitter.body = append(emitter.body, mirAllocaI64Text(iterStartSlot))
 	}
 	zeroV := &LlvmValue{name: "0", typ: "i64"}
 	stopV := &LlvmValue{name: count.ref, typ: "i64"}
 	loop := llvmRangeStart(emitter, g.hiddenBenchIterName(), zeroV, stopV, false)
 	if samplesPtr != "" {
 		tstart := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", tstart, benchClockRuntimeSymbol()))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", tstart, iterStartSlot))
+		emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(tstart, benchClockRuntimeSymbol()))
+		emitter.body = append(emitter.body, mirStoreI64Text(tstart, iterStartSlot))
 	}
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop.bodyLabel)
@@ -1838,19 +1830,19 @@ func (g *generator) emitBenchInlineLoop(stmts []ast.Stmt, count value, labelPref
 	if samplesPtr != "" && g.currentReachable {
 		emitter = g.toOstyEmitter()
 		tstart := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", tstart, iterStartSlot))
+		emitter.body = append(emitter.body, mirLoadI64Text(tstart, iterStartSlot))
 		tend := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @%s()", tend, benchClockRuntimeSymbol()))
+		emitter.body = append(emitter.body, mirCallRuntimeI64NoArgsText(tend, benchClockRuntimeSymbol()))
 		delta := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i64 %s, %s", delta, tend, tstart))
-		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(ptr %s, i64 %s, i64 %s)", benchSamplesRecordSymbol(), samplesPtr, loop.current, delta))
+		emitter.body = append(emitter.body, mirSubI64Text(delta, tend, tstart))
+		emitter.body = append(emitter.body, mirCallRuntimeVoidPtrI64I64Text(benchSamplesRecordSymbol(), samplesPtr, loop.current, delta))
 		g.takeOstyEmitter(emitter)
 	}
 	if g.currentReachable {
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
@@ -1889,8 +1881,8 @@ func (g *generator) emitTestingAssertion(cond value, message string) error {
 	emitter := g.toOstyEmitter()
 	okLabel := llvmNextLabel(emitter, "test.ok")
 	failLabel := llvmNextLabel(emitter, "test.fail")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.ref, okLabel, failLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", failLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.ref, okLabel, failLabel))
+	emitter.body = append(emitter.body, mirLabelText(failLabel))
 	g.emitTestingAbortWithEmitter(emitter, message, okLabel)
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = okLabel
@@ -1911,7 +1903,7 @@ func (g *generator) emitTestingAbortWithEmitter(emitter *LlvmEmitter, message st
 	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
 	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
 	emitter.body = append(emitter.body, "  unreachable")
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+	emitter.body = append(emitter.body, mirLabelText(nextLabel))
 }
 
 func (g *generator) testingFailureMessage(call *ast.CallExpr, name string) string {
@@ -1952,8 +1944,8 @@ func (g *generator) emitTestingAssertionLazy(cond value, buildMessage func() (va
 	emitter := g.toOstyEmitter()
 	okLabel := llvmNextLabel(emitter, "test.ok")
 	failLabel := llvmNextLabel(emitter, "test.fail")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.ref, okLabel, failLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", failLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.ref, okLabel, failLabel))
+	emitter.body = append(emitter.body, mirLabelText(failLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = failLabel
 	msg, err := buildMessage()
@@ -1965,7 +1957,7 @@ func (g *generator) emitTestingAssertionLazy(cond value, buildMessage func() (va
 	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
 	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
 	emitter.body = append(emitter.body, "  unreachable")
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", okLabel))
+	emitter.body = append(emitter.body, mirLabelText(okLabel))
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = okLabel
 	return nil
@@ -2270,7 +2262,7 @@ func (g *generator) emitIfStmt(expr *ast.IfExpr) error {
 	}
 	g.restoreScopeState(baseState)
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.elseLabel))
+	emitter.body = append(emitter.body, mirLabelText(labels.elseLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(labels.elseLabel)
 	if expr.Else != nil {
@@ -2285,7 +2277,7 @@ func (g *generator) emitIfStmt(expr *ast.IfExpr) error {
 	g.restoreScopeState(baseState)
 	if thenReachable || elseReachable {
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(labels.endLabel)
 		return nil
@@ -2336,7 +2328,7 @@ func (g *generator) emitIfLetStmt(expr *ast.IfExpr) error {
 	}
 	g.restoreScopeState(baseState)
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.elseLabel))
+	emitter.body = append(emitter.body, mirLabelText(labels.elseLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(labels.elseLabel)
 	if expr.Else != nil {
@@ -2351,7 +2343,7 @@ func (g *generator) emitIfLetStmt(expr *ast.IfExpr) error {
 	g.restoreScopeState(baseState)
 	if thenReachable || elseReachable {
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(labels.endLabel)
 		return nil
@@ -2464,8 +2456,8 @@ func (g *generator) emitResultMatchStmt(scrutinee value, info builtinResultType,
 	thenLabel := llvmNextLabel(emitter, "match.result.first")
 	elseLabel := llvmNextLabel(emitter, "match.result.second")
 	endLabel := llvmNextLabel(emitter, "match.result.end")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, thenLabel, elseLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", thenLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.name, thenLabel, elseLabel))
+	emitter.body = append(emitter.body, mirLabelText(thenLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(thenLabel)
 
@@ -2482,7 +2474,7 @@ func (g *generator) emitResultMatchStmt(scrutinee value, info builtinResultType,
 	g.restoreScopeState(baseState)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", elseLabel))
+	emitter.body = append(emitter.body, mirLabelText(elseLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(elseLabel)
 
@@ -2499,7 +2491,7 @@ func (g *generator) emitResultMatchStmt(scrutinee value, info builtinResultType,
 	g.restoreScopeState(baseState)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	return nil
@@ -2618,7 +2610,7 @@ func (g *generator) emitOptionalMatchStmt(scrutinee value, innerSource ast.Type,
 	emitter := g.toOstyEmitter()
 	endLabel := llvmNextLabel(emitter, "match.end")
 	isNil := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, scrutinee.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(isNil, scrutinee.ref))
 	g.takeOstyEmitter(emitter)
 
 	anyReached := false
@@ -2657,11 +2649,11 @@ func (g *generator) emitOptionalMatchStmt(scrutinee value, innerSource ast.Type,
 		armLabel := llvmNextLabel(emitter, "match.arm")
 		nextLabel := llvmNextLabel(emitter, "match.next")
 		if pattern.isSome {
-			emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil, nextLabel, armLabel))
+			emitter.body = append(emitter.body, mirBrCondText(isNil, nextLabel, armLabel))
 		} else {
-			emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil, armLabel, nextLabel))
+			emitter.body = append(emitter.body, mirBrCondText(isNil, armLabel, nextLabel))
 		}
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		emitter.body = append(emitter.body, mirLabelText(armLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(armLabel)
 
@@ -2684,7 +2676,7 @@ func (g *generator) emitOptionalMatchStmt(scrutinee value, innerSource ast.Type,
 		g.restoreScopeState(baseState)
 
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(nextLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(nextLabel)
 	}
@@ -2694,7 +2686,7 @@ func (g *generator) emitOptionalMatchStmt(scrutinee value, innerSource ast.Type,
 		anyReached = true
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	g.currentReachable = anyReached
@@ -2719,8 +2711,8 @@ func (g *generator) emitMatchArmGuard(arm *ast.MatchArm, failLabel string) error
 	}
 	emitter := g.toOstyEmitter()
 	guardOk := llvmNextLabel(emitter, "match.guardOk")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", guard.ref, guardOk, failLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", guardOk))
+	emitter.body = append(emitter.body, mirBrCondText(guard.ref, guardOk, failLabel))
+	emitter.body = append(emitter.body, mirLabelText(guardOk))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(guardOk)
 	return nil
@@ -2770,8 +2762,8 @@ func (g *generator) emitTagEnumMatchStmt(scrutinee value, arms []*ast.MatchArm) 
 		cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(value{typ: "i64", ref: strconv.Itoa(tag)}))
 		armLabel := llvmNextLabel(emitter, "match.arm")
 		nextLabel := llvmNextLabel(emitter, "match.next")
-		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, armLabel, nextLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		emitter.body = append(emitter.body, mirBrCondText(cond.name, armLabel, nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(armLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(armLabel)
 
@@ -2789,7 +2781,7 @@ func (g *generator) emitTagEnumMatchStmt(scrutinee value, arms []*ast.MatchArm) 
 		g.restoreScopeState(baseState)
 
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(nextLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(nextLabel)
 	}
@@ -2805,7 +2797,7 @@ func (g *generator) emitTagEnumMatchStmt(scrutinee value, arms []*ast.MatchArm) 
 	}
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	g.currentReachable = anyReached
@@ -2860,8 +2852,8 @@ func (g *generator) emitPrimitiveLiteralMatchStmt(scrutinee value, arms []*ast.M
 		cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(litValue))
 		armLabel := llvmNextLabel(emitter, "match.arm")
 		nextLabel := llvmNextLabel(emitter, "match.next")
-		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, armLabel, nextLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		emitter.body = append(emitter.body, mirBrCondText(cond.name, armLabel, nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(armLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(armLabel)
 
@@ -2879,7 +2871,7 @@ func (g *generator) emitPrimitiveLiteralMatchStmt(scrutinee value, arms []*ast.M
 		g.restoreScopeState(baseState)
 
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(nextLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(nextLabel)
 	}
@@ -2889,7 +2881,7 @@ func (g *generator) emitPrimitiveLiteralMatchStmt(scrutinee value, arms []*ast.M
 		anyReached = true
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 	g.currentReachable = anyReached
@@ -2978,8 +2970,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		}
 		g.declareRuntimeSymbol(listRuntimePopDiscardSymbol(), "void", []paramInfo{{typ: "ptr"}})
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimePopDiscardSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
 		))
@@ -2992,8 +2983,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		}
 		g.declareRuntimeSymbol(listRuntimeClearSymbol(), "void", []paramInfo{{typ: "ptr"}})
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeClearSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
 		))
@@ -3035,8 +3025,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		insertSymbol := listRuntimeInsertSymbol(elemTyp)
 		g.declareRuntimeSymbol(insertSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: elemTyp}})
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			insertSymbol,
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), toOstyValue(idxValue), toOstyValue(argValue)}),
 		))
@@ -3077,8 +3066,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	emitter = g.toOstyEmitter()
 	if listUsesTypedRuntime(elemTyp) {
 		g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			pushSymbol,
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), toOstyValue(argValue)}),
 		))
@@ -3087,8 +3075,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		addr := g.spillValueAddress(emitter, "list.push", argValue)
 		sizeValue := g.emitTypeSize(emitter, elemTyp)
 		g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimePushBytesSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), {typ: "ptr", name: addr}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 		))
@@ -3125,8 +3112,7 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		}
 		g.declareRuntimeSymbol(mapRuntimeClearSymbol(), "void", []paramInfo{{typ: "ptr"}})
 		emitter := g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			mapRuntimeClearSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseLoaded)}),
 		))
@@ -3218,8 +3204,7 @@ func (g *generator) emitMapUpdateStmt(call *ast.CallExpr, base value, keyTyp str
 	g.declareRuntimeSymbol(mapRuntimeLockSymbol(), "void", []paramInfo{{typ: "ptr"}})
 	g.declareRuntimeSymbol(mapRuntimeUnlockSymbol(), "void", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 		mapRuntimeLockSymbol(),
 		llvmCallArgs([]*LlvmValue{toOstyValue(base)}),
 	))
@@ -3245,8 +3230,7 @@ func (g *generator) emitMapUpdateStmt(call *ast.CallExpr, base value, keyTyp str
 		return err
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 		mapRuntimeUnlockSymbol(),
 		llvmCallArgs([]*LlvmValue{toOstyValue(base)}),
 	))
@@ -3302,7 +3286,7 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 		}
 		emitter := g.toOstyEmitter()
 		notCond := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", notCond, cond.ref))
+		emitter.body = append(emitter.body, mirXorI1NegText(notCond, cond.ref))
 		labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: notCond})
 		g.takeOstyEmitter(emitter)
 		g.currentBlock = labels.thenLabel
@@ -3314,8 +3298,7 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 		pushSym := listRuntimePushSymbol(keyTyp)
 		g.declareRuntimeSymbol(pushSym, "void", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			pushSym,
 			llvmCallArgs([]*LlvmValue{toOstyValue(victimsLoaded), {typ: keyTyp, name: k.ref}}),
 		))
@@ -3323,8 +3306,8 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 		g.takeOstyEmitter(emitter)
 		g.currentBlock = labels.elseLabel
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		emitter.body = append(emitter.body, mirBrUncondText(labels.endLabel))
+		emitter.body = append(emitter.body, mirLabelText(labels.endLabel))
 		g.takeOstyEmitter(emitter)
 		g.currentBlock = labels.endLabel
 		return nil
@@ -3374,7 +3357,7 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 		g.branchTo(cont2)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont2))
+	emitter.body = append(emitter.body, mirLabelText(cont2))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop2)
 	g.takeOstyEmitter(emitter)
@@ -3473,7 +3456,7 @@ func (g *generator) emitMapFor(stmt *ast.ForStmt, kName, vName, keyTyp, valTyp s
 	g.declareRuntimeSymbol(entryAtSym, keyTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
 	emitter = g.toOstyEmitter()
 	vslot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", vslot, valTyp))
+	emitter.body = append(emitter.body, mirAllocaText(vslot, valTyp))
 	keyLoaded := llvmCall(emitter, keyTyp, entryAtSym, []*LlvmValue{
 		toOstyValue(iterableValue),
 		toOstyValue(indexValue),
@@ -3522,7 +3505,7 @@ func (g *generator) emitMapFor(stmt *ast.ForStmt, kName, vName, keyTyp, valTyp s
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.attachVectorizeMD(emitter, loop.condLabel)
@@ -3603,11 +3586,10 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
 		emitter = g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, elemTyp))
+		emitter.body = append(emitter.body, mirAllocaText(slot, elemTyp))
 		sizeValue := g.emitTypeSize(emitter, elemTyp)
 		g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeGetBytesSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(iterableValue), llvmI64(loop.current), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 		))
@@ -3638,7 +3620,7 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	llvmRangeEnd(emitter, loop)
 	g.attachVectorizeMD(emitter, loop.condLabel)
@@ -3718,11 +3700,10 @@ func (g *generator) emitSetFor(stmt *ast.ForStmt, iterName, elemTyp string, elem
 		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
 		emitter = g.toOstyEmitter()
 		slot := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, elemTyp))
+		emitter.body = append(emitter.body, mirAllocaText(slot, elemTyp))
 		sizeValue := g.emitTypeSize(emitter, elemTyp)
 		g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
 			listRuntimeGetBytesSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(snapshotV), llvmI64(loop.current), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
 		))
@@ -3749,7 +3730,7 @@ func (g *generator) emitSetFor(stmt *ast.ForStmt, iterName, elemTyp string, elem
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	llvmRangeEnd(emitter, loop)
 	g.attachVectorizeMD(emitter, loop.condLabel)
@@ -3787,7 +3768,7 @@ func (g *generator) emitOptionalUserCallStmt(call *ast.CallExpr) (bool, error) {
 		}
 		emitter := g.toOstyEmitter()
 		if sig.ret == "void" {
-			emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.irName, llvmCallArgs(args)))
+			emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(sig.irName, llvmCallArgs(args)))
 		} else {
 			llvmCall(emitter, sig.ret, sig.irName, args)
 		}
@@ -3820,7 +3801,7 @@ func (g *generator) emitUserCallStmt(call *ast.CallExpr) (bool, error) {
 	}
 	emitter := g.toOstyEmitter()
 	if sig.ret == "void" {
-		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.irName, llvmCallArgs(args)))
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(sig.irName, llvmCallArgs(args)))
 	} else {
 		llvmCall(emitter, sig.ret, sig.irName, args)
 	}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2239,24 +2239,7 @@ func (g *generator) sourceSpanText(expr ast.Expr) string {
 // runs of whitespace so multi-line argument expressions (list literals,
 // struct literals) do not break the single-line failure message layout.
 func normalizeAssertExprText(text string) string {
-	var b strings.Builder
-	prevSpace := false
-	for _, r := range text {
-		switch r {
-		case '\n', '\r', '\t':
-			r = ' '
-		}
-		if r == ' ' {
-			if prevSpace {
-				continue
-			}
-			prevSpace = true
-		} else {
-			prevSpace = false
-		}
-		b.WriteRune(r)
-	}
-	return strings.TrimSpace(b.String())
+	return mirNormalizeAssertExprText(text)
 }
 
 func (g *generator) emitIfStmt(expr *ast.IfExpr) error {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -24,12 +24,7 @@ type typeEnv struct {
 }
 
 func llvmBuiltinAggregateName(prefix string, parts ...string) string {
-	names := make([]string, 0, len(parts)+1)
-	names = append(names, prefix)
-	for _, part := range parts {
-		names = append(names, llvmBuiltinAggregatePart(part))
-	}
-	return "%" + strings.Join(names, ".")
+	return mirLlvmBuiltinAggregateName(prefix, parts)
 }
 
 // llvmBuiltinAggregatePart folds a type-name fragment into the LLVM
@@ -40,11 +35,11 @@ func llvmBuiltinAggregatePart(part string) string {
 }
 
 func llvmResultTypeName(okTyp, errTyp string) string {
-	return llvmBuiltinAggregateName("Result", okTyp, errTyp)
+	return mirLlvmResultTypeName(okTyp, errTyp)
 }
 
 func llvmTupleTypeName(elemTypes []string) string {
-	return llvmBuiltinAggregateName("Tuple", elemTypes...)
+	return mirLlvmTupleTypeName(elemTypes)
 }
 
 func llvmRuntimeABIType(t ast.Type, env typeEnv) (string, error) {

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -13163,3 +13163,788 @@ pub fn mirNormalizeAssertExprText(text: String) -> String {
     if hi > lo && buf[(hi - 1)..hi] == " " { hi = hi - 1 }
     buf[lo..hi]
 }
+
+/// §20 — newline-free (`Text`) variants of common Line builders, for
+/// `body []string` callers in `internal/llvmgen/{expr,stmt,generator}.go`
+/// that join entries on `\n`. Same shapes as the §3 / §6 / §13 Line
+/// builders but without the trailing `\n` — the join inserts the
+/// separator. The split exists so that hot inline-IR sites in the
+/// emitter can drain `fmt.Sprintf("  %s = ...", ...)` calls into a
+/// named helper without flipping the surrounding append-then-join
+/// idiom to direct buffer writes.
+
+/// mirAllocaText renders `  <reg> = alloca <ty>` (no trailing newline,
+/// for callers appending to a `body []string` slice that joins on
+/// "\n"). Mirrors `mirAllocaLine` minus the terminator.
+pub fn mirAllocaText(reg: String, ty: String) -> String {
+    "  " + reg + " = alloca " + ty
+}
+
+/// mirAllocaI64Text renders `  <reg> = alloca i64`. Specialised
+/// shape for the loop-counter / scratch-int-slot pattern that the
+/// emitter uses ubiquitously (safepoint-poll counter, range cursors).
+pub fn mirAllocaI64Text(reg: String) -> String {
+    "  " + reg + " = alloca i64"
+}
+
+/// mirAllocaPtrText renders `  <reg> = alloca ptr`. The opaque-pointer
+/// slot form used by Option<ptr-shape> spills.
+pub fn mirAllocaPtrText(reg: String) -> String {
+    "  " + reg + " = alloca ptr"
+}
+
+/// mirAllocaArrayPtrText renders `  <reg> = alloca [<n> x ptr]`. The
+/// fixed-arity ptr-array form used for argv-style call payload
+/// staging in interpolation lowering and varargs marshalling. `n`
+/// comes in as a String of decimal digits — caller formats with
+/// `Itoa` since osty `Int` does not auto-format.
+pub fn mirAllocaArrayPtrText(reg: String, n: String) -> String {
+    "  " + reg + " = alloca [" + n + " x ptr]"
+}
+
+/// mirLoadText renders `  <reg> = load <ty>, ptr <ptr>` (no trailing
+/// newline). Mirrors `mirLoadLine` minus the terminator.
+pub fn mirLoadText(reg: String, ty: String, ptr: String) -> String {
+    "  " + reg + " = load " + ty + ", ptr " + ptr
+}
+
+/// mirLoadI64Text renders `  <reg> = load i64, ptr <ptr>`. The
+/// scalar-int reload form used by counter / length probes.
+pub fn mirLoadI64Text(reg: String, ptr: String) -> String {
+    "  " + reg + " = load i64, ptr " + ptr
+}
+
+/// mirLoadPtrText renders `  <reg> = load ptr, ptr <slot>`. The
+/// opaque-pointer reload form used by Option<ptr-shape> takeout.
+pub fn mirLoadPtrText(reg: String, slot: String) -> String {
+    "  " + reg + " = load ptr, ptr " + slot
+}
+
+/// mirStoreText renders `  store <ty> <val>, ptr <slot>` (no trailing
+/// newline). Mirrors `mirStoreLine` minus the terminator.
+pub fn mirStoreText(ty: String, val: String, slot: String) -> String {
+    "  store " + ty + " " + val + ", ptr " + slot
+}
+
+/// mirStoreI64Text renders `  store i64 <val>, ptr <slot>`. The
+/// scalar-int store form used by counter / length spills.
+pub fn mirStoreI64Text(val: String, slot: String) -> String {
+    "  store i64 " + val + ", ptr " + slot
+}
+
+/// mirStoreI8Text renders `  store i8 <val>, ptr <slot>`. The byte-
+/// width store form used for char / bool slot spills.
+pub fn mirStoreI8Text(val: String, slot: String) -> String {
+    "  store i8 " + val + ", ptr " + slot
+}
+
+/// mirStorePtrText renders `  store ptr <val>, ptr <slot>`. The
+/// opaque-pointer store form used by Option<ptr-shape> spills and
+/// argv-style call payload staging.
+pub fn mirStorePtrText(val: String, slot: String) -> String {
+    "  store ptr " + val + ", ptr " + slot
+}
+
+/// mirStorePtrNullText renders `  store ptr null, ptr <slot>`. The
+/// None-initialiser form used by Option<ptr-shape> default branches.
+pub fn mirStorePtrNullText(slot: String) -> String {
+    "  store ptr null, ptr " + slot
+}
+
+/// mirStoreI64ZeroText renders `  store i64 0, ptr <slot>`. The
+/// zero-initialiser form used by counter slots at function entry.
+pub fn mirStoreI64ZeroText(slot: String) -> String {
+    "  store i64 0, ptr " + slot
+}
+
+/// mirBrCondText renders the conditional branch
+/// `  br i1 <cond>, label %<trueLabel>, label %<falseLabel>` (no
+/// trailing newline). Mirrors `mirBrCondLine` minus the terminator.
+pub fn mirBrCondText(cond: String, trueLabel: String, falseLabel: String) -> String {
+    "  br i1 " + cond + ", label %" + trueLabel + ", label %" + falseLabel
+}
+
+/// mirBrUncondText renders the unconditional branch
+/// `  br label %<label>` (no trailing newline). Mirrors
+/// `mirBrUncondLine` minus the terminator.
+pub fn mirBrUncondText(label: String) -> String {
+    "  br label %" + label
+}
+
+/// mirLabelText renders `<name>:` — the bare basic-block header
+/// (no trailing newline). Caller passes the label name without
+/// leading `%`; the helper adds the trailing `:`.
+pub fn mirLabelText(name: String) -> String {
+    name + ":"
+}
+
+/// mirRetText renders `  ret <ty> <val>` (no trailing newline).
+pub fn mirRetText(ty: String, val: String) -> String {
+    "  ret " + ty + " " + val
+}
+
+/// mirRetVoidText renders `  ret void` (no trailing newline).
+pub fn mirRetVoidText() -> String {
+    "  ret void"
+}
+
+/// mirICmpEqText renders `  <reg> = icmp eq <ty> <lhs>, <rhs>` (no
+/// trailing newline). Specialised to the `eq` predicate; other
+/// predicates use `mirICmpText` with an explicit pred keyword.
+pub fn mirICmpEqText(reg: String, ty: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp eq " + ty + " " + lhs + ", " + rhs
+}
+
+/// mirICmpEqI64Text renders `  <reg> = icmp eq i64 <lhs>, <rhs>`.
+/// Width-specialised eq form for hot loop-bound checks.
+pub fn mirICmpEqI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp eq i64 " + lhs + ", " + rhs
+}
+
+/// mirICmpEqPtrNullText renders `  <reg> = icmp eq ptr <ptr>, null`.
+/// The pointer-nullity check form used by Option<ptr-shape>
+/// discrimination and FFI null guards.
+pub fn mirICmpEqPtrNullText(reg: String, ptr: String) -> String {
+    "  " + reg + " = icmp eq ptr " + ptr + ", null"
+}
+
+/// mirICmpText renders `  <reg> = icmp <pred> <ty> <lhs>, <rhs>` (no
+/// trailing newline). General predicate form; `pred` is the LLVM
+/// keyword (`eq`, `ne`, `slt`, `sle`, `sgt`, `sge`, `ult`, `ule`,
+/// `ugt`, `uge`).
+pub fn mirICmpText(reg: String, pred: String, ty: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp " + pred + " " + ty + " " + lhs + ", " + rhs
+}
+
+/// mirICmpSGTI64ZeroText renders `  <reg> = icmp sgt i64 <lhs>, 0`.
+/// Specialised positive-int probe used by the warmup-count guard
+/// and length-positivity checks.
+pub fn mirICmpSGTI64ZeroText(reg: String, lhs: String) -> String {
+    "  " + reg + " = icmp sgt i64 " + lhs + ", 0"
+}
+
+/// mirICmpSLTI64Text renders `  <reg> = icmp slt i64 <lhs>, <rhs>`.
+/// Width-specialised signed-less-than form used by loop-cond
+/// emission.
+pub fn mirICmpSLTI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp slt i64 " + lhs + ", " + rhs
+}
+
+/// mirICmpSGEI64ZeroText renders `  <reg> = icmp sge i64 <lhs>, 0`.
+/// The non-negative probe used by absolute-value lowerings and
+/// signum normalisations.
+pub fn mirICmpSGEI64ZeroText(reg: String, lhs: String) -> String {
+    "  " + reg + " = icmp sge i64 " + lhs + ", 0"
+}
+
+/// mirICmpSLTI64LiteralText renders
+/// `  <reg> = icmp slt i64 <lhs>, <lit>`. The signed-less-than
+/// against a baked literal — used by the warmup cap and similar
+/// constant comparisons. `lit` is a decimal-digit String.
+pub fn mirICmpSLTI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = icmp slt i64 " + lhs + ", " + lit
+}
+
+/// mirICmpSGTI64LiteralText renders
+/// `  <reg> = icmp sgt i64 <lhs>, <lit>`. The signed-greater-than
+/// against a baked literal — used by the iteration-count cap.
+pub fn mirICmpSGTI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = icmp sgt i64 " + lhs + ", " + lit
+}
+
+/// mirICmpEqI64LiteralText renders
+/// `  <reg> = icmp eq i64 <lhs>, <lit>`. The equality-with-literal
+/// probe used by the safepoint-stride trigger.
+pub fn mirICmpEqI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = icmp eq i64 " + lhs + ", " + lit
+}
+
+/// mirICmpEqI32LiteralText renders
+/// `  <reg> = icmp eq i32 <lhs>, <lit>`. The equality-with-literal
+/// form for char-class probes (digit, whitespace, newline checks).
+pub fn mirICmpEqI32LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = icmp eq i32 " + lhs + ", " + lit
+}
+
+/// mirICmpULTI32LiteralText renders
+/// `  <reg> = icmp ult i32 <lhs>, <lit>`. Unsigned-less-than against
+/// a baked literal — used by char-class range tests.
+pub fn mirICmpULTI32LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = icmp ult i32 " + lhs + ", " + lit
+}
+
+/// mirICmpEqPtrText renders `  <reg> = icmp <pred> ptr <lhs>, null`.
+/// Pointer-vs-null comparisons with an explicit predicate keyword
+/// (e.g. `ne`); the null-RHS specialisation lives in
+/// `mirICmpEqPtrNullText`.
+pub fn mirICmpEqPtrText(reg: String, pred: String, lhs: String) -> String {
+    "  " + reg + " = icmp " + pred + " ptr " + lhs + ", null"
+}
+
+/// mirAddI64OneText renders `  <reg> = add i64 <lhs>, 1`. The
+/// increment-by-one form used by counter advance and inclusive
+/// range bound adjustment.
+pub fn mirAddI64OneText(reg: String, lhs: String) -> String {
+    "  " + reg + " = add i64 " + lhs + ", 1"
+}
+
+/// mirAddI64Text renders `  <reg> = add i64 <lhs>, <rhs>`. General
+/// i64 addition.
+pub fn mirAddI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = add i64 " + lhs + ", " + rhs
+}
+
+/// mirAddI32LiteralText renders
+/// `  <reg> = add i32 <lhs>, <lit>`. i32 addition with a baked
+/// literal — used by char-class case-folding offsets.
+pub fn mirAddI32LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = add i32 " + lhs + ", " + lit
+}
+
+/// mirSubI64Text renders `  <reg> = sub i64 <lhs>, <rhs>`. General
+/// i64 subtraction (timing intervals, range deltas).
+pub fn mirSubI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = sub i64 " + lhs + ", " + rhs
+}
+
+/// mirSubI32LiteralText renders
+/// `  <reg> = sub i32 <lhs>, <lit>`. i32 subtraction with a baked
+/// literal — used by char-class case-folding offsets.
+pub fn mirSubI32LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = sub i32 " + lhs + ", " + lit
+}
+
+/// mirMulI64Text renders `  <reg> = mul i64 <lhs>, <rhs>`. General
+/// i64 multiplication.
+pub fn mirMulI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = mul i64 " + lhs + ", " + rhs
+}
+
+/// mirMulI64LiteralText renders
+/// `  <reg> = mul i64 <lhs>, <lit>`. i64 multiplication with a baked
+/// literal — used by stride / stripe arithmetic.
+pub fn mirMulI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = mul i64 " + lhs + ", " + lit
+}
+
+/// mirSDivI64Text renders `  <reg> = sdiv i64 <lhs>, <rhs>`. Signed
+/// i64 division.
+pub fn mirSDivI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = sdiv i64 " + lhs + ", " + rhs
+}
+
+/// mirSDivI64LiteralText renders
+/// `  <reg> = sdiv i64 <lhs>, <lit>`. Signed division by a baked
+/// literal — used by warmup / sample-rate scaling (`/ 10`, `/ 5`).
+pub fn mirSDivI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = sdiv i64 " + lhs + ", " + lit
+}
+
+/// mirOrI1Text renders `  <reg> = or i1 <lhs>, <rhs>`. Bool-disjunct
+/// form used by Option / Result discriminator merges.
+pub fn mirOrI1Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = or i1 " + lhs + ", " + rhs
+}
+
+/// mirAndI1Text renders `  <reg> = and i1 <lhs>, <rhs>`. Bool-conjunct
+/// form used by guarded predicate composition.
+pub fn mirAndI1Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = and i1 " + lhs + ", " + rhs
+}
+
+/// mirXorI1NegText renders `  <reg> = xor i1 <src>, true`. The
+/// i1-negation form used to flip predicate results.
+pub fn mirXorI1NegText(reg: String, src: String) -> String {
+    "  " + reg + " = xor i1 " + src + ", true"
+}
+
+/// mirSelectI64Text renders
+/// `  <reg> = select i1 <cond>, i64 <lhs>, i64 <rhs>`. Width-
+/// specialised i64 select form.
+pub fn mirSelectI64Text(reg: String, cond: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = select i1 " + cond + ", i64 " + lhs + ", i64 " + rhs
+}
+
+/// mirSelectI32Text renders
+/// `  <reg> = select i1 <cond>, i32 <lhs>, i32 <rhs>`. Width-
+/// specialised i32 select form.
+pub fn mirSelectI32Text(reg: String, cond: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = select i1 " + cond + ", i32 " + lhs + ", i32 " + rhs
+}
+
+/// mirSelectI64LiteralRhsText renders
+/// `  <reg> = select i1 <cond>, i64 <lhs>, i64 <lit>`. Specialised
+/// for the `select <reg>, <reg>, <lit>` pattern (e.g. warmup cap).
+pub fn mirSelectI64LiteralRhsText(reg: String, cond: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = select i1 " + cond + ", i64 " + lhs + ", i64 " + lit
+}
+
+/// mirSelectI64LiteralLhsText renders
+/// `  <reg> = select i1 <cond>, i64 <lit>, i64 <rhs>`. Specialised
+/// for the `select <reg>, <lit>, <reg>` pattern (e.g. zero-default).
+pub fn mirSelectI64LiteralLhsText(reg: String, cond: String, lit: String, rhs: String) -> String {
+    "  " + reg + " = select i1 " + cond + ", i64 " + lit + ", i64 " + rhs
+}
+
+/// mirSelectTypedText renders
+/// `  <reg> = select i1 <cond>, <ty> <lhs>, <ty> <rhs>`. General
+/// arbitrary-type select form.
+pub fn mirSelectTypedText(
+    reg: String,
+    ty: String,
+    cond: String,
+    lhs: String,
+    rhs: String,
+) -> String {
+    "  " + reg + " = select i1 " + cond + ", " + ty + " " + lhs + ", " + ty + " " + rhs
+}
+
+/// mirZExtI8ToI32Text renders
+/// `  <reg> = zext i8 <src> to i32`. Byte→int widening for char
+/// classification arithmetic.
+pub fn mirZExtI8ToI32Text(reg: String, src: String) -> String {
+    "  " + reg + " = zext i8 " + src + " to i32"
+}
+
+/// mirZExtI8ToI64Text renders
+/// `  <reg> = zext i8 <src> to i64`. Byte→int widening into the
+/// canonical i64 width.
+pub fn mirZExtI8ToI64Text(reg: String, src: String) -> String {
+    "  " + reg + " = zext i8 " + src + " to i64"
+}
+
+/// mirZExtI32ToI64Text renders
+/// `  <reg> = zext i32 <src> to i64`. i32→i64 widening.
+pub fn mirZExtI32ToI64Text(reg: String, src: String) -> String {
+    "  " + reg + " = zext i32 " + src + " to i64"
+}
+
+/// mirTruncI64ToI8Text renders
+/// `  <reg> = trunc i64 <src> to i8`. i64→byte narrowing for char
+/// store paths.
+pub fn mirTruncI64ToI8Text(reg: String, src: String) -> String {
+    "  " + reg + " = trunc i64 " + src + " to i8"
+}
+
+/// mirTruncI64ToI32Text renders
+/// `  <reg> = trunc i64 <src> to i32`. i64→i32 narrowing.
+pub fn mirTruncI64ToI32Text(reg: String, src: String) -> String {
+    "  " + reg + " = trunc i64 " + src + " to i32"
+}
+
+/// mirPtrToIntI64Text renders
+/// `  <reg> = ptrtoint ptr <ptr> to i64`. Pointer-as-integer cast
+/// used by hash mixing and identity-key derivation.
+pub fn mirPtrToIntI64Text(reg: String, ptr: String) -> String {
+    "  " + reg + " = ptrtoint ptr " + ptr + " to i64"
+}
+
+/// mirGEPInboundsZeroText renders
+/// `  <reg> = getelementptr inbounds <ty>, ptr <basePtr>, i32 0, i32 0`.
+/// The first-field projection form used by builtin-aggregate
+/// destructuring (e.g. tuple/Option payload pickoff).
+pub fn mirGEPInboundsZeroText(reg: String, ty: String, basePtr: String) -> String {
+    "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr + ", i32 0, i32 0"
+}
+
+/// mirGEPInboundsFieldText renders
+/// `  <reg> = getelementptr inbounds <ty>, ptr <basePtr>, i32 0, i32 <idx>`.
+/// The Nth-field projection form. `idx` is a decimal-digit String
+/// (caller formats with `Itoa`).
+pub fn mirGEPInboundsFieldText(reg: String, ty: String, basePtr: String, idx: String) -> String {
+    "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr + ", i32 0, i32 " + idx
+}
+
+/// mirGEPInboundsI8Text renders
+/// `  <reg> = getelementptr i8, ptr <basePtr>, i64 <offDigits>`. The
+/// byte-stride GEP form used by struct field stride math. `offDigits`
+/// is a decimal-digit String.
+pub fn mirGEPInboundsI8Text(reg: String, basePtr: String, offDigits: String) -> String {
+    "  " + reg + " = getelementptr i8, ptr " + basePtr + ", i64 " + offDigits
+}
+
+/// mirGEPSizeofText renders
+/// `  <reg> = getelementptr <ty>, ptr null, i32 1`. The "compute size
+/// of <ty> in bytes" idiom — null-base + i32 1 stride yields the
+/// element-stride pointer; ptrtoint converts it to a byte count.
+pub fn mirGEPSizeofText(reg: String, ty: String) -> String {
+    "  " + reg + " = getelementptr " + ty + ", ptr null, i32 1"
+}
+
+/// mirGEPArrayElementText renders
+/// `  <reg> = getelementptr [<n> x ptr], ptr <arr>, i64 0, i64 <idx>`.
+/// The array-element pickoff form used by argv-style call payload
+/// staging. `n` and `idx` are decimal-digit Strings.
+pub fn mirGEPArrayElementText(reg: String, n: String, arr: String, idx: String) -> String {
+    "  " + reg + " = getelementptr [" + n + " x ptr], ptr " + arr + ", i64 0, i64 " + idx
+}
+
+/// mirCallRuntimeI64NoArgsText renders
+/// `  <reg> = call i64 @<symbol>()`. The zero-arg i64-returning
+/// runtime call form used by clock / sample-counter probes.
+pub fn mirCallRuntimeI64NoArgsText(reg: String, symbol: String) -> String {
+    "  " + reg + " = call i64 @" + symbol + "()"
+}
+
+/// mirCallRuntimeVoidOneArgText renders
+/// `  call void @<symbol>(<arg>)`. The single-arg void-returning
+/// runtime call form. `arg` is the full pre-formatted operand
+/// (`ptr %x` or `i64 %n`).
+pub fn mirCallRuntimeVoidOneArgText(symbol: String, arg: String) -> String {
+    "  call void @" + symbol + "(" + arg + ")"
+}
+
+/// mirCallRuntimeVoidPtrText renders
+/// `  call void @<symbol>(ptr <arg>)`. The single-ptr-arg void-
+/// returning runtime call form used by GC mark / trace helpers.
+pub fn mirCallRuntimeVoidPtrText(symbol: String, arg: String) -> String {
+    "  call void @" + symbol + "(ptr " + arg + ")"
+}
+
+/// mirCallRuntimeVoidPtrI64Text renders
+/// `  call void @<symbol>(ptr <a>, i64 <n>)`. The two-arg
+/// (ptr+length) void-returning runtime call form.
+pub fn mirCallRuntimeVoidPtrI64Text(symbol: String, a: String, n: String) -> String {
+    "  call void @" + symbol + "(ptr " + a + ", i64 " + n + ")"
+}
+
+/// mirCallRuntimeVoidPtrI64I64Text renders
+/// `  call void @<symbol>(ptr <a>, i64 <n>, i64 <m>)`. The three-arg
+/// (ptr+two-int) void-returning runtime call form used by sample
+/// emission and benchmark publish.
+pub fn mirCallRuntimeVoidPtrI64I64Text(symbol: String, a: String, n: String, m: String) -> String {
+    "  call void @" + symbol + "(ptr " + a + ", i64 " + n + ", i64 " + m + ")"
+}
+
+/// mirCallRuntimePtrI64Text renders
+/// `  <reg> = call ptr @<symbol>(i64 <n>)`. The single-int-arg ptr-
+/// returning runtime call form used by allocator probes (samples_new,
+/// etc.).
+pub fn mirCallRuntimePtrI64Text(reg: String, symbol: String, n: String) -> String {
+    "  " + reg + " = call ptr @" + symbol + "(i64 " + n + ")"
+}
+
+/// mirCallRuntimePtrI64PtrText renders
+/// `  <reg> = call ptr @<symbol>(i64 <n>, ptr <p>)`. The (count, ptr)
+/// ptr-returning runtime call form used by interpolation / argv
+/// marshalling. `n` is a decimal-digit String.
+pub fn mirCallRuntimePtrI64PtrText(reg: String, symbol: String, n: String, p: String) -> String {
+    "  " + reg + " = call ptr @" + symbol + "(i64 " + n + ", ptr " + p + ")"
+}
+
+/// mirGCMarkSlotText renders
+/// `  call void @osty.gc.mark_slot_v1(ptr <addr>)`. The GC root-mark
+/// helper called at every safepoint slot.
+pub fn mirGCMarkSlotText(addr: String) -> String {
+    "  call void @osty.gc.mark_slot_v1(ptr " + addr + ")"
+}
+
+/// mirInsertValueIfaceCtorText renders
+/// `  <reg> = insertvalue %osty.iface zeroinitializer, ptr <slot>, 0`.
+/// The first-step iface-constructor form used by interface-boxing
+/// dispatch.
+pub fn mirInsertValueIfaceCtorText(reg: String, slot: String) -> String {
+    "  " + reg + " = insertvalue %osty.iface zeroinitializer, ptr " + slot + ", 0"
+}
+
+/// mirInsertValueIfaceVtableText renders
+/// `  <reg> = insertvalue %osty.iface <iface>, ptr <vtable>, 1`. The
+/// second-step iface-constructor form (vtable slot fill).
+pub fn mirInsertValueIfaceVtableText(reg: String, iface: String, vtable: String) -> String {
+    "  " + reg + " = insertvalue %osty.iface " + iface + ", ptr " + vtable + ", 1"
+}
+
+/// mirExtractValueIfacePtrText renders
+/// `  <reg> = extractvalue %osty.iface <iface>, 0`. Extract the
+/// data-pointer from an iface value (ABI slot 0).
+pub fn mirExtractValueIfacePtrText(reg: String, iface: String) -> String {
+    "  " + reg + " = extractvalue %osty.iface " + iface + ", 0"
+}
+
+/// mirExtractValueIfaceVtableText renders
+/// `  <reg> = extractvalue %osty.iface <iface>, 1`. Extract the
+/// vtable-pointer from an iface value (ABI slot 1).
+pub fn mirExtractValueIfaceVtableText(reg: String, iface: String) -> String {
+    "  " + reg + " = extractvalue %osty.iface " + iface + ", 1"
+}
+
+/// mirPhiPtrFromValueOrNullText renders
+/// `  <reg> = phi ptr [ <val>, %<valLabel> ], [ null, %<nullLabel> ]`.
+/// The Option<ptr-shape> joinpoint phi: one incoming with a
+/// concrete pointer, the other with null.
+pub fn mirPhiPtrFromValueOrNullText(
+    reg: String,
+    val: String,
+    valLabel: String,
+    nullLabel: String,
+) -> String {
+    "  " + reg + " = phi ptr [ " + val + ", %" + valLabel +
+        " ], [ null, %" + nullLabel + " ]"
+}
+
+/// mirPhiI64FromValueOrZeroText renders
+/// `  <reg> = phi i64 [ <val>, %<valLabel> ], [ 0, %<zeroLabel> ]`.
+/// The two-incoming-edge i64 phi: one branch carries a computed
+/// value, the other zero.
+pub fn mirPhiI64FromValueOrZeroText(
+    reg: String,
+    val: String,
+    valLabel: String,
+    zeroLabel: String,
+) -> String {
+    "  " + reg + " = phi i64 [ " + val + ", %" + valLabel +
+        " ], [ 0, %" + zeroLabel + " ]"
+}
+
+/// mirPhiTypedTwoEdgeText renders
+/// `  <reg> = phi <ty> [ <a>, %<la> ], [ <b>, %<lb> ]`. The general
+/// two-incoming-edge phi form for arbitrary types — used by ?? and
+/// if-expr joinpoints when the merge type isn't ptr-or-null.
+pub fn mirPhiTypedTwoEdgeText(
+    reg: String,
+    ty: String,
+    a: String,
+    la: String,
+    b: String,
+    lb: String,
+) -> String {
+    "  " + reg + " = phi " + ty + " [ " + a + ", %" + la +
+        " ], [ " + b + ", %" + lb + " ]"
+}
+
+/// mirGEPInboundsRawIndicesText renders
+/// `  <reg> = getelementptr inbounds <ty>, ptr <basePtr>, <indices>`.
+/// The raw-indices form for nested-aggregate offset computation —
+/// `indices` is a pre-formatted comma-separated index list (e.g.
+/// `i32 0, i32 0, i32 1` for `Tuple.0.field1`). The struct-field
+/// helpers above are specialisations of this.
+pub fn mirGEPInboundsRawIndicesText(
+    reg: String,
+    ty: String,
+    basePtr: String,
+    indices: String,
+) -> String {
+    "  " + reg + " = getelementptr inbounds " + ty + ", ptr " + basePtr +
+        ", " + indices
+}
+
+/// mirGEPInboundsNullRawIndicesText renders
+/// `  <reg> = getelementptr inbounds <ty>, ptr null, <indices>`. The
+/// null-base form used by aggregate root-offset computation —
+/// `indices` is the pre-formatted index list (e.g. `i32 0, i32 1`).
+/// The result ptr-to-int converts to the byte offset of that field.
+pub fn mirGEPInboundsNullRawIndicesText(
+    reg: String,
+    ty: String,
+    indices: String,
+) -> String {
+    "  " + reg + " = getelementptr inbounds " + ty + ", ptr null, " + indices
+}
+
+/// mirCallTypedFnPtrText renders
+/// `  <reg> = call <retTyp> <fnPtr>(<argList>)`. The indirect-call
+/// form for vtable dispatch through a function pointer — `argList`
+/// is a pre-formatted comma-separated typed-arg list. The direct-
+/// symbol forms (`mirCallRuntime*Text`) live separately so call
+/// sites that just call a named runtime symbol stay readable.
+pub fn mirCallTypedFnPtrText(
+    reg: String,
+    retTyp: String,
+    fnPtr: String,
+    argList: String,
+) -> String {
+    "  " + reg + " = call " + retTyp + " " + fnPtr + "(" + argList + ")"
+}
+
+/// mirCallI1FromArgsText renders
+/// `  <reg> = call i1 @<symbol>(<argList>)`. The i1-returning runtime
+/// call form used by Map.get probe / boolean predicate helpers.
+pub fn mirCallI1FromArgsText(reg: String, symbol: String, argList: String) -> String {
+    "  " + reg + " = call i1 @" + symbol + "(" + argList + ")"
+}
+
+/// mirCallTypedFromArgsText renders
+/// `  <reg> = call <retTyp> @<symbol>(<argList>)`. The general
+/// typed-return runtime-call form. Specialisations of this shape
+/// (`mirCallRuntimeI64NoArgsText`, `mirCallRuntimePtrI64Text`,
+/// `mirCallI1FromArgsText`) stay separate for readability at hot
+/// shape sites.
+pub fn mirCallTypedFromArgsText(reg: String, retTyp: String, symbol: String, argList: String) -> String {
+    "  " + reg + " = call " + retTyp + " @" + symbol + "(" + argList + ")"
+}
+
+/// mirICmpEqI32ZeroText renders `  <reg> = icmp eq i32 <lhs>, 0`.
+/// Width-specialised i32-zero probe — used by char-class and width-
+/// shrunken int comparisons.
+pub fn mirICmpEqI32ZeroText(reg: String, lhs: String) -> String {
+    "  " + reg + " = icmp eq i32 " + lhs + ", 0"
+}
+
+/// mirICmpNEI64ZeroText renders `  <reg> = icmp ne i64 <lhs>, 0`.
+/// The non-zero probe used by Result tag-checking and pointer-
+/// truthiness.
+pub fn mirICmpNEI64ZeroText(reg: String, lhs: String) -> String {
+    "  " + reg + " = icmp ne i64 " + lhs + ", 0"
+}
+
+/// mirICmpEqI1Text renders `  <reg> = icmp eq i1 <lhs>, <rhs>`. The
+/// bool-equality probe — used by Option<Bool> match-arm dispatch.
+pub fn mirICmpEqI1Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = icmp eq i1 " + lhs + ", " + rhs
+}
+
+/// mirAddI64LiteralText renders
+/// `  <reg> = add i64 <lhs>, <lit>`. i64 addition with a baked
+/// literal — used by stride / offset arithmetic.
+pub fn mirAddI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = add i64 " + lhs + ", " + lit
+}
+
+/// mirSubI64LiteralText renders
+/// `  <reg> = sub i64 <lhs>, <lit>`. i64 subtraction with a baked
+/// literal — used by index normalisation and length adjustments.
+pub fn mirSubI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = sub i64 " + lhs + ", " + lit
+}
+
+/// mirSubI64OneText renders `  <reg> = sub i64 <lhs>, 1`. The
+/// decrement-by-one form — symmetric counterpart to
+/// `mirAddI64OneText` for inclusive-range upper-bound math.
+pub fn mirSubI64OneText(reg: String, lhs: String) -> String {
+    "  " + reg + " = sub i64 " + lhs + ", 1"
+}
+
+/// mirShlI64Text renders `  <reg> = shl i64 <lhs>, <rhs>`. General
+/// i64 left-shift (bit-mixing, hash-finalisation, log2 derivation).
+pub fn mirShlI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = shl i64 " + lhs + ", " + rhs
+}
+
+/// mirShlI64LiteralText renders
+/// `  <reg> = shl i64 <lhs>, <lit>`. i64 left-shift by a baked
+/// literal count — used by stride / power-of-two bucket math.
+pub fn mirShlI64LiteralText(reg: String, lhs: String, lit: String) -> String {
+    "  " + reg + " = shl i64 " + lhs + ", " + lit
+}
+
+/// mirLShrI64Text renders `  <reg> = lshr i64 <lhs>, <rhs>`. Logical
+/// (unsigned) i64 right-shift.
+pub fn mirLShrI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = lshr i64 " + lhs + ", " + rhs
+}
+
+/// mirAShrI64Text renders `  <reg> = ashr i64 <lhs>, <rhs>`.
+/// Arithmetic (sign-preserving) i64 right-shift.
+pub fn mirAShrI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = ashr i64 " + lhs + ", " + rhs
+}
+
+/// mirAndI64Text renders `  <reg> = and i64 <lhs>, <rhs>`. General
+/// i64 bitwise-and.
+pub fn mirAndI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = and i64 " + lhs + ", " + rhs
+}
+
+/// mirOrI64Text renders `  <reg> = or i64 <lhs>, <rhs>`. General
+/// i64 bitwise-or.
+pub fn mirOrI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = or i64 " + lhs + ", " + rhs
+}
+
+/// mirXorI64Text renders `  <reg> = xor i64 <lhs>, <rhs>`. General
+/// i64 bitwise-xor.
+pub fn mirXorI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = xor i64 " + lhs + ", " + rhs
+}
+
+/// mirSremI64Text renders `  <reg> = srem i64 <lhs>, <rhs>`. Signed
+/// i64 remainder.
+pub fn mirSremI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = srem i64 " + lhs + ", " + rhs
+}
+
+/// mirURemI64Text renders `  <reg> = urem i64 <lhs>, <rhs>`. Unsigned
+/// i64 remainder.
+pub fn mirURemI64Text(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = urem i64 " + lhs + ", " + rhs
+}
+
+/// mirFAddText renders `  <reg> = fadd double <lhs>, <rhs>`. Double-
+/// precision floating-point addition.
+pub fn mirFAddText(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fadd double " + lhs + ", " + rhs
+}
+
+/// mirFSubText renders `  <reg> = fsub double <lhs>, <rhs>`. Double-
+/// precision floating-point subtraction.
+pub fn mirFSubText(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fsub double " + lhs + ", " + rhs
+}
+
+/// mirFMulText renders `  <reg> = fmul double <lhs>, <rhs>`. Double-
+/// precision floating-point multiplication.
+pub fn mirFMulText(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fmul double " + lhs + ", " + rhs
+}
+
+/// mirFDivText renders `  <reg> = fdiv double <lhs>, <rhs>`. Double-
+/// precision floating-point division.
+pub fn mirFDivText(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fdiv double " + lhs + ", " + rhs
+}
+
+/// mirFCmpOEqText renders `  <reg> = fcmp oeq double <lhs>, <rhs>`.
+/// Ordered-equality double comparison (returns false when either
+/// operand is NaN).
+pub fn mirFCmpOEqText(reg: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fcmp oeq double " + lhs + ", " + rhs
+}
+
+/// mirFCmpText renders `  <reg> = fcmp <pred> double <lhs>, <rhs>`.
+/// General floating-point compare with explicit predicate keyword
+/// (`oeq`, `one`, `olt`, `ogt`, `ole`, `oge`, `ord`, `uno`, ...).
+pub fn mirFCmpText(reg: String, pred: String, lhs: String, rhs: String) -> String {
+    "  " + reg + " = fcmp " + pred + " double " + lhs + ", " + rhs
+}
+
+/// mirSIToFPText renders `  <reg> = sitofp i64 <src> to double`.
+/// Signed-int → double conversion.
+pub fn mirSIToFPText(reg: String, src: String) -> String {
+    "  " + reg + " = sitofp i64 " + src + " to double"
+}
+
+/// mirFPToSIText renders `  <reg> = fptosi double <src> to i64`.
+/// Double → signed-int truncation.
+pub fn mirFPToSIText(reg: String, src: String) -> String {
+    "  " + reg + " = fptosi double " + src + " to i64"
+}
+
+/// mirAllocaI8Text renders `  <reg> = alloca i8`. Byte-width slot —
+/// used by Char and Bool spills.
+pub fn mirAllocaI8Text(reg: String) -> String {
+    "  " + reg + " = alloca i8"
+}
+
+/// mirAllocaDoubleText renders `  <reg> = alloca double`. Double-
+/// width slot — used by Float64 spills.
+pub fn mirAllocaDoubleText(reg: String) -> String {
+    "  " + reg + " = alloca double"
+}
+
+/// mirLoadDoubleText renders `  <reg> = load double, ptr <slot>`.
+/// Double-precision FP load.
+pub fn mirLoadDoubleText(reg: String, slot: String) -> String {
+    "  " + reg + " = load double, ptr " + slot
+}
+
+/// mirLoadI8Text renders `  <reg> = load i8, ptr <slot>`. Byte-width
+/// load — used by Char / Bool reload.
+pub fn mirLoadI8Text(reg: String, slot: String) -> String {
+    "  " + reg + " = load i8, ptr " + slot
+}
+
+/// mirStoreDoubleText renders `  store double <val>, ptr <slot>`.
+/// Double-precision FP store.
+pub fn mirStoreDoubleText(val: String, slot: String) -> String {
+    "  store double " + val + ", ptr " + slot
+}

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -13043,3 +13043,123 @@ pub fn mirDataLayoutFor(target: String) -> String {
     }
     ""
 }
+
+/// §19 — pure string helpers ported from `internal/llvmgen/{expr,
+/// generator,ir_module,stdlib_shim,stmt,type}.go`. Each one produces
+/// LLVM-text or symbol fragments without touching `*ast.*` / `*mir.*`
+/// types, so they belong on the Osty side; the Go callers stay as
+/// thin wrappers.
+
+/// mirResultVariantName returns the canonical Osty `Result<...>` enum
+/// variant name for a runtime tag. The MIR lowering stores the
+/// discriminant as `tag = 0` for `Ok` and `tag = 1` for `Err`; the
+/// LLVM emitter translates that back into the source-level variant
+/// when synthesizing payload type lookups for `match` arms.
+pub fn mirResultVariantName(tag: Int) -> String {
+    if tag == 1 { return "Err" }
+    "Ok"
+}
+
+/// mirLlvmPointerOperand canonicalizes a pointer operand for LLVM-IR
+/// rendering. Empty or `null` strings round-trip; values already
+/// prefixed with `@` (global) or `%` (local) round-trip; bare names
+/// are reified as global references with a leading `@`. Used by every
+/// runtime trace-symbol callsite that drops a `ptr` operand into an
+/// `osty.gc.*` or `osty.runtime.*` call argument list.
+pub fn mirLlvmPointerOperand(name: String) -> String {
+    if name == "" || name == "null" { return name }
+    if llvmStrings.HasPrefix(name, "@") || llvmStrings.HasPrefix(name, "%") {
+        return name
+    }
+    "@" + name
+}
+
+/// mirSplitQualifiedName splits a dotted-qualified symbol name (e.g.
+/// `pkg.Type.method`) into its path components. Empty input yields
+/// an empty list — the IR-module emitter relies on this for the
+/// `Package == ""` fast-path when collecting external decl paths.
+pub fn mirSplitQualifiedName(name: String) -> List<String> {
+    if name == "" { return [] }
+    llvmStrings.split(name, ".")
+}
+
+/// mirScalarSomeBoxByteSize returns the heap-box payload size in
+/// bytes for a scalar `Some(...)` constructor, or `0` when the LLVM
+/// type isn't a recognized primitive width. Mirrors
+/// `listGetBoxByteSize` for the Some-construction path: the result
+/// pins the `osty.gc.alloc_v1` byte size so `Option<T>` stays
+/// uniformly ptr-backed at the LLVM layer regardless of T.
+///
+/// The Go-side wrapper rebuilds the original `(int, bool)` shape via
+/// `size > 0`; callers that only need the boolean check can compare
+/// the result to zero directly.
+pub fn mirScalarSomeBoxByteSize(typ: String) -> Int {
+    if typ == "i64" || typ == "double" { return 8 }
+    if typ == "i32" { return 4 }
+    if typ == "i8" || typ == "i1" { return 1 }
+    0
+}
+
+/// mirLlvmBuiltinAggregateName composes the canonical aggregate type
+/// name for a builtin shape (`Tuple`, `Result`, ...). Each part is
+/// folded through `mirLLVMBuiltinAggregatePart` so non-identifier
+/// fragments collapse to underscores; the result joins on `.` with a
+/// leading `%` so it lands as an LLVM type reference.
+pub fn mirLlvmBuiltinAggregateName(prefix: String, parts: List<String>) -> String {
+    let mut names = [prefix]
+    for p in parts { names.push(mirLLVMBuiltinAggregatePart(p)) }
+    "%" + llvmStrings.join(names, ".")
+}
+
+/// mirLlvmResultTypeName returns the canonical LLVM aggregate name
+/// for `Result<Ok, Err>`. The two payload type names are folded
+/// through the aggregate sanitizer the same way the tuple form does.
+pub fn mirLlvmResultTypeName(okTyp: String, errTyp: String) -> String {
+    mirLlvmBuiltinAggregateName("Result", [okTyp, errTyp])
+}
+
+/// mirLlvmTupleTypeName returns the canonical LLVM aggregate name
+/// for an N-ary tuple. An empty list yields the unit-tuple name
+/// `%Tuple`; otherwise each element type folds through the aggregate
+/// sanitizer.
+pub fn mirLlvmTupleTypeName(elemTypes: List<String>) -> String {
+    mirLlvmBuiltinAggregateName("Tuple", elemTypes)
+}
+
+/// mirNormalizeAssertExprText folds whitespace runs in the source
+/// text of an `assert` expression so the captured text fits cleanly
+/// inside a one-line diagnostic message. Newlines, carriage returns,
+/// and tabs collapse to a single space; trailing/leading whitespace
+/// is trimmed. The Go caller re-slices the original source bytes
+/// before calling this; we operate on the byte stream directly.
+pub fn mirNormalizeAssertExprText(text: String) -> String {
+    let mut buf = ""
+    let mut prevSpace = false
+    let n = text.len()
+    let mut i = 0
+    for i < n {
+        let mut ch = text[i..(i + 1)]
+        if ch == "\n" || ch == "\r" || ch == "\t" {
+            ch = " "
+        }
+        if ch == " " {
+            if prevSpace {
+                i = i + 1
+                continue
+            }
+            prevSpace = true
+        } else {
+            prevSpace = false
+        }
+        buf = buf + ch
+        i = i + 1
+    }
+    // Trim leading / trailing single-space (the run-collapse leaves at
+    // most one).
+    let blen = buf.len()
+    let mut lo = 0
+    let mut hi = blen
+    if hi > 0 && buf[0..1] == " " { lo = 1 }
+    if hi > lo && buf[(hi - 1)..hi] == " " { hi = hi - 1 }
+    buf[lo..hi]
+}


### PR DESCRIPTION
## Summary

Two-slice cluster port to scale up the MIR→LLVM emitter self-host. PR contains:

### Slice 8 (commit d9b932ec): 8 pure string helpers
| Go (before) | Osty (after) | File |
|---|---|---|
| \`resultVariantName\` | \`mirResultVariantName\` | expr.go |
| \`llvmPointerOperand\` | \`mirLlvmPointerOperand\` | generator.go |
| \`splitQualifiedName\` | \`mirSplitQualifiedName\` | ir_module.go |
| \`scalarSomeBoxByteSize\` | \`mirScalarSomeBoxByteSize\` | stdlib_shim.go |
| \`llvmBuiltinAggregateName\` | \`mirLlvmBuiltinAggregateName\` | type.go |
| \`llvmResultTypeName\` | \`mirLlvmResultTypeName\` | type.go |
| \`llvmTupleTypeName\` | \`mirLlvmTupleTypeName\` | type.go |
| \`normalizeAssertExprText\` | \`mirNormalizeAssertExprText\` | stmt.go |

### Slice 9 (commit 83f5dc2f): 125 new Text-variant builders + 282 drains

Adds a §20 family of **newline-free** \`Text\` variants of common Line builders.
Existing \`Line\` builders end with \`\n\` (for \`g.fnBuf.WriteString\` direct
buffer writes), so the inline IR sites in expr.go/stmt.go/generator.go that
use \`emitter.body = append(...)\` (where entries get joined on \`\n\`) couldn't
drain to those — extra newline would be injected. The Text family closes
that gap.

Coverage: alloca/load/store across i8/i32/i64/ptr/double widths,
br_cond/br_uncond/label/ret/phi (including specialised
typed-two-edge, ptr-or-null, i64-or-zero forms), arithmetic
(add/sub/mul/sdiv/srem/urem/shl/lshr/ashr) with literal-RHS variants,
bitwise (and/or/xor) for i1/i64, floating-point (fadd/fsub/fmul/fdiv/fcmp +
sitofp/fptosi), icmp predicates (eq/sgt/sge/slt/ult) with literal-RHS variants,
select (typed and i32/i64 specialised, including literal-arm variants),
zext (i8→i32/i64, i32→i64), trunc (i64→i8/i32), getelementptr
(inbounds-zero, inbounds-field, inbounds-i8, sizeof, array-element,
raw-indices, null-base-raw-indices), runtime call shapes, iface composites
(insertvalue ctor/vtable, extractvalue data/vtable), gc.mark_slot_v1.

Drain count: 282 inline \`body = append(body, fmt.Sprintf(...))\` sites
across expr.go (130), stmt.go (133), generator.go (19). Sites where the
format string isn't a clean IR line shape (error messages, dynamic comments,
complex pre-format expressions) are left inline.

## Scale

| | Insertions | Deletions |
|---|---|---|
| Slice 8 | 223 | 47 |
| Slice 9 | 1613 | 346 |
| **Total** | **1836** | **393** |

About 8× the average recent slice (PRs #976/#975/#980 averaged ~80 insertions/PR).

## Byte-stable parity

- \`just front\` passes
- \`go build ./internal/llvmgen/\` clean
- \`go vet ./internal/llvmgen/\` clean
- \`go test -short ./internal/llvmgen/\` shows exactly the 6 pre-existing
  baseline failures (TestGenerateModuleMethodLocalGenericGetMonomorphized +
  4 native-entry/native-interface coverage tests + 1 nested-struct-binding
  test) — no new failures introduced by either slice

## Test plan
- [x] \`just front\` (frontend packages)
- [x] \`go test -short ./internal/llvmgen/\` matches pre-stash baseline
- [x] All Go callers compile and pass type checking