### PR TITLE
[codex] add std supabase module

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
+++ b/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
@@ -1,0 +1,157 @@
+### 10.43 Supabase (`std.supabase`)
+
+`std.supabase` is a lightweight Supabase API layer on top of `std.http`. It
+does not embed a database driver or storage client runtime. Instead, it builds
+ready-to-send HTTP requests for Supabase's stable gateway paths:
+
+- PostgREST data API under `/rest/v1`
+- Auth under `/auth/v1`
+- Storage under `/storage/v1`
+- Edge Functions under `/functions/v1`
+- GraphQL under `/graphql/v1`
+
+```osty
+use std.env
+use std.supabase
+
+let sb = supabase.project(env.require("SUPABASE_PROJECT_REF")?, env.require("SUPABASE_ANON_KEY")?)?
+let q = supabase.from("todos")?
+    .select("id,title,completed")
+    .eq("completed", "false")?
+    .orderDesc("created_at")?
+    .range(0, 19)?
+
+let req = supabase.selectHttpRequest(sb, q)?
+let rows = supabase.sendSelect::<List<Todo>>(sb, q)?
+```
+
+Core types:
+
+```osty
+pub struct Client
+pub struct TableQuery
+pub struct Prefer
+pub struct ApiError
+
+pub enum CountMode { CountNone, CountExact, CountPlanned, CountEstimated }
+pub enum ReturningMode { ReturnDefault, ReturnMinimal, ReturnRepresentation }
+pub enum ResolutionMode { ResolveDefault, MergeDuplicates, IgnoreDuplicates }
+pub enum OrderDirection { Asc, Desc }
+pub enum NullOrdering { NullsDefault, NullsFirst, NullsLast }
+```
+
+Configuration:
+
+```osty
+supabase.client(baseUrl, apiKey) -> Result<Client, Error>
+supabase.project(projectRef, apiKey) -> Result<Client, Error>
+supabase.local(apiKey) -> Result<Client, Error>
+
+client.withAccessToken(jwt)
+client.withServiceRoleKey(key)
+client.withSchema(schema)
+client.withClientInfo(value)
+client.withHeader(name, value)
+```
+
+`headers(client)` emits the `apikey` header and `Authorization: Bearer ...`.
+When no session token is configured, the bearer value is the API key itself so
+the value exactly matches the `apikey` header. Non-`public` schemas add
+`Accept-Profile` and `Content-Profile`.
+
+PostgREST query helpers:
+
+```osty
+supabase.from(table) -> Result<TableQuery, Error>
+
+query.select(columns)
+query.eq(column, value)
+query.neq(column, value)
+query.gt(column, value)
+query.gte(column, value)
+query.lt(column, value)
+query.lte(column, value)
+query.like(column, pattern)
+query.ilike(column, pattern)
+query.isNull(column)
+query.inList(column, values)
+query.contains(column, value)
+query.containedBy(column, value)
+query.overlaps(column, value)
+query.textSearch(column, query)
+query.order(column, direction, nulls)
+query.orderAsc(column)
+query.orderDesc(column)
+query.limit(n)
+query.offset(n)
+query.range(from, to)
+query.withCount(mode)
+query.returning(mode)
+query.resolveDuplicates(mode)
+query.single()
+query.csv()
+```
+
+Requests:
+
+```osty
+supabase.selectHttpRequest(client, query)
+supabase.insertHttpRequest(client, table, value)
+supabase.insertWithPreferHttpRequest(client, table, value, prefer)
+supabase.upsertHttpRequest(client, table, value)
+supabase.upsertWithPreferHttpRequest(client, table, value, prefer)
+supabase.updateHttpRequest(client, query, value)
+supabase.deleteHttpRequest(client, query)
+supabase.rpcHttpRequest(client, functionName, args)
+supabase.rpcWithPreferHttpRequest(client, functionName, args, prefer)
+supabase.rpcValueHttpRequest(client, functionName, jsonValue)
+supabase.rpcValueWithPreferHttpRequest(client, functionName, jsonValue, prefer)
+```
+
+Convenience senders execute those requests through `std.http.request`, require
+2xx responses, and decode JSON:
+
+```osty
+supabase.sendSelect<T>(client, query)
+supabase.sendInsert<T, U>(client, table, value)
+supabase.sendInsertWithPrefer<T, U>(client, table, value, prefer)
+supabase.sendUpdate<T, U>(client, query, value)
+supabase.sendDelete<T>(client, query)
+supabase.sendRpc<T, U>(client, functionName, args)
+supabase.sendRpcWithPrefer<T, U>(client, functionName, args, prefer)
+```
+
+Auth:
+
+```osty
+supabase.signUpHttpRequest(client, email, password)
+supabase.passwordTokenHttpRequest(client, email, password)
+supabase.refreshTokenHttpRequest(client, refreshToken)
+supabase.logoutHttpRequest(client)
+```
+
+Storage and functions:
+
+```osty
+supabase.publicObjectUrl(client, bucket, path)
+supabase.authenticatedObjectUrl(client, bucket, path)
+supabase.objectUrl(client, bucket, path)
+supabase.authenticatedObjectHttpRequest(client, bucket, path)
+supabase.downloadObjectHttpRequest(client, bucket, path)
+supabase.uploadObjectHttpRequest(client, bucket, path, body, contentType, upsert)
+supabase.updateObjectHttpRequest(client, bucket, path, body, contentType)
+supabase.removeObjectHttpRequest(client, bucket, paths)
+
+supabase.invokeFunctionHttpRequest(client, functionName, payload)
+supabase.graphqlHttpRequest(client, bodyJson)
+```
+
+Errors:
+
+```osty
+supabase.parseApiError(response) -> ApiError
+supabase.requireSuccess(response) -> Result<http.Response, Error>
+```
+
+`ApiError` extracts the common Supabase/PostgREST JSON fields `code`,
+`message`, `details`, and `hint`, while preserving the raw body for logs.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -57,3 +57,4 @@ lowering remains implementation backlog.
 - [§10.40 XLSX (`std.xlsx`)](./40-xlsx.md)
 - [§10.41 Keychain / Secrets (`std.keychain`, `std.secrets`)](./41-keychain-secrets.md)
 - [§10.42 PDF (`std.pdf`)](./42-pdf.md)
+- [§10.43 Supabase (`std.supabase`)](./43-supabase.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 91 공개 모듈. 분류 기준:
+총 92 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (85 / 91 = 93%)
+### ⭐⭐⭐⭐⭐ Production (86 / 92 = 93%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -91,6 +91,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | watch | 535 | pure Osty + fs/time/cmd | polling file watcher: fs.watch snapshot parsing, typed create/modify/remove diff, debounce, hidden/build-dir filters, transform/sync command tasks |
 | clipboard | 125 | pure Osty + os | host clipboard text read/write via pbpaste/pbcopy, Wayland, X11, AppleScript, PowerShell |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
+| supabase | 927 | pure Osty + http/json | Supabase PostgREST/Auth/Storage/Functions/GraphQL request builders, API-key/session headers, filters, Prefer headers, storage object URLs, and response error helpers |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
 | char | 219 | — | Unicode / ASCII methods |
@@ -135,7 +136,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode`, `keychain Linux Secret Service` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -180,6 +181,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | QR / 바코드 문서 | ✅ 가능 | qr + barcode (QR payload/qrencode 계획, ZBar/ZXing 인식 파싱, Code39/EAN-13/UPC-A SVG 렌더링) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
+| Supabase 앱 백엔드 연결 | ✅ 가능 | supabase + http/json/secrets (PostgREST filters/mutations/RPC, Auth password-token requests, Storage object URLs/uploads, Edge Function/GraphQL requests) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |
 | Local KV / 설정 DB | ✅ 즉시 가능 | kv + fs + json (JSONL append-log, compact, typed getters/setters) |
@@ -219,7 +221,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 65 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, template, i18n, char, iter, bytes)
+- 66 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, supabase, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - keychain/secrets 는 macOS/Windows Phase A+B 연결 완료, Linux Secret Service backend 대기
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)

--- a/internal/stdlib/modules/supabase.osty
+++ b/internal/stdlib/modules/supabase.osty
@@ -1,0 +1,927 @@
+// std.supabase - Supabase HTTP request builders.
+//
+// This module deliberately stays on top of std.http. It knows the stable
+// Supabase gateway paths, PostgREST query conventions, API-key/session
+// headers, Auth password-token requests, Storage object URLs, Edge Function
+// invocation, and GraphQL endpoint shape. The actual transport remains
+// std.http.request.
+
+use std.bytes
+use std.encoding
+use std.error
+use std.http
+use std.json
+use std.strings
+
+pub type QueryValues = http.QueryValues
+pub type Headers = http.Headers
+
+pub enum CountMode {
+    CountNone,
+    CountExact,
+    CountPlanned,
+    CountEstimated,
+
+    pub fn toPrefer(self) -> String {
+        match self {
+            CountNone      -> "",
+            CountExact     -> "count=exact",
+            CountPlanned   -> "count=planned",
+            CountEstimated -> "count=estimated",
+        }
+    }
+}
+
+pub enum ReturningMode {
+    ReturnDefault,
+    ReturnMinimal,
+    ReturnRepresentation,
+
+    pub fn toPrefer(self) -> String {
+        match self {
+            ReturnDefault        -> "",
+            ReturnMinimal        -> "return=minimal",
+            ReturnRepresentation -> "return=representation",
+        }
+    }
+}
+
+pub enum ResolutionMode {
+    ResolveDefault,
+    MergeDuplicates,
+    IgnoreDuplicates,
+
+    pub fn toPrefer(self) -> String {
+        match self {
+            ResolveDefault   -> "",
+            MergeDuplicates  -> "resolution=merge-duplicates",
+            IgnoreDuplicates -> "resolution=ignore-duplicates",
+        }
+    }
+}
+
+pub enum OrderDirection {
+    Asc,
+    Desc,
+
+    pub fn toString(self) -> String {
+        match self {
+            Asc  -> "asc",
+            Desc -> "desc",
+        }
+    }
+}
+
+pub enum NullOrdering {
+    NullsDefault,
+    NullsFirst,
+    NullsLast,
+
+    pub fn toOrderSuffix(self) -> String {
+        match self {
+            NullsDefault -> "",
+            NullsFirst   -> ".nullsfirst",
+            NullsLast    -> ".nullslast",
+        }
+    }
+}
+
+pub struct Prefer {
+    pub count: CountMode,
+    pub returning: ReturningMode,
+    pub resolution: ResolutionMode,
+    pub missingDefault: Bool = false,
+
+    pub fn withCount(mut self, count: CountMode) -> Prefer {
+        self.count = count
+        self
+    }
+
+    pub fn withReturning(mut self, returning: ReturningMode) -> Prefer {
+        self.returning = returning
+        self
+    }
+
+    pub fn withResolution(mut self, resolution: ResolutionMode) -> Prefer {
+        self.resolution = resolution
+        self
+    }
+
+    pub fn withMissingDefault(mut self, enabled: Bool) -> Prefer {
+        self.missingDefault = enabled
+        self
+    }
+
+    pub fn headerValue(self) -> String {
+        preferHeaderValue(self)
+    }
+}
+
+pub struct Client {
+    pub baseUrl: String,
+    pub apiKey: String,
+    pub bearerToken: String = "",
+    pub schema: String = "public",
+    pub clientInfo: String = "osty-stdlib-supabase",
+    pub extraHeaders: Headers = {:},
+
+    pub fn withAccessToken(mut self, token: String) -> Client {
+        self.bearerToken = token
+        self
+    }
+
+    pub fn withServiceRoleKey(mut self, key: String) -> Client {
+        self.apiKey = key
+        self.bearerToken = key
+        self
+    }
+
+    pub fn withSchema(mut self, schema: String) -> Result<Client, Error> {
+        let clean = cleanName("schema", schema)?
+        self.schema = clean
+        Ok(self)
+    }
+
+    pub fn withClientInfo(mut self, value: String) -> Client {
+        self.clientInfo = strings.trimSpace(value)
+        self
+    }
+
+    pub fn withHeader(mut self, name: String, value: String) -> Client {
+        self.extraHeaders.insert(name, value)
+        self
+    }
+
+    pub fn resolvedBearer(self) -> String {
+        let token = strings.trimSpace(self.bearerToken)
+        if !token.isEmpty() {
+            return token
+        }
+        strings.trimSpace(self.apiKey)
+    }
+}
+
+pub struct TableQuery {
+    pub table: String,
+    pub params: QueryValues = {:},
+    pub prefer: Prefer,
+    pub accept: String = "application/json",
+
+    pub fn select(mut self, columns: String) -> TableQuery {
+        self.params = setParam(self.params, "select", if strings.trimSpace(columns).isEmpty() { "*" } else { strings.trimSpace(columns) })
+        self
+    }
+
+    pub fn withParam(mut self, name: String, value: String) -> Result<TableQuery, Error> {
+        self.params = appendParam(self.params, cleanQueryName(name)?, value)
+        Ok(self)
+    }
+
+    pub fn filter(mut self, column: String, op: String, value: String) -> Result<TableQuery, Error> {
+        let cleanColumn = cleanColumnName(column)?
+        let cleanOp = cleanOperator(op)?
+        self.params = appendParam(self.params, cleanColumn, "{cleanOp}.{value}")
+        Ok(self)
+    }
+
+    pub fn eq(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "eq", value)
+    }
+
+    pub fn neq(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "neq", value)
+    }
+
+    pub fn gt(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "gt", value)
+    }
+
+    pub fn gte(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "gte", value)
+    }
+
+    pub fn lt(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "lt", value)
+    }
+
+    pub fn lte(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "lte", value)
+    }
+
+    pub fn like(self, column: String, pattern: String) -> Result<TableQuery, Error> {
+        self.filter(column, "like", pattern)
+    }
+
+    pub fn ilike(self, column: String, pattern: String) -> Result<TableQuery, Error> {
+        self.filter(column, "ilike", pattern)
+    }
+
+    pub fn isNull(self, column: String) -> Result<TableQuery, Error> {
+        self.filter(column, "is", "null")
+    }
+
+    pub fn inList(self, column: String, values: List<String>) -> Result<TableQuery, Error> {
+        self.filter(column, "in", "({strings.join(values, \",\")})")
+    }
+
+    pub fn contains(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "cs", value)
+    }
+
+    pub fn containedBy(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "cd", value)
+    }
+
+    pub fn overlaps(self, column: String, value: String) -> Result<TableQuery, Error> {
+        self.filter(column, "ov", value)
+    }
+
+    pub fn textSearch(self, column: String, query: String) -> Result<TableQuery, Error> {
+        self.filter(column, "fts", query)
+    }
+
+    pub fn order(mut self, column: String, direction: OrderDirection, nulls: NullOrdering) -> Result<TableQuery, Error> {
+        let cleanColumn = cleanColumnName(column)?
+        let item = "{cleanColumn}.{direction.toString()}{nulls.toOrderSuffix()}"
+        self.params = appendOrder(self.params, item)
+        Ok(self)
+    }
+
+    pub fn orderAsc(self, column: String) -> Result<TableQuery, Error> {
+        self.order(column, Asc, NullsDefault)
+    }
+
+    pub fn orderDesc(self, column: String) -> Result<TableQuery, Error> {
+        self.order(column, Desc, NullsDefault)
+    }
+
+    pub fn limit(mut self, n: Int) -> Result<TableQuery, Error> {
+        if n < 0 {
+            return Err(error.new("supabase: limit must not be negative"))
+        }
+        self.params = setParam(self.params, "limit", n.toString())
+        Ok(self)
+    }
+
+    pub fn offset(mut self, n: Int) -> Result<TableQuery, Error> {
+        if n < 0 {
+            return Err(error.new("supabase: offset must not be negative"))
+        }
+        self.params = setParam(self.params, "offset", n.toString())
+        Ok(self)
+    }
+
+    pub fn range(mut self, from: Int, to: Int) -> Result<TableQuery, Error> {
+        if from < 0 || to < from {
+            return Err(error.new("supabase: invalid range {from}..{to}"))
+        }
+        self.params = setParam(self.params, "offset", from.toString())
+        self.params = setParam(self.params, "limit", (to - from + 1).toString())
+        Ok(self)
+    }
+
+    pub fn withCount(mut self, count: CountMode) -> TableQuery {
+        self.prefer = self.prefer.withCount(count)
+        self
+    }
+
+    pub fn withPrefer(mut self, prefer: Prefer) -> TableQuery {
+        self.prefer = prefer
+        self
+    }
+
+    pub fn returning(mut self, returning: ReturningMode) -> TableQuery {
+        self.prefer = self.prefer.withReturning(returning)
+        self
+    }
+
+    pub fn resolveDuplicates(mut self, resolution: ResolutionMode) -> TableQuery {
+        self.prefer = self.prefer.withResolution(resolution)
+        self
+    }
+
+    pub fn single(mut self) -> TableQuery {
+        self.accept = "application/vnd.pgrst.object+json"
+        self
+    }
+
+    pub fn csv(mut self) -> TableQuery {
+        self.accept = "text/csv"
+        self
+    }
+}
+
+pub struct ApiError {
+    pub status: Int,
+    pub code: String = "",
+    pub message: String = "",
+    pub details: String = "",
+    pub hint: String = "",
+    pub rawJson: String = "",
+
+    pub fn summary(self) -> String {
+        let msg = if strings.trimSpace(self.message).isEmpty() { "request failed" } else { strings.trimSpace(self.message) }
+        let code = if strings.trimSpace(self.code).isEmpty() { "" } else { " ({strings.trimSpace(self.code)})" }
+        let hint = if strings.trimSpace(self.hint).isEmpty() { "" } else { ": {strings.trimSpace(self.hint)}" }
+        "supabase: HTTP {self.status}: {msg}{code}{hint}"
+    }
+}
+
+pub fn prefer() -> Prefer {
+    Prefer {
+        count: CountNone,
+        returning: ReturnDefault,
+        resolution: ResolveDefault,
+    }
+}
+
+pub fn preferRepresentation() -> Prefer {
+    Prefer {
+        count: CountNone,
+        returning: ReturnRepresentation,
+        resolution: ResolveDefault,
+    }
+}
+
+pub fn preferMinimal() -> Prefer {
+    Prefer {
+        count: CountNone,
+        returning: ReturnMinimal,
+        resolution: ResolveDefault,
+    }
+}
+
+pub fn client(baseUrl: String, apiKey: String) -> Result<Client, Error> {
+    let cleanBase = stripTrailingSlash(strings.trimSpace(baseUrl))
+    if cleanBase.isEmpty() {
+        return Err(error.new("supabase: base URL is empty"))
+    }
+    if strings.trimSpace(apiKey).isEmpty() {
+        return Err(error.new("supabase: API key is empty"))
+    }
+    Ok(Client {
+        baseUrl: cleanBase,
+        apiKey: strings.trimSpace(apiKey),
+    })
+}
+
+pub fn project(projectRef: String, apiKey: String) -> Result<Client, Error> {
+    let clean = cleanProjectRef(projectRef)?
+    client("https://{clean}.supabase.co", apiKey)
+}
+
+pub fn local(apiKey: String) -> Result<Client, Error> {
+    client("http://127.0.0.1:54321", apiKey)
+}
+
+pub fn from(table: String) -> Result<TableQuery, Error> {
+    Ok(TableQuery {
+        table: cleanName("table", table)?,
+        params: {"select": ["*"]},
+        prefer: prefer(),
+    })
+}
+
+pub fn headers(client: Client) -> Headers {
+    dataHeaders(client, "")
+}
+
+pub fn authHeaders(client: Client) -> Headers {
+    baseHeaders(client, false, "application/json")
+}
+
+pub fn storageHeaders(client: Client, contentType: String = "") -> Headers {
+    baseHeaders(client, false, contentType)
+}
+
+pub fn restUrl(client: Client) -> String {
+    joinUrl(client.baseUrl, "/rest/v1")
+}
+
+pub fn tableUrl(client: Client, table: String) -> Result<String, Error> {
+    Ok(joinUrl(restUrl(client), "/{encodePathSegment(cleanName(\"table\", table)?)}"))
+}
+
+pub fn rpcUrl(client: Client, functionName: String) -> Result<String, Error> {
+    Ok(joinUrl(restUrl(client), "/rpc/{encodePathSegment(cleanName(\"function\", functionName)?)}"))
+}
+
+pub fn authUrl(client: Client, path: String) -> Result<String, Error> {
+    Ok(joinUrl(client.baseUrl, "/auth/v1/{cleanRelativePath(path)?}"))
+}
+
+pub fn storageUrl(client: Client, path: String) -> Result<String, Error> {
+    Ok(joinUrl(client.baseUrl, "/storage/v1/{cleanRelativePath(path)?}"))
+}
+
+pub fn functionsUrl(client: Client, functionName: String) -> Result<String, Error> {
+    Ok(joinUrl(client.baseUrl, "/functions/v1/{encodePathSegment(cleanName(\"function\", functionName)?)}"))
+}
+
+pub fn graphqlUrl(client: Client) -> String {
+    joinUrl(client.baseUrl, "/graphql/v1")
+}
+
+pub fn selectHttpRequest(client: Client, query: TableQuery) -> Result<http.Request, Error> {
+    validateClient(client)?
+    validateQuery(query)?
+    Ok(http.newRequest(http.Get, tableUrl(client, query.table)?)
+        .withHeaders(queryHeaders(client, query, false))
+        .withQuery(query.params))
+}
+
+pub fn insertHttpRequest<T>(client: Client, table: String, value: T) -> Result<http.Request, Error> {
+    insertWithPreferHttpRequest(client, table, value, preferRepresentation())
+}
+
+pub fn insertWithPreferHttpRequest<T>(client: Client, table: String, value: T, prefer: Prefer) -> Result<http.Request, Error> {
+    validateClient(client)?
+    let query = TableQuery {
+        table: cleanName("table", table)?,
+        prefer: prefer,
+    }
+    Ok(http.newRequest(http.Post, tableUrl(client, query.table)?)
+        .withHeaders(queryHeaders(client, query, true))
+        .withJson(value))
+}
+
+pub fn upsertHttpRequest<T>(client: Client, table: String, value: T) -> Result<http.Request, Error> {
+    upsertWithPreferHttpRequest(client, table, value, preferRepresentation().withResolution(MergeDuplicates))
+}
+
+pub fn upsertWithPreferHttpRequest<T>(client: Client, table: String, value: T, prefer: Prefer) -> Result<http.Request, Error> {
+    insertWithPreferHttpRequest(client, table, value, prefer)
+}
+
+pub fn updateHttpRequest<T>(client: Client, query: TableQuery, value: T) -> Result<http.Request, Error> {
+    validateClient(client)?
+    validateQuery(query)?
+    Ok(http.newRequest(http.Patch, tableUrl(client, query.table)?)
+        .withHeaders(queryHeaders(client, query, true))
+        .withQuery(query.params)
+        .withJson(value))
+}
+
+pub fn deleteHttpRequest(client: Client, query: TableQuery) -> Result<http.Request, Error> {
+    validateClient(client)?
+    validateQuery(query)?
+    Ok(http.newRequest(http.Delete, tableUrl(client, query.table)?)
+        .withHeaders(queryHeaders(client, query, true))
+        .withQuery(query.params))
+}
+
+pub fn rpcHttpRequest<T>(client: Client, functionName: String, args: T) -> Result<http.Request, Error> {
+    rpcWithPreferHttpRequest(client, functionName, args, preferRepresentation())
+}
+
+pub fn rpcWithPreferHttpRequest<T>(client: Client, functionName: String, args: T, prefer: Prefer) -> Result<http.Request, Error> {
+    validateClient(client)?
+    let query = TableQuery {
+        table: cleanName("function", functionName)?,
+        prefer: prefer,
+    }
+    Ok(http.newRequest(http.Post, rpcUrl(client, query.table)?)
+        .withHeaders(queryHeaders(client, query, true))
+        .withJson(args))
+}
+
+pub fn rpcValueHttpRequest(client: Client, functionName: String, args: json.Json) -> Result<http.Request, Error> {
+    rpcHttpRequest(client, functionName, args)
+}
+
+pub fn rpcValueWithPreferHttpRequest(client: Client, functionName: String, args: json.Json, prefer: Prefer) -> Result<http.Request, Error> {
+    rpcWithPreferHttpRequest(client, functionName, args, prefer)
+}
+
+pub fn signUpHttpRequest(client: Client, email: String, password: String) -> Result<http.Request, Error> {
+    authJsonRequest(client, "signup", authPasswordBody(email, password))
+}
+
+pub fn passwordTokenHttpRequest(client: Client, email: String, password: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, "{authUrl(client, \"token\")?}?grant_type=password")
+        .withHeaders(authHeaders(client))
+        .withText(authPasswordBody(email, password))
+        .withContentType("application/json"))
+}
+
+pub fn refreshTokenHttpRequest(client: Client, refreshToken: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, "{authUrl(client, \"token\")?}?grant_type=refresh_token")
+        .withHeaders(authHeaders(client))
+        .withText(object([prop("refresh_token", quote(strings.trimSpace(refreshToken)))]))
+        .withContentType("application/json"))
+}
+
+pub fn logoutHttpRequest(client: Client) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, authUrl(client, "logout")?)
+        .withHeaders(authHeaders(client)))
+}
+
+pub fn publicObjectUrl(client: Client, bucket: String, path: String) -> Result<String, Error> {
+    Ok(storageUrl(client, "object/public/{encodePathSegment(cleanName(\"bucket\", bucket)?)}" +
+        "/{encodeObjectPath(path)?}")?)
+}
+
+pub fn authenticatedObjectUrl(client: Client, bucket: String, path: String) -> Result<String, Error> {
+    Ok(storageUrl(client, "object/authenticated/{encodePathSegment(cleanName(\"bucket\", bucket)?)}" +
+        "/{encodeObjectPath(path)?}")?)
+}
+
+pub fn objectUrl(client: Client, bucket: String, path: String) -> Result<String, Error> {
+    Ok(storageUrl(client, "object/{encodePathSegment(cleanName(\"bucket\", bucket)?)}" +
+        "/{encodeObjectPath(path)?}")?)
+}
+
+pub fn authenticatedObjectHttpRequest(client: Client, bucket: String, path: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Get, authenticatedObjectUrl(client, bucket, path)?)
+        .withHeaders(storageHeaders(client)))
+}
+
+pub fn downloadObjectHttpRequest(client: Client, bucket: String, path: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Get, objectUrl(client, bucket, path)?)
+        .withHeaders(storageHeaders(client)))
+}
+
+pub fn uploadObjectHttpRequest(client: Client, bucket: String, path: String, body: Bytes, contentType: String, upsert: Bool = false) -> Result<http.Request, Error> {
+    validateClient(client)?
+    let mut h = storageHeaders(client, if strings.trimSpace(contentType).isEmpty() { "application/octet-stream" } else { strings.trimSpace(contentType) })
+    if upsert {
+        h.insert("x-upsert", "true")
+    }
+    Ok(http.newRequest(http.Post, objectUrl(client, bucket, path)?)
+        .withHeaders(h)
+        .withBody(body))
+}
+
+pub fn updateObjectHttpRequest(client: Client, bucket: String, path: String, body: Bytes, contentType: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Put, objectUrl(client, bucket, path)?)
+        .withHeaders(storageHeaders(client, if strings.trimSpace(contentType).isEmpty() { "application/octet-stream" } else { strings.trimSpace(contentType) }))
+        .withBody(body))
+}
+
+pub fn removeObjectHttpRequest(client: Client, bucket: String, paths: List<String>) -> Result<http.Request, Error> {
+    validateClient(client)?
+    if paths.isEmpty() {
+        return Err(error.new("supabase: storage delete paths are empty"))
+    }
+    let mut items: List<String> = []
+    for path in paths {
+        items.push(quote(cleanObjectPath(path)?))
+    }
+    let body = object([prop("prefixes", array(items))])
+    Ok(http.newRequest(http.Delete, storageUrl(client, "object/{encodePathSegment(cleanName(\"bucket\", bucket)?)}")?)
+        .withHeaders(storageHeaders(client, "application/json"))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn invokeFunctionHttpRequest<T>(client: Client, functionName: String, payload: T) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, functionsUrl(client, functionName)?)
+        .withHeaders(authHeaders(client))
+        .withJson(payload))
+}
+
+pub fn graphqlHttpRequest(client: Client, bodyJson: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, graphqlUrl(client))
+        .withHeaders(authHeaders(client))
+        .withText(normalizedJsonObject(bodyJson))
+        .withContentType("application/json"))
+}
+
+pub fn sendSelect<T>(client: Client, query: TableQuery) -> Result<T, Error> {
+    let res = http.request(selectHttpRequest(client, query)?)?
+    requireSuccess(res)?.json::<T>()
+}
+
+pub fn sendInsert<T, U>(client: Client, table: String, value: T) -> Result<U, Error> {
+    let res = http.request(insertHttpRequest(client, table, value)?)?
+    requireSuccess(res)?.json::<U>()
+}
+
+pub fn sendInsertWithPrefer<T, U>(client: Client, table: String, value: T, prefer: Prefer) -> Result<U, Error> {
+    let res = http.request(insertWithPreferHttpRequest(client, table, value, prefer)?)?
+    requireSuccess(res)?.json::<U>()
+}
+
+pub fn sendUpdate<T, U>(client: Client, query: TableQuery, value: T) -> Result<U, Error> {
+    let res = http.request(updateHttpRequest(client, query, value)?)?
+    requireSuccess(res)?.json::<U>()
+}
+
+pub fn sendDelete<T>(client: Client, query: TableQuery) -> Result<T, Error> {
+    let res = http.request(deleteHttpRequest(client, query)?)?
+    requireSuccess(res)?.json::<T>()
+}
+
+pub fn sendRpc<T, U>(client: Client, functionName: String, args: T) -> Result<U, Error> {
+    let res = http.request(rpcHttpRequest(client, functionName, args)?)?
+    requireSuccess(res)?.json::<U>()
+}
+
+pub fn sendRpcWithPrefer<T, U>(client: Client, functionName: String, args: T, prefer: Prefer) -> Result<U, Error> {
+    let res = http.request(rpcWithPreferHttpRequest(client, functionName, args, prefer)?)?
+    requireSuccess(res)?.json::<U>()
+}
+
+pub fn parseApiError(response: http.Response) -> ApiError {
+    let text = response.text() ?? ""
+    let mut out = ApiError {
+        status: response.status,
+        rawJson: text,
+    }
+    match json.parseValue(text) {
+        Ok(value) -> match json.asObject(value) {
+            Ok(obj) -> {
+                out.code = stringField(obj, "code")
+                out.message = stringField(obj, "message")
+                out.details = stringField(obj, "details")
+                out.hint = stringField(obj, "hint")
+            },
+            Err(_) -> {},
+        },
+        Err(_) -> {
+            out.message = strings.trimSpace(text)
+        },
+    }
+    out
+}
+
+pub fn requireSuccess(response: http.Response) -> Result<http.Response, Error> {
+    if response.isSuccess() {
+        return Ok(response)
+    }
+    Err(error.new(parseApiError(response).summary()))
+}
+
+fn validateClient(client: Client) -> Result<(), Error> {
+    if strings.trimSpace(client.baseUrl).isEmpty() {
+        return Err(error.new("supabase: base URL is empty"))
+    }
+    if strings.trimSpace(client.apiKey).isEmpty() {
+        return Err(error.new("supabase: API key is empty"))
+    }
+    Ok(())
+}
+
+fn validateQuery(query: TableQuery) -> Result<(), Error> {
+    let _ = cleanName("table", query.table)?
+    Ok(())
+}
+
+fn baseHeaders(client: Client, includeProfile: Bool, contentType: String) -> Headers {
+    let mut out: Headers = {:}
+    if !strings.trimSpace(client.apiKey).isEmpty() {
+        out.insert("apikey", strings.trimSpace(client.apiKey))
+    }
+    let bearer = client.resolvedBearer()
+    if !strings.trimSpace(bearer).isEmpty() {
+        out.insert("Authorization", "Bearer {strings.trimSpace(bearer)}")
+    }
+    if !strings.trimSpace(contentType).isEmpty() {
+        out.insert("Content-Type", strings.trimSpace(contentType))
+    }
+    if !strings.trimSpace(client.clientInfo).isEmpty() {
+        out.insert("X-Client-Info", strings.trimSpace(client.clientInfo))
+    }
+    if includeProfile && !strings.trimSpace(client.schema).isEmpty() && strings.trimSpace(client.schema) != "public" {
+        out.insert("Accept-Profile", strings.trimSpace(client.schema))
+        out.insert("Content-Profile", strings.trimSpace(client.schema))
+    }
+    for (name, value) in client.extraHeaders {
+        out.insert(name, value)
+    }
+    out
+}
+
+fn dataHeaders(client: Client, accept: String) -> Headers {
+    let mut out = baseHeaders(client, true, "application/json")
+    out.insert("Accept", if strings.trimSpace(accept).isEmpty() { "application/json" } else { strings.trimSpace(accept) })
+    out
+}
+
+fn queryHeaders(client: Client, query: TableQuery, mutation: Bool) -> Headers {
+    let mut out = dataHeaders(client, query.accept)
+    let prefer = query.prefer.headerValue()
+    if !prefer.isEmpty() {
+        out.insert("Prefer", prefer)
+    } else if mutation {
+        out.insert("Prefer", "return=representation")
+    }
+    out
+}
+
+fn authJsonRequest(client: Client, path: String, body: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    Ok(http.newRequest(http.Post, authUrl(client, path)?)
+        .withHeaders(authHeaders(client))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+fn authPasswordBody(email: String, password: String) -> String {
+    object([
+        prop("email", quote(strings.trimSpace(email))),
+        prop("password", quote(password)),
+    ])
+}
+
+fn preferHeaderValue(prefer: Prefer) -> String {
+    let mut parts: List<String> = []
+    let count = prefer.count.toPrefer()
+    if !count.isEmpty() {
+        parts.push(count)
+    }
+    let returning = prefer.returning.toPrefer()
+    if !returning.isEmpty() {
+        parts.push(returning)
+    }
+    let resolution = prefer.resolution.toPrefer()
+    if !resolution.isEmpty() {
+        parts.push(resolution)
+    }
+    if prefer.missingDefault {
+        parts.push("missing=default")
+    }
+    strings.join(parts, ",")
+}
+
+fn setParam(values: QueryValues, key: String, value: String) -> QueryValues {
+    let mut out = values
+    out.insert(key, [value])
+    out
+}
+
+fn appendParam(values: QueryValues, key: String, value: String) -> QueryValues {
+    let mut out = values
+    out.update(key, |existing| {
+        let mut items = existing ?? []
+        items.push(value)
+        items
+    })
+    out
+}
+
+fn appendOrder(values: QueryValues, item: String) -> QueryValues {
+    let mut out = values
+    let current = out.get("order") ?? []
+    if current.isEmpty() {
+        out.insert("order", [item])
+        return out
+    }
+    out.insert("order", ["{current[0]},{item}"])
+    out
+}
+
+fn cleanProjectRef(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("supabase: project ref is empty"))
+    }
+    for c in clean.chars() {
+        if !isProjectRefChar(c) {
+            return Err(error.new("supabase: invalid project ref: {value}"))
+        }
+    }
+    Ok(clean)
+}
+
+fn cleanName(kind: String, value: String) -> Result<String, Error> {
+    let clean = strings.trim(strings.trimSpace(value))
+    if clean.isEmpty() {
+        return Err(error.new("supabase: {kind} is empty"))
+    }
+    if strings.contains(clean, "/") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("supabase: invalid {kind}: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanQueryName(value: String) -> Result<String, Error> {
+    cleanName("query parameter", value)
+}
+
+fn cleanColumnName(value: String) -> Result<String, Error> {
+    let clean = cleanName("column", value)?
+    if strings.contains(clean, " ") || strings.contains(clean, "\t") || strings.contains(clean, "\n") {
+        return Err(error.new("supabase: invalid column: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanOperator(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() || strings.contains(clean, ".") || strings.contains(clean, "/") {
+        return Err(error.new("supabase: invalid filter operator: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanRelativePath(value: String) -> Result<String, Error> {
+    let clean = strings.trimPrefix(strings.trimSpace(value), "/")
+    if clean.isEmpty() {
+        return Err(error.new("supabase: path is empty"))
+    }
+    if strings.contains(clean, "..") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("supabase: unsafe path: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanObjectPath(value: String) -> Result<String, Error> {
+    let clean = strings.trimPrefix(strings.trimSpace(value), "/")
+    if clean.isEmpty() {
+        return Err(error.new("supabase: storage object path is empty"))
+    }
+    if strings.contains(clean, "..") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("supabase: unsafe storage object path: {value}"))
+    }
+    Ok(clean)
+}
+
+fn encodeObjectPath(path: String) -> Result<String, Error> {
+    let clean = cleanObjectPath(path)?
+    let mut parts: List<String> = []
+    for part in strings.split(clean, "/") {
+        if strings.trimSpace(part).isEmpty() {
+            return Err(error.new("supabase: storage object path contains an empty segment"))
+        }
+        parts.push(encodePathSegment(part))
+    }
+    Ok(strings.join(parts, "/"))
+}
+
+fn encodePathSegment(segment: String) -> String {
+    encoding.url.encode(segment)
+}
+
+fn stripTrailingSlash(value: String) -> String {
+    let mut out = strings.trimSpace(value)
+    for strings.endsWith(out, "/") {
+        out = strings.trimSuffix(out, "/")
+    }
+    out
+}
+
+fn joinUrl(base: String, path: String) -> String {
+    let cleanBase = stripTrailingSlash(base)
+    if strings.startsWith(path, "/") {
+        "{cleanBase}{path}"
+    } else {
+        "{cleanBase}/{path}"
+    }
+}
+
+fn isProjectRefChar(c: Char) -> Bool {
+    (c >= 'a' && c <= 'z') ||
+    (c >= '0' && c <= '9') ||
+    c == '-'
+}
+
+fn normalizedJsonObject(text: String) -> String {
+    let raw = strings.trimSpace(text)
+    if raw.isEmpty() {
+        return "\{\}"
+    }
+    match json.parseValue(raw) {
+        Ok(value) -> match json.asObject(value) {
+            Ok(_)  -> json.stringifyValue(value),
+            Err(_) -> "\{\}",
+        },
+        Err(_) -> "\{\}",
+    }
+}
+
+fn stringField(obj: json.JsonObject, key: String) -> String {
+    match obj.get(key) {
+        Some(value) -> match json.asString(value) {
+            Ok(text) -> text,
+            Err(_)   -> "",
+        },
+        None -> "",
+    }
+}
+
+fn object(props: List<String>) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    "{open}{strings.join(props, \",\")}{close}"
+}
+
+fn array(items: List<String>) -> String {
+    "[{strings.join(items, \",\")}]"
+}
+
+fn prop(name: String, value: String) -> String {
+    "{quote(name)}:{value}"
+}
+
+fn quote(text: String) -> String {
+    json.stringifyValue(json.string(text))
+}

--- a/internal/stdlib/supabase_test.go
+++ b/internal/stdlib/supabase_test.go
@@ -1,0 +1,148 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestSupabaseModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := requireSupabaseModule(t, reg)
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"CountMode", resolve.SymEnum},
+		{"ReturningMode", resolve.SymEnum},
+		{"ResolutionMode", resolve.SymEnum},
+		{"OrderDirection", resolve.SymEnum},
+		{"NullOrdering", resolve.SymEnum},
+		{"Prefer", resolve.SymStruct},
+		{"Client", resolve.SymStruct},
+		{"TableQuery", resolve.SymStruct},
+		{"ApiError", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.supabase missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.supabase.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.supabase.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"prefer", "preferRepresentation", "preferMinimal",
+		"client", "project", "local", "from",
+		"headers", "authHeaders", "storageHeaders",
+		"restUrl", "tableUrl", "rpcUrl", "authUrl", "storageUrl", "functionsUrl", "graphqlUrl",
+		"selectHttpRequest", "insertHttpRequest", "insertWithPreferHttpRequest",
+		"upsertHttpRequest", "upsertWithPreferHttpRequest", "updateHttpRequest", "deleteHttpRequest",
+		"rpcHttpRequest", "rpcWithPreferHttpRequest", "rpcValueHttpRequest", "rpcValueWithPreferHttpRequest",
+		"signUpHttpRequest", "passwordTokenHttpRequest", "refreshTokenHttpRequest", "logoutHttpRequest",
+		"publicObjectUrl", "authenticatedObjectUrl", "objectUrl",
+		"authenticatedObjectHttpRequest", "downloadObjectHttpRequest", "uploadObjectHttpRequest",
+		"updateObjectHttpRequest", "removeObjectHttpRequest",
+		"invokeFunctionHttpRequest", "graphqlHttpRequest",
+		"sendSelect", "sendInsert", "sendInsertWithPrefer", "sendUpdate", "sendDelete", "sendRpc", "sendRpcWithPrefer",
+		"parseApiError", "requireSuccess",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.supabase missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.supabase.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.supabase.%s not public", name)
+		}
+	}
+}
+
+func TestSupabaseModuleMethodsAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"CountMode", []string{"toPrefer"}},
+		{"ReturningMode", []string{"toPrefer"}},
+		{"ResolutionMode", []string{"toPrefer"}},
+		{"OrderDirection", []string{"toString"}},
+		{"NullOrdering", []string{"toOrderSuffix"}},
+		{"Prefer", []string{"withCount", "withReturning", "withResolution", "withMissingDefault", "headerValue"}},
+		{"Client", []string{"withAccessToken", "withServiceRoleKey", "withSchema", "withClientInfo", "withHeader", "resolvedBearer"}},
+		{"TableQuery", []string{
+			"select", "withParam", "filter", "eq", "neq", "gt", "gte", "lt", "lte",
+			"like", "ilike", "isNull", "inList", "contains", "containedBy", "overlaps",
+			"textSearch", "order", "orderAsc", "orderDesc", "limit", "offset", "range", "withCount", "withPrefer",
+			"returning", "resolveDuplicates", "single", "csv",
+		}},
+		{"ApiError", []string{"summary"}},
+	} {
+		for _, method := range tc.methods {
+			fn := reg.LookupMethodDecl("supabase", tc.typeName, method)
+			if fn == nil {
+				t.Fatalf("LookupMethodDecl(supabase, %s, %s) = nil, want *ast.FnDecl", tc.typeName, method)
+			}
+			if fn.Body == nil {
+				t.Fatalf("supabase.%s.%s body = nil, want source method body", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestSupabaseModulePinsEndpointAndHeaderBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := requireSupabaseModule(t, reg)
+	src := string(mod.Source)
+	for _, want := range []string{
+		`joinUrl(client.baseUrl, "/rest/v1")`,
+		`joinUrl(client.baseUrl, "/auth/v1/{cleanRelativePath(path)?}")`,
+		`joinUrl(client.baseUrl, "/storage/v1/{cleanRelativePath(path)?}")`,
+		`joinUrl(client.baseUrl, "/functions/v1/{encodePathSegment(cleanName(\"function\", functionName)?)}")`,
+		`joinUrl(client.baseUrl, "/graphql/v1")`,
+		`out.insert("apikey", strings.trimSpace(client.apiKey))`,
+		`out.insert("Authorization", "Bearer {strings.trimSpace(bearer)}")`,
+		`out.insert("Accept-Profile", strings.trimSpace(client.schema))`,
+		`out.insert("Content-Profile", strings.trimSpace(client.schema))`,
+		`self.filter(column, "eq", value)`,
+		`self.filter(column, "fts", query)`,
+		`self.params = setParam(self.params, "offset", from.toString())`,
+		`"application/vnd.pgrst.object+json"`,
+		`"{authUrl(client, \"token\")?}?grant_type=password"`,
+		`"{authUrl(client, \"token\")?}?grant_type=refresh_token"`,
+		`object/authenticated/{encodePathSegment(cleanName(\"bucket\", bucket)?)}"`,
+		`"/{encodeObjectPath(path)?}"`,
+		`h.insert("x-upsert", "true")`,
+		`prop("prefixes", array(items))`,
+		`normalizedJsonObject(bodyJson)`,
+		`parseApiError(response).summary()`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.supabase source missing %q", want)
+		}
+	}
+}
+
+func requireSupabaseModule(t *testing.T, reg *Registry) *Module {
+	t.Helper()
+	mod := reg.Modules["supabase"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		var details []string
+		for _, d := range reg.Diags {
+			if d != nil && (strings.Contains(d.File, "supabase") || strings.Contains(d.Message, "native resolve")) {
+				details = append(details, d.Error())
+			}
+		}
+		t.Fatalf("std.supabase not fully loaded; diagnostics=%v", details)
+	}
+	return mod
+}


### PR DESCRIPTION
## Summary

- Add `std.supabase` as a pure Osty convenience layer over `std.http` for Supabase integration.
- Cover PostgREST table queries, Prefer headers, Auth requests, Storage object URLs/uploads/removals, Edge Function requests, GraphQL requests, and Supabase-style error parsing.
- Document the new standard-library module and include it in the stdlib support matrix.

## Validation

- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlib'`
- `just fmt-check`
- `git diff --check`