### PR TITLE
Port result backend policy to Osty

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -919,41 +919,12 @@ func isSetPtrType(t mir.Type) bool {
 }
 
 func mangledBuiltinSourceNameIs(name, want string) bool {
-	got, ok := monomorphMangledSourceName(name)
-	return ok && got == want
+	return mirMangledBuiltinSourceNameIs(name, want)
 }
 
 func monomorphMangledSourceName(name string) (string, bool) {
-	const prefix = "_ZTSN"
-	if !strings.HasPrefix(name, prefix) {
-		return "", false
-	}
-	rest := strings.TrimPrefix(name, prefix)
-	var ok bool
-	_, rest, ok = consumeLengthPrefixedName(rest)
-	if !ok {
-		return "", false
-	}
-	typeName, _, ok := consumeLengthPrefixedName(rest)
-	if !ok || typeName == "" {
-		return "", false
-	}
-	return typeName, true
-}
-
-func consumeLengthPrefixedName(s string) (string, string, bool) {
-	if s == "" || s[0] < '0' || s[0] > '9' {
-		return "", "", false
-	}
-	i := 0
-	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
-		i++
-	}
-	n, err := strconv.Atoi(s[:i])
-	if err != nil || n < 0 || i+n > len(s) {
-		return "", "", false
-	}
-	return s[i : i+n], s[i+n:], true
+	got := mirMonomorphMangledSourceName(name)
+	return got, got != ""
 }
 
 func vectorListElemType(t mir.Type) mir.Type {
@@ -8822,39 +8793,10 @@ func compatibleEnumAggregateHint(rv *mir.AggregateRV, hintT mir.Type) mir.Type {
 	if mirIsPoisonType(rv.T) || mirIsPoisonType(hintT) || rv.T.String() == hintT.String() {
 		return nil
 	}
-	rvResult, rvOK, rvErr := resultTypeArgs(rv.T)
-	hintResult, hintOK, hintErr := resultTypeArgs(hintT)
-	if rvResult && hintResult {
-		if unitTupleAliasTypes(rvOK, hintOK) && typesStringEqual(rvErr, hintErr) {
-			return hintT
-		}
-		switch rv.VariantTag {
-		case "Err":
-			if typesStringEqual(rvErr, hintErr) {
-				return hintT
-			}
-		case "Ok":
-			if unitTupleAliasTypes(rvOK, hintOK) {
-				return hintT
-			}
-		}
+	if mirCompatibleEnumAggregateHintText(mirTypeString(rv.T), mirTypeString(hintT), rv.VariantTag) {
+		return hintT
 	}
 	return nil
-}
-
-func resultTypeArgs(t mir.Type) (bool, mir.Type, mir.Type) {
-	nt, ok := t.(*ir.NamedType)
-	if !ok || nt.Name != "Result" || len(nt.Args) < 2 {
-		return false, nil, nil
-	}
-	return true, nt.Args[0], nt.Args[1]
-}
-
-func typesStringEqual(a, b mir.Type) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return a.String() == b.String()
 }
 
 // emitEnumVariant builds `{ i64 disc, i64 payload }` for an enum or
@@ -9368,43 +9310,29 @@ func (g *mirGen) coerceOperandValue(val string, fromT, toT mir.Type) (string, er
 }
 
 func compatibleResultUnitTupleAlias(fromT, toT mir.Type) bool {
-	fromResult, fromOK, fromErr := resultTypeArgs(fromT)
-	toResult, toOK, toErr := resultTypeArgs(toT)
-	if !fromResult || !toResult {
+	if fromT == nil || toT == nil {
 		return false
 	}
-	return unitTupleAliasTypes(fromOK, toOK) && typesStringEqual(fromErr, toErr)
+	return mirCompatibleResultUnitTupleAliasText(mirTypeString(fromT), mirTypeString(toT))
 }
 
 func resultUnitTupleLLVMTypeAlias(fromLLVM, toLLVM string) bool {
-	if fromLLVM == "" || toLLVM == "" || fromLLVM == toLLVM {
-		return false
-	}
-	return strings.Replace(fromLLVM, ".unit.", ".Tuple..", 1) == toLLVM ||
-		strings.Replace(toLLVM, ".unit.", ".Tuple..", 1) == fromLLVM
+	return mirResultUnitTupleLLVMTypeAlias(fromLLVM, toLLVM)
 }
 
 func unitTupleAliasTypes(a, b mir.Type) bool {
-	if typesStringEqual(a, b) {
-		return true
+	if a == nil || b == nil {
+		return a == b
 	}
-	return (isUnitType(a) && isEmptyTupleType(b)) || (isEmptyTupleType(a) && isUnitType(b))
-}
-
-func isEmptyTupleType(t mir.Type) bool {
-	tt, ok := t.(*ir.TupleType)
-	return ok && len(tt.Elems) == 0
+	return mirUnitTupleAliasTypeText(mirTypeString(a), mirTypeString(b))
 }
 
 func (g *mirGen) retypeI64PairAggregate(val, fromLLVM, toLLVM string) string {
 	disc := g.fresh()
-	g.fnBuf.WriteString(mirExtractValueLine(disc, fromLLVM, val, "0"))
 	payload := g.fresh()
-	g.fnBuf.WriteString(mirExtractValueLine(payload, fromLLVM, val, "1"))
 	tmp := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueI64Line(tmp, toLLVM, "undef", disc, "0"))
 	out := g.fresh()
-	g.fnBuf.WriteString(mirInsertValueI64Line(out, toLLVM, tmp, payload, "1"))
+	g.fnBuf.WriteString(mirRetypeI64PairAggregateLines(disc, payload, tmp, out, fromLLVM, toLLVM, val))
 	return out
 }
 

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -687,6 +687,154 @@ func mirIsUnitTypeText(typeText string) bool {
 	return typeText == "Unit" || typeText == "()" || typeText == "Never"
 }
 
+// Osty: mirTrimTypeText
+func mirTrimTypeText(typeText string) string {
+	lo := 0
+	hi := len(typeText)
+	for lo < hi && typeText[lo:lo+1] == " " {
+		lo++
+	}
+	for hi > lo && typeText[hi-1:hi] == " " {
+		hi--
+	}
+	return typeText[lo:hi]
+}
+
+// Osty: mirTopLevelTypeCommaIndex
+func mirTopLevelTypeCommaIndex(typeText string) int {
+	depth := 0
+	for i := 0; i < len(typeText); i++ {
+		ch := typeText[i : i+1]
+		switch ch {
+		case "<", "(":
+			depth++
+		case ">", ")":
+			depth--
+		case ",":
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// Osty: mirResultTypeArgsText
+func mirResultTypeArgsText(typeText string) string {
+	head := mirLlvmTypeHeadName(typeText)
+	if head != "Result" && !llvmStrings.HasSuffix(head, ".Result") {
+		return ""
+	}
+	lt := llvmStrings.Index(typeText, "<")
+	if lt < 0 {
+		return ""
+	}
+	if !llvmStrings.HasSuffix(typeText, ">") {
+		return ""
+	}
+	body := typeText[lt+1 : len(typeText)-1]
+	comma := mirTopLevelTypeCommaIndex(body)
+	if comma < 0 {
+		return ""
+	}
+	okText := mirTrimTypeText(body[:comma])
+	errText := mirTrimTypeText(body[comma+1:])
+	if okText == "" || errText == "" {
+		return ""
+	}
+	return okText + "\n" + errText
+}
+
+// Osty: mirResultOkTypeText
+func mirResultOkTypeText(typeText string) string {
+	packed := mirResultTypeArgsText(typeText)
+	idx := llvmStrings.Index(packed, "\n")
+	if idx < 0 {
+		return ""
+	}
+	return packed[:idx]
+}
+
+// Osty: mirResultErrTypeText
+func mirResultErrTypeText(typeText string) string {
+	packed := mirResultTypeArgsText(typeText)
+	idx := llvmStrings.Index(packed, "\n")
+	if idx < 0 {
+		return ""
+	}
+	return packed[idx+1:]
+}
+
+// Osty: mirUnitTupleAliasTypeText
+func mirUnitTupleAliasTypeText(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return (a == "Unit" && b == "()") || (a == "()" && b == "Unit")
+}
+
+// Osty: mirCompatibleResultUnitTupleAliasText
+func mirCompatibleResultUnitTupleAliasText(fromText, toText string) bool {
+	fromOk := mirResultOkTypeText(fromText)
+	fromErr := mirResultErrTypeText(fromText)
+	toOk := mirResultOkTypeText(toText)
+	toErr := mirResultErrTypeText(toText)
+	if fromOk == "" || fromErr == "" || toOk == "" || toErr == "" {
+		return false
+	}
+	return mirUnitTupleAliasTypeText(fromOk, toOk) && fromErr == toErr
+}
+
+// Osty: mirCompatibleEnumAggregateHintText
+func mirCompatibleEnumAggregateHintText(rvText, hintText, variantTag string) bool {
+	rvOk := mirResultOkTypeText(rvText)
+	rvErr := mirResultErrTypeText(rvText)
+	hintOk := mirResultOkTypeText(hintText)
+	hintErr := mirResultErrTypeText(hintText)
+	if rvOk == "" || rvErr == "" || hintOk == "" || hintErr == "" {
+		return false
+	}
+	if mirUnitTupleAliasTypeText(rvOk, hintOk) && rvErr == hintErr {
+		return true
+	}
+	if variantTag == "Err" && rvErr == hintErr {
+		return true
+	}
+	if variantTag == "Ok" && mirUnitTupleAliasTypeText(rvOk, hintOk) {
+		return true
+	}
+	return false
+}
+
+// Osty: mirReplaceFirstText
+func mirReplaceFirstText(text, old, newText string) string {
+	if old == "" {
+		return text
+	}
+	idx := llvmStrings.Index(text, old)
+	if idx < 0 {
+		return text
+	}
+	return text[:idx] + newText + text[idx+len(old):]
+}
+
+// Osty: mirResultUnitTupleLLVMTypeAlias
+func mirResultUnitTupleLLVMTypeAlias(fromLLVM, toLLVM string) bool {
+	if fromLLVM == "" || toLLVM == "" || fromLLVM == toLLVM {
+		return false
+	}
+	return mirReplaceFirstText(fromLLVM, ".unit.", ".Tuple..") == toLLVM ||
+		mirReplaceFirstText(toLLVM, ".unit.", ".Tuple..") == fromLLVM
+}
+
+// Osty: mirRetypeI64PairAggregateLines
+func mirRetypeI64PairAggregateLines(discReg, payloadReg, tmpReg, outReg, fromLLVM, toLLVM, valueReg string) string {
+	return mirExtractValueLine(discReg, fromLLVM, valueReg, "0") +
+		mirExtractValueLine(payloadReg, fromLLVM, valueReg, "1") +
+		mirInsertValueI64Line(tmpReg, toLLVM, "undef", discReg, "0") +
+		mirInsertValueI64Line(outReg, toLLVM, tmpReg, payloadReg, "1")
+}
+
 // Osty: toolchain/mir_generator.osty:585:5
 func mirIsFloatTypeText(typeText string) bool {
 	return typeText == "Float" || typeText == "Float32" || typeText == "Float64" || typeText == "double" || typeText == "float"
@@ -11054,6 +11202,83 @@ func mirIsContainerNamedType(name string, builtin bool) bool {
 // Osty: mirIsPrimUnitName
 func mirIsPrimUnitName(name string) bool {
 	return name == "Unit"
+}
+
+// Osty: mirDecimalDigitValue
+func mirDecimalDigitValue(ch string) int {
+	switch ch {
+	case "0":
+		return 0
+	case "1":
+		return 1
+	case "2":
+		return 2
+	case "3":
+		return 3
+	case "4":
+		return 4
+	case "5":
+		return 5
+	case "6":
+		return 6
+	case "7":
+		return 7
+	case "8":
+		return 8
+	case "9":
+		return 9
+	}
+	return -1
+}
+
+// Osty: mirParseDecimalPrefix
+func mirParseDecimalPrefix(text string, end int) int {
+	if end <= 0 {
+		return -1
+	}
+	out := 0
+	for i := 0; i < end; i++ {
+		d := mirDecimalDigitValue(text[i : i+1])
+		if d < 0 {
+			return -1
+		}
+		out = (out * 10) + d
+	}
+	return out
+}
+
+// Osty: mirMonomorphMangledSourceName
+func mirMonomorphMangledSourceName(name string) string {
+	const prefix = "_ZTSN"
+	if !llvmStrings.HasPrefix(name, prefix) {
+		return ""
+	}
+	rest := name[len(prefix):]
+
+	i := 0
+	for i < len(rest) && mirDecimalDigitValue(rest[i:i+1]) >= 0 {
+		i++
+	}
+	pkgLen := mirParseDecimalPrefix(rest, i)
+	if pkgLen < 0 || i+pkgLen > len(rest) {
+		return ""
+	}
+	rest = rest[i+pkgLen:]
+
+	i = 0
+	for i < len(rest) && mirDecimalDigitValue(rest[i:i+1]) >= 0 {
+		i++
+	}
+	typeLen := mirParseDecimalPrefix(rest, i)
+	if typeLen <= 0 || i+typeLen > len(rest) {
+		return ""
+	}
+	return rest[i : i+typeLen]
+}
+
+// Osty: mirMangledBuiltinSourceNameIs
+func mirMangledBuiltinSourceNameIs(name, want string) bool {
+	return mirMonomorphMangledSourceName(name) == want
 }
 
 // Osty: mirSetElemTypeArgIndex

--- a/internal/llvmgen/mir_result_alias_policy_test.go
+++ b/internal/llvmgen/mir_result_alias_policy_test.go
@@ -1,0 +1,93 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+)
+
+func TestMirResultTypeTextParsesNestedArgs(t *testing.T) {
+	typ := "Result<List<(Int, String)>, Error?>"
+	if got := mirResultOkTypeText(typ); got != "List<(Int, String)>" {
+		t.Fatalf("ok arg = %q", got)
+	}
+	if got := mirResultErrTypeText(typ); got != "Error?" {
+		t.Fatalf("err arg = %q", got)
+	}
+}
+
+func TestMirResultUnitTupleAliasPolicy(t *testing.T) {
+	unitResult := &ir.NamedType{Name: "Result", Args: []ir.Type{ir.TUnit, ir.TString}, Builtin: true}
+	tupleResult := &ir.NamedType{Name: "Result", Args: []ir.Type{&ir.TupleType{}, ir.TString}, Builtin: true}
+	intResult := &ir.NamedType{Name: "Result", Args: []ir.Type{ir.TInt, ir.TString}, Builtin: true}
+
+	if !compatibleResultUnitTupleAlias(unitResult, tupleResult) {
+		t.Fatalf("Result<(), String> should alias empty-tuple Ok spelling")
+	}
+	if compatibleResultUnitTupleAlias(unitResult, intResult) {
+		t.Fatalf("Result<(), String> must not alias Result<Int, String>")
+	}
+	if !resultUnitTupleLLVMTypeAlias("%Result.unit.ptr", "%Result.Tuple..ptr") {
+		t.Fatalf("LLVM Result unit/Tuple type name alias not recognized")
+	}
+}
+
+func TestMirCompatibleEnumAggregateHintPolicy(t *testing.T) {
+	if !mirCompatibleEnumAggregateHintText("Result<Unit, String>", "Result<(), String>", "Ok") {
+		t.Fatalf("Ok unit aggregate text should adopt tuple-context hint")
+	}
+
+	rv := &mir.AggregateRV{
+		Kind:       mir.AggEnumVariant,
+		T:          &ir.NamedType{Name: "Result", Args: []ir.Type{ir.TInt, ir.TString}, Builtin: true},
+		VariantTag: "Err",
+	}
+	hint := &ir.NamedType{Name: "Result", Args: []ir.Type{ir.TUnit, ir.TString}, Builtin: true}
+	if got := compatibleEnumAggregateHint(rv, hint); got != hint {
+		t.Fatalf("Err aggregate should adopt matching-Err Result hint")
+	}
+
+	badHint := &ir.NamedType{Name: "Result", Args: []ir.Type{ir.TUnit, ir.TInt}, Builtin: true}
+	if got := compatibleEnumAggregateHint(rv, badHint); got != nil {
+		t.Fatalf("mismatched Err type should not be hinted: %#v", got)
+	}
+}
+
+func TestMirRetypeI64PairAggregateLines(t *testing.T) {
+	got := mirRetypeI64PairAggregateLines("%disc", "%payload", "%tmp", "%out", "%Result.unit.ptr", "%Result.Tuple..ptr", "%value")
+	for _, want := range []string{
+		"  %disc = extractvalue %Result.unit.ptr %value, 0\n",
+		"  %payload = extractvalue %Result.unit.ptr %value, 1\n",
+		"  %tmp = insertvalue %Result.Tuple..ptr undef, i64 %disc, 0\n",
+		"  %out = insertvalue %Result.Tuple..ptr %tmp, i64 %payload, 1\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestMirMonomorphMangledSourceName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "_ZTSN3std4List", want: "List"},
+		{name: "_ZTSN4core6Result", want: "Result"},
+		{name: "_ZTSN3std3MapI64", want: "Map"},
+		{name: "List", want: ""},
+		{name: "_ZTSN3std0", want: ""},
+	} {
+		if got := mirMonomorphMangledSourceName(tc.name); got != tc.want {
+			t.Fatalf("mirMonomorphMangledSourceName(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+	if !mangledBuiltinSourceNameIs("_ZTSN3std4List", "List") {
+		t.Fatalf("mangled builtin List predicate failed")
+	}
+	if mangledBuiltinSourceNameIs("_ZTSN3std4List", "Map") {
+		t.Fatalf("mangled builtin predicate matched wrong source name")
+	}
+}

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -202,6 +202,9 @@ build_self_binary() {
 		fi
 	fi
 	if [[ "$count" != "1" ]]; then
+		if [[ -z "$candidate" && -x "$default_candidate" ]] && grep -Fxq "$default_candidate" "$candidates"; then
+			candidate="$default_candidate"
+		fi
 		if [[ -z "$candidate" ]]; then
 			printf 'self-rebuild: %s produced multiple binary candidates:\n' "$label" >&2
 			sed 's/^/  /' "$candidates" >&2

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -649,6 +649,191 @@ pub fn mirIsUnitTypeText(typeText: String) -> Bool {
     typeText == "Unit" || typeText == "()" || typeText == "Never"
 }
 
+/// mirTrimTypeText trims the single-space padding that `NamedType`
+/// rendering inserts after top-level commas (`Result<T, E>`). This is
+/// deliberately small and ASCII-only because type strings are compiler-
+/// authored, not user text.
+pub fn mirTrimTypeText(typeText: String) -> String {
+    let mut lo = 0
+    let mut hi = typeText.len()
+    for lo < hi && typeText[lo..(lo + 1)] == " " {
+        lo = lo + 1
+    }
+    for hi > lo && typeText[(hi - 1)..hi] == " " {
+        hi = hi - 1
+    }
+    typeText[lo..hi]
+}
+
+/// mirTopLevelTypeCommaIndex returns the comma that splits a generic
+/// argument list at depth zero. Nested generic / tuple / fn shapes are
+/// skipped so `Result<List<(Int, String)>, Error>` still splits on the
+/// Result comma rather than an inner tuple separator.
+pub fn mirTopLevelTypeCommaIndex(typeText: String) -> Int {
+    let mut depth = 0
+    let mut i = 0
+    let n = typeText.len()
+    for i < n {
+        let ch = typeText[i..(i + 1)]
+        if ch == "<" || ch == "(" {
+            depth = depth + 1
+        } else if ch == ">" || ch == ")" {
+            depth = depth - 1
+        } else if ch == "," && depth == 0 {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirResultTypeArgsText extracts the two textual type arguments from
+/// `Result<T, E>`. The packed return is `ok + "\n" + err`; `""`
+/// means the input is not a two-arg Result shape. Keeping the parser
+/// here lets Result-layout compatibility policy live in Osty while Go
+/// still owns the actual `mir.Type` nodes.
+pub fn mirResultTypeArgsText(typeText: String) -> String {
+    let head = mirLlvmTypeHeadName(typeText)
+    if head != "Result" && !llvmStrings.HasSuffix(head, ".Result") {
+        return ""
+    }
+    let lt = llvmStrings.Index(typeText, "<")
+    if lt < 0 {
+        return ""
+    }
+    if !llvmStrings.HasSuffix(typeText, ">") {
+        return ""
+    }
+    let body = typeText[(lt + 1)..(typeText.len() - 1)]
+    let comma = mirTopLevelTypeCommaIndex(body)
+    if comma < 0 {
+        return ""
+    }
+    let okText = mirTrimTypeText(body[0..comma])
+    let errText = mirTrimTypeText(body[(comma + 1)..body.len()])
+    if okText == "" || errText == "" {
+        return ""
+    }
+    okText + "\n" + errText
+}
+
+pub fn mirResultOkTypeText(typeText: String) -> String {
+    let packed = mirResultTypeArgsText(typeText)
+    let idx = llvmStrings.Index(packed, "\n")
+    if idx < 0 {
+        return ""
+    }
+    packed[0..idx]
+}
+
+pub fn mirResultErrTypeText(typeText: String) -> String {
+    let packed = mirResultTypeArgsText(typeText)
+    let idx = llvmStrings.Index(packed, "\n")
+    if idx < 0 {
+        return ""
+    }
+    packed[(idx + 1)..packed.len()]
+}
+
+/// mirUnitTupleAliasTypeText centralizes the no-value aliasing policy
+/// used when the frontend alternates between primitive Unit and the
+/// empty tuple spelling. Both render as `()` in the HIR/MIR type text,
+/// so equality covers the common MIR path; `"Unit"` is accepted for
+/// call sites that still forward pre-canonicalized surface text.
+pub fn mirUnitTupleAliasTypeText(a: String, b: String) -> Bool {
+    if a == b {
+        return true
+    }
+    (a == "Unit" && b == "()") || (a == "()" && b == "Unit")
+}
+
+/// mirCompatibleResultUnitTupleAliasText reports whether two Result
+/// type texts are layout-compatible when their Ok channel is only a
+/// Unit / empty-tuple spelling difference and their Err channel is the
+/// same. This is the pure policy half of the Go-side `mir.Type` check.
+pub fn mirCompatibleResultUnitTupleAliasText(fromText: String, toText: String) -> Bool {
+    let fromOk = mirResultOkTypeText(fromText)
+    let fromErr = mirResultErrTypeText(fromText)
+    let toOk = mirResultOkTypeText(toText)
+    let toErr = mirResultErrTypeText(toText)
+    if fromOk == "" || fromErr == "" || toOk == "" || toErr == "" {
+        return false
+    }
+    mirUnitTupleAliasTypeText(fromOk, toOk) && fromErr == toErr
+}
+
+/// mirCompatibleEnumAggregateHintText decides whether an enum-variant
+/// aggregate should adopt its contextual Result type. The full Result
+/// match accepts only Unit/tuple Ok aliases plus identical Err types;
+/// variant-specific construction can be looser because `Err(...)` does
+/// not observe Ok payload spelling and `Ok(())` does not observe Err
+/// payload storage.
+pub fn mirCompatibleEnumAggregateHintText(rvText: String, hintText: String, variantTag: String) -> Bool {
+    let rvOk = mirResultOkTypeText(rvText)
+    let rvErr = mirResultErrTypeText(rvText)
+    let hintOk = mirResultOkTypeText(hintText)
+    let hintErr = mirResultErrTypeText(hintText)
+    if rvOk == "" || rvErr == "" || hintOk == "" || hintErr == "" {
+        return false
+    }
+    if mirUnitTupleAliasTypeText(rvOk, hintOk) && rvErr == hintErr {
+        return true
+    }
+    if variantTag == "Err" && rvErr == hintErr {
+        return true
+    }
+    if variantTag == "Ok" && mirUnitTupleAliasTypeText(rvOk, hintOk) {
+        return true
+    }
+    false
+}
+
+/// mirReplaceFirstText returns `text` with the first `old` occurrence
+/// replaced by `newText`. Empty needles are ignored so callers do not
+/// accidentally manufacture aliases from every string boundary.
+pub fn mirReplaceFirstText(text: String, old: String, newText: String) -> String {
+    if old == "" {
+        return text
+    }
+    let idx = llvmStrings.Index(text, old)
+    if idx < 0 {
+        return text
+    }
+    text[0..idx] + newText + text[(idx + old.len())..text.len()]
+}
+
+/// mirResultUnitTupleLLVMTypeAlias recognizes the LLVM named-type
+/// alias produced by Result<(), E> when one path spells the Ok tag as
+/// `.unit.` and another as `.Tuple..`. The layouts are both `{ i64,
+/// i64 }`; only the textual type handle differs.
+pub fn mirResultUnitTupleLLVMTypeAlias(fromLLVM: String, toLLVM: String) -> Bool {
+    if fromLLVM == "" || toLLVM == "" || fromLLVM == toLLVM {
+        return false
+    }
+    mirReplaceFirstText(fromLLVM, ".unit.", ".Tuple..") == toLLVM ||
+        mirReplaceFirstText(toLLVM, ".unit.", ".Tuple..") == fromLLVM
+}
+
+/// mirRetypeI64PairAggregateLines rebuilds a `{ i64, i64 }` Result /
+/// Option aggregate under another compatible named LLVM type. LLVM IR
+/// requires the `extractvalue` source type and `insertvalue` target
+/// type to match their textual handles even when the physical layout is
+/// identical, so this helper owns the exact four-line rewrite shape.
+pub fn mirRetypeI64PairAggregateLines(
+    discReg: String,
+    payloadReg: String,
+    tmpReg: String,
+    outReg: String,
+    fromLLVM: String,
+    toLLVM: String,
+    valueReg: String,
+) -> String {
+    mirExtractValueLine(discReg, fromLLVM, valueReg, "0") +
+    mirExtractValueLine(payloadReg, fromLLVM, valueReg, "1") +
+    mirInsertValueI64Line(tmpReg, toLLVM, "undef", discReg, "0") +
+    mirInsertValueI64Line(outReg, toLLVM, tmpReg, payloadReg, "1")
+}
+
 /// mirIsFloatTypeText reports whether the hir-style type text names a
 /// floating-point primitive. Mirrors `isFloatType` in
 /// `internal/llvmgen/mir_generator.go`. Accepts both the spec surface
@@ -16989,6 +17174,86 @@ pub fn mirIsContainerNamedType(name: String, builtin: Bool) -> Bool {
 /// `internal/llvmgen/ir_native_entry.go`.
 pub fn mirIsPrimUnitName(name: String) -> Bool {
     name == "Unit"
+}
+
+/// mirDecimalDigitValue returns the integer value of an ASCII decimal
+/// digit or `-1` for non-digits. Kept near the name-mangling helpers
+/// because the Itanium-ish monomorph spellings use decimal length
+/// prefixes.
+pub fn mirDecimalDigitValue(ch: String) -> Int {
+    if ch == "0" { return 0 }
+    if ch == "1" { return 1 }
+    if ch == "2" { return 2 }
+    if ch == "3" { return 3 }
+    if ch == "4" { return 4 }
+    if ch == "5" { return 5 }
+    if ch == "6" { return 6 }
+    if ch == "7" { return 7 }
+    if ch == "8" { return 8 }
+    if ch == "9" { return 9 }
+    -1
+}
+
+/// mirParseDecimalPrefix parses a non-empty ASCII decimal prefix from
+/// `text[0..end]`. Returns `-1` if any byte is not a digit. The caller
+/// bounds-checks the resulting length against the full mangled string.
+pub fn mirParseDecimalPrefix(text: String, end: Int) -> Int {
+    if end <= 0 {
+        return -1
+    }
+    let mut out = 0
+    let mut i = 0
+    for i < end {
+        let d = mirDecimalDigitValue(text[i..(i + 1)])
+        if d < 0 {
+            return -1
+        }
+        out = (out * 10) + d
+        i = i + 1
+    }
+    out
+}
+
+/// mirMonomorphMangledSourceName extracts the source type name from the
+/// monomorphized layout spelling used by the current Go lowerer:
+/// `_ZTSN<pkgLen><pkg><typeLen><type>...`. Invalid or non-monomorph
+/// inputs return `""`. The package segment is intentionally skipped —
+/// callers only need to know whether the source head was List, Map,
+/// Set, Option, Maybe, or Result.
+pub fn mirMonomorphMangledSourceName(name: String) -> String {
+    let prefix = "_ZTSN"
+    if !llvmStrings.HasPrefix(name, prefix) {
+        return ""
+    }
+    let mut rest = name[prefix.len()..name.len()]
+
+    let mut i = 0
+    for i < rest.len() && mirDecimalDigitValue(rest[i..(i + 1)]) >= 0 {
+        i = i + 1
+    }
+    let pkgLen = mirParseDecimalPrefix(rest, i)
+    if pkgLen < 0 || (i + pkgLen) > rest.len() {
+        return ""
+    }
+    rest = rest[(i + pkgLen)..rest.len()]
+
+    i = 0
+    for i < rest.len() && mirDecimalDigitValue(rest[i..(i + 1)]) >= 0 {
+        i = i + 1
+    }
+    let typeLen = mirParseDecimalPrefix(rest, i)
+    if typeLen <= 0 || (i + typeLen) > rest.len() {
+        return ""
+    }
+    rest[i..(i + typeLen)]
+}
+
+/// mirMangledBuiltinSourceNameIs reports whether a monomorphized
+/// layout name originated from a particular builtin source type. This
+/// is the Osty-owned policy behind Go's List/Map/Set/Option/Result
+/// fallback checks.
+pub fn mirMangledBuiltinSourceNameIs(name: String, want: String) -> Bool {
+    mirMonomorphMangledSourceName(name) == want
 }
 
 /// mirSetElemTypeArgIndex returns the index of the element type in


### PR DESCRIPTION
## Summary
- Move Result unit/tuple alias and enum aggregate hint policy from Go into `toolchain/mir_generator.osty` with mirrored snapshot helpers.
- Move monomorphized builtin source-name parsing into Osty and keep Go as a thin wrapper.
- Make `verify-self-rebuild` prefer the canonical `toolchain/.osty/out/debug/llvm/osty-self` artifact when stale binaries create multiple candidates.

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestMirResult|TestMirCompatible|TestMirRetype|TestMirMonomorph'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryResultUnitErrUsesReturnContext'`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `just verify-selfhost`
- `shellcheck scripts/verify-self-rebuild`
- `just backend-loop` Go backend package phase passed; self-rebuild rerun separately after fixing candidate selection.
- `bash scripts/verify-self-rebuild --skip-gates --reuse-stage1 .bin/osty` byte parity OK: `77e40a85b4b54c9bc5e6abd80e5e18d9f0f073e3c1e3570f2747059ec3b34a00`
- After rebasing onto latest `origin/main`: `just verify-self-rebuild-gates`