### PR TITLE
[codex] add aidev workflow layer

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 77 공개 모듈. 분류 기준:
+총 78 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (74 / 77 = 96%)
+### ⭐⭐⭐⭐⭐ Production (75 / 78 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -38,6 +38,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | aidev.prompt | 267 | pure Osty + aidev/redact/tokenest | Prompt material builders: compact/redacted fix prompts, review prompts, trust-labeled sections, token estimates, patch contract rules |
 | aidev.corpus | 366 | pure Osty + aidev/jsonl | JSONL-friendly repair corpus records: failing cases, repair attempts, before/after summaries, residual diagnostics, and corpus stats |
 | aidev.verify | 449 | pure Osty + aidev | Verification contract: command plans, host result records, required-check accounting, accept/retry/reject decisions, and report summaries |
+| aidev.workflow | 241 | pure Osty + aidev/prompt/corpus/verify | End-to-end AI coding workflow records: diagnostics to prompt, patch proposal, verification report, corpus append, and run summaries |
 | redact | 746 | pure Osty | Deneb-derived secret redaction: vendor tokens, JWTs, URL query/form distinction, JSON/env/key-value, DB URLs, URL userinfo, Telegram/Discord/phone/private-key handling |
 | media | 617 | pure Osty + bytes | Deneb-derived MIME sniffing: magic bytes, icon/ftyp/OOXML ZIP, binary sampling, archive path safety, YouTube + MEDIA token helpers with file:// normalization/directive stripping |
 | security | 483 | pure Osty + url/net | Deneb-derived SSRF-safe URL checks, numeric IPv4 bypass detection, balanced URL-tail cleanup, safe link extraction, HTML escape, session-key validation |
@@ -106,7 +107,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (3 / 77 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 78 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -161,7 +162,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |
 | Local KV / 설정 DB | ✅ 즉시 가능 | kv + fs + json (JSONL append-log, compact, typed getters/setters) |
-| AI code assist loop | ✅ 가능 | aidev + aidev.osty + aidev.prompt + aidev.corpus + aidev.verify (diagnostic model / source spans / fix context / patch validation / Osty source-habit hints / compact prompt material / repair corpus records / verification plans and decisions) |
+| AI code assist loop | ✅ 가능 | aidev + aidev.osty + aidev.prompt + aidev.corpus + aidev.verify + aidev.workflow (diagnostic model / source spans / fix context / patch validation / Osty source-habit hints / compact prompt material / repair corpus records / verification plans and decisions / end-to-end run records) |
 | Agent-safe logs/transcripts | ✅ 가능 | redact + security + tokenest + aiagents |
 | Local document search | ✅ 가능 | search + markdown + media + jsonl |
 | 사람이 읽는 리포트 산출물 | ✅ 가능 | report + markdown/jsonl/csv |
@@ -195,7 +196,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 54 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 55 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
@@ -263,7 +264,7 @@ stdlib audit 중 발견된 *진짜 자랑할 만한* 디자인 패턴:
 10. **`collections.windowed(size, step)`** — sliding window. Rust std 에 없음 (itertools 만)
 11. **`ai.chatHttpRequest` + `sendChat` + `ToolCall` / `ToolResult` + provider별 parser** — OpenAI-compatible / OpenRouter / Anthropic / Gemini / local runtime 연동과 tool loop 를 앱마다 JSON 문자열로 재발명하지 않아도 됨
 12. **`aiagents.ToolPreset` + `SafetyPolicy` + `rankLines`** — Deneb 의존성 없는 agent runtime 규칙을 stdlib 표면으로 포팅. chat-only/web-only 모드와 로그/도구출력 compaction trust boundary 를 앱마다 재발명하지 않아도 됨
-13. **`aidev.SourceSpan` + `Patch` + `FixContext` + `prompt.PromptBundle` + `corpus.RepairAttempt` + `verify.VerifyReport`** — AI 코드 작성 루프를 문자열 로그가 아니라 진단/소스 범위/수정 계획/패치 검증/프롬프트 재료/수리 코퍼스/검증 판정이라는 구조화된 stdlib 계약으로 다룸
+13. **`aidev.SourceSpan` + `Patch` + `FixContext` + `prompt.PromptBundle` + `corpus.RepairAttempt` + `verify.VerifyReport` + `workflow.WorkflowRun`** — AI 코드 작성 루프를 문자열 로그가 아니라 진단/소스 범위/수정 계획/패치 검증/프롬프트 재료/수리 코퍼스/검증 판정/전체 실행 기록이라는 구조화된 stdlib 계약으로 다룸
 14. **`redact` + `security` + `search` + `media` + `tokenest`** — Deneb 에서 "의존성 없이 어렵다" 쪽을 자체 구현한 부분을 stdlib 로 승격. secret 누출 방지, SSRF 우회 차단, local FTS 대체, magic-byte media sniffing, multilingual token budget 계산을 앱마다 재발명하지 않아도 됨
 
 ## 8. 다음 라운드 후보

--- a/internal/backend/stdlib_aidev_check_test.go
+++ b/internal/backend/stdlib_aidev_check_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStdlibCheckResultAidev(t *testing.T) {
 	reg := stdlib.LoadCached()
-	for _, module := range []string{"aidev", "aidev.osty", "aidev.prompt", "aidev.corpus", "aidev.verify"} {
+	for _, module := range []string{"aidev", "aidev.osty", "aidev.prompt", "aidev.corpus", "aidev.verify", "aidev.workflow"} {
 		t.Run(module, func(t *testing.T) {
 			chk := stdlibCheckResult(reg, module)
 			if chk == nil {

--- a/internal/stdlib/aidev_test.go
+++ b/internal/stdlib/aidev_test.go
@@ -259,6 +259,55 @@ func TestAidevVerifyModuleSurface(t *testing.T) {
 	}
 }
 
+func TestAidevWorkflowModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["aidev.workflow"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		t.Fatalf("std.aidev.workflow not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
+	}
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"WorkflowStage", resolve.SymEnum},
+		{"WorkflowStatus", resolve.SymEnum},
+		{"WorkflowStep", resolve.SymStruct},
+		{"WorkflowDraft", resolve.SymStruct},
+		{"WorkflowProposal", resolve.SymStruct},
+		{"WorkflowRun", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.aidev.workflow missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.aidev.workflow.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.aidev.workflow.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"step", "startDefault", "start", "buildContext", "defaultVerifyPlan",
+		"propose", "proposalFromResult", "complete", "completeWithReport",
+		"recordAttempt", "statusForDecision", "isOstyFile", "sourceHabit",
+		"summarizeDraft", "summarizeProposal", "summarizeRun", "formatSteps",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.aidev.workflow missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.aidev.workflow.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.aidev.workflow.%s not public", name)
+		}
+	}
+}
+
 func TestAidevSourcePinsAgentCodingLoopPrimitives(t *testing.T) {
 	src := aidevModuleSource(t)
 	for _, want := range []string{
@@ -360,6 +409,29 @@ func TestAidevSourcePinsAgentCodingLoopPrimitives(t *testing.T) {
 			t.Fatalf("std.aidev.verify source missing %q", want)
 		}
 	}
+
+	workflowSrc := aidevWorkflowModuleSource(t)
+	for _, want := range []string{
+		"end-to-end AI coding workflow records",
+		"diagnostics -> prompt -> patch ->",
+		"pub enum WorkflowStage",
+		"pub enum WorkflowStatus",
+		"pub struct WorkflowDraft",
+		"pub struct WorkflowProposal",
+		"pub struct WorkflowRun",
+		"pub fn startDefault",
+		"pub fn propose",
+		"pub fn complete",
+		"pub fn recordAttempt",
+		"pub fn summarizeRun",
+		"prompt.buildFixPrompt",
+		"verify.buildReport",
+		"corpus.repairAttempt",
+	} {
+		if !strings.Contains(workflowSrc, want) {
+			t.Fatalf("std.aidev.workflow source missing %q", want)
+		}
+	}
 }
 
 func TestAidevImportsResolveMVPWorkflow(t *testing.T) {
@@ -369,6 +441,7 @@ use std.aidev.osty as ostydev
 use std.aidev.prompt as prompt
 use std.aidev.corpus as corpus
 use std.aidev.verify as verify
+use std.aidev.workflow as workflow
 
 pub fn demo() -> prompt.PromptBundle {
     let file = aidev.sourceFile("main.osty", "osty", "println old")
@@ -386,6 +459,10 @@ pub fn demo() -> prompt.PromptBundle {
     let vplan = verify.stdlibAidevPlan()
     let report = verify.buildReport(vplan, [verify.passed("gotest:./internal/stdlib:TestAidev")], [diag], [], applied)
     let _ = verify.summarizeReport(report)
+    let draft = workflow.startDefault("case_0002", "workflow unknown symbol", file, [diag])
+    let proposal = workflow.propose(draft, p)
+    let run = workflow.complete(proposal, [verify.passed("tokens:main.osty"), verify.passed("check:main.osty")], [], [], "")
+    let _ = workflow.summarizeRun(run)
     prompt.buildFixPromptDefault(context)
 }
 `
@@ -448,6 +525,16 @@ func aidevVerifyModuleSource(t *testing.T) string {
 	mod := reg.Modules["aidev.verify"]
 	if mod == nil {
 		t.Fatal("stdlib aidev.verify module missing")
+	}
+	return string(mod.Source)
+}
+
+func aidevWorkflowModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["aidev.workflow"]
+	if mod == nil {
+		t.Fatal("stdlib aidev.workflow module missing")
 	}
 	return string(mod.Source)
 }

--- a/internal/stdlib/modules/aidev/workflow.osty
+++ b/internal/stdlib/modules/aidev/workflow.osty
@@ -1,0 +1,241 @@
+// std.aidev.workflow - end-to-end AI coding workflow records.
+//
+// Hosts still call models, run commands, and write files. This module ties the
+// std.aidev family into one typed loop: diagnostics -> prompt -> patch ->
+// verification -> corpus record.
+
+use std.aidev as aidev
+use std.aidev.corpus as corpus
+use std.aidev.osty as ostydev
+use std.aidev.prompt as prompt
+use std.aidev.verify as verify
+use std.strings
+
+pub enum WorkflowStage {
+    StageDiagnose,
+    StagePrompt,
+    StagePatch,
+    StageVerify,
+    StageRecord,
+
+    pub fn toString(self) -> String {
+        match self {
+            StageDiagnose -> "diagnose",
+            StagePrompt   -> "prompt",
+            StagePatch    -> "patch",
+            StageVerify   -> "verify",
+            StageRecord   -> "record",
+        }
+    }
+}
+
+pub enum WorkflowStatus {
+    WorkflowPlanned,
+    WorkflowPromptReady,
+    WorkflowPatchReady,
+    WorkflowPatchRejected,
+    WorkflowVerified,
+    WorkflowRecorded,
+    WorkflowRetry,
+    WorkflowRejected,
+    WorkflowInvestigate,
+
+    pub fn toString(self) -> String {
+        match self {
+            WorkflowPlanned       -> "planned",
+            WorkflowPromptReady   -> "prompt_ready",
+            WorkflowPatchReady    -> "patch_ready",
+            WorkflowPatchRejected -> "patch_rejected",
+            WorkflowVerified      -> "verified",
+            WorkflowRecorded      -> "recorded",
+            WorkflowRetry         -> "retry",
+            WorkflowRejected      -> "rejected",
+            WorkflowInvestigate   -> "investigate",
+        }
+    }
+
+    pub fn isTerminal(self) -> Bool {
+        self == WorkflowRecorded || self == WorkflowRejected || self == WorkflowPatchRejected
+    }
+}
+
+pub struct WorkflowStep {
+    pub stage: WorkflowStage,
+    pub status: WorkflowStatus,
+    pub summary: String,
+}
+
+pub struct WorkflowDraft {
+    pub id: String,
+    pub caseItem: corpus.CorpusCase,
+    pub context: aidev.FixContext,
+    pub promptBundle: prompt.PromptBundle,
+    pub verifyPlan: verify.VerifyPlan,
+    pub status: WorkflowStatus,
+    pub steps: List<WorkflowStep> = [],
+}
+
+pub struct WorkflowProposal {
+    pub draft: WorkflowDraft,
+    pub patch: aidev.Patch,
+    pub patchResult: aidev.PatchResult,
+    pub status: WorkflowStatus,
+    pub steps: List<WorkflowStep> = [],
+}
+
+pub struct WorkflowRun {
+    pub draft: WorkflowDraft,
+    pub patch: aidev.Patch,
+    pub patchResult: aidev.PatchResult,
+    pub verifyReport: verify.VerifyReport,
+    pub attempt: corpus.RepairAttempt,
+    pub log: String,
+    pub status: WorkflowStatus,
+    pub steps: List<WorkflowStep> = [],
+}
+
+pub fn step(stage: WorkflowStage, status: WorkflowStatus, summary: String) -> WorkflowStep {
+    WorkflowStep { stage, status, summary }
+}
+
+pub fn startDefault(id: String, title: String, file: aidev.SourceFile, diags: List<aidev.Diagnostic>) -> WorkflowDraft {
+    start(id, title, file, diags, prompt.defaultPolicy(), defaultVerifyPlan(file))
+}
+
+pub fn start(id: String, title: String, file: aidev.SourceFile, diags: List<aidev.Diagnostic>, policy: prompt.PromptPolicy, verifyPlan: verify.VerifyPlan) -> WorkflowDraft {
+    let context = buildContext(file, diags)
+    let bundle = prompt.buildFixPrompt(context, policy)
+    let habit = sourceHabit(file)
+    let caseItem = corpus.repairCase(id, title, file, diags, habit)
+    WorkflowDraft {
+        id,
+        caseItem,
+        context,
+        promptBundle: bundle,
+        verifyPlan,
+        status: WorkflowPromptReady,
+        steps: [
+            step(StageDiagnose, WorkflowPlanned, aidev.formatCheckSummary(aidev.checkSummary(diags))),
+            step(StagePrompt, WorkflowPromptReady, bundle.summary),
+        ],
+    }
+}
+
+pub fn buildContext(file: aidev.SourceFile, diags: List<aidev.Diagnostic>) -> aidev.FixContext {
+    if isOstyFile(file) {
+        return ostydev.buildOstyFixContext(file, diags)
+    }
+    aidev.buildFixContext(file, diags, 3, 3)
+}
+
+pub fn defaultVerifyPlan(file: aidev.SourceFile) -> verify.VerifyPlan {
+    if isOstyFile(file) {
+        return verify.ostySourcePlan(file.path)
+    }
+    verify.plan("verify patch for {file.path}", [verify.diffCheckCommand()], [file.path])
+}
+
+pub fn propose(draft: WorkflowDraft, patchValue: aidev.Patch) -> WorkflowProposal {
+    let result = aidev.applyPatchToFile(draft.context.file, patchValue)
+    proposalFromResult(draft, patchValue, result)
+}
+
+pub fn proposalFromResult(draft: WorkflowDraft, patchValue: aidev.Patch, patchResult: aidev.PatchResult) -> WorkflowProposal {
+    let status = if patchResult.status.toString() == "rejected" { WorkflowPatchRejected } else { WorkflowPatchReady }
+    let mut steps = draft.steps
+    steps.push(step(StagePatch, status, patchResult.summary))
+    WorkflowProposal {
+        draft,
+        patch: patchValue,
+        patchResult,
+        status,
+        steps,
+    }
+}
+
+pub fn complete(proposal: WorkflowProposal, results: List<verify.VerifyResult>, afterDiags: List<aidev.Diagnostic>, notes: List<String>, existingLog: String) -> WorkflowRun {
+    let report = verify.buildReport(
+        proposal.draft.verifyPlan,
+        results,
+        proposal.draft.caseItem.diagnostics,
+        afterDiags,
+        proposal.patchResult,
+    )
+    completeWithReport(proposal, report, afterDiags, notes, existingLog)
+}
+
+pub fn completeWithReport(proposal: WorkflowProposal, report: verify.VerifyReport, afterDiags: List<aidev.Diagnostic>, notes: List<String>, existingLog: String) -> WorkflowRun {
+    let attempt = corpus.repairAttempt(
+        "{proposal.draft.id}:attempt",
+        proposal.draft.caseItem.id,
+        proposal.draft.caseItem.diagnostics,
+        afterDiags,
+        proposal.patchResult,
+        notes,
+    )
+    let status = statusForDecision(report.decision)
+    let mut steps = proposal.steps
+    steps.push(step(StageVerify, status, verify.summarizeReport(report)))
+    let log = recordAttempt(existingLog, proposal.draft.caseItem, attempt)
+    steps.push(step(StageRecord, WorkflowRecorded, "case and attempt appended"))
+    WorkflowRun {
+        draft: proposal.draft,
+        patch: proposal.patch,
+        patchResult: proposal.patchResult,
+        verifyReport: report,
+        attempt,
+        log,
+        status: if status == WorkflowRejected || status == WorkflowRetry || status == WorkflowInvestigate { status } else { WorkflowRecorded },
+        steps,
+    }
+}
+
+pub fn recordAttempt(log: String, caseItem: corpus.CorpusCase, attempt: corpus.RepairAttempt) -> String {
+    let withCase = corpus.appendCase(log, caseItem)
+    corpus.appendAttempt(withCase, attempt)
+}
+
+pub fn statusForDecision(decision: verify.VerifyDecision) -> WorkflowStatus {
+    match decision.toString() {
+        "accept"      -> WorkflowVerified,
+        "retry"       -> WorkflowRetry,
+        "reject"      -> WorkflowRejected,
+        "investigate" -> WorkflowInvestigate,
+        _             -> WorkflowPlanned,
+    }
+}
+
+pub fn isOstyFile(file: aidev.SourceFile) -> Bool {
+    file.language == "osty" || strings.endsWith(file.path, ".osty")
+}
+
+pub fn sourceHabit(file: aidev.SourceFile) -> String {
+    if !isOstyFile(file) {
+        return ""
+    }
+    ostydev.classifySourceHabit(file.text).toString()
+}
+
+pub fn summarizeDraft(draft: WorkflowDraft) -> String {
+    let promptTokens = draft.promptBundle.estimatedTokens
+    "{draft.id}: {draft.status.toString()} case={draft.caseItem.sourceFingerprint} prompt_tokens={promptTokens}"
+}
+
+pub fn summarizeProposal(proposal: WorkflowProposal) -> String {
+    let patchSummary = aidev.formatPatchSummary(proposal.patch)
+    "{proposal.draft.id}: {proposal.status.toString()} {patchSummary}"
+}
+
+pub fn summarizeRun(run: WorkflowRun) -> String {
+    let attempt = corpus.summarizeAttempt(run.attempt)
+    let report = verify.summarizeReport(run.verifyReport)
+    "{run.draft.id}: {run.status.toString()} | {attempt} | {report}"
+}
+
+pub fn formatSteps(steps: List<WorkflowStep>) -> String {
+    let mut out: List<String> = []
+    for item in steps {
+        out.push("{item.stage.toString()}:{item.status.toString()} {item.summary}")
+    }
+    strings.join(out, "\n")
+}


### PR DESCRIPTION
## Summary
- add `std.aidev.workflow` to tie diagnostics, prompts, patches, verification reports, and corpus records into one workflow run contract
- pin the workflow module in stdlib surface tests and backend stdlib check coverage
- update `STDLIB_MATRIX.md` for the new AI code assist workflow surface

## Validation
- `go run ./cmd/osty tokens internal/stdlib/modules/aidev/workflow.osty`
- `go run ./cmd/osty check --airepair=false internal/stdlib/modules/aidev/workflow.osty`
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestAidev'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultAidev'`
- `just fmt-check`
- `git diff --check`