### PR TITLE
fix: osty check toolchain 12개 진단 에러 정리

### DIFF
--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -11921,7 +11921,6 @@ func mirLshrTypedLine(dst, typ, a, b string) string {
 	return "  " + dst + " = lshr " + typ + " " + a + ", " + b + "\n"
 }
 
-
 // Osty: mirFCmpOEqLine
 func mirFCmpOEqLine(dst, typ, a, b string) string {
 	return "  " + dst + " = fcmp oeq " + typ + " " + a + ", " + b + "\n"

--- a/internal/stdlib/modules/strings.osty
+++ b/internal/stdlib/modules/strings.osty
@@ -1033,6 +1033,10 @@ pub fn lastIndexOf(s: String, substr: String) -> Int? {
     }
 }
 
+pub fn LastIndex(s: String, substr: String) -> Int {
+    lastIndexOfChars(s.chars(), substr.chars())
+}
+
 pub fn count(s: String, substr: String) -> Int {
     let chars = s.chars()
     let needle = substr.chars()

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -2317,7 +2317,7 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     // String are wired today, composite element types still surface
     // as "not implemented yet".
     checkRegisterFn(env, CheckFnSig {
-        name: "toString", owner: "List", receiverTy: tListT, hasReceiver: true, retTy: tString_,
+        name: "toString", owner: "List", receiverTy: tListT, hasReceiver: true, retTy: tString(tys),
         paramNames: [], paramTys: [],
         generics: ["T"], genericBounds: [],
     })
@@ -2373,7 +2373,7 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     // `key_kind` / `value_kind` to pick per-element formatters.
     // Composite K/V types abort inside the runtime today.
     checkRegisterFn(env, CheckFnSig {
-        name: "toString", owner: "Map", receiverTy: tMapKV, hasReceiver: true, retTy: tString_,
+        name: "toString", owner: "Map", receiverTy: tMapKV, hasReceiver: true, retTy: tString(tys),
         paramNames: [], paramTys: [],
         generics: ["K", "V"], genericBounds: [],
     })
@@ -2521,7 +2521,7 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     // to pick a per-element formatter. Composite element types
     // abort inside the runtime today.
     checkRegisterFn(env, CheckFnSig {
-        name: "toString", owner: "Set", receiverTy: tSetT, hasReceiver: true, retTy: tString_,
+        name: "toString", owner: "Set", receiverTy: tSetT, hasReceiver: true, retTy: tString(tys),
         paramNames: [], paramTys: [],
         generics: ["T"], genericBounds: [],
     })

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -14597,13 +14597,6 @@ pub fn mirSelectI1Text(reg: String, cond: String, thenV: String, elseV: String) 
     "  " + reg + " = select i1 " + cond + ", i1 " + thenV + ", i1 " + elseV
 }
 
-/// mirSelectI64Text renders `<reg> = select i1 <cond>, i64 <thenV>, i64 <elseV>`
-/// for body-slice callers (no trailing newline). Sibling of the line
-/// form already in §6.
-pub fn mirSelectI64Text(reg: String, cond: String, thenV: String, elseV: String) -> String {
-    "  " + reg + " = select i1 " + cond + ", i64 " + thenV + ", i64 " + elseV
-}
-
 /// mirSelectDoubleText renders `<reg> = select i1 <cond>, double <a>, double <b>`.
 pub fn mirSelectDoubleText(reg: String, cond: String, thenV: String, elseV: String) -> String {
     "  " + reg + " = select i1 " + cond + ", double " + thenV +
@@ -16631,7 +16624,7 @@ pub fn mirAsciiToLower(text: String) -> String {
     let mut out = ""
     let mut i = 0
     for i < n {
-        let chs = text.charAt(i)
+        let chs = text[i..(i + 1)]
         out = out + mirAsciiUpperToLowerChar(chs)
         i = i + 1
     }
@@ -16685,7 +16678,7 @@ pub fn mirSubstringRange(text: String, start: Int, end: Int) -> String {
     let mut out = ""
     let mut i = lo
     for i < hi {
-        out = out + text.charAt(i)
+        out = out + text[i..(i + 1)]
         i = i + 1
     }
     out
@@ -16738,7 +16731,7 @@ pub fn mirAsciiOrd(s: String) -> Int {
     if s == "d" { return 100 }
     if s == "e" { return 101 }
     if s == "f" { return 102 }
-    -1
+    return -1
 }
 
 /// mirAsciiChr returns a single-character String for the given ASCII
@@ -16813,7 +16806,7 @@ pub fn mirHexDigitValue(s: String) -> Int {
     if s == "d" || s == "D" { return 13 }
     if s == "e" || s == "E" { return 14 }
     if s == "f" || s == "F" { return 15 }
-    -1
+    return -1
 }
 
 /// mirNativeMapSetKeySupportedScalar reports whether a scalar map/set
@@ -16856,7 +16849,7 @@ pub fn mirTestingConstSourceTextBool(value: Bool) -> String {
 pub fn mirBuiltinResultIRTypeArgIndex(constructor: String) -> Int {
     if constructor == "Err" { return 1 }
     if constructor == "Ok" { return 0 }
-    -1
+    return -1
 }
 
 /// mirIsListPtrTypeName reports whether a NamedType.Name plus its

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -3172,7 +3172,7 @@ fn srCheckDuplicateVariantJSONTags(
             continue
         }
         let tagOpt = srJsonVariantTag(file, memberIdx)
-        if tagOpt == None {
+        if tagOpt.isNone() {
             continue
         }
         let tag = match tagOpt { Some(t) -> t, None -> "" }


### PR DESCRIPTION
## Summary
- `osty check ./toolchain` 이 보고하던 12개 에러 (E0700/E0703/E0744/E0745) 일괄 수정
- self-host toolchain 소스의 typo + ASI 함정 + 누락된 stdlib 메서드 정리
- pre-existing gofmt drift (`mir_generator_snapshot.go`) 같이 정리

## Fixes
- **check_env.osty**: `tString_` (스코프 외 변수) → `tString(tys)` × 3 (List/Map/Set `toString` retTy)
- **mir_generator.osty**: 중복 `mirSelectI64Text` 정의 제거 — 두 번째 정의가 첫 번째의 lhs/rhs 파라미터를 가렸음
- **mir_generator.osty**: `text.charAt(i)` → `text[i..(i+1)]` × 2 (`charAt`은 String 메서드 아님; 두 함수 모두 ASCII 전용)
- **mir_generator.osty**: 끝줄 `-1` → `return -1` × 3 — `}` 다음 `-` 가 binary op 으로 묶여 `if{...} - 1` 로 파싱되며 E0744 발생
- **resolve.osty**: `tagOpt == None` → `tagOpt.isNone()` (Option<T> 단일화 실패)
- **std.strings**: `LastIndex(s, substr) -> Int` 추가 (기존 PascalCase `Index` 와 동일 패턴, `-1` sentinel)

## Test plan
- [x] `just prepush` 로컬 통과 (fmt-check + vet + repair-check + ci)
- [x] `just front` 통과 (lexer/parser/resolve/check/diag/format/lint/pipeline)
- [x] `.bin/osty check ./toolchain` exit 0
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)