### PR TITLE
fix: LIR Proto _ignored binding undefined-name errors

### DIFF
--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -3638,8 +3638,8 @@ fn lirLowerMirHandleJoin(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, retType, [lirPtrType()], false))
     if !(instr.hasDest) {
-        let _ignored = lirFresh(l)
-        l.instrs.push(lirCall(_ignored, retType, "@" + symbol, [lirOperand(lirPtrType(), handle.value)]))
+        let ignored = lirFresh(l)
+        l.instrs.push(lirCall(ignored, retType, "@" + symbol, [lirOperand(lirPtrType(), handle.value)]))
         return
     }
     let dest = lirFresh(l)
@@ -3714,8 +3714,8 @@ fn lirLowerMirSpawn(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
     lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirPtrType(), paramTypes, false))
     if !(instr.hasDest) {
-        let _ignored = lirFresh(l)
-        l.instrs.push(lirCall(_ignored, lirPtrType(), "@" + symbol, args))
+        let ignored = lirFresh(l)
+        l.instrs.push(lirCall(ignored, lirPtrType(), "@" + symbol, args))
         return
     }
     let dest = lirFresh(l)


### PR DESCRIPTION
## Summary
- Fixes two longstanding undefined-name errors in \`toolchain/lir_proto.osty\` flagged by \`osty check\`.
- Two sites used \`let _ignored = lirFresh(l)\` then referenced \`_ignored\`. Osty's unused-binding convention treats \`_\`-prefixed names as discarded — they don't bind — so the subsequent \`lirCall(_ignored, ...)\` was undefined-name (E0500) on every parse.
- Sites: handle.join no-dest path (3641), spawn no-dest path (3717).
- Renaming to \`ignored\` (no underscore prefix) binds the fresh register name. Behavior unchanged — both sites still discard the result.

## Test plan
- [x] \`osty check toolchain/lir_proto.osty\` now reports 0 errors (was 2 errors).
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)