### PR TITLE
[codex] add package graph compile target

### DIFF
--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -93,8 +93,9 @@ func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
 			pkg.RuntimeCapability = req.Package.RuntimeCapability
 		}
 	}
-	results := ws.ResolveAll()
-	checks := check.Workspace(ws, results, check.Opts{
+	graph := resolve.NewPackageGraph(ws)
+	results := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, results, check.Opts{
 
 		Stdlib: ws.Stdlib,
 	})
@@ -123,7 +124,7 @@ func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
 	if chk == nil {
 		chk = &check.Result{}
 	}
-	return backend.PreparePackage("main", entryPath, pkg, entryFile, chk)
+	return backend.PrepareGraphPackage("main", entryPath, graph, "", entryFile, chk)
 }
 
 func writePackageRequest(req llvmgenRequest) (string, string, error) {

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
@@ -324,13 +323,10 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 			os.Exit(1)
 		}
 	}
-	results := ws.ResolveAll()
-	checks := check.Workspace(ws, results, checkOpts())
-	paths := make([]string, 0, len(ws.Packages))
-	for p := range ws.Packages {
-		paths = append(paths, p)
-	}
-	sort.Strings(paths)
+	graph := resolve.NewPackageGraph(ws)
+	results := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, results, checkOpts())
+	paths := graph.PackagePaths()
 	anyErr := false
 	for _, p := range paths {
 		pkg := ws.Packages[p]
@@ -356,7 +352,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 	if m.HasPackage {
 		rootPkg := ws.Packages[""]
 		if rootPkg != nil {
-			return emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
+			return emitAndBuild(dir, m, graph, "", rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
 		}
 	}
 	return nil
@@ -382,9 +378,11 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 			fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 			os.Exit(1)
 		}
-		results := ws.ResolveAll()
-		checks := check.Workspace(ws, results, checkOpts())
-		for key, pkg := range ws.Packages {
+		graph := resolve.NewPackageGraph(ws)
+		results := resolve.ResolveGraph(graph)
+		checks := check.PackageGraph(graph, results, checkOpts())
+		for _, key := range graph.PackagePaths() {
+			pkg := ws.Packages[key]
 			r := results[key]
 			if r == nil || pkg == nil {
 				continue
@@ -400,7 +398,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		}
 		rootPkg := ws.Packages[""]
 		if rootPkg != nil {
-			return emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
+			return emitAndBuild(dir, m, graph, "", rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
 		}
 		return nil
 	}
@@ -409,8 +407,11 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}
-	res := resolve.ResolvePackageDefault(pkg)
-	chk := check.Package(pkg, res, checkOpts())
+	graph := resolve.NewPackageGraphForPackage("", pkg)
+	results := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, results, checkOpts())
+	res := results[""]
+	chk := checks[""]
 	ds := append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...)
 	printPackageDiags(pkg, ds, flags)
 	if hasError(ds) {
@@ -419,7 +420,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 	// Note: the no-deps path feeds a synthetic PackageResult because
 	// emitAndBuild expects a *resolve.PackageResult with Diags; we
 	// already have all of it from ResolvePackage above.
-	return emitAndBuild(dir, m, pkg, res, chk, resolved, feats, backendID, emitMode)
+	return emitAndBuild(dir, m, graph, "", pkg, res, chk, resolved, feats, backendID, emitMode)
 }
 
 // emitAndBuild picks the entry file (manifest `[bin].path` or default
@@ -432,7 +433,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 //
 // A failure at the backend/toolchain step returns a non-zero exit; a gen-time
 // TODO marker is only logged so the clean portion remains inspectable.
-func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
+func emitAndBuild(root string, m *manifest.Manifest, graph *resolve.PackageGraph, packagePath string, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
 	// 1. Locate the entry file. A library project has no entry;
 	// skip the emit path so `osty build` still works as a front-end
 	// check for libs.
@@ -524,7 +525,10 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 			}
 		}
 	}
-	entry, err := backend.PreparePackage("main", entryAbs, pkg, entryFile, chk)
+	if graph == nil {
+		graph = resolve.NewPackageGraphForPackage(packagePath, pkg)
+	}
+	entry, err := backend.PrepareGraphPackage("main", entryAbs, graph, packagePath, entryFile, chk)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)

--- a/cmd/osty/doc.go
+++ b/cmd/osty/doc.go
@@ -236,12 +236,14 @@ func runWorkspaceDoc(root, format, outPath, title string,
 	for _, p := range resolve.WorkspacePackagePaths(root) {
 		_, _ = ws.LoadPackageNative(p)
 	}
+	graph := resolve.NewPackageGraph(ws)
 
 	// Build docgen Packages keyed by the workspace's import paths so
 	// the index page's display order matches the resolver's view.
 	docPkgs := map[string]*docgen.SelfDocPackage{}
 	anyFatal := false
-	for impPath, pkg := range ws.Packages {
+	for _, impPath := range graph.PackagePaths() {
+		pkg := graph.Package(impPath)
 		if pkg == nil {
 			continue
 		}

--- a/cmd/osty/gen_emit.go
+++ b/cmd/osty/gen_emit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/nativellvmgen"
+	"github.com/osty/osty/internal/resolve"
 )
 
 var tryExternalGenLLVMIR = func(entry *genPackageEntry) ([]byte, bool, []error, error) {
@@ -24,7 +25,11 @@ func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Ent
 		return backend.Entry{}, fmt.Errorf("missing package input for gen")
 	}
 	if countLowerableFiles(entry.pkg) > 0 {
-		return backend.PreparePackage(pkgName, entry.sourcePath, entry.pkg, entry.file, entry.chk)
+		graph := entry.graph
+		if graph == nil {
+			graph = resolve.NewPackageGraphForPackage(entry.pkgPath, entry.pkg)
+		}
+		return backend.PrepareGraphPackage(pkgName, entry.sourcePath, graph, entry.pkgPath, entry.file, entry.chk)
 	}
 	file, src, err := parseGenEmitFile(entry.pkg)
 	if err != nil {

--- a/cmd/osty/lint_cmd.go
+++ b/cmd/osty/lint_cmd.go
@@ -54,13 +54,14 @@ func runLintWorkspace(dir string, flags cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
+	graph := resolve.NewPackageGraph(ws)
 	anyErr, anyWarn := false, false
-	for _, path := range nativeWorkspacePaths(ws) {
-		pkg := ws.Packages[path]
+	for _, path := range nativeGraphPaths(graph) {
+		pkg := graph.Package(path)
 		if pkg == nil {
 			continue
 		}
-		imports := check.PackageImportSurfacesForSelfhost(pkg, ws, ws.Stdlib)
+		imports := resolve.PackageGraphImportSurfaces(graph, path)
 		frontendDiags, err := lintNativePackageDiagnostics(pkg, imports)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1549,6 +1549,8 @@ func adjustGenResultForUserOutput(result *backend.Result, name backend.Name, out
 
 type genPackageEntry struct {
 	sourcePath string
+	graph      *resolve.PackageGraph
+	pkgPath    string
 	pkg        *resolve.Package
 	res        *resolve.PackageResult
 	chk        *check.Result
@@ -1576,8 +1578,9 @@ func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTrans
 	if _, err := ws.LoadPackageNative(""); err != nil {
 		return nil, err
 	}
-	results := ws.ResolveAll()
-	checks := check.Workspace(ws, results, checkOpts())
+	graph := resolve.NewPackageGraph(ws)
+	results := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, results, checkOpts())
 	pkg := ws.Packages[""]
 	if pkg == nil {
 		return nil, fmt.Errorf("%s: no package sources were loaded", filepath.Dir(absPath))
@@ -1609,6 +1612,8 @@ func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTrans
 	}
 	return &genPackageEntry{
 		sourcePath: absPath,
+		graph:      graph,
+		pkgPath:    "",
 		pkg:        pkg,
 		res:        res,
 		chk:        chk,
@@ -1634,20 +1639,29 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 		if err != nil {
 			return nil, err
 		}
+		var original []byte
+		transformApplied := false
+		transformChanged := false
 		if transform != nil {
+			original = append([]byte(nil), src...)
 			src = transform(path, src)
+			transformApplied = true
+			transformChanged = !bytes.Equal(original, src)
 		}
 		run := selfhost.Run(src)
 		file := selfhost.LowerPublicFileFromRun(run)
 		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, file)
 		pf := &resolve.PackageFile{
-			Path:            path,
-			Source:          src,
-			CanonicalSource: canonicalSrc,
-			CanonicalMap:    canonicalMap,
-			File:            file,
-			Run:             run,
-			ParseDiags:      run.Diagnostics(),
+			Path:                   path,
+			Source:                 src,
+			OriginalSource:         original,
+			SourceTransformApplied: transformApplied,
+			SourceTransformChanged: transformChanged,
+			CanonicalSource:        canonicalSrc,
+			CanonicalMap:           canonicalMap,
+			File:                   file,
+			Run:                    run,
+			ParseDiags:             run.Diagnostics(),
 		}
 		pkg.Files = append(pkg.Files, pf)
 		res.Diags = append(res.Diags, pf.ParseDiags...)
@@ -1658,8 +1672,11 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 	if entryFile == nil {
 		return nil, fmt.Errorf("%s is not part of the selected gen input set", sourcePath)
 	}
+	graph := resolve.NewPackageGraphForPackage("", pkg)
 	return &genPackageEntry{
 		sourcePath: sourcePath,
+		graph:      graph,
+		pkgPath:    "",
 		pkg:        pkg,
 		res:        res,
 		chk:        chk,

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -308,13 +308,14 @@ func runNativeWorkspaceCheck(dir, mode string, flags cliFlags, emitTypes bool) i
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		return 1
 	}
+	graph := resolve.NewPackageGraph(ws)
 	anyErr := false
-	for _, path := range nativeWorkspacePaths(ws) {
-		pkg := ws.Packages[path]
+	for _, path := range nativeGraphPaths(graph) {
+		pkg := graph.Package(path)
 		if pkg == nil {
 			continue
 		}
-		input := nativePackageCheckInput(pkg, check.PackageImportSurfacesForSelfhost(pkg, ws, ws.Stdlib))
+		input := nativePackageCheckInput(pkg, resolve.PackageGraphImportSurfaces(graph, path))
 		checked, err := selfhost.CheckPackageStructured(input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)
@@ -386,6 +387,22 @@ func nativeWorkspacePaths(ws *resolve.Workspace) []string {
 	sort.Strings(paths)
 	return paths
 }
+
+func nativeGraphPaths(graph *resolve.PackageGraph) []string {
+	if graph == nil {
+		return nil
+	}
+	var paths []string
+	for _, path := range graph.PackagePaths() {
+		if strings.HasPrefix(path, resolve.StdPrefix) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
 func nativePackageCheckInput(pkg *resolve.Package, imports []api.PackageCheckImport) api.PackageCheckInput {
 	input := api.PackageCheckInput{
 		Files: make([]api.PackageCheckFile, 0, len(pkg.Files)),

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -102,14 +102,14 @@ func runRun(args []string, cliF cliFlags) {
 
 	// Step 1: vendor deps (also runs resolve, computes the graph +
 	// DepProvider we'll attach to the workspace).
-	graph, env, err := resolveAndVendorEnvOpts(m, root, resolveOpts{
+	depGraph, env, err := resolveAndVendorEnvOpts(m, root, resolveOpts{
 		Offline: offline, Locked: locked, Frozen: frozen,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(3)
 	}
-	deps := pkgmgr.NewDepProvider(m, graph, env)
+	deps := pkgmgr.NewDepProvider(m, depGraph, env)
 
 	// Turn on the native-checker cache so repeated `osty run` cycles
 	// during development don't re-check packages that haven't changed.
@@ -145,12 +145,14 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}
-	results := ws.ResolveAll()
-	checks := check.Workspace(ws, results, checkOpts())
+	packageGraph := resolve.NewPackageGraph(ws)
+	results := resolve.ResolveGraph(packageGraph)
+	checks := check.PackageGraph(packageGraph, results, checkOpts())
 	// Aggregate diagnostics across every loaded package so front-end
 	// errors in a vendored dep also surface.
 	var all []*diag.Diagnostic
-	for key, pkg := range ws.Packages {
+	for _, key := range packageGraph.PackagePaths() {
+		pkg := packageGraph.Package(key)
 		r := results[key]
 		if r == nil || pkg == nil {
 			continue
@@ -219,7 +221,7 @@ func runRun(args []string, cliF cliFlags) {
 			return
 		}
 	}
-	backendEntry, err := backend.PreparePackage("main", entryAbs, rootPkg, entryFile, chk)
+	backendEntry, err := backend.PrepareGraphPackage("main", entryAbs, packageGraph, "", entryFile, chk)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -748,9 +748,14 @@ func prepareNativeTestBackendEntry(sourcePath string, pkg *resolve.Package) (bac
 		}
 	}
 	if countLowerableFiles(pkg) > 0 {
-		res := resolve.ResolvePackageDefault(pkg)
-		chk := check.Package(pkg, res, checkOpts())
-		return backend.PreparePackage("main", sourcePath, pkg, entryFile, chk)
+		graph := resolve.NewPackageGraphForPackage("", pkg)
+		results := resolve.ResolveGraph(graph)
+		checks := check.PackageGraph(graph, results, checkOpts())
+		chk := checks[""]
+		if chk == nil {
+			chk = &check.Result{}
+		}
+		return backend.PrepareGraphPackage("main", sourcePath, graph, "", entryFile, chk)
 	}
 	file, src, err := parseGenEmitFile(pkg)
 	if err != nil {

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -122,6 +122,20 @@ func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryF
 	return finalizeEntryModule(entry, mod)
 }
 
+// PrepareGraphPackage lowers one package selected from a first-class
+// PackageGraph. It is the graph-native spelling of PreparePackage and lets
+// build orchestrators keep the compile target explicit through backend setup.
+func PrepareGraphPackage(packageName, sourcePath string, graph *resolve.PackageGraph, packagePath string, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
+	if graph == nil {
+		return Entry{}, fmt.Errorf("backend: nil package graph")
+	}
+	pkg := graph.Package(packagePath)
+	if pkg == nil {
+		return Entry{}, fmt.Errorf("backend: graph package %q not found", packagePath)
+	}
+	return PreparePackage(packageName, sourcePath, pkg, entryFile, chk)
+}
+
 // finalizeEntryModule runs the post-lowering pipeline (stdlib injection
 // gate, monomorphize, validate, MIR lowering + optional optimize +
 // validate) shared by PrepareEntry and PreparePackage. Splitting this

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -306,6 +306,48 @@ func Workspace(
 	return out
 }
 
+// PackageGraph returns type-check results for every package in a first-class
+// compile-target graph. Workspace-backed graphs keep using the workspace
+// adapter while standalone graph packages fall back to per-package checks.
+func PackageGraph(
+	graph *resolve.PackageGraph,
+	resolved map[string]*resolve.PackageResult,
+	opts ...Opts,
+) map[string]*Result {
+	if graph == nil {
+		return map[string]*Result{}
+	}
+	if ws := graph.Workspace(); ws != nil {
+		return Workspace(ws, resolved, opts...)
+	}
+	opt := firstOpt(opts)
+	paths := graph.PackagePaths()
+	if len(paths) == 0 {
+		return map[string]*Result{}
+	}
+	shared := newResult()
+	out := make(map[string]*Result, len(paths))
+	for _, path := range paths {
+		pkg := graph.Package(path)
+		if pkg == nil || pkg.PkgScope == nil {
+			continue
+		}
+		pr := resolved[path]
+		result := resultWithSharedMaps(shared)
+		out[path] = result
+		applyNativePackageResult(result, pkg, pr, nil, opt.Stdlib, isPrivilegedPackage(pkg))
+		stampPackageDiags(result.Diags, pkg)
+		for _, pf := range pkg.Files {
+			if pf == nil {
+				continue
+			}
+			recordSelfhostDeclPass(opt.OnDecl, pf.File, "collect")
+			recordSelfhostDeclPass(opt.OnDecl, pf.File, "check")
+		}
+	}
+	return out
+}
+
 func newResult() *Result {
 	return &Result{
 		Types:              map[ast.Expr]types.Type{},

--- a/internal/cihost/host.go
+++ b/internal/cihost/host.go
@@ -31,6 +31,7 @@ type LoadResult struct {
 	Root      string
 	Manifest  *manifest.Manifest
 	Workspace *resolve.Workspace
+	Graph     *resolve.PackageGraph
 	Packages  []*resolve.Package
 	Results   []*resolve.PackageResult
 	Error     string
@@ -113,7 +114,9 @@ func LoadRunnerState(root string, preloaded *manifest.Manifest) LoadResult {
 	}
 	filterPackageCIFiles(pkg)
 	r.Packages = []*resolve.Package{pkg}
-	pr := resolve.ResolvePackageDefault(pkg)
+	r.Graph = resolve.NewPackageGraphForPackage("", pkg)
+	results := resolve.ResolveGraph(r.Graph)
+	pr := results[""]
 	r.Results = []*resolve.PackageResult{pr}
 	return *r
 }
@@ -155,7 +158,8 @@ func loadWorkspace(r *LoadResult, byManifest bool) LoadResult {
 		}
 	}
 
-	allResults := ws.ResolveAll()
+	r.Graph = resolve.NewPackageGraph(ws)
+	allResults := resolve.ResolveGraph(r.Graph)
 	for _, path := range pkgPaths {
 		r.Results = append(r.Results, allResults[path])
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -799,17 +799,23 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 	// has `.osty` files; LoadPackage chases `use` edges from there.
 	seedWorkspace(ws, root)
 	lspMaterializeNativeWorkspace(ws)
-	resolved := ws.ResolveAll()
-	checks := check.Workspace(ws, resolved, lspCheckOpts(nil))
+	graph := resolve.NewPackageGraph(ws)
+	resolved := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, resolved, lspCheckOpts(nil))
 	// Collect every loaded package for cross-file handlers.
-	allPkgs := make([]*resolve.Package, 0, len(ws.Packages))
-	for _, pkg := range ws.Packages {
+	allPkgs := make([]*resolve.Package, 0, len(graph.Packages))
+	for _, pkgPath := range graph.PackagePaths() {
+		pkg := graph.Package(pkgPath)
 		if pkg != nil {
 			allPkgs = append(allPkgs, pkg)
 		}
 	}
 	// Find the package + file entry this document belongs to.
-	for pkgPath, pkg := range ws.Packages {
+	for _, pkgPath := range graph.PackagePaths() {
+		pkg := graph.Package(pkgPath)
+		if pkg == nil {
+			continue
+		}
 		for _, pf := range pkg.Files {
 			if pf.Path == path {
 				// Run lint over this package only — the owner of the
@@ -1235,9 +1241,11 @@ func (s *Server) ensureWorkspaceIndex(root string) []*resolve.Package {
 	ws.Packages = map[string]*resolve.Package{}
 	seedWorkspace(ws, root)
 	lspMaterializeNativeWorkspace(ws)
-	_ = ws.ResolveAll()
-	pkgs := make([]*resolve.Package, 0, len(ws.Packages))
-	for _, pkg := range ws.Packages {
+	graph := resolve.NewPackageGraph(ws)
+	_ = resolve.ResolveGraph(graph)
+	pkgs := make([]*resolve.Package, 0, len(graph.Packages))
+	for _, pkgPath := range graph.PackagePaths() {
+		pkg := graph.Package(pkgPath)
 		if pkg != nil {
 			pkgs = append(pkgs, pkg)
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -415,7 +415,8 @@ func emitConfiguredGenPackage(cfg Config, pkgName string, pkg *resolve.Package, 
 	if sourcePath == "" {
 		sourcePath = "<pipeline>"
 	}
-	entry, err := backend.PreparePackage(pkgName, sourcePath, pkg, entryFile, chk)
+	graph := resolve.NewPackageGraphForPackage("", pkg)
+	entry, err := backend.PrepareGraphPackage(pkgName, sourcePath, graph, "", entryFile, chk)
 	if err != nil {
 		return nil, err
 	}
@@ -814,17 +815,14 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 	for _, p := range resolve.WorkspacePackagePaths(dir) {
 		_, _ = ws.LoadPackageNative(p)
 	}
+	graph := resolve.NewPackageGraph(ws)
 
 	totalFiles, totalBytes, totalDecls, totalStmts, totalUses := 0, 0, 0, 0, 0
 	var loadDiags []*diag.Diagnostic
 	if r.Sources == nil {
 		r.Sources = map[string][]byte{}
 	}
-	pkgPaths := make([]string, 0, len(ws.Packages))
-	for p := range ws.Packages {
-		pkgPaths = append(pkgPaths, p)
-	}
-	sort.Strings(pkgPaths)
+	pkgPaths := graph.PackagePaths()
 	for _, p := range pkgPaths {
 		pkg := ws.Packages[p]
 		if pkg == nil {
@@ -864,7 +862,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 
 	// --- resolve (workspace-wide) ---
 	t0 = time.Now()
-	results := ws.ResolveAll()
+	results := resolve.ResolveGraph(graph)
 	totalRefs, totalTypeRefs := 0, 0
 	var resolveDiags []*diag.Diagnostic
 	for _, p := range pkgPaths {
@@ -910,7 +908,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 			})
 		}
 	}
-	checks := check.Workspace(ws, results, checkOpts)
+	checks := check.PackageGraph(graph, results, checkOpts)
 	var checkDiags []*diag.Diagnostic
 	totalTypedExprs, totalLetTypes, totalSymTypes := 0, 0, 0
 	for _, p := range pkgPaths {

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -91,6 +91,7 @@ func (rp *ResolvedPackage) FileResult(path string) *resolve.Result {
 // handlers.
 type ResolvedWorkspace struct {
 	root     string
+	graph    *resolve.PackageGraph
 	pkgs     []*resolve.Package
 	pkgMap   map[string]*resolve.Package       // normalized dir → Package
 	results  map[string]*resolve.PackageResult // normalized dir → PackageResult
@@ -99,6 +100,14 @@ type ResolvedWorkspace struct {
 
 // Root returns the workspace root directory (normalized).
 func (rw *ResolvedWorkspace) Root() string { return rw.root }
+
+// Graph returns the first-class package graph used for workspace resolution.
+func (rw *ResolvedWorkspace) Graph() *resolve.PackageGraph {
+	if rw == nil {
+		return nil
+	}
+	return rw.graph
+}
 
 // Packages returns every loaded package. Callers must treat the
 // returned slice as read-only.
@@ -250,16 +259,15 @@ type Queries struct {
 	CheckFile *query.Query[string, *check.Result]
 
 	// ResolveWorkspace: (rootDir) -> full cross-package resolution.
-	// Assembles a resolve.Workspace from BuildPackage outputs and
-	// runs ws.ResolveAll(). Use this when WorkspaceMembers has been
-	// seeded (workspace mode) instead of the per-package
-	// ResolvePackage query.
+	// Assembles a PackageGraph from BuildPackage outputs and runs
+	// resolve.ResolveGraph. Use this when WorkspaceMembers has been seeded
+	// (workspace mode) instead of the per-package ResolvePackage query.
 	// Depends on: WorkspaceMembers, BuildPackage(dir) for each dir.
 	ResolveWorkspace *query.Query[string, *ResolvedWorkspace]
 
 	// CheckWorkspace: (rootDir) -> per-package check results for
-	// the entire workspace. Calls check.Workspace with the output
-	// of ResolveWorkspace.
+	// the entire workspace. Calls check.PackageGraph with the output of
+	// ResolveWorkspace.
 	// Depends on: ResolveWorkspace(rootDir).
 	CheckWorkspace *query.Query[string, *WorkspaceCheckResult]
 
@@ -463,7 +471,8 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			}
 
 			// Cross-package resolution (declare pass + body pass).
-			resolved := ws.ResolveAll()
+			graph := resolve.NewPackageGraph(ws)
+			resolved := resolve.ResolveGraph(graph)
 
 			// Build the result, converting dotted-path keys back to
 			// normalized directory keys.
@@ -480,6 +489,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			}
 			return &ResolvedWorkspace{
 				root:     rootDir,
+				graph:    graph,
 				pkgs:     pkgList,
 				pkgMap:   builtPkgs,
 				results:  resultsByDir,
@@ -489,9 +499,8 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 		hashResolvedWorkspaceFn,
 	)
 
-	// CheckWorkspace runs check.Workspace over the resolved packages.
-	// It rebuilds a temporary resolve.Workspace from the
-	// ResolveWorkspace output because check.Workspace expects one.
+	// CheckWorkspace runs check.PackageGraph over the resolved packages,
+	// reusing the first-class graph captured by ResolveWorkspace.
 	qs.CheckWorkspace = query.Register(db, "CheckWorkspace",
 		func(ctx *query.Ctx, rootDir string) *WorkspaceCheckResult {
 			rw := qs.ResolveWorkspace.Fetch(ctx, rootDir)
@@ -499,18 +508,15 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				return &WorkspaceCheckResult{}
 			}
 
-			// Rebuild a resolve.Workspace + resolved map for
-			// check.Workspace, which expects dotted-path keys.
-			ws, _ := resolve.NewWorkspace(rootDir)
+			// Rebuild dotted-path result keys for check.PackageGraph.
 			resolvedMap := make(map[string]*resolve.PackageResult, len(rw.resolved))
 			for dir, rp := range rw.resolved {
 				dotPath := dotPathFromDir(rootDir, dir)
-				ws.Packages[dotPath] = rp.pkg
 				resolvedMap[dotPath] = rp.res
 			}
 
 			opts := check.Opts{Stdlib: resolveStdlibProvider(ctx)}
-			checks := check.Workspace(ws, resolvedMap, opts)
+			checks := check.PackageGraph(rw.Graph(), resolvedMap, opts)
 
 			// Convert dotted-path keys back to directory keys.
 			byDir := make(map[string]*check.Result, len(checks))

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -81,15 +82,24 @@ func loadPackageNativePaths(paths []string, dir, name string, transform SourceTr
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
+		var original []byte
+		transformApplied := false
+		transformChanged := false
 		if transform != nil {
+			original = append([]byte(nil), src...)
 			src = transform(p, src)
+			transformApplied = true
+			transformChanged = !bytes.Equal(original, src)
 		}
 		run := selfhost.Run(src)
 		pkg.Files = append(pkg.Files, &PackageFile{
-			Path:       p,
-			Source:     src,
-			Run:        run,
-			ParseDiags: append([]*diag.Diagnostic(nil), run.Diagnostics()...),
+			Path:                   p,
+			Source:                 src,
+			OriginalSource:         original,
+			SourceTransformApplied: transformApplied,
+			SourceTransformChanged: transformChanged,
+			Run:                    run,
+			ParseDiags:             append([]*diag.Diagnostic(nil), run.Diagnostics()...),
 		})
 	}
 	return pkg, nil

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -41,6 +41,10 @@ type Package struct {
 	// when a cycle is detected mid-load. The resolver emits
 	// CodeCyclicImport against the use site that completed the cycle.
 	isCycleMarker bool
+	// isExternalDep marks a package loaded through the dependency provider
+	// instead of the workspace root. PackageGraph uses this to classify
+	// compile-target edges without re-running provider lookup.
+	isExternalDep bool
 	// nativeResolve caches the read-only selfhost resolve projection so
 	// host-side tools can reuse one native run across several queries.
 	nativeResolve nativeResolveCache
@@ -57,6 +61,14 @@ type PackageFile struct {
 	// Source is the raw UTF-8 bytes. Retained so diagnostics can render
 	// source snippets without re-reading the file.
 	Source []byte
+	// OriginalSource is the on-disk UTF-8 bytes before SourceTransform ran.
+	// Nil means the parser saw Source directly.
+	OriginalSource []byte
+	// SourceTransformApplied records that the workspace source transform
+	// hook was invoked for this file.
+	SourceTransformApplied bool
+	// SourceTransformChanged records that Source differs from OriginalSource.
+	SourceTransformChanged bool
 	// CanonicalSource is the checker-facing canonical Osty source produced from
 	// the parsed AST after parser-owned canonicalization. When empty,
 	// callers should fall back to Source.

--- a/internal/resolve/package_graph.go
+++ b/internal/resolve/package_graph.go
@@ -1,0 +1,580 @@
+package resolve
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/token"
+)
+
+// PackageGraph is the first-class compile target IR. It snapshots the packages,
+// source files, import edges, stdlib/external-dependency routing, cfg state, and
+// source-transform metadata that older callers reached through Workspace
+// helpers directly.
+type PackageGraph struct {
+	Root string
+
+	Packages map[string]*PackageGraphPackage
+	Order    []string
+	Files    []PackageGraphFile
+
+	Imports          []PackageGraphImport
+	Edges            []PackageGraphEdge
+	StdlibEdges      []PackageGraphEdge
+	ExternalDepEdges []PackageGraphEdge
+
+	Cfg      *CfgEnv
+	Features []string
+
+	SourceTransforms []PackageGraphSourceTransform
+
+	workspace *Workspace
+}
+
+// PackageGraphPackage is the graph node for one loaded package.
+type PackageGraphPackage struct {
+	Path              string
+	Dir               string
+	Name              string
+	Package           *Package
+	Files             []PackageGraphFile
+	IsStdlib          bool
+	IsExternalDep     bool
+	IsStub            bool
+	IsCycleMarker     bool
+	RuntimeCapability bool
+}
+
+// PackageGraphFile is the graph node for one source file.
+type PackageGraphFile struct {
+	PackagePath            string
+	Path                   string
+	File                   *PackageFile
+	SourceBytes            int
+	OriginalBytes          int
+	HasSelfhostRun         bool
+	HasPublicAST           bool
+	SourceTransformApplied bool
+	SourceTransformChanged bool
+}
+
+// PackageGraphEdgeKind classifies one package import edge.
+type PackageGraphEdgeKind string
+
+const (
+	PackageGraphEdgeWorkspace  PackageGraphEdgeKind = "workspace"
+	PackageGraphEdgeStdlib     PackageGraphEdgeKind = "stdlib"
+	PackageGraphEdgeExternal   PackageGraphEdgeKind = "external"
+	PackageGraphEdgeUnresolved PackageGraphEdgeKind = "unresolved"
+)
+
+// PackageGraphImport is the use-site level import record. For scoped imports,
+// Path is the written member path while TargetPath is the package edge target.
+type PackageGraphImport struct {
+	PackagePath  string
+	FilePath     string
+	Path         string
+	Alias        string
+	TargetPath   string
+	IsScoped     bool
+	ScopedBase   string
+	ScopedMember string
+	IsPub        bool
+	Pos          token.Pos
+	End          token.Pos
+	Kind         PackageGraphEdgeKind
+	Resolved     bool
+}
+
+// PackageGraphEdge is the package-level edge derived from a PackageGraphImport.
+type PackageGraphEdge struct {
+	From       string
+	To         string
+	FilePath   string
+	ImportPath string
+	Alias      string
+	Kind       PackageGraphEdgeKind
+	IsPub      bool
+	Pos        token.Pos
+	End        token.Pos
+	Resolved   bool
+}
+
+// PackageGraphSourceTransform records parser-facing source transform state for
+// graph consumers that need to distinguish on-disk bytes from compiler input.
+type PackageGraphSourceTransform struct {
+	PackagePath string
+	FilePath    string
+	Applied     bool
+	Changed     bool
+	InputBytes  int
+	OutputBytes int
+}
+
+// NewPackageGraph snapshots a Workspace as a first-class package graph. Loading
+// still happens before this call; graph construction is side-effect free.
+func NewPackageGraph(ws *Workspace) *PackageGraph {
+	g := &PackageGraph{
+		Packages:  map[string]*PackageGraphPackage{},
+		workspace: ws,
+	}
+	if ws == nil {
+		return g
+	}
+	g.Root = ws.Root
+	g.Cfg = cloneCfgEnv(workspaceEffectiveCfgEnv(ws))
+	g.Features = sortedCfgFeatures(g.Cfg)
+
+	paths := make([]string, 0, len(ws.Packages))
+	for path := range ws.Packages {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	paths = ws.resolveOrder(paths)
+	for _, path := range paths {
+		g.addPackage(path, ws.Packages[path])
+	}
+	for _, path := range paths {
+		g.addPackageImports(ws, path, ws.Packages[path])
+	}
+	return g
+}
+
+// NewSingleFilePackageGraph builds a graph for in-memory single-file compile
+// paths. When stdlib is provided the graph carries the same stdlib-only
+// workspace that ResolveFileSourceDefault has historically used.
+func NewSingleFilePackageGraph(src []byte, file *ast.File, stdlib StdlibProvider) *PackageGraph {
+	pkg := &Package{
+		Name: "<file>",
+		Files: []*PackageFile{{
+			Path:            "<input>",
+			Source:          append([]byte(nil), src...),
+			CanonicalSource: append([]byte(nil), src...),
+			File:            file,
+		}},
+	}
+	if stdlib != nil {
+		ws := newStdlibOnlyWorkspace(stdlib)
+		ws.Packages[""] = pkg
+		return NewPackageGraph(ws)
+	}
+	g := &PackageGraph{Packages: map[string]*PackageGraphPackage{}}
+	g.addPackage("", pkg)
+	g.addPackageImports(nil, "", pkg)
+	return g
+}
+
+// NewPackageGraphForPackage snapshots a standalone already-loaded package.
+// Use this for package-mode compile paths that have no workspace/dependency
+// provider attached.
+func NewPackageGraphForPackage(path string, pkg *Package) *PackageGraph {
+	g := &PackageGraph{Packages: map[string]*PackageGraphPackage{}}
+	g.addPackage(path, pkg)
+	g.addPackageImports(nil, path, pkg)
+	return g
+}
+
+// Workspace returns a frozen workspace projection for legacy adapters. It
+// contains exactly the packages captured in the graph and disables root-based
+// lazy loading, so graph consumers do not silently widen the compile target.
+func (g *PackageGraph) Workspace() *Workspace {
+	return g.resolveWorkspace()
+}
+
+// Package returns the loaded resolver package for path, if present.
+func (g *PackageGraph) Package(path string) *Package {
+	if g == nil || g.Packages == nil {
+		return nil
+	}
+	node := g.Packages[path]
+	if node == nil {
+		return nil
+	}
+	return node.Package
+}
+
+// PackagePaths returns graph package paths in deterministic dependency order.
+func (g *PackageGraph) PackagePaths() []string {
+	if g == nil {
+		return nil
+	}
+	return append([]string(nil), g.Order...)
+}
+
+// ImportSurfaces projects graph import edges for one package into the
+// selfhost package-import surface used by resolve/check adapters.
+func (g *PackageGraph) ImportSurfaces(pkgPath string) []api.PackageCheckImport {
+	if g == nil {
+		return nil
+	}
+	seen := map[string]string{}
+	var out []api.PackageCheckImport
+	for _, imp := range g.Imports {
+		if imp.PackagePath != pkgPath || imp.Alias == "" || imp.TargetPath == "" {
+			continue
+		}
+		target := g.Package(imp.TargetPath)
+		if target == nil && g.workspace != nil && g.workspace.Stdlib != nil {
+			target = g.workspace.Stdlib.LookupPackage(imp.TargetPath)
+		}
+		if target == nil {
+			continue
+		}
+		if prev, ok := seen[imp.Alias]; ok {
+			if prev == imp.TargetPath {
+				continue
+			}
+			continue
+		}
+		seen[imp.Alias] = imp.TargetPath
+		out = append(out, PackageExportSurface(imp.TargetPath, imp.Alias, target))
+	}
+	return out
+}
+
+// PackageGraphImportSurfaces is the package-level helper for callers that
+// should consume PackageGraph without reaching back into Workspace state.
+func PackageGraphImportSurfaces(g *PackageGraph, pkgPath string) []api.PackageCheckImport {
+	if g == nil {
+		return nil
+	}
+	return g.ImportSurfaces(pkgPath)
+}
+
+// ResolveAll runs resolver output over the graph compile target.
+func (g *PackageGraph) ResolveAll() map[string]*PackageResult {
+	if g == nil {
+		return map[string]*PackageResult{}
+	}
+	if g.workspace != nil {
+		return g.resolveWorkspace().ResolveAll()
+	}
+	results := map[string]*PackageResult{}
+	prelude := NewPrelude()
+	for _, path := range g.Order {
+		pkg := g.Package(path)
+		if pkg == nil {
+			continue
+		}
+		if pkg.isStub {
+			results[path] = &PackageResult{PackageScope: nil}
+			continue
+		}
+		results[path] = ResolvePackage(pkg, prelude)
+	}
+	return results
+}
+
+// ResolveGraph is the package-graph entry point for name resolution.
+func ResolveGraph(g *PackageGraph) map[string]*PackageResult {
+	if g == nil {
+		return map[string]*PackageResult{}
+	}
+	return g.ResolveAll()
+}
+
+func (g *PackageGraph) resolveWorkspace() *Workspace {
+	if g == nil || g.workspace == nil {
+		return nil
+	}
+	ws := *g.workspace
+	ws.Root = ""
+	ws.Packages = map[string]*Package{}
+	for path, node := range g.Packages {
+		if node != nil && node.Package != nil {
+			ws.Packages[path] = node.Package
+		}
+	}
+	ws.cfgEnv = cloneCfgEnv(g.Cfg)
+	ws.loading = map[string]bool{}
+	return &ws
+}
+
+func (g *PackageGraph) addPackage(path string, pkg *Package) {
+	if pkg == nil {
+		return
+	}
+	if g.Packages == nil {
+		g.Packages = map[string]*PackageGraphPackage{}
+	}
+	node := &PackageGraphPackage{
+		Path:              path,
+		Dir:               pkg.Dir,
+		Name:              pkg.Name,
+		Package:           pkg,
+		IsStdlib:          strings.HasPrefix(path, StdPrefix),
+		IsExternalDep:     pkg.isExternalDep,
+		IsStub:            pkg.isStub,
+		IsCycleMarker:     pkg.isCycleMarker,
+		RuntimeCapability: pkg.RuntimeCapability,
+	}
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		file := PackageGraphFile{
+			PackagePath:            path,
+			Path:                   pf.Path,
+			File:                   pf,
+			SourceBytes:            len(pf.Source),
+			OriginalBytes:          len(pf.OriginalSource),
+			HasSelfhostRun:         pf.Run != nil,
+			HasPublicAST:           pf.File != nil,
+			SourceTransformApplied: pf.SourceTransformApplied,
+			SourceTransformChanged: pf.SourceTransformChanged,
+		}
+		node.Files = append(node.Files, file)
+		g.Files = append(g.Files, file)
+		if pf.SourceTransformApplied {
+			inputBytes := len(pf.Source)
+			if pf.OriginalSource != nil {
+				inputBytes = len(pf.OriginalSource)
+			}
+			g.SourceTransforms = append(g.SourceTransforms, PackageGraphSourceTransform{
+				PackagePath: path,
+				FilePath:    pf.Path,
+				Applied:     true,
+				Changed:     pf.SourceTransformChanged,
+				InputBytes:  inputBytes,
+				OutputBytes: len(pf.Source),
+			})
+		}
+	}
+	g.Packages[path] = node
+	g.Order = append(g.Order, path)
+}
+
+func (g *PackageGraph) addPackageImports(ws *Workspace, path string, pkg *Package) {
+	for _, imp := range packageGraphImports(pkg, path) {
+		imp.Kind = graphEdgeKind(ws, imp.TargetPath)
+		imp.Resolved = graphEdgeResolved(ws, imp.TargetPath, imp.Kind)
+		g.Imports = append(g.Imports, imp)
+		edge := PackageGraphEdge{
+			From:       path,
+			To:         imp.TargetPath,
+			FilePath:   imp.FilePath,
+			ImportPath: imp.Path,
+			Alias:      imp.Alias,
+			Kind:       imp.Kind,
+			IsPub:      imp.IsPub,
+			Pos:        imp.Pos,
+			End:        imp.End,
+			Resolved:   imp.Resolved,
+		}
+		g.Edges = append(g.Edges, edge)
+		switch edge.Kind {
+		case PackageGraphEdgeStdlib:
+			g.StdlibEdges = append(g.StdlibEdges, edge)
+		case PackageGraphEdgeExternal:
+			g.ExternalDepEdges = append(g.ExternalDepEdges, edge)
+		}
+	}
+}
+
+func packageGraphImports(pkg *Package, pkgPath string) []PackageGraphImport {
+	if pkg == nil {
+		return nil
+	}
+	var out []PackageGraphImport
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		if pf.Run != nil {
+			for _, use := range selfhost.PackageUsesFromRun(pf.Run) {
+				if imp, ok := packageGraphImportFromSelfhost(pkgPath, pf, use); ok {
+					out = append(out, imp)
+				}
+			}
+			continue
+		}
+		if pf.File != nil {
+			for _, use := range pf.File.Uses {
+				if imp, ok := packageGraphImportFromAST(pkgPath, pf, use); ok {
+					out = append(out, imp)
+				}
+			}
+			continue
+		}
+		if len(pf.Source) > 0 {
+			run := selfhost.Run(pf.Source)
+			for _, use := range selfhost.PackageUsesFromRun(run) {
+				if imp, ok := packageGraphImportFromSelfhost(pkgPath, pf, use); ok {
+					out = append(out, imp)
+				}
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].FilePath != out[j].FilePath {
+			return out[i].FilePath < out[j].FilePath
+		}
+		if out[i].Pos.Offset != out[j].Pos.Offset {
+			return out[i].Pos.Offset < out[j].Pos.Offset
+		}
+		return out[i].TargetPath < out[j].TargetPath
+	})
+	return out
+}
+
+func packageGraphImportFromSelfhost(pkgPath string, pf *PackageFile, use selfhost.PackageUseRef) (PackageGraphImport, bool) {
+	if use.IsGo || use.Path == "" {
+		return PackageGraphImport{}, false
+	}
+	target := use.Path
+	alias := use.Alias
+	scopedBase := use.ScopedBase
+	if use.IsScoped {
+		target = use.ScopedBase
+		alias = lastDotSeg(target)
+	}
+	if alias == "" {
+		alias = lastSegment(use.Path)
+	}
+	if target == "" || alias == "" {
+		return PackageGraphImport{}, false
+	}
+	return PackageGraphImport{
+		PackagePath:  pkgPath,
+		FilePath:     pf.Path,
+		Path:         use.Path,
+		Alias:        alias,
+		TargetPath:   target,
+		IsScoped:     use.IsScoped,
+		ScopedBase:   scopedBase,
+		ScopedMember: use.ScopedMember,
+		IsPub:        use.IsPub,
+		Pos:          sourcePosAt(pf.Source, use.Start),
+		End:          sourcePosAt(pf.Source, use.End),
+	}, true
+}
+
+func packageGraphImportFromAST(pkgPath string, pf *PackageFile, use *ast.UseDecl) (PackageGraphImport, bool) {
+	if use == nil || use.IsFFI() {
+		return PackageGraphImport{}, false
+	}
+	path := UseKey(use)
+	target := path
+	alias := useAliasName(use)
+	scopedBase := ""
+	if use.IsScoped {
+		scopedBase = scopedUseBaseKey(use)
+		target = scopedBase
+		alias = lastDotSeg(target)
+	}
+	if path == "" || target == "" || alias == "" {
+		return PackageGraphImport{}, false
+	}
+	return PackageGraphImport{
+		PackagePath:  pkgPath,
+		FilePath:     pf.Path,
+		Path:         path,
+		Alias:        alias,
+		TargetPath:   target,
+		IsScoped:     use.IsScoped,
+		ScopedBase:   scopedBase,
+		ScopedMember: use.ScopedMember,
+		IsPub:        use.IsPub,
+		Pos:          use.PosV,
+		End:          use.EndV,
+	}, true
+}
+
+func graphEdgeKind(ws *Workspace, target string) PackageGraphEdgeKind {
+	if target == "" {
+		return PackageGraphEdgeUnresolved
+	}
+	if strings.HasPrefix(target, StdPrefix) {
+		return PackageGraphEdgeStdlib
+	}
+	if isURLStyle(target) {
+		return PackageGraphEdgeExternal
+	}
+	if ws == nil {
+		return PackageGraphEdgeUnresolved
+	}
+	pkg := ws.Packages[target]
+	if pkg == nil {
+		return PackageGraphEdgeUnresolved
+	}
+	if pkg.isExternalDep || packageOutsideWorkspace(ws, pkg) {
+		return PackageGraphEdgeExternal
+	}
+	return PackageGraphEdgeWorkspace
+}
+
+func graphEdgeResolved(ws *Workspace, target string, kind PackageGraphEdgeKind) bool {
+	if target == "" {
+		return false
+	}
+	if kind == PackageGraphEdgeUnresolved {
+		return false
+	}
+	if ws == nil {
+		return false
+	}
+	return ws.Packages[target] != nil || (ws.Stdlib != nil && ws.Stdlib.LookupPackage(target) != nil)
+}
+
+func packageOutsideWorkspace(ws *Workspace, pkg *Package) bool {
+	if ws == nil || ws.Root == "" || pkg == nil || pkg.Dir == "" {
+		return false
+	}
+	root, err := filepath.Abs(ws.Root)
+	if err != nil {
+		return false
+	}
+	dir, err := filepath.Abs(pkg.Dir)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return false
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func workspaceEffectiveCfgEnv(ws *Workspace) *CfgEnv {
+	if ws == nil {
+		return nil
+	}
+	if ws.cfgEnv != nil {
+		return ws.cfgEnv
+	}
+	return DefaultCfgEnv()
+}
+
+func cloneCfgEnv(env *CfgEnv) *CfgEnv {
+	if env == nil {
+		return nil
+	}
+	out := &CfgEnv{
+		OS:       env.OS,
+		Arch:     env.Arch,
+		Target:   env.Target,
+		Features: map[string]bool{},
+	}
+	for k, v := range env.Features {
+		out.Features[k] = v
+	}
+	return out
+}
+
+func sortedCfgFeatures(env *CfgEnv) []string {
+	if env == nil {
+		return nil
+	}
+	features := make([]string, 0, len(env.Features))
+	for name, enabled := range env.Features {
+		if enabled {
+			features = append(features, name)
+		}
+	}
+	sort.Strings(features)
+	return features
+}

--- a/internal/resolve/package_graph_test.go
+++ b/internal/resolve/package_graph_test.go
@@ -1,0 +1,159 @@
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+type graphTestStdlib struct {
+	pkgs map[string]*Package
+}
+
+func (s graphTestStdlib) LookupPackage(dotPath string) *Package {
+	return s.pkgs[dotPath]
+}
+
+type graphTestDeps map[string]string
+
+func (d graphTestDeps) LookupDep(rawPath string) (string, bool) {
+	dir, ok := d[rawPath]
+	return dir, ok
+}
+
+func TestPackageGraphCapturesCompileTargetState(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	extDir := filepath.Join(t.TempDir(), "extpkg")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.osty"), []byte(`use dep
+use std.fs
+use extpkg
+
+fn main() {
+    dep.value()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "lib.osty"), []byte(`pub fn value() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "lib.osty"), []byte(`pub fn ext() -> Int { 2 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	ws.Stdlib = graphTestStdlib{pkgs: map[string]*Package{
+		"std.fs": {Name: "fs"},
+	}}
+	ws.Deps = graphTestDeps{"extpkg": extDir}
+	ws.SetCfgEnv(&CfgEnv{
+		OS:       "darwin",
+		Arch:     "arm64",
+		Target:   "darwin",
+		Features: map[string]bool{"net": true, "ssl": false},
+	})
+	ws.SourceTransform = func(path string, src []byte) []byte {
+		if filepath.Base(path) == "main.osty" {
+			return append(append([]byte(nil), src...), []byte("\n// transformed\n")...)
+		}
+		return src
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+
+	graph := NewPackageGraph(ws)
+	if graph.Root == "" {
+		t.Fatal("PackageGraph.Root is empty")
+	}
+	if got, want := graph.PackagePaths(), []string{"dep", "extpkg", "std.fs", ""}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PackagePaths() = %#v, want %#v", got, want)
+	}
+	if graph.Cfg == nil || graph.Cfg.OS != "darwin" || graph.Cfg.Arch != "arm64" || graph.Cfg.Target != "darwin" {
+		t.Fatalf("graph cfg = %#v, want darwin/arm64/darwin", graph.Cfg)
+	}
+	if got, want := graph.Features, []string{"net"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("graph features = %#v, want %#v", got, want)
+	}
+	changedTransforms := 0
+	for _, tr := range graph.SourceTransforms {
+		if !tr.Applied {
+			t.Fatalf("transform record was not marked applied: %#v", tr)
+		}
+		if tr.Changed {
+			changedTransforms++
+			if filepath.Base(tr.FilePath) != "main.osty" || tr.OutputBytes <= tr.InputBytes {
+				t.Fatalf("unexpected changed source transform record: %#v", tr)
+			}
+		}
+	}
+	if changedTransforms != 1 {
+		t.Fatalf("changed source transforms = %d, want 1", changedTransforms)
+	}
+
+	kinds := map[string]PackageGraphEdgeKind{}
+	for _, edge := range graph.Edges {
+		kinds[edge.To] = edge.Kind
+		if !edge.Resolved {
+			t.Fatalf("edge to %q was not marked resolved: %#v", edge.To, edge)
+		}
+	}
+	if got, want := kinds["dep"], PackageGraphEdgeWorkspace; got != want {
+		t.Fatalf("dep edge kind = %q, want %q", got, want)
+	}
+	if got, want := kinds["std.fs"], PackageGraphEdgeStdlib; got != want {
+		t.Fatalf("std.fs edge kind = %q, want %q", got, want)
+	}
+	if got, want := kinds["extpkg"], PackageGraphEdgeExternal; got != want {
+		t.Fatalf("extpkg edge kind = %q, want %q", got, want)
+	}
+	if len(graph.StdlibEdges) != 1 {
+		t.Fatalf("stdlib edges = %d, want 1", len(graph.StdlibEdges))
+	}
+	if len(graph.ExternalDepEdges) != 1 {
+		t.Fatalf("external dep edges = %d, want 1", len(graph.ExternalDepEdges))
+	}
+	if pkg := graph.Package("extpkg"); pkg == nil || !pkg.isExternalDep {
+		t.Fatalf("external package marker missing: %#v", pkg)
+	}
+}
+
+func TestSingleFilePackageGraphCapturesStdlibImport(t *testing.T) {
+	src := []byte(`use std.fs
+
+fn main() {
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	graph := NewSingleFilePackageGraph(src, file, graphTestStdlib{pkgs: map[string]*Package{
+		"std.fs": {Name: "fs"},
+	}})
+	if got, want := graph.PackagePaths(), []string{""}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PackagePaths() = %#v, want %#v", got, want)
+	}
+	if len(graph.Imports) != 1 {
+		t.Fatalf("imports = %d, want 1", len(graph.Imports))
+	}
+	imp := graph.Imports[0]
+	if imp.TargetPath != "std.fs" || imp.Kind != PackageGraphEdgeStdlib || !imp.Resolved {
+		t.Fatalf("unexpected import graph record: %#v", imp)
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -73,19 +73,16 @@ func ResolvePackageDefault(pkg *Package) *PackageResult {
 // and the already-parsed AST, using the selfhost resolver as the source
 // of truth while still projecting refs and scopes back onto the Go AST.
 func ResolveFileSourceDefault(src []byte, file *ast.File, stdlib StdlibProvider) *Result {
-	pkg := &Package{
-		Name: "<file>",
-		Files: []*PackageFile{{
-			Path:            "<input>",
-			Source:          append([]byte(nil), src...),
-			CanonicalSource: append([]byte(nil), src...),
-			File:            file,
-		}},
+	graph := NewSingleFilePackageGraph(src, file, stdlib)
+	results := ResolveGraph(graph)
+	pkg := graph.Package("")
+	if pkg == nil {
+		return &Result{}
 	}
-	if stdlib != nil {
-		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
+	pr := results[""]
+	if pr == nil {
+		pr = &PackageResult{}
 	}
-	pr := ResolvePackage(pkg, NewPrelude())
 	pf := pkg.Files[0]
 	return &Result{
 		RefsByID:      pf.RefsByID,

--- a/internal/resolve/workspace_native.go
+++ b/internal/resolve/workspace_native.go
@@ -81,6 +81,7 @@ func (w *Workspace) loadFromExternalDirNative(key, dir string) (*Package, error)
 		return nil, err
 	}
 	pkg.Name = lastSegment(key)
+	pkg.isExternalDep = true
 	w.Packages[key] = pkg
 
 	w.loadNativePackageDependencies(pkg)


### PR DESCRIPTION
## Summary
- Add `resolve.PackageGraph` as a first-class compile target IR for packages, files, imports, stdlib edges, external dependency edges, cfg features, and source-transform metadata.
- Route build, run, gen, native check/lint/doc, native llvmgen, pipeline, LSP, query, and CI host flows through PackageGraph entry points.
- Add graph-native resolver/checker/backend adapters and tests covering workspace, stdlib, external dependency, cfg, and transform state.

## Validation
- `go test -count=1 -vet=off ./internal/resolve ./internal/check ./cmd/osty ./cmd/osty-native-llvmgen`
- `go test -count=1 -vet=off ./internal/pipeline ./internal/query/... ./internal/lsp ./internal/cihost`
- `go test -count=1 -vet=off ./internal/backend -run 'TestPrepare(Package|Entry)|Test.*Package'`
- `go test -count=1 -vet=off ./internal/query/osty`
- `just fmt-check`
- `git diff --check`