### PR TITLE
[codex] add std.cloudflare edge helpers

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 96 공개 모듈. 분류 기준:
+총 97 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (90 / 96 = 94%)
+### ⭐⭐⭐⭐⭐ Production (91 / 97 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -97,6 +97,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | supabase | 1214 | pure Osty + http/json/env | Supabase PostgREST/Auth/Storage/Functions/GraphQL request builders, env-backed config, API-key/session headers, filters, Prefer/count headers, typed select pages, Content-Range metadata, signed Storage URLs, storage listing/search, object URLs, and response error helpers |
 | github | 1127 | pure Osty + http/json/crypto | GitHub REST request builders for issues, PRs, Actions, releases, release asset upload, typed error parsing, and webhook HMAC/constant-time verification |
 | webhook | 696 | pure Osty + http/crypto/json/time | Stripe/GitHub/Slack/Supabase-style HMAC verification, Discord Ed25519-modeled externally-verified path, replay-window checks, idempotency store, and retry-safe dispatch |
+| cloudflare | 1437 | pure Osty + http/json/crypto | Cloudflare edge request builders: Turnstile siteverify, KV namespace/value/bulk helpers, R2 bucket/temp-credential management plus S3 SigV4 object requests, Queues push/pull/ack/batch/purge, DNS records, cache purge, Worker invoke/script helpers |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
 | char | 219 | — | Unicode / ASCII methods |
@@ -123,7 +124,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (6 / 96 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (6 / 97 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -141,7 +142,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase`, `github`, `observability`, `sentry`, `webhook` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase`, `github`, `observability`, `sentry`, `webhook`, `cloudflare` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode`, `keychain Linux Secret Service` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -190,6 +191,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | Supabase 앱 백엔드 연결 | ✅ 가능 | supabase + http/json/env/secrets (env-backed clients, PostgREST filters/mutations/RPC/count metadata, Auth password-token requests, Storage object URLs/uploads/signed URLs/listing, Edge Function/GraphQL requests) |
 | GitHub 개발 자동화 | ✅ 가능 | github + http/json/crypto (issue/PR request builders, Actions dispatch/runs/jobs/artifacts, release/create/upload, webhook HMAC verification) |
 | 외부 서비스 webhook intake | ✅ 가능 | webhook + http/crypto/json/time (Stripe/GitHub/Slack/Supabase-style HMAC verify, replay-window checks, idempotency, retry-safe dispatch) |
+| Cloudflare edge 보완 | ✅ 가능 | cloudflare + http/json/crypto/secrets (Turnstile bot 방어, KV, R2 파일 저장/SigV4 object requests, Queues durable queue, DNS, cache purge, Worker 호출) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |
 | Local KV / 설정 DB | ✅ 즉시 가능 | kv + fs + json (JSONL append-log, compact, typed getters/setters) |
@@ -229,7 +231,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 70 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, webhook, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, template, i18n, char, iter, bytes)
+- 71 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, webhook, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, cloudflare, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - keychain/secrets 는 macOS/Windows Phase A+B 연결 완료, Linux Secret Service backend 대기
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)

--- a/internal/backend/stdlib_cloudflare_check_test.go
+++ b/internal/backend/stdlib_cloudflare_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultCloudflare(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "cloudflare")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(cloudflare) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("cloudflare module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/cloudflare_test.go
+++ b/internal/stdlib/cloudflare_test.go
@@ -1,0 +1,162 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestCloudflareModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := requireCloudflareModule(t, reg)
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.SymbolKind
+	}{
+		{"R2Jurisdiction", resolve.SymEnum},
+		{"R2StorageClass", resolve.SymEnum},
+		{"R2Permission", resolve.SymEnum},
+		{"DnsRecordKind", resolve.SymEnum},
+		{"Client", resolve.SymStruct},
+		{"TurnstileChallenge", resolve.SymStruct},
+		{"TurnstileResult", resolve.SymStruct},
+		{"ApiError", resolve.SymStruct},
+		{"KvPutOptions", resolve.SymStruct},
+		{"QueueMessage", resolve.SymStruct},
+		{"QueuePullOptions", resolve.SymStruct},
+		{"R2BucketOptions", resolve.SymStruct},
+		{"R2TemporaryCredentials", resolve.SymStruct},
+		{"R2Signer", resolve.SymStruct},
+		{"R2SigningDates", resolve.SymStruct},
+		{"DnsRecord", resolve.SymStruct},
+		{"CachePurge", resolve.SymStruct},
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(tc.name)
+		if sym == nil {
+			t.Fatalf("std.cloudflare missing type %q", tc.name)
+		}
+		if sym.Kind != tc.kind {
+			t.Fatalf("std.cloudflare.%s kind = %s, want %s", tc.name, sym.Kind, tc.kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.cloudflare.%s not public", tc.name)
+		}
+	}
+
+	for _, name := range []string{
+		"apiBaseUrl", "client", "account", "zone", "accountZone", "headers", "jsonHeaders",
+		"turnstile", "turnstileSiteverifyUrl", "turnstileJsonBody", "turnstileFormValues",
+		"turnstileSiteverifyJsonRequest", "turnstileSiteverifyFormRequest", "sendTurnstile", "parseTurnstileResult",
+		"accountUrl", "zoneUrl",
+		"kvNamespacesUrl", "kvNamespaceUrl", "kvValueUrl",
+		"listKvNamespacesHttpRequest", "createKvNamespaceHttpRequest", "renameKvNamespaceHttpRequest",
+		"deleteKvNamespaceHttpRequest", "getKvValueHttpRequest", "putKvValueHttpRequest",
+		"deleteKvValueHttpRequest", "putKvValueWithOptionsHttpRequest", "kvBulkEntryText", "kvBulkEntryTextWithOptions", "kvBulkPutHttpRequest", "kvBulkDeleteHttpRequest",
+		"r2BucketsUrl", "r2BucketUrl", "listR2BucketsHttpRequest", "getR2BucketHttpRequest",
+		"r2BucketOptions", "createR2BucketHttpRequest", "createR2BucketWithOptionsHttpRequest", "deleteR2BucketHttpRequest", "r2TempCredentialsHttpRequest",
+		"r2S3Endpoint", "r2ObjectUrl", "r2Signer", "r2SigningDates",
+		"r2PutObjectHttpRequest", "r2GetObjectHttpRequest", "r2DeleteObjectHttpRequest",
+		"queueBaseUrl", "queueUrl", "listQueuesHttpRequest", "createQueueHttpRequest",
+		"queueTextMessage", "queueJsonMessage", "queueMessageJson",
+		"pushQueueMessageHttpRequest", "pushQueueBatchHttpRequest", "pushQueueBatchWithDelayHttpRequest",
+		"queuePullOptions", "pullQueueMessagesHttpRequest", "pullQueueMessagesWithOptionsHttpRequest",
+		"ackQueueMessagesHttpRequest", "ackRetryQueueMessagesHttpRequest", "purgeQueueHttpRequest",
+		"dnsRecordsUrl", "dnsRecordUrl", "dnsRecord", "listDnsRecordsHttpRequest",
+		"listDnsRecordsFilteredHttpRequest", "createDnsRecordHttpRequest", "updateDnsRecordHttpRequest", "deleteDnsRecordHttpRequest",
+		"purgeEverything", "purgeFiles", "purgeTags", "purgeHosts", "purgePrefixes", "cachePurgeHttpRequest",
+		"workerUrl", "workerInvokeEmptyHttpRequest", "workerInvokeEmptyWithTokenHttpRequest",
+		"workerInvokeHttpRequest", "workerInvokeWithTokenHttpRequest", "workerInvokeJsonHttpRequest", "workerInvokeJsonWithTokenHttpRequest",
+		"workerScriptUrl", "getWorkerScriptHttpRequest", "deleteWorkerScriptHttpRequest",
+		"sendJson", "requireSuccess", "parseApiError",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.cloudflare missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.cloudflare.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.cloudflare.%s not public", name)
+		}
+	}
+}
+
+func TestCloudflareModuleMethodsAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"R2Jurisdiction", []string{"toString"}},
+		{"R2StorageClass", []string{"toString"}},
+		{"R2Permission", []string{"toString"}},
+		{"DnsRecordKind", []string{"toString"}},
+		{"Client", []string{"withAccountId", "withZoneId", "withBaseUrl", "withClientInfo", "withHeader"}},
+		{"TurnstileChallenge", []string{"withRemoteIp", "withIdempotencyKey"}},
+		{"TurnstileResult", []string{"summary"}},
+		{"ApiError", []string{"summary"}},
+		{"KvPutOptions", []string{"withExpiration", "withExpirationTtl"}},
+		{"QueueMessage", []string{"withDelay"}},
+		{"QueuePullOptions", []string{"withBatchSize", "withVisibilityTimeout"}},
+		{"R2Signer", []string{"withSessionToken"}},
+		{"CachePurge", []string{"withFile", "withTag", "withHost", "withPrefix"}},
+	} {
+		for _, method := range tc.methods {
+			fn := reg.LookupMethodDecl("cloudflare", tc.typeName, method)
+			if fn == nil {
+				t.Fatalf("LookupMethodDecl(cloudflare, %s, %s) = nil, want *ast.FnDecl", tc.typeName, method)
+			}
+			if fn.Body == nil {
+				t.Fatalf("cloudflare.%s.%s body = nil, want source method body", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestCloudflareModulePinsEndpointAndSigningBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := requireCloudflareModule(t, reg)
+	src := string(mod.Source)
+	for _, want := range []string{
+		`https://api.cloudflare.com/client/v4`,
+		`https://challenges.cloudflare.com/turnstile/v0/siteverify`,
+		`storage/kv/namespaces`,
+		`/values/{encodeKeyName(key)?}`,
+		`r2/buckets`,
+		`r2/temp-access-credentials`,
+		`https://{account}.r2.cloudflarestorage.com`,
+		`AWS4-HMAC-SHA256`,
+		`{dates.shortDate}/auto/s3/aws4_request`,
+		`crypto.hmac.sha256(kRegion, bytes.fromString("s3"))`,
+		`queues/{queue}`,
+		`messages/batch`,
+		`messages/ack`,
+		`dns_records/{cleanRecordId}`,
+		`zoneUrl(client, "purge_cache")`,
+		`purge_everything`,
+		`.workers.dev`,
+		`workers/scripts/{encodePathSegment(cleanWorkerScriptName(scriptName)?)}`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.cloudflare source missing %q", want)
+		}
+	}
+}
+
+func requireCloudflareModule(t *testing.T, reg *Registry) *Module {
+	t.Helper()
+	mod := reg.Modules["cloudflare"]
+	if mod == nil || mod.Package == nil || mod.Package.PkgScope == nil {
+		var details []string
+		for _, d := range reg.Diags {
+			if d != nil && (strings.Contains(d.File, "cloudflare") || strings.Contains(d.Message, "cloudflare")) {
+				details = append(details, d.Error())
+			}
+		}
+		t.Fatalf("std.cloudflare not fully loaded; diagnostics=%v", details)
+	}
+	return mod
+}

--- a/internal/stdlib/modules/cloudflare.osty
+++ b/internal/stdlib/modules/cloudflare.osty
@@ -1,0 +1,1437 @@
+// std.cloudflare - Cloudflare edge service request builders.
+//
+// This module stays transport-light and composes with std.http/std.json. It
+// covers the common web-service jobs: Turnstile server validation, KV, R2,
+// Queues, DNS records, cache purge, and direct Worker invocation. R2 object
+// calls include the small AWS SigV4 signer needed by Cloudflare's S3-compatible
+// API; callers provide deterministic signing dates so the surface stays pure.
+
+use std.bytes
+use std.crypto
+use std.encoding
+use std.error
+use std.http
+use std.json
+use std.strings
+
+pub type Headers = http.Headers
+pub type QueryValues = http.QueryValues
+pub type FormValues = http.FormValues
+
+pub enum R2Jurisdiction {
+    R2Default,
+    R2Eu,
+    R2Fedramp,
+
+    pub fn toString(self) -> String {
+        match self {
+            R2Default  -> "default",
+            R2Eu       -> "eu",
+            R2Fedramp  -> "fedramp",
+        }
+    }
+}
+
+pub enum R2StorageClass {
+    R2Standard,
+    R2InfrequentAccess,
+
+    pub fn toString(self) -> String {
+        match self {
+            R2Standard         -> "Standard",
+            R2InfrequentAccess -> "InfrequentAccess",
+        }
+    }
+}
+
+pub enum R2Permission {
+    AdminReadWrite,
+    AdminReadOnly,
+    ObjectReadWrite,
+    ObjectReadOnly,
+
+    pub fn toString(self) -> String {
+        match self {
+            AdminReadWrite  -> "admin-read-write",
+            AdminReadOnly   -> "admin-read-only",
+            ObjectReadWrite -> "object-read-write",
+            ObjectReadOnly  -> "object-read-only",
+        }
+    }
+}
+
+pub enum DnsRecordKind {
+    DnsA,
+    DnsAAAA,
+    DnsCNAME,
+    DnsTXT,
+    DnsMX,
+    DnsNS,
+    DnsSRV,
+    DnsCAA,
+
+    pub fn toString(self) -> String {
+        match self {
+            DnsA     -> "A",
+            DnsAAAA  -> "AAAA",
+            DnsCNAME -> "CNAME",
+            DnsTXT   -> "TXT",
+            DnsMX    -> "MX",
+            DnsNS    -> "NS",
+            DnsSRV   -> "SRV",
+            DnsCAA   -> "CAA",
+        }
+    }
+}
+
+pub struct Client {
+    pub apiBaseUrl: String = "https://api.cloudflare.com/client/v4",
+    pub accountId: String = "",
+    pub zoneId: String = "",
+    pub apiToken: String,
+    pub clientInfo: String = "osty-stdlib-cloudflare",
+    pub extraHeaders: Headers = {:},
+
+    pub fn withAccountId(mut self, accountId: String) -> Result<Client, Error> {
+        self.accountId = cleanIdentifier("account ID", accountId)?
+        Ok(self)
+    }
+
+    pub fn withZoneId(mut self, zoneId: String) -> Result<Client, Error> {
+        self.zoneId = cleanIdentifier("zone ID", zoneId)?
+        Ok(self)
+    }
+
+    pub fn withBaseUrl(mut self, baseUrl: String) -> Result<Client, Error> {
+        let clean = stripTrailingSlash(strings.trimSpace(baseUrl))
+        if clean.isEmpty() {
+            return Err(error.new("cloudflare: API base URL is empty"))
+        }
+        self.apiBaseUrl = clean
+        Ok(self)
+    }
+
+    pub fn withClientInfo(mut self, value: String) -> Client {
+        self.clientInfo = strings.trimSpace(value)
+        self
+    }
+
+    pub fn withHeader(mut self, name: String, value: String) -> Client {
+        self.extraHeaders.insert(name, value)
+        self
+    }
+}
+
+pub struct TurnstileChallenge {
+    pub secret: String,
+    pub response: String,
+    pub remoteIp: String = "",
+    pub idempotencyKey: String = "",
+
+    pub fn withRemoteIp(mut self, ip: String) -> TurnstileChallenge {
+        self.remoteIp = strings.trimSpace(ip)
+        self
+    }
+
+    pub fn withIdempotencyKey(mut self, key: String) -> TurnstileChallenge {
+        self.idempotencyKey = strings.trimSpace(key)
+        self
+    }
+}
+
+pub struct TurnstileResult {
+    pub success: Bool,
+    pub challengeTs: String = "",
+    pub hostname: String = "",
+    pub action: String = "",
+    pub cdata: String = "",
+    pub errorCodes: List<String> = [],
+    pub rawJson: String = "",
+
+    pub fn summary(self) -> String {
+        if self.success {
+            let host = if self.hostname.isEmpty() { "unknown host" } else { self.hostname }
+            return "cloudflare: turnstile accepted for {host}"
+        }
+        let codes = if self.errorCodes.isEmpty() { "unknown-error" } else { strings.join(self.errorCodes, ",") }
+        "cloudflare: turnstile rejected: {codes}"
+    }
+}
+
+pub struct ApiError {
+    pub status: Int,
+    pub code: String = "",
+    pub message: String = "",
+    pub rawJson: String = "",
+
+    pub fn summary(self) -> String {
+        let msg = if strings.trimSpace(self.message).isEmpty() { "request failed" } else { strings.trimSpace(self.message) }
+        let code = if strings.trimSpace(self.code).isEmpty() { "" } else { " ({strings.trimSpace(self.code)})" }
+        "cloudflare: HTTP {self.status}: {msg}{code}"
+    }
+}
+
+pub struct KvPutOptions {
+    pub expiration: Int = 0,
+    pub expirationTtl: Int = 0,
+
+    pub fn withExpiration(mut self, unixSeconds: Int) -> Result<KvPutOptions, Error> {
+        if unixSeconds < 0 {
+            return Err(error.new("cloudflare: KV expiration must not be negative"))
+        }
+        self.expiration = unixSeconds
+        Ok(self)
+    }
+
+    pub fn withExpirationTtl(mut self, seconds: Int) -> Result<KvPutOptions, Error> {
+        if seconds < 0 {
+            return Err(error.new("cloudflare: KV expiration_ttl must not be negative"))
+        }
+        self.expirationTtl = seconds
+        Ok(self)
+    }
+}
+
+pub struct QueueMessage {
+    pub bodyJson: String,
+    pub contentType: String = "json",
+    pub delaySeconds: Int = 0,
+
+    pub fn withDelay(mut self, seconds: Int) -> Result<QueueMessage, Error> {
+        if seconds < 0 {
+            return Err(error.new("cloudflare: queue delay must not be negative"))
+        }
+        self.delaySeconds = seconds
+        Ok(self)
+    }
+}
+
+pub struct QueuePullOptions {
+    pub batchSize: Int = 1,
+    pub visibilityTimeoutMs: Int = 30000,
+
+    pub fn withBatchSize(mut self, size: Int) -> Result<QueuePullOptions, Error> {
+        if size <= 0 {
+            return Err(error.new("cloudflare: queue batch size must be positive"))
+        }
+        self.batchSize = size
+        Ok(self)
+    }
+
+    pub fn withVisibilityTimeout(mut self, ms: Int) -> Result<QueuePullOptions, Error> {
+        if ms <= 0 {
+            return Err(error.new("cloudflare: queue visibility timeout must be positive"))
+        }
+        self.visibilityTimeoutMs = ms
+        Ok(self)
+    }
+}
+
+pub struct R2BucketOptions {
+    pub jurisdiction: R2Jurisdiction,
+    pub storageClass: R2StorageClass,
+}
+
+pub struct R2TemporaryCredentials {
+    pub bucket: String,
+    pub parentAccessKeyId: String,
+    pub permission: R2Permission,
+    pub ttlSeconds: Int,
+    pub objects: List<String> = [],
+    pub prefixes: List<String> = [],
+}
+
+pub struct R2Signer {
+    pub accountId: String,
+    pub accessKeyId: String,
+    pub secretAccessKey: String,
+    pub sessionToken: String = "",
+
+    pub fn withSessionToken(mut self, token: String) -> R2Signer {
+        self.sessionToken = strings.trimSpace(token)
+        self
+    }
+}
+
+pub struct R2SigningDates {
+    pub amzDate: String,
+    pub shortDate: String,
+}
+
+pub struct DnsRecord {
+    pub typ: DnsRecordKind,
+    pub name: String,
+    pub content: String,
+    pub ttl: Int = 1,
+    pub proxied: Bool = false,
+    pub comment: String = "",
+    pub priority: Int = 0,
+}
+
+pub struct CachePurge {
+    pub purgeEverything: Bool = false,
+    pub files: List<String> = [],
+    pub tags: List<String> = [],
+    pub hosts: List<String> = [],
+    pub prefixes: List<String> = [],
+
+    pub fn withFile(mut self, url: String) -> CachePurge {
+        self.files.push(strings.trimSpace(url))
+        self
+    }
+
+    pub fn withTag(mut self, tag: String) -> CachePurge {
+        self.tags.push(strings.trimSpace(tag))
+        self
+    }
+
+    pub fn withHost(mut self, host: String) -> CachePurge {
+        self.hosts.push(strings.trimSpace(host))
+        self
+    }
+
+    pub fn withPrefix(mut self, prefix: String) -> CachePurge {
+        self.prefixes.push(strings.trimSpace(prefix))
+        self
+    }
+}
+
+pub fn apiBaseUrl() -> String {
+    "https://api.cloudflare.com/client/v4"
+}
+
+pub fn client(apiToken: String) -> Result<Client, Error> {
+    let token = strings.trimSpace(apiToken)
+    if token.isEmpty() {
+        return Err(error.new("cloudflare: API token is empty"))
+    }
+    Ok(Client { apiToken: token })
+}
+
+pub fn account(accountId: String, apiToken: String) -> Result<Client, Error> {
+    let c = client(apiToken)?
+    c.withAccountId(accountId)
+}
+
+pub fn zone(zoneId: String, apiToken: String) -> Result<Client, Error> {
+    let c = client(apiToken)?
+    c.withZoneId(zoneId)
+}
+
+pub fn accountZone(accountId: String, zoneId: String, apiToken: String) -> Result<Client, Error> {
+    let c = account(accountId, apiToken)?
+    c.withZoneId(zoneId)
+}
+
+pub fn headers(client: Client) -> Headers {
+    baseHeaders(client, "")
+}
+
+pub fn jsonHeaders(client: Client) -> Headers {
+    baseHeaders(client, "application/json")
+}
+
+pub fn turnstile(secret: String, response: String) -> Result<TurnstileChallenge, Error> {
+    let cleanSecret = strings.trimSpace(secret)
+    let cleanResponse = strings.trimSpace(response)
+    if cleanSecret.isEmpty() {
+        return Err(error.new("cloudflare: Turnstile secret is empty"))
+    }
+    if cleanResponse.isEmpty() {
+        return Err(error.new("cloudflare: Turnstile response is empty"))
+    }
+    if cleanResponse.charCount() > 2048 {
+        return Err(error.new("cloudflare: Turnstile response is too long"))
+    }
+    Ok(TurnstileChallenge {
+        secret: cleanSecret,
+        response: cleanResponse,
+    })
+}
+
+pub fn turnstileSiteverifyUrl() -> String {
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+}
+
+pub fn turnstileJsonBody(challenge: TurnstileChallenge) -> String {
+    let mut props = [
+        prop("secret", quote(challenge.secret)),
+        prop("response", quote(challenge.response)),
+    ]
+    if !strings.trimSpace(challenge.remoteIp).isEmpty() {
+        props.push(prop("remoteip", quote(strings.trimSpace(challenge.remoteIp))))
+    }
+    if !strings.trimSpace(challenge.idempotencyKey).isEmpty() {
+        props.push(prop("idempotency_key", quote(strings.trimSpace(challenge.idempotencyKey))))
+    }
+    object(props)
+}
+
+pub fn turnstileFormValues(challenge: TurnstileChallenge) -> FormValues {
+    let mut form: FormValues = {
+        "secret": [challenge.secret],
+        "response": [challenge.response],
+    }
+    if !strings.trimSpace(challenge.remoteIp).isEmpty() {
+        form.insert("remoteip", [strings.trimSpace(challenge.remoteIp)])
+    }
+    if !strings.trimSpace(challenge.idempotencyKey).isEmpty() {
+        form.insert("idempotency_key", [strings.trimSpace(challenge.idempotencyKey)])
+    }
+    form
+}
+
+pub fn turnstileSiteverifyJsonRequest(challenge: TurnstileChallenge) -> Result<http.Request, Error> {
+    validateTurnstile(challenge)?
+    Ok(http.newRequest(Post, turnstileSiteverifyUrl())
+        .withText(turnstileJsonBody(challenge))
+        .withContentType("application/json"))
+}
+
+pub fn turnstileSiteverifyFormRequest(challenge: TurnstileChallenge) -> Result<http.Request, Error> {
+    validateTurnstile(challenge)?
+    Ok(http.newRequest(Post, turnstileSiteverifyUrl())
+        .withForm(turnstileFormValues(challenge)))
+}
+
+pub fn sendTurnstile(challenge: TurnstileChallenge) -> Result<TurnstileResult, Error> {
+    let response = http.request(turnstileSiteverifyJsonRequest(challenge)?)?
+    Ok(parseTurnstileResult(response))
+}
+
+pub fn parseTurnstileResult(response: http.Response) -> TurnstileResult {
+    let text = response.text().unwrapOr("")
+    let mut out = TurnstileResult {
+        success: false,
+        rawJson: text,
+    }
+    match json.parseValue(text) {
+        Ok(root) -> {
+            out.success = boolField(root, "success")
+            out.challengeTs = stringField(root, "challenge_ts")
+            out.hostname = stringField(root, "hostname")
+            out.action = stringField(root, "action")
+            out.cdata = stringField(root, "cdata")
+            out.errorCodes = stringArrayField(root, "error-codes")
+        },
+        Err(_) -> {},
+    }
+    out
+}
+
+pub fn accountUrl(client: Client, path: String) -> Result<String, Error> {
+    validateClient(client)?
+    let accountId = cleanIdentifier("account ID", client.accountId)?
+    Ok(apiUrl(client, "/accounts/{accountId}/{cleanRelativePath(path)?}"))
+}
+
+pub fn zoneUrl(client: Client, path: String) -> Result<String, Error> {
+    validateClient(client)?
+    let zoneId = cleanIdentifier("zone ID", client.zoneId)?
+    Ok(apiUrl(client, "/zones/{zoneId}/{cleanRelativePath(path)?}"))
+}
+
+pub fn kvNamespacesUrl(client: Client) -> Result<String, Error> {
+    accountUrl(client, "storage/kv/namespaces")
+}
+
+pub fn kvNamespaceUrl(client: Client, namespaceId: String) -> Result<String, Error> {
+    let ns = cleanIdentifier("KV namespace ID", namespaceId)?
+    accountUrl(client, "storage/kv/namespaces/{ns}")
+}
+
+pub fn kvValueUrl(client: Client, namespaceId: String, key: String) -> Result<String, Error> {
+    let ns = cleanIdentifier("KV namespace ID", namespaceId)?
+    accountUrl(client, "storage/kv/namespaces/{ns}/values/{encodeKeyName(key)?}")
+}
+
+pub fn listKvNamespacesHttpRequest(client: Client) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, kvNamespacesUrl(client)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn createKvNamespaceHttpRequest(client: Client, title: String) -> Result<http.Request, Error> {
+    let clean = cleanName("KV namespace title", title)?
+    Ok(http.newRequest(Post, kvNamespacesUrl(client)?)
+        .withHeaders(jsonHeaders(client))
+        .withText(object([prop("title", quote(clean))]))
+        .withContentType("application/json"))
+}
+
+pub fn renameKvNamespaceHttpRequest(client: Client, namespaceId: String, title: String) -> Result<http.Request, Error> {
+    let clean = cleanName("KV namespace title", title)?
+    Ok(http.newRequest(Put, kvNamespaceUrl(client, namespaceId)?)
+        .withHeaders(jsonHeaders(client))
+        .withText(object([prop("title", quote(clean))]))
+        .withContentType("application/json"))
+}
+
+pub fn deleteKvNamespaceHttpRequest(client: Client, namespaceId: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Delete, kvNamespaceUrl(client, namespaceId)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn getKvValueHttpRequest(client: Client, namespaceId: String, key: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, kvValueUrl(client, namespaceId, key)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn putKvValueHttpRequest(client: Client, namespaceId: String, key: String, value: Bytes) -> Result<http.Request, Error> {
+    putKvValueWithOptionsHttpRequest(client, namespaceId, key, value, KvPutOptions {})
+}
+
+pub fn putKvValueWithOptionsHttpRequest(client: Client, namespaceId: String, key: String, value: Bytes, opts: KvPutOptions) -> Result<http.Request, Error> {
+    let mut req = http.newRequest(Put, kvValueUrl(client, namespaceId, key)?)
+        .withHeaders(headers(client))
+        .withBody(value)
+    let query = kvPutQuery(opts)?
+    if !query.isEmpty() {
+        req = req.withQuery(query)
+    }
+    Ok(req)
+}
+
+pub fn deleteKvValueHttpRequest(client: Client, namespaceId: String, key: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Delete, kvValueUrl(client, namespaceId, key)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn kvBulkEntryText(key: String, value: String) -> Result<String, Error> {
+    kvBulkEntryTextWithOptions(key, value, 0, "")
+}
+
+pub fn kvBulkEntryTextWithOptions(key: String, value: String, expirationTtl: Int, metadataJson: String) -> Result<String, Error> {
+    let clean = cleanKeyName(key)?
+    let mut props = [
+        prop("key", quote(clean)),
+        prop("value", quote(value)),
+    ]
+    if expirationTtl > 0 {
+        props.push(prop("expiration_ttl", expirationTtl.toString()))
+    }
+    let metadata = normalizedJsonObject(metadataJson)
+    if metadata != "\{\}" {
+        props.push(prop("metadata", metadata))
+    }
+    Ok(object(props))
+}
+
+pub fn kvBulkPutHttpRequest(client: Client, namespaceId: String, entriesJson: List<String>) -> Result<http.Request, Error> {
+    if entriesJson.isEmpty() {
+        return Err(error.new("cloudflare: KV bulk entries are empty"))
+    }
+    let ns = cleanIdentifier("KV namespace ID", namespaceId)?
+    Ok(http.newRequest(Put, accountUrl(client, "storage/kv/namespaces/{ns}/bulk")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(array(entriesJson))
+        .withContentType("application/json"))
+}
+
+pub fn kvBulkDeleteHttpRequest(client: Client, namespaceId: String, keys: List<String>) -> Result<http.Request, Error> {
+    if keys.isEmpty() {
+        return Err(error.new("cloudflare: KV bulk delete keys are empty"))
+    }
+    let mut items: List<String> = []
+    for key in keys {
+        items.push(quote(cleanKeyName(key)?))
+    }
+    let ns = cleanIdentifier("KV namespace ID", namespaceId)?
+    Ok(http.newRequest(Post, accountUrl(client, "storage/kv/namespaces/{ns}/bulk/delete")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(array(items))
+        .withContentType("application/json"))
+}
+
+pub fn r2BucketsUrl(client: Client) -> Result<String, Error> {
+    accountUrl(client, "r2/buckets")
+}
+
+pub fn r2BucketUrl(client: Client, bucket: String) -> Result<String, Error> {
+    accountUrl(client, "r2/buckets/{encodePathSegment(cleanBucketName(bucket)?)}")
+}
+
+pub fn listR2BucketsHttpRequest(client: Client) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, r2BucketsUrl(client)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn getR2BucketHttpRequest(client: Client, bucket: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, r2BucketUrl(client, bucket)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn r2BucketOptions() -> R2BucketOptions {
+    R2BucketOptions {
+        jurisdiction: R2Default,
+        storageClass: R2Standard,
+    }
+}
+
+pub fn createR2BucketHttpRequest(client: Client, bucket: String) -> Result<http.Request, Error> {
+    createR2BucketWithOptionsHttpRequest(client, bucket, r2BucketOptions())
+}
+
+pub fn createR2BucketWithOptionsHttpRequest(client: Client, bucket: String, opts: R2BucketOptions) -> Result<http.Request, Error> {
+    let body = object([
+        prop("name", quote(cleanBucketName(bucket)?)),
+        prop("jurisdiction", quote(opts.jurisdiction.toString())),
+        prop("storage_class", quote(opts.storageClass.toString())),
+    ])
+    Ok(http.newRequest(Post, r2BucketsUrl(client)?)
+        .withHeaders(jsonHeaders(client))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn deleteR2BucketHttpRequest(client: Client, bucket: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Delete, r2BucketUrl(client, bucket)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn r2TempCredentialsHttpRequest(client: Client, spec: R2TemporaryCredentials) -> Result<http.Request, Error> {
+    if spec.ttlSeconds <= 0 || spec.ttlSeconds > 604800 {
+        return Err(error.new("cloudflare: R2 temporary credentials ttl must be 1..604800 seconds"))
+    }
+    let mut props = [
+        prop("bucket", quote(cleanBucketName(spec.bucket)?)),
+        prop("parentAccessKeyId", quote(cleanName("R2 access key ID", spec.parentAccessKeyId)?)),
+        prop("permission", quote(spec.permission.toString())),
+        prop("ttlSeconds", spec.ttlSeconds.toString()),
+    ]
+    if !spec.objects.isEmpty() {
+        props.push(prop("objects", quoteList(cleanObjectList(spec.objects)?)))
+    }
+    if !spec.prefixes.isEmpty() {
+        props.push(prop("prefixes", quoteList(cleanObjectList(spec.prefixes)?)))
+    }
+    Ok(http.newRequest(Post, accountUrl(client, "r2/temp-access-credentials")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(object(props))
+        .withContentType("application/json"))
+}
+
+pub fn r2S3Endpoint(accountId: String) -> Result<String, Error> {
+    let account = cleanIdentifier("account ID", accountId)?
+    Ok("https://{account}.r2.cloudflarestorage.com")
+}
+
+pub fn r2ObjectUrl(accountId: String, bucket: String, key: String) -> Result<String, Error> {
+    Ok("{r2S3Endpoint(accountId)?}/{encodePathSegment(cleanBucketName(bucket)?)}" +
+        "/{encodeObjectPath(key)?}")
+}
+
+pub fn r2Signer(accountId: String, accessKeyId: String, secretAccessKey: String) -> Result<R2Signer, Error> {
+    let cleanAccount = cleanIdentifier("account ID", accountId)?
+    let cleanAccess = cleanName("R2 access key ID", accessKeyId)?
+    let cleanSecret = strings.trimSpace(secretAccessKey)
+    if cleanSecret.isEmpty() {
+        return Err(error.new("cloudflare: R2 secret access key is empty"))
+    }
+    Ok(R2Signer {
+        accountId: cleanAccount,
+        accessKeyId: cleanAccess,
+        secretAccessKey: cleanSecret,
+    })
+}
+
+pub fn r2SigningDates(amzDate: String) -> Result<R2SigningDates, Error> {
+    let clean = strings.trimSpace(amzDate)
+    if clean.charCount() < 8 {
+        return Err(error.new("cloudflare: invalid AWS date"))
+    }
+    Ok(R2SigningDates {
+        amzDate: clean,
+        shortDate: strings.slice(clean, 0, 8),
+    })
+}
+
+pub fn r2PutObjectHttpRequest(signer: R2Signer, bucket: String, key: String, body: Bytes, contentType: String, dates: R2SigningDates) -> Result<http.Request, Error> {
+    let mediaType = if strings.trimSpace(contentType).isEmpty() { "application/octet-stream" } else { strings.trimSpace(contentType) }
+    let payloadHash = sha256Hex(body)
+    let signed = r2SignedHeaders(signer, "PUT", bucket, key, payloadHash, mediaType, dates)?
+    Ok(http.newRequest(Put, r2ObjectUrl(signer.accountId, bucket, key)?)
+        .withHeaders(signed)
+        .withBody(body)
+        .withContentType(mediaType))
+}
+
+pub fn r2GetObjectHttpRequest(signer: R2Signer, bucket: String, key: String, dates: R2SigningDates) -> Result<http.Request, Error> {
+    let payloadHash = sha256Hex(bytes.fromString(""))
+    let signed = r2SignedHeaders(signer, "GET", bucket, key, payloadHash, "", dates)?
+    Ok(http.newRequest(Get, r2ObjectUrl(signer.accountId, bucket, key)?)
+        .withHeaders(signed))
+}
+
+pub fn r2DeleteObjectHttpRequest(signer: R2Signer, bucket: String, key: String, dates: R2SigningDates) -> Result<http.Request, Error> {
+    let payloadHash = sha256Hex(bytes.fromString(""))
+    let signed = r2SignedHeaders(signer, "DELETE", bucket, key, payloadHash, "", dates)?
+    Ok(http.newRequest(Delete, r2ObjectUrl(signer.accountId, bucket, key)?)
+        .withHeaders(signed))
+}
+
+pub fn queueBaseUrl(client: Client, queueId: String) -> Result<String, Error> {
+    queueUrl(client, queueId, "")
+}
+
+pub fn queueUrl(client: Client, queueId: String, path: String) -> Result<String, Error> {
+    let queue = cleanIdentifier("queue ID", queueId)?
+    let base = "queues/{queue}"
+    let suffix = strings.trimPrefix(strings.trimSpace(path), "/")
+    if suffix.isEmpty() {
+        return accountUrl(client, base)
+    }
+    if strings.contains(suffix, "..") || strings.contains(suffix, "?") || strings.contains(suffix, "#") {
+        return Err(error.new("cloudflare: unsafe queue path: {path}"))
+    }
+    accountUrl(client, "{base}/{suffix}")
+}
+
+pub fn listQueuesHttpRequest(client: Client) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, accountUrl(client, "queues")?)
+        .withHeaders(headers(client)))
+}
+
+pub fn createQueueHttpRequest(client: Client, name: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Post, accountUrl(client, "queues")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(object([prop("queue_name", quote(cleanName("queue name", name)?))]))
+        .withContentType("application/json"))
+}
+
+pub fn queueTextMessage(body: String) -> QueueMessage {
+    QueueMessage {
+        bodyJson: quote(body),
+        contentType: "text",
+    }
+}
+
+pub fn queueJsonMessage(bodyJson: String) -> QueueMessage {
+    QueueMessage {
+        bodyJson: normalizedJsonValue(bodyJson),
+        contentType: "json",
+    }
+}
+
+pub fn queueMessageJson(message: QueueMessage) -> String {
+    let mut props = [
+        prop("body", message.bodyJson),
+        prop("content_type", quote(message.contentType)),
+    ]
+    if message.delaySeconds > 0 {
+        props.push(prop("delay_seconds", message.delaySeconds.toString()))
+    }
+    object(props)
+}
+
+pub fn pushQueueMessageHttpRequest(client: Client, queueId: String, message: QueueMessage) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Post, queueUrl(client, queueId, "messages")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(queueMessageJson(message))
+        .withContentType("application/json"))
+}
+
+pub fn pushQueueBatchHttpRequest(client: Client, queueId: String, messages: List<QueueMessage>) -> Result<http.Request, Error> {
+    pushQueueBatchWithDelayHttpRequest(client, queueId, messages, 0)
+}
+
+pub fn pushQueueBatchWithDelayHttpRequest(client: Client, queueId: String, messages: List<QueueMessage>, delaySeconds: Int) -> Result<http.Request, Error> {
+    if messages.isEmpty() {
+        return Err(error.new("cloudflare: queue batch is empty"))
+    }
+    if delaySeconds < 0 {
+        return Err(error.new("cloudflare: queue batch delay must not be negative"))
+    }
+    let mut items: List<String> = []
+    for message in messages {
+        items.push(queueMessageJson(message))
+    }
+    let mut props = [prop("messages", array(items))]
+    if delaySeconds > 0 {
+        props.push(prop("delay_seconds", delaySeconds.toString()))
+    }
+    Ok(http.newRequest(Post, queueUrl(client, queueId, "messages/batch")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(object(props))
+        .withContentType("application/json"))
+}
+
+pub fn queuePullOptions() -> QueuePullOptions {
+    QueuePullOptions {}
+}
+
+pub fn pullQueueMessagesHttpRequest(client: Client, queueId: String) -> Result<http.Request, Error> {
+    pullQueueMessagesWithOptionsHttpRequest(client, queueId, queuePullOptions())
+}
+
+pub fn pullQueueMessagesWithOptionsHttpRequest(client: Client, queueId: String, opts: QueuePullOptions) -> Result<http.Request, Error> {
+    if opts.batchSize <= 0 || opts.visibilityTimeoutMs <= 0 {
+        return Err(error.new("cloudflare: invalid queue pull options"))
+    }
+    let body = object([
+        prop("batch_size", opts.batchSize.toString()),
+        prop("visibility_timeout_ms", opts.visibilityTimeoutMs.toString()),
+    ])
+    Ok(http.newRequest(Post, queueUrl(client, queueId, "messages/pull")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn ackQueueMessagesHttpRequest(client: Client, queueId: String, ackLeaseIds: List<String>) -> Result<http.Request, Error> {
+    ackRetryQueueMessagesHttpRequest(client, queueId, ackLeaseIds, [])
+}
+
+pub fn ackRetryQueueMessagesHttpRequest(client: Client, queueId: String, ackLeaseIds: List<String>, retryLeaseIds: List<String>) -> Result<http.Request, Error> {
+    if ackLeaseIds.isEmpty() && retryLeaseIds.isEmpty() {
+        return Err(error.new("cloudflare: queue ack request has no lease IDs"))
+    }
+    let body = object([
+        prop("acks", quoteList(cleanIdentifierList("lease ID", ackLeaseIds)?)),
+        prop("retries", quoteList(cleanIdentifierList("lease ID", retryLeaseIds)?)),
+    ])
+    Ok(http.newRequest(Post, queueUrl(client, queueId, "messages/ack")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn purgeQueueHttpRequest(client: Client, queueId: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Post, queueUrl(client, queueId, "purge")?)
+        .withHeaders(jsonHeaders(client))
+        .withText("\{\}")
+        .withContentType("application/json"))
+}
+
+pub fn dnsRecordsUrl(client: Client) -> Result<String, Error> {
+    zoneUrl(client, "dns_records")
+}
+
+pub fn dnsRecordUrl(client: Client, recordId: String) -> Result<String, Error> {
+    let cleanRecordId = cleanIdentifier("DNS record ID", recordId)?
+    zoneUrl(client, "dns_records/{cleanRecordId}")
+}
+
+pub fn dnsRecord(kind: DnsRecordKind, name: String, content: String) -> Result<DnsRecord, Error> {
+    Ok(DnsRecord {
+        typ: kind,
+        name: cleanName("DNS record name", name)?,
+        content: cleanName("DNS record content", content)?,
+    })
+}
+
+pub fn listDnsRecordsHttpRequest(client: Client) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, dnsRecordsUrl(client)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn listDnsRecordsFilteredHttpRequest(client: Client, typ: String, name: String) -> Result<http.Request, Error> {
+    let mut req = http.newRequest(Get, dnsRecordsUrl(client)?)
+        .withHeaders(headers(client))
+    let mut query: QueryValues = {:}
+    if !strings.trimSpace(typ).isEmpty() {
+        query.insert("type", [strings.toUpper(strings.trimSpace(typ))])
+    }
+    if !strings.trimSpace(name).isEmpty() {
+        query.insert("name", [strings.trimSpace(name)])
+    }
+    if !query.isEmpty() {
+        req = req.withQuery(query)
+    }
+    Ok(req)
+}
+
+pub fn createDnsRecordHttpRequest(client: Client, record: DnsRecord) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Post, dnsRecordsUrl(client)?)
+        .withHeaders(jsonHeaders(client))
+        .withText(dnsRecordBody(record))
+        .withContentType("application/json"))
+}
+
+pub fn updateDnsRecordHttpRequest(client: Client, recordId: String, record: DnsRecord) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Put, dnsRecordUrl(client, recordId)?)
+        .withHeaders(jsonHeaders(client))
+        .withText(dnsRecordBody(record))
+        .withContentType("application/json"))
+}
+
+pub fn deleteDnsRecordHttpRequest(client: Client, recordId: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Delete, dnsRecordUrl(client, recordId)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn purgeEverything() -> CachePurge {
+    CachePurge { purgeEverything: true }
+}
+
+pub fn purgeFiles(files: List<String>) -> CachePurge {
+    CachePurge { files: files }
+}
+
+pub fn purgeTags(tags: List<String>) -> CachePurge {
+    CachePurge { tags: tags }
+}
+
+pub fn purgeHosts(hosts: List<String>) -> CachePurge {
+    CachePurge { hosts: hosts }
+}
+
+pub fn purgePrefixes(prefixes: List<String>) -> CachePurge {
+    CachePurge { prefixes: prefixes }
+}
+
+pub fn cachePurgeHttpRequest(client: Client, purge: CachePurge) -> Result<http.Request, Error> {
+    validatePurge(purge)?
+    Ok(http.newRequest(Post, zoneUrl(client, "purge_cache")?)
+        .withHeaders(jsonHeaders(client))
+        .withText(cachePurgeBody(purge))
+        .withContentType("application/json"))
+}
+
+pub fn workerUrl(subdomain: String, scriptName: String) -> Result<String, Error> {
+    let cleanSubdomain = cleanWorkerSubdomain(subdomain)?
+    let cleanScript = cleanWorkerScriptName(scriptName)?
+    Ok("https://{cleanScript}.{cleanSubdomain}.workers.dev")
+}
+
+pub fn workerInvokeEmptyHttpRequest(url: String, method: http.Method) -> Result<http.Request, Error> {
+    workerInvokeHttpRequest(url, method, bytes.fromString(""))
+}
+
+pub fn workerInvokeEmptyWithTokenHttpRequest(url: String, method: http.Method, bearerToken: String) -> Result<http.Request, Error> {
+    workerInvokeWithTokenHttpRequest(url, method, bytes.fromString(""), bearerToken)
+}
+
+pub fn workerInvokeHttpRequest(url: String, method: http.Method, body: Bytes) -> Result<http.Request, Error> {
+    workerInvokeWithTokenHttpRequest(url, method, body, "")
+}
+
+pub fn workerInvokeWithTokenHttpRequest(url: String, method: http.Method, body: Bytes, bearerToken: String) -> Result<http.Request, Error> {
+    let cleanUrl = strings.trimSpace(url)
+    if cleanUrl.isEmpty() {
+        return Err(error.new("cloudflare: Worker URL is empty"))
+    }
+    let mut req = http.newRequest(method, cleanUrl).withBody(body)
+    if !strings.trimSpace(bearerToken).isEmpty() {
+        req = req.withBearerToken(strings.trimSpace(bearerToken))
+    }
+    Ok(req)
+}
+
+pub fn workerInvokeJsonHttpRequest<T>(url: String, payload: T) -> Result<http.Request, Error> {
+    workerInvokeJsonWithTokenHttpRequest(url, payload, "")
+}
+
+pub fn workerInvokeJsonWithTokenHttpRequest<T>(url: String, payload: T, bearerToken: String) -> Result<http.Request, Error> {
+    let cleanUrl = strings.trimSpace(url)
+    if cleanUrl.isEmpty() {
+        return Err(error.new("cloudflare: Worker URL is empty"))
+    }
+    let mut req = http.newRequest(Post, cleanUrl).withJson(payload)
+    if !strings.trimSpace(bearerToken).isEmpty() {
+        req = req.withBearerToken(strings.trimSpace(bearerToken))
+    }
+    Ok(req)
+}
+
+pub fn workerScriptUrl(client: Client, scriptName: String) -> Result<String, Error> {
+    accountUrl(client, "workers/scripts/{encodePathSegment(cleanWorkerScriptName(scriptName)?)}")
+}
+
+pub fn getWorkerScriptHttpRequest(client: Client, scriptName: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Get, workerScriptUrl(client, scriptName)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn deleteWorkerScriptHttpRequest(client: Client, scriptName: String) -> Result<http.Request, Error> {
+    Ok(http.newRequest(Delete, workerScriptUrl(client, scriptName)?)
+        .withHeaders(headers(client)))
+}
+
+pub fn sendJson<T>(request: http.Request) -> Result<T, Error> {
+    let response = http.request(request)?
+    let ok = requireSuccess(response)?
+    ok.json::<T>()
+}
+
+pub fn requireSuccess(response: http.Response) -> Result<http.Response, Error> {
+    if response.isSuccess() {
+        return Ok(response)
+    }
+    Err(error.new(parseApiError(response).summary()))
+}
+
+pub fn parseApiError(response: http.Response) -> ApiError {
+    let text = response.text().unwrapOr("")
+    let mut out = ApiError { status: response.status, rawJson: text }
+    match json.parseValue(text) {
+        Ok(root) -> {
+            match firstError(root) {
+                Some(err) -> {
+                    out.code = numberOrStringField(err, "code")
+                    out.message = stringField(err, "message")
+                },
+                None -> {
+                    out.code = numberOrStringField(root, "code")
+                    out.message = stringField(root, "message")
+                },
+            }
+        },
+        Err(_) -> {
+            out.message = strings.trimSpace(text)
+        },
+    }
+    out
+}
+
+fn validateClient(client: Client) -> Result<(), Error> {
+    if strings.trimSpace(client.apiBaseUrl).isEmpty() {
+        return Err(error.new("cloudflare: API base URL is empty"))
+    }
+    if strings.trimSpace(client.apiToken).isEmpty() {
+        return Err(error.new("cloudflare: API token is empty"))
+    }
+    Ok(())
+}
+
+fn validateTurnstile(challenge: TurnstileChallenge) -> Result<(), Error> {
+    let _ = turnstile(challenge.secret, challenge.response)?
+    Ok(())
+}
+
+fn baseHeaders(client: Client, contentType: String) -> Headers {
+    let mut out: Headers = {:}
+    if !strings.trimSpace(client.apiToken).isEmpty() {
+        out.insert("Authorization", "Bearer {strings.trimSpace(client.apiToken)}")
+    }
+    if !strings.trimSpace(contentType).isEmpty() {
+        out.insert("Content-Type", strings.trimSpace(contentType))
+    }
+    if !strings.trimSpace(client.clientInfo).isEmpty() {
+        out.insert("User-Agent", strings.trimSpace(client.clientInfo))
+    }
+    for (name, value) in client.extraHeaders {
+        out.insert(name, value)
+    }
+    out
+}
+
+fn apiUrl(client: Client, path: String) -> String {
+    joinUrl(client.apiBaseUrl, path)
+}
+
+fn kvPutQuery(opts: KvPutOptions) -> Result<QueryValues, Error> {
+    if opts.expiration < 0 || opts.expirationTtl < 0 {
+        return Err(error.new("cloudflare: KV expiration values must not be negative"))
+    }
+    let mut query: QueryValues = {:}
+    if opts.expiration > 0 {
+        query.insert("expiration", [opts.expiration.toString()])
+    }
+    if opts.expirationTtl > 0 {
+        query.insert("expiration_ttl", [opts.expirationTtl.toString()])
+    }
+    Ok(query)
+}
+
+fn r2SignedHeaders(signer: R2Signer, method: String, bucket: String, key: String, payloadHash: String, contentType: String, dates: R2SigningDates) -> Result<Headers, Error> {
+    let cleanBucket = cleanBucketName(bucket)?
+    let encodedKey = encodeObjectPath(key)?
+    let host = "{signer.accountId}.r2.cloudflarestorage.com"
+    let scope = "{dates.shortDate}/auto/s3/aws4_request"
+    let canonicalUri = "/{encodePathSegment(cleanBucket)}/{encodedKey}"
+    let canonicalHeaders = r2CanonicalHeaders(host, contentType, payloadHash, dates.amzDate, signer.sessionToken)
+    let signedHeaders = r2SignedHeaderNames(contentType, signer.sessionToken)
+    let canonicalRequest = "{strings.toUpper(method)}\n{canonicalUri}\n\n{canonicalHeaders}\n{signedHeaders}\n{payloadHash}"
+    let stringToSign = "AWS4-HMAC-SHA256\n{dates.amzDate}\n{scope}\n{sha256Hex(bytes.fromString(canonicalRequest))}"
+    let signature = r2SignatureHex(signer.secretAccessKey, dates.shortDate, stringToSign)
+    let authorization = "AWS4-HMAC-SHA256 Credential={signer.accessKeyId}/{scope}, SignedHeaders={signedHeaders}, Signature={signature}"
+    let mut out: Headers = {
+        "Host": host,
+        "x-amz-content-sha256": payloadHash,
+        "x-amz-date": dates.amzDate,
+        "Authorization": authorization,
+    }
+    if !strings.trimSpace(contentType).isEmpty() {
+        out.insert("Content-Type", strings.trimSpace(contentType))
+    }
+    if !strings.trimSpace(signer.sessionToken).isEmpty() {
+        out.insert("x-amz-security-token", strings.trimSpace(signer.sessionToken))
+    }
+    Ok(out)
+}
+
+fn r2CanonicalHeaders(host: String, contentType: String, payloadHash: String, amzDate: String, sessionToken: String) -> String {
+    let mut out = ""
+    if !strings.trimSpace(contentType).isEmpty() {
+        out = "{out}content-type:{strings.trimSpace(contentType)}\n"
+    }
+    out = "{out}host:{strings.trimSpace(host)}\n"
+    out = "{out}x-amz-content-sha256:{payloadHash}\n"
+    out = "{out}x-amz-date:{strings.trimSpace(amzDate)}\n"
+    if !strings.trimSpace(sessionToken).isEmpty() {
+        out = "{out}x-amz-security-token:{strings.trimSpace(sessionToken)}\n"
+    }
+    out
+}
+
+fn r2SignedHeaderNames(contentType: String, sessionToken: String) -> String {
+    let mut names: List<String> = []
+    if !strings.trimSpace(contentType).isEmpty() {
+        names.push("content-type")
+    }
+    names.push("host")
+    names.push("x-amz-content-sha256")
+    names.push("x-amz-date")
+    if !strings.trimSpace(sessionToken).isEmpty() {
+        names.push("x-amz-security-token")
+    }
+    strings.join(names, ";")
+}
+
+fn r2SignatureHex(secret: String, shortDate: String, stringToSign: String) -> String {
+    let kDate = crypto.hmac.sha256(bytes.fromString("AWS4{secret}"), bytes.fromString(shortDate))
+    let kRegion = crypto.hmac.sha256(kDate, bytes.fromString("auto"))
+    let kService = crypto.hmac.sha256(kRegion, bytes.fromString("s3"))
+    let kSigning = crypto.hmac.sha256(kService, bytes.fromString("aws4_request"))
+    encoding.hex.encode(crypto.hmac.sha256(kSigning, bytes.fromString(stringToSign)))
+}
+
+fn sha256Hex(data: Bytes) -> String {
+    encoding.hex.encode(crypto.sha256(data))
+}
+
+fn dnsRecordBody(record: DnsRecord) -> String {
+    let mut props = [
+        prop("type", quote(record.typ.toString())),
+        prop("name", quote(strings.trimSpace(record.name))),
+        prop("content", quote(strings.trimSpace(record.content))),
+        prop("ttl", record.ttl.toString()),
+        prop("proxied", boolJson(record.proxied)),
+    ]
+    if !strings.trimSpace(record.comment).isEmpty() {
+        props.push(prop("comment", quote(strings.trimSpace(record.comment))))
+    }
+    if record.priority > 0 {
+        props.push(prop("priority", record.priority.toString()))
+    }
+    object(props)
+}
+
+fn cachePurgeBody(purge: CachePurge) -> String {
+    if purge.purgeEverything {
+        return object([prop("purge_everything", "true")])
+    }
+    let mut props: List<String> = []
+    if !purge.files.isEmpty() {
+        props.push(prop("files", quoteList(cleanStringList("cache file", purge.files))))
+    }
+    if !purge.tags.isEmpty() {
+        props.push(prop("tags", quoteList(cleanStringList("cache tag", purge.tags))))
+    }
+    if !purge.hosts.isEmpty() {
+        props.push(prop("hosts", quoteList(cleanStringList("cache host", purge.hosts))))
+    }
+    if !purge.prefixes.isEmpty() {
+        props.push(prop("prefixes", quoteList(cleanStringList("cache prefix", purge.prefixes))))
+    }
+    object(props)
+}
+
+fn validatePurge(purge: CachePurge) -> Result<(), Error> {
+    if purge.purgeEverything {
+        return Ok(())
+    }
+    if purge.files.isEmpty() && purge.tags.isEmpty() && purge.hosts.isEmpty() && purge.prefixes.isEmpty() {
+        return Err(error.new("cloudflare: cache purge target is empty"))
+    }
+    Ok(())
+}
+
+fn cleanIdentifier(kind: String, value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: {kind} is empty"))
+    }
+    if clean.charCount() > 128 {
+        return Err(error.new("cloudflare: {kind} is too long"))
+    }
+    if strings.containsAny(clean, "/?# \t\r\n") {
+        return Err(error.new("cloudflare: invalid {kind}: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanIdentifierList(kind: String, items: List<String>) -> Result<List<String>, Error> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(cleanIdentifier(kind, item)?)
+    }
+    Ok(out)
+}
+
+fn cleanName(kind: String, value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: {kind} is empty"))
+    }
+    if strings.containsAny(clean, "\r\n") {
+        return Err(error.new("cloudflare: invalid {kind}: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanBucketName(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.charCount() < 3 || clean.charCount() > 64 {
+        return Err(error.new("cloudflare: R2 bucket name must be 3..64 characters"))
+    }
+    if strings.containsAny(clean, "/?# \t\r\n") {
+        return Err(error.new("cloudflare: invalid R2 bucket name: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanKeyName(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: KV key is empty"))
+    }
+    if clean.bytes().len() > 512 {
+        return Err(error.new("cloudflare: KV key is too long"))
+    }
+    if strings.containsAny(clean, "\r\n\t ") {
+        return Err(error.new("cloudflare: invalid KV key: {value}"))
+    }
+    Ok(clean)
+}
+
+fn encodeKeyName(value: String) -> Result<String, Error> {
+    Ok(encoding.url.encode(cleanKeyName(value)?))
+}
+
+fn cleanRelativePath(value: String) -> Result<String, Error> {
+    let clean = strings.trimPrefix(strings.trimSpace(value), "/")
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: path is empty"))
+    }
+    if strings.contains(clean, "..") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("cloudflare: unsafe path: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanObjectPath(value: String) -> Result<String, Error> {
+    let clean = strings.trimPrefix(strings.trimSpace(value), "/")
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: object path is empty"))
+    }
+    if strings.contains(clean, "..") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("cloudflare: unsafe object path: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanObjectList(items: List<String>) -> Result<List<String>, Error> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(cleanObjectPath(item)?)
+    }
+    Ok(out)
+}
+
+fn encodeObjectPath(path: String) -> Result<String, Error> {
+    let clean = cleanObjectPath(path)?
+    let mut parts: List<String> = []
+    for part in strings.split(clean, "/") {
+        if strings.trimSpace(part).isEmpty() {
+            return Err(error.new("cloudflare: object path contains an empty segment"))
+        }
+        parts.push(encodePathSegment(part))
+    }
+    Ok(strings.join(parts, "/"))
+}
+
+fn cleanWorkerSubdomain(value: String) -> Result<String, Error> {
+    let clean = strings.trimSuffix(strings.trimSpace(value), ".workers.dev")
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: Worker subdomain is empty"))
+    }
+    if strings.containsAny(clean, "/?# \t\r\n") {
+        return Err(error.new("cloudflare: invalid Worker subdomain: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanWorkerScriptName(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("cloudflare: Worker script name is empty"))
+    }
+    if strings.containsAny(clean, "/?# \t\r\n") {
+        return Err(error.new("cloudflare: invalid Worker script name: {value}"))
+    }
+    Ok(clean)
+}
+
+fn cleanStringList(kind: String, items: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for item in items {
+        let clean = strings.trimSpace(item)
+        if !clean.isEmpty() {
+            out.push(clean)
+        }
+    }
+    out
+}
+
+fn encodePathSegment(segment: String) -> String {
+    encoding.url.encode(segment)
+}
+
+fn stripTrailingSlash(value: String) -> String {
+    let mut out = strings.trimSpace(value)
+    for strings.endsWith(out, "/") {
+        out = strings.trimSuffix(out, "/")
+    }
+    out
+}
+
+fn joinUrl(base: String, path: String) -> String {
+    let cleanBase = stripTrailingSlash(base)
+    if strings.startsWith(path, "/") {
+        "{cleanBase}{path}"
+    } else {
+        "{cleanBase}/{path}"
+    }
+}
+
+fn normalizedJsonObject(text: String) -> String {
+    let raw = strings.trimSpace(text)
+    if raw.isEmpty() {
+        return "\{\}"
+    }
+    match json.parseValue(raw) {
+        Ok(value) -> match json.asObject(value) {
+            Ok(_)  -> json.stringifyValue(value),
+            Err(_) -> "\{\}",
+        },
+        Err(_) -> "\{\}",
+    }
+}
+
+fn normalizedJsonValue(text: String) -> String {
+    let raw = strings.trimSpace(text)
+    if raw.isEmpty() {
+        return "null"
+    }
+    match json.parseValue(raw) {
+        Ok(value) -> json.stringifyValue(value),
+        Err(_)    -> quote(raw),
+    }
+}
+
+fn field(obj: json.Json, key: String) -> json.Json? {
+    match json.getField(obj, key) {
+        Ok(value) -> Some(value),
+        Err(_)    -> None,
+    }
+}
+
+fn stringField(obj: json.Json, key: String) -> String {
+    match field(obj, key) {
+        Some(value) -> match json.asString(value) {
+            Ok(text) -> text,
+            Err(_)   -> "",
+        },
+        None -> "",
+    }
+}
+
+fn numberOrStringField(obj: json.Json, key: String) -> String {
+    match field(obj, key) {
+        Some(value) -> match json.asString(value) {
+            Ok(text) -> text,
+            Err(_)   -> match json.asNumber(value) {
+                Ok(number) -> number.toInt().toString(),
+                Err(_)     -> "",
+            },
+        },
+        None -> "",
+    }
+}
+
+fn boolField(obj: json.Json, key: String) -> Bool {
+    match field(obj, key) {
+        Some(value) -> match json.asBool(value) {
+            Ok(flag) -> flag,
+            Err(_)   -> false,
+        },
+        None -> false,
+    }
+}
+
+fn stringArrayField(obj: json.Json, key: String) -> List<String> {
+    match field(obj, key) {
+        Some(value) -> match json.asArray(value) {
+            Ok(items) -> {
+                let mut out: List<String> = []
+                for item in items {
+                    match json.asString(item) {
+                        Ok(text) -> out.push(text),
+                        Err(_)   -> {},
+                    }
+                }
+                out
+            },
+            Err(_) -> [],
+        },
+        None -> [],
+    }
+}
+
+fn firstError(root: json.Json) -> json.Json? {
+    match field(root, "errors") {
+        Some(value) -> match json.asArray(value) {
+            Ok(items) -> {
+                if items.isEmpty() {
+                    return None
+                }
+                Some(items[0])
+            },
+            Err(_) -> None,
+        },
+        None -> None,
+    }
+}
+
+fn object(props: List<String>) -> String {
+    let open = 123.toChar()
+    let close = 125.toChar()
+    let sep = ","
+    "{open}{strings.join(props, sep)}{close}"
+}
+
+fn array(items: List<String>) -> String {
+    let sep = ","
+    "[{strings.join(items, sep)}]"
+}
+
+fn prop(name: String, value: String) -> String {
+    "{quote(name)}:{value}"
+}
+
+fn quoteList(items: List<String>) -> String {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(quote(item))
+    }
+    array(out)
+}
+
+fn quote(text: String) -> String {
+    json.stringifyValue(json.string(text))
+}
+
+fn boolJson(value: Bool) -> String {
+    if value { "true" } else { "false" }
+}


### PR DESCRIPTION
## Summary
- add `std.cloudflare` request builders for Turnstile, KV, R2, Queues, DNS, cache purge, and Worker invocation
- include R2 S3-compatible SigV4 object request helpers and typed API error parsing
- lock the public surface with stdlib/backend tests and update `STDLIB_MATRIX.md`

## Validation
- `go run ./cmd/osty check internal/stdlib/modules/cloudflare.osty`
- `go test -count=1 -vet=off ./internal/stdlib -run 'TestCloudflare'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultCloudflare'`
- `just fmt-check`
- `git diff --check`

Note: a broader `go test -count=1 -vet=off ./internal/backend` run failed on unrelated macOS Keychain runtime linker symbols (`SecKeychain*` / `CFRelease`), while the focused Cloudflare backend check passed after rebasing onto `origin/main`.