### PR TITLE
feat: regex Phase 3b — Regex.findAll returning List<Match>

### DIFF
--- a/examples/regex_find_all/main.osty
+++ b/examples/regex_find_all/main.osty
@@ -1,0 +1,68 @@
+use std.regex
+
+fn main() {
+    // Multiple non-overlapping word matches.
+    match regex.compile(r"\w+") {
+        Ok(re) -> {
+            let list = re.findAll("alpha beta gamma 42")
+            let n = list.len()
+            println("words: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let m = list[i]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [{i}] '{t}' [{s}..{e})")
+                i += 1
+            }
+        },
+        Err(_) -> println("words compile failed"),
+    }
+
+    // No match: empty list.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let list = re.findAll("hello world")
+            let n = list.len()
+            println("nomatch: {n} match(es)")
+        },
+        Err(_) -> println("nomatch compile failed"),
+    }
+
+    // Anchored: only one match max.
+    match regex.compile(r"^\w+") {
+        Ok(re) -> {
+            let list = re.findAll("hello world tail")
+            let n = list.len()
+            println("anchored: {n} match(es)")
+            if n > 0 {
+                let m = list[0]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [0] '{t}' [{s}..{e})")
+            }
+        },
+        Err(_) -> println("anchored compile failed"),
+    }
+
+    // Greedy quantifier: each match takes as much as possible.
+    match regex.compile(r"a+") {
+        Ok(re) -> {
+            let list = re.findAll("aaabbaab a aaaa")
+            let n = list.len()
+            println("greedy: {n} match(es)")
+            let mut i = 0
+            while i < n {
+                let m = list[i]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [{i}] '{t}' [{s}..{e})")
+                i += 1
+            }
+        },
+        Err(_) -> println("greedy compile failed"),
+    }
+}

--- a/examples/regex_find_all/osty.toml
+++ b/examples/regex_find_all/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_find_all"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -15972,6 +15972,61 @@ void osty_rt_regex_match_free(void *raw) {
     free(raw);
 }
 
+/* Phase 3b — findAll runtime contract:
+ *
+ * `osty_rt_regex_find_all(re, text)` returns a `List<Match>` where
+ * each element is the synthetic Match struct (`{ptr text, i64 start,
+ * i64 end}`) stored inline in the list's data buffer. The list
+ * runtime is configured with elem_size=24 and gc_offsets=[0] so the
+ * tracer marks each element's text field on each cycle.
+ *
+ * Empty matches advance the cursor by one byte to avoid infinite
+ * loops (mirrors `replace_all` / `captures_all`). Non-overlapping
+ * left-to-right semantics. Returns an empty `List<Match>` on no match.
+ */
+void *osty_rt_regex_find_all(void *raw_re, const char *text) {
+    if (raw_re == NULL) {
+        osty_rt_abort("runtime.regex.find_all: nil Regex");
+    }
+    osty_regex_compiled *re = (osty_regex_compiled *)raw_re;
+    char inline_buf[8];
+    const char *src = text == NULL ? "" : text;
+    osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
+    int len = (int)strlen(src);
+
+    void *list = osty_rt_list_new();
+    /* Match has one managed pointer (text) at offset 0; the list's
+     * tracer needs that single offset to keep the String alive across
+     * GC cycles while the Match sits in the list's heap buffer. */
+    static const int64_t match_gc_offsets[1] = { 0 };
+
+    int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
+    int slot_count = 2 * re->ngroups;
+    int start = 0;
+    while (start <= len) {
+        for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        if (!osty_re_match_from(re, src, len, start, slots)) {
+            break;
+        }
+        int32_t match_start = slots[0];
+        int32_t match_end = slots[1];
+        if (match_start < 0 || match_end < 0 || match_end > len || match_start < start) {
+            break;
+        }
+        osty_rt_regex_match_raw entry;
+        entry.text = osty_rt_string_dup_site(src + match_start, (size_t)(match_end - match_start), "runtime.regex.find_all.text");
+        entry.start = (int64_t)match_start;
+        entry.end = (int64_t)match_end;
+        osty_rt_list_push_bytes_roots_v1(list, &entry, (int64_t)sizeof(entry), match_gc_offsets, 1);
+        if (match_end > match_start) {
+            start = match_end;
+        } else {
+            start = match_start + 1;
+        }
+    }
+    return list;
+}
+
 /* Phase 4 — replace / replaceAll / split helpers.
  *
  * `replace` / `replaceAll` produce a fresh String with non-overlapping

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1677,6 +1677,23 @@ func (g *mirGen) emitStdRegexCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, err
 		return true, g.emitRuntimeCallToDest(c, ostyRtRegexSplitSymbol, "ptr", []mirRuntimeArg{recv, text})
 	case "find":
 		return g.emitStdRegexFindMIR(c)
+	case "findAll":
+		if len(c.Args) != 2 {
+			return true, unsupported("mir-mvp", "Regex.findAll requires receiver and text")
+		}
+		recv, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+		if err != nil {
+			return true, err
+		}
+		text, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return true, err
+		}
+		// Runtime returns List<Match> (always non-null; empty list if no
+		// matches). Element layout (elem_size=24, gc_offsets=[0]) is
+		// configured at first push inside the runtime — IR-side just
+		// receives the list pointer.
+		return true, g.emitRuntimeCallToDest(c, ostyRtRegexFindAllSymbol, "ptr", []mirRuntimeArg{recv, text})
 	}
 	return false, nil
 }

--- a/internal/llvmgen/stdlib_regex_shim.go
+++ b/internal/llvmgen/stdlib_regex_shim.go
@@ -15,6 +15,7 @@ const (
 	ostyRtRegexReplaceAllSymbol   = "osty_rt_regex_replace_all"
 	ostyRtRegexSplitSymbol        = "osty_rt_regex_split"
 	ostyRtRegexFindSymbol         = "osty_rt_regex_find"
+	ostyRtRegexFindAllSymbol      = "osty_rt_regex_find_all"
 	ostyRtRegexMatchFreeSymbol    = "osty_rt_regex_match_free"
 	ostyRtRegexCapturesNamedSymbol = "osty_rt_regex_captures_named"
 )
@@ -56,6 +57,15 @@ var stdRegexStringOptionSourceTypeSingleton ast.Type = &ast.OptionalType{
 var stdRegexCapturesListSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"List"},
 	Args: []ast.Type{stdRegexCapturesSourceTypeSingleton},
+}
+
+var stdRegexMatchSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{stdRegexSyntheticMatchTypeName},
+}
+
+var stdRegexMatchListSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"List"},
+	Args: []ast.Type{stdRegexMatchSourceTypeSingleton},
 }
 
 var stdRegexCompileResultSourceTypeSingleton ast.Type = &ast.NamedType{
@@ -242,6 +252,8 @@ func (g *generator) emitStdRegexMethodCall(call *ast.CallExpr) (value, bool, err
 			return g.emitStdRegexReplaceCall(call, field, true)
 		case "split":
 			return g.emitStdRegexSplitCall(call, field)
+		case "findAll":
+			return g.emitStdRegexFindAllCall(call, field)
 		}
 		return value{}, false, nil
 	}
@@ -285,6 +297,13 @@ func (g *generator) stdRegexMethodStaticResult(call *ast.CallExpr) (value, bool)
 				listElemString: true,
 				sourceType:     stdRegexStringListSourceTypeSingleton,
 			}, true
+		case "findAll":
+			return value{
+				typ:         "ptr",
+				gcManaged:   true,
+				listElemTyp: llvmStructTypeName(stdRegexSyntheticMatchTypeName),
+				sourceType:  stdRegexMatchListSourceTypeSingleton,
+			}, true
 		}
 		return value{}, false
 	}
@@ -317,6 +336,8 @@ func (g *generator) staticStdRegexMethodSourceType(call *ast.CallExpr) (ast.Type
 			return stringSourceTypeSingleton, true
 		case "split":
 			return stdRegexStringListSourceTypeSingleton, true
+		case "findAll":
+			return stdRegexMatchListSourceTypeSingleton, true
 		}
 		return nil, false
 	}
@@ -701,4 +722,36 @@ func (g *generator) emitStdRegexStringArg(arg *ast.Arg, method string, index int
 		return value{}, unsupportedf("type-system", "%s arg %d type %s, want String", method, index+1, loaded.typ)
 	}
 	return loaded, nil
+}
+
+func (g *generator) emitStdRegexFindAllCall(call *ast.CallExpr, field *ast.FieldExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "Regex.findAll expects 1 argument, got %d", len(call.Args))
+	}
+	recv, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	recv, err = g.loadIfPointer(recv)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Regex receiver type %s", recv.typ)
+	}
+	text, err := g.emitStdRegexStringArg(call.Args[0], "Regex.findAll", 0, "regex.findAll.arg")
+	if err != nil {
+		return value{}, true, err
+	}
+	g.declareRuntimeSymbol(ostyRtRegexFindAllSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	out := llvmCall(emitter, "ptr", ostyRtRegexFindAllSymbol, []*LlvmValue{toOstyValue(recv), toOstyValue(text)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.listElemTyp = llvmStructTypeName(stdRegexSyntheticMatchTypeName)
+	v.sourceType = stdRegexMatchListSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
 }

--- a/internal/llvmgen/stdlib_regex_shim_test.go
+++ b/internal/llvmgen/stdlib_regex_shim_test.go
@@ -191,6 +191,43 @@ fn main() {
 	}
 }
 
+func TestStdRegexFindAllRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.regex
+
+fn run(re: Regex) -> Int {
+    re.findAll("alpha beta").len()
+}
+
+fn main() {
+    match regex.compile(r"\w+") {
+        Ok(re) -> {
+            let n = run(re)
+            println("count")
+        },
+        Err(_) -> println("compile failed"),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_regex_find_all.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_regex_find_all(ptr, ptr)",
+		"call ptr @osty_rt_regex_find_all",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestStdRegexCapturesNamedRoutesToRuntime(t *testing.T) {
 	file := parseLLVMGenFile(t, `use std.regex
 


### PR DESCRIPTION
## Summary
- `Regex.findAll(text) -> List<Match>` 구현 — std.regex §10.9 마지막 spec 메서드.
- List 런타임의 **custom element layout** (`elem_size=24`, `gc_offsets=[0]`) 활용. Match struct 값(`{ptr text, i64 start, i64 end}`)이 list 데이터 버퍼에 **인라인** 저장됨 — 별도 박싱 없음. `list_trace`가 매 GC 사이클마다 각 element의 text 필드(offset 0)를 mark해서 String이 GC에 살아남는다.
- 런타임 루프: 비-overlapping 매치 left-to-right 순회 → 각 매치마다 Match struct 빌드 → `osty_rt_list_push_bytes_roots_v1(list, &entry, 24, gc_offsets=[0], 1)`로 push. 빈 매치는 +1 forward로 무한루프 회피, no-match면 빈 list 반환.
- AST + MIR 양 경로에 dispatch + `listElemTyp = "%__osty_std_regex_Match"` 명시 → `list[i]` 인덱싱이 올바른 elem_size로 lower.

## Test plan
- [x] IR-level 포커스 테스트 1개 추가 (`TestStdRegexFindAllRoutesToRuntime`)
- [x] llvmgen short suite 통과
- [x] E2E ([examples/regex_find_all/main.osty](examples/regex_find_all/main.osty)) 4 케이스:
  - `\w+` on `"alpha beta gamma 42"` → 4 matches with correct text/start/end
  - `\d+` on `"hello world"` → 0 matches (empty list)
  - `^\w+` on `"hello world tail"` → 1 match (anchor 단일 위치)
  - `a+` on `"aaabbaab a aaaa"` → 4 greedy matches: aaa[0..3), aa[5..7), a[9..10), aaaa[11..15)
- [x] Phase 1/2/2b/3a/4/5 회귀 없음 (regex_smoke / regex_captures / regex_captures_all / regex_replace_split / regex_find / regex_named / uuid_smoke 모두 정상)
- [x] `just fmt-check` / `just vet` clean
- [ ] CI 그린 확인

## std.regex 현재 상태 — spec §10.9 모든 메서드 ✓

| API | 상태 |
|---|---|
| `compile`, `Regex.matches` | ✓ Phase 1 |
| `Regex.captures` / `Captures.get` | ✓ Phase 2 |
| `Regex.capturesAll` | ✓ Phase 2b |
| `Regex.replace` / `replaceAll` / `split` | ✓ Phase 4 |
| `Regex.find` | ✓ Phase 3a |
| `(?P<name>...)` / `Captures.named` | ✓ Phase 5 |
| **`Regex.findAll`** | **✓ Phase 3b (이번 PR)** |

스펙 §10.9의 모든 surface 메서드 + 명명 캡처 완료. 남은 건 spec에 없는 확장(`$1` backref in replacement, `(?i)` flags, `\b`/`\B` word boundaries, full Unicode classes) 정도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)