### PR TITLE
[codex] Add explicit backend capability matrix

### DIFF
--- a/internal/backend/capability.go
+++ b/internal/backend/capability.go
@@ -1,0 +1,306 @@
+package backend
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/llvmgen"
+)
+
+// CapabilityID names one explicit backend coverage row. Rows are intentionally
+// small and data-shaped so dispatch policy can be audited without reading the
+// emitter control flow.
+type CapabilityID string
+
+const (
+	CapabilityGoFFI         CapabilityID = "hir.use.go-ffi"
+	CapabilityHIRNode       CapabilityID = "hir.node"
+	CapabilityMIRLowerIssue CapabilityID = "mir.lower.issue"
+	CapabilityMIREmit       CapabilityID = "mir.emit"
+	CapabilityRuntimeFFI    CapabilityID = "hir.use.runtime-ffi"
+	CapabilityNativeOwned   CapabilityID = "backend.llvm.native-owned"
+	CapabilityMIRDirect     CapabilityID = "backend.llvm.mir-direct"
+)
+
+// CapabilityRow records whether one source/backend shape can cross each
+// pipeline boundary. RuntimeABIKnown is meaningful only when
+// RuntimeABIRequired is true.
+type CapabilityRow struct {
+	ID                 CapabilityID
+	Subject            string
+	HIRSupported       bool
+	MIRLowerable       bool
+	LLVMEmittable      bool
+	RuntimeABIRequired bool
+	RuntimeABIKnown    bool
+	FallbackAllowed    bool
+	DiagnosticKind     string
+	DiagnosticDetail   string
+	Diagnostic         llvmgen.UnsupportedDiagnostic
+	Route              string
+	Count              int
+}
+
+// CapabilityMatrix is the explicit HIR -> MIR -> LLVM coverage contract for
+// one backend entry.
+type CapabilityMatrix struct {
+	rows []CapabilityRow
+}
+
+// NewLLVMCapabilityMatrix builds the coverage matrix used by LLVM backend
+// dispatch. The matrix is deliberately derived from Entry rather than the AST:
+// backend policy should be stated over the backend-neutral contract.
+func NewLLVMCapabilityMatrix(entry Entry, opts llvmgen.Options) CapabilityMatrix {
+	return newLLVMCapabilityMatrix(entry, opts, nil, "", false)
+}
+
+func newLLVMDispatchCapabilityMatrix(entry Entry, opts llvmgen.Options, features []string, emit EmitMode) CapabilityMatrix {
+	return newLLVMCapabilityMatrix(entry, opts, features, emit, true)
+}
+
+func newLLVMCapabilityMatrix(entry Entry, opts llvmgen.Options, features []string, emit EmitMode, includeNativeRoute bool) CapabilityMatrix {
+	rows := make([]CapabilityRow, 0, 16)
+	rows = appendHIRNodeCapabilities(rows, entry)
+	rows = appendIRUseCapabilities(rows, entry.IR)
+	rows = appendMIRLoweringCapabilities(rows, entry)
+	rows = appendLLVMRouteCapabilities(rows, entry, opts, features, emit, includeNativeRoute)
+	rows = appendMIREmitCapabilities(rows, entry, opts)
+	return CapabilityMatrix{rows: rows}
+}
+
+// Rows returns a stable snapshot of the matrix rows.
+func (m CapabilityMatrix) Rows() []CapabilityRow {
+	return append([]CapabilityRow(nil), m.rows...)
+}
+
+// BlockingDiagnostic returns the first row that cannot be emitted and cannot
+// legally fall back to another backend path.
+func (m CapabilityMatrix) BlockingDiagnostic() (llvmgen.UnsupportedDiagnostic, CapabilityRow, bool) {
+	for _, row := range m.rows {
+		if !rowHasDiagnostic(row) || row.LLVMEmittable || row.FallbackAllowed {
+			continue
+		}
+		return rowDiagnostic(row), row, true
+	}
+	return llvmgen.UnsupportedDiagnostic{}, CapabilityRow{}, false
+}
+
+func (m CapabilityMatrix) PreflightBlockingDiagnostic() (llvmgen.UnsupportedDiagnostic, CapabilityRow, bool) {
+	for _, row := range m.rows {
+		if row.Route != "" || row.FallbackAllowed || row.LLVMEmittable {
+			continue
+		}
+		if !rowHasDiagnostic(row) {
+			continue
+		}
+		return rowDiagnostic(row), row, true
+	}
+	return llvmgen.UnsupportedDiagnostic{}, CapabilityRow{}, false
+}
+
+func (m CapabilityMatrix) RouteBlockingDiagnostic(route llvmDispatchRoute) (llvmgen.UnsupportedDiagnostic, CapabilityRow, bool) {
+	for _, row := range m.rows {
+		if row.Route != string(route) || row.FallbackAllowed || row.LLVMEmittable {
+			continue
+		}
+		if !rowHasDiagnostic(row) {
+			continue
+		}
+		return rowDiagnostic(row), row, true
+	}
+	return llvmgen.UnsupportedDiagnostic{}, CapabilityRow{}, false
+}
+
+func (m CapabilityMatrix) DispatchRoute() llvmDispatchRoute {
+	for _, row := range m.rows {
+		if row.Route == string(llvmDispatchMIRDirect) {
+			return llvmDispatchMIRDirect
+		}
+	}
+	for _, row := range m.rows {
+		if row.Route == "" || !row.LLVMEmittable {
+			continue
+		}
+		if row.Route == string(llvmDispatchNativeOwned) {
+			continue
+		}
+		return llvmDispatchRoute(row.Route)
+	}
+	return llvmDispatchMIRDirect
+}
+
+func (m CapabilityMatrix) CanRoute(route llvmDispatchRoute) bool {
+	for _, row := range m.rows {
+		if row.Route == string(route) && row.LLVMEmittable {
+			return true
+		}
+	}
+	return false
+}
+
+func rowHasDiagnostic(row CapabilityRow) bool {
+	return row.Diagnostic.Code != "" || row.Diagnostic.Kind != "" || row.Diagnostic.Message != "" || row.DiagnosticKind != ""
+}
+
+func rowDiagnostic(row CapabilityRow) llvmgen.UnsupportedDiagnostic {
+	if row.Diagnostic.Code != "" || row.Diagnostic.Kind != "" || row.Diagnostic.Message != "" {
+		return row.Diagnostic
+	}
+	return llvmgen.UnsupportedDiagnosticFor(row.DiagnosticKind, row.DiagnosticDetail)
+}
+
+func appendHIRNodeCapabilities(rows []CapabilityRow, entry Entry) []CapabilityRow {
+	if entry.IR == nil {
+		return rows
+	}
+	counts := map[string]int{}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		if n == nil {
+			return true
+		}
+		counts[fmt.Sprintf("%T", n)]++
+		return true
+	}), entry.IR)
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	mirReady := entry.MIR != nil && !hasMIRLoweringIssues(entry)
+	for _, key := range keys {
+		rows = append(rows, CapabilityRow{
+			ID:            CapabilityHIRNode,
+			Subject:       key,
+			HIRSupported:  true,
+			MIRLowerable:  mirReady,
+			LLVMEmittable: mirReady,
+			Count:         counts[key],
+		})
+	}
+	return rows
+}
+
+func hasMIRLoweringIssues(entry Entry) bool {
+	for _, issue := range entry.MIRIssues {
+		if issue != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func appendIRUseCapabilities(rows []CapabilityRow, mod *ir.Module) []CapabilityRow {
+	if mod == nil {
+		return rows
+	}
+	for _, decl := range mod.Decls {
+		use, ok := decl.(*ir.UseDecl)
+		if !ok || use == nil {
+			continue
+		}
+		if use.IsGoFFI {
+			rows = append(rows, CapabilityRow{
+				ID:               CapabilityGoFFI,
+				Subject:          use.GoPath,
+				HIRSupported:     true,
+				MIRLowerable:     false,
+				LLVMEmittable:    false,
+				FallbackAllowed:  false,
+				DiagnosticKind:   "go-ffi",
+				DiagnosticDetail: use.GoPath,
+			})
+			continue
+		}
+		if use.IsRuntimeFFI {
+			known := llvmgen.IsKnownRuntimeFFIPath(use.RuntimePath)
+			row := CapabilityRow{
+				ID:                 CapabilityRuntimeFFI,
+				Subject:            use.RuntimePath,
+				HIRSupported:       true,
+				MIRLowerable:       known,
+				LLVMEmittable:      known,
+				RuntimeABIRequired: true,
+				RuntimeABIKnown:    known,
+				FallbackAllowed:    false,
+			}
+			if !known {
+				row.DiagnosticKind = "runtime-ffi"
+				row.DiagnosticDetail = use.RuntimePath
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func appendMIRLoweringCapabilities(rows []CapabilityRow, entry Entry) []CapabilityRow {
+	for i, issue := range entry.MIRIssues {
+		if issue == nil {
+			continue
+		}
+		rows = append(rows, CapabilityRow{
+			ID:               CapabilityMIRLowerIssue,
+			Subject:          fmt.Sprintf("mir.lower.issue:%d", i),
+			HIRSupported:     entry.IR != nil,
+			MIRLowerable:     false,
+			LLVMEmittable:    false,
+			FallbackAllowed:  true,
+			DiagnosticKind:   "unsupported-source",
+			DiagnosticDetail: issue.Error(),
+			Count:            1,
+		})
+	}
+	return rows
+}
+
+func appendLLVMRouteCapabilities(rows []CapabilityRow, entry Entry, opts llvmgen.Options, features []string, emit EmitMode, includeNativeRoute bool) []CapabilityRow {
+	hirReady := entry.IR != nil
+	if includeNativeRoute {
+		nativeReady := hirReady && useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR)
+		rows = append(rows, CapabilityRow{
+			ID:              CapabilityNativeOwned,
+			Subject:         string(llvmDispatchNativeOwned),
+			HIRSupported:    hirReady,
+			MIRLowerable:    false,
+			LLVMEmittable:   nativeReady,
+			FallbackAllowed: true,
+			Route:           string(llvmDispatchNativeOwned),
+		})
+	}
+	mirReady := entry.MIR != nil
+	rows = append(rows, CapabilityRow{
+		ID:                 CapabilityMIRDirect,
+		Subject:            string(llvmDispatchMIRDirect),
+		HIRSupported:       hirReady,
+		MIRLowerable:       mirReady,
+		LLVMEmittable:      hirReady && mirReady,
+		RuntimeABIRequired: opts.EmitGC,
+		RuntimeABIKnown:    opts.EmitGC,
+		FallbackAllowed:    false,
+		Route:              string(llvmDispatchMIRDirect),
+	})
+	return rows
+}
+
+func appendMIREmitCapabilities(rows []CapabilityRow, entry Entry, opts llvmgen.Options) []CapabilityRow {
+	if entry.MIR == nil && !opts.UseMIR {
+		return rows
+	}
+	for _, reportRow := range llvmgen.MIRCapabilityReport(entry.MIR, opts) {
+		row := CapabilityRow{
+			ID:                 CapabilityMIREmit,
+			Subject:            reportRow.Subject,
+			HIRSupported:       entry.IR != nil,
+			MIRLowerable:       entry.MIR != nil,
+			LLVMEmittable:      reportRow.LLVMEmittable,
+			RuntimeABIRequired: reportRow.RuntimeABIRequired,
+			RuntimeABIKnown:    reportRow.RuntimeABIKnown,
+			Diagnostic:         reportRow.Diagnostic,
+			Route:              string(llvmDispatchMIRDirect),
+			Count:              1,
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}

--- a/internal/backend/capability_test.go
+++ b/internal/backend/capability_test.go
@@ -1,0 +1,366 @@
+package backend
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/mir"
+)
+
+func TestLLVMCapabilityMatrixReportsGoFFIBlocker(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR: &ir.Module{
+			Decls: []ir.Decl{
+				&ir.UseDecl{IsGoFFI: true, GoPath: "strings"},
+			},
+		},
+		MIR: &mir.Module{},
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+
+	row, ok := capabilityRow(matrix, CapabilityGoFFI)
+	if !ok {
+		t.Fatal("go FFI capability row missing")
+	}
+	if !row.HIRSupported {
+		t.Fatal("go FFI HIRSupported = false, want true")
+	}
+	if row.MIRLowerable {
+		t.Fatal("go FFI MIRLowerable = true, want false")
+	}
+	if row.LLVMEmittable {
+		t.Fatal("go FFI LLVMEmittable = true, want false")
+	}
+	if row.RuntimeABIRequired {
+		t.Fatal("go FFI RuntimeABIRequired = true, want false")
+	}
+	if row.FallbackAllowed {
+		t.Fatal("go FFI FallbackAllowed = true, want false")
+	}
+	diag, blocker, ok := matrix.BlockingDiagnostic()
+	if !ok {
+		t.Fatal("BlockingDiagnostic not reported")
+	}
+	if got, want := blocker.DiagnosticKind, "go-ffi"; got != want {
+		t.Fatalf("blocker.DiagnosticKind = %q, want %q", got, want)
+	}
+	if got, want := diag.Kind, "foreign-ffi"; got != want {
+		t.Fatalf("diag.Kind = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMCapabilityMatrixRecordsRuntimeABIKnownness(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR: &ir.Module{
+			Decls: []ir.Decl{
+				&ir.UseDecl{IsRuntimeFFI: true, RuntimePath: "runtime.strings"},
+				&ir.UseDecl{IsRuntimeFFI: true, RuntimePath: "runtime.unknown"},
+			},
+		},
+		MIR: &mir.Module{},
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+
+	rows := rowsByID(matrix, CapabilityRuntimeFFI)
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("runtime FFI row count = %d, want %d", got, want)
+	}
+	known := rowBySubject(rows, "runtime.strings")
+	if known == nil {
+		t.Fatal("runtime.strings capability row missing")
+	}
+	if !known.RuntimeABIRequired || !known.RuntimeABIKnown || !known.LLVMEmittable {
+		t.Fatalf("runtime.strings row = %+v, want known ABI and LLVM-emittable", *known)
+	}
+	unknown := rowBySubject(rows, "runtime.unknown")
+	if unknown == nil {
+		t.Fatal("runtime.unknown capability row missing")
+	}
+	if !unknown.RuntimeABIRequired || unknown.RuntimeABIKnown || unknown.LLVMEmittable {
+		t.Fatalf("runtime.unknown row = %+v, want required-but-unknown ABI blocker", *unknown)
+	}
+	diag, _, ok := matrix.BlockingDiagnostic()
+	if !ok {
+		t.Fatal("BlockingDiagnostic not reported")
+	}
+	if got, want := diag.Kind, "runtime-ffi"; got != want {
+		t.Fatalf("diag.Kind = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMCapabilityMatrixRecordsHIRNodeCoverage(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR: &ir.Module{
+			Decls: []ir.Decl{
+				&ir.FnDecl{
+					Name:   "answer",
+					Return: ir.TInt,
+					Body: &ir.Block{
+						Result: &ir.IntLit{Text: "1", T: ir.TInt},
+					},
+				},
+			},
+		},
+		MIR: &mir.Module{},
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+
+	rows := rowsByID(matrix, CapabilityHIRNode)
+	fn := rowBySubject(rows, "*ir.FnDecl")
+	if fn == nil {
+		t.Fatalf("HIR capability rows missing *ir.FnDecl: %+v", rows)
+	}
+	if got, want := fn.Count, 1; got != want {
+		t.Fatalf("*ir.FnDecl Count = %d, want %d", got, want)
+	}
+	if !fn.HIRSupported || !fn.MIRLowerable || !fn.LLVMEmittable {
+		t.Fatalf("*ir.FnDecl row = %+v, want supported through MIR and LLVM", *fn)
+	}
+
+	entry.MIRIssues = []error{errors.New("synthetic MIR lowering gap")}
+	matrix = NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+	fn = rowBySubject(rowsByID(matrix, CapabilityHIRNode), "*ir.FnDecl")
+	if fn == nil {
+		t.Fatal("HIR capability row missing after MIR issue")
+	}
+	if !fn.HIRSupported || fn.MIRLowerable || fn.LLVMEmittable {
+		t.Fatalf("*ir.FnDecl row with MIR issue = %+v, want HIR-only coverage", *fn)
+	}
+	issue, ok := capabilityRow(matrix, CapabilityMIRLowerIssue)
+	if !ok {
+		t.Fatal("MIR lowering issue capability row missing")
+	}
+	if !issue.FallbackAllowed {
+		t.Fatalf("MIR lowering issue row = %+v, want fallback allowed", issue)
+	}
+	if _, _, ok := matrix.PreflightBlockingDiagnostic(); ok {
+		t.Fatal("MIR lowering issue should not be a preflight blocker while fallback is allowed")
+	}
+}
+
+func TestLLVMCapabilityMatrixSelectsDispatchRoute(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR:  &ir.Module{},
+		MIR: &mir.Module{},
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+	if got, want := matrix.DispatchRoute(), llvmDispatchMIRDirect; got != want {
+		t.Fatalf("DispatchRoute = %q, want %q", got, want)
+	}
+	row, ok := capabilityRow(matrix, CapabilityMIRDirect)
+	if !ok {
+		t.Fatal("MIR route row missing")
+	}
+	if !row.HIRSupported || !row.MIRLowerable || !row.LLVMEmittable {
+		t.Fatalf("MIR route row = %+v, want all pipeline stages ready", row)
+	}
+	if !row.RuntimeABIRequired || !row.RuntimeABIKnown {
+		t.Fatalf("MIR route runtime ABI row = %+v, want required and known", row)
+	}
+
+	entry.MIR = nil
+	matrix = NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+	if got, want := matrix.DispatchRoute(), llvmDispatchMIRDirect; got != want {
+		t.Fatalf("DispatchRoute without MIR = %q, want %q", got, want)
+	}
+	diag, row, ok := matrix.RouteBlockingDiagnostic(llvmDispatchMIRDirect)
+	if !ok {
+		t.Fatal("missing-MIR route blocker not reported")
+	}
+	if row.ID != CapabilityMIREmit || row.Subject != "mir.module" {
+		t.Fatalf("missing-MIR route blocker = %+v, want MIR module emit blocker", row)
+	}
+	if got, want := diag.Kind, "source-layout"; got != want {
+		t.Fatalf("diag.Kind = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMCapabilityMatrixRecordsMIRRouteBlocker(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR:  &ir.Module{},
+		MIR: mirModuleWithFunction(unsupportedMIRFunction()),
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+
+	if got, want := matrix.DispatchRoute(), llvmDispatchMIRDirect; got != want {
+		t.Fatalf("DispatchRoute = %q, want %q", got, want)
+	}
+	if _, _, ok := matrix.PreflightBlockingDiagnostic(); ok {
+		t.Fatal("MIR emitter gap should not block preflight before route selection")
+	}
+	diag, row, ok := matrix.RouteBlockingDiagnostic(llvmDispatchMIRDirect)
+	if !ok {
+		t.Fatal("RouteBlockingDiagnostic(mir-direct) not reported")
+	}
+	if row.ID != CapabilityMIREmit {
+		t.Fatalf("route blocker ID = %q, want %q", row.ID, CapabilityMIREmit)
+	}
+	if row.Route != string(llvmDispatchMIRDirect) {
+		t.Fatalf("route blocker Route = %q, want %q", row.Route, llvmDispatchMIRDirect)
+	}
+	if row.Subject != "mir.local:bad:poison:1" {
+		t.Fatalf("route blocker Subject = %q, want poisoned local row", row.Subject)
+	}
+	if row.LLVMEmittable {
+		t.Fatalf("route blocker row = %+v, want LLVMEmittable=false", row)
+	}
+	if got, want := diag.Kind, "unsupported-source"; got != want {
+		t.Fatalf("diag.Kind = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMCapabilityMatrixRecordsMIRRuntimeABI(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR:  &ir.Module{},
+		MIR: mirModuleWithFunction(printlnMIRFunction()),
+	}
+	matrix := NewLLVMCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true})
+
+	row := rowBySubject(rowsByID(matrix, CapabilityMIREmit), "mir.instr:main:bb0:0:*mir.IntrinsicInstr")
+	if row == nil {
+		t.Fatalf("MIR intrinsic capability row missing: %+v", rowsByID(matrix, CapabilityMIREmit))
+	}
+	if !row.LLVMEmittable {
+		t.Fatalf("MIR intrinsic row = %+v, want LLVM-emittable", *row)
+	}
+	if !row.RuntimeABIRequired || !row.RuntimeABIKnown {
+		t.Fatalf("MIR intrinsic row = %+v, want known runtime ABI", *row)
+	}
+	if _, _, ok := matrix.RouteBlockingDiagnostic(llvmDispatchMIRDirect); ok {
+		t.Fatal("supported MIR intrinsic unexpectedly blocked mir-direct route")
+	}
+}
+
+func TestLLVMCapabilityMatrixRecordsNativeOwnedRoute(t *testing.T) {
+	t.Parallel()
+
+	entry := Entry{
+		IR:  &ir.Module{},
+		MIR: &mir.Module{},
+	}
+	matrix := newLLVMDispatchCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true}, nil, EmitLLVMIR)
+	row, ok := capabilityRow(matrix, CapabilityNativeOwned)
+	if !ok {
+		t.Fatal("native-owned row missing")
+	}
+	if !row.HIRSupported || row.MIRLowerable || !row.LLVMEmittable || !row.FallbackAllowed {
+		t.Fatalf("native-owned row = %+v, want HIR-only route with fallback allowed", row)
+	}
+	if !matrix.CanRoute(llvmDispatchNativeOwned) {
+		t.Fatal("CanRoute(native-owned) = false, want true")
+	}
+
+	matrix = newLLVMDispatchCapabilityMatrix(entry, llvmgen.Options{UseMIR: true, EmitGC: true}, []string{"mir-backend"}, EmitLLVMIR)
+	row, ok = capabilityRow(matrix, CapabilityNativeOwned)
+	if !ok {
+		t.Fatal("native-owned row missing when feature disables it")
+	}
+	if row.LLVMEmittable {
+		t.Fatalf("native-owned row = %+v, want LLVMEmittable=false under mir-backend feature", row)
+	}
+	if matrix.CanRoute(llvmDispatchNativeOwned) {
+		t.Fatal("CanRoute(native-owned) = true under mir-backend feature, want false")
+	}
+	if got, want := matrix.DispatchRoute(), llvmDispatchMIRDirect; got != want {
+		t.Fatalf("DispatchRoute = %q, want %q", got, want)
+	}
+}
+
+func mirModuleWithFunction(fn *mir.Function) *mir.Module {
+	return &mir.Module{
+		Package:   "main",
+		Functions: []*mir.Function{fn},
+		Layouts:   mir.NewLayoutTable(),
+	}
+}
+
+func unsupportedMIRFunction() *mir.Function {
+	return &mir.Function{
+		Name:        "bad",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+			{ID: 1, Name: "poison", Type: ir.ErrTypeVal},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Term: &mir.BranchTerm{
+					Cond: &mir.CopyOp{Place: mir.Place{Local: 1}, T: ir.ErrTypeVal},
+					Then: 0,
+					Else: 0,
+				},
+			},
+		},
+	}
+}
+
+func printlnMIRFunction() *mir.Function {
+	return &mir.Function{
+		Name:        "main",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					&mir.IntrinsicInstr{
+						Kind: mir.IntrinsicPrintln,
+						Args: []mir.Operand{
+							&mir.ConstOp{Const: &mir.IntConst{Value: 42, T: ir.TInt}, T: ir.TInt},
+						},
+					},
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+}
+
+func capabilityRow(matrix CapabilityMatrix, id CapabilityID) (CapabilityRow, bool) {
+	for _, row := range matrix.Rows() {
+		if row.ID == id {
+			return row, true
+		}
+	}
+	return CapabilityRow{}, false
+}
+
+func rowsByID(matrix CapabilityMatrix, id CapabilityID) []CapabilityRow {
+	var rows []CapabilityRow
+	for _, row := range matrix.Rows() {
+		if row.ID == id {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func rowBySubject(rows []CapabilityRow, subject string) *CapabilityRow {
+	for i := range rows {
+		if rows[i].Subject == subject {
+			return &rows[i]
+		}
+	}
+	return nil
+}

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -9,15 +9,19 @@
 // The dispatcher never falls back to Request.Entry.File when lowering
 // hits an unsupported shape.
 //
-// Dispatch order is intentionally small and observable:
+// LLVM dispatch is driven by CapabilityMatrix, an explicit per-entry
+// contract with rows for HIR node coverage, MIR lowering issues, MIR
+// emitter support, runtime ABI requirements, route coverage, and fallback
+// policy. Dispatch order is intentionally small and observable:
 //
-//   - `unsupported-preflight`: IR preflight rejects backend-capability gaps
+//   - `unsupported-preflight`: capability preflight rejects backend gaps
 //     such as Go FFI or unknown runtime FFI before any concrete emitter is
 //     selected.
 //   - `native-owned`: the native-owned llvmgen slice gets the first chance
 //     when the feature set allows it and no injected stdlib bodies are present.
 //   - `mir-direct`: every remaining normal backend request routes through
-//     MIR-direct emission.
+//     MIR-direct emission; MIR route blockers are read from the same
+//     capability matrix before emission.
 //
 // Unsupported input is not a fatal compiler crash and is not silently
 // retried through an older AST path. The backend writes an inspectable

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -158,11 +158,20 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
 	warnings := append([]error(nil), entry.IRIssues...)
-	if diag, ok := llvmgen.UnsupportedDiagnosticForModule(entry.IR); ok {
-		traceLLVMDispatch("%s rejected %s: %s %s", llvmDispatchUnsupportedPreflight, entry.SourcePath, diag.Code, diag.Kind)
+	opts := llvmgen.Options{
+		PackageName: entry.PackageName,
+		SourcePath:  entry.SourcePath,
+		Source:      entry.Source,
+		Target:      target,
+		UseMIR:      useMIRBackend(features, emit),
+		EmitGC:      true,
+	}
+	capabilities := newLLVMDispatchCapabilityMatrix(entry, opts, features, emit)
+	if diag, row, ok := capabilities.PreflightBlockingDiagnostic(); ok {
+		traceLLVMDispatch("%s rejected %s: %s %s (%s)", llvmDispatchUnsupportedPreflight, entry.SourcePath, diag.Code, diag.Kind, row.ID)
 		return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, llvmDispatchUnsupportedPreflight)
 	}
-	if useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR) {
+	if capabilities.CanRoute(llvmDispatchNativeOwned) {
 		traceLLVMDispatch("%s try package=%s source=%s emit=%s target=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath, emit, target)
 		if out, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
 			traceLLVMDispatch("%s error: %v", llvmDispatchNativeOwned, err)
@@ -175,14 +184,6 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	} else {
 		traceLLVMDispatch("%s skipped package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
 	}
-	opts := llvmgen.Options{
-		PackageName: entry.PackageName,
-		SourcePath:  entry.SourcePath,
-		Source:      entry.Source,
-		Target:      target,
-		UseMIR:      useMIRBackend(features, emit),
-		EmitGC:      true,
-	}
 	// IR is the sole input contract. The backend dispatcher never reaches
 	// for entry.File — the AST is a front-end artifact that the LLVM
 	// backend does not consume directly any more.
@@ -192,8 +193,12 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// emitter. MIR refusal now surfaces as the normal unsupported
 	// skeleton diagnostic; the LLVM backend no longer retries the
 	// legacy HIR bridge behind the user's back.
-	route := llvmFallbackDispatchRoute(opts, entry)
+	route := capabilities.DispatchRoute()
 	traceLLVMDispatch("%s emit package=%s source=%s emit=%s target=%s", route, entry.PackageName, entry.SourcePath, emit, target)
+	if diag, row, ok := capabilities.RouteBlockingDiagnostic(route); ok {
+		traceLLVMDispatch("%s unsupported: %s %s (%s)", route, diag.Code, diag.Kind, row.Subject)
+		return renderUnsupportedLLVMIR(entry, target, emit, warnings, diag, route)
+	}
 	irOut, genErr := emitLLVMFallback(route, entry, opts)
 	if genErr == nil {
 		traceLLVMDispatch("%s succeeded package=%s source=%s", route, entry.PackageName, entry.SourcePath)
@@ -205,10 +210,7 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 }
 
 func llvmFallbackDispatchRoute(opts llvmgen.Options, entry Entry) llvmDispatchRoute {
-	if opts.UseMIR {
-		return llvmDispatchMIRDirect
-	}
-	return llvmDispatchMIRDirect
+	return NewLLVMCapabilityMatrix(entry, opts).DispatchRoute()
 }
 
 func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmgen.Options) ([]byte, error) {

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -1,6 +1,6 @@
 // Package llvmgen emits textual LLVM IR for the native backend.
 //
-// Public API surface (IR-only)
+// Public API surface (IR/MIR-only)
 //
 //   - GenerateModule(*ir.Module, Options) ([]byte, error) — the
 //     legacy IR entry point for code generation. Consumes the
@@ -9,9 +9,17 @@
 //     ([]byte, bool, error) — native-owned primitive/control-flow
 //     fast path only. Returns ok=false when the module should continue
 //     through the broader MIR backend path.
+//   - GenerateFromMIR(*mir.Module, Options) ([]byte, error) — direct
+//     MIR emitter used by backend dispatch after native-owned coverage
+//     declines.
+//   - MIRCapabilityReport(*mir.Module, Options) []MIRCapabilityRow —
+//     data-shaped MIR emitter coverage derived from the same whitelist
+//     that guards GenerateFromMIR.
 //   - UnsupportedDiagnosticForModule(*ir.Module)
 //     (UnsupportedDiagnostic, bool) — preflight backend-capability
 //     policy before a concrete emitter route is selected.
+//   - IsKnownRuntimeFFIPath(string) bool — exported runtime ABI
+//     knownness check shared with backend capability rows.
 //
 // The package previously exposed Generate(*ast.File, Options) as an
 // alternate entry point. That AST route has been removed: the LLVM

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -231,7 +231,7 @@ func UnsupportedDiagnosticForModule(mod *ostyir.Module) (UnsupportedDiagnostic, 
 		if use.IsGoFFI {
 			return UnsupportedDiagnosticFor("go-ffi", use.GoPath), true
 		}
-		if use.IsRuntimeFFI && !llvmIsKnownRuntimeFfiPath(use.RuntimePath) {
+		if use.IsRuntimeFFI && !IsKnownRuntimeFFIPath(use.RuntimePath) {
 			return UnsupportedDiagnosticFor("runtime-ffi", use.RuntimePath), true
 		}
 	}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -108,6 +108,27 @@ func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	return withDataLayout([]byte(g.out.String()), opts.Target), nil
 }
 
+// MIRCapabilityRow is one explicit MIR-direct LLVM emitter coverage row.
+type MIRCapabilityRow struct {
+	Subject            string
+	LLVMEmittable      bool
+	RuntimeABIRequired bool
+	RuntimeABIKnown    bool
+	Diagnostic         UnsupportedDiagnostic
+}
+
+// MIRCapabilityReport walks a MIR module through the same support whitelist
+// GenerateFromMIR uses before emission. It returns data rows instead of only
+// the first UnsupportedError so backend dispatch can expose capability policy
+// without duplicating the emitter's rules.
+func MIRCapabilityReport(m *mir.Module, opts Options) []MIRCapabilityRow {
+	if m == nil {
+		return []MIRCapabilityRow{unsupportedMIRCapabilityRow("mir.module", unsupported("source-layout", "nil MIR module"), false, false)}
+	}
+	opts.Target = CanonicalLLVMTarget(opts.Target)
+	return newMIRGen(m, opts).capabilityRows()
+}
+
 // ==== generator state ====
 
 type mirGen struct {
@@ -379,67 +400,151 @@ func (g *mirGen) emitLoopMetadata() {
 // so callers can render an explicit unsupported skeleton instead of
 // emitting malformed LLVM IR.
 func (g *mirGen) checkSupported() error {
+	for _, row := range g.capabilityRows() {
+		if row.LLVMEmittable {
+			continue
+		}
+		if row.Diagnostic.Code != "" || row.Diagnostic.Kind != "" || row.Diagnostic.Message != "" {
+			return &UnsupportedError{Diagnostic: row.Diagnostic}
+		}
+		return unsupported("unsupported-source", row.Subject)
+	}
+	return nil
+}
+
+func (g *mirGen) capabilityRows() []MIRCapabilityRow {
+	var rows []MIRCapabilityRow
 	for _, fn := range g.mod.Functions {
 		if fn == nil {
 			continue
 		}
+		fnSubject := "mir.function:" + fn.Name
 		if fn.IsIntrinsic {
-			return unsupported("mir-mvp", "intrinsic function declaration "+fn.Name)
+			rows = append(rows, unsupportedMIRCapabilityRow(fnSubject, unsupported("mir-mvp", "intrinsic function declaration "+fn.Name), false, false))
+			continue
 		}
 		if !fn.IsExternal && len(fn.Blocks) == 0 {
-			return unsupported("mir-mvp", "function "+fn.Name+" has no blocks")
+			rows = append(rows, unsupportedMIRCapabilityRow(fnSubject, unsupported("mir-mvp", "function "+fn.Name+" has no blocks"), false, false))
+			continue
 		}
+		rows = append(rows, supportedMIRCapabilityRow(fnSubject, false, false))
 		for _, loc := range fn.Locals {
 			if loc == nil {
 				continue
 			}
+			subject := fmt.Sprintf("mir.local:%s:%s:%d", fn.Name, localDisplayName(loc), loc.ID)
 			if allowUnusedErrLocal(fn, loc) {
+				rows = append(rows, supportedMIRCapabilityRow(subject, false, false))
 				continue
 			}
 			if !g.typeSupported(loc.Type) {
 				hint := localDefiningSiteHint(fn, loc.ID)
 				if hint != "" {
-					return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint))
+					rows = append(rows, unsupportedMIRCapabilityRow(subject, unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint)), false, false))
+					continue
 				}
-				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID))
+				rows = append(rows, unsupportedMIRCapabilityRow(subject, unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID)), false, false))
+				continue
 			}
+			rows = append(rows, supportedMIRCapabilityRow(subject, false, false))
 		}
+		retSubject := "mir.return:" + fn.Name
 		if fn.ReturnType != nil && !g.typeSupported(fn.ReturnType) {
-			return unsupported("mir-mvp", fmt.Sprintf("unsupported return type %s in %s", mirTypeString(fn.ReturnType), fn.Name))
+			rows = append(rows, unsupportedMIRCapabilityRow(retSubject, unsupported("mir-mvp", fmt.Sprintf("unsupported return type %s in %s", mirTypeString(fn.ReturnType), fn.Name)), false, false))
+		} else {
+			rows = append(rows, supportedMIRCapabilityRow(retSubject, false, false))
 		}
 		for _, bb := range fn.Blocks {
 			if bb == nil {
 				continue
 			}
-			for _, inst := range bb.Instrs {
-				if err := g.checkInstrSupported(fn, inst); err != nil {
-					return err
-				}
+			for i, inst := range bb.Instrs {
+				runtimeRequired, runtimeKnown := mirInstrRuntimeABI(inst)
+				subject := fmt.Sprintf("mir.instr:%s:bb%d:%d:%T", fn.Name, bb.ID, i, inst)
+				rows = append(rows, mirCapabilityRowForError(subject, g.checkInstrSupported(fn, inst), runtimeRequired, runtimeKnown))
 			}
-			if err := g.checkTermSupported(fn, bb.Term); err != nil {
-				return err
-			}
+			subject := fmt.Sprintf("mir.term:%s:bb%d:%T", fn.Name, bb.ID, bb.Term)
+			rows = append(rows, mirCapabilityRowForError(subject, g.checkTermSupported(fn, bb.Term), false, false))
 		}
 	}
 	for _, glob := range g.mod.Globals {
 		if glob == nil {
 			continue
 		}
+		subject := "mir.global:" + glob.Name
 		if glob.Name == "" {
-			return unsupported("mir-mvp", "global with empty name")
+			rows = append(rows, unsupportedMIRCapabilityRow(subject, unsupported("mir-mvp", "global with empty name"), false, false))
+			continue
 		}
 		if !g.typeSupported(glob.Type) {
-			return unsupported("mir-mvp", fmt.Sprintf("global %q has unsupported type %s", glob.Name, mirTypeString(glob.Type)))
+			rows = append(rows, unsupportedMIRCapabilityRow(subject, unsupported("mir-mvp", fmt.Sprintf("global %q has unsupported type %s", glob.Name, mirTypeString(glob.Type))), false, false))
+		} else {
+			rows = append(rows, supportedMIRCapabilityRow(subject, false, false))
 		}
 		if glob.Init != nil && !glob.Init.IsExternal {
 			// Init fns aren't in Module.Functions, so walk them
 			// through the same whitelist checks as user fns.
-			if err := g.checkFunctionSupported(glob.Init); err != nil {
-				return err
-			}
+			rows = append(rows, mirCapabilityRowForError("mir.global-init:"+glob.Name, g.checkFunctionSupported(glob.Init), false, false))
 		}
 	}
-	return nil
+	return rows
+}
+
+func supportedMIRCapabilityRow(subject string, runtimeRequired, runtimeKnown bool) MIRCapabilityRow {
+	return MIRCapabilityRow{
+		Subject:            subject,
+		LLVMEmittable:      true,
+		RuntimeABIRequired: runtimeRequired,
+		RuntimeABIKnown:    runtimeKnown,
+	}
+}
+
+func unsupportedMIRCapabilityRow(subject string, err error, runtimeRequired, runtimeKnown bool) MIRCapabilityRow {
+	row := supportedMIRCapabilityRow(subject, runtimeRequired, runtimeKnown)
+	row.LLVMEmittable = false
+	row.Diagnostic = UnsupportedDiagnosticForError(err)
+	return row
+}
+
+func mirCapabilityRowForError(subject string, err error, runtimeRequired, runtimeKnown bool) MIRCapabilityRow {
+	if err != nil {
+		return unsupportedMIRCapabilityRow(subject, err, runtimeRequired, runtimeKnown)
+	}
+	return supportedMIRCapabilityRow(subject, runtimeRequired, runtimeKnown)
+}
+
+func mirInstrRuntimeABI(inst mir.Instr) (required, known bool) {
+	switch x := inst.(type) {
+	case *mir.IntrinsicInstr:
+		required = mirIntrinsicNeedsRuntimeABI(x.Kind)
+		known = !required || isSupportedIntrinsic(x.Kind)
+		return required, known
+	case *mir.CallInstr:
+		fn, ok := x.Callee.(*mir.FnRef)
+		if !ok || fn == nil {
+			return false, false
+		}
+		path, _, ok := splitRuntimeFFICallee(fn.Symbol)
+		if !ok {
+			return false, false
+		}
+		return true, IsKnownRuntimeFFIPath(path)
+	default:
+		return false, false
+	}
+}
+
+func mirIntrinsicNeedsRuntimeABI(k mir.IntrinsicKind) bool {
+	switch k {
+	case mir.IntrinsicInvalid,
+		mir.IntrinsicRawNull,
+		mir.IntrinsicByteToInt, mir.IntrinsicCharToInt,
+		mir.IntrinsicIntToByte, mir.IntrinsicIntToChar,
+		mir.IntrinsicByteToChar, mir.IntrinsicCharToByte:
+		return false
+	default:
+		return true
+	}
 }
 
 // checkFunctionSupported validates a single function against the

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -492,6 +492,81 @@ func TestGenerateFromMIRUnsupportedReportsDiagnostic(t *testing.T) {
 	}
 }
 
+func TestMIRCapabilityReportMatchesUnsupportedSentinel(t *testing.T) {
+	unknownT := &ir.NamedType{Name: "Unknown"}
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:   "use",
+				Return: ir.TUnit,
+				Params: []*ir.Param{{Name: "x", Type: unknownT}},
+				Body:   &ir.Block{},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	rows := MIRCapabilityReport(m, Options{PackageName: "main", SourcePath: "/tmp/cap_unknown.osty"})
+
+	var blocked *MIRCapabilityRow
+	for i := range rows {
+		if !rows[i].LLVMEmittable {
+			blocked = &rows[i]
+			break
+		}
+	}
+	if blocked == nil {
+		t.Fatalf("MIRCapabilityReport did not report unsupported row: %+v", rows)
+	}
+	if blocked.Diagnostic.Code == "" || blocked.Diagnostic.Kind != "unsupported-source" {
+		t.Fatalf("blocked diagnostic = %+v, want structured unsupported-source", blocked.Diagnostic)
+	}
+
+	_, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/cap_unknown.osty"})
+	if err == nil {
+		t.Fatal("GenerateFromMIR unexpectedly accepted capability blocker")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("GenerateFromMIR error = %T: %v, want ErrUnsupported sentinel", err, err)
+	}
+}
+
+func TestMIRCapabilityReportMarksRuntimeABI(t *testing.T) {
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:   "main",
+				Return: ir.TUnit,
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.ExprStmt{X: &ir.IntrinsicCall{
+							Kind: ir.IntrinsicPrintln,
+							Args: []ir.Arg{{Value: &ir.IntLit{Text: "42", T: ir.TInt}}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	rows := MIRCapabilityReport(m, Options{PackageName: "main", SourcePath: "/tmp/cap_print.osty"})
+
+	for _, row := range rows {
+		if !strings.Contains(row.Subject, "*mir.IntrinsicInstr") {
+			continue
+		}
+		if !row.LLVMEmittable {
+			t.Fatalf("println capability row = %+v, want LLVM-emittable", row)
+		}
+		if !row.RuntimeABIRequired || !row.RuntimeABIKnown {
+			t.Fatalf("println capability row = %+v, want known runtime ABI", row)
+		}
+		return
+	}
+	t.Fatalf("MIRCapabilityReport missing intrinsic row: %+v", rows)
+}
+
 func TestGenerateFromMIRAllowsPoisonedUnusedLocal(t *testing.T) {
 	fn := &mir.Function{
 		Name:       "answer",

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -37,6 +37,12 @@ type runtimeDecl struct {
 	params []paramInfo
 }
 
+// IsKnownRuntimeFFIPath reports whether the LLVM backend has a runtime ABI
+// contract for a `use runtime.*` import path.
+func IsKnownRuntimeFFIPath(path string) bool {
+	return llvmIsKnownRuntimeFfiPath(path)
+}
+
 func collectRuntimeFFI(file *ast.File, env typeEnv) map[string]map[string]*runtimeFFIFunction {
 	out := map[string]map[string]*runtimeFFIFunction{}
 	if file == nil {


### PR DESCRIPTION
## Summary

- Add an explicit LLVM backend `CapabilityMatrix` covering HIR node support, MIR lowering issues, MIR emitter support, runtime ABI requirements, route coverage, and fallback policy.
- Drive LLVM dispatch preflight, native-owned routing, MIR route selection, and route blockers from the matrix instead of scattered implicit checks.
- Expose MIR emitter capability reporting from the same whitelist used by `GenerateFromMIR`, and share runtime FFI knownness through a public llvmgen helper.
- Update backend/llvmgen docs and add focused tests for HIR coverage rows, MIR route blockers, runtime ABI rows, and unsupported sentinel parity.

## Validation

- `go test -count=1 -vet=off ./internal/backend`
- `go test -count=1 -vet=off -timeout=20m ./internal/llvmgen` (passed before final rebase; a later full rerun was interrupted without failure output)
- `go test -count=1 -vet=off -timeout=20m ./internal/llvmgen -run '^TestProbeNativeToolchainMergedMIR$'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMCapabilityMatrix|TestLLVMBackendMissingMIRDoesNotRetryLegacyIRBridge|TestLLVMBackendDispatchTraceReportsSelectedRoute'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestMIRCapabilityReport|TestGenerateFromMIRUnsupportedReportsDiagnostic|TestMIRUnsupportedKeepsErrUnsupportedSentinel|TestGenerateFromMIRPrintln'`
- `git diff --check HEAD~1..HEAD`
- `just fmt-check`