### PR TITLE
feat: expose Channel<T> and Handle<T> as stdlib stubs

### DIFF
--- a/internal/stdlib/modules/thread.osty
+++ b/internal/stdlib/modules/thread.osty
@@ -7,12 +7,28 @@
 
 pub struct Duration {}
 
+pub struct Handle<T> {
+    pub fn join(self) -> T
+}
+
 pub struct Group {
     pub fn spawn<T>(self, body: fn() -> T) -> Handle<T>
 
     pub fn cancel(self) {}
 
     pub fn isCancelled(self) -> Bool
+}
+
+pub struct Channel<T> {
+    pub fn close(self)
+
+    pub fn recv(self) -> T?
+
+    pub fn send(self, value: T)
+
+    pub fn len(self) -> Int
+
+    pub fn isClosed(self) -> Bool
 }
 
 pub struct Select {


### PR DESCRIPTION
## Summary
- Add body-less `pub struct Channel<T>` (close / recv / send / len / isClosed) and `pub struct Handle<T>` (join) to `internal/stdlib/modules/thread.osty`.
- Method signatures mirror the intrinsic registrations in `toolchain/check_env.osty:checkInstallChannelIntrinsics`; same dual-registration pattern `Group` / `Group.spawn` already use today.
- Closes the discoverability gap where spec §8.5 references `Channel<T>` but no source-level declaration existed — LSP go-to-definition / hover now resolves these types.

## Why
The runtime intrinsic types were registered programmatically only (in `check_env.osty` + the LLVM backend's NamedType match), so `rg "pub struct Channel"` returned nothing. Stubs surface the API in the same module that already exports `chan<T>` / `Group` / `Select`, without changing checker or backend behavior.

## Test plan
- [x] `just prepush` (fmt-check + vet + repair-check + airepair-capture + ci) green locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)