### PR TITLE
feat: wire std.compress gzip runtime

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -1083,6 +1083,35 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryStdCompressGzipRoundTrip(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.compress as compress
+
+fn main() {
+    let payload = Bytes.from("hello".bytes())
+    let encoded = compress.gzip.encode(payload)
+    match compress.gzip.decode(encoded) {
+        Ok(decoded) -> println(decoded.len()),
+        Err(_) -> println(0),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "5\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinaryStdEnvGetReadsProcessEnv(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -28,11 +28,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#if !defined(_WIN32)
+#include <zlib.h>
+#endif
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
@@ -4706,6 +4711,8 @@ bool osty_rt_bytes_is_valid_utf8(void *raw_bytes);
 const char *osty_rt_bytes_to_string(void *raw_bytes);
 uint8_t osty_rt_bytes_get(void *raw_bytes, int64_t index);
 void *osty_rt_bytes_slice(void *raw_bytes, int64_t start, int64_t end);
+void *osty_rt_compress_gzip_encode(void *raw_bytes);
+void *osty_rt_compress_gzip_decode(void *raw_bytes);
 bool osty_rt_set_insert_i64(void *raw_set, int64_t item);
 bool osty_rt_set_insert_i1(void *raw_set, bool item);
 bool osty_rt_set_insert_f64(void *raw_set, double item);
@@ -10316,6 +10323,214 @@ static void *osty_rt_bytes_dup_site(const unsigned char *start, size_t len, cons
         memcpy(data, start, len);
     }
     return out;
+}
+
+static unsigned char *osty_rt_compress_grow_buffer(unsigned char *buf, size_t *cap, size_t min_cap, const char *site) {
+    unsigned char *grown;
+    size_t next = (*cap == 0) ? 256 : *cap;
+
+    if (min_cap <= *cap) {
+        return buf;
+    }
+    while (next < min_cap) {
+        if (next > SIZE_MAX / 2) {
+            next = min_cap;
+            break;
+        }
+        next *= 2;
+    }
+    grown = (unsigned char *)realloc(buf, next);
+    if (grown == NULL) {
+        free(buf);
+        osty_rt_abort(site);
+    }
+    *cap = next;
+    return grown;
+}
+
+static bool osty_rt_compress_all_zero(const unsigned char *data, size_t len) {
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        if (data[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void *osty_rt_compress_gzip_encode(void *raw_bytes) {
+#if defined(_WIN32)
+    (void)raw_bytes;
+    osty_rt_abort("runtime.compress.gzip.encode: zlib unavailable on windows");
+    return NULL;
+#else
+    osty_rt_bytes *input = (osty_rt_bytes *)raw_bytes;
+    const unsigned char *input_data = NULL;
+    size_t input_len = 0;
+    size_t input_off = 0;
+    unsigned char *out = NULL;
+    size_t out_cap = 0;
+    z_stream stream;
+    int rc;
+
+    if (input != NULL) {
+        if (input->len < 0) {
+            osty_rt_abort("runtime.compress.gzip.encode: negative length");
+        }
+        input_data = input->data;
+        input_len = (size_t)input->len;
+    }
+
+    memset(&stream, 0, sizeof(stream));
+    rc = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+    if (rc != Z_OK) {
+        osty_rt_abort("runtime.compress.gzip.encode: deflateInit2 failed");
+    }
+
+    out = osty_rt_compress_grow_buffer(NULL, &out_cap, 256, "runtime.compress.gzip.encode: out of memory");
+    stream.next_out = out;
+    stream.avail_out = (uInt)((out_cap > (size_t)UINT_MAX) ? (size_t)UINT_MAX : out_cap);
+
+    for (;;) {
+        if (stream.avail_in == 0 && input_off < input_len) {
+            size_t chunk = input_len - input_off;
+            if (chunk > (size_t)UINT_MAX) {
+                chunk = (size_t)UINT_MAX;
+            }
+            stream.next_in = (Bytef *)(input_data + input_off);
+            stream.avail_in = (uInt)chunk;
+            input_off += chunk;
+        }
+
+        rc = deflate(&stream, (input_off == input_len && stream.avail_in == 0) ? Z_FINISH : Z_NO_FLUSH);
+        if (rc == Z_STREAM_END) {
+            size_t produced = (size_t)(stream.next_out - out);
+            void *managed = osty_rt_bytes_dup_site(produced == 0 ? NULL : out, produced, "runtime.compress.gzip.encode");
+            free(out);
+            deflateEnd(&stream);
+            return managed;
+        }
+        if (rc != Z_OK) {
+            free(out);
+            deflateEnd(&stream);
+            osty_rt_abort("runtime.compress.gzip.encode: deflate failed");
+        }
+        if (stream.avail_out == 0) {
+            size_t produced = (size_t)(stream.next_out - out);
+            size_t min_cap = out_cap + ((out_cap < 4096) ? out_cap : 4096);
+            if (min_cap <= out_cap) {
+                min_cap = out_cap + 1;
+            }
+            out = osty_rt_compress_grow_buffer(out, &out_cap, min_cap, "runtime.compress.gzip.encode: out of memory");
+            stream.next_out = out + produced;
+            stream.avail_out = (uInt)(((out_cap - produced) > (size_t)UINT_MAX) ? (size_t)UINT_MAX : (out_cap - produced));
+        }
+    }
+#endif
+}
+
+void *osty_rt_compress_gzip_decode(void *raw_bytes) {
+#if defined(_WIN32)
+    (void)raw_bytes;
+    return NULL;
+#else
+    osty_rt_bytes *input = (osty_rt_bytes *)raw_bytes;
+    const unsigned char *input_data = NULL;
+    size_t input_len = 0;
+    size_t input_off = 0;
+    unsigned char *out = NULL;
+    size_t out_cap = 0;
+    z_stream stream;
+    int rc;
+
+    if (input != NULL) {
+        if (input->len < 0) {
+            osty_rt_abort("runtime.compress.gzip.decode: negative length");
+        }
+        input_data = input->data;
+        input_len = (size_t)input->len;
+    }
+    if (input_len == 0) {
+        return NULL;
+    }
+
+    memset(&stream, 0, sizeof(stream));
+    rc = inflateInit2(&stream, 15 + 16);
+    if (rc != Z_OK) {
+        osty_rt_abort("runtime.compress.gzip.decode: inflateInit2 failed");
+    }
+
+    out = osty_rt_compress_grow_buffer(NULL, &out_cap, 256, "runtime.compress.gzip.decode: out of memory");
+    stream.next_out = out;
+    stream.avail_out = (uInt)((out_cap > (size_t)UINT_MAX) ? (size_t)UINT_MAX : out_cap);
+
+    for (;;) {
+        if (stream.avail_in == 0 && input_off < input_len) {
+            size_t chunk = input_len - input_off;
+            if (chunk > (size_t)UINT_MAX) {
+                chunk = (size_t)UINT_MAX;
+            }
+            stream.next_in = (Bytef *)(input_data + input_off);
+            stream.avail_in = (uInt)chunk;
+            input_off += chunk;
+        }
+
+        rc = inflate(&stream, Z_NO_FLUSH);
+        if (rc == Z_STREAM_END) {
+            size_t consumed = input_off - (size_t)stream.avail_in;
+            size_t remaining = input_len - consumed;
+
+            if (remaining == 0 || osty_rt_compress_all_zero(input_data + consumed, remaining)) {
+                size_t produced = (size_t)(stream.next_out - out);
+                void *managed = osty_rt_bytes_dup_site(produced == 0 ? NULL : out, produced, "runtime.compress.gzip.decode");
+                free(out);
+                inflateEnd(&stream);
+                return managed;
+            }
+            rc = inflateReset(&stream);
+            if (rc != Z_OK) {
+                free(out);
+                inflateEnd(&stream);
+                return NULL;
+            }
+            continue;
+        }
+        if (rc == Z_BUF_ERROR) {
+            if (stream.avail_out == 0) {
+                size_t produced = (size_t)(stream.next_out - out);
+                size_t min_cap = out_cap + ((out_cap < 4096) ? out_cap : 4096);
+                if (min_cap <= out_cap) {
+                    min_cap = out_cap + 1;
+                }
+                out = osty_rt_compress_grow_buffer(out, &out_cap, min_cap, "runtime.compress.gzip.decode: out of memory");
+                stream.next_out = out + produced;
+                stream.avail_out = (uInt)(((out_cap - produced) > (size_t)UINT_MAX) ? (size_t)UINT_MAX : (out_cap - produced));
+                continue;
+            }
+            if (stream.avail_in == 0 && input_off == input_len) {
+                free(out);
+                inflateEnd(&stream);
+                return NULL;
+            }
+        } else if (rc != Z_OK) {
+            free(out);
+            inflateEnd(&stream);
+            return NULL;
+        }
+
+        if (stream.avail_out == 0) {
+            size_t produced = (size_t)(stream.next_out - out);
+            size_t min_cap = out_cap + ((out_cap < 4096) ? out_cap : 4096);
+            if (min_cap <= out_cap) {
+                min_cap = out_cap + 1;
+            }
+            out = osty_rt_compress_grow_buffer(out, &out_cap, min_cap, "runtime.compress.gzip.decode: out of memory");
+            stream.next_out = out + produced;
+            stream.avail_out = (uInt)(((out_cap - produced) > (size_t)UINT_MAX) ? (size_t)UINT_MAX : (out_cap - produced));
+        }
+    }
+#endif
 }
 
 void *osty_rt_bytes_from_list(void *raw_list) {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7292,6 +7292,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdBytesCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdCompressCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitBytesNamespaceCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -52,6 +52,7 @@ type generator struct {
 	stdTestingGenAliases map[string]bool
 	stdIoAliases         map[string]bool
 	stdBytesAliases      map[string]bool
+	stdCompressAliases   map[string]bool
 	stdStringsAliases    map[string]bool
 	stdEnvAliases        map[string]bool
 	runtimeDecls         map[string]runtimeDecl

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -272,6 +272,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdTestingGenAliases = collectStdTestingGenAliases(file)
 		g.stdIoAliases = collectStdIoAliases(file)
 		g.stdBytesAliases = collectStdBytesAliases(file)
+		g.stdCompressAliases = collectStdCompressAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
@@ -305,6 +306,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdTestingGenAliases = collectStdTestingGenAliases(file)
 	g.stdIoAliases = collectStdIoAliases(file)
 	g.stdBytesAliases = collectStdBytesAliases(file)
+	g.stdCompressAliases = collectStdCompressAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -148,6 +148,31 @@ func TestGeneratedClangLinkBinaryArgsPthreadWindowsBranching(t *testing.T) {
 	}
 }
 
+func TestGeneratedClangLinkBinaryArgsZlibWindowsBranching(t *testing.T) {
+	cases := []struct {
+		target string
+		want   bool
+	}{
+		{"", true},
+		{"x86_64-unknown-linux-gnu", true},
+		{"aarch64-unknown-linux-gnu", true},
+		{"x86_64-apple-darwin", true},
+		{"arm64-apple-darwin", true},
+		{"x86_64-pc-windows-msvc", false},
+		{"aarch64-pc-windows-msvc", false},
+		{"x86_64-pc-windows-gnu", false},
+	}
+	for _, c := range cases {
+		args := llvmClangLinkBinaryArgs(c.target, []string{"/tmp/main.o"}, "/tmp/app")
+		got := strings.Join(args, " ")
+		has := strings.Contains(got, "-lz")
+		if has != c.want {
+			t.Errorf("target=%q: -lz present=%v, want=%v; full args: %s",
+				c.target, has, c.want, got)
+		}
+	}
+}
+
 func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if !llvmIsCompareOp("==") {
 		t.Fatal(`llvmIsCompareOp("==") = false, want true`)

--- a/internal/llvmgen/stdlib_compress_shim.go
+++ b/internal/llvmgen/stdlib_compress_shim.go
@@ -1,0 +1,199 @@
+package llvmgen
+
+import "github.com/osty/osty/internal/ast"
+
+const ostyRtCompressGzipEncodeSymbol = "osty_rt_compress_gzip_encode"
+const ostyRtCompressGzipDecodeSymbol = "osty_rt_compress_gzip_decode"
+
+func collectStdCompressAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "compress" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "compress"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func gzipDecodeResultSourceType() ast.Type {
+	return &ast.NamedType{
+		Path: []string{"Result"},
+		Args: []ast.Type{
+			&ast.NamedType{Path: []string{"Bytes"}},
+			&ast.NamedType{Path: []string{"Error"}},
+		},
+	}
+}
+
+func (g *generator) emitStdCompressCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdCompressGzipCallInfo(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "encode":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "compress.gzip.encode expects 1 argument, got %d", len(call.Args))
+		}
+		data, err := g.emitStdBytesArg(call.Args[0], "gzip.encode", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitGzipEncodeRuntime(data)
+		return out, true, err
+	case "decode":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "compress.gzip.decode expects 1 argument, got %d", len(call.Args))
+		}
+		data, err := g.emitStdBytesArg(call.Args[0], "gzip.decode", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitGzipDecodeResult(data)
+		return out, true, err
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdCompressCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdCompressGzipCallInfo(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "encode":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "decode":
+		if info, ok := builtinResultTypeFromAST(gzipDecodeResultSourceType(), g.typeEnv()); ok {
+			return value{typ: info.typ, sourceType: gzipDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+		}
+		return value{}, false
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdCompressCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdCompressGzipCallInfo(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "encode":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
+	case "decode":
+		return gzipDecodeResultSourceType(), true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) stdCompressGzipCallInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdCompressAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	gzipField, ok := field.X.(*ast.FieldExpr)
+	if !ok || gzipField == nil || gzipField.IsOptional || gzipField.Name != "gzip" {
+		return nil, false
+	}
+	alias, ok := gzipField.X.(*ast.Ident)
+	if !ok || alias == nil || !g.stdCompressAliases[alias.Name] {
+		return nil, false
+	}
+	switch field.Name {
+	case "encode", "decode":
+		return field, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) emitGzipEncodeRuntime(data value) (value, error) {
+	g.declareRuntimeSymbol(ostyRtCompressGzipEncodeSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", ostyRtCompressGzipEncodeSymbol, []*LlvmValue{toOstyValue(data)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
+func (g *generator) emitGzipDecodeResult(data value) (value, error) {
+	sourceType := gzipDecodeResultSourceType()
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, unsupported("type-system", "compress.gzip.decode Result<Bytes, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	g.declareRuntimeSymbol(ostyRtCompressGzipDecodeSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+
+	emitter := g.toOstyEmitter()
+	decoded := llvmCall(emitter, "ptr", ostyRtCompressGzipDecodeSymbol, []*LlvmValue{toOstyValue(data)})
+	notNil := llvmCompare(emitter, "ne", decoded, &LlvmValue{typ: "ptr", name: "null"})
+	labels := llvmIfExprStart(emitter, notNil)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	emitter = g.toOstyEmitter()
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		decoded,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	g.takeOstyEmitter(emitter)
+	thenValue := value{
+		typ:        info.typ,
+		ref:        okResult.name,
+		sourceType: sourceType,
+		rootPaths:  g.rootPathsForType(info.typ),
+	}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	emitter = g.toOstyEmitter()
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	g.takeOstyEmitter(emitter)
+	elseValue := value{
+		typ:        info.typ,
+		ref:        errResult.name,
+		sourceType: sourceType,
+		rootPaths:  g.rootPathsForType(info.typ),
+	}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+	if err != nil {
+		return value{}, err
+	}
+	out.sourceType = sourceType
+	out.rootPaths = g.rootPathsForType(info.typ)
+	return out, nil
+}

--- a/internal/llvmgen/stdlib_compress_shim_test.go
+++ b/internal/llvmgen/stdlib_compress_shim_test.go
@@ -1,0 +1,35 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStdCompressGzipCallsRouteToRuntimeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.compress as compress
+
+fn roundTrip(data: Bytes) -> Result<Bytes, Error> {
+    let encoded = compress.gzip.encode(data)
+    compress.gzip.decode(encoded)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_compress_gzip_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_compress_gzip_encode(ptr)",
+		"declare ptr @osty_rt_compress_gzip_decode(ptr)",
+		"call ptr @osty_rt_compress_gzip_encode(",
+		"call ptr @osty_rt_compress_gzip_decode(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1659,6 +1659,8 @@ func llvmClangLinkBinaryArgs(target string, objectPaths []string, binaryPath str
 	if !llvmStrings.Contains(target, "windows") {
 		// Osty: toolchain/llvmgen.osty:1205:9
 		func() struct{} { args = append(args, "-pthread"); return struct{}{} }()
+		// Osty: toolchain/llvmgen.osty:1209:9
+		func() struct{} { args = append(args, "-lz"); return struct{}{} }()
 	}
 	// Osty: toolchain/llvmgen.osty:1207:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -434,6 +434,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdBytesCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdCompressCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticStdStringsCallSourceType(e); ok {
 			return src, true
 		}
@@ -921,6 +924,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return value{typ: fn.ret, listElemTyp: fn.listElemTyp, gcManaged: fn.listElemTyp != ""}, true
 		}
 		if out, ok := g.stdBytesCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdCompressCallStaticResult(e); ok {
 			return out, true
 		}
 		if out, ok := g.stdStringsCallStaticResult(e); ok {

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -1,6 +1,7 @@
 package selfhost
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -179,6 +180,23 @@ fn main() {
 				t.Fatalf("CheckStructuredFromRun diverges from CheckSourceStructured\nlegacy=%#v\nfresh=%#v", legacy, fresh)
 			}
 		})
+	}
+}
+
+func TestCheckSourceStructuredAcceptsStdNamespaceValues(t *testing.T) {
+	src := []byte(`use std.compress as compress
+use std.encoding as encoding
+
+fn main() {
+    let _ = compress.gzip
+    let _ = encoding.base64
+    let _ = encoding.hex
+    let _ = encoding.url
+}
+`)
+	result := CheckSourceStructured(src)
+	if result.Summary.Errors != 0 {
+		t.Fatalf("errors = %d, want 0\nresult=%s", result.Summary.Errors, fmt.Sprintf("%#v", result))
 	}
 }
 

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -47379,6 +47379,10 @@ func collectUseDecl(cx *ElabCx, declIdx int, node *AstNode) {
 		} else if node.text == "std.io" {
 			// Osty: /tmp/selfhost_merged.osty:23286:13
 			registerStdIoAliasFns(env, alias)
+		} else if node.text == "std.compress" {
+			registerStdCompressAliasFields(env, alias)
+		} else if node.text == "std.encoding" {
+			registerStdEncodingAliasFields(env, alias)
 		} else {
 			// Osty: /tmp/selfhost_merged.osty:23288:13
 			_ = env
@@ -47743,6 +47747,22 @@ func registerStdIoAliasFns(env *CheckEnv, alias string) {
 	}
 	// Osty: /tmp/selfhost_merged.osty:23710:5
 	checkRegisterFn(env, &CheckFnSig{name: "readLine", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tString_, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+}
+
+func registerStdCompressAliasFields(env *CheckEnv, alias string) {
+	tys := env.tys
+	tGzip := tyNamed(tys, "Gzip", make([]int, 0, 1))
+	tBytes_ := tBytes(tys)
+	tResultBytesError := tyNamed(tys, "Result", []int{tBytes_, tyNamed(tys, "Error", make([]int, 0, 1))})
+	checkRegisterField(env, &CheckFieldSig{owner: alias, name: "gzip", ty: tGzip, exported: true, hasDefault: false})
+	checkRegisterFn(env, &CheckFnSig{name: "encode", owner: "Gzip", receiverTy: tGzip, hasReceiver: true, retTy: tBytes_, paramNames: []string{"data"}, paramTys: []int{tBytes_}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "decode", owner: "Gzip", receiverTy: tGzip, hasReceiver: true, retTy: tResultBytesError, paramNames: []string{"data"}, paramTys: []int{tBytes_}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+}
+
+func registerStdEncodingAliasFields(env *CheckEnv, alias string) {
+	checkRegisterField(env, &CheckFieldSig{owner: alias, name: "base64", ty: tyNamed(env.tys, "Base64", make([]int, 0, 1)), exported: true, hasDefault: false})
+	checkRegisterField(env, &CheckFieldSig{owner: alias, name: "hex", ty: tyNamed(env.tys, "Hex", make([]int, 0, 1)), exported: true, hasDefault: false})
+	checkRegisterField(env, &CheckFieldSig{owner: alias, name: "url", ty: tyNamed(env.tys, "UrlEncoding", make([]int, 0, 1)), exported: true, hasDefault: false})
 }
 
 // Osty: /tmp/selfhost_merged.osty:23720:1

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -329,6 +329,10 @@ fn collectUseDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
             registerStdThreadAliasFns(env, alias)
         } else if node.text == "std.io" {
             registerStdIoAliasFns(env, alias)
+        } else if node.text == "std.compress" {
+            registerStdCompressAliasFields(env, alias)
+        } else if node.text == "std.encoding" {
+            registerStdEncodingAliasFields(env, alias)
         } else {
             let _ = env
         }
@@ -756,6 +760,56 @@ fn registerStdIoAliasFns(env: CheckEnv, alias: String) {
         name: "readLine", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tString_,
         paramNames: [], paramTys: [],
         generics: [], genericBounds: [],
+    })
+}
+
+fn registerStdCompressAliasFields(env: CheckEnv, alias: String) {
+    let tys = env.tys
+    let tGzip = tyNamed(tys, "Gzip", [])
+    let tBytes_ = tBytes(tys)
+    let tResultBytesError = tyNamed(tys, "Result", [tBytes_, tyNamed(tys, "Error", [])])
+    checkRegisterField(env, CheckFieldSig {
+        owner: alias,
+        name: "gzip",
+        ty: tGzip,
+        exported: true,
+        hasDefault: false,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "encode", owner: "Gzip", receiverTy: tGzip, hasReceiver: true,
+        retTy: tBytes_,
+        paramNames: ["data"], paramTys: [tBytes_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "decode", owner: "Gzip", receiverTy: tGzip, hasReceiver: true,
+        retTy: tResultBytesError,
+        paramNames: ["data"], paramTys: [tBytes_],
+        generics: [], genericBounds: [],
+    })
+}
+
+fn registerStdEncodingAliasFields(env: CheckEnv, alias: String) {
+    checkRegisterField(env, CheckFieldSig {
+        owner: alias,
+        name: "base64",
+        ty: tyNamed(env.tys, "Base64", []),
+        exported: true,
+        hasDefault: false,
+    })
+    checkRegisterField(env, CheckFieldSig {
+        owner: alias,
+        name: "hex",
+        ty: tyNamed(env.tys, "Hex", []),
+        exported: true,
+        hasDefault: false,
+    })
+    checkRegisterField(env, CheckFieldSig {
+        owner: alias,
+        name: "url",
+        ty: tyNamed(env.tys, "UrlEncoding", []),
+        exported: true,
+        hasDefault: false,
     })
 }
 

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2214,6 +2214,10 @@ pub fn llvmClangLinkBinaryArgs(
     // the -pthread flag under clang-msvc, so it is omitted there.
     if !target.contains("windows") {
         args.push("-pthread")
+        // The gzip runtime uses zlib on POSIX targets. Link it
+        // explicitly so the bundled runtime object can resolve
+        // deflate/inflate at binary-link time.
+        args.push("-lz")
     }
     args.push("-o")
     args.push(binaryPath)


### PR DESCRIPTION
## Summary
- add LLVM/runtime lowering for `std.compress.gzip.encode/decode` backed by zlib
- register std namespace singleton values and gzip methods in the selfhost checker
- add gzip IR/backend/linker regression coverage

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)