### PR TITLE
[codex] simplify backend dispatch diagnostics

### DIFF
--- a/cmd/osty/backend_helpers.go
+++ b/cmd/osty/backend_helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/runner"
@@ -95,6 +96,9 @@ func backendFromCLI(tool string, name backend.Name) backend.Backend {
 func exitBackendEmitError(tool string, result *backend.Result, err error) {
 	if errors.Is(err, backend.ErrLLVMNotImplemented) {
 		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		if detail := backendUnsupportedDetail(result); detail != nil {
+			fmt.Fprintf(os.Stderr, "  detail: %v\n", detail)
+		}
 		if result != nil {
 			if artifact := result.Artifacts.SourcePath(); artifact != "" {
 				fmt.Fprintf(os.Stderr, "  artifact: %s\n", artifact)
@@ -107,4 +111,24 @@ func exitBackendEmitError(tool string, result *backend.Result, err error) {
 	}
 	fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
 	os.Exit(1)
+}
+
+func backendUnsupportedDetail(r *backend.Result) error {
+	if r == nil {
+		return nil
+	}
+	var fallback error
+	for _, warning := range r.Warnings {
+		if warning == nil || errors.Is(warning, backend.ErrLLVMNotImplemented) {
+			continue
+		}
+		if fallback == nil {
+			fallback = warning
+		}
+		msg := warning.Error()
+		if strings.Contains(msg, "LLVM0") || strings.Contains(msg, "backend-route:") {
+			return warning
+		}
+	}
+	return fallback
 }

--- a/cmd/osty/backend_helpers_test.go
+++ b/cmd/osty/backend_helpers_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/backend"
+)
+
+func TestBackendUnsupportedDetailPrefersStructuredLLVMRoute(t *testing.T) {
+	result := &backend.Result{
+		Warnings: []error{
+			errors.New("lowering warning without route"),
+			errors.New("LLVM013 expression: call target; hint: reduce; backend-route: mir-direct"),
+			backend.ErrLLVMNotImplemented,
+		},
+	}
+
+	got := backendUnsupportedDetail(result)
+	if got == nil {
+		t.Fatal("backendUnsupportedDetail returned nil")
+	}
+	if want := "backend-route: mir-direct"; !strings.Contains(got.Error(), want) {
+		t.Fatalf("detail = %q, want substring %q", got.Error(), want)
+	}
+}

--- a/cmd/osty/gen_emit.go
+++ b/cmd/osty/gen_emit.go
@@ -58,9 +58,6 @@ func emitGenLLVMIR(entry backend.Entry, pkgEntry *genPackageEntry) ([]byte, []er
 	if out, ok, warnings, err := tryExternalGenLLVMIR(pkgEntry); err == nil && ok {
 		return out, warnings, nil
 	}
-	if out, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(entry, ""); err == nil && ok {
-		return out, warnings, nil
-	}
 	return backend.EmitLLVMIRText(entry, "", nil)
 }
 

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -4,9 +4,27 @@
 // The CLI routes native emission through this package so every backend
 // uses the same artifact / cache layout contract. The LLVM dispatcher
 // (llvm.go) consumes IR exclusively: Request.Entry.IR is the sole
-// input it hands to llvmgen. The dispatcher no longer falls back to
-// Request.Entry.File when IR lowering hits an unsupported shape —
-// unsupported input produces an inspectable skeleton artifact instead.
+// semantic input it hands to llvmgen. Request.Entry.MIR is the optional
+// MIR projection prepared from that same IR for the MIR-direct emitter.
+// The dispatcher never falls back to Request.Entry.File when lowering
+// hits an unsupported shape.
+//
+// Dispatch order is intentionally small and observable:
+//
+//   - IR preflight rejects backend-capability gaps such as Go FFI or
+//     unknown runtime FFI before any concrete emitter is selected.
+//   - the native-owned llvmgen slice gets the first chance when the
+//     feature set allows it and no injected stdlib bodies are present.
+//   - every remaining normal backend request routes through MIR-direct
+//     emission; the legacy IR bridge is only a last resort for direct
+//     callers that provide no MIR.
+//
+// Unsupported input is not a fatal compiler crash and is not silently
+// retried through an older AST path. The backend writes an inspectable
+// skeleton artifact, returns ErrLLVMNotImplemented, and includes the
+// structured LLVM00x diagnostic plus the backend route in Result.Warnings.
+// Set OSTY_BACKEND_TRACE=1 to stream the selected LLVM dispatch route to
+// stderr while debugging backend selection.
 //
 // LLVM lowering is still small, but it can produce textual IR and
 // drive a host clang toolchain for supported object / binary

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -23,6 +23,15 @@ type llvmToolchain interface {
 	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string) error
 }
 
+type llvmDispatchRoute string
+
+const (
+	llvmDispatchUnsupportedPreflight llvmDispatchRoute = "unsupported-preflight"
+	llvmDispatchNativeOwned          llvmDispatchRoute = "native-owned"
+	llvmDispatchMIRDirect            llvmDispatchRoute = "mir-direct"
+	llvmDispatchLegacyIRBridge       llvmDispatchRoute = "legacy-ir-bridge"
+)
+
 // LLVMBackend emits textual LLVM IR and can drive a host LLVM-compatible
 // toolchain for object/binary artifacts.
 type LLVMBackend struct {
@@ -149,12 +158,23 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	if entry.IR == nil {
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
+	warnings := append([]error(nil), entry.IRIssues...)
+	if diag, ok := llvmgen.UnsupportedDiagnosticForModule(entry.IR); ok {
+		traceLLVMDispatch("%s rejected %s: %s %s", llvmDispatchUnsupportedPreflight, entry.SourcePath, diag.Code, diag.Kind)
+		return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, llvmDispatchUnsupportedPreflight)
+	}
 	if useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR) {
+		traceLLVMDispatch("%s try package=%s source=%s emit=%s target=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath, emit, target)
 		if out, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
+			traceLLVMDispatch("%s error: %v", llvmDispatchNativeOwned, err)
 			return nil, warnings, err
 		} else if ok {
+			traceLLVMDispatch("%s covered package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
 			return out, warnings, nil
 		}
+		traceLLVMDispatch("%s declined package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
+	} else {
+		traceLLVMDispatch("%s skipped package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
 	}
 	opts := llvmgen.Options{
 		PackageName: entry.PackageName,
@@ -173,30 +193,72 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// emitter. MIR refusal now surfaces as the normal unsupported
 	// skeleton diagnostic; the LLVM backend no longer retries the
 	// legacy HIR bridge behind the user's back.
-	var (
-		irOut  []byte
-		genErr error
-	)
-	if opts.UseMIR && entry.MIR != nil {
-		irOut, genErr = llvmgen.GenerateFromMIR(entry.MIR, opts)
-	} else {
-		irOut, genErr = llvmgen.GenerateModule(entry.IR, opts)
-	}
-	warnings := append([]error(nil), entry.IRIssues...)
+	route := llvmFallbackDispatchRoute(opts, entry)
+	traceLLVMDispatch("%s emit package=%s source=%s emit=%s target=%s", route, entry.PackageName, entry.SourcePath, emit, target)
+	irOut, genErr := emitLLVMFallback(route, entry, opts)
 	if genErr == nil {
+		traceLLVMDispatch("%s succeeded package=%s source=%s", route, entry.PackageName, entry.SourcePath)
 		return irOut, warnings, nil
 	}
+	traceLLVMDispatch("%s unsupported: %v", route, genErr)
 	diag := llvmgen.UnsupportedDiagnosticForError(genErr)
-	return llvmgen.RenderSkeleton(
-			entry.PackageName,
-			entry.SourcePath,
-			string(emit),
-			target,
-			errors.New(llvmgen.UnsupportedSummary(diag)),
-		), append(warnings,
-			errors.New(llvmgen.UnsupportedSummary(diag)),
-			ErrLLVMNotImplemented,
-		), ErrLLVMNotImplemented
+	return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, route)
+}
+
+func llvmFallbackDispatchRoute(opts llvmgen.Options, entry Entry) llvmDispatchRoute {
+	if opts.UseMIR && entry.MIR != nil {
+		return llvmDispatchMIRDirect
+	}
+	return llvmDispatchLegacyIRBridge
+}
+
+func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmgen.Options) ([]byte, error) {
+	switch route {
+	case llvmDispatchMIRDirect:
+		return llvmgen.GenerateFromMIR(entry.MIR, opts)
+	default:
+		return llvmgen.GenerateModule(entry.IR, opts)
+	}
+}
+
+func renderUnsupportedLLVMIR(entry Entry, target string, emit EmitMode, warnings []error, diag llvmgen.UnsupportedDiagnostic, route llvmDispatchRoute) ([]byte, []error, error) {
+	summary := llvmUnsupportedTraceSummary(diag, route)
+	skeleton := llvmgen.RenderSkeleton(
+		entry.PackageName,
+		entry.SourcePath,
+		string(emit),
+		target,
+		errors.New(summary),
+	)
+	warnings = append(warnings,
+		errors.New(summary),
+		ErrLLVMNotImplemented,
+	)
+	return skeleton, warnings, ErrLLVMNotImplemented
+}
+
+func llvmUnsupportedTraceSummary(diag llvmgen.UnsupportedDiagnostic, route llvmDispatchRoute) string {
+	summary := llvmgen.UnsupportedSummary(diag)
+	if route == "" {
+		return summary
+	}
+	return summary + "; backend-route: " + string(route)
+}
+
+func traceLLVMDispatch(format string, args ...any) {
+	if !llvmBackendTraceEnabled() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "backend trace: llvm "+format+"\n", args...)
+}
+
+func llvmBackendTraceEnabled() bool {
+	switch os.Getenv("OSTY_BACKEND_TRACE") {
+	case "", "0", "false", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 func hasInjectedStdlibBodies(mod *ir.Module) bool {

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -886,6 +887,45 @@ func TestLLVMBackendRefusesNilIR(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing lowered IR entry") {
 		t.Fatalf("expected IR-missing diagnostic, got: %v", err)
+	}
+}
+
+func TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug(t *testing.T) {
+	t.Parallel()
+
+	backend := LLVMBackend{toolchain: &fakeLLVMToolchain{}}
+	req := newBackendRequest(t, EmitLLVMIR, `use go "strings" as strings {
+    fn ToUpper(s: String) -> String
+}
+
+fn main() {
+    println(1)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if !errors.Is(err, ErrLLVMNotImplemented) {
+		t.Fatalf("Emit error = %v, want ErrLLVMNotImplemented", err)
+	}
+	if result == nil {
+		t.Fatal("Emit result is nil")
+	}
+	gotBytes, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	got := string(gotBytes)
+	for _, want := range []string{
+		"Osty LLVM backend skeleton",
+		"LLVM001 foreign-ffi",
+		"backend-route: unsupported-preflight",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("unsupported skeleton missing %q:\n%s", want, got)
+		}
+	}
+	if warningContaining(result.Warnings, "backend-route: unsupported-preflight") == nil {
+		t.Fatalf("warnings = %v, want backend route detail", result.Warnings)
 	}
 }
 

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -9,6 +9,9 @@
 //     ([]byte, bool, error) — native-owned primitive/control-flow
 //     fast path only. Returns ok=false when the module should continue
 //     through the broader MIR backend path.
+//   - UnsupportedDiagnosticForModule(*ir.Module)
+//     (UnsupportedDiagnostic, bool) — preflight backend-capability
+//     policy before a concrete emitter route is selected.
 //
 // The package previously exposed Generate(*ast.File, Options) as an
 // alternate entry point. That AST route has been removed: the LLVM
@@ -32,8 +35,15 @@
 // generalisation for `Float` and `String` payload enums and the phase
 // 64-73 value/control-flow smoke expansion.
 //
-// Unsupported shapes return ErrUnsupported so the backend dispatcher
-// can render inspectable skeleton IR while the backend grows.
+// Unsupported shapes return ErrUnsupported carrying an UnsupportedDiagnostic
+// when the failure is a known policy category. The mapping is stable:
+// LLVM001/LLVM002 are backend-capability gaps (Go FFI and unknown runtime FFI),
+// LLVM010-LLVM018 classify source/layout/type/call/name/stdlib gaps, and
+// LLVM000 is the generic fallback. The backend dispatcher renders these as
+// inspectable skeleton IR and appends its selected route
+// (unsupported-preflight, native-owned, mir-direct, or legacy-ir-bridge) to
+// the warning text so traces explain both what failed and which backend path
+// observed it.
 //
 // Implementation note (transitional)
 //

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -66,7 +66,7 @@ func prepareModuleGeneration(mod *ostyir.Module) error {
 	if err := validateLegacyFFISurface(mod); err != nil {
 		return err
 	}
-	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
+	if diag, ok := UnsupportedDiagnosticForModule(mod); ok {
 		return &UnsupportedError{Diagnostic: diag}
 	}
 	return nil
@@ -217,7 +217,12 @@ func appendExportAliases(out []byte, mod *ostyir.Module) []byte {
 	return out
 }
 
-func moduleUnsupportedDiagnostic(mod *ostyir.Module) (UnsupportedDiagnostic, bool) {
+// UnsupportedDiagnosticForModule reports backend-capability gaps that are
+// visible from the backend-neutral IR before a concrete LLVM emitter is chosen.
+// The backend dispatcher uses this as a preflight gate so Go-only FFI and
+// unknown runtime FFI imports cannot accidentally slip through a broader
+// fallback path.
+func UnsupportedDiagnosticForModule(mod *ostyir.Module) (UnsupportedDiagnostic, bool) {
 	if mod == nil {
 		return UnsupportedDiagnostic{}, false
 	}


### PR DESCRIPTION
## Summary

- Simplify LLVM backend dispatch so `osty gen` routes through the backend helper instead of duplicating the native-owned fast path.
- Add unsupported preflight diagnostics for backend capability gaps and include the selected backend route in skeleton warnings.
- Document the unsupported policy and add focused regression coverage for route-aware diagnostics and CLI detail selection.

## Validation

- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug|TestLLVMBackendRefusesNilIR|TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered|TestUseNativeOwnedLLVMIR'`
- `go test -count=1 -vet=off ./cmd/osty -run 'TestBackendUnsupportedDetailPrefersStructuredLLVMRoute|TestEmitGenArtifactUsesNativeOwnedFastPath|TestEmitGenArtifactUsesManagedNativeLLVMGenWhenCovered|TestEmitGenArtifactUsesMIRDirectForStdTesting'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestUnsupportedDiagnostic|TestGeneratedRenderSkeletonInterpolatesQuotedFields|TestGenerateUnknownRuntimeFFIStillReportsLLVM002'`
- `git diff --check`