### PR TITLE
[codex] make public AST lowering explicit

### DIFF
--- a/internal/lsp/server_native_test.go
+++ b/internal/lsp/server_native_test.go
@@ -29,14 +29,11 @@ func TestAnalyzePackageContainingUsesNativeCompatibilityPath(t *testing.T) {
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
 	}
-	// The engine-based package path routes through parser.ParseDetailed,
-	// which calls run.File() once per file. With 2 .osty files in this
-	// package the count is 2. The legacy path (LowerPublicFileFromRun)
-	// was astbridge-free; the engine path trades that for incremental
-	// caching. Assert an upper bound to catch regressions without
-	// pinning the exact count.
-	if got := selfhost.AstbridgeLowerCount(); got > 4 {
-		t.Fatalf("AstbridgeLowerCount after package analyze = %d, want <= 4", got)
+	// The engine-based package path may still materialize public ASTs for
+	// compatibility consumers, but parser.ParseDetailed must use the explicit
+	// adapter rather than FrontendRun.File's legacy astbridge entry point.
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after package analyze = %d, want 0", got)
 	}
 	if len(a.packages) != 1 {
 		t.Fatalf("packages = %d, want 1", len(a.packages))
@@ -55,14 +52,10 @@ func TestAnalyzeSingleFileUsesNativeCompatibilityPath(t *testing.T) {
 	if a == nil {
 		t.Fatal("analyzeSingleFileViaEngine returned nil")
 	}
-	// Phase 1c.4 retired the Go-legacy \`analyzeSingleFile\` this test
-	// originally pinned to zero astbridge lowerings. The engine path
-	// reuses selfhost.LowerPublicFileFromRun for public-AST lift and
-	// still routes through a single astbridge step for the linter's
-	// diagnostic-stamping pass, so the invariant relaxed to "at most
-	// one" — the public-AST surface itself stays astbridge-free.
-	if got := selfhost.AstbridgeLowerCount(); got > 1 {
-		t.Fatalf("AstbridgeLowerCount after single-file analyze = %d, want <= 1", got)
+	// The public-AST compatibility surface stays explicit; no LSP single-file
+	// analysis path should call FrontendRun.File.
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after single-file analyze = %d, want 0", got)
 	}
 	if got := lspFirstFnName(a.file); got != "fresh" {
 		t.Fatalf("first function = %q, want %q", got, "fresh")
@@ -97,13 +90,10 @@ func TestAnalyzeWorkspaceUsesNativeCompatibilityPath(t *testing.T) {
 	if a == nil {
 		t.Fatal("analyzePackageContaining returned nil")
 	}
-	// The engine-based workspace path routes through parser.ParseDetailed,
-	// which calls run.File() once per file. With 2 .osty files across
-	// the workspace the count is 2. The legacy path was astbridge-free;
-	// the engine path trades that for incremental caching. Assert an
-	// upper bound to catch regressions without pinning the exact count.
-	if got := selfhost.AstbridgeLowerCount(); got > 6 {
-		t.Fatalf("AstbridgeLowerCount after workspace analyze = %d, want <= 6", got)
+	// Workspace analysis can still expose public ASTs to compatibility
+	// consumers, but it must not use FrontendRun.File as the authority path.
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after workspace analyze = %d, want 0", got)
 	}
 	if len(a.packages) != 2 {
 		t.Fatalf("packages = %d, want 2", len(a.packages))

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -34,12 +34,14 @@ func Parse(src []byte) (*ast.File, []error) {
 // ParseDetailed lexes, parses, and canonicalizes src, returning the public
 // semantic AST plus parser-level compatibility provenance. Compatibility
 // helper syntax is canonicalized in the parser core; this facade only records
-// source alias provenance that remains useful at legacy boundaries.
+// source alias provenance that remains useful at legacy boundaries. The public
+// AST is produced through the explicit compatibility adapter so ParseDetailed
+// does not exercise FrontendRun.File's legacy astbridge entry point.
 func ParseDetailed(src []byte) Result {
 	pipeline := newParsePipeline(src)
 	run := pipeline.parseRun()
 	pipeline.applySourceCompat(run)
-	file, diags := run.File(), run.Diagnostics()
+	file, diags := selfhost.LowerPublicFileFromRun(run), run.Diagnostics()
 	return pipeline.result(file, diags)
 }
 
@@ -52,7 +54,7 @@ func ParseDetailed(src []byte) Result {
 func ParseCanonical(src []byte) (*ast.File, []*diag.Diagnostic) {
 	pipeline := newParsePipeline(src)
 	run := pipeline.parseRun()
-	return run.File(), run.Diagnostics()
+	return selfhost.LowerPublicFileFromRun(run), run.Diagnostics()
 }
 
 // ParseDiagnostics lexes and parses src, returning the AST and rich

--- a/internal/parser/parser_features_test.go
+++ b/internal/parser/parser_features_test.go
@@ -160,9 +160,13 @@ func TestParseAcceptsStableAliases(t *testing.T) {
 func TestParseCanonicalAcceptsStableAliases(t *testing.T) {
 	src := []byte("import std.testing as t\nfunc main() {\n    while false {\n        break\n    }\n}\n")
 
+	selfhost.ResetAstbridgeLowerCount()
 	file, diags := ParseCanonical(src)
 	if len(diags) > 0 {
 		t.Fatalf("ParseCanonical returned %d diagnostics: %v", len(diags), diags[0])
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("ParseCanonical astbridge count = %d, want 0", got)
 	}
 	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
 		t.Fatalf("parsed file = %#v, want one use and one decl", file)
@@ -197,6 +201,22 @@ func TestParseStableAliasesPreservedAsIdentifiers(t *testing.T) {
 	}
 	if result.Provenance != nil && len(result.Provenance.Aliases) != 0 {
 		t.Fatalf("alias provenance = %#v, want no rewrites for param names", result.Provenance.Aliases)
+	}
+}
+
+func TestParseDetailedUsesExplicitPublicCompatibilityAdapter(t *testing.T) {
+	src := []byte("fn main() {\n    let items = [1]\n    let count = len(items)\n}\n")
+
+	selfhost.ResetAstbridgeLowerCount()
+	result := ParseDetailed(src)
+	if len(result.Diagnostics) > 0 {
+		t.Fatalf("ParseDetailed returned %d diagnostics: %v", len(result.Diagnostics), result.Diagnostics[0])
+	}
+	if result.File == nil {
+		t.Fatal("ParseDetailed returned nil file")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("ParseDetailed astbridge count = %d, want 0", got)
 	}
 }
 

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -16,6 +16,15 @@ Today the public entrypoints are:
 - `internal/check` — prefers the external native checker binary and uses the
   embedded selfhost bridge as the fallback / adaptation boundary
 
+Authority rule:
+
+- Production front-end paths must treat `FrontendRun` / arena / structured
+  results as the source of truth. Public `*ast.File` values are compatibility
+  output only.
+- `FrontendRun.File()` is deprecated for production code. If a legacy consumer
+  still needs public AST shape, use `LowerPublicFileFromRun()` at that explicit
+  boundary so the compatibility hop is visible and searchable.
+
 The exact merged Osty inputs live in
 [`internal/selfhost/bundle/bundle.go`](./bundle/bundle.go):
 

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -159,6 +159,10 @@ func (r *FrontendRun) Comments() []token.Comment {
 // arena via astLowerPublicFile. Subsequent calls return the cached result
 // without touching astbridge again, so each FrontendRun contributes at most one
 // lowering to AstbridgeLowerCount regardless of how many callers poke it.
+//
+// Deprecated: production front-end paths should keep FrontendRun / arena /
+// structured results as the source of truth. Use LowerPublicFileFromRun only at
+// explicit public-AST compatibility boundaries.
 func (r *FrontendRun) File() *ast.File {
 	if r.file != nil {
 		return r.file

--- a/internal/selfhost/frontend_authority_test.go
+++ b/internal/selfhost/frontend_authority_test.go
@@ -1,0 +1,64 @@
+package selfhost
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var frontendRunFileCallRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:[Rr]un)\.File\(\)`)
+
+func TestProductionFrontendPathsDoNotCallFrontendRunFile(t *testing.T) {
+	root := repoRootForAuthorityTest(t)
+	for _, dir := range []string{"cmd", "internal"} {
+		scanDir := filepath.Join(root, dir)
+		err := filepath.WalkDir(scanDir, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				switch entry.Name() {
+				case ".git", ".osty", ".direnv":
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for i, line := range strings.Split(string(data), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "//") {
+					continue
+				}
+				if frontendRunFileCallRE.MatchString(line) {
+					rel, _ := filepath.Rel(root, path)
+					t.Fatalf("%s:%d calls FrontendRun.File(); use FrontendRun/arena/structured results, or LowerPublicFileFromRun at an explicit compatibility boundary", rel, i+1)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+	}
+}
+
+func repoRootForAuthorityTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("locate repo root from %s: %v", file, err)
+	}
+	return root
+}

--- a/internal/selfhost/parse.go
+++ b/internal/selfhost/parse.go
@@ -6,8 +6,9 @@ import (
 )
 
 // Parse runs the bootstrapped pure-Osty lexer and parser, then lowers the
-// self-hosted arena into the compiler's public AST.
+// self-hosted arena into the compiler's public AST through the explicit
+// compatibility adapter.
 func Parse(src []byte) (*ast.File, []*diag.Diagnostic) {
 	run := Run(src)
-	return run.File(), run.Diagnostics()
+	return LowerPublicFileFromRun(run), run.Diagnostics()
 }

--- a/internal/selfhost/parse_stable_alias_test.go
+++ b/internal/selfhost/parse_stable_alias_test.go
@@ -5,6 +5,18 @@ import "testing"
 func TestParseStableAliasesDirectly(t *testing.T) {
 	src := []byte("import std.testing as t\nfunc main() {\n    while false {\n        break\n    }\n}\n")
 
+	ResetAstbridgeLowerCount()
+	file, diags := Parse(src)
+	if len(diags) > 0 {
+		t.Fatalf("Parse returned %d diagnostics: %v", len(diags), diags[0])
+	}
+	if got := AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("Parse astbridge count = %d, want 0", got)
+	}
+	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
+		t.Fatalf("parsed file = %#v, want one use and one decl", file)
+	}
+
 	run := Run(src)
 	aliases := run.StableAliases()
 	if got, want := len(aliases), 3; got != want {
@@ -18,14 +30,6 @@ func TestParseStableAliasesDirectly(t *testing.T) {
 	}
 	if aliases[2].Alias != "while" || aliases[2].Canonical != "for" {
 		t.Fatalf("third alias = %#v, want while -> for", aliases[2])
-	}
-
-	file, diags := run.File(), run.Diagnostics()
-	if len(diags) > 0 {
-		t.Fatalf("Parse returned %d diagnostics: %v", len(diags), diags[0])
-	}
-	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
-		t.Fatalf("parsed file = %#v, want one use and one decl", file)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route `parser.ParseDetailed`, `parser.ParseCanonical`, and `selfhost.Parse` through `LowerPublicFileFromRun` instead of `FrontendRun.File`
- document `FrontendRun.File()` as deprecated for production paths and define the front-end authority rule in `internal/selfhost/README.md`
- tighten LSP native tests from loose astbridge upper bounds to exact zero and add a static authority gate that rejects production `run.File()` calls

## Validation
- `go test -count=1 -vet=off ./internal/parser ./internal/selfhost ./internal/lsp`
- `go test -count=1 -vet=off ./cmd/osty -run 'TestRunCheckFileNative|TestRunCheckPackageNative|TestRunCheckWorkspaceNative|TestRunTypecheckFileNative|TestRunTypecheckPackageNative|TestRunTypecheckWorkspaceNative|TestRunResolveFile|TestRunResolvePackage'`
- `just front`
- `go test -count=1 -vet=off ./internal/selfhost/bundle`
- `go run ./cmd/osty check toolchain`
- `just ci`
- `just short`
- `just verify-selfhost`