### PR TITLE
feat(runtime): drop gc_lock around dispatch_trace for safe kinds (Phase 0h)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3478,6 +3478,134 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeLockfreeTraceDispatch covers Phase 0h — when a
+// kind's `trace_lockfree_safe` flag is set in the descriptor table,
+// `mark_drain_budget` releases `osty_gc_lock` around dispatch_trace
+// so the tracer body runs concurrently with the mutator. The test
+// allocates a mix of closure_env (safe) and list (unsafe), drives a
+// cycle, and asserts both counters advance — proving the per-kind
+// dispatch decision actually fires.
+func TestBundledRuntimeLockfreeTraceDispatch(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_lockfree_trace_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_lockfree_trace_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+void *osty_rt_closure_env_alloc_v2(int64_t capture_count, const char *site, uint64_t pointer_bitmap) __asm__(OSTY_GC_SYMBOL("osty.rt.closure_env_alloc_v2"));
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+bool osty_gc_collect_incremental_step(int64_t budget);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_lockfree_trace_total(void);
+int64_t osty_gc_debug_locked_trace_total(void);
+
+int main(void) {
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    void *children[5];
+    for (int i = 0; i < 5; i++) {
+        children[i] = osty_gc_alloc_v1(7, 16, "child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, children[i]);
+        osty_gc_post_write_v1(list, children[i], 0);
+    }
+
+    /* Closure env with 3 captures (zeroed slots). The kind's
+     * trace_lockfree_safe flag routes its tracer through the
+     * lockfree path — the captures themselves don't need to point
+     * to anything for the dispatch counter to bump. */
+    void *env = osty_rt_closure_env_alloc_v2(3, "env", 0x7);
+    osty_gc_root_bind_v1(env);
+
+    long long lockfree_before = (long long)osty_gc_debug_lockfree_trace_total();
+    long long locked_before   = (long long)osty_gc_debug_locked_trace_total();
+
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+    while (osty_gc_collect_incremental_step(100)) {}
+    osty_gc_collect_incremental_finish();
+
+    long long lockfree_after = (long long)osty_gc_debug_lockfree_trace_total();
+    long long locked_after   = (long long)osty_gc_debug_locked_trace_total();
+    long long state          = (long long)osty_gc_debug_state();
+    long long live           = (long long)osty_gc_debug_live_count();
+
+    printf("lockfree_delta=%lld locked_delta=%lld state=%lld live=%lld\n",
+        lockfree_after - lockfree_before,
+        locked_after - locked_before,
+        state, live);
+
+    osty_gc_root_release_v1(env);
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_ASSIST_BYTES_PER_UNIT=0")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	if !strings.Contains(out, "state=0 ") {
+		t.Fatalf("state!=IDLE; full output:\n%s", out)
+	}
+	if !strings.Contains(out, "live=7") {
+		t.Fatalf("live count wrong (want 7 = list + 5 children + env); full output:\n%s", out)
+	}
+	var lockfreeDelta, lockedDelta, state, live int64
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "lockfree_delta=") {
+			continue
+		}
+		if _, err := fmt.Sscanf(line,
+			"lockfree_delta=%d locked_delta=%d state=%d live=%d",
+			&lockfreeDelta, &lockedDelta, &state, &live); err != nil {
+			t.Fatalf("could not parse %q: %v", line, err)
+		}
+		break
+	}
+	if lockfreeDelta < 1 {
+		t.Fatalf("lockfree_delta=%d, want >=1 (closure_env should dispatch lockfree)\nfull output:\n%s",
+			lockfreeDelta, out)
+	}
+	if lockedDelta < 1 {
+		t.Fatalf("locked_delta=%d, want >=1 (list_trace should dispatch locked)\nfull output:\n%s",
+			lockedDelta, out)
+	}
+}
+
 // TestBundledRuntimeColorCASBookkeeping covers Phase 0g — every
 // WHITE→GREY transition (mark_header path + SATB pre_write path) now
 // runs through a CAS so a future lock-free tracer can race safely.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -712,6 +712,15 @@ typedef struct osty_gc_kind_descriptor {
     /* Whether the no-header young arena can carry this kind. Toggle
      * at the table row, not in `osty_gc_young_eligible`. */
     bool young_eligible;
+    /* Phase 0h: whether the trace function is safe to invoke without
+     * `osty_gc_lock` held. False for kinds whose payload backing
+     * storage can be reallocated mid-trace by the mutator (list,
+     * map, set, channel) — those would need deferred-realloc or
+     * hazard-pointer reclamation, which is its own piece of work.
+     * True for kinds whose tracer reads either fixed-layout fields
+     * (closure_env captures, generic enum payloads) or single
+     * pointer slots that cannot move. */
+    bool trace_lockfree_safe;
     /* Per-kind cleanup for UNFORWARDED young objects swept by
      * `cheney_destroy_dead_from_space`. NULL when the payload has
      * no external buffers. */
@@ -745,18 +754,26 @@ enum {
 
 static const osty_gc_kind_descriptor osty_gc_generic_patterns[] = {
     /* NONE — opaque payload, cheney handles it as raw bytes. */
-    [OSTY_GC_GENERIC_NONE] = {.young_eligible = true},
+    [OSTY_GC_GENERIC_NONE] = {
+        .young_eligible = true,
+        /* Phase 0h: NONE has no trace fn, so the lockfree flag is
+         * moot. Setting true keeps the predicate result consistent
+         * (no trace = nothing to race on). */
+        .trace_lockfree_safe = true,
+    },
     /* ENUM_PTR routes through `OSTY_GC_KIND_GENERIC_ENUM_PTR`'s row
      * in the kind table; this row is only consulted on the headerful
      * fallback dispatch, so the young flag stays false. */
     [OSTY_GC_GENERIC_ENUM_PTR] = {
         .trace = osty_rt_enum_ptr_payload_trace,
+        .trace_lockfree_safe = true,
     },
     /* Same shape as ENUM_PTR — TASK_HANDLE now routes through
      * `OSTY_GC_KIND_GENERIC_TASK_HANDLE`'s row in the kind table.
      * This row is parity-only for the headerful fallback dispatch. */
     [OSTY_GC_GENERIC_TASK_HANDLE] = {
         .destroy = osty_rt_task_handle_destroy,
+        .trace_lockfree_safe = true,
     },
 };
 
@@ -805,6 +822,10 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
     [OSTY_GC_KIND_CLOSURE_ENV - OSTY_GC_KIND_LIST] = {
         .trace = osty_rt_closure_env_trace,
         .young_eligible = true,
+        /* Phase 0h: captures populated synchronously at creation, never
+         * mutated, fixed-length array — safe to trace without the GC
+         * lock once the rest of the lock-free invariants are in place. */
+        .trace_lockfree_safe = true,
         .remap = osty_gc_remap_closure_env_payload,
     },
     /* CHANNEL young-safe through the same handoff pattern as Map:
@@ -817,12 +838,21 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .trace = osty_rt_chan_trace,
         .destroy = osty_rt_chan_destroy,
         .young_eligible = true,
+        /* Phase 0h: NOT lockfree-safe — the channel slot ring uses a
+         * mutex+cond and the head/tail counters mutate on send/recv;
+         * even reading the slots while a sender is mid-update could
+         * race the slot allocation. Future lock-free path needs a
+         * snapshot or hazard pointer. */
         .cleanup_young_dead = osty_gc_cleanup_young_dead_chan,
         .remap = osty_gc_remap_chan_payload,
     },
     [OSTY_GC_KIND_GENERIC_ENUM_PTR - OSTY_GC_KIND_LIST] = {
         .trace = osty_rt_enum_ptr_payload_trace,
         .young_eligible = true,
+        /* Phase 0h: payload is a single managed pointer slot — read
+         * is atomic on aligned platforms and the slot itself doesn't
+         * move. SATB barrier on slot writes preserves the invariant. */
+        .trace_lockfree_safe = true,
         .remap = osty_gc_remap_slot,
     },
     /* TASK_HANDLE young-safe through `osty_gc_task_handle_safe_handoff`
@@ -831,6 +861,10 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
     [OSTY_GC_KIND_GENERIC_TASK_HANDLE - OSTY_GC_KIND_LIST] = {
         .destroy = osty_rt_task_handle_destroy,
         .young_eligible = true,
+        /* Phase 0h: no trace fn at all (no managed pointer payload),
+         * so the lockfree flag is moot — but mark it true so a future
+         * trace fn addition would have to opt out explicitly. */
+        .trace_lockfree_safe = true,
         .cleanup_young_dead = osty_gc_cleanup_young_dead_task_handle,
     },
 };
@@ -848,6 +882,26 @@ static inline const osty_gc_kind_descriptor *osty_gc_kind_descriptor_lookup(
         return NULL;
     }
     return &osty_gc_kind_table[kind - OSTY_GC_KIND_LIST];
+}
+
+/* Phase 0h: predicate that decides whether `mark_drain_budget` may
+ * release `osty_gc_lock` around the tracer call for this header.
+ * GENERIC kinds fall through to their generic_pattern row, which
+ * defaults to NOT-safe except for the patterns marked above —
+ * conservative because GENERIC users that add a trace fn need to
+ * audit it explicitly before flipping the flag. */
+static inline bool osty_gc_trace_lockfree_safe(osty_gc_header *header) {
+    const osty_gc_kind_descriptor *desc =
+        osty_gc_kind_descriptor_lookup(header->object_kind);
+    if (desc != NULL) {
+        return desc->trace_lockfree_safe;
+    }
+    /* GENERIC fallback. Look at the pattern row. */
+    uint8_t pat = header->generic_pattern;
+    if (pat >= OSTY_GC_GENERIC_PATTERN_COUNT) {
+        return false;
+    }
+    return osty_gc_generic_patterns[pat].trace_lockfree_safe;
 }
 
 /* Phase 2 dispatch (RUNTIME_GC_DELTA tiny-tag young plan).
@@ -5239,6 +5293,14 @@ static OSTY_RT_TLS bool osty_gc_local_mark_active = false;
 static int64_t osty_gc_local_mark_pushes_total = 0;
 static int64_t osty_gc_local_mark_overflow_total = 0;
 
+/* Phase 0h: TLS flag set while a marker thread is mid-dispatch on a
+ * lockfree-safe kind. `mark_stack_push` consults it to abort with a
+ * clear message if the local TLS stack overflows during such a
+ * dispatch — central pushes without `osty_gc_lock` would race
+ * mutator-side SATB pushes. Defined ahead of `mark_stack_push` so
+ * the reference resolves in single-pass C compilation. */
+static OSTY_RT_TLS bool osty_gc_in_lockfree_trace = false;
+
 static void osty_gc_mark_stack_push_central(osty_gc_header *header) {
     if (osty_gc_mark_stack_count == osty_gc_mark_stack_cap) {
         int64_t new_cap;
@@ -5290,6 +5352,22 @@ static void osty_gc_mark_stack_push(osty_gc_header *header) {
          * confirm the local cap is sized right for the workload. */
         (void)__atomic_add_fetch(&osty_gc_local_mark_overflow_total, 1,
                                  __ATOMIC_RELAXED);
+        /* Phase 0h safety: a lockfree-safe tracer is currently
+         * mid-dispatch with `osty_gc_lock` released. Pushing to the
+         * central stack here would race with mutator-side SATB
+         * pushes (which take `osty_gc_lock`). Abort with a clear
+         * message so the issue is visible — this is a design bound
+         * (closure captures cap at 64, generic enum ptr pushes 1),
+         * so realistic workloads can't hit it. If a future kind
+         * lifts the bound, the kind's `trace_lockfree_safe` flag
+         * needs to flip to false. */
+        if (osty_gc_in_lockfree_trace) {
+            osty_rt_abort(
+                "lockfree trace: local mark stack overflow without "
+                "gc_lock held — bound the kind's trace push count "
+                "below OSTY_GC_LOCAL_MARK_STACK_CAP or set "
+                "trace_lockfree_safe=false in the kind descriptor");
+        }
     }
     osty_gc_mark_stack_push_central(header);
 }
@@ -5302,6 +5380,13 @@ static void osty_gc_mark_stack_push(osty_gc_header *header) {
  * 0h) these counters become the contention signal. */
 static int64_t osty_gc_mark_cas_attempts_total = 0;
 static int64_t osty_gc_mark_cas_failures_total = 0;
+
+/* Phase 0h: counters for trace-dispatch lock state. Each call to
+ * `dispatch_trace` either ran with `osty_gc_lock` released
+ * (`lockfree_total`) or held (`locked_total`). The TLS flag itself
+ * is defined ahead of `mark_stack_push` for forward-reference. */
+static int64_t osty_gc_lockfree_trace_total = 0;
+static int64_t osty_gc_locked_trace_total = 0;
 
 static void osty_gc_mark_header(osty_gc_header *header) {
     /* Enqueue only — the actual trace happens in `osty_gc_mark_drain`.
@@ -5379,11 +5464,30 @@ static int64_t osty_gc_mark_drain_budget(int64_t budget) {
          * also see the trace's full effects (children pushed). */
         __atomic_store_n(&header->color, OSTY_GC_COLOR_BLACK,
                          __ATOMIC_RELEASE);
-        /* Trace callbacks re-enter `osty_gc_mark_*` for children,
-         * which push more GREY work — into TLS via mark_stack_push's
-         * routing. The C call stack stays bounded regardless of
-         * object graph depth. */
-        osty_gc_dispatch_trace(header);
+        /* Phase 0h: per-kind decision on whether the tracer can run
+         * with `osty_gc_lock` released. closure_env / generic enum
+         * payloads are safe (fixed-layout reads, bounded push count
+         * within local TLS cap); list / map / set / channel still
+         * need the lock because their backing storage can be
+         * reallocated by a concurrent mutator. */
+        bool lockfree = osty_gc_trace_lockfree_safe(header);
+        if (lockfree) {
+            (void)__atomic_add_fetch(&osty_gc_lockfree_trace_total, 1,
+                                     __ATOMIC_RELAXED);
+            osty_gc_in_lockfree_trace = true;
+            osty_gc_release();
+            osty_gc_dispatch_trace(header);
+            osty_gc_acquire();
+            osty_gc_in_lockfree_trace = false;
+        } else {
+            (void)__atomic_add_fetch(&osty_gc_locked_trace_total, 1,
+                                     __ATOMIC_RELAXED);
+            /* Trace callbacks re-enter `osty_gc_mark_*` for children,
+             * which push more GREY work — into TLS via mark_stack_push's
+             * routing. The C call stack stays bounded regardless of
+             * object graph depth. */
+            osty_gc_dispatch_trace(header);
+        }
         done += 1;
     }
 
@@ -12668,6 +12772,22 @@ int64_t osty_gc_debug_mark_cas_attempts_total(void) {
 
 int64_t osty_gc_debug_mark_cas_failures_total(void) {
     return osty_gc_mark_cas_failures_total;
+}
+
+/* Phase 0h trace-dispatch counters. `lockfree_trace_total` is the
+ * count of `dispatch_trace` calls that ran with `osty_gc_lock`
+ * released (closure_env, generic enum); `locked_trace_total` is the
+ * count that kept the lock (list/map/set/channel). The ratio is the
+ * fraction of trace work newly able to run concurrently with
+ * mutator activity. */
+int64_t osty_gc_debug_lockfree_trace_total(void) {
+    return __atomic_load_n(&osty_gc_lockfree_trace_total,
+                           __ATOMIC_ACQUIRE);
+}
+
+int64_t osty_gc_debug_locked_trace_total(void) {
+    return __atomic_load_n(&osty_gc_locked_trace_total,
+                           __ATOMIC_ACQUIRE);
 }
 
 int64_t osty_gc_debug_color_of(void *payload) {


### PR DESCRIPTION
## Summary

`mark_drain_budget` now decides per-header whether the tracer can run without `osty_gc_lock` held. Kinds whose trace function reads only fixed-layout state get the lockfree path; kinds whose payload backing storage can be reallocated by a concurrent mutator keep the lock. This is the first PR where bg marker tracer work runs *concurrently* with mutator activity for real, building on:

- #993 — Phase 0a–0d (background marker thread, multi-thread cycles, parallel workers, batch fairness)
- #1003 — Phase 0e + 0e' (concurrent sweep, TLS local mark stack)
- #1008 — Phase 0f (atomic-safe hash index + cycle-deferred resize)
- #1011 — Phase 0g (atomic color CAS for WHITE→GREY)

## Per-kind decision

Lockfree-safe (new `trace_lockfree_safe = true` in kind descriptor):
- **CLOSURE_ENV** — captures populated synchronously at creation, never mutated, fixed-length array bounded by the 64-bit pointer bitmap
- **GENERIC_ENUM_PTR** — payload is a single managed pointer slot, atomic read on aligned platforms, doesn't move
- **GENERIC_TASK_HANDLE / GENERIC_NONE** — no trace fn at all

Locked (default):
- **LIST, MAP, SET, CHANNEL** — backing storage reallocates on push/insert; dropping the lock around their tracers would race the realloc and free old data the marker is reading

## Safety bound

While a marker is in lockfree dispatch, `mark_stack_push` overflow into the central stack would race mutator-side SATB pushes that take `osty_gc_lock`. The TLS `osty_gc_in_lockfree_trace` flag makes `mark_stack_push` abort with a clear error if local TLS overflows mid-dispatch.

The flag is design-bound by:
- Closure capture cap is 64 (pointer bitmap is 64 bits wide), well under the 256-slot local TLS
- Generic enum payload pushes at most 1 child

So realistic workloads can't trip the abort. It exists to catch a future kind that lifts the push bound without flipping the descriptor flag back to `false`.

## Followup

The locked kinds (list/map/set/channel) are the next surgical target. Two paths to lock-free trace for them:
- **Deferred realloc during cycle** — mirrors #1008's index pre-grow + defer pattern. List/map/set push grows backing inline normally but during a cycle just sets a pending flag and uses the existing buffer; finish_locked drains the flag under STW. Bounds capacity to whatever pre-grow allocated.
- **Hazard-pointer reclamation** — old buffers retired but not freed until no marker is reading them. Smaller mutator pause but bigger surgery.

## Telemetry

- `osty_gc_debug_lockfree_trace_total` — dispatch_trace calls that ran with `osty_gc_lock` released
- `osty_gc_debug_locked_trace_total` — calls that kept the lock

## Test plan

- [x] `TestBundledRuntimeLockfreeTraceDispatch` — rooted list with 5 children + closure_env with 3 captures; asserts both counters move (per-kind dispatch fires) and live count = 7 (cycle correctness preserved)
- [x] All Phase 0a–0g tests pass unchanged
- [x] All existing `TestBundledRuntimeIncremental*` (Step / Budget / SATB / AutoDispatcher / MutatorAssist / Stress / DeepGraph) pass
- [x] Scheduler / channel / taskgroup tests pass
- [x] `go test ./internal/backend/` green (45s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)