### PR TITLE
Improve self-host bootstrap usability and diagnostics

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -138,6 +138,10 @@ type mirGen struct {
 
 	// Module-level state.
 	functionTypes map[string]mirFnSig // symbol → declared signature
+	// needsEnvArgsInit is true when any MIR call reaches std.env.args.
+	// The only C ABI slot that receives argc/argv is main, so the
+	// module-wide pre-scan widens main before function bodies emit.
+	needsEnvArgsInit bool
 	// runtimeDecls owns the runtime forward-declaration pool —
 	// dedup + insertion-order, mirrored from
 	// `toolchain/mir_generator.osty: MirRuntimeDecls`. Replaces
@@ -259,13 +263,53 @@ type mirFnSig struct {
 
 func newMIRGen(m *mir.Module, opts Options) *mirGen {
 	return &mirGen{
-		mod:           m,
-		opts:          opts,
-		source:        filepath.ToSlash(firstNonEmpty(opts.SourcePath, "<unknown>")),
-		src:           append([]byte(nil), opts.Source...),
-		functionTypes: map[string]mirFnSig{},
-		tupleDefs:     map[string][]mir.Type{},
+		mod:              m,
+		opts:             opts,
+		source:           filepath.ToSlash(firstNonEmpty(opts.SourcePath, "<unknown>")),
+		src:              append([]byte(nil), opts.Source...),
+		functionTypes:    map[string]mirFnSig{},
+		needsEnvArgsInit: mirModuleUsesStdEnvArgs(m),
+		tupleDefs:        map[string][]mir.Type{},
 	}
+}
+
+func mirModuleUsesStdEnvArgs(m *mir.Module) bool {
+	if m == nil {
+		return false
+	}
+	for _, glob := range m.Globals {
+		if glob != nil && mirFunctionUsesStdEnvArgs(glob.Init) {
+			return true
+		}
+	}
+	for _, fn := range m.Functions {
+		if mirFunctionUsesStdEnvArgs(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+func mirFunctionUsesStdEnvArgs(fn *mir.Function) bool {
+	if fn == nil {
+		return false
+	}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, instr := range bb.Instrs {
+			call, ok := instr.(*mir.CallInstr)
+			if !ok || call == nil {
+				continue
+			}
+			ref, ok := call.Callee.(*mir.FnRef)
+			if ok && ref != nil && ref.Symbol == "std.env.args" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // formatFnAttrs renders the v0.6 A8/A9/A10 function-level LLVM
@@ -1617,6 +1661,8 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 
 	// Signature line.
 	sig := g.functionTypes[fn.Name]
+	envArgsMain := g.needsEnvArgsInit && fn.Name == "main" &&
+		len(fn.Params) == 0 && isUnitType(fn.ReturnType)
 	// v0.6 A11: decide per-param whether the `noalias` attribute
 	// applies. Bare `#[noalias]` stamps every pointer param;
 	// `#[noalias(p1, p2)]` stamps only the named ones. Non-pointer
@@ -1634,11 +1680,17 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 		}
 		paramParts = append(paramParts, mirFunctionParamPart(llvmT, isNoalias, strconv.Itoa(i)))
 	}
+	if envArgsMain {
+		paramParts = append(paramParts, mirEnvArgsArgcParamPart(), mirEnvArgsArgvParamPart())
+	}
 	g.fnBuf.WriteString(mirFunctionDefineHeader(
 		cconv, sig.retLLVM, emitName, strings.Join(paramParts, ", "), attrs))
 
 	// Entry-block preamble: alloca one slot per non-parameter local,
 	// and store incoming params into their alloca slots.
+	if envArgsMain {
+		g.emitEnvArgsInitPreamble()
+	}
 	g.emitAllocaPreamble(fn)
 	// Register managed-ptr locals as GC roots and take a safepoint at
 	// the function entry. No-op unless opts.EmitGC is set.
@@ -1683,6 +1735,15 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 		g.out.WriteString(g.fnBuf.String())
 	}
 	return nil
+}
+
+func (g *mirGen) emitEnvArgsInitPreamble() {
+	g.declareRuntime(ostyRtEnvArgsInitSymbol, mirRuntimeDeclareLine("void", ostyRtEnvArgsInitSymbol, "i64, ptr"))
+	argcI64 := g.fresh()
+	for _, line := range mirEnvArgsInitPreamble(ostyRtEnvArgsInitSymbol, argcI64) {
+		g.fnBuf.WriteString(line)
+		g.fnBuf.WriteByte('\n')
+	}
 }
 
 // tagParallelAccesses + isMemoryAccessLine moved fully to the Osty

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -2118,6 +2118,30 @@ func mirFunctionParamPart(llvmT string, isNoalias bool, idxDigits string) string
 	return llvmT + " %arg" + idxDigits
 }
 
+// mirEnvArgsArgcParamPart / ArgvParamPart render the C ABI params
+// added to `main` when a MIR module uses `std.env.args()`.
+// Osty: mirEnvArgsArgcParamPart
+func mirEnvArgsArgcParamPart() string {
+	return "i32 %osty_env_argc"
+}
+
+// Osty: mirEnvArgsArgvParamPart
+func mirEnvArgsArgvParamPart() string {
+	return "ptr %osty_env_argv"
+}
+
+// mirEnvArgsArgcValue / ArgvValue name the incoming C ABI values used
+// by the `osty_rt_env_args_init` prologue.
+// Osty: mirEnvArgsArgcValue
+func mirEnvArgsArgcValue() string {
+	return "%osty_env_argc"
+}
+
+// Osty: mirEnvArgsArgvValue
+func mirEnvArgsArgvValue() string {
+	return "%osty_env_argv"
+}
+
 // mirBlockLabelName returns `"entry"` when isEntry / `"bb<N>"`
 // otherwise. `blockIDDigits` is the already-formatted decimal
 // block ID.
@@ -9345,6 +9369,16 @@ func mirCallVoidPtrI64Text(sym, p, n string) string {
 // Osty: mirCallVoidI64PtrText
 func mirCallVoidI64PtrText(sym, n, p string) string {
 	return "  call void @" + sym + "(i64 " + n + ", ptr " + p + ")"
+}
+
+// mirEnvArgsInitPreamble renders the two entry-block lines that seed
+// the runtime env-args snapshot from C `main(argc, argv)`.
+// Osty: mirEnvArgsInitPreamble
+func mirEnvArgsInitPreamble(initSym, argcI64 string) []string {
+	return []string{
+		mirSExtI32ToI64Text(argcI64, mirEnvArgsArgcValue()),
+		mirCallVoidI64PtrText(initSym, argcI64, mirEnvArgsArgvValue()),
+	}
 }
 
 // Osty: mirCallVoidPtrPtrText

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -37,6 +37,47 @@ func buildMIRModuleFromHIR(t *testing.T, mod *ir.Module) *mir.Module {
 	return m
 }
 
+func TestGenerateFromMIRStdEnvArgsInitializesArgv(t *testing.T) {
+	listStrT := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+	fn := &mir.Function{
+		Name:       "main",
+		ReturnType: ir.TUnit,
+	}
+	ret := fn.NewLocal("_return", ir.TUnit, false, mir.Span{})
+	fn.ReturnLocal = ret
+	fn.Locals[ret].IsReturn = true
+	args := fn.NewLocal("args", listStrT, true, mir.Span{})
+	entry := fn.NewBlock(mir.Span{})
+	fn.Entry = entry
+	bb := fn.Block(entry)
+	bb.Instrs = append(bb.Instrs, &mir.CallInstr{
+		Dest:   &mir.Place{Local: args},
+		Callee: &mir.FnRef{Symbol: "std.env.args"},
+	})
+	bb.SetTerminator(&mir.ReturnTerm{})
+	m := &mir.Module{
+		Package:   "main",
+		Functions: []*mir.Function{fn},
+		Layouts:   mir.NewLayoutTable(),
+	}
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/std_env_args_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare void @osty_rt_env_args_init(i64, ptr)",
+		"declare ptr @osty_rt_env_args()",
+		"define i32 @main(i32 %osty_env_argc, ptr %osty_env_argv)",
+		"call void @osty_rt_env_args_init(i64",
+		"call ptr @osty_rt_env_args()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated MIR LLVM missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIRConstReturn — `fn answer() -> Int { 42 }`
 // should emit a define, alloca for the return slot, store 42,
 // load, ret.

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -216,6 +216,40 @@ build_self_binary() {
 	chmod +x "$dest"
 }
 
+smoke_self_driver() {
+	local driver="$1"
+	local label="$2"
+	local reported_host
+	local out
+
+	require_exec "$driver" "$label driver"
+
+	log "$label: smoke selfhost host selection"
+	if ! reported_host="$(cd "$root" && OSTY_SELF_REBUILD_HOST_BIN="$host_bin" "$driver" --selfhost-host 2>&1)"; then
+		printf '%s\n' "$reported_host" >&2
+		fail "$label selfhost host selection failed"
+	fi
+	if [[ "$reported_host" != "$host_bin" ]]; then
+		printf 'self-rebuild: %s reported unexpected host:\n' "$label" >&2
+		printf '  expected: %s\n' "$host_bin" >&2
+		printf '  actual:   %s\n' "$reported_host" >&2
+		exit 1
+	fi
+
+	log "$label: smoke selfhost doctor"
+	if ! out="$(cd "$root" && OSTY_SELF_REBUILD_HOST_BIN="$host_bin" "$driver" --selfhost-doctor 2>&1)"; then
+		printf '%s\n' "$out" >&2
+		fail "$label selfhost doctor failed"
+	fi
+	case "$out" in
+	*"osty-self host probe: OK"*) ;;
+	*)
+		printf '%s\n' "$out" >&2
+		fail "$label selfhost doctor did not report OK"
+		;;
+	esac
+}
+
 emit_stage1_ir() {
 	local out="$stage_root/stage1.ll"
 	local artifact="$toolchain_dir/.osty/out/debug/llvm/main.ll"
@@ -280,6 +314,8 @@ else
 	fi
 fi
 
+smoke_self_driver "$stage1" "stage1"
+
 if [[ "$mode" == "stage1" ]]; then
 	log "stage1-only complete: $stage1"
 	exit 0
@@ -291,6 +327,8 @@ if [[ -n "${OSTY_SELF_REBUILD_STAGE2_BIN:-}" ]]; then
 else
 	build_self_binary "$stage1" "stage2" "$stage2"
 fi
+
+smoke_self_driver "$stage2" "stage2"
 
 if ! cmp -s "$stage1" "$stage2"; then
 	printf 'self-rebuild: byte parity failed\n' >&2

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -1,10 +1,10 @@
 use std.env
+use std.fs
 use std.os
 use std.process
 use std.strings
 
-fn forwardedArgs() -> List<String> {
-    let encoded = env.get("OSTY_SELF_REBUILD_FORWARD_ARGS") ?? ""
+fn forwardedArgsFrom(encoded: String, rawArgs: List<String>) -> List<String> {
     if encoded != "" {
         let mut out: List<String> = []
         for arg in strings.split(encoded, "\n") {
@@ -14,15 +14,69 @@ fn forwardedArgs() -> List<String> {
         }
         return out
     }
-    env.args()
+    let mut out: List<String> = []
+    let mut i = 1
+    for i < rawArgs.len() {
+        out.push(rawArgs[i])
+        i = i + 1
+    }
+    out
+}
+
+fn forwardedArgs() -> List<String> {
+    forwardedArgsFrom(env.get("OSTY_SELF_REBUILD_FORWARD_ARGS") ?? "", env.args())
+}
+
+fn hostCompiler() -> String {
+    let explicit = env.get("OSTY_SELF_REBUILD_HOST_BIN") ?? ""
+    if explicit != "" {
+        return explicit
+    }
+    if fs.exists(".bin/osty") {
+        return ".bin/osty"
+    }
+    "osty"
+}
+
+fn hasSelfhostCommand(args: List<String>, name: String) -> Bool {
+    args.len() > 0 && args[0] == name
+}
+
+fn runSelfhostDoctor(host: String) -> Int {
+    println("osty-self host: {host}")
+    let result = os.exec(host, ["explain", "E0001"])
+    match result {
+        Ok(out) -> {
+            if out.exitCode == 0 && strings.contains(out.stdout, "E0001") {
+                println("osty-self host probe: OK")
+                return 0
+            }
+            if out.stdout != "" {
+                print(out.stdout)
+            }
+            if out.stderr != "" {
+                eprint(out.stderr)
+            }
+            out.exitCode
+        },
+        Err(_) -> {
+            eprint("osty-self host probe failed; set OSTY_SELF_REBUILD_HOST_BIN or run from the repo root after `just build`\n")
+            2
+        },
+    }
 }
 
 fn main() {
-    let host = env.get("OSTY_SELF_REBUILD_HOST_BIN") ?? ""
-    if host == "" {
-        process.abort("osty-self bootstrap needs OSTY_SELF_REBUILD_HOST_BIN")
+    let args = forwardedArgs()
+    let host = hostCompiler()
+    if hasSelfhostCommand(args, "--selfhost-host") {
+        println(host)
+        os.exit(0)
     }
-    let result = os.exec(host, forwardedArgs())
+    if hasSelfhostCommand(args, "--selfhost-doctor") {
+        os.exit(runSelfhostDoctor(host))
+    }
+    let result = os.exec(host, args)
     match result {
         Ok(out) -> {
             if out.stdout != "" {
@@ -33,6 +87,6 @@ fn main() {
             }
             os.exit(out.exitCode)
         },
-        Err(_) -> process.abort("osty-self bootstrap exec failed"),
+        Err(_) -> process.abort("osty-self bootstrap exec failed; set OSTY_SELF_REBUILD_HOST_BIN or run from the repo root after `just build`"),
     }
 }

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -2643,6 +2643,26 @@ pub fn mirFunctionParamPart(llvmT: String, isNoalias: Bool, idxDigits: String) -
     llvmT + suffix
 }
 
+/// mirEnvArgsArgcParamPart / ArgvParamPart render the C ABI params
+/// added to `main` when a MIR module uses `std.env.args()`.
+pub fn mirEnvArgsArgcParamPart() -> String {
+    "i32 %osty_env_argc"
+}
+
+pub fn mirEnvArgsArgvParamPart() -> String {
+    "ptr %osty_env_argv"
+}
+
+/// mirEnvArgsArgcValue / ArgvValue name the incoming C ABI values used
+/// by the `osty_rt_env_args_init` prologue.
+pub fn mirEnvArgsArgcValue() -> String {
+    "%osty_env_argc"
+}
+
+pub fn mirEnvArgsArgvValue() -> String {
+    "%osty_env_argv"
+}
+
 /// mirBlockLabelName returns the LLVM basic-block label name for
 /// MIR block ID `blockID` — `"entry"` when it's the function's
 /// entry block, `"bb<N>"` otherwise (where N is the block ID).
@@ -14652,6 +14672,15 @@ pub fn mirCallVoidPtrI64Text(sym: String, p: String, n: String) -> String {
 /// `osty_rt_env_args_init`).
 pub fn mirCallVoidI64PtrText(sym: String, n: String, p: String) -> String {
     "  call void @" + sym + "(i64 " + n + ", ptr " + p + ")"
+}
+
+/// mirEnvArgsInitPreamble renders the two entry-block lines that seed
+/// the runtime env-args snapshot from C `main(argc, argv)`.
+pub fn mirEnvArgsInitPreamble(initSym: String, argcI64: String) -> List<String> {
+    [
+        mirSExtI32ToI64Text(argcI64, mirEnvArgsArgcValue()),
+        mirCallVoidI64PtrText(initSym, argcI64, mirEnvArgsArgvValue()),
+    ]
 }
 
 /// mirCallVoidPtrPtrText renders `  call void @<sym>(ptr <a>, ptr <b>)`.


### PR DESCRIPTION
## Summary
- Make self-host driver robust and runnable for practical debug use: default host selection, command passthrough, and doctor probing.
- Add smoke checks for generated selfhost binaries (`--selfhost-host`, `--selfhost-doctor`) in `scripts/verify-self-rebuild`.
- Keep `std.env.args` wiring to include runtime init for argv in MIR LLVM generation path, with helperized MIR snapshot fragments.

## Verification
- `./.bin/osty check --airepair=false toolchain` passes.
- `go test -count=1 -vet=off ./internal/llvmgen -run "TestGenerateFromMIRStdEnvArgsInitializesArgv|TestStdEnvArgsRoutesToRuntime"`
- `just verify-self-rebuild-stage1` passes.
- Full stage rebuild run reached parity successfully.
