### PR TITLE
fix: regex flat-alternation parser drops branches 1..N-2 for N>=3

### DIFF
--- a/examples/regex_alt_wide/main.osty
+++ b/examples/regex_alt_wide/main.osty
@@ -1,0 +1,63 @@
+use std.regex
+
+// Regression: wide flat alternations under a `+` quantifier (and bare
+// alternations with three or more branches). Earlier the parser's
+// shift-and-bump pass in osty_re_parse_alt used a strict `<` upper
+// bound, so the JMP that closed the previously parsed branch — patched
+// to ps->prog_len, exactly equal to the next iteration's branch_end —
+// was left unbumped. After the shift it pointed at the stray last
+// instruction of the most recently added branch, breaking every
+// branch except the last two. Tokenizer-style alternations are common
+// (URL schemes, keyword sets) so this matters for real callers.
+
+fn main() {
+    // 24-branch alt under `+`. Expect every match to land:
+    //   abx [0..3), aby [4..7), aby [8..11), abz [12..15),
+    //   abk [19..22), abkabq [23..29).
+    match regex.compile(r"(abc|abd|abe|abf|abg|abh|abi|abj|abk|abl|abm|abn|abo|abp|abq|abr|abs|abt|abu|abv|abw|abx|aby|abz)+") {
+        Ok(re) -> {
+            let list = re.findAll("abx aby aby abz NO abk abkabq")
+            let n = list.len()
+            println("wide+: {n}")
+            let mut i = 0
+            for _ in 0..n {
+                let m = list[i]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [{i}] '{t}' [{s}..{e})")
+                i += 1
+            }
+            // Captures path: one `+`-driven match spanning three branches.
+            match re.captures("xxabkabxabq yy") {
+                Some(c) -> match c.get(0) {
+                    Some(s) -> println("captures: '{s}'"),
+                    None    -> println("captures: group 0 unset"),
+                },
+                None -> println("captures: no match"),
+            }
+        },
+        Err(_) -> println("wide+ compile failed"),
+    }
+
+    // Bare 5-way alt (no quantifier). All five branches must match.
+    // (`https` is listed before `http` so the leftmost-priority Pike VM
+    // doesn't match `https` as the shorter `http`.)
+    match regex.compile(r"(https|http|ftp|ssh|file)") {
+        Ok(re) -> {
+            let list = re.findAll("http ssh nope ftp https file")
+            let n = list.len()
+            println("scheme: {n}")
+            let mut i = 0
+            for _ in 0..n {
+                let m = list[i]
+                let t = m.text
+                let s = m.start
+                let e = m.end
+                println("  [{i}] '{t}' [{s}..{e})")
+                i += 1
+            }
+        },
+        Err(_) -> println("scheme compile failed"),
+    }
+}

--- a/examples/regex_alt_wide/osty.toml
+++ b/examples/regex_alt_wide/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_alt_wide"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -15836,12 +15836,22 @@ static int osty_re_parse_alt(osty_re_parser *ps) {
             ps->prog[i] = ps->prog[i - 1];
         }
         ps->prog_len++;
-        /* Adjust internal jumps in the shifted block. */
+        /* Adjust internal jumps in the shifted block. Use the inclusive
+         * upper bound `<= branch_end`: the JMP that closed the previous
+         * branch was patched at end of the prior iteration to
+         * ps->prog_len, which is exactly branch_end here. After the
+         * shift, "branch_end" in old coords is "branch_end + 1" in new
+         * coords (the next free slot, where the new JMP will land), so
+         * that target needs the +1 too. Strict `<` left those
+         * past-end-of-block targets unbumped, which after the shift
+         * pointed at the stray last-instruction byte of the previously
+         * added branch — corrupting every alternation with three or
+         * more branches. */
         for (int i = branch_start + 1; i <= branch_end; i++) {
             osty_re_inst *ins = &ps->prog[i];
             if (ins->op == OSTY_RE_OP_JMP || ins->op == OSTY_RE_OP_SPLIT) {
-                if (ins->x >= branch_start && ins->x < branch_end) ins->x++;
-                if (ins->op == OSTY_RE_OP_SPLIT && ins->y >= branch_start && ins->y < branch_end) ins->y++;
+                if (ins->x >= branch_start && ins->x <= branch_end) ins->x++;
+                if (ins->op == OSTY_RE_OP_SPLIT && ins->y >= branch_start && ins->y <= branch_end) ins->y++;
             }
         }
         /* Place JMP after the shifted block. */


### PR DESCRIPTION
## Summary

The regex parser's `osty_re_parse_alt` shift-and-bump pass used a strict `<` upper bound when adjusting JMP/SPLIT targets after each `|`. The previous iteration's branch-end JMP was patched at end-of-iter to `ps->prog_len`, which equals the next iteration's `branch_end` exactly — so the strict bound left it unbumped. After the shift it pointed at the stray last instruction of the most recently added branch, which (almost) never matches the input that comes after a successful branch literal. Net effect: only the last two branches of any 3+ way alternation matched correctly.

Repro before the fix:

```osty
let re = regex.compile(r"(abc|abd|abe|abf|abg)+").unwrap()
re.findAll("abc abd abe abf abg")
// Got: [abf [12..15), abg [16..19)]
// Want: [abc, abd, abe, abf, abg]
```

The fix flips the comparison to `<= branch_end` so JMP/SPLIT targets sitting exactly at the past-end-of-block sentinel get the +1 too. Comments updated to spell out why the inclusive bound is necessary, since the off-by-one is subtle.

The bug pre-dates the in-flight lazy-DFA work — confirmed against `origin/main` HEAD `2544e948`. Patterns of the form `(prefix1|prefix2|...|prefixN)+` show up in tokenizers and URL-scheme parsers, so this matters for real callers.

## Test plan

- [x] Original 24-branch repro: 6 expected `findAll` matches, captures returns `'abkabxabq'` for `"xxabkabxabq yy"`.
- [x] All 11 existing `examples/regex_*/` E2Es continue to produce sensible output (manually inspected — outputs match spec semantics for find/captures/replace/split, anchors, lookaround-style, named groups, captures-all, the backward DFA, and DFA fast-path).
- [x] `go test ./internal/stdlib/ -run TestRegex`, `./internal/llvmgen -run "Regex"`, `./internal/backend -run "Regex"` — all pass.
- [x] `just front` (front-end go tests + spec corpus) — pass.
- [x] New `examples/regex_alt_wide/` regression example added (24-branch + bare 5-way alt).

Generated with [Claude Code](https://claude.com/claude-code)