### PR TITLE
[codex] Reduce native gen test loop latency

### DIFF
--- a/internal/nativellvmgen/exec_test.go
+++ b/internal/nativellvmgen/exec_test.go
@@ -2,13 +2,21 @@ package nativellvmgen
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/osty/osty/internal/resolve"
+)
+
+var (
+	fakeNativeLLVMGenOnce sync.Once
+	fakeNativeLLVMGenPath string
+	fakeNativeLLVMGenErr  error
 )
 
 func TestTrySourceUsesEnvBinaryAndDecodesResponse(t *testing.T) {
@@ -107,10 +115,23 @@ func TestTryPackageUsesManagedBinaryWhenEnvUnset(t *testing.T) {
 func buildFakeNativeLLVMGen(t *testing.T) string {
 	t.Helper()
 
-	dir := t.TempDir()
+	fakeNativeLLVMGenOnce.Do(func() {
+		fakeNativeLLVMGenPath, fakeNativeLLVMGenErr = buildFakeNativeLLVMGenOnce()
+	})
+	if fakeNativeLLVMGenErr != nil {
+		t.Fatal(fakeNativeLLVMGenErr)
+	}
+	return fakeNativeLLVMGenPath
+}
+
+func buildFakeNativeLLVMGenOnce() (string, error) {
+	dir, err := os.MkdirTemp("", "fake-native-llvmgen-*")
+	if err != nil {
+		return "", fmt.Errorf("mktemp: %w", err)
+	}
 	src := filepath.Join(dir, "main.go")
 	if err := os.WriteFile(src, []byte(fakeNativeLLVMGenProgram), 0o644); err != nil {
-		t.Fatalf("write fake native llvmgen: %v", err)
+		return "", fmt.Errorf("write fake native llvmgen: %w", err)
 	}
 	name := "fake-native-llvmgen"
 	if runtime.GOOS == "windows" {
@@ -120,9 +141,9 @@ func buildFakeNativeLLVMGen(t *testing.T) string {
 	cmd := exec.Command("go", "build", "-o", bin, src)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("go build fake native llvmgen: %v\n%s", err, out)
+		return "", fmt.Errorf("go build fake native llvmgen: %w\n%s", err, out)
 	}
-	return bin
+	return bin, nil
 }
 
 func decodeCapturedRequest(t *testing.T, path string, out any) {

--- a/internal/pipeline/pipeline_gen_test.go
+++ b/internal/pipeline/pipeline_gen_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestRunLoadedPackageGenUsesPackageLoweringForSiblingFiles(t *testing.T) {
+	forcePipelineGenFallback(t)
+
 	dir := t.TempDir()
 	writePipelineTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
 	writePipelineTestFile(t, dir, "b.osty", "fn main() { println(helper()) }\n")
@@ -35,6 +37,8 @@ func TestRunLoadedPackageGenUsesPackageLoweringForSiblingFiles(t *testing.T) {
 }
 
 func TestRunWorkspaceGenAggregatesPerPackageModules(t *testing.T) {
+	forcePipelineGenFallback(t)
+
 	root := t.TempDir()
 	alpha := filepath.Join(root, "alpha")
 	beta := filepath.Join(root, "beta")
@@ -135,4 +139,13 @@ func writePipelineTestFile(t *testing.T, dir, name, contents string) string {
 		t.Fatalf("write %s: %v", path, err)
 	}
 	return path
+}
+
+func forcePipelineGenFallback(t *testing.T) {
+	t.Helper()
+	oldTry := tryExternalPipelineLLVMIR
+	tryExternalPipelineLLVMIR = func(string, *resolve.Package) ([]byte, bool, []error, error) {
+		return nil, false, nil, nil
+	}
+	t.Cleanup(func() { tryExternalPipelineLLVMIR = oldTry })
 }


### PR DESCRIPTION
## Summary

- Reuse the fake native-llvmgen helper binary across `internal/nativellvmgen` tests instead of rebuilding it for each case.
- Force pipeline package/workspace gen fallback tests onto the fallback path so they do not pay for external native-llvmgen setup already covered by neighboring tests.

## Impact

This keeps the same behavior coverage while reducing repeated local verification latency after PR #1050.

## Validation

- `go test -count=1 -vet=off -short ./internal/nativellvmgen` passed in about 1.53s.
- `go test -count=1 -vet=off -short ./internal/pipeline` passed in about 1.33s.
- Full short target passed; stable rerun measured about 12.57s after a 31.65s post-merge baseline.