### PR TITLE
feat: LIR Proto ListRemoveAt/MapGetOr/StringSplitInto/StringNthSegment

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -936,6 +936,40 @@ both arm stores + ret. The narrowing helper's other branches
 / FirstOrLast / parse fixtures that already exercise the
 i64-payload boxing direction.
 
+Design decision: the next batch lands four MIR intrinsics that
+each compose existing primitives (per-lane gets, probe runtime,
+fixed-signature ABI calls):
+
+- `MirIntrinsicListRemoveAt` — `list.removeAt(idx) -> T`. Two
+  calls in strict order: `osty_rt_list_get_<lane>(list, idx)`
+  captures the element BEFORE the slot is dropped, then
+  `osty_rt_list_remove_at_discard(list, idx)` shifts the tail.
+  Mirrors production `IntrinsicListRemoveAt` — load-before-discard
+  is required for correctness.
+- `MirIntrinsicMapGetOr` — `m.getOr(k, default) -> V`. Probe
+  `osty_rt_map_get_<keysuf>(map, key, slot)` returns `i1` and
+  memcpys V into `slot` on hit. Hit arm loads V from the slot,
+  miss arm evaluates the fallback operand, both merge through
+  alloca-backed slot. Reuses the same probe helpers `lirLowerMirMapGet`
+  uses, just without the Option<V> wrap.
+- `MirIntrinsicStringSplitInto` → `osty_rt_strings_SplitInto(out,
+  val, sep)`. Statement-only (no dest); the void runtime call
+  rebuilds `out` in place — used by the
+  `hoistNonEscapingSplitInLoops` MIR pass to avoid per-iteration
+  List<String> allocations.
+- `MirIntrinsicStringNthSegment` →
+  `osty_rt_strings_NthSegment(value, sep, idx) -> ptr`. Direct
+  fused `expr.split(sep)[K]` — runtime walks past the first K
+  separators and dups the segment after, never materialising the
+  intermediate List<String>. Produced by the
+  `fuseNonEscapingSplitNth` MIR pass.
+
+Four Phase-4 fixtures pin the shapes:
+- `list_remove_at` — runtime decls + load-before-discard ordering.
+- `map_get_or` — probe decl + alloca slot + i1 + ret V.
+- `string_split_into` — void 3-ptr decl + call (no return).
+- `string_nth_segment` — 3-arg ptr decl + call + ret String.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -418,6 +418,11 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualOptionUnwrapOrFixture", []string{"%Option.Int = type", "extractvalue %Option.Int", "icmp eq i64", "alloca i64", "ret i64"}},
 		{"lirParityManualResultUnwrapFixture", []string{"%Result.Int_Error = type", "declare void @osty_rt_result_unwrap_err()", "extractvalue %Result.Int_Error", "icmp eq i64", "call void @osty_rt_result_unwrap_err()", "unreachable", "ret i64"}},
 		{"lirParityManualResultUnwrapOrFixture", []string{"%Result.Int_Error = type", "extractvalue %Result.Int_Error", "icmp eq i64", "alloca i64", "ret i64"}},
+		// ----- ListRemoveAt + MapGetOr + StringSplitInto + StringNthSegment -----
+		{"lirParityManualListRemoveAtFixture", []string{"declare i64 @osty_rt_list_get_i64(ptr, i64)", "declare void @osty_rt_list_remove_at_discard(ptr, i64)", "call i64 @osty_rt_list_get_i64(", "call void @osty_rt_list_remove_at_discard(", "ret i64"}},
+		{"lirParityManualMapGetOrFixture", []string{"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "alloca i64", "call i1 @osty_rt_map_get_string(", "ret i64"}},
+		{"lirParityManualStringSplitIntoFixture", []string{"declare void @osty_rt_strings_SplitInto(ptr, ptr, ptr)", "call void @osty_rt_strings_SplitInto("}},
+		{"lirParityManualStringNthSegmentFixture", []string{"declare ptr @osty_rt_strings_NthSegment(ptr, ptr, i64)", "call ptr @osty_rt_strings_NthSegment(", "ret ptr"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2275,6 +2275,10 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicOptionUnwrapOr -> lirLowerMirAlgebraicUnwrapOr(l, instr, "option.unwrapOr"),
         MirIntrinsicResultUnwrap -> lirLowerMirAlgebraicUnwrap(l, instr, mirRtResultUnwrapErrSymbol(), "result.unwrap"),
         MirIntrinsicResultUnwrapOr -> lirLowerMirAlgebraicUnwrapOr(l, instr, "result.unwrapOr"),
+        MirIntrinsicStringSplitInto -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringSplitIntoSymbol(), lirVoidType(), [lirPtrType(), lirPtrType(), lirPtrType()], "string.splitInto"),
+        MirIntrinsicStringNthSegment -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringNthSegmentSymbol(), lirPtrType(), [lirPtrType(), lirPtrType(), lirIntType(64)], "string.nthSegment"),
+        MirIntrinsicListRemoveAt -> lirLowerMirListRemoveAt(l, instr),
+        MirIntrinsicMapGetOr -> lirLowerMirMapGetOr(l, instr),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
@@ -4283,6 +4287,112 @@ fn lirLowerMirAlgebraicUnwrapOr(l: LirMirFunctionLowerer, instr: MirInstr, label
     let merged = lirFresh(l)
     l.instrs.push(lirLoad(merged, destType, mergeSlot, 0))
     lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, label + " result")
+}
+// `lirLowerMirListRemoveAt` lowers `list.removeAt(idx) -> T` as a
+// 2-step pattern: per-lane `osty_rt_list_get_<suffix>(list, idx)`
+// captures the element at `idx` BEFORE the runtime splice drops it,
+// then `osty_rt_list_remove_at_discard(list, idx)` shifts the tail
+// left by one slot. Mirrors production
+// (mir_generator.go::IntrinsicListRemoveAt) — the load-before-discard
+// ordering is required for correctness because the discard helper
+// reuses the slot.
+fn lirLowerMirListRemoveAt(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, "list.removeAt expects (list, idx)", "list.removeAt")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "list.removeAt", "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "list.removeAt composite element type `" + recv.elemTypeName + "` needs the bytes-v1 runtime fallback (deferred)", "list.removeAt")
+        return
+    }
+    let idx = lirLowerCoercedOperand(l, instr.args[1], "Int", lirIntType(64), "list.removeAt idx")
+    if idx.value == "" {
+        return
+    }
+    let getSym = llvmListRuntimeGetSymbolFor(recv.elemLir.llvm, recv.isString)
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(getSym, recv.elemLir, [lirPtrType(), lirIntType(64)], false))
+    let elemReg = lirFresh(l)
+    l.instrs.push(lirCall(elemReg, recv.elemLir, "@" + getSym, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), idx.value)]))
+    let spliceSym = mirRtListRemoveAtDiscardSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(spliceSym, lirVoidType(), [lirPtrType(), lirIntType(64)], false))
+    l.instrs.push(lirCall("", lirVoidType(), "@" + spliceSym, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), idx.value)]))
+    if instr.hasDest {
+        lirStoreMirResult(l, instr.dest, lirOperand(recv.elemLir, elemReg), recv.elemTypeName, "list.removeAt result")
+    }
+}
+// `lirLowerMirMapGetOr` lowers `m.getOr(k, default) -> V` to the
+// allocation-free probe pattern: `osty_rt_map_get_<keysuf>(m, k, slot)`
+// returns i1 + memcpys V into `slot` on hit; the hit arm loads V from
+// the slot, the miss arm evaluates the fallback operand, and both
+// arms merge through an alloca-backed slot. Mirrors production
+// `emitMapGetIntrinsic` IntrinsicMapGetOr branch (mir_generator.go:6224)
+// — production uses a phi node, alloca-merge is equivalent and matches
+// the existing LIR Proto sites (lirWrapOptionFromI64Sentinel etc).
+fn lirLowerMirMapGetOr(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 3 {
+        lirLowerError(l, LirDiagInvalidInput, "map.getOr expects (map, key, default)", "map.getOr")
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, "map.getOr requires a destination", "map.getOr")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "map.getOr", "map.kv")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.valueLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, "map.getOr composite value type `" + recv.valueTypeName + "` needs the bytes-v1 runtime fallback (deferred)", "map.getOr")
+        return
+    }
+    let key = lirLowerCoercedOperand(l, instr.args[1], recv.elemTypeName, recv.elemLir, "map.getOr key")
+    if key.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "map.getOr destination local out of range", "map.getOr")
+        return
+    }
+    let destType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(destType) {
+        lirLowerError(l, LirDiagUnsupported, "map.getOr destination type `" + loc.typ + "` is not implemented", "map.getOr")
+        return
+    }
+    if destType.llvm != recv.valueLir.llvm {
+        lirLowerError(l, LirDiagUnsupported, "map.getOr destination type `" + loc.typ + "` does not match value type `" + recv.valueTypeName + "`", "map.getOr")
+        return
+    }
+    let symbol = mirRtMapSymbol("get_" + llvmMapKeySuffix(recv.elemLir.llvm, recv.isString))
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirIntType(1), [lirPtrType(), recv.elemLir, lirPtrType()], false))
+    let outSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(outSlot, recv.valueLir, 0))
+    let presentReg = lirFresh(l)
+    l.instrs.push(lirCall(presentReg, lirIntType(1), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(lirPtrType(), outSlot)]))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, destType, 0))
+    let hitLabel = lirFreshAuxLabel(l, "map.getOr.hit")
+    let missLabel = lirFreshAuxLabel(l, "map.getOr.miss")
+    let endLabel = lirFreshAuxLabel(l, "map.getOr.end")
+    lirCutBlockCondBr(l, presentReg, hitLabel, missLabel, hitLabel)
+    let loaded = lirFresh(l)
+    l.instrs.push(lirLoad(loaded, recv.valueLir, outSlot, 0))
+    l.instrs.push(lirStore(lirOperand(destType, loaded), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = missLabel
+    let fallback = lirLowerMirOperand(l, instr.args[2], loc.typ, destType)
+    if fallback.value == "" {
+        return
+    }
+    l.instrs.push(lirStore(lirOperand(destType, fallback.value), mergeSlot, 0))
+    lirCutBlockBr(l, endLabel)
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, destType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, "map.getOr result")
 }
 // Widen a parsed scalar (i64 / double / i32 / i8 / i1) into the i64
 // the Ok payload slot uses. Production widens the same way

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture(), lirParityManualListSliceFixture(), lirParityManualListToSetI64Fixture(), lirParityManualListToSetStringFixture(), lirParityManualStringFieldsFixture(), lirParityManualStringSplitNFixture(), lirParityManualOptionUnwrapFixture(), lirParityManualOptionUnwrapOrFixture(), lirParityManualResultUnwrapFixture(), lirParityManualResultUnwrapOrFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture(), lirParityManualListSliceFixture(), lirParityManualListToSetI64Fixture(), lirParityManualListToSetStringFixture(), lirParityManualStringFieldsFixture(), lirParityManualStringSplitNFixture(), lirParityManualOptionUnwrapFixture(), lirParityManualOptionUnwrapOrFixture(), lirParityManualResultUnwrapFixture(), lirParityManualResultUnwrapOrFixture(), lirParityManualListRemoveAtFixture(), lirParityManualMapGetOrFixture(), lirParityManualStringSplitIntoFixture(), lirParityManualStringNthSegmentFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -644,6 +644,18 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "result_unwrap_or" {
         return lirParityBuildResultUnwrapOrModule()
+    }
+    if name == "list_remove_at" {
+        return lirParityBuildListRemoveAtModule()
+    }
+    if name == "map_get_or" {
+        return lirParityBuildMapGetOrModule()
+    }
+    if name == "string_split_into" {
+        return lirParityBuildStringSplitIntoModule()
+    }
+    if name == "string_nth_segment" {
+        return lirParityBuildStringNthSegmentModule()
     }
     mirModule("main")
 }
@@ -2227,6 +2239,66 @@ pub fn lirParityBuildResultUnwrapOrModule() -> MirModule {
     let dflt = lirParityParam(fn_, "d", "Int")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicResultUnwrapOr, [mirOperandCopy(mirPlace(r), "Result<Int, Error>"), mirOperandCopy(mirPlace(dflt), "Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// ListRemoveAt + MapGetOr + StringSplitInto + StringNthSegment
+// ====================================================================
+//
+// Four fixtures pin previously-unsupported MIR intrinsics:
+//
+//   * list_remove_at      — per-lane get + osty_rt_list_remove_at_discard
+//   * map_get_or          — probe + alloca-merge fallback
+//   * string_split_into   — void in-place split
+//   * string_nth_segment  — direct fused split[N]
+pub fn lirParityManualListRemoveAtFixture() -> LirParityFixture {
+    lirParityFixture("list_remove_at", LirParityManualMIR, "/tmp/lir_proto_parity_list_remove_at.osty", "", "phase4-list", ["list", "remove-at"], [lirParityNeedle("declare i64 @osty_rt_list_get_i64(ptr, i64)", "per-lane get decl"), lirParityNeedle("declare void @osty_rt_list_remove_at_discard(ptr, i64)", "discard runtime decl"), lirParityNeedle("call i64 @osty_rt_list_get_i64(", "load element BEFORE splice"), lirParityNeedle("call void @osty_rt_list_remove_at_discard(", "splice call"), lirParityNeedle("ret i64", "Int element returned")])
+}
+pub fn lirParityManualMapGetOrFixture() -> LirParityFixture {
+    lirParityFixture("map_get_or", LirParityManualMIR, "/tmp/lir_proto_parity_map_get_or.osty", "", "phase4-map", ["map", "get-or"], [lirParityNeedle("declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "map.get probe decl"), lirParityNeedle("alloca i64", "out-slot for V on hit"), lirParityNeedle("call i1 @osty_rt_map_get_string(", "probe call"), lirParityNeedle("ret i64", "Int return")])
+}
+pub fn lirParityManualStringSplitIntoFixture() -> LirParityFixture {
+    lirParityFixture("string_split_into", LirParityManualMIR, "/tmp/lir_proto_parity_string_split_into.osty", "", "phase4-string", ["string", "split-into"], [lirParityNeedle("declare void @osty_rt_strings_SplitInto(ptr, ptr, ptr)", "SplitInto decl"), lirParityNeedle("call void @osty_rt_strings_SplitInto(", "void in-place split call")])
+}
+pub fn lirParityManualStringNthSegmentFixture() -> LirParityFixture {
+    lirParityFixture("string_nth_segment", LirParityManualMIR, "/tmp/lir_proto_parity_string_nth_segment.osty", "", "phase4-string", ["string", "nth-segment"], [lirParityNeedle("declare ptr @osty_rt_strings_NthSegment(ptr, ptr, i64)", "NthSegment decl"), lirParityNeedle("call ptr @osty_rt_strings_NthSegment(", "fused split[N] call"), lirParityNeedle("ret ptr", "String return")])
+}
+pub fn lirParityBuildListRemoveAtModule() -> MirModule {
+    let mut fn_ = lirParityFunction("listRemoveAt", "Int")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let idx = lirParityParam(fn_, "i", "Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListRemoveAt, [mirOperandCopy(mirPlace(xs), "List<Int>"), mirOperandCopy(mirPlace(idx), "Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildMapGetOrModule() -> MirModule {
+    let mut fn_ = lirParityFunction("mapGetOr", "Int")
+    let m = lirParityParam(fn_, "m", "Map<String, Int>")
+    let k = lirParityParam(fn_, "k", "String")
+    let dflt = lirParityParam(fn_, "d", "Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapGetOr, [mirOperandCopy(mirPlace(m), "Map<String, Int>"), mirOperandCopy(mirPlace(k), "String"), mirOperandCopy(mirPlace(dflt), "Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringSplitIntoModule() -> MirModule {
+    let mut fn_ = lirParityFunction("stringSplitInto", "Unit")
+    let out = lirParityParam(fn_, "out", "List<String>")
+    let s = lirParityParam(fn_, "s", "String")
+    let sep = lirParityParam(fn_, "sep", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicStringSplitInto, [mirOperandCopy(mirPlace(out), "List<String>"), mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(sep), "String")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildStringNthSegmentModule() -> MirModule {
+    let mut fn_ = lirParityFunction("stringNthSegment", "String")
+    let s = lirParityParam(fn_, "s", "String")
+    let sep = lirParityParam(fn_, "sep", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringNthSegment, [mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(sep), "String"), mirOperandConst(mirConstInt(2, "Int"))], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary
- Lands four MIR intrinsics that previously fell through the unsupported wildcard: \`ListRemoveAt\`, \`MapGetOr\`, \`StringSplitInto\`, \`StringNthSegment\`.
- Each composes existing primitives — per-lane gets + discard, probe + alloca-merge, fixed-signature ABI calls.
- Four Phase-4 fixtures pin runtime decls + call ordering (load-before-discard for ListRemoveAt is correctness-critical).

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` passes.
- [ ] CI green on the fast lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)