### PR TITLE
[codex] use structured selfhost api types

### DIFF
--- a/cmd/osty/inspect.go
+++ b/cmd/osty/inspect.go
@@ -20,7 +20,7 @@ func runInspectSource(path string, src []byte, flags cliFlags) {
 	writeInspect(check.InspectSource(src, nil), flags)
 }
 
-func runInspectPackageInput(input selfhost.PackageCheckInput, onlyPath string, flags cliFlags) {
+func runInspectPackageInput(input api.PackageCheckInput, onlyPath string, flags cliFlags) {
 	recs, err := selfhost.InspectPackageStructured(input)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty check --inspect: %v\n", err)

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 // runLintPackage runs the lint pass over every .osty file in dir as a
@@ -105,7 +106,7 @@ func runLintLoadedPackage(
 	return lintPackageOutcome{anyErr: hasError(all), anyWarn: hasWarning(all)}
 }
 
-func lintNativePackageDiagnostics(pkg *resolve.Package, imports []selfhost.PackageCheckImport) ([]*diag.Diagnostic, error) {
+func lintNativePackageDiagnostics(pkg *resolve.Package, imports []api.PackageCheckImport) ([]*diag.Diagnostic, error) {
 	if pkg == nil {
 		return nil, nil
 	}

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -232,11 +233,11 @@ func runTypecheckWorkspaceNative(dir string, flags cliFlags) int {
 // `# <path>` header followed by the single-file printNativeTypes
 // rows for each file that has at least one typed node. Files with
 // no typed nodes are silently skipped so the dump stays compact.
-func printNativePackageTypes(result selfhost.CheckResult, files []selfhost.PackageCheckFile) {
+func printNativePackageTypes(result api.CheckResult, files []api.PackageCheckFile) {
 	if len(result.TypedNodes) == 0 || len(files) == 0 {
 		return
 	}
-	buckets := make(map[int][]selfhost.CheckedNode, len(files))
+	buckets := make(map[int][]api.CheckedNode, len(files))
 	for _, n := range result.TypedNodes {
 		if n.Type == nil {
 			continue
@@ -262,7 +263,7 @@ func printNativePackageTypes(result selfhost.CheckResult, files []selfhost.Packa
 			continue
 		}
 		fmt.Printf("# %s\n", f.Path)
-		printNativeTypes(f.Source, selfhost.CheckResult{TypedNodes: bucket})
+		printNativeTypes(f.Source, api.CheckResult{TypedNodes: bucket})
 	}
 }
 
@@ -385,15 +386,15 @@ func nativeWorkspacePaths(ws *resolve.Workspace) []string {
 	sort.Strings(paths)
 	return paths
 }
-func nativePackageCheckInput(pkg *resolve.Package, imports []selfhost.PackageCheckImport) selfhost.PackageCheckInput {
-	input := selfhost.PackageCheckInput{
-		Files: make([]selfhost.PackageCheckFile, 0, len(pkg.Files)),
+func nativePackageCheckInput(pkg *resolve.Package, imports []api.PackageCheckImport) api.PackageCheckInput {
+	input := api.PackageCheckInput{
+		Files: make([]api.PackageCheckFile, 0, len(pkg.Files)),
 	}
 	if len(imports) == 0 {
 		imports = check.PackageImportSurfacesForSelfhost(pkg, nil, nativeLazyStdlibProvider{})
 	}
 	if len(imports) > 0 {
-		input.Imports = append([]selfhost.PackageCheckImport(nil), imports...)
+		input.Imports = append([]api.PackageCheckImport(nil), imports...)
 	}
 	base := 0
 	for _, pf := range pkg.Files {
@@ -405,7 +406,7 @@ func nativePackageCheckInput(pkg *resolve.Package, imports []selfhost.PackageChe
 			continue
 		}
 		name := filepath.Base(pf.Path)
-		input.Files = append(input.Files, selfhost.PackageCheckFile{
+		input.Files = append(input.Files, api.PackageCheckFile{
 			Source: append([]byte(nil), src...),
 			Base:   base,
 			Name:   name,
@@ -423,11 +424,11 @@ func nativePackageCheckInput(pkg *resolve.Package, imports []selfhost.PackageChe
 // not the concatenated bundle. Records that don't land inside any
 // file range (should not happen for well-formed output) are dropped
 // with their bundle offsets preserved as a defensive fallback.
-func nativePackageCheckDiags(records []selfhost.CheckDiagnosticRecord, files []selfhost.PackageCheckFile) []*diag.Diagnostic {
+func nativePackageCheckDiags(records []api.CheckDiagnosticRecord, files []api.PackageCheckFile) []*diag.Diagnostic {
 	if len(records) == 0 || len(files) == 0 {
 		return nil
 	}
-	buckets := make(map[int][]selfhost.CheckDiagnosticRecord, len(files))
+	buckets := make(map[int][]api.CheckDiagnosticRecord, len(files))
 	for _, rec := range records {
 		idx := findOwningFile(files, rec.Start)
 		if idx < 0 {
@@ -455,7 +456,7 @@ func nativePackageCheckDiags(records []selfhost.CheckDiagnosticRecord, files []s
 	}
 	return out
 }
-func findOwningFile(files []selfhost.PackageCheckFile, offset int) int {
+func findOwningFile(files []api.PackageCheckFile, offset int) int {
 	for i, f := range files {
 		end := f.Base + len(f.Source)
 		if offset >= f.Base && offset <= end {
@@ -467,7 +468,7 @@ func findOwningFile(files []selfhost.PackageCheckFile, offset int) int {
 
 // runTypecheckFileNative is runCheckFileNative plus the type dump.
 // After the check runs on the arena, prints every typed-node range
-// selfhost.CheckResult.TypedNodes recorded — one row per node with
+// api.CheckResult.TypedNodes recorded — one row per node with
 // line/column span and the inferred type. Zero astbridge lowerings
 // on the happy path (same counter invariant as runCheckFileNative).
 func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
@@ -495,12 +496,12 @@ func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, 
 }
 
 // printNativeTypes is the --native sibling of printTypes: it renders
-// selfhost.CheckResult.TypedNodes (node.Start, node.End are byte
+// api.CheckResult.TypedNodes (node.Start, node.End are byte
 // offsets produced by the native checker) as
 // `line:col-line:col\tType` rows sorted by start position. Rows
 // with nil Type (the checker's signal-only placeholders) are
 // dropped so output stays compact.
-func printNativeTypes(src []byte, result selfhost.CheckResult) {
+func printNativeTypes(src []byte, result api.CheckResult) {
 	type row struct {
 		start, end int
 		text       string

--- a/cmd/osty/resolve_native.go
+++ b/cmd/osty/resolve_native.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -28,7 +28,7 @@ func printNativeResolutionRows(rows []resolve.NativeResolutionRow) {
 // resolve result into printNativeResolutionRows input. Pair with
 // selfhost.ResolveFromSource so the caller never threads a
 // *selfhost.FrontendRun through the CLI layer.
-func nativeResolveRowsFromResolved(resolved selfhost.ResolveResult, src []byte, path string) []resolve.NativeResolutionRow {
+func nativeResolveRowsFromResolved(resolved api.ResolveResult, src []byte, path string) []resolve.NativeResolutionRow {
 	lineStarts := computeLineStartsBytes(src)
 	kindByNode := map[int]string{}
 	for _, sym := range resolved.Symbols {
@@ -77,7 +77,7 @@ func nativeResolveRowsFromResolved(resolved selfhost.ResolveResult, src []byte, 
 // native resolver's structured diagnostics into *diag.Diagnostic,
 // preserving the code + primary span + hint shape callers expect.
 // Pair with selfhost.ResolveFromSource for the astbridge-free path.
-func nativeResolveDiagnosticsFromResolved(resolved selfhost.ResolveResult, src []byte, path string) []*diag.Diagnostic {
+func nativeResolveDiagnosticsFromResolved(resolved api.ResolveResult, src []byte, path string) []*diag.Diagnostic {
 	lineStarts := computeLineStartsBytes(src)
 	out := make([]*diag.Diagnostic, 0, len(resolved.Diagnostics))
 	for _, record := range resolved.Diagnostics {

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -177,7 +177,7 @@ func (c cachedNativeChecker) CheckSourceStructured(src []byte) (api.CheckResult,
 	return res, err
 }
 
-func (c cachedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (api.CheckResult, error) {
+func (c cachedNativeChecker) CheckPackageStructured(input api.PackageCheckInput) (api.CheckResult, error) {
 	// Key on the raw source + a stable subset of the import surface.
 	// Hashing the full PackageCheckInput through json.Marshal would
 	// traverse the entire parsed AST — multi-second for the regen
@@ -218,7 +218,7 @@ func (c cachedNativeChecker) CheckPackageStructured(input selfhost.PackageCheckI
 	return res, err
 }
 
-func packageCheckFingerprint(input selfhost.PackageCheckInput) []byte {
+func packageCheckFingerprint(input api.PackageCheckInput) []byte {
 	h := sha256.New()
 	for _, f := range input.Files {
 		fmt.Fprintf(h, "file=%s base=%d len=%d\n", f.Name, f.Base, len(f.Source))

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
-func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider, layout selfhostCheckedSource) selfhost.PackageCheckInput {
-	input := selfhost.PackageCheckInput{
-		Files:   make([]selfhost.PackageCheckFile, 0, len(layout.files)),
+func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider, layout selfhostCheckedSource) api.PackageCheckInput {
+	input := api.PackageCheckInput{
+		Files:   make([]api.PackageCheckFile, 0, len(layout.files)),
 		Imports: resolve.PackageImportSurfaces(pkg, ws, stdlib),
 	}
 	segmentIdx := 0
@@ -30,7 +30,7 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 		if pf.Path != "" {
 			name = filepath.Base(pf.Path)
 		}
-		input.Files = append(input.Files, selfhost.PackageCheckFile{
+		input.Files = append(input.Files, api.PackageCheckFile{
 			Source: append([]byte(nil), src...),
 			Base:   base,
 			Name:   name,
@@ -41,14 +41,14 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 	return input
 }
 
-func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.StdlibProvider) selfhost.PackageCheckInput {
-	input := selfhost.PackageCheckInput{
+func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.StdlibProvider) api.PackageCheckInput {
+	input := api.PackageCheckInput{
 		Imports: resolve.PackageImportSurfacesForUses(fileUses(file), nil, stdlib),
 	}
 	if len(src) == 0 {
 		return input
 	}
-	input.Files = append(input.Files, selfhost.PackageCheckFile{
+	input.Files = append(input.Files, api.PackageCheckFile{
 		Source: append([]byte(nil), src...),
 		Base:   0,
 	})
@@ -57,12 +57,12 @@ func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.Std
 
 // selfhostPackageImportSurfaces is kept for tests and external adapters in
 // this package; the resolver owns the actual import-surface contract.
-func selfhostPackageImportSurfaces(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
+func selfhostPackageImportSurfaces(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []api.PackageCheckImport {
 	return resolve.PackageImportSurfaces(pkg, ws, stdlib)
 }
 
 // selfhostUsesImportSurfaces serves older package-local call sites; new code
 // should call resolve.PackageImportSurfacesForUses directly.
-func selfhostUsesImportSurfaces(uses []*ast.UseDecl, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
+func selfhostUsesImportSurfaces(uses []*ast.UseDecl, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []api.PackageCheckImport {
 	return resolve.PackageImportSurfacesForUses(uses, ws, stdlib)
 }

--- a/internal/check/package_input_export.go
+++ b/internal/check/package_input_export.go
@@ -2,13 +2,13 @@ package check
 
 import (
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 // PackageImportSurfacesForSelfhost exposes the package-import surface adapter
 // used by the host/native checker boundary so CLI-native workspace runners can
 // stitch sibling-package exports into CheckPackageStructured without copying
 // the surface-building logic.
-func PackageImportSurfacesForSelfhost(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
+func PackageImportSurfacesForSelfhost(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []api.PackageCheckImport {
 	return selfhostPackageImportSurfaces(pkg, ws, stdlib)
 }

--- a/internal/resolve/cfg.go
+++ b/internal/resolve/cfg.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 // CfgEnv carries the values that `#[cfg(key = "value")]` predicates
@@ -63,10 +63,10 @@ func DefaultCfgEnv() *CfgEnv {
 	}
 }
 
-// toSelfhost projects this Go-side CfgEnv onto the selfhost.CfgEnv the
+// toSelfhost projects this Go-side CfgEnv onto the structured CfgEnv that the
 // bootstrapped resolver consumes. Returns nil for a nil receiver so the
 // native path inherits "no filtering" behaviour without extra casing.
-func (c *CfgEnv) toSelfhost() *selfhost.CfgEnv {
+func (c *CfgEnv) toSelfhost() *api.CfgEnv {
 	if c == nil {
 		return nil
 	}
@@ -76,7 +76,7 @@ func (c *CfgEnv) toSelfhost() *selfhost.CfgEnv {
 			features = append(features, name)
 		}
 	}
-	return &selfhost.CfgEnv{
+	return &api.CfgEnv{
 		OS:       c.OS,
 		Arch:     c.Arch,
 		Target:   c.Target,

--- a/internal/resolve/import_surface.go
+++ b/internal/resolve/import_surface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 type importUseRef struct {
@@ -19,7 +20,7 @@ type importUseRef struct {
 // The selfhost resolver and checker both consume this surface so package
 // export shape is decided in one place instead of being rebuilt by downstream
 // passes from resolver internals.
-func PackageImportSurfaces(pkg *Package, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+func PackageImportSurfaces(pkg *Package, ws *Workspace, stdlib StdlibProvider) []api.PackageCheckImport {
 	if pkg == nil {
 		return nil
 	}
@@ -29,7 +30,7 @@ func PackageImportSurfaces(pkg *Package, ws *Workspace, stdlib StdlibProvider) [
 // PackageImportSurfacesForUses is the single-file sibling of
 // PackageImportSurfaces. It exists for file-mode checker calls that already
 // hold a parsed public AST rather than a Package.
-func PackageImportSurfacesForUses(uses []*ast.UseDecl, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+func PackageImportSurfacesForUses(uses []*ast.UseDecl, ws *Workspace, stdlib StdlibProvider) []api.PackageCheckImport {
 	if len(uses) == 0 {
 		return nil
 	}
@@ -44,7 +45,7 @@ func PackageImportSurfacesForUses(uses []*ast.UseDecl, ws *Workspace, stdlib Std
 
 // PackageExportSurface projects one resolved package into the selfhost
 // package-import surface used by both resolve and check.
-func PackageExportSurface(importPath, alias string, pkg *Package) selfhost.PackageCheckImport {
+func PackageExportSurface(importPath, alias string, pkg *Package) api.PackageCheckImport {
 	return selfhost.PackageImportSurface(importPath, alias, packageFrontendRuns(pkg))
 }
 
@@ -117,12 +118,12 @@ func importUseRefFromAST(use *ast.UseDecl) (importUseRef, bool) {
 	return ref, true
 }
 
-func packageImportSurfacesFromRefs(refs []importUseRef, ws *Workspace, stdlib StdlibProvider) []selfhost.PackageCheckImport {
+func packageImportSurfacesFromRefs(refs []importUseRef, ws *Workspace, stdlib StdlibProvider) []api.PackageCheckImport {
 	if len(refs) == 0 {
 		return nil
 	}
 	seen := map[string]string{}
-	var out []selfhost.PackageCheckImport
+	var out []api.PackageCheckImport
 	for _, ref := range refs {
 		if ref.isGo || ref.alias == "" {
 			continue

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -10,13 +10,14 @@ import (
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
 )
 
 type nativeResolveCache struct {
 	once   sync.Once
-	result selfhost.ResolveResult
+	result api.ResolveResult
 	files  []nativeResolveFileInfo
 	err    error
 }
@@ -41,7 +42,7 @@ type NativeResolutionRow struct {
 
 // NativeStructuredResult returns the cached selfhost structured resolve result
 // for pkg. The returned slices should be treated as read-only.
-func NativeStructuredResult(pkg *Package) (selfhost.ResolveResult, error) {
+func NativeStructuredResult(pkg *Package) (api.ResolveResult, error) {
 	result, _, err := nativeResolveArtifacts(pkg)
 	return result, err
 }
@@ -67,9 +68,9 @@ func NativeDiagnostics(pkg *Package) ([]*diag.Diagnostic, error) {
 	return nativeResolveDiagnosticsFromArtifacts(result, files), nil
 }
 
-func nativeResolveArtifacts(pkg *Package) (selfhost.ResolveResult, []nativeResolveFileInfo, error) {
+func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, error) {
 	if pkg == nil {
-		return selfhost.ResolveResult{}, nil, fmt.Errorf("native resolve: nil package")
+		return api.ResolveResult{}, nil, fmt.Errorf("native resolve: nil package")
 	}
 	pkg.nativeResolve.once.Do(func() {
 		input, files, err := nativeResolveInput(pkg)
@@ -94,7 +95,7 @@ func nativeResolveArtifacts(pkg *Package) (selfhost.ResolveResult, []nativeResol
 // DefaultCfgEnv when the workspace hasn't set one), so cross-compilation
 // flags populate both paths identically. Standalone packages (no workspace)
 // stay unfiltered.
-func nativeCfgEnvFor(pkg *Package) *selfhost.CfgEnv {
+func nativeCfgEnvFor(pkg *Package) *api.CfgEnv {
 	if pkg == nil || pkg.workspace == nil {
 		return nil
 	}
@@ -105,9 +106,9 @@ func nativeCfgEnvFor(pkg *Package) *selfhost.CfgEnv {
 	return env.toSelfhost()
 }
 
-func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeResolveFileInfo, error) {
-	input := selfhost.PackageResolveInput{
-		Files:       make([]selfhost.PackageResolveFile, 0, len(pkg.Files)),
+func nativeResolveInput(pkg *Package) (api.PackageResolveInput, []nativeResolveFileInfo, error) {
+	input := api.PackageResolveInput{
+		Files:       make([]api.PackageResolveFile, 0, len(pkg.Files)),
 		Imports:     PackageImportSurfaces(pkg, pkg.workspace, nil),
 		PackagePath: nativeResolvePackagePath(pkg),
 		Cfg:         nativeCfgEnvFor(pkg),
@@ -120,7 +121,7 @@ func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeRes
 		}
 		src, err := nativeResolveSourceForFile(pf)
 		if err != nil {
-			return selfhost.PackageResolveInput{}, nil, err
+			return api.PackageResolveInput{}, nil, err
 		}
 		if len(src) == 0 {
 			continue
@@ -128,7 +129,7 @@ func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeRes
 		// ResolvePackageStructured re-parses Source via the self-host
 		// lexer + parser — no *ast.File round-trip, so we only pass
 		// source bytes + routing metadata here.
-		input.Files = append(input.Files, selfhost.PackageResolveFile{
+		input.Files = append(input.Files, api.PackageResolveFile{
 			Source: append([]byte(nil), src...),
 			Base:   base,
 			Name:   filepath.Base(pf.Path),
@@ -196,7 +197,7 @@ func nativeResolveLineStarts(src []byte) []int {
 	return starts
 }
 
-func nativeResolutionRowsFromArtifacts(path string, resolved selfhost.ResolveResult, files []nativeResolveFileInfo) []NativeResolutionRow {
+func nativeResolutionRowsFromArtifacts(path string, resolved api.ResolveResult, files []nativeResolveFileInfo) []NativeResolutionRow {
 	kindByNode := map[int]string{}
 	for _, sym := range resolved.Symbols {
 		kindByNode[sym.Node] = nativeResolveKindLabel(sym.Kind)
@@ -240,7 +241,7 @@ func nativeResolutionRowsFromArtifacts(path string, resolved selfhost.ResolveRes
 	return rows
 }
 
-func nativeResolveDiagnosticsFromArtifacts(resolved selfhost.ResolveResult, files []nativeResolveFileInfo) []*diag.Diagnostic {
+func nativeResolveDiagnosticsFromArtifacts(resolved api.ResolveResult, files []nativeResolveFileInfo) []*diag.Diagnostic {
 	out := make([]*diag.Diagnostic, 0, len(resolved.Diagnostics))
 	for _, record := range resolved.Diagnostics {
 		builder := diag.New(diag.Error, record.Message).Code(record.Code).File(record.File)

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -477,8 +477,8 @@ func walkReflect(v reflect.Value, onIdent identVisitor, onType typeVisitor) {
 // --- Bridge functions ---
 
 func bridgeRefs(
-	refs []selfhost.ResolvedRef,
-	symbols []selfhost.ResolvedSymbol,
+	refs []api.ResolvedRef,
+	symbols []api.ResolvedSymbol,
 	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	identIdx map[int]*ast.Ident,
@@ -595,8 +595,8 @@ func supplementUseAliasRefs(
 }
 
 func bridgeTypeRefs(
-	typeRefs []selfhost.ResolvedTypeRef,
-	symbols []selfhost.ResolvedSymbol,
+	typeRefs []api.ResolvedTypeRef,
+	symbols []api.ResolvedSymbol,
 	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	typeIdx map[int]*ast.NamedType,
@@ -626,8 +626,8 @@ func bridgeTypeRefs(
 
 func findOrCreateTypeSymbol(
 	cache map[nativeSymbolTarget]*Symbol,
-	ref selfhost.ResolvedTypeRef,
-	symByTarget map[nativeSymbolTarget]selfhost.ResolvedSymbol,
+	ref api.ResolvedTypeRef,
+	symByTarget map[nativeSymbolTarget]api.ResolvedSymbol,
 	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	declIndexes map[string]map[int]ast.Node,
@@ -693,8 +693,8 @@ func findOrCreateTypeSymbol(
 
 func findOrCreateSymbol(
 	cache map[nativeSymbolTarget]*Symbol,
-	ref selfhost.ResolvedRef,
-	symByTarget map[nativeSymbolTarget]selfhost.ResolvedSymbol,
+	ref api.ResolvedRef,
+	symByTarget map[nativeSymbolTarget]api.ResolvedSymbol,
 	files []nativeResolveFileInfo,
 	fi nativeResolveFileInfo,
 	declIndexes map[string]map[int]ast.Node,
@@ -743,7 +743,7 @@ func findOrCreateSymbol(
 	return sym
 }
 
-func fillSymbolIDsFromRef(sym *Symbol, ref selfhost.ResolvedRef) {
+func fillSymbolIDsFromRef(sym *Symbol, ref api.ResolvedRef) {
 	if sym == nil {
 		return
 	}
@@ -755,7 +755,7 @@ func fillSymbolIDsFromRef(sym *Symbol, ref selfhost.ResolvedRef) {
 	}
 }
 
-func fillSymbolIDsFromTypeRef(sym *Symbol, ref selfhost.ResolvedTypeRef) {
+func fillSymbolIDsFromTypeRef(sym *Symbol, ref api.ResolvedTypeRef) {
 	if sym == nil {
 		return
 	}
@@ -773,8 +773,8 @@ type nativeSymbolTarget struct {
 	start, end int
 }
 
-func nativeSymbolByTarget(symbols []selfhost.ResolvedSymbol) map[nativeSymbolTarget]selfhost.ResolvedSymbol {
-	out := make(map[nativeSymbolTarget]selfhost.ResolvedSymbol, len(symbols))
+func nativeSymbolByTarget(symbols []api.ResolvedSymbol) map[nativeSymbolTarget]api.ResolvedSymbol {
+	out := make(map[nativeSymbolTarget]api.ResolvedSymbol, len(symbols))
 	for _, sym := range symbols {
 		out[nativeSymbolTarget{file: sym.File, node: sym.Node, start: sym.Start, end: sym.End}] = sym
 	}
@@ -798,7 +798,7 @@ func findNearestDecl(declIdx map[int]ast.Node, targetOff int) ast.Node {
 
 func defineTopLevelSymbols(
 	scope *Scope,
-	symbols []selfhost.ResolvedSymbol,
+	symbols []api.ResolvedSymbol,
 	fi nativeResolveFileInfo,
 	declIdx map[int]ast.Node,
 ) {

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -9,8 +9,8 @@ import (
 
 // Type aliases re-export the cross-boundary shapes from
 // internal/selfhost/api so existing `selfhost.CheckResult` callers
-// continue to compile. Future work can switch consumers (cmd/osty,
-// internal/check) to `api.CheckResult` directly.
+// continue to compile. New consumers should import internal/selfhost/api
+// directly and reserve these aliases for compatibility edges.
 type (
 	TypeRepr              = api.TypeRepr
 	CheckSummary          = api.CheckSummary

--- a/internal/selfhost/frontend_authority_test.go
+++ b/internal/selfhost/frontend_authority_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var frontendRunFileCallRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:[Rr]un)\.File\(\)`)
+var structuredSelfhostAliasRE = regexp.MustCompile(`selfhost\.(PackageCheckInput|PackageCheckFile|PackageCheckImport|CheckResult|CheckedNode|CheckDiagnosticRecord|ResolveResult|ResolvedRef|ResolvedSymbol|ResolvedTypeRef|PackageResolveInput|PackageResolveFile|CfgEnv)\b`)
 
 func TestProductionFrontendPathsDoNotCallFrontendRunFile(t *testing.T) {
 	root := repoRootForAuthorityTest(t)
@@ -40,6 +41,46 @@ func TestProductionFrontendPathsDoNotCallFrontendRunFile(t *testing.T) {
 				if frontendRunFileCallRE.MatchString(line) {
 					rel, _ := filepath.Rel(root, path)
 					t.Fatalf("%s:%d calls FrontendRun.File(); use FrontendRun/arena/structured results, or LowerPublicFileFromRun at an explicit compatibility boundary", rel, i+1)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+	}
+}
+
+func TestNativeConsumersImportStructuredAPITypesDirectly(t *testing.T) {
+	root := repoRootForAuthorityTest(t)
+	for _, dir := range []string{"cmd/osty", "internal/check", "internal/resolve"} {
+		scanDir := filepath.Join(root, filepath.FromSlash(dir))
+		err := filepath.WalkDir(scanDir, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				switch entry.Name() {
+				case ".git", ".osty", ".direnv":
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for i, line := range strings.Split(string(data), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "//") {
+					continue
+				}
+				if structuredSelfhostAliasRE.MatchString(line) {
+					rel, _ := filepath.Rel(root, path)
+					t.Fatalf("%s:%d uses a selfhost compatibility alias for structured API data; import internal/selfhost/api directly", rel, i+1)
 				}
 			}
 			return nil

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Package-level type aliases re-export the shared boundary shapes from
-// internal/selfhost/api. See selfhost/api/package.go for definitions.
+// internal/selfhost/api for compatibility. New consumers should import
+// internal/selfhost/api directly.
 type (
 	PackageCheckFile         = api.PackageCheckFile
 	PackageCheckGenericBound = api.PackageCheckGenericBound

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -11,8 +11,8 @@ import (
 	"github.com/osty/osty/internal/selfhost/api"
 )
 
-// Resolve-side types re-exported from internal/selfhost/api. See
-// selfhost/api/package.go for definitions.
+// Resolve-side types re-exported from internal/selfhost/api for compatibility.
+// New consumers should import internal/selfhost/api directly.
 type (
 	PackageResolveFile  = api.PackageResolveFile
 	PackageResolveInput = api.PackageResolveInput


### PR DESCRIPTION
## Summary
- Move native check/resolve/CLI structured selfhost data consumers to import `internal/selfhost/api` directly instead of using `selfhost` compatibility aliases.
- Keep selfhost execution entrypoints in place while narrowing the compatibility alias boundary.
- Add an authority test that prevents native consumers from regressing back to structured `selfhost.*` aliases.

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestProductionFrontendPathsDoNotCallFrontendRunFile|TestNativeConsumersImportStructuredAPITypesDirectly|TestCheckStructuredFromRunIsAstbridgeFree|TestCheckPackageStructuredIsAstbridgeFree'`
- `go test -count=1 -vet=off ./internal/check ./internal/resolve ./cmd/osty ./cmd/osty-native-checker ./cmd/osty-native-resolver`
- `git diff --check`