### PR TITLE
[codex] split std.path from std.os

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 97 공개 모듈. 분류 기준:
+총 98 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (91 / 97 = 94%)
+### ⭐⭐⭐⭐⭐ Production (92 / 98 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -75,9 +75,9 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | xml | 391 | pure Osty | escape / unescape / tag builder / tokenizer |
 | tui | 383 | pure Osty + term | retained frame buffers, ANSI render/diff helpers |
 | image | 372 | pure Osty + bytes | PNG / JPEG / GIF / BMP / WebP format + dimension metadata parser |
-| ocr | 1136 | pure Osty + os/fs/json | PaddleOCR v5 / Tesseract command adapters, fast/accurate presets, batch JSON ingestion, confidence review queues, search, key-value extraction, RAG-friendly chunks |
+| ocr | 1136 | pure Osty + os/fs/json/path | PaddleOCR v5 / Tesseract command adapters, fast/accurate presets, batch JSON ingestion, confidence review queues, search, key-value extraction, RAG-friendly chunks |
 | rpa | 1089 | pure Osty + os/strings | Desktop RPA command plans: mouse move/click/drag/scroll, keyboard typing/hotkeys/paste, window query/focus/wait, script repeat/delay, macOS cliclick+osascript / Linux xdotool / Windows PowerShell adapters |
-| scan | 670 | pure Osty + os/fs/image/ocr | SANE `scanimage` / custom scanner command planning, device-list parsing, batch page paths, image metadata probe, manifest generation, scan→OCR indexed document handoff |
+| scan | 670 | pure Osty + os/fs/image/ocr/path | SANE `scanimage` / custom scanner command planning, device-list parsing, batch page paths, image metadata probe, manifest generation, scan→OCR indexed document handoff |
 | barcode | 709 | pure Osty + os | Code39 / EAN-13 / UPC-A native renderers, SVG/ASCII output, scanner command adapters, ZBar/ZXing output parsing, inventory/shipment/access label helpers |
 | qr | 564 | pure Osty + os | QR payload builders, matrix/SVG render helpers, qrencode generation plans, ZBar/ZXing recognition plans and result parsing |
 | smtp | 358 | pure Osty + email/encoding | SMTP commands / AUTH payloads / reply parsing / transaction scripts |
@@ -110,7 +110,8 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | testing_gen | 168 | test property lowering + runtime | property generators: int/intRange/bool/float/char/byte/asciiString/list/listOfSize/option/result/pair/triple/oneOf/oneOfGens/map/filter/constant |
 | log | 133 | — | Level + Handler + TextHandler / JsonHandler + value/level constructors — slog 동급 |
 | regex | 74 | — | compile / matches / find / findAll / replace / split |
-| os | 71 | shim + runtime | exec / execShell / execWith / execShellWith / exit / pid / hostname / onSignal |
+| path | 172 | pure Osty + runtime boundary | lexical join/split/extension/dirname/basename/isAbsolute/separator; absolute/canonical stay host-runtime backed |
+| os | 43 | shim + runtime | exec / execShell / execWith / execShellWith / exit / pid / hostname / onSignal |
 | thread | 59 | thread 16 + chan 10 + select 22 | spawn / race / chan / select / cancel — 구조적 동시성 |
 | math | 42 | float 40 runtime | sin/cos/tan/asin/acos/atan/atan2/sinh/cosh/tanh/exp/log/log2/log10/sqrt/cbrt/pow/floor/ceil/round/trunc/abs/min/max/hypot/clamp/fract/signum + libm 매핑 |
 | fs | 29 | shim 685 + runtime 21 | read/write/exists/create/remove/rename/copy/mkdir/mkdirAll — 11 API |
@@ -124,7 +125,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (6 / 97 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (6 / 98 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|

--- a/internal/backend/stdlib_inject_e2e_test.go
+++ b/internal/backend/stdlib_inject_e2e_test.go
@@ -387,16 +387,15 @@ func TestInjectReachableStdlibBodiesSkipsBodylessRuntimeBackedDecls(t *testing.T
 			{Value: irString("hello")},
 		},
 	}
-	osCall := &ir.MethodCall{
-		Receiver: &ir.Ident{Name: "path", T: &ir.NamedType{Package: "os", Name: "Path"}},
-		Name:     "dirname",
-		Args:     []ir.Arg{{Value: irString("one/two")}},
+	pathCall := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "path"}, Name: "absolute"},
+		Args:   []ir.Arg{{Value: irString("one/two")}},
 	}
 	mod := &ir.Module{
 		Package: "main",
 		Script: []ir.Stmt{
 			&ir.ExprStmt{X: fsCall},
-			&ir.ExprStmt{X: osCall},
+			&ir.ExprStmt{X: pathCall},
 		},
 	}
 	injected, issues := injectReachableStdlibBodies(mod, reg)
@@ -409,8 +408,8 @@ func TestInjectReachableStdlibBodiesSkipsBodylessRuntimeBackedDecls(t *testing.T
 	if _, ok := fsCall.Callee.(*ir.FieldExpr); !ok {
 		t.Fatalf("fs.writeString callsite was rewritten; want runtime-backed call left intact")
 	}
-	if osCall.Name != "dirname" {
-		t.Fatalf("os.Path.dirname method call was rewritten; want runtime-backed method left intact")
+	if field, ok := pathCall.Callee.(*ir.FieldExpr); !ok || field.Name != "absolute" {
+		t.Fatalf("path.absolute callsite was rewritten; want runtime-backed function left intact")
 	}
 }
 

--- a/internal/backend/stdlib_inject_test.go
+++ b/internal/backend/stdlib_inject_test.go
@@ -174,7 +174,6 @@ func TestReachableStdlibValuePathReceiversMatchBackendSpecialCases(t *testing.T)
 		{name: "encoding url", module: "encoding", path: []string{"url"}, valuePath: "url", method: "encode", typeName: "UrlEncoding"},
 		{name: "compress gzip", module: "compress", path: []string{"gzip"}, valuePath: "gzip", method: "encode", typeName: "Gzip"},
 		{name: "crypto hmac", module: "crypto", path: []string{"hmac"}, valuePath: "hmac", method: "sha256", typeName: "Hmac"},
-		{name: "os path", module: "os", path: []string{"path"}, valuePath: "path", method: "basename", typeName: "Path"},
 		{
 			name:      "net localhost v4",
 			module:    "net",

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -322,8 +322,6 @@ func stdlibSingletonReceiverExpr(module, path, typeName string, fallback ir.Expr
 		return stdlibStructLit(module, "Gzip", span)
 	case module == "crypto" && path == "hmac" && typeName == "Hmac":
 		return stdlibStructLit(module, "Hmac", span)
-	case module == "os" && path == "path" && typeName == "Path":
-		return stdlibStructLit(module, "Path", span)
 	case module == "net" && typeName == "Ipv4Addr":
 		switch path {
 		case "LOCALHOST_V4":

--- a/internal/backend/stdlib_path_check_test.go
+++ b/internal/backend/stdlib_path_check_test.go
@@ -1,0 +1,26 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestStdlibCheckResultPath(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "path")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(path) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("path module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/ocr.osty
+++ b/internal/stdlib/modules/ocr.osty
@@ -8,6 +8,7 @@ use std.error
 use std.fs
 use std.json
 use std.os
+use std.path
 use std.strings
 pub enum Engine {
     PaddleOCR,
@@ -389,9 +390,9 @@ pub fn paddleJsonPath(imagePath: String, savePath: String) -> Result<String, Err
     if strings.endsWith(strings.toLower(cleanSavePath), ".json") {
         return Ok(cleanSavePath)
     }
-    let base = os.path.basename(imagePath)
+    let base = path.basename(imagePath)
     let stem = fileStem(base)
-    Ok(os.path.join([cleanSavePath, "{stem}_res.json"]))
+    Ok(path.join([cleanSavePath, "{stem}_res.json"]))
 }
 pub fn parseOutput(text: String, source: String, options: Options) -> Result<Document, Error> {
     match options.outputFormat {
@@ -1052,8 +1053,8 @@ fn paddleBool(value: Bool) -> String {
         "False"
     }
 }
-fn fileStem(path: String) -> String {
-    let base = os.path.basename(path)
+fn fileStem(rawPath: String) -> String {
+    let base = path.basename(rawPath)
     match strings.lastIndexOf(base, ".") {
         Some(i) -> if i > 0 {
             strings.slice(base, 0, i)

--- a/internal/stdlib/modules/os.osty
+++ b/internal/stdlib/modules/os.osty
@@ -1,39 +1,8 @@
-// std.os — process, environment, signals, and path helpers.
+// std.os - process, environment, and signals.
 //
-// `Path` primitives and process-control entries are body-less; the
-// backend lowers each call to the host-OS runtime. `basename` is a
-// pure derivation from `split` and stays as Osty code.
-
-use std.strings
-
-pub let path: Path = Path {}
-
-pub struct Path {
-    pub fn join(self, parts: List<String>) -> String
-
-    pub fn split(self, p: String) -> List<String>
-
-    pub fn extension(self, p: String) -> String
-
-    pub fn dirname(self, p: String) -> String
-
-    pub fn basename(self, p: String) -> String {
-        let parts = self.split(p)
-        if parts.len() == 0 {
-            ""
-        } else {
-            parts[parts.len() - 1]
-        }
-    }
-
-    pub fn absolute(self, p: String) -> Result<String, Error>
-
-    pub fn canonical(self, p: String) -> Result<String, Error>
-
-    pub fn isAbsolute(self, p: String) -> Bool
-
-    pub fn separator(self) -> String
-}
+// Lexical path manipulation lives in std.path. The process-control
+// entries here are body-less; the backend lowers each call to the
+// host-OS runtime.
 
 pub struct Output {
     pub exitCode: Int,

--- a/internal/stdlib/modules/path.osty
+++ b/internal/stdlib/modules/path.osty
@@ -1,0 +1,191 @@
+// std.path - host-neutral path string helpers.
+//
+// This module owns lexical path manipulation. It accepts both Unix and
+// Windows separators for parsing, and emits "/" when it needs to join
+// path components. Host filesystem resolution stays behind the
+// body-less `absolute` and `canonical` declarations.
+
+use std.strings
+
+pub fn join(parts: List<String>) -> String {
+    let mut out = ""
+    for part in parts {
+        if part.isEmpty() {
+            continue
+        }
+        let clean = if out.isEmpty() { part } else { trimLeadingSeparators(part) }
+        if clean.isEmpty() {
+            continue
+        }
+        if out.isEmpty() {
+            out = clean
+        } else if endsWithSeparator(out) {
+            out = "{out}{clean}"
+        } else {
+            out = "{out}/{clean}"
+        }
+    }
+    out
+}
+
+pub fn split(p: String) -> List<String> {
+    let chars = p.chars()
+    let mut out: List<String> = []
+    let mut start = 0
+    let mut i = 0
+    for i < chars.len() {
+        if isSeparator(chars[i]) {
+            if i > start {
+                out.push(strings.slice(p, start, i))
+            }
+            start = i + 1
+        }
+        i = i + 1
+    }
+    if start < chars.len() {
+        out.push(strings.slice(p, start, chars.len()))
+    }
+    out
+}
+
+pub fn extension(p: String) -> String {
+    let base = basename(p)
+    match strings.lastIndexOf(base, ".") {
+        Some(i) -> {
+            if i <= 0 || i + 1 >= base.len() {
+                ""
+            } else {
+                strings.slice(base, i, base.len())
+            }
+        },
+        None -> "",
+    }
+}
+
+pub fn dirname(p: String) -> String {
+    if p.isEmpty() {
+        return "."
+    }
+    let trimmed = trimTrailingSeparatorsExceptRoot(p)
+    if trimmed.isEmpty() {
+        return "."
+    }
+    let sep = lastSeparatorIndex(trimmed)
+    if sep < 0 {
+        return "."
+    }
+    if sep == 0 {
+        return strings.slice(trimmed, 0, 1)
+    }
+    let dir = strings.slice(trimmed, 0, sep)
+    let clean = trimTrailingSeparatorsExceptRoot(dir)
+    if clean.isEmpty() {
+        "."
+    } else {
+        clean
+    }
+}
+
+pub fn basename(p: String) -> String {
+    if p.isEmpty() {
+        return "."
+    }
+    let trimmed = trimTrailingSeparatorsExceptRoot(p)
+    if trimmed.isEmpty() {
+        return separator()
+    }
+    let sep = lastSeparatorIndex(trimmed)
+    if sep < 0 {
+        trimmed
+    } else if sep + 1 >= trimmed.len() {
+        separator()
+    } else {
+        strings.slice(trimmed, sep + 1, trimmed.len())
+    }
+}
+
+pub fn absolute(p: String) -> Result<String, Error>
+
+pub fn canonical(p: String) -> Result<String, Error>
+
+pub fn isAbsolute(p: String) -> Bool {
+    if p.isEmpty() {
+        return false
+    }
+    let chars = p.chars()
+    if chars.len() > 0 && isSeparator(chars[0]) {
+        return true
+    }
+    chars.len() >= 3 && isAsciiLetter(chars[0]) && chars[1] == ':' && isSeparator(chars[2])
+}
+
+pub fn separator() -> String {
+    "/"
+}
+
+fn trimLeadingSeparators(p: String) -> String {
+    let chars = p.chars()
+    let mut i = 0
+    for i < chars.len() && isSeparator(chars[i]) {
+        i = i + 1
+    }
+    if i <= 0 {
+        p
+    } else if i >= chars.len() {
+        ""
+    } else {
+        strings.slice(p, i, chars.len())
+    }
+}
+
+fn trimTrailingSeparatorsExceptRoot(p: String) -> String {
+    let chars = p.chars()
+    let mut end = chars.len()
+    for end > rootLength(chars) && isSeparator(chars[end - 1]) {
+        end = end - 1
+    }
+    if end == chars.len() {
+        p
+    } else {
+        strings.slice(p, 0, end)
+    }
+}
+
+fn rootLength(chars: List<Char>) -> Int {
+    if chars.len() == 0 {
+        return 0
+    }
+    if isSeparator(chars[0]) {
+        return 1
+    }
+    if chars.len() >= 3 && isAsciiLetter(chars[0]) && chars[1] == ':' && isSeparator(chars[2]) {
+        return 3
+    }
+    0
+}
+
+fn lastSeparatorIndex(p: String) -> Int {
+    let chars = p.chars()
+    let mut out = -1
+    let mut i = 0
+    for i < chars.len() {
+        if isSeparator(chars[i]) {
+            out = i
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn endsWithSeparator(p: String) -> Bool {
+    let chars = p.chars()
+    chars.len() > 0 && isSeparator(chars[chars.len() - 1])
+}
+
+fn isSeparator(c: Char) -> Bool {
+    c == '/' || c == '\\'
+}
+
+fn isAsciiLetter(c: Char) -> Bool {
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}

--- a/internal/stdlib/modules/scan.osty
+++ b/internal/stdlib/modules/scan.osty
@@ -10,6 +10,7 @@ use std.fs
 use std.image
 use std.ocr
 use std.os
+use std.path
 use std.strings
 
 pub enum Backend {
@@ -227,7 +228,7 @@ pub fn plannedPaths(options: Options) -> List<String> {
 }
 
 pub fn pagePath(outputDir: String, prefix: String, index: Int, format: ScanFormat) -> String {
-    os.path.join([outputDir, "{normalizedPrefix(prefix)}-{padLeft(index.toString(), 3, "0")}.{formatExtension(format)}"])
+    path.join([outputDir, "{normalizedPrefix(prefix)}-{padLeft(index.toString(), 3, "0")}.{formatExtension(format)}"])
 }
 
 pub fn plan(options: Options) -> Result<CommandPlan, Error> {
@@ -534,7 +535,7 @@ fn between(text: String, startMarker: String, endMarker: String) -> String {
 }
 
 fn batchPattern(options: Options) -> String {
-    os.path.join([options.outputDir, "{normalizedPrefix(options.filePrefix)}-%03d.{formatExtension(options.format)}"])
+    path.join([options.outputDir, "{normalizedPrefix(options.filePrefix)}-%03d.{formatExtension(options.format)}"])
 }
 
 fn scanimageSource(options: Options) -> String {

--- a/internal/stdlib/path_test.go
+++ b/internal/stdlib/path_test.go
@@ -1,0 +1,60 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+func TestPathModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["path"]
+	if mod == nil || mod.File == nil {
+		t.Fatalf("std.path not loaded")
+	}
+	decls := map[string]ast.Decl{}
+	for _, decl := range mod.File.Decls {
+		if fn, ok := decl.(*ast.FnDecl); ok {
+			decls[fn.Name] = fn
+		}
+	}
+	for _, name := range []string{"join", "split", "extension", "dirname", "basename", "isAbsolute", "separator"} {
+		fn, ok := decls[name].(*ast.FnDecl)
+		if !ok {
+			t.Fatalf("std.path missing fn %q", name)
+		}
+		if !fn.Pub {
+			t.Errorf("std.path.%s not public", name)
+		}
+		if fn.Body == nil {
+			t.Errorf("std.path.%s body = nil, want lexical Osty implementation", name)
+		}
+	}
+	for _, name := range []string{"absolute", "canonical"} {
+		fn, ok := decls[name].(*ast.FnDecl)
+		if !ok {
+			t.Fatalf("std.path missing fn %q", name)
+		}
+		if !fn.Pub {
+			t.Errorf("std.path.%s not public", name)
+		}
+		if fn.Body != nil {
+			t.Errorf("std.path.%s body != nil, want host-runtime boundary", name)
+		}
+	}
+}
+
+func TestOsModuleNoLongerOwnsPathHelpers(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["os"]
+	if mod == nil {
+		t.Fatal("stdlib os module missing")
+	}
+	src := string(mod.Source)
+	for _, forbidden := range []string{"pub let path", "pub struct Path", "fn join", "fn basename", "fn dirname"} {
+		if strings.Contains(src, forbidden) {
+			t.Fatalf("std.os still exposes path helper surface %q", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `std.path` as the owner for lexical path helpers
- remove the old `std.os.path` singleton surface
- update stdlib users, backend injection tests, and the stdlib matrix

## Validation
- `go run ./cmd/osty tokens internal/stdlib/modules/path.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/os.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/ocr.osty`
- `go run ./cmd/osty tokens internal/stdlib/modules/scan.osty`
- `go test -count=1 -vet=off ./internal/stdlib`
- `go test -count=1 -vet=off ./internal/backend -run 'Test(StdlibCheckResult(Path|Ocr|Scan)|InjectReachableStdlibBodiesSkipsBodylessRuntimeBackedDecls|ReachableStdlibValuePathReceiversMatchBackendSpecialCases)'`\n- `just fmt-check`\n- `git diff --check`