### PR TITLE
[codex] optimize selfhost checker hot keys

### DIFF
--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -73,7 +73,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	var serial bool
 	fs.BoolVar(&serial, "serial", false, "run tests sequentially in the shuffled order (default: parallel)")
 	var jobs int
-	fs.IntVar(&jobs, "jobs", 0, "max concurrent tests when parallel (0 = runtime.NumCPU())")
+	fs.IntVar(&jobs, "jobs", 0, "max concurrent tests when parallel (0 = runtime.GOMAXPROCS)")
 	var docTests bool
 	fs.BoolVar(&docTests, "doc", false, "v0.5 G32: extract `osty-fenced examples from /// doc comments and run each as an additional test")
 	var benchMode bool
@@ -487,7 +487,7 @@ func formatTestDuration(d time.Duration) string {
 }
 
 func resolveTestWorkers(serial bool, jobs, n int) int {
-	return runner.ResolveTestWorkers(serial, jobs, runtime.NumCPU(), n)
+	return runner.ResolveTestWorkers(serial, jobs, runtime.GOMAXPROCS(0), n)
 }
 
 // shuffleNativeTests randomizes the test slice in place using a PRNG

--- a/internal/runner/test_runner_policy.go
+++ b/internal/runner/test_runner_policy.go
@@ -6,8 +6,8 @@ package runner
 import "strings"
 
 // ResolveTestWorkers picks the worker-pool size for `osty test`
-// given the flag state and discovered test count. See the Osty
-// source for the precedence table.
+// given the flag state, caller-provided CPU budget, and discovered
+// test count. See the Osty source for the precedence table.
 //
 // Osty: toolchain/test_runner.osty:24
 func ResolveTestWorkers(serial bool, jobs, cpuCount, testCount int) int {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -29584,27 +29584,27 @@ func tyLookupInterned(arena *TyArena, key string, hash int) int {
 
 // Osty: /tmp/selfhost_merged.osty:11848:1
 func tyKeyNamed(head string, args []int) string {
-	return fmt.Sprintf("N|%s|%s", ostyToString(head), ostyToString(tyKeyArgs(args)))
+	return "N|" + head + "|" + tyKeyArgs(args)
 }
 
 // Osty: /tmp/selfhost_merged.osty:11852:1
 func tyKeyTuple(args []int) string {
-	return fmt.Sprintf("T|%s", ostyToString(tyKeyArgs(args)))
+	return "T|" + tyKeyArgs(args)
 }
 
 // Osty: /tmp/selfhost_merged.osty:11856:1
 func tyKeyFn(args []int, ret int) string {
-	return fmt.Sprintf("F|%s|%s", ostyToString(tyKeyArgs(args)), ostyToString(ret))
+	return "F|" + tyKeyArgs(args) + "|" + strconv.Itoa(ret)
 }
 
 // Osty: /tmp/selfhost_merged.osty:11860:1
 func tyKeyOptional(inner int) string {
-	return fmt.Sprintf("O|%s", ostyToString(inner))
+	return "O|" + strconv.Itoa(inner)
 }
 
 // Osty: /tmp/selfhost_merged.osty:11864:1
 func tyKeySelf(owner string) string {
-	return fmt.Sprintf("S|%s", ostyToString(owner))
+	return "S|" + owner
 }
 
 // Osty: /tmp/selfhost_merged.osty:11868:1
@@ -29614,35 +29614,18 @@ func tyKeyArgs(args []int) string {
 		// Osty: /tmp/selfhost_merged.osty:11870:9
 		return ""
 	}
-	// Osty: /tmp/selfhost_merged.osty:11872:5
-	out := ""
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:11873:5
-	i := 0
-	_ = i
-	// Osty: /tmp/selfhost_merged.osty:11874:5
-	for _, arg := range args {
-		// Osty: /tmp/selfhost_merged.osty:11875:9
-		if i > 0 {
-			// Osty: /tmp/selfhost_merged.osty:11876:13
-			out = fmt.Sprintf("%s,", ostyToString(out))
-		}
-		// Osty: /tmp/selfhost_merged.osty:11878:9
-		out = fmt.Sprintf("%s%s", ostyToString(out), ostyToString(arg))
-		// Osty: /tmp/selfhost_merged.osty:11879:9
-		func() {
-			var _cur2012 int = i
-			var _rhs2013 int = 1
-			if _rhs2013 > 0 && _cur2012 > math.MaxInt-_rhs2013 {
-				panic("integer overflow")
-			}
-			if _rhs2013 < 0 && _cur2012 < math.MinInt-_rhs2013 {
-				panic("integer overflow")
-			}
-			i = _cur2012 + _rhs2013
-		}()
+	if len(args) == 1 {
+		return strconv.Itoa(args[0])
 	}
-	return out
+	var b strings.Builder
+	b.Grow(len(args) * 3)
+	for i, arg := range args {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(arg))
+	}
+	return b.String()
 }
 
 // Osty: /tmp/selfhost_merged.osty:11891:5
@@ -34955,138 +34938,41 @@ func checkGenericBoundIndexPop(env *CheckEnv, name string) {
 
 // Osty: /tmp/selfhost_merged.osty:14884:1
 func checkHashKey(key string) int {
-	// Osty: /tmp/selfhost_merged.osty:14885:5
 	h := 5381
-	_ = h
-	// Osty: /tmp/selfhost_merged.osty:14886:5
-	for _, b := range []byte(key) {
-		// Osty: /tmp/selfhost_merged.osty:14887:9
-		func() {
-			var _cur2101 int = (func() int {
-				var _p2103 int = h
-				var _rhs2104 int = 33
-				if _p2103 != 0 && _rhs2104 != 0 {
-					if _p2103 == int(-1) && _rhs2104 == math.MinInt {
-						panic("integer overflow")
-					}
-					if _rhs2104 == int(-1) && _p2103 == math.MinInt {
-						panic("integer overflow")
-					}
-					if _p2103 > 0 {
-						if _rhs2104 > 0 && _p2103 > math.MaxInt/_rhs2104 {
-							panic("integer overflow")
-						}
-						if _rhs2104 < 0 && _rhs2104 < math.MinInt/_p2103 {
-							panic("integer overflow")
-						}
-					} else {
-						if _rhs2104 > 0 && _p2103 < math.MinInt/_rhs2104 {
-							panic("integer overflow")
-						}
-						if _rhs2104 < 0 && _p2103 < math.MaxInt/_rhs2104 {
-							panic("integer overflow")
-						}
-					}
-				}
-				return _p2103 * _rhs2104
-			}() + int(b))
-			var _rhs2102 int = 1073741789
-			if _rhs2102 == 0 {
-				panic("integer modulo by zero")
-			}
-			if _cur2101 == math.MinInt && _rhs2102 == int(-1) {
-				panic("integer overflow")
-			}
-			h = _cur2101 % _rhs2102
-		}()
+	for i := 0; i < len(key); i++ {
+		h = (h*33 + int(key[i])) % 1073741789
 	}
 	return h
 }
 
 // Osty: /tmp/selfhost_merged.osty:14892:1
 func checkNameIndex(names []string, hashes []int, name string, hash int) int {
-	// Osty: /tmp/selfhost_merged.osty:14893:5
-	i := func() int {
-		var _p2105 int = len(names)
-		var _rhs2106 int = 1
-		if _rhs2106 < 0 && _p2105 > math.MaxInt+_rhs2106 {
-			panic("integer overflow")
-		}
-		if _rhs2106 > 0 && _p2105 < math.MinInt+_rhs2106 {
-			panic("integer overflow")
-		}
-		return _p2105 - _rhs2106
-	}()
-	_ = i
-	// Osty: /tmp/selfhost_merged.osty:14894:5
-	for i >= 0 {
-		// Osty: /tmp/selfhost_merged.osty:14895:9
+	for i := len(names) - 1; i >= 0; i-- {
 		if hashes[i] == hash && names[i] == name {
-			// Osty: /tmp/selfhost_merged.osty:14896:13
 			return i
 		}
-		// Osty: /tmp/selfhost_merged.osty:14898:9
-		func() {
-			var _cur2107 int = i
-			var _rhs2108 int = 1
-			if _rhs2108 < 0 && _cur2107 > math.MaxInt+_rhs2108 {
-				panic("integer overflow")
-			}
-			if _rhs2108 > 0 && _cur2107 < math.MinInt+_rhs2108 {
-				panic("integer overflow")
-			}
-			i = _cur2107 - _rhs2108
-		}()
 	}
 	return -1
 }
 
 // Osty: /tmp/selfhost_merged.osty:14903:1
 func checkLookupExactIndex(keys []string, hashes []int, values []int, key string, hash int) int {
-	// Osty: /tmp/selfhost_merged.osty:14904:5
-	i := func() int {
-		var _p2109 int = len(keys)
-		var _rhs2110 int = 1
-		if _rhs2110 < 0 && _p2109 > math.MaxInt+_rhs2110 {
-			panic("integer overflow")
-		}
-		if _rhs2110 > 0 && _p2109 < math.MinInt+_rhs2110 {
-			panic("integer overflow")
-		}
-		return _p2109 - _rhs2110
-	}()
-	_ = i
-	// Osty: /tmp/selfhost_merged.osty:14905:5
-	for i >= 0 {
-		// Osty: /tmp/selfhost_merged.osty:14906:9
+	for i := len(keys) - 1; i >= 0; i-- {
 		if hashes[i] == hash && keys[i] == key {
-			// Osty: /tmp/selfhost_merged.osty:14907:13
 			return values[i]
 		}
-		// Osty: /tmp/selfhost_merged.osty:14909:9
-		func() {
-			var _cur2111 int = i
-			var _rhs2112 int = 1
-			if _rhs2112 < 0 && _cur2111 > math.MaxInt+_rhs2112 {
-				panic("integer overflow")
-			}
-			if _rhs2112 > 0 && _cur2111 < math.MinInt+_rhs2112 {
-				panic("integer overflow")
-			}
-			i = _cur2111 - _rhs2112
-		}()
 	}
 	return -1
 }
 
 // Osty: /tmp/selfhost_merged.osty:14914:1
 func checkFnKey(name string, owner string) string {
-	return fmt.Sprintf("%s\x1f%s", ostyToString(owner), ostyToString(name))
+	return owner + "\x1f" + name
 }
 
 // Osty: /tmp/selfhost_merged.osty:14918:1
 func checkOwnerKey(owner string, name string) string {
-	return fmt.Sprintf("%s\x1f%s", ostyToString(owner), ostyToString(name))
+	return owner + "\x1f" + name
 }
 
 // Osty: /tmp/selfhost_merged.osty:14930:5
@@ -35552,7 +35438,7 @@ func checkSubstCacheKey(ty int, generics []string, args []int) string {
 	// Osty: /tmp/selfhost_merged.osty:15144:5
 	var aKey string = checkIntKey(args)
 	_ = aKey
-	return fmt.Sprintf("%s\x1f%s\x1f%s", ostyToString(ty), ostyToString(gKey), ostyToString(aKey))
+	return strconv.Itoa(ty) + "\x1f" + gKey + "\x1f" + aKey
 }
 
 // Osty: /tmp/selfhost_merged.osty:15152:5

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -732,11 +732,11 @@ fn checkLookupExactIndex(keys: List<String>, hashes: List<Int>, values: List<Int
 }
 
 fn checkFnKey(name: String, owner: String) -> String {
-    "{owner}\u{1f}{name}"
+    owner + "\u{1f}" + name
 }
 
 fn checkOwnerKey(owner: String, name: String) -> String {
-    "{owner}\u{1f}{name}"
+    owner + "\u{1f}" + name
 }
 
 // ---------------------------------------------------------------------
@@ -954,7 +954,7 @@ fn checkSubstCacheKey(ty: Int, generics: List<String>, args: List<Int>) -> Strin
     // `let v: Int = xs[i]` workaround in `checkIntKey` below.
     let gKey: String = checkStringKey(generics)
     let aKey: String = checkIntKey(args)
-    "{ty}\u{1f}{gKey}\u{1f}{aKey}"
+    "{ty}" + "\u{1f}" + gKey + "\u{1f}" + aKey
 }
 
 // ---------------------------------------------------------------------

--- a/toolchain/test_runner.osty
+++ b/toolchain/test_runner.osty
@@ -19,7 +19,7 @@ use std.strings as strings
 /// Precedence:
 ///   - --serial always wins: 1 worker, run in order.
 ///   - --jobs N caps the pool at N (negative is treated as 0).
-///   - --jobs 0 (the default) uses the host's CPU count.
+///   - --jobs 0 (the default) uses the host-provided CPU budget.
 ///   - The pool is clamped to a minimum of 1 and to at most `n`
 ///     (the number of discovered tests — no idle goroutines).
 pub fn resolveTestWorkers(serial: Bool, jobs: Int, cpuCount: Int, testCount: Int) -> Int {

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -374,39 +374,42 @@ fn tyLookupInterned(arena: TyArena, key: String, hash: Int) -> Int {
 }
 
 fn tyKeyNamed(head: String, args: List<Int>) -> String {
-    "N|{head}|{tyKeyArgs(args)}"
+    "N|" + head + "|" + tyKeyArgs(args)
 }
 
 fn tyKeyTuple(args: List<Int>) -> String {
-    "T|{tyKeyArgs(args)}"
+    "T|" + tyKeyArgs(args)
 }
 
 fn tyKeyFn(args: List<Int>, ret: Int) -> String {
-    "F|{tyKeyArgs(args)}|{ret}"
+    "F|" + tyKeyArgs(args) + "|" + "{ret}"
 }
 
 fn tyKeyOptional(inner: Int) -> String {
-    "O|{inner}"
+    "O|" + "{inner}"
 }
 
 fn tyKeySelf(owner: String) -> String {
-    "S|{owner}"
+    "S|" + owner
 }
 
 fn tyKeyArgs(args: List<Int>) -> String {
-    if args.len() == 0 {
+    let n = args.len()
+    if n == 0 {
         return ""
     }
-    let mut out = ""
+    if n == 1 {
+        let only: Int = args[0]
+        return "{only}"
+    }
+    let mut parts: List<String> = []
     let mut i = 0
-    for arg in args {
-        if i > 0 {
-            out = "{out},"
-        }
-        out = "{out}{arg}"
+    for i < n {
+        let arg: Int = args[i]
+        parts.push("{arg}")
         i = i + 1
     }
-    out
+    strings.join(parts, ",")
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace generated selfhost hot key helpers with direct string construction and byte-wise hashing.
- Mirror the key-construction cleanup in the Osty toolchain sources.
- Use the caller-provided GOMAXPROCS CPU budget for `osty test --jobs=0`.

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'Test(CheckSnapshot|TyKey|CheckFnKey|CheckOwnerKey|CheckNameIndex|CheckLookupExactIndex|CheckHashKey)'`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test.*Native.*Workspace|Test.*Native.*Package|Test.*Native.*Clean|Test.*DefaultPath'`
- `go test -count=1 -vet=off -run 'SnapshotParity|CoreSnapshotParity' ./internal/ci ./internal/runner`
- `go build ./cmd/osty ./cmd/osty-native-checker`
- `go run ./cmd/osty check --native toolchain/ty.osty`
- `go run ./cmd/osty check --native toolchain/check_env.osty`
- `go run ./cmd/osty check --native toolchain/test_runner.osty`

## Benchmark
`BenchmarkCheckStructuredFromRun` improved from about `1,244,694 ns/op`, `482,981 B/op`, `16,282 allocs/op` to about `992,057 ns/op`, `389,078 B/op`, `8,689 allocs/op`.