### PR TITLE
feat: LIR Proto Option/Result inspection intrinsics + raw.null

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -846,6 +846,29 @@ deliberately identical — variation lives entirely in
 `lirNextLoopMD` property selection surfaces in exactly one
 fixture each.
 
+Design decision: the disc-tag inspection intrinsics
+(`OptionIsSome`, `OptionIsNone`, `ResultIsOk`, `ResultIsErr`)
+plus `RawNull` (LANG_SPEC §19) land as a paired LIR Proto +
+fixture batch. The four disc checks all reduce to the same
+shape — `extractvalue %Algebraic.<...>, 0` on the i64 disc
+field then `icmp ne` (present-tag) or `icmp eq` (absent-tag)
+against `0` — so a single helper `lirLowerMirAlgebraicTagCheck(l,
+instr, cmp, label)` covers all four; the dispatcher passes
+`"ne"` for IsSome/IsOk and `"eq"` for IsNone/IsErr. `RawNull`
+is the trivial constant case: no operand, no extractvalue, no
+compare — just `store ptr null` into the dest local. Mirrors
+production `emitOptionIntrinsic` / `emitResultIntrinsic` /
+`emitRuntimeRawNull`.
+
+Five Phase-4 fixtures pin the new shape:
+`option_is_some` / `option_is_none` (each takes `Option<Int>`
+param → returns Bool, pin Option.Int aggregate def + extractvalue
++ correct icmp predicate), `result_is_ok` / `result_is_err`
+(each takes `Result<Int, Error>` param → returns Bool, same
+shape with Result.Int_Error aggregate), and `raw_null` (no
+params → returns RawPtr, pins `define ptr @rawNull()` +
+`store ptr null` + `ret ptr`).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -401,6 +401,12 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualLoopMDUnrollEnableBareFixture", []string{"!{!\"llvm.loop.unroll.enable\", i1 true}", ", !llvm.loop !"}},
 		{"lirParityManualLoopMDCombinedVectorizeUnrollFixture", []string{"!{!\"llvm.loop.vectorize.enable\", i1 true}", "!{!\"llvm.loop.unroll.count\", i32 2}", ", !llvm.loop !"}},
 		{"lirParityManualLoopMDParallelOnlyFixture", []string{"= distinct !{}", "!{!\"llvm.loop.parallel_accesses\", !", ", !llvm.loop !"}},
+		// ----- Option / Result inspection intrinsics + RawNull -----
+		{"lirParityManualOptionIsSomeFixture", []string{"%Option.Int = type", "extractvalue %Option.Int", "icmp ne i64", "ret i1"}},
+		{"lirParityManualOptionIsNoneFixture", []string{"%Option.Int = type", "extractvalue %Option.Int", "icmp eq i64", "ret i1"}},
+		{"lirParityManualResultIsOkFixture", []string{"%Result.Int_Error = type", "extractvalue %Result.Int_Error", "icmp ne i64", "ret i1"}},
+		{"lirParityManualResultIsErrFixture", []string{"%Result.Int_Error = type", "extractvalue %Result.Int_Error", "icmp eq i64", "ret i1"}},
+		{"lirParityManualRawNullFixture", []string{"define ptr @rawNull()", "store ptr null", "ret ptr"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2262,6 +2262,11 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicBytesLastIndexOf -> lirLowerMirIndexOf(l, instr, mirRtBytesSymbol("last_index_of"), [lirPtrType(), lirPtrType()], "bytes.lastIndexOf"),
         MirIntrinsicStringToInt -> lirLowerMirStringParse(l, instr, mirRtStringIsValidIntSymbol(), mirRtStringToIntSymbol(), lirIntType(64), "string.toInt"),
         MirIntrinsicStringToFloat -> lirLowerMirStringParse(l, instr, mirRtStringIsValidFloatSymbol(), mirRtStringToFloatSymbol(), lirFloatType("double"), "string.toFloat"),
+        MirIntrinsicOptionIsSome -> lirLowerMirAlgebraicTagCheck(l, instr, "ne", "option.isSome"),
+        MirIntrinsicOptionIsNone -> lirLowerMirAlgebraicTagCheck(l, instr, "eq", "option.isNone"),
+        MirIntrinsicResultIsOk -> lirLowerMirAlgebraicTagCheck(l, instr, "ne", "result.isOk"),
+        MirIntrinsicResultIsErr -> lirLowerMirAlgebraicTagCheck(l, instr, "eq", "result.isErr"),
+        MirIntrinsicRawNull -> lirLowerMirRawNull(l, instr),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
@@ -4034,6 +4039,51 @@ fn lirLowerMirStringParse(l: LirMirFunctionLowerer, instr: MirInstr, validateSym
     let merged = lirFresh(l)
     l.instrs.push(lirLoad(merged, resultType, slot, 0))
     lirStoreMirResult(l, instr.dest, lirOperand(resultType, merged), loc.typ, label + " result")
+}
+// `lirLowerMirAlgebraicTagCheck` lowers Option / Result discriminator
+// inspection (`is_some` / `is_none` / `is_ok` / `is_err`). The four
+// intrinsics share the same shape: extract the i64 disc field at index
+// 0 of the `%Option.<T>` / `%Result.<T>_<E>` aggregate and icmp it
+// against `0`. `cmp` is `"ne"` for the present-tag intrinsics
+// (IsSome / IsOk; disc==1 → true) and `"eq"` for the absent-tag
+// intrinsics (IsNone / IsErr; disc==0 → true). Mirrors production
+// `emitOptionIntrinsic` / `emitResultIntrinsic`
+// (mir_generator.go:5283-5294 / similar Result block).
+fn lirLowerMirAlgebraicTagCheck(l: LirMirFunctionLowerer, instr: MirInstr, cmp: String, label: String) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects (option|result)", label)
+        return
+    }
+    let aggType = lirLowerMirType(l, instr.args[0].typ)
+    if lirTypeIsZero(aggType) {
+        lirLowerError(l, LirDiagUnsupported, label + " operand type `" + instr.args[0].typ + "` is not implemented", label)
+        return
+    }
+    let aggValue = lirLowerMirOperand(l, instr.args[0], instr.args[0].typ, aggType)
+    if aggValue.value == "" {
+        return
+    }
+    let discReg = lirFresh(l)
+    l.instrs.push(lirExtractValue(discReg, aggType, aggValue.value, [0]))
+    let cmpDest = lirFresh(l)
+    l.instrs.push(lirBinary(cmpDest, "icmp " + cmp, lirIntType(64), discReg, "0"))
+    if instr.hasDest {
+        lirStoreMirResult(l, instr.dest, lirOperand(lirIntType(1), cmpDest), "Bool", label + " result")
+    }
+}
+// `lirLowerMirRawNull` lowers LANG_SPEC §19's `raw.null()` to the LLVM
+// `ptr null` constant. No runtime call, no extra instructions —
+// just store `null` of `ptr` type into the dest local. Mirrors
+// production `emitRuntimeRawNull` (mir_generator.go:10956-10961).
+fn lirLowerMirRawNull(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 0 {
+        lirLowerError(l, LirDiagInvalidInput, "raw.null() takes no arguments", "raw.null")
+        return
+    }
+    if !(instr.hasDest) {
+        return
+    }
+    lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), "null"), "RawPtr", "raw.null result")
 }
 // Widen a parsed scalar (i64 / double / i32 / i8 / i1) into the i64
 // the Ok payload slot uses. Production widens the same way

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -602,6 +602,21 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "loop_md_parallel_only" {
         return lirParityBuildLoopMDParallelOnlyModule()
+    }
+    if name == "option_is_some" {
+        return lirParityBuildOptionIsSomeModule()
+    }
+    if name == "option_is_none" {
+        return lirParityBuildOptionIsNoneModule()
+    }
+    if name == "result_is_ok" {
+        return lirParityBuildResultIsOkModule()
+    }
+    if name == "result_is_err" {
+        return lirParityBuildResultIsErrModule()
+    }
+    if name == "raw_null" {
+        return lirParityBuildRawNullModule()
     }
     mirModule("main")
 }
@@ -1981,5 +1996,74 @@ pub fn lirParityBuildLoopMDParallelOnlyModule() -> MirModule {
     let body = mirFunctionNewBlock(fn_, mirNoSpan())
     mirFunctionTerminate(fn_, entry, mirGotoTerm(body, mirNoSpan()))
     mirFunctionTerminate(fn_, body, mirGotoBackEdgeTerm(body, mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Option / Result inspection intrinsics + RawNull
+// ====================================================================
+//
+// Five fixtures pin the disc-tag inspection intrinsics
+// (OptionIsSome / IsNone / ResultIsOk / IsErr) plus the
+// LANG_SPEC §19 raw.null() constant intrinsic.
+//
+// The four disc checks all share the same shape: extract the i64
+// at index 0 of the `%Option.<T>` / `%Result.<T>_<E>` aggregate and
+// icmp `ne 0` (IsSome / IsOk) or `eq 0` (IsNone / IsErr). raw.null
+// degenerates to a `store ptr null` with no extract or compare.
+pub fn lirParityManualOptionIsSomeFixture() -> LirParityFixture {
+    lirParityFixture("option_is_some", LirParityManualMIR, "/tmp/lir_proto_parity_option_is_some.osty", "", "phase4-option", ["option", "is-some"], [lirParityNeedle("%Option.Int = type", "Option<Int> aggregate def"), lirParityNeedle("extractvalue %Option.Int", "extract disc field"), lirParityNeedle("icmp ne i64", "ne-against-zero compare for present-tag"), lirParityNeedle("ret i1", "Bool return")])
+}
+pub fn lirParityManualOptionIsNoneFixture() -> LirParityFixture {
+    lirParityFixture("option_is_none", LirParityManualMIR, "/tmp/lir_proto_parity_option_is_none.osty", "", "phase4-option", ["option", "is-none"], [lirParityNeedle("%Option.Int = type", "Option<Int> aggregate def"), lirParityNeedle("extractvalue %Option.Int", "extract disc field"), lirParityNeedle("icmp eq i64", "eq-against-zero compare for absent-tag"), lirParityNeedle("ret i1", "Bool return")])
+}
+pub fn lirParityManualResultIsOkFixture() -> LirParityFixture {
+    lirParityFixture("result_is_ok", LirParityManualMIR, "/tmp/lir_proto_parity_result_is_ok.osty", "", "phase4-result", ["result", "is-ok"], [lirParityNeedle("%Result.Int_Error = type", "Result<Int,Error> aggregate def"), lirParityNeedle("extractvalue %Result.Int_Error", "extract disc field"), lirParityNeedle("icmp ne i64", "ne-against-zero compare for present-tag"), lirParityNeedle("ret i1", "Bool return")])
+}
+pub fn lirParityManualResultIsErrFixture() -> LirParityFixture {
+    lirParityFixture("result_is_err", LirParityManualMIR, "/tmp/lir_proto_parity_result_is_err.osty", "", "phase4-result", ["result", "is-err"], [lirParityNeedle("%Result.Int_Error = type", "Result<Int,Error> aggregate def"), lirParityNeedle("extractvalue %Result.Int_Error", "extract disc field"), lirParityNeedle("icmp eq i64", "eq-against-zero compare for absent-tag"), lirParityNeedle("ret i1", "Bool return")])
+}
+pub fn lirParityManualRawNullFixture() -> LirParityFixture {
+    lirParityFixture("raw_null", LirParityManualMIR, "/tmp/lir_proto_parity_raw_null.osty", "", "phase4-raw", ["raw", "null"], [lirParityNeedle("define ptr @rawNull()", "raw.null returning ptr"), lirParityNeedle("store ptr null", "null pointer constant stored to slot"), lirParityNeedle("ret ptr", "raw pointer return")])
+}
+// Module builders — each takes an Option<Int> / Result<Int,Error>
+// param and returns Bool, except raw.null which takes nothing and
+// returns a RawPtr.
+pub fn lirParityBuildOptionIsSomeModule() -> MirModule {
+    let mut fn_ = lirParityFunction("optIsSome", "Bool")
+    let opt = lirParityParam(fn_, "o", "Option<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicOptionIsSome, [mirOperandCopy(mirPlace(opt), "Option<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildOptionIsNoneModule() -> MirModule {
+    let mut fn_ = lirParityFunction("optIsNone", "Bool")
+    let opt = lirParityParam(fn_, "o", "Option<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicOptionIsNone, [mirOperandCopy(mirPlace(opt), "Option<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildResultIsOkModule() -> MirModule {
+    let mut fn_ = lirParityFunction("resIsOk", "Bool")
+    let r = lirParityParam(fn_, "r", "Result<Int, Error>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicResultIsOk, [mirOperandCopy(mirPlace(r), "Result<Int, Error>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildResultIsErrModule() -> MirModule {
+    let mut fn_ = lirParityFunction("resIsErr", "Bool")
+    let r = lirParityParam(fn_, "r", "Result<Int, Error>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicResultIsErr, [mirOperandCopy(mirPlace(r), "Result<Int, Error>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildRawNullModule() -> MirModule {
+    let mut fn_ = lirParityFunction("rawNull", "RawPtr")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicRawNull, [], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary
- Lands five MIR intrinsics that previously fell through the unsupported wildcard in \`lirLowerMirIntrinsic\`: \`OptionIsSome\` / \`OptionIsNone\` / \`ResultIsOk\` / \`ResultIsErr\` (disc-tag check on the algebraic aggregate) and \`RawNull\` (LANG_SPEC §19 \`raw.null()\` constant).
- The four disc checks share a single helper \`lirLowerMirAlgebraicTagCheck(l, instr, cmp, label)\` — \`extractvalue\` index 0, then \`icmp ne 0\` (present) or \`icmp eq 0\` (absent). Mirrors production \`emitOptionIntrinsic\` / \`emitResultIntrinsic\`.
- RawNull is the trivial constant case: \`store ptr null\` into dest local. Mirrors \`emitRuntimeRawNull\`.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` passes (incl. 5 new fixtures).
- [ ] CI green on the fast lanes.

## Fixtures
- \`option_is_some\` / \`option_is_none\` — Option<Int> → Bool; pin aggregate def + extractvalue + correct icmp predicate.
- \`result_is_ok\` / \`result_is_err\` — Result<Int,Error> → Bool; same shape on Result.Int_Error aggregate.
- \`raw_null\` — () → RawPtr; pins \`define ptr @rawNull()\` + \`store ptr null\` + \`ret ptr\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)