### PR TITLE
feat(runtime): concurrent GC — bg marker thread + multi-thread cycles + parallel workers + batch fairness (Phase 0a–0d)

### DIFF
--- a/RUNTIME_GC.md
+++ b/RUNTIME_GC.md
@@ -24,6 +24,7 @@ Today the runtime collector is a precise root-driven mark/sweep collector with:
 - allocation-pressure-triggered collection requests fulfilled at safepoints
 - write-barrier edge logging — `osty.gc.pre_write_v1` accumulates a SATB log of overwritten values, `osty.gc.post_write_v1` records deduplicated (owner, value) edges; both cleared at the end of each collection. The live STW marker does not yet consume these logs, but they are produced so that generational minor collection and concurrent / incremental marking can plug in without revisiting emit sites.
 - managed temporary protection in LLVM lowering for params, locals, aggregates, loop iterables, and nested call arguments
+- **opt-in background marker thread** (Phase 0a) — when `OSTY_GC_BG_MARKER=1`, `osty_gc_collect_incremental_start_with_stack_roots` lazily spawns a single OS thread that drains the grey queue while the cycle is in `MARK_INCREMENTAL`. Initial root scan and final remark/sweep stay STW; mid-cycle mark work runs concurrently with the mutator. Telemetry: `osty_gc_debug_bg_marker_{started,kicks,drained,loops,naps,active}`. Lock-skip fast paths in alloc / load / post_write / map ops route through `osty_gc_serialized_now()` so they re-engage the recursive mutex while the marker is live.
 
 This is the implementation we are extending toward end-to-end native execution.
 

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3143,6 +3143,170 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeBackgroundMarkerMultiThreadCycle covers Phase 0b —
+// when user worker threads are live, incremental_start (previously
+// hard-gated to early-return on workers > 0) must instead drive an STW
+// handshake that parks every worker, unions their published roots into
+// the seed set, kicks the bg marker for concurrent drain, and finishes
+// via a second handshake. The test spawns one worker that runs a
+// safepoint+alloc+sleep loop, kicks an incremental cycle from the main
+// thread mid-flight, and asserts the cycle actually started (state went
+// to MARK_INCREMENTAL — the regression signal would be state == 0
+// because of the old early-return) and reached IDLE on finish.
+func TestBundledRuntimeBackgroundMarkerMultiThreadCycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_bg_marker_mt_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_bg_marker_mt_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void *osty_rt_task_spawn(void *body_env);
+int64_t osty_rt_task_handle_join(void *handle);
+void osty_rt_sched_preempt_check_v1(void);
+void osty_rt_thread_sleep(int64_t nanos);
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_bg_marker_kicks_total(void);
+int64_t osty_gc_debug_bg_marker_drained_total(void);
+
+typedef struct env_slot { void *fn; int64_t capture; } env_slot;
+
+/* Worker body: 200ms of safepoint + alloc + sleep. The safepoint
+ * check makes the worker observe stop_request and park promptly; the
+ * alloc burns through the lock-skip-disabled fast path so we exercise
+ * the bg marker reading the index concurrently. */
+static int64_t worker_body(void *env) {
+    (void)env;
+    for (int i = 0; i < 200; i++) {
+        (void)osty_gc_alloc_v1(7, 16, "mt_worker");
+        osty_rt_sched_preempt_check_v1();
+        osty_rt_thread_sleep(1000000LL);  /* 1ms */
+    }
+    return 0;
+}
+
+int main(void) {
+    /* Build a rooted graph BEFORE starting workers so the cycle has
+     * real work to drain. 50 children reachable through a pinned
+     * list — bg marker should trace 51 headers between start and
+     * finish. */
+    enum { N = 50 };
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    for (int i = 0; i < N; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "main_child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+
+    env_slot e = { (void *)worker_body, 0 };
+    void *h = osty_rt_task_spawn((void *)&e);
+
+    /* Let the worker actually start running so concurrent_workers > 0
+     * is observed by incremental_start. */
+    osty_rt_thread_sleep(20000000LL);  /* 20ms */
+
+    long long pre_state = (long long)osty_gc_debug_state();
+
+    /* Phase 0b critical path: previously this would early-return
+     * silently because of the workers > 0 gate. With the STW
+     * handshake the cycle actually starts. */
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+    long long mid_state = (long long)osty_gc_debug_state();
+    long long mid_kicks = (long long)osty_gc_debug_bg_marker_kicks_total();
+
+    /* Concurrent drain window. Worker keeps running, bg marker
+     * traces. */
+    osty_rt_thread_sleep(50000000LL);  /* 50ms */
+
+    long long mid_drained = (long long)osty_gc_debug_bg_marker_drained_total();
+
+    /* Finish parks the worker again, drains residual greys, sweeps. */
+    osty_gc_collect_incremental_finish();
+
+    long long final_state    = (long long)osty_gc_debug_state();
+    long long final_drained  = (long long)osty_gc_debug_bg_marker_drained_total();
+
+    /* Wait for the worker to finish its loop. */
+    (void)osty_rt_task_handle_join(h);
+
+    printf("pre_state=%lld mid_state=%lld mid_kicks=%lld mid_drained=%lld final_state=%lld final_drained=%lld\n",
+        pre_state, mid_state, mid_kicks, mid_drained, final_state, final_drained);
+
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_BG_MARKER=1",
+		"OSTY_GC_ASSIST_BYTES_PER_UNIT=0",
+	)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	/* Required:
+	 *   - pre_state=0: IDLE before start.
+	 *   - mid_state=1: MARK_INCREMENTAL — Phase 0b cycle actually
+	 *     started despite workers > 0 (the regression signal is mid_state=0,
+	 *     meaning the old early-return is still in place).
+	 *   - mid_kicks>=1: bg marker was signalled.
+	 *   - mid_drained>=1: bg marker did real work concurrently with the
+	 *     running worker.
+	 *   - final_state=0: IDLE after finish (sweep done). */
+	mustContain := []string{
+		"pre_state=0 ",
+		"mid_state=1 ",
+		"final_state=0 ",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(out, frag) {
+			t.Fatalf("multi-thread cycle harness missing %q\nfull output:\n%s",
+				frag, out)
+		}
+	}
+	if strings.Contains(out, "mid_kicks=0 ") || strings.Contains(out, "mid_drained=0 ") {
+		t.Fatalf("bg marker did not engage during multi-thread cycle\nfull output:\n%s",
+			out)
+	}
+}
+
 // TestBundledRuntimeValidateHeapNegativeInvariantsPhaseC covers the
 // Phase C1 depth follow-up — three new tri-colour invariants each get
 // a dedicated injector that trips exactly one error code.

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3311,6 +3311,150 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeBackgroundMarkerWorkSplit covers Phase 0d — when
+// multiple bg workers share the queue, the smaller per-iteration
+// drain batch (budget/4) gives siblings a chance to grab the lock
+// between batches. The test sets a small OSTY_GC_BG_MARKER_BUDGET so
+// per_iter is small, and a graph large enough that no single worker
+// can drain it in one batch. At least 2 workers must show non-zero
+// per-worker drained — proves real parallelism rather than
+// theoretical N-thread spawn.
+func TestBundledRuntimeBackgroundMarkerWorkSplit(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_bg_marker_split_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_bg_marker_split_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_bg_marker_workers(void);
+int64_t osty_gc_debug_bg_marker_drained_total(void);
+int64_t osty_gc_debug_bg_marker_per_worker_drained(int64_t worker_id);
+
+static void nap_ms(int ms) {
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000 * 1000;
+    nanosleep(&ts, NULL);
+}
+
+int main(void) {
+    /* 800-element graph to give 4 workers room to interleave across
+     * multiple batches. With OSTY_GC_BG_MARKER_BUDGET=256 and 4
+     * workers, per_iter is 64 (256/4). 800 items / 64 = 12.5 batches
+     * → fair distribution should put non-zero counts on all 4. */
+    enum { N = 800 };
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    for (int i = 0; i < N; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+
+    /* Generous nap so all workers cycle through several drain
+     * iterations. */
+    nap_ms(200);
+
+    osty_gc_collect_incremental_finish();
+
+    int64_t workers = osty_gc_debug_bg_marker_workers();
+    int64_t drained = osty_gc_debug_bg_marker_drained_total();
+
+    int active = 0;
+    for (int64_t i = 0; i < workers; i++) {
+        int64_t w = osty_gc_debug_bg_marker_per_worker_drained(i);
+        if (w > 0) active++;
+        if (i < 8) printf("w%lld=%lld ", i, w);
+    }
+    printf("\nworkers=%lld drained=%lld active=%d state=%lld\n",
+        workers, drained, active, (long long)osty_gc_debug_state());
+
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_BG_MARKER=1",
+		"OSTY_GC_BG_WORKERS=4",
+		/* Small budget so per_iter (budget/4) is small enough that
+		 * the 800-item graph requires many drain batches and
+		 * siblings interleave. */
+		"OSTY_GC_BG_MARKER_BUDGET=256",
+		"OSTY_GC_ASSIST_BYTES_PER_UNIT=0",
+	)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	if !strings.Contains(out, "workers=4 ") {
+		t.Fatalf("workers!=4\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "state=0") {
+		t.Fatalf("state!=IDLE\nfull output:\n%s", out)
+	}
+	/* Parse active count and assert >= 2. With Phase 0d's smaller
+	 * per-iteration batch, 800 items / per_iter=64 = 12+ batches,
+	 * which 4 workers should split. The regression signal is
+	 * active=1 — the old behaviour where worker 0 monopolises the
+	 * lock and drains everything alone. */
+	var active int
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "workers=") {
+			continue
+		}
+		var workers, drained int64
+		var state int
+		if _, err := fmt.Sscanf(line, "workers=%d drained=%d active=%d state=%d",
+			&workers, &drained, &active, &state); err != nil {
+			t.Fatalf("could not parse %q: %v", line, err)
+		}
+		break
+	}
+	if active < 2 {
+		t.Fatalf("only %d worker(s) contributed; Phase 0d batch split failed to engage parallelism\nfull output:\n%s",
+			active, out)
+	}
+}
+
 // TestBundledRuntimeBackgroundMarkerMultiThreadCycle covers Phase 0b —
 // when user worker threads are live, incremental_start (previously
 // hard-gated to early-return on workers > 0) must instead drive an STW

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3143,6 +3143,174 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeBackgroundMarkerParallelWorkers covers Phase 0c —
+// when OSTY_GC_BG_WORKERS=N is set, the runtime spawns N marker
+// threads that share the grey queue. The test asserts the spawned-
+// worker count matches the env var and that the cycle's total drained
+// matches the rooted graph size, proving the multi-worker path
+// completes correctly. Per-worker drain counts may be lopsided under
+// the shared lock — Phase 0d will balance them — so we don't assert
+// strict fairness, only that N threads engaged.
+func TestBundledRuntimeBackgroundMarkerParallelWorkers(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_bg_marker_parallel_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_bg_marker_parallel_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_bg_marker_workers(void);
+int64_t osty_gc_debug_bg_marker_drained_total(void);
+int64_t osty_gc_debug_bg_marker_per_worker_drained(int64_t worker_id);
+
+static void nap_ms(int ms) {
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000 * 1000;
+    nanosleep(&ts, NULL);
+}
+
+int main(void) {
+    /* Larger graph than the single-worker test so drain takes more
+     * than one budget step; this gives more than one worker a chance
+     * to contribute. */
+    enum { N = 200 };
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    for (int i = 0; i < N; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+
+    /* Generous nap so all workers get a chance to wake from cv_wait
+     * and at least attempt the drain loop. */
+    nap_ms(50);
+
+    osty_gc_collect_incremental_finish();
+
+    int64_t workers = osty_gc_debug_bg_marker_workers();
+    int64_t drained = osty_gc_debug_bg_marker_drained_total();
+    int64_t state   = osty_gc_debug_state();
+
+    /* Per-worker breakdown for diagnostic output. Sum is reported so
+     * the test can sanity-check it equals the aggregate counter
+     * (atomic add vs. per-worker thread-local add — they should
+     * agree). */
+    int64_t per_sum = 0;
+    int active_workers = 0;
+    for (int64_t i = 0; i < workers; i++) {
+        int64_t w = osty_gc_debug_bg_marker_per_worker_drained(i);
+        if (w > 0) active_workers++;
+        per_sum += w;
+        /* Print up to 8 worker counters so diff failures stay
+         * readable. */
+        if (i < 8) printf("w%lld=%lld ", i, w);
+    }
+    printf("\n");
+    printf("workers=%lld drained=%lld per_sum=%lld active=%d state=%lld\n",
+        workers, drained, per_sum, active_workers, state);
+
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_BG_MARKER=1",
+		"OSTY_GC_BG_WORKERS=4",
+		"OSTY_GC_ASSIST_BYTES_PER_UNIT=0",
+	)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	/* Required:
+	 *   - workers=4: env var honored and N threads spawned.
+	 *   - drained=201: graph size (200 children + 1 list); aggregate
+	 *     across all workers. Equality, not >=, because finish drains
+	 *     residual greys via the *caller* (not bg marker), so any
+	 *     leftover work after our nap lands on the caller side.
+	 *     The non-bg drain doesn't bump per_sum — exact equality of
+	 *     drained vs per_sum is asserted separately to prove the
+	 *     two counter paths agree.
+	 *   - per_sum == drained: atomic aggregate matches per-worker sum
+	 *     (no torn updates, no missed contributions).
+	 *   - state=0: cycle reached IDLE. */
+	mustContain := []string{
+		"workers=4 ",
+		"state=0",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(out, frag) {
+			t.Fatalf("parallel marker harness missing %q\nfull output:\n%s",
+				frag, out)
+		}
+	}
+	if strings.Contains(out, "drained=0 ") {
+		t.Fatalf("bg marker did no work despite 4 workers\nfull output:\n%s",
+			out)
+	}
+	/* per_sum == drained_total: the atomic aggregate vs sum of
+	 * per-worker counters. If they don't agree, either the atomic
+	 * add lost an update or a worker wrote into the wrong slot. */
+	var workers, drained, perSum int64
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "workers=") {
+			continue
+		}
+		if _, err := fmt.Sscanf(line, "workers=%d drained=%d per_sum=%d ",
+			&workers, &drained, &perSum); err != nil {
+			t.Fatalf("could not parse counters from line %q: %v", line, err)
+		}
+		break
+	}
+	if workers != 4 {
+		t.Fatalf("workers=%d, want 4\nfull output:\n%s", workers, out)
+	}
+	if drained != perSum {
+		t.Fatalf("aggregate drained=%d != per-worker sum=%d (counter race)\nfull output:\n%s",
+			drained, perSum, out)
+	}
+}
+
 // TestBundledRuntimeBackgroundMarkerMultiThreadCycle covers Phase 0b —
 // when user worker threads are live, incremental_start (previously
 // hard-gated to early-return on workers > 0) must instead drive an STW

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -2984,6 +2984,165 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeBackgroundMarkerDrainsCycle covers Phase 0a — when
+// OSTY_GC_BG_MARKER=1 is set, an incremental cycle started without any
+// step calls should still drain to completion via the background marker
+// thread, leaving the queue empty and the live set correct after finish.
+//
+// The test is the smallest end-to-end proof that the marker thread is
+// actually running concurrently with the mutator: the harness sleeps
+// between start and finish without itself doing any mark work, and
+// asserts the bg marker advanced the cycle.
+func TestBundledRuntimeBackgroundMarkerDrainsCycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_bg_marker_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_bg_marker_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_mark_stack_count(void);
+int64_t osty_gc_debug_bg_marker_started(void);
+int64_t osty_gc_debug_bg_marker_kicks_total(void);
+int64_t osty_gc_debug_bg_marker_drained_total(void);
+int64_t osty_gc_debug_bg_marker_loops_total(void);
+int64_t osty_gc_debug_bg_marker_active(void);
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+static void nap_ms(int ms) {
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000 * 1000;
+    nanosleep(&ts, NULL);
+}
+
+int main(void) {
+    /* 50 children reachable through a rooted list, plus 30 dangling
+     * allocations. The bg marker must trace 51 reachable headers
+     * (list + 50 children) and the sweep must reclaim 30. */
+    enum { N = 50, M = 30 };
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    for (int i = 0; i < N; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+    for (int i = 0; i < M; i++) {
+        (void)osty_gc_alloc_v1(7, 16, "drop");
+    }
+
+    /* Kick a cycle. Crucially, do NOT call osty_gc_collect_incremental_step
+     * here — without the bg marker, this leaves the queue intact until
+     * finish drains it inline. With the bg marker, the queue empties in
+     * the background. */
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+
+    /* Wait long enough for the bg marker to drain and nap at least once.
+     * Marker default budget is 1024 — the 51 grey objects clear in a
+     * single drain step plus a 200µs nap. 50 ms is multiple orders of
+     * magnitude slack so the test stays robust under CI load. */
+    nap_ms(50);
+
+    /* Snapshot mid-cycle counters before finish parks the marker. */
+    long long mid_started = (long long)osty_gc_debug_bg_marker_started();
+    long long mid_kicks   = (long long)osty_gc_debug_bg_marker_kicks_total();
+    long long mid_drained = (long long)osty_gc_debug_bg_marker_drained_total();
+    long long mid_active  = (long long)osty_gc_debug_bg_marker_active();
+    long long mid_stack   = (long long)osty_gc_debug_mark_stack_count();
+
+    osty_gc_collect_incremental_finish();
+
+    long long final_state   = (long long)osty_gc_debug_state();
+    long long final_live    = (long long)osty_gc_debug_live_count();
+    long long final_active  = (long long)osty_gc_debug_bg_marker_active();
+    long long final_drained = (long long)osty_gc_debug_bg_marker_drained_total();
+
+    printf("started=%lld kicks=%lld mid_active=%lld mid_stack=%lld mid_drained=%lld\n",
+        mid_started, mid_kicks, mid_active, mid_stack, mid_drained);
+    printf("state=%lld live=%lld active=%lld final_drained=%lld\n",
+        final_state, final_live, final_active, final_drained);
+
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	/* Enable bg marker; disable mutator assist so the marker is the
+	 * sole non-mutator drain channel — without this, assist could
+	 * trace everything via the alloc path and the test would not
+	 * actually exercise the bg thread. */
+	runCmd.Env = append(os.Environ(),
+		"OSTY_GC_BG_MARKER=1",
+		"OSTY_GC_ASSIST_BYTES_PER_UNIT=0",
+	)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	/* Required invariants:
+	 *   - started=1: thread spawned on first kick.
+	 *   - kicks=1:   exactly one start-side kick this run.
+	 *   - mid_drained > 0:  bg marker did real work between start and
+	 *                       finish — this is the load-bearing concurrent
+	 *                       proof. mid_stack should be 0 (drained) but
+	 *                       under heavy CI load could still hold a few;
+	 *                       what matters is that drained > 0.
+	 *   - state=0 (IDLE), final_active=0 (parked) after finish.
+	 *   - live=51 (list + 50 children). 30 dangling reclaimed by sweep.
+	 *   - final_drained >= mid_drained (monotonic). */
+	mustContain := []string{
+		"started=1 ",
+		" kicks=1 ",
+		"state=0 live=51 active=0",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(out, frag) {
+			t.Fatalf("bg marker harness output missing %q\nfull output:\n%s",
+				frag, out)
+		}
+	}
+	if strings.Contains(out, "mid_drained=0\n") {
+		t.Fatalf("bg marker did no work — mid_drained=0; full output:\n%s",
+			out)
+	}
+}
+
 // TestBundledRuntimeValidateHeapNegativeInvariantsPhaseC covers the
 // Phase C1 depth follow-up — three new tri-colour invariants each get
 // a dedicated injector that trips exactly one error code.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1683,6 +1683,110 @@ static void osty_sched_workers_dec(void) {
     osty_gc_release();
 }
 
+/* Phase 0a background marker thread (RUNTIME_GC.md follow-up).
+ *
+ * When `OSTY_GC_BG_MARKER=1` is set, the first call to
+ * `osty_gc_collect_incremental_start_with_stack_roots` lazily spawns a
+ * single OS thread that drains the grey queue while the collector is
+ * in MARK_INCREMENTAL. This is the first real "concurrent" mark step:
+ * before this, `incremental_step` and the mutator-assist path were the
+ * only ways to advance a cycle, so progress was bounded by mutator
+ * activity (incremental was budgeted, not concurrent). With the bg
+ * thread, mark work proceeds on another core while the mutator runs
+ * non-allocating code — only the initial root scan and the final
+ * remark/sweep window remain STW.
+ *
+ * The marker shares `osty_gc_lock` with the mutator. That keeps the
+ * design conservative for Phase 0a: the lock-skip fast paths
+ * (allocate_managed, load_v1, post_write_v1, map mutex) must take the
+ * lock when the marker is active because they otherwise race with the
+ * marker's tracer reads of the payload→header index and forwarding
+ * map. `osty_gc_serialized_now()` consolidates that gate.
+ *
+ * Kick / park protocol:
+ *   - `osty_gc_collect_incremental_start_with_stack_roots` flips
+ *     `bg_marker_active = 1` and signals the cv.
+ *   - `osty_gc_collect_incremental_finish_locked` clears it back to 0
+ *     before the final drain so the marker exits its inner loop on the
+ *     next iteration. The marker observes the cleared flag through the
+ *     atomic load at the top of each drain step.
+ *
+ * Lifecycle: thread starts on demand and lives until process exit. No
+ * explicit shutdown — standard for a GC daemon. */
+#define OSTY_GC_BG_MARKER_ENV "OSTY_GC_BG_MARKER"
+#define OSTY_GC_BG_MARKER_BUDGET_ENV "OSTY_GC_BG_MARKER_BUDGET"
+#define OSTY_GC_BG_MARKER_BUDGET_DEFAULT 1024
+/* Idle nap when the queue is drained but the cycle is still active.
+ * Mutator SATB barriers can push more work; a short nap keeps the
+ * marker responsive without spinning. */
+#define OSTY_GC_BG_MARKER_IDLE_NAP_NS 200000ULL  /* 200 µs */
+
+static int osty_gc_bg_marker_enabled_loaded = 0;
+static int osty_gc_bg_marker_enabled_value = 0;
+static int osty_gc_bg_marker_budget_loaded = 0;
+static int64_t osty_gc_bg_marker_budget_value = OSTY_GC_BG_MARKER_BUDGET_DEFAULT;
+
+static osty_rt_thread_t osty_gc_bg_marker_thread;
+static int osty_gc_bg_marker_started = 0;
+static osty_rt_mu_t osty_gc_bg_marker_mu;
+static osty_rt_cond_t osty_gc_bg_marker_cv;
+/* `active` flag: 1 between incremental.start and finish, 0 otherwise.
+ * Atomic so the marker can fast-exit its drain loop without holding
+ * the kick mutex on every iteration. */
+static int osty_gc_bg_marker_active = 0;
+
+static int64_t osty_gc_bg_marker_drained_total = 0;
+static int64_t osty_gc_bg_marker_loops_total = 0;
+static int64_t osty_gc_bg_marker_naps_total = 0;
+static int64_t osty_gc_bg_marker_kicks_total = 0;
+
+static bool osty_gc_bg_marker_enabled_now(void) {
+    if (osty_gc_bg_marker_enabled_loaded) {
+        return osty_gc_bg_marker_enabled_value != 0;
+    }
+    osty_gc_bg_marker_enabled_loaded = 1;
+    const char *value = getenv(OSTY_GC_BG_MARKER_ENV);
+    if (value == NULL || value[0] == '\0' || strcmp(value, "0") == 0 ||
+        strcmp(value, "false") == 0 || strcmp(value, "FALSE") == 0) {
+        osty_gc_bg_marker_enabled_value = 0;
+    } else {
+        osty_gc_bg_marker_enabled_value = 1;
+    }
+    return osty_gc_bg_marker_enabled_value != 0;
+}
+
+static int64_t osty_gc_bg_marker_budget_now(void) {
+    if (osty_gc_bg_marker_budget_loaded) {
+        return osty_gc_bg_marker_budget_value;
+    }
+    osty_gc_bg_marker_budget_loaded = 1;
+    const char *value = getenv(OSTY_GC_BG_MARKER_BUDGET_ENV);
+    if (value == NULL || value[0] == '\0') {
+        return osty_gc_bg_marker_budget_value;
+    }
+    char *end = NULL;
+    long long parsed = strtoll(value, &end, 10);
+    if (end == value || (end != NULL && *end != '\0') || parsed <= 0) {
+        osty_rt_abort("invalid " OSTY_GC_BG_MARKER_BUDGET_ENV);
+    }
+    osty_gc_bg_marker_budget_value = (int64_t)parsed;
+    return osty_gc_bg_marker_budget_value;
+}
+
+/* True when no other thread can read or mutate GC-managed state, so
+ * the lock-skip fast paths in alloc / load / post_write / map ops are
+ * safe. Both user worker threads (`osty_concurrent_workers`) and the
+ * background marker (`osty_gc_bg_marker_active`) count — either being
+ * live makes the lock necessary. */
+static inline bool osty_gc_serialized_now(void) {
+    return osty_rt_concurrent_workers_load() == 0 &&
+           __atomic_load_n(&osty_gc_bg_marker_active,
+                           __ATOMIC_ACQUIRE) == 0;
+}
+
+static void osty_gc_bg_marker_kick(void);
+static void osty_gc_bg_marker_park(void);
+
 /* SplitMix64-style mixing for pointer hashing. Pointers on x86_64 / ARM64
  * have alignment-induced low-bit correlation (headers are 16-byte aligned
  * thanks to `calloc`), so naive `& mask` would cluster. This finaliser
@@ -4086,8 +4190,12 @@ static void *osty_gc_allocate_managed_headerful(size_t byte_size,
      * so the recursive mutex is unnecessary on the hot alloc path when
      * no worker thread is live. Profile post-#870 had ~13% of CPU
      * sitting in `_pthread_mutex_firstfit_*` under
-     * `osty_gc_allocate_managed` + `osty_gc_load_v1` combined. */
-    single_threaded = (osty_rt_concurrent_workers_load() == 0);
+     * `osty_gc_allocate_managed` + `osty_gc_load_v1` combined.
+     *
+     * Phase 0a: also gated on bg-marker quiescence — the marker reads
+     * the payload→header index and forwarding map concurrently while
+     * tracing, so an unlocked allocator insert into either would race. */
+    single_threaded = osty_gc_serialized_now();
 
     if (!humongous) {
         if (!single_threaded) osty_gc_acquire();
@@ -5964,6 +6072,10 @@ static void osty_gc_auto_drive_incremental(void *const *root_slots, int64_t root
         /* Start a fresh cycle. */
         osty_gc_state = OSTY_GC_STATE_MARK_INCREMENTAL;
         osty_gc_incremental_seed_roots(root_slots, root_slot_count);
+        /* Phase 0a: same kick path as the public start — the bg
+         * marker helps drain between safepoints if this auto-drive
+         * leaves the cycle open. */
+        osty_gc_bg_marker_kick();
     }
     if (osty_gc_state == OSTY_GC_STATE_MARK_INCREMENTAL) {
         int64_t budget = osty_gc_incremental_budget_now();
@@ -5975,6 +6087,7 @@ static void osty_gc_auto_drive_incremental(void *const *root_slots, int64_t root
              * walk now fuses the sweep, so no separate
              * `osty_gc_incremental_sweep()` call is needed when we
              * compact. */
+            osty_gc_bg_marker_park();
             osty_gc_state = OSTY_GC_STATE_SWEEPING;
             (void)osty_gc_compact_major_with_stack_roots(
                 root_slots, root_slot_count);
@@ -6130,6 +6243,14 @@ void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots,
     }
     osty_gc_state = OSTY_GC_STATE_MARK_INCREMENTAL;
     osty_gc_incremental_seed_roots(root_slots, root_slot_count);
+    /* Phase 0a: kick the background marker after seeding so it has
+     * grey work waiting. The kick promotes the cycle from
+     * "budgeted-incremental" (mutator-driven) to truly concurrent —
+     * the bg thread starts draining while the mutator returns from
+     * this call. Lock-skip fast paths (alloc, load, post_write) all
+     * gate on `osty_gc_serialized_now()`, which observes the active
+     * flag set inside `bg_marker_kick`. */
+    osty_gc_bg_marker_kick();
     osty_gc_release();
 }
 
@@ -6166,6 +6287,12 @@ bool osty_gc_collect_incremental_step(int64_t budget) {
  * `osty_gc_collect_incremental_finish_with_stack_roots`. */
 static void osty_gc_collect_incremental_finish_locked(
     void *const *root_slots, int64_t root_slot_count, bool compact) {
+    /* Phase 0a: park the background marker before the final drain.
+     * Clearing `bg_marker_active` makes the marker exit its drain loop
+     * the next time it wakes from a nap; the GC lock we hold here
+     * prevents any in-flight bg drain from racing with the work below.
+     * Park is a no-op when bg-marker is disabled or never started. */
+    osty_gc_bg_marker_park();
     /* Drain any remaining greys so the sweep sees a consistent
      * colouring. The incremental barrier (SATB pre_write) could have
      * dropped new greys on us between the last step and this call. */
@@ -6249,6 +6376,115 @@ void osty_gc_collect_incremental_finish_with_stack_roots(
             osty_gc_collection_nanos_max = elapsed;
         }
     }
+}
+
+/* Phase 0a: background marker thread main loop.
+ *
+ * Outer loop: cv-wait until `bg_marker_active` flips to 1 (or shutdown
+ * is signalled — currently the runtime has no clean shutdown so the
+ * thread lives until process exit).
+ *
+ * Inner loop: while active, repeatedly grab `osty_gc_lock`, drain a
+ * bounded budget of greys, then release. When the queue drains we nap
+ * briefly so SATB pre_writes can land — they push under the same lock
+ * and grow the queue back. When `active` flips to 0 we exit the inner
+ * loop and re-suspend.
+ *
+ * State observation: the marker reads `osty_gc_state` under the GC
+ * lock, so it never trips on a transient SWEEPING state set by
+ * `incremental_finish_locked`. The `active` flag is flipped to 0
+ * before that transition, which is the primary exit signal. */
+static void *osty_gc_bg_marker_main(void *arg) {
+    (void)arg;
+    int64_t budget = osty_gc_bg_marker_budget_now();
+    for (;;) {
+        osty_rt_mu_lock(&osty_gc_bg_marker_mu);
+        while (__atomic_load_n(&osty_gc_bg_marker_active,
+                               __ATOMIC_ACQUIRE) == 0) {
+            osty_rt_cond_wait(&osty_gc_bg_marker_cv,
+                              &osty_gc_bg_marker_mu);
+        }
+        osty_rt_mu_unlock(&osty_gc_bg_marker_mu);
+
+        for (;;) {
+            if (__atomic_load_n(&osty_gc_bg_marker_active,
+                                __ATOMIC_ACQUIRE) == 0) {
+                break;
+            }
+            osty_gc_acquire();
+            if (osty_gc_state != OSTY_GC_STATE_MARK_INCREMENTAL) {
+                osty_gc_release();
+                break;
+            }
+            int64_t done = osty_gc_mark_drain_budget(budget);
+            osty_gc_bg_marker_drained_total += done;
+            osty_gc_bg_marker_loops_total += 1;
+            int64_t remaining = osty_gc_mark_stack_count;
+            osty_gc_release();
+            if (remaining == 0) {
+                /* Queue empty — nap and re-check. SATB barriers may
+                 * push more before finish runs. */
+                osty_gc_bg_marker_naps_total += 1;
+                osty_rt_sleep_ns(OSTY_GC_BG_MARKER_IDLE_NAP_NS);
+            } else {
+                osty_rt_plat_yield();
+            }
+        }
+    }
+}
+
+static void osty_gc_bg_marker_lazy_init(void) {
+    if (osty_rt_mu_init(&osty_gc_bg_marker_mu) != 0) {
+        osty_rt_abort("bg marker: mutex init failed");
+    }
+    if (osty_rt_cond_init(&osty_gc_bg_marker_cv) != 0) {
+        osty_rt_abort("bg marker: cond init failed");
+    }
+}
+
+static osty_rt_once_t osty_gc_bg_marker_once = OSTY_RT_ONCE_INIT;
+
+/* Caller holds `osty_gc_lock`. Lazy: starts the thread on first call,
+ * no-ops on subsequent calls. Enables the runtime-concurrency flag so
+ * `osty_rt_map_lock` / `osty_rt_map_unlock` engage their per-map
+ * mutexes — the marker traces map internals concurrently with mutator
+ * inserts, and the per-map mutex serializes index/slot reallocation. */
+static void osty_gc_bg_marker_ensure_started(void) {
+    osty_rt_once(&osty_gc_bg_marker_once, osty_gc_bg_marker_lazy_init);
+    if (osty_gc_bg_marker_started) {
+        return;
+    }
+    if (osty_rt_thread_start(&osty_gc_bg_marker_thread,
+                             osty_gc_bg_marker_main, NULL) != 0) {
+        osty_rt_abort("bg marker: thread start failed");
+    }
+    osty_gc_bg_marker_started = 1;
+    osty_rt_enable_concurrency_runtime();
+}
+
+/* Caller holds `osty_gc_lock`. Sets active=1 and signals the cv so the
+ * marker wakes from its outer cv-wait. */
+static void osty_gc_bg_marker_kick(void) {
+    if (!osty_gc_bg_marker_enabled_now()) {
+        return;
+    }
+    osty_gc_bg_marker_ensure_started();
+    osty_rt_mu_lock(&osty_gc_bg_marker_mu);
+    __atomic_store_n(&osty_gc_bg_marker_active, 1, __ATOMIC_RELEASE);
+    osty_gc_bg_marker_kicks_total += 1;
+    osty_rt_cond_signal(&osty_gc_bg_marker_cv);
+    osty_rt_mu_unlock(&osty_gc_bg_marker_mu);
+}
+
+/* Caller holds `osty_gc_lock`. Clears active so the marker exits its
+ * drain loop on the next iteration. No cv signal needed: if the marker
+ * is in cond_wait it stays there until the next kick; if it's in the
+ * drain loop the atomic load picks up the cleared flag. */
+static void osty_gc_bg_marker_park(void) {
+    if (!osty_gc_bg_marker_started) {
+        return;
+    }
+    __atomic_store_n(&osty_gc_bg_marker_active, 0, __ATOMIC_RELEASE);
 }
 
 static bool osty_gc_safepoint_stress_enabled_now(void) {
@@ -8725,9 +8961,10 @@ void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, 
 // a user callback into the same map (e.g. counts.len()) re-acquire
 // instead of self-deadlocking.
 //
-// Single-threaded fast path: when `osty_concurrent_workers == 0`
-// there are no other threads that could observe partial state, so
-// both lock and unlock become no-ops. This is safe because:
+// Single-threaded fast path: when `osty_gc_serialized_now()` (no
+// user worker threads AND the bg marker is parked), there are no
+// other threads that could observe partial state, so both lock and
+// unlock become no-ops. This is safe because:
 //   - The counter is incremented by the spawning thread BEFORE the
 //     new worker thread starts (see osty_rt_task_spawn), so a live
 //     worker always has workers >= 1 from every reader's view.
@@ -8757,7 +8994,7 @@ OSTY_HOT_INLINE void osty_rt_map_lock(void *raw_map) {
     if (!osty_rt_runtime_has_concurrency()) return;
     osty_rt_map *map = osty_rt_map_cast(raw_map);
     if (map == NULL || !map->mu_init) return;
-    if (osty_concurrent_workers == 0) return;
+    if (osty_gc_serialized_now()) return;
     osty_rt_rmu_lock(&map->mu);
 }
 
@@ -8765,7 +9002,7 @@ OSTY_HOT_INLINE void osty_rt_map_unlock(void *raw_map) {
     if (!osty_rt_runtime_has_concurrency()) return;
     osty_rt_map *map = osty_rt_map_cast(raw_map);
     if (map == NULL || !map->mu_init) return;
-    if (osty_concurrent_workers == 0) return;
+    if (osty_gc_serialized_now()) return;
     osty_rt_rmu_unlock(&map->mu);
 }
 
@@ -10627,8 +10864,11 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
      * and `osty_gc_collection_requested` are all updated the same way.
      * When a worker thread is live (`osty_concurrent_workers > 0`) we fall
      * through to the locked path so concurrent task-group programs keep the
-     * old single-writer guarantee. */
-    if (osty_rt_concurrent_workers_load() == 0) {
+     * old single-writer guarantee. Phase 0a: `osty_gc_serialized_now()`
+     * also gates on the bg marker — its tracer reads the same
+     * payload→header index this fast path probes, so concurrent reads
+     * vs the unlocked appends here would race. */
+    if (osty_gc_serialized_now()) {
         osty_gc_post_write_count += 1;
         if (owner == NULL || value == NULL) {
             return;
@@ -10765,7 +11005,7 @@ void *osty_gc_load_v1(void *value) {
             return redirected;
         }
     }
-    if (osty_rt_concurrent_workers_load() == 0 &&
+    if (osty_gc_serialized_now() &&
         osty_gc_forwarding_count == 0) {
         osty_gc_load_count += 1;
         if (value != NULL) {
@@ -10776,7 +11016,7 @@ void *osty_gc_load_v1(void *value) {
 
     /* Single-mutator path with forwarding active: skip the lock but
      * keep the full hash + forwarding lookup. */
-    if (osty_rt_concurrent_workers_load() == 0) {
+    if (osty_gc_serialized_now()) {
         osty_gc_load_count += 1;
         if (osty_gc_find_header(value) != NULL) {
             osty_gc_load_managed_count += 1;
@@ -11249,6 +11489,35 @@ int64_t osty_gc_debug_incremental_work_total(void) {
 
 int64_t osty_gc_debug_satb_barrier_greyed_total(void) {
     return osty_gc_satb_barrier_greyed_total;
+}
+
+/* Phase 0a background marker accessors. Tests assert these advance
+ * when `OSTY_GC_BG_MARKER=1` is enabled and a cycle runs. Counters
+ * are written without atomic stores because they're only mutated by
+ * the marker thread and read by mutator-side debug calls; a stale
+ * read just lags one step behind which is acceptable for telemetry. */
+int64_t osty_gc_debug_bg_marker_started(void) {
+    return osty_gc_bg_marker_started ? 1 : 0;
+}
+
+int64_t osty_gc_debug_bg_marker_drained_total(void) {
+    return osty_gc_bg_marker_drained_total;
+}
+
+int64_t osty_gc_debug_bg_marker_loops_total(void) {
+    return osty_gc_bg_marker_loops_total;
+}
+
+int64_t osty_gc_debug_bg_marker_naps_total(void) {
+    return osty_gc_bg_marker_naps_total;
+}
+
+int64_t osty_gc_debug_bg_marker_kicks_total(void) {
+    return osty_gc_bg_marker_kicks_total;
+}
+
+int64_t osty_gc_debug_bg_marker_active(void) {
+    return __atomic_load_n(&osty_gc_bg_marker_active, __ATOMIC_ACQUIRE) ? 1 : 0;
 }
 
 int64_t osty_gc_debug_color_of(void *payload) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1787,6 +1787,37 @@ static inline bool osty_gc_serialized_now(void) {
 static void osty_gc_bg_marker_kick(void);
 static void osty_gc_bg_marker_park(void);
 
+/* Phase 0b: STW handshake helper for multi-thread incremental cycles.
+ *
+ * `osty_gc_collect_incremental_start_with_stack_roots` and its finish
+ * counterpart are normally driven by the main thread of a
+ * single-mutator program. When user worker threads are live
+ * (`osty_concurrent_workers > 0`), the caller's own root slots are
+ * not enough — sibling mutators hold roots on their own stacks that
+ * the cycle must scan. The handshake parks every worker at a
+ * safepoint, walks the published-roots registry built up by
+ * `osty_rt_sched_preempt_park_for_collector`, and unions those roots
+ * with the caller's into a flat array suitable for
+ * `osty_gc_incremental_seed_roots` or
+ * `osty_gc_collect_incremental_finish_locked`.
+ *
+ * Caller contract: must NOT be a pool worker (`osty_sched_is_worker`
+ * = false). A worker calling this would have to park itself and
+ * deadlock the wait_all_parked loop. Tests and main-thread runtime
+ * paths satisfy this naturally; auto-drive paths route around it via
+ * the existing single-thread gate. */
+typedef struct osty_gc_stw_handshake_state {
+    void **flat_roots;
+    int64_t total_count;
+    int held;
+} osty_gc_stw_handshake_state;
+
+static void osty_gc_stw_handshake_acquire(
+    void *const *caller_roots, int64_t caller_count,
+    osty_gc_stw_handshake_state *out);
+static void osty_gc_stw_handshake_release(
+    osty_gc_stw_handshake_state *state);
+
 /* SplitMix64-style mixing for pointer hashing. Pointers on x86_64 / ARM64
  * have alignment-induced low-bit correlation (headers are 16-byte aligned
  * thanks to `calloc`), so naive `& mask` would cluster. This finaliser
@@ -6232,17 +6263,32 @@ static void osty_gc_incremental_sweep(void) {
  * calls it with an empty stack-slot array so tests / callers without
  * visible frame descriptors can still drive the machinery. */
 void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count) {
+    /* Phase 0b: when user worker threads are live, drive an STW
+     * handshake so every parked mutator's roots get folded into the
+     * cycle's seed set. Single-threaded path stays branch-free.
+     *
+     * The handshake itself is the only STW window for cycle start —
+     * after `seed_roots` returns and we kick the bg marker, mutators
+     * resume and mark proceeds concurrently in the bg thread. */
+    bool multi_thread = osty_rt_concurrent_workers_load() > 0;
+    osty_gc_stw_handshake_state hs = {0};
+    void *const *seed_roots = root_slots;
+    int64_t seed_count = root_slot_count;
+    if (multi_thread) {
+        osty_gc_stw_handshake_acquire(root_slots, root_slot_count, &hs);
+        seed_roots = (void *const *)hs.flat_roots;
+        seed_count = hs.total_count;
+    }
     osty_gc_acquire();
     if (osty_gc_state != OSTY_GC_STATE_IDLE) {
         osty_gc_release();
+        if (multi_thread) {
+            osty_gc_stw_handshake_release(&hs);
+        }
         osty_rt_abort("incremental start called while collection already in progress");
     }
-    if (osty_rt_concurrent_workers_load() > 0) {
-        osty_gc_release();
-        return;
-    }
     osty_gc_state = OSTY_GC_STATE_MARK_INCREMENTAL;
-    osty_gc_incremental_seed_roots(root_slots, root_slot_count);
+    osty_gc_incremental_seed_roots(seed_roots, seed_count);
     /* Phase 0a: kick the background marker after seeding so it has
      * grey work waiting. The kick promotes the cycle from
      * "budgeted-incremental" (mutator-driven) to truly concurrent —
@@ -6252,6 +6298,9 @@ void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots,
      * flag set inside `bg_marker_kick`. */
     osty_gc_bg_marker_kick();
     osty_gc_release();
+    if (multi_thread) {
+        osty_gc_stw_handshake_release(&hs);
+    }
 }
 
 /* Returns true if more mark work remains; false when the queue is
@@ -6326,17 +6375,29 @@ static void osty_gc_collect_incremental_finish_locked(
 
 void osty_gc_collect_incremental_finish(void) {
     int64_t t_start = osty_gc_now_nanos();
+    /* Phase 0b: park mutators before the final drain + sweep so SATB
+     * barriers have flushed and no new edges race the sweep. The
+     * compact path is skipped here (`compact = false`) because we
+     * lack frame descriptors for the caller — callers that need
+     * compaction must use the `_with_stack_roots` variant. */
+    bool multi_thread = osty_rt_concurrent_workers_load() > 0;
+    osty_gc_stw_handshake_state hs = {0};
+    if (multi_thread) {
+        osty_gc_stw_handshake_acquire(NULL, 0, &hs);
+    }
     osty_gc_acquire();
     if (osty_gc_state == OSTY_GC_STATE_IDLE) {
         osty_gc_release();
+        if (multi_thread) {
+            osty_gc_stw_handshake_release(&hs);
+        }
         return;
     }
-    /* No-stack-roots path: skip compaction (see rationale in
-     * `osty_gc_collect_incremental_finish_locked`). Callers that own
-     * their frame descriptors should prefer the `_with_stack_roots`
-     * variant so Phase D compaction runs. */
     osty_gc_collect_incremental_finish_locked(NULL, 0, false);
     osty_gc_release();
+    if (multi_thread) {
+        osty_gc_stw_handshake_release(&hs);
+    }
 
     int64_t t_end = osty_gc_now_nanos();
     if (t_start != 0 && t_end >= t_start) {
@@ -6357,14 +6418,33 @@ void osty_gc_collect_incremental_finish(void) {
 void osty_gc_collect_incremental_finish_with_stack_roots(
     void *const *root_slots, int64_t root_slot_count) {
     int64_t t_start = osty_gc_now_nanos();
+    /* Phase 0b: park mutators and union their published roots with
+     * the caller's so compaction can remap every live stack slot.
+     * Without the union, the compaction step in `finish_locked` would
+     * leave dangling pointers on parked mutators' stacks. */
+    bool multi_thread = osty_rt_concurrent_workers_load() > 0;
+    osty_gc_stw_handshake_state hs = {0};
+    void *const *finish_roots = root_slots;
+    int64_t finish_count = root_slot_count;
+    if (multi_thread) {
+        osty_gc_stw_handshake_acquire(root_slots, root_slot_count, &hs);
+        finish_roots = (void *const *)hs.flat_roots;
+        finish_count = hs.total_count;
+    }
     osty_gc_acquire();
     if (osty_gc_state == OSTY_GC_STATE_IDLE) {
         osty_gc_release();
+        if (multi_thread) {
+            osty_gc_stw_handshake_release(&hs);
+        }
         return;
     }
     osty_gc_collect_incremental_finish_locked(
-        root_slots, root_slot_count, true);
+        finish_roots, finish_count, true);
     osty_gc_release();
+    if (multi_thread) {
+        osty_gc_stw_handshake_release(&hs);
+    }
 
     int64_t t_end = osty_gc_now_nanos();
     if (t_start != 0 && t_end >= t_start) {
@@ -13936,6 +14016,83 @@ void osty_rt_sched_concurrent_stop_release_v1(void) {
                      __ATOMIC_RELEASE);
     osty_rt_cond_broadcast(&osty_gc_stop_cv);
     osty_rt_mu_unlock(&osty_gc_stop_mu);
+}
+
+/* Forward decl for the helper below; full definition lives further
+ * down with the rest of the scheduler-side preempt machinery. */
+void osty_rt_sched_kick_worker_v1(int64_t worker_id);
+
+/* Phase 0b: STW root handshake helper. Definitions of the forward
+ * declarations near the top of the file. Used by the multi-thread
+ * branch of `incremental_start_with_stack_roots` and `incremental_finish*`
+ * to bring every pool worker to a safepoint and union published roots
+ * with the caller's. */
+static void osty_gc_stw_handshake_acquire(
+    void *const *caller_roots, int64_t caller_count,
+    osty_gc_stw_handshake_state *out) {
+    out->flat_roots = NULL;
+    out->total_count = 0;
+    out->held = 0;
+    if (caller_count < 0) {
+        caller_count = 0;
+    }
+
+    osty_rt_sched_concurrent_stop_request_v1();
+    osty_rt_sched_kick_worker_v1(-1);
+
+    osty_rt_mu_lock(&osty_gc_stop_mu);
+    for (;;) {
+        int64_t inflight =
+            __atomic_load_n(&osty_concurrent_workers, __ATOMIC_ACQUIRE);
+        if (osty_gc_parked_mutator_count >= inflight) {
+            break;
+        }
+        osty_rt_cond_wait(&osty_gc_stop_cv, &osty_gc_stop_mu);
+    }
+
+    int64_t total = caller_count;
+    for (osty_gc_parked_roots_entry *e = osty_gc_parked_roots_head;
+         e != NULL; e = e->next) {
+        total += e->count;
+    }
+    void **flat = NULL;
+    if (total > 0) {
+        flat = (void **)calloc((size_t)total, sizeof(void *));
+        if (flat == NULL) {
+            osty_rt_mu_unlock(&osty_gc_stop_mu);
+            osty_rt_sched_concurrent_stop_release_v1();
+            osty_rt_abort("stw handshake: flat union OOM");
+        }
+        int64_t idx = 0;
+        for (int64_t i = 0; i < caller_count; i++) {
+            flat[idx++] = (void *)caller_roots[i];
+        }
+        for (osty_gc_parked_roots_entry *e = osty_gc_parked_roots_head;
+             e != NULL; e = e->next) {
+            for (int64_t i = 0; i < e->count; i++) {
+                flat[idx++] = (void *)e->slots[i];
+            }
+        }
+    }
+    osty_rt_mu_unlock(&osty_gc_stop_mu);
+
+    out->flat_roots = flat;
+    out->total_count = total;
+    out->held = 1;
+}
+
+static void osty_gc_stw_handshake_release(
+    osty_gc_stw_handshake_state *state) {
+    if (!state->held) {
+        return;
+    }
+    if (state->flat_roots != NULL) {
+        free(state->flat_roots);
+        state->flat_roots = NULL;
+    }
+    state->total_count = 0;
+    state->held = 0;
+    osty_rt_sched_concurrent_stop_release_v1();
 }
 
 /* Phase 3 step 2 — concurrent collection driver.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1721,13 +1721,26 @@ static void osty_sched_workers_dec(void) {
  * marker responsive without spinning. */
 #define OSTY_GC_BG_MARKER_IDLE_NAP_NS 200000ULL  /* 200 µs */
 
+/* Phase 0c: parallel marker workers. `OSTY_GC_BG_WORKERS` controls the
+ * worker count (default 1, max OSTY_GC_BG_MARKER_MAX_WORKERS). All N
+ * workers share the same grey queue under `osty_gc_lock`; lock
+ * contention is the limiting factor — Phase 0d reduces it with a
+ * segregated push/pop path. Per-worker drain counters expose the work
+ * split so tests can prove parallelism actually engaged. */
+#define OSTY_GC_BG_WORKERS_ENV "OSTY_GC_BG_WORKERS"
+#define OSTY_GC_BG_WORKERS_DEFAULT 1
+#define OSTY_GC_BG_MARKER_MAX_WORKERS 16
+
 static int osty_gc_bg_marker_enabled_loaded = 0;
 static int osty_gc_bg_marker_enabled_value = 0;
 static int osty_gc_bg_marker_budget_loaded = 0;
 static int64_t osty_gc_bg_marker_budget_value = OSTY_GC_BG_MARKER_BUDGET_DEFAULT;
+static int osty_gc_bg_workers_loaded = 0;
+static int osty_gc_bg_workers_value = OSTY_GC_BG_WORKERS_DEFAULT;
 
-static osty_rt_thread_t osty_gc_bg_marker_thread;
+static osty_rt_thread_t osty_gc_bg_marker_threads[OSTY_GC_BG_MARKER_MAX_WORKERS];
 static int osty_gc_bg_marker_started = 0;
+static int osty_gc_bg_marker_worker_count = 0;
 static osty_rt_mu_t osty_gc_bg_marker_mu;
 static osty_rt_cond_t osty_gc_bg_marker_cv;
 /* `active` flag: 1 between incremental.start and finish, 0 otherwise.
@@ -1735,10 +1748,20 @@ static osty_rt_cond_t osty_gc_bg_marker_cv;
  * the kick mutex on every iteration. */
 static int osty_gc_bg_marker_active = 0;
 
+/* Atomic counters because N>=2 marker threads update them concurrently.
+ * For N==1 the atomics still compile to plain loads/stores on x86 +
+ * release-store on ARM — overhead in the noise vs. the trace work
+ * itself. */
 static int64_t osty_gc_bg_marker_drained_total = 0;
 static int64_t osty_gc_bg_marker_loops_total = 0;
 static int64_t osty_gc_bg_marker_naps_total = 0;
 static int64_t osty_gc_bg_marker_kicks_total = 0;
+/* Per-worker drained counter for parallelism observability. Each
+ * worker owns one slot indexed by its TLS worker_id. The aggregate
+ * `drained_total` is the sum of these but is also tracked atomically
+ * so a reader doesn't have to walk the array. */
+static int64_t osty_gc_bg_marker_per_worker_drained[OSTY_GC_BG_MARKER_MAX_WORKERS];
+static OSTY_RT_TLS int osty_gc_bg_marker_worker_id = -1;
 
 static bool osty_gc_bg_marker_enabled_now(void) {
     if (osty_gc_bg_marker_enabled_loaded) {
@@ -1771,6 +1794,27 @@ static int64_t osty_gc_bg_marker_budget_now(void) {
     }
     osty_gc_bg_marker_budget_value = (int64_t)parsed;
     return osty_gc_bg_marker_budget_value;
+}
+
+static int osty_gc_bg_workers_now(void) {
+    if (osty_gc_bg_workers_loaded) {
+        return osty_gc_bg_workers_value;
+    }
+    osty_gc_bg_workers_loaded = 1;
+    const char *value = getenv(OSTY_GC_BG_WORKERS_ENV);
+    if (value == NULL || value[0] == '\0') {
+        return osty_gc_bg_workers_value;
+    }
+    char *end = NULL;
+    long long parsed = strtoll(value, &end, 10);
+    if (end == value || (end != NULL && *end != '\0') || parsed <= 0) {
+        osty_rt_abort("invalid " OSTY_GC_BG_WORKERS_ENV);
+    }
+    if (parsed > OSTY_GC_BG_MARKER_MAX_WORKERS) {
+        parsed = OSTY_GC_BG_MARKER_MAX_WORKERS;
+    }
+    osty_gc_bg_workers_value = (int)parsed;
+    return osty_gc_bg_workers_value;
 }
 
 /* True when no other thread can read or mutate GC-managed state, so
@@ -6475,7 +6519,8 @@ void osty_gc_collect_incremental_finish_with_stack_roots(
  * `incremental_finish_locked`. The `active` flag is flipped to 0
  * before that transition, which is the primary exit signal. */
 static void *osty_gc_bg_marker_main(void *arg) {
-    (void)arg;
+    /* arg encodes the worker_id (0..N-1) for per-worker counters. */
+    osty_gc_bg_marker_worker_id = (int)(intptr_t)arg;
     int64_t budget = osty_gc_bg_marker_budget_now();
     for (;;) {
         osty_rt_mu_lock(&osty_gc_bg_marker_mu);
@@ -6497,14 +6542,28 @@ static void *osty_gc_bg_marker_main(void *arg) {
                 break;
             }
             int64_t done = osty_gc_mark_drain_budget(budget);
-            osty_gc_bg_marker_drained_total += done;
-            osty_gc_bg_marker_loops_total += 1;
+            /* Atomic adds — N>=2 workers race here. The per-worker
+             * slot is single-writer so a relaxed add suffices; the
+             * aggregate counter aggregates across writers so it
+             * needs RELAXED + ACQ_REL semantics on test reads (we
+             * use ACQUIRE on the reader side). */
+            (void)__atomic_add_fetch(&osty_gc_bg_marker_drained_total,
+                                     done, __ATOMIC_RELAXED);
+            (void)__atomic_add_fetch(&osty_gc_bg_marker_loops_total,
+                                     1, __ATOMIC_RELAXED);
+            if (osty_gc_bg_marker_worker_id >= 0 &&
+                osty_gc_bg_marker_worker_id <
+                    OSTY_GC_BG_MARKER_MAX_WORKERS) {
+                osty_gc_bg_marker_per_worker_drained
+                    [osty_gc_bg_marker_worker_id] += done;
+            }
             int64_t remaining = osty_gc_mark_stack_count;
             osty_gc_release();
             if (remaining == 0) {
                 /* Queue empty — nap and re-check. SATB barriers may
                  * push more before finish runs. */
-                osty_gc_bg_marker_naps_total += 1;
+                (void)__atomic_add_fetch(&osty_gc_bg_marker_naps_total,
+                                         1, __ATOMIC_RELAXED);
                 osty_rt_sleep_ns(OSTY_GC_BG_MARKER_IDLE_NAP_NS);
             } else {
                 osty_rt_plat_yield();
@@ -6524,26 +6583,38 @@ static void osty_gc_bg_marker_lazy_init(void) {
 
 static osty_rt_once_t osty_gc_bg_marker_once = OSTY_RT_ONCE_INIT;
 
-/* Caller holds `osty_gc_lock`. Lazy: starts the thread on first call,
- * no-ops on subsequent calls. Enables the runtime-concurrency flag so
- * `osty_rt_map_lock` / `osty_rt_map_unlock` engage their per-map
- * mutexes — the marker traces map internals concurrently with mutator
- * inserts, and the per-map mutex serializes index/slot reallocation. */
+/* Caller holds `osty_gc_lock`. Lazy: starts N marker threads on first
+ * call (N from `OSTY_GC_BG_WORKERS`, default 1, capped at
+ * `OSTY_GC_BG_MARKER_MAX_WORKERS`), no-ops on subsequent calls.
+ * Enables the runtime-concurrency flag so `osty_rt_map_lock` /
+ * `osty_rt_map_unlock` engage their per-map mutexes — the marker
+ * traces map internals concurrently with mutator inserts, and the
+ * per-map mutex serializes index/slot reallocation. */
 static void osty_gc_bg_marker_ensure_started(void) {
     osty_rt_once(&osty_gc_bg_marker_once, osty_gc_bg_marker_lazy_init);
     if (osty_gc_bg_marker_started) {
         return;
     }
-    if (osty_rt_thread_start(&osty_gc_bg_marker_thread,
-                             osty_gc_bg_marker_main, NULL) != 0) {
-        osty_rt_abort("bg marker: thread start failed");
+    int n = osty_gc_bg_workers_now();
+    if (n < 1) n = 1;
+    if (n > OSTY_GC_BG_MARKER_MAX_WORKERS) {
+        n = OSTY_GC_BG_MARKER_MAX_WORKERS;
     }
+    for (int i = 0; i < n; i++) {
+        if (osty_rt_thread_start(&osty_gc_bg_marker_threads[i],
+                                 osty_gc_bg_marker_main,
+                                 (void *)(intptr_t)i) != 0) {
+            osty_rt_abort("bg marker: thread start failed");
+        }
+    }
+    osty_gc_bg_marker_worker_count = n;
     osty_gc_bg_marker_started = 1;
     osty_rt_enable_concurrency_runtime();
 }
 
-/* Caller holds `osty_gc_lock`. Sets active=1 and signals the cv so the
- * marker wakes from its outer cv-wait. */
+/* Caller holds `osty_gc_lock`. Sets active=1 and broadcasts the cv so
+ * every marker thread wakes from its outer cv-wait. Broadcast (not
+ * signal) because N >= 1 workers may be parked. */
 static void osty_gc_bg_marker_kick(void) {
     if (!osty_gc_bg_marker_enabled_now()) {
         return;
@@ -6551,8 +6622,9 @@ static void osty_gc_bg_marker_kick(void) {
     osty_gc_bg_marker_ensure_started();
     osty_rt_mu_lock(&osty_gc_bg_marker_mu);
     __atomic_store_n(&osty_gc_bg_marker_active, 1, __ATOMIC_RELEASE);
-    osty_gc_bg_marker_kicks_total += 1;
-    osty_rt_cond_signal(&osty_gc_bg_marker_cv);
+    (void)__atomic_add_fetch(&osty_gc_bg_marker_kicks_total,
+                             1, __ATOMIC_RELAXED);
+    osty_rt_cond_broadcast(&osty_gc_bg_marker_cv);
     osty_rt_mu_unlock(&osty_gc_bg_marker_mu);
 }
 
@@ -11571,33 +11643,50 @@ int64_t osty_gc_debug_satb_barrier_greyed_total(void) {
     return osty_gc_satb_barrier_greyed_total;
 }
 
-/* Phase 0a background marker accessors. Tests assert these advance
+/* Phase 0a/0c background marker accessors. Tests assert these advance
  * when `OSTY_GC_BG_MARKER=1` is enabled and a cycle runs. Counters
- * are written without atomic stores because they're only mutated by
- * the marker thread and read by mutator-side debug calls; a stale
- * read just lags one step behind which is acceptable for telemetry. */
+ * are atomically updated by the marker threads (potentially N>=2)
+ * so reads use ACQUIRE to pair with the writers' RELEASE/RELAXED
+ * adds. Per-worker counters are single-writer so a plain load is
+ * fine. */
 int64_t osty_gc_debug_bg_marker_started(void) {
     return osty_gc_bg_marker_started ? 1 : 0;
 }
 
+int64_t osty_gc_debug_bg_marker_workers(void) {
+    return (int64_t)osty_gc_bg_marker_worker_count;
+}
+
 int64_t osty_gc_debug_bg_marker_drained_total(void) {
-    return osty_gc_bg_marker_drained_total;
+    return __atomic_load_n(&osty_gc_bg_marker_drained_total,
+                           __ATOMIC_ACQUIRE);
 }
 
 int64_t osty_gc_debug_bg_marker_loops_total(void) {
-    return osty_gc_bg_marker_loops_total;
+    return __atomic_load_n(&osty_gc_bg_marker_loops_total,
+                           __ATOMIC_ACQUIRE);
 }
 
 int64_t osty_gc_debug_bg_marker_naps_total(void) {
-    return osty_gc_bg_marker_naps_total;
+    return __atomic_load_n(&osty_gc_bg_marker_naps_total,
+                           __ATOMIC_ACQUIRE);
 }
 
 int64_t osty_gc_debug_bg_marker_kicks_total(void) {
-    return osty_gc_bg_marker_kicks_total;
+    return __atomic_load_n(&osty_gc_bg_marker_kicks_total,
+                           __ATOMIC_ACQUIRE);
 }
 
 int64_t osty_gc_debug_bg_marker_active(void) {
     return __atomic_load_n(&osty_gc_bg_marker_active, __ATOMIC_ACQUIRE) ? 1 : 0;
+}
+
+/* Per-worker drained — index 0..workers-1. Returns -1 for OOB. */
+int64_t osty_gc_debug_bg_marker_per_worker_drained(int64_t worker_id) {
+    if (worker_id < 0 || worker_id >= OSTY_GC_BG_MARKER_MAX_WORKERS) {
+        return -1;
+    }
+    return osty_gc_bg_marker_per_worker_drained[(int)worker_id];
 }
 
 int64_t osty_gc_debug_color_of(void *payload) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -6522,6 +6522,20 @@ static void *osty_gc_bg_marker_main(void *arg) {
     /* arg encodes the worker_id (0..N-1) for per-worker counters. */
     osty_gc_bg_marker_worker_id = (int)(intptr_t)arg;
     int64_t budget = osty_gc_bg_marker_budget_now();
+    /* Phase 0d: when multiple workers share the queue, drain in
+     * smaller per-iteration batches so the lock cycles more often
+     * and siblings actually get a turn. The N==1 path keeps the full
+     * budget for max throughput (no contention to share). The factor
+     * 4× is heuristic — small enough that N=4 workers get multiple
+     * turns on a few-hundred-item graph, large enough to amortise the
+     * per-batch acquire/release cycle. */
+    int n = osty_gc_bg_marker_worker_count;
+    int64_t per_iter = budget;
+    if (n >= 2) {
+        per_iter = budget / 4;
+        if (per_iter < 64) per_iter = 64;
+        if (per_iter > budget) per_iter = budget;
+    }
     for (;;) {
         osty_rt_mu_lock(&osty_gc_bg_marker_mu);
         while (__atomic_load_n(&osty_gc_bg_marker_active,
@@ -6541,7 +6555,7 @@ static void *osty_gc_bg_marker_main(void *arg) {
                 osty_gc_release();
                 break;
             }
-            int64_t done = osty_gc_mark_drain_budget(budget);
+            int64_t done = osty_gc_mark_drain_budget(per_iter);
             /* Atomic adds — N>=2 workers race here. The per-worker
              * slot is single-writer so a relaxed add suffices; the
              * aggregate counter aggregates across writers so it


### PR DESCRIPTION
## Summary

Real concurrent GC across 4 phases (each its own commit). Default OFF — single-threaded programs see zero behavior change. Opt in via `OSTY_GC_BG_MARKER=1` (and optionally `OSTY_GC_BG_WORKERS=N`, `OSTY_GC_BG_MARKER_BUDGET=B`).

### Phase 0a — Background marker thread
Lazily spawns a single OS thread that drains the grey queue concurrently with the mutator. Initial root scan and final remark/sweep stay STW; mid-cycle mark work runs in the background. `osty_gc_serialized_now()` consolidates the lock-skip gate so alloc / load / post_write / map ops re-engage the recursive mutex while the marker is live.

### Phase 0b — Multi-thread cycles via STW handshake
Lifts the `concurrent_workers > 0` early-return gate that made `incremental_start_with_stack_roots` and `incremental_finish*` no-ops in multi-threaded programs. The new `osty_gc_stw_handshake_acquire` / `_release` helpers reuse the existing `osty_rt_sched_concurrent_stop_request_v1` / `_release_v1` infrastructure to park every pool worker, walk the published-roots registry, and union those roots with the caller's into the cycle's seed set. The bg marker takes over from there — the only STW windows are the start (root scan) and finish (final drain + sweep) handshakes.

### Phase 0c — Parallel marker workers
`OSTY_GC_BG_WORKERS=N` (default 1, capped at 16) spawns N marker threads sharing the grey queue. Aggregate counters are atomic; per-worker counters indexed by TLS `worker_id` expose work split for testability. The kick path broadcasts the cv (was signal) so every worker wakes on cycle start.

### Phase 0d — Per-iteration batch split for fairness
With shared `osty_gc_lock`, N workers serialised on a single drain — the first to grab the lock would drain everything alone (`w0=201 w1=0 w2=0 w3=0` on 200-item graphs). Capping bg drain at `budget/4` (floor 64) when N>=2 makes the lock cycle more often so siblings interleave. Real lock-free / work-stealing queue is a separate followup PR; this is a fairness fix, not a throughput uncap.

## Telemetry (new)

- `osty_gc_debug_bg_marker_started` — thread spawned?
- `osty_gc_debug_bg_marker_workers` — N spawned
- `osty_gc_debug_bg_marker_kicks_total` — cycles started
- `osty_gc_debug_bg_marker_drained_total` — aggregate trace count
- `osty_gc_debug_bg_marker_loops_total` — drain iterations
- `osty_gc_debug_bg_marker_naps_total` — idle naps
- `osty_gc_debug_bg_marker_active` — currently in-cycle?
- `osty_gc_debug_bg_marker_per_worker_drained(i)` — per-worker breakdown

## Test plan

- [x] `TestBundledRuntimeBackgroundMarkerDrainsCycle` — single-thread cycle, no manual step calls; bg thread drains 51-item graph
- [x] `TestBundledRuntimeBackgroundMarkerMultiThreadCycle` — Phase 0b: cycle starts despite `workers > 0`, mid_state=MARK_INCREMENTAL (regression signal: mid_state=0)
- [x] `TestBundledRuntimeBackgroundMarkerParallelWorkers` — 4 threads spawn, atomic-aggregate vs per-worker-sum agree (no torn updates)
- [x] `TestBundledRuntimeBackgroundMarkerWorkSplit` — Phase 0d: 800-item graph + N=4 + budget=256, asserts active workers >= 2
- [x] All existing `TestBundledRuntimeIncremental*` (Step / Budget / SATB / AutoDispatcher / MutatorAssist / Stress) pass unchanged
- [x] All existing scheduler/channel/taskgroup tests pass unchanged
- [x] Backend full suite: `go test ./internal/backend/` green
- [x] Rebased onto current main (#991 sweep+clone fuse) cleanly
- [x] Default OFF: no behavior change for programs that don't set `OSTY_GC_BG_MARKER`

## Followup (separate PR)

True lock-free / work-stealing grey queue. Phase 0d's batch-split is a fairness fix; throughput is still bounded by `osty_gc_lock` for grey push/pop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)