### PR TITLE
[codex] Add ONB phase 1 println backend

### DIFF
--- a/MIR_EMITTER_PORT.md
+++ b/MIR_EMITTER_PORT.md
@@ -61,6 +61,30 @@ document is the shared landing target: any perf / correctness change
 to the MIR emitter should ship alongside (or instead of) the Osty
 counterpart here.
 
+## Relationship to ONB
+
+This document is **not** the ONB implementation plan. It tracks the
+self-hosting of the existing LLVM MIR emitter: LLVM text builders,
+support checks, instruction/intrinsic routing, and the Go glue that still
+delegates to `internal/llvmgen/mir_generator.go`.
+
+[`ONB_DESIGN.md`](./ONB_DESIGN.md) is the source of truth for the LLVM
+complementary dev/debug backend. ONB consumes the same MIR meaning but
+lowers it through its own native pipeline (minimal opt, aarch64 LIR,
+register allocation, object writer, DWARF, and lld). LLVM remains the
+reference/release backend; ONB remains the fast dev/debug backend.
+
+Use this split when choosing work:
+
+- If the change improves the existing LLVM IR emitter or moves that
+  emitter's behavior into `toolchain/mir_generator.osty`, track it here.
+- If the change creates or advances the separate fast dev/debug backend
+  used by `osty run`, `osty test`, or watch loops, track it in
+  `ONB_DESIGN.md`.
+- If both backends touch the same MIR semantic case, keep LLVM as the
+  reference and add ONB cross-validation rather than treating this port
+  document as the ONB roadmap.
+
 ## Workflow (post-#854)
 
 The bootstrap-transpile flow described in the historical "Pipeline"

--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -1,6 +1,17 @@
 # ONB 설계 — Osty Native Backend
 
-> **Status: Paper design (2026-04-27).** 33개 설계 결정 통합. 구현 전 단계.
+> **Status: Phase 0 scaffold started (2026-04-30).** 33개 설계 결정 통합.
+> `internal/onb` + `--backend onb` 등록까지 착수했고, `fn main() {}`의 MIR를
+> ONB Program으로 낮춘 뒤 첫 aarch64 LIR (`mov w0, #0`; `ret`)까지 생성하는
+> Phase 1.0 slice가 구현됐다. ONB assembly text artifact (`main.s`) 렌더링과
+> 최소 Mach-O relocatable object (`main.o`) emission이 가능하다. Binary emit은
+> ONB object를 host linker에 넘겨 실행 파일을 만들며, darwin/aarch64
+> `fn main() {}` smoke는 exit 0까지 확인됐다. 다음 slice로
+> `println("literal")` MIR intrinsic을 ONB LIR + assembly text까지 낮추며
+> `_puts` 호출과 `__cstring` 섹션을 렌더링하고, Mach-O `PAGE21` / `PAGEOFF12`
+> / `BR26` relocation을 포함한 object emission까지 확장했다. 이어서
+> `println(123)` 같은 정수 리터럴 출력도 `_printf("%lld\n", value)` 경로로
+> lowering/object/binary smoke까지 통과한다.
 > 본 문서는 결정 lock-in이며, 후속 의제(예: aarch64 LIR opcode 카탈로그,
 > cross-validation harness, simple inliner 도입 검토)는 별도 문서로 분기한다.
 
@@ -10,6 +21,29 @@ ONB는 **LLVM과 ABI·의미 100% 호환되는 단순 dev 백엔드**. Non-SSA M
 입력으로 받아 aarch64 LIR을 거쳐 lld로 darwin/linux binary를 emit. Full
 DWARF 디버그, 옵티마이저는 4-pass minimal, vectorize·SIMD·incremental GC는
 LLVM에 **영구 위임**한다.
+
+---
+
+## 0. 관련 문서와 경계
+
+이 문서가 **LLVM 보완용 dev/debug 백엔드(ONB)** 의 주 설계 문서다.
+실행 속도, 디버그 경험, `osty run` / `osty test` / watch loop의 기본 개발
+경로, 그리고 "무엇을 하지 않을지"는 여기 결정이 우선한다.
+
+[`MIR_EMITTER_PORT.md`](./MIR_EMITTER_PORT.md)는 별도 보조 트랙이다. 그 문서는
+기존 LLVM emitter (`internal/llvmgen/mir_generator.go`)의 LLVM 텍스트 생성
+의미를 `toolchain/mir_generator.osty` 쪽으로 옮기는 포팅 현황표이지,
+ONB 구현 계획이 아니다. ONB는 LLVM IR을 더 self-host로 잘 생성하는 작업이
+아니라, 같은 MIR 의미를 입력으로 받는 **별도 dev backend**다.
+
+판단 규칙:
+- 새 작업이 `osty run` / `osty test` / watch loop를 더 빠르고 디버그하기
+  쉽게 만드는 별도 backend 구현이면 이 문서를 따른다.
+- 새 작업이 기존 LLVM IR emitter의 문자열 builder, 지원성 검사, intrinsic
+  lowering을 Osty 소유로 옮기는 일이면 `MIR_EMITTER_PORT.md`를 따른다.
+- ONB와 LLVM emitter가 같은 의미를 다루는 경우 LLVM은 reference/release
+  backend, ONB는 dev/debug backend로 두고 cross-validation으로 동등성을
+  확인한다.
 
 ---
 

--- a/cmd/osty/backend_helpers.go
+++ b/cmd/osty/backend_helpers.go
@@ -28,6 +28,9 @@ func defaultBackendName() string {
 // exposes llvm-ir / binary / object; both of runner's outputs
 // (llvm-ir, binary) parse cleanly in the default build.
 func defaultEmitMode(tool string, name backend.Name) backend.EmitMode {
+	if (tool == "gen" || tool == "pipeline") && name == backend.NameONB {
+		return backend.EmitASM
+	}
 	raw := runner.DefaultEmitMode(tool)
 	mode, err := backend.ParseEmitMode(raw)
 	if err != nil {
@@ -105,6 +108,18 @@ func exitBackendEmitError(tool string, result *backend.Result, err error) {
 			}
 			if result.Artifacts.RuntimeDir != "" {
 				fmt.Fprintf(os.Stderr, "  runtime: %s\n", result.Artifacts.RuntimeDir)
+			}
+		}
+		os.Exit(1)
+	}
+	if errors.Is(err, backend.ErrONBNotImplemented) {
+		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		if result != nil {
+			if artifact := result.Artifacts.SourcePath(); artifact != "" {
+				fmt.Fprintf(os.Stderr, "  artifact: %s\n", artifact)
+			}
+			if result.Artifacts.OutputDir != "" {
+				fmt.Fprintf(os.Stderr, "  output-dir: %s\n", result.Artifacts.OutputDir)
 			}
 		}
 		os.Exit(1)

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -56,7 +56,7 @@ func runBuild(args []string, flags cliFlags) {
 	registerAIRepairCommandFlags(fs, &flags.aiRepair, &aiRepairModeName)
 	var backendName string
 	var emitName string
-	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm)")
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm, onb)")
 	fs.StringVar(&emitName, "emit", "", "artifact mode (llvm-ir, object, or binary)")
 	var pf profileFlags
 	pf.register(fs)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1269,7 +1269,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "gen-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  -o PATH            write generated artifact to PATH instead of stdout")
 	fmt.Fprintln(os.Stderr, "  --package NAME     backend package/module name (default: main)")
-	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (llvm; default llvm)")
+	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (llvm, onb; default llvm)")
 	fmt.Fprintln(os.Stderr, "  --emit MODE        artifact mode (llvm-ir; default follows backend)")
 	fmt.Fprintln(os.Stderr, "new-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --lib              scaffold a library project (lib.osty, no main)")
@@ -1296,7 +1296,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --target TRIPLE    cross-compilation target (e.g. amd64-linux)")
 	fmt.Fprintln(os.Stderr, "  --features LIST    comma-separated feature flags to enable")
 	fmt.Fprintln(os.Stderr, "  --no-default-features  drop the manifest's [features].default set")
-	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (llvm; default llvm)")
+	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (llvm, onb; default llvm)")
 	fmt.Fprintln(os.Stderr, "  --emit MODE        artifact mode (llvm-ir, object, or binary)")
 	fmt.Fprintln(os.Stderr, "build-specific flags:")
 	fmt.Fprintln(os.Stderr, "  --force            ignore the build cache and rebuild from source")
@@ -1482,8 +1482,8 @@ func runGen(args []string, flags cliFlags) {
 	fs.StringVar(&outPath, "o", "", "write generated artifact to this file instead of stdout")
 	fs.StringVar(&outPath, "out", "", "alias for -o")
 	fs.StringVar(&pkgName, "package", "main", "backend package/module name (default: main)")
-	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm)")
-	fs.StringVar(&emitName, "emit", "", "artifact mode (llvm-ir; default follows backend)")
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm, onb)")
+	fs.StringVar(&emitName, "emit", "", "artifact mode (llvm-ir, asm; default follows backend)")
 	_ = fs.Parse(args)
 	backendID, emitMode := resolveBackendAndEmitFlags("gen", backendName, emitName)
 	if fs.NArg() != 1 {
@@ -1545,6 +1545,9 @@ func adjustGenResultForUserOutput(result *backend.Result, name backend.Name, out
 	}
 	if name == backend.NameLLVM {
 		result.Artifacts.LLVMIR = outPath
+	}
+	if name == backend.NameONB {
+		result.Artifacts.Assembly = outPath
 	}
 }
 

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -51,7 +51,7 @@ func runRun(args []string, cliF cliFlags) {
 	registerAIRepairCommandFlags(fs, &cliF.aiRepair, &aiRepairModeName)
 	var backendName string
 	var emitName string
-	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm)")
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm, onb)")
 	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
 	var pf profileFlags
 	pf.register(fs)

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -66,7 +66,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	registerAIRepairCommandFlags(fs, &flags.aiRepair, &aiRepairModeName)
 	var backendName string
 	var emitName string
-	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm)")
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm, onb)")
 	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
 	var seedFlag string
 	fs.StringVar(&seedFlag, "seed", "", "deterministic test-order seed (decimal or 0x-hex); default is a fresh random seed")

--- a/internal/backend/artifacts.go
+++ b/internal/backend/artifacts.go
@@ -8,5 +8,8 @@ func (a Artifacts) SourcePath() string {
 	if a.LLVMIR != "" {
 		return filepath.Clean(a.LLVMIR)
 	}
+	if a.Assembly != "" {
+		return filepath.Clean(a.Assembly)
+	}
 	return ""
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -17,6 +17,7 @@ type Name string
 
 const (
 	NameLLVM Name = "llvm"
+	NameONB  Name = "onb"
 )
 
 // ParseName converts a CLI/config backend name into a Name.
@@ -24,8 +25,10 @@ func ParseName(s string) (Name, error) {
 	switch Name(s) {
 	case NameLLVM:
 		return NameLLVM, nil
+	case NameONB:
+		return NameONB, nil
 	default:
-		return "", fmt.Errorf("unknown backend %q (want llvm)", s)
+		return "", fmt.Errorf("unknown backend %q (want llvm or onb)", s)
 	}
 }
 
@@ -34,7 +37,7 @@ func (n Name) String() string { return string(n) }
 // Valid reports whether n is a known backend name.
 func (n Name) Valid() bool {
 	switch n {
-	case NameLLVM:
+	case NameLLVM, NameONB:
 		return true
 	default:
 		return false
@@ -46,6 +49,7 @@ type EmitMode string
 
 const (
 	EmitLLVMIR EmitMode = "llvm-ir"
+	EmitASM    EmitMode = "asm"
 	EmitObject EmitMode = "object"
 	EmitBinary EmitMode = "binary"
 )
@@ -55,12 +59,14 @@ func ParseEmitMode(s string) (EmitMode, error) {
 	switch EmitMode(s) {
 	case EmitLLVMIR:
 		return EmitLLVMIR, nil
+	case EmitASM:
+		return EmitASM, nil
 	case EmitObject:
 		return EmitObject, nil
 	case EmitBinary:
 		return EmitBinary, nil
 	default:
-		return "", fmt.Errorf("unknown emit mode %q (want llvm-ir, object, or binary)", s)
+		return "", fmt.Errorf("unknown emit mode %q (want llvm-ir, asm, object, or binary)", s)
 	}
 }
 
@@ -69,7 +75,7 @@ func (m EmitMode) String() string { return string(m) }
 // Valid reports whether m is a known emit mode.
 func (m EmitMode) Valid() bool {
 	switch m {
-	case EmitLLVMIR, EmitObject, EmitBinary:
+	case EmitLLVMIR, EmitASM, EmitObject, EmitBinary:
 		return true
 	default:
 		return false
@@ -81,6 +87,8 @@ func (m EmitMode) ValidFor(n Name) bool {
 	switch n {
 	case NameLLVM:
 		return m == EmitLLVMIR || m == EmitObject || m == EmitBinary
+	case NameONB:
+		return m == EmitASM || m == EmitObject || m == EmitBinary
 	default:
 		return false
 	}

--- a/internal/backend/factory.go
+++ b/internal/backend/factory.go
@@ -7,6 +7,8 @@ func New(name Name) (Backend, error) {
 	switch name {
 	case NameLLVM:
 		return LLVMBackend{}, nil
+	case NameONB:
+		return ONBBackend{}, nil
 	default:
 		return nil, fmt.Errorf("unknown backend %q", name)
 	}

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -54,9 +54,10 @@ type Artifacts struct {
 	OutputDir string
 	CachePath string
 
-	LLVMIR string
-	Object string
-	Binary string
+	LLVMIR   string
+	Assembly string
+	Object   string
+	Binary   string
 
 	RuntimeDir string
 }
@@ -72,6 +73,10 @@ func (l Layout) Artifacts(n Name, binaryName string) Artifacts {
 	switch n {
 	case NameLLVM:
 		out.LLVMIR = filepath.Join(out.OutputDir, "main.ll")
+		out.Object = filepath.Join(out.OutputDir, "main.o")
+		out.RuntimeDir = filepath.Join(out.OutputDir, "runtime")
+	case NameONB:
+		out.Assembly = filepath.Join(out.OutputDir, "main.s")
 		out.Object = filepath.Join(out.OutputDir, "main.o")
 		out.RuntimeDir = filepath.Join(out.OutputDir, "runtime")
 	}

--- a/internal/backend/onb.go
+++ b/internal/backend/onb.go
@@ -1,0 +1,99 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/onb"
+)
+
+// ErrONBNotImplemented marks ONB requests that reached the dev-backend phase
+// boundary before object emission exists.
+var ErrONBNotImplemented = onb.ErrNotImplemented
+
+type onbLinker interface {
+	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string) error
+}
+
+// ONBBackend is the LLVM-complementary dev/debug backend. It consumes MIR and
+// emits native aarch64 objects directly; LLVM remains the reference/release
+// backend.
+type ONBBackend struct {
+	linker onbLinker
+}
+
+func (ONBBackend) Name() Name { return NameONB }
+
+func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := ValidateEmit(NameONB, req.Emit); err != nil {
+		return nil, err
+	}
+	artifacts := req.Artifacts(NameONB)
+	if err := os.MkdirAll(artifacts.OutputDir, 0o755); err != nil {
+		return nil, err
+	}
+	plan, err := onb.BuildPlan(onb.Request{
+		Module:       req.Entry.MIR,
+		TargetTriple: req.Layout.Target,
+		EmitMode:     req.Emit.String(),
+		ObjectPath:   artifacts.Object,
+		BinaryPath:   artifacts.Binary,
+	})
+	warnings := append([]error(nil), req.Entry.MIRIssues...)
+	if plan != nil {
+		warnings = append(warnings, fmt.Errorf("onb phase plan for %s/%s: %s", plan.Target.OS, plan.Target.Arch, plan.StageSummary()))
+	}
+	result := &Result{
+		Backend:   NameONB,
+		Emit:      req.Emit,
+		Artifacts: artifacts,
+		Warnings:  warnings,
+	}
+	if err != nil {
+		return result, err
+	}
+	asm, err := onb.RenderAssembly(plan.Program)
+	if err != nil {
+		return result, err
+	}
+	if artifacts.Assembly != "" {
+		if err := os.WriteFile(artifacts.Assembly, asm, 0o644); err != nil {
+			return result, err
+		}
+	}
+	if req.Emit == EmitASM {
+		return result, nil
+	}
+	if req.Emit == EmitObject || req.Emit == EmitBinary {
+		object, err := onb.EmitObject(plan.Program)
+		if err != nil {
+			return result, err
+		}
+		if artifacts.Object != "" {
+			if err := os.WriteFile(artifacts.Object, object, 0o644); err != nil {
+				return result, err
+			}
+		}
+		if req.Emit == EmitObject {
+			return result, nil
+		}
+	}
+	if artifacts.Binary == "" {
+		return result, fmt.Errorf("onb backend: missing binary artifact path")
+	}
+	if err := b.onbLinker().LinkBinary(ctx, []string{artifacts.Object}, artifacts.Binary, req.Layout.Target); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (b ONBBackend) onbLinker() onbLinker {
+	if b.linker != nil {
+		return b.linker
+	}
+	return clangToolchain{}
+}

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1,0 +1,240 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type fakeONBLinker struct {
+	links []linkCall
+}
+
+func (f *fakeONBLinker) LinkBinary(_ context.Context, objectPaths []string, binaryPath, target string) error {
+	f.links = append(f.links, linkCall{
+		objectPaths: append([]string(nil), objectPaths...),
+		binaryPath:  binaryPath,
+		target:      target,
+	})
+	return os.WriteFile(binaryPath, []byte("onb fake binary"), 0o755)
+}
+
+func TestONBBackendRegisteredAsDevBackend(t *testing.T) {
+	t.Parallel()
+
+	name, err := ParseName("onb")
+	if err != nil {
+		t.Fatalf("ParseName(onb) returned error: %v", err)
+	}
+	if name != NameONB {
+		t.Fatalf("ParseName(onb) = %q, want %q", name, NameONB)
+	}
+	if !EmitBinary.ValidFor(NameONB) || !EmitObject.ValidFor(NameONB) {
+		t.Fatal("ONB should accept object and binary emission")
+	}
+	if !EmitASM.ValidFor(NameONB) {
+		t.Fatal("ONB should accept assembly emission")
+	}
+	if EmitLLVMIR.ValidFor(NameONB) {
+		t.Fatal("ONB must not claim LLVM IR emission")
+	}
+}
+
+func TestONBBackendEmitAssemblyWritesArtifact(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitASM, `fn main() {}`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(asm) returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Assembly == "" {
+		t.Fatalf("ONBBackend.Emit(asm) result = %+v", result)
+	}
+	data, err := os.ReadFile(result.Artifacts.Assembly)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) returned error: %v", result.Artifacts.Assembly, err)
+	}
+	text := string(data)
+	for _, want := range []string{"_main:", "\tmov w0, #0", "\tret"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestONBBackendEmitAssemblyForPrintlnLiteral(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitASM, `fn main() { println("hi") }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(asm) returned error: %v", err)
+	}
+	data, err := os.ReadFile(result.Artifacts.Assembly)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) returned error: %v", result.Artifacts.Assembly, err)
+	}
+	text := string(data)
+	for _, want := range []string{"\tbl _puts", ".section __TEXT,__cstring,cstring_literals", "\t.asciz \"hi\""} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestONBBackendEmitAssemblyForPrintlnIntLiteral(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitASM, `fn main() { println(123) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(asm) returned error: %v", err)
+	}
+	data, err := os.ReadFile(result.Artifacts.Assembly)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) returned error: %v", result.Artifacts.Assembly, err)
+	}
+	text := string(data)
+	for _, want := range []string{"\tmovz x1, #123", "\tstr x1, [sp]", "\tbl _printf", "\t.asciz \"%lld\\n\""} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestONBBackendEmitObjectWritesMachOArtifact(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitObject, `fn main() {}`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(object) returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("ONBBackend.Emit() returned nil result")
+	}
+	if result.Backend != NameONB {
+		t.Fatalf("result.Backend = %q, want %q", result.Backend, NameONB)
+	}
+	if result.Artifacts.Object == "" {
+		t.Fatal("ONB object artifact path is empty")
+	}
+	if _, err := os.Stat(result.Artifacts.Object); err != nil {
+		t.Fatalf("ONB object artifact was not written: %v", err)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatal("ONB result should include the phase plan warning")
+	}
+}
+
+func TestONBBackendEmitBinaryInvokesHostLinker(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitBinary, `fn main() {}`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	linker := &fakeONBLinker{}
+	result, err := (ONBBackend{linker: linker}).Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(binary) returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Object == "" || result.Artifacts.Binary == "" {
+		t.Fatalf("ONBBackend.Emit(binary) result = %+v", result)
+	}
+	if _, err := os.Stat(result.Artifacts.Object); err != nil {
+		t.Fatalf("ONB binary path should leave object artifact for debugging: %v", err)
+	}
+	if _, err := os.Stat(result.Artifacts.Binary); err != nil {
+		t.Fatalf("ONB binary artifact was not written: %v", err)
+	}
+	if len(linker.links) != 1 {
+		t.Fatalf("link calls = %d, want 1", len(linker.links))
+	}
+	if got := linker.links[0].objectPaths; len(got) != 1 || got[0] != result.Artifacts.Object {
+		t.Fatalf("link object paths = %v, want [%s]", got, result.Artifacts.Object)
+	}
+}
+
+func TestONBBackendBinaryRunsUnitMainOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB phase 1.0 executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	req := newBackendRequest(t, EmitBinary, `fn main() {}`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(binary) returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Binary == "" {
+		t.Fatalf("ONBBackend.Emit(binary) result = %+v", result)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ONB binary returned error: %v\n%s", err, out)
+	}
+}
+
+func TestONBBackendBinaryRunsPrintlnLiteralOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB println executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	req := newBackendRequest(t, EmitBinary, `fn main() { println("hi") }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(binary) returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Binary == "" {
+		t.Fatalf("ONBBackend.Emit(binary) result = %+v", result)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ONB binary returned error: %v\n%s", err, out)
+	}
+	if string(out) != "hi\n" {
+		t.Fatalf("ONB binary output = %q, want hi newline", out)
+	}
+}
+
+func TestONBBackendBinaryRunsPrintlnIntLiteralOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB println executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	req := newBackendRequest(t, EmitBinary, `fn main() { println(123) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit(binary) returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Binary == "" {
+		t.Fatalf("ONBBackend.Emit(binary) result = %+v", result)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ONB binary returned error: %v\n%s", err, out)
+	}
+	if string(out) != "123\n" {
+		t.Fatalf("ONB binary output = %q, want 123 newline", out)
+	}
+}

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -1,0 +1,207 @@
+package onb
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderAssembly renders the current ONB LIR slice as readable aarch64
+// assembly. It stays deliberately readable so ONB has a debuggable artifact
+// alongside the native object writer.
+func RenderAssembly(program *Program) ([]byte, error) {
+	if program == nil {
+		return nil, fmt.Errorf("onb: missing program")
+	}
+	var b strings.Builder
+	b.WriteString(".text\n")
+	for _, fn := range program.Functions {
+		if err := renderFunctionAssembly(&b, program.Target, fn); err != nil {
+			return nil, err
+		}
+	}
+	if err := renderCStringSection(&b, program.Target, program.CStrings); err != nil {
+		return nil, err
+	}
+	return []byte(b.String()), nil
+}
+
+func renderFunctionAssembly(b *strings.Builder, target Target, fn Function) error {
+	if fn.Name == "" {
+		return fmt.Errorf("onb: function without name")
+	}
+	sym := asmSymbolName(target, fn.Name)
+	if target.ObjectFormat == "elf" {
+		fmt.Fprintf(b, ".globl %s\n.type %s, %%function\n", sym, sym)
+	} else {
+		fmt.Fprintf(b, ".globl %s\n.p2align 2\n", sym)
+	}
+	fmt.Fprintf(b, "%s:\n", sym)
+	needsFrame := functionNeedsFrame(fn)
+	needsStackArgs := functionNeedsStackArgs(fn)
+	if needsFrame {
+		if needsStackArgs {
+			b.WriteString("\tsub sp, sp, #32\n")
+			b.WriteString("\tstp x29, x30, [sp, #16]\n")
+			b.WriteString("\tadd x29, sp, #16\n")
+		} else {
+			b.WriteString("\tstp x29, x30, [sp, #-16]!\n")
+			b.WriteString("\tmov x29, sp\n")
+		}
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if err := renderInstrAssembly(b, target, instr, needsFrame, needsStackArgs); err != nil {
+				return err
+			}
+		}
+	}
+	if target.ObjectFormat == "elf" {
+		fmt.Fprintf(b, ".size %s, .-%s\n", sym, sym)
+	}
+	return nil
+}
+
+func renderInstrAssembly(b *strings.Builder, target Target, instr Instr, needsFrame, needsStackArgs bool) error {
+	switch i := instr.(type) {
+	case *LoadCStringAddress:
+		label := asmCStringLabel(target, i.Label)
+		switch target.ObjectFormat {
+		case "mach-o":
+			fmt.Fprintf(b, "\tadrp %s, %s@PAGE\n", i.Dst, label)
+			fmt.Fprintf(b, "\tadd %s, %s, %s@PAGEOFF\n", i.Dst, i.Dst, label)
+		case "elf":
+			fmt.Fprintf(b, "\tadrp %s, %s\n", i.Dst, label)
+			fmt.Fprintf(b, "\tadd %s, %s, :lo12:%s\n", i.Dst, i.Dst, label)
+		default:
+			return fmt.Errorf("onb: assembly renderer does not support %s object format", target.ObjectFormat)
+		}
+	case *BranchLink:
+		fmt.Fprintf(b, "\tbl %s\n", asmSymbolName(target, i.Symbol))
+	case *MovImm32:
+		fmt.Fprintf(b, "\tmov %s, #%d\n", i.Dst, i.Imm)
+	case *MovImm64:
+		if err := renderMovImm64Assembly(b, i.Dst, uint64(i.Imm)); err != nil {
+			return err
+		}
+	case *Store64Stack:
+		if i.Offset == 0 {
+			fmt.Fprintf(b, "\tstr %s, [sp]\n", i.Src)
+		} else {
+			fmt.Fprintf(b, "\tstr %s, [sp, #%d]\n", i.Src, i.Offset)
+		}
+	case *Ret:
+		if needsFrame {
+			if needsStackArgs {
+				b.WriteString("\tldp x29, x30, [sp, #16]\n")
+				b.WriteString("\tadd sp, sp, #32\n")
+			} else {
+				b.WriteString("\tldp x29, x30, [sp], #16\n")
+			}
+		}
+		b.WriteString("\tret\n")
+	default:
+		return fmt.Errorf("onb: assembly renderer does not support %T", instr)
+	}
+	return nil
+}
+
+func renderMovImm64Assembly(b *strings.Builder, dst Reg, imm uint64) error {
+	if _, ok := xRegisterNumber(dst); !ok {
+		return fmt.Errorf("onb: mov64 destination %s is not an x register", dst)
+	}
+	wrote := false
+	for shift := 0; shift < 64; shift += 16 {
+		chunk := uint16(imm >> shift)
+		if chunk == 0 && wrote {
+			continue
+		}
+		if !wrote {
+			fmt.Fprintf(b, "\tmovz %s, #%d", dst, chunk)
+			wrote = true
+		} else {
+			fmt.Fprintf(b, "\tmovk %s, #%d", dst, chunk)
+		}
+		if shift != 0 {
+			fmt.Fprintf(b, ", lsl #%d", shift)
+		}
+		b.WriteByte('\n')
+	}
+	if !wrote {
+		fmt.Fprintf(b, "\tmovz %s, #0\n", dst)
+	}
+	return nil
+}
+
+func renderCStringSection(b *strings.Builder, target Target, cstrings []CStringLiteral) error {
+	if len(cstrings) == 0 {
+		return nil
+	}
+	switch target.ObjectFormat {
+	case "mach-o":
+		b.WriteString(".section __TEXT,__cstring,cstring_literals\n")
+	case "elf":
+		b.WriteString(".section .rodata\n")
+	default:
+		return fmt.Errorf("onb: assembly renderer does not support %s string section", target.ObjectFormat)
+	}
+	for _, cstr := range cstrings {
+		if cstr.Label == "" {
+			return fmt.Errorf("onb: string literal without label")
+		}
+		fmt.Fprintf(b, "%s:\n\t.asciz %s\n", asmCStringLabel(target, cstr.Label), asmCStringLiteral(cstr.Value))
+	}
+	return nil
+}
+
+func asmSymbolName(target Target, name string) string {
+	if target.ObjectFormat == "mach-o" {
+		return "_" + name
+	}
+	return name
+}
+
+func asmCStringLabel(target Target, label string) string {
+	if target.ObjectFormat == "mach-o" {
+		return "L_." + label
+	}
+	return ".L." + label
+}
+
+func asmCStringLiteral(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\\':
+			b.WriteString("\\\\")
+		case '"':
+			b.WriteString("\\\"")
+		case '\n':
+			b.WriteString("\\n")
+		case '\r':
+			b.WriteString("\\r")
+		case '\t':
+			b.WriteString("\\t")
+		default:
+			if c >= 0x20 && c <= 0x7e {
+				b.WriteByte(c)
+				continue
+			}
+			fmt.Fprintf(&b, "\\%03o", c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func xRegisterNumber(reg Reg) (uint32, bool) {
+	switch reg {
+	case RegX0:
+		return 0, true
+	case RegX1:
+		return 1, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -1,0 +1,114 @@
+package onb
+
+// Program is ONB's first native-owned lowering product. It is deliberately
+// smaller than the final backend IR, but it already speaks in aarch64-shaped
+// instructions so the pipeline can grow toward object emission one opcode at a
+// time.
+type Program struct {
+	Target    Target
+	Functions []Function
+	CStrings  []CStringLiteral
+}
+
+// CStringLiteral is a null-terminated string payload referenced by ONB code.
+type CStringLiteral struct {
+	Label string
+	Value string
+}
+
+// Function is one lowered ONB function.
+type Function struct {
+	Name   string
+	Blocks []Block
+}
+
+// Block is a linear basic block.
+type Block struct {
+	Label  string
+	Instrs []Instr
+}
+
+// Instr is one ONB aarch64 LIR instruction.
+type Instr interface {
+	instrNode()
+}
+
+// Reg names an aarch64 architectural register in the current minimal LIR.
+type Reg string
+
+const (
+	RegX0 Reg = "x0"
+	RegX1 Reg = "x1"
+	RegW0 Reg = "w0"
+)
+
+// MovImm32 lowers a small integer immediate into a 32-bit destination
+// register. `fn main() {}` starts with `mov w0, #0` for the process exit code.
+type MovImm32 struct {
+	Dst Reg
+	Imm int64
+}
+
+func (*MovImm32) instrNode() {}
+
+// MovImm64 loads a 64-bit integer immediate into an x register. The object
+// writer expands this into a movz/movk sequence as needed.
+type MovImm64 struct {
+	Dst Reg
+	Imm int64
+}
+
+func (*MovImm64) instrNode() {}
+
+// Store64Stack stores a 64-bit register into the current call frame. Darwin
+// aarch64 uses this for C varargs such as printf's integer argument area.
+type Store64Stack struct {
+	Src    Reg
+	Offset int64
+}
+
+func (*Store64Stack) instrNode() {}
+
+// LoadCStringAddress materializes the address of a C string literal into a
+// register using the platform's PC-relative addressing form.
+type LoadCStringAddress struct {
+	Dst   Reg
+	Label string
+}
+
+func (*LoadCStringAddress) instrNode() {}
+
+// BranchLink calls an external or local function symbol.
+type BranchLink struct {
+	Symbol string
+}
+
+func (*BranchLink) instrNode() {}
+
+// Ret returns to the platform entry trampoline. For `main`, the return code is
+// already in w0.
+type Ret struct{}
+
+func (*Ret) instrNode() {}
+
+func functionNeedsFrame(fn Function) bool {
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if _, ok := instr.(*BranchLink); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func functionNeedsStackArgs(fn Function) bool {
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if _, ok := instr.(*Store64Stack); ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -1,0 +1,185 @@
+package onb
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/mir"
+)
+
+// LowerMIR lowers the supported phase 1 MIR slice into ONB's own LIR.
+// The initial slice is intentionally tiny: parameterless unit-returning main
+// functions, plus string-literal println calls. That is enough to turn "MIR
+// consumer" from a paper stage into a debuggable compiler boundary.
+func LowerMIR(mod *mir.Module, target Target) (*Program, error) {
+	if mod == nil {
+		return nil, fmt.Errorf("onb: missing MIR module")
+	}
+	mainFn := mod.LookupFunction("main")
+	if mainFn == nil {
+		return nil, fmt.Errorf("onb: missing main function")
+	}
+	state := &lowerState{target: target}
+	fn, err := state.lowerMainFunction(mainFn)
+	if err != nil {
+		return nil, err
+	}
+	return &Program{
+		Target:    target,
+		Functions: []Function{fn},
+		CStrings:  state.cstrings,
+	}, nil
+}
+
+type lowerState struct {
+	target   Target
+	cstrings []CStringLiteral
+}
+
+func (s *lowerState) lowerMainFunction(fn *mir.Function) (Function, error) {
+	if fn == nil {
+		return Function{}, fmt.Errorf("onb: nil main function")
+	}
+	if len(fn.Params) != 0 {
+		return Function{}, fmt.Errorf("onb: main parameters are outside phase 1")
+	}
+	if fn.ReturnType != mir.TUnit {
+		return Function{}, fmt.Errorf("onb: main return type %s is outside phase 1", fn.ReturnType)
+	}
+	out := Function{Name: fn.Name}
+	for _, block := range fn.Blocks {
+		lowered, err := s.lowerBlock(fn, block)
+		if err != nil {
+			return Function{}, err
+		}
+		out.Blocks = append(out.Blocks, lowered)
+	}
+	if len(out.Blocks) == 0 {
+		return Function{}, fmt.Errorf("onb: main has no basic blocks")
+	}
+	return out, nil
+}
+
+func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock) (Block, error) {
+	if block == nil {
+		return Block{}, fmt.Errorf("onb: nil basic block")
+	}
+	var instrs []Instr
+	for _, instr := range block.Instrs {
+		lowered, err := s.lowerInstr(fn, instr)
+		if err != nil {
+			return Block{}, err
+		}
+		instrs = append(instrs, lowered...)
+	}
+	switch block.Term.(type) {
+	case *mir.ReturnTerm:
+		instrs = append(instrs,
+			&MovImm32{Dst: RegW0, Imm: 0},
+			&Ret{},
+		)
+		return Block{
+			Label:  blockLabel(block.ID),
+			Instrs: instrs,
+		}, nil
+	default:
+		return Block{}, fmt.Errorf("onb: terminator %T is outside phase 1", block.Term)
+	}
+}
+
+func blockLabel(id mir.BlockID) string {
+	return fmt.Sprintf("bb%d", int(id))
+}
+
+func (s *lowerState) lowerInstr(fn *mir.Function, instr mir.Instr) ([]Instr, error) {
+	switch i := instr.(type) {
+	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+		return nil, nil
+	case *mir.AssignInstr:
+		if isUnitReturnAssignment(fn, i) {
+			return nil, nil
+		}
+	case *mir.IntrinsicInstr:
+		return s.lowerIntrinsic(i)
+	}
+	return nil, fmt.Errorf("onb: instruction %T is outside phase 1", instr)
+}
+
+func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	switch instr.Kind {
+	case mir.IntrinsicPrintln:
+		if text, ok := stringLiteralOperand(instr.Args); ok {
+			label := s.addCString(text)
+			return []Instr{
+				&LoadCStringAddress{Dst: RegX0, Label: label},
+				&BranchLink{Symbol: "puts"},
+			}, nil
+		}
+		if value, ok := intLiteralOperand(instr.Args); ok {
+			label := s.addCString("%lld\n")
+			out := []Instr{
+				&LoadCStringAddress{Dst: RegX0, Label: label},
+				&MovImm64{Dst: RegX1, Imm: value},
+			}
+			if s.target.ObjectFormat == "mach-o" {
+				out = append(out, &Store64Stack{Src: RegX1})
+			}
+			out = append(out, &BranchLink{Symbol: "printf"})
+			return out, nil
+		}
+		return nil, fmt.Errorf("onb: println currently requires one string or int literal argument")
+	default:
+		return nil, fmt.Errorf("onb: intrinsic %s is outside phase 1", instr.Kind)
+	}
+}
+
+func (s *lowerState) addCString(value string) string {
+	label := fmt.Sprintf("str%d", len(s.cstrings))
+	s.cstrings = append(s.cstrings, CStringLiteral{Label: label, Value: value})
+	return label
+}
+
+func isUnitReturnAssignment(fn *mir.Function, instr *mir.AssignInstr) bool {
+	if fn == nil || instr == nil || instr.Dest.HasProjections() || instr.Dest.Local != fn.ReturnLocal {
+		return false
+	}
+	use, ok := instr.Src.(*mir.UseRV)
+	if !ok {
+		return false
+	}
+	c, ok := use.Op.(*mir.ConstOp)
+	if !ok {
+		return false
+	}
+	_, ok = c.Const.(*mir.UnitConst)
+	return ok
+}
+
+func stringLiteralOperand(args []mir.Operand) (string, bool) {
+	if len(args) != 1 {
+		return "", false
+	}
+	c, ok := args[0].(*mir.ConstOp)
+	if !ok {
+		return "", false
+	}
+	s, ok := c.Const.(*mir.StringConst)
+	if !ok {
+		return "", false
+	}
+	return s.Value, true
+}
+
+func intLiteralOperand(args []mir.Operand) (int64, bool) {
+	if len(args) != 1 {
+		return 0, false
+	}
+	c, ok := args[0].(*mir.ConstOp)
+	if !ok {
+		return 0, false
+	}
+	i, ok := c.Const.(*mir.IntConst)
+	if !ok {
+		return 0, false
+	}
+	return i.Value, true
+}

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -1,0 +1,498 @@
+package onb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+)
+
+const (
+	machoMagic64                       = 0xfeedfacf
+	machoCPUTypeARM64                  = 0x0100000c
+	machoCPUSubtypeARM64All            = 0
+	machoFileTypeObject                = 1
+	machoLCSegment64                   = 0x19
+	machoLCSymtab                      = 0x2
+	machoLCDysymtab                    = 0xb
+	machoMHSubsectionsViaSyms          = 0x2000
+	machoVMProtRead                    = 0x1
+	machoVMProtExecute                 = 0x4
+	machoSectionRegular                = 0x0
+	machoSectionCStringLiterals        = 0x2
+	machoSectionSomeInstr              = 0x00000400
+	machoSectionPureInstr              = 0x80000000
+	machoARM64RelocBranch26            = 2
+	machoARM64RelocPage21              = 3
+	machoARM64RelocPageOff12           = 4
+	machoNExt                          = 0x01
+	machoNSect                         = 0x0e
+	machoHeader64Size                  = 32
+	machoSegment64Size                 = 72
+	machoSection64Size                 = 80
+	machoSymtabCommandSize             = 24
+	machoDysymtabCommandSize           = 80
+	machoNlist64Size                   = 16
+	machoRelocSize                     = 8
+	machoTextAlignPower         uint32 = 2
+	machoCStringSectionNumber   uint8  = 2
+	machoTextSectionNumber      uint8  = 1
+)
+
+func emitMachOObject(program *Program) ([]byte, error) {
+	if len(program.CStrings) == 0 {
+		return emitMinimalMachOObject(program)
+	}
+	return emitMachOObjectWithCStringRelocs(program)
+}
+
+func emitMinimalMachOObject(program *Program) ([]byte, error) {
+	code, err := encodeMachOText(program)
+	if err != nil {
+		return nil, err
+	}
+
+	sizeofcmds := uint32(machoSegment64Size + machoSection64Size + machoSymtabCommandSize)
+	textOffset := uint32(machoHeader64Size) + sizeofcmds
+	symoff := textOffset + uint32(len(code))
+	stroff := symoff + machoNlist64Size
+	strtab := []byte{0, '_', 'm', 'a', 'i', 'n', 0}
+
+	var b bytes.Buffer
+	writeU32(&b, machoMagic64)
+	writeU32(&b, machoCPUTypeARM64)
+	writeU32(&b, machoCPUSubtypeARM64All)
+	writeU32(&b, machoFileTypeObject)
+	writeU32(&b, 2)
+	writeU32(&b, sizeofcmds)
+	writeU32(&b, machoMHSubsectionsViaSyms)
+	writeU32(&b, 0)
+
+	writeU32(&b, machoLCSegment64)
+	writeU32(&b, machoSegment64Size+machoSection64Size)
+	writeName16(&b, "")
+	writeU64(&b, 0)
+	writeU64(&b, uint64(len(code)))
+	writeU64(&b, uint64(textOffset))
+	writeU64(&b, uint64(len(code)))
+	writeU32(&b, machoVMProtRead|machoVMProtExecute)
+	writeU32(&b, machoVMProtRead|machoVMProtExecute)
+	writeU32(&b, 1)
+	writeU32(&b, 0)
+
+	writeName16(&b, "__text")
+	writeName16(&b, "__TEXT")
+	writeU64(&b, 0)
+	writeU64(&b, uint64(len(code)))
+	writeU32(&b, textOffset)
+	writeU32(&b, machoTextAlignPower)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, machoSectionRegular|machoSectionSomeInstr|machoSectionPureInstr)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+
+	writeU32(&b, machoLCSymtab)
+	writeU32(&b, machoSymtabCommandSize)
+	writeU32(&b, symoff)
+	writeU32(&b, 1)
+	writeU32(&b, stroff)
+	writeU32(&b, uint32(len(strtab)))
+
+	if b.Len() != int(textOffset) {
+		return nil, fmt.Errorf("onb: internal Mach-O layout mismatch: header=%d textOffset=%d", b.Len(), textOffset)
+	}
+	b.Write(code)
+
+	writeU32(&b, 1)
+	b.WriteByte(machoNExt | machoNSect)
+	b.WriteByte(1)
+	writeU16(&b, 0)
+	writeU64(&b, 0)
+	b.Write(strtab)
+	return b.Bytes(), nil
+}
+
+type machoReloc struct {
+	address   uint32
+	symbolnum uint32
+	pcrel     bool
+	length    uint8
+	extern    bool
+	typ       uint8
+}
+
+type machoStringTable struct {
+	data []byte
+}
+
+func newMachOStringTable() *machoStringTable {
+	return &machoStringTable{data: []byte{0}}
+}
+
+func (s *machoStringTable) add(name string) uint32 {
+	off := uint32(len(s.data))
+	s.data = append(s.data, name...)
+	s.data = append(s.data, 0)
+	return off
+}
+
+type machoTextEncoding struct {
+	code            []byte
+	relocs          []machoReloc
+	externalSymbols []string
+}
+
+func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
+	cstringIndex := make(map[string]uint32, len(program.CStrings))
+	for i, cstr := range program.CStrings {
+		if cstr.Label == "" {
+			return nil, fmt.Errorf("onb: Mach-O string literal without label")
+		}
+		if _, exists := cstringIndex[cstr.Label]; exists {
+			return nil, fmt.Errorf("onb: duplicate Mach-O string literal label %q", cstr.Label)
+		}
+		cstringIndex[cstr.Label] = uint32(i)
+	}
+	enc, err := encodeMachOTextWithRelocs(program, cstringIndex)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(enc.relocs, func(i, j int) bool {
+		return enc.relocs[i].address > enc.relocs[j].address
+	})
+
+	sizeofcmds := uint32(machoSegment64Size + 2*machoSection64Size + machoSymtabCommandSize + machoDysymtabCommandSize)
+	textOffset := uint32(machoHeader64Size) + sizeofcmds
+	cstringOffset := textOffset + uint32(len(enc.code))
+	cstringData, cstringAddrs := encodeMachOCStrings(program.CStrings, uint64(len(enc.code)))
+	relocOffset := alignUp(cstringOffset+uint32(len(cstringData)), 4)
+	symoff := relocOffset + uint32(len(enc.relocs))*machoRelocSize
+	nsyms := uint32(len(program.CStrings) + 1 + len(enc.externalSymbols))
+	stroff := symoff + nsyms*machoNlist64Size
+	strtab := newMachOStringTable()
+
+	var b bytes.Buffer
+	writeU32(&b, machoMagic64)
+	writeU32(&b, machoCPUTypeARM64)
+	writeU32(&b, machoCPUSubtypeARM64All)
+	writeU32(&b, machoFileTypeObject)
+	writeU32(&b, 3)
+	writeU32(&b, sizeofcmds)
+	writeU32(&b, machoMHSubsectionsViaSyms)
+	writeU32(&b, 0)
+
+	segmentSize := uint64(len(enc.code) + len(cstringData))
+	writeU32(&b, machoLCSegment64)
+	writeU32(&b, machoSegment64Size+2*machoSection64Size)
+	writeName16(&b, "")
+	writeU64(&b, 0)
+	writeU64(&b, segmentSize)
+	writeU64(&b, uint64(textOffset))
+	writeU64(&b, segmentSize)
+	writeU32(&b, machoVMProtRead|machoVMProtExecute)
+	writeU32(&b, machoVMProtRead|machoVMProtExecute)
+	writeU32(&b, 2)
+	writeU32(&b, 0)
+
+	writeName16(&b, "__text")
+	writeName16(&b, "__TEXT")
+	writeU64(&b, 0)
+	writeU64(&b, uint64(len(enc.code)))
+	writeU32(&b, textOffset)
+	writeU32(&b, machoTextAlignPower)
+	writeU32(&b, relocOffset)
+	writeU32(&b, uint32(len(enc.relocs)))
+	writeU32(&b, machoSectionRegular|machoSectionSomeInstr|machoSectionPureInstr)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+
+	writeName16(&b, "__cstring")
+	writeName16(&b, "__TEXT")
+	writeU64(&b, uint64(len(enc.code)))
+	writeU64(&b, uint64(len(cstringData)))
+	writeU32(&b, cstringOffset)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, machoSectionCStringLiterals)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+	writeU32(&b, 0)
+
+	writeU32(&b, machoLCSymtab)
+	writeU32(&b, machoSymtabCommandSize)
+	writeU32(&b, symoff)
+	writeU32(&b, nsyms)
+	writeU32(&b, stroff)
+
+	strtabLenOffset := b.Len()
+	writeU32(&b, 0)
+
+	writeU32(&b, machoLCDysymtab)
+	writeU32(&b, machoDysymtabCommandSize)
+	writeU32(&b, 0)
+	writeU32(&b, uint32(len(program.CStrings)))
+	writeU32(&b, uint32(len(program.CStrings)))
+	writeU32(&b, 1)
+	writeU32(&b, uint32(len(program.CStrings)+1))
+	writeU32(&b, uint32(len(enc.externalSymbols)))
+	for i := 0; i < 12; i++ {
+		writeU32(&b, 0)
+	}
+
+	if b.Len() != int(textOffset) {
+		return nil, fmt.Errorf("onb: internal Mach-O layout mismatch: header=%d textOffset=%d", b.Len(), textOffset)
+	}
+	b.Write(enc.code)
+	b.Write(cstringData)
+	writePadding(&b, int(relocOffset)-b.Len())
+	if b.Len() != int(relocOffset) {
+		return nil, fmt.Errorf("onb: internal Mach-O layout mismatch: reloc=%d relocOffset=%d", b.Len(), relocOffset)
+	}
+	for _, reloc := range enc.relocs {
+		writeMachOReloc(&b, reloc)
+	}
+	if b.Len() != int(symoff) {
+		return nil, fmt.Errorf("onb: internal Mach-O layout mismatch: sym=%d symoff=%d", b.Len(), symoff)
+	}
+	for _, cstr := range program.CStrings {
+		writeMachONlist64(&b, strtab.add(asmCStringLabel(program.Target, cstr.Label)), machoNSect, machoCStringSectionNumber, 0, cstringAddrs[cstr.Label])
+	}
+	writeMachONlist64(&b, strtab.add(asmSymbolName(program.Target, "main")), machoNExt|machoNSect, machoTextSectionNumber, 0, 0)
+	for _, symbol := range enc.externalSymbols {
+		writeMachONlist64(&b, strtab.add(asmSymbolName(program.Target, symbol)), machoNExt, 0, 0, 0)
+	}
+	if b.Len() != int(stroff) {
+		return nil, fmt.Errorf("onb: internal Mach-O layout mismatch: str=%d stroff=%d", b.Len(), stroff)
+	}
+	b.Write(strtab.data)
+	out := b.Bytes()
+	binary.LittleEndian.PutUint32(out[strtabLenOffset:strtabLenOffset+4], uint32(len(strtab.data)))
+	return out, nil
+}
+
+func encodeMachOCStrings(cstrings []CStringLiteral, baseAddr uint64) ([]byte, map[string]uint64) {
+	var out []byte
+	addrs := make(map[string]uint64, len(cstrings))
+	for _, cstr := range cstrings {
+		addrs[cstr.Label] = baseAddr + uint64(len(out))
+		out = append(out, cstr.Value...)
+		out = append(out, 0)
+	}
+	return out, addrs
+}
+
+func encodeMachOTextWithRelocs(program *Program, cstringIndex map[string]uint32) (machoTextEncoding, error) {
+	if len(program.Functions) != 1 || program.Functions[0].Name != "main" {
+		return machoTextEncoding{}, fmt.Errorf("onb: Mach-O phase 1 only supports main")
+	}
+	fn := program.Functions[0]
+	if len(fn.Blocks) != 1 {
+		return machoTextEncoding{}, fmt.Errorf("onb: Mach-O phase 1 only supports one block")
+	}
+	externalIndex := map[string]uint32{}
+	var enc machoTextEncoding
+	needsFrame := functionNeedsFrame(fn)
+	needsStackArgs := functionNeedsStackArgs(fn)
+	if needsFrame {
+		if needsStackArgs {
+			enc.code = appendU32LE(enc.code, 0xd10083ff) // sub sp, sp, #32
+			enc.code = appendU32LE(enc.code, 0xa9017bfd) // stp x29, x30, [sp, #16]
+			enc.code = appendU32LE(enc.code, 0x910043fd) // add x29, sp, #16
+		} else {
+			enc.code = appendU32LE(enc.code, 0xa9bf7bfd) // stp x29, x30, [sp, #-16]!
+			enc.code = appendU32LE(enc.code, 0x910003fd) // mov x29, sp
+		}
+	}
+	for _, instr := range fn.Blocks[0].Instrs {
+		switch i := instr.(type) {
+		case *LoadCStringAddress:
+			if i.Dst != RegX0 {
+				return machoTextEncoding{}, fmt.Errorf("%w: Mach-O encoder only supports cstring loads into x0", ErrNotImplemented)
+			}
+			sym, ok := cstringIndex[i.Label]
+			if !ok {
+				return machoTextEncoding{}, fmt.Errorf("onb: unknown Mach-O string literal label %q", i.Label)
+			}
+			addr := uint32(len(enc.code))
+			enc.code = appendU32LE(enc.code, 0x90000000)
+			enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, pcrel: true, length: 2, extern: true, typ: machoARM64RelocPage21})
+			addr = uint32(len(enc.code))
+			enc.code = appendU32LE(enc.code, 0x91000000)
+			enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, length: 2, extern: true, typ: machoARM64RelocPageOff12})
+		case *BranchLink:
+			if i.Symbol == "" {
+				return machoTextEncoding{}, fmt.Errorf("onb: Mach-O branch without symbol")
+			}
+			sym, ok := externalIndex[i.Symbol]
+			if !ok {
+				sym = uint32(len(cstringIndex) + 1 + len(enc.externalSymbols))
+				externalIndex[i.Symbol] = sym
+				enc.externalSymbols = append(enc.externalSymbols, i.Symbol)
+			}
+			addr := uint32(len(enc.code))
+			enc.code = appendU32LE(enc.code, 0x94000000)
+			enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, pcrel: true, length: 2, extern: true, typ: machoARM64RelocBranch26})
+		case *MovImm32:
+			if i.Dst != RegW0 || i.Imm != 0 {
+				return machoTextEncoding{}, fmt.Errorf("onb: Mach-O phase 1 only supports mov w0, #0")
+			}
+			enc.code = append(enc.code, 0x00, 0x00, 0x80, 0x52)
+		case *MovImm64:
+			words, err := encodeMachOMovImm64(i.Dst, uint64(i.Imm))
+			if err != nil {
+				return machoTextEncoding{}, err
+			}
+			for _, word := range words {
+				enc.code = appendU32LE(enc.code, word)
+			}
+		case *Store64Stack:
+			word, err := encodeMachOStore64Stack(i)
+			if err != nil {
+				return machoTextEncoding{}, err
+			}
+			enc.code = appendU32LE(enc.code, word)
+		case *Ret:
+			if needsFrame {
+				if needsStackArgs {
+					enc.code = appendU32LE(enc.code, 0xa9417bfd) // ldp x29, x30, [sp, #16]
+					enc.code = appendU32LE(enc.code, 0x910083ff) // add sp, sp, #32
+				} else {
+					enc.code = appendU32LE(enc.code, 0xa8c17bfd) // ldp x29, x30, [sp], #16
+				}
+			}
+			enc.code = append(enc.code, 0xc0, 0x03, 0x5f, 0xd6)
+		default:
+			return machoTextEncoding{}, fmt.Errorf("%w: Mach-O encoder does not support %T", ErrNotImplemented, instr)
+		}
+	}
+	return enc, nil
+}
+
+func encodeMachOStore64Stack(instr *Store64Stack) (uint32, error) {
+	if instr.Offset < 0 || instr.Offset%8 != 0 {
+		return 0, fmt.Errorf("%w: Mach-O stack store offset %d", ErrNotImplemented, instr.Offset)
+	}
+	reg, ok := xRegisterNumber(instr.Src)
+	if !ok {
+		return 0, fmt.Errorf("%w: Mach-O stack store source %s", ErrNotImplemented, instr.Src)
+	}
+	scaled := uint32(instr.Offset / 8)
+	if scaled > 0xfff {
+		return 0, fmt.Errorf("%w: Mach-O stack store offset %d", ErrNotImplemented, instr.Offset)
+	}
+	return 0xf90003e0 | (scaled << 10) | reg, nil
+}
+
+func encodeMachOMovImm64(dst Reg, imm uint64) ([]uint32, error) {
+	reg, ok := xRegisterNumber(dst)
+	if !ok {
+		return nil, fmt.Errorf("%w: Mach-O mov64 destination %s", ErrNotImplemented, dst)
+	}
+	var out []uint32
+	for shift := 0; shift < 64; shift += 16 {
+		chunk := uint32((imm >> shift) & 0xffff)
+		if chunk == 0 && len(out) != 0 {
+			continue
+		}
+		hw := uint32(shift / 16)
+		if len(out) == 0 {
+			out = append(out, 0xd2800000|(hw<<21)|(chunk<<5)|reg)
+			continue
+		}
+		out = append(out, 0xf2800000|(hw<<21)|(chunk<<5)|reg)
+	}
+	if len(out) == 0 {
+		out = append(out, 0xd2800000|reg)
+	}
+	return out, nil
+}
+
+func encodeMachOText(program *Program) ([]byte, error) {
+	if len(program.Functions) != 1 || program.Functions[0].Name != "main" {
+		return nil, fmt.Errorf("onb: Mach-O phase 1.0 only supports main")
+	}
+	fn := program.Functions[0]
+	if len(fn.Blocks) != 1 {
+		return nil, fmt.Errorf("onb: Mach-O phase 1.0 only supports one block")
+	}
+	var out []byte
+	for _, instr := range fn.Blocks[0].Instrs {
+		switch i := instr.(type) {
+		case *MovImm32:
+			if i.Dst != RegW0 || i.Imm != 0 {
+				return nil, fmt.Errorf("onb: Mach-O phase 1.0 only supports mov w0, #0")
+			}
+			out = append(out, 0x00, 0x00, 0x80, 0x52)
+		case *Ret:
+			out = append(out, 0xc0, 0x03, 0x5f, 0xd6)
+		default:
+			return nil, fmt.Errorf("%w: Mach-O encoder does not support %T", ErrNotImplemented, instr)
+		}
+	}
+	return out, nil
+}
+
+func appendU32LE(out []byte, v uint32) []byte {
+	return append(out, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
+}
+
+func alignUp(v, align uint32) uint32 {
+	if align == 0 {
+		return v
+	}
+	rem := v % align
+	if rem == 0 {
+		return v
+	}
+	return v + align - rem
+}
+
+func writePadding(b *bytes.Buffer, n int) {
+	for i := 0; i < n; i++ {
+		b.WriteByte(0)
+	}
+}
+
+func writeMachOReloc(b *bytes.Buffer, reloc machoReloc) {
+	writeU32(b, reloc.address)
+	word := reloc.symbolnum & 0x00ffffff
+	if reloc.pcrel {
+		word |= 1 << 24
+	}
+	word |= uint32(reloc.length&0x3) << 25
+	if reloc.extern {
+		word |= 1 << 27
+	}
+	word |= uint32(reloc.typ&0xf) << 28
+	writeU32(b, word)
+}
+
+func writeMachONlist64(b *bytes.Buffer, strx uint32, typ uint8, sect uint8, desc uint16, value uint64) {
+	writeU32(b, strx)
+	b.WriteByte(typ)
+	b.WriteByte(sect)
+	writeU16(b, desc)
+	writeU64(b, value)
+}
+
+func writeU16(b *bytes.Buffer, v uint16) {
+	_ = binary.Write(b, binary.LittleEndian, v)
+}
+
+func writeU32(b *bytes.Buffer, v uint32) {
+	_ = binary.Write(b, binary.LittleEndian, v)
+}
+
+func writeU64(b *bytes.Buffer, v uint64) {
+	_ = binary.Write(b, binary.LittleEndian, v)
+}
+
+func writeName16(b *bytes.Buffer, name string) {
+	var buf [16]byte
+	copy(buf[:], []byte(name))
+	b.Write(buf[:])
+}

--- a/internal/onb/object.go
+++ b/internal/onb/object.go
@@ -1,0 +1,16 @@
+package onb
+
+import "fmt"
+
+// EmitObject emits a relocatable object for the current phase 1.0 ONB slice.
+func EmitObject(program *Program) ([]byte, error) {
+	if program == nil {
+		return nil, fmt.Errorf("onb: missing program")
+	}
+	switch program.Target.ObjectFormat {
+	case "mach-o":
+		return emitMachOObject(program)
+	default:
+		return nil, fmt.Errorf("%w: %s object writer", ErrNotImplemented, program.Target.ObjectFormat)
+	}
+}

--- a/internal/onb/onb.go
+++ b/internal/onb/onb.go
@@ -1,0 +1,178 @@
+// Package onb contains the Osty Native Backend dev/debug pipeline.
+//
+// ONB is intentionally not an LLVM replacement. It is the fast development
+// backend described in ONB_DESIGN.md: MIR in, simple aarch64 native pipeline
+// out, with LLVM remaining the release/reference backend.
+package onb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/osty/osty/internal/mir"
+)
+
+var (
+	// ErrNotImplemented marks ONB phases whose boundary is wired but whose
+	// implementation is still intentionally narrow.
+	ErrNotImplemented = errors.New("onb phase slice is not implemented")
+
+	// ErrUnsupportedTarget marks a target outside ONB's initial aarch64 scope.
+	ErrUnsupportedTarget = errors.New("onb target is outside phase 1.0 scope")
+)
+
+// Request is the backend-owned half of a build request. Host-facing CLI and
+// artifact layout stay in internal/backend; ONB starts from MIR.
+type Request struct {
+	Module       *mir.Module
+	TargetTriple string
+	EmitMode     string
+	ObjectPath   string
+	BinaryPath   string
+}
+
+// Target is the ONB-normalized target contract for phase 1.0.
+type Target struct {
+	Triple       string
+	OS           string
+	Arch         string
+	ObjectFormat string
+}
+
+// Stage is one planned ONB pipeline stage.
+type Stage struct {
+	Name   string
+	Status string
+}
+
+// Plan is the executable ONB phase boundary. Today it records the pipeline that
+// must exist before emission can succeed; later phases replace the scaffolded
+// stages with real data flowing between them.
+type Plan struct {
+	Target  Target
+	Emit    string
+	Program *Program
+	Stages  []Stage
+}
+
+// ResolveTarget accepts an explicit target triple, or infers the host target
+// when the triple is empty. ONB phase 1.0 is aarch64-only.
+func ResolveTarget(triple string) (Target, error) {
+	raw := strings.TrimSpace(triple)
+	if raw == "" {
+		raw = hostTriple()
+	}
+	lower := strings.ToLower(raw)
+	if !isAArch64Triple(lower) {
+		return Target{}, fmt.Errorf("%w: %q (want darwin/aarch64 or linux/aarch64)", ErrUnsupportedTarget, raw)
+	}
+	switch {
+	case strings.Contains(lower, "darwin") || strings.Contains(lower, "apple"):
+		return Target{Triple: raw, OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"}, nil
+	case strings.Contains(lower, "linux"):
+		return Target{Triple: raw, OS: "linux", Arch: "aarch64", ObjectFormat: "elf"}, nil
+	default:
+		return Target{}, fmt.Errorf("%w: %q (want darwin/aarch64 or linux/aarch64)", ErrUnsupportedTarget, raw)
+	}
+}
+
+func hostTriple() string {
+	arch := runtime.GOARCH
+	if arch == "arm64" {
+		arch = "aarch64"
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return arch + "-apple-darwin"
+	case "linux":
+		return arch + "-unknown-linux-gnu"
+	default:
+		return arch + "-" + runtime.GOOS
+	}
+}
+
+func isAArch64Triple(lower string) bool {
+	return strings.HasPrefix(lower, "aarch64-") || strings.HasPrefix(lower, "arm64-")
+}
+
+// BuildPlan validates the request and returns the phase 1.0 pipeline shape.
+func BuildPlan(req Request) (*Plan, error) {
+	if req.Module == nil {
+		return nil, fmt.Errorf("onb: missing MIR module")
+	}
+	target, err := ResolveTarget(req.TargetTriple)
+	if err != nil {
+		return nil, err
+	}
+	program, err := LowerMIR(req.Module, target)
+	if err != nil {
+		return nil, err
+	}
+	objectWriterStatus := "planned"
+	relocationStatus := "planned"
+	if target.ObjectFormat == "mach-o" {
+		objectWriterStatus = "implemented"
+		relocationStatus = "implemented"
+	}
+	return &Plan{
+		Target:  target,
+		Emit:    req.EmitMode,
+		Program: program,
+		Stages: []Stage{
+			{Name: "MIR consumer", Status: "implemented"},
+			{Name: "4-pass minimal optimizer", Status: "planned"},
+			{Name: "aarch64 LIR lowerer", Status: "implemented"},
+			{Name: "aarch64 assembly renderer", Status: "implemented"},
+			{Name: "linear register allocation", Status: "planned"},
+			{Name: target.ObjectFormat + " object writer", Status: objectWriterStatus},
+			{Name: "string/puts relocations", Status: relocationStatus},
+			{Name: "DWARF .debug_line", Status: "planned"},
+			{Name: "host linker", Status: "implemented"},
+		},
+	}, nil
+}
+
+// Compile returns the ONB plan plus the next broad pipeline stage that remains
+// intentionally planned. The backend adapter drives concrete artifact emission.
+func Compile(ctx context.Context, req Request) (*Plan, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	plan, err := BuildPlan(req)
+	if err != nil {
+		return nil, err
+	}
+	return plan, fmt.Errorf("%w: next stage is %s", ErrNotImplemented, plan.NextPlannedStage())
+}
+
+// StageSummary returns a compact human-readable stage list for diagnostics.
+func (p *Plan) StageSummary() string {
+	if p == nil || len(p.Stages) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(p.Stages))
+	for _, stage := range p.Stages {
+		if stage.Status == "" {
+			parts = append(parts, stage.Name)
+			continue
+		}
+		parts = append(parts, stage.Name+"="+stage.Status)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// NextPlannedStage returns the first stage still waiting for implementation.
+func (p *Plan) NextPlannedStage() string {
+	if p == nil {
+		return ""
+	}
+	for _, stage := range p.Stages {
+		if stage.Status == "planned" {
+			return stage.Name
+		}
+	}
+	return ""
+}

--- a/internal/onb/onb_test.go
+++ b/internal/onb/onb_test.go
@@ -1,0 +1,408 @@
+package onb
+
+import (
+	"bytes"
+	"debug/macho"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/mir"
+)
+
+func TestResolveTargetAcceptsPhaseOneAArch64Targets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		triple string
+		os     string
+		format string
+	}{
+		{triple: "aarch64-apple-darwin", os: "darwin", format: "mach-o"},
+		{triple: "arm64-apple-darwin", os: "darwin", format: "mach-o"},
+		{triple: "aarch64-unknown-linux-gnu", os: "linux", format: "elf"},
+	}
+	for _, tt := range tests {
+		got, err := ResolveTarget(tt.triple)
+		if err != nil {
+			t.Fatalf("ResolveTarget(%q) returned error: %v", tt.triple, err)
+		}
+		if got.OS != tt.os || got.Arch != "aarch64" || got.ObjectFormat != tt.format {
+			t.Fatalf("ResolveTarget(%q) = %+v", tt.triple, got)
+		}
+	}
+}
+
+func TestResolveTargetRejectsNonAArch64(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveTarget("x86_64-unknown-linux-gnu")
+	if !errors.Is(err, ErrUnsupportedTarget) {
+		t.Fatalf("ResolveTarget() error = %v, want ErrUnsupportedTarget", err)
+	}
+}
+
+func TestCompileReturnsPhasePlanAndNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	mod := &mir.Module{
+		Functions: []*mir.Function{unitMainMIR()},
+	}
+	plan, err := Compile(t.Context(), Request{
+		Module:       mod,
+		TargetTriple: "aarch64-apple-darwin",
+		EmitMode:     "object",
+	})
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("Compile() error = %v, want ErrNotImplemented", err)
+	}
+	if plan == nil {
+		t.Fatal("Compile() returned nil plan")
+	}
+	if plan.Program == nil || len(plan.Program.Functions) != 1 {
+		t.Fatalf("Compile() program = %+v", plan.Program)
+	}
+	if got := plan.StageSummary(); !strings.Contains(got, "MIR consumer=implemented") {
+		t.Fatalf("StageSummary() = %q", got)
+	}
+	if got := plan.StageSummary(); !strings.Contains(got, "aarch64 assembly renderer=implemented") {
+		t.Fatalf("StageSummary() = %q", got)
+	}
+	if got := plan.NextPlannedStage(); got != "4-pass minimal optimizer" {
+		t.Fatalf("NextPlannedStage() = %q, want 4-pass minimal optimizer", got)
+	}
+}
+
+func TestLowerMIRLowersUnitMainToAArch64LIR(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{unitMainMIR()},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	if len(program.Functions) != 1 || len(program.Functions[0].Blocks) != 1 {
+		t.Fatalf("LowerMIR() = %+v", program)
+	}
+	instrs := program.Functions[0].Blocks[0].Instrs
+	if len(instrs) != 2 {
+		t.Fatalf("main instr count = %d, want 2", len(instrs))
+	}
+	mov, ok := instrs[0].(*MovImm32)
+	if !ok {
+		t.Fatalf("main instr[0] = %T, want *MovImm32", instrs[0])
+	}
+	if mov.Dst != RegW0 || mov.Imm != 0 {
+		t.Fatalf("main mov = %+v, want w0/#0", mov)
+	}
+	if _, ok := instrs[1].(*Ret); !ok {
+		t.Fatalf("main instr[1] = %T, want *Ret", instrs[1])
+	}
+}
+
+func TestLowerMIRLowersPrintlnStringLiteral(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{helloMainMIR("hi")},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	if len(program.CStrings) != 1 {
+		t.Fatalf("CStrings = %+v, want one literal", program.CStrings)
+	}
+	if program.CStrings[0].Label != "str0" || program.CStrings[0].Value != "hi" {
+		t.Fatalf("CStrings[0] = %+v, want str0/hi", program.CStrings[0])
+	}
+	instrs := program.Functions[0].Blocks[0].Instrs
+	if len(instrs) != 4 {
+		t.Fatalf("main instr count = %d, want 4", len(instrs))
+	}
+	load, ok := instrs[0].(*LoadCStringAddress)
+	if !ok {
+		t.Fatalf("main instr[0] = %T, want *LoadCStringAddress", instrs[0])
+	}
+	if load.Dst != RegX0 || load.Label != "str0" {
+		t.Fatalf("load = %+v, want x0/str0", load)
+	}
+	bl, ok := instrs[1].(*BranchLink)
+	if !ok {
+		t.Fatalf("main instr[1] = %T, want *BranchLink", instrs[1])
+	}
+	if bl.Symbol != "puts" {
+		t.Fatalf("branch symbol = %q, want puts", bl.Symbol)
+	}
+}
+
+func TestLowerMIRLowersPrintlnIntLiteral(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{intPrintlnMainMIR(123)},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	if len(program.CStrings) != 1 || program.CStrings[0].Value != "%lld\n" {
+		t.Fatalf("CStrings = %+v, want printf format", program.CStrings)
+	}
+	instrs := program.Functions[0].Blocks[0].Instrs
+	if len(instrs) != 6 {
+		t.Fatalf("main instr count = %d, want 6", len(instrs))
+	}
+	mov, ok := instrs[1].(*MovImm64)
+	if !ok {
+		t.Fatalf("main instr[1] = %T, want *MovImm64", instrs[1])
+	}
+	if mov.Dst != RegX1 || mov.Imm != 123 {
+		t.Fatalf("mov64 = %+v, want x1/#123", mov)
+	}
+	store, ok := instrs[2].(*Store64Stack)
+	if !ok {
+		t.Fatalf("main instr[2] = %T, want *Store64Stack", instrs[2])
+	}
+	if store.Src != RegX1 || store.Offset != 0 {
+		t.Fatalf("store = %+v, want x1/[sp]", store)
+	}
+	bl, ok := instrs[3].(*BranchLink)
+	if !ok {
+		t.Fatalf("main instr[3] = %T, want *BranchLink", instrs[3])
+	}
+	if bl.Symbol != "printf" {
+		t.Fatalf("branch symbol = %q, want printf", bl.Symbol)
+	}
+}
+
+func TestRenderAssemblyRendersDarwinMain(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{unitMainMIR()},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	asm, err := RenderAssembly(program)
+	if err != nil {
+		t.Fatalf("RenderAssembly() returned error: %v", err)
+	}
+	text := string(asm)
+	for _, want := range []string{".globl _main", "_main:", "\tmov w0, #0", "\tret"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderAssemblyRendersDarwinPrintlnLiteral(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{helloMainMIR("hi")},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	asm, err := RenderAssembly(program)
+	if err != nil {
+		t.Fatalf("RenderAssembly() returned error: %v", err)
+	}
+	text := string(asm)
+	for _, want := range []string{
+		"\tstp x29, x30, [sp, #-16]!",
+		"\tadrp x0, L_.str0@PAGE",
+		"\tadd x0, x0, L_.str0@PAGEOFF",
+		"\tbl _puts",
+		"\tldp x29, x30, [sp], #16",
+		".section __TEXT,__cstring,cstring_literals",
+		"L_.str0:",
+		"\t.asciz \"hi\"",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderAssemblyRendersDarwinPrintlnIntLiteral(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{intPrintlnMainMIR(123)},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	asm, err := RenderAssembly(program)
+	if err != nil {
+		t.Fatalf("RenderAssembly() returned error: %v", err)
+	}
+	text := string(asm)
+	for _, want := range []string{
+		"\tsub sp, sp, #32",
+		"\tadrp x0, L_.str0@PAGE",
+		"\tmovz x1, #123",
+		"\tstr x1, [sp]",
+		"\tbl _printf",
+		"\tadd sp, sp, #32",
+		"\t.asciz \"%lld\\n\"",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("assembly missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestEmitObjectWritesMinimalMachO(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{unitMainMIR()},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	obj, err := EmitObject(program)
+	if err != nil {
+		t.Fatalf("EmitObject() returned error: %v", err)
+	}
+	f, err := macho.NewFile(bytes.NewReader(obj))
+	if err != nil {
+		t.Fatalf("macho.NewFile() returned error: %v", err)
+	}
+	if f.Type != macho.TypeObj {
+		t.Fatalf("Mach-O type = %v, want object", f.Type)
+	}
+	if f.Cpu != macho.CpuArm64 {
+		t.Fatalf("Mach-O CPU = %v, want arm64", f.Cpu)
+	}
+	if len(f.Sections) != 1 || f.Sections[0].Name != "__text" {
+		t.Fatalf("Mach-O sections = %+v", f.Sections)
+	}
+	text, err := f.Sections[0].Data()
+	if err != nil {
+		t.Fatalf("__text Data() returned error: %v", err)
+	}
+	wantText := []byte{0x00, 0x00, 0x80, 0x52, 0xc0, 0x03, 0x5f, 0xd6}
+	if !bytes.Equal(text, wantText) {
+		t.Fatalf("__text = % x, want % x", text, wantText)
+	}
+	if f.Symtab == nil || len(f.Symtab.Syms) != 1 || f.Symtab.Syms[0].Name != "_main" {
+		t.Fatalf("Mach-O symtab = %+v", f.Symtab)
+	}
+}
+
+func TestEmitObjectWritesMachOPrintlnRelocations(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{helloMainMIR("hi")},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	obj, err := EmitObject(program)
+	if err != nil {
+		t.Fatalf("EmitObject() returned error: %v", err)
+	}
+	f, err := macho.NewFile(bytes.NewReader(obj))
+	if err != nil {
+		t.Fatalf("macho.NewFile() returned error: %v", err)
+	}
+	if len(f.Sections) != 2 || f.Sections[0].Name != "__text" || f.Sections[1].Name != "__cstring" {
+		t.Fatalf("Mach-O sections = %+v", f.Sections)
+	}
+	if len(f.Sections[0].Relocs) != 3 {
+		t.Fatalf("__text relocs = %+v, want 3", f.Sections[0].Relocs)
+	}
+	if f.Symtab == nil {
+		t.Fatal("Mach-O symtab is nil")
+	}
+	var sawMain, sawString, sawPuts bool
+	for _, sym := range f.Symtab.Syms {
+		switch sym.Name {
+		case "_main":
+			sawMain = true
+		case "L_.str0":
+			sawString = true
+		case "_puts":
+			sawPuts = true
+		}
+	}
+	if !sawMain || !sawString || !sawPuts {
+		t.Fatalf("Mach-O symbols = %+v, want _main, L_.str0, _puts", f.Symtab.Syms)
+	}
+}
+
+func TestEmitObjectWritesMachOPrintlnIntRelocations(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(&mir.Module{
+		Functions: []*mir.Function{intPrintlnMainMIR(123)},
+	}, Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR() returned error: %v", err)
+	}
+	obj, err := EmitObject(program)
+	if err != nil {
+		t.Fatalf("EmitObject() returned error: %v", err)
+	}
+	f, err := macho.NewFile(bytes.NewReader(obj))
+	if err != nil {
+		t.Fatalf("macho.NewFile() returned error: %v", err)
+	}
+	if len(f.Sections) != 2 || f.Sections[0].Name != "__text" || f.Sections[1].Name != "__cstring" {
+		t.Fatalf("Mach-O sections = %+v", f.Sections)
+	}
+	if len(f.Sections[0].Relocs) != 3 {
+		t.Fatalf("__text relocs = %+v, want 3", f.Sections[0].Relocs)
+	}
+	var sawPrintf bool
+	for _, sym := range f.Symtab.Syms {
+		if sym.Name == "_printf" {
+			sawPrintf = true
+		}
+	}
+	if !sawPrintf {
+		t.Fatalf("Mach-O symbols = %+v, want _printf", f.Symtab.Syms)
+	}
+}
+
+func unitMainMIR() *mir.Function {
+	fn := &mir.Function{
+		Name:        "main",
+		ReturnType:  mir.TUnit,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TUnit, IsReturn: true},
+		},
+	}
+	block := fn.NewBlock(mir.Span{})
+	fn.Block(block).SetTerminator(&mir.ReturnTerm{})
+	return fn
+}
+
+func helloMainMIR(text string) *mir.Function {
+	fn := unitMainMIR()
+	fn.Block(fn.Entry).Instrs = append(fn.Block(fn.Entry).Instrs, &mir.IntrinsicInstr{
+		Kind: mir.IntrinsicPrintln,
+		Args: []mir.Operand{
+			&mir.ConstOp{Const: &mir.StringConst{Value: text}, T: mir.TString},
+		},
+	})
+	return fn
+}
+
+func intPrintlnMainMIR(value int64) *mir.Function {
+	fn := unitMainMIR()
+	fn.Block(fn.Entry).Instrs = append(fn.Block(fn.Entry).Instrs, &mir.IntrinsicInstr{
+		Kind: mir.IntrinsicPrintln,
+		Args: []mir.Operand{
+			&mir.ConstOp{Const: &mir.IntConst{Value: value, T: mir.TInt}, T: mir.TInt},
+		},
+	})
+	return fn
+}

--- a/internal/runner/policy.go
+++ b/internal/runner/policy.go
@@ -195,6 +195,9 @@ func ToolEmitCompat(tool, backend, emit string) *Diag {
 		if backend == "llvm" && emit != "llvm-ir" {
 			return toolEmitMismatch(tool, backend, emit, "llvm-ir", "R0011")
 		}
+		if backend == "onb" && emit != "asm" {
+			return toolEmitMismatch(tool, backend, emit, "asm", "R0013")
+		}
 	}
 	if tool == "run" || tool == "test" {
 		if emit != "binary" {

--- a/toolchain/runner.osty
+++ b/toolchain/runner.osty
@@ -233,6 +233,9 @@ pub fn toolEmitCompat(tool: String, backend: String, emit: String) -> RunnerDiag
         if backend == "llvm" && emit != "llvm-ir" {
             return Some(toolEmitMismatch(tool, backend, emit, "llvm-ir", "R0011"))
         }
+        if backend == "onb" && emit != "asm" {
+            return Some(toolEmitMismatch(tool, backend, emit, "asm", "R0013"))
+        }
     }
     if tool == "run" || tool == "test" {
         if emit != "binary" {


### PR DESCRIPTION
## Summary

- Adds the ONB dev/debug backend package and wires `--backend onb` through backend selection, artifact layout, CLI help, and runner emit compatibility.
- Lowers the first practical ONB slice from MIR into aarch64 LIR: empty `main`, `println("literal")`, and `println(123)`.
- Emits readable assembly plus Mach-O relocatable objects with `__cstring`, `_puts` / `_printf` calls, aarch64 relocations, and Darwin varargs stack handling.
- Documents ONB as the primary LLVM-complementary debug backend plan and clarifies how it relates to the MIR emitter port document.

## Validation

- `go test -count=1 -vet=off ./internal/onb ./internal/backend -run "TestResolveTarget|TestCompileReturnsPhasePlan|TestLowerMIR|TestRenderAssembly|TestEmitObject|TestONBBackend"`
- `go test -count=1 -vet=off ./cmd/osty ./internal/runner -run "Test.*Backend|Test.*Emit|TestPrepareGen|TestToolEmit"`
- `git diff --check`