### PR TITLE
[codex] preserve runtime capability in query packages

### DIFF
--- a/cmd/osty/query.go
+++ b/cmd/osty/query.go
@@ -56,6 +56,7 @@ func runQueryCheck(args []string) {
 
 	eng.Inputs.SourceText.Set(eng.DB, key, src)
 	eng.Inputs.PackageFiles.Set(eng.DB, dir, []string{key})
+	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	before := eng.DB.Metrics()
 	diags := eng.Queries.FileDiagnostics.Get(eng.DB, key)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -594,6 +594,7 @@ func (s *Server) analyzePackageViaEngine(pkgDir, path string, src []byte) *docAn
 
 	// Seed PackageFiles so BuildPackage can assemble the resolve.Package.
 	s.engine.Inputs.PackageFiles.Set(s.engine.DB, dir, filePaths)
+	s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	// Pull per-file results from the engine query chain.
 	pr := s.engine.Queries.Parse.Get(s.engine.DB, key)
@@ -730,6 +731,7 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 		}
 
 		s.engine.Inputs.PackageFiles.Set(s.engine.DB, pkgDir, filePaths)
+		s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, pkgDir, ostyquery.PackageRuntimeCapabilityFromManifest(pkgDir))
 	}
 
 	// Seed WorkspaceMembers so ResolveWorkspace knows which packages
@@ -1079,6 +1081,7 @@ func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis
 	// knows about — i.e., just this one file. Multi-file scratch
 	// scenarios are rare in single-file mode.
 	s.engine.Inputs.PackageFiles.Set(s.engine.DB, dir, []string{key})
+	s.engine.Inputs.PackageRuntimeCapability.Set(s.engine.DB, dir, ostyquery.PackageRuntimeCapabilityFromManifest(dir))
 
 	pr := s.engine.Queries.Parse.Get(s.engine.DB, key)
 	rr := s.engine.Queries.ResolveFile.Get(s.engine.DB, key)

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -256,6 +256,7 @@ func hashResolvedPackage(rp *ResolvedPackage) [32]byte {
 	}
 	h.str(rp.pkg.Dir)
 	h.str(rp.pkg.Name)
+	h.bool(rp.pkg.RuntimeCapability)
 
 	// Files are already in lexicographic order by Path, but sort
 	// defensively.
@@ -725,6 +726,12 @@ func hashError(h *stableHasher, err error) {
 // ---- Input hashers ----
 
 func hashBytesInput(b []byte) [32]byte { return sha256.Sum256(b) }
+
+func hashBoolInput(v bool) [32]byte {
+	h := newHasher()
+	h.bool(v)
+	return h.sum()
+}
 
 func hashStringSlice(ss []string) [32]byte {
 	// Fast path for the single-file case — single-file LSP analyze

--- a/internal/query/osty/inputs.go
+++ b/internal/query/osty/inputs.go
@@ -14,8 +14,8 @@ type WorkspacePackage struct {
 	Name    string
 }
 
-// Inputs groups the three primitive input handles that drive the
-// entire Osty query graph. Callers (LSP, CLI) use these to push the
+// Inputs groups the primitive input handles that drive the entire Osty query
+// graph. Callers (LSP, CLI) use these to push the
 // current world state into the Database; every derived query reads
 // from them transitively.
 //
@@ -38,6 +38,12 @@ type Inputs struct {
 	// to the package by path convention.
 	PackageFiles *query.Input[string, []string]
 
+	// PackageRuntimeCapability maps a normalized package directory to whether
+	// its manifest opted into the runtime sublanguage via
+	// `[capabilities] runtime = true`. Scratch and ad-hoc LSP packages seed
+	// false explicitly.
+	PackageRuntimeCapability *query.Input[string, bool]
+
 	// WorkspaceMembers lists every package directory in the current
 	// workspace. Keyed by struct{} so there is exactly one slot.
 	// CLI entry points populate this from the osty.toml manifest;
@@ -54,9 +60,10 @@ type Inputs struct {
 
 func registerInputs(db *query.Database) Inputs {
 	return Inputs{
-		SourceText:        query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
-		PackageFiles:      query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
-		WorkspaceMembers:  query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
-		WorkspacePackages: query.RegisterInput[string, []WorkspacePackage](db, "WorkspacePackages", hashWorkspacePackageSlice),
+		SourceText:               query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
+		PackageFiles:             query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
+		PackageRuntimeCapability: query.RegisterInput[string, bool](db, "PackageRuntimeCapability", hashBoolInput),
+		WorkspaceMembers:         query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
+		WorkspacePackages:        query.RegisterInput[string, []WorkspacePackage](db, "WorkspacePackages", hashWorkspacePackageSlice),
 	}
 }

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -531,10 +531,12 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 	qs.BuildPackage = query.Register(db, "BuildPackage",
 		func(ctx *query.Ctx, dir string) *resolve.Package {
 			files := inp.PackageFiles.Fetch(ctx, dir)
+			runtimeCapability := inp.PackageRuntimeCapability.Fetch(ctx, dir)
 			pkg := &resolve.Package{
-				Dir:   dir,
-				Name:  packageNameFromDir(dir),
-				Files: make([]*resolve.PackageFile, 0, len(files)),
+				Dir:               dir,
+				Name:              packageNameFromDir(dir),
+				RuntimeCapability: runtimeCapability,
+				Files:             make([]*resolve.PackageFile, 0, len(files)),
 			}
 			for _, f := range files {
 				pr := qs.Parse.Fetch(ctx, f)
@@ -564,9 +566,10 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 			// already-parsed FrontendRun / *ast.File pointers — they
 			// are read-only.
 			pkg := &resolve.Package{
-				Dir:   built.Dir,
-				Name:  built.Name,
-				Files: make([]*resolve.PackageFile, len(built.Files)),
+				Dir:               built.Dir,
+				Name:              built.Name,
+				RuntimeCapability: built.RuntimeCapability,
+				Files:             make([]*resolve.PackageFile, len(built.Files)),
 			}
 			for i, pf := range built.Files {
 				pkg.Files[i] = &resolve.PackageFile{
@@ -1133,9 +1136,10 @@ func copyPackageForWorkspace(src *resolve.Package) *resolve.Package {
 		return nil
 	}
 	pkg := &resolve.Package{
-		Dir:   src.Dir,
-		Name:  src.Name,
-		Files: make([]*resolve.PackageFile, len(src.Files)),
+		Dir:               src.Dir,
+		Name:              src.Name,
+		RuntimeCapability: src.RuntimeCapability,
+		Files:             make([]*resolve.PackageFile, len(src.Files)),
 	}
 	for i, pf := range src.Files {
 		if pf == nil {

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -20,9 +20,37 @@ import (
 // Helper: seed one "package" with one file for tests.
 func seedFile(eng *Engine, dir, name, src string) string {
 	path := NormalizePath(dir + "/" + name)
+	dir = NormalizePath(dir)
 	eng.Inputs.SourceText.Set(eng.DB, path, []byte(src))
-	eng.Inputs.PackageFiles.Set(eng.DB, NormalizePath(dir), []string{path})
+	eng.Inputs.PackageFiles.Set(eng.DB, dir, []string{path})
+	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, false)
 	return path
+}
+
+func writeRuntimeCapabilityPackage(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
+name = "toolchain"
+version = "1.0.0"
+edition = "0.5"
+
+[capabilities]
+runtime = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.osty"), []byte("#[repr(c)]\nstruct Raw { x: Int }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasDiagnosticCode(ds []*diag.Diagnostic, code string) bool {
+	for _, d := range ds {
+		if d != nil && d.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestParseMissThenHit(t *testing.T) {
@@ -78,6 +106,88 @@ func TestBuildPackagePreservesFrontendRuns(t *testing.T) {
 	}
 	if pkg.Files[0].File == nil {
 		t.Fatal("BuildPackage should still expose public AST compatibility output")
+	}
+}
+
+func TestRuntimeCapabilityInputInvalidatesCheckPackage(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := NormalizePath("/tmp/pkg_runtime_capability_input")
+	_ = seedFile(eng, dir, "main.osty", "#[repr(c)]\nstruct Raw { x: Int }\n")
+
+	chk := eng.Queries.CheckPackage.Get(eng.DB, dir)
+	if !hasDiagnosticCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("unprivileged check missing %s: %#v", diag.CodeRuntimePrivilegeViolation, chk.Diags)
+	}
+
+	eng.Inputs.PackageRuntimeCapability.Set(eng.DB, dir, true)
+	rp := eng.Queries.ResolvePackage.Get(eng.DB, dir)
+	if rp == nil || rp.Package() == nil || !rp.Package().RuntimeCapability {
+		t.Fatalf("ResolvePackage RuntimeCapability = %#v, want true", rp)
+	}
+	chk = eng.Queries.CheckPackage.Get(eng.DB, dir)
+	if hasDiagnosticCode(chk.Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("privileged check retained %s: %#v", diag.CodeRuntimePrivilegeViolation, chk.Diags)
+	}
+}
+
+func TestSeedPackageDirReadsRuntimeCapability(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeCapabilityPackage(t, dir)
+
+	eng := NewEngine()
+	defer eng.Close()
+	seeded, err := eng.SeedPackageDir(dir, nil)
+	if err != nil {
+		t.Fatalf("SeedPackageDir: %v", err)
+	}
+	if !seeded.RuntimeCapability {
+		t.Fatal("seeded RuntimeCapability = false, want true")
+	}
+	pkg := eng.Queries.BuildPackage.Get(eng.DB, seeded.Dir)
+	if pkg == nil || !pkg.RuntimeCapability {
+		t.Fatalf("BuildPackage RuntimeCapability = %#v, want true", pkg)
+	}
+}
+
+func TestSeedLoadedWorkspacePreservesRuntimeCapability(t *testing.T) {
+	root := t.TempDir()
+	writeRuntimeCapabilityPackage(t, root)
+
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		t.Fatalf("LoadPackageNative: %v", err)
+	}
+
+	eng := NewEngine()
+	defer eng.Close()
+	seeded, err := eng.SeedLoadedWorkspace(ws)
+	if err != nil {
+		t.Fatalf("SeedLoadedWorkspace: %v", err)
+	}
+	rootDir := NormalizePath(root)
+	built := eng.Queries.BuildPackage.Get(eng.DB, rootDir)
+	if built == nil || !built.RuntimeCapability {
+		t.Fatalf("BuildPackage RuntimeCapability = %#v, want true", built)
+	}
+	rw := eng.Queries.ResolveWorkspace.Get(eng.DB, seeded.Root)
+	if rw == nil {
+		t.Fatal("ResolveWorkspace returned nil")
+	}
+	pkg := rw.PackageByDir(rootDir)
+	if pkg == nil || !pkg.RuntimeCapability {
+		t.Fatalf("workspace package RuntimeCapability = %#v, want true", pkg)
+	}
+	cw := eng.Queries.CheckWorkspace.Get(eng.DB, seeded.Root)
+	if cw == nil || cw.ResultByDir(rootDir) == nil {
+		t.Fatal("CheckWorkspace missing root result")
+	}
+	if hasDiagnosticCode(cw.ResultByDir(rootDir).Diags, diag.CodeRuntimePrivilegeViolation) {
+		t.Fatalf("workspace check retained %s: %#v", diag.CodeRuntimePrivilegeViolation, cw.ResultByDir(rootDir).Diags)
 	}
 }
 

--- a/internal/query/osty/seed.go
+++ b/internal/query/osty/seed.go
@@ -7,16 +7,18 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/resolve"
 )
 
 // SeededPackage describes the package inputs written into an Engine.
 type SeededPackage struct {
-	Dir     string
-	DotPath string
-	Name    string
-	Files   []string
-	Sources map[string][]byte
+	Dir               string
+	DotPath           string
+	Name              string
+	RuntimeCapability bool
+	Files             []string
+	Sources           map[string][]byte
 }
 
 // SeededWorkspace describes the workspace inputs written into an Engine.
@@ -34,12 +36,14 @@ func (e *Engine) SeedPackageDir(dir string, transform resolve.SourceTransform) (
 	if err != nil {
 		return SeededPackage{}, err
 	}
-	e.seedPackageInputs(dir, files, sources)
+	runtimeCapability := PackageRuntimeCapabilityFromManifest(dir)
+	e.seedPackageInputs(dir, files, sources, runtimeCapability)
 	return SeededPackage{
-		Dir:     dir,
-		Name:    packageNameFromDir(dir),
-		Files:   files,
-		Sources: sources,
+		Dir:               dir,
+		Name:              packageNameFromDir(dir),
+		RuntimeCapability: runtimeCapability,
+		Files:             files,
+		Sources:           sources,
 	}, nil
 }
 
@@ -57,16 +61,18 @@ func (e *Engine) SeedWorkspaceDirs(root string, packages []WorkspacePackage, tra
 		if err != nil {
 			return SeededWorkspace{}, err
 		}
-		e.seedPackageInputs(member.Dir, files, sources)
+		runtimeCapability := PackageRuntimeCapabilityFromManifest(member.Dir)
+		e.seedPackageInputs(member.Dir, files, sources, runtimeCapability)
 		for path, src := range sources {
 			out.Sources[path] = src
 		}
 		out.Packages = append(out.Packages, SeededPackage{
-			Dir:     member.Dir,
-			DotPath: member.DotPath,
-			Name:    member.Name,
-			Files:   files,
-			Sources: sources,
+			Dir:               member.Dir,
+			DotPath:           member.DotPath,
+			Name:              member.Name,
+			RuntimeCapability: runtimeCapability,
+			Files:             files,
+			Sources:           sources,
 		})
 	}
 	e.Inputs.WorkspacePackages.Set(e.DB, root, members)
@@ -122,13 +128,14 @@ func (e *Engine) SeedLoadedWorkspace(ws *resolve.Workspace) (SeededWorkspace, er
 			out.Sources[path] = src
 		}
 		sort.Strings(files)
-		e.seedPackageInputs(dir, files, sources)
+		e.seedPackageInputs(dir, files, sources, pkg.RuntimeCapability)
 		out.Packages = append(out.Packages, SeededPackage{
-			Dir:     dir,
-			DotPath: key,
-			Name:    pkg.Name,
-			Files:   files,
-			Sources: sources,
+			Dir:               dir,
+			DotPath:           key,
+			Name:              pkg.Name,
+			RuntimeCapability: pkg.RuntimeCapability,
+			Files:             files,
+			Sources:           sources,
 		})
 	}
 	members = normalizeWorkspacePackages(root, members)
@@ -136,11 +143,12 @@ func (e *Engine) SeedLoadedWorkspace(ws *resolve.Workspace) (SeededWorkspace, er
 	return out, nil
 }
 
-func (e *Engine) seedPackageInputs(dir string, files []string, sources map[string][]byte) {
+func (e *Engine) seedPackageInputs(dir string, files []string, sources map[string][]byte, runtimeCapability bool) {
 	for _, path := range files {
 		e.Inputs.SourceText.Set(e.DB, path, sources[path])
 	}
 	e.Inputs.PackageFiles.Set(e.DB, dir, files)
+	e.Inputs.PackageRuntimeCapability.Set(e.DB, dir, runtimeCapability)
 }
 
 func readPackageSources(dir string, transform resolve.SourceTransform) ([]string, map[string][]byte, error) {
@@ -171,4 +179,19 @@ func readPackageSources(dir string, transform resolve.SourceTransform) ([]string
 	}
 	sort.Strings(files)
 	return files, sources, nil
+}
+
+// PackageRuntimeCapabilityFromManifest reads dir/osty.toml and reports whether
+// it declares `[capabilities] runtime = true`. Missing or invalid manifests are
+// treated as ordinary unprivileged packages, matching the native loader.
+func PackageRuntimeCapabilityFromManifest(dir string) bool {
+	src, err := os.ReadFile(filepath.Join(dir, manifest.ManifestFile))
+	if err != nil {
+		return false
+	}
+	m, err := manifest.Parse(src)
+	if err != nil || m == nil || m.Capabilities == nil {
+		return false
+	}
+	return m.Capabilities.Runtime
 }


### PR DESCRIPTION
## Summary

- Add `PackageRuntimeCapability` as a query input seeded alongside package files.
- Carry `RuntimeCapability` through `BuildPackage`, package copies, workspace copies, and resolved-package hashing.
- Seed capability bits from `osty.toml` for query/LSP paths and from loaded native workspaces for build/run paths.
- Add regressions for manifest seeding, loaded-workspace seeding, and checker invalidation when the capability bit changes.

## Root Cause

`BuildPackage` reconstructed fresh `resolve.Package` values with only directory, name, and files. After build/run emission moved through this query path, packages declaring `[capabilities] runtime = true` in `osty.toml` lost that privilege and could emit stale runtime-gate diagnostics.

## Validation

- `go test -count=1 -vet=off ./internal/query/osty ./cmd/osty ./internal/lsp`
- `git diff --check`