### PR TITLE
[codex] Implement std list reverse

### DIFF
--- a/internal/llvmgen/stdlib_method_lookup.go
+++ b/internal/llvmgen/stdlib_method_lookup.go
@@ -131,6 +131,7 @@ var ListCanonicalHelperNames = []string{
 	"windowed",
 	"partition",
 	"flatMap",
+	"reverse",
 }
 
 // LookupStructMethod returns the bodied AST method `methodName` on the

--- a/internal/stdlib/collections_test.go
+++ b/internal/stdlib/collections_test.go
@@ -1,0 +1,38 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollectionsListReverseIsBodied(t *testing.T) {
+	reg := LoadCached()
+	fn := reg.LookupMethodDecl("collections", "List", "reverse")
+	if fn == nil {
+		t.Fatal("LookupMethodDecl(collections, List, reverse) = nil, want stdlib helper")
+	}
+	if fn.Body == nil {
+		t.Fatal("List.reverse body = nil, want Osty helper body")
+	}
+}
+
+func TestCollectionsListReverseSourcePinsSwapLoop(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["collections"]
+	if mod == nil {
+		t.Fatal("stdlib collections module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"let mut lo = 0",
+		"let mut hi = self.len()",
+		"for lo < hi",
+		"let tmp = self[lo]",
+		"self[lo] = self[hi]",
+		"self[hi] = tmp",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("List.reverse source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -299,7 +299,19 @@ pub struct List<T> {
     pub fn insert(mut self, index: Int, item: T)
     pub fn removeAt(mut self, index: Int) -> T
     pub fn sort(mut self)
-    pub fn reverse(mut self)
+    pub fn reverse(mut self) {
+        let mut lo = 0
+        let mut hi = self.len()
+        for lo < hi {
+            hi = hi - 1
+            if lo < hi {
+                let tmp = self[lo]
+                self[lo] = self[hi]
+                self[hi] = tmp
+                lo = lo + 1
+            }
+        }
+    }
     pub fn clear(mut self) {
         for self.len() > 0 {
             self.removeAt(self.len() - 1)


### PR DESCRIPTION
## Summary
- Implement `List.reverse` in `std.collections` as a pure Osty in-place two-pointer swap loop.
- Add stdlib tests pinning that `List.reverse` is a bodied helper and keeps the expected swap-loop source shape.
- Add `reverse` to the canonical List helper lookup set for future stdlib method body routing.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestCollectionsListReverse'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestLookupListCanonicalHelpersPresent'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsListReverseInPlace'`

Note: a broad `stdlibCheckResult(collections)` check was intentionally not added because existing unrelated collection helpers currently fail that full-module selfhost check.