### PR TITLE
[codex] optimize string key construction

### DIFF
--- a/benchmarks/osty-vs-go/README.md
+++ b/benchmarks/osty-vs-go/README.md
@@ -16,11 +16,13 @@ benchmarks/osty-vs-go/
 ├── hash_lookup/     # Map<Int,Int> insert + lookup (real dictionary workload)
 ├── lane_route/      # branchy 1D dynamic programming / route relaxation
 ├── loop_sum/        # tight scalar loop (vectorization regressions)
+├── string_key_build/ # big-map key creation: Int→String + "key:" concat
+├── map_string_lookup/ # prebuilt Map<String,Int> hash + lookup probe cost
+├── ephemeral_gc_churn/ # short-lived string/list writes + GC barriers
 ├── matmul/          # 64×64 integer matmul (nested-loop numeric kernel)
 ├── quicksort/       # iterative in-place Lomuto quicksort over List<Int>
 ├── record_pipeline/ # struct-heavy filter + group + sorted-key aggregate
 ├── simd_stats/      # long integer-array passes (vector-friendly hot loops)
-├── simd_stats/
 ├── word_freq/       # collections + sort + string-heavy aggregation
 └── <each>/
     ├── go/          # package <name>bench — BenchmarkFoo
@@ -43,6 +45,11 @@ style:
   `quicksort`): collections, structs, sort, hash. These dominate real
   application time and are the pairs most representative of deployed
   Osty code.
+- **Big-map decomposition** (`string_key_build`, `map_string_lookup`,
+  `ephemeral_gc_churn`): isolates the three costs that make
+  `benchmarks/programs/big-map` stand out — fresh string-key
+  construction, stable `Map<String, Int>` probes, and short-lived
+  String/List allocation plus GC barrier traffic.
 
 ### DCE defense — always use `#[inline(never)]`
 

--- a/benchmarks/osty-vs-go/ephemeral_gc_churn/go/ephemeral_gc_churn.go
+++ b/benchmarks/osty-vs-go/ephemeral_gc_churn/go/ephemeral_gc_churn.go
@@ -1,0 +1,23 @@
+package ephemeralgcchurnbench
+
+import "strconv"
+
+var keepAliveStrings []string
+
+//go:noinline
+func EphemeralGCChurn(n int) int64 {
+	var total int64
+	for i := 0; i < n; i++ {
+		a := "key:" + strconv.Itoa(i%200000)
+		b := a + ":" + strconv.Itoa((i*17)%97)
+		xs := make([]string, 0, 3)
+		xs = append(xs, a)
+		xs = append(xs, b)
+		xs = append(xs, "tail")
+		total += int64(len(xs[0]) + len(xs[1]) + len(xs[2]) + len(xs))
+		if i == n-1 {
+			keepAliveStrings = xs
+		}
+	}
+	return total
+}

--- a/benchmarks/osty-vs-go/ephemeral_gc_churn/go/ephemeral_gc_churn_test.go
+++ b/benchmarks/osty-vs-go/ephemeral_gc_churn/go/ephemeral_gc_churn_test.go
@@ -1,0 +1,11 @@
+package ephemeralgcchurnbench
+
+import "testing"
+
+var ephemeralGCChurnSink int64
+
+func BenchmarkEphemeralGCChurn(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ephemeralGCChurnSink = EphemeralGCChurn(2048)
+	}
+}

--- a/benchmarks/osty-vs-go/ephemeral_gc_churn/osty/ephemeral_gc_churn.osty
+++ b/benchmarks/osty-vs-go/ephemeral_gc_churn/osty/ephemeral_gc_churn.osty
@@ -1,0 +1,20 @@
+fn intToStr(n: Int) -> String {
+    n.toString()
+}
+
+#[inline(never)]
+pub fn ephemeralGCChurn(n: Int) -> Int {
+    let mut total = 0
+    let mut i = 0
+    for i < n {
+        let a = "key:" + intToStr(i % 200000)
+        let b = a + ":" + intToStr((i * 17) % 97)
+        let mut xs: List<String> = []
+        xs.push(a)
+        xs.push(b)
+        xs.push("tail")
+        total = total + xs[0].len() + xs[1].len() + xs[2].len() + xs.len()
+        i = i + 1
+    }
+    total
+}

--- a/benchmarks/osty-vs-go/ephemeral_gc_churn/osty/ephemeral_gc_churn_test.osty
+++ b/benchmarks/osty-vs-go/ephemeral_gc_churn/osty/ephemeral_gc_churn_test.osty
@@ -1,0 +1,8 @@
+use std.testing
+
+fn benchEphemeralGCChurn() {
+    testing.benchmark(20, || {
+        let _ = ephemeralGCChurn(2048)
+        Ok(())
+    })
+}

--- a/benchmarks/osty-vs-go/map_string_lookup/go/map_string_lookup.go
+++ b/benchmarks/osty-vs-go/map_string_lookup/go/map_string_lookup.go
@@ -1,0 +1,49 @@
+package mapstringlookupbench
+
+import "strconv"
+
+const (
+	mapStringEntries    = 4096
+	mapStringQueryCount = 16384
+)
+
+var (
+	mapStringKeys    = buildStringKeys(mapStringEntries)
+	mapStringQueries = buildStringQueries(mapStringQueryCount, mapStringEntries)
+	mapStringIndex   = buildStringMap(mapStringKeys)
+)
+
+func buildStringKeys(n int) []string {
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		keys[i] = "key:" + strconv.Itoa(i)
+	}
+	return keys
+}
+
+func buildStringQueries(n, modulo int) []string {
+	keys := make([]string, n)
+	state := 1
+	for i := 0; i < n; i++ {
+		state = (state*1103515245 + 12345) & 0x7fffffff
+		keys[i] = "key:" + strconv.Itoa(state%modulo)
+	}
+	return keys
+}
+
+func buildStringMap(keys []string) map[string]int64 {
+	m := make(map[string]int64, len(keys))
+	for i, k := range keys {
+		m[k] = int64(i + 1)
+	}
+	return m
+}
+
+//go:noinline
+func StringLookupChecksum(m map[string]int64, queries []string) int64 {
+	var total int64
+	for _, key := range queries {
+		total += m[key]
+	}
+	return total
+}

--- a/benchmarks/osty-vs-go/map_string_lookup/go/map_string_lookup_test.go
+++ b/benchmarks/osty-vs-go/map_string_lookup/go/map_string_lookup_test.go
@@ -1,0 +1,11 @@
+package mapstringlookupbench
+
+import "testing"
+
+var mapStringLookupSink int64
+
+func BenchmarkStringLookup(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		mapStringLookupSink = StringLookupChecksum(mapStringIndex, mapStringQueries)
+	}
+}

--- a/benchmarks/osty-vs-go/map_string_lookup/osty/map_string_lookup.osty
+++ b/benchmarks/osty-vs-go/map_string_lookup/osty/map_string_lookup.osty
@@ -1,0 +1,46 @@
+fn intToStr(n: Int) -> String {
+    n.toString()
+}
+
+fn buildStringKeys(n: Int) -> List<String> {
+    let mut keys: List<String> = []
+    let mut i = 0
+    for i < n {
+        keys.push("key:" + intToStr(i))
+        i = i + 1
+    }
+    keys
+}
+
+fn buildStringQueries(n: Int, modulo: Int) -> List<String> {
+    let mut keys: List<String> = []
+    let mut state = 1
+    let mut i = 0
+    for i < n {
+        state = (state * 1103515245 + 12345) % 2147483648
+        keys.push("key:" + intToStr(state % modulo))
+        i = i + 1
+    }
+    keys
+}
+
+fn buildStringMap(keys: List<String>) -> Map<String, Int> {
+    let mut m: Map<String, Int> = {:}
+    let mut i = 0
+    for i < keys.len() {
+        m.insert(keys[i], i + 1)
+        i = i + 1
+    }
+    m
+}
+
+#[inline(never)]
+pub fn stringLookupChecksum(m: Map<String, Int>, queries: List<String>) -> Int {
+    let mut total = 0
+    let mut i = 0
+    for i < queries.len() {
+        total = total + m.getOr(queries[i], 0)
+        i = i + 1
+    }
+    total
+}

--- a/benchmarks/osty-vs-go/map_string_lookup/osty/map_string_lookup_test.osty
+++ b/benchmarks/osty-vs-go/map_string_lookup/osty/map_string_lookup_test.osty
@@ -1,0 +1,11 @@
+use std.testing
+
+fn benchStringLookup() {
+    let keys = buildStringKeys(4096)
+    let queries = buildStringQueries(16384, 4096)
+    let index = buildStringMap(keys)
+    testing.benchmark(20, || {
+        let _ = stringLookupChecksum(index, queries)
+        Ok(())
+    })
+}

--- a/benchmarks/osty-vs-go/string_key_build/go/string_key_build.go
+++ b/benchmarks/osty-vs-go/string_key_build/go/string_key_build.go
@@ -1,0 +1,16 @@
+package stringkeybuildbench
+
+import "strconv"
+
+//go:noinline
+func BuildStringKeys(n int) int64 {
+	var total int64
+	state := 1
+	for i := 0; i < n; i++ {
+		state = (state*1103515245 + 12345) & 0x7fffffff
+		target := state % 200000
+		key := "key:" + strconv.Itoa(target)
+		total += int64(len(key))
+	}
+	return total
+}

--- a/benchmarks/osty-vs-go/string_key_build/go/string_key_build_test.go
+++ b/benchmarks/osty-vs-go/string_key_build/go/string_key_build_test.go
@@ -1,0 +1,11 @@
+package stringkeybuildbench
+
+import "testing"
+
+var stringKeyBuildSink int64
+
+func BenchmarkStringKeyBuild(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stringKeyBuildSink = BuildStringKeys(4096)
+	}
+}

--- a/benchmarks/osty-vs-go/string_key_build/osty/string_key_build.osty
+++ b/benchmarks/osty-vs-go/string_key_build/osty/string_key_build.osty
@@ -1,0 +1,18 @@
+fn intToStr(n: Int) -> String {
+    n.toString()
+}
+
+#[inline(never)]
+pub fn buildStringKeys(n: Int) -> Int {
+    let mut total = 0
+    let mut state = 1
+    let mut i = 0
+    for i < n {
+        state = (state * 1103515245 + 12345) % 2147483648
+        let target = state % 200000
+        let key = "key:" + intToStr(target)
+        total = total + key.len()
+        i = i + 1
+    }
+    total
+}

--- a/benchmarks/osty-vs-go/string_key_build/osty/string_key_build_test.osty
+++ b/benchmarks/osty-vs-go/string_key_build/osty/string_key_build_test.osty
@@ -1,0 +1,8 @@
+use std.testing
+
+fn benchStringKeyBuild() {
+    testing.benchmark(20, || {
+        let _ = buildStringKeys(4096)
+        Ok(())
+    })
+}

--- a/benchmarks/programs/README.md
+++ b/benchmarks/programs/README.md
@@ -133,8 +133,9 @@ For every program the Osty implementation:
   the MIR LLVM lowering path (the alternate path mishandles
   String concat chains in some module shapes — seen during
   development on `markdown-stats`)
-- **avoids `Int.toString()`** (LLVM backend limit; uses a local
-  `intToStr` digit helper)
+- mostly **avoids `Int.toString()`** in older fixtures that still carry
+  local `intToStr` helpers; `big-map` intentionally uses native
+  `Int.toString()` so the suite tracks the current String-key fast path
 - **avoids `Option<scalar>` boxing in hot loops** — uses preallocated
   `List<Int>` + Int stack pointer rather than `pop() -> T?`
 - **avoids `xs.split(...)` of strings declared as `let body = a + b

--- a/benchmarks/programs/big-map/osty/main.osty
+++ b/benchmarks/programs/big-map/osty/main.osty
@@ -1,25 +1,7 @@
 // big-map — synthetic benchmark to measure Map<String, Int> at scale.
 
-use std.strings
-
 fn intToStr(n: Int) -> String {
-    let digits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
-    if n == 0 {
-        return "0"
-    }
-    let mut x = n
-    let mut chunks: List<String> = []
-    for x > 0 {
-        chunks.push(digits[x % 10])
-        x = x / 10
-    }
-    let mut pieces: List<String> = []
-    let mut i = chunks.len()
-    for i > 0 {
-        i = i - 1
-        pieces.push(chunks[i])
-    }
-    strings.join(pieces, "")
+    n.toString()
 }
 
 fn main() {

--- a/internal/backend/llvm_runtime_strings_chars_test.go
+++ b/internal/backend/llvm_runtime_strings_chars_test.go
@@ -126,6 +126,134 @@ int main(void) {
 	}
 }
 
+func TestBundledRuntimeIntToStringShortValuesAreInline(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_int_to_string_sso_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_int_to_string_sso_harness")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdint.h>
+#include <stdio.h>
+
+const char *osty_rt_int_to_string(int64_t value);
+int64_t osty_rt_strings_ByteLen(const char *value);
+int osty_rt_strings_Equal(const char *left, const char *right);
+int64_t osty_gc_debug_young_alloc_count_total(void);
+
+static void dump_short(int64_t value, const char *want) {
+    int64_t before = osty_gc_debug_young_alloc_count_total();
+    const char *s = osty_rt_int_to_string(value);
+    int64_t after = osty_gc_debug_young_alloc_count_total();
+    printf("%lld %d %lld\n",
+           (long long)osty_rt_strings_ByteLen(s),
+           osty_rt_strings_Equal(s, want),
+           (long long)(after - before));
+}
+
+int main(void) {
+    dump_short(0, "0");
+    dump_short(1234567, "1234567");
+    dump_short(-123456, "-123456");
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+
+	want := "1 1 0\n" +
+		"7 1 0\n" +
+		"7 1 0\n"
+	if got := string(runOutput); got != want {
+		t.Fatalf("runtime int_to_string SSO harness stdout mismatch\n---got---\n%s\n---want---\n%s", got, want)
+	}
+}
+
+func TestBundledRuntimeStringConcatI64FastPaths(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_string_concat_i64_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_string_concat_i64_harness")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdint.h>
+#include <stdio.h>
+
+const char *osty_rt_int_to_string(int64_t value);
+const char *osty_rt_strings_ConcatI64Right(const char *left, int64_t right);
+const char *osty_rt_strings_ConcatI64Left(int64_t left, const char *right);
+int64_t osty_rt_strings_ByteLen(const char *value);
+int osty_rt_strings_Equal(const char *left, const char *right);
+int64_t osty_gc_debug_young_alloc_count_total(void);
+
+static void dump_right(const char *left, int64_t right, const char *want) {
+    int64_t before = osty_gc_debug_young_alloc_count_total();
+    const char *s = osty_rt_strings_ConcatI64Right(left, right);
+    int64_t after = osty_gc_debug_young_alloc_count_total();
+    printf("%lld %d %lld\n",
+           (long long)osty_rt_strings_ByteLen(s),
+           osty_rt_strings_Equal(s, want),
+           (long long)(after - before));
+}
+
+static void dump_left(int64_t left, const char *right, const char *want) {
+    int64_t before = osty_gc_debug_young_alloc_count_total();
+    const char *s = osty_rt_strings_ConcatI64Left(left, right);
+    int64_t after = osty_gc_debug_young_alloc_count_total();
+    printf("%lld %d %lld\n",
+           (long long)osty_rt_strings_ByteLen(s),
+           osty_rt_strings_Equal(s, want),
+           (long long)(after - before));
+}
+
+int main(void) {
+    dump_right("key:", 12345, "key:12345");
+    dump_left(-42, ":x", "-42:x");
+    dump_right(osty_rt_int_to_string(7), 8, "78");
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+
+	want := "9 1 1\n" +
+		"5 1 1\n" +
+		"2 1 1\n"
+	if got := string(runOutput); got != want {
+		t.Fatalf("runtime string concat_i64 harness stdout mismatch\n---got---\n%s\n---want---\n%s", got, want)
+	}
+}
+
 func TestBundledRuntimeStringsHelpersPreserveSemantics(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -7788,16 +7788,14 @@ static char *osty_rt_string_dup_site(const char *start, size_t len, const char *
 }
 
 /* SSO-eligible dup. Strings up to 7 bytes pack into the pointer
- * itself, eliminating the `osty_gc_allocate_managed` call on the
- * hottest source of short-string allocs (split pieces). The other
- * `dup_site` callers (int_to_string / bool_to_string / chars / bytes
- * / case helpers) keep producing heap strings via the unsuffixed
- * variant — they all flow through `dup_site` whose body is now SSO-
- * input-safe (`osty_rt_string_copy_bytes`), so callers that splice
- * bytes from an inline source still work, but the OUTPUT of those
- * sites stays heap-resident. SSO output is opt-in via this `_sso`
- * variant so concat/IO-bound producers don't accidentally hand a
- * tagged pointer to libc.
+ * itself, eliminating the `osty_gc_allocate_managed` call on hot
+ * short-string producers (split pieces, small Int.toString results).
+ * Other `dup_site` callers keep producing heap strings via the
+ * unsuffixed variant; they all flow through `dup_site` whose body is
+ * SSO-input-safe (`osty_rt_string_copy_bytes`), so callers that splice
+ * bytes from an inline source still work. SSO output is opt-in via
+ * this `_sso` variant so each producer can be audited for downstream
+ * runtime support before it starts returning tagged pointers.
  *
  * `static inline`: single hot caller (`osty_rt_string_dup_range`)
  * benefits from inlining the length-branch so the constant-length
@@ -8499,13 +8497,51 @@ OSTY_HOT_INLINE bool osty_rt_strings_Equal(const char *left, const char *right) 
     return memcmp(left, right, left_len) == 0;
 }
 
+static OSTY_HOT_INLINE char *osty_rt_format_i64_decimal(char *end, int64_t value) {
+    char *p = end;
+    uint64_t n;
+
+    if (value < 0) {
+        n = (uint64_t)(-(value + 1)) + 1;
+    } else {
+        n = (uint64_t)value;
+    }
+    do {
+        *--p = (char)('0' + (n % 10));
+        n /= 10;
+    } while (n != 0);
+    if (value < 0) {
+        *--p = '-';
+    }
+    return p;
+}
+
+static OSTY_HOT_INLINE bool osty_rt_strings_equal_right_measured(const char *left,
+                                                                 const char *right,
+                                                                 size_t right_len) {
+    size_t left_len = 0;
+    char left_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    char right_buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+    if (left == right) {
+        return true;
+    }
+    if (left == NULL || right == NULL) {
+        return false;
+    }
+    osty_rt_string_measure(left, &left_len, NULL);
+    if (left_len != right_len) {
+        return false;
+    }
+    osty_rt_string_decode_to_buf_if_inline(&left, left_buf);
+    osty_rt_string_decode_to_buf_if_inline(&right, right_buf);
+    return memcmp(left, right, left_len) == 0;
+}
+
 const char *osty_rt_int_to_string(int64_t value) {
     char buffer[32];
-    int written = snprintf(buffer, sizeof(buffer), "%lld", (long long)value);
-    if (written < 0) {
-        osty_rt_abort("failed to format Int as String");
-    }
-    return osty_rt_string_dup_site(buffer, (size_t)written, "runtime.int.to_string");
+    char *end = buffer + sizeof(buffer);
+    char *p = osty_rt_format_i64_decimal(end, value);
+    return osty_rt_string_dup_site_sso(p, (size_t)(end - p), "runtime.int.to_string");
 }
 
 /* List<T>.toString runtime entries. One per element ABI lane; each
@@ -9316,6 +9352,36 @@ OSTY_HOT_INLINE const char *osty_rt_strings_Concat(const char *left, const char 
      * Inline operands are decoded via `osty_rt_string_copy_bytes`. */
     out = (char *)osty_gc_allocate_managed(total_len + 1, OSTY_GC_KIND_STRING, "runtime.strings.concat", NULL, NULL);
     osty_rt_string_copy_bytes(out, left, left_len);
+    osty_rt_string_copy_bytes(out + left_len, right, right_len);
+    out[total_len] = '\0';
+    return out;
+}
+
+OSTY_HOT_INLINE const char *osty_rt_strings_ConcatI64Right(const char *left, int64_t right) {
+    char buffer[32];
+    char *end = buffer + sizeof(buffer);
+    char *right_start = osty_rt_format_i64_decimal(end, right);
+    size_t left_len = osty_rt_string_len(left);
+    size_t right_len = (size_t)(end - right_start);
+    size_t total_len = left_len + right_len;
+    char *out = (char *)osty_gc_allocate_managed(total_len + 1, OSTY_GC_KIND_STRING, "runtime.strings.concat_i64_right", NULL, NULL);
+
+    osty_rt_string_copy_bytes(out, left, left_len);
+    memcpy(out + left_len, right_start, right_len);
+    out[total_len] = '\0';
+    return out;
+}
+
+OSTY_HOT_INLINE const char *osty_rt_strings_ConcatI64Left(int64_t left, const char *right) {
+    char buffer[32];
+    char *end = buffer + sizeof(buffer);
+    char *left_start = osty_rt_format_i64_decimal(end, left);
+    size_t left_len = (size_t)(end - left_start);
+    size_t right_len = osty_rt_string_len(right);
+    size_t total_len = left_len + right_len;
+    char *out = (char *)osty_gc_allocate_managed(total_len + 1, OSTY_GC_KIND_STRING, "runtime.strings.concat_i64_left", NULL, NULL);
+
+    memcpy(out, left_start, left_len);
     osty_rt_string_copy_bytes(out + left_len, right, right_len);
     out[total_len] = '\0';
     return out;
@@ -10589,6 +10655,68 @@ static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_indexed(osty_rt_map *map, 
     }
 }
 
+static OSTY_HOT_INLINE bool osty_rt_map_string_slot_equals(osty_rt_map *map,
+                                                           int64_t slot,
+                                                           const char *key,
+                                                           size_t key_len) {
+    const char *slot_key = NULL;
+    memcpy(&slot_key, osty_rt_map_key_slot(map, slot), sizeof(slot_key));
+    slot_key = (const char *)osty_gc_load_v1((void *)slot_key);
+    return osty_rt_strings_equal_right_measured(slot_key, key, key_len);
+}
+
+static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_string_indexed(osty_rt_map *map,
+                                                                     const char *key) {
+    size_t key_len = 0;
+    size_t key_hash;
+    uint32_t key_fingerprint;
+    uint64_t mask;
+    uint64_t idx;
+
+    key = (const char *)osty_gc_load_v1((void *)key);
+    osty_rt_string_measure(key, &key_len, &key_hash);
+    key_fingerprint = osty_rt_map_key_fingerprint(key_hash);
+    mask = (uint64_t)(map->index_cap - 1);
+    idx = (uint64_t)key_hash & mask;
+
+    for (;;) {
+        int64_t entry = map->index_slots[idx];
+        int64_t slot;
+        if (entry == 0) {
+            return -1;
+        }
+        slot = entry - 1;
+        if (slot >= 0 && slot < map->len &&
+            map->index_hashes[idx] == key_fingerprint &&
+            osty_rt_map_string_slot_equals(map, slot, key, key_len)) {
+            return slot;
+        }
+        idx = (idx + 1) & mask;
+    }
+}
+
+static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_string_linear(osty_rt_map *map,
+                                                                    const char *key) {
+    int64_t i;
+    size_t key_len = 0;
+    key = (const char *)osty_gc_load_v1((void *)key);
+    osty_rt_string_measure(key, &key_len, NULL);
+    for (i = 0; i < map->len; i++) {
+        if (osty_rt_map_string_slot_equals(map, i, key, key_len)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static OSTY_HOT_INLINE int64_t osty_rt_map_find_index_string(osty_rt_map *map,
+                                                            const char *key) {
+    if (map->index_cap > 0 && map->index_slots != NULL) {
+        return osty_rt_map_find_index_string_indexed(map, key);
+    }
+    return osty_rt_map_find_index_string_linear(map, key);
+}
+
 /* OSTY_HOT_INLINE on the dispatcher only — `find_index_indexed` (with
  * the probe loop) and `find_index_linear` (small-map scan) keep their
  * out-of-line forms because either body has enough instructions that
@@ -11139,7 +11267,90 @@ OSTY_RT_DEFINE_MAP_KEY_OPS(i64, int64_t)
 OSTY_RT_DEFINE_MAP_KEY_OPS(i1, bool)
 OSTY_RT_DEFINE_MAP_KEY_OPS(f64, double)
 OSTY_RT_DEFINE_MAP_KEY_OPS(ptr, void *)
-OSTY_RT_DEFINE_MAP_KEY_OPS(string, const char *)
+
+OSTY_HOT_INLINE bool osty_rt_map_contains_string(void *raw_map, const char *key) {
+    bool r;
+    osty_rt_map_lock(raw_map);
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    r = map != NULL && osty_rt_map_find_index_string(map, key) >= 0;
+    osty_rt_map_unlock(raw_map);
+    return r;
+}
+
+OSTY_HOT_INLINE void osty_rt_map_insert_string(void *raw_map, const char *key, const void *value) {
+    osty_rt_map_lock(raw_map);
+    osty_rt_map_insert_raw(raw_map, &key, value);
+    osty_rt_map_unlock(raw_map);
+}
+
+OSTY_HOT_INLINE bool osty_rt_map_remove_string(void *raw_map, const char *key) {
+    bool r;
+    osty_rt_map_lock(raw_map);
+    r = osty_rt_map_remove_raw(raw_map, &key);
+    osty_rt_map_unlock(raw_map);
+    return r;
+}
+
+OSTY_HOT_INLINE void osty_rt_map_get_or_abort_string(void *raw_map, const char *key, void *out_value) {
+    osty_rt_map_lock(raw_map);
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    int64_t index;
+    if (map == NULL || out_value == NULL) {
+        osty_rt_abort("invalid map get");
+    }
+    index = osty_rt_map_find_index_string(map, key);
+    if (index < 0) {
+        osty_rt_abort("map key not found");
+    }
+    memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+    osty_rt_map_unlock(raw_map);
+}
+
+OSTY_HOT_INLINE bool osty_rt_map_get_string(void *raw_map, const char *key, void *out_value) {
+    bool r = false;
+    osty_rt_map_lock(raw_map);
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    int64_t index;
+    if (map == NULL || out_value == NULL) {
+        osty_rt_abort("invalid map get");
+    }
+    index = osty_rt_map_find_index_string(map, key);
+    if (index >= 0) {
+        memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+        r = true;
+    }
+    osty_rt_map_unlock(raw_map);
+    return r;
+}
+
+const char *osty_rt_map_key_at_string(void *raw_map, int64_t index) {
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    const char *out;
+    if (map == NULL) osty_rt_abort("map is null");
+    osty_rt_map_lock(raw_map);
+    if (index < 0 || index >= map->len) {
+        osty_rt_map_unlock(raw_map);
+        osty_rt_abort("map key_at out of bounds");
+    }
+    memcpy(&out, osty_rt_map_key_slot(map, index), sizeof(out));
+    osty_rt_map_unlock(raw_map);
+    return out;
+}
+
+const char *osty_rt_map_entry_at_string(void *raw_map, int64_t index, void *out_value) {
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    const char *out;
+    if (map == NULL || out_value == NULL) osty_rt_abort("map entry_at invalid args");
+    osty_rt_map_lock(raw_map);
+    if (index < 0 || index >= map->len) {
+        osty_rt_map_unlock(raw_map);
+        osty_rt_abort("map entry_at out of bounds");
+    }
+    memcpy(&out, osty_rt_map_key_slot(map, index), sizeof(out));
+    memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+    osty_rt_map_unlock(raw_map);
+    return out;
+}
 
 // `osty_rt_map_incr_i64_<suffix>(map, key, delta)`: perform
 // `map[key] = (map.get(key) ?? 0) + delta` as a single atomic
@@ -11188,7 +11399,24 @@ OSTY_RT_DEFINE_MAP_INCR_I64_OPS(i64, int64_t)
 OSTY_RT_DEFINE_MAP_INCR_I64_OPS(i1, bool)
 OSTY_RT_DEFINE_MAP_INCR_I64_OPS(f64, double)
 OSTY_RT_DEFINE_MAP_INCR_I64_OPS(ptr, void *)
-OSTY_RT_DEFINE_MAP_INCR_I64_OPS(string, const char *)
+
+OSTY_HOT_INLINE int64_t osty_rt_map_incr_i64_string(void *raw_map, const char *key, int64_t delta) {
+    int64_t next;
+    osty_rt_map_lock(raw_map);
+    osty_rt_map *map = osty_rt_map_cast(raw_map);
+    int64_t index = osty_rt_map_find_index_string(map, key);
+    if (index >= 0) {
+        int64_t current;
+        memcpy(&current, osty_rt_map_value_slot(map, index), sizeof(current));
+        next = current + delta;
+        memcpy(osty_rt_map_value_slot(map, index), &next, sizeof(next));
+    } else {
+        next = delta;
+        osty_rt_map_insert_raw(raw_map, &key, &next);
+    }
+    osty_rt_map_unlock(raw_map);
+    return next;
+}
 
 static void osty_rt_set_reserve(osty_rt_set *set, int64_t min_cap) {
     int64_t next_cap = set->cap;
@@ -14356,6 +14584,9 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
         if (owner == NULL || value == NULL) {
             return;
         }
+        if (osty_rt_string_is_inline((const char *)value)) {
+            return;
+        }
         /* Tinytag-young owner fast path. Pin / root-bind on a young
          * payload promotes it out of the no-header arena (Phase 7
          * step 2 contract), so any address we observe inside the
@@ -14445,6 +14676,10 @@ locked_path:
     osty_gc_acquire();
     osty_gc_post_write_count += 1;
     if (owner == NULL || value == NULL) {
+        osty_gc_release();
+        return;
+    }
+    if (osty_rt_string_is_inline((const char *)value)) {
         osty_gc_release();
         return;
     }

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -6892,6 +6892,14 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		if len(i.Args) == 0 {
 			return unsupported("mir-mvp", "string_concat with no args")
 		}
+		if len(i.Args) == 2 {
+			if out, handled, err := g.emitStringConcatI64Pair(i.Args[0], i.Args[1]); handled || err != nil {
+				if err != nil {
+					return err
+				}
+				return g.storeIntrinsicResult(i, out)
+			}
+		}
 		parts := make([]*LlvmValue, 0, len(i.Args))
 		for idx, op := range i.Args {
 			if !isStringLLVMType(op.Type()) {
@@ -7268,6 +7276,59 @@ func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
 	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: partsReg}, {typ: "ptr", name: sepReg}})
 	g.flushOstyEmitter(em)
 	return g.storeIntrinsicResult(i, result)
+}
+
+func mirRtStringConcatI64RightSymbol() string { return mirRtStringSymbol("ConcatI64Right") }
+func mirRtStringConcatI64LeftSymbol() string  { return mirRtStringSymbol("ConcatI64Left") }
+
+func isI64StringConcatOperand(t mir.Type) bool {
+	prim, ok := t.(*ir.PrimType)
+	if !ok {
+		return false
+	}
+	return prim.Kind == ir.PrimInt || prim.Kind == ir.PrimInt64
+}
+
+func (g *mirGen) emitStringConcatI64Pair(left, right mir.Operand) (*LlvmValue, bool, error) {
+	if isStringLLVMType(left.Type()) && isI64StringConcatOperand(right.Type()) {
+		leftReg, err := g.evalOperand(left, left.Type())
+		if err != nil {
+			return nil, true, err
+		}
+		rightReg, err := g.evalOperand(right, right.Type())
+		if err != nil {
+			return nil, true, err
+		}
+		sym := mirRtStringConcatI64RightSymbol()
+		g.declareRuntime(sym, mirRuntimeDeclareLine("ptr", sym, "ptr, i64"))
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "ptr", name: leftReg},
+			{typ: "i64", name: rightReg},
+		})
+		g.flushOstyEmitter(em)
+		return out, true, nil
+	}
+	if isI64StringConcatOperand(left.Type()) && isStringLLVMType(right.Type()) {
+		leftReg, err := g.evalOperand(left, left.Type())
+		if err != nil {
+			return nil, true, err
+		}
+		rightReg, err := g.evalOperand(right, right.Type())
+		if err != nil {
+			return nil, true, err
+		}
+		sym := mirRtStringConcatI64LeftSymbol()
+		g.declareRuntime(sym, mirRuntimeDeclareLine("ptr", sym, "i64, ptr"))
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "i64", name: leftReg},
+			{typ: "ptr", name: rightReg},
+		})
+		g.flushOstyEmitter(em)
+		return out, true, nil
+	}
+	return nil, false, nil
 }
 
 func (g *mirGen) emitStringConcatN(parts []*LlvmValue) *LlvmValue {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -4271,6 +4271,104 @@ func TestGenerateFromMIRBinaryStringAddUsesRuntimeConcat(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRStringAddFusesIntToStringLeaf(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "key",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Body: &ir.Block{
+			Result: &ir.BinaryExpr{
+				Op:   ir.BinAdd,
+				Left: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "key:"}}},
+				Right: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+					Name:     "toString",
+					T:        ir.TString,
+				},
+				T: ir.TString,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_add_int_to_string.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_ConcatI64Right(ptr, i64)",
+		"call ptr @osty_rt_strings_ConcatI64Right(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	for _, bad := range []string{
+		"osty_rt_int_to_string",
+		"call ptr @osty_rt_strings_Concat(",
+	} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("unexpected %q in fused string add:\n%s", bad, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRStringAddFusesIntToStringWrapperLeaf(t *testing.T) {
+	wrapper := &ir.FnDecl{
+		Name:   "intToStr",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+				Name:     "toString",
+				T:        ir.TString,
+			},
+		},
+	}
+	fn := &ir.FnDecl{
+		Name:   "key",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Body: &ir.Block{
+			Result: &ir.BinaryExpr{
+				Op:   ir.BinAdd,
+				Left: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "key:"}}},
+				Right: &ir.CallExpr{
+					Callee: &ir.Ident{Name: "intToStr", Kind: ir.IdentFn, T: &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TString}},
+					Args:   []ir.Arg{{Value: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt}}},
+					T:      ir.TString,
+				},
+				T: ir.TString,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{wrapper, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_add_int_to_string_wrapper.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_ConcatI64Right(ptr, i64)",
+		"call ptr @osty_rt_strings_ConcatI64Right(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	for _, bad := range []string{
+		"call ptr @intToStr(",
+		"call ptr @osty_rt_strings_Concat(",
+	} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("unexpected %q in fused wrapper string add:\n%s", bad, got)
+		}
+	}
+}
+
 func TestGenerateFromMIRStringInterpolationRecoversFieldExprTypes(t *testing.T) {
 	diagT := &ir.NamedType{Name: "Diag"}
 	fn := &ir.FnDecl{

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2753,7 +2753,75 @@ func (bs *bodyState) appendStringConcatLeaves(e ir.Expr, out *[]Operand) {
 		bs.appendStringConcatLeaves(be.Right, out)
 		return
 	}
+	if op, ok := bs.lowerPrimitiveIntToStringConcatLeaf(e); ok {
+		*out = append(*out, op)
+		return
+	}
 	*out = append(*out, bs.lowerExprAsOperand(e))
+}
+
+func (bs *bodyState) lowerPrimitiveIntToStringConcatLeaf(e ir.Expr) (Operand, bool) {
+	switch x := e.(type) {
+	case *ir.MethodCall:
+		if x == nil || x.Name != "toString" || len(x.Args) != 0 || !isI64PrimitiveInt(bs.recoveredTypeOf(x.Receiver)) {
+			return nil, false
+		}
+		return bs.lowerExprAsOperand(x.Receiver), true
+	case *ir.CallExpr:
+		if x == nil {
+			return nil, false
+		}
+		if len(x.Args) == 0 {
+			field, ok := x.Callee.(*ir.FieldExpr)
+			if !ok || field == nil || field.Optional || field.Name != "toString" || !isI64PrimitiveInt(bs.recoveredTypeOf(field.X)) {
+				return nil, false
+			}
+			return bs.lowerExprAsOperand(field.X), true
+		}
+		id, ok := x.Callee.(*ir.Ident)
+		if !ok || id == nil || id.Kind != ir.IdentFn || len(x.Args) != 1 || x.Args[0].IsKeyword() {
+			return nil, false
+		}
+		if !bs.l.isPrimitiveIntToStringWrapper(id.Name) || !isI64PrimitiveInt(bs.recoveredTypeOf(x.Args[0].Value)) {
+			return nil, false
+		}
+		return bs.lowerExprAsOperand(x.Args[0].Value), true
+	}
+	return nil, false
+}
+
+func (l *lowerer) isPrimitiveIntToStringWrapper(name string) bool {
+	sig := l.signatureForFn(name)
+	if sig == nil || sig.ir == nil || len(sig.params) != 1 || !isStringReceiver(sig.retType) || sig.ir.Body == nil {
+		return false
+	}
+	param := sig.params[0]
+	if param == nil || !isI64PrimitiveInt(param.Type) {
+		return false
+	}
+	call, ok := sig.ir.Body.Result.(*ir.MethodCall)
+	if !ok || call == nil || call.Name != "toString" || len(call.Args) != 0 {
+		return false
+	}
+	recv, ok := call.Receiver.(*ir.Ident)
+	return ok && recv != nil && recv.Name == param.Name && isI64PrimitiveInt(recv.Type())
+}
+
+func isI64PrimitiveInt(t ir.Type) bool {
+	pt, ok := t.(*ir.PrimType)
+	if !ok {
+		return false
+	}
+	return pt.Kind == ir.PrimInt || pt.Kind == ir.PrimInt64
+}
+
+func stringConcatPartsAllString(parts []Operand) bool {
+	for _, part := range parts {
+		if part == nil || !isStringReceiver(part.Type()) {
+			return false
+		}
+	}
+	return true
 }
 
 // pathQualifier returns the "." joined Path of a UseDecl, so
@@ -2964,7 +3032,7 @@ func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
 		// too so leaves lower exactly once.
 		if x.Op == ir.BinAdd && isStringReceiver(x.T) {
 			parts := bs.flattenStringConcatChain(x)
-			if len(parts) >= 3 {
+			if len(parts) >= 3 || !stringConcatPartsAllString(parts) {
 				tmp := bs.freshTemp(TString, exprSpan(x))
 				bs.emit(&IntrinsicInstr{
 					Dest:  &Place{Local: tmp},


### PR DESCRIPTION
## Summary
- Add Osty-vs-Go microbenchmarks for string key creation, string map lookup, and short-lived GC churn.
- Make short `Int.toString()` results use the SSO path and skip GC post-write handling for inline strings.
- Add MIR/LLVM lowering for `String + Int.toString()` and thin `intToStr` wrappers so hot key construction calls `osty_rt_strings_ConcatI64Right/Left` directly.
- Add runtime and LLVM regression tests for the new fast paths.

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'IntToStringShortValuesAreInline|StringConcatI64FastPaths|StringsHelpersPreserveSemantics'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'StringAddFusesIntToStringLeaf|StringAddFusesIntToStringWrapperLeaf|BinaryStringAddUsesRuntimeConcat'`
- `go test -count=1 -vet=off ./internal/mir -run 'String|Concat|MIR'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `just build`
- `diff -u <(benchmarks/programs/big-map/bin-go-release) <(benchmarks/programs/big-map/osty/.osty/out/release/llvm/big-map)`
- `git diff --check`