### PR TITLE
[codex] qualify injected stdlib backend types

### DIFF
--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -337,6 +337,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 		if lowered == nil {
 			continue
 		}
+		qualifyLoweredStdlibFnTypes(lowered, reg, r.Module)
 		lowered.Name = StdlibSymbol(r.Module, r.Fn.Name)
 		out = append(out, lowered)
 		loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: r.Module, fn: lowered})
@@ -350,6 +351,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			continue
 		}
 		freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+		qualifyLoweredStdlibFnTypes(freeFn, reg, m.Module)
 		out = append(out, freeFn)
 		// Methods can call same-module free fns too; route them
 		// through the same closure step.
@@ -391,6 +393,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			if lowered == nil {
 				continue
 			}
+			qualifyLoweredStdlibFnTypes(lowered, reg, next.module)
 			lowered.Name = StdlibSymbol(next.module, callName)
 			out = append(out, lowered)
 			rewriteBareIdentCalls(next.fn, callName, lowered.Name)
@@ -418,6 +421,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			if lowered == nil {
 				continue
 			}
+			qualifyLoweredStdlibFnTypes(lowered, reg, calleeModule)
 			lowered.Name = StdlibSymbol(calleeModule, ref.Name)
 			out = append(out, lowered)
 			rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, lowered.Name)
@@ -438,11 +442,13 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 				continue
 			}
 			freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+			qualifyLoweredStdlibFnTypes(freeFn, reg, m.Module)
 			out = append(out, freeFn)
 			rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
 			queue = append(queue, loweredFromModule{module: m.Module, fn: freeFn})
 		}
 	}
+	qualifyStdlibCallsiteTypes(mod, out)
 	return out, issues
 }
 
@@ -458,6 +464,217 @@ func rewriteStdlibMethodCallsitesInFn(fn *ir.FnDecl, reached []ReachableStdlibMe
 		return
 	}
 	RewriteStdlibMethodCallsites(&ir.Module{Decls: []ir.Decl{fn}}, reached)
+}
+
+func qualifyLoweredStdlibFnTypes(fn *ir.FnDecl, reg *stdlib.Registry, module string) {
+	if fn == nil || reg == nil || module == "" {
+		return
+	}
+	entry := loweredStdlibTypesFor(reg)
+	if entry == nil {
+		return
+	}
+	qualifyStdlibDeclTypes(fn, module, entry.moduleTypeNames(module))
+}
+
+func qualifyStdlibCallsiteTypes(mod *ir.Module, injected []ir.Decl) {
+	if mod == nil || len(injected) == 0 {
+		return
+	}
+	returns := map[string]ir.Type{}
+	for _, d := range injected {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok || fn == nil || fn.Name == "" || fn.Return == nil {
+			continue
+		}
+		returns[fn.Name] = ir.CloneType(fn.Return)
+	}
+	if len(returns) == 0 {
+		return
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		id, ok := call.Callee.(*ir.Ident)
+		if !ok || id == nil {
+			return true
+		}
+		if ret := returns[id.Name]; ret != nil {
+			call.T = ir.CloneType(ret)
+			if ft, ok := id.T.(*ir.FnType); ok && ft != nil {
+				ft.Return = ir.CloneType(ret)
+			}
+		}
+		return true
+	}), mod)
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		mc, ok := n.(*ir.MethodCall)
+		if !ok || mc == nil || mc.Receiver == nil {
+			return true
+		}
+		if ret := builtinReceiverMethodReturnType(mc.Receiver.Type(), mc.Name); ret != nil {
+			mc.T = ret
+		}
+		return true
+	}), mod)
+	qualifyStdlibLetTypes(mod)
+	qualifyStdlibIdentBindings(mod)
+	qualifyStdlibCollectionLiteralTypes(mod)
+	qualifyStdlibLetTypes(mod)
+	qualifyStdlibIdentBindings(mod)
+}
+
+func qualifyStdlibCollectionLiteralTypes(mod *ir.Module) {
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		switch x := n.(type) {
+		case *ir.ListLit:
+			if typeContainsQualifiedNamed(x.Elem) {
+				return true
+			}
+			for _, elem := range x.Elems {
+				if t := qualifiedValueType(elem); t != nil {
+					x.Elem = t
+					break
+				}
+			}
+		case *ir.MapLit:
+			if !typeContainsQualifiedNamed(x.KeyT) {
+				for _, entry := range x.Entries {
+					if t := qualifiedValueType(entry.Key); t != nil {
+						x.KeyT = t
+						break
+					}
+				}
+			}
+			if !typeContainsQualifiedNamed(x.ValT) {
+				for _, entry := range x.Entries {
+					if t := qualifiedValueType(entry.Value); t != nil {
+						x.ValT = t
+						break
+					}
+				}
+			}
+		}
+		return true
+	}), mod)
+}
+
+func qualifyStdlibLetTypes(mod *ir.Module) {
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		let, ok := n.(*ir.LetStmt)
+		if !ok || let == nil || let.Value == nil {
+			return true
+		}
+		if t := qualifiedValueType(let.Value); t != nil {
+			let.Type = t
+		}
+		return true
+	}), mod)
+}
+
+func qualifyStdlibIdentBindings(mod *ir.Module) {
+	bindings := map[string]ir.Type{}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		let, ok := n.(*ir.LetStmt)
+		if !ok || let == nil || let.Name == "" || !typeContainsQualifiedNamed(let.Type) {
+			return true
+		}
+		bindings[let.Name] = ir.CloneType(let.Type)
+		return true
+	}), mod)
+	if len(bindings) > 0 {
+		ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+			id, ok := n.(*ir.Ident)
+			if !ok || id == nil {
+				return true
+			}
+			if t := bindings[id.Name]; t != nil {
+				id.T = ir.CloneType(t)
+			}
+			return true
+		}), mod)
+	}
+}
+
+func builtinReceiverMethodReturnType(receiver ir.Type, method string) ir.Type {
+	switch t := receiver.(type) {
+	case *ir.OptionalType:
+		switch method {
+		case "unwrap", "unwrapOr":
+			return ir.CloneType(t.Inner)
+		case "isSome", "isNone":
+			return ir.TBool
+		}
+	case *ir.NamedType:
+		switch t.Name {
+		case "Option", "Maybe":
+			switch method {
+			case "unwrap", "unwrapOr":
+				if len(t.Args) >= 1 {
+					return ir.CloneType(t.Args[0])
+				}
+			case "isSome", "isNone":
+				return ir.TBool
+			}
+		case "Result":
+			switch method {
+			case "unwrap", "unwrapOr":
+				if len(t.Args) >= 1 {
+					return ir.CloneType(t.Args[0])
+				}
+			case "unwrapErr":
+				if len(t.Args) >= 2 {
+					return ir.CloneType(t.Args[1])
+				}
+			case "isOk", "isErr":
+				return ir.TBool
+			}
+		}
+	}
+	return nil
+}
+
+func qualifiedValueType(e ir.Expr) ir.Type {
+	if e == nil {
+		return nil
+	}
+	t := e.Type()
+	if !typeContainsQualifiedNamed(t) {
+		return nil
+	}
+	return ir.CloneType(t)
+}
+
+func typeContainsQualifiedNamed(t ir.Type) bool {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		if x.Package != "" {
+			return true
+		}
+		for _, a := range x.Args {
+			if typeContainsQualifiedNamed(a) {
+				return true
+			}
+		}
+	case *ir.OptionalType:
+		return typeContainsQualifiedNamed(x.Inner)
+	case *ir.TupleType:
+		for _, e := range x.Elems {
+			if typeContainsQualifiedNamed(e) {
+				return true
+			}
+		}
+	case *ir.FnType:
+		for _, p := range x.Params {
+			if typeContainsQualifiedNamed(p) {
+				return true
+			}
+		}
+		return typeContainsQualifiedNamed(x.Return)
+	}
+	return false
 }
 
 func sortedBareIdentCallNames(fn *ir.FnDecl) []string {

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -300,23 +300,23 @@ func stdlibJoinFieldPath(path []string) string {
 func stdlibSingletonReceiverExpr(module, path, typeName string, fallback ir.Expr, span ir.Span) ir.Expr {
 	switch {
 	case module == "encoding" && path == "base64" && typeName == "Base64":
-		return stdlibStructLit("Base64", span, ir.StructLitField{
+		return stdlibStructLit(module, "Base64", span, ir.StructLitField{
 			Name:  "url",
-			Value: stdlibStructLit("Base64Url", span),
+			Value: stdlibStructLit(module, "Base64Url", span),
 			SpanV: span,
 		})
 	case module == "encoding" && path == "base64.url" && typeName == "Base64Url":
-		return stdlibStructLit("Base64Url", span)
+		return stdlibStructLit(module, "Base64Url", span)
 	case module == "encoding" && path == "hex" && typeName == "Hex":
-		return stdlibStructLit("Hex", span)
+		return stdlibStructLit(module, "Hex", span)
 	case module == "encoding" && path == "url" && typeName == "UrlEncoding":
-		return stdlibStructLit("UrlEncoding", span)
+		return stdlibStructLit(module, "UrlEncoding", span)
 	case module == "compress" && path == "gzip" && typeName == "Gzip":
-		return stdlibStructLit("Gzip", span)
+		return stdlibStructLit(module, "Gzip", span)
 	case module == "crypto" && path == "hmac" && typeName == "Hmac":
-		return stdlibStructLit("Hmac", span)
+		return stdlibStructLit(module, "Hmac", span)
 	case module == "os" && path == "path" && typeName == "Path":
-		return stdlibStructLit("Path", span)
+		return stdlibStructLit(module, "Path", span)
 	case module == "net" && typeName == "Ipv4Addr":
 		switch path {
 		case "LOCALHOST_V4":
@@ -337,17 +337,17 @@ func stdlibSingletonReceiverExpr(module, path, typeName string, fallback ir.Expr
 	return fallback
 }
 
-func stdlibStructLit(typeName string, span ir.Span, fields ...ir.StructLitField) *ir.StructLit {
+func stdlibStructLit(module, typeName string, span ir.Span, fields ...ir.StructLitField) *ir.StructLit {
 	return &ir.StructLit{
 		TypeName: typeName,
 		Fields:   fields,
-		T:        &ir.NamedType{Name: typeName},
+		T:        &ir.NamedType{Package: module, Name: typeName},
 		SpanV:    span,
 	}
 }
 
 func stdlibIpv4Lit(a, b, c, d int, span ir.Span) *ir.StructLit {
-	return stdlibStructLit("Ipv4Addr", span,
+	return stdlibStructLit("net", "Ipv4Addr", span,
 		stdlibIntField("a", a, span),
 		stdlibIntField("b", b, span),
 		stdlibIntField("c", c, span),
@@ -360,7 +360,7 @@ func stdlibIpv6Lit(groups []int, span ir.Span) *ir.StructLit {
 	for _, g := range groups {
 		elems = append(elems, stdlibIntLit(g, span))
 	}
-	return stdlibStructLit("Ipv6Addr", span, ir.StructLitField{
+	return stdlibStructLit("net", "Ipv6Addr", span, ir.StructLitField{
 		Name: "groups",
 		Value: &ir.ListLit{
 			Elems: elems,

--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -56,6 +56,22 @@ type loweredStdlibTypesEntry struct {
 	decls map[stdlibTypeKey]ir.Decl
 }
 
+func (e *loweredStdlibTypesEntry) moduleTypeNames(module string) map[string]bool {
+	if e == nil || module == "" || len(e.decls) == 0 {
+		return nil
+	}
+	out := map[string]bool{}
+	for key := range e.decls {
+		if key.Module == module && key.Name != "" {
+			out[key.Name] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // injectReachableStdlibTypes appends stdlib built-in type decls
 // (`Map<K, V>`, `Option<T>`, …) to mod.Decls when user code
 // references them. After this pass, ir.Monomorphize sees the generic
@@ -99,7 +115,7 @@ func injectReachableStdlibTypes(mod *ir.Module, reg *stdlib.Registry) ([]ir.Decl
 			return
 		}
 		seen[key] = true
-		out = append(out, cloneStdlibTypeDecl(decl))
+		out = append(out, cloneStdlibTypeDecl(key, decl, entry.moduleTypeNames(key.Module)))
 	}
 	for _, key := range referenced {
 		appendKey(key)
@@ -673,14 +689,148 @@ func isInjectableTypeName(name string) bool {
 
 // cloneStdlibTypeDecl deep-clones a StructDecl or EnumDecl so the
 // per-user-module appended copy can be rewritten by the monomorphizer
-// without disturbing the shared cache. Uses the public ir.Clone and
-// type-asserts back to Decl.
-func cloneStdlibTypeDecl(d ir.Decl) ir.Decl {
+// without disturbing the shared cache. Non-builtin stdlib-local types
+// are qualified as "<module>.<Type>" so they cannot collide with a
+// user's ordinary top-level type named Reply, Header, Image, etc.
+func cloneStdlibTypeDecl(key stdlibTypeKey, d ir.Decl, moduleTypes map[string]bool) ir.Decl {
 	if d == nil {
 		return nil
 	}
 	cp, _ := ir.Clone(d).(ir.Decl)
+	qualifyStdlibDeclTypes(cp, key.Module, moduleTypes)
+	switch x := cp.(type) {
+	case *ir.StructDecl:
+		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
+			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
+		}
+	case *ir.EnumDecl:
+		if shouldQualifyStdlibTypeName(key.Module, x.Name, moduleTypes) {
+			x.Name = qualifiedStdlibTypeName(key.Module, x.Name)
+		}
+	}
 	return cp
+}
+
+func qualifyStdlibDeclTypes(d ir.Decl, module string, moduleTypes map[string]bool) {
+	if d == nil || module == "" || len(moduleTypes) == 0 {
+		return
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		switch x := n.(type) {
+		case *ir.FnDecl:
+			x.Return = qualifyStdlibType(x.Return, module, moduleTypes)
+		case *ir.Param:
+			x.Type = qualifyStdlibType(x.Type, module, moduleTypes)
+		case *ir.Field:
+			x.Type = qualifyStdlibType(x.Type, module, moduleTypes)
+		case *ir.LetDecl:
+			x.Type = qualifyStdlibType(x.Type, module, moduleTypes)
+		case *ir.LetStmt:
+			x.Type = qualifyStdlibType(x.Type, module, moduleTypes)
+		case *ir.IntLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.FloatLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.Ident:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			qualifyStdlibTypeList(x.TypeArgs, module, moduleTypes)
+		case *ir.UnaryExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.BinaryExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.CallExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			qualifyStdlibTypeList(x.TypeArgs, module, moduleTypes)
+		case *ir.MethodCall:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			qualifyStdlibTypeList(x.TypeArgs, module, moduleTypes)
+		case *ir.ListLit:
+			x.Elem = qualifyStdlibType(x.Elem, module, moduleTypes)
+		case *ir.MapLit:
+			x.KeyT = qualifyStdlibType(x.KeyT, module, moduleTypes)
+			x.ValT = qualifyStdlibType(x.ValT, module, moduleTypes)
+		case *ir.TupleLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.StructLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			if shouldQualifyStdlibTypeName(module, x.TypeName, moduleTypes) {
+				x.TypeName = qualifiedStdlibTypeName(module, x.TypeName)
+			}
+		case *ir.VariantLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			if shouldQualifyStdlibTypeName(module, x.Enum, moduleTypes) {
+				x.Enum = qualifiedStdlibTypeName(module, x.Enum)
+			}
+		case *ir.BlockExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.IfExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.IfLetExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.MatchExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.FieldExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.IndexExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.TupleAccess:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.RangeLit:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.QuestionExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.CoalesceExpr:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+		case *ir.Closure:
+			x.T = qualifyStdlibType(x.T, module, moduleTypes)
+			x.Return = qualifyStdlibType(x.Return, module, moduleTypes)
+		}
+		return true
+	}), d)
+}
+
+func qualifyStdlibTypeList(types []ir.Type, module string, moduleTypes map[string]bool) {
+	for i, t := range types {
+		types[i] = qualifyStdlibType(t, module, moduleTypes)
+	}
+}
+
+func qualifyStdlibType(t ir.Type, module string, moduleTypes map[string]bool) ir.Type {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		for i, a := range x.Args {
+			x.Args[i] = qualifyStdlibType(a, module, moduleTypes)
+		}
+		if shouldQualifyStdlibTypeName(module, x.Name, moduleTypes) && x.Package == "" {
+			x.Package = module
+		}
+	case *ir.OptionalType:
+		x.Inner = qualifyStdlibType(x.Inner, module, moduleTypes)
+	case *ir.TupleType:
+		for i, e := range x.Elems {
+			x.Elems[i] = qualifyStdlibType(e, module, moduleTypes)
+		}
+	case *ir.FnType:
+		for i, p := range x.Params {
+			x.Params[i] = qualifyStdlibType(p, module, moduleTypes)
+		}
+		x.Return = qualifyStdlibType(x.Return, module, moduleTypes)
+	}
+	return t
+}
+
+func shouldQualifyStdlibTypeName(module, name string, moduleTypes map[string]bool) bool {
+	if module == "" || name == "" || !moduleTypes[name] {
+		return false
+	}
+	return !isInjectableTypeName(name)
+}
+
+func qualifiedStdlibTypeName(module, name string) string {
+	if module == "" || name == "" || strings.Contains(name, ".") {
+		return name
+	}
+	return module + "." + name
 }
 
 // moduleForStdlibType is a lookup helper used by tests and

--- a/internal/backend/stdlib_type_inject_test.go
+++ b/internal/backend/stdlib_type_inject_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
@@ -225,6 +227,262 @@ fn main() {}
 	if !foundOption {
 		t.Fatalf("Option enum not injected for `Int?` parameter — surface `T?` sugar must trigger injection")
 	}
+}
+
+// TestInjectReachableStdlibTypesKeepsStdlibLayoutsQualified guards the
+// #1093 stdlib-type injection collision: importing a module like std.smtp
+// pulls in its internal Reply struct for injected bodies, but that must not
+// overwrite an ordinary user-declared struct Reply in backend layout tables.
+func TestInjectReachableStdlibTypesKeepsStdlibLayoutsQualified(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.UseDecl{Path: []string{"std", "smtp"}, RawPath: "std.smtp", Alias: "smtp"},
+			&ir.StructDecl{
+				Name: "Reply",
+				Fields: []*ir.Field{
+					{Name: "local", Type: ir.TInt},
+				},
+			},
+			&ir.FnDecl{
+				Name: "parse",
+				Return: &ir.NamedType{
+					Name:    "Result",
+					Builtin: true,
+					Args: []ir.Type{
+						&ir.NamedType{Package: "smtp", Name: "Reply"},
+						&ir.NamedType{Name: "Error", Builtin: true},
+					},
+				},
+				Body: &ir.Block{},
+			},
+			&ir.FnDecl{Name: "main", Return: ir.TUnit, Body: &ir.Block{}},
+		},
+	}
+	reg := stdlib.LoadCached()
+	injected, _ := injectReachableStdlibTypes(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("ir.Monomorphize returned nil: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	userReply := mirMod.Layouts.Structs["Reply"]
+	if userReply == nil {
+		t.Fatalf("user Reply layout missing; layouts=%v", mirMod.Layouts.Structs)
+	}
+	if len(userReply.Fields) != 1 || userReply.Fields[0].Name != "local" {
+		t.Fatalf("user Reply layout was overwritten by injected stdlib Reply: %#v", userReply.Fields)
+	}
+	if stdReply := mirMod.Layouts.Structs["smtp.Reply"]; stdReply == nil {
+		t.Fatalf("qualified stdlib smtp.Reply layout missing; layouts=%v", mirMod.Layouts.Structs)
+	}
+}
+
+func TestInjectReachableStdlibBodiesQualifiesUnwrapCallsiteTypes(t *testing.T) {
+	src := `use std.zip
+
+fn main() {
+    let entry = zip.file("hello.txt", "hello".toBytes()).unwrap()
+    let archive = zip.encode([entry]).unwrap()
+    println(zip.isArchive(archive))
+}
+`
+	mod := lowerUserProgramForTest(t, src)
+	reg := stdlib.LoadCached()
+	injected, _ := injectReachableStdlibBodies(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+
+	var entryType ir.Type
+	var entryLetType ir.Type
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		if entryType != nil {
+			return false
+		}
+		let, ok := n.(*ir.LetStmt)
+		if !ok || let == nil || let.Name != "entry" || let.Value == nil {
+			return true
+		}
+		entryLetType = let.Type
+		entryType = let.Value.Type()
+		return false
+	}), mod)
+	named, ok := entryType.(*ir.NamedType)
+	if !ok || named.Package != "zip" || named.Name != "Entry" {
+		t.Fatalf("entry type = %#v, want zip.Entry", entryType)
+	}
+	letNamed, ok := entryLetType.(*ir.NamedType)
+	if !ok || letNamed.Package != "zip" || letNamed.Name != "Entry" {
+		t.Fatalf("entry let type = %#v, want zip.Entry", entryLetType)
+	}
+
+	injectedTypes, _ := injectReachableStdlibTypes(mod, reg)
+	mod.Decls = append(mod.Decls, injectedTypes...)
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("ir.Monomorphize returned nil: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	mainFn := mirMod.LookupFunction("main")
+	if mainFn == nil {
+		t.Fatalf("main MIR function missing")
+	}
+	foundEntryLocal := false
+	for _, loc := range mainFn.Locals {
+		if loc.Name != "entry" {
+			continue
+		}
+		foundEntryLocal = true
+		named, ok := loc.Type.(*ir.NamedType)
+		if !ok || named.Package != "zip" || named.Name != "Entry" {
+			t.Fatalf("MIR entry local type = %#v, want zip.Entry", loc.Type)
+		}
+	}
+	if !foundEntryLocal {
+		t.Fatalf("MIR entry local missing")
+	}
+	for _, fn := range mirMod.Functions {
+		if fn == nil || !strings.HasPrefix(fn.Name, "osty_std_zip__") {
+			continue
+		}
+		for _, loc := range fn.Locals {
+			if named, ok := loc.Type.(*ir.NamedType); ok && named.Package == "" && named.Name == "Entry" {
+				t.Fatalf("%s local %q type = %#v, want zip.Entry", fn.Name, loc.Name, loc.Type)
+			}
+		}
+	}
+	irOut, err := llvmgen.GenerateFromMIR(mirMod, llvmgen.Options{PackageName: "main", UseMIR: true, EmitGC: true})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR returned error: %v", err)
+	}
+	if strings.Contains(string(irOut), "%Entry") {
+		t.Fatalf("LLVM output still mentions bare %%Entry:\n%s", contextAround(string(irOut), "%Entry"))
+	}
+}
+
+func TestInjectReachableStdlibBodiesQualifiesForInElementTypes(t *testing.T) {
+	src := `use std.email
+
+fn main() {
+    let from = email.address("sender@example.com").unwrap()
+    let recipients = [email.address("rcpt@example.com").unwrap()]
+    let msg = email.message(from, recipients, "Subject", "Body")
+    let env = email.envelope(msg).unwrap()
+    println(env.to[0])
+}
+`
+	mod := lowerUserProgramForTest(t, src)
+	reg := stdlib.LoadCached()
+	injected, _ := injectReachableStdlibBodies(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+	injectedTypes, _ := injectReachableStdlibTypes(mod, reg)
+	for _, d := range injectedTypes {
+		st, ok := d.(*ir.StructDecl)
+		if !ok || st.Name != "email.Message" {
+			continue
+		}
+		for _, f := range st.Fields {
+			if f.Name != "to" {
+				continue
+			}
+			list, ok := f.Type.(*ir.NamedType)
+			if !ok || list.Name != "List" || len(list.Args) != 1 {
+				t.Fatalf("Message.to type = %#v, want List<email.Address>", f.Type)
+			}
+			addr, ok := list.Args[0].(*ir.NamedType)
+			if !ok || addr.Package != "email" || addr.Name != "Address" {
+				t.Fatalf("Message.to elem type = %#v, want email.Address", list.Args[0])
+			}
+		}
+	}
+	mod.Decls = append(mod.Decls, injectedTypes...)
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("ir.Monomorphize returned nil: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	for _, mirFn := range mirMod.Functions {
+		if mirFn == nil {
+			continue
+		}
+		for _, loc := range mirFn.Locals {
+			if named, ok := loc.Type.(*ir.NamedType); ok && named.Package == "" && named.Name == "Address" {
+				t.Fatalf("%s local %q type = %#v, want email.Address", mirFn.Name, loc.Name, loc.Type)
+			}
+		}
+	}
+	fn := mirMod.LookupFunction("osty_std_email__recipients")
+	if fn == nil {
+		t.Fatalf("osty_std_email__recipients MIR function missing")
+	}
+	for _, loc := range fn.Locals {
+		if loc.Name != "_elem" {
+			continue
+		}
+		named, ok := loc.Type.(*ir.NamedType)
+		if !ok || named.Package != "email" || named.Name != "Address" {
+			t.Fatalf("_elem type = %#v, want email.Address", loc.Type)
+		}
+		return
+	}
+	t.Fatalf("_elem local missing")
+}
+
+func TestInjectReachableStdlibBodiesQualifiesSmtpEmailLLVMTypes(t *testing.T) {
+	src := `use std.email
+use std.smtp
+
+fn main() {
+    let cfg = smtp.withAuth(
+        smtp.withSecurity(
+            smtp.config("smtp.example.com", smtp.defaultPort(StartTls), "client.local").unwrap(),
+            StartTls,
+        ),
+        smtp.plainAuth("user", "secret"),
+    )
+    let from = email.address("sender@example.com").unwrap()
+    let recipients = [email.address("rcpt@example.com").unwrap()]
+    let msg = email.message(from, recipients, "Subject", "Body")
+    let env = email.envelope(msg).unwrap()
+    let cmds = smtp.commands(smtp.transaction(cfg, env)).unwrap()
+    println(cmds.len())
+}
+`
+	mod := lowerUserProgramForTest(t, src)
+	reg := stdlib.LoadCached()
+	injected, _ := injectReachableStdlibBodies(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+	injectedTypes, _ := injectReachableStdlibTypes(mod, reg)
+	mod.Decls = append(mod.Decls, injectedTypes...)
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("ir.Monomorphize returned nil: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	irOut, err := llvmgen.GenerateFromMIR(mirMod, llvmgen.Options{PackageName: "main", UseMIR: true, EmitGC: true})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR returned error: %v", err)
+	}
+	if strings.Contains(string(irOut), "%Address") {
+		t.Fatalf("LLVM output still mentions bare %%Address:\n%s", contextAround(string(irOut), "%Address"))
+	}
+}
+
+func contextAround(s, needle string) string {
+	idx := strings.Index(s, needle)
+	if idx < 0 {
+		return ""
+	}
+	start := idx - 300
+	if start < 0 {
+		start = 0
+	}
+	end := idx + 300
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[start:end]
 }
 
 // lowerUserProgramForTest runs the parse / resolve / check / ir.Lower

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -1994,14 +1994,15 @@ func typeCodeOf(t Type, pkg string) string {
 		// template-nested form so a generic free function whose type arg
 		// is itself user-generic (e.g. `id::<Pair<Int,Int>>`) gets a
 		// unique mangled fn symbol per concrete Pair instantiation.
+		ownerPkg := namedTypeCodePackage(t, pkg)
 		if len(t.Args) > 0 {
 			var sb strings.Builder
 			for _, a := range t.Args {
 				sb.WriteString(typeCodeOf(a, pkg))
 			}
-			return MonomorphUserTemplateNested(firstNonEmpty(pkg, "main"), t.Name, sb.String())
+			return MonomorphUserTemplateNested(ownerPkg, t.Name, sb.String())
 		}
-		return MonomorphUserNested(firstNonEmpty(pkg, "main"), t.Name)
+		return MonomorphUserNested(ownerPkg, t.Name)
 	case *OptionalType:
 		inner := typeCodeOf(t.Inner, pkg)
 		return MonomorphBuiltinTemplate("Option", inner)
@@ -2058,4 +2059,11 @@ func firstNonEmpty(a, b string) string {
 		return a
 	}
 	return b
+}
+
+func namedTypeCodePackage(t *NamedType, fallback string) string {
+	if t != nil && t.Package != "" {
+		return firstNonEmpty(strings.TrimPrefix(t.Package, "std."), "main")
+	}
+	return firstNonEmpty(fallback, "main")
 }

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -663,6 +663,32 @@ func TestTypeCodeOfUserNamedWithoutArgsUnchanged(t *testing.T) {
 	}
 }
 
+func TestTypeCodeOfQualifiedNamedTypeUsesOwnerPackage(t *testing.T) {
+	got := typeCodeOf(&NamedType{Package: "email", Name: "Address"}, "main")
+	const want = "N5email7AddressE"
+	if got != want {
+		t.Fatalf("typeCodeOf(email.Address): got %q, want %q", got, want)
+	}
+}
+
+func TestTypeCodeOfBuiltinArgKeepsQualifiedNamedPackage(t *testing.T) {
+	list := &NamedType{
+		Name:    "List",
+		Builtin: true,
+		Args: []Type{
+			&NamedType{Package: "email", Name: "Address"},
+		},
+	}
+	got := typeCodeOf(list, "main")
+	const want = "N4osty4ListIN5email7AddressEEE"
+	if got != want {
+		t.Fatalf("typeCodeOf(List<email.Address>): got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "main") {
+		t.Fatalf("qualified type arg should not fall back to main package: %q", got)
+	}
+}
+
 // ==== Phase 2 rewriteType helper ====
 
 // newTestMonoState builds a blank monoState populated only with the

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -529,18 +529,19 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		if isStdlibModuleMarkerTypeName(x.Name) {
 			return true
 		}
+		layoutKey := mirNamedTypeLayoutKey(x)
 		if g.mod != nil && g.mod.Layouts != nil {
-			if _, ok := g.mod.Layouts.Structs[x.Name]; ok {
+			if _, ok := g.mod.Layouts.Structs[layoutKey]; ok {
 				return true
 			}
-			if _, ok := g.mod.Layouts.Enums[x.Name]; ok {
+			if _, ok := g.mod.Layouts.Enums[layoutKey]; ok {
 				return true
 			}
 			// User-declared interface. The MIR lowerer populates
 			// Layouts.Interfaces for every surviving InterfaceDecl;
 			// values of interface type flow as `%osty.iface = { ptr,
 			// ptr }` at the LLVM level.
-			if _, ok := g.mod.Layouts.Interfaces[x.Name]; ok {
+			if _, ok := g.mod.Layouts.Interfaces[layoutKey]; ok {
 				return true
 			}
 		}
@@ -3660,7 +3661,7 @@ func (g *mirGen) resultPayloadTypes(t mir.Type) (mir.Type, mir.Type, bool) {
 	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
 		return nil, nil, false
 	}
-	if el := g.mod.Layouts.Enums[nt.Name]; el != nil && el.BuiltinSource == "Result" && len(el.BuiltinSourceArgs) >= 2 {
+	if el := g.mod.Layouts.Enums[mirNamedTypeLayoutKey(nt)]; el != nil && el.BuiltinSource == "Result" && len(el.BuiltinSourceArgs) >= 2 {
 		return el.BuiltinSourceArgs[0], el.BuiltinSourceArgs[1], true
 	}
 	return nil, nil, false
@@ -6952,7 +6953,7 @@ func (g *mirGen) emitEnumStringConcatBoxed(op mir.Operand, t mir.Type) (*LlvmVal
 	if !ok || nt.Name == "" || g.mod == nil || g.mod.Layouts == nil {
 		return nil, false, nil
 	}
-	layout := g.mod.Layouts.Enums[nt.Name]
+	layout := g.mod.Layouts.Enums[mirNamedTypeLayoutKey(nt)]
 	if layout == nil || len(layout.Variants) == 0 {
 		return nil, false, nil
 	}
@@ -7805,7 +7806,7 @@ func (g *mirGen) mapKeyValueTypes(t mir.Type) (mir.Type, mir.Type) {
 	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
 		return nil, nil
 	}
-	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "Map" && len(sl.BuiltinSourceArgs) == 2 {
+	if sl := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(nt)]; sl != nil && sl.BuiltinSource == "Map" && len(sl.BuiltinSourceArgs) == 2 {
 		return sl.BuiltinSourceArgs[0], sl.BuiltinSourceArgs[1]
 	}
 	return nil, nil
@@ -7842,7 +7843,7 @@ func (g *mirGen) setElemType(t mir.Type) mir.Type {
 	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
 		return nil
 	}
-	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "Set" && len(sl.BuiltinSourceArgs) == 1 {
+	if sl := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(nt)]; sl != nil && sl.BuiltinSource == "Set" && len(sl.BuiltinSourceArgs) == 1 {
 		return sl.BuiltinSourceArgs[0]
 	}
 	return nil
@@ -8751,7 +8752,7 @@ func (g *mirGen) listElemType(t mir.Type) mir.Type {
 	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
 		return nil
 	}
-	if sl := g.mod.Layouts.Structs[nt.Name]; sl != nil && sl.BuiltinSource == "List" && len(sl.BuiltinSourceArgs) == 1 {
+	if sl := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(nt)]; sl != nil && sl.BuiltinSource == "List" && len(sl.BuiltinSourceArgs) == 1 {
 		return sl.BuiltinSourceArgs[0]
 	}
 	return nil
@@ -8770,7 +8771,7 @@ func (g *mirGen) aggregateElementTypes(aggT mir.Type, rv *mir.AggregateRV) ([]mi
 		if g.mod == nil || g.mod.Layouts == nil {
 			return nil, fmt.Errorf("mir-mvp: missing layout table for struct %s", nt.Name)
 		}
-		sl := g.mod.Layouts.Structs[nt.Name]
+		sl := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(nt)]
 		if sl == nil {
 			return nil, fmt.Errorf("mir-mvp: missing layout for struct %s", nt.Name)
 		}
@@ -9365,7 +9366,7 @@ func (g *mirGen) isEnumValueType(t mir.Type) bool {
 	if !ok || g == nil || g.mod == nil || g.mod.Layouts == nil {
 		return false
 	}
-	return g.mod.Layouts.Enums[nt.Name] != nil
+	return g.mod.Layouts.Enums[mirNamedTypeLayoutKey(nt)] != nil
 }
 
 func (g *mirGen) emitEnumDiscriminantEquality(op mir.BinaryOp, left, right string, argT mir.Type) (string, error) {
@@ -9591,6 +9592,16 @@ func encodeLLVMString(s string) (string, int) {
 
 // ==== type mapping ====
 
+func mirNamedTypeLayoutKey(t *ir.NamedType) string {
+	if t == nil {
+		return ""
+	}
+	if t.Package != "" && !t.Builtin {
+		return strings.TrimPrefix(t.Package, "std.") + "." + t.Name
+	}
+	return t.Name
+}
+
 func (g *mirGen) llvmType(t mir.Type) string {
 	switch x := t.(type) {
 	case *ir.PrimType:
@@ -9642,24 +9653,25 @@ func (g *mirGen) llvmType(t mir.Type) string {
 		}
 		// User-declared struct or enum — register the enum in the
 		// layout pool on first use and emit by name.
+		layoutKey := mirNamedTypeLayoutKey(x)
 		if g.mod != nil && g.mod.Layouts != nil {
-			if sl := g.mod.Layouts.Structs[x.Name]; sl != nil && isOpaqueBuiltinStructLayout(sl) {
+			if sl := g.mod.Layouts.Structs[layoutKey]; sl != nil && isOpaqueBuiltinStructLayout(sl) {
 				return "ptr"
 			}
-			if _, ok := g.mod.Layouts.Structs[x.Name]; ok {
-				return "%" + x.Name
+			if _, ok := g.mod.Layouts.Structs[layoutKey]; ok {
+				return "%" + layoutKey
 			}
-			if en := g.mod.Layouts.Enums[x.Name]; en != nil {
+			if en := g.mod.Layouts.Enums[layoutKey]; en != nil {
 				if builtinLLVM := g.builtinEnumLayoutLLVMType(en); builtinLLVM != "" {
 					return builtinLLVM
 				}
-				g.registerEnumLayout(x.Name)
-				return "%" + x.Name
+				g.registerEnumLayout(layoutKey)
+				return "%" + layoutKey
 			}
 			// Interface values are fat pointers `{data, vtable}`. The
 			// concrete type name doesn't participate in LLVM typing —
 			// every interface lowers to the same `%osty.iface`.
-			if _, ok := g.mod.Layouts.Interfaces[x.Name]; ok {
+			if _, ok := g.mod.Layouts.Interfaces[layoutKey]; ok {
 				g.ifaceTouched = true
 				return "%osty.iface"
 			}
@@ -9720,7 +9732,7 @@ func (g *mirGen) isStdTermSizeType(t *ir.NamedType) bool {
 		return false
 	}
 	if g.mod != nil && g.mod.Layouts != nil {
-		if _, ok := g.mod.Layouts.Structs[t.Name]; ok {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
 			return false
 		}
 	}
@@ -9733,7 +9745,7 @@ func (g *mirGen) isStdOsOutputType(t *ir.NamedType) bool {
 		return false
 	}
 	if g.mod != nil && g.mod.Layouts != nil {
-		if _, ok := g.mod.Layouts.Structs[t.Name]; ok {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
 			return false
 		}
 	}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1454,7 +1454,7 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 }
 
 func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
-	iterT := f.Iter.Type()
+	iterT := bs.recoveredTypeOf(f.Iter)
 	if isChannelType(iterT) {
 		bs.lowerForInChannel(f, iterT)
 		return
@@ -2273,6 +2273,11 @@ func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 	case *ir.FieldExpr, *ir.IndexExpr, *ir.TupleAccess, *ir.MethodCall:
 		if rt := bs.recoverOperandType(e); rt != nil && !isPoisonType(rt) && !irHasPoisonedTypeArg(rt) {
 			return rt
+		}
+	}
+	if field, ok := e.(*ir.FieldExpr); ok {
+		if ft := bs.fieldExprType(field); ft != nil && !isPoisonType(ft) && !irHasPoisonedTypeArg(ft) {
+			return ft
 		}
 	}
 	t := e.Type()
@@ -4935,10 +4940,11 @@ func (l *lowerer) stdlibIntrinsicForMethod(receiverType Type, name string) Intri
 
 func (l *lowerer) stdlibReceiverName(t Type) string {
 	if nt, ok := t.(*ir.NamedType); ok && l != nil {
-		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource != "" {
+		key := typeNameOf(nt)
+		if st := l.structs[key]; st != nil && st.BuiltinSource != "" {
 			return st.BuiltinSource
 		}
-		if en := l.enums[nt.Name]; en != nil && en.BuiltinSource != "" {
+		if en := l.enums[key]; en != nil && en.BuiltinSource != "" {
 			return en.BuiltinSource
 		}
 	}
@@ -4950,7 +4956,7 @@ func (l *lowerer) isListType(t ir.Type) bool {
 		return true
 	}
 	if nt, ok := t.(*ir.NamedType); ok && l != nil {
-		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "List" {
+		if st := l.structs[typeNameOf(nt)]; st != nil && st.BuiltinSource == "List" {
 			return true
 		}
 	}
@@ -4962,7 +4968,7 @@ func (l *lowerer) listElementType(t ir.Type) Type {
 		return elemT
 	}
 	if nt, ok := t.(*ir.NamedType); ok && l != nil {
-		if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "List" && len(st.BuiltinSourceArgs) >= 1 {
+		if st := l.structs[typeNameOf(nt)]; st != nil && st.BuiltinSource == "List" && len(st.BuiltinSourceArgs) >= 1 {
 			return st.BuiltinSourceArgs[0]
 		}
 	}
@@ -4974,7 +4980,7 @@ func (l *lowerer) indexElementType(base Type) Type {
 		return elemT
 	}
 	if nt, ok := base.(*ir.NamedType); ok && l != nil {
-		if st := l.structs[nt.Name]; st != nil {
+		if st := l.structs[typeNameOf(nt)]; st != nil {
 			switch st.BuiltinSource {
 			case "List":
 				if len(st.BuiltinSourceArgs) >= 1 {
@@ -4996,7 +5002,7 @@ func (l *lowerer) mapKeyType(base Type) Type {
 			return nt.Args[0]
 		}
 		if l != nil {
-			if st := l.structs[nt.Name]; st != nil && st.BuiltinSource == "Map" && len(st.BuiltinSourceArgs) >= 1 {
+			if st := l.structs[typeNameOf(nt)]; st != nil && st.BuiltinSource == "Map" && len(st.BuiltinSourceArgs) >= 1 {
 				return st.BuiltinSourceArgs[0]
 			}
 		}
@@ -5797,7 +5803,7 @@ func (l *lowerer) variantIndexInType(t ir.Type, name string) (int, bool) {
 	if !ok || nt.Name == "" {
 		return 0, false
 	}
-	e := l.enums[nt.Name]
+	e := l.enums[typeNameOf(nt)]
 	if e == nil {
 		return 0, false
 	}
@@ -6057,6 +6063,10 @@ func variantLookupPayloadType(l *lowerer, scrutT ir.Type, variant string, idx in
 func typeNameOf(t ir.Type) string {
 	switch x := t.(type) {
 	case *ir.NamedType:
+		if x.Package != "" && !x.Builtin {
+			pkg := strings.TrimPrefix(x.Package, "std.")
+			return pkg + "." + x.Name
+		}
 		return x.Name
 	case *ir.OptionalType:
 		return "Option"


### PR DESCRIPTION
## Summary
- Qualify injected stdlib-local nominal types such as `smtp.Reply`, `zip.Entry`, and `email.Address` so they cannot collide with user-declared top-level names.
- Preserve qualified stdlib types through body injection, generic monomorphization, MIR layout lookup, and LLVM layout emission.
- Add regressions for user/std type layout collisions, unwrap/list callsite propagation, for-in element types, and smtp/email LLVM output.

## Validation
- `go test -count=1 -vet=off ./internal/ir -run 'TestTypeCodeOfQualifiedNamedTypeUsesOwnerPackage|TestTypeCodeOfBuiltinArgKeepsQualifiedNamedPackage' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestInjectReachableStdlibTypesKeepsStdlibLayoutsQualified|TestInjectReachableStdlibBodiesQualifiesUnwrapCallsiteTypes|TestInjectReachableStdlibBodiesQualifiesForInElementTypes' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsStdZipStoredArchive|TestLLVMBackendBinaryRunsStdImageMetadata|TestLLVMBackendBinaryRunsStdSmtpPlanning' -v`
- `go test -count=1 -vet=off ./internal/backend ./internal/mir ./internal/llvmgen`
- `go test -count=1 -vet=off ./cmd/osty`
- `just build-all`
- `just verify-selfhost`
- `just short`