### PR TITLE
refactor: port more llvmgen native helpers to Osty

### DIFF
--- a/internal/llvmgen/closure_lift.go
+++ b/internal/llvmgen/closure_lift.go
@@ -73,13 +73,11 @@ type closureCapture struct {
 //
 // Caller must ensure len(captures) <= 64 (enforced at emit time).
 func pointerBitmapForCaptures(captures []closureCapture) uint64 {
-	var bitmap uint64
-	for i, c := range captures {
-		if c.llvmTyp == "ptr" {
-			bitmap |= uint64(1) << uint(i)
-		}
+	types := make([]string, 0, len(captures))
+	for _, c := range captures {
+		types = append(types, c.llvmTyp)
 	}
-	return bitmap
+	return uint64(llvmClosureEnvPointerBitmap(types))
 }
 
 // liftedClosure is the per-closure record produced by the lift pass.

--- a/internal/llvmgen/closure_lift_test.go
+++ b/internal/llvmgen/closure_lift_test.go
@@ -286,3 +286,11 @@ fn main() {
 		t.Fatalf("expected bitmap `i64 1)` or `i64 2)` for one-pointer-one-scalar env, got:\n%s", got)
 	}
 }
+
+func TestLLVMClosureEnvPointerBitmapTracksPtrSlots(t *testing.T) {
+	got := llvmClosureEnvPointerBitmap([]string{"i64", "ptr", "double", "ptr", "i1"})
+	want := (1 << 1) | (1 << 3)
+	if got != want {
+		t.Fatalf("llvmClosureEnvPointerBitmap(...) = %d, want %d", got, want)
+	}
+}

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -552,24 +552,6 @@ func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal,
 	}
 }
 
-// llvmNativeInlineAttrKeyword mirrors toolchain/llvmgen.osty's
-// `llvmNativeInlineAttrKeyword`. Maps the v0.6 A8 `#[inline]` family
-// discriminant to the matching LLVM fn-attribute keyword; unknown
-// modes fall through to the empty string so the renderer produces the
-// attribute-free `define ... (...) {` shape.
-func llvmNativeInlineAttrKeyword(mode int) string {
-	switch mode {
-	case 1:
-		return mirFnAttrInlineHint()
-	case 2:
-		return mirFnAttrAlwaysInline()
-	case 3:
-		return mirFnAttrNoInline()
-	default:
-		return ""
-	}
-}
-
 // llvmNativeFnAttrString mirrors toolchain/llvmgen.osty's
 // `llvmNativeFnAttrString`. Assembles the fn-attribute string spliced
 // between `)` and `{` on a `llvmNativeFunction`'s `define` line.
@@ -577,7 +559,7 @@ func llvmNativeFnAttrString(fn *llvmNativeFunction) string {
 	if fn == nil {
 		return ""
 	}
-	return llvmNativeInlineAttrKeyword(fn.inlineMode)
+	return llvmNativeFnAttrStringForInlineMode(fn.inlineMode)
 }
 
 // llvmRenderFunctionWithAttrs mirrors toolchain/llvmgen.osty's
@@ -973,52 +955,6 @@ func llvmNativeCondLenSources(expr *llvmNativeExpr) []string {
 	return []string{left, right}
 }
 
-// llvmNativePushSafeIndices marks (idxName, list) pairs as bounds-
-// safe for the body emission that follows. The map's value is the
-// maximum addend `k` for which `list[idxName + k]` is still proven
-// in-bounds; values can be 0. Pass nil to mean "no safety
-// established for this loop" — still call the matching pop so the
-// symbol is restored to its prior state cleanly.
-func llvmNativePushSafeIndices(emitter *LlvmEmitter, idxName string, lists map[string]int) {
-	if idxName == "" {
-		return
-	}
-	if len(lists) == 0 {
-		// Still record an empty entry so pop doesn't restore stale
-		// safety from an outer loop with the same loop-var name.
-		emitter.nativeSafeIndices[idxName] = nil
-		return
-	}
-	emitter.nativeSafeIndices[idxName] = cloneOffsetMap(lists)
-}
-
-// llvmNativePopSafeIndices clears the safe-index entry for the given
-// loop variable. The native AST has no nested scoping for loop names
-// in our current shape — peeling on body-end is sufficient.
-func llvmNativePopSafeIndices(emitter *LlvmEmitter, idxName string) {
-	if idxName == "" {
-		return
-	}
-	delete(emitter.nativeSafeIndices, idxName)
-}
-
-// llvmNativeIsSafeListAccess reports whether `paramName[idxName +
-// addend]` is proven in-bounds by the analysis above. idxName == ""
-// means the caller couldn't pin the index back to a source-level
-// identifier (e.g. an expression that isn't `loopvar` or
-// `loopvar + constant`); those keep the runtime check.
-func llvmNativeIsSafeListAccess(emitter *LlvmEmitter, paramName, idxName string, addend int) bool {
-	if paramName == "" || idxName == "" || addend < 0 {
-		return false
-	}
-	set := emitter.nativeSafeIndices[idxName]
-	maxOff, ok := set[paramName]
-	if !ok {
-		return false
-	}
-	return addend <= maxOff
-}
-
 // llvmNativeIntLiteralValue extracts the int value from a literal
 // integer expression. Used to recognise constant addends and
 // constant subtrahends.
@@ -1250,7 +1186,7 @@ func llvmNativeEvalInterfaceCall(emitter *LlvmEmitter, expr *llvmNativeExpr) *Ll
 	var argList strings.Builder
 	argList.WriteString("ptr ")
 	argList.WriteString(data)
-	argTypes := splitArgTypes(expr.text)
+	argTypes := llvmSplitArgTypes(expr.text)
 	for i := 1; i < len(expr.childExprs); i++ {
 		argVal := llvmNativeEvalExpr(emitter, expr.childExprs[i])
 		argList.WriteString(", ")
@@ -1302,13 +1238,8 @@ func llvmNativeEvalClosureEnvAlloc(emitter *LlvmEmitter, expr *llvmNativeExpr) *
 		siteLabel = expr.text[:idx]
 		capTypesRaw = expr.text[idx+1:]
 	}
-	capTypes := splitArgTypes(capTypesRaw)
-	var bitmap uint64
-	for i, t := range capTypes {
-		if t == "ptr" {
-			bitmap |= uint64(1) << uint(i)
-		}
-	}
+	capTypes := llvmSplitArgTypes(capTypesRaw)
+	bitmap := uint64(llvmClosureEnvPointerBitmap(capTypes))
 	site := llvmStringLiteral(emitter, siteLabel)
 	env := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v2(i64 %d, ptr %s, i64 %d)", env, len(capTypes), site.name, bitmap))
@@ -1349,7 +1280,7 @@ func llvmNativeEvalFnValueCall(emitter *LlvmEmitter, expr *llvmNativeExpr) *Llvm
 	var argList strings.Builder
 	argList.WriteString("ptr ")
 	argList.WriteString(env.name)
-	argTypes := splitArgTypes(expr.text)
+	argTypes := llvmSplitArgTypes(expr.text)
 	for i := 1; i < len(expr.childExprs); i++ {
 		arg := llvmNativeEvalExpr(emitter, expr.childExprs[i])
 		argList.WriteString(", ")
@@ -1373,20 +1304,6 @@ func llvmNativeEvalFnValueCall(emitter *LlvmEmitter, expr *llvmNativeExpr) *Llvm
 	res := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", res, ret, fnPtr, argList.String()))
 	return &LlvmValue{typ: ret, name: res}
-}
-
-// splitArgTypes parses a comma-separated list of LLVM types out of
-// the `text` field. Empty input yields a nil slice. No input
-// sanitization — callers control this field.
-func splitArgTypes(text string) []string {
-	if text == "" {
-		return nil
-	}
-	parts := strings.Split(text, ",")
-	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
-	}
-	return parts
 }
 
 func llvmNativeEvalListLit(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
@@ -1717,21 +1634,4 @@ func llvmNativeBlockValue(emitter *LlvmEmitter, block *llvmNativeBlock, llvmType
 		return value.value
 	}
 	return llvmNativeZeroValue(llvmType)
-}
-
-func llvmNativeZeroValue(llvmType string) *LlvmValue {
-	switch llvmType {
-	case "", "void":
-		return llvmI64("0")
-	default:
-		return &LlvmValue{typ: llvmType, name: llvmZeroLiteral(llvmType)}
-	}
-}
-
-func llvmNativeBodyHasTerminator(body []string) bool {
-	if len(body) == 0 {
-		return false
-	}
-	last := body[len(body)-1]
-	return strings.HasPrefix(last, "  ret ") || strings.HasPrefix(last, "  br ")
 }

--- a/internal/llvmgen/native_inline_attr_test.go
+++ b/internal/llvmgen/native_inline_attr_test.go
@@ -77,3 +77,27 @@ fn main() {
 		t.Fatalf("unannotated plain() define line should end `) {` (no attrs), got:\n  %s", defineLine)
 	}
 }
+
+func TestNativeInlineAttrHelpersUseOstyMapping(t *testing.T) {
+	cases := []struct {
+		mode int
+		want string
+	}{
+		{0, ""},
+		{1, "inlinehint"},
+		{2, "alwaysinline"},
+		{3, "noinline"},
+		{99, ""},
+	}
+	for _, tc := range cases {
+		if got := llvmNativeInlineAttrKeyword(tc.mode); got != tc.want {
+			t.Fatalf("llvmNativeInlineAttrKeyword(%d) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+	if got := llvmNativeFnAttrString(nil); got != "" {
+		t.Fatalf("llvmNativeFnAttrString(nil) = %q, want empty", got)
+	}
+	if got := llvmNativeFnAttrString(&llvmNativeFunction{inlineMode: 2}); got != "alwaysinline" {
+		t.Fatalf("llvmNativeFnAttrString(always) = %q, want alwaysinline", got)
+	}
+}

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -188,6 +188,82 @@ func TestGeneratedGCRootPoliciesAreOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedSplitArgTypesTrimsCommaSeparatedLLVMTypes(t *testing.T) {
+	got := llvmSplitArgTypes(" i64, ptr ,double ")
+	want := []string{"i64", "ptr", "double"}
+	if len(got) != len(want) {
+		t.Fatalf("len(llvmSplitArgTypes) = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("llvmSplitArgTypes()[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+	if got := llvmSplitArgTypes(""); got != nil {
+		t.Fatalf("llvmSplitArgTypes(\"\") = %#v, want nil", got)
+	}
+}
+
+func TestGeneratedNativeTailHelpersAreOstyOwned(t *testing.T) {
+	if got := llvmNativeZeroValue(""); got.typ != "i64" || got.name != "0" {
+		t.Fatalf("llvmNativeZeroValue(\"\") = %#v, want i64 zero", got)
+	}
+	if got := llvmNativeZeroValue("void"); got.typ != "i64" || got.name != "0" {
+		t.Fatalf("llvmNativeZeroValue(\"void\") = %#v, want i64 zero", got)
+	}
+	if got := llvmNativeZeroValue("ptr"); got.typ != "ptr" || got.name != "null" {
+		t.Fatalf("llvmNativeZeroValue(\"ptr\") = %#v, want ptr null", got)
+	}
+	if got := llvmNativeZeroValue("double"); got.typ != "double" || got.name != "0.0" {
+		t.Fatalf("llvmNativeZeroValue(\"double\") = %#v, want double 0.0", got)
+	}
+	if llvmNativeBodyHasTerminator(nil) {
+		t.Fatal("empty body must not report a terminator")
+	}
+	if !llvmNativeBodyHasTerminator([]string{"entry:", "  ret i64 0"}) {
+		t.Fatal("ret-terminated body must report a terminator")
+	}
+	if !llvmNativeBodyHasTerminator([]string{"entry:", "  br label %done"}) {
+		t.Fatal("br-terminated body must report a terminator")
+	}
+	if llvmNativeBodyHasTerminator([]string{"entry:", "  %t0 = add i64 1, 2"}) {
+		t.Fatal("plain instruction tail must not report a terminator")
+	}
+}
+
+func TestGeneratedNativeSafeIndexHelpersAreOstyOwned(t *testing.T) {
+	em := llvmEmitter()
+	llvmNativePushSafeIndices(em, "i", map[string]int{"xs": 2, "ys": 0})
+	if !llvmNativeIsSafeListAccess(em, "xs", "i", 0) {
+		t.Fatal("xs[i] should be safe after push")
+	}
+	if !llvmNativeIsSafeListAccess(em, "xs", "i", 2) {
+		t.Fatal("xs[i+2] should be safe within recorded slack")
+	}
+	if llvmNativeIsSafeListAccess(em, "xs", "i", 3) {
+		t.Fatal("xs[i+3] should not be safe beyond recorded slack")
+	}
+	if !llvmNativeIsSafeListAccess(em, "ys", "i", 0) {
+		t.Fatal("ys[i] should be safe with zero slack")
+	}
+	if llvmNativeIsSafeListAccess(em, "ys", "i", 1) {
+		t.Fatal("ys[i+1] should not be safe with zero slack")
+	}
+	llvmNativePushSafeIndices(em, "i", map[string]int{})
+	if llvmNativeIsSafeListAccess(em, "xs", "i", 0) {
+		t.Fatal("empty push must clear prior slack for reused loop variable")
+	}
+	llvmNativePushSafeIndices(em, "", map[string]int{"xs": 9})
+	if llvmNativeIsSafeListAccess(em, "xs", "", 0) {
+		t.Fatal("empty idx name must never report safe access")
+	}
+	llvmNativePushSafeIndices(em, "j", map[string]int{"xs": 1})
+	llvmNativePopSafeIndices(em, "j")
+	if llvmNativeIsSafeListAccess(em, "xs", "j", 0) {
+		t.Fatal("pop must clear loop-variable safety entry")
+	}
+}
+
 func TestGeneratedClangLinkBinaryArgsAcceptMultipleObjects(t *testing.T) {
 	args := llvmClangLinkBinaryArgs("", []string{"/tmp/main.o", "/tmp/runtime/gc_runtime.o"}, "/tmp/app")
 	got := strings.Join(args, " ")

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -6772,3 +6772,100 @@ func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
 	}()
 	return name
 }
+
+// Osty: toolchain/llvmgen.osty:5158:1
+func llvmClosureEnvPointerBitmap(captureTypes []string) int {
+	var bitmap uint64
+	for i, typ := range captureTypes {
+		if typ == "ptr" {
+			bitmap |= uint64(1) << uint(i)
+		}
+	}
+	return int(bitmap)
+}
+
+// Osty: toolchain/llvmgen.osty:5171:1
+func llvmSplitArgTypes(text string) []string {
+	if text == "" {
+		return nil
+	}
+	raw := llvmStrings.Split(text, ",")
+	out := make([]string, 0, len(raw))
+	for _, part := range raw {
+		out = append(out, llvmStrings.TrimSpace(part))
+	}
+	return out
+}
+
+// Osty: toolchain/llvmgen.osty:5183:1
+func llvmNativeInlineAttrKeyword(mode int) string {
+	switch mode {
+	case 1:
+		return "inlinehint"
+	case 2:
+		return "alwaysinline"
+	case 3:
+		return "noinline"
+	default:
+		return ""
+	}
+}
+
+// Osty: toolchain/llvmgen.osty:5190:1
+func llvmNativeFnAttrStringForInlineMode(mode int) string {
+	return llvmNativeInlineAttrKeyword(mode)
+}
+
+// Osty: toolchain/llvmgen.osty:2196:1
+func llvmNativeZeroValue(llvmType string) *LlvmValue {
+	if llvmType == "" || llvmType == "void" {
+		return llvmI64("0")
+	}
+	return &LlvmValue{typ: llvmType, name: llvmZeroLiteral(llvmType), pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:2206:1
+func llvmNativeBodyHasTerminator(body []string) bool {
+	if len(body) == 0 {
+		return false
+	}
+	last := body[len(body)-1]
+	return llvmStrings.HasPrefix(last, "  ret ") || llvmStrings.HasPrefix(last, "  br ")
+}
+
+// Osty: toolchain/llvmgen.osty:2213:1
+func llvmNativePushSafeIndices(emitter *LlvmEmitter, idxName string, lists map[string]int) {
+	if idxName == "" || emitter == nil {
+		return
+	}
+	if len(lists) == 0 {
+		emitter.nativeSafeIndices[idxName] = map[string]int{}
+		return
+	}
+	copied := make(map[string]int, len(lists))
+	for key, value := range lists {
+		copied[key] = value
+	}
+	emitter.nativeSafeIndices[idxName] = copied
+}
+
+// Osty: toolchain/llvmgen.osty:2228:1
+func llvmNativePopSafeIndices(emitter *LlvmEmitter, idxName string) {
+	if idxName == "" || emitter == nil {
+		return
+	}
+	delete(emitter.nativeSafeIndices, idxName)
+}
+
+// Osty: toolchain/llvmgen.osty:2236:1
+func llvmNativeIsSafeListAccess(emitter *LlvmEmitter, paramName string, idxName string, addend int) bool {
+	if emitter == nil || paramName == "" || idxName == "" || addend < 0 {
+		return false
+	}
+	set := emitter.nativeSafeIndices[idxName]
+	maxOff, ok := set[paramName]
+	if !ok {
+		return false
+	}
+	return addend <= maxOff
+}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1414,13 +1414,21 @@ pub fn llvmNativeInlineAttrKeyword(mode: Int) -> String {
     }
 }
 
+/// Pure inline-mode projection used by Go snapshot wrappers that don't
+/// carry the full `LlvmNativeFunction` struct shape. Keeps the native
+/// define-line attribute policy owned by the Osty source even when the
+/// Go side only has the discriminant handy.
+pub fn llvmNativeFnAttrStringForInlineMode(mode: Int) -> String {
+    llvmNativeInlineAttrKeyword(mode)
+}
+
 /// Assemble the fn-attribute string spliced between `)` and `\{` on a
 /// `LlvmNativeFunction`'s `define` line. Currently only the A8 inline
 /// family contributes; future v0.6 annotations (hot/cold/pure/target
 /// features/noalias) land in this helper as they gain Osty-emitter
 /// coverage so all callers stay on one call shape.
 pub fn llvmNativeFnAttrString(function: LlvmNativeFunction) -> String {
-    llvmNativeInlineAttrKeyword(function.inlineMode)
+    llvmNativeFnAttrStringForInlineMode(function.inlineMode)
 }
 
 /// Variant of `llvmRenderFunction` that splices a fn-attribute string
@@ -2180,16 +2188,88 @@ fn llvmNativeBlockValue(
     llvmNativeZeroValue(llvmType)
 }
 
-fn llvmNativeZeroValue(llvmType: String) -> LlvmValue {
+/// Zero-value constructor shared by the native-entry snapshot helpers.
+/// `""` / `"void"` normalize to the legacy native-path sentinel
+/// `i64 0` so callers that need "no meaningful value" still receive a
+/// non-empty `LlvmValue` handle and can pass it through existing scalar
+/// helper code without special casing.
+pub fn llvmNativeZeroValue(llvmType: String) -> LlvmValue {
+    if llvmType == "" || llvmType == "void" {
+        return llvmI64("0")
+    }
     LlvmValue { typ: llvmType, name: llvmZeroLiteral(llvmType), pointer: false }
 }
 
-fn llvmNativeBodyHasTerminator(body: List<String>) -> Bool {
+/// Reports whether a native-entry block body already ends in a
+/// terminator (`ret` or `br`). The snapshot uses this before appending a
+/// synthetic fallthrough return.
+pub fn llvmNativeBodyHasTerminator(body: List<String>) -> Bool {
     if body.len() == 0 {
         return false
     }
     let last = body[body.len() - 1]
     llvmStrings.hasPrefix(last, "  ret ") || llvmStrings.hasPrefix(last, "  br ")
+}
+
+fn llvmNativeCloneOffsetMap(input: Map<String, Int>) -> Map<String, Int> {
+    let mut out: Map<String, Int> = {:}
+    for key in input.keys() {
+        let value = input.get(key)
+        if value.isSome() {
+            out.insert(key, value.unwrap())
+        }
+    }
+    out
+}
+
+/// Records the per-loop safe-index slack map for `idxName`. Empty input
+/// deliberately overwrites any prior entry with an empty map so reusing
+/// the same loop-var name in an inner scope cannot inherit stale bounds
+/// facts from an outer loop.
+pub fn llvmNativePushSafeIndices(
+    emitter: LlvmEmitter,
+    idxName: String,
+    lists: Map<String, Int>,
+) {
+    if idxName == "" {
+        return
+    }
+    if lists.len() == 0 {
+        emitter.nativeSafeIndices.insert(idxName, {:})
+        return
+    }
+    emitter.nativeSafeIndices.insert(idxName, llvmNativeCloneOffsetMap(lists))
+}
+
+/// Clears the native safe-index entry for a loop variable after its body
+/// has been emitted.
+pub fn llvmNativePopSafeIndices(emitter: LlvmEmitter, idxName: String) {
+    if idxName == "" {
+        return
+    }
+    let _ = emitter.nativeSafeIndices.remove(idxName)
+}
+
+/// Reports whether `paramName[idxName + addend]` is proven in-bounds by
+/// the current native safe-index table.
+pub fn llvmNativeIsSafeListAccess(
+    emitter: LlvmEmitter,
+    paramName: String,
+    idxName: String,
+    addend: Int,
+) -> Bool {
+    if paramName == "" || idxName == "" || addend < 0 {
+        return false
+    }
+    let set = emitter.nativeSafeIndices.get(idxName)
+    if set.isNone() {
+        return false
+    }
+    let maxOff = set.unwrap().get(paramName)
+    if maxOff.isNone() {
+        return false
+    }
+    addend <= maxOff.unwrap()
 }
 
 /// Phase A4 fn-value thunk template. Renders the IR body of a private
@@ -6887,4 +6967,35 @@ fn llvmNextLabel(emitter: LlvmEmitter, prefix: String) -> String {
     let name = "{prefix}{emitter.label}"
     emitter.label = emitter.label + 1
     name
+}
+
+/// llvmClosureEnvPointerBitmap encodes which closure-capture slots hold
+/// managed pointers (bit i = 1 iff `captureTypes[i] == "ptr"`). The
+/// helper lives in Osty so both the legacy AST bridge and the native
+/// entry snapshot share one source of truth for the GC-visible capture
+/// layout policy. Callers cap the list at 64 entries and may reinterpret
+/// the returned signed Int as an unsigned 64-bit bitmap on the Go side.
+pub fn llvmClosureEnvPointerBitmap(captureTypes: List<String>) -> Int {
+    let mut bitmap = 0
+    for i in 0..captureTypes.len() {
+        if captureTypes[i] == "ptr" {
+            bitmap = bitmap | (1 << i)
+        }
+    }
+    bitmap
+}
+
+/// llvmSplitArgTypes parses a comma-separated LLVM type list used by the
+/// native-entry snapshot helpers (`expr.text` for interface/fn-value
+/// shims, closure capture layouts, etc.). Empty input yields an empty
+/// list; each part is trimmed so both `"i64, ptr"` and `"i64,ptr"`
+/// normalize to the same result.
+pub fn llvmSplitArgTypes(text: String) -> List<String> {
+    if text == "" { return [] }
+    let raw = llvmStrings.split(text, ",")
+    let mut out: List<String> = []
+    for part in raw {
+        out.push(llvmStrings.trimSpace(part))
+    }
+    out
 }


### PR DESCRIPTION
## Summary
- port more pure llvmgen native helpers into `toolchain/llvmgen.osty`
- route native entry and closure lowering through `support_snapshot.go` mirrors
- extend llvmgen regression coverage for helper ownership and parity

## Test plan
- [x] `just prepush` 로컬 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)