### PR TITLE
feat: LIR Proto Channel send/recv per-element ABI (+ chan_close symbol fix)

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -468,6 +468,23 @@ shapes (out-pointer + i1 present, len-bounds check, runtime parser
 status, etc.) — each is its own follow-up slice that reuses the
 basic-block-splitting + Option/Result aggregate helpers added here.
 
+Design decision: a follow-up Phase-4 slice replaces the Turn-2
+hardcoded `osty_rt_chan_close` symbol with the canonical
+`osty_rt_thread_chan_close` from `toolchain/llvmgen.osty`'s
+`llvmChanRuntime*` resolver family, then adds `MirIntrinsicChanMake`,
+`ChanIsClosed`, `ChanSend` (per-element-lane resolution mirroring
+List/Map/Set), and `ChanRecv` (whose runtime helper already returns
+the `{i64, i64}` Option<T> aggregate, so the LIR side just declares
+the lane-specific symbol and stores the call result into the dest).
+Composite element types route through a structured unsupported
+diagnostic — the bytes-v1 channel fallback is a separate slice
+because it shares its alloca + sizeof shape with the same fallback
+already deferred for List push/get.
+
+Five Phase-4 fixtures pin the new shape: corrected `chan_close`,
+`chan_make`, `chan_is_closed`, `chan_send_int` (i64 lane),
+`chan_recv_int` (returns `%Option.Int`).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -322,7 +322,7 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualSetInsertStringFixture", []string{"declare void @osty_rt_set_insert_string(ptr, ptr)", "call void @osty_rt_set_insert_string("}},
 		{"lirParityManualSetContainsI64Fixture", []string{"declare i1 @osty_rt_set_contains_i64(ptr, i64)", "call i1 @osty_rt_set_contains_i64("}},
 		{"lirParityManualSetToListFixture", []string{"declare ptr @osty_rt_set_to_list(ptr)", "call ptr @osty_rt_set_to_list("}},
-		{"lirParityManualChanCloseFixture", []string{"declare void @osty_rt_chan_close(ptr)", "call void @osty_rt_chan_close("}},
+		{"lirParityManualChanCloseFixture", []string{"declare void @osty_rt_thread_chan_close(ptr)", "call void @osty_rt_thread_chan_close("}},
 		{"lirParityManualYieldFixture", []string{"declare void @osty_rt_task_yield()", "call void @osty_rt_task_yield()"}},
 		{"lirParityManualIsCancelledFixture", []string{"declare i1 @osty_rt_cancel_is_cancelled()", "call i1 @osty_rt_cancel_is_cancelled()"}},
 		// ----- Phase 5: GC entry safepoint + function/parameter attributes -----
@@ -335,6 +335,11 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualStringIndexOfRawFixture", []string{"declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "call i64 @osty_rt_strings_IndexOf(", "ret i64"}},
 		{"lirParityManualStringIndexOfOptionFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "icmp sge i64", "alloca %Option.Int", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "load %Option.Int", "ret %Option.Int"}},
 		{"lirParityManualBytesIndexOfOptionFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_bytes_index_of(ptr, ptr)", "icmp sge i64", "ret %Option.Int"}},
+		// ----- Slice B: Channel send/recv per-element ABI -----
+		{"lirParityManualChanMakeFixture", []string{"declare ptr @osty_rt_thread_chan_make(i64)", "call ptr @osty_rt_thread_chan_make("}},
+		{"lirParityManualChanIsClosedFixture", []string{"declare i1 @osty_rt_thread_chan_is_closed(ptr)", "call i1 @osty_rt_thread_chan_is_closed("}},
+		{"lirParityManualChanSendIntFixture", []string{"declare void @osty_rt_thread_chan_send_i64(ptr, i64)", "call void @osty_rt_thread_chan_send_i64("}},
+		{"lirParityManualChanRecvIntFixture", []string{"%Option.Int = type", "declare %Option.Int @osty_rt_thread_chan_recv_i64(ptr)", "call %Option.Int @osty_rt_thread_chan_recv_i64(", "ret %Option.Int"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2130,7 +2130,11 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicSetInsert -> lirLowerMirSetInsert(l, instr),
         MirIntrinsicSetContains -> lirLowerMirSetContains(l, instr),
         MirIntrinsicSetRemove -> lirLowerMirSetRemove(l, instr),
-        MirIntrinsicChanClose -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_chan_close", lirVoidType(), [lirPtrType()], "chan.close"),
+        MirIntrinsicChanMake -> lirLowerMirStringRuntimeCall(l, instr, llvmChanRuntimeMakeSymbol(), lirPtrType(), [lirIntType(64)], "chan.make"),
+        MirIntrinsicChanClose -> lirLowerMirStringRuntimeCall(l, instr, llvmChanRuntimeCloseSymbol(), lirVoidType(), [lirPtrType()], "chan.close"),
+        MirIntrinsicChanIsClosed -> lirLowerMirStringRuntimeCall(l, instr, llvmChanRuntimeIsClosedSymbol(), lirIntType(1), [lirPtrType()], "chan.isClosed"),
+        MirIntrinsicChanSend -> lirLowerMirChanSend(l, instr),
+        MirIntrinsicChanRecv -> lirLowerMirChanRecv(l, instr),
         MirIntrinsicYield -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_task_yield", lirVoidType(), [], "task.yield"),
         MirIntrinsicIsCancelled -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_cancel_is_cancelled", lirIntType(1), [], "cancel.isCancelled"),
         MirIntrinsicStringIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("IndexOf"), [lirPtrType(), lirPtrType()], "string.indexOf"),
@@ -2936,6 +2940,97 @@ fn lirLowerMirIndexOf(l: LirMirFunctionLowerer, instr: MirInstr, symbol: String,
 // names already arrive from the monomorphizer with stable spellings.
 fn lirIsOptionTypeName(name: String) -> Bool {
     strings.startsWith(name, "Option<") || strings.startsWith(name, "Maybe<")
+}
+// Channel<T> send/recv lowering. Like List/Map/Set, the runtime splits
+// the helper symbol by element-type lane:
+// `osty_rt_thread_chan_send_<lane>` / `_recv_<lane>`. The composite
+// element fallback (`bytes_v1`) needs alloca + sizeof, which the
+// scalar-only LIR Proto path skips for now and surfaces as a structured
+// unsupported diagnostic.
+fn lirChannelElementTypeName(name: String) -> String {
+    if strings.startsWith(name, "Channel<") {
+        return lirContainerInnerArg(name, "Channel<")
+    }
+    ""
+}
+fn lirLowerMirChanSend(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, "chan.send expects (channel, value)", "chan.send")
+        return
+    }
+    let elemName = lirChannelElementTypeName(instr.args[0].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "chan.send could not extract element type from `" + instr.args[0].typ + "`", "chan.send")
+        return
+    }
+    let elemLir = lirContainerElemLaneType(elemName)
+    if lirTypeIsZero(elemLir) {
+        lirLowerError(l, LirDiagUnsupported, "chan.send element type `" + elemName + "` has no LIR runtime lane", "chan.send")
+        return
+    }
+    if !(llvmListUsesTypedRuntime(elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "chan.send composite element type `" + elemName + "` needs the bytes-v1 runtime fallback (deferred)", "chan.send")
+        return
+    }
+    let chReg = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "chan.send channel")
+    if chReg.value == "" {
+        return
+    }
+    let value = lirLowerCoercedOperand(l, instr.args[1], elemName, elemLir, "chan.send value")
+    if value.value == "" {
+        return
+    }
+    let symbol = llvmChanRuntimeSendSymbol(llvmListElementSuffix(elemLir.llvm))
+    lirEmitContainerCall(l, instr, symbol, lirVoidType(), [lirPtrType(), elemLir], [lirOperand(lirPtrType(), chReg.value), lirOperand(elemLir, value.value)], "", "chan.send")
+}
+// Channel recv returns the runtime's `{i64 disc, i64 payload}` shape
+// that already matches the `%Option.<T>` aggregate layout — disc=0 for
+// closed/cancelled, disc=1 for received value. The runtime helper does
+// the wrapping itself, so the LIR side only needs to declare the
+// recv-by-lane symbol and store the call result into the dest.
+fn lirLowerMirChanRecv(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "chan.recv expects (channel)", "chan.recv")
+        return
+    }
+    let elemName = lirChannelElementTypeName(instr.args[0].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "chan.recv could not extract element type from `" + instr.args[0].typ + "`", "chan.recv")
+        return
+    }
+    let elemLir = lirContainerElemLaneType(elemName)
+    if lirTypeIsZero(elemLir) {
+        lirLowerError(l, LirDiagUnsupported, "chan.recv element type `" + elemName + "` has no LIR runtime lane", "chan.recv")
+        return
+    }
+    if !(llvmListUsesTypedRuntime(elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "chan.recv composite element type `" + elemName + "` needs the bytes-v1 runtime fallback (deferred)", "chan.recv")
+        return
+    }
+    let chReg = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "chan.recv channel")
+    if chReg.value == "" {
+        return
+    }
+    let symbol = llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemLir.llvm))
+    if !(instr.hasDest) {
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirRawType("\{ i64, i64 \}"), [lirPtrType()], false))
+        l.instrs.push(lirCall("", lirRawType("\{ i64, i64 \}"), "@" + symbol, [lirOperand(lirPtrType(), chReg.value)]))
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "chan.recv destination local out of range", "chan.recv")
+        return
+    }
+    let destType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(destType) {
+        lirLowerError(l, LirDiagUnsupported, "chan.recv dest type `" + loc.typ + "` is not implemented", "chan.recv")
+        return
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, destType, [lirPtrType()], false))
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, destType, "@" + symbol, [lirOperand(lirPtrType(), chReg.value)]))
+    lirStoreMirResult(l, instr.dest, lirOperand(destType, dest), loc.typ, "chan.recv result")
 }
 fn lirIsResultTypeName(name: String) -> Bool {
     strings.startsWith(name, "Result<")

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -440,6 +440,18 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "bytes_index_of_option" {
         return lirParityBuildBytesIndexOfOptionModule()
+    }
+    if name == "chan_make" {
+        return lirParityBuildChanMakeModule()
+    }
+    if name == "chan_is_closed" {
+        return lirParityBuildChanIsClosedModule()
+    }
+    if name == "chan_send_int" {
+        return lirParityBuildChanSendIntModule()
+    }
+    if name == "chan_recv_int" {
+        return lirParityBuildChanRecvIntModule()
     }
     mirModule("main")
 }
@@ -822,7 +834,7 @@ pub fn lirParityManualSetToListFixture() -> LirParityFixture {
     lirParityFixture("set_to_list", LirParityManualMIR, "/tmp/lir_proto_parity_set_to_list.osty", "", "phase4b-set", ["set", "runtime"], [lirParityNeedle("declare ptr @osty_rt_set_to_list(ptr)", "set to_list runtime"), lirParityNeedle("call ptr @osty_rt_set_to_list(", "to_list call site")])
 }
 pub fn lirParityManualChanCloseFixture() -> LirParityFixture {
-    lirParityFixture("chan_close", LirParityManualMIR, "/tmp/lir_proto_parity_chan_close.osty", "", "phase4b-concurrency", ["concurrency", "runtime"], [lirParityNeedle("declare void @osty_rt_chan_close(ptr)", "chan close runtime"), lirParityNeedle("call void @osty_rt_chan_close(", "close call site")])
+    lirParityFixture("chan_close", LirParityManualMIR, "/tmp/lir_proto_parity_chan_close.osty", "", "phase4b-concurrency", ["concurrency", "runtime"], [lirParityNeedle("declare void @osty_rt_thread_chan_close(ptr)", "chan close runtime"), lirParityNeedle("call void @osty_rt_thread_chan_close(", "close call site")])
 }
 pub fn lirParityManualYieldFixture() -> LirParityFixture {
     lirParityFixture("yield", LirParityManualMIR, "/tmp/lir_proto_parity_yield.osty", "", "phase4b-concurrency", ["concurrency", "runtime"], [lirParityNeedle("declare void @osty_rt_task_yield()", "yield runtime"), lirParityNeedle("call void @osty_rt_task_yield()", "yield call site")])
@@ -1090,6 +1102,53 @@ pub fn lirParityBuildBytesIndexOfOptionModule() -> MirModule {
     let needle = lirParityParam(fn_, "needle", "Bytes")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesIndexOf, [mirOperandCopy(mirPlace(b), "Bytes"), mirOperandCopy(mirPlace(needle), "Bytes")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Slice B: Channel send/recv per-element ABI fixtures
+// ====================================================================
+pub fn lirParityManualChanMakeFixture() -> LirParityFixture {
+    lirParityFixture("chan_make", LirParityManualMIR, "/tmp/lir_proto_parity_chan_make.osty", "", "phase4-channel", ["channel", "runtime"], [lirParityNeedle("declare ptr @osty_rt_thread_chan_make(i64)", "chan make runtime"), lirParityNeedle("call ptr @osty_rt_thread_chan_make(", "chan make call site")])
+}
+pub fn lirParityManualChanIsClosedFixture() -> LirParityFixture {
+    lirParityFixture("chan_is_closed", LirParityManualMIR, "/tmp/lir_proto_parity_chan_is_closed.osty", "", "phase4-channel", ["channel", "runtime"], [lirParityNeedle("declare i1 @osty_rt_thread_chan_is_closed(ptr)", "chan is_closed runtime"), lirParityNeedle("call i1 @osty_rt_thread_chan_is_closed(", "chan is_closed call site")])
+}
+pub fn lirParityManualChanSendIntFixture() -> LirParityFixture {
+    lirParityFixture("chan_send_int", LirParityManualMIR, "/tmp/lir_proto_parity_chan_send_int.osty", "", "phase4-channel", ["channel", "runtime", "lane-i64"], [lirParityNeedle("declare void @osty_rt_thread_chan_send_i64(ptr, i64)", "i64 chan send runtime"), lirParityNeedle("call void @osty_rt_thread_chan_send_i64(", "send call site")])
+}
+pub fn lirParityManualChanRecvIntFixture() -> LirParityFixture {
+    lirParityFixture("chan_recv_int", LirParityManualMIR, "/tmp/lir_proto_parity_chan_recv_int.osty", "", "phase4-channel", ["channel", "runtime", "lane-i64"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare %Option.Int @osty_rt_thread_chan_recv_i64(ptr)", "i64 chan recv runtime"), lirParityNeedle("call %Option.Int @osty_rt_thread_chan_recv_i64(", "recv call site"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+// Module builders.
+pub fn lirParityBuildChanMakeModule() -> MirModule {
+    let mut fn_ = lirParityFunction("makeCh", "Channel<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicChanMake, [mirOperandConst(mirConstInt(4, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildChanIsClosedModule() -> MirModule {
+    let mut fn_ = lirParityFunction("isClosed", "Bool")
+    let ch = lirParityParam(fn_, "ch", "Channel<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicChanIsClosed, [mirOperandCopy(mirPlace(ch), "Channel<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildChanSendIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("ship", "Unit")
+    let ch = lirParityParam(fn_, "ch", "Channel<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicChanSend, [mirOperandCopy(mirPlace(ch), "Channel<Int>"), mirOperandConst(mirConstInt(7, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildChanRecvIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("take", "Option<Int>")
+    let ch = lirParityParam(fn_, "ch", "Channel<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicChanRecv, [mirOperandCopy(mirPlace(ch), "Channel<Int>")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Wires `Channel<T>` intrinsics through the same per-element-lane resolution pattern List/Map/Set already use, and corrects a Turn-2 symbol naming mistake along the way.

**Symbol fix**: Channel runtime symbols live under `osty_rt_thread_chan_*` — Turn 2 hardcoded `osty_rt_chan_close` which is the wrong family entirely. The fix routes `ChanClose` through `llvmChanRuntimeCloseSymbol()` so LIR Proto and the production MIR generator emit the same name; the `chan_close` fixture is updated to match. Without this, even the zero-arg primitive Turn 2 thought was working would mismatch production at the symbol level.

**New intrinsics**:
- `ChanMake` → `osty_rt_thread_chan_make(i64) -> ptr`
- `ChanIsClosed` → `osty_rt_thread_chan_is_closed(ptr) -> i1`
- `ChanSend` → `osty_rt_thread_chan_send_<lane>(ptr, <T>) -> void` — per-element-lane resolution (i64 / i1 / f64 / ptr) mirroring List/Map/Set
- `ChanRecv` → `osty_rt_thread_chan_recv_<lane>(ptr) -> %Option.<T>` — the runtime helper already returns the canonical `{i64, i64}` Option<T> aggregate, so the LIR side just declares the lane-specific symbol with the right return type and stores the call result into the destination

Composite element types surface a structured unsupported diagnostic — the bytes-v1 channel fallback is a separate slice because it shares the alloca + sizeof shape already deferred for List push/get.

A new helper `lirChannelElementTypeName` parses `Channel<T>` using the same `lirContainerInnerArg` shape used by List<T>/Map<K,V>/Set<T>.

**Pin**: five Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- corrected `chan_close` (now `osty_rt_thread_chan_close`)
- `chan_make` (i64 capacity → ptr)
- `chan_is_closed` (ptr → i1)
- `chan_send_int` (i64 lane)
- `chan_recv_int` (returns `%Option.Int`)

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)