### PR TITLE
[codex] extend std.fs tooling helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.5/10-standard-library/01-tier-1-core.md
@@ -5,7 +5,9 @@
   stream helpers such as `readAll`, `readExact`, `copy`, `writeString`
 - `std.fs` — whole-file and path operations:
   `read`, `readToString`, `write`, `writeString`, `exists`,
-  `create`, `remove`, `rename`, `copy`, `mkdir`, `mkdirAll`
+  `walk`, `glob`, `watch`, `create`, `remove`, `rename`, `copy`,
+  `copyDir`, `mkdir`, `mkdirAll`, `atomicWrite`, `atomicWriteString`,
+  `lockFile`, `hashFile`, `diffFiles`
 - `std.strings` — string manipulation
 - `std.collections` — `List`, `Map`, `Set`
 - `std.option` — `Option`, `Some`, `None` (auto-imported), plus rich

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -184,7 +184,8 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 **현재 상태**:
 - 46 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, aiagents, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
-- 6 모듈은 Phase A 충실 + Phase B declaration-only (fs, env, random, os, crypto, compress)
+- 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
+- fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
 ## 5. 평가 함정: `.osty` 줄 수 모델의 한계
@@ -193,11 +194,12 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 ### 5.1 Bodyless declaration + runtime intrinsic
 
-`math.osty` 42 줄, `fs.osty` 29 줄, `crypto.osty` 23 줄 모두 *각 함수가 한 줄 declaration*:
+`math.osty` 42 줄, `fs.osty`, `crypto.osty` 23 줄 모두 *각 함수가 한 줄 declaration*:
 
 ```osty
 pub fn sin(x: Float) -> Float
 pub fn read(path: String) -> Result<Bytes, Error>
+pub fn walk(root: String) -> Result<List<String>, Error>
 pub fn sha256(data: Bytes) -> Bytes
 ```
 

--- a/internal/backend/llvm_runtime_fs_test.go
+++ b/internal/backend/llvm_runtime_fs_test.go
@@ -1,0 +1,172 @@
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundledRuntimeFsToolingHelpers(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "fs-root")
+	if err := os.MkdirAll(filepath.Join(root, "src", "nested"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "a.txt"), []byte("alpha\nsame\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile a.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "nested", "b.osty"), []byte("beta\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile b.osty: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "other.txt"), []byte("gamma\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile other.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "right.txt"), []byte("alpha\nchanged\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile right.txt: %v", err)
+	}
+
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_fs_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_fs_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void *osty_rt_fs_walk(const char *root);
+void *osty_rt_fs_glob(const char *pattern);
+void *osty_rt_fs_watch(const char *root);
+void *osty_rt_fs_atomic_write_string(const char *path, const char *contents);
+void *osty_rt_fs_lock_file(const char *path);
+void *osty_rt_fs_hash_file(const char *path);
+void *osty_rt_fs_copy_dir(const char *from, const char *to);
+void *osty_rt_fs_diff_files(const char *left, const char *right);
+void *osty_rt_fs_read_string(const char *path);
+bool osty_rt_fs_exists(const char *path);
+int64_t osty_rt_list_len(void *raw_list);
+const char *osty_rt_list_get_string(void *raw_list, int64_t index);
+
+static void join(char *out, size_t cap, const char *base, const char *suffix) {
+    int n = snprintf(out, cap, "%s/%s", base, suffix);
+    if (n < 0 || (size_t)n >= cap) {
+        fprintf(stderr, "path too long\n");
+        exit(2);
+    }
+}
+
+static void fail(const char *msg) {
+    fprintf(stderr, "%s\n", msg);
+    exit(1);
+}
+
+static void require_no_error(void *err, const char *label) {
+    if (err != NULL) {
+        fprintf(stderr, "%s failed\n", label);
+        exit(1);
+    }
+}
+
+static int list_contains(void *list, const char *needle) {
+    int64_t n = osty_rt_list_len(list);
+    for (int64_t i = 0; i < n; i++) {
+        const char *item = osty_rt_list_get_string(list, i);
+        if (item != NULL && strcmp(item, needle) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fail("usage: runtime_fs_harness ROOT");
+    }
+    const char *root = argv[1];
+    char path[4096];
+    char path2[4096];
+    char pattern[4096];
+
+    void *walked = osty_rt_fs_walk(root);
+    if (walked == NULL) {
+        fail("walk returned null");
+    }
+    join(path, sizeof(path), root, "src/");
+    if (!list_contains(walked, path)) {
+        fail("walk missing src directory");
+    }
+    join(path, sizeof(path), root, "src/nested/b.osty");
+    if (!list_contains(walked, path)) {
+        fail("walk missing nested file");
+    }
+
+    join(pattern, sizeof(pattern), root, "**/*.osty");
+    void *matched = osty_rt_fs_glob(pattern);
+    if (matched == NULL || osty_rt_list_len(matched) != 1 || !list_contains(matched, path)) {
+        fail("glob did not match nested osty file");
+    }
+
+    void *snapshot = osty_rt_fs_watch(root);
+    if (snapshot == NULL || osty_rt_list_len(snapshot) < osty_rt_list_len(walked)) {
+        fail("watch snapshot too small");
+    }
+
+    join(path, sizeof(path), root, "src/a.txt");
+    void *hash = osty_rt_fs_hash_file(path);
+    if (hash == NULL || strlen((const char *)hash) != 64) {
+        fail("hashFile did not return sha256 hex");
+    }
+    join(path2, sizeof(path2), root, "right.txt");
+    const char *diff = (const char *)osty_rt_fs_diff_files(path, path2);
+    if (diff == NULL || strstr(diff, "- same") == NULL || strstr(diff, "+ changed") == NULL) {
+        fail("diffFiles missing line diff");
+    }
+
+    join(path, sizeof(path), root, "atomic.txt");
+    require_no_error(osty_rt_fs_atomic_write_string(path, "atom"), "atomicWriteString");
+    const char *text = (const char *)osty_rt_fs_read_string(path);
+    if (text == NULL || strcmp(text, "atom") != 0) {
+        fail("atomicWriteString did not write content");
+    }
+
+    join(path, sizeof(path), root, "tool.lock");
+    require_no_error(osty_rt_fs_lock_file(path), "lockFile first");
+    if (osty_rt_fs_lock_file(path) == NULL) {
+        fail("lockFile second call should fail");
+    }
+
+    join(path, sizeof(path), root, "src");
+    join(path2, sizeof(path2), root, "copy");
+    require_no_error(osty_rt_fs_copy_dir(path, path2), "copyDir");
+    join(path, sizeof(path), root, "copy/nested/b.osty");
+    if (!osty_rt_fs_exists(path)) {
+        fail("copyDir did not copy nested file");
+    }
+
+    printf("ok\n");
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+
+	buildOutput, err := runtimeClangCommand("-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath, root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got := string(runOutput); got != "ok\n" {
+		t.Fatalf("runtime fs stdout = %q, want ok", got)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -81,6 +81,7 @@
 #  include <direct.h>
 #  define OSTY_RT_MKDIR_ONE(path) _mkdir(path)
 #else
+#  include <dirent.h>
 #  include <fcntl.h>
 #  include <sys/stat.h>
 #  include <sys/types.h>
@@ -21313,6 +21314,450 @@ static int osty_rt_fs_mkdir_p(const char *path) {
     return rc;
 }
 
+typedef struct osty_rt_fs_path_vec {
+    char **items;
+    size_t len;
+    size_t cap;
+} osty_rt_fs_path_vec;
+
+static void osty_rt_fs_path_vec_init(osty_rt_fs_path_vec *vec) {
+    vec->items = NULL;
+    vec->len = 0;
+    vec->cap = 0;
+}
+
+static void osty_rt_fs_path_vec_free(osty_rt_fs_path_vec *vec) {
+    if (vec == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < vec->len; i++) {
+        free(vec->items[i]);
+    }
+    free(vec->items);
+    vec->items = NULL;
+    vec->len = 0;
+    vec->cap = 0;
+}
+
+static void osty_rt_fs_path_vec_push_take(osty_rt_fs_path_vec *vec, char *value) {
+    if (vec->len == vec->cap) {
+        size_t next = vec->cap == 0 ? 16U : vec->cap * 2U;
+        char **items = (char **)realloc(vec->items, next * sizeof(char *));
+        if (items == NULL) {
+            free(value);
+            osty_rt_abort("runtime.fs.path_vec: out of memory");
+        }
+        vec->items = items;
+        vec->cap = next;
+    }
+    vec->items[vec->len++] = value;
+}
+
+static void osty_rt_fs_path_vec_push_dup(osty_rt_fs_path_vec *vec, const char *value, const char *site) {
+    const char *text = value == NULL ? "" : value;
+    osty_rt_fs_path_vec_push_take(vec, osty_rt_strndup(text, strlen(text), site));
+}
+
+static int osty_rt_fs_path_cmp(const void *a, const void *b) {
+    const char *lhs = *(const char * const *)a;
+    const char *rhs = *(const char * const *)b;
+    return strcmp(lhs == NULL ? "" : lhs, rhs == NULL ? "" : rhs);
+}
+
+static void *osty_rt_fs_path_vec_to_list(osty_rt_fs_path_vec *vec, const char *site) {
+    void *out = osty_rt_list_new();
+    if (vec == NULL) {
+        return out;
+    }
+    if (vec->len > 1) {
+        qsort(vec->items, vec->len, sizeof(char *), osty_rt_fs_path_cmp);
+    }
+    for (size_t i = 0; i < vec->len; i++) {
+        const char *raw = vec->items[i] == NULL ? "" : vec->items[i];
+        const char *managed = osty_rt_string_dup_site(raw, strlen(raw), site);
+        osty_rt_list_push_string(out, managed);
+    }
+    return out;
+}
+
+static char *osty_rt_fs_join_path(const char *base, const char *name, bool trailing_slash) {
+    const char *lhs = base == NULL ? "" : base;
+    const char *rhs = name == NULL ? "" : name;
+    size_t lhs_len = strlen(lhs);
+    size_t rhs_len = strlen(rhs);
+    bool need_sep = lhs_len != 0 && lhs[lhs_len - 1] != '/' && lhs[lhs_len - 1] != '\\';
+    size_t total = lhs_len + (need_sep ? 1U : 0U) + rhs_len + (trailing_slash ? 1U : 0U);
+    char *out = (char *)osty_rt_xmalloc(total + 1U, "runtime.fs.join_path");
+    size_t off = 0;
+    if (lhs_len != 0) {
+        memcpy(out + off, lhs, lhs_len);
+        off += lhs_len;
+    }
+    if (need_sep) {
+        out[off++] = '/';
+    }
+    if (rhs_len != 0) {
+        memcpy(out + off, rhs, rhs_len);
+        off += rhs_len;
+    }
+    if (trailing_slash) {
+        out[off++] = '/';
+    }
+    out[off] = '\0';
+    return out;
+}
+
+static void osty_rt_fs_normalize_slashes(char *path) {
+    if (path == NULL) {
+        return;
+    }
+    for (char *p = path; *p != '\0'; p++) {
+        if (*p == '\\') {
+            *p = '/';
+        }
+    }
+}
+
+static char *osty_rt_fs_snapshot_row(char kind, const char *path, int64_t size, int64_t mtime_sec) {
+    const char *text = path == NULL ? "" : path;
+    int needed = snprintf(NULL, 0, "%c\t%lld\t%lld\t%s",
+                          kind, (long long)size, (long long)mtime_sec, text);
+    if (needed < 0) {
+        osty_rt_abort("runtime.fs.watch: snprintf failed");
+    }
+    char *out = (char *)osty_rt_xmalloc((size_t)needed + 1U, "runtime.fs.watch.row");
+    snprintf(out, (size_t)needed + 1U, "%c\t%lld\t%lld\t%s",
+             kind, (long long)size, (long long)mtime_sec, text);
+    return out;
+}
+
+void *osty_rt_fs_copy(const char *from, const char *to);
+
+#if defined(OSTY_RT_PLATFORM_POSIX)
+static int osty_rt_fs_collect_path(const char *path, const struct stat *st, osty_rt_fs_path_vec *out, bool snapshot) {
+    bool is_dir = S_ISDIR(st->st_mode);
+    bool is_link = S_ISLNK(st->st_mode);
+    char *stored = NULL;
+    if (snapshot) {
+        char kind = is_dir ? 'D' : (is_link ? 'L' : 'F');
+        stored = osty_rt_fs_snapshot_row(kind, path, (int64_t)st->st_size, (int64_t)st->st_mtime);
+    } else {
+        stored = osty_rt_strndup(path, strlen(path), "runtime.fs.walk.path");
+        osty_rt_fs_normalize_slashes(stored);
+    }
+    osty_rt_fs_path_vec_push_take(out, stored);
+    return is_dir ? 1 : 0;
+}
+
+static int osty_rt_fs_walk_dir_children_posix(const char *dir_path, osty_rt_fs_path_vec *out, bool snapshot) {
+    DIR *dir = opendir(dir_path);
+    if (dir == NULL) {
+        return -1;
+    }
+    for (;;) {
+        errno = 0;
+        struct dirent *ent = readdir(dir);
+        if (ent == NULL) {
+            int err = errno;
+            closedir(dir);
+            if (err != 0) {
+                errno = err;
+                return -1;
+            }
+            return 0;
+        }
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+            continue;
+        }
+        char *child = osty_rt_fs_join_path(dir_path, ent->d_name, false);
+        struct stat st;
+        if (lstat(child, &st) != 0) {
+            int err = errno;
+            free(child);
+            closedir(dir);
+            errno = err;
+            return -1;
+        }
+        char *visible = child;
+        if (S_ISDIR(st.st_mode)) {
+            visible = osty_rt_fs_join_path(child, "", false);
+        }
+        int recurse = osty_rt_fs_collect_path(visible, &st, out, snapshot);
+        if (visible != child) {
+            free(visible);
+        }
+        if (recurse < 0) {
+            free(child);
+            closedir(dir);
+            return -1;
+        }
+        if (recurse > 0) {
+            if (osty_rt_fs_walk_dir_children_posix(child, out, snapshot) != 0) {
+                int err = errno;
+                free(child);
+                closedir(dir);
+                errno = err;
+                return -1;
+            }
+        }
+        free(child);
+    }
+}
+
+static int osty_rt_fs_walk_root_posix(const char *root, osty_rt_fs_path_vec *out, bool snapshot) {
+    struct stat st;
+    if (lstat(root, &st) != 0) {
+        return -1;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        (void)osty_rt_fs_collect_path(root, &st, out, snapshot);
+        return 0;
+    }
+    return osty_rt_fs_walk_dir_children_posix(root, out, snapshot);
+}
+
+static int osty_rt_fs_copy_dir_posix(const char *from, const char *to) {
+    struct stat st;
+    DIR *dir;
+
+    if (lstat(from, &st) != 0) {
+        return -1;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        osty_rt_fs_set_last_error_literal("source is not a directory");
+        errno = 0;
+        return -1;
+    }
+    if (osty_rt_fs_mkdir_p(to) != 0) {
+        return -1;
+    }
+    dir = opendir(from);
+    if (dir == NULL) {
+        return -1;
+    }
+    for (;;) {
+        errno = 0;
+        struct dirent *ent = readdir(dir);
+        if (ent == NULL) {
+            int err = errno;
+            closedir(dir);
+            if (err != 0) {
+                errno = err;
+                return -1;
+            }
+            return 0;
+        }
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+            continue;
+        }
+        char *src = osty_rt_fs_join_path(from, ent->d_name, false);
+        char *dst = osty_rt_fs_join_path(to, ent->d_name, false);
+        struct stat child_st;
+        int rc;
+        if (lstat(src, &child_st) != 0) {
+            int err = errno;
+            free(src);
+            free(dst);
+            closedir(dir);
+            errno = err;
+            return -1;
+        }
+        if (S_ISDIR(child_st.st_mode)) {
+            rc = osty_rt_fs_copy_dir_posix(src, dst);
+        } else {
+            void *err = osty_rt_fs_copy(src, dst);
+            rc = err == NULL ? 0 : -1;
+        }
+        if (rc != 0) {
+            int err = errno;
+            free(src);
+            free(dst);
+            closedir(dir);
+            if (err != 0) {
+                errno = err;
+            }
+            return -1;
+        }
+        free(src);
+        free(dst);
+    }
+}
+#endif
+
+static bool osty_rt_fs_glob_has_wildcard(const char *pattern) {
+    if (pattern == NULL) {
+        return false;
+    }
+    for (const char *p = pattern; *p != '\0'; p++) {
+        if (*p == '*' || *p == '?') {
+            return true;
+        }
+    }
+    return false;
+}
+
+static char *osty_rt_fs_glob_root(const char *pattern) {
+    const char *first = NULL;
+    const char *last_sep = NULL;
+    if (pattern == NULL || pattern[0] == '\0') {
+        return osty_rt_strndup(".", 1, "runtime.fs.glob.root");
+    }
+    for (const char *p = pattern; *p != '\0'; p++) {
+        if (*p == '*' || *p == '?') {
+            first = p;
+            break;
+        }
+        if (*p == '/' || *p == '\\') {
+            last_sep = p;
+        }
+    }
+    if (first == NULL) {
+        return osty_rt_strndup(pattern, strlen(pattern), "runtime.fs.glob.root");
+    }
+    if (last_sep == NULL) {
+        return osty_rt_strndup(".", 1, "runtime.fs.glob.root");
+    }
+    if (last_sep == pattern) {
+        return osty_rt_strndup(pattern, 1, "runtime.fs.glob.root");
+    }
+    return osty_rt_strndup(pattern, (size_t)(last_sep - pattern), "runtime.fs.glob.root");
+}
+
+static bool osty_rt_fs_glob_match_here(const char *pattern, const char *path) {
+    if (*pattern == '\0') {
+        return *path == '\0';
+    }
+    if (pattern[0] == '*' && pattern[1] == '*') {
+        const char *next = pattern + 2;
+        if (*next == '/') {
+            if (osty_rt_fs_glob_match_here(next + 1, path)) {
+                return true;
+            }
+            for (const char *p = path; *p != '\0'; p++) {
+                if (*p == '/' && osty_rt_fs_glob_match_here(next + 1, p + 1)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        do {
+            if (osty_rt_fs_glob_match_here(next, path)) {
+                return true;
+            }
+        } while (*path++ != '\0');
+        return false;
+    }
+    if (*pattern == '*') {
+        const char *next = pattern + 1;
+        const char *p = path;
+        do {
+            if (osty_rt_fs_glob_match_here(next, p)) {
+                return true;
+            }
+            if (*p == '\0' || *p == '/') {
+                return false;
+            }
+            p++;
+        } while (true);
+    }
+    if (*pattern == '?') {
+        return *path != '\0' && *path != '/' && osty_rt_fs_glob_match_here(pattern + 1, path + 1);
+    }
+    if (*pattern == *path) {
+        return osty_rt_fs_glob_match_here(pattern + 1, path + 1);
+    }
+    return false;
+}
+
+static bool osty_rt_fs_glob_match(const char *pattern, const char *path) {
+    char *pat = osty_rt_strndup(pattern == NULL ? "" : pattern, strlen(pattern == NULL ? "" : pattern), "runtime.fs.glob.pattern");
+    char *candidate = osty_rt_strndup(path == NULL ? "" : path, strlen(path == NULL ? "" : path), "runtime.fs.glob.candidate");
+    osty_rt_fs_normalize_slashes(pat);
+    osty_rt_fs_normalize_slashes(candidate);
+    bool ok = osty_rt_fs_glob_match_here(pat, candidate);
+    free(pat);
+    free(candidate);
+    return ok;
+}
+
+static char *osty_rt_fs_atomic_temp_path(const char *path, unsigned int attempt) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    long pid = (long)_getpid();
+#else
+    long pid = (long)getpid();
+#endif
+    int needed = snprintf(NULL, 0, "%s.tmp.%ld.%u", path == NULL ? "" : path, pid, attempt);
+    if (needed < 0) {
+        osty_rt_abort("runtime.fs.atomic_write: snprintf failed");
+    }
+    char *out = (char *)osty_rt_xmalloc((size_t)needed + 1U, "runtime.fs.atomic_write.temp");
+    snprintf(out, (size_t)needed + 1U, "%s.tmp.%ld.%u", path == NULL ? "" : path, pid, attempt);
+    return out;
+}
+
+static int osty_rt_fs_atomic_write_data(const char *path, const unsigned char *data, size_t len) {
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return -1;
+    }
+    for (unsigned int attempt = 0; attempt < 32U; attempt++) {
+        char *tmp = osty_rt_fs_atomic_temp_path(path, attempt);
+        FILE *f = fopen(tmp, "rb");
+        if (f != NULL) {
+            fclose(f);
+            free(tmp);
+            continue;
+        }
+        if (osty_rt_fs_write_all(tmp, data, len) != 0) {
+            int err = errno;
+            remove(tmp);
+            free(tmp);
+            errno = err;
+            return -1;
+        }
+        if (rename(tmp, path) == 0) {
+            free(tmp);
+            return 0;
+        }
+        int err = errno;
+        remove(tmp);
+        free(tmp);
+        errno = err;
+        return -1;
+    }
+    osty_rt_fs_set_last_error_literal("could not allocate temporary file name");
+    errno = 0;
+    return -1;
+}
+
+static int osty_rt_fs_lock_file_raw(const char *path) {
+    if (path == NULL) {
+        osty_rt_fs_set_last_error_literal("path is null");
+        errno = 0;
+        return -1;
+    }
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    HANDLE h = CreateFileA(path, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+        DWORD code = GetLastError();
+        errno = code == ERROR_FILE_EXISTS || code == ERROR_ALREADY_EXISTS ? EEXIST : EIO;
+        return -1;
+    }
+    CloseHandle(h);
+    return 0;
+#else
+    int fd = open(path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+    if (fd < 0) {
+        return -1;
+    }
+    if (close(fd) != 0) {
+        return -1;
+    }
+    return 0;
+#endif
+}
+
 void *osty_rt_fs_read(const char *path) {
     char path_buf[9];
     unsigned char *raw = NULL;
@@ -21559,6 +22004,268 @@ void *osty_rt_fs_mkdir_all(const char *path) {
         return NULL;
     }
     return osty_rt_fs_error_message("failed to create directory tree", "runtime.fs.mkdir_all.error");
+}
+
+void *osty_rt_fs_error(void) {
+    return osty_rt_fs_error_message("filesystem operation failed", "runtime.fs.error");
+}
+
+void *osty_rt_fs_walk(const char *root) {
+    char root_buf[9];
+    osty_rt_fs_path_vec vec;
+
+    osty_rt_string_decode_to_buf_if_inline(&root, root_buf);
+    if (root == NULL) {
+        osty_rt_fs_set_last_error_literal("root path is null");
+        errno = 0;
+        return NULL;
+    }
+    osty_rt_fs_clear_last_error();
+    osty_rt_fs_path_vec_init(&vec);
+#if defined(OSTY_RT_PLATFORM_POSIX)
+    if (osty_rt_fs_walk_root_posix(root, &vec, false) != 0) {
+        osty_rt_fs_path_vec_free(&vec);
+        return NULL;
+    }
+#else
+    osty_rt_fs_path_vec_free(&vec);
+    osty_rt_fs_set_last_error_literal("walk is not supported on this platform");
+    errno = 0;
+    return NULL;
+#endif
+    void *out = osty_rt_fs_path_vec_to_list(&vec, "runtime.fs.walk.entry");
+    osty_rt_fs_path_vec_free(&vec);
+    return out;
+}
+
+void *osty_rt_fs_glob(const char *pattern) {
+    char pattern_buf[9];
+    osty_rt_fs_path_vec candidates;
+    osty_rt_fs_path_vec matches;
+    char *root;
+
+    osty_rt_string_decode_to_buf_if_inline(&pattern, pattern_buf);
+    if (pattern == NULL) {
+        osty_rt_fs_set_last_error_literal("pattern is null");
+        errno = 0;
+        return NULL;
+    }
+    osty_rt_fs_clear_last_error();
+    osty_rt_fs_path_vec_init(&matches);
+    if (!osty_rt_fs_glob_has_wildcard(pattern)) {
+        if (osty_rt_fs_exists(pattern)) {
+            osty_rt_fs_path_vec_push_dup(&matches, pattern, "runtime.fs.glob.literal");
+        }
+        void *out = osty_rt_fs_path_vec_to_list(&matches, "runtime.fs.glob.entry");
+        osty_rt_fs_path_vec_free(&matches);
+        return out;
+    }
+
+    root = osty_rt_fs_glob_root(pattern);
+    osty_rt_fs_path_vec_init(&candidates);
+#if defined(OSTY_RT_PLATFORM_POSIX)
+    if (osty_rt_fs_walk_root_posix(root, &candidates, false) != 0) {
+        int err = errno;
+        if (err == ENOENT || err == ENOTDIR) {
+            osty_rt_fs_path_vec_free(&candidates);
+            free(root);
+            void *out = osty_rt_fs_path_vec_to_list(&matches, "runtime.fs.glob.entry");
+            osty_rt_fs_path_vec_free(&matches);
+            osty_rt_fs_clear_last_error();
+            errno = 0;
+            return out;
+        }
+        osty_rt_fs_path_vec_free(&candidates);
+        osty_rt_fs_path_vec_free(&matches);
+        free(root);
+        errno = err;
+        return NULL;
+    }
+#else
+    osty_rt_fs_path_vec_free(&candidates);
+    osty_rt_fs_path_vec_free(&matches);
+    free(root);
+    osty_rt_fs_set_last_error_literal("glob is not supported on this platform");
+    errno = 0;
+    return NULL;
+#endif
+    for (size_t i = 0; i < candidates.len; i++) {
+        const char *candidate = candidates.items[i] == NULL ? "" : candidates.items[i];
+        const char *visible = candidate;
+        if (strcmp(root, ".") == 0 && strncmp(candidate, "./", 2) == 0) {
+            visible = candidate + 2;
+        }
+        if (osty_rt_fs_glob_match(pattern, visible)) {
+            osty_rt_fs_path_vec_push_dup(&matches, visible, "runtime.fs.glob.match");
+        }
+    }
+    free(root);
+    osty_rt_fs_path_vec_free(&candidates);
+    void *out = osty_rt_fs_path_vec_to_list(&matches, "runtime.fs.glob.entry");
+    osty_rt_fs_path_vec_free(&matches);
+    return out;
+}
+
+void *osty_rt_fs_watch(const char *root) {
+    char root_buf[9];
+    osty_rt_fs_path_vec vec;
+
+    osty_rt_string_decode_to_buf_if_inline(&root, root_buf);
+    if (root == NULL) {
+        osty_rt_fs_set_last_error_literal("root path is null");
+        errno = 0;
+        return NULL;
+    }
+    osty_rt_fs_clear_last_error();
+    osty_rt_fs_path_vec_init(&vec);
+#if defined(OSTY_RT_PLATFORM_POSIX)
+    if (osty_rt_fs_walk_root_posix(root, &vec, true) != 0) {
+        osty_rt_fs_path_vec_free(&vec);
+        return NULL;
+    }
+#else
+    osty_rt_fs_path_vec_free(&vec);
+    osty_rt_fs_set_last_error_literal("watch snapshot is not supported on this platform");
+    errno = 0;
+    return NULL;
+#endif
+    void *out = osty_rt_fs_path_vec_to_list(&vec, "runtime.fs.watch.entry");
+    osty_rt_fs_path_vec_free(&vec);
+    return out;
+}
+
+void *osty_rt_fs_atomic_write_bytes(const char *path, void *raw_bytes) {
+    char path_buf[9];
+    osty_rt_bytes *bytes = (osty_rt_bytes *)raw_bytes;
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    if (bytes == NULL) {
+        osty_rt_fs_set_last_error_literal("contents is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to atomically write file", "runtime.fs.atomic_write.error");
+    }
+    osty_rt_fs_clear_last_error();
+    if (osty_rt_fs_atomic_write_data(path, bytes->data, (size_t)bytes->len) != 0) {
+        return osty_rt_fs_error_message("failed to atomically write file", "runtime.fs.atomic_write.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_atomic_write_string(const char *path, const char *contents) {
+    char path_buf[9];
+    char contents_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    osty_rt_string_decode_to_buf_if_inline(&contents, contents_buf);
+    if (contents == NULL) {
+        osty_rt_fs_set_last_error_literal("contents is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to atomically write text file", "runtime.fs.atomic_write_string.error");
+    }
+    osty_rt_fs_clear_last_error();
+    if (osty_rt_fs_atomic_write_data(path, (const unsigned char *)contents, osty_rt_string_len(contents)) != 0) {
+        return osty_rt_fs_error_message("failed to atomically write text file", "runtime.fs.atomic_write_string.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_lock_file(const char *path) {
+    char path_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    osty_rt_fs_clear_last_error();
+    if (osty_rt_fs_lock_file_raw(path) != 0) {
+        return osty_rt_fs_error_message("failed to create lock file", "runtime.fs.lock_file.error");
+    }
+    return NULL;
+}
+
+void *osty_rt_fs_copy_dir(const char *from, const char *to) {
+    char from_buf[9];
+    char to_buf[9];
+
+    osty_rt_string_decode_to_buf_if_inline(&from, from_buf);
+    osty_rt_string_decode_to_buf_if_inline(&to, to_buf);
+    if (from == NULL) {
+        osty_rt_fs_set_last_error_literal("source path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to copy directory", "runtime.fs.copy_dir.error");
+    }
+    if (to == NULL) {
+        osty_rt_fs_set_last_error_literal("destination path is null");
+        errno = 0;
+        return osty_rt_fs_error_message("failed to copy directory", "runtime.fs.copy_dir.error");
+    }
+    osty_rt_fs_clear_last_error();
+#if defined(OSTY_RT_PLATFORM_POSIX)
+    if (osty_rt_fs_copy_dir_posix(from, to) != 0) {
+        return osty_rt_fs_error_message("failed to copy directory", "runtime.fs.copy_dir.error");
+    }
+    return NULL;
+#else
+    osty_rt_fs_set_last_error_literal("copyDir is not supported on this platform");
+    errno = 0;
+    return osty_rt_fs_error_message("failed to copy directory", "runtime.fs.copy_dir.error");
+#endif
+}
+
+void *osty_rt_fs_hash_file(const char *path) {
+    char path_buf[9];
+    unsigned char *raw = NULL;
+    size_t raw_len = 0;
+    unsigned char digest[32];
+    char hex[65];
+    static const char alphabet[] = "0123456789abcdef";
+
+    osty_rt_string_decode_to_buf_if_inline(&path, path_buf);
+    osty_rt_crypto_require_selftest();
+    if (osty_rt_fs_read_all(path, &raw, &raw_len) != 0) {
+        return NULL;
+    }
+    osty_rt_crypto_sha256_digest(raw, raw_len, digest);
+    for (size_t i = 0; i < sizeof(digest); i++) {
+        hex[i * 2U] = alphabet[digest[i] >> 4U];
+        hex[i * 2U + 1U] = alphabet[digest[i] & 0x0FU];
+    }
+    hex[64] = '\0';
+    free(raw);
+    osty_rt_crypto_secure_zero(digest, sizeof(digest));
+    return osty_rt_string_dup_site(hex, 64, "runtime.fs.hash_file");
+}
+
+void *osty_rt_fs_diff_files(const char *left, const char *right) {
+    char left_buf[9];
+    char right_buf[9];
+    unsigned char *left_raw = NULL;
+    unsigned char *right_raw = NULL;
+    size_t left_len = 0;
+    size_t right_len = 0;
+    const char *diff;
+
+    osty_rt_string_decode_to_buf_if_inline(&left, left_buf);
+    osty_rt_string_decode_to_buf_if_inline(&right, right_buf);
+    if (osty_rt_fs_read_all(left, &left_raw, &left_len) != 0) {
+        return NULL;
+    }
+    if (osty_rt_fs_read_all(right, &right_raw, &right_len) != 0) {
+        free(left_raw);
+        return NULL;
+    }
+    if (left_len == right_len && (left_len == 0 || memcmp(left_raw, right_raw, left_len) == 0)) {
+        free(left_raw);
+        free(right_raw);
+        return osty_rt_string_dup_site("", 0, "runtime.fs.diff_files.empty");
+    }
+    if (!osty_rt_bytes_validate_utf8_data(left_raw, left_len) ||
+        !osty_rt_bytes_validate_utf8_data(right_raw, right_len)) {
+        free(left_raw);
+        free(right_raw);
+        return osty_rt_string_dup_site("binary files differ", 19, "runtime.fs.diff_files.binary");
+    }
+    diff = osty_rt_strings_DiffLines((const char *)left_raw, (const char *)right_raw);
+    free(left_raw);
+    free(right_raw);
+    return (void *)diff;
 }
 
 /* std.os process-control surface.

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -2115,9 +2115,11 @@ func nativeStdFsResultInfo(ctx *nativeProjectionCtx, method string) (*nativeResu
 	switch method {
 	case "read":
 		okIR = ostyir.TBytes
-	case "readToString":
+	case "readToString", "hashFile", "diffFiles":
 		okIR = ostyir.TString
-	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+	case "walk", "glob", "watch":
+		okIR = &ostyir.NamedType{Name: "List", Args: []ostyir.Type{ostyir.TString}, Builtin: true}
+	case "write", "writeString", "create", "remove", "rename", "copy", "copyDir", "mkdir", "mkdirAll", "atomicWrite", "atomicWriteString", "lockFile":
 		okIR = &ostyir.TupleType{}
 	default:
 		return nil, false
@@ -2131,28 +2133,17 @@ func nativeStdFsResultInfo(ctx *nativeProjectionCtx, method string) (*nativeResu
 	return info, info != nil
 }
 
-func nativeStdFsPtrResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, valueSymbol, errorSymbol string) (*llvmNativeExpr, bool) {
-	if ctx == nil || call == nil || len(call.Args) != 1 || call.Args[0].IsKeyword() || call.Args[0].Value == nil {
+func nativeStdFsPtrResultExpr(ctx *nativeProjectionCtx, method, valueSymbol, errorSymbol string, args ...*llvmNativeExpr) (*llvmNativeExpr, bool) {
+	if ctx == nil || len(args) == 0 {
 		return nil, false
-	}
-	method, _, _ := strings.Cut(strings.TrimPrefix(valueSymbol, "osty_rt_fs_"), "_")
-	if valueSymbol == ostyRtFsReadSymbol {
-		method = "read"
-	}
-	if valueSymbol == ostyRtFsReadStringSymbol {
-		method = "readToString"
 	}
 	resultInfo, ok := nativeStdFsResultInfo(ctx, method)
 	if !ok {
 		return nil, false
 	}
-	path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
-	if !ok {
-		return nil, false
-	}
-	ctx.addRuntimeDecl("declare ptr @" + valueSymbol + "(ptr)")
+	ctx.addRuntimeDecl("declare ptr @" + valueSymbol + "(" + strings.Join(nativeStdFsDeclParams(len(args)), ", ") + ")")
 	ctx.addRuntimeDecl("declare ptr @" + errorSymbol + "()")
-	read := nativeRuntimeCallExpr("ptr", valueSymbol, path)
+	read := nativeRuntimeCallExpr("ptr", valueSymbol, args...)
 	return &llvmNativeExpr{
 		kind:     llvmNativeExprIf,
 		llvmType: resultInfo.def.llvmType,
@@ -2194,6 +2185,32 @@ func nativeStdFsPtrResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, v
 	}, true
 }
 
+func nativeStdFsSingleStringPtrResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, method, valueSymbol, errorSymbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 1 || call.Args[0].IsKeyword() || call.Args[0].Value == nil {
+		return nil, false
+	}
+	path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	return nativeStdFsPtrResultExpr(ctx, method, valueSymbol, errorSymbol, path)
+}
+
+func nativeStdFsTwoStringPtrResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, method, valueSymbol, errorSymbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return nil, false
+	}
+	left, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	right, ok := nativeStdFsStringExpr(ctx, call.Args[1].Value)
+	if !ok {
+		return nil, false
+	}
+	return nativeStdFsPtrResultExpr(ctx, method, valueSymbol, errorSymbol, left, right)
+}
+
 func nativeStdFsUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, symbol string, args ...*llvmNativeExpr) (*llvmNativeExpr, bool) {
 	if ctx == nil || call == nil {
 		return nil, false
@@ -2207,6 +2224,18 @@ func nativeStdFsUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, 
 	}
 	if method == "mkdir_all" {
 		method = "mkdirAll"
+	}
+	if method == "atomic_write_bytes" {
+		method = "atomicWrite"
+	}
+	if method == "atomic_write_string" {
+		method = "atomicWriteString"
+	}
+	if method == "lock_file" {
+		method = "lockFile"
+	}
+	if method == "copy_dir" {
+		method = "copyDir"
 	}
 	resultInfo, ok := nativeStdFsResultInfo(ctx, method)
 	if !ok {
@@ -2277,6 +2306,36 @@ func nativeStdFsSinglePathUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.
 	return nativeStdFsUnitResultExpr(ctx, call, symbol, path)
 }
 
+func nativeStdFsTwoStringUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, symbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return nil, false
+	}
+	left, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	right, ok := nativeStdFsStringExpr(ctx, call.Args[1].Value)
+	if !ok {
+		return nil, false
+	}
+	return nativeStdFsUnitResultExpr(ctx, call, symbol, left, right)
+}
+
+func nativeStdFsStringBytesUnitResultExpr(ctx *nativeProjectionCtx, call *ostyir.CallExpr, symbol string) (*llvmNativeExpr, bool) {
+	if ctx == nil || call == nil || len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return nil, false
+	}
+	path, ok := nativeStdFsStringExpr(ctx, call.Args[0].Value)
+	if !ok {
+		return nil, false
+	}
+	contents, ok := nativeStdFsBytesExpr(ctx, call.Args[1].Value)
+	if !ok {
+		return nil, false
+	}
+	return nativeStdFsUnitResultExpr(ctx, call, symbol, path, contents)
+}
+
 func nativeStdFsExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeExpr, bool) {
 	method, ok := nativeStdFsCallMethod(ctx, call)
 	if !ok {
@@ -2284,9 +2343,9 @@ func nativeStdFsExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*ll
 	}
 	switch method {
 	case "read":
-		return nativeStdFsPtrResultExpr(ctx, call, ostyRtFsReadSymbol, ostyRtFsReadErrorSymbol)
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "read", ostyRtFsReadSymbol, ostyRtFsReadErrorSymbol)
 	case "readToString":
-		return nativeStdFsPtrResultExpr(ctx, call, ostyRtFsReadStringSymbol, ostyRtFsReadStringErrorSymbol)
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "readToString", ostyRtFsReadStringSymbol, ostyRtFsReadStringErrorSymbol)
 	case "write":
 		if len(call.Args) != 2 || call.Args[0].IsKeyword() || call.Args[1].IsKeyword() || call.Args[0].Value == nil || call.Args[1].Value == nil {
 			return nil, false
@@ -2323,6 +2382,12 @@ func nativeStdFsExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*ll
 		}
 		ctx.addRuntimeDecl("declare i1 @" + ostyRtFsExistsSymbol + "(ptr)")
 		return nativeRuntimeCallExpr("i1", ostyRtFsExistsSymbol, path), true
+	case "walk":
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "walk", ostyRtFsWalkSymbol, ostyRtFsErrorSymbol)
+	case "glob":
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "glob", ostyRtFsGlobSymbol, ostyRtFsErrorSymbol)
+	case "watch":
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "watch", ostyRtFsWatchSymbol, ostyRtFsErrorSymbol)
 	case "create":
 		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsCreateSymbol)
 	case "remove":
@@ -2353,10 +2418,22 @@ func nativeStdFsExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*ll
 			return nil, false
 		}
 		return nativeStdFsUnitResultExpr(ctx, call, ostyRtFsCopySymbol, from, to)
+	case "copyDir":
+		return nativeStdFsTwoStringUnitResultExpr(ctx, call, ostyRtFsCopyDirSymbol)
 	case "mkdir":
 		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsMkdirSymbol)
 	case "mkdirAll":
 		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsMkdirAllSymbol)
+	case "atomicWrite":
+		return nativeStdFsStringBytesUnitResultExpr(ctx, call, ostyRtFsAtomicWriteBytesSymbol)
+	case "atomicWriteString":
+		return nativeStdFsTwoStringUnitResultExpr(ctx, call, ostyRtFsAtomicWriteStringSymbol)
+	case "lockFile":
+		return nativeStdFsSinglePathUnitResultExpr(ctx, call, ostyRtFsLockFileSymbol)
+	case "hashFile":
+		return nativeStdFsSingleStringPtrResultExpr(ctx, call, "hashFile", ostyRtFsHashFileSymbol, ostyRtFsErrorSymbol)
+	case "diffFiles":
+		return nativeStdFsTwoStringPtrResultExpr(ctx, call, "diffFiles", ostyRtFsDiffFilesSymbol, ostyRtFsErrorSymbol)
 	default:
 		return nil, false
 	}

--- a/internal/llvmgen/stdlib_fs_shim.go
+++ b/internal/llvmgen/stdlib_fs_shim.go
@@ -21,8 +21,19 @@ const ostyRtFsRenameSymbol = "osty_rt_fs_rename"
 const ostyRtFsCopySymbol = "osty_rt_fs_copy"
 const ostyRtFsMkdirSymbol = "osty_rt_fs_mkdir"
 const ostyRtFsMkdirAllSymbol = "osty_rt_fs_mkdir_all"
+const ostyRtFsWalkSymbol = "osty_rt_fs_walk"
+const ostyRtFsGlobSymbol = "osty_rt_fs_glob"
+const ostyRtFsWatchSymbol = "osty_rt_fs_watch"
+const ostyRtFsErrorSymbol = "osty_rt_fs_error"
+const ostyRtFsAtomicWriteBytesSymbol = "osty_rt_fs_atomic_write_bytes"
+const ostyRtFsAtomicWriteStringSymbol = "osty_rt_fs_atomic_write_string"
+const ostyRtFsLockFileSymbol = "osty_rt_fs_lock_file"
+const ostyRtFsHashFileSymbol = "osty_rt_fs_hash_file"
+const ostyRtFsCopyDirSymbol = "osty_rt_fs_copy_dir"
+const ostyRtFsDiffFilesSymbol = "osty_rt_fs_diff_files"
 
 var fsBytesSourceTypeSingleton ast.Type = &ast.NamedType{Path: []string{"Bytes"}}
+var fsStringSourceTypeSingleton ast.Type = &ast.NamedType{Path: []string{"String"}}
 
 var stdFsReadResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
@@ -35,7 +46,22 @@ var stdFsReadResultSourceTypeSingleton ast.Type = &ast.NamedType{
 var stdFsReadStringResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
 	Args: []ast.Type{
-		&ast.NamedType{Path: []string{"String"}},
+		fsStringSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdFsListStringSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"List"},
+	Args: []ast.Type{
+		fsStringSourceTypeSingleton,
+	},
+}
+
+var stdFsListStringResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdFsListStringSourceTypeSingleton,
 		errorSourceTypeSingleton,
 	},
 }
@@ -87,6 +113,12 @@ func (g *generator) emitStdFsCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdFsWriteStringCall(call)
 	case "exists":
 		return g.emitStdFsExistsCall(call)
+	case "walk":
+		return g.emitStdFsSingleStringPtrResultCall(call, "walk", stdFsListStringResultSourceTypeSingleton, ostyRtFsWalkSymbol, ostyRtFsErrorSymbol)
+	case "glob":
+		return g.emitStdFsSingleStringPtrResultCall(call, "glob", stdFsListStringResultSourceTypeSingleton, ostyRtFsGlobSymbol, ostyRtFsErrorSymbol)
+	case "watch":
+		return g.emitStdFsSingleStringPtrResultCall(call, "watch", stdFsListStringResultSourceTypeSingleton, ostyRtFsWatchSymbol, ostyRtFsErrorSymbol)
 	case "create":
 		return g.emitStdFsCreateCall(call)
 	case "remove":
@@ -95,10 +127,22 @@ func (g *generator) emitStdFsCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdFsRenameCall(call)
 	case "copy":
 		return g.emitStdFsCopyCall(call)
+	case "copyDir":
+		return g.emitStdFsTwoStringUnitCall(call, "copyDir", ostyRtFsCopyDirSymbol)
 	case "mkdir":
 		return g.emitStdFsMkdirCall(call)
 	case "mkdirAll":
 		return g.emitStdFsMkdirAllCall(call)
+	case "atomicWrite":
+		return g.emitStdFsStringBytesUnitCall(call, "atomicWrite", ostyRtFsAtomicWriteBytesSymbol)
+	case "atomicWriteString":
+		return g.emitStdFsStringStringUnitCall(call, "atomicWriteString", ostyRtFsAtomicWriteStringSymbol)
+	case "lockFile":
+		return g.emitStdFsUnitCall(call, "lockFile", ostyRtFsLockFileSymbol)
+	case "hashFile":
+		return g.emitStdFsSingleStringPtrResultCall(call, "hashFile", stdFsReadStringResultSourceTypeSingleton, ostyRtFsHashFileSymbol, ostyRtFsErrorSymbol)
+	case "diffFiles":
+		return g.emitStdFsTwoStringPtrResultCall(call, "diffFiles", stdFsReadStringResultSourceTypeSingleton, ostyRtFsDiffFilesSymbol, ostyRtFsErrorSymbol)
 	default:
 		return value{}, false, nil
 	}
@@ -122,7 +166,19 @@ func (g *generator) stdFsCallStaticResult(call *ast.CallExpr) (value, bool) {
 			return value{}, false
 		}
 		return value{typ: info.typ, sourceType: stdFsReadStringResultSourceTypeSingleton}, true
-	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+	case "walk", "glob", "watch":
+		info, ok := builtinResultTypeFromAST(stdFsListStringResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdFsListStringResultSourceTypeSingleton}, true
+	case "hashFile", "diffFiles":
+		info, ok := builtinResultTypeFromAST(stdFsReadStringResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdFsReadStringResultSourceTypeSingleton}, true
+	case "write", "writeString", "create", "remove", "rename", "copy", "copyDir", "mkdir", "mkdirAll", "atomicWrite", "atomicWriteString", "lockFile":
 		info, ok := builtinResultTypeFromAST(stdFsUnitErrorResultSourceTypeSingleton, g.typeEnv())
 		if !ok {
 			return value{}, false
@@ -145,7 +201,11 @@ func (g *generator) staticStdFsCallSourceType(call *ast.CallExpr) (ast.Type, boo
 		return stdFsReadResultSourceTypeSingleton, true
 	case "readToString":
 		return stdFsReadStringResultSourceTypeSingleton, true
-	case "write", "writeString", "create", "remove", "rename", "copy", "mkdir", "mkdirAll":
+	case "walk", "glob", "watch":
+		return stdFsListStringResultSourceTypeSingleton, true
+	case "hashFile", "diffFiles":
+		return stdFsReadStringResultSourceTypeSingleton, true
+	case "write", "writeString", "create", "remove", "rename", "copy", "copyDir", "mkdir", "mkdirAll", "atomicWrite", "atomicWriteString", "lockFile":
 		return stdFsUnitErrorResultSourceTypeSingleton, true
 	case "exists":
 		return &ast.NamedType{Path: []string{"Bool"}}, true
@@ -302,6 +362,94 @@ func (g *generator) emitStdFsCopyCall(call *ast.CallExpr) (value, bool, error) {
 		[]*LlvmValue{toOstyValue(from), toOstyValue(to)},
 	)
 	return v, true, err
+}
+
+func (g *generator) emitStdFsSingleStringPtrResultCall(call *ast.CallExpr, name string, sourceType ast.Type, valueSymbol, errorSymbol string) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "fs.%s expects 1 argument, got %d", name, len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], name, 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	return g.emitStdFsPtrResultFromRuntimeCall(
+		"fs."+name,
+		sourceType,
+		valueSymbol,
+		errorSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path)},
+	)
+}
+
+func (g *generator) emitStdFsTwoStringPtrResultCall(call *ast.CallExpr, name string, sourceType ast.Type, valueSymbol, errorSymbol string) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.%s expects 2 arguments, got %d", name, len(call.Args))
+	}
+	left, err := g.emitStdFsStringArg(call.Args[0], name, 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	right, err := g.emitStdFsStringArg(call.Args[1], name, 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	return g.emitStdFsPtrResultFromRuntimeCall(
+		"fs."+name,
+		sourceType,
+		valueSymbol,
+		errorSymbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(left), toOstyValue(right)},
+	)
+}
+
+func (g *generator) emitStdFsStringBytesUnitCall(call *ast.CallExpr, name, symbol string) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.%s expects 2 arguments, got %d", name, len(call.Args))
+	}
+	path, err := g.emitStdFsStringArg(call.Args[0], name, 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	contents, err := g.emitStdFsBytesArg(call.Args[1], name, 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs."+name,
+		stdFsUnitErrorResultSourceTypeSingleton,
+		symbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(path), toOstyValue(contents)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsStringStringUnitCall(call *ast.CallExpr, name, symbol string) (value, bool, error) {
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "fs.%s expects 2 arguments, got %d", name, len(call.Args))
+	}
+	left, err := g.emitStdFsStringArg(call.Args[0], name, 0)
+	if err != nil {
+		return value{}, true, err
+	}
+	right, err := g.emitStdFsStringArg(call.Args[1], name, 1)
+	if err != nil {
+		return value{}, true, err
+	}
+	v, _, err := g.emitStdEnvUnitErrorResultFromRuntimeCall(
+		"fs."+name,
+		stdFsUnitErrorResultSourceTypeSingleton,
+		symbol,
+		[]paramInfo{{typ: "ptr"}, {typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(left), toOstyValue(right)},
+	)
+	return v, true, err
+}
+
+func (g *generator) emitStdFsTwoStringUnitCall(call *ast.CallExpr, name, symbol string) (value, bool, error) {
+	return g.emitStdFsStringStringUnitCall(call, name, symbol)
 }
 
 func (g *generator) emitStdFsMkdirCall(call *ast.CallExpr) (value, bool, error) {
@@ -461,6 +609,12 @@ func (g *mirGen) emitStdFsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 		return true, g.emitStdFsWriteStringMIR(c)
 	case "exists":
 		return true, g.emitStdFsExistsMIR(c)
+	case "walk":
+		return true, g.emitStdFsPtrResultMIR(c, "walk", ostyRtFsWalkSymbol, ostyRtFsErrorSymbol)
+	case "glob":
+		return true, g.emitStdFsPtrResultMIR(c, "glob", ostyRtFsGlobSymbol, ostyRtFsErrorSymbol)
+	case "watch":
+		return true, g.emitStdFsPtrResultMIR(c, "watch", ostyRtFsWatchSymbol, ostyRtFsErrorSymbol)
 	case "create":
 		return true, g.emitStdFsUnitResultMIR(c, "create", ostyRtFsCreateSymbol)
 	case "remove":
@@ -469,10 +623,22 @@ func (g *mirGen) emitStdFsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 		return true, g.emitStdFsRenameMIR(c)
 	case "copy":
 		return true, g.emitStdFsCopyMIR(c)
+	case "copyDir":
+		return true, g.emitStdFsTwoStringUnitResultMIR(c, "copyDir", ostyRtFsCopyDirSymbol)
 	case "mkdir":
 		return true, g.emitStdFsUnitResultMIR(c, "mkdir", ostyRtFsMkdirSymbol)
 	case "mkdirAll":
 		return true, g.emitStdFsUnitResultMIR(c, "mkdirAll", ostyRtFsMkdirAllSymbol)
+	case "atomicWrite":
+		return true, g.emitStdFsStringBytesUnitResultMIR(c, "atomicWrite", ostyRtFsAtomicWriteBytesSymbol)
+	case "atomicWriteString":
+		return true, g.emitStdFsStringStringUnitResultMIR(c, "atomicWriteString", ostyRtFsAtomicWriteStringSymbol)
+	case "lockFile":
+		return true, g.emitStdFsUnitResultMIR(c, "lockFile", ostyRtFsLockFileSymbol)
+	case "hashFile":
+		return true, g.emitStdFsPtrResultMIR(c, "hashFile", ostyRtFsHashFileSymbol, ostyRtFsErrorSymbol)
+	case "diffFiles":
+		return true, g.emitStdFsTwoStringPtrResultMIR(c, "diffFiles", ostyRtFsDiffFilesSymbol, ostyRtFsErrorSymbol)
 	default:
 		return false, nil
 	}
@@ -506,6 +672,40 @@ func (g *mirGen) emitStdFsWriteStringMIR(c *mir.CallInstr) error {
 		return err
 	}
 	return g.emitStdFsUnitResultMIRArgs(c, ostyRtFsWriteStringSymbol, []string{mirArgSlotPtr(path), mirArgSlotPtr(contents)})
+}
+
+func (g *mirGen) emitStdFsStringBytesUnitResultMIR(c *mir.CallInstr, method, symbol string) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.%s requires two positional arguments, got %d", method, len(c.Args)))
+	}
+	path, err := g.emitStdFsStringOperandMIR(c.Args[0], method, 0)
+	if err != nil {
+		return err
+	}
+	contents, err := g.emitStdFsBytesOperandMIR(c.Args[1], method, 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, symbol, []string{mirArgSlotPtr(path), mirArgSlotPtr(contents)})
+}
+
+func (g *mirGen) emitStdFsStringStringUnitResultMIR(c *mir.CallInstr, method, symbol string) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.%s requires two positional arguments, got %d", method, len(c.Args)))
+	}
+	left, err := g.emitStdFsStringOperandMIR(c.Args[0], method, 0)
+	if err != nil {
+		return err
+	}
+	right, err := g.emitStdFsStringOperandMIR(c.Args[1], method, 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsUnitResultMIRArgs(c, symbol, []string{mirArgSlotPtr(left), mirArgSlotPtr(right)})
+}
+
+func (g *mirGen) emitStdFsTwoStringUnitResultMIR(c *mir.CallInstr, method, symbol string) error {
+	return g.emitStdFsStringStringUnitResultMIR(c, method, symbol)
 }
 
 func (g *mirGen) emitStdFsExistsMIR(c *mir.CallInstr) error {
@@ -612,9 +812,28 @@ func (g *mirGen) emitStdFsPtrResultMIR(c *mir.CallInstr, method, valueSymbol, er
 	if err != nil {
 		return err
 	}
-	g.declareRuntime(valueSymbol, mirRuntimeDeclareLine("ptr", valueSymbol, "ptr"))
+	return g.emitStdFsPtrResultMIRArgs(c, method, valueSymbol, errorSymbol, []string{mirArgSlotPtr(path)})
+}
+
+func (g *mirGen) emitStdFsTwoStringPtrResultMIR(c *mir.CallInstr, method, valueSymbol, errorSymbol string) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("std.fs.%s requires two positional arguments, got %d", method, len(c.Args)))
+	}
+	left, err := g.emitStdFsStringOperandMIR(c.Args[0], method, 0)
+	if err != nil {
+		return err
+	}
+	right, err := g.emitStdFsStringOperandMIR(c.Args[1], method, 1)
+	if err != nil {
+		return err
+	}
+	return g.emitStdFsPtrResultMIRArgs(c, method, valueSymbol, errorSymbol, []string{mirArgSlotPtr(left), mirArgSlotPtr(right)})
+}
+
+func (g *mirGen) emitStdFsPtrResultMIRArgs(c *mir.CallInstr, method, valueSymbol, errorSymbol string, argStrs []string) error {
+	g.declareRuntime(valueSymbol, mirRuntimeDeclareLine("ptr", valueSymbol, strings.Join(mirPtrParamList(len(argStrs)), ", ")))
 	if c.Dest == nil {
-		g.fnBuf.WriteString(mirCallStmtLine("ptr", valueSymbol, mirArgSlotPtr(path)))
+		g.fnBuf.WriteString(mirCallStmtLine("ptr", valueSymbol, strings.Join(argStrs, ", ")))
 		return nil
 	}
 	destLoc := g.fn.Local(c.Dest.Local)
@@ -624,7 +843,7 @@ func (g *mirGen) emitStdFsPtrResultMIR(c *mir.CallInstr, method, valueSymbol, er
 	aggLLVM := g.llvmType(destLoc.Type)
 	g.declareRuntime(errorSymbol, mirRuntimeDeclarePtrNoArgsLine(errorSymbol))
 	valReg := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(valReg, "ptr", valueSymbol, mirArgSlotPtr(path)))
+	g.fnBuf.WriteString(mirCallValueLine(valReg, "ptr", valueSymbol, strings.Join(argStrs, ", ")))
 	isNil := g.fresh()
 	g.fnBuf.WriteString(mirICmpEqLine(isNil, "ptr", valReg, "null"))
 	errLabel := g.freshLabel("fs.ptr.err")

--- a/internal/llvmgen/stdlib_fs_shim_test.go
+++ b/internal/llvmgen/stdlib_fs_shim_test.go
@@ -69,11 +69,27 @@ fn main() {
         Ok(_) -> println("ok"),
         Err(err) -> println(err.message()),
     }
+    match fs.copyDir("tree", "tree-copy") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
     match fs.mkdir("one") {
         Ok(_) -> println("ok"),
         Err(err) -> println(err.message()),
     }
     match fs.mkdirAll("one/two") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.atomicWrite("atomic.bin", bytes.fromString("abc")) {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.atomicWriteString("atomic.txt", "hello") {
+        Ok(_) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+    match fs.lockFile("tool.lock") {
         Ok(_) -> println("ok"),
         Err(err) -> println(err.message()),
     }
@@ -97,9 +113,47 @@ fn main() {
 		"declare ptr @osty_rt_fs_create(ptr)",
 		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
 		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy_dir(ptr, ptr)",
 		"declare ptr @osty_rt_fs_mkdir(ptr)",
 		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_atomic_write_bytes(ptr, ptr)",
+		"declare ptr @osty_rt_fs_atomic_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_lock_file(ptr)",
 		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsToolingQueriesRouteToRuntimeInAST(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.fs as fs
+
+fn main() {
+    let walked = fs.walk(".")
+    let matched = fs.glob("**/*.osty")
+    let snapshot = fs.watch(".")
+    let digest = fs.hashFile("input.txt")
+    let diff = fs.diffFiles("left.txt", "right.txt")
+    println(1)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_tool_ast.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_walk(ptr)",
+		"declare ptr @osty_rt_fs_glob(ptr)",
+		"declare ptr @osty_rt_fs_watch(ptr)",
+		"declare ptr @osty_rt_fs_hash_file(ptr)",
+		"declare ptr @osty_rt_fs_diff_files(ptr, ptr)",
+		"declare ptr @osty_rt_fs_error()",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in IR:\n%s", want, got)
@@ -174,9 +228,12 @@ fn main() {
     let b = fs.create("empty.txt")
     let c = fs.rename("out.txt", "renamed.txt")
     let d = fs.copy("renamed.txt", "copied.txt")
-    let e = fs.mkdir("one")
-    let f = fs.mkdirAll("one/two")
-    let g = fs.remove("renamed.txt")
+    let e = fs.copyDir("tree", "tree-copy")
+    let f = fs.mkdir("one")
+    let g = fs.mkdirAll("one/two")
+    let h = fs.atomicWriteString("atomic.txt", "hello")
+    let i = fs.lockFile("tool.lock")
+    let j = fs.remove("renamed.txt")
     println(1)
 }
 `)
@@ -194,9 +251,47 @@ fn main() {
 		"declare ptr @osty_rt_fs_create(ptr)",
 		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
 		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy_dir(ptr, ptr)",
 		"declare ptr @osty_rt_fs_mkdir(ptr)",
 		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_atomic_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_lock_file(ptr)",
 		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsToolingQueriesRouteToRuntimeInMIR(t *testing.T) {
+	mod := lowerSrcLLVM(t, `use std.fs as fs
+
+fn main() {
+    let walked = fs.walk(".")
+    let matched = fs.glob("**/*.osty")
+    let snapshot = fs.watch(".")
+    let digest = fs.hashFile("input.txt")
+    let diff = fs.diffFiles("left.txt", "right.txt")
+    println(1)
+}
+`)
+	mirMod := buildMIRModuleFromHIR(t, mod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_tool_mir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_walk(ptr)",
+		"declare ptr @osty_rt_fs_glob(ptr)",
+		"declare ptr @osty_rt_fs_watch(ptr)",
+		"declare ptr @osty_rt_fs_hash_file(ptr)",
+		"declare ptr @osty_rt_fs_diff_files(ptr, ptr)",
+		"declare ptr @osty_rt_fs_error()",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in IR:\n%s", want, got)
@@ -270,9 +365,12 @@ fn main() {
     let b = fs.create("empty.txt")
     let c = fs.rename("out.txt", "renamed.txt")
     let d = fs.copy("renamed.txt", "copied.txt")
-    let e = fs.mkdir("one")
-    let f = fs.mkdirAll("one/two")
-    let g = fs.remove("renamed.txt")
+    let e = fs.copyDir("tree", "tree-copy")
+    let f = fs.mkdir("one")
+    let g = fs.mkdirAll("one/two")
+    let h = fs.atomicWriteString("atomic.txt", "hello")
+    let i = fs.lockFile("tool.lock")
+    let j = fs.remove("renamed.txt")
     println(1)
 }
 `)
@@ -292,9 +390,49 @@ fn main() {
 		"declare ptr @osty_rt_fs_create(ptr)",
 		"declare ptr @osty_rt_fs_rename(ptr, ptr)",
 		"declare ptr @osty_rt_fs_copy(ptr, ptr)",
+		"declare ptr @osty_rt_fs_copy_dir(ptr, ptr)",
 		"declare ptr @osty_rt_fs_mkdir(ptr)",
 		"declare ptr @osty_rt_fs_mkdir_all(ptr)",
+		"declare ptr @osty_rt_fs_atomic_write_string(ptr, ptr)",
+		"declare ptr @osty_rt_fs_lock_file(ptr)",
 		"declare ptr @osty_rt_fs_remove(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdFsToolingQueriesRouteToRuntimeInNativeOwnedEntry(t *testing.T) {
+	mod := lowerNativeEntryModule(t, `use std.fs as fs
+
+fn main() {
+    let walked = fs.walk(".")
+    let matched = fs.glob("**/*.osty")
+    let snapshot = fs.watch(".")
+    let digest = fs.hashFile("input.txt")
+    let diff = fs.diffFiles("left.txt", "right.txt")
+    println(1)
+}
+`)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_fs_tool_native.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported unsupported")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_fs_walk(ptr)",
+		"declare ptr @osty_rt_fs_glob(ptr)",
+		"declare ptr @osty_rt_fs_watch(ptr)",
+		"declare ptr @osty_rt_fs_hash_file(ptr)",
+		"declare ptr @osty_rt_fs_diff_files(ptr, ptr)",
+		"declare ptr @osty_rt_fs_error()",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in IR:\n%s", want, got)

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -48325,38 +48325,57 @@ func useDeclAliasName(cx *ElabCx, node *AstNode) string {
 	}()
 }
 
-// Osty: /tmp/selfhost_merged.osty:23612:1
 func registerStdFsAliasFns(env *CheckEnv, alias string) {
-	// Osty: /tmp/selfhost_merged.osty:23613:5
 	tys := env.tys
 	_ = tys
-	// Osty: /tmp/selfhost_merged.osty:23614:5
 	tString_ := tString(tys)
 	_ = tString_
-	// Osty: /tmp/selfhost_merged.osty:23615:5
+	tBytes_ := tBytes(tys)
+	_ = tBytes_
 	tBool_ := tBool(tys)
 	_ = tBool_
-	// Osty: /tmp/selfhost_merged.osty:23616:5
 	tUnit_ := tUnit(tys)
 	_ = tUnit_
-	// Osty: /tmp/selfhost_merged.osty:23617:5
-	tResUnit := tyNamed(tys, "Result", []int{tUnit_, tyNamed(tys, "Error", make([]int, 0, 1))})
+	tError_ := tyNamed(tys, "Error", make([]int, 0, 1))
+	_ = tError_
+	tListString := tyNamed(tys, "List", []int{tString_})
+	_ = tListString
+	tResUnit := tyNamed(tys, "Result", []int{tUnit_, tError_})
 	_ = tResUnit
-	// Osty: /tmp/selfhost_merged.osty:23618:5
-	tResString := tyNamed(tys, "Result", []int{tString_, tyNamed(tys, "Error", make([]int, 0, 1))})
+	tResBytes := tyNamed(tys, "Result", []int{tBytes_, tError_})
+	_ = tResBytes
+	tResString := tyNamed(tys, "Result", []int{tString_, tError_})
 	_ = tResString
-	// Osty: /tmp/selfhost_merged.osty:23619:5
+	tResListString := tyNamed(tys, "Result", []int{tListString, tError_})
+	_ = tResListString
 	var emptyGenerics []string = make([]string, 0, 1)
 	_ = emptyGenerics
-	// Osty: /tmp/selfhost_merged.osty:23620:5
 	var emptyBounds []*CheckGenericBound = make([]*CheckGenericBound, 0, 1)
 	_ = emptyBounds
-	// Osty: /tmp/selfhost_merged.osty:23621:5
-	add := []*CheckFnSig{&CheckFnSig{name: "exists", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds}, &CheckFnSig{name: "readToString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds}, &CheckFnSig{name: "writeString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path", "contents"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds}, &CheckFnSig{name: "remove", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds}, &CheckFnSig{name: "create", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds}}
+	add := []*CheckFnSig{
+		&CheckFnSig{name: "exists", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "read", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResBytes, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "readToString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "walk", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString, paramNames: []string{"root"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "glob", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString, paramNames: []string{"pattern"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "watch", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString, paramNames: []string{"root"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "write", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path", "contents"}, paramTys: []int{tString_, tBytes_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "writeString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path", "contents"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "create", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "remove", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "rename", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"from", "to"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "copy", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"from", "to"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "copyDir", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"from", "to"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "mkdir", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "mkdirAll", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "atomicWrite", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path", "contents"}, paramTys: []int{tString_, tBytes_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "atomicWriteString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path", "contents"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "lockFile", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "hashFile", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString, paramNames: []string{"path"}, paramTys: []int{tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+		&CheckFnSig{name: "diffFiles", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString, paramNames: []string{"left", "right"}, paramTys: []int{tString_, tString_}, generics: emptyGenerics, genericBounds: emptyBounds},
+	}
 	_ = add
-	// Osty: /tmp/selfhost_merged.osty:23633:5
 	for _, sig := range add {
-		// Osty: /tmp/selfhost_merged.osty:23634:9
 		checkRegisterFn(env, sig)
 	}
 }

--- a/internal/stdlib/big_gaps_test.go
+++ b/internal/stdlib/big_gaps_test.go
@@ -28,6 +28,22 @@ func TestSmtpModuleSurface(t *testing.T) {
 	}
 }
 
+func TestFsModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["fs"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.fs not loaded")
+	}
+	for _, name := range []string{
+		"read", "readToString", "write", "writeString", "exists",
+		"walk", "glob", "watch", "create", "remove", "rename", "copy",
+		"copyDir", "mkdir", "mkdirAll", "atomicWrite", "atomicWriteString",
+		"lockFile", "hashFile", "diffFiles",
+	} {
+		requirePublicFn(t, mod, "fs", name)
+	}
+}
+
 func TestZipModuleSurface(t *testing.T) {
 	reg := LoadCached()
 	mod := reg.Modules["zip"]
@@ -64,6 +80,16 @@ func TestImageModuleSurface(t *testing.T) {
 func TestBigGapModuleSourcePinsBehavior(t *testing.T) {
 	reg := LoadCached()
 	cases := map[string][]string{
+		"fs": {
+			`pub fn walk(root: String) -> Result<List<String>, Error>`,
+			`pub fn glob(pattern: String) -> Result<List<String>, Error>`,
+			`pub fn watch(root: String) -> Result<List<String>, Error>`,
+			`pub fn atomicWrite(path: String, contents: Bytes) -> Result<(), Error>`,
+			`pub fn lockFile(path: String) -> Result<(), Error>`,
+			`pub fn hashFile(path: String) -> Result<String, Error>`,
+			`pub fn copyDir(from: String, to: String) -> Result<(), Error>`,
+			`pub fn diffFiles(left: String, right: String) -> Result<String, Error>`,
+		},
 		"smtp": {
 			`pub fn authPlain(username: String, password: String) -> String`,
 			`pub fn parseReply(line: String) -> Result<Reply, Error>`,

--- a/internal/stdlib/modules/fs.osty
+++ b/internal/stdlib/modules/fs.osty
@@ -1,10 +1,14 @@
 // std.fs — practical filesystem access.
 //
 // The Tier 1 surface stays intentionally whole-file oriented: read and
-// write files, probe existence, create/remove/rename paths, and create
-// directories. Streaming handles remain a higher-tier concern. The
-// concrete behavior is provided by the backend/runtime bridge.
+// write files, enumerate trees, probe existence, mutate paths, hash and
+// diff files, and create directories. Streaming handles remain a
+// higher-tier concern. The concrete behavior is provided by the
+// backend/runtime bridge.
 // `readToString` returns Err when the file bytes are not valid UTF-8.
+// `walk` returns sorted descendants; directory paths end in `/`.
+// `glob` supports `*`, `?`, and `**` over slash-normalized paths.
+// `watch` is a polling snapshot: each row is `kind<TAB>size<TAB>mtime<TAB>path`.
 
 pub fn read(path: String) -> Result<Bytes, Error>
 
@@ -16,6 +20,12 @@ pub fn writeString(path: String, contents: String) -> Result<(), Error>
 
 pub fn exists(path: String) -> Bool
 
+pub fn walk(root: String) -> Result<List<String>, Error>
+
+pub fn glob(pattern: String) -> Result<List<String>, Error>
+
+pub fn watch(root: String) -> Result<List<String>, Error>
+
 pub fn create(path: String) -> Result<(), Error>
 
 pub fn remove(path: String) -> Result<(), Error>
@@ -24,6 +34,18 @@ pub fn rename(from: String, to: String) -> Result<(), Error>
 
 pub fn copy(from: String, to: String) -> Result<(), Error>
 
+pub fn copyDir(from: String, to: String) -> Result<(), Error>
+
 pub fn mkdir(path: String) -> Result<(), Error>
 
 pub fn mkdirAll(path: String) -> Result<(), Error>
+
+pub fn atomicWrite(path: String, contents: Bytes) -> Result<(), Error>
+
+pub fn atomicWriteString(path: String, contents: String) -> Result<(), Error>
+
+pub fn lockFile(path: String) -> Result<(), Error>
+
+pub fn hashFile(path: String) -> Result<String, Error>
+
+pub fn diffFiles(left: String, right: String) -> Result<String, Error>

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -803,27 +803,62 @@ fn useDeclAliasName(cx: ElabCx, node: AstNode) -> String {
     }
 }
 
-/// registerStdFsAliasFns — hot subset of std.fs.
+/// registerStdFsAliasFns — tool-facing std.fs surface.
 fn registerStdFsAliasFns(env: CheckEnv, alias: String) {
     let tys = env.tys
     let tString_ = tString(tys)
+    let tBytes_ = tBytes(tys)
     let tBool_ = tBool(tys)
     let tUnit_ = tUnit(tys)
+    let tError_ = tyNamed(tys, "Error", [])
+    let tListString = tyNamed(tys, "List", [tString_])
     let tResUnit = tyNamed(tys, "Result", [tUnit_, tyNamed(tys, "Error", [])])
+    let tResBytes = tyNamed(tys, "Result", [tBytes_, tError_])
     let tResString = tyNamed(tys, "Result", [tString_, tyNamed(tys, "Error", [])])
+    let tResListString = tyNamed(tys, "Result", [tListString, tError_])
     let emptyGenerics: List<String> = []
     let emptyBounds: List<CheckGenericBound> = []
     let add = [
         CheckFnSig { name: "exists", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tBool_,
             paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "read", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResBytes,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
         CheckFnSig { name: "readToString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString,
             paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "walk", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString,
+            paramNames: ["root"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "glob", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString,
+            paramNames: ["pattern"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "watch", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResListString,
+            paramNames: ["root"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "write", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path", "contents"], paramTys: [tString_, tBytes_], generics: emptyGenerics, genericBounds: emptyBounds },
         CheckFnSig { name: "writeString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
             paramNames: ["path", "contents"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
-        CheckFnSig { name: "remove", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
-            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
         CheckFnSig { name: "create", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
             paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "remove", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "rename", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["from", "to"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "copy", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["from", "to"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "copyDir", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["from", "to"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "mkdir", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "mkdirAll", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "atomicWrite", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path", "contents"], paramTys: [tString_, tBytes_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "atomicWriteString", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path", "contents"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "lockFile", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResUnit,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "hashFile", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString,
+            paramNames: ["path"], paramTys: [tString_], generics: emptyGenerics, genericBounds: emptyBounds },
+        CheckFnSig { name: "diffFiles", owner: alias, receiverTy: -1, hasReceiver: false, retTy: tResString,
+            paramNames: ["left", "right"], paramTys: [tString_, tString_], generics: emptyGenerics, genericBounds: emptyBounds },
     ]
     for sig in add {
         checkRegisterFn(env, sig)


### PR DESCRIPTION
## Summary
- extend std.fs with walk, glob, watch snapshots, atomic writes, lock files, file hashing, directory copy, and file diffs
- wire the new surface through LLVM AST/MIR/native-owned lowering, selfhost checker aliases, and the C runtime
- update stdlib docs/matrix and add focused surface, lowering, and runtime harness coverage

## Validation
- go run ./cmd/osty tokens internal/stdlib/modules/fs.osty
- go test -count=1 -vet=off ./internal/stdlib -run 'Test(FsModuleSurface|BigGapModuleSourcePinsBehavior)' -v\n- go test -count=1 -vet=off ./internal/llvmgen -run 'TestStdFs' -v\n- go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntimeFsToolingHelpers' -v\n- go test -count=1 -vet=off ./internal/selfhost -run '^$'\n- go run ./cmd/osty tokens toolchain/check.osty\n- just fmt-check\n- git diff --check\n\nNote: go run ./cmd/osty check toolchain/check.osty was started but stopped after a long no-output run; the touched generated selfhost Go still compiles.