### PR TITLE
feat: LIR Proto Option<Int> wrapping for IndexOf-family intrinsics

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -426,6 +426,48 @@ Go-side `TestLIRProtoManualFixtureCatalog` is the single pin so a missed
 runtime symbol on either the Osty or the production side surfaces as a
 test failure.
 
+Design decision: a Phase-4 deferred slice adds Option<Int> wrapping for
+the IndexOf-family intrinsics (`StringIndexOf`, `StringLastIndexOf`,
+`BytesIndexOf`, `BytesLastIndexOf`). Two pieces of new infrastructure:
+
+- **Basic-block splitting in the lowerer.** `LirMirFunctionLowerer`
+  grows `currentBlockLabel`, `extraBlocks`, and `auxLabel`, plus
+  `lirCutBlockBr` / `lirCutBlockCondBr` helpers that close the active
+  sub-block with the requested terminator and start a fresh one. The
+  MIR-block lowering loop splices `extraBlocks` ahead of the final block
+  before pushing — the MIR terminator always lands on whichever sub-
+  block is current at the end of the MIR block. Production uses a phi
+  node here; the alloca shape that LIR Proto picks (slot in the entry
+  block, store in each arm, load on the join sub-block) is equivalent
+  for correctness and avoids extending the LIR instruction vocabulary
+  for one site.
+- **Algebraic 2-i64 type lowering.** `lirLowerMirType` now emits a
+  named `%Option.<T> = type { i64, i64 }` (and the matching `%Result.*`
+  / `%Maybe.*`) typedef when it sees the corresponding type-name prefix.
+  `lirMangleAlgebraicTypeName` strips angle brackets / commas / spaces
+  so nested generics like `Result<Option<Int>, Error>` produce a valid
+  identifier without colliding. Production uses the same `{ i64, i64 }`
+  shape (`mir_generator_snapshot.go::mirOkAggregateLines /
+  mirNoneAggregateLines`).
+
+`lirEmitOptionNone` / `lirEmitOptionSome` / `lirEmitResultOk` /
+`lirEmitResultErr` produce the canonical insertvalue chain;
+`lirWrapOptionFromI64Sentinel` glues them together with the sentinel
+test for the IndexOf shape (sge 0 → present). `lirLowerMirIndexOf`
+checks the destination local's type and routes Option-typed dests
+through the wrapper, raw-Int dests through the bare i64 store.
+
+Three Phase-4 fixtures pin the new shape — raw-i64 destination (no
+wrap), Option<Int> destination on `String.indexOf`, Option<Int> on
+`Bytes.indexOf` — through `TestLIRProtoManualFixtureCatalog`.
+
+The remaining Option-returning safe forms (`MapGet`, `ListFirst`,
+`ListLast`, `BytesGet`, `ListGet` safe form, `ListPop`,
+`StringToInt`/`ToFloat` Result wrapping) need different sentinel
+shapes (out-pointer + i1 present, len-bounds check, runtime parser
+status, etc.) — each is its own follow-up slice that reuses the
+basic-block-splitting + Option/Result aggregate helpers added here.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -331,6 +331,10 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualFnAttrHotPureFixture", []string{" hot ", " readnone "}},
 		{"lirParityManualFnAttrTargetFeaturesFixture", []string{"\"target-features\"=\"+avx512f,+avx512bw\""}},
 		{"lirParityManualFnAttrNoaliasFixture", []string{"ptr noalias %p1", "ptr noalias %p2"}},
+		// ----- Phase 4 deferred slice: IndexOf-family Option<Int> wrapping -----
+		{"lirParityManualStringIndexOfRawFixture", []string{"declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "call i64 @osty_rt_strings_IndexOf(", "ret i64"}},
+		{"lirParityManualStringIndexOfOptionFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "icmp sge i64", "alloca %Option.Int", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "load %Option.Int", "ret %Option.Int"}},
+		{"lirParityManualBytesIndexOfOptionFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_bytes_index_of(ptr, ptr)", "icmp sge i64", "ret %Option.Int"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -1637,6 +1637,9 @@ pub struct LirMirFunctionLowerer {
     pub labels: List<LirBlockLabel>,
     pub temp: Int,
     pub safepointSerial: Int,
+    pub currentBlockLabel: String,
+    pub extraBlocks: List<LirBlock>,
+    pub auxLabel: Int,
 }
 pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult {
     let packageName = if cfg.packageName == "" {
@@ -1678,7 +1681,7 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
     LirLowerResult {module: out, diagnostics: diags}
 }
 pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModule, fn_: MirFunction) -> LirLowerResult {
-    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0, safepointSerial: 0}
+    let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0, safepointSerial: 0, currentBlockLabel: "", extraBlocks: [], auxLabel: 0}
     l.out.typeDefs = module.typeDefs
     l.out.runtimeDecls = module.runtimeDecls
     l.out.stringPool = module.stringPool
@@ -1722,6 +1725,8 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
     let mut blocks: List<LirBlock> = []
     for bb in lirOrderedMirBlocks(fn_) {
         l.instrs = []
+        l.extraBlocks = []
+        l.currentBlockLabel = lirLabelForMirBlock(l, bb.id)
         if bb.id == fn_.entry {
             for s in entryPrologue {
                 l.instrs.push(s)
@@ -1734,7 +1739,10 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
             lirLowerMirInstr(l, instr)
         }
         let term = lirLowerMirTerm(l, bb.term, ret)
-        blocks.push(LirBlock {label: lirLabelForMirBlock(l, bb.id), instrs: l.instrs, term})
+        for extra in l.extraBlocks {
+            blocks.push(extra)
+        }
+        blocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term})
     }
     if l.diagnostics.len() == 0 {
         let mut outFn = lirFunction(name, ret)
@@ -1748,6 +1756,11 @@ pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModul
     }
     LirLowerResult {module: l.out, diagnostics: l.diagnostics}
 }
+// Splice in any sub-blocks an instr lowering created (Option/Result
+// wrapping, safe-form intrinsics, etc.) before pushing the final
+// block. The MIR block's terminator always lives on the last
+// sub-block since `currentBlockLabel` advances each time a cut
+// happens.
 // Function-entry safepoint sits at the very front of the prologue so
 // every entered function gets one poll regardless of which MIR block
 // is `fn_.entry`. Production runs the same emit order
@@ -2120,9 +2133,14 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicChanClose -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_chan_close", lirVoidType(), [lirPtrType()], "chan.close"),
         MirIntrinsicYield -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_task_yield", lirVoidType(), [], "task.yield"),
         MirIntrinsicIsCancelled -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_cancel_is_cancelled", lirIntType(1), [], "cancel.isCancelled"),
+        MirIntrinsicStringIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("IndexOf"), [lirPtrType(), lirPtrType()], "string.indexOf"),
+        MirIntrinsicStringLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("LastIndexOf"), [lirPtrType(), lirPtrType()], "string.lastIndexOf"),
+        MirIntrinsicBytesIndexOf -> lirLowerMirIndexOf(l, instr, mirRtBytesSymbol("index_of"), [lirPtrType(), lirPtrType()], "bytes.indexOf"),
+        MirIntrinsicBytesLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtBytesSymbol("last_index_of"), [lirPtrType(), lirPtrType()], "bytes.lastIndexOf"),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
+// ----- IndexOf-family Option<Int> wrapping (Phase 4 deferred slice) -----
 fn lirLowerMirPrintIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr, newline: Bool, stderr: Bool) {
     if instr.args.len() != 1 {
         lirLowerError(l, LirDiagInvalidInput, "print intrinsic expects exactly one argument", "intrinsic.print")
@@ -2283,6 +2301,100 @@ fn lirParamAttrsFromMir(fn_: MirFunction, paramType: LirType) -> List<String> {
         return []
     }
     ["noalias"]
+}
+// ====================================================================
+// Basic-block splitting + Option<T> aggregate construction
+// ====================================================================
+//
+// Some MIR intrinsics (StringIndexOf, ListIndexOf, BytesGet, MapGet,
+// etc.) lower to a runtime call followed by a Some/None branch — the
+// result is an Option<T> aggregate stored into the destination. To
+// emit those as legal LLVM, the LIR block they live in must split
+// across new sub-blocks (some/none/end), each with its own terminator.
+//
+// `lirCutBlockBr` / `lirCutBlockCondBr` close the current block with
+// the requested terminator, push it into l.extraBlocks, then start a
+// fresh sub-block whose label `currentBlockLabel` advances to. The
+// MIR block's "real" terminator always lands on whichever sub-block
+// is current when the MIR-block lowering finishes.
+fn lirFreshAuxLabel(l: LirMirFunctionLowerer, hint: String) -> String {
+    let id = l.auxLabel
+    l.auxLabel = l.auxLabel + 1
+    l.currentBlockLabel + "." + hint + "." + lirIntToString(id)
+}
+fn lirCutBlockBr(l: LirMirFunctionLowerer, target: String) {
+    l.extraBlocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term: lirBr(target)})
+    l.instrs = []
+    l.currentBlockLabel = target
+}
+fn lirCutBlockCondBr(l: LirMirFunctionLowerer, cond: String, thenLabel: String, elseLabel: String, nextLabel: String) {
+    l.extraBlocks.push(LirBlock {label: l.currentBlockLabel, instrs: l.instrs, term: lirCondBr(cond, thenLabel, elseLabel)})
+    l.instrs = []
+    l.currentBlockLabel = nextLabel
+}
+// `lirEmitOptionNone` / `lirEmitOptionSome` build the canonical 2-i64
+// `{i64 disc, i64 payload}` aggregate production uses for every
+// Option<T> at the LLVM boundary
+// (mir_generator_snapshot.go::mirNoneAggregateLines /
+// mirSomeAggregateLines / mirOkAggregateLines / mirErrAggregateLines).
+// `payloadI64` must already be the i64-encoded form of the payload —
+// the caller is responsible for zext / ptrtoint / bitcast as
+// appropriate. Returns the temporary holding the constructed aggregate.
+fn lirEmitOptionNone(l: LirMirFunctionLowerer, optType: LirType) -> String {
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, optType, "undef", lirOperand(lirIntType(64), "0"), [0]))
+    let value = lirFresh(l)
+    l.instrs.push(lirInsertValue(value, optType, step, lirOperand(lirIntType(64), "0"), [1]))
+    value
+}
+fn lirEmitOptionSome(l: LirMirFunctionLowerer, optType: LirType, payloadI64: String) -> String {
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, optType, "undef", lirOperand(lirIntType(64), "1"), [0]))
+    let value = lirFresh(l)
+    l.instrs.push(lirInsertValue(value, optType, step, lirOperand(lirIntType(64), payloadI64), [1]))
+    value
+}
+fn lirEmitResultOk(l: LirMirFunctionLowerer, resultType: LirType, payloadI64: String) -> String {
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), "1"), [0]))
+    let value = lirFresh(l)
+    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirIntType(64), payloadI64), [1]))
+    value
+}
+fn lirEmitResultErr(l: LirMirFunctionLowerer, resultType: LirType, payloadI64: String) -> String {
+    let step = lirFresh(l)
+    l.instrs.push(lirInsertValue(step, resultType, "undef", lirOperand(lirIntType(64), "0"), [0]))
+    let value = lirFresh(l)
+    l.instrs.push(lirInsertValue(value, resultType, step, lirOperand(lirIntType(64), payloadI64), [1]))
+    value
+}
+// `lirWrapOptionFromI64Sentinel` lowers the IndexOf-family
+// `i64 → Option<Int>` shape: test the i64 against -1 (sge), branch to
+// some/none, materialize the Option aggregate in each arm, and merge
+// through an alloca-backed slot so the merged value is loadable on
+// the join sub-block. Production uses a phi node here; the alloca
+// shape is equivalent for correctness and avoids extending the LIR
+// instruction vocabulary just for this site. Returns the temporary
+// holding the merged Option<Int> value on the join sub-block.
+fn lirWrapOptionFromI64Sentinel(l: LirMirFunctionLowerer, indexReg: String, optType: LirType, hint: String) -> String {
+    let presentReg = lirFresh(l)
+    l.instrs.push(lirBinary(presentReg, "icmp sge", lirIntType(64), indexReg, "0"))
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, optType, 0))
+    let someLabel = lirFreshAuxLabel(l, hint + ".some")
+    let noneLabel = lirFreshAuxLabel(l, hint + ".none")
+    let endLabel = lirFreshAuxLabel(l, hint + ".end")
+    lirCutBlockCondBr(l, presentReg, someLabel, noneLabel, someLabel)
+    let someValue = lirEmitOptionSome(l, optType, indexReg)
+    l.instrs.push(lirStore(lirOperand(optType, someValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = noneLabel
+    let noneValue = lirEmitOptionNone(l, optType)
+    l.instrs.push(lirStore(lirOperand(optType, noneValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, optType, slot, 0))
+    merged
 }
 // Generic Phase-4 runtime call lowering. Handles String / Bytes intrinsics
 // whose ABI is "0..N coerced operand args returning one scalar or pointer
@@ -2776,6 +2888,81 @@ fn lirLowerMirSetRemove(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     lirEmitContainerCall(l, instr, llvmSetRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, elem.value)], "", "set.remove")
 }
+// IndexOf-family lowering: 2-ptr runtime returning i64 with -1 sentinel
+// for "not found". When the destination local is `Option<Int>` (or any
+// 2-i64 aggregate type — production also accepts `Maybe<Int>`), wrap
+// the result through `lirWrapOptionFromI64Sentinel`. Otherwise store
+// the raw i64 — useful for fused MIR call sites that consume the
+// sentinel directly.
+fn lirLowerMirIndexOf(l: LirMirFunctionLowerer, instr: MirInstr, symbol: String, paramTypes: List<LirType>, label: String) {
+    if instr.args.len() != paramTypes.len() {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects " + lirIntToString(paramTypes.len()) + " arguments", label)
+        return
+    }
+    let mut args: List<LirOperand> = []
+    let mut i = 0
+    for arg in instr.args {
+        let pt = paramTypes[i]
+        let value = lirLowerCoercedOperand(l, arg, arg.typ, pt, label + " arg " + lirIntToString(i))
+        if value.value == "" {
+            return
+        }
+        args.push(lirOperand(pt, value.value))
+        i = i + 1
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirIntType(64), paramTypes, false))
+    let indexReg = lirFresh(l)
+    l.instrs.push(lirCall(indexReg, lirIntType(64), "@" + symbol, args))
+    if !(instr.hasDest) {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
+        return
+    }
+    let destType = lirLowerMirType(l, loc.typ)
+    if lirIsOptionTypeName(loc.typ) && !lirTypeIsZero(destType) {
+        let merged = lirWrapOptionFromI64Sentinel(l, indexReg, destType, label)
+        lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, label + " result")
+        return
+    }
+    lirStoreMirResult(l, instr.dest, lirOperand(lirIntType(64), indexReg), "Int", label + " result")
+}
+// `Option<...>` / `Maybe<...>` are the canonical 2-i64 aggregate types
+// production lowers Option-returning intrinsics into. The check is a
+// string-prefix sniff because LIR Proto's type lowering does not carry
+// nominal-vs-structural shape distinctions yet — the canonical type
+// names already arrive from the monomorphizer with stable spellings.
+fn lirIsOptionTypeName(name: String) -> Bool {
+    strings.startsWith(name, "Option<") || strings.startsWith(name, "Maybe<")
+}
+fn lirIsResultTypeName(name: String) -> Bool {
+    strings.startsWith(name, "Result<")
+}
+// `lirMangleAlgebraicTypeName` produces a stable LLVM identifier from a
+// canonical Osty type name like "Option<Int>" or "Result<String, Error>".
+// Replaces `<`, `>`, `,`, ` ` with `.` / `_` / `_` so the result reads
+// naturally in LLVM IR (`%Option.Int`, `%Result.String_Error`) and stays
+// a valid identifier even for nested generics (`%Option.List_Int_`).
+fn lirMangleAlgebraicTypeName(name: String) -> String {
+    let mut out = ""
+    let chars = strings.chars(name)
+    for ch in chars {
+        if ch == '<' {
+            out = out + "."
+        } else if ch == '>' {
+            out = out + ""
+        } else if ch == ',' {
+            out = out + "_"
+        } else if ch == ' ' {
+            out = out + ""
+        } else {
+            out = out + strings.fromChar(ch)
+        }
+    }
+    out
+}
 fn lirLowerMirTerm(l: LirMirFunctionLowerer, term: MirTerm, ret: LirType) -> LirTerm {
     match term.kind {
         MirTermReturn -> {
@@ -3141,6 +3328,11 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, name: String) -> LirType {
     if lirIsRefBuiltinTypeName(name) {
         return lirPtrType()
     }
+    if lirIsOptionTypeName(name) || lirIsResultTypeName(name) {
+        let typeName = "%" + lirMangleAlgebraicTypeName(name)
+        lirModuleDeclareTypeDef(l.out, lirTypeDef(typeName, "\{ i64, i64 \}"))
+        return lirAggregateType(typeName)
+    }
     for layout in l.mirModule.layouts.structs {
         if lirMirStructLayoutMatches(layout, name) {
             let typeName = "%" + if layout.mangled == "" {
@@ -3184,6 +3376,12 @@ fn lirLowerMirType(l: LirMirFunctionLowerer, name: String) -> LirType {
     }
     lirTypeInvalid()
 }
+// Option<T> / Maybe<T> / Result<T, E> all lower to the canonical
+// `{ i64 disc, i64 payload }` aggregate production uses for every
+// 2-i64 algebraic type at the LLVM boundary
+// (mir_generator_snapshot.go::mirNoneAggregate / mirOkAggregate).
+// The mangled name strips angle brackets and commas so it stays a
+// valid LLVM identifier; the layout itself does not vary per-T.
 // Reference-shaped builtin generics (List/Map/Set/Channel/Handle/Box)
 // and the structured-task surfaces all reach LLVM as opaque ptr. The
 // monomorphizer keeps the printed type name intact so we just sniff

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -431,6 +431,15 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "fn_attr_noalias" {
         return lirParityBuildFnAttrNoaliasModule()
+    }
+    if name == "string_index_of_raw" {
+        return lirParityBuildStringIndexOfRawModule()
+    }
+    if name == "string_index_of_option" {
+        return lirParityBuildStringIndexOfOptionModule()
+    }
+    if name == "bytes_index_of_option" {
+        return lirParityBuildBytesIndexOfOptionModule()
     }
     mirModule("main")
 }
@@ -1036,5 +1045,51 @@ pub fn lirParityBuildFnAttrNoaliasModule() -> MirModule {
     let p2 = lirParityParam(fn_, "p2", "String")
     let entry = lirParityEntry(fn_)
     lirParityReturnConst(fn_, entry, 0)
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Phase 4 deferred slice: IndexOf-family Option<Int> wrapping fixtures
+// ====================================================================
+//
+// Three shapes pin the new lowering: a raw-i64 destination (no Option
+// wrapping), an Option<Int> destination on String.indexOf, and an
+// Option<Int> destination on Bytes.indexOf. Each fixture asserts the
+// runtime declare line plus the basic-block split / aggregate / merge
+// shape that the new lirWrapOptionFromI64Sentinel emits.
+pub fn lirParityManualStringIndexOfRawFixture() -> LirParityFixture {
+    lirParityFixture("string_index_of_raw", LirParityManualMIR, "/tmp/lir_proto_parity_string_index_of_raw.osty", "", "phase4-option", ["option", "indexOf"], [lirParityNeedle("declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "indexOf runtime"), lirParityNeedle("call i64 @osty_rt_strings_IndexOf(", "indexOf call site"), lirParityNeedle("ret i64", "raw i64 return — no Option wrap")])
+}
+pub fn lirParityManualStringIndexOfOptionFixture() -> LirParityFixture {
+    lirParityFixture("string_index_of_option", LirParityManualMIR, "/tmp/lir_proto_parity_string_index_of_option.osty", "", "phase4-option", ["option", "indexOf"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "indexOf runtime"), lirParityNeedle("call i64 @osty_rt_strings_IndexOf(", "indexOf call site"), lirParityNeedle("icmp sge i64", "sentinel test"), lirParityNeedle("alloca %Option.Int", "merge slot"), lirParityNeedle("insertvalue %Option.Int undef, i64 1, 0", "Some disc"), lirParityNeedle("insertvalue %Option.Int undef, i64 0, 0", "None disc"), lirParityNeedle("load %Option.Int", "merge load"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+pub fn lirParityManualBytesIndexOfOptionFixture() -> LirParityFixture {
+    lirParityFixture("bytes_index_of_option", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_index_of_option.osty", "", "phase4-option", ["option", "indexOf", "bytes"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare i64 @osty_rt_bytes_index_of(ptr, ptr)", "bytes indexOf runtime"), lirParityNeedle("call i64 @osty_rt_bytes_index_of(", "bytes indexOf call site"), lirParityNeedle("icmp sge i64", "sentinel test"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+// Module builders.
+pub fn lirParityBuildStringIndexOfRawModule() -> MirModule {
+    let mut fn_ = lirParityFunction("findRaw", "Int")
+    let s = lirParityParam(fn_, "s", "String")
+    let needle = lirParityParam(fn_, "needle", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringIndexOf, [mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(needle), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringIndexOfOptionModule() -> MirModule {
+    let mut fn_ = lirParityFunction("findOpt", "Option<Int>")
+    let s = lirParityParam(fn_, "s", "String")
+    let needle = lirParityParam(fn_, "needle", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringIndexOf, [mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(needle), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesIndexOfOptionModule() -> MirModule {
+    let mut fn_ = lirParityFunction("findByte", "Option<Int>")
+    let b = lirParityParam(fn_, "b", "Bytes")
+    let needle = lirParityParam(fn_, "needle", "Bytes")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesIndexOf, [mirOperandCopy(mirPlace(b), "Bytes"), mirOperandCopy(mirPlace(needle), "Bytes")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Adds the basic-block splitting + Option/Result aggregate construction infrastructure that every safe-form intrinsic in Phase 4 needs, then wires the IndexOf family through it (`StringIndexOf`, `StringLastIndexOf`, `BytesIndexOf`, `BytesLastIndexOf`).

**Basic-block splitting**:
- `LirMirFunctionLowerer` grows `currentBlockLabel`, `extraBlocks`, `auxLabel`
- `lirCutBlockBr` / `lirCutBlockCondBr` close the active sub-block with the requested terminator and start a fresh one
- The MIR-block lowering loop splices `extraBlocks` before the final block — the MIR terminator always lands on whichever sub-block is current at the end of the MIR block

**Algebraic 2-i64 type lowering**:
- `lirLowerMirType` emits `%Option.<T> = type { i64, i64 }` (and the matching `%Result.*` / `%Maybe.*`) when it sees the type-name prefix
- `lirMangleAlgebraicTypeName` produces a valid LLVM identifier even for nested generics like `Result<Option<Int>, Error>`

**Aggregate construction helpers**:
- `lirEmitOptionNone` / `lirEmitOptionSome` / `lirEmitResultOk` / `lirEmitResultErr` generate the canonical insertvalue chain matching production (`mir_generator_snapshot.go::mirOkAggregateLines / mirNoneAggregateLines`)
- `lirWrapOptionFromI64Sentinel` composes them with the sge-0 sentinel test for IndexOf — runtime returns -1 for "not found", >= 0 for the index

**Wiring**:
- `lirLowerMirIndexOf` inspects the dest local type and routes Option-typed dests through the wrapper, raw-Int dests through the bare i64 store
- Production uses a phi node at the merge point; LIR Proto picks the alloca-backed shape (slot in entry block, store in each arm, load on join sub-block) which is equivalent for correctness without growing the LIR instruction vocabulary

**Pin**: three Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- raw-i64 destination (no Option wrap)
- `Option<Int>` destination on `String.indexOf`
- `Option<Int>` destination on `Bytes.indexOf`

Each asserts the runtime declare line, the sentinel test, the some/none aggregate construction, and the merge load.

The remaining Option-returning safe forms (`MapGet`, `ListFirst`, `ListLast`, `BytesGet`, `ListGet` safe form, `ListPop`, plus `String.toInt`/`toFloat` Result wrapping) reuse the same basic-block-splitting infrastructure in follow-up slices — each only needs its own sentinel-shape helper.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass (all fixture catalog tests + the 3 new IndexOf pins)
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)