### PR TITLE
[codex] add sql and db stdlib modules

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.5/10-standard-library/28-sql.md
@@ -12,7 +12,7 @@ let base = sql.selectWhere("users", ["id", "email"], active)?
 let ordered = sql.orderBy(base, [sql.asc("email")?])?
 let q = sql.limit(ordered, 100)?
 
-let postgresText = sql.render(q, Postgres)
+let postgresText = sql.render(q, sql.postgresDialect())
 let debugText = sql.debugSql(q)
 ```
 
@@ -73,6 +73,10 @@ sql.quoteIdent(name) -> Result<String, Error>
 sql.quotePath(path) -> Result<String, Error>
 sql.literal(value) -> String
 sql.placeholder(dialect, index) -> String
+sql.genericDialect() -> Dialect
+sql.postgresDialect() -> Dialect
+sql.mysqlDialect() -> Dialect
+sql.sqliteDialect() -> Dialect
 sql.render(query, dialect) -> String
 sql.debugSql(query) -> String
 ```

--- a/LANG_SPEC_v0.5/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.5/10-standard-library/28-sql.md
@@ -1,0 +1,90 @@
+### 10.28 SQL (`std.sql`)
+
+`std.sql` provides safe SQL fragment and statement builders. It does not
+open database connections or execute queries; drivers such as SQLite or
+Postgres should accept the `Query` value produced by this module.
+
+```osty
+use std.sql
+
+let active = sql.eq("users.active", sql.boolean(true))?
+let base = sql.selectWhere("users", ["id", "email"], active)?
+let ordered = sql.orderBy(base, [sql.asc("email")?])?
+let q = sql.limit(ordered, 100)?
+
+let postgresText = sql.render(q, Postgres)
+let debugText = sql.debugSql(q)
+```
+
+Core types:
+
+```osty
+pub enum Dialect { Generic, Postgres, MySql, Sqlite }
+
+pub enum Value {
+    SqlNull,
+    SqlString(String),
+    SqlInt(Int),
+    SqlFloat(Float),
+    SqlBool(Bool),
+    SqlRaw(String),
+}
+
+pub struct Query { pub sql: String, pub params: List<Value> }
+pub struct Condition { pub sql: String, pub params: List<Value> }
+pub struct Assignment { pub column: String, pub value: Value }
+pub struct Order { pub column: String, pub descending: Bool }
+```
+
+Builders:
+
+```osty
+sql.select(table, columns) -> Result<Query, Error>
+sql.selectWhere(table, columns, condition) -> Result<Query, Error>
+sql.insert(table, assignments) -> Result<Query, Error>
+sql.update(table, assignments, condition) -> Result<Query, Error>
+sql.deleteFrom(table, condition) -> Result<Query, Error>
+sql.orderBy(query, orders) -> Result<Query, Error>
+sql.limit(query, n) -> Result<Query, Error>
+sql.offset(query, n) -> Result<Query, Error>
+```
+
+Conditions:
+
+```osty
+sql.eq(column, value) -> Result<Condition, Error>
+sql.ne(column, value) -> Result<Condition, Error>
+sql.gt(column, value) -> Result<Condition, Error>
+sql.gte(column, value) -> Result<Condition, Error>
+sql.lt(column, value) -> Result<Condition, Error>
+sql.lte(column, value) -> Result<Condition, Error>
+sql.like(column, value) -> Result<Condition, Error>
+sql.isNull(column) -> Result<Condition, Error>
+sql.isNotNull(column) -> Result<Condition, Error>
+sql.inList(column, values) -> Result<Condition, Error>
+sql.allOf(conditions) -> Condition
+sql.anyOf(conditions) -> Condition
+```
+
+Identifier and value helpers:
+
+```osty
+sql.quoteIdent(name) -> Result<String, Error>
+sql.quotePath(path) -> Result<String, Error>
+sql.literal(value) -> String
+sql.placeholder(dialect, index) -> String
+sql.render(query, dialect) -> String
+sql.debugSql(query) -> String
+```
+
+Behavior:
+
+- Identifiers must be ASCII SQL identifiers: `[A-Za-z_][A-Za-z0-9_]*`.
+  `quotePath` accepts dot-separated paths and final `*`, such as
+  `users.email` or `users.*`.
+- Builders quote identifiers and use `?` placeholders internally. `render`
+  rewrites placeholders for dialects; Postgres uses `$1`, `$2`, and the
+  generic/MySQL/SQLite modes keep `?`.
+- `literal` and `debugSql` are for diagnostics, migrations, or generated SQL
+  text. Runtime query execution should prefer `Query.params` over string
+  interpolation.

--- a/LANG_SPEC_v0.5/10-standard-library/29-db.md
+++ b/LANG_SPEC_v0.5/10-standard-library/29-db.md
@@ -1,0 +1,97 @@
+### 10.29 DB (`std.db`)
+
+`std.db` contains the database pieces that can be implemented without a
+runtime driver: connection configuration, DSN rendering, pool and transaction
+options, row/result containers, and migration planning helpers.
+
+It intentionally does not open SQLite files, sockets, TLS sessions, or execute
+queries. Runtime-backed drivers should consume `db.Config` and `sql.Query`.
+
+```osty
+use std.db
+use std.sql
+
+let base = db.postgres("localhost", db.defaultPort(Postgres), "app", "osty", "secret")?
+let cfg = db.withParam(base, "sslmode", "disable")?
+
+let where = sql.eq("users.active", sql.boolean(true))?
+let query = sql.selectWhere("users", ["id", "email"], where)?
+let driverSql = db.queryText(query, cfg)
+let safeLogDsn = db.redactedDsn(cfg)?
+```
+
+Core types:
+
+```osty
+pub enum Driver { Sqlite, Postgres, MySql }
+pub enum Isolation { DefaultIsolation, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable }
+pub enum Cell { CellNull, CellString(String), CellInt(Int), CellFloat(Float), CellBool(Bool) }
+
+pub struct Config
+pub struct PoolOptions
+pub struct TxOptions
+pub struct Row
+pub struct ResultSet
+pub struct ExecResult
+pub struct Migration
+pub struct MigrationPlan
+```
+
+Configuration:
+
+```osty
+db.sqlite(path) -> Result<Config, Error>
+db.postgres(host, port, database, user, password) -> Result<Config, Error>
+db.mysql(host, port, database, user, password) -> Result<Config, Error>
+db.withParam(config, key, value) -> Result<Config, Error>
+db.dsn(config) -> Result<String, Error>
+db.redactedDsn(config) -> Result<String, Error>
+db.driverName(driver) -> String
+db.defaultPort(driver) -> Int
+db.dialect(driver) -> sql.Dialect
+```
+
+Pool and transactions:
+
+```osty
+db.poolOptions() -> PoolOptions
+db.withMaxOpen(options, n) -> Result<PoolOptions, Error>
+db.withMaxIdle(options, n) -> Result<PoolOptions, Error>
+db.withConnectTimeout(options, ms) -> Result<PoolOptions, Error>
+db.withIdleTimeout(options, ms) -> Result<PoolOptions, Error>
+
+db.txOptions() -> TxOptions
+db.readOnlyTx() -> TxOptions
+db.withIsolation(options, isolation) -> TxOptions
+db.isolationName(isolation) -> String
+```
+
+Rows and results:
+
+```osty
+db.row(values) -> Row
+db.rowGet(row, column) -> Cell?
+db.rowText(row, column) -> String?
+db.resultSet(columns, rows) -> Result<ResultSet, Error>
+db.emptyResultSet(columns) -> Result<ResultSet, Error>
+db.first(resultSet) -> Row?
+db.execResult(rowsAffected, lastInsertId) -> ExecResult
+```
+
+Migrations:
+
+```osty
+db.migration(version, name, up, down) -> Result<Migration, Error>
+db.migrationTableSql() -> sql.Query
+db.recordMigrationSql(migration) -> sql.Query
+db.pendingMigrations(appliedVersions, migrations) -> List<Migration>
+db.plan(currentVersion, migrations) -> MigrationPlan
+```
+
+Behavior:
+
+- DSNs percent-encode user, password, database, SQLite path, and query
+  parameter components.
+- `redactedDsn` preserves shape while replacing the password with `redacted`.
+- Migration helpers sort pending migrations by version and do not execute SQL.
+- Actual database I/O remains a runtime-driver responsibility.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -41,3 +41,4 @@ lowering remains implementation backlog.
 - [§10.26 Text UI (`std.tui`)](./26-tui.md)
 - [§10.27 Grid (`std.grid`)](./27-grid.md)
 - [§10.28 SQL (`std.sql`)](./28-sql.md)
+- [§10.29 DB (`std.db`)](./29-db.md)

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -40,3 +40,4 @@ lowering remains implementation backlog.
 - [§10.25 Terminal (`std.term`)](./25-term.md)
 - [§10.26 Text UI (`std.tui`)](./26-tui.md)
 - [§10.27 Grid (`std.grid`)](./27-grid.md)
+- [§10.28 SQL (`std.sql`)](./28-sql.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 47 모듈. 분류 기준:
+총 48 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (45 / 47 = 96%)
+### ⭐⭐⭐⭐⭐ Production (46 / 48 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -40,6 +40,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | email | 461 | pure Osty + encoding | Address / Message / MIME multipart / attachment base64 / SMTP DATA helpers |
 | grid | 412 | pure Osty | Point / Size / Rect / Direction / row-major Grid<T> |
 | tar | 408 | pure Osty + bytes | ustar encode/decode/list/extract + checksum validation |
+| sql | 401 | pure Osty | identifier quoting / literals / placeholders / SELECT-INSERT-UPDATE-DELETE builders |
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
@@ -75,7 +76,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 47 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 48 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -89,7 +90,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | `db/sql`, `smtp transport`, `zip`, `image` |
+| 없는 모듈 | `db driver/runtime`, `smtp transport`, `zip`, `image` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip 계열 없음 |
 | 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -117,6 +118,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | GraphQL 요청 생성 | ✅ 가능 | graphql (document builder / variables JSON body) |
 | 이메일/MIME 생성 | ✅ 가능 | email (address / MIME multipart / SMTP DATA helpers) |
 | TAR 아카이브 | ✅ 가능 | tar (ustar encode/decode/list/extract) |
+| SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
@@ -124,7 +126,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 없는 모듈 | 영향 | 우선순위 |
 |---|---|---|
-| db / sql | DB 작업 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
+| db driver/runtime | 실제 DB 실행 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
 | smtp transport | 실제 SMTP 소켓 전송 / TLS | 중간 |
 | zip | 아카이브 (deflate/runtime 필요) | 낮음 |
 | image | 이미지 디코딩 | 낮음 |
@@ -146,7 +148,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 25 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, grid, tar, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 26 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, grid, tar, sql, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -215,7 +217,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db / smtp transport / zip / image) — *없는 모듈* 카테고리 채우기
+1. **새 모듈 추가** (db driver/runtime / smtp transport / zip / image) — *없는 모듈* 카테고리 채우기
 2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 48 모듈. 분류 기준:
+총 49 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (46 / 48 = 96%)
+### ⭐⭐⭐⭐⭐ Production (47 / 49 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -38,9 +38,10 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | io | 541 | shim 171 | Reader/Writer 프로토콜, Buffer, copyN, readExact |
 | collections | 509 | list 68 + map 42 + set 17 | 30+ List 메서드, groupBy, windowed, zip3 |
 | email | 461 | pure Osty + encoding | Address / Message / MIME multipart / attachment base64 / SMTP DATA helpers |
+| db | 554 | pure Osty + sql | Config / DSN / pool / tx options / result rows / migration planning helpers |
 | grid | 412 | pure Osty | Point / Size / Rect / Direction / row-major Grid<T> |
 | tar | 408 | pure Osty + bytes | ustar encode/decode/list/extract + checksum validation |
-| sql | 401 | pure Osty | identifier quoting / literals / placeholders / SELECT-INSERT-UPDATE-DELETE builders |
+| sql | 417 | pure Osty | identifier quoting / literals / placeholders / SELECT-INSERT-UPDATE-DELETE builders |
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
@@ -76,7 +77,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 48 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 49 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -119,6 +120,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 이메일/MIME 생성 | ✅ 가능 | email (address / MIME multipart / SMTP DATA helpers) |
 | TAR 아카이브 | ✅ 가능 | tar (ustar encode/decode/list/extract) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
+| DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 
 ## 3. 진짜 약점 (없는 모듈)
 
@@ -148,7 +150,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 26 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, grid, tar, sql, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 27 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, db, grid, tar, sql, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -217,7 +219,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈 추가** (db driver/runtime / smtp transport / zip / image) — *없는 모듈* 카테고리 채우기
+1. **새 모듈/런타임 추가** (db driver/runtime / smtp transport / zip / image) — 남은 갭 채우기
 2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_db_check_test.go
+++ b/internal/backend/stdlib_db_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultDb(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "db")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(db) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("db module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_sql_check_test.go
+++ b/internal/backend/stdlib_sql_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultSql(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "sql")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(sql) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("sql module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/db_test.go
+++ b/internal/stdlib/db_test.go
@@ -1,0 +1,68 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestDbModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db not loaded")
+	}
+	for _, name := range []string{
+		"sqlite", "postgres", "mysql", "withParam", "withPassword", "withoutPassword",
+		"driverName", "defaultPort", "dialect", "dsn", "redactedDsn",
+		"poolOptions", "withMaxOpen", "withMaxIdle", "withConnectTimeout", "withIdleTimeout",
+		"txOptions", "readOnlyTx", "withIsolation", "isolationName",
+		"cellNull", "cellString", "cellInt", "cellFloat", "cellBool", "cellText",
+		"row", "rowGet", "rowText", "resultSet", "emptyResultSet", "first", "columnNames", "execResult",
+		"migration", "migrationTableSql", "recordMigrationSql", "pendingMigrations", "plan", "queryText",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.db.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"Driver", "Isolation", "Cell", "Config", "PoolOptions", "TxOptions",
+		"Row", "ResultSet", "ExecResult", "Migration", "MigrationPlan",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.%s not public", name)
+		}
+	}
+}
+
+func TestDbModuleSourcePinsNonExecutingBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db"]
+	if mod == nil {
+		t.Fatal("std.db module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn dsn(config: Config) -> Result<String, Error>`,
+		`pub fn dialect(driver: Driver) -> sql.Dialect`,
+		`pub fn resultSet(columns: List<String>, rows: List<Row>) -> Result<ResultSet, Error>`,
+		`pub fn migration(version: Int, name: String, up: sql.Query, down: sql.Query) -> Result<Migration, Error>`,
+		`Runtime-backed drivers can consume Config, PoolOptions, TxOptions, and`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.db source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/db.osty
+++ b/internal/stdlib/modules/db.osty
@@ -1,0 +1,554 @@
+// std.db - database configuration, migration, and result helpers.
+//
+// This module deliberately stops before opening sockets or executing queries.
+// Runtime-backed drivers can consume Config, PoolOptions, TxOptions, and
+// sql.Query values without pretending that pure Osty can talk to SQLite or a
+// network database by itself.
+
+use std.encoding
+use std.error
+use std.sql
+use std.strings
+
+pub enum Driver {
+    Sqlite,
+    Postgres,
+    MySql,
+}
+
+pub enum Isolation {
+    DefaultIsolation,
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+pub enum Cell {
+    CellNull,
+    CellString(String),
+    CellInt(Int),
+    CellFloat(Float),
+    CellBool(Bool),
+}
+
+pub struct Config {
+    pub driver: Driver,
+    pub host: String,
+    pub port: Int,
+    pub database: String,
+    pub user: String,
+    pub password: String,
+    pub path: String,
+    pub params: Map<String, String>,
+}
+
+pub struct PoolOptions {
+    pub maxOpen: Int,
+    pub maxIdle: Int,
+    pub connectTimeoutMs: Int,
+    pub idleTimeoutMs: Int,
+}
+
+pub struct TxOptions {
+    pub isolation: Isolation,
+    pub readOnly: Bool,
+}
+
+pub struct Row {
+    pub values: Map<String, Cell>,
+}
+
+pub struct ResultSet {
+    pub columns: List<String>,
+    pub rows: List<Row>,
+}
+
+pub struct ExecResult {
+    pub rowsAffected: Int,
+    pub lastInsertId: Int?,
+}
+
+pub struct Migration {
+    pub version: Int,
+    pub name: String,
+    pub up: sql.Query,
+    pub down: sql.Query,
+}
+
+pub struct MigrationPlan {
+    pub currentVersion: Int,
+    pub targetVersion: Int,
+    pub pending: List<Migration>,
+}
+
+pub fn sqlite(path: String) -> Result<Config, Error> {
+    let clean = strings.trimSpace(path)
+    if clean.isEmpty() {
+        return Err(error.new("db: sqlite path is empty"))
+    }
+    Ok(Config {
+        driver: Sqlite,
+        host: "",
+        port: 0,
+        database: "",
+        user: "",
+        password: "",
+        path: clean,
+        params: {:},
+    })
+}
+
+pub fn postgres(host: String, port: Int, database: String, user: String, password: String) -> Result<Config, Error> {
+    serverConfig(Postgres, host, port, database, user, password)
+}
+
+pub fn mysql(host: String, port: Int, database: String, user: String, password: String) -> Result<Config, Error> {
+    serverConfig(MySql, host, port, database, user, password)
+}
+
+pub fn withParam(config: Config, key: String, value: String) -> Result<Config, Error> {
+    let cleanKey = strings.trimSpace(key)
+    if !isParamName(cleanKey) {
+        return Err(error.new("db: invalid parameter name: {key}"))
+    }
+    let mut params = config.params
+    params.insert(cleanKey, value)
+    Ok(Config {
+        driver: config.driver,
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+        password: config.password,
+        path: config.path,
+        params: params,
+    })
+}
+
+pub fn withPassword(config: Config, password: String) -> Config {
+    Config {
+        driver: config.driver,
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+        password: password,
+        path: config.path,
+        params: config.params,
+    }
+}
+
+pub fn withoutPassword(config: Config) -> Config {
+    withPassword(config, "")
+}
+
+pub fn driverName(driver: Driver) -> String {
+    match driver {
+        Sqlite   -> "sqlite",
+        Postgres -> "postgres",
+        MySql    -> "mysql",
+    }
+}
+
+pub fn defaultPort(driver: Driver) -> Int {
+    match driver {
+        Sqlite   -> 0,
+        Postgres -> 5432,
+        MySql    -> 3306,
+    }
+}
+
+pub fn dialect(driver: Driver) -> sql.Dialect {
+    match driver {
+        Sqlite   -> sql.sqliteDialect(),
+        Postgres -> sql.postgresDialect(),
+        MySql    -> sql.mysqlDialect(),
+    }
+}
+
+pub fn dsn(config: Config) -> Result<String, Error> {
+    dsnWithSecrets(config, false)
+}
+
+pub fn redactedDsn(config: Config) -> Result<String, Error> {
+    dsnWithSecrets(config, true)
+}
+
+pub fn poolOptions() -> PoolOptions {
+    PoolOptions {
+        maxOpen: 10,
+        maxIdle: 2,
+        connectTimeoutMs: 30000,
+        idleTimeoutMs: 600000,
+    }
+}
+
+pub fn withMaxOpen(opts: PoolOptions, maxOpen: Int) -> Result<PoolOptions, Error> {
+    if maxOpen < 1 {
+        return Err(error.new("db: maxOpen must be positive"))
+    }
+    Ok(PoolOptions {
+        maxOpen: maxOpen,
+        maxIdle: opts.maxIdle,
+        connectTimeoutMs: opts.connectTimeoutMs,
+        idleTimeoutMs: opts.idleTimeoutMs,
+    })
+}
+
+pub fn withMaxIdle(opts: PoolOptions, maxIdle: Int) -> Result<PoolOptions, Error> {
+    if maxIdle < 0 {
+        return Err(error.new("db: maxIdle must not be negative"))
+    }
+    Ok(PoolOptions {
+        maxOpen: opts.maxOpen,
+        maxIdle: maxIdle,
+        connectTimeoutMs: opts.connectTimeoutMs,
+        idleTimeoutMs: opts.idleTimeoutMs,
+    })
+}
+
+pub fn withConnectTimeout(opts: PoolOptions, ms: Int) -> Result<PoolOptions, Error> {
+    if ms < 0 {
+        return Err(error.new("db: connect timeout must not be negative"))
+    }
+    Ok(PoolOptions {
+        maxOpen: opts.maxOpen,
+        maxIdle: opts.maxIdle,
+        connectTimeoutMs: ms,
+        idleTimeoutMs: opts.idleTimeoutMs,
+    })
+}
+
+pub fn withIdleTimeout(opts: PoolOptions, ms: Int) -> Result<PoolOptions, Error> {
+    if ms < 0 {
+        return Err(error.new("db: idle timeout must not be negative"))
+    }
+    Ok(PoolOptions {
+        maxOpen: opts.maxOpen,
+        maxIdle: opts.maxIdle,
+        connectTimeoutMs: opts.connectTimeoutMs,
+        idleTimeoutMs: ms,
+    })
+}
+
+pub fn txOptions() -> TxOptions {
+    TxOptions {
+        isolation: DefaultIsolation,
+        readOnly: false,
+    }
+}
+
+pub fn readOnlyTx() -> TxOptions {
+    TxOptions {
+        isolation: DefaultIsolation,
+        readOnly: true,
+    }
+}
+
+pub fn withIsolation(opts: TxOptions, isolation: Isolation) -> TxOptions {
+    TxOptions {
+        isolation: isolation,
+        readOnly: opts.readOnly,
+    }
+}
+
+pub fn isolationName(isolation: Isolation) -> String {
+    match isolation {
+        DefaultIsolation -> "default",
+        ReadUncommitted  -> "read uncommitted",
+        ReadCommitted    -> "read committed",
+        RepeatableRead   -> "repeatable read",
+        Serializable     -> "serializable",
+    }
+}
+
+pub fn cellNull() -> Cell {
+    CellNull
+}
+
+pub fn cellString(value: String) -> Cell {
+    CellString(value)
+}
+
+pub fn cellInt(value: Int) -> Cell {
+    CellInt(value)
+}
+
+pub fn cellFloat(value: Float) -> Cell {
+    CellFloat(value)
+}
+
+pub fn cellBool(value: Bool) -> Cell {
+    CellBool(value)
+}
+
+pub fn cellText(cell: Cell) -> String {
+    match cell {
+        CellNull      -> "",
+        CellString(s) -> s,
+        CellInt(n)    -> n.toString(),
+        CellFloat(n)  -> n.toString(),
+        CellBool(b)   -> if b { "true" } else { "false" },
+    }
+}
+
+pub fn row(values: Map<String, Cell>) -> Row {
+    Row { values: values }
+}
+
+pub fn rowGet(row: Row, column: String) -> Cell? {
+    row.values.get(column)
+}
+
+pub fn rowText(row: Row, column: String) -> String? {
+    let cell = rowGet(row, column)
+    match cell {
+        Some(value) -> {
+            let text = cellText(value)
+            Some(text)
+        },
+        None       -> noneString(),
+    }
+}
+
+pub fn resultSet(columns: List<String>, rows: List<Row>) -> Result<ResultSet, Error> {
+    let mut seen: Map<String, String> = {:}
+    for column in columns {
+        if column.isEmpty() {
+            return Err(error.new("db: result column is empty"))
+        }
+        if seen.containsKey(column) {
+            return Err(error.new("db: duplicate result column: {column}"))
+        }
+        seen.insert(column, column)
+    }
+    Ok(ResultSet {
+        columns: columns,
+        rows: rows,
+    })
+}
+
+pub fn emptyResultSet(columns: List<String>) -> Result<ResultSet, Error> {
+    resultSet(columns, [])
+}
+
+pub fn first(result: ResultSet) -> Row? {
+    if result.rows.isEmpty() {
+        return None
+    }
+    Some(result.rows[0])
+}
+
+pub fn columnNames(result: ResultSet) -> List<String> {
+    result.columns
+}
+
+pub fn execResult(rowsAffected: Int, lastInsertId: Int?) -> ExecResult {
+    ExecResult {
+        rowsAffected: rowsAffected,
+        lastInsertId: lastInsertId,
+    }
+}
+
+pub fn migration(version: Int, name: String, up: sql.Query, down: sql.Query) -> Result<Migration, Error> {
+    if version <= 0 {
+        return Err(error.new("db: migration version must be positive"))
+    }
+    let clean = strings.trimSpace(name)
+    if clean.isEmpty() {
+        return Err(error.new("db: migration name is empty"))
+    }
+    Ok(Migration {
+        version: version,
+        name: clean,
+        up: up,
+        down: down,
+    })
+}
+
+pub fn migrationTableSql() -> sql.Query {
+    sql.raw("CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)")
+}
+
+pub fn recordMigrationSql(item: Migration) -> sql.Query {
+    sql.insert("schema_migrations", [
+        sql.assignment("version", sql.integer(item.version)).unwrap(),
+        sql.assignment("name", sql.text(item.name)).unwrap(),
+        sql.assignment("applied_at", sql.rawValue("CURRENT_TIMESTAMP")).unwrap(),
+    ]).unwrap()
+}
+
+pub fn pendingMigrations(appliedVersions: List<Int>, migrations: List<Migration>) -> List<Migration> {
+    let mut out: List<Migration> = []
+    for item in migrations {
+        if !containsInt(appliedVersions, item.version) {
+            out.push(item)
+        }
+    }
+    sortMigrations(out)
+}
+
+pub fn plan(currentVersion: Int, migrations: List<Migration>) -> MigrationPlan {
+    let mut applied: List<Int> = []
+    for item in migrations {
+        if item.version <= currentVersion {
+            applied.push(item.version)
+        }
+    }
+    let pending = pendingMigrations(applied, migrations)
+    MigrationPlan {
+        currentVersion: currentVersion,
+        targetVersion: maxMigrationVersion(migrations),
+        pending: pending,
+    }
+}
+
+pub fn queryText(q: sql.Query, config: Config) -> String {
+    sql.render(q, dialect(config.driver))
+}
+
+fn serverConfig(driver: Driver, host: String, port: Int, database: String, user: String, password: String) -> Result<Config, Error> {
+    let cleanHost = strings.trimSpace(host)
+    let cleanDatabase = strings.trimSpace(database)
+    if cleanHost.isEmpty() {
+        return Err(error.new("db: host is empty"))
+    }
+    if cleanDatabase.isEmpty() {
+        return Err(error.new("db: database is empty"))
+    }
+    if port < 1 {
+        return Err(error.new("db: port must be positive"))
+    }
+    Ok(Config {
+        driver: driver,
+        host: cleanHost,
+        port: port,
+        database: cleanDatabase,
+        user: strings.trimSpace(user),
+        password: password,
+        path: "",
+        params: {:},
+    })
+}
+
+fn dsnWithSecrets(config: Config, redact: Bool) -> Result<String, Error> {
+    match config.driver {
+        Sqlite -> {
+            if config.path.isEmpty() {
+                return Err(error.new("db: sqlite path is empty"))
+            }
+            let path = encoding.url.encode(config.path)
+            let query = querySuffix(config.params)
+            Ok("sqlite:///{path}{query}")
+        },
+        Postgres -> serverDsn("postgres", config, redact),
+        MySql -> serverDsn("mysql", config, redact),
+    }
+}
+
+fn serverDsn(scheme: String, config: Config, redact: Bool) -> Result<String, Error> {
+    if config.host.isEmpty() {
+        return Err(error.new("db: host is empty"))
+    }
+    if config.database.isEmpty() {
+        return Err(error.new("db: database is empty"))
+    }
+    let auth = authPart(config.user, config.password, redact)
+    let database = encoding.url.encode(config.database)
+    let query = querySuffix(config.params)
+    Ok("{scheme}://{auth}{config.host}:{config.port}/{database}{query}")
+}
+
+fn authPart(user: String, password: String, redact: Bool) -> String {
+    if user.isEmpty() {
+        return ""
+    }
+    let encodedUser = encoding.url.encode(user)
+    if password.isEmpty() {
+        return "{encodedUser}@"
+    }
+    let encodedPassword = if redact { "redacted" } else { encoding.url.encode(password) }
+    "{encodedUser}:{encodedPassword}@"
+}
+
+fn querySuffix(params: Map<String, String>) -> String {
+    let keys = params.keys().sorted()
+    if keys.isEmpty() {
+        return ""
+    }
+    let mut parts: List<String> = []
+    for key in keys {
+        let value = params.get(key).unwrap()
+        let encodedKey = encoding.url.encode(key)
+        let encodedValue = encoding.url.encode(value)
+        parts.push("{encodedKey}={encodedValue}")
+    }
+    let joined = strings.join(parts, "&")
+    "?{joined}"
+}
+
+fn isParamName(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    let chars = name.chars()
+    for c in chars {
+        if !isParamChar(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn isParamChar(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= 'a' && c <= 'z') ||
+    (c >= '0' && c <= '9') ||
+    c == '_' || c == '-' || c == '.'
+}
+
+fn containsInt(values: List<Int>, needle: Int) -> Bool {
+    for value in values {
+        if value == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn sortMigrations(items: List<Migration>) -> List<Migration> {
+    let mut out = items
+    let mut i = 0
+    for i < out.len() {
+        let mut best = i
+        let mut j = i + 1
+        for j < out.len() {
+            if out[j].version < out[best].version {
+                best = j
+            }
+            j = j + 1
+        }
+        if best != i {
+            let tmp = out[i]
+            out[i] = out[best]
+            out[best] = tmp
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn maxMigrationVersion(items: List<Migration>) -> Int {
+    let mut version = 0
+    for item in items {
+        if item.version > version {
+            version = item.version
+        }
+    }
+    version
+}
+
+fn noneString() -> String? {
+    None
+}

--- a/internal/stdlib/modules/sql.osty
+++ b/internal/stdlib/modules/sql.osty
@@ -1,0 +1,401 @@
+// std.sql - safe SQL fragment and query builders.
+
+use std.error
+use std.strings
+
+pub enum Dialect {
+    Generic,
+    Postgres,
+    MySql,
+    Sqlite,
+}
+
+pub enum Value {
+    SqlNull,
+    SqlString(String),
+    SqlInt(Int),
+    SqlFloat(Float),
+    SqlBool(Bool),
+    SqlRaw(String),
+}
+
+pub struct Query {
+    pub sql: String,
+    pub params: List<Value>,
+}
+
+pub struct Condition {
+    pub sql: String,
+    pub params: List<Value>,
+}
+
+pub struct Assignment {
+    pub column: String,
+    pub value: Value,
+}
+
+pub struct Order {
+    pub column: String,
+    pub descending: Bool,
+}
+
+pub fn null() -> Value {
+    SqlNull
+}
+
+pub fn text(value: String) -> Value {
+    SqlString(value)
+}
+
+pub fn integer(value: Int) -> Value {
+    SqlInt(value)
+}
+
+pub fn float(value: Float) -> Value {
+    SqlFloat(value)
+}
+
+pub fn boolean(value: Bool) -> Value {
+    SqlBool(value)
+}
+
+pub fn rawValue(value: String) -> Value {
+    SqlRaw(value)
+}
+
+pub fn query(sql: String, params: List<Value>) -> Query {
+    Query {
+        sql: strings.trimSpace(sql),
+        params: params,
+    }
+}
+
+pub fn raw(sql: String) -> Query {
+    query(sql, [])
+}
+
+pub fn condition(sql: String, params: List<Value>) -> Condition {
+    Condition {
+        sql: strings.trimSpace(sql),
+        params: params,
+    }
+}
+
+pub fn assignment(column: String, value: Value) -> Result<Assignment, Error> {
+    validatePath(column)?
+    Ok(Assignment {
+        column: column,
+        value: value,
+    })
+}
+
+pub fn asc(column: String) -> Result<Order, Error> {
+    validatePath(column)?
+    Ok(Order {
+        column: column,
+        descending: false,
+    })
+}
+
+pub fn desc(column: String) -> Result<Order, Error> {
+    validatePath(column)?
+    Ok(Order {
+        column: column,
+        descending: true,
+    })
+}
+
+pub fn quoteIdent(name: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(name)
+    if !isIdent(clean) {
+        return Err(error.new("sql: invalid identifier: {name}"))
+    }
+    Ok("\"{escapeIdent(clean)}\"")
+}
+
+pub fn quotePath(path: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(path)
+    if clean == "*" {
+        return Ok("*")
+    }
+    let parts = strings.split(clean, ".")
+    if parts.isEmpty() {
+        return Err(error.new("sql: empty identifier path"))
+    }
+    let mut out: List<String> = []
+    let mut i = 0
+    for i < parts.len() {
+        let part = strings.trimSpace(parts[i])
+        if part == "*" && i == parts.len() - 1 {
+            out.push("*")
+        } else {
+            out.push(quoteIdent(part)?)
+        }
+        i = i + 1
+    }
+    Ok(strings.join(out, "."))
+}
+
+pub fn literal(value: Value) -> String {
+    match value {
+        SqlNull      -> "NULL",
+        SqlString(s) -> "'{escapeString(s)}'",
+        SqlInt(n)    -> n.toString(),
+        SqlFloat(n)  -> n.toString(),
+        SqlBool(b)   -> if b { "TRUE" } else { "FALSE" },
+        SqlRaw(s)    -> s,
+    }
+}
+
+pub fn placeholder(dialect: Dialect, index: Int) -> String {
+    match dialect {
+        Postgres -> "${index}",
+        MySql    -> "?",
+        Sqlite   -> "?",
+        Generic  -> "?",
+    }
+}
+
+pub fn render(q: Query, dialect: Dialect) -> String {
+    let mut out = ""
+    let mut index = 1
+    for c in q.sql.chars() {
+        if c.toInt() == 0x3F {
+            let marker = placeholder(dialect, index)
+            out = "{out}{marker}"
+            index = index + 1
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+pub fn debugSql(q: Query) -> String {
+    let mut out = ""
+    let mut index = 0
+    for c in q.sql.chars() {
+        if c.toInt() == 0x3F && index < q.params.len() {
+            let value = literal(q.params[index])
+            out = "{out}{value}"
+            index = index + 1
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+pub fn eq(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, "=", value)
+}
+
+pub fn ne(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, "<>", value)
+}
+
+pub fn gt(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, ">", value)
+}
+
+pub fn gte(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, ">=", value)
+}
+
+pub fn lt(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, "<", value)
+}
+
+pub fn lte(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, "<=", value)
+}
+
+pub fn like(column: String, value: Value) -> Result<Condition, Error> {
+    compare(column, "LIKE", value)
+}
+
+pub fn isNull(column: String) -> Result<Condition, Error> {
+    let col = quotePath(column)?
+    Ok(condition("{col} IS NULL", []))
+}
+
+pub fn isNotNull(column: String) -> Result<Condition, Error> {
+    let col = quotePath(column)?
+    Ok(condition("{col} IS NOT NULL", []))
+}
+
+pub fn inList(column: String, values: List<Value>) -> Result<Condition, Error> {
+    if values.isEmpty() {
+        return Err(error.new("sql: IN list is empty"))
+    }
+    let mut placeholders: List<String> = []
+    let mut i = 0
+    for i < values.len() {
+        placeholders.push("?")
+        i = i + 1
+    }
+    let col = quotePath(column)?
+    let markers = strings.join(placeholders, ", ")
+    Ok(condition("{col} IN ({markers})", values))
+}
+
+pub fn allOf(conditions: List<Condition>) -> Condition {
+    joinConditions(conditions, "AND")
+}
+
+pub fn anyOf(conditions: List<Condition>) -> Condition {
+    joinConditions(conditions, "OR")
+}
+
+pub fn select(table: String, columns: List<String>) -> Result<Query, Error> {
+    let cols = renderColumns(columns)?
+    let tableName = quotePath(table)?
+    Ok(query("SELECT {cols} FROM {tableName}", []))
+}
+
+pub fn selectWhere(table: String, columns: List<String>, cond: Condition) -> Result<Query, Error> {
+    let base = select(table, columns)?
+    Ok(query("{base.sql} WHERE {cond.sql}", cond.params))
+}
+
+pub fn insert(table: String, values: List<Assignment>) -> Result<Query, Error> {
+    if values.isEmpty() {
+        return Err(error.new("sql: insert values are empty"))
+    }
+    let mut columns: List<String> = []
+    let mut markers: List<String> = []
+    let mut params: List<Value> = []
+    for item in values {
+        columns.push(quotePath(item.column)?)
+        markers.push("?")
+        params.push(item.value)
+    }
+    let tableName = quotePath(table)?
+    let colList = strings.join(columns, ", ")
+    let markerList = strings.join(markers, ", ")
+    Ok(query("INSERT INTO {tableName} ({colList}) VALUES ({markerList})", params))
+}
+
+pub fn update(table: String, values: List<Assignment>, cond: Condition) -> Result<Query, Error> {
+    if values.isEmpty() {
+        return Err(error.new("sql: update values are empty"))
+    }
+    let mut assigns: List<String> = []
+    let mut params: List<Value> = []
+    for item in values {
+        let col = quotePath(item.column)?
+        assigns.push("{col} = ?")
+        params.push(item.value)
+    }
+    appendValues(params, cond.params)
+    let tableName = quotePath(table)?
+    let setList = strings.join(assigns, ", ")
+    Ok(query("UPDATE {tableName} SET {setList} WHERE {cond.sql}", params))
+}
+
+pub fn deleteFrom(table: String, cond: Condition) -> Result<Query, Error> {
+    let tableName = quotePath(table)?
+    Ok(query("DELETE FROM {tableName} WHERE {cond.sql}", cond.params))
+}
+
+pub fn orderBy(q: Query, orders: List<Order>) -> Result<Query, Error> {
+    if orders.isEmpty() {
+        return Ok(q)
+    }
+    let mut parts: List<String> = []
+    for item in orders {
+        let dir = if item.descending { "DESC" } else { "ASC" }
+        let col = quotePath(item.column)?
+        parts.push("{col} {dir}")
+    }
+    let orderList = strings.join(parts, ", ")
+    Ok(query("{q.sql} ORDER BY {orderList}", q.params))
+}
+
+pub fn limit(q: Query, n: Int) -> Result<Query, Error> {
+    if n < 0 {
+        return Err(error.new("sql: negative limit"))
+    }
+    Ok(query("{q.sql} LIMIT {n}", q.params))
+}
+
+pub fn offset(q: Query, n: Int) -> Result<Query, Error> {
+    if n < 0 {
+        return Err(error.new("sql: negative offset"))
+    }
+    Ok(query("{q.sql} OFFSET {n}", q.params))
+}
+
+pub fn isIdent(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    let chars = name.chars()
+    if !isIdentStart(chars[0]) {
+        return false
+    }
+    for c in chars {
+        if !isIdentContinue(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn validatePath(path: String) -> Result<(), Error> {
+    quotePath(path)?
+    Ok(())
+}
+
+fn renderColumns(columns: List<String>) -> Result<String, Error> {
+    if columns.isEmpty() {
+        return Ok("*")
+    }
+    let mut out: List<String> = []
+    for column in columns {
+        out.push(quotePath(column)?)
+    }
+    Ok(strings.join(out, ", "))
+}
+
+fn compare(column: String, op: String, value: Value) -> Result<Condition, Error> {
+    let col = quotePath(column)?
+    Ok(condition("{col} {op} ?", [value]))
+}
+
+fn joinConditions(conditions: List<Condition>, op: String) -> Condition {
+    if conditions.isEmpty() {
+        return condition("1 = 1", [])
+    }
+    let mut parts: List<String> = []
+    let mut params: List<Value> = []
+    for cond in conditions {
+        parts.push("({cond.sql})")
+        appendValues(params, cond.params)
+    }
+    condition(strings.join(parts, " {op} "), params)
+}
+
+fn appendValues(out: List<Value>, values: List<Value>) {
+    for value in values {
+        out.push(value)
+    }
+}
+
+fn escapeIdent(name: String) -> String {
+    strings.replaceAll(name, "\"", "\"\"")
+}
+
+fn escapeString(value: String) -> String {
+    strings.replaceAll(value, "'", "''")
+}
+
+fn isIdentStart(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= 'a' && c <= 'z') ||
+    c == '_'
+}
+
+fn isIdentContinue(c: Char) -> Bool {
+    isIdentStart(c) || (c >= '0' && c <= '9')
+}

--- a/internal/stdlib/modules/sql.osty
+++ b/internal/stdlib/modules/sql.osty
@@ -156,6 +156,22 @@ pub fn placeholder(dialect: Dialect, index: Int) -> String {
     }
 }
 
+pub fn genericDialect() -> Dialect {
+    Generic
+}
+
+pub fn postgresDialect() -> Dialect {
+    Postgres
+}
+
+pub fn mysqlDialect() -> Dialect {
+    MySql
+}
+
+pub fn sqliteDialect() -> Dialect {
+    Sqlite
+}
+
 pub fn render(q: Query, dialect: Dialect) -> String {
     let mut out = ""
     let mut index = 1

--- a/internal/stdlib/sql_test.go
+++ b/internal/stdlib/sql_test.go
@@ -16,7 +16,9 @@ func TestSqlModuleSurface(t *testing.T) {
 	for _, name := range []string{
 		"null", "text", "integer", "float", "boolean", "rawValue",
 		"query", "raw", "condition", "assignment", "asc", "desc",
-		"quoteIdent", "quotePath", "literal", "placeholder", "render", "debugSql",
+		"quoteIdent", "quotePath", "literal", "placeholder",
+		"genericDialect", "postgresDialect", "mysqlDialect", "sqliteDialect",
+		"render", "debugSql",
 		"eq", "ne", "gt", "gte", "lt", "lte", "like", "isNull", "isNotNull", "inList",
 		"allOf", "anyOf", "select", "selectWhere", "insert", "update", "deleteFrom",
 		"orderBy", "limit", "offset", "isIdent",

--- a/internal/stdlib/sql_test.go
+++ b/internal/stdlib/sql_test.go
@@ -1,0 +1,64 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestSqlModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["sql"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.sql not loaded")
+	}
+	for _, name := range []string{
+		"null", "text", "integer", "float", "boolean", "rawValue",
+		"query", "raw", "condition", "assignment", "asc", "desc",
+		"quoteIdent", "quotePath", "literal", "placeholder", "render", "debugSql",
+		"eq", "ne", "gt", "gte", "lt", "lte", "like", "isNull", "isNotNull", "inList",
+		"allOf", "anyOf", "select", "selectWhere", "insert", "update", "deleteFrom",
+		"orderBy", "limit", "offset", "isIdent",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.sql missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.sql.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.sql.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Dialect", "Value", "Query", "Condition", "Assignment", "Order"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.sql missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.sql.%s not public", name)
+		}
+	}
+}
+
+func TestSqlModuleSourcePinsBuilderBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["sql"]
+	if mod == nil {
+		t.Fatal("std.sql module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn quoteIdent(name: String) -> Result<String, Error>`,
+		`pub fn placeholder(dialect: Dialect, index: Int) -> String`,
+		`pub fn render(q: Query, dialect: Dialect) -> String`,
+		`pub fn insert(table: String, values: List<Assignment>) -> Result<Query, Error>`,
+		`strings.replaceAll(value, "'", "''")`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.sql source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `std.sql` as a pure Osty SQL fragment/query builder module.
- Cover identifier quoting, value literals, dialect placeholder rendering, debug SQL rendering, predicates, ordering, limits, and SELECT/INSERT/UPDATE/DELETE builders.
- Add `std.db` for the DB pieces that can be implemented without runtime drivers: config/DSN rendering, pool and tx options, row/result containers, migration helpers, and `std.sql.Query` dialect rendering.
- Add module surface tests, backend checker coverage, and standard-library docs/matrix updates that separate query/config utilities from future DB driver/runtime work.

## Validation

- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult(Db|Sql)'`
- `go test -count=1 -vet=off ./internal/backend`
- `just fmt-check`
- `git diff --check`