### PR TITLE
[codex] add semantic db frontend surface

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
@@ -55,6 +56,11 @@ type Result struct {
 	// stable selfhost-node-id structured surface over span-rematching through
 	// the Go AST.
 	NativeCheckResult *api.CheckResult
+
+	// SemanticDB joins the authoritative resolve and check structured facts
+	// when both phases ran through the selfhost frontend. This is the migration
+	// surface for consumers that want to leave AST-keyed maps behind.
+	SemanticDB *semanticdb.DB
 
 	// inspectSource is the single-file source used to preserve the legacy
 	// Inspect(file, result) helper without reintroducing Go-side inference
@@ -116,6 +122,15 @@ func (r *Result) NativeIndex() api.CheckResultIndex {
 		return (*api.CheckResult)(nil).Index()
 	}
 	return r.NativeCheckResult.Index()
+}
+
+// Semantic returns the central selfhost semantic database, if the current
+// checking path had enough structured frontend data to assemble one.
+func (r *Result) Semantic() *semanticdb.DB {
+	if r == nil {
+		return nil
+	}
+	return r.SemanticDB
 }
 
 // Opts bundles optional inputs to File / Package / Workspace.
@@ -192,6 +207,7 @@ func SelfhostRun(run *selfhost.FrontendRun, opts ...Opts) *Result {
 	result.Diags = append(result.Diags, nativeCheckerDiags(src, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
+	result.SemanticDB = semanticdb.FromCheck(checked)
 	diag.StampFile(result.Diags, opt.Path)
 	return result
 }

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -21,6 +21,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
@@ -420,6 +421,7 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 	result.Diags = append(result.Diags, nativeCheckerDiagsForCheckedSource(checkedSrc, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
+	result.SemanticDB = semanticdb.FromCheck(checked)
 	overlaySelfhostResult(result, checkedSrc, checked)
 }
 
@@ -427,7 +429,7 @@ func applyNativePackageResult(result *Result, pkg *resolve.Package, pr *resolve.
 	applySelfhostPackageResult(result, pkg, pr, ws, stdlib, privileged)
 }
 
-func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool) {
+func applySelfhostPackageResult(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool) {
 	if result == nil || pkg == nil {
 		return
 	}
@@ -474,6 +476,7 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 	result.Diags = append(result.Diags, nativeCheckerDiagsForCheckedSource(src, checked, policy)...)
 	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
+	attachSemanticDB(result, pr, checked)
 	overlaySelfhostResult(result, src, checked)
 }
 
@@ -481,7 +484,7 @@ func applyNativeWorkspaceResults(ws *resolve.Workspace, resolved map[string]*res
 	applySelfhostWorkspaceResults(ws, resolved, results, stdlib)
 }
 
-func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.PackageResult, results map[string]*Result, stdlib resolve.StdlibProvider) {
+func applySelfhostWorkspaceResults(ws *resolve.Workspace, resolved map[string]*resolve.PackageResult, results map[string]*Result, stdlib resolve.StdlibProvider) {
 	if ws == nil {
 		return
 	}
@@ -503,6 +506,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 	type pkgJob struct {
 		path       string
 		pkg        *resolve.Package
+		pr         *resolve.PackageResult
 		result     *Result
 		privileged bool
 	}
@@ -513,14 +517,14 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 			continue
 		}
 		privileged := isPrivilegedPackagePath(path) || isPrivilegedPackage(pkg)
-		jobs = append(jobs, pkgJob{path: path, pkg: pkg, result: result, privileged: privileged})
+		jobs = append(jobs, pkgJob{path: path, pkg: pkg, pr: resolved[path], result: result, privileged: privileged})
 	}
 	if len(jobs) == 0 {
 		return
 	}
 	if len(jobs) == 1 || os.Getenv("OSTY_CHECK_PARALLEL") == "0" {
 		for _, j := range jobs {
-			applySelfhostPackageResult(j.result, j.pkg, nil, ws, stdlib, j.privileged)
+			applySelfhostPackageResult(j.result, j.pkg, j.pr, ws, stdlib, j.privileged)
 		}
 		return
 	}
@@ -539,7 +543,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 		go func() {
 			defer wg.Done()
 			for j := range ch {
-				runSelfhostPackageResultLocked(j.result, j.pkg, ws, stdlib, j.privileged, &mu)
+				runSelfhostPackageResultLocked(j.result, j.pkg, j.pr, ws, stdlib, j.privileged, &mu)
 			}
 		}()
 	}
@@ -557,7 +561,7 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 // the shared type maps under `mu`. This is the parallel variant of
 // applySelfhostPackageResult; the single-threaded fast path in
 // applySelfhostWorkspaceResults still calls the non-locked version.
-func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool, mu *sync.Mutex) {
+func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool, mu *sync.Mutex) {
 	if result == nil || pkg == nil {
 		return
 	}
@@ -615,7 +619,19 @@ func runSelfhostPackageResultLocked(result *Result, pkg *resolve.Package, ws *re
 	result.Diags = append(result.Diags, diags...)
 	result.NativeCheckerTelemetry = telemetry
 	result.NativeCheckResult = cloneNativeCheckResult(checked)
+	attachSemanticDB(result, pr, checked)
 	overlaySelfhostResult(result, src, checked)
+}
+
+func attachSemanticDB(result *Result, pr *resolve.PackageResult, checked api.CheckResult) {
+	if result == nil {
+		return
+	}
+	if pr != nil && pr.SemanticDB != nil {
+		result.SemanticDB = pr.SemanticDB.WithCheck(checked)
+		return
+	}
+	result.SemanticDB = semanticdb.FromCheck(checked)
 }
 
 func cloneNativeCheckResult(checked api.CheckResult) *api.CheckResult {

--- a/internal/check/semanticdb_test.go
+++ b/internal/check/semanticdb_test.go
@@ -1,0 +1,53 @@
+package check
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestPackageResultCarriesCombinedSemanticDB(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn id<T>(x: T) -> T {
+    x
+}
+
+fn main() -> Int {
+    id::<Int>(1)
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := resolve.LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	pr := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	if pr == nil || pr.SemanticDB == nil {
+		t.Fatalf("ResolvePackage SemanticDB = %#v, want non-nil", pr)
+	}
+
+	result := Package(pkg, pr)
+	if result == nil || result.SemanticDB == nil {
+		t.Fatalf("Package SemanticDB = %#v, want non-nil", result)
+	}
+	if result.SemanticDB.Resolve.PackageID != pr.SemanticDB.Resolve.PackageID {
+		t.Fatalf("resolve PackageID = %q, want %q", result.SemanticDB.Resolve.PackageID, pr.SemanticDB.Resolve.PackageID)
+	}
+	if result.SemanticDB.Check == nil {
+		t.Fatal("SemanticDB Check is nil")
+	}
+	if len(result.SemanticDB.Check.TypedNodes) == 0 {
+		t.Fatalf("SemanticDB typed nodes are empty: %#v", result.SemanticDB.Check)
+	}
+	if len(result.SemanticDB.CheckIndex().InstantiationsByStableID) == 0 {
+		t.Fatalf("SemanticDB instantiation index is empty: %#v", result.SemanticDB.Check.Instantiations)
+	}
+	if pr.SemanticDB.Check != nil {
+		t.Fatal("checker attachment mutated the resolve PackageResult DB")
+	}
+}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -238,6 +238,10 @@ func (s *Server) handleHover(req *rpcRequest) {
 		return
 	}
 	pos := doc.analysis.lines.lspToOsty(params.Position)
+	if h, ok := semanticHoverAt(doc.analysis, pos); ok {
+		replyJSON(s.conn, req.ID, h)
+		return
+	}
 
 	var (
 		node     ast.Node
@@ -260,6 +264,72 @@ func (s *Server) handleHover(req *rpcRequest) {
 	h.Range = ptrRange(doc.analysis.lines.ostyRange(
 		diag.Span{Start: node.Pos(), End: node.End()}))
 	replyJSON(s.conn, req.ID, h)
+}
+
+func semanticHoverAt(a *docAnalysis, pos token.Pos) (*Hover, bool) {
+	if a == nil || a.semantic == nil {
+		return nil, false
+	}
+	hover, ok := a.semantic.HoverAt(a.sourcePath, pos.Offset)
+	if !ok || hover.Name == "" {
+		return nil, false
+	}
+	typeText := ""
+	if hover.Type != nil {
+		typeText = hover.Type.String()
+	}
+	docText, fallbackType := semanticHoverLegacyContext(a, pos)
+	if typeText == "" {
+		typeText = fallbackType
+	}
+	view := selfhost.LSPSymbolView{
+		Name:     hover.Name,
+		Kind:     semanticHoverKind(hover.Kind),
+		TypeText: typeText,
+		DocText:  docText,
+		HasSym:   true,
+	}
+	return &Hover{
+		Contents: MarkupContent{
+			Kind:  MarkupKindMarkdown,
+			Value: selfhost.LSPHoverMarkdown(view),
+		},
+		Range: ptrRange(a.lines.rangeFromOffsets(hover.Span.Start, hover.Span.End)),
+	}, true
+}
+
+func semanticHoverLegacyContext(a *docAnalysis, pos token.Pos) (docText string, typeText string) {
+	if a == nil {
+		return "", ""
+	}
+	var sym *resolve.Symbol
+	if _, hit := findIdentAt(a, pos); hit != nil {
+		sym = hit
+	} else if _, hit := findNamedTypeAt(a, pos); hit != nil {
+		sym = hit
+	}
+	if sym == nil {
+		return "", ""
+	}
+	if a.check != nil {
+		if t := a.check.LookupSymType(sym); t != nil {
+			typeText = t.String()
+		}
+	}
+	return symbolDoc(sym), typeText
+}
+
+func semanticHoverKind(kind string) string {
+	switch kind {
+	case "fn":
+		return "function"
+	case "value":
+		return "binding"
+	case "generic":
+		return "type parameter"
+	default:
+		return kind
+	}
 }
 
 // hoverForSymbol formats the markdown block shown on hover. The
@@ -381,6 +451,10 @@ func (s *Server) handleDefinition(req *rpcRequest) {
 		return
 	}
 	pos := doc.analysis.lines.lspToOsty(params.Position)
+	if loc, ok := semanticDefinitionAt(doc, pos); ok {
+		replyJSON(s.conn, req.ID, loc)
+		return
+	}
 
 	var sym *resolve.Symbol
 	if _, s2 := findIdentAt(doc.analysis, pos); s2 != nil {
@@ -404,6 +478,33 @@ func (s *Server) handleDefinition(req *rpcRequest) {
 		End:   sym.Decl.End(),
 	})
 	replyJSON(s.conn, req.ID, Location{URI: params.TextDocument.URI, Range: rng})
+}
+
+func semanticDefinitionAt(doc *document, pos token.Pos) (Location, bool) {
+	if doc == nil {
+		return Location{}, false
+	}
+	a := doc.analysis
+	if a == nil || a.semantic == nil {
+		return Location{}, false
+	}
+	sp, ok := a.semantic.DefinitionAt(a.sourcePath, pos.Offset)
+	if !ok || sp.File == "" {
+		return Location{}, false
+	}
+	uri := doc.uri
+	if sp.File != a.sourcePath {
+		uri = pathToURI(sp.File)
+	}
+	li := a.lines
+	if sp.File != a.sourcePath {
+		file := a.semantic.FileForPath(sp.File)
+		if file == nil {
+			return Location{}, false
+		}
+		li = newLineIndex(file.OriginalSourceBytes())
+	}
+	return Location{URI: uri, Range: li.rangeFromOffsets(sp.Start, sp.End)}, true
 }
 
 // ---- Formatting ----

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/semanticdb"
 )
 
 // handleReferences answers `textDocument/references`. When available, it uses
@@ -23,6 +24,10 @@ func (s *Server) handleReferences(req *rpcRequest) {
 	doc := s.docs.get(params.TextDocument.URI)
 	if doc == nil || doc.analysis == nil {
 		replyJSON(s.conn, req.ID, []Location{})
+		return
+	}
+	if locs, ok := s.semanticReferences(doc, params.Position, params.Context.IncludeDeclaration); ok {
+		replyJSON(s.conn, req.ID, locs)
 		return
 	}
 	if ref := structuredReferenceAt(doc, params.Position); ref != nil {
@@ -73,6 +78,10 @@ func (s *Server) handleRename(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, nil)
 		return
 	}
+	if edits, ok := s.semanticRenameEdits(doc, params.Position, params.NewName); ok {
+		replyJSON(s.conn, req.ID, &WorkspaceEdit{Changes: edits})
+		return
+	}
 	if ref := structuredReferenceAt(doc, params.Position); ref != nil {
 		if ref.targetSymbolID == "" {
 			replyJSON(s.conn, req.ID, nil)
@@ -110,6 +119,57 @@ func (s *Server) handleRename(req *rpcRequest) {
 	}
 	edits := s.renameEditsFor(doc, target, params.NewName)
 	replyJSON(s.conn, req.ID, &WorkspaceEdit{Changes: edits})
+}
+
+func (s *Server) semanticReferences(doc *document, lspPos Position, includeDecl bool) ([]Location, bool) {
+	if doc == nil || doc.analysis == nil || doc.analysis.semantic == nil {
+		return nil, false
+	}
+	pos := doc.analysis.lines.lspToOsty(lspPos)
+	spans, _, ok := doc.analysis.semantic.ReferencesAt(doc.analysis.sourcePath, pos.Offset, includeDecl)
+	if !ok {
+		return []Location{}, true
+	}
+	return sortDedupLocations(locationsFromSemanticSpans(doc, spans)), true
+}
+
+func (s *Server) semanticRenameEdits(doc *document, lspPos Position, newName string) (map[string][]TextEdit, bool) {
+	if doc == nil || doc.analysis == nil || doc.analysis.semantic == nil {
+		return nil, false
+	}
+	pos := doc.analysis.lines.lspToOsty(lspPos)
+	spans, target, ok := doc.analysis.semantic.ReferencesAt(doc.analysis.sourcePath, pos.Offset, true)
+	if !ok {
+		return nil, false
+	}
+	if target.Kind == "builtin" {
+		return nil, false
+	}
+	out := map[string][]TextEdit{}
+	for _, loc := range sortDedupLocations(locationsFromSemanticSpans(doc, spans)) {
+		out[loc.URI] = append(out[loc.URI], TextEdit{Range: loc.Range, NewText: newName})
+	}
+	return out, true
+}
+
+func locationsFromSemanticSpans(doc *document, spans []semanticdb.Span) []Location {
+	out := make([]Location, 0, len(spans))
+	for _, sp := range spans {
+		uri := doc.uri
+		src := doc.src
+		if sp.File != "" && sp.File != doc.analysis.sourcePath {
+			uri = pathToURI(sp.File)
+			if file := doc.analysis.semantic.FileForPath(sp.File); file != nil {
+				src = file.OriginalSourceBytes()
+			}
+		}
+		li := doc.analysis.lines
+		if sp.File != "" && sp.File != doc.analysis.sourcePath {
+			li = newLineIndex(src)
+		}
+		out = append(out, Location{URI: uri, Range: li.rangeFromOffsets(sp.Start, sp.End)})
+	}
+	return out
 }
 
 // targetSymbolAt resolves the identifier under an LSP Position to the

--- a/internal/lsp/selfhost_policy_test.go
+++ b/internal/lsp/selfhost_policy_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -115,6 +117,107 @@ func TestHoverMarkdownWrapsSelfHostedPolicy(t *testing.T) {
 	if want := "```osty\nraw\n```"; fallback != want {
 		t.Fatalf("fallback markdown = %q, want %q", fallback, want)
 	}
+}
+
+func TestSemanticHoverUsesSemanticDB(t *testing.T) {
+	path := "/tmp/main.osty"
+	src, declStart, refStart, db := semanticNavFixture(path)
+	hover, ok := semanticHoverAt(&docAnalysis{
+		sourcePath: path,
+		lines:      newLineIndex(src),
+		semantic:   db,
+	}, token.Pos{Offset: refStart + 1})
+	if !ok {
+		t.Fatal("semanticHoverAt returned !ok")
+	}
+	if !strings.Contains(hover.Contents.Value, "helper") || !strings.Contains(hover.Contents.Value, "Int") {
+		t.Fatalf("semantic hover markdown = %q, want helper with Int type", hover.Contents.Value)
+	}
+	wantRange := newLineIndex(src).rangeFromOffsets(refStart, refStart+len("helper"))
+	if hover.Range == nil || *hover.Range != wantRange {
+		t.Fatalf("semantic hover range = %#v, want %#v", hover.Range, wantRange)
+	}
+	if declStart < 0 {
+		t.Fatal("fixture did not find helper declaration")
+	}
+}
+
+func TestSemanticDefinitionReferencesAndRenameUseSemanticDB(t *testing.T) {
+	path := "/tmp/main.osty"
+	src, declStart, refStart, db := semanticNavFixture(path)
+	a := &docAnalysis{
+		sourcePath: path,
+		lines:      newLineIndex(src),
+		semantic:   db,
+	}
+	doc := &document{uri: pathToURI(path), src: src, analysis: a}
+	refPos := a.lines.offsetToLSP(refStart + 1)
+
+	def, ok := semanticDefinitionAt(doc, token.Pos{Offset: refStart + 1})
+	if !ok {
+		t.Fatal("semanticDefinitionAt returned !ok")
+	}
+	if def.Range != a.lines.rangeFromOffsets(declStart, declStart+len("helper")) {
+		t.Fatalf("definition range = %#v, want helper decl", def.Range)
+	}
+
+	locs, ok := (&Server{}).semanticReferences(doc, refPos, true)
+	if !ok {
+		t.Fatal("semanticReferences returned !ok")
+	}
+	if len(locs) != 2 {
+		t.Fatalf("semantic references = %#v, want use + decl", locs)
+	}
+	edits, ok := (&Server{}).semanticRenameEdits(doc, refPos, "renamed")
+	if !ok {
+		t.Fatal("semanticRenameEdits returned !ok")
+	}
+	if got := len(edits[doc.uri]); got != 2 {
+		t.Fatalf("rename edits = %#v, want 2 edits for document", edits)
+	}
+}
+
+func semanticNavFixture(path string) ([]byte, int, int, *semanticdb.DB) {
+	src := []byte("fn helper() -> Int { 1 }\nfn main() -> Int { helper() }\n")
+	declStart := strings.Index(string(src), "helper")
+	refStart := strings.LastIndex(string(src), "helper")
+	db := semanticdb.New([]semanticdb.File{{Path: path, Source: src}}, api.ResolveResult{
+		PackageID: "pkg",
+		Symbols: []api.ResolvedSymbol{{
+			ID:    "sym-helper",
+			File:  path,
+			Node:  1,
+			Name:  "helper",
+			Kind:  "fn",
+			Start: declStart,
+			End:   declStart + len("helper"),
+		}},
+		Refs: []api.ResolvedRef{{
+			ID:             "ref-helper",
+			File:           path,
+			Node:           2,
+			Name:           "helper",
+			Start:          refStart,
+			End:            refStart + len("helper"),
+			TargetSymbolID: "sym-helper",
+			TargetFile:     path,
+			TargetNode:     1,
+			TargetStart:    declStart,
+			TargetEnd:      declStart + len("helper"),
+		}},
+	}).WithCheck(api.CheckResult{
+		Symbols: []api.CheckedSymbol{{
+			Name: "helper",
+			Kind: "fn",
+			Type: &api.TypeRepr{
+				Kind:   "fn",
+				Return: &api.TypeRepr{Kind: "primitive", Name: "Int"},
+			},
+			Start: declStart,
+			End:   declStart + len("helper"),
+		}},
+	})
+	return src, declStart, refStart, db
 }
 
 func TestFindNameOffsetUsesSelfHostedLexerPolicy(t *testing.T) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -21,6 +21,7 @@ import (
 	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -299,12 +300,14 @@ type document struct {
 // is fast enough that incremental reuse isn't worth the complexity
 // at this stage.
 type docAnalysis struct {
+	sourcePath string
 	lines      *lineIndex
 	file       *ast.File
 	provenance *parser.Provenance
 	canonical  []byte
 	resolve    *resolve.Result
 	check      *check.Result
+	semantic   *semanticdb.DB
 	// lint is the lint pass output (may be nil if the pipeline
 	// skipped linting, e.g. a future mode flag). Downstream handlers
 	// use it for the source.organizeImports / source.fixAll actions
@@ -607,14 +610,20 @@ func (s *Server) analyzePackageViaEngine(pkgDir, path string, src []byte) *docAn
 	if rp != nil && rp.Package() != nil {
 		packages = []*resolve.Package{rp.Package()}
 	}
+	var prResult *resolve.PackageResult
+	if rp != nil {
+		prResult = rp.PackageResult()
+	}
 
 	return &docAnalysis{
+		sourcePath:        key,
 		lines:             newLineIndex(src),
 		file:              pr.File,
 		provenance:        pr.Provenance,
 		canonical:         pr.CanonicalSource,
 		resolve:           rr,
 		check:             chk,
+		semantic:          semanticDBForAnalysis(chk, prResult),
 		lint:              lr,
 		diags:             all,
 		identIndex:        idx,
@@ -772,12 +781,14 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 	allDiags := collectDiagsForFile(pkg, pr, chk, lr, pf)
 
 	return &docAnalysis{
+		sourcePath:        key,
 		lines:             newLineIndex(src),
 		file:              pf.File,
 		provenance:        pf.ParseProvenance,
 		canonical:         pf.CanonicalSource,
 		resolve:           rr,
 		check:             chk,
+		semantic:          semanticDBForAnalysis(chk, pr),
 		lint:              lr,
 		diags:             allDiags,
 		identIndex:        identIndexForFile(pkg, path, rr),
@@ -936,12 +947,14 @@ func analysisForFileInPackage(
 	}
 	all := collectDiagsForFile(pkg, pr, chk, lr, pf)
 	return &docAnalysis{
+		sourcePath:        path,
 		lines:             newLineIndex(src),
 		file:              pf.File,
 		provenance:        pf.ParseProvenance,
 		canonical:         pf.CanonicalSource,
 		resolve:           fileRes,
 		check:             chk,
+		semantic:          semanticDBForAnalysis(chk, pr),
 		lint:              lr,
 		diags:             all,
 		identIndex:        identIndexForFile(pkg, path, fileRes),
@@ -1078,13 +1091,19 @@ func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis
 	if rp != nil && rp.Package() != nil {
 		packages = []*resolve.Package{rp.Package()}
 	}
+	var prResult *resolve.PackageResult
+	if rp != nil {
+		prResult = rp.PackageResult()
+	}
 	return &docAnalysis{
+		sourcePath:        key,
 		lines:             newLineIndex(src),
 		file:              pr.File,
 		provenance:        pr.Provenance,
 		canonical:         pr.CanonicalSource,
 		resolve:           rr,
 		check:             chk,
+		semantic:          semanticDBForAnalysis(chk, prResult),
 		lint:              lr,
 		diags:             all,
 		identIndex:        idx,
@@ -1093,6 +1112,16 @@ func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis
 		structuredSymbols: buildStructuredSymbols(packages),
 		structuredImports: buildStructuredImports(packages),
 	}
+}
+
+func semanticDBForAnalysis(chk *check.Result, pr *resolve.PackageResult) *semanticdb.DB {
+	if chk != nil && chk.Semantic() != nil {
+		return chk.Semantic()
+	}
+	if pr != nil {
+		return pr.SemanticDB
+	}
+	return nil
 }
 
 // engineKeyForURI converts an LSP URI to the engine's canonical key.

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osty/osty/internal/query"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/spanid"
 )
@@ -59,6 +60,14 @@ func (rp *ResolvedPackage) Package() *resolve.Package { return rp.pkg }
 // PackageResult returns the resolver's summary output (package scope
 // and diagnostics). Read-only.
 func (rp *ResolvedPackage) PackageResult() *resolve.PackageResult { return rp.res }
+
+// SemanticDB returns the package's authoritative selfhost semantic database.
+func (rp *ResolvedPackage) SemanticDB() *semanticdb.DB {
+	if rp == nil || rp.res == nil {
+		return nil
+	}
+	return rp.res.SemanticDB
+}
 
 // FileResult produces a per-file resolve.Result slice for the given
 // path. Returns nil if the path does not belong to this package.
@@ -142,6 +151,18 @@ func (rw *ResolvedWorkspace) ResolvedByDir(dir string) *ResolvedPackage {
 	return rw.resolved[dir]
 }
 
+// SemanticDBByDir returns the resolve-phase semantic database for dir.
+func (rw *ResolvedWorkspace) SemanticDBByDir(dir string) *semanticdb.DB {
+	if rw == nil {
+		return nil
+	}
+	pr := rw.results[dir]
+	if pr == nil {
+		return nil
+	}
+	return pr.SemanticDB
+}
+
 // DirForPath returns the normalized directory of the package that
 // contains the given file path, or "" if the file is not in any
 // workspace package.
@@ -203,6 +224,15 @@ func (wcr *WorkspaceCheckResult) ResultByDir(dir string) *check.Result {
 		return nil
 	}
 	return wcr.byDir[dir]
+}
+
+// SemanticDBByDir returns the combined resolve/check semantic database for dir.
+func (wcr *WorkspaceCheckResult) SemanticDBByDir(dir string) *semanticdb.DB {
+	result := wcr.ResultByDir(dir)
+	if result == nil {
+		return nil
+	}
+	return result.Semantic()
 }
 
 // Len returns the number of packages with check results.

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -346,6 +346,33 @@ func TestResolveDiagnosticsUseNativeStructuredResult(t *testing.T) {
 	}
 }
 
+func TestSemanticDBAccessorsExposeResolveAndCheckFacts(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := NormalizePath("/tmp/pkg_semanticdb")
+	path := seedFile(eng, dir, "main.osty", "fn id<T>(x: T) -> T { x }\nfn main() { let value = id::<Int>(1) }\n")
+
+	rp := eng.Queries.ResolvePackage.Get(eng.DB, dir)
+	if rp == nil || rp.SemanticDB() == nil {
+		t.Fatalf("ResolvePackage SemanticDB = %#v, want non-nil", rp)
+	}
+	if rp.SemanticDB().FileForPath(path) == nil {
+		t.Fatalf("SemanticDB missing file %q", path)
+	}
+
+	chk := eng.Queries.CheckFile.Get(eng.DB, path)
+	if chk == nil || chk.Semantic() == nil {
+		t.Fatalf("CheckFile SemanticDB = %#v, want non-nil", chk)
+	}
+	if chk.Semantic().Check == nil {
+		t.Fatal("combined SemanticDB missing checker facts")
+	}
+	if len(chk.Semantic().CheckIndex().InstantiationsByStableID) == 0 {
+		t.Fatalf("combined SemanticDB instantiations = %#v, want generic call facts", chk.Semantic().Check.Instantiations)
+	}
+}
+
 func TestNormalizePathIdempotent(t *testing.T) {
 	samples := []string{
 		"/abs/path/main.osty",

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
@@ -24,16 +25,18 @@ type nativeResolveCache struct {
 	check      api.CheckResult
 	checkInput api.PackageCheckInput
 	files      []nativeResolveFileInfo
+	db         *semanticdb.DB
 	err        error
 }
 
 type nativeResolveFileInfo struct {
-	path       string
-	sourceID   spanid.SourceFileID
-	base       int
-	source     []byte
-	sourceMap  *sourcemap.Map
-	lineStarts []int
+	path           string
+	sourceID       spanid.SourceFileID
+	base           int
+	source         []byte
+	originalSource []byte
+	sourceMap      *sourcemap.Map
+	lineStarts     []int
 }
 
 // NativeResolutionRow is one human-readable row derived from the selfhost
@@ -103,6 +106,17 @@ func NativeStructuredResult(pkg *Package) (api.ResolveResult, error) {
 	return result, err
 }
 
+// NativeSemanticDB returns the cached semantic database for pkg's selfhost
+// resolver run. The DB is read-only and can be shared by LSP/query/backend code
+// that wants stable resolver facts without projecting through Go AST maps.
+func NativeSemanticDB(pkg *Package) (*semanticdb.DB, error) {
+	_, _, err := nativeResolveArtifacts(pkg)
+	if err != nil {
+		return nil, err
+	}
+	return pkg.nativeResolve.db, nil
+}
+
 // NativeResolutionRows returns the cached selfhost resolve rows for one file in
 // pkg, sorted by source position.
 func NativeResolutionRows(pkg *Package, path string) ([]NativeResolutionRow, error) {
@@ -170,6 +184,7 @@ func nativeResolveArtifacts(pkg *Package) (api.ResolveResult, []nativeResolveFil
 		}
 		pkg.nativeResolve.result = resolved
 		pkg.nativeResolve.files = files
+		pkg.nativeResolve.db = semanticdb.New(nativeResolveSemanticFiles(files), resolved)
 	})
 	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.err
 }
@@ -186,6 +201,22 @@ func nativeResolveFactArtifacts(pkg *Package) (api.ResolveResult, []nativeResolv
 		}
 	})
 	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.check, pkg.nativeResolve.err
+}
+
+func nativeResolveSemanticFiles(files []nativeResolveFileInfo) []semanticdb.File {
+	out := make([]semanticdb.File, 0, len(files))
+	for _, file := range files {
+		out = append(out, semanticdb.File{
+			Path:           file.path,
+			Name:           filepath.Base(file.path),
+			Base:           file.base,
+			Source:         append([]byte(nil), file.source...),
+			OriginalSource: append([]byte(nil), file.originalSource...),
+			SourceMap:      file.sourceMap,
+			LineStarts:     append([]int(nil), file.lineStarts...),
+		})
+	}
+	return out
 }
 
 // nativeCfgEnvFor picks the `#[cfg(...)]` evaluation env the native resolver
@@ -236,12 +267,13 @@ func nativeResolveInput(pkg *Package) (api.PackageResolveInput, []nativeResolveF
 			SourceFileID: string(sourceFileIDForPackageFile(pf)),
 		})
 		files = append(files, nativeResolveFileInfo{
-			path:       pf.Path,
-			sourceID:   sourceFileIDForPackageFile(pf),
-			base:       base,
-			source:     append([]byte(nil), src...),
-			sourceMap:  pf.CheckerSourceMap(),
-			lineStarts: nativeResolveLineStarts(src),
+			path:           pf.Path,
+			sourceID:       sourceFileIDForPackageFile(pf),
+			base:           base,
+			source:         append([]byte(nil), src...),
+			originalSource: append([]byte(nil), pf.Source...),
+			sourceMap:      pf.CheckerSourceMap(),
+			lineStarts:     nativeResolveLineStarts(src),
 		})
 		base += len(src) + 1
 	}

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/spanid"
 )
@@ -245,6 +246,10 @@ type PackageResult struct {
 	// non-`use` top-level declarations live here regardless of which
 	// file they were parsed from.
 	PackageScope *Scope
+	// SemanticDB carries the authoritative selfhost resolver facts in a stable
+	// structured form. Legacy fields above remain populated for existing
+	// consumers; new consumers should prefer this DB over AST-keyed projections.
+	SemanticDB *semanticdb.DB
 	// Diags is every diagnostic produced by the parser (across all
 	// files) and the resolver, in a deterministic order.
 	Diags []*diag.Diagnostic

--- a/internal/resolve/resolve_bridge.go
+++ b/internal/resolve/resolve_bridge.go
@@ -21,6 +21,7 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 			},
 		}
 	}
+	semanticDB := pkg.nativeResolve.db
 
 	pkgScope := NewScope(prelude, "package:"+pkg.Name)
 	diags := nativeParseDiagnostics(pkg)
@@ -63,7 +64,7 @@ func resolvePackageViaNative(pkg *Package, prelude *Scope) *PackageResult {
 	pkg.PkgScope = pkgScope
 
 	diags = append(diags, nativeResolveDiagnosticsFromArtifacts(result, files)...)
-	return &PackageResult{PackageScope: pkgScope, Diags: diags}
+	return &PackageResult{PackageScope: pkgScope, SemanticDB: semanticDB, Diags: diags}
 }
 
 func nativeParseDiagnostics(pkg *Package) []*diag.Diagnostic {

--- a/internal/resolve/semanticdb_test.go
+++ b/internal/resolve/semanticdb_test.go
@@ -1,0 +1,127 @@
+package resolve
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestNativeSemanticDBKeepsResolveFactsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	helperPath := filepath.Join(dir, "helper.osty")
+	mainPath := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(helperPath, []byte(`pub fn helper() -> Int {
+    1
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mainPath, []byte(`fn main() -> Int {
+    helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	selfhost.ResetAstbridgeLowerCount()
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	db, err := NativeSemanticDB(pkg)
+	if err != nil {
+		t.Fatalf("NativeSemanticDB: %v", err)
+	}
+	if db == nil {
+		t.Fatal("NativeSemanticDB returned nil")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("NativeSemanticDB astbridge count = %d, want 0", got)
+	}
+	if db.PackageID == "" {
+		t.Fatal("SemanticDB PackageID is empty")
+	}
+	if len(db.Files) != 2 {
+		t.Fatalf("SemanticDB files = %d, want 2", len(db.Files))
+	}
+
+	var helperID string
+	for _, sym := range db.Resolve.Symbols {
+		if sym.Name == "helper" && sym.Kind == "fn" {
+			helperID = sym.ID
+			break
+		}
+	}
+	if helperID == "" {
+		t.Fatalf("missing helper symbol in SemanticDB: %#v", db.Resolve.Symbols)
+	}
+	refs := db.ResolveIndex().RefsByTargetSymbolID[helperID]
+	if len(refs) == 0 {
+		t.Fatalf("SemanticDB refs by helper target are empty; refs=%#v", db.Resolve.Refs)
+	}
+	if refs[0].File != mainPath {
+		t.Fatalf("helper ref file = %q, want %q", refs[0].File, mainPath)
+	}
+}
+
+func TestResolvePackageAttachesSemanticDB(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() -> Int {
+    1
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	pr := ResolvePackage(pkg, NewPrelude())
+	if pr == nil || pr.SemanticDB == nil {
+		t.Fatalf("ResolvePackage SemanticDB = %#v, want non-nil", pr)
+	}
+	if pr.SemanticDB.Resolve.Summary.Symbols == 0 {
+		t.Fatalf("SemanticDB resolve summary = %#v, want symbols", pr.SemanticDB.Resolve.Summary)
+	}
+}
+
+func TestSemanticDBKeepsOriginalSourceForSourceMappedSpans(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	raw := []byte(`fn main() {
+    let mut items = [1]
+    let count = len(items)
+    items = append(items, count)
+}
+`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	pr := ResolvePackage(pkg, NewPrelude())
+	if pr == nil || pr.SemanticDB == nil {
+		t.Fatalf("ResolvePackage SemanticDB = %#v, want non-nil", pr)
+	}
+	file := pr.SemanticDB.FileForPath(path)
+	if file == nil {
+		t.Fatalf("SemanticDB missing file %q", path)
+	}
+	if !bytes.Equal(file.OriginalSourceBytes(), raw) {
+		t.Fatalf("OriginalSourceBytes = %q, want raw source", file.OriginalSourceBytes())
+	}
+	if file.SourceMap == nil {
+		t.Fatal("SemanticDB SourceMap is nil, want canonical-to-original map")
+	}
+	if bytes.Equal(file.Source, file.OriginalSourceBytes()) {
+		t.Fatal("SemanticDB canonical source unexpectedly equals original source")
+	}
+}

--- a/internal/semanticdb/db.go
+++ b/internal/semanticdb/db.go
@@ -1,0 +1,669 @@
+// Package semanticdb collects authoritative frontend facts in one stable,
+// structured surface. It is intentionally independent from the legacy Go AST,
+// resolver.Scope, and check.Result maps so new consumers can move away from
+// span rematching and AST-keyed overlays one query at a time.
+package semanticdb
+
+import (
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/token"
+)
+
+// File describes one source segment that contributed facts to the DB. Offsets
+// in Resolve and Check facts are package offsets; Base converts them back to a
+// file-relative span before CanonicalMap is applied.
+type File struct {
+	Path           string
+	Name           string
+	Base           int
+	Source         []byte
+	OriginalSource []byte
+	SourceMap      *sourcemap.Map
+	LineStarts     []int
+}
+
+// DB is the central semantic database for one frontend run/package. Resolve is
+// always value-owned by the DB. Check is optional because resolve-only callers
+// can build the DB before type checking runs.
+type DB struct {
+	PackageID string
+	Files     []File
+	Resolve   api.ResolveResult
+	Check     *api.CheckResult
+
+	resolveIndex *ResolveIndex
+	checkIndex   *api.CheckResultIndex
+}
+
+// New builds a DB from resolved facts and source segments.
+func New(files []File, resolved api.ResolveResult) *DB {
+	db := &DB{
+		PackageID: resolved.PackageID,
+		Files:     cloneFiles(files),
+		Resolve:   resolved,
+	}
+	return db
+}
+
+// FromCheck builds a check-only DB. It is useful for arena-direct or
+// single-file checker paths that do not have a package resolve DB yet.
+func FromCheck(checked api.CheckResult) *DB {
+	checked.EnsureStableIDs()
+	return &DB{Check: &checked}
+}
+
+// WithCheck returns a shallow DB copy with checked facts attached. The original
+// DB remains resolve-only, which lets resolver caches stay read-only.
+func (db *DB) WithCheck(checked api.CheckResult) *DB {
+	checked.EnsureStableIDs()
+	if db == nil {
+		return FromCheck(checked)
+	}
+	out := *db
+	out.Check = &checked
+	out.checkIndex = nil
+	return &out
+}
+
+// ResolveIndex returns stable lookup tables over resolver facts.
+func (db *DB) ResolveIndex() ResolveIndex {
+	if db == nil {
+		return emptyResolveIndex()
+	}
+	if db.resolveIndex == nil {
+		idx := buildResolveIndex(&db.Resolve)
+		db.resolveIndex = &idx
+	}
+	return *db.resolveIndex
+}
+
+// CheckIndex returns stable lookup tables over checker facts.
+func (db *DB) CheckIndex() api.CheckResultIndex {
+	if db == nil || db.Check == nil {
+		return (*api.CheckResult)(nil).Index()
+	}
+	if db.checkIndex == nil {
+		idx := db.Check.Index()
+		db.checkIndex = &idx
+	}
+	return *db.checkIndex
+}
+
+// FileForPath returns the source segment for path, if present.
+func (db *DB) FileForPath(path string) *File {
+	if db == nil || path == "" {
+		return nil
+	}
+	for i := range db.Files {
+		if db.Files[i].Path == path {
+			return &db.Files[i]
+		}
+	}
+	return nil
+}
+
+// FileForOffset returns the source segment that owns a package offset.
+func (db *DB) FileForOffset(offset int) *File {
+	if db == nil {
+		return nil
+	}
+	for i := range db.Files {
+		file := &db.Files[i]
+		if len(file.Source) == 0 {
+			continue
+		}
+		if offset >= file.Base && offset <= file.Base+len(file.Source) {
+			return file
+		}
+	}
+	return nil
+}
+
+// OriginalSourceBytes returns the source bytes that original/source-mapped DB
+// spans address. It falls back to Source when no canonicalization occurred.
+func (f *File) OriginalSourceBytes() []byte {
+	if f == nil {
+		return nil
+	}
+	if len(f.OriginalSource) > 0 {
+		return f.OriginalSource
+	}
+	return f.Source
+}
+
+// PackageOffset converts a file-relative byte offset to the DB's package-wide
+// offset space.
+func (db *DB) PackageOffset(path string, relative int) (int, bool) {
+	file := db.FileForPath(path)
+	if file == nil || relative < 0 || relative > len(file.Source) {
+		return 0, false
+	}
+	return file.Base + relative, true
+}
+
+// OriginalOffset maps a package offset back to the original file's byte offset.
+// If the file has no canonical source map, the file-relative offset is returned.
+func (db *DB) OriginalOffset(path string, packageOffset int) (int, bool) {
+	file := db.FileForPath(path)
+	if file == nil {
+		return 0, false
+	}
+	rel := packageOffset - file.Base
+	if rel < 0 || rel > len(file.Source) {
+		return 0, false
+	}
+	if file.SourceMap == nil {
+		return rel, true
+	}
+	remapped, ok := file.SourceMap.RemapSpan(diag.Span{
+		Start: token.Pos{Offset: rel},
+		End:   token.Pos{Offset: rel},
+	})
+	if !ok {
+		return 0, false
+	}
+	return remapped.Start.Offset, true
+}
+
+// NodeKey identifies a selfhost node in package offset space.
+type NodeKey struct {
+	File       string
+	Node       int
+	Start, End int
+}
+
+// Span is an original-source byte span. It is what editor-facing consumers want
+// after DB offsets and canonical source maps have been resolved.
+type Span struct {
+	File       string
+	Start, End int
+}
+
+// Hover describes the best semantic record at a source offset.
+type Hover struct {
+	Name   string
+	Kind   string
+	Type   *api.TypeRepr
+	Span   Span
+	Target *api.ResolvedSymbol
+}
+
+// Target is a resolved symbol identity selected at a source offset.
+type Target struct {
+	SymbolID string
+	Name     string
+	Kind     string
+	Span     Span
+	DeclSpan Span
+	Symbol   *api.ResolvedSymbol
+}
+
+// ResolvedRefAt returns the narrowest value/name reference containing offset.
+func (db *DB) ResolvedRefAt(path string, offset int) *api.ResolvedRef {
+	if db == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Resolve.Refs {
+		rec := &db.Resolve.Refs[i]
+		sp, ok := db.originalSpanForRecord(rec.File, rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Resolve.Refs[best]
+}
+
+// ResolvedTypeRefAt returns the narrowest type-name reference containing offset.
+func (db *DB) ResolvedTypeRefAt(path string, offset int) *api.ResolvedTypeRef {
+	if db == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Resolve.TypeRefs {
+		rec := &db.Resolve.TypeRefs[i]
+		sp, ok := db.originalSpanForRecord(rec.File, rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Resolve.TypeRefs[best]
+}
+
+// CheckedBindingAt returns the narrowest checker binding containing offset.
+func (db *DB) CheckedBindingAt(path string, offset int) *api.CheckedBinding {
+	if db == nil || db.Check == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Check.Bindings {
+		rec := &db.Check.Bindings[i]
+		sp, ok := db.originalSpanForRecord("", rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Check.Bindings[best]
+}
+
+// CheckedSymbolAt returns the narrowest checker declaration symbol containing offset.
+func (db *DB) CheckedSymbolAt(path string, offset int) *api.CheckedSymbol {
+	if db == nil || db.Check == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Check.Symbols {
+		rec := &db.Check.Symbols[i]
+		sp, ok := db.originalSpanForRecord("", rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Check.Symbols[best]
+}
+
+// CheckedNodeAt returns the narrowest typed node containing offset.
+func (db *DB) CheckedNodeAt(path string, offset int) *api.CheckedNode {
+	if db == nil || db.Check == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Check.TypedNodes {
+		rec := &db.Check.TypedNodes[i]
+		sp, ok := db.originalSpanForRecord("", rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Check.TypedNodes[best]
+}
+
+// HoverAt returns the best declaration/reference hover payload for path+offset.
+func (db *DB) HoverAt(path string, offset int) (Hover, bool) {
+	if binding := db.CheckedBindingAt(path, offset); binding != nil {
+		sp, _ := db.originalSpanForRecord("", binding.Start, binding.End)
+		return Hover{Name: binding.Name, Kind: "binding", Type: binding.Type, Span: sp}, true
+	}
+	if symbol := db.CheckedSymbolAt(path, offset); symbol != nil {
+		sp, _ := db.originalSpanForRecord("", symbol.Start, symbol.End)
+		return Hover{Name: symbol.Name, Kind: symbol.Kind, Type: symbol.Type, Span: sp}, true
+	}
+	if ref := db.ResolvedRefAt(path, offset); ref != nil {
+		target := db.ResolveIndex().SymbolsByStableID[ref.TargetSymbolID]
+		sp, _ := db.originalSpanForRecord(ref.File, ref.Start, ref.End)
+		kind := "binding"
+		if target != nil && target.Kind != "" {
+			kind = target.Kind
+		}
+		return Hover{Name: ref.Name, Kind: kind, Type: db.typeForResolvedRef(ref, target), Span: sp, Target: target}, true
+	}
+	if ref := db.ResolvedTypeRefAt(path, offset); ref != nil {
+		target := db.ResolveIndex().SymbolsByStableID[ref.TargetSymbolID]
+		sp, _ := db.originalSpanForRecord(ref.File, ref.Start, ref.End)
+		kind := "type"
+		if target != nil && target.Kind != "" {
+			kind = target.Kind
+		}
+		return Hover{Name: ref.Name, Kind: kind, Type: db.typeForResolvedTypeRef(ref, target), Span: sp, Target: target}, true
+	}
+	return Hover{}, false
+}
+
+// TargetAt returns the resolved target selected at path+offset. It works for
+// declaration sites, value/name refs, and type refs.
+func (db *DB) TargetAt(path string, offset int) (Target, bool) {
+	if symbol := db.resolvedSymbolAt(path, offset); symbol != nil {
+		sp, _ := db.originalSpanForRecord(symbol.File, symbol.Start, symbol.End)
+		return Target{
+			SymbolID: symbol.ID,
+			Name:     symbol.Name,
+			Kind:     symbol.Kind,
+			Span:     sp,
+			DeclSpan: sp,
+			Symbol:   symbol,
+		}, true
+	}
+	if ref := db.ResolvedRefAt(path, offset); ref != nil {
+		target := db.ResolveIndex().SymbolsByStableID[ref.TargetSymbolID]
+		sp, _ := db.originalSpanForRecord(ref.File, ref.Start, ref.End)
+		decl := db.targetDeclSpan(ref.TargetFile, ref.TargetStart, ref.TargetEnd)
+		name, kind := ref.Name, ""
+		if target != nil {
+			name, kind = target.Name, target.Kind
+		}
+		return Target{SymbolID: ref.TargetSymbolID, Name: name, Kind: kind, Span: sp, DeclSpan: decl, Symbol: target}, true
+	}
+	if ref := db.ResolvedTypeRefAt(path, offset); ref != nil {
+		target := db.ResolveIndex().SymbolsByStableID[ref.TargetSymbolID]
+		sp, _ := db.originalSpanForRecord(ref.File, ref.Start, ref.End)
+		decl := db.targetDeclSpan(ref.TargetFile, ref.TargetStart, ref.TargetEnd)
+		name, kind := ref.Name, "type"
+		if target != nil {
+			name, kind = target.Name, target.Kind
+		}
+		return Target{SymbolID: ref.TargetSymbolID, Name: name, Kind: kind, Span: sp, DeclSpan: decl, Symbol: target}, true
+	}
+	return Target{}, false
+}
+
+// DefinitionAt returns the target declaration span selected at path+offset.
+func (db *DB) DefinitionAt(path string, offset int) (Span, bool) {
+	target, ok := db.TargetAt(path, offset)
+	if !ok || target.DeclSpan.File == "" {
+		return Span{}, false
+	}
+	return target.DeclSpan, true
+}
+
+// ReferencesTo returns every ref/type-ref span pointing at target. Declaration
+// is included when requested and available.
+func (db *DB) ReferencesTo(target Target, includeDecl bool) []Span {
+	if db == nil || target.SymbolID == "" {
+		return nil
+	}
+	var out []Span
+	for _, ref := range db.ResolveIndex().RefsByTargetSymbolID[target.SymbolID] {
+		if sp, ok := db.originalSpanForRecord(ref.File, ref.Start, ref.End); ok {
+			out = append(out, sp)
+		}
+	}
+	for _, ref := range db.ResolveIndex().TypeRefsByTargetSymbolID[target.SymbolID] {
+		if sp, ok := db.originalSpanForRecord(ref.File, ref.Start, ref.End); ok {
+			out = append(out, sp)
+		}
+	}
+	if includeDecl && target.DeclSpan.File != "" {
+		out = append(out, target.DeclSpan)
+	}
+	return out
+}
+
+// ReferencesAt resolves path+offset to a target and returns its reference spans.
+func (db *DB) ReferencesAt(path string, offset int, includeDecl bool) ([]Span, Target, bool) {
+	target, ok := db.TargetAt(path, offset)
+	if !ok {
+		return nil, Target{}, false
+	}
+	return db.ReferencesTo(target, includeDecl), target, true
+}
+
+func (db *DB) typeForResolvedRef(ref *api.ResolvedRef, target *api.ResolvedSymbol) *api.TypeRepr {
+	if db == nil || db.Check == nil || ref == nil {
+		return nil
+	}
+	if binding := db.checkedBindingAtPackageSpan(ref.TargetStart, ref.TargetEnd, ref.Name); binding != nil {
+		return binding.Type
+	}
+	if target != nil {
+		if symbol := db.checkedSymbolAtPackageSpan(target.Start, target.End, target.Name); symbol != nil {
+			return symbol.Type
+		}
+	}
+	return nil
+}
+
+func (db *DB) typeForResolvedTypeRef(ref *api.ResolvedTypeRef, target *api.ResolvedSymbol) *api.TypeRepr {
+	if db == nil || db.Check == nil || ref == nil {
+		return nil
+	}
+	if target != nil {
+		if symbol := db.checkedSymbolAtPackageSpan(target.Start, target.End, target.Name); symbol != nil {
+			return symbol.Type
+		}
+		if target.Type != nil {
+			return target.Type
+		}
+	}
+	return nil
+}
+
+func (db *DB) resolvedSymbolAt(path string, offset int) *api.ResolvedSymbol {
+	if db == nil {
+		return nil
+	}
+	best := -1
+	bestWidth := 0
+	for i := range db.Resolve.Symbols {
+		rec := &db.Resolve.Symbols[i]
+		sp, ok := db.originalSpanForRecord(rec.File, rec.Start, rec.End)
+		if !ok || !spanContains(sp, path, offset) {
+			continue
+		}
+		width := sp.End - sp.Start
+		if best < 0 || width < bestWidth {
+			best = i
+			bestWidth = width
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &db.Resolve.Symbols[best]
+}
+
+func (db *DB) targetDeclSpan(targetFile string, targetStart, targetEnd int) Span {
+	sp, _ := db.originalSpanForRecord(targetFile, targetStart, targetEnd)
+	return sp
+}
+
+func (db *DB) checkedBindingAtPackageSpan(start, end int, name string) *api.CheckedBinding {
+	if db == nil || db.Check == nil {
+		return nil
+	}
+	for i := range db.Check.Bindings {
+		rec := &db.Check.Bindings[i]
+		if rec.Start == start && rec.End == end && (name == "" || rec.Name == name) {
+			return rec
+		}
+	}
+	return nil
+}
+
+func (db *DB) checkedSymbolAtPackageSpan(start, end int, name string) *api.CheckedSymbol {
+	if db == nil || db.Check == nil {
+		return nil
+	}
+	for i := range db.Check.Symbols {
+		rec := &db.Check.Symbols[i]
+		if rec.Start == start && rec.End == end && (name == "" || rec.Name == name) {
+			return rec
+		}
+	}
+	return nil
+}
+
+func (db *DB) originalSpanForRecord(path string, start, end int) (Span, bool) {
+	if db == nil {
+		return Span{}, false
+	}
+	if len(db.Files) == 0 {
+		return Span{File: path, Start: start, End: end}, true
+	}
+	file := db.FileForPath(path)
+	if file == nil {
+		file = db.FileForOffset(start)
+	}
+	if file == nil {
+		return Span{}, false
+	}
+	startOff, ok := db.OriginalOffset(file.Path, start)
+	if !ok {
+		return Span{}, false
+	}
+	endOff, ok := db.OriginalOffset(file.Path, end)
+	if !ok {
+		endOff = startOff
+	}
+	if endOff < startOff {
+		endOff = startOff
+	}
+	return Span{File: file.Path, Start: startOff, End: endOff}, true
+}
+
+func spanContains(sp Span, path string, offset int) bool {
+	if path != "" && sp.File != "" && sp.File != path {
+		return false
+	}
+	if sp.End <= sp.Start {
+		return offset == sp.Start
+	}
+	return offset >= sp.Start && offset < sp.End
+}
+
+// ResolveIndex is the resolver half of SemanticDB. Pointer values refer to
+// records inside DB.Resolve; treat the DB as immutable while using the index.
+type ResolveIndex struct {
+	SymbolsByStableID        map[string]*api.ResolvedSymbol
+	SymbolsByDeclID          map[string]*api.ResolvedSymbol
+	SymbolsByTarget          map[NodeKey]*api.ResolvedSymbol
+	RefsByStableID           map[string]*api.ResolvedRef
+	RefsByBindingID          map[string]*api.ResolvedRef
+	RefsByNode               map[NodeKey][]*api.ResolvedRef
+	RefsByTargetSymbolID     map[string][]*api.ResolvedRef
+	TypeRefsByStableID       map[string]*api.ResolvedTypeRef
+	TypeRefsByNode           map[NodeKey][]*api.ResolvedTypeRef
+	TypeRefsByTargetSymbolID map[string][]*api.ResolvedTypeRef
+	DiagnosticsByStableID    map[string]*api.ResolveDiagnosticRecord
+	DiagnosticsByCode        map[string][]*api.ResolveDiagnosticRecord
+}
+
+func emptyResolveIndex() ResolveIndex {
+	return ResolveIndex{
+		SymbolsByStableID:        map[string]*api.ResolvedSymbol{},
+		SymbolsByDeclID:          map[string]*api.ResolvedSymbol{},
+		SymbolsByTarget:          map[NodeKey]*api.ResolvedSymbol{},
+		RefsByStableID:           map[string]*api.ResolvedRef{},
+		RefsByBindingID:          map[string]*api.ResolvedRef{},
+		RefsByNode:               map[NodeKey][]*api.ResolvedRef{},
+		RefsByTargetSymbolID:     map[string][]*api.ResolvedRef{},
+		TypeRefsByStableID:       map[string]*api.ResolvedTypeRef{},
+		TypeRefsByNode:           map[NodeKey][]*api.ResolvedTypeRef{},
+		TypeRefsByTargetSymbolID: map[string][]*api.ResolvedTypeRef{},
+		DiagnosticsByStableID:    map[string]*api.ResolveDiagnosticRecord{},
+		DiagnosticsByCode:        map[string][]*api.ResolveDiagnosticRecord{},
+	}
+}
+
+func buildResolveIndex(result *api.ResolveResult) ResolveIndex {
+	if result == nil {
+		return emptyResolveIndex()
+	}
+	idx := ResolveIndex{
+		SymbolsByStableID:        make(map[string]*api.ResolvedSymbol, len(result.Symbols)),
+		SymbolsByDeclID:          make(map[string]*api.ResolvedSymbol, len(result.Symbols)),
+		SymbolsByTarget:          make(map[NodeKey]*api.ResolvedSymbol, len(result.Symbols)),
+		RefsByStableID:           make(map[string]*api.ResolvedRef, len(result.Refs)),
+		RefsByBindingID:          make(map[string]*api.ResolvedRef, len(result.Refs)),
+		RefsByNode:               make(map[NodeKey][]*api.ResolvedRef),
+		RefsByTargetSymbolID:     make(map[string][]*api.ResolvedRef),
+		TypeRefsByStableID:       make(map[string]*api.ResolvedTypeRef, len(result.TypeRefs)),
+		TypeRefsByNode:           make(map[NodeKey][]*api.ResolvedTypeRef),
+		TypeRefsByTargetSymbolID: make(map[string][]*api.ResolvedTypeRef),
+		DiagnosticsByStableID:    make(map[string]*api.ResolveDiagnosticRecord, len(result.Diagnostics)),
+		DiagnosticsByCode:        make(map[string][]*api.ResolveDiagnosticRecord),
+	}
+	for i := range result.Symbols {
+		rec := &result.Symbols[i]
+		if rec.ID != "" {
+			idx.SymbolsByStableID[rec.ID] = rec
+		}
+		if rec.DeclID != "" {
+			idx.SymbolsByDeclID[rec.DeclID] = rec
+		}
+		idx.SymbolsByTarget[NodeKey{File: rec.File, Node: rec.Node, Start: rec.Start, End: rec.End}] = rec
+	}
+	for i := range result.Refs {
+		rec := &result.Refs[i]
+		if rec.ID != "" {
+			idx.RefsByStableID[rec.ID] = rec
+		}
+		if rec.BindingID != "" {
+			idx.RefsByBindingID[rec.BindingID] = rec
+		}
+		idx.RefsByNode[NodeKey{File: rec.File, Node: rec.Node, Start: rec.Start, End: rec.End}] = append(idx.RefsByNode[NodeKey{File: rec.File, Node: rec.Node, Start: rec.Start, End: rec.End}], rec)
+		if rec.TargetSymbolID != "" {
+			idx.RefsByTargetSymbolID[rec.TargetSymbolID] = append(idx.RefsByTargetSymbolID[rec.TargetSymbolID], rec)
+		}
+	}
+	for i := range result.TypeRefs {
+		rec := &result.TypeRefs[i]
+		if rec.ID != "" {
+			idx.TypeRefsByStableID[rec.ID] = rec
+		}
+		idx.TypeRefsByNode[NodeKey{File: rec.File, Node: rec.Node, Start: rec.Start, End: rec.End}] = append(idx.TypeRefsByNode[NodeKey{File: rec.File, Node: rec.Node, Start: rec.Start, End: rec.End}], rec)
+		if rec.TargetSymbolID != "" {
+			idx.TypeRefsByTargetSymbolID[rec.TargetSymbolID] = append(idx.TypeRefsByTargetSymbolID[rec.TargetSymbolID], rec)
+		}
+	}
+	for i := range result.Diagnostics {
+		rec := &result.Diagnostics[i]
+		if rec.ID != "" {
+			idx.DiagnosticsByStableID[rec.ID] = rec
+		}
+		if rec.Code != "" {
+			idx.DiagnosticsByCode[rec.Code] = append(idx.DiagnosticsByCode[rec.Code], rec)
+		}
+	}
+	return idx
+}
+
+func cloneFiles(files []File) []File {
+	if len(files) == 0 {
+		return nil
+	}
+	out := make([]File, len(files))
+	for i := range files {
+		out[i] = files[i]
+		out[i].Source = append([]byte(nil), files[i].Source...)
+		out[i].OriginalSource = append([]byte(nil), files[i].OriginalSource...)
+		out[i].LineStarts = append([]int(nil), files[i].LineStarts...)
+	}
+	return out
+}

--- a/internal/semanticdb/db_test.go
+++ b/internal/semanticdb/db_test.go
@@ -1,0 +1,231 @@
+package semanticdb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost/api"
+)
+
+func TestResolveIndexUsesStableIDsAndTargets(t *testing.T) {
+	resolved := api.ResolveResult{
+		PackageID: "pkg",
+		Symbols: []api.ResolvedSymbol{{
+			ID:     "sym-helper",
+			DeclID: "decl-helper",
+			File:   "helper.osty",
+			Node:   4,
+			Name:   "helper",
+			Kind:   "fn",
+			Start:  0,
+			End:    6,
+		}},
+		Refs: []api.ResolvedRef{{
+			ID:             "ref-helper",
+			BindingID:      "binding-helper",
+			File:           "main.osty",
+			Node:           8,
+			Name:           "helper",
+			Start:          20,
+			End:            26,
+			TargetSymbolID: "sym-helper",
+			TargetFile:     "helper.osty",
+			TargetNode:     4,
+			TargetStart:    0,
+			TargetEnd:      6,
+		}},
+		TypeRefs: []api.ResolvedTypeRef{{
+			ID:             "type-ref-box",
+			File:           "main.osty",
+			Node:           9,
+			Name:           "Box",
+			Start:          30,
+			End:            33,
+			TargetSymbolID: "sym-box",
+		}},
+		Diagnostics: []api.ResolveDiagnosticRecord{{
+			ID:      "diag",
+			Code:    "E0500",
+			File:    "main.osty",
+			Message: "missing",
+			Start:   40,
+			End:     41,
+		}},
+	}
+	db := New([]File{{Path: "main.osty", Source: []byte("fn main() {}\n")}}, resolved)
+
+	idx := db.ResolveIndex()
+	if idx.SymbolsByStableID["sym-helper"] == nil {
+		t.Fatal("missing symbol by stable id")
+	}
+	if got := idx.SymbolsByTarget[NodeKey{File: "helper.osty", Node: 4, Start: 0, End: 6}]; got == nil || got.Name != "helper" {
+		t.Fatalf("symbol by target = %#v, want helper", got)
+	}
+	if got := idx.RefsByBindingID["binding-helper"]; got == nil || got.TargetSymbolID != "sym-helper" {
+		t.Fatalf("ref by binding id = %#v, want helper target", got)
+	}
+	if refs := idx.RefsByTargetSymbolID["sym-helper"]; len(refs) != 1 || refs[0].Name != "helper" {
+		t.Fatalf("refs by target = %#v, want helper ref", refs)
+	}
+	if typeRefs := idx.TypeRefsByTargetSymbolID["sym-box"]; len(typeRefs) != 1 || typeRefs[0].Name != "Box" {
+		t.Fatalf("type refs by target = %#v, want Box ref", typeRefs)
+	}
+	if diags := idx.DiagnosticsByCode["E0500"]; len(diags) != 1 || diags[0].ID != "diag" {
+		t.Fatalf("diagnostics by code = %#v, want diag", diags)
+	}
+}
+
+func TestWithCheckKeepsResolveDBImmutable(t *testing.T) {
+	base := New(nil, api.ResolveResult{PackageID: "pkg"})
+	checked := api.CheckResult{
+		TypedNodes: []api.CheckedNode{{
+			Node:  1,
+			Kind:  "Ident",
+			Start: 0,
+			End:   1,
+			Type:  &api.TypeRepr{Kind: "primitive", Name: "Int"},
+		}},
+	}
+
+	withCheck := base.WithCheck(checked)
+	if base.Check != nil {
+		t.Fatal("WithCheck mutated the original DB")
+	}
+	if withCheck.Check == nil {
+		t.Fatal("WithCheck did not attach checker facts")
+	}
+	if len(withCheck.CheckIndex().TypedNodesByStableID) != 1 {
+		t.Fatalf("check index size = %d, want 1", len(withCheck.CheckIndex().TypedNodesByStableID))
+	}
+}
+
+func TestFileOffsetHelpers(t *testing.T) {
+	original := []byte("let x = 1\n")
+	db := New([]File{{
+		Path:           "main.osty",
+		Base:           10,
+		Source:         []byte("let x = 1\n"),
+		OriginalSource: original,
+	}}, api.ResolveResult{})
+	original[0] = 'X'
+
+	file := db.FileForOffset(14)
+	if file == nil || file.Path != "main.osty" {
+		t.Fatalf("FileForOffset = %#v, want main.osty", file)
+	}
+	if got := string(file.OriginalSourceBytes()); got != "let x = 1\n" {
+		t.Fatalf("OriginalSourceBytes = %q, want cloned original source", got)
+	}
+	if got, ok := db.PackageOffset("main.osty", 4); !ok || got != 14 {
+		t.Fatalf("PackageOffset = (%d, %v), want (14, true)", got, ok)
+	}
+	if got, ok := db.OriginalOffset("main.osty", 14); !ok || got != 4 {
+		t.Fatalf("OriginalOffset = (%d, %v), want (4, true)", got, ok)
+	}
+}
+
+func TestHoverAtUsesStructuredResolveAndCheckFacts(t *testing.T) {
+	src := "fn helper() -> Int { 1 }\nfn main() -> Int { helper() }\n"
+	declStart := strings.Index(src, "helper")
+	refStart := strings.LastIndex(src, "helper")
+	fnType := &api.TypeRepr{
+		Kind:   "fn",
+		Return: &api.TypeRepr{Kind: "primitive", Name: "Int"},
+	}
+	db := New([]File{{Path: "main.osty", Source: []byte(src)}}, api.ResolveResult{
+		PackageID: "pkg",
+		Symbols: []api.ResolvedSymbol{{
+			ID:    "sym-helper",
+			File:  "main.osty",
+			Node:  1,
+			Name:  "helper",
+			Kind:  "fn",
+			Start: declStart,
+			End:   declStart + len("helper"),
+		}},
+		Refs: []api.ResolvedRef{{
+			ID:             "ref-helper",
+			File:           "main.osty",
+			Node:           2,
+			Name:           "helper",
+			Start:          refStart,
+			End:            refStart + len("helper"),
+			TargetSymbolID: "sym-helper",
+			TargetFile:     "main.osty",
+			TargetNode:     1,
+			TargetStart:    declStart,
+			TargetEnd:      declStart + len("helper"),
+		}},
+	}).WithCheck(api.CheckResult{
+		Symbols: []api.CheckedSymbol{{
+			Name:  "helper",
+			Kind:  "fn",
+			Type:  fnType,
+			Start: declStart,
+			End:   declStart + len("helper"),
+		}},
+	})
+
+	hover, ok := db.HoverAt("main.osty", refStart+1)
+	if !ok {
+		t.Fatal("HoverAt returned !ok for helper ref")
+	}
+	if hover.Name != "helper" || hover.Kind != "fn" || hover.Type.String() != "fn() -> Int" {
+		t.Fatalf("hover = %#v, want helper fn type", hover)
+	}
+	if hover.Span.Start != refStart || hover.Span.End != refStart+len("helper") {
+		t.Fatalf("hover span = %#v, want helper ref span", hover.Span)
+	}
+}
+
+func TestDefinitionAndReferencesUseStableTargetID(t *testing.T) {
+	src := "fn helper() -> Int { 1 }\nfn main() -> Int { helper() }\n"
+	declStart := strings.Index(src, "helper")
+	refStart := strings.LastIndex(src, "helper")
+	db := New([]File{{Path: "main.osty", Source: []byte(src)}}, api.ResolveResult{
+		PackageID: "pkg",
+		Symbols: []api.ResolvedSymbol{{
+			ID:    "sym-helper",
+			File:  "main.osty",
+			Node:  1,
+			Name:  "helper",
+			Kind:  "fn",
+			Start: declStart,
+			End:   declStart + len("helper"),
+		}},
+		Refs: []api.ResolvedRef{{
+			ID:             "ref-helper",
+			File:           "main.osty",
+			Node:           2,
+			Name:           "helper",
+			Start:          refStart,
+			End:            refStart + len("helper"),
+			TargetSymbolID: "sym-helper",
+			TargetFile:     "main.osty",
+			TargetNode:     1,
+			TargetStart:    declStart,
+			TargetEnd:      declStart + len("helper"),
+		}},
+	})
+
+	def, ok := db.DefinitionAt("main.osty", refStart+1)
+	if !ok {
+		t.Fatal("DefinitionAt returned !ok")
+	}
+	if def.Start != declStart || def.End != declStart+len("helper") {
+		t.Fatalf("definition span = %#v, want helper decl", def)
+	}
+	refs, target, ok := db.ReferencesAt("main.osty", refStart+1, true)
+	if !ok {
+		t.Fatal("ReferencesAt returned !ok")
+	}
+	if target.SymbolID != "sym-helper" {
+		t.Fatalf("target symbol id = %q, want sym-helper", target.SymbolID)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("references = %#v, want use + decl", refs)
+	}
+	if refs[0].Start != refStart || refs[1].Start != declStart {
+		t.Fatalf("references = %#v, want use then declaration", refs)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/semanticdb` as a central semantic database for selfhost resolver/checker facts.
- Attach resolve-only and combined resolve/check `SemanticDB` instances through resolver, checker, and query APIs.
- Move LSP hover, definition, references, and rename to use SemanticDB first, with legacy paths retained as fallback.
- Preserve original source bytes alongside canonical resolver source so source-mapped LSP ranges stay editor-accurate.

## Validation

- `go test -count=1 -vet=off ./internal/semanticdb ./internal/resolve ./internal/lsp`
- `go test -count=1 -vet=off ./internal/check ./internal/query/osty ./cmd/osty`
- `just short`
- `just fmt-check`
- `git diff --check`