### PR TITLE
feat: LIR Proto Phase 5 entry safepoint + function/parameter attributes

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -585,6 +585,54 @@ Exit criteria:
 - Return-value load and root release ordering matches current behavior.
 - The plan remains render-only after construction.
 
+Design decision: the first Phase-5 slice covers function-entry GC
+safepoints plus the always-on function/parameter attribute surface
+(`#[inline(always|never)]`, `#[hot]`, `#[cold]`, `#[pure]`,
+`#[target_feature]`, `#[noalias]`). MIR already carries every flag on
+`MirFunction` (toolchain/mir.osty:1090–1104), so this slice just
+translates them into LLVM strings:
+
+- `lirEmitGcSafepoint(l, kind)` records `osty.gc.safepoint_v1` exactly
+  once per module and pushes a `call void @osty.gc.safepoint_v1(i64 id,
+  ptr null, i64 0)` whose `id` is `llvmEncodeSafepointId(kind, serial)`.
+  Per-function `LirMirFunctionLowerer.safepointSerial` bumps so each
+  emit gets a fresh low-56-bit slot while sharing the high-8 kind
+  byte, matching production's encoding (mir_generator_test.go:3469
+  pins the entry kind id `72057594037927936 = 1 << 56`).
+- `lirLowerMirFunction` emits one entry safepoint at the very front of
+  the prologue — before any local `alloca` / projection store — so
+  every entered function can be observed by the runtime regardless of
+  which MIR block is `fn_.entry`.
+- `lirFnAttrsFromMir(fn_)` derives the function-header attribute list:
+  `inlinehint` / `alwaysinline` / `noinline` from `MirInlineMode`,
+  `hot` / `cold` from the matching flags, `readnone` from `pure`, and
+  `"target-features"="+f1,+f2"` from `targetFeatures`.
+- `lirParamAttrsFromMir(fn_, paramType)` adds `noalias` to every `ptr`
+  parameter when `noaliasAll` is set; the per-param `#[noalias(p1, p2)]`
+  selector form is deferred because MIR drops the per-name metadata
+  today.
+
+The matching parity fixtures (`entry_safepoint`, four `fn_attr_*`)
+pin the rendered LLVM line shape from Go via
+`TestLIRProtoManualFixtureCatalog`, so a regression in the runtime
+declare line, the entry id encoding, or any attribute spelling
+surfaces without needing a production wiring switch.
+
+Deliberately deferred to a later Phase-5 slice:
+
+- Per-call follow-up safepoints around runtime calls (need root
+  visibility tracking before the empty-roots form is replaced).
+- GC root binding / release pairs (`osty.gc.root_bind_v1` /
+  `osty.gc.root_release_v1`) — depend on the same root-visibility pass.
+- Per-instruction `!llvm.access.group` and per-loop `!llvm.loop.*`
+  metadata — need MIR loop-back-edge classification before LIR can
+  attach the metadata to the right `br` terminator.
+- `#[noalias(p1, p2)]` selector form — MIR needs to preserve the
+  per-parameter name list first.
+- Per-loop `vectorize.enable` / `unroll.enable` / `unroll.count`
+  metadata — the `MirFunction.vectorize` / `unroll` flags arrive but
+  there is no MIR loop tag yet to attach them to.
+
 ## Phase 6: full parity harness
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -325,6 +325,12 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualChanCloseFixture", []string{"declare void @osty_rt_chan_close(ptr)", "call void @osty_rt_chan_close("}},
 		{"lirParityManualYieldFixture", []string{"declare void @osty_rt_task_yield()", "call void @osty_rt_task_yield()"}},
 		{"lirParityManualIsCancelledFixture", []string{"declare i1 @osty_rt_cancel_is_cancelled()", "call i1 @osty_rt_cancel_is_cancelled()"}},
+		// ----- Phase 5: GC entry safepoint + function/parameter attributes -----
+		{"lirParityManualEntrySafepointFixture", []string{"declare void @osty.gc.safepoint_v1(i64, ptr, i64)", "call void @osty.gc.safepoint_v1(i64 72057594037927936, ptr null, i64 0)"}},
+		{"lirParityManualFnAttrInlineAlwaysFixture", []string{"alwaysinline"}},
+		{"lirParityManualFnAttrHotPureFixture", []string{" hot ", " readnone "}},
+		{"lirParityManualFnAttrTargetFeaturesFixture", []string{"\"target-features\"=\"+avx512f,+avx512bw\""}},
+		{"lirParityManualFnAttrNoaliasFixture", []string{"ptr noalias %p1", "ptr noalias %p2"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -163,9 +163,13 @@ pub fn lirGlobal(name: String, typ: LirType, init: String) -> LirGlobal {
 pub struct LirParam {
     pub name: String,
     pub typ: LirType,
+    pub attrs: List<String>,
 }
 pub fn lirParam(name: String, typ: LirType) -> LirParam {
-    LirParam {name, typ}
+    LirParam {name, typ, attrs: []}
+}
+pub fn lirParamWithAttrs(name: String, typ: LirType, attrs: List<String>) -> LirParam {
+    LirParam {name, typ, attrs}
 }
 /// LirInstr is a sealed-by-convention flat variant. The `kind` field selects
 /// which payload fields are live. Keeping this as one struct mirrors the rest
@@ -734,10 +738,14 @@ pub fn lirRenderFunction(fn_: LirFunction) -> String {
 pub fn lirRenderParams(params: List<LirParam>) -> String {
     let mut out: List<String> = []
     for p in params {
+        let mut head = lirTypeString(p.typ)
+        for attr in p.attrs {
+            head = head + " " + attr
+        }
         if p.name == "" {
-            out.push(lirTypeString(p.typ))
+            out.push(head)
         } else {
-            out.push(lirTypeString(p.typ) + " " + p.name)
+            out.push(head + " " + p.name)
         }
     }
     strings.join(out, ", ")
@@ -1628,6 +1636,7 @@ pub struct LirMirFunctionLowerer {
     pub slots: List<LirLocalSlot>,
     pub labels: List<LirBlockLabel>,
     pub temp: Int,
+    pub safepointSerial: Int,
 }
 pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult {
     let packageName = if cfg.packageName == "" {
@@ -1669,7 +1678,7 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
     LirLowerResult {module: out, diagnostics: diags}
 }
 pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModule, fn_: MirFunction) -> LirLowerResult {
-    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0}
+    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0, safepointSerial: 0}
     l.out.typeDefs = module.typeDefs
     l.out.runtimeDecls = module.runtimeDecls
     l.out.stringPool = module.stringPool
@@ -1700,13 +1709,23 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
             lirLowerError(l, LirDiagUnsupported, "unsupported param type `" + loc.typ + "`", name)
             continue
         }
-        params.push(lirParam(lirMirParamName(id), typ))
+        let attrs = lirParamAttrsFromMir(fn_, typ)
+        params.push(lirParamWithAttrs(lirMirParamName(id), typ, attrs))
     }
     lirLowerMirLocals(l)
+    let mut entryPrologue: List<LirInstr> = []
+    let savedInstrs = l.instrs
+    l.instrs = entryPrologue
+    lirEmitGcSafepointEntry(l)
+    entryPrologue = l.instrs
+    l.instrs = savedInstrs
     let mut blocks: List<LirBlock> = []
     for bb in lirOrderedMirBlocks(fn_) {
         l.instrs = []
         if bb.id == fn_.entry {
+            for s in entryPrologue {
+                l.instrs.push(s)
+            }
             for p in l.prologue {
                 l.instrs.push(p)
             }
@@ -1721,6 +1740,7 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
         let mut outFn = lirFunction(name, ret)
         outFn.params = params
         outFn.blocks = blocks
+        outFn.attrs = lirFnAttrsFromMir(fn_)
         if fn_.cAbi {
             outFn.callingConv = "ccc"
         }
@@ -1728,6 +1748,10 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
     }
     LirLowerResult {module: l.out, diagnostics: l.diagnostics}
 }
+// Function-entry safepoint sits at the very front of the prologue so
+// every entered function gets one poll regardless of which MIR block
+// is `fn_.entry`. Production runs the same emit order
+// (LANG_SPEC §3.8.6 + RUNTIME_GC_DELTA §10.1).
 fn lirLowerError(l: LirMirFunctionLowerer, kind: LirDiagnosticKind, message: String, path: String) {
     l.diagnostics.push(lirDiagnosticError(kind, message, path))
 }
@@ -2174,6 +2198,91 @@ fn lirLowerMirIntegerConversionIntrinsic(l: LirMirFunctionLowerer, instr: MirIns
     if instr.hasDest {
         lirStoreMirResult(l, instr.dest, result, toName, "intrinsic conversion result")
     }
+}
+// ====================================================================
+// Phase 5: GC safepoint emission and function/parameter attributes
+// ====================================================================
+//
+// Safepoint encoding mirrors production
+// (`internal/llvmgen/generator.go::encodeSafepointID`): the i64 id packs
+// the safepoint kind into the top 8 bits and a per-function serial into
+// the low 56 bits. Reusing the helpers from `toolchain/llvmgen.osty`
+// keeps the encoding aligned with the runtime
+// (`OSTY_GC_SAFEPOINT_KIND_*` in `internal/backend/runtime/osty_runtime.c`).
+fn lirGcSafepointSymbol() -> String {
+    "osty.gc.safepoint_v1"
+}
+fn lirGcSafepointDecl() -> LirRuntimeDecl {
+    lirRuntimeDecl(lirGcSafepointSymbol(), lirVoidType(), [lirIntType(64), lirPtrType(), lirIntType(64)], false)
+}
+// `lirEmitGcSafepoint` records the runtime declaration once and pushes a
+// `call void @osty.gc.safepoint_v1(i64 id, ptr null, i64 0)` into the
+// current instruction buffer. The roots-empty form covers the function-
+// entry case (no managed locals are visible yet) and the per-call follow-
+// up site that every Phase-4 lowering should bracket once root-tracking
+// lands. Per-function serials let the runtime distinguish
+// kind-of-safepoint counters cheaply in profiles.
+fn lirEmitGcSafepoint(l: LirMirFunctionLowerer, kind: Int) {
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirGcSafepointDecl())
+    let serial = l.safepointSerial
+    l.safepointSerial = l.safepointSerial + 1
+    let id = llvmEncodeSafepointId(kind, serial)
+    l.instrs.push(lirCall("", lirVoidType(), "@" + lirGcSafepointSymbol(), [lirOperand(lirIntType(64), lirIntToString(id)), lirOperand(lirPtrType(), "null"), lirOperand(lirIntType(64), "0")]))
+}
+// Convenience wrappers — the kinds are the only thing call sites care
+// about, so spelling them out at the call site beats threading magic
+// integers through the pipeline.
+fn lirEmitGcSafepointEntry(l: LirMirFunctionLowerer) {
+    lirEmitGcSafepoint(l, llvmSafepointKindEntry())
+}
+fn lirEmitGcSafepointCall(l: LirMirFunctionLowerer) {
+    lirEmitGcSafepoint(l, llvmSafepointKindCall())
+}
+// Derive LLVM function-attribute strings from the MIR function's
+// annotation flags. Mirrors production's per-flag mapping
+// (LANG_SPEC v0.6 A8 inline / A9 hot+cold / A10 target-features /
+// A13 pure). `noaliasAll` is handled separately on parameters since
+// `noalias` is a parameter attribute.
+fn lirFnAttrsFromMir(fn_: MirFunction) -> List<String> {
+    let mut attrs: List<String> = []
+    match fn_.inlineMode {
+        MirInlineSoft -> attrs.push("inlinehint"),
+        MirInlineAlways -> attrs.push("alwaysinline"),
+        MirInlineNever -> attrs.push("noinline"),
+        _ -> {
+        },
+    }
+    if fn_.hot {
+        attrs.push("hot")
+    }
+    if fn_.cold {
+        attrs.push("cold")
+    }
+    if fn_.pure {
+        attrs.push("readnone")
+    }
+    if fn_.targetFeatures.len() > 0 {
+        let mut spec: List<String> = []
+        for feature in fn_.targetFeatures {
+            spec.push("+" + feature)
+        }
+        attrs.push("\"target-features\"=\"" + strings.join(spec, ",") + "\"")
+    }
+    attrs
+}
+// Param attrs derive from `noaliasAll` (LANG_SPEC v0.6 A11) — every
+// pointer-typed parameter gets `noalias`. The parameter-level form of
+// the annotation (`#[noalias(p1, p2)]` selecting only specific params)
+// is deliberately deferred because it needs MIR to keep param-name
+// metadata that today only the HIR/AST tier preserves.
+fn lirParamAttrsFromMir(fn_: MirFunction, paramType: LirType) -> List<String> {
+    if !(fn_.noaliasAll) {
+        return []
+    }
+    if paramType.className != LirTypePtr {
+        return []
+    }
+    ["noalias"]
 }
 // Generic Phase-4 runtime call lowering. Handles String / Bytes intrinsics
 // whose ABI is "0..N coerced operand args returning one scalar or pointer

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -416,6 +416,21 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "is_cancelled" {
         return lirParityBuildIsCancelledModule()
+    }
+    if name == "entry_safepoint" {
+        return lirParityBuildEntrySafepointModule()
+    }
+    if name == "fn_attr_inline_always" {
+        return lirParityBuildFnAttrInlineAlwaysModule()
+    }
+    if name == "fn_attr_hot_pure" {
+        return lirParityBuildFnAttrHotPureModule()
+    }
+    if name == "fn_attr_target_features" {
+        return lirParityBuildFnAttrTargetFeaturesModule()
+    }
+    if name == "fn_attr_noalias" {
+        return lirParityBuildFnAttrNoaliasModule()
     }
     mirModule("main")
 }
@@ -958,5 +973,68 @@ pub fn lirParityBuildIsCancelledModule() -> MirModule {
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicIsCancelled, [], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Phase 5: GC entry safepoint + function/parameter attribute fixtures
+// ====================================================================
+//
+// Each fixture asserts the safepoint declaration line, the entry call
+// shape with the kind=1 (Entry) packing in the high 8 bits of the i64
+// id, and any function/parameter attribute strings the corresponding
+// MIR annotation flag should produce. The Entry kind id literal is
+// 72057594037927936 (= 1 << 56), matching production
+// (mir_generator_test.go:3469).
+pub fn lirParityManualEntrySafepointFixture() -> LirParityFixture {
+    lirParityFixture("entry_safepoint", LirParityManualMIR, "/tmp/lir_proto_parity_entry_safepoint.osty", "", "phase5-safepoint", ["safepoint", "runtime"], [lirParityNeedle("declare void @osty.gc.safepoint_v1(i64, ptr, i64)", "safepoint runtime decl"), lirParityNeedle("call void @osty.gc.safepoint_v1(i64 72057594037927936, ptr null, i64 0)", "entry safepoint call (kind=1, serial=0)"), lirParityNeedle("ret i64", "scalar return")])
+}
+pub fn lirParityManualFnAttrInlineAlwaysFixture() -> LirParityFixture {
+    lirParityFixture("fn_attr_inline_always", LirParityManualMIR, "/tmp/lir_proto_parity_fn_attr_inline_always.osty", "", "phase5-fnattr", ["fnattr", "inline"], [lirParityNeedle("define i64 @tiny() alwaysinline", "alwaysinline attribute on signature"), lirParityNeedle("ret i64", "scalar return")])
+}
+pub fn lirParityManualFnAttrHotPureFixture() -> LirParityFixture {
+    lirParityFixture("fn_attr_hot_pure", LirParityManualMIR, "/tmp/lir_proto_parity_fn_attr_hot_pure.osty", "", "phase5-fnattr", ["fnattr", "hot", "pure"], [lirParityNeedle("define i64 @hot()", "function header"), lirParityNeedle(" hot ", "hot attribute"), lirParityNeedle(" readnone ", "readnone (#[pure]) attribute")])
+}
+pub fn lirParityManualFnAttrTargetFeaturesFixture() -> LirParityFixture {
+    lirParityFixture("fn_attr_target_features", LirParityManualMIR, "/tmp/lir_proto_parity_fn_attr_target_features.osty", "", "phase5-fnattr", ["fnattr", "target-features"], [lirParityNeedle("define i64 @vec()", "function header"), lirParityNeedle("\"target-features\"=\"+avx512f,+avx512bw\"", "target-features attribute string")])
+}
+pub fn lirParityManualFnAttrNoaliasFixture() -> LirParityFixture {
+    lirParityFixture("fn_attr_noalias", LirParityManualMIR, "/tmp/lir_proto_parity_fn_attr_noalias.osty", "", "phase5-fnattr", ["fnattr", "noalias"], [lirParityNeedle("define i64 @safe(ptr noalias %p1, ptr noalias %p2)", "noalias on every ptr param")])
+}
+// Module builders.
+pub fn lirParityBuildEntrySafepointModule() -> MirModule {
+    let mut fn_ = lirParityFunction("entered", "Int")
+    let entry = lirParityEntry(fn_)
+    lirParityReturnConst(fn_, entry, 0)
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildFnAttrInlineAlwaysModule() -> MirModule {
+    let mut fn_ = lirParityFunction("tiny", "Int")
+    fn_.inlineMode = MirInlineAlways
+    let entry = lirParityEntry(fn_)
+    lirParityReturnConst(fn_, entry, 7)
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildFnAttrHotPureModule() -> MirModule {
+    let mut fn_ = lirParityFunction("hot", "Int")
+    fn_.hot = true
+    fn_.pure = true
+    let entry = lirParityEntry(fn_)
+    lirParityReturnConst(fn_, entry, 1)
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildFnAttrTargetFeaturesModule() -> MirModule {
+    let mut fn_ = lirParityFunction("vec", "Int")
+    fn_.targetFeatures = ["avx512f", "avx512bw"]
+    let entry = lirParityEntry(fn_)
+    lirParityReturnConst(fn_, entry, 0)
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildFnAttrNoaliasModule() -> MirModule {
+    let mut fn_ = lirParityFunction("safe", "Int")
+    fn_.noaliasAll = true
+    let p1 = lirParityParam(fn_, "p1", "String")
+    let p2 = lirParityParam(fn_, "p2", "String")
+    let entry = lirParityEntry(fn_)
+    lirParityReturnConst(fn_, entry, 0)
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

First Phase-5 slice for LIR Proto — function-entry GC safepoint plus the always-on attribute surface from v0.6 annotations.

**GC entry safepoint**:
- `lirEmitGcSafepoint(l, kind)` declares `osty.gc.safepoint_v1` once and emits `call void @osty.gc.safepoint_v1(i64 id, ptr null, i64 0)` with `id = (kind << 56) | serial`. Per-function `safepointSerial` counter on `LirMirFunctionLowerer` keeps the low 56 bits unique while the kind tag stays in the high 8 bits.
- `lirLowerMirFunction` emits one entry safepoint at the very front of the prologue, regardless of which MIR block is `fn_.entry`. Matches production's `osty.gc.safepoint_v1` encoding (entry kind=1 → id `72057594037927936`).

**Function attributes from MIR annotations**:
- `lirFnAttrsFromMir(fn_)` derives `inlinehint` / `alwaysinline` / `noinline` from `MirInlineMode`, `hot` / `cold` from the matching flags, `readnone` from `pure`, and `\"target-features\"=\"+f1,+f2\"` from `targetFeatures`.

**Parameter attributes**:
- `LirParam.attrs` field + `lirParamWithAttrs` constructor; `lirRenderParams` threads the attrs between the type spelling and the param name (`ptr noalias %p1`).
- `lirParamAttrsFromMir(fn_, paramType)` returns `[noalias]` for every `ptr` param when `noaliasAll` is true.

**Reuse**: `llvmEncodeSafepointId` and `llvmSafepointKindEntry/Call/Loop/...` come from `toolchain/llvmgen.osty` so LIR Proto and production share one packing convention. No new constants or shadow registries.

**Pin**: five Phase-5 fixtures (`entry_safepoint`, four `fn_attr_*`) are added to the manual catalog and asserted by `TestLIRProtoManualFixtureCatalog` so a regression in the runtime declare line, the entry-id encoding, or any attribute spelling surfaces from the Go side without needing the production switch.

Deferred to a later Phase-5 slice:
- Per-call follow-up safepoints around runtime calls (need root-visibility tracking before the empty-roots form is replaced).
- `osty.gc.root_bind_v1` / `osty.gc.root_release_v1` pairs (depend on the same root-visibility pass).
- Per-instruction `!llvm.access.group` and per-loop `!llvm.loop.*` metadata (need MIR loop-back-edge classification first).
- `#[noalias(p1, p2)]` selector form (MIR drops per-name metadata today).

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass (10 source-fixture parity + manual catalog pin)
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)