### PR TITLE
feat: enforce pure function bodies

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1085,7 +1085,7 @@ forward-compatibility hatch.
 
 ---
 
-## Runtime sublanguage (E0771–E0774)
+## Runtime sublanguage (E0771–E0775)
 
 ### E0771 — `CodePodShapeViolation`
 
@@ -1142,6 +1142,14 @@ let p = Point.builder().x(3).build()
 ```
 
 **Fix**: add `.y(<value>)` to the chain before `.build()`, or set
+
+### E0775 — `CodePureViolation`
+
+CodePureViolation: a function carrying `#[pure]` contains a body operation that would make the LLVM `readnone` promise unsound: non-local write, I/O, managed allocation, or a call to a function that is not itself proven `#[pure]`.
+
+Spec: v0.6 A13
+
+**Fix**: remove `#[pure]`, prove and mark the callee `#[pure]`, or rewrite the body to local scalar computation.
 
 ---
 

--- a/LANG_SPEC_v0.5/10-standard-library/08-json.md
+++ b/LANG_SPEC_v0.5/10-standard-library/08-json.md
@@ -42,6 +42,9 @@ Mapping:
 - **Lone surrogates in strings** (e.g. `"\uD800"`) are a decode `Err`.
   Osty's `String` is strict UTF-8 (§2.1) and does not represent
   surrogate code points.
+- **Non-finite or out-of-range numbers are rejected.** JSON has no
+  representation for `NaN` or infinities, and numbers that overflow the
+  implementation's `Float` range decode as `Err`.
 
 Custom serialization via `Encode`/`Decode` interfaces:
 
@@ -57,3 +60,11 @@ interface Decode {
 
 `Json` is an enum of `Object`, `Array`, `String`, `Number`, `Bool`,
 `Null`.
+
+Value-level helpers:
+
+- `json.parseValue(text)` parses UTF-8 JSON text into `Json`.
+- `json.stringifyValue(value)` serializes a `Json` tree as compact JSON.
+  Object keys are emitted in sorted order so output is deterministic.
+  String contents preserve their UTF-8 bytes and escape only JSON-required
+  characters/control bytes.

--- a/LANG_SPEC_v0.5/10-standard-library/18-csv.md
+++ b/LANG_SPEC_v0.5/10-standard-library/18-csv.md
@@ -36,3 +36,20 @@ pub struct CsvOptions {
     pub trimSpace: Bool = false,
 }
 ```
+
+Behavior:
+
+- `encode` emits CRLF row separators. Fields containing the delimiter,
+  quote, CR, or LF are quoted, and embedded quotes are doubled.
+- `encodeWith` aborts on invalid options. `decodeWith` returns an error
+  for the same invalid options. `delimiter` and `quote` must differ, and
+  neither may be CR or LF.
+- `decode` accepts CRLF and bare LF row terminators, accepts a final row
+  without a trailing terminator, and returns `[]` for empty input.
+- `trimSpace` trims ASCII space and tab from unquoted fields. It also
+  permits quoted fields to be surrounded by ASCII space or tab, and
+  `encodeWith(..., trimSpace = true)` quotes fields whose leading or
+  trailing space/tab would otherwise be lost on decode.
+- `decodeHeaders` treats the first row as column names. Header names must
+  be non-empty and unique, and every data row must have exactly the same
+  field count as the header row.

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -1,61 +1,49 @@
 # LLVM Migration Plan
 
-> **Status (2026-04): Historical.** 공개 백엔드는 이미 LLVM 하나뿐이며,
+> **Status (2026-04-28): Historical with current sync notes.** 공개 백엔드는 이미 LLVM 하나뿐이며,
 > 기존 Osty→Go 부트스트랩 트랜스파일러는 제거되었다 — `internal/selfhost/generated.go`
-> 는 커밋된 시드 산출물로 동결되어 있다. 이 문서는 이주 과정의 기록이며, 아래
-> "현재 상태" 및 phase 설명은 당시 시점의 기준이다.
+> 는 커밋된 시드 산출물로 동결되어 있다. 이 문서는 이주 과정의 기록이며, phase
+> 설명은 당시 시점의 기준이다. 현재 pass/fail 상태는 바로 아래 동기화 노트가
+> 기준이다.
 
 이 문서는 Osty의 실행 백엔드를 현재 Go transpiler 중심 구조에서 LLVM 기반
 네이티브 백엔드로 옮기기 위한 이주 계획이다. 목표는 기존 Go 백엔드를 즉시
 제거하는 것이 아니라, front-end 안정성을 유지한 채 LLVM 백엔드를 병렬로
 도입하고 충분한 parity가 확보된 뒤 기본 경로를 전환하는 것이다.
 
-## 현재 상태
+## 현재 동기화 상태 (2026-04-28)
 
-- Front-end는 `lexer -> parser -> resolve -> check`까지 안정적으로 분리되어
-  있고, diagnostics/source position 모델도 CLI와 테스트에 이미 공유된다.
-- 실행 경로는 `internal/gen` Go transpiler가 담당한다. `osty gen`, `osty build`,
-  `osty run`, `osty test`는 Go source를 만들고 `go build` 또는 `go run`으로
-  이어진다.
-- `internal/ir`는 backend-agnostic IR로 이미 존재하지만, 현재 Go transpiler는
-  AST와 `resolve/check` 결과를 직접 소비한다.
-- Runtime helper는 Go 출력물 안에 조건부로 주입되는 구조다. LLVM으로 가려면
-  ABI가 고정된 별도 runtime surface가 필요하다.
-- Manifest profile/target은 Go toolchain 플래그와 `GOOS/GOARCH/CGO_ENABLED`
-  중심이다. LLVM target triple, linker, sysroot, runtime artifact 위치를
-  표현할 수 있도록 확장해야 한다.
-- Multi-file package, vendored dependency, workspace build의 실제 code emission은
-  아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
-  한다.
-- 현재 Phase 45까지의 LLVM backend 의미는 `toolchain/llvmgen.osty`
-  쪽으로 옮겨지고 있다. 여기에는 smoke IR builder, skeleton renderer,
-  toolchain command plan, executable parity corpus, go-only diagnostic, 그리고
-  unsupported source-shape taxonomy가 포함된다. 성공 경로의 scalar instruction
-  strings, temp/label naming, plain/escaped ASCII `String` `println` module
-  constant/formatting shape, immutable/mutable local String value paths, and
-  simple String function return/parameter paths, simple named struct type
-  definitions, struct literals, field reads, struct function boundaries, and
-  mutable struct locals, plus bare enum tag values across simple function and
-  mutable-local paths와 그 다음 payload-free enum match-expression paths도 같은
-  toolchain에서 생성한다. `Float`는 현재 double-subset로만 `Float`-smoke
-  경로를 처리하며, `Float32`/`Float64` width/ABI 정책은 후속 단계로 미룬다.
+- 공개 실행 백엔드는 LLVM만 남았다. 이전 Osty→Go transpiler 경로는 제거됐고,
+  `internal/selfhost/generated.go`는 재생성 대상이 아니라 frozen seed다.
+- `osty check`, `osty typecheck`, `osty resolve`의 happy path는 self-host arena
+  구조체를 직접 소비한다. 현재 기준 `just front`, `just spec`,
+  `just verify-selfhost`, `go run ./cmd/osty check toolchain`은 통과한다.
+- 남은 release gate는 front-end type-check drift가 아니라 native LLVM/backend
+  coverage다. `go test -count=1 -vet=off -short ./...`의 현재 빨간 항목은
+  `cmd/osty` benchmark `?` Err-path, `cmd/osty-native-llvmgen` nested struct
+  binding pattern, `internal/backend` `Map.update` locked lowering,
+  `internal/llvmgen` generic method turbofish, optional aggregate/field
+  lowering, interface boxing/dispatch, nested struct binding pattern이다.
+- 아래 phase 설명은 migration history로 보존한다. 새 작업 우선순위는 이
+  동기화 노트와 다음 critical-path 표를 기준으로 판단한다.
 
-## 셀프호스팅 critical path (2026-04 실사용 기반 재감사)
+## 셀프호스팅 critical path (2026-04-28 재동기화)
 
-기존 phase 번호(0~73)는 feature-slice 중심으로 쌓아왔다. 실제
-`toolchain/*.osty` 非-test 파일의 usage grep으로 재감사한 결과,
-셀프호스팅까지의 blocker 순서는 다음과 같다.
+기존 phase 번호(0~73)는 feature-slice 중심으로 쌓아왔다. 현재는 프론트엔드
+toolchain check가 통과하므로, blocker 순서는 native LLVM 경로가 실제로 아직
+cover하지 못하는 source shape 기준으로 본다.
 
 ### Tier A — 核 toolchain (`lexer → parser → check → ir → llvmgen`) 자가 컴파일 blocker
 
-| 기능 | 非-test 사용 | 현재 상태 | 관련 phase |
+| 기능 | 현재 상태 | 현재 증거 | 다음 초점 |
 |---|---|---|---|
-| `List<T>` literal + 메서드 lowering | 974회 | 🟡 부분 구현 — legacy AST emitter가 list literal + `push` 및 일부 컬렉션 브리지를 낮춘다. 다만 whole-toolchain coverage는 아직 incomplete | TBD (Tier A-1) |
-| `Map<K,V>` literal + 메서드 lowering | 심볼 테이블 등 다수 | 🟡 부분 구현 — legacy AST emitter가 map literal + `insert` / `remove`를 낮춘다. 더 넓은 toolchain surface는 아직 incomplete | TBD (Tier A-2) |
-| `String` concat/slice/interpolation | 대부분 파일 | 🟡 부분 구현 — ASCII / runtime-backed concat / interpolation은 존재하지만 `Char`/`Byte` iteration (`String.chars` / `bytes`)과 더 넓은 string ABI가 blocker | TBD (Tier A-3) |
-| Closure + env capture | AST visitor 전반 | 🟡 부분 구현 — MIR path에는 capturing-closure env emission + tests가 있다. legacy AST emitter의 first-class fn-value/capture surface는 아직 incomplete | TBD (Tier A-4) |
-| Multi-file package emit + link | 37개 non-test 파일 | ❌ merged-probe가 주 검증 경로이며 package-level native self-compile/link는 아직 blocker | TBD (Tier A-5) |
-| `std.strings` 함수 구현 | 20+ 파일에서 import | 🟡 부분 구현 — legacy llvmgen이 일부 함수를 runtime shim으로 우회하지만 pure-Osty body는 여전히 `Char` / `List<Char>` lowering에 막힘 | TBD (Tier A-6) |
+| `List<T>` literal + 메서드 lowering | 🟡 기본 literal/intrinsic 경로는 있음 | README status + green front-end tests | whole-toolchain native probe에서 residual collection helper shape 확인 |
+| `Map<K,V>` literal + 메서드 lowering | 🔴 `Map.update` 전용 locked lowering 회귀 | `TestPhase2gUpdateUserCallsiteKeepsLockedLowering` | `get + callback + insert`를 `osty_rt_map_lock/unlock` 안에 유지 |
+| Optional aggregate lowering | 🔴 struct payload `?` / `?.field` 미커버 | `TestNativeOwnedModuleEntryOptionalQuestionStructBatch`, `TestNativeOwnedModuleEntryOptionalFieldBatch` | `%Struct` load/extract + null phi shape |
+| Generic / interface call lowering | 🔴 generic method turbofish + interface boxing/dispatch 미커버 | `TestGenerateModuleMethodLocalGenericGetMonomorphized`, interface dispatch tests | monomorphized method symbol selection, `%osty.iface` boxing, vtable indirect call args |
+| Pattern lowering | 🔴 nested binding/destructuring 미커버 | `TestRunCoversNestedStructBindingPattern`, `TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern` | recursive `extractvalue` plus `name @ pattern` alias |
+| Multi-file package emit + link | 🟡 native self-compile/link gate는 아직 최종 green 아님 | short-suite backend gaps block merged native confidence | P0 native shape failures 해소 후 merged toolchain probe 재측정 |
+| `String` / `std.strings` surface | 🟡 runtime-backed paths expanded; pure-body coverage는 계속 추적 | previous `String.bytes()` / `String.chars()` walls are closed | pure Osty helper bodies and remaining ABI edge cases |
 
 ### Tier B — pkgmgr (`semver`, `manifest`, `registry`, `solve`, `pkgmgr`) 자가 컴파일 blocker
 
@@ -83,12 +71,14 @@ single-scalar-payload + bare tag이다.
 
 ### 관심 순서
 
-1. Tier A-1 (List) + A-3 (String concat/slice) — 모든 frontend 경로가 의존.
-2. Tier A-6 (`std.strings` 순수 구현) — 현재 native probe first-wall이 `Char`이므로 A-3와 사실상 한 묶음.
-3. Tier A-2 (Map) + A-4 (Closure) — resolve/check/visitor가 의존.
-4. Tier A-5 (Multi-file linking) — Tier A가 한 파일에서 되면 즉시 다음 관문.
-5. Tier B — pkgmgr 경로. 核 셀프호스트와 독립적으로 진행 가능.
-6. 非-blocker는 유저 코드 예시 호환성 위주로 여유 시 진행.
+1. P0 short-suite failures — benchmark `?` Err-path, `Map.update`, optional
+   aggregate lowering, generic method turbofish, interface dispatch, nested
+   binding patterns.
+2. Merged native toolchain probes — P0 shape failures를 닫은 뒤 AST/MIR probe를
+   다시 측정해 실제 first wall을 갱신한다.
+3. Multi-file native emit/link — package-level self-compile/link 관문.
+4. Pure stdlib helper bodies — runtime shim이 아닌 Osty body native lowering.
+5. 非-blocker는 유저 코드 예시 호환성 위주로 여유 시 진행.
 
 ---
 
@@ -742,11 +732,20 @@ match 분해)를 추가한다.
 
 ### Probe 쌍
 
-- `TestProbeWholeToolchainMerged` — 모든 파일 포함. 2026-04-24 실측 첫 wall: **LLVM011 `type-system`** on `CheckFnSig.hasReceiver` default field (`struct "CheckFnSig" field "hasReceiver" has a default value`). `ci.osty` 의 `runtime.cihost` 는 AST probe 에서도 더 이상 첫 wall 이 아니다.
-- `TestProbeNativeToolchainMerged` — bootstrap-only 파일 제외. 2026-04-24 실측: `ci.osty` 1개를 스킵하고도 첫 wall 은 **동일한 `CheckFnSig.hasReceiver` default field** 다. 이전 `list_mixed_ptr`, `Char`/`Byte`, match-as-statement, nested-field assignment, parser precedence, `String.bytes()` / `String.chars()` 계열 벽은 닫혔다.
-- `TestProbeNativeToolchainMergedMIR` — real self-host 측정에 가장 가까운 info-only probe. 2026-04-24 실측: checker diagnostics 0, MIR first wall **LLVM000 `unsupported-source`** (`indirect call on non-function type SelfDocDecl`). `TestNativeToolchainMergedMIRPipelineIsClean` 은 MIR refusal 뒤 legacy fallback 이 `CheckFnSig.hasReceiver` default-field wall 에 걸려 실패한다. 반면 `TestNativeToolchainMergedMIRErrTypeFloor` 는 ErrType count 0 으로 통과한다.
+- `TestProbeWholeToolchainMerged` — 모든 파일 포함. 2026-04-28 기준
+  이전 AST default-field wall은 현재 red list가 아니다. P0 native shape
+  failures를 먼저 닫고 재측정해야 한다.
+- `TestProbeNativeToolchainMerged` — bootstrap-only 파일 제외. 이전
+  `list_mixed_ptr`, `Char`/`Byte`, match-as-statement, nested-field assignment,
+  parser precedence, `String.bytes()` / `String.chars()` 계열 벽은 닫혔다.
+- `TestProbeNativeToolchainMergedMIR` — real self-host 측정에 가장 가까운
+  info-only probe. 2026-04-28 기준 이전 indirect-call wall은 현재 short-suite
+  red list가 아니며, 실제 다음 wall은 P0 native shape failures 해소 후 다시
+  측정해야 한다.
 
-AST probe 쌍의 첫-wall 차이는 현재 0 이다. migration 진전은 `CheckFnSig` default-field lowering 과 MIR `SelfDocDecl` indirect-call lowering 이 움직이는지로 측정한다.
+현재 migration 진전은 오래된 probe wall 문구가 아니라, short-suite에 남은
+generic method turbofish, optional aggregate, interface boxing/dispatch,
+nested binding pattern, `Map.update` locked lowering이 움직이는지로 측정한다.
 
 ### astbridge 제거 경로
 

--- a/README.md
+++ b/README.md
@@ -45,25 +45,24 @@ compiler path is now native-only through the LLVM backend.
 | CI quality tooling (`internal/ci`, `osty ci`) | done — Osty-authored generated CI core, signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, backend-aware gen, baseline diff, LSP trace, `--explain` |
 | Profiles / targets / features / cache (`internal/profile`, `osty profiles` / `targets` / `features` / `cache`) | done — built-in and manifest profiles, cross-target env, feature closure + file pragmas, backend-aware fingerprints |
-| LLVM backend (`internal/backend`, `internal/llvmgen`, `--backend llvm`) | executable — textual IR / object / binary through `clang` for scalar / control-flow / Bool / String (ASCII + multi-byte UTF-8), all four payload-free/single-scalar/struct/enum-payload `Result<T, E>` shapes with `?` propagation (phase 54-63 + phase 74 closed), match-as-expression and match-as-statement over bare-variant and wildcard arms, nested field assignment, `Char`/`Byte` parameter + return lowering with width/sign conversions, interface vtable dispatch with generic monomorphization, list / map / set literals and intrinsics (`isEmpty`, `pop` discard, nested `IndexExpr`, source-type tracked list literals), payload-free enum match and `Float` / String payload enums, simple struct aggregates and method calls, `String.bytes` / `String.chars` lowering, host `clang` driver, and categorized `LLVM00x` / `LLVM01x` Osty-authored diagnostics for source shapes that still skeletonize. The merged toolchain native gate is not clean yet; current first walls are tracked below. |
+| LLVM backend (`internal/backend`, `internal/llvmgen`, `--backend llvm`) | executable — textual IR / object / binary through `clang` for scalar / control-flow / Bool / String (ASCII + multi-byte UTF-8), all four payload-free/single-scalar/struct/enum-payload `Result<T, E>` shapes with `?` propagation (phase 54-63 + phase 74 closed), match-as-expression and match-as-statement over bare-variant and wildcard arms, nested field assignment, `Char`/`Byte` parameter + return lowering with width/sign conversions, interface vtable dispatch with generic monomorphization, list / map / set literals and intrinsics (`isEmpty`, `pop` discard, nested `IndexExpr`, source-type tracked list literals), payload-free enum match and `Float` / String payload enums, simple struct aggregates and method calls, `String.bytes` / `String.chars` lowering, host `clang` driver, and categorized `LLVM00x` / `LLVM01x` Osty-authored diagnostics for source shapes that still skeletonize. The merged toolchain native gate is not clean yet; current short-suite blockers are tracked below. |
 | Package registry backend / `osty registry serve` | done — file-backed HTTP server for index/search/download/publish/yank, with ETag index responses and bearer-token write auth |
 | Package registry / `osty add` / `osty update` / `osty run` | done (resolve + vendor + lockfile-honoring re-resolves, ETag-cached registry index, copy fallback for symlink-less filesystems; CLI: `add`, `remove`/`rm`, `update`, `run`, `fetch`, `publish`, `search`, `info`, `yank`/`unyank`, `login`/`logout`; `--locked` / `--frozen` CI guards) |
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
 | `osty run` (build + exec through backend) | wired — resolves manifest, vendors deps, emits the native entry artifact, runs the backend binary with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
 
-Status note (revalidated 2026-04-26, post-rebase to PR #921): the universal
+Status note (revalidated 2026-04-28): the universal
 LLVM CLI wedge called out in older status docs is closed. A hello-world
 `osty gen --backend=llvm` run is not the blocker anymore. The bootstrap
 Osty→Go transpiler was retired in PR #854 (2026-04-23), so the older
 "checked-in bootstrap output drift" framing no longer applies —
 `internal/selfhost/generated.go` is now a frozen seed with no `go generate`
 regen pipeline, and the corresponding "verify selfhost regen is clean" CI
-step was removed. Current self-hosting tracking is about three gaps:
-internal toolchain source drift, the merged native MIR pipeline gate, and
-selfhost-overlay scaling.
+step was removed. Current self-hosting tracking is about the native LLVM
+coverage gate rather than front-end type-check drift.
 
-Code-level re-audit on 2026-04-26: the tree is not yet "fully self-hosted"
+Code-level re-audit on 2026-04-28: the tree is not yet "fully self-hosted"
 end-to-end, but the front-end CLI path is ahead of several older documents.
 `osty check`, `osty typecheck`, and `osty resolve` now run the self-host arena
 path by default, and the Go-hosted `--legacy` check/typecheck escape hatch has
@@ -74,56 +73,29 @@ been removed. `--native` is still accepted only as a backwards-compatible no-op.
 The front-end astbridge-free guards currently pass for the CLI and the
 selfhost adapters (`TestRun{Resolve,Check,Typecheck}*AstbridgeFree`,
 `TestCheckCLIDefaultPathExitsZero`, and the selfhost
-`Check*Structured*AstbridgeFree` tests). `just front` and `just verify-selfhost`
-also pass in the same audit (note: `verify-selfhost` is narrow — it runs
+`Check*Structured*AstbridgeFree` tests). `just front`, `just spec`,
+`just verify-selfhost`, and `go run ./cmd/osty check toolchain` pass in the
+same audit (note: `verify-selfhost` is narrow — it runs
 `SnapshotParity|CoreSnapshotParity` under `internal/ci` and `internal/runner`,
 not the merged toolchain MIR pipeline).
 
-The current red lights are explicit:
+The current red lights are explicit native LLVM/backend coverage gaps from
+`go test -count=1 -vet=off -short ./...`:
 
-- **`osty check toolchain` fails with 11 type errors.** The merged toolchain
-  package no longer type-checks cleanly through the production CLI path:
-  - `E0702 no field 'typeName'` × 9 sites in [toolchain/inspect.osty](toolchain/inspect.osty)
-    and [toolchain/lint.osty](toolchain/lint.osty:2884) — drift from PR #892
-    (`refactor(selfhost): replace string-based typeName round-trip with
-    structured TypeRepr`), which renamed `typeName: String` → `typeRepr:
-    FrontTypeRepr` on `FrontCheckedNode` / `FrontCheckedBinding` /
-    `FrontCheckedSymbol` in `toolchain/check.osty` but did not migrate the
-    `inspect.osty` / `lint.osty` consumers.
-  - `E0708 missing field 'valueText' / 'targetLabel'` × 2 in
-    [toolchain/mir.osty:895](toolchain/mir.osty:895) — duplicate `pub struct
-    MirSwitchCase` declarations: [toolchain/mir.osty:888](toolchain/mir.osty:888)
-    has `value/target/label` and [toolchain/mir_generator.osty:2185](toolchain/mir_generator.osty:2185)
-    has `valueText/targetLabel`. Same name, different fields, same package
-    — landed during recent §-template porting (#891–#915).
-- **Merged-toolchain probes wall on the same duplicate.** The info-only
-  AST probes report `LLVM010 source-layout: duplicate struct "MirSwitchCase"`
-  as their first wall ([TestProbeWholeToolchainMerged](internal/llvmgen/multifile_probe_test.go:151)
-  and `TestProbeNativeToolchainMerged`, with `ci.osty` skipped in the
-  latter). The MIR-path probe
-  ([TestProbeNativeToolchainMergedMIR](internal/llvmgen/multifile_probe_test.go:252))
-  reports 12 checker diagnostics and first-walls inside `mir.Lower` on
-  `LLVM000 unsupported-source: unsupported local type <error> in
-  tyToRepr` — `<error>` types are leaking into the MIR boundary because
-  the upstream `osty check toolchain` failures poison the type table.
-  Older status notes citing `LLVM000 SelfDocDecl indirect call` and
-  `LLVM011 CheckFnSig.hasReceiver default value` as the merged walls
-  reflect a previous tree state and no longer match.
-- **`TestNativeToolchainMergedMIRErrTypeFloor` regressed.** The floor
-  is 40 ErrType locals; the merged native pipeline currently produces
-  **474** (~12× over), driven by the same poisoned-type cascade. Earlier
-  revisions of this section claiming the floor "passes with ErrType count
-  0" were stale.
-- **`TestNativeToolchainMergedMIRPipelineIsClean` times out.** The
-  enforcing version of the probe (the same pipeline minus the info-only
-  logging) fails its 300s timeout inside
-  [internal/check/host_boundary.go:930](internal/check/host_boundary.go:930)
-  `selfhostSpanIndex.scopeFor` — a linear scan over every span on every
-  cache miss, which becomes effectively O(N²) once `applySelfhostFileResult`
-  feeds the merged toolchain through `overlaySelfhostResult`. The non-
-  enforcing MIR probe finishes the same path in ~280s with sparser
-  bookkeeping, which is how the LLVM010/LLVM000 walls above are observable
-  at all.
+- **`osty test` benchmark error propagation.**
+  `TestRunTestMainBenchModeQuestionMarkErrPathFails` currently treats a
+  benchmark closure whose `?` propagates `Err` as a passing benchmark instead
+  of a failing run.
+- **Native-owned aggregate and pattern lowering.** The native path still lacks
+  complete coverage for `Profile?` struct payload `?`, optional field chains
+  (`profile?.name`), and nested binding/destructuring patterns such as
+  `outer @ Outer { inner: Inner { x } }`.
+- **Native-owned generic and interface calls.** Generic method turbofish calls
+  (`b.get::<Int>(7)`) and interface boxing / indirect dispatch with non-self
+  arguments remain short-suite failures.
+- **Map helper lowering.** `Map.update(k, callback)` must keep its dedicated
+  locked lowering (`osty_rt_map_lock` / `osty_rt_map_unlock`) instead of
+  falling through to the specialized stdlib body path.
 
 The `TestGoGenerateSelfhostLeavesGeneratedArtifactsClean` red light cited
 in earlier revisions of this section is gone — that test was removed when
@@ -455,9 +427,9 @@ newline-separated `else`.
   String / List / Map / Set / GC / scheduler / channel ABIs.
   Unsupported shapes still prepare skeleton artifacts and report
   `LLVM00x` / `LLVM01x` diagnostics authored by the toolchain backend
-  policy. The merged native toolchain first-walls are currently
-  `CheckFnSig.hasReceiver` default-field lowering on the AST path and
-  `SelfDocDecl` indirect-call lowering on the MIR path)
+  policy. Current short-suite native gaps are optional aggregate lowering,
+  nested struct binding patterns, generic method turbofish calls, interface
+  boxing/dispatch, and `Map.update` locked lowering)
 - `--emit MODE` — requested text artifact. `llvm-ir` emits LLVM IR.
 
 `pipeline --gen` accepts the same source-artifact backend selection:

--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -194,5 +194,3 @@ func renderWarnings(warnings []error) []string {
 	}
 	return out
 }
-
-

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -7280,12 +7280,12 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	want := strings.Join([]string{
-		"1",            // young alloc landed in young arena
-		"2",            // forward tag = PROMOTED after root_bind
-		"0",            // OLD copy carries OSTY_GC_GENERIC_NONE
+		"1",                // young alloc landed in young arena
+		"2",                // forward tag = PROMOTED after root_bind
+		"0",                // OLD copy carries OSTY_GC_GENERIC_NONE
 		"deadbeefcafebabe", // payload bytes survived young → OLD memcpy
-		"1 1",          // collect kept the rooted OLD copy alive
-		"0",            // release + collect reclaimed the OLD copy
+		"1 1",              // collect kept the rooted OLD copy alive
+		"0",                // release + collect reclaimed the OLD copy
 		"",
 	}, "\n")
 	if got := string(runOutput); got != want {
@@ -7399,12 +7399,12 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	want := strings.Join([]string{
-		"1",         // fresh Set landed in young arena
-		"2",         // forward tag = PROMOTED after root_bind
-		"4",         // post-promote insert via stale young handle worked (load_v1 follow)
-		"1 1 1 1",   // all four items contained
-		"4",         // items survived forced collect (still rooted)
-		"1",         // dead-Set cleanup fired on the unrooted transient
+		"1",       // fresh Set landed in young arena
+		"2",       // forward tag = PROMOTED after root_bind
+		"4",       // post-promote insert via stale young handle worked (load_v1 follow)
+		"1 1 1 1", // all four items contained
+		"4",       // items survived forced collect (still rooted)
+		"1",       // dead-Set cleanup fired on the unrooted transient
 		"",
 	}, "\n")
 	if got := string(runOutput); got != want {
@@ -8164,10 +8164,10 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	want := strings.Join([]string{
-		"tag-after-bind:2",      // PROMOTED tag stamped
-		"classified-young:1",    // full-mmap predicate keeps stale addr classified
-		"tag-after-swaps:2",     // PROMOTED tag survives swaps (memory not zeroed)
-		"live-after-release:0",  // release followed redirect, OLD swept
+		"tag-after-bind:2",     // PROMOTED tag stamped
+		"classified-young:1",   // full-mmap predicate keeps stale addr classified
+		"tag-after-swaps:2",    // PROMOTED tag survives swaps (memory not zeroed)
+		"live-after-release:0", // release followed redirect, OLD swept
 		"",
 	}, "\n")
 	if got := string(runOutput); got != want {
@@ -8386,12 +8386,12 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	want := strings.Join([]string{
-		"header_size:80",         // shrunk from 96 (16 B saved by dropping trace/destroy)
-		"enum_ptr_pattern:0",     // KIND_GENERIC_ENUM_PTR uses kind_table dispatch; header pattern stays NONE
-		"enum_scalar_pattern:0",  // NONE = 0
-		"live_after_collect:2",   // both rooted
-		"fallback_bumped:1",      // enum_scalar (KIND_GENERIC) still fires the GENERIC fallback path
-		"live_after_release:0",   // both swept
+		"header_size:80",        // shrunk from 96 (16 B saved by dropping trace/destroy)
+		"enum_ptr_pattern:0",    // KIND_GENERIC_ENUM_PTR uses kind_table dispatch; header pattern stays NONE
+		"enum_scalar_pattern:0", // NONE = 0
+		"live_after_collect:2",  // both rooted
+		"fallback_bumped:1",     // enum_scalar (KIND_GENERIC) still fires the GENERIC fallback path
+		"live_after_release:0",  // both swept
 		"",
 	}, "\n")
 	if got := string(runOutput); got != want {

--- a/internal/backend/stdlib_csv_check_test.go
+++ b/internal/backend/stdlib_csv_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultCsv pins that std.csv's pure-Osty implementation
+// type-checks cleanly. CSV is a user-facing production module; regressions
+// here usually mean a helper drifted away from the canonical collection or
+// Result surfaces.
+func TestStdlibCheckResultCsv(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "csv")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(csv) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("csv module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1031,6 +1031,15 @@ const (
 	// to drop it from the required set.
 	CodeBuilderMissingRequiredField = "E0774"
 
+	// CodePureViolation: a function carrying `#[pure]` contains a body
+	// operation that would make the LLVM `readnone` promise unsound:
+	// non-local write, I/O, managed allocation, or a call to a function
+	// that is not itself proven `#[pure]`.
+	//
+	// Spec: v0.6 A13
+	// Fix: remove `#[pure]`, prove and mark the callee `#[pure]`, or rewrite the body to local scalar computation.
+	CodePureViolation = "E0775"
+
 	// Manifest — TOML syntax.
 
 	// Fallback TOML syntax error in `osty.toml`.

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -5645,9 +5645,10 @@ func mirGEPNamedFieldLine(reg, ty, basePtr, fieldIdxDigits string) string {
 // §6 runtime-symbol composers.
 
 // Osty: mirRtSymbol / mirRtListSymbol / mirRtMapSymbol / mirRtSetSymbol /
-//       mirRtStringSymbol / mirRtBytesSymbol / mirRtChanSymbol /
-//       mirRtTaskGroupSymbol / mirRtGCSymbol / mirRtTestSymbol /
-//       mirRtMathSymbol / mirRtRandomSymbol / mirRtCancelSymbol
+//
+//	mirRtStringSymbol / mirRtBytesSymbol / mirRtChanSymbol /
+//	mirRtTaskGroupSymbol / mirRtGCSymbol / mirRtTestSymbol /
+//	mirRtMathSymbol / mirRtRandomSymbol / mirRtCancelSymbol
 func mirRtSymbol(suffix string) string          { return "osty_rt_" + suffix }
 func mirRtListSymbol(suffix string) string      { return "osty_rt_list_" + suffix }
 func mirRtMapSymbol(suffix string) string       { return "osty_rt_map_" + suffix }
@@ -5700,7 +5701,8 @@ func mirPredI1Eq(a, b string) string {
 // §7 typed-store / typed-load shapes with !alias.scope metadata.
 
 // Osty: mirStoreI64WithAliasScopeLine / DoubleWithAliasScopeLine / PtrWithAliasScopeLine /
-//       LoadI64WithAliasScopeLine / DoubleWithAliasScopeLine / PtrWithAliasScopeLine
+//
+//	LoadI64WithAliasScopeLine / DoubleWithAliasScopeLine / PtrWithAliasScopeLine
 func mirStoreI64WithAliasScopeLine(val, slot, scopeRef string) string {
 	return "  " + mirInstrStore() + " i64 " + val + ", ptr " + slot + ", !alias.scope " + scopeRef + "\n"
 }
@@ -5739,8 +5741,9 @@ func mirLoadPtrWithNoAliasLine(reg, slot, ref string) string {
 // §7 LLVM access-group metadata helpers.
 
 // Osty: mirLLVMAccessGroupRef / mirStoreI64WithAccessGroupLine /
-//       DoubleWithAccessGroupLine / LoadI64WithAccessGroupLine /
-//       DoubleWithAccessGroupLine
+//
+//	DoubleWithAccessGroupLine / LoadI64WithAccessGroupLine /
+//	DoubleWithAccessGroupLine
 func mirLLVMAccessGroupRef(ref string) string {
 	return "!access_group " + ref
 }
@@ -5846,7 +5849,8 @@ func mirRtTaskGroupRootSymbol() string { return mirRtSymbol("task_group") }
 // §7 LLVM-text type-text composers.
 
 // Osty: mirListTypeText / MapTypeText / SetTypeText / mirOptionTypeTextScalar /
-//       OptionTypeTextPtr / mirResultTypeTextScalar / ResultTypeTextPtr
+//
+//	OptionTypeTextPtr / mirResultTypeTextScalar / ResultTypeTextPtr
 func mirListTypeText() string         { return mirTypePtr() }
 func mirMapTypeText() string          { return mirTypePtr() }
 func mirSetTypeText() string          { return mirTypePtr() }
@@ -5858,7 +5862,8 @@ func mirResultTypeTextPtr() string    { return mirOptionPtrAggregateType() }
 // §7 LLVM-text discriminant probe / payload-extract shapes.
 
 // Osty: mirOptionDiscProbeLine / PayloadProbeLine / mirOptionPtrDiscProbeLine /
-//       PtrPayloadProbeLine / mirResultDiscProbeLine / PayloadProbeLine
+//
+//	PtrPayloadProbeLine / mirResultDiscProbeLine / PayloadProbeLine
 func mirOptionDiscProbeLine(reg, aggReg string) string {
 	return mirExtractValueLine(reg, mirOptionAggregateType(), aggReg, "0")
 }
@@ -5881,7 +5886,8 @@ func mirResultPayloadProbeLine(reg, aggReg string) string {
 // §7 LLVM-text Option / Result aggregate-construction shapes.
 
 // Osty: mirOptionNoneAggregateLine / SomeDiscAggregateLine / SomePayloadAggregateLine /
-//       mirResultOkDiscAggregateLine / ErrDiscAggregateLine
+//
+//	mirResultOkDiscAggregateLine / ErrDiscAggregateLine
 func mirOptionNoneAggregateLine(reg string) string {
 	return mirInsertValueAggLine(reg, mirOptionAggregateType(), mirAggregateUndef(), mirTypeI64(), mirDiscriminantNone(), "0")
 }
@@ -5919,7 +5925,8 @@ func mirConditionalBranch3Line(cmpReg, ty, a, b, thenLbl, elseLbl string) string
 // §7 LLVM-text loop-prelude shape helpers.
 
 // Osty: mirLoopHeaderBlockLine / mirLoopBodyBlockLine / mirLoopExitBlockLine /
-//       mirLoopLatchBlockLine
+//
+//	mirLoopLatchBlockLine
 func mirLoopHeaderBlockLine(head string) string { return mirBlockHeaderLine(head) }
 func mirLoopBodyBlockLine(body string) string   { return mirBlockHeaderLine(body) }
 func mirLoopExitBlockLine(exit string) string   { return mirBlockHeaderLine(exit) }
@@ -6187,10 +6194,10 @@ func mirGCRootSafepointWithCommentLine(slotsPtr, slotCount string) string {
 // §8 LLVM-text builder-buffer helpers.
 
 // Osty: mirBuildLines{2,3,4,5}
-func mirBuildLines2(a, b string) string             { return a + b }
-func mirBuildLines3(a, b, c string) string          { return a + b + c }
-func mirBuildLines4(a, b, c, d string) string       { return a + b + c + d }
-func mirBuildLines5(a, b, c, d, e string) string    { return a + b + c + d + e }
+func mirBuildLines2(a, b string) string          { return a + b }
+func mirBuildLines3(a, b, c string) string       { return a + b + c }
+func mirBuildLines4(a, b, c, d string) string    { return a + b + c + d }
+func mirBuildLines5(a, b, c, d, e string) string { return a + b + c + d + e }
 
 // §8 LLVM-text type alias helpers.
 
@@ -6271,7 +6278,8 @@ func mirAppendArgI32(prev, reg string) string    { return prev + ", i32 " + reg 
 // §9 LLVM-text list-len / list-isEmpty common shape composers.
 
 // Osty: mirCallListLenLine / mirCallListIsEmptyLine / mirCallMapLenLine /
-//       mirCallSetLenLine / mirCallBytesLenLine
+//
+//	mirCallSetLenLine / mirCallBytesLenLine
 func mirCallListLenLine(reg, listReg string) string {
 	return "  " + reg + " = " + mirInstrCall() + " i64 @" + mirRtListLenSymbolName() + "(ptr " + listReg + ")\n"
 }
@@ -6341,8 +6349,9 @@ func mirLabelResultErr() string      { return "result.err" }
 // §10 expanded fixed-symbol composers — Bytes runtime long-tail.
 
 // Osty: mirRtBytes{IndexOf,LastIndexOf,Split,Join,Concat,Repeat,Replace,ReplaceAll,
-//       TrimLeft,TrimRight,Trim,TrimSpace,ToUpper,ToLower,ToHex,Slice,Contains,
-//       StartsWith,EndsWith}Symbol
+//
+//	TrimLeft,TrimRight,Trim,TrimSpace,ToUpper,ToLower,ToHex,Slice,Contains,
+//	StartsWith,EndsWith}Symbol
 func mirRtBytesIndexOfSymbol() string     { return mirRtBytesSymbol("index_of") }
 func mirRtBytesLastIndexOfSymbol() string { return mirRtBytesSymbol("last_index_of") }
 func mirRtBytesSplitSymbol() string       { return mirRtBytesSymbol("split") }
@@ -6366,9 +6375,10 @@ func mirRtBytesEndsWithSymbol() string    { return mirRtBytesSymbol("ends_with")
 // §10 String runtime symbol composers.
 
 // Osty: mirRtString{Chars,Bytes,ByteLen,ToUpper,ToLower,IsValidInt,ToInt,
-//       IsValidFloat,ToFloat,Count,Slice,SplitInto,NthSegment,IndexOf,
-//       LastIndexOf,Contains,StartsWith,EndsWith,Trim,Split,Join,Replace,
-//       Repeat,Hash,IsEmpty,Len}Symbol
+//
+//	IsValidFloat,ToFloat,Count,Slice,SplitInto,NthSegment,IndexOf,
+//	LastIndexOf,Contains,StartsWith,EndsWith,Trim,Split,Join,Replace,
+//	Repeat,Hash,IsEmpty,Len}Symbol
 func mirRtStringCharsSymbol() string        { return mirRtStringSymbol("Chars") }
 func mirRtStringBytesSymbol() string        { return mirRtStringSymbol("Bytes") }
 func mirRtStringByteLenSymbol() string      { return mirRtStringSymbol("ByteLen") }
@@ -6646,15 +6656,15 @@ func mirFastMathFlagsForArith() string {
 // §11 LLVM-text small-helper shapes.
 
 // Osty: mirNullPtrConst / Zero{I64,I32,Double}Const / One{I64,I32,Double}Const / True{I1}Const / FalseI1Const
-func mirNullPtrConst() string     { return mirPtrNullLiteral() }
-func mirZeroI64Const() string     { return "i64 0" }
-func mirZeroI32Const() string     { return "i32 0" }
-func mirZeroDoubleConst() string  { return "double 0.0" }
-func mirOneI64Const() string      { return "i64 1" }
-func mirOneI32Const() string      { return "i32 1" }
-func mirOneDoubleConst() string   { return "double 1.0" }
-func mirTrueI1Const() string      { return "i1 1" }
-func mirFalseI1Const() string     { return "i1 0" }
+func mirNullPtrConst() string    { return mirPtrNullLiteral() }
+func mirZeroI64Const() string    { return "i64 0" }
+func mirZeroI32Const() string    { return "i32 0" }
+func mirZeroDoubleConst() string { return "double 0.0" }
+func mirOneI64Const() string     { return "i64 1" }
+func mirOneI32Const() string     { return "i32 1" }
+func mirOneDoubleConst() string  { return "double 1.0" }
+func mirTrueI1Const() string     { return "i1 1" }
+func mirFalseI1Const() string    { return "i1 0" }
 
 // §11 LLVM-text minus-one constant tokens.
 
@@ -6717,29 +6727,32 @@ func mirICmpNonNullPtrLine(reg, a string) string {
 // §12 task / select / race runtime symbol composers.
 
 // Osty: mirRtTask{Spawn,GroupSpawn,HandleJoin,GroupCancel,GroupIsCancelled,Race,CollectAll}Symbol
-func mirRtTaskSpawnSymbol() string             { return mirRtSymbol("task_spawn") }
-func mirRtTaskGroupSpawnSymbol() string        { return mirRtSymbol("task_group_spawn") }
-func mirRtTaskHandleJoinSymbol() string        { return mirRtSymbol("task_handle_join") }
-func mirRtTaskGroupCancelSymbol() string       { return mirRtSymbol("task_group_cancel") }
-func mirRtTaskGroupIsCancelledSymbol() string  { return mirRtSymbol("task_group_is_cancelled") }
-func mirRtTaskRaceSymbol() string              { return mirRtSymbol("task_race") }
-func mirRtTaskCollectAllSymbol() string        { return mirRtSymbol("task_collect_all") }
+func mirRtTaskSpawnSymbol() string            { return mirRtSymbol("task_spawn") }
+func mirRtTaskGroupSpawnSymbol() string       { return mirRtSymbol("task_group_spawn") }
+func mirRtTaskHandleJoinSymbol() string       { return mirRtSymbol("task_handle_join") }
+func mirRtTaskGroupCancelSymbol() string      { return mirRtSymbol("task_group_cancel") }
+func mirRtTaskGroupIsCancelledSymbol() string { return mirRtSymbol("task_group_is_cancelled") }
+func mirRtTaskRaceSymbol() string             { return mirRtSymbol("task_race") }
+func mirRtTaskCollectAllSymbol() string       { return mirRtSymbol("task_collect_all") }
 
 // Osty: mirRtSelect{,Recv,Timeout,Default}Symbol / mirRtSelectSendBytesV1Symbol
-func mirRtSelectSymbol() string             { return mirRtSymbol("select") }
-func mirRtSelectRecvSymbol() string         { return mirRtSymbol("select_recv") }
-func mirRtSelectTimeoutSymbol() string      { return mirRtSymbol("select_timeout") }
-func mirRtSelectDefaultSymbol() string      { return mirRtSymbol("select_default") }
-func mirRtSelectSendBytesV1Symbol() string  { return mirRtSymbol("select_send_bytes_v1") }
+func mirRtSelectSymbol() string            { return mirRtSymbol("select") }
+func mirRtSelectRecvSymbol() string        { return mirRtSymbol("select_recv") }
+func mirRtSelectTimeoutSymbol() string     { return mirRtSymbol("select_timeout") }
+func mirRtSelectDefaultSymbol() string     { return mirRtSymbol("select_default") }
+func mirRtSelectSendBytesV1Symbol() string { return mirRtSymbol("select_send_bytes_v1") }
 
 // Osty: mirRtListSetBytesV1Symbol / GetBytesV1Symbol / SetSuffixSymbol / GetSuffixSymbol /
-//       MapKeysSortedSuffixSymbol / SelectSendSuffixSymbol
-func mirRtListSetBytesV1Symbol() string                   { return mirRtListSymbol("set_bytes_v1") }
-func mirRtListGetBytesV1Symbol() string                   { return mirRtListSymbol("get_bytes_v1") }
-func mirRtListSetSuffixSymbol(suffix string) string       { return mirRtListSymbol("set_" + suffix) }
-func mirRtListGetSuffixSymbol(suffix string) string       { return mirRtListSymbol("get_" + suffix) }
-func mirRtMapKeysSortedSuffixSymbol(suffix string) string { return mirRtMapSymbol("keys_sorted_" + suffix) }
-func mirRtSelectSendSuffixSymbol(suffix string) string    { return mirRtSymbol("select_send_" + suffix) }
+//
+//	MapKeysSortedSuffixSymbol / SelectSendSuffixSymbol
+func mirRtListSetBytesV1Symbol() string             { return mirRtListSymbol("set_bytes_v1") }
+func mirRtListGetBytesV1Symbol() string             { return mirRtListSymbol("get_bytes_v1") }
+func mirRtListSetSuffixSymbol(suffix string) string { return mirRtListSymbol("set_" + suffix) }
+func mirRtListGetSuffixSymbol(suffix string) string { return mirRtListSymbol("get_" + suffix) }
+func mirRtMapKeysSortedSuffixSymbol(suffix string) string {
+	return mirRtMapSymbol("keys_sorted_" + suffix)
+}
+func mirRtSelectSendSuffixSymbol(suffix string) string { return mirRtSymbol("select_send_" + suffix) }
 
 // §12 LLVM-text typed-arg slot composer specialisations.
 
@@ -6774,8 +6787,9 @@ func mirAllocaInitDoubleLine(slotReg, val string) string {
 // §12 LLVM-text typed-load + typed-cast composite helpers.
 
 // Osty: mirLoadAndZExtI8ToI64Line / mirLoadAndSExtI8ToI64Line /
-//       mirLoadAndZExtI1ToI64Line / mirLoadI64AndTruncToI8Line /
-//       mirLoadI64AndTruncToI1Line
+//
+//	mirLoadAndZExtI1ToI64Line / mirLoadI64AndTruncToI8Line /
+//	mirLoadI64AndTruncToI1Line
 func mirLoadAndZExtI8ToI64Line(loadReg, zextReg, slot string) string {
 	return mirLoadI8Line(loadReg, slot) + mirZExtI8ToI64Line(zextReg, loadReg)
 }
@@ -6975,7 +6989,8 @@ func mirGEPThenStorePtrLine(slotReg, ty, basePtr, idxDigits, val string) string 
 // §14 LLVM-text aggregate-construction composite shapes.
 
 // Osty: mirOptionSomeI64BuildLine / mirOptionSomePtrBuildLine /
-//       mirResultOk{I64,Ptr}BuildLine / mirResultErrPtrBuildLine
+//
+//	mirResultOk{I64,Ptr}BuildLine / mirResultErrPtrBuildLine
 func mirOptionSomeI64BuildLine(stepReg, fullReg, payload string) string {
 	return mirInsertValueI64Line(stepReg, mirOptionAggregateType(), mirAggregateUndef(), mirDiscriminantSome(), "0") +
 		mirInsertValueI64Line(fullReg, mirOptionAggregateType(), stepReg, payload, "1")
@@ -7000,7 +7015,8 @@ func mirResultErrPtrBuildLine(stepReg, fullReg, errPtr string) string {
 // §14 LLVM-text Option / Result destructure helpers.
 
 // Osty: mirOptionUnwrapDestructureLine / mirOptionPtrUnwrapDestructureLine /
-//       mirResultUnwrapDestructureLine
+//
+//	mirResultUnwrapDestructureLine
 func mirOptionUnwrapDestructureLine(discReg, payloadReg, agg string) string {
 	return mirOptionDiscProbeLine(discReg, agg) + mirOptionPayloadProbeLine(payloadReg, agg)
 }
@@ -7144,7 +7160,8 @@ func mirEmitOptionNonePtrLine(reg string) string {
 // §14 Module-globals helpers.
 
 // Osty: mirInternedI64GlobalLine / mirInternedPtrGlobalLine /
-//       mirMutableI64GlobalLine / mirMutablePtrGlobalLine
+//
+//	mirMutableI64GlobalLine / mirMutablePtrGlobalLine
 func mirInternedI64GlobalLine(sym, val string) string {
 	return mirGlobalConstantI64DeclLine(sym, val)
 }
@@ -7162,7 +7179,8 @@ func mirMutablePtrGlobalLine(sym, init string) string {
 // composite helpers.
 
 // Osty: mirCallI64NoArgsAndStoreLine / mirCallI1NoArgsAndStoreLine /
-//       mirCallPtrNoArgsAndStoreLine
+//
+//	mirCallPtrNoArgsAndStoreLine
 func mirCallI64NoArgsAndStoreLine(reg, sym, slot string) string {
 	return mirCallI64NoArgsLine(reg, sym) +
 		"  " + mirInstrStore() + " i64 " + reg + ", ptr " + slot + "\n"
@@ -7195,7 +7213,8 @@ func mirLoadPtrThenCallI1Line(loadReg, slot, resultReg, sym string) string {
 // §15 LLVM-text predicate-then-branch composite helpers.
 
 // Osty: mirICmp{Eq,Ne,Slt,Sgt,Sle,Sge}I64ThenBranchLine / mirICmpEqPtrThenBranchLine /
-//       mirICmpNullPtrThenBranchLine
+//
+//	mirICmpNullPtrThenBranchLine
 func mirICmpEqI64ThenBranchLine(cmpReg, a, b, thenLbl, elseLbl string) string {
 	return mirICmpI64EqLine(cmpReg, a, b) + mirBrCondLine(cmpReg, thenLbl, elseLbl)
 }
@@ -7313,7 +7332,8 @@ func mirIfThenElseSkeletonLine(cmpReg, cond, thenLbl, elseLbl string) string {
 // §15 LLVM-text typed-aggregate-store composite helpers.
 
 // Osty: mirStoreOptionAggregateLine / mirStoreOptionPtrAggregateLine /
-//       mirStoreResultAggregateLine / mirStoreResultPtrAggregateLine
+//
+//	mirStoreResultAggregateLine / mirStoreResultPtrAggregateLine
 func mirStoreOptionAggregateLine(agg, slot string) string {
 	return "  " + mirInstrStore() + " " + mirOptionAggregateType() + " " + agg + ", ptr " + slot + "\n"
 }
@@ -7330,7 +7350,8 @@ func mirStoreResultPtrAggregateLine(agg, slot string) string {
 // §15 LLVM-text typed-aggregate-load composite helpers.
 
 // Osty: mirLoadOptionAggregateLine / mirLoadOptionPtrAggregateLine /
-//       mirLoadResultAggregateLine / mirLoadResultPtrAggregateLine
+//
+//	mirLoadResultAggregateLine / mirLoadResultPtrAggregateLine
 func mirLoadOptionAggregateLine(reg, slot string) string {
 	return "  " + reg + " = " + mirInstrLoad() + " " + mirOptionAggregateType() + ", ptr " + slot + "\n"
 }
@@ -7555,7 +7576,8 @@ func mirTruncI64ToI32ThenStoreLine(truncReg, val, slot string) string {
 // §17 LLVM-text typed list / map / set runtime call aliases.
 
 // Osty: mirCallListLengthLine / MapLengthLine / SetLengthLine /
-//       StringLengthLine / BytesLengthLine
+//
+//	StringLengthLine / BytesLengthLine
 func mirCallListLengthLine(reg, listReg string) string {
 	return mirCallListLenLine(reg, listReg)
 }
@@ -7575,7 +7597,8 @@ func mirCallBytesLengthLine(reg, bytesReg string) string {
 // §17 LLVM-text typed iterator-call shapes.
 
 // Osty: mirCallList{Reverse,Reversed,Clear,PopDiscard,IsEmptyTyped}Line /
-//       mirCallMapClearLine / mirCallSetClearLine
+//
+//	mirCallMapClearLine / mirCallSetClearLine
 func mirCallListReverseLine(listReg string) string {
 	return mirCallVoidPtrLine(mirRtListReverseSymbol(), listReg)
 }
@@ -7713,7 +7736,8 @@ func mirCallSetRemoveLine(setReg, elemArgs string) string {
 // §17 LLVM-text typed runtime-callable structured-concurrency.
 
 // Osty: mirCallTaskGroup{New,Cancel,IsCancelled}Line / mirCallTaskHandleJoinLine /
-//       mirCallTaskCollectAllLine / mirCallTaskRaceLine
+//
+//	mirCallTaskCollectAllLine / mirCallTaskRaceLine
 func mirCallTaskGroupNewLine(reg string) string {
 	return mirCallPtrNoArgsLine(reg, mirRtTaskGroupRootSymbol())
 }

--- a/internal/mir/fuse_split_nth_test.go
+++ b/internal/mir/fuse_split_nth_test.go
@@ -19,8 +19,8 @@ import (
 // buildStraightLineSplitFn synthesises a simple straight-line function
 // that:
 //
-//   parts = value.split(sep)
-//   ... callers append `parts[K]`-style reads here
+//	parts = value.split(sep)
+//	... callers append `parts[K]`-style reads here
 //
 // Returns the function, its only block, the value local, the sep
 // local (filled in from a string literal), and the parts local for

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -45,6 +45,7 @@ func CheckSourceStructured(src []byte) CheckResult {
 	}
 	result := adaptCheckResult(checked, lexed)
 	selfhostAppendIntrinsicBodyGateForSource(&result, src)
+	selfhostAppendPureGateForSource(&result, src)
 	return result
 }
 
@@ -88,6 +89,7 @@ func CheckStructuredFromRun(run *FrontendRun) CheckResult {
 	}
 	result := adaptCheckResultFromRuneStream(checked, run.rt, run.stream)
 	selfhostAppendIntrinsicBodyGateForRun(&result, run)
+	selfhostAppendPureGateForRun(&result, run)
 	return result
 }
 

--- a/internal/selfhost/gate_adapter.go
+++ b/internal/selfhost/gate_adapter.go
@@ -50,6 +50,18 @@ func selfhostAppendIntrinsicBodyGateForSource(result *CheckResult, src []byte) {
 	selfhostMergeDiagnosticRecords(result, records...)
 }
 
+func selfhostAppendPureGateForSource(result *CheckResult, src []byte) {
+	if result == nil || len(src) == 0 {
+		return
+	}
+	run := Run(src)
+	if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
+		return
+	}
+	records := selfhostPureDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
+	selfhostMergeDiagnosticRecords(result, records...)
+}
+
 // selfhostAppendIntrinsicBodyGateForRun is the FrontendRun-aware
 // sibling of selfhostAppendIntrinsicBodyGateForSource. It walks the
 // run's AstArena directly via selfhostIntrinsicBodyDiagnosticsFromArena
@@ -64,6 +76,17 @@ func selfhostAppendIntrinsicBodyGateForRun(result *CheckResult, run *FrontendRun
 		return
 	}
 	records := selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
+	selfhostMergeDiagnosticRecords(result, records...)
+}
+
+func selfhostAppendPureGateForRun(result *CheckResult, run *FrontendRun) {
+	if result == nil || run == nil {
+		return
+	}
+	if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
+		return
+	}
+	records := selfhostPureDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
 	selfhostMergeDiagnosticRecords(result, records...)
 }
 
@@ -198,6 +221,324 @@ func selfhostArenaHasAnnotation(arena *AstArena, extra int, name string) bool {
 	return n.text == name
 }
 
+func selfhostPureDiagnosticsFromArena(arena *AstArena, rt runeTable, stream *FrontLexStream, base int, path string) []CheckDiagnosticRecord {
+	if arena == nil {
+		return nil
+	}
+	pureNames := selfhostCollectAnnotatedFnNames(arena, "pure")
+	if len(pureNames) == 0 {
+		return nil
+	}
+	var out []CheckDiagnosticRecord
+	for _, declIdx := range arena.decls {
+		selfhostPureWalkDecl(arena, declIdx, rt, stream, base, path, pureNames, &out)
+	}
+	return out
+}
+
+func selfhostCollectAnnotatedFnNames(arena *AstArena, annotation string) map[string]struct{} {
+	out := map[string]struct{}{}
+	if arena == nil {
+		return out
+	}
+	for _, declIdx := range arena.decls {
+		if declIdx < 0 || declIdx >= len(arena.nodes) {
+			continue
+		}
+		n := arena.nodes[declIdx]
+		if n == nil {
+			continue
+		}
+		switch n.kind.(type) {
+		case *AstNodeKind_AstNFnDecl:
+			if n.right >= 0 && selfhostArenaHasAnnotation(arena, n.extra, annotation) {
+				out[n.text] = struct{}{}
+			}
+		case *AstNodeKind_AstNStructDecl, *AstNodeKind_AstNEnumDecl:
+			for _, childIdx := range n.children {
+				if childIdx < 0 || childIdx >= len(arena.nodes) {
+					continue
+				}
+				child := arena.nodes[childIdx]
+				if child == nil {
+					continue
+				}
+				if _, ok := child.kind.(*AstNodeKind_AstNFnDecl); ok && child.right >= 0 && selfhostArenaHasAnnotation(arena, child.extra, annotation) {
+					out[child.text] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func selfhostPureWalkDecl(arena *AstArena, idx int, rt runeTable, stream *FrontLexStream, base int, path string, pureNames map[string]struct{}, out *[]CheckDiagnosticRecord) {
+	if out == nil || idx < 0 || idx >= len(arena.nodes) {
+		return
+	}
+	n := arena.nodes[idx]
+	if n == nil {
+		return
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNFnDecl:
+		selfhostPureCheckFn(arena, n, rt, stream, base, path, pureNames, out)
+	case *AstNodeKind_AstNStructDecl, *AstNodeKind_AstNEnumDecl:
+		for _, childIdx := range n.children {
+			if childIdx < 0 || childIdx >= len(arena.nodes) {
+				continue
+			}
+			child := arena.nodes[childIdx]
+			if child == nil {
+				continue
+			}
+			if _, ok := child.kind.(*AstNodeKind_AstNFnDecl); ok {
+				selfhostPureCheckFn(arena, child, rt, stream, base, path, pureNames, out)
+			}
+		}
+	}
+}
+
+func selfhostPureCheckFn(arena *AstArena, fn *AstNode, rt runeTable, stream *FrontLexStream, base int, path string, pureNames map[string]struct{}, out *[]CheckDiagnosticRecord) {
+	if fn == nil || fn.right < 0 || !selfhostArenaHasAnnotation(arena, fn.extra, "pure") {
+		return
+	}
+	locals := map[string]struct{}{}
+	for _, paramIdx := range fn.children {
+		if paramIdx < 0 || paramIdx >= len(arena.nodes) {
+			continue
+		}
+		param := arena.nodes[paramIdx]
+		if param == nil {
+			continue
+		}
+		if _, ok := param.kind.(*AstNodeKind_AstNParam); ok && param.text != "" && param.text != "self" {
+			locals[param.text] = struct{}{}
+		}
+	}
+	selfhostPureWalkExpr(arena, fn.right, fn.text, pureNames, locals, rt, stream, base, path, out)
+}
+
+func selfhostPureWalkExpr(arena *AstArena, idx int, fnName string, pureNames map[string]struct{}, locals map[string]struct{}, rt runeTable, stream *FrontLexStream, base int, path string, out *[]CheckDiagnosticRecord) {
+	if idx < 0 || idx >= len(arena.nodes) {
+		return
+	}
+	n := arena.nodes[idx]
+	if n == nil {
+		return
+	}
+	switch n.kind.(type) {
+	case *AstNodeKind_AstNList:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "allocate a list literal", "remove `#[pure]`, pass in precomputed data, or rewrite without managed allocation", n)
+		for _, childIdx := range n.children {
+			selfhostPureWalkExpr(arena, childIdx, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+	case *AstNodeKind_AstNMap:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "allocate a map literal", "remove `#[pure]`, pass in precomputed data, or rewrite without managed allocation", n)
+		for _, childIdx := range n.children {
+			selfhostPureWalkExpr(arena, childIdx, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+		for _, childIdx := range n.children2 {
+			selfhostPureWalkExpr(arena, childIdx, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+	case *AstNodeKind_AstNStructLit:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "allocate a struct literal", "return scalar data or drop `#[pure]` until the value construction can be proven allocation-free", n)
+		for _, fieldIdx := range n.children {
+			if fieldIdx < 0 || fieldIdx >= len(arena.nodes) || arena.nodes[fieldIdx] == nil {
+				continue
+			}
+			selfhostPureWalkExpr(arena, arena.nodes[fieldIdx].left, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNClosure:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "allocate a closure", "closures capture an environment; use a direct `#[pure]` helper function instead", n)
+	case *AstNodeKind_AstNStringLit:
+		if isAllocatingStringText(n.text) {
+			selfhostPureAppendRecord(out, rt, stream, base, path, fnName, classifyAllocatingString(n.text), "only plain `\"...\"` literals are accepted in `#[pure]` bodies", n)
+		}
+	case *AstNodeKind_AstNCall:
+		if !selfhostPureCalleeAllowed(arena, n.left, pureNames) {
+			what := "call a function that is not `#[pure]`"
+			if selfhostPureCalleeLooksLikeIO(arena, n.left) {
+				what = "perform I/O"
+			}
+			selfhostPureAppendRecord(out, rt, stream, base, path, fnName, what, "mark the callee `#[pure]` only if it is side-effect free, or remove `#[pure]` from this function", n)
+		}
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		for _, argIdx := range n.children {
+			selfhostPureWalkExpr(arena, argIdx, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+	case *AstNodeKind_AstNAssign:
+		if !selfhostPureAssignTargetLocal(arena, n.left, locals) {
+			selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "write non-local state", "only assignment to local bindings declared inside the `#[pure]` function is allowed", n)
+		}
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNChanSend:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "send on a channel", "channel sends are observable side effects; remove `#[pure]`", n)
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNDefer:
+		selfhostPureAppendRecord(out, rt, stream, base, path, fnName, "register a deferred effect", "defer runs code after the function returns and is not allowed in `#[pure]` bodies", n)
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNLet:
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNBlock:
+		scoped := selfhostCopyStringSet(locals)
+		for _, stmtIdx := range n.children {
+			selfhostPureWalkExpr(arena, stmtIdx, fnName, pureNames, scoped, rt, stream, base, path, out)
+			if stmtIdx >= 0 && stmtIdx < len(arena.nodes) && arena.nodes[stmtIdx] != nil {
+				if _, ok := arena.nodes[stmtIdx].kind.(*AstNodeKind_AstNLet); ok {
+					selfhostPureCollectPatternBindings(arena, arena.nodes[stmtIdx].left, scoped)
+				}
+			}
+		}
+	case *AstNodeKind_AstNExprStmt, *AstNodeKind_AstNReturn, *AstNodeKind_AstNQuestion, *AstNodeKind_AstNField, *AstNodeKind_AstNParen, *AstNodeKind_AstNTurbofish:
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNFor:
+		loopLocals := selfhostCopyStringSet(locals)
+		selfhostPureCollectPatternBindings(arena, n.left, loopLocals)
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		if len(n.children) >= 2 {
+			selfhostPureWalkExpr(arena, n.children[1], fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, loopLocals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNIf:
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+		if len(n.children) > 0 {
+			selfhostPureWalkExpr(arena, n.children[0], fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+	case *AstNodeKind_AstNMatch:
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		for _, armIdx := range n.children {
+			if armIdx < 0 || armIdx >= len(arena.nodes) || arena.nodes[armIdx] == nil {
+				continue
+			}
+			arm := arena.nodes[armIdx]
+			armLocals := selfhostCopyStringSet(locals)
+			selfhostPureCollectPatternBindings(arena, arm.left, armLocals)
+			if len(arm.children) > 0 {
+				selfhostPureWalkExpr(arena, arm.children[0], fnName, pureNames, armLocals, rt, stream, base, path, out)
+			}
+			selfhostPureWalkExpr(arena, arm.right, fnName, pureNames, armLocals, rt, stream, base, path, out)
+		}
+	case *AstNodeKind_AstNUnary:
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNBinary, *AstNodeKind_AstNIndex, *AstNodeKind_AstNRange:
+		selfhostPureWalkExpr(arena, n.left, fnName, pureNames, locals, rt, stream, base, path, out)
+		selfhostPureWalkExpr(arena, n.right, fnName, pureNames, locals, rt, stream, base, path, out)
+	case *AstNodeKind_AstNTuple:
+		for _, childIdx := range n.children {
+			selfhostPureWalkExpr(arena, childIdx, fnName, pureNames, locals, rt, stream, base, path, out)
+		}
+	}
+}
+
+func selfhostPureAppendRecord(out *[]CheckDiagnosticRecord, rt runeTable, stream *FrontLexStream, base int, path, fnName, what, hint string, n *AstNode) {
+	if out == nil || n == nil {
+		return
+	}
+	startOffset, endOffset := checkNodeOffsets(rt, stream, n.start, n.end)
+	start := base + startOffset
+	end := base + endOffset
+	if end < start {
+		end = start
+	}
+	*out = append(*out, CheckDiagnosticRecord{
+		Code:     diag.CodePureViolation,
+		Severity: "error",
+		Message:  "`#[pure]` function `" + fnName + "` cannot " + what,
+		Start:    start,
+		End:      end,
+		File:     path,
+		Notes: []string{
+			"LANG_SPEC v0.6 A13: `#[pure]` lowers to LLVM `readnone`, so the body must not write non-local state, perform I/O, allocate, or call impure functions",
+			"hint: " + hint,
+		},
+	})
+}
+
+func selfhostPureAssignTargetLocal(arena *AstArena, targetIdx int, locals map[string]struct{}) bool {
+	if arena == nil || targetIdx < 0 || targetIdx >= len(arena.nodes) || arena.nodes[targetIdx] == nil {
+		return false
+	}
+	target := arena.nodes[targetIdx]
+	if _, ok := target.kind.(*AstNodeKind_AstNIdent); !ok {
+		return false
+	}
+	_, ok := locals[target.text]
+	return ok
+}
+
+func selfhostPureCalleeAllowed(arena *AstArena, calleeIdx int, pureNames map[string]struct{}) bool {
+	if arena == nil || calleeIdx < 0 || calleeIdx >= len(arena.nodes) || arena.nodes[calleeIdx] == nil {
+		return false
+	}
+	callee := arena.nodes[calleeIdx]
+	switch callee.kind.(type) {
+	case *AstNodeKind_AstNIdent, *AstNodeKind_AstNField:
+		_, ok := pureNames[callee.text]
+		return ok
+	case *AstNodeKind_AstNTurbofish:
+		return selfhostPureCalleeAllowed(arena, callee.left, pureNames)
+	default:
+		return false
+	}
+}
+
+func selfhostPureCalleeLooksLikeIO(arena *AstArena, calleeIdx int) bool {
+	switch selfhostPureCalleeLastName(arena, calleeIdx) {
+	case "print", "println", "eprint", "eprintln", "read", "readAll", "readToString", "write", "writeAll", "open", "create":
+		return true
+	default:
+		return false
+	}
+}
+
+func selfhostPureCalleeLastName(arena *AstArena, calleeIdx int) string {
+	if arena == nil || calleeIdx < 0 || calleeIdx >= len(arena.nodes) || arena.nodes[calleeIdx] == nil {
+		return ""
+	}
+	callee := arena.nodes[calleeIdx]
+	switch callee.kind.(type) {
+	case *AstNodeKind_AstNIdent, *AstNodeKind_AstNField:
+		return callee.text
+	case *AstNodeKind_AstNTurbofish:
+		return selfhostPureCalleeLastName(arena, callee.left)
+	default:
+		return ""
+	}
+}
+
+func selfhostCopyStringSet(in map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func selfhostPureCollectPatternBindings(arena *AstArena, patIdx int, out map[string]struct{}) {
+	if arena == nil || patIdx < 0 || patIdx >= len(arena.nodes) || arena.nodes[patIdx] == nil {
+		return
+	}
+	pat := arena.nodes[patIdx]
+	if _, ok := pat.kind.(*AstNodeKind_AstNPattern); !ok {
+		return
+	}
+	if pat.extra == astPatternIdentKind() || pat.extra == astPatternBindingKind() {
+		if pat.text != "" && pat.text != "_" {
+			out[pat.text] = struct{}{}
+		}
+	}
+	selfhostPureCollectPatternBindings(arena, pat.left, out)
+	selfhostPureCollectPatternBindings(arena, pat.right, out)
+	for _, childIdx := range pat.children {
+		selfhostPureCollectPatternBindings(arena, childIdx, out)
+	}
+}
+
 func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input PackageCheckInput) {
 	if result == nil || len(input.Files) == 0 {
 		return
@@ -212,6 +553,24 @@ func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input Packag
 			continue
 		}
 		records = append(records, selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, file.Base, file.Path)...)
+	}
+	selfhostMergeDiagnosticRecords(result, records...)
+}
+
+func selfhostAppendPureGateForPackage(result *CheckResult, input PackageCheckInput) {
+	if result == nil || len(input.Files) == 0 {
+		return
+	}
+	var records []CheckDiagnosticRecord
+	for _, file := range input.Files {
+		if len(file.Source) == 0 {
+			continue
+		}
+		run := Run(file.Source)
+		if selfhostRunHasErrorDiagnostics(run) || run.parser == nil || run.parser.arena == nil {
+			continue
+		}
+		records = append(records, selfhostPureDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, file.Base, file.Path)...)
 	}
 	selfhostMergeDiagnosticRecords(result, records...)
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -35046,14 +35046,33 @@ func checkExpectAssignable(env *CheckEnv, expected int, got int, start int, end 
 	return false
 }
 
+var checkIsAssignableRecursionDepth int
+var checkIsAssignableActive = map[string]int{}
+
 // Osty: /tmp/selfhost_merged.osty:15205:5
 func checkIsAssignable(env *CheckEnv, dst int, src int) bool {
+	checkIsAssignableRecursionDepth++
+	defer func() { checkIsAssignableRecursionDepth-- }()
+	if checkIsAssignableRecursionDepth > 128 {
+		return true
+	}
 	// Osty: /tmp/selfhost_merged.osty:15206:5
 	d := checkResolveAliasDeep(env, dst)
 	_ = d
 	// Osty: /tmp/selfhost_merged.osty:15207:5
 	s := checkResolveAliasDeep(env, src)
 	_ = s
+	activeKey := fmt.Sprintf("%d:%d", d, s)
+	if checkIsAssignableActive[activeKey] > 0 {
+		return true
+	}
+	checkIsAssignableActive[activeKey]++
+	defer func() {
+		checkIsAssignableActive[activeKey]--
+		if checkIsAssignableActive[activeKey] == 0 {
+			delete(checkIsAssignableActive, activeKey)
+		}
+	}()
 	// Osty: /tmp/selfhost_merged.osty:15208:5
 	if tyIsBad(env.tys, d) || tyIsBad(env.tys, s) {
 		// Osty: /tmp/selfhost_merged.osty:15209:9

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -40,6 +40,7 @@ func CheckPackageStructured(input PackageCheckInput) (CheckResult, error) {
 	elabFile(cx)
 	result := adaptCheckResultWithTokenLayout(serializeCheckResult(cx), layout)
 	selfhostAppendIntrinsicBodyGateForPackage(&result, input)
+	selfhostAppendPureGateForPackage(&result, input)
 	return result, nil
 }
 

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -316,6 +316,45 @@ fn main() {
 	}
 }
 
+func TestCheckPackageStructuredASTNativeRunsPureGate(t *testing.T) {
+	input := canonicalSelfhostInput(t, []byte(`fn impure() -> Int { 1 }
+
+#[pure]
+fn bad() -> Int {
+    let items = [1]
+    impure()
+}
+`), 0)
+	checked, err := selfhost.CheckPackageStructured(selfhost.PackageCheckInput{
+		Files: []selfhost.PackageCheckFile{input},
+	})
+	if err != nil {
+		t.Fatalf("CheckPackageStructured: %v", err)
+	}
+	if got := findDiagnosticCode(checked, "E0775"); got == nil {
+		t.Fatalf("expected E0775, got diagnostics %#v", checked.Diagnostics)
+	}
+	if got := checked.Summary.ErrorsByContext["E0775"]; got == 0 {
+		t.Fatalf("summary E0775 count = %d, want non-zero (summary=%#v)", got, checked.Summary)
+	}
+}
+
+func TestCheckSourceStructuredAcceptsPureLocalComputation(t *testing.T) {
+	checked := selfhost.CheckSourceStructured([]byte(`#[pure]
+fn mix(a: Int, b: Int) -> Int { a * 31 + b }
+
+#[pure]
+fn caller(a: Int, b: Int) -> Int {
+    let mut acc = 0
+    acc = acc + mix(a, b)
+    acc
+}
+`))
+	if got := findDiagnosticCode(checked, "E0775"); got != nil {
+		t.Fatalf("unexpected E0775: %#v", checked.Diagnostics)
+	}
+}
+
 func TestCheckPackageStructuredImportedDefaultMethodBoundsASTNative(t *testing.T) {
 	input := canonicalSelfhostInput(t, []byte(`use dep
 

--- a/internal/stdlib/csv_test.go
+++ b/internal/stdlib/csv_test.go
@@ -1,0 +1,89 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestCsvModuleSurface(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["csv"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.csv not loaded")
+	}
+
+	for _, name := range []string{"encode", "encodeWith", "decode", "decodeWith", "decodeHeaders"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.csv missing export %q", name)
+			continue
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Errorf("std.csv.%s kind = %s, want SymFn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Errorf("std.csv.%s not public", name)
+		}
+		fn, ok := sym.Decl.(*ast.FnDecl)
+		if !ok || fn.Body == nil {
+			t.Errorf("std.csv.%s has no bodied implementation", name)
+		}
+	}
+
+	sym := mod.Package.PkgScope.LookupLocal("CsvOptions")
+	if sym == nil {
+		t.Fatalf("std.csv missing CsvOptions")
+	}
+	if sym.Kind != resolve.SymStruct {
+		t.Fatalf("std.csv.CsvOptions kind = %s, want SymStruct", sym.Kind)
+	}
+	opts, ok := sym.Decl.(*ast.StructDecl)
+	if !ok {
+		t.Fatalf("std.csv.CsvOptions decl = %T, want *ast.StructDecl", sym.Decl)
+	}
+	fields := map[string]*ast.Field{}
+	for _, f := range opts.Fields {
+		fields[f.Name] = f
+	}
+	for _, name := range []string{"delimiter", "quote", "trimSpace"} {
+		f := fields[name]
+		if f == nil {
+			t.Errorf("CsvOptions missing field %q", name)
+			continue
+		}
+		if !f.Pub {
+			t.Errorf("CsvOptions.%s not public", name)
+		}
+		if f.Default == nil {
+			t.Errorf("CsvOptions.%s has no default", name)
+		}
+	}
+}
+
+func TestCsvModuleSourcePinsQualityGuards(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["csv"]
+	if mod == nil {
+		t.Fatalf("std.csv not loaded")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"validateOptions(options)?",
+		"abortInvalidOptions(options)",
+		"validateHeaders(headers)?",
+		"duplicate header",
+		"row.len() != headers.len()",
+		"record.insert(headers[c], row[c])",
+		"options.trimSpace && hasOuterAsciiSpace(field)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("std.csv source missing quality guard %q", want)
+		}
+	}
+	if strings.Contains(src, "record.set(") {
+		t.Errorf("std.csv still calls Map.set; use canonical Map.insert")
+	}
+}

--- a/internal/stdlib/json_test.go
+++ b/internal/stdlib/json_test.go
@@ -1,0 +1,72 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJsonGenericWrappersAreLoweringStubs(t *testing.T) {
+	reg := LoadCached()
+	for _, name := range []string{"encode", "decode"} {
+		fn := reg.LookupFnDecl("json", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(json, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body != nil {
+			t.Fatalf("json.%s has a source body, want declaration-only lowering stub", name)
+		}
+	}
+	for _, name := range []string{"stringify", "parse"} {
+		fn := reg.LookupFnDecl("json", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(json, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("json.%s body = nil, want source wrapper body", name)
+		}
+	}
+}
+
+func TestJsonValueStringifierPreservesUTF8Bytes(t *testing.T) {
+	src := jsonModuleSource(t)
+	if strings.Contains(src, "b.toChar()") {
+		t.Fatal("json stringifier must not transcode raw UTF-8 bytes through Byte.toChar")
+	}
+	for _, want := range []string{
+		"out.push(b)",
+		"bytes.from(out).toString().unwrap()",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("json stringifier source missing %q", want)
+		}
+	}
+}
+
+func TestJsonValueObjectStringifierIsDeterministic(t *testing.T) {
+	src := jsonModuleSource(t)
+	if !strings.Contains(src, "obj.keys().sorted()") {
+		t.Fatal("json object stringifier must sort object keys before emission")
+	}
+}
+
+func TestJsonValueParserRejectsNonFiniteNumbers(t *testing.T) {
+	src := jsonModuleSource(t)
+	for _, want := range []string{
+		"n.isNaN() || n.isInfinite()",
+		"json: number out of range",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("json number parser source missing %q", want)
+		}
+	}
+}
+
+func jsonModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["json"]
+	if mod == nil {
+		t.Fatal("stdlib json module missing")
+	}
+	return string(mod.Source)
+}

--- a/internal/stdlib/modules/csv.osty
+++ b/internal/stdlib/modules/csv.osty
@@ -3,13 +3,14 @@
 // The encoder and decoder are implemented in pure Osty. Encoding
 // follows RFC 4180: fields containing the delimiter, quote, or a CR
 // or LF are wrapped in quotes, and embedded quotes are doubled.
-// Decoding is a small state machine over `chars()` that accepts
-// either CRLF or bare LF as a row terminator and tolerates a final
-// row without a trailing newline. `trimSpace` strips ASCII space and
-// tab from the start and end of each *unquoted* field.
+// Decoding is a small state machine over `chars()` that accepts either
+// CRLF or bare LF as a row terminator and tolerates a final row without
+// a trailing newline. `trimSpace` strips ASCII space and tab from the
+// start and end of each unquoted field, and lets quoted fields be
+// surrounded by those spaces.
 
-use std.strings
 use std.error
+use std.process
 
 pub struct CsvOptions {
     pub delimiter: Char = ',',
@@ -22,6 +23,8 @@ pub fn encode(rows: List<List<String>>) -> String {
 }
 
 pub fn encodeWith(rows: List<List<String>>, options: CsvOptions) -> String {
+    abortInvalidOptions(options)
+
     let mut out = ""
     let mut first = true
     for row in rows {
@@ -39,6 +42,8 @@ pub fn decode(text: String) -> Result<List<List<String>>, Error> {
 }
 
 pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error> {
+    validateOptions(options)?
+
     let chars = text.chars()
     let n = chars.len()
     let delim = options.delimiter
@@ -83,6 +88,8 @@ pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>
                 } else {
                     i = i + 1
                 }
+            } else if options.trimSpace && isAsciiSpace(c) {
+                i = i + 1
             } else {
                 field = "{field}{c}"
                 state = 1
@@ -153,6 +160,8 @@ pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>
                 } else {
                     i = i + 1
                 }
+            } else if options.trimSpace && isAsciiSpace(c) {
+                i = i + 1
             } else {
                 return Err(error.new("csv: unexpected character after closing quote"))
             }
@@ -178,15 +187,24 @@ pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
         return Ok([])
     }
     let headers = rows[0]
+    validateHeaders(headers)?
+
     let mut records: List<Map<String, String>> = []
     let mut r = 1
     for r < rows.len() {
         let row = rows[r]
+        if row.len() != headers.len() {
+            let rowNo = r + 1
+            let expected = headers.len()
+            let got = row.len()
+            return Err(csvError("record {rowNo}: expected {expected} fields, got {got}"))
+        }
+
         let mut record: Map<String, String> = {:}
         let mut c = 0
-        let cols = if row.len() < headers.len() { row.len() } else { headers.len() }
+        let cols = headers.len()
         for c < cols {
-            record.set(headers[c], row[c])
+            record.insert(headers[c], row[c])
             c = c + 1
         }
         records.push(record)
@@ -220,6 +238,9 @@ fn encodeField(field: String, options: CsvOptions) -> String {
 }
 
 fn needsQuoting(field: String, options: CsvOptions) -> Bool {
+    if options.trimSpace && hasOuterAsciiSpace(field) {
+        return true
+    }
     for c in field.chars() {
         if c == options.delimiter || c == options.quote || c == '\n' || c == '\r' {
             return true
@@ -270,4 +291,61 @@ fn trimAscii(s: String) -> String {
 
 fn isAsciiSpace(c: Char) -> Bool {
     c == ' ' || c == '\t'
+}
+
+fn hasOuterAsciiSpace(s: String) -> Bool {
+    let chars = s.chars()
+    let n = chars.len()
+    n > 0 && (isAsciiSpace(chars[0]) || isAsciiSpace(chars[n - 1]))
+}
+
+fn validateHeaders(headers: List<String>) -> Result<(), Error> {
+    let mut seen: Map<String, Bool> = {:}
+    let mut i = 0
+    for i < headers.len() {
+        let header = headers[i]
+        let col = i + 1
+        if header == "" {
+            return Err(csvError("empty header at column {col}"))
+        }
+        if seen.get(header).isSome() {
+            return Err(csvError("duplicate header: {header}"))
+        }
+        seen.insert(header, true)
+        i = i + 1
+    }
+    Ok(())
+}
+
+fn validateOptions(options: CsvOptions) -> Result<(), Error> {
+    if options.delimiter == options.quote {
+        return Err(csvError("delimiter and quote must differ"))
+    }
+    if isRecordTerminator(options.delimiter) {
+        return Err(csvError("delimiter cannot be a record terminator"))
+    }
+    if isRecordTerminator(options.quote) {
+        return Err(csvError("quote cannot be a record terminator"))
+    }
+    Ok(())
+}
+
+fn abortInvalidOptions(options: CsvOptions) {
+    if options.delimiter == options.quote {
+        process.abort("csv: delimiter and quote must differ")
+    }
+    if isRecordTerminator(options.delimiter) {
+        process.abort("csv: delimiter cannot be a record terminator")
+    }
+    if isRecordTerminator(options.quote) {
+        process.abort("csv: quote cannot be a record terminator")
+    }
+}
+
+fn isRecordTerminator(c: Char) -> Bool {
+    c == '\n' || c == '\r'
+}
+
+fn csvError(message: String) -> Error {
+    error.new("csv: {message}")
 }

--- a/internal/stdlib/modules/json.osty
+++ b/internal/stdlib/modules/json.osty
@@ -50,17 +50,13 @@ pub interface Decode {
 // Generic wrappers (codegen-lowered)
 // ---------------------------------------------------------------------------
 
-pub fn encode<T>(value: T) -> String {
-    ""
-}
+pub fn encode<T>(value: T) -> String
 
 pub fn stringify<T>(value: T) -> String {
     encode(value)
 }
 
-pub fn decode<T>(text: String) -> Result<T, Error> {
-    decode::<T>(text)
-}
+pub fn decode<T>(text: String) -> Result<T, Error>
 
 pub fn parse<T>(text: String) -> Result<T, Error> {
     decode(text)
@@ -99,15 +95,16 @@ fn stringifyArray(arr: JsonArray) -> String {
 }
 
 fn stringifyObject(obj: JsonObject) -> String {
-    let entries = obj.entries()
-    let len = entries.len()
+    let keys = obj.keys().sorted()
+    let len = keys.len()
     if len == 0 {
         return "\{\}"
     }
     let mut out = "\{"
     let mut i = 0
     for i < len {
-        let (key, val) = entries[i]
+        let key = keys[i]
+        let val = obj.get(key).unwrap()
         if i > 0 {
             out = "{out},"
         }
@@ -120,38 +117,58 @@ fn stringifyObject(obj: JsonObject) -> String {
 fn escapeJsonString(s: String) -> String {
     let bs = s.bytes()
     let len = bs.len()
-    let mut out = "\""
+    let mut out: List<Byte> = []
+    pushByte(out, 0x22)
     let mut i = 0
     for i < len {
         let b = bs[i]
         let c = b.toInt()
         if c == 0x22 {
-            out = "{out}\\\""
+            pushAscii(out, "\\\"")
         } else if c == 0x5C {
-            out = "{out}\\\\"
+            pushAscii(out, "\\\\")
         } else if c == 0x08 {
-            out = "{out}\\b"
+            pushAscii(out, "\\b")
         } else if c == 0x0C {
-            out = "{out}\\f"
+            pushAscii(out, "\\f")
         } else if c == 0x0A {
-            out = "{out}\\n"
+            pushAscii(out, "\\n")
         } else if c == 0x0D {
-            out = "{out}\\r"
+            pushAscii(out, "\\r")
         } else if c == 0x09 {
-            out = "{out}\\t"
+            pushAscii(out, "\\t")
         } else if c < 0x20 {
-            out = "{out}\\u{hexNibble(c >> 12)}{hexNibble((c >> 8) & 0x0F)}{hexNibble((c >> 4) & 0x0F)}{hexNibble(c & 0x0F)}"
+            pushUnicodeEscape(out, c)
         } else {
-            out = "{out}{b.toChar()}"
+            out.push(b)
         }
         i = i + 1
     }
-    "{out}\""
+    pushByte(out, 0x22)
+    bytes.from(out).toString().unwrap()
 }
 
-fn hexNibble(n: Int) -> Char {
-    let lut = "0123456789abcdef"
-    lut[n & 0x0F].toChar()
+fn pushAscii(buf: List<Byte>, s: String) {
+    let bs = s.bytes()
+    let len = bs.len()
+    let mut i = 0
+    for i < len {
+        buf.push(bs[i])
+        i = i + 1
+    }
+}
+
+fn pushUnicodeEscape(buf: List<Byte>, cp: Int) {
+    pushAscii(buf, "\\u")
+    pushHexNibbleByte(buf, cp >> 12)
+    pushHexNibbleByte(buf, (cp >> 8) & 0x0F)
+    pushHexNibbleByte(buf, (cp >> 4) & 0x0F)
+    pushHexNibbleByte(buf, cp & 0x0F)
+}
+
+fn pushHexNibbleByte(buf: List<Byte>, n: Int) {
+    let lut = "0123456789abcdef".bytes()
+    buf.push(lut[n & 0x0F])
 }
 
 fn formatJsonNumber(n: Float) -> String {
@@ -415,6 +432,9 @@ fn parseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     }
     let numStr = bytes.from(numBuf).toString()?
     let n = numStr.toFloat()?
+    if n.isNaN() || n.isInfinite() {
+        return Err(error.new("json: number out of range"))
+    }
     Ok((Number(n), i))
 }
 

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 315 `.osty` file(s)  
-**Captured:** 148 residual case(s) — **0** AI-slip(s) airepair rewrote, **148** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 320 `.osty` file(s)  
+**Captured:** 152 residual case(s) — **0** AI-slip(s) airepair rewrote, **152** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -74,6 +74,7 @@ pub fn checkCodePodShapeViolation() -> String { "E0771" }
 pub fn checkCodeNoAllocViolation() -> String { "E0772" }
 pub fn checkCodeIntrinsicNonEmptyBody() -> String { "E0773" }
 pub fn checkCodeBuilderMissingRequiredField() -> String { "E0774" }
+pub fn checkCodePureViolation() -> String { "E0775" }
 
 // ---------------------------------------------------------------------
 // Low-level builder. Higher-level constructors below wrap this so call
@@ -497,6 +498,26 @@ pub fn diagIntrinsicNonEmptyBody(fnName: String, start: Int, end: Int) -> CheckD
             "LANG_SPEC §19.6: intrinsic implementations are supplied by the lowering layer; the source body is ignored",
             "hint: keep the signature and drop the body, or use an empty block",
         ],
+    )
+}
+
+/// diagPureViolation reports a side-effectful operation inside a
+/// `#[pure]` function body. `what` names the rejected operation; the
+/// hint points at either removing `#[pure]` or making the callee/body
+/// obey the readnone contract that LLVM receives.
+pub fn diagPureViolation(fnName: String, what: String, fixHint: String, start: Int, end: Int) -> CheckDiagnostic {
+    let mut notes: List<String> = [
+        "LANG_SPEC v0.6 A13: `#[pure]` lowers to LLVM `readnone`, so the body must not write non-local state, perform I/O, allocate, or call impure functions",
+    ]
+    if fixHint != "" {
+        notes.push("hint: {fixHint}")
+    }
+    checkDiagWithNotes(
+        checkCodePureViolation(),
+        "`#[pure]` function `{fnName}` cannot {what}",
+        start,
+        end,
+        notes,
     )
 }
 

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -997,6 +997,13 @@ pub fn checkExpectAssignable(env: CheckEnv, expected: Int, got: Int, start: Int,
 /// Ty arena. Mirrors the legacy rules (`toolchain/check.osty:1419-1495`)
 /// while dropping the repeated string parsing.
 pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
+    checkIsAssignableDepth(env, dst, src, 0)
+}
+
+fn checkIsAssignableDepth(env: CheckEnv, dst: Int, src: Int, depth: Int) -> Bool {
+    if depth > 128 {
+        return true
+    }
     let d = checkResolveAliasDeep(env, dst)
     let s = checkResolveAliasDeep(env, src)
     if tyIsBad(env.tys, d) || tyIsBad(env.tys, s) {
@@ -1042,7 +1049,7 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
         }
         let mut i = 0
         for de in da {
-            if !(checkIsAssignable(env, de, sa[i])) {
+            if !(checkIsAssignableDepth(env, de, sa[i], depth + 1)) {
                 return false
             }
             i = i + 1
@@ -1060,12 +1067,12 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
             let spe = sp[i]
             // Function parameters are invariant (contravariant treated
             // as equivalence to keep the checker predictable).
-            if !(checkIsAssignable(env, dpe, spe)) || !(checkIsAssignable(env, spe, dpe)) {
+            if !(checkIsAssignableDepth(env, dpe, spe, depth + 1)) || !(checkIsAssignableDepth(env, spe, dpe, depth + 1)) {
                 return false
             }
             i = i + 1
         }
-        return checkIsAssignable(env, tyRetAt(env.tys, d), tyRetAt(env.tys, s))
+        return checkIsAssignableDepth(env, tyRetAt(env.tys, d), tyRetAt(env.tys, s), depth + 1)
     }
     if dk == TkNamed && sk == TkNamed && tyHeadAt(env.tys, d) == tyHeadAt(env.tys, s) {
         let da = tyArgsAt(env.tys, d)
@@ -1075,7 +1082,7 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
         }
         let mut i = 0
         for de in da {
-            if !(checkIsAssignable(env, de, sa[i])) {
+            if !(checkIsAssignableDepth(env, de, sa[i], depth + 1)) {
                 return false
             }
             i = i + 1
@@ -1083,33 +1090,44 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
         return true
     }
     if dk == TkOptional && sk == TkOptional {
-        return checkIsAssignable(env, tyInnerAt(env.tys, d), tyInnerAt(env.tys, s))
+        return checkIsAssignableDepth(env, tyInnerAt(env.tys, d), tyInnerAt(env.tys, s), depth + 1)
     }
     // `T?` (TkOptional) and `Option<T>` (TkNamed "Option") are the
     // same type spelled two ways. Normalise before comparing.
     if dk == TkOptional && sk == TkNamed && tyHeadAt(env.tys, s) == "Option" {
         let sa = tyArgsAt(env.tys, s)
         if checkIntListLen(sa) == 1 {
-            return checkIsAssignable(env, tyInnerAt(env.tys, d), sa[0])
+            return checkIsAssignableDepth(env, tyInnerAt(env.tys, d), sa[0], depth + 1)
         }
     }
     if dk == TkNamed && tyHeadAt(env.tys, d) == "Option" && sk == TkOptional {
         let da = tyArgsAt(env.tys, d)
         if checkIntListLen(da) == 1 {
-            return checkIsAssignable(env, da[0], tyInnerAt(env.tys, s))
+            return checkIsAssignableDepth(env, da[0], tyInnerAt(env.tys, s), depth + 1)
         }
     }
     if dk == TkNamed && checkIsInterface(env, tyHeadAt(env.tys, d)) {
-        return checkTypeSatisfiesInterface(env, s, d)
+        return checkTypeSatisfiesInterfaceDepth(env, s, d, depth + 1)
     }
     false
 }
 
 pub fn checkTypeSatisfiesInterface(env: CheckEnv, concrete: Int, iface: Int) -> Bool {
-    checkTypeSatisfiesInterfaceSeen(env, concrete, iface, [])
+    checkTypeSatisfiesInterfaceDepth(env, concrete, iface, 0)
+}
+
+fn checkTypeSatisfiesInterfaceDepth(env: CheckEnv, concrete: Int, iface: Int, depth: Int) -> Bool {
+    checkTypeSatisfiesInterfaceSeenDepth(env, concrete, iface, [], depth)
 }
 
 fn checkTypeSatisfiesInterfaceSeen(env: CheckEnv, concrete: Int, iface: Int, seen: List<String>) -> Bool {
+    checkTypeSatisfiesInterfaceSeenDepth(env, concrete, iface, seen, 0)
+}
+
+fn checkTypeSatisfiesInterfaceSeenDepth(env: CheckEnv, concrete: Int, iface: Int, seen: List<String>, depth: Int) -> Bool {
+    if depth > 128 {
+        return true
+    }
     let concreteResolved = checkResolveAliasDeep(env, concrete)
     let ifaceResolved = checkResolveAliasDeep(env, iface)
     if tyIsBad(env.tys, concreteResolved) || tyIsBad(env.tys, ifaceResolved) {
@@ -1139,14 +1157,14 @@ fn checkTypeSatisfiesInterfaceSeen(env: CheckEnv, concrete: Int, iface: Int, see
     if tyKindAt(env.tys, concreteResolved) == TkNamed {
         let concreteHead = tyHeadAt(env.tys, concreteResolved)
         for boundTy in checkGenericBoundsFor(env, concreteHead) {
-            if checkTypeSatisfiesInterfaceSeen(env, boundTy, ifaceResolved, nextSeen) {
+            if checkTypeSatisfiesInterfaceSeenDepth(env, boundTy, ifaceResolved, nextSeen, depth + 1) {
                 return true
             }
         }
         let methods = checkInterfaceMethodSet(env, ifaceHead)
         let required = checkInterfaceRequiredMethodSet(env, ifaceHead)
         for req in required {
-            if !(checkConcreteMethodSatisfiesInterfaceMethod(env, concreteResolved, concreteHead, ifaceResolved, req, true)) {
+            if !(checkConcreteMethodSatisfiesInterfaceMethodDepth(env, concreteResolved, concreteHead, ifaceResolved, req, true, depth + 1)) {
                 return false
             }
         }
@@ -1154,7 +1172,7 @@ fn checkTypeSatisfiesInterfaceSeen(env: CheckEnv, concrete: Int, iface: Int, see
             if !(checkFnHasBody(env, req.name, req.owner)) {
                 continue
             }
-            if !(checkConcreteMethodSatisfiesInterfaceMethod(env, concreteResolved, concreteHead, ifaceResolved, req, false)) {
+            if !(checkConcreteMethodSatisfiesInterfaceMethodDepth(env, concreteResolved, concreteHead, ifaceResolved, req, false, depth + 1)) {
                 return false
             }
         }
@@ -1389,13 +1407,25 @@ fn checkConcreteMethodSatisfiesInterfaceMethod(
     req: CheckFnSig,
     required: Bool,
 ) -> Bool {
+    checkConcreteMethodSatisfiesInterfaceMethodDepth(env, concreteResolved, concreteHead, ifaceResolved, req, required, 0)
+}
+
+fn checkConcreteMethodSatisfiesInterfaceMethodDepth(
+    env: CheckEnv,
+    concreteResolved: Int,
+    concreteHead: String,
+    ifaceResolved: Int,
+    req: CheckFnSig,
+    required: Bool,
+    depth: Int,
+) -> Bool {
     let found = checkLookupMethod(env, concreteHead, req.name)
     if found.name == "" {
         return !(required)
     }
     let wantTy = checkConcreteMethodTy(env, req, ifaceResolved, concreteResolved)
     let gotTy = checkConcreteMethodTy(env, found, concreteResolved, concreteResolved)
-    checkIsAssignable(env, wantTy, gotTy)
+    checkIsAssignableDepth(env, wantTy, gotTy, depth + 1)
 }
 
 fn checkCollectInterfaceMethods(env: CheckEnv, owner: String, out: List<CheckFnSig>, seen: List<String>) -> List<CheckFnSig> {

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -47,6 +47,11 @@ use std.strings as strings
 //     raw), and calls into callees that are not themselves
 //     `#[no_alloc]` in the same file (with a `raw.*` / `self.*`
 //     escape hatch matching the Go gate's spike behaviour).
+//
+//   runPureGate           — E0775 (v0.6 A13)
+//     Inside the body of a `#[pure]` function, reject operations that
+//     would make the LLVM `readnone` promise unsound: non-local writes,
+//     I/O/impure calls, managed allocation, and closures.
 
 // ---------------------------------------------------------------------
 // Entry point — called from check.osty:elabFile after elaborateDecls.
@@ -57,6 +62,7 @@ pub fn runCheckGates(cx: ElabCx) {
     runPodShapeGate(cx)
     runPrivilegeGate(cx)
     runNoAllocGate(cx)
+    runPureGate(cx)
 }
 
 // ---------------------------------------------------------------------
@@ -1113,4 +1119,323 @@ fn containsInterpolation(text: String) -> Bool {
 
 fn checkGateStringListLen(xs: List<String>) -> Int {
     xs.len()
+}
+
+// ---------------------------------------------------------------------
+// E0775 — `#[pure]` body discipline (v0.6 A13).
+//
+// `#[pure]` is not just an optimization hint: the LLVM backend lowers it
+// to `readnone`. The body must therefore be side-effect free. This gate is
+// intentionally file-local for calls, matching `#[no_alloc]`: a direct call
+// is accepted only when the target function/method in this file is also
+// annotated `#[pure]`. Unknown function values and external calls are
+// rejected instead of silently trusting them.
+// ---------------------------------------------------------------------
+
+fn runPureGate(cx: ElabCx) {
+    let arena = cx.ast.arena
+    let pureNames = collectPureFnNames(arena)
+    if pureNames.len() == 0 {
+        return
+    }
+    for declIdx in arena.decls {
+        let node = astArenaNodeAt(arena, declIdx)
+        match node.kind {
+            AstNFnDecl -> pureCheckFn(cx, arena, node, pureNames),
+            AstNStructDecl -> pureCheckMethods(cx, arena, node, pureNames),
+            AstNEnumDecl -> pureCheckMethods(cx, arena, node, pureNames),
+            _ -> {},
+        }
+    }
+}
+
+fn collectPureFnNames(arena: AstArena) -> List<String> {
+    let mut out: List<String> = []
+    for declIdx in arena.decls {
+        let node = astArenaNodeAt(arena, declIdx)
+        if node.kind == AstNFnDecl {
+            if fnHasPureAnnotationAndBody(arena, node) {
+                out.push(node.text)
+            }
+        } else if node.kind == AstNStructDecl || node.kind == AstNEnumDecl {
+            for memberIdx in node.children {
+                let member = astArenaNodeAt(arena, memberIdx)
+                if member.kind == AstNFnDecl && fnHasPureAnnotationAndBody(arena, member) {
+                    out.push(member.text)
+                }
+            }
+        }
+    }
+    out
+}
+
+fn fnHasPureAnnotationAndBody(arena: AstArena, fn_: AstNode) -> Bool {
+    if fn_.right < 0 {
+        return false
+    }
+    checkGateAnnotationContains(arena, fn_.extra, "pure")
+}
+
+fn pureCheckFn(cx: ElabCx, arena: AstArena, fn_: AstNode, pureNames: List<String>) {
+    if !fnHasPureAnnotationAndBody(arena, fn_) {
+        return
+    }
+    let mut locals: List<String> = []
+    for paramIdx in fn_.children {
+        let param = astArenaNodeAt(arena, paramIdx)
+        if param.kind == AstNParam && param.text != "self" && param.text != "" {
+            locals.push(param.text)
+        }
+    }
+    pureWalkBlock(cx, arena, fn_.right, fn_.text, pureNames, locals)
+}
+
+fn pureCheckMethods(cx: ElabCx, arena: AstArena, parent: AstNode, pureNames: List<String>) {
+    for memberIdx in parent.children {
+        let member = astArenaNodeAt(arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            pureCheckFn(cx, arena, member, pureNames)
+        }
+    }
+}
+
+fn pureWalkBlock(cx: ElabCx, arena: AstArena, blockIdx: Int, fnName: String, pureNames: List<String>, locals: List<String>) {
+    if blockIdx < 0 {
+        return
+    }
+    let node = astArenaNodeAt(arena, blockIdx)
+    if node.kind != AstNBlock {
+        pureWalkExpr(cx, arena, blockIdx, fnName, pureNames, locals)
+        return
+    }
+    for stmtIdx in node.children {
+        pureWalkExpr(cx, arena, stmtIdx, fnName, pureNames, locals)
+    }
+}
+
+fn pureEmit(cx: ElabCx, fnName: String, what: String, fixHint: String, start: Int, end: Int) {
+    cx.env.diagnostics.push(diagPureViolation(fnName, what, fixHint, start, end))
+}
+
+fn pureWalkExpr(cx: ElabCx, arena: AstArena, idx: Int, fnName: String, pureNames: List<String>, locals: List<String>) {
+    if idx < 0 {
+        return
+    }
+    let node = astArenaNodeAt(arena, idx)
+    match node.kind {
+        AstNList -> {
+            pureEmit(cx, fnName, "allocate a list literal", "remove `#[pure]`, pass in precomputed data, or rewrite without managed allocation", node.start, node.end)
+            for elIdx in node.children {
+                pureWalkExpr(cx, arena, elIdx, fnName, pureNames, locals)
+            }
+        },
+        AstNMap -> {
+            pureEmit(cx, fnName, "allocate a map literal", "remove `#[pure]`, pass in precomputed data, or rewrite without managed allocation", node.start, node.end)
+            for entryIdx in node.children {
+                let entry = astArenaNodeAt(arena, entryIdx)
+                pureWalkExpr(cx, arena, entry.left, fnName, pureNames, locals)
+                pureWalkExpr(cx, arena, entry.right, fnName, pureNames, locals)
+            }
+        },
+        AstNStructLit -> {
+            pureEmit(cx, fnName, "allocate a struct literal", "return scalar data or drop `#[pure]` until the value construction can be proven allocation-free", node.start, node.end)
+            for fieldIdx in node.children {
+                let field = astArenaNodeAt(arena, fieldIdx)
+                pureWalkExpr(cx, arena, field.left, fnName, pureNames, locals)
+            }
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNClosure -> {
+            pureEmit(cx, fnName, "allocate a closure", "closures capture an environment; use a direct `#[pure]` helper function instead", node.start, node.end)
+        },
+        AstNStringLit -> {
+            if isAllocatingStringText(node.text) {
+                let what = classifyAllocatingString(node.text)
+                pureEmit(cx, fnName, what, "only plain `\"...\"` literals are accepted in `#[pure]` bodies", node.start, node.end)
+            }
+        },
+        AstNCall -> {
+            if !pureCalleeAllowed(arena, node.left, pureNames) {
+                let what = if pureCalleeLooksLikeIO(arena, node.left) {
+                    "perform I/O"
+                } else {
+                    "call a function that is not `#[pure]`"
+                }
+                pureEmit(cx, fnName, what, "mark the callee `#[pure]` only if it is side-effect free, or remove `#[pure]` from this function", node.start, node.end)
+            }
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            for argIdx in node.children {
+                pureWalkExpr(cx, arena, argIdx, fnName, pureNames, locals)
+            }
+        },
+        AstNAssign -> {
+            if !pureAssignTargetLocal(arena, node.left, locals) {
+                pureEmit(cx, fnName, "write non-local state", "only assignment to local bindings declared inside the `#[pure]` function is allowed", node.start, node.end)
+            }
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNChanSend -> {
+            pureEmit(cx, fnName, "send on a channel", "channel sends are observable side effects; remove `#[pure]`", node.start, node.end)
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNDefer -> {
+            pureEmit(cx, fnName, "register a deferred effect", "defer runs code after the function returns and is not allowed in `#[pure]` bodies", node.start, node.end)
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+        },
+        AstNLet -> {
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNBlock -> {
+            let mut scopedLocals = locals
+            for stmtIdx in node.children {
+                let stmt = astArenaNodeAt(arena, stmtIdx)
+                pureWalkExpr(cx, arena, stmtIdx, fnName, pureNames, scopedLocals)
+                if stmt.kind == AstNLet {
+                    scopedLocals = pureAddPatternBindings(arena, stmt.left, scopedLocals)
+                }
+            }
+        },
+        AstNExprStmt -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNReturn -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNFor -> {
+            let loopLocals = pureAddPatternBindings(arena, node.left, locals)
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            if node.children.len() >= 2 {
+                pureWalkExpr(cx, arena, node.children[1], fnName, pureNames, locals)
+            }
+            pureWalkBlock(cx, arena, node.right, fnName, pureNames, loopLocals)
+        },
+        AstNIf -> {
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+            if node.children.len() > 0 {
+                pureWalkExpr(cx, arena, node.children[0], fnName, pureNames, locals)
+            }
+        },
+        AstNMatch -> {
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            for armIdx in node.children {
+                let arm = astArenaNodeAt(arena, armIdx)
+                if arm.kind == AstNMatchArm {
+                    let armLocals = pureAddPatternBindings(arena, arm.left, locals)
+                    if arm.children.len() > 0 {
+                        pureWalkExpr(cx, arena, arm.children[0], fnName, pureNames, armLocals)
+                    }
+                    pureWalkExpr(cx, arena, arm.right, fnName, pureNames, armLocals)
+                }
+            }
+        },
+        AstNUnary -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNBinary -> {
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNQuestion -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNField -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNIndex -> {
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNRange -> {
+            pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals)
+            pureWalkExpr(cx, arena, node.right, fnName, pureNames, locals)
+        },
+        AstNParen -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNTurbofish -> pureWalkExpr(cx, arena, node.left, fnName, pureNames, locals),
+        AstNTuple -> {
+            for elIdx in node.children {
+                pureWalkExpr(cx, arena, elIdx, fnName, pureNames, locals)
+            }
+        },
+        _ -> {},
+    }
+}
+
+fn pureAssignTargetLocal(arena: AstArena, targetIdx: Int, locals: List<String>) -> Bool {
+    if targetIdx < 0 {
+        return false
+    }
+    let target = astArenaNodeAt(arena, targetIdx)
+    if target.kind == AstNIdent {
+        return listContainsString(locals, target.text)
+    }
+    false
+}
+
+fn pureCalleeAllowed(arena: AstArena, calleeIdx: Int, pureNames: List<String>) -> Bool {
+    if calleeIdx < 0 {
+        return false
+    }
+    let callee = astArenaNodeAt(arena, calleeIdx)
+    if callee.kind == AstNIdent {
+        return listContainsString(pureNames, callee.text)
+    }
+    if callee.kind == AstNField {
+        return listContainsString(pureNames, callee.text)
+    }
+    if callee.kind == AstNTurbofish {
+        return pureCalleeAllowed(arena, callee.left, pureNames)
+    }
+    false
+}
+
+fn pureCalleeLooksLikeIO(arena: AstArena, calleeIdx: Int) -> Bool {
+    let name = pureCalleeLastName(arena, calleeIdx)
+    name == "print"
+        || name == "println"
+        || name == "eprint"
+        || name == "eprintln"
+        || name == "read"
+        || name == "readAll"
+        || name == "readToString"
+        || name == "write"
+        || name == "writeAll"
+        || name == "open"
+        || name == "create"
+}
+
+fn pureCalleeLastName(arena: AstArena, calleeIdx: Int) -> String {
+    if calleeIdx < 0 {
+        return ""
+    }
+    let callee = astArenaNodeAt(arena, calleeIdx)
+    if callee.kind == AstNIdent || callee.kind == AstNField {
+        return callee.text
+    }
+    if callee.kind == AstNTurbofish {
+        return pureCalleeLastName(arena, callee.left)
+    }
+    ""
+}
+
+fn pureAddPatternBindings(arena: AstArena, patIdx: Int, locals: List<String>) -> List<String> {
+    let mut out = locals
+    pureCollectPatternBindings(arena, patIdx, out)
+    out
+}
+
+fn pureCollectPatternBindings(arena: AstArena, patIdx: Int, out: List<String>) {
+    if patIdx < 0 {
+        return
+    }
+    let pat = astArenaNodeAt(arena, patIdx)
+    if pat.kind != AstNPattern {
+        return
+    }
+    if pat.extra == astPatternIdentKind() || pat.extra == astPatternBindingKind() {
+        if pat.text != "_" && pat.text != "" && !(listContainsString(out, pat.text)) {
+            out.push(pat.text)
+        }
+    }
+    if pat.left >= 0 {
+        pureCollectPatternBindings(arena, pat.left, out)
+    }
+    if pat.right >= 0 {
+        pureCollectPatternBindings(arena, pat.right, out)
+    }
+    for childIdx in pat.children {
+        pureCollectPatternBindings(arena, childIdx, out)
+    }
 }

--- a/toolchain/check_test.osty
+++ b/toolchain/check_test.osty
@@ -200,6 +200,50 @@ fn sawDiagnosticWithNote(result: FrontCheckResult, code: String, note: String) -
     false
 }
 
+fn sawDiagnosticCode(result: FrontCheckResult, code: String) -> Bool {
+    for d in result.diagnostics {
+        if d.code == code {
+            return true
+        }
+    }
+    false
+}
+
+fn testSelfCheckerRejectsImpurePureFunctionBodies() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn impure() -> Int { 1 }
+
+            #[pure]
+            fn bad() -> Int {
+                let xs = [1]
+                impure()
+            }
+            """,
+    )
+
+    testing.assert(checked.summary.errors > 0)
+    testing.assert(sawDiagnosticCode(checked, "E0775"))
+}
+
+fn testSelfCheckerAllowsPureCallsAndLocalMutationInPureFunction() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            #[pure]
+            fn mix(a: Int, b: Int) -> Int { a * 31 + b }
+
+            #[pure]
+            fn caller(a: Int, b: Int) -> Int {
+                let mut acc = 0
+                acc = acc + mix(a, b)
+                acc
+            }
+            """,
+    )
+
+    testing.assertEq(checked.summary.errors, 0)
+}
+
 fn testSelfCheckerReportsAssignmentReturnAndCallErrors() {
     let checked = frontendCheckSource(
         r"""

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -143,12 +143,13 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "E0554" { return FamilyResolution }
     // Annotations — cfg (E0405)
     if code == "E0405" { return FamilyAnnotation }
-    // Runtime sublanguage (E0771–E0774)
+    // Runtime sublanguage (E0771–E0775)
     if code == "E0771" { return FamilyTypeChecking }
     if code == "E0770" { return FamilyTypeChecking }
     if code == "E0772" { return FamilyTypeChecking }
     if code == "E0773" { return FamilyTypeChecking }
     if code == "E0774" { return FamilyTypeChecking }
+    if code == "E0775" { return FamilyTypeChecking }
     // Manifest — TOML syntax (E2000–E2004)
     if code == "E2000" { return FamilyManifest }
     if code == "E2001" { return FamilyManifest }

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -743,6 +743,7 @@ fn srAstCollectDecl(
                 out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetMethod(), out)
             }
         }
+        out = srCheckDuplicateVariantJSONTags(file, idx, out)
     } else if node.kind == AstNLet {
         let names = srAstPatternNames(file, node.left, [])
         for item in names {
@@ -3122,6 +3123,89 @@ fn srJsonFieldTypeAllowsOptional(file: AstFile, typeIdx: Int) -> Bool {
     }
     let parts = strings.split(t.text, ".")
     parts.len() == 1 && t.text == "Option"
+}
+
+/// srJsonVariantTag returns the JSON tag for a variant node, or None if
+/// the variant has `#[json(skip)]`. Mirrors
+/// internal/resolve/resolve.go::jsonVariantTag.
+fn srJsonVariantTag(file: AstFile, variantIdx: Int) -> Option<String> {
+    let node = srAstNode(file, variantIdx)
+    let mut tag = node.text
+    let mut skipped = false
+    if node.extra >= 0 {
+        let anns = srCollectAnnotationNodes(file, node.extra)
+        for ann in anns {
+            if ann.text != "json" {
+                continue
+            }
+            for argIdx in ann.children {
+                let view = srAnnotArgView(file, argIdx)
+                if view.key == "key" {
+                    if srIsStringLitAtIdx(file, view.valueIdx) {
+                        tag = srAstNode(file, view.valueIdx).text
+                    }
+                } else if view.key == "skip" {
+                    skipped = true
+                }
+            }
+        }
+    }
+    if skipped { None } else { Some(tag) }
+}
+
+/// srCheckDuplicateVariantJSONTags checks for duplicate JSON tags
+/// across variants of a single enum. Mirrors
+/// internal/resolve/resolve.go::checkDuplicateVariantJSONTags.
+fn srCheckDuplicateVariantJSONTags(
+    file: AstFile,
+    enumIdx: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let node = srAstNode(file, enumIdx)
+    let mut out = result
+    let mut seenTags: List<String> = []
+    let mut seenStarts: List<Int> = []
+    let mut seenEnds: List<Int> = []
+    for memberIdx in node.children {
+        let member = srAstNode(file, memberIdx)
+        if member.kind != AstNVariant {
+            continue
+        }
+        let tagOpt = srJsonVariantTag(file, memberIdx)
+        if tagOpt == None {
+            continue
+        }
+        let tag = match tagOpt { Some(t) -> t, None -> "" }
+        let mut dup = false
+        for i in 0..seenTags.len() {
+            if seenTags[i] == tag {
+                dup = true
+                out.diagnostics.push(selfResolveDiagnostic(
+                    "E0501",
+                    "enum `{node.text}` has duplicate JSON tag `{tag}`",
+                    "",
+                    member.start,
+                    member.end,
+                ))
+                out.diagnostics.push(selfResolveDiagnosticHintAtNode(
+                    "E0501",
+                    "previous JSON tag here",
+                    "",
+                    seenStarts[i],
+                    seenEnds[i],
+                    -1,
+                    "",
+                ))
+                break
+            }
+        }
+        if !dup {
+            seenTags.push(tag)
+            seenStarts.push(member.start)
+            seenEnds.push(member.end)
+        }
+    }
+    out
 }
 
 fn srCheckDeprecatedArgs(


### PR DESCRIPTION
## Summary
- enforce `#[pure]` body purity with E0775 diagnostics for allocation, impure calls, I/O, and non-local writes
- mirror the purity gate through the selfhost arena adapter and add checker coverage
- refresh stdlib json/csv behavior docs and repair-check stability fixes surfaced by prepush

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)