### PR TITLE
feat: LIR Proto String.toInt / toFloat → Result<T, Error> wrapping

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -485,6 +485,34 @@ Five Phase-4 fixtures pin the new shape: corrected `chan_close`,
 `chan_make`, `chan_is_closed`, `chan_send_int` (i64 lane),
 `chan_recv_int` (returns `%Option.Int`).
 
+Design decision: a follow-up Phase-4 slice wires `String.toInt` /
+`String.toFloat` through the Result<T, Error> aggregate helpers added
+in the IndexOf-Option slice. `lirLowerMirStringParse` runs the
+validate-call (`osty_rt_strings_IsValidInt` / `IsValidFloat`,
+returning i1), branches on validity, and on the Ok arm calls
+`osty_rt_strings_ToInt` / `ToFloat` (returning i64 / double),
+widens / bitcasts the parsed value into the i64 payload slot, and
+constructs the Ok aggregate. The Err arm constructs an Err(0)
+placeholder. Production uses a phi node at the merge point; LIR Proto
+keeps the alloca shape from the IndexOf slice for the same
+"no-new-instruction-vocabulary" reason.
+
+`lirParseResultPayloadAsI64` widens parsed scalars into the i64
+payload slot exactly the way production's `toI64Slot` does:
+- i64 passes through.
+- double bitcasts to i64 (preserves the bit pattern).
+- float zero-extends to double then bitcasts.
+- ptr ptrtoints to i64.
+- narrower ints zext to i64.
+
+Two Phase-4 fixtures pin the shape: `string_to_int` (returns
+`%Result.Int_Error`) and `string_to_float` (returns
+`%Result.Float_Error` with the double-to-i64 bitcast on the Ok arm).
+Together with the IndexOf-Option fixtures, this exercises every
+sentinel pattern the basic-block-splitting infrastructure was added
+to support: i64 sge sentinel for the IndexOf family, i1 boolean
+present-flag for the parse family.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -340,6 +340,9 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualChanIsClosedFixture", []string{"declare i1 @osty_rt_thread_chan_is_closed(ptr)", "call i1 @osty_rt_thread_chan_is_closed("}},
 		{"lirParityManualChanSendIntFixture", []string{"declare void @osty_rt_thread_chan_send_i64(ptr, i64)", "call void @osty_rt_thread_chan_send_i64("}},
 		{"lirParityManualChanRecvIntFixture", []string{"%Option.Int = type", "declare %Option.Int @osty_rt_thread_chan_recv_i64(ptr)", "call %Option.Int @osty_rt_thread_chan_recv_i64(", "ret %Option.Int"}},
+		// ----- String parse → Result<T, Error> -----
+		{"lirParityManualStringToIntFixture", []string{"%Result.Int_Error = type", "declare i1 @osty_rt_strings_IsValidInt(ptr)", "declare i64 @osty_rt_strings_ToInt(ptr)", "alloca %Result.Int_Error", "insertvalue %Result.Int_Error undef, i64 1, 0", "insertvalue %Result.Int_Error undef, i64 0, 0", "load %Result.Int_Error", "ret %Result.Int_Error"}},
+		{"lirParityManualStringToFloatFixture", []string{"%Result.Float_Error = type", "declare i1 @osty_rt_strings_IsValidFloat(ptr)", "declare double @osty_rt_strings_ToFloat(ptr)", "bitcast double", "ret %Result.Float_Error"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2141,10 +2141,11 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicStringLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("LastIndexOf"), [lirPtrType(), lirPtrType()], "string.lastIndexOf"),
         MirIntrinsicBytesIndexOf -> lirLowerMirIndexOf(l, instr, mirRtBytesSymbol("index_of"), [lirPtrType(), lirPtrType()], "bytes.indexOf"),
         MirIntrinsicBytesLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtBytesSymbol("last_index_of"), [lirPtrType(), lirPtrType()], "bytes.lastIndexOf"),
+        MirIntrinsicStringToInt -> lirLowerMirStringParse(l, instr, mirRtStringIsValidIntSymbol(), mirRtStringToIntSymbol(), lirIntType(64), "string.toInt"),
+        MirIntrinsicStringToFloat -> lirLowerMirStringParse(l, instr, mirRtStringIsValidFloatSymbol(), mirRtStringToFloatSymbol(), lirFloatType("double"), "string.toFloat"),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
-// ----- IndexOf-family Option<Int> wrapping (Phase 4 deferred slice) -----
 fn lirLowerMirPrintIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr, newline: Bool, stderr: Bool) {
     if instr.args.len() != 1 {
         lirLowerError(l, LirDiagInvalidInput, "print intrinsic expects exactly one argument", "intrinsic.print")
@@ -2932,6 +2933,93 @@ fn lirLowerMirIndexOf(l: LirMirFunctionLowerer, instr: MirInstr, symbol: String,
         return
     }
     lirStoreMirResult(l, instr.dest, lirOperand(lirIntType(64), indexReg), "Int", label + " result")
+}
+// String parse → Result<T, Error> lowering: validate-call (i1) gates
+// the parse-call (i64 / double). On valid, the parsed value is widened
+// to i64 and wrapped in Ok; on invalid, the Err arm constructs an
+// Err(0) placeholder. Production uses a phi node at the merge point;
+// LIR Proto reuses the alloca-backed shape established by
+// `lirWrapOptionFromI64Sentinel` so the LIR instruction vocabulary
+// stays unchanged. Destination MUST be a `Result<...>` aggregate;
+// callers that pass a non-Result dest get a structured unsupported
+// diagnostic rather than a silent miscompile.
+fn lirLowerMirStringParse(l: LirMirFunctionLowerer, instr: MirInstr, validateSym: String, parseSym: String, parsedType: LirType, label: String) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects (string)", label)
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, label + " requires a destination (Result<T, Error>)", label)
+        return
+    }
+    let strReg = lirLowerCoercedOperand(l, instr.args[0], "String", lirPtrType(), label + " string")
+    if strReg.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
+        return
+    }
+    if !(lirIsResultTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination must be Result<...>, got `" + loc.typ + "`", label)
+        return
+    }
+    let resultType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(resultType) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination type `" + loc.typ + "` is not implemented", label)
+        return
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(validateSym, lirIntType(1), [lirPtrType()], false))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(parseSym, parsedType, [lirPtrType()], false))
+    let validReg = lirFresh(l)
+    l.instrs.push(lirCall(validReg, lirIntType(1), "@" + validateSym, [lirOperand(lirPtrType(), strReg.value)]))
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, resultType, 0))
+    let okLabel = lirFreshAuxLabel(l, label + ".ok")
+    let errLabel = lirFreshAuxLabel(l, label + ".err")
+    let endLabel = lirFreshAuxLabel(l, label + ".end")
+    lirCutBlockCondBr(l, validReg, okLabel, errLabel, okLabel)
+    let parsedReg = lirFresh(l)
+    l.instrs.push(lirCall(parsedReg, parsedType, "@" + parseSym, [lirOperand(lirPtrType(), strReg.value)]))
+    let payloadReg = lirParseResultPayloadAsI64(l, parsedReg, parsedType)
+    let okValue = lirEmitResultOk(l, resultType, payloadReg)
+    l.instrs.push(lirStore(lirOperand(resultType, okValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = errLabel
+    let errValue = lirEmitResultErr(l, resultType, "0")
+    l.instrs.push(lirStore(lirOperand(resultType, errValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, resultType, slot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(resultType, merged), loc.typ, label + " result")
+}
+// Widen a parsed scalar (i64 / double / i32 / i8 / i1) into the i64
+// the Ok payload slot uses. Production widens the same way
+// (mir_generator.go::toI64Slot): integers zext/sext to i64; floats
+// bitcast through `bitcast double %x to i64` so the bit pattern is
+// preserved. Returns the i64 register name.
+fn lirParseResultPayloadAsI64(l: LirMirFunctionLowerer, valueReg: String, valueType: LirType) -> String {
+    if valueType.llvm == "i64" {
+        return valueReg
+    }
+    let dest = lirFresh(l)
+    if valueType.llvm == "double" {
+        l.instrs.push(lirCast(dest, "bitcast", lirOperand(valueType, valueReg), lirIntType(64)))
+        return dest
+    }
+    if valueType.className == LirTypeFloat {
+        let widened = lirFresh(l)
+        l.instrs.push(lirCast(widened, "fpext", lirOperand(valueType, valueReg), lirFloatType("double")))
+        l.instrs.push(lirCast(dest, "bitcast", lirOperand(lirFloatType("double"), widened), lirIntType(64)))
+        return dest
+    }
+    if valueType.className == LirTypePtr {
+        l.instrs.push(lirCast(dest, "ptrtoint", lirOperand(valueType, valueReg), lirIntType(64)))
+        return dest
+    }
+    l.instrs.push(lirCast(dest, "zext", lirOperand(valueType, valueReg), lirIntType(64)))
+    dest
 }
 // `Option<...>` / `Maybe<...>` are the canonical 2-i64 aggregate types
 // production lowers Option-returning intrinsics into. The check is a

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -452,6 +452,12 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "chan_recv_int" {
         return lirParityBuildChanRecvIntModule()
+    }
+    if name == "string_to_int" {
+        return lirParityBuildStringToIntModule()
+    }
+    if name == "string_to_float" {
+        return lirParityBuildStringToFloatModule()
     }
     mirModule("main")
 }
@@ -1149,6 +1155,35 @@ pub fn lirParityBuildChanRecvIntModule() -> MirModule {
     let ch = lirParityParam(fn_, "ch", "Channel<Int>")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicChanRecv, [mirOperandCopy(mirPlace(ch), "Channel<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// String parse → Result<T, Error> fixtures
+// ====================================================================
+//
+// Two fixtures pin the parse-validate-Ok/Err shape: String.toInt
+// (i64 payload) and String.toFloat (double payload bitcast through
+// i64 for the Ok aggregate slot).
+pub fn lirParityManualStringToIntFixture() -> LirParityFixture {
+    lirParityFixture("string_to_int", LirParityManualMIR, "/tmp/lir_proto_parity_string_to_int.osty", "", "phase4-result", ["result", "string", "parse"], [lirParityNeedle("%Result.Int_Error = type \{ i64, i64 \}", "Result<Int, Error> aggregate type"), lirParityNeedle("declare i1 @osty_rt_strings_IsValidInt(ptr)", "validate runtime"), lirParityNeedle("declare i64 @osty_rt_strings_ToInt(ptr)", "parse runtime"), lirParityNeedle("call i1 @osty_rt_strings_IsValidInt(", "validate call site"), lirParityNeedle("call i64 @osty_rt_strings_ToInt(", "parse call site"), lirParityNeedle("alloca %Result.Int_Error", "merge slot"), lirParityNeedle("insertvalue %Result.Int_Error undef, i64 1, 0", "Ok disc"), lirParityNeedle("insertvalue %Result.Int_Error undef, i64 0, 0", "Err disc"), lirParityNeedle("load %Result.Int_Error", "merge load"), lirParityNeedle("ret %Result.Int_Error", "Result return")])
+}
+pub fn lirParityManualStringToFloatFixture() -> LirParityFixture {
+    lirParityFixture("string_to_float", LirParityManualMIR, "/tmp/lir_proto_parity_string_to_float.osty", "", "phase4-result", ["result", "string", "parse"], [lirParityNeedle("%Result.Float_Error = type \{ i64, i64 \}", "Result<Float, Error> aggregate type"), lirParityNeedle("declare i1 @osty_rt_strings_IsValidFloat(ptr)", "validate runtime"), lirParityNeedle("declare double @osty_rt_strings_ToFloat(ptr)", "parse runtime"), lirParityNeedle("call double @osty_rt_strings_ToFloat(", "parse call site"), lirParityNeedle("bitcast double", "double-to-i64 payload coercion"), lirParityNeedle("ret %Result.Float_Error", "Result return")])
+}
+pub fn lirParityBuildStringToIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("parseInt", "Result<Int, Error>")
+    let s = lirParityParam(fn_, "s", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringToInt, [mirOperandCopy(mirPlace(s), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringToFloatModule() -> MirModule {
+    let mut fn_ = lirParityFunction("parseFloat", "Result<Float, Error>")
+    let s = lirParityParam(fn_, "s", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringToFloat, [mirOperandCopy(mirPlace(s), "String")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Wires String parse intrinsics (`String.toInt`, `String.toFloat`) through the Result<T, Error> aggregate helpers added in the IndexOf-Option slice. Both reuse the basic-block splitting infrastructure — no new LIR instruction vocabulary needed.

**Pattern**: validate-call (i1 present-flag) gates the parse-call (i64 / double). On Ok arm, the parsed value is widened into the i64 payload slot and wrapped in `Result.Ok`; on Err arm, `Result.Err(0)` placeholder.

**`lirLowerMirStringParse`**:
1. Lowers the receiver string to ptr
2. Calls `osty_rt_strings_IsValidInt` / `IsValidFloat` returning i1
3. Conditional branch on validity (sub-blocks: ok / err / end)
4. Ok arm: calls `osty_rt_strings_ToInt` / `ToFloat` returning i64 / double, widens via `lirParseResultPayloadAsI64`, builds `Result.Ok(payload)`
5. Err arm: builds `Result.Err(0)` placeholder
6. Both arms store into alloca-backed merge slot, end-block loads the merged Result

**`lirParseResultPayloadAsI64`** widens parsed scalars into the i64 payload slot the same way production's `toI64Slot` does:
- i64 passes through
- double bitcasts to i64 (preserves bit pattern)
- float zero-extends to double then bitcasts
- ptr ptrtoints to i64
- narrower ints zext to i64

**Pin**: two Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- `string_to_int` — returns `%Result.Int_Error`
- `string_to_float` — returns `%Result.Float_Error` with the double-to-i64 bitcast on the Ok arm

Together with the IndexOf-Option fixtures, this exercises every sentinel pattern the basic-block-splitting infrastructure was added to support: i64 sge sentinel for IndexOf, i1 boolean present-flag for parse.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)