### PR TITLE
[codex] port runtime strings FFI policy to Osty

### DIFF
--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -462,10 +462,12 @@ func TestGeneratedListRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		{"push_i64", llvmListRuntimePushSymbol("i64"), "osty_rt_list_push_i64"},
 		{"push_f64", llvmListRuntimePushSymbol("f64"), "osty_rt_list_push_f64"},
 		{"get_ptr", llvmListRuntimeGetSymbol("ptr"), "osty_rt_list_get_ptr"},
+		{"push_for_i64", llvmListRuntimePushSymbolFor("i64", false), "osty_rt_list_push_i64"},
 		{"push_string", listRuntimePushSymbolFor("ptr", true), "osty_rt_list_push_string"},
 		{"get_string", listRuntimeGetSymbolFor("ptr", true), "osty_rt_list_get_string"},
 		{"set_string", listRuntimeSetSymbolFor("ptr", true), "osty_rt_list_set_string"},
 		{"insert_string", listRuntimeInsertSymbolFor("ptr", true), "osty_rt_list_insert_string"},
+		{"insert_ptr", llvmListRuntimeInsertSymbolFor("ptr", false), "osty_rt_list_insert_ptr"},
 		{"set_i1", llvmListRuntimeSetSymbol("i1"), "osty_rt_list_set_i1"},
 		{"sorted_i64", llvmListRuntimeSortedSymbol("i64", false), "osty_rt_list_sorted_i64"},
 		{"sorted_string", llvmListRuntimeSortedSymbol("ptr", true), "osty_rt_list_sorted_string"},
@@ -897,6 +899,66 @@ func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		if c.got != c.want {
 			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
 		}
+	}
+}
+
+func TestGeneratedRuntimeStringsFFIPolicyIsOstyOwned(t *testing.T) {
+	canonical := []struct {
+		name string
+		want string
+	}{
+		{"Equal", "Equal"},
+		{"len", "ByteLen"},
+		{"Index", "IndexOf"},
+		{"LastIndex", "LastIndexOf"},
+		{"startsWith", "HasPrefix"},
+		{"endsWith", "HasSuffix"},
+		{"trimLeft", "TrimStart"},
+		{"TrimRight", "TrimEnd"},
+		{"substring", "Slice"},
+		{"unknown", ""},
+	}
+	for _, c := range canonical {
+		if got := llvmRuntimeStringsCanonicalFfiName(c.name); got != c.want {
+			t.Fatalf("canonical %s = %q, want %q", c.name, got, c.want)
+		}
+	}
+
+	shape := []struct {
+		canonical  string
+		symbol     string
+		retKind    int
+		paramKinds []int
+		paramNames []string
+	}{
+		{"Equal", "osty_rt_strings_Equal", llvmRuntimeFfiKindBool(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"left", "right"}},
+		{"SplitN", "osty_rt_strings_SplitN", llvmRuntimeFfiKindListString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString(), llvmRuntimeFfiKindInt()}, []string{"value", "sep", "n"}},
+		{"Join", "osty_rt_strings_Join", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindListString(), llvmRuntimeFfiKindString()}, []string{"parts", "sep"}},
+		{"Chars", "osty_rt_strings_Chars", llvmRuntimeFfiKindListChar(), []int{llvmRuntimeFfiKindString()}, []string{"value"}},
+		{"ToBytes", "osty_rt_strings_ToBytes", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindString()}, []string{"value"}},
+		{"CharAt", "osty_rt_strings_CharAt", llvmRuntimeFfiKindChar(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindInt()}, []string{"value", "index"}},
+	}
+	for _, c := range shape {
+		if got := llvmRuntimeStringsFfiSymbol(c.canonical); got != c.symbol {
+			t.Fatalf("%s symbol = %q, want %q", c.canonical, got, c.symbol)
+		}
+		if got := llvmRuntimeStringsFfiReturnKind(c.canonical); got != c.retKind {
+			t.Fatalf("%s return kind = %d, want %d", c.canonical, got, c.retKind)
+		}
+		if got := llvmRuntimeStringsFfiParamCount(c.canonical); got != len(c.paramKinds) {
+			t.Fatalf("%s param count = %d, want %d", c.canonical, got, len(c.paramKinds))
+		}
+		for i, wantKind := range c.paramKinds {
+			if got := llvmRuntimeStringsFfiParamKind(c.canonical, i); got != wantKind {
+				t.Fatalf("%s param %d kind = %d, want %d", c.canonical, i, got, wantKind)
+			}
+			if got := llvmRuntimeStringsFfiParamName(c.canonical, i); got != c.paramNames[i] {
+				t.Fatalf("%s param %d name = %q, want %q", c.canonical, i, got, c.paramNames[i])
+			}
+		}
+	}
+	if got := llvmRuntimeStringsFfiParamKind("Split", 99); got != llvmRuntimeFfiKindUnknown() {
+		t.Fatalf("out-of-range param kind = %d, want unknown", got)
 	}
 }
 

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -288,215 +288,62 @@ func runtimeStringsKnownFFIFunction(name string) *runtimeFFIFunction {
 	if !ok {
 		return nil
 	}
-	stringType := runtimeFFIStringSourceType()
-	intType := runtimeFFIIntSourceType()
-	boolType := runtimeFFIBoolSourceType()
-	charType := runtimeFFICharSourceType()
-	floatType := runtimeFFIFloatSourceType()
-	listStringType := runtimeFFIListSourceType(stringType)
-	listCharType := runtimeFFIListSourceType(charType)
-	listByteType := runtimeFFIListSourceType(runtimeFFIByteSourceType())
-	bytesType := runtimeFFIBytesSourceType()
+	retTyp, retSource, retListTyp, retListString, ok := runtimeFFIKindInfo(llvmRuntimeStringsFfiReturnKind(canonical))
+	if !ok {
+		return nil
+	}
 	fn := &runtimeFFIFunction{
-		path:       "runtime.strings",
-		sourceName: name,
+		path:             "runtime.strings",
+		sourceName:       name,
+		symbol:           llvmRuntimeStringsFfiSymbol(canonical),
+		ret:              retTyp,
+		returnSourceType: retSource,
+		listElemTyp:      retListTyp,
+		listElemString:   retListString,
 	}
-	p := func(paramName, typ string, source ast.Type) paramInfo {
-		info := paramInfo{name: paramName, typ: typ, sourceType: source}
-		if list, ok := source.(*ast.NamedType); ok && len(list.Path) == 1 && list.Path[0] == "List" && len(list.Args) == 1 {
-			switch elem := list.Args[0].(type) {
-			case *ast.NamedType:
-				if len(elem.Path) == 1 {
-					switch elem.Path[0] {
-					case "String":
-						info.listElemTyp = "ptr"
-						info.listElemString = true
-					case "Char":
-						info.listElemTyp = "i32"
-					case "Byte":
-						info.listElemTyp = "i8"
-					case "Int":
-						info.listElemTyp = "i64"
-					case "Bool":
-						info.listElemTyp = "i1"
-					case "Float":
-						info.listElemTyp = "double"
-					}
-				}
-			}
+	for i := 0; i < llvmRuntimeStringsFfiParamCount(canonical); i++ {
+		paramTyp, paramSource, paramListTyp, paramListString, ok := runtimeFFIKindInfo(llvmRuntimeStringsFfiParamKind(canonical, i))
+		if !ok {
+			return nil
 		}
-		return info
+		fn.params = append(fn.params, paramInfo{
+			name:           llvmRuntimeStringsFfiParamName(canonical, i),
+			typ:            paramTyp,
+			sourceType:     paramSource,
+			listElemTyp:    paramListTyp,
+			listElemString: paramListString,
+		})
 	}
-	ret := func(symbol, typ string, source ast.Type, params ...paramInfo) *runtimeFFIFunction {
-		fn.symbol = symbol
-		fn.ret = typ
-		fn.returnSourceType = source
-		fn.params = params
-		if list, ok := source.(*ast.NamedType); ok && len(list.Path) == 1 && list.Path[0] == "List" && len(list.Args) == 1 {
-			switch elem := list.Args[0].(type) {
-			case *ast.NamedType:
-				if len(elem.Path) == 1 {
-					switch elem.Path[0] {
-					case "String":
-						fn.listElemTyp = "ptr"
-						fn.listElemString = true
-					case "Char":
-						fn.listElemTyp = "i32"
-					case "Byte":
-						fn.listElemTyp = "i8"
-					case "Int":
-						fn.listElemTyp = "i64"
-					case "Bool":
-						fn.listElemTyp = "i1"
-					case "Float":
-						fn.listElemTyp = "double"
-					}
-				}
-			}
-		}
-		return fn
-	}
-	switch canonical {
-	case "Equal":
-		return ret("osty_rt_strings_Equal", "i1", boolType, p("left", "ptr", stringType), p("right", "ptr", stringType))
-	case "Compare":
-		return ret(llvmStringRuntimeCompareSymbol(), "i64", intType, p("left", "ptr", stringType), p("right", "ptr", stringType))
-	case "Count":
-		return ret(llvmStringRuntimeCountSymbol(), "i64", intType, p("value", "ptr", stringType), p("substr", "ptr", stringType))
-	case "IndexOf":
-		return ret(llvmStringRuntimeIndexOfSymbol(), "i64", intType, p("value", "ptr", stringType), p("substr", "ptr", stringType))
-	case "LastIndexOf":
-		return ret(mirRtStringLastIndexOfSymbol(), "i64", intType, p("value", "ptr", stringType), p("substr", "ptr", stringType))
-	case "CharAt":
-		return ret(mirRtStringSymbol("CharAt"), "i32", charType, p("value", "ptr", stringType), p("index", "i64", intType))
-	case "ByteLen":
-		return ret(llvmStringRuntimeByteLenSymbol(), "i64", intType, p("value", "ptr", stringType))
-	case "Contains":
-		return ret(llvmStringRuntimeContainsSymbol(), "i1", boolType, p("value", "ptr", stringType), p("substr", "ptr", stringType))
-	case "HasPrefix":
-		return ret(llvmStringRuntimeHasPrefixSymbol(), "i1", boolType, p("value", "ptr", stringType), p("prefix", "ptr", stringType))
-	case "HasSuffix":
-		return ret(llvmStringRuntimeHasSuffixSymbol(), "i1", boolType, p("value", "ptr", stringType), p("suffix", "ptr", stringType))
-	case "Split":
-		return ret(llvmStringRuntimeSplitSymbol(), "ptr", listStringType, p("value", "ptr", stringType), p("sep", "ptr", stringType))
-	case "SplitN":
-		return ret(llvmStringRuntimeSplitNSymbol(), "ptr", listStringType, p("value", "ptr", stringType), p("sep", "ptr", stringType), p("n", "i64", intType))
-	case "Fields":
-		return ret(mirRtStringSymbol("Fields"), "ptr", listStringType, p("value", "ptr", stringType))
-	case "Join":
-		return ret(llvmStringRuntimeJoinSymbol(), "ptr", stringType, p("parts", "ptr", listStringType), p("sep", "ptr", stringType))
-	case "Concat":
-		return ret(llvmStringRuntimeConcatSymbol(), "ptr", stringType, p("left", "ptr", stringType), p("right", "ptr", stringType))
-	case "Repeat":
-		return ret(llvmStringRuntimeRepeatSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("n", "i64", intType))
-	case "Replace":
-		return ret(llvmStringRuntimeReplaceSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("old", "ptr", stringType), p("new", "ptr", stringType))
-	case "ReplaceAll":
-		return ret(llvmStringRuntimeReplaceAllSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("old", "ptr", stringType), p("new", "ptr", stringType))
-	case "Slice":
-		return ret(llvmStringRuntimeSliceSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("start", "i64", intType), p("end", "i64", intType))
-	case "ToUpper":
-		return ret(llvmStringRuntimeToUpperSymbol(), "ptr", stringType, p("value", "ptr", stringType))
-	case "ToLower":
-		return ret(llvmStringRuntimeToLowerSymbol(), "ptr", stringType, p("value", "ptr", stringType))
-	case "IsValidInt":
-		return ret(llvmStringRuntimeIsValidIntSymbol(), "i1", boolType, p("value", "ptr", stringType))
-	case "ToInt":
-		return ret(llvmStringRuntimeToIntSymbol(), "i64", intType, p("value", "ptr", stringType))
-	case "IsValidFloat":
-		return ret(llvmStringRuntimeIsValidFloatSymbol(), "i1", boolType, p("value", "ptr", stringType))
-	case "ToFloat":
-		return ret(llvmStringRuntimeToFloatSymbol(), "double", floatType, p("value", "ptr", stringType))
-	case "TrimStart":
-		return ret(llvmStringRuntimeTrimStartSymbol(), "ptr", stringType, p("value", "ptr", stringType))
-	case "TrimEnd":
-		return ret(llvmStringRuntimeTrimEndSymbol(), "ptr", stringType, p("value", "ptr", stringType))
-	case "TrimPrefix":
-		return ret(llvmStringRuntimeTrimPrefixSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("prefix", "ptr", stringType))
-	case "TrimSuffix":
-		return ret(llvmStringRuntimeTrimSuffixSymbol(), "ptr", stringType, p("value", "ptr", stringType), p("suffix", "ptr", stringType))
-	case "TrimSpace":
-		return ret(llvmStringRuntimeTrimSpaceSymbol(), "ptr", stringType, p("value", "ptr", stringType))
-	case "Chars":
-		return ret(llvmStringRuntimeCharsSymbol(), "ptr", listCharType, p("value", "ptr", stringType))
-	case "Bytes":
-		return ret(llvmStringRuntimeBytesSymbol(), "ptr", listByteType, p("value", "ptr", stringType))
-	case "ToBytes":
-		return ret(llvmStringRuntimeToBytesSymbol(), "ptr", bytesType, p("value", "ptr", stringType))
-	}
-	return nil
+	return fn
 }
 
 func runtimeStringsCanonicalFFIName(name string) (string, bool) {
-	switch canonicalStdStringsCallName(name) {
-	case "Equal", "equal":
-		return "Equal", true
-	case "compare":
-		return "Compare", true
-	case "count":
-		return "Count", true
-	case "indexOf", "Index", "IndexOf":
-		return "IndexOf", true
-	case "lastIndexOf", "LastIndex", "LastIndexOf":
-		return "LastIndexOf", true
-	case "charAt", "CharAt":
-		return "CharAt", true
-	case "len", "Len", "byteLen", "ByteLen":
-		return "ByteLen", true
-	case "contains":
-		return "Contains", true
-	case "hasPrefix":
-		return "HasPrefix", true
-	case "hasSuffix":
-		return "HasSuffix", true
-	case "split":
-		return "Split", true
-	case "splitN":
-		return "SplitN", true
-	case "fields":
-		return "Fields", true
-	case "join":
-		return "Join", true
-	case "concat":
-		return "Concat", true
-	case "repeat":
-		return "Repeat", true
-	case "replace":
-		return "Replace", true
-	case "replaceAll":
-		return "ReplaceAll", true
-	case "slice", "substring", "Substring":
-		return "Slice", true
-	case "toUpper":
-		return "ToUpper", true
-	case "toLower":
-		return "ToLower", true
-	case "isValidInt", "IsValidInt":
-		return "IsValidInt", true
-	case "toInt":
-		return "ToInt", true
-	case "isValidFloat", "IsValidFloat":
-		return "IsValidFloat", true
-	case "toFloat":
-		return "ToFloat", true
-	case "trimStart", "trimLeft", "TrimLeft":
-		return "TrimStart", true
-	case "trimEnd", "trimRight", "TrimRight":
-		return "TrimEnd", true
-	case "trimPrefix":
-		return "TrimPrefix", true
-	case "trimSuffix":
-		return "TrimSuffix", true
-	case "trim", "trimSpace":
-		return "TrimSpace", true
-	case "chars", "Chars":
-		return "Chars", true
-	case "bytes", "Bytes":
-		return "Bytes", true
-	case "toBytes":
-		return "ToBytes", true
+	canonical := llvmRuntimeStringsCanonicalFfiName(name)
+	return canonical, canonical != ""
+}
+
+func runtimeFFIKindInfo(kind int) (typ string, source ast.Type, listElemTyp string, listElemString bool, ok bool) {
+	switch kind {
+	case 1:
+		return "ptr", runtimeFFIStringSourceType(), "", false, true
+	case 2:
+		return "i64", runtimeFFIIntSourceType(), "", false, true
+	case 3:
+		return "i1", runtimeFFIBoolSourceType(), "", false, true
+	case 4:
+		return "i32", runtimeFFICharSourceType(), "", false, true
+	case 5:
+		return "double", runtimeFFIFloatSourceType(), "", false, true
+	case 6:
+		return "ptr", runtimeFFIBytesSourceType(), "", false, true
+	case 7:
+		return "ptr", runtimeFFIListSourceType(runtimeFFIStringSourceType()), "ptr", true, true
+	case 8:
+		return "ptr", runtimeFFIListSourceType(runtimeFFICharSourceType()), "i32", false, true
+	case 9:
+		return "ptr", runtimeFFIListSourceType(runtimeFFIByteSourceType()), "i8", false, true
 	default:
-		return "", false
+		return "", nil, "", false, false
 	}
 }
 
@@ -610,10 +457,7 @@ func listRuntimePushSymbol(elemTyp string) string {
 }
 
 func listRuntimePushSymbolFor(elemTyp string, elemString bool) string {
-	if elemTyp == "ptr" && elemString {
-		return mirRtListSymbol("push_string")
-	}
-	return listRuntimePushSymbol(elemTyp)
+	return llvmListRuntimePushSymbolFor(elemTyp, elemString)
 }
 
 func listRuntimeGetSymbol(elemTyp string) string {
@@ -621,10 +465,7 @@ func listRuntimeGetSymbol(elemTyp string) string {
 }
 
 func listRuntimeGetSymbolFor(elemTyp string, elemString bool) string {
-	if elemTyp == "ptr" && elemString {
-		return mirRtListSymbol("get_string")
-	}
-	return listRuntimeGetSymbol(elemTyp)
+	return llvmListRuntimeGetSymbolFor(elemTyp, elemString)
 }
 
 func listRuntimeSetSymbol(elemTyp string) string {
@@ -632,10 +473,7 @@ func listRuntimeSetSymbol(elemTyp string) string {
 }
 
 func listRuntimeSetSymbolFor(elemTyp string, elemString bool) string {
-	if elemTyp == "ptr" && elemString {
-		return mirRtListSymbol("set_string")
-	}
-	return listRuntimeSetSymbol(elemTyp)
+	return llvmListRuntimeSetSymbolFor(elemTyp, elemString)
 }
 
 func listRuntimeInsertSymbol(elemTyp string) string {
@@ -643,10 +481,7 @@ func listRuntimeInsertSymbol(elemTyp string) string {
 }
 
 func listRuntimeInsertSymbolFor(elemTyp string, elemString bool) string {
-	if elemTyp == "ptr" && elemString {
-		return mirRtListSymbol("insert_string")
-	}
-	return listRuntimeInsertSymbol(elemTyp)
+	return llvmListRuntimeInsertSymbolFor(elemTyp, elemString)
 }
 
 func listRuntimeInsertBytesV1Symbol() string {

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -225,6 +225,34 @@ fn stitch(s: String) -> String {
 	}
 }
 
+func TestRuntimeStringsSyntheticFFIUsesOstyPolicyDescriptor(t *testing.T) {
+	splitN := runtimeStringsKnownFFIFunction("splitN")
+	if splitN == nil {
+		t.Fatal("splitN synthetic FFI missing")
+	}
+	if splitN.symbol != "osty_rt_strings_SplitN" || splitN.ret != "ptr" || splitN.listElemTyp != "ptr" || !splitN.listElemString {
+		t.Fatalf("splitN descriptor drifted: %#v", splitN)
+	}
+	if len(splitN.params) != 3 || splitN.params[0].name != "value" || splitN.params[1].name != "sep" || splitN.params[2].name != "n" || splitN.params[2].typ != "i64" {
+		t.Fatalf("splitN params drifted: %#v", splitN.params)
+	}
+
+	join := runtimeStringsKnownFFIFunction("join")
+	if join == nil || len(join.params) != 2 || join.params[0].listElemTyp != "ptr" || !join.params[0].listElemString {
+		t.Fatalf("join List<String> param metadata drifted: %#v", join)
+	}
+
+	chars := runtimeStringsKnownFFIFunction("chars")
+	if chars == nil || chars.listElemTyp != "i32" || chars.listElemString {
+		t.Fatalf("chars List<Char> metadata drifted: %#v", chars)
+	}
+
+	toBytes := runtimeStringsKnownFFIFunction("toBytes")
+	if toBytes == nil || toBytes.symbol != "osty_rt_strings_ToBytes" || toBytes.ret != "ptr" || toBytes.listElemTyp != "" {
+		t.Fatalf("toBytes descriptor drifted: %#v", toBytes)
+	}
+}
+
 // TestGenerateUseCSurfaceCharByteCoverage exercises `use c` with the
 // Char (i32) and Byte (i8) primitives that the runtime ABI gained in
 // LLVM011 follow-up work (#404). This is the regression net for

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -675,66 +675,7 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 }
 
 func canonicalStdStringsCallName(name string) string {
-	switch name {
-	case "Compare":
-		return "compare"
-	case "Count":
-		return "count"
-	case "Index":
-		return "Index"
-	case "LastIndex":
-		return "LastIndex"
-	case "Concat":
-		return "concat"
-	case "Contains":
-		return "contains"
-	case "HasPrefix", "StartsWith", "startsWith":
-		return "hasPrefix"
-	case "HasSuffix", "EndsWith", "endsWith":
-		return "hasSuffix"
-	case "Join":
-		return "join"
-	case "Repeat":
-		return "repeat"
-	case "Replace":
-		return "replace"
-	case "ReplaceAll":
-		return "replaceAll"
-	case "Split":
-		return "split"
-	case "SplitN":
-		return "splitN"
-	case "Fields":
-		return "fields"
-	case "Slice":
-		return "slice"
-	case "ToInt":
-		return "toInt"
-	case "ToFloat":
-		return "toFloat"
-	case "ToBytes":
-		return "toBytes"
-	case "TrimPrefix":
-		return "trimPrefix"
-	case "TrimSuffix":
-		return "trimSuffix"
-	case "TrimStart":
-		return "trimStart"
-	case "TrimEnd":
-		return "trimEnd"
-	case "Trim":
-		return "trim"
-	case "TrimSpace":
-		return "trimSpace"
-	case "ToUpper":
-		return "toUpper"
-	case "ToLower":
-		return "toLower"
-	case "lastIndexOf":
-		return "lastIndexOf"
-	default:
-		return name
-	}
+	return llvmCanonicalStdStringsCallName(name)
 }
 
 // stdStringsCallStaticResult mirrors runtimeFFICallTarget for the std.strings

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2157,9 +2157,25 @@ func llvmListRuntimePushSymbol(suffix string) string {
 	return fmt.Sprintf("osty_rt_list_push_%s", ostyToString(suffix))
 }
 
+// Osty: llvmListRuntimePushSymbolFor
+func llvmListRuntimePushSymbolFor(elemTyp string, isString bool) string {
+	if elemTyp == "ptr" && isString {
+		return "osty_rt_list_push_string"
+	}
+	return llvmListRuntimePushSymbol(llvmListElementSuffix(elemTyp))
+}
+
 // Osty: toolchain/llvmgen.osty:1625:5
 func llvmListRuntimeGetSymbol(suffix string) string {
 	return fmt.Sprintf("osty_rt_list_get_%s", ostyToString(suffix))
+}
+
+// Osty: llvmListRuntimeGetSymbolFor
+func llvmListRuntimeGetSymbolFor(elemTyp string, isString bool) string {
+	if elemTyp == "ptr" && isString {
+		return "osty_rt_list_get_string"
+	}
+	return llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
 }
 
 // Osty: toolchain/llvmgen.osty:1629:5
@@ -2167,9 +2183,25 @@ func llvmListRuntimeSetSymbol(suffix string) string {
 	return fmt.Sprintf("osty_rt_list_set_%s", ostyToString(suffix))
 }
 
+// Osty: llvmListRuntimeSetSymbolFor
+func llvmListRuntimeSetSymbolFor(elemTyp string, isString bool) string {
+	if elemTyp == "ptr" && isString {
+		return "osty_rt_list_set_string"
+	}
+	return llvmListRuntimeSetSymbol(llvmListElementSuffix(elemTyp))
+}
+
 // Osty: toolchain/llvmgen.osty:1633:5
 func llvmListRuntimeInsertSymbol(suffix string) string {
 	return fmt.Sprintf("osty_rt_list_insert_%s", ostyToString(suffix))
+}
+
+// Osty: llvmListRuntimeInsertSymbolFor
+func llvmListRuntimeInsertSymbolFor(elemTyp string, isString bool) string {
+	if elemTyp == "ptr" && isString {
+		return "osty_rt_list_insert_string"
+	}
+	return llvmListRuntimeInsertSymbol(llvmListElementSuffix(elemTyp))
 }
 
 // Osty: toolchain/llvmgen.osty:1642:5
@@ -3423,6 +3455,357 @@ func llvmStringRuntimeBytesSymbol() string {
 // Osty: toolchain/llvmgen.osty:2721:5
 func llvmStringRuntimeToBytesSymbol() string {
 	return "osty_rt_strings_ToBytes"
+}
+
+// Osty: llvmCanonicalStdStringsCallName
+func llvmCanonicalStdStringsCallName(name string) string {
+	switch name {
+	case "Compare":
+		return "compare"
+	case "Count":
+		return "count"
+	case "Index":
+		return "Index"
+	case "LastIndex":
+		return "LastIndex"
+	case "Concat":
+		return "concat"
+	case "Contains":
+		return "contains"
+	case "HasPrefix", "StartsWith", "startsWith":
+		return "hasPrefix"
+	case "HasSuffix", "EndsWith", "endsWith":
+		return "hasSuffix"
+	case "Join":
+		return "join"
+	case "Repeat":
+		return "repeat"
+	case "Replace":
+		return "replace"
+	case "ReplaceAll":
+		return "replaceAll"
+	case "Split":
+		return "split"
+	case "SplitN":
+		return "splitN"
+	case "Fields":
+		return "fields"
+	case "Slice":
+		return "slice"
+	case "ToInt":
+		return "toInt"
+	case "ToFloat":
+		return "toFloat"
+	case "ToBytes":
+		return "toBytes"
+	case "TrimPrefix":
+		return "trimPrefix"
+	case "TrimSuffix":
+		return "trimSuffix"
+	case "TrimStart":
+		return "trimStart"
+	case "TrimEnd":
+		return "trimEnd"
+	case "Trim":
+		return "trim"
+	case "TrimSpace":
+		return "trimSpace"
+	case "ToUpper":
+		return "toUpper"
+	case "ToLower":
+		return "toLower"
+	case "lastIndexOf":
+		return "lastIndexOf"
+	default:
+		return name
+	}
+}
+
+// Osty: llvmRuntimeFfiKindUnknown
+func llvmRuntimeFfiKindUnknown() int { return 0 }
+
+// Osty: llvmRuntimeFfiKindString
+func llvmRuntimeFfiKindString() int { return 1 }
+
+// Osty: llvmRuntimeFfiKindInt
+func llvmRuntimeFfiKindInt() int { return 2 }
+
+// Osty: llvmRuntimeFfiKindBool
+func llvmRuntimeFfiKindBool() int { return 3 }
+
+// Osty: llvmRuntimeFfiKindChar
+func llvmRuntimeFfiKindChar() int { return 4 }
+
+// Osty: llvmRuntimeFfiKindFloat
+func llvmRuntimeFfiKindFloat() int { return 5 }
+
+// Osty: llvmRuntimeFfiKindBytes
+func llvmRuntimeFfiKindBytes() int { return 6 }
+
+// Osty: llvmRuntimeFfiKindListString
+func llvmRuntimeFfiKindListString() int { return 7 }
+
+// Osty: llvmRuntimeFfiKindListChar
+func llvmRuntimeFfiKindListChar() int { return 8 }
+
+// Osty: llvmRuntimeFfiKindListByte
+func llvmRuntimeFfiKindListByte() int { return 9 }
+
+// Osty: llvmRuntimeStringsCanonicalFfiName
+func llvmRuntimeStringsCanonicalFfiName(name string) string {
+	canon := llvmCanonicalStdStringsCallName(name)
+	switch canon {
+	case "Equal", "equal":
+		return "Equal"
+	case "compare":
+		return "Compare"
+	case "count":
+		return "Count"
+	case "indexOf", "Index", "IndexOf":
+		return "IndexOf"
+	case "lastIndexOf", "LastIndex", "LastIndexOf":
+		return "LastIndexOf"
+	case "charAt", "CharAt":
+		return "CharAt"
+	case "len", "Len", "byteLen", "ByteLen":
+		return "ByteLen"
+	case "contains":
+		return "Contains"
+	case "hasPrefix":
+		return "HasPrefix"
+	case "hasSuffix":
+		return "HasSuffix"
+	case "split":
+		return "Split"
+	case "splitN":
+		return "SplitN"
+	case "fields":
+		return "Fields"
+	case "join":
+		return "Join"
+	case "concat":
+		return "Concat"
+	case "repeat":
+		return "Repeat"
+	case "replace":
+		return "Replace"
+	case "replaceAll":
+		return "ReplaceAll"
+	case "slice", "substring", "Substring":
+		return "Slice"
+	case "toUpper":
+		return "ToUpper"
+	case "toLower":
+		return "ToLower"
+	case "isValidInt", "IsValidInt":
+		return "IsValidInt"
+	case "toInt":
+		return "ToInt"
+	case "isValidFloat", "IsValidFloat":
+		return "IsValidFloat"
+	case "toFloat":
+		return "ToFloat"
+	case "trimStart", "trimLeft", "TrimLeft":
+		return "TrimStart"
+	case "trimEnd", "trimRight", "TrimRight":
+		return "TrimEnd"
+	case "trimPrefix":
+		return "TrimPrefix"
+	case "trimSuffix":
+		return "TrimSuffix"
+	case "trim", "trimSpace":
+		return "TrimSpace"
+	case "chars", "Chars":
+		return "Chars"
+	case "bytes", "Bytes":
+		return "Bytes"
+	case "toBytes":
+		return "ToBytes"
+	default:
+		return ""
+	}
+}
+
+// Osty: llvmRuntimeStringsFfiSymbol
+func llvmRuntimeStringsFfiSymbol(canonical string) string {
+	switch canonical {
+	case "Equal":
+		return llvmStringRuntimeEqualSymbol()
+	case "Compare":
+		return llvmStringRuntimeCompareSymbol()
+	case "Count":
+		return llvmStringRuntimeCountSymbol()
+	case "IndexOf":
+		return llvmStringRuntimeIndexOfSymbol()
+	case "LastIndexOf":
+		return "osty_rt_strings_LastIndexOf"
+	case "CharAt":
+		return "osty_rt_strings_CharAt"
+	case "ByteLen":
+		return llvmStringRuntimeByteLenSymbol()
+	case "Contains":
+		return llvmStringRuntimeContainsSymbol()
+	case "HasPrefix":
+		return llvmStringRuntimeHasPrefixSymbol()
+	case "HasSuffix":
+		return llvmStringRuntimeHasSuffixSymbol()
+	case "Split":
+		return llvmStringRuntimeSplitSymbol()
+	case "SplitN":
+		return llvmStringRuntimeSplitNSymbol()
+	case "Fields":
+		return "osty_rt_strings_Fields"
+	case "Join":
+		return llvmStringRuntimeJoinSymbol()
+	case "Concat":
+		return llvmStringRuntimeConcatSymbol()
+	case "Repeat":
+		return llvmStringRuntimeRepeatSymbol()
+	case "Replace":
+		return llvmStringRuntimeReplaceSymbol()
+	case "ReplaceAll":
+		return llvmStringRuntimeReplaceAllSymbol()
+	case "Slice":
+		return llvmStringRuntimeSliceSymbol()
+	case "ToUpper":
+		return llvmStringRuntimeToUpperSymbol()
+	case "ToLower":
+		return llvmStringRuntimeToLowerSymbol()
+	case "IsValidInt":
+		return llvmStringRuntimeIsValidIntSymbol()
+	case "ToInt":
+		return llvmStringRuntimeToIntSymbol()
+	case "IsValidFloat":
+		return llvmStringRuntimeIsValidFloatSymbol()
+	case "ToFloat":
+		return llvmStringRuntimeToFloatSymbol()
+	case "TrimStart":
+		return llvmStringRuntimeTrimStartSymbol()
+	case "TrimEnd":
+		return llvmStringRuntimeTrimEndSymbol()
+	case "TrimPrefix":
+		return llvmStringRuntimeTrimPrefixSymbol()
+	case "TrimSuffix":
+		return llvmStringRuntimeTrimSuffixSymbol()
+	case "TrimSpace":
+		return llvmStringRuntimeTrimSpaceSymbol()
+	case "Chars":
+		return llvmStringRuntimeCharsSymbol()
+	case "Bytes":
+		return llvmStringRuntimeBytesSymbol()
+	case "ToBytes":
+		return llvmStringRuntimeToBytesSymbol()
+	default:
+		return ""
+	}
+}
+
+// Osty: llvmRuntimeStringsFfiReturnKind
+func llvmRuntimeStringsFfiReturnKind(canonical string) int {
+	switch canonical {
+	case "Equal", "Contains", "HasPrefix", "HasSuffix", "IsValidInt", "IsValidFloat":
+		return llvmRuntimeFfiKindBool()
+	case "Compare", "Count", "IndexOf", "LastIndexOf", "ByteLen", "ToInt":
+		return llvmRuntimeFfiKindInt()
+	case "CharAt":
+		return llvmRuntimeFfiKindChar()
+	case "ToFloat":
+		return llvmRuntimeFfiKindFloat()
+	case "Split", "SplitN", "Fields":
+		return llvmRuntimeFfiKindListString()
+	case "Chars":
+		return llvmRuntimeFfiKindListChar()
+	case "Bytes":
+		return llvmRuntimeFfiKindListByte()
+	case "ToBytes":
+		return llvmRuntimeFfiKindBytes()
+	default:
+		if llvmRuntimeStringsFfiSymbol(canonical) != "" {
+			return llvmRuntimeFfiKindString()
+		}
+		return llvmRuntimeFfiKindUnknown()
+	}
+}
+
+// Osty: llvmRuntimeStringsFfiParamCount
+func llvmRuntimeStringsFfiParamCount(canonical string) int {
+	switch canonical {
+	case "ByteLen", "Fields", "ToUpper", "ToLower", "IsValidInt", "ToInt", "IsValidFloat", "ToFloat", "TrimStart", "TrimEnd", "TrimSpace", "Chars", "Bytes", "ToBytes":
+		return 1
+	case "SplitN", "Replace", "ReplaceAll", "Slice":
+		return 3
+	default:
+		if llvmRuntimeStringsFfiSymbol(canonical) != "" {
+			return 2
+		}
+		return 0
+	}
+}
+
+// Osty: llvmRuntimeStringsFfiParamName
+func llvmRuntimeStringsFfiParamName(canonical string, index int) string {
+	switch index {
+	case 0:
+		switch canonical {
+		case "Equal", "Compare", "Concat":
+			return "left"
+		case "Join":
+			return "parts"
+		default:
+			return "value"
+		}
+	case 1:
+		switch canonical {
+		case "Equal", "Compare", "Concat":
+			return "right"
+		case "Count", "IndexOf", "LastIndexOf", "Contains":
+			return "substr"
+		case "CharAt":
+			return "index"
+		case "HasPrefix", "TrimPrefix":
+			return "prefix"
+		case "HasSuffix", "TrimSuffix":
+			return "suffix"
+		case "Split", "SplitN", "Join":
+			return "sep"
+		case "Repeat":
+			return "n"
+		case "Replace", "ReplaceAll":
+			return "old"
+		case "Slice":
+			return "start"
+		}
+	case 2:
+		switch canonical {
+		case "SplitN":
+			return "n"
+		case "Replace", "ReplaceAll":
+			return "new"
+		case "Slice":
+			return "end"
+		}
+	}
+	return ""
+}
+
+// Osty: llvmRuntimeStringsFfiParamKind
+func llvmRuntimeStringsFfiParamKind(canonical string, index int) int {
+	if index < 0 || index >= llvmRuntimeStringsFfiParamCount(canonical) {
+		return llvmRuntimeFfiKindUnknown()
+	}
+	if canonical == "Join" && index == 0 {
+		return llvmRuntimeFfiKindListString()
+	}
+	if (canonical == "CharAt" || canonical == "Repeat") && index == 1 {
+		return llvmRuntimeFfiKindInt()
+	}
+	if canonical == "SplitN" && index == 2 {
+		return llvmRuntimeFfiKindInt()
+	}
+	if canonical == "Slice" && (index == 1 || index == 2) {
+		return llvmRuntimeFfiKindInt()
+	}
+	return llvmRuntimeFfiKindString()
 }
 
 // Osty: toolchain/llvmgen.osty:2731:5

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2638,16 +2638,44 @@ pub fn llvmListRuntimePushSymbol(suffix: String) -> String {
     "osty_rt_list_push_{suffix}"
 }
 
+pub fn llvmListRuntimePushSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_push_string"
+    }
+    llvmListRuntimePushSymbol(llvmListElementSuffix(elemTyp))
+}
+
 pub fn llvmListRuntimeGetSymbol(suffix: String) -> String {
     "osty_rt_list_get_{suffix}"
+}
+
+pub fn llvmListRuntimeGetSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_get_string"
+    }
+    llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
 }
 
 pub fn llvmListRuntimeSetSymbol(suffix: String) -> String {
     "osty_rt_list_set_{suffix}"
 }
 
+pub fn llvmListRuntimeSetSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_set_string"
+    }
+    llvmListRuntimeSetSymbol(llvmListElementSuffix(elemTyp))
+}
+
 pub fn llvmListRuntimeInsertSymbol(suffix: String) -> String {
     "osty_rt_list_insert_{suffix}"
+}
+
+pub fn llvmListRuntimeInsertSymbolFor(elemTyp: String, isString: Bool) -> String {
+    if elemTyp == "ptr" && isString {
+        return "osty_rt_list_insert_string"
+    }
+    llvmListRuntimeInsertSymbol(llvmListElementSuffix(elemTyp))
 }
 
 /// Pick the `osty_rt_list_sorted_*` entry point for an element LLVM
@@ -3787,6 +3815,226 @@ pub fn llvmStringRuntimeBytesSymbol() -> String {
 
 pub fn llvmStringRuntimeToBytesSymbol() -> String {
     "osty_rt_strings_ToBytes"
+}
+
+pub fn llvmCanonicalStdStringsCallName(name: String) -> String {
+    if name == "Compare" { return "compare" }
+    if name == "Count" { return "count" }
+    if name == "Index" { return "Index" }
+    if name == "LastIndex" { return "LastIndex" }
+    if name == "Concat" { return "concat" }
+    if name == "Contains" { return "contains" }
+    if name == "HasPrefix" || name == "StartsWith" || name == "startsWith" {
+        return "hasPrefix"
+    }
+    if name == "HasSuffix" || name == "EndsWith" || name == "endsWith" {
+        return "hasSuffix"
+    }
+    if name == "Join" { return "join" }
+    if name == "Repeat" { return "repeat" }
+    if name == "Replace" { return "replace" }
+    if name == "ReplaceAll" { return "replaceAll" }
+    if name == "Split" { return "split" }
+    if name == "SplitN" { return "splitN" }
+    if name == "Fields" { return "fields" }
+    if name == "Slice" { return "slice" }
+    if name == "ToInt" { return "toInt" }
+    if name == "ToFloat" { return "toFloat" }
+    if name == "ToBytes" { return "toBytes" }
+    if name == "TrimPrefix" { return "trimPrefix" }
+    if name == "TrimSuffix" { return "trimSuffix" }
+    if name == "TrimStart" { return "trimStart" }
+    if name == "TrimEnd" { return "trimEnd" }
+    if name == "Trim" { return "trim" }
+    if name == "TrimSpace" { return "trimSpace" }
+    if name == "ToUpper" { return "toUpper" }
+    if name == "ToLower" { return "toLower" }
+    if name == "lastIndexOf" { return "lastIndexOf" }
+    name
+}
+
+/// Runtime-strings FFI descriptor kind. The Go emitter still constructs
+/// AST source-type nodes, but the stable signature policy is owned here.
+pub fn llvmRuntimeFfiKindUnknown() -> Int { 0 }
+pub fn llvmRuntimeFfiKindString() -> Int { 1 }
+pub fn llvmRuntimeFfiKindInt() -> Int { 2 }
+pub fn llvmRuntimeFfiKindBool() -> Int { 3 }
+pub fn llvmRuntimeFfiKindChar() -> Int { 4 }
+pub fn llvmRuntimeFfiKindFloat() -> Int { 5 }
+pub fn llvmRuntimeFfiKindBytes() -> Int { 6 }
+pub fn llvmRuntimeFfiKindListString() -> Int { 7 }
+pub fn llvmRuntimeFfiKindListChar() -> Int { 8 }
+pub fn llvmRuntimeFfiKindListByte() -> Int { 9 }
+
+pub fn llvmRuntimeStringsCanonicalFfiName(name: String) -> String {
+    let canon = llvmCanonicalStdStringsCallName(name)
+    if canon == "Equal" || canon == "equal" { return "Equal" }
+    if canon == "compare" { return "Compare" }
+    if canon == "count" { return "Count" }
+    if canon == "indexOf" || canon == "Index" || canon == "IndexOf" { return "IndexOf" }
+    if canon == "lastIndexOf" || canon == "LastIndex" || canon == "LastIndexOf" { return "LastIndexOf" }
+    if canon == "charAt" || canon == "CharAt" { return "CharAt" }
+    if canon == "len" || canon == "Len" || canon == "byteLen" || canon == "ByteLen" { return "ByteLen" }
+    if canon == "contains" { return "Contains" }
+    if canon == "hasPrefix" { return "HasPrefix" }
+    if canon == "hasSuffix" { return "HasSuffix" }
+    if canon == "split" { return "Split" }
+    if canon == "splitN" { return "SplitN" }
+    if canon == "fields" { return "Fields" }
+    if canon == "join" { return "Join" }
+    if canon == "concat" { return "Concat" }
+    if canon == "repeat" { return "Repeat" }
+    if canon == "replace" { return "Replace" }
+    if canon == "replaceAll" { return "ReplaceAll" }
+    if canon == "slice" || canon == "substring" || canon == "Substring" { return "Slice" }
+    if canon == "toUpper" { return "ToUpper" }
+    if canon == "toLower" { return "ToLower" }
+    if canon == "isValidInt" || canon == "IsValidInt" { return "IsValidInt" }
+    if canon == "toInt" { return "ToInt" }
+    if canon == "isValidFloat" || canon == "IsValidFloat" { return "IsValidFloat" }
+    if canon == "toFloat" { return "ToFloat" }
+    if canon == "trimStart" || canon == "trimLeft" || canon == "TrimLeft" { return "TrimStart" }
+    if canon == "trimEnd" || canon == "trimRight" || canon == "TrimRight" { return "TrimEnd" }
+    if canon == "trimPrefix" { return "TrimPrefix" }
+    if canon == "trimSuffix" { return "TrimSuffix" }
+    if canon == "trim" || canon == "trimSpace" { return "TrimSpace" }
+    if canon == "chars" || canon == "Chars" { return "Chars" }
+    if canon == "bytes" || canon == "Bytes" { return "Bytes" }
+    if canon == "toBytes" { return "ToBytes" }
+    ""
+}
+
+pub fn llvmRuntimeStringsFfiSymbol(canonical: String) -> String {
+    if canonical == "Equal" { return llvmStringRuntimeEqualSymbol() }
+    if canonical == "Compare" { return llvmStringRuntimeCompareSymbol() }
+    if canonical == "Count" { return llvmStringRuntimeCountSymbol() }
+    if canonical == "IndexOf" { return llvmStringRuntimeIndexOfSymbol() }
+    if canonical == "LastIndexOf" { return "osty_rt_strings_LastIndexOf" }
+    if canonical == "CharAt" { return "osty_rt_strings_CharAt" }
+    if canonical == "ByteLen" { return llvmStringRuntimeByteLenSymbol() }
+    if canonical == "Contains" { return llvmStringRuntimeContainsSymbol() }
+    if canonical == "HasPrefix" { return llvmStringRuntimeHasPrefixSymbol() }
+    if canonical == "HasSuffix" { return llvmStringRuntimeHasSuffixSymbol() }
+    if canonical == "Split" { return llvmStringRuntimeSplitSymbol() }
+    if canonical == "SplitN" { return llvmStringRuntimeSplitNSymbol() }
+    if canonical == "Fields" { return "osty_rt_strings_Fields" }
+    if canonical == "Join" { return llvmStringRuntimeJoinSymbol() }
+    if canonical == "Concat" { return llvmStringRuntimeConcatSymbol() }
+    if canonical == "Repeat" { return llvmStringRuntimeRepeatSymbol() }
+    if canonical == "Replace" { return llvmStringRuntimeReplaceSymbol() }
+    if canonical == "ReplaceAll" { return llvmStringRuntimeReplaceAllSymbol() }
+    if canonical == "Slice" { return llvmStringRuntimeSliceSymbol() }
+    if canonical == "ToUpper" { return llvmStringRuntimeToUpperSymbol() }
+    if canonical == "ToLower" { return llvmStringRuntimeToLowerSymbol() }
+    if canonical == "IsValidInt" { return llvmStringRuntimeIsValidIntSymbol() }
+    if canonical == "ToInt" { return llvmStringRuntimeToIntSymbol() }
+    if canonical == "IsValidFloat" { return llvmStringRuntimeIsValidFloatSymbol() }
+    if canonical == "ToFloat" { return llvmStringRuntimeToFloatSymbol() }
+    if canonical == "TrimStart" { return llvmStringRuntimeTrimStartSymbol() }
+    if canonical == "TrimEnd" { return llvmStringRuntimeTrimEndSymbol() }
+    if canonical == "TrimPrefix" { return llvmStringRuntimeTrimPrefixSymbol() }
+    if canonical == "TrimSuffix" { return llvmStringRuntimeTrimSuffixSymbol() }
+    if canonical == "TrimSpace" { return llvmStringRuntimeTrimSpaceSymbol() }
+    if canonical == "Chars" { return llvmStringRuntimeCharsSymbol() }
+    if canonical == "Bytes" { return llvmStringRuntimeBytesSymbol() }
+    if canonical == "ToBytes" { return llvmStringRuntimeToBytesSymbol() }
+    ""
+}
+
+pub fn llvmRuntimeStringsFfiReturnKind(canonical: String) -> Int {
+    if canonical == "Equal" || canonical == "Contains" ||
+        canonical == "HasPrefix" || canonical == "HasSuffix" ||
+        canonical == "IsValidInt" || canonical == "IsValidFloat" {
+        return llvmRuntimeFfiKindBool()
+    }
+    if canonical == "Compare" || canonical == "Count" ||
+        canonical == "IndexOf" || canonical == "LastIndexOf" ||
+        canonical == "ByteLen" || canonical == "ToInt" {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "CharAt" { return llvmRuntimeFfiKindChar() }
+    if canonical == "ToFloat" { return llvmRuntimeFfiKindFloat() }
+    if canonical == "Split" || canonical == "SplitN" || canonical == "Fields" {
+        return llvmRuntimeFfiKindListString()
+    }
+    if canonical == "Chars" { return llvmRuntimeFfiKindListChar() }
+    if canonical == "Bytes" { return llvmRuntimeFfiKindListByte() }
+    if canonical == "ToBytes" { return llvmRuntimeFfiKindBytes() }
+    if llvmRuntimeStringsFfiSymbol(canonical) != "" {
+        return llvmRuntimeFfiKindString()
+    }
+    llvmRuntimeFfiKindUnknown()
+}
+
+pub fn llvmRuntimeStringsFfiParamCount(canonical: String) -> Int {
+    if canonical == "ByteLen" || canonical == "Fields" ||
+        canonical == "ToUpper" || canonical == "ToLower" ||
+        canonical == "IsValidInt" || canonical == "ToInt" ||
+        canonical == "IsValidFloat" || canonical == "ToFloat" ||
+        canonical == "TrimStart" || canonical == "TrimEnd" ||
+        canonical == "TrimSpace" || canonical == "Chars" ||
+        canonical == "Bytes" || canonical == "ToBytes" {
+        return 1
+    }
+    if canonical == "SplitN" || canonical == "Replace" ||
+        canonical == "ReplaceAll" || canonical == "Slice" {
+        return 3
+    }
+    if llvmRuntimeStringsFfiSymbol(canonical) != "" {
+        return 2
+    }
+    0
+}
+
+pub fn llvmRuntimeStringsFfiParamName(canonical: String, index: Int) -> String {
+    if index == 0 {
+        if canonical == "Equal" || canonical == "Compare" || canonical == "Concat" {
+            return "left"
+        }
+        if canonical == "Join" { return "parts" }
+        return "value"
+    }
+    if index == 1 {
+        if canonical == "Equal" || canonical == "Compare" || canonical == "Concat" {
+            return "right"
+        }
+        if canonical == "Count" || canonical == "IndexOf" ||
+            canonical == "LastIndexOf" || canonical == "Contains" {
+            return "substr"
+        }
+        if canonical == "CharAt" { return "index" }
+        if canonical == "HasPrefix" || canonical == "TrimPrefix" { return "prefix" }
+        if canonical == "HasSuffix" || canonical == "TrimSuffix" { return "suffix" }
+        if canonical == "Split" || canonical == "SplitN" || canonical == "Join" { return "sep" }
+        if canonical == "Repeat" { return "n" }
+        if canonical == "Replace" || canonical == "ReplaceAll" { return "old" }
+        if canonical == "Slice" { return "start" }
+    }
+    if index == 2 {
+        if canonical == "SplitN" { return "n" }
+        if canonical == "Replace" || canonical == "ReplaceAll" { return "new" }
+        if canonical == "Slice" { return "end" }
+    }
+    ""
+}
+
+pub fn llvmRuntimeStringsFfiParamKind(canonical: String, index: Int) -> Int {
+    if index < 0 || index >= llvmRuntimeStringsFfiParamCount(canonical) {
+        return llvmRuntimeFfiKindUnknown()
+    }
+    if canonical == "Join" && index == 0 {
+        return llvmRuntimeFfiKindListString()
+    }
+    if (canonical == "CharAt" || canonical == "Repeat") && index == 1 {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "SplitN" && index == 2 {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "Slice" && (index == 1 || index == 2) {
+        return llvmRuntimeFfiKindInt()
+    }
+    llvmRuntimeFfiKindString()
 }
 
 /// LLVM forward declarations for the string runtime surface plus the


### PR DESCRIPTION
## Summary
- move runtime/std strings call canonicalization into `toolchain/llvmgen.osty`
- replace the Go `runtime.strings` synthetic FFI switch table with an Osty-owned descriptor policy for canonical names, runtime symbols, return kinds, parameter kinds, and parameter names
- move `List<String>` typed runtime symbol selection into Osty helpers while keeping Go wrappers as stable call sites

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGeneratedListRuntimeSymbolsAreOstyOwned|TestGeneratedRuntimeStringsFFIPolicyIsOstyOwned|TestGenerateRuntimeStringsDeclaredAliasesUseCanonicalRuntimeABI|TestGenerateRuntimeStringsSyntheticSurfaceCarriesListMetadata|TestRuntimeStringsSyntheticFFIUsesOstyPolicyDescriptor|TestStringTrimPrefixMethodCall|TestStringEndsWithMethodCall'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'RuntimeFFI|RuntimeStrings|StdStrings|StringRuntime|StringTrim|StringContains|StringEndsWith|GeneratedString|GeneratedListRuntime|ListInsertString'`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `just fmt-check`
- `git diff --check`
- `just verify-selfhost`
- `go test -count=1 -vet=off ./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen`
- after rebasing onto `origin/main` (`d034d8ee`): `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGeneratedListRuntimeSymbolsAreOstyOwned|TestGeneratedRuntimeStringsFFIPolicyIsOstyOwned|TestGenerateRuntimeStringsDeclaredAliasesUseCanonicalRuntimeABI|TestGenerateRuntimeStringsSyntheticSurfaceCarriesListMetadata|TestRuntimeStringsSyntheticFFIUsesOstyPolicyDescriptor|RuntimeFFI|RuntimeStrings|StdStrings'`
- after rebasing: `just fmt-check && git diff --check`
- after rebasing: `just verify-selfhost`
- after rebasing: `just verify-self-rebuild-gates`
- after rebasing: `just verify-self-rebuild-fast` (stage1/stage2 byte parity OK: `56e75449529aa9a11a5b761d8a3d0380c40e0e761d2687519977bf76f2a6601f`)