### PR TITLE
[codex] polish stdlib protocol edge cases

### DIFF
--- a/internal/stdlib/big_gaps_test.go
+++ b/internal/stdlib/big_gaps_test.go
@@ -19,7 +19,7 @@ func TestSmtpModuleSurface(t *testing.T) {
 		"dataCommand", "quit", "rset", "noop", "authPlain", "authLogin", "authCommands",
 		"transaction", "commands", "renderCommands", "parseReply", "parseReplies",
 		"isPositiveCompletion", "isPositiveIntermediate", "isTransientFailure", "isPermanentFailure",
-		"capabilities", "hasCapability", "supportsAuth",
+		"capabilities", "hasCapability", "supportsAuth", "dotStuff", "dataBlock",
 	} {
 		requirePublicFn(t, mod, "smtp", name)
 	}
@@ -68,16 +68,23 @@ func TestBigGapModuleSourcePinsBehavior(t *testing.T) {
 			`pub fn authPlain(username: String, password: String) -> String`,
 			`pub fn parseReply(line: String) -> Result<Reply, Error>`,
 			`pub fn commands(tx: Transaction) -> Result<List<String>, Error>`,
+			`pub fn dotStuff(data: String) -> String`,
+			`pub fn dataBlock(data: String) -> String`,
+			`out.push(ensureDataBlock(tx.envelope.data))`,
+			`strings.endsWith(data, "{crlf()}.{crlf()}")`,
 		},
 		"zip": {
 			`pub fn encode(entries: List<Entry>) -> Result<Bytes, Error>`,
 			`pub fn decode(archive: Bytes) -> Result<List<Entry>, Error>`,
 			`pub fn crc32(data: Bytes) -> Int`,
+			`strings.contains(clean, "\\")`,
+			`fn isDriveLetterPath(name: String) -> Bool`,
 		},
 		"image": {
 			`pub fn identify(data: Bytes) -> Format`,
 			`fn parsePng(data: Bytes) -> Result<Metadata, Error>`,
 			`fn parseJpeg(data: Bytes) -> Result<Metadata, Error>`,
+			`if data.len() < 11`,
 		},
 	}
 	for module, wants := range cases {

--- a/internal/stdlib/modules/image.osty
+++ b/internal/stdlib/modules/image.osty
@@ -148,7 +148,7 @@ fn parsePng(data: Bytes) -> Result<Metadata, Error> {
 }
 
 fn parseGif(data: Bytes) -> Result<Metadata, Error> {
-    if data.len() < 10 {
+    if data.len() < 11 {
         return Err(error.new("image: truncated GIF header"))
     }
     let packed = byteAt(data, 10).toInt()

--- a/internal/stdlib/modules/smtp.osty
+++ b/internal/stdlib/modules/smtp.osty
@@ -151,6 +151,25 @@ pub fn dataCommand() -> String {
     "DATA"
 }
 
+pub fn dotStuff(data: String) -> String {
+    let normalized = normalizeBody(data)
+    let lines = strings.split(normalized, crlf())
+    let mut out: List<String> = []
+    for line in lines {
+        if strings.startsWith(line, ".") {
+            out.push(".{line}")
+        } else {
+            out.push(line)
+        }
+    }
+    strings.join(out, crlf())
+}
+
+pub fn dataBlock(data: String) -> String {
+    let body = stripDataTerminator(data)
+    "{dotStuff(body)}{crlf()}.{crlf()}"
+}
+
 pub fn quit() -> String {
     "QUIT"
 }
@@ -205,7 +224,7 @@ pub fn commands(tx: Transaction) -> Result<List<String>, Error> {
         out.push(rcptTo(rcpt)?)
     }
     out.push(dataCommand())
-    out.push(tx.envelope.data)
+    out.push(ensureDataBlock(tx.envelope.data))
     out.push(quit())
     Ok(out)
 }
@@ -315,6 +334,30 @@ fn parseCapability(message: String) -> Capability {
         name: strings.toUpper(fields[0]),
         args: args,
     }
+}
+
+fn ensureDataBlock(data: String) -> String {
+    let normalized = normalizeBody(data)
+    if hasDataTerminator(normalized) {
+        return normalized
+    }
+    dataBlock(normalized)
+}
+
+fn stripDataTerminator(data: String) -> String {
+    let normalized = normalizeBody(data)
+    if hasDataTerminator(normalized) {
+        return strings.slice(normalized, 0, normalized.len() - 5)
+    }
+    normalized
+}
+
+fn hasDataTerminator(data: String) -> Bool {
+    strings.endsWith(data, "{crlf()}.{crlf()}")
+}
+
+fn normalizeBody(value: String) -> String {
+    strings.replaceAll(strings.replaceAll(value, "\r\n", "\n"), "\n", crlf())
 }
 
 fn plainPayload(username: String, password: String) -> String {

--- a/internal/stdlib/modules/zip.osty
+++ b/internal/stdlib/modules/zip.osty
@@ -239,6 +239,12 @@ fn normalizeName(name: String) -> Result<String, Error> {
     if strings.startsWith(clean, "/") {
         return Err(error.new("zip: absolute paths are not allowed"))
     }
+    if strings.contains(clean, "\\") {
+        return Err(error.new("zip: backslashes are not allowed in entry names"))
+    }
+    if isDriveLetterPath(clean) {
+        return Err(error.new("zip: drive-letter paths are not allowed"))
+    }
     if strings.endsWith(clean, "/") {
         return Err(error.new("zip: directory entries are not supported yet"))
     }
@@ -246,6 +252,14 @@ fn normalizeName(name: String) -> Result<String, Error> {
         return Err(error.new("zip: parent path segments are not allowed"))
     }
     Ok(clean)
+}
+
+fn isDriveLetterPath(name: String) -> Bool {
+    if name.len() < 2 {
+        return false
+    }
+    let c = name[0]
+    ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) && name[1] == ':'
 }
 
 fn appendBytes(out: List<Byte>, data: Bytes) {


### PR DESCRIPTION
## Summary
- Fix the GIF parser length guard before reading the packed field at byte 10.
- Add SMTP DATA helpers for dot-stuffing and terminator handling, and use them in transaction command generation.
- Reject ZIP entry names containing backslashes or Windows drive-letter prefixes.
- Pin the new stdlib surfaces and edge-case checks in big-gap source tests.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(Smtp|Zip|Image|BigGap)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultBigGaps' -v`
- `go run ./cmd/osty tokens internal/stdlib/modules/smtp.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/zip.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/image.osty`
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend`
- `just fmt-check`
- `git diff --check`