### PR TITLE
[codex] remove selfhost check global lock

### DIFF
--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -35,8 +35,6 @@ func CheckSource(src []byte) CheckSummary {
 // structured result consumed by the Go check.Result bridge.
 func CheckSourceStructured(src []byte) (result CheckResult) {
 	defer recoverCheckResult(&result, "source")
-	selfhostCheckMu.Lock()
-	defer selfhostCheckMu.Unlock()
 
 	lexed := ostyLexSource(string(src))
 	if lexed == nil {
@@ -83,8 +81,6 @@ func CheckStructuredFromRun(run *FrontendRun) (result CheckResult) {
 	if run == nil {
 		return CheckResult{}
 	}
-	selfhostCheckMu.Lock()
-	defer selfhostCheckMu.Unlock()
 
 	file := run.semanticAstFile()
 	if file == nil {

--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -3,6 +3,7 @@ package selfhost
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -70,6 +71,97 @@ func BenchmarkNewElabCx(b *testing.B) {
 		if cx == nil || cx.env == nil || cx.core == nil {
 			b.Fatal("newElabCx returned incomplete context")
 		}
+	}
+}
+
+func TestSelfhostEntryPointsRunConcurrently(t *testing.T) {
+	sources := [][]byte{
+		[]byte(`fn main() {
+    let xs = [1, 2, 3]
+    let y = xs[0] + 2
+    y
+}
+`),
+		[]byte(`fn id<T>(x: T) -> T { x }
+
+fn main() {
+    let value = id(42)
+    value
+}
+`),
+		[]byte(`struct User {
+    name: String
+}
+
+fn main() {
+    let user = User { name: "Ada" }
+    user.name
+}
+`),
+	}
+	packageInput := PackageCheckInput{
+		Files: []PackageCheckFile{{
+			Source: sources[0],
+			Base:   0,
+		}},
+	}
+	const rounds = 8
+	start := make(chan struct{})
+	errs := make(chan string, rounds*4)
+	var wg sync.WaitGroup
+	launch := func(name string, idx int, run func(int) string) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if msg := run(idx); msg != "" {
+				errs <- fmt.Sprintf("%s[%d]: %s", name, idx, msg)
+			}
+		}()
+	}
+	for i := 0; i < rounds; i++ {
+		i := i
+		launch("source", i, func(idx int) string {
+			result := CheckSourceStructured(sources[idx%len(sources)])
+			if result.Summary.Errors != 0 {
+				return fmt.Sprintf("errors=%d details=%v", result.Summary.Errors, result.Summary.ErrorDetails)
+			}
+			return ""
+		})
+		launch("run", i, func(idx int) string {
+			run := Run(sources[idx%len(sources)])
+			result := CheckStructuredFromRun(run)
+			if result.Summary.Errors != 0 {
+				return fmt.Sprintf("errors=%d details=%v", result.Summary.Errors, result.Summary.ErrorDetails)
+			}
+			return ""
+		})
+		launch("package", i, func(int) string {
+			result, err := CheckPackageStructured(packageInput)
+			if err != nil {
+				return err.Error()
+			}
+			if result.Summary.Errors != 0 {
+				return fmt.Sprintf("errors=%d details=%v", result.Summary.Errors, result.Summary.ErrorDetails)
+			}
+			return ""
+		})
+		launch("inspect", i, func(int) string {
+			records, err := InspectPackageStructured(packageInput)
+			if err != nil {
+				return err.Error()
+			}
+			if len(records) == 0 {
+				return "no inspect records"
+			}
+			return ""
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Error(msg)
 	}
 }
 

--- a/internal/selfhost/check_serial.go
+++ b/internal/selfhost/check_serial.go
@@ -1,8 +1,0 @@
-package selfhost
-
-import "sync"
-
-// The generated checker still carries small package-level recursion guards.
-// Keep public checker entry points serialized until those guards move into
-// CheckEnv.
-var selfhostCheckMu sync.Mutex

--- a/internal/selfhost/inspect_adapter.go
+++ b/internal/selfhost/inspect_adapter.go
@@ -19,8 +19,6 @@ func InspectFromSource(src []byte) (records []api.InspectRecord) {
 	if len(src) == 0 {
 		return nil
 	}
-	selfhostCheckMu.Lock()
-	defer selfhostCheckMu.Unlock()
 
 	lexed := ostyLexSource(string(src))
 	if lexed == nil {

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -30,8 +30,6 @@ type (
 // point — no *ast.File round-trip, no astbridge bumps.
 func CheckPackageStructured(input PackageCheckInput) (result CheckResult, err error) {
 	defer recoverCheckResult(&result, "package")
-	selfhostCheckMu.Lock()
-	defer selfhostCheckMu.Unlock()
 
 	file, layout, err := selfhostBuildPackageAst(input.Files)
 	if err != nil {
@@ -59,8 +57,6 @@ func InspectPackageStructured(input PackageCheckInput) (records []api.InspectRec
 			err = fmt.Errorf("selfhost inspect recovered from panic: %v", recovered)
 		}
 	}()
-	selfhostCheckMu.Lock()
-	defer selfhostCheckMu.Unlock()
 
 	file, layout, err := selfhostBuildPackageAst(input.Files)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove the package-wide `selfhostCheckMu` from source, run, package, and inspect checker entry points.
- Delete the now-stale `check_serial.go` lock wrapper.
- Add concurrent entry-point coverage that exercises source, run, package, and inspect checks at the same time.

## Why

After the `CheckEnv` global/local split, independent checker calls materialize their own per-check state from the immutable prelude/global snapshot. Keeping `selfhostCheckMu` around made workspace/package parallelism queue behind one process-wide mutex, so CPU cores could not help embedded selfhost checks. The remaining generated shared cache (`frontPositionCache`) keeps its own narrow mutex.

## Validation

- `go test -count=1 -vet=off ./internal/selfhost -run 'TestSelfhostEntryPointsRunConcurrently'`
- `go test -race -count=1 -vet=off ./internal/selfhost -run 'TestSelfhostEntryPointsRunConcurrently'`
- `git diff --check`
- `go test -count=1 -vet=off ./internal/selfhost`
- `go test -count=1 -vet=off ./cmd/osty -run '^$'`
- `go build ./cmd/osty ./cmd/osty-native-checker`
- `go run ./cmd/osty check --native toolchain/check_env.osty`
- `go test -count=1 -vet=off ./internal/selfhost -run '^$' -bench 'Benchmark(NewElabCx|CheckStructuredFromRun|RunDiagnostics)' -benchmem`