### PR TITLE
[codex] exclude bootstrap adapter from checker bundle

### DIFF
--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -19,13 +19,17 @@ Today the public entrypoints are:
 The exact merged Osty inputs live in
 [`internal/selfhost/bundle/bundle.go`](./bundle/bundle.go):
 
-- `ToolchainCheckerFiles()` feeds the native checker binary
+- `ToolchainCheckerFiles()` is the native-checker-ready toolchain core; it
+  deliberately excludes bootstrap-only Go bridge adapters.
 
 Notable inputs currently include:
 
 - `toolchain/{semver,semver_parse,frontend,lexer,parser,formatter_ast,check_bridge,diagnostic,check_diag,diag_manifest,diag_examples,ty,core,check_env,solve,elab,check,resolve,lint}.osty`
 - `toolchain/lsp.osty`
-- `internal/selfhost/ast_lower.osty`
+
+`internal/selfhost/ast_lower.osty` remains as the public-AST compatibility
+adapter used by legacy Go callers, but it is not part of the native checker
+bundle because it imports the Go `astbridge` surface.
 
 `internal/selfhost/generated.go` and `internal/selfhost/astbridge/generated.go`
 are committed seed artifacts — the Osty→Go bootstrap transpiler that produced

--- a/internal/selfhost/bundle/bundle.go
+++ b/internal/selfhost/bundle/bundle.go
@@ -33,7 +33,6 @@ var toolchainCheckerFiles = []string{
 	"toolchain/inspect.osty",
 	"toolchain/inspect_hint.osty",
 	"toolchain/toml.osty",
-	"internal/selfhost/ast_lower.osty",
 }
 
 const stringsPrelude = `use runtime.strings as strings {

--- a/internal/selfhost/bundle/bundle_test.go
+++ b/internal/selfhost/bundle/bundle_test.go
@@ -22,6 +22,19 @@ func TestToolchainCheckerBundleIsToolchainOnly(t *testing.T) {
 	}
 }
 
+func TestToolchainCheckerBundleExcludesBootstrapOnlyAdapters(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	for _, rel := range ToolchainCheckerFiles() {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if hasBootstrapOnlyUse(data) {
+			t.Fatalf("toolchain checker bundle includes bootstrap-only adapter %q", rel)
+		}
+	}
+}
+
 func TestMergeFilesPrependsPreludeAndNormalizesStringsUsage(t *testing.T) {
 	root := t.TempDir()
 	writeBundleFile(t, root, "go_strings.osty", `use go "strings" as strings {
@@ -129,6 +142,20 @@ func writeBundleFile(t *testing.T, root, rel, contents string) {
 func contains(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBootstrapOnlyUse(src []byte) bool {
+	for _, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, `use go "`) ||
+			strings.HasPrefix(trimmed, "use runtime.golegacy.") {
 			return true
 		}
 	}

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -10,7 +10,12 @@ Today they pull from:
 
 - `toolchain/*.osty` for the front-end/checker/backend-facing logic
 - including `toolchain/lsp.osty` for the self-hosted LSP pure-policy surface
-- `internal/selfhost/ast_lower.osty` for the Go-bridge lowering step
+
+The native checker bundle deliberately excludes
+`internal/selfhost/ast_lower.osty`. That file is still present under
+`internal/selfhost/` as a public-AST compatibility adapter for legacy Go
+callers, but it imports the Go `astbridge` surface and must not be part of the
+native-selfhost checker input set.
 
 Mainstream Go packages should call `internal/lexer`, `internal/parser`, and
 `internal/check`. `internal/lexer` and `internal/parser` are thin facades over


### PR DESCRIPTION
## Summary
- Remove `internal/selfhost/ast_lower.osty` from the native checker bundle input list.
- Add a bundle regression test that rejects non-comment `use go` and `runtime.golegacy` adapter imports in `ToolchainCheckerFiles()`.
- Update selfhost/toolchain docs to distinguish the native checker bundle from the legacy public-AST compatibility adapter.

## Validation
- `go test -count=1 -vet=off ./internal/selfhost/bundle`
- `go test -count=1 -vet=off ./internal/selfhost`
- `go test -count=1 -vet=off ./cmd/osty -run 'CheckNative|TypecheckNative|Lint'`
- `go test -count=1 -vet=off ./internal/llvmgen -run TestNativeToolchainMergedMIRPipelineIsClean`
- `just front`
- `just short`
- `just ci`