### PR TITLE
[codex] centralize stdlib builtin surface

### DIFF
--- a/internal/backend/stdlib_inject_test.go
+++ b/internal/backend/stdlib_inject_test.go
@@ -146,6 +146,97 @@ func TestReachableStdlibMethodsFindsEncodingSingletonMethod(t *testing.T) {
 	}
 }
 
+func TestReachableStdlibValuePathReceiversMatchBackendSpecialCases(t *testing.T) {
+	reg := stdlib.LoadCached()
+	cases := []struct {
+		name      string
+		module    string
+		path      []string
+		valuePath string
+		method    string
+		typeName  string
+		check     func(*testing.T, *ir.StructLit)
+	}{
+		{
+			name:      "encoding base64",
+			module:    "encoding",
+			path:      []string{"base64"},
+			valuePath: "base64",
+			method:    "encode",
+			typeName:  "Base64",
+			check: func(t *testing.T, st *ir.StructLit) {
+				url := requireStructField(t, st, "url")
+				requireStructReceiver(t, url, "encoding", "Base64Url")
+			},
+		},
+		{name: "encoding base64 url", module: "encoding", path: []string{"base64", "url"}, valuePath: "base64.url", method: "encode", typeName: "Base64Url"},
+		{name: "encoding hex", module: "encoding", path: []string{"hex"}, valuePath: "hex", method: "encode", typeName: "Hex"},
+		{name: "encoding url", module: "encoding", path: []string{"url"}, valuePath: "url", method: "encode", typeName: "UrlEncoding"},
+		{name: "compress gzip", module: "compress", path: []string{"gzip"}, valuePath: "gzip", method: "encode", typeName: "Gzip"},
+		{name: "crypto hmac", module: "crypto", path: []string{"hmac"}, valuePath: "hmac", method: "sha256", typeName: "Hmac"},
+		{name: "os path", module: "os", path: []string{"path"}, valuePath: "path", method: "basename", typeName: "Path"},
+		{
+			name:      "net localhost v4",
+			module:    "net",
+			path:      []string{"LOCALHOST_V4"},
+			valuePath: "LOCALHOST_V4",
+			method:    "toString",
+			typeName:  "Ipv4Addr",
+			check: func(t *testing.T, st *ir.StructLit) {
+				requireIntField(t, st, "a", "127")
+				requireIntField(t, st, "b", "0")
+				requireIntField(t, st, "c", "0")
+				requireIntField(t, st, "d", "1")
+			},
+		},
+		{
+			name:      "net unspecified v6",
+			module:    "net",
+			path:      []string{"UNSPECIFIED_V6"},
+			valuePath: "UNSPECIFIED_V6",
+			method:    "toString",
+			typeName:  "Ipv6Addr",
+			check: func(t *testing.T, st *ir.StructLit) {
+				requireIntListField(t, st, "groups", []string{"0", "0", "0", "0", "0", "0", "0", "0"})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := &ir.ExprStmt{X: &ir.MethodCall{
+				Receiver: stdlibPathExprForTest(tc.module, tc.path),
+				Name:     tc.method,
+			}}
+			mod := &ir.Module{Package: "main", Script: []ir.Stmt{stmt}}
+			reached := ReachableStdlibMethods(mod, reg)
+			if len(reached) != 1 {
+				t.Fatalf("ReachableStdlibMethods = %d entries (%v), want 1", len(reached), reached)
+			}
+			if reached[0].Module != tc.module || reached[0].Type != tc.typeName ||
+				reached[0].Method != tc.method || reached[0].ValuePath != tc.valuePath {
+				t.Fatalf("reached[0] = {%s, %s, %s, %s}, want {%s, %s, %s, %s}",
+					reached[0].Module, reached[0].Type, reached[0].Method, reached[0].ValuePath,
+					tc.module, tc.typeName, tc.method, tc.valuePath)
+			}
+			if got := RewriteStdlibMethodCallsites(mod, reached); got != 1 {
+				t.Fatalf("RewriteStdlibMethodCallsites rewrote %d callsites, want 1", got)
+			}
+			call, ok := stmt.X.(*ir.CallExpr)
+			if !ok {
+				t.Fatalf("rewritten stmt.X = %T, want *ir.CallExpr", stmt.X)
+			}
+			if len(call.Args) == 0 || call.Args[0].Value == nil {
+				t.Fatalf("rewritten call args = %#v, want receiver prepended", call.Args)
+			}
+			receiver := requireStructReceiver(t, call.Args[0].Value, tc.module, tc.typeName)
+			if tc.check != nil {
+				tc.check(t, receiver)
+			}
+		})
+	}
+}
+
 func TestReachableStdlibMethodsKeepsSingletonPathWhenTypedReceiverAlsoReached(t *testing.T) {
 	reg := stdlib.LoadCached()
 	b64T := &ir.NamedType{Package: "encoding", Name: "Base64"}
@@ -174,6 +265,71 @@ func TestReachableStdlibMethodsKeepsSingletonPathWhenTypedReceiverAlsoReached(t 
 	}
 	if got[0].ValuePath != "base64" {
 		t.Fatalf("got[0].ValuePath = %q, want base64", got[0].ValuePath)
+	}
+}
+
+func stdlibPathExprForTest(module string, path []string) ir.Expr {
+	var expr ir.Expr = &ir.Ident{Name: module}
+	for _, part := range path {
+		expr = &ir.FieldExpr{X: expr, Name: part}
+	}
+	return expr
+}
+
+func requireStructReceiver(t *testing.T, expr ir.Expr, module, typeName string) *ir.StructLit {
+	t.Helper()
+	st, ok := expr.(*ir.StructLit)
+	if !ok {
+		t.Fatalf("receiver = %T, want *ir.StructLit", expr)
+	}
+	if st.TypeName != typeName {
+		t.Fatalf("receiver TypeName = %q, want %q", st.TypeName, typeName)
+	}
+	named, ok := st.T.(*ir.NamedType)
+	if !ok || named.Package != module || named.Name != typeName {
+		t.Fatalf("receiver type = %#v, want %s.%s", st.T, module, typeName)
+	}
+	return st
+}
+
+func requireStructField(t *testing.T, st *ir.StructLit, name string) ir.Expr {
+	t.Helper()
+	for _, field := range st.Fields {
+		if field.Name == name {
+			if field.Value == nil {
+				t.Fatalf("field %s has nil value", name)
+			}
+			return field.Value
+		}
+	}
+	t.Fatalf("field %s missing from %#v", name, st.Fields)
+	return nil
+}
+
+func requireIntField(t *testing.T, st *ir.StructLit, name, text string) {
+	t.Helper()
+	value := requireStructField(t, st, name)
+	lit, ok := value.(*ir.IntLit)
+	if !ok || lit.Text != text || lit.T != ir.TInt {
+		t.Fatalf("field %s = %#v, want IntLit(%s)", name, value, text)
+	}
+}
+
+func requireIntListField(t *testing.T, st *ir.StructLit, name string, want []string) {
+	t.Helper()
+	value := requireStructField(t, st, name)
+	list, ok := value.(*ir.ListLit)
+	if !ok || list.Elem != ir.TInt {
+		t.Fatalf("field %s = %#v, want List<Int>", name, value)
+	}
+	if len(list.Elems) != len(want) {
+		t.Fatalf("field %s len = %d, want %d", name, len(list.Elems), len(want))
+	}
+	for i, elem := range list.Elems {
+		lit, ok := elem.(*ir.IntLit)
+		if !ok || lit.Text != want[i] || lit.T != ir.TInt {
+			t.Fatalf("field %s[%d] = %#v, want IntLit(%s)", name, i, elem, want[i])
+		}
 	}
 }
 

--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -10,29 +10,6 @@ import (
 	"github.com/osty/osty/internal/stdlib"
 )
 
-// stdlibInjectableTypes lists the built-in generic types that live in
-// stdlib modules and whose bodied methods should be monomorphized
-// alongside user code. Each entry pairs the surface name (as written
-// by user code) with the stdlib module that holds its StructDecl or
-// EnumDecl.
-//
-// Option B's foundation: once these decls land in the user's IR
-// module, `ir.Monomorphize` specializes them automatically (the
-// existing generic-struct machinery at internal/ir/monomorph.go's
-// emitStructSpecialization + emitMethodSpecialization already handles
-// the heavy lifting — we just need to feed it the templates).
-var stdlibInjectableTypes = []struct {
-	Name   string // e.g. "Map", "Option"
-	Module string // stdlib module that declares it
-	Kind   string // "struct" | "enum"
-}{
-	{"Map", "collections", "struct"},
-	{"List", "collections", "struct"},
-	{"Set", "collections", "struct"},
-	{"Option", "option", "enum"},
-	{"Result", "result", "enum"},
-}
-
 type stdlibTypeKey struct {
 	Module string
 	Name   string
@@ -219,8 +196,10 @@ func collectReferencedStdlibTypes(mod *ir.Module) []stdlibTypeKey {
 		return nil
 	}
 	builtinModule := map[string]string{}
-	for _, t := range stdlibInjectableTypes {
-		builtinModule[t.Name] = t.Module
+	for _, surface := range stdlib.BuiltinTypeSurfaces() {
+		if surface.Injectable {
+			builtinModule[surface.Name] = surface.Module
+		}
 	}
 	seen := map[stdlibTypeKey]bool{}
 	var out []stdlibTypeKey
@@ -679,12 +658,8 @@ func lowerStdlibModule(reg *stdlib.Registry, module string) []ir.Decl {
 }
 
 func isInjectableTypeName(name string) bool {
-	for _, t := range stdlibInjectableTypes {
-		if t.Name == name {
-			return true
-		}
-	}
-	return false
+	surface, ok := stdlib.BuiltinTypeSurfaceByName(name)
+	return ok && surface.Injectable
 }
 
 // cloneStdlibTypeDecl deep-clones a StructDecl or EnumDecl so the
@@ -837,12 +812,11 @@ func qualifiedStdlibTypeName(module, name string) string {
 // diagnostics: given a built-in type name, returns the stdlib module
 // that declares it, or "" if unknown.
 func moduleForStdlibType(name string) string {
-	for _, t := range stdlibInjectableTypes {
-		if t.Name == name {
-			return t.Module
-		}
+	surface, ok := stdlib.BuiltinTypeSurfaceByName(name)
+	if !ok || !surface.Injectable {
+		return ""
 	}
-	return ""
+	return surface.Module
 }
 
 // The walker relies on ir.Walk visiting concrete types via their

--- a/internal/backend/stdlib_type_inject_test.go
+++ b/internal/backend/stdlib_type_inject_test.go
@@ -229,6 +229,58 @@ fn main() {}
 	}
 }
 
+func TestInjectReachableStdlibTypesUsesStdlibBuiltinSurfaceTable(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name: "touch",
+				Params: []*ir.Param{
+					{Name: "list", Type: &ir.NamedType{Name: "List", Builtin: true, Args: []ir.Type{ir.TInt}}},
+					{Name: "map", Type: &ir.NamedType{Name: "Map", Builtin: true, Args: []ir.Type{ir.TString, ir.TInt}}},
+					{Name: "set", Type: &ir.NamedType{Name: "Set", Builtin: true, Args: []ir.Type{ir.TString}}},
+					{Name: "option", Type: &ir.NamedType{Name: "Option", Builtin: true, Args: []ir.Type{ir.TInt}}},
+					{Name: "result", Type: &ir.NamedType{Name: "Result", Builtin: true, Args: []ir.Type{ir.TInt, &ir.NamedType{Name: "Error", Builtin: true}}}},
+				},
+				Return: ir.TUnit,
+				Body:   &ir.Block{},
+			},
+		},
+	}
+	reg := stdlib.LoadCached()
+	injected, _ := injectReachableStdlibTypes(mod, reg)
+
+	want := map[string]string{}
+	for _, surface := range stdlib.BuiltinTypeSurfaces() {
+		if surface.Injectable {
+			want[surface.Name] = surface.Module
+		}
+	}
+	got := map[string]bool{}
+	for _, d := range injected {
+		switch x := d.(type) {
+		case *ir.StructDecl:
+			got[x.Name] = true
+		case *ir.EnumDecl:
+			got[x.Name] = true
+		}
+	}
+	for name, module := range want {
+		if !got[name] {
+			t.Fatalf("injectReachableStdlibTypes did not inject prelude builtin %s from std.%s; got %v", name, module, got)
+		}
+		if gotModule := moduleForStdlibType(name); gotModule != module {
+			t.Fatalf("moduleForStdlibType(%s) = %q, want %q from stdlib surface table", name, gotModule, module)
+		}
+		if !isInjectableTypeName(name) {
+			t.Fatalf("isInjectableTypeName(%s) = false, want true from stdlib surface table", name)
+		}
+	}
+	if got["Error"] {
+		t.Fatalf("Error was injected as a generic builtin template; only method-specializable generic surfaces should inject")
+	}
+}
+
 // TestInjectReachableStdlibTypesKeepsStdlibLayoutsQualified guards the
 // #1093 stdlib-type injection collision: importing a module like std.smtp
 // pulls in its internal Reply struct for injected bodies, but that must not

--- a/internal/stdlib/lookup_test.go
+++ b/internal/stdlib/lookup_test.go
@@ -1,6 +1,11 @@
 package stdlib
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
 
 func TestLookupFnDeclFindsStringsCompare(t *testing.T) {
 	reg := LoadCached()
@@ -176,4 +181,59 @@ func TestLookupMethodDeclAndFnAreDistinctSurfaces(t *testing.T) {
 	if got := reg.LookupMethodDecl("encoding", "Hex", "encode"); got == nil {
 		t.Fatalf("LookupMethodDecl(encoding, Hex, encode) = nil, want non-nil")
 	}
+}
+
+func TestBuiltinTypeSurfacesBindPreludeBuiltinsToStdlibModules(t *testing.T) {
+	reg := LoadCached()
+	prelude := resolve.NewPrelude()
+	seen := map[string]bool{}
+	for _, surface := range BuiltinTypeSurfaces() {
+		if seen[surface.Name] {
+			t.Fatalf("duplicate builtin type surface for %s", surface.Name)
+		}
+		seen[surface.Name] = true
+		preludeSym := prelude.LookupLocal(surface.Name)
+		if preludeSym == nil || preludeSym.Kind != resolve.SymBuiltin {
+			t.Fatalf("%s prelude symbol = %#v, want SymBuiltin", surface.Name, preludeSym)
+		}
+		mod := reg.Modules[surface.Module]
+		if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil || mod.File == nil {
+			t.Fatalf("%s surface module %q is missing from registry", surface.Name, surface.Module)
+		}
+		moduleSym := mod.Package.PkgScope.LookupLocal(surface.Name)
+		if moduleSym == nil || moduleSym.Kind != resolve.SymBuiltin || moduleSym.Decl != nil {
+			t.Fatalf("%s.%s symbol = %#v, want rebounded prelude builtin with nil Decl",
+				surface.Module, surface.Name, moduleSym)
+		}
+		if !stdlibFileDeclaresBuiltinSurface(mod.File, surface.Name, surface.Kind) {
+			t.Fatalf("%s.%s has no %s declaration backing the builtin surface",
+				surface.Module, surface.Name, surface.Kind)
+		}
+		if surface.Injectable && len(surface.GenericParams) == 0 {
+			t.Fatalf("%s marked injectable without generic params", surface.Name)
+		}
+	}
+}
+
+func stdlibFileDeclaresBuiltinSurface(file *ast.File, name string, kind BuiltinTypeKind) bool {
+	if file == nil {
+		return false
+	}
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.StructDecl:
+			if kind == BuiltinTypeStruct && d.Name == name {
+				return true
+			}
+		case *ast.EnumDecl:
+			if kind == BuiltinTypeEnum && d.Name == name {
+				return true
+			}
+		case *ast.InterfaceDecl:
+			if kind == BuiltinTypeInterface && d.Name == name {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -93,6 +93,63 @@ type Module struct {
 	Package *resolve.Package
 }
 
+// BuiltinTypeKind describes the stdlib declaration shape backing a
+// prelude-owned builtin type.
+type BuiltinTypeKind string
+
+const (
+	BuiltinTypeStruct    BuiltinTypeKind = "struct"
+	BuiltinTypeEnum      BuiltinTypeKind = "enum"
+	BuiltinTypeInterface BuiltinTypeKind = "interface"
+)
+
+// BuiltinTypeSurface records the one stdlib declaration that backs a
+// prelude builtin type. The resolver owns the public symbol identity
+// (SymBuiltin in NewPrelude); the stdlib module owns the source
+// declaration, method bodies, and generic template used by backend
+// injection.
+type BuiltinTypeSurface struct {
+	Name          string
+	Module        string
+	Kind          BuiltinTypeKind
+	GenericParams []string
+	Injectable    bool
+}
+
+var builtinTypeSurfaces = []BuiltinTypeSurface{
+	{Name: "List", Module: "collections", Kind: BuiltinTypeStruct, GenericParams: []string{"T"}, Injectable: true},
+	{Name: "Map", Module: "collections", Kind: BuiltinTypeStruct, GenericParams: []string{"K", "V"}, Injectable: true},
+	{Name: "Set", Module: "collections", Kind: BuiltinTypeStruct, GenericParams: []string{"T"}, Injectable: true},
+	{Name: "Option", Module: "option", Kind: BuiltinTypeEnum, GenericParams: []string{"T"}, Injectable: true},
+	{Name: "Result", Module: "result", Kind: BuiltinTypeEnum, GenericParams: []string{"T", "E"}, Injectable: true},
+	{Name: "Error", Module: "error", Kind: BuiltinTypeInterface},
+}
+
+// BuiltinTypeSurfaces returns the canonical stdlib-owned surfaces for
+// prelude builtin types. The returned slice is detached from the
+// package-level table so callers cannot mutate global registry policy.
+func BuiltinTypeSurfaces() []BuiltinTypeSurface {
+	out := make([]BuiltinTypeSurface, len(builtinTypeSurfaces))
+	for i, surface := range builtinTypeSurfaces {
+		out[i] = surface
+		out[i].GenericParams = append([]string(nil), surface.GenericParams...)
+	}
+	return out
+}
+
+// BuiltinTypeSurfaceByName returns the stdlib surface backing a prelude
+// builtin type.
+func BuiltinTypeSurfaceByName(name string) (BuiltinTypeSurface, bool) {
+	for _, surface := range builtinTypeSurfaces {
+		if surface.Name == name {
+			out := surface
+			out.GenericParams = append([]string(nil), surface.GenericParams...)
+			return out, true
+		}
+	}
+	return BuiltinTypeSurface{}, false
+}
+
 // Load reads every embedded stub, parses it, resolves it against a
 // fresh prelude, and returns a Registry. Parse and resolve diagnostics
 // from every stub are aggregated in Registry.Diags; a well-formed stub
@@ -204,11 +261,17 @@ func cloneRegistry(r *Registry) *Registry {
 	return out
 }
 
-var preludeBuiltinRebinds = map[string][]string{
-	"collections": {"List", "Map", "Set"},
-	"error":       {"Error"},
-	"option":      {"Option"},
-	"result":      {"Result"},
+var preludeBuiltinRebinds = builtinTypeRebindsByModule()
+
+func builtinTypeRebindsByModule() map[string][]string {
+	out := map[string][]string{}
+	for _, surface := range builtinTypeSurfaces {
+		out[surface.Module] = append(out[surface.Module], surface.Name)
+	}
+	for _, names := range out {
+		sort.Strings(names)
+	}
+	return out
 }
 
 // rebindPreludeBuiltinTypes makes stdlib module exports that mirror


### PR DESCRIPTION
## Summary
- Move prelude-backed stdlib builtin type surface metadata into `internal/stdlib` as the canonical source.
- Make backend generic builtin type injection read that stdlib surface instead of maintaining its own duplicate list.
- Add tests for prelude/stdlib ownership, generic builtin injection, and value-path method receiver parity with existing backend special cases.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestReachableStdlib|TestInjectReachableStdlib'`