### PR TITLE
feat: LIR Proto bytes-v1 fallback + concurrency + Map fused + Bytes conversions (10 intrinsics)

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -573,6 +573,46 @@ need the same alloca + sizeof shape), plus the closure-env
 intrinsics (TaskGroup/Spawn/HandleJoin/Parallel/Race/CollectAll/
 Select*) that depend on the GC root-binding pass.
 
+Design decision: a five-slice batch covers the bytes-v1 fallback
+infrastructure plus several straightforward intrinsic
+groups in one PR:
+
+- **bytes-v1 fallback for List push (composite element)**:
+  `lirEmitSizeOf` materialises the runtime byte size via the canonical
+  `getelementptr inbounds %T, ptr null, i32 1` + `ptrtoint` idiom,
+  matching production's `llvmSizeOf`. `lirLowerMirListPush` now
+  detects composite element types up front (no LIR runtime lane) and
+  routes through `lirLowerMirListPushBytesV1` which spills the value
+  into a stack slot and calls
+  `osty_rt_list_push_bytes_v1(list, slot, size)`. The other composite
+  paths (List get/insert/set, Map insert/get composite value, Set
+  insert/contains/remove composite elem, Channel send composite) all
+  share the same shape and reuse `lirEmitSizeOf` in follow-up slices.
+
+- **Concurrency primitives** without closure-env: `Sleep`,
+  `GroupCancel`, `GroupIsCancelled` lower as plain runtime calls
+  through the existing `lirLowerMirStringRuntimeCall` helper.
+  `HandleJoin` reads its return type off the destination local
+  (production picks the LLVM type from `i.Dest.Local.Type`).
+
+- **`MapKeysSorted`**: per-key-lane symbol
+  `osty_rt_map_keys_sorted_<i64|string>` selected via the existing
+  `LirContainerReceiver` key-lane info.
+
+- **Bytes ↔ String/List conversions**: `BytesFromString`,
+  `BytesFromList` are simple ptr→ptr calls through the existing
+  helper. `BytesToString` and `BytesFromHex` use the new
+  `lirLowerMirBytesValidatedResult` which mirrors the
+  `lirLowerMirStringParse` shape but with ptr success values
+  (production:
+  mir_generator.go::emitBytesValidatedResult).
+
+Eleven Phase-4 fixtures pin every shape: `list_push_bytes_v1`,
+`handle_join_int`, `group_cancel`, `group_is_cancelled`, `sleep`,
+`map_keys_sorted_i64`, `bytes_from_string`, `bytes_from_list`,
+`bytes_to_string`, `bytes_from_hex` (10 new + the existing
+`check_cancelled` reuse).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -356,6 +356,17 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualMapToStringFixture", []string{"declare ptr @osty_rt_map_to_string(ptr)", "call ptr @osty_rt_map_to_string("}},
 		{"lirParityManualSetToStringFixture", []string{"declare ptr @osty_rt_set_to_string(ptr)", "call ptr @osty_rt_set_to_string("}},
 		{"lirParityManualCheckCancelledFixture", []string{"declare { i64, i64 } @osty_rt_cancel_check_cancelled()", "call { i64, i64 } @osty_rt_cancel_check_cancelled()"}},
+		// ----- Batched: bytes-v1 / concurrency / Map fused / Bytes conversions -----
+		{"lirParityManualListPushBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)", "alloca %Cell", "getelementptr inbounds %Cell, ptr null, i32 1", "ptrtoint ptr", "call void @osty_rt_list_push_bytes_v1("}},
+		{"lirParityManualHandleJoinIntFixture", []string{"declare i64 @osty_rt_task_handle_join(ptr)", "call i64 @osty_rt_task_handle_join("}},
+		{"lirParityManualGroupCancelFixture", []string{"declare void @osty_rt_task_group_cancel(ptr)", "call void @osty_rt_task_group_cancel("}},
+		{"lirParityManualGroupIsCancelledFixture", []string{"declare i1 @osty_rt_task_group_is_cancelled(ptr)", "call i1 @osty_rt_task_group_is_cancelled("}},
+		{"lirParityManualSleepFixture", []string{"declare void @osty_rt_thread_sleep(ptr)", "call void @osty_rt_thread_sleep("}},
+		{"lirParityManualMapKeysSortedI64Fixture", []string{"declare ptr @osty_rt_map_keys_sorted_i64(ptr)", "call ptr @osty_rt_map_keys_sorted_i64("}},
+		{"lirParityManualBytesFromStringFixture", []string{"declare ptr @osty_rt_strings_ToBytes(ptr)", "call ptr @osty_rt_strings_ToBytes("}},
+		{"lirParityManualBytesFromListFixture", []string{"declare ptr @osty_rt_bytes_from_list(ptr)", "call ptr @osty_rt_bytes_from_list("}},
+		{"lirParityManualBytesToStringFixture", []string{"%Result.String_Error = type", "declare i1 @osty_rt_bytes_is_valid_utf8(ptr)", "declare ptr @osty_rt_bytes_to_string(ptr)", "ptrtoint ptr", "ret %Result.String_Error"}},
+		{"lirParityManualBytesFromHexFixture", []string{"%Result.Bytes_Error = type", "declare i1 @osty_rt_bytes_is_valid_hex(ptr)", "declare ptr @osty_rt_bytes_from_hex(ptr)", "ret %Result.Bytes_Error"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2144,6 +2144,15 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicChanSend -> lirLowerMirChanSend(l, instr),
         MirIntrinsicChanRecv -> lirLowerMirChanRecv(l, instr),
         MirIntrinsicYield -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_task_yield", lirVoidType(), [], "task.yield"),
+        MirIntrinsicSleep -> lirLowerMirStringRuntimeCall(l, instr, mirRtThreadSleepSymbol(), lirVoidType(), [lirPtrType()], "task.sleep"),
+        MirIntrinsicGroupCancel -> lirLowerMirStringRuntimeCall(l, instr, mirRtTaskGroupCancelSymbol(), lirVoidType(), [lirPtrType()], "group.cancel"),
+        MirIntrinsicGroupIsCancelled -> lirLowerMirStringRuntimeCall(l, instr, mirRtTaskGroupIsCancelledSymbol(), lirIntType(1), [lirPtrType()], "group.isCancelled"),
+        MirIntrinsicHandleJoin -> lirLowerMirHandleJoin(l, instr),
+        MirIntrinsicMapKeysSorted -> lirLowerMirMapKeysSorted(l, instr),
+        MirIntrinsicBytesFromList -> lirLowerMirStringRuntimeCall(l, instr, mirRtBytesFromListSymbol(), lirPtrType(), [lirPtrType()], "bytes.fromList"),
+        MirIntrinsicBytesFromString -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringToBytesSymbol(), lirPtrType(), [lirPtrType()], "bytes.fromString"),
+        MirIntrinsicBytesToString -> lirLowerMirBytesValidatedResult(l, instr, mirRtBytesIsValidUTF8Symbol(), mirRtBytesToStringSymbol(), "bytes.toString"),
+        MirIntrinsicBytesFromHex -> lirLowerMirBytesValidatedResult(l, instr, mirRtBytesIsValidHexSymbol(), mirRtBytesFromHexSymbol(), "bytes.fromHex"),
         MirIntrinsicIsCancelled -> lirLowerMirStringRuntimeCall(l, instr, "osty_rt_cancel_is_cancelled", lirIntType(1), [], "cancel.isCancelled"),
         MirIntrinsicStringIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("IndexOf"), [lirPtrType(), lirPtrType()], "string.indexOf"),
         MirIntrinsicStringLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtStringSymbol("LastIndexOf"), [lirPtrType(), lirPtrType()], "string.lastIndexOf"),
@@ -2723,6 +2732,16 @@ fn lirLowerMirListPush(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "list.push expects (list, elem)", "list.push")
         return
     }
+    let elemName = lirListElemTypeName(instr.args[0].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "list.push could not extract element type from receiver `" + instr.args[0].typ + "`", "list.push")
+        return
+    }
+    let elemLane = lirContainerElemLaneType(elemName)
+    if lirTypeIsZero(elemLane) {
+        lirLowerMirListPushBytesV1(l, instr, elemName)
+        return
+    }
     let recv = lirLowerMirContainerReceiver(l, instr, "list.push", "list.elem")
     if !(recv.ok) {
         return
@@ -2732,6 +2751,53 @@ fn lirLowerMirListPush(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     lirEmitContainerCall(l, instr, llvmListRuntimePushSymbolFor(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, value.value)], "", "list.push")
+}
+// Composite element type: route through the bytes-v1 fallback
+// (alloca + sizeof + osty_rt_list_push_bytes_v1) instead of the
+// typed-lane path. Production shares the same shape across List/
+// Map/Set/Channel composite element ABIs (mir_generator.go).
+// `lirLowerMirListPushBytesV1` lowers a composite-element List.push
+// through the bytes-v1 runtime ABI. Production uses the same shape
+// (mir_generator.go::emitListPushOperand bytes branch): spill the
+// value into a stack slot, compute the element size via the
+// `getelementptr null` idiom, and call
+// `osty_rt_list_push_bytes_v1(list, slot, size)`.
+fn lirLowerMirListPushBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemName: String) {
+    let elemType = lirLowerMirType(l, elemName)
+    if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+        lirLowerError(l, LirDiagUnsupported, "list.push composite element type `" + elemName + "` has no MIR layout", "list.push")
+        return
+    }
+    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    if recv.value == "" {
+        return
+    }
+    let value = lirLowerMirOperand(l, instr.args[1], elemName, elemType)
+    if value.value == "" {
+        return
+    }
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, elemType, 0))
+    l.instrs.push(lirStore(lirOperand(elemType, value.value), slot, 0))
+    let sizeReg = lirEmitSizeOf(l, elemType)
+    let symbol = mirRtListSymbol("push_bytes_v1")
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirPtrType(), lirIntType(64)], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), recv.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg)]))
+    if instr.hasDest {
+        lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "list.push")
+    }
+}
+// `lirEmitSizeOf` materialises the runtime byte size of a composite
+// type via the canonical `getelementptr inbounds %T, ptr null, i32 1`
+// + `ptrtoint` idiom. Production uses the same idiom
+// (`llvmSizeOf` in toolchain/llvmgen.osty). Returns the i64 register
+// holding the size.
+fn lirEmitSizeOf(l: LirMirFunctionLowerer, typ: LirType) -> String {
+    let endPtr = lirFresh(l)
+    l.instrs.push(lirGep(endPtr, typ, "null", [lirOperand(lirIntType(32), "1")], true))
+    let sizeReg = lirFresh(l)
+    l.instrs.push(lirCast(sizeReg, "ptrtoint", lirOperand(lirPtrType(), endPtr), lirIntType(64)))
+    sizeReg
 }
 fn lirLowerMirListGet(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {
@@ -3240,6 +3306,121 @@ fn lirLowerMirCheckCancelled(l: LirMirFunctionLowerer, instr: MirInstr) {
 }
 // Force the named aggregate typedef to be registered so the dest
 // slot's element type is a known module-level definition.
+// `Handle<T>.join() -> T` lowering. The runtime helper returns the
+// value the spawned task produced; the LIR side picks the LLVM
+// return type off the destination local (production:
+// mir_generator.go::IntrinsicHandleJoin). When the dest is Unit (or
+// missing) the call returns ptr that gets discarded.
+fn lirLowerMirHandleJoin(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "handle.join expects (handle)", "handle.join")
+        return
+    }
+    let handle = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "handle.join handle")
+    if handle.value == "" {
+        return
+    }
+    let symbol = mirRtTaskHandleJoinSymbol()
+    let mut retType = lirPtrType()
+    if instr.hasDest {
+        let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+        if loc.id < 0 {
+            lirLowerError(l, LirDiagInvalidInput, "handle.join destination local out of range", "handle.join")
+            return
+        }
+        let lowered = lirLowerMirType(l, loc.typ)
+        if !(lirTypeIsZero(lowered)) && !(lirTypeIsVoid(lowered)) {
+            retType = lowered
+        }
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, retType, [lirPtrType()], false))
+    if !(instr.hasDest) {
+        let _ignored = lirFresh(l)
+        l.instrs.push(lirCall(_ignored, retType, "@" + symbol, [lirOperand(lirPtrType(), handle.value)]))
+        return
+    }
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, retType, "@" + symbol, [lirOperand(lirPtrType(), handle.value)]))
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    lirStoreMirResult(l, instr.dest, lirOperand(retType, dest), loc.typ, "handle.join result")
+}
+// `Map.keys().sorted()` fused → single per-key-lane runtime call.
+// Production picks `osty_rt_map_keys_sorted_<i64|string>` based on
+// the receiver's key lane (mir_generator.go::IntrinsicMapKeysSorted).
+fn lirLowerMirMapKeysSorted(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "map.keysSorted expects (map)", "map.keysSorted")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "map.keysSorted", "map.key")
+    if !(recv.ok) {
+        return
+    }
+    let suffix = if recv.isString {
+        "string"
+    } else {
+        llvmMapKeySuffix(recv.elemLir.llvm, false)
+    }
+    let symbol = mirRtMapSymbol("keys_sorted_" + suffix)
+    lirEmitContainerCall(l, instr, symbol, lirPtrType(), [lirPtrType()], [lirOperand(lirPtrType(), recv.receiverReg)], "List", "map.keysSorted")
+}
+// `Bytes.toString() -> Result<String, Error>` /
+// `Bytes.fromHex() -> Result<Bytes, Error>` lowering. Same
+// validate-then-call shape as `lirLowerMirStringParse`, except both
+// the validate input and the success result are ptr (instead of
+// String→i64/double). The Ok arm wraps the success ptr via ptrtoint
+// into the i64 payload slot; the Err arm wraps Err(0).
+fn lirLowerMirBytesValidatedResult(l: LirMirFunctionLowerer, instr: MirInstr, validateSym: String, successSym: String, label: String) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects (bytes)", label)
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, label + " requires a destination (Result<...>)", label)
+        return
+    }
+    let inputReg = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), label + " input")
+    if inputReg.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
+        return
+    }
+    if !(lirIsResultTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination must be Result<...>, got `" + loc.typ + "`", label)
+        return
+    }
+    let resultType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(resultType) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination type `" + loc.typ + "` is not implemented", label)
+        return
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(validateSym, lirIntType(1), [lirPtrType()], false))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(successSym, lirPtrType(), [lirPtrType()], false))
+    let validReg = lirFresh(l)
+    l.instrs.push(lirCall(validReg, lirIntType(1), "@" + validateSym, [lirOperand(lirPtrType(), inputReg.value)]))
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, resultType, 0))
+    let okLabel = lirFreshAuxLabel(l, label + ".ok")
+    let errLabel = lirFreshAuxLabel(l, label + ".err")
+    let endLabel = lirFreshAuxLabel(l, label + ".end")
+    lirCutBlockCondBr(l, validReg, okLabel, errLabel, okLabel)
+    let successReg = lirFresh(l)
+    l.instrs.push(lirCall(successReg, lirPtrType(), "@" + successSym, [lirOperand(lirPtrType(), inputReg.value)]))
+    let payloadReg = lirParseResultPayloadAsI64(l, successReg, lirPtrType())
+    let okValue = lirEmitResultOk(l, resultType, payloadReg)
+    l.instrs.push(lirStore(lirOperand(resultType, okValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = errLabel
+    let errValue = lirEmitResultErr(l, resultType, "0")
+    l.instrs.push(lirStore(lirOperand(resultType, errValue), slot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, resultType, slot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(resultType, merged), loc.typ, label + " result")
+}
 // ----- Set intrinsic lowerings (typed elem lane) -----
 fn lirLowerMirSetInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -488,6 +488,36 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "check_cancelled" {
         return lirParityBuildCheckCancelledModule()
+    }
+    if name == "list_push_bytes_v1" {
+        return lirParityBuildListPushBytesV1Module()
+    }
+    if name == "handle_join_int" {
+        return lirParityBuildHandleJoinIntModule()
+    }
+    if name == "group_cancel" {
+        return lirParityBuildGroupCancelModule()
+    }
+    if name == "group_is_cancelled" {
+        return lirParityBuildGroupIsCancelledModule()
+    }
+    if name == "sleep" {
+        return lirParityBuildSleepModule()
+    }
+    if name == "map_keys_sorted_i64" {
+        return lirParityBuildMapKeysSortedI64Module()
+    }
+    if name == "bytes_from_string" {
+        return lirParityBuildBytesFromStringModule()
+    }
+    if name == "bytes_from_list" {
+        return lirParityBuildBytesFromListModule()
+    }
+    if name == "bytes_to_string" {
+        return lirParityBuildBytesToStringModule()
+    }
+    if name == "bytes_from_hex" {
+        return lirParityBuildBytesFromHexModule()
     }
     mirModule("main")
 }
@@ -1346,6 +1376,122 @@ pub fn lirParityBuildCheckCancelledModule() -> MirModule {
     let mut fn_ = lirParityFunction("ask", "Result<Unit, Error>")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicCheckCancelled, [], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Batched: bytes-v1 / concurrency / Map fused / Bytes conversions
+// ====================================================================
+pub fn lirParityManualListPushBytesV1Fixture() -> LirParityFixture {
+    lirParityFixture("list_push_bytes_v1", LirParityManualMIR, "/tmp/lir_proto_parity_list_push_bytes_v1.osty", "", "phase4-bytesv1", ["list", "push", "bytes-v1", "composite"], [lirParityNeedle("%Cell = type \{ i64, i64 \}", "composite element layout"), lirParityNeedle("declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)", "bytes-v1 push runtime"), lirParityNeedle("alloca %Cell", "composite element slot"), lirParityNeedle("getelementptr inbounds %Cell, ptr null, i32 1", "sizeof gep idiom"), lirParityNeedle("ptrtoint ptr", "sizeof ptrtoint"), lirParityNeedle("call void @osty_rt_list_push_bytes_v1(", "bytes-v1 push call site")])
+}
+pub fn lirParityManualHandleJoinIntFixture() -> LirParityFixture {
+    lirParityFixture("handle_join_int", LirParityManualMIR, "/tmp/lir_proto_parity_handle_join_int.osty", "", "phase4-concurrency", ["concurrency", "handle"], [lirParityNeedle("declare i64 @osty_rt_task_handle_join(ptr)", "handle join runtime"), lirParityNeedle("call i64 @osty_rt_task_handle_join(", "join call site")])
+}
+pub fn lirParityManualGroupCancelFixture() -> LirParityFixture {
+    lirParityFixture("group_cancel", LirParityManualMIR, "/tmp/lir_proto_parity_group_cancel.osty", "", "phase4-concurrency", ["concurrency", "group"], [lirParityNeedle("declare void @osty_rt_task_group_cancel(ptr)", "group cancel runtime"), lirParityNeedle("call void @osty_rt_task_group_cancel(", "cancel call site")])
+}
+pub fn lirParityManualGroupIsCancelledFixture() -> LirParityFixture {
+    lirParityFixture("group_is_cancelled", LirParityManualMIR, "/tmp/lir_proto_parity_group_is_cancelled.osty", "", "phase4-concurrency", ["concurrency", "group"], [lirParityNeedle("declare i1 @osty_rt_task_group_is_cancelled(ptr)", "group is_cancelled runtime"), lirParityNeedle("call i1 @osty_rt_task_group_is_cancelled(", "is_cancelled call site")])
+}
+pub fn lirParityManualSleepFixture() -> LirParityFixture {
+    lirParityFixture("sleep", LirParityManualMIR, "/tmp/lir_proto_parity_sleep.osty", "", "phase4-concurrency", ["concurrency", "sleep"], [lirParityNeedle("declare void @osty_rt_thread_sleep(ptr)", "sleep runtime"), lirParityNeedle("call void @osty_rt_thread_sleep(", "sleep call site")])
+}
+pub fn lirParityManualMapKeysSortedI64Fixture() -> LirParityFixture {
+    lirParityFixture("map_keys_sorted_i64", LirParityManualMIR, "/tmp/lir_proto_parity_map_keys_sorted_i64.osty", "", "phase4-map", ["map", "fused", "sort"], [lirParityNeedle("declare ptr @osty_rt_map_keys_sorted_i64(ptr)", "i64-key sorted runtime"), lirParityNeedle("call ptr @osty_rt_map_keys_sorted_i64(", "sorted call site")])
+}
+pub fn lirParityManualBytesFromStringFixture() -> LirParityFixture {
+    lirParityFixture("bytes_from_string", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_from_string.osty", "", "phase4-bytes-conv", ["bytes", "convert"], [lirParityNeedle("declare ptr @osty_rt_strings_ToBytes(ptr)", "String to Bytes runtime"), lirParityNeedle("call ptr @osty_rt_strings_ToBytes(", "convert call site")])
+}
+pub fn lirParityManualBytesFromListFixture() -> LirParityFixture {
+    lirParityFixture("bytes_from_list", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_from_list.osty", "", "phase4-bytes-conv", ["bytes", "convert"], [lirParityNeedle("declare ptr @osty_rt_bytes_from_list(ptr)", "List to Bytes runtime"), lirParityNeedle("call ptr @osty_rt_bytes_from_list(", "convert call site")])
+}
+pub fn lirParityManualBytesToStringFixture() -> LirParityFixture {
+    lirParityFixture("bytes_to_string", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_to_string.osty", "", "phase4-bytes-conv", ["bytes", "convert", "result"], [lirParityNeedle("%Result.String_Error = type \{ i64, i64 \}", "Result<String, Error>"), lirParityNeedle("declare i1 @osty_rt_bytes_is_valid_utf8(ptr)", "validate runtime"), lirParityNeedle("declare ptr @osty_rt_bytes_to_string(ptr)", "convert runtime"), lirParityNeedle("call i1 @osty_rt_bytes_is_valid_utf8(", "validate call"), lirParityNeedle("call ptr @osty_rt_bytes_to_string(", "convert call"), lirParityNeedle("ptrtoint ptr", "ptr-to-i64 payload coercion"), lirParityNeedle("ret %Result.String_Error", "Result return")])
+}
+pub fn lirParityManualBytesFromHexFixture() -> LirParityFixture {
+    lirParityFixture("bytes_from_hex", LirParityManualMIR, "/tmp/lir_proto_parity_bytes_from_hex.osty", "", "phase4-bytes-conv", ["bytes", "convert", "result"], [lirParityNeedle("%Result.Bytes_Error = type \{ i64, i64 \}", "Result<Bytes, Error>"), lirParityNeedle("declare i1 @osty_rt_bytes_is_valid_hex(ptr)", "validate runtime"), lirParityNeedle("declare ptr @osty_rt_bytes_from_hex(ptr)", "convert runtime"), lirParityNeedle("ret %Result.Bytes_Error", "Result return")])
+}
+// Module builders.
+pub fn lirParityBuildListPushBytesV1Module() -> MirModule {
+    let mut fn_ = lirParityFunction("appendCell", "Unit")
+    let xs = lirParityParam(fn_, "xs", "List<Cell>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicListPush, [mirOperandCopy(mirPlace(xs), "List<Cell>"), mirOperandCopy(mirPlace(xs), "Cell")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    let mut m = lirParityModule([fn_])
+    m.layouts.structs.push(lirParityStructLayout("Cell", [lirParityField(0, "value", "Int"), lirParityField(1, "other", "Int")]))
+    m
+}
+pub fn lirParityBuildHandleJoinIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("await", "Int")
+    let h = lirParityParam(fn_, "h", "Handle<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicHandleJoin, [mirOperandCopy(mirPlace(h), "Handle<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildGroupCancelModule() -> MirModule {
+    let mut fn_ = lirParityFunction("kill", "Unit")
+    let g = lirParityParam(fn_, "g", "TaskGroup")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicGroupCancel, [mirOperandCopy(mirPlace(g), "TaskGroup")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildGroupIsCancelledModule() -> MirModule {
+    let mut fn_ = lirParityFunction("ask", "Bool")
+    let g = lirParityParam(fn_, "g", "TaskGroup")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicGroupIsCancelled, [mirOperandCopy(mirPlace(g), "TaskGroup")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSleepModule() -> MirModule {
+    let mut fn_ = lirParityFunction("rest", "Unit")
+    let d = lirParityParam(fn_, "d", "Duration")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSleep, [mirOperandCopy(mirPlace(d), "Duration")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildMapKeysSortedI64Module() -> MirModule {
+    let mut fn_ = lirParityFunction("ks", "List<Int>")
+    let m = lirParityParam(fn_, "m", "Map<Int, String>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapKeysSorted, [mirOperandCopy(mirPlace(m), "Map<Int, String>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesFromStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("encode", "Bytes")
+    let s = lirParityParam(fn_, "s", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesFromString, [mirOperandCopy(mirPlace(s), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesFromListModule() -> MirModule {
+    let mut fn_ = lirParityFunction("pack", "Bytes")
+    let xs = lirParityParam(fn_, "xs", "List<Byte>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesFromList, [mirOperandCopy(mirPlace(xs), "List<Byte>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesToStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("decode", "Result<String, Error>")
+    let b = lirParityParam(fn_, "b", "Bytes")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesToString, [mirOperandCopy(mirPlace(b), "Bytes")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildBytesFromHexModule() -> MirModule {
+    let mut fn_ = lirParityFunction("parseHex", "Result<Bytes, Error>")
+    let h = lirParityParam(fn_, "h", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesFromHex, [mirOperandCopy(mirPlace(h), "String")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Five-slice batch — bytes-v1 fallback infrastructure plus several straightforward intrinsic groups in one PR.

**bytes-v1 fallback for List push (composite element)**:
- `lirEmitSizeOf` materialises the runtime byte size via the canonical `getelementptr inbounds %T, ptr null, i32 1` + `ptrtoint` idiom, matching production's `llvmSizeOf`.
- `lirLowerMirListPush` now detects composite element types up front (no LIR runtime lane) and routes through `lirLowerMirListPushBytesV1`, which spills the value into a stack slot and calls `osty_rt_list_push_bytes_v1(list, slot, size)`.
- The other composite paths (List get/insert/set, Map insert/get composite value, Set insert/contains/remove composite elem, Channel send composite) all share the same shape and reuse `lirEmitSizeOf` in follow-up slices.

**Concurrency primitives without closure-env**:
- `Sleep`, `GroupCancel`, `GroupIsCancelled` lower as plain runtime calls.
- `HandleJoin` reads its return type off the destination local (production picks the LLVM type from `i.Dest.Local.Type`).

**`MapKeysSorted`**: per-key-lane symbol `osty_rt_map_keys_sorted_<i64|string>` via the existing `LirContainerReceiver` key-lane info.

**Bytes ↔ String/List conversions**:
- `BytesFromString`, `BytesFromList`: simple ptr→ptr through the existing helper.
- `BytesToString`, `BytesFromHex`: validate-then-call `Result<T, Error>` wrapping via the new `lirLowerMirBytesValidatedResult` helper. Same basic-block-splitting + Result aggregate as the String parse slice but with ptr success values.

**Pin**: ten new Phase-4 fixtures through `TestLIRProtoManualFixtureCatalog`:
- `list_push_bytes_v1`
- `handle_join_int`, `group_cancel`, `group_is_cancelled`, `sleep`
- `map_keys_sorted_i64`
- `bytes_from_string`, `bytes_from_list`, `bytes_to_string`, `bytes_from_hex`

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)