### PR TITLE
[codex] Fix native test compile fallback lowering

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -229,17 +229,18 @@ func isOstySource(name string) bool {
 	return filepath.Ext(name) == ".osty"
 }
 
-// countLowerableFiles reports how many of pkg.Files actually carry a
-// parsed AST. PackageFile entries with a nil File slip through resolve
-// when parse fails fatally; ir.LowerPackage skips them, and the gen path
-// uses the same predicate to decide whether package lowering is viable.
+// countLowerableFiles reports how many package files can enter the legacy IR
+// package-lowering boundary. Native-owned packages carry Run with File left nil
+// until that boundary explicitly materializes public AST compatibility, so
+// counting only pf.File would incorrectly route compile fallbacks through the
+// synthetic single-file path.
 func countLowerableFiles(pkg *resolve.Package) int {
 	if pkg == nil {
 		return 0
 	}
 	n := 0
 	for _, pf := range pkg.Files {
-		if pf != nil && pf.File != nil {
+		if pf.CanMaterializeFile() {
 			n++
 		}
 	}

--- a/cmd/osty/test_native_inline_test.go
+++ b/cmd/osty/test_native_inline_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/osty/osty/internal/resolve"
@@ -160,6 +161,47 @@ fn inline_case() { let _ = 1 }
 	}
 	if benchNames["testAlpha"] || benchNames["inline_case"] {
 		t.Errorf("bench-mode must not pull test-prefixed / #[test] functions, got %v", benchNames)
+	}
+}
+
+func TestPrepareNativeTestBackendEntryFallbackKeepsNativePackageScopes(t *testing.T) {
+	dir := t.TempDir()
+	helperPath := filepath.Join(dir, "helper.osty")
+	testPath := filepath.Join(dir, "main_test.osty")
+	helperSrc := []byte("pub fn helper() -> Int { 1 }\n")
+	testSrc := []byte("fn testUsesHelper() { let _ = helper() }\n")
+	pkg := &resolve.Package{
+		Name: "native_test_pkg",
+		Dir:  dir,
+		Files: []*resolve.PackageFile{
+			{Path: helperPath, Source: helperSrc, Run: selfhost.Run(helperSrc)},
+			{Path: testPath, Source: testSrc, Run: selfhost.Run(testSrc)},
+		},
+	}
+	for _, pf := range pkg.Files {
+		if pf.File != nil {
+			t.Fatalf("test setup unexpectedly materialized %s", pf.Path)
+		}
+	}
+	if got := countLowerableFiles(pkg); got != 2 {
+		t.Fatalf("countLowerableFiles(native run-only package) = %d, want 2", got)
+	}
+
+	entry, err := prepareNativeTestBackendEntry(testPath, pkg)
+	if err != nil {
+		t.Fatalf("prepareNativeTestBackendEntry() error = %v", err)
+	}
+	if pkg.Files[0].File == nil || pkg.Files[1].File == nil {
+		t.Fatal("package lowering fallback did not materialize native-owned package files")
+	}
+	if entry.File != pkg.Files[1].File {
+		t.Fatal("backend entry did not keep the original package entry file")
+	}
+	if string(entry.Source) != string(testSrc) {
+		t.Fatalf("backend entry source = %q, want entry-file source; fallback must not merge package text", entry.Source)
+	}
+	if entry.IR == nil || len(entry.IR.Decls) != 2 {
+		t.Fatalf("backend entry decl count = %d, want 2 package decls", len(entry.IR.Decls))
 	}
 }
 

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -92,7 +92,7 @@ func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryF
 	}
 	if entryFile == nil {
 		for _, pf := range pkg.Files {
-			if pf != nil && pf.File != nil {
+			if pf.CanMaterializeFile() {
 				entryFile = pf
 				break
 			}
@@ -104,7 +104,7 @@ func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryF
 		Check:       chk,
 	}
 	if entryFile != nil {
-		entry.File = entryFile.File
+		entry.File = entryFile.EnsureFile()
 		entry.Source = entryFile.Source
 		entry.Resolve = &resolve.Result{
 			FileScope: entryFile.FileScope,

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -76,7 +76,11 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 	mod := &Module{Package: pkgName}
 	var issues []error
 	for i, pf := range pkg.Files {
-		if pf == nil || pf.File == nil {
+		if pf == nil {
+			continue
+		}
+		file := pf.EnsureFile()
+		if file == nil {
 			continue
 		}
 		res := &resolve.Result{
@@ -86,7 +90,7 @@ func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Mod
 			TypeRefIdents: pf.TypeRefIdents,
 			FileScope:     pf.FileScope,
 		}
-		l := &lowerer{pkgName: pkgName, file: pf.File, res: res, chk: chk}
+		l := &lowerer{pkgName: pkgName, file: file, res: res, chk: chk}
 		fileMod, fileIssues := l.run()
 		if i == 0 {
 			mod.SpanV = fileMod.SpanV

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -374,7 +374,7 @@ func countLowerableFiles(pkg *resolve.Package) int {
 	}
 	n := 0
 	for _, pf := range pkg.Files {
-		if pf != nil && pf.File != nil {
+		if pf.CanMaterializeFile() {
 			n++
 		}
 	}

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -111,6 +111,14 @@ func (pf *PackageFile) CheckerSource() []byte {
 	return pf.Source
 }
 
+// CanMaterializeFile reports whether EnsureFile can produce the public AST
+// compatibility surface without stitching package source into a synthetic
+// single file. Native-loaded packages carry Run instead of File until a legacy
+// boundary explicitly asks for it.
+func (pf *PackageFile) CanMaterializeFile() bool {
+	return pf != nil && (pf.File != nil || pf.Run != nil)
+}
+
 // EnsureFile materializes the *ast.File for this PackageFile. Packages loaded
 // via LoadPackageForNative populate Run but leave File nil; calling EnsureFile
 // uses the explicit public-AST compatibility adapter on demand. Returns the


### PR DESCRIPTION
## Summary
- Count native-loaded package files as lowerable when they can materialize the public AST compatibility surface from `PackageFile.Run`.
- Make backend package lowering materialize run-only package files at the legacy IR boundary instead of silently skipping them.
- Add a regression test covering native test compile fallback so it keeps package lowering and does not merge files into synthetic single-file source.

## Validation
- `go test -count=1 -vet=off ./cmd/osty -run TestPrepareNativeTestBackendEntryFallbackKeepsNativePackageScopes`
- `go test -count=1 -vet=off ./cmd/osty ./internal/backend ./internal/ir ./internal/pipeline ./internal/resolve`
- `just front`
- `git diff --check`