### PR TITLE
[codex] add email stdlib module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 43 모듈. 분류 기준:
+총 44 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (40 / 43 = 93%)
+### ⭐⭐⭐⭐⭐ Production (41 / 44 = 93%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -37,6 +37,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | url | 592 | — | parse / join / format |
 | io | 541 | shim 171 | Reader/Writer 프로토콜, Buffer, copyN, readExact |
 | collections | 509 | list 68 + map 42 + set 17 | 30+ List 메서드, groupBy, windowed, zip3 |
+| email | 461 | pure Osty + encoding | Address / Message / MIME multipart / attachment base64 / SMTP DATA helpers |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
 | csv | 351 | — | options-driven, header-aware decode |
@@ -70,7 +71,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 43 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 44 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -84,7 +85,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | `db/sql`, `email/smtp`, `tar/zip`, `image` |
+| 없는 모듈 | `db/sql`, `smtp transport`, `tar/zip`, `image` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip/tar 계열 없음 |
 | 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -110,6 +111,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 다국어 메시지 | ✅ 가능 | i18n (locale / catalog / placeholder / plural category) |
 | WebSocket handshake/frame | ✅ 가능 | websocket (accept key / headers / frame encode/decode) |
 | GraphQL 요청 생성 | ✅ 가능 | graphql (document builder / variables JSON body) |
+| 이메일/MIME 생성 | ✅ 가능 | email (address / MIME multipart / SMTP DATA helpers) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
@@ -118,7 +120,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 없는 모듈 | 영향 | 우선순위 |
 |---|---|---|
 | db / sql | DB 작업 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
-| email / smtp | 메일 발송 | 중간 |
+| smtp transport | 실제 SMTP 소켓 전송 / TLS | 중간 |
 | tar / zip | 아카이브 (compress 는 gzip 만) | 낮음 |
 | image | 이미지 디코딩 | 낮음 |
 
@@ -139,7 +141,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 20 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, result, option, csv, xml, encoding, websocket, graphql, template, i18n, char, iter, bytes)
+- 21 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, result, option, csv, xml, encoding, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -208,7 +210,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db / email / archive / image) — *없는 모듈* 카테고리 채우기
+1. **새 모듈 추가** (db / smtp transport / archive / image) — *없는 모듈* 카테고리 채우기
 2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_email_check_test.go
+++ b/internal/backend/stdlib_email_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultEmail(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "email")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(email) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("email module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/email_test.go
+++ b/internal/stdlib/email_test.go
@@ -1,0 +1,60 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestEmailModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["email"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.email not loaded")
+	}
+	for _, name := range []string{"address", "namedAddress", "parseAddress", "formatAddress", "attachment", "message", "withCc", "withBcc", "withHtml", "withHeader", "withAttachment", "recipients", "render", "envelope", "smtpData", "smtpCommands", "isEmail"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.email missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.email.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.email.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Address", "Attachment", "Message", "Envelope"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.email missing type %q", name)
+		}
+		if sym.Kind != resolve.SymStruct {
+			t.Fatalf("std.email.%s kind = %s, want struct", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.email.%s not public", name)
+		}
+	}
+}
+
+func TestEmailModuleSourcePinsMimeBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["email"]
+	if mod == nil {
+		t.Fatal("std.email module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn render(msg: Message) -> Result<String, Error>`,
+		`Content-Type: multipart/mixed; boundary=`,
+		`encoding.base64.encode(part.data)`,
+		`pub fn smtpCommands(hostname: String, env: Envelope) -> List<String>`,
+		`fn dotStuff(value: String) -> String`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.email source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/email.osty
+++ b/internal/stdlib/modules/email.osty
@@ -1,0 +1,461 @@
+// std.email - RFC-style address, MIME message, and SMTP data helpers.
+
+use std.bytes
+use std.encoding
+use std.error
+use std.strings
+
+pub struct Address {
+    pub name: String,
+    pub email: String,
+}
+
+pub struct Attachment {
+    pub filename: String,
+    pub contentType: String,
+    pub data: Bytes,
+}
+
+pub struct Message {
+    pub from: Address,
+    pub to: List<Address>,
+    pub cc: List<Address>,
+    pub bcc: List<Address>,
+    pub subject: String,
+    pub text: String,
+    pub html: String,
+    pub headers: Map<String, String>,
+    pub attachments: List<Attachment>,
+}
+
+pub struct Envelope {
+    pub from: String,
+    pub recipients: List<String>,
+    pub data: String,
+}
+
+pub fn address(email: String) -> Result<Address, Error> {
+    namedAddress("", email)
+}
+
+pub fn namedAddress(name: String, email: String) -> Result<Address, Error> {
+    let clean = strings.trimSpace(email)
+    if !isEmail(clean) {
+        return Err(error.new("email: invalid address: {email}"))
+    }
+    Ok(Address {
+        name: sanitizeHeader(name),
+        email: clean,
+    })
+}
+
+pub fn parseAddress(raw: String) -> Result<Address, Error> {
+    let text = strings.trimSpace(raw)
+    match strings.indexOf(text, "<") {
+        Some(open) -> {
+            match strings.indexOf(text, ">") {
+                Some(close) -> {
+                    if close <= open {
+                        return Err(error.new("email: invalid address: {raw}"))
+                    }
+                    let name = strings.trimSpace(strings.slice(text, 0, open))
+                    let email = strings.trimSpace(strings.slice(text, open + 1, close))
+                    namedAddress(unquoteDisplayName(name), email)
+                },
+                None -> Err(error.new("email: invalid address: {raw}")),
+            }
+        },
+        None -> address(text),
+    }
+}
+
+pub fn formatAddress(addr: Address) -> String {
+    if addr.name.isEmpty() {
+        return addr.email
+    }
+    "{quoteDisplayName(addr.name)} <{addr.email}>"
+}
+
+pub fn attachment(filename: String, contentType: String, data: Bytes) -> Result<Attachment, Error> {
+    let cleanName = sanitizeHeader(filename)
+    if cleanName.isEmpty() {
+        return Err(error.new("email: attachment filename is empty"))
+    }
+    Ok(Attachment {
+        filename: cleanName,
+        contentType: sanitizeContentType(contentType),
+        data: data,
+    })
+}
+
+pub fn message(from: Address, to: List<Address>, subject: String, text: String) -> Message {
+    Message {
+        from: from,
+        to: to,
+        cc: [],
+        bcc: [],
+        subject: sanitizeHeader(subject),
+        text: text,
+        html: "",
+        headers: {:},
+        attachments: [],
+    }
+}
+
+pub fn withCc(msg: Message, addr: Address) -> Message {
+    let mut cc = msg.cc
+    cc.push(addr)
+    Message {
+        from: msg.from,
+        to: msg.to,
+        cc: cc,
+        bcc: msg.bcc,
+        subject: msg.subject,
+        text: msg.text,
+        html: msg.html,
+        headers: msg.headers,
+        attachments: msg.attachments,
+    }
+}
+
+pub fn withBcc(msg: Message, addr: Address) -> Message {
+    let mut bcc = msg.bcc
+    bcc.push(addr)
+    Message {
+        from: msg.from,
+        to: msg.to,
+        cc: msg.cc,
+        bcc: bcc,
+        subject: msg.subject,
+        text: msg.text,
+        html: msg.html,
+        headers: msg.headers,
+        attachments: msg.attachments,
+    }
+}
+
+pub fn withHtml(msg: Message, html: String) -> Message {
+    Message {
+        from: msg.from,
+        to: msg.to,
+        cc: msg.cc,
+        bcc: msg.bcc,
+        subject: msg.subject,
+        text: msg.text,
+        html: html,
+        headers: msg.headers,
+        attachments: msg.attachments,
+    }
+}
+
+pub fn withHeader(msg: Message, name: String, value: String) -> Result<Message, Error> {
+    if !isHeaderName(name) {
+        return Err(error.new("email: invalid header name: {name}"))
+    }
+    let mut headers = msg.headers
+    headers.insert(name, sanitizeHeader(value))
+    Ok(Message {
+        from: msg.from,
+        to: msg.to,
+        cc: msg.cc,
+        bcc: msg.bcc,
+        subject: msg.subject,
+        text: msg.text,
+        html: msg.html,
+        headers: headers,
+        attachments: msg.attachments,
+    })
+}
+
+pub fn withAttachment(msg: Message, part: Attachment) -> Message {
+    let mut attachments = msg.attachments
+    attachments.push(part)
+    Message {
+        from: msg.from,
+        to: msg.to,
+        cc: msg.cc,
+        bcc: msg.bcc,
+        subject: msg.subject,
+        text: msg.text,
+        html: msg.html,
+        headers: msg.headers,
+        attachments: attachments,
+    }
+}
+
+pub fn recipients(msg: Message) -> List<String> {
+    let mut out: List<String> = []
+    for addr in msg.to {
+        out.push(addr.email)
+    }
+    for addr in msg.cc {
+        out.push(addr.email)
+    }
+    for addr in msg.bcc {
+        out.push(addr.email)
+    }
+    out
+}
+
+pub fn render(msg: Message) -> Result<String, Error> {
+    if msg.to.isEmpty() && msg.cc.isEmpty() && msg.bcc.isEmpty() {
+        return Err(error.new("email: message has no recipients"))
+    }
+    let mut out = renderHeaders(msg)?
+    let mixedBoundary = boundary("mixed", msg.subject)
+    let altBoundary = boundary("alt", msg.subject)
+
+    if !msg.attachments.isEmpty() {
+        out = "{out}Content-Type: multipart/mixed; boundary=\"{mixedBoundary}\"{crlf()}{crlf()}"
+        out = "{out}--{mixedBoundary}{crlf()}"
+        if msg.html.isEmpty() {
+            out = "{out}{renderTextPart(msg.text)}"
+        } else {
+            out = "{out}Content-Type: multipart/alternative; boundary=\"{altBoundary}\"{crlf()}{crlf()}"
+            out = "{out}{renderAlternative(msg.text, msg.html, altBoundary)}"
+        }
+        for part in msg.attachments {
+            out = "{out}--{mixedBoundary}{crlf()}{renderAttachment(part)}"
+        }
+        return Ok("{out}--{mixedBoundary}--{crlf()}")
+    }
+
+    if !msg.html.isEmpty() {
+        out = "{out}Content-Type: multipart/alternative; boundary=\"{altBoundary}\"{crlf()}{crlf()}"
+        return Ok("{out}{renderAlternative(msg.text, msg.html, altBoundary)}")
+    }
+
+    Ok("{out}{renderTextPart(msg.text)}")
+}
+
+pub fn envelope(msg: Message) -> Result<Envelope, Error> {
+    Ok(Envelope {
+        from: msg.from.email,
+        recipients: recipients(msg),
+        data: smtpData(msg)?,
+    })
+}
+
+pub fn smtpData(msg: Message) -> Result<String, Error> {
+    let rendered = render(msg)?
+    Ok("{dotStuff(rendered)}{crlf()}.{crlf()}")
+}
+
+pub fn smtpCommands(hostname: String, env: Envelope) -> List<String> {
+    let mut out: List<String> = []
+    out.push("EHLO {sanitizeHeader(hostname)}")
+    out.push("MAIL FROM:<{env.from}>")
+    for rcpt in env.recipients {
+        out.push("RCPT TO:<{rcpt}>")
+    }
+    out.push("DATA")
+    out.push(env.data)
+    out.push("QUIT")
+    out
+}
+
+pub fn isEmail(email: String) -> Bool {
+    let text = strings.trimSpace(email)
+    match strings.indexOf(text, "@") {
+        Some(at) -> {
+            if at <= 0 || at >= text.len() - 1 {
+                return false
+            }
+            let local = strings.slice(text, 0, at)
+            let domain = strings.slice(text, at + 1, text.len())
+            !hasSpace(local) && isDomain(domain)
+        },
+        None -> false,
+    }
+}
+
+fn renderHeaders(msg: Message) -> Result<String, Error> {
+    let mut out = ""
+    out = "{out}From: {formatAddress(msg.from)}{crlf()}"
+    if !msg.to.isEmpty() {
+        out = "{out}To: {formatAddressList(msg.to)}{crlf()}"
+    }
+    if !msg.cc.isEmpty() {
+        out = "{out}Cc: {formatAddressList(msg.cc)}{crlf()}"
+    }
+    out = "{out}Subject: {sanitizeHeader(msg.subject)}{crlf()}"
+    out = "{out}MIME-Version: 1.0{crlf()}"
+    let keys = msg.headers.keys().sorted()
+    for key in keys {
+        if !isHeaderName(key) {
+            return Err(error.new("email: invalid header name: {key}"))
+        }
+        out = "{out}{key}: {sanitizeHeader(msg.headers.get(key).unwrap())}{crlf()}"
+    }
+    Ok(out)
+}
+
+fn renderTextPart(text: String) -> String {
+    "Content-Type: text/plain; charset=utf-8{crlf()}Content-Transfer-Encoding: 8bit{crlf()}{crlf()}{normalizeBody(text)}{crlf()}"
+}
+
+fn renderHtmlPart(html: String) -> String {
+    "Content-Type: text/html; charset=utf-8{crlf()}Content-Transfer-Encoding: 8bit{crlf()}{crlf()}{normalizeBody(html)}{crlf()}"
+}
+
+fn renderAlternative(text: String, html: String, boundary: String) -> String {
+    let mut out = ""
+    out = "{out}--{boundary}{crlf()}{renderTextPart(text)}"
+    out = "{out}--{boundary}{crlf()}{renderHtmlPart(html)}"
+    "{out}--{boundary}--{crlf()}"
+}
+
+fn renderAttachment(part: Attachment) -> String {
+    let encoded = wrapBase64(encoding.base64.encode(part.data))
+    "Content-Type: {part.contentType}; name=\"{part.filename}\"{crlf()}Content-Disposition: attachment; filename=\"{part.filename}\"{crlf()}Content-Transfer-Encoding: base64{crlf()}{crlf()}{encoded}{crlf()}"
+}
+
+fn formatAddressList(addrs: List<Address>) -> String {
+    let mut parts: List<String> = []
+    for addr in addrs {
+        parts.push(formatAddress(addr))
+    }
+    strings.join(parts, ", ")
+}
+
+fn quoteDisplayName(name: String) -> String {
+    let clean = sanitizeHeader(name)
+    let quote = '"'
+    if clean.isEmpty() {
+        return ""
+    }
+    if displayNameNeedsQuotes(clean) {
+        return "{quote}{strings.replaceAll(clean, \"\\\"\", \"\\\\\\\"\")}{quote}"
+    }
+    clean
+}
+
+fn unquoteDisplayName(name: String) -> String {
+    let text = strings.trimSpace(name)
+    if text.len() >= 2 && text[0] == '"' && text[text.len() - 1] == '"' {
+        return strings.slice(text, 1, text.len() - 1)
+    }
+    text
+}
+
+fn sanitizeHeader(value: String) -> String {
+    strings.replaceAll(strings.replaceAll(value, "\r", " "), "\n", " ")
+}
+
+fn sanitizeContentType(value: String) -> String {
+    let clean = sanitizeHeader(strings.trimSpace(value))
+    if clean.isEmpty() {
+        return "application/octet-stream"
+    }
+    clean
+}
+
+fn normalizeBody(value: String) -> String {
+    strings.replaceAll(strings.replaceAll(value, "\r\n", "\n"), "\n", crlf())
+}
+
+fn dotStuff(value: String) -> String {
+    let normalized = normalizeBody(value)
+    let lines = strings.split(normalized, crlf())
+    let mut out: List<String> = []
+    for line in lines {
+        if strings.startsWith(line, ".") {
+            out.push(".{line}")
+        } else {
+            out.push(line)
+        }
+    }
+    strings.join(out, crlf())
+}
+
+fn wrapBase64(value: String) -> String {
+    let mut lines: List<String> = []
+    let mut i = 0
+    for i < value.len() {
+        let end = minInt(i + 76, value.len())
+        lines.push(strings.slice(value, i, end))
+        i = end
+    }
+    strings.join(lines, crlf())
+}
+
+fn boundary(prefix: String, seed: String) -> String {
+    "osty-{prefix}-{seed.len()}-{sanitizeBoundarySeed(seed)}"
+}
+
+fn sanitizeBoundarySeed(seed: String) -> String {
+    let mut out = ""
+    for c in seed.chars() {
+        if isBoundaryChar(c) {
+            out = "{out}{c}"
+        }
+    }
+    if out.isEmpty() {
+        return "message"
+    }
+    strings.slice(out, 0, minInt(out.len(), 24))
+}
+
+fn isHeaderName(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    for c in name.chars() {
+        if !isHeaderNameChar(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn isDomain(domain: String) -> Bool {
+    if domain.isEmpty() || !strings.contains(domain, ".") {
+        return false
+    }
+    for c in domain.chars() {
+        if !(isAlphaNum(c) || c == '-' || c == '.') {
+            return false
+        }
+    }
+    true
+}
+
+fn hasSpace(text: String) -> Bool {
+    for c in text.chars() {
+        if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+            return true
+        }
+    }
+    false
+}
+
+fn displayNameNeedsQuotes(text: String) -> Bool {
+    for c in text.chars() {
+        if c == ',' || c == ';' || c == '<' || c == '>' || c == '@' || c == '"' {
+            return true
+        }
+    }
+    false
+}
+
+fn isHeaderNameChar(c: Char) -> Bool {
+    isAlphaNum(c) || c == '-'
+}
+
+fn isBoundaryChar(c: Char) -> Bool {
+    isAlphaNum(c) || c == '-' || c == '_'
+}
+
+fn isAlphaNum(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= 'a' && c <= 'z') ||
+    (c >= '0' && c <= '9')
+}
+
+fn minInt(a: Int, b: Int) -> Int {
+    if a < b { a } else { b }
+}
+
+fn crlf() -> String {
+    "\r\n"
+}


### PR DESCRIPTION
## Summary
- Add `std.email` with address parsing/formatting, message composition, MIME multipart rendering, attachment base64 encoding, and SMTP DATA helper utilities.
- Update `STDLIB_MATRIX.md` so email/MIME moves out of the missing-module bucket while SMTP transport remains listed separately.

## Validation
- go test -count=1 -vet=off ./internal/stdlib
- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultEmail'
- just fmt-check
- git diff --check