### PR TITLE
[codex] use native checker IDs in legacy overlays

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -359,6 +359,10 @@ type selfhostFileSegment struct {
 	refs      map[ast.NodeID]*resolve.Symbol
 	base      int
 	sourceMap *sourcemap.Map
+	// nativeNodeIDs marks segments where public AST IDs can be translated to
+	// native checker NodeIDs as nativeNodeIDBase + publicID - 2.
+	nativeNodeIDs    bool
+	nativeNodeIDBase int
 }
 
 func applyNativeFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider, privileged bool) {
@@ -1041,16 +1045,28 @@ type selfhostNameSpanKey struct {
 	name string
 }
 
+type selfhostNameNodeKey struct {
+	nodeID int
+	name   string
+}
+
 type selfhostSpanIndex struct {
-	exprs       map[selfhostSpanKey]ast.Expr
-	exprsByFrom map[int][]ast.Expr
-	exprKeys    map[ast.Expr]selfhostSpanKey
-	calls       map[selfhostSpanKey]*ast.CallExpr
-	callsByFrom map[int][]*ast.CallExpr
-	callKeys    map[*ast.CallExpr]selfhostSpanKey
-	scopes      map[selfhostSpanKey]*resolve.Scope
-	bindings    map[selfhostNameSpanKey]ast.Node
-	symbols     map[selfhostNameSpanKey]*resolve.Symbol
+	exprs          map[selfhostSpanKey]ast.Expr
+	exprsByFrom    map[int][]ast.Expr
+	exprKeys       map[ast.Expr]selfhostSpanKey
+	exprsByNode    map[int]ast.Expr
+	calls          map[selfhostSpanKey]*ast.CallExpr
+	callsByFrom    map[int][]*ast.CallExpr
+	callKeys       map[*ast.CallExpr]selfhostSpanKey
+	callsByNode    map[int]*ast.CallExpr
+	scopes         map[selfhostSpanKey]*resolve.Scope
+	scopesByNode   map[int]*resolve.Scope
+	bindings       map[selfhostNameSpanKey]ast.Node
+	bindingsByNode map[selfhostNameNodeKey]selfhostBindingNodeEntry
+	symbols        map[selfhostNameSpanKey]*resolve.Symbol
+	symbolsByNode  map[selfhostNameNodeKey]selfhostSymbolNodeEntry
+
+	nativeNodeIDBaseBySourceBase map[int]int
 
 	// scopeSpans is `scopes` sorted by span.start asc, materialised lazily on
 	// the first scopeFor cache miss. Lets the slow path binary-search the
@@ -1094,6 +1110,16 @@ type callSpanEntry struct {
 	call *ast.CallExpr
 }
 
+type selfhostBindingNodeEntry struct {
+	span selfhostSpanKey
+	node ast.Node
+}
+
+type selfhostSymbolNodeEntry struct {
+	span   selfhostSpanKey
+	symbol *resolve.Symbol
+}
+
 type exprQueryKey struct {
 	span selfhostSpanKey
 	kind string
@@ -1106,6 +1132,21 @@ func (idx *selfhostSpanIndex) bindNode(key selfhostNameSpanKey, n ast.Node) {
 	idx.bindings[key] = n
 }
 
+func (idx *selfhostSpanIndex) bindNodeByNativeID(anchor ast.Node, base int, key selfhostSpanKey, name string, n ast.Node) {
+	if name == "" || n == nil {
+		return
+	}
+	nodeID, ok := idx.nativeNodeIDForNode(anchor, base)
+	if !ok {
+		return
+	}
+	nodeKey := selfhostNameNodeKey{nodeID: nodeID, name: name}
+	if idx.bindingsByNode[nodeKey].node != nil {
+		return
+	}
+	idx.bindingsByNode[nodeKey] = selfhostBindingNodeEntry{span: key, node: n}
+}
+
 func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked api.CheckResult) {
 	if result == nil {
 		return
@@ -1114,11 +1155,24 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 	idx := buildSelfhostSpanIndex(src)
 	for _, node := range checked.TypedNodes {
 		key := selfhostSpanKey{start: node.Start, end: node.End}
-		expr := idx.lookupExpr(key, node.Kind)
+		var expr ast.Expr
+		var scope *resolve.Scope
+		if nodeID, ok := selfhostResultNodeID(node.NodeID, node.Node); ok {
+			expr = idx.lookupExprByNodeID(nodeID, key, node.Kind)
+			if expr != nil {
+				scope = idx.scopesByNode[nodeID]
+			}
+		}
+		if expr == nil {
+			expr = idx.lookupExpr(key, node.Kind)
+		}
 		if expr == nil {
 			continue
 		}
-		t := typeReprToType(node.Type, idx.scopeFor(key))
+		if scope == nil {
+			scope = idx.scopeFor(key)
+		}
+		t := typeReprToType(node.Type, scope)
 		if t == nil {
 			continue
 		}
@@ -1126,38 +1180,81 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 	}
 	for _, binding := range checked.Bindings {
 		key := selfhostSpanKey{start: binding.Start, end: binding.End}
-		t := typeReprToType(binding.Type, idx.scopeFor(key))
+		var scope *resolve.Scope
+		var directNode ast.Node
+		var directSym *resolve.Symbol
+		if nodeID, ok := selfhostResultNodeID(binding.NodeID, binding.Node); ok {
+			directNode = idx.lookupBindingByNodeID(nodeID, key, binding.Name)
+			directSym = idx.lookupSymbolByNodeID(nodeID, key, binding.Name)
+			if directNode != nil || directSym != nil {
+				scope = idx.scopesByNode[nodeID]
+			}
+		}
+		if scope == nil {
+			scope = idx.scopeFor(key)
+		}
+		t := typeReprToType(binding.Type, scope)
 		if t == nil {
 			continue
 		}
 		nameKey := selfhostNameSpanKey{selfhostSpanKey: key, name: binding.Name}
-		if n := idx.bindings[nameKey]; n != nil {
+		if n := directNode; n != nil {
+			result.LetTypes[n] = t
+		} else if n := idx.bindings[nameKey]; n != nil {
 			result.LetTypes[n] = t
 		}
-		if sym := idx.symbols[nameKey]; sym != nil {
+		if sym := directSym; sym != nil {
+			result.SymTypes[sym] = t
+		} else if sym := idx.symbols[nameKey]; sym != nil {
 			result.SymTypes[sym] = t
 		}
 	}
 	for _, symbol := range checked.Symbols {
 		key := selfhostSpanKey{start: symbol.Start, end: symbol.End}
-		t := typeReprToType(symbol.Type, idx.scopeFor(key))
+		var scope *resolve.Scope
+		var directSym *resolve.Symbol
+		if nodeID, ok := selfhostResultNodeID(symbol.NodeID, symbol.Node); ok {
+			directSym = idx.lookupSymbolByNodeID(nodeID, key, symbol.Name)
+			if directSym != nil {
+				scope = idx.scopesByNode[nodeID]
+			}
+		}
+		if scope == nil {
+			scope = idx.scopeFor(key)
+		}
+		t := typeReprToType(symbol.Type, scope)
 		if t == nil {
 			continue
 		}
 		nameKey := selfhostNameSpanKey{selfhostSpanKey: key, name: symbol.Name}
-		if sym := idx.symbols[nameKey]; sym != nil {
+		if sym := directSym; sym != nil {
+			result.SymTypes[sym] = t
+		} else if sym := idx.symbols[nameKey]; sym != nil {
 			result.SymTypes[sym] = t
 		}
 	}
 	for _, inst := range checked.Instantiations {
 		key := selfhostSpanKey{start: inst.Start, end: inst.End}
-		call := idx.lookupCall(key)
+		var call *ast.CallExpr
+		var scope *resolve.Scope
+		if nodeID, ok := selfhostResultNodeID(inst.NodeID, inst.Node); ok {
+			call = idx.lookupCallByNodeID(nodeID, key)
+			if call != nil {
+				scope = idx.scopesByNode[nodeID]
+			}
+		}
+		if call == nil {
+			call = idx.lookupCall(key)
+		}
 		if call == nil || len(inst.TypeArgs) == 0 {
 			continue
 		}
+		if scope == nil {
+			scope = idx.scopeFor(key)
+		}
 		args := make([]types.Type, 0, len(inst.TypeArgs))
 		for i := range inst.TypeArgs {
-			if t := typeReprToType(&inst.TypeArgs[i], idx.scopeFor(key)); t != nil {
+			if t := typeReprToType(&inst.TypeArgs[i], scope); t != nil {
 				args = append(args, t)
 			}
 		}
@@ -1172,19 +1269,28 @@ func overlaySelfhostResult(result *Result, src selfhostCheckedSource, checked ap
 
 func buildSelfhostSpanIndex(src selfhostCheckedSource) *selfhostSpanIndex {
 	idx := &selfhostSpanIndex{
-		exprs:       map[selfhostSpanKey]ast.Expr{},
-		exprsByFrom: map[int][]ast.Expr{},
-		exprKeys:    map[ast.Expr]selfhostSpanKey{},
-		calls:       map[selfhostSpanKey]*ast.CallExpr{},
-		callsByFrom: map[int][]*ast.CallExpr{},
-		callKeys:    map[*ast.CallExpr]selfhostSpanKey{},
-		scopes:      map[selfhostSpanKey]*resolve.Scope{},
-		bindings:    map[selfhostNameSpanKey]ast.Node{},
-		symbols:     map[selfhostNameSpanKey]*resolve.Symbol{},
+		exprs:                        map[selfhostSpanKey]ast.Expr{},
+		exprsByFrom:                  map[int][]ast.Expr{},
+		exprKeys:                     map[ast.Expr]selfhostSpanKey{},
+		exprsByNode:                  map[int]ast.Expr{},
+		calls:                        map[selfhostSpanKey]*ast.CallExpr{},
+		callsByFrom:                  map[int][]*ast.CallExpr{},
+		callKeys:                     map[*ast.CallExpr]selfhostSpanKey{},
+		callsByNode:                  map[int]*ast.CallExpr{},
+		scopes:                       map[selfhostSpanKey]*resolve.Scope{},
+		scopesByNode:                 map[int]*resolve.Scope{},
+		bindings:                     map[selfhostNameSpanKey]ast.Node{},
+		bindingsByNode:               map[selfhostNameNodeKey]selfhostBindingNodeEntry{},
+		symbols:                      map[selfhostNameSpanKey]*resolve.Symbol{},
+		symbolsByNode:                map[selfhostNameNodeKey]selfhostSymbolNodeEntry{},
+		nativeNodeIDBaseBySourceBase: map[int]int{},
 	}
 	for _, file := range src.files {
 		if file.file == nil {
 			continue
+		}
+		if file.nativeNodeIDs {
+			idx.nativeNodeIDBaseBySourceBase[file.base] = file.nativeNodeIDBase
 		}
 		for _, decl := range file.file.Decls {
 			idx.addNode(decl, file.base, file.scope, file.sourceMap)
@@ -1198,6 +1304,19 @@ func buildSelfhostSpanIndex(src selfhostCheckedSource) *selfhostSpanIndex {
 		}
 	}
 	return idx
+}
+
+func selfhostResultNodeID(nodeID, legacyNode int) (int, bool) {
+	if nodeID != 0 {
+		return nodeID, true
+	}
+	if legacyNode != 0 {
+		return legacyNode, true
+	}
+	// Arena node 0 is valid. Direct lookups still validate span/kind/name
+	// before accepting it, so trying 0 is safer than silently forcing the
+	// oldest record in each native result back through span rematching.
+	return 0, true
 }
 
 func (idx *selfhostSpanIndex) scopeFor(key selfhostSpanKey) *resolve.Scope {
@@ -1225,8 +1344,11 @@ func (idx *selfhostSpanIndex) scopeFor(key selfhostSpanKey) *resolve.Scope {
 
 	var best *resolve.Scope
 	bestSize := int(^uint(0) >> 1)
-	for i := 0; i < lo; i++ {
+	for i := lo - 1; i >= 0; i-- {
 		e := list[i]
+		if best != nil && key.end-e.span.start >= bestSize {
+			break
+		}
 		if e.span.end < key.end {
 			continue
 		}
@@ -1279,17 +1401,28 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 		if _, ok := idx.scopes[key]; !ok {
 			idx.scopes[key] = scope
 		}
-		idx.addDeclaredSymbol(n, key, scope)
+		if nodeID, ok := idx.nativeNodeIDForNode(n, base); ok {
+			if _, have := idx.scopesByNode[nodeID]; !have {
+				idx.scopesByNode[nodeID] = scope
+			}
+		}
+		idx.addDeclaredSymbol(n, key, scope, base)
 		if e, ok := n.(ast.Expr); ok {
 			if _, have := idx.exprs[key]; !have {
 				idx.exprs[key] = e
 			}
 			idx.exprsByFrom[key.start] = append(idx.exprsByFrom[key.start], e)
 			idx.exprKeys[e] = key
+			if nodeID, ok := idx.nativeNodeIDForNode(n, base); ok {
+				idx.exprsByNode[nodeID] = e
+			}
 			if c, ok := e.(*ast.CallExpr); ok {
 				idx.calls[key] = c
 				idx.callsByFrom[key.start] = append(idx.callsByFrom[key.start], c)
 				idx.callKeys[c] = key
+				if nodeID, ok := idx.nativeNodeIDForNode(n, base); ok {
+					idx.callsByNode[nodeID] = c
+				}
 			}
 		}
 	}
@@ -1356,6 +1489,7 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 	case *ast.Param:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
+			idx.bindNodeByNativeID(v, base, key, v.Name, v)
 		}
 		idx.addNode(v.Pattern, base, scope, sm)
 		idx.addNode(v.Type, base, scope, sm)
@@ -1387,6 +1521,7 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 		if name := bindingPatternName(v.Pattern); name != "" {
 			if patKey, ok := spanKeyForNode(v.Pattern, base, sm); ok {
 				idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: patKey, name: name}, v)
+				idx.bindNodeByNativeID(v.Pattern, base, patKey, name, v)
 			}
 		}
 		idx.addNode(v.Pattern, base, scope, sm)
@@ -1487,6 +1622,7 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 	case *ast.IdentPat:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
+			idx.bindNodeByNativeID(v, base, key, v.Name, v)
 		}
 	case *ast.TuplePat:
 		for _, p := range v.Elems {
@@ -1512,6 +1648,7 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 	case *ast.BindingPat:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
+			idx.bindNodeByNativeID(v, base, key, v.Name, v)
 		}
 		idx.addNode(v.Pattern, base, scope, sm)
 	}
@@ -1529,12 +1666,18 @@ func (idx *selfhostSpanIndex) addScopeSubtree(scope *resolve.Scope, base int, sm
 	}
 }
 
-func (idx *selfhostSpanIndex) addDeclaredSymbol(n ast.Node, key selfhostSpanKey, scope *resolve.Scope) {
+func (idx *selfhostSpanIndex) addDeclaredSymbol(n ast.Node, key selfhostSpanKey, scope *resolve.Scope, base int) {
 	sym := declaredSymbolForNode(n, scope)
 	if sym == nil {
 		return
 	}
 	idx.symbols[selfhostNameSpanKey{selfhostSpanKey: key, name: sym.Name}] = sym
+	if nodeID, ok := idx.nativeNodeIDForNode(n, base); ok {
+		idx.symbolsByNode[selfhostNameNodeKey{nodeID: nodeID, name: sym.Name}] = selfhostSymbolNodeEntry{
+			span:   key,
+			symbol: sym,
+		}
+	}
 }
 
 func declaredSymbolForNode(n ast.Node, scope *resolve.Scope) *resolve.Symbol {
@@ -1579,6 +1722,20 @@ func lookupLocalDeclSymbol(scope *resolve.Scope, name string, decl ast.Node) *re
 	return sym
 }
 
+func (idx *selfhostSpanIndex) lookupExprByNodeID(nodeID int, key selfhostSpanKey, kind string) ast.Expr {
+	expr := idx.exprsByNode[nodeID]
+	if expr == nil {
+		return nil
+	}
+	if kind != "" && selfhostExprKind(expr) != kind {
+		return nil
+	}
+	if exprKey, ok := idx.exprKeys[expr]; !ok || exprKey != key {
+		return nil
+	}
+	return expr
+}
+
 func (idx *selfhostSpanIndex) lookupExpr(key selfhostSpanKey, kind string) ast.Expr {
 	if expr := idx.exprs[key]; expr != nil {
 		if kind == "" || selfhostExprKind(expr) == kind {
@@ -1620,8 +1777,11 @@ func (idx *selfhostSpanIndex) lookupExpr(key selfhostSpanKey, kind string) ast.E
 			hi = mid
 		}
 	}
-	for i := 0; i < lo; i++ {
+	for i := lo - 1; i >= 0; i-- {
 		e := list[i]
+		if best != nil && key.end-e.span.start >= bestSize {
+			break
+		}
 		if kind != "" && e.kind != kind {
 			continue
 		}
@@ -1656,6 +1816,17 @@ func (idx *selfhostSpanIndex) ensureExprSpans() {
 		list = []exprSpanEntry{}
 	}
 	idx.exprSpans = list
+}
+
+func (idx *selfhostSpanIndex) lookupCallByNodeID(nodeID int, key selfhostSpanKey) *ast.CallExpr {
+	call := idx.callsByNode[nodeID]
+	if call == nil {
+		return nil
+	}
+	if callKey, ok := idx.callKeys[call]; !ok || callKey != key {
+		return nil
+	}
+	return call
 }
 
 func (idx *selfhostSpanIndex) lookupCall(key selfhostSpanKey) *ast.CallExpr {
@@ -1693,8 +1864,11 @@ func (idx *selfhostSpanIndex) lookupCall(key selfhostSpanKey) *ast.CallExpr {
 			hi = mid
 		}
 	}
-	for i := 0; i < lo; i++ {
+	for i := lo - 1; i >= 0; i-- {
 		e := list[i]
+		if best != nil && key.end-e.span.start >= bestSize {
+			break
+		}
 		if e.span.end < key.end {
 			continue
 		}
@@ -1726,6 +1900,22 @@ func (idx *selfhostSpanIndex) ensureCallSpans() {
 		list = []callSpanEntry{}
 	}
 	idx.callSpans = list
+}
+
+func (idx *selfhostSpanIndex) lookupBindingByNodeID(nodeID int, key selfhostSpanKey, name string) ast.Node {
+	entry := idx.bindingsByNode[selfhostNameNodeKey{nodeID: nodeID, name: name}]
+	if entry.node == nil || entry.span != key {
+		return nil
+	}
+	return entry.node
+}
+
+func (idx *selfhostSpanIndex) lookupSymbolByNodeID(nodeID int, key selfhostSpanKey, name string) *resolve.Symbol {
+	entry := idx.symbolsByNode[selfhostNameNodeKey{nodeID: nodeID, name: name}]
+	if entry.symbol == nil || entry.span != key {
+		return nil
+	}
+	return entry.symbol
 }
 
 func selfhostExprKind(expr ast.Expr) string {
@@ -1792,10 +1982,59 @@ func (idx *selfhostSpanIndex) addSymbol(sym *resolve.Symbol, base int, scope *re
 		return
 	}
 	idx.symbols[selfhostNameSpanKey{selfhostSpanKey: key, name: sym.Name}] = sym
+	if nodeID, ok := idx.nativeNodeIDForNode(sym.Decl, base); ok {
+		idx.symbolsByNode[selfhostNameNodeKey{nodeID: nodeID, name: sym.Name}] = selfhostSymbolNodeEntry{
+			span:   key,
+			symbol: sym,
+		}
+	}
 	if _, ok := idx.scopes[key]; !ok {
 		idx.scopes[key] = scope
 	}
+	if nodeID, ok := idx.nativeNodeIDForNode(sym.Decl, base); ok {
+		if _, have := idx.scopesByNode[nodeID]; !have {
+			idx.scopesByNode[nodeID] = scope
+		}
+	}
 }
+
+func (idx *selfhostSpanIndex) nativeNodeIDForNode(n ast.Node, sourceBase int) (int, bool) {
+	nativeBase, ok := idx.nativeNodeIDBaseBySourceBase[sourceBase]
+	if !ok {
+		return 0, false
+	}
+	id, ok := publicASTNodeID(n)
+	if !ok || id <= 1 {
+		return 0, false
+	}
+	return nativeBase + int(id) - 2, true
+}
+
+func publicASTNodeID(n ast.Node) (ast.NodeID, bool) {
+	if n == nil {
+		return 0, false
+	}
+	rv := reflect.ValueOf(n)
+	if !rv.IsValid() {
+		return 0, false
+	}
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return 0, false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return 0, false
+	}
+	field := rv.FieldByName("ID")
+	if !field.IsValid() || field.Type() != astNodeIDReflectType {
+		return 0, false
+	}
+	return ast.NodeID(field.Uint()), true
+}
+
+var astNodeIDReflectType = reflect.TypeOf(ast.NodeID(0))
 
 func spanKeyForNode(n ast.Node, base int, sm *sourcemap.Map) (key selfhostSpanKey, ok bool) {
 	if n == nil {
@@ -2014,12 +2253,13 @@ func selfhostFileStructuredSource(file *ast.File, rr *resolve.Result, src []byte
 	return selfhostCheckedSource{
 		source: append([]byte(nil), src...),
 		files: []selfhostFileSegment{{
-			file:      file,
-			source:    append([]byte(nil), src...),
-			scope:     scope,
-			refs:      refs,
-			base:      0,
-			sourceMap: canonicalMap,
+			file:          file,
+			source:        append([]byte(nil), src...),
+			scope:         scope,
+			refs:          refs,
+			base:          0,
+			sourceMap:     canonicalMap,
+			nativeNodeIDs: true,
 		}},
 	}
 }

--- a/internal/check/host_boundary_native_overlay_test.go
+++ b/internal/check/host_boundary_native_overlay_test.go
@@ -1,0 +1,139 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost/api"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+func TestOverlaySelfhostResultPrefersNativeNodeIDForTypedNodes(t *testing.T) {
+	start := token.Pos{Line: 1, Column: 1, Offset: 0}
+	end := token.Pos{Line: 1, Column: 2, Offset: 1}
+	first := &ast.Ident{ID: 12, PosV: start, EndV: end, Name: "first"}
+	second := &ast.Ident{ID: 2, PosV: start, EndV: end, Name: "second"}
+	file := &ast.File{
+		Stmts: []ast.Stmt{
+			&ast.ExprStmt{ID: 20, X: first},
+			&ast.ExprStmt{ID: 21, X: second},
+		},
+		PosV: start,
+		EndV: end,
+	}
+	result := &Result{
+		Types:              map[ast.Expr]types.Type{},
+		LetTypes:           map[ast.Node]types.Type{},
+		SymTypes:           map[*resolve.Symbol]types.Type{},
+		InstantiationsByID: map[ast.NodeID][]types.Type{},
+	}
+
+	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
+		TypedNodes: []api.CheckedNode{{
+			Node:   0,
+			NodeID: 0,
+			Kind:   "Ident",
+			Type:   &api.TypeRepr{Kind: "primitive", Name: "Int"},
+			Start:  0,
+			End:    1,
+		}},
+	})
+
+	if got := result.Types[second]; got != types.Int {
+		t.Fatalf("second type = %v, want Int", got)
+	}
+	if got := result.Types[first]; got != nil {
+		t.Fatalf("first type = %v, want nil; overlay fell back to span match", got)
+	}
+}
+
+func TestOverlaySelfhostResultPrefersNativeNodeIDForInstantiations(t *testing.T) {
+	start := token.Pos{Line: 1, Column: 1, Offset: 0}
+	end := token.Pos{Line: 1, Column: 5, Offset: 4}
+	firstFn := &ast.Ident{ID: 30, PosV: start, EndV: end, Name: "id"}
+	secondFn := &ast.Ident{ID: 31, PosV: start, EndV: end, Name: "id"}
+	first := &ast.CallExpr{ID: 20, PosV: start, EndV: end, Fn: firstFn}
+	second := &ast.CallExpr{ID: 21, PosV: start, EndV: end, Fn: secondFn}
+	file := &ast.File{
+		Stmts: []ast.Stmt{
+			&ast.ExprStmt{ID: 22, X: first},
+			&ast.ExprStmt{ID: 23, X: second},
+		},
+		PosV: start,
+		EndV: end,
+	}
+	result := &Result{
+		Types:              map[ast.Expr]types.Type{},
+		LetTypes:           map[ast.Node]types.Type{},
+		SymTypes:           map[*resolve.Symbol]types.Type{},
+		InstantiationsByID: map[ast.NodeID][]types.Type{},
+	}
+
+	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
+		Instantiations: []api.CheckInstantiation{{
+			Node:     18,
+			NodeID:   18,
+			Callee:   "id",
+			TypeArgs: []api.TypeRepr{{Kind: "primitive", Name: "Int"}},
+			Start:    0,
+			End:      4,
+		}},
+	})
+
+	if got := result.InstantiationsByID[first.ID]; len(got) != 1 || got[0] != types.Int {
+		t.Fatalf("first instantiation = %v, want [Int]", got)
+	}
+	if got := result.InstantiationsByID[second.ID]; got != nil {
+		t.Fatalf("second instantiation = %v, want nil; overlay fell back to span match", got)
+	}
+}
+
+func TestOverlaySelfhostResultPrefersNativeNodeIDForBindings(t *testing.T) {
+	start := token.Pos{Line: 1, Column: 5, Offset: 4}
+	end := token.Pos{Line: 1, Column: 10, Offset: 9}
+	firstPat := &ast.IdentPat{ID: 40, PosV: start, EndV: end, Name: "value"}
+	secondPat := &ast.IdentPat{ID: 41, PosV: start, EndV: end, Name: "value"}
+	first := &ast.LetStmt{ID: 42, PosV: start, EndV: end, Pattern: firstPat}
+	second := &ast.LetStmt{ID: 43, PosV: start, EndV: end, Pattern: secondPat}
+	file := &ast.File{
+		Stmts: []ast.Stmt{first, second},
+		PosV:  start,
+		EndV:  end,
+	}
+	result := &Result{
+		Types:              map[ast.Expr]types.Type{},
+		LetTypes:           map[ast.Node]types.Type{},
+		SymTypes:           map[*resolve.Symbol]types.Type{},
+		InstantiationsByID: map[ast.NodeID][]types.Type{},
+	}
+
+	overlaySelfhostResult(result, nativeIDTestSource(file), api.CheckResult{
+		Bindings: []api.CheckedBinding{{
+			Node:   39,
+			NodeID: 39,
+			Name:   "value",
+			Type:   &api.TypeRepr{Kind: "primitive", Name: "Bool"},
+			Start:  4,
+			End:    9,
+		}},
+	})
+
+	if got := result.LetTypes[second]; got != types.Bool {
+		t.Fatalf("second binding type = %v, want Bool", got)
+	}
+	if got := result.LetTypes[first]; got != nil {
+		t.Fatalf("first binding type = %v, want nil; overlay fell back to span match", got)
+	}
+}
+
+func nativeIDTestSource(file *ast.File) selfhostCheckedSource {
+	return selfhostCheckedSource{
+		source: []byte("test\n"),
+		files: []selfhostFileSegment{{
+			file:          file,
+			nativeNodeIDs: true,
+		}},
+	}
+}

--- a/internal/ir/doc.go
+++ b/internal/ir/doc.go
@@ -60,7 +60,11 @@
 //   - Lower(pkg, file, res, chk) → (*Module, []error) — convert a
 //     type-checked AST into an IR Module. Non-fatal issues are
 //     returned separately; poisoned spots collapse to ErrorStmt /
-//     ErrorExpr / ErrorPat rather than panicking.
+//     ErrorExpr / ErrorPat rather than panicking. When chk carries a
+//     NativeCheckResult, lowering reads expression, binding, symbol,
+//     and generic-instantiation facts through the structured NativeIndex
+//     first, falling back to legacy AST-keyed checker maps only for
+//     compatibility or ambiguous package surfaces.
 //
 //   - Walk(v, n) / Inspect(n, fn) — pre-order traversal over every
 //     reachable Node (decl, stmt, expr, pattern).

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -127,6 +127,9 @@ type lowerer struct {
 	// field access on a partial struct re-walks the file's decls
 	// looking for the matching StructDecl.
 	fieldTypeCache map[fieldKey]Type
+
+	// native caches structured selfhost checker facts for this lowering pass.
+	native nativeCheckCache
 }
 
 // ==== Top level ====
@@ -606,6 +609,11 @@ func (l *lowerer) lowerLetDecl(ld *ast.LetDecl) *LetDecl {
 			out.Type = out.Value.Type()
 		}
 	}
+	if !usableRecoveredType(out.Type) {
+		if t := l.nativeSymbolTypeForNode(ld, ld.Name); usableRecoveredType(t) {
+			out.Type = t
+		}
+	}
 	return out
 }
 
@@ -927,18 +935,8 @@ func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
 		// No checker; be conservative: don't promote.
 		return false
 	}
-	if t := l.chk.Types[e]; t != nil {
-		if p, ok := t.(*types.Primitive); ok {
-			if p.Kind == types.PUnit || p.Kind == types.PNever {
-				return false
-			}
-		}
-		if _, ok := t.(*types.Error); !ok {
-			return true
-		}
-		// Error type: fall through to the syntactic fallback so
-		// non-error literal shapes still promote when the checker
-		// didn't infer them.
+	if t := l.exprType(e); usableRecoveredType(t) {
+		return expressionTypeYieldsValue(t)
 	}
 	if t := l.bindingTypeFromAST(e); expressionTypeYieldsValue(t) {
 		return true
@@ -1037,6 +1035,13 @@ func (l *lowerer) lowerLetStmt(s *ast.LetStmt) Stmt {
 		out.Value = l.lowerExpr(s.Value)
 		if out.Type == nil {
 			out.Type = out.Value.Type()
+		}
+	}
+	if !usableRecoveredType(out.Type) {
+		if name, ok := simpleBindName(s.Pattern); ok {
+			if t := l.nativeBindingType(s.Pattern, name); usableRecoveredType(t) {
+				out.Type = t
+			}
 		}
 	}
 	// Record the inferred binding-pattern type so later references
@@ -1140,6 +1145,12 @@ func (l *lowerer) bindingIdentType(id *ast.Ident) Type {
 	sym := l.symbol(id)
 	if sym == nil {
 		return nil
+	}
+	if t := l.nativeBindingTypeForSymbol(sym); usableRecoveredType(t) {
+		return t
+	}
+	if t := l.nativeSymbolType(sym); usableRecoveredType(t) {
+		return t
 	}
 	if l.chk != nil {
 		if st := l.chk.SymTypes[sym]; st != nil {
@@ -1534,6 +1545,9 @@ func (l *lowerer) exprType(e ast.Expr) Type {
 	if l.chk == nil {
 		return ErrTypeVal
 	}
+	if t := l.nativeCheckedType(e); t != nil && t != ErrTypeVal {
+		return t
+	}
 	t := l.chk.Types[e]
 	if t == nil {
 		return ErrTypeVal
@@ -1573,11 +1587,15 @@ func (l *lowerer) lowerIdent(id *ast.Ident) Expr {
 		}
 	}
 	if l.chk != nil {
-		if t := l.chk.Types[id]; t != nil {
-			out.T = l.fromCheckerType(t)
+		if t := l.exprType(id); usableRecoveredType(t) {
+			out.T = t
 		} else if sym != nil {
-			if st := l.chk.SymTypes[sym]; st != nil {
-				out.T = l.fromCheckerType(st)
+			if t := l.nativeSymbolType(sym); usableRecoveredType(t) {
+				out.T = t
+			} else if l.chk.SymTypes != nil {
+				if st := l.chk.SymTypes[sym]; st != nil {
+					out.T = l.fromCheckerType(st)
+				}
 			}
 		}
 	}
@@ -2174,6 +2192,12 @@ func (l *lowerer) structDeclFromReceiver(e ast.Expr) *ast.StructDecl {
 		}
 		if l.chk != nil {
 			if sym := l.symbol(n); sym != nil {
+				if sd := l.structDeclByType(l.nativeBindingTypeForSymbol(sym)); sd != nil {
+					return sd
+				}
+				if sd := l.structDeclByType(l.nativeSymbolType(sym)); sd != nil {
+					return sd
+				}
 				if st := l.chk.SymTypes[sym]; st != nil {
 					if sd := l.structDeclByType(l.fromCheckerType(st)); sd != nil {
 						return sd
@@ -2220,6 +2244,12 @@ func (l *lowerer) structDeclFromReceiver(e ast.Expr) *ast.StructDecl {
 func (l *lowerer) structDeclFromSymbolDecl(sym *resolve.Symbol) *ast.StructDecl {
 	if sym == nil || sym.Decl == nil {
 		return nil
+	}
+	if sd := l.structDeclByType(l.nativeBindingTypeForSymbol(sym)); sd != nil {
+		return sd
+	}
+	if sd := l.structDeclByType(l.nativeSymbolType(sym)); sd != nil {
+		return sd
 	}
 	switch d := sym.Decl.(type) {
 	case *ast.LetStmt:
@@ -2455,7 +2485,13 @@ func (l *lowerer) lowerArg(a *ast.Arg) Arg {
 // checker recorded for this call site (monomorphisation info), or nil
 // when the checker did not annotate it.
 func (l *lowerer) instantiationArgs(e *ast.CallExpr) []Type {
-	if l.chk == nil || l.chk.InstantiationsByID == nil || e == nil {
+	if l.chk == nil || e == nil {
+		return nil
+	}
+	if args := l.nativeInstantiationArgs(e); len(args) > 0 {
+		return args
+	}
+	if l.chk.InstantiationsByID == nil {
 		return nil
 	}
 	raw, ok := l.chk.InstantiationsByID[e.ID]

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost/api"
 	"github.com/osty/osty/internal/stdlib"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
 )
 
 func TestLowerClassifiesTopLevelLetRefsAsGlobal(t *testing.T) {
@@ -95,6 +98,272 @@ func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
 	}
 	if got := len(lit.Args); got != 1 {
 		t.Fatalf("variant args = %d, want 1", got)
+	}
+}
+
+func TestLowerCallTypeUsesNativeIndexWithoutLegacyTypeMap(t *testing.T) {
+	call := &ast.CallExpr{
+		ID: 7,
+		Fn: &ast.Ident{Name: "make_string"},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.LetStmt{
+			Pattern: &ast.IdentPat{Name: "s"},
+			Value:   call,
+		}},
+	}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{{
+				NodeID: int(call.ID),
+				Kind:   "Call",
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "String"},
+			}},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	let, ok := mod.Script[0].(*LetStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *LetStmt", mod.Script[0])
+	}
+	if let.Type != TString {
+		t.Fatalf("let type = %#v, want TString", let.Type)
+	}
+	loweredCall, ok := let.Value.(*CallExpr)
+	if !ok {
+		t.Fatalf("let value = %T, want *CallExpr", let.Value)
+	}
+	if loweredCall.T != TString {
+		t.Fatalf("call type = %#v, want TString", loweredCall.T)
+	}
+}
+
+func TestLowerInstantiationArgsUseNativeIndexWithoutLegacyMap(t *testing.T) {
+	call := &ast.CallExpr{
+		ID: 11,
+		Fn: &ast.Ident{Name: "id"},
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.ExprStmt{X: call}}}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			Instantiations: []api.CheckInstantiation{{
+				NodeID:   int(call.ID),
+				Callee:   "id",
+				TypeArgs: []api.TypeRepr{{Kind: "primitive", Name: "Int"}},
+			}},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	loweredCall, ok := stmt.X.(*CallExpr)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *CallExpr", stmt.X)
+	}
+	if got := loweredCall.TypeArgs; len(got) != 1 || got[0] != TInt {
+		t.Fatalf("call type args = %#v, want [TInt]", got)
+	}
+}
+
+func TestLowerNativeDuplicateNodeIDsFallBackToLegacyTypeMap(t *testing.T) {
+	call := &ast.CallExpr{
+		ID: 13,
+		Fn: &ast.Ident{Name: "ambiguous"},
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.ExprStmt{X: call}}}
+	chk := &check.Result{
+		Types: map[ast.Expr]types.Type{
+			call: types.Bool,
+		},
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{
+				{NodeID: int(call.ID), Kind: "Call", Type: &api.TypeRepr{Kind: "primitive", Name: "String"}},
+				{NodeID: int(call.ID), Kind: "Call", Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}},
+			},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	loweredCall, ok := stmt.X.(*CallExpr)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *CallExpr", stmt.X)
+	}
+	if loweredCall.T != TBool {
+		t.Fatalf("call type = %#v, want TBool from legacy map fallback", loweredCall.T)
+	}
+}
+
+func TestLowerNativeDuplicateNodeIDsUseSpanDisambiguation(t *testing.T) {
+	call := &ast.CallExpr{
+		ID:   15,
+		PosV: token.Pos{Line: 1, Column: 5, Offset: 4},
+		EndV: token.Pos{Line: 1, Column: 14, Offset: 13},
+		Fn:   &ast.Ident{Name: "current"},
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.ExprStmt{X: call}}}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{
+				{NodeID: int(call.ID), Kind: "Call", Start: 40, End: 50, Type: &api.TypeRepr{Kind: "primitive", Name: "String"}},
+				{NodeID: int(call.ID), Kind: "Call", Start: 4, End: 13, Type: &api.TypeRepr{Kind: "primitive", Name: "Int"}},
+			},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	loweredCall, ok := stmt.X.(*CallExpr)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *CallExpr", stmt.X)
+	}
+	if loweredCall.T != TInt {
+		t.Fatalf("call type = %#v, want TInt from span-disambiguated native record", loweredCall.T)
+	}
+}
+
+func TestLowerNativeNodeIDSpanMismatchFallsBackToLegacyTypeMap(t *testing.T) {
+	call := &ast.CallExpr{
+		ID:   17,
+		PosV: token.Pos{Line: 1, Column: 11, Offset: 10},
+		EndV: token.Pos{Line: 1, Column: 22, Offset: 21},
+		Fn:   &ast.Ident{Name: "span_checked"},
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.ExprStmt{X: call}}}
+	chk := &check.Result{
+		Types: map[ast.Expr]types.Type{
+			call: types.Bool,
+		},
+		NativeCheckResult: &api.CheckResult{
+			TypedNodes: []api.CheckedNode{{
+				NodeID: int(call.ID),
+				Kind:   "Call",
+				Start:  0,
+				End:    4,
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "String"},
+			}},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	loweredCall, ok := stmt.X.(*CallExpr)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *CallExpr", stmt.X)
+	}
+	if loweredCall.T != TBool {
+		t.Fatalf("call type = %#v, want TBool from legacy map fallback", loweredCall.T)
+	}
+}
+
+func TestLowerLetStmtUsesNativeBindingTypeWithoutLegacyMap(t *testing.T) {
+	pat := &ast.IdentPat{
+		ID:   21,
+		PosV: token.Pos{Line: 1, Column: 5, Offset: 4},
+		EndV: token.Pos{Line: 1, Column: 6, Offset: 5},
+		Name: "x",
+	}
+	file := &ast.File{Stmts: []ast.Stmt{&ast.LetStmt{
+		Pattern: pat,
+		Value:   &ast.CallExpr{ID: 22, Fn: &ast.Ident{Name: "unknown"}},
+	}}}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			Bindings: []api.CheckedBinding{{
+				NodeID: int(pat.ID),
+				Name:   "x",
+				Start:  4,
+				End:    5,
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "Int"},
+			}},
+		},
+	}
+
+	mod, issues := Lower("main", file, nil, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	let, ok := mod.Script[0].(*LetStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *LetStmt", mod.Script[0])
+	}
+	if let.Type != TInt {
+		t.Fatalf("let type = %#v, want TInt from native binding", let.Type)
+	}
+}
+
+func TestLowerIdentUsesNativeSymbolTypeWithoutLegacyMap(t *testing.T) {
+	global := &ast.LetDecl{ID: 31, Name: "g"}
+	ref := &ast.Ident{ID: 32, Name: "g"}
+	file := &ast.File{
+		Decls: []ast.Decl{global},
+		Stmts: []ast.Stmt{&ast.LetStmt{
+			Pattern: &ast.IdentPat{Name: "y"},
+			Value:   ref,
+		}},
+	}
+	res := &resolve.Result{
+		RefsByID: map[ast.NodeID]*resolve.Symbol{
+			ref.ID: {Name: "g", Kind: resolve.SymLet, Decl: global},
+		},
+		RefIdents: []*ast.Ident{ref},
+	}
+	chk := &check.Result{
+		NativeCheckResult: &api.CheckResult{
+			Symbols: []api.CheckedSymbol{{
+				NodeID: int(global.ID),
+				Kind:   "let",
+				Name:   "g",
+				Type:   &api.TypeRepr{Kind: "primitive", Name: "String"},
+			}},
+		},
+	}
+
+	mod, issues := Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	let, ok := mod.Script[0].(*LetStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *LetStmt", mod.Script[0])
+	}
+	if let.Type != TString {
+		t.Fatalf("let type = %#v, want TString from native symbol", let.Type)
+	}
+	id, ok := let.Value.(*Ident)
+	if !ok {
+		t.Fatalf("let value = %T, want *Ident", let.Value)
+	}
+	if id.T != TString {
+		t.Fatalf("ident type = %#v, want TString from native symbol", id.T)
 	}
 }
 

--- a/internal/ir/native_check.go
+++ b/internal/ir/native_check.go
@@ -1,0 +1,359 @@
+package ir
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost/api"
+)
+
+type nativeCheckCache struct {
+	idx                api.CheckResultIndex
+	ready              bool
+	typedNodesByNodeID map[int][]*api.CheckedNode
+}
+
+func (l *lowerer) nativeIndex() (api.CheckResultIndex, bool) {
+	if l.native.ready {
+		return l.native.idx, l.chk != nil && l.chk.NativeResult() != nil
+	}
+	l.native.ready = true
+	if l.chk == nil || l.chk.NativeResult() == nil {
+		return l.native.idx, false
+	}
+	native := l.chk.NativeResult()
+	native.EnsureStableIDs()
+	l.native.idx = native.Index()
+	l.native.typedNodesByNodeID = typedNodesByNodeID(native.TypedNodes)
+	return l.native.idx, true
+}
+
+func typedNodesByNodeID(nodes []api.CheckedNode) map[int][]*api.CheckedNode {
+	out := make(map[int][]*api.CheckedNode, len(nodes))
+	for i := range nodes {
+		id := nativeRecordNodeID(nodes[i].NodeID, nodes[i].Node)
+		if id == 0 {
+			continue
+		}
+		out[id] = append(out[id], &nodes[i])
+	}
+	return out
+}
+
+func nativeRecordNodeID(nodeID, legacyNode int) int {
+	if nodeID != 0 {
+		return nodeID
+	}
+	return legacyNode
+}
+
+func (l *lowerer) nativeCheckedType(e ast.Expr) Type {
+	id := astNodeID(e)
+	if id == 0 {
+		return nil
+	}
+	if _, ok := l.nativeIndex(); !ok {
+		return nil
+	}
+	rec := selectNativeTypedNode(l.native.typedNodesByNodeID[int(id)], e)
+	if rec == nil {
+		return nil
+	}
+	return l.fromNativeTypeRepr(rec.Type)
+}
+
+func selectNativeTypedNode(records []*api.CheckedNode, n ast.Node) *api.CheckedNode {
+	var out *api.CheckedNode
+	for _, rec := range records {
+		if rec == nil || !nativeRecordMatchesNode(rec.Start, rec.End, n) {
+			continue
+		}
+		if out != nil {
+			return nil
+		}
+		out = rec
+	}
+	return out
+}
+
+func (l *lowerer) nativeInstantiationArgs(e *ast.CallExpr) []Type {
+	id := astNodeID(e)
+	if id == 0 {
+		return nil
+	}
+	idx, ok := l.nativeIndex()
+	if !ok {
+		return nil
+	}
+	rec := selectNativeInstantiation(idx.InstantiationsByNodeID[int(id)], e)
+	if rec == nil || len(rec.TypeArgs) == 0 {
+		return nil
+	}
+	out := make([]Type, 0, len(rec.TypeArgs))
+	for i := range rec.TypeArgs {
+		out = append(out, l.fromNativeTypeRepr(&rec.TypeArgs[i]))
+	}
+	return out
+}
+
+func selectNativeInstantiation(records []*api.CheckInstantiation, n ast.Node) *api.CheckInstantiation {
+	var out *api.CheckInstantiation
+	for _, rec := range records {
+		if rec == nil || !nativeRecordMatchesNode(rec.Start, rec.End, n) {
+			continue
+		}
+		if out != nil {
+			return nil
+		}
+		out = rec
+	}
+	return out
+}
+
+func (l *lowerer) nativeBindingTypeForSymbol(sym *resolve.Symbol) Type {
+	if sym == nil {
+		return nil
+	}
+	return l.nativeBindingType(sym.Decl, sym.Name)
+}
+
+func (l *lowerer) nativeBindingType(n ast.Node, name string) Type {
+	id := astNodeID(n)
+	if id == 0 {
+		return nil
+	}
+	idx, ok := l.nativeIndex()
+	if !ok {
+		return nil
+	}
+	rec := selectNativeBinding(idx.BindingsByNodeID[int(id)], n, name)
+	if rec == nil {
+		return nil
+	}
+	return l.fromNativeTypeRepr(rec.Type)
+}
+
+func selectNativeBinding(records []*api.CheckedBinding, n ast.Node, name string) *api.CheckedBinding {
+	var out *api.CheckedBinding
+	for _, rec := range records {
+		if rec == nil || (name != "" && rec.Name != name) || !nativeRecordMatchesNode(rec.Start, rec.End, n) {
+			continue
+		}
+		if out != nil {
+			return nil
+		}
+		out = rec
+	}
+	return out
+}
+
+func (l *lowerer) nativeSymbolType(sym *resolve.Symbol) Type {
+	if sym == nil {
+		return nil
+	}
+	return l.nativeSymbolTypeForNode(sym.Decl, sym.Name)
+}
+
+func (l *lowerer) nativeSymbolTypeForNode(n ast.Node, name string) Type {
+	id := astNodeID(n)
+	if id == 0 {
+		return nil
+	}
+	idx, ok := l.nativeIndex()
+	if !ok {
+		return nil
+	}
+	rec := selectNativeSymbol(idx.SymbolsByNodeID[int(id)], n, name)
+	if rec == nil {
+		return nil
+	}
+	return l.fromNativeTypeRepr(rec.Type)
+}
+
+func selectNativeSymbol(records []*api.CheckedSymbol, n ast.Node, name string) *api.CheckedSymbol {
+	var out *api.CheckedSymbol
+	for _, rec := range records {
+		if rec == nil || (name != "" && rec.Name != name) || !nativeRecordMatchesNode(rec.Start, rec.End, n) {
+			continue
+		}
+		if out != nil {
+			return nil
+		}
+		out = rec
+	}
+	return out
+}
+
+func (l *lowerer) fromNativeTypeRepr(tr *api.TypeRepr) Type {
+	if tr == nil {
+		return nil
+	}
+	switch tr.Kind {
+	case "error", "poison":
+		return ErrTypeVal
+	case "primitive":
+		switch tr.Name {
+		case "", "Invalid", "Poison":
+			return ErrTypeVal
+		case "UntypedInt":
+			return TInt
+		case "UntypedFloat":
+			return TFloat
+		case "()", "Unit":
+			return TUnit
+		case "Never":
+			return TNever
+		default:
+			if p := primitiveByName(tr.Name); p != nil {
+				return p
+			}
+			return ErrTypeVal
+		}
+	case "unit":
+		return TUnit
+	case "never":
+		return TNever
+	case "optional":
+		inner := l.fromNativeTypeRepr(tr.Return)
+		if inner == nil {
+			inner = ErrTypeVal
+		}
+		return &OptionalType{Inner: inner}
+	case "tuple":
+		elems := make([]Type, len(tr.Args))
+		for i := range tr.Args {
+			elems[i] = l.fromNativeTypeRepr(&tr.Args[i])
+		}
+		return &TupleType{Elems: elems}
+	case "fn":
+		params := make([]Type, len(tr.Args))
+		for i := range tr.Args {
+			params[i] = l.fromNativeTypeRepr(&tr.Args[i])
+		}
+		ret := l.fromNativeTypeRepr(tr.Return)
+		if ret == nil {
+			ret = TUnit
+		}
+		return &FnType{Params: params, Return: ret}
+	case "named":
+		return l.nativeNamedType(tr)
+	case "typevar":
+		name := tr.Name
+		if name == "" {
+			name = "?"
+		}
+		return &TypeVar{Name: name}
+	case "self":
+		return &TypeVar{Name: "Self"}
+	default:
+		if tr.Name != "" {
+			return l.nativeNamedType(tr)
+		}
+		return ErrTypeVal
+	}
+}
+
+func (l *lowerer) nativeNamedType(tr *api.TypeRepr) Type {
+	name := tr.Name
+	if name == "" {
+		name = tr.Path
+	}
+	if name == "" {
+		return ErrTypeVal
+	}
+	pkg, base := splitQualifiedTypeName(name)
+	if pkg == "" && len(tr.Args) == 0 {
+		if p := primitiveByName(base); p != nil {
+			return p
+		}
+	}
+	if alias := l.localTypeAliasTarget(pkg, base); alias != nil {
+		return alias
+	}
+	args := make([]Type, len(tr.Args))
+	for i := range tr.Args {
+		args[i] = l.fromNativeTypeRepr(&tr.Args[i])
+	}
+	builtin := pkg == "" && isNativeBuiltinNamedType(base)
+	return &NamedType{Package: pkg, Name: base, Args: args, Builtin: builtin}
+}
+
+func splitQualifiedTypeName(name string) (string, string) {
+	dot := strings.LastIndexByte(name, '.')
+	if dot <= 0 || dot == len(name)-1 {
+		return "", name
+	}
+	return name[:dot], name[dot+1:]
+}
+
+func isNativeBuiltinNamedType(name string) bool {
+	switch name {
+	case "List", "Map", "Set", "Option", "Result":
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *lowerer) localTypeAliasTarget(pkg, name string) Type {
+	if pkg != "" || name == "" || l.file == nil {
+		return nil
+	}
+	for _, decl := range l.file.Decls {
+		alias, ok := decl.(*ast.TypeAliasDecl)
+		if !ok || alias == nil || alias.Name != name || alias.Target == nil {
+			continue
+		}
+		return l.lowerType(alias.Target)
+	}
+	return nil
+}
+
+var astNodeIDType = reflect.TypeOf(ast.NodeID(0))
+
+func astNodeID(n ast.Node) ast.NodeID {
+	if n == nil {
+		return 0
+	}
+	v := reflect.ValueOf(n)
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return 0
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return 0
+	}
+	f := v.FieldByName("ID")
+	if !f.IsValid() || f.Type() != astNodeIDType {
+		return 0
+	}
+	return ast.NodeID(f.Uint())
+}
+
+func nativeRecordMatchesNode(start, end int, n ast.Node) bool {
+	nodeStart, nodeEnd, ok := astNodeByteRange(n)
+	if !ok {
+		return true
+	}
+	return start == nodeStart && end == nodeEnd
+}
+
+func astNodeByteRange(n ast.Node) (int, int, bool) {
+	if n == nil {
+		return 0, 0, false
+	}
+	start := n.Pos()
+	end := n.End()
+	if start.Line == 0 && start.Column == 0 && start.Offset == 0 &&
+		end.Line == 0 && end.Column == 0 && end.Offset == 0 {
+		return 0, 0, false
+	}
+	return start.Offset, end.Offset, true
+}


### PR DESCRIPTION
## Summary
- Prefer native checker NodeID lookups when rebuilding legacy checker maps for structured single-file results.
- Keep span/kind/name fallback compatibility for older or synthetic checker paths, while making the fallback scan cheaper on large files.
- Move structured native consumers toward `internal/selfhost/api` and add regressions for same-span overlay ambiguity.

## Validation
- `go test -count=1 -vet=off ./internal/check ./internal/ir ./internal/resolve ./internal/selfhost`
- `just short`
- `git diff --check HEAD~1..HEAD`