### PR TITLE
feat: regex Phase 3a — Regex.find returning Match?

### DIFF
--- a/examples/regex_find/main.osty
+++ b/examples/regex_find/main.osty
@@ -1,0 +1,65 @@
+use std.regex
+
+fn main() {
+    // Found match — fields populated.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            match re.find("hello 123 world 456") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("found: text='{t}' start={s} end={e}")
+                },
+                None -> println("found: no match"),
+            }
+        },
+        Err(_) -> println("digits compile failed"),
+    }
+
+    // No match — None branch.
+    match regex.compile(r"xyz") {
+        Ok(re) -> {
+            match re.find("hello world") {
+                Some(m) -> {
+                    let t = m.text
+                    println("nomatch: should not happen — got '{t}'")
+                },
+                None -> println("nomatch: correctly None"),
+            }
+        },
+        Err(_) -> println("xyz compile failed"),
+    }
+
+    // Anchored: matches at start only.
+    match regex.compile(r"^\w+") {
+        Ok(re) -> {
+            match re.find("hello world") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("anchored: text='{t}' start={s} end={e}")
+                },
+                None -> println("anchored: no match"),
+            }
+        },
+        Err(_) -> println("anchored compile failed"),
+    }
+
+    // Greedy: matches longest run.
+    match regex.compile(r"a+") {
+        Ok(re) -> {
+            match re.find("xxxaaaayy") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("greedy: text='{t}' start={s} end={e}")
+                },
+                None -> println("greedy: no match"),
+            }
+        },
+        Err(_) -> println("greedy compile failed"),
+    }
+}

--- a/examples/regex_find/osty.toml
+++ b/examples/regex_find/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_find"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -15741,6 +15741,63 @@ static void *osty_re_build_captures(int ngroups, const char *text, int text_len,
     return caps;
 }
 
+/* Phase 3a — find runtime contract:
+ *
+ * `osty_rt_regex_find(re, text)` returns a pointer to a 3-field xmalloc'd
+ * struct on match (NULL on no match). The struct mirrors the user-visible
+ * Match shape `{text: String, start: Int, end: Int}` exactly so the MIR
+ * shim can lift it into the synthetic `__osty_std_regex_Match` aggregate
+ * by loading three fields, then immediately calling
+ * `osty_rt_regex_match_free` to release the raw pointer.
+ *
+ * The raw struct is NOT GC-managed; the embedded String pointer IS
+ * (`osty_rt_string_dup_site` returns a GC string), but it must stay
+ * live only across the call/extract window before the shim parks it
+ * in a GC root. This mirrors the os.exec → ExecOutput pattern.
+ */
+typedef struct osty_rt_regex_match_raw {
+    void *text;
+    int64_t start;
+    int64_t end;
+} osty_rt_regex_match_raw;
+
+/* xmalloc lives further down (~line 20780) but is `static`; forward
+ * declare so the regex section, which sits earlier in the translation
+ * unit, can call it. */
+static void *osty_rt_xmalloc(size_t n, const char *site);
+
+void *osty_rt_regex_find(void *raw_re, const char *text) {
+    if (raw_re == NULL) {
+        osty_rt_abort("runtime.regex.find: nil Regex");
+    }
+    osty_regex_compiled *re = (osty_regex_compiled *)raw_re;
+    char inline_buf[8];
+    const char *src = text;
+    if (src == NULL) src = "";
+    osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
+    int len = (int)strlen(src);
+    int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
+    int slot_count = 2 * re->ngroups;
+    for (int i = 0; i < slot_count; i++) slots[i] = -1;
+    if (!osty_re_match_from(re, src, len, 0, slots)) {
+        return NULL;
+    }
+    int32_t start = slots[0];
+    int32_t end = slots[1];
+    if (start < 0 || end < 0 || end < start || end > len) {
+        return NULL;
+    }
+    osty_rt_regex_match_raw *out = (osty_rt_regex_match_raw *)osty_rt_xmalloc(sizeof(*out), "runtime.regex.find.raw");
+    out->text = osty_rt_string_dup_site(src + start, (size_t)(end - start), "runtime.regex.find.text");
+    out->start = (int64_t)start;
+    out->end = (int64_t)end;
+    return out;
+}
+
+void osty_rt_regex_match_free(void *raw) {
+    free(raw);
+}
+
 /* Phase 4 — replace / replaceAll / split helpers.
  *
  * `replace` / `replaceAll` produce a fresh String with non-overlapping

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -214,6 +214,7 @@ type mirGen struct {
 	stdCmdCommandTouched   bool // synthetic std.cmd Command payload used by MIR
 	stdCmdRunOutputTouched bool // synthetic std.cmd RunOutput payload used by MIR
 	stdCmdPipelineTouched  bool // synthetic std.cmd Pipeline payload used by MIR
+	stdRegexMatchTouched   bool // synthetic std.regex Match payload used by MIR
 
 	// Closure-env thunks generated on demand when a bare `FnConst`
 	// (top-level fn used as a value) reaches an indirect-call site.
@@ -727,7 +728,8 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			g.isStdOsExecOutputType(x) ||
 			g.isStdCmdCommandType(x) ||
 			g.isStdCmdRunOutputType(x) ||
-			g.isStdCmdPipelineType(x) {
+			g.isStdCmdPipelineType(x) ||
+			g.isStdRegexMatchType(x) {
 			return true
 		}
 		if strings.Contains(x.QualifiedName(), ".") {
@@ -1626,7 +1628,8 @@ func (g *mirGen) emitTypeDefs() {
 		!g.stdOsExecOutputTouched &&
 		!g.stdCmdCommandTouched &&
 		!g.stdCmdRunOutputTouched &&
-		!g.stdCmdPipelineTouched {
+		!g.stdCmdPipelineTouched &&
+		!g.stdRegexMatchTouched {
 		return
 	}
 
@@ -1656,6 +1659,9 @@ func (g *mirGen) emitTypeDefs() {
 	}
 	if g.stdOsExecOutputTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdOsSyntheticExecOutputTypeName, "i64, ptr, ptr, i1"))
+	}
+	if g.stdRegexMatchTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdRegexSyntheticMatchTypeName, "ptr, i64, i64"))
 	}
 	if g.stdCmdCommandTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdCmdSyntheticCommandTypeName, "ptr, ptr, ptr, ptr, i64, i1"))
@@ -9582,6 +9588,8 @@ func (g *mirGen) syntheticStdlibStructElementTypes(nt *ir.NamedType) ([]mir.Type
 		return []mir.Type{ir.TInt, ir.TString, ir.TString, ir.TBool}, true
 	case g.isStdCmdPipelineType(nt):
 		return []mir.Type{stdCmdCommandListType(), ir.TString, stdCmdStringMapType(), ir.TInt}, true
+	case g.isStdRegexMatchType(nt):
+		return []mir.Type{ir.TString, ir.TInt, ir.TInt}, true
 	default:
 		return nil, false
 	}
@@ -10126,6 +10134,16 @@ func (g *mirGen) projectionIndexForType(base mir.Type, p mir.Projection) (int, b
 					return 3, true
 				}
 			}
+			if g.isStdRegexMatchType(nt) {
+				switch fp.Name {
+				case "text":
+					return 0, true
+				case "start":
+					return 1, true
+				case "end":
+					return 2, true
+				}
+			}
 		}
 	}
 	return projectionIndex(p)
@@ -10635,6 +10653,10 @@ func (g *mirGen) llvmType(t mir.Type) string {
 			g.stdCmdPipelineTouched = true
 			return "%" + stdCmdSyntheticPipelineTypeName
 		}
+		if g.isStdRegexMatchType(x) {
+			g.stdRegexMatchTouched = true
+			return "%" + stdRegexSyntheticMatchTypeName
+		}
 		// Prelude Option / Maybe / Result. Mint an anonymous
 		// `%Option.<T>` / `%Result.<T>.<E>` so the IR carries the
 		// element type in its name — mimicking how the legacy
@@ -10754,6 +10776,23 @@ func (g *mirGen) isStdCmdPipelineType(t *ir.NamedType) bool {
 	}
 	q := t.QualifiedName()
 	return q == "Pipeline" || q == "std.cmd.Pipeline" || q == "cmd.Pipeline"
+}
+
+// isStdRegexMatchType recognises the user-facing `Match` struct from
+// regex.osty. A real user-declared struct elsewhere with the same name
+// (registered in Layouts.Structs) takes precedence; only the bare
+// stdlib variant routes through the synthetic Match aggregate.
+func (g *mirGen) isStdRegexMatchType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "Match" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "Match" || q == "std.regex.Match" || q == "regex.Match"
 }
 
 // ==== enum layout helpers ====

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1675,8 +1675,105 @@ func (g *mirGen) emitStdRegexCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, err
 			return true, err
 		}
 		return true, g.emitRuntimeCallToDest(c, ostyRtRegexSplitSymbol, "ptr", []mirRuntimeArg{recv, text})
+	case "find":
+		return g.emitStdRegexFindMIR(c)
 	}
 	return false, nil
+}
+
+// emitStdRegexFindMIR lowers `Regex.find(text) -> Match?`. Mirrors the
+// os.exec → Result<Output, Error> pattern: the runtime returns a raw
+// xmalloc'd `{ptr, i64, i64}` (NULL on no match), the shim loads the
+// three fields off the raw pointer, frees it, lifts them into the
+// synthetic `__osty_std_regex_Match` aggregate, then boxes the
+// aggregate onto the GC heap so the i64 payload of `Option<Match>`
+// can hold a ptrtoint of the box.
+func (g *mirGen) emitStdRegexFindMIR(c *mir.CallInstr) (bool, error) {
+	if len(c.Args) != 2 {
+		return true, unsupported("mir-mvp", "Regex.find requires receiver and text")
+	}
+	recv, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+	if err != nil {
+		return true, err
+	}
+	text, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+	if err != nil {
+		return true, err
+	}
+
+	g.declareRuntime(ostyRtRegexFindSymbol, mirRuntimeDeclareLine("ptr", ostyRtRegexFindSymbol, "ptr, ptr"))
+	g.declareRuntime(ostyRtRegexMatchFreeSymbol, mirRuntimeDeclareLine("void", ostyRtRegexMatchFreeSymbol, "ptr"))
+	raw := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtRegexFindSymbol, mirRuntimeArgList([]mirRuntimeArg{recv, text})))
+
+	if c.Dest == nil {
+		// Result discarded — still need to free the raw pointer so the
+		// xmalloc doesn't leak. Issue free guarded by NULL check.
+		g.emitStdRegexFindFreeIfNonNull(raw)
+		return true, nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return true, fmt.Errorf("mir-mvp: Regex.find dest into unknown local %d", c.Dest.Local)
+	}
+	optT, ok := destLoc.Type.(*ir.OptionalType)
+	if !ok {
+		return true, unsupported("mir-mvp", "Regex.find dest must be Option<Match>")
+	}
+	matchT := optT.Inner
+	optLLVM := g.llvmType(optT)
+
+	isNull := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqLine(isNull, "ptr", raw, "null"))
+	noneLabel := g.freshLabel("regex.find.none")
+	someLabel := g.freshLabel("regex.find.some")
+	contLabel := g.freshLabel("regex.find.cont")
+	g.fnBuf.WriteString(mirBrCondLine(isNull, noneLabel, someLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(noneLabel))
+	noneValue := g.emitOptionValue(optLLVM, false, "0")
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(someLabel))
+	textField := g.emitRecordFieldLoad(raw, stdRegexMatchRuntimeRecordLLVMType, "ptr", 0)
+	startField := g.emitRecordFieldLoad(raw, stdRegexMatchRuntimeRecordLLVMType, "i64", 1)
+	endField := g.emitRecordFieldLoad(raw, stdRegexMatchRuntimeRecordLLVMType, "i64", 2)
+	g.fnBuf.WriteString(mirCallVoidLine(ostyRtRegexMatchFreeSymbol, mirArgSlotPtr(raw)))
+	matchValue, err := g.buildAggregateValue(matchT, []mirRuntimeArg{
+		{typ: "ptr", val: textField},
+		{typ: "i64", val: startField},
+		{typ: "i64", val: endField},
+	})
+	if err != nil {
+		return true, err
+	}
+	payload, err := g.toI64Slot(matchValue, matchT)
+	if err != nil {
+		return true, err
+	}
+	someValue := g.emitOptionValue(optLLVM, true, payload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, optLLVM, noneValue, noneLabel, someValue, someLabel))
+	g.fnBuf.WriteString(mirStoreLine(optLLVM, phi, g.localSlots[c.Dest.Local]))
+	return true, nil
+}
+
+// emitStdRegexFindFreeIfNonNull guards the match_free call with a
+// NULL check — used when the call result is discarded. Without this
+// the runtime would crash on no-match (NULL passed to free).
+func (g *mirGen) emitStdRegexFindFreeIfNonNull(raw string) {
+	isNull := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqLine(isNull, "ptr", raw, "null"))
+	skipLabel := g.freshLabel("regex.find.skip")
+	freeLabel := g.freshLabel("regex.find.free")
+	g.fnBuf.WriteString(mirBrCondLine(isNull, skipLabel, freeLabel))
+	g.fnBuf.WriteString(mirLabelLine(freeLabel))
+	g.fnBuf.WriteString(mirCallVoidLine(ostyRtRegexMatchFreeSymbol, mirArgSlotPtr(raw)))
+	g.fnBuf.WriteString(mirBrUncondLine(skipLabel))
+	g.fnBuf.WriteString(mirLabelLine(skipLabel))
 }
 
 // emitStdRegexReplaceMIR shares the lowering for replace/replaceAll —

--- a/internal/llvmgen/stdlib_regex_shim.go
+++ b/internal/llvmgen/stdlib_regex_shim.go
@@ -14,7 +14,22 @@ const (
 	ostyRtRegexReplaceSymbol      = "osty_rt_regex_replace"
 	ostyRtRegexReplaceAllSymbol   = "osty_rt_regex_replace_all"
 	ostyRtRegexSplitSymbol        = "osty_rt_regex_split"
+	ostyRtRegexFindSymbol         = "osty_rt_regex_find"
+	ostyRtRegexMatchFreeSymbol    = "osty_rt_regex_match_free"
 )
+
+// Synthetic struct name mirroring the user-facing `Match` shape from
+// regex.osty (`{text: String, start: Int, end: Int}`). MIR allocates
+// it as a value-typed aggregate; Option<Match> boxes the aggregate
+// onto the GC heap and stores ptrtoint(box) into the enum payload —
+// same pattern os.exec uses for Result<Output, Error>.
+const stdRegexSyntheticMatchTypeName = "__osty_std_regex_Match"
+
+// stdRegexMatchRuntimeRecordLLVMType is the inline {ptr, i64, i64}
+// layout the runtime allocates via xmalloc. The MIR shim does
+// getelementptr/load on the three offsets before freeing the raw
+// pointer and lifting the values into the synthetic Match aggregate.
+const stdRegexMatchRuntimeRecordLLVMType = "{ ptr, i64, i64 }"
 
 var stdRegexStringListSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"List"},


### PR DESCRIPTION
## Summary
- `Regex.find(text) -> Match?` 구현. spec §10.9의 first-class Match 결과 (`{text, start, end}`) 노출.
- os.exec → ExecOutput 패턴을 그대로 따라간다 (synthetic struct value + GC 박싱):
  - 런타임 `osty_rt_regex_find`가 xmalloc `{ptr, i64, i64}` 반환 (NULL=no match)
  - MIR shim이 GEP+load로 3 필드 추출, raw 해제, synthetic `%__osty_std_regex_Match` aggregate 빌드
  - GC 박싱 후 `ptrtoint(box)`를 `Option<Match>` payload i64에 저장
  - `m.text` / `m.start` / `m.end`는 일반 struct field projection으로 접근 (synthetic Match가 `g.structsByName`에 등록돼 있어 normal path 활용)

## Phase 3b (findAll) 보류
- `List<Match>` 원소가 by-value 24-byte aggregate라 List 런타임의 element-size + GC offset metadata 추가가 별도 작업
- 본 PR 범위 밖, 후속 진행

## Test plan
- [x] llvmgen short suite 통과
- [x] E2E ([examples/regex_find/main.osty](examples/regex_find/main.osty)) 4 케이스:
  - `\d+` on `"hello 123 world 456"` → `text='123' start=6 end=9`
  - `xyz` on `"hello world"` → `None`
  - `^\w+` on `"hello world"` → `text='hello' start=0 end=5`
  - `a+` on `"xxxaaaayy"` → `text='aaaa' start=3 end=7` (greedy)
- [x] Phase 1/2/2b/4 회귀 없음 (regex_smoke / regex_captures / regex_captures_all / regex_replace_split / uuid_smoke 모두 정상)
- [x] `just fmt-check` / `just vet` clean
- [ ] CI 그린 확인

## std.regex 현재 상태

| API | 상태 |
|---|---|
| `compile`, `Regex.matches` | ✓ Phase 1 |
| `Regex.captures` / `Captures.get` | ✓ Phase 2 |
| `Regex.capturesAll` | ✓ Phase 2b |
| `Regex.replace` / `replaceAll` / `split` | ✓ Phase 4 |
| **`Regex.find`** | **✓ Phase 3a (이번 PR)** |
| `Regex.findAll` | Phase 3b — List<Match> by-value layout 작업 |
| 명명 캡처 `(?P<name>...)` / `Captures.named` | Phase 5 |
| backref `$1` in replacement | 후속 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)