### PR TITLE
feat: Map<K,V>.toString runtime intrinsic for primitive K/V

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -10113,6 +10113,81 @@ void *osty_rt_map_keys_sorted_i64(void *raw_map) {
     return keys;
 }
 
+/* Map<K, V>.toString — `{k1: v1, k2: v2}`-shaped. Reuses the per-
+ * element formatters from the list_to_string family; a single
+ * runtime entry is enough because the Map struct already carries
+ * `key_kind` / `value_kind` (set at `osty_rt_map_new` time) and we
+ * dispatch on those internally. The value-side formatter has to know
+ * the slot size — Map<K, Int> stores 8-byte values, Map<K, Bool>
+ * stores `sizeof(bool)` — so we look it up from `map->value_size`
+ * directly rather than recomputing from `value_kind`. Keys always
+ * use the kind's canonical width via `osty_rt_kind_size`.
+ *
+ * Format: empty → "{}". Pairs joined with ", "; keys and values
+ * separated by ": ". String values are quoted to match the
+ * list_to_string convention so users can pattern-match round-trip
+ * representations across collection kinds. */
+static osty_rt_list_format_one_fn osty_rt_map_pick_kind_formatter(int64_t kind) {
+    switch (kind) {
+    case OSTY_RT_ABI_I64:
+        return osty_rt_list_format_i64;
+    case OSTY_RT_ABI_F64:
+        return osty_rt_list_format_f64;
+    case OSTY_RT_ABI_I1:
+        return osty_rt_list_format_i1;
+    case OSTY_RT_ABI_STRING:
+        return osty_rt_list_format_string;
+    case OSTY_RT_ABI_PTR:
+        /* Reuse the string formatter for the ptr lane: today the only
+         * ptr-shaped Map keys/values that show up at this entry are
+         * Strings (per `osty_rt_map_key_hash`'s OSTY_RT_ABI_PTR arm,
+         * which already special-cases String content). Composite ptr
+         * values trigger the abort below — the caller gets a clear
+         * message instead of garbage bytes. */
+        return osty_rt_list_format_string;
+    default:
+        return NULL;
+    }
+}
+
+const char *osty_rt_map_to_string(void *raw_map) {
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    if (map == NULL || map->len == 0) {
+        return osty_rt_string_dup_site("{}", 2, "runtime.map.to_string");
+    }
+    osty_rt_list_format_one_fn fmt_key = osty_rt_map_pick_kind_formatter(map->key_kind);
+    osty_rt_list_format_one_fn fmt_val = osty_rt_map_pick_kind_formatter(map->value_kind);
+    if (fmt_key == NULL || fmt_val == NULL) {
+        osty_rt_abort("runtime.map.to_string: unsupported key/value kind");
+    }
+    size_t key_size = osty_rt_kind_size(map->key_kind);
+    size_t value_size = map->value_size;
+    size_t cap = 64;
+    size_t len = 0;
+    char *buf = (char *)malloc(cap);
+    if (buf == NULL) {
+        osty_rt_abort("runtime.map.to_string: out of memory");
+    }
+    buf[len++] = '{';
+    osty_rt_map_lock(raw_map);
+    for (int64_t i = 0; i < map->len; i++) {
+        if (i > 0) {
+            osty_rt_list_to_string_append(&buf, &cap, &len, ", ", 2);
+        }
+        const unsigned char *key_slot = map->keys + (size_t)i * key_size;
+        const unsigned char *value_slot = map->values + (size_t)i * value_size;
+        fmt_key(&buf, &cap, &len, key_slot);
+        osty_rt_list_to_string_append(&buf, &cap, &len, ": ", 2);
+        fmt_val(&buf, &cap, &len, value_slot);
+    }
+    osty_rt_map_unlock(raw_map);
+    osty_rt_list_to_string_grow(&buf, &cap, len + 2);
+    buf[len++] = '}';
+    const char *out = osty_rt_string_dup_site(buf, len, "runtime.map.to_string");
+    free(buf);
+    return out;
+}
+
 // Every public keyed op takes the per-map lock, runs the raw op, and
 // releases. Recursive so that `update`'s outer lock + a re-entrant op
 // from a user callback (e.g. counts.len() inside f) don't deadlock.

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1174,7 +1174,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
 		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
 		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted,
-		mir.IntrinsicMapIncr:
+		mir.IntrinsicMapIncr, mir.IntrinsicMapToString:
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -4053,7 +4053,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapGetOr,
 		mir.IntrinsicMapSet, mir.IntrinsicMapContains, mir.IntrinsicMapLen,
 		mir.IntrinsicMapKeys, mir.IntrinsicMapRemove, mir.IntrinsicMapKeysSorted,
-		mir.IntrinsicMapIncr:
+		mir.IntrinsicMapIncr, mir.IntrinsicMapToString:
 		return g.emitMapIntrinsic(i)
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
@@ -5027,6 +5027,18 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			g.fnBuf.WriteString(mirStorePtrLine(tmp, g.localSlots[i.Dest.Local]))
 		}
 		return nil
+	case mir.IntrinsicMapToString:
+		// `{k: v, k: v}`-shaped stringification. One runtime entry —
+		// the Map struct already carries `key_kind` / `value_kind` set
+		// at allocation time, so dispatch happens inside C; lowering
+		// just emits the call. Composite key/value types (struct,
+		// enum, nested collection) abort inside the runtime today.
+		sym := mirRtMapToStringSymbol()
+		g.declareRuntime(sym, mirRuntimeDeclarePtrFromPtrLine(sym))
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: mapReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("map intrinsic kind %d", i.Kind))
 }

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -5779,6 +5779,7 @@ func mirRtMapLenSymbolName() string   { return mirRtMapSymbol("len") }
 func mirRtMapValuesSymbol() string    { return mirRtMapSymbol("values") }
 func mirRtMapEntriesSymbol() string   { return mirRtMapSymbol("entries") }
 func mirRtMapMergeWithSymbol() string { return mirRtMapSymbol("merge_with") }
+func mirRtMapToStringSymbol() string  { return mirRtMapSymbol("to_string") }
 
 // Osty: mirRtSet* fixed-symbols
 func mirRtSetClearSymbol() string   { return mirRtSetSymbol("clear") }

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4228,6 +4228,8 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 			return IntrinsicMapValues
 		case "remove":
 			return IntrinsicMapRemove
+		case "toString":
+			return IntrinsicMapToString
 		}
 	case "Set":
 		switch name {

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -527,6 +527,11 @@ const (
 	// registered (i64 / string); the HIR pattern matcher that emits
 	// this rejects other keys and falls back to the unfused lowering.
 	IntrinsicMapKeysSorted
+	// IntrinsicMapToString returns a `{k1: v1, k2: v2}`-shaped String.
+	// Args: [map]. Dest is String. The runtime entry inspects the
+	// Map's stored `key_kind` / `value_kind` to pick per-element
+	// formatters; the lowering side just emits the call.
+	IntrinsicMapToString
 
 	// ---- stdlib collections: Set<T> ----
 
@@ -1626,6 +1631,8 @@ func (k IntrinsicKind) String() string {
 		return "map_remove"
 	case IntrinsicMapKeysSorted:
 		return "map_keys_sorted"
+	case IntrinsicMapToString:
+		return "map_to_string"
 	case IntrinsicSetNew:
 		return "set_new"
 	case IntrinsicSetInsert:

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36550,6 +36550,11 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "containsKey", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys), paramNames: []string{"key"}, paramTys: []int{tK}, generics: []string{"K", "V"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16451:5
 	checkRegisterFn(env, &CheckFnSig{name: "clear", owner: "Map", receiverTy: tMapKV, retTy: tUnit(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"K", "V"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Map<K, V>.toString() -> String — mirrors List.toString. Single
+	// runtime entry; the Map carries `key_kind` / `value_kind` so the
+	// C code dispatches per-element formatters internally. Composite
+	// keys/values abort with a clear runtime message.
+	checkRegisterFn(env, &CheckFnSig{name: "toString", owner: "Map", receiverTy: tMapKV, retTy: tString(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"K", "V"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16460:5
 	tR_map := tyNamed(tys, "R", make([]int, 0, 1))
 	_ = tR_map

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -2287,6 +2287,15 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         paramNames: [], paramTys: [],
         generics: ["K", "V"], genericBounds: [],
     })
+    // `{k: v, k: v}`-shaped stringification. Single runtime entry —
+    // `osty_rt_map_to_string` dispatches on the Map's stored
+    // `key_kind` / `value_kind` to pick per-element formatters.
+    // Composite K/V types abort inside the runtime today.
+    checkRegisterFn(env, CheckFnSig {
+        name: "toString", owner: "Map", receiverTy: tMapKV, hasReceiver: true, retTy: tString_,
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
     // Map helpers backed by runtime intrinsics in `osty_runtime.c`
     // (see PR #470). `get` is already registered above; these five
     // surface the matching checker signatures so user code can call


### PR DESCRIPTION
## Summary

- Adds `Map<K, V>.toString()` returning a `{k: v, k: v}`-shaped String. Mirrors PR #1010's `List<T>.toString`.
- A **single** runtime entry (`osty_rt_map_to_string`) dispatches per-element formatting internally using the Map's stored `key_kind` / `value_kind` (set at `osty_rt_map_new` time) — no per-(K,V) symbol explosion.
- Reuses the `osty_rt_list_format_*` formatters and the grow/append helpers from #1010, so empty / quoting / numeric formatting match `List.toString` byte-for-byte.

## Format

| Map | Output |
|---|---|
| `Map<String, Int> { "a": 1, "b": 2 }` | `{"a": 1, "b": 2}` |
| `Map<Int, Bool> { 1: true, 2: false }` | `{1: true, 2: false}` |
| `Map<String, String> { "k": "v" }` | `{"k": "v"}` |
| `Map<Int, Int> { 10: 100 }` | `{10: 100}` |
| `Map<String, Float> { "pi": 3.14 }` | `{"pi": 3.140000}` |
| empty | `{}` |

Composite keys/values (struct, enum, nested collection) abort inside the runtime today — a callback-driven entry would lift that.

## Surfaces touched

- `internal/backend/runtime/osty_runtime.c` — `osty_rt_map_to_string` + the per-kind formatter picker. Lock the Map for the iteration so concurrent inserts can't race the buffer build.
- `internal/mir/{mir.go,lower.go}` — `IntrinsicMapToString` enum + `Map.toString` → intrinsic dispatch + label for MIR debug printing.
- `internal/llvmgen/mir_generator{,_snapshot}.go` — `mirRtMapToStringSymbol()` + `emitMapIntrinsic` case + intrinsic supported/dispatch lists.
- `internal/selfhost/generated.go` + `toolchain/check_env.osty` — register `Map<K, V>.toString -> String` in both checker mirrors.

## Test plan

- [x] `Map<String, Int>` round-trips: `{"a": 1, "b": 2}`
- [x] `Map<Int, Bool>` round-trips: `{1: true, 2: false}`
- [x] `Map<String, String>` round-trips with quoting on both sides
- [x] `Map<Int, Int>`, `Map<String, Float>` round-trip with numeric formatters
- [x] Empty `Map<Int, Bool>` → `{}`
- [x] `just front` clean
- [x] `internal/selfhost`, `internal/mir` packages clean; the `internal/llvmgen` failures (`TestNativeOwnedModuleEntry*`, `TestNativeToolchainMergedMIRPipelineIsClean`, `TestNativeToolchainMergedMIRErrTypeFloor`) reproduce on `origin/main` without these changes — pre-existing baseline failures, not regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)