### PR TITLE
[codex] Add std.table dataframe helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -19,6 +19,8 @@
 - `std.url` — URL parsing and building
 - `std.math` — mathematical functions and constants
 - `std.csv` — CSV read/write
+- `std.table` — small dataframe helpers for CSV/TSV-scale table work:
+  type inference, schema validation/coercion, typed sort, aggregation, join
 - `std.compress` — gzip compression
 - `std.term` — terminal mode, ANSI control, size, and key input
 - `std.tui` — retained terminal frame buffers and diff rendering

--- a/LANG_SPEC_v0.5/10-standard-library/03-excluded-from-stdlib.md
+++ b/LANG_SPEC_v0.5/10-standard-library/03-excluded-from-stdlib.md
@@ -3,5 +3,5 @@
 Asymmetric cryptography (RSA, Ed25519, etc.), compression formats other
 than gzip (zstd, brotli, lz4), OS-specific APIs (systemd, Windows
 registry, etc.), database drivers, message queue clients, serialization
-formats other than JSON/CSV (protobuf, msgpack, avro) — obtained from
+formats other than JSON/CSV/TSV table text (protobuf, msgpack, avro) — obtained from
 community packages or Go FFI.

--- a/LANG_SPEC_v0.5/10-standard-library/18-csv.md
+++ b/LANG_SPEC_v0.5/10-standard-library/18-csv.md
@@ -12,6 +12,7 @@ let text = csv.encode([
 ])
 
 let rows: List<List<String>> = csv.decode(text)?
+let tsvRows: List<List<String>> = csv.decodeTsv("name\tage\nalice\t30")?
 
 // With headers
 let records: List<Map<String, String>> = csv.decodeHeaders(text)?
@@ -24,11 +25,15 @@ API:
 
 ```
 csv.encode(rows: List<List<String>>) -> String
+csv.encodeTsv(rows: List<List<String>>) -> String
 csv.encodeWith(rows: List<List<String>>, options: CsvOptions) -> String
 
 csv.decode(text: String) -> Result<List<List<String>>, Error>
+csv.decodeTsv(text: String) -> Result<List<List<String>>, Error>
 csv.decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error>
+csv.decodeTsvHeaders(text: String) -> Result<List<Map<String, String>>, Error>
 csv.decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error>
+csv.tsvOptions() -> CsvOptions
 
 pub struct CsvOptions {
     pub delimiter: Char = ',',

--- a/LANG_SPEC_v0.5/10-standard-library/35-table.md
+++ b/LANG_SPEC_v0.5/10-standard-library/35-table.md
@@ -1,0 +1,188 @@
+### 10.35 Tables (`std.table`)
+
+`std.table` is a small dataframe layer for command-line tools and data
+cleanup jobs. It keeps cells as strings for lossless CSV/TSV round-trips,
+then layers typed access and column inference on top.
+
+```osty
+use std.table
+
+let people = table.fromCsv("name,age,city\nalice,30,seoul\nbob,25,busan")?
+let adults = people
+    .select(["name", "age"])?
+    .sortBy("age", false)?
+
+let counts = people.countBy("city", "count")?
+let text = counts.toTsv()
+```
+
+Typed sort, validation, and aggregation are available when the table is
+being used as a practical dataframe rather than only a CSV wrapper:
+
+```osty
+let sales = table.fromCsv("city,amount\nseoul,10\nbusan,7\nseoul,5")?
+let schema = table.schemaFrom(["city", "amount"], [table.TextColumn, table.FloatColumn])?
+let clean = sales.coerce(schema)?
+let ranked = clean.sortByFloat("amount", true)?
+let byCity = clean.summarizeBy("city", "amount")?
+```
+
+Core API:
+
+```osty
+pub enum ColumnType {
+    EmptyColumn,
+    BoolColumn,
+    IntColumn,
+    FloatColumn,
+    TextColumn,
+    MixedColumn,
+}
+
+pub struct ColumnSchema {
+    pub name: String,
+    pub kind: ColumnType,
+}
+
+pub struct Row {
+    pub values: Map<String, String>,
+
+    pub fn get(self, column: String) -> String?
+    pub fn getOr(self, column: String, fallback: String) -> String
+    pub fn int(self, column: String) -> Int?
+    pub fn float(self, column: String) -> Float?
+    pub fn bool(self, column: String) -> Bool?
+}
+
+pub struct TableGroup {
+    pub key: String,
+    pub rows: List<Row>,
+}
+
+pub struct NumericSummary {
+    pub count: Int,
+    pub sum: Float,
+    pub avg: Float,
+    pub min: Float,
+    pub max: Float,
+}
+
+pub struct JoinIndex {
+    pub columns: List<String>,
+    pub column: String,
+    pub keys: List<String>,
+    pub buckets: Map<String, List<Row>>,
+}
+
+pub struct Table {
+    pub columns: List<String>,
+    pub rows: List<Row>,
+
+    pub fn len(self) -> Int
+    pub fn isEmpty(self) -> Bool
+    pub fn width(self) -> Int
+    pub fn hasColumn(self, column: String) -> Bool
+    pub fn get(self, row: Int, column: String) -> String?
+
+    pub fn select(self, columns: List<String>) -> Result<Table, Error>
+    pub fn drop(self, columns: List<String>) -> Result<Table, Error>
+    pub fn filter(self, pred: fn(Row) -> Bool) -> Table
+    pub fn sortBy(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByType(self, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error>
+    pub fn sortByInt(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByFloat(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByBool(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn groupBy(self, column: String) -> Result<List<TableGroup>, Error>
+    pub fn countBy(self, column: String, countColumn: String) -> Result<Table, Error>
+    pub fn innerJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+    pub fn leftJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+    pub fn innerJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+    pub fn leftJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+    pub fn inferTypes(self) -> List<ColumnSchema>
+    pub fn validateSchema(self, schema: List<ColumnSchema>) -> Result<(), Error>
+    pub fn coerce(self, schema: List<ColumnSchema>) -> Result<Table, Error>
+    pub fn summarize(self, column: String) -> Result<NumericSummary, Error>
+    pub fn summarizeBy(self, groupColumn: String, valueColumn: String) -> Result<Table, Error>
+    pub fn sum(self, column: String) -> Result<Float, Error>
+    pub fn avg(self, column: String) -> Result<Float, Error>
+    pub fn min(self, column: String) -> Result<Float, Error>
+    pub fn max(self, column: String) -> Result<Float, Error>
+    pub fn indexBy(self, column: String) -> Result<JoinIndex, Error>
+
+    pub fn dataRows(self) -> List<List<String>>
+    pub fn toRows(self) -> List<List<String>>
+    pub fn records(self) -> List<Map<String, String>>
+    pub fn toCsv(self) -> String
+    pub fn toTsv(self) -> String
+}
+
+pub fn empty() -> Table
+pub fn row(values: Map<String, String>) -> Row
+pub fn schema(name: String, kind: ColumnType) -> ColumnSchema
+pub fn schemaFrom(columns: List<String>, kinds: List<ColumnType>) -> Result<List<ColumnSchema>, Error>
+
+pub fn fromRows(columns: List<String>, rows: List<List<String>>) -> Result<Table, Error>
+pub fn fromRecords(columns: List<String>, rows: List<Map<String, String>>) -> Result<Table, Error>
+pub fn fromCsv(text: String) -> Result<Table, Error>
+pub fn fromTsv(text: String) -> Result<Table, Error>
+pub fn fromDelimited(text: String, options: csv.CsvOptions) -> Result<Table, Error>
+
+pub fn toCsv(table: Table) -> String
+pub fn toTsv(table: Table) -> String
+pub fn toDelimited(table: Table, options: csv.CsvOptions) -> String
+
+pub fn select(table: Table, columns: List<String>) -> Result<Table, Error>
+pub fn drop(table: Table, columns: List<String>) -> Result<Table, Error>
+pub fn sortBy(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByType(table: Table, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error>
+pub fn sortByInt(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByFloat(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByBool(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn groupBy(table: Table, column: String) -> Result<List<TableGroup>, Error>
+pub fn countBy(table: Table, column: String, countColumn: String) -> Result<Table, Error>
+pub fn innerJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+pub fn leftJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+pub fn innerJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+pub fn leftJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+pub fn inferTypes(table: Table) -> List<ColumnSchema>
+pub fn validateSchema(table: Table, schema: List<ColumnSchema>) -> Result<(), Error>
+pub fn coerce(table: Table, schema: List<ColumnSchema>) -> Result<Table, Error>
+pub fn summarize(table: Table, column: String) -> Result<NumericSummary, Error>
+pub fn summarizeBy(table: Table, groupColumn: String, valueColumn: String) -> Result<Table, Error>
+pub fn sum(table: Table, column: String) -> Result<Float, Error>
+pub fn avg(table: Table, column: String) -> Result<Float, Error>
+pub fn min(table: Table, column: String) -> Result<Float, Error>
+pub fn max(table: Table, column: String) -> Result<Float, Error>
+pub fn indexBy(table: Table, column: String) -> Result<JoinIndex, Error>
+pub fn columnTypeName(kind: ColumnType) -> String
+```
+
+Behavior:
+
+- `fromCsv` and `fromTsv` treat the first row as headers. Header names
+  must be non-empty and unique; data rows must have the same width.
+- `toCsv` and `toTsv` include the header row and delegate escaping to
+  `std.csv`.
+- `select`, `drop`, `sortBy`, `groupBy`, and joins return `Error` for
+  unknown columns instead of silently producing sparse output.
+- `sortBy` is stable enough for small tool data and compares cell text
+  lexicographically.
+- `sortByType` and its `Int`/`Float`/`Bool` wrappers parse cells before
+  comparison and return `Error` for non-conforming values.
+- `validateSchema` accepts empty cells as missing values but checks every
+  non-empty cell against the requested type. `coerce` normalizes typed
+  columns to canonical strings while preserving unspecified columns.
+- `groupBy` preserves first-seen group order. `countBy` is the common
+  aggregation shortcut.
+- `summarize` computes numeric count/sum/avg/min/max for one column.
+  `summarizeBy` returns those statistics as a table grouped by a key
+  column.
+- `innerJoin` and `leftJoin` keep all left columns and include right-side
+  non-key columns. They build a right-side `JoinIndex` internally, so
+  repeated key lookup is linear in the number of rows instead of a nested
+  scan. Reused joins can build the index explicitly with `indexBy`.
+  Conflicting right column names are prefixed with `right.` and suffixed
+  when needed.
+- `inferTypes` ignores empty cells, promotes `IntColumn` plus
+  `FloatColumn` to `FloatColumn`, treats any text cell as `TextColumn`,
+  and returns `MixedColumn` for incompatible non-text mixes.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -49,3 +49,4 @@ lowering remains implementation backlog.
 - [§10.34 Deneb-Derived Utilities (`std.redact`, `std.security`,
   `std.search`, `std.markdown`, `std.media`, `std.httpretry`, `std.jsonl`,
   `std.tokenest`, `std.shortid`, `std.metrics`)](./34-deneb-utilities.md)
+- [§10.35 Tables (`std.table`)](./35-table.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -45,6 +45,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | net | 1084 | net 40 runtime | TCP/UDP, IPv4/IPv6, parseSocketAddr, tcpListen |
 | fmt | 926 | (surface heavy) | graphem-aware width, format spec engine |
 | json | 629 | (parser self) | generic encode<T> / decode<T>, UTF-8 / surrogate pair |
+| table | 1112 | pure Osty + csv | small dataframe: CSV/TSV read-write, type inference, schema validation/coercion, typed sort, group aggregation, indexed join |
 | url | 592 | — | parse / join / format |
 | io | 541 | shim 171 | Reader/Writer 프로토콜, Buffer, copyN, readExact |
 | collections | 509 | list 68 + map 42 + set 17 | 30+ List 메서드, groupBy, windowed, zip3 |
@@ -61,7 +62,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
-| csv | 351 | — | options-driven, header-aware decode |
+| csv | 376 | — | options-driven, header-aware decode plus TSV convenience wrappers |
 | encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
 | zip | 327 | pure Osty + bytes | ZIP stored-entry encode/decode/list/extract + CRC32 |
 | term | 320 | host-backed + pure ANSI | terminal mode/size/input declarations + ANSI sequence builders |
@@ -121,7 +122,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 |---|---|---|
 | HTTP 웹 서버 | ✅ 즉시 가능 | http + io + json + net |
 | CLI 도구 | ✅ 즉시 가능 | os + fs + io + fmt + env |
-| 데이터 처리 (CSV / JSON) | ✅ 즉시 가능 | csv + json + collections + iter + fmt |
+| 데이터 처리 (CSV / TSV / JSON / tables) | ✅ 즉시 가능 | table + csv + json + collections + iter + fmt |
 | 파일 변환기 / 아카이브 | ✅ 가능 | fs + io + tar + compress (gzip 만) + fmt |
 | 암호화 / 해시 | ✅ 가능 | crypto (sha256 / hmac / random / constantTimeEq) |
 | 랜덤 게임 / 시뮬레이션 | ✅ 가능 | random (seeded RNG) + math |
@@ -178,7 +179,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 43 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, aiagents, redact, media, security, search, markdown, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, url, io, collections, email, db, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 44 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, aiagents, redact, media, security, search, markdown, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, table, url, io, collections, email, db, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 

--- a/internal/backend/stdlib_table_check_test.go
+++ b/internal/backend/stdlib_table_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultTable pins std.table's pure-Osty dataframe layer
+// against the selfhost checker. It leans on std.csv, std.strings, function
+// parameters, maps, and nested collection shapes, so it catches several
+// practical stdlib drift modes at once.
+func TestStdlibCheckResultTable(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "table")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(table) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("table module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/csv_test.go
+++ b/internal/stdlib/csv_test.go
@@ -15,7 +15,7 @@ func TestCsvModuleSurface(t *testing.T) {
 		t.Fatalf("std.csv not loaded")
 	}
 
-	for _, name := range []string{"encode", "encodeWith", "decode", "decodeWith", "decodeHeaders"} {
+	for _, name := range []string{"encode", "encodeTsv", "encodeWith", "decode", "decodeTsv", "decodeWith", "decodeHeaders", "decodeTsvHeaders", "tsvOptions"} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Errorf("std.csv missing export %q", name)
@@ -78,6 +78,8 @@ func TestCsvModuleSourcePinsQualityGuards(t *testing.T) {
 		"row.len() != headers.len()",
 		"record.insert(headers[c], row[c])",
 		"options.trimSpace && hasOuterAsciiSpace(field)",
+		"decodeWith(text, tsvOptions())",
+		"encodeWith(rows, tsvOptions())",
 	} {
 		if !strings.Contains(src, want) {
 			t.Errorf("std.csv source missing quality guard %q", want)

--- a/internal/stdlib/modules/csv.osty
+++ b/internal/stdlib/modules/csv.osty
@@ -22,6 +22,10 @@ pub fn encode(rows: List<List<String>>) -> String {
     encodeWith(rows, CsvOptions {})
 }
 
+pub fn encodeTsv(rows: List<List<String>>) -> String {
+    encodeWith(rows, tsvOptions())
+}
+
 pub fn encodeWith(rows: List<List<String>>, options: CsvOptions) -> String {
     abortInvalidOptions(options)
 
@@ -39,6 +43,10 @@ pub fn encodeWith(rows: List<List<String>>, options: CsvOptions) -> String {
 
 pub fn decode(text: String) -> Result<List<List<String>>, Error> {
     decodeWith(text, CsvOptions {})
+}
+
+pub fn decodeTsv(text: String) -> Result<List<List<String>>, Error> {
+    decodeWith(text, tsvOptions())
 }
 
 pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error> {
@@ -183,6 +191,25 @@ pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>
 
 pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
     let rows = decode(text)?
+    recordsFromHeaderRows(rows)
+}
+
+pub fn decodeTsvHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
+    let rows = decodeTsv(text)?
+    recordsFromHeaderRows(rows)
+}
+
+pub fn tsvOptions() -> CsvOptions {
+    CsvOptions {
+        delimiter: '\t',
+        quote: '"',
+        trimSpace: false,
+    }
+}
+
+// Internal helpers ────────────────────────────────────────────────────────────
+
+fn recordsFromHeaderRows(rows: List<List<String>>) -> Result<List<Map<String, String>>, Error> {
     if rows.len() == 0 {
         return Ok([])
     }
@@ -212,8 +239,6 @@ pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
     }
     Ok(records)
 }
-
-// Internal helpers ────────────────────────────────────────────────────────────
 
 fn encodeRow(row: List<String>, options: CsvOptions) -> String {
     let mut out = ""

--- a/internal/stdlib/modules/table.osty
+++ b/internal/stdlib/modules/table.osty
@@ -1,0 +1,1112 @@
+// std.table - small dataframe helpers for CSV/TSV-scale data work.
+//
+// Tables keep raw cell text so round-trips preserve user data, while typed
+// helpers and column inference let CLI tools quickly sort, group, and join
+// records without building a custom row model first.
+
+use std.csv
+use std.error
+use std.strings
+
+pub enum ColumnType {
+    EmptyColumn,
+    BoolColumn,
+    IntColumn,
+    FloatColumn,
+    TextColumn,
+    MixedColumn,
+}
+
+pub struct ColumnSchema {
+    pub name: String,
+    pub kind: ColumnType,
+}
+
+pub struct Row {
+    pub values: Map<String, String>,
+
+    pub fn get(self, column: String) -> String? {
+        self.values.get(column)
+    }
+
+    pub fn getOr(self, column: String, fallback: String) -> String {
+        self.values.get(column) ?? fallback
+    }
+
+    pub fn int(self, column: String) -> Int? {
+        match self.values.get(column) {
+            Some(value) -> parseInt(value),
+            None -> noneInt(),
+        }
+    }
+
+    pub fn float(self, column: String) -> Float? {
+        match self.values.get(column) {
+            Some(value) -> parseFloat(value),
+            None -> noneFloat(),
+        }
+    }
+
+    pub fn bool(self, column: String) -> Bool? {
+        match self.values.get(column) {
+            Some(value) -> parseBool(value),
+            None -> noneBool(),
+        }
+    }
+}
+
+pub struct TableGroup {
+    pub key: String,
+    pub rows: List<Row>,
+}
+
+pub struct NumericSummary {
+    pub count: Int,
+    pub sum: Float,
+    pub avg: Float,
+    pub min: Float,
+    pub max: Float,
+}
+
+pub struct JoinIndex {
+    pub columns: List<String>,
+    pub column: String,
+    pub keys: List<String>,
+    pub buckets: Map<String, List<Row>>,
+}
+
+pub struct Table {
+    pub columns: List<String>,
+    pub rows: List<Row>,
+
+    pub fn len(self) -> Int {
+        self.rows.len()
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.rows.isEmpty()
+    }
+
+    pub fn width(self) -> Int {
+        self.columns.len()
+    }
+
+    pub fn hasColumn(self, column: String) -> Bool {
+        hasColumn(self.columns, column)
+    }
+
+    pub fn get(self, row: Int, column: String) -> String? {
+        match self.rows.get(row) {
+            Some(item) -> item.get(column),
+            None -> noneString(),
+        }
+    }
+
+    pub fn select(self, columns: List<String>) -> Result<Table, Error> {
+        select(self, columns)
+    }
+
+    pub fn drop(self, columns: List<String>) -> Result<Table, Error> {
+        drop(self, columns)
+    }
+
+    pub fn filter(self, pred: fn(Row) -> Bool) -> Table {
+        let mut out: List<Row> = []
+        for row in self.rows {
+            if pred(row) {
+                out.push(row)
+            }
+        }
+        Table { columns: copyStrings(self.columns), rows: out }
+    }
+
+    pub fn sortBy(self, column: String, descending: Bool) -> Result<Table, Error> {
+        sortBy(self, column, descending)
+    }
+
+    pub fn sortByType(self, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error> {
+        sortByType(self, column, kind, descending)
+    }
+
+    pub fn sortByInt(self, column: String, descending: Bool) -> Result<Table, Error> {
+        sortByInt(self, column, descending)
+    }
+
+    pub fn sortByFloat(self, column: String, descending: Bool) -> Result<Table, Error> {
+        sortByFloat(self, column, descending)
+    }
+
+    pub fn sortByBool(self, column: String, descending: Bool) -> Result<Table, Error> {
+        sortByBool(self, column, descending)
+    }
+
+    pub fn groupBy(self, column: String) -> Result<List<TableGroup>, Error> {
+        groupBy(self, column)
+    }
+
+    pub fn countBy(self, column: String, countColumn: String) -> Result<Table, Error> {
+        countBy(self, column, countColumn)
+    }
+
+    pub fn innerJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error> {
+        innerJoin(self, right, leftColumn, rightColumn)
+    }
+
+    pub fn leftJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error> {
+        leftJoin(self, right, leftColumn, rightColumn)
+    }
+
+    pub fn innerJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error> {
+        innerJoinIndex(self, right, leftColumn)
+    }
+
+    pub fn leftJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error> {
+        leftJoinIndex(self, right, leftColumn)
+    }
+
+    pub fn inferTypes(self) -> List<ColumnSchema> {
+        inferTypes(self)
+    }
+
+    pub fn validateSchema(self, schema: List<ColumnSchema>) -> Result<(), Error> {
+        validateSchema(self, schema)
+    }
+
+    pub fn coerce(self, schema: List<ColumnSchema>) -> Result<Table, Error> {
+        coerce(self, schema)
+    }
+
+    pub fn summarize(self, column: String) -> Result<NumericSummary, Error> {
+        summarize(self, column)
+    }
+
+    pub fn summarizeBy(self, groupColumn: String, valueColumn: String) -> Result<Table, Error> {
+        summarizeBy(self, groupColumn, valueColumn)
+    }
+
+    pub fn sum(self, column: String) -> Result<Float, Error> {
+        sum(self, column)
+    }
+
+    pub fn avg(self, column: String) -> Result<Float, Error> {
+        avg(self, column)
+    }
+
+    pub fn min(self, column: String) -> Result<Float, Error> {
+        min(self, column)
+    }
+
+    pub fn max(self, column: String) -> Result<Float, Error> {
+        max(self, column)
+    }
+
+    pub fn indexBy(self, column: String) -> Result<JoinIndex, Error> {
+        indexBy(self, column)
+    }
+
+    pub fn dataRows(self) -> List<List<String>> {
+        dataRows(self)
+    }
+
+    pub fn toRows(self) -> List<List<String>> {
+        toRows(self)
+    }
+
+    pub fn records(self) -> List<Map<String, String>> {
+        records(self)
+    }
+
+    pub fn toCsv(self) -> String {
+        toCsv(self)
+    }
+
+    pub fn toTsv(self) -> String {
+        toTsv(self)
+    }
+}
+
+pub fn empty() -> Table {
+    Table { columns: [], rows: [] }
+}
+
+pub fn row(values: Map<String, String>) -> Row {
+    Row { values: values }
+}
+
+pub fn schema(name: String, kind: ColumnType) -> ColumnSchema {
+    ColumnSchema { name: name, kind: kind }
+}
+
+pub fn schemaFrom(columns: List<String>, kinds: List<ColumnType>) -> Result<List<ColumnSchema>, Error> {
+    validateColumns(columns)?
+    if columns.len() != kinds.len() {
+        let expected = columns.len()
+        let got = kinds.len()
+        return Err(tableError("schema kind count mismatch: expected {expected}, got {got}"))
+    }
+
+    let mut out: List<ColumnSchema> = []
+    let mut i = 0
+    for i < columns.len() {
+        out.push(ColumnSchema { name: columns[i], kind: kinds[i] })
+        i = i + 1
+    }
+    Ok(out)
+}
+
+pub fn fromRows(columns: List<String>, rows: List<List<String>>) -> Result<Table, Error> {
+    validateColumns(columns)?
+
+    let mut out: List<Row> = []
+    let mut r = 0
+    for r < rows.len() {
+        let raw = rows[r]
+        if raw.len() != columns.len() {
+            let rowNo = r + 1
+            let expected = columns.len()
+            let got = raw.len()
+            return Err(tableError("row {rowNo}: expected {expected} fields, got {got}"))
+        }
+        out.push(rowFromCells(columns, raw))
+        r = r + 1
+    }
+    Ok(Table { columns: copyStrings(columns), rows: out })
+}
+
+pub fn fromRecords(columns: List<String>, rows: List<Map<String, String>>) -> Result<Table, Error> {
+    validateColumns(columns)?
+
+    let mut out: List<Row> = []
+    for values in rows {
+        let mut record: Map<String, String> = {:}
+        for column in columns {
+            record.insert(column, values.get(column) ?? "")
+        }
+        out.push(Row { values: record })
+    }
+    Ok(Table { columns: copyStrings(columns), rows: out })
+}
+
+pub fn fromCsv(text: String) -> Result<Table, Error> {
+    let rows = csv.decode(text)?
+    fromDecodedRows(rows)
+}
+
+pub fn fromTsv(text: String) -> Result<Table, Error> {
+    let rows = csv.decodeTsv(text)?
+    fromDecodedRows(rows)
+}
+
+pub fn fromDelimited(text: String, options: csv.CsvOptions) -> Result<Table, Error> {
+    let rows = csv.decodeWith(text, options)?
+    fromDecodedRows(rows)
+}
+
+pub fn toCsv(table: Table) -> String {
+    csv.encode(table.toRows())
+}
+
+pub fn toTsv(table: Table) -> String {
+    csv.encodeTsv(table.toRows())
+}
+
+pub fn toDelimited(table: Table, options: csv.CsvOptions) -> String {
+    csv.encodeWith(table.toRows(), options)
+}
+
+pub fn dataRows(table: Table) -> List<List<String>> {
+    let mut rows: List<List<String>> = []
+    for item in table.rows {
+        rows.push(rowCells(table.columns, item))
+    }
+    rows
+}
+
+pub fn toRows(table: Table) -> List<List<String>> {
+    let mut rows: List<List<String>> = [copyStrings(table.columns)]
+    for item in table.rows {
+        rows.push(rowCells(table.columns, item))
+    }
+    rows
+}
+
+pub fn records(table: Table) -> List<Map<String, String>> {
+    let mut out: List<Map<String, String>> = []
+    for item in table.rows {
+        let mut values: Map<String, String> = {:}
+        for column in table.columns {
+            values.insert(column, item.getOr(column, ""))
+        }
+        out.push(values)
+    }
+    out
+}
+
+pub fn select(table: Table, columns: List<String>) -> Result<Table, Error> {
+    validateSelection(table.columns, columns)?
+
+    let mut rows: List<Row> = []
+    for item in table.rows {
+        let mut values: Map<String, String> = {:}
+        for column in columns {
+            values.insert(column, item.getOr(column, ""))
+        }
+        rows.push(Row { values: values })
+    }
+    Ok(Table { columns: copyStrings(columns), rows: rows })
+}
+
+pub fn drop(table: Table, columns: List<String>) -> Result<Table, Error> {
+    for column in columns {
+        ensureColumn(table.columns, column)?
+    }
+
+    let mut selected: List<String> = []
+    for column in table.columns {
+        if !hasColumn(columns, column) {
+            selected.push(column)
+        }
+    }
+    select(table, selected)
+}
+
+pub fn sortBy(table: Table, column: String, descending: Bool) -> Result<Table, Error> {
+    ensureColumn(table.columns, column)?
+
+    let mut rows = copyRows(table.rows)
+    let mut i = 0
+    for i < rows.len() {
+        let mut best = i
+        let mut j = i + 1
+        for j < rows.len() {
+            let candidate = rows[j].getOr(column, "")
+            let current = rows[best].getOr(column, "")
+            if shouldSortBefore(candidate, current, descending) {
+                best = j
+            }
+            j = j + 1
+        }
+        if best != i {
+            let tmp = rows[i]
+            rows[i] = rows[best]
+            rows[best] = tmp
+        }
+        i = i + 1
+    }
+    Ok(Table { columns: copyStrings(table.columns), rows: rows })
+}
+
+pub fn sortByType(table: Table, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error> {
+    ensureColumn(table.columns, column)?
+    ensureSortableKind(kind)?
+
+    let mut rows = copyRows(table.rows)
+    let mut i = 0
+    for i < rows.len() {
+        let mut best = i
+        let mut j = i + 1
+        for j < rows.len() {
+            let candidate = rows[j].getOr(column, "")
+            let current = rows[best].getOr(column, "")
+            if shouldSortBeforeType(candidate, current, column, kind, descending)? {
+                best = j
+            }
+            j = j + 1
+        }
+        if best != i {
+            let tmp = rows[i]
+            rows[i] = rows[best]
+            rows[best] = tmp
+        }
+        i = i + 1
+    }
+    Ok(Table { columns: copyStrings(table.columns), rows: rows })
+}
+
+pub fn sortByInt(table: Table, column: String, descending: Bool) -> Result<Table, Error> {
+    sortByType(table, column, IntColumn, descending)
+}
+
+pub fn sortByFloat(table: Table, column: String, descending: Bool) -> Result<Table, Error> {
+    sortByType(table, column, FloatColumn, descending)
+}
+
+pub fn sortByBool(table: Table, column: String, descending: Bool) -> Result<Table, Error> {
+    sortByType(table, column, BoolColumn, descending)
+}
+
+pub fn groupBy(table: Table, column: String) -> Result<List<TableGroup>, Error> {
+    ensureColumn(table.columns, column)?
+
+    let mut groups: List<TableGroup> = []
+    let mut indexByKey: Map<String, Int> = {:}
+    for item in table.rows {
+        let key = item.getOr(column, "")
+        match indexByKey.get(key) {
+            Some(idx) -> {
+                let group = groups[idx]
+                let mut rows = group.rows
+                rows.push(item)
+                groups[idx] = TableGroup { key: group.key, rows: rows }
+            },
+            None -> {
+                indexByKey.insert(key, groups.len())
+                groups.push(TableGroup { key: key, rows: [item] })
+            },
+        }
+    }
+    Ok(groups)
+}
+
+pub fn countBy(table: Table, column: String, countColumn: String) -> Result<Table, Error> {
+    ensureColumn(table.columns, column)?
+    let cleanCount = strings.trimSpace(countColumn)
+    if cleanCount.isEmpty() {
+        return Err(tableError("count column is empty"))
+    }
+    if cleanCount == column {
+        return Err(tableError("count column duplicates grouped column: {column}"))
+    }
+
+    let groups = groupBy(table, column)?
+    let columns = [column, cleanCount]
+    let mut rows: List<Row> = []
+    for group in groups {
+        let mut values: Map<String, String> = {:}
+        values.insert(column, group.key)
+        values.insert(cleanCount, group.rows.len().toString())
+        rows.push(Row { values: values })
+    }
+    Ok(Table { columns: columns, rows: rows })
+}
+
+pub fn innerJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error> {
+    joinTables(left, right, leftColumn, rightColumn, false)
+}
+
+pub fn leftJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error> {
+    joinTables(left, right, leftColumn, rightColumn, true)
+}
+
+pub fn innerJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error> {
+    joinIndexed(left, right, leftColumn, false)
+}
+
+pub fn leftJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error> {
+    joinIndexed(left, right, leftColumn, true)
+}
+
+pub fn inferTypes(table: Table) -> List<ColumnSchema> {
+    let mut out: List<ColumnSchema> = []
+    for column in table.columns {
+        let mut kind = EmptyColumn
+        for item in table.rows {
+            kind = mergeColumnType(kind, inferCellType(item.getOr(column, "")))
+        }
+        out.push(ColumnSchema { name: column, kind: kind })
+    }
+    out
+}
+
+pub fn validateSchema(table: Table, schema: List<ColumnSchema>) -> Result<(), Error> {
+    validateSchemaList(schema)?
+    for spec in schema {
+        ensureColumn(table.columns, spec.name)?
+        let mut rowNo = 1
+        for item in table.rows {
+            validateCell(spec.name, item.getOr(spec.name, ""), spec.kind, rowNo)?
+            rowNo = rowNo + 1
+        }
+    }
+    Ok(())
+}
+
+pub fn coerce(table: Table, schema: List<ColumnSchema>) -> Result<Table, Error> {
+    validateSchema(table, schema)?
+
+    let mut schemaKinds: Map<String, ColumnType> = {:}
+    for spec in schema {
+        schemaKinds.insert(spec.name, spec.kind)
+    }
+
+    let mut rows: List<Row> = []
+    for item in table.rows {
+        let mut values: Map<String, String> = {:}
+        for column in table.columns {
+            match schemaKinds.get(column) {
+                Some(kind) -> values.insert(column, coerceCell(column, item.getOr(column, ""), kind)?),
+                None -> values.insert(column, item.getOr(column, "")),
+            }
+        }
+        rows.push(Row { values: values })
+    }
+    Ok(Table { columns: copyStrings(table.columns), rows: rows })
+}
+
+pub fn summarize(table: Table, column: String) -> Result<NumericSummary, Error> {
+    ensureColumn(table.columns, column)?
+    summarizeRows(table.rows, column)
+}
+
+pub fn summarizeBy(table: Table, groupColumn: String, valueColumn: String) -> Result<Table, Error> {
+    ensureColumn(table.columns, groupColumn)?
+    ensureColumn(table.columns, valueColumn)?
+    ensureSummaryColumnDoesNotConflict(groupColumn)?
+
+    let groups = groupBy(table, groupColumn)?
+    let columns = [groupColumn, "count", "sum", "avg", "min", "max"]
+    let mut rows: List<Row> = []
+    for group in groups {
+        let summary = summarizeRows(group.rows, valueColumn)?
+        let mut values: Map<String, String> = {:}
+        values.insert(groupColumn, group.key)
+        values.insert("count", summary.count.toString())
+        values.insert("sum", summary.sum.toString())
+        values.insert("avg", summary.avg.toString())
+        values.insert("min", summary.min.toString())
+        values.insert("max", summary.max.toString())
+        rows.push(Row { values: values })
+    }
+    Ok(Table { columns: columns, rows: rows })
+}
+
+pub fn sum(table: Table, column: String) -> Result<Float, Error> {
+    let summary = summarize(table, column)?
+    Ok(summary.sum)
+}
+
+pub fn avg(table: Table, column: String) -> Result<Float, Error> {
+    let summary = summarize(table, column)?
+    Ok(summary.avg)
+}
+
+pub fn min(table: Table, column: String) -> Result<Float, Error> {
+    let summary = summarize(table, column)?
+    Ok(summary.min)
+}
+
+pub fn max(table: Table, column: String) -> Result<Float, Error> {
+    let summary = summarize(table, column)?
+    Ok(summary.max)
+}
+
+pub fn indexBy(table: Table, column: String) -> Result<JoinIndex, Error> {
+    ensureColumn(table.columns, column)?
+
+    let mut keys: List<String> = []
+    let mut buckets: Map<String, List<Row>> = {:}
+    for item in table.rows {
+        let key = item.getOr(column, "")
+        match buckets.get(key) {
+            Some(existing) -> {
+                let mut rows = existing
+                rows.push(item)
+                buckets.insert(key, rows)
+            },
+            None -> {
+                keys.push(key)
+                buckets.insert(key, [item])
+            },
+        }
+    }
+    Ok(JoinIndex { columns: copyStrings(table.columns), column: column, keys: keys, buckets: buckets })
+}
+
+pub fn columnTypeName(kind: ColumnType) -> String {
+    match kind {
+        EmptyColumn -> "empty",
+        BoolColumn  -> "bool",
+        IntColumn   -> "int",
+        FloatColumn -> "float",
+        TextColumn  -> "text",
+        MixedColumn -> "mixed",
+    }
+}
+
+// Internal helpers -----------------------------------------------------------
+
+fn fromDecodedRows(rows: List<List<String>>) -> Result<Table, Error> {
+    if rows.isEmpty() {
+        return Ok(empty())
+    }
+    let headers = rows[0]
+    let data = rows.drop(1)
+    fromRows(headers, data)
+}
+
+fn validateColumns(columns: List<String>) -> Result<(), Error> {
+    let mut seen: Map<String, Bool> = {:}
+    let mut i = 0
+    for i < columns.len() {
+        let name = columns[i]
+        let colNo = i + 1
+        if strings.trimSpace(name).isEmpty() {
+            return Err(tableError("empty column at position {colNo}"))
+        }
+        if seen.containsKey(name) {
+            return Err(tableError("duplicate column: {name}"))
+        }
+        seen.insert(name, true)
+        i = i + 1
+    }
+    Ok(())
+}
+
+fn validateSelection(available: List<String>, selected: List<String>) -> Result<(), Error> {
+    validateColumns(selected)?
+    for column in selected {
+        ensureColumn(available, column)?
+    }
+    Ok(())
+}
+
+fn ensureColumn(columns: List<String>, column: String) -> Result<(), Error> {
+    if !hasColumn(columns, column) {
+        return Err(tableError("unknown column: {column}"))
+    }
+    Ok(())
+}
+
+fn hasColumn(columns: List<String>, column: String) -> Bool {
+    for item in columns {
+        if item == column {
+            return true
+        }
+    }
+    false
+}
+
+fn rowFromCells(columns: List<String>, cells: List<String>) -> Row {
+    let mut values: Map<String, String> = {:}
+    let mut i = 0
+    for i < columns.len() {
+        values.insert(columns[i], cells[i])
+        i = i + 1
+    }
+    Row { values: values }
+}
+
+fn rowCells(columns: List<String>, item: Row) -> List<String> {
+    let mut out: List<String> = []
+    for column in columns {
+        out.push(item.getOr(column, ""))
+    }
+    out
+}
+
+fn copyStrings(items: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(item)
+    }
+    out
+}
+
+fn copyRows(items: List<Row>) -> List<Row> {
+    let mut out: List<Row> = []
+    for item in items {
+        out.push(item)
+    }
+    out
+}
+
+fn shouldSortBefore(candidate: String, current: String, descending: Bool) -> Bool {
+    if descending {
+        candidate > current
+    } else {
+        candidate < current
+    }
+}
+
+fn shouldSortBeforeType(candidate: String, current: String, column: String, kind: ColumnType, descending: Bool) -> Result<Bool, Error> {
+    match kind {
+        IntColumn -> {
+            let a = parseIntCell(column, candidate)?
+            let b = parseIntCell(column, current)?
+            Ok(sortIntBefore(a, b, descending))
+        },
+        FloatColumn -> {
+            let a = parseFloatCell(column, candidate)?
+            let b = parseFloatCell(column, current)?
+            Ok(sortFloatBefore(a, b, descending))
+        },
+        BoolColumn -> {
+            let a = parseBoolCell(column, candidate)?
+            let b = parseBoolCell(column, current)?
+            Ok(sortBoolBefore(a, b, descending))
+        },
+        TextColumn -> Ok(shouldSortBefore(candidate, current, descending)),
+        EmptyColumn -> Err(tableError("cannot sort empty column type")),
+        MixedColumn -> Err(tableError("cannot sort mixed column type")),
+    }
+}
+
+fn sortIntBefore(a: Int, b: Int, descending: Bool) -> Bool {
+    if descending {
+        a > b
+    } else {
+        a < b
+    }
+}
+
+fn sortFloatBefore(a: Float, b: Float, descending: Bool) -> Bool {
+    if descending {
+        a > b
+    } else {
+        a < b
+    }
+}
+
+fn sortBoolBefore(a: Bool, b: Bool, descending: Bool) -> Bool {
+    if a == b {
+        return false
+    }
+    if descending {
+        a && !b
+    } else {
+        !a && b
+    }
+}
+
+fn ensureSortableKind(kind: ColumnType) -> Result<(), Error> {
+    match kind {
+        EmptyColumn -> Err(tableError("cannot sort empty column type")),
+        MixedColumn -> Err(tableError("cannot sort mixed column type")),
+        _ -> Ok(()),
+    }
+}
+
+fn validateSchemaList(schema: List<ColumnSchema>) -> Result<(), Error> {
+    let mut names: List<String> = []
+    for spec in schema {
+        names.push(spec.name)
+    }
+    validateColumns(names)
+}
+
+fn validateCell(column: String, value: String, kind: ColumnType, rowNo: Int) -> Result<(), Error> {
+    let clean = strings.trimSpace(value)
+    match kind {
+        EmptyColumn -> {
+            if clean.isEmpty() {
+                Ok(())
+            } else {
+                Err(tableError("column {column} row {rowNo}: expected empty, got {value}"))
+            }
+        },
+        IntColumn -> {
+            if clean.isEmpty() {
+                Ok(())
+            } else {
+                parseIntCell(column, clean)?
+                Ok(())
+            }
+        },
+        FloatColumn -> {
+            if clean.isEmpty() {
+                Ok(())
+            } else {
+                parseFloatCell(column, clean)?
+                Ok(())
+            }
+        },
+        BoolColumn -> {
+            if clean.isEmpty() {
+                Ok(())
+            } else {
+                parseBoolCell(column, clean)?
+                Ok(())
+            }
+        },
+        TextColumn -> Ok(()),
+        MixedColumn -> Ok(()),
+    }
+}
+
+fn coerceCell(column: String, value: String, kind: ColumnType) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Ok("")
+    }
+
+    match kind {
+        EmptyColumn -> Ok(""),
+        IntColumn -> {
+            let value = parseIntCell(column, clean)?
+            Ok(value.toString())
+        },
+        FloatColumn -> {
+            let value = parseFloatCell(column, clean)?
+            Ok(value.toString())
+        },
+        BoolColumn -> {
+            let value = parseBoolCell(column, clean)?
+            Ok(boolText(value))
+        },
+        TextColumn -> Ok(value),
+        MixedColumn -> Ok(value),
+    }
+}
+
+fn parseIntCell(column: String, value: String) -> Result<Int, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(tableError("column {column}: expected int, got empty"))
+    }
+    match strings.toInt(clean) {
+        Ok(n) -> Ok(n),
+        Err(_) -> Err(tableError("column {column}: expected int, got {value}")),
+    }
+}
+
+fn parseFloatCell(column: String, value: String) -> Result<Float, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(tableError("column {column}: expected float, got empty"))
+    }
+    match strings.toFloat(clean) {
+        Ok(n) -> Ok(n),
+        Err(_) -> Err(tableError("column {column}: expected float, got {value}")),
+    }
+}
+
+fn parseBoolCell(column: String, value: String) -> Result<Bool, Error> {
+    match parseBool(value) {
+        Some(flag) -> Ok(flag),
+        None -> Err(tableError("column {column}: expected bool, got {value}")),
+    }
+}
+
+fn boolText(value: Bool) -> String {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+fn summarizeRows(rows: List<Row>, column: String) -> Result<NumericSummary, Error> {
+    let mut count = 0
+    let mut total = 0.0
+    let mut minValue = 0.0
+    let mut maxValue = 0.0
+
+    for item in rows {
+        let raw = item.getOr(column, "")
+        if !strings.trimSpace(raw).isEmpty() {
+            let value = parseFloatCell(column, raw)?
+            if count == 0 {
+                minValue = value
+                maxValue = value
+            } else {
+                if value < minValue {
+                    minValue = value
+                }
+                if value > maxValue {
+                    maxValue = value
+                }
+            }
+            total = total + value
+            count = count + 1
+        }
+    }
+
+    if count == 0 {
+        return Err(tableError("column {column}: no numeric values"))
+    }
+    Ok(NumericSummary {
+        count: count,
+        sum: total,
+        avg: total / count.toFloat(),
+        min: minValue,
+        max: maxValue,
+    })
+}
+
+fn ensureSummaryColumnDoesNotConflict(groupColumn: String) -> Result<(), Error> {
+    if groupColumn == "count" || groupColumn == "sum" || groupColumn == "avg" || groupColumn == "min" || groupColumn == "max" {
+        return Err(tableError("group column conflicts with summary output column: {groupColumn}"))
+    }
+    Ok(())
+}
+
+fn joinTables(left: Table, right: Table, leftColumn: String, rightColumn: String, includeUnmatchedLeft: Bool) -> Result<Table, Error> {
+    ensureColumn(left.columns, leftColumn)?
+    ensureColumn(right.columns, rightColumn)?
+    let index = indexBy(right, rightColumn)?
+    joinIndexed(left, index, leftColumn, includeUnmatchedLeft)
+}
+
+fn joinIndexed(left: Table, right: JoinIndex, leftColumn: String, includeUnmatchedLeft: Bool) -> Result<Table, Error> {
+    ensureColumn(left.columns, leftColumn)?
+    ensureColumn(right.columns, right.column)?
+
+    let mut outputColumns = copyStrings(left.columns)
+    let mut rightAliases: List<String> = []
+    for column in right.columns {
+        if column == right.column {
+            rightAliases.push("")
+        } else {
+            let name = rightOutputName(left.columns, outputColumns, column)
+            rightAliases.push(name)
+            outputColumns.push(name)
+        }
+    }
+
+    let mut rows: List<Row> = []
+    for leftRow in left.rows {
+        let key = leftRow.getOr(leftColumn, "")
+        let mut matched = false
+        match right.buckets.get(key) {
+            Some(matches) -> {
+                for rightRow in matches {
+                    rows.push(joinRow(left.columns, leftRow, right.columns, rightAliases, rightRow, right.column))
+                    matched = true
+                }
+            },
+            None -> {},
+        }
+        if includeUnmatchedLeft && !matched {
+            rows.push(joinMissingRight(left.columns, leftRow, right.columns, rightAliases, right.column))
+        }
+    }
+    Ok(Table { columns: outputColumns, rows: rows })
+}
+
+fn rightOutputName(leftColumns: List<String>, outputColumns: List<String>, column: String) -> String {
+    let base = if hasColumn(leftColumns, column) { "right.{column}" } else { column }
+    let mut name = base
+    let mut i = 2
+    for hasColumn(outputColumns, name) {
+        name = "{base}_{i}"
+        i = i + 1
+    }
+    name
+}
+
+fn joinRow(leftColumns: List<String>, leftRow: Row, rightColumns: List<String>, rightAliases: List<String>, rightRow: Row, rightColumn: String) -> Row {
+    let mut values: Map<String, String> = {:}
+    for column in leftColumns {
+        values.insert(column, leftRow.getOr(column, ""))
+    }
+
+    let mut i = 0
+    for i < rightColumns.len() {
+        let column = rightColumns[i]
+        if column != rightColumn {
+            values.insert(rightAliases[i], rightRow.getOr(column, ""))
+        }
+        i = i + 1
+    }
+    Row { values: values }
+}
+
+fn joinMissingRight(leftColumns: List<String>, leftRow: Row, rightColumns: List<String>, rightAliases: List<String>, rightColumn: String) -> Row {
+    let mut values: Map<String, String> = {:}
+    for column in leftColumns {
+        values.insert(column, leftRow.getOr(column, ""))
+    }
+
+    let mut i = 0
+    for i < rightColumns.len() {
+        let column = rightColumns[i]
+        if column != rightColumn {
+            values.insert(rightAliases[i], "")
+        }
+        i = i + 1
+    }
+    Row { values: values }
+}
+
+fn inferCellType(value: String) -> ColumnType {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return EmptyColumn
+    }
+    if parseInt(clean).isSome() {
+        return IntColumn
+    }
+    if parseFloat(clean).isSome() {
+        return FloatColumn
+    }
+    if parseBool(clean).isSome() {
+        return BoolColumn
+    }
+    TextColumn
+}
+
+fn mergeColumnType(current: ColumnType, next: ColumnType) -> ColumnType {
+    match current {
+        EmptyColumn -> next,
+        IntColumn -> match next {
+            EmptyColumn -> IntColumn,
+            IntColumn -> IntColumn,
+            FloatColumn -> FloatColumn,
+            TextColumn -> TextColumn,
+            _ -> MixedColumn,
+        },
+        FloatColumn -> match next {
+            EmptyColumn -> FloatColumn,
+            IntColumn -> FloatColumn,
+            FloatColumn -> FloatColumn,
+            TextColumn -> TextColumn,
+            _ -> MixedColumn,
+        },
+        BoolColumn -> match next {
+            EmptyColumn -> BoolColumn,
+            BoolColumn -> BoolColumn,
+            TextColumn -> TextColumn,
+            _ -> MixedColumn,
+        },
+        TextColumn -> TextColumn,
+        MixedColumn -> match next {
+            TextColumn -> TextColumn,
+            _ -> MixedColumn,
+        },
+    }
+}
+
+fn parseInt(value: String) -> Int? {
+    match strings.toInt(strings.trimSpace(value)) {
+        Ok(n) -> Some(n),
+        Err(_) -> noneInt(),
+    }
+}
+
+fn parseFloat(value: String) -> Float? {
+    match strings.toFloat(strings.trimSpace(value)) {
+        Ok(n) -> Some(n),
+        Err(_) -> noneFloat(),
+    }
+}
+
+fn parseBool(value: String) -> Bool? {
+    let clean = strings.toLower(strings.trimSpace(value))
+    if clean == "true" || clean == "yes" || clean == "y" {
+        return Some(true)
+    }
+    if clean == "false" || clean == "no" || clean == "n" {
+        return Some(false)
+    }
+    noneBool()
+}
+
+fn noneString() -> String? {
+    None
+}
+
+fn noneInt() -> Int? {
+    None
+}
+
+fn noneFloat() -> Float? {
+    None
+}
+
+fn noneBool() -> Bool? {
+    None
+}
+
+fn tableError(message: String) -> Error {
+    error.new("table: {message}")
+}

--- a/internal/stdlib/table_test.go
+++ b/internal/stdlib/table_test.go
@@ -1,0 +1,76 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTableModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["table"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.table not loaded")
+	}
+
+	for _, name := range []string{
+		"empty", "row", "schema", "schemaFrom", "fromRows", "fromRecords", "fromCsv", "fromTsv",
+		"fromDelimited", "toCsv", "toTsv", "toDelimited", "dataRows", "toRows",
+		"records", "select", "drop", "sortBy", "sortByType", "sortByInt",
+		"sortByFloat", "sortByBool", "groupBy", "countBy", "innerJoin",
+		"leftJoin", "innerJoinIndex", "leftJoinIndex", "inferTypes",
+		"validateSchema", "coerce", "summarize", "summarizeBy", "sum", "avg",
+		"min", "max", "indexBy", "columnTypeName",
+	} {
+		requirePublicFn(t, mod, "table", name)
+	}
+	for _, name := range []string{"ColumnType", "ColumnSchema", "Row", "TableGroup", "NumericSummary", "JoinIndex", "Table"} {
+		requirePublicType(t, mod, "table", name)
+	}
+	for _, method := range []string{"get", "getOr", "int", "float", "bool"} {
+		if got := reg.LookupMethodDecl("table", "Row", method); got == nil {
+			t.Fatalf("LookupMethodDecl(table, Row, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{
+		"len", "isEmpty", "width", "hasColumn", "get", "select", "drop",
+		"filter", "sortBy", "sortByType", "sortByInt", "sortByFloat",
+		"sortByBool", "groupBy", "countBy", "innerJoin", "leftJoin",
+		"innerJoinIndex", "leftJoinIndex", "inferTypes", "validateSchema",
+		"coerce", "summarize", "summarizeBy", "sum", "avg", "min", "max",
+		"indexBy", "dataRows", "toRows", "records", "toCsv", "toTsv",
+	} {
+		if got := reg.LookupMethodDecl("table", "Table", method); got == nil {
+			t.Fatalf("LookupMethodDecl(table, Table, %s) = nil", method)
+		}
+	}
+}
+
+func TestTableModuleSourcePinsDataframeBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["table"]
+	if mod == nil {
+		t.Fatal("std.table module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"csv.decodeTsv(text)?",
+		"csv.encodeTsv(table.toRows())",
+		"pub fn filter(self, pred: fn(Row) -> Bool) -> Table",
+		"pub fn sortByType(table: Table, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error>",
+		"pub fn validateSchema(table: Table, schema: List<ColumnSchema>) -> Result<(), Error>",
+		"pub fn coerce(table: Table, schema: List<ColumnSchema>) -> Result<Table, Error>",
+		"pub fn summarizeBy(table: Table, groupColumn: String, valueColumn: String) -> Result<Table, Error>",
+		"pub fn indexBy(table: Table, column: String) -> Result<JoinIndex, Error>",
+		"pub fn groupBy(table: Table, column: String) -> Result<List<TableGroup>, Error>",
+		"pub fn innerJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>",
+		"fn joinIndexed(left: Table, right: JoinIndex, leftColumn: String, includeUnmatchedLeft: Bool) -> Result<Table, Error>",
+		"fn rightOutputName(leftColumns: List<String>, outputColumns: List<String>, column: String) -> String",
+		"pub fn inferTypes(table: Table) -> List<ColumnSchema>",
+		"strings.toInt(strings.trimSpace(value))",
+		"strings.toFloat(strings.trimSpace(value))",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.table source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add pure-Osty std.table for CSV/TSV-scale dataframe workflows
- add typed sort, schema validation/coercion, numeric aggregation, and indexed joins
- document the table surface and pin stdlib/backend tests

## Validation
- go test -count=1 -vet=off ./internal/stdlib -run 'Test(Csv|Table)' -v
- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultTable' -v
- git diff --check
- just support-stdlib-medium