### PR TITLE
feat: add std.os process runtime support

### DIFF
--- a/internal/backend/llvm_os_process_test.go
+++ b/internal/backend/llvm_os_process_test.go
@@ -1,0 +1,121 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+func stdOsProcessCommands() (directProgram string, directArgs []string, shellCommand string) {
+	if runtime.GOOS == "windows" {
+		return "cmd",
+			[]string{"/d", "/s", "/c", "(echo|set /p =direct-out) & (echo direct-err 1>&2) & exit /b 3"},
+			"(echo|set /p =shell-out) & (echo shell-err 1>&2)"
+	}
+	return "sh",
+		[]string{"-c", "printf direct-out && printf direct-err 1>&2 && exit 3"},
+		"printf shell-out && printf shell-err 1>&2"
+}
+
+func ostyStringListLiteral(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+	out := "["
+	for i, value := range values {
+		if i != 0 {
+			out += ", "
+		}
+		out += fmt.Sprintf("%q", value)
+	}
+	out += "]"
+	return out
+}
+
+func TestLLVMBackendBinaryRunsStdOsProcessSurface(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	prog, args, shellCmd := stdOsProcessCommands()
+	src := fmt.Sprintf(`use std.os
+
+fn main() {
+    match os.exec(%q, %s) {
+        Ok(direct) -> {
+            println(direct.exitCode == 3)
+            println(direct.stdout == "direct-out")
+            println(direct.stderr.contains("direct-err"))
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+            println(false)
+        },
+    }
+
+    match os.execShell(%q) {
+        Ok(shell) -> {
+            println(shell.exitCode == 0)
+            println(shell.stdout == "shell-out")
+            println(shell.stderr.contains("shell-err"))
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+            println(false)
+        },
+    }
+
+    println(os.pid() > 0)
+    match os.hostname() {
+        Ok(host) -> println(host.len() > 0),
+        Err(err) -> println(err.message()),
+    }
+}
+`, prog, ostyStringListLiteral(args), shellCmd)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, src)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryStdOsExitUsesRequestedCode(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.os
+
+fn main() {
+    os.exit(7)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected %q to exit non-zero, got success with output %q", result.Artifacts.Binary, output)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("run error type = %T, want *exec.ExitError (%v)", err, err)
+	}
+	if exitErr.ExitCode() != 7 {
+		t.Fatalf("exit code = %d, want 7; output=%q", exitErr.ExitCode(), output)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -73,8 +73,10 @@
 #  include <direct.h>
 #  define OSTY_RT_MKDIR_ONE(path) _mkdir(path)
 #else
+#  include <fcntl.h>
 #  include <sys/stat.h>
 #  include <sys/types.h>
+#  include <sys/wait.h>
 #  include <unistd.h>
 #  define OSTY_RT_MKDIR_ONE(path) mkdir((path), 0755)
 #endif
@@ -16903,4 +16905,669 @@ void *osty_rt_env_set_current_dir(const char *path) {
     }
     return osty_rt_env_error_message("failed to set current directory", strerror(err), "runtime.env.set_current_dir.error");
 #endif
+}
+
+/* std.os process-control surface.
+ *
+ * `std.os.exec` / `execShell` lower to `osty_rt_os_exec(cmd, args, shell)`.
+ * The helper returns a by-value aggregate so the emitter can distinguish
+ * launch/runtime failures from ordinary non-zero child exit codes without
+ * re-running the process:
+ *
+ *   tag = 0 -> success, exit_code/stdout/stderr populated, error_text NULL
+ *   tag = 1 -> failure, error_text populated, output fields zeroed
+ *
+ * `std.os.hostname()` follows the same pattern with a narrower
+ * `{tag, value, error}` result. `pid()` and `exit(code)` are direct
+ * runtime calls. `onSignal` is intentionally not implemented here. */
+typedef struct osty_rt_os_exec_result {
+    int64_t tag;
+    int64_t exit_code;
+    void *stdout_text;
+    void *stderr_text;
+    void *error_text;
+} osty_rt_os_exec_result;
+
+typedef struct osty_rt_os_string_result {
+    int64_t tag;
+    void *value_text;
+    void *error_text;
+} osty_rt_os_string_result;
+
+static void *osty_rt_os_error_message(const char *prefix, const char *detail, const char *site) {
+    const char *lhs = prefix == NULL ? "process error" : prefix;
+    const char *rhs = (detail != NULL && detail[0] != '\0') ? detail : "unknown error";
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
+    size_t total = lhs_len + 2 + rhs_len;
+    char *buf = (char *)osty_rt_xmalloc(total + 1, site);
+    memcpy(buf, lhs, lhs_len);
+    buf[lhs_len] = ':';
+    buf[lhs_len + 1] = ' ';
+    memcpy(buf + lhs_len + 2, rhs, rhs_len);
+    buf[total] = '\0';
+    void *out = osty_rt_string_dup_site(buf, total, site);
+    free(buf);
+    return out;
+}
+
+static void *osty_rt_os_empty_string(const char *site) {
+    return osty_rt_string_dup_site("", 0, site);
+}
+
+static void *osty_rt_os_read_file_to_string(const char *path, const char *site) {
+    FILE *fp;
+    long size;
+    size_t read_n;
+    char *buf;
+    void *out;
+    if (path == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+    fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return NULL;
+    }
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+    size = ftell(fp);
+    if (size < 0) {
+        fclose(fp);
+        return NULL;
+    }
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+    buf = (char *)osty_rt_xmalloc((size_t)size + 1, site);
+    read_n = fread(buf, 1, (size_t)size, fp);
+    if (read_n != (size_t)size) {
+        free(buf);
+        fclose(fp);
+        return NULL;
+    }
+    buf[size] = '\0';
+    out = osty_rt_string_dup_site(buf, (size_t)size, site);
+    free(buf);
+    fclose(fp);
+    return out;
+}
+
+static osty_rt_os_exec_result *osty_rt_os_exec_error_result(const char *prefix, const char *detail, const char *site) {
+    osty_rt_os_exec_result *out =
+        (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), site);
+    out->tag = 1;
+    out->exit_code = 0;
+    out->stdout_text = NULL;
+    out->stderr_text = NULL;
+    out->error_text = osty_rt_os_error_message(prefix, detail, site);
+    return out;
+}
+
+static osty_rt_os_string_result *osty_rt_os_string_error_result(const char *prefix, const char *detail, const char *site) {
+    osty_rt_os_string_result *out =
+        (osty_rt_os_string_result *)osty_rt_xmalloc(sizeof(*out), site);
+    out->tag = 1;
+    out->value_text = NULL;
+    out->error_text = osty_rt_os_error_message(prefix, detail, site);
+    return out;
+}
+
+#if defined(_WIN32)
+static char *osty_rt_os_win_strdup(const char *text, const char *site) {
+    size_t n = text == NULL ? 0 : strlen(text);
+    char *out = (char *)osty_rt_xmalloc(n + 1, site);
+    if (n != 0) {
+        memcpy(out, text, n);
+    }
+    out[n] = '\0';
+    return out;
+}
+
+static bool osty_rt_os_open_tempfile_win(char **out_path, HANDLE *out_handle) {
+    char dir[MAX_PATH + 1];
+    char name[MAX_PATH + 1];
+    SECURITY_ATTRIBUTES sa;
+    DWORD dir_len;
+    if (out_path == NULL || out_handle == NULL) {
+        return false;
+    }
+    dir_len = GetTempPathA((DWORD)sizeof(dir), dir);
+    if (dir_len == 0 || dir_len >= sizeof(dir)) {
+        return false;
+    }
+    if (GetTempFileNameA(dir, "ost", 0, name) == 0) {
+        return false;
+    }
+    sa.nLength = sizeof(sa);
+    sa.lpSecurityDescriptor = NULL;
+    sa.bInheritHandle = TRUE;
+    *out_handle = CreateFileA(
+        name,
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        &sa,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_SEQUENTIAL_SCAN,
+        NULL
+    );
+    if (*out_handle == INVALID_HANDLE_VALUE) {
+        DeleteFileA(name);
+        return false;
+    }
+    *out_path = osty_rt_os_win_strdup(name, "runtime.os.tempfile.path");
+    return true;
+}
+
+static size_t osty_rt_os_win_quoted_len(const char *arg) {
+    size_t n = 0;
+    size_t backslashes = 0;
+    bool needs_quotes = false;
+    const unsigned char *p = (const unsigned char *)(arg == NULL ? "" : arg);
+    if (*p == '\0') {
+        return 2;
+    }
+    for (; *p != '\0'; p++) {
+        if (*p == ' ' || *p == '\t' || *p == '"') {
+            needs_quotes = true;
+        }
+    }
+    if (!needs_quotes) {
+        return strlen(arg);
+    }
+    n = 2;
+    p = (const unsigned char *)(arg == NULL ? "" : arg);
+    for (; *p != '\0'; p++) {
+        if (*p == '\\') {
+            backslashes++;
+            continue;
+        }
+        if (*p == '"') {
+            n += backslashes * 2 + 2;
+            backslashes = 0;
+            continue;
+        }
+        n += backslashes + 1;
+        backslashes = 0;
+    }
+    n += backslashes * 2;
+    return n;
+}
+
+static char *osty_rt_os_win_append_quoted(char *dst, const char *arg) {
+    size_t backslashes = 0;
+    bool needs_quotes = false;
+    const unsigned char *p = (const unsigned char *)(arg == NULL ? "" : arg);
+    if (*p == '\0') {
+        *dst++ = '"';
+        *dst++ = '"';
+        return dst;
+    }
+    for (; *p != '\0'; p++) {
+        if (*p == ' ' || *p == '\t' || *p == '"') {
+            needs_quotes = true;
+        }
+    }
+    if (!needs_quotes) {
+        size_t n = strlen(arg);
+        memcpy(dst, arg, n);
+        return dst + n;
+    }
+    *dst++ = '"';
+    p = (const unsigned char *)(arg == NULL ? "" : arg);
+    for (; *p != '\0'; p++) {
+        if (*p == '\\') {
+            backslashes++;
+            continue;
+        }
+        if (*p == '"') {
+            while (backslashes-- > 0) {
+                *dst++ = '\\';
+                *dst++ = '\\';
+            }
+            backslashes = 0;
+            *dst++ = '\\';
+            *dst++ = '"';
+            continue;
+        }
+        while (backslashes-- > 0) {
+            *dst++ = '\\';
+        }
+        backslashes = 0;
+        *dst++ = (char)(*p);
+    }
+    while (backslashes-- > 0) {
+        *dst++ = '\\';
+        *dst++ = '\\';
+    }
+    *dst++ = '"';
+    return dst;
+}
+
+static char *osty_rt_os_build_windows_command_line(const char *cmd, void *args, bool shell) {
+    int64_t arg_count = args != NULL ? osty_rt_list_len(args) : 0;
+    size_t total = 1;
+    char *buf;
+    char *cursor;
+    int64_t i;
+    if (shell) {
+        total += osty_rt_os_win_quoted_len("cmd.exe") + 1;
+        total += osty_rt_os_win_quoted_len("/d") + 1;
+        total += osty_rt_os_win_quoted_len("/s") + 1;
+        total += osty_rt_os_win_quoted_len("/c") + 1;
+        total += osty_rt_os_win_quoted_len(cmd == NULL ? "" : cmd);
+    } else {
+        total += osty_rt_os_win_quoted_len(cmd == NULL ? "" : cmd);
+        for (i = 0; i < arg_count; i++) {
+            const char *arg = (const char *)osty_rt_list_get_ptr(args, i);
+            total += 1 + osty_rt_os_win_quoted_len(arg == NULL ? "" : arg);
+        }
+    }
+    buf = (char *)osty_rt_xmalloc(total, "runtime.os.exec.win.cmdline");
+    cursor = buf;
+    if (shell) {
+        cursor = osty_rt_os_win_append_quoted(cursor, "cmd.exe");
+        *cursor++ = ' ';
+        cursor = osty_rt_os_win_append_quoted(cursor, "/d");
+        *cursor++ = ' ';
+        cursor = osty_rt_os_win_append_quoted(cursor, "/s");
+        *cursor++ = ' ';
+        cursor = osty_rt_os_win_append_quoted(cursor, "/c");
+        *cursor++ = ' ';
+        cursor = osty_rt_os_win_append_quoted(cursor, cmd == NULL ? "" : cmd);
+    } else {
+        cursor = osty_rt_os_win_append_quoted(cursor, cmd == NULL ? "" : cmd);
+        for (i = 0; i < arg_count; i++) {
+            const char *arg = (const char *)osty_rt_list_get_ptr(args, i);
+            *cursor++ = ' ';
+            cursor = osty_rt_os_win_append_quoted(cursor, arg == NULL ? "" : arg);
+        }
+    }
+    *cursor = '\0';
+    return buf;
+}
+
+static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *args, bool shell) {
+    char *stdout_path = NULL;
+    char *stderr_path = NULL;
+    char *cmdline = NULL;
+    void *stdout_text = NULL;
+    void *stderr_text = NULL;
+    HANDLE stdout_handle = INVALID_HANDLE_VALUE;
+    HANDLE stderr_handle = INVALID_HANDLE_VALUE;
+    HANDLE stdin_handle = INVALID_HANDLE_VALUE;
+    PROCESS_INFORMATION pi;
+    STARTUPINFOA si;
+    DWORD exit_code = 0;
+    osty_rt_os_exec_result *out;
+    if (cmd == NULL || cmd[0] == '\0') {
+        return osty_rt_os_exec_error_result("failed to launch process", "command is empty", "runtime.os.exec.error");
+    }
+    if (!osty_rt_os_open_tempfile_win(&stdout_path, &stdout_handle)) {
+        return osty_rt_os_exec_error_result("failed to launch process", "could not create stdout temp file", "runtime.os.exec.error");
+    }
+    if (!osty_rt_os_open_tempfile_win(&stderr_path, &stderr_handle)) {
+        CloseHandle(stdout_handle);
+        DeleteFileA(stdout_path);
+        free(stdout_path);
+        return osty_rt_os_exec_error_result("failed to launch process", "could not create stderr temp file", "runtime.os.exec.error");
+    }
+    {
+        SECURITY_ATTRIBUTES sa;
+        sa.nLength = sizeof(sa);
+        sa.lpSecurityDescriptor = NULL;
+        sa.bInheritHandle = TRUE;
+        stdin_handle = CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, &sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (stdin_handle == INVALID_HANDLE_VALUE) {
+            CloseHandle(stdout_handle);
+            CloseHandle(stderr_handle);
+            DeleteFileA(stdout_path);
+            DeleteFileA(stderr_path);
+            free(stdout_path);
+            free(stderr_path);
+            return osty_rt_os_exec_error_result("failed to launch process", "could not open NUL for stdin", "runtime.os.exec.error");
+        }
+    }
+    cmdline = osty_rt_os_build_windows_command_line(cmd, args, shell);
+    ZeroMemory(&pi, sizeof(pi));
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = stdin_handle;
+    si.hStdOutput = stdout_handle;
+    si.hStdError = stderr_handle;
+    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
+        DWORD code = GetLastError();
+        char buf[96];
+        int written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+        CloseHandle(stdin_handle);
+        CloseHandle(stdout_handle);
+        CloseHandle(stderr_handle);
+        DeleteFileA(stdout_path);
+        DeleteFileA(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        free(cmdline);
+        if (written < 0) {
+            return osty_rt_os_exec_error_result("failed to launch process", "CreateProcessA failed", "runtime.os.exec.error");
+        }
+        return osty_rt_os_exec_error_result("failed to launch process", buf, "runtime.os.exec.error");
+    }
+    CloseHandle(stdin_handle);
+    CloseHandle(stdout_handle);
+    CloseHandle(stderr_handle);
+    free(cmdline);
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    if (!GetExitCodeProcess(pi.hProcess, &exit_code)) {
+        DWORD code = GetLastError();
+        char buf[96];
+        int written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        DeleteFileA(stdout_path);
+        DeleteFileA(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        if (written < 0) {
+            return osty_rt_os_exec_error_result("failed to inspect process exit code", "GetExitCodeProcess failed", "runtime.os.exec.error");
+        }
+        return osty_rt_os_exec_error_result("failed to inspect process exit code", buf, "runtime.os.exec.error");
+    }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    stdout_text = osty_rt_os_read_file_to_string(stdout_path, "runtime.os.exec.stdout");
+    stderr_text = osty_rt_os_read_file_to_string(stderr_path, "runtime.os.exec.stderr");
+    DeleteFileA(stdout_path);
+    DeleteFileA(stderr_path);
+    free(stdout_path);
+    free(stderr_path);
+    if (stdout_text == NULL) {
+        return osty_rt_os_exec_error_result("failed to read process stdout", strerror(errno), "runtime.os.exec.error");
+    }
+    if (stderr_text == NULL) {
+        return osty_rt_os_exec_error_result("failed to read process stderr", strerror(errno), "runtime.os.exec.error");
+    }
+    out = (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.exec.result");
+    out->tag = 0;
+    out->exit_code = (int64_t)exit_code;
+    out->stdout_text = stdout_text;
+    out->stderr_text = stderr_text;
+    out->error_text = NULL;
+    return out;
+}
+#else
+static char **osty_rt_os_build_posix_argv(const char *cmd, void *args, bool shell) {
+    int64_t arg_count = args != NULL ? osty_rt_list_len(args) : 0;
+    char **argv;
+    int64_t i;
+    if (shell) {
+        argv = (char **)osty_rt_xmalloc(sizeof(char *) * 4, "runtime.os.exec.argv");
+        argv[0] = (char *)"/bin/sh";
+        argv[1] = (char *)"-c";
+        argv[2] = (char *)(cmd == NULL ? "" : cmd);
+        argv[3] = NULL;
+        return argv;
+    }
+    argv = (char **)osty_rt_xmalloc(sizeof(char *) * (size_t)(arg_count + 2), "runtime.os.exec.argv");
+    argv[0] = (char *)(cmd == NULL ? "" : cmd);
+    for (i = 0; i < arg_count; i++) {
+        char *arg = (char *)osty_rt_list_get_ptr(args, i);
+        argv[i + 1] = arg == NULL ? (char *)"" : arg;
+    }
+    argv[arg_count + 1] = NULL;
+    return argv;
+}
+
+static int osty_rt_os_open_tempfile_posix(const char *prefix, char **out_path) {
+    const char *tmp = getenv("TMPDIR");
+    size_t tmp_len;
+    size_t total;
+    char *path;
+    int fd;
+    if (out_path == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (tmp == NULL || tmp[0] == '\0') {
+        tmp = "/tmp";
+    }
+    tmp_len = strlen(tmp);
+    total = tmp_len + 1 + strlen(prefix) + 6 + 1;
+    path = (char *)osty_rt_xmalloc(total, "runtime.os.exec.tmp.path");
+    snprintf(path, total, "%s/%sXXXXXX", tmp, prefix);
+    fd = mkstemp(path);
+    if (fd < 0) {
+        free(path);
+        return -1;
+    }
+    *out_path = path;
+    return fd;
+}
+
+static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args, bool shell) {
+    char *stdout_path = NULL;
+    char *stderr_path = NULL;
+    int stdout_fd = -1;
+    int stderr_fd = -1;
+    int exec_pipe[2] = {-1, -1};
+    char **argv = NULL;
+    pid_t pid;
+    int status = 0;
+    int exec_errno = 0;
+    ssize_t exec_read;
+    pid_t waited;
+    void *stdout_text = NULL;
+    void *stderr_text = NULL;
+    osty_rt_os_exec_result *out;
+    sigset_t sigurg_mask;
+    sigset_t old_mask;
+    int sigmask_set = 0;
+    struct sigaction old_sigchld;
+    struct sigaction default_sigchld;
+    int sigchld_reset = 0;
+    if (cmd == NULL || cmd[0] == '\0') {
+        return osty_rt_os_exec_error_result("failed to launch process", "command is empty", "runtime.os.exec.error");
+    }
+    stdout_fd = osty_rt_os_open_tempfile_posix("osty-out.", &stdout_path);
+    if (stdout_fd < 0) {
+        return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
+    }
+    stderr_fd = osty_rt_os_open_tempfile_posix("osty-err.", &stderr_path);
+    if (stderr_fd < 0) {
+        close(stdout_fd);
+        unlink(stdout_path);
+        free(stdout_path);
+        return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
+    }
+    if (pipe(exec_pipe) != 0) {
+        close(stdout_fd);
+        close(stderr_fd);
+        unlink(stdout_path);
+        unlink(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
+    }
+    (void)fcntl(exec_pipe[1], F_SETFD, FD_CLOEXEC);
+    argv = osty_rt_os_build_posix_argv(cmd, args, shell);
+    if (sigaction(SIGCHLD, NULL, &old_sigchld) == 0 && old_sigchld.sa_handler == SIG_IGN) {
+        memset(&default_sigchld, 0, sizeof(default_sigchld));
+        default_sigchld.sa_handler = SIG_DFL;
+        sigemptyset(&default_sigchld.sa_mask);
+        if (sigaction(SIGCHLD, &default_sigchld, NULL) == 0) {
+            sigchld_reset = 1;
+        }
+    }
+    pid = fork();
+    if (pid < 0) {
+        int err = errno;
+        if (sigchld_reset) {
+            (void)sigaction(SIGCHLD, &old_sigchld, NULL);
+        }
+        close(stdout_fd);
+        close(stderr_fd);
+        close(exec_pipe[0]);
+        close(exec_pipe[1]);
+        unlink(stdout_path);
+        unlink(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        free(argv);
+        return osty_rt_os_exec_error_result("failed to launch process", strerror(err), "runtime.os.exec.error");
+    }
+    if (pid == 0) {
+        close(exec_pipe[0]);
+        if (dup2(stdout_fd, STDOUT_FILENO) < 0 || dup2(stderr_fd, STDERR_FILENO) < 0) {
+            int err = errno;
+            (void)write(exec_pipe[1], &err, sizeof(err));
+            _exit(127);
+        }
+        close(stdout_fd);
+        close(stderr_fd);
+        if (shell) {
+            execv("/bin/sh", argv);
+        } else {
+            execvp(cmd, argv);
+        }
+        {
+            int err = errno;
+            (void)write(exec_pipe[1], &err, sizeof(err));
+        }
+        _exit(127);
+    }
+    close(stdout_fd);
+    close(stderr_fd);
+    close(exec_pipe[1]);
+    sigemptyset(&sigurg_mask);
+    sigaddset(&sigurg_mask, SIGURG);
+    if (sigprocmask(SIG_BLOCK, &sigurg_mask, &old_mask) == 0) {
+        sigmask_set = 1;
+    }
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    do {
+        exec_read = read(exec_pipe[0], &exec_errno, sizeof(exec_errno));
+    } while (exec_read < 0 && errno == EINTR);
+    close(exec_pipe[0]);
+    if (sigmask_set) {
+        (void)sigprocmask(SIG_SETMASK, &old_mask, NULL);
+    }
+    if (sigchld_reset) {
+        (void)sigaction(SIGCHLD, &old_sigchld, NULL);
+    }
+    free(argv);
+    if (waited < 0) {
+        unlink(stdout_path);
+        unlink(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        return osty_rt_os_exec_error_result("failed to wait for process", strerror(errno), "runtime.os.exec.error");
+    }
+    if (exec_read > 0) {
+        unlink(stdout_path);
+        unlink(stderr_path);
+        free(stdout_path);
+        free(stderr_path);
+        return osty_rt_os_exec_error_result("failed to launch process", strerror(exec_errno), "runtime.os.exec.error");
+    }
+    stdout_text = osty_rt_os_read_file_to_string(stdout_path, "runtime.os.exec.stdout");
+    stderr_text = osty_rt_os_read_file_to_string(stderr_path, "runtime.os.exec.stderr");
+    unlink(stdout_path);
+    unlink(stderr_path);
+    free(stdout_path);
+    free(stderr_path);
+    if (stdout_text == NULL) {
+        return osty_rt_os_exec_error_result("failed to read process stdout", strerror(errno), "runtime.os.exec.error");
+    }
+    if (stderr_text == NULL) {
+        return osty_rt_os_exec_error_result("failed to read process stderr", strerror(errno), "runtime.os.exec.error");
+    }
+    out = (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.exec.result");
+    out->tag = 0;
+    if (WIFEXITED(status)) {
+        out->exit_code = (int64_t)WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        out->exit_code = 128 + (int64_t)WTERMSIG(status);
+    } else {
+        out->exit_code = 1;
+    }
+    out->stdout_text = stdout_text;
+    out->stderr_text = stderr_text;
+    out->error_text = NULL;
+    return out;
+}
+#endif
+
+osty_rt_os_exec_result *osty_rt_os_exec(const char *cmd, void *args, bool shell) {
+#if defined(_WIN32)
+    return osty_rt_os_exec_windows(cmd, args, shell);
+#else
+    return osty_rt_os_exec_posix(cmd, args, shell);
+#endif
+}
+
+osty_rt_os_string_result *osty_rt_os_hostname(void) {
+#if defined(_WIN32)
+    char buf[MAX_COMPUTERNAME_LENGTH + 1];
+    DWORD size = (DWORD)sizeof(buf);
+    if (!GetComputerNameA(buf, &size)) {
+        DWORD code = GetLastError();
+        char errbuf[96];
+        int written = snprintf(errbuf, sizeof(errbuf), "win32 error %lu", (unsigned long)code);
+        if (written < 0) {
+            return osty_rt_os_string_error_result("failed to get hostname", "GetComputerNameA failed", "runtime.os.hostname.error");
+        }
+        return osty_rt_os_string_error_result("failed to get hostname", errbuf, "runtime.os.hostname.error");
+    }
+    {
+        osty_rt_os_string_result *out =
+            (osty_rt_os_string_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.hostname.result");
+        out->tag = 0;
+        out->value_text = osty_rt_string_dup_site(buf, (size_t)size, "runtime.os.hostname");
+        out->error_text = NULL;
+        return out;
+    }
+#else
+    char buf[256];
+    if (gethostname(buf, sizeof(buf)) != 0) {
+        int err = errno;
+        if (err == 0) {
+            return osty_rt_os_string_error_result("failed to get hostname", "gethostname failed", "runtime.os.hostname.error");
+        }
+        return osty_rt_os_string_error_result("failed to get hostname", strerror(err), "runtime.os.hostname.error");
+    }
+    buf[sizeof(buf) - 1] = '\0';
+    {
+        osty_rt_os_string_result *out =
+            (osty_rt_os_string_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.hostname.result");
+        out->tag = 0;
+        out->value_text = osty_rt_string_dup_site(buf, strlen(buf), "runtime.os.hostname");
+        out->error_text = NULL;
+        return out;
+    }
+#endif
+}
+
+void osty_rt_os_exec_result_free(osty_rt_os_exec_result *result) {
+    free(result);
+}
+
+void osty_rt_os_string_result_free(osty_rt_os_string_result *result) {
+    free(result);
+}
+
+int64_t osty_rt_os_pid(void) {
+#if defined(_WIN32)
+    return (int64_t)GetCurrentProcessId();
+#else
+    return (int64_t)getpid();
+#endif
+}
+
+void osty_rt_os_exit(int32_t code) {
+    exit((int)code);
 }

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7301,6 +7301,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdOsCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitStdIoCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,6 +54,7 @@ type generator struct {
 	stdBytesAliases      map[string]bool
 	stdStringsAliases    map[string]bool
 	stdEnvAliases        map[string]bool
+	stdOsAliases         map[string]bool
 	runtimeDecls         map[string]runtimeDecl
 	runtimeDeclOrder     []string
 	traceHelpers         map[string]string

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -274,6 +274,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
+		g.stdOsAliases = collectStdOsAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -307,6 +308,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdBytesAliases = collectStdBytesAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
+	g.stdOsAliases = collectStdOsAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/stdlib_os_shim.go
+++ b/internal/llvmgen/stdlib_os_shim.go
@@ -1,0 +1,421 @@
+package llvmgen
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+const ostyRtOsExecSymbol = "osty_rt_os_exec"
+const ostyRtOsHostnameSymbol = "osty_rt_os_hostname"
+const ostyRtOsPidSymbol = "osty_rt_os_pid"
+const ostyRtOsExitSymbol = "osty_rt_os_exit"
+const ostyRtOsExecResultFreeSymbol = "osty_rt_os_exec_result_free"
+const ostyRtOsStringResultFreeSymbol = "osty_rt_os_string_result_free"
+
+const stdOsExecRuntimeRecordLLVMType = "{ i64, i64, ptr, ptr, ptr }"
+const stdOsStringRuntimeRecordLLVMType = "{ i64, ptr, ptr }"
+const stdOsSyntheticOutputTypeName = "__osty_std_os_Output"
+
+func llvmRuntimeStructFieldPtr(emitter *LlvmEmitter, structType string, base *LlvmValue, index int) *LlvmValue {
+	reg := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body,
+		fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d", reg, structType, base.name, index))
+	return &LlvmValue{typ: "ptr", name: reg, pointer: true}
+}
+
+func llvmLoadFromPtr(emitter *LlvmEmitter, typ string, ptr *LlvmValue) *LlvmValue {
+	reg := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", reg, typ, ptr.name))
+	return &LlvmValue{typ: typ, name: reg}
+}
+
+var stdOsOutputSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{stdOsSyntheticOutputTypeName},
+}
+
+var stdOsExecResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdOsOutputSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdOsHostnameResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		&ast.NamedType{Path: []string{"String"}},
+		errorSourceTypeSingleton,
+	},
+}
+
+func collectStdOsAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "os" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "os"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func ensureStdOsSyntheticOutputStruct(g *generator) *structInfo {
+	if g == nil {
+		return nil
+	}
+	if info := g.structsByName[stdOsSyntheticOutputTypeName]; info != nil {
+		return info
+	}
+	if g.structsByName == nil {
+		g.structsByName = map[string]*structInfo{}
+	}
+	if g.structsByType == nil {
+		g.structsByType = map[string]*structInfo{}
+	}
+	info := &structInfo{
+		name:   stdOsSyntheticOutputTypeName,
+		typ:    llvmStructTypeName(stdOsSyntheticOutputTypeName),
+		byName: map[string]fieldInfo{},
+	}
+	fields := []fieldInfo{
+		{
+			name:       "exitCode",
+			typ:        "i64",
+			index:      0,
+			sourceType: &ast.NamedType{Path: []string{"Int"}},
+		},
+		{
+			name:       "stdout",
+			typ:        "ptr",
+			index:      1,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "stderr",
+			typ:        "ptr",
+			index:      2,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+	}
+	info.fields = fields
+	for _, field := range fields {
+		info.byName[field.name] = field
+	}
+	g.structs = append(g.structs, info)
+	g.structsByName[info.name] = info
+	g.structsByType[info.typ] = info
+	return info
+}
+
+func (g *generator) emitStdOsCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdOsCallField(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "exec":
+		return g.emitStdOsExecCall(call)
+	case "execShell":
+		return g.emitStdOsExecShellCall(call)
+	case "pid":
+		return g.emitStdOsPidCall(call)
+	case "hostname":
+		return g.emitStdOsHostnameCall(call)
+	case "exit":
+		return g.emitStdOsExitCall(call)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdOsCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdOsCallField(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "exec", "execShell":
+		ensureStdOsSyntheticOutputStruct(g)
+		info, ok := builtinResultTypeFromAST(stdOsExecResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdOsExecResultSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType(info.typ),
+		}, true
+	case "pid":
+		return value{typ: "i64"}, true
+	case "hostname":
+		info, ok := builtinResultTypeFromAST(stdOsHostnameResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdOsHostnameResultSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType(info.typ),
+		}, true
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdOsCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdOsCallField(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "exec", "execShell":
+		ensureStdOsSyntheticOutputStruct(g)
+		return stdOsExecResultSourceTypeSingleton, true
+	case "pid":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "hostname":
+		return stdOsHostnameResultSourceTypeSingleton, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) stdOsCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdOsAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || alias == nil || !g.stdOsAliases[alias.Name] {
+		return nil, false
+	}
+	return field, true
+}
+
+func (g *generator) emitStdOsExecCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, false)
+}
+
+func (g *generator) emitStdOsExecShellCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, true)
+}
+
+func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool) (value, bool, error) {
+	ensureStdOsSyntheticOutputStruct(g)
+	info, ok := builtinResultTypeFromAST(stdOsExecResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "std.os exec Result<Output, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if len(call.Args) == 0 || len(call.Args) > 2 {
+		name := "os.exec"
+		if shell {
+			name = "os.execShell"
+		}
+		return value{}, true, unsupportedf("call", "%s received %d arguments", name, len(call.Args))
+	}
+	cmdArg := call.Args[0]
+	if cmdArg == nil || (cmdArg.Name != "" && cmdArg.Name != "cmd" && cmdArg.Name != "command") || cmdArg.Value == nil {
+		name := "os.exec"
+		if shell {
+			name = "os.execShell"
+		}
+		return value{}, true, unsupported("call", name+" requires a String command argument")
+	}
+	cmd, err := g.emitExpr(cmdArg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	cmd = g.protectManagedTemporary("os.exec.cmd", cmd)
+	cmd, err = g.loadIfPointer(cmd)
+	if err != nil {
+		return value{}, true, err
+	}
+	if cmd.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "os.exec command type %s, want String", cmd.typ)
+	}
+	argsValue := value{typ: "ptr", ref: "null"}
+	if !shell && len(call.Args) == 2 {
+		argsArg := call.Args[1]
+		if argsArg == nil || (argsArg.Name != "" && argsArg.Name != "args") || argsArg.Value == nil {
+			return value{}, true, unsupported("call", "os.exec requires args as a positional or `args:` List<String> argument")
+		}
+		argsValue, err = g.emitExpr(argsArg.Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		argsValue = g.protectManagedTemporary("os.exec.args", argsValue)
+		argsValue, err = g.loadIfPointer(argsValue)
+		if err != nil {
+			return value{}, true, err
+		}
+		if argsValue.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "os.exec args type %s, want List<String>", argsValue.typ)
+		}
+	}
+	g.declareRuntimeSymbol(ostyRtOsExecSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}})
+	g.declareRuntimeSymbol(ostyRtOsExecResultFreeSymbol, "void", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	raw := llvmCall(emitter, "ptr", ostyRtOsExecSymbol, []*LlvmValue{
+		toOstyValue(cmd),
+		toOstyValue(argsValue),
+		llvmStdIoBoolValue(shell),
+	})
+	tag := llvmLoadFromPtr(emitter, "i64", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 0))
+	exitCode := llvmLoadFromPtr(emitter, "i64", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 1))
+	stdoutText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 2))
+	stderrText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 3))
+	errText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 4))
+	emitter.body = append(emitter.body, "  call void @"+ostyRtOsExecResultFreeSymbol+"(ptr "+raw.name+")")
+	failed := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: "1"}))
+	errLabel := llvmNextLabel(emitter, "os.exec.err")
+	okLabel := llvmNextLabel(emitter, "os.exec.ok")
+	contLabel := llvmNextLabel(emitter, "os.exec.cont")
+	emitter.body = append(emitter.body, mirBrCondText(failed.name, errLabel, okLabel))
+
+	emitter.body = append(emitter.body, mirLabelText(errLabel))
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, mirLabelText(okLabel))
+	outputInfo := ensureStdOsSyntheticOutputStruct(g)
+	outputValue := llvmStructLiteral(emitter, outputInfo.typ, []*LlvmValue{
+		exitCode,
+		stdoutText,
+		stderrText,
+	})
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		outputValue,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, mirLabelText(contLabel))
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: stdOsExecResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdOsPidCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "os.pid takes no arguments, got %d", len(call.Args))
+	}
+	g.declareRuntimeSymbol(ostyRtOsPidSymbol, "i64", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i64", ostyRtOsPidSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), true, nil
+}
+
+func (g *generator) emitStdOsHostnameCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "os.hostname takes no arguments, got %d", len(call.Args))
+	}
+	info, ok := builtinResultTypeFromAST(stdOsHostnameResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "std.os hostname Result<String, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	g.declareRuntimeSymbol(ostyRtOsHostnameSymbol, "ptr", nil)
+	g.declareRuntimeSymbol(ostyRtOsStringResultFreeSymbol, "void", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	raw := llvmCall(emitter, "ptr", ostyRtOsHostnameSymbol, nil)
+	tag := llvmLoadFromPtr(emitter, "i64", llvmRuntimeStructFieldPtr(emitter, stdOsStringRuntimeRecordLLVMType, raw, 0))
+	valueText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsStringRuntimeRecordLLVMType, raw, 1))
+	errText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsStringRuntimeRecordLLVMType, raw, 2))
+	emitter.body = append(emitter.body, "  call void @"+ostyRtOsStringResultFreeSymbol+"(ptr "+raw.name+")")
+	failed := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: "1"}))
+	errLabel := llvmNextLabel(emitter, "os.hostname.err")
+	okLabel := llvmNextLabel(emitter, "os.hostname.ok")
+	contLabel := llvmNextLabel(emitter, "os.hostname.cont")
+	emitter.body = append(emitter.body, mirBrCondText(failed.name, errLabel, okLabel))
+
+	emitter.body = append(emitter.body, mirLabelText(errLabel))
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, mirLabelText(okLabel))
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		valueText,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, mirLabelText(contLabel))
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        phi,
+		sourceType: stdOsHostnameResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdOsExitCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "os.exit expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || (arg.Name != "" && arg.Name != "code") || arg.Value == nil {
+		return value{}, true, unsupported("call", "os.exit requires one positional or `code:` Int argument")
+	}
+	code, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if code.typ != "i64" {
+		return value{}, true, unsupportedf("type-system", "os.exit arg type %s, want Int", code.typ)
+	}
+	emitter := g.toOstyEmitter()
+	code32 := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+code32+" = trunc i64 "+code.ref+" to i32")
+	g.declareRuntimeSymbol(ostyRtOsExitSymbol, "void", []paramInfo{{typ: "i32"}})
+	emitter.body = append(emitter.body, "  call void @"+ostyRtOsExitSymbol+"(i32 "+code32+")")
+	emitter.body = append(emitter.body, mirUnreachableText())
+	g.takeOstyEmitter(emitter)
+	return value{typ: "void", ref: "undef"}, true, nil
+}

--- a/internal/llvmgen/stdlib_os_shim_test.go
+++ b/internal/llvmgen/stdlib_os_shim_test.go
@@ -1,0 +1,85 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStdOsExecRoutesToRuntimeAndSupportsOutputFields(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.os as os
+
+fn main() {
+    match os.exec("sh", ["-c", "printf hi"]) {
+        Ok(out) -> {
+            println(out.stdout)
+            println(out.stderr)
+            println(out.exitCode)
+        },
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_os_exec.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%__osty_std_os_Output = type { i64, ptr, ptr }",
+		"declare ptr @osty_rt_os_exec(ptr, ptr, i1)",
+		"declare void @osty_rt_os_exec_result_free(ptr)",
+		"call ptr @osty_rt_os_exec(ptr",
+		"getelementptr inbounds { i64, i64, ptr, ptr, ptr }, ptr",
+		"load i64, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdOsPidHostnameAndExitRouteToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.os as os
+
+fn main() {
+    println(os.pid())
+    match os.hostname() {
+        Ok(host) -> println(host),
+        Err(err) -> println(err.message()),
+    }
+}
+
+fn stop() {
+    os.exit(7)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_os_misc.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare i64 @osty_rt_os_pid()",
+		"call i64 @osty_rt_os_pid()",
+		"declare ptr @osty_rt_os_hostname()",
+		"declare void @osty_rt_os_string_result_free(ptr)",
+		"call ptr @osty_rt_os_hostname()",
+		"declare void @osty_rt_os_exit(i32)",
+		"call void @osty_rt_os_exit(i32",
+		"unreachable",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1273,6 +1273,9 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 	if emitted, err := g.emitStdIoCallStmt(call); emitted || err != nil {
 		return err
 	}
+	if emitted, err := g.emitStdOsCallStmt(call); emitted || err != nil {
+		return err
+	}
 	if emitted, err := g.emitOptionalUserCallStmt(call); emitted || err != nil {
 		return err
 	}
@@ -1286,6 +1289,14 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 		return g.emitPrintln(call)
 	}
 	return g.emitPrintln(call)
+}
+
+func (g *generator) emitStdOsCallStmt(call *ast.CallExpr) (bool, error) {
+	if _, ok := g.stdOsCallField(call); !ok {
+		return false, nil
+	}
+	_, _, err := g.emitStdOsCall(call)
+	return true, err
 }
 
 func (g *generator) emitTestingCallStmt(call *ast.CallExpr) (bool, error) {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -440,6 +440,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdEnvCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdOsCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticPtrBackedErrorCallSourceType(e); ok {
 			return src, true
 		}
@@ -927,6 +930,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return out, true
 		}
 		if out, ok := g.stdEnvCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdOsCallStaticResult(e); ok {
 			return out, true
 		}
 	case *ast.FieldExpr:


### PR DESCRIPTION
## Summary
- add llvmgen lowering for std.os exec, execShell, pid, hostname, and exit
- add runtime C support and switch std.os runtime results to pointer-return ABI records
- cover the std.os process surface with focused llvmgen and backend tests

## Test plan
- [x] `just prepush` local pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)