### PR TITLE
[codex] clarify loader graph source maps

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1635,26 +1635,19 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 	chk := &check.Result{}
 	var entryFile *resolve.PackageFile
 	for _, path := range files {
-		src, err := os.ReadFile(path)
+		original, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		var original []byte
-		transformApplied := false
-		transformChanged := false
-		if transform != nil {
-			original = append([]byte(nil), src...)
-			src = transform(path, src)
-			transformApplied = true
-			transformChanged = !bytes.Equal(original, src)
-		}
+		src, transformMap := resolve.ApplySourceTransform(path, original, resolve.LoadOptions{Transform: transform})
+		transformApplied := transform != nil
+		transformChanged := transformApplied && !bytes.Equal(src, original)
 		run := selfhost.Run(src)
 		file := selfhost.LowerPublicFileFromRun(run)
 		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, file)
 		pf := &resolve.PackageFile{
 			Path:                   path,
 			Source:                 src,
-			OriginalSource:         original,
 			SourceTransformApplied: transformApplied,
 			SourceTransformChanged: transformChanged,
 			CanonicalSource:        canonicalSrc,
@@ -1662,6 +1655,10 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 			File:                   file,
 			Run:                    run,
 			ParseDiags:             run.Diagnostics(),
+		}
+		if transformMap != nil {
+			pf.OriginalSource = append([]byte(nil), original...)
+			pf.TransformMap = transformMap
 		}
 		pkg.Files = append(pkg.Files, pf)
 		res.Diags = append(res.Diags, pf.ParseDiags...)

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1921,7 +1921,7 @@ func selfhostPackageSource(pkg *resolve.Package, ws *resolve.Workspace, stdlib r
 			scope:     pf.FileScope,
 			refs:      pf.RefsByID,
 			base:      base,
-			sourceMap: pf.CanonicalMap,
+			sourceMap: pf.CheckerSourceMap(),
 		})
 	}
 	return selfhostCheckedSource{source: b.Bytes(), files: files}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -501,7 +501,9 @@ func dirHasOstySiblings(dir, selfPath string) bool {
 // as one package. The file whose URI the client opened is substituted
 // with `src` so unsaved edits are honored.
 func (s *Server) analyzePackage(pkgDir, path string, src []byte) *docAnalysis {
-	pkg, err := resolve.LoadPackageForNativeWithTransform(pkgDir, lspSourceOverrideTransform(path, src))
+	pkg, err := resolve.LoadPackageForNativeWithOptions(pkgDir, resolve.LoadOptions{
+		Transformer: lspSourceOverrideTransformer(path, src),
+	})
 	if err != nil {
 		return nil
 	}
@@ -794,7 +796,7 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 	if err != nil {
 		return nil
 	}
-	ws.SourceTransform = lspSourceOverrideTransform(path, src)
+	ws.SourceTransformer = lspSourceOverrideTransformer(path, src)
 	// Seed the root package (if any) and every immediate subdir that
 	// has `.osty` files; LoadPackage chases `use` edges from there.
 	seedWorkspace(ws, root)
@@ -853,28 +855,28 @@ func seedWorkspace(ws *resolve.Workspace, root string) {
 	}
 }
 
-func lspSourceOverrideTransform(path string, src []byte) resolve.SourceTransform {
+func lspSourceOverrideTransformer(path string, src []byte) resolve.SourceTransformer {
 	if path == "" {
 		return nil
 	}
-	return func(candidate string, original []byte) []byte {
+	return func(candidate string, original []byte) resolve.SourceTransformResult {
 		if candidate != path {
-			return original
+			return resolve.SourceTransformResult{Source: original, MapKnown: true}
 		}
-		return append([]byte(nil), src...)
+		return resolve.SourceTransformResult{Source: append([]byte(nil), src...), MapKnown: true}
 	}
 }
 
-func lspSourceOverrideMapTransform(overrides map[string][]byte) resolve.SourceTransform {
+func lspSourceOverrideMapTransformer(overrides map[string][]byte) resolve.SourceTransformer {
 	if len(overrides) == 0 {
 		return nil
 	}
-	return func(candidate string, original []byte) []byte {
+	return func(candidate string, original []byte) resolve.SourceTransformResult {
 		src, ok := overrides[candidate]
 		if !ok {
-			return original
+			return resolve.SourceTransformResult{Source: original, MapKnown: true}
 		}
-		return append([]byte(nil), src...)
+		return resolve.SourceTransformResult{Source: append([]byte(nil), src...), MapKnown: true}
 	}
 }
 
@@ -1237,7 +1239,7 @@ func (s *Server) ensureWorkspaceIndex(root string) []*resolve.Package {
 		}
 	}
 	s.docs.mu.Unlock()
-	ws.SourceTransform = lspSourceOverrideMapTransform(openBufs)
+	ws.SourceTransformer = lspSourceOverrideMapTransformer(openBufs)
 	ws.Packages = map[string]*resolve.Package{}
 	seedWorkspace(ws, root)
 	lspMaterializeNativeWorkspace(ws)

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -382,6 +382,8 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				pkg.Files[i] = &resolve.PackageFile{
 					Path:            pf.Path,
 					Source:          pf.Source,
+					OriginalSource:  pf.OriginalSource,
+					TransformMap:    pf.TransformMap,
 					CanonicalSource: pf.CanonicalSource,
 					CanonicalMap:    pf.CanonicalMap,
 					File:            pf.File,
@@ -718,6 +720,8 @@ func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 		pkg.Files[i] = &resolve.PackageFile{
 			Path:            pf.Path,
 			Source:          pf.Source,
+			OriginalSource:  pf.OriginalSource,
+			TransformMap:    pf.TransformMap,
 			CanonicalSource: pf.CanonicalSource,
 			CanonicalMap:    pf.CanonicalMap,
 			File:            pf.File,

--- a/internal/resolve/load_selected.go
+++ b/internal/resolve/load_selected.go
@@ -16,6 +16,10 @@ func LoadPackageFiles(paths []string, stdlib StdlibProvider) (*Package, error) {
 // LoadPackageFilesWithTransform is LoadPackageFiles plus an optional
 // pre-parse source transform.
 func LoadPackageFilesWithTransform(paths []string, stdlib StdlibProvider, transform SourceTransform) (*Package, error) {
+	return LoadPackageFilesWithOptions(paths, stdlib, LoadOptions{Transform: transform})
+}
+
+func LoadPackageFilesWithOptions(paths []string, stdlib StdlibProvider, opts LoadOptions) (*Package, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("load selected package: no files")
 	}
@@ -36,7 +40,7 @@ func LoadPackageFilesWithTransform(paths []string, stdlib StdlibProvider, transf
 	if stdlib != nil {
 		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
 	}
-	loaded, err := loadPackageNativePaths(absPaths, dir, filepath.Base(dir), transform)
+	loaded, err := loadPackageNativePaths(absPaths, dir, filepath.Base(dir), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -11,11 +11,35 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/sourcemap"
 )
 
 // SourceTransform lets callers rewrite raw source bytes before the
 // parser sees them. nil preserves the on-disk bytes.
 type SourceTransform func(path string, src []byte) []byte
+
+// SourceTransformResult is the structured form of SourceTransform.
+// Map projects Source spans back onto the bytes supplied to the transformer.
+// When MapKnown is true, Map is authoritative; a nil Map explicitly means the
+// transformed source should be treated as the diagnostic source too.
+type SourceTransformResult struct {
+	Source   []byte
+	Map      *sourcemap.Map
+	MapKnown bool
+}
+
+// SourceTransformer lets callers rewrite source and provide an exact source
+// map. It is useful for non-file-backed sources where deriving an on-disk
+// diagnostic map would be wrong, such as LSP open-buffer overlays.
+type SourceTransformer func(path string, src []byte) SourceTransformResult
+
+// LoadOptions is the unified native loader configuration shared by package,
+// test-package, selected-file, and workspace call paths.
+type LoadOptions struct {
+	IncludeTests bool
+	Transform    SourceTransform
+	Transformer  SourceTransformer
+}
 
 // LoadPackageForNative is the astbridge-free sibling of LoadPackage: it
 // discovers every `.osty` file under dir (non-recursive, test files
@@ -32,7 +56,7 @@ func LoadPackageForNative(dir string) (*Package, error) {
 // LoadPackageForNativeWithTransform is LoadPackageForNative plus an
 // optional pre-parse source transform.
 func LoadPackageForNativeWithTransform(dir string, transform SourceTransform) (*Package, error) {
-	return loadPackageForNativeWithTransform(dir, transform, false)
+	return LoadPackageForNativeWithOptions(dir, LoadOptions{Transform: transform})
 }
 
 // LoadPackageForNativeWithTests is like LoadPackageForNative but also includes
@@ -45,10 +69,10 @@ func LoadPackageForNativeWithTests(dir string) (*Package, error) {
 // LoadPackageForNativeWithTestsTransform is LoadPackageForNativeWithTests plus
 // an optional pre-parse source transform.
 func LoadPackageForNativeWithTestsTransform(dir string, transform SourceTransform) (*Package, error) {
-	return loadPackageForNativeWithTransform(dir, transform, true)
+	return LoadPackageForNativeWithOptions(dir, LoadOptions{IncludeTests: true, Transform: transform})
 }
 
-func loadPackageForNativeWithTransform(dir string, transform SourceTransform, includeTests bool) (*Package, error) {
+func LoadPackageForNativeWithOptions(dir string, opts LoadOptions) (*Package, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -66,43 +90,67 @@ func loadPackageForNativeWithTransform(dir string, transform SourceTransform, in
 		if !strings.HasSuffix(name, ".osty") {
 			continue
 		}
-		if !includeTests && strings.HasSuffix(name, "_test.osty") {
+		if !opts.IncludeTests && strings.HasSuffix(name, "_test.osty") {
 			continue
 		}
 		paths = append(paths, filepath.Join(abs, name))
 	}
 	sort.Strings(paths)
-	return loadPackageNativePaths(paths, abs, filepath.Base(abs), transform)
+	return loadPackageNativePaths(paths, abs, filepath.Base(abs), opts)
 }
 
-func loadPackageNativePaths(paths []string, dir, name string, transform SourceTransform) (*Package, error) {
+func loadPackageNativePaths(paths []string, dir, name string, opts LoadOptions) (*Package, error) {
 	pkg := &Package{Dir: dir, Name: name, RuntimeCapability: packageRuntimeCapability(dir)}
 	for _, p := range paths {
-		src, err := os.ReadFile(p)
+		original, err := os.ReadFile(p)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
-		var original []byte
-		transformApplied := false
-		transformChanged := false
-		if transform != nil {
-			original = append([]byte(nil), src...)
-			src = transform(p, src)
-			transformApplied = true
-			transformChanged = !bytes.Equal(original, src)
-		}
+		src, transformMap := ApplySourceTransform(p, original, opts)
+		transformApplied := opts.Transform != nil || opts.Transformer != nil
+		transformChanged := transformApplied && !bytes.Equal(src, original)
 		run := selfhost.Run(src)
-		pkg.Files = append(pkg.Files, &PackageFile{
+		pf := &PackageFile{
 			Path:                   p,
 			Source:                 src,
-			OriginalSource:         original,
 			SourceTransformApplied: transformApplied,
 			SourceTransformChanged: transformChanged,
 			Run:                    run,
 			ParseDiags:             append([]*diag.Diagnostic(nil), run.Diagnostics()...),
-		})
+		}
+		if transformMap != nil {
+			pf.OriginalSource = append([]byte(nil), original...)
+			pf.TransformMap = transformMap
+		}
+		pkg.Files = append(pkg.Files, pf)
 	}
 	return pkg, nil
+}
+
+// ApplySourceTransform applies the loader's pre-parse source rewrite policy.
+// Legacy Transform functions get a derived best-effort source map when their
+// output changes. Structured Transformer results may provide an exact map, or
+// set MapKnown with a nil map to opt out of original-source remapping.
+func ApplySourceTransform(path string, original []byte, opts LoadOptions) ([]byte, *sourcemap.Map) {
+	if opts.Transformer != nil {
+		result := opts.Transformer(path, append([]byte(nil), original...))
+		src := append([]byte(nil), result.Source...)
+		if result.MapKnown {
+			return src, result.Map
+		}
+		if bytes.Equal(src, original) {
+			return src, nil
+		}
+		return src, sourcemap.FromSourceTransform(original, src)
+	}
+	if opts.Transform == nil {
+		return append([]byte(nil), original...), nil
+	}
+	src := opts.Transform(path, append([]byte(nil), original...))
+	if bytes.Equal(src, original) {
+		return append([]byte(nil), src...), nil
+	}
+	return append([]byte(nil), src...), sourcemap.FromSourceTransform(original, src)
 }
 
 func packageRuntimeCapability(dir string) bool {

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -20,8 +20,8 @@ type nativeResolveCache struct {
 	once       sync.Once
 	checkOnce  sync.Once
 	result     api.ResolveResult
-	check      selfhost.CheckResult
-	checkInput selfhost.PackageCheckInput
+	check      api.CheckResult
+	checkInput api.PackageCheckInput
 	files      []nativeResolveFileInfo
 	err        error
 }
@@ -162,7 +162,7 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 			pkg.nativeResolve.err = err
 			return
 		}
-		pkg.nativeResolve.checkInput = selfhost.PackageCheckInput{
+		pkg.nativeResolve.checkInput = api.PackageCheckInput{
 			Files:   input.Files,
 			Imports: input.Imports,
 		}
@@ -172,10 +172,10 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.err
 }
 
-func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, selfhost.CheckResult, error) {
+func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, api.CheckResult, error) {
 	result, files, err := nativeResolveArtifacts(pkg)
 	if err != nil || pkg == nil {
-		return result, files, selfhost.CheckResult{}, err
+		return result, files, api.CheckResult{}, err
 	}
 	pkg.nativeResolve.checkOnce.Do(func() {
 		checked, err := selfhost.CheckPackageStructured(pkg.nativeResolve.checkInput)
@@ -236,7 +236,7 @@ func nativeResolveInput(pkg *Package) (api.PackageResolveInput, []nativeResolveF
 			path:       pf.Path,
 			base:       base,
 			source:     append([]byte(nil), src...),
-			sourceMap:  pf.CanonicalMap,
+			sourceMap:  pf.CheckerSourceMap(),
 			lineStarts: nativeResolveLineStarts(src),
 		})
 		base += len(src) + 1
@@ -338,7 +338,7 @@ func nativeResolutionRowsFromArtifacts(path string, resolved api.ResolveResult, 
 	return rows
 }
 
-func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeResolveFileInfo, checked selfhost.CheckResult) NativeResolveFactSet {
+func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeResolveFileInfo, checked api.CheckResult) NativeResolveFactSet {
 	facts := NativeResolveFactSet{
 		Symbols: make([]NativeResolvedSymbol, 0, len(resolved.Symbols)),
 		Refs:    make([]NativeResolvedRef, 0, len(resolved.Refs)+len(resolved.TypeRefs)),
@@ -409,7 +409,7 @@ func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeR
 	return facts
 }
 
-func nativeCheckSymbolTypes(checked selfhost.CheckResult) map[int]string {
+func nativeCheckSymbolTypes(checked api.CheckResult) map[int]string {
 	if len(checked.Symbols) == 0 {
 		return nil
 	}
@@ -493,14 +493,14 @@ func nativeImportLocalName(name string) string {
 	return name
 }
 
-func nativeTypeReprText(repr *selfhost.TypeRepr, fallback string) string {
+func nativeTypeReprText(repr *api.TypeRepr, fallback string) string {
 	if repr != nil {
 		return repr.String()
 	}
 	return fallback
 }
 
-func nativeImportFnType(fn selfhost.PackageCheckFn) string {
+func nativeImportFnType(fn api.PackageCheckFn) string {
 	params := make([]string, 0, len(fn.ParamTypes)+len(fn.ParamTypeReprs))
 	if len(fn.ParamTypeReprs) > 0 {
 		for i := range fn.ParamTypeReprs {
@@ -516,7 +516,7 @@ func nativeImportFnType(fn selfhost.PackageCheckFn) string {
 	return "fn(" + strings.Join(params, ", ") + ") -> " + ret
 }
 
-func nativeImportVariantType(variant selfhost.PackageCheckVariant) string {
+func nativeImportVariantType(variant api.PackageCheckVariant) string {
 	fields := make([]string, 0, len(variant.FieldTypes)+len(variant.FieldTypeReprs))
 	if len(variant.FieldTypeReprs) > 0 {
 		for i := range variant.FieldTypeReprs {

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -58,17 +58,22 @@ type Package struct {
 type PackageFile struct {
 	// Path is the file's filesystem path.
 	Path string
-	// Source is the raw UTF-8 bytes. Retained so diagnostics can render
-	// source snippets without re-reading the file.
+	// Source is the parser-facing UTF-8 bytes. When a SourceTransform was
+	// applied, this is the transformed source.
 	Source []byte
-	// OriginalSource is the on-disk UTF-8 bytes before SourceTransform ran.
-	// Nil means the parser saw Source directly.
+	// OriginalSource is the on-disk source before SourceTransform. Empty when
+	// Source already matches the file contents or the transform opted out of
+	// original-source remapping.
 	OriginalSource []byte
 	// SourceTransformApplied records that the workspace source transform
 	// hook was invoked for this file.
 	SourceTransformApplied bool
 	// SourceTransformChanged records that Source differs from OriginalSource.
 	SourceTransformChanged bool
+	// TransformMap projects parser-facing Source spans back onto OriginalSource.
+	// Nil when no transform changed the file or when the transform explicitly
+	// keeps diagnostics on Source.
+	TransformMap *sourcemap.Map
 	// CanonicalSource is the checker-facing canonical Osty source produced from
 	// the parsed AST after parser-owned canonicalization. When empty,
 	// callers should fall back to Source.
@@ -124,6 +129,50 @@ func (pf *PackageFile) CheckerSource() []byte {
 		return pf.CanonicalSource
 	}
 	return pf.Source
+}
+
+func (pf *PackageFile) DiagnosticSource() []byte {
+	if pf == nil {
+		return nil
+	}
+	if len(pf.OriginalSource) > 0 {
+		return pf.OriginalSource
+	}
+	return pf.Source
+}
+
+func (pf *PackageFile) DiagnosticMap() *sourcemap.Map {
+	if pf == nil {
+		return nil
+	}
+	return pf.TransformMap
+}
+
+// CheckerSourceMap projects CheckerSource spans back onto parser-facing Source
+// spans. It deliberately stops before TransformMap so native bridge indexes can
+// still match the public AST, whose positions are in Source coordinates.
+func (pf *PackageFile) CheckerSourceMap() *sourcemap.Map {
+	if pf == nil {
+		return nil
+	}
+	return pf.CanonicalMap
+}
+
+// CheckerDiagnosticMap projects CheckerSource spans onto DiagnosticSource
+// spans. Use it only for diagnostics that are known to be checker-source
+// relative; parser and resolver diagnostics usually live in Source coordinates
+// and should use DiagnosticMap instead.
+func (pf *PackageFile) CheckerDiagnosticMap() *sourcemap.Map {
+	if pf == nil {
+		return nil
+	}
+	if pf.CanonicalMap == nil {
+		return pf.TransformMap
+	}
+	if pf.TransformMap == nil {
+		return pf.CanonicalMap
+	}
+	return pf.CanonicalMap.Compose(pf.TransformMap)
 }
 
 // CanMaterializeFile reports whether EnsureFile can produce the public AST

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -164,6 +164,106 @@ runtime = true
 	}
 }
 
+func TestLoadPackageForNativeWithTransformKeepsOriginalDiagnosticSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	original := []byte("func main() {\n    let value = 1\n}\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageForNativeWithTransform(dir, func(_ string, src []byte) []byte {
+		return []byte("fn main() {\n    let value = 1\n}\n")
+	})
+	if err != nil {
+		t.Fatalf("LoadPackageForNativeWithTransform: %v", err)
+	}
+	if len(pkg.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(pkg.Files))
+	}
+	pf := pkg.Files[0]
+	if got := string(pf.Source); got[:2] != "fn" {
+		t.Fatalf("Source prefix = %q, want transformed fn", got[:2])
+	}
+	if got := string(pf.DiagnosticSource()); got[:4] != "func" {
+		t.Fatalf("DiagnosticSource prefix = %q, want original func", got[:4])
+	}
+	if pf.TransformMap == nil {
+		t.Fatal("TransformMap is nil, want remap for changed source")
+	}
+}
+
+func TestLoadPackageForNativeWithTransformerCanOptOutOfOriginalRemap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte("fn main() {\n    let value = 1\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageForNativeWithOptions(dir, LoadOptions{
+		Transformer: func(_ string, _ []byte) SourceTransformResult {
+			return SourceTransformResult{
+				Source:   []byte("fn main() {\n    let value = 2\n}\n"),
+				MapKnown: true,
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadPackageForNativeWithOptions: %v", err)
+	}
+	pf := pkg.Files[0]
+	if got := string(pf.DiagnosticSource()); got != string(pf.Source) {
+		t.Fatalf("DiagnosticSource = %q, want transformed Source %q", got, string(pf.Source))
+	}
+	if pf.TransformMap != nil {
+		t.Fatal("TransformMap is non-nil, want explicit opt-out")
+	}
+}
+
+func TestWorkspacePackageGraphExposesLoadedEdges(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.osty"), []byte("pub use dep\nfn main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "lib.osty"), []byte("pub fn value() -> Int { 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+	graph := NewPackageGraph(ws)
+	if len(graph.Packages) != 2 {
+		t.Fatalf("graph packages = %d, want 2", len(graph.Packages))
+	}
+	if len(graph.Edges) != 1 {
+		t.Fatalf("graph edges = %d, want 1", len(graph.Edges))
+	}
+	rootNode := graph.Packages[""]
+	depNode := graph.Packages["dep"]
+	if rootNode == nil || depNode == nil {
+		t.Fatalf("graph packages = %#v, want root and dep", graph.Packages)
+	}
+	if rootNode.IsStdlib || rootNode.IsExternalDep || depNode.IsStdlib || depNode.IsExternalDep {
+		t.Fatalf("graph package classifications = root %#v dep %#v, want workspace packages", rootNode, depNode)
+	}
+	edge := graph.Edges[0]
+	if edge.From != "" || edge.To != "dep" || !edge.IsPub || edge.Kind != PackageGraphEdgeWorkspace {
+		t.Fatalf("edge = %#v, want root pub edge to dep", edge)
+	}
+	if graph.Package("dep") != depNode.Package {
+		t.Fatalf("graph.Package(\"dep\") = %#v, want dep package %#v", graph.Package("dep"), depNode.Package)
+	}
+}
+
 func TestNativeResolveBridgeIndexesScriptScopeBindings(t *testing.T) {
 	src := []byte("let x = 1\nlet y = x\n")
 	file, parseDiags := parser.ParseDiagnostics(src)

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -132,6 +132,11 @@ type Workspace struct {
 	// resolver work begins.
 	SourceTransform SourceTransform
 
+	// SourceTransformer is the structured source rewrite hook. When set, it
+	// takes precedence over SourceTransform and may provide exact source-map
+	// metadata or deliberately opt out of original-source remapping.
+	SourceTransformer SourceTransformer
+
 	// stdlibStub is set to true when the workspace should tolerate
 	// `std.*` imports even though no stdlib sources are present. Useful
 	// in tests and before the stdlib is bundled with the compiler.
@@ -148,6 +153,16 @@ type Workspace struct {
 	// driver sets this explicitly when cross-compiling or toggling
 	// features.
 	cfgEnv *CfgEnv
+}
+
+func (w *Workspace) loadOptions() LoadOptions {
+	if w == nil {
+		return LoadOptions{}
+	}
+	return LoadOptions{
+		Transform:   w.SourceTransform,
+		Transformer: w.SourceTransformer,
+	}
 }
 
 // SetCfgEnv installs a CfgEnv that subsequent ResolveAll calls use

--- a/internal/resolve/workspace_native.go
+++ b/internal/resolve/workspace_native.go
@@ -50,7 +50,7 @@ func (w *Workspace) LoadPackageNative(dotPath string) (*Package, error) {
 	w.loading[dotPath] = true
 	defer delete(w.loading, dotPath)
 
-	pkg, err := LoadPackageForNativeWithTransform(dir, w.SourceTransform)
+	pkg, err := LoadPackageForNativeWithOptions(dir, w.loadOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (w *Workspace) loadFromExternalDirNative(key, dir string) (*Package, error)
 	w.loading[key] = true
 	defer delete(w.loading, key)
 
-	pkg, err := LoadPackageForNativeWithTransform(dir, w.SourceTransform)
+	pkg, err := LoadPackageForNativeWithOptions(dir, w.loadOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sourcemap/map.go
+++ b/internal/sourcemap/map.go
@@ -1,6 +1,7 @@
 package sourcemap
 
 import (
+	"bytes"
 	"sort"
 	"sync"
 	"unicode/utf8"
@@ -44,6 +45,40 @@ func (m *Map) Entries() []Entry {
 	return m.entries
 }
 
+// Clone returns a copy of the map metadata. Entry values are immutable, so a
+// shallow entry copy is enough to keep callers from mutating this map's slice.
+func (m *Map) Clone() *Map {
+	if m == nil || len(m.entries) == 0 {
+		return nil
+	}
+	return &Map{entries: append([]Entry(nil), m.entries...)}
+}
+
+// Compose chains this map with next. The returned map projects this map's
+// generated spans through this map's original spans and then through next,
+// e.g. canonical source -> transformed source -> on-disk source.
+func (m *Map) Compose(next *Map) *Map {
+	if m == nil || len(m.entries) == 0 {
+		return nil
+	}
+	if next == nil || len(next.entries) == 0 {
+		return m.Clone()
+	}
+	out := &Map{entries: make([]Entry, 0, len(m.entries))}
+	for _, entry := range m.entries {
+		original := entry.Original
+		if remapped, ok := next.RemapSpanProjected(entry.Original); ok {
+			original = remapped
+		}
+		out.entries = append(out.entries, Entry{
+			Kind:      entry.Kind,
+			Generated: entry.Generated,
+			Original:  original,
+		})
+	}
+	return out
+}
+
 // RemapSpan projects a canonical/generated span back onto the original source.
 func (m *Map) RemapSpan(span diag.Span) (diag.Span, bool) {
 	entry := m.entryForGenerated(span.Start.Offset, span.End.Offset)
@@ -51,6 +86,33 @@ func (m *Map) RemapSpan(span diag.Span) (diag.Span, bool) {
 		return diag.Span{}, false
 	}
 	return entry.Original, true
+}
+
+// RemapSpanProjected projects a generated span back onto the original source
+// while preserving sub-span offsets when a map entry has enough information.
+func (m *Map) RemapSpanProjected(span diag.Span) (diag.Span, bool) {
+	entry := m.entryForGenerated(span.Start.Offset, span.End.Offset)
+	if entry != nil {
+		return projectSpan(entry, span), true
+	}
+	start, ok := m.RemapPos(span.Start)
+	if !ok {
+		return diag.Span{}, false
+	}
+	end, ok := m.RemapPos(span.End)
+	if !ok || end.Offset < start.Offset {
+		end = start
+	}
+	return diag.Span{Start: start, End: end}, true
+}
+
+// RemapPos projects a generated position back onto the original source.
+func (m *Map) RemapPos(pos token.Pos) (token.Pos, bool) {
+	entry := m.entryForGeneratedPoint(pos.Offset)
+	if entry == nil {
+		return token.Pos{}, false
+	}
+	return projectPos(entry.Generated, entry.Original, pos.Offset), true
 }
 
 // GeneratedSpanForOriginal projects an original AST/source span into the
@@ -103,6 +165,15 @@ func (m *Map) exactOriginalEntry(start, end int) *Entry {
 // RemapDiagnostic returns a deep-cloned diagnostic whose spans and structured
 // suggestions are projected back into the original source wherever possible.
 func (m *Map) RemapDiagnostic(in *diag.Diagnostic) *diag.Diagnostic {
+	return m.remapDiagnostic(in, m.RemapSpan)
+}
+
+// RemapDiagnosticProjected is RemapDiagnostic with sub-span projection.
+func (m *Map) RemapDiagnosticProjected(in *diag.Diagnostic) *diag.Diagnostic {
+	return m.remapDiagnostic(in, m.RemapSpanProjected)
+}
+
+func (m *Map) remapDiagnostic(in *diag.Diagnostic, remap func(diag.Span) (diag.Span, bool)) *diag.Diagnostic {
 	if in == nil {
 		return nil
 	}
@@ -111,7 +182,7 @@ func (m *Map) RemapDiagnostic(in *diag.Diagnostic) *diag.Diagnostic {
 		out.Spans = make([]diag.LabeledSpan, len(in.Spans))
 		for i, sp := range in.Spans {
 			out.Spans[i] = sp
-			if remapped, ok := m.RemapSpan(sp.Span); ok {
+			if remapped, ok := remap(sp.Span); ok {
 				out.Spans[i].Span = remapped
 			}
 		}
@@ -120,12 +191,12 @@ func (m *Map) RemapDiagnostic(in *diag.Diagnostic) *diag.Diagnostic {
 		out.Suggestions = make([]diag.Suggestion, len(in.Suggestions))
 		for i, sg := range in.Suggestions {
 			out.Suggestions[i] = sg
-			if remapped, ok := m.RemapSpan(sg.Span); ok {
+			if remapped, ok := remap(sg.Span); ok {
 				out.Suggestions[i].Span = remapped
 			}
 			if sg.CopyFrom != nil {
 				copied := *sg.CopyFrom
-				if remapped, ok := m.RemapSpan(copied); ok {
+				if remapped, ok := remap(copied); ok {
 					copied = remapped
 				}
 				out.Suggestions[i].CopyFrom = &copied
@@ -137,12 +208,22 @@ func (m *Map) RemapDiagnostic(in *diag.Diagnostic) *diag.Diagnostic {
 
 // RemapDiagnostics clones and remaps every diagnostic in the slice.
 func (m *Map) RemapDiagnostics(in []*diag.Diagnostic) []*diag.Diagnostic {
+	return m.remapDiagnostics(in, m.RemapDiagnostic)
+}
+
+// RemapDiagnosticsProjected clones and remaps diagnostics using sub-span
+// projection.
+func (m *Map) RemapDiagnosticsProjected(in []*diag.Diagnostic) []*diag.Diagnostic {
+	return m.remapDiagnostics(in, m.RemapDiagnosticProjected)
+}
+
+func (m *Map) remapDiagnostics(in []*diag.Diagnostic, remap func(*diag.Diagnostic) *diag.Diagnostic) []*diag.Diagnostic {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make([]*diag.Diagnostic, 0, len(in))
 	for _, d := range in {
-		out = append(out, m.RemapDiagnostic(d))
+		out = append(out, remap(d))
 	}
 	return out
 }
@@ -172,6 +253,34 @@ func (m *Map) entryForGenerated(start, end int) *Entry {
 				best = entry
 				bestSize = size
 			}
+			continue
+		}
+		if size < bestSize {
+			best = entry
+			bestSize = size
+		}
+	}
+	return best
+}
+
+func (m *Map) entryForGeneratedPoint(offset int) *Entry {
+	if m == nil {
+		return nil
+	}
+	var best *Entry
+	bestSize := int(^uint(0) >> 1)
+	for i := range m.entries {
+		entry := &m.entries[i]
+		es := entry.Generated.Start.Offset
+		ee := entry.Generated.End.Offset
+		if ee < es {
+			ee = es
+		}
+		if offset < es || offset > ee {
+			continue
+		}
+		size := ee - es
+		if offset == ee && size > 0 && best != nil {
 			continue
 		}
 		if size < bestSize {
@@ -224,6 +333,176 @@ func (m *Map) entryForOriginal(start, end int) *Entry {
 		}
 	}
 	return best
+}
+
+func projectSpan(entry *Entry, span diag.Span) diag.Span {
+	if entry == nil {
+		return diag.Span{}
+	}
+	start := projectPos(entry.Generated, entry.Original, span.Start.Offset)
+	end := projectPos(entry.Generated, entry.Original, span.End.Offset)
+	if end.Offset < start.Offset {
+		end = start
+	}
+	return diag.Span{Start: start, End: end}
+}
+
+func projectPos(generated, original diag.Span, offset int) token.Pos {
+	gs := generated.Start.Offset
+	ge := generated.End.Offset
+	if ge < gs {
+		ge = gs
+	}
+	os := original.Start.Offset
+	oe := original.End.Offset
+	if oe < os {
+		oe = os
+	}
+	if offset <= gs || ge == gs {
+		return original.Start
+	}
+	if offset >= ge {
+		return original.End
+	}
+	gLen := ge - gs
+	oLen := oe - os
+	if oLen == 0 {
+		return original.Start
+	}
+	projected := os + ((offset-gs)*oLen)/gLen
+	if projected < os {
+		projected = os
+	}
+	if projected > oe {
+		projected = oe
+	}
+	return interpolatePos(original, projected)
+}
+
+func interpolatePos(span diag.Span, offset int) token.Pos {
+	if offset <= span.Start.Offset {
+		return span.Start
+	}
+	if offset >= span.End.Offset {
+		return span.End
+	}
+	if span.Start.Line == span.End.Line && span.Start.Line > 0 {
+		return token.Pos{
+			Offset: offset,
+			Line:   span.Start.Line,
+			Column: span.Start.Column + (offset - span.Start.Offset),
+		}
+	}
+	return token.Pos{Offset: offset, Line: span.Start.Line, Column: span.Start.Column}
+}
+
+// FromSourceTransform builds a best-effort map from transformed/generated source
+// back to the original bytes supplied to a loader transform. It records exact
+// unchanged line segments and a coarse segment for each edited region, which is
+// enough to keep most parser/checker diagnostics anchored to the user's file
+// after keyword and helper-syntax rewrites.
+func FromSourceTransform(original, generated []byte) *Map {
+	if bytes.Equal(original, generated) {
+		return nil
+	}
+	builder := NewBuilder()
+	origLines := sourceLineRanges(original)
+	genLines := sourceLineRanges(generated)
+	origStarts := computeLineStarts(original)
+
+	n := len(genLines)
+	for i := 0; i < n; i++ {
+		if i < len(origLines) {
+			addLineTransformMap(builder, original, generated, origStarts, origLines[i], genLines[i])
+			continue
+		}
+		eof := len(original)
+		addTransformSegment(builder, generated, original, origStarts, genLines[i].start, genLines[i].next, eof, eof)
+	}
+	sm := builder.Build(generated)
+	if sm == nil || sm.Empty() {
+		return nil
+	}
+	return sm
+}
+
+type sourceLineRange struct {
+	start int
+	end   int
+	next  int
+}
+
+func sourceLineRanges(src []byte) []sourceLineRange {
+	if len(src) == 0 {
+		return nil
+	}
+	var out []sourceLineRange
+	start := 0
+	for i, b := range src {
+		if b != '\n' {
+			continue
+		}
+		end := i
+		if end > start && src[end-1] == '\r' {
+			end--
+		}
+		out = append(out, sourceLineRange{start: start, end: end, next: i + 1})
+		start = i + 1
+	}
+	if start < len(src) {
+		out = append(out, sourceLineRange{start: start, end: len(src), next: len(src)})
+	}
+	return out
+}
+
+func addLineTransformMap(builder *Builder, original, generated []byte, origStarts []int, orig, gen sourceLineRange) {
+	origText := original[orig.start:orig.end]
+	genText := generated[gen.start:gen.end]
+	prefix := commonPrefixBytes(origText, genText)
+	suffix := commonSuffixBytes(origText[prefix:], genText[prefix:])
+
+	addTransformSegment(builder, generated, original, origStarts, gen.start, gen.start+prefix, orig.start, orig.start+prefix)
+	addTransformSegment(builder, generated, original, origStarts, gen.start+prefix, gen.end-suffix, orig.start+prefix, orig.end-suffix)
+	addTransformSegment(builder, generated, original, origStarts, gen.end-suffix, gen.end, orig.end-suffix, orig.end)
+	if gen.next > gen.end {
+		addTransformSegment(builder, generated, original, origStarts, gen.end, gen.next, orig.end, orig.next)
+	}
+}
+
+func addTransformSegment(builder *Builder, generated, original []byte, origStarts []int, genStart, genEnd, origStart, origEnd int) {
+	if builder == nil || genEnd <= genStart {
+		return
+	}
+	builder.Add("source-transform", genStart, genEnd, diag.Span{
+		Start: posForOffset(original, origStarts, origStart),
+		End:   posForOffset(original, origStarts, origEnd),
+	})
+}
+
+func commonPrefixBytes(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+func commonSuffixBytes(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[len(a)-1-i] != b[len(b)-1-i] {
+			return i
+		}
+	}
+	return n
 }
 
 type rawEntry struct {

--- a/internal/sourcemap/map_test.go
+++ b/internal/sourcemap/map_test.go
@@ -40,3 +40,103 @@ func TestGeneratedSpanForOriginalPrefersLargestExactGeneratedSpan(t *testing.T) 
 		t.Fatalf("generated span = %#v, want %#v", got, want)
 	}
 }
+
+func TestFromSourceTransformMapsEditedKeywordBackToOriginal(t *testing.T) {
+	original := []byte("func main() {\n    return 1\n}\n")
+	generated := []byte("fn main() {\n    return 1\n}\n")
+	sm := FromSourceTransform(original, generated)
+	if sm == nil {
+		t.Fatal("FromSourceTransform returned nil")
+	}
+
+	got, ok := sm.RemapSpanProjected(diag.Span{
+		Start: token.Pos{Offset: 0, Line: 1, Column: 1},
+		End:   token.Pos{Offset: 2, Line: 1, Column: 3},
+	})
+	if !ok {
+		t.Fatal("RemapSpan returned false")
+	}
+	if got.Start.Offset != 0 || got.End.Offset != 4 {
+		t.Fatalf("remapped keyword offsets = %d..%d, want 0..4", got.Start.Offset, got.End.Offset)
+	}
+	if got.Start.Line != 1 || got.Start.Column != 1 || got.End.Line != 1 || got.End.Column != 5 {
+		t.Fatalf("remapped keyword position = %#v, want line 1 columns 1..5", got)
+	}
+
+	got, ok = sm.RemapSpanProjected(diag.Span{
+		Start: token.Pos{Offset: 3, Line: 1, Column: 4},
+		End:   token.Pos{Offset: 7, Line: 1, Column: 8},
+	})
+	if !ok {
+		t.Fatal("RemapSpan for suffix returned false")
+	}
+	if got.Start.Offset != 5 || got.End.Offset != 9 {
+		t.Fatalf("remapped suffix offsets = %d..%d, want 5..9", got.Start.Offset, got.End.Offset)
+	}
+}
+
+func TestComposeProjectsCanonicalSpansThroughSourceTransform(t *testing.T) {
+	original := []byte("func main() {}\n")
+	transformed := []byte("fn main() {}\n")
+	transformMap := FromSourceTransform(original, transformed)
+	if transformMap == nil {
+		t.Fatal("FromSourceTransform returned nil")
+	}
+
+	builder := NewBuilder()
+	builder.Add("keyword", 0, 2, diag.Span{
+		Start: token.Pos{Offset: 0, Line: 1, Column: 1},
+		End:   token.Pos{Offset: 2, Line: 1, Column: 3},
+	})
+	canonicalMap := builder.Build(transformed)
+	composed := canonicalMap.Compose(transformMap)
+	if composed == nil {
+		t.Fatal("Compose returned nil")
+	}
+
+	got, ok := composed.RemapSpanProjected(diag.Span{
+		Start: token.Pos{Offset: 0, Line: 1, Column: 1},
+		End:   token.Pos{Offset: 2, Line: 1, Column: 3},
+	})
+	if !ok {
+		t.Fatal("RemapSpanProjected returned false")
+	}
+	if got.Start.Offset != 0 || got.End.Offset != 4 {
+		t.Fatalf("composed offsets = %d..%d, want 0..4", got.Start.Offset, got.End.Offset)
+	}
+}
+
+func TestRemapSpanKeepsLegacyWholeEntrySemantics(t *testing.T) {
+	sm := &Map{entries: []Entry{{
+		Generated: diag.Span{
+			Start: token.Pos{Offset: 10, Line: 1, Column: 11},
+			End:   token.Pos{Offset: 20, Line: 1, Column: 21},
+		},
+		Original: diag.Span{
+			Start: token.Pos{Offset: 100, Line: 2, Column: 1},
+			End:   token.Pos{Offset: 120, Line: 2, Column: 21},
+		},
+	}}}
+
+	got, ok := sm.RemapSpan(diag.Span{
+		Start: token.Pos{Offset: 12, Line: 1, Column: 13},
+		End:   token.Pos{Offset: 14, Line: 1, Column: 15},
+	})
+	if !ok {
+		t.Fatal("RemapSpan returned false")
+	}
+	if got.Start.Offset != 100 || got.End.Offset != 120 {
+		t.Fatalf("RemapSpan offsets = %d..%d, want whole entry 100..120", got.Start.Offset, got.End.Offset)
+	}
+
+	projected, ok := sm.RemapSpanProjected(diag.Span{
+		Start: token.Pos{Offset: 12, Line: 1, Column: 13},
+		End:   token.Pos{Offset: 14, Line: 1, Column: 15},
+	})
+	if !ok {
+		t.Fatal("RemapSpanProjected returned false")
+	}
+	if projected.Start.Offset != 104 || projected.End.Offset != 108 {
+		t.Fatalf("RemapSpanProjected offsets = %d..%d, want 104..108", projected.Start.Offset, projected.End.Offset)
+	}
+}


### PR DESCRIPTION
## Summary
- unify native loader variants behind structured load options and source transform metadata
- expose workspace package graph nodes and edges explicitly
- strengthen source-map remapping after transforms while preserving native bridge span behavior

## Validation
- `go test -count=1 -vet=off ./internal/sourcemap ./internal/resolve ./internal/lsp ./internal/check ./internal/query/osty ./cmd/osty -run 'TestGeneratedSpan|TestFromSourceTransform|TestLoadPackage|TestWorkspace|TestAIRepair|TestNative|Test'`
- `go test -count=1 -vet=off ./internal/selfhost -run TestNativeConsumersImportStructuredAPITypesDirectly`
- `go test -count=1 -vet=off ./internal/resolve ./internal/selfhost -run 'TestNativeConsumersImportStructuredAPITypesDirectly|TestLoadPackage|TestWorkspace|TestNativeResolve'`
- `git diff --check origin/main...HEAD`
- `just short`