### PR TITLE
[codex] add diagnostic source identities

### DIFF
--- a/internal/canonical/source.go
+++ b/internal/canonical/source.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/format"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // Source returns the canonical checker-facing source for a parsed file.
@@ -23,4 +24,18 @@ func SourceWithMap(original []byte, file *ast.File) ([]byte, *sourcemap.Map) {
 		return out, m
 	}
 	return append([]byte(nil), original...), nil
+}
+
+// SourceWithMapForFile is SourceWithMap plus global file/span identity
+// stamping. The canonical output gets a derived SourceFileID while map entries
+// keep provenance back to the original source file.
+func SourceWithMapForFile(path string, original []byte, file *ast.File) ([]byte, *sourcemap.Map) {
+	out, m := SourceWithMap(original, file)
+	if m == nil || path == "" {
+		return out, m
+	}
+	originalID := spanid.SourceFileIDFor(path)
+	generatedID := spanid.DerivedSourceFileID(originalID, spanid.ProvenanceCanonical, "canonical")
+	m.StampFileIDs(originalID, generatedID)
+	return out, m
 }

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
@@ -350,6 +351,9 @@ type selfhostCheckedSource struct {
 
 type selfhostFileSegment struct {
 	file      *ast.File
+	path      string
+	source    []byte
+	sourceID  spanid.SourceFileID
 	scope     *resolve.Scope
 	refs      map[ast.NodeID]*resolve.Symbol
 	base      int
@@ -413,7 +417,7 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		return
 	}
 	policy := nativeDiagPolicy{privileged: privileged}
-	result.Diags = append(result.Diags, nativeCheckerDiags(checkedSrc.source, checked, policy)...)
+	result.Diags = append(result.Diags, nativeCheckerDiagsForCheckedSource(checkedSrc, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
 	overlaySelfhostResult(result, checkedSrc, checked)
@@ -467,7 +471,7 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 		return
 	}
 	policy := nativeDiagPolicy{privileged: privileged}
-	result.Diags = append(result.Diags, nativeCheckerDiags(src.source, checked, policy)...)
+	result.Diags = append(result.Diags, nativeCheckerDiagsForCheckedSource(src, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
 	overlaySelfhostResult(result, src, checked)
@@ -603,7 +607,7 @@ func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, ws *re
 		return
 	}
 	policy := nativeDiagPolicy{privileged: privileged}
-	diags := nativeCheckerDiags(src.source, checked, policy)
+	diags := nativeCheckerDiagsForCheckedSource(src, checked, policy)
 	telemetry := nativeCheckerTelemetry(checked, policy)
 
 	mu.Lock()
@@ -748,6 +752,90 @@ func nativeCheckerDiags(src []byte, checked api.CheckResult, policy nativeDiagPo
 	return out
 }
 
+func nativeCheckerDiagsForCheckedSource(src selfhostCheckedSource, checked api.CheckResult, policy nativeDiagPolicy) []*diag.Diagnostic {
+	out := make([]*diag.Diagnostic, 0, len(checked.Diagnostics))
+	for _, d := range checked.Diagnostics {
+		if shouldSuppressNativeDiag(d, policy) {
+			continue
+		}
+		if converted := convertNativeDiagForCheckedSource(src, d); converted != nil {
+			out = append(out, converted)
+		}
+	}
+	summary := filteredNativeSummary(checked, policy)
+	if summary.Errors == 0 {
+		return out
+	}
+	label := "native checker reported type errors"
+	if summary.Errors == 1 {
+		label = "native checker reported a type error"
+	}
+	out = append(out,
+		diag.New(diag.Error, fmt.Sprintf("%s: %d error(s)", label, summary.Errors)).
+			Code(diag.CodeTypeMismatch).
+			Primary(fileStartSpan(src.source), "native checker summary").
+			Note(fmt.Sprintf(
+				"native checker accepted %d of %d assignment/return/call checks",
+				summary.Accepted,
+				summary.Assignments,
+			)).
+			Build(),
+	)
+	return out
+}
+
+func convertNativeDiagForCheckedSource(src selfhostCheckedSource, d api.CheckDiagnosticRecord) *diag.Diagnostic {
+	seg, relStart, relEnd, ok := nativeDiagSegment(src, d)
+	if !ok {
+		return convertNativeDiag(src.source, d)
+	}
+	mapped := d
+	mapped.Start = relStart
+	mapped.End = relEnd
+	if mapped.File == "" {
+		mapped.File = seg.path
+	}
+	if mapped.SourceFileID == "" && seg.sourceID != "" {
+		mapped.SourceFileID = string(seg.sourceID)
+	}
+	if mapped.SpanID == "" && mapped.SourceFileID != "" {
+		mapped.SpanID = string(spanid.SpanIDFor(spanid.SourceFileID(mapped.SourceFileID), mapped.Start, mapped.End))
+	}
+	if seg.base != 0 {
+		mapped.Provenance = append(mapped.Provenance, api.SpanProvenanceRecord{
+			Kind:         string(spanid.ProvenanceSelfhostShift),
+			SourceFileID: mapped.SourceFileID,
+			SpanID:       mapped.SpanID,
+			Detail:       fmt.Sprintf("base:%d", seg.base),
+		})
+	}
+	return convertNativeDiag(seg.source, mapped)
+}
+
+func nativeDiagSegment(src selfhostCheckedSource, d api.CheckDiagnosticRecord) (selfhostFileSegment, int, int, bool) {
+	for _, seg := range src.files {
+		if d.File != "" && seg.path != "" && d.File != seg.path {
+			continue
+		}
+		if len(seg.source) == 0 {
+			continue
+		}
+		relStart := d.Start - seg.base
+		relEnd := d.End - seg.base
+		if relStart < 0 || relStart > len(seg.source) {
+			continue
+		}
+		if relEnd < relStart {
+			relEnd = relStart
+		}
+		if relEnd > len(seg.source) {
+			relEnd = len(seg.source)
+		}
+		return seg, relStart, relEnd, true
+	}
+	return selfhostFileSegment{}, 0, 0, false
+}
+
 func filteredNativeSummary(checked api.CheckResult, policy nativeDiagPolicy) api.CheckSummary {
 	summary := checked.Summary
 	if !policy.privileged {
@@ -818,7 +906,7 @@ func convertNativeDiag(src []byte, d api.CheckDiagnosticRecord) *diag.Diagnostic
 	if d.File != "" {
 		b = b.File(d.File)
 	}
-	b = b.Primary(nativeDiagSpan(src, d), "")
+	b = b.Primary(nativeDiagSpanWithIdentity(src, d), "")
 	for _, note := range d.Notes {
 		if strings.TrimSpace(note) == "" {
 			continue
@@ -844,6 +932,25 @@ func nativeDiagSpan(src []byte, d api.CheckDiagnosticRecord) diag.Span {
 		}
 	}
 	return byteRangeSpan(src, d.Start, d.End)
+}
+
+func nativeDiagSpanWithIdentity(src []byte, d api.CheckDiagnosticRecord) diag.Span {
+	span := nativeDiagSpan(src, d)
+	if d.SourceFileID != "" {
+		span = diag.StampSpanSourceFileID(span, spanid.SourceFileID(d.SourceFileID))
+	}
+	if d.SpanID != "" {
+		span.ID = spanid.SpanID(d.SpanID)
+	}
+	for _, p := range d.Provenance {
+		span.Provenance = spanid.AppendProvenance(span.Provenance, spanid.Provenance{
+			Kind:         spanid.ProvenanceKind(p.Kind),
+			SourceFileID: spanid.SourceFileID(p.SourceFileID),
+			SpanID:       spanid.SpanID(p.SpanID),
+			Detail:       p.Detail,
+		})
+	}
+	return span
 }
 
 // byteRangeSpan builds a `diag.Span` for a [start, end) byte range
@@ -1866,6 +1973,7 @@ func selfhostFileSource(file *ast.File, rr *resolve.Result, src []byte, stdlib r
 		source: b.Bytes(),
 		files: []selfhostFileSegment{{
 			file:      file,
+			source:    append([]byte(nil), src...),
 			scope:     scope,
 			refs:      refs,
 			base:      base,
@@ -1891,6 +1999,7 @@ func selfhostFileStructuredSource(file *ast.File, rr *resolve.Result, src []byte
 		source: append([]byte(nil), src...),
 		files: []selfhostFileSegment{{
 			file:      file,
+			source:    append([]byte(nil), src...),
 			scope:     scope,
 			refs:      refs,
 			base:      0,
@@ -1918,6 +2027,9 @@ func selfhostPackageSource(pkg *resolve.Package, ws *resolve.Workspace, stdlib r
 		}
 		files = append(files, selfhostFileSegment{
 			file:      pf.File,
+			path:      pf.Path,
+			source:    append([]byte(nil), src...),
+			sourceID:  checkSourceFileID(pf),
 			scope:     pf.FileScope,
 			refs:      pf.RefsByID,
 			base:      base,
@@ -1925,6 +2037,16 @@ func selfhostPackageSource(pkg *resolve.Package, ws *resolve.Workspace, stdlib r
 		})
 	}
 	return selfhostCheckedSource{source: b.Bytes(), files: files}
+}
+
+func checkSourceFileID(pf *resolve.PackageFile) spanid.SourceFileID {
+	if pf == nil {
+		return ""
+	}
+	if pf.SourceFileID != "" {
+		return pf.SourceFileID
+	}
+	return spanid.SourceFileIDFor(pf.Path)
 }
 
 func writeSelfhostPackageImports(b *bytes.Buffer, pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) {

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -31,10 +31,11 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 			name = filepath.Base(pf.Path)
 		}
 		input.Files = append(input.Files, api.PackageCheckFile{
-			Source: append([]byte(nil), src...),
-			Base:   base,
-			Name:   name,
-			Path:   pf.Path,
+			Source:       append([]byte(nil), src...),
+			Base:         base,
+			Name:         name,
+			Path:         pf.Path,
+			SourceFileID: string(pf.SourceFileID),
 		})
 		segmentIdx++
 	}

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -11,7 +11,10 @@
 // fields directly.
 package diag
 
-import "github.com/osty/osty/internal/token"
+import (
+	"github.com/osty/osty/internal/spanid"
+	"github.com/osty/osty/internal/token"
+)
 
 // Severity classifies a diagnostic.
 type Severity int
@@ -44,6 +47,14 @@ func (s Severity) String() string {
 type Span struct {
 	Start token.Pos
 	End   token.Pos
+	// SourceFileID/ID are optional global identities for consumers that need to
+	// distinguish equal byte offsets from different source surfaces.
+	SourceFileID spanid.SourceFileID
+	ID           spanid.SpanID
+	// Provenance records how generated/canonical/injected spans relate back to
+	// earlier source surfaces. Empty means the span is an original source span
+	// or predates the global identity system.
+	Provenance *spanid.ProvenanceList
 }
 
 // LabeledSpan is a span with an attached label, used to highlight the
@@ -120,15 +131,24 @@ type Suggestion struct {
 // first span's start if no primary span is present, or the zero Pos if
 // there are no spans.
 func (d *Diagnostic) PrimaryPos() token.Pos {
+	if span, ok := d.PrimarySpan(); ok {
+		return span.Start
+	}
+	return token.Pos{}
+}
+
+// PrimarySpan returns the first primary span, or the first span when no primary
+// span is explicitly marked.
+func (d *Diagnostic) PrimarySpan() (Span, bool) {
 	for _, s := range d.Spans {
 		if s.Primary {
-			return s.Span.Start
+			return s.Span, true
 		}
 	}
 	if len(d.Spans) > 0 {
-		return d.Spans[0].Span.Start
+		return d.Spans[0].Span, true
 	}
-	return token.Pos{}
+	return Span{}, false
 }
 
 // Error implements the error interface so a Diagnostic can be returned
@@ -164,6 +184,7 @@ func (b *Builder) Code(code string) *Builder { b.d.Code = code; return b }
 
 // Primary attaches a primary span with an optional label.
 func (b *Builder) Primary(span Span, label string) *Builder {
+	span = b.stampSpan(span)
 	b.d.Spans = append(b.d.Spans, LabeledSpan{Span: span, Label: label, Primary: true})
 	return b
 }
@@ -175,6 +196,7 @@ func (b *Builder) PrimaryPos(pos token.Pos, label string) *Builder {
 
 // Secondary attaches a secondary span (context, not the main culprit).
 func (b *Builder) Secondary(span Span, label string) *Builder {
+	span = b.stampSpan(span)
 	b.d.Spans = append(b.d.Spans, LabeledSpan{Span: span, Label: label, Primary: false})
 	return b
 }
@@ -191,7 +213,11 @@ func (b *Builder) Hint(text string) *Builder { b.d.Hint = text; return b }
 // File stamps the owning source file path. Used by multi-file package
 // walkers so the renderer can route the diagnostic to the right source
 // snippet even though `token.Pos` does not carry file identity.
-func (b *Builder) File(path string) *Builder { b.d.File = path; return b }
+func (b *Builder) File(path string) *Builder {
+	b.d.File = path
+	StampDiagnosticSourceFileID(b.d, spanid.SourceFileIDFor(path))
+	return b
+}
 
 // StampFile sets d.File on every diagnostic in ds that does not yet
 // have one. Call sites that know the file context (per-file checker
@@ -202,10 +228,72 @@ func StampFile(ds []*Diagnostic, path string) {
 		return
 	}
 	for _, d := range ds {
-		if d == nil || d.File != "" {
+		if d == nil {
 			continue
 		}
-		d.File = path
+		stampPath := path
+		if d.File == "" {
+			d.File = path
+		} else {
+			stampPath = d.File
+		}
+		StampDiagnosticSourceFileID(d, spanid.SourceFileIDFor(stampPath))
+	}
+}
+
+// StampSpanSourceFileID attaches a SourceFileID and stable SpanID without
+// rewriting existing identity from a more specific source map.
+func StampSpanSourceFileID(span Span, fileID spanid.SourceFileID) Span {
+	if fileID == "" {
+		return span
+	}
+	if span.SourceFileID == "" {
+		span.SourceFileID = fileID
+	}
+	if span.ID == "" {
+		span.ID = spanid.SpanIDFor(span.SourceFileID, span.Start.Offset, span.End.Offset)
+	}
+	return span
+}
+
+// DeriveSpanSource records a provenance edge from parent to span.
+func DeriveSpanSource(span Span, kind spanid.ProvenanceKind, detail string, parent Span) Span {
+	parent = StampSpanSourceFileID(parent, parent.SourceFileID)
+	if span.SourceFileID == "" && span.ID == "" && parent.SourceFileID == "" && parent.ID == "" {
+		return span
+	}
+	if span.SourceFileID == "" {
+		span.SourceFileID = parent.SourceFileID
+	}
+	if span.ID == "" {
+		span.ID = spanid.DerivedSpanID(span.SourceFileID, kind, span.Start.Offset, span.End.Offset, parent.ID)
+	}
+	if parent.SourceFileID != "" || parent.ID != "" || detail != "" || kind != "" {
+		span.Provenance = spanid.AppendProvenance(span.Provenance, spanid.Provenance{
+			Kind:         kind,
+			SourceFileID: parent.SourceFileID,
+			SpanID:       parent.ID,
+			Detail:       detail,
+		})
+	}
+	return span
+}
+
+// StampDiagnosticSourceFileID attaches file/span identity to every span-bearing
+// field in d while preserving existing source-map identities.
+func StampDiagnosticSourceFileID(d *Diagnostic, fileID spanid.SourceFileID) {
+	if d == nil || fileID == "" {
+		return
+	}
+	for i := range d.Spans {
+		d.Spans[i].Span = StampSpanSourceFileID(d.Spans[i].Span, fileID)
+	}
+	for i := range d.Suggestions {
+		d.Suggestions[i].Span = StampSpanSourceFileID(d.Suggestions[i].Span, fileID)
+		if d.Suggestions[i].CopyFrom != nil {
+			copied := StampSpanSourceFileID(*d.Suggestions[i].CopyFrom, fileID)
+			d.Suggestions[i].CopyFrom = &copied
+		}
 	}
 }
 
@@ -213,6 +301,7 @@ func StampFile(ds []*Diagnostic, path string) {
 // replacement, labelled for the user. MachineApplicable=true marks it
 // safe for tools to auto-apply.
 func (b *Builder) Suggest(span Span, replacement, label string, machineApplicable bool) *Builder {
+	span = b.stampSpan(span)
 	b.d.Suggestions = append(b.d.Suggestions, Suggestion{
 		Span:              span,
 		Replacement:       replacement,
@@ -230,6 +319,8 @@ func (b *Builder) Suggest(span Span, replacement, label string, machineApplicabl
 // sub-expressions (e.g. `!!x` → `x`, `x == true` → `x`) without
 // the lint pass needing access to the raw source bytes.
 func (b *Builder) SuggestCopy(span, copyFrom Span, template, label string, machineApplicable bool) *Builder {
+	span = b.stampSpan(span)
+	copyFrom = b.stampSpan(copyFrom)
 	cf := copyFrom
 	b.d.Suggestions = append(b.d.Suggestions, Suggestion{
 		Span:              span,
@@ -242,4 +333,16 @@ func (b *Builder) SuggestCopy(span, copyFrom Span, template, label string, machi
 }
 
 // Build returns the finished Diagnostic.
-func (b *Builder) Build() *Diagnostic { return b.d }
+func (b *Builder) Build() *Diagnostic {
+	if b.d.File != "" {
+		StampDiagnosticSourceFileID(b.d, spanid.SourceFileIDFor(b.d.File))
+	}
+	return b.d
+}
+
+func (b *Builder) stampSpan(span Span) Span {
+	if b == nil || b.d == nil || b.d.File == "" {
+		return span
+	}
+	return StampSpanSourceFileID(span, spanid.SourceFileIDFor(b.d.File))
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -901,7 +901,7 @@ func lspMaterializeNativePackageFiles(pkg *resolve.Package) {
 			pf.File = selfhost.LowerPublicFileFromRun(pf.Run)
 		}
 		if len(pf.CanonicalSource) == 0 && pf.File != nil {
-			pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMap(pf.Source, pf.File)
+			pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMapForFile(pf.Path, pf.Source, pf.File)
 		}
 	}
 }
@@ -959,11 +959,10 @@ func identIndexForFile(pkg *resolve.Package, path string, fallback *resolve.Resu
 }
 
 // collectDiagsForFile picks out the parser, resolver, checker, and
-// lint diagnostics that belong to one file. Parser diagnostics are
-// already file-attributed via PackageFile.ParseDiags; the other three
-// stages are filtered by byte-offset containment — positions from
-// different files have disjoint offset ranges because each file was
-// lexed against its own source buffer.
+// lint diagnostics that belong to one file. Parser/lint diagnostics are
+// file-attributed at their per-file boundaries; resolver/checker diagnostics
+// are routed by File or SourceFileID when available, with the old containment
+// heuristic left only as a compatibility fallback.
 func collectDiagsForFile(
 	pkg *resolve.Package,
 	pr *resolve.PackageResult,
@@ -1016,7 +1015,7 @@ func nativeResolveDiagsForFile(pkg *resolve.Package, pf *resolve.PackageFile) ([
 		if d == nil {
 			continue
 		}
-		if d.File != "" && d.File != pf.Path {
+		if !diagBelongsToFile(d, pf) {
 			continue
 		}
 		out = append(out, d)
@@ -1024,15 +1023,17 @@ func nativeResolveDiagsForFile(pkg *resolve.Package, pf *resolve.PackageFile) ([
 	return out, true
 }
 
-// diagBelongsToFile returns true when the diagnostic's primary
-// position could plausibly have come from this file. Positions carry
-// no file identity, so we filter on byte-range containment: a
-// diagnostic from file B at offset N would fail this test for any
-// file A with `len(A.Source) < N`. The heuristic misclassifies when
-// multiple files in the same package share an overlapping offset
-// range; fixing that requires threading a file identifier through
-// every diag.Diagnostic, which is a resolver-side change.
+// diagBelongsToFile returns true when the diagnostic is attributed to pf.
 func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
+	if d == nil || pf == nil {
+		return false
+	}
+	if d.File != "" {
+		return ostyquery.NormalizePath(d.File) == ostyquery.NormalizePath(pf.Path)
+	}
+	if span, ok := d.PrimarySpan(); ok && span.SourceFileID != "" && pf.SourceFileID != "" {
+		return span.SourceFileID == pf.SourceFileID
+	}
 	pos := d.PrimaryPos()
 	if pos.Line == 0 {
 		return false

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
@@ -98,6 +99,7 @@ func (s *stableHasher) pos(p token.Pos) {
 // alter resolver or checker output.
 func hashParseResult(r ParseResult) [32]byte {
 	h := newHasher()
+	h.str(string(r.SourceFileID))
 	h.bytes(r.Source)
 	h.u32(uint32(len(r.Diags)))
 	for _, d := range r.Diags {
@@ -128,12 +130,12 @@ func hashDiagnostic(h *stableHasher, d *diag.Diagnostic) {
 	}
 	h.byte(1)
 	h.byte(byte(d.Severity))
+	h.str(d.File)
 	h.str(d.Code)
 	h.str(d.Message)
 	h.u32(uint32(len(d.Spans)))
 	for _, sp := range d.Spans {
-		h.pos(sp.Span.Start)
-		h.pos(sp.Span.End)
+		hashSpan(h, sp.Span)
 		h.str(sp.Label)
 		h.bool(sp.Primary)
 	}
@@ -151,16 +153,29 @@ func hashDiagnostic(h *stableHasher, d *diag.Diagnostic) {
 func hashSuggestion(h *stableHasher, s diag.Suggestion) {
 	h.str(s.Label)
 	h.str(s.Replacement)
-	h.pos(s.Span.Start)
-	h.pos(s.Span.End)
+	hashSpan(h, s.Span)
 	if s.CopyFrom != nil {
 		h.byte(1)
-		h.pos(s.CopyFrom.Start)
-		h.pos(s.CopyFrom.End)
+		hashSpan(h, *s.CopyFrom)
 	} else {
 		h.byte(0)
 	}
 	h.bool(s.MachineApplicable)
+}
+
+func hashSpan(h *stableHasher, s diag.Span) {
+	h.pos(s.Start)
+	h.pos(s.End)
+	h.str(string(s.SourceFileID))
+	h.str(string(s.ID))
+	provenance := spanid.ProvenanceEntries(s.Provenance)
+	h.u32(uint32(len(provenance)))
+	for _, p := range provenance {
+		h.str(string(p.Kind))
+		h.str(string(p.SourceFileID))
+		h.str(string(p.SpanID))
+		h.str(p.Detail)
+	}
 }
 
 func hashDiagsList(h *stableHasher, ds []*diag.Diagnostic) {
@@ -250,6 +265,7 @@ func hashResolvedPackage(rp *ResolvedPackage) [32]byte {
 	facts, hasNativeFacts := nativeResolveFactsForHash(rp.pkg)
 	for _, pf := range files {
 		h.str(pf.Path)
+		h.str(string(pf.SourceFileID))
 		if !hasNativeFacts {
 			hashFileRefs(h, pf)
 		}

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // ---- Value types ----
@@ -25,6 +26,7 @@ import (
 // rendering without re-reading the file.
 type ParseResult struct {
 	Source          []byte
+	SourceFileID    spanid.SourceFileID
 	CanonicalSource []byte
 	CanonicalMap    *sourcemap.Map
 	File            *ast.File
@@ -306,9 +308,11 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 		func(ctx *query.Ctx, path string) ParseResult {
 			src := inp.SourceText.Fetch(ctx, path)
 			parsed := parser.ParseDetailed(src)
-			canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
+			canonicalSrc, canonicalMap := canonical.SourceWithMapForFile(path, src, parsed.File)
+			diag.StampFile(parsed.Diagnostics, path)
 			return ParseResult{
 				Source:          src,
+				SourceFileID:    spanid.SourceFileIDFor(path),
 				CanonicalSource: canonicalSrc,
 				CanonicalMap:    canonicalMap,
 				File:            parsed.File,
@@ -352,6 +356,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				pkg.Files = append(pkg.Files, &resolve.PackageFile{
 					Path:            f,
 					Source:          pr.Source,
+					SourceFileID:    pr.SourceFileID,
 					CanonicalSource: pr.CanonicalSource,
 					CanonicalMap:    pr.CanonicalMap,
 					File:            pr.File,
@@ -382,6 +387,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				pkg.Files[i] = &resolve.PackageFile{
 					Path:            pf.Path,
 					Source:          pf.Source,
+					SourceFileID:    pf.SourceFileID,
 					OriginalSource:  pf.OriginalSource,
 					TransformMap:    pf.TransformMap,
 					CanonicalSource: pf.CanonicalSource,
@@ -620,13 +626,23 @@ func collectFileDiagnostics(
 	lr *lint.Result,
 ) []*diag.Diagnostic {
 	norm := NormalizePath(path)
-	out := make([]*diag.Diagnostic, 0, len(pr.Diags)+len(resolveDiags)+len(chk.Diags)+len(lr.Diags))
+	fileID := pr.SourceFileID
+	if fileID == "" {
+		fileID = spanid.SourceFileIDFor(norm)
+	}
+	diag.StampFile(pr.Diags, norm)
+	if lr != nil {
+		// LintFile is source-only and therefore has no file context until this
+		// per-path aggregation boundary.
+		diag.StampFile(lr.Diags, norm)
+	}
+	out := make([]*diag.Diagnostic, 0, len(pr.Diags)+len(resolveDiags)+diagLen(chk)+diagLen(lr))
 	appendFiltered := func(ds []*diag.Diagnostic) {
 		for _, d := range ds {
 			if d == nil {
 				continue
 			}
-			if !diagnosticBelongsTo(d, norm) {
+			if !diagnosticBelongsTo(d, norm, fileID) {
 				continue
 			}
 			out = append(out, d)
@@ -636,8 +652,12 @@ func collectFileDiagnostics(
 	// no position-based filtering needed.
 	out = append(out, pr.Diags...)
 	appendFiltered(resolveDiags)
-	appendFiltered(chk.Diags)
-	appendFiltered(lr.Diags)
+	if chk != nil {
+		appendFiltered(chk.Diags)
+	}
+	if lr != nil {
+		appendFiltered(lr.Diags)
+	}
 	return out
 }
 
@@ -645,17 +665,24 @@ func nativeResolveDiagnosticsForFile(path string, pkg *resolve.Package) []*diag.
 	if pkg == nil {
 		return nil
 	}
+	norm := NormalizePath(path)
+	fileID := spanid.SourceFileIDFor(norm)
+	for _, pf := range pkg.Files {
+		if pf != nil && NormalizePath(pf.Path) == norm && pf.SourceFileID != "" {
+			fileID = pf.SourceFileID
+			break
+		}
+	}
 	ds, err := resolve.NativeDiagnostics(pkg)
 	if err != nil {
 		return nil
 	}
-	norm := NormalizePath(path)
 	out := make([]*diag.Diagnostic, 0, len(ds))
 	for _, d := range ds {
 		if d == nil {
 			continue
 		}
-		if d.File != "" && NormalizePath(d.File) != norm {
+		if !diagnosticBelongsTo(d, norm, fileID) {
 			continue
 		}
 		out = append(out, d)
@@ -663,12 +690,35 @@ func nativeResolveDiagnosticsForFile(path string, pkg *resolve.Package) []*diag.
 	return out
 }
 
-// diagnosticBelongsTo is a placeholder for per-file filtering. Span
-// filtering by path can't be done until token.Pos carries a file
-// identifier; callers currently receive every diagnostic and sort by
-// position for rendering.
-func diagnosticBelongsTo(d *diag.Diagnostic, normalizedPath string) bool {
-	return d != nil
+func diagLen(v any) int {
+	switch x := v.(type) {
+	case *check.Result:
+		if x != nil {
+			return len(x.Diags)
+		}
+	case *lint.Result:
+		if x != nil {
+			return len(x.Diags)
+		}
+	}
+	return 0
+}
+
+// diagnosticBelongsTo routes multi-file diagnostics by explicit path first and
+// then by SourceFileID carried on the primary span. Diagnostics without either
+// identity are retained as a compatibility fallback so older single-file
+// producers do not disappear from editor output.
+func diagnosticBelongsTo(d *diag.Diagnostic, normalizedPath string, fileID spanid.SourceFileID) bool {
+	if d == nil {
+		return false
+	}
+	if d.File != "" {
+		return NormalizePath(d.File) == normalizedPath
+	}
+	if span, ok := d.PrimarySpan(); ok && span.SourceFileID != "" {
+		return span.SourceFileID == fileID
+	}
+	return true
 }
 
 // ---- Workspace helpers ----
@@ -720,6 +770,7 @@ func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 		pkg.Files[i] = &resolve.PackageFile{
 			Path:            pf.Path,
 			Source:          pf.Source,
+			SourceFileID:    pf.SourceFileID,
 			OriginalSource:  pf.OriginalSource,
 			TransformMap:    pf.TransformMap,
 			CanonicalSource: pf.CanonicalSource,

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -4,9 +4,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/cst"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/spanid"
+	"github.com/osty/osty/internal/token"
 )
 
 // Helper: seed one "package" with one file for tests.
@@ -191,6 +195,59 @@ func TestDiagnosticsChangeOnError(t *testing.T) {
 	if len(diags) <= validDiagCount {
 		t.Fatalf("expected new diagnostics after parse error; before=%d after=%d",
 			validDiagCount, len(diags))
+	}
+}
+
+func TestParseDiagnosticsCarrySourceFileIdentity(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	path := seedFile(eng, "/tmp/pkg_span_parse", "main.osty", "pub fn {")
+	pr := eng.Queries.Parse.Get(eng.DB, path)
+	if len(pr.Diags) == 0 {
+		t.Fatal("expected parse diagnostics")
+	}
+	if pr.SourceFileID == "" {
+		t.Fatal("parse result SourceFileID is empty")
+	}
+	got := pr.Diags[0]
+	if got.File != path {
+		t.Fatalf("diagnostic file = %q, want %q", got.File, path)
+	}
+	span, ok := got.PrimarySpan()
+	if !ok {
+		t.Fatal("diagnostic missing primary span")
+	}
+	if span.SourceFileID != pr.SourceFileID || span.ID == "" {
+		t.Fatalf("diagnostic span identity = (%q, %q), want file %q and non-empty span", span.SourceFileID, span.ID, pr.SourceFileID)
+	}
+}
+
+func TestCollectFileDiagnosticsFiltersByFileIdentity(t *testing.T) {
+	pathA := NormalizePath("/tmp/pkg_span_filter/a.osty")
+	pathB := NormalizePath("/tmp/pkg_span_filter/b.osty")
+	pos := token.Pos{Offset: 4, Line: 1, Column: 5}
+	spanA := diag.StampSpanSourceFileID(
+		diag.Span{Start: pos, End: token.Pos{Offset: 5, Line: 1, Column: 6}},
+		spanid.SourceFileIDFor(pathA),
+	)
+	spanB := diag.StampSpanSourceFileID(
+		diag.Span{Start: pos, End: token.Pos{Offset: 5, Line: 1, Column: 6}},
+		spanid.SourceFileIDFor(pathB),
+	)
+	resolveDiags := []*diag.Diagnostic{
+		diag.New(diag.Error, "belongs to a by span id").Primary(spanA, "").Build(),
+		diag.New(diag.Error, "belongs to b by file").File(pathB).Primary(spanB, "").Build(),
+	}
+	chk := &check.Result{}
+	lr := &lint.Result{}
+
+	got := collectFileDiagnostics(pathA, ParseResult{}, resolveDiags, chk, lr)
+	if len(got) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Message != "belongs to a by span id" {
+		t.Fatalf("diagnostic = %q, want span-id-routed diagnostic", got[0].Message)
 	}
 }
 

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // SourceTransform lets callers rewrite raw source bytes before the
@@ -109,14 +110,34 @@ func loadPackageNativePaths(paths []string, dir, name string, opts LoadOptions) 
 		src, transformMap := ApplySourceTransform(p, original, opts)
 		transformApplied := opts.Transform != nil || opts.Transformer != nil
 		transformChanged := transformApplied && !bytes.Equal(src, original)
+		originalSourceID := spanid.SourceFileIDFor(p)
+		sourceFileID := originalSourceID
+		if transformMap != nil {
+			sourceFileID = spanid.DerivedSourceFileID(originalSourceID, spanid.ProvenanceExpansion, "source-transform")
+			transformMap.StampFileIDs(originalSourceID, sourceFileID)
+		}
 		run := selfhost.Run(src)
+		diags := append([]*diag.Diagnostic(nil), run.Diagnostics()...)
+		for _, d := range diags {
+			if d == nil {
+				continue
+			}
+			if d.File == "" {
+				d.File = p
+			}
+			diag.StampDiagnosticSourceFileID(d, sourceFileID)
+		}
+		if transformMap != nil {
+			diags = transformMap.RemapDiagnosticsProjected(diags)
+		}
 		pf := &PackageFile{
 			Path:                   p,
 			Source:                 src,
+			SourceFileID:           sourceFileID,
 			SourceTransformApplied: transformApplied,
 			SourceTransformChanged: transformChanged,
 			Run:                    run,
-			ParseDiags:             append([]*diag.Diagnostic(nil), run.Diagnostics()...),
+			ParseDiags:             diags,
 		}
 		if transformMap != nil {
 			pf.OriginalSource = append([]byte(nil), original...)

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -28,6 +29,7 @@ type nativeResolveCache struct {
 
 type nativeResolveFileInfo struct {
 	path       string
+	sourceID   spanid.SourceFileID
 	base       int
 	source     []byte
 	sourceMap  *sourcemap.Map
@@ -227,13 +229,15 @@ func nativeResolveInput(pkg *Package) (api.PackageResolveInput, []nativeResolveF
 		// lexer + parser — no *ast.File round-trip, so we only pass
 		// source bytes + routing metadata here.
 		input.Files = append(input.Files, api.PackageResolveFile{
-			Source: append([]byte(nil), src...),
-			Base:   base,
-			Name:   filepath.Base(pf.Path),
-			Path:   pf.Path,
+			Source:       append([]byte(nil), src...),
+			Base:         base,
+			Name:         filepath.Base(pf.Path),
+			Path:         pf.Path,
+			SourceFileID: string(sourceFileIDForPackageFile(pf)),
 		})
 		files = append(files, nativeResolveFileInfo{
 			path:       pf.Path,
+			sourceID:   sourceFileIDForPackageFile(pf),
 			base:       base,
 			source:     append([]byte(nil), src...),
 			sourceMap:  pf.CheckerSourceMap(),
@@ -242,6 +246,16 @@ func nativeResolveInput(pkg *Package) (api.PackageResolveInput, []nativeResolveF
 		base += len(src) + 1
 	}
 	return input, files, nil
+}
+
+func sourceFileIDForPackageFile(pf *PackageFile) spanid.SourceFileID {
+	if pf == nil {
+		return ""
+	}
+	if pf.SourceFileID != "" {
+		return pf.SourceFileID
+	}
+	return spanid.SourceFileIDFor(pf.Path)
 }
 
 func nativeResolvePackagePath(pkg *Package) string {
@@ -280,7 +294,7 @@ func nativeResolveSourceForFile(pf *PackageFile) ([]byte, error) {
 		// mutation of input.Files does not corrupt pf.Source.
 		return append([]byte(nil), pf.Source...), nil
 	}
-	src, _ := canonical.SourceWithMap(pf.Source, pf.File)
+	src, _ := canonical.SourceWithMapForFile(pf.Path, pf.Source, pf.File)
 	return src, nil
 }
 
@@ -661,6 +675,7 @@ func nativeResolveDiagnosticsFromArtifacts(resolved api.ResolveResult, files []n
 	for _, record := range resolved.Diagnostics {
 		builder := diag.New(diag.Error, record.Message).Code(record.Code).File(record.File)
 		if span, ok := nativeResolveSpan(files, record.File, record.Start, record.End); ok {
+			span = nativeResolveRecordSpanWithIdentity(span, record)
 			builder.Primary(span, "")
 		}
 		if record.Hint != "" {
@@ -669,6 +684,24 @@ func nativeResolveDiagnosticsFromArtifacts(resolved api.ResolveResult, files []n
 		out = append(out, builder.Build())
 	}
 	return out
+}
+
+func nativeResolveRecordSpanWithIdentity(span diag.Span, record api.ResolveDiagnosticRecord) diag.Span {
+	if record.SourceFileID != "" {
+		span = diag.StampSpanSourceFileID(span, spanid.SourceFileID(record.SourceFileID))
+	}
+	if record.SpanID != "" {
+		span.ID = spanid.SpanID(record.SpanID)
+	}
+	for _, p := range record.Provenance {
+		span.Provenance = spanid.AppendProvenance(span.Provenance, spanid.Provenance{
+			Kind:         spanid.ProvenanceKind(p.Kind),
+			SourceFileID: spanid.SourceFileID(p.SourceFileID),
+			SpanID:       spanid.SpanID(p.SpanID),
+			Detail:       p.Detail,
+		})
+	}
+	return span
 }
 
 func nativeResolveSpan(files []nativeResolveFileInfo, path string, start, end int) (diag.Span, bool) {
@@ -688,6 +721,7 @@ func nativeResolveSpan(files []nativeResolveFileInfo, path string, start, end in
 			Start: token.Pos{Offset: relStart},
 			End:   token.Pos{Offset: relEnd},
 		}); ok {
+			remapped = diag.StampSpanSourceFileID(remapped, file.sourceID)
 			return remapped, true
 		}
 	}
@@ -702,7 +736,7 @@ func nativeResolveSpan(files []nativeResolveFileInfo, path string, start, end in
 	if endPos.Offset < startPos.Offset {
 		endPos = startPos
 	}
-	return diag.Span{Start: startPos, End: endPos}, true
+	return diag.StampSpanSourceFileID(diag.Span{Start: startPos, End: endPos}, file.sourceID), true
 }
 
 func nativeResolveLineCol(files []nativeResolveFileInfo, path string, start, end int) (int, int, bool) {

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // Package is the resolver's view of one Osty package — i.e. one directory
@@ -61,6 +62,9 @@ type PackageFile struct {
 	// Source is the parser-facing UTF-8 bytes. When a SourceTransform was
 	// applied, this is the transformed source.
 	Source []byte
+	// SourceFileID is the global identity for Source. It lets diagnostics and
+	// overlays distinguish identical offset ranges in different package files.
+	SourceFileID spanid.SourceFileID
 	// OriginalSource is the on-disk source before SourceTransform. Empty when
 	// Source already matches the file contents or the transform opted out of
 	// original-source remapping.
@@ -229,7 +233,7 @@ func (pkg *Package) MaterializeCanonicalSources() {
 		if pf == nil || pf.File == nil || len(pf.CanonicalSource) > 0 {
 			continue
 		}
-		pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMap(pf.Source, pf.File)
+		pf.CanonicalSource, pf.CanonicalMap = canonical.SourceWithMapForFile(pf.Path, pf.Source, pf.File)
 	}
 }
 

--- a/internal/resolve/package_graph.go
+++ b/internal/resolve/package_graph.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -153,6 +154,7 @@ func NewSingleFilePackageGraph(src []byte, file *ast.File, stdlib StdlibProvider
 		Files: []*PackageFile{{
 			Path:            "<input>",
 			Source:          append([]byte(nil), src...),
+			SourceFileID:    spanid.SourceFileIDFor("<input>"),
 			CanonicalSource: append([]byte(nil), src...),
 			File:            file,
 		}},

--- a/internal/selfhost/api/package.go
+++ b/internal/selfhost/api/package.go
@@ -12,7 +12,8 @@ type PackageCheckFile struct {
 	// Path is the owning source path when known. Package-mode diagnostics carry
 	// this through the native checker boundary so multi-file callers do not
 	// need to guess which file owned a given span.
-	Path string `json:"path,omitempty"`
+	Path         string `json:"path,omitempty"`
+	SourceFileID string `json:"sourceFileId,omitempty"`
 }
 
 // PackageCheckGenericBound describes one `<T: Iface>` constraint on a

--- a/internal/selfhost/api/types.go
+++ b/internal/selfhost/api/types.go
@@ -204,17 +204,20 @@ type CheckInstantiation struct {
 // consumed. StartLine/StartColumn/EndLine/EndColumn, when present, are the
 // checker-owned display positions for that span.
 type CheckDiagnosticRecord struct {
-	Code        string   `json:"code"`
-	Severity    string   `json:"severity"`
-	Message     string   `json:"message"`
-	Start       int      `json:"start"`
-	End         int      `json:"end"`
-	StartLine   int      `json:"startLine,omitempty"`
-	StartColumn int      `json:"startColumn,omitempty"`
-	EndLine     int      `json:"endLine,omitempty"`
-	EndColumn   int      `json:"endColumn,omitempty"`
-	File        string   `json:"file,omitempty"`
-	Notes       []string `json:"notes,omitempty"`
+	Code         string                 `json:"code"`
+	Severity     string                 `json:"severity"`
+	Message      string                 `json:"message"`
+	Start        int                    `json:"start"`
+	End          int                    `json:"end"`
+	StartLine    int                    `json:"startLine,omitempty"`
+	StartColumn  int                    `json:"startColumn,omitempty"`
+	EndLine      int                    `json:"endLine,omitempty"`
+	EndColumn    int                    `json:"endColumn,omitempty"`
+	File         string                 `json:"file,omitempty"`
+	Notes        []string               `json:"notes,omitempty"`
+	SourceFileID string                 `json:"sourceFileId,omitempty"`
+	SpanID       string                 `json:"spanId,omitempty"`
+	Provenance   []SpanProvenanceRecord `json:"provenance,omitempty"`
 }
 
 // CheckResult is the structured Go-facing surface for the bootstrapped checker.
@@ -589,16 +592,28 @@ type ResolvedTypeRef struct {
 // ResolveDiagnosticRecord is one structured diagnostic produced by the
 // self-host resolver.
 type ResolveDiagnosticRecord struct {
-	ID        string `json:"diagnosticId,omitempty"`
-	PackageID string `json:"packageId,omitempty"`
-	Code      string `json:"code"`
-	Message   string `json:"message"`
-	Name      string `json:"name,omitempty"`
-	Hint      string `json:"hint,omitempty"`
-	Node      int    `json:"node"`
-	Start     int    `json:"start"`
-	End       int    `json:"end"`
-	File      string `json:"file,omitempty"`
+	ID           string                 `json:"diagnosticId,omitempty"`
+	PackageID    string                 `json:"packageId,omitempty"`
+	Code         string                 `json:"code"`
+	Message      string                 `json:"message"`
+	Name         string                 `json:"name,omitempty"`
+	Hint         string                 `json:"hint,omitempty"`
+	Node         int                    `json:"node"`
+	Start        int                    `json:"start"`
+	End          int                    `json:"end"`
+	File         string                 `json:"file,omitempty"`
+	SourceFileID string                 `json:"sourceFileId,omitempty"`
+	SpanID       string                 `json:"spanId,omitempty"`
+	Provenance   []SpanProvenanceRecord `json:"provenance,omitempty"`
+}
+
+// SpanProvenanceRecord is the JSON-stable form of span provenance emitted by
+// selfhost adapters and consumed by host diagnostics.
+type SpanProvenanceRecord struct {
+	Kind         string `json:"kind,omitempty"`
+	SourceFileID string `json:"sourceFileId,omitempty"`
+	SpanID       string `json:"spanId,omitempty"`
+	Detail       string `json:"detail,omitempty"`
 }
 
 // ResolveResult is the structured Go-facing surface for the bootstrapped

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // Type aliases re-export the cross-boundary shapes from
@@ -202,6 +203,7 @@ type checkResultTokenMapper struct {
 	offsets    func(startToken, endToken int) (int, int)
 	tokenRange func(startToken, endToken int) (start, end, startLine, startColumn, endLine, endColumn int)
 	file       func(tokenIdx int) string
+	sourceID   func(tokenIdx int) string
 }
 
 func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResultTokenMapper) CheckResult {
@@ -293,18 +295,28 @@ func adaptCheckResultWithTokenMapper(checked *FrontCheckResult, mapper checkResu
 		if mapper.file != nil {
 			file = mapper.file(d.start)
 		}
+		sourceID := ""
+		if mapper.sourceID != nil {
+			sourceID = mapper.sourceID(d.start)
+		}
+		spanID := ""
+		if sourceID != "" {
+			spanID = string(spanid.SpanIDFor(spanid.SourceFileID(sourceID), start, end))
+		}
 		result.Diagnostics = append(result.Diagnostics, CheckDiagnosticRecord{
-			Code:        d.code,
-			Severity:    diagnosticSeverityName(d.severity),
-			Message:     d.message,
-			Start:       start,
-			End:         end,
-			StartLine:   startLine,
-			StartColumn: startColumn,
-			EndLine:     endLine,
-			EndColumn:   endColumn,
-			File:        file,
-			Notes:       append([]string(nil), d.notes...),
+			Code:         d.code,
+			Severity:     diagnosticSeverityName(d.severity),
+			Message:      d.message,
+			Start:        start,
+			End:          end,
+			StartLine:    startLine,
+			StartColumn:  startColumn,
+			EndLine:      endLine,
+			EndColumn:    endColumn,
+			File:         file,
+			Notes:        append([]string(nil), d.notes...),
+			SourceFileID: sourceID,
+			SpanID:       spanID,
 		})
 	}
 	result.EnsureStableIDs()

--- a/internal/selfhost/check_diag_convert.go
+++ b/internal/selfhost/check_diag_convert.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -60,7 +62,7 @@ func checkDiagnosticRecordAsDiagWithIndex(src []byte, index diagLineIndex, rec C
 	if rec.File != "" {
 		b = b.File(rec.File)
 	}
-	b = b.Primary(diagnosticRecordSpan(index, rec), "")
+	b = b.Primary(checkDiagnosticRecordSpanWithIdentity(index, rec), "")
 	for _, note := range rec.Notes {
 		if strings.TrimSpace(note) == "" {
 			continue
@@ -86,6 +88,29 @@ func diagnosticRecordSpan(index diagLineIndex, rec CheckDiagnosticRecord) diag.S
 		}
 	}
 	return index.byteRangeSpan(rec.Start, rec.End)
+}
+
+func checkDiagnosticRecordSpanWithIdentity(index diagLineIndex, rec CheckDiagnosticRecord) diag.Span {
+	span := diagnosticRecordSpan(index, rec)
+	return spanWithAPIIdentity(span, rec.SourceFileID, rec.SpanID, rec.Provenance)
+}
+
+func spanWithAPIIdentity(span diag.Span, sourceFileID, id string, provenance []api.SpanProvenanceRecord) diag.Span {
+	if sourceFileID != "" {
+		span = diag.StampSpanSourceFileID(span, spanid.SourceFileID(sourceFileID))
+	}
+	if id != "" {
+		span.ID = spanid.SpanID(id)
+	}
+	for _, p := range provenance {
+		span.Provenance = spanid.AppendProvenance(span.Provenance, spanid.Provenance{
+			Kind:         spanid.ProvenanceKind(p.Kind),
+			SourceFileID: spanid.SourceFileID(p.SourceFileID),
+			SpanID:       spanid.SpanID(p.SpanID),
+			Detail:       p.Detail,
+		})
+	}
+	return span
 }
 
 type diagLineIndex struct {

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -89,6 +89,7 @@ type selfhostPackageTokenLayout struct {
 	// the telemetry suffix drops back to `@Lnn:Cnn`).
 	fileIdx []int
 	files   []string
+	fileIDs []string
 }
 
 func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPackageTokenLayout, error) {
@@ -114,9 +115,10 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 		if displayName == "" {
 			displayName = file.Name
 		}
-		if displayName != "" {
+		if displayName != "" || file.SourceFileID != "" {
 			fileIdx = len(layout.files)
 			layout.files = append(layout.files, displayName)
+			layout.fileIDs = append(layout.fileIDs, file.SourceFileID)
 		}
 		selfhostAppendTokenLayout(layout, lexed, file.Base, fileIdx)
 		selfhostMergeAstArena(arena, parsed.arena, tokenBase)
@@ -302,6 +304,9 @@ func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhost
 		file: func(tokenIdx int) string {
 			return checkFilePathWithTokenLayout(layout, tokenIdx)
 		},
+		sourceID: func(tokenIdx int) string {
+			return checkSourceFileIDWithTokenLayout(layout, tokenIdx)
+		},
 	})
 }
 
@@ -314,6 +319,17 @@ func checkFilePathWithTokenLayout(layout *selfhostPackageTokenLayout, tokenIdx i
 		return ""
 	}
 	return layout.files[idx]
+}
+
+func checkSourceFileIDWithTokenLayout(layout *selfhostPackageTokenLayout, tokenIdx int) string {
+	if layout == nil || tokenIdx < 0 || tokenIdx >= len(layout.fileIdx) {
+		return ""
+	}
+	idx := layout.fileIdx[tokenIdx]
+	if idx < 0 || idx >= len(layout.fileIDs) {
+		return ""
+	}
+	return layout.fileIDs[idx]
 }
 
 func checkNodeRangeWithTokenLayout(layout *selfhostPackageTokenLayout, startToken, endToken int) (start, end, startLine, startColumn, endLine, endColumn int) {

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/spanid"
 )
 
 // Resolve-side types re-exported from internal/selfhost/api for compatibility.
@@ -688,6 +689,14 @@ func selfhostAnnotateResolveFiles(result *ResolveResult, files []PackageResolveF
 	}
 	for i := range result.Diagnostics {
 		result.Diagnostics[i].File = selfhostResolveFilePath(files, result.Diagnostics[i].Start)
+		result.Diagnostics[i].SourceFileID = selfhostResolveFileID(files, result.Diagnostics[i].Start)
+		if result.Diagnostics[i].SourceFileID != "" {
+			result.Diagnostics[i].SpanID = string(spanid.SpanIDFor(
+				spanid.SourceFileID(result.Diagnostics[i].SourceFileID),
+				result.Diagnostics[i].Start,
+				result.Diagnostics[i].End,
+			))
+		}
 	}
 }
 
@@ -700,6 +709,20 @@ func selfhostResolveFilePath(files []PackageResolveFile, offset int) string {
 		end := file.Base + len(file.Source)
 		if offset >= start && offset <= end {
 			return file.Path
+		}
+	}
+	return ""
+}
+
+func selfhostResolveFileID(files []PackageResolveFile, offset int) string {
+	for _, file := range files {
+		if file.SourceFileID == "" || len(file.Source) == 0 {
+			continue
+		}
+		start := file.Base
+		end := file.Base + len(file.Source)
+		if offset >= start && offset <= end {
+			return file.SourceFileID
 		}
 	}
 	return ""

--- a/internal/selfhost/resolve_surface.go
+++ b/internal/selfhost/resolve_surface.go
@@ -62,6 +62,8 @@ type ResolveDiagnosticSurfaceRecord struct {
 	File         string
 	Start        int
 	End          int
+	SourceFileID string
+	SpanID       string
 }
 
 func ResolveSurfaceFromResult(result ResolveResult) ResolveSurface {
@@ -124,6 +126,8 @@ func ResolveSurfaceFromResult(result ResolveResult) ResolveSurface {
 			File:         d.File,
 			Start:        d.Start,
 			End:          d.End,
+			SourceFileID: d.SourceFileID,
+			SpanID:       d.SpanID,
 		})
 	}
 	sort.Slice(surface.Symbols, func(i, j int) bool {

--- a/internal/sourcemap/map.go
+++ b/internal/sourcemap/map.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -16,12 +17,16 @@ type Entry struct {
 	Kind      string
 	Generated diag.Span
 	Original  diag.Span
+	// Provenance describes the derivation from Original to Generated.
+	Provenance []spanid.Provenance
 }
 
 // Map stores a coarse bidirectional mapping between canonical source emitted by
 // the formatter and the original spans carried on the AST.
 type Map struct {
-	entries []Entry
+	entries         []Entry
+	originalFileID  spanid.SourceFileID
+	generatedFileID spanid.SourceFileID
 
 	originalExactOnce sync.Once
 	originalExact     map[spanKey]*Entry
@@ -51,7 +56,11 @@ func (m *Map) Clone() *Map {
 	if m == nil || len(m.entries) == 0 {
 		return nil
 	}
-	return &Map{entries: append([]Entry(nil), m.entries...)}
+	return &Map{
+		entries:         append([]Entry(nil), m.entries...),
+		originalFileID:  m.originalFileID,
+		generatedFileID: m.generatedFileID,
+	}
 }
 
 // Compose chains this map with next. The returned map projects this map's
@@ -64,19 +73,41 @@ func (m *Map) Compose(next *Map) *Map {
 	if next == nil || len(next.entries) == 0 {
 		return m.Clone()
 	}
-	out := &Map{entries: make([]Entry, 0, len(m.entries))}
+	out := &Map{
+		entries:         make([]Entry, 0, len(m.entries)),
+		originalFileID:  next.originalFileID,
+		generatedFileID: m.generatedFileID,
+	}
 	for _, entry := range m.entries {
 		original := entry.Original
 		if remapped, ok := next.RemapSpanProjected(entry.Original); ok {
 			original = remapped
 		}
 		out.entries = append(out.entries, Entry{
-			Kind:      entry.Kind,
-			Generated: entry.Generated,
-			Original:  original,
+			Kind:       entry.Kind,
+			Generated:  entry.Generated,
+			Original:   original,
+			Provenance: append([]spanid.Provenance(nil), entry.Provenance...),
 		})
 	}
 	return out
+}
+
+// StampFileIDs attaches stable identities to every entry in the map.
+func (m *Map) StampFileIDs(originalFileID, generatedFileID spanid.SourceFileID) {
+	if m == nil {
+		return
+	}
+	m.originalFileID = originalFileID
+	m.generatedFileID = generatedFileID
+	for i := range m.entries {
+		entry := &m.entries[i]
+		entry.Original = diag.StampSpanSourceFileID(entry.Original, originalFileID)
+		entry.Generated = diag.StampSpanSourceFileID(entry.Generated, generatedFileID)
+		entry.Provenance = provenanceForEntry(*entry)
+	}
+	m.originalExactOnce = sync.Once{}
+	m.originalExact = nil
 }
 
 // RemapSpan projects a canonical/generated span back onto the original source.
@@ -85,7 +116,7 @@ func (m *Map) RemapSpan(span diag.Span) (diag.Span, bool) {
 	if entry == nil {
 		return diag.Span{}, false
 	}
-	return entry.Original, true
+	return m.remappedOriginal(span, *entry), true
 }
 
 // RemapSpanProjected projects a generated span back onto the original source
@@ -93,7 +124,8 @@ func (m *Map) RemapSpan(span diag.Span) (diag.Span, bool) {
 func (m *Map) RemapSpanProjected(span diag.Span) (diag.Span, bool) {
 	entry := m.entryForGenerated(span.Start.Offset, span.End.Offset)
 	if entry != nil {
-		return projectSpan(entry, span), true
+		projected := projectSpan(entry, span)
+		return m.remappedProjectedOriginal(projected, span, *entry), true
 	}
 	start, ok := m.RemapPos(span.Start)
 	if !ok {
@@ -125,7 +157,7 @@ func (m *Map) GeneratedSpanForOriginal(span diag.Span) (diag.Span, bool) {
 	if entry == nil {
 		return diag.Span{}, false
 	}
-	return entry.Generated, true
+	return m.generatedFromOriginal(span, *entry), true
 }
 
 func (m *Map) exactOriginalEntry(start, end int) *Entry {
@@ -160,6 +192,46 @@ func (m *Map) exactOriginalEntry(start, end int) *Entry {
 		m.originalExact = cache
 	})
 	return m.originalExact[spanKey{start: start, end: end}]
+}
+
+func (m *Map) remappedOriginal(generated diag.Span, entry Entry) diag.Span {
+	out := entry.Original
+	return m.remappedProjectedOriginal(out, generated, entry)
+}
+
+func (m *Map) remappedProjectedOriginal(out, generated diag.Span, entry Entry) diag.Span {
+	if m != nil && m.originalFileID != "" {
+		out = diag.StampSpanSourceFileID(out, m.originalFileID)
+	}
+	parent := generated
+	if parent.SourceFileID == "" {
+		parent = entry.Generated
+	}
+	if m != nil && m.generatedFileID != "" {
+		parent = diag.StampSpanSourceFileID(parent, m.generatedFileID)
+	}
+	if len(entry.Provenance) > 0 {
+		out.Provenance = spanid.AppendProvenance(out.Provenance, entry.Provenance...)
+	}
+	return diag.DeriveSpanSource(out, provenanceKindForEntryKind(entry.Kind), entry.Kind, parent)
+}
+
+func (m *Map) generatedFromOriginal(original diag.Span, entry Entry) diag.Span {
+	out := entry.Generated
+	if m != nil && m.generatedFileID != "" {
+		out = diag.StampSpanSourceFileID(out, m.generatedFileID)
+	}
+	parent := original
+	if parent.SourceFileID == "" {
+		parent = entry.Original
+	}
+	if m != nil && m.originalFileID != "" {
+		parent = diag.StampSpanSourceFileID(parent, m.originalFileID)
+	}
+	if len(entry.Provenance) > 0 {
+		out.Provenance = spanid.AppendProvenance(out.Provenance, entry.Provenance...)
+	}
+	return diag.DeriveSpanSource(out, provenanceKindForEntryKind(entry.Kind), entry.Kind, parent)
 }
 
 // RemapDiagnostic returns a deep-cloned diagnostic whose spans and structured
@@ -577,16 +649,38 @@ func (b *Builder) Build(generated []byte) *Map {
 		entries: make([]Entry, 0, len(b.entries)),
 	}
 	for _, entry := range b.entries {
-		out.entries = append(out.entries, Entry{
+		built := Entry{
 			Kind: entry.kind,
 			Generated: diag.Span{
 				Start: posForOffset(generated, lineStarts, entry.generatedFrom),
 				End:   posForOffset(generated, lineStarts, entry.generatedTo),
 			},
 			Original: entry.original,
-		})
+		}
+		built.Provenance = provenanceForEntry(built)
+		out.entries = append(out.entries, built)
 	}
 	return out
+}
+
+func provenanceForEntry(entry Entry) []spanid.Provenance {
+	if entry.Original.SourceFileID == "" && entry.Original.ID == "" {
+		return nil
+	}
+	parent := diag.StampSpanSourceFileID(entry.Original, entry.Original.SourceFileID)
+	return []spanid.Provenance{{
+		Kind:         provenanceKindForEntryKind(entry.Kind),
+		SourceFileID: parent.SourceFileID,
+		SpanID:       parent.ID,
+		Detail:       entry.Kind,
+	}}
+}
+
+func provenanceKindForEntryKind(kind string) spanid.ProvenanceKind {
+	if kind == "source-transform" {
+		return spanid.ProvenanceExpansion
+	}
+	return spanid.ProvenanceCanonical
 }
 
 func computeLineStarts(src []byte) []int {

--- a/internal/sourcemap/map_test.go
+++ b/internal/sourcemap/map_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -138,5 +139,40 @@ func TestRemapSpanKeepsLegacyWholeEntrySemantics(t *testing.T) {
 	}
 	if projected.Start.Offset != 104 || projected.End.Offset != 108 {
 		t.Fatalf("RemapSpanProjected offsets = %d..%d, want 104..108", projected.Start.Offset, projected.End.Offset)
+	}
+}
+
+func TestRemapSpanPreservesSourceIdentityAndProvenance(t *testing.T) {
+	originalID := spanid.SourceFileIDFor("/tmp/original.osty")
+	generatedID := spanid.DerivedSourceFileID(originalID, spanid.ProvenanceCanonical, "canonical")
+	original := diag.StampSpanSourceFileID(diag.Span{
+		Start: token.Pos{Offset: 10, Line: 1, Column: 11},
+		End:   token.Pos{Offset: 15, Line: 1, Column: 16},
+	}, originalID)
+	generated := diag.StampSpanSourceFileID(diag.Span{
+		Start: token.Pos{Offset: 100, Line: 5, Column: 1},
+		End:   token.Pos{Offset: 105, Line: 5, Column: 6},
+	}, generatedID)
+	sm := &Map{entries: []Entry{{
+		Kind:      "ident",
+		Generated: generated,
+		Original:  original,
+	}}}
+	sm.StampFileIDs(originalID, generatedID)
+
+	got, ok := sm.RemapSpan(generated)
+	if !ok {
+		t.Fatal("RemapSpan() = false")
+	}
+	if got.SourceFileID != originalID || got.ID == "" {
+		t.Fatalf("remapped identity = (%q, %q), want original file and non-empty span", got.SourceFileID, got.ID)
+	}
+	provenance := spanid.ProvenanceEntries(got.Provenance)
+	if len(provenance) == 0 {
+		t.Fatalf("remapped provenance is empty: %#v", got)
+	}
+	last := provenance[len(provenance)-1]
+	if last.Kind != spanid.ProvenanceCanonical || last.SourceFileID != generatedID {
+		t.Fatalf("provenance = %#v, want canonical edge from generated file", last)
 	}
 }

--- a/internal/spanid/spanid.go
+++ b/internal/spanid/spanid.go
@@ -1,0 +1,126 @@
+// Package spanid defines stable source/span identity primitives shared by
+// diagnostics, source maps, LSP, and host/selfhost adapter boundaries.
+package spanid
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// SourceFileID identifies one logical source file across compiler stages.
+type SourceFileID string
+
+// SpanID identifies one source span within a SourceFileID.
+type SpanID string
+
+// ProvenanceKind classifies why a span identity was derived from another span.
+type ProvenanceKind string
+
+const (
+	ProvenanceOriginal      ProvenanceKind = "original"
+	ProvenanceCanonical     ProvenanceKind = "canonical"
+	ProvenanceExpansion     ProvenanceKind = "expansion"
+	ProvenanceInjection     ProvenanceKind = "injection"
+	ProvenancePackageMerge  ProvenanceKind = "package_merge"
+	ProvenanceSelfhostShift ProvenanceKind = "selfhost_offset"
+)
+
+// Provenance links a derived span back to the span that produced it.
+type Provenance struct {
+	Kind         ProvenanceKind
+	SourceFileID SourceFileID
+	SpanID       SpanID
+	Detail       string
+}
+
+// ProvenanceList is referenced from comparable span structs via pointer.
+type ProvenanceList []Provenance
+
+// AppendProvenance returns a list containing prior plus entries.
+func AppendProvenance(prior *ProvenanceList, entries ...Provenance) *ProvenanceList {
+	if len(entries) == 0 {
+		return prior
+	}
+	var out ProvenanceList
+	if prior != nil {
+		out = append(out, (*prior)...)
+	}
+	out = append(out, entries...)
+	return &out
+}
+
+// ProvenanceEntries returns a nil-safe immutable view of list.
+func ProvenanceEntries(list *ProvenanceList) []Provenance {
+	if list == nil {
+		return nil
+	}
+	return *list
+}
+
+// SourceFileIDFor returns a stable, path-derived source file identity.
+func SourceFileIDFor(path string) SourceFileID {
+	clean := normalizePath(path)
+	if clean == "" {
+		clean = "<input>"
+	}
+	return SourceFileID("sf:" + shortHash(clean))
+}
+
+// DerivedSourceFileID returns an identity for generated source tied to parent.
+func DerivedSourceFileID(parent SourceFileID, kind ProvenanceKind, detail string) SourceFileID {
+	if parent == "" {
+		if detail == "" {
+			detail = string(kind)
+		}
+		return SourceFileIDFor(detail)
+	}
+	return SourceFileID("sf:" + shortHash(string(parent)+"|"+string(kind)+"|"+detail))
+}
+
+// SpanIDFor returns a stable identity for [start, end) inside fileID.
+func SpanIDFor(fileID SourceFileID, start, end int) SpanID {
+	if end < start {
+		end = start
+	}
+	return SpanID("sp:" + shortHash(string(fileID)+"|"+strconv.Itoa(start)+"|"+strconv.Itoa(end)))
+}
+
+// DerivedSpanID returns a stable identity for a generated span.
+func DerivedSpanID(fileID SourceFileID, kind ProvenanceKind, start, end int, parents ...SpanID) SpanID {
+	if end < start {
+		end = start
+	}
+	var b strings.Builder
+	b.WriteString(string(fileID))
+	b.WriteByte('|')
+	b.WriteString(string(kind))
+	b.WriteByte('|')
+	b.WriteString(strconv.Itoa(start))
+	b.WriteByte('|')
+	b.WriteString(strconv.Itoa(end))
+	for _, parent := range parents {
+		b.WriteByte('|')
+		b.WriteString(string(parent))
+	}
+	return SpanID("sp:" + shortHash(b.String()))
+}
+
+func normalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	clean := filepath.Clean(path)
+	if clean == "." && path != "." {
+		clean = path
+	}
+	return filepath.ToSlash(clean)
+}
+
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:8])
+}


### PR DESCRIPTION
## Summary

- Add a global span identity layer with `SourceFileID`, `SpanID`, and provenance records.
- Thread source identities through diagnostics, sourcemaps, canonical source materialization, query/package resolution, LSP diagnostic routing, and selfhost/native checker boundaries.
- Remap package-merged and selfhost-shifted diagnostics back onto file-relative spans with provenance, so overlays and editor diagnostics can route by identity instead of offset guesses.

## Validation

- `go test -count=1 -vet=off ./internal/query/osty ./internal/lsp ./internal/resolve ./internal/check ./internal/selfhost ./internal/sourcemap ./internal/canonical ./internal/spanid`
- `go test -count=1 -vet=off ./internal/llvmgen -run TestProbeNativeToolchainMergedMIR -timeout 15m`
- `git diff --check`