### PR TITLE
[codex] add std rpa automation module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 84 공개 모듈. 분류 기준:
+총 85 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (80 / 84 = 95%)
+### ⭐⭐⭐⭐⭐ Production (81 / 85 = 95%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -72,6 +72,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | image | 372 | pure Osty + bytes | PNG / JPEG / GIF / BMP / WebP format + dimension metadata parser |
 | ocr | 1136 | pure Osty + os/fs/json | PaddleOCR v5 / Tesseract command adapters, fast/accurate presets, batch JSON ingestion, confidence review queues, search, key-value extraction, RAG-friendly chunks |
+| rpa | 1089 | pure Osty + os/strings | Desktop RPA command plans: mouse move/click/drag/scroll, keyboard typing/hotkeys/paste, window query/focus/wait, script repeat/delay, macOS cliclick+osascript / Linux xdotool / Windows PowerShell adapters |
 | scan | 670 | pure Osty + os/fs/image/ocr | SANE `scanimage` / custom scanner command planning, device-list parsing, batch page paths, image metadata probe, manifest generation, scan→OCR indexed document handoff |
 | smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
@@ -112,7 +113,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (4 / 84 = 5%)
+### ⭐⭐⭐⭐ Production-adjacent (4 / 85 = 5%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -128,7 +129,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `schedule`, `dialog`, `watch`, `scan`, `print`, `clipboard` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `print`, `clipboard` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -167,6 +168,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | 이미지 메타데이터 | ✅ 가능 | image (PNG / JPEG / GIF / BMP / WebP dimensions) |
 | OCR 엔진 연결 / 결과 분석 | ✅ 가능 | ocr (PaddleOCR v5 / Tesseract 실행 계획, JSON/TSV normalize, confidence/search/key-value/chunk helpers) |
 | 스캔→OCR 문서 자동화 | ✅ 가능 | scan + ocr + image + fs/os (SANE/custom scanner command plan, scanned page metadata, OCR batch/index/manifest) |
+| Desktop RPA / 반복 업무 자동화 | ✅ 가능 | rpa (마우스 이동/클릭/드래그/스크롤, 키 입력/hotkey/paste, 창 검색/focus/wait, 반복 스크립트, macOS/Linux/Windows command plan) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
@@ -207,7 +209,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 60 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
+- 61 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, ocr, rpa, scan, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)
 - print 는 기존 `std.os` host process bridge 위에서 CUPS/Windows/custom spooler 실행 계획을 제공한다. 실제 출력은 가능하지만 프린터별 capability discovery 는 production-adjacent 로 남긴다.

--- a/internal/backend/stdlib_rpa_check_test.go
+++ b/internal/backend/stdlib_rpa_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultRpa(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "rpa")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(rpa) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("rpa module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/rpa.osty
+++ b/internal/stdlib/modules/rpa.osty
@@ -1,0 +1,1089 @@
+// std.rpa - desktop automation plans for repetitive work.
+//
+// This module stays host-tool-backed instead of pretending that mouse,
+// keyboard, and window-manager access is portable inside the language
+// runtime. It gives Osty programs a typed automation script model, OS-specific
+// command plans, and parsers for common window-list output. The default
+// backends target practical tools: cliclick/osascript on macOS, xdotool on X11,
+// and PowerShell on Windows.
+
+use std.error
+use std.os
+use std.strings
+
+pub enum Platform {
+    MacOS,
+    WindowsDesktop,
+    LinuxX11,
+    LinuxWayland,
+    CustomPlatform,
+
+    pub fn toString(self) -> String {
+        match self {
+            MacOS          -> "macos",
+            WindowsDesktop -> "windows",
+            LinuxX11       -> "linux-x11",
+            LinuxWayland   -> "linux-wayland",
+            CustomPlatform -> "custom",
+        }
+    }
+}
+
+pub enum MouseButton {
+    LeftButton,
+    RightButton,
+    MiddleButton,
+
+    pub fn number(self) -> Int {
+        match self {
+            LeftButton   -> 1,
+            MiddleButton -> 2,
+            RightButton  -> 3,
+        }
+    }
+
+    pub fn cliclickName(self) -> String {
+        match self {
+            LeftButton   -> "c",
+            RightButton  -> "rc",
+            MiddleButton -> "mc",
+        }
+    }
+}
+
+pub enum ScrollDirection {
+    ScrollUp,
+    ScrollDown,
+    ScrollLeft,
+    ScrollRight,
+}
+
+pub enum Modifier {
+    Shift,
+    Control,
+    Alt,
+    Meta,
+}
+
+pub enum MatchMode {
+    MatchContains,
+    MatchExact,
+    MatchPrefix,
+    MatchSuffix,
+}
+
+pub enum WindowState {
+    WindowUnknown,
+    WindowVisible,
+    WindowMinimized,
+    WindowFocused,
+}
+
+pub struct Point {
+    pub x: Int = 0,
+    pub y: Int = 0,
+
+    pub fn translate(self, dx: Int, dy: Int) -> Point {
+        Point { x: self.x + dx, y: self.y + dy }
+    }
+
+    pub fn toPair(self) -> String {
+        "{self.x},{self.y}"
+    }
+}
+
+pub struct Bounds {
+    pub x: Int = 0,
+    pub y: Int = 0,
+    pub width: Int = 0,
+    pub height: Int = 0,
+
+    pub fn isEmpty(self) -> Bool {
+        self.width <= 0 || self.height <= 0
+    }
+
+    pub fn contains(self, p: Point) -> Bool {
+        p.x >= self.x && p.y >= self.y && p.x < self.x + self.width && p.y < self.y + self.height
+    }
+
+    pub fn center(self) -> Point {
+        Point { x: self.x + self.width / 2, y: self.y + self.height / 2 }
+    }
+}
+
+pub struct WindowQuery {
+    pub title: String = "",
+    pub appName: String = "",
+    pub processName: String = "",
+    pub id: String = "",
+    pub mode: MatchMode,
+    pub onlyVisible: Bool = true,
+    pub limit: Int = 20,
+
+    pub fn matches(self, win: WindowInfo) -> Bool {
+        matchesWindow(win, self)
+    }
+
+    pub fn withLimit(mut self, limit: Int) -> WindowQuery {
+        self.limit = limit
+        self
+    }
+
+    pub fn visible(mut self, onlyVisible: Bool) -> WindowQuery {
+        self.onlyVisible = onlyVisible
+        self
+    }
+}
+
+pub struct WindowInfo {
+    pub id: String = "",
+    pub appName: String = "",
+    pub processName: String = "",
+    pub title: String = "",
+    pub bounds: Bounds,
+    pub state: WindowState,
+
+    pub fn label(self) -> String {
+        if self.appName.isEmpty() {
+            self.title
+        } else if self.title.isEmpty() {
+            self.appName
+        } else {
+            "{self.appName} - {self.title}"
+        }
+    }
+}
+
+pub struct Backend {
+    pub platform: Platform,
+    pub mouseCommand: String = "",
+    pub keyboardCommand: String = "",
+    pub windowCommand: String = "",
+    pub shellCommand: String = "",
+    pub dryRun: Bool = false,
+
+    pub fn dry(mut self) -> Backend {
+        self.dryRun = true
+        self
+    }
+
+    pub fn withMouseCommand(mut self, command: String) -> Backend {
+        self.mouseCommand = command
+        self
+    }
+
+    pub fn withKeyboardCommand(mut self, command: String) -> Backend {
+        self.keyboardCommand = command
+        self
+    }
+
+    pub fn withWindowCommand(mut self, command: String) -> Backend {
+        self.windowCommand = command
+        self
+    }
+}
+
+pub struct CommandPlan {
+    pub command: String,
+    pub args: List<String>,
+    pub description: String,
+    pub sensitive: Bool = false,
+    pub capturesWindows: Bool = false,
+
+    pub fn commandLine(self) -> String {
+        let mut parts = [self.command]
+        for arg in self.args {
+            parts.push(arg)
+        }
+        strings.join(parts, " ")
+    }
+
+    pub fn sensitive(mut self) -> CommandPlan {
+        self.sensitive = true
+        self
+    }
+}
+
+pub enum Action {
+    MoveMouse(Point),
+    ClickMouse(Point, MouseButton, Int),
+    DragMouse(Point, Point, Int),
+    ScrollMouse(ScrollDirection, Int),
+    TypeText(String),
+    KeyTap(List<Modifier>, String),
+    PasteText(String),
+    FindWindows(WindowQuery),
+    FocusWindow(WindowQuery),
+    WaitWindow(WindowQuery, Int, Int),
+    Pause(Int),
+
+    pub fn description(self) -> String {
+        match self {
+            MoveMouse(pos) -> "move mouse to {pos.toPair()}",
+            ClickMouse(pos, button, clicks) -> "click {button.number()} at {pos.toPair()} x{clicks}",
+            DragMouse(from, to, _) -> "drag from {from.toPair()} to {to.toPair()}",
+            ScrollMouse(_, amount) -> "scroll {amount}",
+            TypeText(text) -> "type {text.charCount()} chars",
+            KeyTap(_, key) -> "press {key}",
+            PasteText(text) -> "paste {text.charCount()} chars",
+            FindWindows(query) -> "find windows {query.title}",
+            FocusWindow(query) -> "focus window {query.title}",
+            WaitWindow(query, timeoutMillis, _) -> "wait {timeoutMillis}ms for window {query.title}",
+            Pause(millis) -> "pause {millis}ms",
+        }
+    }
+}
+
+pub struct ActionResult {
+    pub action: Action,
+    pub plan: CommandPlan,
+    pub output: os.Output? = None,
+    pub skipped: Bool = false,
+    pub windows: List<WindowInfo> = [],
+
+    pub fn ok(self) -> Bool {
+        match self.output {
+            Some(out) -> out.exitCode == 0,
+            None      -> self.skipped,
+        }
+    }
+}
+
+pub struct Script {
+    pub actions: List<Action>,
+    pub defaultDelayMillis: Int = 0,
+    pub repeatCount: Int = 1,
+
+    pub fn append(mut self, action: Action) -> Script {
+        self.actions.push(action)
+        self
+    }
+
+    pub fn delay(mut self, millis: Int) -> Script {
+        self.defaultDelayMillis = millis
+        self
+    }
+
+    pub fn repeat(mut self, count: Int) -> Script {
+        self.repeatCount = maxInt(1, count)
+        self
+    }
+}
+
+pub fn point(x: Int, y: Int) -> Point {
+    Point { x, y }
+}
+
+pub fn bounds(x: Int, y: Int, width: Int, height: Int) -> Bounds {
+    Bounds { x, y, width, height }
+}
+
+pub fn windowQuery() -> WindowQuery {
+    WindowQuery {
+        mode: MatchContains,
+    }
+}
+
+pub fn titleContains(title: String) -> WindowQuery {
+    let mut query = windowQuery()
+    query.title = title
+    query
+}
+
+pub fn appContains(appName: String) -> WindowQuery {
+    let mut query = windowQuery()
+    query.appName = appName
+    query
+}
+
+pub fn processContains(processName: String) -> WindowQuery {
+    let mut query = windowQuery()
+    query.processName = processName
+    query
+}
+
+pub fn windowID(id: String) -> WindowQuery {
+    let mut query = windowQuery()
+    query.id = id
+    query.mode = MatchExact
+    query
+}
+
+pub fn exactTitle(title: String) -> WindowQuery {
+    let mut query = titleContains(title)
+    query.mode = MatchExact
+    query
+}
+
+pub fn macBackend() -> Backend {
+    Backend {
+        platform: MacOS,
+        mouseCommand: "cliclick",
+        keyboardCommand: "osascript",
+        windowCommand: "osascript",
+        shellCommand: "sh",
+    }
+}
+
+pub fn linuxX11Backend() -> Backend {
+    Backend {
+        platform: LinuxX11,
+        mouseCommand: "xdotool",
+        keyboardCommand: "xdotool",
+        windowCommand: "xdotool",
+        shellCommand: "sh",
+    }
+}
+
+pub fn linuxWaylandBackend() -> Backend {
+    Backend {
+        platform: LinuxWayland,
+        mouseCommand: "ydotool",
+        keyboardCommand: "ydotool",
+        windowCommand: "wlrctl",
+        shellCommand: "sh",
+    }
+}
+
+pub fn windowsBackend() -> Backend {
+    Backend {
+        platform: WindowsDesktop,
+        mouseCommand: "powershell",
+        keyboardCommand: "powershell",
+        windowCommand: "powershell",
+        shellCommand: "powershell",
+    }
+}
+
+pub fn customBackend(platform: Platform, mouseCommand: String, keyboardCommand: String, windowCommand: String) -> Backend {
+    Backend {
+        platform,
+        mouseCommand,
+        keyboardCommand,
+        windowCommand,
+        shellCommand: "",
+    }
+}
+
+pub fn moveTo(x: Int, y: Int) -> Action {
+    MoveMouse(point(x, y))
+}
+
+pub fn clickAt(x: Int, y: Int) -> Action {
+    ClickMouse(point(x, y), LeftButton, 1)
+}
+
+pub fn doubleClickAt(x: Int, y: Int) -> Action {
+    ClickMouse(point(x, y), LeftButton, 2)
+}
+
+pub fn rightClickAt(x: Int, y: Int) -> Action {
+    ClickMouse(point(x, y), RightButton, 1)
+}
+
+pub fn click(pos: Point, button: MouseButton, clicks: Int) -> Action {
+    ClickMouse(pos, button, maxInt(1, clicks))
+}
+
+pub fn drag(from: Point, to: Point, durationMillis: Int) -> Action {
+    DragMouse(from, to, maxInt(0, durationMillis))
+}
+
+pub fn scroll(direction: ScrollDirection, amount: Int) -> Action {
+    ScrollMouse(direction, maxInt(1, amount))
+}
+
+pub fn typeText(text: String) -> Action {
+    TypeText(text)
+}
+
+pub fn keyTap(key: String) -> Action {
+    KeyTap([], key)
+}
+
+pub fn hotkey(modifiers: List<Modifier>, key: String) -> Action {
+    KeyTap(modifiers, key)
+}
+
+pub fn pasteText(text: String) -> Action {
+    PasteText(text)
+}
+
+pub fn findWindowsAction(query: WindowQuery) -> Action {
+    FindWindows(query)
+}
+
+pub fn focus(query: WindowQuery) -> Action {
+    FocusWindow(query)
+}
+
+pub fn waitWindow(query: WindowQuery, timeoutMillis: Int, pollMillis: Int) -> Action {
+    WaitWindow(query, maxInt(0, timeoutMillis), maxInt(50, pollMillis))
+}
+
+pub fn pause(millis: Int) -> Action {
+    Pause(maxInt(0, millis))
+}
+
+pub fn script(actions: List<Action>) -> Script {
+    Script { actions }
+}
+
+pub fn repeatAction(action: Action, count: Int) -> Script {
+    script([action]).repeat(count)
+}
+
+pub fn plan(action: Action, backend: Backend) -> Result<CommandPlan, Error> {
+    planAction(action, backend)
+}
+
+pub fn plans(scriptValue: Script, backend: Backend) -> Result<List<CommandPlan>, Error> {
+    let mut out: List<CommandPlan> = []
+    let actions = expand(scriptValue)
+    for action in actions {
+        out.push(planAction(action, backend)?)
+        if scriptValue.defaultDelayMillis > 0 {
+            out.push(pausePlan(scriptValue.defaultDelayMillis, backend)?)
+        }
+    }
+    Ok(out)
+}
+
+pub fn run(action: Action, backend: Backend) -> Result<ActionResult, Error> {
+    match action {
+        WaitWindow(query, timeoutMillis, pollMillis) -> runWaitWindow(query, timeoutMillis, pollMillis, backend),
+        _ -> runPlanned(action, backend),
+    }
+}
+
+pub fn runScript(scriptValue: Script, backend: Backend) -> Result<List<ActionResult>, Error> {
+    let mut out: List<ActionResult> = []
+    let actions = expand(scriptValue)
+    for action in actions {
+        out.push(run(action, backend)?)
+        if scriptValue.defaultDelayMillis > 0 {
+            out.push(run(Pause(scriptValue.defaultDelayMillis), backend)?)
+        }
+    }
+    Ok(out)
+}
+
+pub fn findWindows(query: WindowQuery, backend: Backend) -> Result<List<WindowInfo>, Error> {
+    let plan = findWindowPlan(query, backend)?
+    if backend.dryRun {
+        return Ok([])
+    }
+    let output = os.exec(plan.command, plan.args)?
+    Ok(filterWindows(parseWindowList(output.stdout, backend.platform), query))
+}
+
+pub fn firstWindow(query: WindowQuery, backend: Backend) -> Result<WindowInfo?, Error> {
+    let wins = findWindows(query, backend)?
+    if wins.isEmpty() {
+        Ok(None)
+    } else {
+        Ok(Some(wins[0]))
+    }
+}
+
+pub fn focusFirstWindow(query: WindowQuery, backend: Backend) -> Result<ActionResult, Error> {
+    run(FocusWindow(query), backend)
+}
+
+pub fn parseWindowList(text: String, platform: Platform) -> List<WindowInfo> {
+    let mut out: List<WindowInfo> = []
+    for line in strings.splitLines(text) {
+        let trimmed = strings.trimSpace(line)
+        if trimmed.isEmpty() {
+            continue
+        }
+        out.push(parseWindowLine(trimmed, platform))
+    }
+    out
+}
+
+pub fn filterWindows(windows: List<WindowInfo>, query: WindowQuery) -> List<WindowInfo> {
+    let mut out: List<WindowInfo> = []
+    for win in windows {
+        if matchesWindow(win, query) {
+            out.push(win)
+            if query.limit > 0 && out.len() >= query.limit {
+                return out
+            }
+        }
+    }
+    out
+}
+
+pub fn matchesWindow(win: WindowInfo, query: WindowQuery) -> Bool {
+    if !query.id.isEmpty() && win.id != query.id {
+        return false
+    }
+    if !query.title.isEmpty() && !matchText(win.title, query.title, query.mode) {
+        return false
+    }
+    if !query.appName.isEmpty() && !matchText(win.appName, query.appName, query.mode) {
+        return false
+    }
+    if !query.processName.isEmpty() && !matchText(win.processName, query.processName, query.mode) {
+        return false
+    }
+    if query.onlyVisible && win.state == WindowMinimized {
+        return false
+    }
+    true
+}
+
+pub fn summarize(scriptValue: Script) -> String {
+    let mut lines: List<String> = []
+    for action in expand(scriptValue) {
+        lines.push(action.description())
+    }
+    strings.join(lines, "\n")
+}
+
+fn runPlanned(action: Action, backend: Backend) -> Result<ActionResult, Error> {
+    let plan = planAction(action, backend)?
+    if backend.dryRun {
+        return Ok(ActionResult { action, plan, skipped: true })
+    }
+    let output = os.exec(plan.command, plan.args)?
+    let windows = if plan.capturesWindows {
+        filterWindows(parseWindowList(output.stdout, backend.platform), queryForAction(action))
+    } else {
+        []
+    }
+    Ok(ActionResult {
+        action,
+        plan,
+        output: Some(output),
+        windows,
+    })
+}
+
+fn runWaitWindow(query: WindowQuery, timeoutMillis: Int, pollMillis: Int, backend: Backend) -> Result<ActionResult, Error> {
+    let action = WaitWindow(query, timeoutMillis, pollMillis)
+    let plan = findWindowPlan(query, backend)?
+    if backend.dryRun {
+        return Ok(ActionResult { action, plan, skipped: true })
+    }
+    let mut elapsed = 0
+    for elapsed <= timeoutMillis {
+        let output = os.exec(plan.command, plan.args)?
+        let wins = filterWindows(parseWindowList(output.stdout, backend.platform), query)
+        if !wins.isEmpty() {
+            return Ok(ActionResult {
+                action,
+                plan,
+                output: Some(output),
+                windows: wins,
+            })
+        }
+        let pause = pausePlan(pollMillis, backend)?
+        let _ = os.exec(pause.command, pause.args)?
+        elapsed = elapsed + pollMillis
+    }
+    Err(error.new("rpa: window wait timed out"))
+}
+
+fn planAction(action: Action, backend: Backend) -> Result<CommandPlan, Error> {
+    match action {
+        MoveMouse(pos) -> movePlan(pos, backend),
+        ClickMouse(pos, button, clicks) -> clickPlan(pos, button, clicks, backend),
+        DragMouse(from, to, durationMillis) -> dragPlan(from, to, durationMillis, backend),
+        ScrollMouse(direction, amount) -> scrollPlan(direction, amount, backend),
+        TypeText(text) -> typePlan(text, backend),
+        KeyTap(modifiers, key) -> keyPlan(modifiers, key, backend),
+        PasteText(text) -> pastePlan(text, backend),
+        FindWindows(query) -> findWindowPlan(query, backend),
+        FocusWindow(query) -> focusWindowPlan(query, backend),
+        WaitWindow(query, _, _) -> findWindowPlan(query, backend),
+        Pause(millis) -> pausePlan(millis, backend),
+    }
+}
+
+fn movePlan(pos: Point, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(planOf(backend.mouseCommand, ["m:{pos.toPair()}"], "move mouse to {pos.toPair()}")),
+        LinuxX11 -> Ok(planOf(backend.mouseCommand, ["mousemove", "{pos.x}", "{pos.y}"], "move mouse to {pos.toPair()}")),
+        LinuxWayland -> Ok(planOf(backend.mouseCommand, ["mousemove", "--absolute", "{pos.x}", "{pos.y}"], "move mouse to {pos.toPair()}")),
+        WindowsDesktop -> Ok(powershellPlan(windowsMouseMoveScript(pos), "move mouse to {pos.toPair()}")),
+        CustomPlatform -> Err(error.new("rpa: custom mouse backend needs an adapter")),
+    }
+}
+
+fn clickPlan(pos: Point, button: MouseButton, clicks: Int, backend: Backend) -> Result<CommandPlan, Error> {
+    let n = maxInt(1, clicks)
+    match backend.platform {
+        MacOS -> {
+            let verb = if n > 1 && button == LeftButton { "dc" } else { button.cliclickName() }
+            Ok(planOf(backend.mouseCommand, ["{verb}:{pos.toPair()}"], "click at {pos.toPair()}"))
+        },
+        LinuxX11 -> Ok(planOf(backend.mouseCommand, ["mousemove", "{pos.x}", "{pos.y}", "click", "--repeat", "{n}", "{button.number()}"], "click at {pos.toPair()}")),
+        LinuxWayland -> Ok(planOf(backend.mouseCommand, ["mousemove", "--absolute", "{pos.x}", "{pos.y}", "click", "{button.number()}"], "click at {pos.toPair()}")),
+        WindowsDesktop -> Ok(powershellPlan(windowsClickScript(pos, button, n), "click at {pos.toPair()}")),
+        CustomPlatform -> Err(error.new("rpa: custom mouse backend needs an adapter")),
+    }
+}
+
+fn dragPlan(from: Point, to: Point, durationMillis: Int, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(planOf(backend.mouseCommand, ["dd:{from.toPair()}", "w:{durationMillis}", "du:{to.toPair()}"], "drag mouse")),
+        LinuxX11 -> Ok(planOf(backend.mouseCommand, ["mousemove", "{from.x}", "{from.y}", "mousedown", "1", "mousemove", "--sync", "{to.x}", "{to.y}", "mouseup", "1"], "drag mouse")),
+        LinuxWayland -> Ok(planOf(backend.mouseCommand, ["mousemove", "--absolute", "{from.x}", "{from.y}", "click", "0x40", "mousemove", "--absolute", "{to.x}", "{to.y}", "click", "0x80"], "drag mouse")),
+        WindowsDesktop -> Ok(powershellPlan(windowsDragScript(from, to, durationMillis), "drag mouse")),
+        CustomPlatform -> Err(error.new("rpa: custom mouse backend needs an adapter")),
+    }
+}
+
+fn scrollPlan(direction: ScrollDirection, amount: Int, backend: Backend) -> Result<CommandPlan, Error> {
+    let n = maxInt(1, amount)
+    match backend.platform {
+        MacOS -> Ok(planOf(backend.mouseCommand, ["{cliclickScroll(direction)}:{n}"], "scroll")),
+        LinuxX11 -> Ok(planOf(backend.mouseCommand, ["click", "--repeat", "{n}", "{x11ScrollButton(direction)}"], "scroll")),
+        LinuxWayland -> Ok(planOf(backend.mouseCommand, ["wheel", "{waylandWheel(direction, n)}"], "scroll")),
+        WindowsDesktop -> Ok(powershellPlan(windowsScrollScript(direction, n), "scroll")),
+        CustomPlatform -> Err(error.new("rpa: custom mouse backend needs an adapter")),
+    }
+}
+
+fn typePlan(text: String, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(osascriptPlan("tell application \"System Events\" to keystroke \"{appleString(text)}\"", "type text").sensitive()),
+        LinuxX11 -> Ok(planOf(backend.keyboardCommand, ["type", "--clearmodifiers", text], "type text").sensitive()),
+        LinuxWayland -> Ok(planOf(backend.keyboardCommand, ["type", text], "type text").sensitive()),
+        WindowsDesktop -> Ok(powershellPlan(windowsSendKeysScript(sendKeysEscape(text)), "type text").sensitive()),
+        CustomPlatform -> Err(error.new("rpa: custom keyboard backend needs an adapter")),
+    }
+}
+
+fn keyPlan(modifiers: List<Modifier>, key: String, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(osascriptPlan(macKeyScript(modifiers, key), "press key")),
+        LinuxX11 -> Ok(planOf(backend.keyboardCommand, ["key", x11KeyChord(modifiers, key)], "press key")),
+        LinuxWayland -> Ok(planOf(backend.keyboardCommand, ["key", x11KeyChord(modifiers, key)], "press key")),
+        WindowsDesktop -> Ok(powershellPlan(windowsSendKeysScript(windowsKeyChord(modifiers, key)), "press key")),
+        CustomPlatform -> Err(error.new("rpa: custom keyboard backend needs an adapter")),
+    }
+}
+
+fn pastePlan(text: String, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(osascriptPlan("set the clipboard to \"{appleString(text)}\"\ntell application \"System Events\" to keystroke \"v\" using {command down}", "paste text").sensitive()),
+        LinuxX11 -> Ok(planOf("sh", ["-lc", "printf %s \"$1\" | xclip -selection clipboard && xdotool key ctrl+v", "osty-rpa", text], "paste text").sensitive()),
+        LinuxWayland -> Ok(planOf("sh", ["-lc", "printf %s \"$1\" | wl-copy && wtype -M ctrl v -m ctrl", "osty-rpa", text], "paste text").sensitive()),
+        WindowsDesktop -> Ok(powershellPlan("Set-Clipboard -Value '{psSingle(text)}'; $wshell = New-Object -ComObject WScript.Shell; $wshell.SendKeys('^v')", "paste text").sensitive()),
+        CustomPlatform -> Err(error.new("rpa: custom keyboard backend needs an adapter")),
+    }
+}
+
+fn findWindowPlan(query: WindowQuery, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> {
+            let plan = osascriptPlan(macFindWindowsScript(), "find windows")
+            Ok(CommandPlan { command: plan.command, args: plan.args, description: plan.description, capturesWindows: true })
+        },
+        LinuxX11 -> Ok(CommandPlan {
+            command: "sh",
+            args: ["-lc", x11FindWindowsShell(query), "osty-rpa", query.title],
+            description: "find windows",
+            capturesWindows: true,
+        }),
+        LinuxWayland -> Ok(CommandPlan {
+            command: backend.windowCommand,
+            args: ["toplevel", "list"],
+            description: "find windows",
+            capturesWindows: true,
+        }),
+        WindowsDesktop -> Ok(CommandPlan {
+            command: backend.windowCommand,
+            args: ["-NoProfile", "-Command", windowsFindWindowsScript(query)],
+            description: "find windows",
+            capturesWindows: true,
+        }),
+        CustomPlatform -> Err(error.new("rpa: custom window backend needs an adapter")),
+    }
+}
+
+fn focusWindowPlan(query: WindowQuery, backend: Backend) -> Result<CommandPlan, Error> {
+    match backend.platform {
+        MacOS -> Ok(osascriptPlan(macFocusWindowScript(query), "focus window")),
+        LinuxX11 -> Ok(planOf("sh", ["-lc", "xdotool search --onlyvisible --name \"$1\" windowactivate %@ ", "osty-rpa", query.title], "focus window")),
+        LinuxWayland -> Ok(planOf(backend.windowCommand, ["toplevel", "focus", query.title], "focus window")),
+        WindowsDesktop -> Ok(powershellPlan("$wshell = New-Object -ComObject WScript.Shell; $wshell.AppActivate('{psSingle(bestQueryText(query))}')", "focus window")),
+        CustomPlatform -> Err(error.new("rpa: custom window backend needs an adapter")),
+    }
+}
+
+fn pausePlan(millis: Int, backend: Backend) -> Result<CommandPlan, Error> {
+    let n = maxInt(0, millis)
+    match backend.platform {
+        MacOS -> Ok(osascriptPlan("delay {secondsForMillis(n)}", "pause")),
+        LinuxX11 | LinuxWayland -> Ok(planOf("sleep", ["{secondsForMillis(n)}"], "pause")),
+        WindowsDesktop -> Ok(powershellPlan("Start-Sleep -Milliseconds {n}", "pause")),
+        CustomPlatform -> Ok(planOf("sleep", ["{secondsForMillis(n)}"], "pause")),
+    }
+}
+
+fn expand(scriptValue: Script) -> List<Action> {
+    let mut out: List<Action> = []
+    let repeat = maxInt(1, scriptValue.repeatCount)
+    let mut i = 0
+    for i < repeat {
+        for action in scriptValue.actions {
+            out.push(action)
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn queryForAction(action: Action) -> WindowQuery {
+    match action {
+        FindWindows(query) -> query,
+        WaitWindow(query, _, _) -> query,
+        FocusWindow(query) -> query,
+        _ -> windowQuery(),
+    }
+}
+
+fn parseWindowLine(line: String, platform: Platform) -> WindowInfo {
+    match platform {
+        LinuxWayland -> parseWaylandWindowLine(line),
+        _ -> parseTabbedWindowLine(line),
+    }
+}
+
+fn parseTabbedWindowLine(line: String) -> WindowInfo {
+    let fields = strings.split(line, "\t")
+    WindowInfo {
+        id: fieldOrEmpty(fields, 0),
+        appName: fieldOrEmpty(fields, 1),
+        processName: fieldOrEmpty(fields, 1),
+        title: fieldOrEmpty(fields, 2),
+        bounds: parseBoundsField(fieldOrEmpty(fields, 3)),
+        state: WindowVisible,
+    }
+}
+
+fn parseWaylandWindowLine(line: String) -> WindowInfo {
+    WindowInfo {
+        id: "",
+        appName: "",
+        processName: "",
+        title: strings.trimSpace(line),
+        bounds: Bounds {},
+        state: WindowVisible,
+    }
+}
+
+fn parseBoundsField(text: String) -> Bounds {
+    let parts = strings.split(text, ",")
+    if parts.len() < 4 {
+        return Bounds {}
+    }
+    Bounds {
+        x: intOrZero(parts[0]),
+        y: intOrZero(parts[1]),
+        width: intOrZero(parts[2]),
+        height: intOrZero(parts[3]),
+    }
+}
+
+fn fieldOrEmpty(fields: List<String>, index: Int) -> String {
+    if index < 0 || index >= fields.len() {
+        ""
+    } else {
+        strings.trimSpace(fields[index])
+    }
+}
+
+fn intOrZero(text: String) -> Int {
+    match strings.toInt(strings.trimSpace(text)) {
+        Ok(n) -> n,
+        Err(_) -> 0,
+    }
+}
+
+fn matchText(text: String, needle: String, mode: MatchMode) -> Bool {
+    let t = strings.toLower(text)
+    let n = strings.toLower(needle)
+    match mode {
+        MatchContains -> strings.contains(t, n),
+        MatchExact    -> t == n,
+        MatchPrefix   -> strings.startsWith(t, n),
+        MatchSuffix   -> strings.endsWith(t, n),
+    }
+}
+
+fn bestQueryText(query: WindowQuery) -> String {
+    if !query.title.isEmpty() {
+        return query.title
+    }
+    if !query.appName.isEmpty() {
+        return query.appName
+    }
+    if !query.processName.isEmpty() {
+        return query.processName
+    }
+    query.id
+}
+
+fn planOf(command: String, args: List<String>, description: String) -> CommandPlan {
+    CommandPlan {
+        command,
+        args,
+        description,
+    }
+}
+
+fn osascriptPlan(scriptText: String, description: String) -> CommandPlan {
+    planOf("osascript", ["-e", scriptText], description)
+}
+
+fn powershellPlan(scriptText: String, description: String) -> CommandPlan {
+    planOf("powershell", ["-NoProfile", "-Command", scriptText], description)
+}
+
+fn appleString(text: String) -> String {
+    strings.replaceAll(strings.replaceAll(text, "\\", "\\\\"), "\"", "\\\"")
+}
+
+fn psSingle(text: String) -> String {
+    strings.replaceAll(text, "'", "''")
+}
+
+fn sendKeysEscape(text: String) -> String {
+    let mut out = ""
+    for c in text.chars() {
+        if c == '+' || c == '^' || c == '%' || c == '~' || c == '(' || c == ')' || c == '\{' || c == '\}' {
+            out = "{out}{{}{c}{}}"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+fn cliclickScroll(direction: ScrollDirection) -> String {
+    match direction {
+        ScrollUp    -> "wu",
+        ScrollDown  -> "wd",
+        ScrollLeft  -> "wl",
+        ScrollRight -> "wr",
+    }
+}
+
+fn x11ScrollButton(direction: ScrollDirection) -> String {
+    match direction {
+        ScrollUp    -> "4",
+        ScrollDown  -> "5",
+        ScrollLeft  -> "6",
+        ScrollRight -> "7",
+    }
+}
+
+fn waylandWheel(direction: ScrollDirection, amount: Int) -> String {
+    match direction {
+        ScrollUp    -> "0 {amount}",
+        ScrollDown  -> "0 -{amount}",
+        ScrollLeft  -> "-{amount} 0",
+        ScrollRight -> "{amount} 0",
+    }
+}
+
+fn x11KeyChord(modifiers: List<Modifier>, key: String) -> String {
+    let mut parts: List<String> = []
+    for modifier in modifiers {
+        parts.push(x11Modifier(modifier))
+    }
+    parts.push(key)
+    strings.join(parts, "+")
+}
+
+fn x11Modifier(modifier: Modifier) -> String {
+    match modifier {
+        Shift   -> "shift",
+        Control -> "ctrl",
+        Alt     -> "alt",
+        Meta    -> "super",
+    }
+}
+
+fn macKeyScript(modifiers: List<Modifier>, key: String) -> String {
+    let usingText = macUsing(modifiers)
+    let lower = strings.toLower(key)
+    match macKeyCode(lower) {
+        Some(code) -> "tell application \"System Events\" to key code {code}{usingText}",
+        None       -> "tell application \"System Events\" to keystroke \"{appleString(key)}\"{usingText}",
+    }
+}
+
+fn macUsing(modifiers: List<Modifier>) -> String {
+    if modifiers.isEmpty() {
+        return ""
+    }
+    let mut parts: List<String> = []
+    for modifier in modifiers {
+        parts.push(macModifier(modifier))
+    }
+    " using {" + strings.join(parts, ", ") + "}"
+}
+
+fn macModifier(modifier: Modifier) -> String {
+    match modifier {
+        Shift   -> "shift down",
+        Control -> "control down",
+        Alt     -> "option down",
+        Meta    -> "command down",
+    }
+}
+
+fn macKeyCode(key: String) -> Int? {
+    match key {
+        "return" | "enter" -> Some(36),
+        "tab"              -> Some(48),
+        "space"            -> Some(49),
+        "delete"           -> Some(51),
+        "escape" | "esc"   -> Some(53),
+        "left"             -> Some(123),
+        "right"            -> Some(124),
+        "down"             -> Some(125),
+        "up"               -> Some(126),
+        _                  -> None,
+    }
+}
+
+fn windowsKeyChord(modifiers: List<Modifier>, key: String) -> String {
+    let mut prefix = ""
+    for modifier in modifiers {
+        prefix = "{prefix}{windowsModifier(modifier)}"
+    }
+    "{prefix}{windowsKey(key)}"
+}
+
+fn windowsModifier(modifier: Modifier) -> String {
+    match modifier {
+        Shift   -> "+",
+        Control -> "^",
+        Alt     -> "%",
+        Meta    -> "^{ESC}",
+    }
+}
+
+fn windowsKey(key: String) -> String {
+    match strings.toLower(key) {
+        "enter" | "return" -> "{ENTER}",
+        "tab"              -> "{TAB}",
+        "escape" | "esc"   -> "{ESC}",
+        "space"            -> " ",
+        "backspace"        -> "{BACKSPACE}",
+        "delete"           -> "{DELETE}",
+        "left"             -> "{LEFT}",
+        "right"            -> "{RIGHT}",
+        "up"               -> "{UP}",
+        "down"             -> "{DOWN}",
+        _                  -> sendKeysEscape(key),
+    }
+}
+
+fn windowsSendKeysScript(keys: String) -> String {
+    "$wshell = New-Object -ComObject WScript.Shell; $wshell.SendKeys('{psSingle(keys)}')"
+}
+
+fn windowsMouseMoveScript(pos: Point) -> String {
+    windowsUser32Preamble() + "[Native]::SetCursorPos({pos.x}, {pos.y}) | Out-Null"
+}
+
+fn windowsClickScript(pos: Point, button: MouseButton, clicks: Int) -> String {
+    let flags = windowsClickFlags(button)
+    let mut body = windowsMouseMoveScript(pos)
+    let mut i = 0
+    for i < maxInt(1, clicks) {
+        body = "{body}; [Native]::mouse_event({flags}, 0, 0, 0, 0)"
+        i = i + 1
+    }
+    body
+}
+
+fn windowsDragScript(from: Point, to: Point, durationMillis: Int) -> String {
+    windowsUser32Preamble() +
+    "[Native]::SetCursorPos({from.x}, {from.y}) | Out-Null; " +
+    "[Native]::mouse_event(2, 0, 0, 0, 0); " +
+    "Start-Sleep -Milliseconds {durationMillis}; " +
+    "[Native]::SetCursorPos({to.x}, {to.y}) | Out-Null; " +
+    "[Native]::mouse_event(4, 0, 0, 0, 0)"
+}
+
+fn windowsScrollScript(direction: ScrollDirection, amount: Int) -> String {
+    let delta = match direction {
+        ScrollUp    -> amount * 120,
+        ScrollDown  -> 0 - amount * 120,
+        ScrollLeft  -> 0 - amount * 120,
+        ScrollRight -> amount * 120,
+    }
+    let flag = match direction {
+        ScrollLeft | ScrollRight -> 4096,
+        _                       -> 2048,
+    }
+    windowsUser32Preamble() + "[Native]::mouse_event({flag}, 0, 0, {delta}, 0)"
+}
+
+fn windowsClickFlags(button: MouseButton) -> Int {
+    match button {
+        LeftButton   -> 2 + 4,
+        RightButton  -> 8 + 16,
+        MiddleButton -> 32 + 64,
+    }
+}
+
+fn windowsUser32Preamble() -> String {
+    "Add-Type -Name Native -Namespace Win32 -MemberDefinition '[DllImport(\"user32.dll\")] public static extern bool SetCursorPos(int x, int y); [DllImport(\"user32.dll\")] public static extern void mouse_event(int flags, int dx, int dy, int data, int extra);'; "
+}
+
+fn macFindWindowsScript() -> String {
+    "set output to \"\"\n" +
+    "tell application \"System Events\"\n" +
+    "repeat with proc in application processes\n" +
+    "if visible of proc then\n" +
+    "repeat with win in windows of proc\n" +
+    "set output to output & (unix id of proc as text) & tab & (name of proc as text) & tab & (name of win as text) & tab & \"0,0,0,0\" & linefeed\n" +
+    "end repeat\n" +
+    "end if\n" +
+    "end repeat\n" +
+    "end tell\n" +
+    "return output"
+}
+
+fn macFocusWindowScript(query: WindowQuery) -> String {
+    let app = appleString(if query.appName.isEmpty() { query.processName } else { query.appName })
+    if !app.isEmpty() {
+        return "tell application \"System Events\" to set frontmost of first application process whose name contains \"{app}\" to true"
+    }
+    let title = appleString(query.title)
+    "tell application \"System Events\" to perform action \"AXRaise\" of first window of first application process whose name of windows contains \"{title}\""
+}
+
+fn x11FindWindowsShell(query: WindowQuery) -> String {
+    let needle = if query.title.isEmpty() { ".*" } else { "$1" }
+    "xdotool search --onlyvisible --name \"{needle}\" | while read id; do printf '%s\\t%s\\t%s\\t0,0,0,0\\n' \"$id\" \"\" \"$(xdotool getwindowname \"$id\")\"; done"
+}
+
+fn windowsFindWindowsScript(query: WindowQuery) -> String {
+    let needle = psSingle(bestQueryText(query))
+    "$needle = '{needle}'; " +
+    "Get-Process | Where-Object \{ $_.MainWindowTitle -ne \"\" -and ($needle -eq \"\" -or $_.MainWindowTitle.ToLower().Contains($needle.ToLower()) -or $_.ProcessName.ToLower().Contains($needle.ToLower())) \} | " +
+    "Select-Object -First {maxInt(1, query.limit)} | " +
+    "ForEach-Object \{ [string]$_.Id + \"`t\" + $_.ProcessName + \"`t\" + $_.MainWindowTitle + \"`t0,0,0,0\" \}"
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}
+
+fn secondsForMillis(millis: Int) -> Int {
+    if millis <= 0 {
+        return 0
+    }
+    (millis + 999) / 1000
+}

--- a/internal/stdlib/rpa_test.go
+++ b/internal/stdlib/rpa_test.go
@@ -1,0 +1,99 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRpaModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["rpa"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.rpa not loaded")
+	}
+	for _, name := range []string{
+		"point", "bounds", "windowQuery", "titleContains", "appContains",
+		"processContains", "windowID", "exactTitle", "macBackend",
+		"linuxX11Backend", "linuxWaylandBackend", "windowsBackend",
+		"customBackend", "moveTo", "clickAt", "doubleClickAt", "rightClickAt",
+		"click", "drag", "scroll", "typeText", "keyTap", "hotkey",
+		"pasteText", "findWindowsAction", "focus", "waitWindow", "pause",
+		"script", "repeatAction", "plan", "plans", "run", "runScript",
+		"findWindows", "firstWindow", "focusFirstWindow", "parseWindowList",
+		"filterWindows", "matchesWindow", "summarize",
+	} {
+		requirePublicFn(t, mod, "rpa", name)
+	}
+	for _, name := range []string{
+		"Platform", "MouseButton", "ScrollDirection", "Modifier", "MatchMode",
+		"WindowState", "Point", "Bounds", "WindowQuery", "WindowInfo",
+		"Backend", "CommandPlan", "Action", "ActionResult", "Script",
+	} {
+		requirePublicType(t, mod, "rpa", name)
+	}
+}
+
+func TestRpaModulePinsDesktopAutomationBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["rpa"]
+	if mod == nil {
+		t.Fatal("std.rpa module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`std.rpa - desktop automation plans for repetitive work`,
+		`pub enum Action`,
+		`MoveMouse(Point)`,
+		`ClickMouse(Point, MouseButton, Int)`,
+		`KeyTap(List<Modifier>, String)`,
+		`FindWindows(WindowQuery)`,
+		`pub fn macBackend() -> Backend`,
+		`mouseCommand: "cliclick"`,
+		`windowCommand: "osascript"`,
+		`pub fn linuxX11Backend() -> Backend`,
+		`mouseCommand: "xdotool"`,
+		`pub fn windowsBackend() -> Backend`,
+		`windowCommand: "powershell"`,
+		`pub fn runScript(scriptValue: Script, backend: Backend) -> Result<List<ActionResult>, Error>`,
+		`pub fn findWindows(query: WindowQuery, backend: Backend) -> Result<List<WindowInfo>, Error>`,
+		`pub fn parseWindowList(text: String, platform: Platform) -> List<WindowInfo>`,
+		`filterWindows(parseWindowList(output.stdout, backend.platform), query)`,
+		`xdotool search --onlyvisible --name`,
+		`System Events`,
+		`Get-Process | Where-Object`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.rpa source missing %q", want)
+		}
+	}
+}
+
+func TestRpaModuleMethodsAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"Platform", []string{"toString"}},
+		{"MouseButton", []string{"number", "cliclickName"}},
+		{"Point", []string{"translate", "toPair"}},
+		{"Bounds", []string{"isEmpty", "contains", "center"}},
+		{"WindowQuery", []string{"matches", "withLimit", "visible"}},
+		{"WindowInfo", []string{"label"}},
+		{"Backend", []string{"dry", "withMouseCommand", "withKeyboardCommand", "withWindowCommand"}},
+		{"CommandPlan", []string{"commandLine", "sensitive"}},
+		{"Action", []string{"description"}},
+		{"ActionResult", []string{"ok"}},
+		{"Script", []string{"append", "delay", "repeat"}},
+	} {
+		for _, method := range tc.methods {
+			fn := reg.LookupMethodDecl("rpa", tc.typeName, method)
+			if fn == nil {
+				t.Fatalf("LookupMethodDecl(rpa, %s, %s) = nil, want *ast.FnDecl", tc.typeName, method)
+			}
+			if fn.Body == nil {
+				t.Fatalf("rpa.%s.%s body = nil, want source method body", tc.typeName, method)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `std.rpa` with typed desktop automation actions, command plans, script repetition, and window query/filter helpers
- support default macOS, Linux X11/Wayland, Windows, and custom backend profiles
- add stdlib surface and backend check coverage, then update `STDLIB_MATRIX.md`

## Validation
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestRpa'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultRpa'`
- `just support-stdlib-fast`
- `just fmt-check`
- `git diff --check`