### PR TITLE
[codex] Make selfhost resolver result canonical

### DIFF
--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -2,7 +2,6 @@ package check
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
@@ -12,7 +11,7 @@ import (
 func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider, layout selfhostCheckedSource) selfhost.PackageCheckInput {
 	input := selfhost.PackageCheckInput{
 		Files:   make([]selfhost.PackageCheckFile, 0, len(layout.files)),
-		Imports: selfhostPackageImportSurfaces(pkg, ws, stdlib),
+		Imports: resolve.PackageImportSurfaces(pkg, ws, stdlib),
 	}
 	segmentIdx := 0
 	for _, pf := range pkg.Files {
@@ -44,7 +43,7 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 
 func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.StdlibProvider) selfhost.PackageCheckInput {
 	input := selfhost.PackageCheckInput{
-		Imports: selfhostUsesImportSurfaces(fileUses(file), nil, stdlib),
+		Imports: resolve.PackageImportSurfacesForUses(fileUses(file), nil, stdlib),
 	}
 	if len(src) == 0 {
 		return input
@@ -56,155 +55,14 @@ func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.Std
 	return input
 }
 
-// selfhostPackageImportSurfaces aggregates cross-package import surfaces
-// for pkg by walking each `use` decl's target package's AstArena. It
-// supersedes the *ast.File.Decls-based walker that used to live in this
-// file — the workspace `--native` path lands here and must not trigger
-// astbridge lowering. See LLVM_MIGRATION_PLAN.md § "Workspace --native".
+// selfhostPackageImportSurfaces is kept for tests and external adapters in
+// this package; the resolver owns the actual import-surface contract.
 func selfhostPackageImportSurfaces(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
-	if pkg == nil {
-		return nil
-	}
-	seen := map[string]string{}
-	var out []selfhost.PackageCheckImport
-	for _, pf := range pkg.Files {
-		if pf == nil {
-			continue
-		}
-		run := runForPackageFile(pf)
-		if run == nil {
-			continue
-		}
-		for _, use := range selfhost.PackageUsesFromRun(run) {
-			if use.IsGo || use.Alias == "" {
-				continue
-			}
-			targetPath := use.Path
-			importAlias := use.Alias
-			if use.IsScoped {
-				targetPath = use.ScopedBase
-				importAlias = lastPathSegment(targetPath)
-			}
-			target := selfhostLookupPackageImportByPath(targetPath, ws, stdlib)
-			if target == nil {
-				continue
-			}
-			key := targetPath
-			if prev, ok := seen[importAlias]; ok {
-				if prev == key {
-					continue
-				}
-				continue
-			}
-			seen[importAlias] = key
-			out = append(out, selfhost.PackageImportSurface(targetPath, importAlias, runsForPackage(target)))
-		}
-	}
-	return out
+	return resolve.PackageImportSurfaces(pkg, ws, stdlib)
 }
 
-// selfhostUsesImportSurfaces serves the single-file check path (caller
-// already holds a parsed *ast.File). It delegates the actual surface
-// walk to selfhost.PackageImportSurface so the shape matches the
-// package-mode path exactly — only the alias-resolution source differs.
+// selfhostUsesImportSurfaces serves older package-local call sites; new code
+// should call resolve.PackageImportSurfacesForUses directly.
 func selfhostUsesImportSurfaces(uses []*ast.UseDecl, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
-	seen := map[string]string{}
-	var out []selfhost.PackageCheckImport
-	for _, use := range uses {
-		targetPath := strings.Join(use.Path, ".")
-		importAlias := selfhostUseAlias(use)
-		if use.IsScoped {
-			targetPath = strings.Join(use.ScopedBase, ".")
-			importAlias = lastPathSegment(targetPath)
-		}
-		target := selfhostLookupPackageImportByPath(targetPath, ws, stdlib)
-		if target == nil {
-			continue
-		}
-		if importAlias == "" {
-			continue
-		}
-		key := targetPath
-		if prev, ok := seen[importAlias]; ok {
-			if prev == key {
-				continue
-			}
-			continue
-		}
-		seen[importAlias] = key
-		out = append(out, selfhost.PackageImportSurface(key, importAlias, runsForPackage(target)))
-	}
-	return out
-}
-
-func selfhostLookupPackageImport(use *ast.UseDecl, ws *resolve.Workspace, stdlib resolve.StdlibProvider) *resolve.Package {
-	if use == nil {
-		return nil
-	}
-	return selfhostLookupPackageImportByPath(strings.Join(use.Path, "."), ws, stdlib)
-}
-
-func selfhostLookupPackageImportByPath(dotPath string, ws *resolve.Workspace, stdlib resolve.StdlibProvider) *resolve.Package {
-	if dotPath == "" {
-		return nil
-	}
-	if ws != nil {
-		if target := ws.Packages[dotPath]; target != nil {
-			return target
-		}
-		if ws.Stdlib != nil {
-			if target := ws.Stdlib.LookupPackage(dotPath); target != nil {
-				return target
-			}
-		}
-	}
-	if stdlib != nil {
-		return stdlib.LookupPackage(dotPath)
-	}
-	return nil
-}
-
-func selfhostUseAlias(use *ast.UseDecl) string {
-	if use == nil {
-		return ""
-	}
-	if use.Alias != "" {
-		return use.Alias
-	}
-	if len(use.Path) == 0 {
-		return ""
-	}
-	return use.Path[len(use.Path)-1]
-}
-
-// runForPackageFile materializes a selfhost FrontendRun for pf without
-// forcing *ast.File lowering. Files loaded via resolve.LoadPackageForNative
-// already carry Run; legacy-loaded files (notably stdlib fixtures) are
-// re-parsed from Source here. Both cases stay astbridge-free — parse
-// cost for the legacy case is comparable to the original
-// *ast.File.Decls walk it replaces.
-func runForPackageFile(pf *resolve.PackageFile) *selfhost.FrontendRun {
-	if pf == nil {
-		return nil
-	}
-	if pf.Run != nil {
-		return pf.Run
-	}
-	if len(pf.Source) == 0 {
-		return nil
-	}
-	return selfhost.Run(pf.Source)
-}
-
-func runsForPackage(pkg *resolve.Package) []*selfhost.FrontendRun {
-	if pkg == nil {
-		return nil
-	}
-	runs := make([]*selfhost.FrontendRun, 0, len(pkg.Files))
-	for _, pf := range pkg.Files {
-		if run := runForPackageFile(pf); run != nil {
-			runs = append(runs, run)
-		}
-	}
-	return runs
+	return resolve.PackageImportSurfacesForUses(uses, ws, stdlib)
 }

--- a/internal/resolve/cycle_detection_test.go
+++ b/internal/resolve/cycle_detection_test.go
@@ -132,6 +132,53 @@ func TestWorkspaceDetectsReexportCycleTwoPackage(t *testing.T) {
 	}
 }
 
+func TestWorkspaceDetectsCycleThroughScopedUse(t *testing.T) {
+	root := t.TempDir()
+	pkgA := filepath.Join(root, "alpha")
+	pkgB := filepath.Join(root, "beta")
+	if err := os.MkdirAll(pkgA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pkgB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgA, "lib.osty"), []byte(`use beta::{world}
+
+pub fn hello() -> Int { world() }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgB, "lib.osty"), []byte(`use alpha::{hello}
+
+pub fn world() -> Int { hello() }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	for _, p := range WorkspacePackagePaths(root) {
+		if _, err := ws.LoadPackageArenaFirst(p); err != nil {
+			t.Fatalf("LoadPackage %s: %v", p, err)
+		}
+	}
+	results := ws.ResolveAll()
+
+	for _, pr := range results {
+		if pr == nil {
+			continue
+		}
+		for _, d := range pr.Diags {
+			if d.Code == diag.CodeCyclicImport {
+				return
+			}
+		}
+	}
+	t.Fatalf("expected %s for scoped-use cycle, got %#v", diag.CodeCyclicImport, results)
+}
+
 // Three-package cycle: alpha → beta → gamma → alpha. Exactly one
 // back-edge should emit E0506 (the gamma → alpha edge closes the cycle
 // during DFS starting from alpha).

--- a/internal/resolve/import_surface.go
+++ b/internal/resolve/import_surface.go
@@ -1,0 +1,218 @@
+package resolve
+
+import (
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+type importUseRef struct {
+	path       string
+	alias      string
+	isGo       bool
+	isScoped   bool
+	scopedBase string
+}
+
+// PackageImportSurfaces returns the resolver-owned import contract for pkg.
+// The selfhost resolver and checker both consume this surface so package
+// export shape is decided in one place instead of being rebuilt by downstream
+// passes from resolver internals.
+func PackageImportSurfaces(pkg *Package, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+	if pkg == nil {
+		return nil
+	}
+	return packageImportSurfacesFromRefs(packageImportUseRefs(pkg), ws, stdlib)
+}
+
+// PackageImportSurfacesForUses is the single-file sibling of
+// PackageImportSurfaces. It exists for file-mode checker calls that already
+// hold a parsed public AST rather than a Package.
+func PackageImportSurfacesForUses(uses []*ast.UseDecl, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+	if len(uses) == 0 {
+		return nil
+	}
+	refs := make([]importUseRef, 0, len(uses))
+	for _, use := range uses {
+		if ref, ok := importUseRefFromAST(use); ok {
+			refs = append(refs, ref)
+		}
+	}
+	return packageImportSurfacesFromRefs(refs, ws, stdlib)
+}
+
+// PackageExportSurface projects one resolved package into the selfhost
+// package-import surface used by both resolve and check.
+func PackageExportSurface(importPath, alias string, pkg *Package) selfhost.PackageCheckImport {
+	return selfhost.PackageImportSurface(importPath, alias, packageFrontendRuns(pkg))
+}
+
+func packageImportUseRefs(pkg *Package) []importUseRef {
+	var refs []importUseRef
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		if pf.Run != nil {
+			for _, use := range selfhost.PackageUsesFromRun(pf.Run) {
+				if ref, ok := importUseRefFromSelfhost(use); ok {
+					refs = append(refs, ref)
+				}
+			}
+			continue
+		}
+		if pf.File != nil {
+			for _, use := range pf.File.Uses {
+				if ref, ok := importUseRefFromAST(use); ok {
+					refs = append(refs, ref)
+				}
+			}
+			continue
+		}
+		if len(pf.Source) > 0 {
+			run := selfhost.Run(pf.Source)
+			for _, use := range selfhost.PackageUsesFromRun(run) {
+				if ref, ok := importUseRefFromSelfhost(use); ok {
+					refs = append(refs, ref)
+				}
+			}
+		}
+	}
+	return refs
+}
+
+func importUseRefFromSelfhost(use selfhost.PackageUseRef) (importUseRef, bool) {
+	if use.IsGo || use.Path == "" {
+		return importUseRef{}, false
+	}
+	ref := importUseRef{
+		path:       use.Path,
+		alias:      use.Alias,
+		isGo:       use.IsGo,
+		isScoped:   use.IsScoped,
+		scopedBase: use.ScopedBase,
+	}
+	if ref.alias == "" {
+		ref.alias = lastSegment(ref.path)
+	}
+	return ref, ref.alias != ""
+}
+
+func importUseRefFromAST(use *ast.UseDecl) (importUseRef, bool) {
+	if use == nil || use.IsFFI() {
+		return importUseRef{}, false
+	}
+	ref := importUseRef{
+		path:     UseKey(use),
+		alias:    useAliasName(use),
+		isScoped: use.IsScoped,
+	}
+	if ref.path == "" || ref.alias == "" {
+		return importUseRef{}, false
+	}
+	if use.IsScoped {
+		ref.scopedBase = scopedUseBaseKey(use)
+	}
+	return ref, true
+}
+
+func packageImportSurfacesFromRefs(refs []importUseRef, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+	if len(refs) == 0 {
+		return nil
+	}
+	seen := map[string]string{}
+	var out []selfhost.PackageCheckImport
+	for _, ref := range refs {
+		if ref.isGo || ref.alias == "" {
+			continue
+		}
+		targetPath := ref.path
+		importAlias := ref.alias
+		if ref.isScoped {
+			targetPath = ref.scopedBase
+			importAlias = lastDotSeg(targetPath)
+		}
+		if targetPath == "" || importAlias == "" {
+			continue
+		}
+		target := LookupPackageImportByPath(targetPath, ws, stdlib)
+		if target == nil {
+			continue
+		}
+		if prev, ok := seen[importAlias]; ok {
+			if prev == targetPath {
+				continue
+			}
+			continue
+		}
+		seen[importAlias] = targetPath
+		out = append(out, PackageExportSurface(targetPath, importAlias, target))
+	}
+	return out
+}
+
+// LookupPackageImportByPath resolves an imported package for import-surface
+// construction. It prefers already loaded workspace packages, then stdlib
+// providers, then native workspace loading for lazy package edges.
+func LookupPackageImportByPath(dotPath string, ws *Workspace, stdlib StdlibProvider) *Package {
+	if dotPath == "" {
+		return nil
+	}
+	if ws != nil {
+		if target := ws.Packages[dotPath]; target != nil {
+			return target
+		}
+		if ws.Stdlib != nil {
+			if target := ws.Stdlib.LookupPackage(dotPath); target != nil {
+				return target
+			}
+		}
+		if ws.Root != "" {
+			target, err := ws.LoadPackageNative(dotPath)
+			if err == nil && target != nil && !target.isCycleMarker {
+				return target
+			}
+		}
+	}
+	if stdlib != nil {
+		return stdlib.LookupPackage(dotPath)
+	}
+	return nil
+}
+
+func packageFrontendRuns(pkg *Package) []*selfhost.FrontendRun {
+	if pkg == nil {
+		return nil
+	}
+	runs := make([]*selfhost.FrontendRun, 0, len(pkg.Files))
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		if pf.Run != nil {
+			runs = append(runs, pf.Run)
+			continue
+		}
+		if len(pf.Source) > 0 {
+			runs = append(runs, selfhost.Run(pf.Source))
+		}
+	}
+	return runs
+}
+
+func useAliasName(use *ast.UseDecl) string {
+	if use == nil {
+		return ""
+	}
+	if use.Alias != "" {
+		return use.Alias
+	}
+	if use.RawPath != "" && strings.ContainsAny(use.RawPath, "/") {
+		return lastSegment(use.RawPath)
+	}
+	if len(use.Path) == 0 {
+		return ""
+	}
+	return lastSegment(use.Path[len(use.Path)-1])
+}

--- a/internal/resolve/import_surface_test.go
+++ b/internal/resolve/import_surface_test.go
@@ -1,0 +1,92 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestPackageImportSurfacesCoverUseShapes(t *testing.T) {
+	foo := packageWithRun("foo", []byte(`pub fn bar() -> Int { 1 }
+pub struct Baz {}
+`))
+	fooBar := packageWithRun("bar", []byte(`pub fn leaf() -> Int { 2 }
+`))
+	fooUpperBar := packageWithRun("Bar", []byte(`pub fn make() -> Int { 3 }
+`))
+	client := packageWithRun("client", []byte(`use foo
+use foo.bar
+use foo::{bar as callBar, Baz}
+use foo.Bar as BazPkg
+pub use foo.Bar as PublicBar
+`))
+	ws := &Workspace{
+		Packages: map[string]*Package{
+			"foo":     foo,
+			"foo.bar": fooBar,
+			"foo.Bar": fooUpperBar,
+		},
+		loading: map[string]bool{},
+	}
+
+	surfaces := PackageImportSurfaces(client, ws, nil)
+	for _, alias := range []string{"foo", "bar", "BazPkg", "PublicBar"} {
+		if findImportSurface(surfaces, alias) == nil {
+			t.Fatalf("missing import surface alias %q in %#v", alias, surfaces)
+		}
+	}
+	if findImportSurface(surfaces, "callBar") != nil {
+		t.Fatalf("scoped member alias should not create a separate package surface: %#v", surfaces)
+	}
+	fooSurface := findImportSurface(surfaces, "foo")
+	if !surfaceHasFn(*fooSurface, "bar") {
+		t.Fatalf("foo surface missing exported fn bar: %#v", fooSurface)
+	}
+	if !surfaceHasType(*fooSurface, "Baz") {
+		t.Fatalf("foo surface missing exported type Baz: %#v", fooSurface)
+	}
+	if !surfaceHasFn(*findImportSurface(surfaces, "bar"), "leaf") {
+		t.Fatalf("foo.bar surface missing exported fn leaf: %#v", surfaces)
+	}
+	if !surfaceHasFn(*findImportSurface(surfaces, "BazPkg"), "make") {
+		t.Fatalf("foo.Bar as BazPkg surface missing exported fn make: %#v", surfaces)
+	}
+}
+
+func packageWithRun(name string, src []byte) *Package {
+	return &Package{
+		Name: name,
+		Files: []*PackageFile{{
+			Path:   name + ".osty",
+			Source: src,
+			Run:    selfhost.Run(src),
+		}},
+	}
+}
+
+func findImportSurface(surfaces []selfhost.PackageCheckImport, alias string) *selfhost.PackageCheckImport {
+	for i := range surfaces {
+		if surfaces[i].Alias == alias {
+			return &surfaces[i]
+		}
+	}
+	return nil
+}
+
+func surfaceHasFn(surface selfhost.PackageCheckImport, name string) bool {
+	for _, fn := range surface.Functions {
+		if fn.Owner == "" && fn.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func surfaceHasType(surface selfhost.PackageCheckImport, name string) bool {
+	for _, typ := range surface.TypeDecls {
+		if typ.Name == name || typ.Name == surface.Alias+"."+name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -107,9 +107,10 @@ func nativeCfgEnvFor(pkg *Package) *selfhost.CfgEnv {
 
 func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeResolveFileInfo, error) {
 	input := selfhost.PackageResolveInput{
-		Files:   make([]selfhost.PackageResolveFile, 0, len(pkg.Files)),
-		Imports: nativeResolveImportSurfaces(pkg),
-		Cfg:     nativeCfgEnvFor(pkg),
+		Files:       make([]selfhost.PackageResolveFile, 0, len(pkg.Files)),
+		Imports:     PackageImportSurfaces(pkg, pkg.workspace, nil),
+		PackagePath: nativeResolvePackagePath(pkg),
+		Cfg:         nativeCfgEnvFor(pkg),
 	}
 	files := make([]nativeResolveFileInfo, 0, len(pkg.Files))
 	base := 0
@@ -145,81 +146,21 @@ func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeRes
 	return input, files, nil
 }
 
-func nativeResolveImportSurfaces(pkg *Package) []selfhost.PackageCheckImport {
-	if pkg == nil || pkg.workspace == nil {
-		return nil
-	}
-	seen := map[string]bool{}
-	var out []selfhost.PackageCheckImport
-	for _, pf := range pkg.Files {
-		if pf == nil || pf.File == nil {
-			continue
-		}
-		for _, u := range pf.File.Uses {
-			if u == nil || u.IsFFI() {
-				continue
-			}
-			targetPath := UseKey(u)
-			importAlias := nativeUseAlias(u)
-			if u.IsScoped {
-				targetPath = scopedUseBaseKey(u)
-				importAlias = lastDotSeg(targetPath)
-			}
-			if targetPath == "" || importAlias == "" {
-				continue
-			}
-			key := targetPath + "\x00" + importAlias
-			if seen[key] {
-				continue
-			}
-			target := nativeResolveSurfacePackage(pkg.workspace, targetPath)
-			if target == nil {
-				continue
-			}
-			seen[key] = true
-			out = append(out, selfhost.PackageImportSurface(targetPath, importAlias, nativeResolveRunsForPackage(target)))
-		}
-	}
-	return out
-}
-
-func nativeResolveSurfacePackage(w *Workspace, dotPath string) *Package {
-	if w == nil || dotPath == "" {
-		return nil
-	}
-	if pkg := w.Packages[dotPath]; pkg != nil {
-		return pkg
-	}
-	if w.Stdlib != nil {
-		if pkg := w.Stdlib.LookupPackage(dotPath); pkg != nil {
-			return pkg
-		}
-	}
-	pkg, err := w.LoadPackage(dotPath)
-	if err != nil {
-		return nil
-	}
-	return pkg
-}
-
-func nativeResolveRunsForPackage(pkg *Package) []*selfhost.FrontendRun {
+func nativeResolvePackagePath(pkg *Package) string {
 	if pkg == nil {
-		return nil
+		return ""
 	}
-	runs := make([]*selfhost.FrontendRun, 0, len(pkg.Files))
-	for _, pf := range pkg.Files {
-		if pf == nil {
-			continue
-		}
-		if pf.Run != nil {
-			runs = append(runs, pf.Run)
-			continue
-		}
-		if len(pf.Source) > 0 {
-			runs = append(runs, selfhost.Run(pf.Source))
+	if pkg.workspace != nil {
+		for path, candidate := range pkg.workspace.Packages {
+			if candidate == pkg {
+				return path
+			}
 		}
 	}
-	return runs
+	if pkg.Dir != "" {
+		return pkg.Dir
+	}
+	return pkg.Name
 }
 
 func nativeResolveSourceForFile(pf *PackageFile) ([]byte, error) {

--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -125,6 +125,120 @@ func TestNativeResolutionRowsCrossFile(t *testing.T) {
 	}
 }
 
+func TestNativeStructuredCrossFileRefCarriesStableTargetID(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageArenaFirst(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageArenaFirst: %v", err)
+	}
+	result := ResolvePackage(pkg, NewPrelude())
+	if len(result.Diags) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", result.Diags)
+	}
+	helper := pkg.PkgScope.LookupLocal("helper")
+	if helper == nil || helper.StableID == "" || helper.PackageID == "" || helper.DeclID == "" {
+		t.Fatalf("helper stable ids missing: %#v", helper)
+	}
+	structured, err := NativeStructuredResult(pkg)
+	if err != nil {
+		t.Fatalf("NativeStructuredResult: %v", err)
+	}
+	var helperSym *selfhost.ResolvedSymbol
+	for i := range structured.Symbols {
+		if structured.Symbols[i].Name == "helper" && structured.Symbols[i].File == aPath {
+			helperSym = &structured.Symbols[i]
+			break
+		}
+	}
+	if helperSym == nil || helperSym.ID == "" {
+		t.Fatalf("missing native helper symbol id: %#v", structured.Symbols)
+	}
+	if helper.StableID != helperSym.ID || helper.DeclID != helperSym.DeclID {
+		t.Fatalf("bridged helper ids = stable:%q decl:%q, want native stable:%q decl:%q",
+			helper.StableID, helper.DeclID, helperSym.ID, helperSym.DeclID)
+	}
+	foundRef := false
+	for _, ref := range structured.Refs {
+		if ref.Name == "helper" && ref.File == bPath && ref.TargetSymbolID == helperSym.ID && ref.BindingID != "" {
+			foundRef = true
+			break
+		}
+	}
+	if !foundRef {
+		t.Fatalf("missing native helper ref with target symbol id %q: %#v", helperSym.ID, structured.Refs)
+	}
+}
+
+func TestNativeBridgeImportedUseCarriesStableTargetID(t *testing.T) {
+	root := t.TempDir()
+	alphaDir := filepath.Join(root, "alpha")
+	betaDir := filepath.Join(root, "beta")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(betaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(alphaDir, "lib.osty"), []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(betaDir, "lib.osty"), []byte(`use alpha::{helper}
+
+fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	for _, path := range []string{"alpha", "beta"} {
+		if _, err := ws.LoadPackageNative(path); err != nil {
+			t.Fatalf("LoadPackageNative %s: %v", path, err)
+		}
+	}
+	results := ws.ResolveAll()
+	if got := results["beta"]; got == nil || len(got.Diags) != 0 {
+		t.Fatalf("beta diagnostics = %#v, want none", got)
+	}
+
+	alphaHelper := ws.Packages["alpha"].PkgScope.LookupLocal("helper")
+	if alphaHelper == nil || alphaHelper.StableID == "" || alphaHelper.PackageID == "" || alphaHelper.DeclID == "" {
+		t.Fatalf("alpha helper stable ids missing: %#v", alphaHelper)
+	}
+	betaFile := ws.Packages["beta"].Files[0]
+	imported := betaFile.FileScope.LookupLocal("helper")
+	if imported == nil {
+		t.Fatalf("missing imported helper in file scope")
+	}
+	if imported.Kind != SymFn {
+		t.Fatalf("imported helper kind = %v, want SymFn (%#v)", imported.Kind, imported)
+	}
+	if imported.StableID != alphaHelper.StableID {
+		t.Fatalf("imported helper stable id = %q, want target id %q", imported.StableID, alphaHelper.StableID)
+	}
+	if imported.DeclID != alphaHelper.DeclID {
+		t.Fatalf("imported helper decl id = %q, want target decl id %q", imported.DeclID, alphaHelper.DeclID)
+	}
+}
+
 func TestNativeResolutionRowsCachesResult(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
@@ -226,6 +340,32 @@ fn main() {
 	}
 	if sym.Package == nil || sym.Package.PkgScope == nil {
 		t.Fatalf("fs package = %#v, want resolved stdlib package", sym.Package)
+	}
+}
+
+func TestResolveFileDefaultScopedStdlibMemberUse(t *testing.T) {
+	src := []byte(`use std.fs::{readToString as read}
+
+fn main() {
+    let _ = read("demo.txt")
+}
+`)
+	file, diags := parser.ParseDiagnostics(src)
+	if len(diags) != 0 {
+		t.Fatalf("parse diagnostics = %#v, want none", diags)
+	}
+	pkgScope := NewScope(NewPrelude(), "package:std.fs")
+	pkgScope.DefineForce(&Symbol{Name: "readToString", Kind: SymFn, Pub: true})
+	reg := stubStdlibProvider{
+		"std.fs": &Package{Name: "fs", PkgScope: pkgScope},
+	}
+	res := ResolveFileSourceDefault(src, file, reg)
+	if len(res.Diags) != 0 {
+		t.Fatalf("resolve diagnostics = %#v, want none", res.Diags)
+	}
+	sym := res.FileScope.Lookup("read")
+	if sym == nil || sym.Kind != SymFn || !sym.Pub {
+		t.Fatalf("read = %#v, want public function imported from std.fs", sym)
 	}
 }
 
@@ -511,6 +651,121 @@ func TestResolvePackageViaNativePubScopedUsePrivateMemberEmitsE0553(t *testing.T
 	}
 	if sym := ws.Packages["beta"].PkgScope.LookupLocal("hidden"); sym != nil {
 		t.Fatalf("private pub use should not export hidden, got %#v", sym)
+	}
+}
+
+func TestResolvePackageViaNativeUseShapeParity(t *testing.T) {
+	root := t.TempDir()
+	writePkg := func(path, src string) {
+		t.Helper()
+		dir := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "lib.osty"), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writePkg("foo", `pub fn bar() -> Int { 1 }
+pub struct Baz {}
+`)
+	writePkg("foo/bar", `pub fn leaf() -> Int { 2 }
+`)
+	writePkg("foo/Bar", `pub fn make() -> Int { 3 }
+`)
+	writePkg("client", `use foo
+use foo.bar
+use foo::{bar as callBar, Baz}
+use foo.Bar as BazPkg
+pub use foo.Bar as PublicBar
+
+fn main() {
+    let _ = foo.bar()
+    let _ = bar.leaf()
+    let _ = callBar()
+    let _ = BazPkg.make()
+}
+`)
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	for _, path := range []string{"foo", "foo.bar", "foo.Bar", "client"} {
+		if _, err := ws.LoadPackageNative(path); err != nil {
+			t.Fatalf("LoadPackageNative %s: %v", path, err)
+		}
+	}
+	results := ws.ResolveAll()
+	if got := results["client"]; got == nil || len(got.Diags) != 0 {
+		t.Fatalf("client diagnostics = %#v, want none", got)
+	}
+	client := ws.Packages["client"]
+	fileScope := client.Files[0].FileScope
+	cases := []struct {
+		name string
+		kind SymbolKind
+	}{
+		{"foo", SymPackage},
+		{"bar", SymPackage},
+		{"callBar", SymFn},
+		{"Baz", SymStruct},
+		{"BazPkg", SymPackage},
+	}
+	for _, tc := range cases {
+		sym := fileScope.Lookup(tc.name)
+		if sym == nil || sym.Kind != tc.kind {
+			t.Fatalf("%s = %#v, want kind %v", tc.name, sym, tc.kind)
+		}
+	}
+	pub := client.PkgScope.LookupLocal("PublicBar")
+	if pub == nil || pub.Kind != SymPackage || !pub.Pub {
+		t.Fatalf("PublicBar = %#v, want exported package alias", pub)
+	}
+}
+
+func TestResolvePackageViaNativeScopedUsePrivateMemberEmitsE0507(t *testing.T) {
+	root := t.TempDir()
+	alphaDir := filepath.Join(root, "alpha")
+	betaDir := filepath.Join(root, "beta")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(betaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(alphaDir, "lib.osty"), []byte(`fn hidden() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(betaDir, "lib.osty"), []byte(`use alpha::{hidden}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	for _, path := range WorkspacePackagePaths(root) {
+		if _, err := ws.LoadPackageNative(path); err != nil {
+			t.Fatalf("LoadPackageNative %s: %v", path, err)
+		}
+	}
+	results := ws.ResolveAll()
+	betaResult := results["beta"]
+	if betaResult == nil {
+		t.Fatalf("missing beta result")
+	}
+	found := false
+	for _, d := range betaResult.Diags {
+		if d.Code == diag.CodePrivateAcrossPackages {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s, got %#v", diag.CodePrivateAcrossPackages, betaResult.Diags)
 	}
 }
 

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -24,12 +24,14 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 
 	pkgScope := NewScope(prelude, "package:"+pkg.Name)
 	diags := nativeParseDiagnostics(pkg)
+	declIndexes := make(map[string]map[int]ast.Node, len(pkg.Files))
 	for _, pf := range pkg.Files {
 		if pf.File == nil || len(pf.Source) == 0 && len(pf.CanonicalSource) == 0 {
 			continue
 		}
 		fi := nativeResolveFileInfoFor(files, pf.Path)
 		declIdx := buildDeclIndex(pf.File)
+		declIndexes[pf.Path] = declIdx
 		defineTopLevelSymbols(pkgScope, result.Symbols, fi, declIdx)
 	}
 
@@ -40,11 +42,15 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 		fi := nativeResolveFileInfoFor(files, pf.Path)
 		identIdx := buildIdentIndex(pf.File)
 		typeIdx := buildNamedTypeIndex(pf.File)
-		declIdx := buildDeclIndex(pf.File)
+		declIdx := declIndexes[pf.Path]
+		if declIdx == nil {
+			declIdx = buildDeclIndex(pf.File)
+			declIndexes[pf.Path] = declIdx
+		}
 		fileScope := NewScope(pkgScope, "file:"+pf.Path)
 		nativeDeclareUses(fileScope, pkgScope, pkg, pf, &diags)
 
-		refsByID, refIdents := bridgeRefs(result.Refs, fi, identIdx, declIdx, fileScope)
+		refsByID, refIdents := bridgeRefs(result.Refs, result.Symbols, files, fi, identIdx, declIndexes, fileScope)
 		refsByID, refIdents = supplementUseAliasRefs(pf.File, fileScope, refsByID, refIdents)
 		pf.RefsByID = refsByID
 		pf.RefIdents = refIdents
@@ -103,12 +109,15 @@ func nativeDeclareUses(fileScope, pkgScope *Scope, pkg *Package, pf *PackageFile
 			}
 			if u.IsPub && sym.Pub && pkgScope != nil && pkgScope != fileScope {
 				pkgSym := &Symbol{
-					Name:    sym.Name,
-					Kind:    sym.Kind,
-					Pos:     sym.Pos,
-					Decl:    sym.Decl,
-					Pub:     sym.Pub,
-					Package: sym.Package,
+					StableID:  sym.StableID,
+					PackageID: sym.PackageID,
+					DeclID:    sym.DeclID,
+					Name:      sym.Name,
+					Kind:      sym.Kind,
+					Pos:       sym.Pos,
+					Decl:      sym.Decl,
+					Pub:       sym.Pub,
+					Package:   sym.Package,
 				}
 				pkgScope.Define(pkgSym)
 			}
@@ -120,12 +129,15 @@ func nativeDeclareUses(fileScope, pkgScope *Scope, pkg *Package, pf *PackageFile
 		}
 		if u.IsPub && sym.Pub && pkgScope != nil && pkgScope != fileScope {
 			pkgSym := &Symbol{
-				Name:    sym.Name,
-				Kind:    sym.Kind,
-				Pos:     sym.Pos,
-				Decl:    sym.Decl,
-				Pub:     sym.Pub,
-				Package: sym.Package,
+				StableID:  sym.StableID,
+				PackageID: sym.PackageID,
+				DeclID:    sym.DeclID,
+				Name:      sym.Name,
+				Kind:      sym.Kind,
+				Pos:       sym.Pos,
+				Decl:      sym.Decl,
+				Pub:       sym.Pub,
+				Package:   sym.Package,
 			}
 			pkgScope.Define(pkgSym)
 		}
@@ -321,14 +333,17 @@ func walkReflect(v reflect.Value, onIdent identVisitor, onType typeVisitor) {
 
 func bridgeRefs(
 	refs []selfhost.ResolvedRef,
+	symbols []selfhost.ResolvedSymbol,
+	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	identIdx map[int]*ast.Ident,
-	declIdx map[int]ast.Node,
+	declIndexes map[string]map[int]ast.Node,
 	fileScope *Scope,
 ) (map[ast.NodeID]*Symbol, []*ast.Ident) {
 	refsByID := make(map[ast.NodeID]*Symbol, len(refs))
 	refIdents := make([]*ast.Ident, 0, len(refs))
-	symCache := make(map[int]*Symbol)
+	symCache := make(map[nativeSymbolTarget]*Symbol)
+	symByTarget := nativeSymbolByTarget(symbols)
 
 	for _, ref := range refs {
 		if ref.File != "" {
@@ -341,15 +356,55 @@ func bridgeRefs(
 		if !ok {
 			continue
 		}
-		ident := identIdx[origOff]
+		origEnd, ok := nativeToOriginalOffset(fi, ref.End)
+		if !ok {
+			origEnd = origOff
+		}
+		ident := findIdentForResolvedRef(identIdx, ref.Name, origOff, origEnd)
 		if ident == nil {
 			continue
 		}
-		sym := findOrCreateSymbol(symCache, ref.Name, ref.TargetStart, ref.TargetEnd, fi, declIdx, fileScope)
+		sym := findOrCreateSymbol(symCache, ref, symByTarget, files, fi, declIndexes, fileScope)
 		refsByID[ident.ID] = sym
 		refIdents = append(refIdents, ident)
 	}
 	return refsByID, refIdents
+}
+
+func findIdentForResolvedRef(identIdx map[int]*ast.Ident, name string, start, end int) *ast.Ident {
+	if ident := identIdx[start]; ident != nil && ident.Name == name {
+		return ident
+	}
+	if end < start {
+		end = start
+	}
+	var best *ast.Ident
+	bestDistance := int(^uint(0) >> 1)
+	for _, ident := range identIdx {
+		if ident == nil || ident.Name != name {
+			continue
+		}
+		idStart := ident.Pos().Offset
+		idEnd := ident.End().Offset
+		if idEnd < idStart {
+			idEnd = idStart
+		}
+		distance := 0
+		switch {
+		case idEnd < start:
+			distance = start - idEnd
+		case idStart > end:
+			distance = idStart - end
+		}
+		if distance < bestDistance {
+			bestDistance = distance
+			best = ident
+		}
+	}
+	if bestDistance > 8 {
+		return nil
+	}
+	return best
 }
 
 func supplementUseAliasRefs(
@@ -424,40 +479,81 @@ func bridgeTypeRefs(
 }
 
 func findOrCreateSymbol(
-	cache map[int]*Symbol,
-	name string,
-	targetStart, targetEnd int,
+	cache map[nativeSymbolTarget]*Symbol,
+	ref selfhost.ResolvedRef,
+	symByTarget map[nativeSymbolTarget]selfhost.ResolvedSymbol,
+	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
-	declIdx map[int]ast.Node,
+	declIndexes map[string]map[int]ast.Node,
 	fileScope *Scope,
 ) *Symbol {
-	targetOrigOff, ok := nativeToOriginalOffset(fi, targetStart)
-	if !ok {
-		return &Symbol{Name: name, Kind: SymBuiltin, Pub: true}
-	}
-	if sym, ok := cache[targetOrigOff]; ok {
+	key := nativeSymbolTarget{file: ref.TargetFile, node: ref.TargetNode, start: ref.TargetStart, end: ref.TargetEnd}
+	if sym, ok := cache[key]; ok {
 		return sym
 	}
+	nativeSym := symByTarget[key]
+	targetFI := nativeResolveFileInfoFor(files, ref.TargetFile)
+	if targetFI.path == "" && ref.TargetFile == "" {
+		targetFI = fi
+	}
+	targetOrigOff, ok := nativeToOriginalOffset(targetFI, ref.TargetStart)
+	if !ok {
+		return &Symbol{StableID: ref.TargetSymbolID, PackageID: ref.PackageID, Name: ref.Name, Kind: SymBuiltin, Pub: true}
+	}
+	declIdx := declIndexes[ref.TargetFile]
 	decl := findNearestDecl(declIdx, targetOrigOff)
-	if _, isUse := decl.(*ast.UseDecl); isUse && fileScope != nil {
-		if sym := fileScope.LookupLocal(name); sym != nil {
-			cache[targetOrigOff] = sym
+	if _, isUse := decl.(*ast.UseDecl); isUse && fileScope != nil && ref.TargetFile == fi.path {
+		if sym := fileScope.LookupLocal(ref.Name); sym != nil {
+			fillSymbolIDsFromRef(sym, ref)
+			cache[key] = sym
 			return sym
 		}
 	}
 	sym := &Symbol{
-		Name: name,
-		Kind: SymUnknown,
-		Pub:  true,
-		Decl: decl,
+		StableID:  ref.TargetSymbolID,
+		PackageID: ref.PackageID,
+		DeclID:    nativeSym.DeclID,
+		Name:      ref.Name,
+		Kind:      nativeKindToSymbolKind(nativeSym.Kind),
+		Pub:       true,
+		Decl:      decl,
+	}
+	if sym.Kind == SymUnknown && nativeSym.Kind == "" {
+		sym.Kind = SymUnknown
 	}
 	if decl != nil {
 		sym.Pos = decl.Pos()
 	} else {
 		sym.Pos = token.Pos{Offset: targetOrigOff}
 	}
-	cache[targetOrigOff] = sym
+	cache[key] = sym
 	return sym
+}
+
+func fillSymbolIDsFromRef(sym *Symbol, ref selfhost.ResolvedRef) {
+	if sym == nil {
+		return
+	}
+	if sym.StableID == "" {
+		sym.StableID = ref.TargetSymbolID
+	}
+	if sym.PackageID == "" {
+		sym.PackageID = ref.PackageID
+	}
+}
+
+type nativeSymbolTarget struct {
+	file       string
+	node       int
+	start, end int
+}
+
+func nativeSymbolByTarget(symbols []selfhost.ResolvedSymbol) map[nativeSymbolTarget]selfhost.ResolvedSymbol {
+	out := make(map[nativeSymbolTarget]selfhost.ResolvedSymbol, len(symbols))
+	for _, sym := range symbols {
+		out[nativeSymbolTarget{file: sym.File, node: sym.Node, start: sym.Start, end: sym.End}] = sym
+	}
+	return out
 }
 
 func findNearestDecl(declIdx map[int]ast.Node, targetOff int) ast.Node {
@@ -494,10 +590,13 @@ func defineTopLevelSymbols(
 		}
 		decl := findNearestDecl(declIdx, origOff)
 		goSym := &Symbol{
-			Name: sym.Name,
-			Kind: nativeKindToSymbolKind(sym.Kind),
-			Pub:  sym.Public,
-			Decl: decl,
+			StableID:  sym.ID,
+			PackageID: sym.PackageID,
+			DeclID:    sym.DeclID,
+			Name:      sym.Name,
+			Kind:      nativeKindToSymbolKind(sym.Kind),
+			Pub:       sym.Public,
+			Decl:      decl,
 		}
 		if decl != nil {
 			goSym.Pos = decl.Pos()

--- a/internal/resolve/scope.go
+++ b/internal/resolve/scope.go
@@ -92,8 +92,16 @@ func (k SymbolKind) IsValue() bool {
 
 // Symbol is a single declared name.
 type Symbol struct {
-	Name string
-	Kind SymbolKind
+	// StableID is the selfhost resolver's canonical symbol_id when the
+	// symbol was projected from a ResolveResult. Legacy Go-created symbols may
+	// leave it empty and use ID() as a compatibility identity.
+	StableID string
+	// PackageID and DeclID mirror the resolver-owned package_id / decl_id
+	// fields from the selfhost structured result.
+	PackageID string
+	DeclID    string
+	Name      string
+	Kind      SymbolKind
 	// Pos is the position of the declaration. Builtin symbols return the
 	// zero Pos.
 	Pos token.Pos

--- a/internal/resolve/use_binding.go
+++ b/internal/resolve/use_binding.go
@@ -1,7 +1,6 @@
 package resolve
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -89,12 +88,15 @@ func importedUseSymbol(source *Symbol, u *ast.UseDecl, name string) *Symbol {
 		return placeholderUseSymbol(u, name, SymUnknown, false)
 	}
 	return &Symbol{
-		Name:    name,
-		Kind:    source.Kind,
-		Pos:     source.Pos,
-		Decl:    source.Decl,
-		Pub:     source.Pub,
-		Package: source.Package,
+		StableID:  source.StableID,
+		PackageID: source.PackageID,
+		DeclID:    source.DeclID,
+		Name:      name,
+		Kind:      source.Kind,
+		Pos:       source.Pos,
+		Decl:      source.Decl,
+		Pub:       source.Pub,
+		Package:   source.Package,
 	}
 }
 
@@ -117,13 +119,17 @@ func packageMemberDiagnostic(pkgName, member string, pos token.Pos, file string,
 }
 
 func privateReexportDiagnostic(pos token.Pos, pkgName, member, file string) *diag.Diagnostic {
-	target := pkgName + "." + member
-	out := diag.New(diag.Error, fmt.Sprintf("`pub use` cannot re-export private symbol `%s`", target)).
-		Code(diag.CodeReexportPrivate).
-		PrimaryPos(pos, "private re-export").
-		Note(fmt.Sprintf("`%s` is declared without `pub` in package `%s`", member, pkgName)).
-		Hint(fmt.Sprintf("make `%s` public or remove `pub` from this use", member)).
-		Build()
+	res := selfhost.ReexportPrivateDiagnostic(pkgName, member)
+	d := diag.New(diag.Error, res.Message).
+		Code(res.Code).
+		PrimaryPos(pos, res.Primary)
+	if res.Note != "" {
+		d.Note(res.Note)
+	}
+	if res.Hint != "" {
+		d.Hint(res.Hint)
+	}
+	out := d.Build()
 	if out.File == "" {
 		out.File = file
 	}

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -260,7 +260,7 @@ func (w *Workspace) ResolveAll() map[string]*PackageResult {
 	for path := range w.Packages {
 		paths = append(paths, path)
 	}
-	sort.Strings(paths)
+	paths = w.resolveOrder(paths)
 	for _, path := range paths {
 		pkg := w.Packages[path]
 		if pkg == nil {
@@ -285,6 +285,66 @@ func (w *Workspace) ResolveAll() map[string]*PackageResult {
 		}
 	}
 	return results
+}
+
+func (w *Workspace) resolveOrder(paths []string) []string {
+	sort.Strings(paths)
+	inSet := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		inSet[path] = true
+	}
+	visiting := map[string]bool{}
+	visited := map[string]bool{}
+	out := make([]string, 0, len(paths))
+	var visit func(string)
+	visit = func(path string) {
+		if visited[path] {
+			return
+		}
+		if visiting[path] {
+			return
+		}
+		visiting[path] = true
+		for _, dep := range w.packageUseTargets(path) {
+			if inSet[dep] {
+				visit(dep)
+			}
+		}
+		visiting[path] = false
+		visited[path] = true
+		out = append(out, path)
+	}
+	for _, path := range paths {
+		visit(path)
+	}
+	return out
+}
+
+func (w *Workspace) packageUseTargets(path string) []string {
+	pkg := w.Packages[path]
+	if pkg == nil || pkg.isStub || pkg.isCycleMarker {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, f := range pkg.Files {
+		if f == nil || f.File == nil {
+			continue
+		}
+		for _, u := range f.File.Uses {
+			if u == nil || u.IsFFI() {
+				continue
+			}
+			target := w.useGraphTarget(u)
+			if target == "" || seen[target] {
+				continue
+			}
+			seen[target] = true
+			out = append(out, target)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // isPreResolvedStdlib reports whether pkg came from an attached

--- a/internal/selfhost/api/package.go
+++ b/internal/selfhost/api/package.go
@@ -111,8 +111,9 @@ type PackageResolveFile = PackageCheckFile
 // synthetic package so the self-host resolver can see one shared
 // top-level namespace.
 type PackageResolveInput struct {
-	Files   []PackageResolveFile `json:"files,omitempty"`
-	Imports []PackageCheckImport `json:"imports,omitempty"`
+	Files       []PackageResolveFile `json:"files,omitempty"`
+	Imports     []PackageCheckImport `json:"imports,omitempty"`
+	PackagePath string               `json:"packagePath,omitempty"`
 	// Cfg, when non-nil, activates the `#[cfg(key = "value")]`
 	// pre-resolve filter per LANG_SPEC v0.5 §5 / G29. A nil Cfg leaves
 	// every decl alive (cfg shape validation still emits E0405/E0739

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -224,57 +224,69 @@ type ResolveSummary struct {
 
 // ResolvedSymbol records one symbol declared by the self-host resolver.
 type ResolvedSymbol struct {
-	Node   int       `json:"node"`
-	Name   string    `json:"name"`
-	Kind   string    `json:"kind"`
-	Type   *TypeRepr `json:"type"`
-	Arity  int       `json:"arity"`
-	Depth  int       `json:"depth"`
-	Start  int       `json:"start"`
-	End    int       `json:"end"`
-	Public bool      `json:"public"`
-	File   string    `json:"file,omitempty"`
+	ID        string    `json:"symbolId,omitempty"`
+	PackageID string    `json:"packageId,omitempty"`
+	DeclID    string    `json:"declId,omitempty"`
+	Node      int       `json:"node"`
+	Name      string    `json:"name"`
+	Kind      string    `json:"kind"`
+	Type      *TypeRepr `json:"type"`
+	Arity     int       `json:"arity"`
+	Depth     int       `json:"depth"`
+	Start     int       `json:"start"`
+	End       int       `json:"end"`
+	Public    bool      `json:"public"`
+	File      string    `json:"file,omitempty"`
 }
 
 // ResolvedRef records one value/name reference plus its resolved target span
 // when available.
 type ResolvedRef struct {
-	Name        string `json:"name"`
-	Node        int    `json:"node"`
-	Start       int    `json:"start"`
-	End         int    `json:"end"`
-	File        string `json:"file,omitempty"`
-	TargetNode  int    `json:"targetNode"`
-	TargetStart int    `json:"targetStart"`
-	TargetEnd   int    `json:"targetEnd"`
-	TargetFile  string `json:"targetFile,omitempty"`
+	ID             string `json:"refId,omitempty"`
+	PackageID      string `json:"packageId,omitempty"`
+	BindingID      string `json:"bindingId,omitempty"`
+	TargetSymbolID string `json:"targetSymbolId,omitempty"`
+	Name           string `json:"name"`
+	Node           int    `json:"node"`
+	Start          int    `json:"start"`
+	End            int    `json:"end"`
+	File           string `json:"file,omitempty"`
+	TargetNode     int    `json:"targetNode"`
+	TargetStart    int    `json:"targetStart"`
+	TargetEnd      int    `json:"targetEnd"`
+	TargetFile     string `json:"targetFile,omitempty"`
 }
 
 // ResolvedTypeRef records one resolved type-name reference.
 type ResolvedTypeRef struct {
-	Name  string `json:"name"`
-	Node  int    `json:"node"`
-	Start int    `json:"start"`
-	End   int    `json:"end"`
-	File  string `json:"file,omitempty"`
+	ID        string `json:"typeRefId,omitempty"`
+	PackageID string `json:"packageId,omitempty"`
+	Name      string `json:"name"`
+	Node      int    `json:"node"`
+	Start     int    `json:"start"`
+	End       int    `json:"end"`
+	File      string `json:"file,omitempty"`
 }
 
 // ResolveDiagnosticRecord is one structured diagnostic produced by the
 // self-host resolver.
 type ResolveDiagnosticRecord struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Name    string `json:"name,omitempty"`
-	Hint    string `json:"hint,omitempty"`
-	Node    int    `json:"node"`
-	Start   int    `json:"start"`
-	End     int    `json:"end"`
-	File    string `json:"file,omitempty"`
+	ID        string `json:"diagnosticId,omitempty"`
+	PackageID string `json:"packageId,omitempty"`
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Name      string `json:"name,omitempty"`
+	Hint      string `json:"hint,omitempty"`
+	Node      int    `json:"node"`
+	Start     int    `json:"start"`
+	End       int    `json:"end"`
+	File      string `json:"file,omitempty"`
 }
 
 // ResolveResult is the structured Go-facing surface for the bootstrapped
 // resolver.
 type ResolveResult struct {
+	PackageID   string                    `json:"packageId,omitempty"`
 	Summary     ResolveSummary            `json:"summary"`
 	Symbols     []ResolvedSymbol          `json:"symbols"`
 	Refs        []ResolvedRef             `json:"refs"`

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -1,6 +1,12 @@
 package selfhost
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
 )
@@ -65,6 +71,22 @@ func LookupPackageMember(pkgName, member string, typePos, found, public bool) Me
 		Primary: r.primary,
 		Note:    r.note,
 		Hint:    r.hint,
+	}
+}
+
+// ReexportPrivateDiagnostic owns the E0553 wording for `pub use` of a private
+// package member. The Go resolver still knows which imported symbol is private,
+// but it converts this selfhost-owned diagnostic shape instead of rendering its
+// own message.
+func ReexportPrivateDiagnostic(pkgName, member string) MemberLookupResult {
+	target := pkgName + "." + member
+	return MemberLookupResult{
+		Status:  MemberLookupPrivate,
+		Code:    diag.CodeReexportPrivate,
+		Message: fmt.Sprintf("`pub use` cannot re-export private symbol `%s`", target),
+		Primary: "private re-export",
+		Note:    fmt.Sprintf("`%s` is declared without `pub` in package `%s`", member, pkgName),
+		Hint:    fmt.Sprintf("make `%s` public or remove `pub` from this use", member),
 	}
 }
 
@@ -200,6 +222,7 @@ func ResolveFromSource(src []byte, path string) ([]*diag.Diagnostic, ResolveResu
 func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResult {
 	result := ResolveStructuredFromRun(run)
 	if path == "" {
+		selfhostAssignResolveIDs(&result, "")
 		return result
 	}
 	for i := range result.Symbols {
@@ -217,6 +240,7 @@ func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResul
 	for i := range result.Diagnostics {
 		result.Diagnostics[i].File = path
 	}
+	selfhostAssignResolveIDs(&result, path)
 	return result
 }
 
@@ -245,6 +269,7 @@ func ResolvePackageStructured(input PackageResolveInput) (ResolveResult, error) 
 		return checkNodeOffsetsWithTokenLayout(layout, start, end)
 	})
 	selfhostAnnotateResolveFiles(&result, input.Files)
+	selfhostAssignResolveIDs(&result, selfhostResolvePackageKey(input))
 	return result, nil
 }
 
@@ -450,7 +475,74 @@ func adaptResolveResult(resolved *SelfResolveResult, file *AstFile, offsets func
 			End:     end,
 		})
 	}
+	selfhostAssignResolveIDs(&result, "")
 	return result
+}
+
+func selfhostResolvePackageKey(input PackageResolveInput) string {
+	if input.PackagePath != "" {
+		return input.PackagePath
+	}
+	parts := make([]string, 0, len(input.Files))
+	for _, file := range input.Files {
+		if file.Path != "" {
+			parts = append(parts, file.Path)
+		} else if file.Name != "" {
+			parts = append(parts, file.Name)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\x00")
+}
+
+func selfhostAssignResolveIDs(result *ResolveResult, packageKey string) {
+	if result == nil {
+		return
+	}
+	packageID := stableResolveID("package", packageKey)
+	result.PackageID = packageID
+	byTarget := map[string]string{}
+	for i := range result.Symbols {
+		sym := &result.Symbols[i]
+		sym.PackageID = packageID
+		sym.DeclID = stableResolveID("decl", packageKey, sym.File, sym.Kind, sym.Name, fmt.Sprint(sym.Node), fmt.Sprint(sym.Start), fmt.Sprint(sym.End))
+		sym.ID = stableResolveID("symbol", packageKey, sym.File, sym.Kind, sym.Name, fmt.Sprint(sym.Node), fmt.Sprint(sym.Start), fmt.Sprint(sym.End), fmt.Sprint(sym.Public))
+		byTarget[resolveTargetKey(sym.File, sym.Node, sym.Start, sym.End)] = sym.ID
+	}
+	for i := range result.Refs {
+		ref := &result.Refs[i]
+		ref.PackageID = packageID
+		ref.BindingID = stableResolveID("binding", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End))
+		ref.ID = stableResolveID("ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End), fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd), ref.TargetFile)
+		if id := byTarget[resolveTargetKey(ref.TargetFile, ref.TargetNode, ref.TargetStart, ref.TargetEnd)]; id != "" {
+			ref.TargetSymbolID = id
+		} else if ref.TargetNode >= 0 {
+			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd))
+		}
+	}
+	for i := range result.TypeRefs {
+		ref := &result.TypeRefs[i]
+		ref.PackageID = packageID
+		ref.ID = stableResolveID("type-ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End))
+	}
+	for i := range result.Diagnostics {
+		d := &result.Diagnostics[i]
+		d.PackageID = packageID
+		d.ID = stableResolveID("diagnostic", packageKey, d.File, d.Code, d.Name, fmt.Sprint(d.Node), fmt.Sprint(d.Start), fmt.Sprint(d.End), d.Message)
+	}
+}
+
+func resolveTargetKey(file string, node, start, end int) string {
+	return file + "\x00" + fmt.Sprint(node) + "\x00" + fmt.Sprint(start) + "\x00" + fmt.Sprint(end)
+}
+
+func stableResolveID(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = h.Write([]byte(part))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func selfhostResolveNodeOffsets(file *AstFile, node int, offsets func(start, end int) (int, int)) (int, int) {

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -84,6 +84,100 @@ func TestResolvePackageStructuredHandlesCrossFileRefsASTNative(t *testing.T) {
 	}
 }
 
+func TestResolvePackageStructuredAssignsStableIDs(t *testing.T) {
+	dir := t.TempDir()
+	helperPath := filepath.Join(dir, "helper.osty")
+	mainPath := filepath.Join(dir, "main.osty")
+
+	helper := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+    41
+}
+`), 0)
+	helper.Name = "helper.osty"
+	helper.Path = helperPath
+
+	main := canonicalSelfhostInput(t, []byte(`fn main() {
+    let value = helper()
+}
+`), len(helper.Source)+1)
+	main.Name = "main.osty"
+	main.Path = mainPath
+
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		PackagePath: "demo.pkg",
+		Files:       []selfhost.PackageResolveFile{helper, main},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	helperSym := findResolvedSymbol(resolved, "helper", "fn")
+	if helperSym == nil {
+		t.Fatalf("missing helper symbol in %#v", resolved.Symbols)
+	}
+	ref := findResolvedRef(resolved, "helper")
+	if ref == nil {
+		t.Fatalf("missing helper ref in %#v", resolved.Refs)
+	}
+	if resolved.PackageID == "" || helperSym.ID == "" || helperSym.PackageID == "" || helperSym.DeclID == "" {
+		t.Fatalf("stable symbol ids missing: package=%q helper=%#v", resolved.PackageID, helperSym)
+	}
+	if ref.ID == "" || ref.BindingID == "" || ref.TargetSymbolID == "" || ref.PackageID == "" {
+		t.Fatalf("stable ref ids missing: %#v", ref)
+	}
+	if helperSym.PackageID != resolved.PackageID || ref.PackageID != resolved.PackageID {
+		t.Fatalf("package ids diverged: result=%q helper=%q ref=%q", resolved.PackageID, helperSym.PackageID, ref.PackageID)
+	}
+	if ref.TargetSymbolID != helperSym.ID {
+		t.Fatalf("ref target symbol id = %q, want helper symbol id %q", ref.TargetSymbolID, helperSym.ID)
+	}
+
+	surface := selfhost.ResolveSurfaceFromResult(resolved)
+	if surface.PackageID != resolved.PackageID {
+		t.Fatalf("surface package id = %q, want %q", surface.PackageID, resolved.PackageID)
+	}
+	if len(surface.Symbols) != len(resolved.Symbols) || len(surface.Refs) != len(resolved.Refs) {
+		t.Fatalf("surface sizes = symbols:%d refs:%d, want symbols:%d refs:%d",
+			len(surface.Symbols), len(surface.Refs), len(resolved.Symbols), len(resolved.Refs))
+	}
+	foundSurfaceRef := false
+	for _, r := range surface.Refs {
+		if r.Name == "helper" && r.TargetSymbolID == helperSym.ID && r.BindingID == ref.BindingID {
+			foundSurfaceRef = true
+			break
+		}
+	}
+	if !foundSurfaceRef {
+		t.Fatalf("surface missing helper ref with stable ids: %#v", surface.Refs)
+	}
+}
+
+func TestResolveSnapshotGolden(t *testing.T) {
+	resolved := selfhost.ResolveSourceStructured([]byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`))
+	got := selfhost.ResolveSnapshot(resolved)
+	const want = `package efc54114cf42
+symbols
+  <source> fn helper 0:34 pub=false id=acd850f616a7 decl=9d2ba9416b05
+  <source> fn main 36:75 pub=false id=4ab9ed6ae928 decl=d820d6987074
+refs
+  <source> x 31:32 -> <source> 10:16 target=3c1090f85cd3 binding=3b74ed8bdf62
+  <source> helper 64:70 -> <source> 0:34 target=acd850f616a7 binding=d165f3eb124f
+typeRefs
+  <source> Int 13:16 id=0c33e363e987
+  <source> Int 21:24 id=a14d0d87d94d
+diagnostics
+`
+	if got != want {
+		t.Fatalf("ResolveSnapshot mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
 func TestResolvePackageStructuredUseBodyMissingMemberASTNative(t *testing.T) {
 	dir := t.TempDir()
 	srcPath := filepath.Join(dir, "main.osty")
@@ -1052,5 +1146,18 @@ func TestLookupPackageMemberPrivateIgnoresTypePos(t *testing.T) {
 	if valueRes.Message != typeRes.Message {
 		t.Errorf("E0507 message must not vary with typePos\n  value: %q\n  type:  %q",
 			valueRes.Message, typeRes.Message)
+	}
+}
+
+func TestReexportPrivateDiagnosticEmitsE0553(t *testing.T) {
+	res := selfhost.ReexportPrivateDiagnostic("pkg", "hidden")
+	if res.Code != "E0553" {
+		t.Fatalf("code = %q, want E0553", res.Code)
+	}
+	if res.Primary != "private re-export" {
+		t.Fatalf("primary = %q, want private re-export", res.Primary)
+	}
+	if !strings.Contains(res.Message, "pkg.hidden") || !strings.Contains(res.Hint, "remove `pub`") {
+		t.Fatalf("unexpected diagnostic shape: %#v", res)
 	}
 }

--- a/internal/selfhost/resolve_snapshot.go
+++ b/internal/selfhost/resolve_snapshot.go
@@ -1,0 +1,81 @@
+package selfhost
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResolveSnapshot renders the canonical resolver output surface in a compact,
+// deterministic text form for golden tests. It intentionally snapshots the
+// selfhost ResolveResult rather than the Go compatibility scopes.
+func ResolveSnapshot(result ResolveResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s\n", shortResolveID(result.PackageID))
+
+	symbols := append([]ResolvedSymbol(nil), result.Symbols...)
+	sort.Slice(symbols, func(i, j int) bool {
+		return resolveSnapshotKey(symbols[i].File, symbols[i].Start, symbols[i].End, symbols[i].Kind, symbols[i].Name) <
+			resolveSnapshotKey(symbols[j].File, symbols[j].Start, symbols[j].End, symbols[j].Kind, symbols[j].Name)
+	})
+	b.WriteString("symbols\n")
+	for _, sym := range symbols {
+		fmt.Fprintf(&b, "  %s %s %s %d:%d pub=%t id=%s decl=%s\n",
+			resolveSnapshotFile(sym.File), sym.Kind, sym.Name, sym.Start, sym.End, sym.Public, shortResolveID(sym.ID), shortResolveID(sym.DeclID))
+	}
+
+	refs := append([]ResolvedRef(nil), result.Refs...)
+	sort.Slice(refs, func(i, j int) bool {
+		return resolveSnapshotKey(refs[i].File, refs[i].Start, refs[i].End, refs[i].Name, refs[i].TargetFile) <
+			resolveSnapshotKey(refs[j].File, refs[j].Start, refs[j].End, refs[j].Name, refs[j].TargetFile)
+	})
+	b.WriteString("refs\n")
+	for _, ref := range refs {
+		fmt.Fprintf(&b, "  %s %s %d:%d -> %s %d:%d target=%s binding=%s\n",
+			resolveSnapshotFile(ref.File), ref.Name, ref.Start, ref.End, resolveSnapshotFile(ref.TargetFile), ref.TargetStart, ref.TargetEnd,
+			shortResolveID(ref.TargetSymbolID), shortResolveID(ref.BindingID))
+	}
+
+	typeRefs := append([]ResolvedTypeRef(nil), result.TypeRefs...)
+	sort.Slice(typeRefs, func(i, j int) bool {
+		return resolveSnapshotKey(typeRefs[i].File, typeRefs[i].Start, typeRefs[i].End, typeRefs[i].Name) <
+			resolveSnapshotKey(typeRefs[j].File, typeRefs[j].Start, typeRefs[j].End, typeRefs[j].Name)
+	})
+	b.WriteString("typeRefs\n")
+	for _, ref := range typeRefs {
+		fmt.Fprintf(&b, "  %s %s %d:%d id=%s\n", resolveSnapshotFile(ref.File), ref.Name, ref.Start, ref.End, shortResolveID(ref.ID))
+	}
+
+	diags := append([]ResolveDiagnosticRecord(nil), result.Diagnostics...)
+	sort.Slice(diags, func(i, j int) bool {
+		return resolveSnapshotKey(diags[i].File, diags[i].Start, diags[i].End, diags[i].Code, diags[i].Name) <
+			resolveSnapshotKey(diags[j].File, diags[j].Start, diags[j].End, diags[j].Code, diags[j].Name)
+	})
+	b.WriteString("diagnostics\n")
+	for _, d := range diags {
+		fmt.Fprintf(&b, "  %s %s %s %d:%d id=%s\n", resolveSnapshotFile(d.File), d.Code, d.Name, d.Start, d.End, shortResolveID(d.ID))
+	}
+	return b.String()
+}
+
+func resolveSnapshotFile(file string) string {
+	if file == "" {
+		return "<source>"
+	}
+	return file
+}
+
+func resolveSnapshotKey(parts ...any) string {
+	var b strings.Builder
+	for _, part := range parts {
+		fmt.Fprintf(&b, "%v\x00", part)
+	}
+	return b.String()
+}
+
+func shortResolveID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}

--- a/internal/selfhost/resolve_surface.go
+++ b/internal/selfhost/resolve_surface.go
@@ -1,0 +1,150 @@
+package selfhost
+
+import "sort"
+
+// ResolveSurface is the resolver-owned, consumer-oriented view of a
+// ResolveResult. Compiler adapters can still consume ResolveResult directly,
+// while LSP, docgen, inspect, and snapshot tests can depend on this stable
+// symbol/reference/diagnostic surface without walking Go compatibility scopes.
+type ResolveSurface struct {
+	PackageID   string
+	Symbols     []ResolveSymbolSurfaceRecord
+	Refs        []ResolveReferenceSurfaceRecord
+	TypeRefs    []ResolveTypeReferenceSurfaceRecord
+	Diagnostics []ResolveDiagnosticSurfaceRecord
+}
+
+type ResolveSymbolSurfaceRecord struct {
+	SymbolID  string
+	PackageID string
+	DeclID    string
+	Name      string
+	Kind      string
+	File      string
+	Start     int
+	End       int
+	Public    bool
+}
+
+type ResolveReferenceSurfaceRecord struct {
+	RefID          string
+	PackageID      string
+	BindingID      string
+	TargetSymbolID string
+	Name           string
+	File           string
+	Start          int
+	End            int
+	TargetFile     string
+	TargetStart    int
+	TargetEnd      int
+}
+
+type ResolveTypeReferenceSurfaceRecord struct {
+	TypeRefID string
+	PackageID string
+	Name      string
+	File      string
+	Start     int
+	End       int
+}
+
+type ResolveDiagnosticSurfaceRecord struct {
+	DiagnosticID string
+	PackageID    string
+	Code         string
+	Message      string
+	Name         string
+	File         string
+	Start        int
+	End          int
+}
+
+func ResolveSurfaceFromResult(result ResolveResult) ResolveSurface {
+	surface := ResolveSurface{
+		PackageID:   result.PackageID,
+		Symbols:     make([]ResolveSymbolSurfaceRecord, 0, len(result.Symbols)),
+		Refs:        make([]ResolveReferenceSurfaceRecord, 0, len(result.Refs)),
+		TypeRefs:    make([]ResolveTypeReferenceSurfaceRecord, 0, len(result.TypeRefs)),
+		Diagnostics: make([]ResolveDiagnosticSurfaceRecord, 0, len(result.Diagnostics)),
+	}
+	for _, sym := range result.Symbols {
+		surface.Symbols = append(surface.Symbols, ResolveSymbolSurfaceRecord{
+			SymbolID:  sym.ID,
+			PackageID: sym.PackageID,
+			DeclID:    sym.DeclID,
+			Name:      sym.Name,
+			Kind:      sym.Kind,
+			File:      sym.File,
+			Start:     sym.Start,
+			End:       sym.End,
+			Public:    sym.Public,
+		})
+	}
+	for _, ref := range result.Refs {
+		surface.Refs = append(surface.Refs, ResolveReferenceSurfaceRecord{
+			RefID:          ref.ID,
+			PackageID:      ref.PackageID,
+			BindingID:      ref.BindingID,
+			TargetSymbolID: ref.TargetSymbolID,
+			Name:           ref.Name,
+			File:           ref.File,
+			Start:          ref.Start,
+			End:            ref.End,
+			TargetFile:     ref.TargetFile,
+			TargetStart:    ref.TargetStart,
+			TargetEnd:      ref.TargetEnd,
+		})
+	}
+	for _, ref := range result.TypeRefs {
+		surface.TypeRefs = append(surface.TypeRefs, ResolveTypeReferenceSurfaceRecord{
+			TypeRefID: ref.ID,
+			PackageID: ref.PackageID,
+			Name:      ref.Name,
+			File:      ref.File,
+			Start:     ref.Start,
+			End:       ref.End,
+		})
+	}
+	for _, d := range result.Diagnostics {
+		surface.Diagnostics = append(surface.Diagnostics, ResolveDiagnosticSurfaceRecord{
+			DiagnosticID: d.ID,
+			PackageID:    d.PackageID,
+			Code:         d.Code,
+			Message:      d.Message,
+			Name:         d.Name,
+			File:         d.File,
+			Start:        d.Start,
+			End:          d.End,
+		})
+	}
+	sort.Slice(surface.Symbols, func(i, j int) bool {
+		return resolveSurfaceSymbolKey(surface.Symbols[i]) < resolveSurfaceSymbolKey(surface.Symbols[j])
+	})
+	sort.Slice(surface.Refs, func(i, j int) bool {
+		return resolveSurfaceRefKey(surface.Refs[i]) < resolveSurfaceRefKey(surface.Refs[j])
+	})
+	sort.Slice(surface.TypeRefs, func(i, j int) bool {
+		return resolveSurfaceTypeRefKey(surface.TypeRefs[i]) < resolveSurfaceTypeRefKey(surface.TypeRefs[j])
+	})
+	sort.Slice(surface.Diagnostics, func(i, j int) bool {
+		return resolveSurfaceDiagnosticKey(surface.Diagnostics[i]) < resolveSurfaceDiagnosticKey(surface.Diagnostics[j])
+	})
+	return surface
+}
+
+func resolveSurfaceSymbolKey(s ResolveSymbolSurfaceRecord) string {
+	return resolveSnapshotKey(s.File, s.Start, s.End, s.Kind, s.Name, s.SymbolID)
+}
+
+func resolveSurfaceRefKey(r ResolveReferenceSurfaceRecord) string {
+	return resolveSnapshotKey(r.File, r.Start, r.End, r.Name, r.TargetFile, r.TargetStart, r.TargetEnd)
+}
+
+func resolveSurfaceTypeRefKey(r ResolveTypeReferenceSurfaceRecord) string {
+	return resolveSnapshotKey(r.File, r.Start, r.End, r.Name)
+}
+
+func resolveSurfaceDiagnosticKey(d ResolveDiagnosticSurfaceRecord) string {
+	return resolveSnapshotKey(d.File, d.Start, d.End, d.Code, d.Name)
+}


### PR DESCRIPTION
## Summary

- Move package import-surface construction into `internal/resolve` so resolver and checker share one contract.
- Treat selfhost resolver output as the canonical result by adding stable package/symbol/decl/binding IDs and projecting Go resolver symbols from that output.
- Add resolver snapshot and consumer surface helpers, plus regression coverage for scoped use/member imports, cycles, stdlib member imports, private member access, and private re-export diagnostics.

## Validation

- `go test -count=1 -vet=off ./internal/selfhost`
- `go test -count=1 -vet=off ./internal/resolve`
- `go test -count=1 -vet=off ./internal/check`
- `go test -count=1 -vet=off -short ./cmd/osty ./cmd/osty-native-resolver`
- `go test -count=1 -vet=off ./internal/lsp ./internal/docgen ./internal/query/osty`
- `just front`
- `just short`