### PR TITLE
stdlib: add observability and sentry modules

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,19 +18,19 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 93 공개 모듈. 분류 기준:
+총 95 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (87 / 93 = 94%)
+### ⭐⭐⭐⭐⭐ Production (89 / 95 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
 | strings | 7242 | string 17 + bytes 29 runtime | 압도적. UTF-8 / casefold / normalize / grapheme |
-| http | 1468 | net 40 runtime | Router + Cookie + MediaType + Form + Query + dispatch |
+| http | 1588 | net 40 runtime | Router + Cookie + MediaType + Form + Query + dispatch |
 | ai | 1793 | pure Osty + http/json | OpenAI-compatible / OpenRouter / Anthropic / Gemini / local-runtime chat requests, headers, structured tool calls/results, response parsing, models, embeddings, SSE data helpers |
 | aiagents | 736 | pure Osty | Deneb-derived agent/session/message types, tool presets, safety boundary, RankLines / TruncateHeadTail compaction |
 | aidev | 701 | pure Osty | AI coding-loop data model: SourceFile / SourceSpan / Diagnostic / Patch / FixContext, source excerpts, non-overlap validation, safe text patch application |
@@ -53,6 +53,8 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | redis | 1439 | pure Osty + net/bytes | Redis integration helpers: Config/auth/DB selection, RESP2 byte-stream reader, command builders for strings/hash/list/set/pubsub/scan/streams, pipelines/transactions, typed reply converters, and convenience client helpers |
 | shortid | 65 | pure Osty | Deneb-style `prefix_0000` deterministic short id generator |
 | metrics | 48 | pure Osty | Deneb-style labeled counter snapshots without a metrics backend |
+| observability | 602 | pure Osty + log/metrics/json/redact | Backend-neutral telemetry layer: resource/trace/span/breadcrumb/metric/event builders, traceparent+baggage headers, redacted JSON/log records, counter snapshots |
+| sentry | 650 | pure Osty + observability/http | Sentry DSN parsing, envelope/auth/header generation, event/exception/transaction payloads, HTTP request/send helpers, trace propagation |
 | net | 1084 | net 40 runtime | TCP/UDP, IPv4/IPv6, parseSocketAddr, tcpListen |
 | fmt | 926 | (surface heavy) | graphem-aware width, format spec engine |
 | json | 662 | (parser self) | generic encode<T> / decode<T>, UTF-8 / surrogate pair, value constructors |
@@ -104,7 +106,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | time | 89 | (검색 필요) | Duration / Instant / Zone / Weekday / ZonedTime |
 | testing | 88 | test 5 + bench 7 | assert + benchmark + snapshot + property runner entrypoints |
 | testing_gen | 168 | test property lowering + runtime | property generators: int/intRange/bool/float/char/byte/asciiString/list/listOfSize/option/result/pair/triple/oneOf/oneOfGens/map/filter/constant |
-| log | 85 | — | Level + Handler + TextHandler / JsonHandler — slog 동급 |
+| log | 133 | — | Level + Handler + TextHandler / JsonHandler + value/level constructors — slog 동급 |
 | regex | 74 | — | compile / matches / find / findAll / replace / split |
 | os | 71 | shim + runtime | exec / execShell / execWith / execShellWith / exit / pid / hostname / onSignal |
 | thread | 59 | thread 16 + chan 10 + select 22 | spawn / race / chan / select / cancel — 구조적 동시성 |
@@ -120,7 +122,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (6 / 93 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (6 / 95 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -138,7 +140,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase`, `observability`, `sentry` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode`, `keychain Linux Secret Service` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -161,6 +163,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | Regex 매칭 | ✅ 가능 | regex (compile / find / replace / split) |
 | Property-based testing | ✅ 가능 | testing (Gen<T> / property / propertySeeded) |
 | Structured logging | ✅ 가능 | log (Handler / TextHandler / JsonHandler) |
+| Error reporting / tracing / performance monitoring | ✅ 가능 | observability + sentry + http/log/metrics/redact (trace headers, breadcrumbs, transactions, Sentry envelopes) |
 | 동시성 (구조적) | ✅ 가능 | thread (spawn / race / chan / select / cancel) |
 | 예약 작업 / 재시도 | ✅ 가능 | schedule (cron / interval / daily / due tick / retry backoff) |
 | HTML 템플릿 | ✅ 가능 | template (escaped/raw placeholder render) |
@@ -224,7 +227,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 66 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, supabase, template, i18n, char, iter, bytes)
+- 69 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - keychain/secrets 는 macOS/Windows Phase A+B 연결 완료, Linux Secret Service backend 대기
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)

--- a/internal/backend/stdlib_observability_sentry_check_test.go
+++ b/internal/backend/stdlib_observability_sentry_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultObservabilityAndSentry(t *testing.T) {
+	reg := stdlib.LoadCached()
+	for _, module := range []string{"observability", "sentry"} {
+		t.Run(module, func(t *testing.T) {
+			chk := stdlibCheckResult(reg, module)
+			if chk == nil {
+				t.Fatalf("stdlibCheckResult(%s) = nil, want non-nil *check.Result", module)
+			}
+			var errs []string
+			for _, d := range chk.Diags {
+				if d != nil && strings.Contains(d.Error(), "error") {
+					msg := d.Error()
+					if len(d.Notes) > 0 {
+						msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+					}
+					errs = append(errs, msg)
+				}
+			}
+			if len(errs) > 0 {
+				t.Fatalf("%s module check produced %d error diagnostic(s):\n%s",
+					module, len(errs), strings.Join(errs, "\n"))
+			}
+		})
+	}
+}

--- a/internal/stdlib/modules/http.osty
+++ b/internal/stdlib/modules/http.osty
@@ -68,6 +68,26 @@ pub enum Method {
     }
 }
 
+pub fn getMethod() -> Method {
+    Get
+}
+
+pub fn postMethod() -> Method {
+    Post
+}
+
+pub fn putMethod() -> Method {
+    Put
+}
+
+pub fn patchMethod() -> Method {
+    Patch
+}
+
+pub fn deleteMethod() -> Method {
+    Delete
+}
+
 pub enum SameSite {
     Strict,
     Lax,

--- a/internal/stdlib/modules/log.osty
+++ b/internal/stdlib/modules/log.osty
@@ -54,6 +54,54 @@ pub fn fields() -> Fields {
     {:}
 }
 
+pub fn debugLevel() -> Level {
+    Debug
+}
+
+pub fn infoLevel() -> Level {
+    Info
+}
+
+pub fn warnLevel() -> Level {
+    Warn
+}
+
+pub fn errorLevel() -> Level {
+    Error
+}
+
+pub fn nullValue() -> LogValue {
+    Null
+}
+
+pub fn boolValue(value: Bool) -> LogValue {
+    Bool(value)
+}
+
+pub fn intValue(value: Int) -> LogValue {
+    Int(value)
+}
+
+pub fn floatValue(value: Float) -> LogValue {
+    Float(value)
+}
+
+pub fn stringValue(value: String) -> LogValue {
+    String(value)
+}
+
+pub fn bytesValue(value: Bytes) -> LogValue {
+    Bytes(value)
+}
+
+pub fn listValue(value: LogValueList) -> LogValue {
+    List(value)
+}
+
+pub fn mapValue(value: Fields) -> LogValue {
+    Map(value)
+}
+
 fn write(level: String, msg: String, fields: Fields) {
     println(msg)
 }

--- a/internal/stdlib/modules/observability.osty
+++ b/internal/stdlib/modules/observability.osty
@@ -1,0 +1,602 @@
+// std.observability - errors, traces, breadcrumbs, and performance events.
+//
+// The module is intentionally backend-neutral. It builds normalized telemetry
+// records that can be logged, counted, serialized as JSON, or handed to a
+// vendor adapter such as std.sentry.
+
+use std.error
+use std.json
+use std.log
+use std.metrics
+use std.redact
+use std.strings
+
+pub type Attributes = Map<String, json.Json>
+pub type Tags = Map<String, String>
+
+pub enum Severity {
+    DebugSeverity,
+    InfoSeverity,
+    WarningSeverity,
+    ErrorSeverity,
+    FatalSeverity,
+
+    pub fn toString(self) -> String {
+        match self {
+            DebugSeverity   -> "debug",
+            InfoSeverity    -> "info",
+            WarningSeverity -> "warning",
+            ErrorSeverity   -> "error",
+            FatalSeverity   -> "fatal",
+        }
+    }
+
+    pub fn toLogLevel(self) -> log.Level {
+        match self {
+            DebugSeverity   -> log.debugLevel(),
+            InfoSeverity    -> log.infoLevel(),
+            WarningSeverity -> log.warnLevel(),
+            ErrorSeverity   -> log.errorLevel(),
+            FatalSeverity   -> log.errorLevel(),
+        }
+    }
+}
+
+pub enum SignalKind {
+    MessageSignal,
+    ErrorSignal,
+    SpanSignal,
+    MetricSignal,
+    BreadcrumbSignal,
+
+    pub fn toString(self) -> String {
+        match self {
+            MessageSignal    -> "message",
+            ErrorSignal      -> "error",
+            SpanSignal       -> "span",
+            MetricSignal     -> "metric",
+            BreadcrumbSignal -> "breadcrumb",
+        }
+    }
+}
+
+pub enum SpanStatus {
+    StatusUnset,
+    StatusOk,
+    StatusError,
+    StatusCancelled,
+    StatusDeadlineExceeded,
+    StatusNotFound,
+    StatusPermissionDenied,
+    StatusResourceExhausted,
+    StatusUnavailable,
+
+    pub fn toString(self) -> String {
+        match self {
+            StatusUnset             -> "unset",
+            StatusOk                -> "ok",
+            StatusError             -> "error",
+            StatusCancelled         -> "cancelled",
+            StatusDeadlineExceeded  -> "deadline_exceeded",
+            StatusNotFound          -> "not_found",
+            StatusPermissionDenied  -> "permission_denied",
+            StatusResourceExhausted -> "resource_exhausted",
+            StatusUnavailable       -> "unavailable",
+        }
+    }
+}
+
+pub struct Resource {
+    pub serviceName: String,
+    pub serviceVersion: String = "",
+    pub environment: String = "",
+    pub release: String = "",
+    pub instanceId: String = "",
+    pub attributes: Attributes = {:},
+
+    pub fn withVersion(mut self, version: String) -> Resource {
+        self.serviceVersion = strings.trimSpace(version)
+        self
+    }
+
+    pub fn withEnvironment(mut self, environment: String) -> Resource {
+        self.environment = strings.trimSpace(environment)
+        self
+    }
+
+    pub fn withRelease(mut self, release: String) -> Resource {
+        self.release = strings.trimSpace(release)
+        self
+    }
+
+    pub fn withInstance(mut self, instanceId: String) -> Resource {
+        self.instanceId = strings.trimSpace(instanceId)
+        self
+    }
+
+    pub fn withAttribute(mut self, key: String, value: json.Json) -> Resource {
+        self.attributes.insert(cleanKey(key), value)
+        self
+    }
+}
+
+pub struct TraceContext {
+    pub traceId: String,
+    pub spanId: String,
+    pub parentSpanId: String = "",
+    pub sampled: Bool = true,
+    pub baggage: Tags = {:},
+
+    pub fn child(mut self, spanId: String) -> TraceContext {
+        self.parentSpanId = self.spanId
+        self.spanId = strings.trimSpace(spanId)
+        self
+    }
+
+    pub fn withSampled(mut self, sampled: Bool) -> TraceContext {
+        self.sampled = sampled
+        self
+    }
+
+    pub fn withBaggage(mut self, key: String, value: String) -> TraceContext {
+        self.baggage.insert(cleanKey(key), strings.trimSpace(value))
+        self
+    }
+}
+
+pub struct Span {
+    pub name: String,
+    pub op: String = "",
+    pub description: String = "",
+    pub trace: TraceContext,
+    pub status: SpanStatus,
+    pub startUnixMs: Int = 0,
+    pub endUnixMs: Int = 0,
+    pub durationMs: Int = 0,
+    pub attributes: Attributes = {:},
+
+    pub fn withDescription(mut self, description: String) -> Span {
+        self.description = strings.trimSpace(description)
+        self
+    }
+
+    pub fn withStatus(mut self, status: SpanStatus) -> Span {
+        self.status = status
+        self
+    }
+
+    pub fn withAttribute(mut self, key: String, value: json.Json) -> Span {
+        self.attributes.insert(cleanKey(key), value)
+        self
+    }
+
+    pub fn finish(mut self, endUnixMs: Int, status: SpanStatus) -> Span {
+        finishSpan(self, endUnixMs, status)
+    }
+}
+
+pub struct Breadcrumb {
+    pub category: String,
+    pub message: String,
+    pub level: Severity,
+    pub timestampUnixMs: Int = 0,
+    pub data: Attributes = {:},
+}
+
+pub struct Metric {
+    pub name: String,
+    pub value: Float,
+    pub unit: String = "",
+    pub timestampUnixMs: Int = 0,
+    pub tags: Tags = {:},
+}
+
+pub struct Event {
+    pub kind: SignalKind,
+    pub level: Severity,
+    pub message: String,
+    pub errorMessage: String = "",
+    pub errorChain: List<String> = [],
+    pub fingerprint: List<String> = [],
+    pub resource: Resource,
+    pub trace: TraceContext? = None,
+    pub span: Span? = None,
+    pub attributes: Attributes = {:},
+    pub tags: Tags = {:},
+    pub breadcrumbs: List<Breadcrumb> = [],
+    pub metrics: List<Metric> = [],
+    pub timestampUnixMs: Int = 0,
+
+    pub fn withTrace(mut self, trace: TraceContext) -> Event {
+        self.trace = Some(trace)
+        self
+    }
+
+    pub fn withSpan(mut self, span: Span) -> Event {
+        self.trace = Some(span.trace)
+        self.span = Some(span)
+        self
+    }
+
+    pub fn withAttribute(mut self, key: String, value: json.Json) -> Event {
+        self.attributes.insert(cleanKey(key), value)
+        self
+    }
+
+    pub fn withTag(mut self, key: String, value: String) -> Event {
+        self.tags.insert(cleanKey(key), strings.trimSpace(value))
+        self
+    }
+
+    pub fn withBreadcrumb(mut self, crumb: Breadcrumb) -> Event {
+        self.breadcrumbs.push(crumb)
+        self
+    }
+
+    pub fn withMetric(mut self, metric: Metric) -> Event {
+        self.metrics.push(metric)
+        self
+    }
+
+    pub fn redacted(mut self) -> Event {
+        self.message = redact.redact(self.message)
+        self.errorMessage = redact.redact(self.errorMessage)
+        let mut chain: List<String> = []
+        for item in self.errorChain {
+            chain.push(redact.redact(item))
+        }
+        self.errorChain = chain
+        self
+    }
+}
+
+pub fn resource(serviceName: String) -> Resource {
+    Resource { serviceName: strings.trimSpace(serviceName) }
+}
+
+pub fn defaultResource() -> Resource {
+    resource("osty-app")
+}
+
+pub fn attributes() -> Attributes {
+    {:}
+}
+
+pub fn tags() -> Tags {
+    {:}
+}
+
+pub fn attrString(value: String) -> json.Json {
+    json.string(value)
+}
+
+pub fn attrInt(value: Int) -> json.Json {
+    json.int(value)
+}
+
+pub fn attrFloat(value: Float) -> json.Json {
+    json.number(value)
+}
+
+pub fn attrBool(value: Bool) -> json.Json {
+    json.bool(value)
+}
+
+pub fn traceContext(traceId: String, spanId: String) -> TraceContext {
+    TraceContext {
+        traceId: strings.trimSpace(traceId),
+        spanId: strings.trimSpace(spanId),
+    }
+}
+
+pub fn childTrace(parent: TraceContext, spanId: String) -> TraceContext {
+    parent.child(spanId)
+}
+
+pub fn traceparent(trace: TraceContext) -> String {
+    let sampled = if trace.sampled { "01" } else { "00" }
+    "00-{strings.trimSpace(trace.traceId)}-{strings.trimSpace(trace.spanId)}-{sampled}"
+}
+
+pub fn baggage(trace: TraceContext) -> String {
+    let keys = trace.baggage.keys().sorted()
+    let mut pairs: List<String> = []
+    for key in keys {
+        pairs.push("{key}={trace.baggage.get(key).unwrap()}")
+    }
+    strings.join(pairs, ",")
+}
+
+pub fn traceHeaders(trace: TraceContext) -> Map<String, String> {
+    let mut out: Map<String, String> = {:}
+    out.insert("traceparent", traceparent(trace))
+    let bag = baggage(trace)
+    if !bag.isEmpty() {
+        out.insert("baggage", bag)
+    }
+    out
+}
+
+pub fn startSpan(name: String, op: String, trace: TraceContext, startUnixMs: Int) -> Span {
+    Span {
+        name: strings.trimSpace(name),
+        op: strings.trimSpace(op),
+        trace: trace,
+        status: StatusUnset,
+        startUnixMs: startUnixMs,
+    }
+}
+
+pub fn finishSpan(mut span: Span, endUnixMs: Int, status: SpanStatus) -> Span {
+    span.endUnixMs = endUnixMs
+    span.status = status
+    if endUnixMs >= span.startUnixMs {
+        span.durationMs = endUnixMs - span.startUnixMs
+    }
+    span
+}
+
+pub fn breadcrumb(category: String, message: String, level: Severity) -> Breadcrumb {
+    Breadcrumb {
+        category: strings.trimSpace(category),
+        message: message,
+        level: level,
+    }
+}
+
+pub fn metric(name: String, value: Float, unit: String) -> Metric {
+    Metric {
+        name: cleanKey(name),
+        value: value,
+        unit: strings.trimSpace(unit),
+    }
+}
+
+pub fn metricFromSample(sample: metrics.Sample) -> Metric {
+    let mut tagMap: Tags = {:}
+    let mut i = 0
+    for i < sample.labels.len() {
+        tagMap.insert("label{i.toString()}", sample.labels[i])
+        i = i + 1
+    }
+    Metric {
+        name: sample.key,
+        value: sample.value.toFloat(),
+        unit: "count",
+        tags: tagMap,
+    }
+}
+
+pub fn counterMetrics(counter: metrics.Counter) -> List<Metric> {
+    let mut out: List<Metric> = []
+    for sample in metrics.snapshot(counter) {
+        out.push(metricFromSample(sample))
+    }
+    out
+}
+
+pub fn messageEvent(message: String, level: Severity, res: Resource) -> Event {
+    Event {
+        kind: MessageSignal,
+        level: level,
+        message: message,
+        resource: res,
+    }
+}
+
+pub fn errorEvent(err: Error, res: Resource) -> Event {
+    let chain = errorChain(err)
+    Event {
+        kind: ErrorSignal,
+        level: ErrorSeverity,
+        message: err.message(),
+        errorMessage: err.message(),
+        errorChain: chain,
+        resource: res,
+    }
+}
+
+pub fn spanEvent(span: Span, res: Resource) -> Event {
+    Event {
+        kind: SpanSignal,
+        level: if span.status == StatusError { ErrorSeverity } else { InfoSeverity },
+        message: span.name,
+        resource: res,
+        trace: Some(span.trace),
+        span: Some(span),
+    }
+}
+
+pub fn metricEvent(metric: Metric, res: Resource) -> Event {
+    Event {
+        kind: MetricSignal,
+        level: InfoSeverity,
+        message: metric.name,
+        resource: res,
+        metrics: [metric],
+    }
+}
+
+pub fn logRecord(event: Event) -> log.Record {
+    let mut fields = log.fields()
+    fields.insert("kind", log.stringValue(event.kind.toString()))
+    fields.insert("service", log.stringValue(event.resource.serviceName))
+    fields.insert("level", log.stringValue(event.level.toString()))
+    match event.trace {
+        Some(trace) -> {
+            fields.insert("trace_id", log.stringValue(trace.traceId))
+            fields.insert("span_id", log.stringValue(trace.spanId))
+        },
+        None -> {},
+    }
+    log.Record {
+        level: event.level.toLogLevel(),
+        message: event.message,
+        fields: fields,
+    }
+}
+
+pub fn eventJson(event: Event) -> String {
+    let mut props: List<String> = [
+        prop("kind", quote(event.kind.toString())),
+        prop("level", quote(event.level.toString())),
+        prop("message", quote(redact.redact(event.message))),
+        prop("resource", resourceJson(event.resource)),
+        prop("attributes", attrsJson(event.attributes)),
+        prop("tags", tagsJson(event.tags)),
+        prop("breadcrumbs", breadcrumbsJson(event.breadcrumbs)),
+        prop("metrics", metricsJson(event.metrics)),
+    ]
+    if !event.errorMessage.isEmpty() {
+        props.push(prop("error_message", quote(redact.redact(event.errorMessage))))
+        props.push(prop("error_chain", stringArrayJson(redactList(event.errorChain))))
+    }
+    if !event.fingerprint.isEmpty() {
+        props.push(prop("fingerprint", stringArrayJson(event.fingerprint)))
+    }
+    if event.timestampUnixMs > 0 {
+        props.push(prop("timestamp_unix_ms", event.timestampUnixMs.toString()))
+    }
+    match event.trace {
+        Some(trace) -> props.push(prop("trace", traceJson(trace))),
+        None        -> {},
+    }
+    match event.span {
+        Some(span) -> props.push(prop("span", spanJson(span))),
+        None       -> {},
+    }
+    object(props)
+}
+
+pub fn spanJson(span: Span) -> String {
+    object([
+        prop("name", quote(span.name)),
+        prop("op", quote(span.op)),
+        prop("description", quote(span.description)),
+        prop("status", quote(span.status.toString())),
+        prop("start_unix_ms", span.startUnixMs.toString()),
+        prop("end_unix_ms", span.endUnixMs.toString()),
+        prop("duration_ms", span.durationMs.toString()),
+        prop("trace", traceJson(span.trace)),
+        prop("attributes", attrsJson(span.attributes)),
+    ])
+}
+
+pub fn traceJson(trace: TraceContext) -> String {
+    object([
+        prop("trace_id", quote(trace.traceId)),
+        prop("span_id", quote(trace.spanId)),
+        prop("parent_span_id", quote(trace.parentSpanId)),
+        prop("sampled", if trace.sampled { "true" } else { "false" }),
+        prop("baggage", tagsJson(trace.baggage)),
+    ])
+}
+
+pub fn attrsJson(attrs: Attributes) -> String {
+    let keys = attrs.keys().sorted()
+    let mut props: List<String> = []
+    for key in keys {
+        props.push(prop(key, json.stringifyValue(attrs.get(key).unwrap())))
+    }
+    object(props)
+}
+
+pub fn tagsJson(tagMap: Tags) -> String {
+    let keys = tagMap.keys().sorted()
+    let mut props: List<String> = []
+    for key in keys {
+        props.push(prop(key, quote(tagMap.get(key).unwrap())))
+    }
+    object(props)
+}
+
+fn resourceJson(res: Resource) -> String {
+    object([
+        prop("service_name", quote(res.serviceName)),
+        prop("service_version", quote(res.serviceVersion)),
+        prop("environment", quote(res.environment)),
+        prop("release", quote(res.release)),
+        prop("instance_id", quote(res.instanceId)),
+        prop("attributes", attrsJson(res.attributes)),
+    ])
+}
+
+fn breadcrumbsJson(items: List<Breadcrumb>) -> String {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(object([
+            prop("category", quote(item.category)),
+            prop("message", quote(redact.redact(item.message))),
+            prop("level", quote(item.level.toString())),
+            prop("timestamp_unix_ms", item.timestampUnixMs.toString()),
+            prop("data", attrsJson(item.data)),
+        ]))
+    }
+    array(out)
+}
+
+fn metricsJson(items: List<Metric>) -> String {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(object([
+            prop("name", quote(item.name)),
+            prop("value", item.value.toString()),
+            prop("unit", quote(item.unit)),
+            prop("timestamp_unix_ms", item.timestampUnixMs.toString()),
+            prop("tags", tagsJson(item.tags)),
+        ]))
+    }
+    array(out)
+}
+
+fn errorChain(err: Error) -> List<String> {
+    let mut out: List<String> = []
+    for item in err.chain() {
+        out.push(item.message())
+    }
+    out
+}
+
+fn redactList(items: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(redact.redact(item))
+    }
+    out
+}
+
+fn cleanKey(key: String) -> String {
+    let clean = strings.trimSpace(key)
+    if clean.isEmpty() {
+        return "unknown"
+    }
+    strings.replaceAll(strings.replaceAll(clean, " ", "_"), "\n", "_")
+}
+
+fn stringArrayJson(items: List<String>) -> String {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(quote(item))
+    }
+    array(out)
+}
+
+fn object(props: List<String>) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let sep = ","
+    "{open}{strings.join(props, sep)}{close}"
+}
+
+fn array(items: List<String>) -> String {
+    let sep = ","
+    "[{strings.join(items, sep)}]"
+}
+
+fn prop(name: String, value: String) -> String {
+    "{quote(name)}:{value}"
+}
+
+fn quote(text: String) -> String {
+    json.stringifyValue(json.string(text))
+}

--- a/internal/stdlib/modules/sentry.osty
+++ b/internal/stdlib/modules/sentry.osty
@@ -1,0 +1,650 @@
+// std.sentry - Sentry envelope and HTTP request helpers.
+//
+// This module sits on std.observability and std.http. It parses DSNs, builds
+// Sentry-compatible event/transaction payloads, serializes envelopes, and can
+// hand the final request to std.http.request. The transport remains explicit.
+
+use std.error
+use std.http
+use std.json
+use std.observability
+use std.redact
+use std.strings
+use std.time
+use std.uuid
+
+pub type Attributes = observability.Attributes
+pub type Tags = observability.Tags
+pub type Headers = http.Headers
+
+pub let SDK_NAME: String = "osty.std.sentry"
+pub let SDK_VERSION: String = "0.1.0"
+pub let SENTRY_VERSION: String = "7"
+
+pub struct Dsn {
+    pub raw: String,
+    pub scheme: String,
+    pub publicKey: String,
+    pub secretKey: String = "",
+    pub authority: String,
+    pub pathPrefix: String = "",
+    pub projectId: String,
+
+    pub fn baseUrl(self) -> String {
+        if self.pathPrefix.isEmpty() {
+            return "{self.scheme}://{self.authority}"
+        }
+        "{self.scheme}://{self.authority}{self.pathPrefix}"
+    }
+
+    pub fn envelopeUrl(self) -> String {
+        "{self.baseUrl()}/api/{self.projectId}/envelope/"
+    }
+}
+
+pub struct Client {
+    pub dsn: Dsn,
+    pub environment: String = "",
+    pub release: String = "",
+    pub serverName: String = "",
+    pub sampleRate: Float = 1.0,
+    pub tracesSampleRate: Float = 0.0,
+    pub sendDefaultPii: Bool = false,
+    pub extraHeaders: Headers = {:},
+
+    pub fn withEnvironment(mut self, environment: String) -> Client {
+        self.environment = strings.trimSpace(environment)
+        self
+    }
+
+    pub fn withRelease(mut self, release: String) -> Client {
+        self.release = strings.trimSpace(release)
+        self
+    }
+
+    pub fn withServerName(mut self, serverName: String) -> Client {
+        self.serverName = strings.trimSpace(serverName)
+        self
+    }
+
+    pub fn withSampleRate(mut self, sampleRate: Float) -> Client {
+        self.sampleRate = clampFloat(sampleRate, 0.0, 1.0)
+        self
+    }
+
+    pub fn withTracesSampleRate(mut self, sampleRate: Float) -> Client {
+        self.tracesSampleRate = clampFloat(sampleRate, 0.0, 1.0)
+        self
+    }
+
+    pub fn withSendDefaultPii(mut self, enabled: Bool) -> Client {
+        self.sendDefaultPii = enabled
+        self
+    }
+
+    pub fn withHeader(mut self, name: String, value: String) -> Client {
+        self.extraHeaders.insert(strings.trimSpace(name), value)
+        self
+    }
+}
+
+pub struct User {
+    pub id: String = "",
+    pub username: String = "",
+    pub email: String = "",
+    pub ipAddress: String = "",
+}
+
+pub struct Scope {
+    pub user: User? = None,
+    pub tags: Tags = {:},
+    pub extra: Attributes = {:},
+    pub contexts: Attributes = {:},
+    pub breadcrumbs: List<observability.Breadcrumb> = [],
+    pub fingerprint: List<String> = [],
+
+    pub fn withUser(mut self, user: User) -> Scope {
+        self.user = Some(user)
+        self
+    }
+
+    pub fn withTag(mut self, key: String, value: String) -> Scope {
+        self.tags.insert(cleanKey(key), strings.trimSpace(value))
+        self
+    }
+
+    pub fn withExtra(mut self, key: String, value: json.Json) -> Scope {
+        self.extra.insert(cleanKey(key), value)
+        self
+    }
+
+    pub fn withContext(mut self, key: String, value: json.Json) -> Scope {
+        self.contexts.insert(cleanKey(key), value)
+        self
+    }
+
+    pub fn withBreadcrumb(mut self, crumb: observability.Breadcrumb) -> Scope {
+        self.breadcrumbs.push(crumb)
+        self
+    }
+
+    pub fn withFingerprint(mut self, value: String) -> Scope {
+        self.fingerprint.push(strings.trimSpace(value))
+        self
+    }
+}
+
+pub struct CaptureOptions {
+    pub eventId: String = "",
+    pub timestamp: String = "",
+    pub handled: Bool = true,
+    pub mechanism: String = "generic",
+    pub scope: Scope,
+
+    pub fn withEventId(mut self, eventId: String) -> CaptureOptions {
+        self.eventId = eventId
+        self
+    }
+
+    pub fn withTimestampIfEmpty(mut self, timestamp: String) -> CaptureOptions {
+        if strings.trimSpace(self.timestamp).isEmpty() {
+            self.timestamp = strings.trimSpace(timestamp)
+        }
+        self
+    }
+}
+
+pub fn parseDsn(raw: String) -> Result<Dsn, Error> {
+    let text = strings.trimSpace(raw)
+    if text.isEmpty() {
+        return Err(error.new("sentry: DSN is empty"))
+    }
+    let (scheme, rest) = splitScheme(text)?
+    if scheme != "https" && scheme != "http" {
+        return Err(error.new("sentry: DSN scheme must be http or https"))
+    }
+    let atOpt = strings.indexOf(rest, "@")
+    if atOpt.isNone() {
+        return Err(error.new("sentry: DSN missing public key"))
+    }
+    let at = atOpt.unwrap()
+    let userinfo = strings.slice(rest, 0, at)
+    let afterAt = strings.slice(rest, at + 1, rest.len())
+    let (publicKey, secretKey) = splitUserinfo(userinfo)?
+    let (authority, path) = splitAuthorityPath(afterAt)?
+    let (prefix, projectId) = splitProjectPath(path)?
+    Ok(Dsn {
+        raw: text,
+        scheme: scheme,
+        publicKey: publicKey,
+        secretKey: secretKey,
+        authority: authority,
+        pathPrefix: prefix,
+        projectId: projectId,
+    })
+}
+
+pub fn client(rawDsn: String) -> Result<Client, Error> {
+    Ok(Client { dsn: parseDsn(rawDsn)? })
+}
+
+pub fn scope() -> Scope {
+    Scope {}
+}
+
+pub fn options() -> CaptureOptions {
+    CaptureOptions { scope: Scope {} }
+}
+
+pub fn user(id: String, username: String, email: String) -> User {
+    User {
+        id: strings.trimSpace(id),
+        username: strings.trimSpace(username),
+        email: strings.trimSpace(email),
+    }
+}
+
+pub fn endpointUrl(client: Client) -> String {
+    client.dsn.envelopeUrl()
+}
+
+pub fn sentryTraceHeader(trace: observability.TraceContext) -> String {
+    let sampled = if trace.sampled { "1" } else { "0" }
+    "{trace.traceId}-{trace.spanId}-{sampled}"
+}
+
+pub fn traceHeaders(trace: observability.TraceContext) -> Headers {
+    let mut out: Headers = {:}
+    out.insert("sentry-trace", sentryTraceHeader(trace))
+    let bag = observability.baggage(trace)
+    if !bag.isEmpty() {
+        out.insert("baggage", bag)
+    }
+    out
+}
+
+pub fn authHeader(client: Client) -> String {
+    let mut parts: List<String> = [
+        "sentry_version={SENTRY_VERSION}",
+        "sentry_client={SDK_NAME}/{SDK_VERSION}",
+        "sentry_key={client.dsn.publicKey}",
+    ]
+    if !client.dsn.secretKey.isEmpty() {
+        parts.push("sentry_secret={client.dsn.secretKey}")
+    }
+    let sep = ", "
+    "Sentry {strings.join(parts, sep)}"
+}
+
+pub fn headers(client: Client) -> Headers {
+    let mut out: Headers = {:}
+    out.insert("Content-Type", "application/x-sentry-envelope")
+    out.insert("User-Agent", "{SDK_NAME}/{SDK_VERSION}")
+    out.insert("X-Sentry-Auth", authHeader(client))
+    for (name, value) in client.extraHeaders {
+        out.insert(name, value)
+    }
+    out
+}
+
+pub fn captureMessageHttpRequest(client: Client, message: String, level: observability.Severity) -> http.Request {
+    eventHttpRequest(client, observability.messageEvent(message, level, observability.defaultResource()), options())
+}
+
+pub fn captureExceptionHttpRequest(client: Client, err: Error, opts: CaptureOptions) -> http.Request {
+    eventHttpRequest(client, observability.errorEvent(err, observability.defaultResource()), opts)
+}
+
+pub fn captureEventHttpRequest(client: Client, event: observability.Event, opts: CaptureOptions) -> http.Request {
+    eventHttpRequest(client, event, opts)
+}
+
+pub fn captureTransactionHttpRequest(client: Client, span: observability.Span, opts: CaptureOptions) -> http.Request {
+    transactionHttpRequest(client, span, opts)
+}
+
+pub fn captureMessage(client: Client, message: String, level: observability.Severity) -> Result<http.Response, Error> {
+    http.request(captureMessageHttpRequest(client, message, level))
+}
+
+pub fn captureException(client: Client, err: Error, opts: CaptureOptions) -> Result<http.Response, Error> {
+    http.request(captureExceptionHttpRequest(client, err, opts))
+}
+
+pub fn captureEvent(client: Client, event: observability.Event, opts: CaptureOptions) -> Result<http.Response, Error> {
+    http.request(captureEventHttpRequest(client, event, opts))
+}
+
+pub fn captureTransaction(client: Client, span: observability.Span, opts: CaptureOptions) -> Result<http.Response, Error> {
+    http.request(captureTransactionHttpRequest(client, span, opts))
+}
+
+pub fn eventPayload(client: Client, event: observability.Event, opts: CaptureOptions) -> String {
+    let eventId = eventIdOrNew(opts.eventId)
+    let mergedScope = mergeScope(event, opts.scope)
+    let mut props: List<String> = [
+        prop("event_id", quote(eventId)),
+        prop("platform", quote("osty")),
+        prop("level", quote(event.level.toString())),
+        prop("message", quote(redact.redact(event.message))),
+        prop("environment", quote(client.environment)),
+        prop("release", quote(client.release)),
+        prop("server_name", quote(client.serverName)),
+        prop("sdk", sdkJson()),
+        prop("tags", observability.tagsJson(mergedScope.tags)),
+        prop("extra", observability.attrsJson(mergedScope.extra)),
+        prop("breadcrumbs", sentryBreadcrumbsJson(mergedScope.breadcrumbs)),
+        prop("contexts", contextsJson(client, event, mergedScope)),
+        prop("fingerprint", stringArrayJson(mergedScope.fingerprint)),
+    ]
+    if !opts.timestamp.isEmpty() {
+        props.push(prop("timestamp", quote(opts.timestamp)))
+    }
+    if event.kind.toString() == "error" {
+        props.push(prop("exception", exceptionJson(event, opts)))
+    }
+    match mergedScope.user {
+        Some(u) -> {
+            if client.sendDefaultPii {
+                props.push(prop("user", userJson(u)))
+            }
+        },
+        None -> {},
+    }
+    object(props)
+}
+
+pub fn transactionPayload(client: Client, span: observability.Span, opts: CaptureOptions) -> String {
+    let eventId = eventIdOrNew(opts.eventId)
+    let event = observability.spanEvent(span, observability.defaultResource())
+    let mergedScope = mergeScope(event, opts.scope)
+    let mut props: List<String> = [
+        prop("event_id", quote(eventId)),
+        prop("type", quote("transaction")),
+        prop("transaction", quote(span.name)),
+        prop("platform", quote("osty")),
+        prop("level", quote("info")),
+        prop("environment", quote(client.environment)),
+        prop("release", quote(client.release)),
+        prop("server_name", quote(client.serverName)),
+        prop("sdk", sdkJson()),
+        prop("contexts", contextsJson(client, event, mergedScope)),
+        prop("tags", observability.tagsJson(mergedScope.tags)),
+        prop("extra", observability.attrsJson(mergedScope.extra)),
+        prop("measurements", measurementsJson(event.metrics)),
+    ]
+    if !opts.timestamp.isEmpty() {
+        props.push(prop("timestamp", quote(opts.timestamp)))
+    }
+    if span.startUnixMs > 0 {
+        props.push(prop("start_timestamp", unixMsToSeconds(span.startUnixMs)))
+    }
+    object(props)
+}
+
+pub fn envelopeForEvent(client: Client, event: observability.Event, opts: CaptureOptions) -> String {
+    let eventId = eventIdOrNew(opts.eventId)
+    let payload = eventPayload(client, event, opts.withEventId(eventId))
+    envelope(client, eventId, "event", payload, opts.timestamp)
+}
+
+pub fn envelopeForTransaction(client: Client, span: observability.Span, opts: CaptureOptions) -> String {
+    let eventId = eventIdOrNew(opts.eventId)
+    let payload = transactionPayload(client, span, opts.withEventId(eventId))
+    envelope(client, eventId, "transaction", payload, opts.timestamp)
+}
+
+pub fn envelope(client: Client, eventId: String, itemType: String, payload: String, sentAt: String) -> String {
+    let header = envelopeHeader(client, eventId, sentAt)
+    let item = envelopeItem(itemType, payload)
+    "{header}\n{item}\n"
+}
+
+pub fn envelopeHeader(client: Client, eventId: String, sentAt: String) -> String {
+    let mut props: List<String> = [
+        prop("event_id", quote(eventId)),
+        prop("dsn", quote(client.dsn.raw)),
+        prop("sdk", sdkJson()),
+    ]
+    if !sentAt.isEmpty() {
+        props.push(prop("sent_at", quote(sentAt)))
+    }
+    object(props)
+}
+
+pub fn envelopeItem(itemType: String, payload: String) -> String {
+    let header = object([
+        prop("type", quote(itemType)),
+        prop("length", payload.bytes().len().toString()),
+        prop("content_type", quote("application/json")),
+    ])
+    "{header}\n{payload}"
+}
+
+pub fn eventHttpRequest(client: Client, event: observability.Event, opts: CaptureOptions) -> http.Request {
+    let eventId = eventIdOrNew(opts.eventId)
+    let nextOpts = opts.withEventId(eventId).withTimestampIfEmpty(sentAtNow())
+    let body = envelopeForEvent(client, event, nextOpts)
+    http.newRequest(http.postMethod(), endpointUrl(client))
+        .withHeaders(headers(client))
+        .withText(body)
+        .withContentType("application/x-sentry-envelope")
+}
+
+pub fn transactionHttpRequest(client: Client, span: observability.Span, opts: CaptureOptions) -> http.Request {
+    let eventId = eventIdOrNew(opts.eventId)
+    let nextOpts = opts.withEventId(eventId).withTimestampIfEmpty(sentAtNow())
+    let body = envelopeForTransaction(client, span, nextOpts)
+    http.newRequest(http.postMethod(), endpointUrl(client))
+        .withHeaders(headers(client))
+        .withText(body)
+        .withContentType("application/x-sentry-envelope")
+}
+
+pub fn sentAtNow() -> String {
+    time.now().format(time.RFC_3339)
+}
+
+pub fn isSampled(sampleRate: Float, n: Float) -> Bool {
+    n >= 0.0 && n <= clampFloat(sampleRate, 0.0, 1.0)
+}
+
+pub fn disabledClient(rawDsn: String) -> Result<Client, Error> {
+    let c = client(rawDsn)?
+    Ok(c.withSampleRate(0.0).withTracesSampleRate(0.0))
+}
+
+pub fn normalizeEventId(eventId: String) -> String {
+    let clean = strings.replaceAll(strings.trimSpace(eventId), "-", "")
+    if clean.isEmpty() {
+        return strings.replaceAll(uuid.v4().toString(), "-", "")
+    }
+    clean
+}
+
+pub fn eventIdOrNew(eventId: String) -> String {
+    normalizeEventId(eventId)
+}
+
+fn splitScheme(text: String) -> Result<(String, String), Error> {
+    match strings.indexOf(text, "://") {
+        Some(i) -> Ok((strings.toLower(strings.slice(text, 0, i)), strings.slice(text, i + 3, text.len()))),
+        None    -> Err(error.new("sentry: DSN missing scheme")),
+    }
+}
+
+fn splitUserinfo(userinfo: String) -> Result<(String, String), Error> {
+    if strings.trimSpace(userinfo).isEmpty() {
+        return Err(error.new("sentry: DSN public key is empty"))
+    }
+    match strings.indexOf(userinfo, ":") {
+        Some(i) -> {
+            let publicKey = strings.trimSpace(strings.slice(userinfo, 0, i))
+            if publicKey.isEmpty() {
+                return Err(error.new("sentry: DSN public key is empty"))
+            }
+            Ok((publicKey, strings.trimSpace(strings.slice(userinfo, i + 1, userinfo.len()))))
+        },
+        None -> Ok((strings.trimSpace(userinfo), "")),
+    }
+}
+
+fn splitAuthorityPath(text: String) -> Result<(String, String), Error> {
+    match strings.indexOf(text, "/") {
+        Some(i) -> {
+            let authority = strings.trimSpace(strings.slice(text, 0, i))
+            if authority.isEmpty() {
+                return Err(error.new("sentry: DSN host is empty"))
+            }
+            Ok((authority, strings.slice(text, i + 1, text.len())))
+        },
+        None -> Err(error.new("sentry: DSN missing project id")),
+    }
+}
+
+fn splitProjectPath(path: String) -> Result<(String, String), Error> {
+    let clean = strings.trimChars(strings.trimSpace(path), "/")
+    if clean.isEmpty() {
+        return Err(error.new("sentry: DSN project id is empty"))
+    }
+    let parts = strings.split(clean, "/")
+    let projectId = parts[parts.len() - 1]
+    if strings.trimSpace(projectId).isEmpty() {
+        return Err(error.new("sentry: DSN project id is empty"))
+    }
+    if parts.len() == 1 {
+        return Ok(("", projectId))
+    }
+    let mut prefixParts: List<String> = []
+    let mut i = 0
+    for i < parts.len() - 1 {
+        prefixParts.push(parts[i])
+        i = i + 1
+    }
+    let slash = "/"
+    Ok(("/{strings.join(prefixParts, slash)}", projectId))
+}
+
+fn mergeScope(event: observability.Event, scope: Scope) -> Scope {
+    let mut out = scope
+    for (key, value) in event.tags {
+        out.tags.insert(key, value)
+    }
+    for (key, value) in event.attributes {
+        out.extra.insert(key, value)
+    }
+    for crumb in event.breadcrumbs {
+        out.breadcrumbs.push(crumb)
+    }
+    for fp in event.fingerprint {
+        out.fingerprint.push(fp)
+    }
+    out
+}
+
+fn contextsJson(client: Client, event: observability.Event, scope: Scope) -> String {
+    let mut props: List<String> = [
+        prop("runtime", object([
+            prop("name", quote("osty")),
+            prop("sdk", quote("{SDK_NAME}/{SDK_VERSION}")),
+        ])),
+        prop("client", object([
+            prop("sample_rate", client.sampleRate.toString()),
+            prop("traces_sample_rate", client.tracesSampleRate.toString()),
+        ])),
+    ]
+    match event.trace {
+        Some(trace) -> props.push(prop("trace", sentryTraceContextJson(trace, event.span))),
+        None        -> {},
+    }
+    let keys = scope.contexts.keys().sorted()
+    for key in keys {
+        props.push(prop(key, json.stringifyValue(scope.contexts.get(key).unwrap())))
+    }
+    object(props)
+}
+
+fn sentryTraceContextJson(trace: observability.TraceContext, span: observability.Span?) -> String {
+    let mut props: List<String> = [
+        prop("trace_id", quote(trace.traceId)),
+        prop("span_id", quote(trace.spanId)),
+        prop("parent_span_id", quote(trace.parentSpanId)),
+        prop("sampled", if trace.sampled { "true" } else { "false" }),
+    ]
+    match span {
+        Some(s) -> {
+            props.push(prop("op", quote(s.op)))
+            props.push(prop("description", quote(s.description)))
+            props.push(prop("status", quote(s.status.toString())))
+        },
+        None -> {},
+    }
+    object(props)
+}
+
+fn exceptionJson(event: observability.Event, opts: CaptureOptions) -> String {
+    let chain = if event.errorChain.isEmpty() { [event.errorMessage] } else { event.errorChain }
+    let mut values: List<String> = []
+    for msg in chain {
+        values.push(object([
+            prop("type", quote("Error")),
+            prop("value", quote(redact.redact(msg))),
+            prop("mechanism", object([
+                prop("type", quote(opts.mechanism)),
+                prop("handled", if opts.handled { "true" } else { "false" }),
+            ])),
+        ]))
+    }
+    object([prop("values", array(values))])
+}
+
+fn sentryBreadcrumbsJson(items: List<observability.Breadcrumb>) -> String {
+    let mut values: List<String> = []
+    for item in items {
+        values.push(object([
+            prop("category", quote(item.category)),
+            prop("message", quote(redact.redact(item.message))),
+            prop("level", quote(item.level.toString())),
+            prop("timestamp", item.timestampUnixMs.toString()),
+            prop("data", observability.attrsJson(item.data)),
+        ]))
+    }
+    object([prop("values", array(values))])
+}
+
+fn measurementsJson(items: List<observability.Metric>) -> String {
+    let mut props: List<String> = []
+    for item in items {
+        props.push(prop(item.name, object([
+            prop("value", item.value.toString()),
+            prop("unit", quote(item.unit)),
+        ])))
+    }
+    object(props)
+}
+
+fn userJson(user: User) -> String {
+    object([
+        prop("id", quote(user.id)),
+        prop("username", quote(redact.redact(user.username))),
+        prop("email", quote(redact.redact(user.email))),
+        prop("ip_address", quote(user.ipAddress)),
+    ])
+}
+
+fn sdkJson() -> String {
+    object([
+        prop("name", quote(SDK_NAME)),
+        prop("version", quote(SDK_VERSION)),
+    ])
+}
+
+fn unixMsToSeconds(ms: Int) -> String {
+    (ms.toFloat() / 1000.0).toString()
+}
+
+fn clampFloat(value: Float, min: Float, max: Float) -> Float {
+    if value < min {
+        return min
+    }
+    if value > max {
+        return max
+    }
+    value
+}
+
+fn cleanKey(key: String) -> String {
+    let clean = strings.trimSpace(key)
+    if clean.isEmpty() {
+        return "unknown"
+    }
+    strings.replaceAll(strings.replaceAll(clean, " ", "_"), "\n", "_")
+}
+
+fn stringArrayJson(items: List<String>) -> String {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(quote(item))
+    }
+    array(out)
+}
+
+fn object(props: List<String>) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let sep = ","
+    "{open}{strings.join(props, sep)}{close}"
+}
+
+fn array(items: List<String>) -> String {
+    let sep = ","
+    "[{strings.join(items, sep)}]"
+}
+
+fn prop(name: String, value: String) -> String {
+    "{quote(name)}:{value}"
+}
+
+fn quote(text: String) -> String {
+    json.stringifyValue(json.string(text))
+}

--- a/internal/stdlib/observability_test.go
+++ b/internal/stdlib/observability_test.go
@@ -1,0 +1,94 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestObservabilityModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := requireObservabilityModule(t, reg)
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"Severity", resolve.SymEnum},
+		{"SignalKind", resolve.SymEnum},
+		{"SpanStatus", resolve.SymEnum},
+		{"Resource", resolve.SymStruct},
+		{"TraceContext", resolve.SymStruct},
+		{"Span", resolve.SymStruct},
+		{"Breadcrumb", resolve.SymStruct},
+		{"Metric", resolve.SymStruct},
+		{"Event", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.observability missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.observability.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.observability.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"resource", "defaultResource", "attributes", "tags",
+		"attrString", "attrInt", "attrFloat", "attrBool",
+		"traceContext", "childTrace", "traceparent", "baggage", "traceHeaders",
+		"startSpan", "finishSpan", "breadcrumb", "metric", "metricFromSample", "counterMetrics",
+		"messageEvent", "errorEvent", "spanEvent", "metricEvent",
+		"logRecord", "eventJson", "spanJson", "traceJson", "attrsJson", "tagsJson",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.observability missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.observability.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.observability.%s not public", name)
+		}
+	}
+}
+
+func TestObservabilityModulePinsOperationalBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := requireObservabilityModule(t, reg)
+	src := string(mod.Source)
+	for _, want := range []string{
+		`"00-{strings.trimSpace(trace.traceId)}-{strings.trimSpace(trace.spanId)}-{sampled}"`,
+		`out.insert("traceparent", traceparent(trace))`,
+		`out.insert("baggage", bag)`,
+		`metrics.snapshot(counter)`,
+		`redact.redact(event.message)`,
+		`log.Record`,
+		`prop("duration_ms", span.durationMs.toString())`,
+		`prop("error_chain", stringArrayJson(redactList(event.errorChain)))`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.observability source missing %q", want)
+		}
+	}
+}
+
+func requireObservabilityModule(t *testing.T, reg *Registry) *Module {
+	t.Helper()
+	mod := reg.Modules["observability"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		var details []string
+		for _, d := range reg.Diags {
+			if d != nil && (strings.Contains(d.File, "observability") || strings.Contains(d.Message, "observability")) {
+				details = append(details, d.Error())
+			}
+		}
+		t.Fatalf("std.observability not fully loaded; diagnostics=%v", details)
+	}
+	return mod
+}

--- a/internal/stdlib/sentry_test.go
+++ b/internal/stdlib/sentry_test.go
@@ -1,0 +1,94 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestSentryModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := requireSentryModule(t, reg)
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"Dsn", resolve.SymStruct},
+		{"Client", resolve.SymStruct},
+		{"User", resolve.SymStruct},
+		{"Scope", resolve.SymStruct},
+		{"CaptureOptions", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.sentry missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.sentry.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.sentry.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"parseDsn", "client", "scope", "options", "user",
+		"endpointUrl", "sentryTraceHeader", "traceHeaders", "authHeader", "headers",
+		"captureMessageHttpRequest", "captureExceptionHttpRequest", "captureEventHttpRequest", "captureTransactionHttpRequest",
+		"captureMessage", "captureException", "captureEvent", "captureTransaction",
+		"eventPayload", "transactionPayload", "envelopeForEvent", "envelopeForTransaction",
+		"envelope", "envelopeHeader", "envelopeItem", "eventHttpRequest", "transactionHttpRequest",
+		"sentAtNow", "isSampled", "disabledClient", "normalizeEventId", "eventIdOrNew",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.sentry missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.sentry.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.sentry.%s not public", name)
+		}
+	}
+}
+
+func TestSentryModulePinsEnvelopeAndTraceBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := requireSentryModule(t, reg)
+	src := string(mod.Source)
+	for _, want := range []string{
+		`"{self.baseUrl()}/api/{self.projectId}/envelope/"`,
+		`out.insert("Content-Type", "application/x-sentry-envelope")`,
+		`out.insert("X-Sentry-Auth", authHeader(client))`,
+		`"Sentry {strings.join(parts, sep)}"`,
+		`prop("dsn", quote(client.dsn.raw))`,
+		`prop("type", quote(itemType))`,
+		`prop("length", payload.bytes().len().toString())`,
+		`prop("type", quote("transaction"))`,
+		`prop("measurements", measurementsJson(event.metrics))`,
+		`out.insert("sentry-trace", sentryTraceHeader(trace))`,
+		`observability.attrsJson(mergedScope.extra)`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.sentry source missing %q", want)
+		}
+	}
+}
+
+func requireSentryModule(t *testing.T, reg *Registry) *Module {
+	t.Helper()
+	mod := reg.Modules["sentry"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		var details []string
+		for _, d := range reg.Diags {
+			if d != nil && (strings.Contains(d.File, "sentry") || strings.Contains(d.Message, "sentry")) {
+				details = append(details, d.Error())
+			}
+		}
+		t.Fatalf("std.sentry not fully loaded; diagnostics=%v", details)
+	}
+	return mod
+}


### PR DESCRIPTION
## Summary
- add std.observability and std.sentry module surfaces
- add focused stdlib and backend coverage for the new modules
- update stdlib support matrix and helper surfaces used by the new modules