### PR TITLE
[codex] preserve query package metadata

### DIFF
--- a/cmd/osty/query.go
+++ b/cmd/osty/query.go
@@ -55,8 +55,8 @@ func runQueryCheck(args []string) {
 	dir := ostyquery.PackageDirOf(key)
 
 	eng.Inputs.SourceText.Set(eng.DB, key, src)
+	eng.Inputs.PackageMetadata.Set(eng.DB, dir, ostyquery.PackageMetadataForDir(dir, ""))
 	eng.Inputs.PackageFiles.Set(eng.DB, dir, []string{key})
-	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	before := eng.DB.Metrics()
 	diags := eng.Queries.FileDiagnostics.Get(eng.DB, key)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -593,8 +593,8 @@ func (s *Server) analyzePackageViaEngine(pkgDir, path string, src []byte) *docAn
 	}
 
 	// Seed PackageFiles so BuildPackage can assemble the resolve.Package.
+	s.engine.Inputs.PackageMetadata.Set(s.engine.DB, dir, ostyquery.PackageMetadataForDir(pkgDir, ""))
 	s.engine.Inputs.PackageFiles.Set(s.engine.DB, dir, filePaths)
-	s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	// Pull per-file results from the engine query chain.
 	pr := s.engine.Queries.Parse.Get(s.engine.DB, key)
@@ -730,8 +730,8 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 			s.engine.Inputs.SourceText.Set(s.engine.DB, fp, diskSrc)
 		}
 
+		s.engine.Inputs.PackageMetadata.Set(s.engine.DB, pkgDir, ostyquery.PackageMetadataForDir(pkgDir, ""))
 		s.engine.Inputs.PackageFiles.Set(s.engine.DB, pkgDir, filePaths)
-		s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, pkgDir, ostyquery.PackageRuntimeCapabilityFromManifest(pkgDir))
 	}
 
 	// Seed WorkspaceMembers so ResolveWorkspace knows which packages
@@ -1080,8 +1080,10 @@ func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis
 	// Build the list deterministically from what the engine already
 	// knows about — i.e., just this one file. Multi-file scratch
 	// scenarios are rare in single-file mode.
+	if path, ok := fileURIPath(uri); ok {
+		s.engine.Inputs.PackageMetadata.Set(s.engine.DB, dir, ostyquery.PackageMetadataForDir(filepath.Dir(path), ""))
+	}
 	s.engine.Inputs.PackageFiles.Set(s.engine.DB, dir, []string{key})
-	s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	pr := s.engine.Queries.Parse.Get(s.engine.DB, key)
 	rr := s.engine.Queries.ResolveFile.Get(s.engine.DB, key)

--- a/internal/query/db_test.go
+++ b/internal/query/db_test.go
@@ -439,6 +439,48 @@ func TestInputHas(t *testing.T) {
 	}
 }
 
+func TestHasFetchAbsentInputDoesNotRerunOnUnrelatedChange(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	optional := RegisterInput[string, string](db, "Optional", hashString)
+	other := RegisterInput[string, string](db, "Other", hashString)
+
+	bodyCount := 0
+	derived := Register(db, "Derived",
+		func(ctx *Ctx, key string) string {
+			bodyCount++
+			if optional.HasFetch(ctx, key) {
+				return optional.Fetch(ctx, key)
+			}
+			return "missing"
+		},
+		hashString,
+	)
+
+	other.Set(db, "noise", "v1")
+	if got := derived.Get(db, "pkg"); got != "missing" {
+		t.Fatalf("initial derived = %q, want missing", got)
+	}
+	if bodyCount != 1 {
+		t.Fatalf("initial body count = %d, want 1", bodyCount)
+	}
+
+	other.Set(db, "noise", "v2")
+	if got := derived.Get(db, "pkg"); got != "missing" {
+		t.Fatalf("after unrelated change derived = %q, want missing", got)
+	}
+	if bodyCount != 1 {
+		t.Fatalf("absent optional input caused rerun; body count = %d, want 1", bodyCount)
+	}
+
+	optional.Set(db, "pkg", "present")
+	if got := derived.Get(db, "pkg"); got != "present" {
+		t.Fatalf("after optional set derived = %q, want present", got)
+	}
+	if bodyCount != 2 {
+		t.Fatalf("optional set should rerun body once, got %d", bodyCount)
+	}
+}
+
 // ---- Metrics sanity ----
 
 func TestMetricsSubtraction(t *testing.T) {

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -755,6 +755,13 @@ func hashStringSlice(ss []string) [32]byte {
 	return h.sum()
 }
 
+func hashPackageMetadata(m PackageMetadata) [32]byte {
+	h := newHasher()
+	h.str(m.Name)
+	h.bool(m.RuntimeCapability)
+	return h.sum()
+}
+
 func hashWorkspacePackageSlice(ms []WorkspacePackage) [32]byte {
 	h := newHasher()
 	if len(ms) == 0 {

--- a/internal/query/osty/inputs.go
+++ b/internal/query/osty/inputs.go
@@ -14,8 +14,15 @@ type WorkspacePackage struct {
 	Name    string
 }
 
-// Inputs groups the primitive input handles that drive the entire Osty query
-// graph. Callers (LSP, CLI) use these to push the
+// PackageMetadata carries the manifest-derived metadata that belongs on the
+// query-built resolve.Package, separate from source-file membership.
+type PackageMetadata struct {
+	Name              string
+	RuntimeCapability bool
+}
+
+// Inputs groups the primitive input handles that drive the
+// entire Osty query graph. Callers (LSP, CLI) use these to push the
 // current world state into the Database; every derived query reads
 // from them transitively.
 //
@@ -38,11 +45,10 @@ type Inputs struct {
 	// to the package by path convention.
 	PackageFiles *query.Input[string, []string]
 
-	// PackageRuntimeCapability maps a normalized package directory to whether
-	// its manifest opted into the runtime sublanguage via
-	// `[capabilities] runtime = true`. Scratch and ad-hoc LSP packages seed
-	// false explicitly.
-	PackageRuntimeCapability *query.Input[string, bool]
+	// PackageMetadata maps a normalized package directory to metadata read from
+	// osty.toml (or from an already-loaded resolve.Package). BuildPackage uses
+	// it when present and otherwise falls back to directory-derived defaults.
+	PackageMetadata *query.Input[string, PackageMetadata]
 
 	// WorkspaceMembers lists every package directory in the current
 	// workspace. Keyed by struct{} so there is exactly one slot.
@@ -60,10 +66,10 @@ type Inputs struct {
 
 func registerInputs(db *query.Database) Inputs {
 	return Inputs{
-		SourceText:               query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
-		PackageFiles:             query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
-		PackageRuntimeCapability: query.RegisterInput[string, bool](db, "PackageRuntimeCapability", hashBoolInput),
-		WorkspaceMembers:         query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
-		WorkspacePackages:        query.RegisterInput[string, []WorkspacePackage](db, "WorkspacePackages", hashWorkspacePackageSlice),
+		SourceText:        query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
+		PackageFiles:      query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
+		PackageMetadata:   query.RegisterInput[string, PackageMetadata](db, "PackageMetadata", hashPackageMetadata),
+		WorkspaceMembers:  query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
+		WorkspacePackages: query.RegisterInput[string, []WorkspacePackage](db, "WorkspacePackages", hashWorkspacePackageSlice),
 	}
 }

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -531,11 +531,17 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 	qs.BuildPackage = query.Register(db, "BuildPackage",
 		func(ctx *query.Ctx, dir string) *resolve.Package {
 			files := inp.PackageFiles.Fetch(ctx, dir)
-			runtimeCapability := inp.PackageRuntimeCapability.Fetch(ctx, dir)
+			metadata := PackageMetadata{Name: packageNameFromDir(dir)}
+			if inp.PackageMetadata.HasFetch(ctx, dir) {
+				metadata = inp.PackageMetadata.Fetch(ctx, dir)
+				if metadata.Name == "" {
+					metadata.Name = packageNameFromDir(dir)
+				}
+			}
 			pkg := &resolve.Package{
 				Dir:               dir,
-				Name:              packageNameFromDir(dir),
-				RuntimeCapability: runtimeCapability,
+				Name:              metadata.Name,
+				RuntimeCapability: metadata.RuntimeCapability,
 				Files:             make([]*resolve.PackageFile, 0, len(files)),
 			}
 			for _, f := range files {

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -20,37 +20,9 @@ import (
 // Helper: seed one "package" with one file for tests.
 func seedFile(eng *Engine, dir, name, src string) string {
 	path := NormalizePath(dir + "/" + name)
-	dir = NormalizePath(dir)
 	eng.Inputs.SourceText.Set(eng.DB, path, []byte(src))
-	eng.Inputs.PackageFiles.Set(eng.DB, dir, []string{path})
-	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, false)
+	eng.Inputs.PackageFiles.Set(eng.DB, NormalizePath(dir), []string{path})
 	return path
-}
-
-func writeRuntimeCapabilityPackage(t *testing.T, dir string) {
-	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
-name = "toolchain"
-version = "1.0.0"
-edition = "0.5"
-
-[capabilities]
-runtime = true
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "main.osty"), []byte("#[repr(c)]\nstruct Raw { x: Int }\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func hasDiagnosticCode(ds []*diag.Diagnostic, code string) bool {
-	for _, d := range ds {
-		if d != nil && d.Code == code {
-			return true
-		}
-	}
-	return false
 }
 
 func TestParseMissThenHit(t *testing.T) {
@@ -109,85 +81,82 @@ func TestBuildPackagePreservesFrontendRuns(t *testing.T) {
 	}
 }
 
-func TestRuntimeCapabilityInputInvalidatesCheckPackage(t *testing.T) {
+func TestBuildPackagePreservesPackageMetadata(t *testing.T) {
 	eng := NewEngine()
 	defer eng.Close()
 
-	dir := NormalizePath("/tmp/pkg_runtime_capability_input")
-	_ = seedFile(eng, dir, "main.osty", "#[repr(c)]\nstruct Raw { x: Int }\n")
+	dir := NormalizePath(t.TempDir())
+	path := seedFile(eng, dir, "main.osty", `#[no_alloc]
+fn pure() -> Int {
+    1
+}
+`)
+	eng.Inputs.PackageMetadata.Set(eng.DB, dir, PackageMetadata{
+		Name:              "toolchain",
+		RuntimeCapability: true,
+	})
+
+	pkg := eng.Queries.BuildPackage.Get(eng.DB, dir)
+	if pkg == nil {
+		t.Fatal("BuildPackage returned nil")
+	}
+	if got := pkg.Name; got != "toolchain" {
+		t.Fatalf("package name = %q, want toolchain", got)
+	}
+	if !pkg.RuntimeCapability {
+		t.Fatal("BuildPackage dropped RuntimeCapability")
+	}
 
 	chk := eng.Queries.CheckPackage.Get(eng.DB, dir)
-	if !hasDiagnosticCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
-		t.Fatalf("unprivileged check missing %s: %#v", diag.CodeRuntimePrivilegeViolation, chk.Diags)
+	if hasDiagCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("privileged package emitted runtime privilege diagnostic: %#v", chk.Diags)
 	}
 
-	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, true)
-	rp := eng.Queries.ResolvePackage.Get(eng.DB, dir)
-	if rp == nil || rp.Package() == nil || !rp.Package().RuntimeCapability {
-		t.Fatalf("ResolvePackage RuntimeCapability = %#v, want true", rp)
-	}
+	eng.Inputs.PackageMetadata.Set(eng.DB, dir, PackageMetadata{Name: "toolchain"})
 	chk = eng.Queries.CheckPackage.Get(eng.DB, dir)
-	if hasDiagnosticCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
-		t.Fatalf("privileged check retained %s: %#v", diag.CodeRuntimePrivilegeViolation, chk.Diags)
+	if !hasDiagCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("ordinary package did not emit runtime privilege diagnostic for %s: %#v", path, chk.Diags)
 	}
 }
 
-func TestSeedPackageDirReadsRuntimeCapability(t *testing.T) {
-	dir := t.TempDir()
-	writeRuntimeCapabilityPackage(t, dir)
-
+func TestSeedPackageDirReadsManifestPackageMetadata(t *testing.T) {
 	eng := NewEngine()
 	defer eng.Close()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
+name = "toolchain"
+version = "1.0.0"
+edition = "0.5"
+
+[capabilities]
+runtime = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.osty"), []byte("fn main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	seeded, err := eng.SeedPackageDir(dir, nil)
 	if err != nil {
 		t.Fatalf("SeedPackageDir: %v", err)
+	}
+	if got := seeded.Name; got != "toolchain" {
+		t.Fatalf("seeded package name = %q, want toolchain", got)
 	}
 	if !seeded.RuntimeCapability {
 		t.Fatal("seeded RuntimeCapability = false, want true")
 	}
 	pkg := eng.Queries.BuildPackage.Get(eng.DB, seeded.Dir)
-	if pkg == nil || !pkg.RuntimeCapability {
-		t.Fatalf("BuildPackage RuntimeCapability = %#v, want true", pkg)
+	if pkg == nil {
+		t.Fatal("BuildPackage returned nil")
 	}
-}
-
-func TestSeedLoadedWorkspacePreservesRuntimeCapability(t *testing.T) {
-	root := t.TempDir()
-	writeRuntimeCapabilityPackage(t, root)
-
-	ws, err := resolve.NewWorkspace(root)
-	if err != nil {
-		t.Fatalf("NewWorkspace: %v", err)
+	if got := pkg.Name; got != "toolchain" {
+		t.Fatalf("package name = %q, want toolchain", got)
 	}
-	if _, err := ws.LoadPackageNative(""); err != nil {
-		t.Fatalf("LoadPackageNative: %v", err)
-	}
-
-	eng := NewEngine()
-	defer eng.Close()
-	seeded, err := eng.SeedLoadedWorkspace(ws)
-	if err != nil {
-		t.Fatalf("SeedLoadedWorkspace: %v", err)
-	}
-	rootDir := NormalizePath(root)
-	built := eng.Queries.BuildPackage.Get(eng.DB, rootDir)
-	if built == nil || !built.RuntimeCapability {
-		t.Fatalf("BuildPackage RuntimeCapability = %#v, want true", built)
-	}
-	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
-	if rw == nil {
-		t.Fatal("ResolveWorkspace returned nil")
-	}
-	pkg := rw.PackageByDir(rootDir)
-	if pkg == nil || !pkg.RuntimeCapability {
-		t.Fatalf("workspace package RuntimeCapability = %#v, want true", pkg)
-	}
-	cw := eng.Queries.CheckWorkspace.Get(eng.DB, seeded.Root)
-	if cw == nil || cw.ResultByDir(rootDir) == nil {
-		t.Fatal("CheckWorkspace missing root result")
-	}
-	if hasDiagnosticCode(cw.ResultByDir(rootDir).Diags, diag.CodeRuntimePrivilegeViolation) {
-		t.Fatalf("workspace check retained %s: %#v", diag.CodeRuntimePrivilegeViolation, cw.ResultByDir(rootDir).Diags)
+	if !pkg.RuntimeCapability {
+		t.Fatal("manifest [capabilities] runtime=true was not carried into query-built package")
 	}
 }
 
@@ -657,6 +626,65 @@ fn main() {
 	}
 }
 
+func TestSeedLoadedWorkspacePreservesRuntimeCapability(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte(`[package]
+name = "toolchain"
+version = "1.0.0"
+edition = "0.5"
+
+[capabilities]
+runtime = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.osty"), []byte(`#[no_alloc]
+fn pure() -> Int {
+    1
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+
+	eng := NewEngine()
+	defer eng.Close()
+	seeded, err := eng.SeedLoadedWorkspace(ws)
+	if err != nil {
+		t.Fatalf("SeedLoadedWorkspace: %v", err)
+	}
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil {
+		t.Fatal("ResolveWorkspace returned nil")
+	}
+	rootDir := NormalizePath(root)
+	pkg := rw.PackageByDir(rootDir)
+	if pkg == nil {
+		t.Fatal("root package missing from resolved workspace")
+	}
+	if !pkg.RuntimeCapability {
+		t.Fatal("resolved workspace package dropped RuntimeCapability")
+	}
+	if node := rw.Graph().Packages[""]; node == nil || !node.RuntimeCapability {
+		t.Fatalf("package graph node runtime capability = %#v, want true", node)
+	}
+	cw := eng.Queries.CheckWorkspace.Get(eng.DB, seeded.Root)
+	chk := cw.ResultByDir(rootDir)
+	if chk == nil {
+		t.Fatal("CheckWorkspace missing root check result")
+	}
+	if hasDiagCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("workspace query treated runtime-capable package as ordinary: %#v", chk.Diags)
+	}
+}
+
 func TestResolveWorkspaceSwitchesFromMemberFallbackToSeededPackages(t *testing.T) {
 	eng := NewEngine()
 	defer eng.Close()
@@ -686,6 +714,15 @@ func TestResolveWorkspaceSwitchesFromMemberFallbackToSeededPackages(t *testing.T
 	if rw.PackageByDir(depDir) == nil {
 		t.Fatal("ResolveWorkspace did not invalidate after WorkspacePackages was seeded")
 	}
+}
+
+func hasDiagCode(diags []*diag.Diagnostic, code string) bool {
+	for _, d := range diags {
+		if d != nil && d.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestNormalizePathIdempotent(t *testing.T) {

--- a/internal/query/osty/seed.go
+++ b/internal/query/osty/seed.go
@@ -36,12 +36,12 @@ func (e *Engine) SeedPackageDir(dir string, transform resolve.SourceTransform) (
 	if err != nil {
 		return SeededPackage{}, err
 	}
-	runtimeCapability := PackageRuntimeCapabilityFromManifest(dir)
-	e.seedPackageInputs(dir, files, sources, runtimeCapability)
+	metadata := PackageMetadataForDir(dir, packageNameFromDir(dir))
+	e.seedPackageInputs(dir, files, sources, metadata)
 	return SeededPackage{
 		Dir:               dir,
-		Name:              packageNameFromDir(dir),
-		RuntimeCapability: runtimeCapability,
+		Name:              metadataNameOrFallback(metadata, dir),
+		RuntimeCapability: metadata.RuntimeCapability,
 		Files:             files,
 		Sources:           sources,
 	}, nil
@@ -61,16 +61,16 @@ func (e *Engine) SeedWorkspaceDirs(root string, packages []WorkspacePackage, tra
 		if err != nil {
 			return SeededWorkspace{}, err
 		}
-		runtimeCapability := PackageRuntimeCapabilityFromManifest(member.Dir)
-		e.seedPackageInputs(member.Dir, files, sources, runtimeCapability)
+		metadata := PackageMetadataForDir(member.Dir, member.Name)
+		e.seedPackageInputs(member.Dir, files, sources, metadata)
 		for path, src := range sources {
 			out.Sources[path] = src
 		}
 		out.Packages = append(out.Packages, SeededPackage{
 			Dir:               member.Dir,
 			DotPath:           member.DotPath,
-			Name:              member.Name,
-			RuntimeCapability: runtimeCapability,
+			Name:              metadataNameOrFallback(metadata, member.Dir),
+			RuntimeCapability: metadata.RuntimeCapability,
 			Files:             files,
 			Sources:           sources,
 		})
@@ -128,12 +128,16 @@ func (e *Engine) SeedLoadedWorkspace(ws *resolve.Workspace) (SeededWorkspace, er
 			out.Sources[path] = src
 		}
 		sort.Strings(files)
-		e.seedPackageInputs(dir, files, sources, pkg.RuntimeCapability)
+		metadata := PackageMetadata{
+			Name:              pkg.Name,
+			RuntimeCapability: pkg.RuntimeCapability,
+		}
+		e.seedPackageInputs(dir, files, sources, metadata)
 		out.Packages = append(out.Packages, SeededPackage{
 			Dir:               dir,
 			DotPath:           key,
-			Name:              pkg.Name,
-			RuntimeCapability: pkg.RuntimeCapability,
+			Name:              metadataNameOrFallback(metadata, dir),
+			RuntimeCapability: metadata.RuntimeCapability,
 			Files:             files,
 			Sources:           sources,
 		})
@@ -143,12 +147,51 @@ func (e *Engine) SeedLoadedWorkspace(ws *resolve.Workspace) (SeededWorkspace, er
 	return out, nil
 }
 
-func (e *Engine) seedPackageInputs(dir string, files []string, sources map[string][]byte, runtimeCapability bool) {
+func (e *Engine) seedPackageInputs(dir string, files []string, sources map[string][]byte, metadata PackageMetadata) {
 	for _, path := range files {
 		e.Inputs.SourceText.Set(e.DB, path, sources[path])
 	}
+	e.Inputs.PackageMetadata.Set(e.DB, dir, metadata)
 	e.Inputs.PackageFiles.Set(e.DB, dir, files)
-	e.Inputs.PackageRuntimeCapability.Set(e.DB, dir, runtimeCapability)
+}
+
+// PackageMetadataForDir reads manifest-backed package metadata when present.
+// It deliberately tolerates missing or malformed manifests and falls back to the
+// caller's name so editor and scratch-buffer paths can keep analyzing source.
+func PackageMetadataForDir(dir string, fallbackName string) PackageMetadata {
+	dir = NormalizePath(dir)
+	metadata := PackageMetadata{Name: fallbackName}
+	if metadata.Name == "" {
+		metadata.Name = packageNameFromDir(dir)
+	}
+	src, err := os.ReadFile(filepath.Join(dir, manifest.ManifestFile))
+	if err != nil {
+		return metadata
+	}
+	m, err := manifest.Parse(src)
+	if err != nil || m == nil {
+		return metadata
+	}
+	if m.HasPackage && m.Package.Name != "" {
+		metadata.Name = m.Package.Name
+	}
+	if m.Capabilities != nil {
+		metadata.RuntimeCapability = m.Capabilities.Runtime
+	}
+	return metadata
+}
+
+func metadataNameOrFallback(metadata PackageMetadata, dir string) string {
+	if metadata.Name != "" {
+		return metadata.Name
+	}
+	return packageNameFromDir(dir)
+}
+
+// PackageRuntimeCapabilityFromManifest preserves the older narrow helper in
+// terms of the fuller package metadata input.
+func PackageRuntimeCapabilityFromManifest(dir string) bool {
+	return PackageMetadataForDir(dir, "").RuntimeCapability
 }
 
 func readPackageSources(dir string, transform resolve.SourceTransform) ([]string, map[string][]byte, error) {
@@ -179,19 +222,4 @@ func readPackageSources(dir string, transform resolve.SourceTransform) ([]string
 	}
 	sort.Strings(files)
 	return files, sources, nil
-}
-
-// PackageRuntimeCapabilityFromManifest reads dir/osty.toml and reports whether
-// it declares `[capabilities] runtime = true`. Missing or invalid manifests are
-// treated as ordinary unprivileged packages, matching the native loader.
-func PackageRuntimeCapabilityFromManifest(dir string) bool {
-	src, err := os.ReadFile(filepath.Join(dir, manifest.ManifestFile))
-	if err != nil {
-		return false
-	}
-	m, err := manifest.Parse(src)
-	if err != nil || m == nil || m.Capabilities == nil {
-		return false
-	}
-	return m.Capabilities.Runtime
 }

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -239,7 +239,14 @@ func (q *Query[K, V]) validateOrRunLocked(db *Database, key K) *slot {
 	stale := false
 	for _, d := range s.deps {
 		depSlot := db.validateDepLocked(d)
-		if depSlot == nil || depSlot.computedAt > d.changedAt {
+		if depSlot == nil {
+			if d.changedAt != 0 {
+				stale = true
+				break
+			}
+			continue
+		}
+		if depSlot.computedAt > d.changedAt {
 			stale = true
 			break
 		}


### PR DESCRIPTION
## Summary

- Carry manifest-derived package metadata through the query graph via a new `PackageMetadata` input.
- Preserve `RuntimeCapability` when building, resolving, copying, and hashing query-built packages.
- Seed metadata from loaded workspaces, package dirs, LSP engine paths, and `query-check`.
- Fix absent optional input dependency validation so unrelated input changes do not force reruns.

## Why

Packages with `[capabilities] runtime = true` could lose that flag when rebuilt by the query graph. That made privileged packages such as toolchain code vulnerable to being checked as ordinary packages.

## Validation

- `go test -count=1 -vet=off ./internal/query ./internal/query/osty ./internal/lsp ./cmd/osty`
- `git diff --check`