### PR TITLE
feat: ship edition 0.5

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -160,10 +160,10 @@ under v0.5 grammar. Code that wants to opt in today can do so for
 the **shipped** list above; anything under "Not yet shipped" is a
 spec-level commitment, not a usable surface, until regen lands.
 
-The project edition remains `edition = "0.4"` in `osty.toml` — there
-is no `edition = "0.5"` yet because several of the shipped forms
-(scoped imports, `pub use`, `#[cfg]`, `#[test]`) are grammar-additive
-and readable by 0.4 tooling.
+The project edition is now `edition = "0.5"` in newly scaffolded
+`osty.toml` files. Manifest validation keeps accepting historical
+`0.3` and `0.4` projects so existing workspaces can migrate
+incrementally.
 
 ## Implementation history
 

--- a/LANG_SPEC_v0.5/03-declarations.md
+++ b/LANG_SPEC_v0.5/03-declarations.md
@@ -564,9 +564,9 @@ same outputs as a vectorized one.
 
 | Arg | Form | Default | LLVM property | Effect |
 |---|---|---|---|---|
-| `scalable` | flag | absent | `llvm.loop.vectorize.scalable.enable=true` | Prefer scalable vector ISAs (ARM SVE, RISC-V RVV) over fixed-width (NEON) on targets that support both |
+| `scalable` | flag | absent | `llvm.loop.vectorize.scalable.enable=true` | Prefer scalable vector ISAs (ARM SVE, RISC-V RVV) over fixed-width (NEON) on targets that support both. macOS/iOS aarch64 do not expose SVE, so Apple Silicon falls back to fixed-width NEON even when this hint is present |
 | `predicate` | flag | absent | `llvm.loop.vectorize.predicate.enable=true` | Enable tail folding — process trip counts that are not a multiple of the vector width via masked ops instead of a scalar tail loop. Biggest win on SVE / AVX-512 / RVV with native mask registers |
-| `width` | `width = <1..1024>` | compiler chooses | `llvm.loop.vectorize.width, i32 N` | Force a specific vectorization factor. Unlocks AVX-512 ZMM registers on Intel, where the default cost model otherwise prefers 256-bit YMM because of historical downclocking. Note: the LLVM cost model may still override this hint; use `-mllvm -force-vector-width=N` at the build-time flag level when the override is required |
+| `width` | `width = <1..1024>` | compiler chooses | `llvm.loop.vectorize.width, i32 N` | Force a specific vectorization factor. Can unlock AVX-512 ZMM registers on Intel, where the default cost model otherwise prefers 256-bit YMM because of historical downclocking. The LLVM cost model may still override this hint; use `-mllvm -force-vector-width=N` at the build-time flag level when the override is required. Future target profiles may inject that flag for AVX-512 server presets |
 
 ```osty
 // Default: no annotation needed. Every loop gets vectorize metadata
@@ -605,9 +605,10 @@ with `E0739` (`CodeAnnotationBadArg`).
 
 Scope rules:
 
-- The hint is **function-scoped**. A loop in an unannotated sibling
-  function receives no metadata even when the two functions live in
-  the same module.
+- The tuning arguments are **function-scoped**. Every function receives
+  the default vectorize metadata unless it carries `#[no_vectorize]`,
+  but `scalable`, `predicate`, and `width = N` apply only to loops in
+  the function where `#[vectorize(...)]` appears.
 - Only loops originating from a user-written `for` statement carry the
   hint. Loops synthesized by the compiler (e.g. the per-iteration
   scaffold inside `testing.benchmark`, or the key-snapshot traversal

--- a/LANG_SPEC_v0.5/13-tooling.md
+++ b/LANG_SPEC_v0.5/13-tooling.md
@@ -70,7 +70,7 @@ tolerated for forward-compatibility with future additions.
 [package]                        # required unless [workspace] is present
 name        = "myapp"            # required; [A-Za-z_][A-Za-z0-9_-]*
 version     = "0.1.0"            # required; strict semver X.Y.Z[-pre][+build]
-edition     = "0.4"              # required; must be a known spec version
+edition     = "0.5"              # required; must be a known spec version
 description = "A short blurb."   # optional
 authors     = ["Alice <a@x>"]    # optional
 license     = "MIT"              # optional (SPDX identifier recommended)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ declared packages, API documentation generation (`osty doc`), CI quality
 tooling (`osty ci`), profile/target/feature/cache inspection commands, and a
 package manager (`osty add` / `osty update` / `osty publish`) backed by a
 file-backed HTTP registry server for local/private registries. The repository
-tracks spec/grammar work in v0.5, but the shipped manifest/scaffolder path is
-still pinned to edition v0.4 today (`osty new` / `osty init` write
-`edition = "0.4"`, and checked-in fixtures still exercise legacy v0.3/v0.4
-inputs). The next work is native implementation/runtime coverage. The public
-compiler path is now native-only through the LLVM backend.
+tracks spec/grammar work in v0.5, and the shipped manifest/scaffolder path now
+defaults new projects to `edition = "0.5"` while manifest validation continues
+to accept legacy `0.3` / `0.4` inputs for existing projects. The next work is
+native implementation/runtime coverage. The public compiler path is now
+native-only through the LLVM backend.
 
 ## Status
 
@@ -31,7 +31,7 @@ compiler path is now native-only through the LLVM backend.
 | Diagnostics (`error[E0002]:` with caret, hints, notes) | done |
 | Name resolution (single + multi-file, workspace, typo suggestions) | done |
 | Formatter (`internal/format`) | done |
-| Type checker (`internal/check`) | done for the shipped v0.4 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
+| Type checker (`internal/check`) | done for the shipped v0.5 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
 | Linter (`internal/lint`, 28 codes across L0001–L0070 spanning unused / dead-code / naming / simplify / complexity / docs, `--fix` / `--fix-dry-run`, policy via `[lint]` in `osty.toml`) | done |
 | Multi-file packages (`resolve` loader/package/workspace) | done |
 | LSP (`internal/lsp`, wired as `osty lsp`) | done — hover, definition, formatting, documentSymbol, lint diagnostics, editor policy backed by toolchain sources |
@@ -495,7 +495,7 @@ create multi-file binary starters with tests. `--workspace` creates a
 root manifest plus one default member package. `osty new` never
 overwrites an existing directory; `osty init` writes into the current
 directory after checking for conflicting files. The scaffolder currently
-pins `edition = "0.4"`.
+pins `edition = "0.5"`.
 
 `build` / `run` / `test` / `add` / `update` / `fetch`-specific flags
 (after the subcommand):
@@ -737,17 +737,16 @@ regenerations.
 ## Contributing
 
 Spec work in this repo is tracked under **v0.5**
-(`LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`), but the shipped project
-edition is still **0.4** today: `osty new` / `osty init` write
-`edition = "0.4"`, and manifest validation still accepts the
-historical `0.3` / `0.4` range used by checked-in examples. Future
-surface changes follow the normal versioning process and land in a new
-spec directory. See [`SPEC_GAPS.md`](./SPEC_GAPS.md) for the full
-decision log and [`CHANGELOG_v0.5.md`](./CHANGELOG_v0.5.md) for which
-parts of the v0.5 surface are wired in the CLI today versus still
-waiting on regen. When docs discuss newer surface area, be explicit
-about whether it is a design target or behavior already wired in the
-CLI and tests.
+(`LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`), and the shipped project
+edition is **0.5** today: `osty new` / `osty init` write
+`edition = "0.5"`, while manifest validation still accepts the
+historical `0.3` / `0.4` range for existing projects. Future surface
+changes follow the normal versioning process and land in a new spec
+directory. See [`SPEC_GAPS.md`](./SPEC_GAPS.md) for the full decision
+log and [`CHANGELOG_v0.5.md`](./CHANGELOG_v0.5.md) for which parts of
+the v0.5 surface are wired in the CLI today versus still waiting on
+regen. When docs discuss newer surface area, be explicit about whether
+it is a design target or behavior already wired in the CLI and tests.
 
 Conventions:
 - Every new error site gets a stable `Exxxx` code in

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -19,8 +19,9 @@
 vectorize 가 default-ON 이 됐고, `#[no_vectorize]` 로만 opt-out.
 `#[vectorize(width=N, scalable, predicate)]` 는 tuning args, `#[parallel]`
 와 `#[unroll]` 은 별개 opt-in 힌트. Safepoint poll blocker 해소됨
-(§3.8.6 공통 GC contract). 남은 gap 은 iterator-protocol 루프 커버리지와
-AVX-512 cost model 우회 문서화.
+(§3.8.6 공통 GC contract). AVX-512 cost-model 우회와 Apple Silicon
+SVE fallback 은 §3.8.3 에 문서화 완료. 남은 gap 은 iterator-protocol
+루프 커버리지뿐이다.
 
 1. ~~**Safepoint poll hoisting.**~~ **해소됨 (A5).** `#[vectorize]` /
    `#[parallel]` / `#[unroll]` 중 하나라도 붙은 함수는
@@ -49,21 +50,21 @@ AVX-512 cost model 우회 문서화.
    `Iterable<T>` 프로토콜을 구현하는 타입들 중 countable 가능한 것들
    (예: `Array`, `Slice`) 에 한해 index-driven lowering 으로 전환하는
    것. 언어 쪽 스펙은 그대로 둔다 — 어디까지나 backend 구현 선택지.
-3. **AVX-512 cost model 우회.** `#[vectorize(width = 8)]` 가 i64 loop
+3. ~~**AVX-512 cost model 우회 문서화.**~~ **해소됨.** `#[vectorize(width = 8)]` 가 i64 loop
    에 걸려도 LLVM 의 x86 cost model 이 historically downclocking
    penalty 때문에 256-bit YMM 만 선택하는 경우가 있다 (실측: width=8
    요청했으나 vectorizer 가 width=4 선택, ZMM 미사용). 사용자가
    `-mllvm -force-vector-width=8` build-time flag 로 override 할 수
-   있으며 §3.8.3 표 각주에 명시. 향후 `osty build` 가 target profile
-   (예: `--target x86_64-avx512-server`) 에서 이 flag 를 자동 주입하는
-   manifest 단축키를 제공하는 것이 이 gap 의 자연스러운 해소.
-4. **SVE on Linux aarch64.** `#[vectorize(scalable)]` + `-mcpu=neoverse-v1`
+   있음을 §3.8.3 `width` 행에 명시했다. 향후 `osty build` 가 target
+   profile (예: `--target x86_64-avx512-server`) 에서 이 flag 를 자동
+   주입하는 manifest 단축키를 제공하는 것은 별도 target-profile 개선
+   작업으로 추적한다.
+4. ~~**SVE / Apple Silicon target caveat 문서화.**~~ **해소됨.** `#[vectorize(scalable)]` + `-mcpu=neoverse-v1`
    조합이 `vscale x 8` SVE 루프 + 45 개 `z<N>.d` 명령을 생성하는 것을
    실측 확인. 그러나 **macOS/iOS aarch64 는 SVE 를 ISA 로 노출하지
    않으므로** (Apple Silicon 은 NEON 만) scalable hint 가 NEON 2-wide
-   로 폴백한다. 이건 hardware 한계이지 gap 이 아니므로 별도 작업
-   항목 없음. 문서화만 필요 — §3.8.3 표의 scalable 행에 "Apple
-   Silicon 은 NEON 폴백" 각주 추가.
+   로 폴백한다. 이건 hardware 한계이지 gap 이 아니며, §3.8.3
+   `scalable` 행에 Apple Silicon fallback 을 명시했다.
 
 향후 gap 을 닫을 때 같은 entry 에 해결 요지 + 관련 PR 을 기록한다.
 

--- a/benchmarks/programs/dep-resolver/osty/osty.toml
+++ b/benchmarks/programs/dep-resolver/osty/osty.toml
@@ -3,6 +3,6 @@
 [package]
 name = "dep-resolver"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/benchmarks/programs/expr-calc/osty/osty.toml
+++ b/benchmarks/programs/expr-calc/osty/osty.toml
@@ -3,6 +3,6 @@
 [package]
 name = "expr-calc"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/benchmarks/programs/id-tracker/osty/osty.toml
+++ b/benchmarks/programs/id-tracker/osty/osty.toml
@@ -12,6 +12,6 @@
 [package]
 name = "id-tracker"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/benchmarks/programs/log-aggregator/osty/osty.toml
+++ b/benchmarks/programs/log-aggregator/osty/osty.toml
@@ -7,6 +7,6 @@
 [package]
 name = "log-aggregator"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/benchmarks/programs/lru-sim/osty/osty.toml
+++ b/benchmarks/programs/lru-sim/osty/osty.toml
@@ -3,6 +3,6 @@
 [package]
 name = "lru-sim"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/benchmarks/programs/markdown-stats/osty/osty.toml
+++ b/benchmarks/programs/markdown-stats/osty/osty.toml
@@ -3,6 +3,6 @@
 [package]
 name = "markdown-stats"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/examples/gc/osty.toml
+++ b/examples/gc/osty.toml
@@ -8,6 +8,6 @@
 [package]
 name = "gc"
 version = "0.1.0"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]

--- a/internal/manifest/snapshot_freeze_test.go
+++ b/internal/manifest/snapshot_freeze_test.go
@@ -24,7 +24,7 @@ import (
 func TestSnapshotFreezeStamp(t *testing.T) {
 	root := repoRoot(t)
 	wants := map[string]string{
-		"toolchain/manifest_validation.osty": "f1bf7a61582e06a607d320d15e63ee7f9ba9bd5457c168fbaa95806df4206537",
+		"toolchain/manifest_validation.osty": "12e221ded6a62915fc98a1fd5bdd4490324d8b3e2dd6bef6bd7662dc5072ab65",
 	}
 	for rel, want := range wants {
 		got := hashFile(t, filepath.Join(root, rel))

--- a/internal/manifest/validate_snapshot.go
+++ b/internal/manifest/validate_snapshot.go
@@ -1224,7 +1224,7 @@ func validateManifestDiagnostics(spec *ManifestSpec) []*ManifestDiagnosticSpec {
 		if spec.pkg.edition == "" {
 			// Osty: /tmp/manifest_validate_core.osty:735:13
 			func() struct{} {
-				out = append(out, manifestWarning("E2011", fmt.Sprintf("[package] missing `edition`; defaulting to %s", ostyToString(manifestCurrentEdition())), spec.pkg.tableLine, "add edition = \"0.4\" to pin the spec version"))
+				out = append(out, manifestWarning("E2011", fmt.Sprintf("[package] missing `edition`; defaulting to %s", ostyToString(manifestCurrentEdition())), spec.pkg.tableLine, "add edition = \"0.5\" to pin the spec version"))
 				return struct{}{}
 			}()
 		} else if !(manifestEditionKnown(spec.pkg.edition)) {
@@ -1525,7 +1525,7 @@ func manifestPackageVersionValid(version string) bool {
 
 // Osty: /tmp/manifest_validate_core.osty:838:5
 func manifestEditionKnown(edition string) bool {
-	return edition == "0.3" || edition == "0.4"
+	return edition == "0.3" || edition == "0.4" || edition == "0.5"
 }
 
 // Osty: /tmp/manifest_validate_core.osty:842:5
@@ -1711,12 +1711,12 @@ func manifestLine(line int) int {
 
 // Osty: /tmp/manifest_validate_core.osty:949:1
 func manifestCurrentEdition() string {
-	return "0.4"
+	return "0.5"
 }
 
 // Osty: /tmp/manifest_validate_core.osty:953:1
 func manifestKnownEditionsText() string {
-	return "0.3, 0.4"
+	return "0.3, 0.4, 0.5"
 }
 
 // Osty: /tmp/manifest_validate_core.osty:957:1

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -14,7 +14,7 @@ func TestValidateUsesSelfHostedManifestCore(t *testing.T) {
 [package]
 name = "demo"
 version = "1.2.3"
-edition = "0.4"
+edition = "0.5"
 
 [dependencies]
 ok = "^1.0"
@@ -76,7 +76,7 @@ version = "1.2.3"
 	if got := d.PrimaryPos().Line; got != 2 {
 		t.Fatalf("line = %d, want package table line 2", got)
 	}
-	if d.Hint != `add edition = "0.4" to pin the spec version` {
+	if d.Hint != `add edition = "0.5" to pin the spec version` {
 		t.Fatalf("hint = %q", d.Hint)
 	}
 }
@@ -84,7 +84,7 @@ version = "1.2.3"
 func TestParseDefersManifestSemanticsToSelfHostedValidation(t *testing.T) {
 	m, err := Parse([]byte(`
 [package]
-edition = "0.4"
+edition = "0.5"
 `))
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func TestReadRejectsSelfHostedValidationErrors(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ManifestFile)
 	if err := os.WriteFile(path, []byte(`
 [package]
-edition = "0.4"
+edition = "0.5"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -114,7 +114,7 @@ const (
 // CurrentEdition is the spec version the scaffolder records in
 // osty.toml when Options.Edition is empty. Kept in sync with the
 // language spec directory name in the repo root.
-const CurrentEdition = "0.4"
+const CurrentEdition = "0.5"
 
 // Options configures a scaffold run.
 type Options struct {

--- a/toolchain/manifest_validation.osty
+++ b/toolchain/manifest_validation.osty
@@ -299,7 +299,7 @@ pub fn validateManifestDiagnostics(spec: ManifestSpec) -> List<ManifestDiagnosti
                 "E2011",
                 "[package] missing `edition`; defaulting to {manifestCurrentEdition()}",
                 spec.pkg.tableLine,
-                "add edition = \"0.4\" to pin the spec version",
+                "add edition = \"0.5\" to pin the spec version",
             ))
         } else if !(manifestEditionKnown(spec.pkg.edition)) {
             out.push(manifestError(
@@ -399,7 +399,7 @@ pub fn manifestPackageVersionValid(version: String) -> Bool {
 }
 
 pub fn manifestEditionKnown(edition: String) -> Bool {
-    edition == "0.3" || edition == "0.4"
+    edition == "0.3" || edition == "0.4" || edition == "0.5"
 }
 
 pub fn manifestTargetTripleValid(triple: String) -> Bool {
@@ -510,11 +510,11 @@ fn manifestLine(line: Int) -> Int {
 }
 
 fn manifestCurrentEdition() -> String {
-    "0.4"
+    "0.5"
 }
 
 fn manifestKnownEditionsText() -> String {
-    "0.3, 0.4"
+    "0.3, 0.4, 0.5"
 }
 
 fn manifestProfileDiagnostics(

--- a/toolchain/manifest_validation_test.osty
+++ b/toolchain/manifest_validation_test.osty
@@ -96,7 +96,7 @@ fn testManifestValidationExamplesEmitDiagnosticSpecs() {
     testing.assertEq(diagnostics[1].code, "E2015")
     testing.assertEq(diagnostics[1].line, 12)
     testing.assertEq(diagnostics[2].severity, "warning")
-    testing.assertEq(diagnostics[2].hint, "add edition = \"0.4\" to pin the spec version")
+    testing.assertEq(diagnostics[2].hint, "add edition = \"0.5\" to pin the spec version")
     testing.assertEq(diagnostics[3].line, 30)
     testing.assertEq(diagnostics[4].line, 40)
     testing.assertEq(diagnostics[5].message, "dependencies.bad has invalid version requirement \"1.*.3\"")
@@ -128,7 +128,7 @@ fn testManifestValidationExamplesCheckProfiles() {
         manifestProfileSpec("b", "a", false, 0),
     ]
     let spec = manifestSpec(
-        manifestPackageSpec(true, "demo", "1.2.3", "0.4"),
+        manifestPackageSpec(true, "demo", "1.2.3", "0.5"),
         manifestWorkspaceSpec(false, []),
         profiles,
         [],
@@ -146,7 +146,7 @@ fn testManifestValidationExamplesCheckProfiles() {
 
 fn testManifestValidationExamplesCheckTargetTriples() {
     let spec = manifestSpec(
-        manifestPackageSpec(true, "demo", "1.2.3", "0.4"),
+        manifestPackageSpec(true, "demo", "1.2.3", "0.5"),
         manifestWorkspaceSpec(false, []),
         [],
         [
@@ -181,7 +181,7 @@ fn testManifestValidationExamplesCheckDependencyRequirements() {
     testing.assert(!(manifestVersionReqValid("^")))
 
     let spec = manifestSpecWithDeps(
-        manifestPackageSpec(true, "demo", "1.2.3", "0.4"),
+        manifestPackageSpec(true, "demo", "1.2.3", "0.5"),
         manifestWorkspaceSpec(false, []),
         [
             manifestDependencySpec("ok", "^1.0", "", ""),
@@ -204,7 +204,7 @@ fn testManifestValidationExamplesCheckDependencyRequirements() {
 
 fn testManifestValidationExamplesComposeFeatureGraph() {
     let spec = manifestSpec(
-        manifestPackageSpec(true, "demo", "1.2.3", "0.4"),
+        manifestPackageSpec(true, "demo", "1.2.3", "0.5"),
         manifestWorkspaceSpec(false, []),
         [],
         [],


### PR DESCRIPTION
## Summary
- Default newly scaffolded manifests to `edition = "0.5"` and accept `0.5` in manifest validation while preserving legacy `0.3` / `0.4` compatibility.
- Update checked-in examples/benchmarks, v0.5 docs, and manifest validation snapshot/test expectations.
- Document vectorize target caveats for AVX-512 cost-model overrides and Apple Silicon SVE fallback, leaving iterator-protocol loops as the remaining vectorize gap.

## Test plan
- [x] `go test -count=1 -vet=off ./internal/scaffold ./internal/manifest`
- [x] `just front`
- [x] `go test -count=1 -vet=off ./internal/llvmgen -run 'Vectorize|NoVectorize'`
- [ ] CI green 확인

Note: `just prepush` was attempted but stopped at repo-wide `fmt-check` on pre-existing unrelated gofmt drift in `cmd/osty-native-llvmgen/main.go`, `internal/backend/llvm_runtime_gc_test.go`, `internal/llvmgen/mir_generator_snapshot.go`, and `internal/mir/fuse_split_nth_test.go`.

🤖 Generated with GitHub Copilot CLI