### PR TITLE
[codex] implement testing generator stdlib lowering

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -25,7 +25,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (68 / 72 = 94%)
+### ⭐⭐⭐⭐⭐ Production (69 / 72 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -83,7 +83,8 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | sync | 96 | mu 5 + rmu 5 | Mutex<T> / Locked<T> type-state, RwLock, Atomic |
 | error | 96 | — | Error interface + wrap / rootCause cause chain |
 | time | 89 | (검색 필요) | Duration / Instant / Zone / Weekday / ZonedTime |
-| testing | 88 + 168 (gen) | test 5 + bench 7 | assert + benchmark + snapshot + property-based (Gen<T>) |
+| testing | 88 | test 5 + bench 7 | assert + benchmark + snapshot + property runner entrypoints |
+| testing_gen | 168 | test property lowering + runtime | property generators: int/intRange/bool/float/char/byte/asciiString/list/listOfSize/option/result/pair/triple/oneOf/oneOfGens/map/filter/constant |
 | log | 85 | — | Level + Handler + TextHandler / JsonHandler — slog 동급 |
 | regex | 74 | — | compile / matches / find / findAll / replace / split |
 | os | 71 | shim + runtime | exec / execShell / execWith / execShellWith / exit / pid / hostname / onSignal |
@@ -100,14 +101,13 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 72 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 72 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
 | gui.qtquick | 243 | Qt Quick/QML native app backend MVP. `libosty_qt` bridge, runtime diagnostics, reload/import-path helpers, `osty gui doctor qtquick`; bundle/deploy 연계는 후속 |
 | gui.webview2 | 292 | Windows WebView2 C ABI shim. Safe wrapper / scaffold / runtime diagnostics landed; local virtual-origin assets, console-log event bridge, Osty→Web command channel, and handle-lifetime hardening added; Windows smoke and packaged linker flow still pending |
 | compress | 11 | gzip 만 (zstd / deflate 추가 가능). Phase A shim 199 |
-| testing_gen | 168 | property runner 는 int/intRange/asciiString/pair/triple/oneOf/constant subset 실행. bool/float/char/byte/list/listOfSize/option/result/oneOfGens/map/filter 는 아직 실행 subset 밖 |
 
 ### 🚧 실제 미구현 / 갭
 
@@ -119,7 +119,6 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
-| 부분 실행 | `testing_gen` 의 일부 조합자는 표면만 있고 property runner 실행 subset 밖 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
 
 ## 2. 카테고리별 데모 가능성

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -1924,6 +1924,26 @@ use std.testing.gen as gen
 
 fn main() {
     testing.property(
+        "bool generator produces bools",
+        gen.bool(),
+        |b: Bool| b || !(b),
+    )
+    testing.property(
+        "float generator stays in unit range",
+        gen.float(),
+        |f: Float64| f >= 0.0 && f < 1.0,
+    )
+    testing.property(
+        "char generator stays printable ASCII",
+        gen.char(),
+        |c: Char| c.toInt() >= 32 && c.toInt() < 127,
+    )
+    testing.property(
+        "byte generator stays byte-sized",
+        gen.byte(),
+        |b: Byte| b.toInt() >= 0 && b.toInt() < 256,
+    )
+    testing.property(
         "intRange stays inside bounds",
         gen.intRange(-1000, 1000),
         |n: Int| n >= -1000 && n < 1000,
@@ -1944,9 +1964,44 @@ fn main() {
         |(a, b, c): (Int, Int, Int)| a >= 0 && a < 2 && b >= 3 && b < 5 && c >= 6 && c < 8,
     )
     testing.property(
+        "list generator honors max length",
+        gen.list(gen.intRange(0, 5), 4),
+        |xs: List<Int>| xs.len() <= 4,
+    )
+    testing.property(
+        "listOfSize generator honors exact length",
+        gen.listOfSize(gen.bool(), 3),
+        |xs: List<Bool>| xs.len() == 3,
+    )
+    testing.property(
+        "option generator makes valid options",
+        gen.option(gen.intRange(0, 5)),
+        |x: Int?| x.isNone() || x.unwrap() >= 0,
+    )
+    testing.property(
+        "result generator makes valid results",
+        gen.result(gen.intRange(0, 5), gen.constant("err")),
+        |r: Result<Int, String>| r.isOk() || r.isErr(),
+    )
+    testing.property(
+        "map generator transforms samples",
+        gen.map(gen.intRange(0, 5), |n: Int| n + 1),
+        |n: Int| n >= 1 && n <= 5,
+    )
+    testing.property(
+        "filter generator retries until predicate matches",
+        gen.filter(gen.intRange(-8, 8), |n: Int| n >= 0),
+        |n: Int| n >= 0,
+    )
+    testing.property(
         "oneOf chooses from the provided literal pool",
         gen.oneOf(["aa", "bbb", "cccc"]),
         |s: String| s == "aa" || s == "bbb" || s == "cccc",
+    )
+    testing.property(
+        "oneOfGens chooses from generator pool",
+        gen.oneOfGens([gen.constant(1), gen.intRange(2, 4)]),
+        |n: Int| n == 1 || (n >= 2 && n < 4),
     )
     println("ok")
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -20945,6 +20945,11 @@ int64_t osty_rt_test_gen_int_range(int64_t lo, int64_t hi, int64_t seed) {
     return lo + (int64_t)(mixed % span);
 }
 
+double osty_rt_test_gen_float(int64_t seed) {
+    uint64_t mixed = osty_rt_test_gen_mix_u64((uint64_t)seed);
+    return (double)(mixed >> 11) * (1.0 / 9007199254740992.0);
+}
+
 void *osty_rt_test_gen_ascii_string(int64_t max_len, int64_t seed) {
     uint64_t mixed;
     size_t len;

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1201,7 +1201,7 @@ func (g *mirGen) emitStdTestingGenCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool
 	switch method {
 	case "int", "intRange", "bool", "float", "char", "byte", "asciiString",
 		"oneOf", "map", "filter", "pair", "triple", "list", "listOfSize",
-		"option", "result", "constant":
+		"option", "result", "constant", "oneOfGens":
 		return true, g.storeZeroDest(c)
 	}
 	return false, nil

--- a/internal/llvmgen/testing_property.go
+++ b/internal/llvmgen/testing_property.go
@@ -7,6 +7,7 @@ import (
 const (
 	ostyRtTestGenIntSymbol         = "osty_rt_test_gen_int"
 	ostyRtTestGenIntRangeSymbol    = "osty_rt_test_gen_int_range"
+	ostyRtTestGenFloatSymbol       = "osty_rt_test_gen_float"
 	ostyRtTestGenAsciiStringSymbol = "osty_rt_test_gen_ascii_string"
 )
 
@@ -98,30 +99,7 @@ func (g *generator) emitTestingProperty(call *ast.CallExpr, method string) error
 }
 
 func (g *generator) emitTestingPropertyPredicate(predExpr ast.Expr, sample value) (value, error) {
-	if closure, ok := predExpr.(*ast.ClosureExpr); ok && closure != nil {
-		if len(closure.Params) != 1 || closure.Body == nil {
-			return value{}, unsupported("call", "testing.property requires a one-argument closure predicate")
-		}
-		if err := g.bindTestingPropertyParam(closure.Params[0], sample); err != nil {
-			return value{}, err
-		}
-		return g.emitExpr(closure.Body)
-	}
-	predFn, err := g.emitExpr(predExpr)
-	if err != nil {
-		return value{}, err
-	}
-	sig, err := requireFnValueSignature(predFn, "testing.property predicate")
-	if err != nil {
-		return value{}, err
-	}
-	if len(sig.params) != 1 {
-		return value{}, unsupportedf("call", "testing.property predicate arity %d, want 1", len(sig.params))
-	}
-	if sig.params[0].typ != sample.typ {
-		return value{}, unsupportedf("type-system", "testing.property predicate param type %s, sample %s", sig.params[0].typ, sample.typ)
-	}
-	return g.emitFnValueIndirectCall(predFn, sig, []*LlvmValue{toOstyValue(sample)})
+	return g.emitTestingPropertyApplyUnary(predExpr, sample, "testing.property predicate")
 }
 
 func (g *generator) parseTestingPropertyCall(call *ast.CallExpr, method string) (name ast.Expr, gen ast.Expr, pred ast.Expr, iterations value, seed value, err error) {
@@ -211,14 +189,36 @@ func (g *generator) emitTestingPropertySample(expr ast.Expr, seed value) (value,
 			return g.emitTestingPropertyInt(seed)
 		case "intRange":
 			return g.emitTestingPropertyIntRangeCall(e, seed)
+		case "bool":
+			return g.emitTestingPropertyBool(seed)
+		case "float":
+			return g.emitTestingPropertyFloat(seed)
+		case "char":
+			return g.emitTestingPropertyChar(seed)
+		case "byte":
+			return g.emitTestingPropertyByte(seed)
 		case "asciiString":
 			return g.emitTestingPropertyAsciiStringCall(e, seed)
 		case "pair":
 			return g.emitTestingPropertyPairLike(e, seed, 2)
 		case "triple":
 			return g.emitTestingPropertyPairLike(e, seed, 3)
+		case "list":
+			return g.emitTestingPropertyListCall(e, seed, false)
+		case "listOfSize":
+			return g.emitTestingPropertyListCall(e, seed, true)
+		case "option":
+			return g.emitTestingPropertyOptionCall(e, seed)
+		case "result":
+			return g.emitTestingPropertyResultCall(e, seed)
+		case "map":
+			return g.emitTestingPropertyMapCall(e, seed)
+		case "filter":
+			return g.emitTestingPropertyFilterCall(e, seed)
 		case "oneOf":
 			return g.emitTestingPropertyOneOfCall(e, seed)
+		case "oneOfGens":
+			return g.emitTestingPropertyOneOfGensCall(e, seed)
 		case "constant":
 			if len(e.Args) != 1 || e.Args[0] == nil || e.Args[0].Name != "" || e.Args[0].Value == nil {
 				return value{}, unsupported("call", "testing.gen.constant requires one positional argument")
@@ -240,7 +240,9 @@ func (g *generator) emitTestingPropertyInt(seed value) (value, error) {
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "i64", ostyRtTestGenIntSymbol, []*LlvmValue{toOstyValue(seed)})
 	g.takeOstyEmitter(emitter)
-	return fromOstyValue(out), nil
+	v := fromOstyValue(out)
+	v.sourceType = testingPropertyNamedSourceType("Int")
+	return v, nil
 }
 
 func (g *generator) emitTestingPropertyIntRangeCall(call *ast.CallExpr, seed value) (value, error) {
@@ -275,7 +277,70 @@ func (g *generator) emitTestingPropertyIntRange(lo, hi, seed value) (value, erro
 		toOstyValue(seed),
 	})
 	g.takeOstyEmitter(emitter)
-	return fromOstyValue(out), nil
+	v := fromOstyValue(out)
+	v.sourceType = testingPropertyNamedSourceType("Int")
+	return v, nil
+}
+
+func (g *generator) emitTestingPropertyBool(seed value) (value, error) {
+	n, err := g.emitTestingPropertyIntRange(
+		value{typ: "i64", ref: "0"},
+		value{typ: "i64", ref: "2"},
+		seed,
+	)
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirICmpNEI64ZeroText(out, n.ref))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "i1", ref: out, sourceType: testingPropertyNamedSourceType("Bool")}, nil
+}
+
+func (g *generator) emitTestingPropertyFloat(seed value) (value, error) {
+	if seed.typ != "i64" {
+		return value{}, unsupportedf("type-system", "testing property seed type %s, want i64", seed.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtTestGenFloatSymbol, "double", []paramInfo{{typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "double", ostyRtTestGenFloatSymbol, []*LlvmValue{toOstyValue(seed)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.sourceType = testingPropertyNamedSourceType("Float64")
+	return v, nil
+}
+
+func (g *generator) emitTestingPropertyChar(seed value) (value, error) {
+	n, err := g.emitTestingPropertyIntRange(
+		value{typ: "i64", ref: "32"},
+		value{typ: "i64", ref: "127"},
+		seed,
+	)
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirTruncI64ToI32Text(out, n.ref))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "i32", ref: out, sourceType: testingPropertyNamedSourceType("Char")}, nil
+}
+
+func (g *generator) emitTestingPropertyByte(seed value) (value, error) {
+	n, err := g.emitTestingPropertyIntRange(
+		value{typ: "i64", ref: "0"},
+		value{typ: "i64", ref: "256"},
+		seed,
+	)
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirTruncI64ToI8Text(out, n.ref))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "i8", ref: out, sourceType: testingPropertyNamedSourceType("Byte")}, nil
 }
 
 func (g *generator) emitTestingPropertyAsciiStringCall(call *ast.CallExpr, seed value) (value, error) {
@@ -303,6 +368,147 @@ func (g *generator) emitTestingPropertyAsciiStringCall(call *ast.CallExpr, seed 
 	text.gcManaged = true
 	text.sourceType = &ast.NamedType{Path: []string{"String"}}
 	return text, nil
+}
+
+func (g *generator) emitTestingPropertyMapCall(call *ast.CallExpr, seed value) (value, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, unsupported("call", "testing.gen.map requires (generator, transform)")
+	}
+	sample, err := g.emitTestingPropertySample(call.Args[0].Value, seed)
+	if err != nil {
+		return value{}, err
+	}
+	return g.emitTestingPropertyApplyUnary(call.Args[1].Value, sample, "testing.gen.map transform")
+}
+
+func (g *generator) emitTestingPropertyFilterCall(call *ast.CallExpr, seed value) (value, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, unsupported("call", "testing.gen.filter requires (generator, predicate)")
+	}
+	first, err := g.emitTestingPropertySample(call.Args[0].Value, seed)
+	if err != nil {
+		return value{}, err
+	}
+	firstPred, err := g.emitTestingPropertyBoolPredicate(call.Args[1].Value, first, "testing.gen.filter predicate")
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, toOstyValue(firstPred))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+	thenValue := first
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	elseValue, err := g.emitTestingPropertyFilterRetry(call.Args[0].Value, call.Args[1].Value, seed, first)
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+}
+
+func (g *generator) emitTestingPropertyFilterRetry(genExpr, predExpr ast.Expr, seed value, sampleShape value) (value, error) {
+	emitter := g.toOstyEmitter()
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirAllocaText(slot, sampleShape.typ))
+	loop := llvmRangeStart(
+		emitter,
+		g.nextHiddenLocalName("test.property.filter.iter"),
+		llvmIntLiteral(1),
+		llvmIntLiteral(33),
+		false,
+	)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+
+	iterSeed := value{typ: "i64", ref: loop.current}
+	childSeed, err := g.emitTestingPropertyAddI64(seed, iterSeed)
+	if err != nil {
+		return value{}, err
+	}
+	candidate, err := g.emitTestingPropertySample(genExpr, childSeed)
+	if err != nil {
+		return value{}, err
+	}
+	if candidate.typ != sampleShape.typ {
+		return value{}, unsupportedf("type-system", "testing.gen.filter retry sample type %s, want %s", candidate.typ, sampleShape.typ)
+	}
+	pred, err := g.emitTestingPropertyBoolPredicate(predExpr, candidate, "testing.gen.filter predicate")
+	if err != nil {
+		return value{}, err
+	}
+
+	emitter = g.toOstyEmitter()
+	hitLabel := llvmNextLabel(emitter, "test.filter.hit")
+	continueLabel := llvmNextLabel(emitter, "test.filter.cont")
+	doneLabel := llvmNextLabel(emitter, "test.filter.done")
+	emitter.body = append(emitter.body, mirBrCondText(pred.ref, hitLabel, continueLabel))
+	emitter.body = append(emitter.body, mirLabelText(hitLabel))
+	emitter.body = append(emitter.body, mirStoreText(candidate.typ, candidate.ref, slot))
+	emitter.body = append(emitter.body, mirBrUncondText(doneLabel))
+	emitter.body = append(emitter.body, mirLabelText(continueLabel))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = continueLabel
+
+	emitter = g.toOstyEmitter()
+	llvmRangeEnd(emitter, loop)
+	g.emitTestingAbortWithEmitter(emitter, "testing.gen.filter could not produce a matching sample after 32 retries", doneLabel)
+	loaded := llvmLoad(emitter, &LlvmValue{typ: sampleShape.typ, name: slot, pointer: true})
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = doneLabel
+	out := fromOstyValue(loaded)
+	copyContainerMetadata(&out, sampleShape)
+	out.rootPaths = cloneRootPaths(sampleShape.rootPaths)
+	return out, nil
+}
+
+func (g *generator) emitTestingPropertyBoolPredicate(predExpr ast.Expr, sample value, label string) (value, error) {
+	pred, err := g.emitTestingPropertyApplyUnary(predExpr, sample, label)
+	if err != nil {
+		return value{}, err
+	}
+	if pred.typ != "i1" {
+		return value{}, unsupportedf("type-system", "%s type %s, want Bool", label, pred.typ)
+	}
+	return pred, nil
+}
+
+func (g *generator) emitTestingPropertyApplyUnary(fnExpr ast.Expr, sample value, label string) (value, error) {
+	if closure, ok := fnExpr.(*ast.ClosureExpr); ok && closure != nil {
+		if len(closure.Params) != 1 || closure.Body == nil {
+			return value{}, unsupportedf("call", "%s requires a one-argument closure", label)
+		}
+		g.pushScope()
+		defer g.popScope()
+		if err := g.bindTestingPropertyParam(closure.Params[0], sample); err != nil {
+			return value{}, err
+		}
+		return g.emitExpr(closure.Body)
+	}
+	fn, err := g.emitExpr(fnExpr)
+	if err != nil {
+		return value{}, err
+	}
+	sig, err := requireFnValueSignature(fn, label)
+	if err != nil {
+		return value{}, err
+	}
+	if len(sig.params) != 1 {
+		return value{}, unsupportedf("call", "%s arity %d, want 1", label, len(sig.params))
+	}
+	if sig.params[0].typ != sample.typ {
+		return value{}, unsupportedf("type-system", "%s param type %s, sample %s", label, sig.params[0].typ, sample.typ)
+	}
+	return g.emitFnValueIndirectCall(fn, sig, []*LlvmValue{toOstyValue(sample)})
 }
 
 func (g *generator) emitTestingPropertyPairLike(call *ast.CallExpr, seed value, arity int) (value, error) {
@@ -342,10 +548,12 @@ func (g *generator) emitTestingPropertyTuple(parts ...value) (value, error) {
 	fields := make([]*LlvmValue, 0, len(parts))
 	elemTypes := make([]string, 0, len(parts))
 	elemListTypes := make([]string, 0, len(parts))
+	sourceElems := make([]ast.Type, 0, len(parts))
 	for _, part := range parts {
 		fields = append(fields, toOstyValue(part))
 		elemTypes = append(elemTypes, part.typ)
 		elemListTypes = append(elemListTypes, part.listElemTyp)
+		sourceElems = append(sourceElems, testingPropertySourceTypeForValue(part))
 	}
 	info := g.registerTupleType(elemTypes, elemListTypes)
 	emitter := g.toOstyEmitter()
@@ -353,7 +561,309 @@ func (g *generator) emitTestingPropertyTuple(parts ...value) (value, error) {
 	g.takeOstyEmitter(emitter)
 	tupleValue := fromOstyValue(out)
 	tupleValue.rootPaths = g.rootPathsForType(info.typ)
+	tupleValue.sourceType = &ast.TupleType{Elems: sourceElems}
 	return tupleValue, nil
+}
+
+func (g *generator) emitTestingPropertyListCall(call *ast.CallExpr, seed value, fixed bool) (value, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		if fixed {
+			return value{}, unsupported("call", "testing.gen.listOfSize requires (item, size)")
+		}
+		return value{}, unsupported("call", "testing.gen.list requires (item, maxLen)")
+	}
+	limit, err := g.emitExpr(call.Args[1].Value)
+	if err != nil {
+		return value{}, err
+	}
+	if limit.typ != "i64" {
+		return value{}, unsupportedf("type-system", "testing.gen.list size type %s, want Int", limit.typ)
+	}
+	length := limit
+	if !fixed {
+		hi, err := g.emitTestingPropertyAddI64(limit, value{typ: "i64", ref: "1"})
+		if err != nil {
+			return value{}, err
+		}
+		length, err = g.emitTestingPropertyIntRange(value{typ: "i64", ref: "0"}, hi, seed)
+		if err != nil {
+			return value{}, err
+		}
+	}
+
+	previewSeed, err := g.emitTestingPropertySeedOffset(seed, 1)
+	if err != nil {
+		return value{}, err
+	}
+	preview, err := g.emitTestingPropertySample(call.Args[0].Value, previewSeed)
+	if err != nil {
+		return value{}, err
+	}
+	elemTyp := preview.typ
+	elemString := llvmNamedTypeIsString(testingPropertySourceTypeForValue(preview))
+	useAggregateABI := g.usesAggregateListABI(elemTyp)
+	if !useAggregateABI && !listUsesTypedRuntime(elemTyp) {
+		g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
+	}
+
+	g.declareRuntimeSymbol(listRuntimeNewSymbol(), "ptr", nil)
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", listRuntimeNewSymbol(), nil)
+	g.takeOstyEmitter(emitter)
+	listValue := fromOstyValue(out)
+	listValue.gcManaged = true
+	listValue.listElemTyp = elemTyp
+	listValue.listElemString = elemString
+	listValue.sourceType = &ast.NamedType{
+		Path: []string{"List"},
+		Args: []ast.Type{testingPropertySourceTypeForValue(preview)},
+	}
+	listValue.rootPaths = g.rootPathsForType("ptr")
+
+	emitter = g.toOstyEmitter()
+	loop := llvmRangeStart(
+		emitter,
+		g.nextHiddenLocalName("test.property.list.iter"),
+		llvmIntLiteral(0),
+		toOstyValue(length),
+		false,
+	)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+
+	iterSeed := value{typ: "i64", ref: loop.current}
+	childSeed, err := g.emitTestingPropertyAddI64(seed, iterSeed)
+	if err != nil {
+		return value{}, err
+	}
+	childSeed, err = g.emitTestingPropertySeedOffset(childSeed, 2)
+	if err != nil {
+		return value{}, err
+	}
+	elem, err := g.emitTestingPropertySample(call.Args[0].Value, childSeed)
+	if err != nil {
+		return value{}, err
+	}
+	if elem.typ != elemTyp {
+		return value{}, unsupportedf("type-system", "testing.gen.list item type %s, want %s", elem.typ, elemTyp)
+	}
+	if err := g.emitTestingPropertyListPush(listValue, elem, elemTyp, elemString); err != nil {
+		return value{}, err
+	}
+
+	emitter = g.toOstyEmitter()
+	llvmRangeEnd(emitter, loop)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.endLabel)
+	return listValue, nil
+}
+
+func (g *generator) emitTestingPropertyListPush(listValue, elem value, elemTyp string, elemString bool) error {
+	loaded, err := g.loadIfPointer(elem)
+	if err != nil {
+		return err
+	}
+	if g.usesAggregateListABI(elemTyp) {
+		return g.emitListAggregatePush(listValue, loaded)
+	}
+	emitter := g.toOstyEmitter()
+	if listUsesTypedRuntime(elemTyp) {
+		pushSymbol := listRuntimePushSymbolFor(elemTyp, elemString)
+		g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
+			pushSymbol,
+			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(loaded)}),
+		))
+	} else {
+		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
+		addr := g.spillValueAddress(emitter, "test.property.list.elem", loaded)
+		sizeValue := g.emitTypeSize(emitter, elemTyp)
+		g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+		emitter.body = append(emitter.body, mirCallRuntimeVoidOneArgText(
+			listRuntimePushBytesSymbol(),
+			llvmCallArgs([]*LlvmValue{
+				toOstyValue(listValue),
+				{typ: "ptr", name: addr},
+				sizeValue,
+				{typ: "ptr", name: llvmPointerOperand(traceSymbol)},
+			}),
+		))
+	}
+	g.takeOstyEmitter(emitter)
+	return nil
+}
+
+func (g *generator) emitTestingPropertyOptionCall(call *ast.CallExpr, seed value) (value, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, unsupported("call", "testing.gen.option requires one generator argument")
+	}
+	pick, err := g.emitTestingPropertyIntRange(value{typ: "i64", ref: "0"}, value{typ: "i64", ref: "2"}, seed)
+	if err != nil {
+		return value{}, err
+	}
+	cond, err := g.emitTestingPropertyI64EqLiteral(pick, "0")
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, toOstyValue(cond))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	childSeed, err := g.emitTestingPropertySeedOffset(seed, 1)
+	if err != nil {
+		return value{}, err
+	}
+	sample, err := g.emitTestingPropertySample(call.Args[0].Value, childSeed)
+	if err != nil {
+		return value{}, err
+	}
+	someValue, err := g.emitTestingPropertySomeValue(sample)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	noneValue := value{typ: "ptr", ref: "null"}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, someValue, noneValue)
+	if err != nil {
+		return value{}, err
+	}
+	out.sourceType = &ast.OptionalType{Inner: testingPropertySourceTypeForValue(sample)}
+	out.gcManaged = true
+	out.rootPaths = g.rootPathsForType("ptr")
+	return out, nil
+}
+
+func (g *generator) emitTestingPropertySomeValue(sample value) (value, error) {
+	loaded, err := g.loadIfPointer(sample)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ == "ptr" {
+		loaded.gcManaged = true
+		loaded.rootPaths = g.rootPathsForType("ptr")
+		return loaded, nil
+	}
+	emitter := g.toOstyEmitter()
+	box, err := g.emitOptionPayloadBox(emitter, loaded, "testing.gen.option."+optionBoxSiteSuffix(loaded.typ))
+	if err != nil {
+		g.takeOstyEmitter(emitter)
+		return value{}, err
+	}
+	g.takeOstyEmitter(emitter)
+	return box, nil
+}
+
+func (g *generator) emitTestingPropertyResultCall(call *ast.CallExpr, seed value) (value, error) {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, unsupported("call", "testing.gen.result requires (ok, err)")
+	}
+	okSeed, err := g.emitTestingPropertySeedOffset(seed, 1)
+	if err != nil {
+		return value{}, err
+	}
+	okSample, err := g.emitTestingPropertySample(call.Args[0].Value, okSeed)
+	if err != nil {
+		return value{}, err
+	}
+	errSeed, err := g.emitTestingPropertySeedOffset(seed, 2)
+	if err != nil {
+		return value{}, err
+	}
+	errSample, err := g.emitTestingPropertySample(call.Args[1].Value, errSeed)
+	if err != nil {
+		return value{}, err
+	}
+	sourceType := &ast.NamedType{
+		Path: []string{"Result"},
+		Args: []ast.Type{testingPropertySourceTypeForValue(okSample), testingPropertySourceTypeForValue(errSample)},
+	}
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, unsupported("type-system", "testing.gen.result could not build Result<T, E> source type")
+	}
+	if okSample.typ != info.okTyp || errSample.typ != info.errTyp {
+		return value{}, unsupportedf("type-system", "testing.gen.result payload types ok=%s/%s err=%s/%s", okSample.typ, info.okTyp, errSample.typ, info.errTyp)
+	}
+
+	pick, err := g.emitTestingPropertyIntRange(value{typ: "i64", ref: "0"}, value{typ: "i64", ref: "2"}, seed)
+	if err != nil {
+		return value{}, err
+	}
+	cond, err := g.emitTestingPropertyI64EqLiteral(pick, "0")
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, toOstyValue(cond))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	okValue, err := g.emitTestingPropertyResultValue(info, true, okSample)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	errValue, err := g.emitTestingPropertyResultValue(info, false, errSample)
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, okValue, errValue)
+	if err != nil {
+		return value{}, err
+	}
+	out.sourceType = sourceType
+	out.rootPaths = g.rootPathsForType(out.typ)
+	return out, nil
+}
+
+func (g *generator) emitTestingPropertyResultValue(info builtinResultType, isOk bool, payload value) (value, error) {
+	payloadIndex := 1
+	tag := "0"
+	wantTyp := info.okTyp
+	if !isOk {
+		payloadIndex = 2
+		tag = "1"
+		wantTyp = info.errTyp
+	}
+	loaded, err := g.loadIfPointer(payload)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != wantTyp {
+		return value{}, unsupportedf("type-system", "testing.gen.result payload type %s, want %s", loaded.typ, wantTyp)
+	}
+	emitter := g.toOstyEmitter()
+	fields := []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: tag}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	}
+	fields[payloadIndex] = toOstyValue(loaded)
+	out := llvmStructLiteral(emitter, info.typ, fields)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, nil
 }
 
 func (g *generator) emitTestingPropertyOneOfCall(call *ast.CallExpr, seed value) (value, error) {
@@ -381,6 +891,125 @@ func (g *generator) emitTestingPropertyOneOfCall(call *ast.CallExpr, seed value)
 		X:     listExpr,
 		Index: &ast.Ident{Name: indexName},
 	})
+}
+
+func (g *generator) emitTestingPropertyOneOfGensCall(call *ast.CallExpr, seed value) (value, error) {
+	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, unsupported("call", "testing.gen.oneOfGens requires a single list literal argument")
+	}
+	listExpr, ok := unwrapParenExpr(call.Args[0].Value).(*ast.ListExpr)
+	if !ok || listExpr == nil {
+		return value{}, unsupported("call", "testing.gen.oneOfGens currently requires a list literal")
+	}
+	if len(listExpr.Elems) == 0 {
+		return value{}, unsupported("call", "testing.gen.oneOfGens requires a non-empty list literal")
+	}
+	index, err := g.emitTestingPropertyIntRange(
+		value{typ: "i64", ref: "0"},
+		value{typ: "i64", ref: mirGenIntToString(len(listExpr.Elems))},
+		seed,
+	)
+	if err != nil {
+		return value{}, err
+	}
+	return g.emitTestingPropertyOneOfGenChoice(listExpr.Elems, index, seed, 0)
+}
+
+func (g *generator) emitTestingPropertyOneOfGenChoice(choices []ast.Expr, index value, seed value, pos int) (value, error) {
+	if pos >= len(choices) {
+		return value{}, unsupported("call", "testing.gen.oneOfGens choice index out of range")
+	}
+	choiceSeed, err := g.emitTestingPropertySeedOffset(seed, int64(pos+1))
+	if err != nil {
+		return value{}, err
+	}
+	if pos == len(choices)-1 {
+		return g.emitTestingPropertySample(choices[pos], choiceSeed)
+	}
+	cond, err := g.emitTestingPropertyI64EqLiteral(index, mirGenIntToString(pos))
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, toOstyValue(cond))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+	thenValue, err := g.emitTestingPropertySample(choices[pos], choiceSeed)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	elseValue, err := g.emitTestingPropertyOneOfGenChoice(choices, index, seed, pos+1)
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+}
+
+func (g *generator) emitTestingPropertyI64EqLiteral(v value, lit string) (value, error) {
+	if v.typ != "i64" {
+		return value{}, unsupportedf("type-system", "testing property selector type %s, want Int", v.typ)
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, mirICmpEqI64LiteralText(out, v.ref, lit))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "i1", ref: out, sourceType: testingPropertyNamedSourceType("Bool")}, nil
+}
+
+func testingPropertyNamedSourceType(name string) ast.Type {
+	return &ast.NamedType{Path: []string{name}}
+}
+
+func testingPropertySourceTypeForValue(v value) ast.Type {
+	if v.sourceType != nil {
+		return v.sourceType
+	}
+	switch v.typ {
+	case "i64":
+		return testingPropertyNamedSourceType("Int")
+	case "i1":
+		return testingPropertyNamedSourceType("Bool")
+	case "double":
+		return testingPropertyNamedSourceType("Float64")
+	case "i32":
+		return testingPropertyNamedSourceType("Char")
+	case "i8":
+		return testingPropertyNamedSourceType("Byte")
+	}
+	return nil
+}
+
+func testingPropertySourceTypeForGeneratorExpr(expr ast.Expr) ast.Type {
+	call, ok := unwrapParenExpr(expr).(*ast.CallExpr)
+	if !ok || call == nil {
+		return nil
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil
+	}
+	switch field.Name {
+	case "int", "intRange":
+		return testingPropertyNamedSourceType("Int")
+	case "bool":
+		return testingPropertyNamedSourceType("Bool")
+	case "float":
+		return testingPropertyNamedSourceType("Float64")
+	case "char":
+		return testingPropertyNamedSourceType("Char")
+	case "byte":
+		return testingPropertyNamedSourceType("Byte")
+	case "asciiString":
+		return testingPropertyNamedSourceType("String")
+	}
+	return nil
 }
 
 func unwrapParenExpr(expr ast.Expr) ast.Expr {

--- a/internal/llvmgen/testing_property_codegen_test.go
+++ b/internal/llvmgen/testing_property_codegen_test.go
@@ -11,32 +11,7 @@ import (
 )
 
 func TestTestingPropertyLowersGeneratorSubset(t *testing.T) {
-	src := `use std.testing as testing
-use std.testing.gen as gen
-
-fn main() {
-    testing.property(
-        "range",
-        gen.intRange(-5, 5),
-        |n: Int| n >= -5 && n < 5,
-    )
-    testing.property(
-        "ascii",
-        gen.asciiString(8),
-        |s: String| s.len() <= 8,
-    )
-    testing.property(
-        "pair",
-        gen.pair(gen.intRange(0, 3), gen.intRange(10, 13)),
-        |(a, b): (Int, Int)| a >= 0 && a < 3 && b >= 10 && b < 13,
-    )
-    testing.property(
-        "choices",
-        gen.oneOf(["aa", "bbb", "cccc"]),
-        |s: String| s == "aa" || s == "bbb" || s == "cccc",
-    )
-}
-`
+	src := testingPropertyGeneratorSubsetSource()
 	file := parseLLVMGenFile(t, src)
 	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
@@ -50,8 +25,11 @@ fn main() {
 	for _, want := range []string{
 		"declare i64 @osty_rt_test_gen_int_range(i64, i64, i64)",
 		"call i64 @osty_rt_test_gen_int_range(",
+		"declare double @osty_rt_test_gen_float(i64)",
+		"call double @osty_rt_test_gen_float(",
 		"declare ptr @osty_rt_test_gen_ascii_string(i64, i64)",
 		"call ptr @osty_rt_test_gen_ascii_string(",
+		"call void @osty_rt_list_push_i64(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -59,11 +37,31 @@ fn main() {
 	}
 }
 
-func TestGenerateModuleTestingPropertyGeneratorSubset(t *testing.T) {
-	src := `use std.testing as testing
+func testingPropertyGeneratorSubsetSource() string {
+	return `use std.testing as testing
 use std.testing.gen as gen
 
 fn main() {
+    testing.property(
+        "bool",
+        gen.bool(),
+        |b: Bool| b || !(b),
+    )
+    testing.property(
+        "float",
+        gen.float(),
+        |f: Float64| f >= 0.0 && f < 1.0,
+    )
+    testing.property(
+        "char",
+        gen.char(),
+        |c: Char| c.toInt() >= 32 && c.toInt() < 127,
+    )
+    testing.property(
+        "byte",
+        gen.byte(),
+        |b: Byte| b.toInt() >= 0 && b.toInt() < 256,
+    )
     testing.property(
         "range",
         gen.intRange(-5, 5),
@@ -80,12 +78,51 @@ fn main() {
         |(a, b): (Int, Int)| a >= 0 && a < 3 && b >= 10 && b < 13,
     )
     testing.property(
+        "list",
+        gen.list(gen.intRange(0, 5), 4),
+        |xs: List<Int>| xs.len() <= 4,
+    )
+    testing.property(
+        "listOfSize",
+        gen.listOfSize(gen.bool(), 3),
+        |xs: List<Bool>| xs.len() == 3,
+    )
+    testing.property(
+        "option",
+        gen.option(gen.intRange(0, 5)),
+        |x: Int?| x.isNone() || x.unwrap() >= 0,
+    )
+    testing.property(
+        "result",
+        gen.result(gen.intRange(0, 5), gen.constant("err")),
+        |r: Result<Int, String>| r.isOk() || r.isErr(),
+    )
+    testing.property(
+        "map",
+        gen.map(gen.intRange(0, 5), |n: Int| n + 1),
+        |n: Int| n >= 1 && n <= 5,
+    )
+    testing.property(
+        "filter",
+        gen.filter(gen.intRange(-8, 8), |n: Int| n >= 0),
+        |n: Int| n >= 0,
+    )
+    testing.property(
         "choices",
         gen.oneOf(["aa", "bbb", "cccc"]),
         |s: String| s == "aa" || s == "bbb" || s == "cccc",
     )
+    testing.property(
+        "oneOfGens",
+        gen.oneOfGens([gen.constant(1), gen.intRange(2, 4)]),
+        |n: Int| n == 1 || (n >= 2 && n < 4),
+    )
 }
 `
+}
+
+func TestGenerateModuleTestingPropertyGeneratorSubset(t *testing.T) {
+	src := testingPropertyGeneratorSubsetSource()
 	file := parseLLVMGenFile(t, src)
 	res := resolve.ResolveFileSourceDefault([]byte(src), file, stdlib.LoadCached())
 	reg := stdlib.LoadCached()
@@ -118,8 +155,11 @@ fn main() {
 	for _, want := range []string{
 		"declare i64 @osty_rt_test_gen_int_range(i64, i64, i64)",
 		"call i64 @osty_rt_test_gen_int_range(",
+		"declare double @osty_rt_test_gen_float(i64)",
+		"call double @osty_rt_test_gen_float(",
 		"declare ptr @osty_rt_test_gen_ascii_string(i64, i64)",
 		"call ptr @osty_rt_test_gen_ascii_string(",
+		"call void @osty_rt_list_push_i64(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)

--- a/internal/stdlib/modules/testing_gen.osty
+++ b/internal/stdlib/modules/testing_gen.osty
@@ -24,10 +24,10 @@
 //         )
 //     }
 //
-// v0.5 scope: signature stubs only (G18 convention). Runtime
-// sampling / shrinking is supplied by the native test runner; these
-// bodies return deterministic-looking placeholders so the stdlib
-// stub checker passes.
+// v0.5 scope: the LLVM test lowering samples every combinator in
+// this module when it appears inside `testing.property*`. These
+// Osty bodies still return deterministic-looking descriptors so the
+// stdlib stub checker and import surface can stay ordinary Osty.
 
 use std.testing as testing
 

--- a/internal/stdlib/testing_test.go
+++ b/internal/stdlib/testing_test.go
@@ -1,0 +1,58 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTestingModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	if reg.Modules["testing"] == nil {
+		t.Fatal("stdlib testing module missing")
+	}
+	for _, name := range []string{
+		"assert", "assertTrue", "assertFalse", "assertEq", "assertNe",
+		"expectOk", "expectError", "fail", "context", "benchmark",
+		"snapshot", "property", "propertyN", "propertySeeded",
+	} {
+		if fn := reg.LookupFnDecl("testing", name); fn == nil {
+			t.Fatalf("LookupFnDecl(testing, %s) = nil", name)
+		}
+	}
+}
+
+func TestTestingGenModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	if reg.Modules["testing_gen"] == nil {
+		t.Fatal("stdlib testing_gen module missing")
+	}
+	for _, name := range []string{
+		"int", "intRange", "bool", "float", "char", "byte", "asciiString",
+		"oneOf", "map", "filter", "pair", "triple", "list", "listOfSize",
+		"option", "result", "constant", "oneOfGens",
+	} {
+		if fn := reg.LookupFnDecl("testing_gen", name); fn == nil {
+			t.Fatalf("LookupFnDecl(testing_gen, %s) = nil", name)
+		}
+	}
+}
+
+func TestTestingGenModulePinsImplementedCombinators(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["testing_gen"]
+	if mod == nil {
+		t.Fatal("stdlib testing_gen module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"pub fn list<T>",
+		"pub fn listOfSize<T>",
+		"pub fn option<T>",
+		"pub fn result<T, E>",
+		"pub fn oneOfGens<T>",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("testing_gen source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- lower the remaining `std.testing.gen` property generators through the LLVM property runner
- add runtime float sampling and support for list, option, result, map, filter, and generator-pool choices
- add stdlib/LLVM/backend coverage and update the stdlib matrix

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run TestTesting -v`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'Test(TestingPropertyLowersGeneratorSubset|GenerateModuleTestingPropertyGeneratorSubset)' -v`
- `go test -count=1 -vet=off ./internal/backend -run TestLLVMBackendBinaryTestingPropertyGeneratorSubset -v`
- `go run ./cmd/osty tokens internal/stdlib/modules/testing.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/testing_gen.osty`
- `git diff --check HEAD~1..HEAD`