### PR TITLE
[codex] add tar stdlib module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 44 모듈. 분류 기준:
+총 47 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (41 / 44 = 93%)
+### ⭐⭐⭐⭐⭐ Production (45 / 47 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -38,11 +38,15 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | io | 541 | shim 171 | Reader/Writer 프로토콜, Buffer, copyN, readExact |
 | collections | 509 | list 68 + map 42 + set 17 | 30+ List 메서드, groupBy, windowed, zip3 |
 | email | 461 | pure Osty + encoding | Address / Message / MIME multipart / attachment base64 / SMTP DATA helpers |
+| grid | 412 | pure Osty | Point / Size / Rect / Direction / row-major Grid<T> |
+| tar | 408 | pure Osty + bytes | ustar encode/decode/list/extract + checksum validation |
+| xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
+| tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
 | csv | 351 | — | options-driven, header-aware decode |
-| xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
+| term | 320 | host-backed + pure ANSI | terminal mode/size/input declarations + ANSI sequence builders |
 | websocket | 322 | pure Osty + crypto/encoding | RFC 6455 accept key + handshake headers + frame encode/decode |
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
@@ -71,7 +75,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 44 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 47 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -85,8 +89,8 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | `db/sql`, `smtp transport`, `tar/zip`, `image` |
-| 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip/tar 계열 없음 |
+| 없는 모듈 | `db/sql`, `smtp transport`, `zip`, `image` |
+| 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip 계열 없음 |
 | 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
 
@@ -97,7 +101,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | HTTP 웹 서버 | ✅ 즉시 가능 | http + io + json + net |
 | CLI 도구 | ✅ 즉시 가능 | os + fs + io + fmt + env |
 | 데이터 처리 (CSV / JSON) | ✅ 즉시 가능 | csv + json + collections + iter + fmt |
-| 파일 변환기 | ✅ 가능 | fs + io + compress (gzip 만) + fmt |
+| 파일 변환기 / 아카이브 | ✅ 가능 | fs + io + tar + compress (gzip 만) + fmt |
 | 암호화 / 해시 | ✅ 가능 | crypto (sha256 / hmac / random / constantTimeEq) |
 | 랜덤 게임 / 시뮬레이션 | ✅ 가능 | random (seeded RNG) + math |
 | 수치 계산 | ✅ 가능 | math (sin / cos / log / exp / sqrt / pow / floor / ceil / clamp / hypot) |
@@ -112,6 +116,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | WebSocket handshake/frame | ✅ 가능 | websocket (accept key / headers / frame encode/decode) |
 | GraphQL 요청 생성 | ✅ 가능 | graphql (document builder / variables JSON body) |
 | 이메일/MIME 생성 | ✅ 가능 | email (address / MIME multipart / SMTP DATA helpers) |
+| TAR 아카이브 | ✅ 가능 | tar (ustar encode/decode/list/extract) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
@@ -121,7 +126,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 |---|---|---|
 | db / sql | DB 작업 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
 | smtp transport | 실제 SMTP 소켓 전송 / TLS | 중간 |
-| tar / zip | 아카이브 (compress 는 gzip 만) | 낮음 |
+| zip | 아카이브 (deflate/runtime 필요) | 낮음 |
 | image | 이미지 디코딩 | 낮음 |
 
 ## 4. Phase A / B 분리 패턴
@@ -141,7 +146,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 21 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, result, option, csv, xml, encoding, websocket, graphql, template, i18n, char, iter, bytes)
+- 25 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, grid, tar, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -210,7 +215,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db / smtp transport / archive / image) — *없는 모듈* 카테고리 채우기
+1. **새 모듈 추가** (db / smtp transport / zip / image) — *없는 모듈* 카테고리 채우기
 2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_tar_check_test.go
+++ b/internal/backend/stdlib_tar_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultTar(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "tar")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(tar) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("tar module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/tar.osty
+++ b/internal/stdlib/modules/tar.osty
@@ -1,0 +1,412 @@
+// std.tar - small ustar-compatible archive encoder and decoder.
+
+use std.bytes
+use std.error
+use std.strings
+
+pub enum EntryType {
+    File,
+    Directory,
+}
+
+pub struct Entry {
+    pub name: String,
+    pub kind: EntryType,
+    pub mode: Int,
+    pub mtime: Int,
+    pub data: Bytes,
+}
+
+pub fn file(name: String, data: Bytes) -> Result<Entry, Error> {
+    let clean = normalizeFileName(name)?
+    Ok(Entry {
+        name: clean,
+        kind: File,
+        mode: 0o644,
+        mtime: 0,
+        data: data,
+    })
+}
+
+pub fn directory(name: String) -> Result<Entry, Error> {
+    let clean = normalizeDirectoryName(name)?
+    Ok(Entry {
+        name: clean,
+        kind: Directory,
+        mode: 0o755,
+        mtime: 0,
+        data: bytes.fromString(""),
+    })
+}
+
+pub fn withMode(entry: Entry, mode: Int) -> Entry {
+    Entry {
+        name: entry.name,
+        kind: entry.kind,
+        mode: mode,
+        mtime: entry.mtime,
+        data: entry.data,
+    }
+}
+
+pub fn withMtime(entry: Entry, mtime: Int) -> Entry {
+    Entry {
+        name: entry.name,
+        kind: entry.kind,
+        mode: entry.mode,
+        mtime: mtime,
+        data: entry.data,
+    }
+}
+
+pub fn encode(entries: List<Entry>) -> Result<Bytes, Error> {
+    let mut out: List<Byte> = []
+    for entry in entries {
+        appendBytes(out, encodeEntry(entry)?)
+    }
+    appendZeroBlock(out)
+    appendZeroBlock(out)
+    Ok(bytes.from(out))
+}
+
+pub fn decode(archive: Bytes) -> Result<List<Entry>, Error> {
+    if archive.len() == 0 {
+        return Err(error.new("tar: empty archive"))
+    }
+    let mut out: List<Entry> = []
+    let mut pos = 0
+    for pos < archive.len() {
+        if pos + blockSize() > archive.len() {
+            return Err(error.new("tar: incomplete header block"))
+        }
+        if isZeroBlock(archive, pos) {
+            return Ok(out)
+        }
+        if !checksumValid(archive, pos) {
+            return Err(error.new("tar: header checksum mismatch"))
+        }
+        let name = readStringField(archive, pos, 100)
+        if name.isEmpty() {
+            return Err(error.new("tar: empty entry name"))
+        }
+        validateName(name)?
+        let mode = readOctalField(archive, pos + 100, 8)
+        let size = readOctalField(archive, pos + 124, 12)
+        let mtime = readOctalField(archive, pos + 136, 12)
+        let typeflag = byteAt(archive, pos + 156).toInt()
+        let kind = entryTypeFromFlag(typeflag)?
+        let dataStart = pos + blockSize()
+        let dataEnd = dataStart + size
+        if dataEnd > archive.len() {
+            return Err(error.new("tar: entry payload is truncated"))
+        }
+        let payload = if kind == Directory {
+            bytes.fromString("")
+        } else {
+            sliceBytes(archive, dataStart, dataEnd)
+        }
+        out.push(Entry {
+            name: name,
+            kind: kind,
+            mode: mode,
+            mtime: mtime,
+            data: payload,
+        })
+        pos = dataStart + paddedSize(size)
+    }
+    Ok(out)
+}
+
+pub fn list(archive: Bytes) -> Result<List<String>, Error> {
+    let entries = decode(archive)?
+    let mut out: List<String> = []
+    for entry in entries {
+        out.push(entry.name)
+    }
+    Ok(out)
+}
+
+pub fn extract(archive: Bytes, name: String) -> Result<Bytes?, Error> {
+    let entries = decode(archive)?
+    for entry in entries {
+        if entry.name == name && entry.kind == File {
+            return Ok(Some(entry.data))
+        }
+    }
+    Ok(None)
+}
+
+pub fn contains(archive: Bytes, name: String) -> Bool {
+    match list(archive) {
+        Ok(names) -> {
+            for item in names {
+                if item == name {
+                    return true
+                }
+            }
+            false
+        },
+        Err(_) -> false,
+    }
+}
+
+pub fn isArchive(data: Bytes) -> Bool {
+    match decode(data) {
+        Ok(_)  -> true,
+        Err(_) -> false,
+    }
+}
+
+fn encodeEntry(entry: Entry) -> Result<Bytes, Error> {
+    let name = if entry.kind == Directory {
+        normalizeDirectoryName(entry.name)?
+    } else {
+        normalizeFileName(entry.name)?
+    }
+    let size = if entry.kind == Directory { 0 } else { entry.data.len() }
+    let mut header = zeroBytes(blockSize())
+    writeStringField(header, 0, 100, name)
+    writeOctalField(header, 100, 8, entry.mode)
+    writeOctalField(header, 108, 8, 0)
+    writeOctalField(header, 116, 8, 0)
+    writeOctalField(header, 124, 12, size)
+    writeOctalField(header, 136, 12, entry.mtime)
+    for i in 148..156 {
+        header[i] = 0x20.toByte()
+    }
+    header[156] = entryTypeFlag(entry.kind).toByte()
+    writeStringField(header, 257, 6, "ustar")
+    writeStringField(header, 263, 2, "00")
+    writeStringField(header, 265, 32, "osty")
+    writeStringField(header, 297, 32, "osty")
+    writeOctalField(header, 148, 8, checksum(header))
+
+    let mut out: List<Byte> = []
+    for b in header {
+        out.push(b)
+    }
+    if entry.kind == File {
+        appendBytes(out, entry.data)
+        appendPadding(out, size)
+    }
+    Ok(bytes.from(out))
+}
+
+fn normalizeFileName(name: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(name)
+    validateName(clean)?
+    if strings.endsWith(clean, "/") {
+        return Err(error.new("tar: file name must not end with /"))
+    }
+    Ok(clean)
+}
+
+fn normalizeDirectoryName(name: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(name)
+    validateName(clean)?
+    if strings.endsWith(clean, "/") {
+        return Ok(clean)
+    }
+    Ok("{clean}/")
+}
+
+fn validateName(name: String) -> Result<(), Error> {
+    if name.isEmpty() {
+        return Err(error.new("tar: entry name is empty"))
+    }
+    if name.len() > 100 {
+        return Err(error.new("tar: entry name is too long"))
+    }
+    if strings.startsWith(name, "/") {
+        return Err(error.new("tar: absolute paths are not allowed"))
+    }
+    if name == ".." || strings.startsWith(name, "../") || strings.endsWith(name, "/..") || strings.contains(name, "/../") {
+        return Err(error.new("tar: parent path segments are not allowed"))
+    }
+    Ok(())
+}
+
+fn entryTypeFlag(kind: EntryType) -> Int {
+    match kind {
+        File      -> 0x30,
+        Directory -> 0x35,
+    }
+}
+
+fn entryTypeFromFlag(flag: Int) -> Result<EntryType, Error> {
+    if flag == 0 || flag == 0x30 {
+        return Ok(File)
+    }
+    if flag == 0x35 {
+        return Ok(Directory)
+    }
+    Err(error.new("tar: unsupported entry type"))
+}
+
+fn writeStringField(buf: List<Byte>, offset: Int, width: Int, value: String) {
+    let raw = value.bytes()
+    let mut i = 0
+    for i < width && i < raw.len() {
+        buf[offset + i] = raw[i]
+        i = i + 1
+    }
+}
+
+fn writeOctalField(buf: List<Byte>, offset: Int, width: Int, value: Int) {
+    let digits = toOctal(value)
+    let mut start = width - 1 - digits.len()
+    if start < 0 {
+        start = 0
+    }
+    let mut i = 0
+    for i < width {
+        buf[offset + i] = 0x30.toByte()
+        i = i + 1
+    }
+    i = 0
+    for i < digits.len() && start + i < width - 1 {
+        buf[offset + start + i] = digits[i].toInt().toByte()
+        i = i + 1
+    }
+    buf[offset + width - 1] = 0.toByte()
+}
+
+fn readStringField(data: Bytes, offset: Int, width: Int) -> String {
+    let mut out: List<Byte> = []
+    let mut i = 0
+    for i < width {
+        let b = byteAt(data, offset + i)
+        if b.toInt() == 0 {
+            return bytes.toString(bytes.from(out)).unwrap()
+        }
+        out.push(b)
+        i = i + 1
+    }
+    bytes.toString(bytes.from(out)).unwrap()
+}
+
+fn readOctalField(data: Bytes, offset: Int, width: Int) -> Int {
+    let mut value = 0
+    let mut i = 0
+    for i < width {
+        let n = byteAt(data, offset + i).toInt()
+        if n >= 0x30 && n <= 0x37 {
+            value = value * 8 + (n - 0x30)
+        }
+        i = i + 1
+    }
+    value
+}
+
+fn checksumValid(data: Bytes, offset: Int) -> Bool {
+    let expected = readOctalField(data, offset + 148, 8)
+    expected == checksumBlock(data, offset)
+}
+
+fn checksum(header: List<Byte>) -> Int {
+    let mut sum = 0
+    for b in header {
+        sum = sum + b.toInt()
+    }
+    sum
+}
+
+fn checksumBlock(data: Bytes, offset: Int) -> Int {
+    let mut sum = 0
+    let mut i = 0
+    for i < blockSize() {
+        if i >= 148 && i < 156 {
+            sum = sum + 0x20
+        } else {
+            sum = sum + byteAt(data, offset + i).toInt()
+        }
+        i = i + 1
+    }
+    sum
+}
+
+fn appendBytes(out: List<Byte>, data: Bytes) {
+    let mut i = 0
+    for i < data.len() {
+        out.push(byteAt(data, i))
+        i = i + 1
+    }
+}
+
+fn appendPadding(out: List<Byte>, size: Int) {
+    let pad = paddedSize(size) - size
+    let mut i = 0
+    for i < pad {
+        out.push(0.toByte())
+        i = i + 1
+    }
+}
+
+fn appendZeroBlock(out: List<Byte>) {
+    let mut i = 0
+    for i < blockSize() {
+        out.push(0.toByte())
+        i = i + 1
+    }
+}
+
+fn isZeroBlock(data: Bytes, offset: Int) -> Bool {
+    let mut i = 0
+    for i < blockSize() {
+        if byteAt(data, offset + i).toInt() != 0 {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn sliceBytes(data: Bytes, start: Int, end: Int) -> Bytes {
+    let mut out: List<Byte> = []
+    let mut i = start
+    for i < end {
+        out.push(byteAt(data, i))
+        i = i + 1
+    }
+    bytes.from(out)
+}
+
+fn zeroBytes(n: Int) -> List<Byte> {
+    let mut out: List<Byte> = []
+    let mut i = 0
+    for i < n {
+        out.push(0.toByte())
+        i = i + 1
+    }
+    out
+}
+
+fn paddedSize(n: Int) -> Int {
+    let rem = n % blockSize()
+    if rem == 0 {
+        return n
+    }
+    n + blockSize() - rem
+}
+
+fn toOctal(value: Int) -> String {
+    if value <= 0 {
+        return "0"
+    }
+    let mut n = value
+    let mut out = ""
+    for n > 0 {
+        let digit = n % 8
+        out = "{(0x30 + digit).toChar()}{out}"
+        n = n / 8
+    }
+    out
+}
+
+fn byteAt(data: Bytes, index: Int) -> Byte {
+    bytes.get(data, index).unwrap()
+}
+
+fn blockSize() -> Int {
+    512
+}

--- a/internal/stdlib/tar_test.go
+++ b/internal/stdlib/tar_test.go
@@ -1,0 +1,57 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestTarModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["tar"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.tar not loaded")
+	}
+	for _, name := range []string{"file", "directory", "withMode", "withMtime", "encode", "decode", "list", "extract", "contains", "isArchive"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.tar missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.tar.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.tar.%s not public", name)
+		}
+	}
+	for _, name := range []string{"EntryType", "Entry"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.tar missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.tar.%s not public", name)
+		}
+	}
+}
+
+func TestTarModuleSourcePinsUstarBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["tar"]
+	if mod == nil {
+		t.Fatal("std.tar module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn encode(entries: List<Entry>) -> Result<Bytes, Error>`,
+		`pub fn decode(archive: Bytes) -> Result<List<Entry>, Error>`,
+		`writeStringField(header, 257, 6, "ustar")`,
+		`writeOctalField(header, 148, 8, checksum(header))`,
+		`fn checksumBlock(data: Bytes, offset: Int) -> Int`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.tar source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `std.tar` with pure Osty ustar encode/decode/list/extract helpers.
- Validate tar headers with checksum checks and reject unsafe entry paths during encode/decode.
- Update `STDLIB_MATRIX.md` to remove tar from the missing archive bucket and correct matrix drift for existing grid/term/tui modules.

## Validation

- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultTar'`
- `just fmt-check`
- `git diff --check`