### PR TITLE
fix: webview2 inject JS의 for...of를 forEach로 (repair-check 게이트)

### DIFF
--- a/internal/stdlib/modules/gui/webview2.osty
+++ b/internal/stdlib/modules/gui/webview2.osty
@@ -244,27 +244,27 @@ pub fn bridgeScript() -> String {
     }
   };
   Object.defineProperty(window, 'osty', { value: Object.freeze(api), configurable: false, writable: false });
-  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+  ['debug', 'log', 'info', 'warn', 'error'].forEach((level) => {
     const original = console[level] && console[level].bind(console);
-    if (!original) continue;
+    if (!original) return;
     try {
       console[level] = (...args) => {
         original(...args);
         emitConsole(level, args);
       };
     } catch (_) {}
-  }
+  });
   if (window.chrome && window.chrome.webview) {
     window.chrome.webview.addEventListener('message', (event) => {
       if (!event.data) return;
       if (event.data.type === 'command') {
-        for (const handler of commandHandlers) handler(event.data.name, event.data.payload);
+        commandHandlers.forEach((handler) => handler(event.data.name, event.data.payload));
         return;
       }
       if (event.data.type !== 'state') return;
       hasState = true;
       lastState = event.data.payload;
-      for (const handler of stateHandlers) handler(event.data.payload);
+      stateHandlers.forEach((handler) => handler(event.data.payload));
     });
   }
 })();


### PR DESCRIPTION
## Summary
- `internal/stdlib/modules/gui/webview2.osty`의 raw triple-quoted JS 문자열 내부에 있던 3개의 `for (… of …)` 루프를 `forEach`로 재작성
- 의미는 동일 (`return`으로 `continue` 대체)
- `osty repair --check`의 `js_for_of_loop` 패턴이 raw string literal 안까지 텍스트로 스캔해서 오탐 → 모든 PR의 prepush 게이트 실패가 풀림

## 근본 원인 (별도 follow-up)
- `internal/airepair/foreign_loops.go::wantsForeignLoopRepair`가 source 텍스트에 `" of "`가 포함되면 무조건 후속 스캔으로 진입
- raw 문자열 / 문자열 리터럴 내부를 스킵하는 토큰-aware 필터가 없음
- 이 PR은 증상만 회피, 린터 자체 fix는 별도 이슈

## Test plan
- [x] `osty repair --check internal/stdlib/modules/gui/webview2.osty` exit 0
- [x] `go vet ./...` clean
- [x] `just fmt-check` clean
- [ ] CI prepush 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)