### PR TITLE
[codex] Implement std time duration helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md
+++ b/LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md
@@ -79,6 +79,16 @@ Duration.toString(self) -> String
 // Adaptive output: "1.23s", "15ms", "120µs", "2m30s", "1h05m".
 ```
 
+Whole-unit conversion helpers return truncated integer counts:
+
+```osty
+Duration.abs(self) -> Duration
+Duration.micros(self) -> Int
+Duration.millis(self) -> Int
+Duration.seconds(self) -> Int
+Instant.since(self, earlier: Instant) -> Duration
+```
+
 `Duration` is `Equal`, `Ordered`, `Hashable`. It supports `+`, `-`,
 `*` (by `Int`), `/` (by `Int`).
 

--- a/internal/backend/stdlib_time_check_test.go
+++ b/internal/backend/stdlib_time_check_test.go
@@ -1,0 +1,29 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultTime pins that std.time's pure helper bodies
+// type-check cleanly while runtime-backed clock, zone, and formatting
+// entries remain declaration-only.
+func TestStdlibCheckResultTime(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "time")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(time) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("time module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/time.osty
+++ b/internal/stdlib/modules/time.osty
@@ -12,7 +12,24 @@ pub let RFC_2822: String = "Mon, 02 Jan 2006 15:04:05 -0700"
 pub struct Duration {
     pub nanoseconds: Int64,
 
-    pub fn abs(self) -> Duration
+    pub fn abs(self) -> Duration {
+        Duration { nanoseconds: self.nanoseconds.abs() }
+    }
+
+    pub fn micros(self) -> Int {
+        let nanosPerMicro: Int64 = 1000
+        self.nanoseconds / nanosPerMicro
+    }
+
+    pub fn millis(self) -> Int {
+        let nanosPerMilli: Int64 = 1000000
+        self.nanoseconds / nanosPerMilli
+    }
+
+    pub fn seconds(self) -> Int {
+        let nanosPerSecond: Int64 = 1000000000
+        self.nanoseconds / nanosPerSecond
+    }
 
     pub fn toString(self) -> String
 }
@@ -26,6 +43,10 @@ pub struct Instant {
 
     pub fn sub(self, other: Instant) -> Duration {
         Duration { nanoseconds: self.unixNanos - other.unixNanos }
+    }
+
+    pub fn since(self, earlier: Instant) -> Duration {
+        self.sub(earlier)
     }
 
     pub fn format(self, layout: String) -> String

--- a/internal/stdlib/time_test.go
+++ b/internal/stdlib/time_test.go
@@ -1,0 +1,54 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTimeModuleDerivedHelpersAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		method   string
+	}{
+		{"Duration", "abs"},
+		{"Duration", "micros"},
+		{"Duration", "millis"},
+		{"Duration", "seconds"},
+		{"Instant", "add"},
+		{"Instant", "sub"},
+		{"Instant", "since"},
+		{"Instant", "inZone"},
+		{"ZonedTime", "format"},
+	} {
+		fn := reg.LookupMethodDecl("time", tc.typeName, tc.method)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(time, %s, %s) = nil", tc.typeName, tc.method)
+		}
+		if fn.Body == nil {
+			t.Fatalf("time.%s.%s body = nil, want Osty helper body", tc.typeName, tc.method)
+		}
+	}
+}
+
+func TestTimeModuleSourcePinsDurationHelpers(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["time"]
+	if mod == nil {
+		t.Fatal("stdlib time module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"Duration { nanoseconds: self.nanoseconds.abs() }",
+		"let nanosPerMicro: Int64 = 1000",
+		"let nanosPerMilli: Int64 = 1000000",
+		"let nanosPerSecond: Int64 = 1000000000",
+		"self.nanoseconds / nanosPerMilli",
+		"pub fn since(self, earlier: Instant) -> Duration",
+		"self.sub(earlier)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("time helper source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implement pure `std.time` helpers for `Duration.abs`, `Duration.micros`, `Duration.millis`, `Duration.seconds`, and `Instant.since`.
- Document the whole-unit duration helpers and `Instant.since` in the standard-library time spec.
- Add stdlib loader and backend selfhost-check coverage for the new time helper bodies.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestTimeModule'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultTime'`