### PR TITLE
[codex] Sync backend dispatch docs and guards

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -1,12 +1,14 @@
 # MIR design (Osty compiler)
 
-Status: Stage 3.12 landed (composite map values + ABI fix); Stage 4 partially
-landed — MIR-first IR emission is the default for an expanding shape set while
-`internal/llvmgen`'s IR→AST bridge (`legacyFileFromModule`) stays live as the
-fallback for shapes the MIR emitter does not yet cover. Stage 5 (Go fallback
-removal) is still deferred; the gaps are tracked in the MIR emitter's
-`checkSupported` / `ProbeModule` plus the Stage 5 notes lower in this
-document.
+Status: Stage 3.12 landed (composite map values + ABI fix); Stage 4 is the
+default backend dispatch for ordinary LLVM requests. The dispatcher now tries
+the native-owned slice first, then MIR-direct emission, and reports unsupported
+MIR shapes as an inspectable skeleton with a `backend-route` warning instead of
+silently retrying the legacy HIR→AST bridge. `internal/llvmgen`'s IR→AST bridge
+(`legacyFileFromModule`) stays live only for direct `GenerateModule` callers or
+entries that have no MIR projection. Stage 5 (Go fallback removal) is still
+deferred; the remaining gates are tracked in the dispatch matrix and checklist
+below.
 
 ## Why a second IR
 
@@ -69,13 +71,14 @@ source
   → ir.Validate      (HIR invariants)
   → mir.Lower        (HIR → MIR)              ⟵ Stage 1 landed
   → mir.Validate     (MIR invariants)         ⟵ Stage 1 landed
-  → backend dispatch (Stage 4 partial default):
-      if Options.UseMIR && Entry.MIR != nil:
-        llvmgen.GenerateFromMIR(Entry.MIR, opts)
-        └── on ErrUnsupported, falls back to HIR path
-      else:
-        llvmgen.GenerateModule(Entry.IR, opts)
-        └── legacy HIR→AST bridge (explicit opt-out / fallback path)
+  → backend dispatch (Stage 4 default):
+      preflight: reject Go FFI / unknown runtime FFI before emitter selection
+      native-owned: TryGenerateNativeOwnedModule when eligible
+      mir-direct: llvmgen.GenerateFromMIR(Entry.MIR, opts)
+        └── on ErrUnsupported, emit skeleton + ErrLLVMNotImplemented
+            with `backend-route: mir-direct`
+      legacy-ir-bridge: llvmgen.GenerateModule(Entry.IR, opts)
+        └── last resort for direct callers / missing Entry.MIR only
 ```
 
 MIR lowering runs *after* monomorphisation: every `TypeVar` is gone,
@@ -104,11 +107,60 @@ reason about generics.
 | Compound & multi-target assign   | yes                 | expanded to `BinaryRV` / tuple destructure (Stage 2a) |
 | Top-level global read            | yes (`IdentGlobal`) | `GlobalRefRV` (Stage 2a)                              |
 
-Anything in the "not yet" rows causes `mir.Lower` to return an
-"unsupported" diagnostic today. That signals the caller (e.g. the
-backend dispatcher) to fall back to the existing HIR-based path. As
-each feature gains a settled lowering, it moves from the "not yet" row
-into full MIR coverage.
+Anything in the "not yet" rows now surfaces as an unsupported backend
+diagnostic rather than a hidden retry through the old AST emitter. The backend
+dispatcher records the route in warnings and in the skeleton LLVM artifact so a
+coverage wall is visible at the same call site that hit it. As each feature
+gains a settled lowering, it moves from the "not yet" row into full MIR
+coverage and gets a route-sensitive regression test.
+
+## Backend dispatch trace
+
+The route decision is part of the backend contract, not just an implementation
+detail. Set `OSTY_BACKEND_TRACE=1` when debugging selection; stderr will contain
+lines such as:
+
+```
+backend trace: llvm native-owned skipped package=main source=/tmp/app.osty
+backend trace: llvm mir-direct emit package=main source=/tmp/app.osty emit=llvm-ir target=
+backend trace: llvm mir-direct succeeded package=main source=/tmp/app.osty
+```
+
+Unsupported artifacts also carry the stable warning suffix
+`backend-route: <route>`. That warning is the CI-friendly trace; the env var is
+for local diagnosis.
+
+| Route | When it is selected | Expected result | Guard |
+|-------|---------------------|-----------------|-------|
+| `unsupported-preflight` | `UnsupportedDiagnosticForModule` rejects source-level backend gaps before concrete emitter selection | Skeleton LLVM IR + `ErrLLVMNotImplemented`; no legacy retry | `TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug` |
+| `native-owned` | default LLVM emit modes when the feature set allows it and no injected stdlib bodies are present | Full LLVM IR from `TryGenerateNativeOwnedModule`; decline falls through to MIR-direct | `TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered`, `TestTryEmitNativeOwnedLLVMIRText*` |
+| `mir-direct` | every remaining normal backend request with `Entry.MIR != nil` | Full LLVM IR from `GenerateFromMIR`, or skeleton + `backend-route: mir-direct` on unsupported shape | `TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics`, `TestNativeToolchainMergedMIRPipelineIsClean` |
+| `legacy-ir-bridge` | direct `GenerateModule` callers, or a backend entry that lacks MIR | Transitional IR→AST bridge through `legacyFileFromModule` | `TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing`; new production coverage should not be added here |
+
+Route changes must update this table, `internal/backend/doc.go`, and any
+route-sensitive tests in the same patch.
+
+## MIR-direct coverage ledger
+
+The current coverage source of truth is the MIR emitter whitelist, not the old
+AST bridge. This ledger maps the user-visible route matrix above to the code
+gates that actually decide whether MIR-direct can emit a program.
+
+| Gate | Covered in MIR-direct | Still watched / next wall | Code anchor | Required guard |
+|------|-----------------------|---------------------------|-------------|----------------|
+| Backend route | `Entry.MIR != nil` routes normal backend requests to `mir-direct`; missing MIR is the only backend path to `legacy-ir-bridge` | Any `backend.Emit` request with MIR reaching `legacy-ir-bridge` is a regression | `internal/backend/llvm.go`: `generateLLVMIR`, `llvmFallbackDispatchRoute` | `TestLLVMBackendDispatchTraceReportsSelectedRoute`, `TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing` |
+| Module / function envelope | Non-intrinsic fns with blocks, external stubs, global init fns walked through the same whitelist | Intrinsic fn declarations, empty non-external fns, unsupported global types | `checkSupported`, `checkFunctionSupported` | focused MIR emitter test or source-level backend fixture |
+| Type surface | Primitive ints / uints / byte / bool / char / floats / string / bytes / raw ptr / unit / never; builtin `List` / `Map` / `Set` / `ClosureEnv` / `Range`; declared struct and enum layouts; opaque runtime types (`Channel`, `Handle`, `Group`, `TaskGroup`, `Select`, `Duration`, `Rng`, `Gen`, `Never`); optionals, tuples, fn values | `ErrType` outside explicitly unused locals; named types without layout or runtime policy | `typeSupported`, `allowUnusedErrLocal` | type-specific backend smoke plus unsupported skeleton test |
+| Place / projection surface | `FieldProj`, `TupleProj`, `VariantProj`, `DerefProj` with declared type, `IndexProj` on `List` / `Map` / `String` bases | `IndexProj` on any other base; deref without a MIR type; future borrow/reference projections | `checkProjectionsSupported`, projection emit loop | projection-specific MIR test and source-level fixture |
+| RValue surface | `Use`, `Unary`, `Binary`, `Discriminant`, `Nullary`, `Cast`, `GlobalRef`, aggregate struct / tuple / enum / list / closure, `LenRV` | `AddressOfRV`, `RefRV`, and any future borrow/reference rvalue | `checkRValueSupported` | route-sensitive unsupported test before adding lowering |
+| Instruction / terminator surface | `Assign`, direct `FnRef` calls, `IndirectCall`, supported `IntrinsicInstr`, `StorageLive` / `StorageDead`; `Goto`, `Branch`, `Return`, `Unreachable`, `SwitchInt` | Unknown call targets, new instruction kinds, new terminators | `checkInstrSupported`, `checkTermSupported` | one direct MIR test plus one source-level backend test when syntax can reach it |
+| Intrinsic families | print/eprint, list/map/set, bytes/string, channels/tasks/select/cancellation/helpers, raw null, primitive conversions, option/result methods | New stdlib/runtime intrinsics must be added to `isSupportedIntrinsic` and the emit dispatch together | `isSupportedIntrinsic`, `emit*Intrinsic` helpers | intrinsic family tests under `internal/llvmgen` or `internal/backend` |
+| Whole toolchain | Merged native toolchain lowers through `GenerateFromMIR` without `ErrUnsupported` | Any hard wall in the merged probe is a backend parity regression, not a doc backlog item | `internal/llvmgen/native_toolchain_mir_pipeline_test.go` | `TestNativeToolchainMergedMIRPipelineIsClean` |
+
+Doc sync rule: if a row changes because support was added, removed, or rerouted,
+update the row, the Stage 5 checklist, and `internal/llvmgen` package comments
+in the same patch. `TestLLVMBackendDocsMentionDispatchRoutes` pins the route
+names and section markers so this table cannot silently disappear.
 
 ## MIR node model
 
@@ -710,23 +762,26 @@ MIR tests isolated from front-end churn.
     point. It consumes a `*mir.Module` directly (no HIR→AST bridge)
     and emits textual LLVM IR via an alloca-per-local SSA scheme
     (LLVM's mem2reg pass promotes to register form during opt).
-  - **Dispatcher gate.** `llvmgen.Options.UseMIR` selects the path.
-    The backend dispatcher (`internal/backend/llvm.go`) prefers
+  - **Dispatcher gate.** `llvmgen.Options.UseMIR` selects the MIR
+    entry point. The backend dispatcher (`internal/backend/llvm.go`)
+    runs the native-owned slice first when eligible, then prefers
     `GenerateFromMIR(entry.MIR, opts)` by default on every emit
     mode — raw `llvm-ir`, object, binary. On `ErrUnsupported` the
-    dispatcher catches the sentinel and falls back to
-    `GenerateModule(entry.IR, opts)` automatically, so coverage
-    regressions are impossible while parity lands.
-  - **MVP coverage.** Primitive types (Int / UInt / Byte / Bool /
+    dispatcher renders an unsupported skeleton and appends
+    `backend-route: mir-direct`; it does not silently retry
+    `GenerateModule(entry.IR, opts)` for ordinary backend requests.
+  - **Initial MVP coverage.** Primitive types (Int / UInt / Byte / Bool /
     Char / Float{32,64} / String / Unit), functions with primitive
     params + return types, `Assign` with Use/Unary/Binary/Const
     rvalues, direct `Call` to `FnRef` callees, `IntrinsicPrint` /
     `Println` (printf-backed), `Goto` / `Branch` / `SwitchInt` /
     `Return` / `Unreachable` terminators. Anything outside the MVP
-    returns `ErrUnsupported` with a `mir-mvp` kind so the fallback
-    triggers rather than producing malformed IR. Structs, enums,
-    tuples, lists, maps, optional/result values, closures, and the
-    concurrency family are all follow-up scope.
+    returns `ErrUnsupported` with a `mir-mvp` kind so the dispatcher
+    reports the uncovered route rather than producing malformed IR.
+    Structs, enums, tuples, lists, maps, optional/result values,
+    closures, and the concurrency family were follow-up scope from the
+    first MVP. The current coverage is the staged list below plus the
+    backend dispatch matrix above.
   - **Parity coverage.** Keep host-side MIR/LLVM tests focused on the
     Go/Osty boundary. New source-level MIR parity cases should prefer
     Osty fixtures and toolchain sources instead of rebuilding a broad
@@ -757,12 +812,13 @@ MIR tests isolated from front-end churn.
     the new leaf → insertvalue back up the chain → store. Nested
     projections fan out correctly (e.g. `outer.inner.v = x`
     produces two-level insertvalue).
-  - `checkSupported` accepts `NamedType` receivers only when the
-    module's `LayoutTable` has a matching struct entry — enums
-    still fall through to fallback. `FieldProj` and `TupleProj` are
-    the only projection kinds accepted; `VariantProj`, `IndexProj`,
-    `DerefProj` remain in the unsupported set awaiting later
-    expansion stages.
+  - The original Stage 3.1 gate accepted `NamedType` receivers only
+    when the module's `LayoutTable` had a matching struct entry.
+    Current MIR-direct coverage is broader: enum layouts, variant
+    projections, list/map/string indexes, and typed `DerefProj`
+    are all covered by later stages. Keep this historical note in
+    sync with the coverage ledger above rather than treating it as
+    the live whitelist.
 
 - **Stage 3.2 (landed).** Enum / Option / Maybe / Result + variant
   payload projections.
@@ -811,8 +867,8 @@ MIR tests isolated from front-end churn.
     into the ptr-sized slot through `toI64Slot` + `inttoptr` when
     the map value type is narrower than ptr.
   - Composite list element types (structs, tuples, nested lists)
-    still fall back to legacy — the bytes runtime path needs a
-    struct-size computation that the MVP doesn't ship yet.
+    were outside this stage's coverage — the later bytes-v1 runtime
+    path expands this surface.
 
 - **Stage 3.4 (landed — non-capturing closures + indirect call).**
 
@@ -911,10 +967,11 @@ MIR tests isolated from front-end churn.
     but out of scope here — the common cases (sorting / filtering
     / map-style callbacks consumed in-frame) work without heap.
 
-- **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
-  backend prefers the MIR-direct emitter by default on every emit
-  mode — raw `llvm-ir`, object, binary. The dispatcher falls back
-  automatically on `ErrUnsupported`, so coverage never regresses.
+- **Stage 4 (landed — observable MIR-first IR emission).** The LLVM
+  backend prefers MIR-direct emission by default after the native-owned
+  fast path declines. Unsupported MIR shapes now produce an inspectable
+  skeleton and `ErrLLVMNotImplemented` with a `backend-route` warning;
+  they are no longer hidden by an automatic legacy bridge retry.
 
 - **Stage 3.9 (landed — concurrency intrinsic runtime mapping).**
   All MIR concurrency intrinsics emitted by the MIR lowerer now
@@ -1043,14 +1100,50 @@ MIR tests isolated from front-end churn.
   passed the value bit-pattern as a pointer, which the runtime
   would have dereferenced into garbage if linked end-to-end.
 
-- **Stage 5 (deferred — still needs parity).** Remove
-  `legacyFileFromModule` and the AST-driven emitter. Outstanding
-  parity gaps after Stage 3.12: heap-escaping closure envs and
-  `DerefProj` on anything other than a closure env. Top-level
-  globals crossed off in Stage 3.10; GC roots / safepoints
-  crossed off in Stage 3.11; composite map values crossed off in
-  Stage 3.12. See the MIR emitter's `checkSupported` and
-  `checkRValueSupported` for the current whitelist.
+- **Stage 5 (deferred — legacy bridge removal).** Remove
+  `legacyFileFromModule` and the AST-driven emitter after the bridge
+  has no production route left. Outstanding parity gaps after Stage
+  3.12: heap-escaping closure envs, plus borrow/reference rvalues
+  (`AddressOfRV`, `RefRV`) if they become source-reachable outside
+  current closure-env lowering. Top-level globals crossed off in
+  Stage 3.10; GC roots / safepoints crossed off in Stage 3.11;
+  composite map values crossed off in Stage 3.12. See the MIR emitter's
+  `checkSupported` and `checkRValueSupported` for the current
+  whitelist.
+
+  Stage 5 checklist:
+
+  1. Capture the wall through the observable route first: reproduce with
+     `OSTY_BACKEND_TRACE=1` or a `backend-route` warning, and record
+     whether the wall is `unsupported-preflight`, `native-owned`,
+     `mir-direct`, or `legacy-ir-bridge`.
+  2. Add or move coverage to the production route. Prefer MIR fixtures,
+     source-level backend tests, or `TestNativeToolchainMergedMIRPipelineIsClean`;
+     add direct legacy bridge tests only to pin deletion behavior.
+  3. Update the coverage ledger and this stage note in the same change
+     that changes dispatch behavior. If code says "skeleton", docs must
+     not say "automatic fallback".
+  4. Tighten the dispatch invariant: normal `backend.Emit` requests
+     should reach `legacy-ir-bridge` only when `Entry.MIR == nil`.
+     Add a route-sensitive test before relying on that invariant.
+  5. Delete direct bridge dependencies in layers: first stop new calls
+     to `GenerateModule` from backend entry points, then remove
+     `legacyFileFromModule`, then remove in-package AST helper tests.
+  6. Finish by proving `internal/llvmgen` no longer imports
+     `internal/ast` across its public boundary and rerun the focused
+     backend gates (`go test -count=1 -vet=off ./internal/backend` and
+     the relevant `./internal/llvmgen` route tests).
+
+  Removal ledger:
+
+  | Target | Current dependency | Exit condition | Guard before deletion |
+  |--------|--------------------|----------------|-----------------------|
+  | Hidden backend retry | `internal/backend/llvm.go` route selection | Already removed for normal MIR-backed requests; keep missing-MIR route only as explicit bridge path | `TestLLVMBackendDispatchTraceReportsSelectedRoute`, `TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing` |
+  | Direct bridge entry | `llvmgen.GenerateModule` in `internal/llvmgen/ir_module.go` | No production caller needs `GenerateModule` for shapes outside `TryGenerateNativeOwnedModule`; direct callers either move to `GenerateFromMIR` or become tests of deleted behavior | `rg "GenerateModule" internal cmd toolchain` review plus route tests |
+  | IR→AST bridge body | `legacyFileFromModule` and its side channels (`currentSpecializedBuiltin*`, lifted closure maps) | All runtime/stdlib metadata needed by MIR-direct or native-owned emitters has a non-AST representation | focused stdlib/backend tests for every side-channel family before removal |
+  | In-package AST emitter tests | `generateFromAST` tests and legacy bridge fixtures | Equivalent source-level or MIR-direct tests exist for the behavior being preserved | move tests first, delete helper second |
+  | Public-boundary AST import | `internal/llvmgen` imports `internal/ast` | `internal/llvmgen` public API accepts IR/MIR only and no package-boundary path imports AST | `rg "\"github.com/osty/osty/internal/ast\"" internal/llvmgen` is empty or test-only |
+  | Documentation drift | Route and coverage prose in this document | Route constants, coverage ledger, and Stage 5 checklist all describe the current code | `TestLLVMBackendDocsMentionDispatchRoutes` |
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is
@@ -1062,8 +1155,9 @@ from importing `internal/ast` at the package-boundary level.
 
 - SSA. MIR locals can be reassigned. An SSA pass (`mir.ToSSA`) will
   sit on top once downstream passes want it.
-- Borrow / ownership analysis. `AddressOfRV` and `DerefProj` are
-  in the vocabulary but currently unused.
+- Borrow / ownership analysis. `AddressOfRV` and `RefRV` are in the
+  vocabulary but not part of the MIR-direct rvalue whitelist yet; typed
+  `DerefProj` is currently used for closure-env loads.
 - Region-based diagnostics. MIR carries `Span`s, but the current
   validator reports only structural errors.
 - A production-quality optimizer. The existing HIR optimiser stays

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -168,7 +168,7 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap boundary | merged whole-toolchain probe / checker bundle | the current toolchain host adapter is `toolchain/ci.osty` with `use runtime.cihost as host`. `toolchain/ast_lower.osty` (dead duplicate of `internal/selfhost/ast_lower.osty`, 1672 LOC) was deleted 2026-04-22, and `internal/selfhost/ast_lower.osty` is now deliberately outside `ToolchainCheckerFiles()` as a legacy public-AST adapter for `FrontendRun.File` / `Parse` / `EnsureFile` consumers. `toolchain/docgen.osty` + `toolchain/manifest_validation.osty` were ported from `use go "strings"` to `use std.strings as strings` on the same day. |
-| Native backend surface | merged native-only probe | the old AST merged probe is info-only; the authoritative current gate is `TestNativeToolchainMergedMIRPipelineIsClean`, which mirrors production MIR-first dispatch and legacy fallback. Bootstrap-only sources are filtered by FFI stanza (`use runtime.cihost`, `use runtime.golegacy.*`, or `use go "..."`). Historical 2026-04-21 notes about `TestNativeToolchainMergedIsClean` describe the retired AST gate, not the current pass/fail surface. |
+| Native backend surface | merged native-only probe | the old AST merged probe is info-only; the authoritative current gate is `TestNativeToolchainMergedMIRPipelineIsClean`, which mirrors the production MIR-direct route. Unsupported shapes now surface as skeleton IR plus `backend-route`, not silent legacy fallback. Bootstrap-only sources are filtered by FFI stanza (`use runtime.cihost`, `use runtime.golegacy.*`, or `use go "..."`). Historical 2026-04-21 notes about `TestNativeToolchainMergedIsClean` describe the retired AST gate, not the current pass/fail surface. |
 | Public runtime scheduler | `osty_rt_*` task/thread/select | `#496` complete. Select-send arm landed as typed entry points `osty_rt_select_send_{i64,i1,f64,ptr,bytes_v1}` (scalar packing into channel ring slot, bytes via GC-managed copy). The public LLVM runtime now has zero `osty_sched_unimplemented` call sites — concurrency spec §8 (taskGroup / spawn / join / cancel / chan / select / parallel / race / collectAll) is fully covered. See RUNTIME_SCHEDULER.md |
 | MIR Osty port | `toolchain/mir.osty` | `#503` — MIR core (intrinsic kinds, printer, operand/instr shapes) now has an Osty-native mirror in `toolchain/mir.osty`; Go remains authoritative while the Osty side participates in the spec corpus |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
@@ -392,9 +392,10 @@ rewire the remaining Go-hosted boundaries."
 
 1. **Keep the MIR-first native pipeline gate authoritative.**
    `TestNativeToolchainMergedMIRPipelineIsClean` now locks the production-like
-   path: MIR-first dispatch with legacy fallback. Future changes that
-   re-introduce a hard wall surface there immediately. When a new wall appears,
-   capture it through the MIR-first probe, `.osty` fixtures, or a narrow
+   MIR-direct path. Future changes that re-introduce a hard wall surface there
+   immediately through `ErrLLVMNotImplemented`, skeleton IR, and a
+   `backend-route` warning. When a new wall appears, capture it through
+   `OSTY_BACKEND_TRACE=1`, the MIR-first probe, `.osty` fixtures, or a narrow
    host-boundary test that exercises the remaining Go/Osty handoff.
 
 2. **Keep `osty check toolchain` green.**

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -11,13 +11,15 @@
 //
 // Dispatch order is intentionally small and observable:
 //
-//   - IR preflight rejects backend-capability gaps such as Go FFI or
-//     unknown runtime FFI before any concrete emitter is selected.
-//   - the native-owned llvmgen slice gets the first chance when the
-//     feature set allows it and no injected stdlib bodies are present.
-//   - every remaining normal backend request routes through MIR-direct
-//     emission; the legacy IR bridge is only a last resort for direct
-//     callers that provide no MIR.
+//   - `unsupported-preflight`: IR preflight rejects backend-capability gaps
+//     such as Go FFI or unknown runtime FFI before any concrete emitter is
+//     selected.
+//   - `native-owned`: the native-owned llvmgen slice gets the first chance
+//     when the feature set allows it and no injected stdlib bodies are present.
+//   - `mir-direct`: every remaining normal backend request routes through
+//     MIR-direct emission.
+//   - `legacy-ir-bridge`: the legacy IR bridge is only a last resort for
+//     direct callers that provide no MIR.
 //
 // Unsupported input is not a fatal compiler crash and is not silently
 // retried through an older AST path. The backend writes an inspectable

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	stdast "go/ast"
+	stdparser "go/parser"
+	"go/token"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -927,6 +932,380 @@ fn main() {
 	if warningContaining(result.Warnings, "backend-route: unsupported-preflight") == nil {
 		t.Fatalf("warnings = %v, want backend route detail", result.Warnings)
 	}
+}
+
+func TestLLVMBackendDispatchTraceReportsSelectedRoute(t *testing.T) {
+	backend := LLVMBackend{toolchain: &fakeLLVMToolchain{}}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    let s = "abc"
+    println(s.len())
+}
+`)
+	req.Features = []string{"mir-backend"}
+
+	result, emitErr, trace := captureLLVMBackendTrace(t, backend, req)
+	if emitErr != nil {
+		t.Fatalf("Emit returned error: %v", emitErr)
+	}
+	if result == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	for _, want := range []string{
+		"backend trace: llvm native-owned skipped",
+		"backend trace: llvm mir-direct emit",
+		"backend trace: llvm mir-direct succeeded",
+	} {
+		if !strings.Contains(trace, want) {
+			t.Fatalf("dispatch trace missing %q:\n%s", want, trace)
+		}
+	}
+}
+
+func TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing(t *testing.T) {
+	backend := LLVMBackend{toolchain: &fakeLLVMToolchain{}}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+	req.Features = []string{"mir-backend"}
+	req.Entry.MIR = nil
+
+	result, emitErr, trace := captureLLVMBackendTrace(t, backend, req)
+	if emitErr != nil {
+		t.Fatalf("Emit returned error: %v", emitErr)
+	}
+	if result == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	for _, want := range []string{
+		"backend trace: llvm native-owned skipped",
+		"backend trace: llvm legacy-ir-bridge emit",
+		"backend trace: llvm legacy-ir-bridge succeeded",
+	} {
+		if !strings.Contains(trace, want) {
+			t.Fatalf("dispatch trace missing %q:\n%s", want, trace)
+		}
+	}
+	if strings.Contains(trace, "backend trace: llvm mir-direct emit") {
+		t.Fatalf("missing-MIR entry unexpectedly used MIR route:\n%s", trace)
+	}
+}
+
+func TestLLVMBackendDocsMentionDispatchRoutes(t *testing.T) {
+	root := repoRoot(t)
+	docPath := filepath.Join(root, "docs", "mir_design.md")
+	doc := readTextFile(t, docPath)
+	backendDoc := readTextFile(t, filepath.Join(root, "internal", "backend", "doc.go"))
+
+	for _, want := range []string{
+		"## Backend dispatch trace",
+		"## MIR-direct coverage ledger",
+		"Stage 5 checklist",
+		"Removal ledger",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("docs/mir_design.md missing backend dispatch sync marker %q", want)
+		}
+	}
+
+	sourceRoutes := collectLLVMDispatchRoutesFromSource(t, filepath.Join(root, "internal", "backend", "llvm.go"))
+	docRoutes := map[string]bool{}
+	for _, line := range strings.Split(doc, "\n") {
+		cells := splitMarkdownTableRow(line)
+		if len(cells) == 0 || !strings.HasPrefix(cells[0], "`") || !strings.HasSuffix(cells[0], "`") {
+			continue
+		}
+		route := strings.Trim(cells[0], "`")
+		if strings.Contains(route, "-") {
+			docRoutes[route] = true
+		}
+	}
+
+	routeGuards := map[string][]string{
+		string(llvmDispatchUnsupportedPreflight): {
+			"UnsupportedDiagnosticForModule",
+			"TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug",
+		},
+		string(llvmDispatchNativeOwned): {
+			"TryGenerateNativeOwnedModule",
+			"TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered",
+			"TestTryEmitNativeOwnedLLVMIRText*",
+		},
+		string(llvmDispatchMIRDirect): {
+			"GenerateFromMIR",
+			"TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics",
+			"TestNativeToolchainMergedMIRPipelineIsClean",
+		},
+		string(llvmDispatchLegacyIRBridge): {
+			"GenerateModule",
+			"legacyFileFromModule",
+			"TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing",
+		},
+	}
+	for _, route := range sourceRoutes {
+		guards, ok := routeGuards[route]
+		if !ok {
+			t.Fatalf("dispatch route %q from internal/backend/llvm.go needs doc-sync expectations", route)
+		}
+		if !docRoutes[route] {
+			t.Fatalf("docs/mir_design.md route table missing dispatch route %q from internal/backend/llvm.go", route)
+		}
+		row := markdownTableRowForFirstCell(t, doc, "`"+route+"`")
+		for _, want := range guards {
+			if !strings.Contains(row, want) {
+				t.Fatalf("docs/mir_design.md route row %q missing %q:\n%s", route, want, row)
+			}
+		}
+		if !strings.Contains(backendDoc, route) {
+			t.Fatalf("internal/backend/doc.go missing dispatch route %q", route)
+		}
+	}
+	for route := range docRoutes {
+		if !containsString(sourceRoutes, route) {
+			t.Fatalf("docs/mir_design.md documents stale dispatch route %q not found in internal/backend/llvm.go", route)
+		}
+	}
+
+	testFuncs := collectGoFunctionNames(t,
+		filepath.Join(root, "internal", "backend", "llvm_test.go"),
+		filepath.Join(root, "internal", "llvmgen", "native_toolchain_mir_pipeline_test.go"),
+	)
+	for _, name := range []string{
+		"TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug",
+		"TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered",
+		"TestTryEmitNativeOwnedLLVMIRText*",
+		"TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics",
+		"TestNativeToolchainMergedMIRPipelineIsClean",
+		"TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing",
+		"TestLLVMBackendDocsMentionDispatchRoutes",
+	} {
+		if !functionNameOrPrefixExists(testFuncs, name) {
+			t.Fatalf("docs/mir_design.md names guard %q but no matching test exists", name)
+		}
+	}
+
+	backendFuncs := collectGoFunctionNames(t, filepath.Join(root, "internal", "backend", "llvm.go"))
+	mirFuncs := collectGoFunctionNames(t, filepath.Join(root, "internal", "llvmgen", "mir_generator.go"))
+	ledgerRows := []struct {
+		gate    string
+		anchors map[string]map[string]bool
+	}{
+		{
+			gate: "Backend route",
+			anchors: map[string]map[string]bool{
+				"backend": {"generateLLVMIR": true, "llvmFallbackDispatchRoute": true},
+			},
+		},
+		{
+			gate: "Module / function envelope",
+			anchors: map[string]map[string]bool{
+				"mir": {"checkSupported": true, "checkFunctionSupported": true},
+			},
+		},
+		{
+			gate: "Type surface",
+			anchors: map[string]map[string]bool{
+				"mir": {"typeSupported": true, "allowUnusedErrLocal": true},
+			},
+		},
+		{
+			gate: "Place / projection surface",
+			anchors: map[string]map[string]bool{
+				"mir": {"checkProjectionsSupported": true},
+			},
+		},
+		{
+			gate: "RValue surface",
+			anchors: map[string]map[string]bool{
+				"mir": {"checkRValueSupported": true},
+			},
+		},
+		{
+			gate: "Instruction / terminator surface",
+			anchors: map[string]map[string]bool{
+				"mir": {"checkInstrSupported": true, "checkTermSupported": true},
+			},
+		},
+		{
+			gate: "Intrinsic families",
+			anchors: map[string]map[string]bool{
+				"mir": {"isSupportedIntrinsic": true},
+			},
+		},
+	}
+	for _, row := range ledgerRows {
+		line := markdownTableRowForFirstCell(t, doc, row.gate)
+		for group, names := range row.anchors {
+			for name := range names {
+				if !strings.Contains(line, name) {
+					t.Fatalf("coverage ledger row %q missing code anchor %q:\n%s", row.gate, name, line)
+				}
+				switch group {
+				case "backend":
+					if !backendFuncs[name] {
+						t.Fatalf("coverage ledger anchor %q for row %q does not exist in internal/backend/llvm.go", name, row.gate)
+					}
+				case "mir":
+					if !mirFuncs[name] {
+						t.Fatalf("coverage ledger anchor %q for row %q does not exist in internal/llvmgen/mir_generator.go", name, row.gate)
+					}
+				}
+			}
+		}
+	}
+}
+
+func captureLLVMBackendTrace(t *testing.T, backend LLVMBackend, req Request) (*Result, error, string) {
+	t.Helper()
+	t.Setenv("OSTY_BACKEND_TRACE", "1")
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	result, emitErr := backend.Emit(context.Background(), req)
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("close stderr pipe: %v", closeErr)
+	}
+	os.Stderr = oldStderr
+	traceBytes, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("read trace pipe: %v", readErr)
+	}
+	if closeErr := r.Close(); closeErr != nil {
+		t.Fatalf("close trace pipe: %v", closeErr)
+	}
+	return result, emitErr, string(traceBytes)
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	return root
+}
+
+func readTextFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	return string(data)
+}
+
+func markdownTableRowForFirstCell(t *testing.T, doc, firstCell string) string {
+	t.Helper()
+	for _, line := range strings.Split(doc, "\n") {
+		cells := splitMarkdownTableRow(line)
+		if len(cells) > 0 && cells[0] == firstCell {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatalf("markdown table row with first cell %q not found", firstCell)
+	return ""
+}
+
+func splitMarkdownTableRow(line string) []string {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+		return nil
+	}
+	line = strings.Trim(line, "|")
+	parts := strings.Split(line, "|")
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cells = append(cells, strings.TrimSpace(part))
+	}
+	return cells
+}
+
+func collectLLVMDispatchRoutesFromSource(t *testing.T, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := stdparser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("ParseFile(%q): %v", path, err)
+	}
+	var routes []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*stdast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*stdast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if !strings.HasPrefix(name.Name, "llvmDispatch") || i >= len(valueSpec.Values) {
+					continue
+				}
+				lit, ok := valueSpec.Values[i].(*stdast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				route, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote dispatch route %s in %q: %v", lit.Value, path, err)
+				}
+				routes = append(routes, route)
+			}
+		}
+	}
+	if len(routes) == 0 {
+		t.Fatalf("no llvmDispatch route constants found in %q", path)
+	}
+	return routes
+}
+
+func collectGoFunctionNames(t *testing.T, paths ...string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		file, err := stdparser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("ParseFile(%q): %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*stdast.FuncDecl)
+			if !ok || fn.Name == nil {
+				continue
+			}
+			out[fn.Name.Name] = true
+		}
+	}
+	return out
+}
+
+func functionNameOrPrefixExists(names map[string]bool, want string) bool {
+	if strings.HasSuffix(want, "*") {
+		prefix := strings.TrimSuffix(want, "*")
+		for name := range names {
+			if strings.HasPrefix(name, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+	return names[want]
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics — Stage 5 prep

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -47,14 +47,14 @@
 //
 // Implementation note (transitional)
 //
-// GenerateModule now first tries a native-owned primitive/control-flow
-// slice mirrored from `toolchain/llvmgen.osty` and falls back to the
-// legacy IR -> AST bridge only for shapes still outside that slice
-// (see ir_module.go). TryGenerateNativeOwnedModule exposes just that
-// native-owned slice without taking the fallback. The bridge remains a
-// transitional implementation detail: callers never construct nor
-// observe the intermediate AST. Follow-on work will keep growing the
-// native path until the fallback disappears entirely.
+// GenerateModule first tries a native-owned primitive/control-flow slice
+// mirrored from `toolchain/llvmgen.osty` and then uses the legacy IR -> AST
+// bridge for direct callers whose shapes are still outside that slice (see
+// ir_module.go). The backend dispatcher does not use that bridge as a hidden
+// retry once an Entry has MIR; MIR unsupported shapes are surfaced as
+// route-tagged skeleton artifacts instead. TryGenerateNativeOwnedModule exposes
+// just the native-owned slice without taking the bridge. Follow-on work will
+// keep growing the native/MIR paths until the bridge disappears entirely.
 //
 // The active GC implementation path paired with this lowering lives
 // in `internal/backend/runtime/osty_runtime.c`.

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -7,12 +7,18 @@
 // blocks, projections, and terminators, so the emitter is substantially
 // simpler than the AST-based one.
 //
-// Stage 3 is opt-in: callers set `Options.UseMIR = true` (and supply a
-// MIR module via the backend Entry). The legacy path remains the
-// default until parity lands on the full LLVM test corpus; see
-// docs/mir_design.md for the migration plan.
+// The backend dispatcher now selects this path by default for ordinary
+// LLVM requests after the native-owned fast path declines coverage.
+// Unsupported MIR shapes return an UnsupportedError so the dispatcher
+// can render a route-tagged skeleton artifact; it does not silently
+// retry the legacy HIR→AST bridge for normal backend requests. Direct
+// llvmgen callers that intentionally want the transitional bridge can
+// still call GenerateModule; see docs/mir_design.md for the removal
+// checklist.
 //
-// MVP scope for this patch:
+// Original MVP scope for this entry point was deliberately small; the current
+// supported surface is broader and is guarded by checkSupported plus the
+// route-sensitive backend tests:
 //   - Primitive types: Int (i64), Int32/Int16/Int8/Byte/UInt*, Bool
 //     (i1), Float/Float64 (double), Float32 (float), Unit (void),
 //     String (ptr).
@@ -25,8 +31,8 @@
 //     SSA during optimisation, so the emitter stays alloca-simple.
 //   - No structs, enums, tuples, lists, maps, optional unwrap, closure
 //     aggregates, or concurrency intrinsics. Anything outside the MVP
-//     returns an UnsupportedError so the backend dispatcher can fall
-//     back to the legacy path.
+//     returns an UnsupportedError so the backend dispatcher can report
+//     the uncovered route explicitly.
 
 package llvmgen
 
@@ -54,8 +60,9 @@ func fastPathListWriteEnabled() bool {
 }
 
 // GenerateFromMIR emits textual LLVM IR from a MIR module. It is the
-// Stage 3 entry point into llvmgen. Callers that still want the legacy
-// HIR→AST path should call GenerateModule with Options.UseMIR == false.
+// Stage 3 entry point into llvmgen. Direct callers that still want the legacy
+// HIR→AST bridge should call GenerateModule; the backend dispatcher uses this
+// path for normal requests whenever Entry.MIR is available.
 func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	if m == nil {
 		return nil, unsupported("source-layout", "nil MIR module")
@@ -571,7 +578,7 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		return true
 	case *ir.FnType:
 		// Fn values pass as `ptr` at the LLVM boundary; accept them
-		// for now (closures with captures still fall back to legacy).
+		// for now (heap-escaping captured closures remain a Stage 5 gap).
 		return true
 	}
 	return false
@@ -845,9 +852,10 @@ func (g *mirGen) checkInstrSupported(fn *mir.Function, inst mir.Instr) error {
 }
 
 // checkProjectionsSupported walks a Place's projection chain and
-// refuses anything outside the emitter's current coverage. Stage 3.5
-// adds IndexProj for list-typed bases (e.g. `xs[i]`). DerefProj still
-// belongs to later stages.
+// refuses anything outside the emitter's current coverage. IndexProj
+// is limited to List / Map / String bases; DerefProj must carry the
+// type being loaded so the emit loop can keep the LLVM and MIR type
+// cursors aligned.
 func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx string) error {
 	for i, proj := range p.Projections {
 		switch proj.(type) {
@@ -8606,7 +8614,7 @@ func (g *mirGen) emitDiscriminantRV(rv *mir.DiscriminantRV) (string, error) {
 // emitLenRV lowers MIR's direct length query on a place to the same
 // runtime entrypoints used by the intrinsic path. This is the shape
 // lowerForIn emits for list iteration, so supporting it keeps those
-// loops on the MIR path instead of forcing a legacy fallback.
+// loops on the MIR path instead of surfacing an unsupported route.
 func (g *mirGen) emitLenRV(rv *mir.LenRV) (string, error) {
 	placeT := g.placeType(rv.Place)
 	if placeT == nil {


### PR DESCRIPTION
## Summary
- Document the current LLVM backend dispatch routes, MIR-direct coverage ledger, and Stage 5 legacy bridge removal checklist.
- Align backend and llvmgen package comments with the observable route model.
- Add backend tests that lock MIR-direct vs legacy bridge routing and validate doc/code drift for route names, ledger anchors, and guard tests.

## Validation
- `git diff --check`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendDocsMentionDispatchRoutes|TestLLVMBackendDispatchTraceReportsSelectedRoute|TestLLVMBackendDispatchTraceUsesLegacyRouteOnlyWhenMIRMissing|TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug|TestUseNativeOwnedLLVMIR' -v`
- `go test -count=1 -vet=off ./internal/backend`