### PR TITLE
[codex] optimize selfhost function index lookup

### DIFF
--- a/cmd/osty/dump_native_diags.go
+++ b/cmd/osty/dump_native_diags.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 
 	"github.com/osty/osty/internal/check"
-	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/selfhost/api"
 )
 
 type nativeDiagTelemetry struct {
@@ -51,7 +51,7 @@ func dumpNativeDiagsFor(label string, chk *check.Result) {
 // dumpNativeDiagsForSummary is the native CLI-path sibling of
 // dumpNativeDiagsFor: it reads the already-materialized self-host
 // summary directly instead of going through check.Result.
-func dumpNativeDiagsForSummary(label string, summary selfhost.CheckSummary) {
+func dumpNativeDiagsForSummary(label string, summary api.CheckSummary) {
 	dumpNativeDiagTelemetry(label, nativeDiagTelemetry{
 		Assignments:     summary.Assignments,
 		Accepted:        summary.Accepted,

--- a/cmd/osty/native_check.go
+++ b/cmd/osty/native_check.go
@@ -608,14 +608,14 @@ func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flag
 	return 0
 }
 
-func nativeCheckFile(path string, src []byte) ([]*diag.Diagnostic, selfhost.CheckResult, error) {
+func nativeCheckFile(path string, src []byte) ([]*diag.Diagnostic, api.CheckResult, error) {
 	run := selfhost.Run(src)
 	parseDiags := run.Diagnostics()
 	if hasError(parseDiags) {
-		return parseDiags, selfhost.CheckResult{}, nil
+		return parseDiags, api.CheckResult{}, nil
 	}
 	imports := nativeFileImportSurfaces(run)
-	var checked selfhost.CheckResult
+	var checked api.CheckResult
 	if len(imports) > 0 {
 		var err error
 		checked, err = selfhost.CheckPackageStructured(api.PackageCheckInput{
@@ -627,7 +627,7 @@ func nativeCheckFile(path string, src []byte) ([]*diag.Diagnostic, selfhost.Chec
 			}},
 		})
 		if err != nil {
-			return parseDiags, selfhost.CheckResult{}, err
+			return parseDiags, api.CheckResult{}, err
 		}
 	} else {
 		_, checked = selfhost.CheckFromSource(src)

--- a/internal/selfhost/check_index_fastpath_test.go
+++ b/internal/selfhost/check_index_fastpath_test.go
@@ -31,6 +31,31 @@ func TestCheckLookupExactIndexReturnsLatestValue(t *testing.T) {
 	}
 }
 
+func TestCheckFnIndexSlotReturnsLatestRegistration(t *testing.T) {
+	arena := emptyTyArena()
+	env := emptyCheckEnv(arena)
+	first := &CheckFnSig{name: "value", owner: "Box", retTy: tInt(arena)}
+	second := &CheckFnSig{name: "value", owner: "Box", retTy: tString(arena)}
+
+	checkRegisterFn(env, first)
+	key := checkFnKey("value", "Box")
+	firstSlot, ok := env.fnIndexSlots[key]
+	if !ok {
+		t.Fatalf("fnIndexSlots missing key %q", key)
+	}
+
+	checkRegisterFn(env, second)
+	if got := len(env.fnIndexKeys); got != 1 {
+		t.Fatalf("fnIndexKeys len = %d, want 1", got)
+	}
+	if got := env.fnIndexSlots[key]; got != firstSlot {
+		t.Fatalf("fnIndexSlots[%q] = %d, want %d", key, got, firstSlot)
+	}
+	if got := checkLookupFn(env, "value", "Box"); got != second {
+		t.Fatalf("checkLookupFn returned %#v, want latest registration", got)
+	}
+}
+
 func TestCheckHashKeyIsStable(t *testing.T) {
 	if got, want := checkHashKey("hello::world"), checkHashKey("hello::world"); got != want {
 		t.Fatalf("checkHashKey is not stable: %d != %d", got, want)

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -34058,6 +34058,7 @@ type CheckEnv struct {
 	fnIndexKeys             []string
 	fnIndexHashes           []int
 	fnIndexValues           []int
+	fnIndexSlots            map[string]int
 	fnBodyKeys              []string
 	fnBodyHashes            []int
 	fields                  []*CheckFieldSig
@@ -34105,7 +34106,7 @@ type CheckEnv struct {
 
 // Osty: /tmp/selfhost_merged.osty:14398:5
 func emptyCheckEnv(tys *TyArena) *CheckEnv {
-	return &CheckEnv{tys: tys, bindings: make([]*CheckBinding, 0, 1), bindingIndexNames: make([]string, 0, 1), bindingIndexHashes: make([]int, 0, 1), bindingIndexStacks: make([][]*CheckBinding, 0, 1), fns: make([]*CheckFnSig, 0, 1), fnIndexKeys: make([]string, 0, 1), fnIndexHashes: make([]int, 0, 1), fnIndexValues: make([]int, 0, 1), fnBodyKeys: make([]string, 0, 1), fnBodyHashes: make([]int, 0, 1), fields: make([]*CheckFieldSig, 0, 1), fieldIndexKeys: make([]string, 0, 1), fieldIndexHashes: make([]int, 0, 1), fieldIndexValues: make([]int, 0, 1), variants: make([]*CheckVariantSig, 0, 1), variantIndexKeys: make([]string, 0, 1), variantIndexHashes: make([]int, 0, 1), variantIndexValues: make([]int, 0, 1), variantOwnerIndexKeys: make([]string, 0, 1), variantOwnerIndexHashes: make([]int, 0, 1), variantOwnerIndexValues: make([]int, 0, 1), aliases: make([]*CheckAliasSig, 0, 1), aliasIndexKeys: make([]string, 0, 1), aliasIndexHashes: make([]int, 0, 1), aliasIndexValues: make([]int, 0, 1), types: make([]*CheckTypeSig, 0, 1), typeIndexKeys: make([]string, 0, 1), typeIndexHashes: make([]int, 0, 1), typeIndexValues: make([]int, 0, 1), interfaces: make([]string, 0, 1), interfaceIndexKeys: make([]string, 0, 1), interfaceIndexHashes: make([]int, 0, 1), interfaceExtends: make([]*CheckInterfaceExt, 0, 1), importAliases: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1), genericBoundIndexNames: make([]string, 0, 1), genericBoundIndexHashes: make([]int, 0, 1), genericBoundIndexStacks: make([][]int, 0, 1), aliasDeepCache: make([]int, 0, 1), substCacheKeys: make([]string, 0, 1), substCacheHashes: make([]int, 0, 1), substCacheValues: make([]int, 0, 1), returnTy: tErr(tys), fnName: "", inLoop: false, diagnostics: make([]*CheckDiagnostic, 0, 1), assignments: 0, accepted: 0, bindingRecords: make([]*CheckBindingRecord, 0, 1), symbolRecords: make([]*CheckSymbolRecord, 0, 1), instantiations: make([]*CheckInstantiationRecord, 0, 1)}
+	return &CheckEnv{tys: tys, bindings: make([]*CheckBinding, 0, 1), bindingIndexNames: make([]string, 0, 1), bindingIndexHashes: make([]int, 0, 1), bindingIndexStacks: make([][]*CheckBinding, 0, 1), fns: make([]*CheckFnSig, 0, 256), fnIndexKeys: make([]string, 0, 256), fnIndexHashes: make([]int, 0, 256), fnIndexValues: make([]int, 0, 256), fnIndexSlots: make(map[string]int, 256), fnBodyKeys: make([]string, 0, 1), fnBodyHashes: make([]int, 0, 1), fields: make([]*CheckFieldSig, 0, 1), fieldIndexKeys: make([]string, 0, 1), fieldIndexHashes: make([]int, 0, 1), fieldIndexValues: make([]int, 0, 1), variants: make([]*CheckVariantSig, 0, 1), variantIndexKeys: make([]string, 0, 1), variantIndexHashes: make([]int, 0, 1), variantIndexValues: make([]int, 0, 1), variantOwnerIndexKeys: make([]string, 0, 1), variantOwnerIndexHashes: make([]int, 0, 1), variantOwnerIndexValues: make([]int, 0, 1), aliases: make([]*CheckAliasSig, 0, 1), aliasIndexKeys: make([]string, 0, 1), aliasIndexHashes: make([]int, 0, 1), aliasIndexValues: make([]int, 0, 1), types: make([]*CheckTypeSig, 0, 1), typeIndexKeys: make([]string, 0, 1), typeIndexHashes: make([]int, 0, 1), typeIndexValues: make([]int, 0, 1), interfaces: make([]string, 0, 1), interfaceIndexKeys: make([]string, 0, 1), interfaceIndexHashes: make([]int, 0, 1), interfaceExtends: make([]*CheckInterfaceExt, 0, 1), importAliases: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1), genericBoundIndexNames: make([]string, 0, 1), genericBoundIndexHashes: make([]int, 0, 1), genericBoundIndexStacks: make([][]int, 0, 1), aliasDeepCache: make([]int, 0, 1), substCacheKeys: make([]string, 0, 1), substCacheHashes: make([]int, 0, 1), substCacheValues: make([]int, 0, 1), returnTy: tErr(tys), fnName: "", inLoop: false, diagnostics: make([]*CheckDiagnostic, 0, 1), assignments: 0, accepted: 0, bindingRecords: make([]*CheckBindingRecord, 0, 1), symbolRecords: make([]*CheckSymbolRecord, 0, 1), instantiations: make([]*CheckInstantiationRecord, 0, 1)}
 }
 
 // Osty: /tmp/selfhost_merged.osty:14463:5
@@ -34267,28 +34268,42 @@ func checkRegisterFn(env *CheckEnv, sig *CheckFnSig) {
 	idx := len(env.fns)
 	_ = idx
 	// Osty: /tmp/selfhost_merged.osty:14553:5
-	func() struct{} { env.fns = append(env.fns, sig); return struct{}{} }()
+	env.fns = append(env.fns, sig)
 	// Osty: /tmp/selfhost_merged.osty:14554:5
 	key := checkFnKey(sig.name, sig.owner)
 	_ = key
-	// Osty: /tmp/selfhost_merged.osty:14555:5
-	keyHash := checkHashKey(key)
-	_ = keyHash
 	// Osty: /tmp/selfhost_merged.osty:14556:5
-	slot := checkNameIndex(env.fnIndexKeys, env.fnIndexHashes, key, keyHash)
+	slot := checkFnIndexSlot(env, key)
 	_ = slot
 	// Osty: /tmp/selfhost_merged.osty:14557:5
 	if slot < 0 {
+		// Osty: /tmp/selfhost_merged.osty:14555:5
+		keyHash := checkHashKey(key)
+		_ = keyHash
 		// Osty: /tmp/selfhost_merged.osty:14558:9
-		func() struct{} { env.fnIndexKeys = append(env.fnIndexKeys, key); return struct{}{} }()
+		env.fnIndexKeys = append(env.fnIndexKeys, key)
 		// Osty: /tmp/selfhost_merged.osty:14559:9
-		func() struct{} { env.fnIndexHashes = append(env.fnIndexHashes, keyHash); return struct{}{} }()
+		env.fnIndexHashes = append(env.fnIndexHashes, keyHash)
 		// Osty: /tmp/selfhost_merged.osty:14560:9
-		func() struct{} { env.fnIndexValues = append(env.fnIndexValues, idx); return struct{}{} }()
+		env.fnIndexValues = append(env.fnIndexValues, idx)
+		env.fnIndexSlots[key] = len(env.fnIndexValues) - 1
 	} else {
 		// Osty: /tmp/selfhost_merged.osty:14562:26
 		env.fnIndexValues[slot] = idx
 	}
+}
+
+func checkFnIndexSlot(env *CheckEnv, key string) int {
+	if env.fnIndexSlots == nil {
+		env.fnIndexSlots = make(map[string]int, len(env.fnIndexKeys)+1)
+		for i, existing := range env.fnIndexKeys {
+			env.fnIndexSlots[existing] = i
+		}
+	}
+	if slot, ok := env.fnIndexSlots[key]; ok {
+		return slot
+	}
+	return -1
 }
 
 func checkMarkImportAlias(env *CheckEnv, alias string) {
@@ -34343,7 +34358,12 @@ func checkLookupFn(env *CheckEnv, name string, owner string) *CheckFnSig {
 	key := checkFnKey(name, owner)
 	_ = key
 	// Osty: /tmp/selfhost_merged.osty:14583:5
-	idx := checkLookupExactIndex(env.fnIndexKeys, env.fnIndexHashes, env.fnIndexValues, key, checkHashKey(key))
+	slot := checkFnIndexSlot(env, key)
+	_ = slot
+	idx := -1
+	if slot >= 0 {
+		idx = env.fnIndexValues[slot]
+	}
 	_ = idx
 	// Osty: /tmp/selfhost_merged.osty:14584:5
 	if idx >= 0 {


### PR DESCRIPTION
## Summary
- Add a Go-side slot map for selfhost function signature indexes so registration and lookup avoid repeated reverse scans.
- Pre-size the prelude function index slices/map and remove hot append wrapper calls in `checkRegisterFn`.
- Switch native CLI file-check result plumbing to `internal/selfhost/api` types directly so the selfhost authority test passes on latest `main`.

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'Test(CheckSnapshot|TyKey|CheckFnKey|CheckOwnerKey|CheckNameIndex|CheckLookupExactIndex|CheckHashKey|CheckFnIndexSlotReturnsLatestRegistration)'`
- `go test -count=1 -vet=off ./internal/selfhost`
- `go test -count=1 -vet=off ./cmd/osty -run '^$'`
- `go build ./cmd/osty ./cmd/osty-native-checker`
- `git diff --check`
- `go test -count=1 -vet=off ./internal/selfhost -run '^$' -bench 'Benchmark(CheckStructuredFromRun|CheckDiagnosticsAsDiag)' -benchmem`

## Note
- `go run ./cmd/osty check --native toolchain/check_env.osty` currently fails on latest `main` due an unrelated native checker diagnostic in `toolchain/lir_proto.osty` (`E0740 unreachable pattern`).