### PR TITLE
[codex] lexer selfhost stable token ids

### DIFF
--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -83,6 +84,68 @@ func sourceLineColAt(src string, offset int) (int, int) {
 func TestLexUnterminatedString(t *testing.T) {
 	expectCode(t, "let s = \"hello", "E0001")
 	expectCode(t, "let s = \"hello\n", "E0001")
+}
+
+func TestLexSnapshot(t *testing.T) {
+	src := strings.Join([]string{
+		"/// doc",
+		"fn main() {",
+		`    let s = "hi\n{who}"`,
+		"    // keep",
+		`    let bad = "oops\q"`,
+		"}",
+		"",
+	}, "\n")
+	l := New([]byte(src))
+	got := lexSnapshot(l.Lex(), l.Errors(), l.Comments())
+	const want = `TOKENS
+fn "fn" 2:1-2:3 doc="doc"
+IDENT "main" 2:4-2:8
+( "(" 2:8-2:9
+) ")" 2:9-2:10
+{ "{" 2:11-2:12
+let "let" 3:5-3:8
+IDENT "s" 3:9-3:10
+= "=" 3:11-3:12
+STRING "\"hi\\n{who}\"" 3:13-3:24 parts=[text:"hi\n",expr:IDENT("who")]
+NEWLINE "\n" 3:24-4:1
+let "let" 5:5-5:8
+IDENT "bad" 5:9-5:12
+= "=" 5:13-5:14
+STRING "\"oops\\q\"" 5:15-5:23 parts=[text:"oopsq"]
+} "}" 6:1-6:2
+NEWLINE "\n" 6:2-7:1
+EOF "" 7:1-7:1
+DIAGNOSTICS
+E0003 unknown escape sequence 5:20-5:22
+COMMENTS
+2 1:1-1 text=" doc"
+0 4:5-4 text=" keep"
+`
+	if got != want {
+		t.Fatalf("lexer snapshot drift\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestLexRecoversAfterMalformedLiteral(t *testing.T) {
+	src := strings.Join([]string{
+		`let broken = "bad\q"`,
+		"fn after() { return 1 }",
+		"",
+	}, "\n")
+	l := New([]byte(src))
+	toks := l.Lex()
+	expectCode(t, src, "E0003")
+	var sawAfter bool
+	for i := range toks {
+		if toks[i].Kind == token.IDENT && toks[i].Value == "after" {
+			sawAfter = true
+			break
+		}
+	}
+	if !sawAfter {
+		t.Fatalf("lexer did not recover to the following declaration; tokens=%v", toks)
+	}
 }
 
 func TestLexDiagnosticContracts(t *testing.T) {
@@ -204,6 +267,48 @@ func TestLexDiagnosticContracts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func lexSnapshot(toks []token.Token, errs []*Error, comments []token.Comment) string {
+	var b strings.Builder
+	b.WriteString("TOKENS\n")
+	for _, tk := range toks {
+		fmt.Fprintf(&b, "%s %q %s-%s", tk.Kind, tk.Value, tk.Pos, tk.End)
+		if tk.LeadingDoc != "" {
+			fmt.Fprintf(&b, " doc=%q", tk.LeadingDoc)
+		}
+		if len(tk.Parts) > 0 {
+			b.WriteString(" parts=[")
+			for i, part := range tk.Parts {
+				if i > 0 {
+					b.WriteByte(',')
+				}
+				if part.Kind == token.PartText {
+					fmt.Fprintf(&b, "text:%q", part.Text)
+					continue
+				}
+				b.WriteString("expr:")
+				for j, expr := range part.Expr {
+					if j > 0 {
+						b.WriteByte(' ')
+					}
+					fmt.Fprintf(&b, "%s(%q)", expr.Kind, expr.Value)
+				}
+			}
+			b.WriteByte(']')
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteString("DIAGNOSTICS\n")
+	for _, d := range errs {
+		span := d.Spans[0].Span
+		fmt.Fprintf(&b, "%s %s %s-%s\n", d.Code, d.Message, span.Start, span.End)
+	}
+	b.WriteString("COMMENTS\n")
+	for _, c := range comments {
+		fmt.Fprintf(&b, "%d %s-%d text=%q\n", c.Kind, c.Pos, c.EndLine, c.Text)
+	}
+	return b.String()
 }
 
 func TestLexUppercaseBasePrefix(t *testing.T) {

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -1,7 +1,6 @@
 package selfhost
 
 import (
-	"strings"
 	"sync/atomic"
 	"unicode/utf8"
 
@@ -142,43 +141,6 @@ func matchTextUnits(units []string, start int, text string) bool {
 	return true
 }
 
-func collectLeadingDocs(units []string, stream *FrontLexStream) []string {
-	leadingDocs := make([]string, 0, len(stream.tokens))
-	commentIdx := 0
-	commentCount := len(stream.comments)
-
-	for _, tok := range stream.tokens {
-		for commentIdx < commentCount && stream.comments[commentIdx].end.line < tok.start.line {
-			commentIdx++
-		}
-		if tok.leadingDocLines <= 0 {
-			leadingDocs = append(leadingDocs, "")
-			continue
-		}
-
-		docStartLine := tok.start.line - tok.leadingDocLines
-		docIdx := commentIdx
-		for docIdx > 0 && stream.comments[docIdx-1].end.line >= docStartLine {
-			docIdx--
-		}
-
-		var doc strings.Builder
-		for idx := docIdx; idx < commentIdx; idx++ {
-			c := stream.comments[idx]
-			if !ostyEqual(c.kind, FrontCommentKind(&FrontCommentKind_FrontCommentDoc{})) {
-				continue
-			}
-			if doc.Len() > 0 {
-				doc.WriteByte('\n')
-			}
-			doc.WriteString(strings.TrimSpace(ostyCommentText(units, c)))
-		}
-		leadingDocs = append(leadingDocs, doc.String())
-	}
-
-	return leadingDocs
-}
-
 // Tokens returns the public token stream, including EOF.
 func (r *FrontendRun) Tokens() []token.Token {
 	r.ensureLexAdapted()
@@ -267,7 +229,7 @@ func adaptLexStream(rt runeTable, stream *FrontLexStream, facts *OstyLexFacts) (
 			Triple:     ft.triple,
 			LeadingDoc: adapterStringAt(facts.leadingDocs, len(toks)),
 		}
-		fillLiteralParts(&tok, rt, stream, facts, len(toks))
+		fillLiteralParts(&tok, rt, stream, facts, ft.id)
 		toks = append(toks, tok)
 	}
 	comments := make([]token.Comment, 0, len(facts.comments))
@@ -529,11 +491,11 @@ func mapTokenKind(k FrontTokenKind) token.Kind {
 	return token.ILLEGAL
 }
 
-func fillLiteralParts(tok *token.Token, rt runeTable, stream *FrontLexStream, facts *OstyLexFacts, owner int) {
+func fillLiteralParts(tok *token.Token, rt runeTable, stream *FrontLexStream, facts *OstyLexFacts, ownerID int) {
 	switch tok.Kind {
 	case token.STRING, token.RAWSTRING:
 		for _, p := range facts.stringParts {
-			if p.ownerToken != owner {
+			if p.ownerTokenID != ownerID {
 				continue
 			}
 			if p.kindCode == int(token.PartExpr) {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -1418,6 +1418,7 @@ type FrontPos struct {
 
 // Osty: /tmp/selfhost_merged.osty:644:5
 type FrontLexToken struct {
+	id              int
 	kind            FrontTokenKind
 	start           *FrontPos
 	end             *FrontPos
@@ -1948,7 +1949,181 @@ func emptyFrontPos() *FrontPos {
 
 // Osty: /tmp/selfhost_merged.osty:972:5
 func frontLexToken(kind FrontTokenKind, start *FrontPos, end *FrontPos, length int, leadingDocLines int, triple bool, interpolations int, baseLiteral bool) *FrontLexToken {
-	return &FrontLexToken{kind: kind, start: start, end: end, length: length, leadingDocLines: leadingDocLines, triple: triple, interpolations: interpolations, baseLiteral: baseLiteral}
+	return &FrontLexToken{id: frontStableTokenID(kind, start, end, length), kind: kind, start: start, end: end, length: length, leadingDocLines: leadingDocLines, triple: triple, interpolations: interpolations, baseLiteral: baseLiteral}
+}
+
+func frontStableTokenID(kind FrontTokenKind, start *FrontPos, end *FrontPos, length int) int {
+	_ = end
+	_ = length
+	return (start.offset+1)*257 + frontTokenKindStableCode(kind)
+}
+
+func frontTokenKindStableCode(kind FrontTokenKind) int {
+	switch kind.(type) {
+	case *FrontTokenKind_FrontEOF:
+		return 0
+	case *FrontTokenKind_FrontIllegal:
+		return 1
+	case *FrontTokenKind_FrontNewline:
+		return 2
+	case *FrontTokenKind_FrontIdent:
+		return 3
+	case *FrontTokenKind_FrontLabel:
+		return 4
+	case *FrontTokenKind_FrontInt:
+		return 5
+	case *FrontTokenKind_FrontFloat:
+		return 6
+	case *FrontTokenKind_FrontChar:
+		return 7
+	case *FrontTokenKind_FrontByte:
+		return 8
+	case *FrontTokenKind_FrontString:
+		return 9
+	case *FrontTokenKind_FrontRawString:
+		return 10
+	case *FrontTokenKind_FrontFn:
+		return 11
+	case *FrontTokenKind_FrontStruct:
+		return 12
+	case *FrontTokenKind_FrontEnum:
+		return 13
+	case *FrontTokenKind_FrontInterface:
+		return 14
+	case *FrontTokenKind_FrontType:
+		return 15
+	case *FrontTokenKind_FrontLet:
+		return 16
+	case *FrontTokenKind_FrontMut:
+		return 17
+	case *FrontTokenKind_FrontPub:
+		return 18
+	case *FrontTokenKind_FrontUse:
+		return 19
+	case *FrontTokenKind_FrontIf:
+		return 20
+	case *FrontTokenKind_FrontElse:
+		return 21
+	case *FrontTokenKind_FrontMatch:
+		return 22
+	case *FrontTokenKind_FrontFor:
+		return 23
+	case *FrontTokenKind_FrontReturn:
+		return 24
+	case *FrontTokenKind_FrontBreak:
+		return 25
+	case *FrontTokenKind_FrontContinue:
+		return 26
+	case *FrontTokenKind_FrontDefer:
+		return 27
+	case *FrontTokenKind_FrontLParen:
+		return 28
+	case *FrontTokenKind_FrontRParen:
+		return 29
+	case *FrontTokenKind_FrontLBrace:
+		return 30
+	case *FrontTokenKind_FrontRBrace:
+		return 31
+	case *FrontTokenKind_FrontLBracket:
+		return 32
+	case *FrontTokenKind_FrontRBracket:
+		return 33
+	case *FrontTokenKind_FrontComma:
+		return 34
+	case *FrontTokenKind_FrontColon:
+		return 35
+	case *FrontTokenKind_FrontSemicolon:
+		return 36
+	case *FrontTokenKind_FrontDot:
+		return 37
+	case *FrontTokenKind_FrontPlus:
+		return 38
+	case *FrontTokenKind_FrontMinus:
+		return 39
+	case *FrontTokenKind_FrontStar:
+		return 40
+	case *FrontTokenKind_FrontSlash:
+		return 41
+	case *FrontTokenKind_FrontPercent:
+		return 42
+	case *FrontTokenKind_FrontEq:
+		return 43
+	case *FrontTokenKind_FrontNeq:
+		return 44
+	case *FrontTokenKind_FrontLt:
+		return 45
+	case *FrontTokenKind_FrontGt:
+		return 46
+	case *FrontTokenKind_FrontLeq:
+		return 47
+	case *FrontTokenKind_FrontGeq:
+		return 48
+	case *FrontTokenKind_FrontAnd:
+		return 49
+	case *FrontTokenKind_FrontOr:
+		return 50
+	case *FrontTokenKind_FrontNot:
+		return 51
+	case *FrontTokenKind_FrontBitAnd:
+		return 52
+	case *FrontTokenKind_FrontBitOr:
+		return 53
+	case *FrontTokenKind_FrontBitXor:
+		return 54
+	case *FrontTokenKind_FrontBitNot:
+		return 55
+	case *FrontTokenKind_FrontShl:
+		return 56
+	case *FrontTokenKind_FrontShr:
+		return 57
+	case *FrontTokenKind_FrontAssign:
+		return 58
+	case *FrontTokenKind_FrontPlusEq:
+		return 59
+	case *FrontTokenKind_FrontMinusEq:
+		return 60
+	case *FrontTokenKind_FrontStarEq:
+		return 61
+	case *FrontTokenKind_FrontSlashEq:
+		return 62
+	case *FrontTokenKind_FrontPercentEq:
+		return 63
+	case *FrontTokenKind_FrontBitAndEq:
+		return 64
+	case *FrontTokenKind_FrontBitOrEq:
+		return 65
+	case *FrontTokenKind_FrontBitXorEq:
+		return 66
+	case *FrontTokenKind_FrontShlEq:
+		return 67
+	case *FrontTokenKind_FrontShrEq:
+		return 68
+	case *FrontTokenKind_FrontArrow:
+		return 69
+	case *FrontTokenKind_FrontChanArrow:
+		return 70
+	case *FrontTokenKind_FrontQuestion:
+		return 71
+	case *FrontTokenKind_FrontAsQuestion:
+		return 72
+	case *FrontTokenKind_FrontQDot:
+		return 73
+	case *FrontTokenKind_FrontQQ:
+		return 74
+	case *FrontTokenKind_FrontDotDot:
+		return 75
+	case *FrontTokenKind_FrontDotDotEq:
+		return 76
+	case *FrontTokenKind_FrontColonColon:
+		return 77
+	case *FrontTokenKind_FrontUnderscore:
+		return 78
+	case *FrontTokenKind_FrontAt:
+		return 79
+	case *FrontTokenKind_FrontHash:
+		return 80
+	}
+	return 1
 }
 
 // Osty: /tmp/selfhost_merged.osty:994:5
@@ -16959,6 +17134,7 @@ func ostyFormatCheck(source string) *OstyFormatCheckResult {
 
 // Osty: /tmp/selfhost_merged.osty:6230:5
 type OstyRichToken struct {
+	id          int
 	kind        FrontTokenKind
 	text        string
 	startOffset int
@@ -17003,6 +17179,7 @@ type OstyLexComment struct {
 // Osty: /tmp/selfhost_merged.osty:6273:5
 type OstyLexStringPart struct {
 	ownerToken     int
+	ownerTokenID   int
 	kindCode       int
 	text           string
 	exprTokenStart int
@@ -17074,7 +17251,7 @@ func ostyLex(source string) *OstyLexResult {
 		text := ostyStringAt(facts.tokenTexts, tokenIdx)
 		_ = text
 		// Osty: /tmp/selfhost_merged.osty:6343:9
-		rt := &OstyRichToken{kind: lexTok.kind, text: text, startOffset: lexTok.start.offset, startLine: lexTok.start.line, startCol: lexTok.start.column, endOffset: lexTok.end.offset, endLine: lexTok.end.line, endCol: lexTok.end.column, leadingDoc: ostyStringAt(facts.leadingDocs, tokenIdx), triple: lexTok.triple, partCount: lexTok.interpolations}
+		rt := &OstyRichToken{id: lexTok.id, kind: lexTok.kind, text: text, startOffset: lexTok.start.offset, startLine: lexTok.start.line, startCol: lexTok.start.column, endOffset: lexTok.end.offset, endLine: lexTok.end.line, endCol: lexTok.end.column, leadingDoc: ostyStringAt(facts.leadingDocs, tokenIdx), triple: lexTok.triple, partCount: lexTok.interpolations}
 		_ = rt
 		// Osty: /tmp/selfhost_merged.osty:6356:9
 		func() struct{} { tokens = append(tokens, rt); return struct{}{} }()
@@ -17246,9 +17423,12 @@ func ostyLexFactsFromStream(source string, stream *FrontLexStream) *OstyLexFacts
 			ti = _cur1655 + _rhs1656
 		}()
 	}
-	// Osty: /tmp/selfhost_merged.osty:6370:5
-	leadingDocs := collectLeadingDocs(units, stream)
-	_ = leadingDocs
+	var leadingDocs []string = make([]string, 0, tokenCount)
+	li := 0
+	for li < tokenCount {
+		leadingDocs = append(leadingDocs, ostyJoinDocLines(units, stream, frontLexTokenAt(stream, li)))
+		li = li + 1
+	}
 	return &OstyLexFacts{errors: errors, comments: comments, stringParts: stringParts, leadingDocs: leadingDocs, tokenTexts: tokenTexts, interpolationTokenTexts: interpolationTokenTexts}
 }
 
@@ -17625,7 +17805,7 @@ func ostyLexStringPartFromFront(units []string, tok *FrontLexToken, part *FrontS
 	// Osty: /tmp/selfhost_merged.osty:6596:5
 	if ostyEqual(part.kind, FrontStringPartKind(&FrontStringPartKind_FrontStringInterpolation{})) {
 		// Osty: /tmp/selfhost_merged.osty:6597:9
-		return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 1, text: "", exprTokenStart: part.exprTokenStart, exprTokenCount: part.exprTokenCount}
+		return &OstyLexStringPart{ownerToken: part.ownerToken, ownerTokenID: tok.id, kindCode: 1, text: "", exprTokenStart: part.exprTokenStart, exprTokenCount: part.exprTokenCount}
 	}
 	// Osty: /tmp/selfhost_merged.osty:6606:5
 	text := frontLexemeFromUnits(units, part.start.offset, func() int {
@@ -17641,7 +17821,7 @@ func ostyLexStringPartFromFront(units []string, tok *FrontLexToken, part *FrontS
 	}())
 	_ = text
 	text = ostyPublicStringPartText(units, tok, text)
-	return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 0, text: text, exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: part.ownerToken, ownerTokenID: tok.id, kindCode: 0, text: text, exprTokenStart: 0, exprTokenCount: 0}
 }
 
 // Osty: /tmp/selfhost_merged.osty:6620:1
@@ -17650,7 +17830,7 @@ func ostyDefaultStringPart(units []string, tok *FrontLexToken, owner int) *OstyL
 	text := ostyStringContentRaw(units, tok)
 	_ = text
 	text = ostyPublicStringPartText(units, tok, text)
-	return &OstyLexStringPart{ownerToken: owner, kindCode: 0, text: text, exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: owner, ownerTokenID: tok.id, kindCode: 0, text: text, exprTokenStart: 0, exprTokenCount: 0}
 }
 
 func ostyPublicStringText(tok *FrontLexToken, raw string) string {
@@ -18208,7 +18388,7 @@ func ostyLexResultCommentCount(result *OstyLexResult) int {
 // Osty: /tmp/selfhost_merged.osty:6786:5
 func ostyLexResultTokenAt(result *OstyLexResult, idx int) *OstyRichToken {
 	if idx < 0 || idx >= len(result.tokens) {
-		return &OstyRichToken{kind: FrontTokenKind(&FrontTokenKind_FrontEOF{}), text: "", startOffset: 0, startLine: 0, startCol: 0, endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0}
+		return &OstyRichToken{id: 0, kind: FrontTokenKind(&FrontTokenKind_FrontEOF{}), text: "", startOffset: 0, startLine: 0, startCol: 0, endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0}
 	}
 	return result.tokens[idx]
 }

--- a/internal/selfhost/lexer_contract_test.go
+++ b/internal/selfhost/lexer_contract_test.go
@@ -54,6 +54,48 @@ func TestLexAdapterCopiesCanonicalFacts(t *testing.T) {
 	}
 }
 
+func TestLexResultStableTokenIDs(t *testing.T) {
+	src := `/// doc
+fn main() {
+    let s = "hi {name}"
+    let raw = r"raw"
+}
+`
+
+	lexed, facts, _ := canonicalLexFacts(src)
+	result := ostyLex(src)
+	if got, want := ostyLexResultTokenCount(result), frontLexTokenCount(lexed.stream); got != want {
+		t.Fatalf("rich token count = %d; want %d", got, want)
+	}
+
+	seen := map[int]bool{}
+	for i := 0; i < frontLexTokenCount(lexed.stream); i++ {
+		front := frontLexTokenAt(lexed.stream, i)
+		rich := ostyLexResultTokenAt(result, i)
+		if front.id <= 0 {
+			t.Fatalf("front token %d has non-stable id %d", i, front.id)
+		}
+		if seen[front.id] {
+			t.Fatalf("duplicate token id %d at token %d", front.id, i)
+		}
+		seen[front.id] = true
+		if rich.id != front.id {
+			t.Fatalf("rich token %d id = %d; want front token id %d", i, rich.id, front.id)
+		}
+	}
+
+	str := firstFrontTokenKind(t, lexed.stream, FrontTokenKind(&FrontTokenKind_FrontString{}))
+	parts := canonicalPartsForOwnerID(facts.stringParts, str.id)
+	if len(parts) == 0 {
+		t.Fatalf("missing string parts for stable owner id %d", str.id)
+	}
+	for _, part := range parts {
+		if part.ownerTokenID != str.id {
+			t.Fatalf("part ownerTokenID = %d; want %d", part.ownerTokenID, str.id)
+		}
+	}
+}
+
 func TestLexAdapterDiagnosticsCopyCanonicalFacts(t *testing.T) {
 	src := strings.Join([]string{
 		`let s = "bad\q"`,
@@ -131,7 +173,8 @@ func assertTokensMatchCanonicalFacts(t *testing.T, toks []token.Token, stream *F
 
 func assertTokenPartsMatchCanonicalFacts(t *testing.T, tok token.Token, owner int, stream *FrontLexStream, facts *OstyLexFacts, rt runeTable) {
 	t.Helper()
-	wantParts := canonicalPartsForOwner(facts.stringParts, owner)
+	front := frontLexTokenAt(stream, owner)
+	wantParts := canonicalPartsForOwnerID(facts.stringParts, front.id)
 	if len(tok.Parts) != len(wantParts) {
 		t.Fatalf("token %d parts = %d; want %d (%+v)", owner, len(tok.Parts), len(wantParts), tok.Parts)
 	}
@@ -162,14 +205,26 @@ func assertTokenPartsMatchCanonicalFacts(t *testing.T, tok token.Token, owner in
 	}
 }
 
-func canonicalPartsForOwner(parts []*OstyLexStringPart, owner int) []*OstyLexStringPart {
+func canonicalPartsForOwnerID(parts []*OstyLexStringPart, ownerID int) []*OstyLexStringPart {
 	var out []*OstyLexStringPart
 	for _, part := range parts {
-		if part.ownerToken == owner {
+		if part.ownerTokenID == ownerID {
 			out = append(out, part)
 		}
 	}
 	return out
+}
+
+func firstFrontTokenKind(t *testing.T, stream *FrontLexStream, kind FrontTokenKind) *FrontLexToken {
+	t.Helper()
+	for i := 0; i < frontLexTokenCount(stream); i++ {
+		tok := frontLexTokenAt(stream, i)
+		if ostyEqual(tok.kind, kind) {
+			return tok
+		}
+	}
+	t.Fatalf("missing front token kind %s", frontTokenKindName(kind))
+	return nil
 }
 
 func assertCommentsMatchCanonicalFacts(t *testing.T, comments []token.Comment, facts *OstyLexFacts, rt runeTable) {

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -136,6 +136,7 @@ pub struct FrontPos {
 /// FrontLexToken is the self-hosting token shape. It stores normalized
 /// source positions and literal metadata without copying lexeme text.
 pub struct FrontLexToken {
+    pub id: Int,
     pub kind: FrontTokenKind,
     pub start: FrontPos,
     pub end: FrontPos,
@@ -474,6 +475,7 @@ pub fn frontLexToken(
     baseLiteral: Bool,
 ) -> FrontLexToken {
     FrontLexToken {
+        id: frontStableTokenID(kind, start, end, length),
         kind,
         start,
         end,
@@ -487,6 +489,107 @@ pub fn frontLexToken(
 
 pub fn emptyFrontLexToken() -> FrontLexToken {
     frontLexToken(FrontEOF, emptyFrontPos(), emptyFrontPos(), 0, 0, false, 0, false)
+}
+
+/// frontStableTokenID is a deterministic identity for a lexed token in a
+/// normalized source buffer. It deliberately avoids slice indexes so side
+/// tables can keep referring to the same token even if callers filter or copy
+/// the token list at legacy boundaries.
+pub fn frontStableTokenID(
+    kind: FrontTokenKind,
+    start: FrontPos,
+    end: FrontPos,
+    length: Int,
+) -> Int {
+    let _ = end
+    let _ = length
+    (start.offset + 1) * 257 + frontTokenKindStableCode(kind)
+}
+
+pub fn frontTokenKindStableCode(kind: FrontTokenKind) -> Int {
+    match kind {
+        FrontEOF -> 0,
+        FrontIllegal -> 1,
+        FrontNewline -> 2,
+        FrontIdent -> 3,
+        FrontLabel -> 4,
+        FrontInt -> 5,
+        FrontFloat -> 6,
+        FrontChar -> 7,
+        FrontByte -> 8,
+        FrontString -> 9,
+        FrontRawString -> 10,
+        FrontFn -> 11,
+        FrontStruct -> 12,
+        FrontEnum -> 13,
+        FrontInterface -> 14,
+        FrontType -> 15,
+        FrontLet -> 16,
+        FrontMut -> 17,
+        FrontPub -> 18,
+        FrontUse -> 19,
+        FrontIf -> 20,
+        FrontElse -> 21,
+        FrontMatch -> 22,
+        FrontFor -> 23,
+        FrontReturn -> 24,
+        FrontBreak -> 25,
+        FrontContinue -> 26,
+        FrontDefer -> 27,
+        FrontLParen -> 28,
+        FrontRParen -> 29,
+        FrontLBrace -> 30,
+        FrontRBrace -> 31,
+        FrontLBracket -> 32,
+        FrontRBracket -> 33,
+        FrontComma -> 34,
+        FrontColon -> 35,
+        FrontSemicolon -> 36,
+        FrontDot -> 37,
+        FrontPlus -> 38,
+        FrontMinus -> 39,
+        FrontStar -> 40,
+        FrontSlash -> 41,
+        FrontPercent -> 42,
+        FrontEq -> 43,
+        FrontNeq -> 44,
+        FrontLt -> 45,
+        FrontGt -> 46,
+        FrontLeq -> 47,
+        FrontGeq -> 48,
+        FrontAnd -> 49,
+        FrontOr -> 50,
+        FrontNot -> 51,
+        FrontBitAnd -> 52,
+        FrontBitOr -> 53,
+        FrontBitXor -> 54,
+        FrontBitNot -> 55,
+        FrontShl -> 56,
+        FrontShr -> 57,
+        FrontAssign -> 58,
+        FrontPlusEq -> 59,
+        FrontMinusEq -> 60,
+        FrontStarEq -> 61,
+        FrontSlashEq -> 62,
+        FrontPercentEq -> 63,
+        FrontBitAndEq -> 64,
+        FrontBitOrEq -> 65,
+        FrontBitXorEq -> 66,
+        FrontShlEq -> 67,
+        FrontShrEq -> 68,
+        FrontArrow -> 69,
+        FrontChanArrow -> 70,
+        FrontQuestion -> 71,
+        FrontAsQuestion -> 72,
+        FrontQDot -> 73,
+        FrontQQ -> 74,
+        FrontDotDot -> 75,
+        FrontDotDotEq -> 76,
+        FrontColonColon -> 77,
+        FrontUnderscore -> 78,
+        FrontAt -> 79,
+        FrontHash -> 80,
+    }
 }
 
 pub fn frontLexDiagnostic(

--- a/toolchain/frontend_test.osty
+++ b/toolchain/frontend_test.osty
@@ -113,6 +113,19 @@ fn testFrontendLexerEmitsRichTokenStream() {
     testing.assertEq(doc.start.line, 1)
 }
 
+fn testFrontendLexerAssignsStableTokenIDs() {
+    let stream = frontendLexStream("x")
+    let again = frontendLexStream("x")
+
+    let ident = frontLexTokenAt(stream, 0)
+    let virtualNewline = frontLexTokenAt(stream, 1)
+    let eof = frontLexTokenAt(stream, 2)
+
+    testing.assert(ident.id > 0)
+    testing.assertEq(ident.id, frontLexTokenAt(again, 0).id)
+    testing.assert(virtualNewline.id != eof.id)
+}
+
 fn testFrontendLexerEmitsStructuredDiagnostics() {
     let stream = frontendLexStream("0B101\n\"oops\n/* nope")
 

--- a/toolchain/lexer.osty
+++ b/toolchain/lexer.osty
@@ -14,6 +14,7 @@ use std.strings as strings
 /// the Go token.Token does: kind, position, text, doc comment, triple
 /// flag, and string parts (for interpolation).
 pub struct OstyRichToken {
+    pub id: Int,
     pub kind: FrontTokenKind,
     pub text: String,
     pub startOffset: Int,
@@ -60,6 +61,7 @@ pub struct OstyLexComment {
 /// layer, not to the Go adapter.
 pub struct OstyLexStringPart {
     pub ownerToken: Int,
+    pub ownerTokenID: Int,
     pub kindCode: Int,
     pub text: String,
     pub exprTokenStart: Int,
@@ -132,6 +134,7 @@ pub fn ostyLex(source: String) -> OstyLexResult {
         let text = ostyStringAt(facts.tokenTexts, tokenIdx)
 
         let mut rt = OstyRichToken {
+            id: lexTok.id,
             kind: lexTok.kind,
             text,
             startOffset: lexTok.start.offset,
@@ -378,6 +381,7 @@ fn ostyLexStringPartFromFront(
     if part.kind == FrontStringInterpolation {
         return OstyLexStringPart {
             ownerToken: part.ownerToken,
+            ownerTokenID: tok.id,
             kindCode: 1,
             text: "",
             exprTokenStart: part.exprTokenStart,
@@ -391,6 +395,7 @@ fn ostyLexStringPartFromFront(
     )
     OstyLexStringPart {
         ownerToken: part.ownerToken,
+        ownerTokenID: tok.id,
         kindCode: 0,
         text,
         exprTokenStart: 0,
@@ -402,6 +407,7 @@ fn ostyDefaultStringPart(units: List<String>, tok: FrontLexToken, owner: Int) ->
     let text = ostyPublicStringPartText(units, tok, ostyStringContentRaw(units, tok))
     OstyLexStringPart {
         ownerToken: owner,
+        ownerTokenID: tok.id,
         kindCode: 0,
         text,
         exprTokenStart: 0,
@@ -788,7 +794,7 @@ pub fn ostyLexResultCommentCount(result: OstyLexResult) -> Int {
 pub fn ostyLexResultTokenAt(result: OstyLexResult, idx: Int) -> OstyRichToken {
     if idx < 0 || idx >= result.tokens.len() {
         return OstyRichToken {
-            kind: FrontEOF, text: "", startOffset: 0, startLine: 0, startCol: 0,
+            id: 0, kind: FrontEOF, text: "", startOffset: 0, startLine: 0, startCol: 0,
             endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0,
         }
     }

--- a/toolchain/lossless_lex.osty
+++ b/toolchain/lossless_lex.osty
@@ -72,6 +72,7 @@ pub struct LosslessTrivia {
 /// LosslessToken pairs a raw `FrontLexToken` with its trivia slices
 /// and a state snapshot for incremental re-lex.
 pub struct LosslessToken {
+    pub id: Int,
     pub kind: FrontTokenKind,
     pub offset: Int,
     pub length: Int,
@@ -467,6 +468,7 @@ fn losslessBuildTokens(
 
         out.push(
             LosslessToken {
+                id: tok.id,
                 kind: tok.kind,
                 offset: tok.start.offset,
                 length: tok.length,
@@ -992,6 +994,7 @@ pub fn losslessTokenAt(stream: LosslessStream, target: Int) -> LosslessToken {
         idx = idx + 1
     }
     LosslessToken {
+        id: 0,
         kind: FrontEOF,
         offset: stream.unitCount,
         length: 0,

--- a/toolchain/lossless_lex_test.osty
+++ b/toolchain/lossless_lex_test.osty
@@ -373,6 +373,18 @@ fn testCompatBridgeTokenKinds() {
     testing.assertEq(losslessCount, fronts.len())
 }
 
+fn testLosslessTokensCarryStableIDsAcrossLegacyBridge() {
+    let src = "x"
+    let stream = losslessLex(src)
+    let first = losslessTokenAt(stream, 0)
+    let inner = frontLexTokenAt(stream.inner, 0)
+    let fronts = losslessToFrontTokens(stream)
+
+    testing.assert(first.id > 0)
+    testing.assertEq(first.id, inner.id)
+    testing.assertEq(fronts[0].text, "x")
+}
+
 // -------------------------------------------------------------------
 // ACCESSORS
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add stable selfhost token IDs and carry them through rich/lossless lexer results
- key string-part ownership by stable token ID at the Go adapter boundary
- add lexer snapshot, recovery, stable-ID, and toolchain parser coverage tests

## Validation
- `just front`
- `just build`
- `go test -count=1 -vet=off ./internal/lexer ./internal/selfhost ./internal/selfhost/bundle ./internal/llvmgen -run 'TestLex|FuzzLex|TestToolchainCheckerBundleIsToolchainOnly|TestToolchainFilesParseWithoutDiagnostics|TestToolchainCheckerProbeHelpersStayDeterministic'`
- `go test -count=1 -vet=off ./internal/lexer -run '^$' -fuzz=FuzzLex -fuzztime=5s`
- `git diff --check`

Note: direct `osty test` for `toolchain/frontend_test.osty` and `toolchain/lossless_lex_test.osty` still hits the existing native backend Go FFI limitation for `std.strings`, so the toolchain verification used the existing Go/probe surfaces.