### PR TITLE
[codex] add std.dialog module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 78 공개 모듈. 분류 기준:
+총 79 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (75 / 78 = 96%)
+### ⭐⭐⭐⭐⭐ Production (76 / 79 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -64,6 +64,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | polyglot | 2319 | pure Osty + os/env/fs | 두 언어 repo 표준 레일: Language / Component / Boundary / Workspace, BoundaryContract, ExecutionPolicy, doctorRun/check runner, Go+Rust/Osty+Go/Rust/Python/Node preset, build/test plan, Process/C ABI/shared-file boundary 검증, cwd/env 복원 실행, env/artifact/schema 계약 audit |
 | grid | 412 | pure Osty | Point / Size / Rect / Direction / row-major Grid<T> |
 | gui | 2004 | pure Osty + fs/os/json | retained GUI core: geometry / theme / flex+stack layout / render commands / HTML document renderer / browser event bridge / SVG renderer / browser document write/open launch helpers / browser event state application / pointer-key routing / focus / accessibility audit / snapshot diff |
+| dialog | 644 | pure Osty + os | file picker / multi-file picker / folder picker / save dialog command plans and runners for macOS AppleScript, Windows PowerShell, Zenity, KDialog, custom commands |
 | tar | 408 | pure Osty + bytes | ustar encode/decode/list/extract + checksum validation |
 | sql | 417 | pure Osty | identifier quoting / literals / placeholders / SELECT-INSERT-UPDATE-DELETE builders |
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
@@ -107,7 +108,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (3 / 78 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 79 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -196,7 +197,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 55 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 56 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)

--- a/internal/backend/stdlib_dialog_check_test.go
+++ b/internal/backend/stdlib_dialog_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultDialog(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "dialog")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(dialog) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("dialog module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/dialog_test.go
+++ b/internal/stdlib/dialog_test.go
@@ -1,0 +1,164 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestDialogModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["dialog"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		t.Fatalf("std.dialog not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
+	}
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"Mode", resolve.SymEnum},
+		{"Backend", resolve.SymEnum},
+		{"Filter", resolve.SymStruct},
+		{"Options", resolve.SymStruct},
+		{"CommandPlan", resolve.SymStruct},
+		{"Selection", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.dialog missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.dialog.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.dialog.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"filter", "extensionFilter", "anyFileFilter",
+		"openFileOptions", "openFilesOptions", "folderOptions", "saveFileOptions",
+		"selectFile", "selectFiles", "selectFolder", "saveFile",
+		"plan", "plans", "run", "runPlan", "commandLine",
+		"backendName", "modeName",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.dialog missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.dialog.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.dialog.%s not public", name)
+		}
+	}
+}
+
+func TestDialogModulePinsCommandBackends(t *testing.T) {
+	src := dialogModuleSource(t)
+	for _, want := range []string{
+		"std.dialog -- desktop file/folder/save dialogs",
+		"pub enum Mode",
+		"OpenFile",
+		"OpenFiles",
+		"OpenFolder",
+		"SaveFile",
+		"pub enum Backend",
+		"MacOSAppleScript",
+		"WindowsPowerShell",
+		"Zenity",
+		"KDialog",
+		"CustomCommand(String, List<String>)",
+		"pub fn selectFile(title: String) -> Result<String?, Error>",
+		"pub fn selectFiles(options: Options) -> Result<List<String>, Error>",
+		"pub fn selectFolder(title: String) -> Result<String?, Error>",
+		"pub fn saveFile(title: String, defaultName: String) -> Result<String?, Error>",
+		"pub fn plans(mode: Mode, options: Options) -> Result<List<CommandPlan>, Error>",
+		"pub fn run(mode: Mode, options: Options) -> Result<Selection, Error>",
+		"command: \"osascript\"",
+		"choose file with prompt",
+		"choose folder with prompt",
+		"choose file name with prompt",
+		"New-Object System.Windows.Forms.OpenFileDialog",
+		"New-Object System.Windows.Forms.FolderBrowserDialog",
+		"New-Object System.Windows.Forms.SaveFileDialog",
+		"command: \"zenity\"",
+		"--file-selection",
+		"--directory",
+		"--save",
+		"command: \"kdialog\"",
+		"--getexistingdirectory",
+		"--getsavefilename",
+		"os.exec(plan.command, plan.args)?",
+		"strings.splitLines(stdout)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.dialog source missing %q", want)
+		}
+	}
+}
+
+func TestDialogModuleMethodsAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"Options", []string{"withTitle", "withInitialDirectory", "withDefaultName", "withMultiple", "withConfirmOverwrite", "withShowHidden", "withBackend", "withFilter", "withFilters"}},
+		{"Selection", []string{"first", "pathOr"}},
+	} {
+		for _, method := range tc.methods {
+			fn := reg.LookupMethodDecl("dialog", tc.typeName, method)
+			if fn == nil {
+				t.Fatalf("LookupMethodDecl(dialog, %s, %s) = nil, want *ast.FnDecl", tc.typeName, method)
+			}
+			if fn.Body == nil {
+				t.Fatalf("dialog.%s.%s body = nil, want source method body", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestDialogModuleImportSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["dialog"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("stdlib dialog module missing package")
+	}
+	surface := resolve.PackageExportSurface("std.dialog", "dialog", mod.Package)
+	for _, want := range []string{
+		"selectFile",
+		"selectFiles",
+		"selectFolder",
+		"saveFile",
+		"plans",
+		"run",
+		"runPlan",
+		"commandLine",
+	} {
+		found := false
+		for _, fn := range surface.Functions {
+			if fn.Owner == "dialog" && fn.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("std.dialog import surface missing alias function %q; functions=%d fields=%d types=%d",
+				want, len(surface.Functions), len(surface.Fields), len(surface.TypeDecls))
+		}
+	}
+}
+
+func dialogModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["dialog"]
+	if mod == nil {
+		t.Fatal("stdlib dialog module missing")
+	}
+	return string(mod.Source)
+}

--- a/internal/stdlib/modules/dialog.osty
+++ b/internal/stdlib/modules/dialog.osty
@@ -1,0 +1,644 @@
+// std.dialog -- desktop file/folder/save dialogs.
+//
+// Dialogs are host UI, so the stable stdlib surface is a typed command-plan
+// layer plus small runners over common desktop dialog providers:
+// macOS AppleScript, Windows PowerShell/WinForms, Zenity, and KDialog.
+
+use std.error
+use std.os
+use std.strings
+
+pub enum Mode {
+    OpenFile,
+    OpenFiles,
+    OpenFolder,
+    SaveFile,
+}
+
+pub enum Backend {
+    Auto,
+    MacOSAppleScript,
+    WindowsPowerShell,
+    Zenity,
+    KDialog,
+    CustomCommand(String, List<String>),
+}
+
+pub struct Filter {
+    pub name: String,
+    pub patterns: List<String> = [],
+    pub extensions: List<String> = [],
+}
+
+pub struct Options {
+    pub title: String = "",
+    pub initialDirectory: String = "",
+    pub defaultName: String = "",
+    pub allowMultiple: Bool = false,
+    pub confirmOverwrite: Bool = true,
+    pub showHidden: Bool = false,
+    pub filters: List<Filter> = [],
+    pub backend: Backend,
+
+    pub fn withTitle(mut self, title: String) -> Options {
+        self.title = title
+        self
+    }
+
+    pub fn withInitialDirectory(mut self, path: String) -> Options {
+        self.initialDirectory = path
+        self
+    }
+
+    pub fn withDefaultName(mut self, name: String) -> Options {
+        self.defaultName = name
+        self
+    }
+
+    pub fn withMultiple(mut self, allow: Bool) -> Options {
+        self.allowMultiple = allow
+        self
+    }
+
+    pub fn withConfirmOverwrite(mut self, confirm: Bool) -> Options {
+        self.confirmOverwrite = confirm
+        self
+    }
+
+    pub fn withShowHidden(mut self, show: Bool) -> Options {
+        self.showHidden = show
+        self
+    }
+
+    pub fn withBackend(mut self, backend: Backend) -> Options {
+        self.backend = backend
+        self
+    }
+
+    pub fn withFilter(mut self, filter: Filter) -> Options {
+        self.filters.push(filter)
+        self
+    }
+
+    pub fn withFilters(mut self, filters: List<Filter>) -> Options {
+        self.filters = filters
+        self
+    }
+}
+
+pub struct CommandPlan {
+    pub backend: Backend,
+    pub mode: Mode,
+    pub command: String,
+    pub args: List<String>,
+}
+
+pub struct Selection {
+    pub accepted: Bool = false,
+    pub paths: List<String> = [],
+
+    pub fn first(self) -> String? {
+        if self.paths.len() == 0 {
+            None
+        } else {
+            Some(self.paths[0])
+        }
+    }
+
+    pub fn pathOr(self, fallback: String) -> String {
+        self.first() ?? fallback
+    }
+}
+
+pub fn filter(name: String, patterns: List<String>) -> Filter {
+    Filter {
+        name: name,
+        patterns: patterns,
+        extensions: extensionsFromPatterns(patterns),
+    }
+}
+
+pub fn extensionFilter(name: String, extensions: List<String>) -> Filter {
+    Filter {
+        name: name,
+        patterns: patternsFromExtensions(extensions),
+        extensions: cleanExtensions(extensions),
+    }
+}
+
+pub fn anyFileFilter() -> Filter {
+    Filter { name: "All files", patterns: ["*"], extensions: [] }
+}
+
+pub fn openFileOptions(title: String) -> Options {
+    Options {
+        title: title,
+        allowMultiple: false,
+        confirmOverwrite: true,
+        backend: Auto,
+    }
+}
+
+pub fn openFilesOptions(title: String) -> Options {
+    openFileOptions(title).withMultiple(true)
+}
+
+pub fn folderOptions(title: String) -> Options {
+    Options {
+        title: title,
+        allowMultiple: false,
+        confirmOverwrite: true,
+        backend: Auto,
+    }
+}
+
+pub fn saveFileOptions(title: String, defaultName: String) -> Options {
+    Options {
+        title: title,
+        defaultName: defaultName,
+        allowMultiple: false,
+        confirmOverwrite: true,
+        backend: Auto,
+    }
+}
+
+pub fn selectFile(title: String) -> Result<String?, Error> {
+    let selected = run(OpenFile, openFileOptions(title))?
+    Ok(selected.first())
+}
+
+pub fn selectFiles(options: Options) -> Result<List<String>, Error> {
+    let selected = run(OpenFiles, options.withMultiple(true))?
+    Ok(selected.paths)
+}
+
+pub fn selectFolder(title: String) -> Result<String?, Error> {
+    let selected = run(OpenFolder, folderOptions(title))?
+    Ok(selected.first())
+}
+
+pub fn saveFile(title: String, defaultName: String) -> Result<String?, Error> {
+    let selected = run(SaveFile, saveFileOptions(title, defaultName))?
+    Ok(selected.first())
+}
+
+pub fn plan(mode: Mode, options: Options) -> Result<CommandPlan, Error> {
+    let candidates = plans(mode, options)?
+    if candidates.len() == 0 {
+        Err(error.new("dialog: no command plan available"))
+    } else {
+        Ok(candidates[0])
+    }
+}
+
+pub fn plans(mode: Mode, options: Options) -> Result<List<CommandPlan>, Error> {
+    validate(mode, options)?
+    match options.backend {
+        Auto -> Ok([
+            macOSPlan(mode, options),
+            windowsPowerShellPlan(mode, options),
+            zenityPlan(mode, options),
+            kDialogPlan(mode, options),
+        ]),
+        MacOSAppleScript -> Ok([macOSPlan(mode, options)]),
+        WindowsPowerShell -> Ok([windowsPowerShellPlan(mode, options)]),
+        Zenity -> Ok([zenityPlan(mode, options)]),
+        KDialog -> Ok([kDialogPlan(mode, options)]),
+        CustomCommand(command, args) -> Ok([CommandPlan {
+            backend: CustomCommand(command, args),
+            mode: mode,
+            command: command,
+            args: args,
+        }]),
+    }
+}
+
+pub fn run(mode: Mode, options: Options) -> Result<Selection, Error> {
+    let candidates = plans(mode, options)?
+    let mut errors: List<String> = []
+    for candidate in candidates {
+        match runPlan(candidate) {
+            Ok(selection) -> {
+                return Ok(selection)
+            },
+            Err(err) -> errors.push(err.message()),
+        }
+    }
+    let joined = strings.join(errors, "; ")
+    Err(error.new("dialog: no backend succeeded: {joined}"))
+}
+
+pub fn runPlan(plan: CommandPlan) -> Result<Selection, Error> {
+    let output = os.exec(plan.command, plan.args)?
+    if output.exitCode == 0 {
+        return Ok(selectionFromStdout(output.stdout))
+    }
+    if isCancel(plan.backend, output.exitCode, output.stderr) {
+        return Ok(Selection { accepted: false, paths: [] })
+    }
+    Err(error.new("dialog: {backendName(plan.backend)} failed with exit code {output.exitCode}: {output.stderr}"))
+}
+
+pub fn commandLine(plan: CommandPlan) -> String {
+    let mut parts = [shellQuote(plan.command)]
+    for arg in plan.args {
+        parts.push(shellQuote(arg))
+    }
+    strings.join(parts, " ")
+}
+
+pub fn backendName(backend: Backend) -> String {
+    match backend {
+        Auto -> "auto",
+        MacOSAppleScript -> "macos-applescript",
+        WindowsPowerShell -> "windows-powershell",
+        Zenity -> "zenity",
+        KDialog -> "kdialog",
+        CustomCommand(command, _) -> "custom:{command}",
+    }
+}
+
+pub fn modeName(mode: Mode) -> String {
+    match mode {
+        OpenFile -> "open-file",
+        OpenFiles -> "open-files",
+        OpenFolder -> "open-folder",
+        SaveFile -> "save-file",
+    }
+}
+
+fn validate(mode: Mode, options: Options) -> Result<(), Error> {
+    if mode == SaveFile && strings.trimSpace(options.defaultName).isEmpty() && strings.trimSpace(options.initialDirectory).isEmpty() {
+        return Err(error.new("dialog: save dialogs need a default name or initial directory"))
+    }
+    if mode == OpenFolder && options.allowMultiple {
+        return Err(error.new("dialog: folder selection does not support multiple paths"))
+    }
+    Ok(())
+}
+
+fn macOSPlan(mode: Mode, options: Options) -> CommandPlan {
+    CommandPlan {
+        backend: MacOSAppleScript,
+        mode: mode,
+        command: "osascript",
+        args: ["-e", macOSScript(mode, options)],
+    }
+}
+
+fn windowsPowerShellPlan(mode: Mode, options: Options) -> CommandPlan {
+    CommandPlan {
+        backend: WindowsPowerShell,
+        mode: mode,
+        command: "powershell",
+        args: ["-NoProfile", "-STA", "-Command", windowsScript(mode, options)],
+    }
+}
+
+fn zenityPlan(mode: Mode, options: Options) -> CommandPlan {
+    let mut args: List<String> = ["--file-selection"]
+    if !options.title.isEmpty() {
+        args.push("--title={options.title}")
+    }
+    let filename = dialogInitialPath(options)
+    if !filename.isEmpty() {
+        args.push("--filename={filename}")
+    }
+    if mode == OpenFolder {
+        args.push("--directory")
+    }
+    if mode == SaveFile {
+        args.push("--save")
+        if options.confirmOverwrite {
+            args.push("--confirm-overwrite")
+        }
+    }
+    if (mode == OpenFiles || options.allowMultiple) && mode != OpenFolder && mode != SaveFile {
+        args.push("--multiple")
+        args.push("--separator=\n")
+    }
+    if options.showHidden {
+        args.push("--show-hidden")
+    }
+    for filter in normalizedFilters(options.filters) {
+        args.push("--file-filter={zenityFilter(filter)}")
+    }
+    CommandPlan { backend: Zenity, mode: mode, command: "zenity", args: args }
+}
+
+fn kDialogPlan(mode: Mode, options: Options) -> CommandPlan {
+    let mut args: List<String> = []
+    if !options.title.isEmpty() {
+        args.push("--title")
+        args.push(options.title)
+    }
+    if (mode == OpenFiles || options.allowMultiple) && mode != OpenFolder && mode != SaveFile {
+        args.push("--multiple")
+        args.push("--separate-output")
+    }
+    match mode {
+        OpenFolder -> args.push("--getexistingdirectory"),
+        SaveFile -> args.push("--getsavefilename"),
+        _ -> args.push("--getopenfilename"),
+    }
+    let initial = dialogInitialPath(options)
+    if !initial.isEmpty() {
+        args.push(initial)
+    }
+    let filterText = kDialogFilters(options.filters)
+    if !filterText.isEmpty() && mode != OpenFolder {
+        args.push(filterText)
+    }
+    CommandPlan { backend: KDialog, mode: mode, command: "kdialog", args: args }
+}
+
+fn macOSScript(mode: Mode, options: Options) -> String {
+    let prompt = if options.title.isEmpty() { defaultTitle(mode) } else { options.title }
+    let base = match mode {
+        OpenFolder -> "choose folder with prompt {appleString(prompt)}{appleDefaultLocation(options.initialDirectory)}",
+        SaveFile -> "choose file name with prompt {appleString(prompt)}{appleDefaultName(options.defaultName)}{appleDefaultLocation(options.initialDirectory)}",
+        _ -> "choose file with prompt {appleString(prompt)}{appleDefaultLocation(options.initialDirectory)}{appleTypeClause(options.filters)}{appleMultiClause(mode, options)}",
+    }
+    if mode == OpenFiles || options.allowMultiple {
+        strings.join([
+            "set chosenItems to {base}",
+            "set oldDelims to AppleScript's text item delimiters",
+            "set AppleScript's text item delimiters to linefeed",
+            "set outputPaths to {}",
+            "repeat with itemRef in chosenItems",
+            "set end of outputPaths to POSIX path of itemRef",
+            "end repeat",
+            "set rendered to outputPaths as text",
+            "set AppleScript's text item delimiters to oldDelims",
+            "rendered",
+        ], "\n")
+    } else {
+        "POSIX path of ({base})"
+    }
+}
+
+fn windowsScript(mode: Mode, options: Options) -> String {
+    let mut lines: List<String> = [
+        "Add-Type -AssemblyName System.Windows.Forms",
+        "[System.Windows.Forms.Application]::EnableVisualStyles()",
+    ]
+    match mode {
+        OpenFolder -> {
+            lines.push("$dlg = New-Object System.Windows.Forms.FolderBrowserDialog")
+            if !options.title.isEmpty() {
+                lines.push("$dlg.Description = {psString(options.title)}")
+            }
+            if !options.initialDirectory.isEmpty() {
+                lines.push("$dlg.SelectedPath = {psString(options.initialDirectory)}")
+            }
+            lines.push("if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) \{ Write-Output $dlg.SelectedPath; exit 0 \} else \{ exit 2 \}")
+        },
+        SaveFile -> {
+            lines.push("$dlg = New-Object System.Windows.Forms.SaveFileDialog")
+            appendWindowsCommon(lines, options)
+            lines.push("$dlg.OverwritePrompt = {psBool(options.confirmOverwrite)}")
+            if !options.defaultName.isEmpty() {
+                lines.push("$dlg.FileName = {psString(options.defaultName)}")
+            }
+            lines.push("if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) \{ Write-Output $dlg.FileName; exit 0 \} else \{ exit 2 \}")
+        },
+        _ -> {
+            lines.push("$dlg = New-Object System.Windows.Forms.OpenFileDialog")
+            appendWindowsCommon(lines, options)
+            lines.push("$dlg.Multiselect = {psBool(mode == OpenFiles || options.allowMultiple)}")
+            lines.push("if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) \{ Write-Output ($dlg.FileNames -join '`n'); exit 0 \} else \{ exit 2 \}")
+        },
+    }
+    strings.join(lines, "; ")
+}
+
+fn appendWindowsCommon(lines: List<String>, options: Options) {
+    if !options.title.isEmpty() {
+        lines.push("$dlg.Title = {psString(options.title)}")
+    }
+    if !options.initialDirectory.isEmpty() {
+        lines.push("$dlg.InitialDirectory = {psString(options.initialDirectory)}")
+    }
+    let filterText = windowsFilters(options.filters)
+    if !filterText.isEmpty() {
+        lines.push("$dlg.Filter = {psString(filterText)}")
+    }
+    lines.push("$dlg.RestoreDirectory = $true")
+}
+
+fn selectionFromStdout(stdout: String) -> Selection {
+    let mut paths: List<String> = []
+    for line in strings.splitLines(stdout) {
+        let clean = strings.trimSpace(line)
+        if !clean.isEmpty() {
+            paths.push(clean)
+        }
+    }
+    Selection { accepted: paths.len() > 0, paths: paths }
+}
+
+fn isCancel(backend: Backend, code: Int, stderr: String) -> Bool {
+    let msg = strings.toLower(strings.trimSpace(stderr))
+    match backend {
+        WindowsPowerShell -> code == 2,
+        MacOSAppleScript -> code == 1 && (strings.contains(msg, "user canceled") || strings.contains(msg, "cancelled")),
+        Zenity -> code == 1 && (msg.isEmpty() || strings.contains(msg, "cancel")),
+        KDialog -> code == 1 && (msg.isEmpty() || strings.contains(msg, "cancel")),
+        _ -> false,
+    }
+}
+
+fn dialogInitialPath(options: Options) -> String {
+    if options.initialDirectory.isEmpty() {
+        options.defaultName
+    } else if options.defaultName.isEmpty() {
+        options.initialDirectory
+    } else if strings.endsWith(options.initialDirectory, "/") || strings.endsWith(options.initialDirectory, "\\") {
+        "{options.initialDirectory}{options.defaultName}"
+    } else {
+        "{options.initialDirectory}/{options.defaultName}"
+    }
+}
+
+fn normalizedFilters(filters: List<Filter>) -> List<Filter> {
+    if filters.len() == 0 {
+        [anyFileFilter()]
+    } else {
+        filters
+    }
+}
+
+fn zenityFilter(filter: Filter) -> String {
+    let patterns = normalizedPatterns(filter)
+    let joined = strings.join(patterns, " ")
+    "{filter.name} | {joined}"
+}
+
+fn kDialogFilters(filters: List<Filter>) -> String {
+    let mut parts: List<String> = []
+    for filter in normalizedFilters(filters) {
+        let patterns = normalizedPatterns(filter)
+        let joined = strings.join(patterns, " ")
+        parts.push("{joined}|{filter.name}")
+    }
+    strings.join(parts, "\n")
+}
+
+fn windowsFilters(filters: List<Filter>) -> String {
+    let mut parts: List<String> = []
+    for filter in normalizedFilters(filters) {
+        let patterns = normalizedPatterns(filter)
+        let joined = strings.join(patterns, ";")
+        parts.push("{filter.name} ({joined})")
+        parts.push(strings.join(patterns, ";"))
+    }
+    strings.join(parts, "|")
+}
+
+fn appleTypeClause(filters: List<Filter>) -> String {
+    let mut exts: List<String> = []
+    for filter in filters {
+        for ext in filter.extensions {
+            let clean = cleanExtension(ext)
+            if !clean.isEmpty() {
+                exts.push(appleString(clean))
+            }
+        }
+    }
+    if exts.len() == 0 {
+        ""
+    } else {
+        let open = "\{"
+        let close = "\}"
+        let joined = strings.join(exts, ", ")
+        " of type {open}{joined}{close}"
+    }
+}
+
+fn appleMultiClause(mode: Mode, options: Options) -> String {
+    if mode == OpenFiles || options.allowMultiple {
+        " with multiple selections allowed"
+    } else {
+        ""
+    }
+}
+
+fn appleDefaultLocation(path: String) -> String {
+    if strings.trimSpace(path).isEmpty() {
+        ""
+    } else {
+        " default location POSIX file {appleString(path)}"
+    }
+}
+
+fn appleDefaultName(name: String) -> String {
+    if strings.trimSpace(name).isEmpty() {
+        ""
+    } else {
+        " default name {appleString(name)}"
+    }
+}
+
+fn defaultTitle(mode: Mode) -> String {
+    match mode {
+        OpenFile -> "Choose a file",
+        OpenFiles -> "Choose files",
+        OpenFolder -> "Choose a folder",
+        SaveFile -> "Save as",
+    }
+}
+
+fn normalizedPatterns(filter: Filter) -> List<String> {
+    if filter.patterns.len() > 0 {
+        filter.patterns
+    } else {
+        patternsFromExtensions(filter.extensions)
+    }
+}
+
+fn patternsFromExtensions(extensions: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for ext in cleanExtensions(extensions) {
+        out.push("*.{ext}")
+    }
+    if out.len() == 0 {
+        out.push("*")
+    }
+    out
+}
+
+fn extensionsFromPatterns(patterns: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for pattern in patterns {
+        let clean = cleanPatternExtension(pattern)
+        if !clean.isEmpty() {
+            out.push(clean)
+        }
+    }
+    out
+}
+
+fn cleanExtensions(extensions: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for ext in extensions {
+        let clean = cleanExtension(ext)
+        if !clean.isEmpty() {
+            out.push(clean)
+        }
+    }
+    out
+}
+
+fn cleanPatternExtension(pattern: String) -> String {
+    let clean = strings.trimSpace(pattern)
+    if strings.startsWith(clean, "*.") {
+        return cleanExtension(strings.slice(clean, 2, clean.len()))
+    }
+    if strings.startsWith(clean, ".") {
+        return cleanExtension(clean)
+    }
+    ""
+}
+
+fn cleanExtension(ext: String) -> String {
+    let mut clean = strings.trimSpace(ext)
+    for strings.startsWith(clean, ".") {
+        clean = strings.slice(clean, 1, clean.len())
+    }
+    strings.toLower(clean)
+}
+
+fn appleString(text: String) -> String {
+    "\"{escapeApple(text)}\""
+}
+
+fn escapeApple(text: String) -> String {
+    let slash = strings.replaceAll(text, "\\", "\\\\")
+    let quote = strings.replaceAll(slash, "\"", "\\\"")
+    let newline = strings.replaceAll(quote, "\n", "\\n")
+    strings.replaceAll(newline, "\r", "\\r")
+}
+
+fn psString(text: String) -> String {
+    let escaped = strings.replaceAll(text, "'", "''")
+    "'{escaped}'"
+}
+
+fn psBool(flag: Bool) -> String {
+    if flag { "$true" } else { "$false" }
+}
+
+fn shellQuote(arg: String) -> String {
+    if arg.isEmpty() {
+        return "''"
+    }
+    let mut out = "'"
+    for c in arg.chars() {
+        if c == '\'' {
+            out = "{out}'\\''"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    "{out}'"
+}


### PR DESCRIPTION
## Summary
- Add `std.dialog` for file picker, multi-file picker, folder picker, and save dialog flows.
- Provide command-plan and runner support for macOS AppleScript, Windows PowerShell, Zenity, KDialog, and custom commands.
- Pin the new stdlib surface with registry/import-surface tests, backend checker coverage, and `STDLIB_MATRIX.md` updates.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestDialogModule|TestStdlibSupportMatrix'`
- `go test -count=1 -vet=off ./internal/backend -run TestStdlibCheckResultDialog`
- `git diff --check`