### PR TITLE
[codex] Expand std.iter helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/07-lazy-iterators.md
+++ b/LANG_SPEC_v0.5/10-standard-library/07-lazy-iterators.md
@@ -1,7 +1,6 @@
 ### 10.7 Lazy Iterators (`std.iter`)
 
-For pipelines over large sequences, early termination, or infinite
-sequences:
+For pipeline-style transformations over sequences:
 
 ```osty
 use std.iter
@@ -13,6 +12,63 @@ let result = iter.from(xs)
     .toList()
 ```
 
-Adapters return new `Iter<T>` without evaluation. Terminal methods
-drive evaluation. Infinite sources require `take`, `takeWhile`, etc.
-before a terminal call.
+The current v0.4 stdlib implementation is eager over a backing
+`List<T>`: adapters allocate a new `Iter<T>` immediately. The API is
+kept fluent so user code can move to a lazy pull-based implementation
+later without changing call sites.
+
+API:
+
+```
+iter.from<T>(items: List<T>) -> Iter<T>
+iter.empty<T>() -> Iter<T>
+iter.range(start: Int, stop: Int) -> Iter<Int>
+
+Iter.map<U>(f: fn(T) -> U) -> Iter<U>
+Iter.filter(f: fn(T) -> Bool) -> Iter<T>
+Iter.inspect(f: fn(T) -> ()) -> Iter<T>
+Iter.filterMap<U>(f: fn(T) -> U?) -> Iter<U>
+Iter.mapWhile<U>(f: fn(T) -> U?) -> Iter<U>
+Iter.flatMap<U>(f: fn(T) -> Iter<U>) -> Iter<U>
+Iter.take(n: Int) -> Iter<T>
+Iter.takeLast(n: Int) -> Iter<T>
+Iter.takeWhile(f: fn(T) -> Bool) -> Iter<T>
+Iter.skip(n: Int) -> Iter<T>
+Iter.skipLast(n: Int) -> Iter<T>
+Iter.skipWhile(f: fn(T) -> Bool) -> Iter<T>
+Iter.stepBy(step: Int) -> Iter<T>
+Iter.chain(other: Iter<T>) -> Iter<T>
+Iter.intersperse(separator: T) -> Iter<T>
+Iter.reversed() -> Iter<T>
+Iter.rev() -> Iter<T>
+Iter.enumerate() -> Iter<(Int, T)>
+Iter.zip<U>(other: Iter<U>) -> Iter<(T, U)>
+Iter.zip3<U, V>(other1: Iter<U>, other2: Iter<V>) -> Iter<(T, U, V)>
+Iter.chunked(size: Int) -> Iter<List<T>>
+Iter.chunks(size: Int) -> Iter<List<T>>
+Iter.windowed(size: Int, step: Int) -> Iter<List<T>>
+Iter.windows(size: Int, step: Int) -> Iter<List<T>>
+
+Iter.toList() -> List<T>
+Iter.collect() -> List<T>
+Iter.count() -> Int
+Iter.countWhere(f: fn(T) -> Bool) -> Int
+Iter.isEmpty() -> Bool
+Iter.first() -> T?
+Iter.last() -> T?
+Iter.single() -> T?
+Iter.nth(n: Int) -> T?
+Iter.contains(item: T) -> Bool
+Iter.find(f: fn(T) -> Bool) -> T?
+Iter.lastWhere(f: fn(T) -> Bool) -> T?
+Iter.findMap<U>(f: fn(T) -> U?) -> U?
+Iter.indexWhere(f: fn(T) -> Bool) -> Int?
+Iter.lastIndexWhere(f: fn(T) -> Bool) -> Int?
+Iter.any(f: fn(T) -> Bool) -> Bool
+Iter.all(f: fn(T) -> Bool) -> Bool
+Iter.forEach(f: fn(T) -> ())
+Iter.fold<U>(init: U, f: fn(U, T) -> U) -> U
+Iter.reduce(f: fn(T, T) -> T) -> T?
+Iter.scan<U>(init: U, f: fn(U, T) -> U) -> Iter<U>
+Iter.partition(f: fn(T) -> Bool) -> (List<T>, List<T>)
+```

--- a/internal/backend/stdlib_iter_check_test.go
+++ b/internal/backend/stdlib_iter_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultIter pins that std.iter's pure-Osty pipeline
+// helpers type-check cleanly. The implementation is currently eager
+// over List<T>, but the fluent surface should remain usable from
+// stdlib body injection.
+func TestStdlibCheckResultIter(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "iter")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(iter) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("iter module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/iter_test.go
+++ b/internal/stdlib/iter_test.go
@@ -1,0 +1,224 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestIterModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	if reg.Modules["iter"] == nil {
+		t.Fatal("stdlib iter module missing")
+	}
+	for _, d := range reg.Diags {
+		if d != nil && strings.Contains(d.Error(), "modules/iter.osty") {
+			t.Fatalf("stdlib iter diagnostic: %s", d.Error())
+		}
+	}
+
+	for _, name := range []string{"from", "empty", "range"} {
+		fn := reg.LookupFnDecl("iter", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(iter, %s) = nil, want stdlib helper", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("iter.%s body = nil, want pure-Osty helper body", name)
+		}
+	}
+
+	for _, name := range []string{
+		"map",
+		"filter",
+		"inspect",
+		"filterMap",
+		"mapWhile",
+		"flatMap",
+		"take",
+		"takeLast",
+		"takeWhile",
+		"skip",
+		"skipLast",
+		"skipWhile",
+		"stepBy",
+		"chain",
+		"intersperse",
+		"reversed",
+		"rev",
+		"enumerate",
+		"zip",
+		"zip3",
+		"chunked",
+		"chunks",
+		"windowed",
+		"windows",
+		"toList",
+		"collect",
+		"count",
+		"countWhere",
+		"isEmpty",
+		"first",
+		"last",
+		"single",
+		"nth",
+		"contains",
+		"find",
+		"lastWhere",
+		"findMap",
+		"indexWhere",
+		"lastIndexWhere",
+		"any",
+		"all",
+		"forEach",
+		"fold",
+		"reduce",
+		"scan",
+		"partition",
+	} {
+		fn := reg.LookupMethodDecl("iter", "Iter", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(iter, Iter, %s) = nil, want stdlib helper; methods=%s",
+				name, strings.Join(iterMethodNames(t), ", "))
+		}
+		if fn.Body == nil {
+			t.Fatalf("iter.Iter.%s body = nil, want pure-Osty helper body", name)
+		}
+	}
+}
+
+func TestIterHelpersArePinned(t *testing.T) {
+	src := iterModuleSource(t)
+	for _, want := range []string{
+		"pub fn inspect(self, f: fn(T) -> ()) -> Iter<T>",
+		"pub fn filterMap<U>(self, f: fn(T) -> U?) -> Iter<U>",
+		"match f(item)",
+		"pub fn mapWhile<U>(self, f: fn(T) -> U?) -> Iter<U>",
+		"if mapped.isNone()",
+		"pub fn flatMap<U>(self, f: fn(T) -> Iter<U>) -> Iter<U>",
+		"for value in mapped.items",
+		"pub fn takeLast(self, n: Int) -> Iter<T>",
+		"pub fn skipLast(self, n: Int) -> Iter<T>",
+		"pub fn skipWhile(self, f: fn(T) -> Bool) -> Iter<T>",
+		"pub fn stepBy(self, step: Int) -> Iter<T>",
+		"Iter.stepBy: step must be positive",
+		"pub fn intersperse(self, separator: T) -> Iter<T>",
+		"pub fn reversed(self) -> Iter<T>",
+		"pub fn rev(self) -> Iter<T>",
+		"pub fn enumerate(self) -> Iter<(Int, T)>",
+		"pub fn zip<U>(self, other: Iter<U>) -> Iter<(T, U)>",
+		"pub fn zip3<U, V>(self, other1: Iter<U>, other2: Iter<V>) -> Iter<(T, U, V)>",
+		"pub fn chunked(self, size: Int) -> Iter<List<T>>",
+		"pub fn chunks(self, size: Int) -> Iter<List<T>>",
+		"pub fn windowed(self, size: Int, step: Int) -> Iter<List<T>>",
+		"pub fn windows(self, size: Int, step: Int) -> Iter<List<T>>",
+		"out.push(self.items.drop(start).take(size))",
+		"pub fn collect(self) -> List<T>",
+		"pub fn countWhere(self, f: fn(T) -> Bool) -> Int",
+		"pub fn single(self) -> T?",
+		"pub fn nth(self, n: Int) -> T?",
+		"pub fn contains(self, item: T) -> Bool",
+		"pub fn lastWhere(self, f: fn(T) -> Bool) -> T?",
+		"pub fn findMap<U>(self, f: fn(T) -> U?) -> U?",
+		"pub fn indexWhere(self, f: fn(T) -> Bool) -> Int?",
+		"pub fn lastIndexWhere(self, f: fn(T) -> Bool) -> Int?",
+		"pub fn any(self, f: fn(T) -> Bool) -> Bool",
+		"pub fn all(self, f: fn(T) -> Bool) -> Bool",
+		"pub fn reduce(self, f: fn(T, T) -> T) -> T?",
+		"pub fn scan<U>(self, init: U, f: fn(U, T) -> U) -> Iter<U>",
+		"pub fn partition(self, f: fn(T) -> Bool) -> (List<T>, List<T>)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("iter module source missing %q", want)
+		}
+	}
+}
+
+func TestIterImportResolvesPipelineHelpers(t *testing.T) {
+	src := `
+use std.iter
+
+pub fn demo(xs: List<Int>, labels: List<String>) -> List<Int> {
+    let scanned = iter.from(xs)
+        .filter(|n| n >= 0)
+        .inspect(|n| { let _ = n })
+        .flatMap(|n| iter.from([n, n * 10]))
+        .skipWhile(|n| n < 3)
+        .stepBy(2)
+        .take(4)
+        .scan(0, |acc, n| acc + n)
+        .collect()
+    let _ = iter.from(xs).filterMap(|n| if n > 0 { Some(n.toString()) } else { None }).count()
+    let _ = iter.from(xs).mapWhile(|n| if n < 100 { Some(n * 2) } else { None }).toList()
+    let _ = iter.from(xs).takeLast(2).skipLast(1).toList()
+    let _ = iter.from(xs).reversed().rev().intersperse(0).toList()
+    let _ = iter.from(xs).enumerate().count()
+    let _ = iter.from(xs).zip(iter.from(labels)).count()
+    let _ = iter.from(xs).zip3(iter.from(labels), iter.from(xs)).count()
+    let _ = iter.from(xs).chunked(2).count()
+    let _ = iter.from(xs).chunks(2).count()
+    let _ = iter.from(xs).windowed(2, 1).count()
+    let _ = iter.from(xs).windows(2, 1).count()
+    let _ = iter.from(xs).countWhere(|n| n > 1)
+    let _ = iter.from(xs).single()
+    let _ = iter.from(xs).nth(1)
+    let _ = iter.from(xs).contains(3)
+    let _ = iter.from(xs).find(|n| n > 10)
+    let _ = iter.from(xs).lastWhere(|n| n > 10)
+    let _ = iter.from(xs).findMap(|n| if n > 0 { Some(n.toString()) } else { None })
+    let _ = iter.from(xs).indexWhere(|n| n > 10)
+    let _ = iter.from(xs).lastIndexWhere(|n| n > 10)
+    let _ = iter.from(xs).any(|n| n == 0)
+    let _ = iter.from(xs).all(|n| n >= 0)
+    let _ = iter.from(xs).reduce(|a, b| a + b)
+    let _ = iter.from(xs).partition(|n| n % 2 == 0)
+    scanned
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	res := resolve.ResolveFileDefault(file, Load())
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		t.Errorf("resolver rejected std.iter fixture: %s: %s", d.Code, d.Message)
+	}
+}
+
+func iterModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["iter"]
+	if mod == nil {
+		t.Fatal("stdlib iter module missing")
+	}
+	return string(mod.Source)
+}
+
+func iterMethodNames(t *testing.T) []string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["iter"]
+	if mod == nil || mod.File == nil {
+		return nil
+	}
+	var names []string
+	for _, decl := range mod.File.Decls {
+		structDecl, ok := decl.(*ast.StructDecl)
+		if !ok || structDecl.Name != "Iter" {
+			continue
+		}
+		for _, method := range structDecl.Methods {
+			if method != nil {
+				names = append(names, method.Name)
+			}
+		}
+	}
+	return names
+}

--- a/internal/stdlib/modules/iter.osty
+++ b/internal/stdlib/modules/iter.osty
@@ -6,6 +6,8 @@
 // semantics match `List<T>` methods but live behind the documented
 // fluent API so user code written against the spec works today.
 
+use std.process
+
 pub struct Iter<T> {
     items: List<T>,
 
@@ -27,6 +29,49 @@ pub struct Iter<T> {
         Iter { items: out }
     }
 
+    pub fn inspect(self, f: fn(T) -> ()) -> Iter<T> {
+        let mut out: List<T> = []
+        for item in self.items {
+            f(item)
+            out.push(item)
+        }
+        Iter { items: out }
+    }
+
+    pub fn filterMap<U>(self, f: fn(T) -> U?) -> Iter<U> {
+        let mut out: List<U> = []
+        for item in self.items {
+            match f(item) {
+                Some(value) -> out.push(value),
+                None -> {},
+            }
+        }
+        Iter { items: out }
+    }
+
+    pub fn mapWhile<U>(self, f: fn(T) -> U?) -> Iter<U> {
+        let mut out: List<U> = []
+        for item in self.items {
+            let mapped = f(item)
+            if mapped.isNone() {
+                break
+            }
+            out.push(mapped.unwrap())
+        }
+        Iter { items: out }
+    }
+
+    pub fn flatMap<U>(self, f: fn(T) -> Iter<U>) -> Iter<U> {
+        let mut out: List<U> = []
+        for item in self.items {
+            let mapped = f(item)
+            for value in mapped.items {
+                out.push(value)
+            }
+        }
+        Iter { items: out }
+    }
+
     pub fn take(self, n: Int) -> Iter<T> {
         let mut out: List<T> = []
         let mut i = 0
@@ -35,6 +80,18 @@ pub struct Iter<T> {
                 break
             }
             out.push(item)
+            i = i + 1
+        }
+        Iter { items: out }
+    }
+
+    pub fn takeLast(self, n: Int) -> Iter<T> {
+        let len = self.items.len()
+        let start = if n <= 0 { len } else if n >= len { 0 } else { len - n }
+        let mut out: List<T> = []
+        let mut i = start
+        for i < len {
+            out.push(self.items[i])
             i = i + 1
         }
         Iter { items: out }
@@ -64,6 +121,47 @@ pub struct Iter<T> {
         Iter { items: out }
     }
 
+    pub fn skipLast(self, n: Int) -> Iter<T> {
+        let len = self.items.len()
+        let limit = if n <= 0 { len } else if n >= len { 0 } else { len - n }
+        let mut out: List<T> = []
+        let mut i = 0
+        for i < limit {
+            out.push(self.items[i])
+            i = i + 1
+        }
+        Iter { items: out }
+    }
+
+    pub fn skipWhile(self, f: fn(T) -> Bool) -> Iter<T> {
+        let mut out: List<T> = []
+        let mut dropping = true
+        for item in self.items {
+            if dropping && !f(item) {
+                dropping = false
+            }
+            if !dropping {
+                out.push(item)
+            }
+        }
+        Iter { items: out }
+    }
+
+    pub fn stepBy(self, step: Int) -> Iter<T> {
+        if step <= 0 {
+            process.abort("Iter.stepBy: step must be positive, got {step}")
+        }
+        let mut out: List<T> = []
+        let mut i = 0
+        for item in self.items {
+            if i % step == 0 {
+                out.push(item)
+            }
+            i = i + 1
+        }
+        Iter { items: out }
+    }
+
     pub fn chain(self, other: Iter<T>) -> Iter<T> {
         let mut out: List<T> = []
         for item in self.items {
@@ -75,12 +173,238 @@ pub struct Iter<T> {
         Iter { items: out }
     }
 
+    pub fn intersperse(self, separator: T) -> Iter<T> {
+        let mut out: List<T> = []
+        let mut first = true
+        for item in self.items {
+            if first {
+                first = false
+            } else {
+                out.push(separator)
+            }
+            out.push(item)
+        }
+        Iter { items: out }
+    }
+
+    pub fn reversed(self) -> Iter<T> {
+        let mut out: List<T> = []
+        let mut i = self.items.len()
+        for i > 0 {
+            i = i - 1
+            out.push(self.items[i])
+        }
+        Iter { items: out }
+    }
+
+    pub fn rev(self) -> Iter<T> {
+        self.reversed()
+    }
+
+    pub fn enumerate(self) -> Iter<(Int, T)> {
+        let mut out: List<(Int, T)> = []
+        let mut i = 0
+        for item in self.items {
+            out.push((i, item))
+            i = i + 1
+        }
+        Iter { items: out }
+    }
+
+    pub fn zip<U>(self, other: Iter<U>) -> Iter<(T, U)> {
+        let mut out: List<(T, U)> = []
+        let limit = if self.items.len() < other.items.len() { self.items.len() } else { other.items.len() }
+        for i in 0..limit {
+            out.push((self.items[i], other.items[i]))
+        }
+        Iter { items: out }
+    }
+
+    pub fn zip3<U, V>(self, other1: Iter<U>, other2: Iter<V>) -> Iter<(T, U, V)> {
+        let mut limit = self.items.len()
+        if other1.items.len() < limit {
+            limit = other1.items.len()
+        }
+        if other2.items.len() < limit {
+            limit = other2.items.len()
+        }
+        let mut out: List<(T, U, V)> = []
+        for i in 0..limit {
+            out.push((self.items[i], other1.items[i], other2.items[i]))
+        }
+        Iter { items: out }
+    }
+
+    pub fn chunked(self, size: Int) -> Iter<List<T>> {
+        if size <= 0 {
+            process.abort("Iter.chunked: size must be positive, got {size}")
+        }
+        let mut out: List<List<T>> = []
+        let mut bucket: List<T> = []
+        for item in self.items {
+            bucket.push(item)
+            if bucket.len() >= size {
+                out.push(bucket)
+                bucket = []
+            }
+        }
+        if !bucket.isEmpty() {
+            out.push(bucket)
+        }
+        Iter { items: out }
+    }
+
+    pub fn chunks(self, size: Int) -> Iter<List<T>> {
+        self.chunked(size)
+    }
+
+    pub fn windowed(self, size: Int, step: Int) -> Iter<List<T>> {
+        if size <= 0 {
+            process.abort("Iter.windowed: size must be positive, got {size}")
+        }
+        if step <= 0 {
+            process.abort("Iter.windowed: step must be positive, got {step}")
+        }
+        let mut out: List<List<T>> = []
+        let len = self.items.len()
+        if size > len {
+            return Iter { items: out }
+        }
+        let mut start = 0
+        for start + size <= len {
+            out.push(self.items.drop(start).take(size))
+            start = start + step
+        }
+        Iter { items: out }
+    }
+
+    pub fn windows(self, size: Int, step: Int) -> Iter<List<T>> {
+        self.windowed(size, step)
+    }
+
     pub fn toList(self) -> List<T> {
         self.items
     }
 
+    pub fn collect(self) -> List<T> {
+        self.toList()
+    }
+
     pub fn count(self) -> Int {
         self.items.len()
+    }
+
+    pub fn countWhere(self, f: fn(T) -> Bool) -> Int {
+        let mut n = 0
+        for item in self.items {
+            if f(item) {
+                n = n + 1
+            }
+        }
+        n
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.items.isEmpty()
+    }
+
+    pub fn first(self) -> T? {
+        self.items.first()
+    }
+
+    pub fn last(self) -> T? {
+        self.items.last()
+    }
+
+    pub fn single(self) -> T? {
+        if self.items.len() == 1 {
+            return self.items.first()
+        }
+        None
+    }
+
+    pub fn nth(self, n: Int) -> T? {
+        if n < 0 {
+            return None
+        }
+        self.items.get(n)
+    }
+
+    pub fn contains(self, item: T) -> Bool {
+        self.items.contains(item)
+    }
+
+    pub fn find(self, f: fn(T) -> Bool) -> T? {
+        for item in self.items {
+            if f(item) {
+                return Some(item)
+            }
+        }
+        None
+    }
+
+    pub fn lastWhere(self, f: fn(T) -> Bool) -> T? {
+        let mut i = self.items.len()
+        for i > 0 {
+            i = i - 1
+            let item = self.items[i]
+            if f(item) {
+                return Some(item)
+            }
+        }
+        None
+    }
+
+    pub fn findMap<U>(self, f: fn(T) -> U?) -> U? {
+        for item in self.items {
+            match f(item) {
+                Some(value) -> {
+                    return Some(value)
+                },
+                None -> {},
+            }
+        }
+        None
+    }
+
+    pub fn indexWhere(self, f: fn(T) -> Bool) -> Int? {
+        let mut i = 0
+        for item in self.items {
+            if f(item) {
+                return Some(i)
+            }
+            i = i + 1
+        }
+        None
+    }
+
+    pub fn lastIndexWhere(self, f: fn(T) -> Bool) -> Int? {
+        let mut i = self.items.len()
+        for i > 0 {
+            i = i - 1
+            if f(self.items[i]) {
+                return Some(i)
+            }
+        }
+        None
+    }
+
+    pub fn any(self, f: fn(T) -> Bool) -> Bool {
+        for item in self.items {
+            if f(item) {
+                return true
+            }
+        }
+        false
+    }
+
+    pub fn all(self, f: fn(T) -> Bool) -> Bool {
+        for item in self.items {
+            if !f(item) {
+                return false
+            }
+        }
+        true
     }
 
     pub fn forEach(self, f: fn(T) -> ()) {
@@ -95,6 +419,52 @@ pub struct Iter<T> {
             acc = f(acc, item)
         }
         acc
+    }
+
+    pub fn reduce(self, f: fn(T, T) -> T) -> T? {
+        if self.items.isEmpty() {
+            return None
+        }
+        let mut first: T? = None
+        let mut tail: List<T> = []
+        let mut seenFirst = false
+        for item in self.items {
+            if !seenFirst {
+                first = Some(item)
+                seenFirst = true
+            } else {
+                tail.push(item)
+            }
+        }
+        let acc = first.unwrap()
+        let mut out = acc
+        for item in tail {
+            out = f(out, item)
+        }
+        Some(out)
+    }
+
+    pub fn scan<U>(self, init: U, f: fn(U, T) -> U) -> Iter<U> {
+        let mut out: List<U> = [init]
+        let mut acc = init
+        for item in self.items {
+            acc = f(acc, item)
+            out.push(acc)
+        }
+        Iter { items: out }
+    }
+
+    pub fn partition(self, f: fn(T) -> Bool) -> (List<T>, List<T>) {
+        let mut yes: List<T> = []
+        let mut no: List<T> = []
+        for item in self.items {
+            if f(item) {
+                yes.push(item)
+            } else {
+                no.push(item)
+            }
+        }
+        (yes, no)
     }
 }
 


### PR DESCRIPTION
## Summary
- Expand `std.iter` with a broad eager `List<T>`-backed iterator helper surface.
- Add adapters and terminals such as `filterMap`, `mapWhile`, `flatMap`, `stepBy`, `chunked`, `windowed`, `findMap`, `indexWhere`, `reduce`, `scan`, and `partition`.
- Update the standard library spec and pin resolver/checker coverage for the new surface.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestIter'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultIter'`
- `git diff --check`
- `just short`