### PR TITLE
Port std.bytes shim policy to Osty

### DIFF
--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -962,6 +962,73 @@ func TestGeneratedRuntimeStringsFFIPolicyIsOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedStdBytesCallPolicyIsOstyOwned(t *testing.T) {
+	canonical := []struct {
+		name string
+		want string
+	}{
+		{"From", "from"},
+		{"Split", "split"},
+		{"TrimStart", "trimLeft"},
+		{"trimEnd", "trimRight"},
+		{"Index", "indexOf"},
+		{"LastIndex", "lastIndexOf"},
+		{"Len", "len"},
+		{"unknown", "unknown"},
+	}
+	for _, c := range canonical {
+		if got := llvmStdBytesCallCanonicalName(c.name); got != c.want {
+			t.Fatalf("canonical %s = %q, want %q", c.name, got, c.want)
+		}
+	}
+
+	shape := []struct {
+		name       string
+		retKind    int
+		paramKinds []int
+		paramNames []string
+	}{
+		{"from", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindListByte()}, []string{"items"}},
+		{"split", llvmRuntimeFfiKindListBytes(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindBytes()}, []string{"value", "sep"}},
+		{"join", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindListBytes(), llvmRuntimeFfiKindBytes()}, []string{"parts", "sep"}},
+		{"repeat", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindInt()}, []string{"value", "n"}},
+		{"replace", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindBytes()}, []string{"value", "old", "new"}},
+		{"slice", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindInt(), llvmRuntimeFfiKindInt()}, []string{"value", "start", "end"}},
+		{"fromHex", llvmStdBytesResultKindResultBytesError(), []int{llvmRuntimeFfiKindString()}, []string{"text"}},
+		{"toString", llvmStdBytesResultKindResultStringError(), []int{llvmRuntimeFfiKindBytes()}, []string{"value"}},
+		{"indexOf", llvmStdBytesResultKindOptionInt(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindBytes()}, []string{"value", "needle"}},
+		{"get", llvmStdBytesResultKindOptionByte(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindInt()}, []string{"value", "index"}},
+		{"toHex", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindBytes()}, []string{"value"}},
+		{"contains", llvmRuntimeFfiKindBool(), []int{llvmRuntimeFfiKindBytes(), llvmRuntimeFfiKindBytes()}, []string{"value", "needle"}},
+		{"len", llvmRuntimeFfiKindInt(), []int{llvmRuntimeFfiKindBytes()}, []string{"value"}},
+	}
+	for _, c := range shape {
+		if got := llvmStdBytesCallReturnKind(c.name); got != c.retKind {
+			t.Fatalf("%s return kind = %d, want %d", c.name, got, c.retKind)
+		}
+		if got := llvmStdBytesCallArgCount(c.name); got != len(c.paramKinds) {
+			t.Fatalf("%s arg count = %d, want %d", c.name, got, len(c.paramKinds))
+		}
+		for i, wantKind := range c.paramKinds {
+			if got := llvmStdBytesCallParamKind(c.name, i); got != wantKind {
+				t.Fatalf("%s param %d kind = %d, want %d", c.name, i, got, wantKind)
+			}
+			if got := llvmStdBytesCallParamName(c.name, i); got != c.paramNames[i] {
+				t.Fatalf("%s param %d name = %q, want %q", c.name, i, got, c.paramNames[i])
+			}
+		}
+	}
+	if got := llvmStdBytesCallArgCount("unknown"); got != 0 {
+		t.Fatalf("unknown arg count = %d, want 0", got)
+	}
+	if got := llvmStdBytesCallReturnKind("unknown"); got != llvmRuntimeFfiKindUnknown() {
+		t.Fatalf("unknown return kind = %d, want unknown", got)
+	}
+	if got := llvmStdBytesCallParamKind("split", 99); got != llvmRuntimeFfiKindUnknown() {
+		t.Fatalf("out-of-range param kind = %d, want unknown", got)
+	}
+}
+
 func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
 	decls := strings.Join(llvmStringRuntimeDeclarations(), "\n")
 

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -88,6 +88,30 @@ func collectStdNetAliases(file *ast.File) map[string]bool {
 	return out
 }
 
+func stdBytesArgNoun(n int) string {
+	if n == 1 {
+		return "argument"
+	}
+	return "arguments"
+}
+
+func (g *generator) emitStdBytesDescriptorArg(arg *ast.Arg, name string, index int) (value, error) {
+	switch llvmStdBytesCallParamKind(name, index) {
+	case llvmRuntimeFfiKindBytes():
+		return g.emitStdBytesArg(arg, name, index)
+	case llvmRuntimeFfiKindInt():
+		return g.emitStdBytesIntArg(arg, name, index)
+	case llvmRuntimeFfiKindString():
+		return g.emitStdBytesStringArg(arg, name, index)
+	case llvmRuntimeFfiKindListByte():
+		return g.emitStdBytesListArg(arg, name, index)
+	case llvmRuntimeFfiKindListBytes():
+		return g.emitStdBytesListOfBytesArg(arg, name, index)
+	default:
+		return value{}, unsupportedf("call", "bytes.%s arg %d has unknown descriptor kind", name, index+1)
+	}
+}
+
 func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 	if call == nil || len(g.stdBytesAliases) == 0 {
 		return value{}, false, nil
@@ -100,12 +124,17 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 	if !ok || !g.stdBytesAliases[alias.Name] {
 		return value{}, false, nil
 	}
-	switch field.Name {
+	name := llvmStdBytesCallCanonicalName(field.Name)
+	expected := llvmStdBytesCallArgCount(name)
+	if expected == 0 {
+		return value{}, false, nil
+	}
+	if len(call.Args) != expected {
+		return value{}, true, unsupportedf("call", "bytes.%s expects %d %s, got %d", name, expected, stdBytesArgNoun(expected), len(call.Args))
+	}
+	switch name {
 	case "from":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.from expects 1 argument, got %d", len(call.Args))
-		}
-		items, err := g.emitStdBytesListArg(call.Args[0], "from", 0)
+		items, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -115,14 +144,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "split":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.split expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "split", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		sep, err := g.emitStdBytesArg(call.Args[1], "split", 1)
+		sep, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -132,14 +158,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "join":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.join expects 2 arguments, got %d", len(call.Args))
-		}
-		parts, err := g.emitStdBytesListOfBytesArg(call.Args[0], "join", 0)
+		parts, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		sep, err := g.emitStdBytesArg(call.Args[1], "join", 1)
+		sep, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -149,14 +172,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "concat":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.concat expects 2 arguments, got %d", len(call.Args))
-		}
-		left, err := g.emitStdBytesArg(call.Args[0], "concat", 0)
+		left, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		right, err := g.emitStdBytesArg(call.Args[1], "concat", 1)
+		right, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -166,14 +186,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "repeat":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.repeat expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "repeat", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		n, err := g.emitStdBytesIntArg(call.Args[1], "repeat", 1)
+		n, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -183,18 +200,15 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "replace":
-		if len(call.Args) != 3 {
-			return value{}, true, unsupportedf("call", "bytes.replace expects 3 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "replace", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		oldValue, err := g.emitStdBytesArg(call.Args[1], "replace", 1)
+		oldValue, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
-		newValue, err := g.emitStdBytesArg(call.Args[2], "replace", 2)
+		newValue, err := g.emitStdBytesDescriptorArg(call.Args[2], name, 2)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -204,18 +218,15 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "replaceAll":
-		if len(call.Args) != 3 {
-			return value{}, true, unsupportedf("call", "bytes.replaceAll expects 3 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "replaceAll", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		oldValue, err := g.emitStdBytesArg(call.Args[1], "replaceAll", 1)
+		oldValue, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
-		newValue, err := g.emitStdBytesArg(call.Args[2], "replaceAll", 2)
+		newValue, err := g.emitStdBytesDescriptorArg(call.Args[2], name, 2)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -225,14 +236,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "trimLeft":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.trimLeft expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "trimLeft", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		strip, err := g.emitStdBytesArg(call.Args[1], "trimLeft", 1)
+		strip, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -242,14 +250,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "trimRight":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.trimRight expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "trimRight", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		strip, err := g.emitStdBytesArg(call.Args[1], "trimRight", 1)
+		strip, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -259,14 +264,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "trim":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.trim expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "trim", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		strip, err := g.emitStdBytesArg(call.Args[1], "trim", 1)
+		strip, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -276,10 +278,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "trimSpace":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.trimSpace expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "trimSpace", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -289,10 +288,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "toUpper":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.toUpper expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "toUpper", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -302,10 +298,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "toLower":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.toLower expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "toLower", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -315,10 +308,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "toHex":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.toHex expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "toHex", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -328,10 +318,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "fromHex":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.fromHex expects 1 argument, got %d", len(call.Args))
-		}
-		s, err := g.emitStdBytesStringArg(call.Args[0], "fromHex", 0)
+		s, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -341,14 +328,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "contains":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.contains expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "contains", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		sub, err := g.emitStdBytesArg(call.Args[1], "contains", 1)
+		sub, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -358,14 +342,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "startsWith":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.startsWith expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "startsWith", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		prefix, err := g.emitStdBytesArg(call.Args[1], "startsWith", 1)
+		prefix, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -375,14 +356,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "endsWith":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.endsWith expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "endsWith", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		suffix, err := g.emitStdBytesArg(call.Args[1], "endsWith", 1)
+		suffix, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -392,14 +370,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "indexOf":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.indexOf expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "indexOf", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		sub, err := g.emitStdBytesArg(call.Args[1], "indexOf", 1)
+		sub, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -409,14 +384,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "lastIndexOf":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.lastIndexOf expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "lastIndexOf", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		sub, err := g.emitStdBytesArg(call.Args[1], "lastIndexOf", 1)
+		sub, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -426,18 +398,15 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "slice":
-		if len(call.Args) != 3 {
-			return value{}, true, unsupportedf("call", "bytes.slice expects 3 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "slice", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		start, err := g.emitStdBytesIntArg(call.Args[1], "slice", 1)
+		start, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
-		end, err := g.emitStdBytesIntArg(call.Args[2], "slice", 2)
+		end, err := g.emitStdBytesDescriptorArg(call.Args[2], name, 2)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -447,10 +416,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "toString":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.toString expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "toString", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -460,10 +426,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "len":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.len expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "len", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -474,10 +437,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), true, nil
 	case "isEmpty":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.isEmpty expects 1 argument, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "isEmpty", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -488,14 +448,11 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), true, nil
 	case "get":
-		if len(call.Args) != 2 {
-			return value{}, true, unsupportedf("call", "bytes.get expects 2 arguments, got %d", len(call.Args))
-		}
-		b, err := g.emitStdBytesArg(call.Args[0], "get", 0)
+		b, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
-		index, err := g.emitStdBytesIntArg(call.Args[1], "get", 1)
+		index, err := g.emitStdBytesDescriptorArg(call.Args[1], name, 1)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -505,10 +462,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		}
 		return out, true, nil
 	case "fromString":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "bytes.fromString expects 1 argument, got %d", len(call.Args))
-		}
-		s, err := g.emitStdBytesStringArg(call.Args[0], "fromString", 0)
+		s, err := g.emitStdBytesDescriptorArg(call.Args[0], name, 0)
 		if err != nil {
 			return value{}, true, err
 		}
@@ -747,14 +701,12 @@ func (g *generator) stdBytesCallStaticResult(call *ast.CallExpr) (value, bool) {
 	if !ok || !g.stdBytesAliases[alias.Name] {
 		return value{}, false
 	}
-	switch field.Name {
-	case "len":
+	switch llvmStdBytesCallReturnKind(field.Name) {
+	case llvmRuntimeFfiKindInt():
 		return value{typ: "i64"}, true
-	case "isEmpty":
+	case llvmRuntimeFfiKindBool():
 		return value{typ: "i1"}, true
-	case "contains", "startsWith", "endsWith":
-		return value{typ: "i1"}, true
-	case "indexOf", "lastIndexOf":
+	case llvmStdBytesResultKindOptionInt():
 		return value{
 			typ:       "ptr",
 			gcManaged: true,
@@ -762,7 +714,7 @@ func (g *generator) stdBytesCallStaticResult(call *ast.CallExpr) (value, bool) {
 				Inner: &ast.NamedType{Path: []string{"Int"}},
 			},
 		}, true
-	case "get":
+	case llvmStdBytesResultKindOptionByte():
 		return value{
 			typ:       "ptr",
 			gcManaged: true,
@@ -770,22 +722,18 @@ func (g *generator) stdBytesCallStaticResult(call *ast.CallExpr) (value, bool) {
 				Inner: &ast.NamedType{Path: []string{"Byte"}},
 			},
 		}, true
-	case "fromString":
+	case llvmRuntimeFfiKindBytes():
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
-	case "from":
-		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
-	case "split":
+	case llvmRuntimeFfiKindListBytes():
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", sourceType: bytesListSourceType()}, true
-	case "concat", "join", "repeat", "replace", "replaceAll", "trimLeft", "trimRight", "trim", "trimSpace", "toUpper", "toLower", "slice":
-		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
-	case "toHex":
+	case llvmRuntimeFfiKindString():
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
-	case "fromHex":
+	case llvmStdBytesResultKindResultBytesError():
 		if info, ok := builtinResultTypeFromAST(bytesFromHexResultSourceType(), g.typeEnv()); ok {
 			return value{typ: info.typ, sourceType: bytesFromHexResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
 		}
 		return value{}, false
-	case "toString":
+	case llvmStdBytesResultKindResultStringError():
 		if info, ok := builtinResultTypeFromAST(bytesToStringResultSourceType(), g.typeEnv()); ok {
 			return value{typ: info.typ, sourceType: bytesToStringResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
 		}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -3551,6 +3551,202 @@ func llvmRuntimeFfiKindListChar() int { return 8 }
 // Osty: llvmRuntimeFfiKindListByte
 func llvmRuntimeFfiKindListByte() int { return 9 }
 
+// Osty: llvmRuntimeFfiKindListBytes
+func llvmRuntimeFfiKindListBytes() int { return 10 }
+
+// Osty: llvmStdBytesResultKindOptionInt
+func llvmStdBytesResultKindOptionInt() int { return 100 }
+
+// Osty: llvmStdBytesResultKindOptionByte
+func llvmStdBytesResultKindOptionByte() int { return 101 }
+
+// Osty: llvmStdBytesResultKindResultBytesError
+func llvmStdBytesResultKindResultBytesError() int { return 102 }
+
+// Osty: llvmStdBytesResultKindResultStringError
+func llvmStdBytesResultKindResultStringError() int { return 103 }
+
+// Osty: llvmStdBytesCallCanonicalName
+func llvmStdBytesCallCanonicalName(name string) string {
+	switch name {
+	case "From":
+		return "from"
+	case "Split":
+		return "split"
+	case "Join":
+		return "join"
+	case "Concat":
+		return "concat"
+	case "Repeat":
+		return "repeat"
+	case "Replace":
+		return "replace"
+	case "ReplaceAll":
+		return "replaceAll"
+	case "TrimLeft", "TrimStart", "trimStart":
+		return "trimLeft"
+	case "TrimRight", "TrimEnd", "trimEnd":
+		return "trimRight"
+	case "Trim":
+		return "trim"
+	case "TrimSpace":
+		return "trimSpace"
+	case "ToUpper":
+		return "toUpper"
+	case "ToLower":
+		return "toLower"
+	case "ToHex":
+		return "toHex"
+	case "FromHex":
+		return "fromHex"
+	case "Contains":
+		return "contains"
+	case "StartsWith":
+		return "startsWith"
+	case "EndsWith":
+		return "endsWith"
+	case "IndexOf", "Index":
+		return "indexOf"
+	case "LastIndexOf", "LastIndex":
+		return "lastIndexOf"
+	case "Slice":
+		return "slice"
+	case "ToString":
+		return "toString"
+	case "Len":
+		return "len"
+	case "IsEmpty":
+		return "isEmpty"
+	case "Get":
+		return "get"
+	case "FromString":
+		return "fromString"
+	default:
+		return name
+	}
+}
+
+// Osty: llvmStdBytesCallArgCount
+func llvmStdBytesCallArgCount(name string) int {
+	canonical := llvmStdBytesCallCanonicalName(name)
+	switch canonical {
+	case "from", "trimSpace", "toUpper", "toLower", "toHex", "fromHex", "toString", "len", "isEmpty", "fromString":
+		return 1
+	case "split", "join", "concat", "repeat", "trimLeft", "trimRight", "trim", "contains", "startsWith", "endsWith", "indexOf", "lastIndexOf", "get":
+		return 2
+	case "replace", "replaceAll", "slice":
+		return 3
+	default:
+		return 0
+	}
+}
+
+// Osty: llvmStdBytesCallReturnKind
+func llvmStdBytesCallReturnKind(name string) int {
+	canonical := llvmStdBytesCallCanonicalName(name)
+	switch canonical {
+	case "len":
+		return llvmRuntimeFfiKindInt()
+	case "isEmpty", "contains", "startsWith", "endsWith":
+		return llvmRuntimeFfiKindBool()
+	case "indexOf", "lastIndexOf":
+		return llvmStdBytesResultKindOptionInt()
+	case "get":
+		return llvmStdBytesResultKindOptionByte()
+	case "fromHex":
+		return llvmStdBytesResultKindResultBytesError()
+	case "toString":
+		return llvmStdBytesResultKindResultStringError()
+	case "toHex":
+		return llvmRuntimeFfiKindString()
+	case "split":
+		return llvmRuntimeFfiKindListBytes()
+	default:
+		if llvmStdBytesCallArgCount(canonical) != 0 {
+			return llvmRuntimeFfiKindBytes()
+		}
+		return llvmRuntimeFfiKindUnknown()
+	}
+}
+
+// Osty: llvmStdBytesCallParamName
+func llvmStdBytesCallParamName(name string, index int) string {
+	canonical := llvmStdBytesCallCanonicalName(name)
+	if index < 0 || index >= llvmStdBytesCallArgCount(canonical) {
+		return ""
+	}
+	switch index {
+	case 0:
+		switch canonical {
+		case "from":
+			return "items"
+		case "join":
+			return "parts"
+		case "fromHex", "fromString":
+			return "text"
+		case "concat":
+			return "left"
+		default:
+			return "value"
+		}
+	case 1:
+		switch canonical {
+		case "split", "join":
+			return "sep"
+		case "concat":
+			return "right"
+		case "repeat":
+			return "n"
+		case "replace", "replaceAll":
+			return "old"
+		case "trimLeft", "trimRight", "trim":
+			return "strip"
+		case "contains", "indexOf", "lastIndexOf":
+			return "needle"
+		case "startsWith":
+			return "prefix"
+		case "endsWith":
+			return "suffix"
+		case "slice":
+			return "start"
+		case "get":
+			return "index"
+		}
+	case 2:
+		switch canonical {
+		case "replace", "replaceAll":
+			return "new"
+		case "slice":
+			return "end"
+		}
+	}
+	return ""
+}
+
+// Osty: llvmStdBytesCallParamKind
+func llvmStdBytesCallParamKind(name string, index int) int {
+	canonical := llvmStdBytesCallCanonicalName(name)
+	if index < 0 || index >= llvmStdBytesCallArgCount(canonical) {
+		return llvmRuntimeFfiKindUnknown()
+	}
+	if canonical == "from" && index == 0 {
+		return llvmRuntimeFfiKindListByte()
+	}
+	if canonical == "join" && index == 0 {
+		return llvmRuntimeFfiKindListBytes()
+	}
+	if (canonical == "repeat" || canonical == "get") && index == 1 {
+		return llvmRuntimeFfiKindInt()
+	}
+	if canonical == "slice" && (index == 1 || index == 2) {
+		return llvmRuntimeFfiKindInt()
+	}
+	if (canonical == "fromHex" || canonical == "fromString") && index == 0 {
+		return llvmRuntimeFfiKindString()
+	}
+	return llvmRuntimeFfiKindBytes()
+}
+
 // Osty: llvmRuntimeStringsCanonicalFfiName
 func llvmRuntimeStringsCanonicalFfiName(name string) string {
 	canon := llvmCanonicalStdStringsCallName(name)

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -3865,6 +3865,167 @@ pub fn llvmRuntimeFfiKindBytes() -> Int { 6 }
 pub fn llvmRuntimeFfiKindListString() -> Int { 7 }
 pub fn llvmRuntimeFfiKindListChar() -> Int { 8 }
 pub fn llvmRuntimeFfiKindListByte() -> Int { 9 }
+pub fn llvmRuntimeFfiKindListBytes() -> Int { 10 }
+
+/// std.bytes descriptor-only result kinds. The shared scalar/container
+/// values above stay compatible with runtime FFI descriptors, while these
+/// wrapper shapes are consumed by the Go shim to preserve source types.
+pub fn llvmStdBytesResultKindOptionInt() -> Int { 100 }
+pub fn llvmStdBytesResultKindOptionByte() -> Int { 101 }
+pub fn llvmStdBytesResultKindResultBytesError() -> Int { 102 }
+pub fn llvmStdBytesResultKindResultStringError() -> Int { 103 }
+
+pub fn llvmStdBytesCallCanonicalName(name: String) -> String {
+    if name == "From" { return "from" }
+    if name == "Split" { return "split" }
+    if name == "Join" { return "join" }
+    if name == "Concat" { return "concat" }
+    if name == "Repeat" { return "repeat" }
+    if name == "Replace" { return "replace" }
+    if name == "ReplaceAll" { return "replaceAll" }
+    if name == "TrimLeft" || name == "TrimStart" || name == "trimStart" {
+        return "trimLeft"
+    }
+    if name == "TrimRight" || name == "TrimEnd" || name == "trimEnd" {
+        return "trimRight"
+    }
+    if name == "Trim" { return "trim" }
+    if name == "TrimSpace" { return "trimSpace" }
+    if name == "ToUpper" { return "toUpper" }
+    if name == "ToLower" { return "toLower" }
+    if name == "ToHex" { return "toHex" }
+    if name == "FromHex" { return "fromHex" }
+    if name == "Contains" { return "contains" }
+    if name == "StartsWith" { return "startsWith" }
+    if name == "EndsWith" { return "endsWith" }
+    if name == "IndexOf" || name == "Index" { return "indexOf" }
+    if name == "LastIndexOf" || name == "LastIndex" { return "lastIndexOf" }
+    if name == "Slice" { return "slice" }
+    if name == "ToString" { return "toString" }
+    if name == "Len" { return "len" }
+    if name == "IsEmpty" { return "isEmpty" }
+    if name == "Get" { return "get" }
+    if name == "FromString" { return "fromString" }
+    name
+}
+
+pub fn llvmStdBytesCallArgCount(name: String) -> Int {
+    let canonical = llvmStdBytesCallCanonicalName(name)
+    if canonical == "from" || canonical == "trimSpace" ||
+        canonical == "toUpper" || canonical == "toLower" ||
+        canonical == "toHex" || canonical == "fromHex" ||
+        canonical == "toString" || canonical == "len" ||
+        canonical == "isEmpty" || canonical == "fromString" {
+        return 1
+    }
+    if canonical == "split" || canonical == "join" ||
+        canonical == "concat" || canonical == "repeat" ||
+        canonical == "trimLeft" || canonical == "trimRight" ||
+        canonical == "trim" || canonical == "contains" ||
+        canonical == "startsWith" || canonical == "endsWith" ||
+        canonical == "indexOf" || canonical == "lastIndexOf" ||
+        canonical == "get" {
+        return 2
+    }
+    if canonical == "replace" || canonical == "replaceAll" ||
+        canonical == "slice" {
+        return 3
+    }
+    0
+}
+
+pub fn llvmStdBytesCallReturnKind(name: String) -> Int {
+    let canonical = llvmStdBytesCallCanonicalName(name)
+    if canonical == "len" {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "isEmpty" || canonical == "contains" ||
+        canonical == "startsWith" || canonical == "endsWith" {
+        return llvmRuntimeFfiKindBool()
+    }
+    if canonical == "indexOf" || canonical == "lastIndexOf" {
+        return llvmStdBytesResultKindOptionInt()
+    }
+    if canonical == "get" {
+        return llvmStdBytesResultKindOptionByte()
+    }
+    if canonical == "fromHex" {
+        return llvmStdBytesResultKindResultBytesError()
+    }
+    if canonical == "toString" {
+        return llvmStdBytesResultKindResultStringError()
+    }
+    if canonical == "toHex" {
+        return llvmRuntimeFfiKindString()
+    }
+    if canonical == "split" {
+        return llvmRuntimeFfiKindListBytes()
+    }
+    if llvmStdBytesCallArgCount(canonical) != 0 {
+        return llvmRuntimeFfiKindBytes()
+    }
+    llvmRuntimeFfiKindUnknown()
+}
+
+pub fn llvmStdBytesCallParamName(name: String, index: Int) -> String {
+    let canonical = llvmStdBytesCallCanonicalName(name)
+    if index < 0 || index >= llvmStdBytesCallArgCount(canonical) {
+        return ""
+    }
+    if index == 0 {
+        if canonical == "from" { return "items" }
+        if canonical == "join" { return "parts" }
+        if canonical == "fromHex" || canonical == "fromString" { return "text" }
+        if canonical == "concat" { return "left" }
+        return "value"
+    }
+    if index == 1 {
+        if canonical == "split" || canonical == "join" { return "sep" }
+        if canonical == "concat" { return "right" }
+        if canonical == "repeat" { return "n" }
+        if canonical == "replace" || canonical == "replaceAll" { return "old" }
+        if canonical == "trimLeft" || canonical == "trimRight" ||
+            canonical == "trim" {
+            return "strip"
+        }
+        if canonical == "contains" || canonical == "indexOf" ||
+            canonical == "lastIndexOf" {
+            return "needle"
+        }
+        if canonical == "startsWith" { return "prefix" }
+        if canonical == "endsWith" { return "suffix" }
+        if canonical == "slice" { return "start" }
+        if canonical == "get" { return "index" }
+    }
+    if index == 2 {
+        if canonical == "replace" || canonical == "replaceAll" { return "new" }
+        if canonical == "slice" { return "end" }
+    }
+    ""
+}
+
+pub fn llvmStdBytesCallParamKind(name: String, index: Int) -> Int {
+    let canonical = llvmStdBytesCallCanonicalName(name)
+    if index < 0 || index >= llvmStdBytesCallArgCount(canonical) {
+        return llvmRuntimeFfiKindUnknown()
+    }
+    if canonical == "from" && index == 0 {
+        return llvmRuntimeFfiKindListByte()
+    }
+    if canonical == "join" && index == 0 {
+        return llvmRuntimeFfiKindListBytes()
+    }
+    if (canonical == "repeat" || canonical == "get") && index == 1 {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "slice" && (index == 1 || index == 2) {
+        return llvmRuntimeFfiKindInt()
+    }
+    if (canonical == "fromHex" || canonical == "fromString") && index == 0 {
+        return llvmRuntimeFfiKindString()
+    }
+    llvmRuntimeFfiKindBytes()
+}
 
 pub fn llvmRuntimeStringsCanonicalFfiName(name: String) -> String {
     let canon = llvmCanonicalStdStringsCallName(name)


### PR DESCRIPTION
## Summary
- Move std.bytes call canonicalization, arity, parameter kind/name, and return-shape policy into `toolchain/llvmgen.osty`.
- Mirror the new Osty-owned descriptor in `internal/llvmgen/support_snapshot.go` and route the Go shim through it.
- Replace per-branch bytes argument count/type dispatch with descriptor-backed checks and add policy drift coverage.

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGeneratedStdBytesCallPolicyIsOstyOwned|TestStdBytes'`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `just fmt-check`
- `go test -count=1 -vet=off ./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen`
- `just verify-selfhost`
- `just verify-self-rebuild-gates`
- `just verify-self-rebuild-fast`