### PR TITLE
fix: llvmgen tostring vet + osty check toolchain 진단 2개 정리

### DIFF
--- a/internal/llvmgen/tostring.go
+++ b/internal/llvmgen/tostring.go
@@ -613,14 +613,12 @@ func (g *generator) emitListToString(base value) (value, error) {
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", headerLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", headerLabel))
 	idxTmp := llvmNextTemp(emitter)
-	phiLine := fmt.Sprintf("  %s = phi i64 [ 0, %%%s ], [ __TOSTR_NEXT__, __TOSTR_LATCH__ ]", idxTmp)
 	phiIdx := len(emitter.body)
-	emitter.body = append(emitter.body, phiLine)
+	emitter.body = append(emitter.body, "")
 	condTmp := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp slt i64 %s, %s", condTmp, idxTmp, lenTmp))
 	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", condTmp, bodyLabel, exitLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
-	_ = phiIdx
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(bodyLabel)
 
@@ -651,12 +649,7 @@ func (g *generator) emitListToString(base value) (value, error) {
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add nuw i64 %s, 1", nextTmp, idxTmp))
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", headerLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", exitLabel))
-	for i := range emitter.body {
-		if emitter.body[i] == phiLine {
-			emitter.body[i] = fmt.Sprintf("  %s = phi i64 [ 0, %%%s ], [ %s, %%%s ]", idxTmp, entryPred, nextTmp, latchPred)
-			break
-		}
-	}
+	emitter.body[phiIdx] = fmt.Sprintf("  %s = phi i64 [ 0, %%%s ], [ %s, %%%s ]", idxTmp, entryPred, nextTmp, latchPred)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(exitLabel)
 

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1837,7 +1837,7 @@ pub fn checkInstallPrelude(env: CheckEnv) {
     checkRegisterFn(env, CheckFnSig {
         name: "toString",
         owner: "ToString",
-        receiverTy: tSelfCmp,
+        receiverTy: tSelfCmp, hasReceiver: true,
         retTy: tString(env.tys),
         paramNames: [],
         paramTys: [],

--- a/toolchain/inspect.osty
+++ b/toolchain/inspect.osty
@@ -938,7 +938,11 @@ fn inspectInstantiationNotesByNode(
         if inst.typeArgs.len() == 0 {
             continue
         }
-        notes[inst.node] = "instantiated [" + strings.join(inst.typeArgs, ", ") + "]"
+        let mut argStrs: List<String> = []
+        for ta in inst.typeArgs {
+            argStrs.push(frontTypeReprToString(ta))
+        }
+        notes[inst.node] = "instantiated [" + strings.join(argStrs, ", ") + "]"
     }
     notes
 }


### PR DESCRIPTION
## Summary

- `internal/llvmgen/tostring.go`: `emitListToString`의 phi 라인 패치 단순화 — placeholder/선형 스캔 제거 + 캡처된 인덱스로 직접 덮어쓰기. 이전 코드는 `fmt.Sprintf` 포맷 문자열의 verb 수가 인자와 맞지 않아 `go vet` 에러 (`fmt.Sprintf format %s reads arg #2, but call has 1 arg`)를 발생시켰고, 패치 시점에 `emitter.body` 전체를 문자열 동등성 비교로 선형 스캔하는 구조였다. `phiIdx`가 이미 정확한 위치를 들고 있으므로 빈 슬롯을 예약 후 latch 정보 확보 시 `emitter.body[phiIdx] = ...`로 직접 쓴다. (`_ = phiIdx` no-op 및 placeholder 포맷 문자열 모두 제거.)
- `toolchain/check_env.osty:1840`: ToString 인터페이스의 `toString` CheckFnSig에 누락된 `hasReceiver: true` 필드 추가 — 같은 함수 내 `Comparable.eq` (1820), `Hashable.hash` (1830)와 동일한 형태로 통일 (E0708 해소).
- `toolchain/inspect.osty:941`: `inst.typeArgs`(`List<FrontTypeRepr>`)를 `frontTypeReprToString`으로 풀어 `List<String>`으로 변환 후 `strings.join` 호출 (E0700 해소). `check.osty:117-143`의 `frontTypeReprToString` 자체가 사용하는 imperative `let mut` + push 패턴과 일치.

## Why

머지된 [#1031](https://github.com/choiceoh/osty/pull/1031) (§17 ToString built-in interface + derived lowering)에서 두 토대 진단 (E0708 / E0700)이 누락된 채로 들어왔고, llvmgen 쪽도 `phi` 라인 패치 코드가 `go vet` 게이트를 통과 못 하는 상태였다. `just prepush` 게이트 (vet) 와 `osty check toolchain`이 모두 깨진 상태라 후속 작업의 노이즈를 키우고 있어 일괄 정리.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./cmd/osty` — clean
- [x] `.bin/osty check toolchain` — exit 0 (이전: 2 errors)
- [x] `go test ./internal/llvmgen/ -run "ToString" -count=1 -vet=off` — pass
- [x] `go test ./internal/llvmgen/ -run "List" -count=1 -vet=off` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)