### PR TITLE
stdlib: deepen Supabase helpers

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
+++ b/LANG_SPEC_v0.5/10-standard-library/43-supabase.md
@@ -11,18 +11,19 @@ ready-to-send HTTP requests for Supabase's stable gateway paths:
 - GraphQL under `/graphql/v1`
 
 ```osty
-use std.env
 use std.supabase
 
-let sb = supabase.project(env.require("SUPABASE_PROJECT_REF")?, env.require("SUPABASE_ANON_KEY")?)?
+let sb = supabase.fromEnv()?
 let q = supabase.from("todos")?
     .select("id,title,completed")
     .eq("completed", "false")?
     .orderDesc("created_at")?
+    .withCount(supabase.CountExact)
     .range(0, 19)?
 
-let req = supabase.selectHttpRequest(sb, q)?
-let rows = supabase.sendSelect::<List<Todo>>(sb, q)?
+let page = supabase.sendSelectPage::<List<Todo>>(sb, q)?
+let rows = page.value
+let total = page.count()
 ```
 
 Core types:
@@ -31,6 +32,9 @@ Core types:
 pub struct Client
 pub struct TableQuery
 pub struct Prefer
+pub struct StorageSort
+pub struct PageInfo
+pub struct Page<T>
 pub struct ApiError
 
 pub enum CountMode { CountNone, CountExact, CountPlanned, CountEstimated }
@@ -46,6 +50,9 @@ Configuration:
 supabase.client(baseUrl, apiKey) -> Result<Client, Error>
 supabase.project(projectRef, apiKey) -> Result<Client, Error>
 supabase.local(apiKey) -> Result<Client, Error>
+supabase.fromEnv() -> Result<Client, Error>
+supabase.serviceRoleFromEnv() -> Result<Client, Error>
+supabase.fromEnvNames(urlName, keyName) -> Result<Client, Error>
 
 client.withAccessToken(jwt)
 client.withServiceRoleKey(key)
@@ -58,6 +65,12 @@ client.withHeader(name, value)
 When no session token is configured, the bearer value is the API key itself so
 the value exactly matches the `apikey` header. Non-`public` schemas add
 `Accept-Profile` and `Content-Profile`.
+
+`fromEnv()` reads `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
+`serviceRoleFromEnv()` reads `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY`, and configures the service role key as both the
+`apikey` and bearer token. `fromEnvNames()` is the same pattern with custom
+environment variable names.
 
 PostgREST query helpers:
 
@@ -92,6 +105,23 @@ query.single()
 query.csv()
 ```
 
+Pagination metadata:
+
+```osty
+supabase.parseContentRange(value) -> Result<PageInfo, Error>
+supabase.pageInfo(response) -> Result<PageInfo?, Error>
+supabase.responseCount(response) -> Result<Int?, Error>
+
+page.returned()
+page.isEmpty()
+page.hasTotal()
+page.hasNext()
+```
+
+`PageInfo` parses PostgREST `Content-Range` headers such as `0-19/123`
+or `0-19/*`. It is intended to pair with `query.withCount(CountExact)`,
+`CountPlanned`, or `CountEstimated`.
+
 Requests:
 
 ```osty
@@ -113,6 +143,7 @@ Convenience senders execute those requests through `std.http.request`, require
 
 ```osty
 supabase.sendSelect<T>(client, query)
+supabase.sendSelectPage<T>(client, query)
 supabase.sendInsert<T, U>(client, table, value)
 supabase.sendInsertWithPrefer<T, U>(client, table, value, prefer)
 supabase.sendUpdate<T, U>(client, query, value)
@@ -141,10 +172,22 @@ supabase.downloadObjectHttpRequest(client, bucket, path)
 supabase.uploadObjectHttpRequest(client, bucket, path, body, contentType, upsert)
 supabase.updateObjectHttpRequest(client, bucket, path, body, contentType)
 supabase.removeObjectHttpRequest(client, bucket, paths)
+supabase.signedObjectUrlHttpRequest(client, bucket, path, expiresInSeconds)
+supabase.signedObjectUrlWithTransformHttpRequest(client, bucket, path, expiresInSeconds, transformJson)
+supabase.signedObjectsHttpRequest(client, bucket, paths, expiresInSeconds)
+supabase.storageSort(column, direction)
+supabase.listObjectsHttpRequest(client, bucket, prefix, limit, offset)
+supabase.listObjectsSortedHttpRequest(client, bucket, prefix, limit, offset, sort)
+supabase.searchObjectsHttpRequest(client, bucket, prefix, search, limit, offset)
 
 supabase.invokeFunctionHttpRequest(client, functionName, payload)
 supabase.graphqlHttpRequest(client, bodyJson)
 ```
+
+Signed download requests follow Supabase Storage's `/object/sign/...`
+endpoints. List/search requests target `/object/list/{bucket}` and emit the
+documented `prefix`, `limit`, `offset`, optional `sortBy`, and optional
+`search` JSON fields.
 
 Errors:
 

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -92,7 +92,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | watch | 535 | pure Osty + fs/time/cmd | polling file watcher: fs.watch snapshot parsing, typed create/modify/remove diff, debounce, hidden/build-dir filters, transform/sync command tasks |
 | clipboard | 125 | pure Osty + os | host clipboard text read/write via pbpaste/pbcopy, Wayland, X11, AppleScript, PowerShell |
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
-| supabase | 927 | pure Osty + http/json | Supabase PostgREST/Auth/Storage/Functions/GraphQL request builders, API-key/session headers, filters, Prefer headers, storage object URLs, and response error helpers |
+| supabase | 1214 | pure Osty + http/json/env | Supabase PostgREST/Auth/Storage/Functions/GraphQL request builders, env-backed config, API-key/session headers, filters, Prefer/count headers, typed select pages, Content-Range metadata, signed Storage URLs, storage listing/search, object URLs, and response error helpers |
 | github | 1127 | pure Osty + http/json/crypto | GitHub REST request builders for issues, PRs, Actions, releases, release asset upload, typed error parsing, and webhook HMAC/constant-time verification |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
@@ -183,7 +183,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | QR / 바코드 문서 | ✅ 가능 | qr + barcode (QR payload/qrencode 계획, ZBar/ZXing 인식 파싱, Code39/EAN-13/UPC-A SVG 렌더링) |
 | SQL 쿼리 조립 | ✅ 가능 | sql (identifier quoting / value literals / dialect placeholders / CRUD builders) |
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
-| Supabase 앱 백엔드 연결 | ✅ 가능 | supabase + http/json/secrets (PostgREST filters/mutations/RPC, Auth password-token requests, Storage object URLs/uploads, Edge Function/GraphQL requests) |
+| Supabase 앱 백엔드 연결 | ✅ 가능 | supabase + http/json/env/secrets (env-backed clients, PostgREST filters/mutations/RPC/count metadata, Auth password-token requests, Storage object URLs/uploads/signed URLs/listing, Edge Function/GraphQL requests) |
 | GitHub 개발 자동화 | ✅ 가능 | github + http/json/crypto (issue/PR request builders, Actions dispatch/runs/jobs/artifacts, release/create/upload, webhook HMAC verification) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |

--- a/internal/stdlib/modules/supabase.osty
+++ b/internal/stdlib/modules/supabase.osty
@@ -8,6 +8,7 @@
 
 use std.bytes
 use std.encoding
+use std.env
 use std.error
 use std.http
 use std.json
@@ -83,6 +84,18 @@ pub enum NullOrdering {
             NullsFirst   -> ".nullsfirst",
             NullsLast    -> ".nullslast",
         }
+    }
+}
+
+pub struct StorageSort {
+    pub column: String,
+    pub direction: OrderDirection,
+
+    pub fn toJson(self) -> String {
+        object([
+            prop("column", quote(strings.trimSpace(self.column))),
+            prop("order", quote(self.direction.toString())),
+        ])
     }
 }
 
@@ -311,6 +324,54 @@ pub struct TableQuery {
     }
 }
 
+pub struct PageInfo {
+    pub from: Int,
+    pub to: Int,
+    pub total: Int? = None,
+    pub contentRange: String = "",
+
+    pub fn returned(self) -> Int {
+        if self.to < self.from {
+            return 0
+        }
+        self.to - self.from + 1
+    }
+
+    pub fn isEmpty(self) -> Bool {
+        self.returned() == 0
+    }
+
+    pub fn hasTotal(self) -> Bool {
+        self.total.isSome()
+    }
+
+    pub fn hasNext(self) -> Bool {
+        match self.total {
+            Some(total) -> self.to >= self.from && self.to + 1 < total,
+            None        -> false,
+        }
+    }
+}
+
+pub struct Page<T> {
+    pub value: T,
+    pub info: PageInfo? = None,
+
+    pub fn count(self) -> Int? {
+        match self.info {
+            Some(info) -> info.total,
+            None       -> noneInt(),
+        }
+    }
+
+    pub fn hasNext(self) -> Bool {
+        match self.info {
+            Some(info) -> info.hasNext(),
+            None       -> false,
+        }
+    }
+}
+
 pub struct ApiError {
     pub status: Int,
     pub code: String = "",
@@ -372,6 +433,22 @@ pub fn project(projectRef: String, apiKey: String) -> Result<Client, Error> {
 
 pub fn local(apiKey: String) -> Result<Client, Error> {
     client("http://127.0.0.1:54321", apiKey)
+}
+
+pub fn fromEnv() -> Result<Client, Error> {
+    fromEnvNames("SUPABASE_URL", "SUPABASE_ANON_KEY")
+}
+
+pub fn serviceRoleFromEnv() -> Result<Client, Error> {
+    let url = env.require("SUPABASE_URL")?
+    let key = env.require("SUPABASE_SERVICE_ROLE_KEY")?
+    Ok(client(url, key)?.withServiceRoleKey(key))
+}
+
+pub fn fromEnvNames(urlName: String, keyName: String) -> Result<Client, Error> {
+    let url = env.require(cleanEnvName(urlName)?)?
+    let key = env.require(cleanEnvName(keyName)?)?
+    client(url, key)
 }
 
 pub fn from(table: String) -> Result<TableQuery, Error> {
@@ -580,6 +657,66 @@ pub fn removeObjectHttpRequest(client: Client, bucket: String, paths: List<Strin
         .withContentType("application/json"))
 }
 
+pub fn storageSort(column: String, direction: OrderDirection) -> Result<StorageSort, Error> {
+    Ok(StorageSort {
+        column: cleanName("storage sort column", column)?,
+        direction: direction,
+    })
+}
+
+pub fn signedObjectUrlHttpRequest(client: Client, bucket: String, path: String, expiresInSeconds: Int) -> Result<http.Request, Error> {
+    validateClient(client)?
+    let body = signedUrlBody(expiresInSeconds, "")?
+    Ok(http.newRequest(http.Post, storageUrl(client, "object/sign/{encodePathSegment(cleanName(\"bucket\", bucket)?)}" +
+        "/{encodeObjectPath(path)?}")?)
+        .withHeaders(storageHeaders(client, "application/json"))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn signedObjectUrlWithTransformHttpRequest(client: Client, bucket: String, path: String, expiresInSeconds: Int, transformJson: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    let transform = jsonObjectOrError("storage transform", transformJson)?
+    let body = signedUrlBody(expiresInSeconds, transform)?
+    Ok(http.newRequest(http.Post, storageUrl(client, "object/sign/{encodePathSegment(cleanName(\"bucket\", bucket)?)}" +
+        "/{encodeObjectPath(path)?}")?)
+        .withHeaders(storageHeaders(client, "application/json"))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn signedObjectsHttpRequest(client: Client, bucket: String, paths: List<String>, expiresInSeconds: Int) -> Result<http.Request, Error> {
+    validateClient(client)?
+    validateExpiresIn(expiresInSeconds)?
+    if paths.isEmpty() {
+        return Err(error.new("supabase: signed URL paths are empty"))
+    }
+    let mut items: List<String> = []
+    for path in paths {
+        items.push(quote(cleanObjectPath(path)?))
+    }
+    let body = object([
+        prop("expiresIn", expiresInSeconds.toString()),
+        prop("paths", array(items)),
+    ])
+    Ok(http.newRequest(http.Post, storageUrl(client, "object/sign/{encodePathSegment(cleanName(\"bucket\", bucket)?)}")?)
+        .withHeaders(storageHeaders(client, "application/json"))
+        .withText(body)
+        .withContentType("application/json"))
+}
+
+pub fn listObjectsHttpRequest(client: Client, bucket: String, prefix: String = "", limit: Int = 100, offset: Int = 0) -> Result<http.Request, Error> {
+    listObjectsRequest(client, bucket, prefix, limit, offset, None, "")
+}
+
+pub fn listObjectsSortedHttpRequest(client: Client, bucket: String, prefix: String, limit: Int, offset: Int, sort: StorageSort) -> Result<http.Request, Error> {
+    listObjectsRequest(client, bucket, prefix, limit, offset, Some(sort), "")
+}
+
+pub fn searchObjectsHttpRequest(client: Client, bucket: String, prefix: String, search: String, limit: Int = 100, offset: Int = 0) -> Result<http.Request, Error> {
+    listObjectsRequest(client, bucket, prefix, limit, offset, None, search)
+}
+
 pub fn invokeFunctionHttpRequest<T>(client: Client, functionName: String, payload: T) -> Result<http.Request, Error> {
     validateClient(client)?
     Ok(http.newRequest(http.Post, functionsUrl(client, functionName)?)
@@ -598,6 +735,16 @@ pub fn graphqlHttpRequest(client: Client, bodyJson: String) -> Result<http.Reque
 pub fn sendSelect<T>(client: Client, query: TableQuery) -> Result<T, Error> {
     let res = http.request(selectHttpRequest(client, query)?)?
     requireSuccess(res)?.json::<T>()
+}
+
+pub fn sendSelectPage<T>(client: Client, query: TableQuery) -> Result<Page<T>, Error> {
+    let res = requireSuccess(http.request(selectHttpRequest(client, query)?)?)?
+    let info = pageInfo(res)?
+    let value = res.json::<T>()?
+    Ok(Page<T> {
+        value: value,
+        info: info,
+    })
 }
 
 pub fn sendInsert<T, U>(client: Client, table: String, value: T) -> Result<U, Error> {
@@ -660,6 +807,56 @@ pub fn requireSuccess(response: http.Response) -> Result<http.Response, Error> {
     Err(error.new(parseApiError(response).summary()))
 }
 
+pub fn parseContentRange(value: String) -> Result<PageInfo, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("supabase: Content-Range header is empty"))
+    }
+    let parts = strings.split(clean, "/")
+    if parts.len() != 2 {
+        return Err(error.new("supabase: invalid Content-Range header: {value}"))
+    }
+    let rangePart = strings.trimSpace(parts[0])
+    let total = parseContentRangeTotal(parts[1])?
+    if rangePart == "*" {
+        return Ok(PageInfo {
+            from: 0,
+            to: -1,
+            total: total,
+            contentRange: clean,
+        })
+    }
+    let bounds = strings.split(rangePart, "-")
+    if bounds.len() != 2 {
+        return Err(error.new("supabase: invalid Content-Range range: {value}"))
+    }
+    let from = strings.trimSpace(bounds[0]).toInt()?
+    let to = strings.trimSpace(bounds[1]).toInt()?
+    if from < 0 || to < from {
+        return Err(error.new("supabase: invalid Content-Range bounds: {value}"))
+    }
+    Ok(PageInfo {
+        from: from,
+        to: to,
+        total: total,
+        contentRange: clean,
+    })
+}
+
+pub fn pageInfo(response: http.Response) -> Result<PageInfo?, Error> {
+    match response.header("Content-Range") {
+        Some(value) -> Ok(Some(parseContentRange(value)?)),
+        None        -> Ok(None),
+    }
+}
+
+pub fn responseCount(response: http.Response) -> Result<Int?, Error> {
+    match pageInfo(response)? {
+        Some(info) -> Ok(info.total),
+        None       -> Ok(None),
+    }
+}
+
 fn validateClient(client: Client) -> Result<(), Error> {
     if strings.trimSpace(client.baseUrl).isEmpty() {
         return Err(error.new("supabase: base URL is empty"))
@@ -670,8 +867,26 @@ fn validateClient(client: Client) -> Result<(), Error> {
     Ok(())
 }
 
+fn cleanEnvName(value: String) -> Result<String, Error> {
+    let clean = strings.trimSpace(value)
+    if clean.isEmpty() {
+        return Err(error.new("supabase: environment variable name is empty"))
+    }
+    if strings.contains(clean, "=") || strings.contains(clean, "\n") || strings.contains(clean, "\t") {
+        return Err(error.new("supabase: invalid environment variable name: {value}"))
+    }
+    Ok(clean)
+}
+
 fn validateQuery(query: TableQuery) -> Result<(), Error> {
     let _ = cleanName("table", query.table)?
+    Ok(())
+}
+
+fn validateExpiresIn(value: Int) -> Result<(), Error> {
+    if value <= 0 {
+        return Err(error.new("supabase: expiresIn must be positive"))
+    }
     Ok(())
 }
 
@@ -717,6 +932,33 @@ fn queryHeaders(client: Client, query: TableQuery, mutation: Bool) -> Headers {
     out
 }
 
+fn listObjectsRequest(client: Client, bucket: String, prefix: String, limit: Int, offset: Int, sort: StorageSort?, search: String) -> Result<http.Request, Error> {
+    validateClient(client)?
+    if limit < 0 {
+        return Err(error.new("supabase: storage list limit must not be negative"))
+    }
+    if offset < 0 {
+        return Err(error.new("supabase: storage list offset must not be negative"))
+    }
+    let mut props: List<String> = [
+        prop("prefix", quote(cleanObjectPrefix(prefix)?)),
+        prop("limit", limit.toString()),
+        prop("offset", offset.toString()),
+    ]
+    match sort {
+        Some(value) -> props.push(prop("sortBy", value.toJson())),
+        None        -> {},
+    }
+    let term = strings.trimSpace(search)
+    if !term.isEmpty() {
+        props.push(prop("search", quote(term)))
+    }
+    Ok(http.newRequest(http.Post, storageUrl(client, "object/list/{encodePathSegment(cleanName(\"bucket\", bucket)?)}")?)
+        .withHeaders(storageHeaders(client, "application/json"))
+        .withText(object(props))
+        .withContentType("application/json"))
+}
+
 fn authJsonRequest(client: Client, path: String, body: String) -> Result<http.Request, Error> {
     validateClient(client)?
     Ok(http.newRequest(http.Post, authUrl(client, path)?)
@@ -725,11 +967,32 @@ fn authJsonRequest(client: Client, path: String, body: String) -> Result<http.Re
         .withContentType("application/json"))
 }
 
+fn signedUrlBody(expiresInSeconds: Int, transform: String) -> Result<String, Error> {
+    validateExpiresIn(expiresInSeconds)?
+    let mut props: List<String> = [prop("expiresIn", expiresInSeconds.toString())]
+    if !strings.trimSpace(transform).isEmpty() {
+        props.push(prop("transform", transform))
+    }
+    Ok(object(props))
+}
+
 fn authPasswordBody(email: String, password: String) -> String {
     object([
         prop("email", quote(strings.trimSpace(email))),
         prop("password", quote(password)),
     ])
+}
+
+fn parseContentRangeTotal(value: String) -> Result<Int?, Error> {
+    let clean = strings.trimSpace(value)
+    if clean == "*" {
+        return Ok(noneInt())
+    }
+    let total = clean.toInt()?
+    if total < 0 {
+        return Err(error.new("supabase: invalid Content-Range total: {value}"))
+    }
+    Ok(Some(total))
 }
 
 fn preferHeaderValue(prefer: Prefer) -> String {
@@ -845,6 +1108,14 @@ fn cleanObjectPath(value: String) -> Result<String, Error> {
     Ok(clean)
 }
 
+fn cleanObjectPrefix(value: String) -> Result<String, Error> {
+    let clean = strings.trimPrefix(strings.trimSpace(value), "/")
+    if strings.contains(clean, "..") || strings.contains(clean, "?") || strings.contains(clean, "#") {
+        return Err(error.new("supabase: unsafe storage object prefix: {value}"))
+    }
+    Ok(clean)
+}
+
 fn encodeObjectPath(path: String) -> Result<String, Error> {
     let clean = cleanObjectPath(path)?
     let mut parts: List<String> = []
@@ -882,6 +1153,18 @@ fn isProjectRefChar(c: Char) -> Bool {
     (c >= 'a' && c <= 'z') ||
     (c >= '0' && c <= '9') ||
     c == '-'
+}
+
+fn jsonObjectOrError(kind: String, text: String) -> Result<String, Error> {
+    let raw = strings.trimSpace(text)
+    if raw.isEmpty() {
+        return Err(error.new("supabase: {kind} JSON is empty"))
+    }
+    let value = json.parseValue(raw)?
+    match json.asObject(value) {
+        Ok(_)  -> Ok(json.stringifyValue(value)),
+        Err(_) -> Err(error.new("supabase: {kind} JSON must be an object")),
+    }
 }
 
 fn normalizedJsonObject(text: String) -> String {
@@ -924,4 +1207,8 @@ fn prop(name: String, value: String) -> String {
 
 fn quote(text: String) -> String {
     json.stringifyValue(json.string(text))
+}
+
+fn noneInt() -> Int? {
+    None
 }

--- a/internal/stdlib/supabase_test.go
+++ b/internal/stdlib/supabase_test.go
@@ -20,9 +20,12 @@ func TestSupabaseModuleSurface(t *testing.T) {
 		{"ResolutionMode", resolve.SymEnum},
 		{"OrderDirection", resolve.SymEnum},
 		{"NullOrdering", resolve.SymEnum},
+		{"StorageSort", resolve.SymStruct},
 		{"Prefer", resolve.SymStruct},
 		{"Client", resolve.SymStruct},
 		{"TableQuery", resolve.SymStruct},
+		{"PageInfo", resolve.SymStruct},
+		{"Page", resolve.SymStruct},
 		{"ApiError", resolve.SymStruct},
 	} {
 		sym := mod.Package.PkgScope.LookupLocal(tc.name)
@@ -39,7 +42,7 @@ func TestSupabaseModuleSurface(t *testing.T) {
 
 	for _, name := range []string{
 		"prefer", "preferRepresentation", "preferMinimal",
-		"client", "project", "local", "from",
+		"client", "project", "local", "fromEnv", "serviceRoleFromEnv", "fromEnvNames", "from",
 		"headers", "authHeaders", "storageHeaders",
 		"restUrl", "tableUrl", "rpcUrl", "authUrl", "storageUrl", "functionsUrl", "graphqlUrl",
 		"selectHttpRequest", "insertHttpRequest", "insertWithPreferHttpRequest",
@@ -49,9 +52,11 @@ func TestSupabaseModuleSurface(t *testing.T) {
 		"publicObjectUrl", "authenticatedObjectUrl", "objectUrl",
 		"authenticatedObjectHttpRequest", "downloadObjectHttpRequest", "uploadObjectHttpRequest",
 		"updateObjectHttpRequest", "removeObjectHttpRequest",
+		"storageSort", "signedObjectUrlHttpRequest", "signedObjectUrlWithTransformHttpRequest", "signedObjectsHttpRequest",
+		"listObjectsHttpRequest", "listObjectsSortedHttpRequest", "searchObjectsHttpRequest",
 		"invokeFunctionHttpRequest", "graphqlHttpRequest",
-		"sendSelect", "sendInsert", "sendInsertWithPrefer", "sendUpdate", "sendDelete", "sendRpc", "sendRpcWithPrefer",
-		"parseApiError", "requireSuccess",
+		"sendSelect", "sendSelectPage", "sendInsert", "sendInsertWithPrefer", "sendUpdate", "sendDelete", "sendRpc", "sendRpcWithPrefer",
+		"parseApiError", "requireSuccess", "parseContentRange", "pageInfo", "responseCount",
 	} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
@@ -77,6 +82,7 @@ func TestSupabaseModuleMethodsAreBodied(t *testing.T) {
 		{"ResolutionMode", []string{"toPrefer"}},
 		{"OrderDirection", []string{"toString"}},
 		{"NullOrdering", []string{"toOrderSuffix"}},
+		{"StorageSort", []string{"toJson"}},
 		{"Prefer", []string{"withCount", "withReturning", "withResolution", "withMissingDefault", "headerValue"}},
 		{"Client", []string{"withAccessToken", "withServiceRoleKey", "withSchema", "withClientInfo", "withHeader", "resolvedBearer"}},
 		{"TableQuery", []string{
@@ -85,6 +91,8 @@ func TestSupabaseModuleMethodsAreBodied(t *testing.T) {
 			"textSearch", "order", "orderAsc", "orderDesc", "limit", "offset", "range", "withCount", "withPrefer",
 			"returning", "resolveDuplicates", "single", "csv",
 		}},
+		{"PageInfo", []string{"returned", "isEmpty", "hasTotal", "hasNext"}},
+		{"Page", []string{"count", "hasNext"}},
 		{"ApiError", []string{"summary"}},
 	} {
 		for _, method := range tc.methods {
@@ -109,6 +117,8 @@ func TestSupabaseModulePinsEndpointAndHeaderBehavior(t *testing.T) {
 		`joinUrl(client.baseUrl, "/storage/v1/{cleanRelativePath(path)?}")`,
 		`joinUrl(client.baseUrl, "/functions/v1/{encodePathSegment(cleanName(\"function\", functionName)?)}")`,
 		`joinUrl(client.baseUrl, "/graphql/v1")`,
+		`env.require("SUPABASE_URL")`,
+		`env.require("SUPABASE_SERVICE_ROLE_KEY")`,
 		`out.insert("apikey", strings.trimSpace(client.apiKey))`,
 		`out.insert("Authorization", "Bearer {strings.trimSpace(bearer)}")`,
 		`out.insert("Accept-Profile", strings.trimSpace(client.schema))`,
@@ -123,6 +133,12 @@ func TestSupabaseModulePinsEndpointAndHeaderBehavior(t *testing.T) {
 		`"/{encodeObjectPath(path)?}"`,
 		`h.insert("x-upsert", "true")`,
 		`prop("prefixes", array(items))`,
+		`object/sign/{encodePathSegment(cleanName(\"bucket\", bucket)?)}"`,
+		`object/list/{encodePathSegment(cleanName(\"bucket\", bucket)?)}"`,
+		`prop("expiresIn", expiresInSeconds.toString())`,
+		`prop("sortBy", value.toJson())`,
+		`response.header("Content-Range")`,
+		`Ok(Page<T> {`,
 		`normalizedJsonObject(bodyJson)`,
 		`parseApiError(response).summary()`,
 	} {


### PR DESCRIPTION
## Summary
- add env-backed Supabase client helpers and typed select page/count metadata
- add Storage signed URL, transform, bulk signed URL, list/search/sort request builders
- update Supabase docs, matrix, and surface tests

## Validation
- go test -count=1 -vet=off ./internal/stdlib -run 'TestSupabase|TestStdlibSupportMatrix' -v\n- go test -count=1 -vet=off ./internal/backend -run TestStdlib -v\n- go test -count=1 -vet=off ./internal/stdlib\n- just fmt-check\n- git diff --check