### PR TITLE
feat: LIR Proto concurrency closure-env intrinsics (TaskGroup/Spawn/Select*/Parallel/Race/CollectAll — 11 intrinsics)

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -635,6 +635,46 @@ a comparator callback to compare composite elements. Map composite
 value types now route through the spill path correctly; Map composite
 key types are still unsupported on both sides.
 
+Design decision: a follow-up batch covers the concurrency closure-env
+intrinsics — the runtime callbacks pass through as opaque ptr at the
+LLVM boundary (closures lower to ptr at the function-value boundary
+already), so LIR Proto can emit the per-intrinsic runtime call shape
+without needing a new closure-env ABI surface. The eleven new
+lowerings:
+
+- `TaskGroup(body)` — return type read off the destination local
+  (defaults to void). Matches production's
+  `osty_rt_task_group_root(ptr) -> retType`.
+- `Spawn(body)` (1 arg, detached) and `Spawn(group, body)` (2 args,
+  group-scoped) → `osty_rt_task_spawn(ptr) -> ptr` /
+  `osty_rt_task_group_spawn(ptr, ptr) -> ptr`.
+- `Select(body)`, `SelectRecv(builder, ch, callback)`,
+  `SelectTimeout(builder, duration, callback)`,
+  `SelectDefault(builder, callback)` — all-ptr arg shapes through the
+  existing simple-runtime-call helper.
+- `SelectSend(builder, ch, value, arm)` — per-channel-element-lane
+  dispatch like ChanSend (typed `osty_rt_select_send_<lane>` for
+  scalar, `osty_rt_select_send_bytes_v1` with spill+sizeof for
+  composite values).
+- `Parallel(items, concurrency, f)` →
+  `osty_rt_parallel(ptr, i64, ptr) -> ptr`.
+- `Race(body)` returns `Result<T, Error>` as the raw
+  `{ i64, i64 }` aggregate — same direct-store shape as
+  `CheckCancelled`.
+- `CollectAll(body)` → `osty_rt_task_collect_all(ptr) -> ptr`.
+
+Eleven new fixtures pin every shape: `task_group_unit`,
+`spawn_detached`, `spawn_grouped`, `select`, `select_recv`,
+`select_send_int`, `select_timeout`, `select_default`, `parallel`,
+`race`, `collect_all`.
+
+What stays deferred: the actual GC root binding pass (the closure
+envs are passed by ptr but no per-call root_bind/release pair is
+emitted today), per-loop `!llvm.loop.*` metadata (needs MIR loop
+classification), per-instruction `!llvm.access.group` metadata, the
+Phase-7 actual runner (Osty↔Go bridge), and the Phase-8 default-on
+flip.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -372,6 +372,18 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualListInsertBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_list_insert_bytes_v1(ptr, i64, ptr, i64)", "alloca %Cell", "call void @osty_rt_list_insert_bytes_v1("}},
 		{"lirParityManualChanSendBytesV1Fixture", []string{"%Cell = type", "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)", "alloca %Cell", "call void @osty_rt_thread_chan_send_bytes_v1("}},
 		{"lirParityManualSetRemoveI1Fixture", []string{"declare i1 @osty_rt_set_remove_i64(ptr, i64)", "call i1 @osty_rt_set_remove_i64("}},
+		// ----- Concurrency closure-env intrinsics -----
+		{"lirParityManualTaskGroupUnitFixture", []string{"declare void @osty_rt_task_group_root(ptr)", "call void @osty_rt_task_group_root("}},
+		{"lirParityManualSpawnDetachedFixture", []string{"declare ptr @osty_rt_task_spawn(ptr)", "call ptr @osty_rt_task_spawn("}},
+		{"lirParityManualSpawnGroupedFixture", []string{"declare ptr @osty_rt_task_group_spawn(ptr, ptr)", "call ptr @osty_rt_task_group_spawn("}},
+		{"lirParityManualSelectFixture", []string{"declare void @osty_rt_select(ptr)", "call void @osty_rt_select("}},
+		{"lirParityManualSelectRecvFixture", []string{"declare void @osty_rt_select_recv(ptr, ptr, ptr)", "call void @osty_rt_select_recv("}},
+		{"lirParityManualSelectSendIntFixture", []string{"declare void @osty_rt_select_send_i64(ptr, ptr, i64, ptr)", "call void @osty_rt_select_send_i64("}},
+		{"lirParityManualSelectTimeoutFixture", []string{"declare void @osty_rt_select_timeout(ptr, ptr, ptr)", "call void @osty_rt_select_timeout("}},
+		{"lirParityManualSelectDefaultFixture", []string{"declare void @osty_rt_select_default(ptr, ptr)", "call void @osty_rt_select_default("}},
+		{"lirParityManualParallelFixture", []string{"declare ptr @osty_rt_parallel(ptr, i64, ptr)", "call ptr @osty_rt_parallel("}},
+		{"lirParityManualRaceFixture", []string{"%Result.Int_Error = type", "declare { i64, i64 } @osty_rt_task_race(ptr)", "call { i64, i64 } @osty_rt_task_race("}},
+		{"lirParityManualCollectAllFixture", []string{"declare ptr @osty_rt_task_collect_all(ptr)", "call ptr @osty_rt_task_collect_all("}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2148,6 +2148,16 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicGroupCancel -> lirLowerMirStringRuntimeCall(l, instr, mirRtTaskGroupCancelSymbol(), lirVoidType(), [lirPtrType()], "group.cancel"),
         MirIntrinsicGroupIsCancelled -> lirLowerMirStringRuntimeCall(l, instr, mirRtTaskGroupIsCancelledSymbol(), lirIntType(1), [lirPtrType()], "group.isCancelled"),
         MirIntrinsicHandleJoin -> lirLowerMirHandleJoin(l, instr),
+        MirIntrinsicTaskGroup -> lirLowerMirTaskGroup(l, instr),
+        MirIntrinsicSpawn -> lirLowerMirSpawn(l, instr),
+        MirIntrinsicSelect -> lirLowerMirStringRuntimeCall(l, instr, mirRtSelectSymbol(), lirVoidType(), [lirPtrType()], "select"),
+        MirIntrinsicSelectRecv -> lirLowerMirStringRuntimeCall(l, instr, mirRtSelectRecvSymbol(), lirVoidType(), [lirPtrType(), lirPtrType(), lirPtrType()], "select.recv"),
+        MirIntrinsicSelectTimeout -> lirLowerMirStringRuntimeCall(l, instr, mirRtSelectTimeoutSymbol(), lirVoidType(), [lirPtrType(), lirPtrType(), lirPtrType()], "select.timeout"),
+        MirIntrinsicSelectDefault -> lirLowerMirStringRuntimeCall(l, instr, mirRtSelectDefaultSymbol(), lirVoidType(), [lirPtrType(), lirPtrType()], "select.default"),
+        MirIntrinsicSelectSend -> lirLowerMirSelectSend(l, instr),
+        MirIntrinsicParallel -> lirLowerMirStringRuntimeCall(l, instr, mirRtParallelSymbol(), lirPtrType(), [lirPtrType(), lirIntType(64), lirPtrType()], "parallel"),
+        MirIntrinsicRace -> lirLowerMirRace(l, instr),
+        MirIntrinsicCollectAll -> lirLowerMirStringRuntimeCall(l, instr, mirRtTaskCollectAllSymbol(), lirPtrType(), [lirPtrType()], "collectAll"),
         MirIntrinsicMapKeysSorted -> lirLowerMirMapKeysSorted(l, instr),
         MirIntrinsicBytesFromList -> lirLowerMirStringRuntimeCall(l, instr, mirRtBytesFromListSymbol(), lirPtrType(), [lirPtrType()], "bytes.fromList"),
         MirIntrinsicBytesFromString -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringToBytesSymbol(), lirPtrType(), [lirPtrType()], "bytes.fromString"),
@@ -3435,6 +3445,181 @@ fn lirLowerMirHandleJoin(l: LirMirFunctionLowerer, instr: MirInstr) {
     l.instrs.push(lirCall(dest, retType, "@" + symbol, [lirOperand(lirPtrType(), handle.value)]))
     let loc = mirFunctionLocal(l.fn_, instr.dest.local)
     lirStoreMirResult(l, instr.dest, lirOperand(retType, dest), loc.typ, "handle.join result")
+}
+// `taskGroup(body) -> T` lowering. Production reads the return type
+// off the destination local so the runtime can return an arbitrary
+// value through the spawned closure (mir_generator.go::IntrinsicTaskGroup).
+// Default return is void when there is no dest or the dest is Unit;
+// otherwise the runtime declaration matches the dest type.
+fn lirLowerMirTaskGroup(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "taskGroup expects (body)", "taskGroup")
+        return
+    }
+    let body = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "taskGroup body")
+    if body.value == "" {
+        return
+    }
+    let symbol = mirRtTaskGroupRootSymbol()
+    let mut retType = lirVoidType()
+    if instr.hasDest {
+        let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+        if loc.id < 0 {
+            lirLowerError(l, LirDiagInvalidInput, "taskGroup destination local out of range", "taskGroup")
+            return
+        }
+        let lowered = lirLowerMirType(l, loc.typ)
+        if !(lirTypeIsZero(lowered)) && !(lirTypeIsVoid(lowered)) {
+            retType = lowered
+        }
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, retType, [lirPtrType()], false))
+    if lirTypeIsVoid(retType) {
+        l.instrs.push(lirCall("", retType, "@" + symbol, [lirOperand(lirPtrType(), body.value)]))
+        if instr.hasDest {
+            lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "taskGroup")
+        }
+        return
+    }
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, retType, "@" + symbol, [lirOperand(lirPtrType(), body.value)]))
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    lirStoreMirResult(l, instr.dest, lirOperand(retType, dest), loc.typ, "taskGroup result")
+}
+// `spawn(body)` (1 arg) detached form vs `g.spawn(body)` (2 args)
+// group-scoped form. Both return a `Handle<T>` ptr; production picks
+// `osty_rt_task_spawn(ptr) -> ptr` for 1-arg and
+// `osty_rt_task_group_spawn(ptr group, ptr body) -> ptr` for 2-arg
+// (mir_generator.go::IntrinsicSpawn).
+fn lirLowerMirSpawn(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 && instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, "spawn expects 1 or 2 arguments", "spawn")
+        return
+    }
+    let symbol = if instr.args.len() == 2 {
+        mirRtTaskGroupSpawnSymbol()
+    } else {
+        mirRtTaskSpawnSymbol()
+    }
+    let mut paramTypes: List<LirType> = []
+    let mut args: List<LirOperand> = []
+    for arg in instr.args {
+        let value = lirLowerCoercedOperand(l, arg, arg.typ, lirPtrType(), "spawn arg")
+        if value.value == "" {
+            return
+        }
+        paramTypes.push(lirPtrType())
+        args.push(lirOperand(lirPtrType(), value.value))
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirPtrType(), paramTypes, false))
+    if !(instr.hasDest) {
+        let _ignored = lirFresh(l)
+        l.instrs.push(lirCall(_ignored, lirPtrType(), "@" + symbol, args))
+        return
+    }
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, lirPtrType(), "@" + symbol, args))
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), dest), loc.typ, "spawn result")
+}
+// `s.send(ch, value, arm)` select arm. Like ChanSend, lane-resolves
+// per channel element type. Composite element types route through
+// the bytes-v1 fallback (osty_rt_select_send_bytes_v1).
+fn lirLowerMirSelectSend(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 4 {
+        lirLowerError(l, LirDiagInvalidInput, "select.send expects (builder, channel, value, arm)", "select.send")
+        return
+    }
+    let elemName = lirChannelElementTypeName(instr.args[1].typ)
+    if elemName == "" {
+        lirLowerError(l, LirDiagUnsupported, "select.send could not extract element type from channel `" + instr.args[1].typ + "`", "select.send")
+        return
+    }
+    let elemLir = lirContainerElemLaneType(elemName)
+    let builder = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "select.send builder")
+    if builder.value == "" {
+        return
+    }
+    let chReg = lirLowerCoercedOperand(l, instr.args[1], instr.args[1].typ, lirPtrType(), "select.send channel")
+    if chReg.value == "" {
+        return
+    }
+    let armReg = lirLowerCoercedOperand(l, instr.args[3], instr.args[3].typ, lirPtrType(), "select.send arm")
+    if armReg.value == "" {
+        return
+    }
+    if lirTypeIsZero(elemLir) || !(llvmListUsesTypedRuntime(elemLir.llvm)) {
+        let elemType = lirLowerMirType(l, elemName)
+        if lirTypeIsZero(elemType) || lirTypeIsVoid(elemType) {
+            lirLowerError(l, LirDiagUnsupported, "select.send composite element type `" + elemName + "` has no MIR layout", "select.send")
+            return
+        }
+        let value = lirLowerMirOperand(l, instr.args[2], elemName, elemType)
+        if value.value == "" {
+            return
+        }
+        let slot = lirFresh(l)
+        l.instrs.push(lirAlloca(slot, elemType, 0))
+        l.instrs.push(lirStore(lirOperand(elemType, value.value), slot, 0))
+        let sizeReg = lirEmitSizeOf(l, elemType)
+        let symbol = mirRtSelectSendBytesV1Symbol()
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirPtrType(), lirPtrType(), lirIntType(64), lirPtrType()], false))
+        l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), builder.value), lirOperand(lirPtrType(), chReg.value), lirOperand(lirPtrType(), slot), lirOperand(lirIntType(64), sizeReg), lirOperand(lirPtrType(), armReg.value)]))
+        if instr.hasDest {
+            lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "select.send")
+        }
+        return
+    }
+    let value = lirLowerCoercedOperand(l, instr.args[2], elemName, elemLir, "select.send value")
+    if value.value == "" {
+        return
+    }
+    let symbol = mirRtSelectSendSuffixSymbol(llvmListElementSuffix(elemLir.llvm))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirVoidType(), [lirPtrType(), lirPtrType(), elemLir, lirPtrType()], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + symbol, [lirOperand(lirPtrType(), builder.value), lirOperand(lirPtrType(), chReg.value), lirOperand(elemLir, value.value), lirOperand(lirPtrType(), armReg.value)]))
+    if instr.hasDest {
+        lirCheckVoidMirDestination(l, instr.hasDest, instr.dest, "select.send")
+    }
+}
+// Composite path: spill value, declare bytes-v1, call.
+// `race(body) -> Result<T, Error>`. Runtime returns the canonical
+// `{ i64, i64 }` Result aggregate directly (production parity with
+// chan_recv / check_cancelled). LIR Proto stores at the raw type
+// since the dest's named `%Result.<T>_<E>` is structurally identical.
+fn lirLowerMirRace(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "race expects (body)", "race")
+        return
+    }
+    let body = lirLowerCoercedOperand(l, instr.args[0], instr.args[0].typ, lirPtrType(), "race body")
+    if body.value == "" {
+        return
+    }
+    let symbol = mirRtTaskRaceSymbol()
+    let rawType = lirRawType("\{ i64, i64 \}")
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, rawType, [lirPtrType()], false))
+    if !(instr.hasDest) {
+        l.instrs.push(lirCall("", rawType, "@" + symbol, [lirOperand(lirPtrType(), body.value)]))
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "race destination local out of range", "race")
+        return
+    }
+    if !(lirIsResultTypeName(loc.typ)) {
+        lirLowerError(l, LirDiagUnsupported, "race destination must be Result<...>, got `" + loc.typ + "`", "race")
+        return
+    }
+    lirLowerMirType(l, loc.typ)
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, rawType, "@" + symbol, [lirOperand(lirPtrType(), body.value)]))
+    let slot = lirMirLocalSlot(l, loc.id)
+    if slot.slot == "" {
+        lirLowerError(l, LirDiagLoweringBug, "race destination has no LIR slot", "race")
+        return
+    }
+    l.instrs.push(lirStore(lirOperand(rawType, dest), slot.slot, 0))
 }
 // `Map.keys().sorted()` fused → single per-key-lane runtime call.
 // Production picks `osty_rt_map_keys_sorted_<i64|string>` based on

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -530,6 +530,39 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "set_remove_i1" {
         return lirParityBuildSetRemoveI1Module()
+    }
+    if name == "task_group_unit" {
+        return lirParityBuildTaskGroupUnitModule()
+    }
+    if name == "spawn_detached" {
+        return lirParityBuildSpawnDetachedModule()
+    }
+    if name == "spawn_grouped" {
+        return lirParityBuildSpawnGroupedModule()
+    }
+    if name == "select" {
+        return lirParityBuildSelectModule()
+    }
+    if name == "select_recv" {
+        return lirParityBuildSelectRecvModule()
+    }
+    if name == "select_send_int" {
+        return lirParityBuildSelectSendIntModule()
+    }
+    if name == "select_timeout" {
+        return lirParityBuildSelectTimeoutModule()
+    }
+    if name == "select_default" {
+        return lirParityBuildSelectDefaultModule()
+    }
+    if name == "parallel" {
+        return lirParityBuildParallelModule()
+    }
+    if name == "race" {
+        return lirParityBuildRaceModule()
+    }
+    if name == "collect_all" {
+        return lirParityBuildCollectAllModule()
     }
     mirModule("main")
 }
@@ -1559,6 +1592,141 @@ pub fn lirParityBuildSetRemoveI1Module() -> MirModule {
     let s = lirParityParam(fn_, "s", "Set<Int>")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSetRemove, [mirOperandCopy(mirPlace(s), "Set<Int>"), mirOperandConst(mirConstInt(7, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Concurrency closure-env intrinsic fixtures (TaskGroup / Spawn /
+// Select* / Parallel / Race / CollectAll)
+// ====================================================================
+pub fn lirParityManualTaskGroupUnitFixture() -> LirParityFixture {
+    lirParityFixture("task_group_unit", LirParityManualMIR, "/tmp/lir_proto_parity_task_group_unit.osty", "", "phase4-concurrency", ["concurrency", "taskgroup"], [lirParityNeedle("declare void @osty_rt_task_group_root(ptr)", "task group root runtime"), lirParityNeedle("call void @osty_rt_task_group_root(", "task group call site")])
+}
+pub fn lirParityManualSpawnDetachedFixture() -> LirParityFixture {
+    lirParityFixture("spawn_detached", LirParityManualMIR, "/tmp/lir_proto_parity_spawn_detached.osty", "", "phase4-concurrency", ["concurrency", "spawn"], [lirParityNeedle("declare ptr @osty_rt_task_spawn(ptr)", "detached spawn runtime"), lirParityNeedle("call ptr @osty_rt_task_spawn(", "spawn call site")])
+}
+pub fn lirParityManualSpawnGroupedFixture() -> LirParityFixture {
+    lirParityFixture("spawn_grouped", LirParityManualMIR, "/tmp/lir_proto_parity_spawn_grouped.osty", "", "phase4-concurrency", ["concurrency", "spawn"], [lirParityNeedle("declare ptr @osty_rt_task_group_spawn(ptr, ptr)", "group spawn runtime"), lirParityNeedle("call ptr @osty_rt_task_group_spawn(", "group spawn call site")])
+}
+pub fn lirParityManualSelectFixture() -> LirParityFixture {
+    lirParityFixture("select", LirParityManualMIR, "/tmp/lir_proto_parity_select.osty", "", "phase4-concurrency", ["concurrency", "select"], [lirParityNeedle("declare void @osty_rt_select(ptr)", "select runtime"), lirParityNeedle("call void @osty_rt_select(", "select call site")])
+}
+pub fn lirParityManualSelectRecvFixture() -> LirParityFixture {
+    lirParityFixture("select_recv", LirParityManualMIR, "/tmp/lir_proto_parity_select_recv.osty", "", "phase4-concurrency", ["concurrency", "select", "recv"], [lirParityNeedle("declare void @osty_rt_select_recv(ptr, ptr, ptr)", "select recv runtime"), lirParityNeedle("call void @osty_rt_select_recv(", "select recv call site")])
+}
+pub fn lirParityManualSelectSendIntFixture() -> LirParityFixture {
+    lirParityFixture("select_send_int", LirParityManualMIR, "/tmp/lir_proto_parity_select_send_int.osty", "", "phase4-concurrency", ["concurrency", "select", "send", "lane-i64"], [lirParityNeedle("declare void @osty_rt_select_send_i64(ptr, ptr, i64, ptr)", "i64 select send runtime"), lirParityNeedle("call void @osty_rt_select_send_i64(", "select send call site")])
+}
+pub fn lirParityManualSelectTimeoutFixture() -> LirParityFixture {
+    lirParityFixture("select_timeout", LirParityManualMIR, "/tmp/lir_proto_parity_select_timeout.osty", "", "phase4-concurrency", ["concurrency", "select", "timeout"], [lirParityNeedle("declare void @osty_rt_select_timeout(ptr, ptr, ptr)", "select timeout runtime"), lirParityNeedle("call void @osty_rt_select_timeout(", "select timeout call site")])
+}
+pub fn lirParityManualSelectDefaultFixture() -> LirParityFixture {
+    lirParityFixture("select_default", LirParityManualMIR, "/tmp/lir_proto_parity_select_default.osty", "", "phase4-concurrency", ["concurrency", "select", "default"], [lirParityNeedle("declare void @osty_rt_select_default(ptr, ptr)", "select default runtime"), lirParityNeedle("call void @osty_rt_select_default(", "select default call site")])
+}
+pub fn lirParityManualParallelFixture() -> LirParityFixture {
+    lirParityFixture("parallel", LirParityManualMIR, "/tmp/lir_proto_parity_parallel.osty", "", "phase4-concurrency", ["concurrency", "parallel"], [lirParityNeedle("declare ptr @osty_rt_parallel(ptr, i64, ptr)", "parallel runtime"), lirParityNeedle("call ptr @osty_rt_parallel(", "parallel call site")])
+}
+pub fn lirParityManualRaceFixture() -> LirParityFixture {
+    lirParityFixture("race", LirParityManualMIR, "/tmp/lir_proto_parity_race.osty", "", "phase4-concurrency", ["concurrency", "race"], [lirParityNeedle("%Result.Int_Error = type \{ i64, i64 \}", "Result aggregate type"), lirParityNeedle("declare \{ i64, i64 \} @osty_rt_task_race(ptr)", "race runtime returns Result aggregate"), lirParityNeedle("call \{ i64, i64 \} @osty_rt_task_race(", "race call site")])
+}
+pub fn lirParityManualCollectAllFixture() -> LirParityFixture {
+    lirParityFixture("collect_all", LirParityManualMIR, "/tmp/lir_proto_parity_collect_all.osty", "", "phase4-concurrency", ["concurrency", "collectAll"], [lirParityNeedle("declare ptr @osty_rt_task_collect_all(ptr)", "collectAll runtime"), lirParityNeedle("call ptr @osty_rt_task_collect_all(", "collectAll call site")])
+}
+// Module builders.
+pub fn lirParityBuildTaskGroupUnitModule() -> MirModule {
+    let mut fn_ = lirParityFunction("run", "Unit")
+    let body = lirParityParam(fn_, "body", "()->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicTaskGroup, [mirOperandCopy(mirPlace(body), "()->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSpawnDetachedModule() -> MirModule {
+    let mut fn_ = lirParityFunction("fork", "Handle<Int>")
+    let body = lirParityParam(fn_, "body", "()->Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicSpawn, [mirOperandCopy(mirPlace(body), "()->Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSpawnGroupedModule() -> MirModule {
+    let mut fn_ = lirParityFunction("forkOn", "Handle<Int>")
+    let g = lirParityParam(fn_, "g", "TaskGroup")
+    let body = lirParityParam(fn_, "body", "()->Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicSpawn, [mirOperandCopy(mirPlace(g), "TaskGroup"), mirOperandCopy(mirPlace(body), "()->Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSelectModule() -> MirModule {
+    let mut fn_ = lirParityFunction("dispatch", "Unit")
+    let body = lirParityParam(fn_, "body", "()->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSelect, [mirOperandCopy(mirPlace(body), "()->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSelectRecvModule() -> MirModule {
+    let mut fn_ = lirParityFunction("addRecv", "Unit")
+    let s = lirParityParam(fn_, "s", "Select")
+    let ch = lirParityParam(fn_, "ch", "Channel<Int>")
+    let cb = lirParityParam(fn_, "cb", "(Int)->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSelectRecv, [mirOperandCopy(mirPlace(s), "Select"), mirOperandCopy(mirPlace(ch), "Channel<Int>"), mirOperandCopy(mirPlace(cb), "(Int)->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSelectSendIntModule() -> MirModule {
+    let mut fn_ = lirParityFunction("addSend", "Unit")
+    let s = lirParityParam(fn_, "s", "Select")
+    let ch = lirParityParam(fn_, "ch", "Channel<Int>")
+    let arm = lirParityParam(fn_, "arm", "()->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSelectSend, [mirOperandCopy(mirPlace(s), "Select"), mirOperandCopy(mirPlace(ch), "Channel<Int>"), mirOperandConst(mirConstInt(7, "Int")), mirOperandCopy(mirPlace(arm), "()->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSelectTimeoutModule() -> MirModule {
+    let mut fn_ = lirParityFunction("addTimeout", "Unit")
+    let s = lirParityParam(fn_, "s", "Select")
+    let d = lirParityParam(fn_, "d", "Duration")
+    let cb = lirParityParam(fn_, "cb", "()->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSelectTimeout, [mirOperandCopy(mirPlace(s), "Select"), mirOperandCopy(mirPlace(d), "Duration"), mirOperandCopy(mirPlace(cb), "()->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildSelectDefaultModule() -> MirModule {
+    let mut fn_ = lirParityFunction("addDefault", "Unit")
+    let s = lirParityParam(fn_, "s", "Select")
+    let cb = lirParityParam(fn_, "cb", "()->Unit")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicSelectDefault, [mirOperandCopy(mirPlace(s), "Select"), mirOperandCopy(mirPlace(cb), "()->Unit")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildParallelModule() -> MirModule {
+    let mut fn_ = lirParityFunction("forEach", "List<Result<Int, Error>>")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let f = lirParityParam(fn_, "f", "(Int)->Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicParallel, [mirOperandCopy(mirPlace(xs), "List<Int>"), mirOperandConst(mirConstInt(4, "Int")), mirOperandCopy(mirPlace(f), "(Int)->Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildRaceModule() -> MirModule {
+    let mut fn_ = lirParityFunction("first", "Result<Int, Error>")
+    let body = lirParityParam(fn_, "body", "()->Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicRace, [mirOperandCopy(mirPlace(body), "()->Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildCollectAllModule() -> MirModule {
+    let mut fn_ = lirParityFunction("gather", "List<Result<Int, Error>>")
+    let body = lirParityParam(fn_, "body", "()->Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicCollectAll, [mirOperandCopy(mirPlace(body), "()->Int")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary

Eleven new lowerings — the runtime callbacks pass through as opaque ptr at the LLVM boundary (closures lower to ptr at the function-value boundary already), so LIR Proto can emit the per-intrinsic runtime call shape without needing a new closure-env ABI surface.

**Lowerings**:
- **`TaskGroup(body)`** → `osty_rt_task_group_root(ptr) -> retType`. Return type read off the destination local (defaults to void).
- **`Spawn(body)`** detached (1 arg) → `osty_rt_task_spawn(ptr) -> ptr`
- **`Spawn(group, body)`** group-scoped (2 args) → `osty_rt_task_group_spawn(ptr, ptr) -> ptr`
- **`Select(body)`**, **`SelectRecv(builder, ch, callback)`**, **`SelectTimeout(builder, duration, callback)`**, **`SelectDefault(builder, callback)`** → all-ptr arg shapes through the existing simple-runtime-call helper
- **`SelectSend(builder, ch, value, arm)`** → per-channel-element-lane dispatch like ChanSend (typed `osty_rt_select_send_<lane>` for scalar, `osty_rt_select_send_bytes_v1` with spill+sizeof for composite values)
- **`Parallel(items, concurrency, f)`** → `osty_rt_parallel(ptr, i64, ptr) -> ptr`
- **`Race(body)`** returns `Result<T, Error>` as raw `{ i64, i64 }` aggregate — same direct-store shape as `CheckCancelled`
- **`CollectAll(body)`** → `osty_rt_task_collect_all(ptr) -> ptr`

**Pin**: eleven new fixtures pin every shape through `TestLIRProtoManualFixtureCatalog`:
- `task_group_unit`, `spawn_detached`, `spawn_grouped`
- `select`, `select_recv`, `select_send_int`, `select_timeout`, `select_default`
- `parallel`, `race`, `collect_all`

**What stays deferred**:
- Actual GC `root_bind` / `root_release` per-call (closure envs are passed by ptr but no per-call root binding is emitted today; needs the root-visibility tracking pass)
- Per-loop `!llvm.loop.*` metadata (needs MIR loop classification)
- Per-instruction `!llvm.access.group` metadata
- Phase-7 actual runner (Osty↔Go bridge architecture decision)
- Phase-8 default-on flip

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` — pass
- [x] \`go test -count=1 -vet=off -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/\` — clean
- [x] \`go run ./cmd/osty fmt --check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty\` — clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)