### PR TITLE
[codex] add std scan automation surface

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/37-scan.md
+++ b/LANG_SPEC_v0.5/10-standard-library/37-scan.md
@@ -1,0 +1,41 @@
+### 10.37 Scanner Automation (`std.scan`)
+
+`std.scan` provides a typed automation layer for document scanners. Scanner
+drivers remain host-specific, so the module plans and runs host commands rather
+than embedding a driver stack. The built-in backend targets SANE `scanimage`;
+other tools can be wrapped with `CustomCommand` and placeholder arguments.
+
+Core surface:
+
+```osty
+scan.scanimageOptions(outputDir) -> Options
+scan.adfOptions(outputDir) -> Options
+scan.duplexAdfOptions(outputDir) -> Options
+scan.customCommandOptions(command, outputDir) -> Options
+scan.plan(options) -> Result<CommandPlan, Error>
+scan.run(options) -> Result<ScanResult, Error>
+scan.scanAndOcr(options, ocrOptions, maxChunkChars, reviewThreshold) -> Result<OcrScanResult, Error>
+scan.parseScanimageDevices(text) -> List<Device>
+scan.listDevices(command) -> Result<List<Device>, Error>
+scan.listDefaultDevices() -> Result<List<Device>, Error>
+scan.manifest(result) -> String
+```
+
+`Options` covers device id, source (`Flatbed`, `Adf`, `DuplexAdf`), color mode,
+format (`Png`, `Jpeg`, `Tiff`, `Pnm`, `Pdf`), output directory, filename prefix,
+page count, DPI, page size, timeout, and extra host arguments. `Scanimage`
+rejects `Pdf` because `scanimage` emits image streams; use `CustomCommand` for
+PDF-producing tools.
+
+Custom command placeholders:
+
+- `\{output\}`: first planned page path
+- `\{outputs\}`: all planned page paths joined by spaces
+- `\{outputDir\}`: output directory
+- `\{batchPattern\}`: scanimage-style batch pattern
+- `\{device\}`: configured device id
+- `\{format\}`: lower-case format name
+- `\{dpi\}`: configured resolution
+
+The OCR handoff uses `std.ocr.run` for each scanned page, returns a scan-local
+`OcrBatch`, and builds indexed documents with `ocr.indexDocument`.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -51,3 +51,4 @@ lowering remains implementation backlog.
   `std.tokenest`, `std.shortid`, `std.metrics`)](./34-deneb-utilities.md)
 - [§10.35 Tables (`std.table`)](./35-table.md)
 - [§10.36 AI API (`std.ai`)](./36-ai.md)
+- [§10.37 Scanner Automation (`std.scan`)](./37-scan.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 80 공개 모듈. 분류 기준:
+총 81 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (77 / 80 = 96%)
+### ⭐⭐⭐⭐⭐ Production (78 / 81 = 96%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -71,6 +71,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | image | 372 | pure Osty + bytes | PNG / JPEG / GIF / BMP / WebP format + dimension metadata parser |
 | ocr | 1136 | pure Osty + os/fs/json | PaddleOCR v5 / Tesseract command adapters, fast/accurate presets, batch JSON ingestion, confidence review queues, search, key-value extraction, RAG-friendly chunks |
+| scan | 670 | pure Osty + os/fs/image/ocr | SANE `scanimage` / custom scanner command planning, device-list parsing, batch page paths, image metadata probe, manifest generation, scan→OCR indexed document handoff |
 | smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
@@ -109,7 +110,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (3 / 80 = 4%)
+### ⭐⭐⭐⭐ Production-adjacent (3 / 81 = 4%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -124,7 +125,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `dialog`, `watch`, `scan` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -160,6 +161,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | ZIP 아카이브 | ✅ 가능 | zip (stored-entry encode/decode/list/extract, deflate 는 runtime 후보) |
 | 이미지 메타데이터 | ✅ 가능 | image (PNG / JPEG / GIF / BMP / WebP dimensions) |
 | OCR 엔진 연결 / 결과 분석 | ✅ 가능 | ocr (PaddleOCR v5 / Tesseract 실행 계획, JSON/TSV normalize, confidence/search/key-value/chunk helpers) |
+| 스캔→OCR 문서 자동화 | ✅ 가능 | scan + ocr + image + fs/os (SANE/custom scanner command plan, scanned page metadata, OCR batch/index/manifest) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
@@ -199,7 +201,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 57 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, smtp, result, option, csv, encoding, zip, term, websocket, watch, graphql, template, i18n, char, iter, bytes)
+- 58 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - 나머지는 의도된 범위에서 surface 만으로 완성 (cli, math, cmp, hint, debug, ref, process, log, time, error, sync, thread, regex, testing, uuid)

--- a/internal/backend/stdlib_scan_check_test.go
+++ b/internal/backend/stdlib_scan_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultScan(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "scan")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(scan) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("scan module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/scan.osty
+++ b/internal/stdlib/modules/scan.osty
@@ -1,0 +1,670 @@
+// std.scan - host scanner command adapters plus OCR handoff helpers.
+//
+// Scanners are platform and driver specific, so the stdlib keeps hardware I/O
+// behind host commands. The pure Osty layer plans SANE scanimage or custom
+// command invocations, records expected page images, probes image metadata when
+// files exist, and hands pages directly to std.ocr for document automation.
+
+use std.error
+use std.fs
+use std.image
+use std.ocr
+use std.os
+use std.strings
+
+pub enum Backend {
+    Scanimage,
+    CustomCommand,
+}
+
+pub enum Source {
+    DefaultSource,
+    Flatbed,
+    Adf,
+    DuplexAdf,
+}
+
+pub enum ColorMode {
+    Color,
+    Gray,
+    Lineart,
+}
+
+pub enum ScanFormat {
+    Png,
+    Jpeg,
+    Tiff,
+    Pnm,
+    Pdf,
+}
+
+pub struct Device {
+    pub id: String,
+    pub name: String,
+    pub vendor: String = "",
+    pub model: String = "",
+    pub kind: String = "scanner",
+}
+
+pub struct Options {
+    pub backend: Backend,
+    pub command: String = "",
+    pub device: String = "",
+    pub source: Source,
+    pub colorMode: ColorMode,
+    pub format: ScanFormat,
+    pub outputDir: String,
+    pub filePrefix: String = "scan",
+    pub startIndex: Int = 1,
+    pub pageCount: Int = 1,
+    pub resolutionDpi: Int = 300,
+    pub pageSize: String = "",
+    pub duplex: Bool = false,
+    pub timeoutMillis: Int = 0,
+    pub extraArgs: List<String> = [],
+}
+
+pub struct CommandPlan {
+    pub command: String,
+    pub args: List<String>,
+    pub expectedPaths: List<String> = [],
+    pub batchPattern: String = "",
+}
+
+pub struct ScannedPage {
+    pub index: Int,
+    pub path: String,
+    pub format: ScanFormat,
+    pub mimeType: String,
+    pub metadata: image.Metadata? = None,
+}
+
+pub struct ScanResult {
+    pub id: String,
+    pub plan: CommandPlan,
+    pub output: os.ExecOutput,
+    pub pages: List<ScannedPage> = [],
+}
+
+pub struct OcrPageItem {
+    pub source: String,
+    pub document: ocr.Document? = None,
+    pub error: String = "",
+}
+
+pub struct OcrBatch {
+    pub items: List<OcrPageItem> = [],
+    pub documents: List<ocr.Document> = [],
+    pub errors: List<String> = [],
+}
+
+pub struct OcrScanResult {
+    pub scan: ScanResult,
+    pub ocrBatch: OcrBatch,
+    pub indexed: List<ocr.IndexedDocument> = [],
+}
+
+pub fn scanimageOptions(outputDir: String) -> Options {
+    Options {
+        backend: Scanimage,
+        source: DefaultSource,
+        colorMode: Color,
+        format: Png,
+        outputDir: outputDir,
+    }
+}
+
+pub fn adfOptions(outputDir: String) -> Options {
+    let mut options = scanimageOptions(outputDir)
+    options.source = Adf
+    options.pageCount = 10
+    options
+}
+
+pub fn duplexAdfOptions(outputDir: String) -> Options {
+    let mut options = adfOptions(outputDir)
+    options.source = DuplexAdf
+    options.duplex = true
+    options
+}
+
+pub fn customCommandOptions(command: String, outputDir: String) -> Options {
+    Options {
+        backend: CustomCommand,
+        command: command,
+        source: DefaultSource,
+        colorMode: Color,
+        format: Png,
+        outputDir: outputDir,
+    }
+}
+
+pub fn withCommand(mut options: Options, command: String) -> Options {
+    options.command = command
+    options
+}
+
+pub fn withDevice(mut options: Options, device: String) -> Options {
+    options.device = device
+    options
+}
+
+pub fn withSource(mut options: Options, source: Source) -> Options {
+    options.source = source
+    options
+}
+
+pub fn withColorMode(mut options: Options, mode: ColorMode) -> Options {
+    options.colorMode = mode
+    options
+}
+
+pub fn withFormat(mut options: Options, format: ScanFormat) -> Options {
+    options.format = format
+    options
+}
+
+pub fn withOutput(mut options: Options, outputDir: String, filePrefix: String) -> Options {
+    options.outputDir = outputDir
+    options.filePrefix = filePrefix
+    options
+}
+
+pub fn withPageCount(mut options: Options, count: Int) -> Options {
+    options.pageCount = count
+    options
+}
+
+pub fn withStartIndex(mut options: Options, index: Int) -> Options {
+    options.startIndex = index
+    options
+}
+
+pub fn withResolutionDpi(mut options: Options, dpi: Int) -> Options {
+    options.resolutionDpi = dpi
+    options
+}
+
+pub fn withPageSize(mut options: Options, pageSize: String) -> Options {
+    options.pageSize = pageSize
+    options
+}
+
+pub fn withDuplex(mut options: Options, duplex: Bool) -> Options {
+    options.duplex = duplex
+    if duplex {
+        options.source = DuplexAdf
+    }
+    options
+}
+
+pub fn withTimeoutMillis(mut options: Options, millis: Int) -> Options {
+    options.timeoutMillis = millis
+    options
+}
+
+pub fn withExtraArg(mut options: Options, arg: String) -> Options {
+    options.extraArgs.push(arg)
+    options
+}
+
+pub fn withExtraArgs(mut options: Options, args: List<String>) -> Options {
+    for arg in args {
+        options.extraArgs.push(arg)
+    }
+    options
+}
+
+pub fn plannedPaths(options: Options) -> List<String> {
+    let count = maxInt(1, options.pageCount)
+    let mut out: List<String> = []
+    let mut i = 0
+    for i < count {
+        out.push(pagePath(options.outputDir, options.filePrefix, options.startIndex + i, options.format))
+        i = i + 1
+    }
+    out
+}
+
+pub fn pagePath(outputDir: String, prefix: String, index: Int, format: ScanFormat) -> String {
+    os.path.join([outputDir, "{normalizedPrefix(prefix)}-{padLeft(index.toString(), 3, "0")}.{formatExtension(format)}"])
+}
+
+pub fn plan(options: Options) -> Result<CommandPlan, Error> {
+    validateOptions(options)?
+    match options.backend {
+        Scanimage -> scanimagePlan(options),
+        CustomCommand -> customPlan(options),
+    }
+}
+
+pub fn scanimagePlan(options: Options) -> Result<CommandPlan, Error> {
+    if options.format == Pdf {
+        return Err(error.new("scan: scanimage does not emit PDF directly; scan an image format or use CustomCommand"))
+    }
+    let command = defaultCommand(options.command, "scanimage")
+    let paths = plannedPaths(options)
+    let mut args: List<String> = []
+    if !options.device.isEmpty() {
+        args.push("--device-name")
+        args.push(options.device)
+    }
+    args.push("--format")
+    args.push(scanimageFormat(options.format))
+    if options.resolutionDpi > 0 {
+        args.push("--resolution")
+        args.push(options.resolutionDpi.toString())
+    }
+    let source = scanimageSource(options)
+    if !source.isEmpty() {
+        args.push("--source")
+        args.push(source)
+    }
+    let mode = colorModeName(options.colorMode)
+    if !mode.isEmpty() {
+        args.push("--mode")
+        args.push(mode)
+    }
+    if !options.pageSize.isEmpty() {
+        args.push("--page-size")
+        args.push(options.pageSize)
+    }
+    let batch = if paths.len() > 1 {
+        batchPattern(options)
+    } else {
+        ""
+    }
+    if paths.len() <= 1 {
+        args.push("--output-file")
+        args.push(firstOutputPath(paths))
+    } else {
+        args.push("--batch={batch}")
+        args.push("--batch-start={options.startIndex}")
+        args.push("--batch-count={options.pageCount}")
+    }
+    appendExtraArgs(args, options.extraArgs)
+    Ok(CommandPlan {command: command, args: args, expectedPaths: paths, batchPattern: batch})
+}
+
+pub fn customPlan(options: Options) -> Result<CommandPlan, Error> {
+    if strings.trimSpace(options.command).isEmpty() {
+        return Err(error.new("scan: custom command is empty"))
+    }
+    let paths = plannedPaths(options)
+    Ok(CommandPlan {
+        command: options.command,
+        args: renderCustomArgs(options, paths),
+        expectedPaths: paths,
+        batchPattern: if paths.len() > 1 { batchPattern(options) } else { "" },
+    })
+}
+
+pub fn commandLine(plan: CommandPlan) -> String {
+    let mut parts: List<String> = [shellQuote(plan.command)]
+    for arg in plan.args {
+        parts.push(shellQuote(arg))
+    }
+    strings.join(parts, " ")
+}
+
+pub fn scan(options: Options) -> Result<ScanResult, Error> {
+    run(options)
+}
+
+pub fn run(options: Options) -> Result<ScanResult, Error> {
+    let cmd = plan(options)?
+    let output = os.execWith(cmd.command, cmd.args, "", {:}, options.timeoutMillis)?
+    if output.timedOut {
+        return Err(error.new("scan: command timed out"))
+    }
+    if output.exitCode != 0 {
+        return Err(error.new("scan: command failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    let pages = pagesFromPaths(cmd.expectedPaths, options.format)?
+    Ok(ScanResult {id: stableScanId(cmd, output), plan: cmd, output: output, pages: pages})
+}
+
+pub fn scanAndOcr(options: Options, ocrOptions: ocr.Options, maxChunkChars: Int, reviewThreshold: Float) -> Result<OcrScanResult, Error> {
+    runAndOcr(options, ocrOptions, maxChunkChars, reviewThreshold)
+}
+
+pub fn runAndOcr(options: Options, ocrOptions: ocr.Options, maxChunkChars: Int, reviewThreshold: Float) -> Result<OcrScanResult, Error> {
+    let result = run(options)?
+    let batch = ocrPages(result.pages, ocrOptions)
+    let indexed = indexOcrBatch(batch, maxChunkChars, reviewThreshold)
+    Ok(OcrScanResult {scan: result, ocrBatch: batch, indexed: indexed})
+}
+
+pub fn ocrPages(pages: List<ScannedPage>, options: ocr.Options) -> OcrBatch {
+    let mut items: List<OcrPageItem> = []
+    let mut documents: List<ocr.Document> = []
+    let mut errors: List<String> = []
+    for page in pages {
+        match ocr.run(page.path, options) {
+            Ok(result) -> {
+                documents.push(result.document)
+                items.push(OcrPageItem {source: page.path, document: Some(result.document)})
+            },
+            Err(err) -> {
+                let msg = err.message()
+                errors.push("{page.path}: {msg}")
+                items.push(OcrPageItem {source: page.path, error: msg})
+            },
+        }
+    }
+    OcrBatch {items: items, documents: documents, errors: errors}
+}
+
+pub fn indexOcrBatch(batch: OcrBatch, maxChunkChars: Int, reviewThreshold: Float) -> List<ocr.IndexedDocument> {
+    let mut out: List<ocr.IndexedDocument> = []
+    for doc in batch.documents {
+        out.push(ocr.indexDocument(doc, maxChunkChars, reviewThreshold))
+    }
+    out
+}
+
+pub fn scanimageListDevicesPlan(command: String) -> CommandPlan {
+    CommandPlan {command: defaultCommand(command, "scanimage"), args: ["-L"], expectedPaths: []}
+}
+
+pub fn scanimageDefaultListDevicesPlan() -> CommandPlan {
+    scanimageListDevicesPlan("")
+}
+
+pub fn listDevices(command: String) -> Result<List<Device>, Error> {
+    let cmd = scanimageListDevicesPlan(command)
+    let output = os.execWith(cmd.command, cmd.args, "", {:}, 0)?
+    if output.exitCode != 0 {
+        return Err(error.new("scan: device listing failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(parseScanimageDevices(output.stdout))
+}
+
+pub fn listDefaultDevices() -> Result<List<Device>, Error> {
+    listDevices("")
+}
+
+pub fn parseScanimageDevices(text: String) -> List<Device> {
+    let mut out: List<Device> = []
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if strings.startsWith(trimmed, "device `") {
+            out.push(parseScanimageDeviceLine(trimmed))
+        }
+    }
+    out
+}
+
+pub fn pagesFromPaths(paths: List<String>, format: ScanFormat) -> Result<List<ScannedPage>, Error> {
+    let mut pages: List<ScannedPage> = []
+    let mut i = 0
+    for i < paths.len() {
+        pages.push(pageFromPath(paths[i], i + 1, format)?)
+        i = i + 1
+    }
+    Ok(pages)
+}
+
+pub fn pageFromPath(path: String, index: Int, format: ScanFormat) -> Result<ScannedPage, Error> {
+    let metadata = if fs.exists(path) {
+        match image.parse(fs.read(path)?) {
+            Ok(meta) -> Some(meta),
+            Err(_) -> None,
+        }
+    } else {
+        None
+    }
+    Ok(ScannedPage {index: index, path: path, format: format, mimeType: formatMime(format), metadata: metadata})
+}
+
+pub fn pagePaths(pages: List<ScannedPage>) -> List<String> {
+    let mut out: List<String> = []
+    for page in pages {
+        out.push(page.path)
+    }
+    out
+}
+
+pub fn manifest(result: ScanResult) -> String {
+    let mut lines: List<String> = ["\{"]
+    lines.push("  \"id\": {jsonString(result.id)},")
+    lines.push("  \"command\": {jsonString(commandLine(result.plan))},")
+    lines.push("  \"exitCode\": {result.output.exitCode},")
+    lines.push("  \"pages\": [")
+    let mut i = 0
+    for i < result.pages.len() {
+        let suffix = if i + 1 < result.pages.len() { "," } else { "" }
+        lines.push("    {pageManifest(result.pages[i])}{suffix}")
+        i = i + 1
+    }
+    lines.push("  ]")
+    lines.push("\}")
+    strings.join(lines, "\n")
+}
+
+pub fn writeManifest(path: String, result: ScanResult) -> Result<(), Error> {
+    fs.writeString(path, manifest(result))
+}
+
+pub fn formatName(format: ScanFormat) -> String {
+    match format {
+        Png  -> "png",
+        Jpeg -> "jpeg",
+        Tiff -> "tiff",
+        Pnm  -> "pnm",
+        Pdf  -> "pdf",
+    }
+}
+
+pub fn formatMime(format: ScanFormat) -> String {
+    match format {
+        Png  -> "image/png",
+        Jpeg -> "image/jpeg",
+        Tiff -> "image/tiff",
+        Pnm  -> "image/x-portable-anymap",
+        Pdf  -> "application/pdf",
+    }
+}
+
+fn validateOptions(options: Options) -> Result<(), Error> {
+    if strings.trimSpace(options.outputDir).isEmpty() {
+        return Err(error.new("scan: output directory is empty"))
+    }
+    if options.pageCount <= 0 {
+        return Err(error.new("scan: page count must be positive"))
+    }
+    if options.startIndex <= 0 {
+        return Err(error.new("scan: start index must be positive"))
+    }
+    if options.resolutionDpi <= 0 {
+        return Err(error.new("scan: resolution must be positive"))
+    }
+    Ok(())
+}
+
+fn renderCustomArgs(options: Options, paths: List<String>) -> List<String> {
+    let mut args: List<String> = []
+    let mut sawOutput = false
+    for arg in options.extraArgs {
+        if strings.contains(arg, "\{output\}") || strings.contains(arg, "\{outputs\}") {
+            sawOutput = true
+        }
+        args.push(renderCustomArg(arg, options, paths))
+    }
+    if !sawOutput {
+        args.push(firstOutputPath(paths))
+    }
+    args
+}
+
+fn renderCustomArg(arg: String, options: Options, paths: List<String>) -> String {
+    let mut out = arg
+    out = strings.replaceAll(out, "\{output\}", firstOutputPath(paths))
+    out = strings.replaceAll(out, "\{outputs\}", strings.join(paths, " "))
+    out = strings.replaceAll(out, "\{outputDir\}", options.outputDir)
+    out = strings.replaceAll(out, "\{batchPattern\}", batchPattern(options))
+    out = strings.replaceAll(out, "\{device\}", options.device)
+    out = strings.replaceAll(out, "\{format\}", formatName(options.format))
+    out = strings.replaceAll(out, "\{dpi\}", options.resolutionDpi.toString())
+    out
+}
+
+fn parseScanimageDeviceLine(line: String) -> Device {
+    let id = between(line, "`", "'")
+    let name = match strings.indexOf(line, " is ") {
+        Some(i) -> strings.trimSpace(strings.slice(line, i + 4, line.charCount())),
+        None    -> id,
+    }
+    let fields = strings.fields(name)
+    let vendor = if fields.len() > 0 { fields[0] } else { "" }
+    Device {id: id, name: name, vendor: vendor, model: name, kind: "scanner"}
+}
+
+fn between(text: String, startMarker: String, endMarker: String) -> String {
+    match strings.indexOf(text, startMarker) {
+        Some(start) -> {
+            let rest = strings.slice(text, start + startMarker.charCount(), text.charCount())
+            match strings.indexOf(rest, endMarker) {
+                Some(end) -> strings.slice(rest, 0, end),
+                None      -> "",
+            }
+        },
+        None -> "",
+    }
+}
+
+fn batchPattern(options: Options) -> String {
+    os.path.join([options.outputDir, "{normalizedPrefix(options.filePrefix)}-%03d.{formatExtension(options.format)}"])
+}
+
+fn scanimageSource(options: Options) -> String {
+    if options.duplex {
+        return "ADF Duplex"
+    }
+    match options.source {
+        DefaultSource -> "",
+        Flatbed       -> "Flatbed",
+        Adf           -> "ADF",
+        DuplexAdf     -> "ADF Duplex",
+    }
+}
+
+fn colorModeName(mode: ColorMode) -> String {
+    match mode {
+        Color   -> "Color",
+        Gray    -> "Gray",
+        Lineart -> "Lineart",
+    }
+}
+
+fn scanimageFormat(format: ScanFormat) -> String {
+    match format {
+        Png  -> "png",
+        Jpeg -> "jpeg",
+        Tiff -> "tiff",
+        Pnm  -> "pnm",
+        Pdf  -> "pdf",
+    }
+}
+
+fn formatExtension(format: ScanFormat) -> String {
+    match format {
+        Png  -> "png",
+        Jpeg -> "jpg",
+        Tiff -> "tiff",
+        Pnm  -> "pnm",
+        Pdf  -> "pdf",
+    }
+}
+
+fn normalizedPrefix(prefix: String) -> String {
+    let trimmed = strings.trimSpace(prefix)
+    if trimmed.isEmpty() {
+        "scan"
+    } else {
+        trimmed
+    }
+}
+
+fn firstOutputPath(paths: List<String>) -> String {
+    if paths.len() == 0 {
+        ""
+    } else {
+        paths[0]
+    }
+}
+
+fn stableScanId(plan: CommandPlan, output: os.ExecOutput) -> String {
+    "scan:{firstOutputPath(plan.expectedPaths)}:{output.exitCode}"
+}
+
+fn pageManifest(page: ScannedPage) -> String {
+    let size = match page.metadata {
+        Some(meta) -> ", \"width\": {meta.width}, \"height\": {meta.height}, \"bitsPerPixel\": {meta.bitsPerPixel}",
+        None       -> "",
+    }
+    "\{\"index\": {page.index}, \"path\": {jsonString(page.path)}, \"format\": {jsonString(formatName(page.format))}, \"mime\": {jsonString(page.mimeType)}{size}\}"
+}
+
+fn jsonString(text: String) -> String {
+    "\"{escapeJson(text)}\""
+}
+
+fn escapeJson(text: String) -> String {
+    let slashes = strings.replaceAll(text, "\\", "\\\\")
+    let quotes = strings.replaceAll(slashes, "\"", "\\\"")
+    let lines = strings.replaceAll(quotes, "\n", "\\n")
+    strings.replaceAll(strings.replaceAll(lines, "\r", "\\r"), "\t", "\\t")
+}
+
+fn defaultCommand(value: String, fallback: String) -> String {
+    let trimmed = strings.trimSpace(value)
+    if trimmed.isEmpty() {
+        fallback
+    } else {
+        trimmed
+    }
+}
+
+fn appendExtraArgs(args: List<String>, extra: List<String>) {
+    for arg in extra {
+        args.push(arg)
+    }
+}
+
+fn padLeft(text: String, width: Int, fill: String) -> String {
+    let mut out = text
+    for out.charCount() < width {
+        out = "{fill}{out}"
+    }
+    out
+}
+
+fn shellQuote(text: String) -> String {
+    if text.isEmpty() {
+        return "''"
+    }
+    let mut safe = true
+    for c in text.chars() {
+        if !(isAsciiAlphanumeric(c) || c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '=' || c == '%') {
+            safe = false
+        }
+    }
+    if safe {
+        return text
+    }
+    let escaped = strings.replaceAll(text, "'", "'\\''")
+    "'{escaped}'"
+}
+
+fn isAsciiAlphanumeric(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b {
+        a
+    } else {
+        b
+    }
+}

--- a/internal/stdlib/scan_test.go
+++ b/internal/stdlib/scan_test.go
@@ -1,0 +1,68 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["scan"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.scan not loaded")
+	}
+	for _, name := range []string{
+		"scanimageOptions", "adfOptions", "duplexAdfOptions",
+		"customCommandOptions", "withCommand", "withDevice", "withSource",
+		"withColorMode", "withFormat", "withOutput", "withPageCount",
+		"withStartIndex", "withResolutionDpi", "withPageSize", "withDuplex",
+		"withTimeoutMillis", "withExtraArg", "withExtraArgs", "plannedPaths",
+		"pagePath", "plan", "scanimagePlan", "customPlan", "commandLine",
+		"scan", "run", "scanAndOcr", "runAndOcr", "ocrPages", "indexOcrBatch",
+		"scanimageListDevicesPlan", "scanimageDefaultListDevicesPlan",
+		"listDevices", "listDefaultDevices", "parseScanimageDevices",
+		"pagesFromPaths", "pageFromPath", "pagePaths", "manifest",
+		"writeManifest", "formatName", "formatMime",
+	} {
+		requirePublicFn(t, mod, "scan", name)
+	}
+	for _, name := range []string{
+		"Backend", "Source", "ColorMode", "ScanFormat", "Device",
+		"Options", "CommandPlan", "ScannedPage", "ScanResult", "OcrPageItem",
+		"OcrBatch", "OcrScanResult",
+	} {
+		requirePublicType(t, mod, "scan", name)
+	}
+}
+
+func TestScanModulePinsScannerAndOcrBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["scan"]
+	if mod == nil {
+		t.Fatal("std.scan module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`use std.ocr`,
+		`pub fn scanimageOptions(outputDir: String) -> Options`,
+		`pub fn duplexAdfOptions(outputDir: String) -> Options`,
+		`args.push("--device-name")`,
+		`args.push("--format")`,
+		`args.push("--resolution")`,
+		`args.push("--source")`,
+		`args.push("--batch={batch}")`,
+		`args.push("--batch-count={options.pageCount}")`,
+		`strings.replaceAll(out, "\{output\}", firstOutputPath(paths))`,
+		`pub fn scanAndOcr(options: Options, ocrOptions: ocr.Options, maxChunkChars: Int, reviewThreshold: Float) -> Result<OcrScanResult, Error>`,
+		`match ocr.run(page.path, options)`,
+		`ocr.indexDocument(doc, maxChunkChars, reviewThreshold)`,
+		`pub fn parseScanimageDevices(text: String) -> List<Device>`,
+		`strings.startsWith(trimmed, "device ` + "`" + `")`,
+		`image.parse(fs.read(path)?)`,
+		`pub fn manifest(result: ScanResult) -> String`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.scan source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add std.scan for SANE scanimage/custom scanner command planning and scanned page manifests
- wire scan results into std.ocr document indexing helpers
- document the std.scan surface and update the stdlib support matrix

## Validation
- go run ./cmd/osty check --airepair=false internal/stdlib/modules/scan.osty
- go run ./cmd/osty tokens internal/stdlib/modules/scan.osty
- go test -count=1 -vet=off ./internal/stdlib -run 'TestScanModule|TestStdlibSupportMatrix'\n- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultScan'\n- git diff --check