### PR TITLE
fix(runtime): make List/Channel/EnumPtr trace fns CHENEY-mode safe

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -7116,20 +7116,14 @@ int main(void) {
 
 // TestBundledRuntimeChannelTraceForwardsYoungChildren pins the
 // round-trip of a young managed payload through a ptr-typed
-// channel across cheney_minor. Before this PR, chan_trace called
-// `osty_gc_mark_payload(child)` (mark-only) instead of
-// `osty_gc_mark_slot_v1(&slot)` — the dispatch under CHENEY mode
-// then never invoked cheney_forward on the young child and never
-// rewrote the slot. Correctness held under single-cycle pressure
-// because load_v1's PROMOTED/FORWARDED tag follow saved us, but
-// the slot stayed stale (and could resolve to overwritten bytes
-// after enough subsequent allocation pressure).
-//
-// With the chan_trace fix, the slot gets rewritten in-cycle,
-// matching how Map/Set/List/CLOSURE_ENV/GENERIC_ENUM_PTR all
-// route managed children. This test pins the round-trip end to
-// end: alloc young String, send, root channel, collect, recv,
-// verify content intact.
+// channel across cheney_minor. Before this PR, chan_trace used
+// mark_payload instead of mark_slot_v1 — under CHENEY mode the
+// young child was never forwarded and the slot stayed stale.
+// load_v1's PROMOTED/FORWARDED follow masked the bug under
+// single-cycle pressure, but the slot would resolve to overwritten
+// bytes once enough subsequent allocation churn recycled the
+// young arena. With the trace fix the slot gets rewritten
+// in-cycle.
 func TestBundledRuntimeChannelTraceForwardsYoungChildren(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -7114,6 +7114,119 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeChannelTraceForwardsYoungChildren pins the
+// round-trip of a young managed payload through a ptr-typed
+// channel across cheney_minor. Before this PR, chan_trace called
+// `osty_gc_mark_payload(child)` (mark-only) instead of
+// `osty_gc_mark_slot_v1(&slot)` — the dispatch under CHENEY mode
+// then never invoked cheney_forward on the young child and never
+// rewrote the slot. Correctness held under single-cycle pressure
+// because load_v1's PROMOTED/FORWARDED tag follow saved us, but
+// the slot stayed stale (and could resolve to overwritten bytes
+// after enough subsequent allocation pressure).
+//
+// With the chan_trace fix, the slot gets rewritten in-cycle,
+// matching how Map/Set/List/CLOSURE_ENV/GENERIC_ENUM_PTR all
+// route managed children. This test pins the round-trip end to
+// end: alloc young String, send, root channel, collect, recv,
+// verify content intact.
+func TestBundledRuntimeChannelTraceForwardsYoungChildren(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_chan_managed_young_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_chan_managed_young_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_thread_chan_send_ptr(void *raw, void *value);
+
+typedef struct osty_rt_chan_recv_result {
+    int64_t value;
+    int64_t ok;
+} osty_rt_chan_recv_result;
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_ptr(void *raw);
+
+const char *osty_rt_strings_Repeat(const char *value, int64_t n);
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+
+int64_t osty_gc_debug_arena_is_young_page(void *payload);
+void osty_gc_debug_collect(void);
+
+int main(void) {
+    /* Heap-allocated young String — strings_Repeat returns a fresh
+     * KIND_STRING payload via allocate_managed → young arena. */
+    const char *child = osty_rt_strings_Repeat("ab", 8);
+    printf("%lld\n", (long long)osty_gc_debug_arena_is_young_page((void *)child));
+
+    /* Ptr-typed Channel, also young. Send the young String — slot
+     * holds the int64_t cast of the young String address. */
+    void *chan = osty_rt_thread_chan_make(2);
+    osty_rt_thread_chan_send_ptr(chan, (void *)child);
+
+    /* Root the channel; the String is NOT separately rooted, so its
+     * only liveness path is the channel's slot. With the trace fix,
+     * cheney forwards the young String + rewrites the slot. */
+    osty_gc_root_bind_v1(chan);
+
+    /* Forced collect: cheney processes the (PROMOTED) young channel,
+     * the trace forwards the young String to to-space and rewrites
+     * the slot. */
+    osty_gc_debug_collect();
+
+    /* Recv the String. load_v1 inside recv_ptr follows any forwarding,
+     * but the critical bit is that the channel's slot was rewritten
+     * to the live address — without the trace fix, the slot held a
+     * stale young addr that subsequent young allocs would overwrite. */
+    osty_rt_chan_recv_result r = osty_rt_thread_chan_recv_ptr(chan);
+    if (!r.ok) {
+        printf("recv ok=0\n");
+        return 1;
+    }
+    const char *got = (const char *)(uintptr_t)r.value;
+    /* The string is "abababababababab" (8 * "ab" = 16 chars). Compare
+     * the first 16 bytes to confirm the payload survived intact. */
+    printf("%d\n", strncmp(got, "abababababababab", 16) == 0);
+
+    osty_gc_root_release_v1(chan);
+    osty_gc_debug_collect();
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	want := strings.Join([]string{
+		"1", // young String landed in young arena
+		"1", // recv'd String content matches "abababababababab"
+		"",
+	}, "\n")
+	if got := string(runOutput); got != want {
+		t.Fatalf("chan-managed-young harness output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // Phase 8 step 1 of the tiny-tag young-space landing: end-to-end
 // routing. With the feature flag on, the production allocator entry
 // `osty.gc.alloc_v1` should pick the young arena for eligible kinds

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -14060,12 +14060,10 @@ static void osty_rt_chan_trace(void *payload) {
         !osty_gc_chan_elem_kind_is_managed(ch->elem_kind)) {
         return;
     }
-    /* Pass slot ADDRESSES to mark_slot_v1 (not pre-loaded payloads
-     * to mark_payload) so the cheney path can forward young
-     * children + rewrite the slot. The slots are int64_t (8 bytes)
-     * holding ptr-cast values; on 64-bit systems mark_slot_v1's
-     * `memcpy(&payload, slot_addr, sizeof(void *))` reads exactly
-     * the 8-byte slot. */
+    /* Pass slot ADDRESSES to mark_slot_v1 so the CHENEY path can
+     * forward young children + rewrite the slot. Slots are int64_t
+     * holding ptr-cast values; mark_slot_v1's `memcpy(sizeof(void *))`
+     * reads the pointer back. */
     for (i = 0; i < ch->count; i++) {
         int64_t idx = (ch->head + i) % ch->cap;
         osty_gc_mark_slot_v1((void *)&ch->slots[idx]);

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4353,12 +4353,11 @@ static void osty_rt_list_trace(void *payload) {
         return;
     }
     if (list->pointer_elems) {
+        /* Pass slot addresses to mark_slot_v1 so cheney can forward
+         * young children + rewrite the slot. mark_payload would only
+         * mark via the headerful path — broken under CHENEY mode. */
         for (i = 0; i < list->len; i++) {
-            void *child = NULL;
-            memcpy(&child, list->data + ((size_t)i * list->elem_size), sizeof(child));
-            if (child != NULL) {
-                osty_gc_mark_payload(child);
-            }
+            osty_gc_mark_slot_v1((void *)(list->data + ((size_t)i * list->elem_size)));
         }
         return;
     }
@@ -4368,11 +4367,7 @@ static void osty_rt_list_trace(void *payload) {
     for (i = 0; i < list->len; i++) {
         unsigned char *elem = list->data + ((size_t)i * list->elem_size);
         for (j = 0; j < list->gc_offset_count; j++) {
-            void *child = NULL;
-            memcpy(&child, elem + (size_t)list->gc_offsets[j], sizeof(child));
-            if (child != NULL) {
-                osty_gc_mark_payload(child);
-            }
+            osty_gc_mark_slot_v1((void *)(elem + (size_t)list->gc_offsets[j]));
         }
     }
 }
@@ -10411,7 +10406,11 @@ void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char
 }
 
 static void osty_rt_enum_ptr_payload_trace(void *payload) {
-    osty_gc_mark_root_slot(payload);
+    /* `payload` IS the slot — the box's payload is a single
+     * pointer-sized slot holding the inner managed pointer.
+     * `mark_slot_v1` dispatches by current trace_slot_mode so the
+     * cheney path can forward young inners + rewrite the slot. */
+    osty_gc_mark_slot_v1(payload);
 }
 
 /* Phase A4 depth (RUNTIME_GC_DELTA §2.4). Trace callback for closure
@@ -14061,12 +14060,15 @@ static void osty_rt_chan_trace(void *payload) {
         !osty_gc_chan_elem_kind_is_managed(ch->elem_kind)) {
         return;
     }
+    /* Pass slot ADDRESSES to mark_slot_v1 (not pre-loaded payloads
+     * to mark_payload) so the cheney path can forward young
+     * children + rewrite the slot. The slots are int64_t (8 bytes)
+     * holding ptr-cast values; on 64-bit systems mark_slot_v1's
+     * `memcpy(&payload, slot_addr, sizeof(void *))` reads exactly
+     * the 8-byte slot. */
     for (i = 0; i < ch->count; i++) {
         int64_t idx = (ch->head + i) % ch->cap;
-        void *child = (void *)(uintptr_t)ch->slots[idx];
-        if (child != NULL) {
-            osty_gc_mark_payload(child);
-        }
+        osty_gc_mark_slot_v1((void *)&ch->slots[idx]);
     }
 }
 


### PR DESCRIPTION
## Summary

Audit of every kind's trace fn — done while verifying the "Cheney young coverage complete" claim from [osty#988](https://github.com/choiceoh/osty/pull/988) — turned up four trace paths that called the wrong primitive for managed children. Map / Set / CLOSURE_ENV already used `osty_gc_mark_slot_v1` (which dispatches by the current `trace_slot_mode` → `osty_gc_cheney_slot` under CHENEY mode). The remaining four paths called `osty_gc_mark_payload` or `osty_gc_mark_root_slot`, both of which only handle the MARK / REMAP modes and skip the `cheney_forward` + slot-rewrite step for young children:

| Trace fn | Was | Now |
|---|---|---|
| `osty_rt_chan_trace` | `osty_gc_mark_payload(child)` | `osty_gc_mark_slot_v1(&ch->slots[idx])` |
| `osty_rt_enum_ptr_payload_trace` | `osty_gc_mark_root_slot(payload)` | `osty_gc_mark_slot_v1(payload)` (the box's payload IS the slot) |
| `osty_rt_list_trace` `pointer_elems` branch | `osty_gc_mark_payload(child)` | `osty_gc_mark_slot_v1(...)` (currently dead code — `pointer_elems` is never set true — but kept consistent for future use) |
| `osty_rt_list_trace` `gc_offsets` branch | `osty_gc_mark_payload(child)` | `osty_gc_mark_slot_v1(...)` |

## Why correctness held under single-cycle pressure

`osty_gc_load_v1`'s PROMOTED/FORWARDED tag follow saved us — even with a stale slot pointing at a young address, `load_v1` read the micro-header tag and resolved to the live address. The bug only bit when enough allocation pressure overwrote the stale slot's micro-header bytes (making `load_v1` return the stale address itself, which by then held overwritten contents). With these fixes, slots get rewritten in-cycle and the `load_v1` fallback is no longer load-bearing for these kinds.

This also pre-dated the Channel young-eligibility work — OLD channels with managed elements went through the same buggy path during cheney_minor's `cheney_old_stack` drain. Just less common to hit.

## Audit summary (post-fix)

| Trace fn | Slot primitive |
|---|---|
| LIST `trace_elem` callback | `osty_gc_mark_slot_v1` (registered by `osty_rt_list_push_ptr`) ✓ |
| LIST `pointer_elems` | `osty_gc_mark_slot_v1` ✓ (was buggy, now fixed) |
| LIST `gc_offsets` | `osty_gc_mark_slot_v1` ✓ (was buggy, now fixed) |
| MAP | `osty_gc_mark_slot_v1` ✓ |
| SET | `osty_gc_mark_slot_v1` ✓ |
| CLOSURE_ENV | `osty_gc_mark_slot_v1` ✓ |
| CHANNEL | `osty_gc_mark_slot_v1` ✓ (was buggy, now fixed) |
| GENERIC_ENUM_PTR | `osty_gc_mark_slot_v1` ✓ (was buggy, now fixed) |
| GENERIC_TASK_HANDLE | NULL trace, no managed children ✓ |
| STRING / BYTES / GENERIC NONE | NULL trace, opaque ✓ |

## Changes

`internal/backend/runtime/osty_runtime.c`:
- 4 trace fns updated to use `mark_slot_v1` with slot addresses.

`internal/backend/llvm_runtime_gc_test.go`:
- New `TestBundledRuntimeChannelTraceForwardsYoungChildren`: alloc young String, send into ptr-typed channel, root the channel, force collect, recv, verify content intact. Exercises the chan_trace fix path.

## Test plan

- [x] `go test ./internal/backend/ -run "TestBundledRuntimeChannelTraceForwardsYoungChildren"` — passes
- [x] `go test ./internal/backend/ -run "TestBundledRuntime|TestRuntime"` — full bundled-runtime sweep passes (~50s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)