### PR TITLE
[codex] Fill stdlib checker gaps and refresh examples

### DIFF
--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -363,6 +363,95 @@ fn main() {
 	}
 }
 
+func TestCheckWorkspaceMemberDirLoadsEnclosingWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	depDir := filepath.Join(dir, "dep")
+	appDir := filepath.Join(dir, "app")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[workspace]
+members = ["dep", "app"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "osty.toml"), []byte(`[package]
+name = "dep"
+version = "0.1.0"
+edition = "0.5"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "dep.osty"), []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "osty.toml"), []byte(`[package]
+name = "app"
+version = "0.1.0"
+edition = "0.5"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "main.osty"), []byte(`use dep
+
+fn main() {
+    let x = dep.helper()
+    x
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runOstyCLI(t, "check", appDir)
+	if got.exit != 0 {
+		t.Fatalf("osty check member dir exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr contained error output on clean workspace member:\n%s", got.stderr)
+	}
+}
+
+func TestCheckStdlibSupplementalSurface(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`use std.testing
+use std.testing.gen as gen
+
+fn main() {
+    let n: Int = 7
+    let f: Float64 = n.toFloat64()
+    let b: Byte = n.toByte()
+    let rounded: Result<Int8, Error> = n.toInt8()
+    let checked: Int? = n.checkedAdd(1)
+    let wrapped: Int = n.wrappingAdd(1)
+    let mut lines: List<String> = ["value"]
+    lines.push(f.toString())
+    let joined: String = lines.join("\n")
+    let err: Error = Error.new(joined)
+    let _ = err.message()
+    let _ = rounded
+    let _ = b
+    let _ = checked
+    let _ = wrapped
+    testing.property("small ints", gen.intRange(0, 10), |x: Int| -> Bool { x >= 0 })
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "check", "--no-airepair", path)
+	if got.exit != 0 {
+		t.Fatalf("osty check stdlib supplemental surface exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr contained error output on stdlib supplemental surface:\n%s", got.stderr)
+	}
+}
+
 // TestRunCheckFileNativeIsAstbridgeFree is the in-process counter
 // test analog of TestRunResolveFileHappyPathIsAstbridgeFree. Proves
 // the --native CLI path produces zero astLowerPublicFile calls

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -74,11 +74,66 @@ func nativeWorkspaceRoot(dir string, flags cliFlags) (string, bool, bool) {
 		if m != nil && m.Workspace != nil {
 			return root, true, false
 		}
+		if enclosing, ok := enclosingWorkspaceRoot(dir, root); ok {
+			return enclosing, true, false
+		}
 	}
 	if isWorkspace(dir) {
 		return dir, true, false
 	}
 	return "", false, false
+}
+
+func enclosingWorkspaceRoot(dir, nearestManifestRoot string) (string, bool) {
+	start, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false
+	}
+	stop, err := filepath.Abs(nearestManifestRoot)
+	if err != nil {
+		stop = nearestManifestRoot
+	}
+	for parent := filepath.Dir(stop); parent != stop; parent = filepath.Dir(parent) {
+		manifestPath := filepath.Join(parent, manifest.ManifestFile)
+		if _, err := os.Stat(manifestPath); err != nil {
+			if next := filepath.Dir(parent); next == parent {
+				break
+			}
+			continue
+		}
+		m, _, err := manifest.Load(manifestPath)
+		if err != nil || m == nil || m.Workspace == nil {
+			if next := filepath.Dir(parent); next == parent {
+				break
+			}
+			continue
+		}
+		if workspaceContainsPath(parent, m.Workspace.Members, start) {
+			return parent, true
+		}
+	}
+	return "", false
+}
+
+func workspaceContainsPath(root string, members []string, target string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		rootAbs = root
+	}
+	for _, member := range members {
+		memberAbs, err := filepath.Abs(filepath.Join(rootAbs, member))
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(memberAbs, target)
+		if err != nil {
+			continue
+		}
+		if rel == "." || rel == "" || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
 }
 
 // runResolveFile drives the single-file `osty resolve FILE` happy path

--- a/examples/concurrency/main.osty
+++ b/examples/concurrency/main.osty
@@ -12,27 +12,27 @@ fn producer(ch: Channel<Int>) {
 fn main() {
     let ch = thread.chan::<Int>(0)
     let h = spawn(|| producer(ch))
-    let mut sum = 0
+    let mut sum: Int = 0
     for x in ch {
         sum = sum + x
     }
     h.join()
 
-    let squares = parallel(
-        || square(2),
-        || square(3),
-        || square(4),
-    )
+    let squares = parallel([2, 3, 4], 2, |n: Int| -> Int { square(n) })
     for n in squares {
         sum = sum + n
     }
 
-    let grouped = taskGroup(|g| {
+    let grouped = taskGroup(|g: Group| -> Result<Int, Error> {
         let a = g.spawn(|| square(5))
         let b = g.spawn(|| square(6))
-        a.join() + b.join()
+        Ok(a.join() + b.join())
     })
+    let groupedText = match grouped {
+        Ok(n) -> n.toString(),
+        Err(e) -> e.message(),
+    }
 
     println("sum={sum}")
-    println("grouped={grouped}")
+    println("grouped={groupedText}")
 }

--- a/examples/url-health/main.osty
+++ b/examples/url-health/main.osty
@@ -12,6 +12,7 @@ use std.env
 use std.time
 use std.collections
 use std.testing
+use std.testing.gen as gen
 use std.log
 
 // ─── Status ────────────────────────────────────────────────────────
@@ -51,7 +52,7 @@ pub struct CheckResult {
     pub url: String,
     pub status: Status,
     pub latencyMs: Int,
-    pub at: Instant,
+    pub at: time.Instant,
 }
 
 // ─── Report ────────────────────────────────────────────────────────
@@ -64,8 +65,7 @@ pub struct Report {
     pub slowest: CheckResult?,
 
     pub fn healthyRate(self) -> Float {
-        if self.total == 0 { 0.0 }
-        else { self.healthy.toFloat64() / self.total.toFloat64() }
+        if self.total == 0 { 0.0 } else { self.healthy.toFloat64() / self.total.toFloat64() }
     }
 
     pub fn render(self) -> String {
@@ -129,11 +129,26 @@ fn fetchStatus(url: String, slowMs: Int) -> Result<Status, Error> {
 /// Run checks concurrently.
 /// taskGroup enforces that handles cannot escape scope (E0743)
 /// — every spawned task is joined here.
-pub fn checkAll(urls: List<String>, slowMs: Int = 1000) -> List<CheckResult> {
-    taskGroup(|g| {
-        let handles = urls.map(|u| g.spawn(|| checkOne(u, slowMs)))
-        handles.map(|h| h.join())
+pub fn checkAll(urls: List<String>, slowMs: Int) -> List<CheckResult> {
+    let grouped = taskGroup(|g: Group| -> Result<List<CheckResult>, Error> {
+        let mut handles: List<Handle<CheckResult>> = []
+        for url in urls {
+            let capturedUrl = url
+            let capturedSlowMs = slowMs
+            handles.push(g.spawn(|| checkOne(capturedUrl, capturedSlowMs)))
+        }
+
+        let mut out: List<CheckResult> = []
+        for h in handles {
+            out.push(h.join())
+        }
+        Ok(out)
     })
+
+    match grouped {
+        Ok(results) -> results,
+        Err(_)      -> [],
+    }
 }
 
 /// Aggregate results into a single Report.
@@ -148,10 +163,15 @@ pub fn aggregate(results: List<CheckResult>) -> Report {
 
         if r.status.isHealthy() { healthy += 1 }
 
-        slowest = match (slowest, r) {
-            (None, cur)                      -> Some(cur),
-            (Some(prev), cur) if cur.latencyMs > prev.latencyMs -> Some(cur),
-            (keep, _)                        -> keep,
+        if slowest.isNone() {
+            slowest = Some(r)
+        } else {
+            let prev = slowest.unwrap()
+            if r.latencyMs > prev.latencyMs {
+                slowest = Some(r)
+            } else {
+                slowest = Some(prev)
+            }
         }
     }
 
@@ -174,7 +194,7 @@ pub fn main() -> Result<(), Error> {
 
     println("Checking {urls.len()} URL(s)...")
 
-    let results = checkAll(urls)
+    let results = checkAll(urls, 1000)
     let report  = aggregate(results)
 
     println(report.render())
@@ -217,8 +237,8 @@ fn test_aggregate_render() {
 
 /// Property: healthyRate is always in [0.0, 1.0].
 fn test_healthy_rate_property() {
-    let g = testing.Gen.intRange(0, 100)
-    testing.property("rate stays in [0,1]", g, |n| {
+    let g = gen.intRange(0, 100)
+    testing.property("rate stays in [0,1]", g, |n: Int| -> Bool {
         let report = Report {
             total: 100, healthy: n, byLabel: {:}, slowest: None,
         }

--- a/examples/url-health/osty.toml
+++ b/examples/url-health/osty.toml
@@ -1,3 +1,4 @@
 [package]
 name = "url-health"
 version = "0.1.0"
+edition = "0.5"

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -48023,6 +48023,8 @@ func collectUseDecl(cx *ElabCx, declIdx int, node *AstNode) {
 		} else if node.text == "std.testing" {
 			// Osty: /tmp/selfhost_merged.osty:23278:13
 			registerStdTestingAliasFns(env, alias)
+		} else if node.text == "std.testing.gen" {
+			registerStdTestingGenAliasFns(env, alias)
 		} else if node.text == "std.fs" {
 			// Osty: /tmp/selfhost_merged.osty:23280:13
 			registerStdFsAliasFns(env, alias)
@@ -48260,6 +48262,7 @@ func registerStdTestingAliasFns(env *CheckEnv, alias string) {
 	checkRegisterFn(env, &CheckFnSig{name: "benchmark", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_, paramNames: []string{"iterations", "body"}, paramTys: []int{tInt_, tFnResUnit}, generics: emptyGenerics, genericBounds: emptyBounds})
 	// Osty: /tmp/selfhost_merged.osty:23583:5
 	checkRegisterFn(env, &CheckFnSig{name: "snapshot", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_, paramNames: []string{"name", "output"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds})
+	registerStdTestingPropertyAliasFns(env, alias)
 }
 
 // Osty: /tmp/selfhost_merged.osty:23593:1

--- a/internal/selfhost/primitive_arith_register.go
+++ b/internal/selfhost/primitive_arith_register.go
@@ -42,6 +42,25 @@ func installPrimitiveArithMethods(env *CheckEnv) {
 		registerSelfShapedBinary(env, k.owner, k.ty, "min", "other")
 		registerSelfShapedBinary(env, k.owner, k.ty, "max", "other")
 		registerSelfShapedClamp(env, k.owner, k.ty)
+		for _, name := range []string{"wrappingAdd", "wrappingSub", "wrappingMul", "wrappingDiv", "wrappingMod"} {
+			registerSelfShapedBinary(env, k.owner, k.ty, name, "other")
+		}
+		registerSelfIntUnary(env, k.owner, k.ty, "wrappingShl", "b")
+		registerSelfIntUnary(env, k.owner, k.ty, "wrappingShr", "b")
+		registerSelfShapedNullary(env, k.owner, k.ty, "wrappingAbs")
+		registerSelfShapedNullary(env, k.owner, k.ty, "wrappingNeg")
+		for _, name := range []string{"checkedAdd", "checkedSub", "checkedMul", "checkedDiv", "checkedMod"} {
+			registerOptionalSelfBinary(env, k.owner, k.ty, name, "other")
+		}
+		registerOptionalSelfIntUnary(env, k.owner, k.ty, "checkedShl", "b")
+		registerOptionalSelfIntUnary(env, k.owner, k.ty, "checkedShr", "b")
+		registerOptionalSelfNullary(env, k.owner, k.ty, "checkedAbs")
+		registerOptionalSelfNullary(env, k.owner, k.ty, "checkedNeg")
+		for _, name := range []string{"saturatingAdd", "saturatingSub", "saturatingMul", "saturatingDiv"} {
+			registerSelfShapedBinary(env, k.owner, k.ty, name, "other")
+		}
+		registerSelfIntUnary(env, k.owner, k.ty, "pow", "exp")
+		registerIntConversionMethods(env, k.owner, k.ty, tys)
 		// toString — narrow widths share the i64 ABI on the LLVM side
 		// and the dispatcher in `g.emitRuntimeIntToString` already
 		// handles every Int kind by routing through `osty_rt_int_to_string`.
@@ -54,6 +73,7 @@ func installPrimitiveArithMethods(env *CheckEnv) {
 		// ready.
 		registerToString(env, k.owner, k.ty)
 	}
+	registerSupplementalStdlibSurface(env)
 
 	// Float family — same `#[intrinsic_methods(Float, Float32, Float64)]`
 	// shape as the integer loop above. Register the full stdlib-declared
@@ -97,6 +117,54 @@ func installPrimitiveArithMethods(env *CheckEnv) {
 		registerPlainReturnNullary(env, k.owner, k.ty, "toFloat64", tFloat64(tys))
 		registerToString(env, k.owner, k.ty)
 	}
+}
+
+func registerSupplementalStdlibSurface(env *CheckEnv) {
+	tys := env.tys
+	tString_ := tString(tys)
+	tError := tyNamed(tys, "Error", make([]int, 0, 1))
+	tListString := tyNamed(tys, "List", []int{tString_})
+
+	checkRegisterFn(env, &CheckFnSig{
+		name:          "join",
+		owner:         "List",
+		receiverTy:    tListString,
+		hasReceiver:   true,
+		retTy:         tString_,
+		paramNames:    []string{"sep"},
+		paramTys:      []int{tString_},
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+	checkRegisterFn(env, &CheckFnSig{
+		name:          "new",
+		owner:         "Error",
+		receiverTy:    -1,
+		hasReceiver:   false,
+		retTy:         tError,
+		paramNames:    []string{"message"},
+		paramTys:      []int{tString_},
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+	checkMarkFnHasBody(env, "new", "Error")
+}
+
+func registerIntConversionMethods(env *CheckEnv, owner string, ty int, tys *TyArena) {
+	registerPlainReturnNullary(env, owner, ty, "toInt", tInt(tys))
+	registerResultReturnNullary(env, owner, ty, "toInt8", tInt8(tys), tys)
+	registerResultReturnNullary(env, owner, ty, "toInt16", tInt16(tys), tys)
+	registerResultReturnNullary(env, owner, ty, "toInt32", tInt32(tys), tys)
+	registerPlainReturnNullary(env, owner, ty, "toInt64", tInt64(tys))
+	registerResultReturnNullary(env, owner, ty, "toUInt8", tUInt8(tys), tys)
+	registerPlainReturnNullary(env, owner, ty, "toByte", tByte(tys))
+	registerResultReturnNullary(env, owner, ty, "toUInt16", tUInt16(tys), tys)
+	registerResultReturnNullary(env, owner, ty, "toUInt32", tUInt32(tys), tys)
+	registerResultReturnNullary(env, owner, ty, "toUInt64", tUInt64(tys), tys)
+	registerPlainReturnNullary(env, owner, ty, "toFloat", tFloat(tys))
+	registerPlainReturnNullary(env, owner, ty, "toFloat32", tFloat32(tys))
+	registerPlainReturnNullary(env, owner, ty, "toFloat64", tFloat64(tys))
+	registerPlainReturnNullary(env, owner, ty, "toChar", tChar(tys))
 }
 
 func registerStdMathModule(env *CheckEnv) {
@@ -220,6 +288,20 @@ func registerSelfShapedBinary(env *CheckEnv, owner string, ty int, name, paramNa
 	})
 }
 
+func registerSelfIntUnary(env *CheckEnv, owner string, ty int, name, paramName string) {
+	checkRegisterFn(env, &CheckFnSig{
+		name:          name,
+		owner:         owner,
+		receiverTy:    ty,
+		hasReceiver:   true,
+		retTy:         ty,
+		paramNames:    []string{paramName},
+		paramTys:      []int{tInt(env.tys)},
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+}
+
 func registerSelfShapedClamp(env *CheckEnv, owner string, ty int) {
 	checkRegisterFn(env, &CheckFnSig{
 		name:          "clamp",
@@ -229,6 +311,48 @@ func registerSelfShapedClamp(env *CheckEnv, owner string, ty int) {
 		retTy:         ty,
 		paramNames:    []string{"lo", "hi"},
 		paramTys:      []int{ty, ty},
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+}
+
+func registerOptionalSelfNullary(env *CheckEnv, owner string, ty int, name string) {
+	checkRegisterFn(env, &CheckFnSig{
+		name:          name,
+		owner:         owner,
+		receiverTy:    ty,
+		hasReceiver:   true,
+		retTy:         tyOptional(env.tys, ty),
+		paramNames:    make([]string, 0, 1),
+		paramTys:      make([]int, 0, 1),
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+}
+
+func registerOptionalSelfBinary(env *CheckEnv, owner string, ty int, name, paramName string) {
+	checkRegisterFn(env, &CheckFnSig{
+		name:          name,
+		owner:         owner,
+		receiverTy:    ty,
+		hasReceiver:   true,
+		retTy:         tyOptional(env.tys, ty),
+		paramNames:    []string{paramName},
+		paramTys:      []int{ty},
+		generics:      make([]string, 0, 1),
+		genericBounds: make([]*CheckGenericBound, 0, 1),
+	})
+}
+
+func registerOptionalSelfIntUnary(env *CheckEnv, owner string, ty int, name, paramName string) {
+	checkRegisterFn(env, &CheckFnSig{
+		name:          name,
+		owner:         owner,
+		receiverTy:    ty,
+		hasReceiver:   true,
+		retTy:         tyOptional(env.tys, ty),
+		paramNames:    []string{paramName},
+		paramTys:      []int{tInt(env.tys)},
 		generics:      make([]string, 0, 1),
 		genericBounds: make([]*CheckGenericBound, 0, 1),
 	})
@@ -291,12 +415,16 @@ func registerPlainReturnNullary(env *CheckEnv, owner string, ty int, name string
 }
 
 func registerResultIntErrorNullary(env *CheckEnv, owner string, ty int, name string, tys *TyArena) {
+	registerResultReturnNullary(env, owner, ty, name, tInt(tys), tys)
+}
+
+func registerResultReturnNullary(env *CheckEnv, owner string, ty int, name string, retValueTy int, tys *TyArena) {
 	checkRegisterFn(env, &CheckFnSig{
 		name:          name,
 		owner:         owner,
 		receiverTy:    ty,
 		hasReceiver:   true,
-		retTy:         tyNamed(tys, "Result", []int{tInt(tys), tyNamed(tys, "Error", make([]int, 0, 1))}),
+		retTy:         tyNamed(tys, "Result", []int{retValueTy, tyNamed(tys, "Error", make([]int, 0, 1))}),
 		paramNames:    make([]string, 0, 1),
 		paramTys:      make([]int, 0, 1),
 		generics:      make([]string, 0, 1),

--- a/internal/selfhost/std_testing_register.go
+++ b/internal/selfhost/std_testing_register.go
@@ -1,0 +1,105 @@
+package selfhost
+
+func registerStdTestingPropertyAliasFns(env *CheckEnv, alias string) {
+	tys := env.tys
+	tString_ := tString(tys)
+	tInt_ := tInt(tys)
+	tBool_ := tBool(tys)
+	tUnit_ := tUnit(tys)
+	tT := tyNamed(tys, "T", make([]int, 0, 1))
+	tGenT := tyNamed(tys, "Gen", []int{tT})
+	tFnTBool := tyFn(tys, []int{tT}, tBool_)
+	gT := []string{"T"}
+	emptyBounds := make([]*CheckGenericBound, 0, 1)
+
+	checkRegisterType(env, &CheckTypeSig{
+		name:          "Gen",
+		generics:      []string{"T"},
+		genericBounds: emptyBounds,
+		kind:          "struct",
+	})
+	checkRegisterFn(env, &CheckFnSig{
+		name:          "property",
+		owner:         alias,
+		receiverTy:    -1,
+		hasReceiver:   false,
+		retTy:         tUnit_,
+		paramNames:    []string{"name", "g", "pred"},
+		paramTys:      []int{tString_, tGenT, tFnTBool},
+		generics:      gT,
+		genericBounds: emptyBounds,
+	})
+	checkRegisterFn(env, &CheckFnSig{
+		name:          "propertyN",
+		owner:         alias,
+		receiverTy:    -1,
+		hasReceiver:   false,
+		retTy:         tUnit_,
+		paramNames:    []string{"name", "g", "iterations", "pred"},
+		paramTys:      []int{tString_, tGenT, tInt_, tFnTBool},
+		generics:      gT,
+		genericBounds: emptyBounds,
+	})
+	checkRegisterFn(env, &CheckFnSig{
+		name:          "propertySeeded",
+		owner:         alias,
+		receiverTy:    -1,
+		hasReceiver:   false,
+		retTy:         tUnit_,
+		paramNames:    []string{"name", "g", "seed", "pred"},
+		paramTys:      []int{tString_, tGenT, tInt_, tFnTBool},
+		generics:      gT,
+		genericBounds: emptyBounds,
+	})
+}
+
+func registerStdTestingGenAliasFns(env *CheckEnv, alias string) {
+	tys := env.tys
+	tInt_ := tInt(tys)
+	tBool_ := tBool(tys)
+	tString_ := tString(tys)
+	tT := tyNamed(tys, "T", make([]int, 0, 1))
+	tU := tyNamed(tys, "U", make([]int, 0, 1))
+	tA := tyNamed(tys, "A", make([]int, 0, 1))
+	tB := tyNamed(tys, "B", make([]int, 0, 1))
+	tC := tyNamed(tys, "C", make([]int, 0, 1))
+	tE := tyNamed(tys, "E", make([]int, 0, 1))
+	tGenT := tyNamed(tys, "Gen", []int{tT})
+	tGenU := tyNamed(tys, "Gen", []int{tU})
+	tGenA := tyNamed(tys, "Gen", []int{tA})
+	tGenB := tyNamed(tys, "Gen", []int{tB})
+	tGenC := tyNamed(tys, "Gen", []int{tC})
+	tGenE := tyNamed(tys, "Gen", []int{tE})
+	emptyGenerics := make([]string, 0, 1)
+	emptyBounds := make([]*CheckGenericBound, 0, 1)
+	gT := []string{"T"}
+
+	checkRegisterType(env, &CheckTypeSig{
+		name:          "Gen",
+		generics:      gT,
+		genericBounds: emptyBounds,
+		kind:          "struct",
+	})
+	for _, sig := range []*CheckFnSig{
+		{name: "int", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tInt_}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "intRange", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tInt_}), paramNames: []string{"lo", "hi"}, paramTys: []int{tInt_, tInt_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "bool", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tBool_}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "float", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tFloat64(tys)}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "char", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tChar(tys)}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "byte", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tByte(tys)}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: emptyGenerics, genericBounds: emptyBounds},
+		{name: "asciiString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tString_}), paramNames: []string{"maxLen"}, paramTys: []int{tInt_}, generics: emptyGenerics, genericBounds: emptyBounds},
+	} {
+		checkRegisterFn(env, sig)
+	}
+	checkRegisterFn(env, &CheckFnSig{name: "oneOf", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT, paramNames: []string{"choices"}, paramTys: []int{tyNamed(tys, "List", []int{tT})}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "map", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenU, paramNames: []string{"g", "f"}, paramTys: []int{tGenT, tyFn(tys, []int{tT}, tU)}, generics: []string{"T", "U"}, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "filter", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT, paramNames: []string{"g", "pred"}, paramTys: []int{tGenT, tyFn(tys, []int{tT}, tBool_)}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "pair", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyTuple(tys, []int{tA, tB})}), paramNames: []string{"a", "b"}, paramTys: []int{tGenA, tGenB}, generics: []string{"A", "B"}, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "triple", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyTuple(tys, []int{tA, tB, tC})}), paramNames: []string{"a", "b", "c"}, paramTys: []int{tGenA, tGenB, tGenC}, generics: []string{"A", "B", "C"}, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "list", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyNamed(tys, "List", []int{tT})}), paramNames: []string{"item", "maxLen"}, paramTys: []int{tGenT, tInt_}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "listOfSize", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyNamed(tys, "List", []int{tT})}), paramNames: []string{"item", "size"}, paramTys: []int{tGenT, tInt_}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "option", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyOptional(tys, tT)}), paramNames: []string{"item"}, paramTys: []int{tGenT}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "result", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", []int{tyNamed(tys, "Result", []int{tT, tE})}), paramNames: []string{"ok", "err"}, paramTys: []int{tGenT, tGenE}, generics: []string{"T", "E"}, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "constant", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT, paramNames: []string{"value"}, paramTys: []int{tT}, generics: gT, genericBounds: emptyBounds})
+	checkRegisterFn(env, &CheckFnSig{name: "oneOfGens", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT, paramNames: []string{"gens"}, paramTys: []int{tyNamed(tys, "List", []int{tGenT})}, generics: gT, genericBounds: emptyBounds})
+}

--- a/internal/selfhost/testdata/check_snapshots/basic-let.txt
+++ b/internal/selfhost/testdata/check_snapshots/basic-let.txt
@@ -5,6 +5,6 @@ typedNodes
 bindings
   id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=118 span=0:38 type=fn() -> ()
+  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=133 span=0:38 type=fn() -> ()
 instantiations
 diagnostics

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
@@ -3,16 +3,16 @@ errorsByContext E0702=1
 errorDetails E0702 no field `age` on type `User` @L4:C19=1
 typedNodes
   id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=118 kind=StructLit span=61:76 type=User
-  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=118 kind=Ident span=91:95 type=User
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=133 kind=StructLit span=61:76 type=User
+  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=133 kind=Ident span=91:95 type=User
   id=typed-node:fc919e5a0 nodeKey=node:4c84bd6cefe7767 typeKey=type:520c4bf26e2fabc node=13 nodeId=13 typeId=19 kind=Block span=39:101 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=118 span=49:53 type=User
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=133 span=49:53 type=User
   id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=118 span=0:28 type=User
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=133 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 node=14 nodeId=14 kind=fn name=main owner= typeId=119 span=29:101 type=fn() -> ()
+  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 node=14 nodeId=14 kind=fn name=main owner= typeId=134 span=29:101 type=fn() -> ()
 instantiations
 diagnostics
   code=E0702 severity=error span=95:99 line=4:19-4:23 message=no field `age` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
@@ -11,7 +11,7 @@ bindings
   id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 node=17 nodeId=17 kind=fn name=main owner= typeId=118 span=34:81 type=fn() -> ()
+  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 node=17 nodeId=17 kind=fn name=main owner= typeId=133 span=34:81 type=fn() -> ()
 instantiations
   id=instantiation:0e805f nodeKey=node:c75801d39c9edaa resultTypeKey=type:819354aa58f2166 instantiationId=0 node=14 nodeId=14 callee=id span=76:79 typeArgIds=[21] typeArgKeys=[type:819354aa58f2166] typeArgs=[UntypedInt] resultTypeId=21 resultType=UntypedInt
 diagnostics

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
@@ -6,21 +6,21 @@ typedNodes
   id=typed-node:3c357a296 nodeKey=node:9440cf586cde53e typeKey=type:27afd946bb3613d node=14 nodeId=14 typeId=17 kind=Call span=122:124 type=String
   id=typed-node:f9acd80ba nodeKey=node:e4abda096343b5c typeKey=type:27afd946bb3613d node=16 nodeId=16 typeId=17 kind=Block span=110:126 type=String
   id=typed-node:22c21819d nodeKey=node:09faed5a8f0e6ee typeKey=type:0cbe92b642f4e2f node=21 nodeId=21 typeId=2 kind=IntLit span=172:174 type=Int
-  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 node=23 nodeId=23 typeId=120 kind=StructLit span=165:176 type=User
-  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 node=28 nodeId=28 typeId=120 kind=Ident span=209:213 type=User
+  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 node=23 nodeId=23 typeId=135 kind=StructLit span=165:176 type=User
+  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 node=28 nodeId=28 typeId=135 kind=Ident span=209:213 type=User
   id=typed-node:985a6b5a7 nodeKey=node:3cc4b7378e4d535 typeKey=type:27afd946bb3613d node=29 nodeId=29 typeId=17 kind=Call span=208:214 type=String
   id=typed-node:eb39bd0b2 nodeKey=node:598cc8b8332a80c typeKey=type:520c4bf26e2fabc node=31 nodeId=31 typeId=19 kind=Block span=137:216 type=()
 bindings
-  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 node=18 nodeId=18 name=user mutable=false typeId=120 span=147:151 type=User
+  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 node=18 nodeId=18 name=user mutable=false typeId=135 span=147:151 type=User
   id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d bindingId=1 node=25 nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
 symbols
-  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 node=3 nodeId=3 kind=interface name=Named owner= typeId=118 span=0:43 type=Named
-  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 node=2 nodeId=2 kind=fn name=name owner=Named typeId=119 span=18:41 type=fn() -> String
-  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 node=6 nodeId=6 kind=struct name=User owner= typeId=120 span=44:68 type=User
+  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 node=3 nodeId=3 kind=interface name=Named owner= typeId=133 span=0:43 type=Named
+  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 node=2 nodeId=2 kind=fn name=name owner=Named typeId=134 span=18:41 type=fn() -> String
+  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 node=6 nodeId=6 kind=struct name=User owner= typeId=135 span=44:68 type=User
   id=symbol:01d01384e52f6 nodeKey=node:48daa8c06dff3ae typeKey=type:0cbe92b642f4e2f symbolId=3 node=5 nodeId=5 kind=field name=age owner=User typeId=2 span=58:66 type=Int
-  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 node=17 nodeId=17 kind=fn name=display owner= typeId=121 span=69:126 type=fn(T) -> String
-  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 node=32 nodeId=32 kind=fn name=main owner= typeId=122 span=127:216 type=fn() -> ()
+  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 node=17 nodeId=17 kind=fn name=display owner= typeId=136 span=69:126 type=fn(T) -> String
+  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 node=32 nodeId=32 kind=fn name=main owner= typeId=137 span=127:216 type=fn() -> ()
 instantiations
-  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 node=29 nodeId=29 callee=display span=208:214 typeArgIds=[120] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
+  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 node=29 nodeId=29 callee=display span=208:214 typeArgIds=[135] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
 diagnostics
   code=E0749 severity=error span=208:214 line=6:32-6:38 message=type parameter `T` requires bound `Named`, but `User` does not satisfy it

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
@@ -8,7 +8,7 @@ typedNodes
   id=typed-node:d1cd82bc0 nodeKey=node:4013449fff6a7f8 typeKey=type:0cbe92b642f4e2f node=4 nodeId=4 typeId=2 kind=Block span=29:39 type=Int
 bindings
 symbols
-  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 node=5 nodeId=5 kind=fn name=bad owner= typeId=118 span=13:39 type=fn() -> Int
+  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 node=5 nodeId=5 kind=fn name=bad owner= typeId=133 span=13:39 type=fn() -> Int
 instantiations
 diagnostics
   code=E0773 severity=error span=29:39 line=2:17-4:2 message=`#[intrinsic]` function `bad` must have an empty body

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
@@ -3,16 +3,16 @@ errorsByContext E0703=1
 errorDetails E0703 no method `label` on type `User` @L4:C21=1
 typedNodes
   id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=118 kind=StructLit span=61:76 type=User
-  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=118 kind=Ident span=93:97 type=User
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=133 kind=StructLit span=61:76 type=User
+  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=133 kind=Ident span=93:97 type=User
   id=typed-node:afa66bade nodeKey=node:e5353e717457cf8 typeKey=type:520c4bf26e2fabc node=14 nodeId=14 typeId=19 kind=Block span=39:107 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=118 span=49:53 type=User
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=133 span=49:53 type=User
   id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=118 span=0:28 type=User
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=133 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 node=15 nodeId=15 kind=fn name=main owner= typeId=119 span=29:107 type=fn() -> ()
+  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 node=15 nodeId=15 kind=fn name=main owner= typeId=134 span=29:107 type=fn() -> ()
 instantiations
 diagnostics
   code=E0703 severity=error span=97:103 line=4:21-4:27 message=no method `label` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
@@ -2,14 +2,14 @@ summary assignments=0 accepted=0 errors=1
 errorsByContext E0731=1
 errorDetails E0731 match is not exhaustive: missing `Option.Some(_)` @L2:C5=1
 typedNodes
-  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a node=4 nodeId=4 typeId=118 kind=Ident span=43:44 type=Option<Int>
+  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a node=4 nodeId=4 typeId=133 kind=Ident span=43:44 type=Option<Int>
   id=typed-node:68a6ad56e nodeKey=node:fd8a7b5bb1b9812 typeKey=type:0cbe92b642f4e2f node=7 nodeId=7 typeId=2 kind=IntLit span=67:68 type=Int
   id=typed-node:f658257e8 nodeKey=node:e113441d9af13f2 typeKey=type:0cbe92b642f4e2f node=10 nodeId=10 typeId=2 kind=IntLit span=86:87 type=Int
   id=typed-node:44bdcc86c nodeKey=node:0f2924b336195c7 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Match span=37:94 type=Int
   id=typed-node:6ae0146ac nodeKey=node:64e465f56c81267 typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=31:96 type=Int
 bindings
 symbols
-  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 node=15 nodeId=15 kind=fn name=code owner= typeId=119 span=0:96 type=fn(Option<Int>) -> Int
+  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 node=15 nodeId=15 kind=fn name=code owner= typeId=134 span=0:96 type=fn(Option<Int>) -> Int
 instantiations
 diagnostics
   code=E0731 severity=error span=37:94 line=2:5-5:6 message=match is not exhaustive: missing `Option.Some(_)`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
@@ -6,14 +6,14 @@ typedNodes
   id=typed-node:a08c373e0 nodeKey=node:9acea2dec56778f typeKey=type:0cbe92b642f4e2f node=1 nodeId=1 typeId=2 kind=IntLit span=21:22 type=Int
   id=typed-node:3841a2ccd nodeKey=node:eb04cb8f98779ee typeKey=type:0cbe92b642f4e2f node=3 nodeId=3 typeId=2 kind=Block span=19:24 type=Int
   id=typed-node:700baee84 nodeKey=node:c4e2dcbcd3d09ec typeKey=type:819354aa58f2166 node=8 nodeId=8 typeId=21 kind=IntLit span=65:66 type=UntypedInt
-  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 node=9 nodeId=9 typeId=119 kind=List span=64:67 type=List<UntypedInt>
+  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 node=9 nodeId=9 typeId=134 kind=List span=64:67 type=List<UntypedInt>
   id=typed-node:7e899069d nodeKey=node:650466afaa8a5a9 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Call span=78:80 type=Int
   id=typed-node:bff73e1c9 nodeKey=node:06207226247d8ec typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=49:82 type=Int
 bindings
-  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 node=7 nodeId=7 name=xs mutable=false typeId=119 span=59:61 type=List<UntypedInt>
+  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 node=7 nodeId=7 name=xs mutable=false typeId=134 span=59:61 type=List<UntypedInt>
 symbols
-  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 node=4 nodeId=4 kind=fn name=impure owner= typeId=118 span=0:24 type=fn() -> Int
-  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 node=15 nodeId=15 kind=fn name=bad owner= typeId=118 span=33:82 type=fn() -> Int
+  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 node=4 nodeId=4 kind=fn name=impure owner= typeId=133 span=0:24 type=fn() -> Int
+  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 node=15 nodeId=15 kind=fn name=bad owner= typeId=133 span=33:82 type=fn() -> Int
 instantiations
 diagnostics
   code=E0775 severity=error span=64:67 line=4:14-4:17 message=`#[pure]` function `bad` cannot allocate a list literal

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
@@ -7,7 +7,7 @@ typedNodes
 bindings
   id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=118 span=0:42 type=fn() -> ()
+  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=133 span=0:42 type=fn() -> ()
 instantiations
 diagnostics
   code=E0700 severity=error span=34:40 line=2:23-2:29 message=type mismatch: expected `Int`, found `String`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
@@ -5,7 +5,7 @@ typedNodes
   id=typed-node:ec3886d99 nodeKey=node:c936a377e1a93a2 typeKey=type:520c4bf26e2fabc node=2 nodeId=2 typeId=19 kind=Block span=10:25 type=()
 bindings
 symbols
-  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 node=3 nodeId=3 kind=fn name=main owner= typeId=118 span=0:25 type=fn() -> ()
+  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 node=3 nodeId=3 kind=fn name=main owner= typeId=133 span=0:25 type=fn() -> ()
 instantiations
 diagnostics
   code=E0745 severity=error span=16:23 line=2:5-2:12 message=cannot find `missing` in this scope

--- a/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
+++ b/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
@@ -9,7 +9,7 @@ bindings
   id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 node=16 nodeId=16 kind=fn name=main owner= typeId=118 span=34:73 type=fn() -> ()
+  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 node=16 nodeId=16 kind=fn name=main owner= typeId=133 span=34:73 type=fn() -> ()
 instantiations
   id=instantiation:7468aa nodeKey=node:81030ece726c8c2 resultTypeKey=type:0cbe92b642f4e2f instantiationId=0 node=13 nodeId=13 callee=id span=68:71 typeArgIds=[2] typeArgKeys=[type:0cbe92b642f4e2f] typeArgs=[Int] resultTypeId=2 resultType=Int
 diagnostics

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -340,6 +340,8 @@ fn collectUseDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
             // `use std.testing` (examples use this without an explicit alias,
             // so the alias defaults to "testing" via useDeclAliasName).
             registerStdTestingAliasFns(env, alias)
+        } else if node.text == "std.testing.gen" {
+            registerStdTestingGenAliasFns(env, alias)
         } else if node.text == "std.fs" {
             registerStdFsAliasFns(env, alias)
         } else if node.text == "std.debug" {
@@ -589,14 +591,20 @@ fn registerStdTestingAliasFns(env: CheckEnv, alias: String) {
     let tUnit_ = tUnit(tys)
     let tT = tyNamed(tys, "T", [])
     let tE = tyNamed(tys, "E", [])
+    let tGenT = tyNamed(tys, "Gen", [tT])
     let tResultTE = tyNamed(tys, "Result", [tT, tE])
     let tFnUnit = tyFn(tys, [], tUnit_)
     let tFnResUnit = tyFn(tys, [], tyNamed(tys, "Result", [tUnit_, tyNamed(tys, "Error", [])]))
+    let tFnTBool = tyFn(tys, [tT], tBool_)
 
     let emptyGenerics: List<String> = []
     let emptyBounds: List<CheckGenericBound> = []
     let gT: List<String> = ["T"]
     let gTE: List<String> = ["T", "E"]
+
+    checkRegisterType(env, CheckTypeSig {
+        name: "Gen", generics: gT, genericBounds: emptyBounds, kind: "struct",
+    })
 
     checkRegisterFn(env, CheckFnSig {
         name: "assert", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_,
@@ -652,6 +660,125 @@ fn registerStdTestingAliasFns(env: CheckEnv, alias: String) {
         name: "snapshot", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_,
         paramNames: ["name", "output"], paramTys: [tString_, tString_],
         generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "property", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_,
+        paramNames: ["name", "g", "pred"], paramTys: [tString_, tGenT, tFnTBool],
+        generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "propertyN", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_,
+        paramNames: ["name", "g", "iterations", "pred"], paramTys: [tString_, tGenT, tInt_, tFnTBool],
+        generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "propertySeeded", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tUnit_,
+        paramNames: ["name", "g", "seed", "pred"], paramTys: [tString_, tGenT, tInt_, tFnTBool],
+        generics: gT, genericBounds: emptyBounds,
+    })
+}
+
+fn registerStdTestingGenAliasFns(env: CheckEnv, alias: String) {
+    let tys = env.tys
+    let tInt_ = tInt(tys)
+    let tBool_ = tBool(tys)
+    let tString_ = tString(tys)
+    let tT = tyNamed(tys, "T", [])
+    let tU = tyNamed(tys, "U", [])
+    let tA = tyNamed(tys, "A", [])
+    let tB = tyNamed(tys, "B", [])
+    let tC = tyNamed(tys, "C", [])
+    let tE = tyNamed(tys, "E", [])
+    let tGenT = tyNamed(tys, "Gen", [tT])
+    let tGenU = tyNamed(tys, "Gen", [tU])
+    let tGenA = tyNamed(tys, "Gen", [tA])
+    let tGenB = tyNamed(tys, "Gen", [tB])
+    let tGenC = tyNamed(tys, "Gen", [tC])
+    let tGenE = tyNamed(tys, "Gen", [tE])
+    let emptyGenerics: List<String> = []
+    let emptyBounds: List<CheckGenericBound> = []
+    let gT: List<String> = ["T"]
+
+    checkRegisterType(env, CheckTypeSig {
+        name: "Gen", generics: gT, genericBounds: emptyBounds, kind: "struct",
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "int", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tInt_]),
+        paramNames: [], paramTys: [], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "intRange", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tInt_]),
+        paramNames: ["lo", "hi"], paramTys: [tInt_, tInt_], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "bool", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tBool_]),
+        paramNames: [], paramTys: [], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "float", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tFloat64(tys)]),
+        paramNames: [], paramTys: [], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "char", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tChar(tys)]),
+        paramNames: [], paramTys: [], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "byte", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tByte(tys)]),
+        paramNames: [], paramTys: [], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "asciiString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tyNamed(tys, "Gen", [tString_]),
+        paramNames: ["maxLen"], paramTys: [tInt_], generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "oneOf", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT,
+        paramNames: ["choices"], paramTys: [tyNamed(tys, "List", [tT])], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "map", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenU,
+        paramNames: ["g", "f"], paramTys: [tGenT, tyFn(tys, [tT], tU)], generics: ["T", "U"], genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "filter", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT,
+        paramNames: ["g", "pred"], paramTys: [tGenT, tyFn(tys, [tT], tBool_)], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "pair", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyTuple(tys, [tA, tB])]),
+        paramNames: ["a", "b"], paramTys: [tGenA, tGenB], generics: ["A", "B"], genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "triple", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyTuple(tys, [tA, tB, tC])]),
+        paramNames: ["a", "b", "c"], paramTys: [tGenA, tGenB, tGenC], generics: ["A", "B", "C"], genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "list", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyNamed(tys, "List", [tT])]),
+        paramNames: ["item", "maxLen"], paramTys: [tGenT, tInt_], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "listOfSize", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyNamed(tys, "List", [tT])]),
+        paramNames: ["item", "size"], paramTys: [tGenT, tInt_], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "option", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyOptional(tys, tT)]),
+        paramNames: ["item"], paramTys: [tGenT], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "result", owner: alias, receiverTy: -1, hasReceiver: false,
+        retTy: tyNamed(tys, "Gen", [tyNamed(tys, "Result", [tT, tE])]),
+        paramNames: ["ok", "err"], paramTys: [tGenT, tGenE], generics: ["T", "E"], genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "constant", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT,
+        paramNames: ["value"], paramTys: [tT], generics: gT, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "oneOfGens", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tGenT,
+        paramNames: ["gens"], paramTys: [tyNamed(tys, "List", [tGenT])], generics: gT, genericBounds: emptyBounds,
     })
 }
 

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -2153,7 +2153,7 @@ fn checkInstallErrorIntrinsics(env: CheckEnv) {
     // `Err(Error.new("..."))` resolves. Spec doesn't mandate a
     // specific name but this is the canonical form in demos.
     checkRegisterFn(env, CheckFnSig {
-        name: "new", owner: "Error", receiverTy: tError, hasReceiver: true, retTy: tError,
+        name: "new", owner: "Error", receiverTy: -1, hasReceiver: false, retTy: tError,
         paramNames: ["message"], paramTys: [tString_],
         generics: [], genericBounds: [],
     })
@@ -2303,6 +2303,7 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     let tListV = tyNamed(tys, "List", [tV])
     let tListChar = tyNamed(tys, "List", [tChar(tys)])
     let tListByte = tyNamed(tys, "List", [tByte(tys)])
+    let tListString = tyNamed(tys, "List", [tString(tys)])
     let tMapKV = tyNamed(tys, "Map", [tK, tV])
     let tBytes_ = tBytes(tys)
     let tOptT = tyOptional(tys, tT)
@@ -2367,6 +2368,11 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         name: "toString", owner: "List", receiverTy: tListT, hasReceiver: true, retTy: tString(tys),
         paramNames: [], paramTys: [],
         generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "join", owner: "List", receiverTy: tListString, hasReceiver: true, retTy: tString(tys),
+        paramNames: ["sep"], paramTys: [tString(tys)],
+        generics: [], genericBounds: [],
     })
 
     // ----- Map<K, V> intrinsics (spec §10.6) -----
@@ -3283,6 +3289,132 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         checkRegisterFn(env, CheckFnSig {
             name: "clamp", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: ty,
             paramNames: ["lo", "hi"], paramTys: [ty, ty],
+            generics: [], genericBounds: [],
+        })
+        for name in ["wrappingAdd", "wrappingSub", "wrappingMul", "wrappingDiv", "wrappingMod"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: ty,
+                paramNames: ["other"], paramTys: [ty],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["wrappingShl", "wrappingShr", "pow"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: ty,
+                paramNames: ["b"], paramTys: [tInt(tys)],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["wrappingAbs", "wrappingNeg"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: ty,
+                paramNames: [], paramTys: [],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["checkedAdd", "checkedSub", "checkedMul", "checkedDiv", "checkedMod"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tyOptional(tys, ty),
+                paramNames: ["other"], paramTys: [ty],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["checkedShl", "checkedShr"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tyOptional(tys, ty),
+                paramNames: ["b"], paramTys: [tInt(tys)],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["checkedAbs", "checkedNeg"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tyOptional(tys, ty),
+                paramNames: [], paramTys: [],
+                generics: [], genericBounds: [],
+            })
+        }
+        for name in ["saturatingAdd", "saturatingSub", "saturatingMul", "saturatingDiv"] {
+            checkRegisterFn(env, CheckFnSig {
+                name, owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: ty,
+                paramNames: ["other"], paramTys: [ty],
+                generics: [], genericBounds: [],
+            })
+        }
+        checkRegisterFn(env, CheckFnSig {
+            name: "toInt", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tInt(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toInt8", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tInt8(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toInt16", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tInt16(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toInt32", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tInt32(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toInt64", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tInt64(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toUInt8", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tUInt8(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toByte", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tByte(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toUInt16", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tUInt16(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toUInt32", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tUInt32(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toUInt64", owner: ownerName, receiverTy: ty, hasReceiver: true,
+            retTy: tyNamed(tys, "Result", [tUInt64(tys), tyNamed(tys, "Error", [])]),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toFloat", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tFloat(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toFloat32", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tFloat32(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toFloat64", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tFloat64(tys),
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+        checkRegisterFn(env, CheckFnSig {
+            name: "toChar", owner: ownerName, receiverTy: ty, hasReceiver: true, retTy: tChar(tys),
+            paramNames: [], paramTys: [],
             generics: [], genericBounds: [],
         })
         // toString — narrow widths share the i64 ABI on the LLVM side


### PR DESCRIPTION
## Summary
- teach native check workspace discovery to load an enclosing workspace when invoked from a member package
- register the missing checker surface for integer primitive methods/conversions, `List<String>.join`, `Error.new`, and `std.testing`/`std.testing.gen`
- update concurrency and url-health examples to current taskGroup, property, and time/type surfaces

## Validation
- `go build -o .bin/osty-codex ./cmd/osty`
- checked every `examples/**/osty.toml` package with `.bin/osty-codex check --no-airepair`
- `.bin/osty-codex ci .`
- `go list ./... | rg -v '^github\\.com/osty/osty/benchmarks/' | xargs go test -count=1 -vet=off -short`
- `.bin/osty-codex test --seed 0x1 --serial examples/int_control_e2e`
- `.bin/osty-codex test --seed 0x1 --serial examples/int_methods_e2e`
- `.bin/osty-codex test --seed 0x1 --serial examples/int_struct_e2e`