### PR TITLE
[codex] add std.kv local store

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 71 공개 모듈. 분류 기준:
+총 72 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (67 / 71 = 94%)
+### ⭐⭐⭐⭐⭐ Production (68 / 72 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -42,6 +42,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | tokenest | 305 | pure Osty + bytes | Deneb-derived model-family-aware token estimator with explicit calibration state for Claude/OpenAI/Gemini/default |
 | httpretry | 322 | pure Osty | Deneb-derived retry/backoff decisions and LLM/provider error classification with provider codes, large-session disconnect handling, context/billing/rate-limit disambiguation, and action flags |
 | jsonl | 117 | pure Osty + json | Deneb-style JSON Lines parse/append/compact helpers |
+| kv | 459 | pure Osty + fs/json | JSONL append-log local KV: file-backed cache/history/settings store, string-first typed getters/setters, tombstone delete, compact rewrite, JSON convenience helpers |
 | shortid | 65 | pure Osty | Deneb-style `prefix_0000` deterministic short id generator |
 | metrics | 48 | pure Osty | Deneb-style labeled counter snapshots without a metrics backend |
 | net | 1084 | net 40 runtime | TCP/UDP, IPv4/IPv6, parseSocketAddr, tcpListen |
@@ -98,7 +99,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 71 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 72 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -154,6 +155,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |
+| Local KV / 설정 DB | ✅ 즉시 가능 | kv + fs + json (JSONL append-log, compact, typed getters/setters) |
 | Agent-safe logs/transcripts | ✅ 가능 | redact + security + tokenest + aiagents |
 | Local document search | ✅ 가능 | search + markdown + media + jsonl |
 | 사람이 읽는 리포트 산출물 | ✅ 가능 | report + markdown/jsonl/csv |
@@ -187,7 +189,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 48 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 49 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)

--- a/internal/backend/llvm_big_stdlib_modules_test.go
+++ b/internal/backend/llvm_big_stdlib_modules_test.go
@@ -2,7 +2,9 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -143,6 +145,63 @@ fn main() {
 		"true\n" +
 		"true\n" +
 		"true\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryRunsStdKvFileStore(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	path := filepath.Join(t.TempDir(), "cache.jsonl")
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, fmt.Sprintf(`use std.kv
+
+fn main() {
+    let store = kv.open(%q).unwrap()
+    match kv.putString(store, "name", "osty") {
+        Ok(_) -> {},
+        Err(err) -> {
+            println(err.message())
+            return
+        },
+    }
+    match kv.putInt(store, "count", 2) {
+        Ok(_) -> {},
+        Err(err) -> {
+            println(err.message())
+            return
+        },
+    }
+    println(kv.getString(store, "name").unwrap().unwrap())
+    println(kv.getInt(store, "count").unwrap().unwrap())
+    println(kv.contains(store, "name").unwrap())
+    match kv.remove(store, "name") {
+        Ok(_) -> {},
+        Err(err) -> {
+            println(err.message())
+            return
+        },
+    }
+    println(kv.contains(store, "name").unwrap())
+    println(kv.compact(store).unwrap())
+    let keys = kv.keys(store).unwrap()
+    println(keys.len())
+    println(keys[0])
+}
+`, path))
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "osty\n2\ntrue\nfalse\n1\n1\ncount\n"
 	if got := string(output); got != want {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -304,8 +304,8 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 	if mod == nil || reg == nil {
 		return nil, nil
 	}
-	reachedFns := ReachableStdlibFns(mod, reg)
-	reachedMethods := ReachableStdlibMethods(mod, reg)
+	reachedFns := bodyfulStdlibFns(ReachableStdlibFns(mod, reg))
+	reachedMethods := bodyfulStdlibMethods(ReachableStdlibMethods(mod, reg))
 	if len(reachedFns) == 0 && len(reachedMethods) == 0 {
 		return nil, nil
 	}
@@ -378,6 +378,10 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			if calleeFn == nil {
 				continue
 			}
+			if calleeFn.Body == nil {
+				rewriteBareIdentCalls(next.fn, callName, CanonicalStdlibSymbol(next.module, callName))
+				continue
+			}
 			k := fnKey{module: next.module, name: callName}
 			if injectedFn[k] {
 				// Already injected — just rewrite this body's
@@ -408,6 +412,10 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			if calleeFn == nil {
 				continue
 			}
+			if calleeFn.Body == nil {
+				rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, CanonicalStdlibSymbol(calleeModule, ref.Name))
+				continue
+			}
 			k := fnKey{module: calleeModule, name: ref.Name}
 			if injectedFn[k] {
 				rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, StdlibSymbol(calleeModule, ref.Name))
@@ -428,6 +436,9 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			queue = append(queue, loweredFromModule{module: calleeModule, fn: lowered})
 		}
 		for _, m := range reachableStdlibMethodsInFn(next.fn, reg) {
+			if m.Fn == nil || m.Fn.Body == nil {
+				continue
+			}
 			k := methodKey{module: m.Module, typeName: m.Type, method: m.Method}
 			if injectedMethod[k] {
 				rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
@@ -450,6 +461,34 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 	}
 	qualifyStdlibCallsiteTypes(mod, out)
 	return out, issues
+}
+
+func bodyfulStdlibFns(in []ReachableStdlibFn) []ReachableStdlibFn {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ReachableStdlibFn, 0, len(in))
+	for _, r := range in {
+		if r.Fn == nil || r.Fn.Body == nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func bodyfulStdlibMethods(in []ReachableStdlibMethod) []ReachableStdlibMethod {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ReachableStdlibMethod, 0, len(in))
+	for _, r := range in {
+		if r.Fn == nil || r.Fn.Body == nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 func reachableStdlibMethodsInFn(fn *ir.FnDecl, reg *stdlib.Registry) []ReachableStdlibMethod {

--- a/internal/backend/stdlib_inject_e2e_test.go
+++ b/internal/backend/stdlib_inject_e2e_test.go
@@ -378,6 +378,46 @@ func TestInjectReachableStdlibBodiesTransitiveDedupe(t *testing.T) {
 	}
 }
 
+func TestInjectReachableStdlibBodiesSkipsBodylessRuntimeBackedDecls(t *testing.T) {
+	reg := stdlib.LoadCached()
+	fsCall := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "fs"}, Name: "writeString"},
+		Args: []ir.Arg{
+			{Value: irString("out.txt")},
+			{Value: irString("hello")},
+		},
+	}
+	osCall := &ir.MethodCall{
+		Receiver: &ir.Ident{Name: "path", T: &ir.NamedType{Package: "os", Name: "Path"}},
+		Name:     "dirname",
+		Args:     []ir.Arg{{Value: irString("one/two")}},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: fsCall},
+			&ir.ExprStmt{X: osCall},
+		},
+	}
+	injected, issues := injectReachableStdlibBodies(mod, reg)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %v, want none for bodyless stdlib decls", issues)
+	}
+	if len(injected) != 0 {
+		t.Fatalf("injected = %v, want no bodyless runtime-backed decls", fnDeclNames(injected))
+	}
+	if _, ok := fsCall.Callee.(*ir.FieldExpr); !ok {
+		t.Fatalf("fs.writeString callsite was rewritten; want runtime-backed call left intact")
+	}
+	if osCall.Name != "dirname" {
+		t.Fatalf("os.Path.dirname method call was rewritten; want runtime-backed method left intact")
+	}
+}
+
+func irString(value string) *ir.StringLit {
+	return &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: value}}}
+}
+
 func fnDeclNames(decls []ir.Decl) []string {
 	out := []string{}
 	for _, d := range decls {

--- a/internal/backend/stdlib_kv_check_test.go
+++ b/internal/backend/stdlib_kv_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultKv(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "kv")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(kv) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("kv module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -20,6 +20,13 @@ func StdlibSymbol(module, name string) string {
 	return "osty_std_" + module + "__" + name
 }
 
+// CanonicalStdlibSymbol returns the MIR-visible symbol for bodyless
+// runtime-backed stdlib declarations that must stay routed through
+// backend shims rather than injected as Osty source bodies.
+func CanonicalStdlibSymbol(module, name string) string {
+	return "std." + module + "." + name
+}
+
 // StdlibMethodSymbol returns the mangled IR name for a stdlib struct/
 // enum method lowered into a free-function helper alongside user code.
 // The scheme is `osty_std_<module>__<type>__<method>`, extending

--- a/internal/ir/monomorph_snapshot.go
+++ b/internal/ir/monomorph_snapshot.go
@@ -119,7 +119,7 @@ func MonomorphPrimCode(name string) string {
 	if name == "Char" {
 		return "w"
 	}
-	if name == "Unit" {
+	if name == "Unit" || name == "()" {
 		return "v"
 	}
 	// Osty `String` and `Bytes` are opaque aggregates at IR level but

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -574,6 +574,12 @@ func TestMonomorphMangleTypeEnumMaybeInt(t *testing.T) {
 	}
 }
 
+func TestTypeCodeOfUnitPrimitiveUsesValidCode(t *testing.T) {
+	if got := typeCodeOf(TUnit, "main"); got != "v" {
+		t.Fatalf("typeCodeOf(Unit): got %q, want %q", got, "v")
+	}
+}
+
 func TestMonomorphMangleTypeNamePartMatches(t *testing.T) {
 	// The symbol must be decomposable as `_ZTS` + <nested-template-name>.
 	req := NewMonomorphTypeRequest("main", "Box", []string{"b"})

--- a/internal/stdlib/kv_test.go
+++ b/internal/stdlib/kv_test.go
@@ -1,0 +1,71 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestKvModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["kv"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.kv not loaded")
+	}
+	for _, name := range []string{
+		"open", "ensure",
+		"entry", "entryAt", "tombstone", "tombstoneAt",
+		"text", "integer", "float", "boolean", "nullValue",
+		"encodeEntry", "parseEntry", "parseLog", "replay", "inMemory",
+		"load", "snapshot", "keys", "get", "getString", "getInt", "getFloat", "getBool", "getJson", "contains",
+		"put", "putAt", "putString", "putInt", "putFloat", "putBool",
+		"putJson", "remove", "removeAt", "deleteKey", "clear", "compact", "encodeSnapshot", "appendEntry",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.kv missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.kv.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.kv.%s not public", name)
+		}
+	}
+	for _, name := range []string{"Store", "Entry", "Snapshot"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.kv missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.kv.%s not public", name)
+		}
+	}
+}
+
+func TestKvModuleSourcePinsJsonlFileBackedBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["kv"]
+	if mod == nil {
+		t.Fatal("std.kv module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`use std.fs`,
+		`use std.json`,
+		`pub fn putAt(store: Store, key: String, value: String, updatedAtMs: Int) -> Result<(), Error>`,
+		`pub fn compact(store: Store) -> Result<Int, Error>`,
+		`pub fn getString(store: Store, key: String) -> Result<String?, Error>`,
+		`pub fn getJson(store: Store, key: String) -> Result<json.Json?, Error>`,
+		`fn decodeJsonString(chars: List<Char>, start: Int) -> Result<String, Error>`,
+		`values.remove(item.key)`,
+		`fs.writeString(store.path, next)?`,
+		`fn parentDir(path: String) -> String`,
+		`append-log format`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.kv source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/kv.osty
+++ b/internal/stdlib/modules/kv.osty
@@ -1,0 +1,459 @@
+// std.kv - local JSONL-backed key-value stores.
+//
+// This is intentionally file-backed rather than driver-backed: it gives
+// Osty programs a practical local cache/history/settings store today,
+// while keeping a small append-log format that can later be mirrored by
+// a native SQLite backend without changing most call sites.
+use std.error
+use std.fs
+use std.json
+use std.strings
+pub struct Store {
+    pub path: String,
+}
+pub struct Entry {
+    pub key: String,
+    pub value: String,
+    pub deleted: Bool,
+    pub updatedAtMs: Int = 0,
+}
+pub struct Snapshot {
+    pub values: Map<String, String>,
+    pub records: Int,
+    pub tombstones: Int,
+}
+pub fn open(path: String) -> Result<Store, Error> {
+    let clean = strings.trimSpace(path)
+    validatePath(clean)?
+    Ok(Store {path: clean})
+}
+pub fn ensure(store: Store) -> Result<(), Error> {
+    ensureParent(store.path)?
+    if !fs.exists(store.path) {
+        fs.writeString(store.path, "")?
+    }
+    Ok(())
+}
+pub fn entry(key: String, value: String) -> Result<Entry, Error> {
+    entryAt(key, value, 0)
+}
+pub fn entryAt(key: String, value: String, updatedAtMs: Int) -> Result<Entry, Error> {
+    let clean = strings.trimSpace(key)
+    validateKey(clean)?
+    Ok(Entry {key: clean, value: value, deleted: false, updatedAtMs: updatedAtMs})
+}
+pub fn tombstone(key: String) -> Result<Entry, Error> {
+    tombstoneAt(key, 0)
+}
+pub fn tombstoneAt(key: String, updatedAtMs: Int) -> Result<Entry, Error> {
+    let clean = strings.trimSpace(key)
+    validateKey(clean)?
+    Ok(Entry {key: clean, value: "", deleted: true, updatedAtMs: updatedAtMs})
+}
+pub fn text(value: String) -> String {
+    value
+}
+pub fn integer(value: Int) -> String {
+    value.toString()
+}
+pub fn float(value: Float) -> String {
+    value.toString()
+}
+pub fn boolean(value: Bool) -> String {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+pub fn nullValue() -> String {
+    "null"
+}
+pub fn encodeEntry(item: Entry) -> String {
+    let open = "\{"
+    let close = "\}"
+    let deleted = if item.deleted {
+        "true"
+    } else {
+        "false"
+    }
+    let mut out = "{open}\"deleted\":{deleted},\"key\":{jsonQuote(item.key)},\"updatedAtMs\":{item.updatedAtMs}"
+    out = "{out},\"value\":{jsonQuote(item.value)}"
+    "{out}{close}"
+}
+pub fn parseEntry(line: String) -> Result<Entry, Error> {
+    let trimmed = strings.trimSpace(line)
+    if trimmed.isEmpty() {
+        return Err(error.new("kv: empty log line"))
+    }
+    let key = stringField(trimmed, "key")?
+    let deleted = boolField(trimmed, "deleted", false)?
+    let updatedAtMs = intField(trimmed, "updatedAtMs", 0)?
+    let value = stringField(trimmed, "value")?
+    let clean = strings.trimSpace(key)
+    validateKey(clean)?
+    Ok(Entry {key: clean, value: value, deleted: deleted, updatedAtMs: updatedAtMs})
+}
+pub fn parseLog(text: String) -> Result<List<Entry>, Error> {
+    let mut out: List<Entry> = []
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if trimmed.isEmpty() {
+            continue
+        }
+        out.push(parseEntry(trimmed)?)
+    }
+    Ok(out)
+}
+pub fn replay(entries: List<Entry>) -> Snapshot {
+    let mut values: Map<String, String> = {:}
+    let mut tombstones = 0
+    for item in entries {
+        if item.deleted {
+            values.remove(item.key)
+            tombstones = tombstones + 1
+        } else {
+            values.insert(item.key, item.value)
+        }
+    }
+    Snapshot {values: values, records: entries.len(), tombstones: tombstones}
+}
+pub fn inMemory(values: Map<String, String>) -> Snapshot {
+    Snapshot {values: values, records: values.len(), tombstones: 0}
+}
+pub fn load(store: Store) -> Result<Snapshot, Error> {
+    let text = readLog(store)?
+    Ok(replay(parseLog(text)?))
+}
+pub fn snapshot(store: Store) -> Result<Snapshot, Error> {
+    load(store)
+}
+pub fn keys(store: Store) -> Result<List<String>, Error> {
+    let snap = load(store)?
+    Ok(snap.values.keys().sorted())
+}
+pub fn get(store: Store, key: String) -> Result<String?, Error> {
+    let clean = strings.trimSpace(key)
+    validateKey(clean)?
+    let snap = load(store)?
+    Ok(snap.values.get(clean))
+}
+pub fn getString(store: Store, key: String) -> Result<String?, Error> {
+    get(store, key)
+}
+pub fn getInt(store: Store, key: String) -> Result<Int?, Error> {
+    match get(store, key)? {
+        Some(value) -> Ok(Some(strings.toInt(value)?)),
+        None -> Ok(noneInt()),
+    }
+}
+pub fn getFloat(store: Store, key: String) -> Result<Float?, Error> {
+    match get(store, key)? {
+        Some(value) -> Ok(Some(strings.toFloat(value)?)),
+        None -> Ok(noneFloat()),
+    }
+}
+pub fn getBool(store: Store, key: String) -> Result<Bool?, Error> {
+    match get(store, key)? {
+        Some(value) -> {
+            if value == "true" {
+                Ok(Some(true))
+            } else if value == "false" {
+                Ok(Some(false))
+            } else {
+                Err(error.new("kv: expected bool value"))
+            }
+        },
+        None -> Ok(noneBool()),
+    }
+}
+pub fn getJson(store: Store, key: String) -> Result<json.Json?, Error> {
+    match get(store, key)? {
+        Some(value) -> Ok(Some(json.parseValue(value)?)),
+        None -> Ok(noneJson()),
+    }
+}
+pub fn contains(store: Store, key: String) -> Result<Bool, Error> {
+    let value = get(store, key)?
+    Ok(value.isSome())
+}
+pub fn put(store: Store, key: String, value: String) -> Result<(), Error> {
+    putAt(store, key, value, 0)
+}
+pub fn putAt(store: Store, key: String, value: String, updatedAtMs: Int) -> Result<(), Error> {
+    appendEntry(store, entryAt(key, value, updatedAtMs)?)
+}
+pub fn putString(store: Store, key: String, value: String) -> Result<(), Error> {
+    put(store, key, value)
+}
+pub fn putInt(store: Store, key: String, value: Int) -> Result<(), Error> {
+    put(store, key, integer(value))
+}
+pub fn putFloat(store: Store, key: String, value: Float) -> Result<(), Error> {
+    put(store, key, float(value))
+}
+pub fn putBool(store: Store, key: String, value: Bool) -> Result<(), Error> {
+    put(store, key, boolean(value))
+}
+pub fn putJson(store: Store, key: String, value: json.Json) -> Result<(), Error> {
+    put(store, key, json.stringifyValue(value))
+}
+pub fn remove(store: Store, key: String) -> Result<(), Error> {
+    removeAt(store, key, 0)
+}
+pub fn removeAt(store: Store, key: String, updatedAtMs: Int) -> Result<(), Error> {
+    appendEntry(store, tombstoneAt(key, updatedAtMs)?)
+}
+pub fn deleteKey(store: Store, key: String) -> Result<(), Error> {
+    remove(store, key)
+}
+pub fn clear(store: Store) -> Result<(), Error> {
+    ensureParent(store.path)?
+    fs.writeString(store.path, "")?
+    Ok(())
+}
+pub fn compact(store: Store) -> Result<Int, Error> {
+    let snap = load(store)?
+    let text = encodeSnapshot(snap)
+    ensureParent(store.path)?
+    fs.writeString(store.path, text)?
+    Ok(snap.values.len())
+}
+pub fn encodeSnapshot(snap: Snapshot) -> String {
+    let mut out = ""
+    for key in snap.values.keys().sorted() {
+        let value = snap.values.get(key).unwrap()
+        out = appendLine(out, encodeEntry(entryAt(key, value, 0).unwrap()))
+    }
+    out
+}
+pub fn appendEntry(store: Store, item: Entry) -> Result<(), Error> {
+    ensureParent(store.path)?
+    let current = readLog(store)?
+    let next = appendLine(current, encodeEntry(item))
+    fs.writeString(store.path, next)?
+    Ok(())
+}
+fn readLog(store: Store) -> Result<String, Error> {
+    validatePath(store.path)?
+    if !fs.exists(store.path) {
+        return Ok("")
+    }
+    fs.readToString(store.path)
+}
+fn appendLine(text: String, line: String) -> String {
+    if text.isEmpty() {
+        return line
+    }
+    "{text}\n{line}"
+}
+fn stringField(text: String, name: String) -> Result<String, Error> {
+    let needle = "\"{name}\":"
+    let at = match strings.indexOf(text, needle) {
+        Some(i) -> i,
+        None -> {
+            return Err(error.new("kv: missing field: {name}"))
+        },
+    }
+    let chars = text.chars()
+    let mut pos = at + needle.len()
+    pos = skipSpaces(chars, pos)
+    if pos >= chars.len() || chars[pos] != '"' {
+        return Err(error.new("kv: expected string field: {name}"))
+    }
+    decodeJsonString(chars, pos + 1)
+}
+fn boolField(text: String, name: String, defaultValue: Bool) -> Result<Bool, Error> {
+    let raw = rawField(text, name)?
+    if raw.isEmpty() {
+        return Ok(defaultValue)
+    }
+    if raw == "true" {
+        return Ok(true)
+    }
+    if raw == "false" {
+        return Ok(false)
+    }
+    Err(error.new("kv: expected bool field: {name}"))
+}
+fn intField(text: String, name: String, defaultValue: Int) -> Result<Int, Error> {
+    let raw = rawField(text, name)?
+    if raw.isEmpty() {
+        return Ok(defaultValue)
+    }
+    strings.toInt(raw)
+}
+fn rawField(text: String, name: String) -> Result<String, Error> {
+    let needle = "\"{name}\":"
+    let at = match strings.indexOf(text, needle) {
+        Some(i) -> i,
+        None -> {
+            return Ok("")
+        },
+    }
+    let chars = text.chars()
+    let mut pos = at + needle.len()
+    pos = skipSpaces(chars, pos)
+    let start = pos
+    for pos < chars.len() && chars[pos] != ',' && chars[pos] != '}' {
+        pos = pos + 1
+    }
+    Ok(strings.trimSpace(text[start..pos]))
+}
+fn skipSpaces(chars: List<Char>, pos: Int) -> Int {
+    let mut i = pos
+    for i < chars.len() && (chars[i] == ' ' || chars[i] == '\t' || chars[i] == '\n' || chars[i] == '\r') {
+        i = i + 1
+    }
+    i
+}
+fn decodeJsonString(chars: List<Char>, start: Int) -> Result<String, Error> {
+    let mut out = ""
+    let mut i = start
+    for i < chars.len() {
+        let c = chars[i]
+        if c == '"' {
+            return Ok(out)
+        }
+        if c == '\\' {
+            if i + 1 >= chars.len() {
+                return Err(error.new("kv: unterminated escape"))
+            }
+            let e = chars[i + 1]
+            if e == '"' {
+                out = "{out}\""
+                i = i + 2
+            } else if e == '\\' {
+                out = "{out}\\"
+                i = i + 2
+            } else if e == 'n' {
+                out = "{out}\n"
+                i = i + 2
+            } else if e == 'r' {
+                out = "{out}\r"
+                i = i + 2
+            } else if e == 't' {
+                out = "{out}\t"
+                i = i + 2
+            } else if e == 'u' {
+                if i + 5 >= chars.len() {
+                    return Err(error.new("kv: short unicode escape"))
+                }
+                out = "{out}{decodeUnicodeEscape(chars, i + 2)?}"
+                i = i + 6
+            } else {
+                return Err(error.new("kv: unsupported escape"))
+            }
+        } else {
+            out = "{out}{c}"
+            i = i + 1
+        }
+    }
+    Err(error.new("kv: unterminated string field"))
+}
+fn decodeUnicodeEscape(chars: List<Char>, start: Int) -> Result<String, Error> {
+    let mut value = 0
+    for i in start..start + 4 {
+        value = value * 16 + hexValue(chars[i])?
+    }
+    let c = value.toChar()
+    Ok("{c}")
+}
+fn hexValue(c: Char) -> Result<Int, Error> {
+    if c >= '0' && c <= '9' {
+        return Ok(c.toInt() - '0'.toInt())
+    }
+    if c >= 'a' && c <= 'f' {
+        return Ok(c.toInt() - 'a'.toInt() + 10)
+    }
+    if c >= 'A' && c <= 'F' {
+        return Ok(c.toInt() - 'A'.toInt() + 10)
+    }
+    Err(error.new("kv: invalid hex escape"))
+}
+fn noneInt() -> Int? {
+    None
+}
+fn noneFloat() -> Float? {
+    None
+}
+fn noneBool() -> Bool? {
+    None
+}
+fn noneJson() -> json.Json? {
+    None
+}
+fn validatePath(path: String) -> Result<(), Error> {
+    if path.isEmpty() {
+        return Err(error.new("kv: path is empty"))
+    }
+    for c in path.chars() {
+        if c.toInt() == 0 {
+            return Err(error.new("kv: path contains NUL"))
+        }
+    }
+    Ok(())
+}
+fn validateKey(key: String) -> Result<(), Error> {
+    if key.isEmpty() {
+        return Err(error.new("kv: key is empty"))
+    }
+    for c in key.chars() {
+        if c.toInt() < 0x20 {
+            return Err(error.new("kv: key contains control character"))
+        }
+    }
+    Ok(())
+}
+fn ensureParent(path: String) -> Result<(), Error> {
+    let dir = parentDir(path)
+    if dir.isEmpty() || dir == "." || dir == path {
+        return Ok(())
+    }
+    fs.mkdirAll(dir)
+}
+fn parentDir(path: String) -> String {
+    let chars = path.chars()
+    let mut last = -1
+    for i in 0..chars.len() {
+        if chars[i] == '/' || chars[i] == '\\' {
+            last = i
+        }
+    }
+    if last < 0 {
+        return ""
+    }
+    if last == 0 {
+        return path[0..1]
+    }
+    path[0..last]
+}
+fn jsonQuote(text: String) -> String {
+    let mut out = "\""
+    for c in text.chars() {
+        if c == '"' {
+            out = "{out}\\\""
+        } else if c == '\\' {
+            out = "{out}\\\\"
+        } else if c == '\n' {
+            out = "{out}\\n"
+        } else if c == '\r' {
+            out = "{out}\\r"
+        } else if c == '\t' {
+            out = "{out}\\t"
+        } else if c.toInt() < 0x20 {
+            out = "{out}\\u{hex4(c.toInt())}"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    "{out}\""
+}
+fn hex4(value: Int) -> String {
+    let digits = "0123456789abcdef"
+    let a = digits[(value >> 12) & 0x0F]
+    let b = digits[(value >> 8) & 0x0F]
+    let c = digits[(value >> 4) & 0x0F]
+    let d = digits[value & 0x0F]
+    "{a}{b}{c}{d}"
+}

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -90,7 +90,7 @@ pub fn monomorphPrimCode(name: String) -> String {
     if name == "Char" {
         return "w"
     }
-    if name == "Unit" {
+    if name == "Unit" || name == "()" {
         return "v"
     }
     // Osty string & byte slice are opaque aggregates at the IR level.


### PR DESCRIPTION
## Summary
- add `std.kv`, a JSONL append-log local key-value store for cache/history/settings use cases
- add typed getters/setters, tombstone delete, compact rewrite, and JSON convenience helpers
- keep runtime-backed stdlib declarations out of pure-body injection and fix Unit type-code mangling for `Result<(), Error>`
- update the stdlib matrix and pin stdlib/backend coverage

## Validation
- `go run ./cmd/osty fmt --check internal/stdlib/modules/kv.osty && go run ./cmd/osty check internal/stdlib/modules/kv.osty`
- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(Kv|StdlibSupportMatrix)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'Test(StdlibCheckResultKv|InjectReachableStdlibBodiesSkipsBodylessRuntimeBackedDecls|LLVMBackendBinaryRunsStdKvFileStore)' -v`
- `go test -count=1 -vet=off ./internal/ir -run 'Test(TypeCodeOfUnitPrimitiveUsesValidCode|MonomorphMangleType|TypeCodeOfBuiltinArgKeepsQualifiedNamedPackage)' -v`
- `git diff --check HEAD~1..HEAD`