### PR TITLE
feat: LIR Proto batched ListPop / BytesGet / ToString / CheckCancelled (6 intrinsics)

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -548,6 +548,31 @@ and `list_last_float` (`List<Float>` → `%Option.Float`, idx=len-1,
 exercises the f64 element lane and the sub-from-len idx
 computation plus the bitcast double-to-i64 payload coercion).
 
+Design decision: a batched Phase-4 slice covers the remaining
+straightforward Option/Result-returning intrinsics in one PR:
+`ListPop` (Option<T> with `len-1 → get → discard` capture order),
+`BytesGet` (Option<Byte> with `idx >= 0 && idx < len` AND'd
+in-bounds check), `ListToString` (per-elem-kind dispatch into
+`osty_rt_list_to_string_<i64|f64|i1|char|byte|string>`),
+`MapToString` and `SetToString` (both single-call entries — the
+runtime carries `key_kind` / `elem_kind` set at allocation time so
+the per-kind formatter is picked inside C, lowering just emits the
+call), and `CheckCancelled` (`Result<(), Error>` returned as the raw
+`{ i64, i64 }` aggregate from the runtime — declares and stores at
+the raw type since the dest slot's named `%Result.Unit_Error` type
+is structurally identical and LLVM accepts the direct store).
+
+Six Phase-4 fixtures pin the shape: `list_pop_int`,
+`bytes_get`, `list_to_string_int`, `map_to_string`,
+`set_to_string`, `check_cancelled`.
+
+This closes the bulk of the Option/Result-returning intrinsic gap.
+The remaining Option-related work is the bytes-v1 fallback path for
+composite element types (List/Map/Set/Channel push/get/insert all
+need the same alloca + sizeof shape), plus the closure-env
+intrinsics (TaskGroup/Spawn/HandleJoin/Parallel/Race/CollectAll/
+Select*) that depend on the GC root-binding pass.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -349,6 +349,13 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		// ----- List.first / List.last → Option<T> -----
 		{"lirParityManualListFirstIntFixture", []string{"%Option.Int = type", "declare i64 @osty_rt_list_len(ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "icmp eq i64", "alloca %Option.Int", "call i64 @osty_rt_list_get_i64(", "insertvalue %Option.Int undef, i64 1, 0", "insertvalue %Option.Int undef, i64 0, 0", "ret %Option.Int"}},
 		{"lirParityManualListLastFloatFixture", []string{"%Option.Float = type", "declare i64 @osty_rt_list_len(ptr)", "declare double @osty_rt_list_get_f64(ptr, i64)", "sub i64", "call double @osty_rt_list_get_f64(", "bitcast double", "ret %Option.Float"}},
+		// ----- Batched: ListPop / BytesGet / ToString / CheckCancelled -----
+		{"lirParityManualListPopIntFixture", []string{"%Option.Int = type", "declare void @osty_rt_list_pop_discard(ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "icmp eq i64", "sub i64", "call i64 @osty_rt_list_get_i64(", "call void @osty_rt_list_pop_discard(", "ret %Option.Int"}},
+		{"lirParityManualBytesGetFixture", []string{"%Option.Byte = type", "declare i64 @osty_rt_bytes_len(ptr)", "declare i8 @osty_rt_bytes_get(ptr, i64)", "icmp sge i64", "icmp slt i64", "and i1", "call i8 @osty_rt_bytes_get(", "zext i8", "ret %Option.Byte"}},
+		{"lirParityManualListToStringIntFixture", []string{"declare ptr @osty_rt_list_to_string_i64(ptr)", "call ptr @osty_rt_list_to_string_i64("}},
+		{"lirParityManualMapToStringFixture", []string{"declare ptr @osty_rt_map_to_string(ptr)", "call ptr @osty_rt_map_to_string("}},
+		{"lirParityManualSetToStringFixture", []string{"declare ptr @osty_rt_set_to_string(ptr)", "call ptr @osty_rt_set_to_string("}},
+		{"lirParityManualCheckCancelledFixture", []string{"declare { i64, i64 } @osty_rt_cancel_check_cancelled()", "call { i64, i64 } @osty_rt_cancel_check_cancelled()"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2114,7 +2114,12 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicListFirst -> lirLowerMirListFirstOrLast(l, instr, false),
         MirIntrinsicListLast -> lirLowerMirListFirstOrLast(l, instr, true),
         MirIntrinsicListReversed -> lirLowerMirStringRuntimeCall(l, instr, mirRtListReversedSymbol(), lirPtrType(), [lirPtrType()], "list.reversed"),
-        MirIntrinsicListPop -> lirLowerMirStringRuntimeCall(l, instr, mirRtListPopDiscardSymbol(), lirVoidType(), [lirPtrType()], "list.pop"),
+        MirIntrinsicListPop -> lirLowerMirListPop(l, instr),
+        MirIntrinsicListToString -> lirLowerMirListToString(l, instr),
+        MirIntrinsicBytesGet -> lirLowerMirBytesGet(l, instr),
+        MirIntrinsicMapToString -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_map_to_string", lirPtrType(), [lirPtrType()], "map.toString"),
+        MirIntrinsicSetToString -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_set_to_string", lirPtrType(), [lirPtrType()], "set.toString"),
+        MirIntrinsicCheckCancelled -> lirLowerMirCheckCancelled(l, instr),
         MirIntrinsicListSorted -> lirLowerMirListSorted(l, instr),
         MirIntrinsicListInsert -> lirLowerMirListInsert(l, instr),
         MirIntrinsicMapNew -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeNewSymbol(), lirPtrType(), [], "map.new"),
@@ -3006,6 +3011,235 @@ fn lirLowerMirListFirstOrLast(l: LirMirFunctionLowerer, instr: MirInstr, isLast:
 }
 // isEmpty=true → none arm; isEmpty=false → some arm. Match
 // production's `mirBrCondLine(isEmpty, noneLabel, someLabel)`.
+// `List.pop() -> Option<T>` lowering. Production captures the
+// last element via `osty_rt_list_get_<lane>(list, len-1)` BEFORE
+// calling the discard helper `osty_rt_list_pop_discard(list)` so
+// the value is read out of the slot before the runtime drops the
+// tail. Empty list returns Option.None without touching the discard
+// helper. Statement-position pop (no dest) falls back to a bare
+// discard call.
+fn lirLowerMirListPop(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "list.pop expects (list)", "list.pop")
+        return
+    }
+    if !(instr.hasDest) {
+        let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+        if recv.value == "" {
+            return
+        }
+        let symbol = mirRtListPopDiscardSymbol()
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType()], false))
+        l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), recv.value)]))
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "list.pop", "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "list.pop composite element type `" + recv.elemTypeName + "` needs the bytes-v1 runtime fallback (deferred)", "list.pop")
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "list.pop destination local out of range", "list.pop")
+        return
+    }
+    if !(lirIsOptionTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, "list.pop destination must be Option<T>, got `" + loc.typ + "`", "list.pop")
+        return
+    }
+    let optType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(optType) {
+        lirLowerError(l, LirDiagUnsupported, "list.pop destination type `" + loc.typ + "` is not implemented", "list.pop")
+        return
+    }
+    let lenSym = llvmListRuntimeLenSymbol()
+    let getSym = llvmListRuntimeGetSymbolFor(recv.elemLir.llvm, recv.isString)
+    let discardSym = mirRtListPopDiscardSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDeclI64FromPtr(lenSym))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(getSym, recv.elemLir, [lirPtrType(), lirIntType(64)], false))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(discardSym, lirVoidType(), [lirPtrType()], false))
+    let lenReg = lirFresh(l)
+    l.instrs.push(lirCall(lenReg, lirIntType(64), "@" + lenSym, [lirOperand(lirPtrType(), recv.receiverReg)]))
+    let isEmpty = lirFresh(l)
+    l.instrs.push(lirBinary(isEmpty, "icmp eq", lirIntType(64), lenReg, "0"))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, optType, 0))
+    let someLabel = lirFreshAuxLabel(l, "list.pop.some")
+    let noneLabel = lirFreshAuxLabel(l, "list.pop.none")
+    let endLabel = lirFreshAuxLabel(l, "list.pop.end")
+    lirCutBlockCondBr(l, isEmpty, noneLabel, someLabel, noneLabel)
+    let noneValue = lirEmitOptionNone(l, optType)
+    l.instrs.push(lirStore(lirOperand(optType, noneValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = someLabel
+    let lastIdx = lirFresh(l)
+    l.instrs.push(lirBinary(lastIdx, "sub", lirIntType(64), lenReg, "1"))
+    let elemReg = lirFresh(l)
+    l.instrs.push(lirCall(elemReg, recv.elemLir, "@" + getSym, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), lastIdx)]))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + discardSym, [lirOperand(lirPtrType(), recv.receiverReg)]))
+    let payloadI64 = lirParseResultPayloadAsI64(l, elemReg, recv.elemLir)
+    let someValue = lirEmitOptionSome(l, optType, payloadI64)
+    l.instrs.push(lirStore(lirOperand(optType, someValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, optType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(optType, merged), loc.typ, "list.pop result")
+}
+// Discard form: just drop the last element. Production aborts on
+// empty (the runtime's contract); we keep the same behavior by
+// routing through the same symbol.
+// `Bytes.get(idx) -> Option<Byte>` lowering. Tests `idx >= 0 && idx
+// < len(bytes)` before calling `osty_rt_bytes_get(ptr, i64) -> i8`.
+// In-bounds → Some(byte zext to i64); out-of-bounds → None. Mirrors
+// the production shape (mir_generator.go::IntrinsicBytesGet).
+fn lirLowerMirBytesGet(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, "bytes.get expects (bytes, idx)", "bytes.get")
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, "bytes.get requires a destination (Option<Byte>)", "bytes.get")
+        return
+    }
+    let bytesReg = lirLowerCoercedOperand(l, instr.args[0], "Bytes", lirPtrType(), "bytes.get bytes")
+    if bytesReg.value == "" {
+        return
+    }
+    let idxReg = lirLowerCoercedOperand(l, instr.args[1], "Int", lirIntType(64), "bytes.get idx")
+    if idxReg.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "bytes.get destination local out of range", "bytes.get")
+        return
+    }
+    if !(lirIsOptionTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, "bytes.get destination must be Option<Byte>, got `" + loc.typ + "`", "bytes.get")
+        return
+    }
+    let optType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(optType) {
+        lirLowerError(l, LirDiagUnsupported, "bytes.get destination type `" + loc.typ + "` is not implemented", "bytes.get")
+        return
+    }
+    let lenSym = mirRtBytesLenSymbolName()
+    let getSym = mirRtBytesGetSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDeclI64FromPtr(lenSym))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(getSym, lirIntType(8), [lirPtrType(), lirIntType(64)], false))
+    let lenReg = lirFresh(l)
+    l.instrs.push(lirCall(lenReg, lirIntType(64), "@" + lenSym, [lirOperand(lirPtrType(), bytesReg.value)]))
+    let nonNeg = lirFresh(l)
+    l.instrs.push(lirBinary(nonNeg, "icmp sge", lirIntType(64), idxReg.value, "0"))
+    let beforeEnd = lirFresh(l)
+    l.instrs.push(lirBinary(beforeEnd, "icmp slt", lirIntType(64), idxReg.value, lenReg))
+    let inRange = lirFresh(l)
+    l.instrs.push(lirBinary(inRange, "and", lirIntType(1), nonNeg, beforeEnd))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, optType, 0))
+    let someLabel = lirFreshAuxLabel(l, "bytes.get.some")
+    let noneLabel = lirFreshAuxLabel(l, "bytes.get.none")
+    let endLabel = lirFreshAuxLabel(l, "bytes.get.end")
+    lirCutBlockCondBr(l, inRange, someLabel, noneLabel, someLabel)
+    let byteReg = lirFresh(l)
+    l.instrs.push(lirCall(byteReg, lirIntType(8), "@" + getSym, [lirOperand(lirPtrType(), bytesReg.value), lirOperand(lirIntType(64), idxReg.value)]))
+    let payloadI64 = lirParseResultPayloadAsI64(l, byteReg, lirIntType(8))
+    let someValue = lirEmitOptionSome(l, optType, payloadI64)
+    l.instrs.push(lirStore(lirOperand(optType, someValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = noneLabel
+    let noneValue = lirEmitOptionNone(l, optType)
+    l.instrs.push(lirStore(lirOperand(optType, noneValue), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, optType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(optType, merged), loc.typ, "bytes.get result")
+}
+// `List.toString() -> String` lowering. Per-element-kind dispatch:
+// `osty_rt_list_to_string_<i64|f64|i1|char|byte|string>`. The
+// runtime ships a separate formatter per ABI lane; lowering picks
+// the right symbol off the receiver's element LLVM type. Composite
+// element types (struct / enum / nested collection) surface as
+// unsupported until a callback-driven runtime entry lands.
+fn lirLowerMirListToString(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "list.toString expects (list)", "list.toString")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "list.toString", "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    let symbol = lirListToStringSymbolForLane(recv.elemLir.llvm, recv.isString)
+    if symbol == "" {
+        lirLowerError(l, LirDiagUnsupported, "list.toString has no runtime helper for element type `" + recv.elemTypeName + "`", "list.toString")
+        return
+    }
+    lirEmitContainerCall(l, instr, symbol, lirPtrType(), [lirPtrType()], [lirOperand(lirPtrType(), recv.receiverReg)], "String", "list.toString")
+}
+fn lirListToStringSymbolForLane(elemLLVM: String, isString: Bool) -> String {
+    if isString {
+        return "osty_rt_list_to_string_string"
+    }
+    if elemLLVM == "i64" {
+        return "osty_rt_list_to_string_i64"
+    }
+    if elemLLVM == "double" {
+        return "osty_rt_list_to_string_f64"
+    }
+    if elemLLVM == "i1" {
+        return "osty_rt_list_to_string_i1"
+    }
+    if elemLLVM == "i32" {
+        return "osty_rt_list_to_string_char"
+    }
+    if elemLLVM == "i8" {
+        return "osty_rt_list_to_string_byte"
+    }
+    ""
+}
+// `checkCancelled() -> Result<(), Error>` lowering. Runtime helper
+// returns the raw `{ i64, i64 }` aggregate (production:
+// mir_generator.go::IntrinsicCheckCancelled). LIR Proto declares
+// and calls with the same raw shape; the destination's named
+// `%Result.Unit_Error` type is structurally identical so a direct
+// store works without any bitcast at the LLVM level.
+fn lirLowerMirCheckCancelled(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 0 {
+        lirLowerError(l, LirDiagInvalidInput, "checkCancelled expects no arguments", "cancel.check")
+        return
+    }
+    let symbol = mirRtCancelCheckCancelledSymbol()
+    let rawType = lirRawType("\{ i64, i64 \}")
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, [], false))
+    if !(instr.hasDest) {
+        l.instrs.push(lirCall("", rawType, "@" + symbol, []))
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "checkCancelled destination local out of range", "cancel.check")
+        return
+    }
+    if !(lirIsResultTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, "checkCancelled destination must be Result<...>, got `" + loc.typ + "`", "cancel.check")
+        return
+    }
+    lirLowerMirType(l, loc.typ)
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, rawType, "@" + symbol, []))
+    let slot = lirMirLocalSlot(l, loc.id)
+    if slot.slot == "" {
+        lirLowerError(l, LirDiagLoweringBug, "cancel.check destination has no LIR slot", "cancel.check")
+        return
+    }
+    l.instrs.push(lirStore(lirOperand(rawType, dest), slot.slot, 0))
+}
+// Force the named aggregate typedef to be registered so the dest
+// slot's element type is a known module-level definition.
 // ----- Set intrinsic lowerings (typed elem lane) -----
 fn lirLowerMirSetInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -470,6 +470,24 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "list_last_float" {
         return lirParityBuildListLastFloatModule()
+    }
+    if name == "list_pop_int" {
+        return lirParityBuildListPopIntModule()
+    }
+    if name == "bytes_get" {
+        return lirParityBuildBytesGetModule()
+    }
+    if name == "list_to_string_int" {
+        return lirParityBuildListToStringIntModule()
+    }
+    if name == "map_to_string" {
+        return lirParityBuildMapToStringModule()
+    }
+    if name == "set_to_string" {
+        return lirParityBuildSetToStringModule()
+    }
+    if name == "check_cancelled" {
+        return lirParityBuildCheckCancelledModule()
     }
     mirModule("main")
 }
@@ -1258,6 +1276,76 @@ pub fn lirParityBuildListLastFloatModule() -> MirModule {
     let xs = lirParityParam(fn_, "xs", "List<Float>")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListLast, [mirOperandCopy(mirPlace(xs), "List<Float>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Batched Phase-4 deferred slices: ListPop / BytesGet / ToString /
+// CheckCancelled
+// ====================================================================
+pub fn lirParityManualListPopIntFixture() -> LirParityFixture {
+    lirParityFixture("list_pop_int", LirParityManualMIR, "/tmp/lir_proto_parity_list_pop_int.osty", "", "phase4-option", ["option", "list", "pop"], [lirParityNeedle("%Option.Int = type \{ i64, i64 \}", "Option<Int> aggregate type"), lirParityNeedle("declare i64 @osty_rt_list_len(ptr)", "len runtime"), lirParityNeedle("declare i64 @osty_rt_list_get_i64(ptr, i64)", "i64 get runtime"), lirParityNeedle("declare void @osty_rt_list_pop_discard(ptr)", "pop discard runtime"), lirParityNeedle("icmp eq i64", "empty test"), lirParityNeedle("sub i64", "len-1 idx"), lirParityNeedle("call i64 @osty_rt_list_get_i64(", "value capture before discard"), lirParityNeedle("call void @osty_rt_list_pop_discard(", "discard tail"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+pub fn lirParityManualBytesGetFixture() -> LirParityFixture {
+    lirParityFixture("bytes_get", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_get.osty", "", "phase4-option", ["option", "bytes", "get"], [lirParityNeedle("%Option.Byte = type \{ i64, i64 \}", "Option<Byte> aggregate type"), lirParityNeedle("declare i64 @osty_rt_bytes_len(ptr)", "len runtime"), lirParityNeedle("declare i8 @osty_rt_bytes_get(ptr, i64)", "byte get runtime"), lirParityNeedle("icmp sge i64", "lower-bound check"), lirParityNeedle("icmp slt i64", "upper-bound check"), lirParityNeedle("and i1", "in-range AND"), lirParityNeedle("call i8 @osty_rt_bytes_get(", "byte get on Some arm"), lirParityNeedle("zext i8", "byte-to-i64 payload widen"), lirParityNeedle("ret %Option.Byte", "Option<Byte> return")])
+}
+pub fn lirParityManualListToStringIntFixture() -> LirParityFixture {
+    lirParityFixture("list_to_string_int", LirParityManualMIR, "/tmp/lir_proto_parity_list_to_string_int.osty", "", "phase4-tostring", ["tostring", "list"], [lirParityNeedle("declare ptr @osty_rt_list_to_string_i64(ptr)", "i64 list toString runtime"), lirParityNeedle("call ptr @osty_rt_list_to_string_i64(", "list toString call site")])
+}
+pub fn lirParityManualMapToStringFixture() -> LirParityFixture {
+    lirParityFixture("map_to_string", LirParityManualMIR, "/tmp/lir_proto_parity_map_to_string.osty", "", "phase4-tostring", ["tostring", "map"], [lirParityNeedle("declare ptr @osty_rt_map_to_string(ptr)", "map toString runtime"), lirParityNeedle("call ptr @osty_rt_map_to_string(", "map toString call site")])
+}
+pub fn lirParityManualSetToStringFixture() -> LirParityFixture {
+    lirParityFixture("set_to_string", LirParityManualMIR, "/tmp/lir_proto_parity_set_to_string.osty", "", "phase4-tostring", ["tostring", "set"], [lirParityNeedle("declare ptr @osty_rt_set_to_string(ptr)", "set toString runtime"), lirParityNeedle("call ptr @osty_rt_set_to_string(", "set toString call site")])
+}
+pub fn lirParityManualCheckCancelledFixture() -> LirParityFixture {
+    lirParityFixture("check_cancelled", LirParityManualMIR, "/tmp/lir_proto_parity_check_cancelled.osty", "", "phase4-result", ["result", "cancel"], [lirParityNeedle("declare \{ i64, i64 \} @osty_rt_cancel_check_cancelled()", "cancel check runtime returning Result aggregate"), lirParityNeedle("call \{ i64, i64 \} @osty_rt_cancel_check_cancelled()", "cancel check call site")])
+}
+// Module builders.
+pub fn lirParityBuildListPopIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("popOne", "Option<Int>")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListPop, [mirOperandCopy(mirPlace(xs), "List<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesGetModule() -> MirModule {
+    let mut fn_ = lirParityFunction("at", "Option<Byte>")
+    let b = lirParityParam(fn_, "b", "Bytes")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesGet, [mirOperandCopy(mirPlace(b), "Bytes"), mirOperandConst(mirConstInt(2, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListToStringIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("show", "String")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListToString, [mirOperandCopy(mirPlace(xs), "List<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildMapToStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("show", "String")
+    let m = lirParityParam(fn_, "m", "Map<String, Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapToString, [mirOperandCopy(mirPlace(m), "Map<String, Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSetToStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("show", "String")
+    let s = lirParityParam(fn_, "s", "Set<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicSetToString, [mirOperandCopy(mirPlace(s), "Set<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildCheckCancelledModule() -> MirModule {
+    let mut fn_ = lirParityFunction("ask", "Result<Unit, Error>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicCheckCancelled, [], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Six lowerings batched into one slice so the Phase-4 deferred queue stops looking indefinite:

- **`ListPop -> Option<T>`** — capture last element via `get(len-1)` BEFORE calling `pop_discard` so the value is read out of the slot before the runtime drops the tail. Empty list returns None without touching discard. Statement-position pop (no dest) falls back to bare discard.
- **`BytesGet -> Option<Byte>`** — tests `idx >= 0 && idx < len(bytes)` via ANDed icmp's. In-bounds branch calls `osty_rt_bytes_get(ptr, i64) -> i8`, widens to i64, builds `Some(byte)`; out-of-bounds builds `None`.
- **`ListToString -> String`** — per-element-kind dispatch into `osty_rt_list_to_string_{i64|f64|i1|char|byte|string}` based on the receiver's element LLVM type. Composite elements surface as unsupported until a callback-driven runtime entry lands.
- **`MapToString` / `SetToString` -> String** — single runtime call (`osty_rt_map_to_string` / `osty_rt_set_to_string`). The runtime carries `key_kind` / `elem_kind` set at allocation time so the per-kind formatter is picked inside C.
- **`CheckCancelled -> Result<(), Error>`** — runtime returns the raw `{ i64, i64 }` aggregate; declares and stores at the raw type since the dest slot's named `%Result.Unit_Error` type is structurally identical and LLVM accepts the direct store without any bitcast.

**Pin**: six Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- `list_pop_int` (Option<Int>, exercises the get-before-discard order)
- `bytes_get` (Option<Byte>, exercises the ANDed bounds check + zext payload)
- `list_to_string_int` (i64 lane symbol)
- `map_to_string` (single-call entry)
- `set_to_string` (single-call entry)
- `check_cancelled` (Result aggregate from raw runtime declare)

Closes the bulk of the Option/Result-returning intrinsic gap. Remaining Option-related work is the bytes-v1 fallback for composite elements (List/Map/Set/Channel push/get/insert all share the same alloca + sizeof shape), plus the closure-env intrinsics (TaskGroup / Spawn / Parallel / Select*) that depend on the GC root-binding pass.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)