### PR TITLE
feat: ONB dev 백엔드에 LLVM fallback + timing 로그 추가

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -1,6 +1,7 @@
 # ONB 설계 — Osty Native Backend
 
-> **Status: Phase 0 scaffold started (2026-04-30).** 33개 설계 결정 통합.
+> **Status: Phase 0 scaffold started (2026-04-30); dev-loop integration
+> (Slice A1) landed (2026-05-01).** 33개 설계 결정 통합.
 > `internal/onb` + `--backend onb` 등록까지 착수했고, `fn main() {}`의 MIR를
 > ONB Program으로 낮춘 뒤 첫 aarch64 LIR (`mov w0, #0`; `ret`)까지 생성하는
 > Phase 1.0 slice가 구현됐다. ONB assembly text artifact (`main.s`) 렌더링과
@@ -12,6 +13,19 @@
 > / `BR26` relocation을 포함한 object emission까지 확장했다. 이어서
 > `println(123)` 같은 정수 리터럴 출력도 `_printf("%lld\n", value)` 경로로
 > lowering/object/binary smoke까지 통과한다.
+>
+> **Slice A1 (dev-loop integration)** — 실제 개발자가 `osty run --backend onb`
+> 를 켜둔 채 작업할 수 있도록 두 축이 추가됐다. (1) `internal/onb`가 미지원
+> MIR shape를 만나면 `ErrUnsupportedShape` sentinel을 반환하고, `ONBBackend`
+> 가 `EmitObject` / `EmitBinary` 모드에서 자동으로 LLVM 백엔드에 위임한다
+> (`--emit asm`은 사용자가 ONB asm을 명시적으로 원했다고 보고 hard-fail
+> 유지). 결과 binary는 `.osty/out/llvm/`에 떨어지며 `osty run`이 그대로
+> 실행한다. (2) `OSTY_ONB_TIMING=1`이면 stderr에 한 줄 요약을 찍는다 —
+> `onb: emit 312ms [native: aarch64-apple-darwin]` 또는
+> `onb: emit 1.82s [fallback to llvm: instruction *mir.CallInstr is outside phase 1]`.
+> Cross-validation 흐름은 `OSTY_ONB_STRICT=1`로 fallback을 끄면 raw 거부
+> 에러를 받을 수 있다.
+>
 > 본 문서는 결정 lock-in이며, 후속 의제(예: aarch64 LIR opcode 카탈로그,
 > cross-validation harness, simple inliner 도입 검토)는 별도 문서로 분기한다.
 

--- a/internal/backend/onb.go
+++ b/internal/backend/onb.go
@@ -2,8 +2,11 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"time"
 
 	"github.com/osty/osty/internal/onb"
 )
@@ -19,8 +22,18 @@ type onbLinker interface {
 // ONBBackend is the LLVM-complementary dev/debug backend. It consumes MIR and
 // emits native aarch64 objects directly; LLVM remains the reference/release
 // backend.
+//
+// To make `osty run --backend onb` actually usable on a developer's daily
+// dev loop the backend silently falls back to LLVMBackend whenever ONB's MIR
+// coverage rejects a shape. The fallback only fires for emit modes that
+// produce a runnable artifact (object / binary) — `--emit asm` keeps its
+// hard-fail behaviour because the user is asking specifically for ONB's
+// readable assembly. Setting OSTY_ONB_STRICT=1 disables the fallback so
+// cross-validation harnesses see the raw rejection.
 type ONBBackend struct {
-	linker onbLinker
+	linker       onbLinker
+	llvmFallback Backend
+	logSink      io.Writer
 }
 
 func (ONBBackend) Name() Name { return NameONB }
@@ -32,11 +45,58 @@ func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if err := ValidateEmit(NameONB, req.Emit); err != nil {
 		return nil, err
 	}
+	started := time.Now()
+	target, _ := onb.ResolveTarget(req.Layout.Target)
+	logSink := b.timingSink()
+	timingOn := onb.TimingEnabled()
+	result, err := b.emitNative(ctx, req)
+	if err == nil {
+		if timingOn {
+			onb.LogTiming(logSink, onb.TimingEvent{
+				Path:     "native",
+				Target:   target.Triple,
+				Elapsed:  time.Since(started),
+				BinaryAt: result.Artifacts.Binary,
+			})
+		}
+		return result, nil
+	}
+	if !b.shouldFallback(req, err) {
+		if timingOn {
+			onb.LogTiming(logSink, onb.TimingEvent{
+				Path:    "error",
+				Target:  target.Triple,
+				Elapsed: time.Since(started),
+				Reason:  fallbackReason(err),
+			})
+		}
+		return result, err
+	}
+	fallback, fallbackErr := b.runLLVMFallback(ctx, req, err)
+	if timingOn {
+		path := "llvm-fallback"
+		if fallbackErr != nil {
+			path = "error"
+		}
+		onb.LogTiming(logSink, onb.TimingEvent{
+			Path:    path,
+			Target:  target.Triple,
+			Elapsed: time.Since(started),
+			Reason:  fallbackReason(err),
+		})
+	}
+	return fallback, fallbackErr
+}
+
+// emitNative runs the native ONB pipeline. It returns ErrUnsupportedShape (or
+// a wrapping error) when the dev backend cannot lower the MIR — the public
+// Emit method then decides whether to fall back to LLVM.
+func (b ONBBackend) emitNative(ctx context.Context, req Request) (*Result, error) {
 	artifacts := req.Artifacts(NameONB)
 	if err := os.MkdirAll(artifacts.OutputDir, 0o755); err != nil {
 		return nil, err
 	}
-	plan, err := onb.BuildPlan(onb.Request{
+	plan, planErr := onb.BuildPlan(onb.Request{
 		Module:       req.Entry.MIR,
 		TargetTriple: req.Layout.Target,
 		EmitMode:     req.Emit.String(),
@@ -53,8 +113,8 @@ func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 		Artifacts: artifacts,
 		Warnings:  warnings,
 	}
-	if err != nil {
-		return result, err
+	if planErr != nil {
+		return result, planErr
 	}
 	asm, err := onb.RenderAssembly(plan.Program)
 	if err != nil {
@@ -91,9 +151,73 @@ func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	return result, nil
 }
 
+// shouldFallback decides whether an ONB lowering failure should silently
+// delegate to LLVM. We only fall back for emit modes that produce a runnable
+// artifact, and only when the failure is an "unsupported MIR shape" sentinel.
+// OSTY_ONB_STRICT=1 disables the fallback entirely.
+func (b ONBBackend) shouldFallback(req Request, err error) bool {
+	if err == nil {
+		return false
+	}
+	if onb.StrictMode() {
+		return false
+	}
+	if req.Emit != EmitObject && req.Emit != EmitBinary {
+		return false
+	}
+	return errors.Is(err, onb.ErrUnsupportedShape)
+}
+
+// runLLVMFallback drives LLVM with the same Request, then attaches a warning
+// describing why ONB declined so callers can surface the reason without
+// burying it in stderr. Result.Backend on the fallback path reflects LLVM —
+// honest about what actually built the artifact — and the binary path lives
+// under .osty/out/llvm/, which is what `osty run` will execute.
+func (b ONBBackend) runLLVMFallback(ctx context.Context, req Request, onbErr error) (*Result, error) {
+	llvm := b.llvmBackend()
+	result, err := llvm.Emit(ctx, req)
+	reason := fallbackReason(onbErr)
+	note := fmt.Errorf("onb fallback: lowering delegated to llvm (%s)", reason)
+	if result == nil {
+		return result, err
+	}
+	result.Warnings = append([]error{note}, result.Warnings...)
+	return result, err
+}
+
 func (b ONBBackend) onbLinker() onbLinker {
 	if b.linker != nil {
 		return b.linker
 	}
 	return clangToolchain{}
+}
+
+func (b ONBBackend) llvmBackend() Backend {
+	if b.llvmFallback != nil {
+		return b.llvmFallback
+	}
+	return LLVMBackend{}
+}
+
+func (b ONBBackend) timingSink() io.Writer {
+	if b.logSink != nil {
+		return b.logSink
+	}
+	return os.Stderr
+}
+
+// fallbackReason peels the onb sentinel off so the log line and the warning
+// note both quote a short user-readable string rather than the wrapped error
+// chain. The shape sentinel's message is generic, so we strip it when there
+// is a more specific wrapped detail.
+func fallbackReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	prefix := onb.ErrUnsupportedShape.Error() + ": "
+	if len(msg) > len(prefix) && msg[:len(prefix)] == prefix {
+		return msg[len(prefix):]
+	}
+	return msg
 }

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1,12 +1,16 @@
 package backend
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/onb"
 )
 
 type fakeONBLinker struct {
@@ -237,5 +241,181 @@ func TestONBBackendBinaryRunsPrintlnIntLiteralOnDarwinARM64(t *testing.T) {
 	}
 	if string(out) != "123\n" {
 		t.Fatalf("ONB binary output = %q, want 123 newline", out)
+	}
+}
+
+// recordingBackend captures Emit calls so we can assert that ONB delegated to
+// LLVM exactly when expected, without dragging the real LLVM lowering pipeline
+// into these unit tests.
+type recordingBackend struct {
+	name   Name
+	calls  int
+	last   Request
+	result *Result
+	err    error
+}
+
+func (r *recordingBackend) Name() Name { return r.name }
+func (r *recordingBackend) Emit(_ context.Context, req Request) (*Result, error) {
+	r.calls++
+	r.last = req
+	if r.result != nil {
+		copy := *r.result
+		copy.Emit = req.Emit
+		return &copy, r.err
+	}
+	return nil, r.err
+}
+
+// onbDevTestEnv guards the OSTY_ONB_* env vars so each test starts from a
+// known-clean baseline regardless of what the developer has exported in
+// their shell. Using t.Setenv would conflict with t.Parallel here.
+func onbDevTestEnv(t *testing.T, strict bool, timing bool) {
+	t.Helper()
+	prevStrict := os.Getenv(onb.EnvStrict)
+	prevTiming := os.Getenv(onb.EnvTiming)
+	set := func(key, val string) {
+		if val == "" {
+			os.Unsetenv(key)
+			return
+		}
+		os.Setenv(key, val)
+	}
+	if strict {
+		set(onb.EnvStrict, "1")
+	} else {
+		set(onb.EnvStrict, "")
+	}
+	if timing {
+		set(onb.EnvTiming, "1")
+	} else {
+		set(onb.EnvTiming, "")
+	}
+	t.Cleanup(func() {
+		set(onb.EnvStrict, prevStrict)
+		set(onb.EnvTiming, prevTiming)
+	})
+}
+
+func TestONBBackendFallsBackToLLVMOnUnsupportedShape(t *testing.T) {
+	onbDevTestEnv(t, false, false)
+
+	req := newBackendRequest(t, EmitObject, `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() { println(add(1, 2)) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	fallbackArtifacts := req.Artifacts(NameLLVM)
+	fake := &recordingBackend{
+		name: NameLLVM,
+		result: &Result{
+			Backend:   NameLLVM,
+			Artifacts: fallbackArtifacts,
+		},
+	}
+	result, err := ONBBackend{llvmFallback: fake}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit fallback returned error: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("llvm fallback call count = %d, want 1", fake.calls)
+	}
+	if fake.last.Emit != EmitObject {
+		t.Fatalf("llvm fallback emit = %q, want object", fake.last.Emit)
+	}
+	if result == nil {
+		t.Fatal("fallback result is nil")
+	}
+	if result.Backend != NameLLVM {
+		t.Fatalf("fallback Result.Backend = %q, want %q (be honest about what built it)", result.Backend, NameLLVM)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatal("fallback result should attach an explanatory warning")
+	}
+	first := result.Warnings[0]
+	if first == nil || !strings.Contains(first.Error(), "onb fallback") {
+		t.Fatalf("fallback warning = %v, want onb fallback marker", first)
+	}
+}
+
+func TestONBBackendStrictModeSurfacesShapeError(t *testing.T) {
+	onbDevTestEnv(t, true, false)
+
+	req := newBackendRequest(t, EmitObject, `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() { println(add(1, 2)) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	fake := &recordingBackend{name: NameLLVM}
+	_, err := ONBBackend{llvmFallback: fake}.Emit(context.Background(), req)
+	if err == nil {
+		t.Fatal("strict mode should surface ONB rejection error")
+	}
+	if !errors.Is(err, onb.ErrUnsupportedShape) {
+		t.Fatalf("strict-mode error = %v, want errors.Is ErrUnsupportedShape", err)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("strict mode delegated to llvm %d times; want 0", fake.calls)
+	}
+}
+
+func TestONBBackendASMEmitDoesNotFallback(t *testing.T) {
+	onbDevTestEnv(t, false, false)
+
+	req := newBackendRequest(t, EmitASM, `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() { println(add(1, 2)) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	fake := &recordingBackend{name: NameLLVM}
+	_, err := ONBBackend{llvmFallback: fake}.Emit(context.Background(), req)
+	if err == nil {
+		t.Fatal("ASM emit should hard-fail on shape rejection — user explicitly asked for ONB asm")
+	}
+	if !errors.Is(err, onb.ErrUnsupportedShape) {
+		t.Fatalf("asm-mode error = %v, want errors.Is ErrUnsupportedShape", err)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("asm-mode delegated to llvm %d times; want 0", fake.calls)
+	}
+}
+
+func TestONBBackendTimingLogged(t *testing.T) {
+	onbDevTestEnv(t, false, true)
+
+	req := newBackendRequest(t, EmitASM, `fn main() {}`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	var buf bytes.Buffer
+	_, err := ONBBackend{logSink: &buf}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit returned error: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "onb: emit ") {
+		t.Fatalf("timing log = %q, want onb: emit prefix", got)
+	}
+	if !strings.Contains(got, "[native: aarch64-apple-darwin]") {
+		t.Fatalf("timing log = %q, want native target tag", got)
+	}
+}
+
+func TestONBBackendTimingLogsFallback(t *testing.T) {
+	onbDevTestEnv(t, false, true)
+
+	req := newBackendRequest(t, EmitObject, `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() { println(add(1, 2)) }`)
+	req.Layout.Target = "aarch64-apple-darwin"
+	fake := &recordingBackend{
+		name: NameLLVM,
+		result: &Result{
+			Backend:   NameLLVM,
+			Artifacts: req.Artifacts(NameLLVM),
+		},
+	}
+	var buf bytes.Buffer
+	_, err := ONBBackend{llvmFallback: fake, logSink: &buf}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit fallback returned error: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "fallback to llvm") {
+		t.Fatalf("timing log = %q, want fallback marker", got)
+	}
+	if !strings.Contains(got, "instruction") {
+		t.Fatalf("timing log = %q, want quoted shape reason", got)
 	}
 }

--- a/internal/onb/dev.go
+++ b/internal/onb/dev.go
@@ -1,0 +1,99 @@
+package onb
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// EnvStrict is the env var that forces ONB to surface its own shape-rejection
+// errors instead of letting the backend layer fall back to LLVM. Cross-validation
+// harnesses and self-host bring-up flip this on so they fail loudly when ONB
+// disagrees with LLVM. Day-to-day dev loops keep it unset.
+const EnvStrict = "OSTY_ONB_STRICT"
+
+// EnvTiming, when set to a truthy value, causes the backend layer to write a
+// one-line wall-clock summary to stderr after each ONB emit. The summary names
+// the path that actually ran (native vs llvm fallback) so the developer can
+// tell at a glance whether the dev backend covered their MIR shape.
+const EnvTiming = "OSTY_ONB_TIMING"
+
+// StrictMode reports whether the environment is requesting that ONB never
+// silently delegate to the LLVM backend. Reading the env on every call keeps
+// the toggle responsive to inline `OSTY_ONB_STRICT=1 osty run ...` invocations
+// without process restart.
+func StrictMode() bool { return envTrue(os.Getenv(EnvStrict)) }
+
+// TimingEnabled mirrors StrictMode for the timing log. Two separate env vars
+// keep the strict cross-validation flow independent from the dev-loop perf
+// telemetry.
+func TimingEnabled() bool { return envTrue(os.Getenv(EnvTiming)) }
+
+func envTrue(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// TimingEvent describes one ONB build path so callers can render a stable log
+// line. Path is "native" when ONB lowered the MIR end-to-end, "llvm-fallback"
+// when the backend layer delegated to LLVM after a shape rejection, or
+// "error" when neither path produced an artifact.
+type TimingEvent struct {
+	Path     string
+	Target   string
+	Elapsed  time.Duration
+	Reason   string
+	BinaryAt string
+}
+
+// LogTiming writes a single human-readable line describing the build path
+// taken. It is only meant to run when TimingEnabled() is true. Output goes to
+// the supplied writer; the backend layer wires it to os.Stderr.
+func LogTiming(w io.Writer, ev TimingEvent) {
+	if w == nil {
+		return
+	}
+	target := ev.Target
+	if target == "" {
+		target = "host"
+	}
+	suffix := ""
+	switch ev.Path {
+	case "native":
+		suffix = fmt.Sprintf("[native: %s]", target)
+	case "llvm-fallback":
+		reason := ev.Reason
+		if reason == "" {
+			reason = "shape unsupported"
+		}
+		suffix = fmt.Sprintf("[fallback to llvm: %s]", reason)
+	case "error":
+		reason := ev.Reason
+		if reason == "" {
+			reason = "rejected"
+		}
+		suffix = fmt.Sprintf("[error: %s]", reason)
+	default:
+		suffix = "[" + ev.Path + "]"
+	}
+	fmt.Fprintf(w, "onb: emit %s %s\n", formatElapsed(ev.Elapsed), suffix)
+}
+
+func formatElapsed(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return "0ms"
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.2fms", float64(d.Microseconds())/1000.0)
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -16,7 +16,7 @@ func LowerMIR(mod *mir.Module, target Target) (*Program, error) {
 	}
 	mainFn := mod.LookupFunction("main")
 	if mainFn == nil {
-		return nil, fmt.Errorf("onb: missing main function")
+		return nil, fmt.Errorf("%w: missing main function", ErrUnsupportedShape)
 	}
 	state := &lowerState{target: target}
 	fn, err := state.lowerMainFunction(mainFn)
@@ -40,10 +40,10 @@ func (s *lowerState) lowerMainFunction(fn *mir.Function) (Function, error) {
 		return Function{}, fmt.Errorf("onb: nil main function")
 	}
 	if len(fn.Params) != 0 {
-		return Function{}, fmt.Errorf("onb: main parameters are outside phase 1")
+		return Function{}, fmt.Errorf("%w: main parameters are outside phase 1", ErrUnsupportedShape)
 	}
 	if fn.ReturnType != mir.TUnit {
-		return Function{}, fmt.Errorf("onb: main return type %s is outside phase 1", fn.ReturnType)
+		return Function{}, fmt.Errorf("%w: main return type %s is outside phase 1", ErrUnsupportedShape, fn.ReturnType)
 	}
 	out := Function{Name: fn.Name}
 	for _, block := range fn.Blocks {
@@ -82,7 +82,7 @@ func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock) (Block,
 			Instrs: instrs,
 		}, nil
 	default:
-		return Block{}, fmt.Errorf("onb: terminator %T is outside phase 1", block.Term)
+		return Block{}, fmt.Errorf("%w: terminator %T is outside phase 1", ErrUnsupportedShape, block.Term)
 	}
 }
 
@@ -101,7 +101,7 @@ func (s *lowerState) lowerInstr(fn *mir.Function, instr mir.Instr) ([]Instr, err
 	case *mir.IntrinsicInstr:
 		return s.lowerIntrinsic(i)
 	}
-	return nil, fmt.Errorf("onb: instruction %T is outside phase 1", instr)
+	return nil, fmt.Errorf("%w: instruction %T is outside phase 1", ErrUnsupportedShape, instr)
 }
 
 func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) {
@@ -126,9 +126,9 @@ func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) 
 			out = append(out, &BranchLink{Symbol: "printf"})
 			return out, nil
 		}
-		return nil, fmt.Errorf("onb: println currently requires one string or int literal argument")
+		return nil, fmt.Errorf("%w: println currently requires one string or int literal argument", ErrUnsupportedShape)
 	default:
-		return nil, fmt.Errorf("onb: intrinsic %s is outside phase 1", instr.Kind)
+		return nil, fmt.Errorf("%w: intrinsic %s is outside phase 1", ErrUnsupportedShape, instr.Kind)
 	}
 }
 

--- a/internal/onb/onb.go
+++ b/internal/onb/onb.go
@@ -22,6 +22,15 @@ var (
 
 	// ErrUnsupportedTarget marks a target outside ONB's initial aarch64 scope.
 	ErrUnsupportedTarget = errors.New("onb target is outside phase 1.0 scope")
+
+	// ErrUnsupportedShape marks MIR shapes that ONB's current slice cannot
+	// lower yet. The backend layer uses errors.Is(err, ErrUnsupportedShape)
+	// to decide whether to fall back to the LLVM reference backend so the
+	// developer's `osty run --backend onb` keeps working through the rough
+	// edges of phase 1.x coverage. Construction sites wrap the sentinel
+	// with %w plus a per-site detail string so the fallback log can quote
+	// exactly which MIR construct triggered the fallback.
+	ErrUnsupportedShape = errors.New("onb: unsupported mir shape")
 )
 
 // Request is the backend-owned half of a build request. Host-facing CLI and


### PR DESCRIPTION
## Summary
- ONB가 미지원 MIR shape를 만나면 `EmitObject`/`EmitBinary` 모드에서 자동으로 LLVM에 fallback (`ErrUnsupportedShape` sentinel + `errors.Is`). `osty run --backend onb`가 hello world 외 임의의 코드에도 작동.
- `OSTY_ONB_TIMING=1` — stderr에 native vs llvm-fallback 경로 + wall-clock 한 줄 (`onb: emit 312ms [native: ...]` / `[fallback to llvm: <reason>]`).
- `OSTY_ONB_STRICT=1` — cross-validation 용으로 fallback 끄고 raw 거부 노출.
- `--emit asm`은 사용자 명시 의도라 hard-fail 유지 (LLVM은 ONB asm을 못 만듦).
- ONB_DESIGN.md에 Slice A1 status block 추가.

## Test plan
- [x] `go test ./internal/onb/... ./internal/backend/` 통과
- [x] `just front` 통과
- [x] `osty ci .` 통과
- [x] 5개 신규 테스트 (fallback / strict / asm-no-fallback / timing × 2)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)