### PR TITLE
refactor: make osty resolver authoritative

### DIFF
--- a/SELFHOST_PORT_MATRIX.md
+++ b/SELFHOST_PORT_MATRIX.md
@@ -267,10 +267,12 @@ regression 없음을 확인하고 이 문서의 ⏳ → ✅ 전환. **2026-04-26
 embedded adapter / 아직 포팅되지 않은 consumer shape 를 담당한다:
 
 - **Resolver**
-  - `internal/resolve/workspace.go::LoadPackage` → Go-native resolver helper
-    (CLI check/typecheck/resolve happy path 아님; 삭제 대상)
+  - `internal/resolve/workspace.go::LoadPackage` → arena-first alias over
+    `LoadPackageNative` (Go parser/resolver-specific load path retired)
   - `internal/resolve/workspace_native.go::LoadPackageNative` → `selfhost.LowerPublicFileFromRun`
   - `internal/resolve/native_adapter.go` → `selfhost.ResolvePackageStructured` (Osty `resolve.osty` 구동)
+  - `internal/resolve/workspace.go::ResolveAll` → per-package native resolve bridge
+    + cycle-diag stitching (Go 2-pass resolve walk retired)
 - **Checker** (`toolchain/README.md`에 문서화됨)
   - `internal/check/host_boundary.go::nativeCheckerExec` → 외부 `osty-native-checker`
   - `embeddedNativeChecker` → `selfhost.CheckPackageStructured` (Osty `check.osty` + `elab.osty` 구동)
@@ -316,8 +318,8 @@ embedded adapter / 아직 포팅되지 않은 consumer shape 를 담당한다:
 | Closure scope isolation | `internal/resolve/resolve.go:900` | `toolchain/resolve.osty:1124` | E0605, E0606 | ported | inLoop 리셋 |
 | **Partial struct/enum merge** | `internal/resolve/merge.go:47` | `toolchain/resolve.osty::srHandlePartialType` | E0501 (R19 variants) | **partial** | 2026-04-23 Osty 측 `SelfPartialDecl` + R19 검증기 (pub/generics/fields/method dup) 착륙. 현재 single-file 범위만; cross-file stitching 은 workspace pass 모델 생기면 확장 |
 | **Workspace cycle detection** | `internal/resolve/workspace.go:468` | `toolchain/resolve.osty::selfDetectImportCycles` | E0506 | **ported** | 2026-04-23 DFS (tri-state colour) Osty 이식, Go 쪽은 그래프 prep + token.Pos 복원 + diag 렌더링 glue 만 남음 |
-| **Workspace 2-pass (declare/body)** | `internal/resolve/workspace.go:356` | — | — | n/a | 호스트 경계 — `internal/selfhost/workspace_driver.go` 쪽에서 담당 |
-| **#[cfg] 사전 필터** | `internal/resolve/cfg.go:69` | `toolchain/resolve.osty::srCfgDeclPasses` | E0405, E0739 | **partial** | 2026-04-22 native 경로 Osty 구동 (srCfgDeclPasses + selfResolveAstFileWithCfg). Go `cfg.go` 는 레거시 `ResolveAll` 에 남아있음 — 레거시 retire 시 제거 |
+| **Workspace package dispatch** | `internal/resolve/workspace.go::ResolveAll` | `toolchain/resolve.osty` (per-package via `ResolvePackageStructured`) | — | **ported** | 2026-04-28 workspace가 Go declare/body pass 대신 package별 native resolve bridge + cycle stitching 으로 전환 |
+| **#[cfg] 사전 필터** | `internal/resolve/native_adapter.go:nativeCfgEnvFor` | `toolchain/resolve.osty::srCfgDeclPasses` | E0405, E0739 | **ported** | 2026-04-28 workspace/package 모두 selfhost cfg 필터 경로만 사용. `cfg.go` 는 AST-only compatibility fallback 전용 잔여 |
 | **Cross-package member lookup (E0507/E0508)** | `internal/resolve/resolve.go:420::lookupPackageMember` | `toolchain/resolve.osty::selfLookupPackageMember` + `SelfMemberLookupResult` | E0507, E0508 | **ported** | 2026-04-24 Osty 가 wording (message/primary/note/hint) 단일 소스. Go `lookupPackageMember` 는 Scope lookup 만 수행 후 `selfhost.LookupPackageMember(pkgName, member, typePos, found, public)` 로 분기. status 0/1/2 → OK/Private(E0507)/Missing(E0508). `pub use` 체인 traversal (E0553) 은 별도 |
 | **`pub use` re-export visibility (E0553)** | — | — | E0553 | **go-only (silent)** | `resolve.go:368-390` pub 재노출만 기록; 소스가 private 인데 re-export 하는 케이스 진단 없음. Phase 2.2+ follow-up — workspace pub-symbol graph 필요 |
 | **Runtime privilege gate (E0770)** | `internal/check/privilege.go` (47 LOC 잔존, `isPrivilegedPackage[Path]` helper) | `toolchain/check_gates.osty::runCheckGates` | E0770 | **ported** | 2026-04-23 consolidation. 상세는 Checker 매트릭스 "Privilege system" row 참조 |
@@ -327,7 +329,7 @@ embedded adapter / 아직 포팅되지 않은 consumer shape 를 담당한다:
 
 ### Resolver 포팅 우선순위
 
-1. ~~**`#[cfg]` 사전 필터** (E0405)~~ — **착륙 2026-04-22**. `toolchain/resolve.osty` 의 `srCfgDeclPasses` + `selfResolveAstFileWithCfg` + `srCheckCfgArgs` 로 이식, `PackageResolveInput.Cfg` / `ResolveSourceStructuredWithCfg` 로 bridge. native 경로는 `workspace.cfgEnv` / `DefaultCfgEnv()` 자동 상속. 레거시 `internal/resolve/cfg.go` 는 `ResolveAll` 경로가 살아있는 동안 유지.
+1. ~~**`#[cfg]` 사전 필터** (E0405)~~ — **착륙 2026-04-22**, **workspace 전환 2026-04-28**. `toolchain/resolve.osty` 의 `srCfgDeclPasses` + `selfResolveAstFileWithCfg` + `srCheckCfgArgs` 로 이식, `PackageResolveInput.Cfg` / `ResolveSourceStructuredWithCfg` 로 bridge. native 경로는 `workspace.cfgEnv` / `DefaultCfgEnv()` 자동 상속. `internal/resolve/cfg.go` 는 AST-only compatibility fallback 에만 남음.
 2. ~~**Partial struct/enum merge** (E0509/E0501)~~ — **착륙 2026-04-23**. `SelfPartialDecl` 트래커 + `srHandlePartialType`, R19 4 invariants (pub / generics / fields-in-one / method name uniqueness) 검증. 현재는 single-file (native_adapter 가 `ResolvePackageStructured` 로 다중 파일을 synthetic 단일 네임스페이스로 합쳐 통과). True cross-file stitching 은 workspace 모델 등장 이후.
 3. ~~**Workspace cycle detection** (E0506)~~ — **착륙 2026-04-23**. `selfDetectImportCycles` + `SelfWorkspaceUses` / `SelfPackageUses` / `SelfUseEdge` / `SelfCycleDiag` (toolchain/resolve.osty). `selfhost.DetectImportCycles` Go bridge. `internal/resolve/workspace.go::detectCycles` 는 그래프 준비 + offset 기반 roundtrip 후 `token.Pos` 복원 + 진단 렌더링 glue 만 남김. 알고리즘 (DFS 3-상태 색칠) 은 완전히 Osty 쪽.
 4. ~~**Cross-package member lookup (E0507/E0508)**~~ — **착륙 2026-04-24**. `selfLookupPackageMember` + `SelfMemberLookupResult` 가 wording 단일 소스. Go `lookupPackageMember` 는 Scope lookup 후 bridge 로 분기. `pub use` 재노출 체인 (E0553) 은 workspace pub-symbol graph 가 별도로 필요해 다음 우선순위로 분리.

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -186,7 +186,7 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 func runLintFile(path string, src []byte, formatter *diag.Formatter, flags cliFlags, lintCfg lint.Config, lintCfgOk bool) int {
 	parsed := parser.ParseDetailed(src)
 	file, parseDiags := parsed.File, parsed.Diagnostics
-	res := resolveFile(file)
+	res := resolveFile(src, file)
 	chk := check.SelfhostFile(file, res, checkOptsForFile(path, canonical.Source(src, file)))
 	lr := runLintEngine(file, src, res, chk)
 	if lintCfgOk {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -998,8 +998,8 @@ func isTraceableSingleFileCmd(cmd string) bool {
 // resolveFile runs single-file name resolution with the cached stdlib
 // registry attached. Collapses what would otherwise be a three-line
 // incantation in every single-file subcommand.
-func resolveFile(file *ast.File) *resolve.Result {
-	return resolve.ResolveFileDefault(file, stdlib.LoadCached())
+func resolveFile(src []byte, file *ast.File) *resolve.Result {
+	return resolve.ResolveFileSourceDefault(src, file, stdlib.LoadCached())
 }
 
 // checkOpts builds the check.Opts every subcommand passes to the type

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -109,7 +109,7 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 	}
 	ensureGoResolve := func() *resolve.Result {
 		if res == nil {
-			res = resolveFile(ensureLoweredFile())
+			res = resolveFile(src, ensureLoweredFile())
 		}
 		return res
 	}

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -698,7 +698,7 @@ func prepareNativeTestBackendEntry(sourcePath string, pkg *resolve.Package) (bac
 	if err != nil {
 		return backend.Entry{}, err
 	}
-	res := resolveFile(file)
+	res := resolveFile(src, file)
 	chk := check.SelfhostFile(file, res, checkOptsForSource(src))
 	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
 	if err != nil {

--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -397,7 +397,7 @@ func validLengthFieldOffsets(src []byte) map[int]bool {
 	if parsed.File == nil {
 		return nil
 	}
-	res := resolve.ResolveFileDefault(parsed.File, stdlib.LoadCached())
+	res := resolve.ResolveFileSourceDefault(src, parsed.File, stdlib.LoadCached())
 	chk := check.SelfhostFile(parsed.File, res, checkOptsForSource(canonical.Source(src, parsed.File)))
 	if chk == nil {
 		return nil

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -456,7 +456,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 
 	// --- resolve ---
 	t0 = time.Now()
-	res := resolve.ResolveFileDefault(file, stdlib.LoadCached())
+	res := resolve.ResolveFileSourceDefault(src, file, stdlib.LoadCached())
 	r.Resolve = res
 	r.AllDiags = append(r.AllDiags, res.Diags...)
 	emit(Stage{

--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
 )
 
@@ -193,5 +194,99 @@ func TestNativeDiagnosticsSingleFile(t *testing.T) {
 	}
 	if pos := got.PrimaryPos(); pos.Line != 2 || pos.Column != 5 {
 		t.Fatalf("primary pos = %v, want 2:5", pos)
+	}
+}
+
+func TestResolveFileDefaultDefinesStdlibPackageAlias(t *testing.T) {
+	src := []byte(`use std.fs
+
+fn main() {
+    let _ = fs.readToString("demo.txt")
+}
+`)
+	file, diags := parser.ParseDiagnostics(src)
+	if len(diags) != 0 {
+		t.Fatalf("parse diagnostics = %#v, want none", diags)
+	}
+	pkgScope := NewScope(NewPrelude(), "package:std.fs")
+	pkgScope.DefineForce(&Symbol{Name: "readToString", Kind: SymFn, Pub: true})
+	reg := stubStdlibProvider{
+		"std.fs": &Package{Name: "fs", PkgScope: pkgScope},
+	}
+	res := ResolveFileSourceDefault(src, file, reg)
+	if res.FileScope == nil {
+		t.Fatal("FileScope = nil, want populated scope")
+	}
+	sym := res.FileScope.Lookup("fs")
+	if sym == nil {
+		t.Fatal("FileScope.Lookup(\"fs\") = nil, want package alias")
+	}
+	if sym.Kind != SymPackage {
+		t.Fatalf("fs kind = %v, want SymPackage", sym.Kind)
+	}
+	if sym.Package == nil || sym.Package.PkgScope == nil {
+		t.Fatalf("fs package = %#v, want resolved stdlib package", sym.Package)
+	}
+}
+
+type stubStdlibProvider map[string]*Package
+
+func (s stubStdlibProvider) LookupPackage(dotPath string) *Package {
+	return s[dotPath]
+}
+
+func TestWorkspaceResolveAllDefinesPackageAliases(t *testing.T) {
+	root := t.TempDir()
+	alphaDir := filepath.Join(root, "alpha")
+	betaDir := filepath.Join(root, "beta")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(betaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alphaFile := filepath.Join(alphaDir, "lib.osty")
+	betaFile := filepath.Join(betaDir, "lib.osty")
+	if err := os.WriteFile(alphaFile, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(betaFile, []byte(`use alpha
+
+fn main() {
+    let _ = alpha.helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	for _, path := range WorkspacePackagePaths(root) {
+		if _, err := ws.LoadPackage(path); err != nil {
+			t.Fatalf("LoadPackage %s: %v", path, err)
+		}
+	}
+	results := ws.ResolveAll()
+	beta := ws.Packages["beta"]
+	if beta == nil || len(beta.Files) == 0 {
+		t.Fatalf("beta package = %#v, want loaded package with files", beta)
+	}
+	if got := results["beta"]; got == nil || len(got.Diags) != 0 {
+		t.Fatalf("beta diagnostics = %#v, want none", got)
+	}
+	sym := beta.Files[0].FileScope.Lookup("alpha")
+	if sym == nil {
+		t.Fatal("FileScope.Lookup(\"alpha\") = nil, want imported package symbol")
+	}
+	if sym.Kind != SymPackage {
+		t.Fatalf("alpha kind = %v, want SymPackage", sym.Kind)
+	}
+	if sym.Package == nil || sym.Package.PkgScope == nil {
+		t.Fatalf("alpha package = %#v, want linked package scope", sym.Package)
+	}
+	if helper := sym.Package.PkgScope.LookupLocal("helper"); helper == nil || !helper.Pub {
+		t.Fatalf("alpha helper = %#v, want exported function in target scope", helper)
 	}
 }

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -89,21 +89,26 @@ func newStdlibOnlyWorkspace(stdlib StdlibProvider) *Workspace {
 // Existing parser diagnostics on each file are also merged into the
 // returned Diags list.
 //
-// This is a convenience wrapper that performs both the declaration pass
-// and the body pass in sequence. Workspace.ResolveAll runs the two
-// passes across every package separately so that cross-package member
-// lookups succeed regardless of iteration order.
+// The authoritative execution path is the selfhost resolver
+// (`toolchain/resolve.osty`) projected back onto Go's PackageResult /
+// Scope / Symbol shapes. A Go-native fallback remains only for callers
+// that provide an AST without source bytes (see ResolveFileDefault).
 func ResolvePackage(pkg *Package, prelude *Scope) *PackageResult {
-	if canResolveViaNative(pkg) {
-		return resolvePackageViaNative(pkg, prelude)
+	if pkg == nil {
+		return &PackageResult{}
 	}
-	r := newPkgResolver(pkg, prelude)
-	r.declarePass(pkg)
-	r.bodyPass(pkg)
-	return &PackageResult{
-		PackageScope: pkg.PkgScope,
-		Diags:        r.diags,
+	if !canResolveViaNative(pkg) {
+		r := newPkgResolver(pkg, prelude)
+		r.declarePass(pkg)
+		r.bodyPass(pkg)
+		return &PackageResult{
+			PackageScope: pkg.PkgScope,
+			Diags:        r.diags,
+		}
 	}
+	pkg.EnsureFiles()
+	pkg.MaterializeCanonicalSources()
+	return resolvePackageViaNative(pkg, prelude)
 }
 
 func canResolveViaNative(pkg *Package) bool {
@@ -2329,8 +2334,38 @@ func ResolvePackageDefault(pkg *Package) *PackageResult {
 }
 
 // ResolveFileDefault runs single-file name resolution using the
-// standard prelude and the given stdlib provider. It is the
-// one-call replacement for FileWithStdlib(file, NewPrelude(), stdlib).
+// standard prelude and the given stdlib provider. This AST-only API keeps the
+// legacy Go fallback for callers that no longer have source bytes; new
+// single-file entry points should prefer ResolveFileSourceDefault so the
+// selfhost resolver remains authoritative.
 func ResolveFileDefault(file *ast.File, stdlib StdlibProvider) *Result {
 	return fileWithStdlib(file, NewPrelude(), stdlib)
+}
+
+// ResolveFileSourceDefault runs single-file resolution from source bytes and the
+// already-parsed AST, using the selfhost resolver as the source of truth while
+// still projecting refs and scopes back onto the Go AST.
+func ResolveFileSourceDefault(src []byte, file *ast.File, stdlib StdlibProvider) *Result {
+	pkg := &Package{
+		Name: "<file>",
+		Files: []*PackageFile{{
+			Path:            "<input>",
+			Source:          append([]byte(nil), src...),
+			CanonicalSource: append([]byte(nil), src...),
+			File:            file,
+		}},
+	}
+	if stdlib != nil {
+		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
+	}
+	pr := ResolvePackage(pkg, NewPrelude())
+	pf := pkg.Files[0]
+	return &Result{
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
+		Diags:         pr.Diags,
+	}
 }

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -23,6 +23,16 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 	}
 
 	pkgScope := NewScope(prelude, "package:"+pkg.Name)
+	diags := nativeParseDiagnostics(pkg)
+	for _, pf := range pkg.Files {
+		if pf.File == nil || len(pf.Source) == 0 && len(pf.CanonicalSource) == 0 {
+			continue
+		}
+		fi := nativeResolveFileInfoFor(files, pf.Path)
+		declIdx := buildDeclIndex(pf.File)
+		defineTopLevelSymbols(pkgScope, result.Symbols, fi, declIdx)
+	}
+
 	for _, pf := range pkg.Files {
 		if pf.File == nil || len(pf.Source) == 0 && len(pf.CanonicalSource) == 0 {
 			continue
@@ -31,23 +41,138 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 		identIdx := buildIdentIndex(pf.File)
 		typeIdx := buildNamedTypeIndex(pf.File)
 		declIdx := buildDeclIndex(pf.File)
-
-		defineTopLevelSymbols(pkgScope, result.Symbols, fi, declIdx)
+		fileScope := NewScope(pkgScope, "file:"+pf.Path)
+		nativeDeclareUses(fileScope, pkgScope, pkg, pf, &diags)
 
 		refsByID, refIdents := bridgeRefs(result.Refs, fi, identIdx, declIdx)
 		pf.RefsByID = refsByID
 		pf.RefIdents = refIdents
 
-		typeRefsByID, typeRefIdents := bridgeTypeRefs(result.TypeRefs, fi, typeIdx, pkgScope)
+		typeRefsByID, typeRefIdents := bridgeTypeRefs(result.TypeRefs, fi, typeIdx, fileScope)
 		pf.TypeRefsByID = typeRefsByID
 		pf.TypeRefIdents = typeRefIdents
 
-		pf.FileScope = NewScope(pkgScope, "file:"+pf.Path)
+		pf.FileScope = fileScope
 	}
 	pkg.PkgScope = pkgScope
 
-	diags := nativeResolveDiagnosticsFromArtifacts(result, files)
+	diags = append(diags, nativeResolveDiagnosticsFromArtifacts(result, files)...)
 	return &PackageResult{PackageScope: pkgScope, Diags: diags}
+}
+
+func nativeParseDiagnostics(pkg *Package) []*diag.Diagnostic {
+	if pkg == nil {
+		return nil
+	}
+	var out []*diag.Diagnostic
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		for _, d := range pf.ParseDiags {
+			if d == nil {
+				continue
+			}
+			clone := *d
+			if clone.File == "" {
+				clone.File = pf.Path
+			}
+			out = append(out, &clone)
+		}
+	}
+	return out
+}
+
+func nativeDeclareUses(fileScope, pkgScope *Scope, pkg *Package, pf *PackageFile, diags *[]*diag.Diagnostic) {
+	if pf == nil || pf.File == nil || fileScope == nil {
+		return
+	}
+	for _, u := range pf.File.Uses {
+		name := nativeUseAlias(u)
+		if name == "" {
+			continue
+		}
+		sym := &Symbol{
+			Name: name,
+			Kind: SymPackage,
+			Pos:  u.PosV,
+			Decl: u,
+			Pub:  u.IsPub,
+		}
+		if !u.IsFFI() && pkg != nil && pkg.workspace != nil {
+			targetPath := UseKey(u)
+			target, d := pkg.workspace.ResolveUseTarget(targetPath, u.PosV)
+			if d != nil && diags != nil {
+				*diags = append(*diags, d)
+			}
+			if target != nil && !target.isCycleMarker {
+				sym.Package = target
+			}
+		}
+		if prev, ok := fileScope.Define(sym); !ok {
+			if diags != nil {
+				*diags = append(*diags, duplicateSymbolDiag(u.PosV, name, prev, pf.Path))
+			}
+			continue
+		}
+		if u.IsPub && pkgScope != nil && pkgScope != fileScope {
+			pkgSym := &Symbol{
+				Name:    sym.Name,
+				Kind:    sym.Kind,
+				Pos:     sym.Pos,
+				Decl:    sym.Decl,
+				Pub:     sym.Pub,
+				Package: sym.Package,
+			}
+			if _, ok := pkgScope.Define(pkgSym); !ok {
+				// Re-export collisions remain intentionally silent until the
+				// workspace-level E0553 pass lands.
+			}
+		}
+	}
+}
+
+func nativeUseAlias(u *ast.UseDecl) string {
+	if u == nil {
+		return ""
+	}
+	if u.Alias != "" {
+		return u.Alias
+	}
+	if u.IsFFI() {
+		name := lastSeg(u.FFIPath(), '/')
+		return lastSeg(name, '.')
+	}
+	if u.RawPath != "" && lastSeg(u.RawPath, '/') != u.RawPath {
+		if name := lastSeg(u.RawPath, '/'); name != "" {
+			return name
+		}
+	}
+	if len(u.Path) == 0 {
+		return ""
+	}
+	return lastSeg(u.Path[len(u.Path)-1], '/')
+}
+
+func duplicateSymbolDiag(pos token.Pos, name string, prev *Symbol, file string) *diag.Diagnostic {
+	kind := SymUnknown
+	if prev != nil {
+		kind = prev.Kind
+	}
+	d := diag.New(diag.Error, fmt.Sprintf("`%s` is already defined as a %s", name, kind)).
+		Code(diag.CodeDuplicateDecl).
+		PrimaryPos(pos, "duplicate declaration here")
+	if prev != nil {
+		if prev.Pos.Line > 0 {
+			d.Secondary(diag.Span{Start: prev.Pos, End: prev.Pos}, "previous declaration here")
+		}
+	}
+	d.Hint("rename one of the declarations or remove the duplicate")
+	out := d.Build()
+	if out.File == "" {
+		out.File = file
+	}
+	return out
 }
 
 // --- Offset helpers ---

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -176,104 +176,11 @@ func NewWorkspace(root string) (*Workspace, error) {
 
 // LoadPackage loads the package identified by dotPath into the
 // workspace. If the package has already been loaded it is returned from
-// cache. The walk recursively loads any packages referenced by `use`
-// declarations so a single top-level call assembles the whole import
-// closure.
-//
-// Cycles are detected via the `loading` set and produce a
-// CodeCyclicImport diagnostic attached to the offending `use` site.
-// The cyclic package is still returned (so the caller can keep resolving
-// other parts of the tree), but its diagnostics list will contain the
-// cycle notice.
+// cache. The active implementation is arena-first and delegates to
+// LoadPackageArenaFirst so the workspace no longer has a Go-parser /
+// Go-resolver-specific loading path.
 func (w *Workspace) LoadPackage(dotPath string) (*Package, error) {
-	if pkg, ok := w.Packages[dotPath]; ok {
-		return pkg, nil
-	}
-	if w.loading[dotPath] {
-		// Caller is the cycle-detection entry; return a marker package
-		// with a cycle-note diagnostic so downstream reporting lines up.
-		return cycleMarker(dotPath), nil
-	}
-
-	// URL-style keys never live under w.Root — they route straight
-	// through the DepProvider to the vendor directory. No `stat` on
-	// a bogus path, no std-prefix branch.
-	if isURLStyle(dotPath) {
-		return w.loadExternalDep(dotPath)
-	}
-
-	dir := w.dirFor(dotPath)
-	if _, err := os.Stat(dir); err != nil {
-		if os.IsNotExist(err) && strings.HasPrefix(dotPath, StdPrefix) {
-			// Prefer a resolver-ready Package from the Stdlib provider
-			// when one is attached. The provider owns the symbol table
-			// for the module, so member access (`io.print`) validates
-			// against real `Pub` symbols rather than falling through to
-			// the opaque stub.
-			if w.Stdlib != nil {
-				if pkg := w.Stdlib.LookupPackage(dotPath); pkg != nil {
-					w.Packages[dotPath] = pkg
-					return pkg, nil
-				}
-			}
-			if w.stdlibStub {
-				// Opaque stub fallback: the package exists for resolver
-				// purposes, but there are no sources to parse. Member
-				// access is permissive so `std.fs.readFile` compiles
-				// cleanly until the stdlib provider is wired up.
-				stub := stdlibStub(dotPath)
-				w.Packages[dotPath] = stub
-				return stub, nil
-			}
-		}
-		// Bare-alias fallback: single-segment name that isn't a sibling
-		// package. Consult the DepProvider in case the package manager
-		// has vendored a matching dep.
-		if os.IsNotExist(err) && w.Deps != nil && !strings.ContainsAny(dotPath, ".") {
-			if extDir, ok := w.Deps.LookupDep(dotPath); ok {
-				return w.loadFromExternalDir(dotPath, extDir)
-			}
-		}
-		return nil, fmt.Errorf("package %q: %w", dotPath, err)
-	}
-
-	w.loading[dotPath] = true
-	defer delete(w.loading, dotPath)
-
-	pkg, err := LoadPackageWithTransform(dir, w.SourceTransform)
-	if err != nil {
-		return nil, err
-	}
-	pkg.Name = lastDotSeg(dotPath)
-	w.Packages[dotPath] = pkg
-
-	// Recurse into every `use` target so the closure of dependencies is
-	// loaded before we run resolution on this package.
-	for _, f := range pkg.Files {
-		for _, u := range f.File.Uses {
-			if u.IsFFI() {
-				continue
-			}
-			target := UseKey(u)
-			if target == "" {
-				continue
-			}
-			if w.loading[target] {
-				// Defer the cycle diagnostic to resolver pass — it has
-				// access to the use-site position. We just stop
-				// recursing here.
-				continue
-			}
-			if _, alreadyLoaded := w.Packages[target]; alreadyLoaded {
-				continue
-			}
-			// Best-effort load; missing-package diagnostics are
-			// reported by the resolver, not here, so we swallow the
-			// error and let resolution surface it with source context.
-			_, _ = w.LoadPackage(target)
-		}
-	}
-	return pkg, nil
+	return w.LoadPackageArenaFirst(dotPath)
 }
 
 // loadExternalDep routes a URL-style use target through the
@@ -347,48 +254,24 @@ func (w *Workspace) dirFor(dotPath string) string {
 	return filepath.Join(append([]string{w.Root}, segs...)...)
 }
 
-// ResolveAll runs ResolvePackage on every loaded package, sharing one
-// prelude across the workspace. Before walking bodies it does a cycle
-// check over the import graph; every edge that would close a cycle
-// emits CodeCyclicImport against the offending `use` site.
-//
-// The function does NOT re-walk packages across workspaces; call it
-// once after all LoadPackage calls are done.
+// ResolveAll runs the selfhost resolver over every loaded package,
+// sharing one prelude across the workspace, then stitches cycle
+// diagnostics back onto the owning package result. The Go side no
+// longer performs a workspace-wide two-pass resolve walk.
 func (w *Workspace) ResolveAll() map[string]*PackageResult {
 	cycleDiags := w.detectCycles()
-
 	prelude := NewPrelude()
-
-	// v0.5 (G29) §5: `#[cfg(...)]` pre-resolve filter. Drop every
-	// declaration whose cfg guard is false before any package
-	// resolver inspects the file. Runs across every non-stub,
-	// non-pre-resolved package so cross-package symbol lookups in
-	// subsequent passes see the filtered surface only.
-	cfgEnv := w.cfgEnv
-	if cfgEnv == nil {
-		cfgEnv = DefaultCfgEnv()
-	}
-	cfgDiagsPerPkg := map[string][]*diag.Diagnostic{}
-	for path, pkg := range w.Packages {
-		if pkg.isStub {
-			continue
-		}
-		if w.isPreResolvedStdlib(path, pkg) {
-			continue
-		}
-		for _, f := range pkg.Files {
-			if ds := filterCfgDecls(f.File, cfgEnv); len(ds) > 0 {
-				cfgDiagsPerPkg[path] = append(cfgDiagsPerPkg[path], ds...)
-			}
-		}
-	}
-
-	// Per-package resolvers are needed so diagnostics stay
-	// segregated, but every one shares the same prelude. Build a
-	// resolver for each non-stub package up front.
-	resolvers := map[string]*resolver{}
 	results := map[string]*PackageResult{}
-	for path, pkg := range w.Packages {
+	paths := make([]string, 0, len(w.Packages))
+	for path := range w.Packages {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		pkg := w.Packages[path]
+		if pkg == nil {
+			continue
+		}
 		if pkg.isStub {
 			results[path] = &PackageResult{PackageScope: nil}
 			continue
@@ -398,48 +281,13 @@ func (w *Workspace) ResolveAll() map[string]*PackageResult {
 			results[path] = &PackageResult{PackageScope: pkg.PkgScope}
 			continue
 		}
-		resolvers[path] = newPkgResolver(pkg, prelude)
-	}
-	// Pass A (across workspace): populate every package's PkgScope
-	// with its top-level declarations. Cross-package member lookups in
-	// Pass B can now succeed regardless of iteration order.
-	for path, pkg := range w.Packages {
-		if pkg.isStub {
-			continue
-		}
-		if r := resolvers[path]; r != nil {
-			r.declarePass(pkg)
-		}
-	}
-	// Pass B (across workspace): walk bodies, expression references,
-	// type references. Each resolver sees every other package through
-	// their already-populated PkgScope.
-	for path, pkg := range w.Packages {
-		if pkg.isStub {
-			continue
-		}
-		r := resolvers[path]
-		if r == nil {
-			continue
-		}
-		r.bodyPass(pkg)
-		results[path] = &PackageResult{
-			PackageScope: pkg.PkgScope,
-			Diags:        r.diags,
-		}
+		results[path] = ResolvePackage(pkg, prelude)
 	}
 	// Attach cycle diagnostics to the package they were reported from.
 	// Each entry is (importerPath, diagnostic).
 	for _, cd := range cycleDiags {
 		if r, ok := results[cd.importer]; ok {
 			r.Diags = append(r.Diags, cd.diag)
-		}
-	}
-	// Surface any cfg-argument diagnostics produced by the pre-filter.
-	// These attach to the package the bad cfg lived in.
-	for path, ds := range cfgDiagsPerPkg {
-		if r, ok := results[path]; ok {
-			r.Diags = append(r.Diags, ds...)
 		}
 	}
 	return results


### PR DESCRIPTION
## Summary
- route package and workspace resolution through the selfhost/native resolver bridge
- add a source-aware single-file resolver entry point for CLI, pipeline, and airepair flows
- cover imported package alias bridging and update the selfhost port matrix

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)