### PR TITLE
feat: regex Phase 2b — Regex.capturesAll

### DIFF
--- a/examples/regex_captures_all/main.osty
+++ b/examples/regex_captures_all/main.osty
@@ -1,0 +1,93 @@
+use std.regex
+
+fn main() {
+    // Multiple non-overlapping digit runs.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let list = re.capturesAll("a 1 b 22 c 333 d")
+            let n = list.len()
+            println("digits: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let c = list[i]
+                match c.get(0) {
+                    Some(s) -> println("  whole: {s}"),
+                    None    -> println("  whole: <unset>"),
+                }
+                i += 1
+            }
+        },
+        Err(_) -> println("digits compile failed"),
+    }
+
+    // Group capture across multiple matches.
+    match regex.compile(r"(\w+)=(\w+)") {
+        Ok(re) -> {
+            let list = re.capturesAll("foo=1, bar=baz, qux=42")
+            let n = list.len()
+            println("kv: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let c = list[i]
+                match c.get(1) {
+                    Some(s) -> println("  k={s}"),
+                    None    -> {},
+                }
+                match c.get(2) {
+                    Some(s) -> println("  v={s}"),
+                    None    -> {},
+                }
+                i += 1
+            }
+        },
+        Err(_) -> println("kv compile failed"),
+    }
+
+    // Anchored pattern: `^` only at offset 0, so capturesAll yields ≤ 1.
+    match regex.compile(r"^\w+") {
+        Ok(re) -> {
+            let list = re.capturesAll("hello world")
+            let n = list.len()
+            println("anchored: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let c = list[i]
+                match c.get(0) {
+                    Some(s) -> println("  {s}"),
+                    None    -> {},
+                }
+                i += 1
+            }
+        },
+        Err(_) -> println("anchored compile failed"),
+    }
+
+    // No match at all: empty list.
+    match regex.compile(r"xyz\d+") {
+        Ok(re) -> {
+            let list = re.capturesAll("hello world")
+            let n = list.len()
+            println("nomatch: {n} match(es)")
+        },
+        Err(_) -> println("nomatch compile failed"),
+    }
+
+    // Alternation: only one group participates per match.
+    match regex.compile(r"(\d+)|([a-z]+)") {
+        Ok(re) -> {
+            let list = re.capturesAll("abc 12 def 345")
+            let n = list.len()
+            println("alt: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let c = list[i]
+                match c.get(0) {
+                    Some(s) -> println("  whole={s}"),
+                    None    -> {},
+                }
+                i += 1
+            }
+        },
+        Err(_) -> println("alt compile failed"),
+    }
+}

--- a/examples/regex_captures_all/osty.toml
+++ b/examples/regex_captures_all/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_captures_all"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -15522,13 +15522,18 @@ static void osty_re_add_thread_caps(osty_re_vm *vm, const osty_re_inst *prog, in
            caps, sizeof(int32_t) * (size_t)vm->slots_per_thread);
 }
 
-/* Run the matcher against text. If `out_caps` is non-NULL, on match it
- * receives 2 * ngroups int32_t slots (-1 = unset). Returns 1 on match,
- * 0 on no match. */
-static int osty_re_match(const osty_regex_compiled *re, const char *text, int text_len, int32_t *out_caps) {
+/* Run the matcher against text starting at `start_offset` (Phase 2b:
+ * exposed so capturesAll can scan past prior matches). `^` still
+ * binds to absolute position 0 — start_offset only shifts the search
+ * loop, BOL inside add_thread_caps continues to compare against 0.
+ * If `out_caps` is non-NULL, on match it receives 2 * ngroups int32_t
+ * slots (-1 = unset). Returns 1 on match, 0 on no match. */
+static int osty_re_match_from(const osty_regex_compiled *re, const char *text, int text_len, int start_offset, int32_t *out_caps) {
     if (re->ngroups > OSTY_RE_MAX_GROUPS) {
         return 0;
     }
+    if (start_offset < 0) start_offset = 0;
+    if (start_offset > text_len) return 0;
     osty_re_vm vm;
     memset(&vm, 0, sizeof(vm));
     vm.prog_len = re->prog_len;
@@ -15547,7 +15552,7 @@ static int osty_re_match(const osty_regex_compiled *re, const char *text, int te
     int32_t seed_caps[OSTY_RE_MAX_CAP_SLOTS];
     for (int i = 0; i < vm.slots_per_thread; i++) seed_caps[i] = -1;
 
-    for (int sp = 0; sp <= text_len; sp++) {
+    for (int sp = start_offset; sp <= text_len; sp++) {
         /* Promote nxt -> cur. */
         int *swap_pc = vm.cur_pc; vm.cur_pc = vm.nxt_pc; vm.nxt_pc = swap_pc;
         int32_t *swap_caps = vm.cur_caps; vm.cur_caps = vm.nxt_caps; vm.nxt_caps = swap_caps;
@@ -15710,7 +15715,30 @@ bool osty_rt_regex_matches(void *raw_re, const char *text) {
     if (src == NULL) src = "";
     osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
     int len = (int)strlen(src);
-    return osty_re_match(re, src, len, NULL) ? true : false;
+    return osty_re_match_from(re, src, len, 0, NULL) ? true : false;
+}
+
+/* Build a self-contained Captures GC blob from a successful match.
+ * Layout: [header][full input bytes][2 * ngroups int32 slots]. The
+ * input is copied inline so the Captures has no external GC refs;
+ * Captures.get returns slices into the inlined copy. The whole-input
+ * copy is wasteful but makes capturesAll trivial — every Captures
+ * stays valid even if the caller mutates the input afterwards.  */
+static void *osty_re_build_captures(int ngroups, const char *text, int text_len, const int32_t *slots) {
+    int slot_count = 2 * ngroups;
+    size_t hdr = sizeof(osty_regex_captures);
+    size_t text_bytes = (size_t)text_len;
+    size_t slot_bytes = sizeof(int32_t) * (size_t)slot_count;
+    size_t total = hdr + text_bytes + slot_bytes;
+    osty_regex_captures *caps = (osty_regex_captures *)osty_gc_allocate_managed(total, OSTY_GC_KIND_GENERIC, "runtime.regex.captures", NULL, NULL);
+    caps->ngroups = ngroups;
+    caps->text_len = text_len;
+    if (text_bytes > 0) {
+        memcpy((char *)(caps + 1), text, text_bytes);
+    }
+    int32_t *out_slots = osty_re_captures_slots(caps);
+    memcpy(out_slots, slots, slot_bytes);
+    return caps;
 }
 
 /* regex.captures(text) -> Captures? */
@@ -15727,23 +15755,55 @@ void *osty_rt_regex_captures(void *raw_re, const char *text) {
     int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
     int slot_count = 2 * re->ngroups;
     for (int i = 0; i < slot_count; i++) slots[i] = -1;
-    if (!osty_re_match(re, src, len, slots)) {
+    if (!osty_re_match_from(re, src, len, 0, slots)) {
         return NULL;
     }
-    /* Build self-contained Captures blob: header + text bytes + slot ints. */
-    size_t hdr = sizeof(osty_regex_captures);
-    size_t text_bytes = (size_t)len;
-    size_t slot_bytes = sizeof(int32_t) * (size_t)slot_count;
-    size_t total = hdr + text_bytes + slot_bytes;
-    osty_regex_captures *caps = (osty_regex_captures *)osty_gc_allocate_managed(total, OSTY_GC_KIND_GENERIC, "runtime.regex.captures", NULL, NULL);
-    caps->ngroups = re->ngroups;
-    caps->text_len = (int32_t)len;
-    if (text_bytes > 0) {
-        memcpy((char *)(caps + 1), src, text_bytes);
+    return osty_re_build_captures(re->ngroups, src, len, slots);
+}
+
+/* regex.capturesAll(text) -> List<Captures>. Walks the input collecting
+ * non-overlapping matches in left-to-right order. Empty matches advance
+ * the cursor by one byte to avoid an infinite loop. Anchors continue
+ * to bind to absolute positions: `^` only matches at offset 0, so a
+ * pattern like `^foo` yields at most one entry; `\bfoo\b` (when the
+ * word-boundary lands) yields multiple. Returns an empty List<Captures>
+ * if no match is found. */
+void *osty_rt_regex_captures_all(void *raw_re, const char *text) {
+    if (raw_re == NULL) {
+        osty_rt_abort("runtime.regex.captures_all: nil Regex");
     }
-    int32_t *out_slots = osty_re_captures_slots(caps);
-    memcpy(out_slots, slots, slot_bytes);
-    return caps;
+    osty_regex_compiled *re = (osty_regex_compiled *)raw_re;
+    char inline_buf[8];
+    const char *src = text;
+    if (src == NULL) src = "";
+    osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
+    int len = (int)strlen(src);
+    void *list = osty_rt_list_new();
+    int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
+    int slot_count = 2 * re->ngroups;
+    int start = 0;
+    while (start <= len) {
+        for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        if (!osty_re_match_from(re, src, len, start, slots)) {
+            break;
+        }
+        int32_t match_start = slots[0];
+        int32_t match_end = slots[1];
+        if (match_start < 0 || match_end < 0 || match_end > len || match_start > match_end) {
+            /* Defensive: malformed slots from the matcher. Stop to
+             * avoid spinning. */
+            break;
+        }
+        void *caps = osty_re_build_captures(re->ngroups, src, len, slots);
+        osty_rt_list_push_ptr(list, caps);
+        if (match_end > match_start) {
+            start = match_end;
+        } else {
+            /* Empty match — bump by one to make progress. */
+            start = match_start + 1;
+        }
+    }
+    return list;
 }
 
 /* Captures.get(i) -> String?  Returns NULL when i is out of range or

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1644,6 +1644,20 @@ func (g *mirGen) emitStdRegexCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, err
 		nullable := g.fresh()
 		g.fnBuf.WriteString(mirCallValueLine(nullable, "ptr", ostyRtRegexCapturesSymbol, argList))
 		return true, g.storeOptionPtrFromNullable(c, nullable)
+	case "capturesAll":
+		if len(c.Args) != 2 {
+			return true, unsupported("mir-mvp", "Regex.capturesAll requires receiver and text")
+		}
+		recv, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+		if err != nil {
+			return true, err
+		}
+		text, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return true, err
+		}
+		// Runtime returns List<Captures> ptr (always non-null; empty list if no matches).
+		return true, g.emitRuntimeCallToDest(c, ostyRtRegexCapturesAllSymbol, "ptr", []mirRuntimeArg{recv, text})
 	}
 	return false, nil
 }

--- a/internal/llvmgen/stdlib_regex_shim.go
+++ b/internal/llvmgen/stdlib_regex_shim.go
@@ -9,6 +9,7 @@ const (
 	ostyRtRegexCompileErrorSymbol = "osty_rt_regex_compile_error"
 	ostyRtRegexMatchesSymbol      = "osty_rt_regex_matches"
 	ostyRtRegexCapturesSymbol     = "osty_rt_regex_captures"
+	ostyRtRegexCapturesAllSymbol  = "osty_rt_regex_captures_all"
 	ostyRtRegexCapturesGetSymbol  = "osty_rt_regex_captures_get"
 )
 
@@ -26,6 +27,11 @@ var stdRegexCapturesOptionSourceTypeSingleton ast.Type = &ast.OptionalType{
 
 var stdRegexStringOptionSourceTypeSingleton ast.Type = &ast.OptionalType{
 	Inner: stringSourceTypeSingleton,
+}
+
+var stdRegexCapturesListSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"List"},
+	Args: []ast.Type{stdRegexCapturesSourceTypeSingleton},
 }
 
 var stdRegexCompileResultSourceTypeSingleton ast.Type = &ast.NamedType{
@@ -204,6 +210,8 @@ func (g *generator) emitStdRegexMethodCall(call *ast.CallExpr) (value, bool, err
 			return g.emitStdRegexMatchesCall(call, field)
 		case "captures":
 			return g.emitStdRegexCapturesCall(call, field)
+		case "capturesAll":
+			return g.emitStdRegexCapturesAllCall(call, field)
 		}
 		return value{}, false, nil
 	}
@@ -228,6 +236,13 @@ func (g *generator) stdRegexMethodStaticResult(call *ast.CallExpr) (value, bool)
 			return value{typ: "i1", sourceType: boolSourceTypeSingleton}, true
 		case "captures":
 			return value{typ: "ptr", gcManaged: true, sourceType: stdRegexCapturesOptionSourceTypeSingleton}, true
+		case "capturesAll":
+			return value{
+				typ:         "ptr",
+				gcManaged:   true,
+				listElemTyp: "ptr",
+				sourceType:  stdRegexCapturesListSourceTypeSingleton,
+			}, true
 		}
 		return value{}, false
 	}
@@ -252,6 +267,8 @@ func (g *generator) staticStdRegexMethodSourceType(call *ast.CallExpr) (ast.Type
 			return boolSourceTypeSingleton, true
 		case "captures":
 			return stdRegexCapturesOptionSourceTypeSingleton, true
+		case "capturesAll":
+			return stdRegexCapturesListSourceTypeSingleton, true
 		}
 		return nil, false
 	}
@@ -379,6 +396,58 @@ func (g *generator) emitStdRegexCapturesCall(call *ast.CallExpr, field *ast.Fiel
 	v := fromOstyValue(out)
 	v.gcManaged = true
 	v.sourceType = stdRegexCapturesOptionSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdRegexCapturesAllCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "Regex.capturesAll expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, true, unsupported("call", "Regex.capturesAll requires one positional String argument")
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, true, unsupported("type-system", "Regex.capturesAll arg 1 source type unknown, want String")
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsString(resolved) {
+		return value{}, true, unsupported("type-system", "Regex.capturesAll arg 1 source type is not String")
+	}
+	recv, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	recv, err = g.loadIfPointer(recv)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Regex receiver type %s", recv.typ)
+	}
+	text, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	text = g.protectManagedTemporary("regex.capturesAll.arg", text)
+	textLoaded, err := g.loadIfPointer(text)
+	if err != nil {
+		return value{}, true, err
+	}
+	if textLoaded.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Regex.capturesAll arg 1 type %s, want String", textLoaded.typ)
+	}
+	g.declareRuntimeSymbol(ostyRtRegexCapturesAllSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRegexCapturesAllSymbol, []*LlvmValue{toOstyValue(recv), toOstyValue(textLoaded)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.listElemTyp = "ptr"
+	v.sourceType = stdRegexCapturesListSourceTypeSingleton
 	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil
 }

--- a/internal/llvmgen/stdlib_regex_shim_test.go
+++ b/internal/llvmgen/stdlib_regex_shim_test.go
@@ -76,3 +76,40 @@ fn main() {
 		}
 	}
 }
+
+func TestStdRegexCapturesAllRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.regex
+
+fn run(re: Regex) -> List<Captures> {
+    re.capturesAll("a 1 b 22 c 333")
+}
+
+fn main() {
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let _ = run(re)
+            println("ok")
+        },
+        Err(_) -> println("compile failed"),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_regex_captures_all.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_regex_captures_all(ptr, ptr)",
+		"call ptr @osty_rt_regex_captures_all",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `Regex.capturesAll(text) -> List<Captures>` 구현 — 비-overlapping 매치를 left-to-right 수집.
- Pike VM matcher에 `start_offset` 매개변수를 추가 (`osty_re_match_from`). `^`은 절대 0에 그대로 바인딩되므로 anchored 패턴은 `capturesAll`에서도 ≤ 1 매치.
- 빈 매치는 +1 byte forward로 무한루프 회피, no-match면 빈 `List<Captures>` 반환.
- Captures GC blob 빌드 로직을 `osty_re_build_captures` helper로 추출 — `captures()`와 `capturesAll()`이 공유.
- AST + MIR 양 경로 디스패치, `List<Captures>` `listElemTyp="ptr"` 등록.

## Test plan
- [x] IR-레벨 포커스 테스트 추가 (`TestStdRegexCapturesAllRoutesToRuntime`)
- [x] llvmgen short suite (24s) 통과
- [x] E2E 5 케이스 ([examples/regex_captures_all](examples/regex_captures_all/main.osty)):
  - `\d+` on `"a 1 b 22 c 333 d"` → 3 매치 (1, 22, 333) — greedy non-overlapping
  - `(\w+)=(\w+)` on `"foo=1, bar=baz, qux=42"` → 3 매치 with group capture
  - `^\w+` on `"hello world"` → 1 매치 (anchor 정합성)
  - `xyz\d+` on `"hello world"` → 0 매치 (빈 list)
  - `(\d+)|([a-z]+)` on `"abc 12 def 345"` → 4 매치 (alternation 정상)
- [x] Phase 1 (regex_smoke 20 출력) + Phase 2 (regex_captures 11 케이스) 회귀 없음
- [x] `just fmt-check` / `just vet` clean
- [ ] CI 그린 확인

## 다음
- Phase 3: `find` / `findAll` (Match struct 재료화)
- Phase 4: `replace` / `replaceAll` / `split`
- Phase 5: 명명 캡처 `(?P<name>...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)