### PR TITLE
feat: expand stdlib io and url support

### DIFF
--- a/LANG_SPEC_v0.5/02-type-system.md
+++ b/LANG_SPEC_v0.5/02-type-system.md
@@ -210,7 +210,7 @@ typing).
 
 ```osty
 interface Reader {
-    fn read(self, buf: Bytes) -> Result<Int, Error>
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
 }
 
 interface ReadWriter {

--- a/LANG_SPEC_v0.5/03-declarations.md
+++ b/LANG_SPEC_v0.5/03-declarations.md
@@ -389,7 +389,7 @@ packages (`Color.Red`).
 ```osty
 pub interface Writer {
     fn write(self, data: Bytes) -> Result<Int, Error>
-    fn close(self) -> Result<(), Error>
+    fn flush(self) -> Result<(), Error>
 }
 ```
 

--- a/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
@@ -1,6 +1,8 @@
 ### 10.1 Tier 1 (Core)
 
-- `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`
+- `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`, the
+  `Reader`/`Writer` protocol, in-memory `BytesReader`/`Buffer`, and core
+  stream helpers such as `readAll`, `readExact`, `copy`, `writeString`
 - `std.fs` — file I/O
 - `std.strings` — string manipulation
 - `std.collections` — `List`, `Map`, `Set`

--- a/LANG_SPEC_v0.5/10-standard-library/23-net.md
+++ b/LANG_SPEC_v0.5/10-standard-library/23-net.md
@@ -48,7 +48,7 @@ net.listen(addr: String) -> Result<TcpListener, Error>
 
 pub struct TcpConn {
     // implements Reader, Writer, Closer (§16)
-    fn read(self, buf: mut Bytes) -> Result<Int, Error>
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
     fn write(self, data: Bytes) -> Result<Int, Error>
     fn flush(self) -> Result<(), Error>
     fn close(self) -> Result<(), Error>

--- a/LANG_SPEC_v0.5/16-io-protocol.md
+++ b/LANG_SPEC_v0.5/16-io-protocol.md
@@ -6,11 +6,11 @@ FFI byte-stream bridges.
 
 ```osty
 pub interface Reader {
-    /// Reads up to `buf.len()` bytes into `buf`, starting at offset 0.
-    /// Returns the number of bytes read. A return value of 0 indicates
-    /// end of stream. Implementations may return fewer bytes than
-    /// requested even when the stream is not exhausted.
-    fn read(self, buf: mut Bytes) -> Result<Int, Error>
+    /// Reads up to `maxBytes` from the stream and returns the bytes
+    /// that were produced. An empty result indicates end of stream.
+    /// Implementations may return fewer bytes than requested even when
+    /// more data remains.
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
 }
 
 pub interface Writer {
@@ -45,9 +45,48 @@ pub interface WriteCloser {
     Writer
     Closer
 }
+
+pub interface ByteReader {
+    Reader
+    fn peek(self, maxBytes: Int) -> Result<Bytes, Error>
+    fn readByte(self) -> Result<Byte?, Error>
+    fn unreadByte(self) -> Result<(), Error>
+}
+
+pub interface LineReader {
+    Reader
+    fn readLineBytes(self) -> Result<Bytes?, Error>
+    fn readLine(self) -> Result<String?, Error>
+}
+
+pub interface ByteWriter {
+    Writer
+    fn writeByte(self, b: Byte) -> Result<Int, Error>
+    fn writeString(self, s: String) -> Result<Int, Error>
+    fn writeLine(self, s: String) -> Result<Int, Error>
+}
+
+pub interface ReaderFrom {
+    fn readFrom(self, r: Reader) -> Result<Int, Error>
+}
+
+pub interface WriterTo {
+    fn writeTo(self, w: Writer) -> Result<Int, Error>
+}
+
+pub interface BufferedReader {
+    ByteReader
+    LineReader
+}
+
+pub interface BufferedWriter {
+    ByteWriter
+    ReaderFrom
+    WriterTo
+}
 ```
 
-**EOF.** A `Reader` signals end-of-stream with `Ok(0)`. There is no
+**EOF.** A `Reader` signals end-of-stream with `Ok(b"")`. There is no
 distinguished `EOF` error.
 
 **Cancellation.** Standard library `Reader`/`Writer` implementations
@@ -59,8 +98,47 @@ is being torn down.
 
 ```
 io.copy(dst: Writer, src: Reader) -> Result<Int, Error>
+io.copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error>
 io.readAll(r: Reader) -> Result<Bytes, Error>
+io.readExact(r: Reader, n: Int) -> Result<Bytes, Error>
+io.readString(r: Reader) -> Result<String, Error>
+io.readLines(r: Reader) -> Result<List<String>, Error>
+io.readAllLines(r: LineReader) -> Result<List<String>, Error>
+io.discard(r: Reader) -> Result<Int, Error>
 io.writeAll(w: Writer, data: Bytes) -> Result<(), Error>
+io.writeString(w: Writer, s: String) -> Result<(), Error>
+io.writeLine(w: Writer, s: String) -> Result<(), Error>
+io.writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error>
 ```
+
+`io.readAll` accumulates a whole stream into a single `Bytes` value.
+`io.readExact` and `io.copyN` require exactly `n` bytes and return
+`Err` on early EOF. `io.readString` validates UTF-8 after `readAll`;
+`io.readLines` splits that text into lines and normalizes trailing `\r`
+from CRLF input, while `io.readAllLines` targets incremental
+`LineReader` implementations directly. `io.discard` drains a reader and
+reports how many bytes were skipped. `io.writeAll` retries short writes
+until the full buffer is accepted, then flushes the writer.
+`io.writeLines` targets the richer `ByteWriter` capability surface.
+`io.copy` repeatedly reads chunks from `src`, writes them fully to
+`dst`, flushes once at the end, and returns the total byte count copied.
+
+**In-memory implementations.** `std.io` also ships small concrete types
+for pure-Osty tests, adapters, and pipelines:
+
+```
+io.bytesReader(data: Bytes) -> io.BytesReader
+io.stringReader(s: String) -> io.BytesReader
+io.buffer() -> io.Buffer
+```
+
+`BytesReader` is a `Reader`/`Closer` over an in-memory `Bytes` payload
+with cursor-style methods such as `remaining()`, `peek(n)`,
+`readByte()`, `unreadByte()`, `skip(n)`, `readLineBytes()`,
+`readLine()`, and `remainingBytes()`.
+`Buffer` is an append-only in-memory writer that satisfies `Writer` and
+adds inspection helpers such as `bytes()` and `toString()`, plus
+buffer-management / piping helpers such as `clear()`, `truncate(n)`,
+`reader()`, `readFrom(r)`, and `writeTo(w)`.
 
 ---

--- a/cmd/osty/url_char_native_test.go
+++ b/cmd/osty/url_char_native_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckCLIHandlesStdUrlAndCharImports(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	source := `use std.char
+use std.url
+
+fn main() {
+    let parsed = url.parse("https://[2001:DB8::1]:8443/a%20b/c?z=last&x=1#frag%20ment").unwrap()
+    let rebuilt = parsed.toString()
+    let joined = url.join("https://example.com/a/b/c?q=1#old", "../d?x=1#new").unwrap()
+    let digit = char.hexDigitValue('f').unwrap()
+    let same = char.eqIgnoreAsciiCase('A', 'a')
+    let mapped = char.fromDigit(35, 36).unwrap()
+
+    println(parsed.scheme)
+    println(parsed.host)
+    println(rebuilt)
+    println(joined)
+    println(digit)
+    println(same)
+    println(mapped)
+}
+`
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "check", "--no-airepair", path)
+	if got.exit != 0 {
+		t.Fatalf("osty check exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "code generation is not implemented yet") {
+		t.Fatalf("stderr = %q, did not want backend-lowering failure during check", got.stderr)
+	}
+}

--- a/internal/check/io_protocol_test.go
+++ b/internal/check/io_protocol_test.go
@@ -1,0 +1,199 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestNativeBoundaryExecRecognizesIoProtocolHelpers(t *testing.T) {
+	src := []byte(`use std.io as io
+use std.net
+
+fn copyAll(src: io.Reader, dst: io.Writer) -> Result<Int, Error> {
+    io.copy(dst, src)
+}
+
+fn roundtrip(stream: net.TcpStream) -> Result<(), Error> {
+    let payload = io.readAll(stream)?
+    io.writeAll(stream, payload)?
+    let copied = copyAll(stream, stream)?
+    Ok(())
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	roundtripDecl := file.Decls[1].(*ast.FnDecl)
+	payloadLet := roundtripDecl.Body.Stmts[0].(*ast.LetStmt)
+	copiedLet := roundtripDecl.Body.Stmts[2].(*ast.LetStmt)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := SelfhostFile(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	for _, tc := range []struct {
+		name     string
+		stmt     *ast.LetStmt
+		wantType string
+	}{
+		{"payload", payloadLet, "Bytes"},
+		{"copied", copiedLet, "Int"},
+	} {
+		if got := chk.LetTypes[tc.stmt]; got == nil || got.String() != tc.wantType {
+			t.Errorf("%s binding type = %v, want %s", tc.name, got, tc.wantType)
+		}
+	}
+}
+
+func TestNativeBoundaryExecRecognizesIoBufferedHelpers(t *testing.T) {
+	src := []byte(`use std.io as io
+
+fn main() -> Result<(), Error> {
+    let reader = io.stringReader("alpha\r\nbeta\n")
+    let lines = io.readLines(reader)?
+
+    let exact = io.readExact(io.stringReader("abcdef"), 3)?
+    let mut bytesReader = io.stringReader("gamma\r\ndelta\n")
+    let head = bytesReader.peek(2)?
+    let first = bytesReader.readByte()?
+    bytesReader.unreadByte()?
+    let line = bytesReader.readLine()?
+    let skipped = bytesReader.skip(2)?
+    let rest = bytesReader.remainingBytes()
+
+    let mut sink = io.buffer()
+    sink.writeString("head")?
+    io.writeLine(sink, "tail")?
+    let loaded = sink.readFrom(io.stringReader("++"))?
+    sink.truncate(6)
+    let copied = io.copyN(sink, io.stringReader("xyz"), 2)?
+    let dumped = io.discard(io.stringReader("rest"))?
+    let rendered = sink.toString()?
+    let bytesOut = sink.bytes()
+    let snapText = io.readString(sink.reader())?
+    let wrote = sink.writeTo(io.buffer())?
+    Ok(())
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[0].(*ast.FnDecl)
+	linesLet := mainDecl.Body.Stmts[1].(*ast.LetStmt)
+	exactLet := mainDecl.Body.Stmts[2].(*ast.LetStmt)
+	headLet := mainDecl.Body.Stmts[4].(*ast.LetStmt)
+	firstLet := mainDecl.Body.Stmts[5].(*ast.LetStmt)
+	lineLet := mainDecl.Body.Stmts[7].(*ast.LetStmt)
+	skippedLet := mainDecl.Body.Stmts[8].(*ast.LetStmt)
+	restLet := mainDecl.Body.Stmts[9].(*ast.LetStmt)
+	loadedLet := mainDecl.Body.Stmts[13].(*ast.LetStmt)
+	copiedLet := mainDecl.Body.Stmts[15].(*ast.LetStmt)
+	dumpedLet := mainDecl.Body.Stmts[16].(*ast.LetStmt)
+	renderedLet := mainDecl.Body.Stmts[17].(*ast.LetStmt)
+	bytesOutLet := mainDecl.Body.Stmts[18].(*ast.LetStmt)
+	snapTextLet := mainDecl.Body.Stmts[19].(*ast.LetStmt)
+	wroteLet := mainDecl.Body.Stmts[20].(*ast.LetStmt)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := SelfhostFile(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	for _, tc := range []struct {
+		name     string
+		stmt     *ast.LetStmt
+		wantType string
+	}{
+		{"lines", linesLet, "List<String>"},
+		{"exact", exactLet, "Bytes"},
+		{"head", headLet, "Bytes"},
+		{"first", firstLet, "Byte?"},
+		{"line", lineLet, "String?"},
+		{"skipped", skippedLet, "Int"},
+		{"rest", restLet, "Bytes"},
+		{"loaded", loadedLet, "Int"},
+		{"copied", copiedLet, "Int"},
+		{"dumped", dumpedLet, "Int"},
+		{"rendered", renderedLet, "String"},
+		{"bytesOut", bytesOutLet, "Bytes"},
+		{"snapText", snapTextLet, "String"},
+		{"wrote", wroteLet, "Int"},
+	} {
+		if got := chk.LetTypes[tc.stmt]; got == nil || got.String() != tc.wantType {
+			t.Errorf("%s binding type = %v, want %s", tc.name, got, tc.wantType)
+		}
+	}
+}
+
+func TestNativeBoundaryExecRecognizesIoCapabilityProtocols(t *testing.T) {
+	src := []byte(`use std.io as io
+
+fn collect(r: io.LineReader) -> Result<List<String>, Error> {
+    io.readAllLines(r)
+}
+
+fn emit(w: io.ByteWriter) -> Result<Int, Error> {
+    io.writeLines(w, ["a", "b"])
+}
+
+fn mirror(dst: io.ReaderFrom, src: io.Reader) -> Result<Int, Error> {
+    dst.readFrom(src)
+}
+
+fn spill(src: io.WriterTo, dst: io.Writer) -> Result<Int, Error> {
+    src.writeTo(dst)
+}
+
+fn main() -> Result<(), Error> {
+    let lines = collect(io.stringReader("x\ny\n"))?
+    let mut sink = io.buffer()
+    let wrote = emit(sink)?
+    let mirrored = mirror(sink, io.stringReader("tail"))?
+    let spilled = spill(sink, io.buffer())?
+    Ok(())
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[4].(*ast.FnDecl)
+	linesLet := mainDecl.Body.Stmts[0].(*ast.LetStmt)
+	wroteLet := mainDecl.Body.Stmts[2].(*ast.LetStmt)
+	mirroredLet := mainDecl.Body.Stmts[3].(*ast.LetStmt)
+	spilledLet := mainDecl.Body.Stmts[4].(*ast.LetStmt)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := SelfhostFile(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	for _, tc := range []struct {
+		name     string
+		stmt     *ast.LetStmt
+		wantType string
+	}{
+		{"lines", linesLet, "List<String>"},
+		{"wrote", wroteLet, "Int"},
+		{"mirrored", mirroredLet, "Int"},
+		{"spilled", spilledLet, "Int"},
+	} {
+		if got := chk.LetTypes[tc.stmt]; got == nil || got.String() != tc.wantType {
+			t.Errorf("%s binding type = %v, want %s", tc.name, got, tc.wantType)
+		}
+	}
+}

--- a/internal/stdlib/char_test.go
+++ b/internal/stdlib/char_test.go
@@ -1,6 +1,7 @@
 package stdlib
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/resolve"
@@ -58,4 +59,29 @@ func TestCharModuleSurface(t *testing.T) {
 			t.Errorf("std.char.%s not public", name)
 		}
 	}
+}
+
+func TestCharModuleSourcePinsAsciiContracts(t *testing.T) {
+	src := charModuleSource(t)
+	for _, want := range []string{
+		"'0' <= c && c <= '9'",
+		"('a' <= c && c <= 'f')",
+		"radix < 2 || radix > 36",
+		"toAsciiLower(a) == toAsciiLower(b)",
+		"('a'.toInt() + d - 10).toChar()",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.char source missing %q", want)
+		}
+	}
+}
+
+func charModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["char"]
+	if mod == nil {
+		t.Fatal("stdlib char module missing")
+	}
+	return string(mod.Source)
 }

--- a/internal/stdlib/io_test.go
+++ b/internal/stdlib/io_test.go
@@ -1,0 +1,122 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIoModuleExposesProtocolHelpers(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["io"]
+	if mod == nil {
+		t.Fatal("stdlib io module missing")
+	}
+	for _, want := range []string{
+		"pub interface Reader",
+		"pub interface Writer",
+		"pub interface Closer",
+		"pub interface ReadWriter",
+		"pub interface ReadCloser",
+		"pub interface WriteCloser",
+		"pub interface ByteReader",
+		"pub interface LineReader",
+		"pub interface ByteWriter",
+		"pub interface ReaderFrom",
+		"pub interface WriterTo",
+		"pub interface BufferedReader",
+		"pub interface BufferedWriter",
+		"pub struct BytesReader",
+		"pub struct Buffer",
+		"pub fn bytesReader(data: Bytes) -> BytesReader",
+		"pub fn stringReader(s: String) -> BytesReader",
+		"pub fn buffer() -> Buffer",
+		"pub fn copy(dst: Writer, src: Reader) -> Result<Int, Error>",
+		"pub fn copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error>",
+		"pub fn readAll(r: Reader) -> Result<Bytes, Error>",
+		"pub fn readExact(r: Reader, n: Int) -> Result<Bytes, Error>",
+		"pub fn readString(r: Reader) -> Result<String, Error>",
+		"pub fn readLines(r: Reader) -> Result<List<String>, Error>",
+		"pub fn readAllLines(r: LineReader) -> Result<List<String>, Error>",
+		"pub fn discard(r: Reader) -> Result<Int, Error>",
+		"pub fn writeAll(w: Writer, data: Bytes) -> Result<(), Error>",
+		"pub fn writeString(w: Writer, s: String) -> Result<(), Error>",
+		"pub fn writeLine(w: Writer, s: String) -> Result<(), Error>",
+		"pub fn writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error>",
+	} {
+		if !strings.Contains(string(mod.Source), want) {
+			t.Fatalf("io module source missing %q", want)
+		}
+	}
+	for _, name := range []string{
+		"copy", "copyN", "readAll", "readExact", "readString", "readLines",
+		"readAllLines", "discard", "writeAll", "writeString", "writeLine",
+		"writeLines", "bytesReader", "stringReader", "buffer",
+	} {
+		fn := reg.LookupFnDecl("io", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(io, %s) = nil, want stdlib helper", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("io.%s body = nil, want Osty helper body", name)
+		}
+	}
+	for _, tc := range []struct {
+		typeName string
+		method   string
+	}{
+		{"BytesReader", "read"},
+		{"BytesReader", "peek"},
+		{"BytesReader", "readByte"},
+		{"BytesReader", "unreadByte"},
+		{"BytesReader", "skip"},
+		{"BytesReader", "readLineBytes"},
+		{"BytesReader", "readLine"},
+		{"BytesReader", "remainingBytes"},
+		{"Buffer", "write"},
+		{"Buffer", "writeString"},
+		{"Buffer", "clear"},
+		{"Buffer", "truncate"},
+		{"Buffer", "writeLine"},
+		{"Buffer", "readFrom"},
+		{"Buffer", "writeTo"},
+		{"Buffer", "reader"},
+		{"Buffer", "bytes"},
+	} {
+		if got := reg.LookupMethodDecl("io", tc.typeName, tc.method); got == nil {
+			t.Fatalf("LookupMethodDecl(io, %s, %s) = nil", tc.typeName, tc.method)
+		}
+	}
+}
+
+func TestIoHelpersGuardInvalidShortWrites(t *testing.T) {
+	src := ioModuleSource(t)
+	for _, want := range []string{
+		"wrote <= 0 || wrote > remaining",
+		"error.new(\"io.{op}: writer reported invalid byte count {n} for {want}-byte buffer\")",
+		"error.new(\"io.{op}: unexpected EOF after {got} of {want} bytes\")",
+		"error.new(\"io.{kind}: closed\")",
+		"error.new(\"io.bytesReader: cannot unread at start\")",
+		"trimTrailingCR(bytes.slice(self.data, start, end))",
+		"trimTrailingCR(bytes.slice(self.data, start, total))",
+		"let mut line = r.readLine()?",
+		"total = total + w.writeLine(line)?",
+		"strings.trimSuffix(raw[i], \"\\r\")",
+		"strings.endsWith(text, \"\\n\")",
+		"dst.flush()?",
+		"w.flush()?",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("io helper source missing %q", want)
+		}
+	}
+}
+
+func ioModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["io"]
+	if mod == nil {
+		t.Fatal("stdlib io module missing")
+	}
+	return string(mod.Source)
+}

--- a/internal/stdlib/modules/io.osty
+++ b/internal/stdlib/modules/io.osty
@@ -1,9 +1,534 @@
-// std.io — console I/O.
+// std.io — console I/O plus composable byte-stream helpers.
 //
-// `print`, `println`, `eprint`, `eprintln`, `readLine` are the full
-// Tier 1 surface. All five are backend-owned declarations; the output
-// helpers are prelude-aliased while `readLine` is module-qualified.
-// The LLVM lowering routes them to the runtime stdio helpers.
+// `print`, `println`, `eprint`, `eprintln`, and `readLine` remain
+// backend-owned console primitives. The rest of the module defines the
+// reusable stream protocol used by higher-level stdlib code: pull-based
+// byte readers, short-write-aware writers, in-memory implementations,
+// and helper routines such as `readAll`, `writeAll`, `copy`, and
+// line-oriented text helpers.
+
+use std.bytes
+use std.error
+use std.strings
+
+pub interface Reader {
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
+}
+
+pub interface Writer {
+    fn write(self, data: Bytes) -> Result<Int, Error>
+    fn flush(self) -> Result<(), Error>
+}
+
+pub interface Closer {
+    fn close(self) -> Result<(), Error>
+}
+
+pub interface ReadWriter {
+    Reader
+    Writer
+}
+
+pub interface ReadCloser {
+    Reader
+    Closer
+}
+
+pub interface WriteCloser {
+    Writer
+    Closer
+}
+
+pub interface ByteReader {
+    Reader
+    fn peek(self, maxBytes: Int) -> Result<Bytes, Error>
+    fn readByte(self) -> Result<Byte?, Error>
+    fn unreadByte(self) -> Result<(), Error>
+}
+
+pub interface LineReader {
+    Reader
+    fn readLineBytes(self) -> Result<Bytes?, Error>
+    fn readLine(self) -> Result<String?, Error>
+}
+
+pub interface ByteWriter {
+    Writer
+    fn writeByte(self, b: Byte) -> Result<Int, Error>
+    fn writeString(self, s: String) -> Result<Int, Error>
+    fn writeLine(self, s: String) -> Result<Int, Error>
+}
+
+pub interface ReaderFrom {
+    fn readFrom(self, r: Reader) -> Result<Int, Error>
+}
+
+pub interface WriterTo {
+    fn writeTo(self, w: Writer) -> Result<Int, Error>
+}
+
+pub interface BufferedReader {
+    ByteReader
+    LineReader
+}
+
+pub interface BufferedWriter {
+    ByteWriter
+    ReaderFrom
+    WriterTo
+}
+
+fn emptyBytes() -> Bytes {
+    bytes.fromString("")
+}
+
+fn newlineBytes() -> Bytes {
+    bytes.fromString("\n")
+}
+
+fn carriageReturnByte() -> Byte {
+    bytes.fromString("\r")[0]
+}
+
+fn newlineByte() -> Byte {
+    bytes.fromString("\n")[0]
+}
+
+fn minInt(a: Int, b: Int) -> Int {
+    if a < b { a } else { b }
+}
+
+fn closedError(kind: String) -> Error {
+    error.new("io.{kind}: closed")
+}
+
+fn unexpectedEOFError(op: String, want: Int, got: Int) -> Error {
+    error.new("io.{op}: unexpected EOF after {got} of {want} bytes")
+}
+
+fn invalidUnreadError() -> Error {
+    error.new("io.bytesReader: cannot unread at start")
+}
+
+fn invalidWriteCountError(op: String, n: Int, want: Int) -> Error {
+    error.new("io.{op}: writer reported invalid byte count {n} for {want}-byte buffer")
+}
+
+fn trimTrailingCR(data: Bytes) -> Bytes {
+    let n = data.len()
+    if n > 0 && data[n - 1] == carriageReturnByte() {
+        return bytes.slice(data, 0, n - 1)
+    }
+    data
+}
+
+fn writeChunk(w: Writer, data: Bytes, op: String) -> Result<(), Error> {
+    let total = data.len()
+    let mut offset = 0
+    for offset < total {
+        let remaining = total - offset
+        let wrote = w.write(bytes.slice(data, offset, total))?
+        if wrote <= 0 || wrote > remaining {
+            return Err(invalidWriteCountError(op, wrote, remaining))
+        }
+        offset = offset + wrote
+    }
+    Ok(())
+}
+
+pub struct BytesReader {
+    data: Bytes,
+    offset: Int,
+    closed: Bool,
+
+    pub fn len(self) -> Int {
+        self.data.len()
+    }
+
+    pub fn remaining(self) -> Int {
+        let total = self.data.len()
+        if self.offset >= total {
+            return 0
+        }
+        total - self.offset
+    }
+
+    pub fn isClosed(self) -> Bool {
+        self.closed
+    }
+
+    pub fn rewind(mut self) {
+        self.offset = 0
+    }
+
+    pub fn peek(self, maxBytes: Int) -> Result<Bytes, Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        if maxBytes <= 0 {
+            return Ok(emptyBytes())
+        }
+        let take = minInt(maxBytes, self.remaining())
+        if take <= 0 {
+            return Ok(emptyBytes())
+        }
+        let start = self.offset
+        Ok(bytes.slice(self.data, start, start + take))
+    }
+
+    pub fn remainingBytes(self) -> Bytes {
+        let total = self.data.len()
+        let start = if self.offset < total { self.offset } else { total }
+        bytes.slice(self.data, start, total)
+    }
+
+    pub fn readByte(mut self) -> Result<Byte?, Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        if self.remaining() <= 0 {
+            return Ok(None)
+        }
+        let out = self.data[self.offset]
+        self.offset = self.offset + 1
+        Ok(Some(out))
+    }
+
+    pub fn unreadByte(mut self) -> Result<(), Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        if self.offset <= 0 {
+            return Err(invalidUnreadError())
+        }
+        self.offset = self.offset - 1
+        Ok(())
+    }
+
+    pub fn skip(mut self, n: Int) -> Result<Int, Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        if n <= 0 {
+            return Ok(0)
+        }
+        let skipped = minInt(n, self.remaining())
+        self.offset = self.offset + skipped
+        Ok(skipped)
+    }
+
+    pub fn readLineBytes(mut self) -> Result<Bytes?, Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        let start = self.offset
+        let total = self.data.len()
+        if start >= total {
+            return Ok(None)
+        }
+        let mut end = start
+        for end < total {
+            if self.data[end] == newlineByte() {
+                self.offset = end + 1
+                return Ok(Some(trimTrailingCR(bytes.slice(self.data, start, end))))
+            }
+            end = end + 1
+        }
+        self.offset = total
+        Ok(Some(trimTrailingCR(bytes.slice(self.data, start, total))))
+    }
+
+    pub fn readLine(mut self) -> Result<String?, Error> {
+        match self.readLineBytes()? {
+            Some(line) -> Ok(Some(line.toString()?)),
+            None       -> Ok(None),
+        }
+    }
+
+    pub fn read(mut self, maxBytes: Int) -> Result<Bytes, Error> {
+        if self.closed {
+            return Err(closedError("bytesReader"))
+        }
+        if maxBytes <= 0 {
+            return Ok(emptyBytes())
+        }
+        let take = minInt(maxBytes, self.remaining())
+        if take <= 0 {
+            return Ok(emptyBytes())
+        }
+        let start = self.offset
+        let end = start + take
+        self.offset = end
+        Ok(bytes.slice(self.data, start, end))
+    }
+
+    pub fn close(mut self) -> Result<(), Error> {
+        self.closed = true
+        Ok(())
+    }
+}
+
+pub struct Buffer {
+    buf: List<Byte>,
+    closed: Bool,
+
+    pub fn len(self) -> Int {
+        self.buf.len()
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.buf.isEmpty()
+    }
+
+    pub fn isClosed(self) -> Bool {
+        self.closed
+    }
+
+    pub fn bytes(self) -> Bytes {
+        bytes.from(self.buf)
+    }
+
+    pub fn toString(self) -> Result<String, Error> {
+        self.bytes().toString()
+    }
+
+    pub fn clear(mut self) {
+        self.buf = []
+    }
+
+    pub fn reset(mut self) {
+        self.buf = []
+        self.closed = false
+    }
+
+    pub fn truncate(mut self, n: Int) {
+        let limit = if n <= 0 {
+            0
+        } else if n < self.buf.len() {
+            n
+        } else {
+            self.buf.len()
+        }
+        for self.buf.len() > limit {
+            self.buf.removeAt(self.buf.len() - 1)
+        }
+    }
+
+    pub fn reader(self) -> BytesReader {
+        bytesReader(self.bytes())
+    }
+
+    pub fn write(mut self, data: Bytes) -> Result<Int, Error> {
+        if self.closed {
+            return Err(closedError("buffer"))
+        }
+        let n = data.len()
+        for i in 0..n {
+            self.buf.push(data[i])
+        }
+        Ok(n)
+    }
+
+    pub fn writeByte(mut self, b: Byte) -> Result<Int, Error> {
+        if self.closed {
+            return Err(closedError("buffer"))
+        }
+        self.buf.push(b)
+        Ok(1)
+    }
+
+    pub fn writeString(mut self, s: String) -> Result<Int, Error> {
+        self.write(bytes.fromString(s))
+    }
+
+    pub fn writeLine(mut self, s: String) -> Result<Int, Error> {
+        let text = "{s}\n"
+        self.write(bytes.fromString(text))
+    }
+
+    pub fn readFrom(mut self, r: Reader) -> Result<Int, Error> {
+        if self.closed {
+            return Err(closedError("buffer"))
+        }
+        let mut total = 0
+        for {
+            let chunk = r.read(32 * 1024)?
+            let n = chunk.len()
+            if n == 0 {
+                return Ok(total)
+            }
+            for i in 0..n {
+                self.buf.push(chunk[i])
+            }
+            total = total + n
+        }
+    }
+
+    pub fn writeTo(self, w: Writer) -> Result<Int, Error> {
+        let data = self.bytes()
+        writeChunk(w, data, "buffer.writeTo")?
+        w.flush()?
+        Ok(data.len())
+    }
+
+    pub fn flush(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn close(mut self) -> Result<(), Error> {
+        self.closed = true
+        Ok(())
+    }
+}
+
+pub fn bytesReader(data: Bytes) -> BytesReader {
+    BytesReader { data: data, offset: 0, closed: false }
+}
+
+pub fn stringReader(s: String) -> BytesReader {
+    bytesReader(bytes.fromString(s))
+}
+
+pub fn buffer() -> Buffer {
+    Buffer { buf: [], closed: false }
+}
+
+pub fn copy(dst: Writer, src: Reader) -> Result<Int, Error> {
+    let mut total = 0
+    for {
+        let chunk = src.read(32 * 1024)?
+        let n = chunk.len()
+        if n == 0 {
+            break
+        }
+        writeChunk(dst, chunk, "copy")?
+        total = total + n
+    }
+    dst.flush()?
+    Ok(total)
+}
+
+pub fn readAll(r: Reader) -> Result<Bytes, Error> {
+    let mut out: List<Byte> = []
+    for {
+        let chunk = r.read(32 * 1024)?
+        let n = chunk.len()
+        if n == 0 {
+            break
+        }
+        for i in 0..n {
+            out.push(chunk[i])
+        }
+    }
+    Ok(bytes.from(out))
+}
+
+pub fn writeAll(w: Writer, data: Bytes) -> Result<(), Error> {
+    writeChunk(w, data, "writeAll")?
+    w.flush()?
+    Ok(())
+}
+
+pub fn copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error> {
+    if n <= 0 {
+        return Ok(0)
+    }
+    let mut total = 0
+    for total < n {
+        let want = minInt(32 * 1024, n - total)
+        let chunk = src.read(want)?
+        let got = chunk.len()
+        if got == 0 {
+            return Err(unexpectedEOFError("copyN", n, total))
+        }
+        writeChunk(dst, chunk, "copyN")?
+        total = total + got
+    }
+    dst.flush()?
+    Ok(total)
+}
+
+pub fn readExact(r: Reader, n: Int) -> Result<Bytes, Error> {
+    if n <= 0 {
+        return Ok(emptyBytes())
+    }
+    let mut out: List<Byte> = []
+    let mut total = 0
+    for total < n {
+        let want = minInt(32 * 1024, n - total)
+        let chunk = r.read(want)?
+        let got = chunk.len()
+        if got == 0 {
+            return Err(unexpectedEOFError("readExact", n, total))
+        }
+        for i in 0..got {
+            out.push(chunk[i])
+        }
+        total = total + got
+    }
+    Ok(bytes.from(out))
+}
+
+pub fn discard(r: Reader) -> Result<Int, Error> {
+    let mut total = 0
+    for {
+        let chunk = r.read(32 * 1024)?
+        let n = chunk.len()
+        if n == 0 {
+            return Ok(total)
+        }
+        total = total + n
+    }
+}
+
+pub fn readString(r: Reader) -> Result<String, Error> {
+    readAll(r)?.toString()
+}
+
+pub fn readLines(r: Reader) -> Result<List<String>, Error> {
+    let text = readString(r)?
+    let raw = strings.lines(text)
+    if raw.isEmpty() {
+        return Ok(raw)
+    }
+    let mut out: List<String> = []
+    let last = raw.len() - 1
+    for i in 0..raw.len() {
+        let line = strings.trimSuffix(raw[i], "\r")
+        if i == last && line == "" && strings.endsWith(text, "\n") {
+            continue
+        }
+        out.push(line)
+    }
+    Ok(out)
+}
+
+pub fn readAllLines(r: LineReader) -> Result<List<String>, Error> {
+    let mut out: List<String> = []
+    let mut line = r.readLine()?
+    for let Some(text) = line {
+        out.push(text)
+        line = r.readLine()?
+    }
+    Ok(out)
+}
+
+pub fn writeString(w: Writer, s: String) -> Result<(), Error> {
+    writeAll(w, bytes.fromString(s))
+}
+
+pub fn writeLine(w: Writer, s: String) -> Result<(), Error> {
+    writeAll(w, bytes.concat(bytes.fromString(s), newlineBytes()))
+}
+
+pub fn writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error> {
+    let mut total = 0
+    for line in lines {
+        total = total + w.writeLine(line)?
+    }
+    w.flush()?
+    Ok(total)
+}
 
 pub fn print(s: String)
 

--- a/internal/stdlib/modules/url.osty
+++ b/internal/stdlib/modules/url.osty
@@ -1,15 +1,16 @@
 // std.url — URL parsing and building (spec §10.16).
 //
-// Pure-Osty parsing: scheme / host / port / path / query / fragment are
-// decomposed via `strings.splitN`. IPv6 literal hosts (`[::1]:8080`) are
-// not yet supported — the scheme expects a flat `host[:port]` authority,
-// matching the spec's §10.16 example. `join` implements a minimal
-// relative-reference merge: absolute refs (with scheme) replace the
-// base entirely, root-relative refs ("/x") keep the base authority, and
-// otherwise the relative path is appended to the base path's directory.
+// Goals of this implementation:
+//   - accept hierarchical absolute URLs plus relative references for `join`
+//   - handle bracketed IPv6 literal authorities (`https://[::1]:8443/...`)
+//   - percent-decode query / fragment components while preserving path escapes
+//   - produce deterministic query-string output even though `query` is a Map
+//   - resolve dot-segments per RFC 3986 when merging relative references
 
-use std.strings
+use std.bytes
+use std.char
 use std.error
+use std.strings
 
 pub struct Url {
     pub scheme: String,
@@ -20,20 +21,7 @@ pub struct Url {
     pub fragment: String?,
 
     pub fn toString(self) -> String {
-        let mut out = "{self.scheme}://{self.host}"
-        out = match self.port {
-            Some(p) -> "{out}:{p}",
-            None    -> out,
-        }
-        out = "{out}{self.path}"
-        if self.query.isEmpty() == false {
-            out = "{out}?{encodeQuery(self.query)}"
-        }
-        out = match self.fragment {
-            Some(f) -> "{out}#{f}",
-            None    -> out,
-        }
-        out
+        stringifyParts(urlPartsFromUrl(self))
     }
 
     pub fn queryValues(self, key: String) -> List<String> {
@@ -44,153 +32,608 @@ pub struct Url {
     }
 }
 
-pub fn parse(text: String) -> Result<Url, error.BasicError> {
-    let schemeParts = strings.splitN(text, "://", 2)
-    if schemeParts.len() != 2 {
-        return Err(urlError("url: missing scheme in {text}"))
-    }
-    let scheme = schemeParts[0]
-    if scheme.isEmpty() {
-        return Err(urlError("url: empty scheme in {text}"))
-    }
-    let rest = schemeParts[1]
+pub fn parse(text: String) -> Result<Url, Error> {
+    let parts = parseReference(text, true)?
+    Ok(urlFromParts(parts))
+}
 
-    let fragSplit = strings.splitN(rest, "#", 2)
-    let beforeFragment = fragSplit[0]
-    let fragment: String? = if fragSplit.len() == 2 { Some(fragSplit[1]) } else { None }
+pub fn join(base: String, relative: String) -> Result<String, Error> {
+    if relative.isEmpty() {
+        return Ok(base)
+    }
+    let rel = parseReference(relative, false)?
+    if !rel.scheme.isEmpty() {
+        return Ok(stringifyParts(normalizeAbsoluteReference(rel)))
+    }
+    let baseParts = parseReference(base, true)?
+    Ok(stringifyParts(resolveReference(baseParts, rel)))
+}
 
-    let querySplit = strings.splitN(beforeFragment, "?", 2)
-    let beforeQuery = querySplit[0]
-    let query: Map<String, String> = if querySplit.len() == 2 {
-        parseQuery(querySplit[1])
+struct UrlParts {
+    scheme: String,
+    host: String,
+    port: Int?,
+    path: String,
+    query: Map<String, String>,
+    hasQuery: Bool,
+    fragment: String?,
+    hasAuthority: Bool,
+}
+
+fn urlPartsFromUrl(u: Url) -> UrlParts {
+    UrlParts {
+        scheme: asciiLowerString(u.scheme),
+        host: asciiLowerString(u.host),
+        port: u.port,
+        path: u.path,
+        query: u.query,
+        hasQuery: !u.query.isEmpty(),
+        fragment: u.fragment,
+        hasAuthority: inferHasAuthority(u),
+    }
+}
+
+fn urlFromParts(parts: UrlParts) -> Url {
+    Url {
+        scheme: parts.scheme,
+        host: parts.host,
+        port: parts.port,
+        path: parts.path,
+        query: parts.query,
+        fragment: parts.fragment,
+    }
+}
+
+fn inferHasAuthority(u: Url) -> Bool {
+    if !u.host.isEmpty() || u.port.isSome() {
+        return true
+    }
+    !u.scheme.isEmpty() && strings.startsWith(u.path, "/")
+}
+
+fn parseReference(text: String, requireScheme: Bool) -> Result<UrlParts, Error> {
+    let chars = text.chars()
+    let hash = findChar(chars, '#', 0)
+    let beforeFragment = if hash < 0 {
+        text
     } else {
-        {:}
+        sliceChars(chars, 0, hash)
+    }
+    let fragment = if hash < 0 {
+        None
+    } else {
+        Some(decodePercentComponent(sliceChars(chars, hash + 1, chars.len()), "fragment")?)
     }
 
-    let pathSplit = strings.splitN(beforeQuery, "/", 2)
-    let authority = pathSplit[0]
-    let path = if pathSplit.len() == 2 { "/{pathSplit[1]}" } else { "" }
+    let beforeChars = beforeFragment.chars()
+    let qmark = findChar(beforeChars, '?', 0)
+    let beforeQuery = if qmark < 0 {
+        beforeFragment
+    } else {
+        sliceChars(beforeChars, 0, qmark)
+    }
+    let hasQuery = qmark >= 0
+    let query = if qmark < 0 {
+        {:}
+    } else {
+        parseQuery(sliceChars(beforeChars, qmark + 1, beforeChars.len()))?
+    }
 
-    let (host, port) = parseAuthority(authority)?
+    let (scheme, rest) = parseSchemeAndRest(beforeQuery, requireScheme)?
+    let (hasAuthority, host, port, path) = parseAuthorityAndPath(rest)?
 
-    Ok(Url {
+    Ok(UrlParts {
         scheme: scheme,
         host: host,
         port: port,
         path: path,
         query: query,
+        hasQuery: hasQuery,
         fragment: fragment,
+        hasAuthority: hasAuthority,
     })
 }
 
-pub fn join(base: String, relative: String) -> Result<String, error.BasicError> {
-    if relative.isEmpty() {
-        return Ok(base)
-    }
-    if strings.contains(relative, "://") {
-        return Ok(relative)
-    }
-    let baseUrl = parse(base)?
-    let relativeChars = relative.chars()
-    if relativeChars.len() > 0 && relativeChars[0] == '/' {
-        let merged = Url {
-            scheme: baseUrl.scheme,
-            host: baseUrl.host,
-            port: baseUrl.port,
-            path: relative,
-            query: {:},
-            fragment: None,
-        }
-        return Ok(merged.toString())
-    }
-    let dir = dirnameOf(baseUrl.path)
-    let merged = Url {
-        scheme: baseUrl.scheme,
-        host: baseUrl.host,
-        port: baseUrl.port,
-        path: "{dir}{relative}",
-        query: {:},
-        fragment: None,
-    }
-    Ok(merged.toString())
-}
-
-fn parseAuthority(authority: String) -> Result<(String, Int?), error.BasicError> {
-    if authority.isEmpty() {
-        return Ok(("", None))
-    }
-    let parts = strings.splitN(authority, ":", 2)
-    if parts.len() == 1 {
-        return Ok((parts[0], None))
-    }
-    let host = parts[0]
-    let portStr = parts[1]
-    if portStr.isEmpty() {
-        return Ok((host, None))
-    }
-    let port = parsePort(portStr)?
-    Ok((host, Some(port)))
-}
-
-fn parsePort(s: String) -> Result<Int, error.BasicError> {
-    if s.isEmpty() {
-        return Err(urlError("url: empty port"))
-    }
-    let chars = s.chars()
-    let mut n = 0
+fn parseSchemeAndRest(text: String, requireScheme: Bool) -> Result<(String, String), Error> {
+    let chars = text.chars()
+    let mut colon = -1
     let mut i = 0
     for i < chars.len() {
         let c = chars[i]
-        if c >= '0' && c <= '9' {
-            n = n * 10 + (c.toInt() - '0'.toInt())
-        } else {
-            return Err(urlError("url: invalid port {s}"))
+        if c == ':' {
+            colon = i
+            break
+        }
+        if c == '/' || c == '?' || c == '#' {
+            break
         }
         i = i + 1
     }
-    if n > 65535 {
-        return Err(urlError("url: port out of range: {s}"))
+    if colon < 0 {
+        if requireScheme {
+            return Err(urlError("url: missing scheme in {text}"))
+        }
+        return Ok(("", text))
+    }
+    let scheme = sliceChars(chars, 0, colon)
+    if isValidScheme(scheme) {
+        return Ok((asciiLowerString(scheme), sliceChars(chars, colon + 1, chars.len())))
+    }
+    if requireScheme {
+        return Err(urlError("url: invalid scheme in {text}"))
+    }
+    Ok(("", text))
+}
+
+fn parseAuthorityAndPath(rest: String) -> Result<(Bool, String, Int?, String), Error> {
+    if !strings.startsWith(rest, "//") {
+        validatePercentEncoding(rest, "path")?
+        return Ok((false, "", None, rest))
+    }
+    let chars = rest.chars()
+    let after = sliceChars(chars, 2, chars.len())
+    let afterChars = after.chars()
+    let slash = findChar(afterChars, '/', 0)
+    let authority = if slash < 0 {
+        after
+    } else {
+        sliceChars(afterChars, 0, slash)
+    }
+    let path = if slash < 0 {
+        ""
+    } else {
+        sliceChars(afterChars, slash, afterChars.len())
+    }
+    validatePercentEncoding(path, "path")?
+    let (host, port) = parseAuthority(authority)?
+    Ok((true, host, port, path))
+}
+
+fn parseAuthority(authority: String) -> Result<(String, Int?), Error> {
+    if authority.isEmpty() {
+        return Ok(("", None))
+    }
+    let chars = authority.chars()
+    if findChar(chars, '@', 0) >= 0 {
+        return Err(urlError("url: userinfo not supported: {authority}"))
+    }
+    if chars[0] == '[' {
+        let close = findChar(chars, ']', 1)
+        if close < 0 {
+            return Err(urlError("url: missing ] in authority: {authority}"))
+        }
+        let host = asciiLowerString(sliceChars(chars, 1, close))
+        let rest = sliceChars(chars, close + 1, chars.len())
+        if rest.isEmpty() {
+            return Ok((host, None))
+        }
+        let restChars = rest.chars()
+        if restChars[0] != ':' {
+            return Err(urlError("url: unexpected trailing data in authority: {authority}"))
+        }
+        let portText = sliceChars(restChars, 1, restChars.len())
+        if portText.isEmpty() {
+            return Err(urlError("url: empty port in authority: {authority}"))
+        }
+        return Ok((host, Some(parsePort(portText)?)))
+    }
+    let lastColon = lastIndexOfChar(chars, ':')
+    if lastColon < 0 {
+        return Ok((asciiLowerString(authority), None))
+    }
+    let host = sliceChars(chars, 0, lastColon)
+    let portText = sliceChars(chars, lastColon + 1, chars.len())
+    if findChar(host.chars(), ':', 0) >= 0 {
+        return Err(urlError("url: bracket IPv6 literals in authority: {authority}"))
+    }
+    if portText.isEmpty() {
+        return Err(urlError("url: empty port in authority: {authority}"))
+    }
+    Ok((asciiLowerString(host), Some(parsePort(portText)?)))
+}
+
+fn parsePort(s: String) -> Result<Int, Error> {
+    if s.isEmpty() {
+        return Err(urlError("url: empty port"))
+    }
+    let mut n = 0
+    for c in s.chars() {
+        match char.digitValue(c) {
+            Some(d) -> {
+                n = n * 10 + d
+                if n > 65535 {
+                    return Err(urlError("url: port out of range: {s}"))
+                }
+            },
+            None -> return Err(urlError("url: invalid port {s}")),
+        }
     }
     Ok(n)
 }
 
-fn urlError(message: String) -> error.BasicError {
-    error.BasicError { message: message }
-}
-
-fn parseQuery(s: String) -> Map<String, String> {
+fn parseQuery(s: String) -> Result<Map<String, String>, Error> {
     let mut out: Map<String, String> = {:}
     if s.isEmpty() {
-        return out
+        return Ok(out)
     }
     for pair in strings.split(s, "&") {
         if pair.isEmpty() {
             continue
         }
         let kv = strings.splitN(pair, "=", 2)
-        let key = kv[0]
-        let value = if kv.len() == 2 { kv[1] } else { "" }
+        let key = decodePercentComponent(kv[0], "query key")?
+        let value = if kv.len() == 2 {
+            decodePercentComponent(kv[1], "query value")?
+        } else {
+            ""
+        }
         out.insert(key, value)
     }
-    out
+    Ok(out)
 }
 
 fn encodeQuery(q: Map<String, String>) -> String {
     let mut parts: List<String> = []
-    for (k, v) in q {
-        parts.push("{k}={v}")
+    for key in q.keys().sorted() {
+        let value = q.getOr(key, "")
+        parts.push("{encodeQueryComponent(key)}={encodeQueryComponent(value)}")
     }
     strings.join(parts, "&")
 }
 
-fn dirnameOf(path: String) -> String {
-    let chars = path.chars()
+fn resolveReference(base: UrlParts, rel: UrlParts) -> UrlParts {
+    if !rel.scheme.isEmpty() {
+        return normalizeAbsoluteReference(rel)
+    }
+    if rel.hasAuthority {
+        return UrlParts {
+            scheme: base.scheme,
+            host: rel.host,
+            port: rel.port,
+            path: removeDotSegments(rel.path),
+            query: rel.query,
+            hasQuery: rel.hasQuery,
+            fragment: rel.fragment,
+            hasAuthority: true,
+        }
+    }
+    if rel.path.isEmpty() {
+        let query = if rel.hasQuery { rel.query } else { base.query }
+        let hasQuery = if rel.hasQuery { true } else { base.hasQuery }
+        return UrlParts {
+            scheme: base.scheme,
+            host: base.host,
+            port: base.port,
+            path: base.path,
+            query: query,
+            hasQuery: hasQuery,
+            fragment: rel.fragment,
+            hasAuthority: base.hasAuthority,
+        }
+    }
+    let mergedPath = if strings.startsWith(rel.path, "/") {
+        removeDotSegments(rel.path)
+    } else {
+        removeDotSegments(mergePaths(base.path, rel.path, base.hasAuthority))
+    }
+    UrlParts {
+        scheme: base.scheme,
+        host: base.host,
+        port: base.port,
+        path: mergedPath,
+        query: rel.query,
+        hasQuery: rel.hasQuery,
+        fragment: rel.fragment,
+        hasAuthority: base.hasAuthority,
+    }
+}
+
+fn normalizeAbsoluteReference(parts: UrlParts) -> UrlParts {
+    UrlParts {
+        scheme: parts.scheme,
+        host: parts.host,
+        port: parts.port,
+        path: removeDotSegments(parts.path),
+        query: parts.query,
+        hasQuery: parts.hasQuery,
+        fragment: parts.fragment,
+        hasAuthority: parts.hasAuthority,
+    }
+}
+
+fn mergePaths(basePath: String, relPath: String, baseHasAuthority: Bool) -> String {
+    if baseHasAuthority && basePath.isEmpty() {
+        return "/{relPath}"
+    }
+    let chars = basePath.chars()
+    let slash = lastIndexOfChar(chars, '/')
+    if slash < 0 {
+        return relPath
+    }
+    "{sliceChars(chars, 0, slash + 1)}{relPath}"
+}
+
+fn removeDotSegments(path: String) -> String {
+    let mut input = path
+    let mut output = ""
+    for !input.isEmpty() {
+        if strings.startsWith(input, "../") {
+            input = tailChars(input, 3)
+        } else if strings.startsWith(input, "./") {
+            input = tailChars(input, 2)
+        } else if strings.startsWith(input, "/./") {
+            input = "/{tailChars(input, 3)}"
+        } else if input == "/." {
+            input = "/"
+        } else if strings.startsWith(input, "/../") {
+            input = "/{tailChars(input, 4)}"
+            output = removeLastSegment(output)
+        } else if input == "/.." {
+            input = "/"
+            output = removeLastSegment(output)
+        } else if input == "." || input == ".." {
+            input = ""
+        } else {
+            let cut = nextPathSegmentBoundary(input)
+            output = "{output}{takeChars(input, cut)}"
+            input = tailChars(input, cut)
+        }
+    }
+    output
+}
+
+fn nextPathSegmentBoundary(s: String) -> Int {
+    let chars = s.chars()
+    if chars.len() == 0 {
+        return 0
+    }
+    let mut i = if chars[0] == '/' { 1 } else { 0 }
+    for i < chars.len() {
+        if chars[i] == '/' {
+            return i
+        }
+        i = i + 1
+    }
+    chars.len()
+}
+
+fn removeLastSegment(s: String) -> String {
+    let chars = s.chars()
+    let last = lastIndexOfChar(chars, '/')
+    if last < 0 {
+        return ""
+    }
+    sliceChars(chars, 0, last)
+}
+
+fn stringifyParts(parts: UrlParts) -> String {
+    let mut out = ""
+    if !parts.scheme.isEmpty() {
+        out = "{parts.scheme}:"
+    }
+    if parts.hasAuthority {
+        out = "{out}//{authorityText(parts.host, parts.port)}"
+    }
+    out = "{out}{encodePath(parts.path)}"
+    if parts.hasQuery {
+        out = "{out}?"
+        if !parts.query.isEmpty() {
+            out = "{out}{encodeQuery(parts.query)}"
+        }
+    }
+    out = match parts.fragment {
+        Some(f) -> "{out}#{encodeFragment(f)}",
+        None    -> out,
+    }
+    out
+}
+
+fn authorityText(host: String, port: Int?) -> String {
+    let renderedHost = if hostNeedsBrackets(host) {
+        "[{host}]"
+    } else {
+        host
+    }
+    match port {
+        Some(p) -> "{renderedHost}:{p}",
+        None    -> renderedHost,
+    }
+}
+
+fn hostNeedsBrackets(host: String) -> Bool {
+    findChar(host.chars(), ':', 0) >= 0
+}
+
+fn encodePath(path: String) -> String {
+    encodeComponent(path, pathMode)
+}
+
+fn encodeQueryComponent(text: String) -> String {
+    encodeComponent(text, queryMode)
+}
+
+fn encodeFragment(text: String) -> String {
+    encodeComponent(text, fragmentMode)
+}
+
+let pathMode = 0
+let queryMode = 1
+let fragmentMode = 2
+
+fn encodeComponent(text: String, mode: Int) -> String {
+    let chars = text.chars()
+    let mut out = ""
+    let mut i = 0
+    for i < chars.len() {
+        let c = chars[i]
+        if c == '%' && isHexTriplet(chars, i) {
+            out = "{out}%{char.toAsciiUpper(chars[i + 1])}{char.toAsciiUpper(chars[i + 2])}"
+            i = i + 3
+            continue
+        }
+        if componentAllows(c, mode) {
+            out = "{out}{c}"
+        } else {
+            out = "{out}{percentEncodeChar(c)}"
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn componentAllows(c: Char, mode: Int) -> Bool {
+    if isUnreserved(c) {
+        return true
+    }
+    if mode == queryMode {
+        return false
+    }
+    if isSubdelim(c) || c == ':' || c == '@' {
+        return true
+    }
+    if mode == pathMode {
+        return c == '/'
+    }
+    c == '/' || c == '?'
+}
+
+fn isUnreserved(c: Char) -> Bool {
+    char.isAsciiAlphanumeric(c) || c == '-' || c == '.' || c == '_' || c == '~'
+}
+
+fn isSubdelim(c: Char) -> Bool {
+    c == '!' || c == '$' || c == '&' || c == '(' || c == ')' ||
+    c == '*' || c == '+' || c == ',' || c == ';' || c == '='
+}
+
+fn percentEncodeChar(c: Char) -> String {
+    let mut out = ""
+    for b in c.toString().bytes() {
+        let n = b.toInt()
+        let hi = char.toAsciiUpper(char.fromDigit((n >> 4) & 0x0F, 16).unwrap())
+        let lo = char.toAsciiUpper(char.fromDigit(n & 0x0F, 16).unwrap())
+        out = "{out}%{hi}{lo}"
+    }
+    out
+}
+
+fn decodePercentComponent(text: String, kind: String) -> Result<String, Error> {
+    let chars = text.chars()
+    let mut out: List<Byte> = []
+    let mut i = 0
+    for i < chars.len() {
+        if chars[i] == '%' {
+            if !isHexTriplet(chars, i) {
+                return Err(urlError("url: invalid percent-escape in {kind}: {text}"))
+            }
+            let hi = char.hexDigitValue(chars[i + 1]).unwrap()
+            let lo = char.hexDigitValue(chars[i + 2]).unwrap()
+            out.push(((hi << 4) | lo).toByte().unwrap())
+            i = i + 3
+            continue
+        }
+        for b in chars[i].toString().bytes() {
+            out.push(b)
+        }
+        i = i + 1
+    }
+    bytes.from(out).toString()
+}
+
+fn validatePercentEncoding(text: String, kind: String) -> Result<(), Error> {
+    let chars = text.chars()
+    let mut i = 0
+    for i < chars.len() {
+        if chars[i] == '%' && !isHexTriplet(chars, i) {
+            return Err(urlError("url: invalid percent-escape in {kind}: {text}"))
+        }
+        if chars[i] == '%' {
+            i = i + 3
+        } else {
+            i = i + 1
+        }
+    }
+    Ok(())
+}
+
+fn isHexTriplet(chars: List<Char>, at: Int) -> Bool {
+    at + 2 < chars.len() &&
+    char.isAsciiHexDigit(chars[at + 1]) &&
+    char.isAsciiHexDigit(chars[at + 2])
+}
+
+fn isValidScheme(s: String) -> Bool {
+    let chars = s.chars()
+    if chars.len() == 0 || !char.isAsciiAlpha(chars[0]) {
+        return false
+    }
+    let mut i = 1
+    for i < chars.len() {
+        let c = chars[i]
+        if !char.isAsciiAlphanumeric(c) && c != '+' && c != '-' && c != '.' {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn asciiLowerString(s: String) -> String {
+    let mut out = ""
+    for c in s.chars() {
+        out = "{out}{char.toAsciiLower(c)}"
+    }
+    out
+}
+
+fn sliceChars(chars: List<Char>, start: Int, end: Int) -> String {
+    let mut out = ""
+    let mut i = start
+    for i < end {
+        out = "{out}{chars[i]}"
+        i = i + 1
+    }
+    out
+}
+
+fn takeChars(s: String, n: Int) -> String {
+    let chars = s.chars()
+    sliceChars(chars, 0, n)
+}
+
+fn tailChars(s: String, n: Int) -> String {
+    let chars = s.chars()
+    sliceChars(chars, n, chars.len())
+}
+
+fn findChar(chars: List<Char>, target: Char, start: Int) -> Int {
+    let mut i = start
+    for i < chars.len() {
+        if chars[i] == target {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+fn lastIndexOfChar(chars: List<Char>, target: Char) -> Int {
+    if chars.len() == 0 {
+        return -1
+    }
     let mut i = chars.len() - 1
     for i >= 0 {
-        if chars[i] == '/' {
-            return path[0..i + 1]
+        if chars[i] == target {
+            return i
+        }
+        if i == 0 {
+            break
         }
         i = i - 1
     }
-    ""
+    -1
+}
+
+fn urlError(message: String) -> Error {
+    error.new(message)
 }

--- a/internal/stdlib/url_test.go
+++ b/internal/stdlib/url_test.go
@@ -1,0 +1,100 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestUrlModuleSurface(t *testing.T) {
+	reg := LoadCached()
+
+	mod := reg.Modules["url"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.url not loaded")
+	}
+
+	for _, name := range []string{"parse", "join"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.url missing export %q", name)
+			continue
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Errorf("std.url.%s kind = %s, want SymFn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Errorf("std.url.%s not public", name)
+		}
+		fn, ok := sym.Decl.(*ast.FnDecl)
+		if !ok || fn.Body == nil {
+			t.Errorf("std.url.%s has no bodied implementation", name)
+		}
+	}
+
+	sym := mod.Package.PkgScope.LookupLocal("Url")
+	if sym == nil {
+		t.Fatalf("std.url missing Url")
+	}
+	if sym.Kind != resolve.SymStruct {
+		t.Fatalf("std.url.Url kind = %s, want SymStruct", sym.Kind)
+	}
+	urlDecl, ok := sym.Decl.(*ast.StructDecl)
+	if !ok {
+		t.Fatalf("std.url.Url decl = %T, want *ast.StructDecl", sym.Decl)
+	}
+	fields := map[string]*ast.Field{}
+	for _, f := range urlDecl.Fields {
+		fields[f.Name] = f
+	}
+	for _, name := range []string{"scheme", "host", "port", "path", "query", "fragment"} {
+		field := fields[name]
+		if field == nil {
+			t.Errorf("Url missing field %q", name)
+			continue
+		}
+		if !field.Pub {
+			t.Errorf("Url.%s not public", name)
+		}
+	}
+
+	for _, method := range []string{"toString", "queryValues"} {
+		fn := reg.LookupMethodDecl("url", "Url", method)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(url, Url, %s) = nil", method)
+		}
+		if fn.Body == nil {
+			t.Fatalf("Url.%s body = nil, want bodied method", method)
+		}
+	}
+}
+
+func TestUrlModuleSourcePinsQualityGuards(t *testing.T) {
+	src := urlModuleSource(t)
+	for _, want := range []string{
+		"struct UrlParts",
+		"decodePercentComponent(",
+		"removeDotSegments(",
+		"hostNeedsBrackets(",
+		"keys().sorted()",
+		"userinfo not supported",
+		"invalid percent-escape",
+		"bracket IPv6 literals in authority",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.url source missing %q", want)
+		}
+	}
+}
+
+func urlModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["url"]
+	if mod == nil {
+		t.Fatal("stdlib url module missing")
+	}
+	return string(mod.Source)
+}

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -3,7 +3,7 @@
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
 **Scanned:** 320 `.osty` file(s)  
-**Captured:** 152 residual case(s) — **0** AI-slip(s) airepair rewrote, **152** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Captured:** 153 residual case(s) — **0** AI-slip(s) airepair rewrote, **153** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
- expand `std.io` with buffered readers/writers, capability protocols, and focused checker/stdlib coverage
- add `std.url` parsing/stringifying coverage plus CLI tests for `std.url`/`std.char` imports
- sync the related language docs and refresh the AI repair backlog snapshot

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)