### PR TITLE
refactor: ONB dev backend 정리 — TimingPath 타입화 + 로거 통합

### DIFF
--- a/internal/backend/onb.go
+++ b/internal/backend/onb.go
@@ -45,45 +45,36 @@ func (b ONBBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if err := ValidateEmit(NameONB, req.Emit); err != nil {
 		return nil, err
 	}
+
 	started := time.Now()
-	target, _ := onb.ResolveTarget(req.Layout.Target)
-	logSink := b.timingSink()
 	timingOn := onb.TimingEnabled()
+	ev := onb.TimingEvent{}
+	if timingOn {
+		target, _ := onb.ResolveTarget(req.Layout.Target)
+		ev.Target = target.Triple
+		defer func() {
+			ev.Elapsed = time.Since(started)
+			onb.LogTiming(b.timingSink(), ev)
+		}()
+	}
+
 	result, err := b.emitNative(ctx, req)
 	if err == nil {
-		if timingOn {
-			onb.LogTiming(logSink, onb.TimingEvent{
-				Path:     "native",
-				Target:   target.Triple,
-				Elapsed:  time.Since(started),
-				BinaryAt: result.Artifacts.Binary,
-			})
-		}
+		ev.Path = onb.TimingPathNative
+		ev.BinaryAt = result.Artifacts.Binary
 		return result, nil
 	}
 	if !b.shouldFallback(req, err) {
-		if timingOn {
-			onb.LogTiming(logSink, onb.TimingEvent{
-				Path:    "error",
-				Target:  target.Triple,
-				Elapsed: time.Since(started),
-				Reason:  fallbackReason(err),
-			})
-		}
+		ev.Path = onb.TimingPathError
+		ev.Reason = onb.UnsupportedShapeReason(err)
 		return result, err
 	}
 	fallback, fallbackErr := b.runLLVMFallback(ctx, req, err)
-	if timingOn {
-		path := "llvm-fallback"
-		if fallbackErr != nil {
-			path = "error"
-		}
-		onb.LogTiming(logSink, onb.TimingEvent{
-			Path:    path,
-			Target:  target.Triple,
-			Elapsed: time.Since(started),
-			Reason:  fallbackReason(err),
-		})
+	ev.Reason = onb.UnsupportedShapeReason(err)
+	if fallbackErr != nil {
+		ev.Path = onb.TimingPathError
+	} else {
+		ev.Path = onb.TimingPathLLVMFallback
 	}
 	return fallback, fallbackErr
 }
@@ -176,8 +167,7 @@ func (b ONBBackend) shouldFallback(req Request, err error) bool {
 func (b ONBBackend) runLLVMFallback(ctx context.Context, req Request, onbErr error) (*Result, error) {
 	llvm := b.llvmBackend()
 	result, err := llvm.Emit(ctx, req)
-	reason := fallbackReason(onbErr)
-	note := fmt.Errorf("onb fallback: lowering delegated to llvm (%s)", reason)
+	note := fmt.Errorf("onb fallback: lowering delegated to llvm (%s)", onb.UnsupportedShapeReason(onbErr))
 	if result == nil {
 		return result, err
 	}
@@ -204,20 +194,4 @@ func (b ONBBackend) timingSink() io.Writer {
 		return b.logSink
 	}
 	return os.Stderr
-}
-
-// fallbackReason peels the onb sentinel off so the log line and the warning
-// note both quote a short user-readable string rather than the wrapped error
-// chain. The shape sentinel's message is generic, so we strip it when there
-// is a more specific wrapped detail.
-func fallbackReason(err error) string {
-	if err == nil {
-		return ""
-	}
-	msg := err.Error()
-	prefix := onb.ErrUnsupportedShape.Error() + ": "
-	if len(msg) > len(prefix) && msg[:len(prefix)] == prefix {
-		return msg[len(prefix):]
-	}
-	return msg
 }

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -267,34 +267,23 @@ func (r *recordingBackend) Emit(_ context.Context, req Request) (*Result, error)
 	return nil, r.err
 }
 
-// onbDevTestEnv guards the OSTY_ONB_* env vars so each test starts from a
-// known-clean baseline regardless of what the developer has exported in
-// their shell. Using t.Setenv would conflict with t.Parallel here.
+// onbDevTestEnv pins OSTY_ONB_* to known values for one test. t.Setenv handles
+// snapshot/restore via t.Cleanup; the previous hand-rolled save/restore here
+// existed because we anticipated t.Parallel, but none of the dev-loop tests
+// run in parallel (the backend lifecycle is serialised by Go's test runner
+// for env var safety anyway).
 func onbDevTestEnv(t *testing.T, strict bool, timing bool) {
 	t.Helper()
-	prevStrict := os.Getenv(onb.EnvStrict)
-	prevTiming := os.Getenv(onb.EnvTiming)
-	set := func(key, val string) {
-		if val == "" {
-			os.Unsetenv(key)
-			return
-		}
-		os.Setenv(key, val)
-	}
 	if strict {
-		set(onb.EnvStrict, "1")
+		t.Setenv(onb.EnvStrict, "1")
 	} else {
-		set(onb.EnvStrict, "")
+		t.Setenv(onb.EnvStrict, "")
 	}
 	if timing {
-		set(onb.EnvTiming, "1")
+		t.Setenv(onb.EnvTiming, "1")
 	} else {
-		set(onb.EnvTiming, "")
+		t.Setenv(onb.EnvTiming, "")
 	}
-	t.Cleanup(func() {
-		set(onb.EnvStrict, prevStrict)
-		set(onb.EnvTiming, prevTiming)
-	})
 }
 
 func TestONBBackendFallsBackToLLVMOnUnsupportedShape(t *testing.T) {

--- a/internal/onb/dev.go
+++ b/internal/onb/dev.go
@@ -1,6 +1,7 @@
 package onb
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,14 +25,18 @@ const EnvTiming = "OSTY_ONB_TIMING"
 // silently delegate to the LLVM backend. Reading the env on every call keeps
 // the toggle responsive to inline `OSTY_ONB_STRICT=1 osty run ...` invocations
 // without process restart.
-func StrictMode() bool { return envTrue(os.Getenv(EnvStrict)) }
+func StrictMode() bool { return EnvTrue(os.Getenv(EnvStrict)) }
 
 // TimingEnabled mirrors StrictMode for the timing log. Two separate env vars
 // keep the strict cross-validation flow independent from the dev-loop perf
 // telemetry.
-func TimingEnabled() bool { return envTrue(os.Getenv(EnvTiming)) }
+func TimingEnabled() bool { return EnvTrue(os.Getenv(EnvTiming)) }
 
-func envTrue(s string) bool {
+// EnvTrue reports whether the env-var-style string s should be treated as
+// "enabled". Exported so other backend toggles (`OSTY_BACKEND_TRACE`, future
+// debug flags) can reuse the same parsing rules — keeping accepted spellings
+// in lockstep across packages.
+func EnvTrue(s string) bool {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "1", "true", "yes", "on":
 		return true
@@ -40,12 +45,21 @@ func envTrue(s string) bool {
 	}
 }
 
+// TimingPath names which build path actually ran for one ONB emit attempt.
+// Typed instead of bare strings so a typo in a future call site is a compile
+// error rather than a silent default-branch in LogTiming.
+type TimingPath string
+
+const (
+	TimingPathNative       TimingPath = "native"
+	TimingPathLLVMFallback TimingPath = "llvm-fallback"
+	TimingPathError        TimingPath = "error"
+)
+
 // TimingEvent describes one ONB build path so callers can render a stable log
-// line. Path is "native" when ONB lowered the MIR end-to-end, "llvm-fallback"
-// when the backend layer delegated to LLVM after a shape rejection, or
-// "error" when neither path produced an artifact.
+// line.
 type TimingEvent struct {
-	Path     string
+	Path     TimingPath
 	Target   string
 	Elapsed  time.Duration
 	Reason   string
@@ -63,26 +77,44 @@ func LogTiming(w io.Writer, ev TimingEvent) {
 	if target == "" {
 		target = "host"
 	}
-	suffix := ""
+	var suffix string
 	switch ev.Path {
-	case "native":
+	case TimingPathNative:
 		suffix = fmt.Sprintf("[native: %s]", target)
-	case "llvm-fallback":
+	case TimingPathLLVMFallback:
 		reason := ev.Reason
 		if reason == "" {
 			reason = "shape unsupported"
 		}
 		suffix = fmt.Sprintf("[fallback to llvm: %s]", reason)
-	case "error":
+	case TimingPathError:
 		reason := ev.Reason
 		if reason == "" {
 			reason = "rejected"
 		}
 		suffix = fmt.Sprintf("[error: %s]", reason)
 	default:
-		suffix = "[" + ev.Path + "]"
+		suffix = "[" + string(ev.Path) + "]"
 	}
 	fmt.Fprintf(w, "onb: emit %s %s\n", formatElapsed(ev.Elapsed), suffix)
+}
+
+// UnsupportedShapeReason peels the ErrUnsupportedShape sentinel off so callers
+// can quote the specific MIR construct that triggered the fallback without
+// also surfacing the generic sentinel message. Returns the input error's
+// string verbatim when the sentinel is not present.
+//
+// Owning the prefix-strip here keeps the sentinel's textual format private to
+// the onb package — backend/onb.go consumed to do this manually, which made
+// the message text an implicit ABI between the two packages.
+func UnsupportedShapeReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if !errors.Is(err, ErrUnsupportedShape) {
+		return err.Error()
+	}
+	return strings.TrimPrefix(err.Error(), ErrUnsupportedShape.Error()+": ")
 }
 
 func formatElapsed(d time.Duration) string {


### PR DESCRIPTION
## Summary
A1 follow-up cleanup (이전 PR #1186에 대한 simplify 리뷰 결과 반영):

- `TimingEvent.Path`를 `TimingPath` 타입 + 3개 상수 (`TimingPathNative` / `TimingPathLLVMFallback` / `TimingPathError`)로 변경. 호출 사이트 magic string typo가 컴파일 에러로 잡힘.
- `ONBBackend.Emit`의 3개 timing-log 브랜치를 deferred 클로저로 통합. 미래에 4번째 경로 추가될 때 로그 사이트 빠뜨릴 위험 제거.
- `fallbackReason`을 `internal/onb`로 이동 (`UnsupportedShapeReason`). sentinel 메시지 포맷이 onb 패키지 내부 디테일로 캡슐화됨. `strings.TrimPrefix`로 단순화.
- `onbDevTestEnv` 헬퍼를 `t.Setenv`로 교체. 원래 `t.Parallel` 우려로 hand-roll했지만 실제로 어느 테스트도 `t.Parallel` 안 씀.

기능 변경 없음. 모든 13개 ONB 테스트 그린.

## Test plan
- [x] `go vet ./internal/onb/... ./internal/backend/...` 통과
- [x] `go test ./internal/onb/ ./internal/backend/ -short` 통과
- [x] `TestONBBackend*` 13개 모두 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)