### PR TITLE
[codex] add smtp zip image stdlib modules

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/30-smtp.md
+++ b/LANG_SPEC_v0.5/10-standard-library/30-smtp.md
@@ -1,0 +1,38 @@
+### 10.30 SMTP (`std.smtp`)
+
+`std.smtp` builds SMTP protocol commands and parses server replies. It uses
+`std.email.Envelope` for message data, but does not claim TLS/socket execution
+until the runtime grows that transport layer.
+
+```osty
+use std.smtp
+
+let cfg = smtp.config("smtp.example.com", smtp.defaultPort(StartTls), "client.local")?
+let authed = smtp.withAuth(cfg, smtp.plainAuth("user", "secret"))
+let tx = smtp.transaction(authed, envelope)
+let commands = smtp.commands(tx)?
+```
+
+Core API:
+
+```osty
+smtp.config(host, port, hostname) -> Result<ClientConfig, Error>
+smtp.withSecurity(config, security) -> ClientConfig
+smtp.withAuth(config, auth) -> ClientConfig
+smtp.commands(transaction) -> Result<List<String>, Error>
+smtp.renderCommands(commands) -> String
+
+smtp.authPlain(username, password) -> String
+smtp.authLogin(username, password) -> List<String>
+smtp.parseReply(line) -> Result<Reply, Error>
+smtp.parseReplies(text) -> Result<List<Reply>, Error>
+smtp.capabilities(replies) -> List<Capability>
+```
+
+Behavior:
+
+- AUTH PLAIN and AUTH LOGIN payloads are base64 encoded.
+- Multi-line SMTP replies are represented as individual `Reply` values with
+  `continuation = true` for dashed reply lines.
+- STARTTLS is represented in the command plan; TLS upgrade is runtime-driver
+  work.

--- a/LANG_SPEC_v0.5/10-standard-library/31-zip.md
+++ b/LANG_SPEC_v0.5/10-standard-library/31-zip.md
@@ -1,0 +1,36 @@
+### 10.31 ZIP (`std.zip`)
+
+`std.zip` creates and reads ZIP archives using the standard "store" method.
+This needs no deflate runtime and produces interoperable ZIP files with local
+headers, central directory records, EOCD, and CRC32 checks.
+
+```osty
+use std.bytes
+use std.zip
+
+let entry = zip.file("hello.txt", bytes.fromString("hello"))?
+let archive = zip.encode([entry])?
+let names = zip.list(archive)?
+let payload = zip.extract(archive, "hello.txt")?
+```
+
+Core API:
+
+```osty
+zip.file(name, data) -> Result<Entry, Error>
+zip.encode(entries) -> Result<Bytes, Error>
+zip.decode(archive) -> Result<List<Entry>, Error>
+zip.list(archive) -> Result<List<String>, Error>
+zip.extract(archive, name) -> Result<Bytes?, Error>
+zip.contains(archive, name) -> Bool
+zip.isArchive(data) -> Bool
+zip.crc32(data) -> Int
+```
+
+Behavior:
+
+- Entry names must be relative paths and must not contain parent path
+  segments.
+- Stored entries are fully supported. Deflated entries are detected and return
+  an error until `std.compress` grows a deflate runtime.
+- Decode validates CRC32 and stored payload sizes.

--- a/LANG_SPEC_v0.5/10-standard-library/32-image.md
+++ b/LANG_SPEC_v0.5/10-standard-library/32-image.md
@@ -1,0 +1,34 @@
+### 10.32 Image (`std.image`)
+
+`std.image` detects common image formats and parses header metadata. Full
+pixel decoding is intentionally left for a future runtime-backed codec layer.
+
+Supported metadata formats:
+
+- PNG
+- JPEG
+- GIF
+- BMP
+- WebP
+
+Core API:
+
+```osty
+image.identify(data) -> Format
+image.formatName(format) -> String
+image.parse(data) -> Result<Metadata, Error>
+image.dimensions(data) -> Result<Size, Error>
+image.isImage(data) -> Bool
+image.isPng(data) -> Bool
+image.isJpeg(data) -> Bool
+image.isGif(data) -> Bool
+image.isBmp(data) -> Bool
+image.isWebp(data) -> Bool
+```
+
+Behavior:
+
+- `parse` returns width, height, approximate bits-per-pixel, alpha flag, and
+  animation flag where the container exposes it cheaply.
+- PNG APNG and GIF multi-image files are marked animated by header scanning.
+- Unknown or truncated images return `Error`.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -42,3 +42,6 @@ lowering remains implementation backlog.
 - [§10.27 Grid (`std.grid`)](./27-grid.md)
 - [§10.28 SQL (`std.sql`)](./28-sql.md)
 - [§10.29 DB (`std.db`)](./29-db.md)
+- [§10.30 SMTP (`std.smtp`)](./30-smtp.md)
+- [§10.31 ZIP (`std.zip`)](./31-zip.md)
+- [§10.32 Image (`std.image`)](./32-image.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 49 모듈. 분류 기준:
+총 52 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (47 / 49 = 96%)
+### ⭐⭐⭐⭐⭐ Production (50 / 52 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -44,10 +44,13 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | sql | 417 | pure Osty | identifier quoting / literals / placeholders / SELECT-INSERT-UPDATE-DELETE builders |
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
+| image | 372 | pure Osty + bytes | PNG / JPEG / GIF / BMP / WebP format + dimension metadata parser |
+| smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
 | csv | 351 | — | options-driven, header-aware decode |
 | encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
+| zip | 327 | pure Osty + bytes | ZIP stored-entry encode/decode/list/extract + CRC32 |
 | term | 320 | host-backed + pure ANSI | terminal mode/size/input declarations + ANSI sequence builders |
 | websocket | 322 | pure Osty + crypto/encoding | RFC 6455 accept key + handshake headers + frame encode/decode |
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
@@ -77,7 +80,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 49 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (2 / 52 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -91,8 +94,9 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | `db driver/runtime`, `smtp transport`, `zip`, `image` |
-| 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd/zip 계열 없음 |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image` surface 는 존재) |
+| 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
+| 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
 
@@ -118,20 +122,23 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | WebSocket handshake/frame | ✅ 가능 | websocket (accept key / headers / frame encode/decode) |
 | GraphQL 요청 생성 | ✅ 가능 | graphql (document builder / variables JSON body) |
 | 이메일/MIME 생성 | ✅ 가능 | email (address / MIME multipart / SMTP DATA helpers) |
+| SMTP 트랜잭션 조립 | ✅ 가능 | smtp (EHLO / STARTTLS plan / AUTH / MAIL-RCPT-DATA / reply parsing) |
 | TAR 아카이브 | ✅ 가능 | tar (ustar encode/decode/list/extract) |
+| ZIP 아카이브 | ✅ 가능 | zip (stored-entry encode/decode/list/extract, deflate 는 runtime 후보) |
+| 이미지 메타데이터 | ✅ 가능 | image (PNG / JPEG / GIF / BMP / WebP dimensions) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 
-## 3. 진짜 약점 (없는 모듈)
+## 3. 진짜 약점 (남은 런타임 / 딥 기능)
 
-기존 모듈 대부분은 production-ready 또는 runtime-backed. 진짜 큰 갭은 *없는 모듈*들:
+기존 모듈 대부분은 production-ready 또는 runtime-backed. 큰 갭은 이제 *없는 모듈*보다 runtime-backed 실행/딥 codec 쪽이다:
 
-| 없는 모듈 | 영향 | 우선순위 |
+| 남은 갭 | 영향 | 우선순위 |
 |---|---|---|
 | db driver/runtime | 실제 DB 실행 (sqlite / postgres wrap 필요) | 높음 (실용 어플리케이션 핵심) |
-| smtp transport | 실제 SMTP 소켓 전송 / TLS | 중간 |
-| zip | 아카이브 (deflate/runtime 필요) | 낮음 |
-| image | 이미지 디코딩 | 낮음 |
+| smtp TLS/socket execution | 실제 SMTP 전송 / TLS | 중간 |
+| zip deflate | 압축 ZIP 호환성 | 낮음 |
+| image pixel decode | 실제 픽셀 디코딩 / 변환 | 낮음 |
 
 ## 4. Phase A / B 분리 패턴
 
@@ -150,7 +157,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 27 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, db, grid, tar, sql, xml, tui, result, option, csv, encoding, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 30 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, net, fmt, json, url, io, collections, email, db, grid, tar, sql, xml, tui, image, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
@@ -219,7 +226,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 
 stdlib 자체는 거의 production. 다음 우선순위:
 
-1. **새 모듈/런타임 추가** (db driver/runtime / smtp transport / zip / image) — 남은 갭 채우기
-2. **compress 깊이 / encoding 확장** — zstd / deflate, Base32 등 추가 표준
+1. **runtime-backed 실행 추가** (db driver/runtime / smtp TLS+socket execution) — pure surface 다음 단계
+2. **codec 깊이 추가** — compress deflate/zstd, zip deflate, image pixel decode
 3. **Phase B surface 부풀리기** — random / crypto / compress 는 Phase A 풍부한데 Phase B helper 가 declaration 위주. user-friendly wrapper (예: `crypto.sha256Hex(data)`, `random.shuffle(list)`) 추가
 4. **스펙 문서 동기화** — `LANG_SPEC_v0.5/10-standard-library/*.md` 가 24 시간 sprint 진척 따라잡았는지 확인

--- a/internal/backend/stdlib_big_gaps_check_test.go
+++ b/internal/backend/stdlib_big_gaps_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultBigGaps(t *testing.T) {
+	reg := stdlib.LoadCached()
+	for _, module := range []string{"smtp", "zip", "image"} {
+		t.Run(module, func(t *testing.T) {
+			chk := stdlibCheckResult(reg, module)
+			if chk == nil {
+				t.Fatalf("stdlibCheckResult(%s) = nil, want non-nil *check.Result", module)
+			}
+			var errs []string
+			for _, d := range chk.Diags {
+				if d != nil && strings.Contains(d.Error(), "error") {
+					msg := d.Error()
+					if len(d.Notes) > 0 {
+						msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+					}
+					errs = append(errs, msg)
+				}
+			}
+			if len(errs) > 0 {
+				t.Fatalf("%s module check produced %d error diagnostic(s):\n%s",
+					module, len(errs), strings.Join(errs, "\n"))
+			}
+		})
+	}
+}

--- a/internal/stdlib/big_gaps_test.go
+++ b/internal/stdlib/big_gaps_test.go
@@ -1,0 +1,120 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestSmtpModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["smtp"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.smtp not loaded")
+	}
+	for _, name := range []string{
+		"noAuth", "plainAuth", "loginAuth", "config", "withSecurity", "withAuth",
+		"defaultPort", "ehlo", "helo", "startTls", "mailFrom", "rcptTo",
+		"dataCommand", "quit", "rset", "noop", "authPlain", "authLogin", "authCommands",
+		"transaction", "commands", "renderCommands", "parseReply", "parseReplies",
+		"isPositiveCompletion", "isPositiveIntermediate", "isTransientFailure", "isPermanentFailure",
+		"capabilities", "hasCapability", "supportsAuth",
+	} {
+		requirePublicFn(t, mod, "smtp", name)
+	}
+	for _, name := range []string{"AuthKind", "Security", "Auth", "ClientConfig", "Reply", "Capability", "Transaction"} {
+		requirePublicType(t, mod, "smtp", name)
+	}
+}
+
+func TestZipModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["zip"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.zip not loaded")
+	}
+	for _, name := range []string{
+		"file", "encode", "decode", "list", "extract", "contains", "isArchive", "crc32", "methodName",
+	} {
+		requirePublicFn(t, mod, "zip", name)
+	}
+	for _, name := range []string{"Method", "Entry"} {
+		requirePublicType(t, mod, "zip", name)
+	}
+}
+
+func TestImageModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["image"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.image not loaded")
+	}
+	for _, name := range []string{
+		"identify", "formatName", "parse", "dimensions", "isImage",
+		"isPng", "isJpeg", "isGif", "isBmp", "isWebp",
+	} {
+		requirePublicFn(t, mod, "image", name)
+	}
+	for _, name := range []string{"Format", "Size", "Metadata"} {
+		requirePublicType(t, mod, "image", name)
+	}
+}
+
+func TestBigGapModuleSourcePinsBehavior(t *testing.T) {
+	reg := LoadCached()
+	cases := map[string][]string{
+		"smtp": {
+			`pub fn authPlain(username: String, password: String) -> String`,
+			`pub fn parseReply(line: String) -> Result<Reply, Error>`,
+			`pub fn commands(tx: Transaction) -> Result<List<String>, Error>`,
+		},
+		"zip": {
+			`pub fn encode(entries: List<Entry>) -> Result<Bytes, Error>`,
+			`pub fn decode(archive: Bytes) -> Result<List<Entry>, Error>`,
+			`pub fn crc32(data: Bytes) -> Int`,
+		},
+		"image": {
+			`pub fn identify(data: Bytes) -> Format`,
+			`fn parsePng(data: Bytes) -> Result<Metadata, Error>`,
+			`fn parseJpeg(data: Bytes) -> Result<Metadata, Error>`,
+		},
+	}
+	for module, wants := range cases {
+		mod := reg.Modules[module]
+		if mod == nil {
+			t.Fatalf("std.%s module missing", module)
+		}
+		src := string(mod.Source)
+		for _, want := range wants {
+			if !strings.Contains(src, want) {
+				t.Fatalf("std.%s source missing %q", module, want)
+			}
+		}
+	}
+}
+
+func requirePublicFn(t *testing.T, mod *Module, module, name string) {
+	t.Helper()
+	sym := mod.Package.PkgScope.LookupLocal(name)
+	if sym == nil {
+		t.Fatalf("std.%s missing export %q", module, name)
+	}
+	if sym.Kind != resolve.SymFn {
+		t.Fatalf("std.%s.%s kind = %s, want fn", module, name, sym.Kind)
+	}
+	if !sym.Pub {
+		t.Fatalf("std.%s.%s not public", module, name)
+	}
+}
+
+func requirePublicType(t *testing.T, mod *Module, module, name string) {
+	t.Helper()
+	sym := mod.Package.PkgScope.LookupLocal(name)
+	if sym == nil {
+		t.Fatalf("std.%s missing type %q", module, name)
+	}
+	if !sym.Pub {
+		t.Fatalf("std.%s.%s not public", module, name)
+	}
+}

--- a/internal/stdlib/modules/image.osty
+++ b/internal/stdlib/modules/image.osty
@@ -1,0 +1,372 @@
+// std.image - lightweight image format detection and dimension parsing.
+//
+// Pixel decoding belongs in a future runtime-backed codec layer. This module
+// handles the useful pure-Osty part now: sniff common image formats and read
+// dimensions / basic metadata from their headers.
+
+use std.bytes
+use std.error
+
+pub enum Format {
+    Unknown,
+    Png,
+    Jpeg,
+    Gif,
+    Bmp,
+    Webp,
+}
+
+pub struct Size {
+    pub width: Int,
+    pub height: Int,
+}
+
+pub struct Metadata {
+    pub format: Format,
+    pub width: Int,
+    pub height: Int,
+    pub bitsPerPixel: Int,
+    pub hasAlpha: Bool,
+    pub animated: Bool,
+}
+
+pub fn identify(data: Bytes) -> Format {
+    if isPng(data) {
+        return Png
+    }
+    if isJpeg(data) {
+        return Jpeg
+    }
+    if isGif(data) {
+        return Gif
+    }
+    if isBmp(data) {
+        return Bmp
+    }
+    if isWebp(data) {
+        return Webp
+    }
+    Unknown
+}
+
+pub fn formatName(format: Format) -> String {
+    match format {
+        Png     -> "png",
+        Jpeg    -> "jpeg",
+        Gif     -> "gif",
+        Bmp     -> "bmp",
+        Webp    -> "webp",
+        Unknown -> "unknown",
+    }
+}
+
+pub fn parse(data: Bytes) -> Result<Metadata, Error> {
+    match identify(data) {
+        Png     -> parsePng(data),
+        Jpeg    -> parseJpeg(data),
+        Gif     -> parseGif(data),
+        Bmp     -> parseBmp(data),
+        Webp    -> parseWebp(data),
+        Unknown -> Err(error.new("image: unknown image format")),
+    }
+}
+
+pub fn dimensions(data: Bytes) -> Result<Size, Error> {
+    let meta = parse(data)?
+    Ok(Size {
+        width: meta.width,
+        height: meta.height,
+    })
+}
+
+pub fn isImage(data: Bytes) -> Bool {
+    identify(data) != Unknown
+}
+
+pub fn isPng(data: Bytes) -> Bool {
+    data.len() >= 8 &&
+    byteAt(data, 0).toInt() == 0x89 &&
+    asciiAt(data, 1) == 'P' &&
+    asciiAt(data, 2) == 'N' &&
+    asciiAt(data, 3) == 'G' &&
+    byteAt(data, 4).toInt() == 0x0D &&
+    byteAt(data, 5).toInt() == 0x0A &&
+    byteAt(data, 6).toInt() == 0x1A &&
+    byteAt(data, 7).toInt() == 0x0A
+}
+
+pub fn isJpeg(data: Bytes) -> Bool {
+    data.len() >= 3 &&
+    byteAt(data, 0).toInt() == 0xFF &&
+    byteAt(data, 1).toInt() == 0xD8 &&
+    byteAt(data, 2).toInt() == 0xFF
+}
+
+pub fn isGif(data: Bytes) -> Bool {
+    data.len() >= 6 &&
+    asciiAt(data, 0) == 'G' &&
+    asciiAt(data, 1) == 'I' &&
+    asciiAt(data, 2) == 'F' &&
+    asciiAt(data, 3) == '8' &&
+    (asciiAt(data, 4) == '7' || asciiAt(data, 4) == '9') &&
+    asciiAt(data, 5) == 'a'
+}
+
+pub fn isBmp(data: Bytes) -> Bool {
+    data.len() >= 2 && asciiAt(data, 0) == 'B' && asciiAt(data, 1) == 'M'
+}
+
+pub fn isWebp(data: Bytes) -> Bool {
+    data.len() >= 12 &&
+    asciiAt(data, 0) == 'R' &&
+    asciiAt(data, 1) == 'I' &&
+    asciiAt(data, 2) == 'F' &&
+    asciiAt(data, 3) == 'F' &&
+    asciiAt(data, 8) == 'W' &&
+    asciiAt(data, 9) == 'E' &&
+    asciiAt(data, 10) == 'B' &&
+    asciiAt(data, 11) == 'P'
+}
+
+fn parsePng(data: Bytes) -> Result<Metadata, Error> {
+    if data.len() < 29 {
+        return Err(error.new("image: truncated PNG header"))
+    }
+    if readU32BE(data, 12) != 0x49484452 {
+        return Err(error.new("image: PNG missing IHDR"))
+    }
+    let bitDepth = byteAt(data, 24)
+    let colorType = byteAt(data, 25)
+    Ok(Metadata {
+        format: Png,
+        width: readU32BE(data, 16),
+        height: readU32BE(data, 20),
+        bitsPerPixel: pngBitsPerPixel(bitDepth, colorType),
+        hasAlpha: colorType.toInt() == 4 || colorType.toInt() == 6,
+        animated: pngHasAcTL(data),
+    })
+}
+
+fn parseGif(data: Bytes) -> Result<Metadata, Error> {
+    if data.len() < 10 {
+        return Err(error.new("image: truncated GIF header"))
+    }
+    let packed = byteAt(data, 10).toInt()
+    Ok(Metadata {
+        format: Gif,
+        width: readU16LE(data, 6),
+        height: readU16LE(data, 8),
+        bitsPerPixel: (packed & 0x07) + 1,
+        hasAlpha: true,
+        animated: gifImageCount(data) > 1,
+    })
+}
+
+fn parseBmp(data: Bytes) -> Result<Metadata, Error> {
+    if data.len() < 30 {
+        return Err(error.new("image: truncated BMP header"))
+    }
+    let height = readI32LEAbs(data, 22)
+    Ok(Metadata {
+        format: Bmp,
+        width: readI32LEAbs(data, 18),
+        height: height,
+        bitsPerPixel: readU16LE(data, 28),
+        hasAlpha: readU16LE(data, 28) == 32,
+        animated: false,
+    })
+}
+
+fn parseWebp(data: Bytes) -> Result<Metadata, Error> {
+    if data.len() < 30 {
+        return Err(error.new("image: truncated WebP header"))
+    }
+    let chunk = readFourCC(data, 12)
+    if chunk == "VP8X" {
+        let features = byteAt(data, 20).toInt()
+        return Ok(Metadata {
+            format: Webp,
+            width: readU24LE(data, 24) + 1,
+            height: readU24LE(data, 27) + 1,
+            bitsPerPixel: 32,
+            hasAlpha: (features & 0x10) != 0,
+            animated: (features & 0x02) != 0,
+        })
+    }
+    if chunk == "VP8L" {
+        if data.len() < 25 || byteAt(data, 20).toInt() != 0x2F {
+            return Err(error.new("image: invalid VP8L header"))
+        }
+        let b0 = byteAt(data, 21).toInt()
+        let b1 = byteAt(data, 22).toInt()
+        let b2 = byteAt(data, 23).toInt()
+        let b3 = byteAt(data, 24).toInt()
+        return Ok(Metadata {
+            format: Webp,
+            width: 1 + b0 + ((b1 & 0x3F) << 8),
+            height: 1 + ((b1 & 0xC0) >> 6) + (b2 << 2) + ((b3 & 0x0F) << 10),
+            bitsPerPixel: 32,
+            hasAlpha: (b3 & 0x10) != 0,
+            animated: false,
+        })
+    }
+    if chunk == "VP8 " {
+        if data.len() < 30 {
+            return Err(error.new("image: truncated VP8 header"))
+        }
+        return Ok(Metadata {
+            format: Webp,
+            width: readU16LE(data, 26) & 0x3FFF,
+            height: readU16LE(data, 28) & 0x3FFF,
+            bitsPerPixel: 24,
+            hasAlpha: false,
+            animated: false,
+        })
+    }
+    Err(error.new("image: unsupported WebP chunk"))
+}
+
+fn parseJpeg(data: Bytes) -> Result<Metadata, Error> {
+    let mut pos = 2
+    for pos + 4 < data.len() {
+        for pos < data.len() && byteAt(data, pos).toInt() != 0xFF {
+            pos = pos + 1
+        }
+        for pos < data.len() && byteAt(data, pos).toInt() == 0xFF {
+            pos = pos + 1
+        }
+        if pos >= data.len() {
+            break
+        }
+        let marker = byteAt(data, pos).toInt()
+        pos = pos + 1
+        if marker == 0xD9 || marker == 0xDA {
+            break
+        }
+        if markerHasNoLength(marker) {
+            continue
+        }
+        if pos + 2 > data.len() {
+            return Err(error.new("image: truncated JPEG segment"))
+        }
+        let len = readU16BE(data, pos)
+        if len < 2 || pos + len > data.len() {
+            return Err(error.new("image: invalid JPEG segment length"))
+        }
+        if isSofMarker(marker) {
+            if len < 7 {
+                return Err(error.new("image: truncated JPEG SOF segment"))
+            }
+            let precision = byteAt(data, pos + 2).toInt()
+            return Ok(Metadata {
+                format: Jpeg,
+                width: readU16BE(data, pos + 5),
+                height: readU16BE(data, pos + 3),
+                bitsPerPixel: precision * 3,
+                hasAlpha: false,
+                animated: false,
+            })
+        }
+        pos = pos + len
+    }
+    Err(error.new("image: JPEG dimensions not found"))
+}
+
+fn pngBitsPerPixel(bitDepth: Byte, colorType: Byte) -> Int {
+    let depth = bitDepth.toInt()
+    match colorType.toInt() {
+        0 -> depth,
+        2 -> depth * 3,
+        3 -> depth,
+        4 -> depth * 2,
+        6 -> depth * 4,
+        _ -> depth,
+    }
+}
+
+fn pngHasAcTL(data: Bytes) -> Bool {
+    let mut pos = 8
+    for pos + 12 <= data.len() {
+        let len = readU32BE(data, pos)
+        if pos + 12 + len > data.len() {
+            return false
+        }
+        if readFourCC(data, pos + 4) == "acTL" {
+            return true
+        }
+        pos = pos + 12 + len
+    }
+    false
+}
+
+fn gifImageCount(data: Bytes) -> Int {
+    let mut count = 0
+    let mut i = 13
+    for i < data.len() {
+        if byteAt(data, i).toInt() == 0x2C {
+            count = count + 1
+        }
+        i = i + 1
+    }
+    count
+}
+
+fn isSofMarker(marker: Int) -> Bool {
+    (marker >= 0xC0 && marker <= 0xC3) ||
+    (marker >= 0xC5 && marker <= 0xC7) ||
+    (marker >= 0xC9 && marker <= 0xCB) ||
+    (marker >= 0xCD && marker <= 0xCF)
+}
+
+fn markerHasNoLength(marker: Int) -> Bool {
+    marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7)
+}
+
+fn readFourCC(data: Bytes, offset: Int) -> String {
+    let mut out: List<Byte> = []
+    out.push(byteAt(data, offset))
+    out.push(byteAt(data, offset + 1))
+    out.push(byteAt(data, offset + 2))
+    out.push(byteAt(data, offset + 3))
+    bytes.toString(bytes.from(out)).unwrap()
+}
+
+fn readU16BE(data: Bytes, offset: Int) -> Int {
+    (byteAt(data, offset).toInt() << 8) | byteAt(data, offset + 1).toInt()
+}
+
+fn readU16LE(data: Bytes, offset: Int) -> Int {
+    byteAt(data, offset).toInt() | (byteAt(data, offset + 1).toInt() << 8)
+}
+
+fn readU24LE(data: Bytes, offset: Int) -> Int {
+    byteAt(data, offset).toInt() |
+    (byteAt(data, offset + 1).toInt() << 8) |
+    (byteAt(data, offset + 2).toInt() << 16)
+}
+
+fn readU32BE(data: Bytes, offset: Int) -> Int {
+    (byteAt(data, offset).toInt() << 24) |
+    (byteAt(data, offset + 1).toInt() << 16) |
+    (byteAt(data, offset + 2).toInt() << 8) |
+    byteAt(data, offset + 3).toInt()
+}
+
+fn readI32LEAbs(data: Bytes, offset: Int) -> Int {
+    let raw = byteAt(data, offset).toInt() |
+    (byteAt(data, offset + 1).toInt() << 8) |
+    (byteAt(data, offset + 2).toInt() << 16) |
+    (byteAt(data, offset + 3).toInt() << 24)
+    if raw < 0 {
+        return 0 - raw
+    }
+    raw
+}
+
+fn asciiAt(data: Bytes, index: Int) -> Char {
+    byteAt(data, index).toInt().toChar()
+}
+
+fn byteAt(data: Bytes, index: Int) -> Byte {
+    bytes.get(data, index).unwrap()
+}

--- a/internal/stdlib/modules/smtp.osty
+++ b/internal/stdlib/modules/smtp.osty
@@ -1,0 +1,358 @@
+// std.smtp - SMTP command, reply, and transaction planning helpers.
+//
+// This module covers the protocol surface that can be implemented without a
+// TLS runtime: command construction, AUTH payloads, reply parsing, capability
+// extraction, and full message transaction scripts from std.email.Envelope.
+
+use std.bytes
+use std.email
+use std.encoding
+use std.error
+use std.strings
+
+pub enum AuthKind {
+    NoAuth,
+    Plain,
+    Login,
+}
+
+pub enum Security {
+    PlainText,
+    StartTls,
+    Tls,
+}
+
+pub struct Auth {
+    pub kind: AuthKind,
+    pub username: String,
+    pub password: String,
+}
+
+pub struct ClientConfig {
+    pub host: String,
+    pub port: Int,
+    pub hostname: String,
+    pub security: Security,
+    pub auth: Auth,
+}
+
+pub struct Reply {
+    pub code: Int,
+    pub message: String,
+    pub continuation: Bool,
+}
+
+pub struct Capability {
+    pub name: String,
+    pub args: List<String>,
+}
+
+pub struct Transaction {
+    pub config: ClientConfig,
+    pub envelope: email.Envelope,
+}
+
+pub fn noAuth() -> Auth {
+    Auth {
+        kind: NoAuth,
+        username: "",
+        password: "",
+    }
+}
+
+pub fn plainAuth(username: String, password: String) -> Auth {
+    Auth {
+        kind: Plain,
+        username: username,
+        password: password,
+    }
+}
+
+pub fn loginAuth(username: String, password: String) -> Auth {
+    Auth {
+        kind: Login,
+        username: username,
+        password: password,
+    }
+}
+
+pub fn config(host: String, port: Int, hostname: String) -> Result<ClientConfig, Error> {
+    if strings.trimSpace(host).isEmpty() {
+        return Err(error.new("smtp: host is empty"))
+    }
+    if port <= 0 {
+        return Err(error.new("smtp: port must be positive"))
+    }
+    let local = if strings.trimSpace(hostname).isEmpty() { "localhost" } else { sanitizeAtom(hostname) }
+    Ok(ClientConfig {
+        host: strings.trimSpace(host),
+        port: port,
+        hostname: local,
+        security: PlainText,
+        auth: noAuth(),
+    })
+}
+
+pub fn withSecurity(cfg: ClientConfig, security: Security) -> ClientConfig {
+    ClientConfig {
+        host: cfg.host,
+        port: cfg.port,
+        hostname: cfg.hostname,
+        security: security,
+        auth: cfg.auth,
+    }
+}
+
+pub fn withAuth(cfg: ClientConfig, auth: Auth) -> ClientConfig {
+    ClientConfig {
+        host: cfg.host,
+        port: cfg.port,
+        hostname: cfg.hostname,
+        security: cfg.security,
+        auth: auth,
+    }
+}
+
+pub fn defaultPort(security: Security) -> Int {
+    match security {
+        PlainText -> 25,
+        StartTls  -> 587,
+        Tls       -> 465,
+    }
+}
+
+pub fn ehlo(hostname: String) -> String {
+    "EHLO {sanitizeAtom(hostname)}"
+}
+
+pub fn helo(hostname: String) -> String {
+    "HELO {sanitizeAtom(hostname)}"
+}
+
+pub fn startTls() -> String {
+    "STARTTLS"
+}
+
+pub fn mailFrom(addr: String) -> Result<String, Error> {
+    if !email.isEmail(addr) {
+        return Err(error.new("smtp: invalid sender address: {addr}"))
+    }
+    Ok("MAIL FROM:<{addr}>")
+}
+
+pub fn rcptTo(addr: String) -> Result<String, Error> {
+    if !email.isEmail(addr) {
+        return Err(error.new("smtp: invalid recipient address: {addr}"))
+    }
+    Ok("RCPT TO:<{addr}>")
+}
+
+pub fn dataCommand() -> String {
+    "DATA"
+}
+
+pub fn quit() -> String {
+    "QUIT"
+}
+
+pub fn rset() -> String {
+    "RSET"
+}
+
+pub fn noop() -> String {
+    "NOOP"
+}
+
+pub fn authPlain(username: String, password: String) -> String {
+    "AUTH PLAIN {plainPayload(username, password)}"
+}
+
+pub fn authLogin(username: String, password: String) -> List<String> {
+    [
+        "AUTH LOGIN",
+        encoding.base64.encode(bytes.fromString(username)),
+        encoding.base64.encode(bytes.fromString(password)),
+    ]
+}
+
+pub fn authCommands(auth: Auth) -> List<String> {
+    match auth.kind {
+        NoAuth -> [],
+        Plain  -> [authPlain(auth.username, auth.password)],
+        Login  -> authLogin(auth.username, auth.password),
+    }
+}
+
+pub fn transaction(config: ClientConfig, envelope: email.Envelope) -> Transaction {
+    Transaction {
+        config: config,
+        envelope: envelope,
+    }
+}
+
+pub fn commands(tx: Transaction) -> Result<List<String>, Error> {
+    let mut out: List<String> = []
+    out.push(ehlo(tx.config.hostname))
+    if tx.config.security == StartTls {
+        out.push(startTls())
+        out.push(ehlo(tx.config.hostname))
+    }
+    for cmd in authCommands(tx.config.auth) {
+        out.push(cmd)
+    }
+    out.push(mailFrom(tx.envelope.from)?)
+    for rcpt in tx.envelope.recipients {
+        out.push(rcptTo(rcpt)?)
+    }
+    out.push(dataCommand())
+    out.push(tx.envelope.data)
+    out.push(quit())
+    Ok(out)
+}
+
+pub fn renderCommands(commands: List<String>) -> String {
+    let mut out = ""
+    for cmd in commands {
+        out = "{out}{cmd}{crlf()}"
+    }
+    out
+}
+
+pub fn parseReply(line: String) -> Result<Reply, Error> {
+    let text = strings.trimEndChars(line, "\r\n")
+    if text.len() < 3 {
+        return Err(error.new("smtp: reply line is too short"))
+    }
+    let codeText = strings.slice(text, 0, 3)
+    let code = parseCode(codeText)?
+    let continuation = text.len() > 3 && text[3] == '-'
+    let message = if text.len() > 4 { strings.slice(text, 4, text.len()) } else { "" }
+    Ok(Reply {
+        code: code,
+        message: message,
+        continuation: continuation,
+    })
+}
+
+pub fn parseReplies(text: String) -> Result<List<Reply>, Error> {
+    let mut out: List<Reply> = []
+    for line in strings.splitLines(text) {
+        if !strings.trimSpace(line).isEmpty() {
+            out.push(parseReply(line)?)
+        }
+    }
+    Ok(out)
+}
+
+pub fn isPositiveCompletion(reply: Reply) -> Bool {
+    reply.code >= 200 && reply.code < 300
+}
+
+pub fn isPositiveIntermediate(reply: Reply) -> Bool {
+    reply.code >= 300 && reply.code < 400
+}
+
+pub fn isTransientFailure(reply: Reply) -> Bool {
+    reply.code >= 400 && reply.code < 500
+}
+
+pub fn isPermanentFailure(reply: Reply) -> Bool {
+    reply.code >= 500 && reply.code < 600
+}
+
+pub fn capabilities(replies: List<Reply>) -> List<Capability> {
+    let mut out: List<Capability> = []
+    for reply in replies {
+        if reply.code == 250 {
+            let cap = parseCapability(reply.message)
+            if !cap.name.isEmpty() {
+                out.push(cap)
+            }
+        }
+    }
+    out
+}
+
+pub fn hasCapability(caps: List<Capability>, name: String) -> Bool {
+    let wanted = strings.toUpper(strings.trimSpace(name))
+    for cap in caps {
+        if cap.name == wanted {
+            return true
+        }
+    }
+    false
+}
+
+pub fn supportsAuth(caps: List<Capability>, mechanism: String) -> Bool {
+    let wanted = strings.toUpper(strings.trimSpace(mechanism))
+    for cap in caps {
+        if cap.name == "AUTH" {
+            for arg in cap.args {
+                if strings.toUpper(arg) == wanted {
+                    return true
+                }
+            }
+        }
+    }
+    false
+}
+
+fn parseCapability(message: String) -> Capability {
+    let fields = strings.split(strings.trimSpace(message), " ")
+    if fields.isEmpty() {
+        return Capability { name: "", args: [] }
+    }
+    let mut args: List<String> = []
+    let mut i = 1
+    for i < fields.len() {
+        let arg = strings.trimSpace(fields[i])
+        if !arg.isEmpty() {
+            args.push(arg)
+        }
+        i = i + 1
+    }
+    Capability {
+        name: strings.toUpper(fields[0]),
+        args: args,
+    }
+}
+
+fn plainPayload(username: String, password: String) -> String {
+    let mut raw: List<Byte> = []
+    raw.push(0.toByte())
+    appendStringBytes(raw, username)
+    raw.push(0.toByte())
+    appendStringBytes(raw, password)
+    encoding.base64.encode(bytes.from(raw))
+}
+
+fn appendStringBytes(out: List<Byte>, text: String) {
+    let raw = text.bytes()
+    let mut i = 0
+    for i < raw.len() {
+        out.push(raw[i])
+        i = i + 1
+    }
+}
+
+fn parseCode(text: String) -> Result<Int, Error> {
+    if text.len() != 3 {
+        return Err(error.new("smtp: reply code must have three digits"))
+    }
+    let mut code = 0
+    for c in text.chars() {
+        if c < '0' || c > '9' {
+            return Err(error.new("smtp: invalid reply code: {text}"))
+        }
+        code = code * 10 + (c.toInt() - '0'.toInt())
+    }
+    Ok(code)
+}
+
+fn sanitizeAtom(value: String) -> String {
+    strings.replaceAll(strings.replaceAll(strings.trimSpace(value), "\r", ""), "\n", "")
+}
+
+fn crlf() -> String {
+    "\r\n"
+}

--- a/internal/stdlib/modules/zip.osty
+++ b/internal/stdlib/modules/zip.osty
@@ -1,0 +1,327 @@
+// std.zip - ZIP archive helpers for stored entries.
+//
+// ZIP's "store" method needs no compression runtime, so this module can
+// create and read interoperable archives today. Deflated entries are detected
+// and reported as unsupported until std.compress grows deflate support.
+
+use std.bytes
+use std.error
+use std.strings
+
+pub enum Method {
+    Stored,
+    Deflated,
+}
+
+pub struct Entry {
+    pub name: String,
+    pub method: Method,
+    pub data: Bytes,
+    pub crc32: Int,
+    pub compressedSize: Int,
+    pub uncompressedSize: Int,
+}
+
+pub fn file(name: String, data: Bytes) -> Result<Entry, Error> {
+    let clean = normalizeName(name)?
+    let crc = crc32(data)
+    Ok(Entry {
+        name: clean,
+        method: Stored,
+        data: data,
+        crc32: crc,
+        compressedSize: data.len(),
+        uncompressedSize: data.len(),
+    })
+}
+
+pub fn encode(entries: List<Entry>) -> Result<Bytes, Error> {
+    let mut out: List<Byte> = []
+    let mut central: List<Byte> = []
+    let mut offsets: List<Int> = []
+    for entry in entries {
+        let clean = normalizeName(entry.name)?
+        if entry.method != Stored {
+            return Err(error.new("zip: only stored entries can be encoded without deflate runtime"))
+        }
+        offsets.push(out.len())
+        appendLocalHeader(out, clean, entry.data)
+        appendBytes(out, entry.data)
+    }
+
+    let centralStart = out.len()
+    let mut i = 0
+    for entry in entries {
+        appendCentralHeader(central, normalizeName(entry.name)?, entry.data, offsets[i])
+        i = i + 1
+    }
+    appendBytes(out, bytes.from(central))
+    appendEndOfCentralDirectory(out, entries.len(), central.len(), centralStart)
+    Ok(bytes.from(out))
+}
+
+pub fn decode(archive: Bytes) -> Result<List<Entry>, Error> {
+    if archive.len() == 0 {
+        return Err(error.new("zip: empty archive"))
+    }
+    let mut out: List<Entry> = []
+    let mut pos = 0
+    for pos + 4 <= archive.len() {
+        let sig = readU32(archive, pos)
+        if sig == centralSignature() || sig == endSignature() {
+            return Ok(out)
+        }
+        if sig != localSignature() {
+            if out.isEmpty() {
+                return Err(error.new("zip: missing local file header"))
+            }
+            return Ok(out)
+        }
+        if pos + 30 > archive.len() {
+            return Err(error.new("zip: truncated local file header"))
+        }
+        let flags = readU16(archive, pos + 6)
+        let method = readU16(archive, pos + 8)
+        if (flags & 0x08) != 0 {
+            return Err(error.new("zip: data descriptor entries are not supported"))
+        }
+        if method != 0 {
+            return Err(error.new("zip: compressed entries require deflate runtime"))
+        }
+        let expectedCrc = readU32(archive, pos + 14)
+        let compressedSize = readU32(archive, pos + 18)
+        let uncompressedSize = readU32(archive, pos + 22)
+        let nameLen = readU16(archive, pos + 26)
+        let extraLen = readU16(archive, pos + 28)
+        let nameStart = pos + 30
+        let dataStart = nameStart + nameLen + extraLen
+        let dataEnd = dataStart + compressedSize
+        if dataEnd > archive.len() {
+            return Err(error.new("zip: truncated entry payload"))
+        }
+        let name = readString(archive, nameStart, nameLen)
+        normalizeName(name)?
+        let payload = sliceBytes(archive, dataStart, dataEnd)
+        let actualCrc = crc32(payload)
+        if actualCrc != expectedCrc {
+            return Err(error.new("zip: crc mismatch for {name}"))
+        }
+        if payload.len() != uncompressedSize {
+            return Err(error.new("zip: size mismatch for {name}"))
+        }
+        out.push(Entry {
+            name: name,
+            method: Stored,
+            data: payload,
+            crc32: actualCrc,
+            compressedSize: compressedSize,
+            uncompressedSize: uncompressedSize,
+        })
+        pos = dataEnd
+    }
+    Ok(out)
+}
+
+pub fn list(archive: Bytes) -> Result<List<String>, Error> {
+    let entries = decode(archive)?
+    let mut out: List<String> = []
+    for entry in entries {
+        out.push(entry.name)
+    }
+    Ok(out)
+}
+
+pub fn extract(archive: Bytes, name: String) -> Result<Bytes?, Error> {
+    let clean = normalizeName(name)?
+    for entry in decode(archive)? {
+        if entry.name == clean {
+            return Ok(Some(entry.data))
+        }
+    }
+    Ok(noneBytes())
+}
+
+pub fn contains(archive: Bytes, name: String) -> Bool {
+    match extract(archive, name) {
+        Ok(Some(_)) -> true,
+        _           -> false,
+    }
+}
+
+pub fn isArchive(data: Bytes) -> Bool {
+    if data.len() < 4 {
+        return false
+    }
+    let sig = readU32(data, 0)
+    sig == localSignature() || sig == endSignature()
+}
+
+pub fn crc32(data: Bytes) -> Int {
+    let mut crc = 0xFFFFFFFF
+    let mut i = 0
+    for i < data.len() {
+        crc = crc ^ byteAt(data, i).toInt()
+        let mut bit = 0
+        for bit < 8 {
+            if (crc & 1) != 0 {
+                crc = (crc >> 1) ^ 0xEDB88320
+            } else {
+                crc = crc >> 1
+            }
+            bit = bit + 1
+        }
+        i = i + 1
+    }
+    (crc ^ 0xFFFFFFFF) & 0xFFFFFFFF
+}
+
+pub fn methodName(method: Method) -> String {
+    match method {
+        Stored   -> "stored",
+        Deflated -> "deflated",
+    }
+}
+
+fn appendLocalHeader(out: List<Byte>, name: String, data: Bytes) {
+    let crc = crc32(data)
+    appendU32(out, localSignature())
+    appendU16(out, 20)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, crc)
+    appendU32(out, data.len())
+    appendU32(out, data.len())
+    appendU16(out, name.bytes().len())
+    appendU16(out, 0)
+    appendString(out, name)
+}
+
+fn appendCentralHeader(out: List<Byte>, name: String, data: Bytes, offset: Int) {
+    let crc = crc32(data)
+    appendU32(out, centralSignature())
+    appendU16(out, 20)
+    appendU16(out, 20)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, crc)
+    appendU32(out, data.len())
+    appendU32(out, data.len())
+    appendU16(out, name.bytes().len())
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, 0)
+    appendU32(out, offset)
+    appendString(out, name)
+}
+
+fn appendEndOfCentralDirectory(out: List<Byte>, count: Int, centralSize: Int, centralOffset: Int) {
+    appendU32(out, endSignature())
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, count)
+    appendU16(out, count)
+    appendU32(out, centralSize)
+    appendU32(out, centralOffset)
+    appendU16(out, 0)
+}
+
+fn normalizeName(name: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(name)
+    if clean.isEmpty() {
+        return Err(error.new("zip: entry name is empty"))
+    }
+    if strings.startsWith(clean, "/") {
+        return Err(error.new("zip: absolute paths are not allowed"))
+    }
+    if strings.endsWith(clean, "/") {
+        return Err(error.new("zip: directory entries are not supported yet"))
+    }
+    if clean == ".." || strings.startsWith(clean, "../") || strings.endsWith(clean, "/..") || strings.contains(clean, "/../") {
+        return Err(error.new("zip: parent path segments are not allowed"))
+    }
+    Ok(clean)
+}
+
+fn appendBytes(out: List<Byte>, data: Bytes) {
+    let mut i = 0
+    for i < data.len() {
+        out.push(byteAt(data, i))
+        i = i + 1
+    }
+}
+
+fn appendString(out: List<Byte>, value: String) {
+    let raw = value.bytes()
+    let mut i = 0
+    for i < raw.len() {
+        out.push(raw[i])
+        i = i + 1
+    }
+}
+
+fn appendU16(out: List<Byte>, value: Int) {
+    pushByte(out, value & 0xFF)
+    pushByte(out, (value >> 8) & 0xFF)
+}
+
+fn appendU32(out: List<Byte>, value: Int) {
+    pushByte(out, value & 0xFF)
+    pushByte(out, (value >> 8) & 0xFF)
+    pushByte(out, (value >> 16) & 0xFF)
+    pushByte(out, (value >> 24) & 0xFF)
+}
+
+fn readU16(data: Bytes, offset: Int) -> Int {
+    byteAt(data, offset).toInt() | (byteAt(data, offset + 1).toInt() << 8)
+}
+
+fn readU32(data: Bytes, offset: Int) -> Int {
+    byteAt(data, offset).toInt() |
+    (byteAt(data, offset + 1).toInt() << 8) |
+    (byteAt(data, offset + 2).toInt() << 16) |
+    (byteAt(data, offset + 3).toInt() << 24)
+}
+
+fn readString(data: Bytes, offset: Int, len: Int) -> String {
+    bytes.toString(sliceBytes(data, offset, offset + len)).unwrap()
+}
+
+fn sliceBytes(data: Bytes, start: Int, end: Int) -> Bytes {
+    let mut out: List<Byte> = []
+    let mut i = start
+    for i < end {
+        out.push(byteAt(data, i))
+        i = i + 1
+    }
+    bytes.from(out)
+}
+
+fn pushByte(out: List<Byte>, value: Int) {
+    out.push((value & 0xFF).toByte())
+}
+
+fn byteAt(data: Bytes, index: Int) -> Byte {
+    bytes.get(data, index).unwrap()
+}
+
+fn noneBytes() -> Bytes? {
+    None
+}
+
+fn localSignature() -> Int {
+    0x04034B50
+}
+
+fn centralSignature() -> Int {
+    0x02014B50
+}
+
+fn endSignature() -> Int {
+    0x06054B50
+}


### PR DESCRIPTION
## Summary

- Add `std.smtp` for command construction, AUTH payloads, reply parsing, capability parsing, and full transaction command scripts from `std.email.Envelope`.
- Add `std.zip` with stored-entry ZIP encode/decode/list/extract support, central directory/EOCD writing, safe path validation, and CRC32 checks.
- Add `std.image` for PNG/JPEG/GIF/BMP/WebP format detection and dimension/basic metadata parsing.
- Update the stdlib matrix and spec docs so the former missing module bucket is now reduced to runtime/deep work: DB drivers, SMTP TLS/socket execution, ZIP deflate, and image pixel decode.

## Validation

- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultBigGaps'`
- `go test -count=1 -vet=off ./internal/backend`
- `just fmt-check`
- `git diff --check`