### PR TITLE
perf(regex): literal prefix fast-path via memmem (Phase 9f)

### DIFF
--- a/examples/regex_literal_prefix/main.osty
+++ b/examples/regex_literal_prefix/main.osty
@@ -1,0 +1,119 @@
+use std.regex
+
+fn main() {
+    // ── Bare literal: every match must equal "foo".
+    match regex.compile(r"foo") {
+        Ok(re) -> {
+            match re.find("aaaaaaaaaaaaaaaaaaaaaaafooBBB") {
+                Some(m) -> {
+                    let s = m.start
+                    let e = m.end
+                    println("bare-literal: [{s}..{e})")
+                },
+                None -> println("bare-literal: no match"),
+            }
+            let absent = re.matches("aaaaaaaaaaaaaaaaaaaa")
+            println("bare-literal-absent: {absent}")
+        },
+        Err(_) -> println("bare-literal compile failed"),
+    }
+
+    // ── Literal prefix + quantifier: prefix is "foo", body is \d+.
+    //    memmem skips ahead to "foo" candidates; DFA verifies digits.
+    match regex.compile(r"foo\d+") {
+        Ok(re) -> {
+            let list = re.findAll("xx foo123 yy fooABC zz foo7 ww")
+            let n = list.len()
+            println("prefix+quantifier: {n}")
+            let mut i = 0
+            for _ in 0..n {
+                let m = list[i]
+                let t = m.text
+                println("  [{i}] '{t}'")
+                i += 1
+            }
+        },
+        Err(_) -> println("prefix+quantifier compile failed"),
+    }
+
+    // ── Literal prefix that doesn't lead to a match: "foo" present
+    //    but \d+ doesn't follow. memmem still finds candidates;
+    //    DFA correctly rules them out.
+    match regex.compile(r"foo\d+") {
+        Ok(re) -> {
+            let r = re.matches("fooABC fooXYZ")
+            println("prefix-nomatch: {r}")
+        },
+        Err(_) -> println("prefix-nomatch compile failed"),
+    }
+
+    // ── Long literal prefix.
+    match regex.compile(r"https://example") {
+        Ok(re) -> {
+            match re.find("see https://example.com for details") {
+                Some(m) -> {
+                    let s = m.start
+                    let e = m.end
+                    println("long-literal: [{s}..{e})")
+                },
+                None -> println("long-literal: no match"),
+            }
+        },
+        Err(_) -> println("long-literal compile failed"),
+    }
+
+    // ── replaceAll exercises the cursor-vs-start split: unmatched
+    //    spans between matches must be preserved verbatim, even
+    //    when memmem skips over them.
+    match regex.compile(r"err:\w+") {
+        Ok(re) -> {
+            let r = re.replaceAll("note ok ok err:foo more ok err:bar end", "[E]")
+            println("replace-with-prefix: {r}")
+        },
+        Err(_) -> println("replace-with-prefix compile failed"),
+    }
+
+    // ── split with literal prefix.
+    match regex.compile(r"<sep>") {
+        Ok(re) -> {
+            let parts = re.split("aaa<sep>bbb<sep>ccc")
+            let n = parts.len()
+            println("split: {n}")
+            let mut i = 0
+            for _ in 0..n {
+                let p = parts[i]
+                println("  [{i}] '{p}'")
+                i += 1
+            }
+        },
+        Err(_) -> println("split compile failed"),
+    }
+
+    // ── No literal prefix (alternation at top level): optimization
+    //    silently disabled, normal DFA / NFA path runs.
+    match regex.compile(r"\d+") {
+        Ok(re) -> {
+            let list = re.findAll("a 12 b 345 c")
+            let n = list.len()
+            println("no-prefix: {n}")
+        },
+        Err(_) -> println("no-prefix compile failed"),
+    }
+
+    // ── \b prefix: walker stops at WB instruction, so no literal
+    //    prefix is extracted. NFA fallback must still work.
+    match regex.compile(r"\bword\b") {
+        Ok(re) -> {
+            match re.find("a word in sentence") {
+                Some(m) -> {
+                    let t = m.text
+                    let s = m.start
+                    let e = m.end
+                    println("wb-prefix: '{t}' [{s}..{e})")
+                },
+                None -> println("wb-prefix: no match"),
+            }
+        },
+        Err(_) -> println("wb compile failed"),
+    }
+}

--- a/examples/regex_literal_prefix/osty.toml
+++ b/examples/regex_literal_prefix/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "regex_literal_prefix"
+version = "0.1.0"
+edition = "0.5"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -14757,12 +14757,24 @@ typedef struct osty_regex_compiled {
      *                                over `prog`. preds_total == -1
      *                                means "not embedded" (eager
      *                                backward DFA succeeded, so lazy
-     *                                backward isn't needed). */
+     *                                backward isn't needed).
+     *   literal_prefix_len > 0     → pattern starts with a fixed byte
+     *                                literal (Phase 9f). Every match
+     *                                must begin with this exact
+     *                                sequence, so each entry function
+     *                                runs `memmem` from its current
+     *                                start cursor to find the next
+     *                                candidate position before
+     *                                dispatching to the DFA / NFA.
+     *                                Skips entire spans of input that
+     *                                cannot contain a match. The
+     *                                bytes live inline in the tail. */
     int32_t dfa_state_count;
     int32_t dfa_back_state_count;
     int32_t dfa_lazy_eligible;
     int32_t preds_total;
-    /* Inline tail (Phase 9e layout):
+    int32_t literal_prefix_len;
+    /* Inline tail (Phase 9f layout):
      *   prog[prog_len], classes[class_count],
      *   osty_re_name_entry name_table[name_count],
      *   char name_data[name_data_len],
@@ -14772,6 +14784,7 @@ typedef struct osty_regex_compiled {
      *   uint16_t dfa_back_transitions[dfa_back_state_count * 256],
      *   int32_t preds_offsets[prog_len + 1]   (preds_total >= 0)
      *   int32_t preds_flat[preds_total]       (preds_total >= 0)
+     *   char literal_prefix[literal_prefix_len] (when > 0)
      * Tails are only present when their counts are > 0 (or, for preds,
      * when preds_total >= 0). The lazy DFA itself has no tail bytes —
      * its state cache lives in stack/heap memory for the duration of
@@ -14864,6 +14877,17 @@ static inline const int32_t *osty_re_compiled_preds_offsets(const osty_regex_com
 
 static inline const int32_t *osty_re_compiled_preds_flat(const osty_regex_compiled *re) {
     return osty_re_compiled_preds_offsets(re) + (size_t)re->prog_len + 1;
+}
+
+/* Phase 9f — embedded literal prefix tail. Only present when
+ * literal_prefix_len > 0; sits after the preds tail (or after the
+ * back-DFA tail when preds aren't embedded). */
+static inline const char *osty_re_compiled_literal_prefix(const osty_regex_compiled *re) {
+    const int32_t *preds_end = osty_re_compiled_preds_offsets(re);
+    if (re->preds_total >= 0) {
+        preds_end = osty_re_compiled_preds_flat(re) + (size_t)re->preds_total;
+    }
+    return (const char *)preds_end;
 }
 
 /* Parser scratch state. The growing instruction / class buffers live
@@ -16048,6 +16072,34 @@ static void osty_re_add_thread_caps(osty_re_vm *vm, const osty_re_inst *prog, in
 
 #define OSTY_RE_DFA_MAX_STATES 1024
 
+/* Phase 9f — cap on extracted literal prefix bytes. Patterns with
+ * longer literal prefixes are truncated; the DFA still verifies the
+ * full match, so truncation is purely a storage / scan-cost tradeoff.
+ * 64 bytes covers virtually every real-world prefix (URL schemes,
+ * error tags, log line markers, etc.) while bounding worst-case
+ * memmem cost. */
+#define OSTY_RE_LITERAL_PREFIX_MAX 64
+
+/* Portable substring search. Falls back from glibc / BSD memmem so the
+ * runtime stays buildable on Windows MSVC. Single-byte needle uses
+ * memchr (SIMD-vectorized in modern libcs); larger needles use a
+ * naive loop, which is fine for short literal prefixes. */
+static const char *osty_rt_memmem(const char *haystack, size_t hlen, const char *needle, size_t nlen) {
+    if (nlen == 0) return haystack;
+    if (nlen > hlen) return NULL;
+    if (nlen == 1) return (const char *)memchr(haystack, (unsigned char)needle[0], hlen);
+    unsigned char first = (unsigned char)needle[0];
+    size_t scan_limit = hlen - nlen + 1;
+    size_t i = 0;
+    while (i < scan_limit) {
+        const char *seek = (const char *)memchr(haystack + i, first, scan_limit - i);
+        if (seek == NULL) return NULL;
+        if (memcmp(seek, needle, nlen) == 0) return seek;
+        i = (size_t)(seek - haystack) + 1;
+    }
+    return NULL;
+}
+
 /* Bitset over NFA PCs. word_count = ceil(prog_len / 64). */
 typedef struct {
     int prog_len;
@@ -17046,6 +17098,30 @@ static int osty_re_dfa_or_lazy_find_match_start(const osty_regex_compiled *re,
     return -1;
 }
 
+/* Phase 9f — advance `start` to the next position where the pattern's
+ * literal prefix could begin. When the regex has no literal prefix
+ * (most patterns starting with metachars or alternations), returns
+ * `start` unchanged so the caller proceeds with normal DFA / NFA
+ * scan. Returns -1 when memmem rules out any further match — the
+ * entry function's outer loop should `break` (or return no-match).
+ *
+ * Soundness rests on: every match's first byte is the prefix's first
+ * byte, by construction of the compile-time extractor. So no match
+ * can begin before the leftmost prefix occurrence at or after
+ * `start`, and skipping ahead is safe for both leftmost-match
+ * (find/captures) and non-overlapping iteration (findAll/etc.). */
+static int osty_re_advance_to_literal_prefix(const osty_regex_compiled *re,
+                                                const char *text, int text_len, int start) {
+    if (re->literal_prefix_len <= 0) return start;
+    if (start < 0) start = 0;
+    if (start > text_len) return -1;
+    const char *prefix = osty_re_compiled_literal_prefix(re);
+    const char *hit = osty_rt_memmem(text + start, (size_t)(text_len - start),
+                                      prefix, (size_t)re->literal_prefix_len);
+    if (hit == NULL) return -1;
+    return (int)(hit - text);
+}
+
 /* Phase 9b — DFA-driven boundary scan for find/findAll/captures/etc.
  *
  * Returns the FIRST sp at which the search DFA enters an accept state
@@ -17266,6 +17342,7 @@ void *osty_rt_regex_compile(const char *pattern) {
     probe.dfa_back_state_count = 0;
     probe.dfa_lazy_eligible = 0;
     probe.preds_total = -1;
+    probe.literal_prefix_len = 0;
     uint16_t *dfa_trans = NULL;
     uint8_t *dfa_match = NULL;
     uint16_t *dfa_back_trans = NULL;
@@ -17315,12 +17392,32 @@ void *osty_rt_regex_compile(const char *pattern) {
             has_embedded_preds = 1;
         }
     }
+    /* Phase 9f — extract any literal prefix the pattern starts with.
+     * Walk forward from PC 0, skip zero-width SAVE instructions, and
+     * collect consecutive CHAR bytes. Stop at the first non-CHAR /
+     * non-SAVE op (CCLASS, ANY, SPLIT, JMP, anchor, MATCH). Bounded
+     * by OSTY_RE_LITERAL_PREFIX_MAX so the inline tail stays small.
+     * Patterns with no leading literal (`\d+`, `[a-z]+`, `(?i)foo`,
+     * `(foo|bar)`, `\bword`, ...) yield length 0 and silently skip
+     * the optimization. */
+    char literal_prefix_buf[OSTY_RE_LITERAL_PREFIX_MAX];
+    int literal_prefix_len = 0;
+    for (int pc = 0; pc < ps.prog_len && literal_prefix_len < OSTY_RE_LITERAL_PREFIX_MAX; pc++) {
+        osty_re_inst ins = ps.prog[pc];
+        if (ins.op == OSTY_RE_OP_SAVE) continue;
+        if (ins.op == OSTY_RE_OP_CHAR) {
+            literal_prefix_buf[literal_prefix_len++] = (char)ins.c;
+            continue;
+        }
+        break;
+    }
     size_t dfa_match_bytes = (size_t)dfa_states;
     size_t dfa_trans_bytes = (size_t)dfa_states * 256 * sizeof(uint16_t);
     size_t dfa_back_match_bytes = (size_t)dfa_back_states;
     size_t dfa_back_trans_bytes = (size_t)dfa_back_states * 256 * sizeof(uint16_t);
     size_t preds_offsets_bytes = has_embedded_preds ? sizeof(int32_t) * ((size_t)ps.prog_len + 1) : 0;
     size_t preds_flat_bytes = has_embedded_preds ? sizeof(int32_t) * (size_t)embedded_preds.total : 0;
+    size_t literal_prefix_bytes = (size_t)literal_prefix_len;
 
     /* Allocate one contiguous GC blob: header + prog + classes + name table + name data + dfa + back-dfa + preds. */
     size_t hdr = sizeof(osty_regex_compiled);
@@ -17330,7 +17427,7 @@ void *osty_rt_regex_compile(const char *pattern) {
     size_t name_data_bytes = (size_t)ps.name_data_len;
     size_t total = hdr + prog_bytes + class_bytes + name_table_bytes + name_data_bytes
         + dfa_match_bytes + dfa_trans_bytes + dfa_back_match_bytes + dfa_back_trans_bytes
-        + preds_offsets_bytes + preds_flat_bytes;
+        + preds_offsets_bytes + preds_flat_bytes + literal_prefix_bytes;
     osty_regex_compiled *re = (osty_regex_compiled *)osty_gc_allocate_managed(total, OSTY_GC_KIND_GENERIC, "runtime.regex.compile", NULL, NULL);
     re->prog = (osty_re_inst *)((char *)re + hdr);
     re->prog_len = ps.prog_len;
@@ -17343,6 +17440,7 @@ void *osty_rt_regex_compile(const char *pattern) {
     re->dfa_back_state_count = dfa_back_states;
     re->dfa_lazy_eligible = dfa_lazy_eligible;
     re->preds_total = has_embedded_preds ? embedded_preds.total : -1;
+    re->literal_prefix_len = literal_prefix_len;
     if (ps.prog_len > 0) memcpy(re->prog, ps.prog, prog_bytes);
     if (ps.class_count > 0) memcpy(re->classes, ps.classes, class_bytes);
     if (ps.name_count > 0) {
@@ -17365,6 +17463,9 @@ void *osty_rt_regex_compile(const char *pattern) {
             memcpy((int32_t *)osty_re_compiled_preds_flat(re), embedded_preds.flat, preds_flat_bytes);
         }
         osty_re_preds_free(&embedded_preds);
+    }
+    if (literal_prefix_len > 0) {
+        memcpy((char *)osty_re_compiled_literal_prefix(re), literal_prefix_buf, literal_prefix_bytes);
     }
     free(ps.prog);
     free(ps.classes);
@@ -17393,6 +17494,13 @@ bool osty_rt_regex_matches(void *raw_re, const char *text) {
     if (src == NULL) src = "";
     osty_rt_string_decode_to_buf_if_inline(&src, inline_buf);
     int len = (int)strlen(src);
+    /* Phase 9f — if the pattern has a literal prefix, no match can
+     * exist unless that prefix appears somewhere in the input. Fast
+     * memmem rejection avoids spinning up a DFA / NFA at all. */
+    if (re->literal_prefix_len > 0
+            && osty_re_advance_to_literal_prefix(re, src, len, 0) < 0) {
+        return false;
+    }
     /* Phase 9 — DFA fast path. Available for patterns without `^`/`$`/
      * `\b`/`\B` and within OSTY_RE_DFA_MAX_STATES; Phase 9d adds a
      * per-call lazy DFA for compatible patterns whose state space
@@ -17496,15 +17604,20 @@ void *osty_rt_regex_find(void *raw_re, const char *text) {
      * per-call lazy DFA + LRU runs the same protocol. */
     osty_re_lazy_pair pair;
     osty_re_lazy_pair_init(&pair, re);
-    int nfa_start = 0;
     void *out = NULL;
-    int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, 0);
+    /* Phase 9f — fast-skip to the leftmost literal-prefix occurrence
+     * (no-op when the pattern has no extracted prefix). */
+    int nfa_start = osty_re_advance_to_literal_prefix(re, src, len, 0);
+    if (nfa_start < 0) {
+        goto find_done;
+    }
+    int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, nfa_start);
     if (dfa_end == -1) {
         goto find_done;
     }
     if (dfa_end >= 0) {
         int dfa_start = osty_re_dfa_or_lazy_find_match_start(re, pair.back, src, dfa_end);
-        if (dfa_start >= 0 && dfa_start <= dfa_end) {
+        if (dfa_start >= nfa_start && dfa_start <= dfa_end) {
             nfa_start = dfa_start;
         }
     }
@@ -17567,6 +17680,11 @@ void *osty_rt_regex_find_all(void *raw_re, const char *text) {
     osty_re_lazy_pair_init(&pair, re);
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        /* Phase 9f — bump cursor to the next literal-prefix candidate
+         * before any DFA work. memmem returning -1 means "no more
+         * matches possible past this point" — break cleanly. */
+        start = osty_re_advance_to_literal_prefix(re, src, len, start);
+        if (start < 0) break;
         int nfa_start = start;
         int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, start);
         if (dfa_end == -1) {
@@ -17670,14 +17788,20 @@ static void *osty_rt_regex_replace_impl(void *raw_re, const char *text, const ch
     osty_re_lazy_pair_init(&pair, re);
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        int nfa_start = start;
-        int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, start);
+        /* Phase 9f — `cursor` is the literal-prefix-advanced search
+         * position; `start` stays at the byte just past the previous
+         * match so the unmatched span between matches is emitted
+         * verbatim into the output buffer. */
+        int cursor = osty_re_advance_to_literal_prefix(re, src, len, start);
+        if (cursor < 0) break;
+        int nfa_start = cursor;
+        int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, cursor);
         if (dfa_end == -1) {
             break;
         }
         if (dfa_end >= 0) {
             int dfa_start = osty_re_dfa_or_lazy_find_match_start(re, pair.back, src, dfa_end);
-            if (dfa_start > start && dfa_start <= dfa_end) {
+            if (dfa_start > cursor && dfa_start <= dfa_end) {
                 nfa_start = dfa_start;
             }
         }
@@ -17808,14 +17932,19 @@ void *osty_rt_regex_split(void *raw_re, const char *text) {
     osty_re_lazy_pair_init(&pair, re);
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
-        int nfa_start = start;
-        int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, start);
+        /* Phase 9f — `start` stays at the byte just past the previous
+         * match so each split piece keeps the unmatched span verbatim;
+         * `cursor` is the literal-prefix-advanced search position. */
+        int cursor = osty_re_advance_to_literal_prefix(re, src, len, start);
+        if (cursor < 0) break;
+        int nfa_start = cursor;
+        int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, cursor);
         if (dfa_end == -1) {
             break;
         }
         if (dfa_end >= 0) {
             int dfa_start = osty_re_dfa_or_lazy_find_match_start(re, pair.back, src, dfa_end);
-            if (dfa_start > start && dfa_start <= dfa_end) {
+            if (dfa_start > cursor && dfa_start <= dfa_end) {
                 nfa_start = dfa_start;
             }
         }
@@ -17863,15 +17992,18 @@ void *osty_rt_regex_captures(void *raw_re, const char *text) {
      * nfa_start. */
     osty_re_lazy_pair pair;
     osty_re_lazy_pair_init(&pair, re);
-    int nfa_start = 0;
     void *out = NULL;
-    int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, 0);
+    int nfa_start = osty_re_advance_to_literal_prefix(re, src, len, 0);
+    if (nfa_start < 0) {
+        goto captures_done;
+    }
+    int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, nfa_start);
     if (dfa_end == -1) {
         goto captures_done;
     }
     if (dfa_end >= 0) {
         int dfa_start = osty_re_dfa_or_lazy_find_match_start(re, pair.back, src, dfa_end);
-        if (dfa_start >= 0 && dfa_start <= dfa_end) {
+        if (dfa_start >= nfa_start && dfa_start <= dfa_end) {
             nfa_start = dfa_start;
         }
     }
@@ -17909,6 +18041,12 @@ void *osty_rt_regex_captures_all(void *raw_re, const char *text) {
     osty_re_lazy_pair_init(&pair, re);
     while (start <= len) {
         for (int i = 0; i < slot_count; i++) slots[i] = -1;
+        /* Phase 9f — bump the search cursor to the next literal-prefix
+         * candidate. captures_all collects everything from the input
+         * directly so it's safe to mutate `start` here (no unmatched-
+         * span emission like replace / split). */
+        start = osty_re_advance_to_literal_prefix(re, src, len, start);
+        if (start < 0) break;
         int nfa_start = start;
         int dfa_end = osty_re_dfa_or_lazy_find_first_end(re, pair.fwd, src, len, start);
         if (dfa_end == -1) {


### PR DESCRIPTION
## Summary

Patterns whose first instructions are SAVE/CHAR sequences (`foo`, `foo\d+`, `https://example`, `err:\w+`, ...) carry a fixed byte literal that **every match must begin with**. Phase 9f extracts that literal at compile time, embeds it inline in the regex GC blob, and runs `memmem` from each entry function's start cursor before dispatching to the DFA/NFA. memmem skips entire spans of input that cannot contain a match — for sparse matches in long inputs this is the difference between scanning every byte and jumping directly to candidate positions.

## Mechanism

**Compile time:**
- New header field `literal_prefix_len` and inline tail bytes, capped at 64 via `OSTY_RE_LITERAL_PREFIX_MAX`.
- Extraction walks `prog` from the start, skipping zero-width SAVE ops and collecting consecutive CHAR bytes; stops at the first non-CHAR/non-SAVE op (CCLASS, ANY, SPLIT, JMP, anchor, MATCH). Patterns with no literal prefix get length 0 and silently skip the optimization.

**Runtime:**
- `osty_rt_memmem` — portable substring search (memchr fast path for single-byte needles; naive memchr-then-memcmp for longer; stays buildable on Windows MSVC without `_GNU_SOURCE`/glibc memmem).
- `osty_re_advance_to_literal_prefix` — used in all 7 entry functions:
  - **matches**: short-circuit `false` if memmem returns NULL.
  - **find / captures**: tighten initial `nfa_start` to the leftmost prefix occurrence.
  - **findAll / capturesAll**: bump loop's `start` at every iteration.
  - **replace_impl / split**: introduce a separate `cursor` so the unmatched-span emission (`src[start..match_start)`) keeps its verbatim contract — `start` stays where the previous match ended, `cursor` is the literal-prefix-advanced search position.

## Test plan

- [x] All 13 existing regex/uuid E2Es pass byte-identical.
- [x] New `examples/regex_literal_prefix/` covers:
  - bare literal find / matches-absent
  - literal + quantifier findAll skips non-matching candidates
  - literal-present-but-no-extension correctly returns false
  - long literal (15 bytes) extraction
  - replaceAll preserves unmatched spans verbatim (cursor/start split)
  - split with literal separator
  - no-prefix fallback (`\d+`)
  - `\b` boundary fallback (walker stops, prefix len = 0)
- [x] Temporary trace confirmed prefix extraction triggers for 6/8 patterns in the example.
- [x] `go test ./internal/llvmgen/ -run TestStdRegex` passes.

## Storage

64-byte cap on the embedded prefix → at most 64 bytes added to the regex blob. Patterns without literal prefixes pay zero extra bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)