### PR TITLE
Port std.strings shim policy to Osty

### DIFF
--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -962,6 +962,74 @@ func TestGeneratedRuntimeStringsFFIPolicyIsOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedStdStringsCallPolicyIsOstyOwned(t *testing.T) {
+	canonical := []struct {
+		name string
+		want string
+	}{
+		{"Compare", "compare"},
+		{"Index", "Index"},
+		{"LastIndex", "LastIndex"},
+		{"StartsWith", "hasPrefix"},
+		{"endsWith", "hasSuffix"},
+		{"TrimStart", "trimStart"},
+		{"unknown", "unknown"},
+	}
+	for _, c := range canonical {
+		if got := llvmStdStringsCallCanonicalName(c.name); got != c.want {
+			t.Fatalf("canonical %s = %q, want %q", c.name, got, c.want)
+		}
+	}
+
+	shape := []struct {
+		name       string
+		retKind    int
+		paramKinds []int
+		paramNames []string
+	}{
+		{"compare", llvmRuntimeFfiKindInt(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"left", "right"}},
+		{"count", llvmRuntimeFfiKindInt(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "substr"}},
+		{"Index", llvmStdStringsResultKindRawIndex(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "substr"}},
+		{"indexOf", llvmStdStringsResultKindOptionInt(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "substr"}},
+		{"toInt", llvmStdStringsResultKindResultIntError(), []int{llvmRuntimeFfiKindString()}, []string{"value"}},
+		{"toFloat", llvmStdStringsResultKindResultFloatError(), []int{llvmRuntimeFfiKindString()}, []string{"value"}},
+		{"contains", llvmRuntimeFfiKindBool(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "substr"}},
+		{"toBytes", llvmRuntimeFfiKindBytes(), []int{llvmRuntimeFfiKindString()}, []string{"value"}},
+		{"join", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindListString(), llvmRuntimeFfiKindString()}, []string{"parts", "sep"}},
+		{"repeat", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindInt()}, []string{"value", "n"}},
+		{"replace", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "old", "new"}},
+		{"split", llvmRuntimeFfiKindListString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "sep"}},
+		{"splitN", llvmRuntimeFfiKindListString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString(), llvmRuntimeFfiKindInt()}, []string{"value", "sep", "n"}},
+		{"slice", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindInt(), llvmRuntimeFfiKindInt()}, []string{"value", "start", "end"}},
+		{"trimPrefix", llvmRuntimeFfiKindString(), []int{llvmRuntimeFfiKindString(), llvmRuntimeFfiKindString()}, []string{"value", "prefix"}},
+	}
+	for _, c := range shape {
+		if got := llvmStdStringsCallReturnKind(c.name); got != c.retKind {
+			t.Fatalf("%s return kind = %d, want %d", c.name, got, c.retKind)
+		}
+		if got := llvmStdStringsCallArgCount(c.name); got != len(c.paramKinds) {
+			t.Fatalf("%s arg count = %d, want %d", c.name, got, len(c.paramKinds))
+		}
+		for i, wantKind := range c.paramKinds {
+			if got := llvmStdStringsCallParamKind(c.name, i); got != wantKind {
+				t.Fatalf("%s param %d kind = %d, want %d", c.name, i, got, wantKind)
+			}
+			if got := llvmStdStringsCallParamName(c.name, i); got != c.paramNames[i] {
+				t.Fatalf("%s param %d name = %q, want %q", c.name, i, got, c.paramNames[i])
+			}
+		}
+	}
+	if got := llvmStdStringsCallArgCount("unknown"); got != 0 {
+		t.Fatalf("unknown arg count = %d, want 0", got)
+	}
+	if got := llvmStdStringsCallReturnKind("unknown"); got != llvmRuntimeFfiKindUnknown() {
+		t.Fatalf("unknown return kind = %d, want unknown", got)
+	}
+	if got := llvmStdStringsCallParamKind("join", 99); got != llvmRuntimeFfiKindUnknown() {
+		t.Fatalf("out-of-range param kind = %d, want unknown", got)
+	}
+}
+
 func TestGeneratedStdBytesCallPolicyIsOstyOwned(t *testing.T) {
 	canonical := []struct {
 		name string

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -88,7 +88,7 @@ func collectStdNetAliases(file *ast.File) map[string]bool {
 	return out
 }
 
-func stdBytesArgNoun(n int) string {
+func stdShimArgNoun(n int) string {
 	if n == 1 {
 		return "argument"
 	}
@@ -112,6 +112,19 @@ func (g *generator) emitStdBytesDescriptorArg(arg *ast.Arg, name string, index i
 	}
 }
 
+func (g *generator) emitStdStringsDescriptorArg(arg *ast.Arg, name string, index int) (value, error) {
+	switch llvmStdStringsCallParamKind(name, index) {
+	case llvmRuntimeFfiKindString():
+		return g.emitStdStringsArg(arg, name, index)
+	case llvmRuntimeFfiKindInt():
+		return g.emitStdStringsIntArg(arg, name, index)
+	case llvmRuntimeFfiKindListString():
+		return g.emitStdStringsListArg(arg, name, index)
+	default:
+		return value{}, unsupportedf("call", "strings.%s arg %d has unknown descriptor kind", name, index+1)
+	}
+}
+
 func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 	if call == nil || len(g.stdBytesAliases) == 0 {
 		return value{}, false, nil
@@ -130,7 +143,7 @@ func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
 		return value{}, false, nil
 	}
 	if len(call.Args) != expected {
-		return value{}, true, unsupportedf("call", "bytes.%s expects %d %s, got %d", name, expected, stdBytesArgNoun(expected), len(call.Args))
+		return value{}, true, unsupportedf("call", "bytes.%s expects %d %s, got %d", name, expected, stdShimArgNoun(expected), len(call.Args))
 	}
 	switch name {
 	case "from":
@@ -539,6 +552,13 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 		return value{}, false, nil
 	}
 	name := canonicalStdStringsCallName(field.Name)
+	expected := llvmStdStringsCallArgCount(name)
+	if expected == 0 {
+		return value{}, false, nil
+	}
+	if len(call.Args) != expected {
+		return value{}, true, unsupportedf("call", "strings.%s expects %d %s, got %d", name, expected, stdShimArgNoun(expected), len(call.Args))
+	}
 	switch name {
 	case "compare":
 		v, err := g.emitStdStringsBinary(call, "compare", "i64", llvmStringRuntimeCompareSymbol())
@@ -629,7 +649,7 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 }
 
 func canonicalStdStringsCallName(name string) string {
-	return llvmCanonicalStdStringsCallName(name)
+	return llvmStdStringsCallCanonicalName(name)
 }
 
 // stdStringsCallStaticResult mirrors runtimeFFICallTarget for the std.strings
@@ -651,15 +671,12 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 	}
 	stringT := &ast.NamedType{Path: []string{"String"}}
 	listStringT := &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{stringT}}
-	name := canonicalStdStringsCallName(field.Name)
-	switch name {
-	case "compare":
+	switch llvmStdStringsCallReturnKind(field.Name) {
+	case llvmRuntimeFfiKindInt():
 		return value{typ: "i64"}, true
-	case "count":
-		return value{typ: "i64"}, true
-	case "Index", "LastIndex":
+	case llvmStdStringsResultKindRawIndex():
 		return value{typ: "i64", sourceType: &ast.NamedType{Path: []string{"Int"}}}, true
-	case "indexOf", "lastIndexOf":
+	case llvmStdStringsResultKindOptionInt():
 		return value{
 			typ:       "ptr",
 			gcManaged: true,
@@ -667,23 +684,23 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 				Inner: &ast.NamedType{Path: []string{"Int"}},
 			},
 		}, true
-	case "toInt":
+	case llvmStdStringsResultKindResultIntError():
 		if info, ok := builtinResultTypeFromAST(stringToIntResultSourceType(), g.typeEnv()); ok {
 			return value{typ: info.typ, sourceType: stringToIntResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
 		}
 		return value{}, false
-	case "toFloat":
+	case llvmStdStringsResultKindResultFloatError():
 		if info, ok := builtinResultTypeFromAST(stringToFloatResultSourceType(), g.typeEnv()); ok {
 			return value{typ: info.typ, sourceType: stringToFloatResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
 		}
 		return value{}, false
-	case "contains", "hasPrefix", "hasSuffix":
+	case llvmRuntimeFfiKindBool():
 		return value{typ: "i1"}, true
-	case "toBytes":
+	case llvmRuntimeFfiKindBytes():
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
-	case "concat", "join", "repeat", "replace", "replaceAll", "slice", "trim", "trimSpace", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toUpper", "toLower":
+	case llvmRuntimeFfiKindString():
 		return value{typ: "ptr", gcManaged: true, sourceType: stringT}, true
-	case "split", "splitN", "fields":
+	case llvmRuntimeFfiKindListString():
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true, sourceType: listStringT}, true
 	}
 	return value{}, false
@@ -743,14 +760,11 @@ func (g *generator) stdBytesCallStaticResult(call *ast.CallExpr) (value, bool) {
 }
 
 func (g *generator) emitStdStringsSplit(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.split expects 2 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "split", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "split", 0)
 	if err != nil {
 		return value{}, err
 	}
-	sep, err := g.emitStdStringsArg(call.Args[1], "split", 1)
+	sep, err := g.emitStdStringsDescriptorArg(call.Args[1], "split", 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -769,39 +783,23 @@ func (g *generator) emitStdStringsSplit(call *ast.CallExpr) (value, error) {
 // emitStdStringsSplitN mirrors emitStdStringsSplit but threads a third
 // Int argument to the runtime cap. The runtime body lives in
 // osty_rt_strings_SplitN; semantics match the pure-Osty stdlib body.
-// `n` bypasses emitStdStringsArg because that helper enforces ptr
-// (String) for every argument — splitN's count is the one outlier.
 func (g *generator) emitStdStringsSplitN(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 3 {
-		return value{}, unsupportedf("call", "strings.splitN expects 3 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "splitN", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "splitN", 0)
 	if err != nil {
 		return value{}, err
 	}
-	sep, err := g.emitStdStringsArg(call.Args[1], "splitN", 1)
+	sep, err := g.emitStdStringsDescriptorArg(call.Args[1], "splitN", 1)
 	if err != nil {
 		return value{}, err
 	}
-	nArg := call.Args[2]
-	if nArg == nil || nArg.Name != "" || nArg.Value == nil {
-		return value{}, unsupportedf("call", "strings.splitN requires positional arguments")
-	}
-	nVal, err := g.emitExpr(nArg.Value)
+	n, err := g.emitStdStringsDescriptorArg(call.Args[2], "splitN", 2)
 	if err != nil {
 		return value{}, err
-	}
-	nLoaded, err := g.loadIfPointer(nVal)
-	if err != nil {
-		return value{}, err
-	}
-	if nLoaded.typ != "i64" {
-		return value{}, unsupportedf("type-system", "strings.splitN arg 3 type %s, want Int", nLoaded.typ)
 	}
 	symbol := llvmStringRuntimeSplitNSymbol()
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
-	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(sep), toOstyValue(nLoaded)})
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(sep), toOstyValue(n)})
 	g.takeOstyEmitter(emitter)
 	parts := fromOstyValue(out)
 	parts.gcManaged = true
@@ -816,10 +814,7 @@ func (g *generator) emitStdStringsSplitN(call *ast.CallExpr) (value, error) {
 // internal/stdlib/modules/strings.osty:fields (byte-level ASCII
 // whitespace, consistent with the rest of the shim).
 func (g *generator) emitStdStringsFields(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 1 {
-		return value{}, unsupportedf("call", "strings.fields expects 1 argument, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "fields", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "fields", 0)
 	if err != nil {
 		return value{}, err
 	}
@@ -836,10 +831,7 @@ func (g *generator) emitStdStringsFields(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsUnary(call *ast.CallExpr, name, symbol string) (value, error) {
-	if len(call.Args) != 1 {
-		return value{}, unsupportedf("call", "strings.%s expects 1 argument, got %d", name, len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], name, 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], name, 0)
 	if err != nil {
 		return value{}, err
 	}
@@ -853,10 +845,7 @@ func (g *generator) emitStdStringsUnary(call *ast.CallExpr, name, symbol string)
 }
 
 func (g *generator) emitStdStringsParseResult(call *ast.CallExpr, name string, sourceType ast.Type, validateSymbol, parseSymbol, okTyp string) (value, error) {
-	if len(call.Args) != 1 {
-		return value{}, unsupportedf("call", "strings.%s expects 1 argument, got %d", name, len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], name, 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], name, 0)
 	if err != nil {
 		return value{}, err
 	}
@@ -864,25 +853,11 @@ func (g *generator) emitStdStringsParseResult(call *ast.CallExpr, name string, s
 }
 
 func (g *generator) emitStdStringsJoin(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.join expects 2 arguments, got %d", len(call.Args))
-	}
-	if call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil ||
-		call.Args[1] == nil || call.Args[1].Name != "" || call.Args[1].Value == nil {
-		return value{}, unsupportedf("call", "strings.join requires positional arguments")
-	}
-	parts, err := g.emitExprWithHintAndSourceType(call.Args[0].Value, nil, "ptr", true, "", "", false, "", false)
+	parts, err := g.emitStdStringsDescriptorArg(call.Args[0], "join", 0)
 	if err != nil {
 		return value{}, err
 	}
-	parts, err = g.loadIfPointer(parts)
-	if err != nil {
-		return value{}, err
-	}
-	if parts.typ != "ptr" {
-		return value{}, unsupportedf("type-system", "strings.join arg 1 type %s, want List<String>", parts.typ)
-	}
-	sep, err := g.emitStdStringsArg(call.Args[1], "join", 1)
+	sep, err := g.emitStdStringsDescriptorArg(call.Args[1], "join", 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -897,14 +872,11 @@ func (g *generator) emitStdStringsJoin(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsRepeat(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.repeat expects 2 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "repeat", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "repeat", 0)
 	if err != nil {
 		return value{}, err
 	}
-	n, err := g.emitStdStringsIntArg(call.Args[1], "repeat", 1)
+	n, err := g.emitStdStringsDescriptorArg(call.Args[1], "repeat", 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -919,14 +891,11 @@ func (g *generator) emitStdStringsRepeat(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsIndexOf(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.indexOf expects 2 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "indexOf", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "indexOf", 0)
 	if err != nil {
 		return value{}, err
 	}
-	substr, err := g.emitStdStringsArg(call.Args[1], "indexOf", 1)
+	substr, err := g.emitStdStringsDescriptorArg(call.Args[1], "indexOf", 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -934,14 +903,11 @@ func (g *generator) emitStdStringsIndexOf(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsLastIndexOf(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.lastIndexOf expects 2 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "lastIndexOf", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "lastIndexOf", 0)
 	if err != nil {
 		return value{}, err
 	}
-	substr, err := g.emitStdStringsArg(call.Args[1], "lastIndexOf", 1)
+	substr, err := g.emitStdStringsDescriptorArg(call.Args[1], "lastIndexOf", 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -953,14 +919,11 @@ func (g *generator) emitStdStringsLastIndexOf(call *ast.CallExpr) (value, error)
 }
 
 func (g *generator) emitStdStringsRawIndex(call *ast.CallExpr, name, symbol string) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.%s expects 2 arguments, got %d", name, len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], name, 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], name, 0)
 	if err != nil {
 		return value{}, err
 	}
-	substr, err := g.emitStdStringsArg(call.Args[1], name, 1)
+	substr, err := g.emitStdStringsDescriptorArg(call.Args[1], name, 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -976,18 +939,15 @@ func (g *generator) emitStdStringsRawIndexValue(s, substr value, symbol string) 
 }
 
 func (g *generator) emitStdStringsReplace(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 3 {
-		return value{}, unsupportedf("call", "strings.replace expects 3 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "replace", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "replace", 0)
 	if err != nil {
 		return value{}, err
 	}
-	old, err := g.emitStdStringsArg(call.Args[1], "replace", 1)
+	old, err := g.emitStdStringsDescriptorArg(call.Args[1], "replace", 1)
 	if err != nil {
 		return value{}, err
 	}
-	newValue, err := g.emitStdStringsArg(call.Args[2], "replace", 2)
+	newValue, err := g.emitStdStringsDescriptorArg(call.Args[2], "replace", 2)
 	if err != nil {
 		return value{}, err
 	}
@@ -995,10 +955,7 @@ func (g *generator) emitStdStringsReplace(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsToBytes(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 1 {
-		return value{}, unsupportedf("call", "strings.toBytes expects 1 argument, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "toBytes", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "toBytes", 0)
 	if err != nil {
 		return value{}, err
 	}
@@ -1013,18 +970,15 @@ func (g *generator) emitStdStringsToBytes(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsReplaceAll(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 3 {
-		return value{}, unsupportedf("call", "strings.replaceAll expects 3 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "replaceAll", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "replaceAll", 0)
 	if err != nil {
 		return value{}, err
 	}
-	old, err := g.emitStdStringsArg(call.Args[1], "replaceAll", 1)
+	old, err := g.emitStdStringsDescriptorArg(call.Args[1], "replaceAll", 1)
 	if err != nil {
 		return value{}, err
 	}
-	newValue, err := g.emitStdStringsArg(call.Args[2], "replaceAll", 2)
+	newValue, err := g.emitStdStringsDescriptorArg(call.Args[2], "replaceAll", 2)
 	if err != nil {
 		return value{}, err
 	}
@@ -1039,18 +993,15 @@ func (g *generator) emitStdStringsReplaceAll(call *ast.CallExpr) (value, error) 
 }
 
 func (g *generator) emitStdStringsSlice(call *ast.CallExpr) (value, error) {
-	if len(call.Args) != 3 {
-		return value{}, unsupportedf("call", "strings.slice expects 3 arguments, got %d", len(call.Args))
-	}
-	s, err := g.emitStdStringsArg(call.Args[0], "slice", 0)
+	s, err := g.emitStdStringsDescriptorArg(call.Args[0], "slice", 0)
 	if err != nil {
 		return value{}, err
 	}
-	start, err := g.emitStdStringsIntArg(call.Args[1], "slice", 1)
+	start, err := g.emitStdStringsDescriptorArg(call.Args[1], "slice", 1)
 	if err != nil {
 		return value{}, err
 	}
-	end, err := g.emitStdStringsIntArg(call.Args[2], "slice", 2)
+	end, err := g.emitStdStringsDescriptorArg(call.Args[2], "slice", 2)
 	if err != nil {
 		return value{}, err
 	}
@@ -1065,14 +1016,11 @@ func (g *generator) emitStdStringsSlice(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) emitStdStringsBinary(call *ast.CallExpr, name, retTyp, symbol string) (value, error) {
-	if len(call.Args) != 2 {
-		return value{}, unsupportedf("call", "strings.%s expects 2 arguments, got %d", name, len(call.Args))
-	}
-	left, err := g.emitStdStringsArg(call.Args[0], name, 0)
+	left, err := g.emitStdStringsDescriptorArg(call.Args[0], name, 0)
 	if err != nil {
 		return value{}, err
 	}
-	right, err := g.emitStdStringsArg(call.Args[1], name, 1)
+	right, err := g.emitStdStringsDescriptorArg(call.Args[1], name, 1)
 	if err != nil {
 		return value{}, err
 	}
@@ -1107,6 +1055,27 @@ func (g *generator) emitStdStringsArg(arg *ast.Arg, name string, index int) (val
 	if loaded.typ != "ptr" {
 		return value{}, unsupportedf("type-system", "strings.%s arg %d type %s, want String", name, index+1, loaded.typ)
 	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdStringsListArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "strings.%s requires positional arguments", name)
+	}
+	v, err := g.emitExprWithHintAndSourceType(arg.Value, nil, "ptr", true, "", "", false, "", false)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "strings.%s arg %d type %s, want List<String>", name, index+1, loaded.typ)
+	}
+	loaded.gcManaged = true
+	loaded.listElemTyp = "ptr"
+	loaded.listElemString = true
 	return loaded, nil
 }
 

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -3566,6 +3566,135 @@ func llvmStdBytesResultKindResultBytesError() int { return 102 }
 // Osty: llvmStdBytesResultKindResultStringError
 func llvmStdBytesResultKindResultStringError() int { return 103 }
 
+// Osty: llvmStdStringsResultKindRawIndex
+func llvmStdStringsResultKindRawIndex() int { return 110 }
+
+// Osty: llvmStdStringsResultKindOptionInt
+func llvmStdStringsResultKindOptionInt() int { return 111 }
+
+// Osty: llvmStdStringsResultKindResultIntError
+func llvmStdStringsResultKindResultIntError() int { return 112 }
+
+// Osty: llvmStdStringsResultKindResultFloatError
+func llvmStdStringsResultKindResultFloatError() int { return 113 }
+
+// Osty: llvmStdStringsCallCanonicalName
+func llvmStdStringsCallCanonicalName(name string) string {
+	return llvmCanonicalStdStringsCallName(name)
+}
+
+// Osty: llvmStdStringsCallArgCount
+func llvmStdStringsCallArgCount(name string) int {
+	canonical := llvmStdStringsCallCanonicalName(name)
+	switch canonical {
+	case "fields", "toInt", "toFloat", "toBytes", "trimStart", "trimEnd", "trim", "trimSpace", "toUpper", "toLower":
+		return 1
+	case "compare", "count", "indexOf", "Index", "lastIndexOf", "LastIndex", "concat", "contains", "hasPrefix", "hasSuffix", "join", "repeat", "split", "trimPrefix", "trimSuffix":
+		return 2
+	case "replace", "replaceAll", "splitN", "slice":
+		return 3
+	default:
+		return 0
+	}
+}
+
+// Osty: llvmStdStringsCallReturnKind
+func llvmStdStringsCallReturnKind(name string) int {
+	canonical := llvmStdStringsCallCanonicalName(name)
+	switch canonical {
+	case "compare", "count":
+		return llvmRuntimeFfiKindInt()
+	case "Index", "LastIndex":
+		return llvmStdStringsResultKindRawIndex()
+	case "indexOf", "lastIndexOf":
+		return llvmStdStringsResultKindOptionInt()
+	case "toInt":
+		return llvmStdStringsResultKindResultIntError()
+	case "toFloat":
+		return llvmStdStringsResultKindResultFloatError()
+	case "contains", "hasPrefix", "hasSuffix":
+		return llvmRuntimeFfiKindBool()
+	case "toBytes":
+		return llvmRuntimeFfiKindBytes()
+	case "split", "splitN", "fields":
+		return llvmRuntimeFfiKindListString()
+	default:
+		if llvmStdStringsCallArgCount(canonical) != 0 {
+			return llvmRuntimeFfiKindString()
+		}
+		return llvmRuntimeFfiKindUnknown()
+	}
+}
+
+// Osty: llvmStdStringsCallParamName
+func llvmStdStringsCallParamName(name string, index int) string {
+	canonical := llvmStdStringsCallCanonicalName(name)
+	if index < 0 || index >= llvmStdStringsCallArgCount(canonical) {
+		return ""
+	}
+	switch index {
+	case 0:
+		switch canonical {
+		case "compare", "concat":
+			return "left"
+		case "join":
+			return "parts"
+		default:
+			return "value"
+		}
+	case 1:
+		switch canonical {
+		case "compare", "concat":
+			return "right"
+		case "count", "indexOf", "Index", "lastIndexOf", "LastIndex", "contains":
+			return "substr"
+		case "hasPrefix", "trimPrefix":
+			return "prefix"
+		case "hasSuffix", "trimSuffix":
+			return "suffix"
+		case "join", "split", "splitN":
+			return "sep"
+		case "repeat":
+			return "n"
+		case "replace", "replaceAll":
+			return "old"
+		case "slice":
+			return "start"
+		}
+	case 2:
+		switch canonical {
+		case "replace", "replaceAll":
+			return "new"
+		case "splitN":
+			return "n"
+		case "slice":
+			return "end"
+		}
+	}
+	return ""
+}
+
+// Osty: llvmStdStringsCallParamKind
+func llvmStdStringsCallParamKind(name string, index int) int {
+	canonical := llvmStdStringsCallCanonicalName(name)
+	if index < 0 || index >= llvmStdStringsCallArgCount(canonical) {
+		return llvmRuntimeFfiKindUnknown()
+	}
+	if canonical == "join" && index == 0 {
+		return llvmRuntimeFfiKindListString()
+	}
+	if canonical == "repeat" && index == 1 {
+		return llvmRuntimeFfiKindInt()
+	}
+	if canonical == "splitN" && index == 2 {
+		return llvmRuntimeFfiKindInt()
+	}
+	if canonical == "slice" && (index == 1 || index == 2) {
+		return llvmRuntimeFfiKindInt()
+	}
+	return llvmRuntimeFfiKindString()
+}
+
 // Osty: llvmStdBytesCallCanonicalName
 func llvmStdBytesCallCanonicalName(name string) string {
 	switch name {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -489,7 +489,6 @@ pub fn lirDiagnosticKindName(kind: LirDiagnosticKind) -> String {
         LirDiagInvalidInput -> "invalid_input",
         LirDiagUnsupported -> "unsupported",
         LirDiagValidation -> "validation",
-        _ -> "unknown",
     }
 }
 pub fn lirDiagnosticRender(d: LirDiagnostic) -> String {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -3874,6 +3874,128 @@ pub fn llvmStdBytesResultKindOptionInt() -> Int { 100 }
 pub fn llvmStdBytesResultKindOptionByte() -> Int { 101 }
 pub fn llvmStdBytesResultKindResultBytesError() -> Int { 102 }
 pub fn llvmStdBytesResultKindResultStringError() -> Int { 103 }
+pub fn llvmStdStringsResultKindRawIndex() -> Int { 110 }
+pub fn llvmStdStringsResultKindOptionInt() -> Int { 111 }
+pub fn llvmStdStringsResultKindResultIntError() -> Int { 112 }
+pub fn llvmStdStringsResultKindResultFloatError() -> Int { 113 }
+
+pub fn llvmStdStringsCallCanonicalName(name: String) -> String {
+    llvmCanonicalStdStringsCallName(name)
+}
+
+pub fn llvmStdStringsCallArgCount(name: String) -> Int {
+    let canonical = llvmStdStringsCallCanonicalName(name)
+    if canonical == "fields" || canonical == "toInt" ||
+        canonical == "toFloat" || canonical == "toBytes" ||
+        canonical == "trimStart" || canonical == "trimEnd" ||
+        canonical == "trim" || canonical == "trimSpace" ||
+        canonical == "toUpper" || canonical == "toLower" {
+        return 1
+    }
+    if canonical == "compare" || canonical == "count" ||
+        canonical == "indexOf" || canonical == "Index" ||
+        canonical == "lastIndexOf" || canonical == "LastIndex" ||
+        canonical == "concat" || canonical == "contains" ||
+        canonical == "hasPrefix" || canonical == "hasSuffix" ||
+        canonical == "join" || canonical == "repeat" ||
+        canonical == "split" || canonical == "trimPrefix" ||
+        canonical == "trimSuffix" {
+        return 2
+    }
+    if canonical == "replace" || canonical == "replaceAll" ||
+        canonical == "splitN" || canonical == "slice" {
+        return 3
+    }
+    0
+}
+
+pub fn llvmStdStringsCallReturnKind(name: String) -> Int {
+    let canonical = llvmStdStringsCallCanonicalName(name)
+    if canonical == "compare" || canonical == "count" {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "Index" || canonical == "LastIndex" {
+        return llvmStdStringsResultKindRawIndex()
+    }
+    if canonical == "indexOf" || canonical == "lastIndexOf" {
+        return llvmStdStringsResultKindOptionInt()
+    }
+    if canonical == "toInt" {
+        return llvmStdStringsResultKindResultIntError()
+    }
+    if canonical == "toFloat" {
+        return llvmStdStringsResultKindResultFloatError()
+    }
+    if canonical == "contains" || canonical == "hasPrefix" ||
+        canonical == "hasSuffix" {
+        return llvmRuntimeFfiKindBool()
+    }
+    if canonical == "toBytes" {
+        return llvmRuntimeFfiKindBytes()
+    }
+    if canonical == "split" || canonical == "splitN" ||
+        canonical == "fields" {
+        return llvmRuntimeFfiKindListString()
+    }
+    if llvmStdStringsCallArgCount(canonical) != 0 {
+        return llvmRuntimeFfiKindString()
+    }
+    llvmRuntimeFfiKindUnknown()
+}
+
+pub fn llvmStdStringsCallParamName(name: String, index: Int) -> String {
+    let canonical = llvmStdStringsCallCanonicalName(name)
+    if index < 0 || index >= llvmStdStringsCallArgCount(canonical) {
+        return ""
+    }
+    if index == 0 {
+        if canonical == "compare" || canonical == "concat" { return "left" }
+        if canonical == "join" { return "parts" }
+        return "value"
+    }
+    if index == 1 {
+        if canonical == "compare" || canonical == "concat" { return "right" }
+        if canonical == "count" || canonical == "indexOf" ||
+            canonical == "Index" || canonical == "lastIndexOf" ||
+            canonical == "LastIndex" || canonical == "contains" {
+            return "substr"
+        }
+        if canonical == "hasPrefix" || canonical == "trimPrefix" { return "prefix" }
+        if canonical == "hasSuffix" || canonical == "trimSuffix" { return "suffix" }
+        if canonical == "join" || canonical == "split" || canonical == "splitN" {
+            return "sep"
+        }
+        if canonical == "repeat" { return "n" }
+        if canonical == "replace" || canonical == "replaceAll" { return "old" }
+        if canonical == "slice" { return "start" }
+    }
+    if index == 2 {
+        if canonical == "replace" || canonical == "replaceAll" { return "new" }
+        if canonical == "splitN" { return "n" }
+        if canonical == "slice" { return "end" }
+    }
+    ""
+}
+
+pub fn llvmStdStringsCallParamKind(name: String, index: Int) -> Int {
+    let canonical = llvmStdStringsCallCanonicalName(name)
+    if index < 0 || index >= llvmStdStringsCallArgCount(canonical) {
+        return llvmRuntimeFfiKindUnknown()
+    }
+    if canonical == "join" && index == 0 {
+        return llvmRuntimeFfiKindListString()
+    }
+    if canonical == "repeat" && index == 1 {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "splitN" && index == 2 {
+        return llvmRuntimeFfiKindInt()
+    }
+    if canonical == "slice" && (index == 1 || index == 2) {
+        return llvmRuntimeFfiKindInt()
+    }
+    llvmRuntimeFfiKindString()
+}
 
 pub fn llvmStdBytesCallCanonicalName(name: String) -> String {
     if name == "From" { return "from" }


### PR DESCRIPTION
## Summary
- Move std.strings call canonicalization, arity, parameter kind/name, and return-shape policy into `toolchain/llvmgen.osty`.
- Route the Go std.strings shim and static result inference through the Osty-owned descriptor snapshot.
- Centralize string argument dispatch, including List<String> and Int outlier parameters.
- Remove the unreachable catch-all arm from the new `toolchain/lir_proto.osty` diagnostic-kind matcher so the tightened self-rebuild gate passes on current main.

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGeneratedStdStringsCallPolicyIsOstyOwned|TestStdStrings'`
- `go test -count=1 -vet=off ./internal/llvmgen`
- `just fmt-check`
- `go test -count=1 -vet=off ./internal/ir ./internal/mir ./internal/backend ./internal/llvmgen`
- `just verify-selfhost`
- `just verify-self-rebuild-gates`
- `just verify-self-rebuild-fast` (`byte parity OK: 56c8984eacb0e82b1bc9c6658e62df009fe1341c17e009cd8d75ae9bef536520`)
- After final rebase onto `8b064a2b`: `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGeneratedStdStringsCallPolicyIsOstyOwned|TestStdStrings'`, `just verify-selfhost`, `just verify-self-rebuild-gates`