### PR TITLE
[codex] add std.cmd execution builder

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 71 공개 모듈. 분류 기준:
+총 72 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (67 / 71 = 94%)
+### ⭐⭐⭐⭐⭐ Production (68 / 72 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -72,6 +72,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | term | 320 | host-backed + pure ANSI | terminal mode/size/input declarations + ANSI sequence builders |
 | websocket | 322 | pure Osty + crypto/encoding | RFC 6455 accept key + handshake headers + frame encode/decode |
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
+| cmd | 214 | os shim + runtime | command builder, cwd/env/timeout, captured output, POSIX shell escaping, pipeline rendering |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
@@ -84,7 +85,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | testing | 88 + 168 (gen) | test 5 + bench 7 | assert + benchmark + snapshot + property-based (Gen<T>) |
 | log | 85 | — | Level + Handler + TextHandler / JsonHandler — slog 동급 |
 | regex | 74 | — | compile / matches / find / findAll / replace / split |
-| os | 60 | shim 421 + runtime 22 | exec / execShell / exit / pid / hostname / onSignal |
+| os | 71 | shim + runtime | exec / execShell / execWith / execShellWith / exit / pid / hostname / onSignal |
 | thread | 59 | thread 16 + chan 10 + select 22 | spawn / race / chan / select / cancel — 구조적 동시성 |
 | math | 42 | float 40 runtime | sin/cos/tan/asin/acos/atan/atan2/sinh/cosh/tanh/exp/log/log2/log10/sqrt/cbrt/pow/floor/ceil/round/trunc/abs/min/max/hypot/clamp/fract/signum + libm 매핑 |
 | fs | 29 | shim 685 + runtime 21 | read/write/exists/create/remove/rename/copy/mkdir/mkdirAll — 11 API |
@@ -98,7 +99,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 71 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 72 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|

--- a/internal/backend/llvm_os_process_test.go
+++ b/internal/backend/llvm_os_process_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -137,6 +138,90 @@ fn main() {
 	}
 	if got, want := string(output), "true\ntrue\ntrue\n"; got != want {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func stdCmdEnvCwdCommand() (program string, args []string, timeoutShell string) {
+	if runtime.GOOS == "windows" {
+		return "cmd",
+			[]string{"/d", "/s", "/c", "<nul set /p =%OSTY_CMD_TEST%:%CD%"},
+			"ping -n 3 127.0.0.1 >NUL"
+	}
+	return "sh",
+		[]string{"-c", "printf \"$OSTY_CMD_TEST:$(basename \"$PWD\")\""},
+		"sleep 2"
+}
+
+func TestLLVMBackendBinaryRunsStdCmdBuilderSurface(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	tmp := t.TempDir()
+	prog, args, timeoutShell := stdCmdEnvCwdCommand()
+	base := filepath.Base(tmp)
+	pipelineBlock := ""
+	want := "true\ntrue\ntrue\ntrue\ntrue\ntrue\n"
+	if runtime.GOOS != "windows" {
+		pipelineBlock = `
+    match cmd.pipe(
+        cmd.command("printf").arg("hello\nworld\n"),
+        cmd.command("grep").arg("world"),
+    ).run() {
+        Ok(out) -> {
+            println(out.exitCode == 0)
+            println(out.stdout.contains("world"))
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+        },
+    }
+`
+		want += "true\ntrue\n"
+	}
+	src := fmt.Sprintf(`use std.cmd
+
+fn main() {
+    match cmd.command(%q).withArgs(%s).withCwd(%q).withEnv("OSTY_CMD_TEST", "env-ok").run() {
+        Ok(out) -> {
+            println(out.exitCode == 0)
+            println(out.stdout.contains("env-ok"))
+            println(out.stdout.contains(%q))
+            println(!out.timedOut)
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+            println(false)
+            println(false)
+        },
+    }
+
+    match cmd.shell(%q).withTimeoutMillis(100).run() {
+        Ok(out) -> {
+            println(out.timedOut)
+            println(out.exitCode != 0)
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+        },
+    }
+%s}
+`, prog, ostyStringListLiteral(args), tmp, base, timeoutShell, pipelineBlock)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, src)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q\nsource:\n%s", got, want, src)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -10024,6 +10024,168 @@ const char *osty_rt_strings_Join(void *raw_parts, const char *sep) {
     return out;
 }
 
+static size_t osty_rt_cmd_shell_escape_len(const char *arg) {
+    size_t len;
+    size_t total;
+    size_t i;
+    const char *cursor;
+    char buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+
+    arg = (arg == NULL) ? "" : arg;
+    len = osty_rt_string_len(arg);
+    if (len == 0) {
+        return 2;
+    }
+    osty_rt_string_decode_to_buf_if_inline(&arg, buf);
+    cursor = arg;
+    total = 2;
+    for (i = 0; i < len; i++) {
+        total += (cursor[i] == '\'') ? 4 : 1;
+    }
+    return total;
+}
+
+static char *osty_rt_cmd_write_shell_escape(char *cursor, const char *arg) {
+    size_t len;
+    size_t i;
+    const char *src;
+    char buf[OSTY_RT_SSO_DECODE_BUF_BYTES];
+
+    arg = (arg == NULL) ? "" : arg;
+    len = osty_rt_string_len(arg);
+    if (len == 0) {
+        *cursor++ = '\'';
+        *cursor++ = '\'';
+        return cursor;
+    }
+    osty_rt_string_decode_to_buf_if_inline(&arg, buf);
+    src = arg;
+    *cursor++ = '\'';
+    for (i = 0; i < len; i++) {
+        if (src[i] == '\'') {
+            *cursor++ = '\'';
+            *cursor++ = '\\';
+            *cursor++ = '\'';
+            *cursor++ = '\'';
+        } else {
+            *cursor++ = src[i];
+        }
+    }
+    *cursor++ = '\'';
+    return cursor;
+}
+
+const char *osty_rt_cmd_shell_escape(const char *arg) {
+    size_t total = osty_rt_cmd_shell_escape_len(arg);
+    char *out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.cmd.shell_escape", NULL, NULL);
+    char *cursor = osty_rt_cmd_write_shell_escape(out, arg);
+    *cursor = '\0';
+    return out;
+}
+
+static size_t osty_rt_cmd_shell_line_len(const char *program, void *raw_args, bool use_shell) {
+    osty_rt_list *args;
+    int64_t i;
+    int64_t count;
+    size_t total;
+    const char *arg;
+
+    if (use_shell) {
+        return osty_rt_string_len(program == NULL ? "" : program);
+    }
+    args = osty_rt_list_cast(raw_args);
+    count = args == NULL ? 0 : args->len;
+    total = osty_rt_cmd_shell_escape_len(program);
+    for (i = 0; i < count; i++) {
+        arg = ((const char **)args->data)[i];
+        total += 1 + osty_rt_cmd_shell_escape_len(arg);
+    }
+    return total;
+}
+
+static char *osty_rt_cmd_write_shell_line(char *cursor, const char *program, void *raw_args, bool use_shell) {
+    osty_rt_list *args;
+    int64_t i;
+    int64_t count;
+    const char *arg;
+    size_t len;
+
+    if (use_shell) {
+        program = program == NULL ? "" : program;
+        len = osty_rt_string_len(program);
+        osty_rt_string_copy_bytes(cursor, program, len);
+        return cursor + len;
+    }
+    args = osty_rt_list_cast(raw_args);
+    count = args == NULL ? 0 : args->len;
+    cursor = osty_rt_cmd_write_shell_escape(cursor, program);
+    for (i = 0; i < count; i++) {
+        *cursor++ = ' ';
+        arg = ((const char **)args->data)[i];
+        cursor = osty_rt_cmd_write_shell_escape(cursor, arg);
+    }
+    return cursor;
+}
+
+const char *osty_rt_cmd_shell_line(const char *program, void *raw_args, bool use_shell) {
+    size_t total;
+    char *out;
+    char *cursor;
+
+    total = osty_rt_cmd_shell_line_len(program, raw_args, use_shell);
+    out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.cmd.shell_line", NULL, NULL);
+    cursor = osty_rt_cmd_write_shell_line(out, program, raw_args, use_shell);
+    *cursor = '\0';
+    return out;
+}
+
+typedef struct osty_rt_cmd_command {
+    const char *program;
+    void *args;
+    const char *cwd;
+    void *env;
+    int64_t timeout_millis;
+    bool use_shell;
+} osty_rt_cmd_command;
+
+const char *osty_rt_cmd_pipeline_shell_line(void *raw_stages) {
+    osty_rt_list *stages;
+    osty_rt_cmd_command *commands;
+    int64_t i;
+    int64_t count;
+    size_t total;
+    char *out;
+    char *cursor;
+
+    stages = osty_rt_list_cast(raw_stages);
+    if (stages == NULL || stages->len == 0) {
+        out = (char *)osty_gc_allocate_managed(1, OSTY_GC_KIND_STRING, "runtime.cmd.pipeline.empty", NULL, NULL);
+        out[0] = '\0';
+        return out;
+    }
+    commands = (osty_rt_cmd_command *)stages->data;
+    count = stages->len;
+    total = 0;
+    for (i = 0; i < count; i++) {
+        total += osty_rt_cmd_shell_line_len(commands[i].program, commands[i].args, commands[i].use_shell);
+        if (i + 1 < count) {
+            total += 3;
+        }
+    }
+    out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.cmd.pipeline", NULL, NULL);
+    cursor = out;
+    for (i = 0; i < count; i++) {
+        cursor = osty_rt_cmd_write_shell_line(cursor, commands[i].program, commands[i].args, commands[i].use_shell);
+        if (i + 1 < count) {
+            *cursor++ = ' ';
+            *cursor++ = '|';
+            *cursor++ = ' ';
+        }
+    }
+    *cursor = '\0';
+    return out;
+}
+
 const char *osty_rt_strings_Repeat(const char *value, int64_t n) {
     size_t value_len;
     size_t total;
@@ -22284,6 +22446,7 @@ void *osty_rt_fs_diff_files(const char *left, const char *right) {
 typedef struct osty_rt_os_exec_result {
     int64_t tag;
     int64_t exit_code;
+    bool timed_out;
     void *stdout_text;
     void *stderr_text;
     void *error_text;
@@ -22362,6 +22525,7 @@ static osty_rt_os_exec_result *osty_rt_os_exec_error_result(const char *prefix, 
         (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), site);
     out->tag = 1;
     out->exit_code = 0;
+    out->timed_out = false;
     out->stdout_text = NULL;
     out->stderr_text = NULL;
     out->error_text = osty_rt_os_error_message(prefix, detail, site);
@@ -22392,6 +22556,19 @@ static char *osty_rt_os_cstr_dup(const char *value, const char *site) {
     return out;
 }
 
+static char *osty_rt_os_cstr_dup_optional(const char *value, const char *site) {
+    char *out;
+    if (value == NULL) {
+        return NULL;
+    }
+    out = osty_rt_os_cstr_dup(value, site);
+    if (out[0] == '\0') {
+        free(out);
+        return NULL;
+    }
+    return out;
+}
+
 static void osty_rt_os_argv_free(char **argv) {
     int64_t i;
     if (argv == NULL) {
@@ -22403,7 +22580,145 @@ static void osty_rt_os_argv_free(char **argv) {
     free(argv);
 }
 
+static void osty_rt_os_envp_free(char **envp) {
+    int64_t i;
+    if (envp == NULL) {
+        return;
+    }
+    for (i = 0; envp[i] != NULL; i++) {
+        free(envp[i]);
+    }
+    free(envp);
+}
+
+static bool osty_rt_os_env_overrides_empty(void *overrides) {
+    return overrides == NULL || osty_rt_map_len(overrides) == 0;
+}
+
+static bool osty_rt_os_env_name_valid(const char *name) {
+    return name != NULL && name[0] != '\0' && strchr(name, '=') == NULL;
+}
+
+static bool osty_rt_os_env_entry_key_equals(const char *entry, const char *key, size_t key_len) {
+    const char *eq;
+    if (entry == NULL || key == NULL) {
+        return false;
+    }
+    eq = strchr(entry, '=');
+    if (eq == NULL || eq == entry) {
+        return false;
+    }
+    return (size_t)(eq - entry) == key_len && memcmp(entry, key, key_len) == 0;
+}
+
+static bool osty_rt_os_env_overrides_contains_key(void *overrides, const char *key, size_t key_len) {
+    int64_t n;
+    int64_t i;
+    if (overrides == NULL || key == NULL) {
+        return false;
+    }
+    n = osty_rt_map_len(overrides);
+    for (i = 0; i < n; i++) {
+        const char *raw_key = osty_rt_map_key_at_string(overrides, i);
+        char *name = osty_rt_os_cstr_dup(raw_key, "runtime.os.exec.env.key");
+        bool same = strlen(name) == key_len && memcmp(name, key, key_len) == 0;
+        free(name);
+        if (same) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static char *osty_rt_os_env_assignment_dup(const char *raw_key, const char *raw_value, const char **err_detail) {
+    char *key = osty_rt_os_cstr_dup(raw_key, "runtime.os.exec.env.key");
+    char *value = osty_rt_os_cstr_dup(raw_value, "runtime.os.exec.env.value");
+    size_t key_len;
+    size_t value_len;
+    char *out;
+    if (!osty_rt_os_env_name_valid(key)) {
+        free(key);
+        free(value);
+        if (err_detail != NULL) {
+            *err_detail = "environment variable name is empty or contains '='";
+        }
+        return NULL;
+    }
+    key_len = strlen(key);
+    value_len = strlen(value);
+    out = (char *)osty_rt_xmalloc(key_len + 1 + value_len + 1, "runtime.os.exec.env.entry");
+    memcpy(out, key, key_len);
+    out[key_len] = '=';
+    memcpy(out + key_len + 1, value, value_len);
+    out[key_len + 1 + value_len] = '\0';
+    free(key);
+    free(value);
+    return out;
+}
+
 #if defined(_WIN32)
+static void osty_rt_os_win_env_block_append(char **buf_inout, size_t *cap_inout, size_t *len_inout, const char *text) {
+    size_t n = text == NULL ? 0 : strlen(text);
+    size_t need = *len_inout + n + 1;
+    if (need > *cap_inout) {
+        size_t next = *cap_inout == 0 ? 256 : *cap_inout;
+        char *grown;
+        while (next < need) {
+            next *= 2;
+        }
+        grown = (char *)realloc(*buf_inout, next);
+        if (grown == NULL) {
+            osty_rt_abort("runtime.os.exec.env: out of memory");
+        }
+        *buf_inout = grown;
+        *cap_inout = next;
+    }
+    if (n != 0) {
+        memcpy(*buf_inout + *len_inout, text, n);
+    }
+    *len_inout += n;
+    (*buf_inout)[(*len_inout)++] = '\0';
+}
+
+static char *osty_rt_os_build_env_block_win(void *overrides, const char **err_detail) {
+    LPCH block;
+    LPCH cursor;
+    char *out = NULL;
+    size_t cap = 0;
+    size_t len = 0;
+    int64_t n;
+    int64_t i;
+    if (osty_rt_os_env_overrides_empty(overrides)) {
+        return NULL;
+    }
+    block = GetEnvironmentStringsA();
+    if (block != NULL) {
+        for (cursor = block; cursor[0] != '\0'; cursor += strlen(cursor) + 1) {
+            const char *entry = (const char *)cursor;
+            const char *eq = strchr(entry, '=');
+            if (eq != NULL && eq != entry &&
+                !osty_rt_os_env_overrides_contains_key(overrides, entry, (size_t)(eq - entry))) {
+                osty_rt_os_win_env_block_append(&out, &cap, &len, entry);
+            }
+        }
+        FreeEnvironmentStringsA(block);
+    }
+    n = osty_rt_map_len(overrides);
+    for (i = 0; i < n; i++) {
+        void *raw_value = NULL;
+        const char *raw_key = osty_rt_map_entry_at_string(overrides, i, &raw_value);
+        char *entry = osty_rt_os_env_assignment_dup(raw_key, (const char *)raw_value, err_detail);
+        if (entry == NULL) {
+            free(out);
+            return NULL;
+        }
+        osty_rt_os_win_env_block_append(&out, &cap, &len, entry);
+        free(entry);
+    }
+    osty_rt_os_win_env_block_append(&out, &cap, &len, "");
+    return out;
+}
+
 static char *osty_rt_os_win_strdup(const char *text, const char *site) {
     size_t n = text == NULL ? 0 : strlen(text);
     char *out = (char *)osty_rt_xmalloc(n + 1, site);
@@ -22585,10 +22900,12 @@ static char *osty_rt_os_build_windows_command_line(const char *cmd, void *args, 
     return buf;
 }
 
-static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *args, bool shell) {
+static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
     char *stdout_path = NULL;
     char *stderr_path = NULL;
     char *cmdline = NULL;
+    char *cwd_text = NULL;
+    char *env_block = NULL;
     void *stdout_text = NULL;
     void *stderr_text = NULL;
     HANDLE stdout_handle = INVALID_HANDLE_VALUE;
@@ -22597,17 +22914,29 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     PROCESS_INFORMATION pi;
     STARTUPINFOA si;
     DWORD exit_code = 0;
+    bool timed_out = false;
     osty_rt_os_exec_result *out;
+    const char *env_err = NULL;
     if (cmd == NULL || cmd[0] == '\0') {
         return osty_rt_os_exec_error_result("failed to launch process", "command is empty", "runtime.os.exec.error");
     }
+    cwd_text = osty_rt_os_cstr_dup_optional(cwd, "runtime.os.exec.cwd");
+    env_block = osty_rt_os_build_env_block_win(env_overrides, &env_err);
+    if (env_err != NULL) {
+        free(cwd_text);
+        return osty_rt_os_exec_error_result("failed to launch process", env_err, "runtime.os.exec.error");
+    }
     if (!osty_rt_os_open_tempfile_win(&stdout_path, &stdout_handle)) {
+        free(cwd_text);
+        free(env_block);
         return osty_rt_os_exec_error_result("failed to launch process", "could not create stdout temp file", "runtime.os.exec.error");
     }
     if (!osty_rt_os_open_tempfile_win(&stderr_path, &stderr_handle)) {
         CloseHandle(stdout_handle);
         DeleteFileA(stdout_path);
         free(stdout_path);
+        free(cwd_text);
+        free(env_block);
         return osty_rt_os_exec_error_result("failed to launch process", "could not create stderr temp file", "runtime.os.exec.error");
     }
     {
@@ -22623,6 +22952,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
             DeleteFileA(stderr_path);
             free(stdout_path);
             free(stderr_path);
+            free(cwd_text);
+            free(env_block);
             return osty_rt_os_exec_error_result("failed to launch process", "could not open NUL for stdin", "runtime.os.exec.error");
         }
     }
@@ -22634,7 +22965,7 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     si.hStdInput = stdin_handle;
     si.hStdOutput = stdout_handle;
     si.hStdError = stderr_handle;
-    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
+    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE, 0, env_block, cwd_text, &si, &pi)) {
         DWORD code = GetLastError();
         char buf[96];
         int written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
@@ -22646,6 +22977,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
         free(stdout_path);
         free(stderr_path);
         free(cmdline);
+        free(cwd_text);
+        free(env_block);
         if (written < 0) {
             return osty_rt_os_exec_error_result("failed to launch process", "CreateProcessA failed", "runtime.os.exec.error");
         }
@@ -22655,7 +22988,17 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     CloseHandle(stdout_handle);
     CloseHandle(stderr_handle);
     free(cmdline);
-    WaitForSingleObject(pi.hProcess, INFINITE);
+    if (timeout_ms > 0) {
+        DWORD wait_ms = timeout_ms > (int64_t)0xFFFFFFFF ? 0xFFFFFFFF : (DWORD)timeout_ms;
+        DWORD wait_result = WaitForSingleObject(pi.hProcess, wait_ms);
+        if (wait_result == WAIT_TIMEOUT) {
+            timed_out = true;
+            TerminateProcess(pi.hProcess, 124);
+            WaitForSingleObject(pi.hProcess, INFINITE);
+        }
+    } else {
+        WaitForSingleObject(pi.hProcess, INFINITE);
+    }
     if (!GetExitCodeProcess(pi.hProcess, &exit_code)) {
         DWORD code = GetLastError();
         char buf[96];
@@ -22666,6 +23009,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
         DeleteFileA(stderr_path);
         free(stdout_path);
         free(stderr_path);
+        free(cwd_text);
+        free(env_block);
         if (written < 0) {
             return osty_rt_os_exec_error_result("failed to inspect process exit code", "GetExitCodeProcess failed", "runtime.os.exec.error");
         }
@@ -22679,6 +23024,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     DeleteFileA(stderr_path);
     free(stdout_path);
     free(stderr_path);
+    free(cwd_text);
+    free(env_block);
     if (stdout_text == NULL) {
         return osty_rt_os_exec_error_result("failed to read process stdout", strerror(errno), "runtime.os.exec.error");
     }
@@ -22688,12 +23035,131 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     out = (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.exec.result");
     out->tag = 0;
     out->exit_code = (int64_t)exit_code;
+    out->timed_out = timed_out;
     out->stdout_text = stdout_text;
     out->stderr_text = stderr_text;
     out->error_text = NULL;
     return out;
 }
 #else
+static char **osty_rt_os_build_envp_posix(void *overrides, const char **err_detail) {
+    char *const *entries;
+    char **envp;
+    int64_t override_count;
+    int64_t parent_count = 0;
+    int64_t i;
+    int64_t out_i = 0;
+    if (osty_rt_os_env_overrides_empty(overrides)) {
+        return NULL;
+    }
+    entries = osty_rt_env_entries_posix();
+    if (entries != NULL) {
+        char *const *cursor;
+        for (cursor = entries; *cursor != NULL; cursor++) {
+            const char *entry = *cursor;
+            const char *eq = entry == NULL ? NULL : strchr(entry, '=');
+            if (eq != NULL && eq != entry &&
+                !osty_rt_os_env_overrides_contains_key(overrides, entry, (size_t)(eq - entry))) {
+                parent_count++;
+            }
+        }
+    }
+    override_count = osty_rt_map_len(overrides);
+    envp = (char **)osty_rt_xmalloc(sizeof(char *) * (size_t)(parent_count + override_count + 1), "runtime.os.exec.envp");
+    if (entries != NULL) {
+        char *const *cursor;
+        for (cursor = entries; *cursor != NULL; cursor++) {
+            const char *entry = *cursor;
+            const char *eq = entry == NULL ? NULL : strchr(entry, '=');
+            if (eq != NULL && eq != entry &&
+                !osty_rt_os_env_overrides_contains_key(overrides, entry, (size_t)(eq - entry))) {
+                envp[out_i++] = osty_rt_os_cstr_dup(entry, "runtime.os.exec.env.inherit");
+            }
+        }
+    }
+    for (i = 0; i < override_count; i++) {
+        void *raw_value = NULL;
+        const char *raw_key = osty_rt_map_entry_at_string(overrides, i, &raw_value);
+        char *entry = osty_rt_os_env_assignment_dup(raw_key, (const char *)raw_value, err_detail);
+        if (entry == NULL) {
+            envp[out_i] = NULL;
+            osty_rt_os_envp_free(envp);
+            return NULL;
+        }
+        envp[out_i++] = entry;
+    }
+    envp[out_i] = NULL;
+    return envp;
+}
+
+static const char *osty_rt_os_envp_lookup(char *const envp[], const char *name) {
+    size_t name_len;
+    int64_t i;
+    if (name == NULL) {
+        return NULL;
+    }
+    if (envp == NULL) {
+        return getenv(name);
+    }
+    name_len = strlen(name);
+    for (i = 0; envp[i] != NULL; i++) {
+        if (osty_rt_os_env_entry_key_equals(envp[i], name, name_len)) {
+            return envp[i] + name_len + 1;
+        }
+    }
+    return NULL;
+}
+
+static int osty_rt_os_execvpe_posix(const char *file, char *const argv[], char *const envp[]) {
+    const char *path;
+    const char *cursor;
+    int saved_errno = ENOENT;
+    if (file == NULL || file[0] == '\0') {
+        errno = ENOENT;
+        return -1;
+    }
+    if (strchr(file, '/') != NULL) {
+        execve(file, argv, envp);
+        return -1;
+    }
+    path = osty_rt_os_envp_lookup(envp, "PATH");
+    if (path == NULL || path[0] == '\0') {
+        path = "/bin:/usr/bin";
+    }
+    cursor = path;
+    for (;;) {
+        const char *colon = strchr(cursor, ':');
+        size_t dir_len = colon == NULL ? strlen(cursor) : (size_t)(colon - cursor);
+        size_t file_len = strlen(file);
+        const char *dir = cursor;
+        size_t total;
+        char *candidate;
+        if (dir_len == 0) {
+            dir = ".";
+            dir_len = 1;
+        }
+        total = dir_len + 1 + file_len + 1;
+        candidate = (char *)osty_rt_xmalloc(total, "runtime.os.exec.path");
+        memcpy(candidate, dir, dir_len);
+        candidate[dir_len] = '/';
+        memcpy(candidate + dir_len + 1, file, file_len);
+        candidate[dir_len + 1 + file_len] = '\0';
+        execve(candidate, argv, envp);
+        if (errno == EACCES) {
+            saved_errno = EACCES;
+        } else if (errno != ENOENT && errno != ENOTDIR) {
+            saved_errno = errno;
+        }
+        free(candidate);
+        if (colon == NULL) {
+            break;
+        }
+        cursor = colon + 1;
+    }
+    errno = saved_errno;
+    return -1;
+}
+
 static char **osty_rt_os_build_posix_argv(const char *cmd, void *args, bool shell) {
     int64_t arg_count = args != NULL ? osty_rt_list_len(args) : 0;
     char **argv;
@@ -22742,13 +23208,15 @@ static int osty_rt_os_open_tempfile_posix(const char *prefix, char **out_path) {
     return fd;
 }
 
-static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args, bool shell) {
+static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
     char *stdout_path = NULL;
     char *stderr_path = NULL;
+    char *cwd_text = NULL;
     int stdout_fd = -1;
     int stderr_fd = -1;
     int exec_pipe[2] = {-1, -1};
     char **argv = NULL;
+    char **envp = NULL;
     pid_t pid;
     int status = 0;
     int exec_errno = 0;
@@ -22757,6 +23225,9 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     void *stdout_text = NULL;
     void *stderr_text = NULL;
     osty_rt_os_exec_result *out;
+    bool timed_out = false;
+    uint64_t deadline_ns = 0;
+    const char *env_err = NULL;
     sigset_t sigurg_mask;
     sigset_t old_mask;
     int sigmask_set = 0;
@@ -22766,8 +23237,16 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     if (cmd == NULL || cmd[0] == '\0') {
         return osty_rt_os_exec_error_result("failed to launch process", "command is empty", "runtime.os.exec.error");
     }
+    cwd_text = osty_rt_os_cstr_dup_optional(cwd, "runtime.os.exec.cwd");
+    envp = osty_rt_os_build_envp_posix(env_overrides, &env_err);
+    if (env_err != NULL) {
+        free(cwd_text);
+        return osty_rt_os_exec_error_result("failed to launch process", env_err, "runtime.os.exec.error");
+    }
     stdout_fd = osty_rt_os_open_tempfile_posix("osty-out.", &stdout_path);
     if (stdout_fd < 0) {
+        free(cwd_text);
+        osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
     }
     stderr_fd = osty_rt_os_open_tempfile_posix("osty-err.", &stderr_path);
@@ -22775,6 +23254,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         close(stdout_fd);
         unlink(stdout_path);
         free(stdout_path);
+        free(cwd_text);
+        osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
     }
     if (pipe(exec_pipe) != 0) {
@@ -22784,6 +23265,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         unlink(stderr_path);
         free(stdout_path);
         free(stderr_path);
+        free(cwd_text);
+        osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
     }
     (void)fcntl(exec_pipe[1], F_SETFD, FD_CLOEXEC);
@@ -22810,7 +23293,9 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         unlink(stderr_path);
         free(stdout_path);
         free(stderr_path);
+        free(cwd_text);
         osty_rt_os_argv_free(argv);
+        osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(err), "runtime.os.exec.error");
     }
     if (pid == 0) {
@@ -22822,8 +23307,19 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         }
         close(stdout_fd);
         close(stderr_fd);
+        if (cwd_text != NULL && chdir(cwd_text) != 0) {
+            int err = errno;
+            (void)write(exec_pipe[1], &err, sizeof(err));
+            _exit(127);
+        }
         if (shell) {
-            execv("/bin/sh", argv);
+            if (envp != NULL) {
+                execve("/bin/sh", argv, envp);
+            } else {
+                execv("/bin/sh", argv);
+            }
+        } else if (envp != NULL) {
+            osty_rt_os_execvpe_posix(argv[0], argv, envp);
         } else {
             execvp(argv[0], argv);
         }
@@ -22841,9 +23337,31 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     if (sigprocmask(SIG_BLOCK, &sigurg_mask, &old_mask) == 0) {
         sigmask_set = 1;
     }
-    do {
-        waited = waitpid(pid, &status, 0);
-    } while (waited < 0 && errno == EINTR);
+    if (timeout_ms > 0) {
+        deadline_ns = osty_rt_monotonic_ns() + (uint64_t)timeout_ms * 1000000ULL;
+    }
+    for (;;) {
+        int options = timeout_ms > 0 ? WNOHANG : 0;
+        waited = waitpid(pid, &status, options);
+        if (waited == pid) {
+            break;
+        }
+        if (waited < 0 && errno == EINTR) {
+            continue;
+        }
+        if (waited < 0) {
+            break;
+        }
+        if (timeout_ms > 0 && osty_rt_monotonic_ns() >= deadline_ns) {
+            timed_out = true;
+            (void)kill(pid, SIGKILL);
+            do {
+                waited = waitpid(pid, &status, 0);
+            } while (waited < 0 && errno == EINTR);
+            break;
+        }
+        osty_rt_sleep_ns(1000000ULL);
+    }
     do {
         exec_read = read(exec_pipe[0], &exec_errno, sizeof(exec_errno));
     } while (exec_read < 0 && errno == EINTR);
@@ -22855,6 +23373,8 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         (void)sigaction(SIGCHLD, &old_sigchld, NULL);
     }
     osty_rt_os_argv_free(argv);
+    osty_rt_os_envp_free(envp);
+    free(cwd_text);
     if (waited < 0) {
         unlink(stdout_path);
         unlink(stderr_path);
@@ -22883,7 +23403,10 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     }
     out = (osty_rt_os_exec_result *)osty_rt_xmalloc(sizeof(*out), "runtime.os.exec.result");
     out->tag = 0;
-    if (WIFEXITED(status)) {
+    out->timed_out = timed_out;
+    if (timed_out) {
+        out->exit_code = 124;
+    } else if (WIFEXITED(status)) {
         out->exit_code = (int64_t)WEXITSTATUS(status);
     } else if (WIFSIGNALED(status)) {
         out->exit_code = 128 + (int64_t)WTERMSIG(status);
@@ -22897,12 +23420,16 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
 }
 #endif
 
-osty_rt_os_exec_result *osty_rt_os_exec(const char *cmd, void *args, bool shell) {
+osty_rt_os_exec_result *osty_rt_os_exec_options(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
 #if defined(_WIN32)
-    return osty_rt_os_exec_windows(cmd, args, shell);
+    return osty_rt_os_exec_windows(cmd, args, shell, cwd, env_overrides, timeout_ms);
 #else
-    return osty_rt_os_exec_posix(cmd, args, shell);
+    return osty_rt_os_exec_posix(cmd, args, shell, cwd, env_overrides, timeout_ms);
 #endif
+}
+
+osty_rt_os_exec_result *osty_rt_os_exec(const char *cmd, void *args, bool shell) {
+    return osty_rt_os_exec_options(cmd, args, shell, NULL, NULL, 0);
 }
 
 osty_rt_os_string_result *osty_rt_os_hostname(void) {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -62,6 +62,12 @@ func fastPathListWriteEnabled() bool {
 	return os.Getenv("OSTY_LLVM_LIST_WRITE_FASTPATH") == "1"
 }
 
+const (
+	stdCmdSyntheticCommandTypeName   = "__osty_std_cmd_Command"
+	stdCmdSyntheticRunOutputTypeName = "__osty_std_cmd_RunOutput"
+	stdCmdSyntheticPipelineTypeName  = "__osty_std_cmd_Pipeline"
+)
+
 // GenerateFromMIR emits textual LLVM IR from a MIR module. It is the
 // Stage 3 entry point into llvmgen. Direct callers that still want the legacy
 // HIR→AST bridge should call GenerateModule; the backend dispatcher uses this
@@ -202,8 +208,12 @@ type mirGen struct {
 	layoutCache MirLayoutCache        // §14 enum / tuple order cache (Osty mirror)
 	tupleDefs   map[string][]mir.Type // mangled tuple name → element types
 
-	stdTermSizeTouched bool // synthetic std.term Size payload used by MIR
-	stdOsOutputTouched bool // synthetic std.os Output payload used by MIR
+	stdTermSizeTouched     bool // synthetic std.term Size payload used by MIR
+	stdOsOutputTouched     bool // synthetic std.os Output payload used by MIR
+	stdOsExecOutputTouched bool // synthetic std.os ExecOutput payload used by MIR
+	stdCmdCommandTouched   bool // synthetic std.cmd Command payload used by MIR
+	stdCmdRunOutputTouched bool // synthetic std.cmd RunOutput payload used by MIR
+	stdCmdPipelineTouched  bool // synthetic std.cmd Pipeline payload used by MIR
 
 	// Closure-env thunks generated on demand when a bare `FnConst`
 	// (top-level fn used as a value) reaches an indirect-call site.
@@ -712,7 +722,12 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		case "Option", "Maybe", "Result":
 			return true
 		}
-		if g.isStdTermSizeType(x) || g.isStdOsOutputType(x) {
+		if g.isStdTermSizeType(x) ||
+			g.isStdOsOutputType(x) ||
+			g.isStdOsExecOutputType(x) ||
+			g.isStdCmdCommandType(x) ||
+			g.isStdCmdRunOutputType(x) ||
+			g.isStdCmdPipelineType(x) {
 			return true
 		}
 		if strings.Contains(x.QualifiedName(), ".") {
@@ -1603,7 +1618,15 @@ func (g *mirGen) emitTypeDefs() {
 			g.registerEnumLayout(name)
 		}
 	}
-	if len(g.structOrder) == 0 && g.layoutCache.IsEmpty() && !g.ifaceTouched && !g.stdTermSizeTouched && !g.stdOsOutputTouched {
+	if len(g.structOrder) == 0 &&
+		g.layoutCache.IsEmpty() &&
+		!g.ifaceTouched &&
+		!g.stdTermSizeTouched &&
+		!g.stdOsOutputTouched &&
+		!g.stdOsExecOutputTouched &&
+		!g.stdCmdCommandTouched &&
+		!g.stdCmdRunOutputTouched &&
+		!g.stdCmdPipelineTouched {
 		return
 	}
 
@@ -1630,6 +1653,18 @@ func (g *mirGen) emitTypeDefs() {
 	}
 	if g.stdOsOutputTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdOsSyntheticOutputTypeName, "i64, ptr, ptr"))
+	}
+	if g.stdOsExecOutputTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdOsSyntheticExecOutputTypeName, "i64, ptr, ptr, i1"))
+	}
+	if g.stdCmdCommandTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdCmdSyntheticCommandTypeName, "ptr, ptr, ptr, ptr, i64, i1"))
+	}
+	if g.stdCmdRunOutputTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdCmdSyntheticRunOutputTypeName, "i64, ptr, ptr, i1"))
+	}
+	if g.stdCmdPipelineTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdCmdSyntheticPipelineTypeName, "ptr, ptr, ptr, i64"))
 	}
 	for _, name := range g.layoutCache.EnumLayoutOrder {
 		block.WriteString(mirLlvmEnumLayoutTypeDefLine(name))
@@ -3253,6 +3288,9 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 		if handled, err := g.emitStdCompressCall(c, fnRef); handled {
 			return err
 		}
+	}
+	if handled, err := g.emitStdCmdCall(c, fnRef); handled {
+		return err
 	}
 	if strings.HasPrefix(fnRef.Symbol, "std.os.") {
 		if handled, err := g.emitStdOsCall(c, fnRef); handled {
@@ -9430,6 +9468,35 @@ func (g *mirGen) listElemType(t mir.Type) mir.Type {
 	return nil
 }
 
+func stdCmdStringListType() mir.Type {
+	return &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+}
+
+func stdCmdStringMapType() mir.Type {
+	return &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, ir.TString}, Builtin: true}
+}
+
+func stdCmdCommandNamedType() mir.Type {
+	return &ir.NamedType{Name: "Command"}
+}
+
+func stdCmdCommandListType() mir.Type {
+	return &ir.NamedType{Name: "List", Args: []ir.Type{stdCmdCommandNamedType()}, Builtin: true}
+}
+
+func (g *mirGen) syntheticStdlibStructElementTypes(nt *ir.NamedType) ([]mir.Type, bool) {
+	switch {
+	case g.isStdCmdCommandType(nt):
+		return []mir.Type{ir.TString, stdCmdStringListType(), ir.TString, stdCmdStringMapType(), ir.TInt, ir.TBool}, true
+	case g.isStdCmdRunOutputType(nt):
+		return []mir.Type{ir.TInt, ir.TString, ir.TString, ir.TBool}, true
+	case g.isStdCmdPipelineType(nt):
+		return []mir.Type{stdCmdCommandListType(), ir.TString, stdCmdStringMapType(), ir.TInt}, true
+	default:
+		return nil, false
+	}
+}
+
 // aggregateElementTypes returns the element types an aggregate's
 // Fields should match. For structs this comes from the LayoutTable
 // so field order is authoritative; for tuples it's the type itself.
@@ -9439,6 +9506,9 @@ func (g *mirGen) aggregateElementTypes(aggT mir.Type, rv *mir.AggregateRV) ([]mi
 		nt, ok := aggT.(*ir.NamedType)
 		if !ok {
 			return nil, fmt.Errorf("mir-mvp: struct aggregate type %s", mirTypeString(aggT))
+		}
+		if elems, ok := g.syntheticStdlibStructElementTypes(nt); ok {
+			return elems, nil
 		}
 		if g.mod == nil || g.mod.Layouts == nil {
 			return nil, fmt.Errorf("mir-mvp: missing layout table for struct %s", nt.Name)
@@ -9912,6 +9982,58 @@ func (g *mirGen) projectionIndexForType(base mir.Type, p mir.Projection) (int, b
 					return 1, true
 				case "stderr":
 					return 2, true
+				}
+			}
+			if g.isStdOsExecOutputType(nt) {
+				switch fp.Name {
+				case "exitCode":
+					return 0, true
+				case "stdout":
+					return 1, true
+				case "stderr":
+					return 2, true
+				case "timedOut":
+					return 3, true
+				}
+			}
+			if g.isStdCmdCommandType(nt) {
+				switch fp.Name {
+				case "program":
+					return 0, true
+				case "args":
+					return 1, true
+				case "cwd":
+					return 2, true
+				case "env":
+					return 3, true
+				case "timeoutMillis":
+					return 4, true
+				case "useShell":
+					return 5, true
+				}
+			}
+			if g.isStdCmdRunOutputType(nt) {
+				switch fp.Name {
+				case "exitCode":
+					return 0, true
+				case "stdout":
+					return 1, true
+				case "stderr":
+					return 2, true
+				case "timedOut":
+					return 3, true
+				}
+			}
+			if g.isStdCmdPipelineType(nt) {
+				switch fp.Name {
+				case "stages":
+					return 0, true
+				case "cwd":
+					return 1, true
+				case "env":
+					return 2, true
+				case "timeoutMillis":
+					return 3, true
 				}
 			}
 		}
@@ -10407,6 +10529,22 @@ func (g *mirGen) llvmType(t mir.Type) string {
 			g.stdOsOutputTouched = true
 			return "%" + stdOsSyntheticOutputTypeName
 		}
+		if g.isStdOsExecOutputType(x) {
+			g.stdOsExecOutputTouched = true
+			return "%" + stdOsSyntheticExecOutputTypeName
+		}
+		if g.isStdCmdCommandType(x) {
+			g.stdCmdCommandTouched = true
+			return "%" + stdCmdSyntheticCommandTypeName
+		}
+		if g.isStdCmdRunOutputType(x) {
+			g.stdCmdRunOutputTouched = true
+			return "%" + stdCmdSyntheticRunOutputTypeName
+		}
+		if g.isStdCmdPipelineType(x) {
+			g.stdCmdPipelineTouched = true
+			return "%" + stdCmdSyntheticPipelineTypeName
+		}
 		// Prelude Option / Maybe / Result. Mint an anonymous
 		// `%Option.<T>` / `%Result.<T>.<E>` so the IR carries the
 		// element type in its name — mimicking how the legacy
@@ -10474,6 +10612,58 @@ func (g *mirGen) isStdOsOutputType(t *ir.NamedType) bool {
 	}
 	q := t.QualifiedName()
 	return q == "Output" || q == "std.os.Output" || q == "os.Output"
+}
+
+func (g *mirGen) isStdOsExecOutputType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "ExecOutput" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "ExecOutput" || q == "std.os.ExecOutput" || q == "os.ExecOutput"
+}
+
+func (g *mirGen) isStdCmdCommandType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "Command" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "Command" || q == "std.cmd.Command" || q == "cmd.Command"
+}
+
+func (g *mirGen) isStdCmdRunOutputType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "RunOutput" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "RunOutput" || q == "std.cmd.RunOutput" || q == "cmd.RunOutput"
+}
+
+func (g *mirGen) isStdCmdPipelineType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "Pipeline" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "Pipeline" || q == "std.cmd.Pipeline" || q == "cmd.Pipeline"
 }
 
 // ==== enum layout helpers ====

--- a/internal/llvmgen/stdlib_cmd_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_cmd_mir_runtime_shim.go
@@ -1,0 +1,749 @@
+package llvmgen
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+)
+
+const ostyRtCmdShellEscapeSymbol = "osty_rt_cmd_shell_escape"
+const ostyRtCmdShellLineSymbol = "osty_rt_cmd_shell_line"
+const ostyRtCmdPipelineShellLineSymbol = "osty_rt_cmd_pipeline_shell_line"
+
+func (g *mirGen) emitStdCmdCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	if fnRef == nil {
+		return false, nil
+	}
+	switch fnRef.Symbol {
+	case "std.cmd.command", "cmd.command":
+		return true, g.emitStdCmdConstruct(c, false, false)
+	case "std.cmd.commandArgs", "cmd.commandArgs":
+		return true, g.emitStdCmdConstruct(c, false, true)
+	case "std.cmd.shell", "cmd.shell":
+		return true, g.emitStdCmdConstruct(c, true, false)
+	case "std.cmd.pipeline", "cmd.pipeline":
+		return true, g.emitStdCmdPipelineConstruct(c)
+	case "std.cmd.pipe", "cmd.pipe":
+		return true, g.emitStdCmdPipe(c)
+	case "std.cmd.shellEscape", "cmd.shellEscape":
+		return true, g.emitStdCmdShellEscape(c)
+	case "std.cmd.joinEscaped", "cmd.joinEscaped":
+		return true, g.emitStdCmdJoinEscaped(c)
+	}
+	if method, ok := g.stdCmdMethodName(fnRef.Symbol, "Command", c); ok {
+		return true, g.emitStdCmdCommandMethod(c, method)
+	}
+	if method, ok := g.stdCmdMethodName(fnRef.Symbol, "RunOutput", c); ok {
+		return true, g.emitStdCmdRunOutputMethod(c, method)
+	}
+	if method, ok := g.stdCmdMethodName(fnRef.Symbol, "Pipeline", c); ok {
+		return true, g.emitStdCmdPipelineMethod(c, method)
+	}
+	return false, nil
+}
+
+func (g *mirGen) stdCmdMethodName(symbol, typeName string, c *mir.CallInstr) (string, bool) {
+	marker := typeName + "__"
+	idx := strings.LastIndex(symbol, marker)
+	if idx < 0 {
+		return "", false
+	}
+	if idx > 0 && symbol[idx-1] != '.' {
+		return "", false
+	}
+	if len(c.Args) == 0 {
+		return "", false
+	}
+	nt, _ := c.Args[0].Type().(*ir.NamedType)
+	switch typeName {
+	case "Command":
+		if !g.isStdCmdCommandType(nt) {
+			return "", false
+		}
+	case "RunOutput":
+		if !g.isStdCmdRunOutputType(nt) {
+			return "", false
+		}
+	case "Pipeline":
+		if !g.isStdCmdPipelineType(nt) {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+	return symbol[idx+len(marker):], true
+}
+
+func (g *mirGen) emitStdCmdPipelineConstruct(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.pipeline requires one List<Command> argument")
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.cmd.pipeline dest into unknown local %d", c.Dest.Local)
+	}
+	stages, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	if stages.typ != "ptr" {
+		return unsupported("mir-mvp", "std.cmd.pipeline stages must be List<Command>")
+	}
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		stages,
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.cmd.pipeline")
+}
+
+func (g *mirGen) emitStdCmdPipe(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.cmd.pipe requires two Command arguments")
+	}
+	listReg := g.emitStdCmdEmptyStringList()
+	for _, arg := range c.Args {
+		cmdVal, err := g.evalOperand(arg, arg.Type())
+		if err != nil {
+			return err
+		}
+		g.emitStdCmdListPushCommand(listReg, cmdVal, g.llvmType(arg.Type()))
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.cmd.pipe dest into unknown local %d", c.Dest.Local)
+	}
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		{typ: "ptr", val: listReg},
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.cmd.pipe")
+}
+
+func (g *mirGen) emitStdCmdListPushCommand(listReg, value, commandLLVM string) {
+	sym := listRuntimePushBytesV1Symbol()
+	g.declareRuntime(sym, mirRuntimeDeclareBytesV1PushLine(sym))
+	em := g.ostyEmitter()
+	slot := llvmSpillToSlot(em, &LlvmValue{typ: commandLLVM, name: value})
+	size := llvmSizeOf(em, commandLLVM)
+	llvmCallVoid(em, sym, []*LlvmValue{
+		{typ: "ptr", name: listReg},
+		slot,
+		size,
+	})
+	g.flushOstyEmitter(em)
+}
+
+func (g *mirGen) emitStdCmdConstruct(c *mir.CallInstr, useShell bool, hasArgs bool) error {
+	wantArgs := 1
+	if hasArgs {
+		wantArgs = 2
+	}
+	if len(c.Args) != wantArgs {
+		return unsupported("mir-mvp", "std.cmd command constructor argument shape")
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.cmd constructor dest into unknown local %d", c.Dest.Local)
+	}
+	program, err := g.evalStringArg(c.Args[0], "std.cmd.command", 0)
+	if err != nil {
+		return err
+	}
+	args := mirRuntimeArg{typ: "ptr", val: g.emitStdCmdEmptyStringList()}
+	if hasArgs {
+		args, err = g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		if args.typ != "ptr" {
+			return unsupported("mir-mvp", "std.cmd.commandArgs args must be List<String>")
+		}
+	}
+	shellText := llvmStdIoI1Text(useShell)
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		program,
+		args,
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+		{typ: "i1", val: shellText},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.cmd constructor")
+}
+
+func (g *mirGen) emitStdCmdEmptyStringList() string {
+	g.declareRuntime(listRuntimeNewSymbol(), mirRuntimeDeclareLine("ptr", listRuntimeNewSymbol(), ""))
+	em := g.ostyEmitter()
+	listVal := llvmListNew(em)
+	g.flushOstyEmitter(em)
+	return listVal.name
+}
+
+func (g *mirGen) emitStdCmdEmptyStringMap() string {
+	keyKind := containerAbiKind("ptr", true)
+	valKind := containerAbiKind("ptr", true)
+	valueSize := mapValueSizeBytes("ptr")
+	sym := mirRtMapNewSymbol()
+	g.declareRuntime(sym, mirRuntimeDeclareLine("ptr", sym, "i64, i64, i64, ptr"))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", sym, mirRuntimeArgList([]mirRuntimeArg{
+		{typ: "i64", val: strconv.Itoa(keyKind)},
+		{typ: "i64", val: strconv.Itoa(valKind)},
+		{typ: "i64", val: strconv.Itoa(valueSize)},
+		{typ: "ptr", val: "null"},
+	})))
+	return out
+}
+
+func (g *mirGen) emitStdCmdShellEscape(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.shellEscape requires one String argument")
+	}
+	arg, err := g.evalStringArg(c.Args[0], "std.cmd.shellEscape", 0)
+	if err != nil {
+		return err
+	}
+	g.declareRuntime(ostyRtCmdShellEscapeSymbol, mirRuntimeDeclareLine("ptr", ostyRtCmdShellEscapeSymbol, "ptr"))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", ostyRtCmdShellEscapeSymbol, mirRuntimeArgList([]mirRuntimeArg{arg})))
+	return g.storeStdCmdPtrResult(c, out, "std.cmd.shellEscape")
+}
+
+func (g *mirGen) emitStdCmdJoinEscaped(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.cmd.joinEscaped requires program and args")
+	}
+	program, err := g.evalStringArg(c.Args[0], "std.cmd.joinEscaped", 0)
+	if err != nil {
+		return err
+	}
+	args, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+	if err != nil {
+		return err
+	}
+	if args.typ != "ptr" {
+		return unsupported("mir-mvp", "std.cmd.joinEscaped args must be List<String>")
+	}
+	out := g.emitStdCmdShellLineCall(program.val, args.val, "false")
+	return g.storeStdCmdPtrResult(c, out, "std.cmd.joinEscaped")
+}
+
+func (g *mirGen) emitStdCmdShellLineCall(program, args, useShell string) string {
+	g.declareRuntime(ostyRtCmdShellLineSymbol, mirRuntimeDeclareLine("ptr", ostyRtCmdShellLineSymbol, "ptr, ptr, i1"))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", ostyRtCmdShellLineSymbol, mirRuntimeArgList([]mirRuntimeArg{
+		{typ: "ptr", val: program},
+		{typ: "ptr", val: args},
+		{typ: "i1", val: useShell},
+	})))
+	return out
+}
+
+func (g *mirGen) storeStdCmdPtrResult(c *mir.CallInstr, value, ctx string) error {
+	if c.Dest == nil {
+		return nil
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: "ptr", name: value}, ctx)
+}
+
+func (g *mirGen) emitStdCmdCommandMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "arg":
+		return g.emitStdCmdCommandArg(c)
+	case "withArgs":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 1, 1)
+	case "withCwd":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 2, 1)
+	case "withEnv":
+		return g.emitStdCmdCommandWithEnv(c)
+	case "withEnvMap":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 3, 1)
+	case "withTimeoutMillis":
+		return g.emitStdCmdCommandReplaceIntField(c, method, 4, 1)
+	case "run":
+		return g.emitStdCmdCommandRun(c)
+	case "shellLine":
+		return g.emitStdCmdCommandShellLine(c)
+	default:
+		return unsupported("mir-mvp", "std.cmd Command method "+method)
+	}
+}
+
+func (g *mirGen) evalStdCmdCommandArg(c *mir.CallInstr) (string, string, error) {
+	if len(c.Args) == 0 {
+		return "", "", unsupported("mir-mvp", "std.cmd Command method missing receiver")
+	}
+	selfT := c.Args[0].Type()
+	selfLLVM := g.llvmType(selfT)
+	self, err := g.evalOperand(c.Args[0], selfT)
+	if err != nil {
+		return "", "", err
+	}
+	return self, selfLLVM, nil
+}
+
+func (g *mirGen) storeStdCmdCommandResult(c *mir.CallInstr, self, selfLLVM, ctx string) error {
+	if c.Dest == nil {
+		return nil
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: selfLLVM, name: self}, ctx)
+}
+
+func (g *mirGen) extractStdCmdCommandField(self, selfLLVM string, idx int) string {
+	out := g.fresh()
+	g.fnBuf.WriteString(mirExtractValueLine(out, selfLLVM, self, strconv.Itoa(idx)))
+	return out
+}
+
+func (g *mirGen) replaceStdCmdCommandField(self, selfLLVM, fieldLLVM, val string, idx int) string {
+	out := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueAggLine(out, selfLLVM, self, fieldLLVM, val, strconv.Itoa(idx)))
+	return out
+}
+
+func (g *mirGen) emitStdCmdCommandArg(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.cmd.Command.arg arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalStringArg(c.Args[1], "std.cmd.Command.arg", 1)
+	if err != nil {
+		return err
+	}
+	args := g.extractStdCmdCommandField(self, selfLLVM, 1)
+	g.emitStdCmdListPushString(args, value.val)
+	return g.storeStdCmdCommandResult(c, self, selfLLVM, "std.cmd.Command.arg")
+}
+
+func (g *mirGen) emitStdCmdListPushString(listReg, value string) {
+	sym := listRuntimePushSymbolFor("ptr", true)
+	g.declareRuntime(sym, mirRuntimeDeclareLine("void", sym, "ptr, ptr"))
+	em := g.ostyEmitter()
+	llvmListPushString(em,
+		&LlvmValue{typ: "ptr", name: listReg, pointer: false},
+		&LlvmValue{typ: "ptr", name: value, pointer: false})
+	g.flushOstyEmitter(em)
+}
+
+func (g *mirGen) emitStdCmdCommandReplacePtrField(c *mir.CallInstr, method string, fieldIdx int, argIdx int) error {
+	if len(c.Args) != argIdx+1 {
+		return unsupported("mir-mvp", "std.cmd.Command."+method+" arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalTypedArg(c.Args[argIdx], c.Args[argIdx].Type())
+	if err != nil {
+		return err
+	}
+	if value.typ != "ptr" {
+		return unsupported("mir-mvp", "std.cmd.Command."+method+" value must lower to ptr")
+	}
+	next := g.replaceStdCmdCommandField(self, selfLLVM, "ptr", value.val, fieldIdx)
+	return g.storeStdCmdCommandResult(c, next, selfLLVM, "std.cmd.Command."+method)
+}
+
+func (g *mirGen) emitStdCmdCommandReplaceIntField(c *mir.CallInstr, method string, fieldIdx int, argIdx int) error {
+	if len(c.Args) != argIdx+1 {
+		return unsupported("mir-mvp", "std.cmd.Command."+method+" arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalIntArg(c.Args[argIdx], "std.cmd.Command."+method, argIdx)
+	if err != nil {
+		return err
+	}
+	next := g.replaceStdCmdCommandField(self, selfLLVM, "i64", value.val, fieldIdx)
+	return g.storeStdCmdCommandResult(c, next, selfLLVM, "std.cmd.Command."+method)
+}
+
+func (g *mirGen) emitStdCmdCommandWithEnv(c *mir.CallInstr) error {
+	if len(c.Args) != 3 {
+		return unsupported("mir-mvp", "std.cmd.Command.withEnv arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return err
+	}
+	name, err := g.evalStringArg(c.Args[1], "std.cmd.Command.withEnv", 1)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalStringArg(c.Args[2], "std.cmd.Command.withEnv", 2)
+	if err != nil {
+		return err
+	}
+	env := g.extractStdCmdCommandField(self, selfLLVM, 3)
+	g.emitStdCmdMapInsertString(env, name.val, value.val)
+	return g.storeStdCmdCommandResult(c, self, selfLLVM, "std.cmd.Command.withEnv")
+}
+
+func (g *mirGen) emitStdCmdMapInsertString(mapReg, key, value string) {
+	sym := mapRuntimeInsertSymbol("ptr", true)
+	g.declareRuntime(sym, mirRuntimeDeclareMapInsertLine(sym, "ptr"))
+	em := g.ostyEmitter()
+	slot := llvmSpillToSlot(em, &LlvmValue{typ: "ptr", name: value})
+	llvmMapInsert(em,
+		&LlvmValue{typ: "ptr", name: mapReg},
+		&LlvmValue{typ: "ptr", name: key},
+		slot,
+		true)
+	g.flushOstyEmitter(em)
+}
+
+func (g *mirGen) emitStdCmdCommandShellLine(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.Command.shellLine arity")
+	}
+	fields, err := g.evalStdCmdCommandFields(c)
+	if err != nil {
+		return err
+	}
+	out := g.emitStdCmdShellLineCall(fields.program, fields.args, fields.useShell)
+	return g.storeStdCmdPtrResult(c, out, "std.cmd.Command.shellLine")
+}
+
+type stdCmdCommandFields struct {
+	program  string
+	args     string
+	cwd      string
+	env      string
+	timeout  string
+	useShell string
+}
+
+func (g *mirGen) evalStdCmdCommandFields(c *mir.CallInstr) (stdCmdCommandFields, error) {
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return stdCmdCommandFields{}, err
+	}
+	return stdCmdCommandFields{
+		program:  g.extractStdCmdCommandField(self, selfLLVM, 0),
+		args:     g.extractStdCmdCommandField(self, selfLLVM, 1),
+		cwd:      g.extractStdCmdCommandField(self, selfLLVM, 2),
+		env:      g.extractStdCmdCommandField(self, selfLLVM, 3),
+		timeout:  g.extractStdCmdCommandField(self, selfLLVM, 4),
+		useShell: g.extractStdCmdCommandField(self, selfLLVM, 5),
+	}, nil
+}
+
+func (g *mirGen) emitStdCmdCommandRun(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.Command.run arity")
+	}
+	fields, err := g.evalStdCmdCommandFields(c)
+	if err != nil {
+		return err
+	}
+	return g.emitStdCmdRunWithFields(c, fields.program, fields.args, fields.useShell, fields.cwd, fields.env, fields.timeout, "std.cmd.Command.run")
+}
+
+func (g *mirGen) emitStdCmdRunWithFields(c *mir.CallInstr, program, args, useShell, cwd, env, timeout, label string) error {
+	g.declareRuntime(ostyRtOsExecOptionsSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecOptionsSymbol, "ptr, ptr, i1, ptr, ptr, i64"))
+	g.declareRuntime(ostyRtOsExecResultFreeSymbol, mirRuntimeDeclareLine("void", ostyRtOsExecResultFreeSymbol, "ptr"))
+	raw := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecOptionsSymbol, mirRuntimeArgList([]mirRuntimeArg{
+		{typ: "ptr", val: program},
+		{typ: "ptr", val: args},
+		{typ: "i1", val: useShell},
+		{typ: "ptr", val: cwd},
+		{typ: "ptr", val: env},
+		{typ: "i64", val: timeout},
+	})))
+	tag := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 0)
+	exitCode := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 1)
+	timedOut := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i1", 2)
+	stdoutText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 3)
+	stderrText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 4)
+	errText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 5)
+	g.fnBuf.WriteString(mirCallVoidLine(ostyRtOsExecResultFreeSymbol, mirArgSlotPtr(raw)))
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: %s dest into unknown local %d", label, c.Dest.Local)
+	}
+	okT, _, ok := g.resultSubtypes(destLoc.Type)
+	if !ok {
+		return unsupported("mir-mvp", "std.cmd.Command.run dest is not Result<RunOutput, Error>")
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	failed := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqI64Line(failed, tag, "1"))
+	errLabel := g.freshLabel("cmd.run.err")
+	okLabel := g.freshLabel("cmd.run.ok")
+	contLabel := g.freshLabel("cmd.run.cont")
+	g.fnBuf.WriteString(mirBrCondLine(failed, errLabel, okLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	errPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(errPayload, errText, "i64"))
+	errValue := g.emitResultValue(resultLLVM, false, errPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	output, err := g.buildAggregateValue(okT, []mirRuntimeArg{
+		{typ: "i64", val: exitCode},
+		{typ: "ptr", val: stdoutText},
+		{typ: "ptr", val: stderrText},
+		{typ: "i1", val: timedOut},
+	})
+	if err != nil {
+		return err
+	}
+	okPayload, err := g.toI64Slot(output, okT)
+	if err != nil {
+		return err
+	}
+	okValue := g.emitResultValue(resultLLVM, true, okPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, resultLLVM, errValue, errLabel, okValue, okLabel))
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, phi, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdCmdPipelineMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "run":
+		return g.emitStdCmdPipelineRun(c)
+	case "shellLine":
+		return g.emitStdCmdPipelineShellLine(c)
+	case "withCwd":
+		return g.emitStdCmdPipelineReplacePtrField(c, method, 1, 1)
+	case "withEnvMap":
+		return g.emitStdCmdPipelineReplacePtrField(c, method, 2, 1)
+	case "withTimeoutMillis":
+		return g.emitStdCmdPipelineReplaceIntField(c, method, 3, 1)
+	case "withEnv":
+		return g.emitStdCmdPipelineWithEnv(c)
+	case "stage":
+		return g.emitStdCmdPipelineStage(c)
+	default:
+		return unsupported("mir-mvp", "std.cmd Pipeline method "+method)
+	}
+}
+
+func (g *mirGen) evalStdCmdPipelineArg(c *mir.CallInstr) (string, string, error) {
+	if len(c.Args) == 0 {
+		return "", "", unsupported("mir-mvp", "std.cmd Pipeline method missing receiver")
+	}
+	selfT := c.Args[0].Type()
+	selfLLVM := g.llvmType(selfT)
+	self, err := g.evalOperand(c.Args[0], selfT)
+	if err != nil {
+		return "", "", err
+	}
+	return self, selfLLVM, nil
+}
+
+func (g *mirGen) extractStdCmdPipelineField(self, selfLLVM string, idx int) string {
+	out := g.fresh()
+	g.fnBuf.WriteString(mirExtractValueLine(out, selfLLVM, self, strconv.Itoa(idx)))
+	return out
+}
+
+func (g *mirGen) replaceStdCmdPipelineField(self, selfLLVM, fieldLLVM, val string, idx int) string {
+	out := g.fresh()
+	g.fnBuf.WriteString(mirInsertValueAggLine(out, selfLLVM, self, fieldLLVM, val, strconv.Itoa(idx)))
+	return out
+}
+
+func (g *mirGen) storeStdCmdPipelineResult(c *mir.CallInstr, self, selfLLVM, ctx string) error {
+	if c.Dest == nil {
+		return nil
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: selfLLVM, name: self}, ctx)
+}
+
+func (g *mirGen) emitStdCmdPipelineShellLineValue(stages string) string {
+	g.declareRuntime(ostyRtCmdPipelineShellLineSymbol, mirRuntimeDeclareLine("ptr", ostyRtCmdPipelineShellLineSymbol, "ptr"))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", ostyRtCmdPipelineShellLineSymbol, mirRuntimeArgList([]mirRuntimeArg{{typ: "ptr", val: stages}})))
+	return out
+}
+
+func (g *mirGen) emitStdCmdPipelineRun(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline.run arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	stages := g.extractStdCmdPipelineField(self, selfLLVM, 0)
+	cwd := g.extractStdCmdPipelineField(self, selfLLVM, 1)
+	env := g.extractStdCmdPipelineField(self, selfLLVM, 2)
+	timeout := g.extractStdCmdPipelineField(self, selfLLVM, 3)
+	line := g.emitStdCmdPipelineShellLineValue(stages)
+	return g.emitStdCmdRunWithFields(c, line, "null", "true", cwd, env, timeout, "std.cmd.Pipeline.run")
+}
+
+func (g *mirGen) emitStdCmdPipelineShellLine(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline.shellLine arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	stages := g.extractStdCmdPipelineField(self, selfLLVM, 0)
+	line := g.emitStdCmdPipelineShellLineValue(stages)
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.cmd.Pipeline.shellLine dest into unknown local %d", c.Dest.Local)
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	payload, err := g.toI64Slot(line, ir.TString)
+	if err != nil {
+		return err
+	}
+	okValue := g.emitResultValue(resultLLVM, true, payload)
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, okValue, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdCmdPipelineReplacePtrField(c *mir.CallInstr, method string, fieldIdx int, argIdx int) error {
+	if len(c.Args) != argIdx+1 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline."+method+" arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalTypedArg(c.Args[argIdx], c.Args[argIdx].Type())
+	if err != nil {
+		return err
+	}
+	if value.typ != "ptr" {
+		return unsupported("mir-mvp", "std.cmd.Pipeline."+method+" value must lower to ptr")
+	}
+	next := g.replaceStdCmdPipelineField(self, selfLLVM, "ptr", value.val, fieldIdx)
+	return g.storeStdCmdPipelineResult(c, next, selfLLVM, "std.cmd.Pipeline."+method)
+}
+
+func (g *mirGen) emitStdCmdPipelineReplaceIntField(c *mir.CallInstr, method string, fieldIdx int, argIdx int) error {
+	if len(c.Args) != argIdx+1 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline."+method+" arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalIntArg(c.Args[argIdx], "std.cmd.Pipeline."+method, argIdx)
+	if err != nil {
+		return err
+	}
+	next := g.replaceStdCmdPipelineField(self, selfLLVM, "i64", value.val, fieldIdx)
+	return g.storeStdCmdPipelineResult(c, next, selfLLVM, "std.cmd.Pipeline."+method)
+}
+
+func (g *mirGen) emitStdCmdPipelineWithEnv(c *mir.CallInstr) error {
+	if len(c.Args) != 3 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline.withEnv arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	name, err := g.evalStringArg(c.Args[1], "std.cmd.Pipeline.withEnv", 1)
+	if err != nil {
+		return err
+	}
+	value, err := g.evalStringArg(c.Args[2], "std.cmd.Pipeline.withEnv", 2)
+	if err != nil {
+		return err
+	}
+	env := g.extractStdCmdPipelineField(self, selfLLVM, 2)
+	g.emitStdCmdMapInsertString(env, name.val, value.val)
+	return g.storeStdCmdPipelineResult(c, self, selfLLVM, "std.cmd.Pipeline.withEnv")
+}
+
+func (g *mirGen) emitStdCmdPipelineStage(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.cmd.Pipeline.stage arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	next, err := g.evalOperand(c.Args[1], c.Args[1].Type())
+	if err != nil {
+		return err
+	}
+	stages := g.extractStdCmdPipelineField(self, selfLLVM, 0)
+	g.emitStdCmdListPushCommand(stages, next, g.llvmType(c.Args[1].Type()))
+	return g.storeStdCmdPipelineResult(c, self, selfLLVM, "std.cmd.Pipeline.stage")
+}
+
+func (g *mirGen) emitStdCmdRunOutputMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "ok":
+		return g.emitStdCmdRunOutputOk(c)
+	default:
+		return unsupported("mir-mvp", "std.cmd RunOutput method "+method)
+	}
+}
+
+func (g *mirGen) emitStdCmdRunOutputOk(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.cmd.RunOutput.ok arity")
+	}
+	selfT := c.Args[0].Type()
+	selfLLVM := g.llvmType(selfT)
+	self, err := g.evalOperand(c.Args[0], selfT)
+	if err != nil {
+		return err
+	}
+	exitCode := g.fresh()
+	g.fnBuf.WriteString(mirExtractValueLine(exitCode, selfLLVM, self, "0"))
+	timedOut := g.fresh()
+	g.fnBuf.WriteString(mirExtractValueLine(timedOut, selfLLVM, self, "3"))
+	zero := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqI64Line(zero, exitCode, "0"))
+	notTimedOut := g.fresh()
+	g.fnBuf.WriteString(mirXorI1Line(notTimedOut, timedOut, "true"))
+	ok := g.fresh()
+	g.fnBuf.WriteString(mirBinaryOpLine(ok, "and", "i1", zero, notTimedOut))
+	if c.Dest == nil {
+		return nil
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: "i1", name: ok}, "std.cmd.RunOutput.ok")
+}

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -532,9 +532,13 @@ func (g *mirGen) emitStdOsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 	method := strings.TrimPrefix(fnRef.Symbol, "std.os.")
 	switch method {
 	case "exec":
-		return true, g.emitStdOsExecMIR(c, false)
+		return true, g.emitStdOsExecMIR(c, false, false)
 	case "execShell":
-		return true, g.emitStdOsExecMIR(c, true)
+		return true, g.emitStdOsExecMIR(c, true, false)
+	case "execWith":
+		return true, g.emitStdOsExecMIR(c, false, true)
+	case "execShellWith":
+		return true, g.emitStdOsExecMIR(c, true, true)
 	case "pid":
 		if len(c.Args) != 0 {
 			return true, unsupported("mir-mvp", "std.os.pid requires no arguments")
@@ -559,8 +563,9 @@ func (g *mirGen) emitStdOsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 	return false, nil
 }
 
-func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool) error {
-	if len(c.Args) == 0 || (!shell && len(c.Args) > 2) || (shell && len(c.Args) != 1) {
+func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool) error {
+	if len(c.Args) == 0 || (!withOptions && ((!shell && len(c.Args) > 2) || (shell && len(c.Args) != 1))) ||
+		(withOptions && ((!shell && len(c.Args) != 5) || (shell && len(c.Args) != 4))) {
 		return unsupported("mir-mvp", "std.os.exec/execShell argument shape")
 	}
 	cmdArg, err := g.evalStringArg(c.Args[0], "std.os.exec", 0)
@@ -577,19 +582,59 @@ func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool) error {
 			return unsupported("mir-mvp", "std.os.exec args must be List<String>")
 		}
 	}
+	cwdArg := mirRuntimeArg{typ: "ptr", val: "null"}
+	envArg := mirRuntimeArg{typ: "ptr", val: "null"}
+	timeoutArg := mirRuntimeArg{typ: "i64", val: "0"}
+	if withOptions {
+		argsIndex := 1
+		if !shell {
+			argsArg, err = g.evalTypedArg(c.Args[1], c.Args[1].Type())
+			if err != nil {
+				return err
+			}
+			if argsArg.typ != "ptr" {
+				return unsupported("mir-mvp", "std.os.execWith args must be List<String>")
+			}
+			argsIndex = 2
+		}
+		cwdArg, err = g.evalStringArg(c.Args[argsIndex], "std.os.execWith", argsIndex)
+		if err != nil {
+			return err
+		}
+		envArg, err = g.evalTypedArg(c.Args[argsIndex+1], c.Args[argsIndex+1].Type())
+		if err != nil {
+			return err
+		}
+		if envArg.typ != "ptr" {
+			return unsupported("mir-mvp", "std.os.execWith env must be Map<String, String>")
+		}
+		timeoutArg, err = g.evalIntArg(c.Args[argsIndex+2], "std.os.execWith", argsIndex+2)
+		if err != nil {
+			return err
+		}
+	}
 	shellArg := mirRuntimeArg{typ: "i1", val: "false"}
 	if shell {
 		shellArg.val = "true"
 	}
-	g.declareRuntime(ostyRtOsExecSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecSymbol, "ptr, ptr, i1"))
+	if withOptions {
+		g.declareRuntime(ostyRtOsExecOptionsSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecOptionsSymbol, "ptr, ptr, i1, ptr, ptr, i64"))
+	} else {
+		g.declareRuntime(ostyRtOsExecSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecSymbol, "ptr, ptr, i1"))
+	}
 	g.declareRuntime(ostyRtOsExecResultFreeSymbol, mirRuntimeDeclareLine("void", ostyRtOsExecResultFreeSymbol, "ptr"))
 	raw := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg})))
+	if withOptions {
+		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecOptionsSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg, cwdArg, envArg, timeoutArg})))
+	} else {
+		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg})))
+	}
 	tag := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 0)
 	exitCode := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 1)
-	stdoutText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 2)
-	stderrText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 3)
-	errText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 4)
+	timedOut := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i1", 2)
+	stdoutText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 3)
+	stderrText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 4)
+	errText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 5)
 	g.fnBuf.WriteString(mirCallVoidLine(ostyRtOsExecResultFreeSymbol, mirArgSlotPtr(raw)))
 	if c.Dest == nil {
 		return nil
@@ -617,11 +662,15 @@ func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool) error {
 	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
 
 	g.fnBuf.WriteString(mirLabelLine(okLabel))
-	output, err := g.buildAggregateValue(okT, []mirRuntimeArg{
+	outputArgs := []mirRuntimeArg{
 		{typ: "i64", val: exitCode},
 		{typ: "ptr", val: stdoutText},
 		{typ: "ptr", val: stderrText},
-	})
+	}
+	if withOptions {
+		outputArgs = append(outputArgs, mirRuntimeArg{typ: "i1", val: timedOut})
+	}
+	output, err := g.buildAggregateValue(okT, outputArgs)
 	if err != nil {
 		return err
 	}

--- a/internal/llvmgen/stdlib_os_shim.go
+++ b/internal/llvmgen/stdlib_os_shim.go
@@ -7,15 +7,17 @@ import (
 )
 
 const ostyRtOsExecSymbol = "osty_rt_os_exec"
+const ostyRtOsExecOptionsSymbol = "osty_rt_os_exec_options"
 const ostyRtOsHostnameSymbol = "osty_rt_os_hostname"
 const ostyRtOsPidSymbol = "osty_rt_os_pid"
 const ostyRtOsExitSymbol = "osty_rt_os_exit"
 const ostyRtOsExecResultFreeSymbol = "osty_rt_os_exec_result_free"
 const ostyRtOsStringResultFreeSymbol = "osty_rt_os_string_result_free"
 
-const stdOsExecRuntimeRecordLLVMType = "{ i64, i64, ptr, ptr, ptr }"
+const stdOsExecRuntimeRecordLLVMType = "{ i64, i64, i1, ptr, ptr, ptr }"
 const stdOsStringRuntimeRecordLLVMType = "{ i64, ptr, ptr }"
 const stdOsSyntheticOutputTypeName = "__osty_std_os_Output"
+const stdOsSyntheticExecOutputTypeName = "__osty_std_os_ExecOutput"
 
 func llvmRuntimeStructFieldPtr(emitter *LlvmEmitter, structType string, base *LlvmValue, index int) *LlvmValue {
 	reg := llvmNextTemp(emitter)
@@ -38,6 +40,18 @@ var stdOsExecResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
 	Args: []ast.Type{
 		stdOsOutputSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdOsExecOutputSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{stdOsSyntheticExecOutputTypeName},
+}
+
+var stdOsExecOptionsResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdOsExecOutputSourceTypeSingleton,
 		errorSourceTypeSingleton,
 	},
 }
@@ -119,6 +133,60 @@ func ensureStdOsSyntheticOutputStruct(g *generator) *structInfo {
 	return info
 }
 
+func ensureStdOsSyntheticExecOutputStruct(g *generator) *structInfo {
+	if g == nil {
+		return nil
+	}
+	if info := g.structsByName[stdOsSyntheticExecOutputTypeName]; info != nil {
+		return info
+	}
+	if g.structsByName == nil {
+		g.structsByName = map[string]*structInfo{}
+	}
+	if g.structsByType == nil {
+		g.structsByType = map[string]*structInfo{}
+	}
+	info := &structInfo{
+		name:   stdOsSyntheticExecOutputTypeName,
+		typ:    llvmStructTypeName(stdOsSyntheticExecOutputTypeName),
+		byName: map[string]fieldInfo{},
+	}
+	fields := []fieldInfo{
+		{
+			name:       "exitCode",
+			typ:        "i64",
+			index:      0,
+			sourceType: &ast.NamedType{Path: []string{"Int"}},
+		},
+		{
+			name:       "stdout",
+			typ:        "ptr",
+			index:      1,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "stderr",
+			typ:        "ptr",
+			index:      2,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "timedOut",
+			typ:        "i1",
+			index:      3,
+			sourceType: &ast.NamedType{Path: []string{"Bool"}},
+		},
+	}
+	info.fields = fields
+	for _, field := range fields {
+		info.byName[field.name] = field
+	}
+	g.structs = append(g.structs, info)
+	g.structsByName[info.name] = info
+	g.structsByType[info.typ] = info
+	return info
+}
+
 func (g *generator) emitStdOsCall(call *ast.CallExpr) (value, bool, error) {
 	field, ok := g.stdOsCallField(call)
 	if !ok {
@@ -129,6 +197,10 @@ func (g *generator) emitStdOsCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdOsExecCall(call)
 	case "execShell":
 		return g.emitStdOsExecShellCall(call)
+	case "execWith":
+		return g.emitStdOsExecWithCall(call)
+	case "execShellWith":
+		return g.emitStdOsExecShellWithCall(call)
 	case "pid":
 		return g.emitStdOsPidCall(call)
 	case "hostname":
@@ -157,6 +229,17 @@ func (g *generator) stdOsCallStaticResult(call *ast.CallExpr) (value, bool) {
 			sourceType: stdOsExecResultSourceTypeSingleton,
 			rootPaths:  g.rootPathsForType(info.typ),
 		}, true
+	case "execWith", "execShellWith":
+		ensureStdOsSyntheticExecOutputStruct(g)
+		info, ok := builtinResultTypeFromAST(stdOsExecOptionsResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{
+			typ:        info.typ,
+			sourceType: stdOsExecOptionsResultSourceTypeSingleton,
+			rootPaths:  g.rootPathsForType(info.typ),
+		}, true
 	case "pid":
 		return value{typ: "i64"}, true
 	case "hostname":
@@ -183,6 +266,9 @@ func (g *generator) staticStdOsCallSourceType(call *ast.CallExpr) (ast.Type, boo
 	case "exec", "execShell":
 		ensureStdOsSyntheticOutputStruct(g)
 		return stdOsExecResultSourceTypeSingleton, true
+	case "execWith", "execShellWith":
+		ensureStdOsSyntheticExecOutputStruct(g)
+		return stdOsExecOptionsResultSourceTypeSingleton, true
 	case "pid":
 		return &ast.NamedType{Path: []string{"Int"}}, true
 	case "hostname":
@@ -208,36 +294,56 @@ func (g *generator) stdOsCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
 }
 
 func (g *generator) emitStdOsExecCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, false)
+	return g.emitStdOsExecLikeCall(call, false, false)
 }
 
 func (g *generator) emitStdOsExecShellCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, true)
+	return g.emitStdOsExecLikeCall(call, true, false)
 }
 
-func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool) (value, bool, error) {
+func (g *generator) emitStdOsExecWithCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, false, true)
+}
+
+func (g *generator) emitStdOsExecShellWithCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, true, true)
+}
+
+func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOptions bool) (value, bool, error) {
+	resultSourceType := stdOsExecResultSourceTypeSingleton
 	ensureStdOsSyntheticOutputStruct(g)
-	info, ok := builtinResultTypeFromAST(stdOsExecResultSourceTypeSingleton, g.typeEnv())
+	if withOptions {
+		resultSourceType = stdOsExecOptionsResultSourceTypeSingleton
+		ensureStdOsSyntheticExecOutputStruct(g)
+	}
+	info, ok := builtinResultTypeFromAST(resultSourceType, g.typeEnv())
 	if !ok {
-		return value{}, true, unsupported("type-system", "std.os exec Result<Output, Error> type is unavailable")
+		return value{}, true, unsupported("type-system", "std.os exec Result output type is unavailable")
 	}
 	if g.resultTypes == nil {
 		g.resultTypes = map[string]builtinResultType{}
 	}
 	g.resultTypes[info.typ] = info
-	if len(call.Args) == 0 || len(call.Args) > 2 {
-		name := "os.exec"
+	wantArgs := 2
+	minArgs := 1
+	if shell {
+		wantArgs = 1
+	}
+	if withOptions {
 		if shell {
-			name = "os.execShell"
+			wantArgs = 4
+		} else {
+			wantArgs = 5
 		}
+		minArgs = wantArgs
+	}
+	if len(call.Args) < minArgs || len(call.Args) > wantArgs {
+		name := stdOsExecCallName(shell, withOptions)
 		return value{}, true, unsupportedf("call", "%s received %d arguments", name, len(call.Args))
 	}
 	cmdArg := call.Args[0]
 	if cmdArg == nil || (cmdArg.Name != "" && cmdArg.Name != "cmd" && cmdArg.Name != "command") || cmdArg.Value == nil {
-		name := "os.exec"
-		if shell {
-			name = "os.execShell"
-		}
+		name := stdOsExecCallName(shell, withOptions)
 		return value{}, true, unsupported("call", name+" requires a String command argument")
 	}
 	cmd, err := g.emitExpr(cmdArg.Value)
@@ -271,20 +377,85 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool) (value
 			return value{}, true, unsupportedf("type-system", "os.exec args type %s, want List<String>", argsValue.typ)
 		}
 	}
-	g.declareRuntimeSymbol(ostyRtOsExecSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}})
+	cwdValue := value{typ: "ptr", ref: "null"}
+	envValue := value{typ: "ptr", ref: "null"}
+	timeoutValue := value{typ: "i64", ref: "0"}
+	if withOptions {
+		argsIndex := 1
+		if !shell {
+			argsArg := call.Args[1]
+			if argsArg == nil || (argsArg.Name != "" && argsArg.Name != "args") || argsArg.Value == nil {
+				return value{}, true, unsupported("call", "os.execWith requires args as a positional or `args:` List<String> argument")
+			}
+			argsValue, err = g.emitExpr(argsArg.Value)
+			if err != nil {
+				return value{}, true, err
+			}
+			argsValue = g.protectManagedTemporary("os.execWith.args", argsValue)
+			argsValue, err = g.loadIfPointer(argsValue)
+			if err != nil {
+				return value{}, true, err
+			}
+			if argsValue.typ != "ptr" {
+				return value{}, true, unsupportedf("type-system", "os.execWith args type %s, want List<String>", argsValue.typ)
+			}
+			argsIndex = 2
+		}
+		cwdValue, err = g.emitStdOsExecPtrArg(call.Args[argsIndex], "cwd", "String", "os.execWith.cwd")
+		if err != nil {
+			return value{}, true, err
+		}
+		envValue, err = g.emitStdOsExecPtrArg(call.Args[argsIndex+1], "env", "Map<String, String>", "os.execWith.env")
+		if err != nil {
+			return value{}, true, err
+		}
+		timeoutArg := call.Args[argsIndex+2]
+		if timeoutArg == nil || (timeoutArg.Name != "" && timeoutArg.Name != "timeoutMillis") || timeoutArg.Value == nil {
+			return value{}, true, unsupported("call", "os.execWith requires a timeoutMillis Int argument")
+		}
+		timeoutValue, err = g.emitExpr(timeoutArg.Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		timeoutValue, err = g.loadIfPointer(timeoutValue)
+		if err != nil {
+			return value{}, true, err
+		}
+		if timeoutValue.typ != "i64" {
+			return value{}, true, unsupportedf("type-system", "os.execWith timeoutMillis type %s, want Int", timeoutValue.typ)
+		}
+	}
+	if withOptions {
+		g.declareRuntimeSymbol(ostyRtOsExecOptionsSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}, {typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
+	} else {
+		g.declareRuntimeSymbol(ostyRtOsExecSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}})
+	}
 	g.declareRuntimeSymbol(ostyRtOsExecResultFreeSymbol, "void", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	g.emitCallSafepointIfNeeded(emitter)
-	raw := llvmCall(emitter, "ptr", ostyRtOsExecSymbol, []*LlvmValue{
-		toOstyValue(cmd),
-		toOstyValue(argsValue),
-		llvmStdIoBoolValue(shell),
-	})
+	var raw *LlvmValue
+	if withOptions {
+		raw = llvmCall(emitter, "ptr", ostyRtOsExecOptionsSymbol, []*LlvmValue{
+			toOstyValue(cmd),
+			toOstyValue(argsValue),
+			llvmStdIoBoolValue(shell),
+			toOstyValue(cwdValue),
+			toOstyValue(envValue),
+			toOstyValue(timeoutValue),
+		})
+	} else {
+		raw = llvmCall(emitter, "ptr", ostyRtOsExecSymbol, []*LlvmValue{
+			toOstyValue(cmd),
+			toOstyValue(argsValue),
+			llvmStdIoBoolValue(shell),
+		})
+	}
 	tag := llvmLoadFromPtr(emitter, "i64", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 0))
 	exitCode := llvmLoadFromPtr(emitter, "i64", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 1))
-	stdoutText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 2))
-	stderrText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 3))
-	errText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 4))
+	timedOut := llvmLoadFromPtr(emitter, "i1", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 2))
+	stdoutText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 3))
+	stderrText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 4))
+	errText := llvmLoadFromPtr(emitter, "ptr", llvmRuntimeStructFieldPtr(emitter, stdOsExecRuntimeRecordLLVMType, raw, 5))
 	emitter.body = append(emitter.body, "  call void @"+ostyRtOsExecResultFreeSymbol+"(ptr "+raw.name+")")
 	failed := llvmCompare(emitter, "eq", tag, toOstyValue(value{typ: "i64", ref: "1"}))
 	errLabel := llvmNextLabel(emitter, "os.exec.err")
@@ -301,12 +472,24 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool) (value
 	emitter.body = append(emitter.body, "  br label %"+contLabel)
 
 	emitter.body = append(emitter.body, mirLabelText(okLabel))
-	outputInfo := ensureStdOsSyntheticOutputStruct(g)
-	outputValue := llvmStructLiteral(emitter, outputInfo.typ, []*LlvmValue{
-		exitCode,
-		stdoutText,
-		stderrText,
-	})
+	var outputInfo *structInfo
+	var outputValue *LlvmValue
+	if withOptions {
+		outputInfo = ensureStdOsSyntheticExecOutputStruct(g)
+		outputValue = llvmStructLiteral(emitter, outputInfo.typ, []*LlvmValue{
+			exitCode,
+			stdoutText,
+			stderrText,
+			timedOut,
+		})
+	} else {
+		outputInfo = ensureStdOsSyntheticOutputStruct(g)
+		outputValue = llvmStructLiteral(emitter, outputInfo.typ, []*LlvmValue{
+			exitCode,
+			stdoutText,
+			stderrText,
+		})
+	}
 	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
 		toOstyValue(value{typ: "i64", ref: "0"}),
 		outputValue,
@@ -321,10 +504,42 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool) (value
 	v := value{
 		typ:        info.typ,
 		ref:        phi,
-		sourceType: stdOsExecResultSourceTypeSingleton,
+		sourceType: resultSourceType,
 	}
 	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil
+}
+
+func stdOsExecCallName(shell bool, withOptions bool) string {
+	switch {
+	case shell && withOptions:
+		return "os.execShellWith"
+	case shell:
+		return "os.execShell"
+	case withOptions:
+		return "os.execWith"
+	default:
+		return "os.exec"
+	}
+}
+
+func (g *generator) emitStdOsExecPtrArg(arg *ast.Arg, name string, want string, label string) (value, error) {
+	if arg == nil || (arg.Name != "" && arg.Name != name) || arg.Value == nil {
+		return value{}, unsupported("call", "os.execWith requires "+name+" as a positional or `"+name+":` "+want+" argument")
+	}
+	out, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	out = g.protectManagedTemporary(label, out)
+	out, err = g.loadIfPointer(out)
+	if err != nil {
+		return value{}, err
+	}
+	if out.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "os.execWith %s type %s, want %s", name, out.typ, want)
+	}
+	return out, nil
 }
 
 func (g *generator) emitStdOsPidCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/stdlib_os_shim_test.go
+++ b/internal/llvmgen/stdlib_os_shim_test.go
@@ -34,8 +34,52 @@ fn main() {
 		"declare ptr @osty_rt_os_exec(ptr, ptr, i1)",
 		"declare void @osty_rt_os_exec_result_free(ptr)",
 		"call ptr @osty_rt_os_exec(ptr",
-		"getelementptr inbounds { i64, i64, ptr, ptr, ptr }, ptr",
+		"getelementptr inbounds { i64, i64, i1, ptr, ptr, ptr }, ptr",
 		"load i64, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdOsExecWithRoutesOptionsAndTimedOutField(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.os as os
+
+fn main() {
+    let env: Map<String, String> = {:}
+    match os.execWith("sh", ["-c", "printf hi"], "/tmp", env, 25) {
+        Ok(out) -> {
+            println(out.stdout)
+            println(out.stderr)
+            println(out.exitCode)
+            println(out.timedOut)
+        },
+        Err(err) -> println(err.message()),
+    }
+
+    match os.execShellWith("printf shell", "/tmp", env, 0) {
+        Ok(out) -> println(out.stdout),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_os_exec_with.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%__osty_std_os_ExecOutput = type { i64, ptr, ptr, i1 }",
+		"declare ptr @osty_rt_os_exec_options(ptr, ptr, i1, ptr, ptr, i64)",
+		"call ptr @osty_rt_os_exec_options(ptr",
+		"getelementptr inbounds { i64, i64, i1, ptr, ptr, ptr }, ptr",
+		"load i1, ptr",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in IR:\n%s", want, got)

--- a/internal/stdlib/cmd_test.go
+++ b/internal/stdlib/cmd_test.go
@@ -1,0 +1,53 @@
+package stdlib
+
+import "testing"
+
+func TestCmdModuleExposesAutomationBuilderSurface(t *testing.T) {
+	reg := LoadCached()
+
+	for _, name := range []string{
+		"command", "commandArgs", "shell", "pipeline", "pipe", "shellEscape", "joinEscaped",
+	} {
+		fn := reg.LookupFnDecl("cmd", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(cmd, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("cmd.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{
+		"arg", "withArgs", "withCwd", "withEnv", "withEnvMap", "withTimeoutMillis", "run", "shellLine",
+	} {
+		fn := reg.LookupMethodDecl("cmd", "Command", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(cmd, Command, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("cmd.Command.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{"ok", "check"} {
+		fn := reg.LookupMethodDecl("cmd", "RunOutput", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(cmd, RunOutput, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("cmd.RunOutput.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{
+		"stage", "withCwd", "withEnv", "withEnvMap", "withTimeoutMillis", "run", "shellLine",
+	} {
+		fn := reg.LookupMethodDecl("cmd", "Pipeline", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(cmd, Pipeline, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("cmd.Pipeline.%s body = nil, want source wrapper body", name)
+		}
+	}
+}

--- a/internal/stdlib/modules/cmd.osty
+++ b/internal/stdlib/modules/cmd.osty
@@ -1,0 +1,214 @@
+// std.cmd — automation-friendly command execution.
+//
+// `std.process` remains the abort/todo/result-helper module. OS process
+// execution lives here as a builder over the low-level `std.os` runtime
+// calls, with explicit cwd/env/timeout knobs and shell-safe pipeline
+// rendering.
+
+use std.error
+use std.os
+
+pub struct RunOutput {
+    pub exitCode: Int,
+    pub stdout: String,
+    pub stderr: String,
+    pub timedOut: Bool,
+
+    pub fn ok(self) -> Bool {
+        self.exitCode == 0 && !self.timedOut
+    }
+
+    pub fn check(self) -> Result<RunOutput, Error> {
+        if self.ok() {
+            Ok(self)
+        } else if self.timedOut {
+            Err(error.new("cmd: timed out"))
+        } else {
+            Err(error.new("cmd: exit code {self.exitCode}"))
+        }
+    }
+}
+
+pub struct Command {
+    pub program: String,
+    pub args: List<String>,
+    pub cwd: String,
+    pub env: Map<String, String>,
+    pub timeoutMillis: Int,
+    pub useShell: Bool,
+
+    pub fn arg(mut self, value: String) -> Command {
+        self.args.push(value)
+        self
+    }
+
+    pub fn withArgs(mut self, values: List<String>) -> Command {
+        self.args = values
+        self
+    }
+
+    pub fn withCwd(mut self, path: String) -> Command {
+        self.cwd = path
+        self
+    }
+
+    pub fn withEnv(mut self, name: String, value: String) -> Command {
+        self.env.insert(name, value)
+        self
+    }
+
+    pub fn withEnvMap(mut self, values: Map<String, String>) -> Command {
+        self.env = values
+        self
+    }
+
+    pub fn withTimeoutMillis(mut self, millis: Int) -> Command {
+        self.timeoutMillis = millis
+        self
+    }
+
+    pub fn run(self) -> Result<RunOutput, Error> {
+        if self.useShell {
+            fromOs(os.execShellWith(self.program, self.cwd, self.env, self.timeoutMillis))
+        } else {
+            fromOs(os.execWith(self.program, self.args, self.cwd, self.env, self.timeoutMillis))
+        }
+    }
+
+    pub fn shellLine(self) -> String {
+        if self.useShell {
+            return self.program
+        }
+        joinEscaped(self.program, self.args)
+    }
+}
+
+pub struct Pipeline {
+    pub stages: List<Command>,
+    pub cwd: String,
+    pub env: Map<String, String>,
+    pub timeoutMillis: Int,
+
+    pub fn stage(mut self, next: Command) -> Pipeline {
+        self.stages.push(next)
+        self
+    }
+
+    pub fn withCwd(mut self, path: String) -> Pipeline {
+        self.cwd = path
+        self
+    }
+
+    pub fn withEnv(mut self, name: String, value: String) -> Pipeline {
+        self.env.insert(name, value)
+        self
+    }
+
+    pub fn withEnvMap(mut self, values: Map<String, String>) -> Pipeline {
+        self.env = values
+        self
+    }
+
+    pub fn withTimeoutMillis(mut self, millis: Int) -> Pipeline {
+        self.timeoutMillis = millis
+        self
+    }
+
+    pub fn shellLine(self) -> Result<String, Error> {
+        renderPipeline(self.stages)
+    }
+
+    pub fn run(self) -> Result<RunOutput, Error> {
+        let line = renderPipeline(self.stages)?
+        fromOs(os.execShellWith(line, self.cwd, self.env, self.timeoutMillis))
+    }
+}
+
+pub fn command(program: String) -> Command {
+    Command {
+        program: program,
+        args: [],
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+        useShell: false,
+    }
+}
+
+pub fn commandArgs(program: String, args: List<String>) -> Command {
+    command(program).withArgs(args)
+}
+
+pub fn shell(line: String) -> Command {
+    Command {
+        program: line,
+        args: [],
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+        useShell: true,
+    }
+}
+
+pub fn pipeline(stages: List<Command>) -> Pipeline {
+    Pipeline {
+        stages: stages,
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+    }
+}
+
+pub fn pipe(left: Command, right: Command) -> Pipeline {
+    pipeline([left, right])
+}
+
+pub fn shellEscape(arg: String) -> String {
+    if arg.isEmpty() {
+        return "''"
+    }
+    let mut out = "'"
+    for c in arg.chars() {
+        if c == '\'' {
+            out = "{out}'\\''"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    "{out}'"
+}
+
+pub fn joinEscaped(program: String, args: List<String>) -> String {
+    let mut parts = [shellEscape(program)]
+    for arg in args {
+        parts.push(shellEscape(arg))
+    }
+    " ".join(parts)
+}
+
+fn renderPipeline(stages: List<Command>) -> Result<String, Error> {
+    if stages.len() == 0 {
+        return Err(error.new("cmd: pipeline requires at least one stage"))
+    }
+    let mut parts: List<String> = []
+    for stage in stages {
+        if stage.useShell {
+            parts.push(stage.program)
+        } else {
+            parts.push(stage.shellLine())
+        }
+    }
+    Ok(" | ".join(parts))
+}
+
+fn fromOs(result: Result<os.ExecOutput, Error>) -> Result<RunOutput, Error> {
+    match result {
+        Ok(out) -> Ok(RunOutput {
+            exitCode: out.exitCode,
+            stdout: out.stdout,
+            stderr: out.stderr,
+            timedOut: out.timedOut,
+        }),
+        Err(err) -> Err(err),
+    }
+}

--- a/internal/stdlib/modules/os.osty
+++ b/internal/stdlib/modules/os.osty
@@ -41,6 +41,13 @@ pub struct Output {
     pub stderr: String,
 }
 
+pub struct ExecOutput {
+    pub exitCode: Int,
+    pub stdout: String,
+    pub stderr: String,
+    pub timedOut: Bool,
+}
+
 pub enum Signal {
     Interrupt,
     Terminate,
@@ -50,6 +57,10 @@ pub enum Signal {
 pub fn exec(cmd: String, args: List<String> = []) -> Result<Output, Error>
 
 pub fn execShell(cmd: String) -> Result<Output, Error>
+
+pub fn execWith(cmd: String, args: List<String>, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
+
+pub fn execShellWith(cmd: String, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
 
 pub fn exit(code: Int) -> Never
 


### PR DESCRIPTION
## Summary
- add `std.cmd` as the automation-facing command builder API with cwd/env/timeout/capture helpers
- extend low-level `std.os` execution with `execWith` / `execShellWith` and timed-out output
- wire LLVM/MIR and runtime support for command execution, shell escaping, and simple pipelines

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsStd(Cmd|OsProcessSurface|OsExecWithSplitArgs)' -v`\n- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(Cmd|StdlibSupportMatrix)' -v`\n- `go test -count=1 -vet=off ./internal/llvmgen -run TestStdOs -v`\n- `git diff --check HEAD~1..HEAD`