### PR TITLE
feat: expand option/result composition helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
@@ -4,8 +4,16 @@
 - `std.fs` — file I/O
 - `std.strings` — string manipulation
 - `std.collections` — `List`, `Map`, `Set`
-- `std.option` — `Option`, `Some`, `None` (auto-imported)
-- `std.result` — `Result`, `Ok`, `Err` (auto-imported)
+- `std.option` — `Option`, `Some`, `None` (auto-imported), plus rich
+  combinators (`count`, `forEach`, `toList`, `zipWith`, `reduce`) and
+  nested-shape, composition, and batch helpers `flatten`, `transpose`,
+  `unzip`, `values`, `any`, `all`, `traverse`, `filterMap`, `findMap`,
+  `map2`, `map3`
+- `std.result` — `Result`, `Ok`, `Err` (auto-imported), plus rich
+  combinators (`count`, `forEach`, `toList`, `zip`, `zipWith`) and
+  nested-shape, composition, and batch helpers `flatten`, `transpose`,
+  `values`, `errors`, `partition`, `all`, `traverse`, `map2`, `map3`,
+  `allErrors`, `traverseErrors`
 - `std.error` — `Error`, `BasicError`, `Error.new` (auto-imported)
 - `std.cmp` — `Equal`, `Ordered`, `Hashable` (auto-imported)
 - `std.ref` — `same(a, b)`

--- a/LANG_SPEC_v0.5/18-change-history.md
+++ b/LANG_SPEC_v0.5/18-change-history.md
@@ -43,8 +43,8 @@ real program.
 
 **Additions — stdlib.**
 
-- **`Option<T>`** combinators: `isSome / isNone / isSomeAnd / isNoneOr / contains / take / replace / unwrap / expect / unwrapOr / unwrapOrElse / and / andThen / or / orElse / xor / filter / inspect / map / mapOr / mapOrElse / zip / okOr / okOrElse`.
-- **`Result<T, E>`** combinators: `isOk / isErr / isOkAnd / isErrAnd / contains / containsErr / unwrap / expect / unwrapErr / expectErr / unwrapOr / unwrapOrElse / ok / err / and / andThen / or / orElse / inspect / inspectErr / map / mapErr / mapOr / mapOrElse`.
+- **`Option<T>`** combinators: `isSome / isNone / isSomeAnd / isNoneOr / contains / count / take / replace / unwrap / expect / unwrapOr / unwrapOrElse / and / andThen / or / orElse / xor / filter / inspect / forEach / map / mapOr / mapOrElse / zip / zipWith / reduce / okOr / okOrElse / toList`; module helpers `flatten / transpose / unzip / values / any / all / traverse / filterMap / findMap / map2 / map3`.
+- **`Result<T, E>`** combinators: `isOk / isErr / isOkAnd / isErrAnd / contains / containsErr / count / unwrap / expect / unwrapErr / expectErr / unwrapOr / unwrapOrElse / ok / err / and / andThen / or / orElse / inspect / inspectErr / forEach / map / mapErr / mapOr / mapOrElse / zip / zipWith / toList`; module helpers `flatten / transpose / values / errors / partition / all / traverse / map2 / map3 / allErrors / traverseErrors`.
 - **`List<T>`** extensions: `groupBy / chunked / windowed / partition / reduce / scan / flatMap / zip3` in addition to the existing `map / filter / fold / sorted / sortedBy / reversed / take / drop / appended / concat / zip / enumerate / push / pop / insert / removeAt / sort / reverse / clear`.
 - **`Map<K, V>`** extensions: `getOrInsert / getOrInsertWith / merge / mapValues / filter` on top of `get / containsKey / keys / values / entries / insert / remove / clear`.
 - **§10/24 `std.strings`** — full Unicode-aware chapter (previously referenced by name only).

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -116,6 +116,64 @@ fn main() {
 	}
 }
 
+func TestNativeBoundaryRebindsOptionResultImportSurfaceBuiltins(t *testing.T) {
+	src := []byte(`use std.option
+use std.result
+
+fn main() {}
+`)
+	file, res := parseResolvedFile(t, src)
+
+	fake := &fakeNativePackageChecker{t: t}
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) { return fake, "" }
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	_ = SelfhostFile(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+
+	if fake.packageCalls != 1 {
+		t.Fatalf("packageCalls = %d, want 1", fake.packageCalls)
+	}
+	assertNoQualifiedBuiltin := func(t *testing.T, alias, bad string) {
+		t.Helper()
+		for _, imp := range fake.imports {
+			if imp.Alias != alias {
+				continue
+			}
+			for _, fn := range imp.Functions {
+				if containsQualifiedBuiltinType(fn.ReturnType, bad) {
+					t.Fatalf("%s fn %s return type leaked %q: %s", alias, fn.Name, bad, fn.ReturnType)
+				}
+				for _, param := range fn.ParamTypes {
+					if containsQualifiedBuiltinType(param, bad) {
+						t.Fatalf("%s fn %s param type leaked %q: %s", alias, fn.Name, bad, param)
+					}
+				}
+			}
+			for _, field := range imp.Fields {
+				if containsQualifiedBuiltinType(field.TypeName, bad) {
+					t.Fatalf("%s field %s leaked %q: %s", alias, field.Name, bad, field.TypeName)
+				}
+			}
+		}
+	}
+
+	assertNoQualifiedBuiltin(t, "option", "option.Option")
+	assertNoQualifiedBuiltin(t, "result", "result.Result")
+}
+
+func containsQualifiedBuiltinType(text, qualified string) bool {
+	if text == qualified {
+		return true
+	}
+	for _, suffix := range []string{"<", "?", ",", ")", ">", " "} {
+		if strings.Contains(text, qualified+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestNativeBoundaryOverlaysStructuredCheckResult(t *testing.T) {
 	src := []byte(`fn id<T>(value: T) -> T { value }
 

--- a/internal/check/option_result_module_helpers_test.go
+++ b/internal/check/option_result_module_helpers_test.go
@@ -1,0 +1,59 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestSelfhostFileAcceptsStdOptionResultModuleHelpers(t *testing.T) {
+	src := []byte(`use std.option
+use std.result
+
+enum FsError {
+    NotFound(String)
+
+    pub fn message(self) -> String {
+        match self {
+            NotFound(path) -> "missing {path}",
+        }
+    }
+}
+
+fn main() {
+    let flattenedMaybe: Int? = option.flatten::<Int>(Some(Some(3)))
+    let transposedMaybe: Result<Int?, FsError> = option.transpose::<Int, FsError>(Some(Ok(4)))
+    let unzippedMaybe: (Int?, String?) = option.unzip(Some((5, "zip")))
+    let valuesMaybe: List<Int> = option.values::<Int>([Some(1), None, Some(2)])
+    let anyMaybe: Int? = option.any::<Int>([None, Some(9), None])
+    let allMaybe: List<Int>? = option.all::<Int>([Some(1), Some(2), Some(3)])
+    let traversedMaybe: List<Int>? = option.traverse::<Int, Int>([1, 2, 3], |n: Int| if n > 0 { Some(n * 2) } else { None })
+    let filterMappedMaybe: List<Int> = option.filterMap::<Int, Int>([1, 0, 2], |n: Int| if n > 0 { Some(n * 10) } else { None })
+    let foundMaybe: String? = option.findMap::<Int, String>([0, 1, 2], |n: Int| if n == 2 { Some("two") } else { None })
+    let mapped2Maybe: Int? = option.map2::<Int, Int, Int>(Some(2), Some(3), |a: Int, b: Int| a + b)
+    let mapped3Maybe: Int? = option.map3::<Int, Int, Int, Int>(Some(2), Some(3), Some(4), |a: Int, b: Int, c: Int| a + b + c)
+
+    let flattenedResult: Result<Int, FsError> = result.flatten::<Int, FsError>(Ok(Ok(6)))
+    let transposedResult: Result<Int, FsError>? = result.transpose::<Int, FsError>(Ok(Some(7)))
+    let valuesResult: List<Int> = result.values::<Int, FsError>([Ok(1), Err(FsError.NotFound("a")), Ok(2)])
+    let errorsResult: List<FsError> = result.errors::<Int, FsError>([Ok(1), Err(FsError.NotFound("b"))])
+    let partitionedResult: (List<Int>, List<FsError>) = result.partition::<Int, FsError>([Ok(3), Err(FsError.NotFound("c"))])
+    let allResult: Result<List<Int>, FsError> = result.all::<Int, FsError>([Ok(4), Ok(5)])
+    let traversedResult: Result<List<Int>, FsError> = result.traverse::<Int, Int, FsError>([1, 2], |n: Int| Ok(n * 3))
+    let mapped2Result: Result<Int, FsError> = result.map2::<Int, Int, FsError, Int>(Ok(2), Ok(3), |a: Int, b: Int| a * b)
+    let mapped3Result: Result<Int, FsError> = result.map3::<Int, Int, Int, FsError, Int>(Ok(2), Ok(3), Ok(4), |a: Int, b: Int, c: Int| a + b + c)
+    let allErrorsResult: Result<List<Int>, List<FsError>> = result.allErrors::<Int, FsError>([Ok(1), Err(FsError.NotFound("d")), Err(FsError.NotFound("e"))])
+    let traversedErrorsResult: Result<List<Int>, List<FsError>> = result.traverseErrors::<Int, Int, FsError>([1, -1, 2], |n: Int| if n > 0 { Ok(n) } else { Err(FsError.NotFound("neg")) })
+
+    let _ = (flattenedMaybe, transposedMaybe, unzippedMaybe, valuesMaybe, anyMaybe, allMaybe, mapped2Maybe, mapped3Maybe)
+    let _ = (traversedMaybe, filterMappedMaybe, foundMaybe, flattenedResult, transposedResult, mapped2Result, mapped3Result)
+    let _ = (valuesResult, errorsResult, partitionedResult, allResult, traversedResult, allErrorsResult, traversedErrorsResult)
+}
+`)
+
+	file, res := parseResolvedFile(t, src)
+	chk := SelfhostFile(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("SelfhostFile diagnostics = %v, want none", chk.Diags)
+	}
+}

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -91,7 +91,7 @@ func selfhostPackageImportSurfaces(pkg *resolve.Package, ws *resolve.Workspace, 
 				continue
 			}
 			seen[use.Alias] = key
-			out = append(out, selfhost.PackageImportSurface(use.Alias, runsForPackage(target)))
+			out = append(out, selfhost.PackageImportSurface(use.Path, use.Alias, runsForPackage(target)))
 		}
 	}
 	return out
@@ -121,7 +121,7 @@ func selfhostUsesImportSurfaces(uses []*ast.UseDecl, ws *resolve.Workspace, stdl
 			continue
 		}
 		seen[alias] = key
-		out = append(out, selfhost.PackageImportSurface(alias, runsForPackage(target)))
+		out = append(out, selfhost.PackageImportSurface(key, alias, runsForPackage(target)))
 	}
 	return out
 }

--- a/internal/llvmgen/stdlib_method_lookup_test.go
+++ b/internal/llvmgen/stdlib_method_lookup_test.go
@@ -84,3 +84,26 @@ func TestLookupEnumMethodReachesOptionIsSome(t *testing.T) {
 		t.Fatalf("Option.isSome found but body is nil")
 	}
 }
+
+func TestLookupEnumMethodReachesExpandedOptionAndResultBodies(t *testing.T) {
+	reg := stdlib.LoadCached()
+	cases := []struct {
+		enumName   string
+		methodName string
+	}{
+		{"Option", "zipWith"},
+		{"Option", "reduce"},
+		{"Result", "zip"},
+		{"Result", "zipWith"},
+		{"Result", "toList"},
+	}
+	for _, tc := range cases {
+		fn := LookupEnumMethod(reg, tc.enumName, tc.methodName)
+		if fn == nil {
+			t.Fatalf("%s.%s not reachable via enum-method lookup", tc.enumName, tc.methodName)
+		}
+		if fn.Body == nil {
+			t.Fatalf("%s.%s found but body is nil", tc.enumName, tc.methodName)
+		}
+	}
+}

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -542,20 +542,30 @@ fn main() {
     let some: Bool = maybe.isSomeAnd(|v| v > 0)
     let noneOr: Bool = maybe.isNoneOr(|v| v > 0)
     let contains: Bool = maybe.contains(1)
+    let countMaybe: Int = maybe.count()
     let expected: Int = maybe.expect("need value")
     let fallback: Int = maybe.unwrapOrElse(|| 0)
     let zipped: (Int, String)? = maybe.zip(Some("ok"))
+    let zippedWith: String? = maybe.zipWith(Some("ok"), |v: Int, label: String| "{label}:{v}")
+    let reducedMaybe: Int? = maybe.reduce(Some(2), |a, b| a + b)
     let mapped: String? = maybe.map(|v| "{v}")
     let mappedOr: String = maybe.mapOr("zero", |v| "{v}")
     let okOr: Result<Int, Error> = maybe.okOr("missing")
     let okOrElse: Result<Int, FsError> = maybe.okOrElse(|| FsError.NotFound("fallback"))
+    let maybeList: List<Int> = maybe.toList()
+    maybe.forEach(|v| println("{v}"))
 
     let good: Result<Int, FsError> = Ok(1)
     let okAnd: Bool = good.isOkAnd(|v| v > 0)
     let containsOk: Bool = good.contains(1)
+    let resultCount: Int = good.count()
     let inspected: Result<Int, FsError> = good.inspect(|v| println("{v}"))
     let mappedRes: Result<String, FsError> = good.map(|v| "{v}")
     let mappedOrElse: String = good.mapOrElse(|e| e.message(), |v| "{v}")
+    let zippedResult: Result<(Int, String), FsError> = good.zip(Ok("ok"))
+    let zippedResultWith: Result<String, FsError> = good.zipWith(Ok("ok"), |v: Int, label: String| "{label}:{v}")
+    let goodList: List<Int> = good.toList()
+    good.forEach(|v| println("{v}"))
 
     let bad: Result<Int, FsError> = Err(FsError.NotFound("broken"))
     let errAnd: Bool = bad.isErrAnd(|e| e.message().len() > 0)
@@ -568,8 +578,9 @@ fn main() {
     let containsErr: Bool = textErr.containsErr("bad")
     let expectErr: String = textErr.expectErr("want err")
 
-    let _ = (msg, parent, chain, some, noneOr, contains, expected, fallback, zipped, mapped, mappedOr, okOr, okOrElse)
-    let _ = (okAnd, containsOk, inspected, mappedRes, mappedOrElse, errAnd, recovered, chained, alt, containsErr, expectErr)
+    let _ = (msg, parent, chain, some, noneOr, contains, countMaybe, expected, fallback, zipped, zippedWith, reducedMaybe, mapped, mappedOr, okOr, okOrElse)
+    let _ = (maybeList, okAnd, containsOk, resultCount, inspected, mappedRes, mappedOrElse, zippedResult, zippedResultWith, goodList)
+    let _ = (errAnd, recovered, chained, alt, containsErr, expectErr)
 }
 `)
 
@@ -583,14 +594,22 @@ fn main() {
 		got[binding.Name] = binding.Type.String()
 	}
 	want := map[string]string{
-		"chain":        "List<Error>",
-		"okOrElse":     "Result<Int, FsError>",
-		"mappedOr":     "String",
-		"mappedRes":    "Result<String, FsError>",
-		"promoted":     "Result<Int, Error>",
-		"containsErr":  "Bool",
-		"expectErr":    "String",
-		"mappedOrElse": "String",
+		"chain":            "List<Error>",
+		"countMaybe":       "Int",
+		"zippedWith":       "String?",
+		"reducedMaybe":     "Int?",
+		"okOrElse":         "Result<Int, FsError>",
+		"maybeList":        "List<Int>",
+		"resultCount":      "Int",
+		"mappedOr":         "String",
+		"mappedRes":        "Result<String, FsError>",
+		"mappedOrElse":     "String",
+		"zippedResult":     "Result<(Int, String), FsError>",
+		"zippedResultWith": "Result<String, FsError>",
+		"goodList":         "List<Int>",
+		"promoted":         "Result<Int, Error>",
+		"containsErr":      "Bool",
+		"expectErr":        "String",
 	}
 	for name, wantType := range want {
 		if got[name] != wantType {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36787,6 +36787,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "contains", owner: "Result", receiverTy: tResTE, retTy: tBool(tys), paramNames: []string{"item"}, paramTys: []int{tT}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16801:5
 	checkRegisterFn(env, &CheckFnSig{name: "containsErr", owner: "Result", receiverTy: tResTE, retTy: tBool(tys), paramNames: []string{"err"}, paramTys: []int{tE}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "count", owner: "Result", receiverTy: tResTE, retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16806:5
 	checkRegisterFn(env, &CheckFnSig{name: "expect", owner: "Result", receiverTy: tResTE, retTy: tT, paramNames: []string{"msg"}, paramTys: []int{tStringResult}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16811:5
@@ -36811,6 +36812,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "inspect", owner: "Result", receiverTy: tResTE, retTy: tResTE, paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tUnit(tys))}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16861:5
 	checkRegisterFn(env, &CheckFnSig{name: "inspectErr", owner: "Result", receiverTy: tResTE, retTy: tResTE, paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tE}, tUnit(tys))}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "forEach", owner: "Result", receiverTy: tResTE, retTy: tUnit(tys), paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tUnit(tys))}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16866:5
 	checkRegisterFn(env, &CheckFnSig{name: "map", owner: "Result", receiverTy: tResTE, retTy: tResUE, paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "E", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16871:5
@@ -36819,6 +36821,9 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "mapOr", owner: "Result", receiverTy: tResTE, retTy: tU, paramNames: []string{"fallback", "f"}, paramTys: []int{tU, tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "E", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16881:5
 	checkRegisterFn(env, &CheckFnSig{name: "mapOrElse", owner: "Result", receiverTy: tResTE, retTy: tU, paramNames: []string{"fallback", "f"}, paramTys: []int{tyFn(tys, []int{tE}, tU), tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "E", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "zip", owner: "Result", receiverTy: tResTE, retTy: tyNamed(tys, "Result", []int{tyTuple(tys, []int{tT, tU}), tE}), paramNames: []string{"other"}, paramTys: []int{tResUE}, generics: []string{"T", "E", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "zipWith", owner: "Result", receiverTy: tResTE, retTy: tyNamed(tys, "Result", []int{tR, tE}), paramNames: []string{"other", "f"}, paramTys: []int{tResUE, tyFn(tys, []int{tT, tU}, tR)}, generics: []string{"T", "E", "U", "R"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "toList", owner: "Result", receiverTy: tResTE, retTy: tListT, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16886:5
 	checkRegisterFn(env, &CheckFnSig{name: "toString", owner: "Result", receiverTy: tResTE, retTy: tStringResult, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16891:5
@@ -36836,6 +36841,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "isNoneOr", owner: "Option", receiverTy: tOptTAlias, retTy: tBool(tys), paramNames: []string{"pred"}, paramTys: []int{tyFn(tys, []int{tT}, tBool(tys))}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16917:5
 	checkRegisterFn(env, &CheckFnSig{name: "contains", owner: "Option", receiverTy: tOptTAlias, retTy: tBool(tys), paramNames: []string{"item"}, paramTys: []int{tT}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "count", owner: "Option", receiverTy: tOptTAlias, retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16922:5
 	checkRegisterFn(env, &CheckFnSig{name: "take", owner: "Option", receiverTy: tOptTAlias, retTy: tOptTAlias, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16927:5
@@ -36863,6 +36869,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "filter", owner: "Option", receiverTy: tOptTAlias, retTy: tOptTAlias, paramNames: []string{"pred"}, paramTys: []int{tyFn(tys, []int{tT}, tBool(tys))}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16978:5
 	checkRegisterFn(env, &CheckFnSig{name: "inspect", owner: "Option", receiverTy: tOptTAlias, retTy: tOptTAlias, paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tUnit(tys))}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "forEach", owner: "Option", receiverTy: tOptTAlias, retTy: tUnit(tys), paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tUnit(tys))}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16983:5
 	checkRegisterFn(env, &CheckFnSig{name: "map", owner: "Option", receiverTy: tOptTAlias, retTy: tOptU, paramNames: []string{"f"}, paramTys: []int{tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16988:5
@@ -36871,6 +36878,8 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "mapOrElse", owner: "Option", receiverTy: tOptTAlias, retTy: tU, paramNames: []string{"fallback", "f"}, paramTys: []int{tyFn(tys, make([]int, 0, 1), tU), tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16998:5
 	checkRegisterFn(env, &CheckFnSig{name: "zip", owner: "Option", receiverTy: tOptTAlias, retTy: tyOptional(tys, tyTuple(tys, []int{tT, tU})), paramNames: []string{"other"}, paramTys: []int{tOptU}, generics: []string{"T", "U"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "zipWith", owner: "Option", receiverTy: tOptTAlias, retTy: tyOptional(tys, tR), paramNames: []string{"other", "f"}, paramTys: []int{tOptU, tyFn(tys, []int{tT, tU}, tR)}, generics: []string{"T", "U", "R"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "reduce", owner: "Option", receiverTy: tOptTAlias, retTy: tOptTAlias, paramNames: []string{"other", "f"}, paramTys: []int{tOptTAlias, tyFn(tys, []int{tT, tT}, tT)}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17003:5
 	tResTError := tyNamed(tys, "Result", []int{tT, tyNamed(tys, "Error", make([]int, 0, 1))})
 	_ = tResTError
@@ -36880,6 +36889,7 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "okOr", owner: "Option", receiverTy: tOptTAlias, retTy: tResTError, paramNames: []string{"msg"}, paramTys: []int{tStringResult}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17014:5
 	checkRegisterFn(env, &CheckFnSig{name: "okOrElse", owner: "Option", receiverTy: tOptTAlias, retTy: tResTE, paramNames: []string{"err"}, paramTys: []int{tyFn(tys, make([]int, 0, 1), tE)}, generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "toList", owner: "Option", receiverTy: tOptTAlias, retTy: tListT, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17019:5
 	checkRegisterFn(env, &CheckFnSig{name: "toString", owner: "Option", receiverTy: tOptTAlias, retTy: tStringResult, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17026:5

--- a/internal/selfhost/import_surface_arena.go
+++ b/internal/selfhost/import_surface_arena.go
@@ -144,13 +144,16 @@ func arenaStringUnquote(s string) string {
 // typically obtain runs from resolve.PackageFile.Run (populated by
 // LoadPackageForNative) or by calling selfhost.Run(pf.Source) when Run
 // is not yet available.
-func PackageImportSurface(alias string, runs []*FrontendRun) PackageCheckImport {
+func PackageImportSurface(importPath, alias string, runs []*FrontendRun) PackageCheckImport {
 	surface := PackageCheckImport{Alias: alias}
 	if alias == "" || len(runs) == 0 {
 		return surface
 	}
-	localTypes := arenaLocalTypeNames(alias, runs)
+	localTypes := arenaLocalTypeNames(importPath, alias, runs)
 	for _, qualified := range arenaSortedMapValues(localTypes) {
+		if arenaStdlibBuiltinTypeName(importPath, arenaLocalTypeName(qualified)) != "" {
+			continue
+		}
 		surface.Fields = append(surface.Fields, PackageCheckField{
 			Owner:      alias,
 			Name:       arenaLocalTypeName(qualified),
@@ -195,18 +198,30 @@ func PackageImportSurface(alias string, runs []*FrontendRun) PackageCheckImport 
 					HasDefault: true,
 				})
 			case *AstNodeKind_AstNStructDecl:
+				if arenaStdlibBuiltinTypeName(importPath, n.text) != "" {
+					continue
+				}
 				if n.flags == 1 {
 					arenaAppendImportedStruct(&surface, arena, alias, localTypes, n)
 				}
 			case *AstNodeKind_AstNEnumDecl:
+				if arenaStdlibBuiltinTypeName(importPath, n.text) != "" {
+					continue
+				}
 				if n.flags == 1 {
 					arenaAppendImportedEnum(&surface, arena, alias, localTypes, n)
 				}
 			case *AstNodeKind_AstNInterfaceDecl:
+				if arenaStdlibBuiltinTypeName(importPath, n.text) != "" {
+					continue
+				}
 				if n.flags == 1 {
 					arenaAppendImportedInterface(&surface, arena, alias, localTypes, n)
 				}
 			case *AstNodeKind_AstNTypeAlias:
+				if arenaStdlibBuiltinTypeName(importPath, n.text) != "" {
+					continue
+				}
 				if n.flags == 1 {
 					arenaAppendImportedAlias(&surface, arena, alias, localTypes, n)
 				}
@@ -268,7 +283,7 @@ func arenaFnDeclHasReceiver(arena *AstArena, n *AstNode) bool {
 	return child.text == "self"
 }
 
-func arenaLocalTypeNames(alias string, runs []*FrontendRun) map[string]string {
+func arenaLocalTypeNames(importPath, alias string, runs []*FrontendRun) map[string]string {
 	out := map[string]string{}
 	for _, run := range runs {
 		if run == nil || run.parser == nil || run.parser.arena == nil {
@@ -289,11 +304,38 @@ func arenaLocalTypeNames(alias string, runs []*FrontendRun) map[string]string {
 				if n.text == "" {
 					continue
 				}
+				if rebound := arenaStdlibBuiltinTypeName(importPath, n.text); rebound != "" {
+					out[n.text] = rebound
+					continue
+				}
 				out[n.text] = alias + "." + n.text
 			}
 		}
 	}
 	return out
+}
+
+func arenaStdlibBuiltinTypeName(importPath, name string) string {
+	switch importPath {
+	case "std.collections":
+		switch name {
+		case "List", "Map", "Set":
+			return name
+		}
+	case "std.error":
+		if name == "Error" {
+			return name
+		}
+	case "std.option":
+		if name == "Option" {
+			return name
+		}
+	case "std.result":
+		if name == "Result" {
+			return name
+		}
+	}
+	return ""
 }
 
 func arenaLocalTypeName(qualified string) string {

--- a/internal/selfhost/import_surface_arena_test.go
+++ b/internal/selfhost/import_surface_arena_test.go
@@ -1,0 +1,55 @@
+package selfhost_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestPackageImportSurfaceRebindsStdOptionResultBuiltinTypes(t *testing.T) {
+	reg := stdlib.LoadCached()
+	optionRun := selfhost.Run(reg.Modules["option"].Source)
+	resultRun := selfhost.Run(reg.Modules["result"].Source)
+	if optionRun == nil || resultRun == nil {
+		t.Fatal("expected selfhost runs for std.option/std.result")
+	}
+
+	optionSurface := selfhost.PackageImportSurface("std.option", "option", []*selfhost.FrontendRun{optionRun})
+	resultSurface := selfhost.PackageImportSurface("std.result", "result", []*selfhost.FrontendRun{resultRun})
+
+	assertNoQualifiedBuiltin := func(t *testing.T, surface selfhost.PackageCheckImport, bad string) {
+		t.Helper()
+		for _, fn := range surface.Functions {
+			if containsQualifiedType(fn.ReturnType, bad) {
+				t.Fatalf("fn %s return type leaked qualified builtin %q: %s", fn.Name, bad, fn.ReturnType)
+			}
+			for _, param := range fn.ParamTypes {
+				if containsQualifiedType(param, bad) {
+					t.Fatalf("fn %s param type leaked qualified builtin %q: %s", fn.Name, bad, param)
+				}
+			}
+		}
+		for _, field := range surface.Fields {
+			if containsQualifiedType(field.TypeName, bad) {
+				t.Fatalf("field %s leaked qualified builtin %q: %s", field.Name, bad, field.TypeName)
+			}
+		}
+	}
+
+	assertNoQualifiedBuiltin(t, optionSurface, "option.Option")
+	assertNoQualifiedBuiltin(t, resultSurface, "result.Result")
+}
+
+func containsQualifiedType(text, qualified string) bool {
+	if text == qualified {
+		return true
+	}
+	for _, suffix := range []string{"<", "?", ",", ")", ">", " "} {
+		if strings.Contains(text, qualified+suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/stdlib/lookup_test.go
+++ b/internal/stdlib/lookup_test.go
@@ -19,6 +19,46 @@ func TestLookupFnDeclFindsStringsCompare(t *testing.T) {
 	}
 }
 
+func TestLookupFnDeclFindsOptionAndResultHelpers(t *testing.T) {
+	reg := LoadCached()
+	cases := []struct {
+		module string
+		name   string
+	}{
+		{"option", "flatten"},
+		{"option", "transpose"},
+		{"option", "unzip"},
+		{"option", "values"},
+		{"option", "any"},
+		{"option", "all"},
+		{"option", "traverse"},
+		{"option", "filterMap"},
+		{"option", "findMap"},
+		{"option", "map2"},
+		{"option", "map3"},
+		{"result", "flatten"},
+		{"result", "transpose"},
+		{"result", "values"},
+		{"result", "errors"},
+		{"result", "partition"},
+		{"result", "all"},
+		{"result", "traverse"},
+		{"result", "map2"},
+		{"result", "map3"},
+		{"result", "allErrors"},
+		{"result", "traverseErrors"},
+	}
+	for _, tc := range cases {
+		fn := reg.LookupFnDecl(tc.module, tc.name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(%s, %s) = nil, want *ast.FnDecl", tc.module, tc.name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("LookupFnDecl(%s, %s) body = nil, want bodied helper", tc.module, tc.name)
+		}
+	}
+}
+
 func TestLookupFnDeclUnknownReturnsNil(t *testing.T) {
 	reg := LoadCached()
 	cases := []struct {
@@ -68,6 +108,30 @@ func TestLookupMethodDeclFindsEnumMethod(t *testing.T) {
 	}
 	if fn.Body == nil {
 		t.Fatalf("fn.Body = nil, want bodied enum method")
+	}
+}
+
+func TestLookupMethodDeclFindsExpandedOptionAndResultMethods(t *testing.T) {
+	reg := LoadCached()
+	cases := []struct {
+		module   string
+		typeName string
+		method   string
+	}{
+		{"option", "Option", "zipWith"},
+		{"option", "Option", "reduce"},
+		{"result", "Result", "zip"},
+		{"result", "Result", "zipWith"},
+		{"result", "Result", "toList"},
+	}
+	for _, tc := range cases {
+		fn := reg.LookupMethodDecl(tc.module, tc.typeName, tc.method)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(%s, %s, %s) = nil, want *ast.FnDecl", tc.module, tc.typeName, tc.method)
+		}
+		if fn.Body == nil {
+			t.Fatalf("LookupMethodDecl(%s, %s, %s) body = nil, want bodied enum method", tc.module, tc.typeName, tc.method)
+		}
 	}
 }
 

--- a/internal/stdlib/modules/option.osty
+++ b/internal/stdlib/modules/option.osty
@@ -1,4 +1,4 @@
-// std.option — Option<T> and its core combinators.
+// std.option — Option<T>, its core combinators, and nested-shape helpers.
 //
 // Canonical definition site of `Option<T>`, `Some`, and `None`. The
 // prelude auto-imports these so user code can write `Some(x)` without
@@ -40,6 +40,13 @@ pub enum Option<T> {
         match self {
             Some(value) -> value == item,
             None -> false,
+        }
+    }
+
+    pub fn count(self) -> Int {
+        match self {
+            Some(_) -> 1,
+            None -> 0,
         }
     }
 
@@ -138,6 +145,13 @@ pub enum Option<T> {
         }
     }
 
+    pub fn forEach(self, f: fn(T) -> ()) {
+        match self {
+            Some(value) -> f(value),
+            None -> {},
+        }
+    }
+
     pub fn map<U>(self, f: fn(T) -> U) -> U? {
         match self {
             Some(value) -> Some(f(value)),
@@ -169,6 +183,26 @@ pub enum Option<T> {
         }
     }
 
+    pub fn zipWith<U, R>(self, other: U?, f: fn(T, U) -> R) -> R? {
+        match self {
+            Some(a) -> match other {
+                Some(b) -> Some(f(a, b)),
+                None -> None,
+            },
+            None -> None,
+        }
+    }
+
+    pub fn reduce(self, other: T?, f: fn(T, T) -> T) -> T? {
+        match self {
+            Some(a) -> match other {
+                Some(b) -> Some(f(a, b)),
+                None -> Some(a),
+            },
+            None -> other,
+        }
+    }
+
     pub fn orError(self, msg: String) -> Result<T, Error> {
         match self {
             Some(value) -> Ok(value),
@@ -187,11 +221,121 @@ pub enum Option<T> {
         }
     }
 
+    pub fn toList(self) -> List<T> {
+        match self {
+            Some(value) -> [value],
+            None -> [],
+        }
+    }
+
     pub fn toString(self) -> String {
         match self {
-            Some(_) -> "Some(...)",
+            Some(value) -> "Some({value})",
             None -> "None",
         }
+    }
+}
+
+pub fn flatten<T>(value: T??) -> T? {
+    match value {
+        Some(inner) -> inner,
+        None -> None,
+    }
+}
+
+pub fn transpose<T, E>(value: Result<T, E>?) -> Result<T?, E> {
+    match value {
+        Some(Ok(item)) -> Ok(Some(item)),
+        Some(Err(err)) -> Err(err),
+        None -> Ok(None),
+    }
+}
+
+pub fn unzip<A, B>(value: (A, B)?) -> (A?, B?) {
+    match value {
+        Some((a, b)) -> (Some(a), Some(b)),
+        None -> (None, None),
+    }
+}
+
+pub fn values<T>(items: List<T?>) -> List<T> {
+    let mut out: List<T> = []
+    for item in items {
+        match item {
+            Some(value) -> out.push(value),
+            None -> {},
+        }
+    }
+    out
+}
+
+pub fn any<T>(items: List<T?>) -> T? {
+    for item in items {
+        match item {
+            Some(_) -> return item,
+            None -> {},
+        }
+    }
+    None
+}
+
+pub fn all<T>(items: List<T?>) -> List<T>? {
+    let mut out: List<T> = []
+    for item in items {
+        match item {
+            Some(value) -> out.push(value),
+            None -> return None,
+        }
+    }
+    Some(out)
+}
+
+pub fn traverse<T, U>(items: List<T>, f: fn(T) -> U?) -> List<U>? {
+    let mut out: List<U> = []
+    for item in items {
+        match f(item) {
+            Some(value) -> out.push(value),
+            None -> return None,
+        }
+    }
+    Some(out)
+}
+
+pub fn filterMap<T, U>(items: List<T>, f: fn(T) -> U?) -> List<U> {
+    let mut out: List<U> = []
+    for item in items {
+        match f(item) {
+            Some(value) -> out.push(value),
+            None -> {},
+        }
+    }
+    out
+}
+
+pub fn findMap<T, U>(items: List<T>, f: fn(T) -> U?) -> U? {
+    for item in items {
+        match f(item) {
+            Some(value) -> return Some(value),
+            None -> {},
+        }
+    }
+    None
+}
+
+pub fn map2<A, B, R>(left: A?, right: B?, f: fn(A, B) -> R) -> R? {
+    left.zipWith(right, f)
+}
+
+pub fn map3<A, B, C, R>(a: A?, b: B?, c: C?, f: fn(A, B, C) -> R) -> R? {
+    match a {
+        Some(av) -> match b {
+            Some(bv) -> match c {
+                Some(cv) -> Some(f(av, bv, cv)),
+                None -> None,
+            },
+            None -> None,
+        },
+        None -> None,
     }
 }
 

--- a/internal/stdlib/modules/result.osty
+++ b/internal/stdlib/modules/result.osty
@@ -1,4 +1,4 @@
-// std.result — Result helpers for the Osty standard library.
+// std.result — Result helpers and nested-shape adapters.
 //
 // Canonical definition site of `Result<T, E>`, `Ok`, and `Err`.
 // The prelude auto-imports these so user code can write `Ok(x)` /
@@ -48,6 +48,13 @@ pub enum Result<T, E> {
         match self {
             Ok(_) -> false,
             Err(error) -> error == err,
+        }
+    }
+
+    pub fn count(self) -> Int {
+        match self {
+            Ok(_) -> 1,
+            Err(_) -> 0,
         }
     }
 
@@ -155,6 +162,13 @@ pub enum Result<T, E> {
         }
     }
 
+    pub fn forEach(self, f: fn(T) -> ()) {
+        match self {
+            Ok(value) -> f(value),
+            Err(_) -> {},
+        }
+    }
+
     pub fn map<U>(self, f: fn(T) -> U) -> Result<U, E> {
         match self {
             Ok(value) -> Ok(f(value)),
@@ -183,11 +197,158 @@ pub enum Result<T, E> {
         }
     }
 
+    pub fn zip<U>(self, other: Result<U, E>) -> Result<(T, U), E> {
+        match self {
+            Ok(left) -> match other {
+                Ok(right) -> Ok((left, right)),
+                Err(error) -> Err(error),
+            },
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn zipWith<U, R>(self, other: Result<U, E>, f: fn(T, U) -> R) -> Result<R, E> {
+        match self {
+            Ok(left) -> match other {
+                Ok(right) -> Ok(f(left, right)),
+                Err(error) -> Err(error),
+            },
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn toList(self) -> List<T> {
+        match self {
+            Ok(value) -> [value],
+            Err(_) -> [],
+        }
+    }
+
     pub fn toString(self) -> String {
         match self {
             Ok(value) -> "Ok({value})",
             Err(error) -> "Err({error})",
         }
+    }
+}
+
+pub fn flatten<T, E>(value: Result<Result<T, E>, E>) -> Result<T, E> {
+    match value {
+        Ok(inner) -> inner,
+        Err(err) -> Err(err),
+    }
+}
+
+pub fn transpose<T, E>(value: Result<T?, E>) -> Result<T, E>? {
+    match value {
+        Ok(Some(item)) -> Some(Ok(item)),
+        Ok(None) -> None,
+        Err(err) -> Some(Err(err)),
+    }
+}
+
+pub fn values<T, E>(items: List<Result<T, E>>) -> List<T> {
+    let mut out: List<T> = []
+    for item in items {
+        match item {
+            Ok(value) -> out.push(value),
+            Err(_) -> {},
+        }
+    }
+    out
+}
+
+pub fn errors<T, E>(items: List<Result<T, E>>) -> List<E> {
+    let mut out: List<E> = []
+    for item in items {
+        match item {
+            Ok(_) -> {},
+            Err(err) -> out.push(err),
+        }
+    }
+    out
+}
+
+pub fn partition<T, E>(items: List<Result<T, E>>) -> (List<T>, List<E>) {
+    let mut oks: List<T> = []
+    let mut errs: List<E> = []
+    for item in items {
+        match item {
+            Ok(value) -> oks.push(value),
+            Err(err) -> errs.push(err),
+        }
+    }
+    (oks, errs)
+}
+
+pub fn all<T, E>(items: List<Result<T, E>>) -> Result<List<T>, E> {
+    let mut out: List<T> = []
+    for item in items {
+        match item {
+            Ok(value) -> out.push(value),
+            Err(err) -> return Err(err),
+        }
+    }
+    Ok(out)
+}
+
+pub fn traverse<T, U, E>(items: List<T>, f: fn(T) -> Result<U, E>) -> Result<List<U>, E> {
+    let mut out: List<U> = []
+    for item in items {
+        match f(item) {
+            Ok(value) -> out.push(value),
+            Err(err) -> return Err(err),
+        }
+    }
+    Ok(out)
+}
+
+pub fn map2<A, B, E, R>(left: Result<A, E>, right: Result<B, E>, f: fn(A, B) -> R) -> Result<R, E> {
+    left.zipWith(right, f)
+}
+
+pub fn map3<A, B, C, E, R>(a: Result<A, E>, b: Result<B, E>, c: Result<C, E>, f: fn(A, B, C) -> R) -> Result<R, E> {
+    match a {
+        Ok(av) -> match b {
+            Ok(bv) -> match c {
+                Ok(cv) -> Ok(f(av, bv, cv)),
+                Err(error) -> Err(error),
+            },
+            Err(error) -> Err(error),
+        },
+        Err(error) -> Err(error),
+    }
+}
+
+pub fn allErrors<T, E>(items: List<Result<T, E>>) -> Result<List<T>, List<E>> {
+    let mut values: List<T> = []
+    let mut errs: List<E> = []
+    for item in items {
+        match item {
+            Ok(value) -> values.push(value),
+            Err(err) -> errs.push(err),
+        }
+    }
+    if errs.isEmpty() {
+        Ok(values)
+    } else {
+        Err(errs)
+    }
+}
+
+pub fn traverseErrors<T, U, E>(items: List<T>, f: fn(T) -> Result<U, E>) -> Result<List<U>, List<E>> {
+    let mut values: List<U> = []
+    let mut errs: List<E> = []
+    for item in items {
+        match f(item) {
+            Ok(value) -> values.push(value),
+            Err(err) -> errs.push(err),
+        }
+    }
+    if errs.isEmpty() {
+        Ok(values)
+    } else {
+        Err(errs)
     }
 }
 

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -2640,6 +2640,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         generics: ["T", "E"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
+        name: "count", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
+        generics: ["T", "E"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
         name: "expect", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tT,
         paramNames: ["msg"], paramTys: [tStringResult],
         generics: ["T", "E"], genericBounds: [],
@@ -2700,6 +2705,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         generics: ["T", "E"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
+        name: "forEach", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tUnit(tys),
+        paramNames: ["f"], paramTys: [tyFn(tys, [tT], tUnit(tys))],
+        generics: ["T", "E"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
         name: "map", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tResUE,
         paramNames: ["f"], paramTys: [tyFn(tys, [tT], tU)],
         generics: ["T", "E", "U"], genericBounds: [],
@@ -2718,6 +2728,21 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         name: "mapOrElse", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tU,
         paramNames: ["fallback", "f"], paramTys: [tyFn(tys, [tE], tU), tyFn(tys, [tT], tU)],
         generics: ["T", "E", "U"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "zip", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tyNamed(tys, "Result", [tyTuple(tys, [tT, tU]), tE]),
+        paramNames: ["other"], paramTys: [tResUE],
+        generics: ["T", "E", "U"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "zipWith", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tyNamed(tys, "Result", [tR, tE]),
+        paramNames: ["other", "f"], paramTys: [tResUE, tyFn(tys, [tT, tU], tR)],
+        generics: ["T", "E", "U", "R"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toList", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tListT,
+        paramNames: [], paramTys: [],
+        generics: ["T", "E"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
         name: "toString", owner: "Result", receiverTy: tResTE, hasReceiver: true, retTy: tStringResult,
@@ -2753,6 +2778,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     checkRegisterFn(env, CheckFnSig {
         name: "contains", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tBool(tys),
         paramNames: ["item"], paramTys: [tT],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "count", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
         generics: ["T"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
@@ -2817,6 +2847,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         generics: ["T"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
+        name: "forEach", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tUnit(tys),
+        paramNames: ["f"], paramTys: [tyFn(tys, [tT], tUnit(tys))],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
         name: "map", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tOptU,
         paramNames: ["f"], paramTys: [tyFn(tys, [tT], tU)],
         generics: ["T", "U"], genericBounds: [],
@@ -2836,6 +2871,16 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         paramNames: ["other"], paramTys: [tOptU],
         generics: ["T", "U"], genericBounds: [],
     })
+    checkRegisterFn(env, CheckFnSig {
+        name: "zipWith", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tyOptional(tys, tR),
+        paramNames: ["other", "f"], paramTys: [tOptU, tyFn(tys, [tT, tU], tR)],
+        generics: ["T", "U", "R"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "reduce", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tOptTAlias,
+        paramNames: ["other", "f"], paramTys: [tOptTAlias, tyFn(tys, [tT, tT], tT)],
+        generics: ["T"], genericBounds: [],
+    })
     let tResTError = tyNamed(tys, "Result", [tT, tyNamed(tys, "Error", [])])
     checkRegisterFn(env, CheckFnSig {
         name: "orError", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tResTError,
@@ -2851,6 +2896,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         name: "okOrElse", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tResTE,
         paramNames: ["err"], paramTys: [tyFn(tys, [], tE)],
         generics: ["T", "E"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toList", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tListT,
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
         name: "toString", owner: "Option", receiverTy: tOptTAlias, hasReceiver: true, retTy: tStringResult,


### PR DESCRIPTION
## Summary
- expand std.option/std.result with map2/map3 composition helpers and Result zip/zipWith
- add accumulated-error helpers for Result batches and keep selfhost checker signatures in sync
- normalize imported std.option/std.result surfaces so builtin Option/Result stay canonical

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)