### PR TITLE
feat: std.random LLVM runtime support

### DIFF
--- a/internal/backend/llvm_random_test.go
+++ b/internal/backend/llvm_random_test.go
@@ -1,0 +1,64 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMBackendBinaryRunsStdRandom(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.random
+
+fn main() {
+    let a = random.seeded(42)
+    let b = random.seeded(42)
+    println(a.int(-1000, 1000) == b.int(-1000, 1000))
+    println(a.intInclusive(-1000, 1000) == b.intInclusive(-1000, 1000))
+
+    let wide = a.int((-9223372036854775807) - 1, 9223372036854775807)
+    println(wide >= ((-9223372036854775807) - 1) && wide < 9223372036854775807)
+
+    let inclusive = a.intInclusive((-9223372036854775807) - 1, 9223372036854775807)
+    println(inclusive >= ((-9223372036854775807) - 1) && inclusive <= 9223372036854775807)
+
+    let f = a.float()
+    println(f >= 0.0 && f < 1.0)
+
+    let d = random.default()
+    println(d.bytes(8).len() == 8)
+
+    let blob = a.bytes(16)
+    println(blob.len() == 16)
+
+    println(a.choice([]).isNone())
+    match a.choice([10, 20, 30, 40]) {
+        Some(v) -> println(v == 10 || v == 20 || v == 30 || v == 40),
+        None -> println(false),
+    }
+
+    let xs = [1, 2, 3, 4, 5, 6]
+    let ys = [1, 2, 3, 4, 5, 6]
+    let s1 = random.seeded(7)
+    let s2 = random.seeded(7)
+    s1.shuffle(xs)
+    s2.shuffle(ys)
+    println(xs[0] == ys[0] && xs[1] == ys[1] && xs[2] == ys[2] && xs[3] == ys[3] && xs[4] == ys[4] && xs[5] == ys[5])
+    println(xs[0] == 5 && xs[1] == 2 && xs[2] == 1 && xs[3] == 6 && xs[4] == 4 && xs[5] == 3)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -36,6 +36,9 @@
 
 #if !defined(_WIN32)
 #include <sys/mman.h>
+#if defined(__linux__)
+#include <sys/random.h>
+#endif
 /* `MAP_ANON` is the BSD/macOS spelling; `MAP_ANONYMOUS` is the GNU
  * spelling. Both flags are bit-equal aliases on every supported target.
  * Pick whichever is exposed at runtime-build time (macOS requires
@@ -11211,6 +11214,268 @@ void *osty_rt_bytes_slice(void *raw_bytes, int64_t start, int64_t end) {
         memcpy(data, b->data + (size_t)start, slice_len);
     }
     return out;
+}
+
+typedef struct osty_rt_random_state {
+    uint64_t s[4];
+} osty_rt_random_state;
+
+static uint64_t osty_rt_random_rotl(uint64_t x, int k) {
+    return (x << k) | (x >> (64 - k));
+}
+
+static uint64_t osty_rt_random_splitmix64_step(uint64_t *state) {
+    uint64_t x = *state + 0x9E3779B97F4A7C15ULL;
+    *state = x;
+    x ^= x >> 30;
+    x *= 0xBF58476D1CE4E5B9ULL;
+    x ^= x >> 27;
+    x *= 0x94D049BB133111EBULL;
+    x ^= x >> 31;
+    return x;
+}
+
+static void osty_rt_random_seed_words(osty_rt_random_state *state,
+                                      uint64_t material) {
+    int i;
+    int all_zero = 1;
+    uint64_t x = material;
+
+    if (state == NULL) {
+        osty_rt_abort("runtime.random: nil state");
+    }
+    for (i = 0; i < 4; i++) {
+        state->s[i] = osty_rt_random_splitmix64_step(&x);
+        if (state->s[i] != 0) {
+            all_zero = 0;
+        }
+    }
+    if (all_zero) {
+        x ^= 0xD1B54A32D192ED03ULL;
+        state->s[0] = osty_rt_random_splitmix64_step(&x);
+    }
+}
+
+static int osty_rt_random_fill_entropy(unsigned char *dst, size_t len) {
+    size_t off = 0;
+    FILE *f;
+
+    if (dst == NULL) {
+        return 0;
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    while (off < len) {
+        unsigned int word = 0;
+        size_t take;
+        if (rand_s(&word) != 0) {
+            break;
+        }
+        take = len - off;
+        if (take > sizeof(word)) {
+            take = sizeof(word);
+        }
+        memcpy(dst + off, &word, take);
+        off += take;
+    }
+    if (off == len) {
+        return 1;
+    }
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    arc4random_buf(dst, len);
+    return 1;
+#elif defined(__linux__)
+    while (off < len) {
+        ssize_t got = getrandom(dst + off, len - off, 0);
+        if (got > 0) {
+            off += (size_t)got;
+            continue;
+        }
+        if (got < 0 && errno == EINTR) {
+            continue;
+        }
+        break;
+    }
+    if (off == len) {
+        return 1;
+    }
+#endif
+    f = fopen("/dev/urandom", "rb");
+    if (f == NULL) {
+        return 0;
+    }
+    off = fread(dst, 1, len, f);
+    fclose(f);
+    return off == len;
+}
+
+static osty_rt_random_state *osty_rt_random_new(const char *site) {
+    return (osty_rt_random_state *)osty_gc_allocate_managed(
+        sizeof(osty_rt_random_state), OSTY_GC_KIND_GENERIC, site, NULL, NULL);
+}
+
+static void osty_rt_random_seed_default_state(osty_rt_random_state *state) {
+    unsigned char seed_bytes[32];
+    uint64_t material = 0;
+
+    if (osty_rt_random_fill_entropy(seed_bytes, sizeof(seed_bytes))) {
+        memcpy(state->s, seed_bytes, sizeof(seed_bytes));
+        if (state->s[0] == 0 && state->s[1] == 0 && state->s[2] == 0 &&
+            state->s[3] == 0) {
+            memcpy(&material, seed_bytes, sizeof(material));
+            osty_rt_random_seed_words(state, material ^ 0xA0761D6478BD642FULL);
+        }
+        return;
+    }
+    material = ((uint64_t)(uintptr_t)state << 17) ^
+               ((uint64_t)time(NULL) << 1) ^
+               0xA0761D6478BD642FULL;
+    osty_rt_random_seed_words(state, material);
+}
+
+static uint64_t osty_rt_random_next_u64(osty_rt_random_state *state) {
+    uint64_t result;
+    uint64_t t;
+
+    if (state == NULL) {
+        osty_rt_abort("runtime.random: nil state");
+    }
+    result = osty_rt_random_rotl(state->s[0] + state->s[3], 23) + state->s[0];
+    t = state->s[1] << 17;
+    state->s[2] ^= state->s[0];
+    state->s[3] ^= state->s[1];
+    state->s[1] ^= state->s[2];
+    state->s[0] ^= state->s[3];
+    state->s[2] ^= t;
+    state->s[3] = osty_rt_random_rotl(state->s[3], 45);
+    return result;
+}
+
+static uint64_t osty_rt_random_sample_below(osty_rt_random_state *state,
+                                            uint64_t bound) {
+    uint64_t x;
+    uint64_t limit;
+
+    if (bound == 0) {
+        osty_rt_abort("runtime.random: zero bound");
+    }
+    limit = UINT64_MAX - (UINT64_MAX % bound);
+    do {
+        x = osty_rt_random_next_u64(state);
+    } while (x >= limit);
+    return x % bound;
+}
+
+void *osty_rt_random_default(void) {
+    osty_rt_random_state *state = osty_rt_random_new("runtime.random.default");
+    osty_rt_random_seed_default_state(state);
+    return state;
+}
+
+void *osty_rt_random_seeded(int64_t seed) {
+    osty_rt_random_state *state = osty_rt_random_new("runtime.random.seeded");
+    osty_rt_random_seed_words(state, (uint64_t)seed ^ 0x9E3779B97F4A7C15ULL);
+    return state;
+}
+
+int64_t osty_rt_random_int(void *raw_state, int64_t min, int64_t max) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    uint64_t span;
+    uint64_t offset;
+
+    if (max <= min) {
+        osty_rt_abort("runtime.random.int: invalid bounds");
+    }
+    span = (uint64_t)max - (uint64_t)min;
+    offset = osty_rt_random_sample_below(state, span);
+    return (int64_t)((uint64_t)min + offset);
+}
+
+int64_t osty_rt_random_int_inclusive(void *raw_state, int64_t min,
+                                     int64_t max) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    uint64_t span;
+    uint64_t offset;
+
+    if (max < min) {
+        osty_rt_abort("runtime.random.int_inclusive: invalid bounds");
+    }
+    span = (uint64_t)max - (uint64_t)min;
+    if (span == UINT64_MAX) {
+        return (int64_t)osty_rt_random_next_u64(state);
+    }
+    offset = osty_rt_random_sample_below(state, span + 1);
+    return (int64_t)((uint64_t)min + offset);
+}
+
+double osty_rt_random_float(void *raw_state) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    uint64_t x = osty_rt_random_next_u64(state);
+    return (double)(x >> 11) * (1.0 / 9007199254740992.0);
+}
+
+bool osty_rt_random_bool(void *raw_state) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    return (osty_rt_random_next_u64(state) & 1ULL) != 0;
+}
+
+void *osty_rt_random_bytes(void *raw_state, int64_t n) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    osty_rt_bytes *out;
+    size_t len;
+    size_t total;
+    size_t i;
+
+    if (n < 0) {
+        osty_rt_abort("runtime.random.bytes: negative length");
+    }
+    len = (size_t)n;
+    if (len > SIZE_MAX - sizeof(osty_rt_bytes)) {
+        osty_rt_abort("runtime.random.bytes: size overflow");
+    }
+    total = sizeof(osty_rt_bytes) + len;
+    out = (osty_rt_bytes *)osty_gc_allocate_managed(
+        total, OSTY_GC_KIND_BYTES,
+        len == 0 ? "runtime.random.bytes.empty" : "runtime.random.bytes", NULL,
+        NULL);
+    out->data = (unsigned char *)(out + 1);
+    out->len = (int64_t)len;
+    i = 0;
+    while (i < len) {
+        uint64_t chunk = osty_rt_random_next_u64(state);
+        size_t take = len - i;
+        if (take > sizeof(chunk)) {
+            take = sizeof(chunk);
+        }
+        memcpy(out->data + i, &chunk, take);
+        i += take;
+    }
+    return out;
+}
+
+void osty_rt_random_shuffle(void *raw_state, void *raw_list) {
+    osty_rt_random_state *state = (osty_rt_random_state *)raw_state;
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    int64_t i;
+
+    if (list == NULL || list->len <= 1 || list->elem_size <= 0) {
+        return;
+    }
+    for (i = list->len - 1; i > 0; i--) {
+        int64_t j =
+            (int64_t)osty_rt_random_sample_below(state, (uint64_t)i + 1ULL);
+        if (i != j) {
+            unsigned char *base = (unsigned char *)list->data;
+            size_t elem_size = (size_t)list->elem_size;
+            size_t a = (size_t)i * elem_size;
+            size_t b = (size_t)j * elem_size;
+            size_t k;
+            for (k = 0; k < elem_size; k++) {
+                unsigned char tmp = base[a + k];
+                base[a + k] = base[b + k];
+                base[b + k] = tmp;
+            }
+        }
+    }
 }
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7304,6 +7304,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdIoCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdRandomCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitPtrBackedErrorCall(call); found || err != nil {
 		return v, err
 	}
@@ -7339,6 +7342,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitPrimitiveToStringCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitStdRandomMethodCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitCharByteConversionCall(call); found || err != nil {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,6 +54,7 @@ type generator struct {
 	stdBytesAliases      map[string]bool
 	stdStringsAliases    map[string]bool
 	stdEnvAliases        map[string]bool
+	stdRandomAliases     map[string]bool
 	runtimeDecls         map[string]runtimeDecl
 	runtimeDeclOrder     []string
 	traceHelpers         map[string]string

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -274,6 +274,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
+		g.stdRandomAliases = collectStdRandomAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -307,6 +308,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdBytesAliases = collectStdBytesAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
+	g.stdRandomAliases = collectStdRandomAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/stdlib_random_shim.go
+++ b/internal/llvmgen/stdlib_random_shim.go
@@ -1,0 +1,524 @@
+package llvmgen
+
+import (
+	"github.com/osty/osty/internal/ast"
+)
+
+const ostyRtRandomDefaultSymbol = "osty_rt_random_default"
+const ostyRtRandomSeededSymbol = "osty_rt_random_seeded"
+const ostyRtRandomIntSymbol = "osty_rt_random_int"
+const ostyRtRandomIntInclusiveSymbol = "osty_rt_random_int_inclusive"
+const ostyRtRandomFloatSymbol = "osty_rt_random_float"
+const ostyRtRandomBoolSymbol = "osty_rt_random_bool"
+const ostyRtRandomBytesSymbol = "osty_rt_random_bytes"
+const ostyRtRandomShuffleSymbol = "osty_rt_random_shuffle"
+
+var stdRandomRngSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Rng"},
+}
+
+var stdRandomBytesSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Bytes"},
+}
+
+var stdRandomEmptyChoiceSourceTypeSingleton ast.Type = &ast.OptionalType{
+	Inner: &ast.NamedType{Path: []string{"Int"}},
+}
+
+func collectStdRandomAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "random" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "random"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func (g *generator) emitStdRandomCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdRandomCallField(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "default":
+		return g.emitStdRandomDefaultCall(call)
+	case "seeded":
+		return g.emitStdRandomSeededCall(call)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdRandomCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdRandomCallField(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "default", "seeded":
+		return value{
+			typ:        "ptr",
+			gcManaged:  true,
+			sourceType: stdRandomRngSourceTypeSingleton,
+		}, true
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdRandomCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdRandomCallField(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "default", "seeded":
+		return stdRandomRngSourceTypeSingleton, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) emitStdRandomMethodCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return value{}, false, nil
+	}
+	if !g.isStdRandomRngExpr(field.X) {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "int":
+		return g.emitStdRandomIntCall(call, field)
+	case "intInclusive":
+		return g.emitStdRandomIntInclusiveCall(call, field)
+	case "float":
+		return g.emitStdRandomFloatCall(call, field)
+	case "bool":
+		return g.emitStdRandomBoolCall(call, field)
+	case "bytes":
+		return g.emitStdRandomBytesCall(call, field)
+	case "choice":
+		return g.emitStdRandomChoiceCall(call, field)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdRandomMethodStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || !g.isStdRandomRngExpr(field.X) {
+		return value{}, false
+	}
+	switch field.Name {
+	case "int", "intInclusive":
+		return value{typ: "i64"}, true
+	case "float":
+		return value{typ: "double"}, true
+	case "bool":
+		return value{typ: "i1"}, true
+	case "bytes":
+		return value{
+			typ:        "ptr",
+			gcManaged:  true,
+			sourceType: stdRandomBytesSourceTypeSingleton,
+		}, true
+	case "choice":
+		source, ok := g.staticStdRandomChoiceSourceType(call)
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        "ptr",
+			gcManaged:  true,
+			sourceType: source,
+		}, true
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdRandomMethodSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || !g.isStdRandomRngExpr(field.X) {
+		return nil, false
+	}
+	switch field.Name {
+	case "bytes":
+		return stdRandomBytesSourceTypeSingleton, true
+	case "choice":
+		return g.staticStdRandomChoiceSourceType(call)
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) emitStdRandomCallStmt(call *ast.CallExpr) (bool, error) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || field.Name != "shuffle" || !g.isStdRandomRngExpr(field.X) {
+		return false, nil
+	}
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return true, unsupported("call", "random.Rng.shuffle requires one positional List argument")
+	}
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	g.takeOstyEmitter(emitter)
+
+	rng, err := g.emitExpr(field.X)
+	if err != nil {
+		return true, err
+	}
+	rng, err = g.loadIfPointer(rng)
+	if err != nil {
+		return true, err
+	}
+	if rng.typ != "ptr" {
+		return true, unsupportedf("type-system", "random.Rng receiver type %s", rng.typ)
+	}
+	items, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return true, err
+	}
+	items, err = g.loadIfPointer(items)
+	if err != nil {
+		return true, err
+	}
+	if items.typ != "ptr" || items.listElemTyp == "" {
+		return true, unsupported("type-system", "random.Rng.shuffle requires List<T>")
+	}
+	g.declareRuntimeSymbol(ostyRtRandomShuffleSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
+		ostyRtRandomShuffleSymbol,
+		llvmCallArgs([]*LlvmValue{toOstyValue(rng), toOstyValue(items)}),
+	))
+	g.takeOstyEmitter(emitter)
+	return true, nil
+}
+
+func (g *generator) stdRandomCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdRandomAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdRandomAliases[alias.Name] {
+		return nil, false
+	}
+	return field, true
+}
+
+func (g *generator) emitStdRandomDefaultCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "random.default takes no arguments, got %d", len(call.Args))
+	}
+	g.declareRuntimeSymbol(ostyRtRandomDefaultSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRandomDefaultSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = stdRandomRngSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdRandomSeededCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupported("call", "random.seeded requires one positional Int64 seed")
+	}
+	seed, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	seed, err = g.loadIfPointer(seed)
+	if err != nil {
+		return value{}, true, err
+	}
+	if seed.typ != "i64" {
+		return value{}, true, unsupportedf("type-system", "random.seeded arg 1 type %s, want Int64", seed.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtRandomSeededSymbol, "ptr", []paramInfo{{typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRandomSeededSymbol, []*LlvmValue{toOstyValue(seed)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = stdRandomRngSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdRandomIntCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, true, unsupported("call", "random.Rng.int requires two positional Int arguments")
+	}
+	rng, lo, hi, err := g.emitStdRandomI64Args(field.X, call.Args[0].Value, call.Args[1].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRandomIntSymbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i64", ostyRtRandomIntSymbol, []*LlvmValue{toOstyValue(rng), toOstyValue(lo), toOstyValue(hi)})
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), true, nil
+}
+
+func (g *generator) emitStdRandomIntInclusiveCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, true, unsupported("call", "random.Rng.intInclusive requires two positional Int arguments")
+	}
+	rng, lo, hi, err := g.emitStdRandomI64Args(field.X, call.Args[0].Value, call.Args[1].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRandomIntInclusiveSymbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i64", ostyRtRandomIntInclusiveSymbol, []*LlvmValue{toOstyValue(rng), toOstyValue(lo), toOstyValue(hi)})
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), true, nil
+}
+
+func (g *generator) emitStdRandomFloatCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "random.Rng.float takes no arguments, got %d", len(call.Args))
+	}
+	rng, err := g.emitStdRandomReceiver(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRandomFloatSymbol, "double", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "double", ostyRtRandomFloatSymbol, []*LlvmValue{toOstyValue(rng)})
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), true, nil
+}
+
+func (g *generator) emitStdRandomBoolCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "random.Rng.bool takes no arguments, got %d", len(call.Args))
+	}
+	rng, err := g.emitStdRandomReceiver(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRandomBoolSymbol, "i1", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i1", ostyRtRandomBoolSymbol, []*LlvmValue{toOstyValue(rng)})
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), true, nil
+}
+
+func (g *generator) emitStdRandomBytesCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupported("call", "random.Rng.bytes requires one positional Int argument")
+	}
+	rng, err := g.emitStdRandomReceiver(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	n, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	n, err = g.loadIfPointer(n)
+	if err != nil {
+		return value{}, true, err
+	}
+	if n.typ != "i64" {
+		return value{}, true, unsupportedf("type-system", "random.Rng.bytes arg 1 type %s, want Int", n.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtRandomBytesSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRandomBytesSymbol, []*LlvmValue{toOstyValue(rng), toOstyValue(n)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = stdRandomBytesSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdRandomChoiceCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupported("call", "random.Rng.choice requires one positional List argument")
+	}
+	if list, ok := call.Args[0].Value.(*ast.ListExpr); ok && len(list.Elems) == 0 {
+		return value{
+			typ:        "ptr",
+			ref:        "null",
+			gcManaged:  true,
+			sourceType: stdRandomEmptyChoiceSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType("ptr"),
+		}, true, nil
+	}
+	rng, err := g.emitStdRandomReceiver(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	items, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	items, err = g.loadIfPointer(items)
+	if err != nil {
+		return value{}, true, err
+	}
+	if items.typ != "ptr" || items.listElemTyp == "" {
+		return value{}, true, unsupported("type-system", "random.Rng.choice requires List<T>")
+	}
+	optionSource, ok := g.staticStdRandomChoiceSourceType(call)
+	if !ok {
+		return value{}, true, unsupported("type-system", "random.Rng.choice requires a concrete List<T> element type")
+	}
+	byteSize, scalar, ok := listGetBoxByteSize(items.listElemTyp)
+	if !ok {
+		return value{}, true, unsupportedf("type-system", "random.Rng.choice on List<%s>: Option lowering not yet wired for this element type", items.listElemTyp)
+	}
+
+	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(ostyRtRandomIntSymbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	lenVal := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(items)})
+	hasItems := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirICmpSGTI64ZeroText(hasItems, lenVal.name))
+	inLabel := llvmNextLabel(emitter, "random.choice.some")
+	outLabel := llvmNextLabel(emitter, "random.choice.none")
+	endLabel := llvmNextLabel(emitter, "random.choice.end")
+	emitter.body = append(emitter.body, mirBrCondText(hasItems, inLabel, outLabel))
+	emitter.body = append(emitter.body, mirLabelText(inLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(inLabel)
+
+	emitter = g.toOstyEmitter()
+	idxVal := llvmCall(emitter, "i64", ostyRtRandomIntSymbol, []*LlvmValue{
+		toOstyValue(rng),
+		{typ: "i64", name: "0"},
+		lenVal,
+	})
+	g.takeOstyEmitter(emitter)
+	idx := fromOstyValue(idxVal)
+	got, err := g.emitListElementValue(items, idx)
+	if err != nil {
+		return value{}, true, err
+	}
+	emitter = g.toOstyEmitter()
+	var someRef string
+	if scalar {
+		site := "random.choice.box." + items.listElemTyp
+		box := llvmGcAlloc(emitter, 1, byteSize, site)
+		emitter.body = append(emitter.body, mirStoreText(got.typ, got.ref, box.name))
+		someRef = box.name
+		g.needsGCRuntime = true
+	} else {
+		someRef = got.ref
+	}
+	inPred := g.currentBlock
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(outLabel))
+	emitter.body = append(emitter.body, mirBrUncondText(endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirPhiPtrFromValueOrNullText(tmp, someRef, inPred, outLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+	out := value{typ: "ptr", ref: tmp, gcManaged: true, sourceType: optionSource}
+	out.rootPaths = g.rootPathsForType(out.typ)
+	return out, true, nil
+}
+
+func (g *generator) emitStdRandomReceiver(expr ast.Expr) (value, error) {
+	rng, err := g.emitExpr(expr)
+	if err != nil {
+		return value{}, err
+	}
+	rng, err = g.loadIfPointer(rng)
+	if err != nil {
+		return value{}, err
+	}
+	if rng.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "random.Rng receiver type %s", rng.typ)
+	}
+	return rng, nil
+}
+
+func (g *generator) emitStdRandomI64Args(receiver ast.Expr, loExpr, hiExpr ast.Expr) (value, value, value, error) {
+	rng, err := g.emitStdRandomReceiver(receiver)
+	if err != nil {
+		return value{}, value{}, value{}, err
+	}
+	lo, err := g.emitExpr(loExpr)
+	if err != nil {
+		return value{}, value{}, value{}, err
+	}
+	lo, err = g.loadIfPointer(lo)
+	if err != nil {
+		return value{}, value{}, value{}, err
+	}
+	if lo.typ != "i64" {
+		return value{}, value{}, value{}, unsupportedf("type-system", "random bound type %s, want Int", lo.typ)
+	}
+	hi, err := g.emitExpr(hiExpr)
+	if err != nil {
+		return value{}, value{}, value{}, err
+	}
+	hi, err = g.loadIfPointer(hi)
+	if err != nil {
+		return value{}, value{}, value{}, err
+	}
+	if hi.typ != "i64" {
+		return value{}, value{}, value{}, unsupportedf("type-system", "random bound type %s, want Int", hi.typ)
+	}
+	return rng, lo, hi, nil
+}
+
+func (g *generator) isStdRandomRngExpr(expr ast.Expr) bool {
+	src, ok := g.staticExprSourceType(expr)
+	if !ok {
+		return false
+	}
+	named, ok := src.(*ast.NamedType)
+	return ok && len(named.Path) == 1 && named.Path[0] == "Rng"
+}
+
+func (g *generator) staticStdRandomChoiceSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Value == nil {
+		return nil, false
+	}
+	if list, ok := call.Args[0].Value.(*ast.ListExpr); ok && len(list.Elems) == 0 {
+		return stdRandomEmptyChoiceSourceTypeSingleton, true
+	}
+	argType, ok := g.staticExprSourceType(call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	list, ok := argType.(*ast.NamedType)
+	if !ok || len(list.Path) != 1 || list.Path[0] != "List" || len(list.Args) != 1 {
+		return nil, false
+	}
+	return &ast.OptionalType{Inner: list.Args[0]}, true
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1273,6 +1273,9 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 	if emitted, err := g.emitStdIoCallStmt(call); emitted || err != nil {
 		return err
 	}
+	if emitted, err := g.emitStdRandomCallStmt(call); emitted || err != nil {
+		return err
+	}
 	if emitted, err := g.emitOptionalUserCallStmt(call); emitted || err != nil {
 		return err
 	}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -440,6 +440,12 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdEnvCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdRandomCallSourceType(e); ok {
+			return src, true
+		}
+		if src, ok := g.staticStdRandomMethodSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticPtrBackedErrorCallSourceType(e); ok {
 			return src, true
 		}
@@ -927,6 +933,12 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return out, true
 		}
 		if out, ok := g.stdEnvCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdRandomCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdRandomMethodStaticResult(e); ok {
 			return out, true
 		}
 	case *ast.FieldExpr:
@@ -1939,6 +1951,9 @@ func llvmType(t ast.Type, env typeEnv) (string, error) {
 		}
 		if typ := llvmNamedType(name, len(tt.Path), len(tt.Args), structType, enumType); typ != "" {
 			return typ, nil
+		}
+		if len(tt.Path) == 1 && len(tt.Args) == 0 && tt.Path[0] == "Rng" {
+			return "ptr", nil
 		}
 		return "", unsupportedf("type-system", "type %q", strings.Join(tt.Path, "."))
 	case *ast.OptionalType, *ast.FnType:

--- a/internal/stdlib/modules/random.osty
+++ b/internal/stdlib/modules/random.osty
@@ -1,8 +1,7 @@
 // std.random — non-cryptographic pseudorandom numbers (spec §10.14).
 //
-// Primitive methods and constructors are body-less; the backend lowers
-// them to the runtime RNG bridge. `choice` is a derived helper with a
-// real Osty body that composes over the primitive surface.
+// Constructors and primitive methods are runtime-backed. `choice`
+// stays as the canonical derived helper over the primitive surface.
 
 pub struct Rng {
     pub fn int(self, min: Int, max: Int) -> Int


### PR DESCRIPTION
## Summary
- add runtime-backed std.random support for the public LLVM backend
- wire std.random alias-qualified calls through llvmgen shims and source-type tracking
- cover seeded/default RNG behavior, bytes, choice, and shuffle with backend tests

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)