### PR TITLE
cst: add native green parser

### DIFF
--- a/internal/cst/build.go
+++ b/internal/cst/build.go
@@ -15,16 +15,30 @@ type EntitySpan struct {
 	Kind  GreenKind
 }
 
-// BuildFromEntitySpans lifts top-level syntax spans plus a token stream into a
-// Green tree wrapped in a Red Tree. The resulting tree carries:
+// SyntaxSpan is the nested form of EntitySpan. It describes one source-backed
+// syntax envelope and any already-known child envelopes. Start and End are
+// byte offsets in the normalized source; End is exclusive.
 //
-//  1. Structural Green nodes for the file and every top-level entity
-//     (GkFile, GkFnDecl, GkStructDecl, …). Nested declarations inside
-//     struct/enum bodies are NOT yet broken out — that is a follow-up phase.
-//  2. Flat token runs inside each top-level entity: expressions and
-//     statements are not yet structured. The public Red API does not depend
-//     on that structuring, so consumers can migrate when the native Green
-//     parser (blocked on the self-host generator) lands.
+// This is the compatibility bridge between the current semantic parser arena
+// and the long-term parser-owned Green event stream. Once the parser emits
+// StartNode/Token/FinishNode events directly, callers can bypass SyntaxSpan
+// and feed GreenBuilder without changing Red consumers.
+type SyntaxSpan struct {
+	Start    int
+	End      int
+	Kind     GreenKind
+	Children []SyntaxSpan
+}
+
+// BuildFromEntitySpans lifts flat top-level syntax spans plus a token stream
+// into a Green tree wrapped in a Red Tree. It is kept for older adapter
+// callers; new parser-facing code should prefer BuildFromSyntaxSpans.
+//
+// The resulting tree carries:
+//
+//  1. Structural Green nodes for the file and every supplied entity.
+//  2. Flat token runs inside each entity. Use BuildFromSyntaxSpans when nested
+//     expression/statement/type structure is available.
 //  3. Trivia attached as leading and trailing runs on tokens. Runs between
 //     tokens split at the first newline or doc comment — see
 //     pairTriviaToTokens for the exact rule. Tail trivia after the last
@@ -33,10 +47,20 @@ type EntitySpan struct {
 // Byte coverage: every source byte is reachable from the tree via either a
 // token's text or a trivia record. TestBuildRoundTrip enforces this.
 //
-// This builder is the adapter path while toolchain/lossless_lex.osty and a
-// native Green parser remain blocked on the self-host generator. A native
-// parser can replace this call without changing Red consumers.
+// A native parser can replace this adapter call without changing Red consumers.
 func BuildFromEntitySpans(src []byte, entities []EntitySpan, toks []token.Token, trivias []Trivia) *Tree {
+	spans := make([]SyntaxSpan, 0, len(entities))
+	for _, ent := range entities {
+		spans = append(spans, SyntaxSpan{Start: ent.Start, End: ent.End, Kind: ent.Kind})
+	}
+	return BuildFromSyntaxSpans(src, spans, toks, trivias)
+}
+
+// BuildFromSyntaxSpans lifts a nested syntax span tree plus a token stream into
+// a Green tree wrapped in a Red Tree. It preserves the same byte-coverage and
+// trivia-attachment contract as BuildFromEntitySpans, but keeps child syntax
+// nodes nested instead of flattening every top-level entity into raw tokens.
+func BuildFromSyntaxSpans(src []byte, spans []SyntaxSpan, toks []token.Token, trivias []Trivia) *Tree {
 	b := NewBuilder(nil)
 	arena := b.Arena()
 
@@ -45,31 +69,19 @@ func BuildFromEntitySpans(src []byte, entities []EntitySpan, toks []token.Token,
 		triviaIDs[i] = arena.AddTrivia(tr)
 	}
 	leading, trailing, tailTrivia := pairTriviaToTokens(toks, trivias)
-	entities = append([]EntitySpan(nil), entities...)
-	sort.SliceStable(entities, func(i, j int) bool {
-		if entities[i].Start == entities[j].Start {
-			return entities[i].End < entities[j].End
-		}
-		return entities[i].Start < entities[j].Start
-	})
+	spans = sanitizeSyntaxChildren(spans, 0, len(src))
 
 	b.StartNode(GkFile)
 	tokIdx := 0
-	for _, ent := range entities {
-		startOff := ent.Start
-		endOff := ent.End
+	for _, span := range spans {
+		startOff := span.Start
 
-		// Orphan tokens before the entity attach to the file root.
+		// Orphan tokens before the syntax node attach to the file root.
 		for tokIdx < len(toks) && !isEOF(toks[tokIdx]) && toks[tokIdx].Pos.Offset < startOff {
 			emitToken(b, toks[tokIdx], src, leading[tokIdx], trailing[tokIdx], triviaIDs)
 			tokIdx++
 		}
-		b.StartNode(ent.Kind)
-		for tokIdx < len(toks) && !isEOF(toks[tokIdx]) && toks[tokIdx].Pos.Offset < endOff {
-			emitToken(b, toks[tokIdx], src, leading[tokIdx], trailing[tokIdx], triviaIDs)
-			tokIdx++
-		}
-		b.FinishNode()
+		emitSyntaxSpan(b, span, toks, src, leading, trailing, triviaIDs, &tokIdx)
 	}
 	for tokIdx < len(toks) {
 		tk := toks[tokIdx]
@@ -91,6 +103,70 @@ func BuildFromEntitySpans(src []byte, entities []EntitySpan, toks []token.Token,
 	b.FinishNode() // GkFile
 	_, root := b.Finish()
 	return NewTreeFromSource(arena, root, src)
+}
+
+func emitSyntaxSpan(
+	b *GreenBuilder,
+	span SyntaxSpan,
+	toks []token.Token,
+	src []byte,
+	leading, trailing [][]int,
+	triviaIDs []int,
+	tokIdx *int,
+) {
+	b.StartNode(span.Kind)
+	children := sanitizeSyntaxChildren(span.Children, span.Start, span.End)
+	for _, child := range children {
+		for *tokIdx < len(toks) && !isEOF(toks[*tokIdx]) && toks[*tokIdx].Pos.Offset < child.Start {
+			emitToken(b, toks[*tokIdx], src, leading[*tokIdx], trailing[*tokIdx], triviaIDs)
+			*tokIdx = *tokIdx + 1
+		}
+		emitSyntaxSpan(b, child, toks, src, leading, trailing, triviaIDs, tokIdx)
+	}
+	for *tokIdx < len(toks) && !isEOF(toks[*tokIdx]) && toks[*tokIdx].Pos.Offset < span.End {
+		emitToken(b, toks[*tokIdx], src, leading[*tokIdx], trailing[*tokIdx], triviaIDs)
+		*tokIdx = *tokIdx + 1
+	}
+	b.FinishNode()
+}
+
+func sanitizeSyntaxChildren(children []SyntaxSpan, parentStart, parentEnd int) []SyntaxSpan {
+	if parentEnd < parentStart {
+		parentEnd = parentStart
+	}
+	out := make([]SyntaxSpan, 0, len(children))
+	for _, child := range children {
+		if child.Kind == GkNone {
+			continue
+		}
+		if child.Start < parentStart || child.End > parentEnd || child.End < child.Start {
+			continue
+		}
+		copied := child
+		copied.Children = sanitizeSyntaxChildren(child.Children, child.Start, child.End)
+		out = append(out, copied)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Start == out[j].Start {
+			return out[i].End > out[j].End
+		}
+		return out[i].Start < out[j].Start
+	})
+
+	// Keep direct children non-overlapping. Nested structure belongs inside
+	// the containing child; overlapping siblings make Red offsets ambiguous.
+	filtered := out[:0]
+	cursor := parentStart
+	for _, child := range out {
+		if child.Start < cursor {
+			continue
+		}
+		filtered = append(filtered, child)
+		if child.End > cursor {
+			cursor = child.End
+		}
+	}
+	return filtered
 }
 
 func isEOF(tk token.Token) bool { return tk.Kind == token.EOF }

--- a/internal/cst/build_test.go
+++ b/internal/cst/build_test.go
@@ -1,0 +1,491 @@
+package cst_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/cst"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestBuildRoundTripCorpus is the CST round-trip: the Green tree produced
+// by ParseCST, when walked and concatenated, reconstructs the
+// normalized source byte-for-byte for every corpus file.
+func TestBuildRoundTripCorpus(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for _, rel := range corpus {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("corpus missing: %v", err)
+				return
+			}
+			src := cst.Normalize(raw)
+			tree, _ := selfhost.ParseCST(src)
+			if tree == nil {
+				t.Skip("parser returned nil CST")
+				return
+			}
+			got := emitTreeBytes(tree)
+			if string(got) != string(src) {
+				diff := firstDiff(src, got)
+				t.Fatalf("%s: round-trip mismatch at byte %d\nwant: %q\n got: %q",
+					rel, diff, preview(src, diff), preview(got, diff))
+			}
+		})
+	}
+}
+
+// TestBuildTopLevelStructuring checks that entities get wrapped in their
+// intended Green kind.
+func TestBuildTopLevelStructuring(t *testing.T) {
+	const source = `pub fn main() {
+    let x = 1
+}
+`
+	src := cst.Normalize([]byte(source))
+	tree, _ := selfhost.ParseCST(src)
+
+	var found bool
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.Kind() == cst.GkFnDecl {
+			found = true
+			text := string(src[r.Offset():r.End()])
+			if !strings.Contains(text, "fn main") {
+				t.Errorf("GkFnDecl text range does not cover 'fn main': %q", text)
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("no GkFnDecl node found in tree for `pub fn main() {...}`")
+	}
+}
+
+// TestBuildNestedNativeStructuring checks that ParseCST preserves nested
+// native syntax nodes instead of stopping at top-level declaration wrappers.
+func TestBuildNestedNativeStructuring(t *testing.T) {
+	const source = `fn main() {
+    let x = add(1, 2)
+    return x
+}
+`
+	tree := buildTreeFromSource(t, source)
+
+	var fn cst.Red
+	var foundFn bool
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.Kind() == cst.GkFnDecl {
+			fn = r
+			foundFn = true
+			return false
+		}
+		return true
+	})
+	if !foundFn {
+		t.Fatal("no GkFnDecl node found")
+	}
+
+	for _, kind := range []cst.GreenKind{cst.GkBlock, cst.GkLetStmt, cst.GkCall, cst.GkReturnStmt} {
+		if got := countKindBelow(fn, kind); got == 0 {
+			t.Fatalf("GkFnDecl subtree has no %v node", kind)
+		}
+	}
+}
+
+func TestBuildNestedContextualKinds(t *testing.T) {
+	const source = `#[run(mode = "fast")]
+let top = Point { x: 1, y: 2 }
+`
+	tree := buildTreeFromSource(t, source)
+
+	for _, kind := range []cst.GreenKind{
+		cst.GkAnnotation,
+		cst.GkAnnotationArg,
+		cst.GkLetDecl,
+		cst.GkStructLit,
+		cst.GkStructLitField,
+	} {
+		if got := countKindBelow(tree.Root(), kind); got == 0 {
+			t.Fatalf("tree has no %v node", kind)
+		}
+	}
+}
+
+func TestParseGreenNestedGenericShiftTokens(t *testing.T) {
+	const source = `struct Demo {
+    nested: List<List<Int>>,
+    map: Map<String, List<User>>,
+}
+struct User {}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkGenericParamList); got < 3 {
+		t.Fatalf("nested generic type args produced %d GenericParamList nodes, want at least 3", got)
+	}
+}
+
+func TestParseGreenControlHeadersDoNotLeakStrayBraces(t *testing.T) {
+	const source = `fn f(xs: List<Int>) -> Int {
+    let mut total = 0
+    for x in xs {
+        if x > 0 { total = total + x }
+    }
+    let picked = 'outer: loop {
+        break 'outer total
+    }
+    picked
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+}
+
+// TestBuildUseDeclStructuring verifies use-decls get their own structured
+// node.
+func TestBuildUseDeclStructuring(t *testing.T) {
+	const source = `use std.io as io
+use std.strings as strings
+
+pub fn main() {}
+`
+	src := cst.Normalize([]byte(source))
+	tree, _ := selfhost.ParseCST(src)
+
+	useCount := 0
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.Kind() == cst.GkUseDecl {
+			useCount++
+		}
+		return true
+	})
+	if useCount != 2 {
+		t.Fatalf("expected 2 GkUseDecl nodes, found %d", useCount)
+	}
+}
+
+func TestBuildGroupedUseDeclsHaveDistinctRanges(t *testing.T) {
+	const source = `use std::{fs, io as io}
+`
+	tree := buildTreeFromSource(t, source)
+
+	var ranges [][2]int
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.Kind() == cst.GkUseDecl {
+			lo, hi := r.TextRange()
+			ranges = append(ranges, [2]int{lo, hi})
+		}
+		return true
+	})
+	if len(ranges) != 2 {
+		t.Fatalf("grouped use produced %d GkUseDecl nodes, want 2", len(ranges))
+	}
+	if ranges[0][0] == ranges[1][0] && ranges[0][1] == ranges[1][1] {
+		t.Fatalf("grouped use child ranges should be distinct, got %v", ranges)
+	}
+	for _, r := range ranges {
+		if r[1] <= r[0] {
+			t.Fatalf("grouped use child range must be positive-width, got %v", ranges)
+		}
+	}
+}
+
+// TestBuildLeadingTriviaAttachment sanity-checks that a leading comment is
+// attached to the next real token, not dropped.
+func TestBuildLeadingTriviaAttachment(t *testing.T) {
+	const source = `// top comment
+pub fn main() {}
+`
+	src := cst.Normalize([]byte(source))
+	tree, _ := selfhost.ParseCST(src)
+
+	first, ok := tree.Root().FirstToken()
+	if !ok {
+		t.Fatal("expected at least one real token")
+	}
+	tok := first.Token()
+	sawComment := false
+	for _, triID := range tok.LeadingTrivia {
+		if tree.Arena.TriviaAt(triID).Kind == cst.TriviaLineComment {
+			sawComment = true
+			break
+		}
+	}
+	if !sawComment {
+		t.Fatal("first token's leading trivia has no TriviaLineComment")
+	}
+}
+
+// TestBuildTrailingCommentInline checks that a same-line comment after a
+// real (non-NEWLINE) token ends up as trailing trivia on that token. This is
+// the central case the split policy exists to enable; pre-policy, the
+// comment was buried in the next line's leading.
+func TestBuildTrailingCommentInline(t *testing.T) {
+	const source = `let x = 1 // hi
+let y = 2
+`
+	tree := buildTreeFromSource(t, source)
+	tokens := collectRealTokens(tree)
+
+	oneTok, ok := findTokenByText(tokens, "1")
+	if !ok {
+		t.Fatal("expected a `1` token in the tree")
+	}
+	letIdx := findNthTokenByText(tokens, "let", 2)
+	if letIdx < 0 {
+		t.Fatal("expected a second `let` token in the tree")
+	}
+	secondLet := tokens[letIdx]
+
+	gotTexts := triviaTexts(tree, oneTok.TrailingTrivia)
+	gotKinds := triviaKinds(tree, oneTok.TrailingTrivia)
+	if !containsKind(gotKinds, cst.TriviaLineComment) {
+		t.Errorf("`1` trailing should contain the line comment; got kinds=%v texts=%q", gotKinds, gotTexts)
+	}
+
+	secondLeadKinds := triviaKinds(tree, secondLet.LeadingTrivia)
+	if containsKind(secondLeadKinds, cst.TriviaLineComment) {
+		t.Errorf("second `let` leading must not carry the inline comment; got kinds=%v", secondLeadKinds)
+	}
+}
+
+// TestBuildTrailingNewlineTokenCarriesNoTrailing verifies the NEWLINE-token
+// rule: trivia that sits after a NEWLINE token never becomes its trailing;
+// it flows to the next token's leading. This keeps "the line that just
+// ended" (the NEWLINE text alone) cleanly separated from "what's on the
+// next line" (trivia in the following token's leading).
+func TestBuildTrailingNewlineTokenCarriesNoTrailing(t *testing.T) {
+	const source = `fn a() {}
+
+fn b() {}
+`
+	tree := buildTreeFromSource(t, source)
+
+	// Blank-line extra newline must land on the second fn's leading, never
+	// on the NEWLINE token's trailing.
+	var sawBlankLineOnFn bool
+	var newlineTokensTrailed int
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
+			return true
+		}
+		tok := r.Token()
+		if tok.Text == "\n" {
+			if len(tok.TrailingTrivia) > 0 {
+				newlineTokensTrailed++
+			}
+		}
+		if tok.Text == "fn" && r.Offset() > 0 {
+			if containsKind(triviaKinds(tree, tok.LeadingTrivia), cst.TriviaNewline) {
+				sawBlankLineOnFn = true
+			}
+		}
+		return true
+	})
+
+	if newlineTokensTrailed != 0 {
+		t.Errorf("NEWLINE tokens must not carry trailing trivia; %d did", newlineTokensTrailed)
+	}
+	if !sawBlankLineOnFn {
+		t.Error("second `fn` leading should carry the blank-line TriviaNewline")
+	}
+}
+
+// TestBuildDocCommentAttachesToNext verifies the doc-comment carveout: `///`
+// always stays with the following declaration, even if the previous real
+// token would otherwise accumulate trailing trivia.
+func TestBuildDocCommentAttachesToNext(t *testing.T) {
+	const source = `let x = 1
+/// doc
+fn f() {}
+`
+	tree := buildTreeFromSource(t, source)
+	tokens := collectRealTokens(tree)
+
+	fnIdx := findNthTokenByText(tokens, "fn", 1)
+	if fnIdx < 0 {
+		t.Fatal("expected an `fn` token")
+	}
+	fnTok := tokens[fnIdx]
+
+	fnLeadKinds := triviaKinds(tree, fnTok.LeadingTrivia)
+	if !containsKind(fnLeadKinds, cst.TriviaDocComment) {
+		t.Errorf("`fn` leading should own the doc comment; got kinds=%v", fnLeadKinds)
+	}
+
+	// No real token's trailing should swallow the doc comment.
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
+			return true
+		}
+		tok := r.Token()
+		if containsKind(triviaKinds(tree, tok.TrailingTrivia), cst.TriviaDocComment) {
+			t.Errorf("token %q trailing contains doc comment; doc must always lead the next decl", tok.Text)
+		}
+		return true
+	})
+}
+
+// TestBuildTailTriviaAfterNewline verifies that trivia following a trailing
+// NEWLINE token becomes file-tail trivia (under the GkErrorMissing sentinel
+// for now) rather than being attached as trailing of the NEWLINE. Round-trip
+// must still reproduce the source byte-for-byte.
+func TestBuildTailTriviaAfterNewline(t *testing.T) {
+	const source = "fn f() {}\n// tail\n"
+	tree := buildTreeFromSource(t, source)
+
+	var newlineTrailedLineComment bool
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
+			return true
+		}
+		tok := r.Token()
+		if tok.Text == "\n" && containsKind(triviaKinds(tree, tok.TrailingTrivia), cst.TriviaLineComment) {
+			newlineTrailedLineComment = true
+		}
+		return true
+	})
+	if newlineTrailedLineComment {
+		t.Error("NEWLINE token must not carry a trailing line-comment; it belongs to file tail")
+	}
+
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+}
+
+// --- test helpers ---
+
+func buildTreeFromSource(t *testing.T, source string) *cst.Tree {
+	t.Helper()
+	tree, _ := selfhost.ParseCST([]byte(source))
+	if tree == nil {
+		t.Fatal("ParseCST returned nil tree")
+	}
+	return tree
+}
+
+func collectRealTokens(tree *cst.Tree) []cst.GreenToken {
+	var out []cst.GreenToken
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.IsToken() && r.Kind() == cst.GkToken {
+			out = append(out, r.Token())
+		}
+		return true
+	})
+	return out
+}
+
+func findTokenByText(tokens []cst.GreenToken, text string) (cst.GreenToken, bool) {
+	for _, tok := range tokens {
+		if tok.Text == text {
+			return tok, true
+		}
+	}
+	return cst.GreenToken{}, false
+}
+
+func findNthTokenByText(tokens []cst.GreenToken, text string, n int) int {
+	seen := 0
+	for i, tok := range tokens {
+		if tok.Text == text {
+			seen++
+			if seen == n {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func triviaTexts(tree *cst.Tree, ids []int) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		tri := tree.Arena.TriviaAt(id)
+		lo, hi := tri.Offset, tri.Offset+tri.Length
+		if lo < 0 || hi > len(tree.Source) {
+			out = append(out, "<oob>")
+			continue
+		}
+		out = append(out, string(tree.Source[lo:hi]))
+	}
+	return out
+}
+
+func triviaKinds(tree *cst.Tree, ids []int) []cst.TriviaKind {
+	out := make([]cst.TriviaKind, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, tree.Arena.TriviaAt(id).Kind)
+	}
+	return out
+}
+
+func containsKind(kinds []cst.TriviaKind, target cst.TriviaKind) bool {
+	for _, k := range kinds {
+		if k == target {
+			return true
+		}
+	}
+	return false
+}
+
+func countKindBelow(root cst.Red, kind cst.GreenKind) int {
+	count := 0
+	root.Walk(func(r cst.Red) bool {
+		if r.Kind() == kind {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+// emitTreeBytes walks the tree in pre-order and concatenates, for each token
+// leaf: leading trivia + text + trailing trivia. Result must equal
+// tree.Source. Trailing trivia is the addition over the pre-split-policy
+// implementation; omitting it here would break round-trip as soon as any
+// token carries same-line trailing trivia.
+func emitTreeBytes(tree *cst.Tree) []byte {
+	src := tree.Source
+	out := make([]byte, 0, len(src))
+	emitRun := func(indices []int) {
+		for _, triID := range indices {
+			tri := tree.Arena.TriviaAt(triID)
+			lo, hi := tri.Offset, tri.Offset+tri.Length
+			if lo < 0 {
+				lo = 0
+			}
+			if hi > len(src) {
+				hi = len(src)
+			}
+			if lo < hi {
+				out = append(out, src[lo:hi]...)
+			}
+		}
+	}
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() {
+			return true
+		}
+		tok := r.Token()
+		emitRun(tok.LeadingTrivia)
+		out = append(out, tok.Text...)
+		emitRun(tok.TrailingTrivia)
+		return true
+	})
+	return out
+}

--- a/internal/cst/doc.go
+++ b/internal/cst/doc.go
@@ -2,12 +2,10 @@
 // front end. Unlike the abstract AST in internal/ast, the CST is lossless:
 // every source byte is reachable from either a token or a trivia run.
 //
-// Architecture decision: the lossless parser contract is Red/Green. The
-// current adapter still builds top-level structure from parser spans while the
-// selfhost generator cannot ingest a native lossless event stream, but
-// formatter/repair/LSP consumers should target Tree/Red/Green APIs rather than
-// an AstArena side table. The temporary adapter is therefore a compatibility
-// boundary, not the long-term CST architecture.
+// Architecture decision: the lossless parser contract is Red/Green. ParseCST
+// now uses the native token-stream Green parser, and formatter/repair/LSP
+// consumers should target Tree/Red/Green APIs rather than an AstArena side
+// table.
 //
 // Byte-coverage invariant: for any source src and tokens := selfhost.Lex(src),
 // Extract(src, tokens) returns []Trivia such that:

--- a/internal/cst/green_arena.go
+++ b/internal/cst/green_arena.go
@@ -98,6 +98,16 @@ type GreenBuilder struct {
 	root  int // node id of the final file root, -1 until Finish
 }
 
+// GreenCheckpoint marks a position in the current builder frame. StartNodeAt
+// can later wrap everything emitted since this checkpoint in a new node. This
+// is the key operation for Pratt parsers and other event-stream parsers that
+// discover a parent node after emitting its left edge.
+type GreenCheckpoint struct {
+	frame    int
+	children int
+	width    int
+}
+
 type builderFrame struct {
 	kind     GreenKind
 	children []GreenChild
@@ -117,11 +127,51 @@ func NewBuilder(arena *GreenArena) *GreenBuilder {
 // this after Finish() to traverse the tree.
 func (b *GreenBuilder) Arena() *GreenArena { return b.arena }
 
+// Checkpoint returns a marker for the current frame.
+func (b *GreenBuilder) Checkpoint() GreenCheckpoint {
+	if len(b.stack) == 0 {
+		panic("cst: GreenBuilder.Checkpoint called outside any StartNode frame")
+	}
+	top := b.stack[len(b.stack)-1]
+	return GreenCheckpoint{
+		frame:    len(b.stack) - 1,
+		children: len(top.children),
+		width:    top.width,
+	}
+}
+
 // StartNode opens a new interior node of the given kind. Every StartNode
 // must be matched by FinishNode; children added in between become this
 // node's children.
 func (b *GreenBuilder) StartNode(kind GreenKind) {
 	b.stack = append(b.stack, builderFrame{kind: kind})
+}
+
+// StartNodeAt opens a node that already contains every child emitted in the
+// current frame since checkpoint. This mirrors rowan's checkpoint/precede
+// pattern and lets parsers wrap a completed left-hand side once they see an
+// infix operator.
+func (b *GreenBuilder) StartNodeAt(kind GreenKind, checkpoint GreenCheckpoint) {
+	if len(b.stack) == 0 {
+		panic("cst: GreenBuilder.StartNodeAt called outside any StartNode frame")
+	}
+	frameIdx := len(b.stack) - 1
+	if checkpoint.frame != frameIdx {
+		panic("cst: GreenBuilder.StartNodeAt checkpoint belongs to a different frame")
+	}
+	top := &b.stack[frameIdx]
+	if checkpoint.children < 0 || checkpoint.children > len(top.children) || checkpoint.width < 0 || checkpoint.width > top.width {
+		panic("cst: GreenBuilder.StartNodeAt checkpoint is out of range")
+	}
+	wrappedChildren := append([]GreenChild(nil), top.children[checkpoint.children:]...)
+	wrappedWidth := top.width - checkpoint.width
+	top.children = top.children[:checkpoint.children]
+	top.width = checkpoint.width
+	b.stack = append(b.stack, builderFrame{
+		kind:     kind,
+		children: wrappedChildren,
+		width:    wrappedWidth,
+	})
 }
 
 // Token emits a terminal leaf. Leading/trailing slice are trivia indices

--- a/internal/cst/green_test.go
+++ b/internal/cst/green_test.go
@@ -1,0 +1,162 @@
+package cst
+
+import "testing"
+
+// TestGreenBuilderBasic verifies the minimal build cycle: StartNode → Token →
+// FinishNode produces a File node with one token child, correct width, and a
+// reachable arena root.
+func TestGreenBuilderBasic(t *testing.T) {
+	b := NewBuilder(nil)
+	b.StartNode(GkFile)
+	b.Token(GkToken, 0 /* token.IDENT placeholder */, "x", 1, nil, nil)
+	b.FinishNode()
+
+	arena, root := b.Finish()
+	if root < 0 {
+		t.Fatal("expected a valid root id, got -1")
+	}
+	if len(arena.Nodes) != 1 {
+		t.Fatalf("arena should have 1 node, got %d", len(arena.Nodes))
+	}
+	if len(arena.Tokens) != 1 {
+		t.Fatalf("arena should have 1 token, got %d", len(arena.Tokens))
+	}
+	n := arena.NodeAt(root)
+	if n.Kind != GkFile {
+		t.Errorf("root kind = %v, want GkFile", n.Kind)
+	}
+	if n.Width != 1 {
+		t.Errorf("root width = %d, want 1", n.Width)
+	}
+	if len(n.Children) != 1 || n.Children[0].Tag != GctToken {
+		t.Fatalf("expected single token child, got %+v", n.Children)
+	}
+	tok := arena.TokenAt(n.Children[0].ID)
+	if tok.Text != "x" {
+		t.Errorf("child token text = %q, want %q", tok.Text, "x")
+	}
+}
+
+// TestGreenBuilderNested checks multi-level construction and width
+// aggregation. A Block containing two ExprStmts each containing an Ident
+// should have width equal to the sum of all its descendants.
+func TestGreenBuilderNested(t *testing.T) {
+	b := NewBuilder(nil)
+	b.StartNode(GkBlock)
+	for _, name := range []string{"a", "bc"} {
+		b.StartNode(GkExprStmt)
+		b.Token(GkToken, 0, name, len(name), nil, nil)
+		b.FinishNode()
+	}
+	b.FinishNode()
+	arena, root := b.Finish()
+
+	want := 1 + 2 // len("a") + len("bc")
+	if got := arena.NodeAt(root).Width; got != want {
+		t.Errorf("block width = %d, want %d", got, want)
+	}
+	if n := len(arena.NodeAt(root).Children); n != 2 {
+		t.Fatalf("block should have 2 children, got %d", n)
+	}
+}
+
+func TestGreenBuilderStartNodeAtCheckpoint(t *testing.T) {
+	b := NewBuilder(nil)
+	b.StartNode(GkFile)
+	cp := b.Checkpoint()
+	b.Token(GkToken, 0, "a", 1, nil, nil)
+	b.StartNodeAt(GkBinary, cp)
+	b.Token(GkToken, 0, "+", 1, nil, nil)
+	b.Token(GkToken, 0, "b", 1, nil, nil)
+	b.FinishNode() // Binary
+	b.FinishNode() // File
+	arena, root := b.Finish()
+
+	file := arena.NodeAt(root)
+	if got := len(file.Children); got != 1 {
+		t.Fatalf("file children = %d, want 1", got)
+	}
+	if file.Children[0].Tag != GctNode {
+		t.Fatalf("file child should be a node, got %+v", file.Children[0])
+	}
+	binary := arena.NodeAt(file.Children[0].ID)
+	if binary.Kind != GkBinary {
+		t.Fatalf("wrapped node kind = %v, want Binary", binary.Kind)
+	}
+	if binary.Width != 3 {
+		t.Fatalf("binary width = %d, want 3", binary.Width)
+	}
+	if got := len(binary.Children); got != 3 {
+		t.Fatalf("binary children = %d, want 3", got)
+	}
+}
+
+// TestGreenDedupTokens verifies identical tokens dedupe to one id. Parsing a
+// source full of `,` punctuation is the common case where this matters.
+func TestGreenDedupTokens(t *testing.T) {
+	arena := NewArena()
+	id1 := arena.AddToken(GreenToken{Kind: GkToken, TokenKind: 42, Text: ",", Width: 1})
+	id2 := arena.AddToken(GreenToken{Kind: GkToken, TokenKind: 42, Text: ",", Width: 1})
+	id3 := arena.AddToken(GreenToken{Kind: GkToken, TokenKind: 42, Text: ",", Width: 1})
+	if id1 != id2 || id2 != id3 {
+		t.Fatalf("expected identical tokens to share id, got %d %d %d", id1, id2, id3)
+	}
+	if got := len(arena.Tokens); got != 1 {
+		t.Errorf("arena should hold 1 token, got %d", got)
+	}
+	if hits := arena.DedupHits(); hits != 2 {
+		t.Errorf("dedup hits = %d, want 2", hits)
+	}
+	if misses := arena.DedupMisses(); misses != 1 {
+		t.Errorf("dedup misses = %d, want 1", misses)
+	}
+}
+
+// TestGreenDedupTokensDistinguishedByTriviaIndices ensures tokens with
+// different attached trivia indices are NOT deduplicated, even if the text
+// matches. Leading / trailing trivia carry source-specific positions, so the
+// arena must keep them separate.
+func TestGreenDedupTokensDistinguishedByTriviaIndices(t *testing.T) {
+	arena := NewArena()
+	id1 := arena.AddToken(GreenToken{Kind: GkToken, Text: "x", Width: 1, LeadingTrivia: []int{0}})
+	id2 := arena.AddToken(GreenToken{Kind: GkToken, Text: "x", Width: 1, LeadingTrivia: []int{1}})
+	if id1 == id2 {
+		t.Fatalf("tokens with different leading trivia should have different ids; both got %d", id1)
+	}
+}
+
+// TestGreenDedupNodes verifies structural sharing: the same subtree built
+// twice shares one node id.
+func TestGreenDedupNodes(t *testing.T) {
+	arena := NewArena()
+	mk := func() int {
+		tid := arena.AddToken(GreenToken{Kind: GkToken, Text: "x", Width: 1})
+		return arena.AddNode(GreenNode{
+			Kind:     GkIdent,
+			Width:    1,
+			Children: []GreenChild{{Tag: GctToken, ID: tid}},
+		})
+	}
+	a := mk()
+	b := mk()
+	if a != b {
+		t.Fatalf("identical subtrees should share id, got %d vs %d", a, b)
+	}
+	if got := len(arena.Nodes); got != 1 {
+		t.Errorf("arena should hold 1 node, got %d", got)
+	}
+}
+
+// TestGreenKindNameCoverage catches forgotten-entry mistakes in
+// greenKindNames. Every iota in the const block above must have a label.
+func TestGreenKindNameCoverage(t *testing.T) {
+	// Iterate through the declared range. If a new kind is added without
+	// updating greenKindNames, its String() will fall back to GreenKind(N),
+	// which the eye catches in snapshot diffs; this test makes the failure
+	// explicit.
+	for k := GkNone; k <= GkErrorExtra; k++ {
+		if _, ok := greenKindNames[k]; !ok {
+			t.Errorf("greenKindNames missing label for kind %d (GreenKind(%d))", int(k), int(k))
+		}
+	}
+}

--- a/internal/cst/invariants_test.go
+++ b/internal/cst/invariants_test.go
@@ -1,0 +1,158 @@
+package cst_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/cst"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestInvariantsOffsetMonotonic asserts that within any interior node, child
+// offsets are monotonic (lo[i] <= lo[i+1]) and every child sits inside the
+// parent's [offset, end) range. Violations indicate a bug in width
+// aggregation or emission order.
+func TestInvariantsOffsetMonotonic(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for _, rel := range corpus {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("corpus missing: %v", err)
+				return
+			}
+			tree, _ := selfhost.ParseCST(raw)
+			if tree == nil {
+				t.Fatal("ParseCST returned nil tree")
+			}
+			if report := cst.ValidateTree(tree); !report.OK() {
+				t.Fatalf("%s: CST validation failed: %s", rel, report.Error())
+			}
+			tree.Root().Walk(func(r cst.Red) bool {
+				if r.IsToken() {
+					return true
+				}
+				parentLo, parentHi := r.TextRange()
+				prevHi := parentLo
+				for i := 0; i < r.ChildCount(); i++ {
+					c := r.ChildAt(i)
+					lo, hi := c.TextRange()
+					if lo < prevHi {
+						t.Errorf("%s: child %d of kind %v starts at %d but previous sibling ended at %d (overlap)",
+							rel, i, r.Kind(), lo, prevHi)
+					}
+					if lo < parentLo || hi > parentHi {
+						t.Errorf("%s: child %d of kind %v range [%d,%d) escapes parent range [%d,%d)",
+							rel, i, r.Kind(), lo, hi, parentLo, parentHi)
+					}
+					prevHi = hi
+				}
+				return true
+			})
+		})
+	}
+}
+
+// TestInvariantsParentReachesRoot walks every materialized node and asserts
+// its Parent chain terminates (no cycles).
+func TestInvariantsParentReachesRoot(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for _, rel := range corpus {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("corpus missing: %v", err)
+				return
+			}
+			tree, _ := selfhost.ParseCST(raw)
+			if tree == nil {
+				return
+			}
+			tree.Root().Walk(func(r cst.Red) bool {
+				depth := 0
+				cur := r
+				for {
+					p, ok := cur.Parent()
+					if !ok {
+						break
+					}
+					cur = p
+					depth++
+					if depth > 10_000 {
+						t.Fatalf("%s: parent chain exceeded 10000 steps; probable cycle", rel)
+					}
+				}
+				return true
+			})
+		})
+	}
+}
+
+// TestInvariantsFindCoveringReturnsInRange asserts that for every sampled
+// byte offset in source, FindCoveringNode returns a node containing that
+// offset. Probes a handful of offsets per file to keep runtime bounded.
+func TestInvariantsFindCoveringReturnsInRange(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for _, rel := range corpus {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("corpus missing: %v", err)
+				return
+			}
+			tree, _ := selfhost.ParseCST(raw)
+			if tree == nil || len(tree.Source) == 0 {
+				return
+			}
+			src := tree.Source
+			for _, off := range []int{0, len(src) / 4, len(src) / 2, 3 * len(src) / 4, len(src) - 1} {
+				if off < 0 || off >= len(src) {
+					continue
+				}
+				found := tree.Root().FindCoveringNode(off)
+				lo, hi := found.TextRange()
+				if off < lo || off >= hi {
+					t.Errorf("%s: FindCoveringNode(%d) returned %v with range [%d,%d); offset not covered",
+						rel, off, found.Kind(), lo, hi)
+				}
+			}
+		})
+	}
+}
+
+// TestInvariantsStructuredNodesHaveWidth guards against a subtle failure mode
+// in nested span projection: if two sibling syntax spans overlap, the builder
+// can accidentally emit a structural wrapper after its tokens were already
+// consumed by the previous sibling. Every non-file, non-error structural node
+// should therefore have positive width in non-empty inputs.
+func TestInvariantsStructuredNodesHaveWidth(t *testing.T) {
+	root := filepath.Join("..", "..")
+	for _, rel := range corpus {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("corpus missing: %v", err)
+				return
+			}
+			tree, _ := selfhost.ParseCST(raw)
+			if tree == nil || len(tree.Source) == 0 {
+				return
+			}
+			tree.Root().Walk(func(r cst.Red) bool {
+				if r.IsToken() || r.Kind() == cst.GkFile || r.Kind().IsError() {
+					return true
+				}
+				if r.Width() <= 0 {
+					t.Errorf("%s: %v node at offset %d has non-positive width %d",
+						rel, r.Kind(), r.Offset(), r.Width())
+				}
+				return true
+			})
+		})
+	}
+}

--- a/internal/cst/parse.go
+++ b/internal/cst/parse.go
@@ -1,0 +1,919 @@
+package cst
+
+import "github.com/osty/osty/internal/token"
+
+// ParseGreen parses a token stream directly into a lossless Red/Green tree.
+// It is independent of the semantic AST arena: the parser emits GreenBuilder
+// events from tokens, using checkpoints for Pratt-style expression wrapping.
+//
+// The parser is intentionally recovery-first. When it cannot classify a
+// region precisely, it still consumes tokens into the nearest enclosing node
+// so byte coverage and Red navigation remain reliable.
+func ParseGreen(src []byte, toks []token.Token, trivias []Trivia) *Tree {
+	p := newGreenParser(src, toks, trivias)
+	return p.parse()
+}
+
+type greenParser struct {
+	src        []byte
+	toks       []token.Token
+	leading    [][]int
+	trailing   [][]int
+	tailTrivia []int
+	triviaIDs  []int
+	b          *GreenBuilder
+	pos        int
+
+	// The lexer keeps `>>` as one SHR token. In type-argument context that
+	// single token can close both the inner and outer generic lists, so the
+	// parser records the extra close for the enclosing list.
+	pendingTypeArgClosers int
+}
+
+func newGreenParser(src []byte, toks []token.Token, trivias []Trivia) *greenParser {
+	b := NewBuilder(nil)
+	arena := b.Arena()
+	triviaIDs := make([]int, len(trivias))
+	for i, tr := range trivias {
+		triviaIDs[i] = arena.AddTrivia(tr)
+	}
+	leading, trailing, tailTrivia := pairTriviaToTokens(toks, trivias)
+	return &greenParser{
+		src:        src,
+		toks:       toks,
+		leading:    leading,
+		trailing:   trailing,
+		tailTrivia: tailTrivia,
+		triviaIDs:  triviaIDs,
+		b:          b,
+	}
+}
+
+func (p *greenParser) parse() *Tree {
+	p.b.StartNode(GkFile)
+	for !p.at(token.EOF) {
+		if p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.parseTopLevel()
+		p.recoverIfStalled(start)
+	}
+	if len(p.tailTrivia) > 0 {
+		p.b.Token(GkErrorMissing, 0, "", 0, translateTriviaIDs(p.tailTrivia, p.triviaIDs), nil)
+	}
+	p.b.FinishNode()
+	arena, root := p.b.Finish()
+	return NewTreeFromSource(arena, root, p.src)
+}
+
+func (p *greenParser) parseTopLevel() {
+	cp := p.b.Checkpoint()
+	p.parseAnnotations()
+	kind := p.topLevelKind()
+	if kind == GkUsePath {
+		p.b.StartNodeAt(GkUsePath, cp)
+		p.parseUseDecl(true)
+		p.b.FinishNode()
+		return
+	}
+	if kind != GkNone {
+		p.b.StartNodeAt(kind, cp)
+		switch kind {
+		case GkFnDecl:
+			p.parseFnDecl()
+		case GkStructDecl:
+			p.parseAggregateDecl(GkStructDecl)
+		case GkEnumDecl:
+			p.parseAggregateDecl(GkEnumDecl)
+		case GkInterfaceDecl:
+			p.parseAggregateDecl(GkInterfaceDecl)
+		case GkTypeAlias:
+			p.parseTypeAlias()
+		case GkUseDecl:
+			p.parseUseDecl(false)
+		case GkLetDecl:
+			p.parseLet()
+		default:
+			p.parseStmtBody(kind)
+		}
+		p.b.FinishNode()
+		return
+	}
+	p.parseStmt()
+}
+
+func (p *greenParser) topLevelKind() GreenKind {
+	i := p.pos
+	if p.kindAt(i) == token.PUB {
+		i++
+	}
+	switch p.kindAt(i) {
+	case token.FN:
+		return GkFnDecl
+	case token.STRUCT:
+		return GkStructDecl
+	case token.ENUM:
+		return GkEnumDecl
+	case token.INTERFACE:
+		return GkInterfaceDecl
+	case token.TYPE:
+		return GkTypeAlias
+	case token.USE:
+		if p.useLooksGrouped(i) {
+			return GkUsePath
+		}
+		return GkUseDecl
+	case token.LET:
+		return GkLetDecl
+	case token.RETURN:
+		return GkReturnStmt
+	case token.BREAK:
+		return GkBreakStmt
+	case token.CONTINUE:
+		return GkContinueStmt
+	case token.DEFER:
+		return GkDeferStmt
+	case token.FOR:
+		return GkForStmt
+	}
+	return GkNone
+}
+
+func (p *greenParser) parseAnnotations() {
+	for p.at(token.HASH) && p.kindAt(p.pos+1) == token.LBRACKET {
+		p.b.StartNode(GkAnnotation)
+		p.emit() // #
+		p.emit() // [
+		for !p.at(token.RBRACKET) && !p.at(token.EOF) {
+			if p.at(token.LPAREN) {
+				p.emit()
+				for !p.at(token.RPAREN) && !p.at(token.EOF) {
+					if p.at(token.COMMA) || p.at(token.NEWLINE) {
+						p.emit()
+						continue
+					}
+					p.b.StartNode(GkAnnotationArg)
+					p.parseExprUntil(token.COMMA, token.RPAREN)
+					p.b.FinishNode()
+				}
+				p.eat(token.RPAREN)
+				continue
+			}
+			if p.at(token.ASSIGN) {
+				p.emit()
+				p.b.StartNode(GkAnnotationArg)
+				p.parseExprUntil(token.RBRACKET)
+				p.b.FinishNode()
+				continue
+			}
+			p.emit()
+		}
+		p.eat(token.RBRACKET)
+		p.b.FinishNode()
+		for p.at(token.NEWLINE) {
+			p.emit()
+		}
+	}
+}
+
+func (p *greenParser) parseUseDecl(grouped bool) {
+	p.eat(token.PUB)
+	p.eat(token.USE)
+	for !p.at(token.EOF) && !p.at(token.NEWLINE) {
+		if grouped && p.at(token.LBRACE) {
+			p.emit()
+			for !p.at(token.RBRACE) && !p.at(token.EOF) {
+				if p.at(token.COMMA) || p.at(token.NEWLINE) {
+					p.emit()
+					continue
+				}
+				p.b.StartNode(GkUseDecl)
+				for !p.at(token.COMMA) && !p.at(token.RBRACE) && !p.at(token.NEWLINE) && !p.at(token.EOF) {
+					p.emit()
+				}
+				p.b.FinishNode()
+			}
+			p.eat(token.RBRACE)
+			continue
+		}
+		if p.at(token.LBRACE) {
+			p.parseBalancedNode(GkUseFFIBody, token.LBRACE, token.RBRACE)
+			continue
+		}
+		p.emit()
+	}
+}
+
+func (p *greenParser) parseFnDecl() {
+	p.eat(token.PUB)
+	p.eat(token.FN)
+	p.eat(token.IDENT)
+	p.parseGenericParamList()
+	p.parseParamList()
+	if p.eat(token.ARROW) {
+		p.parseTypeUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	}
+	if p.at(token.LBRACE) {
+		p.parseBlock()
+	}
+}
+
+func (p *greenParser) parseParamList() {
+	if !p.at(token.LPAREN) {
+		return
+	}
+	p.b.StartNode(GkParamList)
+	p.emit()
+	for !p.at(token.RPAREN) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.b.StartNode(GkParam)
+		p.eat(token.MUT)
+		p.eat(token.IDENT)
+		p.eat(token.UNDERSCORE)
+		if p.eat(token.COLON) {
+			p.parseTypeUntil(token.COMMA, token.RPAREN, token.ASSIGN)
+		}
+		if p.eat(token.ASSIGN) {
+			p.parseExprUntil(token.COMMA, token.RPAREN)
+		}
+		p.recoverIfStalled(start)
+		p.b.FinishNode()
+	}
+	p.eat(token.RPAREN)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseAggregateDecl(kind GreenKind) {
+	p.eat(token.PUB)
+	p.emit() // struct/enum/interface
+	p.eat(token.IDENT)
+	p.parseGenericParamList()
+	if !p.at(token.LBRACE) {
+		return
+	}
+	p.emit()
+	for !p.at(token.RBRACE) && !p.at(token.EOF) {
+		if p.at(token.NEWLINE) || p.at(token.COMMA) {
+			p.emit()
+			continue
+		}
+		cp := p.b.Checkpoint()
+		p.parseAnnotations()
+		if p.kindAfterPub() == token.FN {
+			p.b.StartNodeAt(GkFnDecl, cp)
+			p.parseFnDecl()
+			p.b.FinishNode()
+			continue
+		}
+		switch kind {
+		case GkStructDecl:
+			p.b.StartNodeAt(GkField, cp)
+			start := p.pos
+			p.parseFieldLike()
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		case GkEnumDecl:
+			p.b.StartNodeAt(GkVariant, cp)
+			start := p.pos
+			p.parseVariant()
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		case GkInterfaceDecl:
+			p.b.StartNodeAt(GkNamedType, cp)
+			start := p.pos
+			p.parseTypeUntil(token.NEWLINE, token.RBRACE)
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		}
+	}
+	p.eat(token.RBRACE)
+}
+
+func (p *greenParser) parseFieldLike() {
+	p.eat(token.PUB)
+	p.eat(token.IDENT)
+	if p.eat(token.COLON) {
+		p.parseTypeUntil(token.ASSIGN, token.COMMA, token.NEWLINE, token.RBRACE)
+	}
+	if p.eat(token.ASSIGN) {
+		p.parseExprUntil(token.COMMA, token.NEWLINE, token.RBRACE)
+	}
+}
+
+func (p *greenParser) parseVariant() {
+	p.eat(token.IDENT)
+	if p.at(token.LPAREN) {
+		p.b.StartNode(GkFieldList)
+		p.emit()
+		for !p.at(token.RPAREN) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			p.parseTypeUntil(token.COMMA, token.RPAREN)
+		}
+		p.eat(token.RPAREN)
+		p.b.FinishNode()
+	}
+}
+
+func (p *greenParser) parseTypeAlias() {
+	p.eat(token.PUB)
+	p.eat(token.TYPE)
+	p.eat(token.IDENT)
+	p.parseGenericParamList()
+	if p.eat(token.ASSIGN) {
+		p.parseTypeUntil(token.NEWLINE, token.EOF)
+	}
+}
+
+func (p *greenParser) parseGenericParamList() {
+	if !p.at(token.LT) {
+		return
+	}
+	p.b.StartNode(GkGenericParamList)
+	p.emit()
+	for !p.at(token.GT) && !p.at(token.EOF) {
+		if p.at(token.SHR) {
+			p.emit()
+			break
+		}
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.b.StartNode(GkGenericParam)
+		p.eat(token.IDENT)
+		if p.eat(token.COLON) {
+			p.parseTypeUntil(token.COMMA, token.GT)
+		}
+		if p.pos == start {
+			p.emit()
+		}
+		p.b.FinishNode()
+	}
+	p.eat(token.GT)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseStmt() {
+	cp := p.b.Checkpoint()
+	p.parseAnnotations()
+	kind := p.stmtKind()
+	if kind == GkNone {
+		start := p.pos
+		p.b.StartNodeAt(GkExprStmt, cp)
+		p.parseExprsUntil(token.NEWLINE, token.RBRACE, token.EOF)
+		p.recoverIfStalled(start)
+		p.b.FinishNode()
+		return
+	}
+	p.b.StartNodeAt(kind, cp)
+	p.parseStmtBody(kind)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) stmtKind() GreenKind {
+	switch p.kindAfterPub() {
+	case token.LET:
+		return GkLetStmt
+	case token.RETURN:
+		return GkReturnStmt
+	case token.BREAK:
+		return GkBreakStmt
+	case token.CONTINUE:
+		return GkContinueStmt
+	case token.DEFER:
+		return GkDeferStmt
+	case token.FOR:
+		return GkForStmt
+	}
+	return GkNone
+}
+
+func (p *greenParser) parseStmtBody(kind GreenKind) {
+	switch kind {
+	case GkLetStmt, GkLetDecl:
+		p.parseLet()
+	case GkReturnStmt, GkBreakStmt, GkContinueStmt, GkDeferStmt:
+		p.emit()
+		p.parseExprsUntil(token.NEWLINE, token.RBRACE, token.EOF)
+	case GkForStmt:
+		p.eat(token.FOR)
+		p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
+		if p.at(token.LBRACE) {
+			p.parseBlock()
+		}
+	}
+}
+
+func (p *greenParser) parseLet() {
+	p.eat(token.PUB)
+	p.eat(token.LET)
+	p.eat(token.MUT)
+	p.parsePatternUntil(token.COLON, token.ASSIGN, token.NEWLINE, token.RBRACE, token.EOF)
+	if p.eat(token.COLON) {
+		p.parseTypeUntil(token.ASSIGN, token.NEWLINE, token.RBRACE, token.EOF)
+	}
+	if p.eat(token.ASSIGN) {
+		p.parseExprUntil(token.NEWLINE, token.RBRACE, token.EOF)
+	}
+}
+
+func (p *greenParser) parseBlock() {
+	p.b.StartNode(GkBlock)
+	p.eat(token.LBRACE)
+	for !p.at(token.RBRACE) && !p.at(token.EOF) {
+		if p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		p.parseStmt()
+	}
+	p.eat(token.RBRACE)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parsePatternUntil(stops ...token.Kind) {
+	p.parseExprsUntil(stops...)
+}
+
+func (p *greenParser) parseTypeUntil(stops ...token.Kind) {
+	for !p.atAny(stops...) && !p.at(token.EOF) {
+		start := p.pos
+		if p.parseTypeAtom(stops...) {
+			continue
+		}
+		p.emit()
+		if p.pos == start {
+			return
+		}
+	}
+}
+
+func (p *greenParser) parseTypeAtom(stops ...token.Kind) bool {
+	switch {
+	case p.at(token.FN):
+		p.b.StartNode(GkFunctionType)
+		p.emit()
+		p.parseParamList()
+		if p.eat(token.ARROW) {
+			p.parseTypeUntil(stops...)
+		}
+		p.b.FinishNode()
+		return true
+	case p.at(token.LPAREN):
+		p.parseBalancedNode(GkTupleType, token.LPAREN, token.RPAREN)
+		return true
+	case p.at(token.LBRACKET):
+		p.parseBalancedNode(GkListType, token.LBRACKET, token.RBRACKET)
+		return true
+	case p.at(token.IDENT) || p.at(token.UNDERSCORE):
+		p.b.StartNode(GkNamedType)
+		p.emit()
+		if p.at(token.LT) {
+			p.parseTypeArgList()
+		}
+		p.b.FinishNode()
+		p.parseOptionalTypeSuffixes()
+		return true
+	}
+	return false
+}
+
+func (p *greenParser) parseTypeArgList() {
+	if !p.at(token.LT) {
+		return
+	}
+	p.b.StartNode(GkGenericParamList)
+	p.emit()
+	for !p.at(token.EOF) {
+		if p.pendingTypeArgClosers > 0 {
+			p.pendingTypeArgClosers--
+			break
+		}
+		if p.at(token.GT) {
+			p.emit()
+			break
+		}
+		if p.at(token.SHR) {
+			p.emit()
+			p.pendingTypeArgClosers++
+			break
+		}
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.b.StartNode(GkGenericParam)
+		p.parseTypeUntil(token.COMMA, token.GT, token.SHR, token.NEWLINE)
+		if p.pos == start {
+			p.emit()
+		}
+		p.b.FinishNode()
+		if p.pendingTypeArgClosers > 0 {
+			p.pendingTypeArgClosers--
+			break
+		}
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseOptionalTypeSuffixes() {
+	for p.at(token.QUESTION) || p.at(token.QQ) {
+		p.b.StartNode(GkOptionalType)
+		p.emit()
+		p.b.FinishNode()
+	}
+}
+
+func (p *greenParser) parseExprUntil(stops ...token.Kind) {
+	if p.atAny(stops...) || p.at(token.EOF) {
+		return
+	}
+	p.parseExprBP(0, stops...)
+}
+
+func (p *greenParser) parseExprsUntil(stops ...token.Kind) {
+	for !p.atAny(stops...) && !p.at(token.EOF) {
+		start := p.pos
+		p.parseExprUntil(stops...)
+		p.recoverIfStalled(start)
+	}
+}
+
+func (p *greenParser) parseExprBP(minBP int, stops ...token.Kind) GreenCheckpoint {
+	lhs := p.b.Checkpoint()
+	p.parsePrefix(stops...)
+	for {
+		if p.atAny(stops...) || p.at(token.EOF) {
+			break
+		}
+		if p.parsePostfix(lhs, stops...) {
+			continue
+		}
+		lbp, rbp, ok := infixBindingPower(p.peek().Kind)
+		if !ok || lbp < minBP {
+			break
+		}
+		p.b.StartNodeAt(p.infixKind(), lhs)
+		p.emit()
+		p.parseExprBP(rbp, stops...)
+		p.b.FinishNode()
+	}
+	return lhs
+}
+
+func (p *greenParser) parsePrefix(stops ...token.Kind) {
+	if p.atAny(stops...) || p.at(token.EOF) {
+		return
+	}
+	switch p.peek().Kind {
+	case token.MINUS, token.NOT, token.BITNOT, token.STAR:
+		p.b.StartNode(GkUnary)
+		p.emit()
+		p.parseExprBP(13, stops...)
+		p.b.FinishNode()
+	case token.INT:
+		p.parseLeaf(GkIntLit)
+	case token.FLOAT:
+		p.parseLeaf(GkFloatLit)
+	case token.STRING:
+		p.parseLeaf(GkStringLit)
+	case token.RAWSTRING:
+		p.parseLeaf(GkRawStringLit)
+	case token.CHAR:
+		p.parseLeaf(GkCharLit)
+	case token.BYTE:
+		p.parseLeaf(GkByteLit)
+	case token.IDENT, token.UNDERSCORE, token.LABEL:
+		if p.peek().Kind == token.IDENT && (p.peek().Value == "true" || p.peek().Value == "false") {
+			p.parseLeaf(GkBoolLit)
+			return
+		}
+		p.parseLeaf(GkIdent)
+	case token.LPAREN:
+		p.parseParenOrTuple()
+	case token.LBRACKET:
+		p.parseList()
+	case token.LBRACE:
+		p.parseBlock()
+	case token.IF:
+		p.parseIf()
+	case token.MATCH:
+		p.parseMatch()
+	case token.BITOR, token.OR:
+		p.parseClosure()
+	default:
+		p.b.StartNode(GkError)
+		p.emit()
+		p.b.FinishNode()
+	}
+}
+
+func (p *greenParser) parsePostfix(lhs GreenCheckpoint, stops ...token.Kind) bool {
+	switch p.peek().Kind {
+	case token.LPAREN:
+		p.b.StartNodeAt(GkCall, lhs)
+		p.emit()
+		for !p.at(token.RPAREN) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			p.parseExprUntil(token.COMMA, token.RPAREN)
+		}
+		p.eat(token.RPAREN)
+		p.b.FinishNode()
+		return true
+	case token.LBRACKET:
+		p.b.StartNodeAt(GkIndex, lhs)
+		p.emit()
+		p.parseExprUntil(token.RBRACKET)
+		p.eat(token.RBRACKET)
+		p.b.FinishNode()
+		return true
+	case token.DOT, token.QDOT:
+		p.b.StartNodeAt(GkFieldAccess, lhs)
+		p.emit()
+		p.eat(token.IDENT)
+		p.b.FinishNode()
+		return true
+	case token.QUESTION, token.ASQUESTION:
+		p.b.StartNodeAt(GkQuestion, lhs)
+		p.emit()
+		if !p.atAny(stops...) && !p.at(token.EOF) && p.peek().Kind == token.IDENT {
+			p.parseTypeUntil(stops...)
+		}
+		p.b.FinishNode()
+		return true
+	case token.COLONCOLON:
+		p.b.StartNodeAt(GkTurbofish, lhs)
+		p.emit()
+		if p.at(token.LT) {
+			p.parseGenericParamList()
+		}
+		p.b.FinishNode()
+		return true
+	case token.LBRACE:
+		p.b.StartNodeAt(GkStructLit, lhs)
+		p.emit()
+		for !p.at(token.RBRACE) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			start := p.pos
+			p.b.StartNode(GkStructLitField)
+			if p.at(token.DOTDOT) || p.at(token.DOTDOTEQ) {
+				p.emit()
+				p.parseExprUntil(token.COMMA, token.RBRACE)
+			} else {
+				p.eat(token.IDENT)
+				if p.eat(token.COLON) {
+					p.parseExprUntil(token.COMMA, token.RBRACE)
+				}
+			}
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		}
+		p.eat(token.RBRACE)
+		p.b.FinishNode()
+		return true
+	}
+	return false
+}
+
+func (p *greenParser) parseParenOrTuple() {
+	p.b.StartNode(GkTuple)
+	p.emit()
+	for !p.at(token.RPAREN) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		p.parseExprUntil(token.COMMA, token.RPAREN)
+	}
+	p.eat(token.RPAREN)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseList() {
+	p.b.StartNode(GkList)
+	p.emit()
+	for !p.at(token.RBRACKET) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		p.parseExprUntil(token.COMMA, token.RBRACKET)
+	}
+	p.eat(token.RBRACKET)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseIf() {
+	p.b.StartNode(GkIf)
+	p.emit()
+	p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	if p.at(token.LBRACE) {
+		p.parseBlock()
+	}
+	if p.eat(token.ELSE) {
+		if p.at(token.IF) {
+			p.parseIf()
+		} else if p.at(token.LBRACE) {
+			p.parseBlock()
+		}
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseMatch() {
+	p.b.StartNode(GkMatch)
+	p.emit()
+	p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	if p.eat(token.LBRACE) {
+		for !p.at(token.RBRACE) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			p.b.StartNode(GkMatchArm)
+			p.parseExprsUntil(token.ARROW, token.RBRACE)
+			p.eat(token.ARROW)
+			p.parseExprsUntil(token.COMMA, token.NEWLINE, token.RBRACE)
+			p.b.FinishNode()
+		}
+		p.eat(token.RBRACE)
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseClosure() {
+	p.b.StartNode(GkClosure)
+	p.emit()
+	for !p.at(token.LBRACE) && !p.at(token.EOF) && !p.at(token.NEWLINE) {
+		p.emit()
+	}
+	if p.at(token.LBRACE) {
+		p.parseBlock()
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseLeaf(kind GreenKind) {
+	p.b.StartNode(kind)
+	p.emit()
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseBalancedNode(kind GreenKind, open, close token.Kind) {
+	p.b.StartNode(kind)
+	depth := 0
+	for !p.at(token.EOF) {
+		if p.at(open) {
+			depth++
+		}
+		if p.at(close) {
+			p.emit()
+			depth--
+			if depth <= 0 {
+				break
+			}
+			continue
+		}
+		p.emit()
+	}
+	p.b.FinishNode()
+}
+
+func infixBindingPower(kind token.Kind) (int, int, bool) {
+	switch kind {
+	case token.QQ:
+		return 2, 2, true
+	case token.OR:
+		return 3, 4, true
+	case token.AND:
+		return 4, 5, true
+	case token.EQ, token.NEQ, token.LT, token.GT, token.LEQ, token.GEQ:
+		return 5, 6, true
+	case token.DOTDOT, token.DOTDOTEQ:
+		return 6, 7, true
+	case token.BITOR:
+		return 7, 8, true
+	case token.BITXOR:
+		return 8, 9, true
+	case token.BITAND:
+		return 9, 10, true
+	case token.SHL, token.SHR:
+		return 10, 11, true
+	case token.PLUS, token.MINUS:
+		return 11, 12, true
+	case token.STAR, token.SLASH, token.PERCENT:
+		return 12, 13, true
+	case token.ASSIGN, token.PLUSEQ, token.MINUSEQ, token.STAREQ, token.SLASHEQ, token.PERCENTEQ,
+		token.BITANDEQ, token.BITOREQ, token.BITXOREQ, token.SHLEQ, token.SHREQ, token.CHANARROW:
+		return 1, 1, true
+	}
+	return 0, 0, false
+}
+
+func (p *greenParser) infixKind() GreenKind {
+	switch p.peek().Kind {
+	case token.DOTDOT:
+		return GkRangeExcl
+	case token.DOTDOTEQ:
+		return GkRangeIncl
+	case token.ASSIGN, token.PLUSEQ, token.MINUSEQ, token.STAREQ, token.SLASHEQ, token.PERCENTEQ,
+		token.BITANDEQ, token.BITOREQ, token.BITXOREQ, token.SHLEQ, token.SHREQ:
+		return GkAssignStmt
+	case token.CHANARROW:
+		return GkChanSendStmt
+	}
+	return GkBinary
+}
+
+func (p *greenParser) useLooksGrouped(start int) bool {
+	for i := start; i < len(p.toks); i++ {
+		switch p.kindAt(i) {
+		case token.NEWLINE, token.EOF:
+			return false
+		case token.LBRACE:
+			return true
+		}
+	}
+	return false
+}
+
+func (p *greenParser) kindAfterPub() token.Kind {
+	if p.at(token.PUB) {
+		return p.kindAt(p.pos + 1)
+	}
+	return p.peek().Kind
+}
+
+func (p *greenParser) at(kind token.Kind) bool {
+	return p.peek().Kind == kind
+}
+
+func (p *greenParser) atAny(kinds ...token.Kind) bool {
+	cur := p.peek().Kind
+	for _, kind := range kinds {
+		if cur == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *greenParser) kindAt(idx int) token.Kind {
+	if idx < 0 || idx >= len(p.toks) {
+		return token.EOF
+	}
+	return p.toks[idx].Kind
+}
+
+func (p *greenParser) peek() token.Token {
+	if p.pos < 0 || p.pos >= len(p.toks) {
+		return token.Token{Kind: token.EOF}
+	}
+	return p.toks[p.pos]
+}
+
+func (p *greenParser) eat(kind token.Kind) bool {
+	if !p.at(kind) {
+		return false
+	}
+	p.emit()
+	return true
+}
+
+func (p *greenParser) recoverIfStalled(start int) {
+	if p.pos != start || p.at(token.EOF) {
+		return
+	}
+	p.b.StartNode(GkErrorExtra)
+	p.emit()
+	p.b.FinishNode()
+}
+
+func (p *greenParser) emit() {
+	if p.pos < 0 || p.pos >= len(p.toks) {
+		return
+	}
+	tk := p.toks[p.pos]
+	if tk.Kind == token.EOF {
+		return
+	}
+	emitToken(p.b, tk, p.src, p.leading[p.pos], p.trailing[p.pos], p.triviaIDs)
+	p.pos++
+}

--- a/internal/cst/red.go
+++ b/internal/cst/red.go
@@ -180,6 +180,36 @@ func (r Red) End() int { return r.absoluteOffset + r.Width() }
 // TextRange returns the [start, end) offsets in one value for convenience.
 func (r Red) TextRange() (int, int) { return r.Offset(), r.End() }
 
+// Text returns the exact source bytes covered by this Red handle, including
+// token trivia. It returns nil when the tree has no Source buffer or the range
+// is outside that buffer.
+func (r Red) Text() []byte {
+	if r.tree == nil || r.Offset() < 0 || r.End() < r.Offset() || r.End() > len(r.tree.Source) {
+		return nil
+	}
+	return r.tree.Source[r.Offset():r.End()]
+}
+
+// TokenTextRange returns the lexeme-only range for token leaves, excluding
+// leading and trailing trivia. The boolean is false for non-token Reds.
+func (r Red) TokenTextRange() (int, int, bool) {
+	if !r.IsToken() {
+		return 0, 0, false
+	}
+	tok := r.Token()
+	start := r.Offset() + tok.LeadingWidth
+	return start, start + tok.Width, true
+}
+
+// TokenText returns the token lexeme bytes, excluding attached trivia.
+func (r Red) TokenText() []byte {
+	start, end, ok := r.TokenTextRange()
+	if !ok || r.tree == nil || start < 0 || end < start || end > len(r.tree.Source) {
+		return nil
+	}
+	return r.tree.Source[start:end]
+}
+
 // ChildCount returns the number of direct children. Token leaves have 0.
 func (r Red) ChildCount() int {
 	if r.tag != GctNode {
@@ -242,6 +272,19 @@ func (r Red) ChildAt(i int) Red {
 	return child
 }
 
+// Children materializes every direct child in order.
+func (r Red) Children() []Red {
+	count := r.ChildCount()
+	if count == 0 {
+		return nil
+	}
+	out := make([]Red, count)
+	for i := 0; i < count; i++ {
+		out[i] = r.ChildAt(i)
+	}
+	return out
+}
+
 // Parent returns the Red handle of the parent node, or the zero-value Red
 // plus false if r is the root.
 func (r Red) Parent() (Red, bool) {
@@ -249,6 +292,35 @@ func (r Red) Parent() (Red, bool) {
 		return Red{}, false
 	}
 	return r.tree.reds[r.parent].red, true
+}
+
+// Ancestors returns r's parent chain, nearest parent first.
+func (r Red) Ancestors() []Red {
+	var out []Red
+	cur := r
+	for {
+		parent, ok := cur.Parent()
+		if !ok {
+			return out
+		}
+		out = append(out, parent)
+		cur = parent
+	}
+}
+
+// AncestorOfKind returns the nearest ancestor with kind.
+func (r Red) AncestorOfKind(kind GreenKind) (Red, bool) {
+	cur := r
+	for {
+		parent, ok := cur.Parent()
+		if !ok {
+			return Red{}, false
+		}
+		if parent.Kind() == kind {
+			return parent, true
+		}
+		cur = parent
+	}
 }
 
 // Pos converts Offset to a token.Pos using the tree's associated source. The
@@ -303,6 +375,29 @@ func (r Red) FindCoveringNode(offset int) Red {
 		}
 	}
 	return r
+}
+
+// FindTokenAt returns the leaf token containing offset, or false when offset
+// is outside r or only covered by an interior/error node.
+func (r Red) FindTokenAt(offset int) (Red, bool) {
+	found := r.FindCoveringNode(offset)
+	if found.IsToken() {
+		return found, true
+	}
+	return Red{}, false
+}
+
+// FindFirst returns the first node in pre-order with kind.
+func (r Red) FindFirst(kind GreenKind) (Red, bool) {
+	if r.Kind() == kind {
+		return r, true
+	}
+	for i := 0; i < r.ChildCount(); i++ {
+		if found, ok := r.ChildAt(i).FindFirst(kind); ok {
+			return found, true
+		}
+	}
+	return Red{}, false
 }
 
 // Walk visits r then its descendants in pre-order. The visit function may

--- a/internal/cst/test_helpers_test.go
+++ b/internal/cst/test_helpers_test.go
@@ -1,0 +1,53 @@
+package cst_test
+
+// corpus mirrors the parser snapshot oracle so byte-coverage and round-trip
+// are verified on the same set of inputs the parser snapshot locks.
+var corpus = []string{
+	"testdata/spec/positive/01-lexical.osty",
+	"testdata/spec/positive/02-types.osty",
+	"testdata/spec/positive/03-declarations.osty",
+	"testdata/spec/positive/04-expressions.osty",
+	"testdata/spec/positive/05-modules.osty",
+	"testdata/spec/positive/06-scripts.osty",
+	"testdata/spec/positive/07-errors.osty",
+	"testdata/spec/positive/08-concurrency.osty",
+	"testdata/spec/positive/10-collections.osty",
+	"testdata/spec/positive/11-testing.osty",
+	"testdata/spec/negative/reject.osty",
+	"testdata/full.osty",
+	"testdata/hello.osty",
+	"testdata/resolve_ok.osty",
+	"word_freq.osty",
+	"word_freq_test.osty",
+}
+
+func firstDiff(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	if len(a) != len(b) {
+		return n
+	}
+	return -1
+}
+
+func preview(src []byte, start int) string {
+	const span = 20
+	if start < 0 {
+		start = 0
+	}
+	if start >= len(src) {
+		return ""
+	}
+	end := start + span
+	if end > len(src) {
+		end = len(src)
+	}
+	return string(src[start:end])
+}

--- a/internal/cst/validate.go
+++ b/internal/cst/validate.go
@@ -1,0 +1,201 @@
+package cst
+
+import "fmt"
+
+// ValidationError describes one CST invariant violation.
+type ValidationError struct {
+	Message string
+	Kind    GreenKind
+	Offset  int
+	End     int
+}
+
+func (e ValidationError) Error() string {
+	if e.Kind == GkNone {
+		return e.Message
+	}
+	return fmt.Sprintf("%s at %s[%d,%d)", e.Message, e.Kind, e.Offset, e.End)
+}
+
+// ValidationReport is the complete result of ValidateTree.
+type ValidationReport struct {
+	Errors []ValidationError
+}
+
+// OK reports whether the tree satisfied every checked invariant.
+func (r ValidationReport) OK() bool { return len(r.Errors) == 0 }
+
+// Error returns a compact human-readable summary.
+func (r ValidationReport) Error() string {
+	if len(r.Errors) == 0 {
+		return ""
+	}
+	if len(r.Errors) == 1 {
+		return r.Errors[0].Error()
+	}
+	return fmt.Sprintf("%s; and %d more", r.Errors[0].Error(), len(r.Errors)-1)
+}
+
+// ValidateTree checks the core Red/Green CST contract:
+//
+//   - root is a File node covering the full source buffer
+//   - every node's width equals the sum of its children
+//   - child ranges are ordered, non-overlapping, and inside their parent
+//   - token widths match token text and attached trivia widths
+//   - trivia ranges stay inside the source buffer
+//   - reconstructing the tree yields the original source byte-for-byte
+//
+// It is intentionally strict enough for tests and debug assertions, while
+// still cheap enough to run over corpus files in CI.
+func ValidateTree(tree *Tree) ValidationReport {
+	var report ValidationReport
+	add := func(kind GreenKind, lo, hi int, msg string) {
+		report.Errors = append(report.Errors, ValidationError{
+			Message: msg,
+			Kind:    kind,
+			Offset:  lo,
+			End:     hi,
+		})
+	}
+
+	if tree == nil {
+		add(GkNone, 0, 0, "tree is nil")
+		return report
+	}
+	if tree.Arena == nil {
+		add(GkNone, 0, 0, "tree arena is nil")
+		return report
+	}
+	if tree.Root_ < 0 || tree.Root_ >= len(tree.Arena.Nodes) {
+		add(GkNone, 0, 0, "root id is out of range")
+		return report
+	}
+
+	root := tree.Root()
+	if root.Kind() != GkFile {
+		add(root.Kind(), root.Offset(), root.End(), "root is not File")
+	}
+	if tree.Source != nil && root.Width() != len(tree.Source) {
+		add(root.Kind(), root.Offset(), root.End(), "root width does not match source length")
+	}
+
+	for id, tr := range tree.Arena.Trivias {
+		if tr.Length < 0 {
+			add(GkTrivia, tr.Offset, tr.Offset+tr.Length, fmt.Sprintf("trivia %d has negative length", id))
+		}
+		if tree.Source != nil && (tr.Offset < 0 || tr.Offset+tr.Length > len(tree.Source)) {
+			add(GkTrivia, tr.Offset, tr.Offset+tr.Length, fmt.Sprintf("trivia %d escapes source", id))
+		}
+	}
+
+	root.Walk(func(r Red) bool {
+		lo, hi := r.TextRange()
+		if tree.Source != nil && (lo < 0 || hi < lo || hi > len(tree.Source)) {
+			add(r.Kind(), lo, hi, "red range escapes source")
+			return true
+		}
+		if r.IsToken() {
+			validateTokenRed(tree, r, add)
+			return true
+		}
+		validateNodeRed(tree, r, add)
+		return true
+	})
+
+	if tree.Source != nil {
+		rebuilt := tree.Reconstruct()
+		if string(rebuilt) != string(tree.Source) {
+			add(GkFile, 0, root.End(), "tree reconstruction does not match source")
+		}
+	}
+	return report
+}
+
+func validateTokenRed(tree *Tree, r Red, add func(GreenKind, int, int, string)) {
+	tok := r.Token()
+	if tok.Width != len(tok.Text) {
+		add(r.Kind(), r.Offset(), r.End(), "token width does not match text length")
+	}
+	if tok.LeadingWidth != sumTriviaWidths(tree.Arena, tok.LeadingTrivia) {
+		add(r.Kind(), r.Offset(), r.End(), "token leading width does not match trivia")
+	}
+	if tok.TrailingWidth != sumTriviaWidths(tree.Arena, tok.TrailingTrivia) {
+		add(r.Kind(), r.Offset(), r.End(), "token trailing width does not match trivia")
+	}
+	if got, want := r.Width(), tok.TotalWidth(); got != want {
+		add(r.Kind(), r.Offset(), r.End(), fmt.Sprintf("red token width = %d, want %d", got, want))
+	}
+	start, end, ok := r.TokenTextRange()
+	if !ok || end-start != tok.Width {
+		add(r.Kind(), r.Offset(), r.End(), "token text range is invalid")
+	}
+	if tree.Source != nil && ok && (start < 0 || end < start || end > len(tree.Source)) {
+		add(r.Kind(), start, end, "token text range escapes source")
+	}
+}
+
+func validateNodeRed(tree *Tree, r Red, add func(GreenKind, int, int, string)) {
+	node := r.Node()
+	if node.Width != r.Width() {
+		add(r.Kind(), r.Offset(), r.End(), "node width and red width disagree")
+	}
+	sum := 0
+	prevHi := r.Offset()
+	for i := 0; i < r.ChildCount(); i++ {
+		child := r.ChildAt(i)
+		lo, hi := child.TextRange()
+		if lo < prevHi {
+			add(r.Kind(), r.Offset(), r.End(), fmt.Sprintf("child %d overlaps previous sibling", i))
+		}
+		if lo < r.Offset() || hi > r.End() {
+			add(r.Kind(), r.Offset(), r.End(), fmt.Sprintf("child %d escapes parent", i))
+		}
+		prevHi = hi
+		sum += child.Width()
+	}
+	if sum != node.Width {
+		add(r.Kind(), r.Offset(), r.End(), fmt.Sprintf("node child widths sum to %d, want %d", sum, node.Width))
+	}
+	if r.Kind() != GkFile && !r.Kind().IsError() && r.Width() <= 0 {
+		add(r.Kind(), r.Offset(), r.End(), "structural node has non-positive width")
+	}
+}
+
+// Reconstruct rebuilds the exact source bytes represented by tree, using token
+// text plus attached trivia. It returns nil for a nil tree.
+func (t *Tree) Reconstruct() []byte {
+	if t == nil {
+		return nil
+	}
+	src := t.Source
+	out := make([]byte, 0, len(src))
+	emitTrivia := func(indices []int) {
+		for _, id := range indices {
+			if id < 0 || t.Arena == nil || id >= len(t.Arena.Trivias) {
+				continue
+			}
+			tr := t.Arena.TriviaAt(id)
+			lo, hi := tr.Offset, tr.Offset+tr.Length
+			if lo < 0 {
+				lo = 0
+			}
+			if hi > len(src) {
+				hi = len(src)
+			}
+			if lo < hi {
+				out = append(out, src[lo:hi]...)
+			}
+		}
+	}
+	t.Root().Walk(func(r Red) bool {
+		if !r.IsToken() {
+			return true
+		}
+		tok := r.Token()
+		emitTrivia(tok.LeadingTrivia)
+		out = append(out, tok.Text...)
+		emitTrivia(tok.TrailingTrivia)
+		return true
+	})
+	return out
+}

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -3453,6 +3453,9 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 		}
 		return out, true
 	case *ostyir.Ident:
+		if e.Kind == ostyir.IdentVariant {
+			return nativeBareVariantIdentFromIR(ctx, e)
+		}
 		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			info, ok := ctx.lookupScopeName(e.Name)
@@ -5760,6 +5763,38 @@ func nativeBareVariantAccessFromIR(ctx *nativeProjectionCtx, e *ostyir.FieldExpr
 		// A payload-bearing variant referenced without parens is a
 		// function-value form (the constructor as a callable). Bail
 		// — only the zero-arg construction case lowers cleanly here.
+		return nil, false
+	}
+	children := []*llvmNativeExpr{{
+		kind:     llvmNativeExprInt,
+		llvmType: "i64",
+		text:     strconv.Itoa(variant.tag),
+	}}
+	if info.def.payloadSlotType != "" {
+		children = append(children, nativeZeroExprForLLVMType(info.def.payloadSlotType))
+	}
+	return &llvmNativeExpr{
+		kind:       llvmNativeExprStructLit,
+		llvmType:   info.def.llvmType,
+		childExprs: children,
+	}, true
+}
+
+// nativeBareVariantIdentFromIR lowers a resolver-classified bare enum variant
+// (`DivideByZero`) into the same zero-argument variant construction used for
+// qualified field syntax (`CalcError.DivideByZero`). Without this case the
+// generic identifier path treats the variant name as a variable and emits
+// invalid LLVM like `store %CalcError @DivideByZero`.
+func nativeBareVariantIdentFromIR(ctx *nativeProjectionCtx, ident *ostyir.Ident) (*llvmNativeExpr, bool) {
+	if ctx == nil || ident == nil || ident.Kind != ostyir.IdentVariant {
+		return nil, false
+	}
+	info, ok := nativeEnumInfoFromType(ctx, ident.Type())
+	if !ok {
+		return nil, false
+	}
+	variant, ok := info.variantsByName[ident.Name]
+	if !ok || len(variant.payloadIRTypes) != 0 {
 		return nil, false
 	}
 	children := []*llvmNativeExpr{{

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2104,9 +2104,6 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 			return &CopyOp{Place: Place{Local: tmp}, T: hint}
 		}
 	}
-	if !shouldPreferHintType(e.Type(), hint) {
-		return bs.lowerExprAsOperand(e)
-	}
 	if id, ok := e.(*ir.Ident); ok {
 		if id.Name == "None" && id.Kind != ir.IdentLocal && id.Kind != ir.IdentParam {
 			tmp := bs.freshTemp(hint, id.SpanV)
@@ -2134,6 +2131,9 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 				return &CopyOp{Place: Place{Local: tmp}, T: hint}
 			}
 		}
+	}
+	if !shouldPreferHintType(e.Type(), hint) {
+		return bs.lowerExprAsOperand(e)
 	}
 	return bs.lowerExprAsOperand(e)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/cst"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
 )
@@ -73,4 +74,12 @@ func ParseDiagnostics(src []byte) (*ast.File, []*diag.Diagnostic) {
 // semantic arena on first access.
 func ParseRun(src []byte) *selfhost.FrontendRun {
 	return selfhost.Run(src)
+}
+
+// ParseCST lexes and parses src, returning the lossless Red/Green concrete
+// syntax tree plus the same diagnostics reported by the semantic parse path.
+// Use this entry point for formatter, repair, and LSP features that need
+// byte-for-byte source coverage instead of only the semantic AST.
+func ParseCST(src []byte) (*cst.Tree, []*diag.Diagnostic) {
+	return selfhost.ParseCST(src)
 }

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -106,6 +106,19 @@ func hashParseResult(r ParseResult) [32]byte {
 	return h.sum()
 }
 
+// hashCSTParseResult fingerprints a [CSTParseResult]. The CST is lossless, so
+// the normalized source bytes are the stable identity for the tree contents;
+// diagnostics are included for the same cutoff behavior as Parse.
+func hashCSTParseResult(r CSTParseResult) [32]byte {
+	h := newHasher()
+	h.bytes(r.Source)
+	h.u32(uint32(len(r.Diags)))
+	for _, d := range r.Diags {
+		hashDiagnostic(h, d)
+	}
+	return h.sum()
+}
+
 // ---- Diagnostics ----
 
 func hashDiagnostic(h *stableHasher, d *diag.Diagnostic) {

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/cst"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/parser"
@@ -28,6 +29,15 @@ type ParseResult struct {
 	File            *ast.File
 	Diags           []*diag.Diagnostic
 	Provenance      *parser.Provenance
+}
+
+// CSTParseResult is the output of the [ParseCST] query — the lossless
+// Red/Green tree plus parser diagnostics. The Source field is the normalized
+// byte buffer covered by Tree.
+type CSTParseResult struct {
+	Source []byte
+	Tree   *cst.Tree
+	Diags  []*diag.Diagnostic
 }
 
 // ResolvedPackage is an immutable view over a resolved package. Once
@@ -199,6 +209,10 @@ type Queries struct {
 	// Depends on: SourceText(path).
 	Parse *query.Query[string, ParseResult]
 
+	// ParseCST: (path) -> lossless Red/Green CST + diagnostics.
+	// Depends on: SourceText(path).
+	ParseCST *query.Query[string, CSTParseResult]
+
 	// BuildPackage: (dir) -> fresh *resolve.Package with PackageFiles
 	// assembled from Parse'd contents. Not directly useful to
 	// callers; exists so ResolvePackage can rebuild cleanly on each
@@ -282,6 +296,20 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			}
 		},
 		hashParseResult,
+	)
+
+	qs.ParseCST = query.Register(db, "ParseCST",
+		func(ctx *query.Ctx, path string) CSTParseResult {
+			src := inp.SourceText.Fetch(ctx, path)
+			tree, diags := parser.ParseCST(src)
+			normalized := cst.Normalize(src)
+			return CSTParseResult{
+				Source: normalized,
+				Tree:   tree,
+				Diags:  diags,
+			}
+		},
+		hashCSTParseResult,
 	)
 
 	// BuildPackage has no hashFn: its output carries fresh

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -3,6 +3,8 @@ package osty
 import (
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/cst"
 )
 
 // Helper: seed one "package" with one file for tests.
@@ -60,6 +62,50 @@ func TestParseRerunsOnSourceChange(t *testing.T) {
 	after := eng.DB.Metrics().Sub(before)
 	if after.Reruns != 1 {
 		t.Fatalf("expected 1 rerun after source change, got %+v", after)
+	}
+}
+
+func TestParseCSTQueryReturnsNestedLosslessTree(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	path := seedFile(eng, "/tmp/pkg_cst", "main.osty", "fn main() {\n    let x = add(1, 2)\n}\n")
+
+	before := eng.DB.Metrics()
+	res := eng.Queries.ParseCST.Get(eng.DB, path)
+	after := eng.DB.Metrics().Sub(before)
+	if after.Misses == 0 {
+		t.Fatal("expected a miss on first ParseCST")
+	}
+	if res.Tree == nil {
+		t.Fatal("ParseCST returned nil tree")
+	}
+	if string(res.Tree.Source) != string(res.Source) {
+		t.Fatalf("tree source and query source differ: tree=%q query=%q", res.Tree.Source, res.Source)
+	}
+
+	var sawLet, sawCall bool
+	res.Tree.Root().Walk(func(r cst.Red) bool {
+		if r.Kind() == cst.GkLetStmt {
+			sawLet = true
+		}
+		if r.Kind() == cst.GkCall {
+			sawCall = true
+		}
+		return true
+	})
+	if !sawLet || !sawCall {
+		t.Fatalf("ParseCST tree missing nested nodes: sawLet=%v sawCall=%v", sawLet, sawCall)
+	}
+
+	before = eng.DB.Metrics()
+	again := eng.Queries.ParseCST.Get(eng.DB, path)
+	after = eng.DB.Metrics().Sub(before)
+	if again.Tree == nil {
+		t.Fatal("cached ParseCST returned nil tree")
+	}
+	if after.Misses != 0 || after.Reruns != 0 || after.Hits == 0 {
+		t.Fatalf("cached ParseCST should hit without miss/rerun, got %+v", after)
 	}
 }
 

--- a/internal/selfhost/parse_cst.go
+++ b/internal/selfhost/parse_cst.go
@@ -1,17 +1,13 @@
 package selfhost
 
 import (
-	"sort"
-
 	"github.com/osty/osty/internal/cst"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/token"
 )
 
-// ParseCST lexes and parses src, then lifts the parser run plus its token
-// stream into a concrete-syntax Red/Green tree. The returned *cst.Tree is a
-// lossless projection — every source byte (after CRLF normalization) is
-// reachable from the tree.
+// ParseCST lexes and parses src, then feeds the token stream into the native
+// concrete-syntax Green parser. The returned *cst.Tree is lossless: every
+// source byte (after CRLF normalization) is reachable from the tree.
 //
 // Relationship to Parse:
 //
@@ -21,19 +17,15 @@ import (
 //     reproduce source text (formatter, LSP hover highlights, incremental
 //     reparse candidates) use this variant.
 //
-// This is still the compatibility CST path: structure is projected from the
-// selfhost parser arena's top-level spans until the parser emits a native
-// Green tree or lossless event stream. Keep that dependency explicit and local
-// to this adapter.
-//
-// Diagnostics are identical to Parse — no new analysis is performed.
+// Diagnostics are identical to Parse: the semantic parser still owns language
+// diagnostics, while the CST parser owns only the lossless tree.
 func ParseCST(src []byte) (*cst.Tree, []*diag.Diagnostic) {
 	normalized := cst.Normalize(src)
 	run := runFrontend(normalized, true)
 	return ParseCSTFromRun(run, normalized)
 }
 
-// ParseCSTFromRun builds the compatibility CST from an existing front-end run.
+// ParseCSTFromRun builds the native CST from an existing front-end run.
 // normalized must be the CRLF-normalized source bytes used to create run.
 func ParseCSTFromRun(run *FrontendRun, normalized []byte) (*cst.Tree, []*diag.Diagnostic) {
 	if run == nil {
@@ -41,137 +33,6 @@ func ParseCSTFromRun(run *FrontendRun, normalized []byte) (*cst.Tree, []*diag.Di
 	}
 	toks := run.Tokens()
 	trivias := cst.Extract(normalized, toks)
-	entities := cstEntitySpansFromRun(run, toks)
-	tree := cst.BuildFromEntitySpans(normalized, entities, toks, trivias)
+	tree := cst.ParseGreen(normalized, toks, trivias)
 	return tree, run.Diagnostics()
-}
-
-func cstEntitySpansFromRun(run *FrontendRun, toks []token.Token) []cst.EntitySpan {
-	if run == nil || run.parser == nil || run.parser.arena == nil {
-		return nil
-	}
-	return cstEntitySpansFromArena(run.parser.arena, toks)
-}
-
-func cstEntitySpansFromArena(arena *AstArena, toks []token.Token) []cst.EntitySpan {
-	if arena == nil {
-		return nil
-	}
-	entities := make([]cst.EntitySpan, 0, len(arena.decls))
-	for _, idx := range arena.decls {
-		appendCSTEntitySpan(&entities, arena, toks, idx)
-	}
-	sort.SliceStable(entities, func(i, j int) bool {
-		if entities[i].Start == entities[j].Start {
-			return entities[i].End < entities[j].End
-		}
-		return entities[i].Start < entities[j].Start
-	})
-	return entities
-}
-
-func appendCSTEntitySpan(out *[]cst.EntitySpan, arena *AstArena, toks []token.Token, idx int) {
-	n := cstArenaNodeAt(arena, idx)
-	if n == nil {
-		return
-	}
-	if _, ok := n.kind.(*AstNodeKind_AstNUseDecl); ok && astUseDeclIsGroup(n) {
-		for _, child := range n.children {
-			appendCSTEntitySpan(out, arena, toks, child)
-		}
-		return
-	}
-	span, ok := cstEntitySpanForArenaNode(toks, n, cstKindForArenaTopLevel(n, toks))
-	if ok {
-		*out = append(*out, span)
-	}
-}
-
-func cstKindForArenaTopLevel(n *AstNode, toks []token.Token) cst.GreenKind {
-	if n == nil {
-		return cst.GkError
-	}
-	switch n.kind.(type) {
-	case *AstNodeKind_AstNFnDecl:
-		return cst.GkFnDecl
-	case *AstNodeKind_AstNStructDecl:
-		return cst.GkStructDecl
-	case *AstNodeKind_AstNEnumDecl:
-		return cst.GkEnumDecl
-	case *AstNodeKind_AstNInterfaceDecl:
-		return cst.GkInterfaceDecl
-	case *AstNodeKind_AstNTypeAlias:
-		return cst.GkTypeAlias
-	case *AstNodeKind_AstNUseDecl:
-		return cst.GkUseDecl
-	case *AstNodeKind_AstNLet, *AstNodeKind_AstNLetDecl:
-		if cstArenaLetIsPub(n, toks) {
-			return cst.GkLetDecl
-		}
-		return cst.GkLetStmt
-	case *AstNodeKind_AstNReturn:
-		return cst.GkReturnStmt
-	case *AstNodeKind_AstNBreak:
-		return cst.GkBreakStmt
-	case *AstNodeKind_AstNContinue:
-		return cst.GkContinueStmt
-	case *AstNodeKind_AstNDefer:
-		return cst.GkDeferStmt
-	case *AstNodeKind_AstNFor:
-		return cst.GkForStmt
-	case *AstNodeKind_AstNAssign:
-		return cst.GkAssignStmt
-	case *AstNodeKind_AstNChanSend:
-		return cst.GkChanSendStmt
-	case *AstNodeKind_AstNExprStmt:
-		return cst.GkExprStmt
-	case *AstNodeKind_AstNBlock:
-		return cst.GkBlock
-	}
-	return cst.GkError
-}
-
-func cstArenaLetIsPub(n *AstNode, toks []token.Token) bool {
-	if n == nil || n.start <= 0 || n.start-1 >= len(toks) {
-		return false
-	}
-	return toks[n.start-1].Kind == token.PUB
-}
-
-func cstEntitySpanForArenaNode(toks []token.Token, n *AstNode, kind cst.GreenKind) (cst.EntitySpan, bool) {
-	if n == nil || len(toks) == 0 {
-		return cst.EntitySpan{}, false
-	}
-	startIdx := n.start
-	if startIdx < 0 {
-		startIdx = 0
-	}
-	if startIdx >= len(toks) {
-		return cst.EntitySpan{}, false
-	}
-	endIdx := n.end - 1
-	if endIdx < startIdx {
-		endIdx = startIdx
-	}
-	if endIdx >= len(toks) {
-		endIdx = len(toks) - 1
-	}
-	for endIdx >= startIdx && toks[endIdx].Kind == token.EOF {
-		endIdx--
-	}
-	if endIdx < startIdx {
-		return cst.EntitySpan{}, false
-	}
-	return cst.EntitySpan{
-		Start: toks[startIdx].Pos.Offset,
-		End:   toks[endIdx].End.Offset,
-		Kind:  kind,
-	}, true
-}
-
-func cstArenaNodeAt(arena *AstArena, idx int) *AstNode {
-	if arena == nil || idx < 0 || idx >= len(arena.nodes) {
-		return nil
-	}
-	return arena.nodes[idx]
 }


### PR DESCRIPTION
## Summary
- Add a token-stream native Green parser for CST construction and wire ParseCST through it
- Add nested Red traversal/query helpers, tree validation, and lossless reconstruction support
- Add coverage for nested CST shape, grouped use ranges, generic closing tokens, and native Result bare-variant lowering

## Verification
- `go test -count=1 -vet=off ./internal/cst`
- `go test -count=1 -vet=off ./internal/parser ./internal/selfhost ./internal/query/osty`
- `go test -count=1 -vet=off ./internal/backend -run 'TestEmitLLVMIRTextFallsBackForStdTestingMIRBackend|TestLLVMBackendEmitBinaryFallsBackForStdTestingMIRBackend|TestLLVMBackendBinaryBuiltinResult'`
- `git diff --check --cached`
- `just full` was run after syncing `origin/main`; it passed through focused selfhost/CI and was interrupted per request after the latest upstream-only email stdlib change was identified.