### PR TITLE
feat: LIR Proto List.first / List.last → Option<T> wrapping

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -532,6 +532,22 @@ string-key dispatch) and `map_get_i64_string`
 (`Map<Int, String>` → `%Option.String`, exercises both i64-key and
 ptr-value lane resolutions plus the ptrtoint payload coercion).
 
+Design decision: a follow-up Phase-4 slice wires `List.first()` /
+`List.last() -> Option<T>` through the same Option-aggregate
+machinery. Production has no bespoke `_first` / `_last` runtime —
+both compose `osty_rt_list_len` + `osty_rt_list_get_<lane>` and
+gate on `len == 0` (mir_generator.go::IntrinsicListFirst|Last). LIR
+Proto mirrors that composition: call len, icmp eq with 0, on
+non-empty branch call get with `idx=0` (first) or `idx=len-1` (last),
+widen the loaded value via `lirParseResultPayloadAsI64`, build
+Option.Some; on empty branch build Option.None.
+
+Two Phase-4 fixtures pin the shape: `list_first_int`
+(`List<Int>` → `%Option.Int`, idx=0, exercises the i64 element lane)
+and `list_last_float` (`List<Float>` → `%Option.Float`, idx=len-1,
+exercises the f64 element lane and the sub-from-len idx
+computation plus the bitcast double-to-i64 payload coercion).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -346,6 +346,9 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		// ----- Map.get → Option<V> -----
 		{"lirParityManualMapGetStringIntFixture", []string{"%Option.Int = type", "declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "alloca i64", "call i1 @osty_rt_map_get_string(", "alloca %Option.Int", "load i64", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "ret %Option.Int"}},
 		{"lirParityManualMapGetI64StringFixture", []string{"%Option.String = type", "declare i1 @osty_rt_map_get_i64(ptr, i64, ptr)", "alloca ptr", "call i1 @osty_rt_map_get_i64(", "ptrtoint ptr", "ret %Option.String"}},
+		// ----- List.first / List.last → Option<T> -----
+		{"lirParityManualListFirstIntFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_list_len(ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "icmp eq i64", "alloca %Option.Int", "call i64 @osty_rt_list_get_i64(", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "ret %Option.Int"}},
+		{"lirParityManualListLastFloatFixture", []string{"%Option.Float = type", "declare i64 @osty_rt_list_len(ptr)", "declare double @osty_rt_list_get_f64(ptr, i64)", "sub i64", "call double @osty_rt_list_get_f64(", "bitcast double", "ret %Option.Float"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2111,6 +2111,8 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicListGet -> lirLowerMirListGet(l, instr),
         MirIntrinsicListClear -> lirLowerMirStringRuntimeCall(l, instr, mirRtListClearSymbol(), lirVoidType(), [lirPtrType()], "list.clear"),
         MirIntrinsicListReverse -> lirLowerMirStringRuntimeCall(l, instr, mirRtListReverseSymbol(), lirVoidType(), [lirPtrType()], "list.reverse"),
+        MirIntrinsicListFirst -> lirLowerMirListFirstOrLast(l, instr, false),
+        MirIntrinsicListLast -> lirLowerMirListFirstOrLast(l, instr, true),
         MirIntrinsicListReversed -> lirLowerMirStringRuntimeCall(l, instr, mirRtListReversedSymbol(), lirPtrType(), [lirPtrType()], "list.reversed"),
         MirIntrinsicListPop -> lirLowerMirStringRuntimeCall(l, instr, mirRtListPopDiscardSymbol(), lirVoidType(), [lirPtrType()], "list.pop"),
         MirIntrinsicListSorted -> lirLowerMirListSorted(l, instr),
@@ -2921,6 +2923,89 @@ fn lirLowerMirMapGet(l: LirMirFunctionLowerer, instr: MirInstr) {
     l.instrs.push(lirLoad(merged, optType, mergeSlot, 0))
     lirStoreMirResult(l, instr.dest, lirOperand(optType, merged), loc.typ, "map.get result")
 }
+// `List.first()` / `List.last() -> Option<T>` lowering. Runtime has no
+// bespoke `_first` / `_last` symbol — production composes
+// `osty_rt_list_len` + `osty_rt_list_get_<lane>` and gates on
+// `len == 0` (mir_generator.go::IntrinsicListFirst|Last).
+//
+// Mirroring that here keeps LIR Proto and production on the same
+// runtime ABI without inventing a new helper. The Some arm picks
+// idx=0 for first, idx=len-1 for last; the loaded value widens to
+// i64 via `lirParseResultPayloadAsI64` (reused from the parse slice)
+// before going into the Option payload slot.
+fn lirLowerMirListFirstOrLast(l: LirMirFunctionLowerer, instr: MirInstr, isLast: Bool) {
+    let label = if isLast {
+        "list.last"
+    } else {
+        "list.first"
+    }
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects (list)", label)
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, label + " requires a destination (Option<T>)", label)
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, label, "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, label + " composite element type `" + recv.elemTypeName + "` needs the bytes-v1 runtime fallback (deferred)", label)
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
+        return
+    }
+    if !(lirIsOptionTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination must be Option<T>, got `" + loc.typ + "`", label)
+        return
+    }
+    let optType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(optType) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination type `" + loc.typ + "` is not implemented", label)
+        return
+    }
+    let lenSym = llvmListRuntimeLenSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDeclI64FromPtr(lenSym))
+    let lenReg = lirFresh(l)
+    l.instrs.push(lirCall(lenReg, lirIntType(64), "@" + lenSym, [lirOperand(lirPtrType(), recv.receiverReg)]))
+    let isEmpty = lirFresh(l)
+    l.instrs.push(lirBinary(isEmpty, "icmp eq", lirIntType(64), lenReg, "0"))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, optType, 0))
+    let someLabel = lirFreshAuxLabel(l, label + ".some")
+    let noneLabel = lirFreshAuxLabel(l, label + ".none")
+    let endLabel = lirFreshAuxLabel(l, label + ".end")
+    lirCutBlockCondBr(l, isEmpty, noneLabel, someLabel, noneLabel)
+    let noneValue = lirEmitOptionNone(l, optType)
+    l.instrs.push(lirStore(lirOperand(optType, noneValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = someLabel
+    let idxRef = if isLast {
+        let idxReg = lirFresh(l)
+        l.instrs.push(lirBinary(idxReg, "sub", lirIntType(64), lenReg, "1"))
+        idxReg
+    } else {
+        "0"
+    }
+    let getSym = llvmListRuntimeGetSymbolFor(recv.elemLir.llvm, recv.isString)
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(getSym, recv.elemLir, [lirPtrType(), lirIntType(64)], false))
+    let elemReg = lirFresh(l)
+    l.instrs.push(lirCall(elemReg, recv.elemLir, "@" + getSym, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), idxRef)]))
+    let payloadI64 = lirParseResultPayloadAsI64(l, elemReg, recv.elemLir)
+    let someValue = lirEmitOptionSome(l, optType, payloadI64)
+    l.instrs.push(lirStore(lirOperand(optType, someValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, optType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(optType, merged), loc.typ, label + " result")
+}
+// isEmpty=true → none arm; isEmpty=false → some arm. Match
+// production's `mirBrCondLine(isEmpty, noneLabel, someLabel)`.
 // ----- Set intrinsic lowerings (typed elem lane) -----
 fn lirLowerMirSetInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -464,6 +464,12 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "map_get_i64_string" {
         return lirParityBuildMapGetI64StringModule()
+    }
+    if name == "list_first_int" {
+        return lirParityBuildListFirstIntModule()
+    }
+    if name == "list_last_float" {
+        return lirParityBuildListLastFloatModule()
     }
     mirModule("main")
 }
@@ -1222,6 +1228,36 @@ pub fn lirParityBuildMapGetI64StringModule() -> MirModule {
     let m = lirParityParam(fn_, "m", "Map<Int, String>")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapGet, [mirOperandCopy(mirPlace(m), "Map<Int, String>"), mirOperandConst(mirConstInt(7, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// List.first / List.last → Option<T> fixtures
+// ====================================================================
+//
+// Two fixtures pin the len-guarded Option wrap: List<Int>.first()
+// (idx=0, exercises the i64 element lane) and List<Float>.last()
+// (idx=len-1, exercises the f64 element lane and the sub i64
+// idx-from-len computation).
+pub fn lirParityManualListFirstIntFixture() -> LirParityFixture {
+    lirParityFixture("list_first_int", LirParityManualMIR, "/tmp/lir_proto_parity_list_first_int.osty", "", "phase4-option", ["option", "list", "first"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare i64 @osty_rt_list_len(ptr)", "len runtime"), lirParityNeedle("declare i64 @osty_rt_list_get_i64(ptr, i64)", "i64 get runtime"), lirParityNeedle("call i64 @osty_rt_list_len(", "len call"), lirParityNeedle("icmp eq i64", "empty test"), lirParityNeedle("alloca %Option.Int", "merge slot"), lirParityNeedle("call i64 @osty_rt_list_get_i64(", "get call on Some arm"), lirParityNeedle("insertvalue %Option.Int undef, i64 1, 0", "Some disc"), lirParityNeedle("insertvalue %Option.Int undef, i64 0, 0", "None disc"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+pub fn lirParityManualListLastFloatFixture() -> LirParityFixture {
+    lirParityFixture("list_last_float", LirParityManualMIR, "/tmp/lir_proto_parity_list_last_float.osty", "", "phase4-option", ["option", "list", "last"], [lirParityNeedle("%Option.Float = type \{ i64, i64 \}", "Option<Float> aggregate type"), lirParityNeedle("declare i64 @osty_rt_list_len(ptr)", "len runtime"), lirParityNeedle("declare double @osty_rt_list_get_f64(ptr, i64)", "f64 get runtime"), lirParityNeedle("sub i64", "len-1 idx computation"), lirParityNeedle("call double @osty_rt_list_get_f64(", "get call on Some arm"), lirParityNeedle("bitcast double", "double-to-i64 payload coercion"), lirParityNeedle("ret %Option.Float", "Option<Float> return")])
+}
+pub fn lirParityBuildListFirstIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("head", "Option<Int>")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListFirst, [mirOperandCopy(mirPlace(xs), "List<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListLastFloatModule() -> MirModule {
+    let mut fn_ = lirParityFunction("tail", "Option<Float>")
+    let xs = lirParityParam(fn_, "xs", "List<Float>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListLast, [mirOperandCopy(mirPlace(xs), "List<Float>")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Wires `List.first()` / `List.last() -> Option<T>` through the Option<T> aggregate helpers. Production has no bespoke `_first` / `_last` runtime — both compose `osty_rt_list_len` + `osty_rt_list_get_<lane>` and gate on `len == 0`. LIR Proto mirrors that composition exactly.

**Pattern**:
1. Call `osty_rt_list_len(list) -> i64`
2. icmp eq with 0 → `isEmpty`
3. CondBr on `isEmpty`: empty → none arm, non-empty → some arm
4. Some arm:
   - `idx = 0` for first
   - `idx = sub i64 len, 1` for last
   - Call `osty_rt_list_get_<lane>(list, idx)` → typed value
   - Widen via `lirParseResultPayloadAsI64`
   - Build `Option.Some(payload)`
5. None arm: build `Option.None`
6. Both arms store into alloca-backed merge slot, end-block loads the merged Option<T>

Composite element types surface a structured unsupported diagnostic — the bytes-v1 runtime fallback shared with List push/get is a separate slice.

**Pin**: two Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- `list_first_int` — `List<Int>` → `%Option.Int`, idx=0, exercises the i64 element lane
- `list_last_float` — `List<Float>` → `%Option.Float`, idx=len-1, exercises the f64 element lane AND the sub-from-len idx computation AND the bitcast double-to-i64 payload coercion

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)