### PR TITLE
[codex] add std diff module

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -18,14 +18,14 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 
 ## 1. 4-tier 분류
 
-총 97 공개 모듈. 분류 기준:
+총 98 공개 모듈. 분류 기준:
 
 - **⭐⭐⭐⭐⭐ Production**: surface + backend 모두 풀 커버. 외부 사용자에게 추천 가능
 - **⭐⭐⭐⭐ Production-adjacent**: 사용 가능. 일부 helper 미흡 또는 surface 부풀림 다음 라운드
 - **⭐⭐⭐ Functional**: 기본 사용 가능, 깊이는 부족
 - **🚧 Skeleton / Empty**: 작업 안 됨
 
-### ⭐⭐⭐⭐⭐ Production (91 / 97 = 94%)
+### ⭐⭐⭐⭐⭐ Production (92 / 98 = 94%)
 
 | 모듈 | Surface (LOC) | Backend | 비고 |
 |---|---|---|---|
@@ -84,6 +84,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | result | 357 | — | composition (map / mapErr / and / or / collect) |
 | option | 356 | — | flatten / transpose / traverse / map2 / map3 |
 | csv | 376 | — | options-driven, header-aware decode plus TSV convenience wrappers |
+| diff | 392 | pure Osty | line-oriented LCS diff, structured changes/stats, hunk grouping, unified diff rendering, apply helpers |
 | encoding | 329 | pure Osty + bytes | Base64 / Base64Url / Hex / URL percent-encoding 구현 |
 | zip | 327 | pure Osty + bytes | ZIP stored-entry encode/decode/list/extract + CRC32 |
 | term | 320 | host-backed + pure ANSI | terminal mode/size/input declarations + ANSI sequence builders |
@@ -124,7 +125,7 @@ Osty 표준 라이브러리 모듈별 production-ready 상태 매트릭스.
 | debug | 10 | — | dbg<T>(v) — Rust dbg! 매크로 |
 | ref | 9 | — | same<T>(a, b) — reference identity 비교 |
 
-### ⭐⭐⭐⭐ Production-adjacent (6 / 97 = 6%)
+### ⭐⭐⭐⭐ Production-adjacent (6 / 98 = 6%)
 
 | 모듈 | Surface (LOC) | 갭 |
 |---|---|---|
@@ -198,6 +199,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 | AI code assist loop | ✅ 가능 | aidev + aidev.osty + aidev.prompt + aidev.corpus + aidev.verify + aidev.workflow (diagnostic model / source spans / fix context / patch validation / Osty source-habit hints / compact prompt material / repair corpus records / verification plans and decisions / end-to-end run records) |
 | Agent-safe logs/transcripts | ✅ 가능 | redact + security + tokenest + aiagents |
 | Local document search | ✅ 가능 | search + markdown + media + jsonl |
+| 소스/텍스트 변경 리뷰 | ✅ 가능 | diff + fs + fmt/report (structured line changes, hunks, unified diff output) |
 | 사람이 읽는 리포트 산출물 | ✅ 가능 | report + markdown/jsonl/csv |
 | PDF/이미지 인쇄 | ✅ 가능 | print + fs/media/os (기본 CUPS `lp`, `lpr`, Windows shell print, custom command plan) |
 | LLM retry/compaction loop | ✅ 가능 | ai + httpretry + schedule + tokenest + aiagents |
@@ -231,7 +233,7 @@ runtime 또는 LLVM bridge 로 실제 동작하는 표면은 stub 로 세지 않
 **의도된 우선순위**: Phase A 먼저, Phase B 나중. runtime support 없이 surface 만 만들면 *컴파일은 되지만 실행 못 함* 함정. backend 먼저 → wrapper 나중 순서가 정직.
 
 **현재 상태**:
-- 71 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, webhook, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, cloudflare, template, i18n, char, iter, bytes)
+- 72 모듈은 Phase A + Phase B 둘 다 충실 (strings, http, ai, aiagents, aidev, aidev.osty, aidev.prompt, aidev.corpus, aidev.verify, aidev.workflow, redact, media, security, search, markdown, report, tokenest, httpretry, webhook, schedule, jsonl, kv, shortid, metrics, observability, sentry, net, fmt, json, config, table, xlsx, url, io, collections, email, db, polyglot, grid, gui, dialog, tar, sql, xml, tui, image, pdf, ocr, rpa, scan, barcode, qr, smtp, result, option, csv, diff, encoding, zip, term, websocket, watch, clipboard, graphql, github, supabase, cloudflare, template, i18n, char, iter, bytes)
 - 5 모듈은 Phase A 충실 + Phase B declaration-only (env, random, os, crypto, compress)
 - keychain/secrets 는 macOS/Windows Phase A+B 연결 완료, Linux Secret Service backend 대기
 - fs 는 Phase A 충실 + 확장된 tool-facing declaration surface (walk/glob/watch/atomicWrite/lockFile/hashFile/copyDir/diffFiles)

--- a/internal/backend/stdlib_diff_check_test.go
+++ b/internal/backend/stdlib_diff_check_test.go
@@ -1,0 +1,34 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultDiff pins std.diff's pure-Osty line differ against
+// the selfhost checker. The module leans on nested list mutation, enum
+// methods, and structured hunk rendering, so it is a useful regression guard
+// for practical source-review tooling.
+func TestStdlibCheckResultDiff(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "diff")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(diff) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			msg := d.Error()
+			if len(d.Notes) > 0 {
+				msg += "\n  notes: " + strings.Join(d.Notes, "\n  ")
+			}
+			errs = append(errs, msg)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("diff module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/diff_test.go
+++ b/internal/stdlib/diff_test.go
@@ -1,0 +1,75 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiffModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["diff"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.diff not loaded")
+	}
+
+	for _, name := range []string{
+		"options", "lines", "diffText", "diffLines", "hunks",
+		"stats", "changed", "summary", "addedLines", "deletedLines",
+		"applyLines", "applyText", "unified", "unifiedWithContext",
+		"unifiedText", "unifiedLines", "formatUnified",
+	} {
+		requirePublicFn(t, mod, "diff", name)
+	}
+	for _, name := range []string{"ChangeKind", "Change", "Stats", "Hunk", "UnifiedOptions"} {
+		requirePublicType(t, mod, "diff", name)
+	}
+	for _, method := range []string{"marker", "label", "isChange"} {
+		if got := reg.LookupMethodDecl("diff", "ChangeKind", method); got == nil {
+			t.Fatalf("LookupMethodDecl(diff, ChangeKind, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{"marker", "isChange", "format"} {
+		if got := reg.LookupMethodDecl("diff", "Change", method); got == nil {
+			t.Fatalf("LookupMethodDecl(diff, Change, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{"isEmpty", "header", "format"} {
+		if got := reg.LookupMethodDecl("diff", "Hunk", method); got == nil {
+			t.Fatalf("LookupMethodDecl(diff, Hunk, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{"changed", "total", "summary"} {
+		if got := reg.LookupMethodDecl("diff", "Stats", method); got == nil {
+			t.Fatalf("LookupMethodDecl(diff, Stats, %s) = nil", method)
+		}
+	}
+	for _, method := range []string{"withPaths", "withContext"} {
+		if got := reg.LookupMethodDecl("diff", "UnifiedOptions", method); got == nil {
+			t.Fatalf("LookupMethodDecl(diff, UnifiedOptions, %s) = nil", method)
+		}
+	}
+}
+
+func TestDiffModuleSourcePinsBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["diff"]
+	if mod == nil {
+		t.Fatalf("std.diff not loaded")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"strings.splitLines(text)",
+		"fn lcsTable(before: List<String>, after: List<String>) -> List<List<Int>>",
+		"table[i][j + 1] > table[i + 1][j]",
+		"pub fn hunks(changes: List<Change>, context: Int) -> List<Hunk>",
+		"pub fn unifiedText(fromFile: String, toFile: String, before: String, after: String, context: Int) -> String",
+		"@@ -{rangeText(self.oldStart, self.oldLen)} +{rangeText(self.newStart, self.newLen)} @@",
+		"--- {opts.fromFile}",
+		"+++ {opts.toFile}",
+		"pub fn applyLines(before: List<String>, changes: List<Change>) -> List<String>",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.diff source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/diff.osty
+++ b/internal/stdlib/modules/diff.osty
@@ -1,0 +1,392 @@
+// std.diff - pure Osty text and line diff helpers.
+//
+// The module is intentionally line-oriented. It keeps the runtime surface
+// small, produces stable unified diffs for source review tools, and exposes
+// structured changes for higher-level patch, report, and agent workflows.
+
+use std.strings
+
+pub enum ChangeKind {
+    Equal,
+    Delete,
+    Insert,
+
+    pub fn marker(self) -> String {
+        match self {
+            Equal  -> " ",
+            Delete -> "-",
+            Insert -> "+",
+        }
+    }
+
+    pub fn label(self) -> String {
+        match self {
+            Equal  -> "equal",
+            Delete -> "delete",
+            Insert -> "insert",
+        }
+    }
+
+    pub fn isChange(self) -> Bool {
+        self != Equal
+    }
+}
+
+pub struct Change {
+    pub kind: ChangeKind,
+    pub oldLine: Int,
+    pub newLine: Int,
+    pub text: String,
+
+    pub fn marker(self) -> String {
+        self.kind.marker()
+    }
+
+    pub fn isChange(self) -> Bool {
+        self.kind.isChange()
+    }
+
+    pub fn format(self) -> String {
+        "{self.kind.marker()}{self.text}"
+    }
+}
+
+pub struct Stats {
+    pub equal: Int,
+    pub deleted: Int,
+    pub inserted: Int,
+
+    pub fn changed(self) -> Bool {
+        self.deleted > 0 || self.inserted > 0
+    }
+
+    pub fn total(self) -> Int {
+        self.equal + self.deleted + self.inserted
+    }
+
+    pub fn summary(self) -> String {
+        "{self.inserted} insertions, {self.deleted} deletions"
+    }
+}
+
+pub struct Hunk {
+    pub oldStart: Int,
+    pub oldLen: Int,
+    pub newStart: Int,
+    pub newLen: Int,
+    pub changes: List<Change>,
+
+    pub fn isEmpty(self) -> Bool {
+        self.changes.isEmpty()
+    }
+
+    pub fn header(self) -> String {
+        "@@ -{rangeText(self.oldStart, self.oldLen)} +{rangeText(self.newStart, self.newLen)} @@"
+    }
+
+    pub fn format(self) -> String {
+        let mut lines: List<String> = [self.header()]
+        for change in self.changes {
+            lines.push(change.format())
+        }
+        strings.join(lines, "\n")
+    }
+}
+
+pub struct UnifiedOptions {
+    pub fromFile: String = "before",
+    pub toFile: String = "after",
+    pub context: Int = 3,
+
+    pub fn withPaths(mut self, fromFile: String, toFile: String) -> UnifiedOptions {
+        self.fromFile = fromFile
+        self.toFile = toFile
+        self
+    }
+
+    pub fn withContext(mut self, context: Int) -> UnifiedOptions {
+        self.context = maxInt(0, context)
+        self
+    }
+}
+
+pub fn options() -> UnifiedOptions {
+    UnifiedOptions {}
+}
+
+pub fn lines(text: String) -> List<String> {
+    strings.splitLines(text)
+}
+
+pub fn diffText(before: String, after: String) -> List<Change> {
+    diffLines(lines(before), lines(after))
+}
+
+pub fn diffLines(before: List<String>, after: List<String>) -> List<Change> {
+    let table = lcsTable(before, after)
+    let mut out: List<Change> = []
+    let mut i = 0
+    let mut j = 0
+
+    for i < before.len() || j < after.len() {
+        if i < before.len() && j < after.len() && before[i] == after[j] {
+            out.push(Change { kind: Equal, oldLine: i + 1, newLine: j + 1, text: before[i] })
+            i = i + 1
+            j = j + 1
+        } else if j < after.len() && (i >= before.len() || table[i][j + 1] > table[i + 1][j]) {
+            out.push(Change { kind: Insert, oldLine: i + 1, newLine: j + 1, text: after[j] })
+            j = j + 1
+        } else {
+            out.push(Change { kind: Delete, oldLine: i + 1, newLine: j + 1, text: before[i] })
+            i = i + 1
+        }
+    }
+
+    out
+}
+
+pub fn hunks(changes: List<Change>, context: Int) -> List<Hunk> {
+    let ctx = maxInt(0, context)
+    let mut out: List<Hunk> = []
+    let mut i = 0
+
+    for i < changes.len() {
+        for i < changes.len() && changes[i].kind == Equal {
+            i = i + 1
+        }
+        if i >= changes.len() {
+            break
+        }
+
+        let start = maxInt(0, i - ctx)
+        let mut end = i
+        let mut trailing = 0
+        for end < changes.len() {
+            if changes[end].kind == Equal {
+                trailing = trailing + 1
+                if trailing > ctx {
+                    break
+                }
+            } else {
+                trailing = 0
+            }
+            end = end + 1
+        }
+
+        let h = hunkFromRange(changes, start, end)
+        if !h.isEmpty() {
+            out.push(h)
+        }
+        i = end
+    }
+
+    out
+}
+
+pub fn stats(changes: List<Change>) -> Stats {
+    let mut out = Stats { equal: 0, deleted: 0, inserted: 0 }
+    for change in changes {
+        if change.kind == Equal {
+            out.equal = out.equal + 1
+        } else if change.kind == Delete {
+            out.deleted = out.deleted + 1
+        } else {
+            out.inserted = out.inserted + 1
+        }
+    }
+    out
+}
+
+pub fn changed(changes: List<Change>) -> Bool {
+    stats(changes).changed()
+}
+
+pub fn summary(changes: List<Change>) -> String {
+    stats(changes).summary()
+}
+
+pub fn addedLines(changes: List<Change>) -> List<String> {
+    let mut out: List<String> = []
+    for change in changes {
+        if change.kind == Insert {
+            out.push(change.text)
+        }
+    }
+    out
+}
+
+pub fn deletedLines(changes: List<Change>) -> List<String> {
+    let mut out: List<String> = []
+    for change in changes {
+        if change.kind == Delete {
+            out.push(change.text)
+        }
+    }
+    out
+}
+
+pub fn applyLines(before: List<String>, changes: List<Change>) -> List<String> {
+    let mut out: List<String> = []
+    let mut beforeIndex = 0
+    for change in changes {
+        if change.kind == Equal {
+            out.push(change.text)
+            beforeIndex = beforeIndex + 1
+        } else if change.kind == Delete {
+            beforeIndex = beforeIndex + 1
+        } else {
+            out.push(change.text)
+        }
+    }
+    if beforeIndex < before.len() {
+        for i in beforeIndex..before.len() {
+            out.push(before[i])
+        }
+    }
+    out
+}
+
+pub fn applyText(before: String, changes: List<Change>) -> String {
+    strings.join(applyLines(lines(before), changes), "\n")
+}
+
+pub fn unified(before: String, after: String) -> String {
+    unifiedText("before", "after", before, after, 3)
+}
+
+pub fn unifiedWithContext(before: String, after: String, context: Int) -> String {
+    unifiedText("before", "after", before, after, context)
+}
+
+pub fn unifiedText(fromFile: String, toFile: String, before: String, after: String, context: Int) -> String {
+    unifiedLines(fromFile, toFile, lines(before), lines(after), context)
+}
+
+pub fn unifiedLines(fromFile: String, toFile: String, before: List<String>, after: List<String>, context: Int) -> String {
+    let changes = diffLines(before, after)
+    formatUnified(hunks(changes, context), UnifiedOptions { fromFile: fromFile, toFile: toFile, context: maxInt(0, context) })
+}
+
+pub fn formatUnified(items: List<Hunk>, opts: UnifiedOptions) -> String {
+    if items.isEmpty() {
+        return ""
+    }
+
+    let mut lines: List<String> = ["--- {opts.fromFile}", "+++ {opts.toFile}"]
+    for h in items {
+        lines.push(h.header())
+        for change in h.changes {
+            lines.push(change.format())
+        }
+    }
+    "{strings.join(lines, "\n")}\n"
+}
+
+fn lcsTable(before: List<String>, after: List<String>) -> List<List<Int>> {
+    let rowCount = before.len() + 1
+    let colCount = after.len() + 1
+    let mut table: List<List<Int>> = []
+    for unusedRow in 0..rowCount {
+        table.push(zeroRow(colCount))
+    }
+
+    let mut i = before.len()
+    for i > 0 {
+        i = i - 1
+        let mut row = table[i]
+        let mut j = after.len()
+        for j > 0 {
+            j = j - 1
+            if before[i] == after[j] {
+                row[j] = table[i + 1][j + 1] + 1
+            } else {
+                row[j] = maxInt(table[i + 1][j], row[j + 1])
+            }
+        }
+        table[i] = row
+    }
+
+    table
+}
+
+fn zeroRow(width: Int) -> List<Int> {
+    let mut row: List<Int> = []
+    for unusedCol in 0..width {
+        row.push(0)
+    }
+    row
+}
+
+fn hunkFromRange(changes: List<Change>, start: Int, end: Int) -> Hunk {
+    let mut chunk: List<Change> = []
+    let mut i = start
+    for i < end {
+        chunk.push(changes[i])
+        i = i + 1
+    }
+    Hunk {
+        oldStart: firstOldLine(chunk),
+        oldLen: oldLineCount(chunk),
+        newStart: firstNewLine(chunk),
+        newLen: newLineCount(chunk),
+        changes: chunk,
+    }
+}
+
+fn firstOldLine(changes: List<Change>) -> Int {
+    for change in changes {
+        if change.kind != Insert {
+            return change.oldLine
+        }
+    }
+    if changes.isEmpty() {
+        1
+    } else {
+        changes[0].oldLine
+    }
+}
+
+fn firstNewLine(changes: List<Change>) -> Int {
+    for change in changes {
+        if change.kind != Delete {
+            return change.newLine
+        }
+    }
+    if changes.isEmpty() {
+        1
+    } else {
+        changes[0].newLine
+    }
+}
+
+fn oldLineCount(changes: List<Change>) -> Int {
+    let mut n = 0
+    for change in changes {
+        if change.kind != Insert {
+            n = n + 1
+        }
+    }
+    n
+}
+
+fn newLineCount(changes: List<Change>) -> Int {
+    let mut n = 0
+    for change in changes {
+        if change.kind != Delete {
+            n = n + 1
+        }
+    }
+    n
+}
+
+fn rangeText(start: Int, len: Int) -> String {
+    if len == 1 {
+        start.toString()
+    } else {
+        "{start},{len}"
+    }
+}
+
+fn maxInt(a: Int, b: Int) -> Int {
+    if a > b { a } else { b }
+}


### PR DESCRIPTION
## Summary
- add pure-Osty std.diff with structured Change/Hunk/Stats types
- implement line-oriented LCS diff, hunk grouping, unified diff rendering, and apply helpers
- add stdlib surface tests, backend checker coverage, and STDLIB_MATRIX updates

## Validation
- go run ./cmd/osty tokens internal/stdlib/modules/diff.osty
- go run ./cmd/osty check internal/stdlib/modules/diff.osty
- go test -count=1 -vet=off ./internal/stdlib -run 'TestStdlibSupportMatrix|TestDiffModule' -v
- go test -count=1 -vet=off ./internal/backend -run 'TestStdlibCheckResultDiff' -v
- just fmt-check
- git diff --check