### PR TITLE
[codex] add Qt Quick GUI bridge MVP

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 64 top-level 모듈. 분류 기준:
+총 65 top-level 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (62 / 64 = 97%)
+### ⭐⭐⭐⭐⭐ Production (62 / 65 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -92,10 +92,11 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (2 / 64 = 3%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 65 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
+| gui.qtquick | 183 | Qt Quick/QML native app backend MVP. `libosty_qt` bridge 필요, bundle/deploy 연계는 후속 |
 | compress | 11 | gzip 만 (zstd / deflate 추가 가능). Phase A shim 199 |
 | testing_gen | 168 | property runner 는 int/intRange/asciiString/pair/triple/oneOf/constant subset 실행. bool/float/char/byte/list/listOfSize/option/result/oneOfGens/map/filter 는 아직 실행 subset 밖 |
 

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1198,8 +1198,8 @@ func printScopeNode(s *resolve.Scope, depth int) {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage: osty [flags] (parse|tokens|resolve|check|typecheck|lint|fmt|airepair|gen) FILE")
-	fmt.Fprintln(os.Stderr, "       osty new [--bin|--lib|--workspace|--cli|--service] [--member NAME] NAME")
-	fmt.Fprintln(os.Stderr, "       osty init [--bin|--lib|--workspace|--cli|--service] [--name NAME] [--member NAME]")
+	fmt.Fprintln(os.Stderr, "       osty new [--bin|--lib|--workspace|--cli|--service|--gui qtquick] [--member NAME] NAME")
+	fmt.Fprintln(os.Stderr, "       osty init [--bin|--lib|--workspace|--cli|--service|--gui qtquick] [--name NAME] [--member NAME]")
 	fmt.Fprintln(os.Stderr, "       osty build [DIR]          (manifest + deps + front end + backend artifacts)")
 	fmt.Fprintln(os.Stderr, "       osty add NAME[@VER]       (add a dependency; also --path, --git)")
 	fmt.Fprintln(os.Stderr, "       osty update [NAME...]     (refresh osty.lock)")
@@ -1277,6 +1277,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --workspace        scaffold a virtual workspace with one default member")
 	fmt.Fprintln(os.Stderr, "  --cli              scaffold a multi-file CLI app starter")
 	fmt.Fprintln(os.Stderr, "  --service          scaffold a multi-file HTTP service starter")
+	fmt.Fprintln(os.Stderr, "  --gui BACKEND      scaffold a GUI app starter (supported: qtquick)")
 	fmt.Fprintln(os.Stderr, "  --member NAME      workspace member directory name (default: core)")
 	fmt.Fprintln(os.Stderr, "add-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --path DIR         local-path dependency (no network)")
@@ -1824,22 +1825,23 @@ func parseGenEmitFile(pkg *resolve.Package) (*ast.File, []byte, error) {
 func runNew(args []string) {
 	fs := flag.NewFlagSet("new", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty new [--bin|--lib|--workspace|--cli|--service] [--member NAME] NAME")
+		fmt.Fprintln(os.Stderr, "usage: osty new [--bin|--lib|--workspace|--cli|--service|--gui qtquick] [--member NAME] NAME")
 	}
 	var libMode, binMode, wsMode, cliMode, svcMode bool
-	var member string
+	var member, guiBackend string
 	fs.BoolVar(&libMode, "lib", false, "scaffold a library project (lib.osty, no main)")
 	fs.BoolVar(&binMode, "bin", false, "scaffold a binary project (main.osty) [default]")
 	fs.BoolVar(&wsMode, "workspace", false, "scaffold a virtual workspace with one default member")
 	fs.BoolVar(&cliMode, "cli", false, "scaffold a CLI app (Args struct + run() core)")
 	fs.BoolVar(&svcMode, "service", false, "scaffold an HTTP service (Request/Response + handle())")
+	fs.StringVar(&guiBackend, "gui", "", "scaffold a GUI app for backend (qtquick)")
 	fs.StringVar(&member, "member", "core", "default-member directory name when --workspace is set")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		fs.Usage()
 		os.Exit(2)
 	}
-	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode)
+	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode, guiBackend)
 	if usageErr != "" {
 		fmt.Fprintln(os.Stderr, "osty new:", usageErr)
 		os.Exit(2)
@@ -1863,15 +1865,16 @@ func runNew(args []string) {
 func runInit(args []string) {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty init [--bin|--lib|--workspace|--cli|--service] [--name NAME] [--member NAME]")
+		fmt.Fprintln(os.Stderr, "usage: osty init [--bin|--lib|--workspace|--cli|--service|--gui qtquick] [--name NAME] [--member NAME]")
 	}
 	var libMode, binMode, wsMode, cliMode, svcMode bool
-	var name, member string
+	var name, member, guiBackend string
 	fs.BoolVar(&libMode, "lib", false, "scaffold a library project (lib.osty, no main)")
 	fs.BoolVar(&binMode, "bin", false, "scaffold a binary project (main.osty) [default]")
 	fs.BoolVar(&wsMode, "workspace", false, "scaffold a virtual workspace with one default member")
 	fs.BoolVar(&cliMode, "cli", false, "scaffold a CLI app (Args struct + run() core)")
 	fs.BoolVar(&svcMode, "service", false, "scaffold an HTTP service (Request/Response + handle())")
+	fs.StringVar(&guiBackend, "gui", "", "scaffold a GUI app for backend (qtquick)")
 	fs.StringVar(&name, "name", "", "project name (defaults to current directory basename)")
 	fs.StringVar(&member, "member", "core", "default-member directory name when --workspace is set")
 	_ = fs.Parse(args)
@@ -1879,7 +1882,7 @@ func runInit(args []string) {
 		fs.Usage()
 		os.Exit(2)
 	}
-	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode)
+	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode, guiBackend)
 	if usageErr != "" {
 		fmt.Fprintln(os.Stderr, "osty init:", usageErr)
 		os.Exit(2)
@@ -1904,7 +1907,7 @@ func runInit(args []string) {
 // pickScaffoldKind validates the mutually-exclusive kind flags and
 // returns the selected Kind plus an empty string, or the zero Kind
 // and a one-line usage error message.
-func pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode bool) (scaffold.Kind, string) {
+func pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode bool, guiBackend string) (scaffold.Kind, string) {
 	count := 0
 	if libMode {
 		count++
@@ -1921,8 +1924,14 @@ func pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode bool) (scaffold
 	if svcMode {
 		count++
 	}
+	if guiBackend != "" {
+		count++
+	}
 	if count > 1 {
-		return 0, "--bin, --lib, --workspace, --cli, and --service are mutually exclusive"
+		return 0, "--bin, --lib, --workspace, --cli, --service, and --gui are mutually exclusive"
+	}
+	if guiBackend != "" && guiBackend != "qtquick" {
+		return 0, "--gui supports only qtquick"
 	}
 	switch {
 	case libMode:
@@ -1933,6 +1942,8 @@ func pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode bool) (scaffold
 		return scaffold.KindCli, ""
 	case svcMode:
 		return scaffold.KindService, ""
+	case guiBackend == "qtquick":
+		return scaffold.KindGUIQtQuick, ""
 	default:
 		return scaffold.KindBin, ""
 	}
@@ -1950,6 +1961,8 @@ func kindLabel(k scaffold.Kind) string {
 		return "CLI app project"
 	case scaffold.KindService:
 		return "HTTP service project"
+	case scaffold.KindGUIQtQuick:
+		return "Qt Quick GUI app project"
 	default:
 		return "binary project"
 	}

--- a/examples/gui-inspector/main.osty
+++ b/examples/gui-inspector/main.osty
@@ -1,0 +1,74 @@
+use std.gui.qtquick as gui
+use std.json
+
+pub struct InspectorState {
+    pub status: String,
+    pub theme: String,
+    pub selected: String,
+    pub stages: List<String>,
+    pub output: String,
+    pub logs: List<String>,
+}
+
+fn main() {
+    match run() {
+        Ok(_) -> {},
+        Err(err) -> eprintln("gui-inspector: {err.message()}"),
+    }
+}
+
+fn run() -> Result<(), Error> {
+    let app = gui.app("Osty Inspector")?
+    let window = app.window(gui.windowOptions("Osty Inspector", 1100, 720, "ui/main.qml"))?
+
+    app.setState(initialState())?
+    window.show()?
+
+    for app.poll() {
+        for event in app.events() {
+            if event.name == "run" {
+                app.setState(runningState(event.payload))?
+            } else if event.name == "toggle-theme" {
+                app.setState(themeState(event.payload))?
+            } else if event.name == "quit" {
+                let _ = app.quit()
+            }
+        }
+    }
+
+    app.close()
+    Ok(())
+}
+
+fn initialState() -> String {
+    json.encode(InspectorState {
+        status: "ready",
+        theme: "dark",
+        selected: "lexer",
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "Select a stage and press Run.",
+        logs: ["Inspector initialized", "Qt bridge ready"],
+    })
+}
+
+fn runningState(payload: String) -> String {
+    json.encode(InspectorState {
+        status: "completed",
+        theme: "dark",
+        selected: "checker",
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "Latest event payload: {payload}",
+        logs: ["Run requested from QML", "Event reached Osty", "State pushed back to QML"],
+    })
+}
+
+fn themeState(payload: String) -> String {
+    json.encode(InspectorState {
+        status: "theme updated",
+        theme: "light",
+        selected: "backend",
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "Theme event payload: {payload}",
+        logs: ["Theme toggle received", "State model stayed JSON"],
+    })
+}

--- a/examples/gui-inspector/osty.toml
+++ b/examples/gui-inspector/osty.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gui-inspector"
+version = "0.1.0"
+edition = "0.5"
+description = "Osty Inspector demo built on std.gui and Qt Quick."
+
+[dependencies]
+
+[target.arm64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-linux]
+link = ["osty_qt"]
+
+[target.amd64-windows]
+link = ["osty_qt"]

--- a/examples/gui-inspector/ui/main.qml
+++ b/examples/gui-inspector/ui/main.qml
@@ -1,0 +1,108 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+    visible: true
+    width: 1100
+    height: 720
+    title: "Osty Inspector"
+
+    readonly property var state: osty.appState || ({})
+    readonly property bool dark: state.theme !== "light"
+    color: dark ? "#15181d" : "#f4f6f8"
+
+    header: ToolBar {
+        background: Rectangle { color: root.dark ? "#20252d" : "#ffffff" }
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 16
+            anchors.rightMargin: 16
+            spacing: 12
+
+            Label {
+                text: "Osty Inspector"
+                font.pixelSize: 18
+                font.bold: true
+                color: root.dark ? "#f4f7fb" : "#101418"
+            }
+            Label {
+                text: root.state.status || "ready"
+                color: root.dark ? "#9fb0c3" : "#53606e"
+            }
+            Item { Layout.fillWidth: true }
+            Button {
+                text: "Run"
+                onClicked: osty.emit("run", { stage: stageList.currentItem ? stageList.currentItem.text : "lexer" })
+            }
+            Button {
+                text: root.dark ? "Light" : "Dark"
+                onClicked: osty.emit("toggle-theme", { current: root.state.theme || "dark" })
+            }
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 16
+
+        Frame {
+            Layout.preferredWidth: 220
+            Layout.fillHeight: true
+
+            ListView {
+                id: stageList
+                anchors.fill: parent
+                model: root.state.stages || ["lexer", "parser", "checker", "backend"]
+                currentIndex: 0
+                spacing: 6
+
+                delegate: Button {
+                    width: ListView.view.width
+                    text: modelData
+                    checkable: true
+                    checked: ListView.isCurrentItem
+                    onClicked: stageList.currentIndex = index
+                }
+            }
+        }
+
+        SplitView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            orientation: Qt.Vertical
+
+            Frame {
+                SplitView.fillWidth: true
+                SplitView.fillHeight: true
+
+                ScrollView {
+                    anchors.fill: parent
+                    TextArea {
+                        readOnly: true
+                        wrapMode: TextArea.Wrap
+                        text: root.state.output || ""
+                        color: root.dark ? "#e8edf3" : "#17202a"
+                    }
+                }
+            }
+
+            Frame {
+                SplitView.fillWidth: true
+                SplitView.preferredHeight: 180
+
+                ListView {
+                    anchors.fill: parent
+                    model: root.state.logs || []
+                    delegate: Label {
+                        width: ListView.view.width
+                        text: modelData
+                        color: root.dark ? "#aab7c4" : "#42505e"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/qtquick-spike/main.osty
+++ b/examples/qtquick-spike/main.osty
@@ -1,0 +1,42 @@
+use c "osty_qt" as qt {
+    fn osty_qt_app_new(name: String) -> Int
+    fn osty_qt_app_poll(app: Int) -> Bool
+    fn osty_qt_app_quit(app: Int)
+    fn osty_qt_window_new(app: Int, title: String, width: Int, height: Int, qml: String) -> Int
+    fn osty_qt_window_show(window: Int) -> Bool
+    fn osty_qt_event_count(app: Int) -> Int
+    fn osty_qt_event_name(app: Int, index: Int) -> String
+    fn osty_qt_event_payload(app: Int, index: Int) -> String
+    fn osty_qt_event_clear(app: Int)
+    fn osty_qt_last_error() -> String
+}
+
+fn main() {
+    let app = qt.osty_qt_app_new("Osty Qt Spike")
+    if app == 0 {
+        eprintln(qt.osty_qt_last_error())
+        return
+    }
+    let window = qt.osty_qt_window_new(app, "Osty Qt Spike", 720, 420, "ui/main.qml")
+    if window == 0 {
+        eprintln(qt.osty_qt_last_error())
+        return
+    }
+    if !qt.osty_qt_window_show(window) {
+        eprintln(qt.osty_qt_last_error())
+        return
+    }
+
+    for qt.osty_qt_app_poll(app) {
+        let n = qt.osty_qt_event_count(app)
+        for i in 0..n {
+            let name = qt.osty_qt_event_name(app, i)
+            let payload = qt.osty_qt_event_payload(app, i)
+            println("event {name}: {payload}")
+            if name == "quit" {
+                qt.osty_qt_app_quit(app)
+            }
+        }
+        qt.osty_qt_event_clear(app)
+    }
+}

--- a/examples/qtquick-spike/osty.toml
+++ b/examples/qtquick-spike/osty.toml
@@ -1,0 +1,19 @@
+[package]
+name = "qtquick-spike"
+version = "0.1.0"
+edition = "0.5"
+description = "Direct libosty_qt C ABI spike."
+
+[dependencies]
+
+[target.arm64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-linux]
+link = ["osty_qt"]
+
+[target.amd64-windows]
+link = ["osty_qt"]

--- a/examples/qtquick-spike/ui/main.qml
+++ b/examples/qtquick-spike/ui/main.qml
@@ -1,0 +1,40 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    visible: true
+    width: 720
+    height: 420
+    title: "Osty Qt Spike"
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 24
+        spacing: 12
+
+        Label {
+            text: "Osty Qt Spike"
+            font.pixelSize: 24
+            font.bold: true
+        }
+
+        TextField {
+            id: input
+            Layout.fillWidth: true
+            placeholderText: "Payload text"
+            text: "hello from qml"
+        }
+
+        RowLayout {
+            Button {
+                text: "Emit"
+                onClicked: osty.emit("run", { text: input.text })
+            }
+            Button {
+                text: "Quit"
+                onClicked: osty.emit("quit", {})
+            }
+        }
+    }
+}

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -350,6 +350,49 @@ fn main() {
 	}
 }
 
+func TestGenerateUseCOstyQtSpikeSurface(t *testing.T) {
+	file := parseLLVMGenFile(t, `use c "osty_qt" as qt {
+    fn osty_qt_app_new(name: String) -> Int
+    fn osty_qt_app_poll(app: Int) -> Bool
+    fn osty_qt_window_new(app: Int, title: String, width: Int, height: Int, qml: String) -> Int
+    fn osty_qt_event_name(app: Int, index: Int) -> String
+}
+
+fn main() {
+    let app = qt.osty_qt_app_new("Spike")
+    let window = qt.osty_qt_window_new(app, "Spike", 640, 360, "ui/main.qml")
+    if qt.osty_qt_app_poll(app) {
+        println(qt.osty_qt_event_name(app, 0))
+    } else {
+        println(window)
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/use_c_osty_qt.osty",
+		Target:      "x86_64-unknown-linux-gnu",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare i64 @osty_qt_app_new(ptr)",
+		"declare i1 @osty_qt_app_poll(i64)",
+		"declare i64 @osty_qt_window_new(i64, ptr, i64, i64, ptr)",
+		"declare ptr @osty_qt_event_name(i64, i64)",
+		"call i64 @osty_qt_app_new(",
+		"call i64 @osty_qt_window_new(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateRuntimeCABIEmitsLiteralExternSymbol verifies that
 // `use runtime.cabi.<lib>` paths bypass the `osty_rt_` namespace and
 // declare the function name as the literal extern C symbol. This is

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -51,6 +51,15 @@
 //	├── routes_test.osty    # tests every handler + dispatch fan-out
 //	└── .gitignore
 //
+//	# Qt Quick GUI app project (--gui qtquick)
+//	NAME/
+//	├── osty.toml
+//	├── main.osty
+//	├── ui/main.qml
+//	├── assets/
+//	├── README.md
+//	└── .gitignore
+//
 // The --cli and --service variants are still binary packages (they
 // build a `fn main`), but their starter source replaces the bare
 // "Hello, Osty!" with a small but realistic skeleton split across
@@ -109,6 +118,9 @@ const (
 	// not in Tier 1 — but the shape matches what a real service body
 	// would grow into.
 	KindService
+	// KindGUIQtQuick scaffolds a binary package wired to std.gui and
+	// a short Qt Quick/QML entry file.
+	KindGUIQtQuick
 )
 
 // CurrentEdition is the spec version the scaffolder records in
@@ -340,6 +352,14 @@ func expectedPaths(dir string, opts Options) []string {
 			filepath.Join(dir, "routes_test.osty"),
 			filepath.Join(dir, ".gitignore"),
 		}
+	case KindGUIQtQuick:
+		return []string{
+			filepath.Join(dir, "osty.toml"),
+			filepath.Join(dir, "main.osty"),
+			filepath.Join(dir, "ui", "main.qml"),
+			filepath.Join(dir, "README.md"),
+			filepath.Join(dir, ".gitignore"),
+		}
 	default: // KindBin
 		return []string{
 			filepath.Join(dir, "osty.toml"),
@@ -399,6 +419,22 @@ func writeLayout(tx *writeTx, dir string, opts Options) *diag.Diagnostic {
 			{filepath.Join(dir, "main.osty"), serviceMainTemplate},
 			{filepath.Join(dir, "routes.osty"), serviceRoutesTemplate},
 			{filepath.Join(dir, "routes_test.osty"), serviceRoutesTestTemplate},
+			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
+		})
+	case KindGUIQtQuick:
+		uiDir := filepath.Join(dir, "ui")
+		assetsDir := filepath.Join(dir, "assets")
+		if err := tx.mkdir(uiDir); err != nil {
+			return ioErr(uiDir, err)
+		}
+		if err := tx.mkdir(assetsDir); err != nil {
+			return ioErr(assetsDir, err)
+		}
+		return tx.writeFiles([]fileSpec{
+			{filepath.Join(dir, "osty.toml"), renderGUIQtQuickManifest(opts.Name, edition)},
+			{filepath.Join(dir, "main.osty"), guiQtQuickMainTemplate},
+			{filepath.Join(uiDir, "main.qml"), guiQtQuickQMLTemplate},
+			{filepath.Join(dir, "README.md"), renderGUIQtQuickReadme(opts.Name)},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
 		})
 	default: // KindBin
@@ -508,6 +544,8 @@ func RenderSource(k Kind) string {
 		return cliMainTemplate
 	case KindService:
 		return serviceMainTemplate
+	case KindGUIQtQuick:
+		return guiQtQuickMainTemplate
 	default:
 		return binSourceTemplate
 	}
@@ -526,6 +564,8 @@ func RenderTestSource(k Kind) string {
 		return cliAppTestTemplate
 	case KindService:
 		return serviceRoutesTestTemplate
+	case KindGUIQtQuick:
+		return ""
 	default:
 		return binTestTemplate
 	}
@@ -546,6 +586,8 @@ func renderManifest(name, edition string, k Kind) string {
 		header = "# CLI app project; main.osty splits parsed Args from the testable run() core."
 	case KindService:
 		header = "# HTTP service project; main.osty defines Request/Response and a handle() core."
+	case KindGUIQtQuick:
+		header = "# Qt Quick GUI app project; main.osty owns state/events and ui/main.qml owns layout."
 	}
 	return fmt.Sprintf(`%s
 
@@ -558,6 +600,51 @@ edition = "%s"
 # Add dependencies here, for example:
 # json-ext = { path = "../json-ext" }
 `, header, name, edition)
+}
+
+func renderGUIQtQuickManifest(name, edition string) string {
+	return fmt.Sprintf(`# Qt Quick GUI app project; build libosty_qt and make it visible to the linker/runtime.
+
+[package]
+name = "%s"
+version = "0.1.0"
+edition = "%s"
+
+[dependencies]
+
+[gui]
+backend = "qtquick"
+entry = "ui/main.qml"
+
+[target.arm64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-darwin]
+link = ["osty_qt"]
+
+[target.amd64-linux]
+link = ["osty_qt"]
+
+[target.amd64-windows]
+link = ["osty_qt"]
+`, name, edition)
+}
+
+func renderGUIQtQuickReadme(name string) string {
+	return fmt.Sprintf(`# %s
+
+This app uses `+"`std.gui`"+` with the Qt Quick/QML backend.
+
+Build the bridge from the Osty repository root:
+
+`+"```sh"+`
+cmake -S libosty_qt -B .osty/qt-build
+cmake --build .osty/qt-build
+`+"```"+`
+
+Then make the produced library visible to your platform linker/runtime and run
+the app with `+"`osty run`"+`.
+`, name)
 }
 
 func renderWorkspaceManifest(name, edition, member string) string {
@@ -840,6 +927,101 @@ fn testDispatchFallsThroughTo404() {
     let req = Request { method: "GET", path: "/missing" }
     let res = dispatch(req)
     let _ = res.status
+}
+`
+
+const guiQtQuickMainTemplate = `use std.gui.qtquick as gui
+use std.json
+
+pub struct GuiState {
+    pub status: String,
+    pub count: Int,
+    pub logs: List<String>,
+}
+
+fn main() {
+    match run() {
+        Ok(_) -> {},
+        Err(err) -> eprintln("gui app: {err.message()}"),
+    }
+}
+
+fn run() -> Result<(), Error> {
+    let app = gui.app("Osty GUI")?
+    let window = app.window(gui.windowOptions("Osty GUI", 900, 620, "ui/main.qml"))?
+
+    app.setState(readyState())?
+    window.show()?
+
+    for app.poll() {
+        for event in app.events() {
+            if event.name == "click" {
+                app.setState(clickedState(event.payload))?
+            } else if event.name == "quit" {
+                let _ = app.quit()
+            }
+        }
+    }
+
+    app.close()
+    Ok(())
+}
+
+fn readyState() -> String {
+    json.encode(GuiState {
+        status: "ready",
+        count: 0,
+        logs: ["app started"],
+    })
+}
+
+fn clickedState(payload: String) -> String {
+    json.encode(GuiState {
+        status: "clicked",
+        count: 1,
+        logs: ["button clicked", "payload: {payload}"],
+    })
+}
+`
+
+const guiQtQuickQMLTemplate = `import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    visible: true
+    width: 900
+    height: 620
+    title: "Osty GUI"
+
+    readonly property var state: osty.appState || ({})
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 24
+        spacing: 12
+
+        Label {
+            text: state.status || "ready"
+            font.pixelSize: 24
+            font.bold: true
+        }
+
+        Button {
+            text: "Run"
+            onClicked: osty.emit("click", { source: "main.qml" })
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: state.logs || []
+            delegate: Label {
+                width: ListView.view.width
+                text: modelData
+            }
+        }
+    }
 }
 `
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,40 @@ func TestInitHappyPath(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(parent, f)); err != nil {
 			t.Errorf("expected %s to exist: %v", f, err)
 		}
+	}
+}
+
+func TestCreateGUIQtQuickLayout(t *testing.T) {
+	parent := t.TempDir()
+	path, d := Create(Options{Parent: parent, Name: "desk", Kind: KindGUIQtQuick})
+	if d != nil {
+		t.Fatalf("Create returned diagnostic: %v", d)
+	}
+	for _, f := range []string{"osty.toml", "main.osty", "ui/main.qml", "README.md", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(path, f)); err != nil {
+			t.Errorf("expected %s to exist: %v", f, err)
+		}
+	}
+	if info, err := os.Stat(filepath.Join(path, "assets")); err != nil {
+		t.Errorf("expected assets dir to exist: %v", err)
+	} else if !info.IsDir() {
+		t.Errorf("assets is not a directory")
+	}
+	manifest, err := os.ReadFile(filepath.Join(path, "osty.toml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	for _, want := range []string{`[gui]`, `backend = "qtquick"`, `link = ["osty_qt"]`} {
+		if !strings.Contains(string(manifest), want) {
+			t.Fatalf("manifest missing %q:\n%s", want, manifest)
+		}
+	}
+	mainSrc, err := os.ReadFile(filepath.Join(path, "main.osty"))
+	if err != nil {
+		t.Fatalf("read main.osty: %v", err)
+	}
+	if !strings.Contains(string(mainSrc), "use std.gui") {
+		t.Fatalf("main.osty missing std.gui import:\n%s", mainSrc)
 	}
 }
 

--- a/internal/stdlib/gui_test.go
+++ b/internal/stdlib/gui_test.go
@@ -208,6 +208,38 @@ func TestGuiModuleImportSurfaceIncludesRenderers(t *testing.T) {
 	}
 }
 
+func TestGuiQtQuickModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["gui.qtquick"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		t.Fatalf("std.gui.qtquick not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
+	}
+	for _, name := range []string{"App", "Window", "WindowOptions", "Event", "RuntimeInfo"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.gui.qtquick missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.gui.qtquick.%s not public", name)
+		}
+	}
+	for _, name := range []string{"app", "windowOptions", "runtimeInfo", "abiVersion", "available", "lastError"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.gui.qtquick missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.gui.qtquick.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.gui.qtquick.%s not public", name)
+		}
+	}
+	if fn := reg.LookupMethodDecl("gui.qtquick", "App", "events"); fn == nil {
+		t.Fatalf("LookupMethodDecl(gui.qtquick, App, events) = nil, want event polling surface")
+	}
+}
+
 func guiModuleSource(t *testing.T) string {
 	t.Helper()
 	reg := LoadCached()

--- a/internal/stdlib/modules/gui/qtquick.osty
+++ b/internal/stdlib/modules/gui/qtquick.osty
@@ -1,0 +1,183 @@
+// std.gui.qtquick — Qt Quick/QML app backend.
+//
+// The backend keeps Qt object pointers hidden behind process-local handles and
+// routes QML callbacks through a pollable event queue. The retained,
+// backend-neutral GUI primitives stay in std.gui; this module owns the native
+// Qt Quick spike surface.
+
+use std.error
+use c "osty_qt" as qt {
+    fn osty_qt_abi_version() -> String
+    fn osty_qt_has_qt() -> Bool
+    fn osty_qt_last_error() -> String
+    fn osty_qt_app_new(name: String) -> Int
+    fn osty_qt_app_free(app: Int)
+    fn osty_qt_app_run(app: Int) -> Int
+    fn osty_qt_app_poll(app: Int) -> Bool
+    fn osty_qt_app_quit(app: Int)
+    fn osty_qt_app_set_state_json(app: Int, stateJson: String) -> Bool
+    fn osty_qt_window_new(app: Int, title: String, width: Int, height: Int, qml: String) -> Int
+    fn osty_qt_window_show(window: Int) -> Bool
+    fn osty_qt_window_close(window: Int)
+    fn osty_qt_window_set_title(window: Int, title: String) -> Bool
+    fn osty_qt_window_set_state_json(window: Int, stateJson: String) -> Bool
+    fn osty_qt_event_count(app: Int) -> Int
+    fn osty_qt_event_name(app: Int, index: Int) -> String
+    fn osty_qt_event_payload(app: Int, index: Int) -> String
+    fn osty_qt_event_clear(app: Int)
+}
+
+pub struct App {
+    handle: Int,
+
+    pub fn window(self, options: WindowOptions) -> Result<Window, Error> {
+        if options.width <= 0 || options.height <= 0 {
+            return Err(error.new("gui.qtquick: window width and height must be positive"))
+        }
+        let window = qt.osty_qt_window_new(self.handle, options.title, options.width, options.height, options.qml)
+        if window == 0 {
+            return Err(backendError())
+        }
+        Ok(Window { handle: window })
+    }
+
+    pub fn setState(self, stateJson: String) -> Result<(), Error> {
+        if qt.osty_qt_app_set_state_json(self.handle, stateJson) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
+    pub fn poll(self) -> Bool {
+        qt.osty_qt_app_poll(self.handle)
+    }
+
+    pub fn events(self) -> List<Event> {
+        let n = qt.osty_qt_event_count(self.handle)
+        let mut out: List<Event> = []
+        for i in 0..n {
+            out.push(Event {
+                name: qt.osty_qt_event_name(self.handle, i),
+                payload: qt.osty_qt_event_payload(self.handle, i),
+            })
+        }
+        qt.osty_qt_event_clear(self.handle)
+        out
+    }
+
+    pub fn quit(self) {
+        qt.osty_qt_app_quit(self.handle)
+        return
+    }
+
+    pub fn run(self) -> Result<Int, Error> {
+        let code = qt.osty_qt_app_run(self.handle)
+        if code < 0 {
+            return Err(backendError())
+        }
+        Ok(code)
+    }
+
+    pub fn close(self) {
+        qt.osty_qt_app_free(self.handle)
+        return
+    }
+}
+
+pub struct Window {
+    handle: Int,
+
+    pub fn show(self) -> Result<(), Error> {
+        if qt.osty_qt_window_show(self.handle) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
+    pub fn setTitle(self, title: String) -> Result<(), Error> {
+        if qt.osty_qt_window_set_title(self.handle, title) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
+    pub fn setState(self, stateJson: String) -> Result<(), Error> {
+        if qt.osty_qt_window_set_state_json(self.handle, stateJson) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
+    pub fn close(self) {
+        qt.osty_qt_window_close(self.handle)
+        return
+    }
+}
+
+pub struct WindowOptions {
+    pub title: String,
+    pub width: Int,
+    pub height: Int,
+    pub qml: String,
+}
+
+pub struct Event {
+    pub name: String,
+    pub payload: String,
+}
+
+pub fn windowOptions(title: String, width: Int, height: Int, qml: String) -> WindowOptions {
+    WindowOptions {
+        title: title,
+        width: width,
+        height: height,
+        qml: qml,
+    }
+}
+
+pub struct RuntimeInfo {
+    pub abiVersion: String,
+    pub available: Bool,
+    pub lastError: String,
+}
+
+pub fn runtimeInfo() -> RuntimeInfo {
+    RuntimeInfo {
+        abiVersion: qt.osty_qt_abi_version(),
+        available: qt.osty_qt_has_qt(),
+        lastError: qt.osty_qt_last_error(),
+    }
+}
+
+pub fn abiVersion() -> String {
+    qt.osty_qt_abi_version()
+}
+
+pub fn available() -> Bool {
+    qt.osty_qt_has_qt()
+}
+
+pub fn lastError() -> String {
+    qt.osty_qt_last_error()
+}
+
+pub fn app(name: String) -> Result<App, Error> {
+    let handle = qt.osty_qt_app_new(name)
+    if handle == 0 {
+        return Err(backendError())
+    }
+    Ok(App { handle })
+}
+
+fn backendError() -> Error {
+    let msg = qt.osty_qt_last_error()
+    if msg == "" {
+        error.new("gui.qtquick: Qt backend failed without a diagnostic")
+    } else {
+        error.new(msg)
+    }
+}

--- a/libosty_qt/CMakeLists.txt
+++ b/libosty_qt/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(osty_qt LANGUAGES CXX)
+
+option(OSTY_QT_ENABLE_QT "Build libosty_qt against Qt Quick/QML" ON)
+
+add_library(osty_qt SHARED src/osty_qt.cpp)
+target_include_directories(osty_qt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_compile_features(osty_qt PRIVATE cxx_std_17)
+target_compile_definitions(osty_qt PRIVATE OSTY_QT_BUILD_SHARED)
+
+if(OSTY_QT_ENABLE_QT)
+  find_package(Qt6 QUIET COMPONENTS Gui Qml Quick)
+  if(Qt6_FOUND)
+    set_target_properties(osty_qt PROPERTIES AUTOMOC ON)
+    target_compile_definitions(osty_qt PRIVATE OSTY_QT_ENABLE_QT=1)
+    target_link_libraries(osty_qt PRIVATE Qt6::Gui Qt6::Qml Qt6::Quick)
+  else()
+    find_package(Qt5 QUIET COMPONENTS Gui Qml Quick)
+    if(Qt5_FOUND)
+      set_target_properties(osty_qt PROPERTIES AUTOMOC ON)
+      target_compile_definitions(osty_qt PRIVATE OSTY_QT_ENABLE_QT=1)
+      target_link_libraries(osty_qt PRIVATE Qt5::Gui Qt5::Qml Qt5::Quick)
+    else()
+      message(FATAL_ERROR "Qt Quick/QML not found. Install Qt or configure with -DOSTY_QT_ENABLE_QT=OFF for diagnostic-only stubs.")
+    endif()
+  endif()
+endif()

--- a/libosty_qt/README.md
+++ b/libosty_qt/README.md
@@ -1,0 +1,33 @@
+# libosty_qt
+
+`libosty_qt` is the first Qt Quick/QML bridge for Osty GUI experiments. It
+keeps Qt's C++ object model behind a small C ABI so Osty code can use
+`use c "osty_qt"` without exposing Qt pointers or callbacks.
+
+## Build
+
+```sh
+cmake -S libosty_qt -B .osty/qt-build
+cmake --build .osty/qt-build
+```
+
+For machines without Qt, the library can be built in diagnostic-only mode:
+
+```sh
+cmake -S libosty_qt -B .osty/qt-build -DOSTY_QT_ENABLE_QT=OFF
+cmake --build .osty/qt-build
+```
+
+That stub build exports the same symbols, but `osty_qt_app_new` fails with a
+clear error saying Qt support was not compiled in.
+
+## String Boundary
+
+The ABI receives Osty `String` values as the native runtime string pointer, not
+as a generic C-owned `char *`. The shim decodes Osty's current inline
+small-string tag before passing UTF-8 to Qt. Returned strings are stable
+NUL-terminated bridge strings and stay valid until the app handle is freed.
+
+This is good enough for the spike, but the durable runtime shape should expose a
+small public string helper API so external shims do not duplicate runtime string
+layout details.

--- a/libosty_qt/include/osty_qt.h
+++ b/libosty_qt/include/osty_qt.h
@@ -1,0 +1,59 @@
+#ifndef OSTY_QT_H
+#define OSTY_QT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#  if defined(OSTY_QT_BUILD_SHARED)
+#    define OSTY_QT_API __declspec(dllexport)
+#  elif defined(OSTY_QT_USE_SHARED)
+#    define OSTY_QT_API __declspec(dllimport)
+#  else
+#    define OSTY_QT_API
+#  endif
+#else
+#  define OSTY_QT_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int64_t osty_qt_handle;
+typedef const char *osty_qt_string;
+
+OSTY_QT_API osty_qt_string osty_qt_abi_version(void);
+OSTY_QT_API bool osty_qt_has_qt(void);
+OSTY_QT_API osty_qt_string osty_qt_last_error(void);
+
+OSTY_QT_API osty_qt_handle osty_qt_app_new(osty_qt_string name);
+OSTY_QT_API void osty_qt_app_free(osty_qt_handle app);
+OSTY_QT_API int64_t osty_qt_app_run(osty_qt_handle app);
+OSTY_QT_API bool osty_qt_app_poll(osty_qt_handle app);
+OSTY_QT_API void osty_qt_app_quit(osty_qt_handle app);
+OSTY_QT_API bool osty_qt_app_set_state_json(osty_qt_handle app, osty_qt_string state_json);
+OSTY_QT_API bool osty_qt_app_add_import_path(osty_qt_handle app, osty_qt_string path);
+
+OSTY_QT_API osty_qt_handle osty_qt_window_new(
+    osty_qt_handle app,
+    osty_qt_string title,
+    int64_t width,
+    int64_t height,
+    osty_qt_string qml_path);
+OSTY_QT_API bool osty_qt_window_show(osty_qt_handle window);
+OSTY_QT_API void osty_qt_window_close(osty_qt_handle window);
+OSTY_QT_API bool osty_qt_window_set_title(osty_qt_handle window, osty_qt_string title);
+OSTY_QT_API bool osty_qt_window_set_state_json(osty_qt_handle window, osty_qt_string state_json);
+OSTY_QT_API bool osty_qt_window_reload(osty_qt_handle window);
+
+OSTY_QT_API int64_t osty_qt_event_count(osty_qt_handle app);
+OSTY_QT_API osty_qt_string osty_qt_event_name(osty_qt_handle app, int64_t index);
+OSTY_QT_API osty_qt_string osty_qt_event_payload(osty_qt_handle app, int64_t index);
+OSTY_QT_API void osty_qt_event_clear(osty_qt_handle app);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libosty_qt/src/osty_qt.cpp
+++ b/libosty_qt/src/osty_qt.cpp
@@ -1,0 +1,671 @@
+#include "osty_qt.h"
+
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#if defined(OSTY_QT_ENABLE_QT)
+#  include <QCoreApplication>
+#  include <QEventLoop>
+#  include <QFileInfo>
+#  include <QGuiApplication>
+#  include <QJsonDocument>
+#  include <QJsonObject>
+#  include <QJsonParseError>
+#  include <QJsonValue>
+#  include <QQmlApplicationEngine>
+#  include <QQmlContext>
+#  include <QString>
+#  include <QUrl>
+#  include <QVariant>
+#  include <QWindow>
+#  ifdef emit
+#    undef emit
+#  endif
+#endif
+
+namespace {
+
+constexpr const char *kABIVersion = "osty_qt/0.1";
+
+thread_local std::string g_last_error;
+
+void set_error(std::string message) {
+    g_last_error = std::move(message);
+}
+
+void clear_error() {
+    g_last_error.clear();
+}
+
+bool osty_string_is_inline(const char *value) {
+    if (value == nullptr) {
+        return false;
+    }
+    if (std::numeric_limits<uintptr_t>::digits < 64) {
+        return false;
+    }
+    return (reinterpret_cast<uintptr_t>(value) & (uintptr_t{1} << 63)) != 0;
+}
+
+std::string osty_string_to_utf8(const char *value) {
+    if (value == nullptr) {
+        return {};
+    }
+    if (!osty_string_is_inline(value)) {
+        return std::string(value);
+    }
+    uintptr_t packed = reinterpret_cast<uintptr_t>(value);
+    size_t len = (packed >> 56) & 0x7;
+    std::string out;
+    out.resize(len);
+    for (size_t i = 0; i < len; ++i) {
+        out[i] = static_cast<char>((packed >> (i * 8)) & 0xff);
+    }
+    return out;
+}
+
+struct Event {
+    std::string name;
+    std::string payload;
+};
+
+struct App {
+    std::string name;
+    std::string state_json = "{}";
+    bool quitting = false;
+    std::vector<Event> events;
+    std::vector<std::string> import_paths;
+    std::vector<osty_qt_handle> windows;
+    std::deque<std::string> exported_strings;
+};
+
+struct Window {
+    osty_qt_handle app = 0;
+    std::string title;
+    int64_t width = 0;
+    int64_t height = 0;
+    std::string qml_path;
+#if defined(OSTY_QT_ENABLE_QT)
+    std::unique_ptr<QQmlApplicationEngine> engine;
+    QObject *root = nullptr;
+    QWindow *qwindow = nullptr;
+    QObject *bridge = nullptr;
+#endif
+};
+
+std::mutex g_mu;
+osty_qt_handle g_next_handle = 1;
+std::unordered_map<osty_qt_handle, std::unique_ptr<App>> g_apps;
+std::unordered_map<osty_qt_handle, std::unique_ptr<Window>> g_windows;
+
+osty_qt_handle next_handle() {
+    return g_next_handle++;
+}
+
+const char *export_app_string(App *app, std::string value) {
+    if (app == nullptr) {
+        return "";
+    }
+    app->exported_strings.push_back(std::move(value));
+    return app->exported_strings.back().c_str();
+}
+
+App *lookup_app_locked(osty_qt_handle handle) {
+    auto it = g_apps.find(handle);
+    if (it == g_apps.end()) {
+        set_error("osty_qt: invalid app handle");
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+Window *lookup_window_locked(osty_qt_handle handle) {
+    auto it = g_windows.find(handle);
+    if (it == g_windows.end()) {
+        set_error("osty_qt: invalid window handle");
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+void enqueue_event(osty_qt_handle app_handle, std::string name, std::string payload) {
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *app = lookup_app_locked(app_handle);
+    if (app == nullptr) {
+        return;
+    }
+    app->events.push_back(Event{std::move(name), std::move(payload)});
+}
+
+#if defined(OSTY_QT_ENABLE_QT)
+
+int g_qt_argc = 1;
+char g_qt_arg0[] = "osty";
+char *g_qt_argv[] = {g_qt_arg0, nullptr};
+std::unique_ptr<QGuiApplication> g_qt_app;
+
+QGuiApplication *ensure_qt_app(const std::string &name) {
+    if (QGuiApplication::instance() != nullptr) {
+        QCoreApplication::setApplicationName(QString::fromUtf8(name.data(), int(name.size())));
+        return qobject_cast<QGuiApplication *>(QGuiApplication::instance());
+    }
+    g_qt_app = std::make_unique<QGuiApplication>(g_qt_argc, g_qt_argv);
+    QCoreApplication::setApplicationName(QString::fromUtf8(name.data(), int(name.size())));
+    return g_qt_app.get();
+}
+
+QString to_qstring(const std::string &value) {
+    return QString::fromUtf8(value.data(), int(value.size()));
+}
+
+QUrl qml_url(const std::string &path) {
+    QString qpath = to_qstring(path);
+    if (qpath.startsWith(QStringLiteral("qrc:")) ||
+        qpath.startsWith(QStringLiteral(":/")) ||
+        qpath.startsWith(QStringLiteral("file:"))) {
+        return QUrl(qpath);
+    }
+    return QUrl::fromLocalFile(QFileInfo(qpath).absoluteFilePath());
+}
+
+QVariant json_to_variant(const std::string &json, bool *ok = nullptr) {
+    QJsonParseError parse_error;
+    QJsonDocument doc = QJsonDocument::fromJson(QByteArray(json.data(), int(json.size())), &parse_error);
+    if (parse_error.error != QJsonParseError::NoError || doc.isNull()) {
+        if (ok != nullptr) {
+            *ok = false;
+        }
+        return QVariantMap{};
+    }
+    if (ok != nullptr) {
+        *ok = true;
+    }
+    return doc.toVariant();
+}
+
+std::string variant_to_json(const QVariant &payload) {
+    QJsonValue value = QJsonValue::fromVariant(payload);
+    QJsonDocument doc;
+    if (value.isObject()) {
+        doc.setObject(value.toObject());
+    } else if (value.isArray()) {
+        doc.setArray(value.toArray());
+    } else if (value.isUndefined() || value.isNull()) {
+        doc.setObject(QJsonObject{});
+    } else {
+        doc.setObject(QJsonObject{{QStringLiteral("value"), value}});
+    }
+    QByteArray out = doc.toJson(QJsonDocument::Compact);
+    return std::string(out.constData(), size_t(out.size()));
+}
+
+class OstyBridge : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QVariant appState READ appState NOTIFY appStateChanged)
+
+public:
+    OstyBridge(osty_qt_handle app_handle, QObject *parent = nullptr)
+        : QObject(parent), app_handle_(app_handle) {}
+
+    QVariant appState() const {
+        return state_;
+    }
+
+    void setState(QVariant state) {
+        state_ = std::move(state);
+        Q_EMIT appStateChanged();
+    }
+
+    Q_INVOKABLE void emit(const QString &name, const QVariant &payload = QVariant()) {
+        enqueue_event(app_handle_, name.toStdString(), variant_to_json(payload));
+    }
+
+Q_SIGNALS:
+    void appStateChanged();
+
+private:
+    osty_qt_handle app_handle_;
+    QVariant state_;
+};
+
+bool apply_state(Window *window, const std::string &state_json) {
+    if (window == nullptr || window->engine == nullptr || window->bridge == nullptr) {
+        set_error("osty_qt: window is not loaded");
+        return false;
+    }
+    bool ok = false;
+    QVariant state = json_to_variant(state_json, &ok);
+    if (!ok) {
+        set_error("osty_qt: state is not valid JSON");
+        return false;
+    }
+    auto *bridge = qobject_cast<OstyBridge *>(window->bridge);
+    if (bridge != nullptr) {
+        bridge->setState(state);
+    }
+    window->engine->rootContext()->setContextProperty(QStringLiteral("appState"), state);
+    return true;
+}
+
+bool load_window(Window *window) {
+    if (window == nullptr) {
+        set_error("osty_qt: nil window");
+        return false;
+    }
+    App *app = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        app = lookup_app_locked(window->app);
+        if (app == nullptr) {
+            return false;
+        }
+    }
+
+    window->engine = std::make_unique<QQmlApplicationEngine>();
+    window->root = nullptr;
+    window->qwindow = nullptr;
+    auto *bridge = new OstyBridge(window->app, window->engine.get());
+    window->bridge = bridge;
+    bool state_ok = false;
+    QVariant state = json_to_variant(app->state_json, &state_ok);
+    if (!state_ok) {
+        set_error("osty_qt: app state is not valid JSON");
+        return false;
+    }
+    bridge->setState(state);
+    window->engine->rootContext()->setContextProperty(QStringLiteral("osty"), bridge);
+    window->engine->rootContext()->setContextProperty(QStringLiteral("appState"), state);
+    for (const auto &path : app->import_paths) {
+        window->engine->addImportPath(to_qstring(path));
+    }
+    window->engine->load(qml_url(window->qml_path));
+    if (window->engine->rootObjects().isEmpty()) {
+        set_error("osty_qt: QML load failed: " + window->qml_path);
+        return false;
+    }
+    window->root = window->engine->rootObjects().first();
+    window->qwindow = qobject_cast<QWindow *>(window->root);
+    if (window->qwindow != nullptr) {
+        window->qwindow->setTitle(to_qstring(window->title));
+        if (window->width > 0) {
+            window->qwindow->setWidth(int(window->width));
+        }
+        if (window->height > 0) {
+            window->qwindow->setHeight(int(window->height));
+        }
+    }
+    return true;
+}
+
+#else
+
+bool ensure_stub_error() {
+    set_error("osty_qt: libosty_qt was built without Qt support; rebuild with OSTY_QT_ENABLE_QT=ON and Qt Quick/QML installed");
+    return false;
+}
+
+#endif
+
+} // namespace
+
+extern "C" {
+
+osty_qt_string osty_qt_abi_version(void) {
+    return kABIVersion;
+}
+
+bool osty_qt_has_qt(void) {
+#if defined(OSTY_QT_ENABLE_QT)
+    return true;
+#else
+    return false;
+#endif
+}
+
+osty_qt_string osty_qt_last_error(void) {
+    return g_last_error.empty() ? "" : g_last_error.c_str();
+}
+
+osty_qt_handle osty_qt_app_new(osty_qt_string name) {
+    clear_error();
+    std::string app_name = osty_string_to_utf8(name);
+    if (app_name.empty()) {
+        app_name = "Osty";
+    }
+#if defined(OSTY_QT_ENABLE_QT)
+    if (ensure_qt_app(app_name) == nullptr) {
+        set_error("osty_qt: failed to initialize QGuiApplication");
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(g_mu);
+    osty_qt_handle handle = next_handle();
+    auto app = std::make_unique<App>();
+    app->name = app_name;
+    g_apps.emplace(handle, std::move(app));
+    return handle;
+#else
+    (void)app_name;
+    ensure_stub_error();
+    return 0;
+#endif
+}
+
+void osty_qt_app_free(osty_qt_handle app) {
+    std::lock_guard<std::mutex> lock(g_mu);
+    auto it = g_apps.find(app);
+    if (it == g_apps.end()) {
+        return;
+    }
+    for (osty_qt_handle window_handle : it->second->windows) {
+        g_windows.erase(window_handle);
+    }
+    g_apps.erase(it);
+}
+
+int64_t osty_qt_app_run(osty_qt_handle app) {
+    clear_error();
+#if defined(OSTY_QT_ENABLE_QT)
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        if (lookup_app_locked(app) == nullptr) {
+            return -1;
+        }
+    }
+    return QCoreApplication::exec();
+#else
+    (void)app;
+    ensure_stub_error();
+    return -1;
+#endif
+}
+
+bool osty_qt_app_poll(osty_qt_handle app) {
+    clear_error();
+#if defined(OSTY_QT_ENABLE_QT)
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        App *found = lookup_app_locked(app);
+        if (found == nullptr) {
+            return false;
+        }
+        if (found->quitting) {
+            return false;
+        }
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 0);
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    return found != nullptr && !found->quitting;
+#else
+    (void)app;
+    ensure_stub_error();
+    return false;
+#endif
+}
+
+void osty_qt_app_quit(osty_qt_handle app) {
+    clear_error();
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        App *found = lookup_app_locked(app);
+        if (found == nullptr) {
+            return;
+        }
+        found->quitting = true;
+    }
+#if defined(OSTY_QT_ENABLE_QT)
+    QCoreApplication::quit();
+#endif
+}
+
+bool osty_qt_app_set_state_json(osty_qt_handle app, osty_qt_string state_json) {
+    clear_error();
+    std::string state = osty_string_to_utf8(state_json);
+    std::vector<osty_qt_handle> windows;
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        App *found = lookup_app_locked(app);
+        if (found == nullptr) {
+            return false;
+        }
+        found->state_json = state;
+        windows = found->windows;
+    }
+#if defined(OSTY_QT_ENABLE_QT)
+    for (osty_qt_handle window_handle : windows) {
+        Window *window = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(g_mu);
+            window = lookup_window_locked(window_handle);
+        }
+        if (window != nullptr && !apply_state(window, state)) {
+            return false;
+        }
+    }
+    return true;
+#else
+    return ensure_stub_error();
+#endif
+}
+
+bool osty_qt_app_add_import_path(osty_qt_handle app, osty_qt_string path) {
+    clear_error();
+    std::string import_path = osty_string_to_utf8(path);
+    if (import_path.empty()) {
+        set_error("osty_qt: import path is empty");
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found == nullptr) {
+        return false;
+    }
+    found->import_paths.push_back(std::move(import_path));
+    return true;
+}
+
+osty_qt_handle osty_qt_window_new(
+    osty_qt_handle app,
+    osty_qt_string title,
+    int64_t width,
+    int64_t height,
+    osty_qt_string qml_path) {
+    clear_error();
+    if (width <= 0 || height <= 0) {
+        set_error("osty_qt: window size must be positive");
+        return 0;
+    }
+    std::string title_utf8 = osty_string_to_utf8(title);
+    std::string qml_utf8 = osty_string_to_utf8(qml_path);
+    if (qml_utf8.empty()) {
+        set_error("osty_qt: QML path is empty");
+        return 0;
+    }
+#if defined(OSTY_QT_ENABLE_QT)
+    auto window = std::make_unique<Window>();
+    window->app = app;
+    window->title = title_utf8;
+    window->width = width;
+    window->height = height;
+    window->qml_path = qml_utf8;
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        if (lookup_app_locked(app) == nullptr) {
+            return 0;
+        }
+    }
+    if (!load_window(window.get())) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found == nullptr) {
+        return 0;
+    }
+    osty_qt_handle handle = next_handle();
+    found->windows.push_back(handle);
+    g_windows.emplace(handle, std::move(window));
+    return handle;
+#else
+    (void)app;
+    (void)title_utf8;
+    (void)qml_utf8;
+    return ensure_stub_error() ? 0 : 0;
+#endif
+}
+
+bool osty_qt_window_show(osty_qt_handle window) {
+    clear_error();
+#if defined(OSTY_QT_ENABLE_QT)
+    std::lock_guard<std::mutex> lock(g_mu);
+    Window *found = lookup_window_locked(window);
+    if (found == nullptr) {
+        return false;
+    }
+    if (found->qwindow != nullptr) {
+        found->qwindow->show();
+        return true;
+    }
+    if (found->root != nullptr) {
+        found->root->setProperty("visible", true);
+        return true;
+    }
+    set_error("osty_qt: QML root object is not showable");
+    return false;
+#else
+    (void)window;
+    return ensure_stub_error();
+#endif
+}
+
+void osty_qt_window_close(osty_qt_handle window) {
+    clear_error();
+#if defined(OSTY_QT_ENABLE_QT)
+    std::lock_guard<std::mutex> lock(g_mu);
+    Window *found = lookup_window_locked(window);
+    if (found != nullptr && found->qwindow != nullptr) {
+        found->qwindow->close();
+    }
+#else
+    (void)window;
+#endif
+}
+
+bool osty_qt_window_set_title(osty_qt_handle window, osty_qt_string title) {
+    clear_error();
+    std::string title_utf8 = osty_string_to_utf8(title);
+#if defined(OSTY_QT_ENABLE_QT)
+    std::lock_guard<std::mutex> lock(g_mu);
+    Window *found = lookup_window_locked(window);
+    if (found == nullptr) {
+        return false;
+    }
+    found->title = title_utf8;
+    if (found->qwindow != nullptr) {
+        found->qwindow->setTitle(to_qstring(title_utf8));
+    } else if (found->root != nullptr) {
+        found->root->setProperty("title", to_qstring(title_utf8));
+    }
+    return true;
+#else
+    (void)window;
+    (void)title_utf8;
+    return ensure_stub_error();
+#endif
+}
+
+bool osty_qt_window_set_state_json(osty_qt_handle window, osty_qt_string state_json) {
+    clear_error();
+    std::string state = osty_string_to_utf8(state_json);
+#if defined(OSTY_QT_ENABLE_QT)
+    Window *found = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        found = lookup_window_locked(window);
+    }
+    return found != nullptr && apply_state(found, state);
+#else
+    (void)window;
+    (void)state;
+    return ensure_stub_error();
+#endif
+}
+
+bool osty_qt_window_reload(osty_qt_handle window) {
+    clear_error();
+#if defined(OSTY_QT_ENABLE_QT)
+    Window *found = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mu);
+        found = lookup_window_locked(window);
+    }
+    if (found == nullptr) {
+        return false;
+    }
+    return load_window(found);
+#else
+    (void)window;
+    return ensure_stub_error();
+#endif
+}
+
+int64_t osty_qt_event_count(osty_qt_handle app) {
+    clear_error();
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found == nullptr) {
+        return 0;
+    }
+    return int64_t(found->events.size());
+}
+
+osty_qt_string osty_qt_event_name(osty_qt_handle app, int64_t index) {
+    clear_error();
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found == nullptr) {
+        return "";
+    }
+    if (index < 0 || index >= int64_t(found->events.size())) {
+        set_error("osty_qt: event index out of range");
+        return "";
+    }
+    return export_app_string(found, found->events[size_t(index)].name);
+}
+
+osty_qt_string osty_qt_event_payload(osty_qt_handle app, int64_t index) {
+    clear_error();
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found == nullptr) {
+        return "";
+    }
+    if (index < 0 || index >= int64_t(found->events.size())) {
+        set_error("osty_qt: event index out of range");
+        return "";
+    }
+    return export_app_string(found, found->events[size_t(index)].payload);
+}
+
+void osty_qt_event_clear(osty_qt_handle app) {
+    clear_error();
+    std::lock_guard<std::mutex> lock(g_mu);
+    App *found = lookup_app_locked(app);
+    if (found != nullptr) {
+        found->events.clear();
+    }
+}
+
+}
+
+#if defined(OSTY_QT_ENABLE_QT)
+#  include "osty_qt.moc"
+#endif


### PR DESCRIPTION
## Summary

- Add `libosty_qt`, a small C ABI bridge for Qt Quick/QML with diagnostic-only stubs when Qt is unavailable.
- Add `std.gui.qtquick` as the native Qt Quick app backend surface on top of the existing backend-neutral `std.gui` retained GUI core.
- Add `osty new --gui qtquick` scaffolding plus direct spike and `gui-inspector` demo examples.

## Validation

- `go test -count=1 -vet=off ./internal/stdlib ./internal/scaffold ./internal/llvmgen -run 'TestGuiModuleSurface|TestGuiQtQuickModuleSurface|TestStdlibSupportMatrix|TestCreateGUIQtQuickLayout|TestGenerateUseCOstyQtSpikeSurface'`
- `go run ./cmd/osty check examples/gui-inspector`
- `go run ./cmd/osty check examples/qtquick-spike`
- `clang++ -std=c++17 -Ilibosty_qt/include -c libosty_qt/src/osty_qt.cpp -o /tmp/osty_qt_stub.o`

Note: `cmake` is not installed on this machine, so the Qt CMake build path was not run locally.