### PR TITLE
[codex] Fix GUI bin path seeding and link libraries

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -467,6 +467,10 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 	}
 	entryAbs := filepath.Join(root, entryRel)
 	if _, err := os.Stat(entryAbs); err != nil {
+		if m != nil && m.Bin != nil && m.Bin.Path != "" {
+			fmt.Fprintf(os.Stderr, "%s: entry %s not found: %v\n", commandName, entryRel, err)
+			os.Exit(1)
+		}
 		return nil
 	}
 	if skipped, reason := fileIsFeatureGated(entryAbs, feats); skipped {
@@ -504,9 +508,10 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 		Target:  triple,
 	}
 	features := resolvedFeatures(resolved)
+	linkLibraries := resolvedLinkLibraries(resolved)
 
 	if backendID == backend.NameLLVM {
-		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, features, entryAbs, pkg); usedExternal {
+		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, features, linkLibraries, entryAbs, pkg); usedExternal {
 			if err != nil {
 				exitBackendEmitError(command, emitResult, err)
 			}
@@ -517,7 +522,8 @@ func emitViaQuery(command string, root string, m *manifest.Manifest, eng *ostyqu
 	lower.PackageName = "main"
 	lower.SourcePath = entryAbs
 	lower.EntryPath = entryAbs
-	target := ostyquery.NewEmitTarget(lower, backendID, emitMode, layout, binName, features)
+	target := ostyquery.NewEmitTarget(lower, backendID, emitMode, layout, binName, features).
+		WithLinkLibraries(linkLibraries)
 	emitted := eng.Queries.Emit.Get(eng.DB, target)
 	if emitted.Err != nil {
 		exitBackendEmitError(command, emitted.Result, emitted.Err)
@@ -568,6 +574,13 @@ func resolvedFeatures(r *profile.Resolved) []string {
 		return nil
 	}
 	return r.Features
+}
+
+func resolvedLinkLibraries(r *profile.Resolved) []string {
+	if r == nil || r.Target == nil || len(r.Target.Link) == 0 {
+		return nil
+	}
+	return append([]string(nil), r.Target.Link...)
 }
 
 func finishBuildEmitResult(backendID backend.Name, emitMode backend.EmitMode, emitResult *backend.Result, profileName string) *backend.Result {

--- a/cmd/osty/llvm_external_emit.go
+++ b/cmd/osty/llvm_external_emit.go
@@ -17,7 +17,7 @@ var tryExternalPackageLLVMIR = func(entryPath string, pkg *resolve.Package) ([]b
 
 var emitPrebuiltLLVMIR = backend.EmitPrebuiltLLVMIR
 
-func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
+func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, linkLibraries []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
 	if pkg == nil || !backend.UseNativeOwnedLLVMIR(features, emitMode) {
 		return nil, false, nil
 	}
@@ -26,10 +26,11 @@ func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitM
 		return nil, false, nil
 	}
 	result, err := emitPrebuiltLLVMIR(ctx, backend.Request{
-		Layout:     layout,
-		Emit:       emitMode,
-		BinaryName: binaryName,
-		Features:   features,
+		Layout:        layout,
+		Emit:          emitMode,
+		BinaryName:    binaryName,
+		Features:      features,
+		LinkLibraries: linkLibraries,
 	}, out, warnings)
 	return result, true, err
 }

--- a/cmd/osty/llvm_external_emit_test.go
+++ b/cmd/osty/llvm_external_emit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/osty/osty/internal/backend"
@@ -42,6 +43,9 @@ func TestTryExternalPackageLLVMArtifactsUsesCoveredExternalIR(t *testing.T) {
 		if req.BinaryName != "app" {
 			t.Fatalf("binary name = %q, want app", req.BinaryName)
 		}
+		if want := []string{"osty_qt", "WebView2Loader"}; !slices.Equal(req.LinkLibraries, want) {
+			t.Fatalf("link libraries = %v, want %v", req.LinkLibraries, want)
+		}
 		if string(irOut) != "; external ir" {
 			t.Fatalf("ir = %q, want external ir", irOut)
 		}
@@ -60,7 +64,7 @@ func TestTryExternalPackageLLVMArtifactsUsesCoveredExternalIR(t *testing.T) {
 	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitObject, backend.Layout{
 		Root:    pkg.Dir,
 		Profile: "debug",
-	}, "app", nil, "/tmp/main.osty", pkg)
+	}, "app", nil, []string{"osty_qt", "WebView2Loader"}, "/tmp/main.osty", pkg)
 	if err != nil {
 		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
 	}
@@ -87,7 +91,7 @@ func TestTryExternalPackageLLVMArtifactsSkipsWhenFeatureOverridesNativePath(t *t
 	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitBinary, backend.Layout{
 		Root:    pkg.Dir,
 		Profile: "debug",
-	}, "app", []string{"mir-backend"}, "/tmp/main.osty", pkg)
+	}, "app", []string{"mir-backend"}, nil, "/tmp/main.osty", pkg)
 	if err != nil {
 		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
 	}

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -697,7 +697,7 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 	if result, usedExternal, err := tryExternalPackageLLVMArtifacts(ctx, backend.EmitObject, backend.Layout{
 		Root:    layoutRoot,
 		Profile: "test",
-	}, "", nil, sourcePath, pkg); usedExternal {
+	}, "", nil, nil, sourcePath, pkg); usedExternal {
 		if err != nil {
 			return nativeTestBundleAssets{}, err
 		}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -147,11 +147,12 @@ type Entry struct {
 // Request is the backend-neutral build request shared by gen/build/run/test
 // orchestration.
 type Request struct {
-	Layout     Layout
-	Emit       EmitMode
-	Entry      Entry
-	BinaryName string
-	Features   []string
+	Layout        Layout
+	Emit          EmitMode
+	Entry         Entry
+	BinaryName    string
+	Features      []string
+	LinkLibraries []string
 }
 
 // Artifacts returns the conventional artifact paths for backend n.

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -20,7 +20,7 @@ var ErrLLVMNotImplemented = errors.New(llvmgen.UnsupportedBackendErrorMessage())
 type llvmToolchain interface {
 	CompileObject(ctx context.Context, irPath, objectPath, target string) error
 	CompileCObject(ctx context.Context, sourcePath, objectPath, target string) error
-	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string) error
+	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string, linkLibraries []string) error
 }
 
 type llvmDispatchRoute string
@@ -120,7 +120,7 @@ func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []by
 	if runtimeObject != "" {
 		linkObjects = append(linkObjects, runtimeObject)
 	}
-	if err := tc.LinkBinary(ctx, linkObjects, out.Artifacts.Binary, req.Layout.Target); err != nil {
+	if err := tc.LinkBinary(ctx, linkObjects, out.Artifacts.Binary, req.Layout.Target, req.LinkLibraries); err != nil {
 		return out, err
 	}
 	return out, nil
@@ -292,12 +292,37 @@ func (clangToolchain) CompileCObject(ctx context.Context, sourcePath, objectPath
 	return runClang(ctx, "compile runtime", args)
 }
 
-func (clangToolchain) LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string) error {
+func (clangToolchain) LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string, linkLibraries []string) error {
 	args := llvmgen.ClangLinkBinaryArgs(target, objectPaths, binaryPath)
+	args = append(args, clangLinkLibraryArgs(linkLibraries)...)
 	if !isWindowsTarget(target) {
 		args = append(args, "-lm")
 	}
 	return runClang(ctx, "link binary", args)
+}
+
+func clangLinkLibraryArgs(libraries []string) []string {
+	if len(libraries) == 0 {
+		return nil
+	}
+	args := make([]string, 0, len(libraries))
+	for _, lib := range libraries {
+		lib = strings.TrimSpace(lib)
+		if lib == "" {
+			continue
+		}
+		if strings.HasPrefix(lib, "-") ||
+			strings.ContainsAny(lib, `/\`) ||
+			strings.HasSuffix(lib, ".a") ||
+			strings.HasSuffix(lib, ".so") ||
+			strings.HasSuffix(lib, ".dylib") ||
+			strings.HasSuffix(lib, ".lib") {
+			args = append(args, lib)
+			continue
+		}
+		args = append(args, "-l"+lib)
+	}
+	return args
 }
 
 func clangCompileCObjectArgs(target, sourcePath, objectPath string) []string {

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,9 +30,10 @@ type compileCall struct {
 }
 
 type linkCall struct {
-	objectPaths []string
-	binaryPath  string
-	target      string
+	objectPaths   []string
+	binaryPath    string
+	target        string
+	linkLibraries []string
 }
 
 type fakeLLVMToolchain struct {
@@ -58,11 +60,12 @@ func (f *fakeLLVMToolchain) CompileCObject(_ context.Context, sourcePath, object
 	return nil
 }
 
-func (f *fakeLLVMToolchain) LinkBinary(_ context.Context, objectPaths []string, binaryPath, target string) error {
+func (f *fakeLLVMToolchain) LinkBinary(_ context.Context, objectPaths []string, binaryPath, target string, linkLibraries []string) error {
 	f.links = append(f.links, linkCall{
-		objectPaths: append([]string(nil), objectPaths...),
-		binaryPath:  binaryPath,
-		target:      target,
+		objectPaths:   append([]string(nil), objectPaths...),
+		binaryPath:    binaryPath,
+		target:        target,
+		linkLibraries: append([]string(nil), linkLibraries...),
 	})
 	return nil
 }
@@ -203,6 +206,38 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 	}
 	if got := link.objectPaths[1]; got != runtimeObject {
 		t.Fatalf("link object[1] = %q, want %q", got, runtimeObject)
+	}
+}
+
+func TestLLVMBackendPassesRequestLinkLibraries(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    println(1)
+}
+`)
+	req.LinkLibraries = []string{"osty_qt", "WebView2Loader", "user32"}
+
+	if _, err := backend.Emit(context.Background(), req); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if len(tc.links) != 1 {
+		t.Fatalf("link count = %d, want 1", len(tc.links))
+	}
+	if got, want := tc.links[0].linkLibraries, req.LinkLibraries; !slices.Equal(got, want) {
+		t.Fatalf("link libraries = %v, want %v", got, want)
+	}
+}
+
+func TestClangLinkLibraryArgs(t *testing.T) {
+	t.Parallel()
+
+	got := clangLinkLibraryArgs([]string{"osty_qt", " WebView2Loader ", "", "-framework", "/opt/libcustom.a", "foo.lib"})
+	want := []string{"-losty_qt", "-lWebView2Loader", "-framework", "/opt/libcustom.a", "foo.lib"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("clang link library args = %v, want %v", got, want)
 	}
 }
 

--- a/internal/backend/onb.go
+++ b/internal/backend/onb.go
@@ -13,7 +13,7 @@ import (
 var ErrONBNotImplemented = onb.ErrNotImplemented
 
 type onbLinker interface {
-	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string) error
+	LinkBinary(ctx context.Context, objectPaths []string, binaryPath, target string, linkLibraries []string) error
 }
 
 // ONBBackend is the LLVM-complementary dev/debug backend. It consumes MIR and
@@ -85,7 +85,7 @@ func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if artifacts.Binary == "" {
 		return result, fmt.Errorf("onb backend: missing binary artifact path")
 	}
-	if err := b.onbLinker().LinkBinary(ctx, []string{artifacts.Object}, artifacts.Binary, req.Layout.Target); err != nil {
+	if err := b.onbLinker().LinkBinary(ctx, []string{artifacts.Object}, artifacts.Binary, req.Layout.Target, req.LinkLibraries); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -13,11 +13,12 @@ type fakeONBLinker struct {
 	links []linkCall
 }
 
-func (f *fakeONBLinker) LinkBinary(_ context.Context, objectPaths []string, binaryPath, target string) error {
+func (f *fakeONBLinker) LinkBinary(_ context.Context, objectPaths []string, binaryPath, target string, linkLibraries []string) error {
 	f.links = append(f.links, linkCall{
-		objectPaths: append([]string(nil), objectPaths...),
-		binaryPath:  binaryPath,
-		target:      target,
+		objectPaths:   append([]string(nil), objectPaths...),
+		binaryPath:    binaryPath,
+		target:        target,
+		linkLibraries: append([]string(nil), linkLibraries...),
 	})
 	return os.WriteFile(binaryPath, []byte("onb fake binary"), 0o755)
 }

--- a/internal/profile/merge.go
+++ b/internal/profile/merge.go
@@ -92,6 +92,9 @@ func BuildConfig(m *manifest.Manifest) (*Config, error) {
 				t.Env[k] = v
 			}
 		}
+		if len(mt.Link) > 0 {
+			t.Link = append([]string(nil), mt.Link...)
+		}
 		c.Targets[mt.Triple] = t
 	}
 

--- a/internal/profile/merge_test.go
+++ b/internal/profile/merge_test.go
@@ -1,0 +1,35 @@
+package profile
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/osty/osty/internal/manifest"
+)
+
+func TestBuildConfigPreservesTargetLinkLibraries(t *testing.T) {
+	m, err := manifest.Parse([]byte(`[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[target.amd64-windows]
+cgo = true
+link = ["osty_webview2", "WebView2Loader", "user32", "ole32"]
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	cfg, err := BuildConfig(m)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	target, ok := cfg.Target("amd64-windows")
+	if !ok {
+		t.Fatal("target amd64-windows not found")
+	}
+	want := []string{"osty_webview2", "WebView2Loader", "user32", "ole32"}
+	if !slices.Equal(target.Link, want) {
+		t.Fatalf("target link = %v, want %v", target.Link, want)
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -79,6 +79,7 @@ type Target struct {
 	Arch   string
 	CGO    *bool // nil = leave CGO_ENABLED untouched
 	Env    map[string]string
+	Link   []string
 
 	// UserDefined is set for manifest-declared targets.
 	UserDefined bool
@@ -99,6 +100,9 @@ func (t *Target) Clone() *Target {
 		for k, v := range t.Env {
 			cp.Env[k] = v
 		}
+	}
+	if t.Link != nil {
+		cp.Link = append([]string(nil), t.Link...)
 	}
 	return &cp
 }

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -309,14 +309,15 @@ type LowerMIRResult struct {
 // EmitTarget identifies a backend artifact query. FeaturesKey is the stable
 // feature-list encoding returned by FeatureKey.
 type EmitTarget struct {
-	Lower       LowerKey
-	Backend     backend.Name
-	Emit        backend.EmitMode
-	Root        string
-	Profile     string
-	Target      string
-	BinaryName  string
-	FeaturesKey string
+	Lower            LowerKey
+	Backend          backend.Name
+	Emit             backend.EmitMode
+	Root             string
+	Profile          string
+	Target           string
+	BinaryName       string
+	FeaturesKey      string
+	LinkLibrariesKey string
 }
 
 // NewEmitTarget builds a normalized key for the Emit query.
@@ -333,6 +334,13 @@ func NewEmitTarget(lower LowerKey, name backend.Name, mode backend.EmitMode, lay
 	}.normalized()
 }
 
+// WithLinkLibraries returns a copy of t carrying ordered native link library
+// names that should be forwarded to the backend link step.
+func (t EmitTarget) WithLinkLibraries(libraries []string) EmitTarget {
+	t.LinkLibrariesKey = LinkLibrariesKey(libraries)
+	return t.normalized()
+}
+
 func (t EmitTarget) normalized() EmitTarget {
 	t.Lower = t.Lower.normalized()
 	if t.Backend == "" {
@@ -345,6 +353,7 @@ func (t EmitTarget) normalized() EmitTarget {
 		t.Root = NormalizePath(t.Root)
 	}
 	t.FeaturesKey = FeatureKey(t.Features())
+	t.LinkLibrariesKey = LinkLibrariesKey(t.LinkLibraries())
 	return t
 }
 
@@ -354,6 +363,14 @@ func (t EmitTarget) Features() []string {
 		return nil
 	}
 	return strings.Split(t.FeaturesKey, featureKeySep)
+}
+
+// LinkLibraries decodes the ordered native link-library list on EmitTarget.
+func (t EmitTarget) LinkLibraries() []string {
+	if t.LinkLibrariesKey == "" {
+		return nil
+	}
+	return strings.Split(t.LinkLibrariesKey, featureKeySep)
 }
 
 const featureKeySep = "\x00"
@@ -375,6 +392,22 @@ func FeatureKey(features []string) string {
 		return ""
 	}
 	sort.Strings(clean)
+	return strings.Join(clean, featureKeySep)
+}
+
+// LinkLibrariesKey returns an order-preserving comparable key for linker
+// libraries. Unlike features, link order can be semantically meaningful.
+func LinkLibrariesKey(libraries []string) string {
+	if len(libraries) == 0 {
+		return ""
+	}
+	clean := make([]string, 0, len(libraries))
+	for _, lib := range libraries {
+		lib = strings.TrimSpace(lib)
+		if lib != "" {
+			clean = append(clean, lib)
+		}
+	}
 	return strings.Join(clean, featureKeySep)
 }
 
@@ -812,10 +845,11 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					Profile: target.Profile,
 					Target:  target.Target,
 				},
-				Emit:       target.Emit,
-				Entry:      lowered.Entry,
-				BinaryName: target.BinaryName,
-				Features:   target.Features(),
+				Emit:          target.Emit,
+				Entry:         lowered.Entry,
+				BinaryName:    target.BinaryName,
+				Features:      target.Features(),
+				LinkLibraries: target.LinkLibraries(),
 			})
 			return EmitResult{Result: result, Err: err}
 		},

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -25,6 +25,42 @@ func seedFile(eng *Engine, dir, name, src string) string {
 	return path
 }
 
+func TestSeedPackageDirIncludesManifestBinPath(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[bin]
+path = "src/main.osty"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "src", "main.osty")
+	if err := os.WriteFile(mainPath, []byte("pub fn main() { }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	seeded, err := eng.SeedPackageDir(dir, nil)
+	if err != nil {
+		t.Fatalf("SeedPackageDir: %v", err)
+	}
+	want := NormalizePath(mainPath)
+	if len(seeded.Files) != 1 || seeded.Files[0] != want {
+		t.Fatalf("seeded files = %v, want [%s]", seeded.Files, want)
+	}
+	if got := eng.Inputs.SourceText.Get(eng.DB, want); string(got) != "pub fn main() { }\n" {
+		t.Fatalf("seeded source = %q", got)
+	}
+}
+
 func TestParseMissThenHit(t *testing.T) {
 	eng := NewEngine()
 	defer eng.Close()

--- a/internal/query/osty/seed.go
+++ b/internal/query/osty/seed.go
@@ -195,21 +195,14 @@ func PackageRuntimeCapabilityFromManifest(dir string) bool {
 }
 
 func readPackageSources(dir string, transform resolve.SourceTransform) ([]string, map[string][]byte, error) {
-	entries, err := os.ReadDir(dir)
+	paths, err := resolve.PackageSourcePaths(dir, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read %s: %w", dir, err)
 	}
 	var files []string
 	sources := map[string][]byte{}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
-			continue
-		}
-		path := NormalizePath(filepath.Join(dir, name))
+	for _, path := range paths {
+		path := NormalizePath(path)
 		src, err := os.ReadFile(path)
 		if err != nil {
 			return nil, nil, fmt.Errorf("read %s: %w", path, err)

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -78,26 +78,71 @@ func LoadPackageForNativeWithOptions(dir string, opts LoadOptions) (*Package, er
 	if err != nil {
 		return nil, err
 	}
+	paths, err := PackageSourcePaths(abs, opts.IncludeTests)
+	if err != nil {
+		return nil, err
+	}
+	return loadPackageNativePaths(paths, abs, filepath.Base(abs), opts)
+}
+
+// PackageSourcePaths returns the source files that belong to a package root.
+// Root-level .osty files are included for the traditional layout, and explicit
+// manifest entry paths such as [bin].path = "src/main.osty" are added so
+// scaffolded applications with assets under the root still compile.
+func PackageSourcePaths(dir string, includeTests bool) ([]string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
 	entries, err := os.ReadDir(abs)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", abs, err)
 	}
 	var paths []string
+	seen := map[string]bool{}
+	addSource := func(path string) {
+		path = filepath.Clean(path)
+		name := filepath.Base(path)
+		if !strings.HasSuffix(name, ".osty") {
+			return
+		}
+		if !includeTests && strings.HasSuffix(name, "_test.osty") {
+			return
+		}
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") {
-			continue
+		addSource(filepath.Join(abs, e.Name()))
+	}
+	if m := packageManifest(abs); m != nil {
+		if m.Lib != nil && m.Lib.Path != "" {
+			addSource(filepath.Join(abs, m.Lib.Path))
 		}
-		if !opts.IncludeTests && strings.HasSuffix(name, "_test.osty") {
-			continue
+		if m.Bin != nil && m.Bin.Path != "" {
+			addSource(filepath.Join(abs, m.Bin.Path))
 		}
-		paths = append(paths, filepath.Join(abs, name))
 	}
 	sort.Strings(paths)
-	return loadPackageNativePaths(paths, abs, filepath.Base(abs), opts)
+	return paths, nil
+}
+
+func packageManifest(dir string) *manifest.Manifest {
+	src, err := os.ReadFile(filepath.Join(dir, manifest.ManifestFile))
+	if err != nil {
+		return nil
+	}
+	m, err := manifest.Parse(src)
+	if err != nil {
+		return nil
+	}
+	return m
 }
 
 func loadPackageNativePaths(paths []string, dir, name string, opts LoadOptions) (*Package, error) {

--- a/internal/resolve/public_compat_test.go
+++ b/internal/resolve/public_compat_test.go
@@ -164,6 +164,63 @@ runtime = true
 	}
 }
 
+func TestLoadPackageForNativeIncludesManifestBinPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[bin]
+path = "src/main.osty"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "src", "main.osty")
+	if err := os.WriteFile(mainPath, []byte("pub fn main() { }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	if len(pkg.Files) != 1 {
+		t.Fatalf("files = %d, want 1 (%v)", len(pkg.Files), pkg.Files)
+	}
+	if got := filepath.Clean(pkg.Files[0].Path); got != filepath.Clean(mainPath) {
+		t.Fatalf("file path = %q, want %q", got, mainPath)
+	}
+}
+
+func TestWorkspacePackagePathsIncludesManifestBinPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte(`[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[bin]
+path = "src/main.osty"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "main.osty"), []byte("pub fn main() { }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := WorkspacePackagePaths(root)
+	if len(paths) != 1 || paths[0] != "" {
+		t.Fatalf("WorkspacePackagePaths = %v, want root package", paths)
+	}
+}
+
 func TestLoadPackageForNativeWithTransformKeepsOriginalDiagnosticSource(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -13,31 +13,29 @@ import (
 )
 
 // IsWorkspaceRoot reports whether dir is structured as a workspace —
-// it contains at least one immediate subdirectory (other than
-// skipDir) whose files include at least one .osty source. Pass "" for
-// skipDir to scan every subdirectory. Tools that support both
+// it contains at least one immediate subdirectory (other than skipDir)
+// whose package source discovery yields at least one .osty source. Pass
+// "" for skipDir to scan every subdirectory. Tools that support both
 // package and workspace layouts use this as a mode switch.
 func IsWorkspaceRoot(dir, skipDir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
 	}
+	rootOwnedSubdirs := packageSourceSubdirs(dir)
 	for _, e := range entries {
 		if !e.IsDir() {
+			continue
+		}
+		if rootOwnedSubdirs[e.Name()] {
 			continue
 		}
 		sub := filepath.Join(dir, e.Name())
 		if sub == skipDir {
 			continue
 		}
-		subs, err := os.ReadDir(sub)
-		if err != nil {
-			continue
-		}
-		for _, s := range subs {
-			if !s.IsDir() && filepath.Ext(s.Name()) == ".osty" {
-				return true
-			}
+		if packageHasSource(sub) {
+			return true
 		}
 	}
 	return false
@@ -46,10 +44,10 @@ func IsWorkspaceRoot(dir, skipDir string) bool {
 // WorkspacePackagePaths enumerates the dotted import paths that should
 // be seeded into a Workspace rooted at dir. The output contains:
 //
-//   - "" (the root package) when dir itself holds at least one .osty
-//     file; and
-//   - each immediate subdirectory name whose files include at least
-//     one .osty source.
+//   - "" (the root package) when dir itself has package sources, including
+//     manifest-declared [bin].path / [lib].path entries; and
+//   - each immediate subdirectory name whose package source discovery yields
+//     at least one .osty source.
 //
 // The result is a read-only filesystem scan — no Workspace state is
 // touched. Callers typically iterate the returned slice and invoke
@@ -60,25 +58,50 @@ func WorkspacePackagePaths(root string) []string {
 		return nil
 	}
 	var paths []string
-	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == ".osty" {
-			paths = append(paths, "")
-			break
-		}
+	if packageHasSource(root) {
+		paths = append(paths, "")
 	}
+	rootOwnedSubdirs := packageSourceSubdirs(root)
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
-		subs, _ := os.ReadDir(filepath.Join(root, e.Name()))
-		for _, s := range subs {
-			if !s.IsDir() && filepath.Ext(s.Name()) == ".osty" {
-				paths = append(paths, e.Name())
-				break
-			}
+		if rootOwnedSubdirs[e.Name()] {
+			continue
+		}
+		if packageHasSource(filepath.Join(root, e.Name())) {
+			paths = append(paths, e.Name())
 		}
 	}
 	return paths
+}
+
+func packageHasSource(dir string) bool {
+	paths, err := PackageSourcePaths(dir, false)
+	return err == nil && len(paths) > 0
+}
+
+func packageSourceSubdirs(root string) map[string]bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil
+	}
+	paths, err := PackageSourcePaths(absRoot, false)
+	if err != nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, path := range paths {
+		rel, err := filepath.Rel(absRoot, path)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		parts := strings.Split(filepath.Clean(rel), string(filepath.Separator))
+		if len(parts) > 1 && parts[0] != "." && parts[0] != "" {
+			out[parts[0]] = true
+		}
+	}
+	return out
 }
 
 // StdPrefix is the dotted-path prefix that identifies a stdlib import.


### PR DESCRIPTION
## Summary
- Include manifest-declared `[bin].path` / `[lib].path` files in native package and query-graph source discovery.
- Prevent manifest-owned nested source dirs such as `src/main.osty` from being misclassified as separate workspace packages.
- Preserve `[target.*].link` through profile resolution, query emit targets, backend requests, and LLVM/ONB link calls.

## Root Cause
GUI scaffolds can place the executable entrypoint under `src/main.osty`, while package seeding only considered root-level `.osty` files. Separately, manifest target link libraries were parsed but dropped before the native link step.

## Validation
- `go test -count=1 -vet=off ./internal/resolve ./internal/query/osty ./internal/profile ./cmd/osty ./internal/lsp`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendPassesRequestLinkLibraries|TestClangLinkLibraryArgs|TestONBBackend|TestBundledRuntimeSchedulerWorkerScaling'`
- `go run ./cmd/osty build --emit llvm-ir --force examples/gui-webview2-inspector` now reaches `src/main.osty`, emits a skeleton IR artifact with the backend diagnostic, and no longer silently succeeds without an artifact.