### PR TITLE
[codex] fix stdlib review findings

### DIFF
--- a/internal/stdlib/big_gaps_test.go
+++ b/internal/stdlib/big_gaps_test.go
@@ -71,6 +71,8 @@ func TestBigGapModuleSourcePinsBehavior(t *testing.T) {
 			`pub fn dotStuff(data: String) -> String`,
 			`pub fn dataBlock(data: String) -> String`,
 			`out.push(ensureDataBlock(tx.envelope.data))`,
+			`fn ensureDataBlock(data: String) -> String`,
+			`dataBlock(data)`,
 			`strings.endsWith(data, "{crlf()}.{crlf()}")`,
 		},
 		"zip": {

--- a/internal/stdlib/email_test.go
+++ b/internal/stdlib/email_test.go
@@ -51,7 +51,12 @@ func TestEmailModuleSourcePinsMimeBehavior(t *testing.T) {
 		`Content-Type: multipart/mixed; boundary=`,
 		`encoding.base64.encode(part.data)`,
 		`pub fn smtpCommands(hostname: String, env: Envelope) -> List<String>`,
+		`data: render(msg)?`,
+		`out.push(dataBlock(env.data))`,
+		`fn dataBlock(value: String) -> String`,
 		`fn dotStuff(value: String) -> String`,
+		`fn quoteMimeParam(value: String) -> String`,
+		`strings.replaceAll(escapedSlash, "\"", "\\\"")`,
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("std.email source missing %q", want)

--- a/internal/stdlib/http_test.go
+++ b/internal/stdlib/http_test.go
@@ -152,6 +152,9 @@ func TestHttpModuleSourcePinsQualityGuards(t *testing.T) {
 		`withDefaultHeader(self.headers, "Content-Type", "text/plain; charset=utf-8")`,
 		`process.abort("http: header name must not be empty")`,
 		`canonicalHeaderName(key) == canonical`,
+		`fn cookieNameOrAbort(name: String) -> String`,
+		`fn isCookieValueChar(c: Char) -> Bool`,
+		`let name = cookieNameOrAbort(key)`,
 		`bytes.fromString(json.encode(value))`,
 	} {
 		if !strings.Contains(src, want) {

--- a/internal/stdlib/modules/email.osty
+++ b/internal/stdlib/modules/email.osty
@@ -232,13 +232,13 @@ pub fn envelope(msg: Message) -> Result<Envelope, Error> {
     Ok(Envelope {
         from: msg.from.email,
         recipients: recipients(msg),
-        data: smtpData(msg)?,
+        data: render(msg)?,
     })
 }
 
 pub fn smtpData(msg: Message) -> Result<String, Error> {
     let rendered = render(msg)?
-    Ok("{dotStuff(rendered)}{crlf()}.{crlf()}")
+    Ok(dataBlock(rendered))
 }
 
 pub fn smtpCommands(hostname: String, env: Envelope) -> List<String> {
@@ -249,7 +249,7 @@ pub fn smtpCommands(hostname: String, env: Envelope) -> List<String> {
         out.push("RCPT TO:<{rcpt}>")
     }
     out.push("DATA")
-    out.push(env.data)
+    out.push(dataBlock(env.data))
     out.push("QUIT")
     out
 }
@@ -307,7 +307,8 @@ fn renderAlternative(text: String, html: String, boundary: String) -> String {
 
 fn renderAttachment(part: Attachment) -> String {
     let encoded = wrapBase64(encoding.base64.encode(part.data))
-    "Content-Type: {part.contentType}; name=\"{part.filename}\"{crlf()}Content-Disposition: attachment; filename=\"{part.filename}\"{crlf()}Content-Transfer-Encoding: base64{crlf()}{crlf()}{encoded}{crlf()}"
+    let filename = quoteMimeParam(part.filename)
+    "Content-Type: {part.contentType}; name={filename}{crlf()}Content-Disposition: attachment; filename={filename}{crlf()}Content-Transfer-Encoding: base64{crlf()}{crlf()}{encoded}{crlf()}"
 }
 
 fn formatAddressList(addrs: List<Address>) -> String {
@@ -329,6 +330,16 @@ fn quoteDisplayName(name: String) -> String {
         return "{quote}{escaped}{quote}"
     }
     clean
+}
+
+fn quoteMimeParam(value: String) -> String {
+    let quote = '"'
+    "{quote}{escapeQuotedString(sanitizeHeader(value))}{quote}"
+}
+
+fn escapeQuotedString(value: String) -> String {
+    let escapedSlash = strings.replaceAll(value, "\\", "\\\\")
+    strings.replaceAll(escapedSlash, "\"", "\\\"")
 }
 
 fn unquoteDisplayName(name: String) -> String {
@@ -353,6 +364,23 @@ fn sanitizeContentType(value: String) -> String {
 
 fn normalizeBody(value: String) -> String {
     strings.replaceAll(strings.replaceAll(value, "\r\n", "\n"), "\n", crlf())
+}
+
+fn dataBlock(value: String) -> String {
+    let body = stripDataTerminator(value)
+    "{dotStuff(body)}{crlf()}.{crlf()}"
+}
+
+fn stripDataTerminator(value: String) -> String {
+    let normalized = normalizeBody(value)
+    if hasDataTerminator(normalized) {
+        return strings.slice(normalized, 0, normalized.len() - 5)
+    }
+    normalized
+}
+
+fn hasDataTerminator(value: String) -> Bool {
+    strings.endsWith(normalizeBody(value), "{crlf()}.{crlf()}")
 }
 
 fn dotStuff(value: String) -> String {

--- a/internal/stdlib/modules/http.osty
+++ b/internal/stdlib/modules/http.osty
@@ -126,12 +126,16 @@ pub struct Cookie {
     pub sameSite: SameSite?,
 
     pub fn toString(self) -> String {
-        let mut out = "{self.name}={self.value}"
+        let name = cookieNameOrAbort(self.name)
+        let value = cookieValueOrAbort("cookie value", self.value)
+        let mut out = "{name}={value}"
         if !self.path.isEmpty() {
-            out = "{out}; Path={self.path}"
+            let path = cookieValueOrAbort("cookie path", self.path)
+            out = "{out}; Path={path}"
         }
         if !self.domain.isEmpty() {
-            out = "{out}; Domain={self.domain}"
+            let domain = cookieValueOrAbort("cookie domain", self.domain)
+            out = "{out}; Domain={domain}"
         }
         if self.maxAge >= 0 {
             out = "{out}; Max-Age={self.maxAge}"
@@ -1145,7 +1149,9 @@ fn formatCookieHeader(cookies: CookieJar) -> String {
     let keys = cookies.keys().sorted()
     let mut parts: List<String> = []
     for key in keys {
-        parts.push("{key}={cookies.get(key).unwrap()}")
+        let name = cookieNameOrAbort(key)
+        let value = cookieValueOrAbort("cookie value", cookies.get(key).unwrap())
+        parts.push("{name}={value}")
     }
     strings.join(parts, "; ")
 }
@@ -1158,6 +1164,60 @@ fn parseNameValuePair(text: String) -> Result<(String, String), Error> {
     }
     let value = if kv.len() == 2 { strings.trimSpace(kv[1]) } else { "" }
     Ok((name, value))
+}
+
+fn cookieNameOrAbort(name: String) -> String {
+    if !isCookieName(name) {
+        process.abort("http: invalid cookie name")
+    }
+    name
+}
+
+fn cookieValueOrAbort(label: String, value: String) -> String {
+    if !isCookieValue(value) {
+        process.abort("http: invalid {label}")
+    }
+    value
+}
+
+fn isCookieName(name: String) -> Bool {
+    if name.isEmpty() {
+        return false
+    }
+    for c in name.chars() {
+        if !isCookieNameChar(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn isCookieNameChar(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= 'a' && c <= 'z') ||
+    (c >= '0' && c <= '9') ||
+    c == '!' || c == '#' || c == '$' || c == '%' ||
+    c == '&' || c == '\'' || c == '*' || c == '+' ||
+    c == '-' || c == '.' || c == '^' || c == '_' ||
+    c == '`' || c == '|' || c == '~'
+}
+
+fn isCookieValue(value: String) -> Bool {
+    for c in value.chars() {
+        if !isCookieValueChar(c) {
+            return false
+        }
+    }
+    true
+}
+
+fn isCookieValueChar(c: Char) -> Bool {
+    let n = c.toInt()
+    n == 0x21 ||
+    (n >= 0x23 && n <= 0x2B) ||
+    (n >= 0x2D && n <= 0x3A) ||
+    (n >= 0x3C && n <= 0x5B) ||
+    (n >= 0x5D && n <= 0x7E)
 }
 
 fn acceptHeaderMatches(header: String, wanted: String) -> Bool {

--- a/internal/stdlib/modules/smtp.osty
+++ b/internal/stdlib/modules/smtp.osty
@@ -337,11 +337,7 @@ fn parseCapability(message: String) -> Capability {
 }
 
 fn ensureDataBlock(data: String) -> String {
-    let normalized = normalizeBody(data)
-    if hasDataTerminator(normalized) {
-        return normalized
-    }
-    dataBlock(normalized)
+    dataBlock(data)
 }
 
 fn stripDataTerminator(data: String) -> String {

--- a/internal/stdlib/modules/sql.osty
+++ b/internal/stdlib/modules/sql.osty
@@ -175,13 +175,38 @@ pub fn sqliteDialect() -> Dialect {
 pub fn render(q: Query, dialect: Dialect) -> String {
     let mut out = ""
     let mut index = 1
-    for c in q.sql.chars() {
-        if c.toInt() == 0x3F {
+    let chars = q.sql.chars()
+    let mut i = 0
+    for i < chars.len() {
+        let c = chars[i]
+        if startsSqlDollarQuote(chars, i) {
+            let quoted = copySqlDollarQuoted(chars, i)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if c == '`' {
+            let quoted = copySqlBacktickQuoted(chars, i)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if c == '\'' || c == '"' {
+            let quoted = copySqlQuoted(chars, i, c)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if startsSqlLineComment(chars, i) {
+            let comment = copySqlLineComment(chars, i)
+            out = "{out}{comment.0}"
+            i = comment.1
+        } else if startsSqlBlockComment(chars, i) {
+            let comment = copySqlBlockComment(chars, i)
+            out = "{out}{comment.0}"
+            i = comment.1
+        } else if c.toInt() == 0x3F && index <= q.params.len() && !questionLooksLikeOperator(chars, i) {
             let marker = placeholder(dialect, index)
             out = "{out}{marker}"
             index = index + 1
+            i = i + 1
         } else {
             out = "{out}{c}"
+            i = i + 1
         }
     }
     out
@@ -190,13 +215,38 @@ pub fn render(q: Query, dialect: Dialect) -> String {
 pub fn debugSql(q: Query) -> String {
     let mut out = ""
     let mut index = 0
-    for c in q.sql.chars() {
-        if c.toInt() == 0x3F && index < q.params.len() {
+    let chars = q.sql.chars()
+    let mut i = 0
+    for i < chars.len() {
+        let c = chars[i]
+        if startsSqlDollarQuote(chars, i) {
+            let quoted = copySqlDollarQuoted(chars, i)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if c == '`' {
+            let quoted = copySqlBacktickQuoted(chars, i)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if c == '\'' || c == '"' {
+            let quoted = copySqlQuoted(chars, i, c)
+            out = "{out}{quoted.0}"
+            i = quoted.1
+        } else if startsSqlLineComment(chars, i) {
+            let comment = copySqlLineComment(chars, i)
+            out = "{out}{comment.0}"
+            i = comment.1
+        } else if startsSqlBlockComment(chars, i) {
+            let comment = copySqlBlockComment(chars, i)
+            out = "{out}{comment.0}"
+            i = comment.1
+        } else if c.toInt() == 0x3F && index < q.params.len() && !questionLooksLikeOperator(chars, i) {
             let value = literal(q.params[index])
             out = "{out}{value}"
             index = index + 1
+            i = i + 1
         } else {
             out = "{out}{c}"
+            i = i + 1
         }
     }
     out
@@ -396,6 +446,204 @@ fn appendValues(out: List<Value>, values: List<Value>) {
     for value in values {
         out.push(value)
     }
+}
+
+fn copySqlQuoted(chars: List<Char>, start: Int, quote: Char) -> (String, Int) {
+    let mut out = ""
+    let mut i = start
+    for i < chars.len() {
+        let c = chars[i]
+        out = "{out}{c}"
+        i = i + 1
+        if c.toInt() == 0x5C && i < chars.len() {
+            out = "{out}{chars[i]}"
+            i = i + 1
+            continue
+        }
+        if c == quote {
+            if i < chars.len() && chars[i] == quote {
+                out = "{out}{chars[i]}"
+                i = i + 1
+            } else {
+                return (out, i)
+            }
+        }
+    }
+    (out, i)
+}
+
+fn copySqlBacktickQuoted(chars: List<Char>, start: Int) -> (String, Int) {
+    let mut out = ""
+    let mut i = start
+    for i < chars.len() {
+        let c = chars[i]
+        out = "{out}{c}"
+        i = i + 1
+        if c == '`' {
+            if i < chars.len() && chars[i] == '`' {
+                out = "{out}{chars[i]}"
+                i = i + 1
+            } else {
+                return (out, i)
+            }
+        }
+    }
+    (out, i)
+}
+
+fn startsSqlDollarQuote(chars: List<Char>, i: Int) -> Bool {
+    sqlDollarTagEnd(chars, i) >= 0
+}
+
+fn copySqlDollarQuoted(chars: List<Char>, start: Int) -> (String, Int) {
+    let tagEnd = sqlDollarTagEnd(chars, start)
+    if tagEnd < 0 {
+        return ("{chars[start]}", start + 1)
+    }
+    let tagLen = tagEnd - start + 1
+    let tag = copySqlChars(chars, start, tagEnd + 1)
+    let mut out = tag
+    let mut i = tagEnd + 1
+    for i < chars.len() {
+        if startsWithSqlText(chars, i, tag) {
+            out = "{out}{tag}"
+            return (out, i + tagLen)
+        }
+        out = "{out}{chars[i]}"
+        i = i + 1
+    }
+    (out, i)
+}
+
+fn sqlDollarTagEnd(chars: List<Char>, start: Int) -> Int {
+    if start >= chars.len() || chars[start] != '$' {
+        return -1
+    }
+    let mut i = start + 1
+    for i < chars.len() {
+        if chars[i] == '$' {
+            return i
+        }
+        if !isSqlDollarTagChar(chars[i]) {
+            return -1
+        }
+        i = i + 1
+    }
+    -1
+}
+
+fn isSqlDollarTagChar(c: Char) -> Bool {
+    isIdentContinue(c)
+}
+
+fn startsWithSqlText(chars: List<Char>, index: Int, text: String) -> Bool {
+    let target = text.chars()
+    if index + target.len() > chars.len() {
+        return false
+    }
+    let mut i = 0
+    for i < target.len() {
+        if chars[index + i] != target[i] {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn copySqlChars(chars: List<Char>, start: Int, end: Int) -> String {
+    let mut out = ""
+    let mut i = start
+    for i < end {
+        out = "{out}{chars[i]}"
+        i = i + 1
+    }
+    out
+}
+
+fn startsSqlLineComment(chars: List<Char>, i: Int) -> Bool {
+    i + 1 < chars.len() && chars[i] == '-' && chars[i + 1] == '-'
+}
+
+fn copySqlLineComment(chars: List<Char>, start: Int) -> (String, Int) {
+    let mut out = ""
+    let mut i = start
+    for i < chars.len() {
+        let c = chars[i]
+        out = "{out}{c}"
+        i = i + 1
+        if c == '\n' {
+            return (out, i)
+        }
+    }
+    (out, i)
+}
+
+fn startsSqlBlockComment(chars: List<Char>, i: Int) -> Bool {
+    i + 1 < chars.len() && chars[i] == '/' && chars[i + 1] == '*'
+}
+
+fn copySqlBlockComment(chars: List<Char>, start: Int) -> (String, Int) {
+    let mut out = ""
+    let mut i = start
+    for i < chars.len() {
+        let c = chars[i]
+        out = "{out}{c}"
+        if c == '*' && i + 1 < chars.len() && chars[i + 1] == '/' {
+            out = "{out}{chars[i + 1]}"
+            return (out, i + 2)
+        }
+        i = i + 1
+    }
+    (out, i)
+}
+
+fn questionLooksLikeOperator(chars: List<Char>, index: Int) -> Bool {
+    if index + 1 < chars.len() && (chars[index + 1] == '|' || chars[index + 1] == '&') {
+        return true
+    }
+    match previousNonSqlSpace(chars, index) {
+        Some(prev) -> {
+            match nextNonSqlSpace(chars, index + 1) {
+                Some(next) -> isSqlOperandBoundary(prev) && (isSqlOperandBoundary(next) || next == '?'),
+                None       -> false,
+            }
+        },
+        None -> false,
+    }
+}
+
+fn previousNonSqlSpace(chars: List<Char>, index: Int) -> Char? {
+    if index <= 0 {
+        return None
+    }
+    let mut i = index - 1
+    for i >= 0 {
+        if !isSqlSpace(chars[i]) {
+            return Some(chars[i])
+        }
+        i = i - 1
+    }
+    None
+}
+
+fn nextNonSqlSpace(chars: List<Char>, index: Int) -> Char? {
+    let mut i = index
+    for i < chars.len() {
+        if !isSqlSpace(chars[i]) {
+            return Some(chars[i])
+        }
+        i = i + 1
+    }
+    None
+}
+
+fn isSqlSpace(c: Char) -> Bool {
+    c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+fn isSqlOperandBoundary(c: Char) -> Bool {
+    isIdentContinue(c) || c == '\'' || c == '"' || c == '`' || c == ')' || c == ']' || c == '}'
 }
 
 fn escapeIdent(name: String) -> String {

--- a/internal/stdlib/modules/tar.osty
+++ b/internal/stdlib/modules/tar.osty
@@ -220,10 +220,24 @@ fn validateName(name: String) -> Result<(), Error> {
     if strings.startsWith(name, "/") {
         return Err(error.new("tar: absolute paths are not allowed"))
     }
+    if strings.contains(name, "\\") {
+        return Err(error.new("tar: backslashes are not allowed in entry names"))
+    }
+    if isDriveLetterPath(name) {
+        return Err(error.new("tar: drive-letter paths are not allowed"))
+    }
     if name == ".." || strings.startsWith(name, "../") || strings.endsWith(name, "/..") || strings.contains(name, "/../") {
         return Err(error.new("tar: parent path segments are not allowed"))
     }
     Ok(())
+}
+
+fn isDriveLetterPath(name: String) -> Bool {
+    if name.len() < 2 {
+        return false
+    }
+    let c = name[0]
+    ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) && name[1] == ':'
 }
 
 fn entryTypeFlag(kind: EntryType) -> Int {

--- a/internal/stdlib/modules/websocket.osty
+++ b/internal/stdlib/modules/websocket.osty
@@ -62,14 +62,13 @@ pub fn handshakeHeaders(clientKey: String) -> Headers {
 }
 
 pub fn isHandshake(headers: Headers) -> Bool {
-    let connection = strings.toLower(header(headers, "Connection") ?? "")
-    let upgrade = strings.toLower(header(headers, "Upgrade") ?? "")
+    let upgrade = strings.toLower(strings.trimSpace(header(headers, "Upgrade") ?? ""))
     let version = strings.trimSpace(header(headers, "Sec-WebSocket-Version") ?? "")
     let key = strings.trimSpace(header(headers, "Sec-WebSocket-Key") ?? "")
-    strings.contains(connection, "upgrade") &&
+    hasConnectionToken(header(headers, "Connection") ?? "", "upgrade") &&
     upgrade == "websocket" &&
     version == "13" &&
-    !key.isEmpty()
+    isValidClientKey(key)
 }
 
 pub fn text(value: String) -> Frame {
@@ -259,6 +258,23 @@ fn header(headers: Headers, name: String) -> String? {
         }
     }
     None
+}
+
+fn hasConnectionToken(value: String, token: String) -> Bool {
+    let wanted = strings.toLower(strings.trimSpace(token))
+    for part in strings.split(value, ",") {
+        if strings.toLower(strings.trimSpace(part)) == wanted {
+            return true
+        }
+    }
+    false
+}
+
+fn isValidClientKey(key: String) -> Bool {
+    match encoding.base64.decode(strings.trimSpace(key)) {
+        Ok(decoded) -> decoded.len() == 16,
+        Err(_)      -> false,
+    }
 }
 
 fn opcodeFromCode(code: Int) -> Result<Opcode, Error> {

--- a/internal/stdlib/sql_test.go
+++ b/internal/stdlib/sql_test.go
@@ -56,8 +56,15 @@ func TestSqlModuleSourcePinsBuilderBehavior(t *testing.T) {
 		`pub fn quoteIdent(name: String) -> Result<String, Error>`,
 		`pub fn placeholder(dialect: Dialect, index: Int) -> String`,
 		`pub fn render(q: Query, dialect: Dialect) -> String`,
+		`pub fn debugSql(q: Query) -> String`,
 		`pub fn insert(table: String, values: List<Assignment>) -> Result<Query, Error>`,
 		`strings.replaceAll(value, "'", "''")`,
+		`copySqlQuoted(chars, i, c)`,
+		`startsSqlDollarQuote(chars, i)`,
+		`copySqlBacktickQuoted(chars, i)`,
+		`c.toInt() == 0x5C`,
+		`startsSqlLineComment(chars, i)`,
+		`questionLooksLikeOperator(chars, i)`,
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("std.sql source missing %q", want)

--- a/internal/stdlib/tar_test.go
+++ b/internal/stdlib/tar_test.go
@@ -49,6 +49,8 @@ func TestTarModuleSourcePinsUstarBehavior(t *testing.T) {
 		`writeStringField(header, 257, 6, "ustar")`,
 		`writeOctalField(header, 148, 8, checksum(header))`,
 		`fn checksumBlock(data: Bytes, offset: Int) -> Int`,
+		`strings.contains(name, "\\")`,
+		`fn isDriveLetterPath(name: String) -> Bool`,
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("std.tar source missing %q", want)

--- a/internal/stdlib/websocket_test.go
+++ b/internal/stdlib/websocket_test.go
@@ -48,6 +48,11 @@ func TestWebsocketModuleSourcePinsHandshakeAndFrameBehavior(t *testing.T) {
 		`out.insert("Sec-WebSocket-Accept", acceptKey(clientKey))`,
 		`pub fn encode(frame: Frame) -> Result<Bytes, Error>`,
 		`pub fn decode(data: Bytes) -> Result<DecodedFrame, Error>`,
+		`strings.toLower(strings.trimSpace(header(headers, "Upgrade") ?? ""))`,
+		`fn hasConnectionToken(value: String, token: String) -> Bool`,
+		`strings.split(value, ",")`,
+		`fn isValidClientKey(key: String) -> Bool`,
+		`decoded.len() == 16`,
 		`fn xorByte(a: Int, b: Int) -> Int`,
 	} {
 		if !strings.Contains(src, want) {


### PR DESCRIPTION
## Summary
- harden tar entry names, WebSocket handshakes, MIME attachment filenames, SMTP DATA blocks, and cookie rendering
- make SQL placeholder rendering skip quoted strings, comments, dollar-quoted literals, backtick identifiers, and likely dialect operators
- align email/smtp DATA handling around a single canonical dot-stuffing step

## Validation
- `go run ./cmd/osty tokens internal/stdlib/modules/sql.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/email.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/smtp.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/websocket.osty`
- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(Smtp|BigGap|Email|Sql|Websocket|Http|Tar)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult(Smtp|BigGaps|Email|Sql|Websocket|Http|Tar)' -v`
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend`
- `just fmt-check`
- `git diff --check`