### PR TITLE
[codex] share selfhost bootstrap classifier

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -726,7 +726,7 @@ match 분해)를 추가한다.
 
 ### 분류 규칙
 
-`internal/llvmgen/multifile_probe_test.go:isBootstrapOnlyOstyFile`가 다음 세 패턴 중 하나라도 포함한 파일을 자동 bootstrap-only로 분류한다:
+`internal/selfhost/bundle.IsBootstrapOnlyOstyFile`가 주석을 걷어낸 top-level `use` / `pub use` 스탠자에서 다음 세 패턴 중 하나라도 포함한 파일을 자동 bootstrap-only로 분류한다. checker bundle guard와 `internal/llvmgen` whole-toolchain probe가 이 함수를 공유하므로 두 측정면의 skip 기준은 같이 움직인다:
 
 - `use runtime.golegacy.*` — 명시적 legacy bootstrap 브릿지
 - `use runtime.cihost` — CI runner 의 Go host adapter 를 runtime namespace 로 감싼 형태

--- a/internal/llvmgen/multifile_probe_helper_test.go
+++ b/internal/llvmgen/multifile_probe_helper_test.go
@@ -4,33 +4,35 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/osty/osty/internal/selfhost/bundle"
 )
 
-func TestIsBootstrapOnlyOstyFile(t *testing.T) {
+func TestProbeUsesSharedBootstrapOnlyClassifier(t *testing.T) {
 	t.Run("detects real use go ffi", func(t *testing.T) {
 		src := []byte("use go \"strings\" as strings {\n    pub fn trimSpace(s: String) -> String\n}\n")
-		if !isBootstrapOnlyOstyFile(src) {
+		if !bundle.IsBootstrapOnlyOstyFile(src) {
 			t.Fatalf("expected real use-go file to be classified as bootstrap-only")
 		}
 	})
 
 	t.Run("detects real runtime golegacy ffi", func(t *testing.T) {
 		src := []byte("use runtime.golegacy.astbridge as astbridge {\n    pub fn pos() -> Int\n}\n")
-		if !isBootstrapOnlyOstyFile(src) {
+		if !bundle.IsBootstrapOnlyOstyFile(src) {
 			t.Fatalf("expected runtime.golegacy file to be classified as bootstrap-only")
 		}
 	})
 
 	t.Run("detects real runtime cihost ffi", func(t *testing.T) {
 		src := []byte("use runtime.cihost as host {\n    pub fn LoadRunnerState(root: String) -> Bool\n}\n")
-		if !isBootstrapOnlyOstyFile(src) {
+		if !bundle.IsBootstrapOnlyOstyFile(src) {
 			t.Fatalf("expected runtime.cihost file to be classified as bootstrap-only")
 		}
 	})
 
 	t.Run("ignores comments mentioning bootstrap syntax", func(t *testing.T) {
 		src := []byte("// `use go \"...\" { ... }` stays in comments only.\n// `use runtime.golegacy.foo` is also documentation here.\n// `use runtime.cihost as host` too.\npub fn keep() -> Int { 1 }\n")
-		if isBootstrapOnlyOstyFile(src) {
+		if bundle.IsBootstrapOnlyOstyFile(src) {
 			t.Fatalf("expected comment-only mentions to stay in the native merged set")
 		}
 	})

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost/bundle"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -37,7 +38,7 @@ func collectToolchainProbeFiles(dir string, skipBootstrapOnly bool) ([]string, [
 		if err != nil {
 			continue
 		}
-		if isBootstrapOnlyOstyFile(src) {
+		if bundle.IsBootstrapOnlyOstyFile(src) {
 			skipped = append(skipped, name)
 			continue
 		}
@@ -170,38 +171,10 @@ func TestProbeWholeToolchainMerged(t *testing.T) {
 	t.Logf("WHOLE TOOLCHAIN first wall: %s", formatWall(err))
 }
 
-// isBootstrapOnlyOstyFile reports whether the source is a
-// host-boundary bootstrap adapter — i.e., whether it declares either
-//
-//   - a `use runtime.golegacy.*` FFI (the legacy Go AST bridge),
-//   - a `use runtime.cihost` FFI (the CI runner's Go host adapter), or
-//   - a `use go "..."` FFI (arbitrary Go package host binding)
-//
-// Both forms require the Osty compiler to be running under the
-// Go-hosted bootstrap CLI; neither has native LLVM runtime lowering
-// by design. Files carrying either stanza are skipped by the
-// native-path whole-toolchain probe. See LLVM_MIGRATION_PLAN.md
-// § "astbridge bootstrap-only adapter" for the migration path.
-func isBootstrapOnlyOstyFile(src []byte) bool {
-	for _, line := range strings.Split(string(src), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "//") {
-			continue
-		}
-		if strings.HasPrefix(trimmed, "use runtime.golegacy.") ||
-			strings.HasPrefix(trimmed, "use runtime.cihost") ||
-			strings.HasPrefix(trimmed, "use go \"") {
-			return true
-		}
-	}
-	return false
-}
-
 // TestProbeNativeToolchainMerged is the whole-toolchain probe with
-// bootstrap-only files (those that import runtime.golegacy.*) filtered
-// out. Reveals the first real LLVM wall along the native self-host
-// path — the wall that remains once the CLI is rewired off the
-// Go-hosted bridge adapter. Info-only.
+// bootstrap-only host adapters filtered out. Reveals the first real LLVM wall
+// along the native self-host path — the wall that remains once the CLI is
+// rewired off Go-hosted bridge adapters. Info-only.
 //
 // Pair with TestProbeWholeToolchainMerged: the difference between the
 // two walls tells us how much signal the bootstrap bridge is injecting

--- a/internal/llvmgen/native_toolchain_mir_pipeline_test.go
+++ b/internal/llvmgen/native_toolchain_mir_pipeline_test.go
@@ -2,7 +2,6 @@ package llvmgen
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -44,24 +43,9 @@ func TestNativeToolchainMergedMIRPipelineIsClean(t *testing.T) {
 		t.Fatalf("abs root: %v", err)
 	}
 	dir := filepath.Join(root, "toolchain")
-	entries, err := os.ReadDir(dir)
+	files, _, err := collectToolchainProbeFiles(dir, true)
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
-	}
-	var files []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			continue
-		}
-		if isBootstrapOnlyOstyFile(src) {
-			continue
-		}
-		files = append(files, name)
 	}
 	merged := mergeToolchainSources(t, root, files)
 	file, _ := parser.ParseDiagnostics(merged)
@@ -142,24 +126,9 @@ func TestNativeToolchainMergedMIRErrTypeFloor(t *testing.T) {
 		t.Fatalf("abs root: %v", err)
 	}
 	dir := filepath.Join(root, "toolchain")
-	entries, err := os.ReadDir(dir)
+	files, _, err := collectToolchainProbeFiles(dir, true)
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
-	}
-	var files []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			continue
-		}
-		if isBootstrapOnlyOstyFile(src) {
-			continue
-		}
-		files = append(files, name)
 	}
 	merged := mergeToolchainSources(t, root, files)
 	file, _ := parser.ParseDiagnostics(merged)

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -21,6 +21,10 @@ The exact merged Osty inputs live in
 
 - `ToolchainCheckerFiles()` is the native-checker-ready toolchain core; it
   deliberately excludes bootstrap-only Go bridge adapters.
+- `IsBootstrapOnlyOstyFile()` is the shared FFI-stanza classifier used by both
+  the checker bundle guard and the `internal/llvmgen` native toolchain probes.
+  It scans comment-stripped top-level `use` / `pub use` FFI stanzas so
+  documentation examples cannot accidentally remove a native file from probes.
 
 Notable inputs currently include:
 

--- a/internal/selfhost/bundle/bundle.go
+++ b/internal/selfhost/bundle/bundle.go
@@ -87,6 +87,49 @@ func ToolchainCheckerFiles() []string {
 	return append([]string(nil), toolchainCheckerFiles...)
 }
 
+// IsBootstrapOnlyOstyFile reports whether the source declares a host-boundary
+// bootstrap adapter that must stay outside native selfhost bundles/probes.
+func IsBootstrapOnlyOstyFile(src []byte) bool {
+	inBlockComment := false
+	for _, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(stripBlockCommentsFromLine(line, &inBlockComment))
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		trimmed = strings.TrimPrefix(trimmed, "pub ")
+		if strings.HasPrefix(trimmed, `use go "`) ||
+			strings.HasPrefix(trimmed, "use runtime.golegacy.") ||
+			strings.HasPrefix(trimmed, "use runtime.cihost") {
+			return true
+		}
+	}
+	return false
+}
+
+func stripBlockCommentsFromLine(line string, inBlock *bool) string {
+	var out strings.Builder
+	for len(line) > 0 {
+		if *inBlock {
+			end := strings.Index(line, "*/")
+			if end < 0 {
+				return out.String()
+			}
+			line = line[end+len("*/"):]
+			*inBlock = false
+			continue
+		}
+		start := strings.Index(line, "/*")
+		if start < 0 {
+			out.WriteString(line)
+			return out.String()
+		}
+		out.WriteString(line[:start])
+		line = line[start+len("/*"):]
+		*inBlock = true
+	}
+	return out.String()
+}
+
 func MergeToolchainChecker(root string) ([]byte, error) {
 	return MergeFiles(root, toolchainCheckerFiles)
 }

--- a/internal/selfhost/bundle/bundle_test.go
+++ b/internal/selfhost/bundle/bundle_test.go
@@ -39,13 +39,13 @@ func TestToolchainCheckerBundleExcludesBootstrapOnlyAdapters(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", rel, err)
 		}
-		if hasBootstrapOnlyUse(data) {
+		if IsBootstrapOnlyOstyFile(data) {
 			t.Fatalf("toolchain checker bundle includes bootstrap-only adapter %q", rel)
 		}
 	}
 }
 
-func TestToolchainCheckerBootstrapOnlyUseDetection(t *testing.T) {
+func TestIsBootstrapOnlyOstyFile(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
@@ -72,6 +72,31 @@ func TestToolchainCheckerBootstrapOnlyUseDetection(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "block comment only",
+			src:  "/* use go \"strings\" as strings { } */\npub fn keep() -> Int { 1 }\n",
+			want: false,
+		},
+		{
+			name: "multiline block comment only",
+			src:  "/*\nuse runtime.cihost as host {\n    fn KeepAlive() -> Bool\n}\n*/\npub fn keep() -> Int { 1 }\n",
+			want: false,
+		},
+		{
+			name: "inline block comment before real runtime cihost",
+			src:  "/* ignored */ use runtime.cihost as host {\n    fn KeepAlive() -> Bool\n}\n",
+			want: true,
+		},
+		{
+			name: "public use go",
+			src:  "pub use go \"strings\" as strings {\n    fn TrimSpace(s: String) -> String\n}\n",
+			want: true,
+		},
+		{
+			name: "public runtime golegacy",
+			src:  "pub use runtime.golegacy.astbridge as astbridge {\n    fn File() -> Bool\n}\n",
+			want: true,
+		},
+		{
 			name: "native runtime strings",
 			src:  "use runtime.strings as strings {\n    fn Split(s: String, sep: String) -> List<String>\n}\n",
 			want: false,
@@ -80,8 +105,8 @@ func TestToolchainCheckerBootstrapOnlyUseDetection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hasBootstrapOnlyUse([]byte(tt.src)); got != tt.want {
-				t.Fatalf("hasBootstrapOnlyUse() = %v, want %v", got, tt.want)
+			if got := IsBootstrapOnlyOstyFile([]byte(tt.src)); got != tt.want {
+				t.Fatalf("IsBootstrapOnlyOstyFile() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -194,21 +219,6 @@ func writeBundleFile(t *testing.T, root, rel, contents string) {
 func contains(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {
-			return true
-		}
-	}
-	return false
-}
-
-func hasBootstrapOnlyUse(src []byte) bool {
-	for _, line := range strings.Split(string(src), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "//") {
-			continue
-		}
-		if strings.HasPrefix(trimmed, `use go "`) ||
-			strings.HasPrefix(trimmed, "use runtime.golegacy.") ||
-			strings.HasPrefix(trimmed, "use runtime.cihost") {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- move the bootstrap-only FFI stanza classifier into `internal/selfhost/bundle`
- make the classifier ignore `//` / `/* ... */` comment-only mentions and recognize top-level `use` / `pub use` host-boundary stanzas
- use the shared classifier from checker bundle guards, `internal/llvmgen` native probes, and the slow MIR pipeline gates
- update the migration plan / selfhost README so the documented skip rule points at the shared source

## Validation
- `go test -count=1 -vet=off ./internal/selfhost/bundle`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestProbeUsesSharedBootstrapOnlyClassifier|TestCollectToolchainProbeFilesSkipsDirectories'`
- `go run ./cmd/osty check toolchain`
- `just front`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestNativeToolchainMergedMIRPipelineIsClean|TestNativeToolchainMergedMIRErrTypeFloor'`
- `just ci`
- `just short`
- `just verify-selfhost`