### PR TITLE
[codex] resolver selfhost type ref identity

### DIFF
--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -5,9 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/token"
 )
 
 // TestLoadPackageForNativeMultiFileIsAstbridgeFree pins the PR6 wedge:
@@ -179,6 +181,99 @@ func TestNativeStructuredCrossFileRefCarriesStableTargetID(t *testing.T) {
 	}
 	if !foundRef {
 		t.Fatalf("missing native helper ref with target symbol id %q: %#v", helperSym.ID, structured.Refs)
+	}
+}
+
+func TestNativeBridgeTypeRefCarriesStableTargetID(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub struct Box { value: Int }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn useBox(x: Box) -> Int {
+    1
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageArenaFirst(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageArenaFirst: %v", err)
+	}
+	result := ResolvePackage(pkg, NewPrelude())
+	if len(result.Diags) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", result.Diags)
+	}
+	structured, err := NativeStructuredResult(pkg)
+	if err != nil {
+		t.Fatalf("NativeStructuredResult: %v", err)
+	}
+	var boxSym *selfhost.ResolvedSymbol
+	for i := range structured.Symbols {
+		if structured.Symbols[i].Name == "Box" && structured.Symbols[i].File == aPath {
+			boxSym = &structured.Symbols[i]
+			break
+		}
+	}
+	if boxSym == nil || boxSym.ID == "" {
+		t.Fatalf("missing native Box symbol id: %#v", structured.Symbols)
+	}
+	var boxTypeRef *selfhost.ResolvedTypeRef
+	for i := range structured.TypeRefs {
+		if structured.TypeRefs[i].Name == "Box" && structured.TypeRefs[i].File == bPath {
+			boxTypeRef = &structured.TypeRefs[i]
+			break
+		}
+	}
+	if boxTypeRef == nil || boxTypeRef.TargetSymbolID != boxSym.ID {
+		t.Fatalf("Box type ref target = %#v, want symbol id %q", boxTypeRef, boxSym.ID)
+	}
+
+	resolved, files, err := nativeResolveArtifacts(pkg)
+	if err != nil {
+		t.Fatalf("nativeResolveArtifacts: %v", err)
+	}
+	fi := nativeResolveFileInfoFor(files, bPath)
+	origOff, ok := nativeToOriginalOffset(fi, boxTypeRef.Start)
+	if !ok {
+		t.Fatalf("could not remap Box type ref offset %d through %#v", boxTypeRef.Start, fi)
+	}
+	nt := &ast.NamedType{
+		ID:   ast.NodeID(1),
+		PosV: token.Pos{Offset: origOff},
+		EndV: token.Pos{Offset: origOff + len("Box")},
+		Path: []string{"Box"},
+	}
+	declIndexes := make(map[string]map[int]ast.Node, len(pkg.Files))
+	for _, pf := range pkg.Files {
+		if pf.File != nil {
+			declIndexes[pf.Path] = buildDeclIndex(pf.File)
+		}
+	}
+	typeRefsByID, typeRefIdents := bridgeTypeRefs(
+		resolved.TypeRefs,
+		resolved.Symbols,
+		files,
+		fi,
+		map[int]*ast.NamedType{origOff: nt},
+		declIndexes,
+		nil,
+	)
+	if len(typeRefIdents) != 1 || typeRefIdents[0] != nt {
+		t.Fatalf("typeRefIdents = %#v, want synthetic Box NamedType", typeRefIdents)
+	}
+	sym := typeRefsByID[nt.ID]
+	if sym == nil {
+		t.Fatalf("Box NamedType has no bridged symbol")
+	}
+	if sym.StableID != boxSym.ID {
+		t.Fatalf("Box bridged stable id = %q, want %q", sym.StableID, boxSym.ID)
+	}
+	if sym.ID() != (&Symbol{StableID: boxSym.ID}).ID() {
+		t.Fatalf("Box bridged Symbol.ID() did not decode stable id: got %x, want stable %s", sym.ID(), boxSym.ID)
 	}
 }
 

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -55,7 +55,7 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 		pf.RefsByID = refsByID
 		pf.RefIdents = refIdents
 
-		typeRefsByID, typeRefIdents := bridgeTypeRefs(result.TypeRefs, fi, typeIdx, fileScope)
+		typeRefsByID, typeRefIdents := bridgeTypeRefs(result.TypeRefs, result.Symbols, files, fi, typeIdx, declIndexes, fileScope)
 		pf.TypeRefsByID = typeRefsByID
 		pf.TypeRefIdents = typeRefIdents
 
@@ -451,12 +451,17 @@ func supplementUseAliasRefs(
 
 func bridgeTypeRefs(
 	typeRefs []selfhost.ResolvedTypeRef,
+	symbols []selfhost.ResolvedSymbol,
+	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	typeIdx map[int]*ast.NamedType,
-	scope *Scope,
+	declIndexes map[string]map[int]ast.Node,
+	fileScope *Scope,
 ) (map[ast.NodeID]*Symbol, []*ast.NamedType) {
 	typeRefsByID := make(map[ast.NodeID]*Symbol, len(typeRefs))
 	typeRefIdents := make([]*ast.NamedType, 0, len(typeRefs))
+	symCache := make(map[nativeSymbolTarget]*Symbol)
+	symByTarget := nativeSymbolByTarget(symbols)
 
 	for _, ref := range typeRefs {
 		origOff, ok := nativeToOriginalOffset(fi, ref.Start)
@@ -467,15 +472,70 @@ func bridgeTypeRefs(
 		if nt == nil {
 			continue
 		}
-		// Look up the target by name in the scope chain.
-		sym := scope.LookupType(ref.Name)
-		if sym == nil {
-			sym = &Symbol{Name: ref.Name, Kind: SymBuiltin, Pub: true}
-		}
+		sym := findOrCreateTypeSymbol(symCache, ref, symByTarget, files, fi, declIndexes, fileScope)
 		typeRefsByID[nt.ID] = sym
 		typeRefIdents = append(typeRefIdents, nt)
 	}
 	return typeRefsByID, typeRefIdents
+}
+
+func findOrCreateTypeSymbol(
+	cache map[nativeSymbolTarget]*Symbol,
+	ref selfhost.ResolvedTypeRef,
+	symByTarget map[nativeSymbolTarget]selfhost.ResolvedSymbol,
+	files []nativeResolveFileInfo,
+	fi nativeResolveFileInfo,
+	declIndexes map[string]map[int]ast.Node,
+	fileScope *Scope,
+) *Symbol {
+	key := nativeSymbolTarget{file: ref.TargetFile, node: ref.TargetNode, start: ref.TargetStart, end: ref.TargetEnd}
+	if sym, ok := cache[key]; ok {
+		return sym
+	}
+	if ref.TargetNode < 0 {
+		return &Symbol{StableID: ref.TargetSymbolID, PackageID: ref.PackageID, Name: ref.Name, Kind: SymBuiltin, Pub: true}
+	}
+	nativeSym := symByTarget[key]
+	targetFI := nativeResolveFileInfoFor(files, ref.TargetFile)
+	if targetFI.path == "" && ref.TargetFile == "" {
+		targetFI = fi
+	}
+	targetOrigOff, ok := nativeToOriginalOffset(targetFI, ref.TargetStart)
+	if !ok {
+		return &Symbol{StableID: ref.TargetSymbolID, PackageID: ref.PackageID, Name: ref.Name, Kind: SymBuiltin, Pub: true}
+	}
+	declIdx := declIndexes[ref.TargetFile]
+	decl := findNearestDecl(declIdx, targetOrigOff)
+	if _, isUse := decl.(*ast.UseDecl); isUse && fileScope != nil && ref.TargetFile == fi.path {
+		if sym := fileScope.LookupLocal(ref.Name); sym != nil {
+			fillSymbolIDsFromTypeRef(sym, ref)
+			cache[key] = sym
+			return sym
+		}
+	}
+	name := ref.Name
+	if nativeSym.Name != "" {
+		name = nativeSym.Name
+	}
+	sym := &Symbol{
+		StableID:  ref.TargetSymbolID,
+		PackageID: ref.PackageID,
+		DeclID:    nativeSym.DeclID,
+		Name:      name,
+		Kind:      nativeKindToSymbolKind(nativeSym.Kind),
+		Pub:       true,
+		Decl:      decl,
+	}
+	if sym.Kind == SymUnknown && nativeSym.Kind == "" {
+		sym.Kind = SymUnknown
+	}
+	if decl != nil {
+		sym.Pos = decl.Pos()
+	} else {
+		sym.Pos = token.Pos{Offset: targetOrigOff}
+	}
+	cache[key] = sym
+	return sym
 }
 
 func findOrCreateSymbol(
@@ -531,6 +591,18 @@ func findOrCreateSymbol(
 }
 
 func fillSymbolIDsFromRef(sym *Symbol, ref selfhost.ResolvedRef) {
+	if sym == nil {
+		return
+	}
+	if sym.StableID == "" {
+		sym.StableID = ref.TargetSymbolID
+	}
+	if sym.PackageID == "" {
+		sym.PackageID = ref.PackageID
+	}
+}
+
+func fillSymbolIDsFromTypeRef(sym *Symbol, ref selfhost.ResolvedTypeRef) {
 	if sym == nil {
 		return
 	}

--- a/internal/resolve/symbolid.go
+++ b/internal/resolve/symbolid.go
@@ -3,6 +3,7 @@ package resolve
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 )
 
 // SymbolID is a content-addressable identity for a [Symbol]. Two
@@ -41,6 +42,15 @@ func (s *Symbol) ID() SymbolID {
 }
 
 func computeSymbolID(s *Symbol) SymbolID {
+	if s.StableID != "" {
+		if decoded, err := hex.DecodeString(s.StableID); err == nil {
+			var out SymbolID
+			if len(decoded) == len(out) {
+				copy(out[:], decoded)
+				return out
+			}
+		}
+	}
 	h := sha256.New()
 	writeLenBytes(h, []byte(s.Name))
 	h.Write([]byte{byte(s.Kind)})

--- a/internal/resolve/symbolid_test.go
+++ b/internal/resolve/symbolid_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/osty/osty/internal/token"
@@ -87,6 +88,31 @@ func TestSymbolIDNilSafe(t *testing.T) {
 	var s *Symbol
 	if got := s.ID(); got != (SymbolID{}) {
 		t.Fatalf("nil Symbol.ID() should be zero value, got %x", got)
+	}
+}
+
+func TestSymbolIDPrefersSelfhostStableID(t *testing.T) {
+	stable := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	s := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	s.StableID = stable
+	got := s.ID()
+	wantBytes, err := hex.DecodeString(stable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want SymbolID
+	copy(want[:], wantBytes)
+	if got != want {
+		t.Fatalf("Symbol.ID() = %x, want decoded stable id %x", got, want)
+	}
+}
+
+func TestSymbolIDFallsBackWhenStableIDInvalid(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	b := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	a.StableID = "not-a-sha256"
+	if a.ID() != b.ID() {
+		t.Fatalf("invalid StableID should fall back to content hash; got %x vs %x", a.ID(), b.ID())
 	}
 }
 

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -339,13 +339,18 @@ type ResolvedRef struct {
 
 // ResolvedTypeRef records one resolved type-name reference.
 type ResolvedTypeRef struct {
-	ID        string `json:"typeRefId,omitempty"`
-	PackageID string `json:"packageId,omitempty"`
-	Name      string `json:"name"`
-	Node      int    `json:"node"`
-	Start     int    `json:"start"`
-	End       int    `json:"end"`
-	File      string `json:"file,omitempty"`
+	ID             string `json:"typeRefId,omitempty"`
+	PackageID      string `json:"packageId,omitempty"`
+	TargetSymbolID string `json:"targetSymbolId,omitempty"`
+	Name           string `json:"name"`
+	Node           int    `json:"node"`
+	Start          int    `json:"start"`
+	End            int    `json:"end"`
+	File           string `json:"file,omitempty"`
+	TargetNode     int    `json:"targetNode"`
+	TargetStart    int    `json:"targetStart"`
+	TargetEnd      int    `json:"targetEnd"`
+	TargetFile     string `json:"targetFile,omitempty"`
 }
 
 // ResolveDiagnosticRecord is one structured diagnostic produced by the

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -50978,8 +50978,11 @@ type SelfResolvedRef struct {
 
 // Osty: /tmp/selfhost_merged.osty:25674:5
 type SelfResolvedTypeRef struct {
-	name string
-	node int
+	name        string
+	node        int
+	target      int
+	targetStart int
+	targetEnd   int
 }
 
 // Osty: /tmp/selfhost_merged.osty:25681:5
@@ -52661,12 +52664,12 @@ func srResolveOneAstType(name string, start int, end int, node int, scope *SelfR
 			return srSelfTypeOutsideAtNode(out, start, end, node)
 		}
 		// Osty: /tmp/selfhost_merged.osty:27095:9
-		return srRecordTypeRef(out, name, node)
+		return srRecordTypeRef(out, name, node, srScopeLookup(scope, head))
 	}
 	// Osty: /tmp/selfhost_merged.osty:27097:5
 	if srIsBuiltinTypeName(head) {
 		// Osty: /tmp/selfhost_merged.osty:27098:9
-		return srRecordTypeRef(out, name, node)
+		return srRecordTypeRef(out, name, node, srEmptySymbol())
 	}
 	// Osty: /tmp/selfhost_merged.osty:27100:5
 	sym := srScopeLookup(scope, head)
@@ -52703,7 +52706,7 @@ func srResolveOneAstType(name string, start int, end int, node int, scope *SelfR
 		// Osty: /tmp/selfhost_merged.osty:27108:9
 		return out
 	}
-	return srRecordTypeRef(out, name, node)
+	return srRecordTypeRef(out, name, node, sym)
 }
 
 // Osty: /tmp/selfhost_merged.osty:27113:1
@@ -52788,7 +52791,7 @@ func srRecordBareRef(result *SelfResolveResult, name string, node int) *SelfReso
 }
 
 // Osty: /tmp/selfhost_merged.osty:27178:1
-func srRecordTypeRef(result *SelfResolveResult, name string, node int) *SelfResolveResult {
+func srRecordTypeRef(result *SelfResolveResult, name string, node int, target *SelfSymbol) *SelfResolveResult {
 	// Osty: /tmp/selfhost_merged.osty:27179:5
 	out := result
 	_ = out
@@ -52806,7 +52809,7 @@ func srRecordTypeRef(result *SelfResolveResult, name string, node int) *SelfReso
 	}()
 	// Osty: /tmp/selfhost_merged.osty:27181:5
 	func() struct{} {
-		out.typeRefList = append(out.typeRefList, &SelfResolvedTypeRef{name: name, node: node})
+		out.typeRefList = append(out.typeRefList, &SelfResolvedTypeRef{name: name, node: node, target: target.node, targetStart: target.start, targetEnd: target.end})
 		return struct{}{}
 	}()
 	return out
@@ -53243,9 +53246,11 @@ func srResolvePatternTypePath(path string, start int, end int, node int, scope *
 	// Osty: /tmp/selfhost_merged.osty:27476:5
 	if head == "Self" {
 		// Osty: /tmp/selfhost_merged.osty:27477:9
-		if srScopeHas(scope, head) {
+		selfSym := srScopeLookup(scope, head)
+		_ = selfSym
+		if selfSym.name != "" {
 			// Osty: /tmp/selfhost_merged.osty:27478:13
-			return srRecordTypeRef(out, head, node)
+			return srRecordTypeRef(out, head, node, selfSym)
 		}
 		// Osty: /tmp/selfhost_merged.osty:27480:9
 		return srSelfTypeOutsideAtNode(out, start, end, node)
@@ -53253,7 +53258,7 @@ func srResolvePatternTypePath(path string, start int, end int, node int, scope *
 	// Osty: /tmp/selfhost_merged.osty:27482:5
 	if srIsBuiltinTypeName(head) {
 		// Osty: /tmp/selfhost_merged.osty:27483:9
-		return srRecordTypeRef(out, head, node)
+		return srRecordTypeRef(out, head, node, srEmptySymbol())
 	}
 	// Osty: /tmp/selfhost_merged.osty:27485:5
 	sym := srScopeLookup(scope, head)
@@ -53290,7 +53295,7 @@ func srResolvePatternTypePath(path string, start int, end int, node int, scope *
 		// Osty: /tmp/selfhost_merged.osty:27493:9
 		return out
 	}
-	return srRecordTypeRef(out, head, node)
+	return srRecordTypeRef(out, head, node, sym)
 }
 
 // Osty: /tmp/selfhost_merged.osty:27498:1
@@ -53357,7 +53362,7 @@ func srResolvePatternVariantPath(path string, start int, end int, node int, scop
 	// Osty: /tmp/selfhost_merged.osty:27528:5
 	if srIsBuiltinTypeName(head) {
 		// Osty: /tmp/selfhost_merged.osty:27529:9
-		return srRecordTypeRef(out, head, node)
+		return srRecordTypeRef(out, head, node, srEmptySymbol())
 	}
 	// Osty: /tmp/selfhost_merged.osty:27531:5
 	sym := srScopeLookup(scope, head)
@@ -53387,7 +53392,7 @@ func srResolvePatternVariantPath(path string, start int, end int, node int, scop
 	// Osty: /tmp/selfhost_merged.osty:27537:5
 	if srSymbolCanBeType(sym) {
 		// Osty: /tmp/selfhost_merged.osty:27538:9
-		return srRecordTypeRef(out, head, node)
+		return srRecordTypeRef(out, head, node, sym)
 	}
 	// Osty: /tmp/selfhost_merged.osty:27540:5
 	if sym.kind == "variant" {

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -236,6 +236,9 @@ func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResul
 	}
 	for i := range result.TypeRefs {
 		result.TypeRefs[i].File = path
+		if result.TypeRefs[i].TargetNode >= 0 {
+			result.TypeRefs[i].TargetFile = path
+		}
 	}
 	for i := range result.Diagnostics {
 		result.Diagnostics[i].File = path
@@ -453,11 +456,18 @@ func adaptResolveResult(resolved *SelfResolveResult, file *AstFile, offsets func
 			continue
 		}
 		start, end := selfhostResolveNodeOffsets(file, tref.node, offsets)
+		targetStart, targetEnd := -1, -1
+		if tref.target >= 0 {
+			targetStart, targetEnd = offsets(tref.targetStart, tref.targetEnd)
+		}
 		result.TypeRefs = append(result.TypeRefs, ResolvedTypeRef{
-			Name:  tref.name,
-			Node:  tref.node,
-			Start: start,
-			End:   end,
+			Name:        tref.name,
+			Node:        tref.node,
+			Start:       start,
+			End:         end,
+			TargetNode:  tref.target,
+			TargetStart: targetStart,
+			TargetEnd:   targetEnd,
 		})
 	}
 	for _, d := range resolved.diagnostics {
@@ -523,7 +533,12 @@ func selfhostAssignResolveIDs(result *ResolveResult, packageKey string) {
 	for i := range result.TypeRefs {
 		ref := &result.TypeRefs[i]
 		ref.PackageID = packageID
-		ref.ID = stableResolveID("type-ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End))
+		ref.ID = stableResolveID("type-ref", packageKey, ref.File, ref.Name, fmt.Sprint(ref.Node), fmt.Sprint(ref.Start), fmt.Sprint(ref.End), fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd), ref.TargetFile)
+		if id := byTarget[resolveTargetKey(ref.TargetFile, ref.TargetNode, ref.TargetStart, ref.TargetEnd)]; id != "" {
+			ref.TargetSymbolID = id
+		} else if ref.TargetNode >= 0 {
+			ref.TargetSymbolID = stableResolveID("symbol-target", packageKey, ref.TargetFile, ref.Name, fmt.Sprint(ref.TargetNode), fmt.Sprint(ref.TargetStart), fmt.Sprint(ref.TargetEnd))
+		}
 	}
 	for i := range result.Diagnostics {
 		d := &result.Diagnostics[i]
@@ -569,6 +584,9 @@ func selfhostAnnotateResolveFiles(result *ResolveResult, files []PackageResolveF
 	}
 	for i := range result.TypeRefs {
 		result.TypeRefs[i].File = selfhostResolveFilePath(files, result.TypeRefs[i].Start)
+		if result.TypeRefs[i].TargetNode >= 0 {
+			result.TypeRefs[i].TargetFile = selfhostResolveFilePath(files, result.TypeRefs[i].TargetStart)
+		}
 	}
 	for i := range result.Diagnostics {
 		result.Diagnostics[i].File = selfhostResolveFilePath(files, result.Diagnostics[i].Start)

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -42,14 +42,20 @@ func TestResolvePackageStructuredHandlesCrossFileRefsASTNative(t *testing.T) {
 	helperPath := filepath.Join(dir, "helper.osty")
 	mainPath := filepath.Join(dir, "main.osty")
 
-	helper := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+	helper := canonicalSelfhostInput(t, []byte(`pub struct Box { value: Int }
+
+pub fn helper() -> Int {
     41
 }
 `), 0)
 	helper.Name = "helper.osty"
 	helper.Path = helperPath
 
-	main := canonicalSelfhostInput(t, []byte(`fn main() {
+	main := canonicalSelfhostInput(t, []byte(`fn useBox(x: Box) -> Int {
+    helper()
+}
+
+fn main() {
     let value = helper()
 }
 `), len(helper.Source)+1)
@@ -89,14 +95,20 @@ func TestResolvePackageStructuredAssignsStableIDs(t *testing.T) {
 	helperPath := filepath.Join(dir, "helper.osty")
 	mainPath := filepath.Join(dir, "main.osty")
 
-	helper := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+	helper := canonicalSelfhostInput(t, []byte(`pub struct Box { value: Int }
+
+pub fn helper() -> Int {
     41
 }
 `), 0)
 	helper.Name = "helper.osty"
 	helper.Path = helperPath
 
-	main := canonicalSelfhostInput(t, []byte(`fn main() {
+	main := canonicalSelfhostInput(t, []byte(`fn useBox(x: Box) -> Int {
+    helper()
+}
+
+fn main() {
     let value = helper()
 }
 `), len(helper.Source)+1)
@@ -114,9 +126,17 @@ func TestResolvePackageStructuredAssignsStableIDs(t *testing.T) {
 	if helperSym == nil {
 		t.Fatalf("missing helper symbol in %#v", resolved.Symbols)
 	}
+	boxSym := findResolvedSymbol(resolved, "Box", "type")
+	if boxSym == nil {
+		t.Fatalf("missing Box symbol in %#v", resolved.Symbols)
+	}
 	ref := findResolvedRef(resolved, "helper")
 	if ref == nil {
 		t.Fatalf("missing helper ref in %#v", resolved.Refs)
+	}
+	boxTypeRef := findResolvedTypeRef(resolved, "Box", mainPath)
+	if boxTypeRef == nil {
+		t.Fatalf("missing Box type ref in %#v", resolved.TypeRefs)
 	}
 	if resolved.PackageID == "" || helperSym.ID == "" || helperSym.PackageID == "" || helperSym.DeclID == "" {
 		t.Fatalf("stable symbol ids missing: package=%q helper=%#v", resolved.PackageID, helperSym)
@@ -130,14 +150,23 @@ func TestResolvePackageStructuredAssignsStableIDs(t *testing.T) {
 	if ref.TargetSymbolID != helperSym.ID {
 		t.Fatalf("ref target symbol id = %q, want helper symbol id %q", ref.TargetSymbolID, helperSym.ID)
 	}
+	if boxTypeRef.ID == "" || boxTypeRef.TargetSymbolID == "" || boxTypeRef.PackageID == "" {
+		t.Fatalf("stable type-ref ids missing: %#v", boxTypeRef)
+	}
+	if boxTypeRef.TargetSymbolID != boxSym.ID {
+		t.Fatalf("type-ref target symbol id = %q, want Box symbol id %q", boxTypeRef.TargetSymbolID, boxSym.ID)
+	}
+	if boxTypeRef.TargetFile != helperPath {
+		t.Fatalf("type-ref target file = %q, want %q", boxTypeRef.TargetFile, helperPath)
+	}
 
 	surface := selfhost.ResolveSurfaceFromResult(resolved)
 	if surface.PackageID != resolved.PackageID {
 		t.Fatalf("surface package id = %q, want %q", surface.PackageID, resolved.PackageID)
 	}
-	if len(surface.Symbols) != len(resolved.Symbols) || len(surface.Refs) != len(resolved.Refs) {
-		t.Fatalf("surface sizes = symbols:%d refs:%d, want symbols:%d refs:%d",
-			len(surface.Symbols), len(surface.Refs), len(resolved.Symbols), len(resolved.Refs))
+	if len(surface.Symbols) != len(resolved.Symbols) || len(surface.Refs) != len(resolved.Refs) || len(surface.TypeRefs) != len(resolved.TypeRefs) {
+		t.Fatalf("surface sizes = symbols:%d refs:%d typeRefs:%d, want symbols:%d refs:%d typeRefs:%d",
+			len(surface.Symbols), len(surface.Refs), len(surface.TypeRefs), len(resolved.Symbols), len(resolved.Refs), len(resolved.TypeRefs))
 	}
 	foundSurfaceRef := false
 	for _, r := range surface.Refs {
@@ -148,6 +177,16 @@ func TestResolvePackageStructuredAssignsStableIDs(t *testing.T) {
 	}
 	if !foundSurfaceRef {
 		t.Fatalf("surface missing helper ref with stable ids: %#v", surface.Refs)
+	}
+	foundSurfaceTypeRef := false
+	for _, r := range surface.TypeRefs {
+		if r.Name == "Box" && r.TargetSymbolID == boxSym.ID && r.TargetFile == helperPath {
+			foundSurfaceTypeRef = true
+			break
+		}
+	}
+	if !foundSurfaceTypeRef {
+		t.Fatalf("surface missing Box type ref with stable ids: %#v", surface.TypeRefs)
 	}
 }
 
@@ -169,8 +208,8 @@ refs
   <source> x 31:32 -> <source> 10:16 target=3c1090f85cd3 binding=3b74ed8bdf62
   <source> helper 64:70 -> <source> 0:34 target=acd850f616a7 binding=d165f3eb124f
 typeRefs
-  <source> Int 13:16 id=0c33e363e987
-  <source> Int 21:24 id=a14d0d87d94d
+  <source> Int 13:16 -> <source> -1:-1 target= id=8c42640e43d0
+  <source> Int 21:24 -> <source> -1:-1 target= id=3935b86a3bbb
 diagnostics
 `
 	if got != want {
@@ -752,6 +791,15 @@ func findResolvedRef(result selfhost.ResolveResult, name string) *selfhost.Resol
 	for i := range result.Refs {
 		if result.Refs[i].Name == name {
 			return &result.Refs[i]
+		}
+	}
+	return nil
+}
+
+func findResolvedTypeRef(result selfhost.ResolveResult, name string, file string) *selfhost.ResolvedTypeRef {
+	for i := range result.TypeRefs {
+		if result.TypeRefs[i].Name == name && (file == "" || result.TypeRefs[i].File == file) {
+			return &result.TypeRefs[i]
 		}
 	}
 	return nil

--- a/internal/selfhost/resolve_fuzz_test.go
+++ b/internal/selfhost/resolve_fuzz_test.go
@@ -1,0 +1,31 @@
+package selfhost_test
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func FuzzResolveSourceStructuredNoPanic(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"fn main() {",
+		"fn main() -> Int { let x: Missing = 1\n",
+		"pub struct Box<T> { value: T }\nfn main(x: Box<Int>) -> Int { x.value }\n",
+		"struct Counter { value: Int }\nimpl Counter { fn next(self) -> Self { self } }\n",
+		"use dep::{Widget}\nfn make(x: dep.Widget) -> Widget { x }\n",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		if len(src) > 4096 {
+			t.Skip()
+		}
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ResolveSourceStructured panicked: %v", r)
+			}
+		}()
+		_ = selfhost.ResolveSourceStructured([]byte(src))
+	})
+}

--- a/internal/selfhost/resolve_snapshot.go
+++ b/internal/selfhost/resolve_snapshot.go
@@ -38,12 +38,14 @@ func ResolveSnapshot(result ResolveResult) string {
 
 	typeRefs := append([]ResolvedTypeRef(nil), result.TypeRefs...)
 	sort.Slice(typeRefs, func(i, j int) bool {
-		return resolveSnapshotKey(typeRefs[i].File, typeRefs[i].Start, typeRefs[i].End, typeRefs[i].Name) <
-			resolveSnapshotKey(typeRefs[j].File, typeRefs[j].Start, typeRefs[j].End, typeRefs[j].Name)
+		return resolveSnapshotKey(typeRefs[i].File, typeRefs[i].Start, typeRefs[i].End, typeRefs[i].Name, typeRefs[i].TargetFile, typeRefs[i].TargetStart, typeRefs[i].TargetEnd) <
+			resolveSnapshotKey(typeRefs[j].File, typeRefs[j].Start, typeRefs[j].End, typeRefs[j].Name, typeRefs[j].TargetFile, typeRefs[j].TargetStart, typeRefs[j].TargetEnd)
 	})
 	b.WriteString("typeRefs\n")
 	for _, ref := range typeRefs {
-		fmt.Fprintf(&b, "  %s %s %d:%d id=%s\n", resolveSnapshotFile(ref.File), ref.Name, ref.Start, ref.End, shortResolveID(ref.ID))
+		fmt.Fprintf(&b, "  %s %s %d:%d -> %s %d:%d target=%s id=%s\n",
+			resolveSnapshotFile(ref.File), ref.Name, ref.Start, ref.End, resolveSnapshotFile(ref.TargetFile), ref.TargetStart, ref.TargetEnd,
+			shortResolveID(ref.TargetSymbolID), shortResolveID(ref.ID))
 	}
 
 	diags := append([]ResolveDiagnosticRecord(nil), result.Diagnostics...)

--- a/internal/selfhost/resolve_surface.go
+++ b/internal/selfhost/resolve_surface.go
@@ -41,12 +41,16 @@ type ResolveReferenceSurfaceRecord struct {
 }
 
 type ResolveTypeReferenceSurfaceRecord struct {
-	TypeRefID string
-	PackageID string
-	Name      string
-	File      string
-	Start     int
-	End       int
+	TypeRefID      string
+	PackageID      string
+	TargetSymbolID string
+	Name           string
+	File           string
+	Start          int
+	End            int
+	TargetFile     string
+	TargetStart    int
+	TargetEnd      int
 }
 
 type ResolveDiagnosticSurfaceRecord struct {
@@ -98,12 +102,16 @@ func ResolveSurfaceFromResult(result ResolveResult) ResolveSurface {
 	}
 	for _, ref := range result.TypeRefs {
 		surface.TypeRefs = append(surface.TypeRefs, ResolveTypeReferenceSurfaceRecord{
-			TypeRefID: ref.ID,
-			PackageID: ref.PackageID,
-			Name:      ref.Name,
-			File:      ref.File,
-			Start:     ref.Start,
-			End:       ref.End,
+			TypeRefID:      ref.ID,
+			PackageID:      ref.PackageID,
+			TargetSymbolID: ref.TargetSymbolID,
+			Name:           ref.Name,
+			File:           ref.File,
+			Start:          ref.Start,
+			End:            ref.End,
+			TargetFile:     ref.TargetFile,
+			TargetStart:    ref.TargetStart,
+			TargetEnd:      ref.TargetEnd,
 		})
 	}
 	for _, d := range result.Diagnostics {
@@ -142,7 +150,7 @@ func resolveSurfaceRefKey(r ResolveReferenceSurfaceRecord) string {
 }
 
 func resolveSurfaceTypeRefKey(r ResolveTypeReferenceSurfaceRecord) string {
-	return resolveSnapshotKey(r.File, r.Start, r.End, r.Name)
+	return resolveSnapshotKey(r.File, r.Start, r.End, r.Name, r.TargetFile, r.TargetStart, r.TargetEnd)
 }
 
 func resolveSurfaceDiagnosticKey(d ResolveDiagnosticSurfaceRecord) string {

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -63,12 +63,14 @@ pub struct SelfResolvedRef {
     pub targetEnd: Int,
 }
 
-/// SelfResolvedTypeRef is one resolved type-ref head site. Carrying just
-/// the ident's AST node is enough — type-ref consumers only need the name
-/// and the node for disambiguation.
+/// SelfResolvedTypeRef is one resolved type-ref head site plus the resolver-
+/// owned target span when the head resolved to a declared symbol.
 pub struct SelfResolvedTypeRef {
     pub name: String,
     pub node: Int,
+    pub target: Int,
+    pub targetStart: Int,
+    pub targetEnd: Int,
 }
 
 /// SelfResolveResult contains package symbols plus resolver diagnostics and
@@ -1494,10 +1496,10 @@ fn srResolveOneAstType(
         if owner == "" {
             return srSelfTypeOutsideAtNode(out, start, end, node)
         }
-        return srRecordTypeRef(out, name, node)
+        return srRecordTypeRef(out, name, node, srScopeLookup(scope, head))
     }
     if srIsBuiltinTypeName(head) {
-        return srRecordTypeRef(out, name, node)
+        return srRecordTypeRef(out, name, node, srEmptySymbol())
     }
     let sym = srScopeLookup(scope, head)
     if sym.name == "" {
@@ -1509,7 +1511,7 @@ fn srResolveOneAstType(
         out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", head, start, end, node))
         return out
     }
-    srRecordTypeRef(out, name, node)
+    srRecordTypeRef(out, name, node, sym)
 }
 
 fn srResolvePackageMember(
@@ -1577,10 +1579,16 @@ fn srRecordBareRef(result: SelfResolveResult, name: String, node: Int) -> SelfRe
     srRecordRef(result, name, node, srEmptySymbol())
 }
 
-fn srRecordTypeRef(result: SelfResolveResult, name: String, node: Int) -> SelfResolveResult {
+fn srRecordTypeRef(result: SelfResolveResult, name: String, node: Int, target: SelfSymbol) -> SelfResolveResult {
     let mut out = result
     out.typeRefs = out.typeRefs + 1
-    out.typeRefList.push(SelfResolvedTypeRef { name: name, node: node })
+    out.typeRefList.push(SelfResolvedTypeRef {
+        name: name,
+        node: node,
+        target: target.node,
+        targetStart: target.start,
+        targetEnd: target.end,
+    })
     out
 }
 
@@ -1876,13 +1884,14 @@ fn srResolvePatternTypePath(
         return out
     }
     if head == "Self" {
-        if srScopeHas(scope, head) {
-            return srRecordTypeRef(out, head, node)
+        let sym = srScopeLookup(scope, head)
+        if sym.name != "" {
+            return srRecordTypeRef(out, head, node, sym)
         }
         return srSelfTypeOutsideAtNode(out, start, end, node)
     }
     if srIsBuiltinTypeName(head) {
-        return srRecordTypeRef(out, head, node)
+        return srRecordTypeRef(out, head, node, srEmptySymbol())
     }
     let sym = srScopeLookup(scope, head)
     if sym.name == "" {
@@ -1894,7 +1903,7 @@ fn srResolvePatternTypePath(
         out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", head, start, end, node))
         return out
     }
-    srRecordTypeRef(out, head, node)
+    srRecordTypeRef(out, head, node, sym)
 }
 
 fn srResolvePatternVariantPath(
@@ -1928,7 +1937,7 @@ fn srResolvePatternVariantPath(
         return out
     }
     if srIsBuiltinTypeName(head) {
-        return srRecordTypeRef(out, head, node)
+        return srRecordTypeRef(out, head, node, srEmptySymbol())
     }
     let sym = srScopeLookup(scope, head)
     if sym.name == "" {
@@ -1937,7 +1946,7 @@ fn srResolvePatternVariantPath(
         return out
     }
     if srSymbolCanBeType(sym) {
-        return srRecordTypeRef(out, head, node)
+        return srRecordTypeRef(out, head, node, sym)
     }
     if sym.kind == "variant" {
         return srRecordRef(out, head, node, sym)


### PR DESCRIPTION
## Summary

- Moves resolver type-reference target identity into the selfhost resolver result.
- Projects selfhost type-ref targets into legacy Go `TypeRefsByID` structures without recalculating meaning by name lookup.
- Makes Go `Symbol.ID()` prefer the selfhost stable symbol ID when available.
- Adds snapshot, stable-ID, bridge, and no-panic fuzz-seed coverage for the resolver path.

## Why

The resolver authority should live in the selfhost result. Go compatibility structures still exist for downstream consumers, but they should be projections of selfhost decisions rather than a second semantic calculator.

## Validation

- `go test -count=1 -vet=off ./internal/selfhost -run 'TestResolve|FuzzResolve'`
- `go test -count=1 -vet=off ./internal/resolve -run 'TestNative|TestResolve|TestSymbol'`
- `go test -count=1 -vet=off ./cmd/osty -run 'TestRunResolve|TestResolveCLI|TestResolve'`
- `just front`
