### PR TITLE
[codex] cleanup parser negative tail returns

### DIFF
--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -1086,7 +1086,7 @@ fn opTuplePatternFirst(p: OstyParser, idx: Int) -> Int {
     if n.kind == AstNTuple && n.children.len() == 2 {
         return n.children[0]
     }
-    -1
+    return -1
 }
 
 fn opTuplePatternSecond(p: OstyParser, idx: Int) -> Int {
@@ -1100,7 +1100,7 @@ fn opTuplePatternSecond(p: OstyParser, idx: Int) -> Int {
     if n.kind == AstNTuple && n.children.len() == 2 {
         return n.children[1]
     }
-    -1
+    return -1
 }
 
 fn opEnumerateIterExpr(p: OstyParser, idx: Int) -> Int {
@@ -1118,7 +1118,7 @@ fn opEnumerateIterExpr(p: OstyParser, idx: Int) -> Int {
     if callee.kind == AstNField && callee.text == "enumerate" && call.children.len() == 0 {
         return callee.left
     }
-    -1
+    return -1
 }
 
 fn opLowerEnumerateForStmt(p: OstyParser, loopIdx: Int) -> Int {


### PR DESCRIPTION
## Summary

- Makes the three `parser.osty` helper fallbacks return `-1` explicitly.
- Avoids the `if ... { return ... }` followed by `-1` token shape being parsed as an accidental binary expression.

## Validation

- `go run ./cmd/osty parse toolchain/parser.osty | jq -r '.. | objects | select(.Op? == 39 and (.Left?.IsIfLet? != null)) | [.PosV.Line, .PosV.Column, .EndV.Line, .EndV.Column] | @tsv'` produced no matches.
- `just front`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestCheckSourceStructuredAcceptsEarlyReturnIfBeforeNegativeTail|TestCheckStructuredFromRunMatchesCheckSourceStructured|TestCheckSourceStructuredRecordsTypedExprCoverage' -v`
- `go test -count=1 -vet=off ./internal/selfhost/bundle`