### PR TITLE
[codex] backend: run big stdlib modules through MIR

### DIFF
--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmgen"
 )
 
@@ -148,7 +149,7 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	if entry.IR == nil {
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
-	if useNativeOwnedLLVMIR(features, emit) {
+	if useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR) {
 		if out, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
 			return nil, warnings, err
 		} else if ok {
@@ -196,6 +197,22 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 			errors.New(llvmgen.UnsupportedSummary(diag)),
 			ErrLLVMNotImplemented,
 		), ErrLLVMNotImplemented
+}
+
+func hasInjectedStdlibBodies(mod *ir.Module) bool {
+	if mod == nil {
+		return false
+	}
+	for _, decl := range mod.Decls {
+		fn, ok := decl.(*ir.FnDecl)
+		if !ok || fn == nil {
+			continue
+		}
+		if strings.HasPrefix(fn.Name, "osty_std_") && fn.Body != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (b LLVMBackend) llvmToolchain() llvmToolchain {

--- a/internal/backend/llvm_big_stdlib_modules_test.go
+++ b/internal/backend/llvm_big_stdlib_modules_test.go
@@ -1,0 +1,159 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMBackendBinaryRunsStdZipStoredArchive(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.zip
+
+fn main() {
+    let entry = zip.file("hello.txt", "hello".toBytes()).unwrap()
+    let archive = zip.encode([entry]).unwrap()
+    println(zip.isArchive(archive))
+    println(zip.contains(archive, "hello.txt"))
+    let names = zip.list(archive).unwrap()
+    println(names.len())
+    println(names[0])
+    let payload = zip.extract(archive, "hello.txt").unwrap().unwrap()
+    println(payload.toHex())
+    println(zip.crc32("hello".toBytes()))
+    println(zip.methodName(entry.method))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "true\ntrue\n1\nhello.txt\n68656c6c6f\n907060870\nstored\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryRunsStdImageMetadata(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.bytes as bytes
+use std.image
+
+fn main() {
+    let raw: List<Byte> = [b'G', b'I', b'F', b'8', b'9', b'a', 2.toByte(), 0.toByte(), 3.toByte(), 0.toByte(), 0.toByte()]
+    let gif = bytes.from(raw)
+    println(image.formatName(image.identify(gif)))
+    println(image.isImage(gif))
+    let meta = image.parse(gif).unwrap()
+    println(meta.width)
+    println(meta.height)
+    println(meta.bitsPerPixel)
+    println(meta.hasAlpha)
+    let dims = image.dimensions(gif).unwrap()
+    println(dims.width)
+    println(dims.height)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "gif\ntrue\n2\n3\n1\ntrue\n2\n3\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryRunsStdSmtpPlanning(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.email
+use std.smtp
+
+fn main() {
+    let cfg = smtp.withAuth(
+        smtp.withSecurity(
+            smtp.config("smtp.example.com", smtp.defaultPort(StartTls), "client.local").unwrap(),
+            StartTls,
+        ),
+        smtp.plainAuth("user", "secret"),
+    )
+    let from = email.address("sender@example.com").unwrap()
+    let recipients = [email.address("rcpt@example.com").unwrap()]
+    let msg = email.message(from, recipients, "Subject", "Body")
+    let env = email.envelope(msg).unwrap()
+    let cmds = smtp.commands(smtp.transaction(cfg, env)).unwrap()
+    println(cmds.len())
+    println(cmds[0])
+    println(cmds[1])
+    println(cmds[2])
+    println(cmds[3])
+    println(cmds[4])
+    println(cmds[cmds.len() - 1])
+
+    let reply = smtp.parseReply("250-STARTTLS").unwrap()
+    println(reply.code)
+    println(reply.continuation)
+    let caps = smtp.capabilities(smtp.parseReplies("250-localhost\r\n250-AUTH PLAIN LOGIN\r\n250 OK\r\n").unwrap())
+    println(smtp.hasCapability(caps, "auth"))
+    println(smtp.supportsAuth(caps, "login"))
+    println(smtp.dataBlock(".line").startsWith("..line"))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "" +
+		"9\n" +
+		"EHLO client.local\n" +
+		"STARTTLS\n" +
+		"EHLO client.local\n" +
+		"AUTH PLAIN AHVzZXIAc2VjcmV0\n" +
+		"MAIL FROM:<sender@example.com>\n" +
+		"QUIT\n" +
+		"250\n" +
+		"true\n" +
+		"true\n" +
+		"true\n" +
+		"true\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func logBackendWarnings(t *testing.T, result *Result) {
+	t.Helper()
+	if result == nil {
+		return
+	}
+	for i, warning := range result.Warnings {
+		t.Logf("warning[%d]: %v", i, warning)
+	}
+}

--- a/internal/backend/llvm_match_decision_tree_test.go
+++ b/internal/backend/llvm_match_decision_tree_test.go
@@ -121,3 +121,99 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryRunsBareEnumIdentMatch(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `enum AuthKind {
+    NoAuth
+    Plain
+    Login
+}
+
+fn score(kind: AuthKind) -> Int {
+    match kind {
+        NoAuth -> 10,
+        Plain -> 20,
+        Login -> 30,
+    }
+}
+
+fn main() {
+    println(score(Plain))
+    println(score(Login))
+    println(score(NoAuth))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "20\n30\n10\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryRunsCharMethodInterpolation(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn shout(s: String) -> String {
+    let out = ""
+    for c in s.chars() {
+        out = "{out}{c.toUpper()}"
+    }
+    out
+}
+
+fn main() {
+    println(shout("aZ"))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "AZ\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryRunsInjectedStdBytesFrom(t *testing.T) {
+	requireClangForBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.bytes
+
+fn main() {
+    let raw: List<Byte> = [65.toByte(), 66.toByte()]
+    let data = bytes.from(raw)
+    println(data.len())
+    println(data.toHex())
+}
+`)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "2\n4142\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/ir"
@@ -370,7 +371,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 	for len(queue) > 0 {
 		next := queue[0]
 		queue = queue[1:]
-		for callName := range scanBareIdentCallNames(next.fn) {
+		for _, callName := range sortedBareIdentCallNames(next.fn) {
 			calleeFn := reg.LookupFnDecl(next.module, callName)
 			if calleeFn == nil {
 				continue
@@ -395,8 +396,93 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			rewriteBareIdentCalls(next.fn, callName, lowered.Name)
 			queue = append(queue, loweredFromModule{module: next.module, fn: lowered})
 		}
+		for _, ref := range sortedQualifiedStdlibCallRefs(next.fn) {
+			calleeModule := stdlibModuleNameFromQualifier(ref.Qualifier)
+			if calleeModule == "" || calleeModule == "error" {
+				continue
+			}
+			calleeFn := reg.LookupFnDecl(calleeModule, ref.Name)
+			if calleeFn == nil {
+				continue
+			}
+			k := fnKey{module: calleeModule, name: ref.Name}
+			if injectedFn[k] {
+				rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, StdlibSymbol(calleeModule, ref.Name))
+				continue
+			}
+			injectedFn[k] = true
+			res := stdlibResolveResult(reg, calleeModule)
+			chk := stdlibCheckResult(reg, calleeModule)
+			lowered, fnIssues := ir.LowerFnDecl(mod.Package, calleeFn, res, chk)
+			issues = append(issues, fnIssues...)
+			if lowered == nil {
+				continue
+			}
+			lowered.Name = StdlibSymbol(calleeModule, ref.Name)
+			out = append(out, lowered)
+			rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, lowered.Name)
+			queue = append(queue, loweredFromModule{module: calleeModule, fn: lowered})
+		}
+		for _, m := range reachableStdlibMethodsInFn(next.fn, reg) {
+			k := methodKey{module: m.Module, typeName: m.Type, method: m.Method}
+			if injectedMethod[k] {
+				rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
+				continue
+			}
+			injectedMethod[k] = true
+			res := stdlibResolveResult(reg, m.Module)
+			chk := stdlibCheckResult(reg, m.Module)
+			lowered, fnIssues := ir.LowerFnDecl(mod.Package, m.Fn, res, chk)
+			issues = append(issues, fnIssues...)
+			if lowered == nil {
+				continue
+			}
+			freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+			out = append(out, freeFn)
+			rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
+			queue = append(queue, loweredFromModule{module: m.Module, fn: freeFn})
+		}
 	}
 	return out, issues
+}
+
+func reachableStdlibMethodsInFn(fn *ir.FnDecl, reg *stdlib.Registry) []ReachableStdlibMethod {
+	if fn == nil || reg == nil {
+		return nil
+	}
+	return ReachableStdlibMethods(&ir.Module{Decls: []ir.Decl{fn}}, reg)
+}
+
+func rewriteStdlibMethodCallsitesInFn(fn *ir.FnDecl, reached []ReachableStdlibMethod) {
+	if fn == nil || len(reached) == 0 {
+		return
+	}
+	RewriteStdlibMethodCallsites(&ir.Module{Decls: []ir.Decl{fn}}, reached)
+}
+
+func sortedBareIdentCallNames(fn *ir.FnDecl) []string {
+	seen := scanBareIdentCallNames(fn)
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedQualifiedStdlibCallRefs(fn *ir.FnDecl) []ir.QualifiedRef {
+	seen := scanQualifiedCallRefs(fn)
+	out := make([]ir.QualifiedRef, 0, len(seen))
+	for ref := range seen {
+		out = append(out, ref)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Qualifier != out[j].Qualifier {
+			return out[i].Qualifier < out[j].Qualifier
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
 }
 
 // scanBareIdentCallNames returns the set of names referenced in
@@ -431,6 +517,41 @@ func scanBareIdentCallNames(fn *ir.FnDecl) map[string]struct{} {
 	return out
 }
 
+func scanQualifiedCallRefs(fn *ir.FnDecl) map[ir.QualifiedRef]struct{} {
+	out := map[ir.QualifiedRef]struct{}{}
+	if fn == nil || fn.Body == nil {
+		return out
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		field, ok := call.Callee.(*ir.FieldExpr)
+		if !ok || field == nil || field.Name == "" {
+			return true
+		}
+		ident, ok := field.X.(*ir.Ident)
+		if !ok || ident == nil || ident.Name == "" {
+			return true
+		}
+		out[ir.QualifiedRef{Qualifier: ident.Name, Name: field.Name}] = struct{}{}
+		return true
+	}), fn.Body)
+	return out
+}
+
+func stdlibModuleNameFromQualifier(qualifier string) string {
+	if qualifier == "" {
+		return ""
+	}
+	const prefix = "std."
+	if strings.HasPrefix(qualifier, prefix) {
+		return strings.TrimPrefix(qualifier, prefix)
+	}
+	return qualifier
+}
+
 // rewriteBareIdentCalls walks a function body and renames any bare
 // Ident callee whose Name == old to new. Mutates the IR in place.
 // Method calls and FieldExpr callees are not affected — they have
@@ -455,6 +576,33 @@ func rewriteBareIdentCalls(fn *ir.FnDecl, oldName, newName string) {
 		}
 		ident.Name = newName
 		ident.Kind = ir.IdentFn
+		return true
+	}), fn.Body)
+}
+
+func rewriteQualifiedStdlibCalls(fn *ir.FnDecl, qualifier, name, newName string) {
+	if fn == nil || fn.Body == nil || qualifier == "" || name == "" || newName == "" {
+		return
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		field, ok := call.Callee.(*ir.FieldExpr)
+		if !ok || field == nil || field.Name != name {
+			return true
+		}
+		ident, ok := field.X.(*ir.Ident)
+		if !ok || ident == nil || ident.Name != qualifier {
+			return true
+		}
+		call.Callee = &ir.Ident{
+			Name:  newName,
+			Kind:  ir.IdentFn,
+			T:     field.T,
+			SpanV: field.SpanV,
+		}
 		return true
 	}), fn.Body)
 }

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"strconv"
+
 	"github.com/osty/osty/internal/ir"
 )
 
@@ -121,12 +123,13 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 	type key struct{ module, typeName, method string }
 	set := map[key]string{}
 	type valueKey struct{ module, path, method string }
-	valueSet := map[valueKey]string{}
+	type valueRewriteTarget struct{ symbol, typeName string }
+	valueSet := map[valueKey]valueRewriteTarget{}
 	for _, r := range reached {
 		mangled := StdlibMethodSymbol(r.Module, r.Type, r.Method)
 		set[key{module: r.Module, typeName: r.Type, method: r.Method}] = mangled
 		if r.ValuePath != "" {
-			valueSet[valueKey{module: r.Module, path: r.ValuePath, method: r.Method}] = mangled
+			valueSet[valueKey{module: r.Module, path: r.ValuePath, method: r.Method}] = valueRewriteTarget{symbol: mangled, typeName: r.Type}
 		}
 	}
 	valueRewriteCount := 0
@@ -144,15 +147,16 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			if !ok || module == "" || len(path) == 0 {
 				return true
 			}
-			mangled, hit := valueSet[valueKey{
+			vk := valueKey{
 				module: module,
 				path:   stdlibJoinFieldPath(path),
 				method: field.Name,
-			}]
+			}
+			target, hit := valueSet[vk]
 			if !hit {
 				return true
 			}
-			receiver := field.X
+			receiver := stdlibSingletonReceiverExpr(module, vk.path, target.typeName, field.X, field.SpanV)
 			args := make([]ir.Arg, 0, len(call.Args)+1)
 			args = append(args, ir.Arg{
 				Value: receiver,
@@ -160,7 +164,7 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			})
 			args = append(args, call.Args...)
 			call.Callee = &ir.Ident{
-				Name:  mangled,
+				Name:  target.symbol,
 				Kind:  ir.IdentFn,
 				T:     stdlibFnType(args, call.T),
 				SpanV: field.SpanV,
@@ -177,20 +181,22 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			return true
 		}
 		if module, path, ok := stdlibFieldPath(mc.Receiver); ok && module != "" && len(path) != 0 {
-			if mangled, hit := valueSet[valueKey{
+			vk := valueKey{
 				module: module,
 				path:   stdlibJoinFieldPath(path),
 				method: mc.Name,
-			}]; hit {
+			}
+			if target, hit := valueSet[vk]; hit {
+				receiver := stdlibSingletonReceiverExpr(module, vk.path, target.typeName, mc.Receiver, mc.SpanV)
 				args := make([]ir.Arg, 0, len(mc.Args)+1)
 				args = append(args, ir.Arg{
-					Value: mc.Receiver,
+					Value: receiver,
 					SpanV: mc.SpanV,
 				})
 				args = append(args, mc.Args...)
 				swap[mc] = &ir.CallExpr{
 					Callee: &ir.Ident{
-						Name:  mangled,
+						Name:  target.symbol,
 						Kind:  ir.IdentFn,
 						T:     stdlibFnType(args, mc.T),
 						SpanV: mc.SpanV,
@@ -289,6 +295,88 @@ func stdlibJoinFieldPath(path []string) string {
 		out += part
 	}
 	return out
+}
+
+func stdlibSingletonReceiverExpr(module, path, typeName string, fallback ir.Expr, span ir.Span) ir.Expr {
+	switch {
+	case module == "encoding" && path == "base64" && typeName == "Base64":
+		return stdlibStructLit("Base64", span, ir.StructLitField{
+			Name:  "url",
+			Value: stdlibStructLit("Base64Url", span),
+			SpanV: span,
+		})
+	case module == "encoding" && path == "base64.url" && typeName == "Base64Url":
+		return stdlibStructLit("Base64Url", span)
+	case module == "encoding" && path == "hex" && typeName == "Hex":
+		return stdlibStructLit("Hex", span)
+	case module == "encoding" && path == "url" && typeName == "UrlEncoding":
+		return stdlibStructLit("UrlEncoding", span)
+	case module == "compress" && path == "gzip" && typeName == "Gzip":
+		return stdlibStructLit("Gzip", span)
+	case module == "crypto" && path == "hmac" && typeName == "Hmac":
+		return stdlibStructLit("Hmac", span)
+	case module == "os" && path == "path" && typeName == "Path":
+		return stdlibStructLit("Path", span)
+	case module == "net" && typeName == "Ipv4Addr":
+		switch path {
+		case "LOCALHOST_V4":
+			return stdlibIpv4Lit(127, 0, 0, 1, span)
+		case "UNSPECIFIED_V4":
+			return stdlibIpv4Lit(0, 0, 0, 0, span)
+		case "BROADCAST_V4":
+			return stdlibIpv4Lit(255, 255, 255, 255, span)
+		}
+	case module == "net" && typeName == "Ipv6Addr":
+		switch path {
+		case "LOCALHOST_V6":
+			return stdlibIpv6Lit([]int{0, 0, 0, 0, 0, 0, 0, 1}, span)
+		case "UNSPECIFIED_V6":
+			return stdlibIpv6Lit([]int{0, 0, 0, 0, 0, 0, 0, 0}, span)
+		}
+	}
+	return fallback
+}
+
+func stdlibStructLit(typeName string, span ir.Span, fields ...ir.StructLitField) *ir.StructLit {
+	return &ir.StructLit{
+		TypeName: typeName,
+		Fields:   fields,
+		T:        &ir.NamedType{Name: typeName},
+		SpanV:    span,
+	}
+}
+
+func stdlibIpv4Lit(a, b, c, d int, span ir.Span) *ir.StructLit {
+	return stdlibStructLit("Ipv4Addr", span,
+		stdlibIntField("a", a, span),
+		stdlibIntField("b", b, span),
+		stdlibIntField("c", c, span),
+		stdlibIntField("d", d, span),
+	)
+}
+
+func stdlibIpv6Lit(groups []int, span ir.Span) *ir.StructLit {
+	elems := make([]ir.Expr, 0, len(groups))
+	for _, g := range groups {
+		elems = append(elems, stdlibIntLit(g, span))
+	}
+	return stdlibStructLit("Ipv6Addr", span, ir.StructLitField{
+		Name: "groups",
+		Value: &ir.ListLit{
+			Elems: elems,
+			Elem:  ir.TInt,
+			SpanV: span,
+		},
+		SpanV: span,
+	})
+}
+
+func stdlibIntField(name string, value int, span ir.Span) ir.StructLitField {
+	return ir.StructLitField{Name: name, Value: stdlibIntLit(value, span), SpanV: span}
+}
+
+func stdlibIntLit(value int, span ir.Span) *ir.IntLit {
+	return &ir.IntLit{Text: strconv.Itoa(value), T: ir.TInt, SpanV: span}
 }
 
 // stdlibMethodCallsiteSpliceVisitor walks every Expr-bearing slot in

--- a/internal/backend/stdlib_mangle_test.go
+++ b/internal/backend/stdlib_mangle_test.go
@@ -201,8 +201,8 @@ func TestRewriteStdlibMethodCallsitesRewritesSingletonMethod(t *testing.T) {
 	if len(call.Args) != 2 {
 		t.Fatalf("args len = %d, want 2 (receiver + original)", len(call.Args))
 	}
-	if call.Args[0].Value != receiver {
-		t.Fatalf("args[0] = %v, want original receiver pointer", call.Args[0].Value)
+	if lit, ok := call.Args[0].Value.(*ir.StructLit); !ok || lit.TypeName != "Base64" {
+		t.Fatalf("args[0] = %T %v, want materialized Base64 singleton", call.Args[0].Value, call.Args[0].Value)
 	}
 }
 
@@ -240,8 +240,8 @@ func TestRewriteStdlibMethodCallsitesRewritesSingletonMethodCall(t *testing.T) {
 	if len(call.Args) != 2 {
 		t.Fatalf("args len = %d, want 2 (receiver + original)", len(call.Args))
 	}
-	if call.Args[0].Value != receiver {
-		t.Fatalf("args[0] = %v, want original receiver pointer", call.Args[0].Value)
+	if lit, ok := call.Args[0].Value.(*ir.StructLit); !ok || lit.TypeName != "Base64" {
+		t.Fatalf("args[0] = %T %v, want materialized Base64 singleton", call.Args[0].Value, call.Args[0].Value)
 	}
 	if call.T != ir.TString {
 		t.Fatalf("call return T = %v, want String", call.T)

--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/osty/osty/internal/ast"
@@ -31,9 +33,14 @@ var stdlibInjectableTypes = []struct {
 	{"Result", "result", "enum"},
 }
 
+type stdlibTypeKey struct {
+	Module string
+	Name   string
+}
+
 // loweredStdlibTypeCache memoizes one per-registry snapshot of the
-// generic stdlib type decls. Lowering collections.osty / option.osty
-// / result.osty is the expensive step; once lowered, each user module
+// stdlib type decls. Lowering stdlib modules is the expensive step; once
+// lowered, each user module
 // just deep-clones the subset it references. The cache is keyed by
 // stdlib.Registry pointer so a new registry (e.g. a fresh test
 // fixture) gets its own entry.
@@ -41,13 +48,12 @@ var loweredStdlibTypeCache sync.Map // map[*stdlib.Registry]*loweredStdlibTypesE
 
 type loweredStdlibTypesEntry struct {
 	once sync.Once
-	// decls maps the surface type name ("Map", "Option", …) to the
-	// generic StructDecl / EnumDecl extracted from the lowered stdlib
-	// module. Nil values mean the lower pass couldn't find the decl
-	// (e.g. a stdlib refactor that moved it) — those are silently
-	// skipped at injection time so a partial stdlib doesn't block
-	// user builds.
-	decls map[string]ir.Decl
+	// decls maps (module, surface type name) to the StructDecl /
+	// EnumDecl extracted from the lowered stdlib module. Nil values
+	// mean the lower pass couldn't find the decl (e.g. a stdlib
+	// refactor that moved it) — those are silently skipped at
+	// injection time so a partial stdlib doesn't block user builds.
+	decls map[stdlibTypeKey]ir.Decl
 }
 
 // injectReachableStdlibTypes appends stdlib built-in type decls
@@ -75,49 +81,150 @@ func injectReachableStdlibTypes(mod *ir.Module, reg *stdlib.Registry) ([]ir.Decl
 	if entry == nil {
 		return nil, nil
 	}
+	moduleRefs := collectInjectedStdlibModules(mod)
+	for module := range collectImportedStdlibModules(mod) {
+		if moduleRefs == nil {
+			moduleRefs = map[string]bool{}
+		}
+		moduleRefs[module] = true
+	}
 	var out []ir.Decl
-	seen := map[string]bool{}
-	for _, name := range referenced {
-		if seen[name] {
-			continue
+	seen := map[stdlibTypeKey]bool{}
+	appendKey := func(key stdlibTypeKey) {
+		if seen[key] {
+			return
 		}
-		decl, ok := entry.decls[name]
+		decl, ok := entry.decls[key]
 		if !ok || decl == nil {
-			continue
+			return
 		}
-		seen[name] = true
+		seen[key] = true
 		out = append(out, cloneStdlibTypeDecl(decl))
+	}
+	for _, key := range referenced {
+		appendKey(key)
+	}
+	if len(moduleRefs) > 0 {
+		keys := make([]stdlibTypeKey, 0, len(entry.decls))
+		for key := range entry.decls {
+			if moduleRefs[key.Module] {
+				keys = append(keys, key)
+			}
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			if keys[i].Module != keys[j].Module {
+				return keys[i].Module < keys[j].Module
+			}
+			return keys[i].Name < keys[j].Name
+		})
+		for _, key := range keys {
+			appendKey(key)
+		}
 	}
 	return out, nil
 }
 
-// collectReferencedStdlibTypes walks mod's type surfaces (param types,
-// return types, field types, enum-variant payloads, let bindings) and
-// returns the set of stdlib-provided built-in type names that appear.
-// Order is deterministic (first-appearance) so the injection output is
-// reproducible across runs.
-func collectReferencedStdlibTypes(mod *ir.Module) []string {
+func collectInjectedStdlibModules(mod *ir.Module) map[string]bool {
 	if mod == nil {
 		return nil
 	}
-	wanted := map[string]bool{}
-	for _, t := range stdlibInjectableTypes {
-		wanted[t.Name] = true
-	}
-	seen := map[string]bool{}
-	var out []string
+	out := map[string]bool{}
 	record := func(name string) {
-		if !wanted[name] || seen[name] {
+		module, ok := stdlibModuleFromInjectedSymbol(name)
+		if ok {
+			out[module] = true
+		}
+	}
+	for _, d := range mod.Decls {
+		switch x := d.(type) {
+		case *ir.FnDecl:
+			if x != nil {
+				record(x.Name)
+			}
+		case *ir.StructDecl:
+			for _, m := range x.Methods {
+				if m != nil {
+					record(m.Name)
+				}
+			}
+		case *ir.EnumDecl:
+			for _, m := range x.Methods {
+				if m != nil {
+					record(m.Name)
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func collectImportedStdlibModules(mod *ir.Module) map[string]bool {
+	if mod == nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, d := range mod.Decls {
+		u, ok := d.(*ir.UseDecl)
+		if !ok || u == nil || len(u.Path) < 2 || u.Path[0] != "std" {
+			continue
+		}
+		out[u.Path[1]] = true
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func stdlibModuleFromInjectedSymbol(name string) (string, bool) {
+	const prefix = "osty_std_"
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(name, prefix)
+	idx := strings.Index(rest, "__")
+	if idx <= 0 {
+		return "", false
+	}
+	return rest[:idx], true
+}
+
+// collectReferencedStdlibTypes walks mod's type surfaces (param types,
+// return types, field types, enum-variant payloads, let bindings) and
+// expression result types and returns the set of stdlib-provided type
+// decls that appear.
+// Order is deterministic (first-appearance) so the injection output is
+// reproducible across runs.
+func collectReferencedStdlibTypes(mod *ir.Module) []stdlibTypeKey {
+	if mod == nil {
+		return nil
+	}
+	builtinModule := map[string]string{}
+	for _, t := range stdlibInjectableTypes {
+		builtinModule[t.Name] = t.Module
+	}
+	seen := map[stdlibTypeKey]bool{}
+	var out []stdlibTypeKey
+	record := func(key stdlibTypeKey) {
+		key.Module = normalizeStdlibTypeModule(key.Module)
+		if key.Module == "" || key.Name == "" || seen[key] {
 			return
 		}
-		seen[name] = true
-		out = append(out, name)
+		seen[key] = true
+		out = append(out, key)
 	}
 	var walk func(t ir.Type)
 	walk = func(t ir.Type) {
 		switch tt := t.(type) {
 		case *ir.NamedType:
-			record(tt.Name)
+			if tt.Package != "" {
+				record(stdlibTypeKey{Module: tt.Package, Name: tt.Name})
+			} else if module := builtinModule[tt.Name]; module != "" {
+				record(stdlibTypeKey{Module: module, Name: tt.Name})
+			}
 			for _, a := range tt.Args {
 				walk(a)
 			}
@@ -126,7 +233,7 @@ func collectReferencedStdlibTypes(mod *ir.Module) []string {
 			// Option as an enum also triggers isSome / isNone body
 			// specialization, so opt-chains in user code pull in the
 			// Option decl via this branch.
-			record("Option")
+			record(stdlibTypeKey{Module: "option", Name: "Option"})
 			walk(tt.Inner)
 		case *ir.TupleType:
 			for _, e := range tt.Elems {
@@ -140,6 +247,9 @@ func collectReferencedStdlibTypes(mod *ir.Module) []string {
 		}
 	}
 	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		if expr, ok := n.(ir.Expr); ok && expr != nil {
+			walk(expr.Type())
+		}
 		switch x := n.(type) {
 		case *ir.FnDecl:
 			for _, p := range x.Params {
@@ -170,6 +280,11 @@ func collectReferencedStdlibTypes(mod *ir.Module) []string {
 	return out
 }
 
+func normalizeStdlibTypeModule(module string) string {
+	module = strings.TrimPrefix(module, "std.")
+	return module
+}
+
 // loweredStdlibTypesFor returns the cached lowered stdlib type decls
 // for reg, loading them on first access. Safe for concurrent callers
 // via sync.Once.
@@ -185,38 +300,54 @@ func loweredStdlibTypesFor(reg *stdlib.Registry) *loweredStdlibTypesEntry {
 	return entry
 }
 
-// lowerStdlibTypesFromRegistry walks every stdlib module relevant to
-// the built-in type injection set (collections, option, result) and
-// returns a name → Decl map containing each generic Struct/Enum. The
+// lowerStdlibTypesFromRegistry walks stdlib modules and returns a
+// (module, name) → Decl map containing every Struct/Enum surface. The
 // returned decls are fresh clones from a one-shot `ir.Lower` per
 // module so the cache can safely hand them out by reference (each
 // caller deep-clones again before appending to user mods).
-func lowerStdlibTypesFromRegistry(reg *stdlib.Registry) map[string]ir.Decl {
-	out := map[string]ir.Decl{}
+func lowerStdlibTypesFromRegistry(reg *stdlib.Registry) map[stdlibTypeKey]ir.Decl {
+	out := map[stdlibTypeKey]ir.Decl{}
 	if reg == nil {
 		return out
 	}
-	// Gather unique stdlib modules to lower.
-	modules := map[string]bool{}
-	for _, t := range stdlibInjectableTypes {
-		modules[t.Module] = true
-	}
-	for mod := range modules {
-		loweredDecls := lowerStdlibModule(reg, mod)
+	for module := range reg.Modules {
+		loweredDecls := lowerStdlibModule(reg, module)
 		for _, d := range loweredDecls {
 			switch x := d.(type) {
 			case *ir.StructDecl:
-				if len(x.Generics) > 0 && isInjectableTypeName(x.Name) {
-					out[x.Name] = stripMethodsForInjection(x)
-				}
+				out[stdlibTypeKey{Module: module, Name: x.Name}] = stripStdlibTypeForInjection(x)
 			case *ir.EnumDecl:
-				if len(x.Generics) > 0 && isInjectableTypeName(x.Name) {
-					out[x.Name] = stripMethodsForInjection(x)
-				}
+				out[stdlibTypeKey{Module: module, Name: x.Name}] = stripStdlibTypeForInjection(x)
 			}
 		}
 	}
 	return out
+}
+
+func stripStdlibTypeForInjection(d ir.Decl) ir.Decl {
+	switch x := d.(type) {
+	case *ir.StructDecl:
+		switch x.Name {
+		case "List", "Set":
+			x.Methods = nil
+			return x
+		}
+		if len(x.Generics) == 0 {
+			x.Methods = nil
+			return x
+		}
+	case *ir.EnumDecl:
+		switch x.Name {
+		case "Option", "Result":
+			x.Methods = nil
+			return x
+		}
+		if len(x.Generics) == 0 {
+			x.Methods = nil
+			return x
+		}
+	}
+	return stripMethodsForInjection(d)
 }
 
 // stripMethodsForInjection drops methods whose signatures would drive
@@ -360,6 +491,9 @@ func filterMethodsAvoidingOwnerRecursion(owner string, generics []string, method
 func methodHasUnsupportedLLVMShape(owner string, m *ir.FnDecl) bool {
 	if m == nil {
 		return false
+	}
+	if owner == "List" && m.Name == "reverse" {
+		return true
 	}
 	// Map.find returns `(K, V)?`. The legacy AST LLVM path currently
 	// treats optional tuple returns as pointer-shaped at the function

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -669,16 +669,20 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 	// Consult the resolver for the head symbol so we can classify
 	// builtins vs user declarations vs generic parameters.
 	if sym := l.typeRef(nt); sym != nil {
+		symName := sym.Name
+		if pkg != "" && len(nt.Path) > 0 && symName == nt.Path[0] {
+			symName = name
+		}
 		switch sym.Kind {
 		case resolve.SymBuiltin:
 			if len(nt.Args) == 0 {
-				if p := primitiveByName(sym.Name); p != nil {
+				if p := primitiveByName(symName); p != nil {
 					return p
 				}
 			}
-			return &NamedType{Package: pkg, Name: sym.Name, Args: args, Builtin: true}
+			return &NamedType{Package: pkg, Name: symName, Args: args, Builtin: true}
 		case resolve.SymGeneric:
-			return &TypeVar{Name: sym.Name, Owner: ""}
+			return &TypeVar{Name: symName, Owner: ""}
 		case resolve.SymTypeAlias:
 			// Unwrap the alias at IR construction time. Without this,
 			// downstream passes (MIR generator's typeSupported,
@@ -691,7 +695,7 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 				return l.lowerType(aliasDecl.Target)
 			}
 		}
-		return &NamedType{Package: pkg, Name: sym.Name, Args: args}
+		return &NamedType{Package: pkg, Name: symName, Args: args}
 	}
 
 	// No resolver data available — best effort on the source name.

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -513,7 +513,7 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		// doesn't need a declared layout for them. These match what
 		// the runtime ABI hands back from chan_make / spawn / etc.
 		switch x.Name {
-		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration", "Rng", "Gen":
+		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration", "Rng", "Gen", "Never":
 			return true
 		case "Range":
 			// Range<T> is a prelude type but the Go-side resolver
@@ -524,6 +524,9 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			// not — the MIR lowerer emits RangeLit as a placeholder
 			// UseRV(UnitConst) anyway, so the concrete shape is
 			// irrelevant until real lowering arrives.
+			return true
+		}
+		if isStdlibModuleMarkerTypeName(x.Name) {
 			return true
 		}
 		if g.mod != nil && g.mod.Layouts != nil {
@@ -862,8 +865,8 @@ func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx st
 			} else {
 				baseT = projectionType(p.Projections[i-1])
 			}
-			if !isListPtrType(baseT) && !isMapPtrType(baseT) {
-				return unsupported("mir-mvp", fmt.Sprintf("%s IndexProj on non-List/Map base %s in %s", ctx, mirTypeString(baseT), fn.Name))
+			if !isListPtrType(baseT) && !isMapPtrType(baseT) && !isStringPrimType(baseT) {
+				return unsupported("mir-mvp", fmt.Sprintf("%s IndexProj on non-List/Map/String base %s in %s", ctx, mirTypeString(baseT), fn.Name))
 			}
 		default:
 			return unsupported("mir-mvp", fmt.Sprintf("%s projection %T not yet supported in %s", ctx, proj, fn.Name))
@@ -878,7 +881,7 @@ func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx st
 // policy delegates to `mirIsBuiltinList` (`toolchain/mir_generator.osty`).
 func isListPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return mirIsBuiltinList(nt.Name, nt.Builtin)
+		return mirIsBuiltinList(nt.Name, nt.Builtin) || mangledBuiltinSourceNameIs(nt.Name, "List")
 	}
 	return false
 }
@@ -887,7 +890,7 @@ func isListPtrType(t mir.Type) bool {
 // to `mirIsBuiltinMap`.
 func isMapPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return mirIsBuiltinMap(nt.Name, nt.Builtin)
+		return mirIsBuiltinMap(nt.Name, nt.Builtin) || mangledBuiltinSourceNameIs(nt.Name, "Map")
 	}
 	return false
 }
@@ -896,9 +899,47 @@ func isMapPtrType(t mir.Type) bool {
 // `mirIsBuiltinSet`.
 func isSetPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
-		return mirIsBuiltinSet(nt.Name, nt.Builtin)
+		return mirIsBuiltinSet(nt.Name, nt.Builtin) || mangledBuiltinSourceNameIs(nt.Name, "Set")
 	}
 	return false
+}
+
+func mangledBuiltinSourceNameIs(name, want string) bool {
+	got, ok := monomorphMangledSourceName(name)
+	return ok && got == want
+}
+
+func monomorphMangledSourceName(name string) (string, bool) {
+	const prefix = "_ZTSN"
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(name, prefix)
+	var ok bool
+	_, rest, ok = consumeLengthPrefixedName(rest)
+	if !ok {
+		return "", false
+	}
+	typeName, _, ok := consumeLengthPrefixedName(rest)
+	if !ok || typeName == "" {
+		return "", false
+	}
+	return typeName, true
+}
+
+func consumeLengthPrefixedName(s string) (string, string, bool) {
+	if s == "" || s[0] < '0' || s[0] > '9' {
+		return "", "", false
+	}
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	n, err := strconv.Atoi(s[:i])
+	if err != nil || n < 0 || i+n > len(s) {
+		return "", "", false
+	}
+	return s[i : i+n], s[i+n:], true
 }
 
 func vectorListElemType(t mir.Type) mir.Type {
@@ -1602,18 +1643,18 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	// the function entry. No-op unless opts.EmitGC is set.
 	g.emitGCEntry(fn)
 	g.emitVectorListPreamble(fn)
+	g.fnBuf.WriteString(mirBrUncondLine(g.blockLabels[fn.Entry]))
 
-	// Emit each block in ID order. The entry block was already opened
-	// (its label is implicit in LLVM, but we still emit it for clarity
-	// — and because we've appended to the preamble, not the entry
-	// block's content per se).
+	// Emit each block in ID order. The alloca / GC preamble is a real
+	// LLVM basic block now, so it branches to the MIR entry block and
+	// every MIR block is opened with an explicit label. This keeps
+	// functions valid even when MIR's entry block is not the first block
+	// in storage order (common after match lowering).
 	for _, bb := range fn.Blocks {
 		if bb == nil {
 			continue
 		}
-		if bb.ID != fn.Entry {
-			g.fnBuf.WriteString(mirLabelLine(g.blockLabels[bb.ID]))
-		}
+		g.fnBuf.WriteString(mirLabelLine(g.blockLabels[bb.ID]))
 		g.curBlockID = bb.ID
 		for _, inst := range bb.Instrs {
 			if err := g.emitInstr(inst); err != nil {
@@ -2435,7 +2476,7 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 		g.fnBuf.WriteString(mirCallVoidListBytesV1SetWithBarrierLine(sym, contReg, idxReg, valSlot.name, sizeReg, "null"))
 		return nil
 	case isMapPtrType(localT):
-		keyT, _ := mapKeyValueTypes(localT)
+		keyT, _ := g.mapKeyValueTypes(localT)
 		if keyT == nil {
 			return unsupported("mir-mvp", "map indexed write without key type")
 		}
@@ -2602,6 +2643,15 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 	if handled, err := g.emitRuntimeFFICall(c, fnRef); handled {
 		return err
 	}
+	if fnRef.Symbol == "__resultAbort" || fnRef.Symbol == "std.result.__resultAbort" {
+		return g.emitStdlibAbortCallMIR(c, "called unwrap on Err")
+	}
+	if fnRef.Symbol == "__optionAbort" || fnRef.Symbol == "std.option.__optionAbort" {
+		return g.emitStdlibAbortCallMIR(c, "called unwrap on None")
+	}
+	if fnRef.Symbol == "__optionError" || fnRef.Symbol == "std.option.__optionError" {
+		return g.emitStdlibOptionErrorCallMIR(c)
+	}
 	if strings.HasPrefix(fnRef.Symbol, "std.strings.") {
 		if handled, err := g.emitStdStringsCall(c, fnRef); handled {
 			return err
@@ -2643,6 +2693,11 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 		}
 	}
 	if strings.HasPrefix(fnRef.Symbol, "Error__") {
+		if handled, err := g.emitStdErrorCall(c, fnRef); handled {
+			return err
+		}
+	}
+	if strings.HasPrefix(fnRef.Symbol, "std.error.") {
 		if handled, err := g.emitStdErrorCall(c, fnRef); handled {
 			return err
 		}
@@ -2755,6 +2810,59 @@ func (g *mirGen) emitRuntimeFFICall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, e
 	return true, g.emitCallSiteByName(c, sym, retLLVM, argStrs)
 }
 
+func (g *mirGen) emitStdlibAbortCallMIR(c *mir.CallInstr, fallback string) error {
+	msg := g.stringLiteral(fallback)
+	if len(c.Args) > 0 && c.Args[0] != nil {
+		text, err := g.emitStdIoStringOperandMIR(c.Args[0], "stdlib abort")
+		if err != nil {
+			return err
+		}
+		msg = text
+	}
+	g.emitAbortStringPtrAndExit(msg)
+	return nil
+}
+
+func (g *mirGen) emitAbortStringPtrAndExit(msg string) {
+	g.declareRuntime(ostyRtIOWriteSymbol, mirRuntimeDeclareLine("void", ostyRtIOWriteSymbol, "ptr, i1, i1"))
+	g.fnBuf.WriteString(mirCallVoidLine(ostyRtIOWriteSymbol,
+		mirArgSlotPtr(msg)+", "+mirArgSlotI1(llvmStdIoI1Text(true))+", "+mirArgSlotI1(llvmStdIoI1Text(true))))
+	g.declareRuntime("exit", mirRuntimeDeclareExit())
+	g.fnBuf.WriteString(mirCallExitOneLine())
+}
+
+func (g *mirGen) emitStdlibOptionErrorCallMIR(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "__optionError requires one positional String argument")
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: __optionError dest into unknown local %d", c.Dest.Local)
+	}
+	_, errT, ok := g.resultPayloadTypes(destLoc.Type)
+	if !ok {
+		return unsupported("mir-mvp", "__optionError dest is not Result<T, Error>")
+	}
+	msg, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	if msg.typ != "ptr" {
+		return unsupported("mir-mvp", "__optionError message must lower to ptr")
+	}
+	payload, err := g.toI64Slot(msg.val, errT)
+	if err != nil {
+		return err
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	errValue := g.emitResultValue(resultLLVM, false, payload)
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, errValue, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
 func splitRuntimeFFICallee(symbol string) (path string, name string, ok bool) {
 	idx := strings.LastIndex(symbol, ".")
 	if idx <= len("runtime") || idx == len(symbol)-1 {
@@ -2860,6 +2968,11 @@ func (g *mirGen) emitPrimitiveMethodCall(c *mir.CallInstr, fnRef *mir.FnRef) (bo
 	}
 	if isFloat {
 		return g.emitFloatPrimitiveMethodCall(c, method, recv, llvmTy)
+	}
+	if owner == "Char" {
+		if handled, err := g.emitCharPrimitiveMethodCall(c, method, recv); handled {
+			return true, err
+		}
 	}
 
 	// Emit the branchless body, capturing the result register so we
@@ -3045,6 +3158,70 @@ func (g *mirGen) emitPrimitiveMethodCall(c *mir.CallInstr, fnRef *mir.FnRef) (bo
 	return g.storePrimitiveResult(c, resultReg)
 }
 
+func (g *mirGen) emitCharPrimitiveMethodCall(c *mir.CallInstr, method, recv string) (bool, error) {
+	var body string
+	var resultReg string
+	rangeCheck := func(charRef string, low int, count int) string {
+		shifted := g.fresh()
+		cmp := g.fresh()
+		body += mirSubI32LiteralText(shifted, charRef, strconv.Itoa(low)) + "\n"
+		body += mirICmpULTI32LiteralText(cmp, shifted, strconv.Itoa(count)) + "\n"
+		return cmp
+	}
+	switch method {
+	case "isDigit":
+		resultReg = rangeCheck(recv, '0', 10)
+	case "isUpper":
+		resultReg = rangeCheck(recv, 'A', 26)
+	case "isLower":
+		resultReg = rangeCheck(recv, 'a', 26)
+	case "isAlpha":
+		up := rangeCheck(recv, 'A', 26)
+		lo := rangeCheck(recv, 'a', 26)
+		resultReg = g.fresh()
+		body += mirOrI1Text(resultReg, up, lo) + "\n"
+	case "isAlphanumeric":
+		dg := rangeCheck(recv, '0', 10)
+		up := rangeCheck(recv, 'A', 26)
+		lo := rangeCheck(recv, 'a', 26)
+		alpha := g.fresh()
+		body += mirOrI1Text(alpha, up, lo) + "\n"
+		resultReg = g.fresh()
+		body += mirOrI1Text(resultReg, dg, alpha) + "\n"
+	case "isWhitespace":
+		eqSp := g.fresh()
+		body += mirICmpEqI32LiteralText(eqSp, recv, "32") + "\n"
+		eqTab := g.fresh()
+		body += mirICmpEqI32LiteralText(eqTab, recv, "9") + "\n"
+		eqLf := g.fresh()
+		body += mirICmpEqI32LiteralText(eqLf, recv, "10") + "\n"
+		eqCr := g.fresh()
+		body += mirICmpEqI32LiteralText(eqCr, recv, "13") + "\n"
+		left := g.fresh()
+		body += mirOrI1Text(left, eqSp, eqTab) + "\n"
+		right := g.fresh()
+		body += mirOrI1Text(right, eqLf, eqCr) + "\n"
+		resultReg = g.fresh()
+		body += mirOrI1Text(resultReg, left, right) + "\n"
+	case "toLower":
+		isUp := rangeCheck(recv, 'A', 26)
+		shifted := g.fresh()
+		body += mirAddI32LiteralText(shifted, recv, "32") + "\n"
+		resultReg = g.fresh()
+		body += mirSelectI32Text(resultReg, isUp, shifted, recv) + "\n"
+	case "toUpper":
+		isLo := rangeCheck(recv, 'a', 26)
+		shifted := g.fresh()
+		body += mirSubI32LiteralText(shifted, recv, "32") + "\n"
+		resultReg = g.fresh()
+		body += mirSelectI32Text(resultReg, isLo, shifted, recv) + "\n"
+	default:
+		return false, nil
+	}
+	g.fnBuf.WriteString(body)
+	return g.storePrimitiveResult(c, resultReg)
+}
+
 // storePrimitiveResult stores the intrinsic result register into the
 // destination local. Used by emitPrimitiveMethodCall after the
 // branchless body has been written to g.fnBuf.
@@ -3082,7 +3259,11 @@ func (g *mirGen) emitIndirectCall(c *mir.CallInstr, callee *mir.IndirectCall) er
 	}
 	fnT, ok := calleeOp.Type().(*ir.FnType)
 	if !ok {
-		return unsupported("mir-mvp", fmt.Sprintf("indirect call on non-function type %s", mirTypeString(calleeOp.Type())))
+		fnName := "<unknown>"
+		if g.fn != nil && g.fn.Name != "" {
+			fnName = g.fn.Name
+		}
+		return unsupported("mir-mvp", fmt.Sprintf("indirect call on non-function type %s in %s", mirTypeString(calleeOp.Type()), fnName))
 	}
 	// Evaluate the operand to get the env ptr.
 	envPtr, err := g.evalOperand(calleeOp, calleeOp.Type())
@@ -3455,11 +3636,34 @@ type testingResultTypes struct {
 // of monomorphization shapes that may carry extra metadata args (today
 // none do, but the loose check matches the legacy behaviour).
 func testingResultType(t mir.Type) (testingResultTypes, bool) {
-	nt, ok := t.(*ir.NamedType)
-	if !ok || nt.Name != "Result" || len(nt.Args) < 2 {
+	okT, errT, ok := resultPayloadTypes(t)
+	if !ok {
 		return testingResultTypes{}, false
 	}
-	return testingResultTypes{ok: nt.Args[0], err: nt.Args[1]}, true
+	return testingResultTypes{ok: okT, err: errT}, true
+}
+
+func resultPayloadTypes(t mir.Type) (mir.Type, mir.Type, bool) {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt.Name != "Result" || len(nt.Args) < 2 {
+		return nil, nil, false
+	}
+	return nt.Args[0], nt.Args[1], true
+}
+
+func (g *mirGen) resultPayloadTypes(t mir.Type) (mir.Type, mir.Type, bool) {
+	okT, errT, ok := resultPayloadTypes(t)
+	if ok {
+		return okT, errT, true
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
+		return nil, nil, false
+	}
+	if el := g.mod.Layouts.Enums[nt.Name]; el != nil && el.BuiltinSource == "Result" && len(el.BuiltinSourceArgs) >= 2 {
+		return el.BuiltinSourceArgs[0], el.BuiltinSourceArgs[1], true
+	}
+	return nil, nil, false
 }
 
 func (g *mirGen) emitTestingFailureCheck(cond string, failWhenTrue bool, buildMessage func() (*LlvmValue, error)) error {
@@ -4380,7 +4584,7 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		payload := g.fresh()
 		g.fnBuf.WriteString(mirExtractValueLine(payload, optLLVM, optVal, "1"))
-		narrowed, err := g.narrowOptionPayload(payload, destLLVM)
+		narrowed, err := g.fromI64Slot(payload, destLoc.Type)
 		if err != nil {
 			return err
 		}
@@ -4416,7 +4620,7 @@ func (g *mirGen) emitOptionIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteString(mirLabelLine(someLabel))
 		payload := g.fresh()
 		g.fnBuf.WriteString(mirExtractValueLine(payload, optLLVM, optVal, "1"))
-		narrowed, err := g.narrowOptionPayload(payload, destLLVM)
+		narrowed, err := g.fromI64Slot(payload, destLoc.Type)
 		if err != nil {
 			return err
 		}
@@ -4440,12 +4644,12 @@ func (g *mirGen) emitResultIntrinsic(i *mir.IntrinsicInstr) error {
 	if len(i.Args) < 1 {
 		return unsupported("mir-mvp", fmt.Sprintf("%s without operand", mirIntrinsicLabel(i.Kind)))
 	}
-	resultT, ok := i.Args[0].Type().(*ir.NamedType)
-	if !ok || resultT.Name != "Result" || len(resultT.Args) < 2 {
+	resultType := i.Args[0].Type()
+	if _, _, ok := g.resultPayloadTypes(resultType); !ok {
 		return unsupported("mir-mvp", fmt.Sprintf("%s operand is not Result<T, E>", mirIntrinsicLabel(i.Kind)))
 	}
-	resultLLVM := g.llvmType(resultT)
-	resultVal, err := g.evalOperand(i.Args[0], resultT)
+	resultLLVM := g.llvmType(resultType)
+	resultVal, err := g.evalOperand(i.Args[0], resultType)
 	if err != nil {
 		return err
 	}
@@ -4475,9 +4679,7 @@ func (g *mirGen) emitResultIntrinsic(i *mir.IntrinsicInstr) error {
 		okLabel := g.freshLabel("result.unwrap.ok")
 		g.fnBuf.WriteString(mirBrCondLine(isErr, errLabel, okLabel))
 		g.fnBuf.WriteString(mirLabelLine(errLabel))
-		abortSym := mirRtResultUnwrapErrSymbol()
-		g.declareRuntime(abortSym, mirRuntimeDeclareNoReturn("void", abortSym, "", false))
-		g.fnBuf.WriteString(mirCallResultUnwrapErrLine())
+		g.emitAbortStringPtrAndExit(g.stringLiteral("called unwrap on Err"))
 		g.fnBuf.WriteString(mirUnreachableLine())
 		g.fnBuf.WriteString(mirLabelLine(okLabel))
 		if isUnitType(destLoc.Type) {
@@ -4621,7 +4823,7 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 	if err != nil {
 		return err
 	}
-	elemT := listElemType(listOp.Type())
+	elemT := g.listElemType(listOp.Type())
 	if elemT == nil {
 		return unsupported("mir-mvp", "list intrinsic: missing element type")
 	}
@@ -4665,9 +4867,14 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListIsEmpty:
-		sym := mirRtListIsEmptySymbol()
-		g.declareRuntime(sym, mirRuntimeDeclareI1FromPtrLine(sym))
-		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + listReg})
+		sym := listRuntimeLenSymbol()
+		g.declareRuntime(sym, mirRuntimeDeclareMemoryRead("i64", sym, "ptr"))
+		em := g.ostyEmitter()
+		length := llvmListLen(em, &LlvmValue{typ: "ptr", name: listReg})
+		g.flushOstyEmitter(em)
+		isEmpty := g.fresh()
+		g.fnBuf.WriteString(mirICmpEqI64Line(isEmpty, length.name, "0"))
+		return g.storeIntrinsicResult(i, &LlvmValue{typ: "i1", name: isEmpty})
 	case mir.IntrinsicListGet:
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "list_get arity")
@@ -5137,7 +5344,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if destLoc == nil {
 			return unsupported("mir-mvp", "map_new dest into unknown local")
 		}
-		keyT, valT := mapKeyValueTypes(destLoc.Type)
+		keyT, valT := g.mapKeyValueTypes(destLoc.Type)
 		if keyT == nil || valT == nil {
 			return unsupported("mir-mvp", fmt.Sprintf("map_new dest type %s not Map<K,V>", mirTypeString(destLoc.Type)))
 		}
@@ -5171,7 +5378,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 	if err != nil {
 		return err
 	}
-	keyT, valT := mapKeyValueTypes(i.Args[0].Type())
+	keyT, valT := g.mapKeyValueTypes(i.Args[0].Type())
 	keyLLVM := g.llvmType(keyT)
 	keyString := isStringLLVMType(keyT)
 	_ = valT
@@ -5541,7 +5748,7 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 	if err != nil {
 		return err
 	}
-	elemT := setElemType(i.Args[0].Type())
+	elemT := g.setElemType(i.Args[0].Type())
 	elemLLVM := g.llvmType(elemT)
 	elemString := isStringLLVMType(elemT)
 	switch i.Kind {
@@ -6169,12 +6376,11 @@ func (g *mirGen) emitBytesValidatedResult(i *mir.IntrinsicInstr, inputReg, valid
 	if destLoc == nil {
 		return fmt.Errorf("mir-mvp: %s dest %d", mirIntrinsicLabel(i.Kind), i.Dest.Local)
 	}
-	resultT, ok := destLoc.Type.(*ir.NamedType)
-	if !ok || resultT.Name != "Result" || len(resultT.Args) < 2 {
+	okT, _, ok := g.resultPayloadTypes(destLoc.Type)
+	if !ok {
 		return unsupported("mir-mvp", fmt.Sprintf("%s dest is not Result<T, E>", mirIntrinsicLabel(i.Kind)))
 	}
 	resultLLVM := g.llvmType(destLoc.Type)
-	okT := resultT.Args[0]
 	g.declareRuntime(validateSym, mirRuntimeDeclareI1FromPtrLine(validateSym))
 	g.declareRuntime(successSym, mirRuntimeDeclarePtrFromPtrLine(successSym))
 
@@ -6997,8 +7203,8 @@ func (g *mirGen) emitStringParseResultIntrinsic(i *mir.IntrinsicInstr, strReg, v
 	if destLoc == nil {
 		return fmt.Errorf("mir-mvp: string parse dest %d", i.Dest.Local)
 	}
-	resultT, ok := destLoc.Type.(*ir.NamedType)
-	if !ok || resultT.Name != "Result" || len(resultT.Args) < 2 {
+	okT, _, ok := g.resultPayloadTypes(destLoc.Type)
+	if !ok {
 		return unsupported("mir-mvp", "string parse dest is not Result")
 	}
 	resultLLVM := g.llvmType(destLoc.Type)
@@ -7018,7 +7224,7 @@ func (g *mirGen) emitStringParseResultIntrinsic(i *mir.IntrinsicInstr, strReg, v
 	em = g.ostyEmitter()
 	parsed := llvmCall(em, parseLLVM, parseSym, []*LlvmValue{{typ: "ptr", name: strReg}})
 	g.flushOstyEmitter(em)
-	payload, err := g.toI64Slot(parsed.name, resultT.Args[0])
+	payload, err := g.toI64Slot(parsed.name, okT)
 	if err != nil {
 		return err
 	}
@@ -7559,7 +7765,22 @@ func mirIsTwoWordEnumLLVM(llvmT string) bool {
 	name := strings.TrimPrefix(llvmT, "%")
 	return strings.HasPrefix(name, "Option.") ||
 		strings.HasPrefix(name, "Maybe.") ||
-		strings.HasPrefix(name, "Result.")
+		strings.HasPrefix(name, "Result.") ||
+		mangledBuiltinSourceNameIs(name, "Option") ||
+		mangledBuiltinSourceNameIs(name, "Maybe") ||
+		mangledBuiltinSourceNameIs(name, "Result")
+}
+
+func isOpaqueBuiltinStructLayout(sl *mir.StructLayout) bool {
+	if sl == nil {
+		return false
+	}
+	switch sl.BuiltinSource {
+	case "List", "Map", "Set":
+		return true
+	default:
+		return false
+	}
 }
 
 // mapKeyValueTypes returns the (K, V) sub-types of a `Map<K, V>` named
@@ -7573,6 +7794,21 @@ func mapKeyValueTypes(t mir.Type) (mir.Type, mir.Type) {
 		return nil, nil
 	}
 	return nt.Args[0], nt.Args[1]
+}
+
+func (g *mirGen) mapKeyValueTypes(t mir.Type) (mir.Type, mir.Type) {
+	keyT, valT := mapKeyValueTypes(t)
+	if keyT != nil && valT != nil {
+		return keyT, valT
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
+		return nil, nil
+	}
+	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "Map" && len(sl.BuiltinSourceArgs) == 2 {
+		return sl.BuiltinSourceArgs[0], sl.BuiltinSourceArgs[1]
+	}
+	return nil, nil
 }
 
 // mapValueSizeBytes maps an LLVM value type to the byte width used when
@@ -7596,6 +7832,20 @@ func setElemType(t mir.Type) mir.Type {
 		return nil
 	}
 	return nt.Args[idx]
+}
+
+func (g *mirGen) setElemType(t mir.Type) mir.Type {
+	if elem := setElemType(t); elem != nil {
+		return elem
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
+		return nil
+	}
+	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "Set" && len(sl.BuiltinSourceArgs) == 1 {
+		return sl.BuiltinSourceArgs[0]
+	}
+	return nil
 }
 
 func isStringLLVMType(t mir.Type) bool {
@@ -8297,9 +8547,13 @@ func (g *mirGen) closureEnvTypeName(elems []mir.Type) string {
 }
 
 func (g *mirGen) emitListLiteral(rv *mir.AggregateRV, aggT mir.Type) (string, error) {
-	elemT := listElemType(aggT)
+	elemT := g.listElemType(aggT)
 	if elemT == nil {
-		return "", unsupported("mir-mvp", "list literal: missing element type")
+		fnName := "<unknown>"
+		if g.fn != nil && g.fn.Name != "" {
+			fnName = g.fn.Name
+		}
+		return "", unsupportedf("mir-mvp", "list literal: missing element type in %s (aggregate type %s)", fnName, mirTypeString(aggT))
 	}
 	g.declareRuntime(listRuntimeNewSymbol(), mirRuntimeDeclareLine("ptr", listRuntimeNewSymbol(), ""))
 	em := g.ostyEmitter()
@@ -8489,6 +8743,20 @@ func listElemType(t mir.Type) mir.Type {
 	return nil
 }
 
+func (g *mirGen) listElemType(t mir.Type) mir.Type {
+	if elem := listElemType(t); elem != nil {
+		return elem
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
+		return nil
+	}
+	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "List" && len(sl.BuiltinSourceArgs) == 1 {
+		return sl.BuiltinSourceArgs[0]
+	}
+	return nil
+}
+
 // aggregateElementTypes returns the element types an aggregate's
 // Fields should match. For structs this comes from the LayoutTable
 // so field order is authoritative; for tuples it's the type itself.
@@ -8535,9 +8803,17 @@ func (g *mirGen) aggregateElementTypes(aggT mir.Type, rv *mir.AggregateRV) ([]mi
 func (g *mirGen) evalOperand(op mir.Operand, hintT mir.Type) (string, error) {
 	switch o := op.(type) {
 	case *mir.CopyOp:
-		return g.emitLoad(o.Place, o.T)
+		val, err := g.emitLoad(o.Place, o.T)
+		if err != nil {
+			return "", err
+		}
+		return g.coerceOperandValue(val, o.T, hintT)
 	case *mir.MoveOp:
-		return g.emitLoad(o.Place, o.T)
+		val, err := g.emitLoad(o.Place, o.T)
+		if err != nil {
+			return "", err
+		}
+		return g.coerceOperandValue(val, o.T, hintT)
 	case *mir.ConstOp:
 		// Bare `FnConst` in value position (not a direct-call callee —
 		// those use `FnRef` and never flow through evalOperand). Under
@@ -8553,6 +8829,22 @@ func (g *mirGen) evalOperand(op mir.Operand, hintT mir.Type) (string, error) {
 		return g.renderConst(o.Const, o.T)
 	}
 	return "", unsupported("mir-mvp", fmt.Sprintf("operand %T", op))
+}
+
+func (g *mirGen) coerceOperandValue(val string, fromT, toT mir.Type) (string, error) {
+	if fromT == nil || toT == nil {
+		return val, nil
+	}
+	fromLLVM := g.llvmType(fromT)
+	toLLVM := g.llvmType(toT)
+	if fromLLVM == toLLVM {
+		return val, nil
+	}
+	coerced, err := g.coerceValue(val, fromLLVM, toLLVM)
+	if err != nil {
+		return val, nil
+	}
+	return coerced, nil
 }
 
 func mirBinaryArgType(left, right mir.Type) mir.Type {
@@ -8769,13 +9061,27 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 				}
 			}
 			elemLLVM := g.llvmType(elemT)
+			if isStringPrimType(curT) {
+				idxVal, err := g.evalOperand(ip.Index, mir.TInt)
+				if err != nil {
+					return "", err
+				}
+				sym := mirRtStringSymbol("CharAt")
+				g.declareRuntime(sym, mirRuntimeDeclareLine("i32", sym, "ptr, i64"))
+				next := g.fresh()
+				g.fnBuf.WriteString(mirCallValueLine(next, "i32", sym, mirArgListPtrI64(curReg, idxVal)))
+				curReg = next
+				curLLVM = elemLLVM
+				curT = elemT
+				continue
+			}
 			// Map IndexProj: delegate to the shared runtime helper so
 			// `m[k]` and `m.get(k)` share a single ABI. The helper
 			// allocates a fresh out-slot, calls the runtime, loads
 			// the result, and returns the SSA register holding the
 			// loaded value.
 			if isMapPtrType(curT) {
-				keyT, _ := mapKeyValueTypes(curT)
+				keyT, _ := g.mapKeyValueTypes(curT)
 				if keyT == nil {
 					return "", unsupported("mir-mvp", "map IndexProj without key type")
 				}
@@ -9031,6 +9337,9 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 	if (op == mir.BinEq || op == mir.BinNeq) && isHeapEqualityType(argT) {
 		return g.emitHeapEquality(op, left, right)
 	}
+	if (op == mir.BinEq || op == mir.BinNeq) && g.isEnumValueType(argT) {
+		return g.emitEnumDiscriminantEquality(op, left, right, argT)
+	}
 	if isStringOrderingBinOp(op) && isStringPrimType(argT) {
 		return g.emitStringOrdering(op, left, right)
 	}
@@ -9049,6 +9358,30 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 	tmp := g.fresh()
 	g.fnBuf.WriteString(mirBinaryOpLine(tmp, opcode, ty, left, right))
 	return tmp, nil
+}
+
+func (g *mirGen) isEnumValueType(t mir.Type) bool {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
+		return false
+	}
+	return g.mod.Layouts.Enums[nt.Name] != nil
+}
+
+func (g *mirGen) emitEnumDiscriminantEquality(op mir.BinaryOp, left, right string, argT mir.Type) (string, error) {
+	argLLVM := g.llvmType(argT)
+	leftDisc := g.fresh()
+	rightDisc := g.fresh()
+	g.fnBuf.WriteString(mirExtractValueLine(leftDisc, argLLVM, left, "0"))
+	g.fnBuf.WriteString(mirExtractValueLine(rightDisc, argLLVM, right, "0"))
+	eq := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqI64Line(eq, leftDisc, rightDisc))
+	if op == mir.BinEq {
+		return eq, nil
+	}
+	neq := g.fresh()
+	g.fnBuf.WriteString(mirXorI1NegLine(neq, eq))
+	return neq, nil
 }
 
 // isHeapEqualityType reports whether MIR `==` / `!=` on values of type t
@@ -9282,6 +9615,9 @@ func (g *mirGen) llvmType(t mir.Type) string {
 		if x.Name == "Error" {
 			return "ptr"
 		}
+		if x.Name == "Never" {
+			return "void"
+		}
 		// Builtin collection + closure env: flow through the runtime
 		// as opaque pointers. The name table lives in the Osty port
 		// (`mirLlvmTypeForOpaqueNamed`) so callers that already have
@@ -9296,21 +9632,27 @@ func (g *mirGen) llvmType(t mir.Type) string {
 		if x.Name == "Rng" || x.Name == "Gen" {
 			return "ptr"
 		}
+		if isStdlibModuleMarkerTypeName(x.Name) {
+			return "ptr"
+		}
 		// Concurrency runtime types fall into the same ptr-handle
 		// bucket; Osty helper handles both via name match.
 		if s := mirLlvmTypeForOpaqueNamed(x.Name); s != "" {
 			return s
 		}
-		if strings.Contains(x.QualifiedName(), ".") {
-			return "ptr"
-		}
 		// User-declared struct or enum — register the enum in the
 		// layout pool on first use and emit by name.
 		if g.mod != nil && g.mod.Layouts != nil {
+			if sl := g.mod.Layouts.Structs[x.Name]; sl != nil && isOpaqueBuiltinStructLayout(sl) {
+				return "ptr"
+			}
 			if _, ok := g.mod.Layouts.Structs[x.Name]; ok {
 				return "%" + x.Name
 			}
-			if _, ok := g.mod.Layouts.Enums[x.Name]; ok {
+			if en := g.mod.Layouts.Enums[x.Name]; en != nil {
+				if builtinLLVM := g.builtinEnumLayoutLLVMType(en); builtinLLVM != "" {
+					return builtinLLVM
+				}
 				g.registerEnumLayout(x.Name)
 				return "%" + x.Name
 			}
@@ -9340,6 +9682,9 @@ func (g *mirGen) llvmType(t mir.Type) string {
 		case "Result":
 			return "%" + g.resultTypeName(x)
 		}
+		if strings.Contains(x.QualifiedName(), ".") {
+			return "ptr"
+		}
 		return "%" + x.Name
 	case *ir.OptionalType:
 		return "%" + g.optionalTypeName(x)
@@ -9353,6 +9698,21 @@ func (g *mirGen) llvmType(t mir.Type) string {
 	// Fallback: ptr works for anything we end up treating as opaque
 	// heap data.
 	return "ptr"
+}
+
+func (g *mirGen) builtinEnumLayoutLLVMType(en *mir.EnumLayout) string {
+	if en == nil || en.BuiltinSource == "" {
+		return ""
+	}
+	nt := &ir.NamedType{Name: en.BuiltinSource, Args: en.BuiltinSourceArgs, Builtin: true}
+	switch en.BuiltinSource {
+	case "Option", "Maybe":
+		return "%" + g.optionTypeName(nt)
+	case "Result":
+		return "%" + g.resultTypeName(nt)
+	default:
+		return ""
+	}
 }
 
 func (g *mirGen) isStdTermSizeType(t *ir.NamedType) bool {
@@ -9577,6 +9937,14 @@ func isUnitType(t mir.Type) bool {
 func isStdMathMarkerType(t mir.Type) bool {
 	nt, ok := t.(*ir.NamedType)
 	return ok && nt.QualifiedName() == "math.math"
+}
+
+func isStdlibModuleMarkerTypeName(name string) bool {
+	switch name {
+	case "bytes", "char", "email", "encoding", "error", "image", "smtp", "strings", "zip":
+		return true
+	}
+	return false
 }
 
 func stdMathConstLiteral(name string) (string, bool) {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1176,8 +1176,10 @@ func TestGenerateFromMIRResultMethodsLower(t *testing.T) {
 		"define i1 @resultIsErr(%Result.i64.string %arg0)",
 		"define i64 @resultUnwrap(%Result.i64.string %arg0)",
 		"define i64 @resultUnwrapOr(%Result.i64.string %arg0)",
-		"declare void @osty_rt_result_unwrap_err() noreturn",
-		"call void @osty_rt_result_unwrap_err()",
+		"declare void @osty_rt_io_write(ptr, i1, i1)",
+		"declare void @exit(i32)",
+		"called unwrap on Err",
+		"call void @exit(i32 1)",
 		"icmp eq i64",
 		"phi i64",
 	} {

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -281,11 +281,7 @@ func (g *mirGen) emitRecordFieldLoad(raw, recordLLVM, fieldLLVM string, idx int)
 }
 
 func (g *mirGen) resultSubtypes(t mir.Type) (mir.Type, mir.Type, bool) {
-	info, ok := testingResultType(t)
-	if !ok {
-		return nil, nil, false
-	}
-	return info.ok, info.err, true
+	return g.resultPayloadTypes(t)
 }
 
 func (g *mirGen) emitStdEnvCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
@@ -1328,7 +1324,20 @@ func stringStaticIntrinsic(name string) mir.IntrinsicKind {
 
 func (g *mirGen) emitStdErrorCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	method := strings.TrimPrefix(fnRef.Symbol, "Error__")
+	method = strings.TrimPrefix(method, "std.error.")
 	switch method {
+	case "new":
+		if len(c.Args) != 1 {
+			return true, unsupported("mir-mvp", "std.error.new requires one positional String argument")
+		}
+		msg, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+		if err != nil {
+			return true, err
+		}
+		if msg.typ != "ptr" {
+			return true, unsupported("mir-mvp", "std.error.new argument must lower to ptr")
+		}
+		return true, g.storeCallValue(c, "ptr", msg.val)
 	case "message":
 		if len(c.Args) != 1 {
 			return true, unsupported("mir-mvp", "Error.message requires receiver")

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -159,7 +159,12 @@ func (l *lowerer) collectSignatures() {
 
 func (l *lowerer) buildLayouts() {
 	for name, s := range l.structs {
-		sl := &StructLayout{Name: name, Mangled: name}
+		sl := &StructLayout{
+			Name:              name,
+			Mangled:           name,
+			BuiltinSource:     s.BuiltinSource,
+			BuiltinSourceArgs: cloneTypeList(s.BuiltinSourceArgs),
+		}
 		for i, f := range s.Fields {
 			sl.Fields = append(sl.Fields, FieldLayout{
 				Index: i,
@@ -171,9 +176,11 @@ func (l *lowerer) buildLayouts() {
 	}
 	for name, e := range l.enums {
 		el := &EnumLayout{
-			Name:         name,
-			Mangled:      name,
-			Discriminant: TInt,
+			Name:              name,
+			Mangled:           name,
+			BuiltinSource:     e.BuiltinSource,
+			BuiltinSourceArgs: cloneTypeList(e.BuiltinSourceArgs),
+			Discriminant:      TInt,
 		}
 		for i, v := range e.Variants {
 			vl := VariantLayout{Index: i, Name: v.Name}
@@ -189,6 +196,17 @@ func (l *lowerer) buildLayouts() {
 		l.out.Layouts.Enums[name] = el
 	}
 	l.buildInterfaceLayouts()
+}
+
+func cloneTypeList(types []Type) []Type {
+	if len(types) == 0 {
+		return nil
+	}
+	out := make([]Type, len(types))
+	for i, t := range types {
+		out[i] = ir.CloneType(t)
+	}
+	return out
 }
 
 // buildInterfaceLayouts populates Layouts.Interfaces from every
@@ -1441,11 +1459,11 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		bs.lowerForInChannel(f, iterT)
 		return
 	}
-	if !isListType(iterT) {
+	if !bs.l.isListType(iterT) {
 		bs.l.noteIssue("for-in over non-List/Channel iterable is not lowered to MIR yet")
 		return
 	}
-	elemT := listElementType(iterT)
+	elemT := bs.l.listElementType(iterT)
 	if elemT == nil || isPoisonType(elemT) {
 		// List<?> with a poisoned element type would propagate ErrType
 		// to the `_elem` copy and surface as `unsupported local type
@@ -1660,13 +1678,22 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 		_ = arm
 	}
 
+	// Bare enum cases can survive parsing as IdentPat (`Plain -> ...`).
+	// Against an enum scrutinee those names are variant tests, not catch-all
+	// bindings; rebuild the decision tree with normalized patterns so the
+	// MIR path does not collapse to arm 0.
+	decisionArms, normalizedBareVariants := bs.normalizeBareVariantMatchArms(scrutT, arms)
+	if normalizedBareVariants {
+		tree = ir.CompileDecisionTree(scrutT, decisionArms)
+	}
+
 	// Monomorph clones drop Tree (cloneMatchStmt / cloneMatchExpr leave
 	// it nil) — recompile on demand so the post-mono MIR path still sees
 	// a specialised decision tree instead of the goto-armBlocks[0]
 	// fallback, which silently collapses every match on Result / enum
 	// payload bindings to "always take arm 0".
-	if tree == nil && scrutinee.Type() != nil {
-		tree = ir.CompileDecisionTree(scrutinee.Type(), arms)
+	if tree == nil && scrutT != nil && !isPoisonType(scrutT) {
+		tree = ir.CompileDecisionTree(scrutT, decisionArms)
 	}
 
 	// If we have a decision tree, use it.
@@ -1777,6 +1804,80 @@ func (mc *matchContext) lowerTree(node ir.DecisionNode) {
 	default:
 		bs.l.noteIssue("decision tree: unsupported node %T", node)
 		bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+	}
+}
+
+func (bs *bodyState) normalizeBareVariantMatchArms(scrutT Type, arms []*ir.MatchArm) ([]*ir.MatchArm, bool) {
+	if scrutT == nil || isPoisonType(scrutT) || len(arms) == 0 {
+		return arms, false
+	}
+	var out []*ir.MatchArm
+	changedAny := false
+	for i, arm := range arms {
+		if arm == nil {
+			continue
+		}
+		pat, changed := bs.normalizeBareVariantPattern(scrutT, arm.Pattern)
+		if !changed {
+			continue
+		}
+		if out == nil {
+			out = make([]*ir.MatchArm, len(arms))
+			copy(out, arms)
+		}
+		clone := *arm
+		clone.Pattern = pat
+		out[i] = &clone
+		changedAny = true
+	}
+	if !changedAny {
+		return arms, false
+	}
+	return out, true
+}
+
+func (bs *bodyState) normalizeBareVariantPattern(scrutT Type, pat ir.Pattern) (ir.Pattern, bool) {
+	switch p := pat.(type) {
+	case *ir.IdentPat:
+		if !bs.l.identPatternIsEnumVariant(scrutT, p.Name) {
+			return pat, false
+		}
+		return &ir.VariantPat{
+			Enum:    typeNameOf(scrutT),
+			Variant: p.Name,
+			SpanV:   p.SpanV,
+		}, true
+	case *ir.BindingPat:
+		inner, changed := bs.normalizeBareVariantPattern(scrutT, p.Pattern)
+		if !changed {
+			return pat, false
+		}
+		clone := *p
+		clone.Pattern = inner
+		return &clone, true
+	case *ir.OrPat:
+		var out []ir.Pattern
+		changedAny := false
+		for i, alt := range p.Alts {
+			normalized, changed := bs.normalizeBareVariantPattern(scrutT, alt)
+			if !changed {
+				continue
+			}
+			if out == nil {
+				out = make([]ir.Pattern, len(p.Alts))
+				copy(out, p.Alts)
+			}
+			out[i] = normalized
+			changedAny = true
+		}
+		if !changedAny {
+			return pat, false
+		}
+		clone := *p
+		clone.Alts = out
+		return &clone, true
+	default:
+		return pat, false
 	}
 }
 
@@ -2132,10 +2233,28 @@ func (bs *bodyState) lowerExprAsOperandHint(e ir.Expr, hint Type) Operand {
 			}
 		}
 	}
+	if c, ok := e.(*ir.CallExpr); ok && c != nil {
+		if id, ok := c.Callee.(*ir.Ident); ok && id != nil {
+			if _, _, ok := builtinVariantCallShape(hint, id.Name, len(c.Args)); ok {
+				tmp := bs.freshTemp(hint, exprSpan(e))
+				bs.lowerExprInto(e, tmp, hint)
+				return &CopyOp{Place: Place{Local: tmp}, T: hint}
+			}
+		}
+	}
 	if !shouldPreferHintType(e.Type(), hint) {
 		return bs.lowerExprAsOperand(e)
 	}
-	return bs.lowerExprAsOperand(e)
+	switch e.(type) {
+	case *ir.ListLit, *ir.StructLit, *ir.TupleLit, *ir.VariantLit:
+	default:
+		return bs.lowerExprAsOperand(e)
+	}
+	tmp := bs.freshTemp(hint, exprSpan(e))
+	if rv := bs.lowerExprToRValue(e, hint); rv != nil {
+		bs.emit(&AssignInstr{Dest: Place{Local: tmp}, Src: rv, SpanV: exprSpan(e)})
+	}
+	return &CopyOp{Place: Place{Local: tmp}, T: hint}
 }
 
 // recoveredTypeOf returns e.Type() when it's populated, otherwise
@@ -2151,7 +2270,7 @@ func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 		}
 	}
 	switch e.(type) {
-	case *ir.FieldExpr, *ir.IndexExpr, *ir.TupleAccess:
+	case *ir.FieldExpr, *ir.IndexExpr, *ir.TupleAccess, *ir.MethodCall:
 		if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) && !irHasPoisonedTypeArg(rt) {
 			return rt
 		}
@@ -2168,11 +2287,6 @@ func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 
 func (bs *bodyState) recoveredIdentStorageType(id *ir.Ident) ir.Type {
 	if id == nil {
-		return nil
-	}
-	switch id.Kind {
-	case ir.IdentLocal, ir.IdentParam:
-	default:
 		return nil
 	}
 	local, ok := bs.lookup(id.Name)
@@ -2271,7 +2385,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 			}
 		}
 		recvT := bs.recoveredTypeOf(x.Receiver)
-		if rt := builtinMethodReturnType(recvT, x.Name); rt != nil {
+		if rt := bs.recoveredMethodReturnType(recvT, x.Name); rt != nil {
 			return rt
 		}
 		if isPoisonType(recvT) {
@@ -2458,6 +2572,10 @@ func builtinMethodReturnType(recvT ir.Type, method string) ir.Type {
 			}
 		case ir.PrimChar:
 			switch method {
+			case "isDigit", "isAlpha", "isAlphanumeric", "isWhitespace", "isUpper", "isLower":
+				return ir.TBool
+			case "toUpper", "toLower":
+				return ir.TChar
 			case "toInt":
 				return ir.TInt
 			case "toByte":
@@ -2471,6 +2589,26 @@ func builtinMethodReturnType(recvT ir.Type, method string) ir.Type {
 	// last) rarely hit this path because the checker tracks them.
 	if nt, ok := recvT.(*ir.NamedType); ok && nt.Builtin {
 		switch nt.Name {
+		case "Option", "Maybe":
+			if len(nt.Args) >= 1 {
+				switch method {
+				case "unwrap", "unwrapOr":
+					return nt.Args[0]
+				case "isSome", "isNone":
+					return ir.TBool
+				}
+			}
+		case "Result":
+			if len(nt.Args) >= 2 {
+				switch method {
+				case "unwrap", "unwrapOr":
+					return nt.Args[0]
+				case "unwrapErr":
+					return nt.Args[1]
+				case "isOk", "isErr":
+					return ir.TBool
+				}
+			}
 		case "List", "Map", "Set":
 			switch method {
 			case "len":
@@ -2478,6 +2616,69 @@ func builtinMethodReturnType(recvT ir.Type, method string) ir.Type {
 			case "isEmpty":
 				return ir.TBool
 			}
+		}
+	}
+	return nil
+}
+
+func (bs *bodyState) recoveredMethodReturnType(recvT ir.Type, method string) ir.Type {
+	if rt := builtinMethodReturnType(recvT, method); rt != nil {
+		return rt
+	}
+	if _, ok := recvT.(*ir.OptionalType); ok {
+		switch method {
+		case "isSome", "isNone":
+			return ir.TBool
+		case "unwrap", "unwrapOr":
+			return optionInnerType(recvT)
+		}
+	}
+	switch bs.l.stdlibReceiverName(recvT) {
+	case "Map":
+		keyT := bs.l.mapKeyType(recvT)
+		valueT := bs.l.indexElementType(recvT)
+		switch method {
+		case "get":
+			if !isPoisonType(valueT) {
+				return &ir.OptionalType{Inner: valueT}
+			}
+		case "getOr":
+			if !isPoisonType(valueT) {
+				return valueT
+			}
+		case "keys":
+			if !isPoisonType(keyT) {
+				return &ir.NamedType{Name: "List", Args: []ir.Type{keyT}, Builtin: true}
+			}
+		case "values":
+			if !isPoisonType(valueT) {
+				return &ir.NamedType{Name: "List", Args: []ir.Type{valueT}, Builtin: true}
+			}
+		case "len":
+			return ir.TInt
+		case "isEmpty", "contains", "containsKey":
+			return ir.TBool
+		}
+	case "List":
+		elemT := bs.l.listElementType(recvT)
+		switch method {
+		case "first", "last", "pop", "get":
+			if !isPoisonType(elemT) {
+				return &ir.OptionalType{Inner: elemT}
+			}
+		case "sorted", "reversed", "slice":
+			return recvT
+		case "len":
+			return ir.TInt
+		case "isEmpty", "contains":
+			return ir.TBool
+		}
+	case "Set":
+		switch method {
+		case "len":
+			return ir.TInt
+		case "isEmpty", "contains":
+			return ir.TBool
 		}
 	}
 	return nil
@@ -2547,6 +2748,17 @@ func pathQualifier(use *ir.UseDecl) string {
 		return ""
 	}
 	return strings.Join(use.Path, ".")
+}
+
+func isStdlibErrorUse(use *ir.UseDecl) bool {
+	if use == nil {
+		return false
+	}
+	switch qualifierOf(use) {
+	case "error", "std.error":
+		return true
+	}
+	return pathQualifier(use) == "std.error"
 }
 
 // stdlibFreeFnReturnType reports the declared return type for the
@@ -2750,7 +2962,7 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 				if rv, handled := bs.lowerStringSliceRValue(x, rng); handled {
 					return rv
 				}
-			case isListType(baseT):
+			case bs.l.isListType(baseT):
 				if rv, handled := bs.lowerListSliceRValue(x, rng); handled {
 					return rv
 				}
@@ -2773,13 +2985,14 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		}
 		return &AggregateRV{Kind: AggTuple, Fields: fields, T: x.T}
 	case *ir.ListLit:
+		lt := hint
+		if lt == nil || isPoisonType(lt) {
+			lt = x.Type()
+		}
+		elemT := bs.l.listElementType(lt)
 		fields := make([]Operand, len(x.Elems))
 		for i, e := range x.Elems {
-			fields[i] = bs.lowerExprAsOperand(e)
-		}
-		lt := hint
-		if lt == nil {
-			lt = x.Type()
+			fields[i] = bs.lowerExprAsOperandHint(e, elemT)
 		}
 		return &AggregateRV{Kind: AggList, Fields: fields, T: lt}
 	case *ir.StructLit:
@@ -2834,7 +3047,8 @@ func (bs *bodyState) lowerExprToPlace(e ir.Expr) (Place, bool) {
 		// form instead (lowerExprAsRValue catches the string-slice
 		// pattern and emits the intrinsic directly).
 		if _, ok := x.Index.(*ir.RangeLit); ok {
-			if isStringReceiverType(x.X.Type()) || isListType(x.X.Type()) {
+			baseT := bs.recoveredTypeOf(x.X)
+			if isStringReceiverType(baseT) || bs.l.isListType(baseT) {
 				return Place{}, false
 			}
 		}
@@ -3042,7 +3256,7 @@ func (bs *bodyState) recoverOperandStorageType(op Operand) Type {
 		case *VariantProj:
 			cur = variantLookupPayloadType(bs.l, cur, p.Name, p.FieldIdx)
 		case *IndexProj:
-			cur = indexElementType(cur)
+			cur = bs.l.indexElementType(cur)
 		case *DerefProj:
 			cur = p.Type
 		}
@@ -3568,6 +3782,20 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 			return
 		}
+		if module, name, ok := loweredStdlibFreeSymbol(id.Name); ok {
+			switch module {
+			case "bytes":
+				if kind := stdlibBytesFreeFnToIntrinsic("std.bytes", name); kind != IntrinsicInvalid {
+					bs.emitBytesFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+					return
+				}
+			case "strings":
+				if kind := stdlibStringFreeFnToIntrinsic("std.strings", name); kind != IntrinsicInvalid {
+					bs.emitStringFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+					return
+				}
+			}
+		}
 		if kind := bs.builtinFreeCallIntrinsic(id.Name, c.Args); kind != IntrinsicInvalid {
 			bs.emitBuiltinFreeCallIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 			return
@@ -3576,7 +3804,7 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 	if fx, ok := c.Callee.(*ir.FieldExpr); ok {
 		if id, ok := fx.X.(*ir.Ident); ok && id != nil {
 			switch id.Name {
-			case "Bytes":
+			case "Bytes", "bytes":
 				if kind := stdlibBytesFreeFnToIntrinsic("bytes", fx.Name); kind != IntrinsicInvalid {
 					bs.emitBytesFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 					return
@@ -3586,6 +3814,19 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 					bs.emitStringFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 					return
 				}
+			case "Error", "error":
+				args := bs.orderArgs(c.Args, nil)
+				destPtr := dest
+				if destPtr != nil && isUnit(destT) {
+					destPtr = nil
+				}
+				bs.emit(&CallInstr{
+					Dest:   destPtr,
+					Callee: &FnRef{Symbol: "std.error." + fx.Name, Type: c.T},
+					Args:   args,
+					SpanV:  c.SpanV,
+				})
+				return
 			}
 		}
 		if use := bs.l.useAliasFor(fx.X); use != nil {
@@ -3595,6 +3836,20 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			}
 			if kind := runtimeIntrinsicForFree(qualifierOf(use), fx.Name); kind != IntrinsicInvalid {
 				bs.emitRuntimeIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+				return
+			}
+			if isStdlibErrorUse(use) {
+				args := bs.orderArgs(c.Args, nil)
+				destPtr := dest
+				if destPtr != nil && isUnit(destT) {
+					destPtr = nil
+				}
+				bs.emit(&CallInstr{
+					Dest:   destPtr,
+					Callee: &FnRef{Symbol: "std.error." + fx.Name, Type: c.T},
+					Args:   args,
+					SpanV:  c.SpanV,
+				})
 				return
 			}
 			// Route `std.strings.fn(x, ...)` to the equivalent
@@ -4005,6 +4260,20 @@ func (bs *bodyState) orderArgs(args []ir.Arg, sig *fnSignature) []Operand {
 
 func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Type) {
 	recvType := bs.recoveredTypeOf(mc.Receiver)
+	if id, ok := mc.Receiver.(*ir.Ident); ok && id != nil {
+		switch id.Name {
+		case "bytes", "Bytes":
+			if kind := stdlibBytesFreeFnToIntrinsic("bytes", mc.Name); kind != IntrinsicInvalid {
+				bs.emitBytesFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+				return
+			}
+		case "strings", "String":
+			if kind := stdlibStringFreeFnToIntrinsic("strings", mc.Name); kind != IntrinsicInvalid {
+				bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+				return
+			}
+		}
+	}
 	// Package/FFI-qualified calls land here when HIR lowered `pkg.fn()`
 	// into MethodCall{Receiver: Ident(pkg), Name: fn}. The receiver is
 	// a use alias, not a value — fast-path to a concurrency intrinsic
@@ -4117,7 +4386,7 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	// Option / Result methods. Matches the concurrency path above but
 	// for the primitive types whose method bodies in stdlib just
 	// return default values — the runtime handles the real work.
-	if kind := stdlibIntrinsicForMethod(recvType, mc.Name); kind != IntrinsicInvalid {
+	if kind := bs.l.stdlibIntrinsicForMethod(recvType, mc.Name); kind != IntrinsicInvalid {
 		recv := bs.lowerExprAsOperand(mc.Receiver)
 		args := []Operand{recv}
 		for _, a := range mc.Args {
@@ -4505,7 +4774,7 @@ func concurrencyIntrinsicForMethod(receiverType Type, name string) IntrinsicKind
 // The recogniser runs *after* the concurrency recogniser in the
 // method-call path so concurrency receivers (Channel, Handle, Group,
 // Select) never accidentally shadow the primitive names.
-func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
+func (l *lowerer) stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 	// Option<T> has two surface forms — NamedType{"Option"} and
 	// OptionalType (surface `T?`) — handle OptionalType first so the
 	// ordinary typeNameOf branch below doesn't need a special case.
@@ -4556,7 +4825,7 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 		}
 		return IntrinsicInvalid
 	}
-	switch typeNameOf(receiverType) {
+	switch l.stdlibReceiverName(receiverType) {
 	case "List":
 		switch name {
 		case "push":
@@ -4662,6 +4931,77 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 		}
 	}
 	return IntrinsicInvalid
+}
+
+func (l *lowerer) stdlibReceiverName(t Type) string {
+	if nt, ok := t.(*ir.NamedType); ok && l != nil {
+		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource != "" {
+			return st.BuiltinSource
+		}
+		if en := l.enums[nt.Name]; en != nil && en.BuiltinSource != "" {
+			return en.BuiltinSource
+		}
+	}
+	return typeNameOf(t)
+}
+
+func (l *lowerer) isListType(t ir.Type) bool {
+	if isListType(t) {
+		return true
+	}
+	if nt, ok := t.(*ir.NamedType); ok && l != nil {
+		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "List" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *lowerer) listElementType(t ir.Type) Type {
+	if elemT := listElementType(t); !isPoisonType(elemT) {
+		return elemT
+	}
+	if nt, ok := t.(*ir.NamedType); ok && l != nil {
+		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "List" && len(st.BuiltinSourceArgs) >= 1 {
+			return st.BuiltinSourceArgs[0]
+		}
+	}
+	return ir.ErrTypeVal
+}
+
+func (l *lowerer) indexElementType(base Type) Type {
+	if elemT := indexElementType(base); !isPoisonType(elemT) {
+		return elemT
+	}
+	if nt, ok := base.(*ir.NamedType); ok && l != nil {
+		if st := l.structs[nt.Name]; st != nil {
+			switch st.BuiltinSource {
+			case "List":
+				if len(st.BuiltinSourceArgs) >= 1 {
+					return st.BuiltinSourceArgs[0]
+				}
+			case "Map":
+				if len(st.BuiltinSourceArgs) >= 2 {
+					return st.BuiltinSourceArgs[1]
+				}
+			}
+		}
+	}
+	return ir.ErrTypeVal
+}
+
+func (l *lowerer) mapKeyType(base Type) Type {
+	if nt, ok := base.(*ir.NamedType); ok {
+		if nt.Name == "Map" && len(nt.Args) >= 1 {
+			return nt.Args[0]
+		}
+		if l != nil {
+			if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "Map" && len(st.BuiltinSourceArgs) >= 1 {
+				return st.BuiltinSourceArgs[0]
+			}
+		}
+	}
+	return ir.ErrTypeVal
 }
 
 // isVoidStdlibIntrinsic reports whether a stdlib intrinsic produces
@@ -4814,6 +5154,22 @@ func stdlibBytesFreeFnToIntrinsic(qualifier, name string) IntrinsicKind {
 		return IntrinsicBytesToString
 	}
 	return bytesIntrinsicForMethod(name)
+}
+
+func loweredStdlibFreeSymbol(symbol string) (module, name string, ok bool) {
+	const prefix = "osty_std_"
+	if !strings.HasPrefix(symbol, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(symbol, prefix)
+	parts := strings.SplitN(rest, "__", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	if strings.Contains(parts[1], "__") {
+		return "", "", false
+	}
+	return strings.ReplaceAll(parts[0], "_", "."), parts[1], true
 }
 
 // stdlibStringFreeFnToIntrinsic maps `std.strings.Y` free-function
@@ -5453,6 +5809,56 @@ func (l *lowerer) variantIndexInType(t ir.Type, name string) (int, bool) {
 	return 0, false
 }
 
+func (l *lowerer) identPatternIsEnumVariant(t ir.Type, name string) bool {
+	if name == "" || !startsUpperASCII(name) {
+		return false
+	}
+	if builtinEnumHasVariant(t, name) {
+		return true
+	}
+	if _, ok := l.variantIndexInType(t, name); ok {
+		return true
+	}
+	typeName := typeNameOf(t)
+	if typeName == "" || l.out == nil || l.out.Layouts == nil {
+		return false
+	}
+	if el := l.out.Layouts.Enums[typeName]; el != nil {
+		for _, v := range el.Variants {
+			if v.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func startsUpperASCII(name string) bool {
+	if name == "" {
+		return false
+	}
+	return name[0] >= 'A' && name[0] <= 'Z'
+}
+
+func builtinEnumHasVariant(t ir.Type, name string) bool {
+	typeName := typeNameOf(t)
+	switch typeName {
+	case "Option":
+		return name == "None" || name == "Some"
+	case "Result":
+		return name == "Err" || name == "Ok"
+	}
+	if nt, ok := t.(*ir.NamedType); ok && nt != nil && nt.Builtin {
+		switch nt.Name {
+		case "Option":
+			return name == "None" || name == "Some"
+		case "Result":
+			return name == "Err" || name == "Ok"
+		}
+	}
+	return false
+}
+
 func (l *lowerer) variantIndexByName(t ir.Type, name string) int {
 	// Well-known builtins first.
 	switch name {
@@ -5822,12 +6228,12 @@ func (bs *bodyState) indexExprType(x *ir.IndexExpr) Type {
 		if isStringReceiverType(baseT) {
 			return ir.TString
 		}
-		if isListType(baseT) {
+		if bs.l.isListType(baseT) {
 			return baseT
 		}
 	}
 	for _, baseT := range []Type{bs.recoveredTypeOf(x.X), bs.recoverOperandType(x.X)} {
-		if elemT := indexElementType(baseT); !isPoisonType(elemT) {
+		if elemT := bs.l.indexElementType(baseT); !isPoisonType(elemT) {
 			return elemT
 		}
 	}

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -1394,11 +1394,13 @@ func NewLayoutTable() *LayoutTable {
 
 // StructLayout describes a single (possibly monomorphic) struct.
 type StructLayout struct {
-	Name    string
-	Mangled string
-	Fields  []FieldLayout
-	Size    int // 0 when the backend computes it
-	Align   int // 0 when the backend computes it
+	Name              string
+	Mangled           string
+	Fields            []FieldLayout
+	BuiltinSource     string
+	BuiltinSourceArgs []Type
+	Size              int // 0 when the backend computes it
+	Align             int // 0 when the backend computes it
 }
 
 // FieldLayout is one entry inside a StructLayout or VariantLayout.
@@ -1410,10 +1412,12 @@ type FieldLayout struct {
 
 // EnumLayout describes a single (possibly monomorphic) enum.
 type EnumLayout struct {
-	Name         string
-	Mangled      string
-	Discriminant Type
-	Variants     []VariantLayout
+	Name              string
+	Mangled           string
+	BuiltinSource     string
+	BuiltinSourceArgs []Type
+	Discriminant      Type
+	Variants          []VariantLayout
 }
 
 // VariantLayout is one enum arm.

--- a/internal/stdlib/modules/email.osty
+++ b/internal/stdlib/modules/email.osty
@@ -325,7 +325,8 @@ fn quoteDisplayName(name: String) -> String {
         return ""
     }
     if displayNameNeedsQuotes(clean) {
-        return "{quote}{strings.replaceAll(clean, \"\\\"\", \"\\\\\\\"\")}{quote}"
+        let escaped = strings.replaceAll(clean, "\"", "\\\"")
+        return "{quote}{escaped}{quote}"
     }
     clean
 }

--- a/internal/stdlib/modules/smtp.osty
+++ b/internal/stdlib/modules/smtp.osty
@@ -366,7 +366,8 @@ fn plainPayload(username: String, password: String) -> String {
     appendStringBytes(raw, username)
     raw.push(0.toByte())
     appendStringBytes(raw, password)
-    encoding.base64.encode(bytes.from(raw))
+    let data = bytes.from(raw)
+    encoding.base64.encode(data)
 }
 
 fn appendStringBytes(out: List<Byte>, text: String) {


### PR DESCRIPTION
## Summary
- Expanded stdlib body injection so transitive stdlib calls and value-path methods are pulled into MIR lowering instead of falling back to tiny one-off shims.
- Added MIR/LLVM coverage for injected ZIP, Image, SMTP, bytes, enum match, optional list literals, char methods, and builtin enum layout recovery.
- Kept unsafe generic stdlib helpers trimmed while preserving Map helper specialization.

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultBigGaps|TestLLVMBackendBinaryRunsStd(ZipStoredArchive|ImageMetadata|SmtpPlanning)|TestLLVMBackendBinaryRuns(InjectedStdBytesFrom|BareEnumIdentMatch|CharMethodInterpolation)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestInjectedMapTypeMonomorphizes|TestLLVMBackendBinaryRunsStd(ZipStoredArchive|ImageMetadata|SmtpPlanning)' -v`
- `go test -count=1 -vet=off ./internal/backend ./internal/llvmgen ./cmd/osty` (backend passed; llvmgen/cmd were rerun separately after the focused fix)
- `go test -count=1 -vet=off ./internal/llvmgen`
- `go test -count=1 -vet=off ./cmd/osty`