### PR TITLE
feat: expand std.fs whole-file api

### DIFF
--- a/LANG_SPEC_v0.5/04-expressions.md
+++ b/LANG_SPEC_v0.5/04-expressions.md
@@ -378,13 +378,10 @@ exits.
 
 ```osty
 fn process(path: String) -> Result<(), Error> {
-    let f = fs.open(path)?
-    defer f.close()
-
     let conn = net.connect("api.com")?
     defer conn.close()
 
-    let data = f.read()?
+    let data = fs.read(path)?
     let result = conn.send(data)?
     Ok(())
 }
@@ -394,9 +391,11 @@ Inside a loop, `defer` runs at the end of each iteration:
 
 ```osty
 for path in paths {
-    let f = fs.open(path)?
-    defer f.close()
-    process(f)?
+    let tmp = path + ".tmp"
+    defer {
+        ignoreError(fs.remove(tmp))
+    }
+    process(path)?
 }
 ```
 

--- a/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
@@ -1,7 +1,9 @@
 ### 10.1 Tier 1 (Core)
 
 - `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`
-- `std.fs` — file I/O
+- `std.fs` — whole-file and path operations:
+  `read`, `readToString`, `write`, `writeString`, `exists`,
+  `create`, `remove`, `rename`, `copy`, `mkdir`, `mkdirAll`
 - `std.strings` — string manipulation
 - `std.collections` — `List`, `Map`, `Set`
 - `std.option` — `Option`, `Some`, `None` (auto-imported)

--- a/LANG_SPEC_v0.5/16-io-protocol.md
+++ b/LANG_SPEC_v0.5/16-io-protocol.md
@@ -1,8 +1,10 @@
 ## 16. I/O Protocol
 
 The `Reader` and `Writer` interfaces define the streaming I/O contract
-shared across `std.io`, `std.fs`, `std.compress`, `std.http`, and the
-FFI byte-stream bridges.
+shared across `std.io`, stream-oriented standard-library modules, and
+FFI byte-stream bridges. `std.fs` currently exposes whole-file and
+path-mutation helpers; future handle-based filesystem APIs plug into
+this same protocol surface.
 
 ```osty
 pub interface Reader {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -16904,3 +16904,430 @@ void *osty_rt_env_set_current_dir(const char *path) {
     return osty_rt_env_error_message("failed to set current directory", strerror(err), "runtime.env.set_current_dir.error");
 #endif
 }
+
+/* ---- std.fs whole-file and path-mutation helpers --------------------- */
+
+static OSTY_RT_TLS const char *osty_rt_fs_last_error_literal = NULL;
+
+static void osty_rt_fs_clear_last_error(void) {
+    osty_rt_fs_last_error_literal = NULL;
+}
+
+static void osty_rt_fs_set_last_error_literal(const char *detail) {
+    osty_rt_fs_last_error_literal = detail;
+}
+
+static void *osty_rt_fs_error_message(const char *prefix, const char *site) {
+    if (osty_rt_fs_last_error_literal != NULL) {
+        return osty_rt_env_error_message(prefix, osty_rt_fs_last_error_literal, site);
+    }
+    if (errno == 0) {
+        return osty_rt_env_error_message(prefix, "unknown error", site);
+    }
+    return osty_rt_env_error_message(prefix, strerror(errno), site);
+}
+
+static int osty_rt_fs_read_all(const char *path, unsigned char **out, size_t *out_len) {
+    FILE *f;
+    long sz;
+    unsigned char *buf;
+    size_t got;
+
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    osty_rt_fs_clear_last_error();
+    f = fopen(path, "rb");
+    if (f == NULL) {
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        int err = errno;
+        fclose(f);
+        errno = err;
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    sz = ftell(f);
+    if (sz < 0 || fseek(f, 0, SEEK_SET) != 0) {
+        int err = errno;
+        fclose(f);
+        errno = err;
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    buf = (unsigned char *)osty_rt_xmalloc((size_t)sz + 1, "runtime.fs.read.buf");
+    got = fread(buf, 1, (size_t)sz, f);
+    if (got != (size_t)sz) {
+        int err = errno;
+        free(buf);
+        fclose(f);
+        errno = err;
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    if (fclose(f) != 0) {
+        int err = errno;
+        free(buf);
+        errno = err;
+        *out = NULL;
+        *out_len = 0;
+        return -1;
+    }
+    buf[sz] = '\0';
+    *out = buf;
+    *out_len = (size_t)sz;
+    return 0;
+}
+
+static int osty_rt_fs_write_all(const char *path, const unsigned char *data, size_t len) {
+    FILE *f;
+
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return -1;
+    }
+    osty_rt_fs_clear_last_error();
+    f = fopen(path, "wb");
+    if (f == NULL) {
+        return -1;
+    }
+    if (len != 0) {
+        size_t wrote = fwrite(data, 1, len, f);
+        if (wrote != len) {
+            int err = errno;
+            fclose(f);
+            errno = err;
+            return -1;
+        }
+    }
+    if (fclose(f) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int osty_rt_fs_mkdir_allow_existing(const char *path) {
+    if (path == NULL || path[0] == '\0') {
+        errno = ENOENT;
+        return -1;
+    }
+    if (OSTY_RT_MKDIR_ONE(path) == 0) {
+        return 0;
+    }
+    if (errno != EEXIST) {
+        return -1;
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    {
+        DWORD attrs = GetFileAttributesA(path);
+        if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return 0;
+        }
+    }
+    errno = ENOTDIR;
+    return -1;
+#else
+    {
+        struct stat st;
+        if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
+            return 0;
+        }
+    }
+    errno = ENOTDIR;
+    return -1;
+#endif
+}
+
+static int osty_rt_fs_mkdir_p(const char *path) {
+    size_t n;
+    char *buf;
+    size_t i;
+    int rc;
+
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return -1;
+    }
+    if (path[0] == '\0') {
+        errno = ENOENT;
+        return -1;
+    }
+    osty_rt_fs_clear_last_error();
+    n = strlen(path);
+    buf = osty_rt_strndup(path, n, "runtime.fs.mkdir_all.buf");
+    for (i = 1; i < n; i++) {
+        char c = buf[i];
+        if (c == '/' || c == '\\') {
+            buf[i] = '\0';
+            rc = osty_rt_fs_mkdir_allow_existing(buf);
+            buf[i] = c;
+            if (rc != 0) {
+                free(buf);
+                return -1;
+            }
+        }
+    }
+    rc = osty_rt_fs_mkdir_allow_existing(buf);
+    free(buf);
+    return rc;
+}
+
+void *osty_rt_fs_read(const char *path) {
+    char path_buf[9];
+    unsigned char *raw = NULL;
+    size_t raw_len = 0;
+    void *out;
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (osty_rt_fs_read_all(path, &raw, &raw_len) != 0) {
+        return NULL;
+    }
+    out = osty_rt_bytes_dup_site(raw_len == 0 ? NULL : raw, raw_len,
+                                 raw_len == 0 ? "runtime.fs.read.empty" : "runtime.fs.read");
+    free(raw);
+    return out;
+}
+
+void *osty_rt_fs_read_error(void) {
+    return osty_rt_fs_error_message("failed to read file", "runtime.fs.read.error");
+}
+
+void *osty_rt_fs_read_string(const char *path) {
+    char path_buf[9];
+    unsigned char *raw = NULL;
+    size_t raw_len = 0;
+    void *out;
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (osty_rt_fs_read_all(path, &raw, &raw_len) != 0) {
+        return NULL;
+    }
+    if (!osty_rt_bytes_validate_utf8_data(raw, raw_len)) {
+        free(raw);
+        osty_rt_fs_set_last_error_literal("file is not valid UTF-8");
+        errno = 0;
+        return NULL;
+    }
+    out = osty_rt_string_dup_site((const char *)raw, raw_len,
+                                  raw_len == 0 ? "runtime.fs.read_string.empty" : "runtime.fs.read_string");
+    free(raw);
+    return out;
+}
+
+void *osty_rt_fs_read_string_error(void) {
+    return osty_rt_fs_error_message("failed to read text file", "runtime.fs.read_string.error");
+}
+
+bool osty_rt_fs_exists(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (path == NULL || path[0] == '\0') {
+        return false;
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    return GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES;
+#else
+    {
+        struct stat st;
+        return stat(path, &st) == 0;
+    }
+#endif
+}
+
+void *osty_rt_fs_write_bytes(const char *path, void *raw_bytes) {
+    char path_buf[9];
+    osty_rt_bytes *bytes = (osty_rt_bytes *)raw_bytes;
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (bytes == NULL) {
+        osty_rt_fs_set_last_error_literal("contents is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to write file", "runtime.fs.write.error");
+    }
+    if (osty_rt_fs_write_all(path, bytes->data, (size_t)bytes->len) != 0) {
+        return osty_rt_fs_error_message("failed to write file", "runtime.fs.write.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_write_string(const char *path, const char *contents) {
+    char path_buf[9];
+    char contents_buf[9];
+    size_t len;
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    osty_rt_string_decode_to_buf_if_inline(&contents, contents_buf);
+    if (contents == NULL) {
+        osty_rt_fs_set_last_error_literal("contents is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to write text file", "runtime.fs.write_string.error");
+    }
+    len = osty_rt_string_len(contents);
+    if (osty_rt_fs_write_all(path, (const unsigned char *)contents, len) != 0) {
+        return osty_rt_fs_error_message("failed to write text file", "runtime.fs.write_string.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_create(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (osty_rt_fs_write_all(path, NULL, 0) != 0) {
+        return osty_rt_fs_error_message("failed to create file", "runtime.fs.create.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_remove(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to remove path", "runtime.fs.remove.error");
+    }
+    osty_rt_fs_clear_last_error();
+    if (remove(path) == 0) {
+        return NULL;
+    }
+    return osty_rt_fs_error_message("failed to remove path", "runtime.fs.remove.error");
+}
+
+void *osty_rt_fs_rename(const char *from, const char *to) {
+    char from_buf[9];
+    char to_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&from, from_buf);
+    osty_rt_string_decode_to_buf_if_inline(&to, to_buf);
+    if (from == NULL) {
+        osty_rt_fs_set_last_error_literal("source path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to rename path", "runtime.fs.rename.error");
+    }
+    if (to == NULL) {
+        osty_rt_fs_set_last_error_literal("destination path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to rename path", "runtime.fs.rename.error");
+    }
+    osty_rt_fs_clear_last_error();
+    if (rename(from, to) == 0) {
+        return NULL;
+    }
+    return osty_rt_fs_error_message("failed to rename path", "runtime.fs.rename.error");
+}
+
+void *osty_rt_fs_copy(const char *from, const char *to) {
+    char from_buf[9];
+    char to_buf[9];
+    FILE *src = NULL;
+    FILE *dst = NULL;
+    unsigned char buf[8192];
+    int err = 0;
+
+    osty_rt_string_decode_to_buf_if_inline(&from, from_buf);
+    osty_rt_string_decode_to_buf_if_inline(&to, to_buf);
+    if (from == NULL) {
+        osty_rt_fs_set_last_error_literal("source path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to copy file", "runtime.fs.copy.error");
+    }
+    if (to == NULL) {
+        osty_rt_fs_set_last_error_literal("destination path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to copy file", "runtime.fs.copy.error");
+    }
+    osty_rt_fs_clear_last_error();
+    src = fopen(from, "rb");
+    if (src == NULL) {
+        return osty_rt_fs_error_message("failed to copy file", "runtime.fs.copy.error");
+    }
+    dst = fopen(to, "wb");
+    if (dst == NULL) {
+        err = errno;
+        fclose(src);
+        errno = err;
+        return osty_rt_fs_error_message("failed to copy file", "runtime.fs.copy.error");
+    }
+    for (;;) {
+        size_t n = fread(buf, 1, sizeof(buf), src);
+        if (n != 0) {
+            size_t wrote = fwrite(buf, 1, n, dst);
+            if (wrote != n) {
+                err = errno;
+                goto copy_fail;
+            }
+        }
+        if (n < sizeof(buf)) {
+            if (ferror(src)) {
+                err = errno;
+                goto copy_fail;
+            }
+            break;
+        }
+    }
+    if (fclose(dst) != 0) {
+        err = errno;
+        dst = NULL;
+        goto copy_fail;
+    }
+    dst = NULL;
+    if (fclose(src) != 0) {
+        err = errno;
+        src = NULL;
+        goto copy_fail;
+    }
+    return NULL;
+
+copy_fail:
+    if (dst != NULL) {
+        fclose(dst);
+    }
+    if (src != NULL) {
+        fclose(src);
+    }
+    if (err != 0) {
+        errno = err;
+    }
+    return osty_rt_fs_error_message("failed to copy file", "runtime.fs.copy.error");
+}
+
+void *osty_rt_fs_mkdir(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to create directory", "runtime.fs.mkdir.error");
+    }
+    osty_rt_fs_clear_last_error();
+    if (OSTY_RT_MKDIR_ONE(path) == 0) {
+        return NULL;
+    }
+    return osty_rt_fs_error_message("failed to create directory", "runtime.fs.mkdir.error");
+}
+
+void *osty_rt_fs_mkdir_all(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (osty_rt_fs_mkdir_p(path) == 0) {
+        return NULL;
+    }
+    return osty_rt_fs_error_message("failed to create directory tree", "runtime.fs.mkdir_all.error");
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7298,6 +7298,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdStringsCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdFsCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,6 +54,7 @@ type generator struct {
 	stdBytesAliases      map[string]bool
 	stdStringsAliases    map[string]bool
 	stdEnvAliases        map[string]bool
+	stdFsAliases         map[string]bool
 	runtimeDecls         map[string]runtimeDecl
 	runtimeDeclOrder     []string
 	traceHelpers         map[string]string

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -157,6 +157,7 @@ type nativeProjectionCtx struct {
 	runtimeFFI            map[string]map[string]*nativeRuntimeFFIFunction
 	testingAliases        map[string]bool
 	stdIoAliases          map[string]bool
+	stdFsAliases          map[string]bool
 	runtimeDecls          []string
 	runtimeDeclSet        map[string]bool
 	scopes                []map[string]nativeExprInfo
@@ -331,6 +332,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		runtimeFFI:        map[string]map[string]*nativeRuntimeFFIFunction{},
 		testingAliases:    map[string]bool{},
 		stdIoAliases:      map[string]bool{},
+		stdFsAliases:      map[string]bool{},
 		runtimeDeclSet:    map[string]bool{},
 		sourcePath:        firstNonEmpty(opts.SourcePath, "<unknown>"),
 		source:            append([]byte(nil), opts.Source...),
@@ -370,6 +372,9 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 			}
 			if nativeIsStdIoUse(d) {
 				ctx.stdIoAliases[nativeUseAlias(d)] = true
+			}
+			if nativeIsStdFsUse(d) {
+				ctx.stdFsAliases[nativeUseAlias(d)] = true
 			}
 		case *ostyir.StructDecl:
 			info, ok := nativeRegisterStructDecl(d)
@@ -1926,6 +1931,10 @@ func nativeIsStdIoUse(d *ostyir.UseDecl) bool {
 	return d != nil && !d.IsGoFFI && !d.IsRuntimeFFI && d.RawPath == "std.io"
 }
 
+func nativeIsStdFsUse(d *ostyir.UseDecl) bool {
+	return d != nil && !d.IsGoFFI && !d.IsRuntimeFFI && d.RawPath == "std.fs"
+}
+
 func nativeStdIoCallMethod(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (string, bool) {
 	alias, name, ok := nativeQualifiedAliasCall(call)
 	if !ok || ctx == nil || !ctx.stdIoAliases[alias] || !isStdIoOutputMethod(name) {
@@ -2062,6 +2071,283 @@ func nativeStdIoIntrinsicExpr(ctx *nativeProjectionCtx, e *ostyir.IntrinsicCall)
 		return nil, false
 	}
 	return nativeStdIoWriteExpr(ctx, e.Args[0].Value, method)
+}
+
+func nativeStdFsCallMethod(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (string, bool) {
+	alias, name, ok := nativeQualifiedAliasCall(call)
+	if !ok || ctx == nil || !ctx.stdFsAliases[alias] {
+		return "", false
+	}
+	return name, true
+}
+
+func nativeStdFsStringExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeExpr, bool) {
+	if ctx == nil || expr == nil || !nativeTypeIsString(expr.Type()) {
+		return nil, false
+	}
+	return nativeExprFromIR(ctx, expr)
+}
+
+func nativeStdFsBytesExpr(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeExpr, bool) {
+	if ctx == nil || expr == nil || !nativeTypeIsBytes(expr.Type()) {
+		return nil, false
+	}
+	return nativeExprFromIR(ctx, expr)
+}
+
+func nativeStdFsResultInfo(ctx *nativeProjectionCtx, method string) (*nativeResultInfo, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	var okIR ostyir.Type
+	switch method {
+	case "read":
+		okIR = ostyir.TBytes
+	case "readToString":
+		okIR = ostyir.TString
+	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+		okIR = &ostyir.TupleType{}
+	default:
+		return nil, false
+	}
+	errIR := &ostyir.NamedType{Name: "Error", Builtin: true}
+	llvmType, ok := nativeRegisterResultType(ctx, okIR, errIR)
+	if !ok {
+		return nil, false
+	}
+	info := ctx.resultsByLLVMType[llvmType]
+	return info, info != nil
+}
+
+func nativeStdFsPtrResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, valueSymbol, errorSymbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 1 || call.Args[0].IsKeyword() || call.Args[0].Value == nil {
+		return nil, false
+	}
+	method, _, _ := strings.Cut(strings.TrimPrefix(valueSymbol, "osty_rt_fs_"), "_")
+	if valueSymbol == ostyRtFsReadSymbol {
+		method = "read"
+	}
+	if valueSymbol == ostyRtFsReadStringSymbol {
+		method = "readToString"
+	}
+	resultInfo, ok := nativeStdFsResultInfo(ctx, method)
+	if !ok {
+		return nil, false
+	}
+	path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	ctx.addRuntimeDecl("declare ptr @" + valueSymbol + "(ptr)")
+	ctx.addRuntimeDecl("declare ptr @" + errorSymbol + "()")
+	read := nativeRuntimeCallExpr("ptr", valueSymbol, path)
+	return &llvmNativeExpr{
+		kind:     llvmNativeExprIf,
+		llvmType: resultInfo.def.llvmType,
+		childExprs: []*llvmNativeExpr{{
+			kind:     llvmNativeExprBinary,
+			llvmType: "i1",
+			op:       "==",
+			childExprs: []*llvmNativeExpr{
+				read,
+				nativeZeroExprForLLVMType("ptr"),
+			},
+		}},
+		childBlocks: []*llvmNativeBlock{
+			{
+				hasResult: true,
+				result: &llvmNativeExpr{
+					kind:     llvmNativeExprStructLit,
+					llvmType: resultInfo.def.llvmType,
+					childExprs: []*llvmNativeExpr{
+						{kind: llvmNativeExprInt, llvmType: "i64", text: "1"},
+						nativeZeroExprForLLVMType(resultInfo.okType),
+						nativeRuntimeCallExpr("ptr", errorSymbol),
+					},
+				},
+			},
+			{
+				hasResult: true,
+				result: &llvmNativeExpr{
+					kind:     llvmNativeExprStructLit,
+					llvmType: resultInfo.def.llvmType,
+					childExprs: []*llvmNativeExpr{
+						{kind: llvmNativeExprInt, llvmType: "i64", text: "0"},
+						read,
+						nativeZeroExprForLLVMType(resultInfo.errType),
+					},
+				},
+			},
+		},
+	}, true
+}
+
+func nativeStdFsUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, symbol string, args ...*llvmNativeExpr) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil {
+		return nil, false
+	}
+	method := strings.TrimPrefix(symbol, "osty_rt_fs_")
+	if method == "write_bytes" {
+		method = "write"
+	}
+	if method == "write_string" {
+		method = "writeString"
+	}
+	if method == "mkdir_all" {
+		method = "mkdirAll"
+	}
+	resultInfo, ok := nativeStdFsResultInfo(ctx, method)
+	if !ok {
+		return nil, false
+	}
+	ctx.addRuntimeDecl("declare ptr @" + symbol + "(" + strings.Join(nativeStdFsDeclParams(len(args)), ", ") + ")")
+	errExpr := nativeRuntimeCallExpr("ptr", symbol, args...)
+	return &llvmNativeExpr{
+		kind:     llvmNativeExprIf,
+		llvmType: resultInfo.def.llvmType,
+		childExprs: []*llvmNativeExpr{{
+			kind:     llvmNativeExprBinary,
+			llvmType: "i1",
+			op:       "==",
+			childExprs: []*llvmNativeExpr{
+				errExpr,
+				nativeZeroExprForLLVMType("ptr"),
+			},
+		}},
+		childBlocks: []*llvmNativeBlock{
+			{
+				hasResult: true,
+				result: &llvmNativeExpr{
+					kind:     llvmNativeExprStructLit,
+					llvmType: resultInfo.def.llvmType,
+					childExprs: []*llvmNativeExpr{
+						{kind: llvmNativeExprInt, llvmType: "i64", text: "0"},
+						nativeZeroExprForLLVMType(resultInfo.okType),
+						nativeZeroExprForLLVMType(resultInfo.errType),
+					},
+				},
+			},
+			{
+				hasResult: true,
+				result: &llvmNativeExpr{
+					kind:     llvmNativeExprStructLit,
+					llvmType: resultInfo.def.llvmType,
+					childExprs: []*llvmNativeExpr{
+						{kind: llvmNativeExprInt, llvmType: "i64", text: "1"},
+						nativeZeroExprForLLVMType(resultInfo.okType),
+						errExpr,
+					},
+				},
+			},
+		},
+	}, true
+}
+
+func nativeStdFsDeclParams(n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, "ptr")
+	}
+	return out
+}
+
+func nativeStdFsSinglePathUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, symbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 1 || call.Args[0].IsKeyword() || call.Args[0].Value == nil {
+		return nil, false
+	}
+	path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	return nativeStdFsUnitResultExpr(ctx, call, symbol, path)
+}
+
+func nativeStdFsExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeExpr, bool) {
+	method, ok := nativeStdFsCallMethod(ctx, call)
+	if !ok {
+		return nil, false
+	}
+	switch method {
+	case "read":
+		return nativeStdFsPtrResultExpr(ctx, call, ostyRtFsReadSymbol, ostyRtFsReadErrorSymbol)
+	case "readToString":
+		return nativeStdFsPtrResultExpr(ctx, call, ostyRtFsReadStringSymbol, ostyRtFsReadStringErrorSymbol)
+	case "write":
+		if len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return nil, false
+		}
+		path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		contents, ok := nativeStdFsBytesExpr(ctx, call.Args[1].Value)
+		if !ok {
+			return nil, false
+		}
+		return nativeStdFsUnitResultExpr(ctx, call, ostyRtFsWriteBytesSymbol, path, contents)
+	case "writeString":
+		if len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return nil, false
+		}
+		path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		contents, ok := nativeStdFsStringExpr(ctx, call.Args[1].Value)
+		if !ok {
+			return nil, false
+		}
+		return nativeStdFsUnitResultExpr(ctx, call, ostyRtFsWriteStringSymbol, path, contents)
+	case "exists":
+		if len(call.Args) != 1 || call.Args[0].IsKeyword() || call.Args[0].Value == nil {
+			return nil, false
+		}
+		path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		ctx.addRuntimeDecl("declare i1 @" + ostyRtFsExistsSymbol + "(ptr)")
+		return nativeRuntimeCallExpr("i1", ostyRtFsExistsSymbol, path), true
+	case "create":
+		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsCreateSymbol)
+	case "remove":
+		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsRemoveSymbol)
+	case "rename":
+		if len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return nil, false
+		}
+		from, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		to, ok := nativeStdFsStringExpr(ctx, call.Args[1].Value)
+		if !ok {
+			return nil, false
+		}
+		return nativeStdFsUnitResultExpr(ctx, call, ostyRtFsRenameSymbol, from, to)
+	case "copy":
+		if len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return nil, false
+		}
+		from, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		to, ok := nativeStdFsStringExpr(ctx, call.Args[1].Value)
+		if !ok {
+			return nil, false
+		}
+		return nativeStdFsUnitResultExpr(ctx, call, ostyRtFsCopySymbol, from, to)
+	case "mkdir":
+		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsMkdirSymbol)
+	case "mkdirAll":
+		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsMkdirAllSymbol)
+	default:
+		return nil, false
+	}
 }
 
 func nativeSourceSpanText(ctx *nativeProjectionCtx, n ostyir.Node) string {
@@ -3412,6 +3698,9 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 	case *ostyir.CallExpr:
 		if stdIoExpr, ok := nativeStdIoExprFromIR(ctx, e); ok {
 			return stdIoExpr, true
+		}
+		if stdFsExpr, ok := nativeStdFsExprFromIR(ctx, e); ok {
+			return stdFsExpr, true
 		}
 		if testingExpr, ok := nativeTestingResultExprFromIR(ctx, e); ok {
 			return testingExpr, true
@@ -5442,6 +5731,8 @@ func nativeLLVMTypeFromIR(ctx *nativeProjectionCtx, t ostyir.Type) (string, bool
 		if tt.Builtin {
 			switch tt.Name {
 			case "List", "Map", "Set":
+				return "ptr", true
+			case "Error":
 				return "ptr", true
 			case "Result":
 				if len(tt.Args) != 2 {

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -274,6 +274,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
+		g.stdFsAliases = collectStdFsAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -307,6 +308,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdBytesAliases = collectStdBytesAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
+	g.stdFsAliases = collectStdFsAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -2579,6 +2579,11 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 			return err
 		}
 	}
+	if strings.HasPrefix(fnRef.Symbol, "std.fs.") {
+		if handled, err := g.emitStdFsCall(c, fnRef); handled {
+			return err
+		}
+	}
 	if strings.HasPrefix(fnRef.Symbol, "std.hint.") {
 		if handled, err := g.emitStdHintCall(c, fnRef); handled {
 			return err

--- a/internal/llvmgen/stdlib_fs_shim.go
+++ b/internal/llvmgen/stdlib_fs_shim.go
@@ -1,0 +1,685 @@
+package llvmgen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	mir "github.com/osty/osty/internal/mir"
+)
+
+const ostyRtFsReadSymbol = "osty_rt_fs_read"
+const ostyRtFsReadErrorSymbol = "osty_rt_fs_read_error"
+const ostyRtFsReadStringSymbol = "osty_rt_fs_read_string"
+const ostyRtFsReadStringErrorSymbol = "osty_rt_fs_read_string_error"
+const ostyRtFsWriteBytesSymbol = "osty_rt_fs_write_bytes"
+const ostyRtFsWriteStringSymbol = "osty_rt_fs_write_string"
+const ostyRtFsExistsSymbol = "osty_rt_fs_exists"
+const ostyRtFsCreateSymbol = "osty_rt_fs_create"
+const ostyRtFsRemoveSymbol = "osty_rt_fs_remove"
+const ostyRtFsRenameSymbol = "osty_rt_fs_rename"
+const ostyRtFsCopySymbol = "osty_rt_fs_copy"
+const ostyRtFsMkdirSymbol = "osty_rt_fs_mkdir"
+const ostyRtFsMkdirAllSymbol = "osty_rt_fs_mkdir_all"
+
+var fsBytesSourceTypeSingleton ast.Type = &ast.NamedType{Path: []string{"Bytes"}}
+
+var stdFsReadResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		fsBytesSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdFsReadStringResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		&ast.NamedType{Path: []string{"String"}},
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdFsUnitSourceTypeSingleton ast.Type = &ast.TupleType{}
+
+var stdFsUnitErrorResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdFsUnitSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+func collectStdFsAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "fs" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "fs"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func (g *generator) emitStdFsCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdFsCallField(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "read":
+		return g.emitStdFsReadCall(call)
+	case "readToString":
+		return g.emitStdFsReadStringCall(call)
+	case "write":
+		return g.emitStdFsWriteCall(call)
+	case "writeString":
+		return g.emitStdFsWriteStringCall(call)
+	case "exists":
+		return g.emitStdFsExistsCall(call)
+	case "create":
+		return g.emitStdFsCreateCall(call)
+	case "remove":
+		return g.emitStdFsRemoveCall(call)
+	case "rename":
+		return g.emitStdFsRenameCall(call)
+	case "copy":
+		return g.emitStdFsCopyCall(call)
+	case "mkdir":
+		return g.emitStdFsMkdirCall(call)
+	case "mkdirAll":
+		return g.emitStdFsMkdirAllCall(call)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdFsCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdFsCallField(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "read":
+		info, ok := builtinResultTypeFromAST(stdFsReadResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdFsReadResultSourceTypeSingleton}, true
+	case "readToString":
+		info, ok := builtinResultTypeFromAST(stdFsReadStringResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdFsReadStringResultSourceTypeSingleton}, true
+	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+		info, ok := builtinResultTypeFromAST(stdFsUnitErrorResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdFsUnitErrorResultSourceTypeSingleton}, true
+	case "exists":
+		return value{typ: "i1", sourceType: &ast.NamedType{Path: []string{"Bool"}}}, true
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdFsCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdFsCallField(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "read":
+		return stdFsReadResultSourceTypeSingleton, true
+	case "readToString":
+		return stdFsReadStringResultSourceTypeSingleton, true
+	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+		return stdFsUnitErrorResultSourceTypeSingleton, true
+	case "exists":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) emitStdFsReadCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "fs.read expects 1 argument, got %d", len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], "read", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	return g.emitStdFsPtrResultFromRuntimeCall(
+		"fs.read",
+		stdFsReadResultSourceTypeSingleton,
+		ostyRtFsReadSymbol,
+		ostyRtFsReadErrorSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path)},
+	)
+}
+
+func (g *generator) emitStdFsReadStringCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "fs.readToString expects 1 argument, got %d", len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], "readToString", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	return g.emitStdFsPtrResultFromRuntimeCall(
+		"fs.readToString",
+		stdFsReadStringResultSourceTypeSingleton,
+		ostyRtFsReadStringSymbol,
+		ostyRtFsReadStringErrorSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path)},
+	)
+}
+
+func (g *generator) emitStdFsWriteCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.write expects 2 arguments, got %d", len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], "write", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	contents, err := g.emitStdFsBytesArg(call.Args[1], "write", 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs.write",
+		stdFsUnitErrorResultSourceTypeSingleton,
+		ostyRtFsWriteBytesSymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path), toOstyValue(contents)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsWriteStringCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.writeString expects 2 arguments, got %d", len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], "writeString", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	contents, err := g.emitStdFsStringArg(call.Args[1], "writeString", 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs.writeString",
+		stdFsUnitErrorResultSourceTypeSingleton,
+		ostyRtFsWriteStringSymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path), toOstyValue(contents)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsExistsCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "fs.exists expects 1 argument, got %d", len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], "exists", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtFsExistsSymbol, "i1", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i1", ostyRtFsExistsSymbol, []*LlvmValue{toOstyValue(path)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.sourceType = &ast.NamedType{Path: []string{"Bool"}}
+	return v, true, nil
+}
+
+func (g *generator) emitStdFsCreateCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdFsUnitCall(call, "create", ostyRtFsCreateSymbol)
+}
+
+func (g *generator) emitStdFsRemoveCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdFsUnitCall(call, "remove", ostyRtFsRemoveSymbol)
+}
+
+func (g *generator) emitStdFsRenameCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.rename expects 2 arguments, got %d", len(call.Args))
+	}
+	from, err := g.emitStdFsStringArg(call.Args[0], "rename", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	to, err := g.emitStdFsStringArg(call.Args[1], "rename", 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs.rename",
+		stdFsUnitErrorResultSourceTypeSingleton,
+		ostyRtFsRenameSymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(from), toOstyValue(to)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsCopyCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.copy expects 2 arguments, got %d", len(call.Args))
+	}
+	from, err := g.emitStdFsStringArg(call.Args[0], "copy", 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	to, err := g.emitStdFsStringArg(call.Args[1], "copy", 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs.copy",
+		stdFsUnitErrorResultSourceTypeSingleton,
+		ostyRtFsCopySymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(from), toOstyValue(to)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsMkdirCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdFsUnitCall(call, "mkdir", ostyRtFsMkdirSymbol)
+}
+
+func (g *generator) emitStdFsMkdirAllCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdFsUnitCall(call, "mkdirAll", ostyRtFsMkdirAllSymbol)
+}
+
+func (g *generator) emitStdFsUnitCall(call *ast.CallExpr, name, symbol string) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "fs.%s expects 1 argument, got %d", name, len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], name, 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs."+name,
+		stdFsUnitErrorResultSourceTypeSingleton,
+		symbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsPtrResultFromRuntimeCall(prefix string, sourceType ast.Type, valueSymbol, errorSymbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupportedf("type-system", "%s result type unavailable", prefix)
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != "ptr" || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "%s currently needs ptr-backed Result, got ok=%s err=%s", prefix, info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(valueSymbol, "ptr", params)
+	g.declareRuntimeSymbol(errorSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", valueSymbol, args)
+	failed := llvmCompare(emitter, "eq", out, toOstyValue(value{typ: "ptr", ref: "null"}))
+	errLabel := llvmNextLabel(emitter, prefix+".err")
+	okLabel := llvmNextLabel(emitter, prefix+".ok")
+	contLabel := llvmNextLabel(emitter, prefix+".cont")
+	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, errLabel+":")
+	errText := llvmCall(emitter, "ptr", errorSymbol, nil)
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		out,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{typ: info.typ, ref: phi, sourceType: sourceType}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdFsStringArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "fs.%s requires positional arguments", name)
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d source type unknown, want String", name, index+1)
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsString(resolved) {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d source type is not String", name, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	v = g.protectManagedTemporary("fs."+name+".arg", v)
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d type %s, want String", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdFsBytesArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "fs.%s requires positional arguments", name)
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d source type unknown, want Bytes", name, index+1)
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsBytes(resolved) {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d source type is not Bytes", name, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	v = g.protectManagedTemporary("fs."+name+".arg", v)
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "fs.%s arg %d type %s, want Bytes", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) stdFsCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdFsAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdFsAliases[alias.Name] {
+		return nil, false
+	}
+	return field, true
+}
+
+func (g *mirGen) emitStdFsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	method := strings.TrimPrefix(fnRef.Symbol, "std.fs.")
+	switch method {
+	case "read":
+		return true, g.emitStdFsPtrResultMIR(c, "read", ostyRtFsReadSymbol, ostyRtFsReadErrorSymbol)
+	case "readToString":
+		return true, g.emitStdFsPtrResultMIR(c, "readToString", ostyRtFsReadStringSymbol, ostyRtFsReadStringErrorSymbol)
+	case "write":
+		return true, g.emitStdFsWriteMIR(c)
+	case "writeString":
+		return true, g.emitStdFsWriteStringMIR(c)
+	case "exists":
+		return true, g.emitStdFsExistsMIR(c)
+	case "create":
+		return true, g.emitStdFsUnitResultMIR(c, "create", ostyRtFsCreateSymbol)
+	case "remove":
+		return true, g.emitStdFsUnitResultMIR(c, "remove", ostyRtFsRemoveSymbol)
+	case "rename":
+		return true, g.emitStdFsRenameMIR(c)
+	case "copy":
+		return true, g.emitStdFsCopyMIR(c)
+	case "mkdir":
+		return true, g.emitStdFsUnitResultMIR(c, "mkdir", ostyRtFsMkdirSymbol)
+	case "mkdirAll":
+		return true, g.emitStdFsUnitResultMIR(c, "mkdirAll", ostyRtFsMkdirAllSymbol)
+	default:
+		return false, nil
+	}
+}
+
+func (g *mirGen) emitStdFsWriteMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.write requires two positional arguments, got %d", len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], "write", 0)
+	if err != nil {
+		return err
+	}
+	contents, err := g.emitStdFsBytesOperandMIR(c.Args[1], "write", 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, ostyRtFsWriteBytesSymbol, []string{mirArgSlotPtr(path), mirArgSlotPtr(contents)})
+}
+
+func (g *mirGen) emitStdFsWriteStringMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.writeString requires two positional arguments, got %d", len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], "writeString", 0)
+	if err != nil {
+		return err
+	}
+	contents, err := g.emitStdFsStringOperandMIR(c.Args[1], "writeString", 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, ostyRtFsWriteStringSymbol, []string{mirArgSlotPtr(path), mirArgSlotPtr(contents)})
+}
+
+func (g *mirGen) emitStdFsExistsMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.exists requires one positional argument, got %d", len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], "exists", 0)
+	if err != nil {
+		return err
+	}
+	g.declareRuntime(ostyRtFsExistsSymbol, mirRuntimeDeclareLine("i1", ostyRtFsExistsSymbol, "ptr"))
+	return g.emitCallSiteByName(c, ostyRtFsExistsSymbol, "i1", []string{mirArgSlotPtr(path)})
+}
+
+func (g *mirGen) emitStdFsRenameMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.rename requires two positional arguments, got %d", len(c.Args)))
+	}
+	from, err := g.emitStdFsStringOperandMIR(c.Args[0], "rename", 0)
+	if err != nil {
+		return err
+	}
+	to, err := g.emitStdFsStringOperandMIR(c.Args[1], "rename", 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, ostyRtFsRenameSymbol, []string{mirArgSlotPtr(from), mirArgSlotPtr(to)})
+}
+
+func (g *mirGen) emitStdFsCopyMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.copy requires two positional arguments, got %d", len(c.Args)))
+	}
+	from, err := g.emitStdFsStringOperandMIR(c.Args[0], "copy", 0)
+	if err != nil {
+		return err
+	}
+	to, err := g.emitStdFsStringOperandMIR(c.Args[1], "copy", 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, ostyRtFsCopySymbol, []string{mirArgSlotPtr(from), mirArgSlotPtr(to)})
+}
+
+func (g *mirGen) emitStdFsUnitResultMIR(c *mir.CallInstr, method, symbol string) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.%s requires one positional argument, got %d", method, len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], method, 0)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, symbol, []string{mirArgSlotPtr(path)})
+}
+
+func (g *mirGen) emitStdFsUnitResultMIRArgs(c *mir.CallInstr, symbol string, argStrs []string) error {
+	g.declareRuntime(symbol, mirRuntimeDeclareLine("ptr", symbol, strings.Join(mirPtrParamList(len(argStrs)), ", ")))
+	if c.Dest == nil {
+		g.fnBuf.WriteString(mirCallStmtLine("ptr", symbol, strings.Join(argStrs, ", ")))
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.fs unit-result dest into unknown local %d", c.Dest.Local)
+	}
+	aggLLVM := g.llvmType(destLoc.Type)
+	errReg := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(errReg, "ptr", symbol, strings.Join(argStrs, ", ")))
+	isNil := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqLine(isNil, "ptr", errReg, "null"))
+	okLabel := g.freshLabel("fs.unit.ok")
+	errLabel := g.freshLabel("fs.unit.err")
+	contLabel := g.freshLabel("fs.unit.cont")
+	g.fnBuf.WriteString(mirBrCondLine(isNil, okLabel, errLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	ok1 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(ok1, aggLLVM, "undef", "0", "0"))
+	ok2 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(ok2, aggLLVM, ok1, "0", "1"))
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	errPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(errPayload, errReg, "i64"))
+	err1 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(err1, aggLLVM, "undef", "1", "0"))
+	err2 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(err2, aggLLVM, err1, errPayload, "1"))
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, aggLLVM, ok2, okLabel, err2, errLabel))
+	g.fnBuf.WriteString(mirStoreLine(aggLLVM, phi, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdFsPtrResultMIR(c *mir.CallInstr, method, valueSymbol, errorSymbol string) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.%s requires one positional argument, got %d", method, len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], method, 0)
+	if err != nil {
+		return err
+	}
+	g.declareRuntime(valueSymbol, mirRuntimeDeclareLine("ptr", valueSymbol, "ptr"))
+	if c.Dest == nil {
+		g.fnBuf.WriteString(mirCallStmtLine("ptr", valueSymbol, mirArgSlotPtr(path)))
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.fs.%s dest into unknown local %d", method, c.Dest.Local)
+	}
+	aggLLVM := g.llvmType(destLoc.Type)
+	g.declareRuntime(errorSymbol, mirRuntimeDeclarePtrNoArgsLine(errorSymbol))
+	valReg := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(valReg, "ptr", valueSymbol, mirArgSlotPtr(path)))
+	isNil := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqLine(isNil, "ptr", valReg, "null"))
+	errLabel := g.freshLabel("fs.ptr.err")
+	okLabel := g.freshLabel("fs.ptr.ok")
+	contLabel := g.freshLabel("fs.ptr.cont")
+	g.fnBuf.WriteString(mirBrCondLine(isNil, errLabel, okLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	errText := g.fresh()
+	g.fnBuf.WriteString(mirCallValueNoArgsLine(errText, "ptr", errorSymbol))
+	errPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(errPayload, errText, "i64"))
+	err1 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(err1, aggLLVM, "undef", "1", "0"))
+	err2 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(err2, aggLLVM, err1, errPayload, "1"))
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	okPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(okPayload, valReg, "i64"))
+	ok1 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(ok1, aggLLVM, "undef", "0", "0"))
+	ok2 := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueI64Line(ok2, aggLLVM, ok1, okPayload, "1"))
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, aggLLVM, err2, errLabel, ok2, okLabel))
+	g.fnBuf.WriteString(mirStoreLine(aggLLVM, phi, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdFsStringOperandMIR(op mir.Operand, method string, index int) (string, error) {
+	if op == nil || op.Type() == nil || !nativeTypeIsString(op.Type()) {
+		return "", unsupported("mir-mvp", fmt.Sprintf("std.fs.%s arg %d type %s, want String", method, index+1, mirTypeString(op.Type())))
+	}
+	return g.evalOperand(op, op.Type())
+}
+
+func (g *mirGen) emitStdFsBytesOperandMIR(op mir.Operand, method string, index int) (string, error) {
+	if op == nil || op.Type() == nil || !nativeTypeIsBytes(op.Type()) {
+		return "", unsupported("mir-mvp", fmt.Sprintf("std.fs.%s arg %d type %s, want Bytes", method, index+1, mirTypeString(op.Type())))
+	}
+	return g.evalOperand(op, op.Type())
+}
+
+func mirPtrParamList(n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, "ptr")
+	}
+	return out
+}

--- a/internal/llvmgen/stdlib_fs_shim_test.go
+++ b/internal/llvmgen/stdlib_fs_shim_test.go
@@ -1,0 +1,331 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStdFsReadRoutesToRuntimeAndKeepsResultSourceTypeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+use std.fs as fs
+
+fn main() {
+    match fs.read("input.bin") {
+        Ok(data) -> println(bytes.len(data)),
+        Err(err) -> println(err.message()),
+    }
+    match fs.readToString("input.txt") {
+        Ok(text) -> println(text),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_read(ptr)",
+		"declare ptr @osty_rt_fs_read_error()",
+		"call ptr @osty_rt_fs_read(ptr",
+		"call ptr @osty_rt_fs_read_error()",
+		"declare ptr @osty_rt_fs_read_string(ptr)",
+		"declare ptr @osty_rt_fs_read_string_error()",
+		"call ptr @osty_rt_fs_read_string(ptr",
+		"call ptr @osty_rt_fs_read_string_error()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsMutationsRouteToRuntimeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+use std.fs as fs
+
+fn main() {
+    match fs.write("out.bin", bytes.fromString("abc")) {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.writeString("out.txt", "hello") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.create("empty.txt") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.rename("out.txt", "renamed.txt") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.copy("renamed.txt", "copied.txt") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.mkdir("one") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.mkdirAll("one/two") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.remove("renamed.txt") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_mut_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_write_bytes(ptr, ptr)",
+		"declare ptr @osty_rt_fs_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_create(ptr)",
+		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_mkdir(ptr)",
+		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsExistsRoutesToRuntimeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.fs as fs
+
+fn main() {
+    println(fs.exists("demo.txt"))
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_exists_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare i1 @osty_rt_fs_exists(ptr)",
+		"call i1 @osty_rt_fs_exists(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsReadRoutesToRuntimeInMIR(t *testing.T) {
+	mod := lowerSrcLLVM(t, `use std.fs as fs
+
+fn main() {
+    let raw = fs.read("input.bin")
+    let text = fs.readToString("input.txt")
+    println(1)
+}
+`)
+	mirMod := buildMIRModuleFromHIR(t, mod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_mir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_read(ptr)",
+		"declare ptr @osty_rt_fs_read_error()",
+		"call ptr @osty_rt_fs_read(ptr",
+		"call ptr @osty_rt_fs_read_error()",
+		"declare ptr @osty_rt_fs_read_string(ptr)",
+		"declare ptr @osty_rt_fs_read_string_error()",
+		"call ptr @osty_rt_fs_read_string(ptr",
+		"call ptr @osty_rt_fs_read_string_error()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsMutationsRouteToRuntimeInMIR(t *testing.T) {
+	mod := lowerSrcLLVM(t, `use std.fs as fs
+
+fn main() {
+    let a = fs.writeString("out.txt", "hello")
+    let b = fs.create("empty.txt")
+    let c = fs.rename("out.txt", "renamed.txt")
+    let d = fs.copy("renamed.txt", "copied.txt")
+    let e = fs.mkdir("one")
+    let f = fs.mkdirAll("one/two")
+    let g = fs.remove("renamed.txt")
+    println(1)
+}
+`)
+	mirMod := buildMIRModuleFromHIR(t, mod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_mut_mir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_create(ptr)",
+		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_mkdir(ptr)",
+		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsExistsRoutesToRuntimeInMIR(t *testing.T) {
+	mod := lowerSrcLLVM(t, `use std.fs as fs
+
+fn main() {
+    println(fs.exists("demo.txt"))
+}
+`)
+	mirMod := buildMIRModuleFromHIR(t, mod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_exists_mir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_fs_exists(ptr)",
+		"call i1 @osty_rt_fs_exists(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsReadRoutesToRuntimeInNativeOwnedEntry(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `use std.fs as fs
+
+fn main() {
+    let raw = fs.read("input.bin")
+    let text = fs.readToString("input.txt")
+    println(1)
+}
+`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_native.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_read(ptr)",
+		"declare ptr @osty_rt_fs_read_error()",
+		"declare ptr @osty_rt_fs_read_string(ptr)",
+		"declare ptr @osty_rt_fs_read_string_error()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsMutationsRouteToRuntimeInNativeOwnedEntry(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `use std.fs as fs
+
+fn main() {
+    let a = fs.writeString("out.txt", "hello")
+    let b = fs.create("empty.txt")
+    let c = fs.rename("out.txt", "renamed.txt")
+    let d = fs.copy("renamed.txt", "copied.txt")
+    let e = fs.mkdir("one")
+    let f = fs.mkdirAll("one/two")
+    let g = fs.remove("renamed.txt")
+    println(1)
+}
+`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_mut_native.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_create(ptr)",
+		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_mkdir(ptr)",
+		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsExistsRoutesToRuntimeInNativeOwnedEntry(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `use std.fs as fs
+
+fn main() {
+    println(fs.exists("demo.txt"))
+}
+`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_exists_native.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_fs_exists(ptr)",
+		"call i1 @osty_rt_fs_exists(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -437,6 +437,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdStringsCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdFsCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticStdEnvCallSourceType(e); ok {
 			return src, true
 		}
@@ -927,6 +930,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return out, true
 		}
 		if out, ok := g.stdEnvCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdFsCallStaticResult(e); ok {
 			return out, true
 		}
 	case *ast.FieldExpr:

--- a/internal/stdlib/modules/fs.osty
+++ b/internal/stdlib/modules/fs.osty
@@ -1,15 +1,29 @@
-// std.fs — filesystem access (minimal subset per spec §10.1).
+// std.fs — practical filesystem access.
 //
-// The Tier 1 surface is intentionally narrow: read the whole file,
-// write the whole file, check existence, remove. Streaming I/O, file
-// handles, and directory iteration live in higher-tier modules. The
-// runtime implementation is provided by the generator's std.fs bridge.
+// The Tier 1 surface stays intentionally whole-file oriented: read and
+// write files, probe existence, create/remove/rename paths, and create
+// directories. Streaming handles remain a higher-tier concern. The
+// concrete behavior is provided by the backend/runtime bridge.
 // `readToString` returns Err when the file bytes are not valid UTF-8.
 
+pub fn read(path: String) -> Result<Bytes, Error>
+
 pub fn readToString(path: String) -> Result<String, Error>
+
+pub fn write(path: String, contents: Bytes) -> Result<(), Error>
 
 pub fn writeString(path: String, contents: String) -> Result<(), Error>
 
 pub fn exists(path: String) -> Bool
 
+pub fn create(path: String) -> Result<(), Error>
+
 pub fn remove(path: String) -> Result<(), Error>
+
+pub fn rename(from: String, to: String) -> Result<(), Error>
+
+pub fn copy(from: String, to: String) -> Result<(), Error>
+
+pub fn mkdir(path: String) -> Result<(), Error>
+
+pub fn mkdirAll(path: String) -> Result<(), Error>


### PR DESCRIPTION
## Summary
- expand `std.fs` with whole-file and path operations including native-owned lowering
- add runtime helpers and focused llvmgen coverage for the new filesystem surface
- align Tier 1 fs spec/docs with the implemented API surface

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)