### PR TITLE
feat: add std.net runtime bridge

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -114,8 +114,16 @@ typedef INIT_ONCE          osty_rt_once_t;
 #else
 #  define OSTY_RT_PLATFORM_POSIX 1
 #  include <pthread.h>
+#  include <poll.h>
 #  include <sched.h>
 #  include <signal.h>
+#  include <fcntl.h>
+#  include <netdb.h>
+#  include <arpa/inet.h>
+#  include <netinet/in.h>
+#  include <netinet/tcp.h>
+#  include <sys/socket.h>
+#  include <sys/time.h>
 #  if defined(__APPLE__)
 #    include <crt_externs.h>
 #  endif
@@ -16530,6 +16538,778 @@ void *osty_rt_io_read_line(void) {
     free(buf);
     return out;
 }
+
+/* std.net TCP/DNS surface.
+ *
+ * The Osty `std.net` module keeps the public API in Osty source and
+ * calls into these runtime helpers through `use c "osty_runtime"`.
+ * Every helper clears the thread-local net status before work, and on
+ * failure records a human-readable error string retrievable via
+ * `osty_rt_net_last_error()`. */
+static OSTY_RT_TLS int osty_rt_net_failed_flag = 0;
+static OSTY_RT_TLS char *osty_rt_net_error_text = NULL;
+
+static void osty_rt_net_clear_status(void) {
+    osty_rt_net_failed_flag = 0;
+    if (osty_rt_net_error_text != NULL) {
+        free(osty_rt_net_error_text);
+        osty_rt_net_error_text = NULL;
+    }
+}
+
+static void osty_rt_net_set_error_text(const char *prefix, const char *detail, const char *site) {
+    const char *lhs = prefix == NULL ? "network error" : prefix;
+    const char *rhs = (detail != NULL && detail[0] != '\0') ? detail : "unknown error";
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
+    size_t total = lhs_len + 2 + rhs_len;
+    char *buf = (char *)osty_rt_xmalloc(total + 1, site);
+
+    memcpy(buf, lhs, lhs_len);
+    buf[lhs_len] = ':';
+    buf[lhs_len + 1] = ' ';
+    memcpy(buf + lhs_len + 2, rhs, rhs_len);
+    buf[total] = '\0';
+
+    osty_rt_net_clear_status();
+    osty_rt_net_failed_flag = 1;
+    osty_rt_net_error_text = buf;
+}
+
+static void osty_rt_net_set_errno_error(const char *prefix, const char *site) {
+    osty_rt_net_set_error_text(prefix, strerror(errno), site);
+}
+
+static void *osty_rt_net_empty_string(void) {
+    return osty_rt_string_dup_site("", 0, "runtime.net.empty_string");
+}
+
+static void *osty_rt_net_empty_bytes(void) {
+    return osty_rt_bytes_dup_site(NULL, 0, "runtime.net.empty_bytes");
+}
+
+static void *osty_rt_net_empty_list(void) {
+    return osty_rt_list_new();
+}
+
+static const char *osty_rt_net_decode_string_arg(const char *value, char *buf) {
+    const char *out = value != NULL ? value : "";
+    osty_rt_string_decode_to_buf_if_inline(&out, buf);
+    return out;
+}
+
+bool osty_rt_net_failed(void) {
+    return osty_rt_net_failed_flag != 0;
+}
+
+void *osty_rt_net_last_error(void) {
+    const char *msg = osty_rt_net_error_text != NULL
+        ? osty_rt_net_error_text
+        : "network error";
+    return osty_rt_string_dup_site(msg, strlen(msg), "runtime.net.last_error");
+}
+
+#if defined(OSTY_RT_PLATFORM_WIN32)
+
+static void osty_rt_net_unsupported(const char *site) {
+    osty_rt_net_set_error_text("network runtime is not available on this platform",
+                               "Windows socket support is not wired into the current runtime yet",
+                               site);
+}
+
+void *osty_rt_net_lookup_text(const char *host) {
+    (void)host;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.lookup_text");
+    return osty_rt_net_empty_list();
+}
+
+void *osty_rt_net_lookup_addr(const char *ip) {
+    (void)ip;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.lookup_addr");
+    return osty_rt_net_empty_list();
+}
+
+int64_t osty_rt_net_tcp_connect(const char *host, int64_t port) {
+    (void)host;
+    (void)port;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_connect");
+    return 0;
+}
+
+int64_t osty_rt_net_tcp_connect_timeout(const char *host, int64_t port, int64_t timeout_ms) {
+    (void)host;
+    (void)port;
+    (void)timeout_ms;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_connect_timeout");
+    return 0;
+}
+
+int64_t osty_rt_net_tcp_listen(const char *host, int64_t port) {
+    (void)host;
+    (void)port;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_listen");
+    return 0;
+}
+
+void *osty_rt_net_tcp_read(int64_t handle, int64_t max_bytes) {
+    (void)handle;
+    (void)max_bytes;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_read");
+    return osty_rt_net_empty_bytes();
+}
+
+void *osty_rt_net_tcp_read_exact(int64_t handle, int64_t n) {
+    (void)handle;
+    (void)n;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_read_exact");
+    return osty_rt_net_empty_bytes();
+}
+
+int64_t osty_rt_net_tcp_write(int64_t handle, void *data) {
+    (void)handle;
+    (void)data;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_write");
+    return 0;
+}
+
+void osty_rt_net_tcp_write_all(int64_t handle, void *data) {
+    (void)handle;
+    (void)data;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_write_all");
+}
+
+void osty_rt_net_tcp_flush(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+}
+
+void osty_rt_net_tcp_close(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_close");
+}
+
+void *osty_rt_net_tcp_local_addr(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_local_addr");
+    return osty_rt_net_empty_string();
+}
+
+void *osty_rt_net_tcp_peer_addr(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_peer_addr");
+    return osty_rt_net_empty_string();
+}
+
+void osty_rt_net_tcp_set_read_timeout(int64_t handle, int64_t timeout_ms) {
+    (void)handle;
+    (void)timeout_ms;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_set_read_timeout");
+}
+
+void osty_rt_net_tcp_set_write_timeout(int64_t handle, int64_t timeout_ms) {
+    (void)handle;
+    (void)timeout_ms;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_set_write_timeout");
+}
+
+void osty_rt_net_tcp_set_nodelay(int64_t handle, bool on) {
+    (void)handle;
+    (void)on;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_set_nodelay");
+}
+
+void osty_rt_net_tcp_set_keepalive(int64_t handle, bool on) {
+    (void)handle;
+    (void)on;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_set_keepalive");
+}
+
+int64_t osty_rt_net_tcp_accept(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_accept");
+    return 0;
+}
+
+void *osty_rt_net_tcp_listener_local_addr(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_listener_local_addr");
+    return osty_rt_net_empty_string();
+}
+
+void osty_rt_net_tcp_listener_close(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+    osty_rt_net_unsupported("runtime.net.tcp_listener_close");
+}
+
+#else
+
+static void osty_rt_net_set_gai_error(const char *prefix, int code, const char *site) {
+    osty_rt_net_set_error_text(prefix, gai_strerror(code), site);
+}
+
+static bool osty_rt_net_service_string(int64_t port, char *buf, size_t buf_size, const char *site) {
+    int written;
+    if (port < 0 || port > 65535) {
+        osty_rt_net_set_error_text("invalid port", "port must be in 0..65535", site);
+        return false;
+    }
+    written = snprintf(buf, buf_size, "%lld", (long long)port);
+    if (written < 0 || (size_t)written >= buf_size) {
+        osty_rt_net_set_error_text("failed to format port", "buffer overflow", site);
+        return false;
+    }
+    return true;
+}
+
+static void osty_rt_net_prepare_stream_socket(int fd) {
+#if defined(__APPLE__)
+    int on = 1;
+    if (fd >= 0) {
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, (socklen_t)sizeof(on));
+    }
+#else
+    (void)fd;
+#endif
+}
+
+static int osty_rt_net_send_flags(void) {
+#if defined(MSG_NOSIGNAL)
+    return MSG_NOSIGNAL;
+#else
+    return 0;
+#endif
+}
+
+static int osty_rt_net_set_blocking(int fd, bool blocking) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        return -1;
+    }
+    if (blocking) {
+        flags &= ~O_NONBLOCK;
+    } else {
+        flags |= O_NONBLOCK;
+    }
+    return fcntl(fd, F_SETFL, flags);
+}
+
+static void *osty_rt_net_sockaddr_text(const struct sockaddr *sa, socklen_t len, const char *site) {
+    char host[NI_MAXHOST];
+    char serv[NI_MAXSERV];
+    char text[NI_MAXHOST + NI_MAXSERV + 8];
+    int rc = getnameinfo(sa, len, host, sizeof(host), serv, sizeof(serv),
+                         NI_NUMERICHOST | NI_NUMERICSERV);
+    int written;
+    if (rc != 0) {
+        osty_rt_net_set_gai_error("failed to format socket address", rc, site);
+        return osty_rt_net_empty_string();
+    }
+    if (sa->sa_family == AF_INET6) {
+        written = snprintf(text, sizeof(text), "[%s]:%s", host, serv);
+    } else {
+        written = snprintf(text, sizeof(text), "%s:%s", host, serv);
+    }
+    if (written < 0 || (size_t)written >= sizeof(text)) {
+        osty_rt_net_set_error_text("failed to format socket address", "buffer overflow", site);
+        return osty_rt_net_empty_string();
+    }
+    return osty_rt_string_dup_site(text, (size_t)written, site);
+}
+
+static bool osty_rt_net_apply_timeout(int fd, int64_t timeout_ms, int optname, const char *site) {
+    struct timeval tv;
+    if (timeout_ms < 0) {
+        tv.tv_sec = 0;
+        tv.tv_usec = 0;
+    } else {
+        tv.tv_sec = (time_t)(timeout_ms / 1000);
+        tv.tv_usec = (suseconds_t)((timeout_ms % 1000) * 1000);
+    }
+    if (setsockopt(fd, SOL_SOCKET, optname, &tv, (socklen_t)sizeof(tv)) != 0) {
+        osty_rt_net_set_errno_error("failed to configure socket timeout", site);
+        return false;
+    }
+    return true;
+}
+
+static int64_t osty_rt_net_connect_impl(const char *host, int64_t port, int64_t timeout_ms, const char *site) {
+    char service[32];
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *ai;
+    int rc;
+    int last_errno = 0;
+
+    if (host == NULL || host[0] == '\0') {
+        osty_rt_net_set_error_text("failed to connect", "host is empty", site);
+        return 0;
+    }
+    if (!osty_rt_net_service_string(port, service, sizeof(service), site)) {
+        return 0;
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    rc = getaddrinfo(host, service, &hints, &res);
+    if (rc != 0) {
+        osty_rt_net_set_gai_error("failed to resolve remote address", rc, site);
+        return 0;
+    }
+
+    for (ai = res; ai != NULL; ai = ai->ai_next) {
+        int fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd < 0) {
+            last_errno = errno;
+            continue;
+        }
+
+        osty_rt_net_prepare_stream_socket(fd);
+        if (timeout_ms >= 0) {
+            struct pollfd pfd;
+            int so_error = 0;
+            socklen_t so_error_len = (socklen_t)sizeof(so_error);
+
+            if (osty_rt_net_set_blocking(fd, false) != 0) {
+                last_errno = errno;
+                close(fd);
+                continue;
+            }
+
+            do {
+                rc = connect(fd, ai->ai_addr, ai->ai_addrlen);
+            } while (rc != 0 && errno == EINTR);
+
+            if (rc != 0) {
+                if (errno != EINPROGRESS) {
+                    last_errno = errno;
+                    close(fd);
+                    continue;
+                }
+                pfd.fd = fd;
+                pfd.events = POLLOUT;
+                do {
+                    rc = poll(&pfd, 1, (int)timeout_ms);
+                } while (rc < 0 && errno == EINTR);
+                if (rc == 0) {
+                    close(fd);
+                    freeaddrinfo(res);
+                    osty_rt_net_set_error_text("failed to connect", "connect timed out", site);
+                    return 0;
+                }
+                if (rc < 0) {
+                    last_errno = errno;
+                    close(fd);
+                    continue;
+                }
+                if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len) != 0) {
+                    last_errno = errno;
+                    close(fd);
+                    continue;
+                }
+                if (so_error != 0) {
+                    last_errno = so_error;
+                    close(fd);
+                    continue;
+                }
+            }
+            if (osty_rt_net_set_blocking(fd, true) != 0) {
+                last_errno = errno;
+                close(fd);
+                continue;
+            }
+            freeaddrinfo(res);
+            return (int64_t)fd;
+        }
+
+        do {
+            rc = connect(fd, ai->ai_addr, ai->ai_addrlen);
+        } while (rc != 0 && errno == EINTR);
+        if (rc == 0) {
+            freeaddrinfo(res);
+            return (int64_t)fd;
+        }
+        last_errno = errno;
+        close(fd);
+    }
+
+    freeaddrinfo(res);
+    if (last_errno != 0) {
+        errno = last_errno;
+        osty_rt_net_set_errno_error("failed to connect", site);
+    } else {
+        osty_rt_net_set_error_text("failed to connect", "no reachable address", site);
+    }
+    return 0;
+}
+
+void *osty_rt_net_lookup_text(const char *host) {
+    char host_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *decoded = osty_rt_net_decode_string_arg(host, host_buf);
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *ai;
+    int rc;
+    void *out;
+
+    osty_rt_net_clear_status();
+    if (decoded[0] == '\0') {
+        osty_rt_net_set_error_text("failed to resolve host", "host is empty", "runtime.net.lookup_text");
+        return osty_rt_net_empty_list();
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    rc = getaddrinfo(decoded, NULL, &hints, &res);
+    if (rc != 0) {
+        osty_rt_net_set_gai_error("failed to resolve host", rc, "runtime.net.lookup_text");
+        return osty_rt_net_empty_list();
+    }
+
+    out = osty_rt_list_new();
+    for (ai = res; ai != NULL; ai = ai->ai_next) {
+        char text[NI_MAXHOST];
+        rc = getnameinfo(ai->ai_addr, ai->ai_addrlen, text, sizeof(text), NULL, 0, NI_NUMERICHOST);
+        if (rc != 0) {
+            continue;
+        }
+        osty_rt_list_push_ptr(out,
+                              osty_rt_string_dup_site(text, strlen(text), "runtime.net.lookup_text.entry"));
+    }
+    freeaddrinfo(res);
+    return out;
+}
+
+void *osty_rt_net_lookup_addr(const char *ip) {
+    char ip_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *decoded = osty_rt_net_decode_string_arg(ip, ip_buf);
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *ai;
+    int rc;
+    void *out;
+    int64_t count = 0;
+
+    osty_rt_net_clear_status();
+    if (decoded[0] == '\0') {
+        osty_rt_net_set_error_text("failed to reverse lookup address", "address is empty", "runtime.net.lookup_addr");
+        return osty_rt_net_empty_list();
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST;
+    rc = getaddrinfo(decoded, NULL, &hints, &res);
+    if (rc != 0) {
+        osty_rt_net_set_gai_error("failed to parse reverse-lookup address", rc, "runtime.net.lookup_addr");
+        return osty_rt_net_empty_list();
+    }
+
+    out = osty_rt_list_new();
+    for (ai = res; ai != NULL; ai = ai->ai_next) {
+        char text[NI_MAXHOST];
+        rc = getnameinfo(ai->ai_addr, ai->ai_addrlen, text, sizeof(text), NULL, 0, NI_NAMEREQD);
+        if (rc != 0) {
+            continue;
+        }
+        osty_rt_list_push_ptr(out,
+                              osty_rt_string_dup_site(text, strlen(text), "runtime.net.lookup_addr.entry"));
+        count++;
+    }
+    freeaddrinfo(res);
+
+    if (count == 0) {
+        osty_rt_net_set_error_text("failed to reverse lookup address", "no names found", "runtime.net.lookup_addr");
+        return osty_rt_net_empty_list();
+    }
+    return out;
+}
+
+int64_t osty_rt_net_tcp_connect(const char *host, int64_t port) {
+    char host_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *decoded = osty_rt_net_decode_string_arg(host, host_buf);
+    osty_rt_net_clear_status();
+    return osty_rt_net_connect_impl(decoded, port, -1, "runtime.net.tcp_connect");
+}
+
+int64_t osty_rt_net_tcp_connect_timeout(const char *host, int64_t port, int64_t timeout_ms) {
+    char host_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *decoded = osty_rt_net_decode_string_arg(host, host_buf);
+    osty_rt_net_clear_status();
+    return osty_rt_net_connect_impl(decoded, port, timeout_ms, "runtime.net.tcp_connect_timeout");
+}
+
+int64_t osty_rt_net_tcp_listen(const char *host, int64_t port) {
+    char host_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    const char *decoded_host = osty_rt_net_decode_string_arg(host, host_buf);
+    const char *bind_host = (decoded_host[0] == '\0' || strcmp(decoded_host, "*") == 0) ? NULL : decoded_host;
+    char service[32];
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *ai;
+    int rc;
+    int last_errno = 0;
+
+    osty_rt_net_clear_status();
+    if (!osty_rt_net_service_string(port, service, sizeof(service), "runtime.net.tcp_listen")) {
+        return 0;
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    rc = getaddrinfo(bind_host, service, &hints, &res);
+    if (rc != 0) {
+        osty_rt_net_set_gai_error("failed to resolve listen address", rc, "runtime.net.tcp_listen");
+        return 0;
+    }
+
+    for (ai = res; ai != NULL; ai = ai->ai_next) {
+        int on = 1;
+        int fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd < 0) {
+            last_errno = errno;
+            continue;
+        }
+        osty_rt_net_prepare_stream_socket(fd);
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, (socklen_t)sizeof(on));
+        if (bind(fd, ai->ai_addr, ai->ai_addrlen) != 0) {
+            last_errno = errno;
+            close(fd);
+            continue;
+        }
+        if (listen(fd, SOMAXCONN) != 0) {
+            last_errno = errno;
+            close(fd);
+            continue;
+        }
+        freeaddrinfo(res);
+        return (int64_t)fd;
+    }
+
+    freeaddrinfo(res);
+    if (last_errno != 0) {
+        errno = last_errno;
+        osty_rt_net_set_errno_error("failed to listen", "runtime.net.tcp_listen");
+    } else {
+        osty_rt_net_set_error_text("failed to listen", "no bindable address", "runtime.net.tcp_listen");
+    }
+    return 0;
+}
+
+void *osty_rt_net_tcp_read(int64_t handle, int64_t max_bytes) {
+    unsigned char *buf;
+    ssize_t n;
+    void *out;
+
+    osty_rt_net_clear_status();
+    if (max_bytes < 0) {
+        osty_rt_net_set_error_text("failed to read from socket", "maxBytes must be non-negative", "runtime.net.tcp_read");
+        return osty_rt_net_empty_bytes();
+    }
+    if (max_bytes == 0) {
+        return osty_rt_net_empty_bytes();
+    }
+
+    buf = (unsigned char *)osty_rt_xmalloc((size_t)max_bytes, "runtime.net.tcp_read.buf");
+    do {
+        n = recv((int)handle, buf, (size_t)max_bytes, 0);
+    } while (n < 0 && errno == EINTR);
+    if (n < 0) {
+        free(buf);
+        osty_rt_net_set_errno_error("failed to read from socket", "runtime.net.tcp_read");
+        return osty_rt_net_empty_bytes();
+    }
+    out = osty_rt_bytes_dup_site(n == 0 ? NULL : buf, (size_t)n, "runtime.net.tcp_read");
+    free(buf);
+    return out;
+}
+
+void *osty_rt_net_tcp_read_exact(int64_t handle, int64_t want) {
+    unsigned char *buf;
+    size_t off = 0;
+    void *out;
+
+    osty_rt_net_clear_status();
+    if (want < 0) {
+        osty_rt_net_set_error_text("failed to read from socket", "byte count must be non-negative", "runtime.net.tcp_read_exact");
+        return osty_rt_net_empty_bytes();
+    }
+    if (want == 0) {
+        return osty_rt_net_empty_bytes();
+    }
+
+    buf = (unsigned char *)osty_rt_xmalloc((size_t)want, "runtime.net.tcp_read_exact.buf");
+    while (off < (size_t)want) {
+        ssize_t n;
+        do {
+            n = recv((int)handle, buf + off, (size_t)want - off, 0);
+        } while (n < 0 && errno == EINTR);
+        if (n < 0) {
+            free(buf);
+            osty_rt_net_set_errno_error("failed to read from socket", "runtime.net.tcp_read_exact");
+            return osty_rt_net_empty_bytes();
+        }
+        if (n == 0) {
+            free(buf);
+            osty_rt_net_set_error_text("failed to read from socket", "unexpected EOF", "runtime.net.tcp_read_exact");
+            return osty_rt_net_empty_bytes();
+        }
+        off += (size_t)n;
+    }
+    out = osty_rt_bytes_dup_site(buf, (size_t)want, "runtime.net.tcp_read_exact");
+    free(buf);
+    return out;
+}
+
+int64_t osty_rt_net_tcp_write(int64_t handle, void *raw_data) {
+    osty_rt_bytes *data = (osty_rt_bytes *)raw_data;
+    ssize_t written;
+    size_t len = (data == NULL || data->len <= 0) ? 0 : (size_t)data->len;
+
+    osty_rt_net_clear_status();
+    if (len == 0) {
+        return 0;
+    }
+
+    do {
+        written = send((int)handle, data->data, len, osty_rt_net_send_flags());
+    } while (written < 0 && errno == EINTR);
+    if (written < 0) {
+        osty_rt_net_set_errno_error("failed to write to socket", "runtime.net.tcp_write");
+        return 0;
+    }
+    return (int64_t)written;
+}
+
+void osty_rt_net_tcp_write_all(int64_t handle, void *raw_data) {
+    osty_rt_bytes *data = (osty_rt_bytes *)raw_data;
+    size_t len = (data == NULL || data->len <= 0) ? 0 : (size_t)data->len;
+    size_t off = 0;
+
+    osty_rt_net_clear_status();
+    while (off < len) {
+        ssize_t written;
+        do {
+            written = send((int)handle, data->data + off, len - off, osty_rt_net_send_flags());
+        } while (written < 0 && errno == EINTR);
+        if (written < 0) {
+            osty_rt_net_set_errno_error("failed to write to socket", "runtime.net.tcp_write_all");
+            return;
+        }
+        if (written == 0) {
+            osty_rt_net_set_error_text("failed to write to socket", "socket write made no progress", "runtime.net.tcp_write_all");
+            return;
+        }
+        off += (size_t)written;
+    }
+}
+
+void osty_rt_net_tcp_flush(int64_t handle) {
+    (void)handle;
+    osty_rt_net_clear_status();
+}
+
+void osty_rt_net_tcp_close(int64_t handle) {
+    osty_rt_net_clear_status();
+    if (close((int)handle) != 0) {
+        osty_rt_net_set_errno_error("failed to close socket", "runtime.net.tcp_close");
+    }
+}
+
+void *osty_rt_net_tcp_local_addr(int64_t handle) {
+    struct sockaddr_storage addr;
+    socklen_t len = (socklen_t)sizeof(addr);
+    osty_rt_net_clear_status();
+    if (getsockname((int)handle, (struct sockaddr *)&addr, &len) != 0) {
+        osty_rt_net_set_errno_error("failed to read local socket address", "runtime.net.tcp_local_addr");
+        return osty_rt_net_empty_string();
+    }
+    return osty_rt_net_sockaddr_text((struct sockaddr *)&addr, len, "runtime.net.tcp_local_addr");
+}
+
+void *osty_rt_net_tcp_peer_addr(int64_t handle) {
+    struct sockaddr_storage addr;
+    socklen_t len = (socklen_t)sizeof(addr);
+    osty_rt_net_clear_status();
+    if (getpeername((int)handle, (struct sockaddr *)&addr, &len) != 0) {
+        osty_rt_net_set_errno_error("failed to read peer socket address", "runtime.net.tcp_peer_addr");
+        return osty_rt_net_empty_string();
+    }
+    return osty_rt_net_sockaddr_text((struct sockaddr *)&addr, len, "runtime.net.tcp_peer_addr");
+}
+
+void osty_rt_net_tcp_set_read_timeout(int64_t handle, int64_t timeout_ms) {
+    osty_rt_net_clear_status();
+    osty_rt_net_apply_timeout((int)handle, timeout_ms, SO_RCVTIMEO, "runtime.net.tcp_set_read_timeout");
+}
+
+void osty_rt_net_tcp_set_write_timeout(int64_t handle, int64_t timeout_ms) {
+    osty_rt_net_clear_status();
+    osty_rt_net_apply_timeout((int)handle, timeout_ms, SO_SNDTIMEO, "runtime.net.tcp_set_write_timeout");
+}
+
+void osty_rt_net_tcp_set_nodelay(int64_t handle, bool on) {
+    int flag = on ? 1 : 0;
+    osty_rt_net_clear_status();
+    if (setsockopt((int)handle, IPPROTO_TCP, TCP_NODELAY, &flag, (socklen_t)sizeof(flag)) != 0) {
+        osty_rt_net_set_errno_error("failed to configure TCP_NODELAY", "runtime.net.tcp_set_nodelay");
+    }
+}
+
+void osty_rt_net_tcp_set_keepalive(int64_t handle, bool on) {
+    int flag = on ? 1 : 0;
+    osty_rt_net_clear_status();
+    if (setsockopt((int)handle, SOL_SOCKET, SO_KEEPALIVE, &flag, (socklen_t)sizeof(flag)) != 0) {
+        osty_rt_net_set_errno_error("failed to configure SO_KEEPALIVE", "runtime.net.tcp_set_keepalive");
+    }
+}
+
+int64_t osty_rt_net_tcp_accept(int64_t handle) {
+    int fd;
+    osty_rt_net_clear_status();
+    do {
+        fd = accept((int)handle, NULL, NULL);
+    } while (fd < 0 && errno == EINTR);
+    if (fd < 0) {
+        osty_rt_net_set_errno_error("failed to accept TCP connection", "runtime.net.tcp_accept");
+        return 0;
+    }
+    osty_rt_net_prepare_stream_socket(fd);
+    return (int64_t)fd;
+}
+
+void *osty_rt_net_tcp_listener_local_addr(int64_t handle) {
+    return osty_rt_net_tcp_local_addr(handle);
+}
+
+void osty_rt_net_tcp_listener_close(int64_t handle) {
+    osty_rt_net_tcp_close(handle);
+}
+
+#endif
 
 static uint64_t osty_rt_test_gen_mix_u64(uint64_t x) {
     x += 0x9E3779B97F4A7C15ULL;

--- a/internal/ir/lower_stdlib_test.go
+++ b/internal/ir/lower_stdlib_test.go
@@ -14,25 +14,7 @@ import (
 // LowerFnDecl is usable with stdlib-owned resolve data rather than to
 // lock in an exact IR shape that might legitimately change.
 func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
-	reg := stdlib.LoadCached()
-	fn := reg.LookupFnDecl("strings", "compare")
-	if fn == nil {
-		t.Fatalf("stdlib.LookupFnDecl(strings, compare) = nil — stdlib stubs missing?")
-	}
-	mod := reg.Modules["strings"]
-	if mod == nil || mod.Package == nil || len(mod.Package.Files) == 0 {
-		t.Fatalf("stdlib strings module missing parsed package")
-	}
-	pf := mod.Package.Files[0]
-	res := &resolve.Result{
-		RefsByID:      pf.RefsByID,
-		TypeRefsByID:  pf.TypeRefsByID,
-		RefIdents:     pf.RefIdents,
-		TypeRefIdents: pf.TypeRefIdents,
-		FileScope:     pf.FileScope,
-	}
-
-	out, issues := LowerFnDecl("stdlib_strings", fn, res, nil)
+	out, issues := lowerStdlibFn(t, "strings", "compare")
 	if out == nil {
 		t.Fatalf("LowerFnDecl returned nil for strings.compare")
 	}
@@ -49,4 +31,83 @@ func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
 	for _, issue := range issues {
 		t.Logf("non-fatal lowering issue: %v", issue)
 	}
+}
+
+func TestLowerFnDeclLowersStdlibNetSplitHostPort(t *testing.T) {
+	out, issues := lowerStdlibFn(t, "net", "splitHostPort")
+	if out == nil {
+		t.Fatalf("LowerFnDecl returned nil for net.splitHostPort")
+	}
+	if out.Name != "splitHostPort" {
+		t.Errorf("out.Name = %q, want splitHostPort", out.Name)
+	}
+	if out.Body == nil {
+		t.Errorf("out.Body = nil, want lowered block")
+	}
+	if len(out.Params) != 1 {
+		t.Errorf("out.Params = %d, want 1", len(out.Params))
+	}
+	for _, issue := range issues {
+		t.Logf("non-fatal lowering issue: %v", issue)
+	}
+}
+
+func TestLowerFnDeclLowersStdlibNetResolve(t *testing.T) {
+	out, issues := lowerStdlibFn(t, "net", "resolve")
+	if out == nil {
+		t.Fatalf("LowerFnDecl returned nil for net.resolve")
+	}
+	if out.Name != "resolve" {
+		t.Errorf("out.Name = %q, want resolve", out.Name)
+	}
+	if out.Body == nil {
+		t.Errorf("out.Body = nil, want lowered block")
+	}
+	if len(out.Params) != 1 {
+		t.Errorf("out.Params = %d, want 1", len(out.Params))
+	}
+	for _, issue := range issues {
+		t.Logf("non-fatal lowering issue: %v", issue)
+	}
+}
+
+func TestLowerFnDeclLowersStdlibNetTcpConnect(t *testing.T) {
+	out, issues := lowerStdlibFn(t, "net", "tcpConnect")
+	if out == nil {
+		t.Fatalf("LowerFnDecl returned nil for net.tcpConnect")
+	}
+	if out.Name != "tcpConnect" {
+		t.Errorf("out.Name = %q, want tcpConnect", out.Name)
+	}
+	if out.Body == nil {
+		t.Errorf("out.Body = nil, want lowered block")
+	}
+	if len(out.Params) != 1 {
+		t.Errorf("out.Params = %d, want 1", len(out.Params))
+	}
+	for _, issue := range issues {
+		t.Logf("non-fatal lowering issue: %v", issue)
+	}
+}
+
+func lowerStdlibFn(t *testing.T, module, name string) (*FnDecl, []error) {
+	t.Helper()
+	reg := stdlib.LoadCached()
+	fn := reg.LookupFnDecl(module, name)
+	if fn == nil {
+		t.Fatalf("stdlib.LookupFnDecl(%s, %s) = nil — stdlib stubs missing?", module, name)
+	}
+	mod := reg.Modules[module]
+	if mod == nil || mod.Package == nil || len(mod.Package.Files) == 0 {
+		t.Fatalf("stdlib %s module missing parsed package", module)
+	}
+	pf := mod.Package.Files[0]
+	res := &resolve.Result{
+		RefsByID:      pf.RefsByID,
+		TypeRefsByID:  pf.TypeRefsByID,
+		RefIdents:     pf.RefIdents,
+		TypeRefIdents: pf.TypeRefIdents,
+		FileScope:     pf.FileScope,
+	}
+	return LowerFnDecl("stdlib_"+module, fn, res, nil)
 }

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7301,6 +7301,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdNetCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitStdIoCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,6 +54,7 @@ type generator struct {
 	stdBytesAliases      map[string]bool
 	stdStringsAliases    map[string]bool
 	stdEnvAliases        map[string]bool
+	stdNetAliases        map[string]bool
 	runtimeDecls         map[string]runtimeDecl
 	runtimeDeclOrder     []string
 	traceHelpers         map[string]string

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -274,6 +274,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
+		g.stdNetAliases = collectStdNetAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -307,6 +308,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdBytesAliases = collectStdBytesAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
+	g.stdNetAliases = collectStdNetAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -67,6 +67,27 @@ func collectStdBytesAliases(file *ast.File) map[string]bool {
 	return out
 }
 
+func collectStdNetAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "net" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "net"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
 func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 	if call == nil || len(g.stdBytesAliases) == 0 {
 		return value{}, false, nil
@@ -501,6 +522,54 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		return v, true, nil
 	}
 	return value{}, false, nil
+}
+
+func (g *generator) emitStdNetCall(call *ast.CallExpr) (value, bool, error) {
+	if call == nil || len(g.stdNetAliases) == 0 {
+		return value{}, false, nil
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field == nil || field.IsOptional {
+		return value{}, false, nil
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdNetAliases[alias.Name] {
+		return value{}, false, nil
+	}
+	sig := g.functions[field.Name]
+	if sig == nil {
+		return value{}, false, nil
+	}
+	if sig.ret == "" || sig.ret == "void" {
+		return value{}, true, unsupportedf("call", "function %q has no return value", sig.name)
+	}
+	if g.hasVisibleSafepointRoots() {
+		emitter := g.toOstyEmitter()
+		g.emitGCSafepointKind(emitter, safepointKindCall)
+		g.takeOstyEmitter(emitter)
+	}
+	g.pushScope()
+	args, err := g.userCallArgs(sig, nil, call)
+	if err != nil {
+		g.popScope()
+		return value{}, true, err
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, sig.ret, sig.irName, args)
+	g.takeOstyEmitter(emitter)
+	g.popScope()
+	ret := fromOstyValue(out)
+	ret.listElemTyp = sig.retListElemTyp
+	ret.listElemString = sig.retListString
+	ret.mapKeyTyp = sig.retMapKeyTyp
+	ret.mapValueTyp = sig.retMapValueTyp
+	ret.mapKeyString = sig.retMapKeyString
+	ret.setElemTyp = sig.retSetElemTyp
+	ret.setElemString = sig.retSetElemString
+	ret.sourceType = sig.returnSourceType
+	ret.gcManaged = valueNeedsManagedRoot(ret)
+	ret.rootPaths = g.rootPathsForType(sig.ret)
+	return ret, true, nil
 }
 
 func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/stdlib_shim_test.go
+++ b/internal/llvmgen/stdlib_shim_test.go
@@ -64,6 +64,18 @@ fn main() {
 	}
 }
 
+func TestStdNetAliasCollectorRespectsRename(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.net as network
+
+fn main() {}
+`)
+
+	aliases := collectStdNetAliases(file)
+	if !aliases["network"] {
+		t.Fatalf("collectStdNetAliases missing renamed alias: %#v", aliases)
+	}
+}
+
 func TestStdStringsAliasRespectsRename(t *testing.T) {
 	file := parseLLVMGenFile(t, `use std.strings as s
 

--- a/internal/stdlib/modules/net.osty
+++ b/internal/stdlib/modules/net.osty
@@ -2,9 +2,10 @@
 //
 // Pure-Osty surface:
 //   - Ipv4Addr / Ipv6Addr / IpAddr  — parsing, classification, formatting
-//   - SocketAddr                    — (ip, port) pairs with text round-trips
+//   - SocketAddr / Addr             — parsed socket addrs and ergonomic host:port pairs
 //   - Ipv4Net                       — CIDR blocks (mask, network, broadcast, contains)
-//   - splitHostPort / parseSocketAddr / parseCidr
+//   - splitHostPort / parseSocketAddr / parseAddr / parseCidr
+//   - connect / connectTimeout / listen / resolve / resolveAll convenience wrappers
 //
 // Runtime-bridged surface (body-less declarations, gen supplies Go):
 //   - TcpStream / TcpListener       — TCP client and server
@@ -14,6 +15,30 @@
 
 use std.strings
 use std.error
+use c "osty_runtime" as rt {
+    fn osty_rt_net_failed() -> Bool
+    fn osty_rt_net_last_error() -> String
+    fn osty_rt_net_lookup_text(host: String) -> List<String>
+    fn osty_rt_net_lookup_addr(ip: String) -> List<String>
+    fn osty_rt_net_tcp_connect(host: String, port: Int) -> Int64
+    fn osty_rt_net_tcp_connect_timeout(host: String, port: Int, timeoutMs: Int) -> Int64
+    fn osty_rt_net_tcp_listen(host: String, port: Int) -> Int64
+    fn osty_rt_net_tcp_read(handle: Int64, maxBytes: Int) -> Bytes
+    fn osty_rt_net_tcp_read_exact(handle: Int64, n: Int) -> Bytes
+    fn osty_rt_net_tcp_write(handle: Int64, data: Bytes) -> Int
+    fn osty_rt_net_tcp_write_all(handle: Int64, data: Bytes)
+    fn osty_rt_net_tcp_flush(handle: Int64)
+    fn osty_rt_net_tcp_close(handle: Int64)
+    fn osty_rt_net_tcp_local_addr(handle: Int64) -> String
+    fn osty_rt_net_tcp_peer_addr(handle: Int64) -> String
+    fn osty_rt_net_tcp_set_read_timeout(handle: Int64, timeoutMs: Int)
+    fn osty_rt_net_tcp_set_write_timeout(handle: Int64, timeoutMs: Int)
+    fn osty_rt_net_tcp_set_nodelay(handle: Int64, on: Bool)
+    fn osty_rt_net_tcp_set_keepalive(handle: Int64, on: Bool)
+    fn osty_rt_net_tcp_accept(handle: Int64) -> Int64
+    fn osty_rt_net_tcp_listener_local_addr(handle: Int64) -> String
+    fn osty_rt_net_tcp_listener_close(handle: Int64)
+}
 
 // ── IPv4 addresses ────────────────────────────────────────────────────────────
 
@@ -85,6 +110,30 @@ pub struct Ipv4Addr {
         false
     }
 
+    pub fn isShared(self) -> Bool {
+        self.a == 100 && self.b >= 64 && self.b <= 127
+    }
+
+    pub fn isBenchmarking(self) -> Bool {
+        self.a == 198 && (self.b == 18 || self.b == 19)
+    }
+
+    pub fn isReserved(self) -> Bool {
+        if self.a == 0 {
+            return true
+        }
+        if self.a == 192 && self.b == 0 && self.c == 0 && self.d != 9 && self.d != 10 {
+            return true
+        }
+        if self.a == 192 && self.b == 88 && self.c == 99 {
+            return true
+        }
+        if self.a >= 240 && !self.isBroadcast() {
+            return true
+        }
+        false
+    }
+
     pub fn isGlobalUnicast(self) -> Bool {
         if self.isLoopback() {
             return false
@@ -107,6 +156,15 @@ pub struct Ipv4Addr {
         if self.isDocumentation() {
             return false
         }
+        if self.isShared() {
+            return false
+        }
+        if self.isBenchmarking() {
+            return false
+        }
+        if self.isReserved() {
+            return false
+        }
         true
     }
 }
@@ -126,6 +184,9 @@ pub struct Ipv6Addr {
     pub groups: List<Int>,
 
     pub fn toString(self) -> String {
+        if let Some(addr) = self.toMappedIpv4() {
+            return "::ffff:{addr}"
+        }
         let g = self.groups
         let mut bestStart = -1
         let mut bestLen = 0
@@ -213,6 +274,14 @@ pub struct Ipv6Addr {
         (self.groups[0] & 0xFFC0) == 0xFE80
     }
 
+    pub fn isUniqueLocal(self) -> Bool {
+        (self.groups[0] & 0xFE00) == 0xFC00
+    }
+
+    pub fn isDocumentation(self) -> Bool {
+        self.groups[0] == 0x2001 && self.groups[1] == 0x0DB8
+    }
+
     pub fn isMappedIpv4(self) -> Bool {
         let g = self.groups
         g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 &&
@@ -232,6 +301,31 @@ pub struct Ipv6Addr {
         } else {
             None
         }
+    }
+
+    pub fn isGlobalUnicast(self) -> Bool {
+        if let Some(addr) = self.toMappedIpv4() {
+            return addr.isGlobalUnicast()
+        }
+        if self.isLoopback() {
+            return false
+        }
+        if self.isUnspecified() {
+            return false
+        }
+        if self.isMulticast() {
+            return false
+        }
+        if self.isLinkLocal() {
+            return false
+        }
+        if self.isUniqueLocal() {
+            return false
+        }
+        if self.isDocumentation() {
+            return false
+        }
+        true
     }
 }
 
@@ -266,6 +360,13 @@ pub enum IpAddr {
         match self {
             V4(addr) -> addr.isMulticast(),
             V6(addr) -> addr.isMulticast(),
+        }
+    }
+
+    pub fn isGlobalUnicast(self) -> Bool {
+        match self {
+            V4(addr) -> addr.isGlobalUnicast(),
+            V6(addr) -> addr.isGlobalUnicast(),
         }
     }
 
@@ -317,6 +418,23 @@ pub struct SocketAddr {
 
     pub fn isV6(self) -> Bool {
         self.ip.isV6()
+    }
+}
+
+pub struct Addr {
+    pub host: String,
+    pub port: Int,
+
+    pub fn toString(self) -> String {
+        if strings.contains(self.host, ":") {
+            return "[{self.host}]:{self.port}"
+        }
+        "{self.host}:{self.port}"
+    }
+
+    pub fn toSocketAddr(self) -> Result<SocketAddr, Error> {
+        let ip = parseIp(self.host)?
+        Ok(SocketAddr { ip, port: self.port })
     }
 }
 
@@ -435,12 +553,15 @@ pub fn parseIp(text: String) -> Result<IpAddr, Error> {
 
 pub fn parseSocketAddr(text: String) -> Result<SocketAddr, Error> {
     let (host, portStr) = splitHostPort(text)?
-    let port = parseDecInt(portStr)?
-    if port < 0 || port > 65535 {
-        return Err(error.new("net: port out of range: {portStr}"))
-    }
+    let port = parsePort(portStr)?
     let ip = parseIp(host)?
     Ok(SocketAddr { ip, port })
+}
+
+pub fn parseAddr(text: String) -> Result<Addr, Error> {
+    let (host, portStr) = splitHostPort(text)?
+    let port = parsePort(portStr)?
+    Ok(Addr { host, port })
 }
 
 pub fn parseCidr(text: String) -> Result<Ipv4Net, Error> {
@@ -473,8 +594,17 @@ pub fn splitHostPort(hostport: String) -> Result<(String, String), Error> {
         if rest.isEmpty() || rest.chars()[0] != ':' {
             return Err(error.new("net: missing port after ] in address: {hostport}"))
         }
+        if host.isEmpty() {
+            return Err(error.new("net: missing host in address: {hostport}"))
+        }
         let port = rest[1..]
+        if port.isEmpty() {
+            return Err(error.new("net: missing port in address: {hostport}"))
+        }
         return Ok((host, port))
+    }
+    if countChar(hostport, ':') > 1 {
+        return Err(error.new("net: IPv6 addresses with ports must use [host]:port: {hostport}"))
     }
     let lastColon = lastIndexOfChar(hostport, ':')
     if lastColon == -1 {
@@ -482,43 +612,212 @@ pub fn splitHostPort(hostport: String) -> Result<(String, String), Error> {
     }
     let host = hostport[0..lastColon]
     let port = hostport[lastColon + 1..]
+    if host.isEmpty() {
+        return Err(error.new("net: missing host in address: {hostport}"))
+    }
+    if port.isEmpty() {
+        return Err(error.new("net: missing port in address: {hostport}"))
+    }
     Ok((host, port))
+}
+
+pub fn resolve(addr: String) -> Result<Addr, Error> {
+    let parsed = parseAddr(addr)?
+    match parseIp(parsed.host) {
+        Ok(ip) -> Ok(Addr { host: ip.toString(), port: parsed.port }),
+        Err(_) -> {
+            let ips = lookup(parsed.host)?
+            if ips.isEmpty() {
+                return Err(error.new("net: no addresses found for host: {parsed.host}"))
+            }
+            Ok(Addr { host: ips[0].toString(), port: parsed.port })
+        },
+    }
+}
+
+pub fn resolveAll(host: String) -> Result<List<Addr>, Error> {
+    match parseIp(host) {
+        Ok(ip) -> Ok([Addr { host: ip.toString(), port: 0 }]),
+        Err(_) -> {
+            let ips = lookup(host)?
+            let mut out: List<Addr> = []
+            for ip in ips {
+                out.push(Addr { host: ip.toString(), port: 0 })
+            }
+            Ok(out)
+        },
+    }
 }
 
 // ── DNS (runtime-bridged) ─────────────────────────────────────────────────────
 
-pub fn lookup(host: String) -> Result<List<IpAddr>, Error>
+pub fn lookup(host: String) -> Result<List<IpAddr>, Error> {
+    let texts = rt.osty_rt_net_lookup_text(host)
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    let mut out: List<IpAddr> = []
+    for text in texts {
+        out.push(parseIp(text)?)
+    }
+    Ok(out)
+}
 
-pub fn lookupAddr(ip: IpAddr) -> Result<List<String>, Error>
+pub fn lookupAddr(ip: IpAddr) -> Result<List<String>, Error> {
+    netStringListResult(rt.osty_rt_net_lookup_addr(ip.toString()))
+}
 
 // ── TCP (runtime-bridged) ─────────────────────────────────────────────────────
 
+pub type TcpConn = TcpStream
+
 pub struct TcpStream {
-    pub fn read(self, maxBytes: Int) -> Result<Bytes, Error>
-    pub fn readExact(self, n: Int) -> Result<Bytes, Error>
-    pub fn write(self, data: Bytes) -> Result<Int, Error>
-    pub fn writeAll(self, data: Bytes) -> Result<(), Error>
-    pub fn flush(self) -> Result<(), Error>
-    pub fn close(self) -> Result<(), Error>
-    pub fn localAddr(self) -> Result<SocketAddr, Error>
-    pub fn peerAddr(self) -> Result<SocketAddr, Error>
-    pub fn setReadTimeout(self, ms: Int?) -> Result<(), Error>
-    pub fn setWriteTimeout(self, ms: Int?) -> Result<(), Error>
-    pub fn setNoDelay(self, on: Bool) -> Result<(), Error>
-    pub fn setKeepAlive(self, on: Bool) -> Result<(), Error>
+    rawHandle: Int64,
+
+    pub fn read(self, maxBytes: Int) -> Result<Bytes, Error> {
+        netBytesResult(rt.osty_rt_net_tcp_read(self.rawHandle, maxBytes))
+    }
+
+    pub fn readExact(self, n: Int) -> Result<Bytes, Error> {
+        netBytesResult(rt.osty_rt_net_tcp_read_exact(self.rawHandle, n))
+    }
+
+    pub fn write(self, data: Bytes) -> Result<Int, Error> {
+        netIntResult(rt.osty_rt_net_tcp_write(self.rawHandle, data))
+    }
+
+    pub fn writeAll(self, data: Bytes) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_write_all(self.rawHandle, data)
+        netUnitResult()
+    }
+
+    pub fn flush(self) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_flush(self.rawHandle)
+        netUnitResult()
+    }
+
+    pub fn close(self) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_close(self.rawHandle)
+        netUnitResult()
+    }
+
+    pub fn localAddr(self) -> Result<SocketAddr, Error> {
+        let text = rt.osty_rt_net_tcp_local_addr(self.rawHandle)
+        if rt.osty_rt_net_failed() {
+            return Err(netError())
+        }
+        parseSocketAddr(text)
+    }
+
+    pub fn peerAddr(self) -> Result<SocketAddr, Error> {
+        let text = rt.osty_rt_net_tcp_peer_addr(self.rawHandle)
+        if rt.osty_rt_net_failed() {
+            return Err(netError())
+        }
+        parseSocketAddr(text)
+    }
+
+    pub fn setReadTimeout(self, ms: Int?) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_set_read_timeout(self.rawHandle, netTimeoutValue(ms))
+        netUnitResult()
+    }
+
+    pub fn setWriteTimeout(self, ms: Int?) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_set_write_timeout(self.rawHandle, netTimeoutValue(ms))
+        netUnitResult()
+    }
+
+    pub fn setNoDelay(self, on: Bool) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_set_nodelay(self.rawHandle, on)
+        netUnitResult()
+    }
+
+    pub fn setKeepAlive(self, on: Bool) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_set_keepalive(self.rawHandle, on)
+        netUnitResult()
+    }
+
+    pub fn send(self, data: Bytes) -> Result<Int, Error> {
+        self.write(data)
+    }
+
+    pub fn sendAll(self, data: Bytes) -> Result<(), Error> {
+        self.writeAll(data)
+    }
+
+    pub fn recv(self, maxBytes: Int) -> Result<Bytes, Error> {
+        self.read(maxBytes)
+    }
+
+    pub fn remoteAddr(self) -> Result<Addr, Error> {
+        let addr = self.peerAddr()?
+        Ok(socketAddrToAddr(addr))
+    }
 }
 
 pub struct TcpListener {
-    pub fn accept(self) -> Result<TcpStream, Error>
-    pub fn localAddr(self) -> Result<SocketAddr, Error>
-    pub fn close(self) -> Result<(), Error>
+    rawHandle: Int64,
+
+    pub fn accept(self) -> Result<TcpStream, Error> {
+        let handle = rt.osty_rt_net_tcp_accept(self.rawHandle)
+        if rt.osty_rt_net_failed() {
+            return Err(netError())
+        }
+        Ok(TcpStream { rawHandle: handle })
+    }
+
+    pub fn localAddr(self) -> Result<SocketAddr, Error> {
+        let text = rt.osty_rt_net_tcp_listener_local_addr(self.rawHandle)
+        if rt.osty_rt_net_failed() {
+            return Err(netError())
+        }
+        parseSocketAddr(text)
+    }
+
+    pub fn close(self) -> Result<(), Error> {
+        rt.osty_rt_net_tcp_listener_close(self.rawHandle)
+        netUnitResult()
+    }
 }
 
-pub fn tcpConnect(addr: String) -> Result<TcpStream, Error>
+pub fn tcpConnect(addr: String) -> Result<TcpStream, Error> {
+    let parsed = parseAddr(addr)?
+    let handle = rt.osty_rt_net_tcp_connect(parsed.host, parsed.port)
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(TcpStream { rawHandle: handle })
+}
 
-pub fn tcpConnectTimeout(addr: String, timeoutMs: Int) -> Result<TcpStream, Error>
+pub fn tcpConnectTimeout(addr: String, timeoutMs: Int) -> Result<TcpStream, Error> {
+    let parsed = parseAddr(addr)?
+    let handle = rt.osty_rt_net_tcp_connect_timeout(parsed.host, parsed.port, timeoutMs)
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(TcpStream { rawHandle: handle })
+}
 
-pub fn tcpListen(addr: String) -> Result<TcpListener, Error>
+pub fn tcpListen(addr: String) -> Result<TcpListener, Error> {
+    let parsed = parseAddr(addr)?
+    let handle = rt.osty_rt_net_tcp_listen(parsed.host, parsed.port)
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(TcpListener { rawHandle: handle })
+}
+
+pub fn connect(addr: String) -> Result<TcpConn, Error> {
+    tcpConnect(addr)
+}
+
+pub fn connectTimeout(addr: String, timeoutMs: Int) -> Result<TcpConn, Error> {
+    tcpConnectTimeout(addr, timeoutMs)
+}
+
+pub fn listen(addr: String) -> Result<TcpListener, Error> {
+    tcpListen(addr)
+}
 
 // ── UDP (runtime-bridged) ─────────────────────────────────────────────────────
 
@@ -539,12 +838,77 @@ pub fn udpBind(addr: String) -> Result<UdpSocket, Error>
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
+fn socketAddrToAddr(addr: SocketAddr) -> Addr {
+    Addr { host: addr.ip.toString(), port: addr.port }
+}
+
+fn netError() -> Error {
+    error.new(rt.osty_rt_net_last_error())
+}
+
+fn netUnitResult() -> Result<(), Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(())
+}
+
+fn netBytesResult(data: Bytes) -> Result<Bytes, Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(data)
+}
+
+fn netStringResult(text: String) -> Result<String, Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(text)
+}
+
+fn netStringListResult(items: List<String>) -> Result<List<String>, Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(items)
+}
+
+fn netIntResult(n: Int) -> Result<Int, Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(n)
+}
+
+fn netHandleResult(handle: Int64) -> Result<Int64, Error> {
+    if rt.osty_rt_net_failed() {
+        return Err(netError())
+    }
+    Ok(handle)
+}
+
+fn netTimeoutValue(ms: Int?) -> Int {
+    match ms {
+        Some(timeout) -> timeout,
+        None          -> -1,
+    }
+}
+
 fn parseOctet(s: String) -> Result<Int, Error> {
     let n = parseDecInt(s)?
     if n < 0 || n > 255 {
         return Err(error.new("net: octet out of range: {s}"))
     }
     Ok(n)
+}
+
+fn parsePort(s: String) -> Result<Int, Error> {
+    let port = parseDecInt(s)?
+    if port < 0 || port > 65535 {
+        return Err(error.new("net: port out of range: {s}"))
+    }
+    Ok(port)
 }
 
 fn parseDecInt(s: String) -> Result<Int, Error> {
@@ -569,15 +933,28 @@ fn parseDecInt(s: String) -> Result<Int, Error> {
 fn parseHexGroups(text: String) -> Result<List<Int>, Error> {
     let parts = strings.split(text, ":")
     let mut groups: List<Int> = []
-    for part in parts {
+    let mut i = 0
+    for i < parts.len() {
+        let part = parts[i]
         if part.isEmpty() {
             return Err(error.new("net: empty group in IPv6 address"))
+        }
+        if strings.contains(part, ".") {
+            if i != parts.len() - 1 {
+                return Err(error.new("net: embedded IPv4 must be last group in IPv6 address: {text}"))
+            }
+            let addr = parseIpv4(part)?
+            groups.push(((addr.a & 0xFF) << 8) | (addr.b & 0xFF))
+            groups.push(((addr.c & 0xFF) << 8) | (addr.d & 0xFF))
+            i = i + 1
+            continue
         }
         let v = parseHexInt(part)?
         if v < 0 || v > 0xFFFF {
             return Err(error.new("net: group out of range: {part}"))
         }
         groups.push(v)
+        i = i + 1
     }
     Ok(groups)
 }
@@ -665,6 +1042,17 @@ fn lastIndexOfChar(s: String, target: Char) -> Int {
         i = i - 1
     }
     -1
+}
+
+fn countChar(s: String, target: Char) -> Int {
+    let chars = s.chars()
+    let mut count = 0
+    for c in chars {
+        if c == target {
+            count = count + 1
+        }
+    }
+    count
 }
 
 fn cidrMask(prefix: Int) -> Int {

--- a/internal/stdlib/net_test.go
+++ b/internal/stdlib/net_test.go
@@ -1,0 +1,147 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestNetModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	if reg.Modules["net"] == nil {
+		t.Fatal("stdlib net module missing")
+	}
+
+	for _, name := range []string{
+		"lookup",
+		"lookupAddr",
+		"parseIpv4",
+		"parseIpv6",
+		"parseIp",
+		"parseAddr",
+		"parseSocketAddr",
+		"parseCidr",
+		"splitHostPort",
+		"resolve",
+		"resolveAll",
+		"tcpConnect",
+		"tcpConnectTimeout",
+		"tcpListen",
+		"connect",
+		"connectTimeout",
+		"listen",
+	} {
+		fn := reg.LookupFnDecl("net", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(net, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("net.%s body = nil, want pure-Osty implementation", name)
+		}
+	}
+
+	for _, name := range []string{
+		"udpBind",
+	} {
+		fn := reg.LookupFnDecl("net", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(net, %s) = nil", name)
+		}
+		if fn.Body != nil {
+			t.Fatalf("net.%s has a source body, want runtime bridge declaration", name)
+		}
+	}
+
+	for _, tc := range []struct {
+		typeName   string
+		methodName string
+	}{
+		{"Ipv4Addr", "isGlobalUnicast"},
+		{"Ipv6Addr", "isGlobalUnicast"},
+		{"IpAddr", "isGlobalUnicast"},
+		{"TcpStream", "send"},
+		{"TcpStream", "recv"},
+		{"TcpStream", "remoteAddr"},
+	} {
+		fn := reg.LookupMethodDecl("net", tc.typeName, tc.methodName)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(net, %s, %s) = nil", tc.typeName, tc.methodName)
+		}
+		if fn.Body == nil {
+			t.Fatalf("net.%s.%s body = nil, want pure-Osty implementation", tc.typeName, tc.methodName)
+		}
+	}
+}
+
+func TestNetModuleSourcePinsAddressQualityGuards(t *testing.T) {
+	src := netModuleSource(t)
+	for _, want := range []string{
+		"::ffff:{addr}",
+		"self.a == 100 && self.b >= 64 && self.b <= 127",
+		"self.a == 198 && (self.b == 18 || self.b == 19)",
+		"embedded IPv4 must be last group in IPv6 address",
+		"if countChar(hostport, ':') > 1",
+		"IPv6 addresses with ports must use [host]:port",
+		"if port.isEmpty()",
+		"addr.isGlobalUnicast()",
+		"pub struct Addr",
+		"pub type TcpConn = TcpStream",
+		"pub fn connect(addr: String)",
+		"pub fn resolve(addr: String)",
+		`use c "osty_runtime" as rt`,
+		"rt.osty_rt_net_tcp_connect",
+		"rt.osty_rt_net_lookup_text",
+		"self.write(data)",
+		"socketAddrToAddr(addr)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.net source missing %q", want)
+		}
+	}
+}
+
+func TestNetImportResolvesAddressHelpers(t *testing.T) {
+	src := `
+use std.net
+
+pub fn demo() -> Result<String, Error> {
+    let parsed = net.parseAddr("[::1]:443")?
+    let resolved = net.resolve("127.0.0.1:443")?
+    let all = net.resolveAll("127.0.0.1")?
+    let v6 = net.parseIpv6("::ffff:192.0.2.1")?
+    let ip = v6.toIp()
+    let loopback = net.parseIpv4("127.0.0.1")?
+    let (host, port) = net.splitHostPort("[::1]:443")?
+    let sock = net.parseSocketAddr("[::1]:443")?
+    let cidr = net.parseCidr("198.18.0.0/15")?
+    let conn = net.connect("127.0.0.1:443")?
+    let _ = conn.send("ping".toBytes())?
+    let _ = conn.remoteAddr()?
+    Ok("{parsed.toString()}:{resolved.toString()}:{all.len()}:{v6.toString()}:{ip.isGlobalUnicast()}:{host}:{port}:{sock.toString()}:{cidr.contains(loopback)}")
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	res := resolve.ResolveFileDefault(file, Load())
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		t.Errorf("resolver rejected std.net fixture: %s: %s", d.Code, d.Message)
+	}
+}
+
+func netModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["net"]
+	if mod == nil {
+		t.Fatal("stdlib net module missing")
+	}
+	return string(mod.Source)
+}


### PR DESCRIPTION
## Summary
- add a runtime-backed std.net TCP/DNS bridge through the osty_runtime C ABI
- wire std.net connect/listen/lookup surfaces to the new runtime-backed implementation
- extend std.net focused stdlib and lowering coverage for the new path

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)