### PR TITLE
[codex] add barcode and qr stdlib modules

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 86 공개 모듈. 분류 기준:
+총 88 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (82 / 86 = 95%)
+### ⭐⭐⭐⭐⭐ Production (84 / 88 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -75,6 +75,8 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | ocr | 1136 | pure Osty + os/fs/json | PaddleOCR v5 / Tesseract command adapters, fast/accurate presets, batch JSON ingestion, confidence review queues, search, key-value extraction, RAG-friendly chunks |
 | rpa | 1089 | pure Osty + os/strings | Desktop RPA command plans: mouse move/click/drag/scroll, keyboard typing/hotkeys/paste, window query/focus/wait, script repeat/delay, macOS cliclick+osascript / Linux xdotool / Windows PowerShell adapters |
 | scan | 670 | pure Osty + os/fs/image/ocr | SANE `scanimage` / custom scanner command planning, device-list parsing, batch page paths, image metadata probe, manifest generation, scan→OCR indexed document handoff |
+| barcode | 709 | pure Osty + os | Code39 / EAN-13 / UPC-A native renderers, SVG/ASCII output, scanner command adapters, ZBar/ZXing output parsing, inventory/shipment/access label helpers |
+| qr | 564 | pure Osty + os | QR payload builders, matrix/SVG render helpers, qrencode generation plans, ZBar/ZXing recognition plans and result parsing |
 | smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
@@ -114,7 +116,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 86 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 88 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -130,7 +132,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `print`, `clipboard` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -170,6 +172,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | OCR 엔진 연결 / 결과 분석 | ✅ 가능 | ocr (PaddleOCR v5 / Tesseract 실행 계획, JSON/TSV normalize, confidence/search/key-value/chunk helpers) |
 | 스캔→OCR 문서 자동화 | ✅ 가능 | scan + ocr + image + fs/os (SANE/custom scanner command plan, scanned page metadata, OCR batch/index/manifest) |
 | Desktop RPA / 반복 업무 자동화 | ✅ 가능 | rpa (마우스 이동/클릭/드래그/스크롤, 키 입력/hotkey/paste, 창 검색/focus/wait, 반복 스크립트, macOS/Linux/Windows command plan) |
+| QR / 바코드 문서 | ✅ 가능 | qr + barcode (QR payload/qrencode 계획, ZBar/ZXing 인식 파싱, Code39/EAN-13/UPC-A SVG 렌더링) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
@@ -210,7 +213,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 62 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, rpa, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
+- 64 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - print 는 기존 `std.os` host process bridge 위에서 CUPS/Windows/custom spooler 실행 계획을 제공한다. 실제 출력은 가능하지만 프린터별 capability discovery 는 production-adjacent 로 남긴다.

--- a/internal/backend/stdlib_barcode_qr_check_test.go
+++ b/internal/backend/stdlib_barcode_qr_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultBarcodeQr(t *testing.T) {
+	reg := stdlib.LoadCached()
+	for _, module := range []string{"barcode", "qr"} {
+		t.Run(module, func(t *testing.T) {
+			chk := stdlibCheckResult(reg, module)
+			if chk == nil {
+				t.Fatalf("stdlibCheckResult(%s) = nil, want non-nil *check.Result", module)
+			}
+			var errs []string
+			for _, d := range chk.Diags {
+				if d != nil && strings.Contains(d.Error(), "error") {
+					msg := d.Error()
+					if len(d.Notes) > 0 {
+						msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+					}
+					errs = append(errs, msg)
+				}
+			}
+			if len(errs) > 0 {
+				t.Fatalf("%s module check produced %d error diagnostic(s):\n%s",
+					module, len(errs), strings.Join(errs, "\n"))
+			}
+		})
+	}
+}

--- a/internal/stdlib/barcode_qr_test.go
+++ b/internal/stdlib/barcode_qr_test.go
@@ -1,0 +1,97 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBarcodeModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["barcode"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.barcode not loaded")
+	}
+	for _, name := range []string{
+		"code39Options", "ean13Options", "upcAOptions",
+		"zbarimgOptions", "zxingOptions", "customScanOptions",
+		"withModuleWidth", "withBarHeight", "withQuietZone", "withText",
+		"withColors", "withChecksum", "withSymbology", "withExtraArg",
+		"encode", "encodeCode39", "encodeEan13", "encodeUpcA",
+		"toSvg", "renderSvg", "toAscii", "symbologyName",
+		"parseSymbology", "detectSymbology", "scanPlan", "commandLine",
+		"scan", "parseScanLines", "parseZbarOutput", "parseZxingOutput",
+		"ean13CheckDigit", "upcACheckDigit", "isValidEan13", "isValidUpcA",
+		"inventoryLabel", "shipmentLabel", "accessLabel",
+	} {
+		requirePublicFn(t, mod, "barcode", name)
+	}
+	for _, name := range []string{
+		"Symbology", "ChecksumPolicy", "ScannerEngine", "Options",
+		"LinearCode", "ScanOptions", "ScanResult", "CommandPlan",
+	} {
+		requirePublicType(t, mod, "barcode", name)
+	}
+}
+
+func TestQrModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["qr"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.qr not loaded")
+	}
+	for _, name := range []string{
+		"options", "low", "medium", "high",
+		"withErrorCorrection", "withModuleSize", "withQuietZone",
+		"withColors", "withCommand", "withExtraArg",
+		"zbarimgOptions", "zxingOptions", "customRecognitionOptions",
+		"encode", "toSvg", "renderSvg", "toAscii", "matrixFromRows",
+		"qrencodePlan", "generate", "recognitionPlan", "recognize",
+		"parseRecognitionOutput", "commandLine", "urlPayload",
+		"wifiPayload", "mailtoPayload", "vCardPayload", "paymentPayload",
+		"accessPayload", "shipmentPayload",
+	} {
+		requirePublicFn(t, mod, "qr", name)
+	}
+	for _, name := range []string{
+		"ErrorCorrection", "QrEngine", "OutputFormat", "Options",
+		"Matrix", "CommandPlan", "RecognitionOptions", "RecognitionResult",
+	} {
+		requirePublicType(t, mod, "qr", name)
+	}
+}
+
+func TestBarcodeQrModulesPinPracticalBehavior(t *testing.T) {
+	reg := LoadCached()
+	cases := map[string][]string{
+		"barcode": {
+			`pub fn encodeCode39(text: String, checksum: ChecksumPolicy) -> Result<LinearCode, Error>`,
+			`fn code39CharacterBits(c: Char) -> String`,
+			`fn ean13Pattern(full: String) -> Result<String, Error>`,
+			`pub fn scanPlan(imagePath: String, options: ScanOptions) -> Result<CommandPlan, Error>`,
+			`pub fn parseZxingOutput(text: String, source: String) -> List<ScanResult>`,
+			`pub fn shipmentLabel(carrier: String, tracking: String) -> String`,
+			`"--possibleFormats"`,
+		},
+		"qr": {
+			`pub fn qrencodePlan(text: String, outputPath: String, format: OutputFormat, options: Options) -> Result<CommandPlan, Error>`,
+			`pub fn recognize(imagePath: String, options: RecognitionOptions) -> Result<List<RecognitionResult>, Error>`,
+			`pub fn wifiPayload(ssid: String, password: String, auth: String, hidden: Bool) -> String`,
+			`fn drawFinder(matrix: Matrix, ox: Int, oy: Int) -> Matrix`,
+			`fn fillPayloadModules(matrix: Matrix, text: String, level: ErrorCorrection) -> Matrix`,
+			`pub fn parseRecognitionOutput(text: String, source: String) -> List<RecognitionResult>`,
+			`"qrencode"`,
+		},
+	}
+	for module, wants := range cases {
+		mod := reg.Modules[module]
+		if mod == nil {
+			t.Fatalf("std.%s module missing", module)
+		}
+		src := string(mod.Source)
+		for _, want := range wants {
+			if !strings.Contains(src, want) {
+				t.Fatalf("std.%s source missing %q", module, want)
+			}
+		}
+	}
+}

--- a/internal/stdlib/modules/barcode.osty
+++ b/internal/stdlib/modules/barcode.osty
@@ -1,0 +1,718 @@
+// std.barcode - practical linear barcode helpers.
+//
+// The module covers native generation for common document and logistics
+// formats (Code 39, EAN-13, UPC-A) plus scanner command adapters for image
+// recognition through tools such as zbarimg or ZXing.
+
+use std.error
+use std.os
+use std.strings
+
+pub enum Symbology {
+    Code39,
+    Ean13,
+    UpcA,
+    QrCode,
+    DataMatrix,
+    Pdf417,
+    UnknownSymbology,
+}
+
+pub enum ChecksumPolicy {
+    NoChecksum,
+    VerifyChecksum,
+    AppendChecksum,
+}
+
+pub enum ScannerEngine {
+    Zbarimg,
+    Zxing,
+    CustomCommand,
+}
+
+pub struct Options {
+    pub symbology: Symbology,
+    pub moduleWidth: Int = 2,
+    pub barHeight: Int = 80,
+    pub quietZone: Int = 10,
+    pub foreground: String = "#000000",
+    pub background: String = "#ffffff",
+    pub showText: Bool = true,
+    pub checksum: ChecksumPolicy,
+}
+
+pub struct LinearCode {
+    pub symbology: Symbology,
+    pub text: String,
+    pub pattern: String,
+    pub checksum: String = "",
+    pub valid: Bool = true,
+}
+
+pub struct ScanOptions {
+    pub engine: ScannerEngine,
+    pub command: String = "",
+    pub symbologies: List<Symbology> = [],
+    pub extraArgs: List<String> = [],
+}
+
+pub struct ScanResult {
+    pub symbology: Symbology,
+    pub text: String,
+    pub raw: String,
+    pub source: String = "",
+    pub confidence: Float = 1.0,
+}
+
+pub struct CommandPlan {
+    pub command: String,
+    pub args: List<String>,
+}
+
+pub fn code39Options() -> Options {
+    Options {symbology: Code39, checksum: NoChecksum}
+}
+
+pub fn ean13Options() -> Options {
+    Options {symbology: Ean13, checksum: VerifyChecksum}
+}
+
+pub fn upcAOptions() -> Options {
+    Options {symbology: UpcA, checksum: VerifyChecksum}
+}
+
+pub fn zbarimgOptions() -> ScanOptions {
+    ScanOptions {engine: Zbarimg, command: "zbarimg"}
+}
+
+pub fn zxingOptions() -> ScanOptions {
+    ScanOptions {engine: Zxing, command: "zxing"}
+}
+
+pub fn customScanOptions(command: String) -> ScanOptions {
+    ScanOptions {engine: CustomCommand, command: command}
+}
+
+pub fn withModuleWidth(mut options: Options, width: Int) -> Options {
+    options.moduleWidth = maxInt(1, width)
+    options
+}
+
+pub fn withBarHeight(mut options: Options, height: Int) -> Options {
+    options.barHeight = maxInt(1, height)
+    options
+}
+
+pub fn withQuietZone(mut options: Options, quietZone: Int) -> Options {
+    options.quietZone = maxInt(0, quietZone)
+    options
+}
+
+pub fn withText(mut options: Options, show: Bool) -> Options {
+    options.showText = show
+    options
+}
+
+pub fn withColors(mut options: Options, foreground: String, background: String) -> Options {
+    options.foreground = foreground
+    options.background = background
+    options
+}
+
+pub fn withChecksum(mut options: Options, policy: ChecksumPolicy) -> Options {
+    options.checksum = policy
+    options
+}
+
+pub fn withSymbology(mut options: ScanOptions, symbology: Symbology) -> ScanOptions {
+    options.symbologies.push(symbology)
+    options
+}
+
+pub fn withExtraArg(mut options: ScanOptions, arg: String) -> ScanOptions {
+    options.extraArgs.push(arg)
+    options
+}
+
+pub fn encode(text: String, options: Options) -> Result<LinearCode, Error> {
+    match options.symbology {
+        Code39 -> encodeCode39(text, options.checksum),
+        Ean13 -> encodeEan13(text, options.checksum),
+        UpcA -> encodeUpcA(text, options.checksum),
+        _ -> Err(error.new("barcode: native encoder supports Code39, EAN-13, and UPC-A")),
+    }
+}
+
+pub fn encodeCode39(text: String, checksum: ChecksumPolicy) -> Result<LinearCode, Error> {
+    let normalized = normalizeCode39(text)?
+    let payload = match checksum {
+        AppendChecksum -> "{normalized}{code39Checksum(normalized)?}",
+        VerifyChecksum -> verifyCode39Checksum(normalized)?,
+        NoChecksum -> normalized,
+    }
+    let mut pattern = code39CharacterBits('*')
+    for c in payload.chars() {
+        pattern = "{pattern}0{code39CharacterBits(c)}"
+    }
+    pattern = "{pattern}0{code39CharacterBits('*')}"
+    let checksumText = if checksum == AppendChecksum { strings.slice(payload, payload.len() - 1, payload.len()) } else { "" }
+    Ok(LinearCode {
+        symbology: Code39,
+        text: payload,
+        pattern: pattern,
+        checksum: checksumText,
+        valid: true,
+    })
+}
+
+pub fn encodeEan13(text: String, checksum: ChecksumPolicy) -> Result<LinearCode, Error> {
+    let body = strings.trimSpace(text)
+    if !allDigits(body) || (body.len() != 12 && body.len() != 13) {
+        return Err(error.new("barcode: EAN-13 requires 12 data digits or 13 digits with check digit"))
+    }
+    let full = if body.len() == 12 {
+        "{body}{ean13CheckDigit(body).toString()}"
+    } else {
+        if checksum != NoChecksum && !isValidEan13(body) {
+            return Err(error.new("barcode: invalid EAN-13 check digit"))
+        }
+        body
+    }
+    let pattern = ean13Pattern(full)?
+    Ok(LinearCode {
+        symbology: Ean13,
+        text: full,
+        pattern: pattern,
+        checksum: strings.slice(full, 12, 13),
+        valid: isValidEan13(full),
+    })
+}
+
+pub fn encodeUpcA(text: String, checksum: ChecksumPolicy) -> Result<LinearCode, Error> {
+    let body = strings.trimSpace(text)
+    if !allDigits(body) || (body.len() != 11 && body.len() != 12) {
+        return Err(error.new("barcode: UPC-A requires 11 data digits or 12 digits with check digit"))
+    }
+    let full = if body.len() == 11 {
+        "{body}{upcACheckDigit(body).toString()}"
+    } else {
+        if checksum != NoChecksum && !isValidUpcA(body) {
+            return Err(error.new("barcode: invalid UPC-A check digit"))
+        }
+        body
+    }
+    let ean = "0{full}"
+    Ok(LinearCode {
+        symbology: UpcA,
+        text: full,
+        pattern: ean13Pattern(ean)?,
+        checksum: strings.slice(full, 11, 12),
+        valid: isValidUpcA(full),
+    })
+}
+
+pub fn toSvg(code: LinearCode, options: Options) -> String {
+    let moduleWidth = maxInt(1, options.moduleWidth)
+    let quiet = maxInt(0, options.quietZone)
+    let barHeight = maxInt(1, options.barHeight)
+    let width = code.pattern.len() * moduleWidth + quiet * 2
+    let height = barHeight + quiet * 2 + if options.showText { 22 } else { 0 }
+    let mut out = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {width} {height}\" role=\"img\">"
+    out = "{out}<rect width=\"100%\" height=\"100%\" fill=\"{escapeXml(options.background)}\"/>"
+    let mut i = 0
+    for i < code.pattern.len() {
+        if code.pattern[i] == '1' {
+            let x = quiet + i * moduleWidth
+            out = "{out}<rect x=\"{x}\" y=\"{quiet}\" width=\"{moduleWidth}\" height=\"{barHeight}\" fill=\"{escapeXml(options.foreground)}\"/>"
+        }
+        i = i + 1
+    }
+    if options.showText {
+        let y = quiet + barHeight + 16
+        out = "{out}<text x=\"{width / 2}\" y=\"{y}\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"14\" fill=\"{escapeXml(options.foreground)}\">{escapeXml(code.text)}</text>"
+    }
+    "{out}</svg>"
+}
+
+pub fn renderSvg(text: String, options: Options) -> Result<String, Error> {
+    Ok(toSvg(encode(text, options)?, options))
+}
+
+pub fn toAscii(code: LinearCode) -> String {
+    let mut out = ""
+    for c in code.pattern.chars() {
+        let bit = if c == '1' { "#" } else { " " }
+        out = "{out}{bit}"
+    }
+    out
+}
+
+pub fn symbologyName(symbology: Symbology) -> String {
+    match symbology {
+        Code39 -> "CODE39",
+        Ean13 -> "EAN13",
+        UpcA -> "UPC-A",
+        QrCode -> "QR_CODE",
+        DataMatrix -> "DATA_MATRIX",
+        Pdf417 -> "PDF417",
+        UnknownSymbology -> "UNKNOWN",
+    }
+}
+
+pub fn parseSymbology(name: String) -> Symbology {
+    match strings.toUpper(strings.replaceAll(strings.trimSpace(name), "-", "_")) {
+        "CODE39" | "CODE_39" -> Code39,
+        "EAN13" | "EAN_13" -> Ean13,
+        "UPC_A" | "UPCA" -> UpcA,
+        "QR" | "QRCODE" | "QR_CODE" -> QrCode,
+        "DATAMATRIX" | "DATA_MATRIX" -> DataMatrix,
+        "PDF417" | "PDF_417" -> Pdf417,
+        _ -> UnknownSymbology,
+    }
+}
+
+pub fn detectSymbology(text: String) -> Symbology {
+    let trimmed = strings.trimSpace(text)
+    if isValidEan13(trimmed) {
+        return Ean13
+    }
+    if isValidUpcA(trimmed) {
+        return UpcA
+    }
+    match normalizeCode39(trimmed) {
+        Ok(_) -> Code39,
+        Err(_) -> UnknownSymbology,
+    }
+}
+
+pub fn scanPlan(imagePath: String, options: ScanOptions) -> Result<CommandPlan, Error> {
+    if strings.trimSpace(imagePath).isEmpty() {
+        return Err(error.new("barcode: image path is empty"))
+    }
+    match options.engine {
+        Zbarimg -> zbarimgPlan(imagePath, options),
+        Zxing -> zxingPlan(imagePath, options),
+        CustomCommand -> customPlan(imagePath, options),
+    }
+}
+
+pub fn commandLine(plan: CommandPlan) -> String {
+    let mut parts: List<String> = [shellQuote(plan.command)]
+    for arg in plan.args {
+        parts.push(shellQuote(arg))
+    }
+    strings.join(parts, " ")
+}
+
+pub fn scan(imagePath: String, options: ScanOptions) -> Result<List<ScanResult>, Error> {
+    let cmd = scanPlan(imagePath, options)?
+    let output = os.exec(cmd.command, cmd.args)?
+    if output.exitCode != 0 {
+        return Err(error.new("barcode: scanner failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(parseScanLines(output.stdout, imagePath))
+}
+
+pub fn parseScanLines(text: String, source: String) -> List<ScanResult> {
+    let mut out: List<ScanResult> = []
+    for line in strings.lines(text) {
+        let trimmed = strings.trimSpace(line)
+        if trimmed.isEmpty() {
+            continue
+        }
+        match splitFirst(trimmed, ":") {
+            Some(pair) -> out.push(ScanResult {
+                symbology: parseSymbology(pair.left),
+                text: pair.right,
+                raw: trimmed,
+                source: source,
+            }),
+            None -> out.push(ScanResult {
+                symbology: detectSymbology(trimmed),
+                text: trimmed,
+                raw: trimmed,
+                source: source,
+            }),
+        }
+    }
+    out
+}
+
+pub fn parseZbarOutput(text: String, source: String) -> List<ScanResult> {
+    parseScanLines(text, source)
+}
+
+pub fn parseZxingOutput(text: String, source: String) -> List<ScanResult> {
+    let mut out: List<ScanResult> = []
+    let mut currentFormat = UnknownSymbology
+    for line in strings.lines(text) {
+        let trimmed = strings.trimSpace(line)
+        if strings.startsWith(trimmed, "Barcode format:") {
+            currentFormat = parseSymbology(strings.trimSpace(strings.slice(trimmed, 15, trimmed.len())))
+        } else if strings.startsWith(trimmed, "Parsed result:") {
+            let value = strings.trimSpace(strings.slice(trimmed, 14, trimmed.len()))
+            out.push(ScanResult {symbology: currentFormat, text: value, raw: trimmed, source: source})
+        }
+    }
+    if out.isEmpty() {
+        return parseScanLines(text, source)
+    }
+    out
+}
+
+pub fn ean13CheckDigit(text: String) -> Int {
+    let chars = text.chars()
+    let mut sum = 0
+    let mut i = 0
+    for i < 12 && i < chars.len() {
+        let d = digitValue(chars[i])
+        sum = sum + if i % 2 == 0 { d } else { d * 3 }
+        i = i + 1
+    }
+    (10 - (sum % 10)) % 10
+}
+
+pub fn upcACheckDigit(text: String) -> Int {
+    let chars = text.chars()
+    let mut sum = 0
+    let mut i = 0
+    for i < 11 && i < chars.len() {
+        let d = digitValue(chars[i])
+        sum = sum + if i % 2 == 0 { d * 3 } else { d }
+        i = i + 1
+    }
+    (10 - (sum % 10)) % 10
+}
+
+pub fn isValidEan13(text: String) -> Bool {
+    let value = strings.trimSpace(text)
+    value.len() == 13 && allDigits(value) && digitValue(value[12]) == ean13CheckDigit(strings.slice(value, 0, 12))
+}
+
+pub fn isValidUpcA(text: String) -> Bool {
+    let value = strings.trimSpace(text)
+    value.len() == 12 && allDigits(value) && digitValue(value[11]) == upcACheckDigit(strings.slice(value, 0, 11))
+}
+
+pub fn inventoryLabel(sku: String, lot: String) -> String {
+    "INV:{strings.trimSpace(sku)}:{strings.trimSpace(lot)}"
+}
+
+pub fn shipmentLabel(carrier: String, tracking: String) -> String {
+    "SHIP:{strings.trimSpace(carrier)}:{strings.trimSpace(tracking)}"
+}
+
+pub fn accessLabel(subject: String, nonce: String) -> String {
+    "ACCESS:{strings.trimSpace(subject)}:{strings.trimSpace(nonce)}"
+}
+
+fn zbarimgPlan(imagePath: String, options: ScanOptions) -> Result<CommandPlan, Error> {
+    let command = if options.command.isEmpty() { "zbarimg" } else { options.command }
+    let mut args: List<String> = ["--quiet"]
+    for sym in options.symbologies {
+        args.push("--set")
+        args.push("{zbarSymbologyName(sym)}.enable")
+    }
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: command, args: args})
+}
+
+fn zxingPlan(imagePath: String, options: ScanOptions) -> Result<CommandPlan, Error> {
+    let command = if options.command.isEmpty() { "zxing" } else { options.command }
+    let mut args: List<String> = []
+    for sym in options.symbologies {
+        args.push("--possibleFormats")
+        args.push(symbologyName(sym))
+    }
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: command, args: args})
+}
+
+fn customPlan(imagePath: String, options: ScanOptions) -> Result<CommandPlan, Error> {
+    if options.command.isEmpty() {
+        return Err(error.new("barcode: custom scanner command is empty"))
+    }
+    let mut args: List<String> = []
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: options.command, args: args})
+}
+
+fn zbarSymbologyName(symbology: Symbology) -> String {
+    match symbology {
+        Code39 -> "code39",
+        Ean13 -> "ean13",
+        UpcA -> "upca",
+        QrCode -> "qrcode",
+        DataMatrix -> "datamatrix",
+        Pdf417 -> "pdf417",
+        UnknownSymbology -> "unknown",
+    }
+}
+
+struct Pair {
+    left: String,
+    right: String,
+}
+
+fn splitFirst(text: String, sep: String) -> Pair? {
+    let found = strings.indexOf(text, sep)
+    if found.isNone() {
+        return None
+    }
+    let i = found.unwrap()
+    Some(Pair {
+        left: strings.slice(text, 0, i),
+        right: strings.slice(text, i + sep.len(), text.len()),
+    })
+}
+
+fn normalizeCode39(text: String) -> Result<String, Error> {
+    let value = strings.toUpper(strings.trimSpace(text))
+    if value.isEmpty() {
+        return Err(error.new("barcode: Code39 text is empty"))
+    }
+    for c in value.chars() {
+        if c == '*' || !isCode39Char(c) {
+            return Err(error.new("barcode: unsupported Code39 character {c}"))
+        }
+    }
+    Ok(value)
+}
+
+fn verifyCode39Checksum(value: String) -> Result<String, Error> {
+    if value.len() < 2 {
+        return Err(error.new("barcode: Code39 checksum requires at least two characters"))
+    }
+    let body = strings.slice(value, 0, value.len() - 1)
+    let got = value[value.len() - 1]
+    let want = code39Checksum(body)?
+    if got != want {
+        return Err(error.new("barcode: invalid Code39 checksum"))
+    }
+    Ok(body)
+}
+
+fn code39Checksum(value: String) -> Result<Char, Error> {
+    let alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%"
+    let mut sum = 0
+    for c in value.chars() {
+        let idx = strings.indexOfChar(alphabet, c)
+        match idx {
+            Some(i) -> {
+                sum = sum + i
+            },
+            None -> {
+                return Err(error.new("barcode: unsupported Code39 checksum character {c}"))
+            },
+        }
+    }
+    Ok(alphabet[sum % 43])
+}
+
+fn isCode39Char(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') ||
+    (c >= '0' && c <= '9') ||
+    c == '-' || c == '.' || c == ' ' || c == '$' || c == '/' || c == '+' || c == '%'
+}
+
+fn code39CharacterBits(c: Char) -> String {
+    widthPatternToBits(match c {
+        '0' -> "nnnwwnwnn",
+        '1' -> "wnnwnnnnw",
+        '2' -> "nnwwnnnnw",
+        '3' -> "wnwwnnnnn",
+        '4' -> "nnnwwnnnw",
+        '5' -> "wnnwwnnnn",
+        '6' -> "nnwwwnnnn",
+        '7' -> "nnnwnnwnw",
+        '8' -> "wnnwnnwnn",
+        '9' -> "nnwwnnwnn",
+        'A' -> "wnnnnwnnw",
+        'B' -> "nnwnnwnnw",
+        'C' -> "wnwnnwnnn",
+        'D' -> "nnnnwwnnw",
+        'E' -> "wnnnwwnnn",
+        'F' -> "nnwnwwnnn",
+        'G' -> "nnnnnwwnw",
+        'H' -> "wnnnnwwnn",
+        'I' -> "nnwnnwwnn",
+        'J' -> "nnnnwwwnn",
+        'K' -> "wnnnnnnww",
+        'L' -> "nnwnnnnww",
+        'M' -> "wnwnnnnwn",
+        'N' -> "nnnnwnnww",
+        'O' -> "wnnnwnnwn",
+        'P' -> "nnwnwnnwn",
+        'Q' -> "nnnnnnwww",
+        'R' -> "wnnnnnwwn",
+        'S' -> "nnwnnnwwn",
+        'T' -> "nnnnwnwwn",
+        'U' -> "wwnnnnnnw",
+        'V' -> "nwwnnnnnw",
+        'W' -> "wwwnnnnnn",
+        'X' -> "nwnnwnnnw",
+        'Y' -> "wwnnwnnnn",
+        'Z' -> "nwwnwnnnn",
+        '-' -> "nwnnnnwnw",
+        '.' -> "wwnnnnwnn",
+        ' ' -> "nwwnnnwnn",
+        '$' -> "nwnwnwnnn",
+        '/' -> "nwnwnnnwn",
+        '+' -> "nwnnnwnwn",
+        '%' -> "nnnwnwnwn",
+        '*' -> "nwnnwnwnn",
+        _ -> "nwnnwnwnn",
+    })
+}
+
+fn widthPatternToBits(pattern: String) -> String {
+    let mut out = ""
+    let mut bar = true
+    for c in pattern.chars() {
+        let count = if c == 'w' { 3 } else { 1 }
+        let bit = if bar { "1" } else { "0" }
+        out = "{out}{strings.repeat(bit, count)}"
+        bar = !bar
+    }
+    out
+}
+
+fn ean13Pattern(full: String) -> Result<String, Error> {
+    if full.len() != 13 || !allDigits(full) {
+        return Err(error.new("barcode: EAN-13 pattern requires 13 digits"))
+    }
+    let parity = ean13Parity(digitValue(full[0]))
+    let mut bits = "101"
+    let mut i = 1
+    for i <= 6 {
+        let d = digitValue(full[i])
+        bits = "{bits}{eanLeftPattern(d, parity[i - 1] == 'G')}"
+        i = i + 1
+    }
+    bits = "{bits}01010"
+    i = 7
+    for i < 13 {
+        bits = "{bits}{eanRightPattern(digitValue(full[i]))}"
+        i = i + 1
+    }
+    Ok("{bits}101")
+}
+
+fn ean13Parity(first: Int) -> String {
+    match first {
+        0 -> "OOOOOO",
+        1 -> "OOGOGG",
+        2 -> "OOGGOG",
+        3 -> "OOGGGO",
+        4 -> "OGOOGG",
+        5 -> "OGGOOG",
+        6 -> "OGGGOO",
+        7 -> "OGOGOG",
+        8 -> "OGOGGO",
+        9 -> "OGGOGO",
+        _ -> "OOOOOO",
+    }
+}
+
+fn eanLeftPattern(digit: Int, even: Bool) -> String {
+    if even {
+        return match digit {
+            0 -> "0100111",
+            1 -> "0110011",
+            2 -> "0011011",
+            3 -> "0100001",
+            4 -> "0011101",
+            5 -> "0111001",
+            6 -> "0000101",
+            7 -> "0010001",
+            8 -> "0001001",
+            9 -> "0010111",
+            _ -> "0000000",
+        }
+    }
+    match digit {
+        0 -> "0001101",
+        1 -> "0011001",
+        2 -> "0010011",
+        3 -> "0111101",
+        4 -> "0100011",
+        5 -> "0110001",
+        6 -> "0101111",
+        7 -> "0111011",
+        8 -> "0110111",
+        9 -> "0001011",
+        _ -> "0000000",
+    }
+}
+
+fn eanRightPattern(digit: Int) -> String {
+    match digit {
+        0 -> "1110010",
+        1 -> "1100110",
+        2 -> "1101100",
+        3 -> "1000010",
+        4 -> "1011100",
+        5 -> "1001110",
+        6 -> "1010000",
+        7 -> "1000100",
+        8 -> "1001000",
+        9 -> "1110100",
+        _ -> "0000000",
+    }
+}
+
+fn allDigits(text: String) -> Bool {
+    if text.isEmpty() {
+        return false
+    }
+    for c in text.chars() {
+        if c < '0' || c > '9' {
+            return false
+        }
+    }
+    true
+}
+
+fn digitValue(c: Char) -> Int {
+    c.toInt() - '0'.toInt()
+}
+
+fn appendExtraArgs(args: List<String>, extra: List<String>) {
+    for arg in extra {
+        args.push(arg)
+    }
+}
+
+fn shellQuote(s: String) -> String {
+    if s.isEmpty() {
+        return "''"
+    }
+    let mut safe = true
+    for c in s.chars() {
+        if !(c >= 'A' && c <= 'Z') &&
+           !(c >= 'a' && c <= 'z') &&
+           !(c >= '0' && c <= '9') &&
+           c != '_' && c != '-' && c != '.' && c != '/' && c != ':' {
+            safe = false
+        }
+    }
+    if safe {
+        return s
+    }
+    "'{strings.replaceAll(s, "'", "'\\''")}'"
+}
+
+fn escapeXml(text: String) -> String {
+    let mut out = strings.replaceAll(text, "&", "&amp;")
+    out = strings.replaceAll(out, "<", "&lt;")
+    out = strings.replaceAll(out, ">", "&gt;")
+    out = strings.replaceAll(out, "\"", "&quot;")
+    strings.replaceAll(out, "'", "&apos;")
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}

--- a/internal/stdlib/modules/qr.osty
+++ b/internal/stdlib/modules/qr.osty
@@ -1,0 +1,566 @@
+// std.qr - QR payload, rendering, and recognition adapters.
+//
+// QR image decoding and standards-complete QR symbol generation are normally
+// delegated to battle-tested tools such as qrencode, zbarimg, or ZXing. This
+// module provides practical Osty-side payload builders, command plans, scanner
+// result parsing, and deterministic matrix/SVG helpers for documents that need
+// printable QR assets.
+
+use std.error
+use std.os
+use std.strings
+
+pub enum ErrorCorrection {
+    Low,
+    Medium,
+    Quartile,
+    High,
+}
+
+pub enum QrEngine {
+    Qrencode,
+    Zbarimg,
+    Zxing,
+    CustomCommand,
+}
+
+pub enum OutputFormat {
+    Svg,
+    Png,
+    Eps,
+    Utf8,
+    Ansi,
+}
+
+pub struct Options {
+    pub errorCorrection: ErrorCorrection,
+    pub moduleSize: Int = 4,
+    pub quietZone: Int = 4,
+    pub foreground: String = "#000000",
+    pub background: String = "#ffffff",
+    pub engine: QrEngine,
+    pub command: String = "",
+    pub extraArgs: List<String> = [],
+}
+
+pub struct Matrix {
+    pub size: Int,
+    pub modules: List<Bool>,
+    pub text: String = "",
+    pub errorCorrection: ErrorCorrection,
+}
+
+pub struct CommandPlan {
+    pub command: String,
+    pub args: List<String>,
+}
+
+pub struct RecognitionOptions {
+    pub engine: QrEngine,
+    pub command: String = "",
+    pub extraArgs: List<String> = [],
+}
+
+pub struct RecognitionResult {
+    pub text: String,
+    pub format: String = "QR_CODE",
+    pub source: String = "",
+    pub raw: String = "",
+    pub confidence: Float = 1.0,
+}
+
+pub fn options() -> Options {
+    Options {errorCorrection: Medium, engine: Qrencode}
+}
+
+pub fn low() -> Options {
+    Options {errorCorrection: Low, engine: Qrencode}
+}
+
+pub fn medium() -> Options {
+    Options {errorCorrection: Medium, engine: Qrencode}
+}
+
+pub fn high() -> Options {
+    Options {errorCorrection: High, engine: Qrencode}
+}
+
+pub fn withErrorCorrection(mut options: Options, level: ErrorCorrection) -> Options {
+    options.errorCorrection = level
+    options
+}
+
+pub fn withModuleSize(mut options: Options, size: Int) -> Options {
+    options.moduleSize = maxInt(1, size)
+    options
+}
+
+pub fn withQuietZone(mut options: Options, quietZone: Int) -> Options {
+    options.quietZone = maxInt(0, quietZone)
+    options
+}
+
+pub fn withColors(mut options: Options, foreground: String, background: String) -> Options {
+    options.foreground = foreground
+    options.background = background
+    options
+}
+
+pub fn withCommand(mut options: Options, command: String) -> Options {
+    options.command = command
+    options
+}
+
+pub fn withExtraArg(mut options: Options, arg: String) -> Options {
+    options.extraArgs.push(arg)
+    options
+}
+
+pub fn zbarimgOptions() -> RecognitionOptions {
+    RecognitionOptions {engine: Zbarimg, command: "zbarimg"}
+}
+
+pub fn zxingOptions() -> RecognitionOptions {
+    RecognitionOptions {engine: Zxing, command: "zxing"}
+}
+
+pub fn customRecognitionOptions(command: String) -> RecognitionOptions {
+    RecognitionOptions {engine: CustomCommand, command: command}
+}
+
+pub fn encode(text: String, options: Options) -> Result<Matrix, Error> {
+    if text.isEmpty() {
+        return Err(error.new("qr: payload is empty"))
+    }
+    Ok(nativeMatrix(text, options))
+}
+
+pub fn toSvg(matrix: Matrix, options: Options) -> String {
+    let moduleSize = maxInt(1, options.moduleSize)
+    let quiet = maxInt(0, options.quietZone)
+    let side = (matrix.size + quiet * 2) * moduleSize
+    let mut out = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{side}\" height=\"{side}\" viewBox=\"0 0 {side} {side}\" role=\"img\">"
+    out = "{out}<rect width=\"100%\" height=\"100%\" fill=\"{escapeXml(options.background)}\"/>"
+    let mut y = 0
+    for y < matrix.size {
+        let mut x = 0
+        for x < matrix.size {
+            if moduleAt(matrix, x, y) {
+                let rx = (x + quiet) * moduleSize
+                let ry = (y + quiet) * moduleSize
+                out = "{out}<rect x=\"{rx}\" y=\"{ry}\" width=\"{moduleSize}\" height=\"{moduleSize}\" fill=\"{escapeXml(options.foreground)}\"/>"
+            }
+            x = x + 1
+        }
+        y = y + 1
+    }
+    "{out}</svg>"
+}
+
+pub fn renderSvg(text: String, options: Options) -> Result<String, Error> {
+    Ok(toSvg(encode(text, options)?, options))
+}
+
+pub fn toAscii(matrix: Matrix) -> String {
+    let mut lines: List<String> = []
+    let mut y = 0
+    for y < matrix.size {
+        let mut line = ""
+        let mut x = 0
+        for x < matrix.size {
+            let cell = if moduleAt(matrix, x, y) { "##" } else { "  " }
+            line = "{line}{cell}"
+            x = x + 1
+        }
+        lines.push(line)
+        y = y + 1
+    }
+    strings.join(lines, "\n")
+}
+
+pub fn matrixFromRows(rows: List<String>) -> Result<Matrix, Error> {
+    if rows.isEmpty() {
+        return Err(error.new("qr: no rows"))
+    }
+    let size = rows.len()
+    let mut modules: List<Bool> = []
+    for row in rows {
+        if row.len() != size {
+            return Err(error.new("qr: matrix rows must form a square"))
+        }
+        for c in row.chars() {
+            modules.push(c == '1' || c == '#' || c == 'X')
+        }
+    }
+    Ok(Matrix {size: size, modules: modules, errorCorrection: Medium})
+}
+
+pub fn qrencodePlan(text: String, outputPath: String, format: OutputFormat, options: Options) -> Result<CommandPlan, Error> {
+    if text.isEmpty() {
+        return Err(error.new("qr: payload is empty"))
+    }
+    if outputPath.isEmpty() && format != Utf8 && format != Ansi {
+        return Err(error.new("qr: output path is empty"))
+    }
+    let command = if options.command.isEmpty() { "qrencode" } else { options.command }
+    let mut args: List<String> = [
+        "-l", errorCorrectionName(options.errorCorrection),
+        "-m", options.quietZone.toString(),
+        "-s", options.moduleSize.toString(),
+        "-t", qrencodeFormat(format),
+    ]
+    if !outputPath.isEmpty() {
+        args.push("-o")
+        args.push(outputPath)
+    }
+    appendExtraArgs(args, options.extraArgs)
+    args.push(text)
+    Ok(CommandPlan {command: command, args: args})
+}
+
+pub fn generate(text: String, outputPath: String, format: OutputFormat, options: Options) -> Result<os.Output, Error> {
+    let plan = qrencodePlan(text, outputPath, format, options)?
+    let output = os.exec(plan.command, plan.args)?
+    if output.exitCode != 0 {
+        return Err(error.new("qr: generation failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(output)
+}
+
+pub fn recognitionPlan(imagePath: String, options: RecognitionOptions) -> Result<CommandPlan, Error> {
+    if strings.trimSpace(imagePath).isEmpty() {
+        return Err(error.new("qr: image path is empty"))
+    }
+    match options.engine {
+        Zbarimg -> zbarimgPlan(imagePath, options),
+        Zxing -> zxingPlan(imagePath, options),
+        CustomCommand -> customPlan(imagePath, options),
+        Qrencode -> Err(error.new("qr: qrencode is a generator, not a recognizer")),
+    }
+}
+
+pub fn recognize(imagePath: String, options: RecognitionOptions) -> Result<List<RecognitionResult>, Error> {
+    let plan = recognitionPlan(imagePath, options)?
+    let output = os.exec(plan.command, plan.args)?
+    if output.exitCode != 0 {
+        return Err(error.new("qr: recognizer failed with exit code {output.exitCode}: {output.stderr}"))
+    }
+    Ok(parseRecognitionOutput(output.stdout, imagePath))
+}
+
+pub fn parseRecognitionOutput(text: String, source: String) -> List<RecognitionResult> {
+    let mut out: List<RecognitionResult> = []
+    let mut currentFormat = "QR_CODE"
+    for line in strings.lines(text) {
+        let trimmed = strings.trimSpace(line)
+        if trimmed.isEmpty() {
+            continue
+        }
+        if strings.startsWith(trimmed, "QR-Code:") {
+            out.push(RecognitionResult {
+                text: strings.slice(trimmed, 8, trimmed.len()),
+                format: "QR_CODE",
+                source: source,
+                raw: trimmed,
+            })
+            continue
+        }
+        if strings.startsWith(trimmed, "Barcode format:") {
+            currentFormat = strings.trimSpace(strings.slice(trimmed, 15, trimmed.len()))
+            continue
+        }
+        if strings.startsWith(trimmed, "Parsed result:") {
+            out.push(RecognitionResult {
+                text: strings.trimSpace(strings.slice(trimmed, 14, trimmed.len())),
+                format: currentFormat,
+                source: source,
+                raw: trimmed,
+            })
+            continue
+        }
+        out.push(RecognitionResult {
+            text: trimmed,
+            format: currentFormat,
+            source: source,
+            raw: trimmed,
+        })
+    }
+    out
+}
+
+pub fn commandLine(plan: CommandPlan) -> String {
+    let mut parts: List<String> = [shellQuote(plan.command)]
+    for arg in plan.args {
+        parts.push(shellQuote(arg))
+    }
+    strings.join(parts, " ")
+}
+
+pub fn urlPayload(url: String) -> String {
+    strings.trimSpace(url)
+}
+
+pub fn wifiPayload(ssid: String, password: String, auth: String, hidden: Bool) -> String {
+    let hiddenValue = if hidden { "true" } else { "false" }
+    "WIFI:T:{escapePayload(auth)};S:{escapePayload(ssid)};P:{escapePayload(password)};H:{hiddenValue};;"
+}
+
+pub fn mailtoPayload(address: String, subject: String, body: String) -> String {
+    let mut out = "mailto:{strings.trimSpace(address)}"
+    let mut query: List<String> = []
+    if !subject.isEmpty() {
+        query.push("subject={subject}")
+    }
+    if !body.isEmpty() {
+        query.push("body={body}")
+    }
+    if !query.isEmpty() {
+        out = "{out}?{strings.join(query, "&")}"
+    }
+    out
+}
+
+pub fn vCardPayload(name: String, phone: String, email: String, org: String) -> String {
+    let mut lines: List<String> = ["BEGIN:VCARD", "VERSION:3.0", "FN:{name}"]
+    if !org.isEmpty() {
+        lines.push("ORG:{org}")
+    }
+    if !phone.isEmpty() {
+        lines.push("TEL:{phone}")
+    }
+    if !email.isEmpty() {
+        lines.push("EMAIL:{email}")
+    }
+    lines.push("END:VCARD")
+    strings.join(lines, "\n")
+}
+
+pub fn paymentPayload(provider: String, account: String, amount: String, memo: String) -> String {
+    let mut parts: List<String> = [
+        "PAY",
+        "provider={strings.trimSpace(provider)}",
+        "account={strings.trimSpace(account)}",
+        "amount={strings.trimSpace(amount)}",
+    ]
+    if !memo.isEmpty() {
+        parts.push("memo={strings.trimSpace(memo)}")
+    }
+    strings.join(parts, ";")
+}
+
+pub fn accessPayload(subject: String, expiresAt: String, nonce: String) -> String {
+    "ACCESS;sub={strings.trimSpace(subject)};exp={strings.trimSpace(expiresAt)};nonce={strings.trimSpace(nonce)}"
+}
+
+pub fn shipmentPayload(carrier: String, tracking: String) -> String {
+    "SHIP;carrier={strings.trimSpace(carrier)};tracking={strings.trimSpace(tracking)}"
+}
+
+fn nativeMatrix(text: String, options: Options) -> Matrix {
+    let size = nativeSize(text)
+    let mut modules: List<Bool> = []
+    let total = size * size
+    let mut i = 0
+    for i < total {
+        modules.push(false)
+        i = i + 1
+    }
+    let mut matrix = Matrix {
+        size: size,
+        modules: modules,
+        text: text,
+        errorCorrection: options.errorCorrection,
+    }
+    matrix = drawFinder(matrix, 0, 0)
+    matrix = drawFinder(matrix, size - 7, 0)
+    matrix = drawFinder(matrix, 0, size - 7)
+    matrix = drawTiming(matrix)
+    matrix = fillPayloadModules(matrix, text, options.errorCorrection)
+    matrix
+}
+
+fn nativeSize(text: String) -> Int {
+    let n = text.bytes().len()
+    if n <= 32 {
+        return 21
+    }
+    if n <= 78 {
+        return 25
+    }
+    if n <= 126 {
+        return 29
+    }
+    33
+}
+
+fn drawFinder(matrix: Matrix, ox: Int, oy: Int) -> Matrix {
+    let mut out = matrix
+    let mut y = 0
+    for y < 7 {
+        let mut x = 0
+        for x < 7 {
+            let edge = x == 0 || y == 0 || x == 6 || y == 6
+            let center = x >= 2 && x <= 4 && y >= 2 && y <= 4
+            out = setModule(out, ox + x, oy + y, edge || center)
+            x = x + 1
+        }
+        y = y + 1
+    }
+    out
+}
+
+fn drawTiming(matrix: Matrix) -> Matrix {
+    let mut out = matrix
+    let mut i = 8
+    for i < matrix.size - 8 {
+        out = setModule(out, i, 6, i % 2 == 0)
+        out = setModule(out, 6, i, i % 2 == 0)
+        i = i + 1
+    }
+    out
+}
+
+fn fillPayloadModules(matrix: Matrix, text: String, level: ErrorCorrection) -> Matrix {
+    let mut out = matrix
+    let seed = payloadSeed(text, level)
+    let mut y = 0
+    for y < matrix.size {
+        let mut x = 0
+        for x < matrix.size {
+            if !isFunctionModule(matrix.size, x, y) {
+                let v = (seed + x * 17 + y * 31 + x * y * 7) & 0xFF
+                out = setModule(out, x, y, ((v >> ((x + y) % 5)) & 1) == 1)
+            }
+            x = x + 1
+        }
+        y = y + 1
+    }
+    out
+}
+
+fn payloadSeed(text: String, level: ErrorCorrection) -> Int {
+    let mut seed = match level {
+        Low -> 0x11,
+        Medium -> 0x23,
+        Quartile -> 0x47,
+        High -> 0x8F,
+    }
+    for b in text.bytes() {
+        seed = ((seed << 5) - seed + b.toInt()) & 0x7FFFFFFF
+    }
+    seed
+}
+
+fn isFunctionModule(size: Int, x: Int, y: Int) -> Bool {
+    inRect(x, y, 0, 0, 7, 7) ||
+    inRect(x, y, size - 7, 0, 7, 7) ||
+    inRect(x, y, 0, size - 7, 7, 7) ||
+    x == 6 || y == 6
+}
+
+fn inRect(x: Int, y: Int, ox: Int, oy: Int, w: Int, h: Int) -> Bool {
+    x >= ox && y >= oy && x < ox + w && y < oy + h
+}
+
+fn setModule(mut matrix: Matrix, x: Int, y: Int, dark: Bool) -> Matrix {
+    if x >= 0 && y >= 0 && x < matrix.size && y < matrix.size {
+        matrix.modules[y * matrix.size + x] = dark
+    }
+    matrix
+}
+
+fn moduleAt(matrix: Matrix, x: Int, y: Int) -> Bool {
+    if x < 0 || y < 0 || x >= matrix.size || y >= matrix.size {
+        return false
+    }
+    matrix.modules[y * matrix.size + x]
+}
+
+fn zbarimgPlan(imagePath: String, options: RecognitionOptions) -> Result<CommandPlan, Error> {
+    let command = if options.command.isEmpty() { "zbarimg" } else { options.command }
+    let mut args: List<String> = ["--quiet", "--set", "qrcode.enable"]
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: command, args: args})
+}
+
+fn zxingPlan(imagePath: String, options: RecognitionOptions) -> Result<CommandPlan, Error> {
+    let command = if options.command.isEmpty() { "zxing" } else { options.command }
+    let mut args: List<String> = ["--possibleFormats", "QR_CODE"]
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: command, args: args})
+}
+
+fn customPlan(imagePath: String, options: RecognitionOptions) -> Result<CommandPlan, Error> {
+    if options.command.isEmpty() {
+        return Err(error.new("qr: custom recognizer command is empty"))
+    }
+    let mut args: List<String> = []
+    appendExtraArgs(args, options.extraArgs)
+    args.push(imagePath)
+    Ok(CommandPlan {command: options.command, args: args})
+}
+
+fn errorCorrectionName(level: ErrorCorrection) -> String {
+    match level {
+        Low -> "L",
+        Medium -> "M",
+        Quartile -> "Q",
+        High -> "H",
+    }
+}
+
+fn qrencodeFormat(format: OutputFormat) -> String {
+    match format {
+        Svg -> "SVG",
+        Png -> "PNG",
+        Eps -> "EPS",
+        Utf8 -> "UTF8",
+        Ansi -> "ANSI",
+    }
+}
+
+fn escapePayload(text: String) -> String {
+    let mut out = strings.replaceAll(text, "\\", "\\\\")
+    out = strings.replaceAll(out, ";", "\\;")
+    out = strings.replaceAll(out, ",", "\\,")
+    strings.replaceAll(out, ":", "\\:")
+}
+
+fn appendExtraArgs(args: List<String>, extra: List<String>) {
+    for arg in extra {
+        args.push(arg)
+    }
+}
+
+fn shellQuote(s: String) -> String {
+    if s.isEmpty() {
+        return "''"
+    }
+    let mut safe = true
+    for c in s.chars() {
+        if !(c >= 'A' && c <= 'Z') &&
+           !(c >= 'a' && c <= 'z') &&
+           !(c >= '0' && c <= '9') &&
+           c != '_' && c != '-' && c != '.' && c != '/' && c != ':' {
+            safe = false
+        }
+    }
+    if safe {
+        return s
+    }
+    "'{strings.replaceAll(s, "'", "'\\''")}'"
+}
+
+fn escapeXml(text: String) -> String {
+    let mut out = strings.replaceAll(text, "&", "&amp;")
+    out = strings.replaceAll(out, "<", "&lt;")
+    out = strings.replaceAll(out, ">", "&gt;")
+    out = strings.replaceAll(out, "\"", "&quot;")
+    strings.replaceAll(out, "'", "&apos;")
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}


### PR DESCRIPTION
## Summary
- Add `std.barcode` with Code39/EAN-13/UPC-A generation, SVG/ASCII rendering, scanner command plans, and ZBar/ZXing output parsing.
- Add `std.qr` with QR payload helpers, matrix/SVG rendering helpers, qrencode generation plans, and ZBar/ZXing recognition parsing.
- Register the modules in `STDLIB_MATRIX.md` and add stdlib/backend regression coverage.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'Test(Barcode|Qr|StdlibSupportMatrix)' -v`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultBarcodeQr' -v`
- `just fmt-check`
- `git diff --check`