### PR TITLE
feat: LIR Proto Phase 6+7 parity catalog shape pin + OSTY_LLVM_LIR_PROTO gate

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -668,6 +668,19 @@ Exit criteria:
   explicit, documented gap list.
 - No production code calls the prototype yet.
 
+Design decision: the catalog-shape Phase-6 slice is a single Go-side test
+(`TestLIRProtoFixtureCatalogShape` in
+`internal/llvmgen/lir_proto_shadow_parity_test.go`). It walks every parity
+fixture in `toolchain/lir_proto_parity.osty` and asserts catalog-wide
+invariants the per-fixture self-tests only check indirectly: every fixture
+has a non-empty `name` / `sourcePath` / `needles` triple, every source
+fixture is tagged with either `current-generator` or `lir-only` so the
+shadow parity loader knows where to route it, no fixture name appears
+twice, and the cumulative count never regresses below the Phase-3
+baseline (16 manual / 9 source). Catalog drift now surfaces as a failing
+Go test before either the manual-MIR or source-fixture runners would catch
+it at slice-add time.
+
 ## Phase 7: one-shot wiring behind a gate
 
 Deliverables:
@@ -689,6 +702,36 @@ Exit criteria:
 - Gate off: output is unchanged.
 - Gate on: selected fixtures use LIR Proto and pass.
 - Unsupported prototype shapes fall back cleanly.
+
+Design decision: the first Phase-7 slice lands the gate scaffold without
+the runner. `internal/llvmgen/lir_proto_gate.go` exposes `LIRProtoEnvVar`
+(`OSTY_LLVM_LIR_PROTO`), `LIRProtoSelected()` (env-var read with the
+project's standard truthy/falsy rules), and `ErrLIRProtoNotWired` (a
+sentinel that says "you asked for LIR Proto; the Go-side runner that
+would call into `toolchain/lir_proto.osty` does not exist yet; falling
+back to the current path").
+
+`internal/backend/llvm.go::generateLLVMIR` reads the gate at the very top
+of the dispatcher: when set, `ErrLIRProtoNotWired` is appended to the
+warnings slice and the dispatcher continues through whichever fallback
+path it would have chosen (native-owned fast path or MIR-direct), so
+flipping the gate on early stays safe — production output is unchanged
+but the gate selection is visible in build logs and test output. The
+native-owned fast path was simultaneously fixed to forward the outer
+warnings instead of overwriting them, so the Phase-7 warning is never
+silently dropped on the shorter dispatch route.
+
+Pinned by two Go tests: `TestLLVMDispatchAppendsLIRProtoFallbackWarning`
+asserts the gate-on path emits the sentinel; the negative pin
+`TestLLVMDispatchSkipsLIRProtoWarningWhenGateOff` asserts the default
+behavior is unchanged so a regression that always-on'd the warning would
+fail the test instead of silently noisifying every build. Five env-var
+unit tests cover the truthy/falsy parsing rules.
+
+The next Phase-7 slice lands the actual MIR -> LIR Proto -> LLVM text
+runner — at that point the `ErrLIRProtoNotWired` return is replaced with
+a real call into the Osty-owned lowerer plus a structured unsupported-
+diagnostic fallback when the prototype declines.
 
 ## Phase 8: default-on decision
 

--- a/internal/backend/lir_proto_gate_test.go
+++ b/internal/backend/lir_proto_gate_test.go
@@ -1,0 +1,65 @@
+package backend
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/llvmgen"
+)
+
+// lirProtoGateSrc is a small main that compiles cleanly through
+// either the native-owned fast path or the MIR-direct emitter — the
+// Phase-7 gate fires unconditionally at the dispatcher entry, so the
+// fixture only needs to exercise generateLLVMIR end-to-end without
+// preflight failures. We pick println-of-string so the source itself
+// is the smallest thing the dispatcher will accept.
+const lirProtoGateSrc = `fn main() {
+    println("hi")
+}
+`
+
+// TestLLVMDispatchAppendsLIRProtoFallbackWarning pins the Phase-7 gate
+// hook in generateLLVMIR: when OSTY_LLVM_LIR_PROTO is set, the
+// dispatcher records ErrLIRProtoNotWired in the warnings slice and
+// then continues through the regular MIR-direct path so the build
+// stays green even if the gate is flipped on before the runner is
+// wired.
+func TestLLVMDispatchAppendsLIRProtoFallbackWarning(t *testing.T) {
+	req := newBackendRequest(t, EmitLLVMIR, lirProtoGateSrc)
+	t.Setenv(llvmgen.LIRProtoEnvVar, "1")
+	_, warnings, _ := generateLLVMIR(req.Entry, "arm64-apple-macosx", req.Features, req.Emit)
+	found := false
+	for _, w := range warnings {
+		if errors.Is(w, llvmgen.ErrLIRProtoNotWired) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("warnings missing ErrLIRProtoNotWired (have: %s)", joinLirProtoWarnings(warnings))
+	}
+}
+
+// TestLLVMDispatchSkipsLIRProtoWarningWhenGateOff is the negative
+// pin: with the gate off, no LIR Proto warning ever surfaces.
+// Without this, a regression that always-on'd the warning would
+// silently make every backend run noisy.
+func TestLLVMDispatchSkipsLIRProtoWarningWhenGateOff(t *testing.T) {
+	req := newBackendRequest(t, EmitLLVMIR, lirProtoGateSrc)
+	t.Setenv(llvmgen.LIRProtoEnvVar, "")
+	_, warnings, _ := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
+	for _, w := range warnings {
+		if errors.Is(w, llvmgen.ErrLIRProtoNotWired) {
+			t.Fatalf("warnings unexpectedly include ErrLIRProtoNotWired with gate off: %s", joinLirProtoWarnings(warnings))
+		}
+	}
+}
+
+func joinLirProtoWarnings(warnings []error) string {
+	parts := make([]string, 0, len(warnings))
+	for _, w := range warnings {
+		parts = append(parts, w.Error())
+	}
+	return strings.Join(parts, " | ")
+}

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -159,6 +159,18 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
 	warnings := append([]error(nil), entry.IRIssues...)
+	// Phase-7 gate. OSTY_LLVM_LIR_PROTO=1 selects the LIR Proto path
+	// at this dispatcher entry. The Go-side runner that would call
+	// into toolchain/lir_proto.osty does not exist yet, so we attach
+	// ErrLIRProtoNotWired as a warning and then continue with whichever
+	// fallback path the existing dispatcher would have chosen
+	// (native-owned fast path or MIR-direct). Flipping the gate on
+	// stays safe before the runner lands — production output is
+	// unchanged but the selection is visible in build logs.
+	if llvmgen.LIRProtoSelected() {
+		traceLLVMDispatch("lir-proto-gate selected package=%s source=%s — falling back: %v", entry.PackageName, entry.SourcePath, llvmgen.ErrLIRProtoNotWired)
+		warnings = append(warnings, llvmgen.ErrLIRProtoNotWired)
+	}
 	opts := llvmgen.Options{
 		PackageName: entry.PackageName,
 		SourcePath:  entry.SourcePath,
@@ -174,12 +186,15 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	}
 	if capabilities.CanRoute(llvmDispatchNativeOwned) {
 		traceLLVMDispatch("%s try package=%s source=%s emit=%s target=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath, emit, target)
-		if out, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
+		if out, ok, nativeWarnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
 			traceLLVMDispatch("%s error: %v", llvmDispatchNativeOwned, err)
-			return nil, warnings, err
+			return nil, append(warnings, nativeWarnings...), err
 		} else if ok {
 			traceLLVMDispatch("%s covered package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
-			return out, warnings, nil
+			// Carry both the outer warnings (entry IRIssues + Phase-7
+			// gate) and the native-owned path's warnings forward so
+			// neither is silently dropped.
+			return out, append(warnings, nativeWarnings...), nil
 		}
 		traceLLVMDispatch("%s declined package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
 	} else {
@@ -194,6 +209,7 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// emitter. MIR refusal now surfaces as the normal unsupported
 	// skeleton diagnostic; the LLVM backend no longer retries the
 	// legacy HIR bridge behind the user's back.
+	//
 	route := capabilities.DispatchRoute()
 	traceLLVMDispatch("%s emit package=%s source=%s emit=%s target=%s", route, entry.PackageName, entry.SourcePath, emit, target)
 	if diag, row, ok := capabilities.RouteBlockingDiagnostic(route); ok {

--- a/internal/llvmgen/lir_proto_gate.go
+++ b/internal/llvmgen/lir_proto_gate.go
@@ -1,0 +1,45 @@
+package llvmgen
+
+import (
+	"errors"
+	"os"
+)
+
+// LIRProtoEnvVar is the explicit Phase-7 gate documented in
+// docs/lir_proto_plan.md. When the environment variable is set to a
+// non-empty, non-zero value, the LLVM backend dispatcher routes
+// through the LIR Proto path instead of the existing MIR-direct
+// emitter.
+//
+// The LIR Proto runner itself lives in `toolchain/lir_proto.osty` and
+// is not yet callable from the Go side, so the production hookpoint
+// today returns ErrLIRProtoNotWired when the gate is set. A future
+// commit will replace the not-wired sentinel with an actual
+// MIR -> LIR Proto -> LLVM text invocation; the gate is added now so
+// the dispatch site, the env-var contract, and the fallback policy
+// stay one PR rather than three.
+const LIRProtoEnvVar = "OSTY_LLVM_LIR_PROTO"
+
+// ErrLIRProtoNotWired is returned by Phase-7 dispatch sites when the
+// LIR Proto gate is enabled but no Go-side runner exists yet. Treat
+// this as a structured "fall back to the legacy MIR-direct emitter"
+// signal rather than a user-visible error — the dispatcher converts
+// it into a backend warning and continues with the existing path so
+// the gate never breaks production by being flipped on early.
+var ErrLIRProtoNotWired = errors.New("llvmgen: LIR Proto path selected by " + LIRProtoEnvVar + " but Go-side runner is not wired yet — falling back to MIR-direct")
+
+// LIRProtoSelected reports whether the Phase-7 gate is on for the
+// current process. The accepted positive values match the rest of the
+// project's env-var policy: anything other than the empty string and
+// the literal "0" / "false" / "off" turns the gate on.
+func LIRProtoSelected() bool {
+	return lirProtoEnvOn(os.Getenv(LIRProtoEnvVar))
+}
+
+func lirProtoEnvOn(value string) bool {
+	switch value {
+	case "", "0", "false", "FALSE", "False", "off", "OFF", "Off", "no", "NO", "No":
+		return false
+	}
+	return true
+}

--- a/internal/llvmgen/lir_proto_gate_test.go
+++ b/internal/llvmgen/lir_proto_gate_test.go
@@ -1,0 +1,53 @@
+package llvmgen
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestLIRProtoSelectedDefaultOff(t *testing.T) {
+	t.Setenv(LIRProtoEnvVar, "")
+	if LIRProtoSelected() {
+		t.Fatal("LIRProtoSelected() = true with empty env — gate must default off")
+	}
+}
+
+func TestLIRProtoSelectedRecognizesNegativeValues(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"0", "false", "FALSE", "False", "off", "OFF", "Off", "no", "NO", "No"} {
+		if lirProtoEnvOn(value) {
+			t.Fatalf("lirProtoEnvOn(%q) = true, want false", value)
+		}
+	}
+}
+
+func TestLIRProtoSelectedRecognizesPositiveValues(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"1", "true", "TRUE", "True", "on", "yes", "anything-else"} {
+		if !lirProtoEnvOn(value) {
+			t.Fatalf("lirProtoEnvOn(%q) = false, want true", value)
+		}
+	}
+}
+
+func TestLIRProtoSelectedReadsEnvVar(t *testing.T) {
+	t.Setenv(LIRProtoEnvVar, "1")
+	if !LIRProtoSelected() {
+		t.Fatal("LIRProtoSelected() = false with env=1, want true")
+	}
+}
+
+func TestErrLIRProtoNotWiredMentionsEnvVar(t *testing.T) {
+	t.Parallel()
+	if !errors.Is(ErrLIRProtoNotWired, ErrLIRProtoNotWired) {
+		t.Fatal("ErrLIRProtoNotWired must satisfy errors.Is against itself")
+	}
+	msg := ErrLIRProtoNotWired.Error()
+	if !strings.Contains(msg, LIRProtoEnvVar) {
+		t.Fatalf("ErrLIRProtoNotWired message missing %q: %s", LIRProtoEnvVar, msg)
+	}
+	if !strings.Contains(msg, "fall") {
+		t.Fatalf("ErrLIRProtoNotWired message should mention fallback: %s", msg)
+	}
+}

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -361,12 +361,88 @@ func parseLIRProtoManualFixtureDecl(t *testing.T, fn *ast.FnDecl) (lirProtoShado
 		return lirProtoShadowFixture{}, false
 	}
 	name := stringArg(t, fn.Name, call.Args[0].Value)
+	sourcePath := stringArg(t, fn.Name, call.Args[2].Value)
 	tags := stringListArg(t, fn.Name, call.Args[5].Value)
 	needles := needleListArg(t, fn.Name, call.Args[6].Value)
 	if name == "" || len(needles) == 0 {
 		return lirProtoShadowFixture{}, false
 	}
-	return lirProtoShadowFixture{Name: name, Tags: tags, Needles: needles}, true
+	return lirProtoShadowFixture{Name: name, SourcePath: sourcePath, Tags: tags, Needles: needles}, true
+}
+
+// TestLIRProtoFixtureCatalogShape (Phase 6) is a single Go-side pin
+// that walks every parity fixture in toolchain/lir_proto_parity.osty
+// and asserts the catalog-wide invariants the Osty self-test only
+// checks indirectly: every fixture has a non-empty name, source path,
+// and at least one needle, every source fixture is tagged with either
+// `current-generator` or `lir-only` so the shadow parity loader can
+// route it, and no fixture name appears twice. Acts as an early-warning
+// for catalog drift before either the manual-MIR or source-fixture
+// runners would surface the problem at slice-add time.
+func TestLIRProtoFixtureCatalogShape(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	path := filepath.Join(root, "toolchain", "lir_proto_parity.osty")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	file, diags := parser.ParseDiagnostics(src)
+	if len(diags) != 0 {
+		t.Fatalf("parse %s diagnostics = %v", path, diags)
+	}
+
+	manualCount := 0
+	sourceCount := 0
+	seen := map[string]string{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FnDecl)
+		if !ok {
+			continue
+		}
+		var fixture lirProtoShadowFixture
+		var ok2 bool
+		if strings.HasPrefix(fn.Name, "lirParityManual") && strings.HasSuffix(fn.Name, "Fixture") {
+			fixture, ok2 = parseLIRProtoManualFixtureDecl(t, fn)
+			if ok2 {
+				manualCount++
+			}
+		}
+		if strings.HasPrefix(fn.Name, "lirParitySource") && strings.HasSuffix(fn.Name, "Fixture") {
+			fixture, ok2 = parseLIRProtoSourceFixtureDecl(t, fn)
+			if ok2 {
+				sourceCount++
+				if !fixture.hasTag("current-generator") && !fixture.hasTag("lir-only") {
+					t.Fatalf("source fixture %s must carry either `current-generator` or `lir-only` tag (have %v)", fn.Name, fixture.Tags)
+				}
+			}
+		}
+		if !ok2 {
+			continue
+		}
+		if fixture.Name == "" {
+			t.Fatalf("%s: fixture name is empty", fn.Name)
+		}
+		if fixture.SourcePath == "" {
+			t.Fatalf("%s: fixture source path is empty (catalog requires a stable anchor for diagnostics)", fn.Name)
+		}
+		if len(fixture.Needles) == 0 {
+			t.Fatalf("%s: fixture has zero needles — must pin at least one rendered shape", fn.Name)
+		}
+		if owner, dup := seen[fixture.Name]; dup {
+			t.Fatalf("duplicate fixture name %q: defined in both %s and %s", fixture.Name, owner, fn.Name)
+		}
+		seen[fixture.Name] = fn.Name
+	}
+	if manualCount < 16 {
+		t.Fatalf("manual fixture count = %d, want >= 16 (Phase-3 baseline)", manualCount)
+	}
+	if sourceCount < 9 {
+		t.Fatalf("source fixture count = %d, want >= 9 (Phase-3 source-parity baseline)", sourceCount)
+	}
 }
 
 func lowerLIRProtoShadowSourceToMIR(t *testing.T, src string) *mir.Module {


### PR DESCRIPTION
## Summary

Final two LIR Proto phases — parity catalog shape pin (Phase 6) and the `OSTY_LLVM_LIR_PROTO` gate scaffold (Phase 7).

**Phase 6 — catalog shape pin**:
- New `TestLIRProtoFixtureCatalogShape` in `internal/llvmgen/lir_proto_shadow_parity_test.go` walks every parity fixture in `toolchain/lir_proto_parity.osty` and asserts catalog-wide invariants the per-fixture self-tests only check indirectly:
  - non-empty `name` / `sourcePath` / `needles` triple
  - every source fixture tagged with either `current-generator` or `lir-only`
  - no duplicate fixture name
  - manual count >= 16 + source count >= 9 (Phase-3 baselines)
- Catalog drift now surfaces as a Go test failure before either the manual-MIR or source-fixture runners would catch it at slice-add time.

**Phase 7 — gate scaffold**:
- `internal/llvmgen/lir_proto_gate.go` exposes:
  - `LIRProtoEnvVar` (`"OSTY_LLVM_LIR_PROTO"`)
  - `LIRProtoSelected()` — env-var read with the project's standard truthy/falsy rules
  - `ErrLIRProtoNotWired` — sentinel: "you asked for LIR Proto; the Go-side runner that would call into `toolchain/lir_proto.osty` does not exist yet; falling back to the current path"
- `internal/backend/llvm.go::generateLLVMIR` reads the gate at the dispatcher entry: when set, `ErrLIRProtoNotWired` is appended to warnings and the dispatcher continues with whichever fallback path it would have chosen. Flipping `OSTY_LLVM_LIR_PROTO=1` on early stays safe — production output is unchanged but the gate selection is visible in build logs.
- Bonus fix: the native-owned fast path was forwarding only its OWN warnings, silently dropping the outer warnings (entry IRIssues + Phase-7 sentinel) on the shorter dispatch route. Now both are concatenated.

**Test pinning**:
- `TestLLVMDispatchAppendsLIRProtoFallbackWarning` (gate-on emits sentinel) + negative pin `TestLLVMDispatchSkipsLIRProtoWarningWhenGateOff` (default unchanged)
- 5 env-var unit tests covering truthy/falsy parsing rules + sentinel message shape
- All Phase-3..5 fixtures still pass through both `TestLIRProtoCurrentGeneratorSourceFixturesShadowParity` and `TestLIRProtoManualFixtureCatalog`

The next Phase-7 slice replaces the `ErrLIRProtoNotWired` return with an actual MIR -> LIR Proto -> LLVM text runner call into the Osty-owned lowerer, plus a structured unsupported-diagnostic fallback when the prototype declines.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ ./internal/backend/ -run 'LIRProto'\` — pass (15 tests)
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)