### PR TITLE
feat: LIR Proto MapIncr + ListContains + ListIndexOf

### DIFF
--- a/docs/lir_proto_plan.md
+++ b/docs/lir_proto_plan.md
@@ -970,6 +970,44 @@ Four Phase-4 fixtures pin the shapes:
 - `string_split_into` — void 3-ptr decl + call (no return).
 - `string_nth_segment` — 3-arg ptr decl + call + ret String.
 
+Design decision: closing out the remaining intrinsic dispatch
+gaps lands `MapIncr`, `ListContains`, and `ListIndexOf` —
+the latter two share a single helper `lirLowerMirListLinearScan`
+since `Bool` and `Option<Int>` versions diverge only in the
+result-merge slot (i1 init=`false` + match-store=`true` vs
+`%Option.Int` init=None + match-store=Some(idx)). Production
+emits the same inline scan for both
+(mir_generator.go::IntrinsicListIndexOf|ListContains).
+
+- `MirIntrinsicMapIncr` → `osty_rt_map_incr_i64_<keysuf>(map,
+  key, delta) -> i64`. Single-call fused `m[k] += delta` from
+  the `fuseMapInsertGetOrAdd` MIR pass. Returns the new value
+  (statement form discards via `ignored` register, expression
+  form stores into dest).
+- `MirIntrinsicListContains` / `MirIntrinsicListIndexOf` —
+  inline linear scan: head/body/match/cont/end CFG with
+  alloca-merge result slot. Pre-initialise the slot (false /
+  None), iterate `0..len`, compare each element via
+  `icmp eq`/`fcmp oeq`/`osty_rt_strings_Equal` depending on
+  element-LLVM-type, overwrite slot + jump to end on match,
+  fall through to end after `len` iterations otherwise. The
+  String-equal runtime path exists in production because raw
+  pointer compare would reject equal-content separate
+  allocations.
+
+Three Phase-4 fixtures pin the shapes:
+- `map_incr_string` — string-key incr runtime decl + call + ret i64.
+- `list_contains_i64` — len/get decls + alloca i1 + alloca i64 +
+  loop continue/eq checks + ret i1.
+- `list_index_of_string` — Option.Int aggregate def + string-lane
+  get (returns ptr) + Equal runtime + alloca %Option.Int +
+  ret %Option.Int. Exercises the String comparison path the i64
+  scan skips.
+
+Composite element types (struct/enum/non-typed) take the
+`bytes-v1 fallback (deferred)` diagnostic path, same as
+`list.first`/`list.pop` do today.
+
 ## Phase 0: lock the boundary
 
 Deliverables:

--- a/internal/llvmgen/lir_proto_shadow_parity_test.go
+++ b/internal/llvmgen/lir_proto_shadow_parity_test.go
@@ -423,6 +423,10 @@ func TestLIRProtoManualFixtureCatalog(t *testing.T) {
 		{"lirParityManualMapGetOrFixture", []string{"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)", "alloca i64", "call i1 @osty_rt_map_get_string(", "ret i64"}},
 		{"lirParityManualStringSplitIntoFixture", []string{"declare void @osty_rt_strings_SplitInto(ptr, ptr, ptr)", "call void @osty_rt_strings_SplitInto("}},
 		{"lirParityManualStringNthSegmentFixture", []string{"declare ptr @osty_rt_strings_NthSegment(ptr, ptr, i64)", "call ptr @osty_rt_strings_NthSegment(", "ret ptr"}},
+		// ----- MapIncr + ListContains + ListIndexOf -----
+		{"lirParityManualMapIncrStringFixture", []string{"declare i64 @osty_rt_map_incr_i64_string(ptr, ptr, i64)", "call i64 @osty_rt_map_incr_i64_string(", "ret i64"}},
+		{"lirParityManualListContainsI64Fixture", []string{"declare i64 @osty_rt_list_len(ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "alloca i1", "alloca i64", "icmp slt i64", "icmp eq i64", "ret i1"}},
+		{"lirParityManualListIndexOfStringFixture", []string{"%Option.Int = type", "declare ptr @osty_rt_list_get_string(ptr, i64)", "declare i1 @osty_rt_strings_Equal(ptr, ptr)", "alloca %Option.Int", "call i1 @osty_rt_strings_Equal(", "ret %Option.Int"}},
 	}
 
 	for _, tt := range want {

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2279,6 +2279,9 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicStringNthSegment -> lirLowerMirStringRuntimeCall(l, instr, mirRtStringNthSegmentSymbol(), lirPtrType(), [lirPtrType(), lirPtrType(), lirIntType(64)], "string.nthSegment"),
         MirIntrinsicListRemoveAt -> lirLowerMirListRemoveAt(l, instr),
         MirIntrinsicMapGetOr -> lirLowerMirMapGetOr(l, instr),
+        MirIntrinsicMapIncr -> lirLowerMirMapIncr(l, instr),
+        MirIntrinsicListContains -> lirLowerMirListLinearScan(l, instr, false),
+        MirIntrinsicListIndexOf -> lirLowerMirListLinearScan(l, instr, true),
         _ -> lirLowerError(l, LirDiagUnsupported, "unsupported MIR intrinsic `" + mirIntrinsicName(instr.intrinsic) + "`", "intrinsic"),
     }
 }
@@ -4393,6 +4396,155 @@ fn lirLowerMirMapGetOr(l: LirMirFunctionLowerer, instr: MirInstr) {
     let merged = lirFresh(l)
     l.instrs.push(lirLoad(merged, destType, mergeSlot, 0))
     lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, "map.getOr result")
+}
+// `lirLowerMirMapIncr` lowers the fused `m[k] = m.getOr(k, 0) +
+// delta` produced by `fuseMapInsertGetOrAdd`. Single runtime call
+// `osty_rt_map_incr_i64_<keysuf>(map, key, delta) -> i64` probes
+// once, updates in place on hit, falls through to insert on miss.
+// Returns the new map value; MIR may discard it (counter benchmarks
+// only need the side effect) but the runtime declaration must
+// match. Mirrors production `IntrinsicMapIncr`
+// (mir_generator.go:6308).
+fn lirLowerMirMapIncr(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 3 {
+        lirLowerError(l, LirDiagInvalidInput, "map.incr expects (map, key, delta)", "map.incr")
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, "map.incr", "map.kv")
+    if !(recv.ok) {
+        return
+    }
+    let key = lirLowerCoercedOperand(l, instr.args[1], recv.elemTypeName, recv.elemLir, "map.incr key")
+    if key.value == "" {
+        return
+    }
+    let delta = lirLowerCoercedOperand(l, instr.args[2], "Int", lirIntType(64), "map.incr delta")
+    if delta.value == "" {
+        return
+    }
+    let symbol = "osty_rt_map_incr_i64_" + llvmMapKeySuffix(recv.elemLir.llvm, recv.isString)
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirIntType(64), [lirPtrType(), recv.elemLir, lirIntType(64)], false))
+    if !(instr.hasDest) {
+        let ignored = lirFresh(l)
+        l.instrs.push(lirCall(ignored, lirIntType(64), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(lirIntType(64), delta.value)]))
+        return
+    }
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, lirIntType(64), "@" + symbol, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(recv.elemLir, key.value), lirOperand(lirIntType(64), delta.value)]))
+    lirStoreMirResult(l, instr.dest, lirOperand(lirIntType(64), dest), "Int", "map.incr result")
+}
+// `lirLowerMirListLinearScan` lowers `list.contains(x) -> Bool` and
+// `list.indexOf(x) -> Int?` as inline scan loops. Both share the same
+// CFG shape — head/body/match/cont/end — and only differ in:
+//
+//   * `wantIndex=false`: dest is i1; pre-store `false` and overwrite
+//     with `true` on first match, jump to end.
+//   * `wantIndex=true`: dest is %Option.Int; pre-store None and
+//     overwrite with Some(idx) on first match, jump to end.
+//
+// Avoids per-elem-type runtime helpers — the runtime ships per-lane
+// `osty_rt_list_get_<suffix>` and (for String elements) the
+// `osty_rt_strings_Equal` helper, but no `list_contains_*` or
+// `list_index_of_*` symbols exist; production also emits the loop
+// inline (mir_generator.go::IntrinsicListIndexOf|ListContains).
+//
+// Composite element types (struct / enum / non-typed) need the
+// bytes-v1 fallback the same way `list.first` / `list.pop` do — the
+// scan can't generate a comparator. Those paths return a structured
+// unsupported diagnostic.
+fn lirLowerMirListLinearScan(l: LirMirFunctionLowerer, instr: MirInstr, wantIndex: Bool) {
+    let label = if wantIndex {
+        "list.indexOf"
+    } else {
+        "list.contains"
+    }
+    if instr.args.len() != 2 {
+        lirLowerError(l, LirDiagInvalidInput, label + " expects (list, needle)", label)
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, label + " requires a destination", label)
+        return
+    }
+    let recv = lirLowerMirContainerReceiver(l, instr, label, "list.elem")
+    if !(recv.ok) {
+        return
+    }
+    if !(llvmListUsesTypedRuntime(recv.elemLir.llvm)) {
+        lirLowerError(l, LirDiagUnsupported, label + " composite element type `" + recv.elemTypeName + "` needs the bytes-v1 runtime fallback (deferred)", label)
+        return
+    }
+    let needle = lirLowerCoercedOperand(l, instr.args[1], recv.elemTypeName, recv.elemLir, label + " needle")
+    if needle.value == "" {
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, label + " destination local out of range", label)
+        return
+    }
+    let destType = lirLowerMirType(l, loc.typ)
+    if lirTypeIsZero(destType) {
+        lirLowerError(l, LirDiagUnsupported, label + " destination type `" + loc.typ + "` is not implemented", label)
+        return
+    }
+    let lenSym = llvmListRuntimeLenSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDeclI64FromPtr(lenSym))
+    let getSym = llvmListRuntimeGetSymbolFor(recv.elemLir.llvm, recv.isString)
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(getSym, recv.elemLir, [lirPtrType(), lirIntType(64)], false))
+    let lenReg = lirFresh(l)
+    l.instrs.push(lirCall(lenReg, lirIntType(64), "@" + lenSym, [lirOperand(lirPtrType(), recv.receiverReg)]))
+    let mergeSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(mergeSlot, destType, 0))
+    if wantIndex {
+        let noneValue = lirEmitOptionNone(l, destType)
+        l.instrs.push(lirStore(lirOperand(destType, noneValue), mergeSlot, 0))
+    } else {
+        l.instrs.push(lirStore(lirOperand(lirIntType(1), "false"), mergeSlot, 0))
+    }
+    let iSlot = lirFresh(l)
+    l.instrs.push(lirAlloca(iSlot, lirIntType(64), 0))
+    l.instrs.push(lirStore(lirOperand(lirIntType(64), "0"), iSlot, 0))
+    let headLabel = lirFreshAuxLabel(l, label + ".head")
+    let bodyLabel = lirFreshAuxLabel(l, label + ".body")
+    let matchLabel = lirFreshAuxLabel(l, label + ".match")
+    let contLabel = lirFreshAuxLabel(l, label + ".cont")
+    let endLabel = lirFreshAuxLabel(l, label + ".end")
+    lirCutBlockBr(l, headLabel)
+    let iReg = lirFresh(l)
+    l.instrs.push(lirLoad(iReg, lirIntType(64), iSlot, 0))
+    let cont = lirFresh(l)
+    l.instrs.push(lirBinary(cont, "icmp slt", lirIntType(64), iReg, lenReg))
+    lirCutBlockCondBr(l, cont, bodyLabel, endLabel, bodyLabel)
+    let elemReg = lirFresh(l)
+    l.instrs.push(lirCall(elemReg, recv.elemLir, "@" + getSym, [lirOperand(lirPtrType(), recv.receiverReg), lirOperand(lirIntType(64), iReg)]))
+    let eqReg = lirFresh(l)
+    if recv.isString {
+        let eqSym = llvmStringRuntimeEqualSymbol()
+        lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(eqSym, lirIntType(1), [lirPtrType(), lirPtrType()], false))
+        l.instrs.push(lirCall(eqReg, lirIntType(1), "@" + eqSym, [lirOperand(recv.elemLir, elemReg), lirOperand(recv.elemLir, needle.value)]))
+    } else if recv.elemLir.llvm == "double" {
+        l.instrs.push(lirBinary(eqReg, "fcmp oeq", recv.elemLir, elemReg, needle.value))
+    } else {
+        l.instrs.push(lirBinary(eqReg, "icmp eq", recv.elemLir, elemReg, needle.value))
+    }
+    lirCutBlockCondBr(l, eqReg, matchLabel, contLabel, matchLabel)
+    if wantIndex {
+        let someValue = lirEmitOptionSome(l, destType, iReg)
+        l.instrs.push(lirStore(lirOperand(destType, someValue), mergeSlot, 0))
+    } else {
+        l.instrs.push(lirStore(lirOperand(lirIntType(1), "true"), mergeSlot, 0))
+    }
+    lirCutBlockBr(l, endLabel)
+    l.currentBlockLabel = contLabel
+    let nextI = lirFresh(l)
+    l.instrs.push(lirBinary(nextI, "add", lirIntType(64), iReg, "1"))
+    l.instrs.push(lirStore(lirOperand(lirIntType(64), nextI), iSlot, 0))
+    lirCutBlockBr(l, headLabel)
+    l.currentBlockLabel = endLabel
+    let merged = lirFresh(l)
+    l.instrs.push(lirLoad(merged, destType, mergeSlot, 0))
+    lirStoreMirResult(l, instr.dest, lirOperand(destType, merged), loc.typ, label + " result")
 }
 // Widen a parsed scalar (i64 / double / i32 / i8 / i1) into the i64
 // the Ok payload slot uses. Production widens the same way

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -148,7 +148,7 @@ pub fn lirParityBuiltinFixtures() -> List<LirParityFixture> {
     out
 }
 pub fn lirParityManualMIRFixtures() -> List<LirParityFixture> {
-    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture(), lirParityManualListSliceFixture(), lirParityManualListToSetI64Fixture(), lirParityManualListToSetStringFixture(), lirParityManualStringFieldsFixture(), lirParityManualStringSplitNFixture(), lirParityManualOptionUnwrapFixture(), lirParityManualOptionUnwrapOrFixture(), lirParityManualResultUnwrapFixture(), lirParityManualResultUnwrapOrFixture(), lirParityManualListRemoveAtFixture(), lirParityManualMapGetOrFixture(), lirParityManualStringSplitIntoFixture(), lirParityManualStringNthSegmentFixture()]
+    [lirParityManualConstReturnFixture(), lirParityManualDirectCallFixture(), lirParityManualBranchFixture(), lirParityManualSwitchFixture(), lirParityManualPrintlnStringFixture(), lirParityManualCastIntResizeFixture(), lirParityManualCastFloatResizeFixture(), lirParityManualCastIntToFloatFixture(), lirParityManualDirectCallArgCoercionFixture(), lirParityManualPrimitiveIntToByteFixture(), lirParityManualPrimitiveByteToCharFixture(), lirParityManualTupleLiteralReadFixture(), lirParityManualStructLiteralReadFixture(), lirParityManualNestedProjectedAssignFixture(), lirParityManualProjectedCallResultFixture(), lirParityManualProjectedIntrinsicResultFixture(), lirParityManualStringByteLenFixture(), lirParityManualStringIsEmptyFixture(), lirParityManualStringConcatBinaryFixture(), lirParityManualStringConcatNFixture(), lirParityManualStringContainsFixture(), lirParityManualStringTrimSpaceFixture(), lirParityManualStringRepeatFixture(), lirParityManualStringSubstringFixture(), lirParityManualStringReplaceAllFixture(), lirParityManualBytesLenFixture(), lirParityManualBytesConcatFixture(), lirParityManualBytesSliceFixture(), lirParityManualListPushIntFixture(), lirParityManualListPushStringFixture(), lirParityManualListLenFixture(), lirParityManualListIsEmptyFixture(), lirParityManualListGetFloatFixture(), lirParityManualListSortedI64Fixture(), lirParityManualListReversedFixture(), lirParityManualListClearFixture(), lirParityManualMapNewFixture(), lirParityManualMapInsertStringIntFixture(), lirParityManualMapContainsI64Fixture(), lirParityManualMapKeysFixture(), lirParityManualMapLenFixture(), lirParityManualSetInsertStringFixture(), lirParityManualSetContainsI64Fixture(), lirParityManualSetToListFixture(), lirParityManualChanCloseFixture(), lirParityManualYieldFixture(), lirParityManualIsCancelledFixture(), lirParityManualEntrySafepointFixture(), lirParityManualFnAttrInlineAlwaysFixture(), lirParityManualFnAttrHotPureFixture(), lirParityManualFnAttrTargetFeaturesFixture(), lirParityManualFnAttrNoaliasFixture(), lirParityManualStringIndexOfRawFixture(), lirParityManualStringIndexOfOptionFixture(), lirParityManualBytesIndexOfOptionFixture(), lirParityManualChanMakeFixture(), lirParityManualChanIsClosedFixture(), lirParityManualChanSendIntFixture(), lirParityManualChanRecvIntFixture(), lirParityManualStringToIntFixture(), lirParityManualStringToFloatFixture(), lirParityManualMapGetStringIntFixture(), lirParityManualMapGetI64StringFixture(), lirParityManualListFirstIntFixture(), lirParityManualListLastFloatFixture(), lirParityManualListPopIntFixture(), lirParityManualBytesGetFixture(), lirParityManualListToStringIntFixture(), lirParityManualMapToStringFixture(), lirParityManualSetToStringFixture(), lirParityManualCheckCancelledFixture(), lirParityManualListPushBytesV1Fixture(), lirParityManualHandleJoinIntFixture(), lirParityManualGroupCancelFixture(), lirParityManualGroupIsCancelledFixture(), lirParityManualSleepFixture(), lirParityManualMapKeysSortedI64Fixture(), lirParityManualBytesFromStringFixture(), lirParityManualBytesFromListFixture(), lirParityManualBytesToStringFixture(), lirParityManualBytesFromHexFixture(), lirParityManualListGetBytesV1Fixture(), lirParityManualListInsertBytesV1Fixture(), lirParityManualChanSendBytesV1Fixture(), lirParityManualSetRemoveI1Fixture(), lirParityManualTaskGroupUnitFixture(), lirParityManualSpawnDetachedFixture(), lirParityManualSpawnGroupedFixture(), lirParityManualSelectFixture(), lirParityManualSelectRecvFixture(), lirParityManualSelectSendIntFixture(), lirParityManualSelectTimeoutFixture(), lirParityManualSelectDefaultFixture(), lirParityManualParallelFixture(), lirParityManualRaceFixture(), lirParityManualCollectAllFixture(), lirParityManualGcRootBindReleaseFixture(), lirParityManualGcRootMultipleSlotsFixture(), lirParityManualGcRootScalarOnlyFixture(), lirParityManualLoopMDVectorizeFixture(), lirParityManualLoopMDUnrollCountFixture(), lirParityManualLoopMDPlainNoMDFixture(), lirParityManualParallelAccessGroupFixture(), lirParityManualParallelLoopWithAccessGroupFixture(), lirParityManualLoopMDVectorizeWidthFixture(), lirParityManualLoopMDVectorizeFullFixture(), lirParityManualLoopMDUnrollEnableBareFixture(), lirParityManualLoopMDCombinedVectorizeUnrollFixture(), lirParityManualLoopMDParallelOnlyFixture(), lirParityManualOptionIsSomeFixture(), lirParityManualOptionIsNoneFixture(), lirParityManualResultIsOkFixture(), lirParityManualResultIsErrFixture(), lirParityManualRawNullFixture(), lirParityManualListSliceFixture(), lirParityManualListToSetI64Fixture(), lirParityManualListToSetStringFixture(), lirParityManualStringFieldsFixture(), lirParityManualStringSplitNFixture(), lirParityManualOptionUnwrapFixture(), lirParityManualOptionUnwrapOrFixture(), lirParityManualResultUnwrapFixture(), lirParityManualResultUnwrapOrFixture(), lirParityManualListRemoveAtFixture(), lirParityManualMapGetOrFixture(), lirParityManualStringSplitIntoFixture(), lirParityManualStringNthSegmentFixture(), lirParityManualMapIncrStringFixture(), lirParityManualListContainsI64Fixture(), lirParityManualListIndexOfStringFixture()]
 }
 pub fn lirParitySourceFixtures() -> List<LirParityFixture> {
     [lirParitySourceScalarArithmeticFixture(), lirParitySourceScalarBranchFixture(), lirParitySourcePrimitiveByteToCharFixture(), lirParitySourceDirectCallFixture(), lirParitySourceTupleLiteralReadFixture(), lirParitySourceStructLiteralReadFixture(), lirParitySourceNestedProjectedAssignFixture(), lirParitySourceProjectedCallResultFixture(), lirParitySourceProjectedIntrinsicResultFixture(), lirParitySourcePrintlnIntFixture()]
@@ -656,6 +656,15 @@ pub fn lirParityBuildManualModule(name: String) -> MirModule {
     }
     if name == "string_nth_segment" {
         return lirParityBuildStringNthSegmentModule()
+    }
+    if name == "map_incr_string" {
+        return lirParityBuildMapIncrStringModule()
+    }
+    if name == "list_contains_i64" {
+        return lirParityBuildListContainsI64Module()
+    }
+    if name == "list_index_of_string" {
+        return lirParityBuildListIndexOfStringModule()
     }
     mirModule("main")
 }
@@ -2299,6 +2308,56 @@ pub fn lirParityBuildStringNthSegmentModule() -> MirModule {
     let sep = lirParityParam(fn_, "sep", "String")
     let entry = lirParityEntry(fn_)
     mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicStringNthSegment, [mirOperandCopy(mirPlace(s), "String"), mirOperandCopy(mirPlace(sep), "String"), mirOperandConst(mirConstInt(2, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+// ====================================================================
+// MapIncr + ListContains + ListIndexOf
+// ====================================================================
+//
+// Three fixtures pinning intrinsics that previously fell through the
+// unsupported wildcard:
+//
+//   * map_incr_string         — fused `m[k] = m.getOr(k, 0) + delta`
+//                                via osty_rt_map_incr_i64_string
+//   * list_contains_i64       — inline scan loop, i1 dest
+//   * list_index_of_string    — inline scan loop, Option<Int> dest;
+//                                exercises the String-equal runtime
+//                                path (osty_rt_strings_Equal) that
+//                                the i64 lane skips
+pub fn lirParityManualMapIncrStringFixture() -> LirParityFixture {
+    lirParityFixture("map_incr_string", LirParityManualMIR, "/tmp/lir_proto_parity_map_incr_string.osty", "", "phase4-map", ["map", "incr"], [lirParityNeedle("declare i64 @osty_rt_map_incr_i64_string(ptr, ptr, i64)", "incr runtime decl"), lirParityNeedle("call i64 @osty_rt_map_incr_i64_string(", "incr call"), lirParityNeedle("ret i64", "Int return")])
+}
+pub fn lirParityManualListContainsI64Fixture() -> LirParityFixture {
+    lirParityFixture("list_contains_i64", LirParityManualMIR, "/tmp/lir_proto_parity_list_contains_i64.osty", "", "phase4-list", ["list", "contains", "scan"], [lirParityNeedle("declare i64 @osty_rt_list_len(ptr)", "len decl for scan loop"), lirParityNeedle("declare i64 @osty_rt_list_get_i64(ptr, i64)", "per-lane get for scan"), lirParityNeedle("alloca i1", "i1 result slot"), lirParityNeedle("alloca i64", "i64 index slot"), lirParityNeedle("icmp slt i64", "loop continue check"), lirParityNeedle("icmp eq i64", "element equality check"), lirParityNeedle("ret i1", "Bool return")])
+}
+pub fn lirParityManualListIndexOfStringFixture() -> LirParityFixture {
+    lirParityFixture("list_index_of_string", LirParityManualMIR, "/tmp/lir_proto_parity_list_index_of_string.osty", "", "phase4-list", ["list", "index-of", "scan"], [lirParityNeedle("%Option.Int = type", "Option<Int> aggregate def"), lirParityNeedle("declare ptr @osty_rt_list_get_string(ptr, i64)", "string-lane get returns ptr"), lirParityNeedle("declare i1 @osty_rt_strings_Equal(ptr, ptr)", "string equal runtime"), lirParityNeedle("alloca %Option.Int", "Option<Int> result slot"), lirParityNeedle("call i1 @osty_rt_strings_Equal(", "string compare call"), lirParityNeedle("ret %Option.Int", "Option<Int> return")])
+}
+pub fn lirParityBuildMapIncrStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("mapIncr", "Int")
+    let m = lirParityParam(fn_, "m", "Map<String, Int>")
+    let k = lirParityParam(fn_, "k", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicMapIncr, [mirOperandCopy(mirPlace(m), "Map<String, Int>"), mirOperandCopy(mirPlace(k), "String"), mirOperandConst(mirConstInt(1, "Int"))], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListContainsI64Module() -> MirModule {
+    let mut fn_ = lirParityFunction("listContains", "Bool")
+    let xs = lirParityParam(fn_, "xs", "List<Int>")
+    let needle = lirParityParam(fn_, "needle", "Int")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListContains, [mirOperandCopy(mirPlace(xs), "List<Int>"), mirOperandCopy(mirPlace(needle), "Int")], mirNoSpan()))
+    mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
+    lirParityModule([fn_])
+}
+pub fn lirParityBuildListIndexOfStringModule() -> MirModule {
+    let mut fn_ = lirParityFunction("listIndexOf", "Option<Int>")
+    let xs = lirParityParam(fn_, "xs", "List<String>")
+    let needle = lirParityParam(fn_, "needle", "String")
+    let entry = lirParityEntry(fn_)
+    mirFunctionAppend(fn_, entry, mirIntrinsicInstr(true, mirPlace(fn_.returnLocal), MirIntrinsicListIndexOf, [mirOperandCopy(mirPlace(xs), "List<String>"), mirOperandCopy(mirPlace(needle), "String")], mirNoSpan()))
     mirFunctionTerminate(fn_, entry, mirReturnTerm(mirNoSpan()))
     lirParityModule([fn_])
 }


### PR DESCRIPTION
## Summary
- Closes the remaining intrinsic dispatch gaps in \`lirLowerMirIntrinsic\` by landing \`MapIncr\`, \`ListContains\`, and \`ListIndexOf\`.
- ListContains and ListIndexOf share a single \`lirLowerMirListLinearScan\` helper — Bool and Option<Int> versions diverge only in the result-merge slot init/match-store. Mirrors production inline-scan shape.
- MapIncr is the fused \`m[k] += delta\` from \`fuseMapInsertGetOrAdd\` MIR pass: single runtime call.
- Three fixtures pin the shapes including the String-comparison path that the i64 scan skips.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` passes.
- [ ] CI green on the fast lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)