### PR TITLE
feat(runtime): map + set lock-free trace via deferred-free queue (Phase 0j + 0k)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3485,6 +3485,164 @@ int main(void) {
 	}
 }
 
+// TestBundledRuntimeMapAndSetLockfreeTraceWithDeferredFree covers
+// Phase 0j (Map) and Phase 0k (Set) — both kinds flip
+// `trace_lockfree_safe = true`. Their grow paths route old keys /
+// values / items arrays through `osty_gc_defer_or_free` so a
+// concurrent marker reading those buffers sees them stay alive
+// for the duration of its trace. The test allocates a map and a
+// set, starts a cycle, then mid-cycle inserts force realloc + defer
+// on both backing arrays.
+func TestBundledRuntimeMapAndSetLockfreeTraceWithDeferredFree(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_map_set_lockfree_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_map_set_lockfree_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+#define OSTY_RT_ABI_PTR 4
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, void *value_trace);
+void osty_rt_map_insert_ptr(void *raw_map, void *key, const void *value);
+
+void *osty_rt_set_new(int64_t elem_kind);
+bool osty_rt_set_insert_ptr(void *raw_set, void *item);
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+bool osty_gc_collect_incremental_step(int64_t budget);
+void osty_gc_collect_incremental_finish(void);
+
+int64_t osty_gc_debug_state(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_deferred_free_queued_total(void);
+int64_t osty_gc_debug_deferred_free_drained_total(void);
+int64_t osty_gc_debug_lockfree_trace_total(void);
+
+int main(void) {
+    /* Map (PTR -> PTR) and Set (PTR), seeded with a small number of
+     * entries so the first insert pre-cycle establishes heap-backed
+     * storage and a subsequent insert grows it. */
+    void *map = osty_rt_map_new(OSTY_RT_ABI_PTR, OSTY_RT_ABI_PTR,
+                                (int64_t)sizeof(void *), NULL);
+    osty_gc_root_bind_v1(map);
+    void *set = osty_rt_set_new(OSTY_RT_ABI_PTR);
+    osty_gc_root_bind_v1(set);
+
+    enum { PRE = 12 };
+    void *map_keys[PRE], *map_values[PRE], *set_items[PRE];
+    for (int i = 0; i < PRE; i++) {
+        map_keys[i] = osty_gc_alloc_v1(7, 16, "k");
+        map_values[i] = osty_gc_alloc_v1(7, 16, "v");
+        osty_rt_map_insert_ptr(map, map_keys[i], &map_values[i]);
+        set_items[i] = osty_gc_alloc_v1(7, 16, "item");
+        osty_rt_set_insert_ptr(set, set_items[i]);
+    }
+
+    long long queued_before  = (long long)osty_gc_debug_deferred_free_queued_total();
+    long long drained_before = (long long)osty_gc_debug_deferred_free_drained_total();
+    long long lockfree_before = (long long)osty_gc_debug_lockfree_trace_total();
+
+    osty_gc_collect_incremental_start_with_stack_roots(NULL, 0);
+
+    /* Mid-cycle inserts to force realloc + defer-free on both
+     * containers. The doubling cap means a few inserts trigger a
+     * grow; we do 30 to be safely past the next-power-of-two
+     * boundary. */
+    enum { MID = 30 };
+    void *mid_map_keys[MID], *mid_map_values[MID], *mid_set_items[MID];
+    for (int i = 0; i < MID; i++) {
+        mid_map_keys[i] = osty_gc_alloc_v1(7, 16, "mk");
+        mid_map_values[i] = osty_gc_alloc_v1(7, 16, "mv");
+        osty_rt_map_insert_ptr(map, mid_map_keys[i], &mid_map_values[i]);
+        mid_set_items[i] = osty_gc_alloc_v1(7, 16, "mitem");
+        osty_rt_set_insert_ptr(set, mid_set_items[i]);
+    }
+
+    while (osty_gc_collect_incremental_step(100)) {}
+    osty_gc_collect_incremental_finish();
+
+    long long queued_after  = (long long)osty_gc_debug_deferred_free_queued_total();
+    long long drained_after = (long long)osty_gc_debug_deferred_free_drained_total();
+    long long lockfree_after = (long long)osty_gc_debug_lockfree_trace_total();
+    long long state         = (long long)osty_gc_debug_state();
+    long long live          = (long long)osty_gc_debug_live_count();
+
+    printf("queued_delta=%lld drained_delta=%lld lockfree_delta=%lld state=%lld live=%lld\n",
+        queued_after - queued_before,
+        drained_after - drained_before,
+        lockfree_after - lockfree_before,
+        state, live);
+
+    osty_gc_root_release_v1(map);
+    osty_gc_root_release_v1(set);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-lz", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_ASSIST_BYTES_PER_UNIT=0")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	out := string(runOutput)
+	if !strings.Contains(out, "state=0 ") {
+		t.Fatalf("state!=IDLE; full output:\n%s", out)
+	}
+	/* live count: map + set + (PRE+MID) keys + (PRE+MID) values
+	 *           + (PRE+MID) items = 2 + 3*(12+30) = 128. */
+	if !strings.Contains(out, "live=128") {
+		t.Fatalf("live count wrong (want 128); full output:\n%s", out)
+	}
+	var queuedDelta, drainedDelta, lockfreeDelta, state, live int64
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "queued_delta=") {
+			continue
+		}
+		if _, err := fmt.Sscanf(line,
+			"queued_delta=%d drained_delta=%d lockfree_delta=%d state=%d live=%d",
+			&queuedDelta, &drainedDelta, &lockfreeDelta, &state, &live); err != nil {
+			t.Fatalf("could not parse %q: %v", line, err)
+		}
+		break
+	}
+	if queuedDelta < 1 {
+		t.Fatalf("queued_delta=%d, want >=1 (mid-cycle realloc should defer at least one buffer)\nfull output:\n%s",
+			queuedDelta, out)
+	}
+	if drainedDelta != queuedDelta {
+		t.Fatalf("drained_delta=%d != queued_delta=%d (finish should drain the queue exactly)\nfull output:\n%s",
+			drainedDelta, queuedDelta, out)
+	}
+	if lockfreeDelta < 1 {
+		t.Fatalf("lockfree_delta=%d, want >=1 (map/set traces must dispatch lockfree)\nfull output:\n%s",
+			lockfreeDelta, out)
+	}
+}
+
 // TestBundledRuntimeListLockfreeTraceWithDeferredFree covers Phase 0i —
 // LIST kind now flips to trace_lockfree_safe and `osty_rt_list_reserve`
 // always allocates a new buffer + memcpys + defers the old buffer's

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -830,6 +830,13 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .trace = osty_rt_map_trace,
         .destroy = osty_rt_map_destroy,
         .young_eligible = true,
+        /* Phase 0j: map_trace ACQUIRE-loads keys/values/len, and
+         * map_reserve defers the old keys/values arrays through
+         * `osty_gc_defer_or_free` so the marker iterates a stable
+         * buffer for the duration of its trace. Index_slots and
+         * index_hashes are auxiliary lookup data not consulted
+         * during trace, so their realloc path stays as-is. */
+        .trace_lockfree_safe = true,
         .cleanup_young_dead = osty_gc_cleanup_young_dead_map,
         .remap = osty_gc_remap_map_payload,
     },
@@ -837,6 +844,11 @@ static const osty_gc_kind_descriptor osty_gc_kind_table[] = {
         .trace = osty_rt_set_trace,
         .destroy = osty_rt_set_destroy,
         .young_eligible = true,
+        /* Phase 0k: set_trace ACQUIRE-loads items/len, and
+         * set_reserve defers the old items array through
+         * `osty_gc_defer_or_free` so the marker iterates a stable
+         * buffer for the duration of its trace. */
+        .trace_lockfree_safe = true,
         .cleanup_young_dead = osty_gc_cleanup_young_dead_set,
         .remap = osty_gc_remap_set_payload,
     },
@@ -5347,9 +5359,25 @@ static void osty_rt_map_trace(void *payload) {
     if (map == NULL) {
         return;
     }
-    for (i = 0; i < map->len; i++) {
-        unsigned char *key_slot = map->keys + ((size_t)i * osty_rt_kind_size(map->key_kind));
-        unsigned char *value_slot = map->values + ((size_t)i * map->value_size);
+    /* Phase 0j: ACQUIRE-load `keys`, `values`, and `len` once at
+     * trace entry so a concurrent insert that grows the backing
+     * arrays mid-trace doesn't tear our view. Pairs with the
+     * RELEASE store in `osty_rt_map_reserve`. The old buffers stay
+     * alive via the deferred-free queue. `key_kind`, `value_kind`,
+     * `value_size`, `value_trace` are immutable after map creation
+     * so plain loads are fine. */
+    unsigned char *keys = (unsigned char *)__atomic_load_n(
+        (void **)&map->keys, __ATOMIC_ACQUIRE);
+    unsigned char *values = (unsigned char *)__atomic_load_n(
+        (void **)&map->values, __ATOMIC_ACQUIRE);
+    int64_t len = __atomic_load_n(&map->len, __ATOMIC_ACQUIRE);
+    if (keys == NULL || values == NULL || len <= 0) {
+        return;
+    }
+    size_t key_size = osty_rt_kind_size(map->key_kind);
+    for (i = 0; i < len; i++) {
+        unsigned char *key_slot = keys + ((size_t)i * key_size);
+        unsigned char *value_slot = values + ((size_t)i * map->value_size);
         if (map->key_kind == OSTY_RT_ABI_STRING || map->key_kind == OSTY_RT_ABI_PTR) {
             osty_gc_mark_slot_v1((void *)key_slot);
         }
@@ -5387,9 +5415,19 @@ static void osty_rt_set_trace(void *payload) {
     if (set == NULL || (set->elem_kind != OSTY_RT_ABI_STRING && set->elem_kind != OSTY_RT_ABI_PTR)) {
         return;
     }
+    /* Phase 0k: ACQUIRE-load `items` and `len` once at trace entry.
+     * Pairs with the RELEASE store in `osty_rt_set_reserve`. The
+     * old buffer stays alive via the deferred-free queue.
+     * `elem_kind` is immutable after set creation. */
+    unsigned char *items = (unsigned char *)__atomic_load_n(
+        (void **)&set->items, __ATOMIC_ACQUIRE);
+    int64_t len = __atomic_load_n(&set->len, __ATOMIC_ACQUIRE);
+    if (items == NULL || len <= 0) {
+        return;
+    }
     elem_size = osty_rt_kind_size(set->elem_kind);
-    for (i = 0; i < set->len; i++) {
-        osty_gc_mark_slot_v1((void *)(set->items + ((size_t)i * elem_size)));
+    for (i = 0; i < len; i++) {
+        osty_gc_mark_slot_v1((void *)(items + ((size_t)i * elem_size)));
     }
 }
 
@@ -10237,12 +10275,39 @@ static void osty_rt_map_reserve(osty_rt_map *map, int64_t min_cap) {
     }
     key_bytes = (size_t)next_cap * osty_rt_kind_size(map->key_kind);
     value_bytes = (size_t)next_cap * map->value_size;
-    map->keys = (unsigned char *)realloc(map->keys, key_bytes);
-    map->values = (unsigned char *)realloc(map->values, value_bytes);
-    if (map->keys == NULL || map->values == NULL) {
+    /* Phase 0j: malloc+memcpy+defer-free instead of realloc so a
+     * concurrent marker reading the old keys/values arrays sees a
+     * stable buffer for the duration of its trace. The old buffer
+     * lands in the deferred-free queue (drained at finish_locked
+     * end). RELEASE-store on the field so the marker's ACQUIRE-load
+     * either observes the old pointer (still alive in queue) or the
+     * new pointer (with all old contents memcpy'd in). */
+    unsigned char *new_keys = (unsigned char *)malloc(key_bytes);
+    unsigned char *new_values = (unsigned char *)malloc(value_bytes);
+    if (new_keys == NULL || new_values == NULL) {
         osty_rt_abort("out of memory");
     }
+    if (map->len > 0) {
+        if (map->keys != NULL) {
+            memcpy(new_keys, map->keys,
+                   (size_t)map->len * osty_rt_kind_size(map->key_kind));
+        }
+        if (map->values != NULL) {
+            memcpy(new_values, map->values,
+                   (size_t)map->len * map->value_size);
+        }
+    }
+    unsigned char *old_keys = map->keys;
+    unsigned char *old_values = map->values;
+    __atomic_store_n((void **)&map->keys, new_keys, __ATOMIC_RELEASE);
+    __atomic_store_n((void **)&map->values, new_values, __ATOMIC_RELEASE);
     map->cap = next_cap;
+    if (old_keys != NULL) {
+        osty_gc_defer_or_free(old_keys);
+    }
+    if (old_values != NULL) {
+        osty_gc_defer_or_free(old_values);
+    }
 }
 
 static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_linear(osty_rt_map *map, const void *key) {
@@ -10848,11 +10913,26 @@ static void osty_rt_set_reserve(osty_rt_set *set, int64_t min_cap) {
         next_cap *= 2;
     }
     bytes = (size_t)next_cap * osty_rt_kind_size(set->elem_kind);
-    set->items = (unsigned char *)realloc(set->items, bytes);
-    if (set->items == NULL) {
+    /* Phase 0k: malloc + memcpy + defer-free instead of realloc so
+     * a concurrent marker reading the old `items` array sees a
+     * stable buffer for the duration of its trace. RELEASE-store on
+     * the field so the marker's ACQUIRE-load either observes the
+     * old pointer (still alive in queue) or the new pointer (with
+     * old contents memcpy'd in). */
+    unsigned char *new_items = (unsigned char *)malloc(bytes);
+    if (new_items == NULL) {
         osty_rt_abort("out of memory");
     }
+    if (set->len > 0 && set->items != NULL) {
+        memcpy(new_items, set->items,
+               (size_t)set->len * osty_rt_kind_size(set->elem_kind));
+    }
+    unsigned char *old_items = set->items;
+    __atomic_store_n((void **)&set->items, new_items, __ATOMIC_RELEASE);
     set->cap = next_cap;
+    if (old_items != NULL) {
+        osty_gc_defer_or_free(old_items);
+    }
 }
 
 static int64_t osty_rt_set_find_index(osty_rt_set *set, const void *item) {


### PR DESCRIPTION
## Summary

MAP and SET join LIST (#1037) as container kinds whose tracers can run with `osty_gc_lock` released. Same Phase 0i pattern — kill the in-place realloc on the grow path, malloc + memcpy + RELEASE-store the new buffer, route the old buffer through `osty_gc_defer_or_free`. The deferred-free queue (introduced in #1037) handles both kinds without changes.

> Stacked on **#1037**. Once that merges, this PR's diff against main will become trivially clean.

## Phase 0j — Map

- `osty_rt_map_reserve` replaces `realloc(keys) + realloc(values)` with `malloc + memcpy + defer-free` for both arrays. RELEASE on each pointer store.
- `osty_rt_map_trace` ACQUIRE-loads `keys / values / len` once at entry. `key_kind`, `value_kind`, `value_size`, `value_trace` are immutable after `osty_rt_map_new`.
- `index_slots / index_hashes` are NOT touched by the tracer (linear iteration through `keys/values[0..len]`), so their existing realloc/free path stays unchanged.

The marker may briefly observe an inconsistent (new `keys`, old `values`) state when reserve grows in two RELEASE stores. That's fine because both arrays at iteration index `i` either reference live objects (alloc-as-BLACK during cycle, Phase 0e) or untouched-past-len slots. SATB on slot overwrites still covers reachability for the overwritten values.

## Phase 0k — Set

Direct port of the list pattern — `items` is the only backing array. `elem_kind` immutable.

## Channel stays locked

Its slot ring uses mutex+cond and head/tail counters that mutate on every send/receive — harder to define a safe trace snapshot. Probably never lock-free without more design.

## Test plan

- [x] **New** `TestBundledRuntimeMapAndSetLockfreeTraceWithDeferredFree` — PTR→PTR map and PTR set, 12-entry seed each, mid-cycle inserts 30 more, asserts queued >= 1, drained == queued, lockfree >= 1, live = 128
- [x] All Phase 0a–0i tests pass unchanged
- [x] `TestBundledRuntimeIncremental*` pass
- [x] `TestBundledRuntimeMap*` pass (existing map tests unchanged)
- [x] `TestBundledRuntimeSet*` pass
- [x] `go test ./internal/backend/` green (61s)
- [x] 3x repeated runs no flake

## State of concurrent-GC after this lands

| Kind | Lockfree trace? | Mechanism |
|---|---|---|
| `LIST` | ✅ | Phase 0i deferred-free + atomic snapshot |
| `MAP` | ✅ | Phase 0j deferred-free + atomic snapshot |
| `SET` | ✅ | Phase 0k deferred-free + atomic snapshot |
| `CLOSURE_ENV` | ✅ | Phase 0h (fixed-layout, no realloc) |
| `GENERIC_ENUM_PTR` | ✅ | Phase 0h (single ptr slot) |
| `GENERIC_TASK_HANDLE` / `NONE` | ✅ | Phase 0h (no trace fn) |
| `CHANNEL` | ❌ | indefinitely locked — slot ring + mutex+cond |

Every kind that has a trace function and could plausibly hold managed pointers now traces concurrently with the mutator. The remaining `CHANNEL` exception is unlikely to ship — channels are rarely the bottleneck for trace work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)