### PR TITLE
[codex] Close merged MIR backend gaps

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -6555,10 +6555,16 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 	if t == nil {
 		return nil, nil
 	}
+	if _, ok := t.(*ir.FnType); ok {
+		return g.emitFunctionStringConcatBoxed(op), nil
+	}
 	prim, ok := t.(*ir.PrimType)
 	if !ok {
 		if out, handled, err := g.emitEnumStringConcatBoxed(op, t); handled || err != nil {
 			return out, err
+		}
+		if out := g.emitOpaqueStringConcatBoxed(t); out != nil {
+			return out, nil
 		}
 		return nil, nil
 	}
@@ -6621,6 +6627,27 @@ func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
 		return out, nil
 	}
 	return nil, nil
+}
+
+func (g *mirGen) emitFunctionStringConcatBoxed(op mir.Operand) *LlvmValue {
+	label := "<fn>"
+	if co, ok := op.(*mir.ConstOp); ok {
+		if fc, ok := co.Const.(*mir.FnConst); ok && fc.Symbol != "" {
+			label = fc.Symbol
+		}
+	}
+	return &LlvmValue{typ: "ptr", name: g.stringLiteral(label)}
+}
+
+func (g *mirGen) emitOpaqueStringConcatBoxed(t mir.Type) *LlvmValue {
+	if _, poisoned := t.(*ir.ErrType); poisoned {
+		return nil
+	}
+	label := mirTypeString(t)
+	if label == "" || label == "<nil>" {
+		return nil
+	}
+	return &LlvmValue{typ: "ptr", name: g.stringLiteral(label)}
 }
 
 func (g *mirGen) emitEnumStringConcatBoxed(op mir.Operand, t mir.Type) (*LlvmValue, bool, error) {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -3827,6 +3827,99 @@ func TestGenerateFromMIRStringInterpolationBoxesEnumVariantName(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRStringInterpolationBoxesFunctionValue(t *testing.T) {
+	fnT := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}
+	callee := &ir.FnDecl{
+		Name:   "nextValue",
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Result: &ir.BinaryExpr{
+				Op:    ir.BinAdd,
+				Left:  &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+				Right: &ir.IntLit{Text: "1", T: ir.TInt},
+				T:     ir.TInt,
+			},
+		},
+	}
+	render := &ir.FnDecl{
+		Name:   "renderFn",
+		Return: ir.TString,
+		Body: &ir.Block{
+			Result: &ir.StringLit{
+				Parts: []ir.StringPart{
+					{IsLit: true, Lit: "fn="},
+					{Expr: &ir.Ident{Name: "nextValue", Kind: ir.IdentFn, T: fnT}},
+				},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{callee, render}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/fn_concat.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`c"nextValue\00"`,
+		"call ptr @osty_rt_strings_Concat(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "string_concat arg") {
+		t.Fatalf("function interpolation should be boxed before concat:\n%s", got)
+	}
+}
+
+func TestGenerateFromMIRStringInterpolationBoxesOpaqueNamedValue(t *testing.T) {
+	nodeT := &ir.NamedType{Name: "CoreNode"}
+	render := &ir.FnDecl{
+		Name:   "renderNode",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "node", Type: nodeT}},
+		Body: &ir.Block{
+			Result: &ir.StringLit{
+				Parts: []ir.StringPart{
+					{IsLit: true, Lit: "node="},
+					{Expr: &ir.Ident{Name: "node", Kind: ir.IdentParam, T: nodeT}},
+				},
+			},
+		},
+	}
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.StructDecl{
+				Name: "CoreNode",
+				Fields: []*ir.Field{
+					{Name: "kind", Type: ir.TInt, Exported: true},
+				},
+			},
+			render,
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/named_concat.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`c"CoreNode\00"`,
+		"call ptr @osty_rt_strings_Concat(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "string_concat arg") {
+		t.Fatalf("named interpolation should be boxed before concat:\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRBinaryStringAddUsesRuntimeConcat(t *testing.T) {
 	fn := &ir.FnDecl{
 		Name:   "greet",

--- a/internal/llvmgen/native_toolchain_mir_pipeline_test.go
+++ b/internal/llvmgen/native_toolchain_mir_pipeline_test.go
@@ -1,7 +1,6 @@
 package llvmgen
 
 import (
-	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,23 +13,17 @@ import (
 	"github.com/osty/osty/internal/stdlib"
 )
 
-// TestNativeToolchainMergedMIRPipelineIsClean gates the MIR-first
-// dispatcher on the merged non-bootstrap toolchain. It mirrors the
-// production path in internal/backend/llvm.go: attempt
-// GenerateFromMIR; on ErrUnsupported fall back to the legacy
-// HIR→AST emitter. The whole pipeline must produce LLVM IR without
-// a hard error.
+// TestNativeToolchainMergedMIRPipelineIsClean gates the MIR backend on
+// the merged non-bootstrap toolchain. The self-host critical path must
+// now lower the merged native toolchain through MIR directly; falling
+// back to the legacy HIR→AST emitter would hide real backend coverage
+// regressions.
 //
 // This test is the authoritative gate for the "complete MIR-direct
-// pipeline" milestone: both the fast path (MIR) and the graceful
-// fallback (legacy) must cooperate cleanly. MIR coverage gaps inside
-// the merged checker surface used to block the fast path outright
-// (first wall was `unsupported local type <error>`); the operand-based
-// type recovery in ir.Lower now drops ErrType locals by 91 %
-// (444 → 39), with the remainder concentrated in a handful of
-// synthesised-span BinaryRVs. When the fast path still refuses (the
-// typical case for the merged toolchain today) this gate checks the
-// fallback succeeds.
+// pipeline" milestone. Earlier versions accepted ErrUnsupported from
+// GenerateFromMIR and only required the legacy fallback to succeed; the
+// merged native toolchain is now expected to produce LLVM IR on the MIR
+// path itself.
 //
 // Paired with TestProbeNativeToolchainMergedMIR which is info-only
 // and logs the first MIR wall for debugging.
@@ -72,25 +65,13 @@ func TestNativeToolchainMergedMIRPipelineIsClean(t *testing.T) {
 	}
 	opts := Options{PackageName: "main", SourcePath: "/tmp/toolchain_native_merged_mir_pipeline.osty"}
 
-	// Mirror the dispatcher at internal/backend/llvm.go:177-183.
-	var (
-		out    []byte
-		genErr error
-	)
 	mirMod := mir.Lower(monoMod)
-	if mirMod != nil {
-		out, genErr = GenerateFromMIR(mirMod, opts)
+	if mirMod == nil {
+		t.Fatalf("mir.Lower returned nil module")
 	}
-	if genErr != nil && !errors.Is(genErr, ErrUnsupported) {
-		t.Fatalf("GenerateFromMIR hard error (not ErrUnsupported): %v", genErr)
-	}
+	out, genErr := GenerateFromMIR(mirMod, opts)
 	if genErr != nil {
-		// Fall back to legacy HIR path — the production dispatcher
-		// does the same on ErrUnsupported.
-		out, genErr = generateFromAST(file, opts)
-		if genErr != nil {
-			t.Fatalf("legacy fallback failed after MIR refusal: %v", genErr)
-		}
+		t.Fatalf("GenerateFromMIR failed on merged native toolchain: %v", genErr)
 	}
 	if len(out) == 0 {
 		t.Fatalf("pipeline produced empty IR output")
@@ -110,8 +91,9 @@ func firstN(b []byte, n int) string {
 // TestNativeToolchainMergedMIRErrTypeFloor locks the current MIR
 // ErrType leak count as a progress floor. After the operand-based
 // type recovery in ir.Lower (lowerBinary / lowerIfExpr / lowerCall /
-// lowerQualifiedCall), the merged native toolchain carries ≤40
-// ErrType locals into MIR. Regressions that increase that count
+// lowerQualifiedCall), the merged native toolchain carries only a
+// small handful of ErrType locals into MIR. Regressions that increase
+// that count
 // (e.g. a new checker-coverage gap or a reverted recovery helper)
 // will re-expand cascading ErrType propagation and fail this gate.
 //
@@ -120,7 +102,7 @@ func TestNativeToolchainMergedMIRErrTypeFloor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow; skipped in -short")
 	}
-	const floor = 40
+	const floor = 8
 	root, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatalf("abs root: %v", err)


### PR DESCRIPTION
## Summary
- box function values and opaque named values when they appear in MIR string interpolation
- make the merged native toolchain MIR pipeline a direct backend gate instead of hiding ErrUnsupported behind legacy fallback
- tighten the merged toolchain ErrType floor now that the backend path is clean

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIRStringInterpolationBoxesFunctionValue|TestGenerateFromMIRStringInterpolationBoxesOpaqueNamedValue|TestNativeToolchainMergedMIRPipelineIsClean|TestNativeToolchainMergedMIRErrTypeFloor' -v`
- `go build -o .bin/osty-codex ./cmd/osty`
- checked every `examples/**/osty.toml` package with `.bin/osty-codex check --no-airepair --max-errors 30`
- `just short`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `go test -count=1 -vet=off ./internal/mir ./internal/backend ./cmd/osty`