### PR TITLE
[codex] add std.report module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 67 공개 모듈. 분류 기준:
+총 68 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (63 / 67 = 94%)
+### ⭐⭐⭐⭐⭐ Production (64 / 68 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -37,6 +37,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | security | 483 | pure Osty + url/net | Deneb-derived SSRF-safe URL checks, numeric IPv4 bypass detection, balanced URL-tail cleanup, safe link extraction, HTML escape, session-key validation |
 | search | 357 | pure Osty | Deneb-derived stateful in-memory index + stateless search: upsert/remove/OR, Unicode tokenization, AND→OR fallback, BM25-style scoring, snippets |
 | markdown | 836 | pure Osty | Deneb-derived markdown + full-ish htmlmd conversion: Result/Options, title, noise stripping, pre/code, tables, ordered lists, links/images, emphasis, entities, multibyte-safe scanners |
+| report | 400 | pure Osty | Markdown/HTML report builder: summary cards, sections, aligned tables, chart CSV/JSON export |
 | tokenest | 305 | pure Osty + bytes | Deneb-derived model-family-aware token estimator with explicit calibration state for Claude/OpenAI/Gemini/default |
 | httpretry | 322 | pure Osty | Deneb-derived retry/backoff decisions and LLM/provider error classification with provider codes, large-session disconnect handling, context/billing/rate-limit disambiguation, and action flags |
 | jsonl | 117 | pure Osty + json | Deneb-style JSON Lines parse/append/compact helpers |
@@ -94,7 +95,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 67 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 68 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -149,6 +150,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | AI agent shell / chat mode | ✅ 가능 | aiagents + http/json/log/thread |
 | Agent-safe logs/transcripts | ✅ 가능 | redact + security + tokenest + aiagents |
 | Local document search | ✅ 가능 | search + markdown + media + jsonl |
+| 사람이 읽는 리포트 산출물 | ✅ 가능 | report + markdown/jsonl/csv |
 | LLM retry/compaction loop | ✅ 가능 | httpretry + tokenest + aiagents |
 
 ## 3. 진짜 약점 (남은 런타임 / 딥 기능)
@@ -179,7 +181,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 44 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, aiagents, redact, media, security, search, markdown, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, table, url, io, collections, email, db, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 45 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, aiagents, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, table, url, io, collections, email, db, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 

--- a/internal/backend/stdlib_report_check_test.go
+++ b/internal/backend/stdlib_report_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultReport(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "report")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(report) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("report module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/report.osty
+++ b/internal/stdlib/modules/report.osty
@@ -1,0 +1,400 @@
+// std.report - human-readable Markdown and HTML report builders.
+//
+// This module is intentionally pure Osty. CLI tools and analysis passes can
+// format their results without depending on a browser, filesystem, or host
+// charting runtime, while still exporting chart-friendly CSV/JSON data.
+
+use std.strings
+
+pub enum Align {
+    Left,
+    Center,
+    Right,
+}
+
+pub enum CardTone {
+    Neutral,
+    Info,
+    Good,
+    Warning,
+    Danger,
+}
+
+pub struct SummaryCard {
+    pub label: String,
+    pub value: String,
+    pub detail: String = "",
+    pub tone: CardTone,
+}
+
+pub struct TableColumn {
+    pub key: String,
+    pub label: String,
+    pub align: Align,
+}
+
+pub struct TableRow {
+    pub cells: Map<String, String> = {:},
+}
+
+pub struct Table {
+    pub title: String = "",
+    pub columns: List<TableColumn> = [],
+    pub rows: List<TableRow> = [],
+}
+
+pub struct ReportSection {
+    pub heading: String,
+    pub body: String,
+}
+
+pub struct ChartPoint {
+    pub series: String = "",
+    pub label: String,
+    pub value: Float,
+}
+
+pub struct Report {
+    pub title: String,
+    pub subtitle: String = "",
+    pub cards: List<SummaryCard> = [],
+    pub sections: List<ReportSection> = [],
+    pub tables: List<Table> = [],
+    pub chart: List<ChartPoint> = [],
+}
+
+pub fn report(title: String) -> Report {
+    Report { title: title }
+}
+
+pub fn section(heading: String, body: String) -> ReportSection {
+    ReportSection { heading: heading, body: body }
+}
+
+pub fn card(label: String, value: String) -> SummaryCard {
+    SummaryCard { label: label, value: value, tone: Neutral }
+}
+
+pub fn cardDetail(label: String, value: String, detail: String, tone: CardTone) -> SummaryCard {
+    SummaryCard {
+        label: label,
+        value: value,
+        detail: detail,
+        tone: tone,
+    }
+}
+
+pub fn column(key: String, label: String) -> TableColumn {
+    TableColumn { key: key, label: label, align: Left }
+}
+
+pub fn alignedColumn(key: String, label: String, align: Align) -> TableColumn {
+    TableColumn { key: key, label: label, align: align }
+}
+
+pub fn row(cells: Map<String, String>) -> TableRow {
+    TableRow { cells: cells }
+}
+
+pub fn table(title: String, columns: List<TableColumn>, rows: List<TableRow>) -> Table {
+    Table { title: title, columns: columns, rows: rows }
+}
+
+pub fn chartPoint(label: String, value: Float) -> ChartPoint {
+    ChartPoint { label: label, value: value }
+}
+
+pub fn seriesPoint(series: String, label: String, value: Float) -> ChartPoint {
+    ChartPoint { series: series, label: label, value: value }
+}
+
+pub fn renderMarkdown(report: Report) -> String {
+    let mut blocks: List<String> = []
+    blocks.push("# {escapeMarkdownText(report.title)}")
+    if !strings.trimSpace(report.subtitle).isEmpty() {
+        blocks.push(strings.trimSpace(report.subtitle))
+    }
+    let cards = renderCardsMarkdown(report.cards)
+    if !cards.isEmpty() {
+        blocks.push(cards)
+    }
+    for section in report.sections {
+        blocks.push("## {escapeMarkdownText(section.heading)}\n\n{strings.trimSpace(section.body)}")
+    }
+    for table in report.tables {
+        let rendered = renderTableMarkdown(table)
+        if !rendered.isEmpty() {
+            blocks.push(rendered)
+        }
+    }
+    if !report.chart.isEmpty() {
+        blocks.push("## Chart data\n\n```csv\n{exportChartCsv(report.chart)}\n```")
+    }
+    strings.join(blocks, "\n\n")
+}
+
+pub fn renderHtml(report: Report) -> String {
+    let mut body: List<String> = []
+    body.push("<header><h1>{escapeHtml(report.title)}</h1>{subtitleHtml(report.subtitle)}</header>")
+    let cards = renderCardsHtml(report.cards)
+    if !cards.isEmpty() {
+        body.push(cards)
+    }
+    for section in report.sections {
+        body.push("<section><h2>{escapeHtml(section.heading)}</h2>{paragraphsHtml(section.body)}</section>")
+    }
+    for table in report.tables {
+        let rendered = renderTableHtml(table)
+        if !rendered.isEmpty() {
+            body.push(rendered)
+        }
+    }
+    if !report.chart.isEmpty() {
+        body.push("<section><h2>Chart data</h2><pre>{escapeHtml(exportChartCsv(report.chart))}</pre><script type=\"application/json\" data-report-chart>{exportChartJson(report.chart)}</script></section>")
+    }
+    htmlDocument(strings.join(body, "\n"))
+}
+
+pub fn renderCardsMarkdown(cards: List<SummaryCard>) -> String {
+    if cards.isEmpty() {
+        return ""
+    }
+    let mut out: List<String> = []
+    out.push("## Summary")
+    for card in cards {
+        let mut line = "- **{escapeMarkdownText(card.label)}**: {escapeMarkdownText(card.value)}"
+        if !strings.trimSpace(card.detail).isEmpty() {
+            line = "{line} ({escapeMarkdownText(card.detail)})"
+        }
+        out.push(line)
+    }
+    strings.join(out, "\n")
+}
+
+pub fn renderCardsHtml(cards: List<SummaryCard>) -> String {
+    if cards.isEmpty() {
+        return ""
+    }
+    let mut out = "<section class=\"cards\">"
+    for card in cards {
+        out = "{out}<article class=\"card {toneClass(card.tone)}\"><div class=\"card-label\">{escapeHtml(card.label)}</div><div class=\"card-value\">{escapeHtml(card.value)}</div>{cardDetailHtml(card.detail)}</article>"
+    }
+    "{out}</section>"
+}
+
+pub fn renderTableMarkdown(table: Table) -> String {
+    if table.columns.isEmpty() {
+        return ""
+    }
+    let mut lines: List<String> = []
+    if !strings.trimSpace(table.title).isEmpty() {
+        lines.push("### {escapeMarkdownText(table.title)}")
+    }
+    lines.push(markdownTableHeader(table.columns))
+    lines.push(markdownAlignRow(table.columns))
+    for row in table.rows {
+        lines.push(markdownTableRow(table.columns, row))
+    }
+    strings.join(lines, "\n")
+}
+
+pub fn renderTableHtml(table: Table) -> String {
+    if table.columns.isEmpty() {
+        return ""
+    }
+    let mut out = "<section class=\"table-block\">"
+    if !strings.trimSpace(table.title).isEmpty() {
+        out = "{out}<h2>{escapeHtml(table.title)}</h2>"
+    }
+    out = "{out}<table><thead><tr>"
+    for col in table.columns {
+        out = "{out}<th style=\"text-align:{alignCss(col.align)}\">{escapeHtml(col.label)}</th>"
+    }
+    out = "{out}</tr></thead><tbody>"
+    for row in table.rows {
+        out = "{out}<tr>"
+        for col in table.columns {
+            let value = row.cells.get(col.key) ?? ""
+            out = "{out}<td style=\"text-align:{alignCss(col.align)}\">{escapeHtml(value)}</td>"
+        }
+        out = "{out}</tr>"
+    }
+    "{out}</tbody></table></section>"
+}
+
+pub fn exportChartCsv(points: List<ChartPoint>) -> String {
+    let mut lines: List<String> = ["series,label,value"]
+    for point in points {
+        lines.push("{csvCell(point.series)},{csvCell(point.label)},{point.value.toString()}")
+    }
+    strings.join(lines, "\n")
+}
+
+pub fn exportChartJson(points: List<ChartPoint>) -> String {
+    let mut parts: List<String> = []
+    for point in points {
+        let open = 123.toChar()
+        let close = 125.toChar()
+        let quote = '"'
+        parts.push("{open}{quote}series{quote}:{jsonString(point.series)},{quote}label{quote}:{jsonString(point.label)},{quote}value{quote}:{point.value.toString()}{close}")
+    }
+    let joined = strings.join(parts, ",")
+    "[{joined}]"
+}
+
+pub fn escapeHtml(text: String) -> String {
+    let mut out = ""
+    for c in text.chars() {
+        if c == '&' {
+            out = "{out}&amp;"
+        } else if c == '<' {
+            out = "{out}&lt;"
+        } else if c == '>' {
+            out = "{out}&gt;"
+        } else if c == '"' {
+            out = "{out}&quot;"
+        } else if c == '\'' {
+            out = "{out}&#39;"
+        } else {
+            out = "{out}{strings.fromChar(c)}"
+        }
+    }
+    out
+}
+
+pub fn escapeMarkdownText(text: String) -> String {
+    let mut out = text
+    out = strings.replaceAll(out, "\\", "\\\\")
+    out = strings.replaceAll(out, "|", "\\|")
+    out = strings.replaceAll(out, "`", "\\`")
+    out = strings.replaceAll(out, "*", "\\*")
+    out = strings.replaceAll(out, "_", "\\_")
+    out
+}
+
+fn markdownTableHeader(columns: List<TableColumn>) -> String {
+    let mut cells: List<String> = []
+    for col in columns {
+        cells.push(escapeMarkdownCell(col.label))
+    }
+    let joined = strings.join(cells, " | ")
+    "| {joined} |"
+}
+
+fn markdownAlignRow(columns: List<TableColumn>) -> String {
+    let mut cells: List<String> = []
+    for col in columns {
+        match col.align {
+            Left   -> cells.push(":---"),
+            Center -> cells.push(":---:"),
+            Right  -> cells.push("---:"),
+        }
+    }
+    let joined = strings.join(cells, " | ")
+    "| {joined} |"
+}
+
+fn markdownTableRow(columns: List<TableColumn>, row: TableRow) -> String {
+    let mut cells: List<String> = []
+    for col in columns {
+        cells.push(escapeMarkdownCell(row.cells.get(col.key) ?? ""))
+    }
+    let joined = strings.join(cells, " | ")
+    "| {joined} |"
+}
+
+fn escapeMarkdownCell(text: String) -> String {
+    let mut out = escapeMarkdownText(text)
+    out = strings.replaceAll(out, "\r\n", "<br>")
+    out = strings.replaceAll(out, "\n", "<br>")
+    strings.trimSpace(out)
+}
+
+fn subtitleHtml(subtitle: String) -> String {
+    let trimmed = strings.trimSpace(subtitle)
+    if trimmed.isEmpty() {
+        return ""
+    }
+    "<p class=\"subtitle\">{escapeHtml(trimmed)}</p>"
+}
+
+fn paragraphsHtml(text: String) -> String {
+    let mut parts: List<String> = []
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if !trimmed.isEmpty() {
+            parts.push("<p>{escapeHtml(trimmed)}</p>")
+        }
+    }
+    if parts.isEmpty() {
+        return ""
+    }
+    strings.join(parts, "")
+}
+
+fn cardDetailHtml(detail: String) -> String {
+    let trimmed = strings.trimSpace(detail)
+    if trimmed.isEmpty() {
+        return ""
+    }
+    "<div class=\"card-detail\">{escapeHtml(trimmed)}</div>"
+}
+
+fn toneClass(tone: CardTone) -> String {
+    match tone {
+        Neutral -> "tone-neutral",
+        Info    -> "tone-info",
+        Good    -> "tone-good",
+        Warning -> "tone-warning",
+        Danger  -> "tone-danger",
+    }
+}
+
+fn alignCss(align: Align) -> String {
+    match align {
+        Left   -> "left",
+        Center -> "center",
+        Right  -> "right",
+    }
+}
+
+fn csvCell(text: String) -> String {
+    let needsQuote = strings.contains(text, ",") ||
+        strings.contains(text, "\"") ||
+        strings.contains(text, "\n") ||
+        strings.contains(text, "\r")
+    if !needsQuote {
+        return text
+    }
+    let quote = '"'
+    let escaped = strings.replaceAll(text, "\"", "\"\"")
+    "{quote}{escaped}{quote}"
+}
+
+fn jsonString(text: String) -> String {
+    let mut out = "\""
+    for c in text.chars() {
+        if c == '"' {
+            out = "{out}\\\""
+        } else if c == '\\' {
+            out = "{out}\\\\"
+        } else if c == '\n' {
+            out = "{out}\\n"
+        } else if c == '\r' {
+            out = "{out}\\r"
+        } else if c == '\t' {
+            out = "{out}\\t"
+        } else {
+            out = "{out}{strings.fromChar(c)}"
+        }
+    }
+    "{out}\""
+}
+
+fn htmlDocument(body: String) -> String {
+    "<!doctype html><html><head><meta charset=\"utf-8\"><title>Report</title><style>{reportCss()}</style></head><body>{body}</body></html>"
+}
+
+fn reportCss() -> String {
+    "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:32px;color:#172033;background:#f7f8fb}header,section{max-width:960px;margin:0 auto 24px}h1{font-size:32px;margin:0 0 8px}.subtitle{color:#596273;margin:0}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}.card{background:white;border:1px solid #dde2ea;border-radius:8px;padding:14px}.card-label{font-size:12px;text-transform:uppercase;color:#667085}.card-value{font-size:24px;font-weight:700;margin-top:4px}.card-detail{color:#667085;margin-top:6px}.tone-good{border-left:4px solid #1a7f37}.tone-warning{border-left:4px solid #b7791f}.tone-danger{border-left:4px solid #c2410c}.tone-info{border-left:4px solid #2563eb}table{width:100%;border-collapse:collapse;background:white}th,td{border:1px solid #dde2ea;padding:8px 10px}th{background:#eef2f7}pre{background:#101828;color:#f8fafc;padding:12px;overflow:auto;border-radius:8px}"
+}

--- a/internal/stdlib/report_test.go
+++ b/internal/stdlib/report_test.go
@@ -1,0 +1,82 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestReportModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["report"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.report not loaded")
+	}
+	for name, kind := range map[string]resolve.SymbolKind{
+		"Align":         resolve.SymEnum,
+		"CardTone":      resolve.SymEnum,
+		"SummaryCard":   resolve.SymStruct,
+		"TableColumn":   resolve.SymStruct,
+		"TableRow":      resolve.SymStruct,
+		"Table":         resolve.SymStruct,
+		"ReportSection": resolve.SymStruct,
+		"ChartPoint":    resolve.SymStruct,
+		"Report":        resolve.SymStruct,
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.report missing type %q", name)
+		}
+		if sym.Kind != kind {
+			t.Fatalf("std.report.%s kind = %s, want %s", name, sym.Kind, kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.report.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"report", "section", "card", "cardDetail", "column", "alignedColumn", "row", "table",
+		"chartPoint", "seriesPoint", "renderMarkdown", "renderHtml", "renderCardsMarkdown",
+		"renderCardsHtml", "renderTableMarkdown", "renderTableHtml", "exportChartCsv",
+		"exportChartJson", "escapeHtml", "escapeMarkdownText",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.report missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.report.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.report.%s not public", name)
+		}
+	}
+}
+
+func TestReportModuleSourcePinsRenderers(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["report"]
+	if mod == nil {
+		t.Fatal("std.report module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub struct SummaryCard`,
+		`pub struct TableColumn`,
+		`pub struct ChartPoint`,
+		`pub fn renderMarkdown(report: Report) -> String`,
+		`pub fn renderHtml(report: Report) -> String`,
+		`renderTableMarkdown(table)`,
+		`renderTableHtml(table)`,
+		`exportChartCsv(report.chart)`,
+		`exportChartJson(report.chart)`,
+		`data-report-chart`,
+		`let joined = strings.join(cells, " | ")`,
+		`strings.replaceAll(text, "\"", "\"\"")`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.report source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add pure Osty `std.report` for Markdown and HTML report output
- support summary cards, sections, aligned tables, and chart CSV/JSON export
- update the stdlib support matrix and add stdlib/backend coverage

## Validation
- `go run ./cmd/osty tokens internal/stdlib/modules/report.osty`
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultReport' -v`\n- `just fmt-check`\n- `git diff --check`