### PR TITLE
[codex] Implement std random shuffle

### DIFF
--- a/internal/backend/stdlib_random_check_test.go
+++ b/internal/backend/stdlib_random_check_test.go
@@ -1,0 +1,29 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultRandom pins that std.random's pure-Osty derived
+// helpers type-check cleanly. The runtime-backed primitive surface
+// should remain usable from helper bodies like choice and shuffle.
+func TestStdlibCheckResultRandom(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "random")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(random) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("random module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/random.osty
+++ b/internal/stdlib/modules/random.osty
@@ -1,7 +1,8 @@
 // std.random — non-cryptographic pseudorandom numbers (spec §10.14).
 //
-// Constructors and primitive methods are runtime-backed. `choice`
-// stays as the canonical derived helper over the primitive surface.
+// Constructors and primitive methods are runtime-backed. `choice` and
+// `shuffle` stay as canonical derived helpers over that primitive
+// surface, so their edge-case behavior is visible in the stdlib source.
 
 pub struct Rng {
     pub fn int(self, min: Int, max: Int) -> Int
@@ -18,7 +19,21 @@ pub struct Rng {
         }
     }
 
-    pub fn shuffle<T>(self, items: List<T>)
+    /// Shuffle `items` in place with Fisher-Yates. Empty and single-item
+    /// lists are left unchanged; every other permutation is produced by
+    /// the receiver's own random stream.
+    pub fn shuffle<T>(self, items: List<T>) {
+        let mut i = items.len()
+        for i > 1 {
+            i = i - 1
+            let j = self.int(0, i + 1)
+            if j != i {
+                let tmp = items[i]
+                items[i] = items[j]
+                items[j] = tmp
+            }
+        }
+    }
 }
 
 pub fn default() -> Rng

--- a/internal/stdlib/random_test.go
+++ b/internal/stdlib/random_test.go
@@ -1,0 +1,44 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRandomModuleDerivedHelpersAreBodied(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["random"]
+	if mod == nil {
+		t.Fatal("stdlib random module missing")
+	}
+
+	for _, name := range []string{"choice", "shuffle"} {
+		fn := reg.LookupMethodDecl("random", "Rng", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(random, Rng, %s) = nil, want stdlib helper", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("random.Rng.%s body = nil, want Osty helper body", name)
+		}
+	}
+}
+
+func TestRandomShuffleSourcePinsFisherYates(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["random"]
+	if mod == nil {
+		t.Fatal("stdlib random module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"for i > 1",
+		"let j = self.int(0, i + 1)",
+		"let tmp = items[i]",
+		"items[i] = items[j]",
+		"items[j] = tmp",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("random shuffle source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `std.random.Rng.shuffle` in Osty using Fisher-Yates.
- Add stdlib loader coverage so `choice` and `shuffle` remain bodied helpers.
- Add backend stdlib-check coverage for the random module.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestRandom'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultRandom'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsStdRandom'`

Note: full `./internal/stdlib` still has an unrelated pre-existing `TestPreludeBuiltinRebindings` panic, reproduced in a clean temporary checkout.