### PR TITLE
[codex] port GC LLVM policies to Osty

### DIFF
--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -200,10 +200,6 @@ type builtinOptionContext struct {
 	sourceType ast.Type
 }
 
-const (
-	llvmGcRuntimeFrameSlotKind = 5
-)
-
 func (g *generator) beginFunction() {
 	g.temp = 0
 	g.label = 0
@@ -353,7 +349,7 @@ func (g *generator) postGCWriteIfPointer(emitter *LlvmEmitter, slot, v value) {
 	if slot.typ != "ptr" || !slot.gcManaged || v.typ != "ptr" || !v.gcManaged {
 		return
 	}
-	llvmGcPostWrite(emitter, toOstyValue(slot), toOstyValue(v), llvmGcRuntimeFrameSlotKind)
+	llvmGcPostWrite(emitter, toOstyValue(slot), toOstyValue(v), llvmGcRuntimeFrameSlotKind())
 	g.needsGCRuntime = true
 }
 
@@ -1186,7 +1182,15 @@ func (g *generator) registerDefer(stmt *ast.DeferStmt) error {
 }
 
 func (g *generator) bindNamedLocal(name string, v value, mutable bool) {
-	if mutable || (v.typ == "ptr" && valueNeedsManagedRoot(v)) || len(v.rootPaths) != 0 {
+	if llvmShouldBindLocalToSlot(
+		mutable,
+		v.typ,
+		v.gcManaged,
+		v.listElemTyp,
+		v.mapKeyTyp,
+		v.setElemTyp,
+		len(v.rootPaths),
+	) {
 		emitter := g.toOstyEmitter()
 		slot := llvmMutableLetSlot(emitter, name, toOstyValue(v))
 		slotValue := fromOstyValue(slot)
@@ -1203,7 +1207,7 @@ func (g *generator) bindNamedLocal(name string, v value, mutable bool) {
 }
 
 func valueNeedsManagedRoot(v value) bool {
-	return v.gcManaged || v.listElemTyp != "" || v.mapKeyTyp != "" || v.setElemTyp != ""
+	return llvmValueNeedsManagedRoot(v.gcManaged, v.listElemTyp, v.mapKeyTyp, v.setElemTyp)
 }
 
 func copyContainerMetadata(dst *value, src value) {
@@ -1420,32 +1424,28 @@ func (g *generator) safepointRootAddress(emitter *LlvmEmitter, root gcSafepointR
 }
 
 func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
-	if typ == "" {
-		return "null"
+	if direct := llvmTraceCallbackDirectSymbol(typ, len(rootPaths)); direct != "" {
+		if direct == llvmGcMarkSlotSymbol() {
+			g.declareRuntimeSymbol(llvmGcMarkSlotSymbol(), "void", []paramInfo{{typ: "ptr"}})
+			g.needsGCRuntime = true
+		}
+		return direct
 	}
-	if typ == "ptr" {
-		g.declareRuntimeSymbol("osty.gc.mark_slot_v1", "void", []paramInfo{{typ: "ptr"}})
-		g.needsGCRuntime = true
-		return "osty.gc.mark_slot_v1"
-	}
-	if len(rootPaths) == 0 {
-		return "null"
-	}
-	key := typ + ":" + fmt.Sprint(rootPaths)
+	key := llvmTraceHelperCacheKey(typ, fmt.Sprint(rootPaths))
 	if name, ok := g.traceHelpers[key]; ok {
 		return name
 	}
-	name := mirRtSymbol("trace_" + strconv.Itoa(len(g.traceHelpers)))
+	name := llvmTraceHelperSymbol(len(g.traceHelpers))
 	g.traceHelpers[key] = name
-	g.declareRuntimeSymbol("osty.gc.mark_slot_v1", "void", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(llvmGcMarkSlotSymbol(), "void", []paramInfo{{typ: "ptr"}})
 	g.needsGCRuntime = true
 	body := []string{}
 	currentType := ""
 	for _, path := range rootPaths {
-		addr := "%value.addr"
+		addr := llvmTraceCallbackParamRef()
 		currentType = typ
 		for _, index := range path {
-			fieldPtr := fmt.Sprintf("%%trace.field.%d.%d", len(body), index)
+			fieldPtr := llvmTraceFieldTempName(len(body), index)
 			body = append(body, mirGEPInboundsFieldText(fieldPtr, currentType, addr, strconv.Itoa(index)))
 			nextType, ok := g.aggregateFieldType(currentType, index)
 			if !ok {
@@ -1461,7 +1461,7 @@ func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
 		body = append(body, mirGCMarkSlotText(addr))
 	}
 	body = append(body, mirRetVoidText())
-	g.traceHelperDefs = append(g.traceHelperDefs, llvmRenderFunction("void", name, []*LlvmParam{llvmParam("value.addr", "ptr")}, body))
+	g.traceHelperDefs = append(g.traceHelperDefs, llvmRenderFunction("void", name, []*LlvmParam{llvmParam(llvmTraceCallbackParamName(), "ptr")}, body))
 	return name
 }
 
@@ -1546,10 +1546,7 @@ func (g *generator) nextHiddenLocalName(prefix string) string {
 }
 
 func (g *generator) needsSafepointProtection(v value) bool {
-	if v.ptr {
-		return false
-	}
-	return (v.typ == "ptr" && v.gcManaged) || len(v.rootPaths) != 0
+	return llvmNeedsSafepointProtection(v.ptr, v.typ, v.gcManaged, len(v.rootPaths))
 }
 
 func (g *generator) protectManagedTemporary(prefix string, v value) value {

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -110,6 +110,84 @@ func TestGeneratedSafepointChunkPlanIsOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedGCRootPoliciesAreOstyOwned(t *testing.T) {
+	if got, want := llvmGcRuntimeFrameSlotKind(), 5; got != want {
+		t.Fatalf("llvmGcRuntimeFrameSlotKind() = %d, want %d", got, want)
+	}
+	if !llvmValueNeedsManagedRoot(true, "", "", "") {
+		t.Fatal("managed ptr should need a root")
+	}
+	if !llvmValueNeedsManagedRoot(false, "i64", "", "") {
+		t.Fatal("list handle should need a root")
+	}
+	if !llvmValueNeedsManagedRoot(false, "", "ptr", "") {
+		t.Fatal("map handle should need a root")
+	}
+	if !llvmValueNeedsManagedRoot(false, "", "", "i64") {
+		t.Fatal("set handle should need a root")
+	}
+	if llvmValueNeedsManagedRoot(false, "", "", "") {
+		t.Fatal("plain scalar metadata should not need a root")
+	}
+
+	if !llvmShouldBindLocalToSlot(false, "ptr", true, "", "", "", 0) {
+		t.Fatal("managed ptr local should bind to a rootable slot")
+	}
+	if !llvmShouldBindLocalToSlot(false, "%Pair", false, "", "", "", 1) {
+		t.Fatal("aggregate with nested root path should bind to a slot")
+	}
+	if !llvmShouldBindLocalToSlot(true, "i64", false, "", "", "", 0) {
+		t.Fatal("mutable scalar should bind to a slot")
+	}
+	if llvmShouldBindLocalToSlot(false, "i64", false, "", "", "", 0) {
+		t.Fatal("immutable scalar should not bind to a slot")
+	}
+
+	if !llvmNeedsSafepointProtection(false, "ptr", true, 0) {
+		t.Fatal("non-addressable managed ptr temporary should be protected")
+	}
+	if !llvmNeedsSafepointProtection(false, "%Pair", false, 2) {
+		t.Fatal("aggregate temporary with nested root paths should be protected")
+	}
+	if llvmNeedsSafepointProtection(true, "ptr", true, 0) {
+		t.Fatal("addressable managed ptr already has slot protection")
+	}
+	if llvmNeedsSafepointProtection(false, "i64", false, 0) {
+		t.Fatal("plain scalar temporary should not be protected")
+	}
+
+	if got, want := llvmGcMarkSlotSymbol(), "osty.gc.mark_slot_v1"; got != want {
+		t.Fatalf("llvmGcMarkSlotSymbol() = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceCallbackDirectSymbol("", 3), "null"; got != want {
+		t.Fatalf("empty trace direct = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceCallbackDirectSymbol("ptr", 0), "osty.gc.mark_slot_v1"; got != want {
+		t.Fatalf("ptr trace direct = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceCallbackDirectSymbol("%Pair", 0), "null"; got != want {
+		t.Fatalf("rootless aggregate trace direct = %q, want %q", got, want)
+	}
+	if got := llvmTraceCallbackDirectSymbol("%Pair", 2); got != "" {
+		t.Fatalf("aggregate helper-needed trace direct = %q, want empty helper signal", got)
+	}
+	if got, want := llvmTraceHelperCacheKey("%Pair", "[[1] [2 0]]"), "%Pair:[[1] [2 0]]"; got != want {
+		t.Fatalf("llvmTraceHelperCacheKey() = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceHelperSymbol(3), "osty_rt_trace_3"; got != want {
+		t.Fatalf("llvmTraceHelperSymbol(3) = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceCallbackParamName(), "value.addr"; got != want {
+		t.Fatalf("llvmTraceCallbackParamName() = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceCallbackParamRef(), "%value.addr"; got != want {
+		t.Fatalf("llvmTraceCallbackParamRef() = %q, want %q", got, want)
+	}
+	if got, want := llvmTraceFieldTempName(4, 2), "%trace.field.4.2"; got != want {
+		t.Fatalf("llvmTraceFieldTempName(4, 2) = %q, want %q", got, want)
+	}
+}
+
 func TestGeneratedClangLinkBinaryArgsAcceptMultipleObjects(t *testing.T) {
 	args := llvmClangLinkBinaryArgs("", []string{"/tmp/main.o", "/tmp/runtime/gc_runtime.o"}, "/tmp/app")
 	got := strings.Join(args, " ")

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -596,7 +596,82 @@ func llvmGcRootRelease(emitter *LlvmEmitter, value *LlvmValue) {
 	llvmCallVoid(emitter, "osty.gc.root_release_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:460:5
+// Osty: toolchain/llvmgen.osty:456:5
+func llvmGcRuntimeFrameSlotKind() int {
+	return 5
+}
+
+// Osty: toolchain/llvmgen.osty:465:5
+func llvmValueNeedsManagedRoot(gcManaged bool, listElemTyp string, mapKeyTyp string, setElemTyp string) bool {
+	return gcManaged || listElemTyp != "" || mapKeyTyp != "" || setElemTyp != ""
+}
+
+// Osty: toolchain/llvmgen.osty:480:5
+func llvmShouldBindLocalToSlot(mutable bool, typ string, gcManaged bool, listElemTyp string, mapKeyTyp string, setElemTyp string, rootPathCount int) bool {
+	return mutable || (typ == "ptr" && llvmValueNeedsManagedRoot(gcManaged, listElemTyp, mapKeyTyp, setElemTyp)) || rootPathCount > 0
+}
+
+// Osty: toolchain/llvmgen.osty:504:5
+func llvmNeedsSafepointProtection(pointer bool, typ string, gcManaged bool, rootPathCount int) bool {
+	// Osty: toolchain/llvmgen.osty:510:5
+	if pointer {
+		// Osty: toolchain/llvmgen.osty:511:9
+		return false
+	}
+	return (typ == "ptr" && gcManaged) || rootPathCount > 0
+}
+
+// Osty: toolchain/llvmgen.osty:518:5
+func llvmGcMarkSlotSymbol() string {
+	return "osty.gc.mark_slot_v1"
+}
+
+// Osty: toolchain/llvmgen.osty:526:5
+func llvmTraceCallbackDirectSymbol(typ string, rootPathCount int) string {
+	// Osty: toolchain/llvmgen.osty:527:5
+	if typ == "" {
+		// Osty: toolchain/llvmgen.osty:528:9
+		return "null"
+	}
+	// Osty: toolchain/llvmgen.osty:530:5
+	if typ == "ptr" {
+		// Osty: toolchain/llvmgen.osty:531:9
+		return llvmGcMarkSlotSymbol()
+	}
+	// Osty: toolchain/llvmgen.osty:533:5
+	if rootPathCount <= 0 {
+		// Osty: toolchain/llvmgen.osty:534:9
+		return "null"
+	}
+	return ""
+}
+
+// Osty: toolchain/llvmgen.osty:543:5
+func llvmTraceHelperCacheKey(typ string, rootPathsText string) string {
+	return typ + ":" + rootPathsText
+}
+
+// Osty: toolchain/llvmgen.osty:547:5
+func llvmTraceHelperSymbol(index int) string {
+	return fmt.Sprintf("osty_rt_trace_%s", ostyToString(index))
+}
+
+// Osty: toolchain/llvmgen.osty:551:5
+func llvmTraceCallbackParamName() string {
+	return "value.addr"
+}
+
+// Osty: toolchain/llvmgen.osty:553:5
+func llvmTraceCallbackParamRef() string {
+	return "%value.addr"
+}
+
+// Osty: toolchain/llvmgen.osty:555:5
+func llvmTraceFieldTempName(step int, fieldIndex int) string {
+	return fmt.Sprintf("%%trace.field.%s.%s", ostyToString(step), ostyToString(fieldIndex))
+}
+
+// Osty: toolchain/llvmgen.osty:560:5
 func llvmSafepointKindUnspecified() int {
 	return 0
 }

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -477,6 +477,101 @@ pub fn llvmGcRootRelease(emitter: LlvmEmitter, value: LlvmValue) {
     llvmCallVoid(emitter, "osty.gc.root_release_v1", [value])
 }
 
+/// The runtime frame slot-kind used when the legacy emitter records a
+/// mutable local slot through `osty.gc.post_write_v1`. Keeping the tag in
+/// this Osty-owned policy surface prevents Go-side GC constants from
+/// drifting away from `examples/gc` / `osty_runtime.c` terminology.
+pub fn llvmGcRuntimeFrameSlotKind() -> Int { 5 }
+
+/// Reports whether a value's container metadata makes the value GC-visible.
+/// `gcManaged` covers raw managed pointers; the container fields cover
+/// runtime-owned List / Map / Set handles even when their element storage is
+/// not itself a plain `ptr`.
+pub fn llvmValueNeedsManagedRoot(
+    gcManaged: Bool,
+    listElemTyp: String,
+    mapKeyTyp: String,
+    setElemTyp: String,
+) -> Bool {
+    gcManaged || listElemTyp != "" || mapKeyTyp != "" || setElemTyp != ""
+}
+
+/// Local bindings are materialized as slots when mutation requires an address,
+/// when a managed pointer/container handle must be root-bound, or when an
+/// aggregate value carries nested root paths.
+pub fn llvmShouldBindLocalToSlot(
+    mutable: Bool,
+    typ: String,
+    gcManaged: Bool,
+    listElemTyp: String,
+    mapKeyTyp: String,
+    setElemTyp: String,
+    rootPathCount: Int,
+) -> Bool {
+    mutable || (typ == "ptr" && llvmValueNeedsManagedRoot(
+        gcManaged,
+        listElemTyp,
+        mapKeyTyp,
+        setElemTyp,
+    )) || rootPathCount > 0
+}
+
+/// Temporaries that are already addressable (`pointer = true`) are visible to
+/// safepoints through their owning slot. Non-addressable managed pointers and
+/// aggregates with nested root paths need temporary slot protection before a
+/// call can run.
+pub fn llvmNeedsSafepointProtection(
+    pointer: Bool,
+    typ: String,
+    gcManaged: Bool,
+    rootPathCount: Int,
+) -> Bool {
+    if pointer {
+        return false
+    }
+    (typ == "ptr" && gcManaged) || rootPathCount > 0
+}
+
+/// Canonical GC mark-slot callback used for plain managed-pointer fields and
+/// aggregate trace helpers.
+pub fn llvmGcMarkSlotSymbol() -> String { "osty.gc.mark_slot_v1" }
+
+/// Returns a built-in trace callback when no synthetic aggregate trace helper
+/// is needed. Empty / untraced types use `null`; plain managed pointers use
+/// the runtime mark-slot callback; aggregates with root paths return `""` so
+/// the Go glue can synthesize a helper body.
+pub fn llvmTraceCallbackDirectSymbol(typ: String, rootPathCount: Int) -> String {
+    if typ == "" {
+        return "null"
+    }
+    if typ == "ptr" {
+        return llvmGcMarkSlotSymbol()
+    }
+    if rootPathCount <= 0 {
+        return "null"
+    }
+    ""
+}
+
+/// Cache key for synthetic aggregate trace helpers. The second argument is the
+/// Go-rendered root-path list today; owning the separator here keeps the cache
+/// namespace in one place while the type graph still lives in Go.
+pub fn llvmTraceHelperCacheKey(typ: String, rootPathsText: String) -> String {
+    typ + ":" + rootPathsText
+}
+
+pub fn llvmTraceHelperSymbol(index: Int) -> String {
+    "osty_rt_trace_{index}"
+}
+
+pub fn llvmTraceCallbackParamName() -> String { "value.addr" }
+
+pub fn llvmTraceCallbackParamRef() -> String { "%value.addr" }
+
+pub fn llvmTraceFieldTempName(step: Int, fieldIndex: Int) -> String {
+    "%trace.field.{step}.{fieldIndex}"
+}
+
 /// Phase A5 safepoint kind taxonomy (`RUNTIME_GC_DELTA.md` §10.1).
 ///
 /// The id passed to `osty.gc.safepoint_v1` packs a kind tag in the high


### PR DESCRIPTION
## Summary
- Move GC root and safepoint policy helpers into `toolchain/llvmgen.osty`.
- Mirror the helpers in `internal/llvmgen/support_snapshot.go` and keep Go as dispatcher/glue.
- Add generated-policy tests covering root decisions, trace callback symbols, helper keys, and trace temp naming.

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateCollectionsEmitTraceHelpersForManagedAggregateValues|TestGeneratedGCRootPoliciesAreOstyOwned|TestGenerateManagedTemporaryCallArgUsesRootSlot|TestGenerateForInOverTemporaryManagedListUsesRootSlot' -v`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `git diff --check`

## Notes
- After rebasing onto latest `origin/main`, `go run ./cmd/osty check --airepair=false toolchain/llvmgen.osty` reports existing toolchain-package checker errors in `toolchain/airepair_flags.osty` and `toolchain/lir_proto.osty`, outside this PR's touched files.