### PR TITLE
feat: LIR Proto bytes-v1 expand + Set i1 / Map spill production parity (5 changes)

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -613,6 +613,28 @@ Eleven Phase-4 fixtures pin every shape: `list_push_bytes_v1`,
 `bytes_to_string`, `bytes_from_hex` (10 new + the existing
 `check_cancelled` reuse).
 
+Design decision: a follow-up batch extends the bytes-v1 fallback to
+List get / List insert / Channel send composite paths, fixes the
+production-divergent `Set.insert` / `Set.remove` LLVM signature
+(was declared `void`, runtime is `i1` newly-added/removed flag), and
+fixes `Map.set` to spill the value into a stack slot regardless of
+value type — production declares `osty_rt_map_insert_<keysuf>(ptr,
+<keyLLVM>, ptr) -> void` and memcpys `value_size` bytes from the
+pointer, so the typed-i64 form LIR Proto used previously was both a
+linker mismatch and a wrong-bitpattern bug for non-i64 values.
+
+Four new fixtures pin the new shapes: `list_get_bytes_v1`,
+`list_insert_bytes_v1`, `chan_send_bytes_v1`, `set_remove_i1`. Two
+existing fixtures (`map_insert_string_int`, `set_insert_string`)
+update to pin the corrected ABI. The bytes-v1 helper
+`lirEmitSizeOf` is reused unchanged from the prior batch.
+
+Set composite element types remain unsupported — production has no
+bytes-v1 set runtime entry today and the runtime helper would need
+a comparator callback to compare composite elements. Map composite
+value types now route through the spill path correctly; Map composite
+key types are still unsupported on both sides.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -315,11 +315,11 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualListReversedFixture", []string{"declare ptr @osty_rt_list_reversed(ptr)", "call ptr @osty_rt_list_reversed("}},
 		{"lirParityManualListClearFixture", []string{"declare void @osty_rt_list_clear(ptr)", "call void @osty_rt_list_clear("}},
 		{"lirParityManualMapNewFixture", []string{"declare ptr @osty_rt_map_new()", "call ptr @osty_rt_map_new()"}},
-		{"lirParityManualMapInsertStringIntFixture", []string{"declare void @osty_rt_map_insert_string(ptr, ptr, i64)", "call void @osty_rt_map_insert_string("}},
+		{"lirParityManualMapInsertStringIntFixture", []string{"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)", "alloca i64", "call void @osty_rt_map_insert_string("}},
 		{"lirParityManualMapContainsI64Fixture", []string{"declare i1 @osty_rt_map_contains_i64(ptr, i64)", "call i1 @osty_rt_map_contains_i64("}},
 		{"lirParityManualMapKeysFixture", []string{"declare ptr @osty_rt_map_keys(ptr)", "call ptr @osty_rt_map_keys("}},
 		{"lirParityManualMapLenFixture", []string{"declare i64 @osty_rt_map_len(ptr)", "call i64 @osty_rt_map_len("}},
-		{"lirParityManualSetInsertStringFixture", []string{"declare void @osty_rt_set_insert_string(ptr, ptr)", "call void @osty_rt_set_insert_string("}},
+		{"lirParityManualSetInsertStringFixture", []string{"declare i1 @osty_rt_set_insert_string(ptr, ptr)", "call i1 @osty_rt_set_insert_string("}},
 		{"lirParityManualSetContainsI64Fixture", []string{"declare i1 @osty_rt_set_contains_i64(ptr, i64)", "call i1 @osty_rt_set_contains_i64("}},
 		{"lirParityManualSetToListFixture", []string{"declare ptr @osty_rt_set_to_list(ptr)", "call ptr @osty_rt_set_to_list("}},
 		{"lirParityManualChanCloseFixture", []string{"declare void @osty_rt_thread_chan_close(ptr)", "call void @osty_rt_thread_chan_close("}},
@@ -367,6 +367,11 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualBytesFromListFixture", []string{"declare ptr @osty_rt_bytes_from_list(ptr)", "call ptr @osty_rt_bytes_from_list("}},
 		{"lirParityManualBytesToStringFixture", []string{"%Result.String_Error = type", "declare i1 @osty_rt_bytes_is_valid_utf8(ptr)", "declare ptr @osty_rt_bytes_to_string(ptr)", "ptrtoint ptr", "ret %Result.String_Error"}},
 		{"lirParityManualBytesFromHexFixture", []string{"%Result.Bytes_Error = type", "declare i1 @osty_rt_bytes_is_valid_hex(ptr)", "declare ptr @osty_rt_bytes_from_hex(ptr)", "ret %Result.Bytes_Error"}},
+		// ----- Batched: bytes-v1 expand + Set i1 return type pin -----
+		{"lirParityManualListGetBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)", "alloca %Cell", "getelementptr inbounds %Cell, ptr null, i32 1", "call void @osty_rt_list_get_bytes_v1(", "load %Cell"}},
+		{"lirParityManualListInsertBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_list_insert_bytes_v1(ptr, i64, ptr, i64)", "alloca %Cell", "call void @osty_rt_list_insert_bytes_v1("}},
+		{"lirParityManualChanSendBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)", "alloca %Cell", "call void @osty_rt_thread_chan_send_bytes_v1("}},
+		{"lirParityManualSetRemoveI1Fixture", []string{"declare i1 @osty_rt_set_remove_i64(ptr, i64)", "call i1 @osty_rt_set_remove_i64("}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2804,6 +2804,15 @@ fn lirLowerMirListGet(l: LirMirFunctionLowerer, instr: MirInstr) {
         lirLowerError(l, LirDiagInvalidInput, "list.get expects (list, idx)", "list.get")
         return
     }
+    let elemName = lirListElemTypeName(instr.args[0].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "list.get could not extract element type from receiver `" + instr.args[0].typ + "`", "list.get")
+        return
+    }
+    if lirTypeIsZero(lirContainerElemLaneType(elemName)) {
+        lirLowerMirListGetBytesV1(l, instr, elemName)
+        return
+    }
     let recv = lirLowerMirContainerReceiver(l, instr, "list.get", "list.elem")
     if !(recv.ok) {
         return
@@ -2814,9 +2823,48 @@ fn lirLowerMirListGet(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     lirEmitContainerCall(l, instr, llvmListRuntimeGetSymbolFor(recv.elemLir.llvm, recv.isString), recv.elemLir, [lirPtrType(), lirIntType(64)], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), idx.value)], recv.elemTypeName, "list.get")
 }
+// Composite-element List.get via the bytes-v1 runtime: alloca a slot
+// of the element type, ask the runtime to memcpy into it, load the
+// composite back and store into the destination. Mirrors production
+// (mir_generator.go::emitListGetBytes).
+fn lirLowerMirListGetBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemName: String) {
+    let elemType = lirLowerMirType(l, elemName)
+    if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+        lirLowerError(l, LirDiagUnsupported, "list.get composite element type `" + elemName + "` has no MIR layout", "list.get")
+        return
+    }
+    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    if recv.value == "" {
+        return
+    }
+    let idx = lirLowerCoercedOperand(l, instr.args[1], "Int", lirIntType(64), "list.get idx")
+    if idx.value == "" {
+        return
+    }
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, elemType, 0))
+    let sizeReg = lirEmitSizeOf(l, elemType)
+    let symbol = mirRtListGetBytesV1Symbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirIntType(64), lirPtrType(), lirIntType(64)], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), recv.value), lirOperand(lirIntType(64), idx.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg)]))
+    if instr.hasDest {
+        let loaded = lirFresh(l)
+        l.instrs.push(lirLoad(loaded, elemType, slot, 0))
+        lirStoreMirResult(l, instr.dest, lirOperand(elemType, loaded), elemName, "list.get result")
+    }
+}
 fn lirLowerMirListInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 3 {
         lirLowerError(l, LirDiagInvalidInput, "list.insert expects (list, idx, elem)", "list.insert")
+        return
+    }
+    let elemName = lirListElemTypeName(instr.args[0].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "list.insert could not extract element type from receiver `" + instr.args[0].typ + "`", "list.insert")
+        return
+    }
+    if lirTypeIsZero(lirContainerElemLaneType(elemName)) {
+        lirLowerMirListInsertBytesV1(l, instr, elemName)
         return
     }
     let recv = lirLowerMirContainerReceiver(l, instr, "list.insert", "list.elem")
@@ -2832,6 +2880,39 @@ fn lirLowerMirListInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     lirEmitContainerCall(l, instr, llvmListRuntimeInsertSymbolFor(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), lirIntType(64), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), idx.value), lirOperand(recv.elemLir, value.value)], "", "list.insert")
+}
+// Composite-element List.insert via the bytes-v1 runtime: spill the
+// value into a stack slot, compute the element size via the
+// `getelementptr null` idiom, and call
+// `osty_rt_list_insert_bytes_v1(list, idx, slot, size)`.
+fn lirLowerMirListInsertBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemName: String) {
+    let elemType = lirLowerMirType(l, elemName)
+    if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+        lirLowerError(l, LirDiagUnsupported, "list.insert composite element type `" + elemName + "` has no MIR layout", "list.insert")
+        return
+    }
+    let recv = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, lirPtrType())
+    if recv.value == "" {
+        return
+    }
+    let idx = lirLowerCoercedOperand(l, instr.args[1], "Int", lirIntType(64), "list.insert idx")
+    if idx.value == "" {
+        return
+    }
+    let value = lirLowerMirOperand(l, instr.args[2], elemName, elemType)
+    if value.value == "" {
+        return
+    }
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, elemType, 0))
+    l.instrs.push(lirStore(lirOperand(elemType, value.value), slot, 0))
+    let sizeReg = lirEmitSizeOf(l, elemType)
+    let symbol = mirRtListSymbol("insert_bytes_v1")
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirIntType(64), lirPtrType(), lirIntType(64)], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), recv.value), lirOperand(lirIntType(64), idx.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg)]))
+    if instr.hasDest {
+        lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "list.insert")
+    }
 }
 fn lirLowerMirListSorted(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 1 {
@@ -2872,6 +2953,13 @@ fn lirLowerMirListIsEmpty(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
 }
 // ----- Map intrinsic lowerings (typed key lane) -----
+// Map.set always passes the value by spilled-slot pointer regardless
+// of value type. Production declares
+// `osty_rt_map_insert_<keysuf>(ptr, <keyLLVM>, ptr) -> void` so the
+// runtime can memcpy `value_size` bytes — the same shape works for
+// scalar and composite values, sidesteps the wrong-bitpattern bug
+// the typed-i64 form would produce on non-i64 values, and matches
+// production exactly.
 fn lirLowerMirMapInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 3 {
         lirLowerError(l, LirDiagInvalidInput, "map.set expects (map, key, value)", "map.set")
@@ -2889,7 +2977,11 @@ fn lirLowerMirMapInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if value.value == "" {
         return
     }
-    lirEmitContainerCall(l, instr, llvmMapRuntimeInsertSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir, recv.valueLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(recv.valueLir, value.value)], "", "map.set")
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, recv.valueLir, 0))
+    l.instrs.push(lirStore(lirOperand(recv.valueLir, value.value), slot, 0))
+    let symbol = llvmMapRuntimeInsertSymbol(recv.elemLir.llvm, recv.isString)
+    lirEmitContainerCall(l, instr, symbol, lirVoidType(), [lirPtrType(), recv.elemLir, lirPtrType()], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(lirPtrType(), slot)], "", "map.set")
 }
 fn lirLowerMirMapContains(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {
@@ -3435,8 +3527,11 @@ fn lirLowerMirSetInsert(l: LirMirFunctionLowerer, instr: MirInstr) {
     if elem.value == "" {
         return
     }
-    lirEmitContainerCall(l, instr, llvmSetRuntimeInsertSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, elem.value)], "", "set.insert")
+    lirEmitContainerCall(l, instr, llvmSetRuntimeInsertSymbol(recv.elemLir.llvm, recv.isString), lirIntType(1), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, elem.value)], "Bool", "set.insert")
 }
+// Production declares set_insert as `i1 (...)` (returns true when a
+// newly-added element). MIR discards the flag at most call sites
+// but the function-type must match the runtime to link cleanly.
 fn lirLowerMirSetContains(l: LirMirFunctionLowerer, instr: MirInstr) {
     if instr.args.len() != 2 {
         lirLowerError(l, LirDiagInvalidInput, "set.contains expects (set, elem)", "set.contains")
@@ -3465,8 +3560,11 @@ fn lirLowerMirSetRemove(l: LirMirFunctionLowerer, instr: MirInstr) {
     if elem.value == "" {
         return
     }
-    lirEmitContainerCall(l, instr, llvmSetRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirVoidType(), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, elem.value)], "", "set.remove")
+    lirEmitContainerCall(l, instr, llvmSetRuntimeRemoveSymbol(recv.elemLir.llvm, recv.isString), lirIntType(1), [lirPtrType(), recv.elemLir], [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, elem.value)], "Bool", "set.remove")
 }
+// Production declares set_remove as `i1 (...)` (returns true when an
+// element was actually removed). The function-type must match the
+// runtime declaration to link cleanly even if MIR discards the flag.
 // IndexOf-family lowering: 2-ptr runtime returning i64 with -1 sentinel
 // for "not found". When the destination local is `Option<Int>` (or any
 // 2-i64 aggregate type — production also accepts `Maybe<Int>`), wrap
@@ -3626,12 +3724,8 @@ fn lirLowerMirChanSend(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     let elemLir = lirContainerElemLaneType(elemName)
-    if lirTypeIsZero(elemLir) {
-        lirLowerError(l, LirDiagUnsupported, "chan.send element type `" + elemName + "` has no LIR runtime lane", "chan.send")
-        return
-    }
-    if !(llvmListUsesTypedRuntime(elemLir.llvm)) {
-        lirLowerError(l, LirDiagUnsupported, "chan.send composite element type `" + elemName + "` needs the bytes-v1 runtime fallback (deferred)", "chan.send")
+    if lirTypeIsZero(elemLir) || !(llvmListUsesTypedRuntime(elemLir.llvm)) {
+        lirLowerMirChanSendBytesV1(l, instr, elemName)
         return
     }
     let chReg = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "chan.send channel")
@@ -3644,6 +3738,36 @@ fn lirLowerMirChanSend(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     let symbol = llvmChanRuntimeSendSymbol(llvmListElementSuffix(elemLir.llvm))
     lirEmitContainerCall(l, instr, symbol, lirVoidType(), [lirPtrType(), elemLir], [lirOperand(lirPtrType(), chReg.value), lirOperand(elemLir, value.value)], "", "chan.send")
+}
+// Composite element: bytes-v1 fallback. Mirrors production
+// (mir_generator.go::IntrinsicChanSend bytes branch).
+// Composite-element Channel.send via the bytes-v1 runtime: spill the
+// value into a stack slot, compute the element size, and call
+// `osty_rt_thread_chan_send_bytes_v1(ch, slot, size)`.
+fn lirLowerMirChanSendBytesV1(l: LirMirFunctionLowerer, instr: MirInstr, elemName: String) {
+    let elemType = lirLowerMirType(l, elemName)
+    if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+        lirLowerError(l, LirDiagUnsupported, "chan.send composite element type `" + elemName + "` has no MIR layout", "chan.send")
+        return
+    }
+    let chReg = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "chan.send channel")
+    if chReg.value == "" {
+        return
+    }
+    let value = lirLowerMirOperand(l, instr.args[1], elemName, elemType)
+    if value.value == "" {
+        return
+    }
+    let slot = lirFresh(l)
+    l.instrs.push(lirAlloca(slot, elemType, 0))
+    l.instrs.push(lirStore(lirOperand(elemType, value.value), slot, 0))
+    let sizeReg = lirEmitSizeOf(l, elemType)
+    let symbol = llvmChanRuntimeSendBytesSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirPtrType(), lirIntType(64)], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), chReg.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg)]))
+    if instr.hasDest {
+        lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "chan.send")
+    }
 }
 // Channel recv returns the runtime's `{i64 disc, i64 payload}` shape
 // that already matches the `%Option.<T>` aggregate layout — disc=0 for

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -519,6 +519,18 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     if name == "bytes_from_hex" {
         return lirParityBuildBytesFromHexModule()
     }
+    if name == "list_get_bytes_v1" {
+        return lirParityBuildListGetBytesV1Module()
+    }
+    if name == "list_insert_bytes_v1" {
+        return lirParityBuildListInsertBytesV1Module()
+    }
+    if name == "chan_send_bytes_v1" {
+        return lirParityBuildChanSendBytesV1Module()
+    }
+    if name == "set_remove_i1" {
+        return lirParityBuildSetRemoveI1Module()
+    }
     mirModule("main")
 }
 pub fn lirParityBuildConstReturnModule() -> MirModule {
@@ -879,7 +891,7 @@ pub fn lirParityManualMapNewFixture() -> LirParityFixture {
     lirParityFixture("map_new", LirParityManualMIR, "/tmp/lir_proto_parity_map_new.osty", "", "phase4b-map", ["map", "runtime"], [lirParityNeedle("declare ptr @osty_rt_map_new()", "map new runtime"), lirParityNeedle("call ptr @osty_rt_map_new()", "map new call")])
 }
 pub fn lirParityManualMapInsertStringIntFixture() -> LirParityFixture {
-    lirParityFixture("map_insert_string_int", LirParityManualMIR, "/tmp/lir_proto_parity_map_insert_string_int.osty", "", "phase4b-map", ["map", "runtime", "key-string"], [lirParityNeedle("declare void @osty_rt_map_insert_string(ptr, ptr, i64)", "string-key insert runtime"), lirParityNeedle("call void @osty_rt_map_insert_string(", "insert call site")])
+    lirParityFixture("map_insert_string_int", LirParityManualMIR, "/tmp/lir_proto_parity_map_insert_string_int.osty", "", "phase4b-map", ["map", "runtime", "key-string"], [lirParityNeedle("declare void @osty_rt_map_insert_string(ptr, ptr, ptr)", "string-key insert runtime (value-by-spilled-slot)"), lirParityNeedle("alloca i64", "value spill slot"), lirParityNeedle("call void @osty_rt_map_insert_string(", "insert call site")])
 }
 pub fn lirParityManualMapContainsI64Fixture() -> LirParityFixture {
     lirParityFixture("map_contains_i64", LirParityManualMIR, "/tmp/lir_proto_parity_map_contains_i64.osty", "", "phase4b-map", ["map", "runtime", "key-i64"], [lirParityNeedle("declare i1 @osty_rt_map_contains_i64(ptr, i64)", "i64-key contains runtime"), lirParityNeedle("call i1 @osty_rt_map_contains_i64(", "contains call site")])
@@ -891,7 +903,7 @@ pub fn lirParityManualMapLenFixture() -> LirParityFixture {
     lirParityFixture("map_len", LirParityManualMIR, "/tmp/lir_proto_parity_map_len.osty", "", "phase4b-map", ["map", "runtime"], [lirParityNeedle("declare i64 @osty_rt_map_len(ptr)", "map len runtime"), lirParityNeedle("call i64 @osty_rt_map_len(", "len call site")])
 }
 pub fn lirParityManualSetInsertStringFixture() -> LirParityFixture {
-    lirParityFixture("set_insert_string", LirParityManualMIR, "/tmp/lir_proto_parity_set_insert_string.osty", "", "phase4b-set", ["set", "runtime", "lane-string"], [lirParityNeedle("declare void @osty_rt_set_insert_string(ptr, ptr)", "string set insert runtime"), lirParityNeedle("call void @osty_rt_set_insert_string(", "insert call site")])
+    lirParityFixture("set_insert_string", LirParityManualMIR, "/tmp/lir_proto_parity_set_insert_string.osty", "", "phase4b-set", ["set", "runtime", "lane-string"], [lirParityNeedle("declare i1 @osty_rt_set_insert_string(ptr, ptr)", "string set insert runtime (i1 newly-added)"), lirParityNeedle("call i1 @osty_rt_set_insert_string(", "insert call site")])
 }
 pub fn lirParityManualSetContainsI64Fixture() -> LirParityFixture {
     lirParityFixture("set_contains_i64", LirParityManualMIR, "/tmp/lir_proto_parity_set_contains_i64.osty", "", "phase4b-set", ["set", "runtime", "lane-i64"], [lirParityNeedle("declare i1 @osty_rt_set_contains_i64(ptr, i64)", "i64 set contains runtime"), lirParityNeedle("call i1 @osty_rt_set_contains_i64(", "contains call site")])
@@ -1492,6 +1504,61 @@ pub fn lirParityBuildBytesFromHexModule() -> MirModule {
     let h = lirParityParam(fn_, "h", "String")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicBytesFromHex, [mirOperandCopy(mirPlace(h), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Batched: bytes-v1 expand + Set i1 return type pin
+// ====================================================================
+pub fn lirParityManualListGetBytesV1Fixture() -> LirParityFixture {
+    lirParityFixture("list_get_bytes_v1", LirParityManualMIR, "/tmp/lir_proto_parity_list_get_bytes_v1.osty", "", "phase4-bytesv1", ["list", "get", "bytes-v1", "composite"], [lirParityNeedle("%Cell = type \{ i64, i64 \}", "composite element layout"), lirParityNeedle("declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)", "bytes-v1 get runtime"), lirParityNeedle("alloca %Cell", "out-slot for value"), lirParityNeedle("getelementptr inbounds %Cell, ptr null, i32 1", "sizeof gep"), lirParityNeedle("call void @osty_rt_list_get_bytes_v1(", "get call"), lirParityNeedle("load %Cell", "load composite from slot")])
+}
+pub fn lirParityManualListInsertBytesV1Fixture() -> LirParityFixture {
+    lirParityFixture("list_insert_bytes_v1", LirParityManualMIR, "/tmp/lir_proto_parity_list_insert_bytes_v1.osty", "", "phase4-bytesv1", ["list", "insert", "bytes-v1", "composite"], [lirParityNeedle("%Cell = type \{ i64, i64 \}", "composite element layout"), lirParityNeedle("declare void @osty_rt_list_insert_bytes_v1(ptr, i64, ptr, i64)", "bytes-v1 insert runtime"), lirParityNeedle("alloca %Cell", "value spill slot"), lirParityNeedle("call void @osty_rt_list_insert_bytes_v1(", "insert call site")])
+}
+pub fn lirParityManualChanSendBytesV1Fixture() -> LirParityFixture {
+    lirParityFixture("chan_send_bytes_v1", LirParityManualMIR, "/tmp/lir_proto_parity_chan_send_bytes_v1.osty", "", "phase4-bytesv1", ["channel", "send", "bytes-v1", "composite"], [lirParityNeedle("%Cell = type \{ i64, i64 \}", "composite element layout"), lirParityNeedle("declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)", "bytes-v1 chan send runtime"), lirParityNeedle("alloca %Cell", "value spill slot"), lirParityNeedle("call void @osty_rt_thread_chan_send_bytes_v1(", "chan send call site")])
+}
+pub fn lirParityManualSetRemoveI1Fixture() -> LirParityFixture {
+    lirParityFixture("set_remove_i1", LirParityManualMIR, "/tmp/lir_proto_parity_set_remove_i1.osty", "", "phase4-set", ["set", "remove", "i1"], [lirParityNeedle("declare i1 @osty_rt_set_remove_i64(ptr, i64)", "set remove runtime returns i1"), lirParityNeedle("call i1 @osty_rt_set_remove_i64(", "remove call site")])
+}
+pub fn lirParityBuildListGetBytesV1Module() -> MirModule {
+    let mut fn_ = lirParityFunction("readCell", "Cell")
+    let xs = lirParityParam(fn_, "xs", "List<Cell>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListGet, [mirOperandCopy(mirPlace(xs), "List<Cell>"), mirOperandConst(mirConstInt(0, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    let mut m = lirParityModule([fn_])
+    m.layouts.structs.push(lirParityStructLayout("Cell", [lirParityField(0, "value", "Int"), lirParityField(1, "other", "Int")]))
+    m
+}
+pub fn lirParityBuildListInsertBytesV1Module() -> MirModule {
+    let mut fn_ = lirParityFunction("insertCell", "Unit")
+    let xs = lirParityParam(fn_, "xs", "List<Cell>")
+    let v = lirParityParam(fn_, "v", "Cell")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicListInsert, [mirOperandCopy(mirPlace(xs), "List<Cell>"), mirOperandConst(mirConstInt(0, "Int")), mirOperandCopy(mirPlace(v), "Cell")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    let mut m = lirParityModule([fn_])
+    m.layouts.structs.push(lirParityStructLayout("Cell", [lirParityField(0, "value", "Int"), lirParityField(1, "other", "Int")]))
+    m
+}
+pub fn lirParityBuildChanSendBytesV1Module() -> MirModule {
+    let mut fn_ = lirParityFunction("ship", "Unit")
+    let ch = lirParityParam(fn_, "ch", "Channel<Cell>")
+    let v = lirParityParam(fn_, "v", "Cell")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicChanSend, [mirOperandCopy(mirPlace(ch), "Channel<Cell>"), mirOperandCopy(mirPlace(v), "Cell")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    let mut m = lirParityModule([fn_])
+    m.layouts.structs.push(lirParityStructLayout("Cell", [lirParityField(0, "value", "Int"), lirParityField(1, "other", "Int")]))
+    m
+}
+pub fn lirParityBuildSetRemoveI1Module() -> MirModule {
+    let mut fn_ = lirParityFunction("drop", "Unit")
+    let s = lirParityParam(fn_, "s", "Set<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSetRemove, [mirOperandCopy(mirPlace(s), "Set<Int>"), mirOperandConst(mirConstInt(7, "Int"))], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Five-slice batch — three new bytes-v1 composite paths plus two production-parity fixes for previously divergent ABI shapes.

**bytes-v1 expansion (composite element types)**:
- **List.get composite**: alloca slot + `osty_rt_list_get_bytes_v1(list, idx, slot, size)` + load. Mirrors production's `emitListGetBytes`.
- **List.insert composite**: spill + size + `osty_rt_list_insert_bytes_v1(list, idx, slot, size)`.
- **Channel.send composite**: spill + size + `osty_rt_thread_chan_send_bytes_v1(ch, slot, size)`. All three reuse `lirEmitSizeOf` from the prior batch.

**Production-parity fixes**:
- **`Set.insert` / `Set.remove` now declare i1 return type** (was `void`). The runtime returns a "newly-added" / "actually-removed" flag that MIR may discard, but the function signature must match the runtime to link cleanly. `lirEmitContainerCall` captures the i1 into a fresh temp that LLVM DCEs when MIR has no destination.
- **`Map.set` value spill-to-slot**: production always declares `osty_rt_map_insert_<keysuf>(ptr, <keyLLVM>, ptr) -> void` and memcpys `value_size` bytes from the pointer. The typed-i64 form LIR Proto used previously was both a linker mismatch (wrong function signature) and a wrong-bitpattern bug for non-i64 values. The new shape spills the value into a stack slot of its real type and passes the slot pointer.

**Pin**: four new fixtures (`list_get_bytes_v1`, `list_insert_bytes_v1`, `chan_send_bytes_v1`, `set_remove_i1`) plus two updated fixtures (`map_insert_string_int`, `set_insert_string`) that now pin the corrected ABI.

Set composite element types remain unsupported — production has no bytes-v1 set runtime entry today and the runtime helper would need a comparator callback to compare composite elements.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)