### PR TITLE
Move test discovery to selfhost functions

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -474,8 +474,8 @@ func main() {
 
 	switch cmd {
 	case "parse":
-		parsed := parser.ParseDetailed(src)
-		file, diags := parsed.File, parsed.Diagnostics
+		run := selfhost.Run(src)
+		file, diags := selfhost.LowerPublicFileFromRun(run), run.Diagnostics()
 		printDiags(formatter, diags, flags)
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -26,6 +26,7 @@ import (
 	"github.com/osty/osty/internal/llvmgen"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 type nativeTestCase struct {
@@ -138,12 +139,6 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "osty test: parse errors in %s\n", pkgDir)
 		return 1
 	}
-	// Test discovery and the current package backend still consume the public
-	// AST compatibility surface. Keep that boundary explicit now that package
-	// loading itself is native-only.
-	pkg.MaterializePublicCompatibility()
-	pkg.MaterializeCanonicalSources()
-
 	tests, err := discoverNativeTests(pkg, filters, benchMode)
 	if err != nil {
 		fmt.Fprintf(stderr, "osty test: %v\n", err)
@@ -154,6 +149,11 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "osty test: --doc and --bench cannot be combined")
 			return 2
 		}
+		// Doctest extraction still walks doc comments through the public AST.
+		// Keep this compatibility boundary local to --doc instead of forcing
+		// every ordinary `osty test` run through it.
+		pkg.MaterializePublicCompatibility()
+		pkg.MaterializeCanonicalSources()
 		doc, err := appendDoctestCases(pkg, filters)
 		if err != nil {
 			fmt.Fprintf(stderr, "osty test --doc: %v\n", err)
@@ -540,7 +540,29 @@ func discoverNativeTests(pkg *resolve.Package, filters []string, benchMode bool)
 	seen := map[string]string{}
 	var tests []nativeTestCase
 	for _, pf := range pkg.Files {
-		if pf == nil || pf.File == nil {
+		if pf == nil {
+			continue
+		}
+		if pf.Run != nil {
+			for _, fn := range selfhost.PackageFunctionsFromRun(pf.Run) {
+				if fn.Name == "main" {
+					return nil, fmt.Errorf("package %s already defines main; native test runner currently requires a library-style package", pkg.Dir)
+				}
+				if !isDiscoverableNativeTestFn(fn, benchMode) {
+					continue
+				}
+				if !matchesTestFilters(fn.Name, filters) {
+					continue
+				}
+				if prev, exists := seen[fn.Name]; exists {
+					return nil, fmt.Errorf("duplicate %s function %q in %s and %s", singularKindLabel(benchMode), fn.Name, prev, pf.Path)
+				}
+				seen[fn.Name] = pf.Path
+				tests = append(tests, nativeTestCase{Name: fn.Name, Path: pf.Path})
+			}
+			continue
+		}
+		if pf.File == nil {
 			continue
 		}
 		for _, decl := range pf.File.Decls {
@@ -598,6 +620,37 @@ func discoverNativeTests(pkg *resolve.Package, filters []string, benchMode bool)
 		return tests[i].Name < tests[j].Name
 	})
 	return tests, nil
+}
+
+func isDiscoverableNativeTestFn(fn selfhost.PackageFunctionRef, benchMode bool) bool {
+	if fn.HasReceiver || fn.GenericParamCount != 0 {
+		return false
+	}
+	if fn.Name == "testing" {
+		return false
+	}
+	if benchMode {
+		if !strings.HasPrefix(fn.Name, "bench") {
+			return false
+		}
+	} else {
+		if strings.HasPrefix(fn.Name, "bench") {
+			return false
+		}
+		if !strings.HasPrefix(fn.Name, "test") && !hasNativeTestAnnotation(fn) {
+			return false
+		}
+	}
+	return fn.ParamCount == 0 && !fn.HasReturn && fn.HasBody
+}
+
+func hasNativeTestAnnotation(fn selfhost.PackageFunctionRef) bool {
+	for _, name := range fn.Annotations {
+		if name == "test" {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesTestFilters(name string, filters []string) bool {

--- a/cmd/osty/test_native_inline_test.go
+++ b/cmd/osty/test_native_inline_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // v0.5 (G32) inline `#[test]` discovery — the legacy `test*` name
@@ -56,6 +56,11 @@ fn notATest() -> Int {
 	}
 	if gotNames["add"] {
 		t.Error("add should not be discovered (production function)")
+	}
+	for _, pf := range pkg.Files {
+		if pf.File != nil {
+			t.Fatalf("discoverNativeTests materialized public AST for %s", pf.Path)
+		}
 	}
 }
 
@@ -163,14 +168,12 @@ fn inline_case() { let _ = 1 }
 // resolve diagnostic.
 func mustResolveSingleFilePackage(t *testing.T, path string, src []byte) *resolve.Package {
 	t.Helper()
-	file, diags := parser.ParseDiagnostics(src)
+	run := selfhost.Run(src)
+	diags := run.Diagnostics()
 	for _, d := range diags {
 		if d != nil && d.Severity.String() == "error" {
 			t.Fatalf("parse error: %s", d.Message)
 		}
-	}
-	if file == nil {
-		t.Fatal("parse returned nil file")
 	}
 	pkg := &resolve.Package{
 		Name: "inline_test_pkg",
@@ -178,7 +181,7 @@ func mustResolveSingleFilePackage(t *testing.T, path string, src []byte) *resolv
 		Files: []*resolve.PackageFile{{
 			Path:   path,
 			Source: src,
-			File:   file,
+			Run:    run,
 		}},
 	}
 	return pkg

--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -11,9 +11,9 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lexer"
-	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -393,17 +393,18 @@ func rewriteLengthProperties(src []byte) ([]byte, []repair.Change, bool) {
 // whose receiver type already has a `length` field — rewriting these to
 // `.len()` would replace a valid field read with a missing-method call.
 func validLengthFieldOffsets(src []byte) map[int]bool {
-	parsed := parser.ParseDetailed(src)
-	if parsed.File == nil {
+	run := selfhost.Run(src)
+	file := selfhost.LowerPublicFileFromRun(run)
+	if file == nil {
 		return nil
 	}
-	res := resolve.ResolveFileSourceDefault(src, parsed.File, stdlib.LoadCached())
-	chk := check.SelfhostFile(parsed.File, res, checkOptsForSource(canonical.Source(src, parsed.File)))
+	res := resolve.ResolveFileSourceDefault(src, file, stdlib.LoadCached())
+	chk := check.SelfhostFile(file, res, checkOptsForSource(canonical.Source(src, file)))
 	if chk == nil {
 		return nil
 	}
 	skip := make(map[int]bool)
-	walkFieldExprs(parsed.File, func(fe *ast.FieldExpr) {
+	walkFieldExprs(file, func(fe *ast.FieldExpr) {
 		if fe.Name != "length" {
 			return
 		}

--- a/internal/selfhost/function_refs.go
+++ b/internal/selfhost/function_refs.go
@@ -1,0 +1,95 @@
+package selfhost
+
+// PackageFunctionRef is the small, stable view of a top-level function that
+// host-side tools need for selection logic without lowering the public AST.
+type PackageFunctionRef struct {
+	Name              string
+	ParamCount        int
+	HasReceiver       bool
+	HasReturn         bool
+	HasBody           bool
+	GenericParamCount int
+	Annotations       []string
+	Start             int
+	End               int
+}
+
+// PackageFunctionsFromRun walks run's arena and returns one ref for each
+// top-level function declaration. Methods nested in struct/enum declarations
+// are intentionally excluded, matching the public-AST package test discovery
+// path that only scanned file.Decls.
+func PackageFunctionsFromRun(run *FrontendRun) []PackageFunctionRef {
+	if run == nil || run.parser == nil || run.parser.arena == nil {
+		return nil
+	}
+	arena := run.parser.arena
+	out := make([]PackageFunctionRef, 0, len(arena.decls))
+	for _, declIdx := range arena.decls {
+		if declIdx < 0 || declIdx >= len(arena.nodes) {
+			continue
+		}
+		n := arena.nodes[declIdx]
+		if n == nil {
+			continue
+		}
+		if _, ok := n.kind.(*AstNodeKind_AstNFnDecl); !ok {
+			continue
+		}
+		out = append(out, packageFunctionRefFromNode(arena, n))
+	}
+	return out
+}
+
+func packageFunctionRefFromNode(arena *AstArena, n *AstNode) PackageFunctionRef {
+	ref := PackageFunctionRef{
+		Name:              n.text,
+		HasReturn:         n.left >= 0,
+		HasBody:           n.right >= 0,
+		GenericParamCount: len(n.children2),
+		Annotations:       arenaAnnotationNames(arena, n.extra),
+		Start:             n.start,
+		End:               n.end,
+	}
+	for i, childIdx := range n.children {
+		if childIdx < 0 || childIdx >= len(arena.nodes) {
+			continue
+		}
+		child := arena.nodes[childIdx]
+		if child == nil {
+			continue
+		}
+		if _, ok := child.kind.(*AstNodeKind_AstNParam); !ok {
+			continue
+		}
+		if i == 0 && child.text == "self" {
+			ref.HasReceiver = true
+			continue
+		}
+		ref.ParamCount++
+	}
+	return ref
+}
+
+func arenaAnnotationNames(arena *AstArena, idx int) []string {
+	if arena == nil || idx < 0 || idx >= len(arena.nodes) {
+		return nil
+	}
+	n := arena.nodes[idx]
+	if n == nil {
+		return nil
+	}
+	if _, ok := n.kind.(*AstNodeKind_AstNAnnotation); !ok {
+		return nil
+	}
+	if n.text == "__group" {
+		out := make([]string, 0, len(n.children))
+		for _, childIdx := range n.children {
+			out = append(out, arenaAnnotationNames(arena, childIdx)...)
+		}
+		return out
+	}
+	if n.text == "" {
+		return nil
+	}
+	return []string{n.text}
+}

--- a/internal/selfhost/function_refs_test.go
+++ b/internal/selfhost/function_refs_test.go
@@ -1,0 +1,43 @@
+package selfhost
+
+import "testing"
+
+func TestPackageFunctionsFromRunReportsTopLevelTestShape(t *testing.T) {
+	run := Run([]byte(`#[test]
+fn inline_case() {
+    let _ = 1
+}
+
+fn helper(n: Int) -> Int {
+    n
+}
+
+struct Box {
+    value: Int
+    fn method(self) {}
+}
+`))
+	if len(run.Diagnostics()) != 0 {
+		t.Fatalf("parse diagnostics = %#v", run.Diagnostics())
+	}
+
+	funcs := PackageFunctionsFromRun(run)
+	byName := map[string]PackageFunctionRef{}
+	for _, fn := range funcs {
+		byName[fn.Name] = fn
+	}
+	inline := byName["inline_case"]
+	if !inline.HasBody || inline.HasReturn || inline.ParamCount != 0 {
+		t.Fatalf("inline_case shape = %#v, want zero-param body with no return", inline)
+	}
+	if len(inline.Annotations) != 1 || inline.Annotations[0] != "test" {
+		t.Fatalf("inline_case annotations = %#v, want [test]", inline.Annotations)
+	}
+	helper := byName["helper"]
+	if helper.ParamCount != 1 || !helper.HasReturn {
+		t.Fatalf("helper shape = %#v, want one param and return", helper)
+	}
+	if _, ok := byName["method"]; ok {
+		t.Fatal("PackageFunctionsFromRun should not report struct methods")
+	}
+}


### PR DESCRIPTION
## Summary
- add a selfhost arena-derived top-level function view for host tooling
- move ordinary `osty test` discovery onto `PackageFile.Run`, leaving public AST materialization local to `--doc`
- keep inline `#[test]`, `test*`, and `bench*` discovery behavior covered without forcing public AST
- route `osty parse` and airepair length-field protection through direct selfhost runs where parser provenance is not needed

## Verification
- `just front`
- `go test -count=1 -vet=off ./internal/selfhost ./internal/airepair ./cmd/osty ./internal/resolve ./internal/query/osty ./internal/lsp ./internal/stdlib`
- `git diff --check origin/main...HEAD`