### PR TITLE
[codex] add std.print surface

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/38-print.md
+++ b/LANG_SPEC_v0.5/10-standard-library/38-print.md
@@ -1,0 +1,50 @@
+### 10.38 Print (`std.print`)
+
+`std.print` sends existing PDF and image files to the host print spooler. It
+does not implement page rendering in the language runtime; applications should
+produce a PDF or image first, then ask the host printer stack to print it.
+
+Core types:
+
+```osty
+print.DocumentKind
+print.Backend
+print.Orientation
+print.Duplex
+print.ColorMode
+print.Document
+print.Options
+print.Printer
+print.CommandPlan
+print.Job
+```
+
+Core API:
+
+```osty
+print.options() -> Options
+print.file(path) -> Document
+print.pdf(path) -> Document
+print.image(path) -> Document
+print.pageRange(from, to) -> Result<PageRange, Error>
+print.plan(doc, opts) -> Result<CommandPlan, Error>
+print.print(doc, opts) -> Result<Job, Error>
+print.printFile(path) -> Result<Job, Error>
+print.printPdf(path) -> Result<Job, Error>
+print.printImage(path) -> Result<Job, Error>
+print.defaultPrinterName() -> Result<String, Error>
+print.printers() -> Result<List<Printer>, Error>
+```
+
+Behavior:
+
+- `AutoBackend` uses CUPS `lp`, which is available on macOS and common Linux
+  desktops. `Lpr`, `WindowsShell`, and `CustomCommand` expose explicit
+  fallback paths.
+- `plan` validates the requested document kind, copies, page ranges, and
+  command backend without requiring the file to exist.
+- `print` additionally checks that the file exists, runs the command plan, and
+  returns the command output plus a best-effort spooler job id.
+- PDF and image printing are path-based. Byte-to-file rendering, PDF creation,
+  and image pixel conversion remain responsibilities of `std.fs`, `std.gui`,
+  `std.report`, or future codec/runtime layers.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -52,3 +52,4 @@ lowering remains implementation backlog.
 - [§10.35 Tables (`std.table`)](./35-table.md)
 - [§10.36 AI API (`std.ai`)](./36-ai.md)
 - [§10.37 Scanner Automation (`std.scan`)](./37-scan.md)
+- [§10.38 Print (`std.print`)](./38-print.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 81 공개 모듈. 분류 기준:
+총 82 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (78 / 81 = 96%)
+### ⭐⭐⭐⭐⭐ Production (78 / 82 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -110,12 +110,13 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (3 / 81 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 82 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
 | gui.qtquick | 243 | Qt Quick/QML native app backend MVP. `libosty_qt` bridge, runtime diagnostics, reload/import-path helpers, `osty gui doctor qtquick`; bundle/deploy 연계는 후속 |
 | gui.webview2 | 292 | Windows WebView2 C ABI shim. Safe wrapper / scaffold / runtime diagnostics landed; local virtual-origin assets, console-log event bridge, Osty→Web command channel, and handle-lifetime hardening added; Windows smoke and packaged linker flow still pending |
+| print | 461 | 기본 프린터 / PDF / 이미지 인쇄 표면. CUPS `lp`/`lpr`, Windows shell print, custom command plan/exec, 프린터 조회와 옵션 검증은 추가됨; host spooler별 세부 기능 편차는 후속 |
 | compress | 11 | gzip 만 (zstd / deflate 추가 가능). Phase A shim 199 |
 
 ### 🚧 실제 미구현 / 갭
@@ -171,6 +172,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | Agent-safe logs/transcripts | ✅ 가능 | redact + security + tokenest + aiagents |
 | Local document search | ✅ 가능 | search + markdown + media + jsonl |
 | 사람이 읽는 리포트 산출물 | ✅ 가능 | report + markdown/jsonl/csv |
+| PDF/이미지 인쇄 | ✅ 가능 | print + fs/media/os (기본 CUPS `lp`, `lpr`, Windows shell print, custom command plan) |
 | LLM retry/compaction loop | ✅ 가능 | ai + httpretry + tokenest + aiagents |
 
 ## 3. 진짜 약점 (남은 런타임 / 딥 기능)
@@ -204,6 +206,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 - 58 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
+- print 는 기존 `std.os` host process bridge 위에서 CUPS/Windows/custom spooler 실행 계획을 제공한다. 실제 출력은 가능하지만 프린터별 capability discovery 는 production-adjacent 로 남긴다.
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)
 
 ## 5. 평가 함정: `.osty` 줄 수 모델의 한계

--- a/internal/backend/stdlib_print_check_test.go
+++ b/internal/backend/stdlib_print_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultPrint(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "print")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(print) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("print module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/print.osty
+++ b/internal/stdlib/modules/print.osty
@@ -1,0 +1,461 @@
+// std.print - host printer jobs for PDF and image documents.
+//
+// The module keeps print rendering outside the language runtime. It builds and
+// runs explicit host command plans, defaulting to the CUPS `lp` command used by
+// macOS and many Linux desktops. Callers that need a different spooler can
+// choose another backend or pass a custom command.
+
+use std.error
+use std.fs
+use std.media
+use std.os
+use std.strings
+
+pub enum DocumentKind {
+    AutoDocument,
+    PdfDocument,
+    ImageDocument,
+}
+
+pub enum Backend {
+    AutoBackend,
+    Lp,
+    Lpr,
+    WindowsShell,
+    CustomCommand(String),
+}
+
+pub enum Orientation {
+    AutoOrientation,
+    Portrait,
+    Landscape,
+}
+
+pub enum Duplex {
+    DefaultDuplex,
+    OneSided,
+    LongEdge,
+    ShortEdge,
+}
+
+pub enum ColorMode {
+    DefaultColor,
+    Color,
+    Grayscale,
+}
+
+pub struct Document {
+    pub path: String,
+    pub kind: DocumentKind,
+    pub mime: String = "",
+}
+
+pub struct PageRange {
+    pub from: Int,
+    pub to: Int,
+}
+
+pub struct Options {
+    pub printer: String = "",
+    pub copies: Int = 1,
+    pub jobName: String = "",
+    pub media: String = "",
+    pub fitToPage: Bool = true,
+    pub orientation: Orientation,
+    pub duplex: Duplex,
+    pub color: ColorMode,
+    pub pageRanges: List<PageRange> = [],
+    pub backend: Backend,
+}
+
+pub struct Printer {
+    pub name: String,
+    pub description: String = "",
+    pub isDefault: Bool = false,
+}
+
+pub struct CommandPlan {
+    pub command: String,
+    pub args: List<String> = [],
+}
+
+pub struct Job {
+    pub id: String = "",
+    pub printer: String = "",
+    pub document: Document,
+    pub plan: CommandPlan,
+    pub output: os.Output,
+}
+
+pub fn options() -> Options {
+    Options {
+        orientation: AutoOrientation,
+        duplex: DefaultDuplex,
+        color: DefaultColor,
+        backend: AutoBackend,
+    }
+}
+
+pub fn withPrinter(mut opts: Options, printer: String) -> Options {
+    opts.printer = printer
+    opts
+}
+
+pub fn withCopies(mut opts: Options, copies: Int) -> Options {
+    opts.copies = copies
+    opts
+}
+
+pub fn withJobName(mut opts: Options, name: String) -> Options {
+    opts.jobName = name
+    opts
+}
+
+pub fn withMedia(mut opts: Options, mediaName: String) -> Options {
+    opts.media = mediaName
+    opts
+}
+
+pub fn withFitToPage(mut opts: Options, enabled: Bool) -> Options {
+    opts.fitToPage = enabled
+    opts
+}
+
+pub fn withOrientation(mut opts: Options, orientation: Orientation) -> Options {
+    opts.orientation = orientation
+    opts
+}
+
+pub fn withDuplex(mut opts: Options, duplex: Duplex) -> Options {
+    opts.duplex = duplex
+    opts
+}
+
+pub fn withColorMode(mut opts: Options, color: ColorMode) -> Options {
+    opts.color = color
+    opts
+}
+
+pub fn withPageRanges(mut opts: Options, ranges: List<PageRange>) -> Options {
+    opts.pageRanges = ranges
+    opts
+}
+
+pub fn withBackend(mut opts: Options, backend: Backend) -> Options {
+    opts.backend = backend
+    opts
+}
+
+pub fn pageRange(from: Int, to: Int) -> Result<PageRange, Error> {
+    if from <= 0 || to <= 0 {
+        return Err(error.new("print: page ranges are 1-based"))
+    }
+    if to < from {
+        return Err(error.new("print: page range end is before start"))
+    }
+    Ok(PageRange { from: from, to: to })
+}
+
+pub fn file(path: String) -> Document {
+    let detected = media.detectByName(path)
+    Document { path: path, kind: AutoDocument, mime: detected.mime }
+}
+
+pub fn pdf(path: String) -> Document {
+    Document { path: path, kind: PdfDocument, mime: "application/pdf" }
+}
+
+pub fn image(path: String) -> Document {
+    let detected = media.detectByName(path)
+    let mime = if strings.startsWith(detected.mime, "image/") { detected.mime } else { "image/*" }
+    Document { path: path, kind: ImageDocument, mime: mime }
+}
+
+pub fn isPrintable(doc: Document) -> Bool {
+    match doc.kind {
+        PdfDocument -> true,
+        ImageDocument -> true,
+        AutoDocument -> isPrintableMime(doc.mime),
+    }
+}
+
+pub fn defaultPrinterName() -> Result<String, Error> {
+    let output = os.exec("lpstat", ["-d"])?
+    if output.exitCode != 0 {
+        return Err(error.new("print: lpstat -d failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    let name = parseDefaultPrinterName(output.stdout)
+    if name.isEmpty() {
+        Err(error.new("print: no default printer configured"))
+    } else {
+        Ok(name)
+    }
+}
+
+pub fn printers() -> Result<List<Printer>, Error> {
+    let output = os.exec("lpstat", ["-p", "-d"])?
+    if output.exitCode != 0 {
+        return Err(error.new("print: lpstat -p -d failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(parsePrinters(output.stdout))
+}
+
+pub fn plan(doc: Document, opts: Options) -> Result<CommandPlan, Error> {
+    validatePlanInputs(doc, opts)?
+    match opts.backend {
+        AutoBackend -> Ok(lpPlan(doc, opts)),
+        Lp -> Ok(lpPlan(doc, opts)),
+        Lpr -> Ok(lprPlan(doc, opts)),
+        WindowsShell -> windowsShellPlan(doc, opts),
+        CustomCommand(command) -> {
+            if strings.trimSpace(command).isEmpty() {
+                Err(error.new("print: custom command is empty"))
+            } else {
+                Ok(CommandPlan { command: command, args: [doc.path] })
+            }
+        },
+    }
+}
+
+pub fn print(doc: Document, opts: Options) -> Result<Job, Error> {
+    validateDocument(doc)?
+    let p = plan(doc, opts)?
+    let output = os.exec(p.command, p.args)?
+    if output.exitCode != 0 {
+        return Err(error.new("print: command failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(Job {
+        id: parseJobId(output.stdout),
+        printer: opts.printer,
+        document: doc,
+        plan: p,
+        output: output,
+    })
+}
+
+pub fn printFile(path: String) -> Result<Job, Error> {
+    print(file(path), options())
+}
+
+pub fn printPdf(path: String) -> Result<Job, Error> {
+    print(pdf(path), options())
+}
+
+pub fn printImage(path: String) -> Result<Job, Error> {
+    print(image(path), options())
+}
+
+fn validatePlanInputs(doc: Document, opts: Options) -> Result<(), Error> {
+    if strings.trimSpace(doc.path).isEmpty() {
+        return Err(error.new("print: document path is empty"))
+    }
+    if opts.copies <= 0 {
+        return Err(error.new("print: copies must be positive"))
+    }
+    validatePageRanges(opts.pageRanges)?
+    if !isPrintable(doc) {
+        return Err(error.new("print: unsupported document type: {doc.mime}"))
+    }
+    Ok(())
+}
+
+fn validateDocument(doc: Document) -> Result<(), Error> {
+    if strings.trimSpace(doc.path).isEmpty() {
+        return Err(error.new("print: document path is empty"))
+    }
+    if !fs.exists(doc.path) {
+        return Err(error.new("print: document does not exist: {doc.path}"))
+    }
+    if !isPrintable(doc) {
+        return Err(error.new("print: unsupported document type: {doc.mime}"))
+    }
+    Ok(())
+}
+
+fn validatePageRanges(ranges: List<PageRange>) -> Result<(), Error> {
+    for r in ranges {
+        if r.from <= 0 || r.to <= 0 {
+            return Err(error.new("print: page ranges are 1-based"))
+        }
+        if r.to < r.from {
+            return Err(error.new("print: page range end is before start"))
+        }
+    }
+    Ok(())
+}
+
+fn lpPlan(doc: Document, opts: Options) -> CommandPlan {
+    let mut args = commonCupsArgs(opts, true)
+    args.push(doc.path)
+    CommandPlan { command: "lp", args: args }
+}
+
+fn lprPlan(doc: Document, opts: Options) -> CommandPlan {
+    let mut args: List<String> = []
+    if !strings.trimSpace(opts.printer).isEmpty() {
+        args.push("-P")
+        args.push(opts.printer)
+    }
+    if opts.copies > 1 {
+        args.push("-#")
+        args.push(opts.copies.toString())
+    }
+    if !strings.trimSpace(opts.jobName).isEmpty() {
+        args.push("-T")
+        args.push(opts.jobName)
+    }
+    args = appendCupsOptions(args, opts)
+    args.push(doc.path)
+    CommandPlan { command: "lpr", args: args }
+}
+
+fn windowsShellPlan(doc: Document, opts: Options) -> Result<CommandPlan, Error> {
+    if !strings.trimSpace(opts.printer).isEmpty() {
+        return Err(error.new("print: WindowsShell backend supports only the default printer"))
+    }
+    Ok(CommandPlan {
+        command: "powershell",
+        args: ["-NoProfile", "-Command", "Start-Process -FilePath {powerShellQuote(doc.path)} -Verb Print"],
+    })
+}
+
+fn commonCupsArgs(opts: Options, lpStyle: Bool) -> List<String> {
+    let mut args: List<String> = []
+    if !strings.trimSpace(opts.printer).isEmpty() {
+        if lpStyle {
+            args.push("-d")
+        } else {
+            args.push("-P")
+        }
+        args.push(opts.printer)
+    }
+    if opts.copies > 1 {
+        args.push("-n")
+        args.push(opts.copies.toString())
+    }
+    if !strings.trimSpace(opts.jobName).isEmpty() {
+        args.push("-t")
+        args.push(opts.jobName)
+    }
+    args = appendCupsOptions(args, opts)
+    args
+}
+
+fn appendCupsOptions(args: List<String>, opts: Options) -> List<String> {
+    let mut out = args
+    if !strings.trimSpace(opts.media).isEmpty() {
+        out.push("-o")
+        out.push("media={opts.media}")
+    }
+    if opts.fitToPage {
+        out.push("-o")
+        out.push("fit-to-page")
+    }
+    if opts.pageRanges.len() > 0 {
+        out.push("-o")
+        out.push("page-ranges={pageRangesSpec(opts.pageRanges)}")
+    }
+    let orientation = orientationOption(opts.orientation)
+    if !orientation.isEmpty() {
+        out.push("-o")
+        out.push(orientation)
+    }
+    let duplex = duplexOption(opts.duplex)
+    if !duplex.isEmpty() {
+        out.push("-o")
+        out.push(duplex)
+    }
+    let color = colorOption(opts.color)
+    if !color.isEmpty() {
+        out.push("-o")
+        out.push(color)
+    }
+    out
+}
+
+fn orientationOption(value: Orientation) -> String {
+    match value {
+        AutoOrientation -> "",
+        Portrait -> "orientation-requested=3",
+        Landscape -> "orientation-requested=4",
+    }
+}
+
+fn duplexOption(value: Duplex) -> String {
+    match value {
+        DefaultDuplex -> "",
+        OneSided -> "sides=one-sided",
+        LongEdge -> "sides=two-sided-long-edge",
+        ShortEdge -> "sides=two-sided-short-edge",
+    }
+}
+
+fn colorOption(value: ColorMode) -> String {
+    match value {
+        DefaultColor -> "",
+        Color -> "ColorModel=RGB",
+        Grayscale -> "ColorModel=Gray",
+    }
+}
+
+fn pageRangesSpec(ranges: List<PageRange>) -> String {
+    let mut parts: List<String> = []
+    for r in ranges {
+        if r.from == r.to {
+            parts.push(r.from.toString())
+        } else {
+            parts.push("{r.from}-{r.to}")
+        }
+    }
+    strings.join(parts, ",")
+}
+
+fn isPrintableMime(mime: String) -> Bool {
+    let m = strings.toLower(mime)
+    m == "application/pdf" || strings.startsWith(m, "image/")
+}
+
+fn parseDefaultPrinterName(text: String) -> String {
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if strings.startsWith(trimmed, "system default destination:") {
+            return strings.trimSpace(strings.trimPrefix(trimmed, "system default destination:"))
+        }
+        if strings.startsWith(trimmed, "default destination:") {
+            return strings.trimSpace(strings.trimPrefix(trimmed, "default destination:"))
+        }
+    }
+    ""
+}
+
+fn parsePrinters(text: String) -> List<Printer> {
+    let defaultName = parseDefaultPrinterName(text)
+    let mut out: List<Printer> = []
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if strings.startsWith(trimmed, "printer ") {
+            let fields = strings.fields(trimmed)
+            if fields.len() >= 2 {
+                let name = fields[1]
+                out.push(Printer { name: name, isDefault: name == defaultName })
+            }
+        }
+    }
+    out
+}
+
+fn parseJobId(text: String) -> String {
+    let trimmed = strings.trimSpace(text)
+    if strings.startsWith(trimmed, "request id is ") {
+        let rest = strings.trimPrefix(trimmed, "request id is ")
+        let fields = strings.fields(rest)
+        if fields.len() > 0 {
+            return fields[0]
+        }
+    }
+    ""
+}
+
+fn powerShellQuote(value: String) -> String {
+    "'{strings.replaceAll(value, "'", "''")}'"
+}

--- a/internal/stdlib/print_test.go
+++ b/internal/stdlib/print_test.go
@@ -1,0 +1,98 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestPrintModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["print"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		t.Fatalf("std.print not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
+	}
+	for _, name := range []string{
+		"DocumentKind", "Backend", "Orientation", "Duplex", "ColorMode",
+		"Document", "PageRange", "Options", "Printer", "CommandPlan", "Job",
+	} {
+		requirePublicType(t, mod, "print", name)
+	}
+	for _, name := range []string{
+		"options", "withPrinter", "withCopies", "withJobName", "withMedia", "withFitToPage",
+		"withOrientation", "withDuplex", "withColorMode", "withPageRanges", "withBackend",
+		"pageRange", "file", "pdf", "image", "isPrintable", "defaultPrinterName", "printers",
+		"plan", "print", "printFile", "printPdf", "printImage",
+	} {
+		requirePublicFn(t, mod, "print", name)
+	}
+}
+
+func TestPrintModuleSourcePinsHostCommandSurface(t *testing.T) {
+	src := printModuleSource(t)
+	for _, want := range []string{
+		"std.print - host printer jobs",
+		"pub enum Backend",
+		"pub struct Options",
+		"pub struct Job",
+		"pub fn defaultPrinterName() -> Result<String, Error>",
+		"pub fn printers() -> Result<List<Printer>, Error>",
+		"pub fn plan(doc: Document, opts: Options) -> Result<CommandPlan, Error>",
+		"pub fn print(doc: Document, opts: Options) -> Result<Job, Error>",
+		"pub fn printPdf(path: String) -> Result<Job, Error>",
+		"pub fn printImage(path: String) -> Result<Job, Error>",
+		`os.exec("lpstat", ["-d"])`,
+		`CommandPlan { command: "lp", args: args }`,
+		`CommandPlan { command: "lpr", args: args }`,
+		`Start-Process -FilePath {powerShellQuote(doc.path)} -Verb Print`,
+		`fs.exists(doc.path)`,
+		`media.detectByName(path)`,
+		`strings.startsWith(m, "image/")`,
+		`pageRangesSpec(opts.pageRanges)`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.print source missing %q", want)
+		}
+	}
+}
+
+func TestPrintImportResolvesPdfAndImageWorkflow(t *testing.T) {
+	src := `
+use std.print as print
+
+pub fn demo(path: String) -> Result<print.CommandPlan, Error> {
+    let mut opts = print.options()
+    opts = print.withPrinter(opts, "Office")
+    opts = print.withCopies(opts, 2)
+    opts = print.withDuplex(opts, print.LongEdge)
+    opts = print.withColorMode(opts, print.Grayscale)
+    opts = print.withPageRanges(opts, [print.pageRange(1, 3)?])
+    let doc = if path.endsWith(".pdf") { print.pdf(path) } else { print.image(path) }
+    print.plan(doc, opts)
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, Load())
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		t.Errorf("resolver rejected std.print fixture: %s: %s", d.Code, d.Message)
+	}
+}
+
+func printModuleSource(t *testing.T) string {
+	t.Helper()
+	reg := LoadCached()
+	mod := reg.Modules["print"]
+	if mod == nil {
+		t.Fatal("stdlib print module missing")
+	}
+	return string(mod.Source)
+}


### PR DESCRIPTION
## Summary
- Add `std.print` for host-backed PDF/image print jobs through CUPS `lp`/`lpr`, Windows shell print, and custom command plans.
- Add stdlib and backend check coverage for the new print module.
- Document `std.print` in the standard library spec and support matrix.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestPrint|TestStdlibSupportMatrix' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultPrint' -v`
- `git diff --check`