### PR TITLE
[codex] fix selfhost toolchain build

### DIFF
--- a/internal/canonical/source_test.go
+++ b/internal/canonical/source_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestSourceWithMapProjectsLoweredCallSpans(t *testing.T) {
@@ -45,5 +46,28 @@ func TestSourceWithMapProjectsLoweredCallSpans(t *testing.T) {
 	}
 	if remapped != original {
 		t.Fatalf("remapped span = %#v, want %#v", remapped, original)
+	}
+}
+
+func TestSourceEscapesBraceCharAndByteLiteralsForSelfhost(t *testing.T) {
+	src := []byte(`fn main() {
+    let openByte = b'\{'
+    let closeByte = b'\}'
+    let openChar = '\{'
+    let closeChar = '\}'
+}
+`)
+	parsed := parser.ParseDetailed(src)
+	if len(parsed.Diagnostics) != 0 {
+		t.Fatalf("parse diagnostics = %#v, want none", parsed.Diagnostics)
+	}
+	canonicalSrc, _ := SourceWithMap(src, parsed.File)
+	for _, want := range []string{`b'\{'`, `b'\}'`, `'\{'`, `'\}'`} {
+		if !bytes.Contains(canonicalSrc, []byte(want)) {
+			t.Fatalf("canonical source = %q, want %s", canonicalSrc, want)
+		}
+	}
+	if diags := selfhost.ParseDiagnostics(canonicalSrc); len(diags) != 0 {
+		t.Fatalf("selfhost parse diagnostics = %#v", diags)
 	}
 }

--- a/internal/format/escapes.go
+++ b/internal/format/escapes.go
@@ -64,6 +64,12 @@ func escapeForChar(r rune) string {
 	if r == '\'' {
 		return `\'`
 	}
+	if r == '{' {
+		return `\{`
+	}
+	if r == '}' {
+		return `\}`
+	}
 	if s := escapeCommon(r); s != "" {
 		return s
 	}
@@ -76,6 +82,12 @@ func escapeForChar(r rune) string {
 func escapeForByte(b byte) string {
 	if b == '\'' {
 		return `\'`
+	}
+	if b == '{' {
+		return `\{`
+	}
+	if b == '}' {
+		return `\}`
 	}
 	if s := escapeCommon(rune(b)); s != "" {
 		return s

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -54797,12 +54797,12 @@ func srSymbolFound(sym *SelfSymbol) bool {
 
 // Osty: /tmp/selfhost_merged.osty:28147:1
 func srIsBuiltinName(name string) bool {
-	return name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "println" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Float" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "List" || name == "Map" || name == "Set" || name == "Option" || name == "Result" || name == "Error" || name == "Unit"
+	return name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "print" || name == "println" || name == "eprint" || name == "eprintln" || name == "dbg" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
 }
 
 // Osty: /tmp/selfhost_merged.osty:28151:1
 func srIsBuiltinTypeName(name string) bool {
-	return name == "Int" || name == "Float" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "List" || name == "Map" || name == "Set" || name == "Option" || name == "Result" || name == "Error" || name == "Unit"
+	return name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
 }
 
 // Osty: /tmp/selfhost_merged.osty:28155:1

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -272,8 +272,106 @@ func ResolvePackageStructured(input PackageResolveInput) (ResolveResult, error) 
 		return checkNodeOffsetsWithTokenLayout(layout, start, end)
 	})
 	selfhostAnnotateResolveFiles(&result, input.Files)
+	selfhostFilterCrossFileDuplicateUseDiagnostics(&result, file, layout)
 	selfhostAssignResolveIDs(&result, selfhostResolvePackageKey(input))
 	return result, nil
+}
+
+func selfhostFilterCrossFileDuplicateUseDiagnostics(result *ResolveResult, file *AstFile, layout *selfhostPackageTokenLayout) {
+	if result == nil || file == nil || file.arena == nil || layout == nil {
+		return
+	}
+	uses := selfhostPackageUseAliasStarts(file, layout)
+	if len(uses) == 0 {
+		return
+	}
+	out := result.Diagnostics[:0]
+	droppedDuplicateUses := 0
+	for _, d := range result.Diagnostics {
+		if d.Code == "E0554" && !selfhostPackageHasEarlierUseAlias(uses, d.File, d.Name, d.Start) {
+			droppedDuplicateUses++
+			continue
+		}
+		out = append(out, d)
+	}
+	if droppedDuplicateUses == 0 {
+		return
+	}
+	result.Diagnostics = out
+	if result.Summary.Duplicates >= droppedDuplicateUses {
+		result.Summary.Duplicates -= droppedDuplicateUses
+	} else {
+		result.Summary.Duplicates = 0
+	}
+	selfhostRefreshResolveDiagnosticSummary(result)
+}
+
+func selfhostPackageUseAliasStarts(file *AstFile, layout *selfhostPackageTokenLayout) map[string][]int {
+	out := map[string][]int{}
+	if file == nil || file.arena == nil {
+		return out
+	}
+	var walk func(int)
+	walk = func(idx int) {
+		if idx < 0 || idx >= len(file.arena.nodes) {
+			return
+		}
+		node := file.arena.nodes[idx]
+		if node == nil {
+			return
+		}
+		if _, ok := node.kind.(*AstNodeKind_AstNUseDecl); !ok {
+			return
+		}
+		if astUseDeclIsGroup(node) {
+			for _, childIdx := range node.children {
+				walk(childIdx)
+			}
+			return
+		}
+		alias := srAstUseAlias(file, node)
+		path := checkFilePathWithTokenLayout(layout, node.start)
+		start, _ := checkNodeOffsetsWithTokenLayout(layout, node.start, node.end)
+		if alias == "" || path == "" {
+			return
+		}
+		key := path + "\x00" + alias
+		out[key] = append(out[key], start)
+	}
+	for _, declIdx := range file.arena.decls {
+		walk(declIdx)
+	}
+	return out
+}
+
+func selfhostPackageHasEarlierUseAlias(uses map[string][]int, file, name string, start int) bool {
+	if file == "" || name == "" {
+		return false
+	}
+	for _, candidate := range uses[file+"\x00"+name] {
+		if candidate < start {
+			return true
+		}
+	}
+	return false
+}
+
+func selfhostRefreshResolveDiagnosticSummary(result *ResolveResult) {
+	if result == nil {
+		return
+	}
+	result.Summary.Diagnostics = len(result.Diagnostics)
+	byCode := map[string]int{}
+	for _, d := range result.Diagnostics {
+		if d.Code == "" {
+			continue
+		}
+		byCode[d.Code]++
+	}
+	if len(byCode) == 0 {
+		byCode = nil
+	}
+	result.Summary.DiagnosticsByCode = byCode
 }
 
 func selfhostApplyResolveImportSurfaces(result *ResolveResult, file *AstFile, imports []PackageCheckImport, offsets func(start, end int) (int, int)) {

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -37,6 +37,28 @@ fn main() {
 	}
 }
 
+func TestResolveSourceStructuredAcceptsCurrentPreludeTypes(t *testing.T) {
+	resolved := selfhost.ResolveSourceStructured([]byte(`fn accepts(
+    b: Byte,
+    small: Int8,
+    unsigned: UInt64,
+    flt: Float32,
+    ptr: RawPtr,
+    ch: Channel<Int>,
+    legacy: Chan<Int>,
+    h: Handle<Int>,
+) {
+}
+
+fn generic<T: Equal + Ordered + Hashable + ToString + Pod>(x: T) -> T {
+    x
+}
+`))
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("diagnostics = %d, want 0 (summary=%#v diagnostics=%#v)", resolved.Summary.Diagnostics, resolved.Summary, resolved.Diagnostics)
+	}
+}
+
 func TestResolvePackageStructuredHandlesCrossFileRefsASTNative(t *testing.T) {
 	dir := t.TempDir()
 	helperPath := filepath.Join(dir, "helper.osty")
@@ -286,6 +308,58 @@ func TestResolvePackageStructuredDuplicateUsesOwningFilePath(t *testing.T) {
 	}
 	if resolved.Summary.Duplicates != 1 {
 		t.Fatalf("duplicates = %d, want 1 (summary=%#v)", resolved.Summary.Duplicates, resolved.Summary)
+	}
+}
+
+func TestResolvePackageStructuredAllowsPerFileDuplicateUseAlias(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.osty")
+	secondPath := filepath.Join(dir, "second.osty")
+
+	first := canonicalSelfhostInput(t, []byte(`use std.strings as strings
+
+pub fn first() -> Int {
+    1
+}
+`), 0)
+	first.Name = "first.osty"
+	first.Path = firstPath
+
+	second := canonicalSelfhostInput(t, []byte(`use std.strings as strings
+
+pub fn second() -> Int {
+    2
+}
+`), len(first.Source)+1)
+	second.Name = "second.osty"
+	second.Path = secondPath
+
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		Files: []selfhost.PackageResolveFile{first, second},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	if got := findResolveDiagnostic(resolved, "E0554"); got != nil {
+		t.Fatalf("cross-file duplicate use alias should be allowed, got %#v", got)
+	}
+	if resolved.Summary.DiagnosticsByCode != nil && resolved.Summary.DiagnosticsByCode["E0554"] != 0 {
+		t.Fatalf("diagnostic histogram = %#v, want no E0554", resolved.Summary.DiagnosticsByCode)
+	}
+}
+
+func TestResolvePackageStructuredKeepsSameFileDuplicateUseAlias(t *testing.T) {
+	src := canonicalSelfhostInput(t, []byte(`use std.strings as strings
+use std.fs as strings
+`), 0)
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		Files: []selfhost.PackageResolveFile{src},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	if got := findResolveDiagnostic(resolved, "E0554"); got == nil {
+		t.Fatalf("expected same-file E0554, got %#v", resolved.Diagnostics)
 	}
 }
 

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2589,11 +2589,11 @@ fn srSymbolFound(sym: SelfSymbol) -> Bool {
 }
 
 fn srIsBuiltinName(name: String) -> Bool {
-    name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "println" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Float" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "List" || name == "Map" || name == "Set" || name == "Option" || name == "Result" || name == "Error" || name == "Unit"
+    name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "print" || name == "println" || name == "eprint" || name == "eprintln" || name == "dbg" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
 }
 
 fn srIsBuiltinTypeName(name: String) -> Bool {
-    name == "Int" || name == "Float" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "List" || name == "Map" || name == "Set" || name == "Option" || name == "Result" || name == "Error" || name == "Unit"
+    name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
 }
 
 fn srIsBuiltinVariantName(name: String) -> Bool {


### PR DESCRIPTION
## Summary

- Escape brace char and byte literals in canonical output so selfhost package parsing can re-read generated sources.
- Filter package-level duplicate import diagnostics that only arise from merging separate files for selfhost resolution.
- Align selfhost builtin/prelude recognition with the current resolver so `Byte` and related builtins resolve during toolchain builds.

## Validation

- `go test -count=1 -vet=off ./internal/canonical ./internal/format`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestResolveSourceStructuredAcceptsCurrentPreludeTypes|TestResolvePackageStructuredAllowsPerFileDuplicateUseAlias|TestResolvePackageStructuredKeepsSameFileDuplicateUseAlias'`
- `just build`
- `./.bin/osty build --force toolchain`
- `./.bin/osty check --airepair=false toolchain`