### PR TITLE
[codex] add std.clipboard

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -26,6 +26,8 @@
 - `std.tui` — retained terminal frame buffers and diff rendering
 - `std.grid` — `Point`, `Size`, `Rect`, `Direction`, and `Grid<T>` for
   board, map, and turn-based layouts
+- `std.clipboard` — host clipboard text read/write for small workflow tools,
+  implemented through the common platform clipboard commands
 - `std.ai` — provider-neutral AI API request builders, headers, response
   parsers, structured tool call/result loops, model listing, embeddings, and SSE
   data-line helpers for OpenAI-compatible, OpenRouter, Anthropic, Gemini, and

--- a/LANG_SPEC_v0.5/10-standard-library/39-clipboard.md
+++ b/LANG_SPEC_v0.5/10-standard-library/39-clipboard.md
@@ -1,0 +1,27 @@
+### 10.39 Clipboard (`std.clipboard`)
+
+`std.clipboard` provides small-tool clipboard text I/O. It is intentionally
+text-only; binary clipboard formats, MIME negotiation, and platform-native
+pasteboard metadata remain host/runtime concerns.
+
+```osty
+use std.clipboard
+
+clipboard.writeText("ready")?
+let current = clipboard.readText()?
+```
+
+API:
+
+```osty
+clipboard.readText() -> Result<String, Error>
+clipboard.writeText(text: String) -> Result<(), Error>
+clipboard.read() -> Result<String, Error>
+clipboard.write(text: String) -> Result<(), Error>
+clipboard.clear() -> Result<(), Error>
+```
+
+`read` and `write` are short aliases for `readText` and `writeText`.
+Implementations may delegate to host clipboard commands such as `pbpaste`,
+`pbcopy`, Wayland/X11 clipboard tools, AppleScript, or PowerShell. Failure to
+find or run a supported host command returns `Err`.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -53,3 +53,4 @@ lowering remains implementation backlog.
 - [§10.36 AI API (`std.ai`)](./36-ai.md)
 - [§10.37 Scanner Automation (`std.scan`)](./37-scan.md)
 - [§10.38 Print (`std.print`)](./38-print.md)
+- [§10.39 Clipboard (`std.clipboard`)](./39-clipboard.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 83 공개 모듈. 분류 기준:
+총 84 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (79 / 83 = 95%)
+### ⭐⭐⭐⭐⭐ Production (80 / 84 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -84,6 +84,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | cli | 260 | pure Osty + env | flag / option spec, parse / parseEnv / usage |
 | cmd | 214 | os shim + runtime | command builder, cwd/env/timeout, captured output, POSIX shell escaping, pipeline rendering |
 | watch | 535 | pure Osty + fs/time/cmd | polling file watcher: fs.watch snapshot parsing, typed create/modify/remove diff, debounce, hidden/build-dir filters, transform/sync command tasks |
+| clipboard | 125 | pure Osty + os | host clipboard text read/write via pbpaste/pbcopy, Wayland, X11, AppleScript, PowerShell |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
@@ -111,7 +112,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 83 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 84 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -127,7 +128,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `schedule`, `dialog`, `watch`, `scan`, `print` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `schedule`, `dialog`, `watch`, `scan`, `print`, `clipboard` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -142,6 +143,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 데이터 처리 (CSV / TSV / JSON / tables) | ✅ 즉시 가능 | table + csv + json + collections + iter + fmt |
 | 파일 변환기 / 아카이브 | ✅ 가능 | fs + io + tar + compress (gzip 만) + fmt |
 | 파일 변경 감시 / 자동 변환 | ✅ 가능 | watch + fs + time + cmd |
+| 클립보드 업무 도구 | ✅ 가능 | clipboard + os (host clipboard command adapters) |
 | 암호화 / 해시 | ✅ 가능 | crypto (sha256 / hmac / random / constantTimeEq) |
 | 랜덤 게임 / 시뮬레이션 | ✅ 가능 | random (seeded RNG) + math |
 | 수치 계산 | ✅ 가능 | math (sin / cos / log / exp / sqrt / pow / floor / ceil / clamp / hypot) |
@@ -205,7 +207,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 59 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, graphql, template, i18n, char, iter, bytes)
+- 60 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - print 는 기존 `std.os` host process bridge 위에서 CUPS/Windows/custom spooler 실행 계획을 제공한다. 실제 출력은 가능하지만 프린터별 capability discovery 는 production-adjacent 로 남긴다.

--- a/internal/backend/stdlib_clipboard_check_test.go
+++ b/internal/backend/stdlib_clipboard_check_test.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultClipboard(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "clipboard")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(clipboard) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("clipboard module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}
+
+func TestInjectReachableClipboardPreservesOsRuntimeBoundary(t *testing.T) {
+	reg := stdlib.LoadCached()
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "clipboard"}, Name: "readText"},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	injected, issues := injectReachableStdlibBodies(mod, reg)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %v, want none for clipboard injection", issues)
+	}
+	names := fnDeclNames(injected)
+	if !clipboardContainsString(names, "osty_std_clipboard__readText") {
+		t.Fatalf("injected names = %v, want osty_std_clipboard__readText", names)
+	}
+	ident, ok := call.Callee.(*ir.Ident)
+	if !ok || ident.Name != "osty_std_clipboard__readText" {
+		t.Fatalf("clipboard call not rewritten to injected fn: %T %#v", call.Callee, call.Callee)
+	}
+
+	foundRuntimeExec := false
+	for _, decl := range injected {
+		ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+			call, ok := n.(*ir.CallExpr)
+			if !ok || call == nil {
+				return true
+			}
+			id, ok := call.Callee.(*ir.Ident)
+			if ok && id.Name == "std.os.execWith" {
+				foundRuntimeExec = true
+			}
+			return true
+		}), decl)
+	}
+	if !foundRuntimeExec {
+		t.Fatalf("clipboard injected bodies did not retain std.os.execWith runtime boundary; injected=%v", names)
+	}
+}
+
+func clipboardContainsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/stdlib/clipboard_test.go
+++ b/internal/stdlib/clipboard_test.go
@@ -1,0 +1,63 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestClipboardModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["clipboard"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		t.Fatalf("std.clipboard not loaded with package scope; registry diagnostics:\n%s", stdlibRebindDiagSummary(reg))
+	}
+
+	for _, name := range []string{"readText", "writeText", "read", "write", "clear"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.clipboard missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.clipboard.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.clipboard.%s not public", name)
+		}
+		fn := reg.LookupFnDecl("clipboard", name)
+		if fn == nil || fn.Body == nil {
+			t.Fatalf("LookupFnDecl(clipboard, %s) = %v, want bodied fn", name, fn)
+		}
+	}
+}
+
+func TestClipboardModulePinsHostCommandStrategy(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["clipboard"]
+	if mod == nil {
+		t.Fatal("std.clipboard module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn readText() -> Result<String, Error>`,
+		`pub fn writeText(text: String) -> Result<(), Error>`,
+		`os.execWith(program, args, "", emptyEnv(), timeoutMillis())`,
+		`"pbpaste"`,
+		`pbcopy`,
+		`"wl-paste"`,
+		`wl-copy`,
+		`"xclip"`,
+		`"xsel"`,
+		`"osascript"`,
+		`"powershell.exe"`,
+		`"pwsh"`,
+		`"[Console]::Out.Write((Get-Clipboard -Raw))"`,
+		`"Set-Clipboard -Value $args[0]"`,
+		`"printf %s \"$1\" | pbcopy"`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.clipboard source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/clipboard.osty
+++ b/internal/stdlib/modules/clipboard.osty
@@ -1,0 +1,126 @@
+// std.clipboard - host clipboard text I/O for small workflow tools.
+//
+// The implementation deliberately stays in pure Osty and delegates the host
+// boundary to std.os process execution. It tries the common desktop clipboard
+// commands used by macOS, Wayland, X11, PowerShell, and WSL, returning an Error
+// when none of them is available or succeeds.
+
+use std.error
+use std.os
+
+fn timeoutMillis() -> Int {
+    5000
+}
+
+fn emptyEnv() -> Map<String, String> {
+    {:}
+}
+
+fn clipboardError(action: String) -> Error {
+    error.new("clipboard: no supported clipboard {action} command succeeded")
+}
+
+fn outputOk(out: os.ExecOutput) -> Bool {
+    out.exitCode == 0 && !out.timedOut
+}
+
+fn tryRun(program: String, args: List<String>) -> os.ExecOutput? {
+    match os.execWith(program, args, "", emptyEnv(), timeoutMillis()) {
+        Ok(out) -> {
+            if outputOk(out) {
+                Some(out)
+            } else {
+                None
+            }
+        },
+        Err(_) -> None,
+    }
+}
+
+fn tryRead(program: String, args: List<String>) -> String? {
+    let out = tryRun(program, args)
+    if out.isSome() {
+        return Some(out.unwrap().stdout)
+    }
+    None
+}
+
+fn tryWrite(program: String, args: List<String>) -> Bool {
+    tryRun(program, args).isSome()
+}
+
+pub fn readText() -> Result<String, Error> {
+    let pbpaste = tryRead("pbpaste", [])
+    if pbpaste.isSome() {
+        return Ok(pbpaste.unwrap())
+    }
+    let wayland = tryRead("wl-paste", ["--no-newline"])
+    if wayland.isSome() {
+        return Ok(wayland.unwrap())
+    }
+    let xclip = tryRead("xclip", ["-selection", "clipboard", "-out"])
+    if xclip.isSome() {
+        return Ok(xclip.unwrap())
+    }
+    let xsel = tryRead("xsel", ["--clipboard", "--output"])
+    if xsel.isSome() {
+        return Ok(xsel.unwrap())
+    }
+    let osascript = tryRead("osascript", ["-e", "the clipboard as text"])
+    if osascript.isSome() {
+        return Ok(osascript.unwrap())
+    }
+    let powershellExe = tryRead("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "[Console]::Out.Write((Get-Clipboard -Raw))"])
+    if powershellExe.isSome() {
+        return Ok(powershellExe.unwrap())
+    }
+    let powershell = tryRead("powershell", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "[Console]::Out.Write((Get-Clipboard -Raw))"])
+    if powershell.isSome() {
+        return Ok(powershell.unwrap())
+    }
+    let pwsh = tryRead("pwsh", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "[Console]::Out.Write((Get-Clipboard -Raw))"])
+    if pwsh.isSome() {
+        return Ok(pwsh.unwrap())
+    }
+    Err(clipboardError("read"))
+}
+
+pub fn writeText(text: String) -> Result<(), Error> {
+    if tryWrite("sh", ["-c", "printf %s \"$1\" | pbcopy", "osty-clipboard", text]) {
+        return Ok(())
+    }
+    if tryWrite("sh", ["-c", "printf %s \"$1\" | wl-copy", "osty-clipboard", text]) {
+        return Ok(())
+    }
+    if tryWrite("sh", ["-c", "printf %s \"$1\" | xclip -selection clipboard", "osty-clipboard", text]) {
+        return Ok(())
+    }
+    if tryWrite("sh", ["-c", "printf %s \"$1\" | xsel --clipboard --input", "osty-clipboard", text]) {
+        return Ok(())
+    }
+    if tryWrite("osascript", ["-e", "set the clipboard to (item 1 of argv)", "--", text]) {
+        return Ok(())
+    }
+    if tryWrite("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "Set-Clipboard -Value $args[0]", text]) {
+        return Ok(())
+    }
+    if tryWrite("powershell", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "Set-Clipboard -Value $args[0]", text]) {
+        return Ok(())
+    }
+    if tryWrite("pwsh", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "Set-Clipboard -Value $args[0]", text]) {
+        return Ok(())
+    }
+    Err(clipboardError("write"))
+}
+
+pub fn read() -> Result<String, Error> {
+    readText()
+}
+
+pub fn write(text: String) -> Result<(), Error> {
+    writeText(text)
+}
+
+pub fn clear() -> Result<(), Error> {
+    writeText("")
+}


### PR DESCRIPTION
## Summary
- add std.clipboard text read/write helpers backed by common host clipboard commands
- document the new stdlib surface and include it in the stdlib matrix
- add stdlib surface, checker, and injection coverage for the new module

## Validation
- go test -count=1 -vet=off ./internal/stdlib -run 'Test(Clipboard|StdlibSupportMatrix)' -v\n- go test -count=1 -vet=off ./internal/backend -run 'Test(StdlibCheckResultClipboard|InjectReachableClipboardPreservesOsRuntimeBoundary)' -v\n- just support-stdlib-medium\n- git diff --check HEAD~1..HEAD