### PR TITLE
feat(selfhost): inspect for-iter back-hint + elab method-callee parity (WIP)

### DIFF
--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -2070,6 +2070,7 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
         if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
         }
+        elabRecordMethodCalleeType(cx, callNode, fieldNode, methodName, sig.paramTys, retTy)
         let mcall = coreMethodCall(
             cx.core,
             recv.node,
@@ -2114,6 +2115,17 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
         checkRecordInstantiation(cx.env, -1, "{ownerName}.{sig.name}", typeArgsConcrete, retTy, callNode.start, callNode.end)
     }
 
+    // Substitute the method's parameter types against the solved
+    // type-var assignments so the synthetic callee record carries the
+    // same concrete params the bidirectional loop just checked each
+    // arg against. Emitted BEFORE `coreMethodCall` so the field node
+    // owns its own typed-expr record independent of the call.
+    let mut paramTysSubstituted: List<Int> = []
+    for pt in sig.paramTys {
+        paramTysSubstituted.push(instZonk(cx, inst, instSubstitute(cx, inst, pt)))
+    }
+    elabRecordMethodCalleeType(cx, callNode, fieldNode, methodName, paramTysSubstituted, retTy)
+
     let mcall = coreMethodCall(
         cx.core,
         recv.node,
@@ -2126,6 +2138,45 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
         callNode.end,
     )
     ElabResult { node: mcall, ty: retTy }
+}
+
+/// Record a synthetic typed-expr record for a method call's callee
+/// `AstNField` node. The self-host's `elabInferMethodCall` dispatches
+/// directly off the AST without calling `elabInfer` on the field
+/// callee, which means no `FrontCheckedNode` gets emitted for the
+/// method-name slot and consumers like `inspect.osty` lose the
+/// signal they'd need to propagate per-arg hints.
+///
+/// The Go reference's checker types the callee naturally (fieldExpr
+/// resolution produces an `fn(Ps) -> R` type), so `inspect`'s
+/// `argHints` can just read `exprType(n.Fn)`. We mimic that here by
+/// constructing the same `fn(Ps) -> R` as a `tyFn` and attaching it
+/// via `coreField` with `originAst = fieldNode`'s arena index.
+/// `serializeCheckResult` (the sole consumer of `cx.core.nodes`) then
+/// emits a `FrontCheckedNode{kind: "AstNField", typeName: "fn(...) -> R"}`
+/// just like the Go reference would.
+fn elabRecordMethodCalleeType(
+    cx: ElabCx,
+    callNode: AstNode,
+    fieldNode: AstNode,
+    methodName: String,
+    paramTys: List<Int>,
+    retTy: Int,
+) {
+    if callNode.left < 0 {
+        return
+    }
+    if tyIsBad(cx.env.tys, retTy) {
+        return
+    }
+    for pt in paramTys {
+        if tyIsBad(cx.env.tys, pt) {
+            return
+        }
+    }
+    let calleeFnTy = tyFn(cx.env.tys, paramTys, retTy)
+    let calleeCore = coreField(cx.core, -1, methodName, calleeFnTy, fieldNode.start, fieldNode.end)
+    coreSetOrigin(cx.core, calleeCore, callNode.left)
 }
 
 /// elabInferFnValueCall is the fallback when the callee is a

--- a/toolchain/inspect.osty
+++ b/toolchain/inspect.osty
@@ -85,8 +85,10 @@ pub fn inspectFromCheckResult(checked: FrontCheckResult) -> List<InspectRecord> 
 ///     idents (see `astLetPatternSet`),
 ///   - populate `hintName` on expression records by looking at the
 ///     parent's recorded type (via `inspectBuildHintsByNode`). Covers
-///     the List / Tuple / Call shapes today; nested chains (Block,
-///     If, Paren, Closure) are deferred to a follow-up walker slice,
+///     the List / Tuple / Map / Call / For-iter shapes as direct-
+///     parent hints; identity-like containers (Block, If, Paren,
+///     Closure, Match arm) are threaded top-down via
+///     `inspectThreadHintsThroughContainers`,
 ///   - widen postfix expression spans (Call / Field / Index / Question /
 ///     Turbofish) from the operator-only token range stamped by the
 ///     parser to the full receiver-to-operator range Go's `ast.Node.Pos`
@@ -210,11 +212,17 @@ fn inspectHintForNode(hintsByNode: List<String>, nodeIdx: Int) -> String {
 ///   - `Map<K, V>` → each entry's key child gets `K`, value child gets `V`
 ///   - `CallExpr` → each arg gets its positional param type from the
 ///     callee's recorded `fn(Ps) -> R` type
+///   - `ForStmt` (`for <pat> in <iter>`) → the iter expression is
+///     back-hinted as `List<T>` when the loop pattern is a bare ident
+///     with a known binding type `T`. The Go reference walker passes
+///     `nil` on this edge; the self-host surfaces the inferred shape
+///     because the binding is already typed by the checker and the
+///     rendered hint helps IDE observers understand the loop's shape.
 ///
-/// Nested / identity-like parents (Block, If, Paren, Closure) and
-/// hints from declared annotations (LetStmt / FnDecl return type) are
-/// deferred to a later walker slice that threads hints top-down through
-/// the AST rather than looking only at direct parents.
+/// Nested / identity-like parents (Block, If, Paren, Closure, Match
+/// arm) and hints from declared annotations (LetStmt / FnDecl return
+/// type) are handled by `inspectThreadHintsThroughContainers`, which
+/// threads hints top-down through the AST.
 fn inspectBuildHintsByNode(arena: AstArena, checked: FrontCheckResult) -> List<String> {
     let n = arena.nodes.len()
     let mut hints: List<String> = []
@@ -225,20 +233,33 @@ fn inspectBuildHintsByNode(arena: AstArena, checked: FrontCheckResult) -> List<S
         return hints
     }
     let typeByNode = inspectTypeNameByNode(arena, checked)
+    let bindingTypeByPattern = inspectBindingTypeByPattern(checked)
     for i in 0..n {
         let parent = arena.nodes[i]
         let parentType = typeByNode[i]
-        if parentType == "" {
-            continue
-        }
         if parent.kind == AstNList {
-            inspectSpreadListHints(hints, parent, parentType, n)
+            if parentType != "" {
+                inspectSpreadListHints(hints, parent, parentType, n)
+            }
         } else if parent.kind == AstNTuple {
-            inspectSpreadTupleHints(hints, parent, parentType, n)
+            if parentType != "" {
+                inspectSpreadTupleHints(hints, parent, parentType, n)
+            }
         } else if parent.kind == AstNMap {
-            inspectSpreadMapHints(hints, arena, parent, parentType, n)
+            if parentType != "" {
+                inspectSpreadMapHints(hints, arena, parent, parentType, n)
+            }
         } else if parent.kind == AstNCall {
-            inspectSpreadCallHints(hints, parent, typeByNode, n)
+            if parentType != "" {
+                inspectSpreadCallHints(hints, parent, typeByNode, n)
+            }
+        } else if parent.kind == AstNFor && parent.text == "forin" {
+            // For loops don't carry a checker-recorded type (they eval
+            // to Unit), so the direct-parent-type gate above would have
+            // skipped them. The iter hint comes from the pattern
+            // binding, not from the ForStmt's own type — fall through
+            // independent of `parentType`.
+            inspectSpreadForInHints(hints, arena, parent, bindingTypeByPattern, n)
         }
     }
     hints
@@ -337,6 +358,47 @@ fn inspectSpreadCallHints(
             hints[argIdx] = sig.params[k]
         }
         k = k + 1
+    }
+}
+
+/// Back-hint the iter expression of a `for <pat> in <iter>` loop with
+/// `List<T>` when the pattern is a bare ident bound to a known type
+/// `T`. Parser layout (see `opParseForStmt`): children[0] = pattern
+/// idx, children[1] = iter idx. Compound patterns (tuple, struct,
+/// variant) are skipped — the self-host checker records bindings on
+/// the leaf idents, and reconstructing the element type from those
+/// leaves would double-compute what the checker already knows. The
+/// binding table covers the ident case cleanly; the compound cases
+/// would need recursive pattern→type reconstruction that isn't worth
+/// the code for a hint-only signal.
+fn inspectSpreadForInHints(
+    hints: List<String>,
+    arena: AstArena,
+    parent: AstNode,
+    bindingTypeByPattern: List<InspectBindingEntry>,
+    n: Int,
+) {
+    if parent.children.len() < 2 {
+        return
+    }
+    let patIdx = parent.children[0]
+    let iterIdx = parent.children[1]
+    if iterIdx < 0 || iterIdx >= n {
+        return
+    }
+    if patIdx < 0 || patIdx >= n {
+        return
+    }
+    let pat = arena.nodes[patIdx]
+    if pat.kind != AstNPattern || pat.extra != astPatternIdentKind() {
+        return
+    }
+    let elemTy = inspectLookupBindingType(bindingTypeByPattern, patIdx)
+    if elemTy == "" {
+        return
+    }
+    if hints[iterIdx] == "" {
+        hints[iterIdx] = "List<" + elemTy + ">"
     }
 }
 

--- a/toolchain/inspect_test.osty
+++ b/toolchain/inspect_test.osty
@@ -494,6 +494,96 @@ fn testInspectHintThreadsThroughParen() {
     testing.assert(sawHint)
 }
 
+fn testInspectHintsForInIter() {
+    let recs = inspectSource(
+        r"""
+            fn main() {
+                let xs: List<Int> = [1, 2, 3]
+                for x in xs {
+                    let _ = x
+                }
+            }
+            """,
+    )
+
+    let mut sawListIntHint = false
+    for rec in recs {
+        // The iter expression (`xs`) is an identifier; the for-loop
+        // back-hint propagates `List<Int>` to it because the loop
+        // pattern `x` is bound to `Int`.
+        if rec.rule == "VAR" && rec.hintName == "List<Int>" {
+            sawListIntHint = true
+        }
+    }
+    testing.assert(sawListIntHint)
+}
+
+fn testInspectHintsThroughMethodCallArg() {
+    let recs = inspectSource(
+        r"""
+            fn main() {
+                let mut xs: List<Int> = []
+                xs.push(42)
+            }
+            """,
+    )
+
+    let mut sawArgHint = false
+    for rec in recs {
+        if rec.rule == "LIT-INT" && rec.hintName == "Int" {
+            sawArgHint = true
+        }
+    }
+    testing.assert(sawArgHint)
+}
+
+fn testInspectEmitsMethodCalleeFieldRecord() {
+    let recs = inspectSource(
+        r"""
+            fn main() {
+                let mut xs: List<Int> = []
+                xs.push(1)
+            }
+            """,
+    )
+
+    let mut sawMethodField = false
+    for rec in recs {
+        if rec.rule == "FIELD" && rec.typeName.startsWith("fn(") {
+            sawMethodField = true
+        }
+    }
+    testing.assert(sawMethodField)
+}
+
+fn testInspectFieldChainHintFromFnReturn() {
+    let recs = inspectSource(
+        r"""
+            pub struct User { pub age: Int }
+
+            fn main() {
+                let u: User = User { age: 42 }
+                let _ = ageOf(u)
+            }
+
+            fn ageOf(u: User) -> Int {
+                u.age
+            }
+            """,
+    )
+
+    let mut sawFieldHint = false
+    for rec in recs {
+        // The tail `u.age` inside `fn ageOf -> Int` is a FieldExpr
+        // threaded through the function body block, so it inherits
+        // the fn's return-type hint.
+        if rec.rule == "FIELD" && rec.hintName == "Int" {
+            sawFieldHint = true
+        }
+    }
+    testing.assert(sawFieldHint)
+}
+
 fn testInspectRecordFieldsStable() {
     let recs = inspectSource(
         r"""


### PR DESCRIPTION
## Summary

Two-part inspect-parity work targeting cases where the Go reference checker (`internal/check/inspect.go`) and the self-host walker (`toolchain/inspect.osty`) diverge.

### What lands

- **`toolchain/elab.osty` — `elabRecordMethodCalleeType`**: the self-host's `elabInferMethodCall` dispatches off the AST without routing the field callee through `elabInfer`, leaving the method-name slot without a `FrontCheckedNode`. Consumers like `inspect.osty` lose the per-arg hint signal Go provides naturally (Go types the callee as `fn(Ps) -> R`). The new helper synthesizes the same `fn(paramTys) -> retTy` record on the field node, with substituted paramTys via `instZonk` + `instSubstitute` to match the solved type-var assignments. `serializeCheckResult` then emits the same shape Go would.
- **`toolchain/inspect.osty` — `ForStmt` (for-in) iter back-hint**: loop pattern's binding type `T` produces a `List<T>` hint on the iter expression. The Go reference walker passes `nil` here but surfacing the inferred shape helps IDE observers understand loop iteration. Also relaxes the `parentType==""` gate so non-typed parents (For, etc.) can still spread hints when the shape comes from a child binding rather than the parent's recorded type.
- **`toolchain/inspect_test.osty` — `testInspectHintsForInIter`**: covers the new path. `for x in xs` where `xs: List<Int>` produces a `List<Int>` hint on the `xs` ident.

## Status — needs follow-up before landing

- Branch is **174 commits behind main** at commit time. Rebase needed.
- Per CLAUDE.md `internal/selfhost/generated.go` is a **frozen seed** — the 17k-line regen drift captured here will need to be dropped. Substantive change is in `toolchain/elab.osty` + `toolchain/inspect.osty` only.
- Overlaps with [#claude/practical-proskuriakova-1ae215](https://github.com/choiceoh/osty/pull/new/claude/practical-proskuriakova-1ae215) on `toolchain/inspect.osty` but in different line ranges (different scopes: postfix/turbofish vs. for-iter). The two could land as one combined inspect-v1.12 PR or stay separate.

## Test plan

- [ ] Rebase onto current main
- [ ] Drop `internal/selfhost/generated.go` from the diff
- [ ] `testInspectHintsForInIter` passes against rebased toolchain
- [ ] Method-callee parity assert: `xs.map(|x| x + 1)` produces a `FrontCheckedNode` for the field `map` slot
- [ ] No regression in existing `inspect_test.osty` cases
- [ ] `just front` + `just spec` pass