### PR TITLE
[codex] fix smtp rendering and script binding bridge

### DIFF
--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
 )
 
@@ -145,5 +148,57 @@ runtime = true
 	}
 	if !pkg.RuntimeCapability {
 		t.Fatal("RuntimeCapability = false, want true")
+	}
+}
+
+func TestNativeResolveBridgeIndexesScriptScopeBindings(t *testing.T) {
+	src := []byte("let x = 1\nlet y = x\n")
+	file, parseDiags := parser.ParseDiagnostics(src)
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	if len(file.Stmts) != 2 {
+		t.Fatalf("script stmt count = %d, want 2", len(file.Stmts))
+	}
+	letY, ok := file.Stmts[1].(*ast.LetStmt)
+	if !ok {
+		t.Fatalf("second stmt = %T, want *ast.LetStmt", file.Stmts[1])
+	}
+	refX, ok := letY.Value.(*ast.Ident)
+	if !ok {
+		t.Fatalf("second let value = %T, want *ast.Ident", letY.Value)
+	}
+
+	res := ResolveFileSourceDefault(src, file, nil)
+	for _, d := range res.Diags {
+		if d != nil && d.Severity == diag.Error {
+			t.Fatalf("resolve diagnostic: %s: %s", d.Code, d.Message)
+		}
+	}
+
+	sym := res.RefsByID[refX.ID]
+	if sym == nil {
+		t.Fatalf("script ref %q was not bridged", refX.Name)
+	}
+	if sym.Kind != SymLet {
+		t.Fatalf("script ref kind = %s, want %s", sym.Kind, SymLet)
+	}
+	binding, ok := sym.Decl.(*ast.IdentPat)
+	if !ok {
+		t.Fatalf("script ref decl = %T, want *ast.IdentPat", sym.Decl)
+	}
+	if binding.Name != "x" {
+		t.Fatalf("script ref decl name = %q, want x", binding.Name)
+	}
+	if sym.Pos.Offset != binding.Pos().Offset {
+		t.Fatalf("script ref pos offset = %d, want binding offset %d", sym.Pos.Offset, binding.Pos().Offset)
+	}
+
+	scopeSym := res.FileScope.Lookup("x")
+	if scopeSym == nil {
+		t.Fatal("script binding x missing from bridged file scope chain")
+	}
+	if _, ok := scopeSym.Decl.(*ast.IdentPat); !ok {
+		t.Fatalf("script scope decl = %T, want *ast.IdentPat", scopeSym.Decl)
 	}
 }

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -209,6 +209,9 @@ func buildDeclIndex(file *ast.File) map[int]ast.Node {
 		}
 		walkDeclChildren(d, idx)
 	}
+	for _, s := range file.Stmts {
+		indexStmtBindings(s, idx)
+	}
 	return idx
 }
 

--- a/internal/stdlib/big_gaps_test.go
+++ b/internal/stdlib/big_gaps_test.go
@@ -71,6 +71,7 @@ func TestBigGapModuleSourcePinsBehavior(t *testing.T) {
 			`pub fn dotStuff(data: String) -> String`,
 			`pub fn dataBlock(data: String) -> String`,
 			`out.push(ensureDataBlock(tx.envelope.data))`,
+			`if !strings.endsWith(cmd, crlf())`,
 			`fn ensureDataBlock(data: String) -> String`,
 			`dataBlock(data)`,
 			`strings.endsWith(data, "{crlf()}.{crlf()}")`,

--- a/internal/stdlib/modules/smtp.osty
+++ b/internal/stdlib/modules/smtp.osty
@@ -232,7 +232,10 @@ pub fn commands(tx: Transaction) -> Result<List<String>, Error> {
 pub fn renderCommands(commands: List<String>) -> String {
     let mut out = ""
     for cmd in commands {
-        out = "{out}{cmd}{crlf()}"
+        out = "{out}{cmd}"
+        if !strings.endsWith(cmd, crlf()) {
+            out = "{out}{crlf()}"
+        }
     }
     out
 }


### PR DESCRIPTION
## Summary
- Avoid adding an extra command separator after SMTP DATA blocks that already include their protocol terminator.
- Include script-level statements in the native resolver bridge declaration index so script-scope bindings project back to Go AST binding nodes.
- Add regression coverage for script-scope binding projection and pin the SMTP rendering guard in stdlib source checks.

## Validation
- `go run ./cmd/osty tokens internal/stdlib/modules/smtp.osty`
- `go test -count=1 -vet=off ./internal/resolve -run 'TestNativeResolveBridgeIndexesScriptScopeBindings' -v`
- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(SmtpModuleSurface|BigGapModuleSourcePinsBehavior)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultBigGaps' -v`
- `go test -count=1 -vet=off ./internal/stdlib ./internal/backend ./internal/resolve`
- `just fmt-check`
- `git diff --check`