### PR TITLE
[codex] add std.watch module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 79 공개 모듈. 분류 기준:
+총 80 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (76 / 79 = 96%)
+### ⭐⭐⭐⭐⭐ Production (77 / 80 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -81,6 +81,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | websocket | 322 | pure Osty + crypto/encoding | RFC 6455 accept key + handshake headers + frame encode/decode |
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
 | cmd | 214 | os shim + runtime | command builder, cwd/env/timeout, captured output, POSIX shell escaping, pipeline rendering |
+| watch | 535 | pure Osty + fs/time/cmd | polling file watcher: fs.watch snapshot parsing, typed create/modify/remove diff, debounce, hidden/build-dir filters, transform/sync command tasks |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
@@ -108,7 +109,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (3 / 79 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 80 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -137,6 +138,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 설정 파일 로딩 | ✅ 즉시 가능 | config + json + fs + env |
 | 데이터 처리 (CSV / TSV / JSON / tables) | ✅ 즉시 가능 | table + csv + json + collections + iter + fmt |
 | 파일 변환기 / 아카이브 | ✅ 가능 | fs + io + tar + compress (gzip 만) + fmt |
+| 파일 변경 감시 / 자동 변환 | ✅ 가능 | watch + fs + time + cmd |
 | 암호화 / 해시 | ✅ 가능 | crypto (sha256 / hmac / random / constantTimeEq) |
 | 랜덤 게임 / 시뮬레이션 | ✅ 가능 | random (seeded RNG) + math |
 | 수치 계산 | ✅ 가능 | math (sin / cos / log / exp / sqrt / pow / floor / ceil / clamp / hypot) |
@@ -197,7 +199,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 56 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, graphql, template, i18n, char, iter, bytes)
+- 57 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, watch, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)

--- a/internal/backend/llvm_big_stdlib_modules_test.go
+++ b/internal/backend/llvm_big_stdlib_modules_test.go
@@ -207,6 +207,51 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryRunsStdWatchDiffPlanning(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.watch as watch
+
+fn main() {
+    let before = watch.parseRows(".", ["F\t5\t1\t./src/a.md", "F\t2\t1\t./src/old.md"]).unwrap()
+    let after = watch.parseRows(".", ["F\t6\t2\t./src/a.md", "F\t1\t1\t./src/b.md"]).unwrap()
+    let events = watch.diff(before, after)
+    println(events.len())
+    println(watch.kindName(events[0].kind))
+    println(events[0].relativePath)
+    println(watch.kindName(events[1].kind))
+    println(events[1].relativePath)
+    println(watch.kindName(events[2].kind))
+    println(events[2].relativePath)
+    println(watch.summary(events))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "" +
+		"3\n" +
+		"removed\n" +
+		"src/old.md\n" +
+		"modified\n" +
+		"src/a.md\n" +
+		"created\n" +
+		"src/b.md\n" +
+		"1 created, 1 modified, 1 removed\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func logBackendWarnings(t *testing.T, result *Result) {
 	t.Helper()
 	if result == nil {

--- a/internal/backend/stdlib_watch_check_test.go
+++ b/internal/backend/stdlib_watch_check_test.go
@@ -1,0 +1,26 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultWatch(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "watch")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(watch) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("watch module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/watch.osty
+++ b/internal/stdlib/modules/watch.osty
@@ -1,0 +1,541 @@
+// std.watch - polling file-change watcher helpers.
+//
+// The runtime-backed `std.fs.watch` primitive returns one snapshot of a
+// tree. This module turns those rows into typed entries, diffs snapshots,
+// debounces change bursts, and can drive command tasks for transform or
+// sync-style developer tools.
+
+use std.cmd
+use std.error
+use std.fs
+use std.strings
+use std.time
+
+pub enum EntryKind {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+pub enum EventKind {
+    Created,
+    Modified,
+    Removed,
+}
+
+pub struct Entry {
+    pub path: String,
+    pub relativePath: String,
+    pub kind: EntryKind,
+    pub size: Int,
+    pub mtimeSeconds: Int,
+}
+
+pub struct Event {
+    pub kind: EventKind,
+    pub path: String,
+    pub relativePath: String,
+    pub entryKind: EntryKind,
+    pub before: Entry?,
+    pub after: Entry?,
+}
+
+pub struct Snapshot {
+    pub root: String,
+    pub entries: Map<String, Entry>,
+
+    pub fn paths(self) -> List<String> {
+        self.entries.keys().sorted()
+    }
+
+    pub fn len(self) -> Int {
+        self.entries.len()
+    }
+}
+
+pub struct Options {
+    pub root: String,
+    pub pollMillis: Int,
+    pub settleMillis: Int,
+    pub includeDirectories: Bool,
+    pub ignoreHidden: Bool,
+    pub ignorePrefixes: List<String>,
+    pub ignoreSuffixes: List<String>,
+    pub onlySuffixes: List<String>,
+
+    pub fn withPollMillis(mut self, millis: Int) -> Options {
+        self.pollMillis = positiveMillis(millis, self.pollMillis)
+        self
+    }
+
+    pub fn withSettleMillis(mut self, millis: Int) -> Options {
+        self.settleMillis = if millis < 0 { 0 } else { millis }
+        self
+    }
+
+    pub fn withDirectories(mut self, include: Bool) -> Options {
+        self.includeDirectories = include
+        self
+    }
+
+    pub fn withHidden(mut self, include: Bool) -> Options {
+        self.ignoreHidden = !include
+        self
+    }
+
+    pub fn withOnlySuffix(mut self, suffix: String) -> Options {
+        self.onlySuffixes.push(suffix)
+        self
+    }
+
+    pub fn withIgnorePrefix(mut self, prefix: String) -> Options {
+        self.ignorePrefixes.push(prefix)
+        self
+    }
+
+    pub fn withIgnoreSuffix(mut self, suffix: String) -> Options {
+        self.ignoreSuffixes.push(suffix)
+        self
+    }
+}
+
+pub struct Watcher {
+    pub options: Options,
+    pub previous: Snapshot,
+}
+
+pub struct Poll {
+    pub watcher: Watcher,
+    pub events: List<Event>,
+}
+
+pub struct Task {
+    pub name: String,
+    pub command: cmd.Command,
+    pub suffixes: List<String>,
+    pub runOnCreate: Bool,
+    pub runOnModify: Bool,
+    pub runOnRemove: Bool,
+
+    pub fn withSuffix(mut self, suffix: String) -> Task {
+        self.suffixes.push(suffix)
+        self
+    }
+
+    pub fn withCreates(mut self, enabled: Bool) -> Task {
+        self.runOnCreate = enabled
+        self
+    }
+
+    pub fn withModifies(mut self, enabled: Bool) -> Task {
+        self.runOnModify = enabled
+        self
+    }
+
+    pub fn withRemoves(mut self, enabled: Bool) -> Task {
+        self.runOnRemove = enabled
+        self
+    }
+}
+
+pub fn options(root: String) -> Options {
+    Options {
+        root: root,
+        pollMillis: 250,
+        settleMillis: 50,
+        includeDirectories: false,
+        ignoreHidden: true,
+        ignorePrefixes: [".git", ".osty", ".direnv", ".bin", ".profiles", "node_modules"],
+        ignoreSuffixes: ["~", ".tmp", ".swp", ".part"],
+        onlySuffixes: [],
+    }
+}
+
+pub fn snapshot(root: String) -> Result<Snapshot, Error> {
+    snapshotWithOptions(options(root))
+}
+
+pub fn snapshotWithOptions(opts: Options) -> Result<Snapshot, Error> {
+    let raw = parseRows(opts.root, fs.watch(opts.root)?)?
+    Ok(filterSnapshot(raw, opts))
+}
+
+pub fn parseRows(root: String, rows: List<String>) -> Result<Snapshot, Error> {
+    let mut entries: Map<String, Entry> = {:}
+    for row in rows {
+        if strings.trimSpace(row).isEmpty() {
+            continue
+        }
+        let entry = parseEntryForRoot(root, row)?
+        entries.insert(entry.relativePath, entry)
+    }
+    Ok(Snapshot { root: root, entries: entries })
+}
+
+pub fn parseEntry(row: String) -> Result<Entry, Error> {
+    parseEntryForRoot(".", row)
+}
+
+pub fn parseEntryForRoot(root: String, row: String) -> Result<Entry, Error> {
+    let parts = strings.splitN(row, "\t", 4)
+    if parts.len() < 4 {
+        return Err(error.new("watch: malformed snapshot row"))
+    }
+    let path = normalizePath(parts[3])
+    let relative = relativeToRoot(root, path)
+    Ok(Entry {
+        path: path,
+        relativePath: relative,
+        kind: entryKindFromCode(parts[0]),
+        size: strings.toInt(parts[1])?,
+        mtimeSeconds: strings.toInt(parts[2])?,
+    })
+}
+
+pub fn diff(before: Snapshot, after: Snapshot) -> List<Event> {
+    let mut events: List<Event> = []
+    for path in before.entries.keys().sorted() {
+        let old = before.entries.get(path).unwrap()
+        match after.entries.get(path) {
+            Some(_) -> {},
+            None -> {
+                events.push(Event {
+                    kind: Removed,
+                    path: old.path,
+                    relativePath: old.relativePath,
+                    entryKind: old.kind,
+                    before: Some(old),
+                    after: None,
+                })
+            },
+        }
+    }
+    for path in after.entries.keys().sorted() {
+        let next = after.entries.get(path).unwrap()
+        match before.entries.get(path) {
+            Some(old) -> {
+                if entryChanged(old, next) {
+                    events.push(Event {
+                        kind: Modified,
+                        path: next.path,
+                        relativePath: next.relativePath,
+                        entryKind: next.kind,
+                        before: Some(old),
+                        after: Some(next),
+                    })
+                }
+            },
+            None -> {
+                events.push(Event {
+                    kind: Created,
+                    path: next.path,
+                    relativePath: next.relativePath,
+                    entryKind: next.kind,
+                    before: None,
+                    after: Some(next),
+                })
+            },
+        }
+    }
+    events
+}
+
+pub fn open(root: String) -> Result<Watcher, Error> {
+    openWithOptions(options(root))
+}
+
+pub fn openWithOptions(opts: Options) -> Result<Watcher, Error> {
+    Ok(Watcher { options: opts, previous: snapshotWithOptions(opts)? })
+}
+
+pub fn poll(watcher: Watcher) -> Result<Poll, Error> {
+    let next = snapshotWithOptions(watcher.options)?
+    Ok(Poll {
+        watcher: Watcher { options: watcher.options, previous: next },
+        events: diff(watcher.previous, next),
+    })
+}
+
+pub fn wait(watcher: Watcher) -> Result<Poll, Error> {
+    let mut current = watcher
+    for true {
+        time.sleep(millisDuration(current.options.pollMillis))?
+        let first = poll(current)?
+        if first.events.len() > 0 {
+            if first.watcher.options.settleMillis > 0 {
+                time.sleep(millisDuration(first.watcher.options.settleMillis))?
+                return poll(current)
+            }
+            return Ok(first)
+        }
+        current = first.watcher
+    }
+    Ok(Poll { watcher: current, events: [] })
+}
+
+pub fn watch(options: Options, handler: fn(List<Event>) -> Result<(), Error>) -> Result<(), Error> {
+    let mut watcher = openWithOptions(options)?
+    for true {
+        let polled = wait(watcher)?
+        if polled.events.len() > 0 {
+            handler(polled.events)?
+        }
+        watcher = polled.watcher
+    }
+    Ok(())
+}
+
+pub fn task(name: String, command: cmd.Command) -> Task {
+    Task {
+        name: name,
+        command: command,
+        suffixes: [],
+        runOnCreate: true,
+        runOnModify: true,
+        runOnRemove: false,
+    }
+}
+
+pub fn transformTask(name: String, command: cmd.Command, suffixes: List<String>) -> Task {
+    Task {
+        name: name,
+        command: command,
+        suffixes: suffixes,
+        runOnCreate: true,
+        runOnModify: true,
+        runOnRemove: false,
+    }
+}
+
+pub fn shellTask(name: String, line: String, suffixes: List<String>) -> Task {
+    transformTask(name, cmd.shell(line), suffixes)
+}
+
+pub fn syncTask(name: String, command: cmd.Command) -> Task {
+    Task {
+        name: name,
+        command: command,
+        suffixes: [],
+        runOnCreate: true,
+        runOnModify: true,
+        runOnRemove: true,
+    }
+}
+
+pub fn runTask(task: Task, events: List<Event>) -> Result<List<cmd.RunOutput>, Error> {
+    if !taskMatches(task, events) {
+        return Ok([])
+    }
+    let out = task.command.run()?
+    Ok([out])
+}
+
+pub fn runTasks(tasks: List<Task>, events: List<Event>) -> Result<List<cmd.RunOutput>, Error> {
+    let mut outputs: List<cmd.RunOutput> = []
+    for t in tasks {
+        for out in runTask(t, events)? {
+            outputs.push(out)
+        }
+    }
+    Ok(outputs)
+}
+
+pub fn runLoop(options: Options, tasks: List<Task>) -> Result<(), Error> {
+    let mut watcher = openWithOptions(options)?
+    for true {
+        let polled = wait(watcher)?
+        runTasks(tasks, polled.events)?
+        watcher = polled.watcher
+    }
+    Ok(())
+}
+
+pub fn changedPaths(events: List<Event>) -> List<String> {
+    let mut out: List<String> = []
+    for event in events {
+        if event.relativePath.isEmpty() {
+            out.push(event.path)
+        } else {
+            out.push(event.relativePath)
+        }
+    }
+    out
+}
+
+pub fn renderEvents(events: List<Event>) -> List<String> {
+    let mut out: List<String> = []
+    for event in events {
+        let path = if event.relativePath.isEmpty() { event.path } else { event.relativePath }
+        out.push("{kindName(event.kind)}\t{path}")
+    }
+    out
+}
+
+pub fn summary(events: List<Event>) -> String {
+    let mut created = 0
+    let mut modified = 0
+    let mut removed = 0
+    for event in events {
+        match event.kind {
+            Created -> {
+                created = created + 1
+            },
+            Modified -> {
+                modified = modified + 1
+            },
+            Removed -> {
+                removed = removed + 1
+            },
+        }
+    }
+    "{created} created, {modified} modified, {removed} removed"
+}
+
+pub fn kindName(kind: EventKind) -> String {
+    match kind {
+        Created -> "created",
+        Modified -> "modified",
+        Removed -> "removed",
+    }
+}
+
+fn filterSnapshot(snap: Snapshot, opts: Options) -> Snapshot {
+    let mut entries: Map<String, Entry> = {:}
+    for path in snap.entries.keys().sorted() {
+        let entry = snap.entries.get(path).unwrap()
+        if includeEntry(entry, opts) {
+            entries.insert(entry.relativePath, entry)
+        }
+    }
+    Snapshot { root: snap.root, entries: entries }
+}
+
+fn includeEntry(entry: Entry, opts: Options) -> Bool {
+    if entry.kind == Directory && !opts.includeDirectories {
+        return false
+    }
+    if opts.ignoreHidden && isHiddenPath(entry.relativePath) {
+        return false
+    }
+    if hasIgnoredPrefix(entry.relativePath, opts.ignorePrefixes) {
+        return false
+    }
+    if hasAnySuffix(entry.relativePath, opts.ignoreSuffixes) {
+        return false
+    }
+    if opts.onlySuffixes.len() > 0 && !hasAnySuffix(entry.relativePath, opts.onlySuffixes) {
+        return false
+    }
+    true
+}
+
+fn taskMatches(task: Task, events: List<Event>) -> Bool {
+    for event in events {
+        if taskWantsKind(task, event.kind) && taskMatchesSuffix(task, event) {
+            return true
+        }
+    }
+    false
+}
+
+fn taskWantsKind(task: Task, kind: EventKind) -> Bool {
+    match kind {
+        Created -> task.runOnCreate,
+        Modified -> task.runOnModify,
+        Removed -> task.runOnRemove,
+    }
+}
+
+fn taskMatchesSuffix(task: Task, event: Event) -> Bool {
+    if task.suffixes.len() == 0 {
+        return true
+    }
+    let path = if event.relativePath.isEmpty() { event.path } else { event.relativePath }
+    hasAnySuffix(path, task.suffixes)
+}
+
+fn entryChanged(before: Entry, after: Entry) -> Bool {
+    before.kind != after.kind || before.size != after.size || before.mtimeSeconds != after.mtimeSeconds
+}
+
+fn entryKindFromCode(code: String) -> EntryKind {
+    let tag = if code.isEmpty() { "" } else { strings.slice(code, 0, 1) }
+    match tag {
+        "F" -> File,
+        "D" -> Directory,
+        "L" -> Symlink,
+        _ -> Other,
+    }
+}
+
+fn relativeToRoot(root: String, path: String) -> String {
+    let cleanRoot = normalizePath(root)
+    let cleanPath = normalizePath(path)
+    if cleanRoot.isEmpty() || cleanRoot == "." {
+        return cleanPath
+    }
+    if cleanPath == cleanRoot {
+        return ""
+    }
+    let prefix = "{cleanRoot}/"
+    if strings.startsWith(cleanPath, prefix) {
+        return strings.slice(cleanPath, prefix.len(), cleanPath.len())
+    }
+    cleanPath
+}
+
+fn normalizePath(path: String) -> String {
+    let mut out = strings.replaceAll(path, "\\", "/")
+    for strings.startsWith(out, "./") {
+        out = strings.slice(out, 2, out.len())
+    }
+    out
+}
+
+fn isHiddenPath(path: String) -> Bool {
+    for part in strings.split(path, "/") {
+        if part.isEmpty() || part == "." {
+            continue
+        }
+        if strings.startsWith(part, ".") {
+            return true
+        }
+    }
+    false
+}
+
+fn hasIgnoredPrefix(path: String, prefixes: List<String>) -> Bool {
+    for prefix in prefixes {
+        let clean = normalizePath(prefix)
+        if clean.isEmpty() {
+            continue
+        }
+        if path == clean || strings.startsWith(path, "{clean}/") {
+            return true
+        }
+    }
+    false
+}
+
+fn hasAnySuffix(path: String, suffixes: List<String>) -> Bool {
+    for suffix in suffixes {
+        if !suffix.isEmpty() && strings.endsWith(path, suffix) {
+            return true
+        }
+    }
+    false
+}
+
+fn millisDuration(millis: Int) -> time.Duration {
+    let nanosPerMilli: Int64 = 1000000
+    time.Duration { nanoseconds: positiveMillis(millis, 1).toInt64() * nanosPerMilli }
+}
+
+fn positiveMillis(value: Int, fallback: Int) -> Int {
+    if value <= 0 {
+        fallback
+    } else {
+        value
+    }
+}

--- a/internal/stdlib/watch_test.go
+++ b/internal/stdlib/watch_test.go
@@ -1,0 +1,49 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWatchModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["watch"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.watch not loaded")
+	}
+	for _, name := range []string{
+		"options", "snapshot", "snapshotWithOptions", "parseRows", "parseEntry", "parseEntryForRoot",
+		"diff", "open", "openWithOptions", "poll", "wait", "watch",
+		"task", "transformTask", "shellTask", "syncTask", "runTask", "runTasks", "runLoop",
+		"changedPaths", "renderEvents", "summary", "kindName",
+	} {
+		requirePublicFn(t, mod, "watch", name)
+	}
+	for _, name := range []string{"EntryKind", "EventKind", "Entry", "Event", "Snapshot", "Options", "Watcher", "Poll", "Task"} {
+		requirePublicType(t, mod, "watch", name)
+	}
+}
+
+func TestWatchModuleSourcePinsPollingDiffAndTaskBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["watch"]
+	if mod == nil {
+		t.Fatal("std.watch module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn snapshotWithOptions(opts: Options) -> Result<Snapshot, Error>`,
+		`parseRows(opts.root, fs.watch(opts.root)?)?`,
+		`let parts = strings.splitN(row, "\t", 4)`,
+		`pub fn diff(before: Snapshot, after: Snapshot) -> List<Event>`,
+		`time.sleep(millisDuration(current.options.pollMillis))?`,
+		`pub fn watch(options: Options, handler: fn(List<Event>) -> Result<(), Error>) -> Result<(), Error>`,
+		`transformTask(name, cmd.shell(line), suffixes)`,
+		`pub fn runLoop(options: Options, tasks: List<Task>) -> Result<(), Error>`,
+		`Created -> "created"`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.watch source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `std.watch` as a polling watcher layer over `std.fs.watch`
- expose typed snapshots, entries, create/modify/remove diffs, debounce polling, filters, and transform/sync command tasks
- update stdlib matrix and add stdlib/backend coverage including an LLVM binary smoke test

## Validation
- `go run ./cmd/osty check internal/stdlib/modules/watch.osty`
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultWatch|TestLLVMBackendBinaryRunsStdWatchDiffPlanning' -v`
- `just fmt-check`
- `git diff --check`