### PR TITLE
stdlib: add std.xlsx workbook helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -21,6 +21,8 @@
 - `std.csv` — CSV read/write
 - `std.table` — small dataframe helpers for CSV/TSV-scale table work:
   type inference, schema validation/coercion, typed sort, aggregation, join
+- `std.xlsx` — stored-entry XLSX workbook encode/decode helpers with
+  row/table adapters
 - `std.compress` — gzip compression
 - `std.term` — terminal mode, ANSI control, size, and key input
 - `std.tui` — retained terminal frame buffers and diff rendering

--- a/LANG_SPEC_v0.5/10-standard-library/40-xlsx.md
+++ b/LANG_SPEC_v0.5/10-standard-library/40-xlsx.md
@@ -1,0 +1,31 @@
+### 10.40 XLSX (`std.xlsx`)
+
+`std.xlsx` builds simple Excel-compatible `.xlsx` workbooks on top of
+stored ZIP packaging and `std.table` row adapters.
+
+The first supported format is intentionally conservative: workbooks are ZIP
+packages whose entries use the ZIP "store" method, worksheet cells use inline
+strings or scalar numeric/bool values, and decode supports those same stored
+packages plus shared-string tables when present. Deflated third-party XLSX
+archives become readable once `std.compress` grows deflate support for
+`std.zip`.
+
+```osty
+use std.xlsx
+
+let bytes = xlsx.encodeRows("Report", [
+    ["name", "score"],
+    ["Ada", "42"],
+    ["Grace", "99"],
+])?
+
+let rows = xlsx.decodeRows(bytes, "Report")?
+```
+
+Primary surface:
+
+- `CellKind`, `Cell`, `Sheet`, and `Workbook`
+- `text`, `number`, `int`, `bool`, `blank`, `cell`
+- `sheet`, `workbook`, `fromRows`, `fromTable`, `toTable`, `rows`
+- `encode`, `decode`, `encodeRows`, `decodeRows`, `encodeTable`
+- `sheetNames`, `isWorkbook`, `kindName`

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -54,3 +54,4 @@ lowering remains implementation backlog.
 - [§10.37 Scanner Automation (`std.scan`)](./37-scan.md)
 - [§10.38 Print (`std.print`)](./38-print.md)
 - [§10.39 Clipboard (`std.clipboard`)](./39-clipboard.md)
+- [§10.40 XLSX (`std.xlsx`)](./40-xlsx.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 85 공개 모듈. 분류 기준:
+총 86 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (81 / 85 = 95%)
+### ⭐⭐⭐⭐⭐ Production (82 / 86 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -57,6 +57,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | json | 662 | (parser self) | generic encode<T> / decode<T>, UTF-8 / surrogate pair, value constructors |
 | config | 1253 | pure Osty + json/fs/env | TOML / YAML / INI / .env parse, read/load/readAuto/loadAuto, repeated objects, default merge, schema coercion + validation |
 | table | 1112 | pure Osty + csv | small dataframe: CSV/TSV read-write, type inference, schema validation/coercion, typed sort, group aggregation, indexed join |
+| xlsx | 926 | pure Osty + zip/table | XLSX workbook encode/decode over stored ZIP entries, inline/shared strings, row/table adapters |
 | url | 592 | — | parse / join / format |
 | io | 541 | shim 171 | Reader/Writer 프로토콜, Buffer, copyN, readExact |
 | collections | 509 | list 68 + map 42 + set 17 | 30+ List 메서드, groupBy, windowed, zip3 |
@@ -113,7 +114,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 85 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 86 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -141,7 +142,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | HTTP 웹 서버 | ✅ 즉시 가능 | http + io + json + net |
 | CLI 도구 | ✅ 즉시 가능 | os + fs + io + fmt + env |
 | 설정 파일 로딩 | ✅ 즉시 가능 | config + json + fs + env |
-| 데이터 처리 (CSV / TSV / JSON / tables) | ✅ 즉시 가능 | table + csv + json + collections + iter + fmt |
+| 데이터 처리 (CSV / TSV / JSON / XLSX / tables) | ✅ 즉시 가능 | table + csv + xlsx + json + collections + iter + fmt |
 | 파일 변환기 / 아카이브 | ✅ 가능 | fs + io + tar + compress (gzip 만) + fmt |
 | 파일 변경 감시 / 자동 변환 | ✅ 가능 | watch + fs + time + cmd |
 | 클립보드 업무 도구 | ✅ 가능 | clipboard + os (host clipboard command adapters) |
@@ -209,7 +210,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 61 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, rpa, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
+- 62 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, rpa, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - print 는 기존 `std.os` host process bridge 위에서 CUPS/Windows/custom spooler 실행 계획을 제공한다. 실제 출력은 가능하지만 프린터별 capability discovery 는 production-adjacent 로 남긴다.

--- a/internal/backend/llvm_big_stdlib_modules_test.go
+++ b/internal/backend/llvm_big_stdlib_modules_test.go
@@ -45,6 +45,46 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryRunsStdXlsxRowsEncode(t *testing.T) {
+	requireClangForBackendTest(t)
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use std.xlsx
+use std.zip
+
+fn main() {
+    let archive = xlsx.encodeRows("Report", [
+        ["name", "score"],
+        ["Ada", "42"],
+    ]).unwrap()
+    println(zip.isArchive(archive))
+    println(zip.contains(archive, "xl/workbook.xml"))
+    println(zip.contains(archive, "xl/worksheets/sheet1.xml"))
+    let names = zip.list(archive).unwrap()
+    println(names.len())
+    println(names[0])
+    let sheet = zip.extract(archive, "xl/worksheets/sheet1.xml").unwrap().unwrap().toString().unwrap()
+    println(sheet.contains("Ada"))
+    println(sheet.contains("inlineStr"))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		logBackendWarnings(t, result)
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	want := "true\ntrue\ntrue\n7\n[Content_Types].xml\ntrue\ntrue\n"
+	if got := string(output); got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinaryRunsStdImageMetadata(t *testing.T) {
 	requireClangForBackendTest(t)
 	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")

--- a/internal/backend/stdlib_xlsx_check_test.go
+++ b/internal/backend/stdlib_xlsx_check_test.go
@@ -1,0 +1,28 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultXlsx pins that std.xlsx's pure-Osty XLSX package
+// model type-checks cleanly through the selfhost checker.
+func TestStdlibCheckResultXlsx(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "xlsx")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(xlsx) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("xlsx module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/xlsx.osty
+++ b/internal/stdlib/modules/xlsx.osty
@@ -1,0 +1,926 @@
+// std.xlsx - XLSX workbook helpers built on stored ZIP entries.
+//
+// This module writes interoperable XLSX workbooks using inline strings and
+// reads the same store-method packages back into a small workbook model.
+// Deflated third-party XLSX files require std.compress deflate support before
+// std.zip can expose their entries.
+
+use std.bytes
+use std.error
+use std.strings
+use std.table
+use std.zip
+
+pub enum CellKind {
+    BlankCell,
+    TextCell,
+    NumberCell,
+    BoolCell,
+}
+
+pub struct Cell {
+    pub address: String,
+    pub kind: CellKind,
+    pub value: String,
+}
+
+pub struct Sheet {
+    pub name: String,
+    pub cells: List<Cell>,
+
+    pub fn rows(self) -> List<List<String>> {
+        rows(self)
+    }
+
+    pub fn toTable(self) -> Result<table.Table, Error> {
+        toTable(self)
+    }
+}
+
+pub struct Workbook {
+    pub sheets: List<Sheet>,
+
+    pub fn sheetNames(self) -> List<String> {
+        sheetNames(self)
+    }
+
+    pub fn firstSheet(self) -> Sheet? {
+        if self.sheets.isEmpty() {
+            return None
+        }
+        Some(self.sheets[0])
+    }
+}
+
+struct XlsxPart {
+    name: String,
+    data: Bytes,
+}
+
+pub fn cell(address: String, value: String, kind: CellKind) -> Result<Cell, Error> {
+    let clean = normalizeAddress(address)?
+    Ok(Cell {
+        address: clean,
+        kind: kind,
+        value: value,
+    })
+}
+
+pub fn text(address: String, value: String) -> Result<Cell, Error> {
+    cell(address, value, TextCell)
+}
+
+pub fn number(address: String, value: Float) -> Result<Cell, Error> {
+    cell(address, value.toString(), NumberCell)
+}
+
+pub fn int(address: String, value: Int) -> Result<Cell, Error> {
+    cell(address, intText(value), NumberCell)
+}
+
+pub fn bool(address: String, value: Bool) -> Result<Cell, Error> {
+    cell(address, if value { "1" } else { "0" }, BoolCell)
+}
+
+pub fn blank(address: String) -> Result<Cell, Error> {
+    cell(address, "", BlankCell)
+}
+
+pub fn sheet(name: String, cells: List<Cell>) -> Result<Sheet, Error> {
+    let clean = validateSheetName(name)?
+    let mut cleanCells: List<Cell> = []
+    for item in cells {
+        cleanCells.push(Cell {
+            address: normalizeAddress(item.address)?,
+            kind: item.kind,
+            value: item.value,
+        })
+    }
+    Ok(Sheet {
+        name: clean,
+        cells: cleanCells,
+    })
+}
+
+pub fn workbook(sheets: List<Sheet>) -> Result<Workbook, Error> {
+    if sheets.isEmpty() {
+        return Err(error.new("xlsx: workbook needs at least one sheet"))
+    }
+    let mut seen: Map<String, Bool> = {:}
+    let mut cleanSheets: List<Sheet> = []
+    for item in sheets {
+        let clean = sheet(item.name, item.cells)?
+        if seen.get(clean.name).isSome() {
+            return Err(error.new("xlsx: duplicate sheet name: {clean.name}"))
+        }
+        seen.insert(clean.name, true)
+        cleanSheets.push(clean)
+    }
+    Ok(Workbook { sheets: cleanSheets })
+}
+
+pub fn fromRows(name: String, rawRows: List<List<String>>) -> Result<Sheet, Error> {
+    let clean = validateSheetName(name)?
+    let mut cells: List<Cell> = []
+    let mut r = 0
+    for r < rawRows.len() {
+        let row = rawRows[r]
+        let mut c = 0
+        for c < row.len() {
+            cells.push(Cell {
+                address: addressOf(r + 1, c + 1),
+                kind: TextCell,
+                value: row[c],
+            })
+            c = c + 1
+        }
+        r = r + 1
+    }
+    Ok(Sheet { name: clean, cells: cells })
+}
+
+pub fn fromTable(name: String, value: table.Table) -> Result<Sheet, Error> {
+    fromRows(name, value.toRows())
+}
+
+pub fn toTable(sheetValue: Sheet) -> Result<table.Table, Error> {
+    let data = rows(sheetValue)
+    if data.isEmpty() {
+        return table.fromRows([], [])
+    }
+    let columns = data[0]
+    let mut body: List<List<String>> = []
+    let mut i = 1
+    for i < data.len() {
+        body.push(data[i])
+        i = i + 1
+    }
+    table.fromRows(columns, body)
+}
+
+pub fn rows(sheetValue: Sheet) -> List<List<String>> {
+    let height = maxRow(sheetValue.cells)
+    let width = maxColumn(sheetValue.cells)
+    let mut out: List<List<String>> = []
+    let mut r = 1
+    for r <= height {
+        let mut row: List<String> = []
+        let mut c = 1
+        for c <= width {
+            row.push(cellAt(sheetValue.cells, r, c) ?? "")
+            c = c + 1
+        }
+        out.push(row)
+        r = r + 1
+    }
+    out
+}
+
+pub fn sheetNames(book: Workbook) -> List<String> {
+    let mut out: List<String> = []
+    for sheetValue in book.sheets {
+        out.push(sheetValue.name)
+    }
+    out
+}
+
+pub fn encodeRows(name: String, rawRows: List<List<String>>) -> Result<Bytes, Error> {
+    encode(workbook([fromRows(name, rawRows)?])?)
+}
+
+pub fn encodeTable(name: String, value: table.Table) -> Result<Bytes, Error> {
+    encode(workbook([fromTable(name, value)?])?)
+}
+
+pub fn encode(book: Workbook) -> Result<Bytes, Error> {
+    let checked = workbook(book.sheets)?
+    let mut parts: List<XlsxPart> = []
+    parts.push(part("[Content_Types].xml", bytes.fromString(contentTypes(checked))))
+    parts.push(part("_rels/.rels", bytes.fromString(rootRels())))
+    parts.push(part("docProps/core.xml", bytes.fromString(coreProps())))
+    parts.push(part("docProps/app.xml", bytes.fromString(appProps(checked))))
+    parts.push(part("xl/workbook.xml", bytes.fromString(workbookXml(checked))))
+    parts.push(part("xl/_rels/workbook.xml.rels", bytes.fromString(workbookRels(checked))))
+    let mut i = 0
+    for i < checked.sheets.len() {
+        let path = "xl/worksheets/sheet{intText(i + 1)}.xml"
+        parts.push(part(path, bytes.fromString(sheetXml(checked.sheets[i]))))
+        i = i + 1
+    }
+    Ok(encodeParts(parts))
+}
+
+pub fn decode(archive: Bytes) -> Result<Workbook, Error> {
+    let workbookText = requiredText(archive, "xl/workbook.xml")?
+    let relsText = requiredText(archive, "xl/_rels/workbook.xml.rels")?
+    let shared = optionalSharedStrings(archive)?
+    let rels = parseWorkbookRels(relsText)?
+    let specs = parseWorkbookSheets(workbookText)?
+    if specs.isEmpty() {
+        return Err(error.new("xlsx: workbook has no sheets"))
+    }
+
+    let mut sheets: List<Sheet> = []
+    for spec in specs {
+        let target = rels.get(spec.relId) ?? ""
+        if target.isEmpty() {
+            return Err(error.new("xlsx: missing worksheet relationship {spec.relId}"))
+        }
+        let path = normalizeWorksheetTarget(target)
+        let worksheetText = requiredText(archive, path)?
+        let parsed = parseWorksheet(spec.name, worksheetText, shared)?
+        sheets.push(parsed)
+    }
+    workbook(sheets)
+}
+
+pub fn decodeRows(archive: Bytes, name: String) -> Result<List<List<String>>, Error> {
+    let book = decode(archive)?
+    for sheetValue in book.sheets {
+        if sheetValue.name == name {
+            return Ok(rows(sheetValue))
+        }
+    }
+    Err(error.new("xlsx: sheet not found: {name}"))
+}
+
+pub fn isWorkbook(data: Bytes) -> Bool {
+    if !zip.isArchive(data) {
+        return false
+    }
+    zip.contains(data, "xl/workbook.xml")
+}
+
+pub fn kindName(kind: CellKind) -> String {
+    match kind {
+        BlankCell  -> "blank",
+        TextCell   -> "text",
+        NumberCell -> "number",
+        BoolCell   -> "bool",
+    }
+}
+
+// Internal helpers -----------------------------------------------------------
+
+struct SheetSpec {
+    name: String,
+    relId: String,
+}
+
+fn workbookXml(book: Workbook) -> String {
+    let mut body = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><sheets>"
+    let mut i = 0
+    for i < book.sheets.len() {
+        let id = i + 1
+        let idText = intText(id)
+        body = "{body}<sheet name=\"{escapeXml(book.sheets[i].name)}\" sheetId=\"{idText}\" r:id=\"rId{idText}\"/>"
+        i = i + 1
+    }
+    "{body}</sheets></workbook>"
+}
+
+fn part(name: String, data: Bytes) -> XlsxPart {
+    XlsxPart {
+        name: name,
+        data: data,
+    }
+}
+
+fn encodeParts(parts: List<XlsxPart>) -> Bytes {
+    let mut out: List<Byte> = []
+    let mut central: List<Byte> = []
+    let mut offsets: List<Int> = []
+    for item in parts {
+        offsets.push(out.len())
+        appendLocalHeader(out, item.name, item.data)
+        appendBytes(out, item.data)
+    }
+
+    let centralStart = out.len()
+    let mut i = 0
+    for item in parts {
+        appendCentralHeader(central, item.name, item.data, offsets[i])
+        i = i + 1
+    }
+    appendBytes(out, bytes.from(central))
+    appendEndOfCentralDirectory(out, parts.len(), central.len(), centralStart)
+    bytes.from(out)
+}
+
+fn appendLocalHeader(out: List<Byte>, name: String, data: Bytes) {
+    let crc = zip.crc32(data)
+    appendU32(out, localSignature())
+    appendU16(out, 20)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, crc)
+    appendU32(out, data.len())
+    appendU32(out, data.len())
+    appendU16(out, name.bytes().len())
+    appendU16(out, 0)
+    appendString(out, name)
+}
+
+fn appendCentralHeader(out: List<Byte>, name: String, data: Bytes, offset: Int) {
+    let crc = zip.crc32(data)
+    appendU32(out, centralSignature())
+    appendU16(out, 20)
+    appendU16(out, 20)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, crc)
+    appendU32(out, data.len())
+    appendU32(out, data.len())
+    appendU16(out, name.bytes().len())
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU32(out, 0)
+    appendU32(out, offset)
+    appendString(out, name)
+}
+
+fn appendEndOfCentralDirectory(out: List<Byte>, count: Int, centralSize: Int, centralOffset: Int) {
+    appendU32(out, endSignature())
+    appendU16(out, 0)
+    appendU16(out, 0)
+    appendU16(out, count)
+    appendU16(out, count)
+    appendU32(out, centralSize)
+    appendU32(out, centralOffset)
+    appendU16(out, 0)
+}
+
+fn appendBytes(out: List<Byte>, data: Bytes) {
+    let mut i = 0
+    for i < data.len() {
+        out.push(bytes.get(data, i).unwrap())
+        i = i + 1
+    }
+}
+
+fn appendString(out: List<Byte>, value: String) {
+    let raw = value.bytes()
+    let mut i = 0
+    for i < raw.len() {
+        out.push(raw[i])
+        i = i + 1
+    }
+}
+
+fn appendU16(out: List<Byte>, value: Int) {
+    pushByte(out, value & 0xFF)
+    pushByte(out, (value >> 8) & 0xFF)
+}
+
+fn appendU32(out: List<Byte>, value: Int) {
+    pushByte(out, value & 0xFF)
+    pushByte(out, (value >> 8) & 0xFF)
+    pushByte(out, (value >> 16) & 0xFF)
+    pushByte(out, (value >> 24) & 0xFF)
+}
+
+fn pushByte(out: List<Byte>, value: Int) {
+    out.push((value & 0xFF).toByte())
+}
+
+fn localSignature() -> Int {
+    0x04034B50
+}
+
+fn centralSignature() -> Int {
+    0x02014B50
+}
+
+fn endSignature() -> Int {
+    0x06054B50
+}
+
+fn workbookRels(book: Workbook) -> String {
+    let mut body = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+    let mut i = 0
+    for i < book.sheets.len() {
+        let id = i + 1
+        let idText = intText(id)
+        body = "{body}<Relationship Id=\"rId{idText}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet{idText}.xml\"/>"
+        i = i + 1
+    }
+    "{body}</Relationships>"
+}
+
+fn contentTypes(book: Workbook) -> String {
+    let mut body = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/><Default Extension=\"xml\" ContentType=\"application/xml\"/><Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/><Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/><Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>"
+    let mut i = 0
+    for i < book.sheets.len() {
+        let id = i + 1
+        body = "{body}<Override PartName=\"/xl/worksheets/sheet{intText(id)}.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+        i = i + 1
+    }
+    "{body}</Types>"
+}
+
+fn rootRels() -> String {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/><Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/><Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/></Relationships>"
+}
+
+fn coreProps() -> String {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:creator>Osty</dc:creator></cp:coreProperties>"
+}
+
+fn appProps(book: Workbook) -> String {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/extended-properties\"><Application>Osty</Application><Sheets>{intText(book.sheets.len())}</Sheets></Properties>"
+}
+
+fn sheetXml(sheetValue: Sheet) -> String {
+    let height = maxRow(sheetValue.cells)
+    let mut body = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>"
+    let mut r = 1
+    for r <= height {
+        let rowXml = rowXml(sheetValue.cells, r)
+        if !rowXml.isEmpty() {
+            body = "{body}<row r=\"{intText(r)}\">{rowXml}</row>"
+        }
+        r = r + 1
+    }
+    "{body}</sheetData></worksheet>"
+}
+
+fn rowXml(cells: List<Cell>, rowIndex: Int) -> String {
+    let mut out = ""
+    for item in cells {
+        if rowOf(item.address) == rowIndex {
+            out = "{out}{cellXml(item)}"
+        }
+    }
+    out
+}
+
+fn cellXml(item: Cell) -> String {
+    match item.kind {
+        BlankCell -> "<c r=\"{item.address}\"/>",
+        TextCell -> "<c r=\"{item.address}\" t=\"inlineStr\"><is><t xml:space=\"preserve\">{escapeXml(item.value)}</t></is></c>",
+        NumberCell -> "<c r=\"{item.address}\"><v>{escapeXml(item.value)}</v></c>",
+        BoolCell -> "<c r=\"{item.address}\" t=\"b\"><v>{boolValue(item.value)}</v></c>",
+    }
+}
+
+fn boolValue(value: String) -> String {
+    let clean = strings.toLower(strings.trimSpace(value))
+    if clean == "true" || clean == "1" {
+        return "1"
+    }
+    "0"
+}
+
+fn escapeXml(text: String) -> String {
+    let amp = strings.replaceAll(text, "&", "&amp;")
+    let lt = strings.replaceAll(amp, "<", "&lt;")
+    let gt = strings.replaceAll(lt, ">", "&gt;")
+    let quote = strings.replaceAll(gt, "\"", "&quot;")
+    strings.replaceAll(quote, "'", "&apos;")
+}
+
+fn unescapeXml(text: String) -> Result<String, Error> {
+    let quot = strings.replaceAll(text, "&quot;", "\"")
+    let apos = strings.replaceAll(quot, "&apos;", "'")
+    let lt = strings.replaceAll(apos, "&lt;", "<")
+    let gt = strings.replaceAll(lt, "&gt;", ">")
+    Ok(strings.replaceAll(gt, "&amp;", "&"))
+}
+
+fn requiredText(archive: Bytes, path: String) -> Result<String, Error> {
+    match zip.extract(archive, path)? {
+        Some(data) -> bytes.toString(data),
+        None       -> Err(error.new("xlsx: missing part {path}")),
+    }
+}
+
+fn optionalText(archive: Bytes, path: String) -> Result<String?, Error> {
+    match zip.extract(archive, path)? {
+        Some(data) -> Ok(Some(bytes.toString(data)?)),
+        None       -> Ok(noneString()),
+    }
+}
+
+fn optionalSharedStrings(archive: Bytes) -> Result<List<String>, Error> {
+    match optionalText(archive, "xl/sharedStrings.xml")? {
+        Some(text) -> parseSharedStrings(text),
+        None       -> Ok([]),
+    }
+}
+
+fn parseWorkbookSheets(source: String) -> Result<List<SheetSpec>, Error> {
+    let mut out: List<SheetSpec> = []
+    let mut pos = 0
+    for true {
+        let start = indexOfFrom(source, "<sheet ", pos)
+        if start < 0 {
+            break
+        }
+        let end = indexOfFrom(source, ">", start)
+        if end < 0 {
+            return Err(error.new("xlsx: unterminated sheet tag"))
+        }
+        let tag = strings.slice(source, start, end + 1)
+        let name = attrOrEmpty(tag, "name")?
+        let relId = attrOrEmpty(tag, "r:id")?
+        if name.isEmpty() || relId.isEmpty() {
+            return Err(error.new("xlsx: malformed sheet entry"))
+        }
+        out.push(SheetSpec {
+            name: validateSheetName(name)?,
+            relId: relId,
+        })
+        pos = end + 1
+    }
+    Ok(out)
+}
+
+fn parseWorkbookRels(source: String) -> Result<Map<String, String>, Error> {
+    let mut out: Map<String, String> = {:}
+    let mut pos = 0
+    for true {
+        let start = indexOfFrom(source, "<Relationship ", pos)
+        if start < 0 {
+            break
+        }
+        let end = indexOfFrom(source, ">", start)
+        if end < 0 {
+            return Err(error.new("xlsx: unterminated relationship tag"))
+        }
+        let tag = strings.slice(source, start, end + 1)
+        let id = attrOrEmpty(tag, "Id")?
+        let target = attrOrEmpty(tag, "Target")?
+        if !id.isEmpty() && !target.isEmpty() {
+            out.insert(id, target)
+        }
+        pos = end + 1
+    }
+    Ok(out)
+}
+
+fn parseSharedStrings(source: String) -> Result<List<String>, Error> {
+    let mut out: List<String> = []
+    let mut pos = 0
+    for true {
+        let start = indexOfFrom(source, "<si", pos)
+        if start < 0 {
+            break
+        }
+        let openEnd = indexOfFrom(source, ">", start)
+        if openEnd < 0 {
+            return Err(error.new("xlsx: unterminated shared string"))
+        }
+        let close = indexOfFrom(source, "</si>", openEnd + 1)
+        if close < 0 {
+            return Err(error.new("xlsx: unterminated shared string"))
+        }
+        let body = strings.slice(source, openEnd + 1, close)
+        out.push(collectTextNodes(body, "t")?)
+        pos = close + 5
+    }
+    Ok(out)
+}
+
+fn parseWorksheet(name: String, source: String, shared: List<String>) -> Result<Sheet, Error> {
+    let mut cells: List<Cell> = []
+    let mut pos = 0
+    for true {
+        let start = indexOfFrom(source, "<c ", pos)
+        if start < 0 {
+            break
+        }
+        let tagEnd = indexOfFrom(source, ">", start)
+        if tagEnd < 0 {
+            return Err(error.new("xlsx: unterminated cell tag"))
+        }
+        let tag = strings.slice(source, start, tagEnd + 1)
+        let address = normalizeAddress(attrOrEmpty(tag, "r")?)?
+        let rawType = attrOrEmpty(tag, "t")?
+        if isSelfClosingTag(tag) {
+            cells.push(Cell {
+                address: address,
+                kind: BlankCell,
+                value: "",
+            })
+            pos = tagEnd + 1
+            continue
+        }
+        let close = indexOfFrom(source, "</c>", tagEnd + 1)
+        if close < 0 {
+            return Err(error.new("xlsx: unterminated cell"))
+        }
+        let body = strings.slice(source, tagEnd + 1, close)
+        let mut kind = kindFromType(rawType)
+        let mut value = if rawType == "inlineStr" || rawType == "str" {
+            collectTextNodes(body, "t")?
+        } else {
+            collectTextNodes(body, "v")?
+        }
+        if value.isEmpty() && rawType.isEmpty() {
+            kind = BlankCell
+        }
+        if rawType == "s" {
+            value = sharedString(shared, value)?
+            kind = TextCell
+        }
+        cells.push(Cell {
+            address: address,
+            kind: kind,
+            value: value,
+        })
+        pos = close + 4
+    }
+    sheet(name, cells)
+}
+
+fn collectTextNodes(body: String, name: String) -> Result<String, Error> {
+    let mut out = ""
+    let open = "<{name}"
+    let closeTag = "</{name}>"
+    let mut pos = 0
+    for true {
+        let start = indexOfFrom(body, open, pos)
+        if start < 0 {
+            break
+        }
+        let openEnd = indexOfFrom(body, ">", start)
+        if openEnd < 0 {
+            return Err(error.new("xlsx: unterminated text node"))
+        }
+        let close = indexOfFrom(body, closeTag, openEnd + 1)
+        if close < 0 {
+            return Err(error.new("xlsx: unterminated text node"))
+        }
+        match unescapeXml(strings.slice(body, openEnd + 1, close)) {
+            Ok(text) -> {
+                out = "{out}{text}"
+            },
+            Err(err) -> {
+                return Err(err)
+            },
+        }
+        pos = close + closeTag.len()
+    }
+    Ok(out)
+}
+
+fn kindFromType(raw: String) -> CellKind {
+    if raw == "b" {
+        return BoolCell
+    }
+    if raw == "inlineStr" || raw == "str" || raw == "s" {
+        return TextCell
+    }
+    NumberCell
+}
+
+fn sharedString(shared: List<String>, raw: String) -> Result<String, Error> {
+    let idx = strings.toInt(strings.trimSpace(raw))?
+    if idx < 0 || idx >= shared.len() {
+        return Err(error.new("xlsx: shared string index out of range"))
+    }
+    Ok(shared[idx])
+}
+
+fn attrOrEmpty(tag: String, name: String) -> Result<String, Error> {
+    match attrValue(tag, name)? {
+        Some(value) -> Ok(value),
+        None        -> Ok(""),
+    }
+}
+
+fn attrValue(tag: String, name: String) -> Result<String?, Error> {
+    let needle = "{name}=\""
+    let start = indexOfFrom(tag, needle, 0)
+    if start < 0 {
+        return Ok(noneString())
+    }
+    let valueStart = start + needle.len()
+    let valueEnd = indexOfFrom(tag, "\"", valueStart)
+    if valueEnd < 0 {
+        return Err(error.new("xlsx: unterminated attribute {name}"))
+    }
+    match unescapeXml(strings.slice(tag, valueStart, valueEnd)) {
+        Ok(value) -> {
+            Ok(Some(value))
+        },
+        Err(err) -> {
+            Err(err)
+        },
+    }
+}
+
+fn isSelfClosingTag(tag: String) -> Bool {
+    strings.endsWith(strings.trimSpace(tag), "/>")
+}
+
+fn indexOfFrom(text: String, needle: String, start: Int) -> Int {
+    if needle.isEmpty() {
+        return start
+    }
+    let mut i = start
+    for i + needle.len() <= text.len() {
+        if strings.slice(text, i, i + needle.len()) == needle {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+fn normalizeWorksheetTarget(target: String) -> String {
+    if strings.startsWith(target, "/") {
+        return strings.slice(target, 1, target.len())
+    }
+    if strings.startsWith(target, "xl/") {
+        return target
+    }
+    "xl/{target}"
+}
+
+fn validateSheetName(name: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(name)
+    if clean.isEmpty() {
+        return Err(error.new("xlsx: sheet name is empty"))
+    }
+    if clean.len() > 31 {
+        return Err(error.new("xlsx: sheet name is longer than 31 characters"))
+    }
+    for c in clean.chars() {
+        if c == '[' || c == ']' || c == ':' || c == '*' || c == '?' || c == '/' || c == '\\' {
+            return Err(error.new("xlsx: invalid sheet name: {clean}"))
+        }
+    }
+    Ok(clean)
+}
+
+fn normalizeAddress(address: String) -> Result<String, Error> {
+    let clean = strings.toUpper(strings.trimSpace(address))
+    if clean.isEmpty() {
+        return Err(error.new("xlsx: cell address is empty"))
+    }
+    let row = rowOf(clean)
+    let col = columnOf(clean)
+    if row <= 0 || col <= 0 {
+        return Err(error.new("xlsx: invalid cell address: {address}"))
+    }
+    Ok(clean)
+}
+
+fn rowOf(address: String) -> Int {
+    let chars = address.chars()
+    let mut i = 0
+    for i < chars.len() && isLetter(chars[i]) {
+        i = i + 1
+    }
+    if i == 0 || i >= chars.len() {
+        return 0
+    }
+    let mut row = 0
+    for i < chars.len() {
+        if !isDigit(chars[i]) {
+            return 0
+        }
+        row = row * 10 + (chars[i].toInt() - '0'.toInt())
+        i = i + 1
+    }
+    row
+}
+
+fn columnOf(address: String) -> Int {
+    let chars = address.chars()
+    let mut i = 0
+    let mut col = 0
+    for i < chars.len() && isLetter(chars[i]) {
+        col = col * 26 + (chars[i].toInt() - 'A'.toInt() + 1)
+        i = i + 1
+    }
+    if i == 0 {
+        return 0
+    }
+    col
+}
+
+fn addressOf(row: Int, column: Int) -> String {
+    "{columnName(column)}{intText(row)}"
+}
+
+fn intText(value: Int) -> String {
+    if value == 0 {
+        return "0"
+    }
+    let mut n = value
+    let negative = n < 0
+    if negative {
+        n = 0 - n
+    }
+    let mut out = ""
+    for n > 0 {
+        let digit = n % 10
+        out = "{digitText(digit)}{out}"
+        n = n / 10
+    }
+    if negative {
+        return "-{out}"
+    }
+    out
+}
+
+fn columnName(index: Int) -> String {
+    let mut n = index
+    let mut out = ""
+    for n > 0 {
+        let rem = (n - 1) % 26
+        out = "{letterText(rem)}{out}"
+        n = (n - 1) / 26
+    }
+    out
+}
+
+fn digitText(digit: Int) -> String {
+    match digit {
+        0 -> "0",
+        1 -> "1",
+        2 -> "2",
+        3 -> "3",
+        4 -> "4",
+        5 -> "5",
+        6 -> "6",
+        7 -> "7",
+        8 -> "8",
+        9 -> "9",
+        _ -> "",
+    }
+}
+
+fn letterText(index: Int) -> String {
+    strings.slice("ABCDEFGHIJKLMNOPQRSTUVWXYZ", index, index + 1)
+}
+
+fn maxRow(cells: List<Cell>) -> Int {
+    let mut out = 0
+    for item in cells {
+        let row = rowOf(item.address)
+        if row > out {
+            out = row
+        }
+    }
+    out
+}
+
+fn maxColumn(cells: List<Cell>) -> Int {
+    let mut out = 0
+    for item in cells {
+        let col = columnOf(item.address)
+        if col > out {
+            out = col
+        }
+    }
+    out
+}
+
+fn cellAt(cells: List<Cell>, row: Int, column: Int) -> String? {
+    for item in cells {
+        if rowOf(item.address) == row && columnOf(item.address) == column {
+            return Some(displayValue(item))
+        }
+    }
+    None
+}
+
+fn displayValue(item: Cell) -> String {
+    match item.kind {
+        BoolCell -> {
+            if boolValue(item.value) == "1" {
+                return "TRUE"
+            }
+            "FALSE"
+        },
+        _ -> item.value,
+    }
+}
+
+fn localName(name: String) -> String {
+    match strings.lastIndexOf(name, ":") {
+        Some(i) -> strings.slice(name, i + 1, name.len()),
+        None    -> name,
+    }
+}
+
+fn isLetter(c: Char) -> Bool {
+    c >= 'A' && c <= 'Z'
+}
+
+fn isDigit(c: Char) -> Bool {
+    c >= '0' && c <= '9'
+}
+
+fn noneString() -> String? {
+    None
+}

--- a/internal/stdlib/xlsx_test.go
+++ b/internal/stdlib/xlsx_test.go
@@ -1,0 +1,62 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXlsxModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["xlsx"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.xlsx not loaded")
+	}
+
+	for _, name := range []string{
+		"cell", "text", "number", "int", "bool", "blank", "sheet", "workbook",
+		"fromRows", "fromTable", "toTable", "rows", "sheetNames", "encodeRows",
+		"encodeTable", "encode", "decode", "decodeRows", "isWorkbook", "kindName",
+	} {
+		requirePublicFn(t, mod, "xlsx", name)
+	}
+	for _, name := range []string{"CellKind", "Cell", "Sheet", "Workbook"} {
+		requirePublicType(t, mod, "xlsx", name)
+	}
+	for _, method := range []string{"rows", "toTable"} {
+		if got := reg.LookupMethodDecl("xlsx", "Sheet", method); got == nil {
+			t.Fatalf("LookupMethodDecl(xlsx, Sheet, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{"sheetNames", "firstSheet"} {
+		if got := reg.LookupMethodDecl("xlsx", "Workbook", method); got == nil {
+			t.Fatalf("LookupMethodDecl(xlsx, Workbook, %s) = nil", method)
+		}
+	}
+}
+
+func TestXlsxModuleSourcePinsPackageBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["xlsx"]
+	if mod == nil {
+		t.Fatal("std.xlsx module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`use std.zip`,
+		`escapeXml`,
+		`unescapeXml`,
+		`encodeParts(parts)`,
+		`appendEndOfCentralDirectory`,
+		`inlineStr`,
+		`parseWorkbookRels(relsText)?`,
+		`parseSharedStrings(text)`,
+		`table.fromRows(columns, body)`,
+		`return Err(error.new("xlsx: workbook needs at least one sheet"))`,
+		`return Err(error.new("xlsx: sheet name is longer than 31 characters"))`,
+		`std.zip can expose their entries`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.xlsx source missing %q", want)
+		}
+	}
+}

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ backend_packages := "./internal/ir ./internal/mir ./internal/backend ./internal/
 osty_test_dirs := "examples/int_control_e2e examples/int_methods_e2e examples/int_struct_e2e"
 test_flags := "-count=1 -vet=off"
 stdlib_matrix_fast_tests := "TestStdlibSupportMatrix"
-stdlib_matrix_backend_tests := "Test(Stdlib(CheckResult|Symbol|Method)|InjectReachableStdlib|ReachableStdlib|Phase2|LLVMBackendBinaryRunsStd(Zip|Image|Smtp|Crypto|Random|Term|Os)|PrepareEntryRewritesStdEncoding)"
+stdlib_matrix_backend_tests := "Test(Stdlib(CheckResult|Symbol|Method)|InjectReachableStdlib|ReachableStdlib|Phase2|LLVMBackendBinaryRunsStd(Zip|Xlsx|Image|Smtp|Crypto|Random|Term|Os)|PrepareEntryRewritesStdEncoding)"
 stdlib_matrix_llvmgen_tests := "Test(Std(Env|Io|Term|Strings|Bytes|Crypto)|UnsupportedDiagnostic)"
 selfhost_matrix_fast_tests := "Test(CheckCLIDefaultPathExitsZero|RunCheckFileDefaultPathIsAstbridgeFree|ProductionFrontendPathsDoNotCallFrontendRunFile)"
 selfhost_matrix_cmd_tests := "Test(Run(Check|Typecheck|Resolve)(File|Package|Workspace).*AstbridgeFree|CheckCLI(DefaultPathExitsZero|Native.*)|TypecheckCLI.*|ResolveCLI.*)"


### PR DESCRIPTION
## Summary
- add `std.xlsx` workbook, sheet, row, and table helpers backed by pure Osty stored-ZIP XLSX encoding
- add decode helpers for module-produced XLSX packages and shared-string worksheet data
- document the new module, update the stdlib matrix, and add checker/LLVM coverage

## Tests
- `just support-stdlib-medium`
- `just fmt-check`
- `git diff --check`