### PR TITLE
[codex] harden QtQuick GUI workflow

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -98,7 +98,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
-| gui.qtquick | 183 | Qt Quick/QML native app backend MVP. `libosty_qt` bridge 필요, bundle/deploy 연계는 후속 |
+| gui.qtquick | 243 | Qt Quick/QML native app backend MVP. `libosty_qt` bridge, runtime diagnostics, reload/import-path helpers, `osty gui doctor qtquick`; bundle/deploy 연계는 후속 |
 | gui.webview2 | 223 | Windows WebView2 C ABI shim spike. Safe wrapper / scaffold / runtime diagnostics landed; Windows smoke and packaged linker flow still pending |
 | compress | 11 | gzip 만 (zstd / deflate 추가 가능). Phase A shim 199 |
 | testing_gen | 168 | property runner 는 int/intRange/asciiString/pair/triple/oneOf/constant subset 실행. bool/float/char/byte/list/listOfSize/option/result/oneOfGens/map/filter 는 아직 실행 subset 밖 |

--- a/cmd/osty/gui_doctor.go
+++ b/cmd/osty/gui_doctor.go
@@ -1,0 +1,380 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/osty/osty/internal/manifest"
+)
+
+type guiDoctorStatus string
+
+const (
+	guiDoctorPass guiDoctorStatus = "pass"
+	guiDoctorWarn guiDoctorStatus = "warn"
+	guiDoctorFail guiDoctorStatus = "fail"
+)
+
+type guiDoctorCheck struct {
+	Name   string
+	Status guiDoctorStatus
+	Detail string
+	Hint   string
+}
+
+type guiDoctorReport struct {
+	Backend string
+	Root    string
+	Checks  []guiDoctorCheck
+}
+
+type qtQuickDoctorOptions struct {
+	Start      string
+	BridgeRoot string
+	RunCMake   bool
+}
+
+func runGui(args []string, flags cliFlags) {
+	_ = flags
+	if len(args) < 1 || args[0] != "doctor" {
+		fmt.Fprintln(os.Stderr, "usage: osty gui doctor qtquick [--bridge-root DIR] [--no-cmake] [PATH]")
+		os.Exit(2)
+	}
+	runGUIDoctor(args[1:])
+}
+
+func runGUIDoctor(args []string) {
+	if len(args) < 1 || args[0] != "qtquick" {
+		fmt.Fprintln(os.Stderr, "usage: osty gui doctor qtquick [--bridge-root DIR] [--no-cmake] [PATH]")
+		os.Exit(2)
+	}
+	fs := flag.NewFlagSet("gui doctor qtquick", flag.ExitOnError)
+	var bridgeRoot string
+	var noCMake bool
+	fs.StringVar(&bridgeRoot, "bridge-root", "", "path to libosty_qt")
+	fs.BoolVar(&noCMake, "no-cmake", false, "skip Qt CMake configure probe")
+	_ = fs.Parse(args[1:])
+	start := "."
+	if fs.NArg() == 1 {
+		start = fs.Arg(0)
+	} else if fs.NArg() > 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	report := qtQuickDoctorReport(qtQuickDoctorOptions{
+		Start:      start,
+		BridgeRoot: bridgeRoot,
+		RunCMake:   !noCMake,
+	})
+	printGUIDoctorReport(report)
+	if reportHasFailure(report) {
+		os.Exit(1)
+	}
+}
+
+func qtQuickDoctorReport(opts qtQuickDoctorOptions) guiDoctorReport {
+	if opts.Start == "" {
+		opts.Start = "."
+	}
+	report := guiDoctorReport{Backend: "qtquick"}
+	projectRoot, m, manifestErr := loadDoctorManifest(opts.Start)
+	report.Root = projectRoot
+	if manifestErr != nil {
+		report.Checks = append(report.Checks, guiDoctorCheck{
+			Name:   "manifest",
+			Status: guiDoctorFail,
+			Detail: manifestErr.Error(),
+			Hint:   "Run this from an Osty GUI project root or pass the project path.",
+		})
+		return report
+	}
+	report.Checks = append(report.Checks, guiDoctorCheck{
+		Name:   "manifest",
+		Status: guiDoctorPass,
+		Detail: filepath.Join(projectRoot, manifest.ManifestFile),
+	})
+	report.checkQtQuickManifest(projectRoot, m)
+	report.checkQtQuickBridge(projectRoot, opts)
+	return report
+}
+
+func (r *guiDoctorReport) checkQtQuickManifest(root string, m *manifest.Manifest) {
+	if m == nil || m.GUI == nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "gui metadata",
+			Status: guiDoctorFail,
+			Detail: "missing [gui] section",
+			Hint:   `Add [gui] backend = "qtquick" and entry = "ui/main.qml".`,
+		})
+		return
+	}
+	if m.GUI.Backend != "qtquick" {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "gui metadata",
+			Status: guiDoctorFail,
+			Detail: fmt.Sprintf("backend = %q", m.GUI.Backend),
+			Hint:   `Use backend = "qtquick" for Qt Quick apps.`,
+		})
+		return
+	}
+	r.Checks = append(r.Checks, guiDoctorCheck{Name: "gui metadata", Status: guiDoctorPass, Detail: `backend = "qtquick"`})
+
+	entry := m.GUI.Entry
+	if entry == "" {
+		entry = "ui/main.qml"
+	}
+	entryPath := filepath.Join(root, entry)
+	if _, err := os.Stat(entryPath); err != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "qml entry",
+			Status: guiDoctorFail,
+			Detail: fmt.Sprintf("%s: %v", entry, err),
+			Hint:   "Create the QML entry file or update [gui].entry.",
+		})
+	} else {
+		imports := scanQMLImports(entryPath)
+		detail := entry
+		if len(imports) > 0 {
+			detail += " imports " + strings.Join(imports, ", ")
+		}
+		r.Checks = append(r.Checks, guiDoctorCheck{Name: "qml entry", Status: guiDoctorPass, Detail: detail})
+	}
+
+	binEntry := "main.osty"
+	if m.Bin != nil && m.Bin.Path != "" {
+		binEntry = m.Bin.Path
+	}
+	if _, err := os.Stat(filepath.Join(root, binEntry)); err != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "osty entry",
+			Status: guiDoctorFail,
+			Detail: fmt.Sprintf("%s: %v", binEntry, err),
+			Hint:   "Create the Osty entry file or update [bin].path.",
+		})
+	} else {
+		r.Checks = append(r.Checks, guiDoctorCheck{Name: "osty entry", Status: guiDoctorPass, Detail: binEntry})
+	}
+
+	host := runtime.GOARCH + "-" + runtime.GOOS
+	for _, target := range m.Targets {
+		if target == nil || target.Triple != host {
+			continue
+		}
+		for _, lib := range target.Link {
+			if lib == "osty_qt" {
+				r.Checks = append(r.Checks, guiDoctorCheck{Name: "host link", Status: guiDoctorPass, Detail: host + ` links "osty_qt"`})
+				return
+			}
+		}
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "host link",
+			Status: guiDoctorFail,
+			Detail: host + " target exists but does not link osty_qt",
+			Hint:   `Add link = ["osty_qt"] under [target.` + host + `].`,
+		})
+		return
+	}
+	r.Checks = append(r.Checks, guiDoctorCheck{
+		Name:   "host link",
+		Status: guiDoctorWarn,
+		Detail: "no [target." + host + "] entry",
+		Hint:   `Add a host target with link = ["osty_qt"] for local native builds.`,
+	})
+}
+
+func (r *guiDoctorReport) checkQtQuickBridge(projectRoot string, opts qtQuickDoctorOptions) {
+	bridgeRoot := opts.BridgeRoot
+	if bridgeRoot == "" {
+		bridgeRoot = findQtBridgeRoot(projectRoot)
+	}
+	if bridgeRoot == "" {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "libosty_qt",
+			Status: guiDoctorFail,
+			Detail: "libosty_qt directory not found",
+			Hint:   "Run from the Osty repository checkout or pass --bridge-root /path/to/libosty_qt.",
+		})
+		return
+	}
+	r.Checks = append(r.Checks, guiDoctorCheck{Name: "libosty_qt", Status: guiDoctorPass, Detail: bridgeRoot})
+	if !opts.RunCMake {
+		r.Checks = append(r.Checks, guiDoctorCheck{Name: "qt configure", Status: guiDoctorWarn, Detail: "skipped by --no-cmake"})
+		return
+	}
+	if _, err := exec.LookPath("cmake"); err != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "cmake",
+			Status: guiDoctorFail,
+			Detail: "cmake not found on PATH",
+			Hint:   "Install CMake, then build libosty_qt before running the app.",
+		})
+		return
+	}
+	r.Checks = append(r.Checks, guiDoctorCheck{Name: "cmake", Status: guiDoctorPass, Detail: "available"})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+	buildDir, err := os.MkdirTemp("", "osty-qt-doctor-*")
+	if err != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{Name: "qt configure", Status: guiDoctorFail, Detail: err.Error()})
+		return
+	}
+	defer os.RemoveAll(buildDir)
+	cmd := exec.CommandContext(ctx, "cmake", "-S", bridgeRoot, "-B", buildDir, "-DOSTY_QT_ENABLE_QT=ON")
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "qt configure",
+			Status: guiDoctorFail,
+			Detail: "cmake probe timed out",
+			Hint:   "Check that Qt and CMake are installed and responsive.",
+		})
+		return
+	}
+	if err != nil {
+		r.Checks = append(r.Checks, guiDoctorCheck{
+			Name:   "qt configure",
+			Status: guiDoctorFail,
+			Detail: firstOutputLines(out, 8),
+			Hint:   "Install Qt Quick/QML development packages, or use -DOSTY_QT_ENABLE_QT=OFF only for diagnostic stubs.",
+		})
+		return
+	}
+	r.Checks = append(r.Checks, guiDoctorCheck{Name: "qt configure", Status: guiDoctorPass, Detail: "Qt Quick/QML found by CMake"})
+}
+
+func loadDoctorManifest(start string) (string, *manifest.Manifest, error) {
+	info, err := os.Stat(start)
+	if err == nil && !info.IsDir() {
+		start = filepath.Dir(start)
+	}
+	root, err := manifest.FindRoot(start)
+	if err != nil {
+		return "", nil, err
+	}
+	m, diags, err := manifest.Load(filepath.Join(root, manifest.ManifestFile))
+	if err != nil {
+		return root, nil, err
+	}
+	for _, d := range diags {
+		if d != nil && d.Severity.String() == "error" {
+			return root, nil, fmt.Errorf("%s", d.Message)
+		}
+	}
+	return root, m, nil
+}
+
+func findQtBridgeRoot(projectRoot string) string {
+	candidates := []string{}
+	for _, env := range []string{"OSTY_QT_ROOT", "OSTY_QT_BRIDGE_ROOT"} {
+		if value := os.Getenv(env); value != "" {
+			candidates = append(candidates, value)
+		}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, filepath.Join(cwd, "libosty_qt"))
+		candidates = append(candidates, walkUpBridgeCandidates(cwd)...)
+	}
+	candidates = append(candidates, filepath.Join(projectRoot, "libosty_qt"))
+	candidates = append(candidates, walkUpBridgeCandidates(projectRoot)...)
+	for _, c := range candidates {
+		c = filepath.Clean(c)
+		if isQtBridgeRoot(c) {
+			return c
+		}
+	}
+	return ""
+}
+
+func walkUpBridgeCandidates(start string) []string {
+	var out []string
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return out
+	}
+	for {
+		out = append(out, filepath.Join(dir, "libosty_qt"))
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return out
+		}
+		dir = parent
+	}
+}
+
+func isQtBridgeRoot(dir string) bool {
+	for _, rel := range []string{"CMakeLists.txt", "include/osty_qt.h", "src/osty_qt.cpp"} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func scanQMLImports(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "import ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := fields[1]
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func firstOutputLines(out []byte, limit int) string {
+	text := strings.TrimSpace(string(out))
+	if text == "" {
+		return "cmake failed without output"
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func printGUIDoctorReport(report guiDoctorReport) {
+	fmt.Printf("Qt Quick GUI doctor\n")
+	if report.Root != "" {
+		fmt.Printf("project: %s\n", report.Root)
+	}
+	for _, check := range report.Checks {
+		fmt.Printf("[%s] %s: %s\n", check.Status, check.Name, check.Detail)
+		if check.Hint != "" {
+			fmt.Printf("      hint: %s\n", check.Hint)
+		}
+	}
+}
+
+func reportHasFailure(report guiDoctorReport) bool {
+	for _, check := range report.Checks {
+		if check.Status == guiDoctorFail {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/osty/gui_doctor_test.go
+++ b/cmd/osty/gui_doctor_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestQtQuickDoctorReportHealthyWithoutCMakeProbe(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "osty.toml"), `[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[gui]
+backend = "qtquick"
+entry = "ui/main.qml"
+
+[target.`+runtime.GOARCH+`-`+runtime.GOOS+`]
+link = ["osty_qt"]
+`)
+	mustWrite(t, filepath.Join(root, "main.osty"), "fn main() { }\n")
+	mustWrite(t, filepath.Join(root, "ui", "main.qml"), "import QtQuick\nimport QtQuick.Controls\n")
+	bridge := makeFakeQtBridgeRoot(t)
+
+	report := qtQuickDoctorReport(qtQuickDoctorOptions{
+		Start:      root,
+		BridgeRoot: bridge,
+		RunCMake:   false,
+	})
+	if reportHasFailure(report) {
+		t.Fatalf("report has failure: %#v", report.Checks)
+	}
+	if !doctorHasCheck(report, "qml entry", guiDoctorPass) {
+		t.Fatalf("report missing passing qml entry check: %#v", report.Checks)
+	}
+	if !doctorHasCheck(report, "qt configure", guiDoctorWarn) {
+		t.Fatalf("report missing skipped cmake warning: %#v", report.Checks)
+	}
+}
+
+func TestQtQuickDoctorReportCatchesMissingQMLEntry(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "osty.toml"), `[package]
+name = "desk"
+version = "0.1.0"
+edition = "0.5"
+
+[gui]
+backend = "qtquick"
+entry = "ui/missing.qml"
+`)
+	mustWrite(t, filepath.Join(root, "main.osty"), "fn main() { }\n")
+
+	report := qtQuickDoctorReport(qtQuickDoctorOptions{
+		Start:      root,
+		BridgeRoot: makeFakeQtBridgeRoot(t),
+		RunCMake:   false,
+	})
+	if !doctorHasCheck(report, "qml entry", guiDoctorFail) {
+		t.Fatalf("report missing failing qml entry check: %#v", report.Checks)
+	}
+}
+
+func makeFakeQtBridgeRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\n")
+	mustWrite(t, filepath.Join(root, "include", "osty_qt.h"), "")
+	mustWrite(t, filepath.Join(root, "src", "osty_qt.cpp"), "")
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func doctorHasCheck(report guiDoctorReport, name string, status guiDoctorStatus) bool {
+	for _, check := range report.Checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -171,6 +171,10 @@ func main() {
 		runScaffold(args[1:])
 		return
 	}
+	if cmd == "gui" {
+		runGui(args[1:], flags)
+		return
+	}
 	// build is the manifest-driven project pipeline: load osty.toml,
 	// resolve deps, run the front-end, and ask the selected backend to
 	// emit/build artifacts under the profile/target output tree.
@@ -1222,6 +1226,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty targets              (list declared cross-compilation targets)")
 	fmt.Fprintln(os.Stderr, "       osty features             (list declared opt-in features)")
 	fmt.Fprintln(os.Stderr, "       osty cache [ls|clean|info] (inspect / prune the build cache)")
+	fmt.Fprintln(os.Stderr, "       osty gui doctor qtquick   (diagnose Qt Quick runtime/setup)")
 	fmt.Fprintln(os.Stderr, "       osty scaffold <fixture|schema|ffi> [flags] NAME")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
 	fmt.Fprintln(os.Stderr, "       osty explain [CODE]       (describe a diagnostic code; no arg lists every code)")

--- a/examples/gui-inspector/main.osty
+++ b/examples/gui-inspector/main.osty
@@ -5,9 +5,12 @@ pub struct InspectorState {
     pub status: String,
     pub theme: String,
     pub selected: String,
+    pub input: String,
+    pub runCount: Int,
     pub stages: List<String>,
     pub output: String,
     pub logs: List<String>,
+    pub diagnostic: String,
 }
 
 fn main() {
@@ -18,18 +21,29 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
+    let runtime = gui.runtimeDiagnostic()
     let app = gui.app("Osty Inspector")?
-    let window = app.window(gui.windowOptions("Osty Inspector", 1100, 720, "ui/main.qml"))?
+    app.addImportPath("ui")?
+    let window = app.window(gui.defaultWindowOptions("Osty Inspector", "ui/main.qml"))?
 
-    app.setState(initialState())?
+    app.setState(initialState(runtime.message))?
     window.show()?
 
     for app.poll() {
         for event in app.events() {
             if event.name == "run" {
                 app.setState(runningState(event.payload))?
-            } else if event.name == "toggle-theme" {
-                app.setState(themeState(event.payload))?
+            } else if event.name == "input" {
+                app.setState(inputState(event.payload))?
+            } else if event.name == "select-stage" {
+                app.setState(selectedState(event.payload))?
+            } else if event.name == "reload" {
+                window.reload()?
+                app.setState(reloadedState())?
+            } else if event.name == "theme-light" {
+                app.setState(themeState("light"))?
+            } else if event.name == "theme-dark" {
+                app.setState(themeState("dark"))?
             } else if event.name == "quit" {
                 let _ = app.quit()
             }
@@ -40,14 +54,17 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-fn initialState() -> String {
+fn initialState(diagnostic: String) -> String {
     json.encode(InspectorState {
         status: "ready",
         theme: "dark",
         selected: "lexer",
+        input: "let answer = 42",
+        runCount: 0,
         stages: ["lexer", "parser", "checker", "backend"],
         output: "Select a stage and press Run.",
-        logs: ["Inspector initialized", "Qt bridge ready"],
+        logs: ["Inspector initialized", diagnostic],
+        diagnostic,
     })
 }
 
@@ -56,19 +73,67 @@ fn runningState(payload: String) -> String {
         status: "completed",
         theme: "dark",
         selected: "checker",
+        input: "let answer = 42",
+        runCount: 1,
         stages: ["lexer", "parser", "checker", "backend"],
         output: "Latest event payload: {payload}",
-        logs: ["Run requested from QML", "Event reached Osty", "State pushed back to QML"],
+        logs: ["Run requested from QML", "Button click reached Osty", "State pushed back to QML"],
+        diagnostic: "Runtime stayed available through the event loop.",
     })
 }
 
-fn themeState(payload: String) -> String {
+fn inputState(payload: String) -> String {
+    json.encode(InspectorState {
+        status: "input updated",
+        theme: "dark",
+        selected: "parser",
+        input: payload,
+        runCount: 1,
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "Input event payload: {payload}",
+        logs: ["Input changed in QML", "Payload copied through the Qt bridge", "Osty refreshed the state model"],
+        diagnostic: "Text input flow is active.",
+    })
+}
+
+fn selectedState(payload: String) -> String {
+    json.encode(InspectorState {
+        status: "stage selected",
+        theme: "dark",
+        selected: payload,
+        input: "let answer = 42",
+        runCount: 1,
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "List selection payload: {payload}",
+        logs: ["List selection changed", "QML emitted select-stage", "Osty updated selected stage"],
+        diagnostic: "List event flow is active.",
+    })
+}
+
+fn reloadedState() -> String {
+    json.encode(InspectorState {
+        status: "qml reloaded",
+        theme: "dark",
+        selected: "backend",
+        input: "let answer = 42",
+        runCount: 1,
+        stages: ["lexer", "parser", "checker", "backend"],
+        output: "QML view reloaded without replacing the app state contract.",
+        logs: ["Reload requested", "QML engine rebuilt", "State pushed after reload"],
+        diagnostic: "Reload surface is active.",
+    })
+}
+
+fn themeState(theme: String) -> String {
     json.encode(InspectorState {
         status: "theme updated",
-        theme: "light",
+        theme,
         selected: "backend",
+        input: "let answer = 42",
+        runCount: 1,
         stages: ["lexer", "parser", "checker", "backend"],
-        output: "Theme event payload: {payload}",
+        output: "Theme switched to {theme}.",
         logs: ["Theme toggle received", "State model stayed JSON"],
+        diagnostic: "Theme event flow is active.",
     })
 }

--- a/examples/gui-inspector/osty.toml
+++ b/examples/gui-inspector/osty.toml
@@ -6,6 +6,10 @@ description = "Osty Inspector demo built on std.gui and Qt Quick."
 
 [dependencies]
 
+[gui]
+backend = "qtquick"
+entry = "ui/main.qml"
+
 [target.arm64-darwin]
 link = ["osty_qt"]
 

--- a/examples/gui-inspector/ui/main.qml
+++ b/examples/gui-inspector/ui/main.qml
@@ -34,11 +34,15 @@ ApplicationWindow {
             Item { Layout.fillWidth: true }
             Button {
                 text: "Run"
-                onClicked: osty.emit("run", { stage: stageList.currentItem ? stageList.currentItem.text : "lexer" })
+                onClicked: osty.emit("run", { stage: stageList.currentItem ? stageList.currentItem.text : "lexer", input: sourceInput.text })
+            }
+            Button {
+                text: "Reload"
+                onClicked: osty.emit("reload", { source: "toolbar" })
             }
             Button {
                 text: root.dark ? "Light" : "Dark"
-                onClicked: osty.emit("toggle-theme", { current: root.state.theme || "dark" })
+                onClicked: osty.emit(root.dark ? "theme-light" : "theme-dark", {})
             }
         }
     }
@@ -64,7 +68,10 @@ ApplicationWindow {
                     text: modelData
                     checkable: true
                     checked: ListView.isCurrentItem
-                    onClicked: stageList.currentIndex = index
+                    onClicked: {
+                        stageList.currentIndex = index
+                        osty.emit("select-stage", { stage: modelData })
+                    }
                 }
             }
         }
@@ -80,11 +87,35 @@ ApplicationWindow {
 
                 ScrollView {
                     anchors.fill: parent
-                    TextArea {
-                        readOnly: true
-                        wrapMode: TextArea.Wrap
-                        text: root.state.output || ""
-                        color: root.dark ? "#e8edf3" : "#17202a"
+                    ColumnLayout {
+                        width: parent.width
+                        spacing: 12
+
+                        TextField {
+                            id: sourceInput
+                            Layout.fillWidth: true
+                            text: root.state.input || ""
+                            placeholderText: "Osty source"
+                            selectByMouse: true
+                            onAccepted: osty.emit("input", { value: text })
+                            onEditingFinished: osty.emit("input", { value: text })
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            text: root.state.diagnostic || ""
+                            wrapMode: Text.Wrap
+                            color: root.dark ? "#9fb0c3" : "#53606e"
+                        }
+
+                        TextArea {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 280
+                            readOnly: true
+                            wrapMode: TextArea.Wrap
+                            text: root.state.output || ""
+                            color: root.dark ? "#e8edf3" : "#17202a"
+                        }
                     }
                 }
             }
@@ -99,6 +130,7 @@ ApplicationWindow {
                     delegate: Label {
                         width: ListView.view.width
                         text: modelData
+                        padding: 4
                         color: root.dark ? "#aab7c4" : "#42505e"
                     }
                 }

--- a/examples/qtquick-spike/osty.toml
+++ b/examples/qtquick-spike/osty.toml
@@ -6,6 +6,10 @@ description = "Direct libosty_qt C ABI spike."
 
 [dependencies]
 
+[gui]
+backend = "qtquick"
+entry = "ui/main.qml"
+
 [target.arm64-darwin]
 link = ["osty_qt"]
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -725,6 +725,12 @@ cmake --build .osty/qt-build
 
 Then make the produced library visible to your platform linker/runtime and run
 the app with `+"`osty run`"+`.
+
+Before running, check the local Qt setup:
+
+`+"```sh"+`
+osty gui doctor qtquick
+`+"```"+`
 `, name)
 }
 
@@ -1017,7 +1023,9 @@ use std.json
 pub struct GuiState {
     pub status: String,
     pub count: Int,
+    pub input: String,
     pub logs: List<String>,
+    pub diagnostic: String,
 }
 
 fn main() {
@@ -1028,16 +1036,23 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
+    let runtime = gui.runtimeDiagnostic()
     let app = gui.app("Osty GUI")?
-    let window = app.window(gui.windowOptions("Osty GUI", 900, 620, "ui/main.qml"))?
+    app.addImportPath("ui")?
+    let window = app.window(gui.defaultWindowOptions("Osty GUI", "ui/main.qml"))?
 
-    app.setState(readyState())?
+    app.setState(readyState(runtime.message))?
     window.show()?
 
     for app.poll() {
         for event in app.events() {
             if event.name == "click" {
                 app.setState(clickedState(event.payload))?
+            } else if event.name == "input" {
+                app.setState(inputState(event.payload))?
+            } else if event.name == "reload" {
+                window.reload()?
+                app.setState(reloadedState())?
             } else if event.name == "quit" {
                 let _ = app.quit()
             }
@@ -1048,11 +1063,13 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-fn readyState() -> String {
+fn readyState(diagnostic: String) -> String {
     json.encode(GuiState {
         status: "ready",
         count: 0,
-        logs: ["app started"],
+        input: "hello from Osty",
+        logs: ["app started", diagnostic],
+        diagnostic,
     })
 }
 
@@ -1060,7 +1077,29 @@ fn clickedState(payload: String) -> String {
     json.encode(GuiState {
         status: "clicked",
         count: 1,
+        input: "hello from Osty",
         logs: ["button clicked", "payload: {payload}"],
+        diagnostic: "Button event flow is active.",
+    })
+}
+
+fn inputState(payload: String) -> String {
+    json.encode(GuiState {
+        status: "input updated",
+        count: 1,
+        input: payload,
+        logs: ["input changed", "payload: {payload}"],
+        diagnostic: "Input event flow is active.",
+    })
+}
+
+fn reloadedState() -> String {
+    json.encode(GuiState {
+        status: "qml reloaded",
+        count: 1,
+        input: "hello from Osty",
+        logs: ["reload requested", "QML engine rebuilt"],
+        diagnostic: "Reload surface is active.",
     })
 }
 `
@@ -1091,6 +1130,26 @@ ApplicationWindow {
         Button {
             text: "Run"
             onClicked: osty.emit("click", { source: "main.qml" })
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            TextField {
+                id: input
+                Layout.fillWidth: true
+                text: state.input || ""
+                onEditingFinished: osty.emit("input", { value: text })
+            }
+            Button {
+                text: "Reload"
+                onClicked: osty.emit("reload", { source: "main.qml" })
+            }
+        }
+
+        Label {
+            Layout.fillWidth: true
+            text: state.diagnostic || ""
+            wrapMode: Text.Wrap
         }
 
         ListView {

--- a/internal/stdlib/gui_test.go
+++ b/internal/stdlib/gui_test.go
@@ -214,7 +214,7 @@ func TestGuiQtQuickModuleSurface(t *testing.T) {
 	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
 		t.Fatalf("std.gui.qtquick not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
 	}
-	for _, name := range []string{"App", "Window", "WindowOptions", "Event", "RuntimeInfo"} {
+	for _, name := range []string{"App", "Window", "WindowOptions", "Event", "RuntimeInfo", "RuntimeDiagnostic"} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Fatalf("std.gui.qtquick missing type %q", name)
@@ -223,7 +223,7 @@ func TestGuiQtQuickModuleSurface(t *testing.T) {
 			t.Fatalf("std.gui.qtquick.%s not public", name)
 		}
 	}
-	for _, name := range []string{"app", "windowOptions", "runtimeInfo", "abiVersion", "available", "lastError"} {
+	for _, name := range []string{"app", "windowOptions", "defaultWindowOptions", "runtimeInfo", "runtimeDiagnostic", "abiVersion", "available", "lastError", "lastErrorMessage"} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Fatalf("std.gui.qtquick missing export %q", name)
@@ -238,6 +238,23 @@ func TestGuiQtQuickModuleSurface(t *testing.T) {
 	if fn := reg.LookupMethodDecl("gui.qtquick", "App", "events"); fn == nil {
 		t.Fatalf("LookupMethodDecl(gui.qtquick, App, events) = nil, want event polling surface")
 	}
+	if fn := reg.LookupMethodDecl("gui.qtquick", "App", "addImportPath"); fn == nil {
+		t.Fatalf("LookupMethodDecl(gui.qtquick, App, addImportPath) = nil, want QML import path surface")
+	}
+	if fn := reg.LookupMethodDecl("gui.qtquick", "Window", "reload"); fn == nil {
+		t.Fatalf("LookupMethodDecl(gui.qtquick, Window, reload) = nil, want QML reload surface")
+	}
+	src := guiQtQuickModuleSource(t)
+	for _, want := range []string{
+		`fn osty_qt_app_add_import_path(app: Int, path: String) -> Bool`,
+		`fn osty_qt_window_reload(window: Int) -> Bool`,
+		`pub fn runtimeDiagnostic() -> RuntimeDiagnostic`,
+		`strings.concat(s, "")`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.gui.qtquick source missing %q", want)
+		}
+	}
 }
 
 func guiModuleSource(t *testing.T) string {
@@ -246,6 +263,16 @@ func guiModuleSource(t *testing.T) string {
 	mod := reg.Modules["gui"]
 	if mod == nil {
 		t.Fatal("stdlib gui module missing")
+	}
+	return string(mod.Source)
+}
+
+func guiQtQuickModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["gui.qtquick"]
+	if mod == nil {
+		t.Fatal("stdlib gui.qtquick module missing")
 	}
 	return string(mod.Source)
 }

--- a/internal/stdlib/modules/gui/qtquick.osty
+++ b/internal/stdlib/modules/gui/qtquick.osty
@@ -6,6 +6,7 @@
 // Qt Quick spike surface.
 
 use std.error
+use std.strings
 use c "osty_qt" as qt {
     fn osty_qt_abi_version() -> String
     fn osty_qt_has_qt() -> Bool
@@ -16,11 +17,13 @@ use c "osty_qt" as qt {
     fn osty_qt_app_poll(app: Int) -> Bool
     fn osty_qt_app_quit(app: Int)
     fn osty_qt_app_set_state_json(app: Int, stateJson: String) -> Bool
+    fn osty_qt_app_add_import_path(app: Int, path: String) -> Bool
     fn osty_qt_window_new(app: Int, title: String, width: Int, height: Int, qml: String) -> Int
     fn osty_qt_window_show(window: Int) -> Bool
     fn osty_qt_window_close(window: Int)
     fn osty_qt_window_set_title(window: Int, title: String) -> Bool
     fn osty_qt_window_set_state_json(window: Int, stateJson: String) -> Bool
+    fn osty_qt_window_reload(window: Int) -> Bool
     fn osty_qt_event_count(app: Int) -> Int
     fn osty_qt_event_name(app: Int, index: Int) -> String
     fn osty_qt_event_payload(app: Int, index: Int) -> String
@@ -49,6 +52,14 @@ pub struct App {
         }
     }
 
+    pub fn addImportPath(self, path: String) -> Result<(), Error> {
+        if qt.osty_qt_app_add_import_path(self.handle, path) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
     pub fn poll(self) -> Bool {
         qt.osty_qt_app_poll(self.handle)
     }
@@ -58,8 +69,8 @@ pub struct App {
         let mut out: List<Event> = []
         for i in 0..n {
             out.push(Event {
-                name: qt.osty_qt_event_name(self.handle, i),
-                payload: qt.osty_qt_event_payload(self.handle, i),
+                name: copyString(qt.osty_qt_event_name(self.handle, i)),
+                payload: copyString(qt.osty_qt_event_payload(self.handle, i)),
             })
         }
         qt.osty_qt_event_clear(self.handle)
@@ -112,6 +123,14 @@ pub struct Window {
         }
     }
 
+    pub fn reload(self) -> Result<(), Error> {
+        if qt.osty_qt_window_reload(self.handle) {
+            Ok(())
+        } else {
+            Err(backendError())
+        }
+    }
+
     pub fn close(self) {
         qt.osty_qt_window_close(self.handle)
         return
@@ -139,22 +158,55 @@ pub fn windowOptions(title: String, width: Int, height: Int, qml: String) -> Win
     }
 }
 
+pub fn defaultWindowOptions(title: String, qml: String) -> WindowOptions {
+    WindowOptions {
+        title: title,
+        width: 1100,
+        height: 720,
+        qml: qml,
+    }
+}
+
 pub struct RuntimeInfo {
     pub abiVersion: String,
     pub available: Bool,
     pub lastError: String,
 }
 
+pub struct RuntimeDiagnostic {
+    pub available: Bool,
+    pub abiVersion: String,
+    pub message: String,
+    pub lastError: String,
+}
+
 pub fn runtimeInfo() -> RuntimeInfo {
     RuntimeInfo {
-        abiVersion: qt.osty_qt_abi_version(),
+        abiVersion: copyString(qt.osty_qt_abi_version()),
         available: qt.osty_qt_has_qt(),
-        lastError: qt.osty_qt_last_error(),
+        lastError: lastErrorMessage(),
+    }
+}
+
+pub fn runtimeDiagnostic() -> RuntimeDiagnostic {
+    let available = qt.osty_qt_has_qt()
+    let abi = copyString(qt.osty_qt_abi_version())
+    let last = lastErrorMessage()
+    let message = if available {
+        "Qt Quick runtime bridge available: {abi}"
+    } else {
+        "Qt Quick runtime bridge was built without Qt support. Build libosty_qt with Qt Quick/QML installed or run osty gui doctor qtquick."
+    }
+    RuntimeDiagnostic {
+        available,
+        abiVersion: abi,
+        message,
+        lastError: last,
     }
 }
 
 pub fn abiVersion() -> String {
-    qt.osty_qt_abi_version()
+    copyString(qt.osty_qt_abi_version())
 }
 
 pub fn available() -> Bool {
@@ -162,7 +214,7 @@ pub fn available() -> Bool {
 }
 
 pub fn lastError() -> String {
-    qt.osty_qt_last_error()
+    lastErrorMessage()
 }
 
 pub fn app(name: String) -> Result<App, Error> {
@@ -173,11 +225,19 @@ pub fn app(name: String) -> Result<App, Error> {
     Ok(App { handle })
 }
 
+pub fn lastErrorMessage() -> String {
+    copyString(qt.osty_qt_last_error())
+}
+
 fn backendError() -> Error {
-    let msg = qt.osty_qt_last_error()
+    let msg = lastErrorMessage()
     if msg == "" {
         error.new("gui.qtquick: Qt backend failed without a diagnostic")
     } else {
         error.new(msg)
     }
+}
+
+fn copyString(s: String) -> String {
+    strings.concat(s, "")
 }

--- a/libosty_qt/README.md
+++ b/libosty_qt/README.md
@@ -21,6 +21,20 @@ cmake --build .osty/qt-build
 That stub build exports the same symbols, but `osty_qt_app_new` fails with a
 clear error saying Qt support was not compiled in.
 
+## Diagnostics
+
+From a Qt Quick app root, run:
+
+```sh
+osty gui doctor qtquick
+```
+
+The doctor checks the manifest `[gui]` entry, the QML file, the Osty entrypoint,
+host target link hints, the `libosty_qt` source tree, CMake, and whether CMake
+can find Qt Quick/QML. QML load failures from the bridge include the resolved
+QML path, active import paths, captured QML diagnostics, and a pointer back to
+the doctor command.
+
 ## String Boundary
 
 The ABI receives Osty `String` values as the native runtime string pointer, not

--- a/libosty_qt/src/osty_qt.cpp
+++ b/libosty_qt/src/osty_qt.cpp
@@ -22,6 +22,8 @@
 #  include <QJsonValue>
 #  include <QQmlApplicationEngine>
 #  include <QQmlContext>
+#  include <QQmlEngine>
+#  include <QQmlError>
 #  include <QString>
 #  include <QUrl>
 #  include <QVariant>
@@ -98,6 +100,8 @@ struct Window {
     QObject *root = nullptr;
     QWindow *qwindow = nullptr;
     QObject *bridge = nullptr;
+    std::string resolved_qml_url;
+    std::vector<std::string> load_warnings;
 #endif
 };
 
@@ -174,6 +178,48 @@ QUrl qml_url(const std::string &path) {
         return QUrl(qpath);
     }
     return QUrl::fromLocalFile(QFileInfo(qpath).absoluteFilePath());
+}
+
+std::string qurl_to_utf8(const QUrl &url) {
+    QString text = url.isLocalFile() ? url.toLocalFile() : url.toString();
+    return text.toUtf8().toStdString();
+}
+
+std::string join_lines(const std::vector<std::string> &items, const char *prefix) {
+    std::string out;
+    for (const auto &item : items) {
+        if (item.empty()) {
+            continue;
+        }
+        out += "\n";
+        out += prefix;
+        out += item;
+    }
+    return out;
+}
+
+std::string qml_failure_message(Window *window, const std::string &reason) {
+    std::string msg = "osty_qt: " + reason + ": " + window->qml_path;
+    if (!window->resolved_qml_url.empty()) {
+        msg += "\n  resolved: " + window->resolved_qml_url;
+    }
+    if (window->engine != nullptr) {
+        std::vector<std::string> import_paths;
+        const QStringList paths = window->engine->importPathList();
+        for (const auto &path : paths) {
+            import_paths.push_back(path.toUtf8().toStdString());
+        }
+        if (!import_paths.empty()) {
+            msg += "\n  QML import paths:";
+            msg += join_lines(import_paths, "    - ");
+        }
+    }
+    if (!window->load_warnings.empty()) {
+        msg += "\n  QML diagnostics:";
+        msg += join_lines(window->load_warnings, "    - ");
+    }
+    msg += "\n  hint: run `osty gui doctor qtquick` from the app root, and verify Qt Quick/QML modules and platform plugins are installed.";
+    return msg;
 }
 
 QVariant json_to_variant(const std::string &json, bool *ok = nullptr) {
@@ -260,22 +306,34 @@ bool load_window(Window *window) {
         set_error("osty_qt: nil window");
         return false;
     }
-    App *app = nullptr;
+    std::string state_json;
+    std::vector<std::string> import_paths;
     {
         std::lock_guard<std::mutex> lock(g_mu);
-        app = lookup_app_locked(window->app);
+        App *app = lookup_app_locked(window->app);
         if (app == nullptr) {
             return false;
         }
+        state_json = app->state_json;
+        import_paths = app->import_paths;
     }
 
     window->engine = std::make_unique<QQmlApplicationEngine>();
     window->root = nullptr;
     window->qwindow = nullptr;
+    window->bridge = nullptr;
+    window->resolved_qml_url.clear();
+    window->load_warnings.clear();
+    QObject::connect(window->engine.get(), &QQmlEngine::warnings,
+                     [window](const QList<QQmlError> &warnings) {
+                         for (const QQmlError &warning : warnings) {
+                             window->load_warnings.push_back(warning.toString().toUtf8().toStdString());
+                         }
+                     });
     auto *bridge = new OstyBridge(window->app, window->engine.get());
     window->bridge = bridge;
     bool state_ok = false;
-    QVariant state = json_to_variant(app->state_json, &state_ok);
+    QVariant state = json_to_variant(state_json, &state_ok);
     if (!state_ok) {
         set_error("osty_qt: app state is not valid JSON");
         return false;
@@ -283,12 +341,18 @@ bool load_window(Window *window) {
     bridge->setState(state);
     window->engine->rootContext()->setContextProperty(QStringLiteral("osty"), bridge);
     window->engine->rootContext()->setContextProperty(QStringLiteral("appState"), state);
-    for (const auto &path : app->import_paths) {
+    for (const auto &path : import_paths) {
         window->engine->addImportPath(to_qstring(path));
     }
-    window->engine->load(qml_url(window->qml_path));
+    QUrl url = qml_url(window->qml_path);
+    window->resolved_qml_url = qurl_to_utf8(url);
+    if (url.isLocalFile() && !QFileInfo::exists(url.toLocalFile())) {
+        set_error(qml_failure_message(window, "QML file not found"));
+        return false;
+    }
+    window->engine->load(url);
     if (window->engine->rootObjects().isEmpty()) {
-        set_error("osty_qt: QML load failed: " + window->qml_path);
+        set_error(qml_failure_message(window, "QML load failed"));
         return false;
     }
     window->root = window->engine->rootObjects().first();


### PR DESCRIPTION
## Summary
- add `osty gui doctor qtquick` with manifest, QML entry, host link, bridge, and optional CMake/Qt diagnostics
- expand `std.gui.qtquick` with import-path, reload, runtime diagnostic, and copied string helpers
- harden the Qt bridge QML load diagnostics and refresh the QtQuick inspector/scaffold examples

## Validation
- `go test -count=1 -vet=off ./cmd/osty ./internal/stdlib ./internal/scaffold ./internal/manifest`
- `go run ./cmd/osty check examples/gui-inspector`
- `go run ./cmd/osty check examples/qtquick-spike`
- `go run ./cmd/osty gui doctor qtquick --no-cmake examples/gui-inspector`
- `clang++ -std=c++17 -Ilibosty_qt/include -c libosty_qt/src/osty_qt.cpp -o /tmp/osty_qt_stub.o`
- `git diff --check HEAD~1..HEAD`