### PR TITLE
[codex] add websocket and graphql stdlib modules

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 41 모듈. 분류 기준:
+총 43 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (38 / 41 = 93%)
+### ⭐⭐⭐⭐⭐ Production (40 / 43 = 93%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -42,7 +42,9 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | csv | 351 | — | options-driven, header-aware decode |
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
+| websocket | 322 | pure Osty + crypto/encoding | RFC 6455 accept key + handshake headers + frame encode/decode |
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
+| graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
 | char | 219 | — | Unicode / ASCII methods |
@@ -68,7 +70,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 41 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 43 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -82,7 +84,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | `db/sql`, `email/smtp`, `websocket`, `tar/zip`, `image`, `graphql` |
+| 없는 모듈 | `db/sql`, `email/smtp`, `tar/zip`, `image` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip/tar 계열 없음 |
 | 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -106,6 +108,8 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | HTML 템플릿 | ✅ 가능 | template (escaped/raw placeholder render) |
 | XML 처리 | ✅ 가능 | xml (escape / tag build / tokenize) |
 | 다국어 메시지 | ✅ 가능 | i18n (locale / catalog / placeholder / plural category) |
+| WebSocket handshake/frame | ✅ 가능 | websocket (accept key / headers / frame encode/decode) |
+| GraphQL 요청 생성 | ✅ 가능 | graphql (document builder / variables JSON body) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
@@ -115,10 +119,8 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 |---|---|---|
 | db / sql | DB 작업 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
 | email / smtp | 메일 발송 | 중간 |
-| websocket | WS 통신 | 중간 (http 와 페어) |
 | tar / zip | 아카이브 (compress 는 gzip 만) | 낮음 |
 | image | 이미지 디코딩 | 낮음 |
-| graphql | GraphQL 클라이언트 / 서버 | 낮음 |
 
 ## 4. Phase A / B 분리 패턴
 
@@ -137,7 +139,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 18 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, result, option, csv, xml, encoding, template, i18n, char, iter, bytes)
+- 20 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, result, option, csv, xml, encoding, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -206,7 +208,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db / websocket / email) — *없는 모듈* 카테고리 채우기
+1. **새 모듈 추가** (db / email / archive / image) — *없는 모듈* 카테고리 채우기
 2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_graphql_check_test.go
+++ b/internal/backend/stdlib_graphql_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultGraphql(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "graphql")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(graphql) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("graphql module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_websocket_check_test.go
+++ b/internal/backend/stdlib_websocket_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultWebsocket(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "websocket")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(websocket) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("websocket module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/graphql_test.go
+++ b/internal/stdlib/graphql_test.go
@@ -1,0 +1,60 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestGraphqlModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["graphql"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.graphql not loaded")
+	}
+	for _, name := range []string{"arg", "stringValue", "intValue", "floatValue", "boolValue", "nullValue", "variable", "listValue", "objectValue", "field", "fieldArgs", "selection", "operation", "query", "mutation", "subscription", "request", "namedRequest", "withVariablesJson", "encode", "isName"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.graphql missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.graphql.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.graphql.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Argument", "Request"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.graphql missing type %q", name)
+		}
+		if sym.Kind != resolve.SymStruct {
+			t.Fatalf("std.graphql.%s kind = %s, want struct", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.graphql.%s not public", name)
+		}
+	}
+}
+
+func TestGraphqlModuleSourcePinsBuilderBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["graphql"]
+	if mod == nil {
+		t.Fatal("std.graphql module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn fieldArgs(name: String, args: List<Argument>, selectionSet: String) -> Result<String, Error>`,
+		`pub fn operation(kind: String, name: String, selectionSet: String) -> Result<String, Error>`,
+		`pub fn encode(request: Request) -> String`,
+		`out = "{out},{quote}variables{quote}:{strings.trimSpace(request.variablesJson)}"`,
+		`fn jsonString(value: String) -> String`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.graphql source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/graphql.osty
+++ b/internal/stdlib/modules/graphql.osty
@@ -1,0 +1,224 @@
+// std.graphql - GraphQL document and request-body builders.
+
+use std.error
+use std.strings
+
+pub struct Argument {
+    pub name: String,
+    pub value: String,
+}
+
+pub struct Request {
+    pub query: String,
+    pub operationName: String?,
+    pub variablesJson: String,
+}
+
+pub fn arg(name: String, value: String) -> Result<Argument, Error> {
+    if !isName(name) {
+        return Err(error.new("graphql: invalid argument name: {name}"))
+    }
+    Ok(Argument {
+        name: name,
+        value: value,
+    })
+}
+
+pub fn stringValue(value: String) -> String {
+    jsonString(value)
+}
+
+pub fn intValue(value: Int) -> String {
+    value.toString()
+}
+
+pub fn floatValue(value: Float) -> String {
+    value.toString()
+}
+
+pub fn boolValue(value: Bool) -> String {
+    if value { "true" } else { "false" }
+}
+
+pub fn nullValue() -> String {
+    "null"
+}
+
+pub fn variable(name: String) -> Result<String, Error> {
+    if !isName(name) {
+        return Err(error.new("graphql: invalid variable name: {name}"))
+    }
+    Ok("${name}")
+}
+
+pub fn listValue(values: List<String>) -> String {
+    "[{strings.join(values, \", \")}]"
+}
+
+pub fn objectValue(fields: List<Argument>) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let mut parts: List<String> = []
+    for field in fields {
+        parts.push("{field.name}: {field.value}")
+    }
+    "{open}{strings.join(parts, \", \")}{close}"
+}
+
+pub fn field(name: String) -> Result<String, Error> {
+    fieldArgs(name, [], "")
+}
+
+pub fn fieldArgs(name: String, args: List<Argument>, selectionSet: String) -> Result<String, Error> {
+    if !isName(name) {
+        return Err(error.new("graphql: invalid field name: {name}"))
+    }
+    let renderedArgs = renderArgs(args)
+    let renderedSelection = renderSelection(selectionSet)
+    Ok("{name}{renderedArgs}{renderedSelection}")
+}
+
+pub fn selection(fields: List<String>) -> String {
+    strings.join(fields, " ")
+}
+
+pub fn operation(kind: String, name: String, selectionSet: String) -> Result<String, Error> {
+    if kind != "query" && kind != "mutation" && kind != "subscription" {
+        return Err(error.new("graphql: invalid operation kind: {kind}"))
+    }
+    if !name.isEmpty() && !isName(name) {
+        return Err(error.new("graphql: invalid operation name: {name}"))
+    }
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let body = strings.trimSpace(selectionSet)
+    if name.isEmpty() {
+        return Ok("{kind} {open} {body} {close}")
+    }
+    Ok("{kind} {name} {open} {body} {close}")
+}
+
+pub fn query(selectionSet: String) -> Result<String, Error> {
+    operation("query", "", selectionSet)
+}
+
+pub fn mutation(name: String, selectionSet: String) -> Result<String, Error> {
+    operation("mutation", name, selectionSet)
+}
+
+pub fn subscription(name: String, selectionSet: String) -> Result<String, Error> {
+    operation("subscription", name, selectionSet)
+}
+
+pub fn request(query: String) -> Request {
+    Request {
+        query: query,
+        operationName: noneString(),
+        variablesJson: "",
+    }
+}
+
+pub fn namedRequest(query: String, operationName: String) -> Request {
+    Request {
+        query: query,
+        operationName: Some(operationName),
+        variablesJson: "",
+    }
+}
+
+pub fn withVariablesJson(request: Request, variablesJson: String) -> Request {
+    Request {
+        query: request.query,
+        operationName: request.operationName,
+        variablesJson: strings.trimSpace(variablesJson),
+    }
+}
+
+pub fn encode(request: Request) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let quote = '"'
+    let mut out = "{open}{quote}query{quote}:{jsonString(request.query)}"
+    match request.operationName {
+        Some(name) -> {
+            out = "{out},{quote}operationName{quote}:{jsonString(name)}"
+        },
+        None       -> {},
+    }
+    if !strings.trimSpace(request.variablesJson).isEmpty() {
+        out = "{out},{quote}variables{quote}:{strings.trimSpace(request.variablesJson)}"
+    }
+    "{out}{close}"
+}
+
+pub fn isName(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    let chars = name.chars()
+    if !isNameStart(chars[0]) {
+        return false
+    }
+    for c in chars {
+        if !isNameContinue(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn renderArgs(args: List<Argument>) -> String {
+    if args.isEmpty() {
+        return ""
+    }
+    let mut parts: List<String> = []
+    for item in args {
+        parts.push("{item.name}: {item.value}")
+    }
+    "({strings.join(parts, \", \")})"
+}
+
+fn renderSelection(selectionSet: String) -> String {
+    let body = strings.trimSpace(selectionSet)
+    if body.isEmpty() {
+        return ""
+    }
+    let open = 123.toChar()
+    let close = 125.toChar()
+    " {open} {body} {close}"
+}
+
+fn jsonString(value: String) -> String {
+    let quote = '"'
+    let mut out = "{quote}"
+    for c in value.chars() {
+        if c == '"' {
+            out = "{out}\\\""
+        } else if c.toInt() == 92 {
+            out = "{out}\\\\"
+        } else if c == '\n' {
+            out = "{out}\\n"
+        } else if c == '\r' {
+            out = "{out}\\r"
+        } else if c == '\t' {
+            out = "{out}\\t"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    "{out}{quote}"
+}
+
+fn isNameStart(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= 'a' && c <= 'z') ||
+    c == '_'
+}
+
+fn isNameContinue(c: Char) -> Bool {
+    isNameStart(c) || (c >= '0' && c <= '9')
+}
+
+fn noneString() -> String? {
+    None
+}

--- a/internal/stdlib/modules/websocket.osty
+++ b/internal/stdlib/modules/websocket.osty
@@ -1,0 +1,322 @@
+// std.websocket - RFC 6455 handshake and frame helpers.
+
+use std.bytes
+use std.crypto
+use std.encoding
+use std.error
+use std.strings
+
+pub type Headers = Map<String, String>
+
+pub enum Opcode {
+    Continuation,
+    Text,
+    Binary,
+    Close,
+    Ping,
+    Pong,
+
+    pub fn code(self) -> Int {
+        match self {
+            Continuation -> 0x0,
+            Text         -> 0x1,
+            Binary       -> 0x2,
+            Close        -> 0x8,
+            Ping         -> 0x9,
+            Pong         -> 0xA,
+        }
+    }
+
+    pub fn isControl(self) -> Bool {
+        match self {
+            Close | Ping | Pong -> true,
+            _                  -> false,
+        }
+    }
+}
+
+pub struct Frame {
+    pub fin: Bool,
+    pub opcode: Opcode,
+    pub payload: Bytes,
+    pub masked: Bool,
+    pub maskKey: List<Byte>,
+}
+
+pub struct DecodedFrame {
+    pub frame: Frame,
+    pub next: Int,
+}
+
+pub fn acceptKey(clientKey: String) -> String {
+    let seed = bytes.fromString("{strings.trimSpace(clientKey)}258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    encoding.base64.encode(crypto.sha1(seed))
+}
+
+pub fn handshakeHeaders(clientKey: String) -> Headers {
+    let mut out: Headers = {:}
+    out.insert("Upgrade", "websocket")
+    out.insert("Connection", "Upgrade")
+    out.insert("Sec-WebSocket-Accept", acceptKey(clientKey))
+    out
+}
+
+pub fn isHandshake(headers: Headers) -> Bool {
+    let connection = strings.toLower(header(headers, "Connection") ?? "")
+    let upgrade = strings.toLower(header(headers, "Upgrade") ?? "")
+    let version = strings.trimSpace(header(headers, "Sec-WebSocket-Version") ?? "")
+    let key = strings.trimSpace(header(headers, "Sec-WebSocket-Key") ?? "")
+    strings.contains(connection, "upgrade") &&
+    upgrade == "websocket" &&
+    version == "13" &&
+    !key.isEmpty()
+}
+
+pub fn text(value: String) -> Frame {
+    frame(Text, bytes.fromString(value))
+}
+
+pub fn binary(value: Bytes) -> Frame {
+    frame(Binary, value)
+}
+
+pub fn ping(value: Bytes) -> Frame {
+    frame(Ping, value)
+}
+
+pub fn pong(value: Bytes) -> Frame {
+    frame(Pong, value)
+}
+
+pub fn close(code: Int, reason: String) -> Frame {
+    let mut payload: List<Byte> = []
+    pushByte(payload, (code >> 8) & 0xFF)
+    pushByte(payload, code & 0xFF)
+    let reasonBytes = bytes.fromString(reason)
+    for i in 0..reasonBytes.len() {
+        payload.push(byteAt(reasonBytes, i))
+    }
+    frame(Close, bytes.from(payload))
+}
+
+pub fn frame(opcode: Opcode, payload: Bytes) -> Frame {
+    Frame {
+        fin: true,
+        opcode: opcode,
+        payload: payload,
+        masked: false,
+        maskKey: [],
+    }
+}
+
+pub fn masked(frame: Frame, key: List<Byte>) -> Result<Frame, Error> {
+    if key.len() != 4 {
+        return Err(error.new("websocket: mask key must be four bytes"))
+    }
+    Ok(Frame {
+        fin: frame.fin,
+        opcode: frame.opcode,
+        payload: frame.payload,
+        masked: true,
+        maskKey: key,
+    })
+}
+
+pub fn encode(frame: Frame) -> Result<Bytes, Error> {
+    if frame.opcode.isControl() {
+        if !frame.fin {
+            return Err(error.new("websocket: control frames must not be fragmented"))
+        }
+        if frame.payload.len() > 125 {
+            return Err(error.new("websocket: control frame payload too large"))
+        }
+    }
+    if frame.masked && frame.maskKey.len() != 4 {
+        return Err(error.new("websocket: mask key must be four bytes"))
+    }
+
+    let mut out: List<Byte> = []
+    let first = if frame.fin { 0x80 } else { 0 } | frame.opcode.code()
+    pushByte(out, first)
+
+    let maskBit = if frame.masked { 0x80 } else { 0 }
+    let n = frame.payload.len()
+    if n < 126 {
+        pushByte(out, maskBit | n)
+    } else if n <= 0xFFFF {
+        pushByte(out, maskBit | 126)
+        pushByte(out, (n >> 8) & 0xFF)
+        pushByte(out, n & 0xFF)
+    } else {
+        pushByte(out, maskBit | 127)
+        pushUInt64(out, n)
+    }
+
+    if frame.masked {
+        for keyByte in frame.maskKey {
+            out.push(keyByte)
+        }
+    }
+
+    for i in 0..n {
+        let b = byteAt(frame.payload, i).toInt()
+        if frame.masked {
+            pushByte(out, xorByte(b, frame.maskKey[i % 4].toInt()))
+        } else {
+            pushByte(out, b)
+        }
+    }
+    Ok(bytes.from(out))
+}
+
+pub fn decode(data: Bytes) -> Result<DecodedFrame, Error> {
+    if data.len() < 2 {
+        return Err(error.new("websocket: incomplete frame header"))
+    }
+    let b0 = byteAt(data, 0).toInt()
+    let b1 = byteAt(data, 1).toInt()
+    let fin = (b0 & 0x80) != 0
+    let rsv = b0 & 0x70
+    if rsv != 0 {
+        return Err(error.new("websocket: reserved bits are set"))
+    }
+    let opcode = opcodeFromCode(b0 & 0x0F)?
+    let maskedPayload = (b1 & 0x80) != 0
+    let mut length = b1 & 0x7F
+    let mut pos = 2
+
+    if length == 126 {
+        if data.len() < pos + 2 {
+            return Err(error.new("websocket: incomplete extended length"))
+        }
+        length = (byteAt(data, pos).toInt() << 8) | byteAt(data, pos + 1).toInt()
+        pos = pos + 2
+    } else if length == 127 {
+        if data.len() < pos + 8 {
+            return Err(error.new("websocket: incomplete extended length"))
+        }
+        length = readUInt64(data, pos)
+        pos = pos + 8
+    }
+
+    let mut key: List<Byte> = []
+    if maskedPayload {
+        if data.len() < pos + 4 {
+            return Err(error.new("websocket: incomplete mask key"))
+        }
+        for i in 0..4 {
+            key.push(byteAt(data, pos + i))
+        }
+        pos = pos + 4
+    }
+
+    if data.len() < pos + length {
+        return Err(error.new("websocket: incomplete payload"))
+    }
+    if opcode.isControl() {
+        if !fin {
+            return Err(error.new("websocket: control frames must not be fragmented"))
+        }
+        if length > 125 {
+            return Err(error.new("websocket: control frame payload too large"))
+        }
+    }
+
+    let mut payload: List<Byte> = []
+    for i in 0..length {
+        let b = byteAt(data, pos + i).toInt()
+        if maskedPayload {
+            pushByte(payload, xorByte(b, key[i % 4].toInt()))
+        } else {
+            pushByte(payload, b)
+        }
+    }
+
+    Ok(DecodedFrame {
+        frame: Frame {
+            fin: fin,
+            opcode: opcode,
+            payload: bytes.from(payload),
+            masked: maskedPayload,
+            maskKey: key,
+        },
+        next: pos + length,
+    })
+}
+
+pub fn textPayload(frame: Frame) -> Result<String, Error> {
+    match frame.opcode {
+        Text -> bytes.toString(frame.payload),
+        _    -> Err(error.new("websocket: frame is not text")),
+    }
+}
+
+fn header(headers: Headers, name: String) -> String? {
+    let wanted = strings.toLower(name)
+    for (key, value) in headers {
+        if strings.toLower(key) == wanted {
+            return Some(value)
+        }
+    }
+    None
+}
+
+fn opcodeFromCode(code: Int) -> Result<Opcode, Error> {
+    if code == 0x0 {
+        return Ok(Continuation)
+    }
+    if code == 0x1 {
+        return Ok(Text)
+    }
+    if code == 0x2 {
+        return Ok(Binary)
+    }
+    if code == 0x8 {
+        return Ok(Close)
+    }
+    if code == 0x9 {
+        return Ok(Ping)
+    }
+    if code == 0xA {
+        return Ok(Pong)
+    }
+    Err(error.new("websocket: unknown opcode: {code}"))
+}
+
+fn readUInt64(data: Bytes, pos: Int) -> Int {
+    let mut out = 0
+    for i in 0..8 {
+        out = (out << 8) | byteAt(data, pos + i).toInt()
+    }
+    out
+}
+
+fn pushUInt64(out: List<Byte>, value: Int) {
+    let mut shift = 56
+    for shift >= 0 {
+        pushByte(out, (value >> shift) & 0xFF)
+        shift = shift - 8
+    }
+}
+
+fn xorByte(a: Int, b: Int) -> Int {
+    let mut out = 0
+    let mut bit = 1
+    for bit < 256 {
+        let av = (a & bit) != 0
+        let bv = (b & bit) != 0
+        if av != bv {
+            out = out | bit
+        }
+        bit = bit << 1
+    }
+    out
+}
+
+fn pushByte(buf: List<Byte>, n: Int) {
+    buf.push((n & 0xFF).toByte())
+}
+
+fn byteAt(data: Bytes, index: Int) -> Byte {
+    bytes.get(data, index).unwrap()
+}

--- a/internal/stdlib/websocket_test.go
+++ b/internal/stdlib/websocket_test.go
@@ -1,0 +1,57 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestWebsocketModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["websocket"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.websocket not loaded")
+	}
+	for _, name := range []string{"acceptKey", "handshakeHeaders", "isHandshake", "text", "binary", "ping", "pong", "close", "frame", "masked", "encode", "decode", "textPayload"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.websocket missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.websocket.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.websocket.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Opcode", "Frame", "DecodedFrame"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.websocket missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.websocket.%s not public", name)
+		}
+	}
+}
+
+func TestWebsocketModuleSourcePinsHandshakeAndFrameBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["websocket"]
+	if mod == nil {
+		t.Fatal("std.websocket module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`encoding.base64.encode(crypto.sha1(seed))`,
+		`out.insert("Sec-WebSocket-Accept", acceptKey(clientKey))`,
+		`pub fn encode(frame: Frame) -> Result<Bytes, Error>`,
+		`pub fn decode(data: Bytes) -> Result<DecodedFrame, Error>`,
+		`fn xorByte(a: Int, b: Int) -> Int`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.websocket source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `std.websocket` with RFC 6455 accept-key generation, handshake headers, frame encode/decode, masking, and text payload helpers.
- Add `std.graphql` with argument/value builders, field/operation builders, request body encoding, and name validation.
- Update `STDLIB_MATRIX.md` to move websocket/graphql out of the missing-module list.

## Validation
- go test -count=1 -vet=off ./internal/stdlib
- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult(Websocket|Graphql)'
- just fmt-check
- git diff --check