### PR TITLE
[codex] Add terminal TUI grid standard libraries

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -20,3 +20,7 @@
 - `std.math` — mathematical functions and constants
 - `std.csv` — CSV read/write
 - `std.compress` — gzip compression
+- `std.term` — terminal mode, ANSI control, size, and key input
+- `std.tui` — retained terminal frame buffers and diff rendering
+- `std.grid` — `Point`, `Size`, `Rect`, `Direction`, and `Grid<T>` for
+  board, map, and turn-based layouts

--- a/LANG_SPEC_v0.5/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.5/10-standard-library/25-term.md
@@ -1,0 +1,42 @@
+### 10.25 Terminal (`std.term`)
+
+`std.term` is the low-level terminal boundary used by text UIs and simple
+terminal games.
+
+Host-backed primitives:
+
+```osty
+term.open() -> Result<Terminal, Error>
+term.isTerminal() -> Bool
+term.size() -> Result<Size, Error>
+term.setRawMode(enabled: Bool) -> Result<(), Error>
+term.readKey() -> Result<Key, Error>
+term.pollKey(timeoutMillis: Int) -> Result<Key?, Error>
+term.readEvent() -> Result<Event, Error>
+term.write(text: String) -> Result<(), Error>
+term.flush() -> Result<(), Error>
+```
+
+Pure ANSI helpers:
+
+```osty
+term.clearScreenSeq() -> String
+term.clearLineSeq() -> String
+term.moveToSeq(Position { x, y }) -> String
+term.hideCursorSeq() -> String
+term.showCursorSeq() -> String
+term.enterAltScreenSeq() -> String
+term.exitAltScreenSeq() -> String
+term.styleSeq(style: Style) -> String
+term.styled(text: String, style: Style) -> String
+```
+
+Coordinates are zero-based in the Osty API. `moveToSeq` converts to the
+one-based row/column convention used by ANSI terminals.
+
+`Terminal.restore()` is the canonical cleanup point for programs that enter
+raw mode, hide the cursor, or switch to the alternate screen.
+
+Current LLVM backend coverage includes `isTerminal`, `size`, `write`, `flush`,
+and `setRawMode`. Key and resize event decoding is part of the next host-backed
+terminal increment.

--- a/LANG_SPEC_v0.5/10-standard-library/26-tui.md
+++ b/LANG_SPEC_v0.5/10-standard-library/26-tui.md
@@ -1,0 +1,30 @@
+### 10.26 Text UI (`std.tui`)
+
+`std.tui` provides retained frame buffers for terminal UI code. A `Frame`
+contains fixed-size `Cell` values, each with text and style. Rendering can
+emit a whole frame or only the cells that changed compared with a previous
+frame.
+
+Core API:
+
+```osty
+tui.frame(size: grid.Size) -> Frame
+tui.sized(width: Int, height: Int) -> Frame
+tui.screen(size: grid.Size) -> Screen
+
+Frame.put(point: grid.Point, text: String, style: Style) -> Bool
+Frame.drawText(point: grid.Point, text: String, style: Style) -> Int
+Frame.drawHLine(y: Int, x1: Int, x2: Int, text: String, style: Style) -> Int
+Frame.drawVLine(x: Int, y1: Int, y2: Int, text: String, style: Style) -> Int
+Frame.drawRect(rect: grid.Rect, glyph: String, style: Style)
+Frame.renderAnsi() -> String
+Frame.diffAnsi(previous: Frame?) -> String
+
+Screen.next(frame: Frame) -> String
+Screen.present(frame: Frame) -> Result<(), Error>
+Screen.reset()
+```
+
+`std.tui` intentionally renders to strings first. That keeps frame diffing
+testable and lets callers choose whether to write through `std.term`,
+capture output, or compare snapshots.

--- a/LANG_SPEC_v0.5/10-standard-library/27-grid.md
+++ b/LANG_SPEC_v0.5/10-standard-library/27-grid.md
@@ -1,0 +1,31 @@
+### 10.27 Grid (`std.grid`)
+
+`std.grid` contains small spatial types shared by text UIs, board games,
+roguelikes, simulations, and pathfinding libraries.
+
+Core types:
+
+```osty
+pub struct Point { pub x: Int, pub y: Int }
+pub struct Size { pub width: Int, pub height: Int }
+pub struct Rect { pub origin: Point, pub size: Size }
+pub enum Direction { Up, Down, Left, Right, UpLeft, UpRight, DownLeft, DownRight, Wait }
+pub struct Grid<T>
+```
+
+Constructors:
+
+```osty
+grid.point(x, y) -> Point
+grid.size(width, height) -> Size
+grid.rect(x, y, width, height) -> Rect
+grid.grid<T>(width, height, fill) -> Grid<T>
+grid.fromRows<T>(rows) -> Grid<T>?
+```
+
+`Grid<T>` is row-major. `Grid.index(point)` returns `None` outside bounds,
+and all neighbor helpers filter out points outside the grid.
+
+`std.grid` is deliberately not a pathfinding or roguelike engine. Higher
+level packages can build A*, field of view, dungeon generation, and turn
+scheduling on top of this stable geometry layer.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -37,3 +37,6 @@ lowering remains implementation backlog.
 - [§10.22 Formatting (`std.fmt`)](./22-fmt.md)
 - [§10.23 Network (`std.net`)](./23-net.md)
 - [§10.24 HTTP (`std.http`)](./24-http.md)
+- [§10.25 Terminal (`std.term`)](./25-term.md)
+- [§10.26 Text UI (`std.tui`)](./26-tui.md)
+- [§10.27 Grid (`std.grid`)](./27-grid.md)

--- a/internal/backend/llvm_term_test.go
+++ b/internal/backend/llvm_term_test.go
@@ -1,0 +1,53 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMBackendBinaryRunsStdTermBasicSurface(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.term
+
+fn main() {
+    println(term.isTerminal() == term.isTerminal())
+    match term.size() {
+        Ok(size) -> {
+            println(size.width > 0)
+            println(size.height > 0)
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+        },
+    }
+    match term.write("hello") {
+        Ok(_) -> {},
+        Err(err) -> println(err.message()),
+    }
+    match term.flush() {
+        Ok(_) -> println("-flushed"),
+        Err(err) -> println(err.message()),
+    }
+    match term.setRawMode(false) {
+        Ok(_) -> println("raw-off"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "true\ntrue\ntrue\nhello-flushed\nraw-off\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -115,6 +115,7 @@
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <windows.h>
+#  include <io.h>
 #  include <process.h>
 #  include <signal.h>         /* sig_atomic_t for SIGURG TLS flag */
 #  define OSTY_RT_TLS __declspec(thread)
@@ -136,6 +137,8 @@ typedef INIT_ONCE          osty_rt_once_t;
 #  include <netinet/in.h>
 #  include <netinet/tcp.h>
 #  include <sys/socket.h>
+#  include <sys/ioctl.h>
+#  include <termios.h>
 #  include <sys/time.h>
 #  if defined(__APPLE__)
 #    include <crt_externs.h>
@@ -18937,6 +18940,248 @@ void *osty_rt_io_read_line(void) {
     free(buf);
     return out;
 }
+
+/* std.term low-level terminal surface.
+ *
+ * The LLVM shim builds public Result values around these small C helpers:
+ * - size() always succeeds, using the TTY size when available and
+ *   COLUMNS/LINES or 80x24 as a deterministic fallback.
+ * - write(), flush(), and setRawMode() return NULL on success or a managed
+ *   String containing a human-readable error message on failure. */
+static void *osty_rt_term_error_message(const char *prefix, const char *detail, const char *site) {
+    const char *lhs = prefix == NULL ? "terminal error" : prefix;
+    const char *rhs = (detail != NULL && detail[0] != '\0') ? detail : "unknown error";
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
+    size_t total = lhs_len + 2 + rhs_len;
+    char *buf = (char *)osty_rt_xmalloc(total + 1, site);
+    memcpy(buf, lhs, lhs_len);
+    buf[lhs_len] = ':';
+    buf[lhs_len + 1] = ' ';
+    memcpy(buf + lhs_len + 2, rhs, rhs_len);
+    buf[total] = '\0';
+    void *out = osty_rt_string_dup_site(buf, total, site);
+    free(buf);
+    return out;
+}
+
+static void *osty_rt_term_errno_error(const char *prefix, const char *site) {
+    if (errno == 0) {
+        return osty_rt_term_error_message(prefix, "unknown error", site);
+    }
+    return osty_rt_term_error_message(prefix, strerror(errno), site);
+}
+
+static int64_t osty_rt_term_env_dimension(const char *name, int64_t fallback) {
+    const char *raw = getenv(name);
+    char *end = NULL;
+    long parsed;
+    if (raw == NULL || raw[0] == '\0') {
+        return fallback;
+    }
+    errno = 0;
+    parsed = strtol(raw, &end, 10);
+    if (errno != 0 || end == raw || parsed <= 0) {
+        return fallback;
+    }
+    return (int64_t)parsed;
+}
+
+bool osty_rt_term_is_terminal(void) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    return _isatty(_fileno(stdout)) != 0;
+#else
+    return isatty(STDOUT_FILENO) != 0;
+#endif
+}
+
+static bool osty_rt_term_stdout_size(int64_t *width, int64_t *height) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    CONSOLE_SCREEN_BUFFER_INFO info;
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL) {
+        return false;
+    }
+    if (!GetConsoleScreenBufferInfo(handle, &info)) {
+        return false;
+    }
+    int64_t w = (int64_t)(info.srWindow.Right - info.srWindow.Left + 1);
+    int64_t h = (int64_t)(info.srWindow.Bottom - info.srWindow.Top + 1);
+    if (w <= 0 || h <= 0) {
+        return false;
+    }
+    *width = w;
+    *height = h;
+    return true;
+#else
+    struct winsize ws;
+    if (!isatty(STDOUT_FILENO)) {
+        return false;
+    }
+    memset(&ws, 0, sizeof(ws));
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) != 0) {
+        return false;
+    }
+    if (ws.ws_col <= 0 || ws.ws_row <= 0) {
+        return false;
+    }
+    *width = (int64_t)ws.ws_col;
+    *height = (int64_t)ws.ws_row;
+    return true;
+#endif
+}
+
+int64_t osty_rt_term_width(void) {
+    int64_t width = 0;
+    int64_t height = 0;
+    if (osty_rt_term_stdout_size(&width, &height)) {
+        return width;
+    }
+    return osty_rt_term_env_dimension("COLUMNS", 80);
+}
+
+int64_t osty_rt_term_height(void) {
+    int64_t width = 0;
+    int64_t height = 0;
+    if (osty_rt_term_stdout_size(&width, &height)) {
+        return height;
+    }
+    return osty_rt_term_env_dimension("LINES", 24);
+}
+
+void *osty_rt_term_write(const char *text) {
+    const char *safe = text != NULL ? text : "";
+    char inline_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    osty_rt_string_decode_to_buf_if_inline(&safe, inline_buf);
+    errno = 0;
+    if (fputs(safe, stdout) == EOF) {
+        return osty_rt_term_errno_error("failed to write terminal", "runtime.term.write.error");
+    }
+    if (fflush(stdout) != 0) {
+        return osty_rt_term_errno_error("failed to flush terminal", "runtime.term.write.flush_error");
+    }
+    return NULL;
+}
+
+void *osty_rt_term_flush(void) {
+    errno = 0;
+    if (fflush(stdout) != 0) {
+        return osty_rt_term_errno_error("failed to flush terminal", "runtime.term.flush.error");
+    }
+    return NULL;
+}
+
+#if defined(OSTY_RT_PLATFORM_WIN32)
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
+static DWORD osty_rt_term_saved_input_mode = 0;
+static bool osty_rt_term_saved_input_mode_valid = false;
+static bool osty_rt_term_raw_mode_active = false;
+
+static void osty_rt_term_restore_raw_at_exit(void) {
+    if (!osty_rt_term_raw_mode_active || !osty_rt_term_saved_input_mode_valid) {
+        return;
+    }
+    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+    if (handle != INVALID_HANDLE_VALUE && handle != NULL) {
+        SetConsoleMode(handle, osty_rt_term_saved_input_mode);
+    }
+    osty_rt_term_raw_mode_active = false;
+}
+
+void *osty_rt_term_set_raw_mode(bool enabled) {
+    static bool restore_registered = false;
+    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode;
+    if (!enabled && !osty_rt_term_raw_mode_active) {
+        return NULL;
+    }
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL) {
+        return osty_rt_term_error_message("failed to configure raw terminal mode", "stdin is not a console", "runtime.term.raw.error");
+    }
+    if (!GetConsoleMode(handle, &mode)) {
+        return osty_rt_term_error_message("failed to configure raw terminal mode", "GetConsoleMode failed", "runtime.term.raw.error");
+    }
+    if (!enabled) {
+        if (osty_rt_term_saved_input_mode_valid && !SetConsoleMode(handle, osty_rt_term_saved_input_mode)) {
+            return osty_rt_term_error_message("failed to restore terminal mode", "SetConsoleMode failed", "runtime.term.raw.restore_error");
+        }
+        osty_rt_term_raw_mode_active = false;
+        return NULL;
+    }
+    if (!osty_rt_term_saved_input_mode_valid) {
+        osty_rt_term_saved_input_mode = mode;
+        osty_rt_term_saved_input_mode_valid = true;
+    }
+    if (!restore_registered) {
+        atexit(osty_rt_term_restore_raw_at_exit);
+        restore_registered = true;
+    }
+    mode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+    mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+    if (!SetConsoleMode(handle, mode)) {
+        return osty_rt_term_error_message("failed to configure raw terminal mode", "SetConsoleMode failed", "runtime.term.raw.error");
+    }
+    osty_rt_term_raw_mode_active = true;
+    return NULL;
+}
+#else
+static struct termios osty_rt_term_saved_input_mode;
+static bool osty_rt_term_saved_input_mode_valid = false;
+static bool osty_rt_term_raw_mode_active = false;
+
+static void osty_rt_term_restore_raw_at_exit(void) {
+    if (!osty_rt_term_raw_mode_active || !osty_rt_term_saved_input_mode_valid) {
+        return;
+    }
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &osty_rt_term_saved_input_mode);
+    osty_rt_term_raw_mode_active = false;
+}
+
+void *osty_rt_term_set_raw_mode(bool enabled) {
+    static bool restore_registered = false;
+    struct termios raw;
+    if (!enabled && !osty_rt_term_raw_mode_active) {
+        return NULL;
+    }
+    if (!isatty(STDIN_FILENO)) {
+        return osty_rt_term_error_message("failed to configure raw terminal mode", "stdin is not a terminal", "runtime.term.raw.error");
+    }
+    if (!enabled) {
+        errno = 0;
+        if (osty_rt_term_saved_input_mode_valid &&
+            tcsetattr(STDIN_FILENO, TCSAFLUSH, &osty_rt_term_saved_input_mode) != 0) {
+            return osty_rt_term_errno_error("failed to restore terminal mode", "runtime.term.raw.restore_error");
+        }
+        osty_rt_term_raw_mode_active = false;
+        return NULL;
+    }
+    errno = 0;
+    if (!osty_rt_term_saved_input_mode_valid &&
+        tcgetattr(STDIN_FILENO, &osty_rt_term_saved_input_mode) != 0) {
+        return osty_rt_term_errno_error("failed to read terminal mode", "runtime.term.raw.read_error");
+    }
+    osty_rt_term_saved_input_mode_valid = true;
+    if (!restore_registered) {
+        atexit(osty_rt_term_restore_raw_at_exit);
+        restore_registered = true;
+    }
+    raw = osty_rt_term_saved_input_mode;
+    raw.c_iflag &= (tcflag_t) ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    raw.c_oflag &= (tcflag_t) ~(OPOST);
+    raw.c_cflag |= (tcflag_t)CS8;
+    raw.c_lflag &= (tcflag_t) ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cc[VMIN] = 1;
+    raw.c_cc[VTIME] = 0;
+    errno = 0;
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) != 0) {
+        return osty_rt_term_errno_error("failed to configure raw terminal mode", "runtime.term.raw.error");
+    }
+    osty_rt_term_raw_mode_active = true;
+    return NULL;
+}
+#endif
 
 /* std.net TCP/DNS surface.
  *

--- a/internal/backend/stdlib_term_tui_grid_check_test.go
+++ b/internal/backend/stdlib_term_tui_grid_check_test.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultTermTuiGrid pins that the new terminal/game support
+// modules stay within the selfhost checker's supported source subset.
+func TestStdlibCheckResultTermTuiGrid(t *testing.T) {
+	reg := stdlib.LoadCached()
+	for _, module := range []string{"term", "grid", "tui"} {
+		t.Run(module, func(t *testing.T) {
+			chk := stdlibCheckResult(reg, module)
+			if chk == nil {
+				t.Fatalf("stdlibCheckResult(%s) = nil, want non-nil *check.Result", module)
+			}
+			var errs []string
+			for _, d := range chk.Diags {
+				if d != nil && strings.Contains(d.Error(), "error") {
+					errs = append(errs, d.Error())
+				}
+			}
+			if len(errs) > 0 {
+				t.Fatalf("%s module check produced %d error diagnostic(s):\n%s",
+					module, len(errs), strings.Join(errs, "\n"))
+			}
+		})
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -7351,6 +7351,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdOsCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdTermCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitStdMathCall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -61,6 +61,7 @@ type generator struct {
 	stdNetAliases        map[string]bool
 	stdCryptoAliases     map[string]bool
 	stdOsAliases         map[string]bool
+	stdTermAliases       map[string]bool
 	runtimeDecls         map[string]runtimeDecl
 	runtimeDeclOrder     []string
 	traceHelpers         map[string]string

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -281,6 +281,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.stdNetAliases = collectStdNetAliases(file)
 		g.stdCryptoAliases = collectStdCryptoAliases(file)
 		g.stdOsAliases = collectStdOsAliases(file)
+		g.stdTermAliases = collectStdTermAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -321,6 +322,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.stdNetAliases = collectStdNetAliases(file)
 	g.stdCryptoAliases = collectStdCryptoAliases(file)
 	g.stdOsAliases = collectStdOsAliases(file)
+	g.stdTermAliases = collectStdTermAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/stdlib_term_shim.go
+++ b/internal/llvmgen/stdlib_term_shim.go
@@ -1,0 +1,307 @@
+package llvmgen
+
+import "github.com/osty/osty/internal/ast"
+
+const ostyRtTermIsTerminalSymbol = "osty_rt_term_is_terminal"
+const ostyRtTermWidthSymbol = "osty_rt_term_width"
+const ostyRtTermHeightSymbol = "osty_rt_term_height"
+const ostyRtTermWriteSymbol = "osty_rt_term_write"
+const ostyRtTermFlushSymbol = "osty_rt_term_flush"
+const ostyRtTermSetRawModeSymbol = "osty_rt_term_set_raw_mode"
+
+const stdTermSyntheticSizeTypeName = "__osty_std_term_Size"
+
+var stdTermSizeSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{stdTermSyntheticSizeTypeName},
+}
+
+var stdTermSizeResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdTermSizeSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdTermUnitErrorResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		unitTupleSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+func collectStdTermAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "term" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "term"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func ensureStdTermSyntheticSizeStruct(g *generator) *structInfo {
+	if g == nil {
+		return nil
+	}
+	if info := g.structsByName[stdTermSyntheticSizeTypeName]; info != nil {
+		return info
+	}
+	if g.structsByName == nil {
+		g.structsByName = map[string]*structInfo{}
+	}
+	if g.structsByType == nil {
+		g.structsByType = map[string]*structInfo{}
+	}
+	info := &structInfo{
+		name:   stdTermSyntheticSizeTypeName,
+		typ:    llvmStructTypeName(stdTermSyntheticSizeTypeName),
+		byName: map[string]fieldInfo{},
+	}
+	fields := []fieldInfo{
+		{
+			name:       "width",
+			typ:        "i64",
+			index:      0,
+			sourceType: &ast.NamedType{Path: []string{"Int"}},
+		},
+		{
+			name:       "height",
+			typ:        "i64",
+			index:      1,
+			sourceType: &ast.NamedType{Path: []string{"Int"}},
+		},
+	}
+	info.fields = fields
+	for _, field := range fields {
+		info.byName[field.name] = field
+	}
+	g.structs = append(g.structs, info)
+	g.structsByName[info.name] = info
+	g.structsByType[info.typ] = info
+	return info
+}
+
+func (g *generator) emitStdTermCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.stdTermCallField(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "isTerminal":
+		return g.emitStdTermIsTerminalCall(call)
+	case "size":
+		return g.emitStdTermSizeCall(call)
+	case "write":
+		return g.emitStdTermWriteCall(call)
+	case "flush":
+		return g.emitStdTermFlushCall(call)
+	case "setRawMode":
+		return g.emitStdTermSetRawModeCall(call)
+	case "readKey", "pollKey", "readEvent":
+		return value{}, true, unsupportedf("call", "std.term.%s is not supported by LLVM yet", field.Name)
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) stdTermCallStaticResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.stdTermCallField(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "isTerminal":
+		return value{typ: "i1", sourceType: &ast.NamedType{Path: []string{"Bool"}}}, true
+	case "size":
+		ensureStdTermSyntheticSizeStruct(g)
+		info, ok := builtinResultTypeFromAST(stdTermSizeResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdTermSizeResultSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType(info.typ),
+		}, true
+	case "write", "flush", "setRawMode":
+		info, ok := builtinResultTypeFromAST(stdTermUnitErrorResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdTermUnitErrorResultSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType(info.typ),
+		}, true
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) staticStdTermCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.stdTermCallField(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "isTerminal":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "size":
+		ensureStdTermSyntheticSizeStruct(g)
+		return stdTermSizeResultSourceTypeSingleton, true
+	case "write", "flush", "setRawMode":
+		return stdTermUnitErrorResultSourceTypeSingleton, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) stdTermCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	if call == nil || len(g.stdTermAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || alias == nil || !g.stdTermAliases[alias.Name] {
+		return nil, false
+	}
+	return field, true
+}
+
+func (g *generator) emitStdTermIsTerminalCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "term.isTerminal takes no arguments, got %d", len(call.Args))
+	}
+	g.declareRuntimeSymbol(ostyRtTermIsTerminalSymbol, "i1", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "i1", ostyRtTermIsTerminalSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.sourceType = &ast.NamedType{Path: []string{"Bool"}}
+	return v, true, nil
+}
+
+func (g *generator) emitStdTermSizeCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "term.size takes no arguments, got %d", len(call.Args))
+	}
+	sizeInfo := ensureStdTermSyntheticSizeStruct(g)
+	info, ok := builtinResultTypeFromAST(stdTermSizeResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "term.size Result<Size, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if info.okTyp != sizeInfo.typ || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "term.size currently needs Result<%s, ptr>, got ok=%s err=%s", sizeInfo.typ, info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(ostyRtTermWidthSymbol, "i64", nil)
+	g.declareRuntimeSymbol(ostyRtTermHeightSymbol, "i64", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	width := llvmCall(emitter, "i64", ostyRtTermWidthSymbol, nil)
+	height := llvmCall(emitter, "i64", ostyRtTermHeightSymbol, nil)
+	sizeValue := llvmStructLiteral(emitter, sizeInfo.typ, []*LlvmValue{width, height})
+	result := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		sizeValue,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	g.takeOstyEmitter(emitter)
+	v := value{
+		typ:        info.typ,
+		ref:        result.name,
+		sourceType: stdTermSizeResultSourceTypeSingleton,
+	}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdTermWriteCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "term.write expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || (arg.Name != "" && arg.Name != "text") || arg.Value == nil {
+		return value{}, true, unsupported("call", "term.write requires one positional or `text:` String argument")
+	}
+	text, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	text = g.protectManagedTemporary("term.write.text", text)
+	text, err = g.loadIfPointer(text)
+	if err != nil {
+		return value{}, true, err
+	}
+	if text.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "term.write arg 1 type %s, want String", text.typ)
+	}
+	return g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"term.write",
+		stdTermUnitErrorResultSourceTypeSingleton,
+		ostyRtTermWriteSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(text)},
+	)
+}
+
+func (g *generator) emitStdTermFlushCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "term.flush takes no arguments, got %d", len(call.Args))
+	}
+	return g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"term.flush",
+		stdTermUnitErrorResultSourceTypeSingleton,
+		ostyRtTermFlushSymbol,
+		nil,
+		nil,
+	)
+}
+
+func (g *generator) emitStdTermSetRawModeCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "term.setRawMode expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || (arg.Name != "" && arg.Name != "enabled") || arg.Value == nil {
+		return value{}, true, unsupported("call", "term.setRawMode requires one positional or `enabled:` Bool argument")
+	}
+	enabled, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	enabled, err = g.loadIfPointer(enabled)
+	if err != nil {
+		return value{}, true, err
+	}
+	if enabled.typ != "i1" {
+		return value{}, true, unsupportedf("type-system", "term.setRawMode arg 1 type %s, want Bool", enabled.typ)
+	}
+	return g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"term.setRawMode",
+		stdTermUnitErrorResultSourceTypeSingleton,
+		ostyRtTermSetRawModeSymbol,
+		[]paramInfo{{typ: "i1"}},
+		[]*LlvmValue{toOstyValue(enabled)},
+	)
+}

--- a/internal/llvmgen/stdlib_term_shim_test.go
+++ b/internal/llvmgen/stdlib_term_shim_test.go
@@ -1,0 +1,63 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStdTermRoutesToRuntimeAndSupportsSizeFields(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.term as term
+
+fn main() {
+    println(term.isTerminal())
+    match term.size() {
+        Ok(size) -> {
+            println(size.width)
+            println(size.height)
+        },
+        Err(err) -> println(err.message()),
+    }
+    match term.write("x") {
+        Ok(_) -> println("w"),
+        Err(err) -> println(err.message()),
+    }
+    match term.flush() {
+        Ok(_) -> println("f"),
+        Err(err) -> println(err.message()),
+    }
+    match term.setRawMode(false) {
+        Ok(_) -> println("raw"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_term.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%__osty_std_term_Size = type { i64, i64 }",
+		"declare i1 @osty_rt_term_is_terminal()",
+		"call i1 @osty_rt_term_is_terminal()",
+		"declare i64 @osty_rt_term_width()",
+		"declare i64 @osty_rt_term_height()",
+		"call i64 @osty_rt_term_width()",
+		"call i64 @osty_rt_term_height()",
+		"declare ptr @osty_rt_term_write(ptr)",
+		"call ptr @osty_rt_term_write(ptr",
+		"declare ptr @osty_rt_term_flush()",
+		"call ptr @osty_rt_term_flush()",
+		"declare ptr @osty_rt_term_set_raw_mode(i1)",
+		"call ptr @osty_rt_term_set_raw_mode(i1 false)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -487,6 +487,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdOsCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdTermCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticPtrBackedErrorCallSourceType(e); ok {
 			return src, true
 		}
@@ -1001,6 +1004,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return out, true
 		}
 		if out, ok := g.stdOsCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdTermCallStaticResult(e); ok {
 			return out, true
 		}
 	case *ast.FieldExpr:

--- a/internal/stdlib/modules/grid.osty
+++ b/internal/stdlib/modules/grid.osty
@@ -1,0 +1,412 @@
+// std.grid -- rectangular grid helpers for turn-based games and tools.
+//
+// The module intentionally stays pure Osty. It provides the small spatial
+// vocabulary that terminal UIs, roguelikes, board games, and pathfinding
+// examples all tend to rebuild: points, sizes, rectangles, directions, and a
+// row-major Grid<T>.
+
+pub struct Point {
+    pub x: Int,
+    pub y: Int,
+
+    pub fn add(self, other: Point) -> Point {
+        Point { x: self.x + other.x, y: self.y + other.y }
+    }
+
+    pub fn sub(self, other: Point) -> Point {
+        Point { x: self.x - other.x, y: self.y - other.y }
+    }
+
+    pub fn step(self, direction: Direction) -> Point {
+        Point { x: self.x + direction.dx(), y: self.y + direction.dy() }
+    }
+
+    pub fn manhattan(self, other: Point) -> Int {
+        absInt(self.x - other.x) + absInt(self.y - other.y)
+    }
+
+    pub fn neighbors4(self) -> List<Point> {
+        [
+            self.step(Direction.Up),
+            self.step(Direction.Right),
+            self.step(Direction.Down),
+            self.step(Direction.Left),
+        ]
+    }
+
+    pub fn neighbors8(self) -> List<Point> {
+        [
+            self.step(Direction.Up),
+            self.step(Direction.UpRight),
+            self.step(Direction.Right),
+            self.step(Direction.DownRight),
+            self.step(Direction.Down),
+            self.step(Direction.DownLeft),
+            self.step(Direction.Left),
+            self.step(Direction.UpLeft),
+        ]
+    }
+}
+
+pub struct Size {
+    pub width: Int,
+    pub height: Int,
+
+    pub fn area(self) -> Int {
+        if self.width <= 0 || self.height <= 0 {
+            return 0
+        }
+        self.width * self.height
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.area() == 0
+    }
+
+    pub fn contains(self, point: Point) -> Bool {
+        point.x >= 0 && point.y >= 0 && point.x < self.width && point.y < self.height
+    }
+
+    pub fn rect(self) -> Rect {
+        Rect { origin: Point { x: 0, y: 0 }, size: self }
+    }
+}
+
+pub struct Rect {
+    pub origin: Point,
+    pub size: Size,
+
+    pub fn minX(self) -> Int {
+        self.origin.x
+    }
+
+    pub fn minY(self) -> Int {
+        self.origin.y
+    }
+
+    pub fn maxX(self) -> Int {
+        self.origin.x + self.size.width
+    }
+
+    pub fn maxY(self) -> Int {
+        self.origin.y + self.size.height
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.size.isEmpty()
+    }
+
+    pub fn contains(self, point: Point) -> Bool {
+        point.x >= self.minX() &&
+        point.y >= self.minY() &&
+        point.x < self.maxX() &&
+        point.y < self.maxY()
+    }
+
+    pub fn intersects(self, other: Rect) -> Bool {
+        !self.isEmpty() &&
+        !other.isEmpty() &&
+        self.minX() < other.maxX() &&
+        self.maxX() > other.minX() &&
+        self.minY() < other.maxY() &&
+        self.maxY() > other.minY()
+    }
+
+    pub fn intersection(self, other: Rect) -> Rect? {
+        if !self.intersects(other) {
+            return None
+        }
+        let x1 = maxInt(self.minX(), other.minX())
+        let y1 = maxInt(self.minY(), other.minY())
+        let x2 = minInt(self.maxX(), other.maxX())
+        let y2 = minInt(self.maxY(), other.maxY())
+        Some(rect(x1, y1, x2 - x1, y2 - y1))
+    }
+
+    pub fn translate(self, delta: Point) -> Rect {
+        Rect { origin: self.origin.add(delta), size: self.size }
+    }
+
+    pub fn clamp(self, point: Point) -> Point {
+        if self.isEmpty() {
+            return self.origin
+        }
+        Point {
+            x: clampInt(point.x, self.minX(), self.maxX() - 1),
+            y: clampInt(point.y, self.minY(), self.maxY() - 1),
+        }
+    }
+
+    pub fn points(self) -> List<Point> {
+        let mut out: List<Point> = []
+        let mut y = self.minY()
+        for y < self.maxY() {
+            let mut x = self.minX()
+            for x < self.maxX() {
+                out.push(Point { x: x, y: y })
+                x = x + 1
+            }
+            y = y + 1
+        }
+        out
+    }
+}
+
+pub enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+    UpLeft,
+    UpRight,
+    DownLeft,
+    DownRight,
+    Wait,
+
+    pub fn dx(self) -> Int {
+        match self {
+            Left | UpLeft | DownLeft -> -1,
+            Right | UpRight | DownRight -> 1,
+            _ -> 0,
+        }
+    }
+
+    pub fn dy(self) -> Int {
+        match self {
+            Up | UpLeft | UpRight -> -1,
+            Down | DownLeft | DownRight -> 1,
+            _ -> 0,
+        }
+    }
+
+    pub fn isDiagonal(self) -> Bool {
+        match self {
+            UpLeft | UpRight | DownLeft | DownRight -> true,
+            _ -> false,
+        }
+    }
+
+    pub fn opposite(self) -> Direction {
+        match self {
+            Up -> Direction.Down,
+            Down -> Direction.Up,
+            Left -> Direction.Right,
+            Right -> Direction.Left,
+            UpLeft -> Direction.DownRight,
+            UpRight -> Direction.DownLeft,
+            DownLeft -> Direction.UpRight,
+            DownRight -> Direction.UpLeft,
+            Wait -> Direction.Wait,
+        }
+    }
+
+    pub fn toPoint(self) -> Point {
+        Point { x: self.dx(), y: self.dy() }
+    }
+}
+
+pub struct Grid<T> {
+    pub width: Int,
+    pub height: Int,
+    cells: List<T>,
+
+    pub fn size(self) -> Size {
+        Size { width: self.width, height: self.height }
+    }
+
+    pub fn bounds(self) -> Rect {
+        self.size().rect()
+    }
+
+    pub fn len(self) -> Int {
+        self.cells.len()
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.len() == 0
+    }
+
+    pub fn contains(self, point: Point) -> Bool {
+        self.size().contains(point)
+    }
+
+    pub fn index(self, point: Point) -> Int? {
+        if !self.contains(point) {
+            return None
+        }
+        Some(point.y * self.width + point.x)
+    }
+
+    pub fn pointAt(self, index: Int) -> Point? {
+        if index < 0 || index >= self.len() || self.width <= 0 {
+            return None
+        }
+        Some(Point { x: index % self.width, y: index / self.width })
+    }
+
+    pub fn get(self, point: Point) -> T? {
+        match self.index(point) {
+            Some(i) -> {
+                return Some(self.cells[i])
+            },
+            None -> {},
+        }
+        None
+    }
+
+    pub fn set(mut self, point: Point, value: T) -> Bool {
+        match self.index(point) {
+            Some(i) -> {
+                self.cells[i] = value
+                true
+            },
+            None -> false,
+        }
+    }
+
+    pub fn fill(mut self, value: T) {
+        let mut i = 0
+        for i < self.cells.len() {
+            self.cells[i] = value
+            i = i + 1
+        }
+    }
+
+    pub fn points(self) -> List<Point> {
+        self.bounds().points()
+    }
+
+    pub fn neighbors4(self, point: Point) -> List<Point> {
+        boundedNeighbors(self, point, cardinals())
+    }
+
+    pub fn neighbors8(self, point: Point) -> List<Point> {
+        boundedNeighbors(self, point, directions8())
+    }
+
+    pub fn map<U>(self, f: fn(Point, T) -> U) -> Grid<U> {
+        let mut out: List<U> = []
+        let mut i = 0
+        for i < self.cells.len() {
+            let point = self.pointAt(i).unwrap()
+            out.push(f(point, self.cells[i]))
+            i = i + 1
+        }
+        Grid { width: self.width, height: self.height, cells: out }
+    }
+}
+
+pub fn point(x: Int, y: Int) -> Point {
+    Point { x: x, y: y }
+}
+
+pub fn size(width: Int, height: Int) -> Size {
+    Size { width: width, height: height }
+}
+
+pub fn rect(x: Int, y: Int, width: Int, height: Int) -> Rect {
+    Rect { origin: point(x, y), size: size(width, height) }
+}
+
+pub fn grid<T>(width: Int, height: Int, fill: T) -> Grid<T> {
+    let mut cells: List<T> = []
+    let total = size(width, height).area()
+    let mut i = 0
+    for i < total {
+        cells.push(fill)
+        i = i + 1
+    }
+    Grid { width: width, height: height, cells: cells }
+}
+
+pub fn fromRows<T>(rows: List<List<T>>) -> Grid<T>? {
+    if rows.isEmpty() {
+        return None
+    }
+    let height = rows.len()
+    let width = rows[0].len()
+    let mut cells: List<T> = []
+    for row in rows {
+        if row.len() != width {
+            return None
+        }
+        for item in row {
+            cells.push(item)
+        }
+    }
+    let result: Grid<T> = Grid { width: width, height: height, cells: cells }
+    Some(result)
+}
+
+pub fn cardinals() -> List<Direction> {
+    [Direction.Up, Direction.Right, Direction.Down, Direction.Left]
+}
+
+pub fn diagonals() -> List<Direction> {
+    [Direction.UpLeft, Direction.UpRight, Direction.DownRight, Direction.DownLeft]
+}
+
+pub fn directions8() -> List<Direction> {
+    [
+        Direction.Up,
+        Direction.UpRight,
+        Direction.Right,
+        Direction.DownRight,
+        Direction.Down,
+        Direction.DownLeft,
+        Direction.Left,
+        Direction.UpLeft,
+    ]
+}
+
+pub fn directionFromDelta(dx: Int, dy: Int) -> Direction? {
+    let nx = clampInt(dx, -1, 1)
+    let ny = clampInt(dy, -1, 1)
+    match (nx, ny) {
+        (0, -1) -> Some(Direction.Up),
+        (1, -1) -> Some(Direction.UpRight),
+        (1, 0) -> Some(Direction.Right),
+        (1, 1) -> Some(Direction.DownRight),
+        (0, 1) -> Some(Direction.Down),
+        (-1, 1) -> Some(Direction.DownLeft),
+        (-1, 0) -> Some(Direction.Left),
+        (-1, -1) -> Some(Direction.UpLeft),
+        (0, 0) -> Some(Direction.Wait),
+        _ -> {
+            return None
+        },
+    }
+}
+
+fn boundedNeighbors<T>(grid: Grid<T>, point: Point, directions: List<Direction>) -> List<Point> {
+    let mut out: List<Point> = []
+    for direction in directions {
+        let next = point.step(direction)
+        if grid.contains(next) {
+            out.push(next)
+        }
+    }
+    out
+}
+
+fn absInt(n: Int) -> Int {
+    if n < 0 { 0 - n } else { n }
+}
+
+fn minInt(a: Int, b: Int) -> Int {
+    if a < b { a } else { b }
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}
+
+fn clampInt(n: Int, lo: Int, hi: Int) -> Int {
+    if n < lo {
+        return lo
+    }
+    if n > hi {
+        return hi
+    }
+    n
+}

--- a/internal/stdlib/modules/term.osty
+++ b/internal/stdlib/modules/term.osty
@@ -1,0 +1,320 @@
+// std.term -- terminal control primitives for text UIs.
+//
+// Terminal mode, size, and key input are host-backed. ANSI sequence builders
+// are pure Osty so libraries can render deterministic output in tests and in
+// simple stdout-only programs.
+
+use std.error
+use std.io
+
+pub struct Size {
+    pub width: Int,
+    pub height: Int,
+
+    pub fn isEmpty(self) -> Bool {
+        self.width <= 0 || self.height <= 0
+    }
+}
+
+pub struct Position {
+    pub x: Int,
+    pub y: Int,
+}
+
+pub enum Color {
+    DefaultColor,
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
+    Ansi(Int),
+    Rgb(Int, Int, Int),
+}
+
+pub enum Attribute {
+    Bold,
+    Dim,
+    Italic,
+    Underline,
+    Blink,
+    Reverse,
+    Hidden,
+    Strike,
+}
+
+pub struct Style {
+    pub fg: Color,
+    pub bg: Color,
+    pub attrs: List<Attribute>,
+
+    pub fn isDefault(self) -> Bool {
+        self.fg == Color.DefaultColor && self.bg == Color.DefaultColor && self.attrs.isEmpty()
+    }
+}
+
+pub enum Key {
+    Char(String),
+    Enter,
+    EscapeKey,
+    Backspace,
+    Tab,
+    BackTab,
+    Up,
+    Down,
+    Left,
+    Right,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Insert,
+    Delete,
+    Function(Int),
+    Unknown(String),
+}
+
+pub enum Event {
+    KeyEvent(Key),
+    Resize(Size),
+}
+
+pub struct Terminal {
+    raw: Bool,
+    altScreen: Bool,
+    cursorVisible: Bool,
+
+    pub fn size(self) -> Result<Size, Error> {
+        size()
+    }
+
+    pub fn readKey(self) -> Result<Key, Error> {
+        readKey()
+    }
+
+    pub fn pollKey(self, timeoutMillis: Int) -> Result<Key?, Error> {
+        pollKey(timeoutMillis)
+    }
+
+    pub fn setRawMode(mut self, enabled: Bool) -> Result<(), Error> {
+        setRawMode(enabled)?
+        self.raw = enabled
+        Ok(())
+    }
+
+    pub fn enterAltScreen(mut self) -> Result<(), Error> {
+        write(enterAltScreenSeq())?
+        self.altScreen = true
+        Ok(())
+    }
+
+    pub fn exitAltScreen(mut self) -> Result<(), Error> {
+        write(exitAltScreenSeq())?
+        self.altScreen = false
+        Ok(())
+    }
+
+    pub fn clear(self) -> Result<(), Error> {
+        write(clearScreenSeq())
+    }
+
+    pub fn clearLine(self) -> Result<(), Error> {
+        write(clearLineSeq())
+    }
+
+    pub fn moveTo(self, position: Position) -> Result<(), Error> {
+        write(moveToSeq(position))
+    }
+
+    pub fn hideCursor(mut self) -> Result<(), Error> {
+        write(hideCursorSeq())?
+        self.cursorVisible = false
+        Ok(())
+    }
+
+    pub fn showCursor(mut self) -> Result<(), Error> {
+        write(showCursorSeq())?
+        self.cursorVisible = true
+        Ok(())
+    }
+
+    pub fn restore(mut self) -> Result<(), Error> {
+        if !self.cursorVisible {
+            self.showCursor()?
+        }
+        if self.altScreen {
+            self.exitAltScreen()?
+        }
+        if self.raw {
+            self.setRawMode(false)?
+        }
+        Ok(())
+    }
+}
+
+pub fn open() -> Result<Terminal, Error> {
+    Ok(Terminal { raw: false, altScreen: false, cursorVisible: true })
+}
+
+pub fn isTerminal() -> Bool
+
+pub fn size() -> Result<Size, Error>
+
+pub fn setRawMode(enabled: Bool) -> Result<(), Error>
+
+pub fn readKey() -> Result<Key, Error>
+
+pub fn pollKey(timeoutMillis: Int) -> Result<Key?, Error>
+
+pub fn readEvent() -> Result<Event, Error>
+
+pub fn write(text: String) -> Result<(), Error> {
+    io.print(text)
+    Ok(())
+}
+
+pub fn flush() -> Result<(), Error>
+
+pub fn position(x: Int, y: Int) -> Position {
+    Position { x: x, y: y }
+}
+
+pub fn defaultStyle() -> Style {
+    Style { fg: Color.DefaultColor, bg: Color.DefaultColor, attrs: [] }
+}
+
+pub fn style(fg: Color, bg: Color, attrs: List<Attribute>) -> Style {
+    Style { fg: fg, bg: bg, attrs: attrs }
+}
+
+pub fn resetSeq() -> String {
+    "\u{1B}[0m"
+}
+
+pub fn clearScreenSeq() -> String {
+    "\u{1B}[2J\u{1B}[H"
+}
+
+pub fn clearLineSeq() -> String {
+    "\u{1B}[2K"
+}
+
+pub fn moveToSeq(position: Position) -> String {
+    let row = position.y + 1
+    let col = position.x + 1
+    "\u{1B}[{row};{col}H"
+}
+
+pub fn hideCursorSeq() -> String {
+    "\u{1B}[?25l"
+}
+
+pub fn showCursorSeq() -> String {
+    "\u{1B}[?25h"
+}
+
+pub fn enterAltScreenSeq() -> String {
+    "\u{1B}[?1049h"
+}
+
+pub fn exitAltScreenSeq() -> String {
+    "\u{1B}[?1049l"
+}
+
+pub fn styleSeq(style: Style) -> String {
+    if style.isDefault() {
+        return ""
+    }
+    let mut out = ""
+    for attr in style.attrs {
+        out = "{out}{attributeSeq(attr)}"
+    }
+    out = "{out}{fgSeq(style.fg)}{bgSeq(style.bg)}"
+    out
+}
+
+pub fn styled(text: String, style: Style) -> String {
+    "{styleSeq(style)}{text}{resetSeq()}"
+}
+
+pub fn fgSeq(color: Color) -> String {
+    match color {
+        DefaultColor -> "\u{1B}[39m",
+        Black -> "\u{1B}[30m",
+        Red -> "\u{1B}[31m",
+        Green -> "\u{1B}[32m",
+        Yellow -> "\u{1B}[33m",
+        Blue -> "\u{1B}[34m",
+        Magenta -> "\u{1B}[35m",
+        Cyan -> "\u{1B}[36m",
+        White -> "\u{1B}[37m",
+        BrightBlack -> "\u{1B}[90m",
+        BrightRed -> "\u{1B}[91m",
+        BrightGreen -> "\u{1B}[92m",
+        BrightYellow -> "\u{1B}[93m",
+        BrightBlue -> "\u{1B}[94m",
+        BrightMagenta -> "\u{1B}[95m",
+        BrightCyan -> "\u{1B}[96m",
+        BrightWhite -> "\u{1B}[97m",
+        Ansi(n) -> "\u{1B}[38;5;{clampColor(n)}m",
+        Rgb(r, g, b) -> "\u{1B}[38;2;{clampColor(r)};{clampColor(g)};{clampColor(b)}m",
+    }
+}
+
+pub fn bgSeq(color: Color) -> String {
+    match color {
+        DefaultColor -> "\u{1B}[49m",
+        Black -> "\u{1B}[40m",
+        Red -> "\u{1B}[41m",
+        Green -> "\u{1B}[42m",
+        Yellow -> "\u{1B}[43m",
+        Blue -> "\u{1B}[44m",
+        Magenta -> "\u{1B}[45m",
+        Cyan -> "\u{1B}[46m",
+        White -> "\u{1B}[47m",
+        BrightBlack -> "\u{1B}[100m",
+        BrightRed -> "\u{1B}[101m",
+        BrightGreen -> "\u{1B}[102m",
+        BrightYellow -> "\u{1B}[103m",
+        BrightBlue -> "\u{1B}[104m",
+        BrightMagenta -> "\u{1B}[105m",
+        BrightCyan -> "\u{1B}[106m",
+        BrightWhite -> "\u{1B}[107m",
+        Ansi(n) -> "\u{1B}[48;5;{clampColor(n)}m",
+        Rgb(r, g, b) -> "\u{1B}[48;2;{clampColor(r)};{clampColor(g)};{clampColor(b)}m",
+    }
+}
+
+pub fn attributeSeq(attr: Attribute) -> String {
+    match attr {
+        Bold -> "\u{1B}[1m",
+        Dim -> "\u{1B}[2m",
+        Italic -> "\u{1B}[3m",
+        Underline -> "\u{1B}[4m",
+        Blink -> "\u{1B}[5m",
+        Reverse -> "\u{1B}[7m",
+        Hidden -> "\u{1B}[8m",
+        Strike -> "\u{1B}[9m",
+    }
+}
+
+fn clampColor(n: Int) -> Int {
+    if n < 0 {
+        return 0
+    }
+    if n > 255 {
+        return 255
+    }
+    n
+}

--- a/internal/stdlib/modules/tui.osty
+++ b/internal/stdlib/modules/tui.osty
@@ -1,0 +1,383 @@
+// std.tui -- retained frame buffers for terminal UIs.
+//
+// The core renderer is ANSI-string based: callers can use `renderAnsi` for a
+// full frame or `diffAnsi` to emit only cells that changed since a previous
+// frame. Host I/O stays in std.term.
+
+use std.grid
+use std.term
+
+pub enum Color {
+    DefaultColor,
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
+    Ansi(Int),
+    Rgb(Int, Int, Int),
+}
+
+pub enum Attribute {
+    Bold,
+    Dim,
+    Italic,
+    Underline,
+    Blink,
+    Reverse,
+    Hidden,
+    Strike,
+}
+
+pub struct Style {
+    pub fg: Color,
+    pub bg: Color,
+    pub attrs: List<Attribute>,
+
+    pub fn isDefault(self) -> Bool {
+        self.fg == Color.DefaultColor && self.bg == Color.DefaultColor && self.attrs.isEmpty()
+    }
+}
+
+pub struct Cell {
+    pub text: String,
+    pub style: Style,
+}
+
+pub struct Frame {
+    pub size: grid.Size,
+    cells: List<Cell>,
+
+    pub fn bounds(self) -> grid.Rect {
+        self.size.rect()
+    }
+
+    pub fn len(self) -> Int {
+        self.cells.len()
+    }
+
+    pub fn contains(self, point: grid.Point) -> Bool {
+        self.size.contains(point)
+    }
+
+    pub fn index(self, point: grid.Point) -> Int? {
+        if !self.contains(point) {
+            return None
+        }
+        Some(point.y * self.size.width + point.x)
+    }
+
+    pub fn get(self, point: grid.Point) -> Cell? {
+        match self.index(point) {
+            Some(i) -> {
+                return Some(self.cells[i])
+            },
+            None -> {},
+        }
+        None
+    }
+
+    pub fn putCell(mut self, point: grid.Point, cell: Cell) -> Bool {
+        match self.index(point) {
+            Some(i) -> {
+                self.cells[i] = cell
+                true
+            },
+            None -> false,
+        }
+    }
+
+    pub fn put(mut self, point: grid.Point, text: String, style: Style) -> Bool {
+        self.putCell(point, Cell { text: text, style: style })
+    }
+
+    pub fn clear(mut self) {
+        self.fill(blankCell())
+    }
+
+    pub fn fill(mut self, cell: Cell) {
+        let mut i = 0
+        for i < self.cells.len() {
+            self.cells[i] = cell
+            i = i + 1
+        }
+    }
+
+    pub fn drawText(mut self, point: grid.Point, text: String, style: Style) -> Int {
+        let chars = text.chars()
+        let mut written = 0
+        let mut i = 0
+        for i < chars.len() {
+            let p = grid.point(point.x + i, point.y)
+            if self.put(p, chars[i].toString(), style) {
+                written = written + 1
+            }
+            i = i + 1
+        }
+        written
+    }
+
+    pub fn drawHLine(mut self, y: Int, x1: Int, x2: Int, text: String, style: Style) -> Int {
+        let lo = minInt(x1, x2)
+        let hi = maxInt(x1, x2)
+        let mut written = 0
+        let mut x = lo
+        for x <= hi {
+            if self.put(grid.point(x, y), text, style) {
+                written = written + 1
+            }
+            x = x + 1
+        }
+        written
+    }
+
+    pub fn drawVLine(mut self, x: Int, y1: Int, y2: Int, text: String, style: Style) -> Int {
+        let lo = minInt(y1, y2)
+        let hi = maxInt(y1, y2)
+        let mut written = 0
+        let mut y = lo
+        for y <= hi {
+            if self.put(grid.point(x, y), text, style) {
+                written = written + 1
+            }
+            y = y + 1
+        }
+        written
+    }
+
+    pub fn drawRect(mut self, rect: grid.Rect, glyph: String, style: Style) {
+        if rect.isEmpty() {
+            return
+        }
+        let left = rect.minX()
+        let right = rect.maxX() - 1
+        let top = rect.minY()
+        let bottom = rect.maxY() - 1
+        self.drawHLine(top, left, right, glyph, style)
+        self.drawHLine(bottom, left, right, glyph, style)
+        self.drawVLine(left, top, bottom, glyph, style)
+        self.drawVLine(right, top, bottom, glyph, style)
+    }
+
+    pub fn renderAnsi(self) -> String {
+        let mut out = ""
+        let mut y = 0
+        for y < self.size.height {
+            out = "{out}{moveToSeq(grid.point(0, y))}"
+            let mut x = 0
+            for x < self.size.width {
+                let cell = self.cells[y * self.size.width + x]
+                out = "{out}{styleSeq(cell.style)}{cell.text}"
+                x = x + 1
+            }
+            out = "{out}{resetSeq()}"
+            y = y + 1
+        }
+        out
+    }
+
+    pub fn diffAnsi(self, previous: Frame?) -> String {
+        if previous.isNone() {
+            return "{term.clearScreenSeq()}{self.renderAnsi()}"
+        }
+        self.diffFrom(previous.unwrap())
+    }
+
+    fn diffFrom(self, previous: Frame) -> String {
+        if self.size.width != previous.size.width || self.size.height != previous.size.height {
+            return "{term.clearScreenSeq()}{self.renderAnsi()}"
+        }
+        let mut out = ""
+        let mut i = 0
+        for i < self.cells.len() {
+            let current = self.cells[i]
+            let old = previous.cells[i]
+            if !sameCell(current, old) {
+                let point = grid.point(i % self.size.width, i / self.size.width)
+                out = "{out}{moveToSeq(point)}{styleSeq(current.style)}{current.text}{resetSeq()}"
+            }
+            i = i + 1
+        }
+        out
+    }
+}
+
+pub struct Screen {
+    pub size: grid.Size,
+    previous: Frame?,
+
+    pub fn next(mut self, frame: Frame) -> String {
+        let out = frame.diffAnsi(self.previous)
+        self.size = frame.size
+        self.previous = Some(frame)
+        out
+    }
+
+    pub fn present(mut self, frame: Frame) -> Result<(), Error> {
+        term.write(self.next(frame))?
+        Ok(())
+    }
+
+    pub fn reset(mut self) {
+        self.previous = None
+    }
+}
+
+pub fn style(fg: Color, bg: Color, attrs: List<Attribute>) -> Style {
+    Style { fg: fg, bg: bg, attrs: attrs }
+}
+
+pub fn defaultStyle() -> Style {
+    style(Color.DefaultColor, Color.DefaultColor, [])
+}
+
+pub fn cell(text: String, style: Style) -> Cell {
+    Cell { text: text, style: style }
+}
+
+pub fn blankCell() -> Cell {
+    cell(" ", defaultStyle())
+}
+
+pub fn frame(size: grid.Size) -> Frame {
+    Frame { size: size, cells: blankCells(size) }
+}
+
+pub fn sized(width: Int, height: Int) -> Frame {
+    frame(grid.size(width, height))
+}
+
+pub fn screen(size: grid.Size) -> Screen {
+    Screen { size: size, previous: None }
+}
+
+pub fn resetSeq() -> String {
+    "\u{1B}[0m"
+}
+
+pub fn moveToSeq(point: grid.Point) -> String {
+    let row = point.y + 1
+    let col = point.x + 1
+    "\u{1B}[{row};{col}H"
+}
+
+pub fn styleSeq(style: Style) -> String {
+    if style.isDefault() {
+        return ""
+    }
+    let mut out = ""
+    for attr in style.attrs {
+        out = "{out}{attributeSeq(attr)}"
+    }
+    out = "{out}{fgSeq(style.fg)}{bgSeq(style.bg)}"
+    out
+}
+
+pub fn fgSeq(color: Color) -> String {
+    match color {
+        DefaultColor -> "\u{1B}[39m",
+        Black -> "\u{1B}[30m",
+        Red -> "\u{1B}[31m",
+        Green -> "\u{1B}[32m",
+        Yellow -> "\u{1B}[33m",
+        Blue -> "\u{1B}[34m",
+        Magenta -> "\u{1B}[35m",
+        Cyan -> "\u{1B}[36m",
+        White -> "\u{1B}[37m",
+        BrightBlack -> "\u{1B}[90m",
+        BrightRed -> "\u{1B}[91m",
+        BrightGreen -> "\u{1B}[92m",
+        BrightYellow -> "\u{1B}[93m",
+        BrightBlue -> "\u{1B}[94m",
+        BrightMagenta -> "\u{1B}[95m",
+        BrightCyan -> "\u{1B}[96m",
+        BrightWhite -> "\u{1B}[97m",
+        Ansi(n) -> "\u{1B}[38;5;{clampColor(n)}m",
+        Rgb(r, g, b) -> "\u{1B}[38;2;{clampColor(r)};{clampColor(g)};{clampColor(b)}m",
+    }
+}
+
+pub fn bgSeq(color: Color) -> String {
+    match color {
+        DefaultColor -> "\u{1B}[49m",
+        Black -> "\u{1B}[40m",
+        Red -> "\u{1B}[41m",
+        Green -> "\u{1B}[42m",
+        Yellow -> "\u{1B}[43m",
+        Blue -> "\u{1B}[44m",
+        Magenta -> "\u{1B}[45m",
+        Cyan -> "\u{1B}[46m",
+        White -> "\u{1B}[47m",
+        BrightBlack -> "\u{1B}[100m",
+        BrightRed -> "\u{1B}[101m",
+        BrightGreen -> "\u{1B}[102m",
+        BrightYellow -> "\u{1B}[103m",
+        BrightBlue -> "\u{1B}[104m",
+        BrightMagenta -> "\u{1B}[105m",
+        BrightCyan -> "\u{1B}[106m",
+        BrightWhite -> "\u{1B}[107m",
+        Ansi(n) -> "\u{1B}[48;5;{clampColor(n)}m",
+        Rgb(r, g, b) -> "\u{1B}[48;2;{clampColor(r)};{clampColor(g)};{clampColor(b)}m",
+    }
+}
+
+pub fn attributeSeq(attr: Attribute) -> String {
+    match attr {
+        Bold -> "\u{1B}[1m",
+        Dim -> "\u{1B}[2m",
+        Italic -> "\u{1B}[3m",
+        Underline -> "\u{1B}[4m",
+        Blink -> "\u{1B}[5m",
+        Reverse -> "\u{1B}[7m",
+        Hidden -> "\u{1B}[8m",
+        Strike -> "\u{1B}[9m",
+    }
+}
+
+fn blankCells(size: grid.Size) -> List<Cell> {
+    let mut out: List<Cell> = []
+    let total = size.area()
+    let mut i = 0
+    for i < total {
+        out.push(blankCell())
+        i = i + 1
+    }
+    out
+}
+
+fn sameCell(a: Cell, b: Cell) -> Bool {
+    a.text == b.text && sameStyle(a.style, b.style)
+}
+
+fn sameStyle(a: Style, b: Style) -> Bool {
+    a.fg == b.fg && a.bg == b.bg && a.attrs == b.attrs
+}
+
+fn minInt(a: Int, b: Int) -> Int {
+    if a < b { a } else { b }
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}
+
+fn clampColor(n: Int) -> Int {
+    if n < 0 {
+        return 0
+    }
+    if n > 255 {
+        return 255
+    }
+    n
+}

--- a/internal/stdlib/term_tui_grid_test.go
+++ b/internal/stdlib/term_tui_grid_test.go
@@ -1,0 +1,129 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTermTuiGridModulesLoad(t *testing.T) {
+	reg := LoadCached()
+	for _, name := range []string{"term", "tui", "grid"} {
+		mod := reg.Modules[name]
+		if mod == nil || mod.File == nil || mod.Package == nil {
+			t.Fatalf("std.%s not loaded", name)
+		}
+		if pkg := reg.LookupPackage("std." + name); pkg == nil {
+			t.Fatalf("LookupPackage(std.%s) = nil", name)
+		}
+	}
+}
+
+func TestTermModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	src := string(reg.Modules["term"].Source)
+	for _, want := range []string{
+		"pub struct Terminal",
+		"pub enum Key",
+		"pub enum Event",
+		"pub fn setRawMode(enabled: Bool) -> Result<(), Error>",
+		"pub fn readKey() -> Result<Key, Error>",
+		"pub fn clearScreenSeq() -> String",
+		"pub fn styleSeq(style: Style) -> String",
+		"\"\\u{1B}[2J\\u{1B}[H\"",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.term source missing %q", want)
+		}
+	}
+	for _, name := range []string{"open", "write", "clearScreenSeq", "moveToSeq", "styleSeq"} {
+		fn := reg.LookupFnDecl("term", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(term, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("std.term.%s body = nil, want pure helper body", name)
+		}
+	}
+	for _, name := range []string{"size", "setRawMode", "readKey", "pollKey", "readEvent", "flush"} {
+		fn := reg.LookupFnDecl("term", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(term, %s) = nil", name)
+		}
+		if fn.Body != nil {
+			t.Fatalf("std.term.%s body != nil, want host-backed primitive stub", name)
+		}
+	}
+	for _, method := range []string{"setRawMode", "enterAltScreen", "exitAltScreen", "clear", "moveTo", "hideCursor", "showCursor", "restore"} {
+		if got := reg.LookupMethodDecl("term", "Terminal", method); got == nil {
+			t.Fatalf("LookupMethodDecl(term, Terminal, %s) = nil", method)
+		}
+	}
+}
+
+func TestTuiModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	src := string(reg.Modules["tui"].Source)
+	for _, want := range []string{
+		"pub struct Cell",
+		"pub struct Frame",
+		"pub struct Screen",
+		"pub fn frame(size: grid.Size) -> Frame",
+		"pub fn diffAnsi(self, previous: Frame?)",
+		"term.clearScreenSeq()",
+		"moveToSeq(point)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.tui source missing %q", want)
+		}
+	}
+	for _, name := range []string{"style", "cell", "blankCell", "frame", "sized", "screen", "styleSeq"} {
+		fn := reg.LookupFnDecl("tui", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(tui, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("std.tui.%s body = nil, want pure helper body", name)
+		}
+	}
+	for _, method := range []string{"put", "drawText", "drawHLine", "drawVLine", "drawRect", "renderAnsi", "diffAnsi"} {
+		if got := reg.LookupMethodDecl("tui", "Frame", method); got == nil {
+			t.Fatalf("LookupMethodDecl(tui, Frame, %s) = nil", method)
+		}
+	}
+	if got := reg.LookupMethodDecl("tui", "Screen", "present"); got == nil {
+		t.Fatalf("LookupMethodDecl(tui, Screen, present) = nil")
+	}
+}
+
+func TestGridModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	src := string(reg.Modules["grid"].Source)
+	for _, want := range []string{
+		"pub struct Point",
+		"pub struct Size",
+		"pub struct Rect",
+		"pub enum Direction",
+		"pub struct Grid<T>",
+		"pub fn grid<T>(width: Int, height: Int, fill: T) -> Grid<T>",
+		"pub fn fromRows<T>(rows: List<List<T>>) -> Grid<T>?",
+		"boundedNeighbors(self, point, directions8())",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.grid source missing %q", want)
+		}
+	}
+	for _, name := range []string{"point", "size", "rect", "grid", "fromRows", "cardinals", "diagonals", "directions8", "directionFromDelta"} {
+		fn := reg.LookupFnDecl("grid", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(grid, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("std.grid.%s body = nil, want pure helper body", name)
+		}
+	}
+	for _, method := range []string{"size", "bounds", "index", "pointAt", "get", "set", "fill", "neighbors4", "neighbors8", "map"} {
+		if got := reg.LookupMethodDecl("grid", "Grid", method); got == nil {
+			t.Fatalf("LookupMethodDecl(grid, Grid, %s) = nil", method)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `std.term`, `std.tui`, and `std.grid` modules for terminal apps, buffer rendering, and grid/spatial helpers
- wire `std.term` LLVM lowering and runtime support for terminal detection, size, write, flush, and raw-mode toggling
- document the new standard-library surfaces and add focused stdlib/backend/LLVM tests

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestStd(Term|Env|Os)'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsStdTermBasicSurface|TestStdlibCheckResultTermTuiGrid'`
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestTermTuiGrid|TestTermModuleSurface|TestTuiModuleSurface|TestGridModuleSurface|TestRuntimeRawModuleLoads|TestRuntimeRawLookupPackage'`
- `.bin/osty check internal/stdlib/modules/term.osty`