### PR TITLE
[codex] Port LLVM native test paths

### DIFF
--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	ostyir "github.com/osty/osty/internal/ir"
 )
 
 func runLLVMGenSource(t *testing.T, path string, source string) llvmgenResponse {
@@ -174,7 +176,7 @@ func TestRunUsesNativeOwnedExportAndCABIShape(t *testing.T) {
 }
 
 func TestRunCoversRuntimeStringsSplitAndListToSet(t *testing.T) {
-	resp := runLLVMGenSource(t, "main.osty", `use runtime.strings as strings {
+	source := `use runtime.strings as strings {
     fn Split(s: String, sep: String) -> List<String>
 }
 
@@ -183,9 +185,14 @@ fn main() {
     let seen = items.toSet()
     println(seen.contains("pear"))
 }
-`)
+`
+	resp := runLLVMGenSource(t, "main.osty", source)
 	if !resp.Covered {
-		t.Fatalf("covered = false, want true")
+		entry, err := prepareSourceEntry(llvmgenRequest{Path: "main.osty", Source: source})
+		if err != nil {
+			t.Fatalf("covered = false, want true; prepareSourceEntry error: %v", err)
+		}
+		t.Fatalf("covered = false, want true\n%s", ostyir.Print(entry.IR))
 	}
 	for _, want := range []string{
 		"declare ptr @osty_rt_strings_Split(ptr, ptr)",

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -95,7 +95,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -211,7 +211,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -278,7 +278,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -348,7 +348,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -420,7 +420,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -512,7 +512,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -606,7 +606,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -702,7 +702,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -858,7 +858,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1025,7 +1025,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1114,7 +1114,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1208,7 +1208,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1274,7 +1274,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1400,7 +1400,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1477,7 +1477,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1595,7 +1595,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1702,7 +1702,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1802,7 +1802,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1857,7 +1857,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -1949,7 +1949,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2036,7 +2036,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2134,7 +2134,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2218,7 +2218,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2311,7 +2311,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2387,7 +2387,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2519,7 +2519,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2655,7 +2655,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2766,7 +2766,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2870,7 +2870,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -2978,7 +2978,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3119,7 +3119,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3269,7 +3269,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3428,7 +3428,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3589,7 +3589,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3723,7 +3723,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -3865,7 +3865,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4003,7 +4003,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4133,7 +4133,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4276,7 +4276,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4439,7 +4439,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4547,7 +4547,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4632,7 +4632,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4716,7 +4716,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4794,7 +4794,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4889,7 +4889,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -4979,7 +4979,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5073,7 +5073,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5182,7 +5182,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5272,7 +5272,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5343,7 +5343,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5409,7 +5409,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5478,7 +5478,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5549,7 +5549,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5616,7 +5616,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5687,7 +5687,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5766,7 +5766,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5845,7 +5845,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -5944,7 +5944,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6021,7 +6021,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6096,7 +6096,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6179,7 +6179,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6270,7 +6270,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6344,7 +6344,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6441,7 +6441,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6528,7 +6528,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6630,7 +6630,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6742,7 +6742,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6822,7 +6822,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -6943,7 +6943,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -7045,7 +7045,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7133,7 +7133,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7221,7 +7221,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7357,7 +7357,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7486,7 +7486,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7648,7 +7648,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7759,7 +7759,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -7852,7 +7852,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8024,7 +8024,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8132,7 +8132,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8251,7 +8251,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8378,7 +8378,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8493,7 +8493,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8591,7 +8591,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8699,7 +8699,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8787,7 +8787,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -8917,7 +8917,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -9014,7 +9014,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -9130,7 +9130,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -9238,7 +9238,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/llvm_runtime_map_fastpath_test.go
+++ b/internal/backend/llvm_runtime_map_fastpath_test.go
@@ -93,7 +93,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -181,7 +181,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -280,7 +280,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -360,7 +360,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -477,7 +477,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -601,7 +601,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -693,7 +693,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -808,7 +808,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -891,7 +891,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -1006,7 +1006,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -1110,7 +1110,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1216,7 +1216,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1301,7 +1301,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1385,7 +1385,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1510,7 +1510,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1617,7 +1617,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1732,7 +1732,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1821,7 +1821,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -1958,7 +1958,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2093,7 +2093,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2231,7 +2231,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
@@ -2350,7 +2350,7 @@ int main(void) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-O2", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := runtimeClangCommand("-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}

--- a/internal/backend/llvm_runtime_snapshot_test.go
+++ b/internal/backend/llvm_runtime_snapshot_test.go
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -249,7 +249,7 @@ int main(int argc, char **argv) {
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	if out, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+	if out, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
 
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	if out, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+	if out, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, out)
 	}
 

--- a/internal/backend/llvm_runtime_strings_chars_test.go
+++ b/internal/backend/llvm_runtime_strings_chars_test.go
@@ -100,7 +100,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
@@ -184,7 +184,7 @@ int main(void) {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
 
-	buildOutput, err := exec.Command("clang", "-std=c11", "-lz", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}

--- a/internal/backend/llvm_runtime_test_helpers_test.go
+++ b/internal/backend/llvm_runtime_test_helpers_test.go
@@ -1,0 +1,13 @@
+package backend
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func runtimeClangCommand(args ...string) *exec.Cmd {
+	if runtime.GOOS != "windows" {
+		args = append(args, "-lz")
+	}
+	return exec.Command("clang", args...)
+}

--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -316,6 +316,10 @@ func filterMethodsAvoidingOwnerRecursion(owner string, generics []string, method
 		if m == nil {
 			continue
 		}
+		if m.Body != nil && len(m.Generics) == 0 && methodHasUnsupportedLLVMShape(owner, m) {
+			droppedSelfCall[m.Name] = true
+			continue
+		}
 		if m.Body != nil && len(m.Generics) == 0 && methodRecursesOwner(owner, generics, m) {
 			droppedSelfCall[m.Name] = true
 			continue
@@ -346,6 +350,23 @@ func filterMethodsAvoidingOwnerRecursion(owner string, generics []string, method
 		}
 	}
 	return survived
+}
+
+// methodHasUnsupportedLLVMShape drops stdlib helpers that are valid
+// Osty but still outside the legacy AST LLVM emitter's return-shape
+// support. Keeping these on every injected specialization makes
+// unrelated user programs compile unused helper bodies and wall before
+// they reach the method they actually called.
+func methodHasUnsupportedLLVMShape(owner string, m *ir.FnDecl) bool {
+	if m == nil {
+		return false
+	}
+	// Map.find returns `(K, V)?`. The legacy AST LLVM path currently
+	// treats optional tuple returns as pointer-shaped at the function
+	// boundary while expression lowering produces the concrete optional
+	// aggregate, so eager specialization fails even when `find` is not
+	// called. Demand-driven method emission can remove this guard.
+	return owner == "Map" && m.Name == "find"
 }
 
 // ownerUndispatchableMethodSet returns the set of **body-less

--- a/internal/backend/stdlib_type_inject_test.go
+++ b/internal/backend/stdlib_type_inject_test.go
@@ -78,6 +78,13 @@ fn main() {}
 					t.Errorf("injected Map template missing method %q", want)
 				}
 			}
+			for _, skipped := range []string{"find"} {
+				for _, m := range sd.Methods {
+					if m != nil && m.Name == skipped {
+						t.Errorf("injected Map template should temporarily skip unsupported method %q", skipped)
+					}
+				}
+			}
 		}
 	}
 	if !foundMap {

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -1382,7 +1382,7 @@ func (s *monoState) scanStmt(st Stmt) {
 			s.seedVariantTypeFromContext(st.Type, st.Value)
 			s.scanExpr(st.Value)
 			if isUnresolvedType(st.Type) || containsTypeVar(st.Type) {
-				st.Type = cloneResolvedType(st.Value.Type())
+				st.Type = cloneResolvedType(s.resolvedExprType(st.Value))
 			}
 		}
 		if st.Name != "" && !isUnresolvedType(st.Type) {
@@ -1707,6 +1707,10 @@ func (s *monoState) resolvedExprType(e Expr) Type {
 	case *Ident:
 		if inferred, ok := s.lookupLocalType(x.Name); ok {
 			return inferred
+		}
+	case *StructLit:
+		if x.TypeName != "" {
+			return &NamedType{Name: x.TypeName}
 		}
 	case *VariantLit:
 		if inferred := s.inferVariantLiteralType(x); inferred != nil {

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -1561,11 +1561,11 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 	}
 	if sig.ret == "void" {
 		if err := g.emitBlock(sig.decl.Body.Stmts); err != nil {
-			return "", err
+			return "", fmt.Errorf("function %s: %w", sig.name, err)
 		}
 		if g.currentReachable {
 			if err := g.emitAllPendingDefers(); err != nil {
-				return "", err
+				return "", fmt.Errorf("function %s: %w", sig.name, err)
 			}
 		}
 		if g.currentReachable {
@@ -1576,7 +1576,7 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 		}
 	} else {
 		if err := g.emitReturningBlock(sig.decl.Body.Stmts, sig.ret, sig.returnSourceType, sig.retListElemTyp, sig.retListString, sig.retMapKeyTyp, sig.retMapValueTyp, sig.retMapKeyString, sig.retSetElemTyp, sig.retSetElemString); err != nil {
-			return "", err
+			return "", fmt.Errorf("function %s: %w", sig.name, err)
 		}
 	}
 	return g.renderFunction(sig.ret, sig.irName, sig.params), nil

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -158,7 +158,7 @@ func runMonoLowerPipeline(t *testing.T, src, sourcePath string) string {
 		SourcePath:  sourcePath,
 	})
 	if err != nil {
-		t.Fatalf("GenerateModule error: %v\n--- source ---\n%s", err, src)
+		t.Fatalf("GenerateModule error: %v\n--- ir ---\n%s\n--- source ---\n%s", err, ir.Print(monoMod), src)
 	}
 	return string(out)
 }

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -95,6 +95,7 @@ type nativeRuntimeFFIFunction struct {
 	path     string
 	symbol   string
 	retType  string
+	retIR    ostyir.Type
 	paramTys []string
 }
 
@@ -167,6 +168,7 @@ type nativeProjectionCtx struct {
 	stringGlobals         []*LlvmStringGlobal
 	nextStringID          int
 	currentReturnLLVMType string
+	packageName           string
 	sourcePath            string
 	source                []byte
 	// tempCounter mints monotone fresh names for synthetic locals
@@ -333,6 +335,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		stdIoAliases:      map[string]bool{},
 		stdFsAliases:      map[string]bool{},
 		runtimeDeclSet:    map[string]bool{},
+		packageName:       firstNonEmpty(opts.PackageName, mod.Package),
 		sourcePath:        firstNonEmpty(opts.SourcePath, "<unknown>"),
 		source:            append([]byte(nil), opts.Source...),
 	}
@@ -607,6 +610,7 @@ func collectNativeInterfaceImpls(mod *ostyir.Module) []nativeInterfaceImpl {
 		resultsByName:     map[string]*nativeResultInfo{},
 		resultsByLLVMType: map[string]*nativeResultInfo{},
 		methodsByOwner:    map[string]map[string]nativeMethodInfo{},
+		packageName:       mod.Package,
 	}
 	structOrder := make([]string, 0)
 	structDecls := map[string]*ostyir.StructDecl{}
@@ -834,8 +838,15 @@ func nativeInterfaceMethodCallExpr(
 	if receiverValue.llvmType != "%osty.iface" {
 		return nil, false
 	}
-	named, ok := e.Receiver.Type().(*ostyir.NamedType)
+	receiverInfo, infoOK := nativeExprTypeInfo(ctx, e.Receiver)
+	if !infoOK {
+		return nil, false
+	}
+	named, ok := nativeSourceTypeFromExprOrInfo(e.Receiver, receiverInfo).(*ostyir.NamedType)
 	if !ok || named == nil || len(named.Args) != 0 {
+		return nil, false
+	}
+	if named.Package != "" && named.Package != ctx.packageName {
 		return nil, false
 	}
 	iface, ok := ctx.interfacesByName[named.Name]
@@ -1028,6 +1039,7 @@ func nativeRegisterRuntimeFFIUse(ctx *nativeProjectionCtx, use *ostyir.UseDecl) 
 			path:     use.RuntimePath,
 			symbol:   llvmRuntimeFfiSymbol(use.RuntimePath, fn.Name),
 			retType:  retType,
+			retIR:    fn.Return,
 			paramTys: make([]string, 0, len(fn.Params)),
 		}
 		for _, param := range fn.Params {
@@ -1745,6 +1757,22 @@ func nativeBindScopedName(ctx *nativeProjectionCtx, name string, irType ostyir.T
 	ctx.bindScopeName(name, nativeExprInfoFromLLVMType(llvmType))
 }
 
+func nativeBindStructScopedName(ctx *nativeProjectionCtx, name string, irType ostyir.Type, info *nativeStructInfo) {
+	if ctx == nil || name == "" || info == nil || info.def == nil {
+		return
+	}
+	if typed, ok := nativeExprInfoFromType(ctx, irType); ok && typed.kind == nativeExprInfoStruct {
+		ctx.bindScopeName(name, typed)
+		return
+	}
+	ctx.bindScopeName(name, nativeExprInfo{
+		kind:       nativeExprInfoStruct,
+		llvmType:   info.def.llvmType,
+		sourceType: &ostyir.NamedType{Name: info.def.name},
+		structName: info.def.name,
+	})
+}
+
 func nativeUnwrapStructPattern(p ostyir.Pattern, aliases *[]string) (*ostyir.StructPat, bool) {
 	switch pat := p.(type) {
 	case *ostyir.StructPat:
@@ -1824,7 +1852,7 @@ func nativeStructPatternBindings(
 				name:       tempName,
 				childExprs: []*llvmNativeExpr{fieldExpr},
 			})
-			nativeBindScopedName(ctx, tempName, structField.irType, structField.llvmType)
+			nativeBindStructScopedName(ctx, tempName, structField.irType, nestedInfo)
 			tempIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: structField.llvmType, name: tempName}
 			for _, alias := range nestedAliases {
 				out = append(out, &llvmNativeStmt{
@@ -1832,7 +1860,7 @@ func nativeStructPatternBindings(
 					name:       alias,
 					childExprs: []*llvmNativeExpr{tempIdent},
 				})
-				nativeBindScopedName(ctx, alias, structField.irType, structField.llvmType)
+				nativeBindStructScopedName(ctx, alias, structField.irType, nestedInfo)
 			}
 			nested, ok := nativeStructPatternBindings(ctx, nestedPat, tempName, nestedInfo, structField.irType)
 			if !ok {
@@ -1883,7 +1911,7 @@ func nativeLetStructDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt
 			name:       baseName,
 			childExprs: []*llvmNativeExpr{value},
 		})
-		nativeBindScopedName(ctx, baseName, s.Value.Type(), info.def.llvmType)
+		nativeBindStructScopedName(ctx, baseName, s.Value.Type(), info)
 	}
 	baseIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: info.def.llvmType, name: baseName}
 	for _, alias := range rootAliases {
@@ -1892,7 +1920,7 @@ func nativeLetStructDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt
 			name:       alias,
 			childExprs: []*llvmNativeExpr{baseIdent},
 		})
-		nativeBindScopedName(ctx, alias, s.Value.Type(), info.def.llvmType)
+		nativeBindStructScopedName(ctx, alias, s.Value.Type(), info)
 	}
 	fields, ok := nativeStructPatternBindings(ctx, pat, baseName, info, s.Value.Type())
 	if !ok {
@@ -2674,7 +2702,11 @@ func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType s
 		// method-call dispatch on this ident sees the interface
 		// shape rather than the concrete struct's binding.
 		if value.llvmType == "%osty.iface" {
-			ctx.bindScopeName(s.Name, nativeExprInfoFromLLVMType("%osty.iface"))
+			info := nativeExprInfoFromLLVMType("%osty.iface")
+			if nativeTypeResolved(s.Type) {
+				info.sourceType = s.Type
+			}
+			ctx.bindScopeName(s.Name, info)
 		}
 		return &llvmNativeStmt{
 			kind:       kind,
@@ -3027,6 +3059,9 @@ func nativeWritableBaseIdent(ctx *nativeProjectionCtx, ident *ostyir.Ident) bool
 		return true
 	case ostyir.IdentGlobal:
 		return ctx.mutableGlobals[ident.Name]
+	case ostyir.IdentUnknown:
+		_, ok := ctx.lookupScopeName(ident.Name)
+		return ok
 	default:
 		return false
 	}
@@ -3773,6 +3808,9 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 			childExprs: children,
 		}, true
 	case *ostyir.MethodCall:
+		if runtimeCall, ok := nativeRuntimeFFIMethodCallExprFromIR(ctx, e); ok {
+			return runtimeCall, true
+		}
 		if builtin, ok := nativeBuiltinMethodExprFromIR(ctx, e); ok {
 			return builtin, true
 		}
@@ -3790,7 +3828,7 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 		// and check whether it lowers to `%osty.iface`. If so, emit
 		// an indirect vtable call instead of the concrete direct
 		// call below.
-		if recvLLVM, ok := nativeLLVMTypeFromIR(ctx, e.Receiver.Type()); ok && recvLLVM == "%osty.iface" {
+		if receiverInfo, ok := nativeExprTypeInfo(ctx, e.Receiver); ok && receiverInfo.llvmType == "%osty.iface" {
 			receiverValue, ok := nativeExprFromIR(ctx, e.Receiver)
 			if !ok {
 				return nil, false
@@ -3972,9 +4010,41 @@ func nativeSetExprInfo(elemType string, elemString bool) nativeExprInfo {
 }
 
 func nativeTypeResolved(t ostyir.Type) bool {
-	switch t.(type) {
+	switch tt := t.(type) {
 	case nil, *ostyir.ErrType, *ostyir.TypeVar:
 		return false
+	case *ostyir.NamedType:
+		if tt == nil || tt.Name == "" {
+			return false
+		}
+		for _, arg := range tt.Args {
+			if !nativeTypeResolved(arg) {
+				return false
+			}
+		}
+		return true
+	case *ostyir.OptionalType:
+		return tt != nil && nativeTypeResolved(tt.Inner)
+	case *ostyir.TupleType:
+		if tt == nil {
+			return false
+		}
+		for _, elem := range tt.Elems {
+			if !nativeTypeResolved(elem) {
+				return false
+			}
+		}
+		return true
+	case *ostyir.FnType:
+		if tt == nil {
+			return false
+		}
+		for _, param := range tt.Params {
+			if !nativeTypeResolved(param) {
+				return false
+			}
+		}
+		return tt.Return == nil || nativeTypeResolved(tt.Return)
 	default:
 		return true
 	}
@@ -4129,6 +4199,11 @@ func nativeExprInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (nativeExpr
 		}
 		if info := ctx.resultsByName[tt.Name]; info != nil {
 			return nativeExprInfoWithSource(nativeExprInfoFromLLVMType(info.def.llvmType), t), true
+		}
+		if tt.Package == "" || tt.Package == ctx.packageName {
+			if _, ok := ctx.interfacesByName[tt.Name]; ok {
+				return nativeExprInfoWithSource(nativeExprInfoFromLLVMType("%osty.iface"), t), true
+			}
 		}
 		info, ok := nativeStructInfoFromType(ctx, tt)
 		if !ok {
@@ -4291,7 +4366,15 @@ func nativeExprTypeInfo(ctx *nativeProjectionCtx, expr ostyir.Expr) (nativeExprI
 			return nativeExprInfo{}, false
 		}
 		return nativeExprInfoFromLLVMType(leftInfo.optionInnerType), true
+	case *ostyir.CallExpr:
+		if info, ok := nativeRuntimeFFICallReturnInfo(ctx, e); ok {
+			return info, true
+		}
+		return nativeExprInfo{}, false
 	case *ostyir.MethodCall:
+		if info, ok := nativeRuntimeFFIMethodCallReturnInfo(ctx, e); ok {
+			return info, true
+		}
 		return nativeBuiltinMethodReturnInfo(ctx, e)
 	default:
 		return nativeExprInfo{}, false
@@ -4415,7 +4498,10 @@ func nativeStructInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeS
 		return nil, false
 	}
 	named, ok := t.(*ostyir.NamedType)
-	if !ok || named == nil || named.Builtin || named.Package != "" || len(named.Args) != 0 {
+	if !ok || named == nil || named.Builtin || len(named.Args) != 0 {
+		return nil, false
+	}
+	if named.Package != "" && named.Package != ctx.packageName {
 		return nil, false
 	}
 	info := ctx.structsByName[named.Name]
@@ -4431,7 +4517,10 @@ func nativeEnumInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeEnu
 		return nil, false
 	}
 	named, ok := t.(*ostyir.NamedType)
-	if !ok || named == nil || named.Builtin || named.Package != "" || len(named.Args) != 0 {
+	if !ok || named == nil || named.Builtin || len(named.Args) != 0 {
+		return nil, false
+	}
+	if named.Package != "" && named.Package != ctx.packageName {
 		return nil, false
 	}
 	info := ctx.enumsByName[named.Name]
@@ -5408,6 +5497,84 @@ func nativeRuntimeFFICallExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallE
 		name:       sig.symbol,
 		childExprs: args,
 	}, true
+}
+
+func nativeRuntimeFFICallReturnInfo(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (nativeExprInfo, bool) {
+	alias, name, ok := nativeQualifiedAliasCall(call)
+	if !ok || ctx == nil {
+		return nativeExprInfo{}, false
+	}
+	sig := nativeRuntimeFFISig(ctx, alias, name)
+	if sig == nil {
+		return nativeExprInfo{}, false
+	}
+	return nativeRuntimeFFIReturnInfo(ctx, sig)
+}
+
+func nativeRuntimeFFIMethodCallExprFromIR(ctx *nativeProjectionCtx, call *ostyir.MethodCall) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil {
+		return nil, false
+	}
+	receiver, ok := call.Receiver.(*ostyir.Ident)
+	if !ok || receiver == nil {
+		return nil, false
+	}
+	sig := nativeRuntimeFFISig(ctx, receiver.Name, call.Name)
+	if sig == nil {
+		return nil, false
+	}
+	args, ok := nativePositionalArgsFromIRWithHints(ctx, call.Args, sig.paramTys)
+	if !ok {
+		return nil, false
+	}
+	if sig.path == "runtime.strings" {
+		ctx.needsStringRT = true
+	}
+	return &llvmNativeExpr{
+		kind:       llvmNativeExprCall,
+		llvmType:   sig.retType,
+		name:       sig.symbol,
+		childExprs: args,
+	}, true
+}
+
+func nativeRuntimeFFIMethodCallReturnInfo(ctx *nativeProjectionCtx, call *ostyir.MethodCall) (nativeExprInfo, bool) {
+	if ctx == nil || call == nil {
+		return nativeExprInfo{}, false
+	}
+	receiver, ok := call.Receiver.(*ostyir.Ident)
+	if !ok || receiver == nil {
+		return nativeExprInfo{}, false
+	}
+	sig := nativeRuntimeFFISig(ctx, receiver.Name, call.Name)
+	if sig == nil {
+		return nativeExprInfo{}, false
+	}
+	return nativeRuntimeFFIReturnInfo(ctx, sig)
+}
+
+func nativeRuntimeFFISig(ctx *nativeProjectionCtx, alias string, name string) *nativeRuntimeFFIFunction {
+	if ctx == nil || alias == "" || name == "" {
+		return nil
+	}
+	funcs := ctx.runtimeFFI[alias]
+	if funcs == nil {
+		return nil
+	}
+	return funcs[name]
+}
+
+func nativeRuntimeFFIReturnInfo(ctx *nativeProjectionCtx, sig *nativeRuntimeFFIFunction) (nativeExprInfo, bool) {
+	if sig == nil {
+		return nativeExprInfo{}, false
+	}
+	if info, ok := nativeExprInfoFromType(ctx, sig.retIR); ok {
+		return info, true
+	}
+	if sig.retType == "" {
+		return nativeExprInfo{}, false
+	}
+	return nativeExprInfoFromLLVMType(sig.retType), true
 }
 
 // nativeVariantLitFromIR lowers `Maybe.Some(42)` / `Maybe.None` into

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -1356,7 +1356,7 @@ fn requireName(profile: Profile?) -> String? {
 	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_question_struct.osty"}
 	nativeMod, ok := nativeModuleFromIR(mod, opts)
 	if !ok {
-		t.Fatal("nativeModuleFromIR returned unsupported for optional struct question batch")
+		t.Fatalf("nativeModuleFromIR returned unsupported for optional struct question batch\n--- ir ---\n%s", ostyir.Print(mod))
 	}
 	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{
@@ -1390,7 +1390,7 @@ fn maybeName(profile: Profile?) -> String? {
 	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_field.osty"}
 	nativeMod, ok := nativeModuleFromIR(mod, opts)
 	if !ok {
-		t.Fatal("nativeModuleFromIR returned unsupported for optional field batch")
+		t.Fatalf("nativeModuleFromIR returned unsupported for optional field batch\n--- ir ---\n%s", ostyir.Print(mod))
 	}
 	direct := renderNativeOwnedModuleText(nativeMod)
 	for _, want := range []string{

--- a/internal/llvmgen/ir_native_interface_test.go
+++ b/internal/llvmgen/ir_native_interface_test.go
@@ -3,6 +3,8 @@ package llvmgen
 import (
 	"strings"
 	"testing"
+
+	ostyir "github.com/osty/osty/internal/ir"
 )
 
 // TestTryGenerateNativeOwnedModuleCoversInterfaceVtableSurface locks
@@ -134,7 +136,7 @@ fn main() {
 		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
 	}
 	if !ok {
-		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for Sized/Vec boxing + dispatch")
+		t.Fatalf("TryGenerateNativeOwnedModule reported uncovered for Sized/Vec boxing + dispatch\n--- ir ---\n%s", ostyir.Print(mod))
 	}
 	got := string(out)
 	for _, want := range []string{
@@ -213,7 +215,7 @@ fn main() {
 		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
 	}
 	if !ok {
-		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for Combine/Thing dispatch-with-args")
+		t.Fatalf("TryGenerateNativeOwnedModule reported uncovered for Combine/Thing dispatch-with-args\n--- ir ---\n%s", ostyir.Print(mod))
 	}
 	got := string(out)
 	if !strings.Contains(got, ", i64 4)") {

--- a/internal/llvmgen/ir_native_struct_destructure_test.go
+++ b/internal/llvmgen/ir_native_struct_destructure_test.go
@@ -3,6 +3,8 @@ package llvmgen
 import (
 	"strings"
 	"testing"
+
+	ostyir "github.com/osty/osty/internal/ir"
 )
 
 // TestTryGenerateNativeOwnedModuleCoversLetStructDestructureShorthand
@@ -141,7 +143,7 @@ fn main() {
 		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
 	}
 	if !ok {
-		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for nested struct destructure + binding")
+		t.Fatalf("TryGenerateNativeOwnedModule reported uncovered for nested struct destructure + binding\n%s", ostyir.Print(mod))
 	}
 	got := string(out)
 	for _, want := range []string{

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -3620,6 +3620,12 @@ func llvmRuntimeAbiBuiltinType(name string) string {
 
 // Osty: toolchain/llvmgen.osty:2970:5
 func llvmEnumPayloadBuiltinType(name string) string {
+	if name == "String" {
+		return "ptr"
+	}
+	if name == "Bytes" || name == "Error" {
+		return ""
+	}
 	// Osty: toolchain/llvmgen.osty:2971:5
 	if llvmBuiltinType(name) != "" {
 		// Osty: toolchain/llvmgen.osty:2972:9

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2086,8 +2086,8 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 	// the return type off the module's own fn signature table (preferred)
 	// or the callee's FnType (fallback) so every downstream temp has a
 	// concrete width.
-	if isPoisonType(t) {
-		if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) {
+	if isPoisonType(t) || irHasPoisonedTypeArg(t) {
+		if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) && !irHasPoisonedTypeArg(rt) {
 			t = rt
 		}
 	}
@@ -2097,6 +2097,13 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 }
 
 func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
+	if _, ok := e.(*ir.Closure); ok {
+		if _, ok := hint.(*ir.FnType); ok {
+			tmp := bs.freshTemp(hint, exprSpan(e))
+			bs.lowerExprInto(e, tmp, hint)
+			return &CopyOp{Place: Place{Local: tmp}, T: hint}
+		}
+	}
 	if !shouldPreferHintType(e.Type(), hint) {
 		return bs.lowerExprAsOperand(e)
 	}
@@ -2110,6 +2117,23 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 			})
 			return &CopyOp{Place: Place{Local: tmp}, T: hint}
 		}
+		if id.Kind != ir.IdentLocal && id.Kind != ir.IdentParam {
+			if idx, ok := bs.l.variantIndexInType(hint, id.Name); ok {
+				tmp := bs.freshTemp(hint, id.SpanV)
+				bs.emit(&AssignInstr{
+					Dest: Place{Local: tmp},
+					Src: &AggregateRV{
+						Kind:       AggEnumVariant,
+						Fields:     nil,
+						T:          hint,
+						VariantIdx: idx,
+						VariantTag: id.Name,
+					},
+					SpanV: id.SpanV,
+				})
+				return &CopyOp{Place: Place{Local: tmp}, T: hint}
+			}
+		}
 	}
 	return bs.lowerExprAsOperand(e)
 }
@@ -2122,10 +2146,10 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 // `f(x).field` where the checker dropped the call's return type.
 func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 	t := e.Type()
-	if !isPoisonType(t) {
+	if !isPoisonType(t) && !irHasPoisonedTypeArg(t) {
 		return t
 	}
-	if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) {
+	if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) && !irHasPoisonedTypeArg(rt) {
 		return rt
 	}
 	return t
@@ -2447,6 +2471,30 @@ func stdlibFreeFnReturnType(qualifier, name string) ir.Type {
 		return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TChar}, Builtin: true}
 	case "bytes":
 		return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TByte}, Builtin: true}
+	}
+	return nil
+}
+
+func stdlibFreeFnParamTypes(qualifier, name string) []ir.Type {
+	if qualifier != "std.testing" {
+		return nil
+	}
+	switch name {
+	case "benchmark":
+		return []ir.Type{
+			TInt,
+			&ir.FnType{
+				Params: nil,
+				Return: &ir.NamedType{
+					Name: "Result",
+					Args: []ir.Type{
+						TUnit,
+						&ir.NamedType{Name: "Error", Builtin: true},
+					},
+					Builtin: true,
+				},
+			},
+		}
 	}
 	return nil
 }
@@ -3122,8 +3170,8 @@ func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Typ
 func (bs *bodyState) lowerQuestionInto(q *ir.QuestionExpr, dest Place, destT Type) {
 	bs.pushScope()
 	xT := q.X.Type()
-	if isPoisonType(xT) {
-		if rt := bs.recoverOperandType(q.X); rt != nil && !isPoisonType(rt) {
+	if isPoisonType(xT) || irHasPoisonedTypeArg(xT) {
+		if rt := bs.recoverOperandType(q.X); rt != nil && !isPoisonType(rt) && !irHasPoisonedTypeArg(rt) {
 			xT = rt
 		}
 	}
@@ -3374,6 +3422,9 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			}
 		}
 	}
+	if bs.lowerBuiltinVariantCallInto(c, dest, destT) {
+		return
+	}
 	args, callee := bs.resolveCall(c)
 	if callee == nil {
 		bs.l.noteIssue("unsupported call: callee %T", c.Callee)
@@ -3383,6 +3434,59 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 		dest = nil
 	}
 	bs.emit(&CallInstr{Dest: dest, Callee: callee, Args: args, SpanV: c.SpanV})
+}
+
+func (bs *bodyState) lowerBuiltinVariantCallInto(c *ir.CallExpr, dest *Place, destT Type) bool {
+	if c == nil || dest == nil {
+		return false
+	}
+	id, ok := c.Callee.(*ir.Ident)
+	if !ok {
+		return false
+	}
+	idx, payloadHint, ok := builtinVariantCallShape(destT, id.Name, len(c.Args))
+	if !ok {
+		return false
+	}
+	fields := make([]Operand, 0, len(c.Args))
+	for _, arg := range c.Args {
+		fields = append(fields, bs.lowerExprAsOperandHint(arg.Value, payloadHint))
+	}
+	bs.emit(&AssignInstr{
+		Dest: *dest,
+		Src: &AggregateRV{
+			Kind:       AggEnumVariant,
+			Fields:     fields,
+			T:          destT,
+			VariantIdx: idx,
+			VariantTag: id.Name,
+		},
+		SpanV: c.SpanV,
+	})
+	return true
+}
+
+func builtinVariantCallShape(t Type, name string, argc int) (int, Type, bool) {
+	if argc != 1 {
+		return 0, nil, false
+	}
+	switch name {
+	case "Some":
+		if ot, ok := t.(*ir.OptionalType); ok {
+			return 1, ot.Inner, true
+		}
+		if nt, ok := t.(*ir.NamedType); ok && (nt.Name == "Option" || nt.Name == "Maybe") && len(nt.Args) >= 1 {
+			return 1, nt.Args[0], true
+		}
+	case "Ok", "Err":
+		if nt, ok := t.(*ir.NamedType); ok && nt.Name == "Result" && len(nt.Args) >= 2 {
+			if name == "Ok" {
+				return 1, nt.Args[0], true
+			}
+			return 0, nt.Args[1], true
+		}
+	}
+	return 0, nil, false
 }
 
 // emitConcurrencyIntrinsic lowers args in source order and emits a
@@ -3510,10 +3614,7 @@ func (bs *bodyState) resolveCall(c *ir.CallExpr) ([]Operand, Callee) {
 // encodes the qualifier, and the argument list does NOT include a
 // synthetic receiver.
 func (bs *bodyState) resolveQualifiedCall(use *ir.UseDecl, name string, t Type, args []ir.Arg) ([]Operand, Callee) {
-	out := make([]Operand, len(args))
-	for i, a := range args {
-		out[i] = bs.lowerExprAsOperand(a.Value)
-	}
+	out := bs.orderArgsByTypes(args, stdlibFreeFnParamTypes(pathQualifier(use), name))
 	return out, &FnRef{Symbol: qualifiedSymbol(use, name), Type: t}
 }
 
@@ -3668,10 +3769,7 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 			bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
 			return
 		}
-		args := make([]Operand, len(mc.Args))
-		for i, a := range mc.Args {
-			args[i] = bs.lowerExprAsOperand(a.Value)
-		}
+		args := bs.orderArgsByTypes(mc.Args, stdlibFreeFnParamTypes(pathQualifier(use), mc.Name))
 		destPtr := &dest
 		if isUnit(destT) {
 			destPtr = nil
@@ -4573,6 +4671,7 @@ func (bs *bodyState) lowerClosure(cl *ir.Closure, hint Type) RValue {
 	if retT == nil {
 		retT = TUnit
 	}
+	captures := bs.closureCaptures(cl)
 
 	// Build the lifted function. First param is the env ptr; user
 	// params follow. Captures are NOT params — the entry block loads
@@ -4607,9 +4706,9 @@ func (bs *bodyState) lowerClosure(cl *ir.Closure, hint Type) RValue {
 
 	// Env struct layout: `(ptr fn, cap0_type, cap1_type, ...)`. Slot 0
 	// holds the fn pointer at runtime; slots 1..N hold captures.
-	envStructElems := make([]ir.Type, 0, 1+len(cl.Captures))
+	envStructElems := make([]ir.Type, 0, 1+len(captures))
 	envStructElems = append(envStructElems, closureEnvType) // ptr for fn slot
-	for _, cap := range cl.Captures {
+	for _, cap := range captures {
 		ct := cap.T
 		if ct == nil {
 			ct = ir.ErrTypeVal
@@ -4622,7 +4721,7 @@ func (bs *bodyState) lowerClosure(cl *ir.Closure, hint Type) RValue {
 	// capture gets a dedicated local bound to its HIR-level name so
 	// the rest of the body lowers unchanged — reads of the capture
 	// resolve through the regular locals lookup.
-	for i, cap := range cl.Captures {
+	for i, cap := range captures {
 		ct := cap.T
 		if ct == nil {
 			ct = ir.ErrTypeVal
@@ -4672,9 +4771,9 @@ func (bs *bodyState) lowerClosure(cl *ir.Closure, hint Type) RValue {
 	for _, p := range cl.Params {
 		fnType.Params = append(fnType.Params, p.Type)
 	}
-	fields := make([]Operand, 0, 1+len(cl.Captures))
+	fields := make([]Operand, 0, 1+len(captures))
 	fields = append(fields, &ConstOp{Const: &FnConst{Symbol: symbol, T: fnType}, T: fnType})
-	for _, cap := range cl.Captures {
+	for _, cap := range captures {
 		fields = append(fields, bs.captureOperand(cap))
 	}
 	return &AggregateRV{
@@ -4682,6 +4781,63 @@ func (bs *bodyState) lowerClosure(cl *ir.Closure, hint Type) RValue {
 		Fields: fields,
 		T:      closureT,
 	}
+}
+
+func (bs *bodyState) closureCaptures(cl *ir.Closure) []*ir.Capture {
+	if cl == nil {
+		return nil
+	}
+	out := append([]*ir.Capture(nil), cl.Captures...)
+	seen := map[string]bool{}
+	for _, cap := range out {
+		if cap != nil && cap.Name != "" {
+			seen[cap.Name] = true
+		}
+	}
+	bound := map[string]bool{}
+	for _, p := range cl.Params {
+		if p != nil && p.Name != "" {
+			bound[p.Name] = true
+		}
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		if nested, ok := n.(*ir.Closure); ok && nested != cl {
+			return false
+		}
+		id, ok := n.(*ir.Ident)
+		if !ok || id.Name == "" || seen[id.Name] || bound[id.Name] {
+			return true
+		}
+		localID, ok := bs.lookup(id.Name)
+		if !ok {
+			return true
+		}
+		loc := bs.fn.Local(localID)
+		if loc == nil || loc.IsReturn {
+			return true
+		}
+		kind := ir.CaptureLocal
+		if loc.IsParam {
+			kind = ir.CaptureParam
+		}
+		t := loc.Type
+		if t == nil {
+			t = id.T
+		}
+		if t == nil {
+			t = ir.ErrTypeVal
+		}
+		seen[id.Name] = true
+		out = append(out, &ir.Capture{
+			Name:  id.Name,
+			Kind:  kind,
+			T:     t,
+			Mut:   loc.Mut,
+			SpanV: id.SpanV,
+		})
+		return true
+	}), cl.Body)
+	return out
 }
 
 // captureOperand produces an Operand that reads a single capture from
@@ -4893,6 +5049,23 @@ func (l *lowerer) enumForVariant(name string) string {
 		}
 	}
 	return ""
+}
+
+func (l *lowerer) variantIndexInType(t ir.Type, name string) (int, bool) {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt.Name == "" {
+		return 0, false
+	}
+	e := l.enums[nt.Name]
+	if e == nil {
+		return 0, false
+	}
+	for i, v := range e.Variants {
+		if v.Name == name {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 func (l *lowerer) variantIndexByName(t ir.Type, name string) int {

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -98,17 +98,29 @@ func ResolvePackage(pkg *Package, prelude *Scope) *PackageResult {
 		return &PackageResult{}
 	}
 	if !canResolveViaNative(pkg) {
-		r := newPkgResolver(pkg, prelude)
-		r.declarePass(pkg)
-		r.bodyPass(pkg)
-		return &PackageResult{
-			PackageScope: pkg.PkgScope,
-			Diags:        r.diags,
-		}
+		return ResolvePackageFromAST(pkg, prelude)
 	}
 	pkg.EnsureFiles()
 	pkg.MaterializeCanonicalSources()
 	return resolvePackageViaNative(pkg, prelude)
+}
+
+// ResolvePackageFromAST runs the Go AST-backed resolver even when pkg also
+// carries source bytes. This is reserved for bootstrap inputs that have already
+// been parsed by the host parser but are not yet accepted by the self-host
+// resolver/parser bridge.
+func ResolvePackageFromAST(pkg *Package, prelude *Scope) *PackageResult {
+	if pkg == nil {
+		return &PackageResult{}
+	}
+	pkg.EnsureFiles()
+	r := newPkgResolver(pkg, prelude)
+	r.declarePass(pkg)
+	r.bodyPass(pkg)
+	return &PackageResult{
+		PackageScope: pkg.PkgScope,
+		Diags:        r.diags,
+	}
 }
 
 func canResolveViaNative(pkg *Package) bool {

--- a/internal/stdlib/modules/url.osty
+++ b/internal/stdlib/modules/url.osty
@@ -98,7 +98,7 @@ fn parseReference(text: String, requireScheme: Bool) -> Result<UrlParts, Error> 
     } else {
         sliceChars(chars, 0, hash)
     }
-    let fragment = if hash < 0 {
+    let fragment: String? = if hash < 0 {
         None
     } else {
         Some(sliceChars(chars, hash + 1, chars.len()))

--- a/internal/stdlib/rebind_test.go
+++ b/internal/stdlib/rebind_test.go
@@ -1,6 +1,7 @@
 package stdlib
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/resolve"
@@ -21,6 +22,9 @@ func TestPreludeBuiltinRebindings(t *testing.T) {
 		if mod == nil || mod.Package == nil {
 			t.Fatalf("std.%s not loaded", tc.module)
 		}
+		if mod.Package.PkgScope == nil {
+			t.Fatalf("std.%s loaded without package scope; registry diagnostics:\n%s", tc.module, stdlibRebindDiagSummary(reg))
+		}
 		for _, name := range tc.names {
 			sym := mod.Package.PkgScope.LookupLocal(name)
 			if sym == nil {
@@ -40,6 +44,12 @@ func TestPreludeBuiltinRebindings(t *testing.T) {
 		{"result", []string{"Ok", "Err"}},
 	} {
 		mod := reg.Modules[tc.module]
+		if mod == nil || mod.Package == nil {
+			t.Fatalf("std.%s not loaded", tc.module)
+		}
+		if mod.Package.PkgScope == nil {
+			t.Fatalf("std.%s loaded without package scope; registry diagnostics:\n%s", tc.module, stdlibRebindDiagSummary(reg))
+		}
 		for _, name := range tc.names {
 			sym := mod.Package.PkgScope.LookupLocal(name)
 			if sym == nil {
@@ -50,4 +60,28 @@ func TestPreludeBuiltinRebindings(t *testing.T) {
 			}
 		}
 	}
+}
+
+func stdlibRebindDiagSummary(reg *Registry) string {
+	if reg == nil || len(reg.Diags) == 0 {
+		return "<none>"
+	}
+	var b strings.Builder
+	for _, d := range reg.Diags {
+		if d == nil {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		if d.File != "" {
+			b.WriteString(d.File)
+			b.WriteString(": ")
+		}
+		b.WriteString(d.Message)
+	}
+	if b.Len() == 0 {
+		return "<none>"
+	}
+	return b.String()
 }

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -151,7 +151,10 @@ func loadRegistry() *Registry {
 				File:   file,
 			}},
 		}
-		result := resolve.ResolvePackage(pkg, prelude)
+		// Keep stdlib stub resolution on the AST-backed resolver for now:
+		// several generated stubs are accepted by the Go parser but still trip
+		// the self-host parser used by the native resolve bridge.
+		result := resolve.ResolvePackageFromAST(pkg, prelude)
 		r.Diags = append(r.Diags, result.Diags...)
 
 		// Primitive stubs fan their methods out into the primitive-kind

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -3998,6 +3998,12 @@ pub fn llvmRuntimeAbiBuiltinType(name: String) -> String {
 }
 
 pub fn llvmEnumPayloadBuiltinType(name: String) -> String {
+    if name == "String" {
+        return "ptr"
+    }
+    if name == "Bytes" || name == "Error" {
+        return ""
+    }
     if llvmBuiltinType(name) != "" {
         return llvmBuiltinType(name)
     }


### PR DESCRIPTION
## Summary

- Extend the native-owned LLVM path for struct bindings, runtime FFI method calls, interface dispatch, and enum payload typing.
- Harden MIR lowering for benchmark closures, Result/Option variant construction, poisoned Result type recovery, and supplemental closure capture discovery.
- Fix stdlib/native checker edges for registry AST resolving, URL fragment typing, runtime zlib-linked harness tests, and temporarily skip eager Map.find injection until optional tuple returns are supported.

## Validation

- `just build-checker`
- `just short`
- `go test -count=1 -vet=off -short ./cmd/osty`
- `go test -count=1 -vet=off ./internal/mir`
- `go test -count=1 -vet=off -short ./internal/llvmgen`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultCsv|TestStdlibCheckResultUrl|TestPhase2gUpdateUserCallsiteKeepsLockedLowering|TestBundledRuntimeStatsFragmentation|TestBundledRuntimeChannelRemapsCompactionPhaseD' -v`
- `git diff --check`