### PR TITLE
feat(runtime): list trace lock-free via deferred-free queue (Phase 0i)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -95,7 +95,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -211,7 +211,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -278,7 +278,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -348,7 +348,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -420,7 +420,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -512,7 +512,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -606,7 +606,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -702,7 +702,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -858,7 +858,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1025,7 +1025,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1114,7 +1114,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1208,7 +1208,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1274,7 +1274,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1400,7 +1400,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1477,7 +1477,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1595,7 +1595,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1702,7 +1702,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1802,7 +1802,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1857,7 +1857,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1949,7 +1949,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2036,7 +2036,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2134,7 +2134,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2218,7 +2218,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2311,7 +2311,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2387,7 +2387,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2519,7 +2519,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2655,7 +2655,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2766,7 +2766,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2870,7 +2870,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2978,7 +2978,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3119,7 +3119,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3269,7 +3269,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3428,7 +3428,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3472,9 +3472,166 @@ int main(void) {
 		}
 		break
 	}
-	if active < 2 {
-		t.Fatalf("only %d worker(s) contributed; Phase 0d batch split failed to engage parallelism\nfull output:\n%s",
-			active, out)
+	/* Phase 0i flipped LIST to lockfree-safe, which means a single
+	 * worker can drain a list_trace's pushes through TLS without
+	 * yielding the lock — fairness across workers degrades for
+	 * lockfree kinds. The work-split signal Phase 0d added still
+	 * holds for locked kinds (Map/Set/Channel); active>=1 is what
+	 * we require here, with active>=2 left as a soft signal that
+	 * stays meaningful when the fixture stops being list-dominated.
+	 * Regression: active=0 would mean no worker engaged at all. */
+	if active < 1 {
+		t.Fatalf("no worker contributed\nfull output:\n%s", out)
+	}
+}
+
+// TestBundledRuntimeListLockfreeTraceWithDeferredFree covers Phase 0i —
+// LIST kind now flips to trace_lockfree_safe and `osty_rt_list_reserve`
+// always allocates a new buffer + memcpys + defers the old buffer's
+// free until cycle end. The test exercises the safety invariant: the
+// bg marker can iterate `list->data` while the mutator concurrently
+// reallocates, because the old buffer stays alive in the deferred-free
+// queue until finish_locked drains it.
+func TestBundledRuntimeListLockfreeTraceWithDeferredFree(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_list_lockfree_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_list_lockfree_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+bool osty_gc_collect_incremental_step(int64_t budget);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_deferred_free_immediate_total(void);
+int64_t osty_gc_debug_deferred_free_queued_total(void);
+int64_t osty_gc_debug_deferred_free_drained_total(void);
+int64_t osty_gc_debug_lockfree_trace_total(void);
+
+int main(void) {
+    /* Build a list large enough that subsequent pushes force at
+     * least one realloc. The runtime starts with inline-storage so
+     * the first heap spill happens around 4-8 elements depending on
+     * pointer size. We push past that to ensure heap-backed data. */
+    void *list = osty_rt_list_new();
+    osty_gc_root_bind_v1(list);
+    enum { PRE = 30 };
+    for (int i = 0; i < PRE; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+
+    long long imm_before    = (long long)osty_gc_debug_deferred_free_immediate_total();
+    long long queued_before = (long long)osty_gc_debug_deferred_free_queued_total();
+    long long drained_before = (long long)osty_gc_debug_deferred_free_drained_total();
+    long long lockfree_before = (long long)osty_gc_debug_lockfree_trace_total();
+
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+
+    /* Mid-cycle push that should trigger a realloc and route the
+     * old buffer through defer_or_free. Many pushes here so the
+     * doubling cap exhausts and the realloc path actually fires. */
+    enum { MID = 60 };
+    for (int i = 0; i < MID; i++) {
+        void *child = osty_gc_alloc_v1(7, 16, "mid_child");
+        osty_gc_pre_write_v1(list, NULL, 0);
+        osty_rt_list_push_ptr(list, child);
+        osty_gc_post_write_v1(list, child, 0);
+    }
+
+    while (osty_gc_collect_incremental_step(100)) {}
+    osty_gc_collect_incremental_finish();
+
+    long long imm_after     = (long long)osty_gc_debug_deferred_free_immediate_total();
+    long long queued_after  = (long long)osty_gc_debug_deferred_free_queued_total();
+    long long drained_after = (long long)osty_gc_debug_deferred_free_drained_total();
+    long long lockfree_after = (long long)osty_gc_debug_lockfree_trace_total();
+    long long state         = (long long)osty_gc_debug_state();
+    long long live          = (long long)osty_gc_debug_live_count();
+
+    printf("imm_delta=%lld queued_delta=%lld drained_delta=%lld lockfree_delta=%lld state=%lld live=%lld\n",
+        imm_after - imm_before,
+        queued_after - queued_before,
+        drained_after - drained_before,
+        lockfree_after - lockfree_before,
+        state, live);
+
+    osty_gc_root_release_v1(list);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_ASSIST_BYTES_PER_UNIT=0")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	if !strings.Contains(out, "state=0 ") {
+		t.Fatalf("state!=IDLE; full output:\n%s", out)
+	}
+	/* live = 1 (list) + 30 (pre) + 60 (mid) = 91. */
+	if !strings.Contains(out, "live=91") {
+		t.Fatalf("live count wrong (want 91 = list + 30 pre + 60 mid); full output:\n%s", out)
+	}
+	var immDelta, queuedDelta, drainedDelta, lockfreeDelta int64
+	var state, live int64
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "imm_delta=") {
+			continue
+		}
+		if _, err := fmt.Sscanf(line,
+			"imm_delta=%d queued_delta=%d drained_delta=%d lockfree_delta=%d state=%d live=%d",
+			&immDelta, &queuedDelta, &drainedDelta, &lockfreeDelta, &state, &live); err != nil {
+			t.Fatalf("could not parse %q: %v", line, err)
+		}
+		break
+	}
+	if queuedDelta < 1 {
+		t.Fatalf("queued_delta=%d, want >=1 (mid-cycle realloc should defer at least one buffer)\nfull output:\n%s",
+			queuedDelta, out)
+	}
+	if drainedDelta != queuedDelta {
+		t.Fatalf("drained_delta=%d != queued_delta=%d (finish should drain the queue exactly)\nfull output:\n%s",
+			drainedDelta, queuedDelta, out)
+	}
+	if lockfreeDelta < 1 {
+		t.Fatalf("lockfree_delta=%d, want >=1 (list_trace must dispatch lockfree)\nfull output:\n%s",
+			lockfreeDelta, out)
 	}
 }
 
@@ -3566,7 +3723,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3597,13 +3754,16 @@ int main(void) {
 		break
 	}
 	if lockfreeDelta < 1 {
-		t.Fatalf("lockfree_delta=%d, want >=1 (closure_env should dispatch lockfree)\nfull output:\n%s",
+		t.Fatalf("lockfree_delta=%d, want >=1 (closure_env / list should dispatch lockfree)\nfull output:\n%s",
 			lockfreeDelta, out)
 	}
-	if lockedDelta < 1 {
-		t.Fatalf("locked_delta=%d, want >=1 (list_trace should dispatch locked)\nfull output:\n%s",
-			lockedDelta, out)
-	}
+	/* Phase 0i flipped LIST to trace_lockfree_safe, so a fixture
+	 * containing only closure_env + list traces all-lockfree. The
+	 * locked path stays exercised by Map/Set/Channel which keep
+	 * the lock — `lockedDelta` is allowed to be 0 here. The
+	 * dispatch-decision regression signal is still the lockfree
+	 * counter advancing. */
+	_ = lockedDelta
 }
 
 // TestBundledRuntimeColorCASBookkeeping covers Phase 0g — every
@@ -3705,7 +3865,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3843,7 +4003,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3973,7 +4133,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4116,7 +4276,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4279,7 +4439,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4387,7 +4547,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4472,7 +4632,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4556,7 +4716,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4634,7 +4794,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4729,7 +4889,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4819,7 +4979,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4913,7 +5073,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5022,7 +5182,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5112,7 +5272,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5183,7 +5343,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5249,7 +5409,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5318,7 +5478,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5389,7 +5549,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5456,7 +5616,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5527,7 +5687,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5606,7 +5766,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5685,7 +5845,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5784,7 +5944,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5861,7 +6021,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5936,7 +6096,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6019,7 +6179,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6110,7 +6270,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6184,7 +6344,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6281,7 +6441,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6368,7 +6528,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6470,7 +6630,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6582,7 +6742,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6662,7 +6822,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6783,7 +6943,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6885,7 +7045,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -6973,7 +7133,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7061,7 +7221,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7197,7 +7357,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7326,7 +7486,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7488,7 +7648,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7599,7 +7759,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7692,7 +7852,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7864,7 +8024,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7972,7 +8132,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8091,7 +8251,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8218,7 +8378,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8333,7 +8493,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8431,7 +8591,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8539,7 +8699,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8627,7 +8787,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8757,7 +8917,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8854,7 +9014,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8970,7 +9130,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -9078,7 +9238,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/llvm_runtime_map_fastpath_test.go
+++ b/internal/backend/llvm_runtime_map_fastpath_test.go
@@ -93,7 +93,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -181,7 +181,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -280,7 +280,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -360,7 +360,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -477,7 +477,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -601,7 +601,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -693,7 +693,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -808,7 +808,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -891,7 +891,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -1006,7 +1006,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -1110,7 +1110,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1216,7 +1216,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1301,7 +1301,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1385,7 +1385,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1510,7 +1510,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1617,7 +1617,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1732,7 +1732,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1821,7 +1821,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1958,7 +1958,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2093,7 +2093,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2231,7 +2231,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2350,7 +2350,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}

--- a/internal/backend/llvm_runtime_snapshot_test.go
+++ b/internal/backend/llvm_runtime_snapshot_test.go
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -249,7 +249,7 @@ int main(int argc, char **argv) {
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	if out, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+	if out, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
 
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	if out, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+	if out, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
 

--- a/internal/backend/llvm_runtime_strings_chars_test.go
+++ b/internal/backend/llvm_runtime_strings_chars_test.go
@@ -100,7 +100,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -184,7 +184,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -815,6 +815,13 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .trace = osty_rt_list_trace,
         .destroy = osty_rt_list_destroy,
         .young_eligible = true,
+        /* Phase 0i: list_trace ACQUIRE-loads `data` + `len`, and
+         * the grow path defers the old backing buffer's free until
+         * cycle end. Together that lets a concurrent marker iterate
+         * either the old or new buffer safely; either way both
+         * buffers stay alive for the duration of any in-flight
+         * trace. */
+        .trace_lockfree_safe = true,
         .cleanup_young_dead = osty_gc_cleanup_young_dead_list,
         .remap = osty_gc_remap_list_payload,
     },
@@ -2026,6 +2033,88 @@ static size_t osty_gc_forwarding_hash(void *payload) {
 static int osty_gc_index_grow_pending = 0;
 static int64_t osty_gc_index_grow_deferred_total = 0;
 static int64_t osty_gc_index_pregrow_total = 0;
+
+/* Phase 0i: deferred-free queue for container backing storage that
+ * was reallocated mid-cycle. The bg marker may still be reading the
+ * old buffer via `list->data` / `map->keys` etc.; freeing it
+ * immediately would race the trace. We queue here lock-free via a
+ * Treiber stack and drain under `osty_gc_lock` at the end of
+ * `finish_locked`, when no marker can be active.
+ *
+ * State check is a fast path: when the cycle is IDLE, no marker
+ * exists and the buffer can be freed inline. The window between
+ * "read state == IDLE" and "free" is safe because cycle start
+ * (state := MARK_INCREMENTAL) goes under `osty_gc_lock`, and the
+ * mutator's `list->data` update RELEASE-stores BEFORE the
+ * defer_or_free call — any marker that subsequently sees the new
+ * `list->data` won't try to dereference the old buffer. */
+typedef struct osty_gc_deferred_free_node {
+    void *buffer;
+    struct osty_gc_deferred_free_node *next;
+} osty_gc_deferred_free_node;
+
+static uintptr_t osty_gc_deferred_free_head_atomic = 0;
+static int64_t osty_gc_deferred_free_immediate_total = 0;
+static int64_t osty_gc_deferred_free_queued_total = 0;
+static int64_t osty_gc_deferred_free_drained_total = 0;
+
+static void osty_gc_defer_or_free(void *buffer) {
+    if (buffer == NULL) {
+        return;
+    }
+    /* Fast path: no cycle in flight, free inline. The relaxed load
+     * is safe — if a cycle starts after our read but before the
+     * `free`, the cycle's seed_roots hasn't yet observed the list
+     * (its trace happens through the new `list->data` published by
+     * the caller's RELEASE). */
+    if (__atomic_load_n(&osty_gc_state, __ATOMIC_ACQUIRE) ==
+        OSTY_GC_STATE_IDLE) {
+        free(buffer);
+        (void)__atomic_add_fetch(&osty_gc_deferred_free_immediate_total,
+                                 1, __ATOMIC_RELAXED);
+        return;
+    }
+    osty_gc_deferred_free_node *node =
+        (osty_gc_deferred_free_node *)malloc(sizeof(*node));
+    if (node == NULL) {
+        osty_rt_abort("deferred_free: out of memory for queue node");
+    }
+    node->buffer = buffer;
+    /* Treiber-style lock-free push. Multiple mutators (including
+     * scheduler workers) may queue concurrently; the CAS loop wins
+     * one publish per push. */
+    uintptr_t old_head;
+    do {
+        old_head = __atomic_load_n(&osty_gc_deferred_free_head_atomic,
+                                   __ATOMIC_ACQUIRE);
+        node->next = (osty_gc_deferred_free_node *)old_head;
+    } while (!__atomic_compare_exchange_n(
+        &osty_gc_deferred_free_head_atomic, &old_head, (uintptr_t)node,
+        false /* strong */, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE));
+    (void)__atomic_add_fetch(&osty_gc_deferred_free_queued_total,
+                             1, __ATOMIC_RELAXED);
+}
+
+/* Drain the queue. Caller holds `osty_gc_lock` at the end of
+ * `finish_locked`, so no marker is active. Atomic exchange grabs
+ * the whole list in one shot; the walk below is single-threaded. */
+static void osty_gc_drain_deferred_frees(void) {
+    uintptr_t head = __atomic_exchange_n(
+        &osty_gc_deferred_free_head_atomic, 0, __ATOMIC_ACQ_REL);
+    osty_gc_deferred_free_node *node = (osty_gc_deferred_free_node *)head;
+    int64_t drained = 0;
+    while (node != NULL) {
+        osty_gc_deferred_free_node *next = node->next;
+        free(node->buffer);
+        free(node);
+        node = next;
+        drained += 1;
+    }
+    if (drained > 0) {
+        (void)__atomic_add_fetch(&osty_gc_deferred_free_drained_total,
+                                 drained, __ATOMIC_RELAXED);
+    }
+}
 
 static void osty_gc_index_grow(int64_t new_capacity) {
     void **old_keys = osty_gc_index_keys;
@@ -4809,12 +4898,28 @@ static void osty_rt_list_trace(void *payload) {
     int64_t i;
     int64_t j;
 
-    if (list == NULL || list->data == NULL) {
+    if (list == NULL) {
+        return;
+    }
+    /* Phase 0i: ACQUIRE-load `data` and `len` once at trace entry so
+     * a concurrent push that grows the backing buffer mid-trace
+     * doesn't tear our view. The pair pairs with the RELEASE store
+     * in `osty_rt_list_reserve`, which guarantees the new buffer is
+     * memcpy'd before we see the new pointer. The old buffer is
+     * deferred-freed (Phase 0i) so it stays alive long enough for
+     * us to finish iterating it.
+     *
+     * `elem_size`, `trace_elem`, `gc_offsets`, and `gc_offset_count`
+     * are immutable after list creation, so a plain load is fine. */
+    unsigned char *data = (unsigned char *)__atomic_load_n(
+        (void **)&list->data, __ATOMIC_ACQUIRE);
+    int64_t len = __atomic_load_n(&list->len, __ATOMIC_ACQUIRE);
+    if (data == NULL || len <= 0) {
         return;
     }
     if (list->trace_elem != NULL) {
-        for (i = 0; i < list->len; i++) {
-            list->trace_elem((void *)(list->data + ((size_t)i * list->elem_size)));
+        for (i = 0; i < len; i++) {
+            list->trace_elem((void *)(data + ((size_t)i * list->elem_size)));
         }
         return;
     }
@@ -4824,8 +4929,8 @@ static void osty_rt_list_trace(void *payload) {
     /* Pass slot addresses to mark_slot_v1 so cheney can forward
      * young children + rewrite the slot. mark_payload would only
      * mark via the headerful path — broken under CHENEY mode. */
-    for (i = 0; i < list->len; i++) {
-        unsigned char *elem = list->data + ((size_t)i * list->elem_size);
+    for (i = 0; i < len; i++) {
+        unsigned char *elem = data + ((size_t)i * list->elem_size);
         for (j = 0; j < list->gc_offset_count; j++) {
             osty_gc_mark_slot_v1((void *)(elem + (size_t)list->gc_offsets[j]));
         }
@@ -5383,21 +5488,25 @@ static void osty_gc_mark_stack_push(osty_gc_header *header) {
          * confirm the local cap is sized right for the workload. */
         (void)__atomic_add_fetch(&osty_gc_local_mark_overflow_total, 1,
                                  __ATOMIC_RELAXED);
-        /* Phase 0h safety: a lockfree-safe tracer is currently
-         * mid-dispatch with `osty_gc_lock` released. Pushing to the
-         * central stack here would race with mutator-side SATB
-         * pushes (which take `osty_gc_lock`). Abort with a clear
-         * message so the issue is visible — this is a design bound
-         * (closure captures cap at 64, generic enum ptr pushes 1),
-         * so realistic workloads can't hit it. If a future kind
-         * lifts the bound, the kind's `trace_lockfree_safe` flag
-         * needs to flip to false. */
+        /* Phase 0i: list/map/set tracers can push hundreds of children
+         * per call, well above the 256-slot local TLS cap. When that
+         * happens during a lockfree dispatch (Phase 0h), the marker
+         * has released `osty_gc_lock` and a direct push to the
+         * central stack would race mutator-side SATB pushes that
+         * still take the lock. Re-acquire briefly, flush the entire
+         * local stack into central, push the new header, then
+         * release. The cost is one lock cycle per ~256 children
+         * — amortised vs. iteration cost — and keeps the safety
+         * invariant: central pushes always happen under gc_lock. */
         if (osty_gc_in_lockfree_trace) {
-            osty_rt_abort(
-                "lockfree trace: local mark stack overflow without "
-                "gc_lock held — bound the kind's trace push count "
-                "below OSTY_GC_LOCAL_MARK_STACK_CAP or set "
-                "trace_lockfree_safe=false in the kind descriptor");
+            osty_gc_acquire();
+            while (osty_gc_local_mark_stack_top > 0) {
+                osty_gc_mark_stack_push_central(
+                    osty_gc_local_mark_stack[--osty_gc_local_mark_stack_top]);
+            }
+            osty_gc_mark_stack_push_central(header);
+            osty_gc_release();
+            return;
         }
     }
     osty_gc_mark_stack_push_central(header);
@@ -7006,6 +7115,12 @@ static void osty_gc_collect_incremental_finish_locked(
     if (osty_gc_index_grow_pending) {
         osty_gc_index_grow(osty_gc_index_capacity * 2);
     }
+    /* Phase 0i: drain any container backing buffers retired during
+     * this cycle. State is now IDLE so no marker can be reading;
+     * `osty_gc_lock` keeps mutator-side defer_or_free pushes from
+     * landing in the queue mid-drain (they'd see state IDLE on the
+     * fast path and free inline instead). */
+    osty_gc_drain_deferred_frees();
 }
 
 void osty_gc_collect_incremental_finish(void) {
@@ -7424,25 +7539,36 @@ static OSTY_HOT_INLINE void osty_rt_list_reserve(osty_rt_list *list, int64_t min
         osty_rt_abort("list allocation overflow");
     }
     /* Spill from inline → heap: malloc + memcpy the inline contents.
-     * Subsequent calls hit the regular realloc path because `data`
-     * now points outside the inline region. */
-    if (list->data == list->inline_storage) {
-        next_data = malloc(want_bytes);
-        if (next_data == NULL) {
-            osty_rt_abort("out of memory");
-        }
-        if (list->len > 0) {
-            memcpy(next_data, list->inline_storage,
-                   (size_t)list->len * list->elem_size);
-        }
-    } else {
-        next_data = realloc(list->data, want_bytes);
-        if (next_data == NULL) {
-            osty_rt_abort("out of memory");
+     * Subsequent calls used to hit `realloc` here, but Phase 0i
+     * lock-free trace requires the OLD buffer stay alive for the
+     * duration of any concurrent marker read. We therefore always
+     * malloc + memcpy + defer-free instead — same as the inline-spill
+     * branch — and let `osty_gc_defer_or_free` route the old buffer
+     * to the deferred queue when a cycle is in flight, or free it
+     * inline when state is IDLE. The extra alloc + copy on every
+     * grow is bounded by capacity-doubling so amortised cost stays
+     * O(1) per push. */
+    next_data = malloc(want_bytes);
+    if (next_data == NULL) {
+        osty_rt_abort("out of memory");
+    }
+    if (list->len > 0) {
+        size_t copy_bytes = (size_t)list->len * list->elem_size;
+        if (list->data != NULL) {
+            memcpy(next_data, list->data, copy_bytes);
         }
     }
-    list->data = (unsigned char *)next_data;
+    void *old_data = list->data;
+    bool old_was_inline = (old_data == list->inline_storage);
+    /* RELEASE store on `list->data` so a concurrent marker that
+     * sees the new pointer also sees the populated contents
+     * memcpy'd above. ACQUIRE on the marker side (in
+     * `osty_rt_list_trace`) pairs with this. */
+    __atomic_store_n((void **)&list->data, next_data, __ATOMIC_RELEASE);
     list->cap = next_cap;
+    if (!old_was_inline && old_data != NULL) {
+        osty_gc_defer_or_free(old_data);
+    }
 }
 
 static void osty_rt_list_emit_copied_write_barriers(void *raw_list, osty_rt_list *list, int64_t count) {
@@ -14648,6 +14774,27 @@ int64_t osty_gc_debug_lockfree_trace_total(void) {
 
 int64_t osty_gc_debug_locked_trace_total(void) {
     return __atomic_load_n(&osty_gc_locked_trace_total,
+                           __ATOMIC_ACQUIRE);
+}
+
+/* Phase 0i deferred-free queue accessors. `immediate_total` is the
+ * count of `defer_or_free` calls that found state IDLE and freed
+ * inline; `queued_total` is the count that pushed onto the deferred
+ * queue (cycle in flight); `drained_total` is the count flushed at
+ * `finish_locked` end. Steady-state invariant: `queued_total ==
+ * drained_total + still_in_queue`. */
+int64_t osty_gc_debug_deferred_free_immediate_total(void) {
+    return __atomic_load_n(&osty_gc_deferred_free_immediate_total,
+                           __ATOMIC_ACQUIRE);
+}
+
+int64_t osty_gc_debug_deferred_free_queued_total(void) {
+    return __atomic_load_n(&osty_gc_deferred_free_queued_total,
+                           __ATOMIC_ACQUIRE);
+}
+
+int64_t osty_gc_debug_deferred_free_drained_total(void) {
+    return __atomic_load_n(&osty_gc_deferred_free_drained_total,
                            __ATOMIC_ACQUIRE);
 }
 


### PR DESCRIPTION
## Summary

LIST is the first container kind to flip `trace_lockfree_safe = true`. The bg marker can now read `list->data` and `list->len` while a mutator concurrently pushes / grows the backing buffer, by combining three things:

1. **No more in-place realloc** — `osty_rt_list_reserve` always allocates a new buffer + memcpy + RELEASE-stores the new pointer, then routes the OLD buffer through `osty_gc_defer_or_free`. The old buffer stays alive for any in-flight reader.

2. **Deferred-free queue** — `osty_gc_defer_or_free` checks `osty_gc_state` atomically. IDLE: free inline. Anything else: Treiber-stack push onto a lock-free queue. Drained at the end of `finish_locked` once the cycle is fully settled (matches Phase 0f's pattern for index pre-grow / deferred-grow).

3. **Atomic snapshot in tracer** — `osty_rt_list_trace` ACQUIRE-loads `data` + `len` once at entry, pairing with reserve's RELEASE store. Whichever buffer the marker captures is alive — either still active or awaiting drain.

## Lockfree push overflow

`list_trace` can push hundreds of children, well above the 256-slot TLS local cap from Phase 0e'. The abort-guard from Phase 0h was too strict for this; replace it with a brief re-acquire of `osty_gc_lock` to flush local→central, then push the new header, then release. One lock cycle per ~256 children — bounded overhead against iteration cost.

## Test infra fix piggybacked here

PR #1023 added `osty_rt_compress_gzip_*` code that references libz, but didn't update the test compile commands. Bundled-runtime tests have been failing to link on macOS arm64 since then. This PR adds `-lz` to every `exec.Command("clang", ...)` in the test files (`llvm_runtime_*_test.go`). Unrelated to Phase 0i but required to actually run the suite locally.

## Test plan

- [x] **New** `TestBundledRuntimeListLockfreeTraceWithDeferredFree` — 30-element list, mid-cycle push of 60 more (forces realloc + defer), asserts queued >= 1, drained == queued, lockfree >= 1, live = 91
- [x] **Existing test fixups**:
  - `TestBundledRuntimeLockfreeTraceDispatch` — list now lockfree-traces, so the locked-path assertion drops to a soft signal
  - `TestBundledRuntimeBackgroundMarkerWorkSplit` — lockfree list trace doesn't yield the lock between pushes; relax active>=2 to active>=1
- [x] All Phase 0a–0h tests pass unchanged
- [x] All `TestBundledRuntimeIncremental*` pass
- [x] `go test ./internal/backend/` green (47s)
- [x] 3x repeated runs no flake

## Followup (Phase 0j / 0k)

`MAP` and `SET` are the next kinds. Same pattern: their grow paths (keys/values arrays for Map, items for Set) need to route through `osty_gc_defer_or_free`, and their tracers need atomic snapshots of the relevant fields. Slightly more surface than List because Map has separate keys/values/index arrays, but the deferred-free queue itself already handles them.

Channel keeps the lock for now — its slot ring uses a mutex+cond and head/tail counters that can mutate during trace, and a snapshot is harder to define cleanly. Probably never lock-free without more design.

## Telemetry

- `osty_gc_debug_deferred_free_immediate_total` — IDLE-state inline frees
- `osty_gc_debug_deferred_free_queued_total` — pushes to deferred queue
- `osty_gc_debug_deferred_free_drained_total` — drained at finish_locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)