### PR TITLE
perf(runtime): osty_rt_string_len reads len from tinytag-young micro-header

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4578,15 +4578,22 @@ static OSTY_HOT_INLINE void osty_rt_string_measure(const char *value,
         }
     } else if (value != NULL) {
         /* Length fast path via the GC header. Every heap-allocated
-         * string carries `byte_size = len + 1` (alloc size includes
-         * the trailing NUL), so reading the header gives us length
-         * in O(1) — no `strlen` walk, no per-pointer cache lookup.
+         * string carries its allocated byte size (= len + 1 for the
+         * trailing NUL), so reading the header gives us length in
+         * O(1) — no `strlen` walk, no per-pointer cache lookup.
          *
-         * Arena allocations (the dominant case post-#881) put the
-         * header at exactly `payload - sizeof(header)`. Non-arena
-         * payloads — `.rodata` string literals, humongous strings,
-         * forwarded objects — skip this path and fall through to
-         * the existing cache + strlen logic.
+         * Two paths:
+         *   1. Headerful arena (the dominant case before #977 made
+         *      String young-eligible) — header is at
+         *      `payload - sizeof(osty_gc_header)`.
+         *   2. Tinytag young arena (post-#977 every freshly Concat'd
+         *      key, every intToStr return, every Split piece that's
+         *      heap-bound) — micro-header is at
+         *      `payload - sizeof(osty_gc_micro_header)` and the
+         *      `byte_size` field has the same `len + 1` semantic.
+         *
+         * `.rodata` string literals, humongous strings, and forwarded
+         * objects fall through to the cache + strlen path.
          *
          * Hash still uses the 256-slot per-pointer cache; deriving
          * hash from the header would require an extra `cached_hash`
@@ -4600,6 +4607,22 @@ static OSTY_HOT_INLINE void osty_rt_string_measure(const char *value,
                 hdr->object_kind == OSTY_GC_KIND_STRING &&
                 hdr->byte_size > 0) {
                 len = (size_t)hdr->byte_size - 1;
+                len_from_header = true;
+            }
+        } else if (osty_gc_arena_is_young_page((void *)value)) {
+            osty_gc_micro_header *micro =
+                osty_gc_micro_header_for_payload((void *)value);
+            uint64_t fom = micro->forward_or_meta;
+            uint64_t tag = fom & OSTY_GC_FORWARD_TAG_MASK;
+            /* UNFORWARDED tinytag-young string — byte_size is
+             * authoritative. FORWARDED / PROMOTED would mean the
+             * payload moved (the to-space copy has its own header
+             * with a fresh byte_size), so trust micro->byte_size
+             * only when the slot isn't tagged. */
+            if (tag == OSTY_GC_FORWARD_TAG_UNFORWARDED &&
+                micro->object_kind == OSTY_GC_KIND_STRING &&
+                micro->byte_size > 0) {
+                len = (size_t)micro->byte_size - 1;
                 len_from_header = true;
             }
         }


### PR DESCRIPTION
## Summary

\`osty_rt_string_measure\` already had an O(1) length fast path for headerful arena Strings — read the GC header's \`byte_size\` field (set to \`len + 1\` at alloc time). That covered the dominant case before [apps#977](https://github.com/choiceoh/osty/pull/977) made String young-eligible.

Post-#977, every freshly Concat'd Map key, every intToStr return, every Split piece that's heap-bound lives in the no-header young arena. Those payloads have a 16-byte \`osty_gc_micro_header\` whose \`byte_size\` field carries the same \`len + 1\` semantic, so the same trick works — just read 4 bytes from \`payload - 16 + 4\` instead of walking strlen.

## The change

Mirror the headerful-arena fast path: after the \`arena_contains\` check, fall to \`is_young_page\` and grab the length straight off the micro-header when the slot is UNFORWARDED. FORWARDED/PROMOTED tags mean the payload moved to a new header with its own fresh \`byte_size\`, so we can't trust the source — fall through to the cache + strlen path.

\`.rodata\` literals and stack buffers (the canonical \"same pointer, different content\" cases) still fall through to the cache + strlen path; only the new generation of young-arena Strings benefit.

## Net effect

Every String allocation that lands in the young arena now skips a \`strlen\` walk on every length query. The join / concat / hash paths each hit \`string_len\` at least once per call, and big-map's lookup loop calls \`m.containsKey(\"key:\" + intToStr(t))\` 1 M times — every iteration of the lookup chain went through the strlen walk before this PR.

## Regression scope

- All 7 benchmark programs (expr-calc, id-tracker, log-aggregator, dep-resolver, lru-sim, markdown-stats, big-map) build and run with correct output.
- big-map result matches Go reference (size=200000, hits=1000000, sum=2999031).
- Length arithmetic spot-check: \`sum = Σ len(\"key:N\") for N=0..99\` returns 590 (10×5 + 90×6) ✓
- No new test failures.

Note: macOS sample profiler ran into thermal noise during my measurements (1.0–3.0 s spread on identical runs), so I'm landing this on the strength of the principled match with the existing headerful path rather than a clean A/B perf number. The change is neutral-or-positive on correctness — the variance just made it impossible to get a clean signal under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)