### PR TITLE
feat: regex Phase 4 — replace/replaceAll/split

### DIFF
--- a/examples/regex_replace_split/main.osty
+++ b/examples/regex_replace_split/main.osty
@@ -1,0 +1,87 @@
+use std.regex
+
+fn main() {
+    // First-match replace.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let r1 = re.replace("a 1 b 22 c 333", "N")
+            println("replace once: {r1}")
+            let r2 = re.replaceAll("a 1 b 22 c 333", "N")
+            println("replace all : {r2}")
+        },
+        Err(_) -> println("digits compile failed"),
+    }
+
+    // Whitespace collapse.
+    match regex.compile(r"\s+") {
+        Ok(re) -> {
+            let r = re.replaceAll("  hello   world\t\n42", " ")
+            println("collapse    : {r}")
+        },
+        Err(_) -> println("ws compile failed"),
+    }
+
+    // Empty replacement (delete).
+    match regex.compile(r"[aeiou]") {
+        Ok(re) -> {
+            let r = re.replaceAll("Programming", "")
+            println("devowel     : {r}")
+        },
+        Err(_) -> println("vowel compile failed"),
+    }
+
+    // No-match: returns original.
+    match regex.compile(r"xyz") {
+        Ok(re) -> {
+            let r = re.replaceAll("hello world", "?")
+            println("no-match    : {r}")
+        },
+        Err(_) -> println("xyz compile failed"),
+    }
+
+    // Split on comma+space.
+    match regex.compile(r",\s*") {
+        Ok(re) -> {
+            let parts = re.split("a, b,c, d ,e")
+            let n = parts.len()
+            println("split count: {n}")
+            let mut i = 0
+            while i < n {
+                let p = parts[i]
+                println("  [{i}]={p}")
+                i += 1
+            }
+        },
+        Err(_) -> println("split compile failed"),
+    }
+
+    // Split with no match: single-element list (whole input).
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let parts = re.split("hello world")
+            let n = parts.len()
+            println("nosplit count: {n}")
+            if n > 0 {
+                let p0 = parts[0]
+                println("  [0]={p0}")
+            }
+        },
+        Err(_) -> println("ns compile failed"),
+    }
+
+    // Split keeps empty fragments between adjacent matches.
+    match regex.compile(r",") {
+        Ok(re) -> {
+            let parts = re.split(",a,,b,")
+            let n = parts.len()
+            println("empties count: {n}")
+            let mut i = 0
+            while i < n {
+                let p = parts[i]
+                println("  [{i}]='{p}'")
+                i += 1
+            }
+        },
+        Err(_) -> println("empties compile failed"),
+    }
+}

--- a/examples/regex_replace_split/osty.toml
+++ b/examples/regex_replace_split/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_replace_split"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -15741,6 +15741,177 @@ static void *osty_re_build_captures(int ngroups, const char *text, int text_len,
     return caps;
 }
 
+/* Phase 4 — replace / replaceAll / split helpers.
+ *
+ * `replace` / `replaceAll` produce a fresh String with non-overlapping
+ * matches substituted by the literal `replacement` string. No backref
+ * (`$1`) interpolation in Phase 4; the replacement is emitted byte for
+ * byte. `split` returns a `List<String>` of the gaps between matches.
+ *
+ * Empty matches advance the cursor by one byte to avoid infinite loops
+ * (mirrors the rule in `osty_rt_regex_captures_all`). */
+
+typedef struct osty_re_buffer {
+    char *data;
+    size_t len;
+    size_t cap;
+} osty_re_buffer;
+
+static int osty_re_buffer_reserve(osty_re_buffer *buf, size_t need) {
+    if (need <= buf->cap) return 0;
+    size_t next = buf->cap == 0 ? 64 : buf->cap;
+    while (next < need) {
+        if (next > SIZE_MAX / 2) return -1;
+        next *= 2;
+    }
+    char *grown = (char *)realloc(buf->data, next);
+    if (grown == NULL) return -1;
+    buf->data = grown;
+    buf->cap = next;
+    return 0;
+}
+
+static int osty_re_buffer_append(osty_re_buffer *buf, const char *src, size_t n) {
+    if (n == 0) return 0;
+    if (osty_re_buffer_reserve(buf, buf->len + n) != 0) return -1;
+    memcpy(buf->data + buf->len, src, n);
+    buf->len += n;
+    return 0;
+}
+
+static void osty_re_buffer_free(osty_re_buffer *buf) {
+    free(buf->data);
+    buf->data = NULL;
+    buf->len = 0;
+    buf->cap = 0;
+}
+
+static void *osty_rt_regex_replace_impl(void *raw_re, const char *text, const char *replacement, int replace_all) {
+    if (raw_re == NULL) {
+        osty_rt_abort("runtime.regex.replace: nil Regex");
+    }
+    osty_regex_compiled *re = (osty_regex_compiled *)raw_re;
+    char text_inline[8];
+    char repl_inline[8];
+    const char *src = text == NULL ? "" : text;
+    const char *repl = replacement == NULL ? "" : replacement;
+    osty_rt_string_decode_to_buf_if_inline(&src, text_inline);
+    osty_rt_string_decode_to_buf_if_inline(&repl, repl_inline);
+    int len = (int)strlen(src);
+    size_t repl_len = strlen(repl);
+
+    osty_re_buffer buf;
+    memset(&buf, 0, sizeof(buf));
+    int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
+    int slot_count = 2 * re->ngroups;
+    int start = 0;
+    int substituted = 0;
+    while (start <= len) {
+        for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        if (!osty_re_match_from(re, src, len, start, slots)) {
+            break;
+        }
+        int32_t match_start = slots[0];
+        int32_t match_end = slots[1];
+        if (match_start < 0 || match_end < 0 || match_end > len || match_start < start) {
+            break;
+        }
+        if (osty_re_buffer_append(&buf, src + start, (size_t)(match_start - start)) != 0) {
+            osty_re_buffer_free(&buf);
+            osty_rt_abort("runtime.regex.replace: out of memory");
+        }
+        if (osty_re_buffer_append(&buf, repl, repl_len) != 0) {
+            osty_re_buffer_free(&buf);
+            osty_rt_abort("runtime.regex.replace: out of memory");
+        }
+        substituted++;
+        if (match_end > match_start) {
+            start = match_end;
+        } else {
+            /* Empty match — emit the next byte verbatim and advance. */
+            if (start < len) {
+                if (osty_re_buffer_append(&buf, src + start, 1) != 0) {
+                    osty_re_buffer_free(&buf);
+                    osty_rt_abort("runtime.regex.replace: out of memory");
+                }
+            }
+            start++;
+        }
+        if (!replace_all) break;
+    }
+    /* Tail: anything past the last consumed byte. */
+    if (start < len) {
+        if (osty_re_buffer_append(&buf, src + start, (size_t)(len - start)) != 0) {
+            osty_re_buffer_free(&buf);
+            osty_rt_abort("runtime.regex.replace: out of memory");
+        }
+    }
+    void *out;
+    if (substituted == 0) {
+        /* No match: return the original text unchanged. */
+        out = osty_rt_string_dup_site(src, (size_t)len, "runtime.regex.replace.unchanged");
+    } else {
+        out = osty_rt_string_dup_site(buf.data == NULL ? "" : buf.data, buf.len, "runtime.regex.replace");
+    }
+    osty_re_buffer_free(&buf);
+    return out;
+}
+
+void *osty_rt_regex_replace(void *raw_re, const char *text, const char *replacement) {
+    return osty_rt_regex_replace_impl(raw_re, text, replacement, 0);
+}
+
+void *osty_rt_regex_replace_all(void *raw_re, const char *text, const char *replacement) {
+    return osty_rt_regex_replace_impl(raw_re, text, replacement, 1);
+}
+
+/* regex.split(text) -> List<String>. Splits at every non-overlapping
+ * match. Behaves like Go's regexp.Split or Python's re.split (default,
+ * maxsplit=-1): empty fragments between adjacent matches are kept;
+ * the trailing fragment after the last match is appended. An empty
+ * pattern match between every byte position is a degenerate but
+ * valid case — the implementation steps past empties to avoid an
+ * infinite loop, just like replace. */
+void *osty_rt_regex_split(void *raw_re, const char *text) {
+    if (raw_re == NULL) {
+        osty_rt_abort("runtime.regex.split: nil Regex");
+    }
+    osty_regex_compiled *re = (osty_regex_compiled *)raw_re;
+    char inline_buf[8];
+    const char *src = text == NULL ? "" : text;
+    osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
+    int len = (int)strlen(src);
+
+    void *list = osty_rt_list_new();
+    int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
+    int slot_count = 2 * re->ngroups;
+    int start = 0;
+    while (start <= len) {
+        for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        if (!osty_re_match_from(re, src, len, start, slots)) {
+            break;
+        }
+        int32_t match_start = slots[0];
+        int32_t match_end = slots[1];
+        if (match_start < 0 || match_end < 0 || match_end > len || match_start < start) {
+            break;
+        }
+        void *piece = osty_rt_string_dup_site(src + start, (size_t)(match_start - start), "runtime.regex.split.piece");
+        osty_rt_list_push_ptr(list, piece);
+        if (match_end > match_start) {
+            start = match_end;
+        } else {
+            /* Empty match: the slot at `match_start` produced nothing,
+             * advance by 1 to ensure forward progress. */
+            start = match_start + 1;
+        }
+    }
+    /* Trailing piece (or the whole input if no matches). */
+    void *tail = osty_rt_string_dup_site(src + start, (size_t)(len - start), "runtime.regex.split.tail");
+    osty_rt_list_push_ptr(list, tail);
+    return list;
+}
+
 /* regex.captures(text) -> Captures? */
 void *osty_rt_regex_captures(void *raw_re, const char *text) {
     if (raw_re == NULL) {

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1658,8 +1658,46 @@ func (g *mirGen) emitStdRegexCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, err
 		}
 		// Runtime returns List<Captures> ptr (always non-null; empty list if no matches).
 		return true, g.emitRuntimeCallToDest(c, ostyRtRegexCapturesAllSymbol, "ptr", []mirRuntimeArg{recv, text})
+	case "replace":
+		return g.emitStdRegexReplaceMIR(c, ostyRtRegexReplaceSymbol)
+	case "replaceAll":
+		return g.emitStdRegexReplaceMIR(c, ostyRtRegexReplaceAllSymbol)
+	case "split":
+		if len(c.Args) != 2 {
+			return true, unsupported("mir-mvp", "Regex.split requires receiver and text")
+		}
+		recv, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+		if err != nil {
+			return true, err
+		}
+		text, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return true, err
+		}
+		return true, g.emitRuntimeCallToDest(c, ostyRtRegexSplitSymbol, "ptr", []mirRuntimeArg{recv, text})
 	}
 	return false, nil
+}
+
+// emitStdRegexReplaceMIR shares the lowering for replace/replaceAll —
+// both take (receiver, text, replacement) and return a String ptr.
+func (g *mirGen) emitStdRegexReplaceMIR(c *mir.CallInstr, symbol string) (bool, error) {
+	if len(c.Args) != 3 {
+		return true, unsupported("mir-mvp", "Regex.replace/replaceAll requires receiver, text, replacement")
+	}
+	recv, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+	if err != nil {
+		return true, err
+	}
+	text, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+	if err != nil {
+		return true, err
+	}
+	repl, err := g.evalTypedArg(c.Args[2], c.Args[2].Type())
+	if err != nil {
+		return true, err
+	}
+	return true, g.emitRuntimeCallToDest(c, symbol, "ptr", []mirRuntimeArg{recv, text, repl})
 }
 
 func (g *mirGen) emitStdRegexCapturesMethod(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {

--- a/internal/llvmgen/stdlib_regex_shim.go
+++ b/internal/llvmgen/stdlib_regex_shim.go
@@ -11,7 +11,15 @@ const (
 	ostyRtRegexCapturesSymbol     = "osty_rt_regex_captures"
 	ostyRtRegexCapturesAllSymbol  = "osty_rt_regex_captures_all"
 	ostyRtRegexCapturesGetSymbol  = "osty_rt_regex_captures_get"
+	ostyRtRegexReplaceSymbol      = "osty_rt_regex_replace"
+	ostyRtRegexReplaceAllSymbol   = "osty_rt_regex_replace_all"
+	ostyRtRegexSplitSymbol        = "osty_rt_regex_split"
 )
+
+var stdRegexStringListSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"List"},
+	Args: []ast.Type{stringSourceTypeSingleton},
+}
 
 var stdRegexRegexSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Regex"},
@@ -212,6 +220,12 @@ func (g *generator) emitStdRegexMethodCall(call *ast.CallExpr) (value, bool, err
 			return g.emitStdRegexCapturesCall(call, field)
 		case "capturesAll":
 			return g.emitStdRegexCapturesAllCall(call, field)
+		case "replace":
+			return g.emitStdRegexReplaceCall(call, field, false)
+		case "replaceAll":
+			return g.emitStdRegexReplaceCall(call, field, true)
+		case "split":
+			return g.emitStdRegexSplitCall(call, field)
 		}
 		return value{}, false, nil
 	}
@@ -243,6 +257,16 @@ func (g *generator) stdRegexMethodStaticResult(call *ast.CallExpr) (value, bool)
 				listElemTyp: "ptr",
 				sourceType:  stdRegexCapturesListSourceTypeSingleton,
 			}, true
+		case "replace", "replaceAll":
+			return value{typ: "ptr", gcManaged: true, sourceType: stringSourceTypeSingleton}, true
+		case "split":
+			return value{
+				typ:            "ptr",
+				gcManaged:      true,
+				listElemTyp:    "ptr",
+				listElemString: true,
+				sourceType:     stdRegexStringListSourceTypeSingleton,
+			}, true
 		}
 		return value{}, false
 	}
@@ -269,6 +293,10 @@ func (g *generator) staticStdRegexMethodSourceType(call *ast.CallExpr) (ast.Type
 			return stdRegexCapturesOptionSourceTypeSingleton, true
 		case "capturesAll":
 			return stdRegexCapturesListSourceTypeSingleton, true
+		case "replace", "replaceAll":
+			return stringSourceTypeSingleton, true
+		case "split":
+			return stdRegexStringListSourceTypeSingleton, true
 		}
 		return nil, false
 	}
@@ -492,4 +520,112 @@ func (g *generator) emitStdRegexCapturesGetCall(call *ast.CallExpr, field *ast.F
 	v.sourceType = stdRegexStringOptionSourceTypeSingleton
 	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil
+}
+
+// emitStdRegexReplaceCall lowers Regex.replace / Regex.replaceAll. Both
+// share the same shape — three String args (receiver, text, replacement)
+// returning a single String — so the dispatch picks the runtime symbol
+// via the `all` flag.
+func (g *generator) emitStdRegexReplaceCall(call *ast.CallExpr, field *ast.FieldExpr, all bool) (value, bool, error) {
+	method := "Regex.replace"
+	symbol := ostyRtRegexReplaceSymbol
+	if all {
+		method = "Regex.replaceAll"
+		symbol = ostyRtRegexReplaceAllSymbol
+	}
+	if len(call.Args) != 2 {
+		return value{}, true, unsupportedf("call", "%s expects 2 arguments, got %d", method, len(call.Args))
+	}
+	recv, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	recv, err = g.loadIfPointer(recv)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Regex receiver type %s", recv.typ)
+	}
+	text, err := g.emitStdRegexStringArg(call.Args[0], method, 0, "regex.replace.text")
+	if err != nil {
+		return value{}, true, err
+	}
+	repl, err := g.emitStdRegexStringArg(call.Args[1], method, 1, "regex.replace.replacement")
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(recv), toOstyValue(text), toOstyValue(repl)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = stringSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdRegexSplitCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "Regex.split expects 1 argument, got %d", len(call.Args))
+	}
+	recv, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	recv, err = g.loadIfPointer(recv)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Regex receiver type %s", recv.typ)
+	}
+	text, err := g.emitStdRegexStringArg(call.Args[0], "Regex.split", 0, "regex.split.text")
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRegexSplitSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRegexSplitSymbol, []*LlvmValue{toOstyValue(recv), toOstyValue(text)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.listElemTyp = "ptr"
+	v.listElemString = true
+	v.sourceType = stdRegexStringListSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+// emitStdRegexStringArg validates an argument is statically a String,
+// emits its expression, parks managed temporaries against safepoints,
+// and returns the loaded ptr value. Shared by replace/replaceAll/split.
+func (g *generator) emitStdRegexStringArg(arg *ast.Arg, method string, index int, parkSite string) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "%s requires positional String arguments", method)
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, unsupportedf("type-system", "%s arg %d source type unknown, want String", method, index+1)
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsString(resolved) {
+		return value{}, unsupportedf("type-system", "%s arg %d source type is not String", method, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	v = g.protectManagedTemporary(parkSite, v)
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "%s arg %d type %s, want String", method, index+1, loaded.typ)
+	}
+	return loaded, nil
 }

--- a/internal/llvmgen/stdlib_regex_shim_test.go
+++ b/internal/llvmgen/stdlib_regex_shim_test.go
@@ -77,6 +77,83 @@ fn main() {
 	}
 }
 
+func TestStdRegexReplaceRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.regex
+
+fn run(re: Regex) -> String {
+    re.replace("hello world", "X")
+}
+
+fn main() {
+    match regex.compile(r"\w+") {
+        Ok(re) -> println(run(re)),
+        Err(_) -> println("compile failed"),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_regex_replace.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_regex_replace(ptr, ptr, ptr)",
+		"call ptr @osty_rt_regex_replace",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdRegexReplaceAllAndSplitRouteToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.regex
+
+fn run(re: Regex) -> String {
+    re.replaceAll("a-b-c", ".")
+}
+
+fn parts(re: Regex) -> List<String> {
+    re.split("a-b-c-d")
+}
+
+fn main() {
+    match regex.compile(r"-") {
+        Ok(re) -> {
+            println(run(re))
+            let _ = parts(re)
+        },
+        Err(_) -> println("compile failed"),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_regex_replace_all_split.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_regex_replace_all(ptr, ptr, ptr)",
+		"call ptr @osty_rt_regex_replace_all",
+		"declare ptr @osty_rt_regex_split(ptr, ptr)",
+		"call ptr @osty_rt_regex_split",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStdRegexCapturesAllRoutesToRuntime(t *testing.T) {
 	file := parseLLVMGenFile(t, `use std.regex
 


### PR DESCRIPTION
## Summary
- Pike VM 위에 텍스트 합성 레이어 추가. 모두 비-overlapping 매치를 left-to-right로 순회.
- `Regex.replace(text, replacement)` — 첫 매치만 치환, 나머지 그대로
- `Regex.replaceAll(text, replacement)` — 모든 비-overlapping 매치 치환
- `Regex.split(text)` — 매치 경계로 분할 → `List<String>` (인접 매치 사이 빈 fragment 보존, 트레일링 fragment 항상 push)
- Phase 4는 backref (`$1`) 미지원 — `replacement`는 리터럴 바이트 그대로 emit
- Empty 매치는 +1 byte forward로 무한루프 회피 (replace 시 그 위치의 1바이트 원본 그대로 emit, split 시 빈 문자열 push 후 진행)
- AST + MIR 양 경로 디스패치

## Phase 3 (find/findAll) 보류 사유
- spec `Match {text: String, start: Int, end: Int}`은 user-facing struct 값을 반환. 
- `Option<Match>` 인코딩이 `{i64 disc, i64 payload}` 표준 옵션 레이아웃에 안 맞음 (Match는 24바이트). os.exec의 synthetic struct 패턴을 도입하면 가능하지만 Option-of-struct-by-value 전체 LLVM 인코딩 정리가 별도 작업.
- 본 PR에 포함 안 함, 후속.

## Test plan
- [x] IR-레벨 포커스 테스트 2개 추가 (`TestStdRegexReplaceRoutesToRuntime`, `TestStdRegexReplaceAllAndSplitRouteToRuntime`)
- [x] llvmgen short suite 통과
- [x] E2E 8 케이스 ([examples/regex_replace_split/main.osty](examples/regex_replace_split/main.osty)):
  - replace 첫 매치: `\d+` on `"a 1 b 22 c 333"` → `"a N b 22 c 333"`
  - replaceAll: → `"a N b N c N"`
  - 공백 collapse: `\s+` + `" "` 치환
  - devowel: `[aeiou]` + 빈 치환
  - no-match: 원문 그대로
  - split comma+ws: `,\s*` on `"a, b,c, d ,e"` → 5 elements
  - split no-match: single-element list
  - split empties: `,` on `,a,,b,` → `["", "a", "", "b", ""]`
- [x] Phase 1/2/2b 회귀 없음
- [ ] CI 그린 확인

## 다음
- Phase 3: `find` / `findAll` (Match struct 재료화 + Option 인코딩 정리)
- Phase 5: 명명 캡처 `(?P<name>...)` + `Captures.named`
- Phase 4 확장: replacement 내 `\$1` 백레퍼런스 지원

🤖 Generated with [Claude Code](https://claude.com/claude-code)