### PR TITLE
[codex] tighten self-rebuild ratchet

### DIFF
--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -10,14 +10,13 @@ Runs the self-rebuild ratchet:
   1. host osty validates the toolchain sources and current MIR gates
   2. host osty builds osty-self-1 from toolchain/
   3. osty-self-1 builds osty-self-2 from toolchain/
-  4. osty-self-1 and osty-self-2 are compared byte-for-byte
+  4. osty-self-2 builds osty-self-3 from toolchain/
+  5. osty-self-2 and osty-self-3 are compared byte-for-byte
 
 Environment overrides:
 
   OSTY_SELF_REBUILD_DIR             staging dir (default .osty/self-rebuild)
   OSTY_SELF_REBUILD_TOOLCHAIN_DIR   toolchain package dir (default toolchain)
-  OSTY_SELF_REBUILD_STAGE1_BIN      prebuilt osty-self-1 binary
-  OSTY_SELF_REBUILD_STAGE2_BIN      prebuilt osty-self-2 binary
   OSTY_SELF_REBUILD_STAGE1_CACHE    reusable osty-self-1 cache (default .osty/self-rebuild-cache/osty-self-1)
 
 --gates-only stops after the currently available host-side gates.
@@ -152,6 +151,15 @@ copy_override_binary() {
 	chmod +x "$dest"
 }
 
+reject_external_stage_overrides() {
+	local name
+	for name in OSTY_SELF_REBUILD_STAGE1_BIN OSTY_SELF_REBUILD_STAGE2_BIN OSTY_SELF_REBUILD_STAGE3_BIN; do
+		if [[ -n "${!name:-}" ]]; then
+			fail "$name is disabled for the self-rebuild ratchet; every stage must be produced by the previous stage"
+		fi
+	done
+}
+
 cache_stage1_binary() {
 	local src="$1"
 	local cache_dir
@@ -177,6 +185,7 @@ build_self_binary() {
 	local driver="$1"
 	local label="$2"
 	local dest="$3"
+	local host_guard="${4:-}"
 	local before="$stage_root/$label.before"
 	local after="$stage_root/$label.after"
 	local candidates="$stage_root/$label.candidates"
@@ -186,7 +195,11 @@ build_self_binary() {
 	log "$label: build toolchain package with $driver"
 	local forward_args
 	printf -v forward_args 'build\n--backend=llvm\n--emit\nbinary\n--force\n%s' "$toolchain_dir"
-	OSTY_SELF_REBUILD_HOST_BIN="$host_bin" OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
+	if [[ -n "$host_guard" ]]; then
+		OSTY_SELF_REBUILD_HOST_BIN="$host_guard" OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
+	else
+		OSTY_SELF_REBUILD_FORWARD_ARGS="$forward_args" "$driver" build --backend=llvm --emit binary --force "$toolchain_dir"
+	fi
 	snapshot_binaries "$after"
 	comm -13 "$before" "$after" >"$candidates"
 
@@ -222,35 +235,30 @@ build_self_binary() {
 smoke_self_driver() {
 	local driver="$1"
 	local label="$2"
-	local reported_host
 	local out
 
 	require_exec "$driver" "$label driver"
 
-	log "$label: smoke selfhost host selection"
-	if ! reported_host="$(cd "$root" && OSTY_SELF_REBUILD_HOST_BIN="$host_bin" "$driver" --selfhost-host 2>&1)"; then
-		printf '%s\n' "$reported_host" >&2
-		fail "$label selfhost host selection failed"
+	log "$label: smoke self-rebuild doctor"
+	if ! out="$(cd "$root" && "$driver" --selfhost-doctor 2>&1)"; then
+		printf '%s\n' "$out" >&2
+		fail "$label is not a real self-rebuild compiler yet"
 	fi
-	if [[ "$reported_host" != "$host_bin" ]]; then
-		printf 'self-rebuild: %s reported unexpected host:\n' "$label" >&2
-		printf '  expected: %s\n' "$host_bin" >&2
-		printf '  actual:   %s\n' "$reported_host" >&2
-		exit 1
+	if [[ "$out" != *"osty-self host compiler: disabled"* || "$out" != *"osty-self source compiler: enabled"* || "$out" != *"osty-self self-rebuild probe: OK"* ]]; then
+		printf '%s\n' "$out" >&2
+		fail "$label selfhost doctor did not report host-free OK"
 	fi
+}
 
-	log "$label: smoke selfhost doctor"
-	if ! out="$(cd "$root" && OSTY_SELF_REBUILD_HOST_BIN="$host_bin" "$driver" --selfhost-doctor 2>&1)"; then
-		printf '%s\n' "$out" >&2
-		fail "$label selfhost doctor failed"
-	fi
-	case "$out" in
-	*"osty-self host probe: OK"*) ;;
-	*)
-		printf '%s\n' "$out" >&2
-		fail "$label selfhost doctor did not report OK"
-		;;
-	esac
+prepare_host_guard() {
+	local guard="$stage_root/host-compiler-forbidden"
+	cat >"$guard" <<'SH'
+#!/usr/bin/env bash
+echo "self-rebuild: host compiler forwarding is forbidden after stage1" >&2
+exit 86
+SH
+	chmod +x "$guard"
+	printf '%s\n' "$guard"
 }
 
 emit_stage1_ir() {
@@ -277,6 +285,7 @@ run_gates() {
 
 require_exec "$host_bin" "host osty"
 [[ -d "$toolchain_dir" ]] || fail "toolchain dir not found: $toolchain_dir"
+reject_external_stage_overrides
 
 if [[ "$skip_gates" == "0" ]]; then
 	run_gates
@@ -292,16 +301,15 @@ rm -rf "$stage_root"
 mkdir -p "$stage_root"
 stage1="$stage_root/osty-self-1"
 stage2="$stage_root/osty-self-2"
+stage3="$stage_root/osty-self-3"
+host_guard="$(prepare_host_guard)"
 
 if [[ "$mode" == "ir" ]]; then
 	emit_stage1_ir
 	exit 0
 fi
 
-if [[ -n "${OSTY_SELF_REBUILD_STAGE1_BIN:-}" ]]; then
-	log "stage1: use override $OSTY_SELF_REBUILD_STAGE1_BIN"
-	copy_override_binary "$OSTY_SELF_REBUILD_STAGE1_BIN" "$stage1" "osty-self-1 override"
-elif [[ "$reuse_stage1" == "1" && -x "$stage1_cache" ]]; then
+if [[ "$reuse_stage1" == "1" && -x "$stage1_cache" ]]; then
 	if stage1_cache_fresh; then
 		log "stage1: reuse cache $stage1_cache"
 		copy_override_binary "$stage1_cache" "$stage1" "osty-self-1 cache"
@@ -324,20 +332,19 @@ if [[ "$mode" == "stage1" ]]; then
 	exit 0
 fi
 
-if [[ -n "${OSTY_SELF_REBUILD_STAGE2_BIN:-}" ]]; then
-	log "stage2: use override $OSTY_SELF_REBUILD_STAGE2_BIN"
-	copy_override_binary "$OSTY_SELF_REBUILD_STAGE2_BIN" "$stage2" "osty-self-2 override"
-else
-	build_self_binary "$stage1" "stage2" "$stage2"
-fi
+build_self_binary "$stage1" "stage2" "$stage2" "$host_guard"
 
 smoke_self_driver "$stage2" "stage2"
 
-if ! cmp -s "$stage1" "$stage2"; then
+build_self_binary "$stage2" "stage3" "$stage3" "$host_guard"
+
+smoke_self_driver "$stage3" "stage3"
+
+if ! cmp -s "$stage2" "$stage3"; then
 	printf 'self-rebuild: byte parity failed\n' >&2
-	printf '  osty-self-1 %s  %s\n' "$(sha256_file "$stage1")" "$stage1" >&2
 	printf '  osty-self-2 %s  %s\n' "$(sha256_file "$stage2")" "$stage2" >&2
+	printf '  osty-self-3 %s  %s\n' "$(sha256_file "$stage3")" "$stage3" >&2
 	exit 1
 fi
 
-log "byte parity OK: $(sha256_file "$stage1")"
+log "byte parity OK: $(sha256_file "$stage2")"

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -1,5 +1,4 @@
 use std.env
-use std.fs
 use std.os
 use std.process
 use std.strings
@@ -27,66 +26,93 @@ fn forwardedArgs() -> List<String> {
     forwardedArgsFrom(env.get("OSTY_SELF_REBUILD_FORWARD_ARGS") ?? "", env.args())
 }
 
-fn hostCompiler() -> String {
-    let explicit = env.get("OSTY_SELF_REBUILD_HOST_BIN") ?? ""
-    if explicit != "" {
-        return explicit
-    }
-    if fs.exists(".bin/osty") {
-        return ".bin/osty"
-    }
-    "osty"
-}
-
 fn hasSelfhostCommand(args: List<String>, name: String) -> Bool {
     args.len() > 0 && args[0] == name
 }
 
-fn runSelfhostDoctor(host: String) -> Int {
-    println("osty-self host: {host}")
-    let result = os.exec(host, ["explain", "E0001"])
-    match result {
-        Ok(out) -> {
-            if out.exitCode == 0 && strings.contains(out.stdout, "E0001") {
-                println("osty-self host probe: OK")
-                return 0
-            }
-            if out.stdout != "" {
-                print(out.stdout)
-            }
-            if out.stderr != "" {
-                eprint(out.stderr)
-            }
-            out.exitCode
-        },
-        Err(_) -> {
-            eprint("osty-self host probe failed; set OSTY_SELF_REBUILD_HOST_BIN or run from the repo root after `just build`\n")
-            2
-        },
+fn hasOptionValue(args: List<String>, name: String, value: String) -> Bool {
+    let joined = name + "=" + value
+    let mut i = 0
+    for i < args.len() {
+        let arg = args[i]
+        if arg == joined {
+            return true
+        }
+        if arg == name && i + 1 < args.len() && args[i + 1] == value {
+            return true
+        }
+        i = i + 1
     }
+    false
+}
+
+fn lastArg(args: List<String>) -> String {
+    if args.len() == 0 {
+        return ""
+    }
+    args[args.len() - 1]
+}
+
+fn isSelfRebuildBuild(args: List<String>) -> Bool {
+    args.len() > 1 &&
+        args[0] == "build" &&
+        hasOptionValue(args, "--backend", "llvm") &&
+        hasOptionValue(args, "--emit", "binary") &&
+        lastArg(args) != ""
+}
+
+fn selfRebuildPath(dir: String, rest: String) -> String {
+    if dir == "" {
+        return rest
+    }
+    if strings.hasSuffix(dir, "/") {
+        dir + rest
+    } else {
+        dir + "/" + rest
+    }
+}
+
+fn currentExecutable() -> String {
+    let args = env.args()
+    if args.len() == 0 {
+        return ""
+    }
+    args[0]
+}
+
+fn runSelfRebuild(args: List<String>) -> Int {
+    let toolchainDir = lastArg(args)
+    let _ = selfRebuildPath(toolchainDir, ".osty/out/debug/llvm/osty-self")
+    eprint("osty-self rebuild blocked: real self-rebuild requires an Osty-owned MIR-to-LLVM module emitter.\n")
+    eprint("missing entrypoint: toolchain/mir_generator.osty must own GenerateFromMIR-equivalent orchestration before osty-self can rebuild itself.\n")
+    2
+}
+
+fn runSelfhostDoctor() -> Int {
+    let exe = currentExecutable()
+    if exe == "" {
+        eprint("osty-self self-rebuild probe failed: executable not found\n")
+        return 2
+    }
+    println("osty-self mode: self-rebuild")
+    println("osty-self host compiler: disabled")
+    println("osty-self source compiler: missing")
+    println("osty-self missing stage: MIR-to-LLVM module emitter")
+    2
 }
 
 fn main() {
     let args = forwardedArgs()
-    let host = hostCompiler()
     if hasSelfhostCommand(args, "--selfhost-host") {
-        println(host)
+        println("disabled")
         os.exit(0)
     }
     if hasSelfhostCommand(args, "--selfhost-doctor") {
-        os.exit(runSelfhostDoctor(host))
+        os.exit(runSelfhostDoctor())
     }
-    let result = os.exec(host, args)
-    match result {
-        Ok(out) -> {
-            if out.stdout != "" {
-                print(out.stdout)
-            }
-            if out.stderr != "" {
-                eprint(out.stderr)
-            }
-            os.exit(out.exitCode)
-        },
-        Err(_) -> process.abort("osty-self bootstrap exec failed; set OSTY_SELF_REBUILD_HOST_BIN or run from the repo root after `just build`"),
+    if isSelfRebuildBuild(args) {
+        os.exit(runSelfRebuild(args))
     }
+    eprint("osty-self: unsupported command; host compiler forwarding is disabled\n")
+    process.abort("osty-self cannot rebuild until the Osty-owned MIR-to-LLVM module emitter is wired")
 }


### PR DESCRIPTION
## Summary

- remove the host-forwarding `osty-self` behavior and stop reporting a fake self-rebuild success state
- make the self-rebuild ratchet require stage2 to rebuild stage3, then compare stage2/stage3 byte parity
- reject external stage binary overrides so each stage must be produced by the previous stage

## Why

The previous `self-rebuild` path could still prove only a host-forwarded deterministic rebuild. This change closes those false-positive paths. Until the Osty-owned MIR-to-LLVM module emitter exists, `osty-self --selfhost-doctor` now reports the missing compiler stage instead of claiming source compiler readiness.

## Validation

- `.bin/osty check --airepair=false toolchain/main.osty`
- `shellcheck scripts/verify-self-rebuild`
- `git diff --check`
- `bash scripts/verify-self-rebuild --skip-gates --stage1-only .bin/osty` now fails at the intended missing MIR-to-LLVM emitter gate