### PR TITLE
[codex] add std.webhook intake layer

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.5/10-standard-library/02-tier-2-production-essentials.md
@@ -50,6 +50,9 @@
   `MEDIA:` token parsing
 - `std.httpretry` — retry/backoff decisions, provider-code/message
   classification, quota/context disambiguation, and LLM-specific retry flags
+- `std.webhook` — verified external callback intake for Stripe, GitHub, Slack,
+  Supabase-style HMAC hooks, and Discord externally verified/Ed25519-modeled
+  hooks, with replay-window checks, idempotency keys, and retry-safe dispatch
 - `std.jsonl` — JSON Lines parsing and append-only record helpers
 - `std.tokenest` — model-family-aware multilingual token estimation with
   explicit calibration state

--- a/LANG_SPEC_v0.5/10-standard-library/45-webhook.md
+++ b/LANG_SPEC_v0.5/10-standard-library/45-webhook.md
@@ -1,0 +1,133 @@
+### 10.45 Webhooks (`std.webhook`)
+
+`std.webhook` is the safe intake layer for HTTP callbacks from external
+systems. It composes with `std.http`, `std.crypto`, `std.encoding`,
+`std.json`, and `std.time` instead of owning a server runtime. The module
+standardizes four things that should happen before business logic runs:
+
+- verify the raw request body against the provider signature
+- reject stale signed timestamps where the provider supplies one
+- derive a stable delivery id for idempotency
+- dispatch through a retry-safe outcome that separates duplicates, in-flight
+  deliveries, handler failures, and intentional retry responses
+
+```osty
+use std.env
+use std.http
+use std.webhook
+
+let policy = webhook.stripe(env.require("STRIPE_WEBHOOK_SECRET")?)
+let store = webhook.emptyStore()
+
+let outcome = webhook.dispatch(request, policy, store, fn(event) {
+    // Business logic runs only after signature and replay checks pass.
+    webhook.ack()
+})
+
+return outcome.response
+```
+
+Core types:
+
+```osty
+pub enum Provider { Stripe, GitHub, Supabase, Slack, Discord, Custom }
+
+pub enum SignatureScheme {
+    StripeV1,
+    GitHubSha256,
+    SlackV0,
+    SupabaseSha256,
+    HmacSha256Hex,
+    HmacSha256Base64,
+    DiscordEd25519,
+    ExternallyVerified,
+}
+
+pub enum VerificationCode {
+    Verified,
+    MissingSecret,
+    MissingSignature,
+    InvalidSignature,
+    MissingTimestamp,
+    InvalidTimestamp,
+    ReplayWindowExceeded,
+    UnsupportedSignature,
+}
+
+pub enum DispatchStatus { Handled, Duplicate, InFlight, Rejected, RetryLater, Failed }
+
+pub struct Policy
+pub struct Verification
+pub struct Event
+pub struct Store
+pub struct DispatchDecision
+pub struct DispatchOutcome
+```
+
+Provider policies:
+
+```osty
+webhook.stripe(secret)
+webhook.github(secret)
+webhook.supabase(secret)
+webhook.slack(secret)
+webhook.discord(publicKey)
+webhook.hmacSha256Hex(secret, header)
+webhook.hmacSha256Base64(secret, header)
+webhook.unsigned(provider)
+```
+
+The built-in provider policies use the provider's raw-body signature shape:
+
+- Stripe: `Stripe-Signature`, signed payload `t.raw_body`, HMAC-SHA256 hex
+  `v1`, default 5-minute tolerance.
+- GitHub: `X-Hub-Signature-256`, `sha256=` + HMAC-SHA256 hex of the raw body,
+  with `X-GitHub-Delivery` and `X-GitHub-Event` as id/type headers.
+- Slack: `X-Slack-Signature`, signed payload `v0:timestamp:raw_body`,
+  `X-Slack-Request-Timestamp`, default 5-minute tolerance.
+- Supabase: configurable HMAC-SHA256 hex convention using
+  `x-supabase-signature`; callers can override headers with `Policy` methods.
+- Discord: models the required `X-Signature-Ed25519` and
+  `X-Signature-Timestamp` headers but returns `UnsupportedSignature` until the
+  runtime exposes Ed25519 verification. Use `policy.externallyVerified()` only
+  when a host layer has already verified the request.
+
+Verification and extraction:
+
+```osty
+webhook.verify(policy, headers, body) -> Verification
+webhook.verifyRequest(request, policy) -> Verification
+webhook.eventFromRequest(request, policy, verification) -> Event
+webhook.header(headers, name) -> String?
+webhook.bodyFingerprint(body) -> String
+```
+
+Dispatch:
+
+```osty
+webhook.dispatch(request, policy, store, handler) -> DispatchOutcome
+webhook.ack() -> DispatchDecision
+webhook.retryLater(message) -> DispatchDecision
+webhook.reject(status, message) -> DispatchDecision
+```
+
+`dispatch` returns `200` for already processed deliveries so provider retries do
+not re-run business logic. In-flight duplicates return `202`, handler errors
+return `500` and clear the in-flight marker, and retry decisions preserve the
+delivery as unprocessed so a later provider retry can run again.
+
+Idempotency helpers:
+
+```osty
+webhook.emptyStore() -> Store
+webhook.idempotencyKey(event) -> String
+webhook.wasProcessed(store, key) -> Bool
+webhook.isInFlight(store, key) -> Bool
+webhook.markInFlight(store, key) -> Store
+webhook.markProcessed(store, key) -> Store
+webhook.clearInFlight(store, key) -> Store
+```
+
+`Store` is intentionally value-shaped. Small applications can keep it in memory;
+larger services should persist the same `idempotencyKey(event)` in a database or
+queue table before performing side effects.

--- a/LANG_SPEC_v0.5/10-standard-library/README.md
+++ b/LANG_SPEC_v0.5/10-standard-library/README.md
@@ -59,3 +59,4 @@ lowering remains implementation backlog.
 - [§10.42 PDF (`std.pdf`)](./42-pdf.md)
 - [§10.43 Supabase (`std.supabase`)](./43-supabase.md)
 - [§10.44 GitHub (`std.github`)](./44-github.md)
+- [§10.45 Webhooks (`std.webhook`)](./45-webhook.md)

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 95 공개 모듈. 분류 기준:
+총 96 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (89 / 95 = 94%)
+### ⭐⭐⭐⭐⭐ Production (90 / 96 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -96,6 +96,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | graphql | 224 | pure Osty | document / field / argument builders + request JSON body encoding |
 | supabase | 1214 | pure Osty + http/json/env | Supabase PostgREST/Auth/Storage/Functions/GraphQL request builders, env-backed config, API-key/session headers, filters, Prefer/count headers, typed select pages, Content-Range metadata, signed Storage URLs, storage listing/search, object URLs, and response error helpers |
 | github | 1127 | pure Osty + http/json/crypto | GitHub REST request builders for issues, PRs, Actions, releases, release asset upload, typed error parsing, and webhook HMAC/constant-time verification |
+| webhook | 696 | pure Osty + http/crypto/json/time | Stripe/GitHub/Slack/Supabase-style HMAC verification, Discord Ed25519-modeled externally-verified path, replay-window checks, idempotency store, and retry-safe dispatch |
 | template | 148 | pure Osty | escaped/raw `{{name}}` 렌더링 + HTML escape / stripTags |
 | i18n | 136 | pure Osty | Locale / MessageCatalog / fallbackTags / pluralCategory / placeholder format |
 | char | 219 | — | Unicode / ASCII methods |
@@ -122,7 +123,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (6 / 95 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (6 / 96 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -140,7 +141,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 
 | 구분 | 갭 |
 |---|---|
-| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase`, `observability`, `sentry` surface 는 존재) |
+| 없는 모듈 | 없음 (`db`, `smtp`, `zip`, `image`, `xlsx`, `pdf`, `schedule`, `dialog`, `watch`, `scan`, `rpa`, `barcode`, `qr`, `print`, `clipboard`, `keychain`, `secrets`, `supabase`, `github`, `observability`, `sentry`, `webhook` surface 는 존재) |
 | 남은 runtime/deep 기능 | `db driver/runtime`, `smtp TLS/socket execution`, `zip deflate`, `image pixel decode`, `keychain Linux Secret Service` |
 | 부분 구현 | `compress` 는 gzip 만 있음. deflate/zstd 계열 없음 |
 | 문서/코드 드리프트 | 일부 README/매트릭스 문구가 과거 G18 stub 정책을 아직 과장해서 남김 |
@@ -188,6 +189,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | DB 설정/마이그레이션 계획 | ✅ 가능 | db + sql (DSN / pool / tx options / result rows / migration helpers) |
 | Supabase 앱 백엔드 연결 | ✅ 가능 | supabase + http/json/env/secrets (env-backed clients, PostgREST filters/mutations/RPC/count metadata, Auth password-token requests, Storage object URLs/uploads/signed URLs/listing, Edge Function/GraphQL requests) |
 | GitHub 개발 자동화 | ✅ 가능 | github + http/json/crypto (issue/PR request builders, Actions dispatch/runs/jobs/artifacts, release/create/upload, webhook HMAC verification) |
+| 외부 서비스 webhook intake | ✅ 가능 | webhook + http/crypto/json/time (Stripe/GitHub/Slack/Supabase-style HMAC verify, replay-window checks, idempotency, retry-safe dispatch) |
 | 두 언어 앱 / repo 경계 | ✅ 가능 | polyglot + os + env + fs + `osty scaffold polyglot` (Osty+Go/Rust/Python/Node 등 역할 분리, 빌드/테스트/경계 계약, doctorRun/check runner) |
 | AI agent shell / chat mode | ✅ 가능 | ai + aiagents + http/json/log/thread |
 | Local KV / 설정 DB | ✅ 즉시 가능 | kv + fs + json (JSONL append-log, compact, typed getters/setters) |
@@ -227,7 +229,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 69 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, template, i18n, char, iter, bytes)
+- 70 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, webhook, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - keychain/secrets 는 macOS/Windows Phase A+B 연결 완료, Linux Secret Service backend 대기
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)

--- a/internal/backend/stdlib_webhook_check_test.go
+++ b/internal/backend/stdlib_webhook_check_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultWebhook(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "webhook")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(webhook) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("webhook module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/webhook.osty
+++ b/internal/stdlib/modules/webhook.osty
@@ -1,0 +1,696 @@
+// std.webhook - verified webhook intake and retry-safe dispatch.
+//
+// The module keeps provider-specific signature rules close to the common
+// intake path: raw-body verification, timestamp replay windows, stable
+// delivery ids, idempotency state, and handler dispatch decisions.
+
+use std.bytes
+use std.crypto
+use std.encoding
+use std.error
+use std.http
+use std.json
+use std.strings
+use std.time
+
+pub type Headers = http.Headers
+pub type Handler = fn(Event) -> Result<DispatchDecision, Error>
+
+pub enum Provider {
+    Stripe,
+    GitHub,
+    Supabase,
+    Slack,
+    Discord,
+    Custom,
+}
+
+pub enum SignatureScheme {
+    StripeV1,
+    GitHubSha256,
+    SlackV0,
+    SupabaseSha256,
+    HmacSha256Hex,
+    HmacSha256Base64,
+    DiscordEd25519,
+    ExternallyVerified,
+}
+
+pub enum VerificationCode {
+    Verified,
+    MissingSecret,
+    MissingSignature,
+    InvalidSignature,
+    MissingTimestamp,
+    InvalidTimestamp,
+    ReplayWindowExceeded,
+    UnsupportedSignature,
+}
+
+pub enum DispatchStatus {
+    Handled,
+    Duplicate,
+    InFlight,
+    Rejected,
+    RetryLater,
+    Failed,
+}
+
+pub struct Policy {
+    pub provider: Provider,
+    pub scheme: SignatureScheme,
+    pub secret: String = "",
+    pub signatureHeader: String = "",
+    pub timestampHeader: String = "",
+    pub eventIdHeader: String = "",
+    pub eventTypeHeader: String = "",
+    pub toleranceSeconds: Int = 300,
+    pub requireSignature: Bool = true,
+    pub requireTimestamp: Bool = false,
+    pub nowUnixSeconds: Int = 0,
+
+    pub fn withTolerance(mut self, seconds: Int) -> Policy {
+        self.toleranceSeconds = seconds
+        self
+    }
+
+    pub fn withClock(mut self, unixSeconds: Int) -> Policy {
+        self.nowUnixSeconds = unixSeconds
+        self
+    }
+
+    pub fn withSignatureHeader(mut self, name: String) -> Policy {
+        self.signatureHeader = name
+        self
+    }
+
+    pub fn withTimestampHeader(mut self, name: String) -> Policy {
+        self.timestampHeader = name
+        self.requireTimestamp = true
+        self
+    }
+
+    pub fn withEventIdHeader(mut self, name: String) -> Policy {
+        self.eventIdHeader = name
+        self
+    }
+
+    pub fn withEventTypeHeader(mut self, name: String) -> Policy {
+        self.eventTypeHeader = name
+        self
+    }
+
+    pub fn externallyVerified(mut self) -> Policy {
+        self.scheme = ExternallyVerified
+        self.requireSignature = false
+        self
+    }
+}
+
+pub struct Verification {
+    pub provider: Provider,
+    pub accepted: Bool,
+    pub code: VerificationCode,
+    pub reason: String = "",
+    pub signature: String = "",
+    pub timestamp: Int? = None,
+}
+
+pub struct Event {
+    pub provider: Provider,
+    pub id: String,
+    pub eventType: String,
+    pub headers: Headers,
+    pub body: Bytes,
+    pub timestamp: Int? = None,
+    pub payload: json.Json? = None,
+    pub verification: Verification,
+}
+
+pub struct Store {
+    pub processed: Map<String, Bool> = {:},
+    pub inFlight: Map<String, Bool> = {:},
+}
+
+pub struct DispatchDecision {
+    pub status: Int = 200,
+    pub message: String = "ok",
+    pub retryable: Bool = false,
+    pub markProcessed: Bool = true,
+}
+
+pub struct DispatchOutcome {
+    pub status: DispatchStatus,
+    pub event: Event? = None,
+    pub response: http.Response,
+    pub store: Store,
+    pub retryable: Bool = false,
+    pub reason: String = "",
+}
+
+pub fn stripe(secret: String) -> Policy {
+    Policy {
+        provider: Stripe,
+        scheme: StripeV1,
+        secret: secret,
+        signatureHeader: "Stripe-Signature",
+        toleranceSeconds: 300,
+        requireSignature: true,
+        requireTimestamp: true,
+    }
+}
+
+pub fn github(secret: String) -> Policy {
+    Policy {
+        provider: GitHub,
+        scheme: GitHubSha256,
+        secret: secret,
+        signatureHeader: "X-Hub-Signature-256",
+        eventIdHeader: "X-GitHub-Delivery",
+        eventTypeHeader: "X-GitHub-Event",
+        requireSignature: true,
+    }
+}
+
+pub fn supabase(secret: String) -> Policy {
+    Policy {
+        provider: Supabase,
+        scheme: SupabaseSha256,
+        secret: secret,
+        signatureHeader: "x-supabase-signature",
+        eventIdHeader: "x-supabase-event-id",
+        requireSignature: true,
+    }
+}
+
+pub fn slack(secret: String) -> Policy {
+    Policy {
+        provider: Slack,
+        scheme: SlackV0,
+        secret: secret,
+        signatureHeader: "X-Slack-Signature",
+        timestampHeader: "X-Slack-Request-Timestamp",
+        toleranceSeconds: 300,
+        requireSignature: true,
+        requireTimestamp: true,
+    }
+}
+
+pub fn discord(publicKey: String) -> Policy {
+    Policy {
+        provider: Discord,
+        scheme: DiscordEd25519,
+        secret: publicKey,
+        signatureHeader: "X-Signature-Ed25519",
+        timestampHeader: "X-Signature-Timestamp",
+        toleranceSeconds: 300,
+        requireSignature: true,
+        requireTimestamp: true,
+    }
+}
+
+pub fn hmacSha256Hex(secret: String, header: String) -> Policy {
+    Policy {
+        provider: Custom,
+        scheme: HmacSha256Hex,
+        secret: secret,
+        signatureHeader: header,
+        requireSignature: true,
+    }
+}
+
+pub fn hmacSha256Base64(secret: String, header: String) -> Policy {
+    Policy {
+        provider: Custom,
+        scheme: HmacSha256Base64,
+        secret: secret,
+        signatureHeader: header,
+        requireSignature: true,
+    }
+}
+
+pub fn unsigned(provider: Provider) -> Policy {
+    Policy {
+        provider: provider,
+        scheme: ExternallyVerified,
+        requireSignature: false,
+    }
+}
+
+pub fn emptyStore() -> Store {
+    Store {}
+}
+
+pub fn ack() -> DispatchDecision {
+    DispatchDecision {}
+}
+
+pub fn retryLater(message: String) -> DispatchDecision {
+    DispatchDecision { status: 503, message: message, retryable: true, markProcessed: false }
+}
+
+pub fn reject(status: Int, message: String) -> DispatchDecision {
+    DispatchDecision { status: status, message: message, retryable: false, markProcessed: false }
+}
+
+pub fn verifyRequest(request: http.Request, policy: Policy) -> Verification {
+    verify(policy, request.headers, request.body)
+}
+
+pub fn verify(policy: Policy, headers: Headers, body: Bytes) -> Verification {
+    match policy.scheme {
+        StripeV1          -> verifyStripe(policy, headers, body),
+        GitHubSha256     -> verifyHmacHex(policy, headers, body, "sha256=", body),
+        SlackV0          -> verifySlack(policy, headers, body),
+        SupabaseSha256   -> verifyHmacHex(policy, headers, body, "", body),
+        HmacSha256Hex    -> verifyHmacHex(policy, headers, body, "", body),
+        HmacSha256Base64 -> verifyHmacBase64(policy, headers, body, body),
+        DiscordEd25519   -> fail(policy, UnsupportedSignature, "webhook: Discord Ed25519 verification requires a host crypto verifier"),
+        ExternallyVerified -> Verification { provider: policy.provider, accepted: true, code: Verified, reason: "externally verified" },
+    }
+}
+
+pub fn eventFromRequest(request: http.Request, policy: Policy, verification: Verification) -> Event {
+    let payload = parsePayload(request.body)
+    let id = eventId(policy, request.headers, request.body, payload)
+    let typ = eventType(policy, request.headers, payload)
+    Event {
+        provider: policy.provider,
+        id: id,
+        eventType: typ,
+        headers: request.headers,
+        body: request.body,
+        timestamp: verification.timestamp,
+        payload: payload,
+        verification: verification,
+    }
+}
+
+pub fn dispatch(request: http.Request, policy: Policy, store: Store, handler: Handler) -> DispatchOutcome {
+    let verification = verifyRequest(request, policy)
+    if !verification.accepted {
+        return DispatchOutcome {
+            status: Rejected,
+            response: http.textResponse(400, verification.reason, {:}),
+            store: store,
+            retryable: false,
+            reason: verification.reason,
+        }
+    }
+
+    let event = eventFromRequest(request, policy, verification)
+    let key = idempotencyKey(event)
+    if wasProcessed(store, key) {
+        return DispatchOutcome {
+            status: Duplicate,
+            event: Some(event),
+            response: http.textResponse(200, "duplicate delivery ignored", {:}),
+            store: store,
+            retryable: false,
+            reason: "duplicate delivery",
+        }
+    }
+    if isInFlight(store, key) {
+        return DispatchOutcome {
+            status: InFlight,
+            event: Some(event),
+            response: http.textResponse(202, "delivery already in flight", {:}),
+            store: store,
+            retryable: true,
+            reason: "delivery in flight",
+        }
+    }
+
+    let working = markInFlight(store, key)
+    match handler(event) {
+        Ok(decision) -> finishDispatch(event, key, working, decision),
+        Err(err) -> DispatchOutcome {
+            status: Failed,
+            event: Some(event),
+            response: http.textResponse(500, err.message(), {:}),
+            store: clearInFlight(working, key),
+            retryable: true,
+            reason: err.message(),
+        },
+    }
+}
+
+pub fn idempotencyKey(event: Event) -> String {
+    "{providerName(event.provider)}:{event.id}"
+}
+
+pub fn wasProcessed(store: Store, key: String) -> Bool {
+    store.processed.get(key) ?? false
+}
+
+pub fn isInFlight(store: Store, key: String) -> Bool {
+    store.inFlight.get(key) ?? false
+}
+
+pub fn markInFlight(mut store: Store, key: String) -> Store {
+    store.inFlight.insert(key, true)
+    store
+}
+
+pub fn markProcessed(mut store: Store, key: String) -> Store {
+    store.inFlight.remove(key)
+    store.processed.insert(key, true)
+    store
+}
+
+pub fn clearInFlight(mut store: Store, key: String) -> Store {
+    store.inFlight.remove(key)
+    store
+}
+
+pub fn header(headers: Headers, name: String) -> String? {
+    let target = canonicalHeaderName(name)
+    for key in headers.keys() {
+        if canonicalHeaderName(key) == target {
+            return headers.get(key)
+        }
+    }
+    None
+}
+
+pub fn bodyFingerprint(body: Bytes) -> String {
+    encoding.hex.encode(crypto.sha256(body))
+}
+
+fn verifyStripe(policy: Policy, headers: Headers, body: Bytes) -> Verification {
+    let maybeRaw = header(headers, policy.signatureHeader)
+    if maybeRaw.isNone() {
+        return fail(policy, MissingSignature, "webhook: missing Stripe-Signature header")
+    }
+    let raw = maybeRaw.unwrap()
+    if policy.secret.isEmpty() {
+        return fail(policy, MissingSecret, "webhook: missing signing secret")
+    }
+    let maybeTimestampText = firstStripeValue(raw, "t")
+    if maybeTimestampText.isNone() {
+        return fail(policy, MissingTimestamp, "webhook: missing Stripe timestamp")
+    }
+    let timestampText = maybeTimestampText.unwrap()
+    let parsedTimestamp = parseTimestamp(timestampText)
+    if parsedTimestamp.isErr() {
+        return fail(policy, InvalidTimestamp, "webhook: invalid Stripe timestamp")
+    }
+    let timestamp = parsedTimestamp.unwrap()
+    if !withinReplayWindow(policy, timestamp) {
+        return failWithTimestamp(policy, ReplayWindowExceeded, "webhook: Stripe timestamp outside replay window", timestamp)
+    }
+    let signedPayload = bytes.concat(bytes.fromString("{timestampText}."), body)
+    let expected = hmacSha256HexText(policy.secret, signedPayload)
+    for candidate in stripeValues(raw, "v1") {
+        if constantTimeStringEq(strings.toLower(candidate), expected) {
+            return okWithTimestamp(policy, raw, timestamp)
+        }
+    }
+    failWithTimestamp(policy, InvalidSignature, "webhook: invalid Stripe signature", timestamp)
+}
+
+fn verifySlack(policy: Policy, headers: Headers, body: Bytes) -> Verification {
+    let maybeRaw = header(headers, policy.signatureHeader)
+    if maybeRaw.isNone() {
+        return fail(policy, MissingSignature, "webhook: missing Slack signature header")
+    }
+    let raw = maybeRaw.unwrap()
+    if policy.secret.isEmpty() {
+        return fail(policy, MissingSecret, "webhook: missing signing secret")
+    }
+    let maybeTimestampText = header(headers, policy.timestampHeader)
+    if maybeTimestampText.isNone() {
+        return fail(policy, MissingTimestamp, "webhook: missing Slack timestamp header")
+    }
+    let timestampText = strings.trimSpace(maybeTimestampText.unwrap())
+    let parsedTimestamp = parseTimestamp(timestampText)
+    if parsedTimestamp.isErr() {
+        return fail(policy, InvalidTimestamp, "webhook: invalid Slack timestamp")
+    }
+    let timestamp = parsedTimestamp.unwrap()
+    if !withinReplayWindow(policy, timestamp) {
+        return failWithTimestamp(policy, ReplayWindowExceeded, "webhook: Slack timestamp outside replay window", timestamp)
+    }
+    let signedPayload = bytes.concat(bytes.fromString("v0:{timestampText}:"), body)
+    let expected = "v0={hmacSha256HexText(policy.secret, signedPayload)}"
+    if constantTimeStringEq(strings.toLower(raw), expected) {
+        return okWithTimestamp(policy, raw, timestamp)
+    }
+    failWithTimestamp(policy, InvalidSignature, "webhook: invalid Slack signature", timestamp)
+}
+
+fn verifyHmacHex(policy: Policy, headers: Headers, body: Bytes, prefix: String, signedPayload: Bytes) -> Verification {
+    let timestampResult = checkTimestamp(policy, headers)
+    if timestampResult.isErr() {
+        return timestampResult.unwrapErr()
+    }
+    let timestamp = timestampResult.unwrap()
+    let maybeRaw = header(headers, policy.signatureHeader)
+    if maybeRaw.isNone() {
+        return fail(policy, MissingSignature, "webhook: missing signature header")
+    }
+    let raw = maybeRaw.unwrap()
+    if policy.secret.isEmpty() {
+        return fail(policy, MissingSecret, "webhook: missing signing secret")
+    }
+    let expected = "{prefix}{hmacSha256HexText(policy.secret, signedPayload)}"
+    if constantTimeStringEq(strings.toLower(strings.trimSpace(raw)), expected) {
+        return okWithOptionalTimestamp(policy, raw, timestamp)
+    }
+    failWithOptionalTimestamp(policy, InvalidSignature, "webhook: invalid signature", timestamp)
+}
+
+fn verifyHmacBase64(policy: Policy, headers: Headers, body: Bytes, signedPayload: Bytes) -> Verification {
+    let timestampResult = checkTimestamp(policy, headers)
+    if timestampResult.isErr() {
+        return timestampResult.unwrapErr()
+    }
+    let timestamp = timestampResult.unwrap()
+    let maybeRaw = header(headers, policy.signatureHeader)
+    if maybeRaw.isNone() {
+        return fail(policy, MissingSignature, "webhook: missing signature header")
+    }
+    let raw = strings.trimSpace(maybeRaw.unwrap())
+    if policy.secret.isEmpty() {
+        return fail(policy, MissingSecret, "webhook: missing signing secret")
+    }
+    let expected = encoding.base64.encode(crypto.hmac.sha256(bytes.fromString(policy.secret), signedPayload))
+    if constantTimeStringEq(raw, expected) {
+        return okWithOptionalTimestamp(policy, raw, timestamp)
+    }
+    failWithOptionalTimestamp(policy, InvalidSignature, "webhook: invalid signature", timestamp)
+}
+
+fn checkTimestamp(policy: Policy, headers: Headers) -> Result<Int?, Verification> {
+    if policy.timestampHeader.isEmpty() {
+        if policy.requireTimestamp {
+            return Err(fail(policy, MissingTimestamp, "webhook: missing timestamp policy header"))
+        }
+        return Ok(None)
+    }
+    let maybeRaw = header(headers, policy.timestampHeader)
+    if maybeRaw.isNone() {
+        if policy.requireTimestamp {
+            return Err(fail(policy, MissingTimestamp, "webhook: missing timestamp header"))
+        }
+        return Ok(None)
+    }
+    let raw = strings.trimSpace(maybeRaw.unwrap())
+    let parsedTimestamp = parseTimestamp(raw)
+    if parsedTimestamp.isErr() {
+        return Err(fail(policy, InvalidTimestamp, "webhook: invalid timestamp"))
+    }
+    let timestamp = parsedTimestamp.unwrap()
+    if !withinReplayWindow(policy, timestamp) {
+        return Err(failWithTimestamp(policy, ReplayWindowExceeded, "webhook: timestamp outside replay window", timestamp))
+    }
+    Ok(Some(timestamp))
+}
+
+fn finishDispatch(event: Event, key: String, store: Store, decision: DispatchDecision) -> DispatchOutcome {
+    let nextStore = if decision.markProcessed { markProcessed(store, key) } else { clearInFlight(store, key) }
+    if decision.retryable {
+        return DispatchOutcome {
+            status: RetryLater,
+            event: Some(event),
+            response: http.textResponse(decision.status, decision.message, {:}),
+            store: nextStore,
+            retryable: true,
+            reason: decision.message,
+        }
+    }
+    if decision.status >= 500 {
+        return DispatchOutcome {
+            status: Failed,
+            event: Some(event),
+            response: http.textResponse(decision.status, decision.message, {:}),
+            store: nextStore,
+            retryable: true,
+            reason: decision.message,
+        }
+    }
+    DispatchOutcome {
+        status: Handled,
+        event: Some(event),
+        response: http.textResponse(decision.status, decision.message, {:}),
+        store: nextStore,
+        retryable: false,
+        reason: decision.message,
+    }
+}
+
+fn eventId(policy: Policy, headers: Headers, body: Bytes, payload: json.Json?) -> String {
+    if !policy.eventIdHeader.isEmpty() {
+        let maybeHeader = header(headers, policy.eventIdHeader)
+        if maybeHeader.isSome() {
+            let clean = strings.trimSpace(maybeHeader.unwrap())
+            if !clean.isEmpty() {
+                return clean
+            }
+        }
+    }
+    match policy.provider {
+        Stripe | Discord -> {
+            let maybeId = stringField(payload, "id")
+            if maybeId.isSome() {
+                return maybeId.unwrap()
+            }
+        },
+        Slack -> {
+            let maybeEventId = stringField(payload, "event_id")
+            if maybeEventId.isSome() {
+                return maybeEventId.unwrap()
+            }
+            let maybeTriggerId = stringField(payload, "trigger_id")
+            if maybeTriggerId.isSome() {
+                return maybeTriggerId.unwrap()
+            }
+        },
+        _ -> {},
+    }
+    bodyFingerprint(body)
+}
+
+fn eventType(policy: Policy, headers: Headers, payload: json.Json?) -> String {
+    if !policy.eventTypeHeader.isEmpty() {
+        let maybeHeader = header(headers, policy.eventTypeHeader)
+        if maybeHeader.isSome() {
+            let clean = strings.trimSpace(maybeHeader.unwrap())
+            if !clean.isEmpty() {
+                return clean
+            }
+        }
+    }
+    match stringField(payload, "type") {
+        Some(value) -> value,
+        None        -> providerName(policy.provider),
+    }
+}
+
+fn parsePayload(body: Bytes) -> json.Json? {
+    let textResult = bytes.toString(body)
+    if textResult.isErr() {
+        return None
+    }
+    let parsed = json.parseValue(textResult.unwrap())
+    if parsed.isErr() {
+        return None
+    }
+    Some(parsed.unwrap())
+}
+
+fn stringField(payload: json.Json?, key: String) -> String? {
+    if payload.isNone() {
+        return None
+    }
+    let fieldResult = json.getField(payload.unwrap(), key)
+    if fieldResult.isErr() {
+        return None
+    }
+    let textResult = json.asString(fieldResult.unwrap())
+    if textResult.isErr() {
+        return None
+    }
+    Some(textResult.unwrap())
+}
+
+fn firstStripeValue(headerValue: String, key: String) -> String? {
+    let values = stripeValues(headerValue, key)
+    if values.isEmpty() {
+        None
+    } else {
+        Some(values[0])
+    }
+}
+
+fn stripeValues(headerValue: String, key: String) -> List<String> {
+    let mut out: List<String> = []
+    for part in strings.split(headerValue, ",") {
+        let pieces = strings.splitN(strings.trimSpace(part), "=", 2)
+        if pieces.len() == 2 && strings.trimSpace(pieces[0]) == key {
+            out.push(strings.trimSpace(pieces[1]))
+        }
+    }
+    out
+}
+
+fn hmacSha256HexText(secret: String, payload: Bytes) -> String {
+    encoding.hex.encode(crypto.hmac.sha256(bytes.fromString(secret), payload))
+}
+
+fn constantTimeStringEq(a: String, b: String) -> Bool {
+    crypto.constantTimeEq(bytes.fromString(a), bytes.fromString(b))
+}
+
+fn parseTimestamp(value: String) -> Result<Int, Error> {
+    strings.toInt(strings.trimSpace(value))
+}
+
+fn withinReplayWindow(policy: Policy, timestamp: Int) -> Bool {
+    let tolerance = if policy.toleranceSeconds <= 0 { 300 } else { policy.toleranceSeconds }
+    let delta = (nowUnixSeconds(policy) - timestamp).abs()
+    delta <= tolerance
+}
+
+fn nowUnixSeconds(policy: Policy) -> Int {
+    if policy.nowUnixSeconds > 0 {
+        return policy.nowUnixSeconds
+    }
+    let nanosPerSecond: Int64 = 1000000000
+    (time.now().unixNanos / nanosPerSecond).toInt()
+}
+
+fn okWithTimestamp(policy: Policy, signature: String, timestamp: Int) -> Verification {
+    Verification { provider: policy.provider, accepted: true, code: Verified, reason: "verified", signature: signature, timestamp: Some(timestamp) }
+}
+
+fn okWithOptionalTimestamp(policy: Policy, signature: String, timestamp: Int?) -> Verification {
+    Verification { provider: policy.provider, accepted: true, code: Verified, reason: "verified", signature: signature, timestamp: timestamp }
+}
+
+fn fail(policy: Policy, code: VerificationCode, reason: String) -> Verification {
+    Verification { provider: policy.provider, accepted: false, code: code, reason: reason }
+}
+
+fn failWithTimestamp(policy: Policy, code: VerificationCode, reason: String, timestamp: Int) -> Verification {
+    Verification { provider: policy.provider, accepted: false, code: code, reason: reason, timestamp: Some(timestamp) }
+}
+
+fn failWithOptionalTimestamp(policy: Policy, code: VerificationCode, reason: String, timestamp: Int?) -> Verification {
+    Verification { provider: policy.provider, accepted: false, code: code, reason: reason, timestamp: timestamp }
+}
+
+fn canonicalHeaderName(name: String) -> String {
+    strings.toLower(strings.trimSpace(name))
+}
+
+fn providerName(provider: Provider) -> String {
+    match provider {
+        Stripe   -> "stripe",
+        GitHub   -> "github",
+        Supabase -> "supabase",
+        Slack    -> "slack",
+        Discord  -> "discord",
+        Custom   -> "custom",
+    }
+}

--- a/internal/stdlib/webhook_test.go
+++ b/internal/stdlib/webhook_test.go
@@ -1,0 +1,83 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestWebhookModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["webhook"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.webhook not loaded")
+	}
+	for _, name := range []string{
+		"stripe", "github", "supabase", "slack", "discord",
+		"hmacSha256Hex", "hmacSha256Base64", "unsigned",
+		"verify", "verifyRequest", "eventFromRequest", "dispatch",
+		"emptyStore", "ack", "retryLater", "reject",
+		"idempotencyKey", "wasProcessed", "isInFlight",
+		"markInFlight", "markProcessed", "clearInFlight",
+		"header", "bodyFingerprint",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.webhook missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.webhook.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.webhook.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"Provider", "SignatureScheme", "VerificationCode", "DispatchStatus",
+		"Policy", "Verification", "Event", "Store",
+		"DispatchDecision", "DispatchOutcome",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.webhook missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.webhook.%s not public", name)
+		}
+	}
+}
+
+func TestWebhookModuleSourcePinsSecurityAndDispatchBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["webhook"]
+	if mod == nil {
+		t.Fatal("std.webhook module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`signatureHeader: "Stripe-Signature"`,
+		`signatureHeader: "X-Hub-Signature-256"`,
+		`timestampHeader: "X-Slack-Request-Timestamp"`,
+		`signatureHeader: "x-supabase-signature"`,
+		`signatureHeader: "X-Signature-Ed25519"`,
+		`Discord Ed25519 verification requires a host crypto verifier`,
+		`crypto.hmac.sha256(bytes.fromString(secret), payload)`,
+		`crypto.constantTimeEq(bytes.fromString(a), bytes.fromString(b))`,
+		`bytes.concat(bytes.fromString("{timestampText}."), body)`,
+		`bytes.concat(bytes.fromString("v0:{timestampText}:"), body)`,
+		`ReplayWindowExceeded`,
+		`pub struct Store {`,
+		`pub processed: Map<String, Bool> = {:}`,
+		`pub inFlight: Map<String, Bool> = {:}`,
+		`return DispatchOutcome {`,
+		`status: Duplicate`,
+		`status: InFlight`,
+		`status: RetryLater`,
+		`markProcessed(store, key)`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.webhook source missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `std.webhook` as a pure Osty verified webhook intake and dispatch layer.
- Cover Stripe, GitHub, Slack, Supabase-style HMAC hooks, and an explicit Discord Ed25519 unsupported/externally-verified path.
- Add stdlib/backend tests and update the standard-library docs and matrix.

## Validation
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResult(Webhook|Github|Websocket|Graphql)' -v`
- `just support-stdlib-fast`
- `just fmt-check`
- `git diff --check HEAD~1..HEAD`