### PR TITLE
feat: LIR Proto ListSlice/ListToSet/StringFields/StringSplitN

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -869,6 +869,35 @@ shape with Result.Int_Error aggregate), and `raw_null` (no
 params → returns RawPtr, pins `define ptr @rawNull()` +
 `store ptr null` + `ret ptr`).
 
+Design decision: the next batch lands four more MIR intrinsics
+that previously fell through the unsupported wildcard, all of
+which reduce to runtime ABI calls with no extra logic:
+
+- `MirIntrinsicListSlice` → `osty_rt_list_slice(ptr, i64, i64)`.
+  Element-agnostic (memcpy by elem_size) so a single dispatch
+  case via `lirLowerMirStringRuntimeCall` (the existing
+  fixed-signature runtime call helper) covers every `List<T>`.
+- `MirIntrinsicListToSet` → per-element-lane runtime
+  (`osty_rt_list_to_set_<i64|i1|f64|ptr|string>`). Picked by
+  `llvmListRuntimeToSetSymbol(elemLLVM, isString)` from
+  `toolchain/llvmgen.osty` — same selector production uses.
+  A small `lirLowerMirListToSet` helper extracts the element
+  type via `lirLowerMirContainerReceiver` then emits one ptr
+  call.
+- `MirIntrinsicStringFields` → `osty_rt_strings_Fields(ptr) → ptr`.
+  Whitespace-split-into-words: trivial 1-arg ptr call.
+- `MirIntrinsicStringSplitN` → `osty_rt_strings_SplitN(ptr, ptr, i64) → ptr`.
+  Limited-N split: 3-arg call returning `List<String>`.
+
+Five Phase-4 fixtures pin each shape:
+`list_slice` (List<Int> sliced [0..3) → pins runtime decl + call
++ `ret ptr`), `list_to_set_i64` and `list_to_set_string` (the
+two most common `llvmListRuntimeToSetSymbol` branches —
+enforces both the scalar and string-lane symbols are emitted
+correctly), `string_fields` (no-arg `Fields` call returning a
+List<String>), and `string_split_n` (3-arg `SplitN` call with
+String/String/Int param signature).
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -407,6 +407,12 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualResultIsOkFixture", []string{"%Result.Int_Error = type", "extractvalue %Result.Int_Error", "icmp ne i64", "ret i1"}},
 		{"lirParityManualResultIsErrFixture", []string{"%Result.Int_Error = type", "extractvalue %Result.Int_Error", "icmp eq i64", "ret i1"}},
 		{"lirParityManualRawNullFixture", []string{"define ptr @rawNull()", "store ptr null", "ret ptr"}},
+		// ----- Element-agnostic List runtime + per-lane List.toSet + String split/fields -----
+		{"lirParityManualListSliceFixture", []string{"declare ptr @osty_rt_list_slice(ptr, i64, i64)", "call ptr @osty_rt_list_slice(", "ret ptr"}},
+		{"lirParityManualListToSetI64Fixture", []string{"declare ptr @osty_rt_list_to_set_i64(ptr)", "call ptr @osty_rt_list_to_set_i64(", "ret ptr"}},
+		{"lirParityManualListToSetStringFixture", []string{"declare ptr @osty_rt_list_to_set_string(ptr)", "call ptr @osty_rt_list_to_set_string(", "ret ptr"}},
+		{"lirParityManualStringFieldsFixture", []string{"declare ptr @osty_rt_strings_Fields(ptr)", "call ptr @osty_rt_strings_Fields(", "ret ptr"}},
+		{"lirParityManualStringSplitNFixture", []string{"declare ptr @osty_rt_strings_SplitN(ptr, ptr, i64)", "call ptr @osty_rt_strings_SplitN(", "ret ptr"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2267,6 +2267,10 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicResultIsOk -> lirLowerMirAlgebraicTagCheck(l, instr, "ne", "result.isOk"),
         MirIntrinsicResultIsErr -> lirLowerMirAlgebraicTagCheck(l, instr, "eq", "result.isErr"),
         MirIntrinsicRawNull -> lirLowerMirRawNull(l, instr),
+        MirIntrinsicListSlice -> lirLowerMirStringRuntimeCall(l, instr, mirRtListSymbol("slice"), lirPtrType(), [lirPtrType(), lirIntType(64), lirIntType(64)], "list.slice"),
+        MirIntrinsicListToSet -> lirLowerMirListToSet(l, instr),
+        MirIntrinsicStringFields -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringSymbol("Fields"), lirPtrType(), [lirPtrType()], "string.fields"),
+        MirIntrinsicStringSplitN -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringSymbol("SplitN"), lirPtrType(), [lirPtrType(), lirPtrType(), lirIntType(64)], "string.splitN"),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
@@ -4084,6 +4088,36 @@ fn lirLowerMirRawNull(l: LirMirFunctionLowerer, instr: MirInstr) {
         return
     }
     lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), "null"), "RawPtr", "raw.null result")
+}
+// `lirLowerMirListToSet` selects the per-element-lane runtime entry
+// (`osty_rt_list_to_set_<i64|i1|f64|ptr|string>`) and emits a single
+// `ptr` call. Production picks the same symbol via
+// `listRuntimeToSetSymbol`/`llvmListRuntimeToSetSymbol`
+// (toolchain/llvmgen.osty:3172). The receiver-type extraction reuses
+// `lirLowerMirContainerReceiver` so the `List<T>` element name parsing
+// path is shared with every other List intrinsic.
+fn lirLowerMirListToSet(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 1 {
+        lirLowerError(l, LirDiagInvalidInput, "list.toSet expects (list)", "list.toSet")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "list.toSet", "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    let symbol = llvmListRuntimeToSetSymbol(recv.elemLir.llvm, recv.isString)
+    if symbol == "" {
+        lirLowerError(l, LirDiagUnsupported, "list.toSet element type `" + recv.elemTypeName + "` has no runtime conversion", "list.toSet")
+        return
+    }
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirPtrType(), [lirPtrType()], false))
+    if !(instr.hasDest) {
+        l.instrs.push(lirCall("", lirPtrType(), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg)]))
+        return
+    }
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, lirPtrType(), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg)]))
+    lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), dest), "Set<" + recv.elemTypeName + ">", "list.toSet result")
 }
 // Widen a parsed scalar (i64 / double / i32 / i8 / i1) into the i64
 // the Ok payload slot uses. Production widens the same way

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture(), lirParityManualListSliceFixture(), lirParityManualListToSetI64Fixture(), lirParityManualListToSetStringFixture(), lirParityManualStringFieldsFixture(), lirParityManualStringSplitNFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -617,6 +617,21 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "raw_null" {
         return lirParityBuildRawNullModule()
+    }
+    if name == "list_slice" {
+        return lirParityBuildListSliceModule()
+    }
+    if name == "list_to_set_i64" {
+        return lirParityBuildListToSetI64Module()
+    }
+    if name == "list_to_set_string" {
+        return lirParityBuildListToSetStringModule()
+    }
+    if name == "string_fields" {
+        return lirParityBuildStringFieldsModule()
+    }
+    if name == "string_split_n" {
+        return lirParityBuildStringSplitNModule()
     }
     mirModule("main")
 }
@@ -2064,6 +2079,79 @@ pub fn lirParityBuildRawNullModule() -> MirModule {
     let mut fn_ = lirParityFunction("rawNull", "RawPtr")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicRawNull, [], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// Element-agnostic List runtime + per-lane List.toSet + String split/fields
+// ====================================================================
+//
+// Five fixtures pinning runtime ABI calls for intrinsics that
+// previously fell through the unsupported wildcard:
+//
+//   * list_slice              — osty_rt_list_slice(ptr, i64, i64)
+//   * list_to_set_i64         — osty_rt_list_to_set_i64 (scalar lane)
+//   * list_to_set_string      — osty_rt_list_to_set_string (string lane)
+//   * string_fields           — osty_rt_strings_Fields(ptr)
+//   * string_split_n          — osty_rt_strings_SplitN(ptr, ptr, i64)
+//
+// list_slice is element-agnostic (memcpy by elem_size) so a single
+// fixture covers it. list_to_set splits by element-LLVM-type lane;
+// the i64 + string fixtures are the two most common production
+// paths and exercise both branches of `llvmListRuntimeToSetSymbol`.
+pub fn lirParityManualListSliceFixture() -> LirParityFixture {
+    lirParityFixture("list_slice", LirParityManualMIR, "/tmp/lir_proto_parity_list_slice.osty", "", "phase4-list", ["list", "slice"], [lirParityNeedle("declare ptr @osty_rt_list_slice(ptr, i64, i64)", "list slice runtime"), lirParityNeedle("call ptr @osty_rt_list_slice(", "list slice call"), lirParityNeedle("ret ptr", "list return")])
+}
+pub fn lirParityManualListToSetI64Fixture() -> LirParityFixture {
+    lirParityFixture("list_to_set_i64", LirParityManualMIR, "/tmp/lir_proto_parity_list_to_set_i64.osty", "", "phase4-list", ["list", "to-set", "scalar"], [lirParityNeedle("declare ptr @osty_rt_list_to_set_i64(ptr)", "list_to_set i64 runtime"), lirParityNeedle("call ptr @osty_rt_list_to_set_i64(", "scalar lane call"), lirParityNeedle("ret ptr", "Set<Int> return")])
+}
+pub fn lirParityManualListToSetStringFixture() -> LirParityFixture {
+    lirParityFixture("list_to_set_string", LirParityManualMIR, "/tmp/lir_proto_parity_list_to_set_string.osty", "", "phase4-list", ["list", "to-set", "string"], [lirParityNeedle("declare ptr @osty_rt_list_to_set_string(ptr)", "list_to_set string runtime"), lirParityNeedle("call ptr @osty_rt_list_to_set_string(", "string lane call"), lirParityNeedle("ret ptr", "Set<String> return")])
+}
+pub fn lirParityManualStringFieldsFixture() -> LirParityFixture {
+    lirParityFixture("string_fields", LirParityManualMIR, "/tmp/lir_proto_parity_string_fields.osty", "", "phase4-string", ["string", "fields"], [lirParityNeedle("declare ptr @osty_rt_strings_Fields(ptr)", "Fields runtime decl"), lirParityNeedle("call ptr @osty_rt_strings_Fields(", "Fields call"), lirParityNeedle("ret ptr", "List<String> return")])
+}
+pub fn lirParityManualStringSplitNFixture() -> LirParityFixture {
+    lirParityFixture("string_split_n", LirParityManualMIR, "/tmp/lir_proto_parity_string_split_n.osty", "", "phase4-string", ["string", "split-n"], [lirParityNeedle("declare ptr @osty_rt_strings_SplitN(ptr, ptr, i64)", "SplitN runtime decl"), lirParityNeedle("call ptr @osty_rt_strings_SplitN(", "SplitN call"), lirParityNeedle("ret ptr", "List<String> return")])
+}
+pub fn lirParityBuildListSliceModule() -> MirModule {
+    let mut fn_ = lirParityFunction("listSlice", "List<Int>")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListSlice, [mirOperandCopy(mirPlace(xs), "List<Int>"), mirOperandConst(mirConstInt(0, "Int")), mirOperandConst(mirConstInt(3, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListToSetI64Module() -> MirModule {
+    let mut fn_ = lirParityFunction("listToSetI64", "Set<Int>")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListToSet, [mirOperandCopy(mirPlace(xs), "List<Int>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListToSetStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("listToSetString", "Set<String>")
+    let xs = lirParityParam(fn_, "xs", "List<String>")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListToSet, [mirOperandCopy(mirPlace(xs), "List<String>")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringFieldsModule() -> MirModule {
+    let mut fn_ = lirParityFunction("stringFields", "List<String>")
+    let s = lirParityParam(fn_, "s", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringFields, [mirOperandCopy(mirPlace(s), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringSplitNModule() -> MirModule {
+    let mut fn_ = lirParityFunction("stringSplitN", "List<String>")
+    let s = lirParityParam(fn_, "s", "String")
+    let sep = lirParityParam(fn_, "sep", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringSplitN, [mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(sep), "String"), mirOperandConst(mirConstInt(3, "Int"))], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary
- Lands four MIR intrinsics that previously fell through the unsupported wildcard: \`ListSlice\` (element-agnostic), \`ListToSet\` (per-element-lane), \`StringFields\`, and \`StringSplitN\`.
- All four reduce to runtime ABI calls with no extra logic. ListToSet picks its per-lane symbol via the existing \`llvmListRuntimeToSetSymbol\` selector — same path production uses.
- Five fixtures pin the runtime decls + call shapes (list_slice, list_to_set_i64, list_to_set_string, string_fields, string_split_n).

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` passes (incl. 5 new fixtures).
- [ ] CI green on the fast lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)