### PR TITLE
feat: LIR Proto Map.get → Option<V> wrapping

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -513,6 +513,25 @@ sentinel pattern the basic-block-splitting infrastructure was added
 to support: i64 sge sentinel for the IndexOf family, i1 boolean
 present-flag for the parse family.
 
+Design decision: a follow-up Phase-4 slice wires `Map.get(key) ->
+Option<V>` through the same Option-aggregate machinery. Production
+calls `osty_rt_map_get_<keysuf>(map, key, out_ptr) -> i1` — the
+runtime memcpys the value into `out_ptr` on hit and returns true; on
+miss it returns false and leaves `out_ptr` untouched. The Some arm
+loads from the out-slot, widens to i64 via `lirParseResultPayloadAsI64`
+(reused from the parse slice), and builds Option.Some; the None arm
+builds Option.None. Both arms store into an alloca-backed merge slot.
+
+Composite value types (struct / tuple values) need the bytes-v1
+runtime fallback that List/Map/Set/Channel composite elements all
+share — that's a separate slice.
+
+Two Phase-4 fixtures pin the shape: `map_get_string_int`
+(`Map<String, Int>` → `%Option.Int`, exercises the most common
+string-key dispatch) and `map_get_i64_string`
+(`Map<Int, String>` → `%Option.String`, exercises both i64-key and
+ptr-value lane resolutions plus the ptrtoint payload coercion).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -343,6 +343,9 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		// ----- String parse → Result<T, Error> -----
 		{"lirParityManualStringToIntFixture", []string{"%Result.Int_Error = type", "declare i1 @osty_rt_strings_IsValidInt(ptr)", "declare i64 @osty_rt_strings_ToInt(ptr)", "alloca %Result.Int_Error", "insertvalue %Result.Int_Error undef, i64 1, 0", "insertvalue %Result.Int_Error undef, i64 0, 0", "load %Result.Int_Error", "ret %Result.Int_Error"}},
 		{"lirParityManualStringToFloatFixture", []string{"%Result.Float_Error = type", "declare i1 @osty_rt_strings_IsValidFloat(ptr)", "declare double @osty_rt_strings_ToFloat(ptr)", "bitcast double", "ret %Result.Float_Error"}},
+		// ----- Map.get → Option<V> -----
+		{"lirParityManualMapGetStringIntFixture", []string{"%Option.Int = type", "declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "alloca i64", "call i1 @osty_rt_map_get_string(", "alloca %Option.Int", "load i64", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "ret %Option.Int"}},
+		{"lirParityManualMapGetI64StringFixture", []string{"%Option.String = type", "declare i1 @osty_rt_map_get_i64(ptr, i64, ptr)", "alloca ptr", "call i1 @osty_rt_map_get_i64(", "ptrtoint ptr", "ret %Option.String"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2121,6 +2121,7 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicMapValues -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeValuesSymbol(), lirPtrType(), [lirPtrType()], "map.values"),
         MirIntrinsicMapClear -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeClearSymbol(), lirVoidType(), [lirPtrType()], "map.clear"),
         MirIntrinsicMapSet -> lirLowerMirMapInsert(l, instr),
+        MirIntrinsicMapGet -> lirLowerMirMapGet(l, instr),
         MirIntrinsicMapContains -> lirLowerMirMapContains(l, instr),
         MirIntrinsicMapRemove -> lirLowerMirMapRemove(l, instr),
         MirIntrinsicSetNew -> lirLowerMirStringRuntimeCall(l, instr, llvmSetRuntimeNewSymbol(), lirPtrType(), [], "set.new"),
@@ -2846,6 +2847,79 @@ fn lirLowerMirMapRemove(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     lirEmitContainerCall(l, instr, llvmMapRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value)], "", "map.remove")
+}
+// `Map.get(key) -> Option<V>` lowering. Production calls
+// `osty_rt_map_get_<keysuf>(map, key, out_ptr) -> i1` where the runtime
+// memcpys the value into `out_ptr` on hit and returns true; on miss
+// it returns false and leaves `out_ptr` untouched. The Some arm loads
+// from the out-slot, widens to i64 the same way the parse-Result
+// helper does, and builds the canonical `%Option.<V>` aggregate. The
+// None arm builds Option.None. Both arms store into an alloca-backed
+// merge slot and the end-block loads the merged Option<V>.
+//
+// Composite element types (struct / tuple values) need the bytes-v1
+// runtime fallback, which is the same alloca + sizeof shape List/Map/
+// Set/Channel composite elements all share — that's a separate slice.
+fn lirLowerMirMapGet(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, "map.get expects (map, key)", "map.get")
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, "map.get requires a destination (Option<V>)", "map.get")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "map.get", "map.kv")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.valueLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "map.get composite value type `" + recv.valueTypeName + "` needs the bytes-v1 runtime fallback (deferred)", "map.get")
+        return
+    }
+    let key = lirLowerCoercedOperand(l, instr.args[1], recv.elemTypeName, recv.elemLir, "map.get key")
+    if key.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "map.get destination local out of range", "map.get")
+        return
+    }
+    if !(lirIsOptionTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, "map.get destination must be Option<V>, got `" + loc.typ + "`", "map.get")
+        return
+    }
+    let optType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(optType) {
+        lirLowerError(l, LirDiagUnsupported, "map.get destination type `" + loc.typ + "` is not implemented", "map.get")
+        return
+    }
+    let symbol = mirRtMapSymbol("get_" + llvmMapKeySuffix(recv.elemLir.llvm, recv.isString))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirIntType(1), [lirPtrType(), recv.elemLir, lirPtrType()], false))
+    let outSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(outSlot, recv.valueLir, 0))
+    let presentReg = lirFresh(l)
+    l.instrs.push(lirCall(presentReg, lirIntType(1), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(lirPtrType(), outSlot)]))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, optType, 0))
+    let someLabel = lirFreshAuxLabel(l, "map.get.some")
+    let noneLabel = lirFreshAuxLabel(l, "map.get.none")
+    let endLabel = lirFreshAuxLabel(l, "map.get.end")
+    lirCutBlockCondBr(l, presentReg, someLabel, noneLabel, someLabel)
+    let loaded = lirFresh(l)
+    l.instrs.push(lirLoad(loaded, recv.valueLir, outSlot, 0))
+    let payloadI64 = lirParseResultPayloadAsI64(l, loaded, recv.valueLir)
+    let someValue = lirEmitOptionSome(l, optType, payloadI64)
+    l.instrs.push(lirStore(lirOperand(optType, someValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = noneLabel
+    let noneValue = lirEmitOptionNone(l, optType)
+    l.instrs.push(lirStore(lirOperand(optType, noneValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, optType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(optType, merged), loc.typ, "map.get result")
 }
 // ----- Set intrinsic lowerings (typed elem lane) -----
 fn lirLowerMirSetInsert(l: LirMirFunctionLowerer, instr: MirInstr) {

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -458,6 +458,12 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "string_to_float" {
         return lirParityBuildStringToFloatModule()
+    }
+    if name == "map_get_string_int" {
+        return lirParityBuildMapGetStringIntModule()
+    }
+    if name == "map_get_i64_string" {
+        return lirParityBuildMapGetI64StringModule()
     }
     mirModule("main")
 }
@@ -1184,6 +1190,38 @@ pub fn lirParityBuildStringToFloatModule() -> MirModule {
     let s = lirParityParam(fn_, "s", "String")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringToFloat, [mirOperandCopy(mirPlace(s), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Map.get → Option<V> fixtures
+// ====================================================================
+//
+// Two fixtures pin the out-pointer + i1 present pattern: Map<String,
+// Int> (string-key + i64 value) and Map<Int, String> (i64-key + ptr
+// value). The string-key form exercises the most common dispatch
+// (osty_rt_map_get_string), and the i64-key/string-value form covers
+// both lane resolutions in one fixture.
+pub fn lirParityManualMapGetStringIntFixture() -> LirParityFixture {
+    lirParityFixture("map_get_string_int", LirParityManualMIR, "/tmp/lir_proto_parity_map_get_string_int.osty", "", "phase4-option", ["option", "map", "get", "key-string"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "string-key get runtime"), lirParityNeedle("alloca i64", "out-slot for value"), lirParityNeedle("call i1 @osty_rt_map_get_string(", "get call site"), lirParityNeedle("alloca %Option.Int", "merge slot"), lirParityNeedle("load i64", "value load on Some arm"), lirParityNeedle("insertvalue %Option.Int undef, i64 1, 0", "Some disc"), lirParityNeedle("insertvalue %Option.Int undef, i64 0, 0", "None disc"), lirParityNeedle("ret %Option.Int", "Option<V> return")])
+}
+pub fn lirParityManualMapGetI64StringFixture() -> LirParityFixture {
+    lirParityFixture("map_get_i64_string", LirParityManualMIR, "/tmp/lir_proto_parity_map_get_i64_string.osty", "", "phase4-option", ["option", "map", "get", "key-i64", "value-ptr"], [lirParityNeedle("%Option.String = type \{ i64, i64 \}", "Option<String> aggregate type"), lirParityNeedle("declare i1 @osty_rt_map_get_i64(ptr, i64, ptr)", "i64-key get runtime"), lirParityNeedle("alloca ptr", "out-slot for ptr value"), lirParityNeedle("call i1 @osty_rt_map_get_i64(", "get call site"), lirParityNeedle("ptrtoint ptr", "ptr-to-i64 payload coercion"), lirParityNeedle("ret %Option.String", "Option<String> return")])
+}
+pub fn lirParityBuildMapGetStringIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("lookup", "Option<Int>")
+    let m = lirParityParam(fn_, "m", "Map<String, Int>")
+    let k = lirParityParam(fn_, "k", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapGet, [mirOperandCopy(mirPlace(m), "Map<String, Int>"), mirOperandCopy(mirPlace(k), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildMapGetI64StringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("lookupName", "Option<String>")
+    let m = lirParityParam(fn_, "m", "Map<Int, String>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapGet, [mirOperandCopy(mirPlace(m), "Map<Int, String>"), mirOperandConst(mirConstInt(7, "Int"))], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Wires `Map.get(key) -> Option<V>` through the Option<V> aggregate helpers added in earlier slices.

**Pattern**: production calls `osty_rt_map_get_<keysuf>(map, key, out_ptr) -> i1` — the runtime memcpys the value into `out_ptr` on hit and returns true; on miss it returns false and leaves `out_ptr` untouched. The Some arm loads from the out-slot, widens to i64 via `lirParseResultPayloadAsI64` (reused from the parse slice), and builds `Option.Some`; the None arm builds `Option.None`. Both arms store into an alloca-backed merge slot, end-block loads the merged Option<V>.

**`lirLowerMirMapGet`**:
1. Reuses `lirLowerMirContainerReceiver` with `"map.kv"` to get key + value lane info in one parse
2. Allocates `out_slot` of `recv.valueLir`
3. Calls `osty_rt_map_get_<keysuf>(map, key, out_slot) -> i1`
4. Conditional branch on i1 present (sub-blocks: some / none / end)
5. Some arm: load value from out-slot, widen to i64, build `Option.Some(payload)`
6. None arm: build `Option.None`
7. Both arms store into alloca-backed merge slot, end-block loads merged Option<V>

Composite value types (struct / tuple values) surface a structured unsupported diagnostic — the bytes-v1 runtime fallback is the same alloca + sizeof shape List/Map/Set/Channel composite elements all share, deferred to a separate slice.

**Pin**: two Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- `map_get_string_int` — `Map<String, Int>` → `%Option.Int` — exercises the most common string-key dispatch
- `map_get_i64_string` — `Map<Int, String>` → `%Option.String` — exercises both i64-key and ptr-value lane resolutions plus the ptrtoint payload coercion

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)