### PR TITLE
[codex] port MIR backend policy helpers to Osty

### DIFF
--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -193,7 +193,7 @@ func TestGenerateReturnedListOfStringsLiteralPreservesStringHint(t *testing.T) {
 	got := string(ir)
 	for _, want := range []string{
 		"call ptr @osty_rt_list_new()",
-		"call void @osty_rt_list_push_ptr(",
+		"call void @osty_rt_list_push_string(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -1951,7 +1951,7 @@ fn prune(m: Map<String, Int>) {
 		"define private i1 @__osty_closure_thunk_keepPositive(ptr %env, ptr %arg0, i64 %arg1)",
 		"= call i1 (ptr, ptr, i64)",
 		"call ptr @osty_rt_list_new()",
-		"call void @osty_rt_list_push_ptr(",
+		"call void @osty_rt_list_push_string(",
 		// Second pass calls map_remove per victim.
 		"call i1 @osty_rt_map_remove_string(",
 	} {

--- a/internal/llvmgen/list_insert_test.go
+++ b/internal/llvmgen/list_insert_test.go
@@ -73,7 +73,7 @@ func TestListInsertString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list.insert<String> errored: %v", err)
 	}
-	if got := string(ir); !strings.Contains(got, "@osty_rt_list_insert_ptr") {
-		t.Fatalf("list.insert<String> did not invoke insert_ptr:\n%s", got)
+	if got := string(ir); !strings.Contains(got, "@osty_rt_list_insert_string") {
+		t.Fatalf("list.insert<String> did not invoke insert_string:\n%s", got)
 	}
 }

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -7635,7 +7635,7 @@ func (g *mirGen) emitEnumStringConcatBoxed(op mir.Operand, t mir.Type) (*LlvmVal
 	labels := make([]string, len(layout.Variants))
 	values := make([]string, len(layout.Variants))
 	for idx, v := range layout.Variants {
-		label := g.freshLabel("enumstr." + sanitizeLabelFragment(v.Name))
+		label := g.freshLabel("enumstr." + mirSanitizeLabelFragment(v.Name))
 		labels[idx] = label
 		cases = append(cases, MirGenSwitchCase{
 			ValueText:   strconv.Itoa(v.Index),
@@ -7677,25 +7677,6 @@ func (g *mirGen) emitEnumStringConcatBoxed(op mir.Operand, t mir.Type) (*LlvmVal
 	b.WriteString(" ]\n")
 	g.fnBuf.WriteString(b.String())
 	return &LlvmValue{typ: "ptr", name: out}, true, nil
-}
-
-func sanitizeLabelFragment(s string) string {
-	if s == "" {
-		return "variant"
-	}
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('_')
-		}
-	}
-	if b.Len() == 0 {
-		return "variant"
-	}
-	return b.String()
 }
 
 // emitStringSplit emits `.split(sep)` as a call to the runtime
@@ -8413,16 +8394,6 @@ func (g *mirGen) coerceValue(val, from, to string) (string, error) {
 		return g.emitIntResize(val, from, to)
 	}
 	return "", fmt.Errorf("cannot coerce %s to %s", from, to)
-}
-
-func mirIsTwoWordEnumLLVM(llvmT string) bool {
-	name := strings.TrimPrefix(llvmT, "%")
-	return strings.HasPrefix(name, "Option.") ||
-		strings.HasPrefix(name, "Maybe.") ||
-		strings.HasPrefix(name, "Result.") ||
-		mangledBuiltinSourceNameIs(name, "Option") ||
-		mangledBuiltinSourceNameIs(name, "Maybe") ||
-		mangledBuiltinSourceNameIs(name, "Result")
 }
 
 func isOpaqueBuiltinStructLayout(sl *mir.StructLayout) bool {
@@ -10105,30 +10076,15 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 }
 
 func mirBinaryResultIsBool(op mir.BinaryOp) bool {
-	switch op {
-	case mir.BinEq, mir.BinNeq, mir.BinLt, mir.BinLeq, mir.BinGt, mir.BinGeq:
-		return true
-	default:
-		return false
-	}
+	return mirBinaryResultIsBoolSymbol(op.String())
 }
 
 func mirBinaryResultCanUseOperandWidth(op mir.BinaryOp) bool {
-	switch op {
-	case mir.BinAdd, mir.BinSub, mir.BinMul, mir.BinDiv, mir.BinMod,
-		mir.BinAnd, mir.BinOr, mir.BinBitAnd, mir.BinBitOr, mir.BinBitXor,
-		mir.BinShl, mir.BinShr:
-		return true
-	default:
-		return false
-	}
+	return mirBinaryResultCanUseOperandWidthSymbol(op.String())
 }
 
 func numericLLVMResizePossible(from, to string) bool {
-	if intLLVMBits(from) > 0 && intLLVMBits(to) > 0 {
-		return true
-	}
-	return (from == "float" || from == "double") && (to == "float" || to == "double")
+	return mirNumericLLVMResizePossible(from, to)
 }
 
 func (g *mirGen) isEnumValueType(t mir.Type) bool {
@@ -10185,19 +10141,10 @@ func (g *mirGen) emitHeapEquality(op mir.BinaryOp, left, right string) (string, 
 	return neq, nil
 }
 
-// stringEqInlineMaxBytes caps the literal length (excluding NUL) for
-// which `String == literal` / `!=` expands inline as a byte-wise
-// compare instead of dispatching to `osty_rt_strings_Equal`. Short
-// discriminator keywords dominate CSV / log parsing hot paths; inlining
-// eliminates the call overhead and the two strlen scans the runtime
-// performs. 16 covers common codes (regions, HTTP verbs, "enterprise",
-// etc.) while keeping the emitted IR compact.
-const stringEqInlineMaxBytes = 16
-
 // literalStringOperand returns (value, true) if op is a StringConst
-// with length ≤ stringEqInlineMaxBytes and no embedded NUL. Embedded
-// NULs are rejected because the inline compare terminates on the NUL
-// byte — such literals must keep routing to the runtime.
+// accepted by the Osty-owned inline-literal policy. Embedded NULs are
+// rejected because the inline compare terminates on the NUL byte — such
+// literals must keep routing to the runtime.
 func literalStringOperand(op mir.Operand) (string, bool) {
 	c, ok := op.(*mir.ConstOp)
 	if !ok {
@@ -10207,13 +10154,15 @@ func literalStringOperand(op mir.Operand) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if len(sc.Value) > stringEqInlineMaxBytes {
-		return "", false
-	}
+	hasNUL := false
 	for i := 0; i < len(sc.Value); i++ {
 		if sc.Value[i] == 0 {
-			return "", false
+			hasNUL = true
+			break
 		}
+	}
+	if !mirInlineStringLiteralCandidate(len(sc.Value), hasNUL) {
+		return "", false
 	}
 	return sc.Value, true
 }
@@ -10337,6 +10286,9 @@ func earliestAfter(s string, markers []string) int {
 // encodeLLVMString returns the LLVM-style escaped body of s and the
 // byte count of the underlying array (including a trailing NUL).
 func encodeLLVMString(s string) (string, int) {
+	if mirCanEncodeLLVMString(s) {
+		return mirEncodeLLVMString(s), mirLLVMStringArraySize(len(s))
+	}
 	var b strings.Builder
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -367,6 +367,32 @@ func mirBinaryForcesI1Type(symbol string) bool {
 	return symbol == "&&" || symbol == "||"
 }
 
+// Osty: mirBinaryResultIsBoolSymbol
+func mirBinaryResultIsBoolSymbol(symbol string) bool {
+	switch symbol {
+	case "==", "!=", "<", "<=", ">", ">=":
+		return true
+	}
+	return false
+}
+
+// Osty: mirBinaryResultCanUseOperandWidthSymbol
+func mirBinaryResultCanUseOperandWidthSymbol(symbol string) bool {
+	switch symbol {
+	case "+", "-", "*", "/", "%", "&&", "||", "&", "|", "^", "<<", ">>":
+		return true
+	}
+	return false
+}
+
+// Osty: mirNumericLLVMResizePossible
+func mirNumericLLVMResizePossible(from, to string) bool {
+	if mirIntLLVMBits(from) > 0 && mirIntLLVMBits(to) > 0 {
+		return true
+	}
+	return (from == "float" || from == "double") && (to == "float" || to == "double")
+}
+
 // Osty: toolchain/mir_generator.osty:307:5
 func mirUnaryIsIdentity(symbol string) bool {
 	return symbol == "+"
@@ -947,6 +973,32 @@ func mirEncodeLLVMString(s string) string {
 		}()
 	}
 	return out + "\\00"
+}
+
+// Osty: mirCanEncodeLLVMString
+func mirCanEncodeLLVMString(s string) bool {
+	printable := " !#$%&'()*+,-./0123456789:;<=" + ">?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+	for i := 0; i < len(s); i++ {
+		ch := s[i : i+1]
+		if ch == "\\" || ch == "\"" || llvmStrings.Contains(printable, ch) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// Osty: mirLLVMStringArraySize
+func mirLLVMStringArraySize(byteLen int) int {
+	return byteLen + 1
+}
+
+// Osty: mirInlineStringLiteralCandidate
+func mirInlineStringLiteralCandidate(byteLen int, hasNul bool) bool {
+	if hasNul {
+		return false
+	}
+	return byteLen <= 16
 }
 
 // Osty: toolchain/mir_generator.osty:781:5
@@ -9008,6 +9060,25 @@ func mirSanitizeLLVMName(name string) string {
 	return b.String()
 }
 
+// Osty: mirSanitizeLabelFragment
+func mirSanitizeLabelFragment(name string) string {
+	if name == "" {
+		return "variant"
+	}
+	var b llvmStrings.Builder
+	for _, c := range name {
+		if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
+			b.WriteRune(c)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "variant"
+	}
+	return b.String()
+}
+
 // Osty: mirCloneRootPaths
 func mirCloneRootPaths(paths [][]int) [][]int {
 	if len(paths) == 0 {
@@ -11313,6 +11384,20 @@ func mirMonomorphMangledSourceName(name string) string {
 // Osty: mirMangledBuiltinSourceNameIs
 func mirMangledBuiltinSourceNameIs(name, want string) bool {
 	return mirMonomorphMangledSourceName(name) == want
+}
+
+// Osty: mirIsTwoWordEnumLLVM
+func mirIsTwoWordEnumLLVM(llvmT string) bool {
+	name := llvmT
+	if llvmStrings.HasPrefix(name, "%") {
+		name = name[1:]
+	}
+	return llvmStrings.HasPrefix(name, "Option.") ||
+		llvmStrings.HasPrefix(name, "Maybe.") ||
+		llvmStrings.HasPrefix(name, "Result.") ||
+		mirMangledBuiltinSourceNameIs(name, "Option") ||
+		mirMangledBuiltinSourceNameIs(name, "Maybe") ||
+		mirMangledBuiltinSourceNameIs(name, "Result")
 }
 
 // Osty: mirSetElemTypeArgIndex

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1237,7 +1237,7 @@ func TestGenerateFromMIRNestedIndexedElementCallWrite(t *testing.T) {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
 	got := string(out)
-	want := regexp.MustCompile(`(?s)call ptr @makeNestedName\(\).*osty_rt_list_get_bytes_v1.*osty_rt_list_set_ptr.*insertvalue %Cell.*osty_rt_list_set_bytes_v1`)
+	want := regexp.MustCompile(`(?s)call ptr @makeNestedName\(\).*osty_rt_list_get_bytes_v1.*osty_rt_list_set_string.*insertvalue %Cell.*osty_rt_list_set_bytes_v1`)
 	if !want.MatchString(got) {
 		t.Fatalf("nested indexed call result should update the inner list and outer element, got:\n%s", got)
 	}

--- a/internal/llvmgen/mir_result_alias_policy_test.go
+++ b/internal/llvmgen/mir_result_alias_policy_test.go
@@ -91,3 +91,69 @@ func TestMirMonomorphMangledSourceName(t *testing.T) {
 		t.Fatalf("mangled builtin predicate matched wrong source name")
 	}
 }
+
+func TestMirBackendBinaryPolicyHelpers(t *testing.T) {
+	if !mirBinaryResultIsBool(mir.BinEq) || !mirBinaryResultIsBool(mir.BinGeq) {
+		t.Fatalf("comparison operators should report Bool results")
+	}
+	if mirBinaryResultIsBool(mir.BinAdd) {
+		t.Fatalf("addition should not report a Bool result")
+	}
+	if !mirBinaryResultCanUseOperandWidth(mir.BinAdd) || !mirBinaryResultCanUseOperandWidth(mir.BinShl) {
+		t.Fatalf("arithmetic/shift operators should use operand width")
+	}
+	if mirBinaryResultCanUseOperandWidth(mir.BinEq) {
+		t.Fatalf("comparisons must not use operand width")
+	}
+	if !numericLLVMResizePossible("i8", "i64") || !numericLLVMResizePossible("float", "double") {
+		t.Fatalf("numeric resize policy rejected legal resize")
+	}
+	if numericLLVMResizePossible("ptr", "i64") || numericLLVMResizePossible("i64", "double") {
+		t.Fatalf("numeric resize policy accepted illegal resize")
+	}
+}
+
+func TestMirStringLiteralPolicyHelpers(t *testing.T) {
+	encoded, size := encodeLLVMString("a\"b\\c")
+	if encoded != "a\\22b\\\\c\\00" || size != 6 {
+		t.Fatalf("printable encode = (%q, %d)", encoded, size)
+	}
+	encoded, size = encodeLLVMString("\x01")
+	if encoded != "\\01\\00" || size != 2 {
+		t.Fatalf("fallback encode = (%q, %d)", encoded, size)
+	}
+	if !mirCanEncodeLLVMString("alpha-123") || mirCanEncodeLLVMString("line\nbreak") {
+		t.Fatalf("Osty string encoder capability predicate drifted")
+	}
+
+	okLit := &mir.ConstOp{Const: &mir.StringConst{Value: strings.Repeat("a", 16)}}
+	if got, ok := literalStringOperand(okLit); !ok || got != strings.Repeat("a", 16) {
+		t.Fatalf("16-byte literal should inline: %q %v", got, ok)
+	}
+	tooLong := &mir.ConstOp{Const: &mir.StringConst{Value: strings.Repeat("a", 17)}}
+	if _, ok := literalStringOperand(tooLong); ok {
+		t.Fatalf("17-byte literal should not inline")
+	}
+	withNul := &mir.ConstOp{Const: &mir.StringConst{Value: "a\x00b"}}
+	if _, ok := literalStringOperand(withNul); ok {
+		t.Fatalf("NUL literal should not inline")
+	}
+}
+
+func TestMirEnumAndLabelPolicyHelpers(t *testing.T) {
+	if !mirIsTwoWordEnumLLVM("%Result.i64.ptr") || !mirIsTwoWordEnumLLVM("%Option.i64") {
+		t.Fatalf("direct two-word enum LLVM names not recognized")
+	}
+	if !mirIsTwoWordEnumLLVM("_ZTSN4core6Result") {
+		t.Fatalf("monomorphized Result name not recognized")
+	}
+	if mirIsTwoWordEnumLLVM("%List.i64") {
+		t.Fatalf("List should not be treated as two-word enum")
+	}
+	if got := mirSanitizeLabelFragment("A-B!9"); got != "A_B_9" {
+		t.Fatalf("label fragment = %q", got)
+	}
+	if got := mirSanitizeLabelFragment(""); got != "variant" {
+		t.Fatalf("empty label fragment = %q", got)
+	}
+}

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -684,7 +684,7 @@ func TestGenerateManagedListPushStmtUsesSafepoint(t *testing.T) {
 	for _, want := range []string{
 		"declare void @osty.gc.safepoint_v1(i64, ptr, i64)",
 		"call void @osty.gc.safepoint_v1(",
-		"call void @osty_rt_list_push_ptr(",
+		"call void @osty_rt_list_push_string(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)

--- a/internal/llvmgen/selfhost_mir_gaps_test.go
+++ b/internal/llvmgen/selfhost_mir_gaps_test.go
@@ -103,7 +103,7 @@ fn selfDocAddRefsFromText(
 		"define ptr @selfDocAddRefsFromText(",
 		"call ptr @osty_rt_strings_Split(",
 		"call ptr @osty_rt_strings_Concat(",
-		"call void @osty_rt_list_push_ptr(",
+		"call void @osty_rt_list_push_string(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -296,6 +296,38 @@ pub fn mirBinaryForcesI1Type(symbol: String) -> Bool {
     symbol == "&&" || symbol == "||"
 }
 
+/// mirBinaryResultIsBoolSymbol reports whether a MIR binary operator's
+/// result type is Bool regardless of the operand type. The Go caller
+/// forwards `mir.BinaryOp.String()` so the result-shape policy can live
+/// next to the opcode table.
+pub fn mirBinaryResultIsBoolSymbol(symbol: String) -> Bool {
+    symbol == "==" || symbol == "!=" || symbol == "<" || symbol == "<=" ||
+        symbol == ">" || symbol == ">="
+}
+
+/// mirBinaryResultCanUseOperandWidthSymbol reports whether a binary
+/// operation may be widened/narrowed to the destination LLVM integer /
+/// float width before emission. Comparisons always return Bool and are
+/// excluded; arithmetic, logical, bitwise, and shifts can use the
+/// operand/result width selected by type inference.
+pub fn mirBinaryResultCanUseOperandWidthSymbol(symbol: String) -> Bool {
+    symbol == "+" || symbol == "-" || symbol == "*" || symbol == "/" ||
+        symbol == "%" || symbol == "&&" || symbol == "||" ||
+        symbol == "&" || symbol == "|" || symbol == "^" ||
+        symbol == "<<" || symbol == ">>"
+}
+
+/// mirNumericLLVMResizePossible reports whether a value of `from` LLVM
+/// type can be resized to `to` by the MIR binary-op coercion path. Int
+/// widths use zext/sext/trunc through `mirIntLLVMBits`; float widths use
+/// fpext/fptrunc. Mixed int/float and pointer shapes are rejected here.
+pub fn mirNumericLLVMResizePossible(from: String, to: String) -> Bool {
+    if mirIntLLVMBits(from) > 0 && mirIntLLVMBits(to) > 0 {
+        return true
+    }
+    (from == "float" || from == "double") && (to == "float" || to == "double")
+}
+
 /// mirUnaryIsIdentity reports whether a unary operator symbol is the
 /// no-op (unary-plus) form. The caller short-circuits before
 /// requesting an instruction body — unary plus emits nothing and just
@@ -945,6 +977,43 @@ pub fn mirEncodeLLVMString(s: String) -> String {
         i = i + 1
     }
     out + "\\00"
+}
+
+/// mirCanEncodeLLVMString reports whether `mirEncodeLLVMString` can
+/// encode `s` without falling back to the Go byte encoder. It accepts
+/// printable ASCII plus the two explicit structural escapes (`\` and
+/// `"`), matching the selfhost encoder's current capability.
+pub fn mirCanEncodeLLVMString(s: String) -> Bool {
+    let printable = " !#$%&'()*+,-./0123456789:;<=" + ">?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz\{|\}~"
+    let n = s.len()
+    let mut i = 0
+    for i < n {
+        let ch = s[i..(i + 1)]
+        if ch == "\\" || ch == "\"" || llvmStrings.Contains(printable, ch) {
+            i = i + 1
+        } else {
+            return false
+        }
+    }
+    true
+}
+
+/// mirLLVMStringArraySize returns the LLVM constant array byte count
+/// for a string literal: source bytes plus the terminating NUL appended
+/// by `mirEncodeLLVMString`.
+pub fn mirLLVMStringArraySize(byteLen: Int) -> Int {
+    byteLen + 1
+}
+
+/// mirInlineStringLiteralCandidate owns the tiny literal policy for
+/// lowering `String == literal` without calling the runtime equality
+/// helper. The Go caller still extracts the literal and scans for NUL
+/// bytes, but the size threshold and embedded-NUL rejection live here.
+pub fn mirInlineStringLiteralCandidate(byteLen: Int, hasNul: Bool) -> Bool {
+    if hasNul {
+        return false
+    }
+    byteLen <= 16
 }
 
 /// mirLlvmGlobalVarLine renders `@<name> = global <ty> zeroinitializer\n`
@@ -14398,6 +14467,30 @@ pub fn mirSanitizeLLVMName(name: String) -> String {
     out
 }
 
+/// mirSanitizeLabelFragment folds enum variant names into a compact
+/// label suffix for string-interpolation switch blocks. Unlike
+/// `mirSanitizeLLVMName`, a leading digit is allowed because the caller
+/// always prefixes the fragment (`enumstr.<fragment>`). Empty/all-empty
+/// input becomes `"variant"`.
+pub fn mirSanitizeLabelFragment(name: String) -> String {
+    if name == "" { return "variant" }
+    let alnum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    let n = name.len()
+    let mut out = ""
+    let mut i = 0
+    for i < n {
+        let ch = name[i..(i + 1)]
+        if llvmStrings.Contains(alnum, ch) {
+            out = out + ch
+        } else {
+            out = out + "_"
+        }
+        i = i + 1
+    }
+    if out == "" { return "variant" }
+    out
+}
+
 /// mirCloneRootPaths deep-copies a list of int-list paths so the caller
 /// can mutate the result without aliasing the source. Mirrors
 /// `cloneRootPaths` in `internal/llvmgen/generator.go`.
@@ -17283,6 +17376,25 @@ pub fn mirMonomorphMangledSourceName(name: String) -> String {
 /// fallback checks.
 pub fn mirMangledBuiltinSourceNameIs(name: String, want: String) -> Bool {
     mirMonomorphMangledSourceName(name) == want
+}
+
+/// mirIsTwoWordEnumLLVM reports whether an LLVM type name uses the
+/// canonical two-word enum layout (`{ i64, i64 }`) and can therefore be
+/// retyped by extracting/reinserting discriminant + payload. It handles
+/// both direct `%Option.*` / `%Result.*` names and monomorphized builtin
+/// layout spellings whose source head was Option, Maybe, or Result.
+pub fn mirIsTwoWordEnumLLVM(llvmT: String) -> Bool {
+    let name = if llvmStrings.HasPrefix(llvmT, "%") {
+        llvmT[1..llvmT.len()]
+    } else {
+        llvmT
+    }
+    llvmStrings.HasPrefix(name, "Option.") ||
+        llvmStrings.HasPrefix(name, "Maybe.") ||
+        llvmStrings.HasPrefix(name, "Result.") ||
+        mirMangledBuiltinSourceNameIs(name, "Option") ||
+        mirMangledBuiltinSourceNameIs(name, "Maybe") ||
+        mirMangledBuiltinSourceNameIs(name, "Result")
 }
 
 /// mirSetElemTypeArgIndex returns the index of the element type in


### PR DESCRIPTION
## Summary
- move more MIR backend policy helpers into `toolchain/mir_generator.osty`
- route Go MIR emission through the Osty-sourced snapshot for binary result shape, numeric resize, string literal policy, enum two-word layout, and enum label sanitization
- update string-list codegen expectations to the typed string runtime helpers on current main

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestMirBackendBinaryPolicyHelpers|TestMirStringLiteralPolicyHelpers|TestMirEnumAndLabelPolicyHelpers|TestMirResult|TestMirCompatible|TestMirRetype|TestMirMonomorph'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateReturnedListOfStringsLiteralPreservesStringHint|TestGenerateMapRetainIfTwoPass|TestListInsertString|TestGenerateFromMIRNestedIndexedElementCallWrite|TestGenerateManagedListPushStmtUsesSafepoint|TestSelfhostDocgenAddRefsFromTextMIRDirect'`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryResultUnitErrUsesReturnContext'`
- `just fmt-check`
- `git diff --check`
- `just verify-selfhost`
- `just verify-self-rebuild-gates`
- `go test -count=1 -vet=off ./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen`
- `just verify-self-rebuild-fast` (stage1/stage2 byte parity OK: `55e456c3c33861dc2479a1b0e407d31c4a1de7b4d7efa93ad3590846f87018c3`)