### PR TITLE
[codex] redesign pipeline around query graph

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -425,9 +425,13 @@ File-mode analysis flows through a Salsa-style incremental query engine
 default path for a single dirty buffer is `analyzeSingleFileViaEngine`,
 so repeated edits to the same file benefit from query-level reuse of
 parse / resolve / check results. Package- and workspace-mode analysis
-still re-runs the eager per-file path while that migration catches up,
-so cross-file refactors read fresh state on each request. Wired as
-`osty lsp`.
+also seed the same engine first (`analyzePackageViaEngine` /
+`analyzeWorkspaceViaEngine`) and fall back to the eager path only when
+the graph cannot be seeded. The compiler-specific graph now extends
+past front-end diagnostics into backend boundaries: `LowerIRPackage`,
+`LowerMIRPackage`, and `Emit` let LSP/build/CLI callers reuse HIR, MIR,
+and artifact emission work under the same dependency-tracked cache.
+Wired as `osty lsp`.
 
 ### `internal/manifest`
 Project manifest (`osty.toml`) reader, validator, and writer (spec
@@ -483,10 +487,18 @@ revision counter + slot storage. `Frame` tracks the execution stack.
 Cached records per `(QueryID, key)` implement early cutoff: if a
 re-run produces the same hash, downstream dependents skip. The `osty`
 subpackage binds it to the compiler pipeline: `Engine` bundles
-`Database` + `Inputs` (`SourceText`, `PackageFiles`, `WorkspaceMembers`)
-+ registered queries (`Parse`, `ResolvePackage`, `CheckFile`,
-`FileDiagnostics`). The LSP server uses `analyzeSingleFileViaEngine`
-as its default path for a single dirty buffer.
+`Database` + `Inputs` (`SourceText`, `PackageFiles`, `WorkspaceMembers`,
+`WorkspacePackages`)
++ registered queries (`Parse`, `ResolvePackage`, `CheckPackage`,
+`LowerIRPackage`, `LowerMIRPackage`, `Emit`, `LintFile`,
+`FileDiagnostics`). The LSP server uses it for single-file, package,
+and workspace analysis paths; `osty build` and `osty run` seed the same
+graph from manifest/dependency-discovered packages and emit through
+`Emit`. General `osty gen` package input also reuses the graph for
+resolve/check/lower/emit, while its special toolchain-file bundle keeps
+the explicit selected-file path used for bootstrap generation.
+Backend-aware callers can stop at HIR, MIR, or artifact emission without
+re-running unaffected upstream work.
 
 ### `internal/airepair`
 Chains conservative lexical, structural, semantic, and diagnostic-driven

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ osty/
 │   ├── parser/              # Thin Go facade + compatibility lowerings over internal/selfhost
 │   ├── selfhost/            # Committed frozen Osty→Go seed (front end + adapters)
 │   ├── cst/                 # Concrete syntax tree (Red/Green tree for lossless round-trip)
-│   ├── query/               # Salsa-style incremental query engine (LSP backbone)
+│   ├── query/               # Salsa-style incremental query graph (LSP + CLI/backend boundaries)
 │   ├── airepair/            # AI-powered source adaptation / auto-repair
 │   ├── diag/                # Diagnostics + Rust-style renderer
 │   ├── resolve/             # Name resolution (single + multi-file)

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -9,11 +9,11 @@ import (
 	"runtime"
 
 	"github.com/osty/osty/internal/backend"
-	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
+	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/stdlib"
@@ -27,11 +27,11 @@ import (
 //  2. Load + validate the manifest, rendering any E2xxx diagnostics.
 //  3. Resolve dependencies (osty.lock is read; regenerated if stale).
 //  4. Vendor deps into <project>/.osty/deps/<name>/.
-//  5. Run the front-end (parse + resolve + type-check + lint) across
-//     the project sources — as a workspace when [workspace] is present,
-//     as a single package otherwise.
-//  6. Emit the selected backend artifact (LLVM IR/object/binary)
-//     under .osty/out/<profile>[-<target>]/<backend>/.
+//  5. Seed the query graph with project sources, then run the front-end
+//     (parse + resolve + type-check + lint) across the graph — as a workspace
+//     when [workspace] is present, as a single package otherwise.
+//  6. Emit the selected backend artifact through the graph's Emit query
+//     (LLVM IR/object/binary) under .osty/out/<profile>[-<target>]/<backend>/.
 //  7. Record a backend-aware fingerprint under .osty/cache/ so an
 //     unchanged build can skip the front-end and backend work.
 //
@@ -323,36 +323,20 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 			os.Exit(1)
 		}
 	}
-	graph := resolve.NewPackageGraph(ws)
-	results := resolve.ResolveGraph(graph)
-	checks := check.PackageGraph(graph, results, checkOpts())
-	paths := graph.PackagePaths()
-	anyErr := false
-	for _, p := range paths {
-		pkg := ws.Packages[p]
-		r, ok := results[p]
-		if !ok || pkg == nil {
-			continue
-		}
-		ds := append([]*diag.Diagnostic{}, r.Diags...)
-		if cr, ok := checks[p]; ok && cr != nil {
-			ds = append(ds, cr.Diags...)
-		}
-		printPackageDiags(pkg, ds, flags)
-		if hasError(ds) {
-			anyErr = true
-		}
-	}
-	if anyErr {
-		os.Exit(1)
-	}
+	eng, seeded := seedBuildWorkspaceEngine(ws)
+	printBuildWorkspaceQueryDiags(eng, seeded, flags)
+
 	// Emit the root binary package (if any). Library members fall out of the
 	// binary emit for now — multi-target workspace builds are tracked as
 	// emitter/backend parity work.
 	if m.HasPackage {
-		rootPkg := ws.Packages[""]
-		if rootPkg != nil {
-			return emitAndBuild(dir, m, graph, "", rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
+		rootDir := ostyquery.NormalizePath(dir)
+		rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+		if rw != nil && rw.PackageByDir(rootDir) != nil {
+			return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
+				WorkspaceRoot: seeded.Root,
+				Dir:           rootDir,
+			}, resolved, feats, backendID, emitMode)
 		}
 	}
 	return nil
@@ -378,170 +362,218 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 			fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 			os.Exit(1)
 		}
-		graph := resolve.NewPackageGraph(ws)
-		results := resolve.ResolveGraph(graph)
-		checks := check.PackageGraph(graph, results, checkOpts())
-		for _, key := range graph.PackagePaths() {
-			pkg := ws.Packages[key]
-			r := results[key]
-			if r == nil || pkg == nil {
-				continue
-			}
-			ds := append([]*diag.Diagnostic{}, r.Diags...)
-			if cr, ok := checks[key]; ok && cr != nil {
-				ds = append(ds, cr.Diags...)
-			}
-			printPackageDiags(pkg, ds, flags)
-			if hasError(ds) {
-				os.Exit(1)
-			}
-		}
-		rootPkg := ws.Packages[""]
-		if rootPkg != nil {
-			return emitAndBuild(dir, m, graph, "", rootPkg, results[""], checks[""], resolved, feats, backendID, emitMode)
+		eng, seeded := seedBuildWorkspaceEngine(ws)
+		printBuildWorkspaceQueryDiags(eng, seeded, flags)
+		rootDir := ostyquery.NormalizePath(dir)
+		rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+		if rw != nil && rw.PackageByDir(rootDir) != nil {
+			return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
+				WorkspaceRoot: seeded.Root,
+				Dir:           rootDir,
+			}, resolved, feats, backendID, emitMode)
 		}
 		return nil
 	}
-	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform("osty build --airepair", os.Stderr, flags))
+	eng := ostyquery.NewEngine()
+	seeded, err := eng.SeedPackageDir(dir, aiRepairSourceTransform("osty build --airepair", os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}
-	graph := resolve.NewPackageGraphForPackage("", pkg)
-	results := resolve.ResolveGraph(graph)
-	checks := check.PackageGraph(graph, results, checkOpts())
-	res := results[""]
-	chk := checks[""]
-	ds := append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...)
+	rp := eng.Queries.ResolvePackage.Get(eng.DB, seeded.Dir)
+	chk := eng.Queries.CheckPackage.Get(eng.DB, seeded.Dir)
+	var pkg *resolve.Package
+	var res *resolve.PackageResult
+	if rp != nil {
+		pkg = rp.Package()
+		res = rp.PackageResult()
+	}
+	ds := append([]*diag.Diagnostic{}, resDiags(res)...)
+	if chk != nil {
+		ds = append(ds, chk.Diags...)
+	}
 	printPackageDiags(pkg, ds, flags)
 	if hasError(ds) {
 		os.Exit(1)
 	}
-	// Note: the no-deps path feeds a synthetic PackageResult because
-	// emitAndBuild expects a *resolve.PackageResult with Diags; we
-	// already have all of it from ResolvePackage above.
-	return emitAndBuild(dir, m, graph, "", pkg, res, chk, resolved, feats, backendID, emitMode)
+	return emitAndBuildViaQuery(dir, m, eng, ostyquery.LowerKey{
+		Dir: seeded.Dir,
+	}, resolved, feats, backendID, emitMode)
 }
 
-// emitAndBuild picks the entry file (manifest `[bin].path` or default
-// `main.osty`) and drives the selected native backend. Libraries (no entry file
-// on disk) are a no-op until the emitter grows package-per-package output.
-//
-// Files whose header declares `@feature: NAME` via the @feature
-// pragma are skipped when NAME isn't in the active feature set, so
-// feature-gated modules drop out before backend emission.
-//
-// A failure at the backend/toolchain step returns a non-zero exit; a gen-time
-// TODO marker is only logged so the clean portion remains inspectable.
-func emitAndBuild(root string, m *manifest.Manifest, graph *resolve.PackageGraph, packagePath string, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
-	// 1. Locate the entry file. A library project has no entry;
-	// skip the emit path so `osty build` still works as a front-end
-	// check for libs.
+func seedBuildWorkspaceEngine(ws *resolve.Workspace) (*ostyquery.Engine, ostyquery.SeededWorkspace) {
+	eng := ostyquery.NewEngine()
+	seeded, err := eng.SeedLoadedWorkspace(ws)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
+		os.Exit(1)
+	}
+	return eng, seeded
+}
+
+func printBuildWorkspaceQueryDiags(eng *ostyquery.Engine, seeded ostyquery.SeededWorkspace, flags cliFlags) {
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	cw := eng.Queries.CheckWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil {
+		return
+	}
+	anyErr := false
+	for _, member := range seeded.Packages {
+		pkg := rw.PackageByDir(member.Dir)
+		if pkg == nil {
+			continue
+		}
+		var ds []*diag.Diagnostic
+		if pr := rw.ResultByDir(member.Dir); pr != nil {
+			ds = append(ds, pr.Diags...)
+		}
+		if cw != nil {
+			if cr := cw.ResultByDir(member.Dir); cr != nil {
+				ds = append(ds, cr.Diags...)
+			}
+		}
+		printPackageDiags(pkg, ds, flags)
+		if hasError(ds) {
+			anyErr = true
+		}
+	}
+	if anyErr {
+		os.Exit(1)
+	}
+}
+
+func resDiags(res *resolve.PackageResult) []*diag.Diagnostic {
+	if res == nil {
+		return nil
+	}
+	return res.Diags
+}
+
+func emitAndBuildViaQuery(root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode) *backend.Result {
+	profileName, triple := resolvedKey(resolved)
+	binName := buildBinaryNameForEmit(m, resolved, triple, emitMode)
+	emitResult := emitViaQuery("build", root, m, eng, lower, resolved, feats, backendID, emitMode, binName)
+	if emitResult == nil {
+		return nil
+	}
+	return finishBuildEmitResult(backendID, emitMode, emitResult, profileName)
+}
+
+func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyquery.Engine, lower ostyquery.LowerKey, resolved *profile.Resolved, feats map[string]bool, backendID backend.Name, emitMode backend.EmitMode, binName string) *backend.Result {
+	commandName := "osty " + command
 	entryRel := "main.osty"
 	if m != nil && m.Bin != nil && m.Bin.Path != "" {
 		entryRel = m.Bin.Path
 	}
 	entryAbs := filepath.Join(root, entryRel)
 	if _, err := os.Stat(entryAbs); err != nil {
-		// Library or deferred binary: emit step is a no-op.
 		return nil
 	}
-	// 2. Feature-pragma filter: don't emit a file whose pragma
-	// requires an inactive feature. If the entry file is gated out
-	// the whole build degrades to front-end only.
 	if skipped, reason := fileIsFeatureGated(entryAbs, feats); skipped {
-		fmt.Fprintf(os.Stderr, "osty build: skipping %s (feature %q not enabled)\n",
+		fmt.Fprintf(os.Stderr, "%s: skipping %s (feature %q not enabled)\n",
+			commandName,
 			entryRel, reason)
 		return nil
 	}
-	// 3. Find the PackageFile matching entryAbs so we can pass AST +
-	// Refs into gen.
-	var entryFile *resolve.PackageFile
+
+	pkg := queryPackageForLowerKey(eng, lower)
+	if pkg == nil {
+		fmt.Fprintf(os.Stderr, "%s: package %s not in query graph\n", commandName, lower.Dir)
+		os.Exit(1)
+	}
 	absEntry, _ := filepath.Abs(entryAbs)
+	entryInPackage := false
 	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
 		if fp, _ := filepath.Abs(pf.Path); fp == absEntry {
-			entryFile = pf
+			entryInPackage = true
 			break
 		}
 	}
-	if entryFile == nil {
-		fmt.Fprintf(os.Stderr, "osty build: entry %s not in package\n", entryRel)
+	if !entryInPackage {
+		fmt.Fprintf(os.Stderr, "%s: entry %s not in package\n", commandName, entryRel)
 		os.Exit(1)
 	}
-	// 4. Transpile. Unsupported lowering shapes produce TODO markers;
-	// we log the warning but proceed so simple programs build. Package
-	// lowering is now the default even for single-file packages so the
-	// build path has one consistent backend entry contract.
-	if chk == nil {
-		chk = &check.Result{}
-	}
+
 	profileName, triple := resolvedKey(resolved)
-	binName := ""
-	if emitMode == backend.EmitBinary {
-		// Binary filename policy lives in toolchain/runner.osty —
-		// base name + optional -<triple> + optional .exe are all a
-		// function of (manifest, target, host). See internal/runner.
-		binBaseOverride := ""
-		pkgName := ""
-		if m != nil {
-			if m.Bin != nil {
-				binBaseOverride = m.Bin.Name
-			}
-			pkgName = m.Package.Name
-		}
-		targetOS := ""
-		if resolved.Target != nil {
-			targetOS = resolved.Target.OS
-		}
-		binName = runner.BuildBinaryName(binBaseOverride, pkgName, triple, targetOS, runtime.GOOS)
-	}
-	selectedBackend := backendFromCLI("build", backendID)
 	layout := backend.Layout{
 		Root:    root,
 		Profile: profileName,
 		Target:  triple,
 	}
+	features := resolvedFeatures(resolved)
+
 	if backendID == backend.NameLLVM {
-		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, resolved.Features, entryAbs, pkg); usedExternal {
+		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, features, entryAbs, pkg); usedExternal {
 			if err != nil {
-				exitBackendEmitError("build", emitResult, err)
+				exitBackendEmitError(command, emitResult, err)
 			}
-			switch emitMode {
-			case backend.EmitBinary:
-				if emitResult.Artifacts.Binary != "" {
-					fmt.Printf("Built %s (%s)\n", emitResult.Artifacts.Binary, profileName)
-					return emitResult
-				}
-			case backend.EmitObject:
-				if emitResult.Artifacts.Object != "" {
-					fmt.Printf("Generated %s (%s)\n", emitResult.Artifacts.Object, profileName)
-					return emitResult
-				}
-			case backend.EmitLLVMIR:
-				if artifact := emitResult.Artifacts.SourcePath(); artifact != "" {
-					fmt.Printf("Generated %s (%s)\n", artifact, profileName)
-					return emitResult
-				}
-			}
+			return emitResult
 		}
 	}
-	if graph == nil {
-		graph = resolve.NewPackageGraphForPackage(packagePath, pkg)
+
+	lower.PackageName = "main"
+	lower.SourcePath = entryAbs
+	lower.EntryPath = entryAbs
+	target := ostyquery.NewEmitTarget(lower, backendID, emitMode, layout, binName, features)
+	emitted := eng.Queries.Emit.Get(eng.DB, target)
+	if emitted.Err != nil {
+		exitBackendEmitError(command, emitted.Result, emitted.Err)
 	}
-	entry, err := backend.PrepareGraphPackage("main", entryAbs, graph, packagePath, entryFile, chk)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
+	return emitted.Result
+}
+
+func queryPackageForLowerKey(eng *ostyquery.Engine, lower ostyquery.LowerKey) *resolve.Package {
+	if lower.WorkspaceRoot != "" {
+		lower.WorkspaceRoot = ostyquery.NormalizePath(lower.WorkspaceRoot)
+	}
+	lower.Dir = ostyquery.NormalizePath(lower.Dir)
+	if lower.WorkspaceRoot != "" {
+		rw := eng.Queries.ResolveWorkspace.Get(eng.DB, lower.WorkspaceRoot)
+		if rw == nil {
+			return nil
+		}
+		return rw.PackageByDir(lower.Dir)
+	}
+	rp := eng.Queries.ResolvePackage.Get(eng.DB, lower.Dir)
+	if rp == nil {
+		return nil
+	}
+	return rp.Package()
+}
+
+func buildBinaryNameForEmit(m *manifest.Manifest, resolved *profile.Resolved, triple string, emitMode backend.EmitMode) string {
+	if emitMode != backend.EmitBinary {
+		return ""
+	}
+	binBaseOverride := ""
+	pkgName := ""
+	if m != nil {
+		if m.Bin != nil {
+			binBaseOverride = m.Bin.Name
+		}
+		pkgName = m.Package.Name
+	}
+	targetOS := ""
+	if resolved != nil && resolved.Target != nil {
+		targetOS = resolved.Target.OS
+	}
+	return runner.BuildBinaryName(binBaseOverride, pkgName, triple, targetOS, runtime.GOOS)
+}
+
+func resolvedFeatures(r *profile.Resolved) []string {
+	if r == nil {
+		return nil
+	}
+	return r.Features
+}
+
+func finishBuildEmitResult(backendID backend.Name, emitMode backend.EmitMode, emitResult *backend.Result, profileName string) *backend.Result {
+	if emitResult == nil {
+		fmt.Fprintf(os.Stderr, "osty build: backend %q emit %q did not produce a buildable artifact\n", backendID, emitMode)
 		os.Exit(1)
-	}
-	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
-		Layout:     layout,
-		Emit:       emitMode,
-		Entry:      entry,
-		BinaryName: binName,
-		Features:   resolved.Features,
-	})
-	if err != nil {
-		exitBackendEmitError("build", emitResult, err)
 	}
 	switch emitMode {
 	case backend.EmitBinary:

--- a/cmd/osty/gen_emit.go
+++ b/cmd/osty/gen_emit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/nativellvmgen"
+	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -23,6 +24,14 @@ func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Ent
 	}
 	if entry.pkg == nil {
 		return backend.Entry{}, fmt.Errorf("missing package input for gen")
+	}
+	if entry.eng != nil {
+		lower := entry.lower
+		lower.PackageName = pkgName
+		lower.SourcePath = entry.sourcePath
+		lower.EntryPath = entry.sourcePath
+		lowered := entry.eng.Queries.LowerMIRPackage.Get(entry.eng.DB, lower)
+		return lowered.Entry, lowered.Err
 	}
 	if countLowerableFiles(entry.pkg) > 0 {
 		graph := entry.graph
@@ -44,26 +53,62 @@ func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Ent
 }
 
 func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName string, entry *genPackageEntry) ([]byte, *backend.Result, error) {
+	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
+		if out, ok, warnings, err := tryExternalGenLLVMIR(entry); err == nil && ok {
+			return out, &backend.Result{
+				Backend:  name,
+				Emit:     mode,
+				Warnings: warnings,
+			}, nil
+		}
+	}
+	if entry != nil && entry.eng != nil {
+		return emitGenArtifactViaQuery(name, mode, pkgName, entry)
+	}
 	backendEntry, err := prepareGenBackendEntry(pkgName, entry)
 	if err != nil {
 		return nil, nil, err
 	}
-	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
-		out, warnings, emitErr := emitGenLLVMIR(backendEntry, entry)
-		return out, &backend.Result{
-			Backend:  name,
-			Emit:     mode,
-			Warnings: warnings,
-		}, emitErr
-	}
 	return emitGenArtifactViaBackend(name, mode, backendEntry)
 }
 
-func emitGenLLVMIR(entry backend.Entry, pkgEntry *genPackageEntry) ([]byte, []error, error) {
-	if out, ok, warnings, err := tryExternalGenLLVMIR(pkgEntry); err == nil && ok {
-		return out, warnings, nil
+func emitGenArtifactViaQuery(name backend.Name, mode backend.EmitMode, pkgName string, entry *genPackageEntry) ([]byte, *backend.Result, error) {
+	if entry == nil || entry.eng == nil {
+		return nil, nil, fmt.Errorf("missing query graph for gen")
 	}
-	return backend.EmitLLVMIRText(entry, "", nil)
+	tmpRoot, err := os.MkdirTemp("", "osty-gen-*")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	lower := entry.lower
+	lower.PackageName = pkgName
+	lower.SourcePath = entry.sourcePath
+	lower.EntryPath = entry.sourcePath
+	target := ostyquery.NewEmitTarget(lower, name, mode, backend.Layout{
+		Root:    tmpRoot,
+		Profile: "gen",
+	}, "", nil)
+	emitted := entry.eng.Queries.Emit.Get(entry.eng.DB, target)
+	if emitted.Result == nil {
+		return nil, nil, emitted.Err
+	}
+	artifact := emitted.Result.Artifacts.SourcePath()
+	if artifact == "" {
+		if emitted.Err != nil {
+			return nil, emitted.Result, emitted.Err
+		}
+		return nil, emitted.Result, fmt.Errorf("backend %q did not produce a source artifact", name)
+	}
+	data, readErr := os.ReadFile(artifact)
+	if readErr != nil {
+		if emitted.Err != nil {
+			return nil, emitted.Result, emitted.Err
+		}
+		return nil, emitted.Result, readErr
+	}
+	return data, emitted.Result, emitted.Err
 }
 
 func emitGenArtifactViaBackend(name backend.Name, mode backend.EmitMode, entry backend.Entry) ([]byte, *backend.Result, error) {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/osty/osty/internal/lsp"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/pipeline"
+	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
@@ -1549,12 +1550,14 @@ func adjustGenResultForUserOutput(result *backend.Result, name backend.Name, out
 
 type genPackageEntry struct {
 	sourcePath string
+	pkg        *resolve.Package
 	graph      *resolve.PackageGraph
 	pkgPath    string
-	pkg        *resolve.Package
 	res        *resolve.PackageResult
 	chk        *check.Result
 	file       *resolve.PackageFile
+	eng        *ostyquery.Engine
+	lower      ostyquery.LowerKey
 }
 
 func loadGenPackageEntry(path string) (*genPackageEntry, error) {
@@ -1578,10 +1581,18 @@ func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTrans
 	if _, err := ws.LoadPackageNative(""); err != nil {
 		return nil, err
 	}
-	graph := resolve.NewPackageGraph(ws)
-	results := resolve.ResolveGraph(graph)
-	checks := check.PackageGraph(graph, results, checkOpts())
-	pkg := ws.Packages[""]
+	eng := ostyquery.NewEngine()
+	seeded, err := eng.SeedLoadedWorkspace(ws)
+	if err != nil {
+		return nil, err
+	}
+	rootDir := ostyquery.NormalizePath(ws.Root)
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	cw := eng.Queries.CheckWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil {
+		return nil, fmt.Errorf("%s: workspace resolution did not produce a result", filepath.Dir(absPath))
+	}
+	pkg := rw.PackageByDir(rootDir)
 	if pkg == nil {
 		return nil, fmt.Errorf("%s: no package sources were loaded", filepath.Dir(absPath))
 	}
@@ -1602,22 +1613,33 @@ func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTrans
 	if entryFile == nil {
 		return nil, fmt.Errorf("%s is not part of the package rooted at %s", absPath, pkg.Dir)
 	}
-	res := results[""]
+	res := rw.ResultByDir(rootDir)
 	if res == nil {
 		return nil, fmt.Errorf("%s: package resolution did not produce a root result", pkg.Dir)
 	}
-	chk := checks[""]
+	var chk *check.Result
+	if cw != nil {
+		chk = cw.ResultByDir(rootDir)
+	}
 	if chk == nil {
 		chk = &check.Result{}
 	}
 	return &genPackageEntry{
 		sourcePath: absPath,
-		graph:      graph,
-		pkgPath:    "",
 		pkg:        pkg,
+		graph:      rw.Graph(),
+		pkgPath:    rw.DotPathByDir(rootDir),
 		res:        res,
 		chk:        chk,
 		file:       entryFile,
+		eng:        eng,
+		lower: ostyquery.LowerKey{
+			WorkspaceRoot: seeded.Root,
+			Dir:           rootDir,
+			PackageName:   "main",
+			SourcePath:    absPath,
+			EntryPath:     absPath,
+		},
 	}, nil
 }
 
@@ -1635,30 +1657,24 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 	chk := &check.Result{}
 	var entryFile *resolve.PackageFile
 	for _, path := range files {
-		original, err := os.ReadFile(path)
+		src, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		src, transformMap := resolve.ApplySourceTransform(path, original, resolve.LoadOptions{Transform: transform})
-		transformApplied := transform != nil
-		transformChanged := transformApplied && !bytes.Equal(src, original)
+		if transform != nil {
+			src = transform(path, src)
+		}
 		run := selfhost.Run(src)
 		file := selfhost.LowerPublicFileFromRun(run)
 		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, file)
 		pf := &resolve.PackageFile{
-			Path:                   path,
-			Source:                 src,
-			SourceTransformApplied: transformApplied,
-			SourceTransformChanged: transformChanged,
-			CanonicalSource:        canonicalSrc,
-			CanonicalMap:           canonicalMap,
-			File:                   file,
-			Run:                    run,
-			ParseDiags:             run.Diagnostics(),
-		}
-		if transformMap != nil {
-			pf.OriginalSource = append([]byte(nil), original...)
-			pf.TransformMap = transformMap
+			Path:            path,
+			Source:          src,
+			CanonicalSource: canonicalSrc,
+			CanonicalMap:    canonicalMap,
+			File:            file,
+			Run:             run,
+			ParseDiags:      run.Diagnostics(),
 		}
 		pkg.Files = append(pkg.Files, pf)
 		res.Diags = append(res.Diags, pf.ParseDiags...)
@@ -1669,12 +1685,10 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 	if entryFile == nil {
 		return nil, fmt.Errorf("%s is not part of the selected gen input set", sourcePath)
 	}
-	graph := resolve.NewPackageGraphForPackage("", pkg)
 	return &genPackageEntry{
 		sourcePath: sourcePath,
-		graph:      graph,
-		pkgPath:    "",
 		pkg:        pkg,
+		graph:      resolve.NewPackageGraphForPackage("", pkg),
 		res:        res,
 		chk:        chk,
 		file:       entryFile,

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -10,11 +9,10 @@ import (
 	"runtime"
 
 	"github.com/osty/osty/internal/backend"
-	"github.com/osty/osty/internal/check"
-	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
+	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/stdlib"
@@ -25,10 +23,9 @@ import (
 // Flow:
 //
 //  1. Locate osty.toml + vendor deps via pkgmgr.
-//  2. Resolve the project as a package; confirm we have an entry
-//     point (manifest Bin target or default main.osty with fn main).
-//  3. Run the front-end (parse + resolve + type check).
-//  4. Emit the entry file via internal/backend into .osty/out.
+//  2. Confirm we have an entry point (manifest Bin target or default main.osty).
+//  3. Seed the shared query graph and run resolve + check across it.
+//  4. Emit the root package through the graph's backend Emit query.
 //  5. Execute the native backend binary, passing through the
 //     user-supplied arguments after `--`.
 //
@@ -102,14 +99,14 @@ func runRun(args []string, cliF cliFlags) {
 
 	// Step 1: vendor deps (also runs resolve, computes the graph +
 	// DepProvider we'll attach to the workspace).
-	depGraph, env, err := resolveAndVendorEnvOpts(m, root, resolveOpts{
+	graph, env, err := resolveAndVendorEnvOpts(m, root, resolveOpts{
 		Offline: offline, Locked: locked, Frozen: frozen,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(3)
 	}
-	deps := pkgmgr.NewDepProvider(m, depGraph, env)
+	deps := pkgmgr.NewDepProvider(m, graph, env)
 
 	// Turn on the native-checker cache so repeated `osty run` cycles
 	// during development don't re-check packages that haven't changed.
@@ -130,8 +127,10 @@ func runRun(args []string, cliF cliFlags) {
 		os.Exit(2)
 	}
 
-	// Step 3: front-end through a Workspace so `use <dep>` resolves
-	// against vendored packages via the DepProvider.
+	// Step 3: front-end through the shared query graph. A Workspace is
+	// still used for manifest/dependency discovery, then the loaded
+	// packages are seeded into the graph so resolve/check/lower/emit
+	// share the same incremental path as build and LSP.
 	ws, err := resolve.NewWorkspace(root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
@@ -140,60 +139,22 @@ func runRun(args []string, cliF cliFlags) {
 	ws.SourceTransform = aiRepairSourceTransform("osty run --airepair", os.Stderr, cliF)
 	ws.Stdlib = stdlib.Load()
 	ws.Deps = deps
-	rootPkg, err := ws.LoadPackageNative("")
-	if err != nil {
+	if _, err := ws.LoadPackageNative(""); err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}
-	packageGraph := resolve.NewPackageGraph(ws)
-	results := resolve.ResolveGraph(packageGraph)
-	checks := check.PackageGraph(packageGraph, results, checkOpts())
-	// Aggregate diagnostics across every loaded package so front-end
-	// errors in a vendored dep also surface.
-	var all []*diag.Diagnostic
-	for _, key := range packageGraph.PackagePaths() {
-		pkg := packageGraph.Package(key)
-		r := results[key]
-		if r == nil || pkg == nil {
-			continue
-		}
-		ds := append([]*diag.Diagnostic{}, r.Diags...)
-		if cr, ok := checks[key]; ok && cr != nil {
-			ds = append(ds, cr.Diags...)
-		}
-		printPackageDiags(pkg, ds, cliF)
-		all = append(all, ds...)
-	}
-	if hasError(all) {
-		fmt.Fprintf(os.Stderr, "osty run: front-end errors in %s\n", entry)
+	eng, seeded := seedBuildWorkspaceEngine(ws)
+	printBuildWorkspaceQueryDiags(eng, seeded, cliF)
+	rootDir := ostyquery.NormalizePath(root)
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil || rw.PackageByDir(rootDir) == nil {
+		fmt.Fprintf(os.Stderr, "osty run: root package not in query graph\n")
 		os.Exit(1)
-	}
-
-	// Locate the root package entry file for package lowering.
-	var entryFile *resolve.PackageFile
-	entryAbs, _ := filepath.Abs(entry)
-	for _, pf := range rootPkg.Files {
-		if abs, _ := filepath.Abs(pf.Path); abs == entryAbs {
-			entryFile = pf
-			break
-		}
-	}
-	if entryFile == nil {
-		fmt.Fprintf(os.Stderr, "osty run: entry %s not part of the root package\n", entry)
-		os.Exit(1)
-	}
-	chk := checks[""]
-	if chk == nil {
-		chk = &check.Result{}
 	}
 
 	// Step 4: emit the selected backend. Per-profile/target/backend
 	// subdirectories keep debug / release / cross-built artifacts from
 	// clobbering each other.
-	triple := ""
-	if resolved.Target != nil {
-		triple = resolved.Target.Triple
-	}
 	// Binary filename policy (base name + optional .exe suffix) is
 	// authored in toolchain/runner.osty and snapshotted in
 	// internal/runner. Keep this call site free of OS-shape logic.
@@ -205,36 +166,17 @@ func runRun(args []string, cliF cliFlags) {
 		}
 		pkgName = m.Package.Name
 	}
-	binName := runner.BinaryNameFor(binBaseOverride, pkgName, runtime.GOOS)
-	selectedBackend := backendFromCLI("run", backendID)
-	layout := backend.Layout{
-		Root:    root,
-		Profile: resolved.Profile.Name,
-		Target:  triple,
+	binName := ""
+	if emitMode == backend.EmitBinary {
+		binName = runner.BinaryNameFor(binBaseOverride, pkgName, runtime.GOOS)
 	}
-	if backendID == backend.NameLLVM {
-		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, resolved.Features, entryAbs, rootPkg); usedExternal {
-			if err != nil {
-				exitBackendEmitError("run", emitResult, err)
-			}
-			runNativeBinary(emitResult.Artifacts.Binary, runArgs, runDir)
-			return
-		}
-	}
-	backendEntry, err := backend.PrepareGraphPackage("main", entryAbs, packageGraph, "", entryFile, chk)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
+	emitResult := emitViaQuery("run", root, m, eng, ostyquery.LowerKey{
+		WorkspaceRoot: seeded.Root,
+		Dir:           rootDir,
+	}, resolved, featureSet(resolved), backendID, emitMode, binName)
+	if emitResult == nil {
+		fmt.Fprintf(os.Stderr, "osty run: backend did not produce a runnable artifact\n")
 		os.Exit(1)
-	}
-	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
-		Layout:     layout,
-		Emit:       emitMode,
-		Entry:      backendEntry,
-		BinaryName: binName,
-		Features:   resolved.Features,
-	})
-	if err != nil {
-		exitBackendEmitError("run", emitResult, err)
 	}
 	runNativeBinary(emitResult.Artifacts.Binary, runArgs, runDir)
 }

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -56,9 +56,30 @@ func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.R
 	if file == nil {
 		return entry, fmt.Errorf("backend: nil source file")
 	}
+	entry, err := LowerEntryIR(packageName, sourcePath, file, res, chk)
+	if err != nil {
+		return entry, err
+	}
+	return LowerEntryMIR(entry)
+}
+
+// LowerEntryIR lowers a checked single-file front-end result into optimized,
+// validated HIR. It intentionally stops before MIR so incremental callers can
+// cache lowerIR(package) and lowerMIR(package) as separate query nodes.
+func LowerEntryIR(packageName, sourcePath string, file *ast.File, res *resolve.Result, chk *check.Result) (Entry, error) {
+	entry := Entry{
+		PackageName: packageName,
+		SourcePath:  sourcePath,
+		File:        file,
+		Resolve:     res,
+		Check:       chk,
+	}
+	if file == nil {
+		return entry, fmt.Errorf("backend: nil source file")
+	}
 	mod, issues := ir.Lower(packageName, file, res, chk)
 	entry.IRIssues = append(entry.IRIssues, issues...)
-	return finalizeEntryModule(entry, mod)
+	return finalizeEntryIR(entry, mod)
 }
 
 // mirOptimizeEnabled reports whether `PrepareEntry` should call
@@ -91,6 +112,17 @@ func mirOptimizeEnabled() bool {
 // When entryFile is nil the first file in pkg.Files acts as the
 // diagnostic anchor.
 func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
+	entry, err := LowerPackageIR(packageName, sourcePath, pkg, entryFile, chk)
+	if err != nil {
+		return entry, err
+	}
+	return LowerEntryMIR(entry)
+}
+
+// LowerPackageIR is the multi-file analogue of LowerEntryIR. It lowers every
+// file in a resolved package into one optimized, validated HIR module and
+// leaves MIR construction to LowerEntryMIR.
+func LowerPackageIR(packageName, sourcePath string, pkg *resolve.Package, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
 	if pkg == nil {
 		return Entry{}, fmt.Errorf("backend: nil package")
 	}
@@ -119,13 +151,22 @@ func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryF
 	if mod == nil {
 		return entry, fmt.Errorf("backend: ir.LowerPackage returned nil module")
 	}
-	return finalizeEntryModule(entry, mod)
+	return finalizeEntryIR(entry, mod)
 }
 
 // PrepareGraphPackage lowers one package selected from a first-class
 // PackageGraph. It is the graph-native spelling of PreparePackage and lets
 // build orchestrators keep the compile target explicit through backend setup.
 func PrepareGraphPackage(packageName, sourcePath string, graph *resolve.PackageGraph, packagePath string, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
+	entry, err := LowerGraphPackageIR(packageName, sourcePath, graph, packagePath, entryFile, chk)
+	if err != nil {
+		return entry, err
+	}
+	return LowerEntryMIR(entry)
+}
+
+// LowerGraphPackageIR is the PackageGraph analogue of LowerPackageIR.
+func LowerGraphPackageIR(packageName, sourcePath string, graph *resolve.PackageGraph, packagePath string, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
 	if graph == nil {
 		return Entry{}, fmt.Errorf("backend: nil package graph")
 	}
@@ -133,15 +174,15 @@ func PrepareGraphPackage(packageName, sourcePath string, graph *resolve.PackageG
 	if pkg == nil {
 		return Entry{}, fmt.Errorf("backend: graph package %q not found", packagePath)
 	}
-	return PreparePackage(packageName, sourcePath, pkg, entryFile, chk)
+	return LowerPackageIR(packageName, sourcePath, pkg, entryFile, chk)
 }
 
-// finalizeEntryModule runs the post-lowering pipeline (stdlib injection
-// gate, monomorphize, validate, MIR lowering + optional optimize +
-// validate) shared by PrepareEntry and PreparePackage. Splitting this
-// out keeps the two entry points in lock-step: any new pass added here
-// applies to both single-file and multi-file builds at the same time.
-func finalizeEntryModule(entry Entry, mod *ir.Module) (Entry, error) {
+// finalizeEntryIR runs the post-HIR-lowering pipeline (stdlib injection gate,
+// monomorphize, optimize, validate) shared by LowerEntryIR and LowerPackageIR.
+// Splitting MIR into LowerEntryMIR lets the incremental query graph cache the
+// HIR and MIR boundaries independently without changing PrepareEntry /
+// PreparePackage behavior for existing callers.
+func finalizeEntryIR(entry Entry, mod *ir.Module) (Entry, error) {
 	if stdlibBodyLoweringEnabled() {
 		reg := stdlib.LoadCached()
 		injected, injectionErrs := injectReachableStdlibBodies(mod, reg)
@@ -167,7 +208,15 @@ func finalizeEntryModule(entry Entry, mod *ir.Module) (Entry, error) {
 		entry.IRIssues = append(entry.IRIssues, validateErrs...)
 		return entry, errors.Join(validateErrs...)
 	}
-	mirMod := mir.Lower(mod)
+	return entry, nil
+}
+
+// LowerEntryMIR lowers an already-valid HIR backend entry into MIR, applies the
+// optional MIR optimizer, and records MIR validation findings as entry warnings.
+// Any MIR coverage issue is fatal because backend dispatch no longer retries a
+// legacy HIR path.
+func LowerEntryMIR(entry Entry) (Entry, error) {
+	mirMod := mir.Lower(entry.IR)
 	if mirMod == nil {
 		return entry, errors.Join(ErrMIRCoverageIncomplete, fmt.Errorf("mir.Lower returned nil module"))
 	}

--- a/internal/backend/entry_test.go
+++ b/internal/backend/entry_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/osty/osty/internal/ir"
 )
 
-func TestFinalizeEntryModuleRejectsMIRLoweringIssues(t *testing.T) {
+func TestLowerEntryMIRRejectsMIRLoweringIssues(t *testing.T) {
 	rangeLit := &ir.RangeLit{
 		Start: &ir.IntLit{Text: "0", T: ir.TInt},
 		End:   &ir.IntLit{Text: "1", T: ir.TInt},
@@ -27,9 +27,13 @@ func TestFinalizeEntryModuleRejectsMIRLoweringIssues(t *testing.T) {
 		},
 	}
 
-	entry, err := finalizeEntryModule(Entry{PackageName: "main"}, mod)
+	entry, err := finalizeEntryIR(Entry{PackageName: "main"}, mod)
+	if err != nil {
+		t.Fatalf("finalizeEntryIR returned error before MIR lowering: %v", err)
+	}
+	entry, err = LowerEntryMIR(entry)
 	if err == nil {
-		t.Fatal("finalizeEntryModule returned nil error for MIR lowering issue")
+		t.Fatal("LowerEntryMIR returned nil error for MIR lowering issue")
 	}
 	if !errors.Is(err, ErrMIRCoverageIncomplete) {
 		t.Fatalf("error = %v, want ErrMIRCoverageIncomplete", err)

--- a/internal/query/osty/db.go
+++ b/internal/query/osty/db.go
@@ -58,16 +58,21 @@ func newLazyStdlibProvider() resolve.StdlibProvider {
 }
 
 func (p *lazyStdlibProvider) LookupPackage(dotPath string) *resolve.Package {
+	reg := p.registry()
+	if reg == nil {
+		return nil
+	}
+	return reg.LookupPackage(dotPath)
+}
+
+func (p *lazyStdlibProvider) registry() *stdlib.Registry {
 	if p == nil {
 		return nil
 	}
 	p.once.Do(func() {
 		p.reg = stdlib.LoadCached()
 	})
-	if p.reg == nil {
-		return nil
-	}
-	return p.reg.LookupPackage(dotPath)
+	return p.reg
 }
 
 // Close is reserved for future cleanup hooks (e.g. releasing cached

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -9,9 +9,12 @@ import (
 	"sync"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
@@ -632,6 +635,93 @@ func hashCheckWorkspaceMap(m map[string]*check.Result) [32]byte {
 	return h.sum()
 }
 
+// ---- Backend lowering / emit ----
+
+func hashLowerIRResult(r LowerIRResult) [32]byte {
+	h := newHasher()
+	hashBackendEntryBase(h, r.Entry)
+	hashIRModule(h, r.Entry.IR)
+	hashErrorList(h, r.Entry.IRIssues)
+	hashError(h, r.Err)
+	return h.sum()
+}
+
+func hashLowerMIRResult(r LowerMIRResult) [32]byte {
+	h := newHasher()
+	hashBackendEntryBase(h, r.Entry)
+	hashIRModule(h, r.Entry.IR)
+	hashErrorList(h, r.Entry.IRIssues)
+	hashMIRModule(h, r.Entry.MIR)
+	hashErrorList(h, r.Entry.MIRIssues)
+	hashError(h, r.Err)
+	return h.sum()
+}
+
+func hashEmitResult(r EmitResult) [32]byte {
+	h := newHasher()
+	if r.Result == nil {
+		h.byte(0)
+	} else {
+		h.byte(1)
+		h.str(r.Result.Backend.String())
+		h.str(r.Result.Emit.String())
+		hashArtifacts(h, r.Result.Artifacts)
+		hashErrorList(h, r.Result.Warnings)
+	}
+	hashError(h, r.Err)
+	return h.sum()
+}
+
+func hashBackendEntryBase(h *stableHasher, e backend.Entry) {
+	h.str(e.PackageName)
+	h.str(e.SourcePath)
+	h.bytes(e.Source)
+}
+
+func hashIRModule(h *stableHasher, m *ir.Module) {
+	if m == nil {
+		h.byte(0)
+		return
+	}
+	h.byte(1)
+	h.str(ir.Print(m))
+}
+
+func hashMIRModule(h *stableHasher, m *mir.Module) {
+	if m == nil {
+		h.byte(0)
+		return
+	}
+	h.byte(1)
+	h.str(mir.Print(m))
+}
+
+func hashArtifacts(h *stableHasher, a backend.Artifacts) {
+	h.str(a.Key)
+	h.str(a.OutputDir)
+	h.str(a.CachePath)
+	h.str(a.LLVMIR)
+	h.str(a.Object)
+	h.str(a.Binary)
+	h.str(a.RuntimeDir)
+}
+
+func hashErrorList(h *stableHasher, errs []error) {
+	h.u32(uint32(len(errs)))
+	for _, err := range errs {
+		hashError(h, err)
+	}
+}
+
+func hashError(h *stableHasher, err error) {
+	if err == nil {
+		h.byte(0)
+		return
+	}
+	h.byte(1)
+	h.str(err.Error())
+}
+
 // ---- Input hashers ----
 
 func hashBytesInput(b []byte) [32]byte { return sha256.Sum256(b) }
@@ -654,6 +744,32 @@ func hashStringSlice(ss []string) [32]byte {
 	h.u32(uint32(len(sorted)))
 	for _, s := range sorted {
 		h.str(s)
+	}
+	return h.sum()
+}
+
+func hashWorkspacePackageSlice(ms []WorkspacePackage) [32]byte {
+	h := newHasher()
+	if len(ms) == 0 {
+		h.u32(0)
+		return h.sum()
+	}
+	sorted := make([]WorkspacePackage, len(ms))
+	copy(sorted, ms)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].DotPath != sorted[j].DotPath {
+			return sorted[i].DotPath < sorted[j].DotPath
+		}
+		if sorted[i].Dir != sorted[j].Dir {
+			return sorted[i].Dir < sorted[j].Dir
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	h.u32(uint32(len(sorted)))
+	for _, m := range sorted {
+		h.str(m.DotPath)
+		h.str(m.Dir)
+		h.str(m.Name)
 	}
 	return h.sum()
 }

--- a/internal/query/osty/inputs.go
+++ b/internal/query/osty/inputs.go
@@ -4,6 +4,16 @@ import (
 	"github.com/osty/osty/internal/query"
 )
 
+// WorkspacePackage describes one package member in a workspace query graph.
+// Dir is the normalized on-disk package directory; DotPath is the import key
+// used by resolve.Workspace ("" for the root package, "lib" for a sibling,
+// or an external dependency key); Name is the human-readable package name.
+type WorkspacePackage struct {
+	Dir     string
+	DotPath string
+	Name    string
+}
+
 // Inputs groups the three primitive input handles that drive the
 // entire Osty query graph. Callers (LSP, CLI) use these to push the
 // current world state into the Database; every derived query reads
@@ -33,12 +43,20 @@ type Inputs struct {
 	// CLI entry points populate this from the osty.toml manifest;
 	// the LSP populates it by discovering the workspace root on open.
 	WorkspaceMembers *query.Input[struct{}, []string]
+
+	// WorkspacePackages is the package-member input used by build/CLI
+	// consumers that already know the exact import key for every package,
+	// including vendored external dependencies. Keyed by normalized workspace
+	// root. ResolveWorkspace prefers this input when seeded, then falls back to
+	// WorkspaceMembers for older LSP callers.
+	WorkspacePackages *query.Input[string, []WorkspacePackage]
 }
 
 func registerInputs(db *query.Database) Inputs {
 	return Inputs{
-		SourceText:       query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
-		PackageFiles:     query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
-		WorkspaceMembers: query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
+		SourceText:        query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
+		PackageFiles:      query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
+		WorkspaceMembers:  query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
+		WorkspacePackages: query.RegisterInput[string, []WorkspacePackage](db, "WorkspacePackages", hashWorkspacePackageSlice),
 	}
 }

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -1,10 +1,13 @@
 package osty
 
 import (
+	"context"
+	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/cst"
@@ -17,6 +20,7 @@ import (
 	"github.com/osty/osty/internal/semanticdb"
 	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/spanid"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 // ---- Value types ----
@@ -107,6 +111,8 @@ type ResolvedWorkspace struct {
 	pkgMap   map[string]*resolve.Package       // normalized dir → Package
 	results  map[string]*resolve.PackageResult // normalized dir → PackageResult
 	resolved map[string]*ResolvedPackage       // normalized dir → ResolvedPackage
+	dotByDir map[string]string                 // normalized dir → resolve.Workspace dotted key
+	dirByDot map[string]string                 // resolve.Workspace dotted key → normalized dir
 }
 
 // Root returns the workspace root directory (normalized).
@@ -161,6 +167,14 @@ func (rw *ResolvedWorkspace) SemanticDBByDir(dir string) *semanticdb.DB {
 		return nil
 	}
 	return pr.SemanticDB
+}
+
+// DotPathByDir returns the resolve.Workspace key for dir.
+func (rw *ResolvedWorkspace) DotPathByDir(dir string) string {
+	if rw == nil {
+		return ""
+	}
+	return rw.dotByDir[dir]
 }
 
 // DirForPath returns the normalized directory of the package that
@@ -243,6 +257,133 @@ func (wcr *WorkspaceCheckResult) Len() int {
 	return len(wcr.byDir)
 }
 
+// LowerKey identifies a package-lowering query. Dir is the normalized package
+// directory; PackageName is the backend module name; EntryPath selects the
+// diagnostic/source anchor inside the package. When WorkspaceRoot is set,
+// lowering slices the package out of ResolveWorkspace / CheckWorkspace instead
+// of using standalone ResolvePackage / CheckPackage. SourcePath defaults to
+// EntryPath when left empty.
+type LowerKey struct {
+	WorkspaceRoot string
+	Dir           string
+	PackageName   string
+	SourcePath    string
+	EntryPath     string
+}
+
+func (k LowerKey) normalized() LowerKey {
+	if k.WorkspaceRoot != "" {
+		k.WorkspaceRoot = NormalizePath(k.WorkspaceRoot)
+	}
+	k.Dir = NormalizePath(k.Dir)
+	if k.EntryPath != "" {
+		k.EntryPath = NormalizePath(k.EntryPath)
+	}
+	if k.SourcePath == "" {
+		k.SourcePath = k.EntryPath
+	}
+	if k.SourcePath != "" {
+		k.SourcePath = NormalizePath(k.SourcePath)
+	}
+	if k.PackageName == "" {
+		k.PackageName = packageNameFromDir(k.Dir)
+	}
+	return k
+}
+
+// LowerIRResult is the output of LowerIRPackage. Err is set when the HIR
+// boundary rejects the package (for example, IR validation fails).
+type LowerIRResult struct {
+	Entry backend.Entry
+	Err   error
+}
+
+// LowerMIRResult is the output of LowerMIRPackage. Err carries any HIR-stage
+// failure from LowerIRPackage; MIR validation findings remain non-fatal
+// Entry.MIRIssues, matching backend.PreparePackage.
+type LowerMIRResult struct {
+	Entry backend.Entry
+	Err   error
+}
+
+// EmitTarget identifies a backend artifact query. FeaturesKey is the stable
+// feature-list encoding returned by FeatureKey.
+type EmitTarget struct {
+	Lower       LowerKey
+	Backend     backend.Name
+	Emit        backend.EmitMode
+	Root        string
+	Profile     string
+	Target      string
+	BinaryName  string
+	FeaturesKey string
+}
+
+// NewEmitTarget builds a normalized key for the Emit query.
+func NewEmitTarget(lower LowerKey, name backend.Name, mode backend.EmitMode, layout backend.Layout, binaryName string, features []string) EmitTarget {
+	return EmitTarget{
+		Lower:       lower,
+		Backend:     name,
+		Emit:        mode,
+		Root:        layout.Root,
+		Profile:     layout.Profile,
+		Target:      layout.Target,
+		BinaryName:  binaryName,
+		FeaturesKey: FeatureKey(features),
+	}.normalized()
+}
+
+func (t EmitTarget) normalized() EmitTarget {
+	t.Lower = t.Lower.normalized()
+	if t.Backend == "" {
+		t.Backend = backend.NameLLVM
+	}
+	if t.Emit == "" {
+		t.Emit = backend.EmitLLVMIR
+	}
+	if t.Root != "" {
+		t.Root = NormalizePath(t.Root)
+	}
+	t.FeaturesKey = FeatureKey(t.Features())
+	return t
+}
+
+// Features decodes the stable feature-list encoding on EmitTarget.
+func (t EmitTarget) Features() []string {
+	if t.FeaturesKey == "" {
+		return nil
+	}
+	return strings.Split(t.FeaturesKey, featureKeySep)
+}
+
+const featureKeySep = "\x00"
+
+// FeatureKey returns a comparable, order-insensitive feature-list key for
+// query keys. Backend feature handling treats the list as a set.
+func FeatureKey(features []string) string {
+	if len(features) == 0 {
+		return ""
+	}
+	clean := make([]string, 0, len(features))
+	for _, f := range features {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			clean = append(clean, f)
+		}
+	}
+	if len(clean) == 0 {
+		return ""
+	}
+	sort.Strings(clean)
+	return strings.Join(clean, featureKeySep)
+}
+
+// EmitResult is the output of the Emit query.
+type EmitResult struct {
+	Result *backend.Result
+	Err    error
+}
+
 // ---- Queries struct ----
 
 // Queries groups the derived query handles. Constructed once by
@@ -292,16 +433,30 @@ type Queries struct {
 
 	// ResolveWorkspace: (rootDir) -> full cross-package resolution.
 	// Assembles a PackageGraph from BuildPackage outputs and runs
-	// resolve.ResolveGraph. Use this when WorkspaceMembers has been seeded
-	// (workspace mode) instead of the per-package ResolvePackage query.
-	// Depends on: WorkspaceMembers, BuildPackage(dir) for each dir.
+	// resolve.ResolveGraph. Uses WorkspacePackages when seeded so CLI
+	// build can preserve dependency-manager import keys, otherwise
+	// falls back to WorkspaceMembers for LSP/workspace callers.
+	// Depends on: WorkspacePackages or WorkspaceMembers, BuildPackage(dir)
+	// for each dir.
 	ResolveWorkspace *query.Query[string, *ResolvedWorkspace]
 
 	// CheckWorkspace: (rootDir) -> per-package check results for
-	// the entire workspace. Calls check.PackageGraph with the output of
-	// ResolveWorkspace.
+	// the entire workspace. Calls check.PackageGraph with the output
+	// of ResolveWorkspace.
 	// Depends on: ResolveWorkspace(rootDir).
 	CheckWorkspace *query.Query[string, *WorkspaceCheckResult]
+
+	// LowerIRPackage: (LowerKey) -> optimized, validated HIR backend entry.
+	// Depends on: ResolvePackage(dir), CheckPackage(dir).
+	LowerIRPackage *query.Query[LowerKey, LowerIRResult]
+
+	// LowerMIRPackage: (LowerKey) -> backend entry with MIR populated.
+	// Depends on: LowerIRPackage(key).
+	LowerMIRPackage *query.Query[LowerKey, LowerMIRResult]
+
+	// Emit: (EmitTarget) -> backend artifact result.
+	// Depends on: LowerMIRPackage(target.Lower).
+	Emit *query.Query[EmitTarget, EmitResult]
 
 	// LintFile: (path) -> lint diagnostics for one file. The self-hosted
 	// lint pass owns parsing internally, so this query stays source-only and
@@ -415,17 +570,19 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			}
 			for i, pf := range built.Files {
 				pkg.Files[i] = &resolve.PackageFile{
-					Path:            pf.Path,
-					Source:          pf.Source,
-					SourceFileID:    pf.SourceFileID,
-					OriginalSource:  pf.OriginalSource,
-					TransformMap:    pf.TransformMap,
-					CanonicalSource: pf.CanonicalSource,
-					CanonicalMap:    pf.CanonicalMap,
-					File:            pf.File,
-					Run:             pf.Run,
-					ParseDiags:      pf.ParseDiags,
-					ParseProvenance: pf.ParseProvenance,
+					Path:                   pf.Path,
+					Source:                 pf.Source,
+					SourceFileID:           pf.SourceFileID,
+					OriginalSource:         pf.OriginalSource,
+					SourceTransformApplied: pf.SourceTransformApplied,
+					SourceTransformChanged: pf.SourceTransformChanged,
+					TransformMap:           pf.TransformMap,
+					CanonicalSource:        pf.CanonicalSource,
+					CanonicalMap:           pf.CanonicalMap,
+					File:                   pf.File,
+					Run:                    pf.Run,
+					ParseDiags:             pf.ParseDiags,
+					ParseProvenance:        pf.ParseProvenance,
 				}
 			}
 			// Stdlib attachment requires an unexported resolve.Workspace
@@ -459,7 +616,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			if rp == nil || rp.pkg == nil {
 				return &check.Result{}
 			}
-			opts := check.Opts{Stdlib: resolveStdlibProvider(ctx)}
+			opts := checkOptsFromCtx(ctx)
 			return check.Package(rp.pkg, rp.res, opts)
 		},
 		hashCheckResult,
@@ -473,13 +630,12 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 		hashCheckResult,
 	)
 
-	// ResolveWorkspace assembles all packages listed in
-	// WorkspaceMembers into a resolve.Workspace, deep-copies each
-	// package (so ResolveAll's in-place mutation doesn't corrupt
-	// the BuildPackage cache), and runs cross-package resolution.
+	// ResolveWorkspace assembles all seeded packages into a resolve.Workspace,
+	// deep-copies each package (so ResolveAll's in-place mutation doesn't
+	// corrupt the BuildPackage cache), and runs cross-package resolution.
 	qs.ResolveWorkspace = query.Register(db, "ResolveWorkspace",
 		func(ctx *query.Ctx, rootDir string) *ResolvedWorkspace {
-			members := inp.WorkspaceMembers.Fetch(ctx, struct{}{})
+			members := workspaceMembersForRoot(ctx, inp, rootDir)
 			if len(members) == 0 {
 				return nil
 			}
@@ -487,24 +643,34 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			// Build all packages from the engine's cached Parse
 			// results. Deep-copy each one so ResolveAll's in-place
 			// mutation doesn't corrupt the BuildPackage cache.
-			builtPkgs := make(map[string]*resolve.Package, len(members))
-			for _, dir := range members {
-				bp := qs.BuildPackage.Fetch(ctx, dir)
+			builtByDir := make(map[string]*resolve.Package, len(members))
+			builtByDot := make(map[string]*resolve.Package, len(members))
+			dotByDir := make(map[string]string, len(members))
+			dirByDot := make(map[string]string, len(members))
+			for _, member := range members {
+				bp := qs.BuildPackage.Fetch(ctx, member.Dir)
 				if bp == nil || len(bp.Files) == 0 {
 					continue
 				}
-				builtPkgs[dir] = copyPackageForWorkspace(bp)
+				pkg := copyPackageForWorkspace(bp)
+				if member.Name != "" {
+					pkg.Name = member.Name
+				}
+				builtByDir[member.Dir] = pkg
+				builtByDot[member.DotPath] = pkg
+				dotByDir[member.Dir] = member.DotPath
+				dirByDot[member.DotPath] = member.Dir
 			}
-			if len(builtPkgs) == 0 {
+			if len(builtByDot) == 0 {
 				return nil
 			}
 
 			// Assemble a resolve.Workspace. Package keys are dotted
-			// import paths (e.g. "", "app", "lib") derived from the
-			// relative path to the workspace root.
+			// import paths (e.g. "", "app", "lib", or a vendored
+			// external dependency key).
 			ws, _ := resolve.NewWorkspace(rootDir)
-			for dir, pkg := range builtPkgs {
-				dotPath := dotPathFromDir(rootDir, dir)
+			ws.Stdlib = resolveStdlibProvider(ctx)
+			for dotPath, pkg := range builtByDot {
 				ws.Packages[dotPath] = pkg
 			}
 
@@ -514,12 +680,12 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 
 			// Build the result, converting dotted-path keys back to
 			// normalized directory keys.
-			pkgList := make([]*resolve.Package, 0, len(builtPkgs))
-			resultsByDir := make(map[string]*resolve.PackageResult, len(builtPkgs))
-			resolvedByDir := make(map[string]*ResolvedPackage, len(builtPkgs))
-			for dir, pkg := range builtPkgs {
+			pkgList := make([]*resolve.Package, 0, len(builtByDir))
+			resultsByDir := make(map[string]*resolve.PackageResult, len(builtByDir))
+			resolvedByDir := make(map[string]*ResolvedPackage, len(builtByDir))
+			for dir, pkg := range builtByDir {
 				pkgList = append(pkgList, pkg)
-				dotPath := dotPathFromDir(rootDir, dir)
+				dotPath := dotByDir[dir]
 				if pr, ok := resolved[dotPath]; ok {
 					resultsByDir[dir] = pr
 					resolvedByDir[dir] = &ResolvedPackage{pkg: pkg, res: pr}
@@ -529,9 +695,11 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 				root:     rootDir,
 				graph:    graph,
 				pkgs:     pkgList,
-				pkgMap:   builtPkgs,
+				pkgMap:   builtByDir,
 				results:  resultsByDir,
 				resolved: resolvedByDir,
+				dotByDir: dotByDir,
+				dirByDot: dirByDot,
 			}
 		},
 		hashResolvedWorkspaceFn,
@@ -549,17 +717,17 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			// Rebuild dotted-path result keys for check.PackageGraph.
 			resolvedMap := make(map[string]*resolve.PackageResult, len(rw.resolved))
 			for dir, rp := range rw.resolved {
-				dotPath := dotPathFromDir(rootDir, dir)
+				dotPath := rw.DotPathByDir(dir)
 				resolvedMap[dotPath] = rp.res
 			}
 
-			opts := check.Opts{Stdlib: resolveStdlibProvider(ctx)}
+			opts := checkOptsFromCtx(ctx)
 			checks := check.PackageGraph(rw.Graph(), resolvedMap, opts)
 
 			// Convert dotted-path keys back to directory keys.
 			byDir := make(map[string]*check.Result, len(checks))
 			for dotPath, result := range checks {
-				dir := dirFromDotPath(rootDir, dotPath)
+				dir := rw.dirByDot[dotPath]
 				if dir != "" {
 					byDir[dir] = result
 				}
@@ -567,6 +735,82 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			return &WorkspaceCheckResult{byDir: byDir}
 		},
 		hashWorkspaceCheckResultFn,
+	)
+
+	qs.LowerIRPackage = query.Register(db, "LowerIRPackage",
+		func(ctx *query.Ctx, key LowerKey) LowerIRResult {
+			key = key.normalized()
+			if key.WorkspaceRoot != "" {
+				rw := qs.ResolveWorkspace.Fetch(ctx, key.WorkspaceRoot)
+				cw := qs.CheckWorkspace.Fetch(ctx, key.WorkspaceRoot)
+				if rw == nil {
+					return LowerIRResult{Err: fmt.Errorf("query lowerIR: workspace %s not resolved", key.WorkspaceRoot)}
+				}
+				pkg := rw.PackageByDir(key.Dir)
+				if pkg == nil {
+					return LowerIRResult{Err: fmt.Errorf("query lowerIR: package %s not in workspace %s", key.Dir, key.WorkspaceRoot)}
+				}
+				var chk *check.Result
+				if cw != nil {
+					chk = cw.ResultByDir(key.Dir)
+				}
+				if chk == nil {
+					chk = &check.Result{}
+				}
+				entryFile := packageEntryFileForPath(pkg, key.EntryPath)
+				entry, err := backend.LowerGraphPackageIR(key.PackageName, key.SourcePath, rw.Graph(), rw.DotPathByDir(key.Dir), entryFile, chk)
+				return LowerIRResult{Entry: entry, Err: err}
+			}
+			rp := qs.ResolvePackage.Fetch(ctx, key.Dir)
+			chk := qs.CheckPackage.Fetch(ctx, key.Dir)
+			if rp == nil || rp.pkg == nil {
+				return LowerIRResult{Err: fmt.Errorf("query lowerIR: package %s not resolved", key.Dir)}
+			}
+			entryFile := packageEntryFileForPath(rp.pkg, key.EntryPath)
+			entry, err := backend.LowerPackageIR(key.PackageName, key.SourcePath, rp.pkg, entryFile, chk)
+			return LowerIRResult{Entry: entry, Err: err}
+		},
+		hashLowerIRResult,
+	)
+
+	qs.LowerMIRPackage = query.Register(db, "LowerMIRPackage",
+		func(ctx *query.Ctx, key LowerKey) LowerMIRResult {
+			key = key.normalized()
+			lowered := qs.LowerIRPackage.Fetch(ctx, key)
+			if lowered.Err != nil {
+				return LowerMIRResult{Entry: lowered.Entry, Err: lowered.Err}
+			}
+			entry, err := backend.LowerEntryMIR(lowered.Entry)
+			return LowerMIRResult{Entry: entry, Err: err}
+		},
+		hashLowerMIRResult,
+	)
+
+	qs.Emit = query.Register(db, "Emit",
+		func(ctx *query.Ctx, target EmitTarget) EmitResult {
+			target = target.normalized()
+			lowered := qs.LowerMIRPackage.Fetch(ctx, target.Lower)
+			if lowered.Err != nil {
+				return EmitResult{Err: lowered.Err}
+			}
+			b, err := backend.New(target.Backend)
+			if err != nil {
+				return EmitResult{Err: err}
+			}
+			result, err := b.Emit(context.Background(), backend.Request{
+				Layout: backend.Layout{
+					Root:    target.Root,
+					Profile: target.Profile,
+					Target:  target.Target,
+				},
+				Emit:       target.Emit,
+				Entry:      lowered.Entry,
+				BinaryName: target.BinaryName,
+				Features:   target.Features(),
+			})
+			return EmitResult{Result: result, Err: err}
+		},
+		hashEmitResult,
 	)
 
 	qs.LintFile = query.Register(db, "LintFile",
@@ -633,6 +877,26 @@ func packageNameFromDir(dir string) string {
 	return dir
 }
 
+func packageEntryFileForPath(pkg *resolve.Package, entryPath string) *resolve.PackageFile {
+	if pkg == nil {
+		return nil
+	}
+	if entryPath != "" {
+		norm := NormalizePath(entryPath)
+		for _, pf := range pkg.Files {
+			if pf != nil && NormalizePath(pf.Path) == norm {
+				return pf
+			}
+		}
+	}
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.CanMaterializeFile() {
+			return pf
+		}
+	}
+	return nil
+}
+
 // resolveStdlibProvider returns the stdlib provider suitable for
 // passing to check.Opts. Returns nil if the Database was constructed
 // without a stdlib registry.
@@ -642,6 +906,33 @@ func resolveStdlibProvider(ctx *query.Ctx) resolve.StdlibProvider {
 		return nil
 	}
 	return reg
+}
+
+type stdlibRegistryAccessor interface {
+	registry() *stdlib.Registry
+}
+
+func checkOptsFromCtx(ctx *query.Ctx) check.Opts {
+	provider := resolveStdlibProvider(ctx)
+	opts := check.Opts{Stdlib: provider}
+	if reg := stdlibRegistryFromProvider(provider); reg != nil {
+		opts.Primitives = reg.Primitives
+		opts.ResultMethods = reg.ResultMethods
+	}
+	return opts
+}
+
+func stdlibRegistryFromProvider(provider resolve.StdlibProvider) *stdlib.Registry {
+	switch p := provider.(type) {
+	case nil:
+		return nil
+	case *stdlib.Registry:
+		return p
+	case stdlibRegistryAccessor:
+		return p.registry()
+	default:
+		return nil
+	}
 }
 
 // collectFileDiagnostics merges every diagnostic produced by the
@@ -753,6 +1044,59 @@ func diagnosticBelongsTo(d *diag.Diagnostic, normalizedPath string, fileID spani
 
 // ---- Workspace helpers ----
 
+func workspaceMembersForRoot(ctx *query.Ctx, inp Inputs, rootDir string) []WorkspacePackage {
+	rootDir = NormalizePath(rootDir)
+	if inp.WorkspacePackages.HasFetch(ctx, rootDir) {
+		members := inp.WorkspacePackages.Fetch(ctx, rootDir)
+		return normalizeWorkspacePackages(rootDir, members)
+	}
+	dirs := inp.WorkspaceMembers.Fetch(ctx, struct{}{})
+	members := make([]WorkspacePackage, 0, len(dirs))
+	for _, dir := range dirs {
+		dir = NormalizePath(dir)
+		members = append(members, WorkspacePackage{
+			Dir:     dir,
+			DotPath: dotPathFromDir(rootDir, dir),
+			Name:    packageNameFromDir(dir),
+		})
+	}
+	return normalizeWorkspacePackages(rootDir, members)
+}
+
+func normalizeWorkspacePackages(rootDir string, members []WorkspacePackage) []WorkspacePackage {
+	if len(members) == 0 {
+		return nil
+	}
+	out := make([]WorkspacePackage, 0, len(members))
+	seen := map[string]bool{}
+	for _, m := range members {
+		m.Dir = NormalizePath(m.Dir)
+		if m.DotPath == "" && m.Dir != rootDir {
+			m.DotPath = dotPathFromDir(rootDir, m.Dir)
+		}
+		if m.Name == "" {
+			if m.DotPath != "" {
+				m.Name = packageNameFromDir(m.DotPath)
+			} else {
+				m.Name = packageNameFromDir(m.Dir)
+			}
+		}
+		key := m.DotPath + "\x00" + m.Dir
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].DotPath != out[j].DotPath {
+			return out[i].DotPath < out[j].DotPath
+		}
+		return out[i].Dir < out[j].Dir
+	})
+	return out
+}
+
 // dotPathFromDir converts a normalized package directory to the
 // dotted import path used by resolve.Workspace. Returns "" for the
 // root package (dir == root).
@@ -798,17 +1142,19 @@ func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 			continue
 		}
 		pkg.Files[i] = &resolve.PackageFile{
-			Path:            pf.Path,
-			Source:          pf.Source,
-			SourceFileID:    pf.SourceFileID,
-			OriginalSource:  pf.OriginalSource,
-			TransformMap:    pf.TransformMap,
-			CanonicalSource: pf.CanonicalSource,
-			CanonicalMap:    pf.CanonicalMap,
-			File:            pf.File,
-			Run:             pf.Run,
-			ParseDiags:      pf.ParseDiags,
-			ParseProvenance: pf.ParseProvenance,
+			Path:                   pf.Path,
+			Source:                 pf.Source,
+			SourceFileID:           pf.SourceFileID,
+			OriginalSource:         pf.OriginalSource,
+			SourceTransformApplied: pf.SourceTransformApplied,
+			SourceTransformChanged: pf.SourceTransformChanged,
+			TransformMap:           pf.TransformMap,
+			CanonicalSource:        pf.CanonicalSource,
+			CanonicalMap:           pf.CanonicalMap,
+			File:                   pf.File,
+			Run:                    pf.Run,
+			ParseDiags:             pf.ParseDiags,
+			ParseProvenance:        pf.ParseProvenance,
 		}
 	}
 	return pkg

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -1,13 +1,17 @@
 package osty
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/cst"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/spanid"
 	"github.com/osty/osty/internal/token"
@@ -370,6 +374,207 @@ func TestSemanticDBAccessorsExposeResolveAndCheckFacts(t *testing.T) {
 	}
 	if len(chk.Semantic().CheckIndex().InstantiationsByStableID) == 0 {
 		t.Fatalf("combined SemanticDB instantiations = %#v, want generic call facts", chk.Semantic().Check.Instantiations)
+	}
+}
+
+func TestLowerIRAndMIRPackageQueries(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := NormalizePath(t.TempDir())
+	path := seedFile(eng, dir, "main.osty", "pub fn main() { }\n")
+	key := LowerKey{Dir: dir, PackageName: "main", EntryPath: path}.normalized()
+
+	irRes := eng.Queries.LowerIRPackage.Get(eng.DB, key)
+	if irRes.Err != nil {
+		t.Fatalf("LowerIRPackage returned error: %v", irRes.Err)
+	}
+	if irRes.Entry.IR == nil {
+		t.Fatal("LowerIRPackage returned nil IR")
+	}
+	if irRes.Entry.MIR != nil {
+		t.Fatal("LowerIRPackage should stop before MIR lowering")
+	}
+
+	mirRes := eng.Queries.LowerMIRPackage.Get(eng.DB, key)
+	if mirRes.Err != nil {
+		t.Fatalf("LowerMIRPackage returned error: %v", mirRes.Err)
+	}
+	if mirRes.Entry.IR == nil {
+		t.Fatal("LowerMIRPackage dropped IR")
+	}
+	if mirRes.Entry.MIR == nil {
+		t.Fatal("LowerMIRPackage returned nil MIR")
+	}
+}
+
+func TestLowerMIRPackageReusesCacheAfterSemanticCutoff(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := NormalizePath(t.TempDir())
+	path := seedFile(eng, dir, "main.osty", "pub fn main() { }\n")
+	key := LowerKey{Dir: dir, PackageName: "main", EntryPath: path}.normalized()
+
+	primed := eng.Queries.LowerMIRPackage.Get(eng.DB, key)
+	if primed.Err != nil {
+		t.Fatalf("LowerMIRPackage priming returned error: %v", primed.Err)
+	}
+
+	eng.Inputs.SourceText.Set(eng.DB, path, []byte("pub fn main() { }\n\n"))
+	before := eng.DB.Metrics()
+	again := eng.Queries.LowerMIRPackage.Get(eng.DB, key)
+	after := eng.DB.Metrics().Sub(before)
+	if again.Err != nil {
+		t.Fatalf("LowerMIRPackage after edit returned error: %v", again.Err)
+	}
+	if after.Cutoffs == 0 {
+		t.Fatalf("expected at least one semantic cutoff after whitespace edit, got %+v", after)
+	}
+	if again.Entry.IR != primed.Entry.IR {
+		t.Fatal("LowerMIRPackage should reuse cached IR when semantic deps cut off")
+	}
+	if again.Entry.MIR != primed.Entry.MIR {
+		t.Fatal("LowerMIRPackage should reuse cached MIR when semantic deps cut off")
+	}
+}
+
+func TestEmitQueryWritesLLVMIRArtifact(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	root := t.TempDir()
+	dir := NormalizePath(root)
+	path := seedFile(eng, dir, "main.osty", "pub fn main() { }\n")
+	target := NewEmitTarget(
+		LowerKey{Dir: dir, PackageName: "main", EntryPath: path},
+		backend.NameLLVM,
+		backend.EmitLLVMIR,
+		backend.Layout{Root: root, Profile: "debug"},
+		"",
+		nil,
+	)
+
+	emitted := eng.Queries.Emit.Get(eng.DB, target)
+	if emitted.Err != nil {
+		t.Fatalf("Emit returned error: %v", emitted.Err)
+	}
+	if emitted.Result == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	if emitted.Result.Artifacts.LLVMIR == "" {
+		t.Fatal("Emit did not report an LLVM IR artifact")
+	}
+	data, err := os.ReadFile(emitted.Result.Artifacts.LLVMIR)
+	if err != nil {
+		t.Fatalf("reading LLVM IR artifact: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("LLVM IR artifact is empty")
+	}
+
+	before := eng.DB.Metrics()
+	again := eng.Queries.Emit.Get(eng.DB, target)
+	after := eng.DB.Metrics().Sub(before)
+	if again.Err != nil {
+		t.Fatalf("cached Emit returned error: %v", again.Err)
+	}
+	if after.Misses != 0 || after.Reruns != 0 {
+		t.Fatalf("cached Emit should not miss/rerun, got %+v", after)
+	}
+	if again.Result == nil || again.Result.Artifacts.LLVMIR != emitted.Result.Artifacts.LLVMIR {
+		t.Fatalf("cached Emit changed artifact path: first=%#v again=%#v", emitted.Result, again.Result)
+	}
+}
+
+func TestSeedLoadedWorkspacePreservesDotPathForLowering(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(root, "main.osty")
+	if err := os.WriteFile(mainPath, []byte(`use dep
+
+fn main() {
+    dep.value()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depDir, "lib.osty"), []byte(`pub fn value() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+
+	eng := NewEngine()
+	defer eng.Close()
+	seeded, err := eng.SeedLoadedWorkspace(ws)
+	if err != nil {
+		t.Fatalf("SeedLoadedWorkspace: %v", err)
+	}
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil {
+		t.Fatal("ResolveWorkspace returned nil")
+	}
+	rootDir := NormalizePath(root)
+	depNorm := NormalizePath(depDir)
+	if got := rw.DotPathByDir(depNorm); got != "dep" {
+		t.Fatalf("DotPathByDir(dep) = %q, want dep", got)
+	}
+	if rw.PackageByDir(rootDir) == nil || rw.PackageByDir(depNorm) == nil {
+		t.Fatal("workspace query dropped root or dep package")
+	}
+	lowered := eng.Queries.LowerMIRPackage.Get(eng.DB, LowerKey{
+		WorkspaceRoot: seeded.Root,
+		Dir:           rootDir,
+		PackageName:   "main",
+		EntryPath:     NormalizePath(mainPath),
+	})
+	if lowered.Err != nil {
+		t.Fatalf("LowerMIRPackage(workspace root) returned error: %v", lowered.Err)
+	}
+	if lowered.Entry.IR == nil || lowered.Entry.MIR == nil {
+		t.Fatalf("workspace lowering missing IR/MIR: IR=%v MIR=%v", lowered.Entry.IR, lowered.Entry.MIR)
+	}
+}
+
+func TestResolveWorkspaceSwitchesFromMemberFallbackToSeededPackages(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	root := NormalizePath(t.TempDir())
+	depDir := NormalizePath(t.TempDir())
+	_ = seedFile(eng, root, "main.osty", "fn main() { }\n")
+	_ = seedFile(eng, depDir, "lib.osty", "pub fn value() -> Int { 1 }\n")
+
+	eng.Inputs.WorkspaceMembers.Set(eng.DB, struct{}{}, []string{root})
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, root)
+	if rw == nil || rw.PackageByDir(depDir) != nil {
+		t.Fatalf("fallback workspace should contain only root package, got %#v", rw)
+	}
+
+	eng.Inputs.WorkspacePackages.Set(eng.DB, root, []WorkspacePackage{
+		{Dir: root, DotPath: "", Name: "main"},
+		{Dir: depDir, DotPath: "dep", Name: "dep"},
+	})
+	rw = eng.Queries.ResolveWorkspace.Get(eng.DB, root)
+	if rw == nil {
+		t.Fatal("ResolveWorkspace returned nil after seeding WorkspacePackages")
+	}
+	if got := rw.DotPathByDir(depDir); got != "dep" {
+		t.Fatalf("DotPathByDir(depDir) = %q, want dep", got)
+	}
+	if rw.PackageByDir(depDir) == nil {
+		t.Fatal("ResolveWorkspace did not invalidate after WorkspacePackages was seeded")
 	}
 }
 

--- a/internal/query/osty/seed.go
+++ b/internal/query/osty/seed.go
@@ -1,0 +1,174 @@
+package osty
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+// SeededPackage describes the package inputs written into an Engine.
+type SeededPackage struct {
+	Dir     string
+	DotPath string
+	Name    string
+	Files   []string
+	Sources map[string][]byte
+}
+
+// SeededWorkspace describes the workspace inputs written into an Engine.
+type SeededWorkspace struct {
+	Root     string
+	Packages []SeededPackage
+	Sources  map[string][]byte
+}
+
+// SeedPackageDir reads a package directory from disk, applies transform before
+// parsing, and writes SourceText + PackageFiles inputs for the package.
+func (e *Engine) SeedPackageDir(dir string, transform resolve.SourceTransform) (SeededPackage, error) {
+	dir = NormalizePath(dir)
+	files, sources, err := readPackageSources(dir, transform)
+	if err != nil {
+		return SeededPackage{}, err
+	}
+	e.seedPackageInputs(dir, files, sources)
+	return SeededPackage{
+		Dir:     dir,
+		Name:    packageNameFromDir(dir),
+		Files:   files,
+		Sources: sources,
+	}, nil
+}
+
+// SeedWorkspaceDirs reads the supplied package directories from disk and
+// writes SourceText, PackageFiles, and WorkspacePackages inputs under root.
+func (e *Engine) SeedWorkspaceDirs(root string, packages []WorkspacePackage, transform resolve.SourceTransform) (SeededWorkspace, error) {
+	root = NormalizePath(root)
+	members := normalizeWorkspacePackages(root, packages)
+	out := SeededWorkspace{
+		Root:    root,
+		Sources: map[string][]byte{},
+	}
+	for _, member := range members {
+		files, sources, err := readPackageSources(member.Dir, transform)
+		if err != nil {
+			return SeededWorkspace{}, err
+		}
+		e.seedPackageInputs(member.Dir, files, sources)
+		for path, src := range sources {
+			out.Sources[path] = src
+		}
+		out.Packages = append(out.Packages, SeededPackage{
+			Dir:     member.Dir,
+			DotPath: member.DotPath,
+			Name:    member.Name,
+			Files:   files,
+			Sources: sources,
+		})
+	}
+	e.Inputs.WorkspacePackages.Set(e.DB, root, members)
+	return out, nil
+}
+
+// SeedLoadedWorkspace writes the packages already discovered by resolve into
+// the query graph. This preserves dependency-manager import keys, while stdlib
+// provider packages are skipped and resolved through the Engine's stdlib
+// provider instead.
+func (e *Engine) SeedLoadedWorkspace(ws *resolve.Workspace) (SeededWorkspace, error) {
+	if ws == nil {
+		return SeededWorkspace{}, fmt.Errorf("seed workspace: nil workspace")
+	}
+	root := NormalizePath(ws.Root)
+	keys := make([]string, 0, len(ws.Packages))
+	for key := range ws.Packages {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	members := make([]WorkspacePackage, 0, len(keys))
+	out := SeededWorkspace{
+		Root:    root,
+		Sources: map[string][]byte{},
+	}
+	for _, key := range keys {
+		if strings.HasPrefix(key, resolve.StdPrefix) {
+			continue
+		}
+		pkg := ws.Packages[key]
+		if pkg == nil || len(pkg.Files) == 0 {
+			continue
+		}
+		dir := NormalizePath(pkg.Dir)
+		member := WorkspacePackage{
+			Dir:     dir,
+			DotPath: key,
+			Name:    pkg.Name,
+		}
+		members = append(members, member)
+
+		files := make([]string, 0, len(pkg.Files))
+		sources := make(map[string][]byte, len(pkg.Files))
+		for _, pf := range pkg.Files {
+			if pf == nil || pf.Path == "" {
+				continue
+			}
+			path := NormalizePath(pf.Path)
+			src := append([]byte(nil), pf.Source...)
+			files = append(files, path)
+			sources[path] = src
+			out.Sources[path] = src
+		}
+		sort.Strings(files)
+		e.seedPackageInputs(dir, files, sources)
+		out.Packages = append(out.Packages, SeededPackage{
+			Dir:     dir,
+			DotPath: key,
+			Name:    pkg.Name,
+			Files:   files,
+			Sources: sources,
+		})
+	}
+	members = normalizeWorkspacePackages(root, members)
+	e.Inputs.WorkspacePackages.Set(e.DB, root, members)
+	return out, nil
+}
+
+func (e *Engine) seedPackageInputs(dir string, files []string, sources map[string][]byte) {
+	for _, path := range files {
+		e.Inputs.SourceText.Set(e.DB, path, sources[path])
+	}
+	e.Inputs.PackageFiles.Set(e.DB, dir, files)
+}
+
+func readPackageSources(dir string, transform resolve.SourceTransform) ([]string, map[string][]byte, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+	var files []string
+	sources := map[string][]byte{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		path := NormalizePath(filepath.Join(dir, name))
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		if transform != nil {
+			src = transform(path, src)
+		}
+		files = append(files, path)
+		sources[path] = src
+	}
+	sort.Strings(files)
+	return files, sources, nil
+}

--- a/internal/query/osty/uri.go
+++ b/internal/query/osty/uri.go
@@ -1,8 +1,9 @@
 // Package osty wires the Osty compiler pipeline into the generic
 // query engine in [github.com/osty/osty/internal/query]. Callers
-// (LSP, CLI) construct an [Engine], seed inputs (SourceText,
-// PackageFiles, WorkspaceMembers), and pull results via typed query
-// handles (Parse, ResolvePackage, CheckFile, FileDiagnostics, etc.).
+// (LSP, CLI, build daemons) construct an [Engine], seed inputs
+// (SourceText, PackageFiles, WorkspaceMembers / WorkspacePackages), and pull
+// results via typed query handles (Parse, ResolvePackage, CheckFile,
+// LowerIRPackage, LowerMIRPackage, Emit, FileDiagnostics, etc.).
 //
 // # Input seams
 //

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -405,3 +405,24 @@ func (i *Input[K, V]) Has(db *Database, key K) bool {
 	_, ok := db.slots[i.q.id][any(key)]
 	return ok
 }
+
+// HasFetch is the body-facing counterpart to Has. It records a dependency on
+// the key's presence so a query that branches on an optional input is
+// invalidated when that input is later Set or Clear'ed.
+func (i *Input[K, V]) HasFetch(ctx *Ctx, key K) bool {
+	parent := ctx.db.currentFrame()
+	m := ctx.db.slots[i.q.id]
+	s, ok := m[any(key)]
+	var changedAt Revision
+	if ok {
+		changedAt = s.computedAt
+	}
+	if parent != nil {
+		parent.deps = append(parent.deps, depRecord{
+			qid:       i.q.id,
+			key:       key,
+			changedAt: changedAt,
+		})
+	}
+	return ok
+}


### PR DESCRIPTION
## Summary
- Rework build/run/gen lowering and emission onto the incremental query graph path.
- Add query nodes for workspace package seeding, lowerIR/lowerMIR, and backend emit with dependency-sensitive caching.
- Preserve PackageGraph-backed workspace resolution/checking and native LSP diagnostic/index behavior after rebasing onto latest main.

## Verification
- `go test -count=1 -vet=off ./internal/query/... ./cmd/osty ./internal/lsp`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test.*Gen|TestEmitGenArtifact|TestParseGenEmitFile|Test.*Run|Test.*Build'`
- `go test -count=1 -vet=off -short $(go list ./...)`
- `go test -count=1 -vet=off ./internal/backend`
- `just build`
- `just fmt-check && git diff --check`
- `just verify-selfhost`
- `.bin/osty ci .`
- smoke project: `.bin/osty build --emit llvm-ir`, `.bin/osty gen`, `.bin/osty run` (`ok`)