### PR TITLE
[codex] implement missing stdlib modules

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 37 모듈. 분류 기준:
+총 41 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (32 / 37 = 86%)
+### ⭐⭐⭐⭐⭐ Production (38 / 41 = 93%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -40,6 +40,11 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
 | csv | 351 | — | options-driven, header-aware decode |
+| xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
+| encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
+| cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
+| template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
+| i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
 | char | 219 | — | Unicode / ASCII methods |
 | iter | 118 | — | iteration 프로토콜 |
 | bytes | 113 | bytes 29 runtime | byte 슬라이스 조작 |
@@ -63,18 +68,24 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 37 = 11%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 41 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
 | compress | 11 | gzip 만 (zstd / deflate 추가 가능). Phase A shim 199 |
-| encoding | 41 | Base64 / Base64Url / Hex / UrlEncoding 4 표준. struct method 직접 확인 필요 |
-| testing_gen | 168 | property-based testing generator. testing 의 helper |
-| (process) | (위 Production 에 분류) | 이름 함정 — OS process spawn 은 `os.exec` 에 있음 |
+| testing_gen | 168 | property runner 는 int/intRange/asciiString/pair/triple/oneOf/constant subset 실행. bool/float/char/byte/list/listOfSize/option/result/oneOfGens/map/filter 는 아직 실행 subset 밖 |
 
-### 🚧 미확인 / 갭
+### 🚧 실제 미구현 / 갭
 
-기존 37 모듈 중 *진짜 stub* 은 없음. 모든 모듈이 *의도된 범위 안에서 production* 또는 *production-adjacent*.
+기존 모듈 안에도 declaration-only surface 가 많다. 이 중 `fs/env/math/crypto/io/thread/time/term/os/random/uuid` 처럼
+runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않는다. 하지만 아래는 실제 갭이다:
+
+| 구분 | 갭 |
+|---|---|
+| 없는 모듈 | `db/sql`, `email/smtp`, `websocket`, `tar/zip`, `image`, `graphql` |
+| 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip/tar 계열 없음 |
+| 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
+| 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
 
 ## 2. 카테고리별 데모 가능성
 
@@ -92,23 +103,22 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | Property-based testing | ✅ 가능 | testing (Gen<T> / property / propertySeeded) |
 | Structured logging | ✅ 가능 | log (Handler / TextHandler / JsonHandler) |
 | 동시성 (구조적) | ✅ 가능 | thread (spawn / race / chan / select / cancel) |
+| HTML 템플릿 | ✅ 가능 | template (escaped/raw placeholder render) |
+| XML 처리 | ✅ 가능 | xml (escape / tag build / tokenize) |
+| 다국어 메시지 | ✅ 가능 | i18n (locale / catalog / placeholder / plural category) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
-기존 모듈은 production-ready. 진짜 갭은 *없는 모듈*들:
+기존 모듈 대부분은 production-ready 또는 runtime-backed. 진짜 큰 갭은 *없는 모듈*들:
 
 | 없는 모듈 | 영향 | 우선순위 |
 |---|---|---|
 | db / sql | DB 작업 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
 | email / smtp | 메일 발송 | 중간 |
-| template (HTML) | 웹 템플릿 | 중간 (http 와 페어) |
 | websocket | WS 통신 | 중간 (http 와 페어) |
-| cli (argparse-like) | CLI flag 파싱 (현재 env.args 만) | 중간 |
 | tar / zip | 아카이브 (compress 는 gzip 만) | 낮음 |
 | image | 이미지 디코딩 | 낮음 |
-| xml | XML 파싱 | 낮음 |
 | graphql | GraphQL 클라이언트 / 서버 | 낮음 |
-| i18n / l10n | 다국어 | 낮음 |
 
 ## 4. Phase A / B 분리 패턴
 
@@ -127,9 +137,9 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 14 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, result, option, csv, char, iter, bytes)
+- 18 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, result, option, csv, xml, encoding, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
-- 나머지는 의도된 범위에서 surface 만으로 완성 (math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, encoding, uuid)
+- 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
 ## 5. 평가 함정: `.osty` 줄 수 모델의 한계
 
@@ -196,7 +206,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db / template / cli / websocket) — *없는 모듈* 카테고리 채우기
-2. **compress / encoding 깊이** — zstd / deflate / Base32 등 추가 표준
+1. **새 모듈 추가** (db / websocket / email) — *없는 모듈* 카테고리 채우기
+2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_cli_check_test.go
+++ b/internal/backend/stdlib_cli_check_test.go
@@ -1,0 +1,26 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultCli(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "cli")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(cli) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("cli module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_encoding_check_test.go
+++ b/internal/backend/stdlib_encoding_check_test.go
@@ -1,0 +1,28 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultEncoding pins that std.encoding is now a real
+// pure-Osty codec module, not a declaration-only runtime surface.
+func TestStdlibCheckResultEncoding(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "encoding")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(encoding) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("encoding module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_encoding_entry_test.go
+++ b/internal/backend/stdlib_encoding_entry_test.go
@@ -1,0 +1,66 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+func TestPrepareEntryRewritesStdEncodingSingletonMethods(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	req := newBackendRequest(t, EmitLLVMIR, `use std.bytes
+use std.encoding
+
+fn main() {
+    let raw = bytes.fromString("hello world&foo=bar")
+    let b64 = encoding.base64.encode(raw)
+    let round = encoding.base64.decode(b64).unwrap()
+    let b64url = encoding.base64.url.encode(bytes.fromString("??>>"))
+    let hx = encoding.hex.encode(raw)
+    let escaped = encoding.url.encode("hello world&foo=bar")
+    println(b64)
+    println(round.toString().unwrap())
+    println(b64url)
+    println(hx)
+    println(escaped)
+}
+`)
+
+	want := map[string]bool{
+		"osty_std_encoding__Base64__encode":      false,
+		"osty_std_encoding__Base64__decode":      false,
+		"osty_std_encoding__Base64Url__encode":   false,
+		"osty_std_encoding__Hex__encode":         false,
+		"osty_std_encoding__UrlEncoding__encode": false,
+	}
+	ir.Inspect(req.Entry.IR, func(n ir.Node) bool {
+		if mc, ok := n.(*ir.MethodCall); ok && mc != nil {
+			if module, path, ok := stdlibFieldPath(mc.Receiver); ok && module == "encoding" && len(path) != 0 {
+				t.Errorf("encoding singleton method call was not rewritten: %s.%s", strings.Join(path, "."), mc.Name)
+			}
+		}
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		ident, ok := call.Callee.(*ir.Ident)
+		if !ok || ident == nil {
+			return true
+		}
+		if _, hit := want[ident.Name]; !hit {
+			return true
+		}
+		want[ident.Name] = true
+		if _, ok := ident.Type().(*ir.FnType); !ok {
+			t.Errorf("callee %s Type() = %T, want *ir.FnType", ident.Name, ident.Type())
+		}
+		return true
+	})
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("missing rewritten call to %s", name)
+		}
+	}
+}

--- a/internal/backend/stdlib_i18n_check_test.go
+++ b/internal/backend/stdlib_i18n_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultI18n(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "i18n")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(i18n) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("i18n module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -79,7 +79,14 @@ type ReachableStdlibMethod struct {
 	// Fn is the method declaration as held in the registry. Callers
 	// must not mutate it — the registry owns a shared immutable copy.
 	Fn *ast.FnDecl
+	// ValuePath is set for calls through exported stdlib singleton
+	// values such as `encoding.base64.encode(...)` or
+	// `encoding.base64.url.encode(...)`. It is empty for ordinary typed
+	// receiver calls like `h.encode(...)`.
+	ValuePath string
 }
+
+type stdlibMethodReachKey struct{ module, typeName, method string }
 
 // ReachableStdlibMethods returns the stdlib struct/enum methods
 // referenced from mod via typed method calls, in deterministic
@@ -101,11 +108,10 @@ func ReachableStdlibMethods(mod *ir.Module, reg *stdlib.Registry) []ReachableStd
 	if mod == nil || reg == nil {
 		return nil
 	}
-	type key struct{ module, typeName, method string }
-	seen := map[key]struct{}{}
+	seen := map[stdlibMethodReachKey]struct{}{}
 	var found []ReachableStdlibMethod
 	for ref := range ir.ReachMethods(mod) {
-		k := key{module: ref.Module, typeName: ref.Type, method: ref.Method}
+		k := stdlibMethodReachKey{module: ref.Module, typeName: ref.Type, method: ref.Method}
 		if _, dup := seen[k]; dup {
 			continue
 		}
@@ -121,6 +127,34 @@ func ReachableStdlibMethods(mod *ir.Module, reg *stdlib.Registry) []ReachableStd
 			Fn:     fn,
 		})
 	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		var (
+			receiver ir.Expr
+			method   string
+		)
+		switch call := n.(type) {
+		case *ir.CallExpr:
+			if call == nil {
+				return true
+			}
+			field, ok := call.Callee.(*ir.FieldExpr)
+			if !ok || field == nil || field.Name == "" {
+				return true
+			}
+			receiver = field.X
+			method = field.Name
+		case *ir.MethodCall:
+			if call == nil || call.Receiver == nil || call.Name == "" {
+				return true
+			}
+			receiver = call.Receiver
+			method = call.Name
+		default:
+			return true
+		}
+		addStdlibValuePathMethod(reg, &found, seen, receiver, method)
+		return true
+	}), mod)
 	sort.Slice(found, func(i, j int) bool {
 		if found[i].Module != found[j].Module {
 			return found[i].Module < found[j].Module
@@ -131,6 +165,114 @@ func ReachableStdlibMethods(mod *ir.Module, reg *stdlib.Registry) []ReachableStd
 		return found[i].Method < found[j].Method
 	})
 	return found
+}
+
+func addStdlibValuePathMethod(
+	reg *stdlib.Registry,
+	found *[]ReachableStdlibMethod,
+	seen map[stdlibMethodReachKey]struct{},
+	receiver ir.Expr,
+	method string,
+) {
+	module, path, ok := stdlibFieldPath(receiver)
+	if !ok || module == "" || len(path) == 0 || method == "" {
+		return
+	}
+	typeName, ok := stdlibValuePathTypeName(reg, module, path)
+	if !ok || typeName == "" {
+		return
+	}
+	valuePath := stdlibJoinFieldPath(path)
+	k := stdlibMethodReachKey{module: module, typeName: typeName, method: method}
+	if _, dup := seen[k]; dup {
+		for i := range *found {
+			entry := &(*found)[i]
+			if entry.Module == module && entry.Type == typeName && entry.Method == method && entry.ValuePath == "" {
+				entry.ValuePath = valuePath
+				return
+			}
+		}
+		return
+	}
+	fn := reg.LookupMethodDecl(module, typeName, method)
+	if fn == nil {
+		return
+	}
+	seen[k] = struct{}{}
+	*found = append(*found, ReachableStdlibMethod{
+		Module:    module,
+		Type:      typeName,
+		Method:    method,
+		Fn:        fn,
+		ValuePath: valuePath,
+	})
+}
+
+func stdlibValuePathTypeName(reg *stdlib.Registry, module string, path []string) (string, bool) {
+	if reg == nil || module == "" || len(path) == 0 {
+		return "", false
+	}
+	mod := reg.Modules[module]
+	if mod == nil || mod.Package == nil {
+		return "", false
+	}
+	typeName, ok := stdlibTopLevelLetTypeName(mod, path[0])
+	if !ok {
+		return "", false
+	}
+	for _, field := range path[1:] {
+		typeName, ok = stdlibStructFieldTypeName(mod, typeName, field)
+		if !ok {
+			return "", false
+		}
+	}
+	return typeName, true
+}
+
+func stdlibTopLevelLetTypeName(mod *stdlib.Module, name string) (string, bool) {
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil || name == "" {
+		return "", false
+	}
+	sym := mod.Package.PkgScope.LookupLocal(name)
+	if sym == nil {
+		return "", false
+	}
+	decl, ok := sym.Decl.(*ast.LetDecl)
+	if !ok || decl == nil {
+		return "", false
+	}
+	return stdlibNamedTypeName(decl.Type)
+}
+
+func stdlibStructFieldTypeName(mod *stdlib.Module, owner, fieldName string) (string, bool) {
+	if mod == nil || mod.Package == nil || owner == "" || fieldName == "" {
+		return "", false
+	}
+	for _, pf := range mod.Package.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		for _, decl := range pf.File.Decls {
+			st, ok := decl.(*ast.StructDecl)
+			if !ok || st == nil || st.Name != owner {
+				continue
+			}
+			for _, field := range st.Fields {
+				if field != nil && field.Name == fieldName {
+					return stdlibNamedTypeName(field.Type)
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func stdlibNamedTypeName(t ast.Type) (string, bool) {
+	named, ok := t.(*ast.NamedType)
+	if !ok || named == nil || len(named.Path) == 0 {
+		return "", false
+	}
+	return named.Path[len(named.Path)-1], true
 }
 
 // injectReachableStdlibBodies lowers every reachable stdlib function in

--- a/internal/backend/stdlib_inject_test.go
+++ b/internal/backend/stdlib_inject_test.go
@@ -110,6 +110,73 @@ func TestReachableStdlibMethodsFindsHexEncode(t *testing.T) {
 	}
 }
 
+func TestReachableStdlibMethodsFindsEncodingSingletonMethod(t *testing.T) {
+	reg := stdlib.LoadCached()
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.MethodCall{
+				Receiver: &ir.FieldExpr{X: &ir.Ident{Name: "encoding"}, Name: "base64"},
+				Name:     "encode",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "data"}}},
+			}},
+			&ir.ExprStmt{X: &ir.CallExpr{
+				Callee: &ir.FieldExpr{
+					X: &ir.FieldExpr{
+						X:    &ir.FieldExpr{X: &ir.Ident{Name: "encoding"}, Name: "base64"},
+						Name: "url",
+					},
+					Name: "decode",
+				},
+				Args: []ir.Arg{{Value: &ir.Ident{Name: "text"}}},
+			}},
+		},
+	}
+	got := ReachableStdlibMethods(mod, reg)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries (%v), want 2", len(got), got)
+	}
+	if got[0].Module != "encoding" || got[0].Type != "Base64" || got[0].Method != "encode" || got[0].ValuePath != "base64" {
+		t.Fatalf("got[0] = {%s, %s, %s, %s}, want {encoding, Base64, encode, base64}",
+			got[0].Module, got[0].Type, got[0].Method, got[0].ValuePath)
+	}
+	if got[1].Module != "encoding" || got[1].Type != "Base64Url" || got[1].Method != "decode" || got[1].ValuePath != "base64.url" {
+		t.Fatalf("got[1] = {%s, %s, %s, %s}, want {encoding, Base64Url, decode, base64.url}",
+			got[1].Module, got[1].Type, got[1].Method, got[1].ValuePath)
+	}
+}
+
+func TestReachableStdlibMethodsKeepsSingletonPathWhenTypedReceiverAlsoReached(t *testing.T) {
+	reg := stdlib.LoadCached()
+	b64T := &ir.NamedType{Package: "encoding", Name: "Base64"}
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "b", T: b64T},
+				Name:     "encode",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "data"}}},
+			}},
+			&ir.ExprStmt{X: &ir.MethodCall{
+				Receiver: &ir.FieldExpr{X: &ir.Ident{Name: "encoding"}, Name: "base64"},
+				Name:     "encode",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "data"}}},
+			}},
+		},
+	}
+	got := ReachableStdlibMethods(mod, reg)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries (%v), want 1 deduped Base64.encode entry", len(got), got)
+	}
+	if got[0].Module != "encoding" || got[0].Type != "Base64" || got[0].Method != "encode" {
+		t.Fatalf("got[0] = {%s, %s, %s}, want {encoding, Base64, encode}",
+			got[0].Module, got[0].Type, got[0].Method)
+	}
+	if got[0].ValuePath != "base64" {
+		t.Fatalf("got[0].ValuePath = %q, want base64", got[0].ValuePath)
+	}
+}
+
 func TestReachableStdlibMethodsSkipsUnknownMethod(t *testing.T) {
 	reg := stdlib.LoadCached()
 	hexT := &ir.NamedType{Package: "encoding", Name: "Hex"}

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -120,14 +120,88 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 	}
 	type key struct{ module, typeName, method string }
 	set := map[key]string{}
+	type valueKey struct{ module, path, method string }
+	valueSet := map[valueKey]string{}
 	for _, r := range reached {
-		set[key{module: r.Module, typeName: r.Type, method: r.Method}] = StdlibMethodSymbol(r.Module, r.Type, r.Method)
+		mangled := StdlibMethodSymbol(r.Module, r.Type, r.Method)
+		set[key{module: r.Module, typeName: r.Type, method: r.Method}] = mangled
+		if r.ValuePath != "" {
+			valueSet[valueKey{module: r.Module, path: r.ValuePath, method: r.Method}] = mangled
+		}
+	}
+	valueRewriteCount := 0
+	if len(valueSet) > 0 {
+		ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+			call, ok := n.(*ir.CallExpr)
+			if !ok || call == nil {
+				return true
+			}
+			field, ok := call.Callee.(*ir.FieldExpr)
+			if !ok || field == nil || field.Name == "" {
+				return true
+			}
+			module, path, ok := stdlibFieldPath(field.X)
+			if !ok || module == "" || len(path) == 0 {
+				return true
+			}
+			mangled, hit := valueSet[valueKey{
+				module: module,
+				path:   stdlibJoinFieldPath(path),
+				method: field.Name,
+			}]
+			if !hit {
+				return true
+			}
+			receiver := field.X
+			args := make([]ir.Arg, 0, len(call.Args)+1)
+			args = append(args, ir.Arg{
+				Value: receiver,
+				SpanV: field.SpanV,
+			})
+			args = append(args, call.Args...)
+			call.Callee = &ir.Ident{
+				Name:  mangled,
+				Kind:  ir.IdentFn,
+				T:     stdlibFnType(args, call.T),
+				SpanV: field.SpanV,
+			}
+			call.Args = args
+			valueRewriteCount++
+			return true
+		}), mod)
 	}
 	swap := map[*ir.MethodCall]*ir.CallExpr{}
 	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
 		mc, ok := n.(*ir.MethodCall)
 		if !ok || mc == nil || mc.Receiver == nil || mc.Name == "" {
 			return true
+		}
+		if module, path, ok := stdlibFieldPath(mc.Receiver); ok && module != "" && len(path) != 0 {
+			if mangled, hit := valueSet[valueKey{
+				module: module,
+				path:   stdlibJoinFieldPath(path),
+				method: mc.Name,
+			}]; hit {
+				args := make([]ir.Arg, 0, len(mc.Args)+1)
+				args = append(args, ir.Arg{
+					Value: mc.Receiver,
+					SpanV: mc.SpanV,
+				})
+				args = append(args, mc.Args...)
+				swap[mc] = &ir.CallExpr{
+					Callee: &ir.Ident{
+						Name:  mangled,
+						Kind:  ir.IdentFn,
+						T:     stdlibFnType(args, mc.T),
+						SpanV: mc.SpanV,
+					},
+					TypeArgs: mc.TypeArgs,
+					Args:     args,
+					T:        mc.T,
+					SpanV:    mc.SpanV,
+				}
+				return true
+			}
 		}
 		named, ok := mc.Receiver.Type().(*ir.NamedType)
 		if !ok || named == nil || named.Package == "" || named.Name == "" {
@@ -152,6 +226,7 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			Callee: &ir.Ident{
 				Name:  mangled,
 				Kind:  ir.IdentFn,
+				T:     stdlibFnType(args, mc.T),
 				SpanV: mc.SpanV,
 			},
 			TypeArgs: mc.TypeArgs,
@@ -162,11 +237,58 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 		return true
 	}), mod)
 	if len(swap) == 0 {
-		return 0
+		return valueRewriteCount
 	}
 	rw := &stdlibMethodCallsiteSpliceVisitor{swap: swap}
 	ir.Walk(rw, mod)
-	return rw.count
+	return valueRewriteCount + rw.count
+}
+
+func stdlibFnType(args []ir.Arg, ret ir.Type) ir.Type {
+	params := make([]ir.Type, 0, len(args))
+	for _, arg := range args {
+		if arg.Value == nil || arg.Value.Type() == nil {
+			params = append(params, ir.ErrTypeVal)
+			continue
+		}
+		params = append(params, arg.Value.Type())
+	}
+	if ret == nil {
+		ret = ir.ErrTypeVal
+	}
+	return &ir.FnType{Params: params, Return: ret}
+}
+
+func stdlibFieldPath(expr ir.Expr) (string, []string, bool) {
+	switch x := expr.(type) {
+	case *ir.Ident:
+		if x == nil || x.Name == "" {
+			return "", nil, false
+		}
+		return x.Name, nil, true
+	case *ir.FieldExpr:
+		if x == nil || x.Name == "" {
+			return "", nil, false
+		}
+		module, path, ok := stdlibFieldPath(x.X)
+		if !ok {
+			return "", nil, false
+		}
+		return module, append(path, x.Name), true
+	default:
+		return "", nil, false
+	}
+}
+
+func stdlibJoinFieldPath(path []string) string {
+	out := ""
+	for i, part := range path {
+		if i > 0 {
+			out += "."
+		}
+		out += part
+	}
+	return out
 }
 
 // stdlibMethodCallsiteSpliceVisitor walks every Expr-bearing slot in

--- a/internal/backend/stdlib_mangle_test.go
+++ b/internal/backend/stdlib_mangle_test.go
@@ -173,6 +173,81 @@ func TestRewriteStdlibMethodCallsitesRewritesMatch(t *testing.T) {
 	}
 }
 
+func TestRewriteStdlibMethodCallsitesRewritesSingletonMethod(t *testing.T) {
+	receiver := &ir.FieldExpr{X: &ir.Ident{Name: "encoding"}, Name: "base64"}
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: receiver, Name: "encode"},
+		Args:   []ir.Arg{{Value: &ir.Ident{Name: "data"}}},
+		T:      ir.TString,
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	reached := []ReachableStdlibMethod{
+		{Module: "encoding", Type: "Base64", Method: "encode", Fn: &ast.FnDecl{Name: "encode"}, ValuePath: "base64"},
+	}
+	got := RewriteStdlibMethodCallsites(mod, reached)
+	if got != 1 {
+		t.Fatalf("rewrite count = %d, want 1", got)
+	}
+	ident, ok := call.Callee.(*ir.Ident)
+	if !ok {
+		t.Fatalf("callee = %T, want *ir.Ident after rewrite", call.Callee)
+	}
+	if ident.Name != "osty_std_encoding__Base64__encode" {
+		t.Fatalf("callee name = %q, want osty_std_encoding__Base64__encode", ident.Name)
+	}
+	if len(call.Args) != 2 {
+		t.Fatalf("args len = %d, want 2 (receiver + original)", len(call.Args))
+	}
+	if call.Args[0].Value != receiver {
+		t.Fatalf("args[0] = %v, want original receiver pointer", call.Args[0].Value)
+	}
+}
+
+func TestRewriteStdlibMethodCallsitesRewritesSingletonMethodCall(t *testing.T) {
+	receiver := &ir.FieldExpr{X: &ir.Ident{Name: "encoding"}, Name: "base64"}
+	mc := &ir.MethodCall{
+		Receiver: receiver,
+		Name:     "encode",
+		Args:     []ir.Arg{{Value: &ir.Ident{Name: "data"}}},
+		T:        ir.TString,
+	}
+	stmt := &ir.ExprStmt{X: mc}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{stmt},
+	}
+	reached := []ReachableStdlibMethod{
+		{Module: "encoding", Type: "Base64", Method: "encode", Fn: &ast.FnDecl{Name: "encode"}, ValuePath: "base64"},
+	}
+	got := RewriteStdlibMethodCallsites(mod, reached)
+	if got != 1 {
+		t.Fatalf("rewrite count = %d, want 1", got)
+	}
+	call, ok := stmt.X.(*ir.CallExpr)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *ir.CallExpr after rewrite", stmt.X)
+	}
+	ident, ok := call.Callee.(*ir.Ident)
+	if !ok {
+		t.Fatalf("callee = %T, want *ir.Ident after rewrite", call.Callee)
+	}
+	if ident.Name != "osty_std_encoding__Base64__encode" {
+		t.Fatalf("callee name = %q, want osty_std_encoding__Base64__encode", ident.Name)
+	}
+	if len(call.Args) != 2 {
+		t.Fatalf("args len = %d, want 2 (receiver + original)", len(call.Args))
+	}
+	if call.Args[0].Value != receiver {
+		t.Fatalf("args[0] = %v, want original receiver pointer", call.Args[0].Value)
+	}
+	if call.T != ir.TString {
+		t.Fatalf("call return T = %v, want String", call.T)
+	}
+}
+
 func TestRewriteStdlibMethodCallsitesSkipsUserType(t *testing.T) {
 	userT := &ir.NamedType{Package: "", Name: "MyStruct"}
 	mc := &ir.MethodCall{

--- a/internal/backend/stdlib_template_check_test.go
+++ b/internal/backend/stdlib_template_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultTemplate(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "template")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(template) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("template module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_xml_check_test.go
+++ b/internal/backend/stdlib_xml_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultXml(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "xml")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(xml) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("xml module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/cli_test.go
+++ b/internal/stdlib/cli_test.go
@@ -1,0 +1,60 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestCliModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["cli"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.cli not loaded")
+	}
+	for _, name := range []string{"flag", "option", "optionDefault", "requiredOption", "parse", "parseEnv", "usage"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.cli missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.cli.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.cli.%s not public", name)
+		}
+	}
+	for _, name := range []string{"FlagSpec", "ParsedArgs"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.cli missing type %q", name)
+		}
+		if sym.Kind != resolve.SymStruct {
+			t.Fatalf("std.cli.%s kind = %s, want struct", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.cli.%s not public", name)
+		}
+	}
+}
+
+func TestCliModuleSourcePinsParserBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["cli"]
+	if mod == nil {
+		t.Fatal("std.cli module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn parse(args: List<String>, specs: List<FlagSpec>) -> ParsedArgs`,
+		`pub fn parseEnv(specs: List<FlagSpec>) -> ParsedArgs`,
+		`arg == "--"`,
+		`splitInlineValue(strings.slice(arg, 2, arg.len()))`,
+		`errors.push("cli: missing required option --{spec.name}")`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.cli source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/encoding_test.go
+++ b/internal/stdlib/encoding_test.go
@@ -1,0 +1,80 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestEncodingModuleSurfaceHasBodiedMethods(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["encoding"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.encoding not loaded")
+	}
+
+	for _, name := range []string{"base64", "hex", "url"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.encoding missing export %q", name)
+		}
+		if sym.Kind != resolve.SymLet {
+			t.Fatalf("std.encoding.%s kind = %s, want let binding", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.encoding.%s not public", name)
+		}
+	}
+
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"Base64", []string{"encode", "decode"}},
+		{"Base64Url", []string{"encode", "decode"}},
+		{"Hex", []string{"encode", "decode"}},
+		{"UrlEncoding", []string{"encode", "decode"}},
+	} {
+		for _, method := range tc.methods {
+			fn := reg.LookupMethodDecl("encoding", tc.typeName, method)
+			if fn == nil {
+				t.Fatalf("LookupMethodDecl(encoding, %s, %s) = nil", tc.typeName, method)
+			}
+			if fn.Body == nil {
+				t.Fatalf("encoding.%s.%s body = nil, want pure Osty body", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestEncodingModuleSourcePinsPureOstyCodecs(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["encoding"]
+	if mod == nil {
+		t.Fatal("std.encoding module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`fn base64Encode(data: Bytes, alphabet: String, padded: Bool) -> String`,
+		`fn base64Decode(text: String, alphabet: String) -> Result<Bytes, Error>`,
+		`fn hexEncode(data: Bytes) -> String`,
+		`fn hexDecode(text: String) -> Result<Bytes, Error>`,
+		`fn urlEncode(text: String) -> String`,
+		`fn urlDecode(text: String) -> Result<String, Error>`,
+		`bytes.from(out)`,
+		`base64UrlAlphabet()`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.encoding source missing %q", want)
+		}
+	}
+	for _, gone := range []string{
+		"Body-less signature stubs",
+		"remaining blockers",
+	} {
+		if strings.Contains(src, gone) {
+			t.Fatalf("std.encoding source still contains stale blocker text %q", gone)
+		}
+	}
+}

--- a/internal/stdlib/i18n_test.go
+++ b/internal/stdlib/i18n_test.go
@@ -1,0 +1,60 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestI18nModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["i18n"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.i18n not loaded")
+	}
+	for _, name := range []string{"locale", "parseLocale", "normalizeTag", "fallbackTags", "catalog", "translate", "translateDefault", "format", "pluralCategory", "selectPlural"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.i18n missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.i18n.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.i18n.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Locale", "MessageCatalog"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.i18n missing type %q", name)
+		}
+		if sym.Kind != resolve.SymStruct {
+			t.Fatalf("std.i18n.%s kind = %s, want struct", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.i18n.%s not public", name)
+		}
+	}
+}
+
+func TestI18nModuleSourcePinsCatalogBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["i18n"]
+	if mod == nil {
+		t.Fatal("std.i18n module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn fallbackTags(tag: String) -> List<String>`,
+		`pub fn format(message: String, values: Map<String, String>) -> String`,
+		`message[i].toInt() == 123`,
+		`pub fn pluralCategory(tag: String, count: Int) -> String`,
+		`lang == "ja" || lang == "ko" || lang == "zh"`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.i18n source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/cli.osty
+++ b/internal/stdlib/modules/cli.osty
@@ -1,0 +1,260 @@
+// std.cli - small command-line argument parser.
+//
+// This module is pure Osty and intentionally sits above `std.env`.
+// Programs can parse an explicit `List<String>` in tests, or call
+// `parseEnv` to parse process arguments after the executable name.
+
+use std.env
+use std.strings
+
+pub struct FlagSpec {
+    pub name: String,
+    pub short: String,
+    pub takesValue: Bool,
+    pub required: Bool,
+    pub defaultValue: String?,
+    pub help: String,
+}
+
+pub struct ParsedArgs {
+    pub values: Map<String, String>,
+    pub present: Map<String, Bool>,
+    pub positionals: List<String>,
+    pub errors: List<String>,
+
+    pub fn ok(self) -> Bool {
+        self.errors.len() == 0
+    }
+
+    pub fn has(self, name: String) -> Bool {
+        self.present.get(name) ?? false
+    }
+
+    pub fn value(self, name: String) -> String? {
+        self.values.get(name)
+    }
+
+    pub fn valueOr(self, name: String, defaultValue: String) -> String {
+        self.values.get(name) ?? defaultValue
+    }
+}
+
+pub fn flag(name: String, short: String, help: String) -> FlagSpec {
+    FlagSpec {
+        name: name,
+        short: short,
+        takesValue: false,
+        required: false,
+        defaultValue: noneString(),
+        help: help,
+    }
+}
+
+pub fn option(name: String, short: String, help: String) -> FlagSpec {
+    FlagSpec {
+        name: name,
+        short: short,
+        takesValue: true,
+        required: false,
+        defaultValue: noneString(),
+        help: help,
+    }
+}
+
+pub fn optionDefault(name: String, short: String, defaultValue: String, help: String) -> FlagSpec {
+    FlagSpec {
+        name: name,
+        short: short,
+        takesValue: true,
+        required: false,
+        defaultValue: Some(defaultValue),
+        help: help,
+    }
+}
+
+pub fn requiredOption(name: String, short: String, help: String) -> FlagSpec {
+    FlagSpec {
+        name: name,
+        short: short,
+        takesValue: true,
+        required: true,
+        defaultValue: noneString(),
+        help: help,
+    }
+}
+
+pub fn parseEnv(specs: List<FlagSpec>) -> ParsedArgs {
+    parse(env.args().drop(1), specs)
+}
+
+pub fn parse(args: List<String>, specs: List<FlagSpec>) -> ParsedArgs {
+    let mut values: Map<String, String> = {:}
+    let mut present: Map<String, Bool> = {:}
+    let mut positionals: List<String> = []
+    let mut errors: List<String> = []
+
+    for spec in specs {
+        present.insert(spec.name, false)
+        match spec.defaultValue {
+            Some(value) -> values.insert(spec.name, value),
+            None        -> {},
+        }
+    }
+
+    let mut i = 0
+    let mut positionalOnly = false
+    for i < args.len() {
+        let arg = args[i]
+        if positionalOnly {
+            positionals.push(arg)
+            i = i + 1
+            continue
+        }
+        if arg == "--" {
+            positionalOnly = true
+            i = i + 1
+            continue
+        }
+        if strings.startsWith(arg, "--") && arg.len() > 2 {
+            let parsed = splitInlineValue(strings.slice(arg, 2, arg.len()))
+            match findLong(specs, parsed.name) {
+                Some(spec) -> {
+                    let used = applySpec(spec, parsed.value, args, i, values, present, errors)
+                    i = i + used
+                },
+                None -> {
+                    errors.push("cli: unknown option --{parsed.name}")
+                    i = i + 1
+                },
+            }
+            continue
+        }
+        if strings.startsWith(arg, "-") && arg != "-" {
+            let parsed = splitInlineValue(strings.slice(arg, 1, arg.len()))
+            match findShort(specs, parsed.name) {
+                Some(spec) -> {
+                    let used = applySpec(spec, parsed.value, args, i, values, present, errors)
+                    i = i + used
+                },
+                None -> {
+                    errors.push("cli: unknown option -{parsed.name}")
+                    i = i + 1
+                },
+            }
+            continue
+        }
+        positionals.push(arg)
+        i = i + 1
+    }
+
+    for spec in specs {
+        if spec.required && !present.get(spec.name).unwrap() {
+            errors.push("cli: missing required option --{spec.name}")
+        }
+    }
+
+    ParsedArgs {
+        values: values,
+        present: present,
+        positionals: positionals,
+        errors: errors,
+    }
+}
+
+pub fn usage(program: String, specs: List<FlagSpec>) -> String {
+    let mut out = "Usage: {program}"
+    for spec in specs {
+        if spec.takesValue {
+            if spec.short.isEmpty() {
+                out = "{out} [--{spec.name} <value>]"
+            } else {
+                out = "{out} [-{spec.short}|--{spec.name} <value>]"
+            }
+        } else if spec.short.isEmpty() {
+            out = "{out} [--{spec.name}]"
+        } else {
+            out = "{out} [-{spec.short}|--{spec.name}]"
+        }
+    }
+    out
+}
+
+struct InlineArg {
+    name: String,
+    value: String?,
+}
+
+fn splitInlineValue(text: String) -> InlineArg {
+    match strings.indexOf(text, "=") {
+        Some(i) -> InlineArg {
+            name: strings.slice(text, 0, i),
+            value: Some(strings.slice(text, i + 1, text.len())),
+        },
+        None -> InlineArg {
+            name: text,
+            value: noneString(),
+        },
+    }
+}
+
+fn noneString() -> String? {
+    None
+}
+
+fn findLong(specs: List<FlagSpec>, name: String) -> FlagSpec? {
+    for spec in specs {
+        if spec.name == name {
+            return Some(spec)
+        }
+    }
+    None
+}
+
+fn findShort(specs: List<FlagSpec>, short: String) -> FlagSpec? {
+    for spec in specs {
+        if !spec.short.isEmpty() && spec.short == short {
+            return Some(spec)
+        }
+    }
+    None
+}
+
+fn applySpec(
+    spec: FlagSpec,
+    inlineValue: String?,
+    args: List<String>,
+    index: Int,
+    values: Map<String, String>,
+    present: Map<String, Bool>,
+    errors: List<String>,
+) -> Int {
+    present.insert(spec.name, true)
+    if !spec.takesValue {
+        match inlineValue {
+            Some(_) -> errors.push("cli: option --{spec.name} does not take a value"),
+            None    -> {},
+        }
+        values.insert(spec.name, "true")
+        return 1
+    }
+
+    match inlineValue {
+        Some(value) -> {
+            values.insert(spec.name, value)
+            return 1
+        },
+        None -> {},
+    }
+
+    if index + 1 >= args.len() {
+        errors.push("cli: option --{spec.name} requires a value")
+        return 1
+    }
+    let value = args[index + 1]
+    if strings.startsWith(value, "-") {
+        errors.push("cli: option --{spec.name} requires a value")
+        return 1
+    }
+    values.insert(spec.name, value)
+    2
+}

--- a/internal/stdlib/modules/encoding.osty
+++ b/internal/stdlib/modules/encoding.osty
@@ -1,41 +1,329 @@
 // std.encoding — binary-to-text encodings (spec §10.11).
 //
-// Body-less signature stubs: the backend lowers each call to the real
-// codec runtime. A pure-Osty implementation is no longer blocked on
-// the selfhost `Bytes.len/get/from` surface — those intrinsics are now
-// registered in `toolchain/check_env.osty`. The remaining blockers
-// are downstream:
-//   1. Struct-method body injection. Today
-//      `injectReachableStdlibBodies` only walks top-level `fn` decls,
-//      so even if the methods below grew Osty bodies the LLVM backend
-//      would not pick them up. Methods need to be added to the
-//      injection set (or this surface refactored to free helpers that
-//      the methods delegate to).
-//   2. `Bytes.from(List<Byte>)` LLVM codegen. Required by the
-//      decoders to construct the result bytes; the encoder side is
-//      read-only and unblocked.
+// Base64, hex, and URL component percent-encoding are implemented in
+// Osty. The only primitive dependency here is construction of `Bytes`
+// from `List<Byte>`, which belongs to the core Bytes surface.
+
+use std.bytes
+use std.char as ascii
+use std.error
 
 pub struct Base64Url {
-    pub fn encode(self, data: Bytes) -> String
-    pub fn decode(self, text: String) -> Result<Bytes, Error>
+    pub fn encode(self, data: Bytes) -> String {
+        base64Encode(data, base64UrlAlphabet(), false)
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        base64Decode(text, base64UrlAlphabet())
+    }
 }
 
 pub struct Base64 {
     pub url: Base64Url
-    pub fn encode(self, data: Bytes) -> String
-    pub fn decode(self, text: String) -> Result<Bytes, Error>
+
+    pub fn encode(self, data: Bytes) -> String {
+        base64Encode(data, base64Alphabet(), true)
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        base64Decode(text, base64Alphabet())
+    }
 }
 
 pub struct Hex {
-    pub fn encode(self, data: Bytes) -> String
-    pub fn decode(self, text: String) -> Result<Bytes, Error>
+    pub fn encode(self, data: Bytes) -> String {
+        hexEncode(data)
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        hexDecode(text)
+    }
 }
 
 pub struct UrlEncoding {
-    pub fn encode(self, text: String) -> String
-    pub fn decode(self, text: String) -> Result<String, Error>
+    pub fn encode(self, text: String) -> String {
+        urlEncode(text)
+    }
+
+    pub fn decode(self, text: String) -> Result<String, Error> {
+        urlDecode(text)
+    }
 }
 
 pub let base64: Base64 = Base64 { url: Base64Url {} }
 pub let hex: Hex = Hex {}
 pub let url: UrlEncoding = UrlEncoding {}
+
+fn base64Alphabet() -> String {
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+}
+
+fn base64UrlAlphabet() -> String {
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+}
+
+fn base64Encode(data: Bytes, alphabet: String, padded: Bool) -> String {
+    let mut out = ""
+    let mut i = 0
+    let n = data.len()
+    for i < n {
+        let b0 = data.get(i).unwrap().toInt()
+        let has1 = i + 1 < n
+        let has2 = i + 2 < n
+        let b1 = if has1 { data.get(i + 1).unwrap().toInt() } else { 0 }
+        let b2 = if has2 { data.get(i + 2).unwrap().toInt() } else { 0 }
+        let chunk = (b0 << 16) | (b1 << 8) | b2
+
+        out = "{out}{alphabet[(chunk >> 18) & 0x3F]}"
+        out = "{out}{alphabet[(chunk >> 12) & 0x3F]}"
+        if has1 {
+            out = "{out}{alphabet[(chunk >> 6) & 0x3F]}"
+        } else if padded {
+            out = "{out}="
+        }
+        if has2 {
+            out = "{out}{alphabet[chunk & 0x3F]}"
+        } else if padded {
+            out = "{out}="
+        }
+        i = i + 3
+    }
+    out
+}
+
+fn base64Decode(text: String, alphabet: String) -> Result<Bytes, Error> {
+    let mut values: List<Int> = []
+    let mut sawPadding = false
+    for c in text.chars() {
+        if isAsciiSpace(c) {
+            continue
+        }
+        if c == '=' {
+            sawPadding = true
+            values.push(-1)
+            continue
+        }
+        if sawPadding {
+            return Err(encodingError("base64: data after padding"))
+        }
+        let v = indexInAlphabet(alphabet, c)
+        if v < 0 {
+            return Err(encodingError("base64: invalid character {c}"))
+        }
+        values.push(v)
+    }
+
+    let mut out: List<Byte> = []
+    if values.len() == 0 {
+        return Ok(bytes.from(out))
+    }
+    if values.len() % 4 == 1 {
+        return Err(encodingError("base64: invalid length"))
+    }
+
+    let mut i = 0
+    for i < values.len() {
+        let remain = values.len() - i
+        let groupLen = if remain >= 4 { 4 } else { remain }
+        if groupLen == 1 {
+            return Err(encodingError("base64: invalid final quantum"))
+        }
+
+        let v0 = values[i]
+        let v1 = values[i + 1]
+        if v0 < 0 || v1 < 0 {
+            return Err(encodingError("base64: invalid padding"))
+        }
+
+        if groupLen == 2 {
+            if (v1 & 0x0F) != 0 {
+                return Err(encodingError("base64: non-zero trailing bits"))
+            }
+            pushByte(out, (v0 << 2) | (v1 >> 4))
+            i = i + 2
+            continue
+        }
+
+        let v2 = values[i + 2]
+        if groupLen == 3 {
+            if v2 < 0 {
+                return Err(encodingError("base64: invalid padding"))
+            }
+            if (v2 & 0x03) != 0 {
+                return Err(encodingError("base64: non-zero trailing bits"))
+            }
+            pushByte(out, (v0 << 2) | (v1 >> 4))
+            pushByte(out, ((v1 & 0x0F) << 4) | (v2 >> 2))
+            i = i + 3
+            continue
+        }
+
+        let v3 = values[i + 3]
+        let pad2 = v2 < 0
+        let pad3 = v3 < 0
+        if pad2 {
+            if !pad3 {
+                return Err(encodingError("base64: invalid padding"))
+            }
+            if (v1 & 0x0F) != 0 {
+                return Err(encodingError("base64: non-zero trailing bits"))
+            }
+            pushByte(out, (v0 << 2) | (v1 >> 4))
+            if i + 4 != values.len() {
+                return Err(encodingError("base64: data after padding"))
+            }
+        } else if pad3 {
+            if (v2 & 0x03) != 0 {
+                return Err(encodingError("base64: non-zero trailing bits"))
+            }
+            pushByte(out, (v0 << 2) | (v1 >> 4))
+            pushByte(out, ((v1 & 0x0F) << 4) | (v2 >> 2))
+            if i + 4 != values.len() {
+                return Err(encodingError("base64: data after padding"))
+            }
+        } else {
+            pushByte(out, (v0 << 2) | (v1 >> 4))
+            pushByte(out, ((v1 & 0x0F) << 4) | (v2 >> 2))
+            pushByte(out, ((v2 & 0x03) << 6) | v3)
+        }
+        i = i + 4
+    }
+
+    Ok(bytes.from(out))
+}
+
+fn indexInAlphabet(alphabet: String, c: Char) -> Int {
+    let chars = alphabet.chars()
+    let mut i = 0
+    for i < chars.len() {
+        if chars[i] == c {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+fn hexEncode(data: Bytes) -> String {
+    let mut out = ""
+    let mut i = 0
+    for i < data.len() {
+        let n = data.get(i).unwrap().toInt()
+        out = "{out}{lowerHexDigit((n >> 4) & 0x0F)}{lowerHexDigit(n & 0x0F)}"
+        i = i + 1
+    }
+    out
+}
+
+fn hexDecode(text: String) -> Result<Bytes, Error> {
+    let chars = text.chars()
+    if chars.len() % 2 != 0 {
+        return Err(encodingError("hex: odd length"))
+    }
+    let mut out: List<Byte> = []
+    let mut i = 0
+    for i < chars.len() {
+        let hi = hexValueChar(chars[i])
+        let lo = hexValueChar(chars[i + 1])
+        if hi < 0 || lo < 0 {
+            return Err(encodingError("hex: invalid digit"))
+        }
+        pushByte(out, (hi << 4) | lo)
+        i = i + 2
+    }
+    Ok(bytes.from(out))
+}
+
+fn urlEncode(text: String) -> String {
+    let mut out = ""
+    for b in text.bytes() {
+        let n = b.toInt()
+        if isUrlUnreserved(n) {
+            out = "{out}{n.toChar()}"
+        } else {
+            out = "{out}%{upperHexDigit((n >> 4) & 0x0F)}{upperHexDigit(n & 0x0F)}"
+        }
+    }
+    out
+}
+
+fn urlDecode(text: String) -> Result<String, Error> {
+    let input = text.bytes()
+    let mut out: List<Byte> = []
+    let mut i = 0
+    for i < input.len() {
+        let b = input[i]
+        if b.toInt() == 0x25 {
+            if i + 2 >= input.len() {
+                return Err(encodingError("url: incomplete percent escape"))
+            }
+            let hi = hexValueByte(input[i + 1])
+            let lo = hexValueByte(input[i + 2])
+            if hi < 0 || lo < 0 {
+                return Err(encodingError("url: invalid percent escape"))
+            }
+            pushByte(out, (hi << 4) | lo)
+            i = i + 3
+        } else {
+            out.push(b)
+            i = i + 1
+        }
+    }
+    bytes.toString(bytes.from(out))
+}
+
+fn pushByte(buf: List<Byte>, n: Int) {
+    buf.push(n.toByte())
+}
+
+fn lowerHexDigit(n: Int) -> Char {
+    if n < 10 {
+        return ('0'.toInt() + n).toChar()
+    }
+    ('a'.toInt() + n - 10).toChar()
+}
+
+fn upperHexDigit(n: Int) -> Char {
+    if n < 10 {
+        return ('0'.toInt() + n).toChar()
+    }
+    ('A'.toInt() + n - 10).toChar()
+}
+
+fn hexValueChar(c: Char) -> Int {
+    match ascii.hexDigitValue(c) {
+        Some(v) -> v,
+        None    -> -1,
+    }
+}
+
+fn hexValueByte(b: Byte) -> Int {
+    let n = b.toInt()
+    let mut v = -1
+    if n >= 0x30 && n <= 0x39 {
+        v = n - 0x30
+    } else if n >= 0x61 && n <= 0x66 {
+        v = n - 0x61 + 10
+    } else if n >= 0x41 && n <= 0x46 {
+        v = n - 0x41 + 10
+    }
+    v
+}
+
+fn isUrlUnreserved(n: Int) -> Bool {
+    (n >= 0x41 && n <= 0x5A) ||
+    (n >= 0x61 && n <= 0x7A) ||
+    (n >= 0x30 && n <= 0x39) ||
+    n == 0x2D ||
+    n == 0x2E ||
+    n == 0x5F ||
+    n == 0x7E
+}
+
+fn isAsciiSpace(c: Char) -> Bool {
+    c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+fn encodingError(message: String) -> Error {
+    error.new("encoding: {message}")
+}

--- a/internal/stdlib/modules/i18n.osty
+++ b/internal/stdlib/modules/i18n.osty
@@ -1,0 +1,136 @@
+// std.i18n - small locale and message-catalog helpers.
+
+use std.strings
+
+pub struct Locale {
+    pub language: String,
+    pub region: String,
+
+    pub fn tag(self) -> String {
+        if self.region.isEmpty() {
+            return self.language
+        }
+        "{self.language}-{self.region}"
+    }
+}
+
+pub struct MessageCatalog {
+    pub locale: Locale,
+    pub messages: Map<String, String>,
+}
+
+pub fn locale(language: String, region: String) -> Locale {
+    Locale {
+        language: strings.toLower(strings.trimSpace(language)),
+        region: strings.toUpper(strings.trimSpace(region)),
+    }
+}
+
+pub fn parseLocale(tag: String) -> Locale {
+    let normalized = strings.replaceAll(strings.trimSpace(tag), "_", "-")
+    match strings.indexOf(normalized, "-") {
+        Some(i) -> locale(
+            strings.slice(normalized, 0, i),
+            strings.slice(normalized, i + 1, normalized.len()),
+        ),
+        None -> locale(normalized, ""),
+    }
+}
+
+pub fn normalizeTag(tag: String) -> String {
+    parseLocale(tag).tag()
+}
+
+pub fn fallbackTags(tag: String) -> List<String> {
+    let loc = parseLocale(tag)
+    let mut out: List<String> = []
+    let full = loc.tag()
+    if !full.isEmpty() {
+        out.push(full)
+    }
+    if !loc.region.isEmpty() && !loc.language.isEmpty() {
+        out.push(loc.language)
+    }
+    out
+}
+
+pub fn catalog(tag: String, messages: Map<String, String>) -> MessageCatalog {
+    MessageCatalog {
+        locale: parseLocale(tag),
+        messages: messages,
+    }
+}
+
+pub fn translate(cat: MessageCatalog, key: String) -> String? {
+    cat.messages.get(key)
+}
+
+pub fn translateDefault(cat: MessageCatalog, key: String, fallback: String) -> String {
+    match translate(cat, key) {
+        Some(value) -> value,
+        None -> fallback,
+    }
+}
+
+pub fn format(message: String, values: Map<String, String>) -> String {
+    let mut out = ""
+    let mut i = 0
+    for i < message.len() {
+        if message[i].toInt() == 123 {
+            let end = findCloseBrace(message, i + 1)
+            if end > i + 1 {
+                let key = strings.trimSpace(strings.slice(message, i + 1, end))
+                match values.get(key) {
+                    Some(value) -> {
+                        out = "{out}{value}"
+                    },
+                    None -> {
+                        out = "{out}{message[i]}"
+                    },
+                }
+                if values.get(key).isSome() {
+                    i = end + 1
+                    continue
+                }
+            }
+        }
+        out = "{out}{message[i]}"
+        i = i + 1
+    }
+    out
+}
+
+pub fn pluralCategory(tag: String, count: Int) -> String {
+    let lang = parseLocale(tag).language
+    if lang == "ja" || lang == "ko" || lang == "zh" {
+        return "other"
+    }
+    if lang == "fr" {
+        if count == 0 || count == 1 {
+            return "one"
+        }
+        return "other"
+    }
+    if count == 1 {
+        return "one"
+    }
+    "other"
+}
+
+pub fn selectPlural(tag: String, count: Int, one: String, other: String) -> String {
+    if pluralCategory(tag, count) == "one" {
+        return one
+    }
+    other
+}
+
+fn findCloseBrace(text: String, start: Int) -> Int {
+    let mut i = start
+    for i < text.len() {
+        if text[i].toInt() == 125 {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}

--- a/internal/stdlib/modules/template.osty
+++ b/internal/stdlib/modules/template.osty
@@ -1,0 +1,148 @@
+// std.template - tiny string and HTML template rendering.
+//
+// The syntax is deliberately small and deterministic:
+//   - `{{name}}` inserts an HTML-escaped value.
+//   - `{{{name}}}` inserts a raw value.
+//   - missing names are errors in strict render mode.
+
+use std.error
+use std.strings
+
+pub fn render(source: String, data: Map<String, String>) -> Result<String, Error> {
+    renderWith(source, data, true)
+}
+
+pub fn renderLoose(source: String, data: Map<String, String>) -> String {
+    match renderWith(source, data, false) {
+        Ok(out) -> out,
+        Err(_)  -> source,
+    }
+}
+
+pub fn renderRaw(source: String, data: Map<String, String>) -> Result<String, Error> {
+    let mut escaped: Map<String, String> = {:}
+    for (key, value) in data {
+        escaped.insert(key, value)
+    }
+    renderWithRawOnly(source, escaped, true)
+}
+
+pub fn escapeHtml(text: String) -> String {
+    let mut out = ""
+    for c in text.chars() {
+        if c == '&' {
+            out = "{out}&amp;"
+        } else if c == '<' {
+            out = "{out}&lt;"
+        } else if c == '>' {
+            out = "{out}&gt;"
+        } else if c == '"' {
+            out = "{out}&quot;"
+        } else if c == '\'' {
+            out = "{out}&#39;"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+pub fn stripTags(html: String) -> String {
+    let mut out = ""
+    let mut inTag = false
+    for c in html.chars() {
+        if c == '<' {
+            inTag = true
+        } else if c == '>' {
+            inTag = false
+        } else if !inTag {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+fn renderWith(source: String, data: Map<String, String>, strict: Bool) -> Result<String, Error> {
+    let mut escaped: Map<String, String> = {:}
+    for (key, value) in data {
+        escaped.insert(key, escapeHtml(value))
+    }
+    renderWithRawAndEscaped(source, data, escaped, strict)
+}
+
+fn renderWithRawOnly(source: String, data: Map<String, String>, strict: Bool) -> Result<String, Error> {
+    renderWithRawAndEscaped(source, data, data, strict)
+}
+
+fn renderWithRawAndEscaped(
+    source: String,
+    raw: Map<String, String>,
+    escaped: Map<String, String>,
+    strict: Bool,
+) -> Result<String, Error> {
+    let mut out = ""
+    let mut i = 0
+    for i < source.len() {
+        if startsAt(source, i, "\{\{\{") {
+            match closeAt(source, i + 3, "\}\}\}") {
+                Some(end) -> {
+                    let name = strings.trimSpace(strings.slice(source, i + 3, end))
+                    match raw.get(name) {
+                        Some(value) -> {
+                            out = "{out}{value}"
+                        },
+                        None -> {
+                            if strict {
+                                return Err(error.new("template: missing value: {name}"))
+                            }
+                        },
+                    }
+                    i = end + 3
+                    continue
+                },
+                None -> {},
+            }
+        }
+        if startsAt(source, i, "\{\{") {
+            match closeAt(source, i + 2, "\}\}") {
+                Some(end) -> {
+                    let name = strings.trimSpace(strings.slice(source, i + 2, end))
+                    match escaped.get(name) {
+                        Some(value) -> {
+                            out = "{out}{value}"
+                        },
+                        None -> {
+                            if strict {
+                                return Err(error.new("template: missing value: {name}"))
+                            }
+                        },
+                    }
+                    i = end + 2
+                    continue
+                },
+                None -> {},
+            }
+        }
+        out = "{out}{source[i]}"
+        i = i + 1
+    }
+    Ok(out)
+}
+
+fn startsAt(text: String, index: Int, needle: String) -> Bool {
+    if index < 0 || index + needle.len() > text.len() {
+        return false
+    }
+    strings.slice(text, index, index + needle.len()) == needle
+}
+
+fn closeAt(text: String, start: Int, marker: String) -> Int? {
+    let mut i = start
+    for i + marker.len() <= text.len() {
+        if startsAt(text, i, marker) {
+            return Some(i)
+        }
+        i = i + 1
+    }
+    None
+}

--- a/internal/stdlib/modules/xml.osty
+++ b/internal/stdlib/modules/xml.osty
@@ -1,0 +1,391 @@
+// std.xml - lightweight XML escaping, tag building, and tokenization.
+
+use std.error
+use std.strings
+
+pub struct XmlAttr {
+    pub name: String,
+    pub value: String,
+}
+
+pub struct XmlTag {
+    pub name: String,
+    pub attrs: Map<String, String>,
+    pub selfClosing: Bool,
+}
+
+pub enum XmlToken {
+    XmlStart(XmlTag),
+    XmlEnd(String),
+    XmlText(String),
+    XmlComment(String),
+}
+
+pub fn attr(name: String, value: String) -> XmlAttr {
+    XmlAttr {
+        name: name,
+        value: value,
+    }
+}
+
+pub fn escape(text: String) -> String {
+    let mut out = ""
+    for c in text.chars() {
+        if c == '&' {
+            out = "{out}&amp;"
+        } else if c == '<' {
+            out = "{out}&lt;"
+        } else if c == '>' {
+            out = "{out}&gt;"
+        } else if c == '"' {
+            out = "{out}&quot;"
+        } else if c.toInt() == 39 {
+            out = "{out}&apos;"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+pub fn unescape(text: String) -> Result<String, Error> {
+    let mut out = ""
+    let mut i = 0
+    for i < text.len() {
+        if startsAt(text, i, "&amp;") {
+            out = "{out}&"
+            i = i + 5
+            continue
+        }
+        if startsAt(text, i, "&lt;") {
+            out = "{out}<"
+            i = i + 4
+            continue
+        }
+        if startsAt(text, i, "&gt;") {
+            out = "{out}>"
+            i = i + 4
+            continue
+        }
+        if startsAt(text, i, "&quot;") {
+            out = "{out}\""
+            i = i + 6
+            continue
+        }
+        if startsAt(text, i, "&apos;") {
+            out = "{out}{39.toChar()}"
+            i = i + 6
+            continue
+        }
+        if startsAt(text, i, "&#") {
+            match readNumericEntity(text, i + 2) {
+                Some(entity) -> {
+                    out = "{out}{entity.value.toChar()}"
+                    i = entity.next
+                    continue
+                },
+                None -> {
+                    return Err(error.new("xml: invalid numeric entity"))
+                },
+            }
+        }
+        if text[i] == '&' {
+            return Err(error.new("xml: unknown entity"))
+        }
+        out = "{out}{text[i]}"
+        i = i + 1
+    }
+    Ok(out)
+}
+
+pub fn isName(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    let chars = name.chars()
+    if !isNameStart(chars[0]) {
+        return false
+    }
+    for c in chars {
+        if !isNameChar(c) {
+            return false
+        }
+    }
+    true
+}
+
+pub fn startTag(name: String, attrs: List<XmlAttr>) -> Result<String, Error> {
+    if !isName(name) {
+        return Err(error.new("xml: invalid element name: {name}"))
+    }
+    match renderAttrs(attrs) {
+        Ok(suffix) -> Ok("<{name}{suffix}>"),
+        Err(err) -> Err(err),
+    }
+}
+
+pub fn endTag(name: String) -> Result<String, Error> {
+    if !isName(name) {
+        return Err(error.new("xml: invalid element name: {name}"))
+    }
+    Ok("</{name}>")
+}
+
+pub fn emptyElement(name: String, attrs: List<XmlAttr>) -> Result<String, Error> {
+    if !isName(name) {
+        return Err(error.new("xml: invalid element name: {name}"))
+    }
+    match renderAttrs(attrs) {
+        Ok(suffix) -> Ok("<{name}{suffix}/>"),
+        Err(err) -> Err(err),
+    }
+}
+
+pub fn element(name: String, text: String, attrs: List<XmlAttr>) -> Result<String, Error> {
+    match startTag(name, attrs) {
+        Ok(open) -> {
+            match endTag(name) {
+                Ok(close) -> Ok("{open}{escape(text)}{close}"),
+                Err(err) -> Err(err),
+            }
+        },
+        Err(err) -> Err(err),
+    }
+}
+
+pub fn tokenize(source: String) -> Result<List<XmlToken>, Error> {
+    let mut tokens: List<XmlToken> = []
+    let mut i = 0
+    for i < source.len() {
+        if startsAt(source, i, "<!--") {
+            let end = indexOfFrom(source, "-->", i + 4)
+            if end < 0 {
+                return Err(error.new("xml: unterminated comment"))
+            }
+            tokens.push(XmlComment(strings.slice(source, i + 4, end)))
+            i = end + 3
+            continue
+        }
+        if source[i] == '<' {
+            let end = indexOfFrom(source, ">", i + 1)
+            if end < 0 {
+                return Err(error.new("xml: unterminated tag"))
+            }
+            let inside = strings.trimSpace(strings.slice(source, i + 1, end))
+            if inside.isEmpty() {
+                return Err(error.new("xml: empty tag"))
+            }
+            if startsAt(inside, 0, "/") {
+                let name = strings.trimSpace(strings.slice(inside, 1, inside.len()))
+                if !isName(name) {
+                    return Err(error.new("xml: invalid end tag: {name}"))
+                }
+                tokens.push(XmlEnd(name))
+            } else {
+                let selfClosing = lastNonSpaceIsSlash(inside)
+                let body = tagBody(inside, selfClosing)
+                match parseTag(body, selfClosing) {
+                    Ok(tag) -> tokens.push(XmlStart(tag)),
+                    Err(err) -> {
+                        return Err(err)
+                    },
+                }
+            }
+            i = end + 1
+            continue
+        }
+        let end = indexOfFrom(source, "<", i)
+        let next = if end < 0 { source.len() } else { end }
+        let raw = strings.slice(source, i, next)
+        match unescape(raw) {
+            Ok(text) -> {
+                if text != "" {
+                    tokens.push(XmlText(text))
+                }
+            },
+            Err(err) -> {
+                return Err(err)
+            },
+        }
+        i = next
+    }
+    Ok(tokens)
+}
+
+struct NumericEntity {
+    value: Int,
+    next: Int,
+}
+
+fn renderAttrs(attrs: List<XmlAttr>) -> Result<String, Error> {
+    let mut out = ""
+    let quote = '"'
+    for item in attrs {
+        if !isName(item.name) {
+            return Err(error.new("xml: invalid attribute name: {item.name}"))
+        }
+        out = "{out} {item.name}={quote}{escape(item.value)}{quote}"
+    }
+    Ok(out)
+}
+
+fn parseTag(body: String, selfClosing: Bool) -> Result<XmlTag, Error> {
+    let nameEnd = readNameEnd(body, 0)
+    if nameEnd == 0 {
+        return Err(error.new("xml: missing tag name"))
+    }
+    let name = strings.slice(body, 0, nameEnd)
+    let mut attrs: Map<String, String> = {:}
+    let mut i = nameEnd
+    for i < body.len() {
+        i = skipSpace(body, i)
+        if i >= body.len() {
+            break
+        }
+        let attrStart = i
+        let attrEnd = readNameEnd(body, i)
+        if attrEnd == attrStart {
+            return Err(error.new("xml: expected attribute name"))
+        }
+        let attrName = strings.slice(body, attrStart, attrEnd)
+        i = skipSpace(body, attrEnd)
+        if i >= body.len() || body[i] != '=' {
+            return Err(error.new("xml: expected = after attribute name"))
+        }
+        i = skipSpace(body, i + 1)
+        if i >= body.len() {
+            return Err(error.new("xml: expected quoted attribute value"))
+        }
+        let quote = body[i]
+        if quote != '"' && quote.toInt() != 39 {
+            return Err(error.new("xml: expected quoted attribute value"))
+        }
+        i = i + 1
+        let valueStart = i
+        for i < body.len() && body[i] != quote {
+            i = i + 1
+        }
+        if i >= body.len() {
+            return Err(error.new("xml: unterminated attribute value"))
+        }
+        match unescape(strings.slice(body, valueStart, i)) {
+            Ok(value) -> attrs.insert(attrName, value),
+            Err(err) -> {
+                return Err(err)
+            },
+        }
+        i = i + 1
+    }
+    Ok(XmlTag {
+        name: name,
+        attrs: attrs,
+        selfClosing: selfClosing,
+    })
+}
+
+fn readNumericEntity(text: String, start: Int) -> NumericEntity? {
+    let end = indexOfFrom(text, ";", start)
+    if end < 0 {
+        return None
+    }
+    let digits = strings.slice(text, start, end)
+    if digits.isEmpty() {
+        return None
+    }
+    let mut value = 0
+    for c in digits.chars() {
+        if c < '0' || c > '9' {
+            return None
+        }
+        value = value * 10 + (c.toInt() - '0'.toInt())
+    }
+    Some(NumericEntity {
+        value: value,
+        next: end + 1,
+    })
+}
+
+fn tagBody(inside: String, selfClosing: Bool) -> String {
+    if !selfClosing {
+        return inside
+    }
+    let slash = lastNonSpaceIndex(inside)
+    strings.trimSpace(strings.slice(inside, 0, slash))
+}
+
+fn lastNonSpaceIsSlash(text: String) -> Bool {
+    let i = lastNonSpaceIndex(text)
+    if i < 0 {
+        return false
+    }
+    text[i] == '/'
+}
+
+fn lastNonSpaceIndex(text: String) -> Int {
+    let mut i = text.len() - 1
+    for i >= 0 {
+        if !isSpace(text[i]) {
+            return i
+        }
+        i = i - 1
+    }
+    -1
+}
+
+fn readNameEnd(text: String, start: Int) -> Int {
+    if start >= text.len() || !isNameStart(text[start]) {
+        return start
+    }
+    let mut i = start + 1
+    for i < text.len() && isNameChar(text[i]) {
+        i = i + 1
+    }
+    i
+}
+
+fn skipSpace(text: String, start: Int) -> Int {
+    let mut i = start
+    for i < text.len() && isSpace(text[i]) {
+        i = i + 1
+    }
+    i
+}
+
+fn isNameStart(c: Char) -> Bool {
+    (c >= 'a' && c <= 'z') ||
+    (c >= 'A' && c <= 'Z') ||
+    c == '_' ||
+    c == ':'
+}
+
+fn isNameChar(c: Char) -> Bool {
+    isNameStart(c) ||
+    (c >= '0' && c <= '9') ||
+    c == '-' ||
+    c == '.'
+}
+
+fn isSpace(c: Char) -> Bool {
+    c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+fn startsAt(text: String, index: Int, needle: String) -> Bool {
+    if index < 0 || index + needle.len() > text.len() {
+        return false
+    }
+    strings.slice(text, index, index + needle.len()) == needle
+}
+
+fn indexOfFrom(text: String, needle: String, start: Int) -> Int {
+    let mut i = start
+    if needle.isEmpty() {
+        return start
+    }
+    for i + needle.len() <= text.len() {
+        if startsAt(text, i, needle) {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}

--- a/internal/stdlib/template_test.go
+++ b/internal/stdlib/template_test.go
@@ -1,0 +1,48 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestTemplateModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["template"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.template not loaded")
+	}
+	for _, name := range []string{"render", "renderLoose", "renderRaw", "escapeHtml", "stripTags"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.template missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.template.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.template.%s not public", name)
+		}
+	}
+}
+
+func TestTemplateModuleSourcePinsRendererBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["template"]
+	if mod == nil {
+		t.Fatal("std.template module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`{{name}}`,
+		`{{{name}}}`,
+		`pub fn escapeHtml(text: String) -> String`,
+		`return Err(error.new("template: missing value: {name}"))`,
+		`strings.trimSpace(strings.slice(source, i + 2, end))`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.template source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/xml_test.go
+++ b/internal/stdlib/xml_test.go
@@ -1,0 +1,57 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestXmlModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["xml"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.xml not loaded")
+	}
+	for _, name := range []string{"attr", "escape", "unescape", "isName", "startTag", "endTag", "emptyElement", "element", "tokenize"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.xml missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.xml.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.xml.%s not public", name)
+		}
+	}
+	for _, name := range []string{"XmlAttr", "XmlTag", "XmlToken"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.xml missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.xml.%s not public", name)
+		}
+	}
+}
+
+func TestXmlModuleSourcePinsTokenizerBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["xml"]
+	if mod == nil {
+		t.Fatal("std.xml module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn tokenize(source: String) -> Result<List<XmlToken>, Error>`,
+		`startsAt(source, i, "<!--")`,
+		`tokens.push(XmlStart(tag))`,
+		`tokens.push(XmlEnd(name))`,
+		`return Err(error.new("xml: unknown entity"))`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.xml source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implement missing/low-coverage stdlib modules for encoding, CLI parsing, templates, XML, and i18n in pure Osty.
- Add backend support and tests for stdlib singleton method call rewriting used by std.encoding.
- Update STDLIB_MATRIX.md to reflect the new implemented modules and remaining gaps.

## Validation
- go test -count=1 -vet=off ./internal/stdlib
- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult(Encoding|Cli|Template|Xml|I18n)|TestPrepareEntryRewritesStdEncodingSingletonMethods'
- go test -count=1 -vet=off ./internal/backend
- just fmt-check
- git diff --check