### PR TITLE
feat: ONB Phase A2 Week 4 — loops + match (SwitchIntTerm)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,17 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 4 (loops + match, 2026-05-02)** — `while` / `for ... in 0..N`
+> / 중첩 루프 / `match`(non-const scrutinee 포함)이 모두 native path로 통과.
+> 핵심 발견: while/for/단순 match는 Week 3 multi-block + branch fixup
+> 인프라로 이미 동작 — 별도 lowering 없이도 native. 추가된 것은
+> SwitchIntTerm 한 가지 (non-const scrutinee가 있는 일반 match가 사용):
+> - `BranchCond { Cond, Target }` LIR opcode + Mach-O fixup (`b.cond imm19`)
+> - `lowerSwitchIntTerm`: scrutinee를 x9에 load, 각 case는 `mov x10, #imm;
+>   cmp x9, x10; b.eq case_target`, 마지막에 `b default`
+> - `collectTerminatorReads`가 `SwitchIntTerm.Scrutinee`도 walk
+> 부수: `_ = fnStart` 미사용 변수 정리 (simplify 리뷰 피드백).
+>
 > **Slice A2 Week 3 (control flow, 2026-05-02)** — `if/else` + 6개 비교
 > 연산자 (`==`, `!=`, `<`, `<=`, `>`, `>=`) 분기 코드가 native path로 통과.
 > 패턴 `let x = K; if x > 0 { println(1) } else { println(0) }` 모두 OSTY_ONB_STRICT

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -312,6 +312,127 @@ func TestONBBackendBinaryRunsArithOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendBinaryRunsLoopsAndMatchOnDarwinARM64 exercises the Phase A2
+// Week 4 control-flow expansion: `while`, `for ... in 0..N`, nested loops,
+// and `match` (incl. SwitchIntTerm-shaped lowering on non-const scrutinees).
+// Most of these patterns already worked once Week 3 multi-block + branch
+// fixups landed; the new SwitchIntTerm lowering is what unlocks the last
+// `match` shape via b.cond.
+func TestONBBackendBinaryRunsLoopsAndMatchOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB loop/match executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "while_count_up",
+			src: `fn main() {
+    let mut i = 0
+    while i < 3 {
+        println(i)
+        i = i + 1
+    }
+}`,
+			want: "0\n1\n2\n",
+		},
+		{
+			name: "for_range",
+			src: `fn main() {
+    for i in 0..3 {
+        println(i)
+    }
+}`,
+			want: "0\n1\n2\n",
+		},
+		{
+			name: "nested_for",
+			src: `fn main() {
+    for i in 0..2 {
+        for j in 0..2 {
+            println(i * 10 + j)
+        }
+    }
+}`,
+			want: "0\n1\n10\n11\n",
+		},
+		{
+			name: "while_calls_helper",
+			src: `fn double(n: Int) -> Int { n * 2 }
+fn main() {
+    let mut i = 1
+    while i <= 4 {
+        println(double(i))
+        i = i + 1
+    }
+}`,
+			want: "2\n4\n6\n8\n",
+		},
+		{
+			name: "match_via_fn",
+			src: `fn label(n: Int) -> Int {
+    match n {
+        1 -> 10,
+        2 -> 20,
+        3 -> 30,
+        _ -> 0,
+    }
+}
+fn main() {
+    println(label(1))
+    println(label(2))
+    println(label(3))
+    println(label(4))
+}`,
+			want: "10\n20\n30\n0\n",
+		},
+		{
+			name: "sum_to_n",
+			src: `fn sumTo(n: Int) -> Int {
+    let mut sum = 0
+    let mut i = 1
+    while i <= n {
+        sum = sum + i
+        i = i + 1
+    }
+    sum
+}
+fn main() {
+    println(sumTo(5))
+    println(sumTo(10))
+}`,
+			want: "15\n55\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			if result == nil || result.Artifacts.Binary == "" {
+				t.Fatalf("missing binary artifact: %+v", result)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("binary output = %q, want %q", out, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsIfElseOnDarwinARM64 exercises the Phase A2 Week 3
 // control-flow slice end-to-end. The MIR builder shapes `if cond { ... } else
 // { ... }` into 4 basic blocks (entry → cmp+branch, then, else, merge) plus

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -124,6 +124,8 @@ func renderInstrAssembly(b *strings.Builder, target Target, fn Function, instr I
 		fmt.Fprintf(b, "\tb %s\n", asmBlockLabel(target, fn.Name, i.Target))
 	case *BranchCondNotZero:
 		fmt.Fprintf(b, "\tcbnz %s, %s\n", i.Src, asmBlockLabel(target, fn.Name, i.Target))
+	case *BranchCond:
+		fmt.Fprintf(b, "\tb.%s %s\n", i.Cond.AsmName(), asmBlockLabel(target, fn.Name, i.Target))
 	case *Ret:
 		if frameSize > 0 {
 			if fpOffset < 0 {

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -214,6 +214,17 @@ type BranchCondNotZero struct {
 
 func (*BranchCondNotZero) instrNode() {}
 
+// BranchCond is `b.<cond> <block>` — branch to the target block when the
+// flag-setting predecessor (typically a Cmp) leaves the flags consistent
+// with the named condition. Used by the SwitchIntTerm lowering: each case
+// is `cmp scrutinee, immediate; b.eq case_target`.
+type BranchCond struct {
+	Cond   Cond
+	Target int
+}
+
+func (*BranchCond) instrNode() {}
+
 // LoadCStringAddress materializes the address of a C string literal into a
 // register using the platform's PC-relative addressing form.
 type LoadCStringAddress struct {

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -227,6 +227,12 @@ func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock, isEntry
 			return Block{}, err
 		}
 		instrs = append(instrs, condInstrs...)
+	case *mir.SwitchIntTerm:
+		switchInstrs, err := s.lowerSwitchIntTerm(term)
+		if err != nil {
+			return Block{}, err
+		}
+		instrs = append(instrs, switchInstrs...)
 	default:
 		return Block{}, fmt.Errorf("%w: terminator %T is outside phase 1", ErrUnsupportedShape, block.Term)
 	}
@@ -235,6 +241,30 @@ func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock, isEntry
 		OriginalIndex: int(block.ID),
 		Instrs:        instrs,
 	}, nil
+}
+
+// lowerSwitchIntTerm lowers `match scrutinee { case0, case1, ..., _ ->
+// default }` into a linear chain of `cmp + b.eq` per case followed by an
+// unconditional branch to the default block. Cases are tried in MIR order.
+//
+// This is the textbook decision-tree-as-list dispatch — fine for matches
+// up to a handful of cases. A future slice can graduate it to a jump
+// table when case density / count justifies it.
+func (s *lowerState) lowerSwitchIntTerm(term *mir.SwitchIntTerm) ([]Instr, error) {
+	mat, err := s.materialiseOperand(term.Scrutinee, RegX9)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), mat...)
+	for _, c := range term.Cases {
+		out = append(out,
+			&MovImm64{Dst: RegX10, Imm: c.Value},
+			&Cmp{Lhs: RegX9, Rhs: RegX10},
+			&BranchCond{Cond: CondEq, Target: int(c.Target)},
+		)
+	}
+	out = append(out, &Branch{Target: int(term.Default)})
+	return out, nil
 }
 
 // lowerBranchTerm lowers `BranchTerm{Cond, Then, Else}` into a load + cbnz
@@ -672,12 +702,14 @@ func collectOperandLocals(op mir.Operand, out map[mir.LocalID]bool) {
 }
 
 // collectTerminatorReads handles the branch-/switch-style terminators that
-// read locals through their condition operand. ReturnTerm and GotoTerm
-// don't read user locals at the terminator level.
+// read locals through their condition or scrutinee operand. ReturnTerm and
+// GotoTerm don't read user locals at the terminator level.
 func collectTerminatorReads(term mir.Terminator, out map[mir.LocalID]bool) {
 	switch t := term.(type) {
 	case *mir.BranchTerm:
 		collectOperandLocals(t.Cond, out)
+	case *mir.SwitchIntTerm:
+		collectOperandLocals(t.Scrutinee, out)
 	}
 }
 

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -343,6 +343,7 @@ type machoBranchFixup struct {
 	codeOffset  uint32 // byte offset within enc.code where the branch lives
 	targetBlock int    // original MIR block index of the jump target
 	kind        machoBranchKind
+	cond        Cond // populated for machoBranchCond, ignored otherwise
 }
 
 type machoBranchKind uint8
@@ -350,6 +351,7 @@ type machoBranchKind uint8
 const (
 	machoBranchUncond      machoBranchKind = iota // `b imm26`
 	machoBranchCondNotZero                        // `cbnz Xt, imm19`
+	machoBranchCond                               // `b.<cond> imm19`
 )
 
 // encodeMachOFunction appends one lowered function's prologue, body, and
@@ -362,7 +364,6 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 	if len(fn.Blocks) == 0 {
 		return fmt.Errorf("%w: Mach-O encoder requires at least one block", ErrUnsupportedShape)
 	}
-	fnStart := uint32(len(enc.code))
 	blockOffsets := map[int]uint32{}
 	var fixups []machoBranchFixup
 	frameSize := functionFrameSize(fn)
@@ -503,6 +504,14 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 					return err
 				}
 				enc.code = appendU32LE(enc.code, cbnzWord)
+			case *BranchCond:
+				fixups = append(fixups, machoBranchFixup{
+					codeOffset:  uint32(len(enc.code)),
+					targetBlock: i.Target,
+					kind:        machoBranchCond,
+					cond:        i.Cond,
+				})
+				enc.code = appendU32LE(enc.code, encodeMachOBcondPlaceholder(i.Cond))
 			case *Ret:
 				if frameSize > 0 {
 					if fpOffset < 0 {
@@ -538,7 +547,6 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 			return err
 		}
 	}
-	_ = fnStart
 	return nil
 }
 
@@ -565,6 +573,16 @@ func patchMachOBranch(code []byte, fx machoBranchFixup, displacement int32) erro
 		}
 		// Preserve the Xt field (lower 5 bits) emitted earlier; only the
 		// imm19 field at bits [23:5] needs patching.
+		old := readU32LE(code, off)
+		word := (old &^ (uint32(0x7ffff) << 5)) | ((uint32(imm) & 0x7ffff) << 5)
+		writeU32LE(code, off, word)
+	case machoBranchCond:
+		// b.cond imm19 — 19-bit signed immediate
+		if imm < -(1<<18) || imm >= (1<<18) {
+			return fmt.Errorf("onb: b.cond imm19 out of range (%d)", imm)
+		}
+		// Preserve the cond field (low 4 bits + bit 4 = 0 reserved); only
+		// imm19 at bits [23:5] needs patching.
 		old := readU32LE(code, off)
 		word := (old &^ (uint32(0x7ffff) << 5)) | ((uint32(imm) & 0x7ffff) << 5)
 		writeU32LE(code, off, word)
@@ -625,6 +643,15 @@ func encodeMachOCbnzPlaceholder(src Reg) (uint32, error) {
 		return 0, fmt.Errorf("%w: Mach-O cbnz src %s", ErrNotImplemented, src)
 	}
 	return 0xb5000000 | t, nil
+}
+
+// encodeMachOBcondPlaceholder emits `b.<cond> #0`. The imm19 stays zero
+// until the fixup pass patches it; the condition field at bits [3:0] is
+// already correct.
+//
+//	layout: 0x54000000 | (imm19 << 5) | cond
+func encodeMachOBcondPlaceholder(cond Cond) uint32 {
+	return 0x54000000 | uint32(cond)
 }
 
 func encodeMachOStore64Stack(instr *Store64Stack) (uint32, error) {


### PR DESCRIPTION
## Summary
ONB native path 커버리지가 **루프 + match**까지 확장. 핵심 발견: Week 3 multi-block + branch fixup 인프라가 `while`/`for`/중첩 루프/단순 match를 별도 lowering 없이 이미 처리. 이번 PR이 메우는 한 가지 shape는 **non-const scrutinee의 일반 match (SwitchIntTerm)**.

다음 패턴이 모두 native path로 통과 (`OSTY_ONB_STRICT=1`):

```osty
fn main() {
    let mut i = 0
    while i < 3 { println(i); i = i + 1 }       # → 0, 1, 2
}

fn main() {
    for i in 0..3 { println(i) }                # → 0, 1, 2
}

fn main() {
    for i in 0..2 {
        for j in 0..2 { println(i * 10 + j) }   # → 0, 1, 10, 11
    }
}

fn double(n: Int) -> Int { n * 2 }
fn main() {
    let mut i = 1
    while i <= 4 { println(double(i)); i = i + 1 }   # → 2, 4, 6, 8
}

fn label(n: Int) -> Int {
    match n { 1 -> 10, 2 -> 20, 3 -> 30, _ -> 0 }
}
fn main() {
    println(label(1)); println(label(2)); println(label(3)); println(label(4))
    # → 10, 20, 30, 0
}

fn sumTo(n: Int) -> Int {
    let mut sum = 0; let mut i = 1
    while i <= n { sum = sum + i; i = i + 1 }
    sum
}
fn main() { println(sumTo(5)); println(sumTo(10)) }   # → 15, 55
```

## 변경

**Lowering** (`internal/onb/lower.go`):
- `lowerSwitchIntTerm` 추가: scrutinee를 x9에 load한 뒤 각 case별로 `mov x10, #imm; cmp x9, x10; b.eq case_target` 시퀀스, 마지막에 `b default`
- `collectTerminatorReads`가 `SwitchIntTerm.Scrutinee`도 walk

**LIR** (`internal/onb/lir.go`):
- `BranchCond { Cond, Target }` — `b.<cond> bb<n>`. 기존 `BranchCondNotZero` (cbnz)와 별개

**Mach-O encoder** (`internal/onb/macho.go`):
- `machoBranchCond` fixup kind + `b.cond imm19` placeholder/patch
- 부수 정리: 미사용 `fnStart` 변수 제거 (simplify 리뷰 피드백)

**Asm** (`internal/onb/asm.go`):
- `b.<cond>` rendering

## Test plan
- [x] `go test ./internal/onb/` 통과
- [x] `go test ./internal/backend/` 통과
- [x] **6/6 신규 binary smoke** (`while_count_up`, `for_range`, `nested_for`, `while_calls_helper`, `match_via_fn`, `sum_to_n`)
- [x] `gofmt` / `go vet` 통과
- [ ] CI 그린 확인

## 누적 ONB native coverage

| 패턴 | 슬라이스 |
|---|---|
| `fn main() {}`, `println("literal")`, `println(42)` | Phase 1 |
| `let mut n; n = n + M; println(n)` 산술 | Week 1 |
| `let a; let b; println(a - b * 2)` 표현식 체인 | Week 1 |
| `fn helper(...) -> Int { ... }; main { println(helper(...)) }` | Week 2 |
| `if x op K { ... } else { ... }` (6개 비교 op) | Week 3 |
| **`while` / `for ... in 0..N` / 중첩 루프 / `match`** | **Week 4** |

## 알려진 이슈

- **match-or-pattern** (`1 \| 3 \| 5 -> ...`): MIR builder가 const-folded scrutinee에서 항상 첫 arm으로 dispatch하는 버그로 보임. ONB 범위 밖, 별도 트래킹 필요.

## 다음 의제

- **Week 5 후보 A** — Linear scan RA: 매 op마다 stack load+store하는 비효율 제거. Hot path 2-3× 가속
- **Week 5 후보 B** — DWARF `.debug_line`: lldb backtrace에 source 위치
- **Week 5 후보 C** — String/List 기본 연산: `String.len()`, `List<Int>.push/get` runtime call 경로

🤖 Generated with [Claude Code](https://claude.com/claude-code)