### PR TITLE
[codex] deepen std.redis helpers

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -50,7 +50,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | schedule | 637 | pure Osty | cron parser/matcher, interval/daily next-run planning, task state, due/tick helpers, and retry backoff |
 | jsonl | 117 | pure Osty + json | Deneb-style JSON Lines parse/append/compact helpers |
 | kv | 459 | pure Osty + fs/json | JSONL append-log local KV: file-backed cache/history/settings store, string-first typed getters/setters, tombstone delete, compact rewrite, JSON convenience helpers |
-| redis | 1115 | pure Osty + net/bytes | Redis integration helpers: Config/auth/DB selection, RESP2 encode/decode, command builders for strings/hash/list/set/pubsub/scan/streams, pipelines/transactions, small TCP request helpers |
+| redis | 1439 | pure Osty + net/bytes | Redis integration helpers: Config/auth/DB selection, RESP2 byte-stream reader, command builders for strings/hash/list/set/pubsub/scan/streams, pipelines/transactions, typed reply converters, and convenience client helpers |
 | shortid | 65 | pure Osty | Deneb-style `prefix_0000` deterministic short id generator |
 | metrics | 48 | pure Osty | Deneb-style labeled counter snapshots without a metrics backend |
 | net | 1084 | net 40 runtime | TCP/UDP, IPv4/IPv6, parseSocketAddr, tcpListen |

--- a/internal/stdlib/modules/redis.osty
+++ b/internal/stdlib/modules/redis.osty
@@ -1,8 +1,8 @@
-// std.redis - Redis command builders, RESP2 codec, and small TCP request helpers.
+// std.redis - Redis command builders, RESP2 codec, and streaming TCP helpers.
 //
 // The core surface is pure Osty: command construction, safe key/options
 // validation, RESP2 rendering/parsing, and pipeline/transaction planning.
-// The optional Client helper uses std.net for small request/response exchanges;
+// The optional Client helper uses std.net and reads until complete RESP replies;
 // long-lived pooling, TLS, Pub/Sub loops, and cluster routing are intentionally
 // left to a runtime-backed driver.
 
@@ -35,6 +35,7 @@ pub struct Config {
     pub database: Int? = None,
     pub tls: Bool = false,
     pub connectTimeoutMs: Int = 30000,
+    pub responseChunkBytes: Int = 65536,
     pub responseMaxBytes: Int = 1048576,
 }
 
@@ -76,6 +77,21 @@ pub struct ScanOptions {
     pub typ: String? = None,
 }
 
+pub struct ScanResult {
+    pub cursor: Int,
+    pub keys: List<String>,
+}
+
+pub struct StreamEntry {
+    pub id: String,
+    pub fields: Map<String, String>,
+}
+
+pub struct StreamBatch {
+    pub stream: String,
+    pub entries: List<StreamEntry>,
+}
+
 pub fn defaultPort() -> Int {
     6379
 }
@@ -111,6 +127,7 @@ pub fn withAuth(cfg: Config, password: String) -> Result<Config, Error> {
         database: cfg.database,
         tls: cfg.tls,
         connectTimeoutMs: cfg.connectTimeoutMs,
+        responseChunkBytes: cfg.responseChunkBytes,
         responseMaxBytes: cfg.responseMaxBytes,
     })
 }
@@ -129,6 +146,7 @@ pub fn withUserAuth(cfg: Config, username: String, password: String) -> Result<C
         database: withPassword.database,
         tls: withPassword.tls,
         connectTimeoutMs: withPassword.connectTimeoutMs,
+        responseChunkBytes: withPassword.responseChunkBytes,
         responseMaxBytes: withPassword.responseMaxBytes,
     })
 }
@@ -145,6 +163,7 @@ pub fn withDatabase(cfg: Config, database: Int) -> Result<Config, Error> {
         database: Some(database),
         tls: cfg.tls,
         connectTimeoutMs: cfg.connectTimeoutMs,
+        responseChunkBytes: cfg.responseChunkBytes,
         responseMaxBytes: cfg.responseMaxBytes,
     })
 }
@@ -158,6 +177,7 @@ pub fn withTls(cfg: Config, enabled: Bool) -> Config {
         database: cfg.database,
         tls: enabled,
         connectTimeoutMs: cfg.connectTimeoutMs,
+        responseChunkBytes: cfg.responseChunkBytes,
         responseMaxBytes: cfg.responseMaxBytes,
     }
 }
@@ -174,6 +194,24 @@ pub fn withConnectTimeout(cfg: Config, ms: Int) -> Result<Config, Error> {
         database: cfg.database,
         tls: cfg.tls,
         connectTimeoutMs: ms,
+        responseChunkBytes: cfg.responseChunkBytes,
+        responseMaxBytes: cfg.responseMaxBytes,
+    })
+}
+
+pub fn withResponseChunkBytes(cfg: Config, chunkBytes: Int) -> Result<Config, Error> {
+    if chunkBytes <= 0 {
+        return Err(error.new("redis: response chunk bytes must be positive"))
+    }
+    Ok(Config {
+        host: cfg.host,
+        port: cfg.port,
+        username: cfg.username,
+        password: cfg.password,
+        database: cfg.database,
+        tls: cfg.tls,
+        connectTimeoutMs: cfg.connectTimeoutMs,
+        responseChunkBytes: chunkBytes,
         responseMaxBytes: cfg.responseMaxBytes,
     })
 }
@@ -190,6 +228,7 @@ pub fn withResponseMaxBytes(cfg: Config, bytes: Int) -> Result<Config, Error> {
         database: cfg.database,
         tls: cfg.tls,
         connectTimeoutMs: cfg.connectTimeoutMs,
+        responseChunkBytes: cfg.responseChunkBytes,
         responseMaxBytes: bytes,
     })
 }
@@ -464,6 +503,107 @@ pub fn boolValue(value: Resp) -> Result<Bool, Error> {
     }
 }
 
+pub fn stringList(value: Resp) -> Result<List<String>, Error> {
+    match value {
+        Array(items) -> {
+            let mut out: List<String> = []
+            for item in items {
+                out.push(stringValue(item)?)
+            }
+            Ok(out)
+        },
+        NullArray        -> Ok([]),
+        ErrorReply(text) -> Err(error.new("redis: error reply: {text}")),
+        _                -> Err(error.new("redis: expected array reply")),
+    }
+}
+
+pub fn optionalStringList(value: Resp) -> Result<List<String?>, Error> {
+    match value {
+        Array(items) -> {
+            let mut out: List<String?> = []
+            for item in items {
+                match item {
+                    BulkString(text)   -> out.push(Some(text)),
+                    SimpleString(text) -> out.push(Some(text)),
+                    NullBulkString     -> out.push(noneString()),
+                    ErrorReply(text)   -> { return Err(error.new("redis: error reply: {text}")) },
+                    _                  -> { return Err(error.new("redis: expected string array element")) },
+                }
+            }
+            Ok(out)
+        },
+        NullArray        -> Ok([]),
+        ErrorReply(text) -> Err(error.new("redis: error reply: {text}")),
+        _                -> Err(error.new("redis: expected array reply")),
+    }
+}
+
+pub fn stringMap(value: Resp) -> Result<Map<String, String>, Error> {
+    let items = stringList(value)?
+    if items.len() % 2 != 0 {
+        return Err(error.new("redis: expected even field/value array"))
+    }
+    let mut out: Map<String, String> = {:}
+    let mut i = 0
+    for i < items.len() {
+        out.insert(items[i], items[i + 1])
+        i = i + 2
+    }
+    Ok(out)
+}
+
+pub fn scanResult(value: Resp) -> Result<ScanResult, Error> {
+    match value {
+        Array(items) -> {
+            if items.len() != 2 {
+                return Err(error.new("redis: SCAN reply must contain cursor and keys"))
+            }
+            Ok(ScanResult {
+                cursor: strings.toInt(stringValue(items[0])?)?,
+                keys: stringList(items[1])?,
+            })
+        },
+        ErrorReply(text) -> Err(error.new("redis: error reply: {text}")),
+        _                -> Err(error.new("redis: expected SCAN array reply")),
+    }
+}
+
+pub fn streamBatches(value: Resp) -> Result<List<StreamBatch>, Error> {
+    match value {
+        Array(streams) -> {
+            let mut out: List<StreamBatch> = []
+            for streamValue in streams {
+                let pair = arrayItems(streamValue, "XREAD stream")?
+                if pair.len() != 2 {
+                    return Err(error.new("redis: XREAD stream reply must contain stream and entries"))
+                }
+                let streamName = stringValue(pair[0])?
+                let entryValues = arrayItems(pair[1], "XREAD entries")?
+                let mut entries: List<StreamEntry> = []
+                for entryValue in entryValues {
+                    let entry = arrayItems(entryValue, "XREAD entry")?
+                    if entry.len() != 2 {
+                        return Err(error.new("redis: XREAD entry must contain id and fields"))
+                    }
+                    entries.push(StreamEntry {
+                        id: stringValue(entry[0])?,
+                        fields: stringMap(entry[1])?,
+                    })
+                }
+                out.push(StreamBatch {
+                    stream: streamName,
+                    entries: entries,
+                })
+            }
+            Ok(out)
+        },
+        NullArray        -> Ok([]),
+        ErrorReply(text) -> Err(error.new("redis: error reply: {text}")),
+        _                -> Err(error.new("redis: expected XREAD array reply")),
+    }
+}
+
 pub fn expectOk(value: Resp) -> Result<(), Error> {
     match value {
         SimpleString(text) -> {
@@ -515,8 +655,24 @@ pub fn get(key: String) -> Result<Command, Error> {
     keyCommand("GET", key)
 }
 
+pub fn mget(keys: List<String>) -> Result<Command, Error> {
+    keysCommand("MGET", keys)
+}
+
 pub fn set(key: String, value: String) -> Result<Command, Error> {
     command("SET", [validateKey(key)?, value])
+}
+
+pub fn mset(values: Map<String, String>) -> Result<Command, Error> {
+    if values.isEmpty() {
+        return Err(error.new("redis: MSET needs at least one key"))
+    }
+    let mut args: List<String> = []
+    for key in values.keys().sorted() {
+        args.push(validateKey(key)?)
+        args.push(values.get(key).unwrap())
+    }
+    command("MSET", args)
 }
 
 pub fn setOptions() -> SetOptions {
@@ -675,8 +831,24 @@ pub fn hget(key: String, field: String) -> Result<Command, Error> {
     command("HGET", [validateKey(key)?, validateKey(field)?])
 }
 
+pub fn hgetall(key: String) -> Result<Command, Error> {
+    keyCommand("HGETALL", key)
+}
+
 pub fn hset(key: String, field: String, value: String) -> Result<Command, Error> {
     command("HSET", [validateKey(key)?, validateKey(field)?, value])
+}
+
+pub fn hsetMap(key: String, fields: Map<String, String>) -> Result<Command, Error> {
+    if fields.isEmpty() {
+        return Err(error.new("redis: HSET needs at least one field"))
+    }
+    let mut args: List<String> = [validateKey(key)?]
+    for field in fields.keys().sorted() {
+        args.push(validateKey(field)?)
+        args.push(fields.get(field).unwrap())
+    }
+    command("HSET", args)
 }
 
 pub fn hdel(key: String, fields: List<String>) -> Result<Command, Error> {
@@ -811,6 +983,10 @@ pub fn xadd(stream: String, id: String, fields: Map<String, String>) -> Result<C
     command("XADD", args)
 }
 
+pub fn xaddFields(stream: String, fields: Map<String, String>) -> Result<Command, Error> {
+    xadd(stream, "*", fields)
+}
+
 pub fn xread(stream: String, id: String, count: Int?) -> Result<Command, Error> {
     let mut args: List<String> = []
     match count {
@@ -825,7 +1001,11 @@ pub fn xread(stream: String, id: String, count: Int?) -> Result<Command, Error> 
     }
     args.push("STREAMS")
     args.push(validateKey(stream)?)
-    args.push(strings.trimSpace(id))
+    let cleanId = strings.trimSpace(id)
+    if cleanId.isEmpty() {
+        return Err(error.new("redis: XREAD id is empty"))
+    }
+    args.push(cleanId)
     command("XREAD", args)
 }
 
@@ -860,14 +1040,62 @@ pub fn connect(cfg: Config) -> Result<Client, Error> {
 
 pub fn request(client: Client, cmd: Command) -> Result<Resp, Error> {
     client.conn.writeAll(renderCommandBytes(cmd))?
-    let data = client.conn.read(client.config.responseMaxBytes)?
-    parseBytes(data)
+    readResp(client)
 }
 
 pub fn requestPipeline(client: Client, pipe: Pipeline) -> Result<List<Resp>, Error> {
     client.conn.writeAll(renderPipelineBytes(pipe))?
-    let data = client.conn.read(client.config.responseMaxBytes)?
-    parseMany(bytes.toString(data)?)
+    readResponses(client, pipe.commands.len())
+}
+
+pub fn readResp(client: Client) -> Result<Resp, Error> {
+    let parsed = readRespPrefix(client)?
+    Ok(parsed.value)
+}
+
+pub fn readRespPrefix(client: Client) -> Result<Parsed, Error> {
+    let mut buffer: List<Byte> = []
+    for buffer.len() < client.config.responseMaxBytes {
+        readChunkInto(client, buffer)?
+        match parseBytesAt(bytes.from(buffer), 0) {
+            Ok(parsed) -> {
+                return Ok(Parsed {
+                    value: parsed.value,
+                    next: parsed.next,
+                })
+            },
+            Err(err) -> {
+                if !isIncompleteRespError(err) {
+                    return Err(err)
+                }
+            },
+        }
+    }
+    Err(error.new("redis: response exceeds configured byte limit"))
+}
+
+pub fn readResponses(client: Client, count: Int) -> Result<List<Resp>, Error> {
+    if count < 0 {
+        return Err(error.new("redis: response count must not be negative"))
+    }
+    let mut out: List<Resp> = []
+    let mut buffer: List<Byte> = []
+    let mut pos = 0
+    for out.len() < count {
+        match parseBytesAt(bytes.from(buffer), pos) {
+            Ok(parsed) -> {
+                out.push(parsed.value)
+                pos = parsed.next
+            },
+            Err(err) -> {
+                if !isIncompleteRespError(err) {
+                    return Err(err)
+                }
+                readChunkInto(client, buffer)?
+            },
+        }
+    }
+    Ok(out)
 }
 
 pub fn close(client: Client) -> Result<(), Error> {
@@ -891,6 +1119,14 @@ pub fn setStringWithOptions(client: Client, key: String, value: String, opts: Se
     request(client, setWithOptions(key, value, opts)?)
 }
 
+pub fn mgetStrings(client: Client, keys: List<String>) -> Result<List<String?>, Error> {
+    optionalStringList(request(client, mget(keys)?)?)
+}
+
+pub fn msetStrings(client: Client, values: Map<String, String>) -> Result<(), Error> {
+    expectOk(request(client, mset(values)?)?)
+}
+
 pub fn deleteKeys(client: Client, keys: List<String>) -> Result<Int, Error> {
     intValue(request(client, del(keys)?)?)
 }
@@ -901,6 +1137,94 @@ pub fn existsKeys(client: Client, keys: List<String>) -> Result<Int, Error> {
 
 pub fn expireKey(client: Client, key: String, seconds: Int) -> Result<Bool, Error> {
     boolValue(request(client, expire(key, seconds)?)?)
+}
+
+pub fn ttlSeconds(client: Client, key: String) -> Result<Int, Error> {
+    intValue(request(client, ttl(key)?)?)
+}
+
+pub fn incrInt(client: Client, key: String) -> Result<Int, Error> {
+    intValue(request(client, incr(key)?)?)
+}
+
+pub fn hgetString(client: Client, key: String, field: String) -> Result<String?, Error> {
+    match request(client, hget(key, field)?)? {
+        BulkString(value) -> Ok(Some(value)),
+        NullBulkString   -> Ok(noneString()),
+        ErrorReply(text) -> Err(error.new("redis: error reply: {text}")),
+        _                -> Err(error.new("redis: HGET returned a non-string reply")),
+    }
+}
+
+pub fn hsetString(client: Client, key: String, field: String, value: String) -> Result<Int, Error> {
+    intValue(request(client, hset(key, field, value)?)?)
+}
+
+pub fn hsetFields(client: Client, key: String, fields: Map<String, String>) -> Result<Int, Error> {
+    intValue(request(client, hsetMap(key, fields)?)?)
+}
+
+pub fn hgetAll(client: Client, key: String) -> Result<Map<String, String>, Error> {
+    stringMap(request(client, hgetall(key)?)?)
+}
+
+pub fn scanKeys(client: Client, cursor: Int, opts: ScanOptions) -> Result<ScanResult, Error> {
+    scanResult(request(client, scan(cursor, opts)?)?)
+}
+
+pub fn xaddEntry(client: Client, stream: String, id: String, fields: Map<String, String>) -> Result<String, Error> {
+    stringValue(request(client, xadd(stream, id, fields)?)?)
+}
+
+pub fn xaddAuto(client: Client, stream: String, fields: Map<String, String>) -> Result<String, Error> {
+    xaddEntry(client, stream, "*", fields)
+}
+
+pub fn xreadBatches(client: Client, stream: String, id: String, count: Int?) -> Result<List<StreamBatch>, Error> {
+    streamBatches(request(client, xread(stream, id, count)?)?)
+}
+
+fn readChunkInto(client: Client, buffer: List<Byte>) -> Result<(), Error> {
+    if buffer.len() >= client.config.responseMaxBytes {
+        return Err(error.new("redis: response exceeds configured byte limit"))
+    }
+    let chunk = client.conn.read(responseReadSize(client.config, buffer.len()))?
+    if chunk.len() == 0 {
+        return Err(error.new("redis: connection closed before RESP reply"))
+    }
+    appendBytes(buffer, chunk)
+    Ok(())
+}
+
+fn responseReadSize(cfg: Config, buffered: Int) -> Int {
+    let remaining = cfg.responseMaxBytes - buffered
+    if remaining < cfg.responseChunkBytes {
+        remaining
+    } else {
+        cfg.responseChunkBytes
+    }
+}
+
+fn appendBytes(out: List<Byte>, data: Bytes) {
+    let mut i = 0
+    for i < data.len() {
+        out.push(data.get(i).unwrap())
+        i = i + 1
+    }
+}
+
+fn isIncompleteRespError(err: Error) -> Bool {
+    let msg = err.message()
+    strings.startsWith(msg, "redis: incomplete") || msg == "redis: missing CRLF"
+}
+
+fn arrayItems(value: Resp, label: String) -> Result<List<Resp>, Error> {
+    match value {
+        Array(items)      -> Ok(items),
+        NullArray         -> Ok([]),
+        ErrorReply(text)  -> Err(error.new("redis: error reply: {text}")),
+        _                 -> Err(error.new("redis: expected {label} array reply")),
+    }
 }
 
 fn parseBytesAt(data: Bytes, start: Int) -> Result<ByteParsed, Error> {

--- a/internal/stdlib/redis_test.go
+++ b/internal/stdlib/redis_test.go
@@ -15,22 +15,23 @@ func TestRedisModuleSurface(t *testing.T) {
 	}
 	for _, name := range []string{
 		"defaultPort", "config", "localhost", "withAuth", "withUserAuth", "withDatabase",
-		"withTls", "withConnectTimeout", "withResponseMaxBytes", "addr", "url", "redactedUrl",
+		"withTls", "withConnectTimeout", "withResponseChunkBytes", "withResponseMaxBytes", "addr", "url", "redactedUrl",
 		"command", "rawCommand", "withArg", "withArgs", "parts",
 		"pipeline", "emptyPipeline", "append", "transaction",
 		"renderCommand", "renderCommandBytes", "renderPipeline", "renderPipelineBytes",
 		"simpleString", "errorReply", "integer", "bulkString", "nullBulkString", "array", "nullArray",
 		"render", "parse", "parsePrefix", "parseComplete", "parseMany", "parseBytes", "parseBytesPrefix", "parseManyBytes", "parseCommand", "commandFromResp",
-		"stringValue", "intValue", "boolValue", "expectOk",
+		"stringValue", "intValue", "boolValue", "stringList", "optionalStringList", "stringMap", "scanResult", "streamBatches", "expectOk",
 		"ping", "pingMessage", "auth", "authUser", "hello", "selectDb",
-		"get", "set", "setOptions", "setWithOptions", "withExpireSeconds", "withExpireMs",
+		"get", "mget", "set", "mset", "setOptions", "setWithOptions", "withExpireSeconds", "withExpireMs",
 		"setKeepTtl", "setIfExists", "setIfMissing", "setGetOldValue",
 		"del", "exists", "expire", "pexpire", "ttl", "incr", "incrBy", "decr",
-		"hget", "hset", "hdel", "lpush", "rpush", "lpop", "rpop",
+		"hget", "hgetall", "hset", "hsetMap", "hdel", "lpush", "rpush", "lpop", "rpop",
 		"sadd", "srem", "smembers", "publish", "subscribe",
 		"scanOptions", "scanWithPattern", "scanWithCount", "scanWithType", "scan",
-		"xadd", "xread", "bootstrapCommands", "connect", "request", "requestPipeline", "close",
-		"getString", "setString", "setStringWithOptions", "deleteKeys", "existsKeys", "expireKey",
+		"xadd", "xaddFields", "xread", "bootstrapCommands", "connect", "request", "requestPipeline", "readResp", "readRespPrefix", "readResponses", "close",
+		"getString", "setString", "setStringWithOptions", "mgetStrings", "msetStrings", "deleteKeys", "existsKeys", "expireKey",
+		"ttlSeconds", "incrInt", "hgetString", "hsetString", "hsetFields", "hgetAll", "scanKeys", "xaddEntry", "xaddAuto", "xreadBatches",
 	} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
@@ -43,7 +44,7 @@ func TestRedisModuleSurface(t *testing.T) {
 			t.Fatalf("std.redis.%s not public", name)
 		}
 	}
-	for _, name := range []string{"Resp", "SetMode", "Config", "Client", "Command", "Pipeline", "Parsed", "SetOptions", "ScanOptions"} {
+	for _, name := range []string{"Resp", "SetMode", "Config", "Client", "Command", "Pipeline", "Parsed", "SetOptions", "ScanOptions", "ScanResult", "StreamEntry", "StreamBatch"} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Fatalf("std.redis missing type %q", name)
@@ -67,12 +68,23 @@ func TestRedisModuleSourcePinsIntegrationHelpers(t *testing.T) {
 		`value.bytes().len()`,
 		`pub fn parseComplete(text: String) -> Result<Resp, Error>`,
 		`pub fn parseBytesPrefix(data: Bytes) -> Result<Parsed, Error>`,
+		`pub fn readResponses(client: Client, count: Int) -> Result<List<Resp>, Error>`,
+		`readResponses(client, pipe.commands.len())`,
+		`match parseBytesAt(bytes.from(buffer), pos)`,
+		`fn isIncompleteRespError(err: Error) -> Bool`,
 		`pub fn setWithOptions(key: String, value: String, opts: SetOptions) -> Result<Command, Error>`,
+		`pub fn mset(values: Map<String, String>) -> Result<Command, Error>`,
+		`pub fn optionalStringList(value: Resp) -> Result<List<String?>, Error>`,
+		`pub fn stringMap(value: Resp) -> Result<Map<String, String>, Error>`,
 		`pub fn scan(cursor: Int, opts: ScanOptions) -> Result<Command, Error>`,
+		`pub fn scanResult(value: Resp) -> Result<ScanResult, Error>`,
 		`pub fn xadd(stream: String, id: String, fields: Map<String, String>) -> Result<Command, Error>`,
+		`pub fn streamBatches(value: Resp) -> Result<List<StreamBatch>, Error>`,
 		`pub fn bootstrapCommands(cfg: Config) -> Result<Pipeline, Error>`,
 		`expectOk(request(client, cmd)?)?`,
 		`pub fn getString(client: Client, key: String) -> Result<String?, Error>`,
+		`pub fn hgetAll(client: Client, key: String) -> Result<Map<String, String>, Error>`,
+		`pub fn xreadBatches(client: Client, stream: String, id: String, count: Int?) -> Result<List<StreamBatch>, Error>`,
 		`fn parseBytesAt(data: Bytes, start: Int) -> Result<ByteParsed, Error>`,
 		`long-lived pooling, TLS, Pub/Sub loops, and cluster routing`,
 		`Err(error.new("redis: TLS requires a TLS-capable transport"))`,


### PR DESCRIPTION
## Summary
- make std.redis TCP requests read until complete RESP replies instead of assuming one read is enough
- add typed RESP converters for string lists, optional string lists, field maps, SCAN results, and XREAD stream batches
- add convenience Redis helpers for MGET/MSET, HGETALL/HSET map, SCAN, XADD, XREAD, TTL, and INCR
- update STDLIB_MATRIX and expand std.redis surface/source tests

## Verification
- go run ./cmd/osty check internal/stdlib/modules/redis.osty
- go test -count=1 -vet=off ./internal/stdlib -run 'TestRedis' -v\n- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultRedis' -v\n- just support-stdlib-fast\n- go test -count=1 -vet=off ./internal/stdlib\n- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult'\n- just fmt-check\n- git diff --check