### PR TITLE
reduce frontend compatibility surface

### DIFF
--- a/cmd/osty/doctest_runner.go
+++ b/cmd/osty/doctest_runner.go
@@ -73,7 +73,8 @@ func appendDoctestCases(pkg *resolve.Package, filters []string) ([]nativeTestCas
 
 	runnerPath := filepath.Join(pkg.Dir, doctestRunnerFilename)
 	source := doctest.BuildRunnerSource(collected)
-	file, diags := parser.ParseDiagnostics(source)
+	parsed := parser.ParseDetailed(source)
+	file, diags := parsed.File, parsed.Diagnostics
 	if file == nil {
 		return nil, fmt.Errorf("parse doctest runner: %v", diags)
 	}
@@ -89,6 +90,7 @@ func appendDoctestCases(pkg *resolve.Package, filters []string) ([]nativeTestCas
 		CanonicalSource: canonicalSrc,
 		CanonicalMap:    canonicalMap,
 		File:            file,
+		Run:             parsed.Run,
 		ParseDiags:      diags,
 	})
 

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -8,39 +8,38 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/osty/osty/internal/ast"
-	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/manifest"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/stdlib"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // runLintPackage runs the lint pass over every .osty file in dir as a
 // single package so cross-file uses of `use` aliases and top-level
 // declarations don't trigger false "unused" warnings. Workspace mode
 // (dir-of-packages) runs lint per contained package via
-// runLintWorkspace. Single-package path loads arena-first (Phase 1c.2)
-// so parse goes through selfhost.Run; pf.File / canonical materialize
-// lazily for the Go resolver + linter until lint moves onto the
-// engine path in a later Phase 1c.5 slice.
+// runLintWorkspace. Both modes stay on the selfhost arena/native checker path
+// and only run lint from source, so public Go AST compatibility materializes
+// only if some unrelated legacy fallback asks for it.
 func runLintPackage(dir string, flags cliFlags) {
 	if isWorkspace(dir) {
 		runLintWorkspace(dir, flags)
 		return
 	}
-	pkg, err := resolve.LoadPackageArenaFirstWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags))
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	res := resolve.ResolvePackageDefault(pkg)
-	chk := check.Package(pkg, res, checkOpts())
-	cfg, cfgBase, hasCfg := loadLintConfigWithBase(dir)
-	outcome := runLintLoadedPackage(pkg, res, chk, flags, cfg, cfgBase, hasCfg)
+	frontendDiags, err := lintNativePackageDiagnostics(pkg, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)
+		os.Exit(1)
+	}
+	cfg, _, hasCfg := loadLintConfigWithBase(dir)
+	outcome := runLintLoadedPackage(pkg, frontendDiags, flags, cfg, hasCfg)
 	if outcome.anyErr || (flags.strict && outcome.anyWarn) {
 		os.Exit(1)
 	}
@@ -49,34 +48,32 @@ func runLintPackage(dir string, flags cliFlags) {
 // runLintWorkspace lints each package inside dir, aggregating diagnostics
 // so a single strict check covers the whole tree.
 func runLintWorkspace(dir string, flags cliFlags) {
-	ws, err := resolve.NewWorkspace(dir)
+	ws, err := loadNativeWorkspace(dir, "lint", flags)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	ws.SourceTransform = aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags)
-	ws.Stdlib = stdlib.LoadCached()
 	anyErr, anyWarn := false, false
-	runOne := func(path string) {
-		pkg, err := ws.LoadPackageArenaFirst(path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "osty: %v\n", err)
-			anyErr = true
-			return
+	for _, path := range nativeWorkspacePaths(ws) {
+		pkg := ws.Packages[path]
+		if pkg == nil {
+			continue
 		}
-		res := resolve.ResolvePackageDefault(pkg)
-		chk := check.Package(pkg, res, checkOpts())
-		cfg, cfgBase, hasCfg := loadLintConfigWithBase(pkg.Dir)
-		outcome := runLintLoadedPackage(pkg, res, chk, flags, cfg, cfgBase, hasCfg)
+		imports := check.PackageImportSurfacesForSelfhost(pkg, ws, ws.Stdlib)
+		frontendDiags, err := lintNativePackageDiagnostics(pkg, imports)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)
+			anyErr = true
+			continue
+		}
+		cfg, _, hasCfg := loadLintConfigWithBase(pkg.Dir)
+		outcome := runLintLoadedPackage(pkg, frontendDiags, flags, cfg, hasCfg)
 		if outcome.anyErr {
 			anyErr = true
 		}
 		if outcome.anyWarn {
 			anyWarn = true
 		}
-	}
-	for _, p := range resolve.WorkspacePackagePaths(dir) {
-		runOne(p)
 	}
 	if anyErr || (flags.strict && anyWarn) {
 		os.Exit(1)
@@ -90,23 +87,36 @@ type lintPackageOutcome struct {
 
 func runLintLoadedPackage(
 	pkg *resolve.Package,
-	res *resolve.PackageResult,
-	chk *check.Result,
+	frontendDiags []*diag.Diagnostic,
 	flags cliFlags,
 	cfg lint.Config,
-	cfgBase string,
 	hasCfg bool,
 ) lintPackageOutcome {
-	lr := lint.Package(pkg, res, chk)
+	lr := lint.Package(pkg, nil, nil)
 	if hasCfg {
 		lr = cfg.Apply(lr)
 	}
-	all := append(append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...), lr.Diags...)
+	all := append([]*diag.Diagnostic{}, frontendDiags...)
+	all = append(all, lr.Diags...)
 	printPackageDiags(pkg, all, flags)
 	if flags.fix || flags.fixDryRun {
 		applyPackageFixes(pkg, lr.Diags, flags)
 	}
 	return lintPackageOutcome{anyErr: hasError(all), anyWarn: hasWarning(all)}
+}
+
+func lintNativePackageDiagnostics(pkg *resolve.Package, imports []selfhost.PackageCheckImport) ([]*diag.Diagnostic, error) {
+	if pkg == nil {
+		return nil, nil
+	}
+	input := nativePackageCheckInput(pkg, imports)
+	checked, err := selfhost.CheckPackageStructured(input)
+	if err != nil {
+		return nil, err
+	}
+	diags := packageParseDiags(pkg)
+	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+	return diags, nil
 }
 
 // applyPackageFixes runs lint.ApplyFixes on each file in the package
@@ -174,25 +184,19 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 
 // runLintFile is the extracted `osty lint FILE` body (minus the
 // exclude-config early-return, which stays in the caller so the "skip"
-// message fires before parse work begins). Runs parse → resolveFile →
-// check.SelfhostFile → lint engine; handles --fix / --fix-dry-run
-// stdout/disk side-effects inside the function.
-//
-// Uses check.SelfhostFile (not check.File) since Phase 1c.5 — lint on
-// a single file never exercises the AST-level builder-desugar rewrite
-// (desugar runs on check.Package for multi-file auto-derive chains),
-// so the selfhost-direct entry shaves that pass without altering the
-// `*check.Result` shape the lint engine consumes.
+// message fires before parse work begins). It keeps the single-file path on
+// selfhost FrontendRun / structured checker output and runs lint from source,
+// so the command no longer materializes the public Go AST just to surface lint
+// diagnostics. Handles --fix / --fix-dry-run stdout/disk side-effects inside
+// the function.
 func runLintFile(path string, src []byte, formatter *diag.Formatter, flags cliFlags, lintCfg lint.Config, lintCfgOk bool) int {
-	parsed := parser.ParseDetailed(src)
-	file, parseDiags := parsed.File, parsed.Diagnostics
-	res := resolveFile(src, file)
-	chk := check.SelfhostFile(file, res, checkOptsForFile(path, canonical.Source(src, file)))
-	lr := runLintEngine(file, src, res, chk)
+	run := selfhost.Run(src)
+	chk := check.SelfhostRun(run, check.Opts{Source: src, Path: path})
+	lr := runLintEngine(src)
 	if lintCfgOk {
 		lr = lintCfg.Apply(lr)
 	}
-	all := append(append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...), chk.Diags...)
+	all := append([]*diag.Diagnostic{}, chk.Diags...)
 	all = append(all, lr.Diags...)
 	printDiags(formatter, all, flags)
 	if flags.fix || flags.fixDryRun {
@@ -221,8 +225,8 @@ func runLintFile(path string, src []byte, formatter *diag.Formatter, flags cliFl
 	}
 	return 0
 }
-func runLintEngine(file *ast.File, src []byte, res *resolve.Result, chk *check.Result) *lint.Result {
-	return lint.File(file, src, res, chk)
+func runLintEngine(src []byte) *lint.Result {
+	return lint.Source(src)
 }
 
 // loadLintConfigWithBase walks up from the target path collecting

--- a/cmd/osty/lint_native_test.go
+++ b/cmd/osty/lint_native_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestRunLintFileIsAstbridgeFree(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    x
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true}
+	formatter := newFormatter(path, src, flags)
+
+	restore := redirectStdoutStderr(t)
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runLintFile(path, src, formatter, flags, lint.Config{}, false)
+	restore()
+
+	if exit != 0 {
+		t.Fatalf("runLintFile exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runLintFile = %d, want 0", got)
+	}
+}
+
+func TestLintPackageNativeDiagnosticsIsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.osty"), []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.osty"), []byte(`fn main() {
+    let value = helper()
+    value
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := resolve.LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	selfhost.ResetAstbridgeLowerCount()
+	frontendDiags, err := lintNativePackageDiagnostics(pkg, nil)
+	if err != nil {
+		t.Fatalf("lintNativePackageDiagnostics: %v", err)
+	}
+	lintDiags := lint.Package(pkg, nil, nil).Diags
+	if hasError(append(frontendDiags, lintDiags...)) {
+		t.Fatalf("clean package produced diagnostics: frontend=%#v lint=%#v", frontendDiags, lintDiags)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after native package lint path = %d, want 0", got)
+	}
+}
+
+func redirectStdoutStderr(t *testing.T) func() {
+	t.Helper()
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+	return func() {
+		_ = wout.Close()
+		_ = werr.Close()
+		<-drained
+		<-drained
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -572,9 +572,9 @@ func runResolvePackageInner(dir string, flags cliFlags) int {
 		if res != nil {
 			return res
 		}
-		// Go-native resolver reads pf.File directly; materialize
-		// before calling so Run-only loaded files are lowered once.
-		pkg.EnsureFiles()
+		// Go-native resolver reads pf.File directly; materialize the
+		// explicit public-AST compatibility output before calling it.
+		pkg.MaterializePublicCompatibility()
 		res = resolve.ResolvePackageDefault(pkg)
 		return res
 	}
@@ -1644,6 +1644,7 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 			CanonicalSource: canonicalSrc,
 			CanonicalMap:    canonicalMap,
 			File:            parsed.File,
+			Run:             parsed.Run,
 			ParseDiags:      parsed.Diagnostics,
 			ParseProvenance: parsed.Provenance,
 		}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -167,6 +168,32 @@ func firstOpt(opts []Opts) Opts {
 		return Opts{}
 	}
 	return opts[0]
+}
+
+// SelfhostRun checks an existing selfhost FrontendRun without requiring a
+// public *ast.File or resolver Result. It returns the authoritative structured
+// checker result and diagnostics, but intentionally leaves the legacy
+// AST-keyed maps empty because there is no public AST to overlay onto.
+//
+// Use this for new front-end consumers that can stay on stable selfhost node
+// IDs. Keep SelfhostFile for compatibility paths that still need Types /
+// LetTypes / SymTypes keyed by Go AST and resolver symbols.
+func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
+	opt := firstOpt(opts)
+	result := newResult()
+	if run == nil {
+		return result
+	}
+	src := append([]byte(nil), opt.Source...)
+	result.inspectSource = append(result.inspectSource[:0], src...)
+	result.Diags = append(result.Diags, run.Diagnostics()...)
+	checked := selfhost.CheckStructuredFromRun(run)
+	policy := nativeDiagPolicy{privileged: opt.Privileged}
+	result.Diags = append(result.Diags, nativeCheckerDiags(src, checked, policy)...)
+	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
+	result.NativeCheckResult = cloneNativeCheckResult(checked)
+	diag.StampFile(result.Diags, opt.Path)
+	return result
 }
 
 // SelfhostFile runs type checking for one resolved source file through

--- a/internal/check/selfhost_run_test.go
+++ b/internal/check/selfhost_run_test.go
@@ -1,0 +1,28 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestSelfhostRunStaysOffPublicASTCompatibility(t *testing.T) {
+	src := []byte("fn main() {\n    let value = 1\n}\n")
+	run := parser.ParseRun(src)
+	if run == nil {
+		t.Fatal("ParseRun returned nil")
+	}
+
+	selfhost.ResetAstbridgeLowerCount()
+	result := SelfhostRun(run, Opts{Source: src})
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("SelfhostRun astbridge count = %d, want 0", got)
+	}
+	if result == nil || result.NativeCheckResult == nil {
+		t.Fatalf("SelfhostRun result = %#v, want structured native check result", result)
+	}
+	if len(result.NativeCheckResult.TypedNodes) == 0 && len(result.NativeCheckResult.Bindings) == 0 {
+		t.Fatalf("SelfhostRun native result is empty: %#v", result.NativeCheckResult)
+	}
+}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
@@ -45,7 +44,7 @@ var indentCache = strings.Repeat(Indent, cacheLevels)
 // best-effort AST when possible. Callers that want "format only clean
 // files" should inspect the returned diagnostics themselves.
 func Source(src []byte) ([]byte, []*diag.Diagnostic, error) {
-	_, diags := parser.ParseDiagnostics(src)
+	diags := selfhost.ParseDiagnostics(src)
 	for _, d := range diags {
 		if d.Severity == diag.Error {
 			return nil, diags, fmt.Errorf("cannot format file with parse errors")

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,33 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestSourceDoesNotMaterializePublicAST(t *testing.T) {
+	src := []byte(`fn main() {
+let x = 1
+x
+}
+`)
+
+	selfhost.ResetAstbridgeLowerCount()
+	out, diags, err := Source(src)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			t.Fatalf("Source diagnostics contained error: %#v", d)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("Source returned empty formatted output")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("Source astbridge count = %d, want 0", got)
+	}
+}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -21,18 +21,20 @@ type Result struct {
 	Diags []*diag.Diagnostic
 }
 
-// File runs the self-hosted lint pass over one resolved source file. rr and
-// chk are retained in the signature for callers that already have a complete
-// front-end result; the lint rules read the source through selfhost.
-func File(f *ast.File, src []byte, rr *resolve.Result, chk *check.Result) *Result {
-	if f == nil {
-		return &Result{}
-	}
-	_ = rr
-	_ = chk
+// Source runs the self-hosted lint pass over raw source. The Osty-authored lint
+// pass owns parsing and suppression handling, so callers that only need lint
+// diagnostics do not need to materialize the public Go AST.
+func Source(src []byte) *Result {
 	result := &Result{}
 	mergeSelfhostLint(result, src)
 	return result
+}
+
+// File runs the self-hosted lint pass over one source file. The AST / resolve /
+// check inputs are retained for compatibility with older front-end call sites,
+// but lint no longer treats the public Go AST as an authority input.
+func File(_ *ast.File, src []byte, _ *resolve.Result, _ *check.Result) *Result {
+	return Source(src)
 }
 
 // mergeSelfhostLint appends diagnostics from the Osty-authored lint pass
@@ -59,7 +61,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result)
 	}
 	res := &Result{}
 	for _, pf := range pkg.Files {
-		if pf == nil || pf.File == nil {
+		if pf == nil {
 			continue
 		}
 		local := &Result{}

--- a/internal/parser/frontend_authority_test.go
+++ b/internal/parser/frontend_authority_test.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestParseDetailedKeepsFrontendRunAndUsesExplicitPublicCompatibility(t *testing.T) {
+	src := []byte(`fn main() {
+    let items = [1]
+    let count = len(items)
+}
+`)
+
+	selfhost.ResetAstbridgeLowerCount()
+	result := ParseDetailed(src)
+	if len(result.Diagnostics) > 0 {
+		t.Fatalf("ParseDetailed diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if result.Run == nil {
+		t.Fatal("ParseDetailed Run = nil, want retained frontend run")
+	}
+	if result.File == nil {
+		t.Fatal("ParseDetailed File = nil, want public compatibility AST")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("ParseDetailed astbridge count = %d, want 0", got)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -18,6 +18,7 @@ type Error = diag.Diagnostic
 // foreign syntax was absorbed into canonical Osty.
 type Result struct {
 	File        *ast.File
+	Run         *selfhost.FrontendRun
 	Diagnostics []*diag.Diagnostic
 	Provenance  *Provenance
 }
@@ -43,7 +44,7 @@ func ParseDetailed(src []byte) Result {
 	run := pipeline.parseRun()
 	pipeline.applySourceCompat(run)
 	file, diags := selfhost.LowerPublicFileFromRun(run), run.Diagnostics()
-	return pipeline.result(file, diags)
+	return pipeline.result(run, file, diags)
 }
 
 // ParseCanonical parses trusted source and returns the public semantic AST

--- a/internal/parser/pipeline.go
+++ b/internal/parser/pipeline.go
@@ -38,9 +38,10 @@ func (p *parsePipeline) parseRun() *selfhost.FrontendRun {
 	return selfhost.Run(p.parsedSrc)
 }
 
-func (p *parsePipeline) result(file *ast.File, diags []*diag.Diagnostic) Result {
+func (p *parsePipeline) result(run *selfhost.FrontendRun, file *ast.File, diags []*diag.Diagnostic) Result {
 	return Result{
 		File:        file,
+		Run:         run,
 		Diagnostics: diags,
 		Provenance:  p.provenancePtr(),
 	}

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -13,20 +13,22 @@ import (
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/query"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 )
 
 // ---- Value types ----
 
-// ParseResult is the output of the [Parse] query — the AST plus any
-// lexer/parser diagnostics. The Source field holds the bytes the
-// parser consumed, enabling diagnostic rendering without re-reading
-// the file.
+// ParseResult is the output of the [Parse] query — the retained FrontendRun,
+// public-AST compatibility output, and any lexer/parser diagnostics. The
+// Source field holds the bytes the parser consumed, enabling diagnostic
+// rendering without re-reading the file.
 type ParseResult struct {
 	Source          []byte
 	CanonicalSource []byte
 	CanonicalMap    *sourcemap.Map
 	File            *ast.File
+	Run             *selfhost.FrontendRun
 	Diags           []*diag.Diagnostic
 	Provenance      *parser.Provenance
 }
@@ -205,7 +207,8 @@ func (wcr *WorkspaceCheckResult) Len() int {
 // Queries groups the derived query handles. Constructed once by
 // [NewEngine] and reused for the Database's lifetime.
 type Queries struct {
-	// Parse: (path) -> parsed AST + diagnostics.
+	// Parse: (path) -> retained FrontendRun + public AST compatibility output
+	// + diagnostics.
 	// Depends on: SourceText(path).
 	Parse *query.Query[string, ParseResult]
 
@@ -260,8 +263,10 @@ type Queries struct {
 	// Depends on: ResolveWorkspace(rootDir).
 	CheckWorkspace *query.Query[string, *WorkspaceCheckResult]
 
-	// LintFile: (path) -> lint diagnostics for one file.
-	// Depends on: Parse(path), ResolveFile(path), CheckFile(path).
+	// LintFile: (path) -> lint diagnostics for one file. The self-hosted
+	// lint pass owns parsing internally, so this query stays source-only and
+	// does not force public AST materialization through Parse.
+	// Depends on: SourceText(path).
 	LintFile *query.Query[string, *lint.Result]
 
 	// IdentIndex: (path) -> offset → resolver Symbol. Used by LSP
@@ -291,6 +296,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				CanonicalSource: canonicalSrc,
 				CanonicalMap:    canonicalMap,
 				File:            parsed.File,
+				Run:             parsed.Run,
 				Diags:           parsed.Diagnostics,
 				Provenance:      parsed.Provenance,
 			}
@@ -313,10 +319,10 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 	)
 
 	// BuildPackage has no hashFn: its output carries fresh
-	// *resolve.Package + *ast.File pointers every run and cannot be
-	// content-compared cheaply. Downstream ResolvePackage supplies
-	// the real cutoff via its semantic output hash, so BuildPackage
-	// just bumps computedAt on every rerun.
+	// *resolve.Package + FrontendRun / *ast.File pointers every run and
+	// cannot be content-compared cheaply. Downstream ResolvePackage supplies
+	// the real cutoff via its semantic output hash, so BuildPackage just bumps
+	// computedAt on every rerun.
 	qs.BuildPackage = query.Register(db, "BuildPackage",
 		func(ctx *query.Ctx, dir string) *resolve.Package {
 			files := inp.PackageFiles.Fetch(ctx, dir)
@@ -333,6 +339,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					CanonicalSource: pr.CanonicalSource,
 					CanonicalMap:    pr.CanonicalMap,
 					File:            pr.File,
+					Run:             pr.Run,
 					ParseDiags:      pr.Diags,
 					ParseProvenance: pr.Provenance,
 				})
@@ -348,7 +355,8 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			// Allocate a brand-new Package with copied PackageFile
 			// entries so resolve.ResolvePackage's in-place mutation
 			// doesn't corrupt the BuildPackage cache. We reuse the
-			// already-parsed *ast.File pointers — they are read-only.
+			// already-parsed FrontendRun / *ast.File pointers — they
+			// are read-only.
 			pkg := &resolve.Package{
 				Dir:   built.Dir,
 				Name:  built.Name,
@@ -361,6 +369,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					CanonicalSource: pf.CanonicalSource,
 					CanonicalMap:    pf.CanonicalMap,
 					File:            pf.File,
+					Run:             pf.Run,
 					ParseDiags:      pf.ParseDiags,
 					ParseProvenance: pf.ParseProvenance,
 				}
@@ -510,13 +519,8 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 
 	qs.LintFile = query.Register(db, "LintFile",
 		func(ctx *query.Ctx, path string) *lint.Result {
-			pr := qs.Parse.Fetch(ctx, path)
-			if pr.File == nil {
-				return &lint.Result{}
-			}
-			rr := qs.ResolveFile.Fetch(ctx, path)
-			chk := qs.CheckFile.Fetch(ctx, path)
-			return lint.File(pr.File, pr.Source, rr, chk)
+			src := inp.SourceText.Fetch(ctx, path)
+			return lint.Source(src)
 		},
 		hashLintResult,
 	)
@@ -661,10 +665,10 @@ func dirFromDotPath(root, dotPath string) string {
 
 // copyPackageForWorkspace creates a deep copy of a resolve.Package
 // suitable for passing to resolve.Workspace.ResolveAll. The original
-// package's *ast.File pointers are reused (they are read-only), but
-// the PackageFile slice and the Package struct itself are fresh so
-// ResolveAll's in-place mutation (setting PkgScope, RefsByID, etc.)
-// does not corrupt the BuildPackage cache.
+// package's FrontendRun / *ast.File pointers are reused (they are read-only),
+// but the PackageFile slice and the Package struct itself are fresh so
+// ResolveAll's in-place mutation (setting PkgScope, RefsByID, etc.) does not
+// corrupt the BuildPackage cache.
 func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 	if src == nil {
 		return nil
@@ -684,6 +688,7 @@ func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 			CanonicalSource: pf.CanonicalSource,
 			CanonicalMap:    pf.CanonicalMap,
 			File:            pf.File,
+			Run:             pf.Run,
 			ParseDiags:      pf.ParseDiags,
 			ParseProvenance: pf.ParseProvenance,
 		}

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -26,6 +26,9 @@ func TestParseMissThenHit(t *testing.T) {
 	if pr.File == nil {
 		t.Fatal("parse returned nil file")
 	}
+	if pr.Run == nil {
+		t.Fatal("parse returned nil FrontendRun")
+	}
 	after := eng.DB.Metrics().Sub(before)
 	if after.Misses == 0 {
 		t.Fatal("expected at least one miss on first parse")
@@ -38,11 +41,47 @@ func TestParseMissThenHit(t *testing.T) {
 	if pr2.File == nil {
 		t.Fatal("second parse returned nil file")
 	}
+	if pr2.Run == nil {
+		t.Fatal("second parse returned nil FrontendRun")
+	}
 	if after.Misses != 0 || after.Reruns != 0 {
 		t.Fatalf("cached call should not miss/rerun, got %+v", after)
 	}
 	if after.Hits == 0 {
 		t.Fatalf("cached call should hit, got %+v", after)
+	}
+}
+
+func TestBuildPackagePreservesFrontendRuns(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := NormalizePath("/tmp/pkg_run")
+	_ = seedFile(eng, dir, "main.osty", "pub fn main() { }\n")
+
+	pkg := eng.Queries.BuildPackage.Get(eng.DB, dir)
+	if pkg == nil || len(pkg.Files) != 1 {
+		t.Fatalf("BuildPackage returned %#v, want one file", pkg)
+	}
+	if pkg.Files[0].Run == nil {
+		t.Fatal("BuildPackage dropped FrontendRun; native consumers would be forced back through public AST")
+	}
+	if pkg.Files[0].File == nil {
+		t.Fatal("BuildPackage should still expose public AST compatibility output")
+	}
+}
+
+func TestLintFileDependsOnlyOnSourceText(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	path := seedFile(eng, "/tmp/pkg_lint_source", "main.osty", "pub fn main() { }\n")
+
+	before := eng.DB.Metrics()
+	_ = eng.Queries.LintFile.Get(eng.DB, path)
+	after := eng.DB.Metrics().Sub(before)
+	if after.Misses != 1 {
+		t.Fatalf("LintFile should compute without fetching Parse/Resolve/Check, got %+v", after)
 	}
 }
 

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -109,6 +109,7 @@ func loadPackagePaths(paths []string, dir, name string, transform SourceTransfor
 			CanonicalSource: canonicalSrc,
 			CanonicalMap:    canonicalMap,
 			File:            parsed.File,
+			Run:             parsed.Run,
 			ParseDiags:      parsed.Diagnostics,
 			ParseProvenance: parsed.Provenance,
 		})
@@ -178,13 +179,11 @@ func loadPackageNativePaths(paths []string, dir, name string, transform SourceTr
 	return pkg, nil
 }
 
-// LoadPackageArenaFirst is the recommended loader for CLI / pipeline /
-// LSP / cihost consumers that want the astbridge-free parse while still
-// handing downstream passes a Package with pf.File / pf.CanonicalSource
-// populated in the same shape LoadPackage produced. Internally it runs
-// LoadPackageForNative, EnsureFiles (lazy astbridge lowering per file),
-// and MaterializeCanonicalSources. Phase 1c.2 migration target — see
-// SELFHOST_PORT_MATRIX.md.
+// LoadPackageArenaFirst parses through the selfhost arena-first loader, then
+// explicitly materializes the public-AST compatibility surface expected by
+// legacy resolve/check/lint/codegen consumers. New native consumers should use
+// LoadPackageForNative and avoid this compatibility hop until they really need
+// pf.File / pf.CanonicalSource.
 func LoadPackageArenaFirst(dir string) (*Package, error) {
 	return LoadPackageArenaFirstWithTransform(dir, nil)
 }
@@ -196,23 +195,22 @@ func LoadPackageArenaFirstWithTransform(dir string, transform SourceTransform) (
 	if err != nil {
 		return nil, err
 	}
-	pkg.EnsureFiles()
+	pkg.MaterializePublicCompatibility()
 	pkg.MaterializeCanonicalSources()
 	return pkg, nil
 }
 
 // LoadPackageArenaFirst is the Workspace-level sibling of the
-// package-level LoadPackageArenaFirst. Delegates to LoadPackageNative
-// (arena-first parse + lazy *ast.File lowering) and then materializes
-// canonical sources so downstream consumers observe the full legacy
-// Package shape.
+// package-level LoadPackageArenaFirst. Delegates to LoadPackageNative, then
+// explicitly materializes public-AST compatibility output so downstream legacy
+// consumers observe the full Package shape.
 func (w *Workspace) LoadPackageArenaFirst(dotPath string) (*Package, error) {
 	pkg, err := w.LoadPackageNative(dotPath)
 	if err != nil {
 		return nil, err
 	}
 	if pkg != nil {
-		pkg.EnsureFiles()
+		pkg.MaterializePublicCompatibility()
 		pkg.MaterializeCanonicalSources()
 	}
 	return pkg, nil

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -134,10 +134,10 @@ func (pf *PackageFile) EnsureFile() *ast.File {
 	return pf.File
 }
 
-// EnsureFiles forces File materialization on every PackageFile in pkg.
-// Call this before any code path that reads pf.File directly (the
-// Go-native resolver, checker, linter).
-func (pkg *Package) EnsureFiles() {
+// MaterializePublicCompatibility forces File materialization on every
+// PackageFile in pkg through the explicit public-AST compatibility adapter.
+// Call this before a legacy code path that still reads pf.File directly.
+func (pkg *Package) MaterializePublicCompatibility() {
 	if pkg == nil {
 		return
 	}
@@ -146,10 +146,19 @@ func (pkg *Package) EnsureFiles() {
 	}
 }
 
+// EnsureFiles forces File materialization on every PackageFile in pkg.
+//
+// Deprecated: use MaterializePublicCompatibility at explicit public-AST
+// compatibility boundaries. Native front-end paths should keep consuming
+// PackageFile.Run / structured results instead.
+func (pkg *Package) EnsureFiles() {
+	pkg.MaterializePublicCompatibility()
+}
+
 // MaterializeCanonicalSources populates pf.CanonicalSource /
 // pf.CanonicalMap on every file in pkg when either is missing and a
 // lowered *ast.File is available. Needed after arena-first loading
-// (LoadPackageForNative → EnsureFiles) so consumers that project
+// (LoadPackageForNative → MaterializePublicCompatibility) so consumers that project
 // canonical-source spans (native checker bridge, seedgen, LSP query
 // engine) see the same shape LoadPackage's eager loader produces.
 //

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -1,0 +1,76 @@
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	selfhost.ResetAstbridgeLowerCount()
+
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after LoadPackageForNative: astbridge count = %d, want 0", got)
+	}
+	for _, pf := range pkg.Files {
+		if pf.Run == nil {
+			t.Fatalf("LoadPackageForNative left Run nil for %s", pf.Path)
+		}
+		if pf.File != nil {
+			t.Fatalf("LoadPackageForNative populated File for %s, want lazy public compatibility", pf.Path)
+		}
+	}
+
+	diags, err := NativeDiagnostics(pkg)
+	if err != nil {
+		t.Fatalf("NativeDiagnostics: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("clean package diagnostics = %#v, want none", diags)
+	}
+	rows, err := NativeResolutionRows(pkg, bPath)
+	if err != nil {
+		t.Fatalf("NativeResolutionRows: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("NativeResolutionRows returned no rows for helper reference")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after native package queries: astbridge count = %d, want 0", got)
+	}
+
+	pkg.MaterializePublicCompatibility()
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after MaterializePublicCompatibility: astbridge count = %d, want 0", got)
+	}
+	for _, pf := range pkg.Files {
+		if pf.File == nil {
+			t.Fatalf("MaterializePublicCompatibility left File nil for %s", pf.Path)
+		}
+	}
+
+	pkg.MaterializePublicCompatibility()
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("second MaterializePublicCompatibility: astbridge count = %d, want 0", got)
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -100,7 +100,7 @@ func ResolvePackage(pkg *Package, prelude *Scope) *PackageResult {
 	if !canResolveViaNative(pkg) {
 		return ResolvePackageFromAST(pkg, prelude)
 	}
-	pkg.EnsureFiles()
+	pkg.MaterializePublicCompatibility()
 	pkg.MaterializeCanonicalSources()
 	return resolvePackageViaNative(pkg, prelude)
 }
@@ -113,7 +113,7 @@ func ResolvePackageFromAST(pkg *Package, prelude *Scope) *PackageResult {
 	if pkg == nil {
 		return &PackageResult{}
 	}
-	pkg.EnsureFiles()
+	pkg.MaterializePublicCompatibility()
 	r := newPkgResolver(pkg, prelude)
 	r.declarePass(pkg)
 	r.bodyPass(pkg)

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -24,6 +24,14 @@ Authority rule:
 - `FrontendRun.File()` is deprecated for production code. If a legacy consumer
   still needs public AST shape, use `LowerPublicFileFromRun()` at that explicit
   boundary so the compatibility hop is visible and searchable.
+- Package-level code should keep `PackageFile.Run` / structured results where
+  possible. If a legacy package consumer still needs `PackageFile.File`, call
+  `MaterializePublicCompatibility()` at that boundary rather than hiding the
+  hop inside native loaders.
+- Self-hosted source passes that do their own parsing, such as lint and
+  format, should accept source/structured inputs directly. They should not
+  fetch Parse or require `PackageFile.File` just to satisfy an old adapter
+  signature.
 
 The exact merged Osty inputs live in
 [`internal/selfhost/bundle/bundle.go`](./bundle/bundle.go):


### PR DESCRIPTION
## Summary
- Retain FrontendRun through parser/query/package paths and make public AST materialization explicit via MaterializePublicCompatibility.
- Add SelfhostRun for structured single-file checking without public AST overlay.
- Move lint and format source paths off public AST compatibility where they already self-parse.
- Preserve FrontendRun for selected gen/doctest synthetic package files.

## Verification
- go test -count=1 -vet=off ./internal/format ./internal/lint ./internal/query/osty ./internal/check ./internal/parser ./internal/resolve
- go test -count=1 -vet=off ./cmd/osty -run 'TestRunLintFileIsAstbridgeFree|TestLintPackageNativeDiagnosticsIsAstbridgeFree|TestRunCheckFileNativeIsAstbridgeFree|TestRunResolveFileHappyPathIsAstbridgeFree|TestLintFix'
- git diff --check

Note: A broader just front run was intentionally stopped after the first two e2e groups when we switched to fast publish/merge; focused authority checks above passed.