### PR TITLE
refactor: thread.Duration stub 제거, std.time 단일 타입으로 통일

### DIFF
--- a/internal/stdlib/modules/thread.osty
+++ b/internal/stdlib/modules/thread.osty
@@ -5,7 +5,7 @@
 // runtime. `collectAll` is a real Osty helper over `Group.spawn` +
 // `Handle.join`.
 
-pub struct Duration {}
+use std.time
 
 pub struct Group {
     pub fn spawn<T>(self, body: fn() -> T) -> Handle<T>
@@ -24,7 +24,7 @@ pub struct Select {
         self
     }
 
-    pub fn timeout(self, duration: Duration, f: fn() -> ()) -> Select {
+    pub fn timeout(self, duration: time.Duration, f: fn() -> ()) -> Select {
         self
     }
 
@@ -48,7 +48,7 @@ pub fn race<T>(body: fn(Group) -> List<Handle<T>>) -> Result<T, Error>
 
 pub fn chan<T>(capacity: Int = 0) -> Channel<T>
 
-pub fn sleep(duration: Duration) -> Result<(), Error>
+pub fn sleep(duration: time.Duration) -> Result<(), Error>
 
 pub fn yield() {}
 


### PR DESCRIPTION
## Summary
- 스펙 §10.20 위반 수정: `thread.osty:8`의 빈 `pub struct Duration {}` stub이 `time.osty:12`의 진짜 `Duration { nanoseconds: Int64 }` + 메서드를 가리고 있었음
- `use std.time` 추가, `Select.timeout` / `sleep` 시그니처를 `time.Duration`으로 통일
- `5.s` 등 Duration 리터럴이 만드는 `time.Duration`과 thread API가 받는 타입이 같은 nominal 타입이 됨

## Test plan
- [x] `just prepush` 로컬 통과 (fmt-check + vet + repair-check + ci)
- [x] `just front` 로컬 통과 (스펙 코퍼스 + parser/resolve/check/format)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)