### PR TITLE
refactor(llvmgen): port many pure helpers + line builders + drains (slice 11)

### DIFF
--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -300,7 +300,7 @@ type constValue struct {
 }
 
 func (c constValue) typedInit() string {
-	return fmt.Sprintf("%s %s", c.typ, c.init)
+	return mirConstTypedInitText(c.typ, c.init)
 }
 
 type builtinResultType struct {
@@ -1261,7 +1261,7 @@ func signatureOf(fn *ast.FnDecl, ownerName string, env typeEnv) (*fnSig, error) 
 		paramName := p.Name
 		if p.Pattern != nil {
 			if paramName == "" {
-				paramName = fmt.Sprintf("__arg%d", i)
+				paramName = mirSyntheticArgName(strconv.Itoa(i))
 			}
 		} else if paramName == "" {
 			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, true, false, true, "")
@@ -1611,11 +1611,12 @@ func (g *generator) emitGlobalLets(globals []*globalLetInfo) error {
 				listElemTyp = elemTyp
 			}
 		}
-		kind := "constant"
-		if info.mutable {
-			kind = "global"
-		}
-		g.globalDefs = append(g.globalDefs, fmt.Sprintf("%s = internal %s %s %s", info.irName, kind, typ, cv.init))
+		// Trailing newline is intentionally omitted: callers join the
+		// global-def slice with `\n` later. The Osty `Line` form already
+		// appends `\n`, so we trim it here to match the legacy shape.
+		def := mirInternalGlobalDefForKind(info.irName, info.mutable, typ, cv.init)
+		def = def[:len(def)-1]
+		g.globalDefs = append(g.globalDefs, def)
 		g.globals[info.name] = value{
 			typ:         typ,
 			ref:         info.irName,
@@ -1835,7 +1836,7 @@ func (g *generator) constStructLit(lit *ast.StructLit) (constValue, error) {
 		}
 		parts = append(parts, cv.typedInit())
 	}
-	return constValue{typ: info.typ, init: fmt.Sprintf("{ %s }", strings.Join(parts, ", "))}, nil
+	return constValue{typ: info.typ, init: mirConstStructInitText(strings.Join(parts, ", "))}, nil
 }
 
 func (g *generator) constEnumVariantIdent(name string) (constValue, bool, error) {
@@ -1866,7 +1867,7 @@ func (g *generator) constEnumVariant(info *enumInfo, variant variantInfo, payloa
 		}
 		return constValue{
 			typ:  info.typ,
-			init: fmt.Sprintf("{ i64 %d, %s }", variant.tag, payloadValue.typedInit()),
+			init: mirConstEnumVariantInitText(strconv.Itoa(variant.tag), payloadValue.typedInit()),
 		}, nil
 	}
 	if payload != nil {
@@ -1958,37 +1959,29 @@ func constBoolCompare[T comparable](op token.Kind, left, right T) (constValue, e
 	return constValue{typ: "i1", init: strconv.FormatBool(value), kind: constKindBool, boolValue: value}, nil
 }
 
+// constIntBinary applies a binary operator to two i64 operands at
+// compile time. Delegates to the Osty-sourced `mirConstIntBinary` for
+// the value channel and `mirConstIntBinaryStatus` for the error
+// channel; status `0` is success, `1` div0, `2` mod0, `3` unsupported.
+//
+// The token codes are bundled into a single `tokenCodes` value once and
+// then passed by spread to both helpers — this keeps the binary→token
+// mapping in one place even though the multi-return Osty bridge
+// requires the codes to flow through every call.
 func constIntBinary(op token.Kind, left, right int64) (int64, error) {
-	switch op {
-	case token.PLUS:
-		return left + right, nil
-	case token.MINUS:
-		return left - right, nil
-	case token.STAR:
-		return left * right, nil
-	case token.SLASH:
-		if right == 0 {
-			return 0, unsupported("expression", "constant Int division by zero")
-		}
-		return left / right, nil
-	case token.PERCENT:
-		if right == 0 {
-			return 0, unsupported("expression", "constant Int modulo by zero")
-		}
-		return left % right, nil
-	case token.BITAND:
-		return left & right, nil
-	case token.BITOR:
-		return left | right, nil
-	case token.BITXOR:
-		return left ^ right, nil
-	case token.SHL:
-		return left << uint(right), nil
-	case token.SHR:
-		return left >> uint(right), nil
-	default:
+	plus, minus, star := int(token.PLUS), int(token.MINUS), int(token.STAR)
+	slash, percent := int(token.SLASH), int(token.PERCENT)
+	bitAnd, bitOr, bitXor := int(token.BITAND), int(token.BITOR), int(token.BITXOR)
+	shl, shr := int(token.SHL), int(token.SHR)
+	switch mirConstIntBinaryStatus(int(op), right, plus, minus, star, slash, percent, bitAnd, bitOr, bitXor, shl, shr) {
+	case 1:
+		return 0, unsupported("expression", "constant Int division by zero")
+	case 2:
+		return 0, unsupported("expression", "constant Int modulo by zero")
+	case 3:
 		return 0, unsupportedf("expression", "binary operator %q", op)
 	}
+	return mirConstIntBinary(int(op), left, right, plus, minus, star, slash, percent, bitAnd, bitOr, bitXor, shl, shr), nil
 }
 
 func constFloatBinary(op token.Kind, left, right float64) (float64, error) {
@@ -2015,13 +2008,19 @@ func constFloatBinary(op token.Kind, left, right float64) (float64, error) {
 	}
 }
 
+// llvmFloatConstLiteral renders a Float64 as an LLVM constant. NaN and
+// Inf go to the IEEE-754 bit-pattern form (`0x<16-hex>`); everything
+// else uses Go's `strconv.FormatFloat` with the conventional `'e' ,
+// 16, 64` parameters that match LLVM's textual float syntax. The
+// host-side path here computes `math.Float64bits(value)` because Osty
+// has no equivalent today; the `0x...` prefix and the fixed-width
+// uppercase hex form come from the Osty-sourced
+// `mirLlvmFloat64HexLiteral` (`toolchain/mir_generator.osty`).
 func llvmFloatConstLiteral(value float64) string {
-	switch {
-	case math.IsNaN(value), math.IsInf(value, 0):
-		return fmt.Sprintf("0x%016X", math.Float64bits(value))
-	default:
-		return strconv.FormatFloat(value, 'e', 16, 64)
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return mirLlvmFloat64HexLiteral(fmt.Sprintf("%016X", math.Float64bits(value)))
 	}
+	return strconv.FormatFloat(value, 'e', 16, 64)
 }
 
 // llvmGlobalIRName composes the LLVM IR symbol used for an Osty

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2866,7 +2866,7 @@ func (g *generator) emitAggregateRootOffsets(emitter *LlvmEmitter, typ string) (
 	if len(paths) == 0 {
 		return value{typ: "ptr", ref: "null"}, 0, nil
 	}
-	arrayTyp := fmt.Sprintf("[%d x i64]", len(paths))
+	arrayTyp := mirArrayI64TypeText(strconv.Itoa(len(paths)))
 	arrayPtr := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, mirAllocaText(arrayPtr, arrayTyp))
 	for i, path := range paths {
@@ -6783,7 +6783,7 @@ func (g *generator) emitOptionUnwrap(base value, optType *ast.OptionalType, call
 	g.enterBlock(noneLabel)
 
 	emitter = g.toOstyEmitter()
-	msg := fmt.Sprintf("unwrap on None at %s", g.sourceLineLabel(call.Pos().Line, "<unwrap>"))
+	msg := mirOptionUnwrapNoneMessage(g.sourceLineLabel(call.Pos().Line, "<unwrap>"))
 	msgPtr := llvmStringLiteral(emitter, msg)
 	llvmPrintlnString(emitter, msgPtr)
 	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
@@ -7448,13 +7448,13 @@ func debugPatternShape(pattern ast.Pattern) string {
 	case nil:
 		return "<nil>"
 	case *ast.IdentPat:
-		return fmt.Sprintf("ident %q", p.Name)
+		return mirDebugIdentText(strconv.Quote(p.Name))
 	case *ast.VariantPat:
 		path := strings.Join(p.Path, ".")
 		if len(p.Args) == 0 {
-			return fmt.Sprintf("variant %s (no args)", path)
+			return mirDebugVariantNoArgsText(path)
 		}
-		return fmt.Sprintf("variant %s with %d arg(s)", path, len(p.Args))
+		return mirDebugVariantWithArgsText(path, strconv.Itoa(len(p.Args)))
 	case *ast.WildcardPat:
 		return "wildcard"
 	case *ast.LiteralPat:
@@ -7466,9 +7466,9 @@ func debugPatternShape(pattern ast.Pattern) string {
 	case *ast.BindingPat:
 		return "binding"
 	case *ast.TuplePat:
-		return fmt.Sprintf("tuple of %d", len(p.Elems))
+		return mirDebugTupleText(strconv.Itoa(len(p.Elems)))
 	case *ast.StructPat:
-		return fmt.Sprintf("struct %s", strings.Join(p.Type, "."))
+		return mirDebugStructText(strings.Join(p.Type, "."))
 	default:
 		return fmt.Sprintf("%T", pattern)
 	}
@@ -8031,9 +8031,9 @@ func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, er
 	emitter.body = append(emitter.body, mirGEPArrayElementText(fnPtrSlot, strconv.Itoa(len(iface.methods)), vtable, strconv.Itoa(slot)))
 	fnPtr := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, mirLoadPtrText(fnPtr, fnPtrSlot))
-	callArgList := fmt.Sprintf("ptr %s", dataPtr)
+	callArgList := mirCallArgsPtrPrefix(dataPtr)
 	for _, p := range argPairs {
-		callArgList += fmt.Sprintf(", %s %s", p[0], p[1])
+		callArgList = mirAppendArgWithComma(callArgList, p[0], p[1])
 	}
 	ret := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, mirCallTypedFnPtrText(ret, retTyp, fnPtr, callArgList))

--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -13,7 +13,7 @@
 package llvmgen
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -187,7 +187,7 @@ func synthFnSigFromFnType(ft *ast.FnType, env typeEnv) (*fnSig, error) {
 			return nil, err
 		}
 		info := paramInfo{
-			name:  fmt.Sprintf("arg%d", i),
+			name:  mirParamIndexedName(strconv.Itoa(i)),
 			typ:   typ,
 			irTyp: typ,
 		}
@@ -350,8 +350,8 @@ func (g *generator) emitClosureMakerCall(call *ast.CallExpr) (value, bool, error
 	for i, cv := range captureVals {
 		offset := llvmClosureEnvCapturesOffset() + i*8
 		slotPtr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", slotPtr, env.name, offset))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", cv.typ, cv.ref, slotPtr))
+		emitter.body = append(emitter.body, mirEnvCaptureSlotPtrGEPText(slotPtr, env.name, strconv.Itoa(offset)))
+		emitter.body = append(emitter.body, mirEnvCaptureStoreText(cv.typ, cv.ref, slotPtr))
 	}
 	g.takeOstyEmitter(emitter)
 	return value{
@@ -402,44 +402,18 @@ func (g *generator) ensureCapturingClosureThunk(rec *liftedClosure, origParamCou
 
 // llvmCapturingClosureThunkDefinition emits the LLVM IR for a
 // Phase 4 capturing thunk. See ensureCapturingClosureThunk for the
-// shape and call ABI.
+// shape and call ABI. Delegates to the Osty-sourced
+// `mirLlvmCapturingClosureThunkDefinition`
+// (`toolchain/mir_generator.osty`); the host-side wrapper plumbs the
+// fixed `closureEnvCapturesOffset` so the Osty function can stay pure.
 func llvmCapturingClosureThunkDefinition(symbol string, returnType string, origParamTypes []string, captureTypes []string) string {
-	ret := returnType
-	if ret == "" {
-		ret = "void"
-	}
-	headerParts := []string{"ptr %env"}
-	origArgParts := make([]string, 0, len(origParamTypes))
-	for i, p := range origParamTypes {
-		headerParts = append(headerParts, fmt.Sprintf("%s %%arg%d", p, i))
-		origArgParts = append(origArgParts, fmt.Sprintf("%s %%arg%d", p, i))
-	}
-	header := strings.Join(headerParts, ", ")
-	thunk := llvmClosureThunkName(symbol)
-	lines := []string{
-		fmt.Sprintf("define private %s @%s(%s) {", ret, thunk, header),
-		"entry:",
-	}
-	captureArgParts := make([]string, 0, len(captureTypes))
-	for i, ct := range captureTypes {
-		offset := llvmClosureEnvCapturesOffset() + i*8
-		slotName := fmt.Sprintf("%%cap%d_slot", i)
-		valName := fmt.Sprintf("%%cap%d", i)
-		lines = append(lines, fmt.Sprintf("  %s = getelementptr i8, ptr %%env, i64 %d", slotName, offset))
-		lines = append(lines, fmt.Sprintf("  %s = load %s, ptr %s", valName, ct, slotName))
-		captureArgParts = append(captureArgParts, fmt.Sprintf("%s %s", ct, valName))
-	}
-	allArgs := append(origArgParts, captureArgParts...)
-	callArgs := strings.Join(allArgs, ", ")
-	if ret == "void" {
-		lines = append(lines, fmt.Sprintf("  call void @%s(%s)", symbol, callArgs))
-		lines = append(lines, "  ret void")
-	} else {
-		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ret, symbol, callArgs))
-		lines = append(lines, fmt.Sprintf("  ret %s %%ret", ret))
-	}
-	lines = append(lines, "}")
-	return strings.Join(lines, "\n")
+	return mirLlvmCapturingClosureThunkDefinition(
+		symbol,
+		returnType,
+		origParamTypes,
+		captureTypes,
+		llvmClosureEnvCapturesOffset(),
+	)
 }
 
 func (g *generator) protectFnValueCallback(prefix string, v value, label string) (value, *fnSig, error) {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -814,50 +814,18 @@ func (g *generator) renderFunction(ret, name string, params []paramInfo) string 
 // A11 `#[noalias]` rules carry the LLVM `noalias` parameter attribute.
 // Non-pointer params and non-matching names are passed through
 // unchanged. The rewrite only touches the signature line — every
-// subsequent body line with parens is left alone.
+// subsequent body line with parens is left alone. Delegates to the
+// Osty-sourced `mirSpliceNoaliasParams` (`toolchain/mir_generator.osty`)
+// after un-tupling `[]paramInfo` into the parallel `paramTypes` /
+// `paramNames` arrays the Osty function consumes.
 func spliceNoaliasParams(rendered string, params []paramInfo, all bool, names []string) string {
-	nameSet := map[string]bool{}
-	for _, n := range names {
-		nameSet[n] = true
+	paramTypes := make([]string, len(params))
+	paramNames := make([]string, len(params))
+	for i, p := range params {
+		paramTypes[i] = p.typ
+		paramNames[i] = p.name
 	}
-	lineEnd := strings.IndexByte(rendered, '\n')
-	if lineEnd < 0 {
-		return rendered
-	}
-	line := rendered[:lineEnd]
-	rest := rendered[lineEnd:]
-	openParen := strings.IndexByte(line, '(')
-	closeParen := strings.LastIndexByte(line, ')')
-	if openParen < 0 || closeParen < 0 || closeParen <= openParen {
-		return rendered
-	}
-	prefix := line[:openParen+1]
-	suffix := line[closeParen:]
-	inner := line[openParen+1 : closeParen]
-	if inner == "" {
-		return rendered
-	}
-	pieces := strings.Split(inner, ", ")
-	for i, piece := range pieces {
-		if i >= len(params) {
-			break
-		}
-		if params[i].typ != "ptr" {
-			continue
-		}
-		if !all && !nameSet[params[i].name] {
-			continue
-		}
-		// `piece` looks like "ptr %name" — insert `noalias` between
-		// the type and the register name. Defensive: if the shape is
-		// unexpected we leave the piece intact.
-		parts := strings.SplitN(piece, " ", 2)
-		if len(parts) != 2 || parts[0] != "ptr" {
-			continue
-		}
-		pieces[i] = "ptr noalias " + parts[1]
-	}
-	return prefix + strings.Join(pieces, ", ") + suffix + rest
+	return mirSpliceNoaliasParams(rendered, paramTypes, paramNames, all, names)
 }
 
 // formatFnAttrs assembles the function-level LLVM attribute string
@@ -900,17 +868,10 @@ func (g *generator) formatFnAttrs() string {
 // closing paren and the opening brace. Leaves every other line
 // untouched. Used only when the HIR emitter has one or more v0.6 fn
 // attributes to emit — otherwise the renderer's output is byte-
-// identical to the pre-attribute shape.
+// identical to the pre-attribute shape. Delegates to the Osty-sourced
+// `mirSpliceFnAttrs` (`toolchain/mir_generator.osty`).
 func spliceFnAttrs(rendered, attrs string) string {
-	const needle = ") {"
-	// Only touch the first occurrence — a function body may contain
-	// other `) {` sequences in landing-pad blocks or nested
-	// structures, and we must not mis-attach attributes there.
-	idx := strings.Index(rendered, needle)
-	if idx < 0 {
-		return rendered
-	}
-	return rendered[:idx] + ") " + attrs + " {" + rendered[idx+len(needle):]
+	return mirSpliceFnAttrs(rendered, attrs)
 }
 
 // tagParallelAccessesLines is the `[]string` twin of the MIR path's
@@ -918,20 +879,11 @@ func spliceFnAttrs(rendered, attrs string) string {
 // `, !llvm.access.group !N` to load/store lines that do not already
 // carry that attachment. The HIR emitter accumulates the body in a
 // `[]string`, so we operate on the slice directly rather than on a
-// single joined string. The line predicate is shared with the MIR side
-// via `mirIsMemoryAccessLine` (Osty-mirrored in
-// `toolchain/mir_generator.osty`).
+// single joined string. Delegates to the Osty-sourced
+// `mirTagParallelAccessesLines` (`toolchain/mir_generator.osty`); the
+// line predicate is shared with the MIR side via `mirIsMemoryAccessLine`.
 func tagParallelAccessesLines(body []string, groupRef string) []string {
-	suffix := ", !llvm.access.group " + groupRef
-	out := make([]string, len(body))
-	for i, line := range body {
-		if mirIsMemoryAccessLine(line) && !strings.Contains(line, "!llvm.access.group") {
-			out[i] = line + suffix
-			continue
-		}
-		out[i] = line
-	}
-	return out
+	return mirTagParallelAccessesLines(body, groupRef)
 }
 
 func (g *generator) typeEnv() typeEnv {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -1033,45 +1033,19 @@ func legacyBindingTypeFromIR(typ ostyir.Type, hasValue bool) ast.Type {
 	return legacyTypeFromIR(typ)
 }
 
+// legacyPrimTypeName returns the user-visible Osty type name for an
+// `ir.PrimKind`. Delegates to the Osty-sourced `mirLegacyPrimTypeName`.
 func legacyPrimTypeName(kind ostyir.PrimKind) string {
-	switch kind {
-	case ostyir.PrimInt:
-		return "Int"
-	case ostyir.PrimInt8:
-		return "Int8"
-	case ostyir.PrimInt16:
-		return "Int16"
-	case ostyir.PrimInt32:
-		return "Int32"
-	case ostyir.PrimInt64:
-		return "Int64"
-	case ostyir.PrimUInt8:
-		return "UInt8"
-	case ostyir.PrimUInt16:
-		return "UInt16"
-	case ostyir.PrimUInt32:
-		return "UInt32"
-	case ostyir.PrimUInt64:
-		return "UInt64"
-	case ostyir.PrimByte:
-		return "Byte"
-	case ostyir.PrimFloat:
-		return "Float"
-	case ostyir.PrimFloat32:
-		return "Float32"
-	case ostyir.PrimFloat64:
-		return "Float64"
-	case ostyir.PrimBool:
-		return "Bool"
-	case ostyir.PrimChar:
-		return "Char"
-	case ostyir.PrimString:
-		return "String"
-	case ostyir.PrimBytes:
-		return "Bytes"
-	default:
-		return ""
-	}
+	return mirLegacyPrimTypeName(int(kind),
+		int(ostyir.PrimInt), int(ostyir.PrimInt8), int(ostyir.PrimInt16),
+		int(ostyir.PrimInt32), int(ostyir.PrimInt64),
+		int(ostyir.PrimUInt8), int(ostyir.PrimUInt16),
+		int(ostyir.PrimUInt32), int(ostyir.PrimUInt64),
+		int(ostyir.PrimByte),
+		int(ostyir.PrimFloat), int(ostyir.PrimFloat32), int(ostyir.PrimFloat64),
+		int(ostyir.PrimBool), int(ostyir.PrimChar),
+		int(ostyir.PrimString), int(ostyir.PrimBytes),
+	)
 }
 
 func legacyBlockFromIR(block *ostyir.Block) (*ast.Block, error) {
@@ -1208,33 +1182,22 @@ func legacyAssignStmtFromIR(stmt *ostyir.AssignStmt) (ast.Stmt, error) {
 	return out, nil
 }
 
+// legacyAssignOp maps the IR-level `AssignOp` to the `token.Kind` used
+// by AST AssignStmt nodes. Delegates to the Osty-sourced
+// `mirLegacyAssignOpCode`; the wrapper plumbs every relevant enum int
+// so the mapping stays in lockstep with both `internal/ir.AssignOp` and
+// `internal/token`.
 func legacyAssignOp(op ostyir.AssignOp) token.Kind {
-	switch op {
-	case ostyir.AssignEq:
-		return token.ASSIGN
-	case ostyir.AssignAdd:
-		return token.PLUSEQ
-	case ostyir.AssignSub:
-		return token.MINUSEQ
-	case ostyir.AssignMul:
-		return token.STAREQ
-	case ostyir.AssignDiv:
-		return token.SLASHEQ
-	case ostyir.AssignMod:
-		return token.PERCENTEQ
-	case ostyir.AssignAnd:
-		return token.BITANDEQ
-	case ostyir.AssignOr:
-		return token.BITOREQ
-	case ostyir.AssignXor:
-		return token.BITXOREQ
-	case ostyir.AssignShl:
-		return token.SHLEQ
-	case ostyir.AssignShr:
-		return token.SHREQ
-	default:
-		return token.ASSIGN
-	}
+	return token.Kind(mirLegacyAssignOpCode(int(op),
+		int(ostyir.AssignEq), int(ostyir.AssignAdd), int(ostyir.AssignSub),
+		int(ostyir.AssignMul), int(ostyir.AssignDiv), int(ostyir.AssignMod),
+		int(ostyir.AssignAnd), int(ostyir.AssignOr), int(ostyir.AssignXor),
+		int(ostyir.AssignShl), int(ostyir.AssignShr),
+		int(token.ASSIGN), int(token.PLUSEQ), int(token.MINUSEQ),
+		int(token.STAREQ), int(token.SLASHEQ), int(token.PERCENTEQ),
+		int(token.BITANDEQ), int(token.BITOREQ), int(token.BITXOREQ),
+		int(token.SHLEQ), int(token.SHREQ),
+	))
 }
 
 func legacyIfStmtFromIR(stmt *ostyir.IfStmt) (ast.Stmt, error) {
@@ -2072,77 +2035,51 @@ func legacyPatternFromIR(pattern ostyir.Pattern) (ast.Pattern, error) {
 	}
 }
 
+// legacyUnaryOp maps the IR-level `UnOp` to the `token.Kind` used by
+// AST UnaryExpr nodes. Delegates to the Osty-sourced
+// `mirLegacyUnaryOpCode`.
 func legacyUnaryOp(op ostyir.UnOp) token.Kind {
-	switch op {
-	case ostyir.UnNeg:
-		return token.MINUS
-	case ostyir.UnPlus:
-		return token.PLUS
-	case ostyir.UnNot:
-		return token.NOT
-	case ostyir.UnBitNot:
-		return token.BITNOT
-	default:
-		return token.ILLEGAL
-	}
+	return token.Kind(mirLegacyUnaryOpCode(int(op),
+		int(ostyir.UnNeg), int(ostyir.UnPlus), int(ostyir.UnNot), int(ostyir.UnBitNot),
+		int(token.MINUS), int(token.PLUS), int(token.NOT), int(token.BITNOT),
+		int(token.ILLEGAL),
+	))
 }
 
+// legacyBinaryOp maps the IR-level `BinOp` to the `token.Kind` used by
+// AST BinaryExpr nodes. Delegates to the Osty-sourced
+// `mirLegacyBinaryOpCode`.
 func legacyBinaryOp(op ostyir.BinOp) token.Kind {
-	switch op {
-	case ostyir.BinAdd:
-		return token.PLUS
-	case ostyir.BinSub:
-		return token.MINUS
-	case ostyir.BinMul:
-		return token.STAR
-	case ostyir.BinDiv:
-		return token.SLASH
-	case ostyir.BinMod:
-		return token.PERCENT
-	case ostyir.BinEq:
-		return token.EQ
-	case ostyir.BinNeq:
-		return token.NEQ
-	case ostyir.BinLt:
-		return token.LT
-	case ostyir.BinLeq:
-		return token.LEQ
-	case ostyir.BinGt:
-		return token.GT
-	case ostyir.BinGeq:
-		return token.GEQ
-	case ostyir.BinAnd:
-		return token.AND
-	case ostyir.BinOr:
-		return token.OR
-	case ostyir.BinBitAnd:
-		return token.BITAND
-	case ostyir.BinBitOr:
-		return token.BITOR
-	case ostyir.BinBitXor:
-		return token.BITXOR
-	case ostyir.BinShl:
-		return token.SHL
-	case ostyir.BinShr:
-		return token.SHR
-	default:
-		return token.ILLEGAL
-	}
+	return token.Kind(mirLegacyBinaryOpCode(int(op),
+		int(ostyir.BinAdd), int(ostyir.BinSub), int(ostyir.BinMul),
+		int(ostyir.BinDiv), int(ostyir.BinMod),
+		int(ostyir.BinEq), int(ostyir.BinNeq),
+		int(ostyir.BinLt), int(ostyir.BinLeq),
+		int(ostyir.BinGt), int(ostyir.BinGeq),
+		int(ostyir.BinAnd), int(ostyir.BinOr),
+		int(ostyir.BinBitAnd), int(ostyir.BinBitOr), int(ostyir.BinBitXor),
+		int(ostyir.BinShl), int(ostyir.BinShr),
+		int(token.PLUS), int(token.MINUS), int(token.STAR),
+		int(token.SLASH), int(token.PERCENT),
+		int(token.EQ), int(token.NEQ),
+		int(token.LT), int(token.LEQ), int(token.GT), int(token.GEQ),
+		int(token.AND), int(token.OR),
+		int(token.BITAND), int(token.BITOR), int(token.BITXOR),
+		int(token.SHL), int(token.SHR),
+		int(token.ILLEGAL),
+	))
 }
 
+// legacyIntrinsicName returns the user-visible name for an
+// `ir.IntrinsicKind`. Delegates to the Osty-sourced
+// `mirLegacyIntrinsicName`. Note this is distinct from the MIR
+// IntrinsicKind label table — IR-level intrinsics today only cover the
+// print family, while MIR's `mirIntrinsicLabel` covers ~114 cases.
 func legacyIntrinsicName(kind ostyir.IntrinsicKind) string {
-	switch kind {
-	case ostyir.IntrinsicPrint:
-		return "print"
-	case ostyir.IntrinsicPrintln:
-		return "println"
-	case ostyir.IntrinsicEprint:
-		return "eprint"
-	case ostyir.IntrinsicEprintln:
-		return "eprintln"
-	default:
-		return ""
-	}
+	return mirLegacyIntrinsicName(int(kind),
+		int(ostyir.IntrinsicPrint), int(ostyir.IntrinsicPrintln),
+		int(ostyir.IntrinsicEprint), int(ostyir.IntrinsicEprintln),
+	)
 }
 
 func legacyTypeExpr(name string, start, end token.Pos) ast.Expr {

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -926,58 +926,42 @@ func emitNativeInterfaceVtable(impl nativeInterfaceImpl) []byte {
 //
 // For unit-returning methods (ret == "void") the shim ends with
 // `ret void` without capturing a result value.
+// emitNativeInterfaceShim renders an interface→impl shim function for
+// the IR-driven native projection. The shim's signature is
+// `define <ret> @osty.shim.<struct>__<iface>__<method>(ptr %self_data, ...)`;
+// the body loads `%self` from `%self_data` (`align 8`) and forwards
+// to the underlying struct method, then returns. Most of the textual
+// shape lives in the Osty-sourced
+// `mirNativeShim*` helpers (`toolchain/mir_generator.osty`); this
+// wrapper composes them with the param-list and arg-list assembly that
+// is Go-side because it walks the in-memory ifaceMethod / structMethod
+// structs.
 func emitNativeInterfaceShim(impl nativeInterfaceImpl, m nativeInterfaceImplMethod) []byte {
 	var b strings.Builder
 	ret := m.ifaceMethod.returnLLVM
 	if ret == "" {
 		ret = "void"
 	}
-	b.WriteString("define ")
-	b.WriteString(ret)
-	b.WriteString(" @osty.shim.")
-	b.WriteString(impl.structName)
-	b.WriteString("__")
-	b.WriteString(impl.ifaceName)
-	b.WriteString("__")
-	b.WriteString(m.ifaceMethod.name)
-	b.WriteString("(ptr %self_data")
+	// Build the `, <ty> %argN` extension for each ifaceMethod param —
+	// these flow into both the def-header and the call-arg list.
+	var paramExt strings.Builder
 	for i, pt := range m.ifaceMethod.paramLLVMs {
-		b.WriteString(", ")
-		b.WriteString(pt)
-		b.WriteString(" %arg")
-		b.WriteString(strconv.Itoa(i))
+		paramExt.WriteString(", ")
+		paramExt.WriteString(pt)
+		paramExt.WriteString(" %arg")
+		paramExt.WriteString(strconv.Itoa(i))
 	}
-	b.WriteString(") {\nentry:\n")
-	b.WriteString("  %self = load ")
-	b.WriteString(impl.structLLVM)
-	b.WriteString(", ptr %self_data, align 8\n")
-	callLHS := ""
-	if ret != "void" {
-		callLHS = "  %res = "
-	} else {
-		callLHS = "  "
-	}
-	b.WriteString(callLHS)
-	b.WriteString("call ")
-	b.WriteString(ret)
-	b.WriteString(" @")
-	b.WriteString(m.structMethod.irName)
-	b.WriteString("(")
-	b.WriteString(impl.structLLVM)
-	b.WriteString(" %self")
-	for i, pt := range m.ifaceMethod.paramLLVMs {
-		b.WriteString(", ")
-		b.WriteString(pt)
-		b.WriteString(" %arg")
-		b.WriteString(strconv.Itoa(i))
-	}
-	b.WriteString(")\n")
+	b.WriteString(mirNativeShimDefineHeaderText(ret, impl.structName, impl.ifaceName, m.ifaceMethod.name, paramExt.String()))
+	b.WriteString(mirNativeShimLoadSelfText(impl.structLLVM))
+	// Compose the call-arg list: receiver `<structLLVM> %self` plus
+	// the same `, <ty> %argN` extension paramExt holds.
+	argList := mirCallArgsTypePair(impl.structLLVM, "%self") + paramExt.String()
 	if ret == "void" {
-		b.WriteString("  ret void\n")
+		b.WriteString(mirNativeShimCallVoidText(ret, m.structMethod.irName, argList))
+		b.WriteString(mirNativeShimRetVoidText())
 	} else {
-		b.WriteString("  ret ")
-		b.WriteString(ret)
-		b.WriteString(" %res\n")
+		b.WriteString(mirNativeShimCallValueText(ret, m.structMethod.irName, argList))
+		b.WriteString(mirNativeShimRetValueText(ret))
 	}
 	b.WriteString("}\n")
 	return []byte(b.String())
@@ -4520,8 +4504,9 @@ func appendNativeClosureThunks(out []byte, ctx *nativeProjectionCtx) []byte {
 		b.WriteString(") {\nentry:\n")
 		// Load each capture from env at offset `closureEnvCapturesOffset + i*8`.
 		for i, capType := range info.captureLLVMs {
-			b.WriteString(fmt.Sprintf("  %%cap%d_slot = getelementptr i8, ptr %%env, i64 %d\n", i, llvmClosureEnvCapturesOffset()+i*8))
-			b.WriteString(fmt.Sprintf("  %%cap%d = load %s, ptr %%cap%d_slot\n", i, capType, i))
+			idxStr := strconv.Itoa(i)
+			b.WriteString(mirCaptureSlotGEPLine(idxStr, "%env", strconv.Itoa(llvmClosureEnvCapturesOffset()+i*8)))
+			b.WriteString(mirCaptureLoadLine(idxStr, capType))
 		}
 		// Call the lifted fn: (orig_args..., cap0, cap1, ...). Env
 		// is dropped because the lifted fn takes captures as regular

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -592,7 +592,7 @@ func localDefiningSiteHint(fn *mir.Function, id mir.LocalID) string {
 			switch x := inst.(type) {
 			case *mir.AssignInstr:
 				if placeReferencesLocal(x.Dest, id) {
-					return fmt.Sprintf("written by assign at %d:%d (src=%s)", x.SpanV.Start.Line, x.SpanV.Start.Column, mirRValueDebugString(x.Src))
+					return mirAssignWrittenByText(strconv.Itoa(x.SpanV.Start.Line), strconv.Itoa(x.SpanV.Start.Column), mirRValueDebugString(x.Src))
 				}
 			case *mir.CallInstr:
 				if x.Dest != nil && placeReferencesLocal(*x.Dest, id) {
@@ -600,11 +600,11 @@ func localDefiningSiteHint(fn *mir.Function, id mir.LocalID) string {
 					if x.Callee != nil {
 						callee = mirCalleeDebugString(x.Callee)
 					}
-					return fmt.Sprintf("written by call `%s` at %d:%d", callee, x.SpanV.Start.Line, x.SpanV.Start.Column)
+					return mirCallWrittenByText(callee, strconv.Itoa(x.SpanV.Start.Line), strconv.Itoa(x.SpanV.Start.Column))
 				}
 			case *mir.IntrinsicInstr:
 				if x.Dest != nil && placeReferencesLocal(*x.Dest, id) {
-					return fmt.Sprintf("written by intrinsic kind=%d at %d:%d", int(x.Kind), x.SpanV.Start.Line, x.SpanV.Start.Column)
+					return mirIntrinsicWrittenByText(strconv.Itoa(int(x.Kind)), strconv.Itoa(x.SpanV.Start.Line), strconv.Itoa(x.SpanV.Start.Column))
 				}
 			}
 		}
@@ -622,16 +622,16 @@ func mirRValueDebugString(r mir.RValue) string {
 	}
 	switch v := r.(type) {
 	case *mir.BinaryRV:
-		return fmt.Sprintf("BinaryRV(op=%d, T=%s)", int(v.Op), mirTypeString(v.T))
+		return mirRValueBinaryDebugText(strconv.Itoa(int(v.Op)), mirTypeString(v.T))
 	case *mir.UnaryRV:
-		return fmt.Sprintf("UnaryRV(op=%d, T=%s)", int(v.Op), mirTypeString(v.T))
+		return mirRValueUnaryDebugText(strconv.Itoa(int(v.Op)), mirTypeString(v.T))
 	case *mir.AggregateRV:
-		return fmt.Sprintf("AggregateRV(kind=%d, T=%s)", int(v.Kind), mirTypeString(v.T))
+		return mirRValueAggregateDebugText(strconv.Itoa(int(v.Kind)), mirTypeString(v.T))
 	case *mir.UseRV:
 		_ = v
 		return "UseRV"
 	case *mir.CastRV:
-		return fmt.Sprintf("CastRV(kind=%d, To=%s)", int(v.Kind), mirTypeString(v.To))
+		return mirRValueCastDebugText(strconv.Itoa(int(v.Kind)), mirTypeString(v.To))
 	}
 	return fmt.Sprintf("%T", r)
 }
@@ -933,13 +933,14 @@ func mirFunctionHasBackedge(fn *mir.Function) bool {
 	return false
 }
 
+// mirIntrinsicSafeForVectorListFastPath reports whether a MIR intrinsic
+// kind is safe to invoke against a vector-List local that has been
+// hoisted to a single fast-path snapshot. Delegates to the Osty-sourced
+// `mirIntrinsicVectorListFastPathSafe` (renamed there to avoid
+// package-private name collision with this host-side wrapper).
 func mirIntrinsicSafeForVectorListFastPath(k mir.IntrinsicKind) bool {
-	switch k {
-	case mir.IntrinsicListLen, mir.IntrinsicListIsEmpty:
-		return true
-	default:
-		return false
-	}
+	return mirIntrinsicVectorListFastPathSafe(int(k),
+		int(mir.IntrinsicListLen), int(mir.IntrinsicListIsEmpty))
 }
 
 // planVectorListHoists identifies non-param scalar-List locals whose
@@ -1236,7 +1237,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 // families, so the fallback is the same `fmt.Sprintf("kind=%d", int(k))`
 // the original implementation used for unrecognised codes.
 func mirIntrinsicLabel(k mir.IntrinsicKind) string {
-	fallback := fmt.Sprintf("kind=%d", int(k))
+	fallback := mirIntrinsicLabelKindFallback(strconv.Itoa(int(k)))
 	return mirIntrinsicKindLabelFull(int(k), fallback)
 }
 
@@ -1630,14 +1631,14 @@ func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
 			// them. The alloca is named after the param index so it
 			// doesn't clash with the %argN register holding the
 			// incoming value.
-			slot := fmt.Sprintf("%%p%d", loc.ID)
+			slot := mirParamSlotName(strconv.Itoa(int(loc.ID)))
 			g.localSlots[loc.ID] = slot
 			if !isUnitType(loc.Type) {
 				g.fnBuf.WriteString(mirAllocaLine(slot, g.llvmType(loc.Type)))
 			}
 			continue
 		}
-		slot := fmt.Sprintf("%%l%d", loc.ID)
+		slot := mirLocalSlotName(strconv.Itoa(int(loc.ID)))
 		g.localSlots[loc.ID] = slot
 		if isUnitType(loc.Type) {
 			// Unit has no storage.
@@ -3282,7 +3283,7 @@ func (g *mirGen) emitTestingAbortString(message *LlvmValue, nextLabel string) {
 }
 
 func (g *mirGen) testingFailureMessage(line int, method string) string {
-	return fmt.Sprintf("testing.%s failed at %s", method, g.testingSourceLineLabel(line, "<test>"))
+	return mirTestingFailureMessage(method, g.testingSourceLineLabel(line, "<test>"))
 }
 
 func (g *mirGen) testingSourceLineLabel(line int, fallback string) string {
@@ -3292,7 +3293,7 @@ func (g *mirGen) testingSourceLineLabel(line int, fallback string) string {
 	} else if abs, err := filepath.Abs(source); err == nil {
 		source = filepath.ToSlash(abs)
 	}
-	return fmt.Sprintf("%s:%d", source, line)
+	return mirSourceLineLabelText(source, strconv.Itoa(line))
 }
 
 func (g *mirGen) operandSourceText(op mir.Operand) string {
@@ -3372,7 +3373,7 @@ func (g *mirGen) buildAssertCondMessageMIR(line int, method, exprText string) *L
 	if method == "expectOk" || method == "expectError" {
 		label = "expr"
 	}
-	return g.testingStringLiteral(fmt.Sprintf("%s: %s=`%s`", base, label, exprText))
+	return g.testingStringLiteral(mirAssertExprFragmentText(base, label, exprText))
 }
 
 func (g *mirGen) buildAssertCompareMessageMIR(line int, method, leftText, rightText, leftReg string, leftT mir.Type, rightReg string, rightT mir.Type) (*LlvmValue, error) {
@@ -3389,11 +3390,11 @@ func (g *mirGen) buildAssertCompareMessageMIR(line int, method, leftText, rightT
 	if leftText == "" && rightText == "" && !leftHas && !rightHas {
 		return g.testingStringLiteral(base), nil
 	}
-	parts = append(parts, g.testingStringLiteral(fmt.Sprintf("%s: left=`%s`", base, leftText)))
+	parts = append(parts, g.testingStringLiteral(mirAssertExprLeftFragmentText(base, leftText)))
 	if leftHas {
 		parts = append(parts, g.testingStringLiteral(" = "), leftStr)
 	}
-	parts = append(parts, g.testingStringLiteral(fmt.Sprintf(" right=`%s`", rightText)))
+	parts = append(parts, g.testingStringLiteral(mirAssertExprRightFragmentText(rightText)))
 	if rightHas {
 		parts = append(parts, g.testingStringLiteral(" = "), rightStr)
 	}
@@ -8100,7 +8101,7 @@ func isHeapEqualityType(t mir.Type) bool {
 // stay byte-stable.
 func (g *mirGen) emitHeapEquality(op mir.BinaryOp, left, right string) (string, error) {
 	sym := llvmStringRuntimeEqualSymbol()
-	g.declareRuntime(sym, fmt.Sprintf("declare i1 @%s(ptr, ptr)", sym))
+	g.declareRuntime(sym, mirRuntimeDeclareI1FromTwoPtrText(sym))
 	eq := g.fresh()
 	g.fnBuf.WriteString(mirCallI1FromTwoPtrLine(eq, sym, left, right))
 	if op == mir.BinEq {
@@ -8199,7 +8200,7 @@ func isStringOrderingBinOp(op mir.BinaryOp) bool {
 // results for content ordering.
 func (g *mirGen) emitStringOrdering(op mir.BinaryOp, left, right string) (string, error) {
 	sym := llvmStringRuntimeCompareSymbol()
-	g.declareRuntime(sym, fmt.Sprintf("declare i64 @%s(ptr, ptr)", sym))
+	g.declareRuntime(sym, mirRuntimeDeclareI64FromTwoPtrText(sym))
 	cmp := g.fresh()
 	g.fnBuf.WriteString(mirCallI64FromTwoPtrLine(cmp, sym, left, right))
 	pred := stringOrderingPredicate(op)
@@ -8575,15 +8576,14 @@ func mirTypeString(t mir.Type) string {
 	return t.String()
 }
 
+// formatFloat renders a Float64 in a form LLVM's text-IR parser
+// recognises as a float (i.e. with a `.` / `e` / `E` somewhere). The
+// fractional-or-exponent guard runs in the Osty-sourced
+// `mirFormatFloatEnsureDot` (`toolchain/mir_generator.osty`) — only
+// the host-side `strconv.FormatFloat` step stays Go because Osty has
+// no equivalent yet.
 func formatFloat(v float64) string {
-	// Use enough precision so the result round-trips in LLVM's
-	// text-IR float parser. LLVM accepts both decimal and hex-float
-	// literals; decimal is fine for our test corpus.
-	s := strconv.FormatFloat(v, 'g', -1, 64)
-	if !strings.ContainsAny(s, ".eE") {
-		s += ".0"
-	}
-	return s
+	return mirFormatFloatEnsureDot(strconv.FormatFloat(v, 'g', -1, 64))
 }
 
 // Sentinel so goimports doesn't prune sort.

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -8812,6 +8812,14 @@ func mirPrependRootIndex(index int, paths [][]int) [][]int {
 }
 
 // Osty: mirIntrinsicKindLabelFull
+//
+// Slice 11 extension: covers every IntrinsicKind iota value from
+// IntrinsicPrint (1) through IntrinsicMapIncr (113). Diagnostics that
+// formerly rendered "kind=NN" now produce a symbolic label —
+// "list.push", "map.get_or", "select.recv" — making the failure mode
+// substantially easier to read at a glance. The label table is kept on
+// the Osty side so the canonical text lives next to the rest of the
+// MIR-emitter literal surface.
 func mirIntrinsicKindLabelFull(kind int, kindFallback string) string {
 	switch kind {
 	case 1:
@@ -8822,22 +8830,224 @@ func mirIntrinsicKindLabelFull(kind int, kindFallback string) string {
 		return "eprint"
 	case 4:
 		return "eprintln"
+	case 5:
+		return "abort"
 	case 6:
 		return "string_concat"
+	case 7:
+		return "chan.make"
+	case 8:
+		return "chan.send"
+	case 9:
+		return "chan.recv"
+	case 10:
+		return "chan.close"
+	case 11:
+		return "chan.is_closed"
+	case 12:
+		return "task_group"
+	case 13:
+		return "spawn"
+	case 14:
+		return "handle.join"
+	case 15:
+		return "group.cancel"
+	case 16:
+		return "group.is_cancelled"
+	case 17:
+		return "parallel"
+	case 18:
+		return "race"
+	case 19:
+		return "collect_all"
+	case 20:
+		return "select"
+	case 21:
+		return "select.recv"
+	case 22:
+		return "select.send"
+	case 23:
+		return "select.timeout"
+	case 24:
+		return "select.default"
+	case 25:
+		return "is_cancelled"
+	case 26:
+		return "check_cancelled"
+	case 27:
+		return "yield"
+	case 28:
+		return "sleep"
+	case 29:
+		return "list.push"
+	case 30:
+		return "list.len"
+	case 31:
+		return "list.get"
+	case 32:
+		return "list.is_empty"
+	case 33:
+		return "list.first"
+	case 34:
+		return "list.last"
+	case 35:
+		return "list.sorted"
+	case 36:
+		return "list.contains"
+	case 37:
+		return "list.index_of"
+	case 38:
+		return "list.to_set"
+	case 39:
+		return "list.remove_at"
+	case 40:
+		return "list.reverse"
+	case 41:
+		return "list.reversed"
+	case 42:
+		return "map.new"
+	case 43:
+		return "map.get"
+	case 44:
+		return "map.set"
+	case 45:
+		return "map.contains"
+	case 46:
+		return "map.len"
+	case 47:
+		return "map.keys"
+	case 48:
+		return "map.values"
+	case 49:
+		return "map.remove"
+	case 50:
+		return "map.keys_sorted"
+	case 51:
+		return "set.new"
+	case 52:
+		return "set.insert"
+	case 53:
+		return "set.contains"
+	case 54:
+		return "set.len"
+	case 55:
+		return "set.to_list"
+	case 56:
+		return "set.remove"
 	case 57:
 		return "string_len"
 	case 58:
 		return "string_is_empty"
+	case 59:
+		return "string_contains"
+	case 60:
+		return "string_count"
+	case 61:
+		return "string_starts_with"
+	case 62:
+		return "string_ends_with"
+	case 63:
+		return "string_index_of"
+	case 64:
+		return "string_split"
+	case 65:
+		return "string_trim"
+	case 66:
+		return "string_to_upper"
+	case 67:
+		return "string_to_lower"
 	case 68:
 		return "string_to_int"
 	case 69:
 		return "string_to_float"
+	case 70:
+		return "string_replace"
 	case 71:
 		return "string_chars"
 	case 72:
 		return "string_bytes"
+	case 73:
+		return "bytes.len"
+	case 74:
+		return "bytes.is_empty"
+	case 75:
+		return "bytes.get"
+	case 76:
+		return "bytes.contains"
+	case 77:
+		return "bytes.starts_with"
+	case 78:
+		return "bytes.ends_with"
+	case 79:
+		return "bytes.index_of"
+	case 80:
+		return "bytes.last_index_of"
+	case 81:
+		return "bytes.split"
+	case 82:
+		return "bytes.join"
+	case 83:
+		return "bytes.concat"
+	case 84:
+		return "bytes.repeat"
+	case 85:
+		return "bytes.replace"
+	case 86:
+		return "bytes.replace_all"
+	case 87:
+		return "bytes.trim_left"
+	case 88:
+		return "bytes.trim_right"
+	case 89:
+		return "bytes.trim"
+	case 90:
+		return "bytes.trim_space"
+	case 91:
+		return "bytes.to_upper"
+	case 92:
+		return "bytes.to_lower"
+	case 93:
+		return "bytes.to_hex"
+	case 94:
+		return "bytes.slice"
+	case 95:
+		return "option.is_some"
+	case 96:
+		return "option.is_none"
+	case 97:
+		return "option.unwrap"
+	case 98:
+		return "option.unwrap_or"
+	case 99:
+		return "result.is_ok"
+	case 100:
+		return "result.is_err"
+	case 101:
+		return "result.unwrap"
+	case 102:
+		return "result.unwrap_or"
 	case 103:
 		return "raw.null"
+	case 104:
+		return "string_join"
+	case 105:
+		return "list.pop"
+	case 106:
+		return "string_substring"
+	case 107:
+		return "byte.to_int"
+	case 108:
+		return "char.to_int"
+	case 109:
+		return "list.slice"
+	case 110:
+		return "map.get_or"
+	case 111:
+		return "string_split_into"
+	case 112:
+		return "string_nth_segment"
+	case 113:
+		return "map.incr"
 	}
 	return kindFallback
 }
@@ -9448,4 +9658,907 @@ func mirIfaceStructLayout() string {
 // Osty: mirRootFrameStructLayout
 func mirRootFrameStructLayout() string {
 	return "{ ptr, ptr, i64 }"
+}
+
+// Osty: mirSpliceFnAttrs
+func mirSpliceFnAttrs(rendered, attrs string) string {
+	const needle = ") {"
+	idx := llvmStrings.Index(rendered, needle)
+	if idx < 0 {
+		return rendered
+	}
+	return rendered[:idx] + ") " + attrs + " {" + rendered[idx+len(needle):]
+}
+
+// Osty: mirSpliceNoaliasParams
+//
+// Rewrites the first `define ... (<params>) {` line of rendered IR so
+// that pointer parameters whose type is `ptr` and (when `all` is false)
+// whose name appears in `selectedNames` carry the LLVM `noalias`
+// parameter attribute. Mirrors `spliceNoaliasParams` in
+// `internal/llvmgen/generator.go`.
+func mirSpliceNoaliasParams(
+	rendered string,
+	paramTypes, paramNames []string,
+	all bool,
+	selectedNames []string,
+) string {
+	lineEnd := llvmStrings.Index(rendered, "\n")
+	if lineEnd < 0 {
+		return rendered
+	}
+	line := rendered[:lineEnd]
+	rest := rendered[lineEnd:]
+	openParen := llvmStrings.Index(line, "(")
+	closeParen := llvmStrings.LastIndex(line, ")")
+	if openParen < 0 || closeParen < 0 || closeParen <= openParen {
+		return rendered
+	}
+	prefix := line[:openParen+1]
+	suffix := line[closeParen:]
+	inner := line[openParen+1 : closeParen]
+	if inner == "" {
+		return rendered
+	}
+	pieces := mirSplitCommaSep(inner)
+	out := make([]string, 0, len(pieces))
+	for i, piece := range pieces {
+		if i >= len(paramTypes) {
+			out = append(out, piece)
+			continue
+		}
+		if paramTypes[i] != "ptr" {
+			out = append(out, piece)
+			continue
+		}
+		if !all {
+			name := paramNames[i]
+			matched := false
+			for _, sn := range selectedNames {
+				if sn == name {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				out = append(out, piece)
+				continue
+			}
+		}
+		spaceIdx := llvmStrings.Index(piece, " ")
+		if spaceIdx < 0 {
+			out = append(out, piece)
+			continue
+		}
+		head := piece[:spaceIdx]
+		if head != "ptr" {
+			out = append(out, piece)
+			continue
+		}
+		regPart := piece[spaceIdx+1:]
+		out = append(out, "ptr noalias "+regPart)
+	}
+	return prefix + llvmStrings.Join(out, ", ") + suffix + rest
+}
+
+// Osty: mirSplitCommaSep
+func mirSplitCommaSep(input string) []string {
+	if input == "" {
+		return []string{""}
+	}
+	return llvmStrings.Split(input, ", ")
+}
+
+// Osty: mirTagParallelAccessesLines
+//
+// `[]string` twin of mirTagParallelAccesses.
+func mirTagParallelAccessesLines(body []string, groupRef string) []string {
+	suffix := ", !llvm.access.group " + groupRef
+	out := make([]string, len(body))
+	for i, line := range body {
+		if mirIsMemoryAccessLine(line) && !llvmStrings.Contains(line, "!llvm.access.group") {
+			out[i] = line + suffix
+			continue
+		}
+		out[i] = line
+	}
+	return out
+}
+
+// Osty: mirLlvmAggregatePathIndices
+func mirLlvmAggregatePathIndices(path []int) string {
+	parts := make([]string, 0, len(path)+1)
+	parts = append(parts, "i32 0")
+	for _, idx := range path {
+		parts = append(parts, "i32 "+strconv.Itoa(idx))
+	}
+	return llvmStrings.Join(parts, ", ")
+}
+
+// Osty: mirConstIntBinary
+//
+// 0 sentinel for failure (caller must consult mirConstIntBinaryStatus
+// to distinguish "computed 0" from "unsupported / divide-by-zero"):
+// 0 = success, 1 = div0, 2 = mod0, 3 = unsupported op.
+func mirConstIntBinary(
+	op int,
+	left, right int64,
+	plus, minus, star, slash, percent int,
+	bitAnd, bitOr, bitXor int,
+	shl, shr int,
+) int64 {
+	switch op {
+	case plus:
+		return left + right
+	case minus:
+		return left - right
+	case star:
+		return left * right
+	case slash:
+		if right == 0 {
+			return 0
+		}
+		return left / right
+	case percent:
+		if right == 0 {
+			return 0
+		}
+		return left % right
+	case bitAnd:
+		return left & right
+	case bitOr:
+		return left | right
+	case bitXor:
+		return left ^ right
+	case shl:
+		return left << uint(right)
+	case shr:
+		return left >> uint(right)
+	}
+	return 0
+}
+
+// Osty: mirConstIntBinaryStatus
+func mirConstIntBinaryStatus(
+	op int,
+	right int64,
+	plus, minus, star, slash, percent int,
+	bitAnd, bitOr, bitXor int,
+	shl, shr int,
+) int {
+	switch op {
+	case plus, minus, star, bitAnd, bitOr, bitXor, shl, shr:
+		return 0
+	case slash:
+		if right == 0 {
+			return 1
+		}
+		return 0
+	case percent:
+		if right == 0 {
+			return 2
+		}
+		return 0
+	}
+	return 3
+}
+
+// Osty: mirLegacyAssignOpCode
+func mirLegacyAssignOpCode(
+	op int,
+	assignEq, assignAdd, assignSub, assignMul, assignDiv, assignMod int,
+	assignAnd, assignOr, assignXor int,
+	assignShl, assignShr int,
+	tokAssign, tokPlusEq, tokMinusEq, tokStarEq, tokSlashEq, tokPercentEq int,
+	tokBitAndEq, tokBitOrEq, tokBitXorEq int,
+	tokShlEq, tokShrEq int,
+) int {
+	switch op {
+	case assignEq:
+		return tokAssign
+	case assignAdd:
+		return tokPlusEq
+	case assignSub:
+		return tokMinusEq
+	case assignMul:
+		return tokStarEq
+	case assignDiv:
+		return tokSlashEq
+	case assignMod:
+		return tokPercentEq
+	case assignAnd:
+		return tokBitAndEq
+	case assignOr:
+		return tokBitOrEq
+	case assignXor:
+		return tokBitXorEq
+	case assignShl:
+		return tokShlEq
+	case assignShr:
+		return tokShrEq
+	}
+	return tokAssign
+}
+
+// Osty: mirLegacyUnaryOpCode
+func mirLegacyUnaryOpCode(
+	op int,
+	unNeg, unPlus, unNot, unBitNot int,
+	tokMinus, tokPlus, tokNot, tokBitNot int,
+	tokIllegal int,
+) int {
+	switch op {
+	case unNeg:
+		return tokMinus
+	case unPlus:
+		return tokPlus
+	case unNot:
+		return tokNot
+	case unBitNot:
+		return tokBitNot
+	}
+	return tokIllegal
+}
+
+// Osty: mirLegacyBinaryOpCode
+func mirLegacyBinaryOpCode(
+	op int,
+	binAdd, binSub, binMul, binDiv, binMod int,
+	binEq, binNeq, binLt, binLeq, binGt, binGeq int,
+	binAnd, binOr int,
+	binBitAnd, binBitOr, binBitXor int,
+	binShl, binShr int,
+	tokPlus, tokMinus, tokStar, tokSlash, tokPercent int,
+	tokEQ, tokNEQ, tokLT, tokLEQ, tokGT, tokGEQ int,
+	tokAnd, tokOr int,
+	tokBitAnd, tokBitOr, tokBitXor int,
+	tokShl, tokShr int,
+	tokIllegal int,
+) int {
+	switch op {
+	case binAdd:
+		return tokPlus
+	case binSub:
+		return tokMinus
+	case binMul:
+		return tokStar
+	case binDiv:
+		return tokSlash
+	case binMod:
+		return tokPercent
+	case binEq:
+		return tokEQ
+	case binNeq:
+		return tokNEQ
+	case binLt:
+		return tokLT
+	case binLeq:
+		return tokLEQ
+	case binGt:
+		return tokGT
+	case binGeq:
+		return tokGEQ
+	case binAnd:
+		return tokAnd
+	case binOr:
+		return tokOr
+	case binBitAnd:
+		return tokBitAnd
+	case binBitOr:
+		return tokBitOr
+	case binBitXor:
+		return tokBitXor
+	case binShl:
+		return tokShl
+	case binShr:
+		return tokShr
+	}
+	return tokIllegal
+}
+
+// Osty: mirLegacyPrimTypeName
+func mirLegacyPrimTypeName(
+	kind int,
+	primInt, primInt8, primInt16, primInt32, primInt64 int,
+	primUInt8, primUInt16, primUInt32, primUInt64 int,
+	primByte int,
+	primFloat, primFloat32, primFloat64 int,
+	primBool, primChar, primString, primBytes int,
+) string {
+	switch kind {
+	case primInt:
+		return "Int"
+	case primInt8:
+		return "Int8"
+	case primInt16:
+		return "Int16"
+	case primInt32:
+		return "Int32"
+	case primInt64:
+		return "Int64"
+	case primUInt8:
+		return "UInt8"
+	case primUInt16:
+		return "UInt16"
+	case primUInt32:
+		return "UInt32"
+	case primUInt64:
+		return "UInt64"
+	case primByte:
+		return "Byte"
+	case primFloat:
+		return "Float"
+	case primFloat32:
+		return "Float32"
+	case primFloat64:
+		return "Float64"
+	case primBool:
+		return "Bool"
+	case primChar:
+		return "Char"
+	case primString:
+		return "String"
+	case primBytes:
+		return "Bytes"
+	}
+	return ""
+}
+
+// Osty: mirLegacyIntrinsicName
+func mirLegacyIntrinsicName(
+	kind int,
+	intrinsicPrint, intrinsicPrintln, intrinsicEprint, intrinsicEprintln int,
+) string {
+	switch kind {
+	case intrinsicPrint:
+		return "print"
+	case intrinsicPrintln:
+		return "println"
+	case intrinsicEprint:
+		return "eprint"
+	case intrinsicEprintln:
+		return "eprintln"
+	}
+	return ""
+}
+
+// Osty: mirLlvmCapturingClosureThunkDefinition
+func mirLlvmCapturingClosureThunkDefinition(
+	symbol, returnType string,
+	origParamTypes, captureTypes []string,
+	capturesOffset int,
+) string {
+	ret := returnType
+	if ret == "" {
+		ret = "void"
+	}
+	thunk := mirThunkName(symbol)
+	headerParts := []string{"ptr %env"}
+	origArgParts := make([]string, 0, len(origParamTypes))
+	for i, p := range origParamTypes {
+		idxStr := strconv.Itoa(i)
+		headerParts = append(headerParts, p+" %arg"+idxStr)
+		origArgParts = append(origArgParts, p+" %arg"+idxStr)
+	}
+	header := llvmStrings.Join(headerParts, ", ")
+	lines := []string{
+		mirThunkDefineHeaderText(ret, thunk, header),
+		"entry:",
+	}
+	captureArgParts := make([]string, 0, len(captureTypes))
+	for k, ct := range captureTypes {
+		offset := capturesOffset + k*8
+		kStr := strconv.Itoa(k)
+		lines = append(lines, mirCaptureSlotGEPText(kStr, "%env", strconv.Itoa(offset)))
+		lines = append(lines, mirCaptureLoadText(kStr, ct))
+		captureArgParts = append(captureArgParts, ct+" %cap"+kStr)
+	}
+	allArgs := append(origArgParts, captureArgParts...)
+	callArgs := llvmStrings.Join(allArgs, ", ")
+	if ret == "void" {
+		lines = append(lines, mirThunkCallVoidText(symbol, callArgs))
+		lines = append(lines, mirThunkRetVoidText())
+	} else {
+		lines = append(lines, mirThunkCallValueText(ret, symbol, callArgs))
+		lines = append(lines, mirThunkRetValueText(ret))
+	}
+	lines = append(lines, mirThunkBraceCloseText())
+	return llvmStrings.Join(lines, "\n")
+}
+
+// Osty: mirJoinCommaSep
+func mirJoinCommaSep(parts []string) string {
+	return llvmStrings.Join(parts, ", ")
+}
+
+// Osty: mirJoinNewline
+func mirJoinNewline(parts []string) string {
+	return llvmStrings.Join(parts, "\n")
+}
+
+// Osty: mirGEPI8ByteStrideText
+func mirGEPI8ByteStrideText(reg, basePtr, offDigits string) string {
+	return "  " + reg + " = getelementptr i8, ptr " + basePtr + ", i64 " + offDigits
+}
+
+// Osty: mirCaptureSlotGEPText
+func mirCaptureSlotGEPText(idxDigits, env, offDigits string) string {
+	return "  %cap" + idxDigits + "_slot = getelementptr i8, ptr " + env + ", i64 " + offDigits
+}
+
+// Osty: mirCaptureLoadText
+func mirCaptureLoadText(idxDigits, ty string) string {
+	return "  %cap" + idxDigits + " = load " + ty + ", ptr %cap" + idxDigits + "_slot"
+}
+
+// Osty: mirCaptureSlotGEPLine
+func mirCaptureSlotGEPLine(idxDigits, env, offDigits string) string {
+	return mirCaptureSlotGEPText(idxDigits, env, offDigits) + "\n"
+}
+
+// Osty: mirCaptureLoadLine
+func mirCaptureLoadLine(idxDigits, ty string) string {
+	return mirCaptureLoadText(idxDigits, ty) + "\n"
+}
+
+// Osty: mirThunkDefineHeaderText
+func mirThunkDefineHeaderText(ret, thunk, header string) string {
+	return "define private " + ret + " @" + thunk + "(" + header + ") {"
+}
+
+// Osty: mirThunkCallVoidText
+func mirThunkCallVoidText(sym, callArgs string) string {
+	return "  call void @" + sym + "(" + callArgs + ")"
+}
+
+// Osty: mirThunkCallValueText
+func mirThunkCallValueText(ret, sym, callArgs string) string {
+	return "  %ret = call " + ret + " @" + sym + "(" + callArgs + ")"
+}
+
+// Osty: mirThunkRetVoidText
+func mirThunkRetVoidText() string {
+	return "  ret void"
+}
+
+// Osty: mirThunkRetValueText
+func mirThunkRetValueText(ret string) string {
+	return "  ret " + ret + " %ret"
+}
+
+// Osty: mirThunkBraceCloseText
+func mirThunkBraceCloseText() string {
+	return "}"
+}
+
+// Osty: mirEnvCaptureStoreText
+func mirEnvCaptureStoreText(ty, val, slot string) string {
+	return "  store " + ty + " " + val + ", ptr " + slot
+}
+
+// Osty: mirEnvCaptureSlotPtrGEPText
+func mirEnvCaptureSlotPtrGEPText(slotPtr, env, offDigits string) string {
+	return "  " + slotPtr + " = getelementptr i8, ptr " + env + ", i64 " + offDigits
+}
+
+// Osty: mirThunkCallVoidLine
+func mirThunkCallVoidLine(sym, callArgs string) string {
+	return mirThunkCallVoidText(sym, callArgs) + "\n"
+}
+
+// Osty: mirThunkCallValueLine
+func mirThunkCallValueLine(ret, sym, callArgs string) string {
+	return mirThunkCallValueText(ret, sym, callArgs) + "\n"
+}
+
+// Osty: mirThunkRetVoidLine
+func mirThunkRetVoidLine() string {
+	return "  ret void\n"
+}
+
+// Osty: mirThunkRetValueLine
+func mirThunkRetValueLine(ret string) string {
+	return "  ret " + ret + " %ret\n"
+}
+
+// Osty: mirThunkDefineHeaderLine
+func mirThunkDefineHeaderLine(ret, thunk, header string) string {
+	return mirThunkDefineHeaderText(ret, thunk, header) + "\n"
+}
+
+// Osty: mirLlvmMethodIRName
+func mirLlvmMethodIRName(ownerName, methodName string) string {
+	return mirSanitizeLLVMName(ownerName) + "__" + mirSanitizeLLVMName(methodName)
+}
+
+// Osty: mirLlvmMethodReceiverIRType
+func mirLlvmMethodReceiverIRType(ownerType string, mutable bool) string {
+	if mutable {
+		return "ptr"
+	}
+	return ownerType
+}
+
+// Osty: mirIntrinsicVectorListFastPathSafe
+//
+// Renamed on the Osty side to avoid colliding with the existing
+// host-side `mirIntrinsicSafeForVectorListFastPath` symbol in
+// `mir_generator.go` — both would land in the same package.
+func mirIntrinsicVectorListFastPathSafe(
+	kind, intrinsicListLen, intrinsicListIsEmpty int,
+) bool {
+	switch kind {
+	case intrinsicListLen, intrinsicListIsEmpty:
+		return true
+	}
+	return false
+}
+
+// Osty: mirNativeShimDefineHeaderText
+func mirNativeShimDefineHeaderText(ret, structName, ifaceName, methodName, rest string) string {
+	return "define " + ret + " @osty.shim." + structName + "__" + ifaceName + "__" + methodName +
+		"(ptr %self_data" + rest + ") {\nentry:\n"
+}
+
+// Osty: mirNativeShimLoadSelfText
+func mirNativeShimLoadSelfText(structLLVM string) string {
+	return "  %self = load " + structLLVM + ", ptr %self_data, align 8\n"
+}
+
+// Osty: mirNativeShimCallVoidText
+func mirNativeShimCallVoidText(ret, sym, argList string) string {
+	return "  call " + ret + " @" + sym + "(" + argList + ")\n"
+}
+
+// Osty: mirNativeShimCallValueText
+func mirNativeShimCallValueText(ret, sym, argList string) string {
+	return "  %res = call " + ret + " @" + sym + "(" + argList + ")\n"
+}
+
+// Osty: mirNativeShimRetVoidText
+func mirNativeShimRetVoidText() string {
+	return "  ret void\n"
+}
+
+// Osty: mirNativeShimRetValueText
+func mirNativeShimRetValueText(ret string) string {
+	return "  ret " + ret + " %res\n"
+}
+
+// Osty: mirArrayI64TypeText
+func mirArrayI64TypeText(nDigits string) string {
+	return "[" + nDigits + " x i64]"
+}
+
+// Osty: mirArrayPtrTypeText
+func mirArrayPtrTypeText(nDigits string) string {
+	return "[" + nDigits + " x ptr]"
+}
+
+// Osty: mirArrayI8TypeText
+func mirArrayI8TypeText(nDigits string) string {
+	return "[" + nDigits + " x i8]"
+}
+
+// Osty: mirInternalConstantGlobalLine
+func mirInternalConstantGlobalLine(irName, ty, init string) string {
+	return irName + " = internal constant " + ty + " " + init + "\n"
+}
+
+// Osty: mirInternalGlobalLine
+func mirInternalGlobalLine(irName, ty, init string) string {
+	return irName + " = internal global " + ty + " " + init + "\n"
+}
+
+// Osty: mirInternalGlobalDefForKind
+func mirInternalGlobalDefForKind(irName string, mutable bool, ty, init string) string {
+	if mutable {
+		return mirInternalGlobalLine(irName, ty, init)
+	}
+	return mirInternalConstantGlobalLine(irName, ty, init)
+}
+
+// Osty: mirConstStructInitText
+func mirConstStructInitText(parts string) string {
+	return "{ " + parts + " }"
+}
+
+// Osty: mirConstEnumVariantInitText
+func mirConstEnumVariantInitText(tagDigits, typedPayload string) string {
+	return "{ i64 " + tagDigits + ", " + typedPayload + " }"
+}
+
+// Osty: mirConstTypedInitText
+func mirConstTypedInitText(ty, init string) string {
+	return ty + " " + init
+}
+
+// Osty: mirSyntheticArgName
+func mirSyntheticArgName(idxDigits string) string {
+	return "__arg" + idxDigits
+}
+
+// Osty: mirCallArgsPtrPrefix
+func mirCallArgsPtrPrefix(selfPtr string) string {
+	return "ptr " + selfPtr
+}
+
+// Osty: mirCallArgsTypePair
+func mirCallArgsTypePair(ty, val string) string {
+	return ty + " " + val
+}
+
+// Osty: mirAppendArgWithComma
+func mirAppendArgWithComma(existing, ty, val string) string {
+	return existing + ", " + ty + " " + val
+}
+
+// Osty: mirAppendCallArgPart
+func mirAppendCallArgPart(existing, ty, val string) string {
+	if existing == "" {
+		return ty + " " + val
+	}
+	return existing + ", " + ty + " " + val
+}
+
+// Osty: mirLlvmFloat64HexLiteral
+func mirLlvmFloat64HexLiteral(hexDigits string) string {
+	return "0x" + hexDigits
+}
+
+// Osty: mirFormatFloatEnsureDot
+func mirFormatFloatEnsureDot(formatted string) string {
+	if llvmStrings.ContainsAny(formatted, ".eE") {
+		return formatted
+	}
+	return formatted + ".0"
+}
+
+// (mirParamSlotName / mirLocalSlotName already defined earlier in this
+// file as part of the §8 LLVM-text local-name composers — same body,
+// kept singleton.)
+
+// Osty: mirRuntimeDeclareI1FromTwoPtrText
+func mirRuntimeDeclareI1FromTwoPtrText(sym string) string {
+	return "declare i1 @" + sym + "(ptr, ptr)"
+}
+
+// Osty: mirRuntimeDeclareI64FromTwoPtrText
+func mirRuntimeDeclareI64FromTwoPtrText(sym string) string {
+	return "declare i64 @" + sym + "(ptr, ptr)"
+}
+
+// Osty: mirIntrinsicWrittenByText
+func mirIntrinsicWrittenByText(kindDigits, lineDigits, colDigits string) string {
+	return "written by intrinsic kind=" + kindDigits + " at " + lineDigits + ":" + colDigits
+}
+
+// Osty: mirCallWrittenByText
+func mirCallWrittenByText(callee, lineDigits, colDigits string) string {
+	return "written by call `" + callee + "` at " + lineDigits + ":" + colDigits
+}
+
+// Osty: mirAssignWrittenByText
+func mirAssignWrittenByText(lineDigits, colDigits, src string) string {
+	return "written by assign at " + lineDigits + ":" + colDigits + " (src=" + src + ")"
+}
+
+// Osty: mirRValueBinaryDebugText
+func mirRValueBinaryDebugText(opDigits, typeStr string) string {
+	return "BinaryRV(op=" + opDigits + ", T=" + typeStr + ")"
+}
+
+// Osty: mirRValueUnaryDebugText
+func mirRValueUnaryDebugText(opDigits, typeStr string) string {
+	return "UnaryRV(op=" + opDigits + ", T=" + typeStr + ")"
+}
+
+// Osty: mirRValueAggregateDebugText
+func mirRValueAggregateDebugText(kindDigits, typeStr string) string {
+	return "AggregateRV(kind=" + kindDigits + ", T=" + typeStr + ")"
+}
+
+// Osty: mirRValueCastDebugText
+func mirRValueCastDebugText(kindDigits, typeStr string) string {
+	return "CastRV(kind=" + kindDigits + ", To=" + typeStr + ")"
+}
+
+// Osty: mirIntrinsicLabelKindFallback
+func mirIntrinsicLabelKindFallback(kindDigits string) string {
+	return "kind=" + kindDigits
+}
+
+// Osty: mirTestingFailureMessage
+func mirTestingFailureMessage(method, label string) string {
+	return "testing." + method + " failed at " + label
+}
+
+// Osty: mirSourceLineLabelText
+func mirSourceLineLabelText(source, lineDigits string) string {
+	return source + ":" + lineDigits
+}
+
+// Osty: mirAssertExprFragmentText
+func mirAssertExprFragmentText(base, label, exprText string) string {
+	return base + ": " + label + "=`" + exprText + "`"
+}
+
+// Osty: mirAssertExprLeftFragmentText
+func mirAssertExprLeftFragmentText(base, leftText string) string {
+	return base + ": left=`" + leftText + "`"
+}
+
+// Osty: mirAssertExprRightFragmentText
+func mirAssertExprRightFragmentText(rightText string) string {
+	return " right=`" + rightText + "`"
+}
+
+// Osty: mirOptionUnwrapNoneMessage
+func mirOptionUnwrapNoneMessage(label string) string {
+	return "unwrap on None at " + label
+}
+
+// Osty: mirDebugIdentText
+func mirDebugIdentText(quotedName string) string {
+	return "ident " + quotedName
+}
+
+// Osty: mirDebugVariantNoArgsText
+func mirDebugVariantNoArgsText(path string) string {
+	return "variant " + path + " (no args)"
+}
+
+// Osty: mirDebugVariantWithArgsText
+func mirDebugVariantWithArgsText(path, argDigits string) string {
+	return "variant " + path + " with " + argDigits + " arg(s)"
+}
+
+// Osty: mirDebugTupleText
+func mirDebugTupleText(elemDigits string) string {
+	return "tuple of " + elemDigits
+}
+
+// Osty: mirDebugStructText
+func mirDebugStructText(typePath string) string {
+	return "struct " + typePath
+}
+
+// Osty: mirParamIndexedName
+func mirParamIndexedName(idxDigits string) string {
+	return "arg" + idxDigits
+}
+
+// Osty: mirParamRegRef
+func mirParamRegRef(idxDigits string) string {
+	return "%arg" + idxDigits
+}
+
+// Osty: mirCaptureRegRef
+func mirCaptureRegRef(idxDigits string) string {
+	return "%cap" + idxDigits
+}
+
+// Osty: mirReturnRegRef
+func mirReturnRegRef() string {
+	return "%ret"
+}
+
+// Osty: mirSelfRegRef
+func mirSelfRegRef() string {
+	return "%self"
+}
+
+// Osty: mirSelfDataRegRef
+func mirSelfDataRegRef() string {
+	return "%self_data"
+}
+
+// Osty: mirEnvRegRef
+func mirEnvRegRef() string {
+	return "%env"
+}
+
+// Osty: mirCapSlotRegRef
+func mirCapSlotRegRef(idxDigits string) string {
+	return "%cap" + idxDigits + "_slot"
+}
+
+// Osty: mirAtPosLabelText
+func mirAtPosLabelText(pos, offsetDigits string) string {
+	return "at " + pos + " (offset " + offsetDigits + ")"
+}
+
+// Osty: mirAtPosNoOffsetLabelText
+func mirAtPosNoOffsetLabelText(pos string) string {
+	return "at " + pos
+}
+
+// Osty: mirInternalDeclareTextNoArgs
+func mirInternalDeclareTextNoArgs(retTy, sym string) string {
+	return "declare " + retTy + " @" + sym + "()"
+}
+
+// Osty: mirInternalDeclareTextOnePtr
+func mirInternalDeclareTextOnePtr(retTy, sym string) string {
+	return "declare " + retTy + " @" + sym + "(ptr)"
+}
+
+// Osty: mirInternalDeclareTextOneI64
+func mirInternalDeclareTextOneI64(retTy, sym string) string {
+	return "declare " + retTy + " @" + sym + "(i64)"
+}
+
+// Osty: mirInternalDeclareTextOneI32
+func mirInternalDeclareTextOneI32(retTy, sym string) string {
+	return "declare " + retTy + " @" + sym + "(i32)"
+}
+
+// Osty: mirInternalDeclareTextI1FromPtrI64
+func mirInternalDeclareTextI1FromPtrI64(sym string) string {
+	return "declare i1 @" + sym + "(ptr, i64)"
+}
+
+// Osty: mirInternalDeclareTextPtrFromPtrI64
+func mirInternalDeclareTextPtrFromPtrI64(sym string) string {
+	return "declare ptr @" + sym + "(ptr, i64)"
+}
+
+// Osty: mirInternalDeclareTextI64FromPtr
+func mirInternalDeclareTextI64FromPtr(sym string) string {
+	return "declare i64 @" + sym + "(ptr)"
+}
+
+// Osty: mirInternalDeclareTextI32FromPtr
+func mirInternalDeclareTextI32FromPtr(sym string) string {
+	return "declare i32 @" + sym + "(ptr)"
+}
+
+// Osty: mirInternalDeclareTextVoidFromPtr
+func mirInternalDeclareTextVoidFromPtr(sym string) string {
+	return "declare void @" + sym + "(ptr)"
+}
+
+// Osty: mirInternalDeclareTextVoidNoArgs
+func mirInternalDeclareTextVoidNoArgs(sym string) string {
+	return "declare void @" + sym + "()"
+}
+
+// Osty: mirSelfStateRegRef
+func mirSelfStateRegRef() string {
+	return "%self_state"
+}
+
+// Osty: mirSelfPtrRegRef
+func mirSelfPtrRegRef() string {
+	return "%self.ptr"
+}
+
+// Osty: mirSelfValRegRef
+func mirSelfValRegRef() string {
+	return "%self.val"
+}
+
+// Osty: mirRetValRegRef
+func mirRetValRegRef() string {
+	return "%ret.val"
+}
+
+// Osty: mirInterfaceShimVoidCallText
+func mirInterfaceShimVoidCallText(sym, argList string) string {
+	return "  call void @" + sym + "(" + argList + ")"
+}
+
+// Osty: mirInterfaceShimValueCallText
+func mirInterfaceShimValueCallText(retTy, sym, argList string) string {
+	return "  %ret.val = call " + retTy + " @" + sym + "(" + argList + ")"
+}
+
+// Osty: mirInterfaceShimRetVoidText
+func mirInterfaceShimRetVoidText() string {
+	return "  ret void"
+}
+
+// Osty: mirInterfaceShimRetValueText
+func mirInterfaceShimRetValueText(retTy string) string {
+	return "  ret " + retTy + " %ret.val"
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1894,7 +1894,7 @@ func (g *generator) testingFailureMessage(call *ast.CallExpr, name string) strin
 	if call != nil {
 		line = call.Pos().Line
 	}
-	return fmt.Sprintf("testing.%s failed at %s", name, g.sourceLineLabel(line, "<test>"))
+	return mirTestingFailureMessage(name, g.sourceLineLabel(line, "<test>"))
 }
 
 // sourceLineLabel renders `<abs-path>:<line>` for a diagnostic site.
@@ -1907,7 +1907,7 @@ func (g *generator) sourceLineLabel(line int, fallback string) string {
 	} else if abs, err := filepath.Abs(source); err == nil {
 		source = abs
 	}
-	return fmt.Sprintf("%s:%d", source, line)
+	return mirSourceLineLabelText(source, strconv.Itoa(line))
 }
 
 // emitTestingAssertionLazy mirrors emitTestingAssertion but builds the
@@ -1959,11 +1959,11 @@ func (g *generator) buildAssertCompareMessage(call *ast.CallExpr, name, leftText
 	if leftText == "" && rightText == "" && !leftHasVal && !rightHasVal {
 		return g.foldAssertionMessage(staticAssertPart(base))
 	}
-	parts := []assertMsgPart{staticAssertPart(fmt.Sprintf("%s: left=`%s`", base, leftText))}
+	parts := []assertMsgPart{staticAssertPart(mirAssertExprLeftFragmentText(base, leftText))}
 	if leftHasVal {
 		parts = append(parts, staticAssertPart(" = "), dynamicAssertPart(leftStr))
 	}
-	parts = append(parts, staticAssertPart(fmt.Sprintf(" right=`%s`", rightText)))
+	parts = append(parts, staticAssertPart(mirAssertExprRightFragmentText(rightText)))
 	if rightHasVal {
 		parts = append(parts, staticAssertPart(" = "), dynamicAssertPart(rightStr))
 	}
@@ -2075,7 +2075,7 @@ func (g *generator) buildAssertCondMessage(call *ast.CallExpr, name, exprText st
 	if name == "expectOk" || name == "expectError" {
 		label = "expr"
 	}
-	return g.foldAssertionMessage(staticAssertPart(fmt.Sprintf("%s: %s=`%s`", base, label, exprText)))
+	return g.foldAssertionMessage(staticAssertPart(mirAssertExprFragmentText(base, label, exprText)))
 }
 
 // assertMsgPart is a single fragment of a failure message: either a

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -10,7 +10,6 @@
 package llvmgen
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -1888,13 +1887,12 @@ func resolveAliasNamedTarget(name string, env typeEnv, seen map[string]bool) (st
 	return target.Path[0], true, nil
 }
 
+// llvmAggregatePathIndices joins a sequence of GEP path indices into the
+// LLVM `i32 0, i32 N0, i32 N1, ...` form expected by GEP instructions
+// that traverse nested aggregates. Delegates to the Osty-sourced
+// `mirLlvmAggregatePathIndices` (`toolchain/mir_generator.osty`).
 func llvmAggregatePathIndices(path []int) string {
-	parts := make([]string, 0, len(path)+1)
-	parts = append(parts, "i32 0")
-	for _, index := range path {
-		parts = append(parts, fmt.Sprintf("i32 %d", index))
-	}
-	return strings.Join(parts, ", ")
+	return mirLlvmAggregatePathIndices(path)
 }
 
 func llvmType(t ast.Type, env typeEnv) (string, error) {
@@ -1968,15 +1966,17 @@ func llvmMethodOwnerType(ownerName string, structs map[string]*structInfo, enums
 	return "", false
 }
 
+// llvmMethodIRName composes the LLVM IR symbol for a named method.
+// Delegates to the Osty-sourced `mirLlvmMethodIRName`
+// (`toolchain/mir_generator.osty`).
 func llvmMethodIRName(ownerName, methodName string) string {
-	return sanitizeLLVMName(ownerName) + "__" + sanitizeLLVMName(methodName)
+	return mirLlvmMethodIRName(ownerName, methodName)
 }
 
+// llvmMethodReceiverIRType returns the LLVM type for a method receiver.
+// Delegates to `mirLlvmMethodReceiverIRType`.
 func llvmMethodReceiverIRType(ownerType string, mutable bool) string {
-	if mutable {
-		return "ptr"
-	}
-	return ownerType
+	return mirLlvmMethodReceiverIRType(ownerType, mutable)
 }
 
 func llvmParamIRType(param paramInfo) string {

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -14145,39 +14145,148 @@ pub fn mirPrependRootIndex(index: Int, paths: List<List<Int>>) -> List<List<Int>
     out
 }
 
-/// mirIntrinsicKindLabelFull is the 13-case version of
+/// mirIntrinsicKindLabelFull is the full-coverage version of
 /// `mirIntrinsicKindLabel`. The kind values match the order of the
 /// `IntrinsicKind` iota in `internal/mir/mir.go`; non-matching codes
 /// fall back to `kindFallback` (typically `"kind=<n>"`). Mirrors
 /// `mirIntrinsicLabel` in `internal/llvmgen/mir_generator.go`.
 ///
-/// Mapping (iota offsets — all are `IntrinsicKind` values):
-///   1  → print
-///   2  → println
-///   3  → eprint
-///   4  → eprintln
-///   5  → abort                — not in legacy table; falls through
-///   6  → string_concat
-///   57 → string_len
-///   58 → string_is_empty
-///   68 → string_to_int
-///   69 → string_to_float
-///   71 → string_chars
-///   72 → string_bytes
-///   103 → raw.null
+/// Slice 11 extension: every kind from `IntrinsicPrint` (1) through
+/// `IntrinsicMapIncr` (113) now has a canonical label. Diagnostic
+/// strings ("intrinsic %s not yet supported", "%s without operand",
+/// etc.) become substantially more useful when the kind code that
+/// reaches an LLVM-side error path is rendered as the symbolic name
+/// rather than `kind=NN`. The labels were chosen to match the
+/// `osty_rt_*` runtime symbol fragments where one exists, and the
+/// stdlib method name otherwise.
 pub fn mirIntrinsicKindLabelFull(kind: Int, kindFallback: String) -> String {
+    // ---- core IO + abort + string_concat ----
     if kind == 1 { return "print" }
     if kind == 2 { return "println" }
     if kind == 3 { return "eprint" }
     if kind == 4 { return "eprintln" }
+    if kind == 5 { return "abort" }
     if kind == 6 { return "string_concat" }
+    // ---- concurrency: channels ----
+    if kind == 7 { return "chan.make" }
+    if kind == 8 { return "chan.send" }
+    if kind == 9 { return "chan.recv" }
+    if kind == 10 { return "chan.close" }
+    if kind == 11 { return "chan.is_closed" }
+    // ---- concurrency: structured tasks ----
+    if kind == 12 { return "task_group" }
+    if kind == 13 { return "spawn" }
+    if kind == 14 { return "handle.join" }
+    if kind == 15 { return "group.cancel" }
+    if kind == 16 { return "group.is_cancelled" }
+    // ---- concurrency: high-level helpers ----
+    if kind == 17 { return "parallel" }
+    if kind == 18 { return "race" }
+    if kind == 19 { return "collect_all" }
+    // ---- concurrency: select ----
+    if kind == 20 { return "select" }
+    if kind == 21 { return "select.recv" }
+    if kind == 22 { return "select.send" }
+    if kind == 23 { return "select.timeout" }
+    if kind == 24 { return "select.default" }
+    // ---- concurrency: cancellation ----
+    if kind == 25 { return "is_cancelled" }
+    if kind == 26 { return "check_cancelled" }
+    if kind == 27 { return "yield" }
+    if kind == 28 { return "sleep" }
+    // ---- stdlib collections: List<T> ----
+    if kind == 29 { return "list.push" }
+    if kind == 30 { return "list.len" }
+    if kind == 31 { return "list.get" }
+    if kind == 32 { return "list.is_empty" }
+    if kind == 33 { return "list.first" }
+    if kind == 34 { return "list.last" }
+    if kind == 35 { return "list.sorted" }
+    if kind == 36 { return "list.contains" }
+    if kind == 37 { return "list.index_of" }
+    if kind == 38 { return "list.to_set" }
+    if kind == 39 { return "list.remove_at" }
+    if kind == 40 { return "list.reverse" }
+    if kind == 41 { return "list.reversed" }
+    // ---- stdlib collections: Map<K, V> ----
+    if kind == 42 { return "map.new" }
+    if kind == 43 { return "map.get" }
+    if kind == 44 { return "map.set" }
+    if kind == 45 { return "map.contains" }
+    if kind == 46 { return "map.len" }
+    if kind == 47 { return "map.keys" }
+    if kind == 48 { return "map.values" }
+    if kind == 49 { return "map.remove" }
+    if kind == 50 { return "map.keys_sorted" }
+    // ---- stdlib collections: Set<T> ----
+    if kind == 51 { return "set.new" }
+    if kind == 52 { return "set.insert" }
+    if kind == 53 { return "set.contains" }
+    if kind == 54 { return "set.len" }
+    if kind == 55 { return "set.to_list" }
+    if kind == 56 { return "set.remove" }
+    // ---- stdlib: String ----
     if kind == 57 { return "string_len" }
     if kind == 58 { return "string_is_empty" }
+    if kind == 59 { return "string_contains" }
+    if kind == 60 { return "string_count" }
+    if kind == 61 { return "string_starts_with" }
+    if kind == 62 { return "string_ends_with" }
+    if kind == 63 { return "string_index_of" }
+    if kind == 64 { return "string_split" }
+    if kind == 65 { return "string_trim" }
+    if kind == 66 { return "string_to_upper" }
+    if kind == 67 { return "string_to_lower" }
     if kind == 68 { return "string_to_int" }
     if kind == 69 { return "string_to_float" }
+    if kind == 70 { return "string_replace" }
     if kind == 71 { return "string_chars" }
     if kind == 72 { return "string_bytes" }
+    // ---- stdlib: Bytes ----
+    if kind == 73 { return "bytes.len" }
+    if kind == 74 { return "bytes.is_empty" }
+    if kind == 75 { return "bytes.get" }
+    if kind == 76 { return "bytes.contains" }
+    if kind == 77 { return "bytes.starts_with" }
+    if kind == 78 { return "bytes.ends_with" }
+    if kind == 79 { return "bytes.index_of" }
+    if kind == 80 { return "bytes.last_index_of" }
+    if kind == 81 { return "bytes.split" }
+    if kind == 82 { return "bytes.join" }
+    if kind == 83 { return "bytes.concat" }
+    if kind == 84 { return "bytes.repeat" }
+    if kind == 85 { return "bytes.replace" }
+    if kind == 86 { return "bytes.replace_all" }
+    if kind == 87 { return "bytes.trim_left" }
+    if kind == 88 { return "bytes.trim_right" }
+    if kind == 89 { return "bytes.trim" }
+    if kind == 90 { return "bytes.trim_space" }
+    if kind == 91 { return "bytes.to_upper" }
+    if kind == 92 { return "bytes.to_lower" }
+    if kind == 93 { return "bytes.to_hex" }
+    if kind == 94 { return "bytes.slice" }
+    // ---- stdlib: Option / Result ----
+    if kind == 95 { return "option.is_some" }
+    if kind == 96 { return "option.is_none" }
+    if kind == 97 { return "option.unwrap" }
+    if kind == 98 { return "option.unwrap_or" }
+    if kind == 99 { return "result.is_ok" }
+    if kind == 100 { return "result.is_err" }
+    if kind == 101 { return "result.unwrap" }
+    if kind == 102 { return "result.unwrap_or" }
+    // ---- runtime sublanguage ----
     if kind == 103 { return "raw.null" }
+    // ---- deferred String + late additions ----
+    if kind == 104 { return "string_join" }
+    if kind == 105 { return "list.pop" }
+    if kind == 106 { return "string_substring" }
+    if kind == 107 { return "byte.to_int" }
+    if kind == 108 { return "char.to_int" }
+    if kind == 109 { return "list.slice" }
+    if kind == 110 { return "map.get_or" }
+    if kind == 111 { return "string_split_into" }
+    if kind == 112 { return "string_nth_segment" }
+    if kind == 113 { return "map.incr" }
     kindFallback
 }
 
@@ -14947,4 +15056,1264 @@ pub fn mirIfaceStructLayout() -> String {
 /// `{ ptr, ptr, i64 }` — prev frame ptr + slots ptr + count.
 pub fn mirRootFrameStructLayout() -> String {
     "{ ptr, ptr, i64 }"
+}
+
+/// mirSpliceFnAttrs rewrites the first `define ... (<params>) {` line of
+/// a rendered function so that it carries the given attributes between
+/// the closing paren and the opening brace. Only the first occurrence of
+/// `") \{"` is touched — a function body may contain other `") \{"`
+/// sequences in landing-pad blocks or nested structures, and we must not
+/// mis-attach attributes there. Mirrors `spliceFnAttrs` in
+/// `internal/llvmgen/generator.go`.
+pub fn mirSpliceFnAttrs(rendered: String, attrs: String) -> String {
+    let needle = ") \{"
+    let idx = llvmStrings.Index(rendered, needle)
+    if idx < 0 { return rendered }
+    let head = rendered[0..idx]
+    let tail = rendered[(idx + needle.len())..rendered.len()]
+    head + ") " + attrs + " \{" + tail
+}
+
+/// mirSpliceNoaliasParams rewrites the first `define ... (<params>) \{`
+/// line of rendered IR so that pointer parameters whose type is `ptr`
+/// and (when `all` is false) whose name appears in `selectedNames` carry
+/// the LLVM `noalias` parameter attribute. Non-pointer params and
+/// non-matching names are passed through unchanged. Only the signature
+/// line is rewritten; subsequent body lines with parens are left alone.
+/// Mirrors `spliceNoaliasParams` in `internal/llvmgen/generator.go`.
+///
+/// The helper takes the parameter type and name arrays in lock-step:
+/// `paramTypes[i]` and `paramNames[i]` correspond to the `i`-th piece of
+/// the comma-separated parameter list. Pieces where the type isn't `ptr`
+/// or whose name isn't selected are untouched.
+pub fn mirSpliceNoaliasParams(
+    rendered: String,
+    paramTypes: List<String>,
+    paramNames: List<String>,
+    all: Bool,
+    selectedNames: List<String>,
+) -> String {
+    let lineEnd = llvmStrings.Index(rendered, "\n")
+    if lineEnd < 0 { return rendered }
+    let line = rendered[0..lineEnd]
+    let rest = rendered[lineEnd..rendered.len()]
+    let openParen = llvmStrings.Index(line, "(")
+    let closeParen = llvmStrings.LastIndex(line, ")")
+    if openParen < 0 { return rendered }
+    if closeParen < 0 { return rendered }
+    if closeParen <= openParen { return rendered }
+    let prefix = line[0..(openParen + 1)]
+    let suffix = line[closeParen..line.len()]
+    let inner = line[(openParen + 1)..closeParen]
+    if inner == "" { return rendered }
+    let pieces = mirSplitCommaSep(inner)
+    let n = pieces.len()
+    let paramN = paramTypes.len()
+    let selN = selectedNames.len()
+    let mut out: List<String> = []
+    let mut i = 0
+    for i < n {
+        let piece = pieces[i]
+        if i >= paramN {
+            out.push(piece)
+            i = i + 1
+            continue
+        }
+        if paramTypes[i] != "ptr" {
+            out.push(piece)
+            i = i + 1
+            continue
+        }
+        if !all {
+            let name = paramNames[i]
+            let mut matched = false
+            let mut k = 0
+            for k < selN {
+                if selectedNames[k] == name { matched = true }
+                k = k + 1
+            }
+            if !matched {
+                out.push(piece)
+                i = i + 1
+                continue
+            }
+        }
+        // `piece` looks like "ptr %name" — insert `noalias` between
+        // the type and the register name. Defensive: if the shape is
+        // unexpected we leave the piece intact.
+        let spaceIdx = llvmStrings.Index(piece, " ")
+        if spaceIdx < 0 {
+            out.push(piece)
+            i = i + 1
+            continue
+        }
+        let head = piece[0..spaceIdx]
+        if head != "ptr" {
+            out.push(piece)
+            i = i + 1
+            continue
+        }
+        let regPart = piece[(spaceIdx + 1)..piece.len()]
+        out.push("ptr noalias " + regPart)
+        i = i + 1
+    }
+    let mut joined = ""
+    let mut j = 0
+    let on = out.len()
+    for j < on {
+        if j > 0 { joined = joined + ", " }
+        joined = joined + out[j]
+        j = j + 1
+    }
+    prefix + joined + suffix + rest
+}
+
+/// mirSplitCommaSep splits a string on the literal `, ` separator. The
+/// result preserves the original order; an empty input produces one
+/// empty element. Used by splice helpers that operate on LLVM
+/// comma-separated parameter / argument lists.
+pub fn mirSplitCommaSep(input: String) -> List<String> {
+    let n = input.len()
+    let mut out: List<String> = []
+    let mut start = 0
+    let mut i = 0
+    for i + 1 < n {
+        if input[i..(i + 2)] == ", " {
+            out.push(input[start..i])
+            start = i + 2
+            i = i + 2
+        } else {
+            i = i + 1
+        }
+    }
+    out.push(input[start..n])
+    out
+}
+
+/// mirTagParallelAccessesLines is the `[]string` twin of
+/// `mirTagParallelAccesses` — it walks each body line and appends
+/// `, !llvm.access.group !N` to load/store lines that do not already
+/// carry that attachment. The HIR emitter accumulates the body in a
+/// `[]string`, so we operate on the slice directly rather than on a
+/// single joined string. Mirrors `tagParallelAccessesLines` in
+/// `internal/llvmgen/generator.go`.
+pub fn mirTagParallelAccessesLines(body: List<String>, groupRef: String) -> List<String> {
+    let suffix = ", !llvm.access.group " + groupRef
+    let n = body.len()
+    let mut out: List<String> = []
+    let mut i = 0
+    for i < n {
+        let line = body[i]
+        if mirIsMemoryAccessLine(line) && !llvmStrings.Contains(line, "!llvm.access.group") {
+            out.push(line + suffix)
+        } else {
+            out.push(line)
+        }
+        i = i + 1
+    }
+    out
+}
+
+/// mirLlvmAggregatePathIndices joins a sequence of GEP path indices into
+/// the LLVM `i32 0, i32 N0, i32 N1, ...` form expected by GEP
+/// instructions that traverse nested aggregates. The leading `i32 0`
+/// dereferences the base pointer; subsequent `i32 N` entries select the
+/// `N`-th field/element at each level. Mirrors `llvmAggregatePathIndices`
+/// in `internal/llvmgen/type.go`.
+pub fn mirLlvmAggregatePathIndices(path: List<Int>) -> String {
+    let mut out = "i32 0"
+    let n = path.len()
+    let mut i = 0
+    for i < n {
+        out = out + ", i32 " + mirGenIntToString(path[i])
+        i = i + 1
+    }
+    out
+}
+
+/// mirConstIntBinary applies a binary operator to two i64 operands at
+/// compile time. The operator is identified by its `token.Kind` int
+/// code; the same code values flow from
+/// `mirConstBinaryOpCode_*` callers below. Returns `0` plus an error
+/// sentinel — `errCode` is `0` on success, `1` for "division by zero",
+/// `2` for "modulo by zero", `3` for "unsupported operator". The Go
+/// wrapper rebuilds `(int64, error)` from this pair so the host-side
+/// error rendering keeps the same `unsupportedf("expression", ...)`
+/// shape as the legacy implementation. Mirrors `constIntBinary` in
+/// `internal/llvmgen/decl.go`.
+pub fn mirConstIntBinary(
+    op: Int,
+    left: Int,
+    right: Int,
+    plus: Int,
+    minus: Int,
+    star: Int,
+    slash: Int,
+    percent: Int,
+    bitAnd: Int,
+    bitOr: Int,
+    bitXor: Int,
+    shl: Int,
+    shr: Int,
+) -> Int {
+    if op == plus { return left + right }
+    if op == minus { return left - right }
+    if op == star { return left * right }
+    if op == slash {
+        if right == 0 { return 0 }
+        return left / right
+    }
+    if op == percent {
+        if right == 0 { return 0 }
+        return left % right
+    }
+    if op == bitAnd { return left & right }
+    if op == bitOr { return left | right }
+    if op == bitXor { return left ^ right }
+    if op == shl { return left << right }
+    if op == shr { return left >> right }
+    0
+}
+
+/// mirConstIntBinaryStatus returns the error sentinel for the same
+/// inputs `mirConstIntBinary` consumes. `0` = success; `1` = division
+/// by zero; `2` = modulo by zero; `3` = unsupported operator. Split
+/// from `mirConstIntBinary` so the value channel can stay a plain
+/// `Int` (multi-value Osty returns aren't supported in the snapshot
+/// boundary today). Mirrors the err-branch logic of `constIntBinary`
+/// in `internal/llvmgen/decl.go`.
+pub fn mirConstIntBinaryStatus(
+    op: Int,
+    right: Int,
+    plus: Int,
+    minus: Int,
+    star: Int,
+    slash: Int,
+    percent: Int,
+    bitAnd: Int,
+    bitOr: Int,
+    bitXor: Int,
+    shl: Int,
+    shr: Int,
+) -> Int {
+    if op == plus { return 0 }
+    if op == minus { return 0 }
+    if op == star { return 0 }
+    if op == slash {
+        if right == 0 { return 1 }
+        return 0
+    }
+    if op == percent {
+        if right == 0 { return 2 }
+        return 0
+    }
+    if op == bitAnd { return 0 }
+    if op == bitOr { return 0 }
+    if op == bitXor { return 0 }
+    if op == shl { return 0 }
+    if op == shr { return 0 }
+    3
+}
+
+/// mirLegacyAssignOpCode maps the IR-level `AssignOp` int to the
+/// `token.Kind` int used by AST AssignStmt nodes. Mirrors
+/// `legacyAssignOp` in `internal/llvmgen/ir_module.go`. Returns the
+/// `assign` token code for any input not in the known table — that
+/// matches the legacy default arm.
+pub fn mirLegacyAssignOpCode(
+    op: Int,
+    assignEq: Int,
+    assignAdd: Int,
+    assignSub: Int,
+    assignMul: Int,
+    assignDiv: Int,
+    assignMod: Int,
+    assignAnd: Int,
+    assignOr: Int,
+    assignXor: Int,
+    assignShl: Int,
+    assignShr: Int,
+    tokAssign: Int,
+    tokPlusEq: Int,
+    tokMinusEq: Int,
+    tokStarEq: Int,
+    tokSlashEq: Int,
+    tokPercentEq: Int,
+    tokBitAndEq: Int,
+    tokBitOrEq: Int,
+    tokBitXorEq: Int,
+    tokShlEq: Int,
+    tokShrEq: Int,
+) -> Int {
+    if op == assignEq { return tokAssign }
+    if op == assignAdd { return tokPlusEq }
+    if op == assignSub { return tokMinusEq }
+    if op == assignMul { return tokStarEq }
+    if op == assignDiv { return tokSlashEq }
+    if op == assignMod { return tokPercentEq }
+    if op == assignAnd { return tokBitAndEq }
+    if op == assignOr { return tokBitOrEq }
+    if op == assignXor { return tokBitXorEq }
+    if op == assignShl { return tokShlEq }
+    if op == assignShr { return tokShrEq }
+    tokAssign
+}
+
+/// mirLegacyUnaryOpCode maps the IR-level `UnOp` int to the
+/// `token.Kind` int used by AST UnaryExpr nodes. Mirrors
+/// `legacyUnaryOp` in `internal/llvmgen/ir_module.go`. Returns the
+/// `illegal` token code for any input not in the known table.
+pub fn mirLegacyUnaryOpCode(
+    op: Int,
+    unNeg: Int,
+    unPlus: Int,
+    unNot: Int,
+    unBitNot: Int,
+    tokMinus: Int,
+    tokPlus: Int,
+    tokNot: Int,
+    tokBitNot: Int,
+    tokIllegal: Int,
+) -> Int {
+    if op == unNeg { return tokMinus }
+    if op == unPlus { return tokPlus }
+    if op == unNot { return tokNot }
+    if op == unBitNot { return tokBitNot }
+    tokIllegal
+}
+
+/// mirLegacyBinaryOpCode maps the IR-level `BinOp` int to the
+/// `token.Kind` int used by AST BinaryExpr nodes. Mirrors
+/// `legacyBinaryOp` in `internal/llvmgen/ir_module.go`. Returns the
+/// `illegal` token code for any input not in the known table.
+pub fn mirLegacyBinaryOpCode(
+    op: Int,
+    binAdd: Int,
+    binSub: Int,
+    binMul: Int,
+    binDiv: Int,
+    binMod: Int,
+    binEq: Int,
+    binNeq: Int,
+    binLt: Int,
+    binLeq: Int,
+    binGt: Int,
+    binGeq: Int,
+    binAnd: Int,
+    binOr: Int,
+    binBitAnd: Int,
+    binBitOr: Int,
+    binBitXor: Int,
+    binShl: Int,
+    binShr: Int,
+    tokPlus: Int,
+    tokMinus: Int,
+    tokStar: Int,
+    tokSlash: Int,
+    tokPercent: Int,
+    tokEQ: Int,
+    tokNEQ: Int,
+    tokLT: Int,
+    tokLEQ: Int,
+    tokGT: Int,
+    tokGEQ: Int,
+    tokAnd: Int,
+    tokOr: Int,
+    tokBitAnd: Int,
+    tokBitOr: Int,
+    tokBitXor: Int,
+    tokShl: Int,
+    tokShr: Int,
+    tokIllegal: Int,
+) -> Int {
+    if op == binAdd { return tokPlus }
+    if op == binSub { return tokMinus }
+    if op == binMul { return tokStar }
+    if op == binDiv { return tokSlash }
+    if op == binMod { return tokPercent }
+    if op == binEq { return tokEQ }
+    if op == binNeq { return tokNEQ }
+    if op == binLt { return tokLT }
+    if op == binLeq { return tokLEQ }
+    if op == binGt { return tokGT }
+    if op == binGeq { return tokGEQ }
+    if op == binAnd { return tokAnd }
+    if op == binOr { return tokOr }
+    if op == binBitAnd { return tokBitAnd }
+    if op == binBitOr { return tokBitOr }
+    if op == binBitXor { return tokBitXor }
+    if op == binShl { return tokShl }
+    if op == binShr { return tokShr }
+    tokIllegal
+}
+
+/// mirLegacyPrimTypeName returns the user-visible Osty type name for an
+/// `ir.PrimKind` int code. The kind values match the iota order in
+/// `internal/ir/ir.go`. Returns the empty string for unknown / pseudo
+/// kinds (`Invalid`, `RawPtr`, `Unit`, `Never`) — callers fall through to
+/// the surrounding error path. Mirrors `legacyPrimTypeName` in
+/// `internal/llvmgen/ir_module.go`.
+pub fn mirLegacyPrimTypeName(
+    kind: Int,
+    primInt: Int,
+    primInt8: Int,
+    primInt16: Int,
+    primInt32: Int,
+    primInt64: Int,
+    primUInt8: Int,
+    primUInt16: Int,
+    primUInt32: Int,
+    primUInt64: Int,
+    primByte: Int,
+    primFloat: Int,
+    primFloat32: Int,
+    primFloat64: Int,
+    primBool: Int,
+    primChar: Int,
+    primString: Int,
+    primBytes: Int,
+) -> String {
+    if kind == primInt { return "Int" }
+    if kind == primInt8 { return "Int8" }
+    if kind == primInt16 { return "Int16" }
+    if kind == primInt32 { return "Int32" }
+    if kind == primInt64 { return "Int64" }
+    if kind == primUInt8 { return "UInt8" }
+    if kind == primUInt16 { return "UInt16" }
+    if kind == primUInt32 { return "UInt32" }
+    if kind == primUInt64 { return "UInt64" }
+    if kind == primByte { return "Byte" }
+    if kind == primFloat { return "Float" }
+    if kind == primFloat32 { return "Float32" }
+    if kind == primFloat64 { return "Float64" }
+    if kind == primBool { return "Bool" }
+    if kind == primChar { return "Char" }
+    if kind == primString { return "String" }
+    if kind == primBytes { return "Bytes" }
+    ""
+}
+
+/// mirLegacyIntrinsicName returns the user-visible name for an
+/// `ir.IntrinsicKind` int code. Currently only the print-family
+/// intrinsics get a name — anything else returns empty so callers
+/// fall through to the LLVM-side error path. Mirrors
+/// `legacyIntrinsicName` in `internal/llvmgen/ir_module.go`. Note this
+/// is distinct from `mirIntrinsicKindLabelFull` which lives on the
+/// MIR side and labels every kind for diagnostic strings.
+pub fn mirLegacyIntrinsicName(
+    kind: Int,
+    intrinsicPrint: Int,
+    intrinsicPrintln: Int,
+    intrinsicEprint: Int,
+    intrinsicEprintln: Int,
+) -> String {
+    if kind == intrinsicPrint { return "print" }
+    if kind == intrinsicPrintln { return "println" }
+    if kind == intrinsicEprint { return "eprint" }
+    if kind == intrinsicEprintln { return "eprintln" }
+    ""
+}
+
+/// mirLlvmCapturingClosureThunkDefinition emits the Phase 4 capturing-
+/// thunk LLVM IR. The thunk takes a single `ptr %env` parameter
+/// followed by the original function's parameters; it loads each
+/// captured value out of the env at the canonical
+/// `closureEnvCapturesOffset + i*8` stride and forwards them along with
+/// the user args to the underlying symbol. Mirrors
+/// `llvmCapturingClosureThunkDefinition` in
+/// `internal/llvmgen/fn_value.go`.
+///
+///   `symbol`           — underlying real-fn symbol (e.g. `myFn` in the
+///                         original source). The thunk's exported name
+///                         is built from this via `mirThunkName`.
+///   `returnType`       — unwrapped LLVM return type. `""` is treated
+///                         as `void`.
+///   `origParamTypes`   — LLVM types of the original (non-env)
+///                         parameters, in order.
+///   `captureTypes`     — LLVM types of the captured values, in
+///                         allocation order.
+///   `capturesOffset`   — fixed byte offset of the captures payload
+///                         relative to the env pointer (matches
+///                         `llvmClosureEnvCapturesOffset()`).
+pub fn mirLlvmCapturingClosureThunkDefinition(
+    symbol: String,
+    returnType: String,
+    origParamTypes: List<String>,
+    captureTypes: List<String>,
+    capturesOffset: Int,
+) -> String {
+    let mut ret = returnType
+    if ret == "" { ret = "void" }
+    let thunk = mirThunkName(symbol)
+    let origN = origParamTypes.len()
+    let capN = captureTypes.len()
+    let mut headerParts: List<String> = []
+    headerParts.push("ptr %env")
+    let mut origArgParts: List<String> = []
+    let mut i = 0
+    for i < origN {
+        let p = origParamTypes[i]
+        let idxStr = mirGenIntToString(i)
+        headerParts.push(p + " %arg" + idxStr)
+        origArgParts.push(p + " %arg" + idxStr)
+        i = i + 1
+    }
+    let header = mirJoinCommaSep(headerParts)
+    let mut lines: List<String> = []
+    lines.push("define private " + ret + " @" + thunk + "(" + header + ") \{")
+    lines.push("entry:")
+    let mut captureArgParts: List<String> = []
+    let mut k = 0
+    for k < capN {
+        let ct = captureTypes[k]
+        let offset = capturesOffset + k * 8
+        let kStr = mirGenIntToString(k)
+        let slotName = "%cap" + kStr + "_slot"
+        let valName = "%cap" + kStr
+        lines.push("  " + slotName + " = getelementptr i8, ptr %env, i64 " + mirGenIntToString(offset))
+        lines.push("  " + valName + " = load " + ct + ", ptr " + slotName)
+        captureArgParts.push(ct + " " + valName)
+        k = k + 1
+    }
+    let mut allArgs: List<String> = []
+    let mut a = 0
+    for a < origN {
+        allArgs.push(origArgParts[a])
+        a = a + 1
+    }
+    let mut b = 0
+    for b < capN {
+        allArgs.push(captureArgParts[b])
+        b = b + 1
+    }
+    let callArgs = mirJoinCommaSep(allArgs)
+    if ret == "void" {
+        lines.push("  call void @" + symbol + "(" + callArgs + ")")
+        lines.push("  ret void")
+    } else {
+        lines.push("  %ret = call " + ret + " @" + symbol + "(" + callArgs + ")")
+        lines.push("  ret " + ret + " %ret")
+    }
+    lines.push("\}")
+    mirJoinNewline(lines)
+}
+
+/// mirJoinCommaSep joins a list of strings with `, ` between adjacent
+/// elements. An empty list produces the empty string. Mirrors the
+/// `strings.Join(parts, ", ")` Go idiom used throughout llvmgen.
+pub fn mirJoinCommaSep(parts: List<String>) -> String {
+    let n = parts.len()
+    let mut out = ""
+    let mut i = 0
+    for i < n {
+        if i > 0 { out = out + ", " }
+        out = out + parts[i]
+        i = i + 1
+    }
+    out
+}
+
+/// mirJoinNewline joins a list of strings with `\n` between adjacent
+/// elements. Used by line builders that produce multi-line IR blocks.
+pub fn mirJoinNewline(parts: List<String>) -> String {
+    let n = parts.len()
+    let mut out = ""
+    let mut i = 0
+    for i < n {
+        if i > 0 { out = out + "\n" }
+        out = out + parts[i]
+        i = i + 1
+    }
+    out
+}
+
+/// mirGEPI8ByteStrideText renders the byte-stride GEP form (no
+/// `inbounds`, since the runtime sometimes feeds us
+/// past-the-end pointers and the LLVM rules forbid `inbounds` for
+/// those): `  <reg> = getelementptr i8, ptr <basePtr>, i64 <offDigits>`.
+/// `offDigits` is a decimal-digit String — callers feed
+/// `mirGenIntToString(offset)` for fixed offsets or the SSA register
+/// for dynamic ones. The plain (non-`inbounds`) shape distinguishes
+/// this from `mirGEPInboundsI8Text`, which despite its name in slice
+/// 10 also drops `inbounds`. Two distinct names track the call-site
+/// intent: this one for closure-env capture slot math; the older one
+/// for everywhere else.
+pub fn mirGEPI8ByteStrideText(reg: String, basePtr: String, offDigits: String) -> String {
+    "  " + reg + " = getelementptr i8, ptr " + basePtr + ", i64 " + offDigits
+}
+
+/// mirCaptureSlotGEPText renders the closure-env capture-slot GEP that
+/// the capturing-thunk emitter produces:
+///   `  %cap<idxDigits>_slot = getelementptr i8, ptr <env>, i64 <offDigits>`.
+/// This is the slot-pointer side of the load/store pair in
+/// `mirLlvmCapturingClosureThunkDefinition` — exposed standalone for
+/// other capture-style emitters that share the layout but build the
+/// surrounding IR differently.
+pub fn mirCaptureSlotGEPText(idxDigits: String, env: String, offDigits: String) -> String {
+    "  %cap" + idxDigits + "_slot = getelementptr i8, ptr " + env + ", i64 " + offDigits
+}
+
+/// mirCaptureLoadText renders the load that pulls a capture out of its
+/// env slot:
+///   `  %cap<idxDigits> = load <ty>, ptr %cap<idxDigits>_slot`.
+/// Sibling of `mirCaptureSlotGEPText`.
+pub fn mirCaptureLoadText(idxDigits: String, ty: String) -> String {
+    "  %cap" + idxDigits + " = load " + ty + ", ptr %cap" + idxDigits + "_slot"
+}
+
+/// mirCaptureSlotGEPLine is the trailing-newline twin of
+/// `mirCaptureSlotGEPText` — used by direct `WriteString` callers
+/// rather than `body []string` accumulators.
+pub fn mirCaptureSlotGEPLine(idxDigits: String, env: String, offDigits: String) -> String {
+    mirCaptureSlotGEPText(idxDigits, env, offDigits) + "\n"
+}
+
+/// mirCaptureLoadLine is the trailing-newline twin of
+/// `mirCaptureLoadText`.
+pub fn mirCaptureLoadLine(idxDigits: String, ty: String) -> String {
+    mirCaptureLoadText(idxDigits, ty) + "\n"
+}
+
+/// mirThunkDefineHeaderText renders the opening `define private` line
+/// of a closure thunk (no trailing newline):
+///   `define private <ret> @<thunk>(<header>) \{`.
+/// Sibling of `mirThunkHeaderLine` in the §3 family but emitted as
+/// `Text` for `body []string` accumulators (the slice-10 thunk emitter
+/// joined manually with `\n`).
+pub fn mirThunkDefineHeaderText(ret: String, thunk: String, header: String) -> String {
+    "define private " + ret + " @" + thunk + "(" + header + ") \{"
+}
+
+/// mirThunkCallVoidText renders the inner `call void @<sym>(<args>)`
+/// instruction for a void-returning thunk forward-call. No trailing
+/// newline — `body []string` callers join.
+pub fn mirThunkCallVoidText(sym: String, callArgs: String) -> String {
+    "  call void @" + sym + "(" + callArgs + ")"
+}
+
+/// mirThunkCallValueText renders `  %ret = call <ret> @<sym>(<args>)`
+/// — the value-returning sibling of `mirThunkCallVoidText`.
+pub fn mirThunkCallValueText(ret: String, sym: String, callArgs: String) -> String {
+    "  %ret = call " + ret + " @" + sym + "(" + callArgs + ")"
+}
+
+/// mirThunkRetVoidText renders `  ret void` (no trailing newline).
+pub fn mirThunkRetVoidText() -> String {
+    "  ret void"
+}
+
+/// mirThunkRetValueText renders `  ret <ret> %ret`.
+pub fn mirThunkRetValueText(ret: String) -> String {
+    "  ret " + ret + " %ret"
+}
+
+/// mirThunkBraceCloseText renders the closing `\}` of a thunk
+/// definition. Standalone helper so call sites that build the thunk
+/// line-by-line need not embed the literal `\}`.
+pub fn mirThunkBraceCloseText() -> String {
+    "\}"
+}
+
+/// mirEnvCaptureStoreText renders the capture-store line that the
+/// closure-env allocator runs after `osty.rt.closure_env_alloc_v2`:
+///   `  store <ty> <val>, ptr <slot>`.
+/// Identical to `mirStoreText` shape-wise, but exposed under this
+/// name so call-site intent ("write a capture value into its slot")
+/// is preserved when scanning emitter source.
+pub fn mirEnvCaptureStoreText(ty: String, val: String, slot: String) -> String {
+    "  store " + ty + " " + val + ", ptr " + slot
+}
+
+/// mirEnvCaptureSlotPtrGEPText renders the dynamic capture-slot GEP
+/// used at allocation time (where the slot register name is
+/// caller-chosen, not the thunk-side `%capN_slot` form):
+///   `  <slotPtr> = getelementptr i8, ptr <env>, i64 <offDigits>`.
+/// Same shape as `mirGEPI8ByteStrideText`; alias kept so the
+/// allocator's intent reads cleanly.
+pub fn mirEnvCaptureSlotPtrGEPText(slotPtr: String, env: String, offDigits: String) -> String {
+    "  " + slotPtr + " = getelementptr i8, ptr " + env + ", i64 " + offDigits
+}
+
+/// mirThunkCallVoidLine — trailing-newline twin of
+/// `mirThunkCallVoidText` for direct `WriteString` callers.
+pub fn mirThunkCallVoidLine(sym: String, callArgs: String) -> String {
+    mirThunkCallVoidText(sym, callArgs) + "\n"
+}
+
+/// mirThunkCallValueLine — trailing-newline twin of
+/// `mirThunkCallValueText`.
+pub fn mirThunkCallValueLine(ret: String, sym: String, callArgs: String) -> String {
+    mirThunkCallValueText(ret, sym, callArgs) + "\n"
+}
+
+/// mirThunkRetVoidLine — trailing-newline twin of
+/// `mirThunkRetVoidText`.
+pub fn mirThunkRetVoidLine() -> String {
+    "  ret void\n"
+}
+
+/// mirThunkRetValueLine — trailing-newline twin of
+/// `mirThunkRetValueText`.
+pub fn mirThunkRetValueLine(ret: String) -> String {
+    "  ret " + ret + " %ret\n"
+}
+
+/// mirThunkDefineHeaderLine — trailing-newline twin of
+/// `mirThunkDefineHeaderText`.
+pub fn mirThunkDefineHeaderLine(ret: String, thunk: String, header: String) -> String {
+    mirThunkDefineHeaderText(ret, thunk, header) + "\n"
+}
+
+/// mirLlvmMethodIRName composes the LLVM IR symbol for a named method.
+/// The shape is `<sanitised_owner>__<sanitised_method>` — the double
+/// underscore separator matches the Itanium-style mangling the legacy
+/// emitter has used since Phase 1. Mirrors `llvmMethodIRName` in
+/// `internal/llvmgen/type.go`.
+pub fn mirLlvmMethodIRName(ownerName: String, methodName: String) -> String {
+    mirSanitizeLLVMName(ownerName) + "__" + mirSanitizeLLVMName(methodName)
+}
+
+/// mirLlvmMethodReceiverIRType returns the LLVM type for a method
+/// receiver. Mutable receivers (`mut self`) lower to `ptr` (pointer to
+/// the owner struct/enum); immutable receivers pass the owner type by
+/// value. Mirrors `llvmMethodReceiverIRType` in
+/// `internal/llvmgen/type.go`.
+pub fn mirLlvmMethodReceiverIRType(ownerType: String, mutable: Bool) -> String {
+    if mutable { return "ptr" }
+    ownerType
+}
+
+/// mirIntrinsicVectorListFastPathSafe reports whether a MIR intrinsic
+/// kind is safe to invoke against a vector-List local that has been
+/// hoisted to a single fast-path snapshot. Today only
+/// IntrinsicListLen (30) and IntrinsicListIsEmpty (32) qualify — both
+/// are pure reads that touch only the list's length header, so the
+/// hoisted data ptr stays valid even if the surrounding fn never
+/// rebinds the list. Mirrors `mirIntrinsicSafeForVectorListFastPath`
+/// in `internal/llvmgen/mir_generator.go` (the Go-side keeps the longer
+/// name; this Osty companion uses a slightly different name to avoid
+/// the package-private name collision in the Go mirror file).
+pub fn mirIntrinsicVectorListFastPathSafe(
+    kind: Int,
+    intrinsicListLen: Int,
+    intrinsicListIsEmpty: Int,
+) -> Bool {
+    if kind == intrinsicListLen { return true }
+    if kind == intrinsicListIsEmpty { return true }
+    false
+}
+
+/// mirNativeShimDefineHeaderText renders the open of an interface-shim
+/// function definition for the native (IR-driven) projection's
+/// emitNativeInterfaceShim. Shape:
+///   `define <ret> @osty.shim.<struct>__<iface>__<method>(ptr %self_data<rest>) \{\nentry:\n`
+/// The `rest` argument is the pre-joined "<, ty %argN>" extension for
+/// the original interface method's params. Mirrors the inline
+/// b.WriteString(...) preamble in
+/// `internal/llvmgen/ir_native_entry.go:emitNativeInterfaceShim`.
+pub fn mirNativeShimDefineHeaderText(
+    ret: String,
+    structName: String,
+    ifaceName: String,
+    methodName: String,
+    rest: String,
+) -> String {
+    "define " + ret + " @osty.shim." + structName + "__" + ifaceName + "__" + methodName +
+        "(ptr %self_data" + rest + ") \{\nentry:\n"
+}
+
+/// mirNativeShimLoadSelfText renders the receiver-load line for the
+/// native shim:
+///   `  %self = load <structLLVM>, ptr %self_data, align 8\n`.
+/// The native projection always loads with `align 8`. Mirrors the
+/// equivalent inline `b.WriteString` block in `emitNativeInterfaceShim`.
+pub fn mirNativeShimLoadSelfText(structLLVM: String) -> String {
+    "  %self = load " + structLLVM + ", ptr %self_data, align 8\n"
+}
+
+/// mirNativeShimCallVoidText renders the void-return shim call:
+///   `  call <ret> @<sym>(<argList>)\n`.
+/// The leading `call <ret>` is parameterised because callers want to
+/// emit it both for `ret == "void"` and for unused-return value calls.
+pub fn mirNativeShimCallVoidText(ret: String, sym: String, argList: String) -> String {
+    "  call " + ret + " @" + sym + "(" + argList + ")\n"
+}
+
+/// mirNativeShimCallValueText renders the value-return shim call:
+///   `  %res = call <ret> @<sym>(<argList>)\n`.
+pub fn mirNativeShimCallValueText(ret: String, sym: String, argList: String) -> String {
+    "  %res = call " + ret + " @" + sym + "(" + argList + ")\n"
+}
+
+/// mirNativeShimRetVoidText renders `  ret void\n`.
+pub fn mirNativeShimRetVoidText() -> String {
+    "  ret void\n"
+}
+
+/// mirNativeShimRetValueText renders `  ret <ret> %res\n`.
+pub fn mirNativeShimRetValueText(ret: String) -> String {
+    "  ret " + ret + " %res\n"
+}
+
+/// mirArrayI64TypeText renders the `[<n> x i64]` LLVM array-type
+/// fragment used by GC root-offset arrays. `nDigits` is the
+/// pre-formatted decimal count.
+pub fn mirArrayI64TypeText(nDigits: String) -> String {
+    "[" + nDigits + " x i64]"
+}
+
+/// mirArrayPtrTypeText renders the `[<n> x ptr]` LLVM array-type
+/// fragment used by interface vtables and fixed-size pointer slot
+/// arrays.
+pub fn mirArrayPtrTypeText(nDigits: String) -> String {
+    "[" + nDigits + " x ptr]"
+}
+
+/// mirArrayI8TypeText renders the `[<n> x i8]` LLVM array-type
+/// fragment used by string-pool global definitions.
+pub fn mirArrayI8TypeText(nDigits: String) -> String {
+    "[" + nDigits + " x i8]"
+}
+
+/// mirInternalConstantGlobalLine renders the canonical "internal
+/// constant" global-definition line:
+///   `<irName> = internal constant <ty> <init>\n`.
+/// Used by the global emitter for immutable top-level `let`s. The
+/// `kind` in the legacy code is just `"constant"` here — the mutable
+/// counterpart is `mirInternalGlobalLine`.
+pub fn mirInternalConstantGlobalLine(irName: String, ty: String, init: String) -> String {
+    irName + " = internal constant " + ty + " " + init + "\n"
+}
+
+/// mirInternalGlobalLine renders the canonical "internal global"
+/// definition line for mutable top-level `let mut`s:
+///   `<irName> = internal global <ty> <init>\n`.
+pub fn mirInternalGlobalLine(irName: String, ty: String, init: String) -> String {
+    irName + " = internal global " + ty + " " + init + "\n"
+}
+
+/// mirInternalGlobalDefForKind dispatches between
+/// `mirInternalConstantGlobalLine` and `mirInternalGlobalLine` based on
+/// the boolean `mutable` flag. The legacy code switches on a `kind`
+/// string ("constant" / "global"); this helper folds both into one
+/// builder so the call site stays a single line.
+pub fn mirInternalGlobalDefForKind(irName: String, mutable: Bool, ty: String, init: String) -> String {
+    if mutable { return mirInternalGlobalLine(irName, ty, init) }
+    mirInternalConstantGlobalLine(irName, ty, init)
+}
+
+/// mirConstStructInitText renders the `{ <comma-joined parts> }`
+/// LLVM struct-literal form used for constant struct initialisers.
+/// `parts` is the pre-joined comma-separated list of `<ty> <val>`
+/// fragments from each field's `typedInit()`.
+pub fn mirConstStructInitText(parts: String) -> String {
+    "\{ " + parts + " \}"
+}
+
+/// mirConstEnumVariantInitText renders the LLVM struct-literal for an
+/// enum variant constant: `{ i64 <tag>, <typedPayload> }`. Mirrors the
+/// inline `fmt.Sprintf("\{ i64 %d, %s \}", ...)` in
+/// `internal/llvmgen/decl.go:constEnumVariant`.
+pub fn mirConstEnumVariantInitText(tagDigits: String, typedPayload: String) -> String {
+    "\{ i64 " + tagDigits + ", " + typedPayload + " \}"
+}
+
+/// mirConstTypedInitText renders `<ty> <init>` — the canonical
+/// "typed initialiser" form used by struct-init parts and global
+/// definitions. Mirrors `(constValue).typedInit` in
+/// `internal/llvmgen/decl.go`.
+pub fn mirConstTypedInitText(ty: String, init: String) -> String {
+    ty + " " + init
+}
+
+/// mirSyntheticArgName renders `__arg<idxDigits>` — the synthetic
+/// parameter name the param-pattern lowering uses when a destructuring
+/// pattern is nameless (e.g. `fn f((a, b): (Int, Int))`).
+pub fn mirSyntheticArgName(idxDigits: String) -> String {
+    "__arg" + idxDigits
+}
+
+/// mirCallArgsPtrPrefix renders the leading `ptr <selfPtr>` arg of an
+/// interface dispatch call's argument list. Used when threading the
+/// receiver's data ptr as the first call arg ahead of the user args.
+pub fn mirCallArgsPtrPrefix(selfPtr: String) -> String {
+    "ptr " + selfPtr
+}
+
+/// mirCallArgsTypePair renders `<ty> <val>` — one type+register entry
+/// in a call argument list. Pluralised joins via `mirJoinCommaSep` are
+/// the typical caller pattern.
+pub fn mirCallArgsTypePair(ty: String, val: String) -> String {
+    ty + " " + val
+}
+
+/// mirAppendArgWithComma is a convenience for the inline
+/// `arg += ", " + ty + " " + val` pattern. The callers that build call
+/// arg strings by string-concat share this shape; bundling it as a
+/// builder keeps the leading-comma policy in one place.
+pub fn mirAppendArgWithComma(existing: String, ty: String, val: String) -> String {
+    existing + ", " + ty + " " + val
+}
+
+/// mirAppendCallArgPart appends a `, <ty> <val>` arg pair to an
+/// existing argList accumulator only if the existing string is
+/// non-empty; otherwise the leading comma is omitted. Mirrors the
+/// `if argList != "" { argList += ", " }` pattern that pops up in the
+/// IR-text writers in `ir_native_entry.go`.
+pub fn mirAppendCallArgPart(existing: String, ty: String, val: String) -> String {
+    if existing == "" { return ty + " " + val }
+    existing + ", " + ty + " " + val
+}
+
+/// mirLlvmFloat64HexLiteral renders the LLVM hex form of a Float64
+/// bit pattern: `0x<16 hex digits>`. The 16-char `hexDigits` argument
+/// is computed host-side (Go `fmt.Sprintf("%016X", math.Float64bits(v))`
+/// since Osty has no `math.Float64bits` equivalent today). Used by
+/// `llvmFloatConstLiteral` for NaN/Inf. Mirrors the
+/// `fmt.Sprintf("0x%016X", ...)` shape in
+/// `internal/llvmgen/decl.go:llvmFloatConstLiteral`.
+pub fn mirLlvmFloat64HexLiteral(hexDigits: String) -> String {
+    "0x" + hexDigits
+}
+
+/// mirFormatFloatEnsureDot ensures a Float64 string-form has a
+/// recognisable fractional or exponent component so LLVM's text-IR
+/// parser will parse it as a float rather than an integer literal. The
+/// host computes `strconv.FormatFloat(v, 'g', -1, 64)` and feeds the
+/// result here; if the result contains none of `.`, `e`, or `E`, this
+/// helper appends `".0"` to disambiguate. Mirrors `formatFloat` in
+/// `internal/llvmgen/mir_generator.go`.
+pub fn mirFormatFloatEnsureDot(formatted: String) -> String {
+    let n = formatted.len()
+    let mut i = 0
+    let mut hasDotOrExp = false
+    for i < n {
+        let ch = formatted[i..(i + 1)]
+        if ch == "." { hasDotOrExp = true }
+        if ch == "e" { hasDotOrExp = true }
+        if ch == "E" { hasDotOrExp = true }
+        i = i + 1
+    }
+    if hasDotOrExp { return formatted }
+    formatted + ".0"
+}
+
+/// (mirParamSlotName / mirLocalSlotName already exist higher up in this
+/// file as part of the §8 LLVM-text local-name composers — the bodies
+/// are identical, so no duplicate definition is needed here.)
+
+/// mirRuntimeDeclareI1FromTwoPtrText renders the LLVM declaration line
+/// for a runtime helper that takes two `ptr` args and returns `i1`:
+///   `declare i1 @<sym>(ptr, ptr)`.
+/// Used for `osty_rt_strings_Equal`, `osty_rt_bytes_Equal`, and any
+/// future heap-equality helper that share this ABI.
+pub fn mirRuntimeDeclareI1FromTwoPtrText(sym: String) -> String {
+    "declare i1 @" + sym + "(ptr, ptr)"
+}
+
+/// mirRuntimeDeclareI64FromTwoPtrText renders the LLVM declaration line
+/// for a runtime helper that takes two `ptr` args and returns `i64`:
+///   `declare i64 @<sym>(ptr, ptr)`.
+/// Used for cross-collection compare helpers (e.g.
+/// `osty_rt_strings_Compare`).
+pub fn mirRuntimeDeclareI64FromTwoPtrText(sym: String) -> String {
+    "declare i64 @" + sym + "(ptr, ptr)"
+}
+
+/// mirIntrinsicCallStaticPathText renders the canonical "tag with line
+/// info" prefix used in intrinsic-write debug summaries. Currently
+/// renders `intrinsic kind=<n> at <line>:<col>` — leaves the rest of
+/// the message to the caller. Mirrors the inline `fmt.Sprintf` site in
+/// `internal/llvmgen/mir_generator.go:localDefiningSiteHint`.
+pub fn mirIntrinsicWrittenByText(kindDigits: String, lineDigits: String, colDigits: String) -> String {
+    "written by intrinsic kind=" + kindDigits + " at " + lineDigits + ":" + colDigits
+}
+
+/// mirCallWrittenByText renders `written by call `<callee>` at
+/// <line>:<col>`. The callee name is wrapped in backticks (matching
+/// the legacy debug shape).
+pub fn mirCallWrittenByText(callee: String, lineDigits: String, colDigits: String) -> String {
+    "written by call `" + callee + "` at " + lineDigits + ":" + colDigits
+}
+
+/// mirAssignWrittenByText renders the assign site debug summary:
+/// `written by assign at <line>:<col> (src=<src>)`. Used by the
+/// `localDefiningSiteHint` walker.
+pub fn mirAssignWrittenByText(lineDigits: String, colDigits: String, src: String) -> String {
+    "written by assign at " + lineDigits + ":" + colDigits + " (src=" + src + ")"
+}
+
+/// mirRValueBinaryDebugText renders `BinaryRV(op=<n>, T=<typeStr>)`.
+/// Used by `mirRValueDebugString` to identify a Binary rvalue's op /
+/// type pair without paying for the Type interface's full String()
+/// expansion at the diagnostic site.
+pub fn mirRValueBinaryDebugText(opDigits: String, typeStr: String) -> String {
+    "BinaryRV(op=" + opDigits + ", T=" + typeStr + ")"
+}
+
+/// mirRValueUnaryDebugText renders `UnaryRV(op=<n>, T=<typeStr>)`.
+pub fn mirRValueUnaryDebugText(opDigits: String, typeStr: String) -> String {
+    "UnaryRV(op=" + opDigits + ", T=" + typeStr + ")"
+}
+
+/// mirRValueAggregateDebugText renders
+/// `AggregateRV(kind=<n>, T=<typeStr>)`. Used by aggregate-construction
+/// rvalue debug sites.
+pub fn mirRValueAggregateDebugText(kindDigits: String, typeStr: String) -> String {
+    "AggregateRV(kind=" + kindDigits + ", T=" + typeStr + ")"
+}
+
+/// mirRValueCastDebugText renders `CastRV(kind=<n>, To=<typeStr>)`.
+pub fn mirRValueCastDebugText(kindDigits: String, typeStr: String) -> String {
+    "CastRV(kind=" + kindDigits + ", To=" + typeStr + ")"
+}
+
+/// mirIntrinsicLabelKindFallback renders the fallback string used when
+/// `mirIntrinsicKindLabelFull` does not recognise an intrinsic kind:
+/// `kind=<n>`. Centralised so the diagnostic shape stays consistent.
+pub fn mirIntrinsicLabelKindFallback(kindDigits: String) -> String {
+    "kind=" + kindDigits
+}
+
+/// mirTestingFailureMessage renders the canonical
+/// `testing.<method> failed at <label>` message used by
+/// emitTestingAssertion / similar helpers when an assertion fails.
+pub fn mirTestingFailureMessage(method: String, label: String) -> String {
+    "testing." + method + " failed at " + label
+}
+
+/// mirSourceLineLabelText composes `<source>:<lineDigits>` — the
+/// canonical "where in the source did this come from" tag used by
+/// failure messages.
+pub fn mirSourceLineLabelText(source: String, lineDigits: String) -> String {
+    source + ":" + lineDigits
+}
+
+/// mirAssertExprFragmentText renders the per-fragment shape of an
+/// assertion message: `<base>: <label>=`<exprText>``. Mirrors
+/// `fmt.Sprintf("%s: %s=`%s`", ...)` in the assertion lowering.
+pub fn mirAssertExprFragmentText(base: String, label: String, exprText: String) -> String {
+    base + ": " + label + "=`" + exprText + "`"
+}
+
+/// mirAssertExprLeftFragmentText renders the left-hand fragment of an
+/// `assertEq` failure message: `<base>: left=`<leftText>``.
+pub fn mirAssertExprLeftFragmentText(base: String, leftText: String) -> String {
+    base + ": left=`" + leftText + "`"
+}
+
+/// mirAssertExprRightFragmentText renders the right-hand fragment of
+/// an `assertEq` failure message: ` right=`<rightText>``. Note the
+/// leading space — the fragment is intended to be concatenated after a
+/// comma-less left fragment.
+pub fn mirAssertExprRightFragmentText(rightText: String) -> String {
+    " right=`" + rightText + "`"
+}
+
+/// mirOptionUnwrapNoneMessage renders the runtime abort message for an
+/// `Option.unwrap()` that hits None: `unwrap on None at <label>`.
+/// Mirrors the inline `fmt.Sprintf` site in
+/// `internal/llvmgen/expr.go:emitUnwrapCall`.
+pub fn mirOptionUnwrapNoneMessage(label: String) -> String {
+    "unwrap on None at " + label
+}
+
+/// mirDebugIdentText renders `ident <quotedName>` — the debug shape
+/// for an Ident pattern in `debugPatternShape`.
+pub fn mirDebugIdentText(quotedName: String) -> String {
+    "ident " + quotedName
+}
+
+/// mirDebugVariantNoArgsText renders `variant <path> (no args)` for a
+/// payload-free variant pattern.
+pub fn mirDebugVariantNoArgsText(path: String) -> String {
+    "variant " + path + " (no args)"
+}
+
+/// mirDebugVariantWithArgsText renders
+/// `variant <path> with <argDigits> arg(s)` for a payload-carrying
+/// variant pattern.
+pub fn mirDebugVariantWithArgsText(path: String, argDigits: String) -> String {
+    "variant " + path + " with " + argDigits + " arg(s)"
+}
+
+/// mirDebugTupleText renders `tuple of <elemDigits>` for a TuplePat.
+pub fn mirDebugTupleText(elemDigits: String) -> String {
+    "tuple of " + elemDigits
+}
+
+/// mirDebugStructText renders `struct <typePath>` for a StructPat.
+pub fn mirDebugStructText(typePath: String) -> String {
+    "struct " + typePath
+}
+
+/// mirParamIndexedName renders the canonical "argN" param name —
+/// `arg<idxDigits>` (no `%`). Used by paramInfo construction in
+/// `internal/llvmgen/fn_value.go`. Distinct from `mirSyntheticArgName`
+/// (which produces the `__argN` form for nameless destructuring
+/// patterns) — this one drops the leading underscores.
+pub fn mirParamIndexedName(idxDigits: String) -> String {
+    "arg" + idxDigits
+}
+
+/// mirParamRegRef renders `%arg<idxDigits>` — the LLVM SSA register
+/// form for an indexed param. Used by all sites that need the LLVM-side
+/// reference rather than the bare name.
+pub fn mirParamRegRef(idxDigits: String) -> String {
+    "%arg" + idxDigits
+}
+
+/// mirCaptureRegRef renders `%cap<idxDigits>` — the LLVM SSA register
+/// for the i-th loaded capture in a closure thunk.
+pub fn mirCaptureRegRef(idxDigits: String) -> String {
+    "%cap" + idxDigits
+}
+
+/// mirReturnRegRef renders `%ret` — the canonical SSA register name
+/// that the closure thunk uses for the wrapped call's return value.
+pub fn mirReturnRegRef() -> String {
+    "%ret"
+}
+
+/// mirSelfRegRef renders `%self` — the canonical SSA register name
+/// for an interface-shim or method-call receiver.
+pub fn mirSelfRegRef() -> String {
+    "%self"
+}
+
+/// mirSelfDataRegRef renders `%self_data` — the data-pointer side of a
+/// fat-pointer interface receiver (used by `osty.shim.*` shims).
+pub fn mirSelfDataRegRef() -> String {
+    "%self_data"
+}
+
+/// mirEnvRegRef renders `%env` — the env-pointer parameter name used
+/// throughout the closure thunk family.
+pub fn mirEnvRegRef() -> String {
+    "%env"
+}
+
+/// mirCapSlotRegRef renders `%cap<idxDigits>_slot` — the SSA register
+/// that holds the GEP'd byte-offset pointer to a capture's slot in the
+/// thunk's env. Sibling of `mirCaptureRegRef` and the Phase-4 thunk
+/// emitter's `slotName` shape.
+pub fn mirCapSlotRegRef(idxDigits: String) -> String {
+    "%cap" + idxDigits + "_slot"
+}
+
+/// mirAtPosLabelText renders `at <pos> (offset <offsetDigits>)` —
+/// the canonical "where in the source" label used by wall messages.
+/// Note `<pos>` is already pre-formatted (e.g. `file.osty:12:3`).
+pub fn mirAtPosLabelText(pos: String, offsetDigits: String) -> String {
+    "at " + pos + " (offset " + offsetDigits + ")"
+}
+
+/// mirAtPosNoOffsetLabelText renders `at <pos>` — the offset-less form
+/// used when the source position has no usable byte offset (zero-pos).
+pub fn mirAtPosNoOffsetLabelText(pos: String) -> String {
+    "at " + pos
+}
+
+/// mirInternalDeclareTextNoArgs renders `declare <retTy> @<sym>()` for
+/// a runtime helper that takes no arguments.
+pub fn mirInternalDeclareTextNoArgs(retTy: String, sym: String) -> String {
+    "declare " + retTy + " @" + sym + "()"
+}
+
+/// mirInternalDeclareTextOnePtr renders `declare <retTy> @<sym>(ptr)`
+/// for a runtime helper that takes one ptr argument.
+pub fn mirInternalDeclareTextOnePtr(retTy: String, sym: String) -> String {
+    "declare " + retTy + " @" + sym + "(ptr)"
+}
+
+/// mirInternalDeclareTextOneI64 renders `declare <retTy> @<sym>(i64)`.
+pub fn mirInternalDeclareTextOneI64(retTy: String, sym: String) -> String {
+    "declare " + retTy + " @" + sym + "(i64)"
+}
+
+/// mirInternalDeclareTextOneI32 renders `declare <retTy> @<sym>(i32)`.
+pub fn mirInternalDeclareTextOneI32(retTy: String, sym: String) -> String {
+    "declare " + retTy + " @" + sym + "(i32)"
+}
+
+/// mirInternalDeclareTextI1FromPtrI64 renders
+/// `declare i1 @<sym>(ptr, i64)`.
+pub fn mirInternalDeclareTextI1FromPtrI64(sym: String) -> String {
+    "declare i1 @" + sym + "(ptr, i64)"
+}
+
+/// mirInternalDeclareTextPtrFromPtrI64 renders
+/// `declare ptr @<sym>(ptr, i64)`.
+pub fn mirInternalDeclareTextPtrFromPtrI64(sym: String) -> String {
+    "declare ptr @" + sym + "(ptr, i64)"
+}
+
+/// mirInternalDeclareTextI64FromPtr renders `declare i64 @<sym>(ptr)`.
+pub fn mirInternalDeclareTextI64FromPtr(sym: String) -> String {
+    "declare i64 @" + sym + "(ptr)"
+}
+
+/// mirInternalDeclareTextI32FromPtr renders `declare i32 @<sym>(ptr)`.
+pub fn mirInternalDeclareTextI32FromPtr(sym: String) -> String {
+    "declare i32 @" + sym + "(ptr)"
+}
+
+/// mirInternalDeclareTextVoidFromPtr renders `declare void @<sym>(ptr)`.
+pub fn mirInternalDeclareTextVoidFromPtr(sym: String) -> String {
+    "declare void @" + sym + "(ptr)"
+}
+
+/// mirInternalDeclareTextVoidNoArgs renders `declare void @<sym>()`.
+pub fn mirInternalDeclareTextVoidNoArgs(sym: String) -> String {
+    "declare void @" + sym + "()"
+}
+
+/// mirSelfStateRegRef renders `%self_state` — used by some interface
+/// dispatch state-loading shapes for stateful receivers.
+pub fn mirSelfStateRegRef() -> String {
+    "%self_state"
+}
+
+/// mirSelfPtrRegRef renders `%self.ptr` — the ptr side of a fat
+/// receiver (companion to `mirSelfValRegRef`).
+pub fn mirSelfPtrRegRef() -> String {
+    "%self.ptr"
+}
+
+/// mirSelfValRegRef renders `%self.val` — the value side of a fat
+/// receiver (companion to `mirSelfPtrRegRef`).
+pub fn mirSelfValRegRef() -> String {
+    "%self.val"
+}
+
+/// mirRetValRegRef renders `%ret.val` — the canonical SSA register
+/// name for an interface-shim return value.
+pub fn mirRetValRegRef() -> String {
+    "%ret.val"
+}
+
+/// mirInterfaceShimVoidCallText renders the void-return shim call
+/// without the trailing newline:
+///   `  call void @<sym>(<argList>)`.
+pub fn mirInterfaceShimVoidCallText(sym: String, argList: String) -> String {
+    "  call void @" + sym + "(" + argList + ")"
+}
+
+/// mirInterfaceShimValueCallText renders the value-return shim call
+/// without the trailing newline:
+///   `  %ret.val = call <retTy> @<sym>(<argList>)`.
+pub fn mirInterfaceShimValueCallText(retTy: String, sym: String, argList: String) -> String {
+    "  %ret.val = call " + retTy + " @" + sym + "(" + argList + ")"
+}
+
+/// mirInterfaceShimRetVoidText renders `  ret void` without trailing
+/// newline (sibling of the existing `mirInterfaceShimRetVoidLine`).
+pub fn mirInterfaceShimRetVoidText() -> String {
+    "  ret void"
+}
+
+/// mirInterfaceShimRetValueText renders `  ret <retTy> %ret.val`
+/// without trailing newline.
+pub fn mirInterfaceShimRetValueText(retTy: String) -> String {
+    "  ret " + retTy + " %ret.val"
 }


### PR DESCRIPTION
## Summary

Continuing the MIR→LLVM emitter self-host port (Phase 2 slice 11).
Adds 90+ new osty helpers / line builders to `toolchain/mir_generator.osty`
with their Go-side mirrors, drains 13+ inline IR sites, and extends the
IntrinsicKind label table from 13 → 113 cases.

**Scale**: 11 files changed, 2721 insertions(+), 392 deletions(-).

## Pure helper ports (16 new)

| Go (host)                                | Osty (`mirXxxx`) |
| ---------------------------------------- | ---------------- |
| `spliceFnAttrs`                          | `mirSpliceFnAttrs` |
| `spliceNoaliasParams`                    | `mirSpliceNoaliasParams` |
| `tagParallelAccessesLines`               | `mirTagParallelAccessesLines` |
| `llvmAggregatePathIndices`               | `mirLlvmAggregatePathIndices` |
| `llvmFloatConstLiteral` (NaN/Inf branch) | `mirLlvmFloat64HexLiteral` |
| `constIntBinary`                         | `mirConstIntBinary` + `mirConstIntBinaryStatus` |
| `legacyAssignOp`                         | `mirLegacyAssignOpCode` |
| `legacyUnaryOp`                          | `mirLegacyUnaryOpCode` |
| `legacyBinaryOp`                         | `mirLegacyBinaryOpCode` |
| `legacyPrimTypeName`                     | `mirLegacyPrimTypeName` |
| `legacyIntrinsicName`                    | `mirLegacyIntrinsicName` |
| `llvmCapturingClosureThunkDefinition`    | `mirLlvmCapturingClosureThunkDefinition` |
| `llvmMethodIRName`                       | `mirLlvmMethodIRName` |
| `llvmMethodReceiverIRType`               | `mirLlvmMethodReceiverIRType` |
| `mirIntrinsicSafeForVectorListFastPath`  | `mirIntrinsicVectorListFastPathSafe` |
| `formatFloat`                            | `mirFormatFloatEnsureDot` |

The legacy/IR-side mappers (AssignOp, UnaryOp, BinaryOp, PrimKind,
IntrinsicKind) follow the slice 10 `compoundBinaryOp` pattern: the
multi-value Go signature collapses to a single Int / String on the
Osty side, with the Go wrapper plumbing every relevant enum int so
the mapping stays in lockstep.

`constIntBinary` splits into `mirConstIntBinary` (value channel) +
`mirConstIntBinaryStatus` (error channel: 0 ok, 1 div0, 2 mod0, 3
unsupported); the host wrapper rebuilds `(int64, error)`.

## IntrinsicKind label table extension

`mirIntrinsicKindLabelFull` extended from 13 → 113 cases — every
IntrinsicKind iota value from `IntrinsicPrint` (1) through
`IntrinsicMapIncr` (113). Diagnostic strings now render
`list.push` / `map.get_or` / `select.recv` rather than `kind=NN`.

## New line builder families

- **Closure thunks** (~10 builders): `mirLlvmCapturingClosureThunkDefinition`,
  `mirThunkDefineHeaderText/Line`, `mirThunkCallVoidText/Line`,
  `mirThunkCallValueText/Line`, `mirThunkRetVoidText/Line`,
  `mirThunkRetValueText/Line`, `mirThunkBraceCloseText`.
- **Closure env captures** (~5): `mirCaptureSlotGEPText/Line`,
  `mirCaptureLoadText/Line`, `mirEnvCaptureSlotPtrGEPText`,
  `mirEnvCaptureStoreText`.
- **Native interface shims** (~6): `mirNativeShim*Text` family.
- **Array type fragments** (3): `mirArrayI64TypeText`,
  `mirArrayPtrTypeText`, `mirArrayI8TypeText`.
- **Global definitions** (3): `mirInternalConstantGlobalLine`,
  `mirInternalGlobalLine`, `mirInternalGlobalDefForKind`.
- **Constant struct/enum init** (3): `mirConstStructInitText`,
  `mirConstEnumVariantInitText`, `mirConstTypedInitText`.
- **Argument list assembly** (~7): `mirCallArgsPtrPrefix`,
  `mirCallArgsTypePair`, `mirAppendArgWithComma`,
  `mirAppendCallArgPart`, `mirJoinCommaSep`, `mirJoinNewline`,
  `mirSplitCommaSep`.
- **Runtime declarations** (~12): `mirRuntimeDeclareI1FromTwoPtrText`,
  `mirRuntimeDeclareI64FromTwoPtrText`, plus a one-arg family
  (no-args / one-ptr / one-i64 / one-i32 / i1-from-ptr-i64 / etc.).
- **Diagnostic / debug message text** (~20):
  `mirIntrinsicWrittenByText`, `mirCallWrittenByText`,
  `mirAssignWrittenByText`, `mirRValue*DebugText` (Binary / Unary /
  Aggregate / Cast), `mirIntrinsicLabelKindFallback`,
  `mirTestingFailureMessage`, `mirSourceLineLabelText`,
  `mirAssertExpr*FragmentText`, `mirOptionUnwrapNoneMessage`,
  `mirDebug*Text` (Ident / Variant / Tuple / Struct),
  `mirAtPos*LabelText`.
- **Reg refs** (~12): `mirParamIndexedName`, `mirParamRegRef`,
  `mirCaptureRegRef`, `mirReturnRegRef`, `mirSelfRegRef`,
  `mirSelfDataRegRef`, `mirEnvRegRef`, `mirCapSlotRegRef`,
  `mirSelfStateRegRef`, `mirSelfPtrRegRef`, `mirSelfValRegRef`,
  `mirRetValRegRef`.

## Inline IR drains (~13 sites)

Drained inline `fmt.Sprintf` IR-text sites across `expr.go`, `decl.go`,
`mir_generator.go`, `fn_value.go`, `ir_native_entry.go`:

- Closure-env capture stores (fn_value.go, 2 sites)
- Closure-env capture loads (ir_native_entry.go, 2 sites)
- Aggregate root-array `[N x i64]` type (expr.go)
- Interface dispatch arg-list construction (expr.go, 2 sites)
- Synthetic `__argN` name + internal constant/global definitions +
  Constant struct/enum init + typedInit (decl.go)
- Local/param slot names in MIR alloca preamble (mir_generator.go)
- Runtime declares for heap equality / ordering (mir_generator.go)
- Debug-string sites for rvalue / instr / callee (mir_generator.go)
- Testing failure message + source line label (mir_generator.go, stmt.go)
- Assertion fragment text (mir_generator.go, stmt.go)
- Pattern shape debug labels + Option.unwrap None message (expr.go)
- Native interface-shim emission (ir_native_entry.go)
- llvmFloatConstLiteral NaN/Inf hex literal (decl.go)

## Test plan

- [x] `go build ./internal/llvmgen/` clean
- [x] `go vet ./internal/llvmgen/` clean
- [x] `go test -short ./internal/llvmgen/` shows EXACTLY the 6 baseline
      failures and no others:
    - TestGenerateModuleMethodLocalGenericGetMonomorphized
    - TestNativeOwnedModuleEntryOptionalQuestionStructBatch
    - TestNativeOwnedModuleEntryOptionalFieldBatch
    - TestTryGenerateNativeOwnedModuleCoversInterfaceBoxingDispatch
    - TestTryGenerateNativeOwnedModuleCoversInterfaceDispatchWithArgs
    - TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern
- [x] `TestToolchainFilesParseWithoutDiagnostics` passes — Osty parser
      accepts the new toolchain code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)