### PR TITLE
[codex] add support matrix verification loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Format
         run: |
-          unformatted="$(gofmt -l $(git ls-files '*.go'))"
+          mapfile -t go_files < <(git ls-files '*.go')
+          unformatted="$(gofmt -l "${go_files[@]}")"
           if [ -n "$unformatted" ]; then
             echo "$unformatted"
             exit 1
@@ -79,15 +80,13 @@ jobs:
         run: |
           "$OSTY_BIN" ci .
 
-      - name: Verify selfhost snapshot parity
-        run: |
-          go test -count=1 -vet=off -run 'SnapshotParity|CoreSnapshotParity' \
-            ./internal/ci ./internal/runner
+      - name: Support matrix medium
+        run: just support-matrix-medium
 
       - name: Vet
         run: go vet ./...
 
-      - name: Test
+      - name: Full Go test loop
         run: go test -vet=off ./...
 
   cross-compile:

--- a/README.md
+++ b/README.md
@@ -639,6 +639,13 @@ go test -fuzz=FuzzParse -fuzztime=30s ./internal/parser/
 Fast local loops are captured in the `justfile`:
 
 ```sh
+just quick                 # fastest support-matrix smoke: stdlib + selfhost + front packages
+just medium                # matrix smoke plus broader short Go verification
+just verify-full           # full Go/Osty loop plus six-host cross-compile matrix
+just support-matrix-fast   # STDLIB_MATRIX + SELFHOST_PORT_MATRIX fast smoke
+just support-matrix-medium # deeper matrix bundles without the broad short loop
+just support-stdlib-fast   # STDLIB_MATRIX module-set and resolve smoke
+just support-selfhost-fast # SELFHOST_PORT_MATRIX default-path smoke
 just osty                  # build, selfhost parity, `osty ci .`, and live Osty e2e tests
 just osty-tests            # only the live Osty e2e test dirs
 just front                 # Osty-first loop plus front-end package smoke

--- a/internal/stdlib/support_matrix_test.go
+++ b/internal/stdlib/support_matrix_test.go
@@ -1,0 +1,153 @@
+package stdlib
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type stdlibSupportMatrix struct {
+	production         []string
+	productionAdjacent []string
+}
+
+// std.runtime.raw is intentionally internal support surface. It is bundled
+// beside public modules but is not counted in STDLIB_MATRIX.md's 52 rows.
+var stdlibSupportMatrixInternalModules = []string{
+	"runtime.raw",
+}
+
+func TestStdlibSupportMatrixCoversEmbeddedModules(t *testing.T) {
+	reg := LoadCached()
+	matrix := loadStdlibSupportMatrix(t)
+	got := sortedModuleNames(reg.Modules)
+	want := sortedStrings(combineStringSlices(
+		matrix.production,
+		matrix.productionAdjacent,
+		stdlibSupportMatrixInternalModules,
+	))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stdlib support matrix module set drifted\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestStdlibSupportMatrixModulesResolve(t *testing.T) {
+	reg := LoadCached()
+	matrix := loadStdlibSupportMatrix(t)
+	for _, module := range combineStringSlices(matrix.production, matrix.productionAdjacent) {
+		t.Run(module, func(t *testing.T) {
+			mod := reg.Modules[module]
+			if mod == nil {
+				t.Fatalf("std.%s missing from registry", module)
+			}
+			if len(mod.Source) == 0 {
+				t.Fatalf("std.%s source is empty", module)
+			}
+			if mod.File == nil {
+				t.Fatalf("std.%s parsed file is nil", module)
+			}
+			if mod.Package == nil || mod.Package.PkgScope == nil {
+				t.Fatalf("std.%s resolved package scope is nil", module)
+			}
+		})
+	}
+}
+
+func loadStdlibSupportMatrix(t *testing.T) stdlibSupportMatrix {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	data, err := os.ReadFile(filepath.Join(root, "STDLIB_MATRIX.md"))
+	if err != nil {
+		t.Fatalf("read STDLIB_MATRIX.md: %v", err)
+	}
+	matrix := parseStdlibSupportMatrix(string(data))
+	if len(matrix.production) == 0 {
+		t.Fatal("STDLIB_MATRIX.md production section produced no modules")
+	}
+	if len(matrix.productionAdjacent) == 0 {
+		t.Fatal("STDLIB_MATRIX.md production-adjacent section produced no modules")
+	}
+	return matrix
+}
+
+func parseStdlibSupportMatrix(markdown string) stdlibSupportMatrix {
+	const (
+		sectionNone = iota
+		sectionProduction
+		sectionProductionAdjacent
+	)
+	var matrix stdlibSupportMatrix
+	section := sectionNone
+	for _, line := range strings.Split(markdown, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "### ") {
+			switch {
+			case strings.Contains(trimmed, "Production-adjacent"):
+				section = sectionProductionAdjacent
+			case strings.Contains(trimmed, "Production"):
+				section = sectionProduction
+			default:
+				section = sectionNone
+			}
+			continue
+		}
+		module, ok := stdlibSupportMatrixTableModule(trimmed)
+		if !ok {
+			continue
+		}
+		switch section {
+		case sectionProduction:
+			matrix.production = append(matrix.production, module)
+		case sectionProductionAdjacent:
+			matrix.productionAdjacent = append(matrix.productionAdjacent, module)
+		}
+	}
+	return matrix
+}
+
+func stdlibSupportMatrixTableModule(line string) (string, bool) {
+	if !strings.HasPrefix(line, "|") || strings.Contains(line, "---") {
+		return "", false
+	}
+	cells := strings.Split(line, "|")
+	if len(cells) < 3 {
+		return "", false
+	}
+	module := strings.TrimSpace(cells[1])
+	module = strings.Trim(module, "`")
+	if module == "" || module == "모듈" || strings.Contains(module, " ") {
+		return "", false
+	}
+	return module, true
+}
+
+func sortedModuleNames(mods map[string]*Module) []string {
+	names := make([]string, 0, len(mods))
+	for name := range mods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func combineStringSlices(parts ...[]string) []string {
+	var out []string
+	for _, part := range parts {
+		out = append(out, part...)
+	}
+	return out
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string{}, in...)
+	sort.Strings(out)
+	return out
+}

--- a/justfile
+++ b/justfile
@@ -6,6 +6,12 @@ front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./inter
 backend_packages := "./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen"
 osty_test_dirs := "examples/int_control_e2e examples/int_methods_e2e examples/int_struct_e2e"
 test_flags := "-count=1 -vet=off"
+stdlib_matrix_fast_tests := "TestStdlibSupportMatrix"
+stdlib_matrix_backend_tests := "Test(Stdlib(CheckResult|Symbol|Method)|InjectReachableStdlib|ReachableStdlib|Phase2|LLVMBackendBinaryRunsStd(Zip|Image|Smtp|Crypto|Random|Term|Os)|PrepareEntryRewritesStdEncoding)"
+stdlib_matrix_llvmgen_tests := "Test(Std(Env|Io|Term|Strings|Bytes|Crypto)|UnsupportedDiagnostic)"
+selfhost_matrix_fast_tests := "Test(CheckCLIDefaultPathExitsZero|RunCheckFileDefaultPathIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)"
+selfhost_matrix_cmd_tests := "Test(Run(Check|Typecheck|Resolve)(File|Package|Workspace).*AstbridgeFree|CheckCLI(DefaultPathExitsZero|Native.*)|TypecheckCLI.*|ResolveCLI.*)"
+selfhost_matrix_core_tests := "Test(ParseSnapshot|CheckSnapshot|CheckStructuredFromRunIsAstbridgeFree|CheckPackageStructuredIsAstbridgeFree|CheckDiagnosticsAsDiagIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)"
 
 # Osty-first front-end loop.
 default: front
@@ -74,6 +80,51 @@ short:
 full:
     just osty
     go test {{test_flags}} ./...
+
+quick: verify-fast
+
+medium: verify-medium
+
+verify-fast:
+    just support-matrix-fast
+    go test {{test_flags}} {{front_packages}}
+
+verify-medium:
+    just support-matrix-medium
+    just short
+
+verify-full:
+    just full
+    just support-host-matrix
+
+support-matrix-fast:
+    just support-stdlib-fast
+    just support-selfhost-fast
+
+support-matrix-medium:
+    just support-stdlib-medium
+    just support-selfhost-medium
+
+support-stdlib-fast:
+    go test {{test_flags}} ./internal/stdlib -run '{{stdlib_matrix_fast_tests}}' -v
+
+support-stdlib-medium:
+    just support-stdlib-fast
+    go test {{test_flags}} ./internal/stdlib
+    go test {{test_flags}} ./internal/backend -run '{{stdlib_matrix_backend_tests}}' -v
+    go test {{test_flags}} ./internal/llvmgen -run '{{stdlib_matrix_llvmgen_tests}}' -v
+
+support-selfhost-fast:
+    go test {{test_flags}} ./cmd/osty ./internal/selfhost -run '{{selfhost_matrix_fast_tests}}' -v
+
+support-selfhost-medium:
+    just support-selfhost-fast
+    just verify-selfhost
+    go test {{test_flags}} ./cmd/osty -run '{{selfhost_matrix_cmd_tests}}' -v
+    go test {{test_flags}} ./internal/selfhost -run '{{selfhost_matrix_core_tests}}' -v
+
+support-host-matrix:
+    just cross
 
 osty: build verify-selfhost
     {{bin}} ci .


### PR DESCRIPTION
## Summary
- Add fast/medium/full verification loops around the stdlib and selfhost support matrices.
- Add a stdlib support-matrix regression test that parses `STDLIB_MATRIX.md` and checks the documented public module set against the embedded registry.
- Run the medium support-matrix loop in CI and keep the broader Go suite as a separate visible step.

## Validation
- `just support-matrix-medium`
- `just quick`
- `actionlint .github/workflows/ci.yml`
- `just fmt-check`
- `git diff --check`