### PR TITLE
[codex] cache selfhost prelude template

### DIFF
--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -66,10 +66,37 @@ func BenchmarkNewElabCx(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		cx := newElabCx(file, emptyTyArena())
+		cx := newElabCx(file, nil)
 		if cx == nil || cx.env == nil || cx.core == nil {
 			b.Fatal("newElabCx returned incomplete context")
 		}
+	}
+}
+
+func TestNewElabCxClonesFrozenPrelude(t *testing.T) {
+	template := checkPreludeTemplateEnv()
+	templateFnCount := len(template.fns)
+	templateTyCount := len(template.tys.nodes)
+	if templateFnCount == 0 || templateTyCount == 0 {
+		t.Fatalf("empty prelude template: fns=%d tys=%d", templateFnCount, templateTyCount)
+	}
+
+	cx := newElabCx(nil, nil)
+	checkRegisterFn(cx.env, &CheckFnSig{name: "localOnly", owner: "", retTy: tInt(cx.env.tys)})
+	_ = tyNamed(cx.env.tys, "LocalOnly", []int{tInt(cx.env.tys)})
+
+	if got := len(template.fns); got != templateFnCount {
+		t.Fatalf("template fns len = %d, want %d", got, templateFnCount)
+	}
+	if got := len(template.tys.nodes); got != templateTyCount {
+		t.Fatalf("template ty nodes len = %d, want %d", got, templateTyCount)
+	}
+	if checkFnExists(template, "localOnly", "") {
+		t.Fatalf("template observed function registered into cloned env")
+	}
+	fresh := newElabCx(nil, nil)
+	if checkFnExists(fresh.env, "localOnly", "") {
+		t.Fatalf("fresh env observed function registered into earlier clone")
 	}
 }
 

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -38225,10 +38225,8 @@ type InstSession struct {
 // Osty: /tmp/selfhost_merged.osty:17750:5
 func newElabCx(ast *AstFile, tys *TyArena) *ElabCx {
 	// Osty: /tmp/selfhost_merged.osty:17751:5
-	env := emptyCheckEnv(tys)
+	env := clonePreludeCheckEnv(checkPreludeTemplateEnv())
 	_ = env
-	// Osty: /tmp/selfhost_merged.osty:17752:5
-	checkInstallPrelude(env)
 	return &ElabCx{ast: ast, core: emptyCoreArena(), env: env, typedExprNodes: make([]int, 0, 1), typedExprCoreNodes: make([]int, 0, 1), typedExprTypes: make([]int, 0, 1), typedStmtNodes: make([]int, 0, 1), typedStmtCoreNodes: make([]int, 0, 1)}
 }
 
@@ -47834,10 +47832,7 @@ func frontendCheckAst(file *AstFile) *FrontCheckSummary {
 // Osty: /tmp/selfhost_merged.osty:23175:5
 func frontendCheckAstStructured(file *AstFile) *FrontCheckResult {
 	// Osty: /tmp/selfhost_merged.osty:23176:5
-	tys := emptyTyArena()
-	_ = tys
-	// Osty: /tmp/selfhost_merged.osty:23177:5
-	cx := newElabCx(file, tys)
+	cx := newElabCx(file, nil)
 	_ = cx
 	// Osty: /tmp/selfhost_merged.osty:23178:5
 	elabFile(cx)

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -40,7 +40,7 @@ func CheckPackageStructured(input PackageCheckInput) (result CheckResult, err er
 	if file == nil {
 		return CheckResult{}, nil
 	}
-	cx := newElabCx(file, emptyTyArena())
+	cx := newElabCx(file, nil)
 	selfhostInstallImportSurfaces(cx.env, input.Imports)
 	elabFile(cx)
 	result = adaptCheckResultWithTokenLayout(serializeCheckResult(cx), layout)
@@ -69,7 +69,7 @@ func InspectPackageStructured(input PackageCheckInput) (records []api.InspectRec
 	if file == nil {
 		return nil, nil
 	}
-	cx := newElabCx(file, emptyTyArena())
+	cx := newElabCx(file, nil)
 	selfhostInstallImportSurfaces(cx.env, input.Imports)
 	elabFile(cx)
 	checked := serializeCheckResult(cx)

--- a/internal/selfhost/prelude_template.go
+++ b/internal/selfhost/prelude_template.go
@@ -1,0 +1,119 @@
+package selfhost
+
+import "sync"
+
+// The prelude is immutable after installation; each check clones this template
+// instead of rebuilding the same builtin signatures and type arena.
+var checkPreludeTemplateOnce sync.Once
+var checkPreludeTemplate *CheckEnv
+
+func checkPreludeTemplateEnv() *CheckEnv {
+	checkPreludeTemplateOnce.Do(func() {
+		tys := emptyTyArena()
+		env := emptyCheckEnv(tys)
+		checkInstallPrelude(env)
+		checkPreludeTemplate = env
+	})
+	return checkPreludeTemplate
+}
+
+func cloneTyArena(src *TyArena) *TyArena {
+	if src == nil {
+		return nil
+	}
+	out := *src
+	out.nodes = append([]*TyNode(nil), src.nodes...)
+	out.internKeys = append([]string(nil), src.internKeys...)
+	out.internHashes = append([]int(nil), src.internHashes...)
+	out.internValues = append([]int(nil), src.internValues...)
+	return &out
+}
+
+func cloneCheckIntStacks(in [][]int) [][]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]int, len(in))
+	for i := range in {
+		out[i] = append([]int(nil), in[i]...)
+	}
+	return out
+}
+
+func cloneCheckBindingStacks(in [][]*CheckBinding) [][]*CheckBinding {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]*CheckBinding, len(in))
+	for i := range in {
+		out[i] = append([]*CheckBinding(nil), in[i]...)
+	}
+	return out
+}
+
+func cloneCheckStringIntMap(in map[string]int) map[string]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func clonePreludeCheckEnv(src *CheckEnv) *CheckEnv {
+	if src == nil {
+		return emptyCheckEnv(emptyTyArena())
+	}
+	out := *src
+	out.tys = cloneTyArena(src.tys)
+	out.bindings = append([]*CheckBinding(nil), src.bindings...)
+	out.bindingIndexNames = append([]string(nil), src.bindingIndexNames...)
+	out.bindingIndexHashes = append([]int(nil), src.bindingIndexHashes...)
+	out.bindingIndexStacks = cloneCheckBindingStacks(src.bindingIndexStacks)
+	out.fns = append([]*CheckFnSig(nil), src.fns...)
+	out.fnIndexKeys = append([]string(nil), src.fnIndexKeys...)
+	out.fnIndexHashes = append([]int(nil), src.fnIndexHashes...)
+	out.fnIndexValues = append([]int(nil), src.fnIndexValues...)
+	out.fnIndexSlots = cloneCheckStringIntMap(src.fnIndexSlots)
+	out.fnBodyKeys = append([]string(nil), src.fnBodyKeys...)
+	out.fnBodyHashes = append([]int(nil), src.fnBodyHashes...)
+	out.fields = append([]*CheckFieldSig(nil), src.fields...)
+	out.fieldIndexKeys = append([]string(nil), src.fieldIndexKeys...)
+	out.fieldIndexHashes = append([]int(nil), src.fieldIndexHashes...)
+	out.fieldIndexValues = append([]int(nil), src.fieldIndexValues...)
+	out.variants = append([]*CheckVariantSig(nil), src.variants...)
+	out.variantIndexKeys = append([]string(nil), src.variantIndexKeys...)
+	out.variantIndexHashes = append([]int(nil), src.variantIndexHashes...)
+	out.variantIndexValues = append([]int(nil), src.variantIndexValues...)
+	out.variantOwnerIndexKeys = append([]string(nil), src.variantOwnerIndexKeys...)
+	out.variantOwnerIndexHashes = append([]int(nil), src.variantOwnerIndexHashes...)
+	out.variantOwnerIndexValues = append([]int(nil), src.variantOwnerIndexValues...)
+	out.aliases = append([]*CheckAliasSig(nil), src.aliases...)
+	out.aliasIndexKeys = append([]string(nil), src.aliasIndexKeys...)
+	out.aliasIndexHashes = append([]int(nil), src.aliasIndexHashes...)
+	out.aliasIndexValues = append([]int(nil), src.aliasIndexValues...)
+	out.types = append([]*CheckTypeSig(nil), src.types...)
+	out.typeIndexKeys = append([]string(nil), src.typeIndexKeys...)
+	out.typeIndexHashes = append([]int(nil), src.typeIndexHashes...)
+	out.typeIndexValues = append([]int(nil), src.typeIndexValues...)
+	out.interfaces = append([]string(nil), src.interfaces...)
+	out.interfaceIndexKeys = append([]string(nil), src.interfaceIndexKeys...)
+	out.interfaceIndexHashes = append([]int(nil), src.interfaceIndexHashes...)
+	out.interfaceExtends = append([]*CheckInterfaceExt(nil), src.interfaceExtends...)
+	out.importAliases = append([]string(nil), src.importAliases...)
+	out.genericBounds = append([]*CheckGenericBound(nil), src.genericBounds...)
+	out.genericBoundIndexNames = append([]string(nil), src.genericBoundIndexNames...)
+	out.genericBoundIndexHashes = append([]int(nil), src.genericBoundIndexHashes...)
+	out.genericBoundIndexStacks = cloneCheckIntStacks(src.genericBoundIndexStacks)
+	out.aliasDeepCache = append([]int(nil), src.aliasDeepCache...)
+	out.substCacheKeys = append([]string(nil), src.substCacheKeys...)
+	out.substCacheHashes = append([]int(nil), src.substCacheHashes...)
+	out.substCacheValues = append([]int(nil), src.substCacheValues...)
+	out.diagnostics = append([]*CheckDiagnostic(nil), src.diagnostics...)
+	out.bindingRecords = append([]*CheckBindingRecord(nil), src.bindingRecords...)
+	out.symbolRecords = append([]*CheckSymbolRecord(nil), src.symbolRecords...)
+	out.instantiations = append([]*CheckInstantiationRecord(nil), src.instantiations...)
+	return &out
+}


### PR DESCRIPTION
## Summary
- Add a frozen selfhost prelude template built once with `sync.Once`.
- Clone the prelude `CheckEnv`/`TyArena` for each checker run instead of rebuilding builtin signatures and methods every time.
- Route file and package selfhost entry points through the cloned template and add a regression test that mutations in one clone do not leak back into the template or another clone.

## Impact
- Moves the CPU-efficiency work from local hot-path tweaks to a structural reduction: repeated checks no longer reinstall the same prelude graph.
- Keeps per-check mutable state isolated by copying env slices, index stacks, maps, and the type arena slice tables before elaboration.

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'Test(NewElabCxClonesFrozenPrelude|CheckStructuredFromRunMatchesCheckSourceStructured|CheckStructuredFromRunIsAstbridgeFree|CheckSnapshot|CheckSourceStructuredRegistersPreludeFunctions)'`
- `go test -count=1 -vet=off ./internal/selfhost`
- `go test -count=1 -vet=off ./cmd/osty -run '^$'`
- `go build ./cmd/osty ./cmd/osty-native-checker`
- `git diff --check`
- `go run ./cmd/osty check --native toolchain/check_env.osty`
- `go test -count=1 -vet=off ./internal/selfhost -run '^$' -bench 'Benchmark(NewElabCx|CheckStructuredFromRun|CheckDiagnosticsAsDiag)' -benchmem`

Benchmark snapshot:
- `BenchmarkCheckStructuredFromRun`: `104842 ns/op`, `112488 B/op`, `1483 allocs/op`
- `BenchmarkNewElabCx`: `46567 ns/op`, `68729 B/op`, `52 allocs/op`
- `BenchmarkCheckDiagnosticsAsDiag`: `72597 ns/op`, `72448 B/op`, `515 allocs/op`