### PR TITLE
[codex] structure green parser constructs

### DIFF
--- a/internal/cst/build_test.go
+++ b/internal/cst/build_test.go
@@ -155,6 +155,267 @@ func TestParseGreenControlHeadersDoNotLeakStrayBraces(t *testing.T) {
 	}
 }
 
+func TestParseGreenMapLiteralsAreStructured(t *testing.T) {
+	const source = `fn main() {
+    let empty = {:}
+    let scores = {
+        "alice": 3,
+        "bob": add(1, 2),
+    }
+    let block = {
+        let x = 1
+        x
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkMap); got != 2 {
+		t.Fatalf("map literal count = %d, want 2", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkMapEntry); got != 2 {
+		t.Fatalf("map entry count = %d, want 2", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkBlock); got < 2 {
+		t.Fatalf("block count = %d, want at least function body and block expression", got)
+	}
+}
+
+func TestParseGreenParenTupleAndElseAreStructured(t *testing.T) {
+	const source = `fn main() {
+    let grouped = (1 + 2)
+    let unit = ()
+    let single = (grouped,)
+    let pair = (grouped, single)
+    if grouped > 0 {
+        grouped
+    } else {
+        pair
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkParen); got != 1 {
+		t.Fatalf("paren expr count = %d, want 1", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkTuple); got != 3 {
+		t.Fatalf("tuple expr count = %d, want 3", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkElse); got != 1 {
+		t.Fatalf("else count = %d, want 1", got)
+	}
+}
+
+func TestParseGreenLoopAndListsAreStructured(t *testing.T) {
+	const source = `enum Choice {
+    One,
+    Two(Int),
+}
+
+fn main() {
+    let picked = loop {
+        break 1
+    }
+    let labelled = 'outer: loop {
+        break 'outer picked
+    }
+    match Choice.One {
+        Choice.One -> labelled,
+        Choice.Two(n) -> n,
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkLoop); got != 2 {
+		t.Fatalf("loop count = %d, want 2", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkVariantList); got != 1 {
+		t.Fatalf("variant list count = %d, want 1", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkVariant); got != 2 {
+		t.Fatalf("variant count = %d, want 2", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkMatchArmList); got != 1 {
+		t.Fatalf("match arm list count = %d, want 1", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkMatchArm); got != 2 {
+		t.Fatalf("match arm count = %d, want 2", got)
+	}
+}
+
+func TestParseGreenPatternsAreStructured(t *testing.T) {
+	const source = `fn main() {
+    let (x, _) = pair
+    if let Some(n) = maybe {
+        n
+    }
+    match value {
+        Value.IntVal(n @ 1..=9) -> n,
+        Point { x, y: _ } -> 0,
+        1 | 2 -> 12,
+        _ -> 1,
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	for _, kind := range []cst.GreenKind{
+		cst.GkTuplePat,
+		cst.GkWildcardPat,
+		cst.GkIfLet,
+		cst.GkVariantPat,
+		cst.GkBindingPat,
+		cst.GkRangePat,
+		cst.GkStructPat,
+		cst.GkStructPatField,
+		cst.GkOrPat,
+	} {
+		if got := countKindBelow(tree.Root(), kind); got == 0 {
+			t.Fatalf("tree has no %v node", kind)
+		}
+	}
+}
+
+func TestParseGreenForHeadersAreStructured(t *testing.T) {
+	const source = `fn main() {
+    for item in items {
+        item
+    }
+    for (key, value) in entries {
+        value
+    }
+    for let Some(next) = maybe {
+        next
+    }
+    for count < limit {
+        count = count + 1
+    }
+    'outer: for x in xs {
+        continue 'outer
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkForStmt); got != 5 {
+		t.Fatalf("for stmt count = %d, want 5", got)
+	}
+	for _, kind := range []cst.GreenKind{
+		cst.GkIdentPat,
+		cst.GkTuplePat,
+		cst.GkVariantPat,
+		cst.GkBinary,
+		cst.GkContinueStmt,
+	} {
+		if got := countKindBelow(tree.Root(), kind); got == 0 {
+			t.Fatalf("tree has no %v node", kind)
+		}
+	}
+}
+
+func TestParseGreenClosuresAreStructured(t *testing.T) {
+	const source = `fn main() {
+    let empty = || { 1 }
+    let inc = |x| x + 1
+    let labels = pairs.map(|(n, s)| "{n} -> {s}")
+    let addDiff = |label: String, old: String, new: String| {
+        label
+    }
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkClosure); got != 4 {
+		t.Fatalf("closure count = %d, want 4", got)
+	}
+	for _, kind := range []cst.GreenKind{
+		cst.GkParamList,
+		cst.GkParam,
+		cst.GkTuplePat,
+		cst.GkIdentPat,
+		cst.GkNamedType,
+		cst.GkBinary,
+		cst.GkBlock,
+	} {
+		if got := countKindBelow(tree.Root(), kind); got == 0 {
+			t.Fatalf("tree has no %v node", kind)
+		}
+	}
+}
+
+func TestParseGreenCompositeTypesAndGenericBoundsAreStructured(t *testing.T) {
+	const source = `struct Box<T: Display + Clone> {
+    unit: ()
+    owner: Self?
+    callback: fn((), [String]) -> ()
+    reader: std.io.Reader?
+    maybeTuple: (String, Int)?
+    maybeList: [String]?
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	for _, kind := range []cst.GreenKind{
+		cst.GkFunctionType,
+		cst.GkParamList,
+		cst.GkParam,
+		cst.GkTupleType,
+		cst.GkListType,
+		cst.GkNamedType,
+		cst.GkGenericBound,
+		cst.GkUnitType,
+		cst.GkSelfType,
+		cst.GkOptionalType,
+	} {
+		if got := countKindBelow(tree.Root(), kind); got == 0 {
+			t.Fatalf("tree has no %v node", kind)
+		}
+	}
+	if got := countKindBelow(tree.Root(), cst.GkGenericBound); got != 2 {
+		t.Fatalf("generic bound count = %d, want 2", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkOptionalType); got != 4 {
+		t.Fatalf("optional type count = %d, want 4", got)
+	}
+}
+
 // TestBuildUseDeclStructuring verifies use-decls get their own structured
 // node.
 func TestBuildUseDeclStructuring(t *testing.T) {
@@ -201,6 +462,32 @@ func TestBuildGroupedUseDeclsHaveDistinctRanges(t *testing.T) {
 		if r[1] <= r[0] {
 			t.Fatalf("grouped use child range must be positive-width, got %v", ranges)
 		}
+	}
+}
+
+func TestParseGreenUseDeclsAreStructured(t *testing.T) {
+	const source = `use std.io as io
+use std.strings
+use std::{fs, io as groupedIO}
+use go "net/http" as http {
+    fn Get(url: String) -> String
+}
+`
+	tree := buildTreeFromSource(t, source)
+	if report := cst.ValidateTree(tree); !report.OK() {
+		t.Fatalf("CST validation failed: %s", report.Error())
+	}
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkUseFFIBody); got != 1 {
+		t.Fatalf("use FFI body count = %d, want 1", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkUseAlias); got != 3 {
+		t.Fatalf("use alias count = %d, want 3", got)
+	}
+	if got := countKindBelow(tree.Root(), cst.GkUsePath); got < 5 {
+		t.Fatalf("use path count = %d, want at least 5", got)
 	}
 }
 

--- a/internal/cst/green.go
+++ b/internal/cst/green.go
@@ -141,6 +141,10 @@ const (
 	GkError        // a region the parser salvaged with at least one diagnostic
 	GkErrorMissing // zero-width "expected X here" marker
 	GkErrorExtra   // well-formed-looking tokens that were in the wrong place
+
+	// ---- Expression kinds appended after error nodes for kind ID stability ----
+
+	GkLoop
 )
 
 // String returns a stable label for the kind — used in snapshots, test
@@ -267,6 +271,7 @@ var greenKindNames = map[GreenKind]string{
 	GkError:            "Error",
 	GkErrorMissing:     "ErrorMissing",
 	GkErrorExtra:       "ErrorExtra",
+	GkLoop:             "Loop",
 }
 
 // GreenToken is an immutable leaf in the Green tree. It carries its raw

--- a/internal/cst/green_test.go
+++ b/internal/cst/green_test.go
@@ -154,7 +154,7 @@ func TestGreenKindNameCoverage(t *testing.T) {
 	// updating greenKindNames, its String() will fall back to GreenKind(N),
 	// which the eye catches in snapshot diffs; this test makes the failure
 	// explicit.
-	for k := GkNone; k <= GkErrorExtra; k++ {
+	for k := GkNone; k <= GkLoop; k++ {
 		if _, ok := greenKindNames[k]; !ok {
 			t.Errorf("greenKindNames missing label for kind %d (GreenKind(%d))", int(k), int(k))
 		}

--- a/internal/cst/parse.go
+++ b/internal/cst/parse.go
@@ -181,6 +181,7 @@ func (p *greenParser) parseAnnotations() {
 func (p *greenParser) parseUseDecl(grouped bool) {
 	p.eat(token.PUB)
 	p.eat(token.USE)
+	p.parseUsePathUntil(token.LBRACE, token.NEWLINE, token.EOF)
 	for !p.at(token.EOF) && !p.at(token.NEWLINE) {
 		if grouped && p.at(token.LBRACE) {
 			p.emit()
@@ -189,21 +190,52 @@ func (p *greenParser) parseUseDecl(grouped bool) {
 					p.emit()
 					continue
 				}
-				p.b.StartNode(GkUseDecl)
-				for !p.at(token.COMMA) && !p.at(token.RBRACE) && !p.at(token.NEWLINE) && !p.at(token.EOF) {
-					p.emit()
-				}
-				p.b.FinishNode()
+				p.parseGroupedUseDecl()
 			}
 			p.eat(token.RBRACE)
+			continue
+		}
+		if p.atUseAliasKeyword() {
+			p.parseUseAlias()
 			continue
 		}
 		if p.at(token.LBRACE) {
 			p.parseBalancedNode(GkUseFFIBody, token.LBRACE, token.RBRACE)
 			continue
 		}
+		start := p.pos
+		p.parseUsePathUntil(token.LBRACE, token.NEWLINE, token.EOF)
+		p.recoverIfStalled(start)
+	}
+}
+
+func (p *greenParser) parseGroupedUseDecl() {
+	p.b.StartNode(GkUseDecl)
+	p.parseUsePathUntil(token.COMMA, token.RBRACE, token.NEWLINE, token.EOF)
+	if p.atUseAliasKeyword() {
+		p.parseUseAlias()
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseUsePathUntil(stops ...token.Kind) {
+	if p.atAny(stops...) || p.atUseAliasKeyword() || p.at(token.EOF) {
+		return
+	}
+	p.b.StartNode(GkUsePath)
+	for !p.atAny(stops...) && !p.atUseAliasKeyword() && !p.at(token.EOF) {
 		p.emit()
 	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseUseAlias() {
+	p.b.StartNode(GkUseAlias)
+	p.emit()
+	if p.at(token.IDENT) {
+		p.emit()
+	}
+	p.b.FinishNode()
 }
 
 func (p *greenParser) parseFnDecl() {
@@ -258,6 +290,9 @@ func (p *greenParser) parseAggregateDecl(kind GreenKind) {
 		return
 	}
 	p.emit()
+	if kind == GkEnumDecl {
+		p.b.StartNode(GkVariantList)
+	}
 	for !p.at(token.RBRACE) && !p.at(token.EOF) {
 		if p.at(token.NEWLINE) || p.at(token.COMMA) {
 			p.emit()
@@ -291,6 +326,9 @@ func (p *greenParser) parseAggregateDecl(kind GreenKind) {
 			p.recoverIfStalled(start)
 			p.b.FinishNode()
 		}
+	}
+	if kind == GkEnumDecl {
+		p.b.FinishNode()
 	}
 	p.eat(token.RBRACE)
 }
@@ -352,7 +390,7 @@ func (p *greenParser) parseGenericParamList() {
 		p.b.StartNode(GkGenericParam)
 		p.eat(token.IDENT)
 		if p.eat(token.COLON) {
-			p.parseTypeUntil(token.COMMA, token.GT)
+			p.parseGenericBounds()
 		}
 		if p.pos == start {
 			p.emit()
@@ -361,6 +399,19 @@ func (p *greenParser) parseGenericParamList() {
 	}
 	p.eat(token.GT)
 	p.b.FinishNode()
+}
+
+func (p *greenParser) parseGenericBounds() {
+	for !p.atAny(token.COMMA, token.GT, token.SHR, token.NEWLINE) && !p.at(token.EOF) {
+		start := p.pos
+		p.b.StartNode(GkGenericBound)
+		p.parseTypeUntil(token.PLUS, token.COMMA, token.GT, token.SHR, token.NEWLINE)
+		p.recoverIfStalled(start)
+		p.b.FinishNode()
+		if !p.eat(token.PLUS) {
+			return
+		}
+	}
 }
 
 func (p *greenParser) parseStmt() {
@@ -381,6 +432,9 @@ func (p *greenParser) parseStmt() {
 }
 
 func (p *greenParser) stmtKind() GreenKind {
+	if p.at(token.LABEL) && p.kindAt(p.pos+1) == token.COLON && p.kindAt(p.pos+2) == token.FOR {
+		return GkForStmt
+	}
 	switch p.kindAfterPub() {
 	case token.LET:
 		return GkLetStmt
@@ -406,11 +460,34 @@ func (p *greenParser) parseStmtBody(kind GreenKind) {
 		p.emit()
 		p.parseExprsUntil(token.NEWLINE, token.RBRACE, token.EOF)
 	case GkForStmt:
-		p.eat(token.FOR)
+		p.parseForStmt()
+	}
+}
+
+func (p *greenParser) parseForStmt() {
+	if p.at(token.LABEL) && p.kindAt(p.pos+1) == token.COLON {
+		p.emit()
+		p.emit()
+	}
+	p.eat(token.FOR)
+	switch {
+	case p.at(token.LBRACE):
+		// Infinite loop: `for { ... }`.
+	case p.eat(token.LET):
+		p.parsePatternUntil(token.ASSIGN, token.LBRACE, token.NEWLINE, token.EOF)
+		p.eat(token.ASSIGN)
 		p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
-		if p.at(token.LBRACE) {
-			p.parseBlock()
+	case p.forHeaderHasInBeforeBody():
+		p.parsePattern(token.LBRACE, token.NEWLINE, token.EOF)
+		if p.atIdentValue("in") {
+			p.emit()
 		}
+		p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	default:
+		p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	}
+	if p.at(token.LBRACE) {
+		p.parseBlock()
 	}
 }
 
@@ -442,7 +519,171 @@ func (p *greenParser) parseBlock() {
 }
 
 func (p *greenParser) parsePatternUntil(stops ...token.Kind) {
-	p.parseExprsUntil(stops...)
+	for !p.atAny(stops...) && !p.at(token.EOF) {
+		start := p.pos
+		p.parsePattern(stops...)
+		p.recoverIfStalled(start)
+	}
+}
+
+func (p *greenParser) parsePattern(stops ...token.Kind) GreenCheckpoint {
+	cp := p.b.Checkpoint()
+	p.parsePatternRange(stops...)
+	for p.at(token.BITOR) && !tokenKindIn(stops, token.BITOR) {
+		p.b.StartNodeAt(GkOrPat, cp)
+		p.emit()
+		p.parsePatternRange(stops...)
+		p.b.FinishNode()
+	}
+	return cp
+}
+
+func (p *greenParser) parsePatternRange(stops ...token.Kind) GreenCheckpoint {
+	cp := p.b.Checkpoint()
+	p.parsePatternAtom(stops...)
+	if p.at(token.DOTDOT) || p.at(token.DOTDOTEQ) {
+		p.b.StartNodeAt(GkRangePat, cp)
+		p.emit()
+		if !p.patternAtEnd(stops...) {
+			p.parsePatternAtom(stops...)
+		}
+		p.b.FinishNode()
+	}
+	return cp
+}
+
+func (p *greenParser) parsePatternAtom(stops ...token.Kind) {
+	if p.atAny(stops...) || p.at(token.EOF) {
+		return
+	}
+	switch p.peek().Kind {
+	case token.UNDERSCORE:
+		p.parseLeaf(GkWildcardPat)
+	case token.INT, token.FLOAT, token.STRING, token.RAWSTRING, token.CHAR, token.BYTE:
+		p.parseLeaf(GkLiteralPat)
+	case token.MINUS:
+		p.b.StartNode(GkLiteralPat)
+		p.emit()
+		if !p.patternAtEnd(stops...) {
+			p.parsePatternAtom(stops...)
+		}
+		p.b.FinishNode()
+	case token.DOTDOT, token.DOTDOTEQ:
+		p.b.StartNode(GkRangePat)
+		p.emit()
+		if !p.patternAtEnd(stops...) {
+			p.parsePatternAtom(stops...)
+		}
+		p.b.FinishNode()
+	case token.LPAREN:
+		p.parseTuplePattern()
+	case token.IDENT:
+		p.parseNamedPattern(stops...)
+	default:
+		p.b.StartNode(GkError)
+		p.emit()
+		p.b.FinishNode()
+	}
+}
+
+func (p *greenParser) parseTuplePattern() {
+	p.b.StartNode(GkTuplePat)
+	p.eat(token.LPAREN)
+	for !p.at(token.RPAREN) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.parsePattern(token.COMMA, token.RPAREN)
+		p.recoverIfStalled(start)
+	}
+	p.eat(token.RPAREN)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseNamedPattern(stops ...token.Kind) {
+	cp := p.b.Checkpoint()
+	segments := 0
+	for {
+		if !p.eat(token.IDENT) {
+			break
+		}
+		segments++
+		if !(p.at(token.DOT) && p.kindAt(p.pos+1) == token.IDENT) {
+			break
+		}
+		p.emit()
+	}
+	if segments == 1 && (p.previousTokenValue() == "true" || p.previousTokenValue() == "false") {
+		p.b.StartNodeAt(GkLiteralPat, cp)
+		p.b.FinishNode()
+		return
+	}
+	if segments == 1 && p.at(token.AT) {
+		p.b.StartNodeAt(GkBindingPat, cp)
+		p.emit()
+		if !p.patternAtEnd(stops...) {
+			p.parsePatternRange(stops...)
+		}
+		p.b.FinishNode()
+		return
+	}
+	if p.at(token.LPAREN) {
+		p.b.StartNodeAt(GkVariantPat, cp)
+		p.emit()
+		for !p.at(token.RPAREN) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			start := p.pos
+			p.parsePattern(token.COMMA, token.RPAREN)
+			p.recoverIfStalled(start)
+		}
+		p.eat(token.RPAREN)
+		p.b.FinishNode()
+		return
+	}
+	if p.at(token.LBRACE) {
+		p.b.StartNodeAt(GkStructPat, cp)
+		p.emit()
+		for !p.at(token.RBRACE) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			if p.at(token.DOTDOT) || p.at(token.DOTDOTEQ) {
+				p.emit()
+				continue
+			}
+			start := p.pos
+			p.b.StartNode(GkStructPatField)
+			if p.eat(token.IDENT) {
+				if p.eat(token.COLON) {
+					p.parsePattern(token.COMMA, token.RBRACE)
+				}
+			} else {
+				p.parsePattern(token.COMMA, token.RBRACE)
+			}
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		}
+		p.eat(token.RBRACE)
+		p.b.FinishNode()
+		return
+	}
+	if segments > 1 {
+		p.b.StartNodeAt(GkVariantPat, cp)
+		p.b.FinishNode()
+		return
+	}
+	p.b.StartNodeAt(GkIdentPat, cp)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) patternAtEnd(stops ...token.Kind) bool {
+	return p.atAny(stops...) || p.at(token.BITOR) || p.at(token.EOF)
 }
 
 func (p *greenParser) parseTypeUntil(stops ...token.Kind) {
@@ -461,23 +702,34 @@ func (p *greenParser) parseTypeUntil(stops ...token.Kind) {
 func (p *greenParser) parseTypeAtom(stops ...token.Kind) bool {
 	switch {
 	case p.at(token.FN):
-		p.b.StartNode(GkFunctionType)
-		p.emit()
-		p.parseParamList()
-		if p.eat(token.ARROW) {
-			p.parseTypeUntil(stops...)
-		}
-		p.b.FinishNode()
+		p.parseFunctionType(stops...)
+		p.parseOptionalTypeSuffixes()
 		return true
 	case p.at(token.LPAREN):
-		p.parseBalancedNode(GkTupleType, token.LPAREN, token.RPAREN)
+		if p.looksLikeUnitType() {
+			p.parseUnitType()
+		} else {
+			p.parseTupleType()
+		}
+		p.parseOptionalTypeSuffixes()
 		return true
 	case p.at(token.LBRACKET):
-		p.parseBalancedNode(GkListType, token.LBRACKET, token.RBRACKET)
+		p.parseListType()
+		p.parseOptionalTypeSuffixes()
+		return true
+	case p.at(token.IDENT) && p.peek().Value == "Self" && p.kindAt(p.pos+1) != token.DOT:
+		p.b.StartNode(GkSelfType)
+		p.emit()
+		p.b.FinishNode()
+		p.parseOptionalTypeSuffixes()
 		return true
 	case p.at(token.IDENT) || p.at(token.UNDERSCORE):
 		p.b.StartNode(GkNamedType)
 		p.emit()
+		for p.at(token.DOT) && p.kindAt(p.pos+1) == token.IDENT {
+			p.emit()
+			p.emit()
+		}
 		if p.at(token.LT) {
 			p.parseTypeArgList()
 		}
@@ -486,6 +738,74 @@ func (p *greenParser) parseTypeAtom(stops ...token.Kind) bool {
 		return true
 	}
 	return false
+}
+
+func (p *greenParser) parseFunctionType(stops ...token.Kind) {
+	p.b.StartNode(GkFunctionType)
+	p.eat(token.FN)
+	if p.at(token.LPAREN) {
+		p.b.StartNode(GkParamList)
+		p.emit()
+		for !p.at(token.RPAREN) && !p.at(token.EOF) {
+			if p.at(token.COMMA) || p.at(token.NEWLINE) {
+				p.emit()
+				continue
+			}
+			start := p.pos
+			p.b.StartNode(GkParam)
+			p.parseTypeUntil(token.COMMA, token.RPAREN)
+			p.recoverIfStalled(start)
+			p.b.FinishNode()
+		}
+		p.eat(token.RPAREN)
+		p.b.FinishNode()
+	}
+	if p.eat(token.ARROW) {
+		p.parseTypeUntil(stops...)
+	}
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseTupleType() {
+	p.b.StartNode(GkTupleType)
+	p.eat(token.LPAREN)
+	for !p.at(token.RPAREN) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.parseTypeUntil(token.COMMA, token.RPAREN)
+		p.recoverIfStalled(start)
+	}
+	p.eat(token.RPAREN)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseUnitType() {
+	p.b.StartNode(GkUnitType)
+	p.eat(token.LPAREN)
+	for p.at(token.NEWLINE) {
+		p.emit()
+	}
+	p.eat(token.RPAREN)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseListType() {
+	p.b.StartNode(GkListType)
+	p.eat(token.LBRACKET)
+	for !p.at(token.RBRACKET) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.parseTypeUntil(token.COMMA, token.RBRACKET)
+		p.recoverIfStalled(start)
+	}
+	p.eat(token.RBRACKET)
+	p.b.FinishNode()
 }
 
 func (p *greenParser) parseTypeArgList() {
@@ -576,6 +896,10 @@ func (p *greenParser) parsePrefix(stops ...token.Kind) {
 	if p.atAny(stops...) || p.at(token.EOF) {
 		return
 	}
+	if p.atLoopExprStart() {
+		p.parseLoop()
+		return
+	}
 	switch p.peek().Kind {
 	case token.MINUS, token.NOT, token.BITNOT, token.STAR:
 		p.b.StartNode(GkUnary)
@@ -605,13 +929,17 @@ func (p *greenParser) parsePrefix(stops ...token.Kind) {
 	case token.LBRACKET:
 		p.parseList()
 	case token.LBRACE:
-		p.parseBlock()
+		if p.looksLikeMapLit() {
+			p.parseMap()
+		} else {
+			p.parseBlock()
+		}
 	case token.IF:
 		p.parseIf()
 	case token.MATCH:
 		p.parseMatch()
 	case token.BITOR, token.OR:
-		p.parseClosure()
+		p.parseClosure(stops...)
 	default:
 		p.b.StartNode(GkError)
 		p.emit()
@@ -693,7 +1021,11 @@ func (p *greenParser) parsePostfix(lhs GreenCheckpoint, stops ...token.Kind) boo
 }
 
 func (p *greenParser) parseParenOrTuple() {
-	p.b.StartNode(GkTuple)
+	kind := GkParen
+	if p.looksLikeTupleExpr() {
+		kind = GkTuple
+	}
+	p.b.StartNode(kind)
 	p.emit()
 	for !p.at(token.RPAREN) && !p.at(token.EOF) {
 		if p.at(token.COMMA) || p.at(token.NEWLINE) {
@@ -720,19 +1052,59 @@ func (p *greenParser) parseList() {
 	p.b.FinishNode()
 }
 
+func (p *greenParser) parseMap() {
+	p.b.StartNode(GkMap)
+	p.eat(token.LBRACE)
+	if p.eat(token.COLON) {
+		for p.at(token.NEWLINE) {
+			p.emit()
+		}
+		p.eat(token.RBRACE)
+		p.b.FinishNode()
+		return
+	}
+	for !p.at(token.RBRACE) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.b.StartNode(GkMapEntry)
+		p.parseExprUntil(token.COLON, token.COMMA, token.RBRACE)
+		if p.eat(token.COLON) {
+			p.parseExprUntil(token.COMMA, token.RBRACE)
+		}
+		p.recoverIfStalled(start)
+		p.b.FinishNode()
+	}
+	p.eat(token.RBRACE)
+	p.b.FinishNode()
+}
+
 func (p *greenParser) parseIf() {
-	p.b.StartNode(GkIf)
+	kind := GkIf
+	if p.kindAt(p.pos+1) == token.LET {
+		kind = GkIfLet
+	}
+	p.b.StartNode(kind)
 	p.emit()
+	if p.eat(token.LET) {
+		p.parsePatternUntil(token.ASSIGN, token.LBRACE, token.NEWLINE, token.EOF)
+		p.eat(token.ASSIGN)
+	}
 	p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
 	if p.at(token.LBRACE) {
 		p.parseBlock()
 	}
-	if p.eat(token.ELSE) {
+	if p.at(token.ELSE) {
+		p.b.StartNode(GkElse)
+		p.emit()
 		if p.at(token.IF) {
 			p.parseIf()
 		} else if p.at(token.LBRACE) {
 			p.parseBlock()
 		}
+		p.b.FinishNode()
 	}
 	p.b.FinishNode()
 }
@@ -742,32 +1114,91 @@ func (p *greenParser) parseMatch() {
 	p.emit()
 	p.parseExprsUntil(token.LBRACE, token.NEWLINE, token.EOF)
 	if p.eat(token.LBRACE) {
+		p.b.StartNode(GkMatchArmList)
 		for !p.at(token.RBRACE) && !p.at(token.EOF) {
 			if p.at(token.COMMA) || p.at(token.NEWLINE) {
 				p.emit()
 				continue
 			}
 			p.b.StartNode(GkMatchArm)
-			p.parseExprsUntil(token.ARROW, token.RBRACE)
+			p.parsePatternUntil(token.IF, token.ARROW, token.RBRACE)
+			if p.eat(token.IF) {
+				p.parseExprsUntil(token.ARROW, token.RBRACE)
+			}
 			p.eat(token.ARROW)
 			p.parseExprsUntil(token.COMMA, token.NEWLINE, token.RBRACE)
 			p.b.FinishNode()
 		}
+		p.b.FinishNode()
 		p.eat(token.RBRACE)
 	}
 	p.b.FinishNode()
 }
 
-func (p *greenParser) parseClosure() {
-	p.b.StartNode(GkClosure)
-	p.emit()
-	for !p.at(token.LBRACE) && !p.at(token.EOF) && !p.at(token.NEWLINE) {
+func (p *greenParser) parseLoop() {
+	p.b.StartNode(GkLoop)
+	if p.at(token.LABEL) && p.kindAt(p.pos+1) == token.COLON {
+		p.emit()
+		p.emit()
+	}
+	if p.atIdentValue("loop") {
 		p.emit()
 	}
 	if p.at(token.LBRACE) {
 		p.parseBlock()
 	}
 	p.b.FinishNode()
+}
+
+func (p *greenParser) parseClosure(stops ...token.Kind) {
+	p.b.StartNode(GkClosure)
+	if p.at(token.OR) {
+		p.b.StartNode(GkParamList)
+		p.emit()
+		p.b.FinishNode()
+		p.parseClosureBody(stops...)
+		p.b.FinishNode()
+		return
+	}
+	if p.at(token.BITOR) {
+		p.parseClosureParamList()
+	}
+	if p.eat(token.ARROW) {
+		p.parseTypeUntil(token.LBRACE, token.NEWLINE, token.EOF)
+	}
+	p.parseClosureBody(stops...)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseClosureParamList() {
+	p.b.StartNode(GkParamList)
+	p.eat(token.BITOR)
+	for !p.at(token.BITOR) && !p.at(token.EOF) {
+		if p.at(token.COMMA) || p.at(token.NEWLINE) {
+			p.emit()
+			continue
+		}
+		start := p.pos
+		p.b.StartNode(GkParam)
+		p.parsePatternUntil(token.COLON, token.COMMA, token.BITOR)
+		if p.eat(token.COLON) {
+			p.parseTypeUntil(token.COMMA, token.BITOR)
+		}
+		p.recoverIfStalled(start)
+		p.b.FinishNode()
+	}
+	p.eat(token.BITOR)
+	p.b.FinishNode()
+}
+
+func (p *greenParser) parseClosureBody(stops ...token.Kind) {
+	if p.at(token.LBRACE) {
+		p.parseBlock()
+		return
+	}
+	bodyStops := append([]token.Kind{}, stops...)
+	bodyStops = append(bodyStops, token.NEWLINE, token.RBRACE, token.EOF)
+	p.parseExprUntil(bodyStops...)
 }
 
 func (p *greenParser) parseLeaf(kind GreenKind) {
@@ -842,13 +1273,183 @@ func (p *greenParser) infixKind() GreenKind {
 	return GkBinary
 }
 
+func (p *greenParser) looksLikeMapLit() bool {
+	if !p.at(token.LBRACE) {
+		return false
+	}
+	i := p.pos + 1
+	for p.kindAt(i) == token.NEWLINE {
+		i++
+	}
+	if p.kindAt(i) == token.COLON {
+		i++
+		for p.kindAt(i) == token.NEWLINE {
+			i++
+		}
+		return p.kindAt(i) == token.RBRACE
+	}
+	if p.kindAt(i) == token.RBRACE || tokenStartsBlockStmt(p.kindAt(i)) {
+		return false
+	}
+	parenDepth, bracketDepth, braceDepth := 0, 0, 0
+	for ; i < len(p.toks); i++ {
+		switch p.kindAt(i) {
+		case token.EOF:
+			return false
+		case token.NEWLINE:
+			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+				return false
+			}
+		case token.LPAREN:
+			parenDepth++
+		case token.RPAREN:
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case token.LBRACKET:
+			bracketDepth++
+		case token.RBRACKET:
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case token.LBRACE:
+			braceDepth++
+		case token.RBRACE:
+			if braceDepth == 0 {
+				return false
+			}
+			braceDepth--
+		case token.COLON:
+			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func tokenStartsBlockStmt(kind token.Kind) bool {
+	switch kind {
+	case token.LET, token.RETURN, token.BREAK, token.CONTINUE, token.DEFER, token.FOR, token.PUB, token.LABEL:
+		return true
+	}
+	return false
+}
+
+func tokenKindIn(kinds []token.Kind, target token.Kind) bool {
+	for _, kind := range kinds {
+		if kind == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *greenParser) looksLikeTupleExpr() bool {
+	if !p.at(token.LPAREN) {
+		return false
+	}
+	i := p.pos + 1
+	for p.kindAt(i) == token.NEWLINE {
+		i++
+	}
+	if p.kindAt(i) == token.RPAREN {
+		return true
+	}
+	parenDepth, bracketDepth, braceDepth := 0, 0, 0
+	for ; i < len(p.toks); i++ {
+		switch p.kindAt(i) {
+		case token.EOF:
+			return false
+		case token.LPAREN:
+			parenDepth++
+		case token.RPAREN:
+			if parenDepth == 0 {
+				return false
+			}
+			parenDepth--
+		case token.LBRACKET:
+			bracketDepth++
+		case token.RBRACKET:
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case token.LBRACE:
+			braceDepth++
+		case token.RBRACE:
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		case token.COMMA:
+			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *greenParser) looksLikeUnitType() bool {
+	if !p.at(token.LPAREN) {
+		return false
+	}
+	i := p.pos + 1
+	for p.kindAt(i) == token.NEWLINE {
+		i++
+	}
+	return p.kindAt(i) == token.RPAREN
+}
+
+func (p *greenParser) atLoopExprStart() bool {
+	if p.atIdentValue("loop") && p.kindAt(p.pos+1) == token.LBRACE {
+		return true
+	}
+	return p.at(token.LABEL) &&
+		p.kindAt(p.pos+1) == token.COLON &&
+		p.kindAt(p.pos+2) == token.IDENT &&
+		p.tokenValueAt(p.pos+2) == "loop" &&
+		p.kindAt(p.pos+3) == token.LBRACE
+}
+
+func (p *greenParser) forHeaderHasInBeforeBody() bool {
+	parenDepth, bracketDepth := 0, 0
+	for i := p.pos; i < len(p.toks); i++ {
+		switch p.kindAt(i) {
+		case token.EOF, token.NEWLINE:
+			return false
+		case token.LBRACE:
+			return false
+		case token.LPAREN:
+			parenDepth++
+		case token.RPAREN:
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case token.LBRACKET:
+			bracketDepth++
+		case token.RBRACKET:
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case token.IDENT:
+			if parenDepth == 0 && bracketDepth == 0 && p.tokenValueAt(i) == "in" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (p *greenParser) useLooksGrouped(start int) bool {
+	sawColonColon := false
 	for i := start; i < len(p.toks); i++ {
 		switch p.kindAt(i) {
 		case token.NEWLINE, token.EOF:
 			return false
+		case token.COLONCOLON:
+			sawColonColon = true
 		case token.LBRACE:
-			return true
+			return sawColonColon
 		}
 	}
 	return false
@@ -880,6 +1481,28 @@ func (p *greenParser) kindAt(idx int) token.Kind {
 		return token.EOF
 	}
 	return p.toks[idx].Kind
+}
+
+func (p *greenParser) atIdentValue(value string) bool {
+	return p.at(token.IDENT) && p.peek().Value == value
+}
+
+func (p *greenParser) atUseAliasKeyword() bool {
+	return p.atIdentValue("as")
+}
+
+func (p *greenParser) tokenValueAt(idx int) string {
+	if idx < 0 || idx >= len(p.toks) {
+		return ""
+	}
+	return p.toks[idx].Value
+}
+
+func (p *greenParser) previousTokenValue() string {
+	if p.pos <= 0 || p.pos-1 >= len(p.toks) {
+		return ""
+	}
+	return p.toks[p.pos-1].Value
 }
 
 func (p *greenParser) peek() token.Token {

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -20,8 +20,8 @@ type nativeResolveCache struct {
 	once       sync.Once
 	checkOnce  sync.Once
 	result     api.ResolveResult
-	check      selfhost.CheckResult
-	checkInput selfhost.PackageCheckInput
+	check      api.CheckResult
+	checkInput api.PackageCheckInput
 	files      []nativeResolveFileInfo
 	err        error
 }
@@ -162,7 +162,7 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 			pkg.nativeResolve.err = err
 			return
 		}
-		pkg.nativeResolve.checkInput = selfhost.PackageCheckInput{
+		pkg.nativeResolve.checkInput = api.PackageCheckInput{
 			Files:   input.Files,
 			Imports: input.Imports,
 		}
@@ -172,10 +172,10 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.err
 }
 
-func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, selfhost.CheckResult, error) {
+func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFileInfo, api.CheckResult, error) {
 	result, files, err := nativeResolveArtifacts(pkg)
 	if err != nil || pkg == nil {
-		return result, files, selfhost.CheckResult{}, err
+		return result, files, api.CheckResult{}, err
 	}
 	pkg.nativeResolve.checkOnce.Do(func() {
 		checked, err := selfhost.CheckPackageStructured(pkg.nativeResolve.checkInput)
@@ -338,7 +338,7 @@ func nativeResolutionRowsFromArtifacts(path string, resolved api.ResolveResult, 
 	return rows
 }
 
-func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeResolveFileInfo, checked selfhost.CheckResult) NativeResolveFactSet {
+func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeResolveFileInfo, checked api.CheckResult) NativeResolveFactSet {
 	facts := NativeResolveFactSet{
 		Symbols: make([]NativeResolvedSymbol, 0, len(resolved.Symbols)),
 		Refs:    make([]NativeResolvedRef, 0, len(resolved.Refs)+len(resolved.TypeRefs)),
@@ -409,7 +409,7 @@ func nativeResolveFactsFromArtifacts(resolved api.ResolveResult, files []nativeR
 	return facts
 }
 
-func nativeCheckSymbolTypes(checked selfhost.CheckResult) map[int]string {
+func nativeCheckSymbolTypes(checked api.CheckResult) map[int]string {
 	if len(checked.Symbols) == 0 {
 		return nil
 	}
@@ -493,14 +493,14 @@ func nativeImportLocalName(name string) string {
 	return name
 }
 
-func nativeTypeReprText(repr *selfhost.TypeRepr, fallback string) string {
+func nativeTypeReprText(repr *api.TypeRepr, fallback string) string {
 	if repr != nil {
 		return repr.String()
 	}
 	return fallback
 }
 
-func nativeImportFnType(fn selfhost.PackageCheckFn) string {
+func nativeImportFnType(fn api.PackageCheckFn) string {
 	params := make([]string, 0, len(fn.ParamTypes)+len(fn.ParamTypeReprs))
 	if len(fn.ParamTypeReprs) > 0 {
 		for i := range fn.ParamTypeReprs {
@@ -516,7 +516,7 @@ func nativeImportFnType(fn selfhost.PackageCheckFn) string {
 	return "fn(" + strings.Join(params, ", ") + ") -> " + ret
 }
 
-func nativeImportVariantType(variant selfhost.PackageCheckVariant) string {
+func nativeImportVariantType(variant api.PackageCheckVariant) string {
 	fields := make([]string, 0, len(variant.FieldTypes)+len(variant.FieldTypeReprs))
 	if len(variant.FieldTypeReprs) > 0 {
 		for i := range variant.FieldTypeReprs {


### PR DESCRIPTION
## Summary
- Structure more green parser constructs: map literals, patterns, for headers, closures, use declarations, composite types, generic bounds, paren/tuple/else, loop expressions, and enum/match list wrappers.
- Add regression coverage for the new CST shapes and round-trip validation.
- Update `internal/resolve/native_adapter.go` to use `internal/selfhost/api` structured API types directly, satisfying the latest frontend authority guard on `main`.

## Validation
- `go test -count=1 -vet=off ./internal/cst`
- `go test -count=1 -vet=off ./internal/selfhost ./internal/query/osty`
- `just front`