### PR TITLE
refactor(llvmgen): port pure helpers + drain inline IR sites (Phase 2 slice 13)

### DIFF
--- a/internal/llvmgen/closure_lift.go
+++ b/internal/llvmgen/closure_lift.go
@@ -39,8 +39,6 @@
 package llvmgen
 
 import (
-	"fmt"
-
 	"github.com/osty/osty/internal/ast"
 	ostyir "github.com/osty/osty/internal/ir"
 )
@@ -170,7 +168,8 @@ func liftClosuresFromModule(mod *ostyir.Module) []ast.Decl {
 			return true
 		}
 		closureLiftCounter++
-		fnName := fmt.Sprintf("__osty_closure_%d", closureLiftCounter)
+		idDigits := mirGenIntToString(closureLiftCounter)
+		fnName := mirNativeLiftedClosureName(idDigits)
 		fnDecl.Name = fnName
 		rec := &liftedClosure{
 			name:     fnName,
@@ -178,7 +177,7 @@ func liftClosuresFromModule(mod *ostyir.Module) []ast.Decl {
 			captures: captures,
 		}
 		if len(captures) > 0 {
-			rec.makerName = fmt.Sprintf("%s%d", closureMakerNamePrefix, closureLiftCounter)
+			rec.makerName = mirClosureMakerName(idDigits)
 			currentLiftedClosuresByMaker[rec.makerName] = rec
 		}
 		currentLiftedClosures[c] = rec

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1846,9 +1846,10 @@ func (g *generator) emitIfExprPhi(labels *LlvmIfLabels, thenPred, elsePred strin
 // unchanged so the surrounding check reports the real "no arm
 // produced a value" failure.
 func coerceVoidArm(a, b value) (value, value) {
-	if a.typ == "void" && b.typ != "void" && b.typ != "" {
+	switch mirCoerceVoidArmStatus(a.typ, b.typ) {
+	case 1:
 		a = value{typ: b.typ, ref: "undef"}
-	} else if b.typ == "void" && a.typ != "void" && a.typ != "" {
+	case 2:
 		b = value{typ: a.typ, ref: "undef"}
 	}
 	return a, b

--- a/internal/llvmgen/iface_downcast.go
+++ b/internal/llvmgen/iface_downcast.go
@@ -35,8 +35,6 @@ package llvmgen
 // program that uses the syntax.
 
 import (
-	"fmt"
-
 	"github.com/osty/osty/internal/ast"
 )
 
@@ -64,17 +62,13 @@ func (g *generator) emitIfaceDowncastIR(ifaceVal value, targetVtableSym string) 
 	}
 	emitter := g.toOstyEmitter()
 	vt := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = extractvalue %%osty.iface %s, 1", vt, ifaceVal.ref))
+	emitter.body = append(emitter.body, mirExtractValueIfaceVtableText(vt, ifaceVal.ref))
 	data := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = extractvalue %%osty.iface %s, 0", data, ifaceVal.ref))
+	emitter.body = append(emitter.body, mirExtractValueIfacePtrText(data, ifaceVal.ref))
 	isT := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = icmp eq ptr %s, %s", isT, vt, targetVtableSym))
+	emitter.body = append(emitter.body, mirICmpEqText(isT, "ptr", vt, targetVtableSym))
 	opt := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = select i1 %s, ptr %s, ptr null", opt, isT, data))
+	emitter.body = append(emitter.body, mirSelectPtrText(opt, isT, data, "null"))
 	g.takeOstyEmitter(emitter)
 	return value{typ: "ptr", ref: opt}, nil
 }
@@ -225,8 +219,5 @@ func namedTypeSingleSegment(t ast.Type) string {
 	if !ok || nt == nil {
 		return ""
 	}
-	if len(nt.Path) != 1 {
-		return ""
-	}
-	return nt.Path[0]
+	return mirNamedTypeSingleSegmentName(len(nt.Path), firstPathOrEmpty(nt.Path))
 }

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -12122,3 +12122,34 @@ func mirSwitchOpenLine(typ, scrut, defaultLbl string) string {
 func mirSwitchCloseLine() string {
 	return mirSwitchFooterLine()
 }
+
+// Osty: toolchain/mir_generator.osty — mirNamedTypeSingleSegmentName
+// returns firstPath when pathLen == 1, else "".
+func mirNamedTypeSingleSegmentName(pathLen int, firstPath string) string {
+	if pathLen != 1 {
+		return ""
+	}
+	return firstPath
+}
+
+// Osty: toolchain/mir_generator.osty — mirCoerceVoidArmStatus
+// classifies the two-arm void coercion: 1 ⇒ promote A to B's type,
+// 2 ⇒ promote B to A's type, 0 ⇒ no-op. Both-void and empty-type
+// fall to 0 so the surrounding diagnostic surfaces.
+func mirCoerceVoidArmStatus(aType, bType string) int {
+	if aType == "void" && bType != "void" && bType != "" {
+		return 1
+	}
+	if bType == "void" && aType != "void" && aType != "" {
+		return 2
+	}
+	return 0
+}
+
+// Osty: toolchain/mir_generator.osty — mirClosureMakerName formats
+// `__osty_make_closure_<id>`. The prefix is matched by
+// fn_value.go::isClosureMakerCall via strings.HasPrefix, so
+// byte-stability is required.
+func mirClosureMakerName(idDigits string) string {
+	return "__osty_make_closure_" + idDigits
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -12,7 +12,6 @@
 package llvmgen
 
 import (
-	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -521,10 +520,7 @@ func interfaceNominalName(t ast.Type) string {
 	if !ok || nt == nil {
 		return ""
 	}
-	if len(nt.Path) != 1 {
-		return ""
-	}
-	return nt.Path[0]
+	return mirNamedTypeSingleSegmentName(len(nt.Path), firstPathOrEmpty(nt.Path))
 }
 
 func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
@@ -1732,7 +1728,7 @@ func (g *generator) emitBenchAutoTuneN(stmts []ast.Stmt, declaredN string) (stri
 	g.currentBlock = probeLabel
 
 	const probeIters int64 = 10
-	probeCount := value{typ: "i64", ref: fmt.Sprintf("%d", probeIters)}
+	probeCount := value{typ: "i64", ref: mirGenIntToString(int(probeIters))}
 	if err := g.emitBenchInlineLoop(stmts, probeCount, "bench.probe", ""); err != nil {
 		return "", err
 	}
@@ -2450,7 +2446,7 @@ func (g *generator) emitResultMatchStmt(scrutinee value, info builtinResultType,
 
 	emitter := g.toOstyEmitter()
 	tag := llvmExtractValue(emitter, toOstyValue(scrutinee), "i64", 0)
-	cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: fmt.Sprintf("%d", firstInfo.tag)}))
+	cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: mirGenIntToString(firstInfo.tag)}))
 	thenLabel := llvmNextLabel(emitter, "match.result.first")
 	elseLabel := llvmNextLabel(emitter, "match.result.second")
 	endLabel := llvmNextLabel(emitter, "match.result.end")

--- a/internal/llvmgen/testing_property.go
+++ b/internal/llvmgen/testing_property.go
@@ -1,8 +1,6 @@
 package llvmgen
 
 import (
-	"fmt"
-
 	"github.com/osty/osty/internal/ast"
 )
 
@@ -91,7 +89,7 @@ func (g *generator) emitTestingProperty(call *ast.CallExpr, method string) error
 		g.branchTo(continueLabel)
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
 	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
@@ -371,7 +369,7 @@ func (g *generator) emitTestingPropertyOneOfCall(call *ast.CallExpr, seed value)
 	}
 	index, err := g.emitTestingPropertyIntRange(
 		value{typ: "i64", ref: "0"},
-		value{typ: "i64", ref: fmt.Sprintf("%d", len(listExpr.Elems))},
+		value{typ: "i64", ref: mirGenIntToString(len(listExpr.Elems))},
 		seed,
 	)
 	if err != nil {
@@ -396,7 +394,7 @@ func unwrapParenExpr(expr ast.Expr) ast.Expr {
 }
 
 func (g *generator) emitTestingPropertySeedOffset(seed value, delta int64) (value, error) {
-	return g.emitTestingPropertyAddI64(seed, value{typ: "i64", ref: fmt.Sprintf("%d", delta)})
+	return g.emitTestingPropertyAddI64(seed, value{typ: "i64", ref: mirGenIntToString(int(delta))})
 }
 
 func (g *generator) emitTestingPropertyAddI64(left, right value) (value, error) {
@@ -405,7 +403,7 @@ func (g *generator) emitTestingPropertyAddI64(left, right value) (value, error) 
 	}
 	emitter := g.toOstyEmitter()
 	name := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, %s", name, left.ref, right.ref))
+	emitter.body = append(emitter.body, mirAddI64Text(name, left.ref, right.ref))
 	g.takeOstyEmitter(emitter)
 	return value{typ: "i64", ref: name}, nil
 }

--- a/internal/llvmgen/tostring.go
+++ b/internal/llvmgen/tostring.go
@@ -119,12 +119,12 @@ func (g *generator) emitOptionToString(base value, opt *ast.OptionalType) (value
 
 	emitter := g.toOstyEmitter()
 	cmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", cmp, base.ref))
+	emitter.body = append(emitter.body, mirICmpEqPtrNullText(cmp, base.ref))
 	noneLabel := llvmNextLabel(emitter, "tostring.none")
 	someLabel := llvmNextLabel(emitter, "tostring.some")
 	endLabel := llvmNextLabel(emitter, "tostring.optend")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cmp, noneLabel, someLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cmp, noneLabel, someLabel))
+	emitter.body = append(emitter.body, mirLabelText(noneLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(noneLabel)
 
@@ -133,7 +133,7 @@ func (g *generator) emitOptionToString(base value, opt *ast.OptionalType) (value
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	emitter.body = append(emitter.body, mirLabelText(someLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(someLabel)
 
@@ -155,9 +155,9 @@ func (g *generator) emitOptionToString(base value, opt *ast.OptionalType) (value
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ %s, %%%s ]", tmp, noneStr.ref, nonePred, someStr.ref, somePred))
+	emitter.body = append(emitter.body, mirPhi2WayText(tmp, "ptr", noneStr.ref, nonePred, someStr.ref, somePred))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 
@@ -327,14 +327,15 @@ func (g *generator) emitEnumToString(base value, info *enumInfo) (value, error) 
 		nextLabel := ""
 		{
 			emitter := g.toOstyEmitter()
-			armLabel = llvmNextLabel(emitter, fmt.Sprintf("tostring.v%d", i))
-			nextLabel = llvmNextLabel(emitter, fmt.Sprintf("tostring.n%d", i))
+			iDigits := mirGenIntToString(i)
+			armLabel = llvmNextLabel(emitter, "tostring.v"+iDigits)
+			nextLabel = llvmNextLabel(emitter, "tostring.n"+iDigits)
 			g.takeOstyEmitter(emitter)
 		}
 		emitter := g.toOstyEmitter()
 		cond := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: strconv.Itoa(variant.tag)}))
-		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, armLabel, nextLabel))
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		emitter.body = append(emitter.body, mirBrCondText(cond.name, armLabel, nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(armLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(armLabel)
 
@@ -348,7 +349,7 @@ func (g *generator) emitEnumToString(base value, info *enumInfo) (value, error) 
 		}
 
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		emitter.body = append(emitter.body, mirLabelText(nextLabel))
 		g.takeOstyEmitter(emitter)
 		g.enterBlock(nextLabel)
 	}
@@ -360,14 +361,14 @@ func (g *generator) emitEnumToString(base value, info *enumInfo) (value, error) 
 	}
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	phi := fmt.Sprintf("  %s = phi ptr ", tmp)
+	phi := "  " + tmp + " = phi ptr "
 	for i, ex := range exits {
 		if i > 0 {
 			phi += ", "
 		}
-		phi += fmt.Sprintf("[ %s, %%%s ]", ex.ref, ex.pred)
+		phi += "[ " + ex.ref + ", %" + ex.pred + " ]"
 	}
 	emitter.body = append(emitter.body, phi)
 	g.takeOstyEmitter(emitter)
@@ -507,8 +508,8 @@ func (g *generator) emitResultToString(base value, info builtinResultType) (valu
 	okLabel := llvmNextLabel(emitter, "tostring.ok")
 	errLabel := llvmNextLabel(emitter, "tostring.err")
 	endLabel := llvmNextLabel(emitter, "tostring.resend")
-	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, okLabel, errLabel))
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", okLabel))
+	emitter.body = append(emitter.body, mirBrCondText(cond.name, okLabel, errLabel))
+	emitter.body = append(emitter.body, mirLabelText(okLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(okLabel)
 
@@ -520,7 +521,7 @@ func (g *generator) emitResultToString(base value, info builtinResultType) (valu
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", errLabel))
+	emitter.body = append(emitter.body, mirLabelText(errLabel))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(errLabel)
 
@@ -532,9 +533,9 @@ func (g *generator) emitResultToString(base value, info builtinResultType) (valu
 	g.branchTo(endLabel)
 
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	emitter.body = append(emitter.body, mirLabelText(endLabel))
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ %s, %%%s ]", tmp, okStr.ref, okPred, errStr.ref, errPred))
+	emitter.body = append(emitter.body, mirPhi2WayText(tmp, "ptr", okStr.ref, okPred, errStr.ref, errPred))
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(endLabel)
 

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -18282,3 +18282,37 @@ pub fn mirSwitchOpenLine(typ: String, scrut: String, defaultLbl: String) -> Stri
 pub fn mirSwitchCloseLine() -> String {
     mirSwitchFooterLine()
 }
+
+/// mirNamedTypeSingleSegmentName returns `firstPath` when `pathLen`
+/// is 1, else `""`. The bare-leaf-name extraction for AST-NamedType
+/// path shapes — multi-segment / qualified paths fall through.
+pub fn mirNamedTypeSingleSegmentName(pathLen: Int, firstPath: String) -> String {
+    if pathLen != 1 {
+        return ""
+    }
+    firstPath
+}
+
+/// mirCoerceVoidArmStatus classifies the two-arm void coercion needed
+/// for joinpoint phi typing. Returns 1 to promote A to B's type, 2 to
+/// promote B to A's type, 0 otherwise (both typed, both void, or one
+/// side has the empty-type sentinel — the empty case is left to
+/// surrounding diagnostics).
+pub fn mirCoerceVoidArmStatus(aType: String, bType: String) -> Int {
+    if aType == "void" && bType != "void" && bType != "" {
+        return 1
+    }
+    if bType == "void" && aType != "void" && aType != "" {
+        return 2
+    }
+    0
+}
+
+/// mirClosureMakerName formats the `__osty_make_closure_<id>` symbol
+/// the bridge stamps on the closure-construction call. The prefix is
+/// load-bearing: `fn_value.go::isClosureMakerCall` matches it via
+/// `strings.HasPrefix`, so byte-stability is required.
+pub fn mirClosureMakerName(idDigits: String) -> String {
+    "__osty_make_closure_" + idDigits
+}
+


### PR DESCRIPTION
## Summary
- Add 3 new helpers to `toolchain/mir_generator.osty` (`mirNamedTypeSingleSegmentName`, `mirCoerceVoidArmStatus`, `mirClosureMakerName`) with Go-side mirrors in `mir_generator_snapshot.go`.
- Drain inline `fmt.Sprintf` IR text in `iface_downcast.go` / `closure_lift.go` / `testing_property.go` / `stmt.go` / `tostring.go` (Option/enum/Result tostring, iface downcast 4-instr lowering, bench probe count, Result match tag) to existing builders — `mirICmpEqText`, `mirSelectPtrText`, `mirPhi2WayText`, `mirAddI64Text`, `mirLabelText`, `mirBrCondText`, `mirICmpEqPtrNullText`, `mirGenIntToString`, plus existing `mirNativeLiftedClosureName`.
- Net `+103/-52` across 8 files; `fmt` import dropped from 4 files.

## Test plan
- [x] `just prepush` 로컬 통과 (`fmt-check` + `vet` + `repair-check` + `ci`)
- [x] `go test -short ./internal/llvmgen/` — 정확히 baseline 7개 fail만 (slice 12 PR이 명시한 6개 + `TestGeneratedComparePoliciesAreOstyOwned` — `Bytes` enum payload regression introduced by §17 ToString WIP). 새 회귀 없음.
- [x] `TestToolchainFilesParseWithoutDiagnostics` 통과
- [x] `just front` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)