### PR TITLE
Remove arena-first frontend loader

### DIFF
--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -85,7 +85,7 @@ func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
 		return backend.Entry{}, err
 	}
 	ws.Stdlib = stdlib.LoadCached()
-	if _, err := ws.LoadPackageArenaFirst(""); err != nil {
+	if _, err := ws.LoadPackageNative(""); err != nil {
 		return backend.Entry{}, err
 	}
 	results := ws.ResolveAll()

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -315,10 +315,10 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 	ws.Stdlib = stdlib.Load()
 	ws.Deps = deps
 	if m.HasPackage {
-		_, _ = ws.LoadPackageArenaFirst("")
+		_, _ = ws.LoadPackageNative("")
 	}
 	for _, mem := range m.Workspace.Members {
-		if _, err := ws.LoadPackageArenaFirst(mem); err != nil {
+		if _, err := ws.LoadPackageNative(mem); err != nil {
 			fmt.Fprintf(os.Stderr, "osty build: member %s: %v\n", mem, err)
 			os.Exit(1)
 		}
@@ -365,9 +365,8 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 // the selected backend for the binary entry point.
 // When deps is non-nil, we wrap the package in a one-member Workspace
 // so `use` references to vendored external deps resolve through the
-// DepProvider. The plain resolve.LoadPackageArenaFirst path is kept as
-// a fallback for zero-dep projects because it's simpler and has no
-// workspace state to carry.
+// DepProvider. The zero-dep path uses the same native package loader without
+// workspace state.
 func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
 	if deps != nil {
 		ws, err := resolve.NewWorkspace(dir)
@@ -378,7 +377,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		ws.SourceTransform = aiRepairSourceTransform("osty build --airepair", os.Stderr, flags)
 		ws.Stdlib = stdlib.Load()
 		ws.Deps = deps
-		if _, err := ws.LoadPackageArenaFirst(""); err != nil {
+		if _, err := ws.LoadPackageNative(""); err != nil {
 			fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 			os.Exit(1)
 		}
@@ -404,7 +403,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		}
 		return nil
 	}
-	pkg, err := resolve.LoadPackageArenaFirstWithTransform(dir, aiRepairSourceTransform("osty build --airepair", os.Stderr, flags))
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform("osty build --airepair", os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)

--- a/cmd/osty/doc.go
+++ b/cmd/osty/doc.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/docgen"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -106,19 +106,19 @@ func runDoc(args []string, flags cliFlags) {
 
 	var pkgDoc *docgen.SelfDocPackage
 	if info.IsDir() {
-		pkg, err := resolve.LoadPackageArenaFirst(path)
+		pkg, err := resolve.LoadPackageForNative(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty doc: %v\n", err)
 			os.Exit(1)
 		}
 		anyFatal := false
 		for _, f := range pkg.Files {
-			if f.File == nil {
-				anyFatal = true
-			}
 			if len(f.ParseDiags) > 0 {
 				fmter := newFormatter(f.Path, f.Source, flags)
 				printDiags(fmter, f.ParseDiags, flags)
+				if hasError(f.ParseDiags) {
+					anyFatal = true
+				}
 			}
 		}
 		if anyFatal {
@@ -131,12 +131,13 @@ func runDoc(args []string, flags cliFlags) {
 			fmt.Fprintf(os.Stderr, "osty doc: %v\n", err)
 			os.Exit(1)
 		}
-		file, diags := parser.ParseDiagnostics(src)
+		run := selfhost.Run(src)
+		diags := run.Diagnostics()
 		if len(diags) > 0 {
 			fmter := newFormatter(path, src, flags)
 			printDiags(fmter, diags, flags)
 		}
-		if file == nil {
+		if hasError(diags) {
 			os.Exit(1)
 		}
 		label := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
@@ -233,7 +234,7 @@ func runWorkspaceDoc(root, format, outPath, title string,
 	}
 	ws.Stdlib = stdlib.LoadCached()
 	for _, p := range resolve.WorkspacePackagePaths(root) {
-		_, _ = ws.LoadPackageArenaFirst(p)
+		_, _ = ws.LoadPackageNative(p)
 	}
 
 	// Build docgen Packages keyed by the workspace's import paths so
@@ -245,15 +246,14 @@ func runWorkspaceDoc(root, format, outPath, title string,
 			continue
 		}
 		// Surface parse diagnostics for each file as before — keeps
-		// "docs from a noisy WIP tree" workable, fails only on AST-
-		// less files.
+		// "docs from a noisy WIP tree" workable.
 		for _, f := range pkg.Files {
-			if f.File == nil {
-				anyFatal = true
-			}
 			if len(f.ParseDiags) > 0 {
 				fmter := newFormatter(f.Path, f.Source, flags)
 				printDiags(fmter, f.ParseDiags, flags)
+				if hasError(f.ParseDiags) {
+					anyFatal = true
+				}
 			}
 		}
 		dp := docPackageFromResolved(pkg)

--- a/cmd/osty/doctest_runner.go
+++ b/cmd/osty/doctest_runner.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/doctest"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // doctestRunnerFilename is the synthetic file name registered on the
@@ -73,8 +73,8 @@ func appendDoctestCases(pkg *resolve.Package, filters []string) ([]nativeTestCas
 
 	runnerPath := filepath.Join(pkg.Dir, doctestRunnerFilename)
 	source := doctest.BuildRunnerSource(collected)
-	parsed := parser.ParseDetailed(source)
-	file, diags := parsed.File, parsed.Diagnostics
+	run := selfhost.Run(source)
+	file, diags := selfhost.LowerPublicFileFromRun(run), run.Diagnostics()
 	if file == nil {
 		return nil, fmt.Errorf("parse doctest runner: %v", diags)
 	}
@@ -90,7 +90,7 @@ func appendDoctestCases(pkg *resolve.Package, filters []string) ([]nativeTestCas
 		CanonicalSource: canonicalSrc,
 		CanonicalMap:    canonicalMap,
 		File:            file,
-		Run:             parsed.Run,
+		Run:             run,
 		ParseDiags:      diags,
 	})
 

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -63,6 +63,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/scaffold"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -1572,7 +1573,7 @@ func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTrans
 	}
 	ws.SourceTransform = transform
 	ws.Stdlib = stdlib.LoadCached()
-	if _, err := ws.LoadPackageArenaFirst(""); err != nil {
+	if _, err := ws.LoadPackageNative(""); err != nil {
 		return nil, err
 	}
 	results := ws.ResolveAll()
@@ -1636,20 +1637,20 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 		if transform != nil {
 			src = transform(path, src)
 		}
-		parsed := parser.ParseDetailed(src)
-		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
+		run := selfhost.Run(src)
+		file := selfhost.LowerPublicFileFromRun(run)
+		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, file)
 		pf := &resolve.PackageFile{
 			Path:            path,
 			Source:          src,
 			CanonicalSource: canonicalSrc,
 			CanonicalMap:    canonicalMap,
-			File:            parsed.File,
-			Run:             parsed.Run,
-			ParseDiags:      parsed.Diagnostics,
-			ParseProvenance: parsed.Provenance,
+			File:            file,
+			Run:             run,
+			ParseDiags:      run.Diagnostics(),
 		}
 		pkg.Files = append(pkg.Files, pf)
-		res.Diags = append(res.Diags, parsed.Diagnostics...)
+		res.Diags = append(res.Diags, pf.ParseDiags...)
 		if path == sourcePath {
 			entryFile = pf
 		}
@@ -1777,8 +1778,9 @@ func parseGenEmitFile(pkg *resolve.Package) (*ast.File, []byte, error) {
 	// checker inference paths out of sync with the merged byte stream, which in
 	// turn can poison the backend bridge with `<error>` types for otherwise valid
 	// native-test programs.
-	if reparsed, diags := parser.ParseDiagnostics(src); reparsed != nil && !hasError(diags) {
-		return reparsed, src, nil
+	run := selfhost.Run(src)
+	if file, diags := selfhost.LowerPublicFileFromRun(run), run.Diagnostics(); file != nil && !hasError(diags) {
+		return file, src, nil
 	}
 	return nil, nil, fmt.Errorf("%s: merged package source could not be reparsed for backend emission", pkg.Dir)
 }

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/manifest"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
@@ -22,7 +21,7 @@ import (
 // runCheckPackage runs lex + parse + resolve over dir. Two modes:
 //
 //   - **Single-package**: dir contains `.osty` files directly. Loaded
-//     via resolve.LoadPackageArenaFirst.
+//     via resolve.LoadPackageForNativeWithTransform.
 //   - **Workspace**: dir has no top-level `.osty` files but one or
 //     more subdirectories do. The whole tree is loaded via Workspace
 //     so cross-package `use` declarations resolve.
@@ -138,9 +137,8 @@ func workspaceContainsPath(root string, members []string, target string) bool {
 
 // runResolveFile drives the single-file `osty resolve FILE` happy path
 // entirely through the self-host arena (selfhost.ResolveFromSource);
-// the astbridge *ast.File is only materialized lazily via
-// parser.ParseDiagnostics when a fallback needs it (printResolution
-// with no native rows, or --show-scopes). Returns the subcommand's
+// the public *ast.File is only materialized lazily when a fallback needs
+// it (printResolution with no native rows, or --show-scopes). Returns the subcommand's
 // exit code: 0 on clean input, 1 when any error-severity diagnostic
 // surfaces. Keeping the body factored out lets the astbridge counter
 // pin the end-to-end CLI invariant in-process (not just the library
@@ -153,8 +151,7 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 	)
 	ensureLoweredFile := func() *ast.File {
 		if file == nil {
-			parsed, _ := parser.ParseDiagnostics(src)
-			file = parsed
+			file = selfhost.LowerPublicFileFromRun(selfhost.Run(src))
 		}
 		return file
 	}

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -140,7 +140,7 @@ func runRun(args []string, cliF cliFlags) {
 	ws.SourceTransform = aiRepairSourceTransform("osty run --airepair", os.Stderr, cliF)
 	ws.Stdlib = stdlib.Load()
 	ws.Deps = deps
-	rootPkg, err := ws.LoadPackageArenaFirst("")
+	rootPkg, err := ws.LoadPackageNative("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -127,7 +127,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	pkg, err := resolve.LoadPackageWithTestsTransform(pkgDir, aiRepairSourceTransform("osty test --airepair", stderr, flags))
+	pkg, err := resolve.LoadPackageForNativeWithTestsTransform(pkgDir, aiRepairSourceTransform("osty test --airepair", stderr, flags))
 	if err != nil {
 		fmt.Fprintf(stderr, "osty test: %v\n", err)
 		return 1
@@ -138,6 +138,11 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "osty test: parse errors in %s\n", pkgDir)
 		return 1
 	}
+	// Test discovery and the current package backend still consume the public
+	// AST compatibility surface. Keep that boundary explicit now that package
+	// loading itself is native-only.
+	pkg.MaterializePublicCompatibility()
+	pkg.MaterializeCanonicalSources()
 
 	tests, err := discoverNativeTests(pkg, filters, benchMode)
 	if err != nil {

--- a/internal/cihost/host.go
+++ b/internal/cihost/host.go
@@ -107,7 +107,7 @@ func LoadRunnerState(root string, preloaded *manifest.Manifest) LoadResult {
 		return loadWorkspace(r, false)
 	}
 
-	pkg, err := resolve.LoadPackageArenaFirst(r.Root)
+	pkg, err := resolve.LoadPackageForNative(r.Root)
 	if err != nil {
 		return *r
 	}
@@ -134,7 +134,7 @@ func loadWorkspace(r *LoadResult, byManifest bool) LoadResult {
 			return
 		}
 		seen[member] = true
-		if pkg, err := ws.LoadPackageArenaFirst(member); err == nil && pkg != nil {
+		if pkg, err := ws.LoadPackageNative(member); err == nil && pkg != nil {
 			filterPackageCIFiles(pkg)
 			r.Packages = append(r.Packages, pkg)
 			pkgPaths = append(pkgPaths, member)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -600,12 +600,12 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 // separately), and the rest mirrors Run. Workspaces are not handled
 // here — point at a leaf package directory.
 //
-// If loading fails (e.g. directory unreadable), the returned Result
-// has empty Stages and the error is returned to the caller so the
-// CLI can decide whether to abort. Uses the arena-first loader
-// (Phase 1c.2) so parse keeps the astbridge counter low.
+// If loading fails (e.g. directory unreadable), the returned Result has empty
+// Stages and the error is returned to the caller so the CLI can decide whether
+// to abort. Loading starts from the selfhost native package loader; public AST
+// compatibility is materialized later only by legacy stages that still need it.
 func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
-	pkg, err := resolve.LoadPackageArenaFirstWithTransform(dir, cfg.SourceTransform)
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, cfg.SourceTransform)
 	if err != nil {
 		return Result{}, err
 	}
@@ -812,7 +812,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 	ws.Stdlib = stdlib.LoadCached()
 	ws.SourceTransform = cfg.SourceTransform
 	for _, p := range resolve.WorkspacePackagePaths(dir) {
-		_, _ = ws.LoadPackageArenaFirst(p)
+		_, _ = ws.LoadPackageNative(p)
 	}
 
 	totalFiles, totalBytes, totalDecls, totalStmts, totalUses := 0, 0, 0, 0, 0

--- a/internal/resolve/load_selected.go
+++ b/internal/resolve/load_selected.go
@@ -36,7 +36,7 @@ func LoadPackageFilesWithTransform(paths []string, stdlib StdlibProvider, transf
 	if stdlib != nil {
 		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
 	}
-	loaded, err := loadPackagePaths(absPaths, dir, filepath.Base(dir), transform)
+	loaded, err := loadPackageNativePaths(absPaths, dir, filepath.Base(dir), transform)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -7,115 +7,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
 )
 
 // SourceTransform lets callers rewrite raw source bytes before the
 // parser sees them. nil preserves the on-disk bytes.
 type SourceTransform func(path string, src []byte) []byte
-
-// LoadPackageWithTransform discovers and parses every `.osty` file
-// directly under dir (non-recursive) and returns them as a single
-// Package ready for ResolvePackage. Test files (`*_test.osty`) are
-// excluded per v0.4 §11 so production builds don't drag test-only
-// declarations into scope. Accepts an optional pre-parse source
-// transform — callers can normalize foreign syntax or inject generated
-// source before diagnostics are computed.
-//
-// The returned Package has Files sorted lexicographically by path for
-// deterministic diagnostic ordering.
-//
-// Public callers should prefer LoadPackageArenaFirst, which routes
-// through the selfhost arena-first loader. This function is retained
-// as the internal primitive workspace.go uses for its own loading
-// machinery.
-func LoadPackageWithTransform(dir string, transform SourceTransform) (*Package, error) {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return nil, err
-	}
-	entries, err := os.ReadDir(abs)
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", abs, err)
-	}
-
-	var paths []string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") {
-			continue
-		}
-		if strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		paths = append(paths, filepath.Join(abs, name))
-	}
-	sort.Strings(paths)
-	return loadPackagePaths(paths, abs, filepath.Base(abs), transform)
-}
-
-// LoadPackageWithTests is like LoadPackage but also includes every
-// `*_test.osty` file. Used by `osty test` and similar commands.
-func LoadPackageWithTests(dir string) (*Package, error) {
-	return LoadPackageWithTestsTransform(dir, nil)
-}
-
-// LoadPackageWithTestsTransform is LoadPackageWithTests plus an
-// optional pre-parse source transform.
-func LoadPackageWithTestsTransform(dir string, transform SourceTransform) (*Package, error) {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return nil, err
-	}
-	entries, err := os.ReadDir(abs)
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", abs, err)
-	}
-	var paths []string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if strings.HasSuffix(name, ".osty") {
-			paths = append(paths, filepath.Join(abs, name))
-		}
-	}
-	sort.Strings(paths)
-	return loadPackagePaths(paths, abs, filepath.Base(abs), transform)
-}
-
-func loadPackagePaths(paths []string, dir, name string, transform SourceTransform) (*Package, error) {
-	pkg := &Package{Dir: dir, Name: name}
-	for _, p := range paths {
-		src, err := os.ReadFile(p)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", p, err)
-		}
-		if transform != nil {
-			src = transform(p, src)
-		}
-		parsed := parser.ParseDetailed(src)
-		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
-		pkg.Files = append(pkg.Files, &PackageFile{
-			Path:            p,
-			Source:          src,
-			CanonicalSource: canonicalSrc,
-			CanonicalMap:    canonicalMap,
-			File:            parsed.File,
-			Run:             parsed.Run,
-			ParseDiags:      parsed.Diagnostics,
-			ParseProvenance: parsed.Provenance,
-		})
-	}
-	return pkg, nil
-}
 
 // LoadPackageForNative is the astbridge-free sibling of LoadPackage: it
 // discovers every `.osty` file under dir (non-recursive, test files
@@ -132,6 +30,23 @@ func LoadPackageForNative(dir string) (*Package, error) {
 // LoadPackageForNativeWithTransform is LoadPackageForNative plus an
 // optional pre-parse source transform.
 func LoadPackageForNativeWithTransform(dir string, transform SourceTransform) (*Package, error) {
+	return loadPackageForNativeWithTransform(dir, transform, false)
+}
+
+// LoadPackageForNativeWithTests is like LoadPackageForNative but also includes
+// every `*_test.osty` file. Used by `osty test` so test discovery starts from
+// the selfhost arena instead of the old Go parser loader.
+func LoadPackageForNativeWithTests(dir string) (*Package, error) {
+	return LoadPackageForNativeWithTestsTransform(dir, nil)
+}
+
+// LoadPackageForNativeWithTestsTransform is LoadPackageForNativeWithTests plus
+// an optional pre-parse source transform.
+func LoadPackageForNativeWithTestsTransform(dir string, transform SourceTransform) (*Package, error) {
+	return loadPackageForNativeWithTransform(dir, transform, true)
+}
+
+func loadPackageForNativeWithTransform(dir string, transform SourceTransform, includeTests bool) (*Package, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -149,7 +64,7 @@ func LoadPackageForNativeWithTransform(dir string, transform SourceTransform) (*
 		if !strings.HasSuffix(name, ".osty") {
 			continue
 		}
-		if strings.HasSuffix(name, "_test.osty") {
+		if !includeTests && strings.HasSuffix(name, "_test.osty") {
 			continue
 		}
 		paths = append(paths, filepath.Join(abs, name))
@@ -175,43 +90,6 @@ func loadPackageNativePaths(paths []string, dir, name string, transform SourceTr
 			Run:        run,
 			ParseDiags: append([]*diag.Diagnostic(nil), run.Diagnostics()...),
 		})
-	}
-	return pkg, nil
-}
-
-// LoadPackageArenaFirst parses through the selfhost arena-first loader, then
-// explicitly materializes the public-AST compatibility surface expected by
-// legacy resolve/check/lint/codegen consumers. New native consumers should use
-// LoadPackageForNative and avoid this compatibility hop until they really need
-// pf.File / pf.CanonicalSource.
-func LoadPackageArenaFirst(dir string) (*Package, error) {
-	return LoadPackageArenaFirstWithTransform(dir, nil)
-}
-
-// LoadPackageArenaFirstWithTransform is LoadPackageArenaFirst plus an
-// optional pre-parse source transform (e.g. airepair).
-func LoadPackageArenaFirstWithTransform(dir string, transform SourceTransform) (*Package, error) {
-	pkg, err := LoadPackageForNativeWithTransform(dir, transform)
-	if err != nil {
-		return nil, err
-	}
-	pkg.MaterializePublicCompatibility()
-	pkg.MaterializeCanonicalSources()
-	return pkg, nil
-}
-
-// LoadPackageArenaFirst is the Workspace-level sibling of the
-// package-level LoadPackageArenaFirst. Delegates to LoadPackageNative, then
-// explicitly materializes public-AST compatibility output so downstream legacy
-// consumers observe the full Package shape.
-func (w *Workspace) LoadPackageArenaFirst(dotPath string) (*Package, error) {
-	pkg, err := w.LoadPackageNative(dotPath)
-	if err != nil {
-		return nil, err
-	}
-	if pkg != nil {
-		pkg.MaterializePublicCompatibility()
-		pkg.MaterializeCanonicalSources()
 	}
 	return pkg, nil
 }

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -62,21 +62,15 @@ type PackageFile struct {
 	// spans carried by the parsed AST. Nil when the canonical source is a direct
 	// passthrough or no map was produced.
 	CanonicalMap *sourcemap.Map
-	// File is the parsed AST. Normally non-nil, even when Parse reported
-	// errors (best-effort partial trees support multi-error reporting).
-	// Packages loaded via LoadPackageForNative defer File materialization
-	// — they populate Run instead and leave this nil until EnsureFile is
-	// called. All Go-native passes (resolve.ResolvePackage, check.File,
-	// lint) still require File, so callers that may hit those paths should
-	// EnsureFile first.
+	// File is the public AST compatibility surface. Native-loaded packages
+	// populate Run instead and leave this nil until EnsureFile is called.
+	// Legacy passes that still traverse Go AST should materialize it at the
+	// explicit boundary rather than relying on loader side effects.
 	File *ast.File
-	// Run is the self-host FrontendRun that produced this file's
-	// arena. Populated by LoadPackageForNative (and by
-	// LoadPackageWithTransform when File is also eagerly computed) so
-	// the native resolver / checker / llvmgen can consume the arena
-	// directly, skipping the astbridge *ast.File round-trip. Nil on
-	// synthetic packages built from already-parsed ASTs that were not
-	// produced by the self-host front end.
+	// Run is the self-host FrontendRun that produced this file's arena.
+	// Populated by LoadPackageForNative so the native resolver / checker /
+	// llvmgen can consume the arena directly, skipping public AST
+	// materialization unless a compatibility consumer asks for it.
 	Run *selfhost.FrontendRun
 	// ParseDiags are diagnostics produced during lex + parse of this
 	// file. They are merged with resolver diagnostics by the package
@@ -144,15 +138,6 @@ func (pkg *Package) MaterializePublicCompatibility() {
 	for _, pf := range pkg.Files {
 		pf.EnsureFile()
 	}
-}
-
-// EnsureFiles forces File materialization on every PackageFile in pkg.
-//
-// Deprecated: use MaterializePublicCompatibility at explicit public-AST
-// compatibility boundaries. Native front-end paths should keep consuming
-// PackageFile.Run / structured results instead.
-func (pkg *Package) EnsureFiles() {
-	pkg.MaterializePublicCompatibility()
 }
 
 // MaterializeCanonicalSources populates pf.CanonicalSource /

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -74,3 +74,49 @@ func TestMaterializePublicCompatibilityKeepsNativePackageAstbridgeFree(t *testin
 		t.Fatalf("second MaterializePublicCompatibility: astbridge count = %d, want 0", got)
 	}
 }
+
+func TestWorkspaceLoadPackageNativeDiscoversDepsWithoutPublicAST(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.osty"), []byte(`use dep
+
+fn main() {
+    dep.value()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "lib.osty"), []byte(`pub fn value() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	selfhost.ResetAstbridgeLowerCount()
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+	if ws.Packages["dep"] == nil {
+		t.Fatal("LoadPackageNative did not discover dep package from selfhost use refs")
+	}
+	for key, pkg := range ws.Packages {
+		for _, pf := range pkg.Files {
+			if pf.Run == nil {
+				t.Fatalf("package %q file %s has nil Run", key, pf.Path)
+			}
+			if pf.File != nil {
+				t.Fatalf("package %q file %s materialized public AST during native workspace load", key, pf.Path)
+			}
+		}
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after workspace LoadPackageNative: astbridge count = %d, want 0", got)
+	}
+}

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
@@ -175,58 +174,13 @@ func NewWorkspace(root string) (*Workspace, error) {
 	}, nil
 }
 
-// LoadPackage loads the package identified by dotPath into the
-// workspace. If the package has already been loaded it is returned from
-// cache. The active implementation is arena-first and delegates to
-// LoadPackageArenaFirst so the workspace no longer has a Go-parser /
-// Go-resolver-specific loading path.
+// LoadPackage loads the package identified by dotPath into the workspace.
+// If the package has already been loaded it is returned from cache. Loading is
+// native by default: PackageFile.Run is populated while the public AST
+// compatibility surface stays nil until a legacy consumer explicitly asks for
+// it.
 func (w *Workspace) LoadPackage(dotPath string) (*Package, error) {
-	return w.LoadPackageArenaFirst(dotPath)
-}
-
-// loadExternalDep routes a URL-style use target through the
-// DepProvider. Returns a descriptive error when no provider is
-// attached or the provider doesn't recognize the path — the
-// resolver surfaces this as an unknown-package diagnostic with
-// source context.
-func (w *Workspace) loadExternalDep(rawPath string) (*Package, error) {
-	if w.Deps == nil {
-		return nil, fmt.Errorf("package %q: no dependency provider configured (did you forget `osty add`?)", rawPath)
-	}
-	dir, ok := w.Deps.LookupDep(rawPath)
-	if !ok {
-		return nil, fmt.Errorf("package %q: not found among declared dependencies", rawPath)
-	}
-	return w.loadFromExternalDir(rawPath, dir)
-}
-
-// loadFromExternalDir reads the package at dir and registers it
-// under key. Used by both URL-style imports and bare-alias
-// fallbacks once the DepProvider has located the vendored directory.
-// Recursion into transitive `use` declarations still happens — the
-// DepProvider is expected to know about them too.
-func (w *Workspace) loadFromExternalDir(key, dir string) (*Package, error) {
-	w.loading[key] = true
-	defer delete(w.loading, key)
-
-	pkg, err := LoadPackageWithTransform(dir, w.SourceTransform)
-	if err != nil {
-		return nil, err
-	}
-	// Name is the final segment: the last `/` chunk for URL paths,
-	// the alias itself for bare single-segment aliases.
-	pkg.Name = lastSegment(key)
-	w.Packages[key] = pkg
-
-	for _, f := range pkg.Files {
-		for _, u := range f.File.Uses {
-			if u.IsFFI() {
-				continue
-			}
-			w.loadUseDependencyNative(u)
-		}
-	}
-	return pkg, nil
+	return w.LoadPackageNative(dotPath)
 }
 
 // lastSegment picks the final `/`- or `.`-separated chunk of key.
@@ -246,6 +200,29 @@ func (w *Workspace) dirFor(dotPath string) string {
 	}
 	segs := strings.Split(dotPath, ".")
 	return filepath.Join(append([]string{w.Root}, segs...)...)
+}
+
+// MaterializePublicCompatibility forces public-AST compatibility output for
+// every loaded package. Keep calls to this method close to legacy boundaries
+// such as Go AST doc/refactor/lowering paths.
+func (w *Workspace) MaterializePublicCompatibility() {
+	if w == nil {
+		return
+	}
+	for _, pkg := range w.Packages {
+		pkg.MaterializePublicCompatibility()
+	}
+}
+
+// MaterializeCanonicalSources populates canonical sources for every loaded
+// package whose public-AST compatibility surface has been materialized.
+func (w *Workspace) MaterializeCanonicalSources() {
+	if w == nil {
+		return
+	}
+	for _, pkg := range w.Packages {
+		pkg.MaterializeCanonicalSources()
+	}
 }
 
 // ResolveAll runs the selfhost resolver over every loaded package,
@@ -327,21 +304,12 @@ func (w *Workspace) packageUseTargets(path string) []string {
 	}
 	seen := map[string]bool{}
 	var out []string
-	for _, f := range pkg.Files {
-		if f == nil || f.File == nil {
+	for _, edge := range packageUseGraphEdges(pkg) {
+		if edge.target == "" || seen[edge.target] {
 			continue
 		}
-		for _, u := range f.File.Uses {
-			if u == nil || u.IsFFI() {
-				continue
-			}
-			target := w.useGraphTarget(u)
-			if target == "" || seen[target] {
-				continue
-			}
-			seen[target] = true
-			out = append(out, target)
-		}
+		seen[edge.target] = true
+		out = append(out, edge.target)
 	}
 	sort.Strings(out)
 	return out
@@ -389,17 +357,11 @@ func (w *Workspace) detectCycles() []importCycleDiag {
 		if pkg.isStub || pkg.isCycleMarker {
 			continue
 		}
-		for _, f := range pkg.Files {
-			for _, u := range f.File.Uses {
-				if u.IsFFI() {
-					continue
-				}
-				target := w.useGraphTarget(u)
-				if target == "" {
-					continue
-				}
-				adj[path] = append(adj[path], importGraphEdge{target: target, pos: u.PosV, pub: u.IsPub})
+		for _, edge := range packageUseGraphEdges(pkg) {
+			if edge.target == "" {
+				continue
 			}
+			adj[path] = append(adj[path], importGraphEdge{target: edge.target, pos: edge.pos, pub: edge.pub})
 		}
 	}
 	pubReexportClosers := reexportCycleClosers(adj)
@@ -465,15 +427,78 @@ func (w *Workspace) detectCycles() []importCycleDiag {
 	return out
 }
 
-func (w *Workspace) useGraphTarget(u *ast.UseDecl) string {
-	target := useDependencyKey(u)
-	if target == "" {
-		return ""
+type packageUseGraphEdge struct {
+	target string
+	pos    token.Pos
+	pub    bool
+}
+
+func packageUseGraphEdges(pkg *Package) []packageUseGraphEdge {
+	if pkg == nil {
+		return nil
 	}
-	if _, ok := w.Packages[target]; ok {
-		return target
+	var out []packageUseGraphEdge
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		if pf.Run != nil {
+			for _, use := range selfhost.PackageUsesFromRun(pf.Run) {
+				if use.IsGo {
+					continue
+				}
+				target := use.Path
+				if use.IsScoped {
+					target = use.ScopedBase
+				}
+				if target == "" {
+					continue
+				}
+				out = append(out, packageUseGraphEdge{
+					target: target,
+					pos:    sourcePosAt(pf.Source, use.Start),
+					pub:    use.IsPub,
+				})
+			}
+			continue
+		}
+		if pf.File == nil {
+			continue
+		}
+		for _, u := range pf.File.Uses {
+			if u == nil || u.IsFFI() {
+				continue
+			}
+			target := useDependencyKey(u)
+			if target == "" {
+				continue
+			}
+			out = append(out, packageUseGraphEdge{target: target, pos: u.PosV, pub: u.IsPub})
+		}
 	}
-	return target
+	return out
+}
+
+func sourcePosAt(src []byte, offset int) token.Pos {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	pos := token.Pos{Line: 1, Column: 1, Offset: offset}
+	for i, b := range src {
+		if i >= offset {
+			break
+		}
+		if b == '\n' {
+			pos.Line++
+			pos.Column = 1
+			continue
+		}
+		pos.Column++
+	}
+	return pos
 }
 
 type cycleEdgeKey struct {

--- a/internal/resolve/workspace_native.go
+++ b/internal/resolve/workspace_native.go
@@ -3,17 +3,16 @@ package resolve
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
-	"github.com/osty/osty/internal/selfhost"
 )
 
-// LoadPackageNative is the astbridge-counter-free sibling of LoadPackage.
-// Packages are still lowered to public *ast.File nodes for workspace import
-// discovery and import-surface stitching, but that lowering happens through
-// selfhost.LowerPublicFileFromRun instead of FrontendRun.File(), so the native
-// CLI workspace path can stay off the runtime.golegacy.astbridge counter.
+// LoadPackageNative loads PackageFile.Run for each source file and discovers
+// transitive package uses from the selfhost arena. It deliberately leaves
+// PackageFile.File nil; legacy consumers must call
+// MaterializePublicCompatibility at their own boundary.
 func (w *Workspace) LoadPackageNative(dotPath string) (*Package, error) {
 	if pkg, ok := w.Packages[dotPath]; ok {
 		return pkg, nil
@@ -56,20 +55,9 @@ func (w *Workspace) LoadPackageNative(dotPath string) (*Package, error) {
 		return nil, err
 	}
 	pkg.Name = lastDotSeg(dotPath)
-	nativeMaterializePackageFiles(pkg)
 	w.Packages[dotPath] = pkg
 
-	for _, f := range pkg.Files {
-		if f == nil || f.File == nil {
-			continue
-		}
-		for _, u := range f.File.Uses {
-			if u.IsFFI() {
-				continue
-			}
-			w.loadUseDependencyNative(u)
-		}
-	}
+	w.loadNativePackageDependencies(pkg)
 	return pkg, nil
 }
 
@@ -93,25 +81,19 @@ func (w *Workspace) loadFromExternalDirNative(key, dir string) (*Package, error)
 		return nil, err
 	}
 	pkg.Name = lastSegment(key)
-	nativeMaterializePackageFiles(pkg)
 	w.Packages[key] = pkg
 
-	for _, f := range pkg.Files {
-		if f == nil || f.File == nil {
-			continue
-		}
-		for _, u := range f.File.Uses {
-			if u.IsFFI() {
-				continue
-			}
-			w.loadUseDependencyNative(u)
-		}
-	}
+	w.loadNativePackageDependencies(pkg)
 	return pkg, nil
 }
 
-func (w *Workspace) loadUseDependencyNative(u *ast.UseDecl) {
-	target := useDependencyKey(u)
+func (w *Workspace) loadNativePackageDependencies(pkg *Package) {
+	for _, target := range packageUseDependencyKeys(pkg) {
+		w.loadUseDependencyNative(target)
+	}
+}
+
+func (w *Workspace) loadUseDependencyNative(target string) {
 	if target == "" || w.loading[target] {
 		return
 	}
@@ -133,14 +115,26 @@ func useDependencyKey(u *ast.UseDecl) string {
 	return UseKey(u)
 }
 
-func nativeMaterializePackageFiles(pkg *Package) {
+func packageUseDependencyKeys(pkg *Package) []string {
 	if pkg == nil {
-		return
+		return nil
 	}
-	for _, pf := range pkg.Files {
-		if pf == nil || pf.File != nil || pf.Run == nil {
+	seen := map[string]bool{}
+	var out []string
+	for _, ref := range packageImportUseRefs(pkg) {
+		if ref.isGo {
 			continue
 		}
-		pf.File = selfhost.LowerPublicFileFromRun(pf.Run)
+		target := ref.path
+		if ref.isScoped {
+			target = ref.scopedBase
+		}
+		if target == "" || seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, target)
 	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/selfhost/import_surface_arena.go
+++ b/internal/selfhost/import_surface_arena.go
@@ -15,9 +15,12 @@ type PackageUseRef struct {
 	Path         string
 	Alias        string
 	IsGo         bool
+	IsPub        bool
 	IsScoped     bool
 	ScopedBase   string
 	ScopedMember string
+	Start        int
+	End          int
 }
 
 // PackageUsesFromRun walks run's AstArena and returns one PackageUseRef
@@ -69,8 +72,11 @@ func appendArenaUseRefs(out []PackageUseRef, arena *AstArena, n *AstNode) []Pack
 	ref := PackageUseRef{
 		Path:     arenaStringUnquote(n.text),
 		IsGo:     arenaUseDeclIsGo(n),
+		IsPub:    arenaUseDeclIsPub(n),
 		Alias:    arenaUseDeclAlias(arena, n),
 		IsScoped: arenaUseDeclIsScoped(n),
+		Start:    n.start,
+		End:      n.end,
 	}
 	if ref.IsScoped {
 		ref.ScopedBase, ref.ScopedMember, _ = arenaSplitScopedUsePath(ref.Path)
@@ -90,6 +96,13 @@ func arenaUseDeclIsGo(n *AstNode) bool {
 		return false
 	}
 	return n.flags&1 != 0
+}
+
+func arenaUseDeclIsPub(n *AstNode) bool {
+	if n == nil {
+		return false
+	}
+	return n.flags&2 != 0
 }
 
 // arenaUseDeclIsGroup mirrors astUseDeclIsGroup: a synthetic wrapper use


### PR DESCRIPTION
## Summary
- remove the arena-first package loader and route package/workspace consumers through native selfhost loaders
- keep public AST compatibility explicit at legacy boundaries instead of hiding it in loading
- make workspace native loading discover imports from selfhost use refs without materializing public AST
- add coverage that native workspace load discovers deps while leaving `PackageFile.File` nil

## Verification
- `just front`
- `go test -count=1 -vet=off ./internal/resolve ./internal/selfhost ./internal/query/osty ./cmd/osty ./cmd/osty-native-llvmgen ./internal/lsp ./internal/airepair ./internal/stdlib`
- `git diff --check origin/main...HEAD`