### PR TITLE
[codex] Complete std.regex helper surface

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/09-regular-expressions.md
+++ b/LANG_SPEC_v0.5/10-standard-library/09-regular-expressions.md
@@ -36,8 +36,18 @@ Regex.capturesAll(text: String) -> List<Captures>
 Regex.replace(text: String, replacement: String) -> String
 Regex.replaceAll(text: String, replacement: String) -> String
 Regex.split(text: String) -> List<String>
+
+regex.matches(text: String, pattern: String) -> Result<Bool, RegexError>
+regex.find(text: String, pattern: String) -> Result<Match?, RegexError>
+regex.findAll(text: String, pattern: String) -> Result<List<Match>, RegexError>
+regex.captures(text: String, pattern: String) -> Result<Captures?, RegexError>
+regex.capturesAll(text: String, pattern: String) -> Result<List<Captures>, RegexError>
+regex.replace(text: String, pattern: String, replacement: String) -> Result<String, RegexError>
+regex.replaceAll(text: String, pattern: String, replacement: String) -> Result<String, RegexError>
+regex.split(text: String, pattern: String) -> Result<List<String>, RegexError>
 ```
 
 `Match` provides `.text: String`, `.start: Int`, `.end: Int`.
 `Captures` provides `.get(i: Int) -> String?` and
 `.named(name: String) -> String?` for named groups `(?P<name>...)`.
+`RegexError` provides `.message: String` and `.message() -> String`.

--- a/internal/backend/stdlib_regex_check_test.go
+++ b/internal/backend/stdlib_regex_check_test.go
@@ -1,0 +1,29 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultRegex pins that std.regex's pure one-shot
+// wrappers type-check cleanly while RE2 runtime primitives remain
+// declaration-only.
+func TestStdlibCheckResultRegex(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "regex")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(regex) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("regex module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/regex.osty
+++ b/internal/stdlib/modules/regex.osty
@@ -1,6 +1,6 @@
 // std.regex — RE2 regular expressions (spec §10.9).
 //
-// Match / find / replace / split primitives are body-less — the backend
+// Match / find / capture / replace / split primitives are body-less — the backend
 // lowers each call to the RE2 runtime. One-shot free functions at the
 // bottom are real Osty wrappers that compile + apply in one call.
 
@@ -24,6 +24,10 @@ pub struct Regex {
 
 pub struct RegexError {
     pub message: String
+
+    pub fn message(self) -> String {
+        self.message
+    }
 }
 
 pub struct Match {
@@ -56,6 +60,16 @@ pub fn find(text: String, pattern: String) -> Result<Match?, RegexError> {
 pub fn findAll(text: String, pattern: String) -> Result<List<Match>, RegexError> {
     let re = compile(pattern)?
     Ok(re.findAll(text))
+}
+
+pub fn captures(text: String, pattern: String) -> Result<Captures?, RegexError> {
+    let re = compile(pattern)?
+    Ok(re.captures(text))
+}
+
+pub fn capturesAll(text: String, pattern: String) -> Result<List<Captures>, RegexError> {
+    let re = compile(pattern)?
+    Ok(re.capturesAll(text))
 }
 
 pub fn replace(text: String, pattern: String, replacement: String) -> Result<String, RegexError> {

--- a/internal/stdlib/regex_test.go
+++ b/internal/stdlib/regex_test.go
@@ -1,0 +1,133 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestRegexModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	if reg.Modules["regex"] == nil {
+		t.Fatal("stdlib regex module missing")
+	}
+
+	for _, name := range []string{
+		"matches",
+		"find",
+		"findAll",
+		"captures",
+		"capturesAll",
+		"replace",
+		"replaceAll",
+		"split",
+	} {
+		fn := reg.LookupFnDecl("regex", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(regex, %s) = nil, want one-shot helper", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("regex.%s body = nil, want pure-Osty compile-and-apply wrapper", name)
+		}
+	}
+
+	compile := reg.LookupFnDecl("regex", "compile")
+	if compile == nil {
+		t.Fatal("LookupFnDecl(regex, compile) = nil, want runtime bridge declaration")
+	}
+	if compile.Body != nil {
+		t.Fatal("regex.compile has a source body, want runtime bridge declaration")
+	}
+
+	for _, tc := range []struct {
+		typeName string
+		method   string
+		bodied   bool
+	}{
+		{"Regex", "matches", false},
+		{"Regex", "find", false},
+		{"Regex", "findAll", false},
+		{"Regex", "captures", false},
+		{"Regex", "capturesAll", false},
+		{"Regex", "replace", false},
+		{"Regex", "replaceAll", false},
+		{"Regex", "split", false},
+		{"RegexError", "message", true},
+		{"Captures", "get", false},
+		{"Captures", "named", false},
+	} {
+		fn := reg.LookupMethodDecl("regex", tc.typeName, tc.method)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(regex, %s, %s) = nil", tc.typeName, tc.method)
+		}
+		if tc.bodied && fn.Body == nil {
+			t.Fatalf("regex.%s.%s body = nil, want source method body", tc.typeName, tc.method)
+		}
+		if !tc.bodied && fn.Body != nil {
+			t.Fatalf("regex.%s.%s has a source body, want runtime bridge declaration", tc.typeName, tc.method)
+		}
+	}
+}
+
+func TestRegexOneShotCaptureHelpersArePinned(t *testing.T) {
+	src := regexModuleSource(t)
+	for _, want := range []string{
+		"pub fn captures(text: String, pattern: String) -> Result<Captures?, RegexError>",
+		"Ok(re.captures(text))",
+		"pub fn capturesAll(text: String, pattern: String) -> Result<List<Captures>, RegexError>",
+		"Ok(re.capturesAll(text))",
+		"pub fn message(self) -> String",
+		"self.message",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("regex module source missing %q", want)
+		}
+	}
+}
+
+func TestRegexImportResolvesOneShotHelpers(t *testing.T) {
+	src := `
+use std.regex
+
+pub fn demo(text: String) -> Result<String, regex.RegexError> {
+    let re = regex.compile(r"(?P<word>\w+)")?
+    let ok = regex.matches(text, r"\w+")?
+    let first = regex.captures(text, r"(?P<word>\w+)")?
+    let all = regex.capturesAll(text, r"(?P<word>\w+)")?
+    let words = re.findAll(text)
+    let pieces = regex.split(text, r"\s+")?
+    let cleaned = regex.replaceAll(text, r"\s+", " ")?
+    match first {
+        Some(caps) -> {
+            let head = caps.get(0) ?? "missing"
+            Ok("{ok}:{all.len()}:{words.len()}:{pieces.len()}:{head}:{cleaned}")
+        },
+        None -> Ok("{ok}:0"),
+    }
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	res := resolve.ResolveFileDefault(file, Load())
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		t.Errorf("resolver rejected std.regex fixture: %s: %s", d.Code, d.Message)
+	}
+}
+
+func regexModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["regex"]
+	if mod == nil {
+		t.Fatal("stdlib regex module missing")
+	}
+	return string(mod.Source)
+}


### PR DESCRIPTION
## Summary
- add `regex.captures` and `regex.capturesAll` one-shot helpers
- add `RegexError.message()` for ergonomic error handling
- document the complete one-shot helper API and add stdlib/backend regression coverage

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestRegex'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultRegex'`
- `git diff --check`