### PR TITLE
[codex] fix early-return negative tail inference

### DIFF
--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -454,6 +454,19 @@ func TestCheckSourceStructuredRecordsTypedExprCoverage(t *testing.T) {
 	}
 }
 
+func TestCheckSourceStructuredAcceptsEarlyReturnIfBeforeNegativeTail(t *testing.T) {
+	src := []byte(`fn pick(a: Bool, b: Bool) -> Int {
+    if a && b { return 1 }
+    -1
+}
+`)
+
+	checked := CheckSourceStructured(src)
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0 (contexts=%v details=%v diagnostics=%#v)", checked.Summary.Errors, checked.Summary.ErrorsByContext, checked.Summary.ErrorDetails, checked.Diagnostics)
+	}
+}
+
 func TestCheckSourceStructuredRegistersPreludeFunctions(t *testing.T) {
 	src := []byte(`fn main() {
     let p0 = print

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -38947,6 +38947,9 @@ func elabInferBinary(cx *ElabCx, node *AstNode) *ElabResult {
 		// Osty: /tmp/selfhost_merged.osty:18143:9
 		return elabCoalesce(cx, node)
 	}
+	if ostyEqual(node.op, FrontTokenKind(&FrontTokenKind_FrontMinus{})) && astIsIfWithEscapingThenNoElse(cx.ast, node.left) {
+		return elabInferEarlyReturnMinusTail(cx, node)
+	}
 	// Osty: /tmp/selfhost_merged.osty:18145:5
 	left := elabInfer(cx, node.left)
 	_ = left
@@ -38966,6 +38969,36 @@ func elabInferBinary(cx *ElabCx, node *AstNode) *ElabResult {
 	coreIdx := coreBinary(cx.core, op, left.node, right.node, ty, node.start, node.end)
 	_ = coreIdx
 	return &ElabResult{node: coreIdx, ty: ty}
+}
+
+func elabInferEarlyReturnMinusTail(cx *ElabCx, node *AstNode) *ElabResult {
+	stmts := []int{}
+	ifStmt := elabStmt(cx, node.left)
+	if ifStmt >= 0 {
+		stmts = append(stmts, ifStmt)
+	}
+
+	right := elabInfer(cx, node.right)
+	rightTy := checkResolveAliasDeep(cx.env, right.ty)
+	ty := unOpResultType(cx.env, UnOp(&UnOp_UoNeg{}), rightTy, node.start, node.end)
+	tail := coreUnary(cx.core, UnOp(&UnOp_UoNeg{}), right.node, ty, node.start, node.end)
+	coreIdx := coreBlock(cx.core, stmts, tail, ty, node.start, node.end)
+	return &ElabResult{node: coreIdx, ty: ty}
+}
+
+func astIsIfWithEscapingThenNoElse(ast *AstFile, idx int) bool {
+	if idx < 0 {
+		return false
+	}
+	node := astArenaNodeAt(ast.arena, idx)
+	if !ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNIf{})) {
+		return false
+	}
+	elseIdx := checkIntListAt(node.children, 0)
+	if elseIdx >= 0 {
+		return false
+	}
+	return astBlockEscapesMatchResult(ast, astArenaNodeAt(ast.arena, node.right))
 }
 
 // Osty: /tmp/selfhost_merged.osty:18154:1

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -462,6 +462,9 @@ fn elabInferBinary(cx: ElabCx, node: AstNode) -> ElabResult {
     if binOpIsCoalesce(op) {
         return elabCoalesce(cx, node)
     }
+    if node.op == FrontMinus && astIsIfWithEscapingThenNoElse(cx.ast, node.left) {
+        return elabInferEarlyReturnMinusTail(cx, node)
+    }
     let left = elabInfer(cx, node.left)
     let right = elabInfer(cx, node.right)
     let leftTy = checkResolveAliasDeep(cx.env, left.ty)
@@ -469,6 +472,36 @@ fn elabInferBinary(cx: ElabCx, node: AstNode) -> ElabResult {
     let ty = binOpResultType(cx.env, op, leftTy, rightTy, node.start, node.end)
     let coreIdx = coreBinary(cx.core, op, left.node, right.node, ty, node.start, node.end)
     ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferEarlyReturnMinusTail(cx: ElabCx, node: AstNode) -> ElabResult {
+    let mut stmts: List<Int> = []
+    let ifStmt = elabStmt(cx, node.left)
+    if ifStmt >= 0 {
+        stmts.push(ifStmt)
+    }
+
+    let right = elabInfer(cx, node.right)
+    let rightTy = checkResolveAliasDeep(cx.env, right.ty)
+    let ty = unOpResultType(cx.env, UoNeg, rightTy, node.start, node.end)
+    let tail = coreUnary(cx.core, UoNeg, right.node, ty, node.start, node.end)
+    let coreIdx = coreBlock(cx.core, stmts, tail, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn astIsIfWithEscapingThenNoElse(ast: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = astArenaNodeAt(ast.arena, idx)
+    if node.kind != AstNIf {
+        return false
+    }
+    let elseIdx = checkIntListAt(node.children, 0)
+    if elseIdx >= 0 {
+        return false
+    }
+    astBlockEscapesMatchResult(ast, astArenaNodeAt(ast.arena, node.right))
 }
 
 fn binOpResultType(env: CheckEnv, op: BinOp, left: Int, right: Int, start: Int, end: Int) -> Int {

--- a/toolchain/elab_test.osty
+++ b/toolchain/elab_test.osty
@@ -70,6 +70,18 @@ fn testElabAllowsParameterReassignment() {
     testing.assertEq(checked.summary.errors, 0)
 }
 
+fn testElabEarlyReturnIfBeforeNegativeTail() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn pick(a: Bool, b: Bool) -> Int {
+                if a && b { return 1 }
+                -1
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+}
+
 fn testElabAllowsFieldAssignmentThroughParameters() {
     let checked = frontendCheckSourceStructured(
         r"""


### PR DESCRIPTION
## Summary

- Teaches the selfhost elaborator to recover the `if cond { return X }` followed by `-Y` tail shape as an early-return statement plus a negative tail expression.
- Hand-ports the checker change into `internal/selfhost/generated.go` so the current native checker path uses it immediately.
- Adds Osty-side and Go-side regression coverage for `if a && b { return 1 }` followed by `-1`.

## Root Cause

The parser can produce a binary `if ... - 1` AST for a physical negative tail after a single-line early-return `if`. The checker then inferred the left side as `()` and emitted E0744 instead of preserving the intended early-return flow with the negative fallback expression.

## Validation

- `go run ./cmd/osty check --no-airepair` on a temporary reproducer with `if a && b { return 1 }` then `-1`
- `go test -count=1 -vet=off ./internal/selfhost -run TestCheckSourceStructuredAcceptsEarlyReturnIfBeforeNegativeTail -v`
- `just front`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestCheckSourceStructuredAcceptsEarlyReturnIfBeforeNegativeTail|TestCheckStructuredFromRunMatchesCheckSourceStructured|TestCheckSourceStructuredRecordsTypedExprCoverage' -v`
- `go test -count=1 -vet=off ./internal/selfhost/bundle`