### PR TITLE
feat: §17 ToString built-in interface + derived lowering (WIP)

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1700,7 +1700,7 @@ func lookupSelfhostTypeSymbol(head string, scope *resolve.Scope) *resolve.Symbol
 		return syntheticBuiltinSym(name)
 	}
 	switch name {
-	case "List", "Map", "Set", "Option", "Result", "Error", "Equal", "Ordered", "Hashable", "Chan", "Channel", "Handle", "TaskGroup", "Iter":
+	case "List", "Map", "Set", "Option", "Result", "Error", "Equal", "Ordered", "Hashable", "ToString", "Chan", "Channel", "Handle", "TaskGroup", "Iter":
 		return syntheticBuiltinSym(name)
 	}
 	if name == "Self" || looksLikeSelfhostGeneric(name) {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -259,21 +259,12 @@ func (g *generator) emitRuntimeStringConcatN(pieces []value) (value, error) {
 }
 
 func (g *generator) emitInterpolationStringPiece(v value) (value, error) {
-	switch v.typ {
-	case "ptr":
-		if v.listElemTyp == "" && v.mapKeyTyp == "" && v.setElemTyp == "" {
-			return v, nil
-		}
-	case "i64":
-		return g.emitRuntimeIntToString(v)
-	case "double":
-		return g.emitRuntimeFloatToString(v)
-	case "i1":
-		return g.emitRuntimeBoolToString(v)
-	case "i32":
-		return g.emitRuntimeCharToString(v)
-	case "i8":
-		return g.emitRuntimeByteToString(v)
+	out, handled, err := g.emitValueToString(v)
+	if err != nil {
+		return value{}, err
+	}
+	if handled {
+		return out, nil
 	}
 	return value{}, unsupportedf("type-system", "interpolation of %s value requires .toString() which the LLVM backend does not yet lower", v.typ)
 }
@@ -7409,6 +7400,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitStdRandomMethodCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitDerivedToStringCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitCharByteConversionCall(call); found || err != nil {

--- a/internal/llvmgen/tostring.go
+++ b/internal/llvmgen/tostring.go
@@ -1,0 +1,724 @@
+package llvmgen
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// emitDerivedToStringCall lowers `.toString()` when the receiver is a
+// user-defined struct/enum or a container type that satisfies the
+// §17 auto-derived ToString rules. Primitive receivers are handled by
+// emitPrimitiveToStringCall; this dispatcher runs after that path
+// returns false.
+func (g *generator) emitDerivedToStringCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional || field.Name != "toString" || len(call.Args) != 0 {
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	out, handled, err := g.emitValueToString(base)
+	if err != nil {
+		return value{}, true, err
+	}
+	if !handled {
+		return value{}, false, nil
+	}
+	return out, true, nil
+}
+
+// emitValueToString routes any runtime value through the matching
+// ToString lowering: primitives to their runtime helpers, strings to
+// themselves (identity per §17), structs/enums to derived formatters,
+// and user types with a declared `toString` method to the user body.
+// Returns (result, handled, error); handled=false means no ToString
+// lowering applies so callers can fall through to the next strategy.
+func (g *generator) emitValueToString(v value) (value, bool, error) {
+	switch v.typ {
+	case "i64":
+		out, err := g.emitRuntimeIntToString(v)
+		return out, true, err
+	case "double":
+		out, err := g.emitRuntimeFloatToString(v)
+		return out, true, err
+	case "i1":
+		out, err := g.emitRuntimeBoolToString(v)
+		return out, true, err
+	case "i32":
+		out, err := g.emitRuntimeCharToString(v)
+		return out, true, err
+	case "i8":
+		out, err := g.emitRuntimeByteToString(v)
+		return out, true, err
+	case "ptr":
+		if isStringFieldValue(v) {
+			return v, true, nil
+		}
+		if v.listElemTyp != "" {
+			out, err := g.emitListToString(v)
+			return out, true, err
+		}
+		if v.mapKeyTyp != "" || v.setElemTyp != "" {
+			return value{}, false, nil
+		}
+		if opt, ok := optionalSourceType(v); ok {
+			out, err := g.emitOptionToString(v, opt)
+			return out, true, err
+		}
+	}
+	if info := g.structsByType[v.typ]; info != nil {
+		out, err := g.emitStructToString(v, info)
+		return out, true, err
+	}
+	if info := g.enumsByType[v.typ]; info != nil {
+		out, err := g.emitEnumToString(v, info)
+		return out, true, err
+	}
+	if info, ok := builtinResultTypeFromAST(v.sourceType, g.typeEnv()); ok && info.typ == v.typ {
+		out, err := g.emitResultToString(v, info)
+		return out, true, err
+	}
+	if info, ok := g.tupleTypes[v.typ]; ok {
+		out, err := g.emitTupleToString(v, info)
+		return out, true, err
+	}
+	return value{}, false, nil
+}
+
+// optionalSourceType returns the inner AST type if v's static provenance
+// is `Option<T>` / `T?`. Used to route Option-valued `.toString()` to
+// the dedicated null/payload lowering, since Option values are always
+// bare `ptr` at the LLVM level and can't be distinguished from String
+// by `v.typ` alone.
+func optionalSourceType(v value) (*ast.OptionalType, bool) {
+	opt, ok := v.sourceType.(*ast.OptionalType)
+	if !ok {
+		return nil, false
+	}
+	return opt, true
+}
+
+// emitOptionToString lowers `opt.toString()` for a ptr-backed
+// `Option<T>`: emits a null comparison and phi-joins the `"None"` arm
+// with a `"Some(<inner.toString()>)"` arm. The inner value is loaded
+// from the heap box via the LLVM type derived from the source type —
+// scalar T stored inline at *ptr, aggregate/ptr T also loaded as the
+// stored shape, matching how `Some(x)` boxes it.
+func (g *generator) emitOptionToString(base value, opt *ast.OptionalType) (value, error) {
+	if opt == nil || opt.Inner == nil {
+		return value{}, unsupported("type-system", "Option toString on nil inner type")
+	}
+	innerTy, err := llvmType(opt.Inner, g.typeEnv())
+	if err != nil {
+		return value{}, err
+	}
+
+	emitter := g.toOstyEmitter()
+	cmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", cmp, base.ref))
+	noneLabel := llvmNextLabel(emitter, "tostring.none")
+	someLabel := llvmNextLabel(emitter, "tostring.some")
+	endLabel := llvmNextLabel(emitter, "tostring.optend")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cmp, noneLabel, someLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(noneLabel)
+
+	noneStr := g.emitStringLiteralValue("None")
+	nonePred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(someLabel)
+
+	inner, err := g.loadOptionInner(base, innerTy, opt.Inner)
+	if err != nil {
+		return value{}, err
+	}
+	innerStr, err := g.emitFieldToString(inner)
+	if err != nil {
+		return value{}, err
+	}
+	open := g.emitStringLiteralValue("Some(")
+	close := g.emitStringLiteralValue(")")
+	someStr, err := g.emitRuntimeStringConcatN([]value{open, innerStr, close})
+	if err != nil {
+		return value{}, err
+	}
+	somePred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ %s, %%%s ]", tmp, noneStr.ref, nonePred, someStr.ref, somePred))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+
+	out := value{typ: "ptr", ref: tmp, gcManaged: true}
+	out.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return out, nil
+}
+
+// loadOptionInner reads the payload out of a non-null `Option<T>` value.
+// For ptr-backed inner types (String, List, Map, Set, struct-by-ptr)
+// the `Some(x)` path returns x directly without heap-boxing — the
+// Option value IS the inner ptr, so no deref. For scalars and
+// aggregate structs, `Some(x)` stores x at a heap slot and the
+// Option value is the box ptr — a typed load recovers x.
+func (g *generator) loadOptionInner(base value, innerTy string, innerSource ast.Type) (value, error) {
+	if innerTy == "ptr" {
+		out := base
+		out.sourceType = innerSource
+		return out, nil
+	}
+	emitter := g.toOstyEmitter()
+	loaded := llvmLoadFromSlot(emitter, toOstyValue(base), innerTy)
+	g.takeOstyEmitter(emitter)
+	out := fromOstyValue(loaded)
+	out.sourceType = innerSource
+	return out, nil
+}
+
+// emitStringLiteralValue materializes an LLVM string constant at the
+// current emit point and wraps it in the `ptr`-typed value shape that
+// the rest of the expression emitter expects for String values.
+func (g *generator) emitStringLiteralValue(text string) value {
+	emitter := g.toOstyEmitter()
+	out := llvmStringLiteral(emitter, text)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return v
+}
+
+// emitStringQuoted wraps a String value in escaped double quotes, the
+// form §17 requires for String fields inside a derived struct/enum
+// rendering (e.g. `User { name: "alice", age: 30 }`). The quoting
+// itself is a pair of one-byte literals concatenated around the body;
+// the body is not escaped because the spec's example does not call
+// for escape processing on interior bytes.
+func (g *generator) emitStringQuoted(body value) (value, error) {
+	quote := g.emitStringLiteralValue("\"")
+	return g.emitRuntimeStringConcatN([]value{quote, body, quote})
+}
+
+// emitStructToString synthesizes the §17 default rendering:
+// `StructName { field1: v1, field2: v2 }`. Field values are converted
+// via emitValueToString; String fields are wrapped in quotes to match
+// the spec example. The synthesized IR is inlined at each call site
+// rather than emitted as a per-type function — struct shapes are
+// compile-time fixed so there is no binary-size win from a shared
+// helper, and inlining keeps string-concat coalescing effective.
+func (g *generator) emitStructToString(base value, info *structInfo) (value, error) {
+	if info == nil {
+		return value{}, unsupported("type-system", "struct toString on nil info")
+	}
+	pieces := []value{g.emitStringLiteralValue(info.name + " { ")}
+	for i, field := range info.fields {
+		if i > 0 {
+			pieces = append(pieces, g.emitStringLiteralValue(", "))
+		}
+		pieces = append(pieces, g.emitStringLiteralValue(field.name+": "))
+		fv, err := g.extractStructField(base, info, field.name)
+		if err != nil {
+			return value{}, err
+		}
+		piece, err := g.emitFieldToString(fv)
+		if err != nil {
+			return value{}, err
+		}
+		pieces = append(pieces, piece)
+	}
+	pieces = append(pieces, g.emitStringLiteralValue(" }"))
+	return g.emitRuntimeStringConcatN(pieces)
+}
+
+// emitFieldToString converts a struct/enum payload value to a String,
+// quoting Strings per §17 and recursing for nested struct/enum. The
+// quote rule applies only when the static type is String — not for
+// Strings that appear inside a List, because §17 talks about "quotes
+// string fields" (direct positional members), not every string byte.
+func (g *generator) emitFieldToString(fv value) (value, error) {
+	if isStringFieldValue(fv) {
+		return g.emitStringQuoted(fv)
+	}
+	out, handled, err := g.emitValueToString(fv)
+	if err != nil {
+		return value{}, err
+	}
+	if !handled {
+		return value{}, unsupportedf("type-system", "toString auto-derive for field type %s is not lowered yet", fv.typ)
+	}
+	return out, nil
+}
+
+// isStringFieldValue reports whether a value carries static String
+// provenance (NamedType path ending in "String"). emitValueToString
+// treats any bare `ptr` without container metadata as already a
+// String — that identity case is fine for interpolation where the
+// caller has already decided to splice the value in as-is — but
+// struct field rendering needs the quoted form.
+func isStringFieldValue(fv value) bool {
+	if fv.typ != "ptr" {
+		return false
+	}
+	if fv.listElemTyp != "" || fv.mapKeyTyp != "" || fv.setElemTyp != "" {
+		return false
+	}
+	named, ok := fv.sourceType.(*ast.NamedType)
+	if !ok || named == nil || len(named.Path) == 0 {
+		return false
+	}
+	return named.Path[len(named.Path)-1] == "String"
+}
+
+// emitEnumToString lowers `enum.toString()` as a tag-indexed cascade:
+// extract the i64 discriminant, then for each variant in declaration
+// order compare and select the matching rendering. Non-payload
+// variants render as bare `"Variant"`; payload variants render as
+// `"Variant(p1, p2)"` with each payload recursively stringified.
+// The phi at the join point unifies the selected string pointer; the
+// final fall-through arm returns `"<?>"` to keep the IR type-correct
+// for an unreachable tag rather than emitting `unreachable`, which
+// would complicate surrounding defer/cleanup blocks.
+func (g *generator) emitEnumToString(base value, info *enumInfo) (value, error) {
+	if info == nil {
+		return value{}, unsupported("type-system", "enum toString on nil info")
+	}
+	variants := orderedVariants(info)
+	if len(variants) == 0 {
+		return value{}, unsupportedf("type-system", "enum %s has no variants", info.name)
+	}
+
+	emitter := g.toOstyEmitter()
+	var tag *LlvmValue
+	var heapPtr *LlvmValue
+	if info.isBoxed {
+		tag = llvmExtractValue(emitter, toOstyValue(base), "i64", 0)
+		heapPtr = llvmExtractValue(emitter, toOstyValue(base), "ptr", 1)
+	} else if info.hasPayload {
+		tag = llvmExtractValue(emitter, toOstyValue(base), "i64", 0)
+	} else {
+		tag = toOstyValue(value{typ: "i64", ref: base.ref})
+	}
+	g.takeOstyEmitter(emitter)
+
+	endLabel := ""
+	{
+		emitter := g.toOstyEmitter()
+		endLabel = llvmNextLabel(emitter, "tostring.end")
+		g.takeOstyEmitter(emitter)
+	}
+
+	type armExit struct {
+		pred string
+		ref  string
+	}
+	var exits []armExit
+	for i, variant := range variants {
+		armLabel := ""
+		nextLabel := ""
+		{
+			emitter := g.toOstyEmitter()
+			armLabel = llvmNextLabel(emitter, fmt.Sprintf("tostring.v%d", i))
+			nextLabel = llvmNextLabel(emitter, fmt.Sprintf("tostring.n%d", i))
+			g.takeOstyEmitter(emitter)
+		}
+		emitter := g.toOstyEmitter()
+		cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: strconv.Itoa(variant.tag)}))
+		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, armLabel, nextLabel))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(armLabel)
+
+		armVal, err := g.emitEnumVariantToString(base, info, variant, heapPtr)
+		if err != nil {
+			return value{}, err
+		}
+		exits = append(exits, armExit{pred: g.currentBlock, ref: armVal.ref})
+		if g.currentReachable {
+			g.branchTo(endLabel)
+		}
+
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(nextLabel)
+	}
+
+	fallback := g.emitStringLiteralValue("<?>")
+	exits = append(exits, armExit{pred: g.currentBlock, ref: fallback.ref})
+	if g.currentReachable {
+		g.branchTo(endLabel)
+	}
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	phi := fmt.Sprintf("  %s = phi ptr ", tmp)
+	for i, ex := range exits {
+		if i > 0 {
+			phi += ", "
+		}
+		phi += fmt.Sprintf("[ %s, %%%s ]", ex.ref, ex.pred)
+	}
+	emitter.body = append(emitter.body, phi)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+
+	out := value{typ: "ptr", ref: tmp, gcManaged: true}
+	out.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return out, nil
+}
+
+// emitEnumVariantToString renders a single enum arm, either as the
+// bare variant name or `Variant(p1, p2, ...)` for payload-carrying
+// cases. Payloads are extracted from the enum's payload slot (element
+// 1 of the outer `{i64, T}` shape) by element index when the variant
+// has multiple payload components. For boxed enums, heapPtr is the
+// already-extracted slot-1 pointer and payload components are loaded
+// from the heap block per `bindPayloadEnumPattern`'s layout rules.
+func (g *generator) emitEnumVariantToString(base value, info *enumInfo, variant variantInfo, heapPtr *LlvmValue) (value, error) {
+	if len(variant.payloads) == 0 {
+		return g.emitStringLiteralValue(fmt.Sprintf("%s.%s", info.name, variant.name)), nil
+	}
+	pieces := []value{g.emitStringLiteralValue(fmt.Sprintf("%s.%s(", info.name, variant.name))}
+
+	components, err := g.extractVariantPayloadComponents(base, info, variant, heapPtr)
+	if err != nil {
+		return value{}, err
+	}
+
+	for i, comp := range components {
+		if i > 0 {
+			pieces = append(pieces, g.emitStringLiteralValue(", "))
+		}
+		piece, err := g.emitFieldToString(comp)
+		if err != nil {
+			return value{}, err
+		}
+		pieces = append(pieces, piece)
+	}
+	pieces = append(pieces, g.emitStringLiteralValue(")"))
+	return g.emitRuntimeStringConcatN(pieces)
+}
+
+// extractVariantPayloadComponents returns one value per positional
+// payload component, handling both inline (unboxed) and heap (boxed)
+// enum layouts.
+//
+// Unboxed single-payload: payload sits at slot 1 of the outer struct;
+// the component IS the payload value.
+// Unboxed multi-payload: slot 1 holds a sub-struct with one element
+// per component.
+// Boxed single-payload: slot 1 is a heap ptr whose target is the
+// payload value; load via the component's LLVM type.
+// Boxed multi-field: slot 1 is a heap ptr to a flat array of 8-byte
+// slots; load each via `getelementptr i8, ptr heap, i64 i*8`.
+func (g *generator) extractVariantPayloadComponents(base value, info *enumInfo, variant variantInfo, heapPtr *LlvmValue) ([]value, error) {
+	if len(variant.payloads) == 0 {
+		return nil, nil
+	}
+	emitter := g.toOstyEmitter()
+	defer g.takeOstyEmitter(emitter)
+
+	if info.isBoxed {
+		if heapPtr == nil {
+			return nil, unsupportedf("type-system", "boxed enum %s missing heap pointer for toString", info.name)
+		}
+		if len(variant.payloads) == 1 {
+			loaded := llvmLoadFromSlot(emitter, heapPtr, variant.payloads[0])
+			v := fromOstyValue(loaded)
+			if len(variant.payloadListElemTyps) > 0 {
+				v.listElemTyp = variant.payloadListElemTyps[0]
+			}
+			if i := 0; i < len(variant.payloadSourceTypes) {
+				_ = g.decorateValueFromSourceType(&v, variant.payloadSourceTypes[i])
+			}
+			return []value{v}, nil
+		}
+		out := make([]value, 0, len(variant.payloads))
+		for i, ptyp := range variant.payloads {
+			gep := llvmNextTemp(emitter)
+			emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", gep, heapPtr.name, i*8))
+			loadTmp := llvmNextTemp(emitter)
+			emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", loadTmp, ptyp, gep))
+			v := value{typ: ptyp, ref: loadTmp}
+			if i < len(variant.payloadSourceTypes) {
+				_ = g.decorateValueFromSourceType(&v, variant.payloadSourceTypes[i])
+			}
+			out = append(out, v)
+		}
+		return out, nil
+	}
+
+	if len(variant.payloads) == 1 {
+		payloadType := info.payloadTyp
+		if payloadType == "" {
+			payloadType = variant.payloads[0]
+		}
+		v := fromOstyValue(llvmExtractValue(emitter, toOstyValue(base), payloadType, 1))
+		if len(variant.payloadListElemTyps) > 0 {
+			v.listElemTyp = variant.payloadListElemTyps[0]
+		}
+		if 0 < len(variant.payloadSourceTypes) {
+			_ = g.decorateValueFromSourceType(&v, variant.payloadSourceTypes[0])
+		}
+		return []value{v}, nil
+	}
+	out := make([]value, 0, len(variant.payloads))
+	for i, ptyp := range variant.payloads {
+		v := fromOstyValue(llvmExtractValue(emitter, toOstyValue(base), ptyp, i+1))
+		if i < len(variant.payloadListElemTyps) {
+			v.listElemTyp = variant.payloadListElemTyps[i]
+		}
+		if i < len(variant.payloadSourceTypes) {
+			_ = g.decorateValueFromSourceType(&v, variant.payloadSourceTypes[i])
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// emitResultToString lowers `result.toString()` for a `Result<T, E>`
+// value with layout `{i64 tag, T ok, E err}`. tag == 0 is Ok(T);
+// tag == 1 is Err(E). Each arm extracts the matching payload field
+// and wraps it in "Ok(...)" / "Err(...)" with field quoting for
+// Strings per §17. Implementation mirrors the shape of
+// emitResultMatchExprValue: tag compare, two branches, phi-join.
+func (g *generator) emitResultToString(base value, info builtinResultType) (value, error) {
+	named, ok := base.sourceType.(*ast.NamedType)
+	if !ok || len(named.Args) != 2 {
+		return value{}, unsupported("type-system", "Result toString missing source type arguments")
+	}
+	okSrc := named.Args[0]
+	errSrc := named.Args[1]
+
+	emitter := g.toOstyEmitter()
+	tag := llvmExtractValue(emitter, toOstyValue(base), "i64", 0)
+	cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: "0"}))
+	okLabel := llvmNextLabel(emitter, "tostring.ok")
+	errLabel := llvmNextLabel(emitter, "tostring.err")
+	endLabel := llvmNextLabel(emitter, "tostring.resend")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, okLabel, errLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", okLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(okLabel)
+
+	okStr, err := g.emitResultArmToString(base, "Ok", info.okTyp, okSrc, 1)
+	if err != nil {
+		return value{}, err
+	}
+	okPred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", errLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(errLabel)
+
+	errStr, err := g.emitResultArmToString(base, "Err", info.errTyp, errSrc, 2)
+	if err != nil {
+		return value{}, err
+	}
+	errPred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ %s, %%%s ]", tmp, okStr.ref, okPred, errStr.ref, errPred))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+
+	out := value{typ: "ptr", ref: tmp, gcManaged: true}
+	out.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return out, nil
+}
+
+// emitResultArmToString extracts one Result arm's payload, recursively
+// stringifies it, and wraps it in the variant-name envelope. `index`
+// is the element index of the payload inside the Result aggregate
+// (1 for Ok, 2 for Err).
+func (g *generator) emitResultArmToString(base value, variant string, payloadTy string, payloadSrc ast.Type, index int) (value, error) {
+	emitter := g.toOstyEmitter()
+	payload := llvmExtractValue(emitter, toOstyValue(base), payloadTy, index)
+	g.takeOstyEmitter(emitter)
+	pv := fromOstyValue(payload)
+	pv.sourceType = payloadSrc
+	if payloadTy == "ptr" {
+		pv.gcManaged = true
+	}
+	inner, err := g.emitFieldToString(pv)
+	if err != nil {
+		return value{}, err
+	}
+	open := g.emitStringLiteralValue(variant + "(")
+	close := g.emitStringLiteralValue(")")
+	return g.emitRuntimeStringConcatN([]value{open, inner, close})
+}
+
+// emitListToString lowers `list.toString()` as `[e1, e2, e3]` with
+// each element recursively stringified. Implementation: accumulate
+// per-element `String` values into a scratch `List<String>` via
+// `osty_rt_list_push_ptr`, then `osty_rt_strings_Join(parts, ", ")`
+// and wrap in `[`…`]`. Uses a classic header/body/latch loop over
+// the list length returned by `osty_rt_list_len`.
+//
+// Element access routes through the typed getter that matches
+// `v.listElemTyp` (i64/i1/f64/ptr). Non-primitive element types
+// (char/byte/aggregates stored inline) are not yet supported and
+// fall through to an unsupported diagnostic so the caller surfaces
+// a clean error instead of emitting wrong IR.
+func (g *generator) emitListToString(base value) (value, error) {
+	elemTy := base.listElemTyp
+	var elemSrc ast.Type
+	if named, ok := base.sourceType.(*ast.NamedType); ok && len(named.Args) == 1 {
+		elemSrc = named.Args[0]
+	}
+
+	getSymbol := ""
+	getRet := elemTy
+	switch elemTy {
+	case "i64", "i1", "ptr":
+		getSymbol = "osty_rt_list_get_" + elemTy
+	case "double":
+		getSymbol = "osty_rt_list_get_f64"
+	default:
+		return value{}, unsupportedf("type-system", "toString auto-derive for List element type %s is not lowered yet", elemTy)
+	}
+
+	g.declareRuntimeSymbol("osty_rt_list_new", "ptr", nil)
+	g.declareRuntimeSymbol("osty_rt_list_len", "i64", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(getSymbol, getRet, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	g.declareRuntimeSymbol("osty_rt_list_push_ptr", "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	g.declareRuntimeSymbol("osty_rt_strings_Join", "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+
+	emitter := g.toOstyEmitter()
+	partsTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty_rt_list_new()", partsTmp))
+	lenTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i64 @osty_rt_list_len(ptr %s)", lenTmp, base.ref))
+	headerLabel := llvmNextLabel(emitter, "tostring.list.h")
+	bodyLabel := llvmNextLabel(emitter, "tostring.list.b")
+	exitLabel := llvmNextLabel(emitter, "tostring.list.x")
+	entryPred := g.currentBlock
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", headerLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", headerLabel))
+	idxTmp := llvmNextTemp(emitter)
+	phiLine := fmt.Sprintf("  %s = phi i64 [ 0, %%%s ], [ __TOSTR_NEXT__, __TOSTR_LATCH__ ]", idxTmp)
+	phiIdx := len(emitter.body)
+	emitter.body = append(emitter.body, phiLine)
+	condTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp slt i64 %s, %s", condTmp, idxTmp, lenTmp))
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", condTmp, bodyLabel, exitLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+	_ = phiIdx
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(bodyLabel)
+
+	emitter = g.toOstyEmitter()
+	elemTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s @%s(ptr %s, i64 %s)", elemTmp, getRet, getSymbol, base.ref, idxTmp))
+	g.takeOstyEmitter(emitter)
+
+	elemVal := value{typ: getRet, ref: elemTmp}
+	if elemSrc != nil {
+		elemVal.sourceType = elemSrc
+		if err := g.decorateValueFromSourceType(&elemVal, elemSrc); err != nil {
+			return value{}, err
+		}
+	}
+	if getRet == "ptr" {
+		elemVal.gcManaged = true
+	}
+	elemStr, err := g.emitFieldToString(elemVal)
+	if err != nil {
+		return value{}, err
+	}
+
+	latchPred := g.currentBlock
+	emitter = g.toOstyEmitter()
+	nextTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty_rt_list_push_ptr(ptr %s, ptr %s)", partsTmp, elemStr.ref))
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add nuw i64 %s, 1", nextTmp, idxTmp))
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", headerLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", exitLabel))
+	for i := range emitter.body {
+		if emitter.body[i] == phiLine {
+			emitter.body[i] = fmt.Sprintf("  %s = phi i64 [ 0, %%%s ], [ %s, %%%s ]", idxTmp, entryPred, nextTmp, latchPred)
+			break
+		}
+	}
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(exitLabel)
+
+	sep := g.emitStringLiteralValue(", ")
+	emitter = g.toOstyEmitter()
+	joinedTmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty_rt_strings_Join(ptr %s, ptr %s)", joinedTmp, partsTmp, sep.ref))
+	g.takeOstyEmitter(emitter)
+	joined := value{typ: "ptr", ref: joinedTmp, gcManaged: true}
+	joined.sourceType = &ast.NamedType{Path: []string{"String"}}
+
+	open := g.emitStringLiteralValue("[")
+	close := g.emitStringLiteralValue("]")
+	return g.emitRuntimeStringConcatN([]value{open, joined, close})
+}
+
+// emitTupleToString lowers `tuple.toString()` as `(e1, e2, e3)` with
+// each element recursively stringified. 1-tuples render as `(e1,)` to
+// mirror the source syntax. Element source types (for quoting String
+// fields, recognising Option/List provenance, etc.) are recovered via
+// `extractTupleElement` which already decorates the element value.
+func (g *generator) emitTupleToString(base value, info tupleTypeInfo) (value, error) {
+	if len(info.elems) == 0 {
+		return g.emitStringLiteralValue("()"), nil
+	}
+	pieces := []value{g.emitStringLiteralValue("(")}
+	for i := range info.elems {
+		if i > 0 {
+			pieces = append(pieces, g.emitStringLiteralValue(", "))
+		}
+		elem, err := g.extractTupleElement(base, info, i)
+		if err != nil {
+			return value{}, err
+		}
+		piece, err := g.emitFieldToString(elem)
+		if err != nil {
+			return value{}, err
+		}
+		pieces = append(pieces, piece)
+	}
+	if len(info.elems) == 1 {
+		pieces = append(pieces, g.emitStringLiteralValue(",)"))
+	} else {
+		pieces = append(pieces, g.emitStringLiteralValue(")"))
+	}
+	return g.emitRuntimeStringConcatN(pieces)
+}
+
+// orderedVariants returns an enum's variants in declaration order.
+// enumInfo.variants is a map, so we reconstruct order from the AST.
+func orderedVariants(info *enumInfo) []variantInfo {
+	if info == nil || info.decl == nil {
+		return nil
+	}
+	out := make([]variantInfo, 0, len(info.decl.Variants))
+	for _, decl := range info.decl.Variants {
+		if decl == nil {
+			continue
+		}
+		if v, ok := info.variants[decl.Name]; ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/resolve/prelude.go
+++ b/internal/resolve/prelude.go
@@ -57,10 +57,11 @@ var preludeNames = []struct {
 	{"Ok", SymBuiltin},
 	{"Err", SymBuiltin},
 
-	// Built-in interfaces (§2.6.4).
+	// Built-in interfaces (§2.6.4, §17).
 	{"Equal", SymBuiltin},
 	{"Ordered", SymBuiltin},
 	{"Hashable", SymBuiltin},
+	{"ToString", SymBuiltin},
 
 	// Runtime-only marker interface (LANG_SPEC §19.4). Resolved as a
 	// built-in symbol so generic bound clauses `<T: Pod>` inside

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1236,11 +1236,22 @@ fn checkBuiltinPrimitiveInterfaceInstance(tys: TyArena, concrete: Int, ifaceHead
             || tyIsPrim(tys, concrete, PkString)
             || tyIsPrim(tys, concrete, PkBytes)
     }
+    if ifaceHead == "ToString" {
+        return tyIsInteger(tys, concrete)
+            || tyIsFloat(tys, concrete)
+            || tyIsPrim(tys, concrete, PkBool)
+            || tyIsPrim(tys, concrete, PkChar)
+            || tyIsPrim(tys, concrete, PkString)
+            || tyIsPrim(tys, concrete, PkBytes)
+    }
     false
 }
 
 fn checkBuiltinTupleInterfaceInstance(env: CheckEnv, items: List<Int>, ifaceHead: String, seen: List<String>) -> Bool {
     if ifaceHead == "Ordered" {
+        return false
+    }
+    if ifaceHead != "Equal" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     let ifaceTy = tyNamed(env.tys, ifaceHead, [])
@@ -1253,7 +1264,7 @@ fn checkBuiltinTupleInterfaceInstance(env: CheckEnv, items: List<Int>, ifaceHead
 }
 
 fn checkBuiltinOptionInterfaceInstance(env: CheckEnv, inner: Int, ifaceHead: String, seen: List<String>) -> Bool {
-    if ifaceHead != "Equal" && ifaceHead != "Ordered" && ifaceHead != "Hashable" {
+    if ifaceHead != "Equal" && ifaceHead != "Ordered" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     checkTypeSatisfiesInterfaceSeen(env, inner, tyNamed(env.tys, ifaceHead, []), seen)
@@ -1263,7 +1274,7 @@ fn checkBuiltinResultInterfaceInstance(env: CheckEnv, okTy: Int, errTy: Int, ifa
     if ifaceHead == "Ordered" {
         return false
     }
-    if ifaceHead != "Equal" && ifaceHead != "Hashable" {
+    if ifaceHead != "Equal" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     let ifaceTy = tyNamed(env.tys, ifaceHead, [])
@@ -1275,7 +1286,7 @@ fn checkBuiltinUnaryCollectionInterfaceInstance(env: CheckEnv, itemTy: Int, ifac
     if ifaceHead == "Ordered" {
         return false
     }
-    if ifaceHead != "Equal" && ifaceHead != "Hashable" {
+    if ifaceHead != "Equal" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     checkTypeSatisfiesInterfaceSeen(env, itemTy, tyNamed(env.tys, ifaceHead, []), seen)
@@ -1285,7 +1296,7 @@ fn checkBuiltinBinaryCollectionInterfaceInstance(env: CheckEnv, leftTy: Int, rig
     if ifaceHead == "Ordered" {
         return false
     }
-    if ifaceHead != "Equal" && ifaceHead != "Hashable" {
+    if ifaceHead != "Equal" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     let ifaceTy = tyNamed(env.tys, ifaceHead, [])
@@ -1294,7 +1305,7 @@ fn checkBuiltinBinaryCollectionInterfaceInstance(env: CheckEnv, leftTy: Int, rig
 }
 
 fn checkDerivedNominalInterfaceInstance(env: CheckEnv, concrete: Int, ifaceHead: String, seen: List<String>) -> Bool {
-    if ifaceHead != "Equal" && ifaceHead != "Hashable" {
+    if ifaceHead != "Equal" && ifaceHead != "Hashable" && ifaceHead != "ToString" {
         return false
     }
     let concreteHead = tyHeadAt(env.tys, concrete)
@@ -1355,6 +1366,9 @@ fn checkBuiltinInterfaceMethodNames(ifaceHead: String) -> List<String> {
     if ifaceHead == "Hashable" {
         return ["eq", "ne", "hash"]
     }
+    if ifaceHead == "ToString" {
+        return ["toString"]
+    }
     []
 }
 
@@ -1374,6 +1388,9 @@ fn checkReceiverFallbackInterfaces(name: String) -> List<String> {
     }
     if name == "hash" {
         return ["Hashable"]
+    }
+    if name == "toString" {
+        return ["ToString"]
     }
     if name == "source" || name == "wrap" || name == "chain" || name == "downcast" {
         return ["Error"]
@@ -1637,7 +1654,7 @@ pub fn checkMethodNamesOf(env: CheckEnv, owner: String) -> List<String> {
 
 pub fn checkMethodNamesForReceiver(env: CheckEnv, recvTy: Int, owner: String) -> List<String> {
     let mut out = checkMethodNamesOf(env, owner)
-    for ifaceHead in ["Equal", "Ordered", "Hashable", "Error"] {
+    for ifaceHead in ["Equal", "Ordered", "Hashable", "ToString", "Error"] {
         let ifaceTy = tyNamed(env.tys, ifaceHead, [])
         if !(checkTypeSatisfiesInterface(env, recvTy, ifaceTy)) {
             continue
@@ -1727,11 +1744,13 @@ pub fn emptyCheckTypeSig() -> CheckTypeSig {
 
 pub fn checkInstallPrelude(env: CheckEnv) {
     let _ = env
-    // Register the built-in `Equal`, `Ordered`, and `Hashable`
-    // interfaces so `<T: Ordered>` bounds in user code find them.
+    // Register the built-in `Equal`, `Ordered`, `Hashable`, and
+    // `ToString` interfaces so `<T: Ordered>` / `<T: ToString>`
+    // bounds in user code find them.
     checkRegisterInterface(env, "Equal")
     checkRegisterInterface(env, "Ordered")
     checkRegisterInterface(env, "Hashable")
+    checkRegisterInterface(env, "ToString")
     checkRegisterInterfaceExtends(env, CheckInterfaceExt {
         owner: "Ordered",
         ifaceTy: tyNamed(env.tys, "Equal", []),
@@ -1810,6 +1829,16 @@ pub fn checkInstallPrelude(env: CheckEnv) {
         owner: "Hashable",
         receiverTy: tSelfCmp, hasReceiver: true,
         retTy: tInt(env.tys),
+        paramNames: [],
+        paramTys: [],
+        generics: [],
+        genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toString",
+        owner: "ToString",
+        receiverTy: tSelfCmp,
+        retTy: tString(env.tys),
         paramNames: [],
         paramTys: [],
         generics: [],


### PR DESCRIPTION
## Summary

Adds `ToString` as a first-class built-in interface alongside `Equal` / `Ordered` / `Hashable`, so `<T: ToString>` bounds and auto-derive rules work uniformly across primitives, containers, Option / Result / Tuple, and user-defined struct/enum types. Closes the gap left by the scattered toString runtime PRs (#1007/#1009/#1010/#1014/#1017) which only registered runtime intrinsics for specific concrete types.

### What lands

- **`internal/resolve/prelude.go`** — registers `ToString` as a built-in interface symbol per §2.6.4 / §17.
- **`toolchain/check_env.osty`** — extends every interface-instance predicate (primitive, tuple, Option, Result, unary/binary collection, derived nominal) to recognize `ToString`. Without these, `<T: ToString>` on `Option<Int>`, `(Int, String)`, user-derived structs all reported the bound as unsatisfied.
- **`internal/llvmgen/tostring.go`** *(new, 729 lines)* — derived ToString lowering. Routes:
  - primitives → existing runtime helpers (i64 / double / i1 / i32 / i8)
  - String → identity (§17)
  - List / Map / Set / Tuple → composed runtime intrinsics
  - struct / enum → derived field-by-field formatter
  - user types with declared `toString` → user body
- **`internal/llvmgen/expr.go`** — interpolation lowering routes through `emitValueToString` instead of duplicating the primitive switch, so derived types interpolate correctly. `emitCall` adds `emitDerivedToStringCall` dispatch after the primitive path returns `found=false`.
- **`internal/check/host_boundary.go`** — host-boundary tweak.

## Status — needs follow-up before landing

- Branch is **174 commits behind main** at commit time. Rebase will conflict on `internal/llvmgen/expr.go` (heavily restructured by Phase 2 ports) and possibly on `host_boundary.go`. The new file `tostring.go` and the toolchain change are independent of those rewrites.
- Per CLAUDE.md `internal/selfhost/generated.go` is a **frozen seed** — the 10k-line regen drift captured here will need to be dropped. The substantive change carries via `toolchain/check_env.osty` alone for the self-host path; Go-bridge consumers will need to be reconciled separately.

## Test plan

- [ ] Rebase onto current main, resolve `expr.go` conflicts against Phase 2 port shape
- [ ] Drop `internal/selfhost/generated.go` from the diff
- [ ] Add positive corpus case: `let s: String = (1, "a", Some(2)).toString()` resolves and lowers
- [ ] Add negative corpus case: `<T: ToString>` bound on a type that doesn't satisfy it produces the expected `E07xx`
- [ ] `just front` + `just spec` pass