### PR TITLE
perf(runtime): make Channel + GENERIC TASK_HANDLE young-eligible (cheney coverage complete)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3782,7 +3782,11 @@ int main(void) {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
 	runCmd := exec.Command(binaryPath)
-	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	/* Same opt-out as the Map remap tests — pin the headerful
+	 * Phase D compaction + remap path. Channel is now young-eligible
+	 * by default, so without this it goes through cheney instead. */
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_THRESHOLD_BYTES=1", "OSTY_GC_TINYTAG_YOUNG=0")
 	runOutput, err := runCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
@@ -5809,18 +5813,18 @@ int64_t osty_gc_debug_young_header_object_kind(void *payload);
 int64_t osty_gc_debug_young_header_byte_size(void *payload);
 int64_t osty_gc_debug_young_header_generation(void *payload);
 
-void *osty_rt_thread_chan_make(int64_t capacity);
+void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_pinned_v1"));
 
 #define KIND_LIST 1024
 #define KIND_STRING 1025
 
 int main(void) {
-    /* Channel stays headerful (KIND_CHANNEL has a pthread-rich
-     * destroy that the dead-from-space scan doesn't yet cover), so
-     * the predicate must classify it as not-young regardless of
-     * flag state. Picked over Map because Map is now young-eligible. */
-    void *chan = osty_rt_thread_chan_make(1);
-    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(chan));
+    /* Pinned allocs always go headerful regardless of kind / flag
+     * (the pinned arena is a separate bump region — never young).
+     * Picked because every kind in the eligibility set is now
+     * young-eligible by default. */
+    void *headerful = osty_gc_alloc_pinned_v1(KIND_STRING, 32, "non-young");
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(headerful));
 
     /* Direct young alloc (Phase 6 will route real allocators here). */
     void *young = osty_gc_debug_allocate_young(48, KIND_STRING);
@@ -6316,15 +6320,16 @@ int64_t osty_gc_debug_young_eligible(int64_t byte_size, int64_t object_kind);
 void *osty_gc_debug_allocate_young_if_eligible(int64_t byte_size, int64_t object_kind);
 int64_t osty_gc_debug_arena_is_young_page(void *payload);
 
-#define KIND_GENERIC           1
-#define KIND_LIST              1024
-#define KIND_STRING            1025
-#define KIND_MAP               1026
-#define KIND_SET               1027
-#define KIND_BYTES             1028
-#define KIND_CLOSURE_ENV       1029
-#define KIND_CHANNEL           1030
-#define KIND_GENERIC_ENUM_PTR  1031
+#define KIND_GENERIC              1
+#define KIND_LIST                 1024
+#define KIND_STRING               1025
+#define KIND_MAP                  1026
+#define KIND_SET                  1027
+#define KIND_BYTES                1028
+#define KIND_CLOSURE_ENV          1029
+#define KIND_CHANNEL              1030
+#define KIND_GENERIC_ENUM_PTR     1031
+#define KIND_GENERIC_TASK_HANDLE  1032
 
 int main(void) {
     /* Each row prints "<eligible> <ptr_was_young>" where eligible is
@@ -6332,7 +6337,8 @@ int main(void) {
      * returned a payload that lands in the young arena, else 0. */
     int64_t kinds[] = {
         KIND_GENERIC, KIND_LIST, KIND_STRING, KIND_MAP, KIND_SET,
-        KIND_BYTES, KIND_CLOSURE_ENV, KIND_CHANNEL, KIND_GENERIC_ENUM_PTR
+        KIND_BYTES, KIND_CLOSURE_ENV, KIND_CHANNEL,
+        KIND_GENERIC_ENUM_PTR, KIND_GENERIC_TASK_HANDLE
     };
     for (size_t i = 0; i < sizeof(kinds) / sizeof(kinds[0]); i++) {
         int64_t k = kinds[i];
@@ -6375,24 +6381,27 @@ int main(void) {
 				"1029 0 0", // CLOSURE_ENV
 				"1030 0 0", // CHANNEL
 				"1031 0 0", // GENERIC_ENUM_PTR
+				"1032 0 0", // GENERIC_TASK_HANDLE
 			},
 		},
 		{
-			// Default routing: cheney_minor traces OLD reachability
-			// transitively, so Map<String, _> still works even with
-			// young String keys.
+			// Default routing: every kind with a wired safe-clone
+			// path lands young. CHANNEL and GENERIC_TASK_HANDLE
+			// joined the eligible set via the Map-style mutex
+			// + condvar handoff in cheney_forward / promote.
 			name: "default",
 			env:  nil,
 			wantRows: []string{
 				"1 1 1",    // GENERIC: eligible under NONE pattern (debug entry assumes NULL trace/destroy)
 				"1024 1 1", // LIST: eligible (load_v1 PROMOTED follow + cheney self-ref fixup + dead-list scan)
 				"1025 1 1", // STRING: eligible
-				"1026 1 1", // MAP: eligible (cheney_forward + promote re-init mutex; dead-from-space calls map_destroy)
-				"1027 1 1", // SET: eligible (dead-from-space scan frees items buffer; no inline-storage union)
+				"1026 1 1", // MAP: eligible (mutex safe-handoff + dead-from-space delegate)
+				"1027 1 1", // SET: eligible (dead-from-space scan frees items buffer)
 				"1028 1 1", // BYTES: eligible
 				"1029 1 1", // CLOSURE_ENV: eligible (captures populated synchronously before escape)
-				"1030 0 0", // CHANNEL: has destroy
+				"1030 1 1", // CHANNEL: eligible (mutex + 2 condvar safe-handoff)
 				"1031 1 1", // GENERIC_ENUM_PTR: eligible (kind_table dispatch reaches the trace)
+				"1032 1 1", // GENERIC_TASK_HANDLE: eligible (mutex + condvar safe-handoff)
 			},
 		},
 	} {
@@ -6404,8 +6413,8 @@ int main(void) {
 				t.Fatalf("run failed: %v\n%s", err, runOutput)
 			}
 			lines := strings.Split(strings.TrimRight(string(runOutput), "\n"), "\n")
-			if len(lines) != 12 {
-				t.Fatalf("expected 12 output lines, got %d: %q", len(lines), runOutput)
+			if len(lines) != 13 {
+				t.Fatalf("expected 13 output lines, got %d: %q", len(lines), runOutput)
 			}
 			for i, want := range tc.wantRows {
 				if lines[i] != want {
@@ -6413,14 +6422,14 @@ int main(void) {
 						i, lines[i], want, runOutput)
 				}
 			}
-			if lines[9] != "zero 0" {
-				t.Fatalf("zero-size row: got %q, want %q", lines[9], "zero 0")
+			if lines[10] != "zero 0" {
+				t.Fatalf("zero-size row: got %q, want %q", lines[10], "zero 0")
 			}
-			if lines[10] != "huge 0" {
-				t.Fatalf("huge-size row: got %q, want %q", lines[10], "huge 0")
+			if lines[11] != "huge 0" {
+				t.Fatalf("huge-size row: got %q, want %q", lines[11], "huge 0")
 			}
-			if lines[11] != "neg 0" {
-				t.Fatalf("neg-size row: got %q, want %q", lines[11], "neg 0")
+			if lines[12] != "neg 0" {
+				t.Fatalf("neg-size row: got %q, want %q", lines[12], "neg 0")
 			}
 		})
 	}
@@ -7006,6 +7015,102 @@ int main(void) {
 	}, "\n")
 	if got := string(runOutput); got != want {
 		t.Fatalf("generic-enum-ptr-young harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestBundledRuntimeChannelYoungLifecycle covers Channel young
+// eligibility: a fresh `osty_rt_thread_chan_make` lands in the
+// young arena, send/recv keep working through `osty_gc_load_v1`'s
+// PROMOTED follow after `root_bind` promotes the channel to OLD,
+// and the slots heap buffer + mutex + 2 condvars are reclaimed
+// cleanly when an UNFORWARDED young Channel is swept by
+// `osty_gc_cheney_destroy_dead_from_space`.
+func TestBundledRuntimeChannelYoungLifecycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_chan_young_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_chan_young_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_thread_chan_send_i64(void *raw, int64_t value);
+int64_t osty_rt_thread_chan_recv_i64(void *raw);
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+int64_t osty_gc_debug_arena_is_young_page(void *payload);
+int64_t osty_gc_debug_young_forward_tag(void *from_payload);
+void osty_gc_debug_collect(void);
+
+int main(void) {
+    /* Fresh Channel goes young (KIND_CHANNEL is now in the
+     * eligibility list; sizeof(osty_rt_chan_impl) is well under
+     * the humongous threshold). */
+    void *raw = osty_rt_thread_chan_make(4);
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page(raw));
+
+    /* Send before root_bind populates slots through the still-young
+     * channel handle. */
+    osty_rt_thread_chan_send_i64(raw, 100);
+    osty_rt_thread_chan_send_i64(raw, 200);
+
+    /* root_bind promotes the young Channel to OLD via the safe-clone
+     * handoff: re-init dst's mutex + 2 condvars, destroy src's,
+     * null-steal the slots pointer. */
+    osty_gc_root_bind_v1(raw);
+    printf("%lld\n", (long long)osty_gc_debug_young_forward_tag(raw));
+
+    /* Send via the stale young handle works — chan_cast goes through
+     * load_v1 which follows the PROMOTED tag. */
+    osty_rt_thread_chan_send_i64(raw, 300);
+
+    /* Forced collect: cheney processes the (PROMOTED) young channel,
+     * the major sweep keeps OLD alive via the root binding. The
+     * slots buffer survives because the OLD copy now owns it. */
+    osty_gc_debug_collect();
+
+    /* Recv all three values to confirm the slots buffer survived
+     * the cheney + major cycle intact. */
+    int64_t v1 = osty_rt_thread_chan_recv_i64(raw);
+    int64_t v2 = osty_rt_thread_chan_recv_i64(raw);
+    int64_t v3 = osty_rt_thread_chan_recv_i64(raw);
+    printf("%lld %lld %lld\n", (long long)v1, (long long)v2, (long long)v3);
+
+    osty_gc_root_release_v1(raw);
+    osty_gc_debug_collect();
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"1",           // fresh Channel landed in young arena
+		"2",           // forward tag = PROMOTED after root_bind
+		"100 200 300", // all three values readable via load_v1 follow + cheney survival
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("chan-young harness output mismatch\n got: %q\nwant: %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -581,6 +581,13 @@ typedef struct osty_rt_chan_impl {
     int64_t *slots;
 } osty_rt_chan_impl;
 
+/* Forward typedef for the task-handle struct; full definition lives
+ * with the rest of the scheduler down below. The cheney_forward /
+ * promote young paths only need the typedef name to cast the void*
+ * payload — the safe-handoff body that touches struct fields lives
+ * next to the full definition. */
+typedef struct osty_rt_task_handle_impl_ osty_rt_task_handle_impl;
+
 typedef struct osty_gc_free_chunk {
     struct osty_gc_free_chunk *next;
     size_t total_size;
@@ -643,9 +650,15 @@ enum {
      * `header->generic_pattern` byte). Lets `osty_rt_enum_alloc_ptr_v1`
      * route through the no-header young arena: the trace
      * (`osty_rt_enum_ptr_payload_trace`) follows a single managed
-     * pointer payload, and there's no destroy callback. The other
-     * GENERIC patterns (NONE, TASK_HANDLE) keep using OSTY_GC_KIND_GENERIC. */
+     * pointer payload, and there's no destroy callback. */
     OSTY_GC_KIND_GENERIC_ENUM_PTR = 1031,
+    /* Same split for TASK_HANDLE so cheney's young dispatch can find
+     * the destroy + safe-handoff via the kind table. The destroy
+     * tears down the embedded mutex + condvar, so the safe-clone
+     * pattern (re-init dst's sync, destroy src's) is required at
+     * cheney_forward / promote_young_to_old. The remaining GENERIC
+     * pattern (NONE) keeps using OSTY_GC_KIND_GENERIC. */
+    OSTY_GC_KIND_GENERIC_TASK_HANDLE = 1032,
 };
 
 /* Phase 1 of the tiny-tag young space landing: a per-kind descriptor table
@@ -682,6 +695,8 @@ static void osty_gc_remap_set_payload(void *payload);
 static void osty_gc_remap_closure_env_payload(void *payload);
 static void osty_gc_remap_chan_payload(void *payload);
 static void osty_gc_remap_slot(void *slot_addr);
+static void osty_gc_cleanup_young_dead_chan(void *payload);
+static void osty_gc_cleanup_young_dead_task_handle(void *payload);
 
 typedef struct osty_gc_kind_descriptor {
     osty_gc_trace_fn trace;
@@ -783,13 +798,17 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .young_eligible = true,
         .remap = osty_gc_remap_closure_env_payload,
     },
-    /* CHANNEL stays headerful — destroy frees a mutex + 2 condvars
-     * + slots buffer, and the safe-clone primitives that Map uses
-     * for the cheney/promote path don't yet cover condvar
-     * destroy/init pairs. */
+    /* CHANNEL young-safe through the same handoff pattern as Map:
+     * `osty_gc_chan_safe_handoff` re-inits dst's mutex + 2 condvars
+     * and destroys src's, then null-steals the slots pointer. The
+     * cleanup helper delegates to `osty_rt_chan_destroy` to free
+     * the slots buffer + tear down sync state on UNFORWARDED young
+     * channels. */
     [OSTY_GC_KIND_CHANNEL - OSTY_GC_KIND_LIST] = {
         .trace = osty_rt_chan_trace,
         .destroy = osty_rt_chan_destroy,
+        .young_eligible = true,
+        .cleanup_young_dead = osty_gc_cleanup_young_dead_chan,
         .remap = osty_gc_remap_chan_payload,
     },
     [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] = {
@@ -797,18 +816,26 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .young_eligible = true,
         .remap = osty_gc_remap_slot,
     },
+    /* TASK_HANDLE young-safe through `osty_gc_task_handle_safe_handoff`
+     * (mutex + 1 condvar). No managed pointers in the payload, so no
+     * remap entry. */
+    [OSTY_GC_KIND_GENERIC_TASK_HANDLE - OSTY_GC_KIND_LIST] = {
+        .destroy = osty_rt_task_handle_destroy,
+        .young_eligible = true,
+        .cleanup_young_dead = osty_gc_cleanup_young_dead_task_handle,
+    },
 };
 
 _Static_assert(OSTY_GC_KIND_LIST == 1024,
                "kind descriptor table indexed off OSTY_GC_KIND_LIST");
-_Static_assert(OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST + 1 ==
+_Static_assert(OSTY_GC_KIND_GENERIC_TASK_HANDLE - OSTY_GC_KIND_LIST + 1 ==
                    sizeof(osty_gc_kind_table) /
                        sizeof(osty_gc_kind_table[0]),
                "kind descriptor table size mismatches enum range");
 
 static inline const osty_gc_kind_descriptor *osty_gc_kind_descriptor_lookup(
     int64_t kind) {
-    if (kind < OSTY_GC_KIND_LIST || kind > OSTY_GC_KIND_GENERIC_ENUM_PTR) {
+    if (kind < OSTY_GC_KIND_LIST || kind > OSTY_GC_KIND_GENERIC_TASK_HANDLE) {
         return NULL;
     }
     return &osty_gc_kind_table[kind - OSTY_GC_KIND_LIST];
@@ -3310,11 +3337,15 @@ static void *osty_gc_allocate_young_if_eligible(size_t byte_size,
     return osty_gc_allocate_young(byte_size, object_kind);
 }
 
-/* Forward decl for Map's safe-clone helper — used by
- * `cheney_forward`, `promote_young_to_old`, and
- * `osty_gc_clone_map_header_to_bump_region`. Defined further down
- * with the rest of the Map runtime. */
+/* Forward decls for safe-clone helpers used by `cheney_forward`,
+ * `promote_young_to_old`, and (Map only) the headerful compactor's
+ * `osty_gc_clone_map_header_to_bump_region`. Bodies live with each
+ * kind's runtime further down. */
 static void osty_gc_map_safe_handoff(osty_rt_map *src, osty_rt_map *dst);
+static void osty_gc_chan_safe_handoff(osty_rt_chan_impl *src,
+                                      osty_rt_chan_impl *dst);
+static void osty_gc_task_handle_safe_handoff(osty_rt_task_handle_impl *src,
+                                             osty_rt_task_handle_impl *dst);
 
 /* Phase 6 step 1: Cheney semi-space copy mechanic.
  *
@@ -3405,6 +3436,13 @@ static void *osty_gc_cheney_forward(void *from_payload) {
          * and inline-index self-ref re-anchoring. */
         osty_gc_map_safe_handoff((osty_rt_map *)from_payload,
                                  (osty_rt_map *)to_payload);
+    } else if (object_kind == OSTY_GC_KIND_CHANNEL) {
+        osty_gc_chan_safe_handoff((osty_rt_chan_impl *)from_payload,
+                                  (osty_rt_chan_impl *)to_payload);
+    } else if (object_kind == OSTY_GC_KIND_GENERIC_TASK_HANDLE) {
+        osty_gc_task_handle_safe_handoff(
+            (osty_rt_task_handle_impl *)from_payload,
+            (osty_rt_task_handle_impl *)to_payload);
     }
     src->forward_or_meta = (uint64_t)(uintptr_t)to_payload |
                            OSTY_GC_FORWARD_TAG_FORWARDED;
@@ -3461,6 +3499,8 @@ static void osty_gc_cheney_swap_arenas(void) {
 static int64_t osty_gc_young_cheney_dead_lists_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_sets_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_maps_freed_total = 0;
+static int64_t osty_gc_young_cheney_dead_chans_freed_total = 0;
+static int64_t osty_gc_young_cheney_dead_task_handles_freed_total = 0;
 static int64_t osty_gc_young_cheney_dead_buffer_bytes_freed_total = 0;
 
 static size_t osty_gc_micro_object_total_size(int32_t payload_size);
@@ -3498,6 +3538,16 @@ static void osty_gc_cleanup_young_dead_set(void *payload) {
 static void osty_gc_cleanup_young_dead_map(void *payload) {
     osty_rt_map_destroy(payload);
     osty_gc_young_cheney_dead_maps_freed_total += 1;
+}
+
+static void osty_gc_cleanup_young_dead_chan(void *payload) {
+    osty_rt_chan_destroy(payload);
+    osty_gc_young_cheney_dead_chans_freed_total += 1;
+}
+
+static void osty_gc_cleanup_young_dead_task_handle(void *payload) {
+    osty_rt_task_handle_destroy(payload);
+    osty_gc_young_cheney_dead_task_handles_freed_total += 1;
 }
 
 static void osty_gc_cheney_destroy_dead_from_space(unsigned char *from_base,
@@ -3649,6 +3699,13 @@ static void *osty_gc_promote_young_to_old(void *young_payload) {
         /* Same handoff as cheney_forward — see osty_gc_map_safe_handoff. */
         osty_gc_map_safe_handoff((osty_rt_map *)young_payload,
                                  (osty_rt_map *)new_payload);
+    } else if (object_kind == OSTY_GC_KIND_CHANNEL) {
+        osty_gc_chan_safe_handoff((osty_rt_chan_impl *)young_payload,
+                                  (osty_rt_chan_impl *)new_payload);
+    } else if (object_kind == OSTY_GC_KIND_GENERIC_TASK_HANDLE) {
+        osty_gc_task_handle_safe_handoff(
+            (osty_rt_task_handle_impl *)young_payload,
+            (osty_rt_task_handle_impl *)new_payload);
     }
     micro->forward_or_meta = (uint64_t)(uintptr_t)new_payload |
                              OSTY_GC_FORWARD_TAG_PROMOTED;
@@ -4376,6 +4433,32 @@ static void osty_gc_map_safe_handoff(osty_rt_map *src, osty_rt_map *dst) {
     src->index_slots = NULL;
     src->index_hashes = NULL;
 }
+
+/* Move Channel ownership from `src` to `dst` after a bit-copy.
+ * Same shape as osty_gc_map_safe_handoff but with three sync
+ * primitives (mutex + 2 condvars) instead of one. The slots
+ * pointer is heap-allocated (no inline-storage union to fix up). */
+static void osty_gc_chan_safe_handoff(osty_rt_chan_impl *src,
+                                      osty_rt_chan_impl *dst) {
+    if (src->sync_init) {
+        if (osty_rt_mu_init(&dst->mu) != 0 ||
+            osty_rt_cond_init(&dst->not_full) != 0 ||
+            osty_rt_cond_init(&dst->not_empty) != 0) {
+            osty_rt_abort("chan safe-handoff: sync init failed");
+        }
+        dst->sync_init = 1;
+        osty_rt_mu_destroy(&src->mu);
+        osty_rt_cond_destroy(&src->not_full);
+        osty_rt_cond_destroy(&src->not_empty);
+        src->sync_init = 0;
+    }
+    src->slots = NULL;
+}
+
+/* TASK_HANDLE safe-handoff body lives after the
+ * `osty_rt_task_handle_impl_` struct definition (the helper needs
+ * the full layout). Forward-declared earlier next to chan/map
+ * handoffs. */
 
 /* OSTY_HOT_INLINE: called from every Map probe iteration after the
  * fingerprint match short-circuit. The `kind` argument is a struct-
@@ -12510,8 +12593,10 @@ extern int sysctlbyname(const char *name, void *oldp, size_t *oldlenp,
 typedef int64_t (*osty_task_group_body_fn)(void *env, void *group);
 typedef int64_t (*osty_task_spawn_body_fn)(void *env);
 
+/* `osty_rt_task_handle_impl` typedef is forward-declared earlier
+ * (near `osty_rt_chan_impl`) so cheney's safe-handoff helpers can
+ * cast `void *` payloads to it. The full struct body follows below. */
 struct osty_rt_task_handle_impl_;
-typedef struct osty_rt_task_handle_impl_ osty_rt_task_handle_impl;
 
 typedef struct osty_rt_task_handle_node {
     osty_rt_task_handle_impl *handle;
@@ -12533,6 +12618,23 @@ struct osty_rt_task_handle_impl_ {
     osty_rt_cond_t cv;
     int sync_live;                       /* 1 iff mu/cv initialised */
 };
+
+/* TASK_HANDLE safe-handoff (forward-declared earlier with the
+ * cheney young-arena machinery). Mutex + condvar; no external
+ * buffers. Same pattern as osty_gc_chan_safe_handoff. */
+static void osty_gc_task_handle_safe_handoff(osty_rt_task_handle_impl *src,
+                                             osty_rt_task_handle_impl *dst) {
+    if (src->sync_live) {
+        if (osty_rt_mu_init(&dst->mu) != 0 ||
+            osty_rt_cond_init(&dst->cv) != 0) {
+            osty_rt_abort("task_handle safe-handoff: sync init failed");
+        }
+        dst->sync_live = 1;
+        osty_rt_mu_destroy(&src->mu);
+        osty_rt_cond_destroy(&src->cv);
+        src->sync_live = 0;
+    }
+}
 
 typedef struct osty_rt_task_item {
     void *body_env;
@@ -13244,10 +13346,14 @@ static void osty_rt_task_handle_destroy(void *payload) {
  * pauses collection so the pointer the task item carries cannot be
  * freed underneath it. */
 static osty_rt_task_handle_impl *osty_sched_alloc_handle(void) {
+    /* Use the dedicated KIND_GENERIC_GENERIC_TASK_HANDLE so cheney's
+     * young dispatch can find the destroy + safe-handoff via the
+     * kind table. The headerful path resolves the same destroy
+     * via the descriptor too, so behavior is identical. */
     osty_rt_task_handle_impl *h =
         (osty_rt_task_handle_impl *)osty_gc_allocate_managed(
             sizeof(osty_rt_task_handle_impl),
-            OSTY_GC_KIND_GENERIC,
+            OSTY_GC_KIND_GENERIC_TASK_HANDLE,
             "runtime.task.handle",
             NULL, osty_rt_task_handle_destroy);
     if (osty_rt_mu_init(&h->mu) != 0 ||

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -744,8 +744,9 @@ static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
     [OSTY_GC_GENERIC_ENUM_PTR] = {
         .trace = osty_rt_enum_ptr_payload_trace,
     },
-    /* TASK_HANDLE has a pthread-rich destroy — not yet covered by
-     * the safe-clone path that Map uses. */
+    /* Same shape as ENUM_PTR — TASK_HANDLE now routes through
+     * `OSTY_GC_KIND_GENERIC_TASK_HANDLE`'s row in the kind table.
+     * This row is parity-only for the headerful fallback dispatch. */
     [OSTY_GC_GENERIC_TASK_HANDLE] = {
         .destroy = osty_rt_task_handle_destroy,
     },
@@ -3277,10 +3278,11 @@ static void *osty_gc_allocate_young(size_t payload_size, int64_t object_kind) {
  *          their table row instead of editing this predicate.
  *        - For OSTY_GC_KIND_GENERIC, look up the matching pattern
  *          row in `osty_gc_generic_patterns` via (trace, destroy).
- *          The NONE pattern (NULL/NULL) is young-eligible; ENUM_PTR
- *          uses its own dedicated kind (KIND_GENERIC_ENUM_PTR) and
- *          TASK_HANDLE has a pthread-rich destroy that the young
- *          arena's safe-clone primitives don't yet cover.
+ *          Only the NONE pattern (NULL/NULL) lands here today —
+ *          ENUM_PTR and TASK_HANDLE both have their own dedicated
+ *          kinds (KIND_GENERIC_ENUM_PTR / KIND_GENERIC_TASK_HANDLE)
+ *          so cheney can dispatch their trace/destroy via the
+ *          kind-table descriptor.
  *   3. Payload size must fit comfortably under the humongous
  *      threshold. Humongous allocs already take a separate path in
  *      the headerful allocator and have no benefit from being
@@ -12593,10 +12595,10 @@ extern int sysctlbyname(const char *name, void *oldp, size_t *oldlenp,
 typedef int64_t (*osty_task_group_body_fn)(void *env, void *group);
 typedef int64_t (*osty_task_spawn_body_fn)(void *env);
 
-/* `osty_rt_task_handle_impl` typedef is forward-declared earlier
- * (near `osty_rt_chan_impl`) so cheney's safe-handoff helpers can
- * cast `void *` payloads to it. The full struct body follows below. */
-struct osty_rt_task_handle_impl_;
+/* `osty_rt_task_handle_impl` typedef + struct tag are
+ * forward-declared earlier (near `osty_rt_chan_impl`) so cheney's
+ * safe-handoff helpers can cast `void *` payloads. Full struct
+ * body follows below. */
 
 typedef struct osty_rt_task_handle_node {
     osty_rt_task_handle_impl *handle;
@@ -13346,7 +13348,7 @@ static void osty_rt_task_handle_destroy(void *payload) {
  * pauses collection so the pointer the task item carries cannot be
  * freed underneath it. */
 static osty_rt_task_handle_impl *osty_sched_alloc_handle(void) {
-    /* Use the dedicated KIND_GENERIC_GENERIC_TASK_HANDLE so cheney's
+    /* Use the dedicated KIND_GENERIC_TASK_HANDLE so cheney's
      * young dispatch can find the destroy + safe-handoff via the
      * kind table. The headerful path resolves the same destroy
      * via the descriptor too, so behavior is identical. */


### PR DESCRIPTION
## Summary

Final two kinds join the no-header young arena. **Cheney now covers every currently-defined kind:** STRING, BYTES, LIST, MAP, SET, CLOSURE_ENV, GENERIC_ENUM_PTR, GENERIC NONE, CHANNEL, GENERIC_TASK_HANDLE.

Both Channel and TASK_HANDLE shared Map's blocker (pthread sync state in struct, bit-copy is UB). Solved by extending the Map-style safe-handoff pattern:

- `osty_gc_chan_safe_handoff(src, dst)` — re-init dst's mutex + 2 condvars, destroy src's, null-steal the slots pointer. Mirrors `osty_gc_map_safe_handoff` with three sync primitives.
- `osty_gc_task_handle_safe_handoff(src, dst)` — same shape with 1 mutex + 1 condvar.

Wired into `cheney_forward` + `promote_young_to_old` next to the existing Map branch.

TASK_HANDLE gets its own kind value (`OSTY_GC_KIND_GENERIC_TASK_HANDLE = 1032`) — same kind-split pattern as GENERIC_ENUM_PTR — so cheney's young dispatch can find the destroy via the kind table descriptor (the 16-byte micro-header has no `generic_pattern` byte to recover the per-instance pattern at scan time). The remaining GENERIC pattern is NONE, which stays on KIND_GENERIC.

## Changes

`internal/backend/runtime/osty_runtime.c`:
- New kind: `OSTY_GC_KIND_GENERIC_TASK_HANDLE = 1032`. Static assert + descriptor lookup range bumped.
- Two new safe-handoff helpers (`osty_gc_chan_safe_handoff`, `osty_gc_task_handle_safe_handoff`). Forward-declared with the rest of the cheney machinery; bodies live next to each kind's full struct.
- Two new dead-from-space cleanup helpers that delegate to the existing destroy fns and bump per-kind counters (`osty_gc_cleanup_young_dead_chan`, `osty_gc_cleanup_young_dead_task_handle`).
- `cheney_forward` + `promote_young_to_old` add CHANNEL and GENERIC_TASK_HANDLE branches for the safe-handoff dispatch.
- `osty_sched_alloc_handle` allocates with the new kind.
- Kind table: CHANNEL row flips to `young_eligible = true` + adds cleanup; new TASK_HANDLE row.

`internal/backend/llvm_runtime_gc_test.go`:
- `TestBundledRuntimeYoungEligibilityFilter`: CHANNEL row flips `"1030 0 0"` → `"1030 1 1"`; new `"1032 1 1"` / `"1032 0 0"` rows for GENERIC_TASK_HANDLE; line-count bumped to 13.
- `TestBundledRuntimeChannelRemapsCompactionPhaseD`: opt out via `OSTY_GC_TINYTAG_YOUNG=0` (same pattern as the Map remap tests in [osty#977](https://github.com/choiceoh/osty/pull/977)).
- `TestBundledRuntimeYoungArenaAllocAndShimReconstructs`: switch the "non-young example" from Channel to a pinned alloc (every registered kind is now young-eligible by default).
- New `TestBundledRuntimeChannelYoungLifecycle`: send pre-promote, `root_bind` (verify PROMOTED tag), send post-promote via stale handle (verify `load_v1` follow), forced collect, recv all three values to confirm slots survived.

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeChannelYoungLifecycle|TestBundledRuntimeYoungEligibilityFilter|TestBundledRuntimeAllocV1RoutesToYoungWhenFlagOn|TestBundledRuntimeChannelRemapsCompactionPhaseD|TestBundledRuntimeYoungArenaAllocAndShimReconstructs"` — all pass
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime sweep passes (~50s)

## Cheney young-arena status: complete

After this PR, every kind defined in `OSTY_GC_KIND_*` lands in the young arena by default:

| Kind | Young-safe path |
|---|---|
| STRING / BYTES | Immutable byte payload, opaque to cheney |
| LIST | `data` self-ref fixup + dead-list scan + load_v1 PROMOTED follow |
| SET | Dead-from-space scan frees `items` |
| CLOSURE_ENV | Captures populated synchronously before escape |
| MAP | Mutex safe-handoff + inline-index re-anchor |
| CHANNEL | Mutex + 2 condvar safe-handoff |
| GENERIC NONE | Opaque payload |
| GENERIC_ENUM_PTR | Dedicated kind for trace dispatch via kind table |
| GENERIC_TASK_HANDLE | Dedicated kind + mutex + condvar safe-handoff |

The descriptor-driven dispatch ([osty#981](https://github.com/choiceoh/osty/pull/981) + [osty#984](https://github.com/choiceoh/osty/pull/984)) means each kind's young-arena work is wired through one row update — eligibility filter, dead-from-space cleanup, and young-arena remap all dispatch through `osty_gc_kind_descriptor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)