### PR TITLE
perf(regex): DFA-driven find/findAll/captures/replace/split

### DIFF
--- a/examples/regex_dfa_check/main.osty
+++ b/examples/regex_dfa_check/main.osty
@@ -1,0 +1,117 @@
+use std.regex
+
+fn main() {
+    // ── DFA boundary correctness: longer match must extend through
+    //    accept run, not stop at first accept.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            match re.find("12345abc") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("digits: '{t}' [{s}..{e})")
+                },
+                None -> println("digits: no match"),
+            }
+        },
+        Err(_) -> println("digits compile failed"),
+    }
+
+    // ── findAll: each iteration's DFA-bounded NFA must find correct
+    //    boundaries.
+    match regex.compile(r"[a-z]+") {
+        Ok(re) -> {
+            let list = re.findAll("foo 123 bar 456 baz")
+            let n = list.len()
+            println("words: {n}")
+            let mut i = 0
+            while i < n {
+                let m = list[i]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [{i}] '{t}' [{s}..{e})")
+                i += 1
+            }
+        },
+        Err(_) -> println("words compile failed"),
+    }
+
+    // ── Sparse-match findAll: most input is non-matching tail.
+    match regex.compile(r"x+") {
+        Ok(re) -> {
+            let list = re.findAll("aaaaaaaaaaxxxbbbbbbbbbbbb")
+            let n = list.len()
+            println("sparse: {n}")
+            if n > 0 {
+                let m = list[0]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  '{t}' [{s}..{e})")
+            }
+        },
+        Err(_) -> println("sparse compile failed"),
+    }
+
+    // ── Replace with backref under DFA precheck.
+    match regex.compile(r"(\w+)=(\d+)") {
+        Ok(re) -> {
+            let r = re.replaceAll("a=1, b=22, c=333", "[$1->$2]")
+            println("backref: {r}")
+        },
+        Err(_) -> println("backref compile failed"),
+    }
+
+    // ── Split where pattern doesn't match → single piece.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let parts = re.split("hello world")
+            let n = parts.len()
+            println("split-nomatch: {n}")
+            if n > 0 {
+                let p = parts[0]
+                println("  '{p}'")
+            }
+        },
+        Err(_) -> println("split compile failed"),
+    }
+
+    // ── Captures with named groups under DFA precheck.
+    match regex.compile(r"(?P<host>\w+):(?P<port>\d+)") {
+        Ok(re) -> {
+            match re.captures("server:8080") {
+                Some(c) -> {
+                    match c.named("host") {
+                        Some(s) -> println("host: {s}"),
+                        None    -> println("host: <none>"),
+                    }
+                    match c.named("port") {
+                        Some(s) -> println("port: {s}"),
+                        None    -> println("port: <none>"),
+                    }
+                },
+                None -> println("hostport: no match"),
+            }
+        },
+        Err(_) -> println("hostport compile failed"),
+    }
+
+    // ── \b pattern: DFA NOT eligible — must use NFA path
+    //    (verifies our fallback still works correctly).
+    match regex.compile(r"\bword\b") {
+        Ok(re) -> {
+            match re.find("a word in sentence") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("\\bword\\b: '{t}' [{s}..{e})")
+                },
+                None -> println("\\bword\\b: no match"),
+            }
+        },
+        Err(_) -> println("\\b compile failed"),
+    }
+}

--- a/examples/regex_dfa_check/osty.toml
+++ b/examples/regex_dfa_check/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_dfa_check"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -16219,6 +16219,41 @@ static int osty_re_dfa_match(const osty_regex_compiled *re, const char *text, in
     return 0;
 }
 
+/* Phase 9b — DFA-driven boundary scan for find/findAll/captures/etc.
+ *
+ * Returns the leftmost-longest match end position (one past the last
+ * consumed byte) for a match starting at or after `start_offset`, or
+ * -1 when no match exists. Caller has already verified
+ * `dfa_state_count > 0`.
+ *
+ * Greedy semantics under the search DFA: the DFA enters an accept
+ * state at the EARLIEST sp where the pattern can complete, and stays
+ * in accept while the match keeps extending (e.g., `\d+` over
+ * "12345"). The match END is the LAST sp before the DFA leaves accept
+ * — exactly what leftmost-longest wants. Once we leave accept, the
+ * first match is sealed; later positions belong to a separate match
+ * which subsequent calls (with advanced start_offset) will pick up.
+ */
+static int osty_re_dfa_find_first_end_from(const osty_regex_compiled *re, const char *text, int text_len, int start_offset) {
+    const uint8_t *is_match = osty_re_compiled_dfa_is_match(re);
+    const uint16_t *trans = osty_re_compiled_dfa_transitions(re);
+    int state = 0;
+    int last_accept = is_match[state] ? start_offset : -1;
+    int seen_accept = is_match[state];
+    for (int sp = start_offset; sp < text_len; sp++) {
+        unsigned char ch = (unsigned char)text[sp];
+        state = trans[state * 256 + ch];
+        if (is_match[state]) {
+            last_accept = sp + 1;
+            seen_accept = 1;
+        } else if (seen_accept) {
+            /* Just left accept run — first match complete. */
+            return last_accept;
+        }
+    }
+    return last_accept;
+}
+
 /* Run the matcher against text starting at `start_offset` (Phase 2b:
  * exposed so capturesAll can scan past prior matches). `^` still
  * binds to absolute position 0 — start_offset only shifts the search
@@ -16555,7 +16590,21 @@ void *osty_rt_regex_find(void *raw_re, const char *text) {
     int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
     int slot_count = 2 * re->ngroups;
     for (int i = 0; i < slot_count; i++) slots[i] = -1;
-    if (!osty_re_match_from(re, src, len, 0, slots)) {
+    /* Phase 9b — DFA boundary precheck. When the DFA is built and says
+     * no match exists, skip the NFA scan entirely (typical no-match
+     * inputs were the dominant Pike VM cost). When the DFA says a
+     * match ends at `dfa_end`, bound the NFA's text_len to that — the
+     * NFA only needs to verify and extract captures within the known
+     * matched region. */
+    int nfa_text_len = len;
+    if (re->dfa_state_count > 0) {
+        int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, 0);
+        if (dfa_end < 0) {
+            return NULL;
+        }
+        nfa_text_len = dfa_end;
+    }
+    if (!osty_re_match_from(re, src, nfa_text_len, 0, slots)) {
         return NULL;
     }
     int32_t start = slots[0];
@@ -16607,7 +16656,20 @@ void *osty_rt_regex_find_all(void *raw_re, const char *text) {
     int start = 0;
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        if (!osty_re_match_from(re, src, len, start, slots)) {
+        /* Phase 9b — DFA boundary precheck. Cuts NFA scans over
+         * non-matching tail regions (the dominant cost when matches
+         * are sparse). NFA's text_len gets bounded to the DFA-known
+         * match end so capture extraction stays in the matched
+         * region. */
+        int nfa_text_len = len;
+        if (re->dfa_state_count > 0) {
+            int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, start);
+            if (dfa_end < 0) {
+                break;
+            }
+            nfa_text_len = dfa_end;
+        }
+        if (!osty_re_match_from(re, src, nfa_text_len, start, slots)) {
             break;
         }
         int32_t match_start = slots[0];
@@ -16696,7 +16758,16 @@ static void *osty_rt_regex_replace_impl(void *raw_re, const char *text, const ch
     int substituted = 0;
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        if (!osty_re_match_from(re, src, len, start, slots)) {
+        /* Phase 9b — DFA boundary precheck (see find_all comment). */
+        int nfa_text_len = len;
+        if (re->dfa_state_count > 0) {
+            int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, start);
+            if (dfa_end < 0) {
+                break;
+            }
+            nfa_text_len = dfa_end;
+        }
+        if (!osty_re_match_from(re, src, nfa_text_len, start, slots)) {
             break;
         }
         int32_t match_start = slots[0];
@@ -16820,7 +16891,16 @@ void *osty_rt_regex_split(void *raw_re, const char *text) {
     int start = 0;
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        if (!osty_re_match_from(re, src, len, start, slots)) {
+        /* Phase 9b — DFA boundary precheck (see find_all comment). */
+        int nfa_text_len = len;
+        if (re->dfa_state_count > 0) {
+            int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, start);
+            if (dfa_end < 0) {
+                break;
+            }
+            nfa_text_len = dfa_end;
+        }
+        if (!osty_re_match_from(re, src, nfa_text_len, start, slots)) {
             break;
         }
         int32_t match_start = slots[0];
@@ -16858,7 +16938,16 @@ void *osty_rt_regex_captures(void *raw_re, const char *text) {
     int32_t slots[OSTY_RE_MAX_CAP_SLOTS];
     int slot_count = 2 * re->ngroups;
     for (int i = 0; i < slot_count; i++) slots[i] = -1;
-    if (!osty_re_match_from(re, src, len, 0, slots)) {
+    /* Phase 9b — DFA boundary precheck (see find_all comment). */
+    int nfa_text_len = len;
+    if (re->dfa_state_count > 0) {
+        int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, 0);
+        if (dfa_end < 0) {
+            return NULL;
+        }
+        nfa_text_len = dfa_end;
+    }
+    if (!osty_re_match_from(re, src, nfa_text_len, 0, slots)) {
         return NULL;
     }
     return osty_re_build_captures(re, src, len, slots);
@@ -16887,7 +16976,16 @@ void *osty_rt_regex_captures_all(void *raw_re, const char *text) {
     int start = 0;
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        if (!osty_re_match_from(re, src, len, start, slots)) {
+        /* Phase 9b — DFA boundary precheck (see find_all comment). */
+        int nfa_text_len = len;
+        if (re->dfa_state_count > 0) {
+            int dfa_end = osty_re_dfa_find_first_end_from(re, src, len, start);
+            if (dfa_end < 0) {
+                break;
+            }
+            nfa_text_len = dfa_end;
+        }
+        if (!osty_re_match_from(re, src, nfa_text_len, start, slots)) {
             break;
         }
         int32_t match_start = slots[0];


### PR DESCRIPTION
## Summary
Phase 9 DFA를 `matches()` 외에도 모든 search-iterating 진입점(`find` / `findAll` / `captures` / `capturesAll` / `replace` / `replaceAll` / `split`)에서 boundary-finding 역할로 활용. 두 win:

1. **매치 없는 입력**: NFA Pike VM 호출 자체를 스킵. DFA 한 번의 forward 스캔으로 조기 종료. 검증/필터링 패턴(대부분 fail)의 dominant 비용 제거.
2. **매치 있는 입력**: NFA의 `text_len`을 DFA가 찾은 leftmost-longest 매치 end로 bound → NFA가 매치된 영역만 스캔하면서 captures 추출. Sparse 매치 + 긴 trailing tail 패턴에서 큰 절감.

## 핵심 헬퍼
`osty_re_dfa_find_first_end_from(re, text, len, start)`:
- search DFA가 `start` 이후 첫 **leftmost-longest** 매치의 end 위치를 forward-only 한 번 스캔으로 반환
- accept-state run에서 마지막 sp를 추적하다 run을 벗어나면 그 sp가 greedy match end. 매치 없으면 -1
- DFA가 search semantics (모든 state가 seed 포함) 라서 한 번의 forward 스캔이면 충분

## 통합 (`re->dfa_state_count > 0` 일 때만 활성, 그렇지 않으면 NFA 단독)
- `find` / `captures`: precheck → no match면 즉시 NULL, 매치면 NFA가 bounded text_len으로 captures 채움
- `findAll` / `capturesAll` / `replaceImpl` / `split`: 매 루프 iteration마다 DFA precheck. no-more-match면 break, else NFA bounded scan으로 단일 매치 처리

## Anchored / `\b` 패턴
DFA 미빌드 → 기존 NFA loop 그대로. `regex_extensions` (\\b foo \\b) / `regex_dfa_check` (\\bword\\b) 예제로 fallback 정합성 확인.

## Captures 정합성
NFA는 leftmost-longest, DFA도 동일 — 둘이 같은 매치를 찾으므로 DFA-bounded NFA 스캔이 정확한 captures 추출. Match end가 같다는 것이 안전성 근거.

## Test plan
- [x] llvmgen short suite (~20s) 통과
- [x] 10개 E2E 모두 정확:
  - regex_smoke / regex_captures / regex_captures_all / regex_replace_split / regex_find / regex_named / regex_find_all / regex_extensions / regex_advanced / uuid_smoke
- [x] 신규 [examples/regex_dfa_check/main.osty](examples/regex_dfa_check/main.osty) — 7 케이스:
  - `\d+` greedy boundary on `"12345abc"` → `[0..5)`
  - `[a-z]+` findAll on `"foo 123 bar 456 baz"` → 3 정확한 위치
  - `x+` sparse on `"aaaaxxxbbb..."` → `[10..13)`
  - `(\w+)=(\d+)` replaceAll backref → `[a->1], [b->22], [c->333]`
  - `\d+` split on `"hello world"` → 1 piece (whole)
  - `(?P<host>\w+):(?P<port>\d+)` named captures
  - `\bword\b` (NFA fallback path) — 정확
- [x] `just fmt-check` / `just vet` clean
- [ ] CI 그린 확인

## 후속 후보
- Backward DFA로 매치 START도 DFA로 찾기 (NFA scan 영역을 더 줄임)
- Lazy DFA + LRU 캐시 (state 폭발 패턴 방어)
- Literal prefix Boyer-Moore pre-scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)