### PR TITLE
feat: LIR Proto Phase 7 Slice 2 — runner interface + dispatcher wiring

### DIFF
--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -160,16 +160,30 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	}
 	warnings := append([]error(nil), entry.IRIssues...)
 	// Phase-7 gate. OSTY_LLVM_LIR_PROTO=1 selects the LIR Proto path
-	// at this dispatcher entry. The Go-side runner that would call
-	// into toolchain/lir_proto.osty does not exist yet, so we attach
-	// ErrLIRProtoNotWired as a warning and then continue with whichever
-	// fallback path the existing dispatcher would have chosen
+	// at this dispatcher entry. The dispatcher invokes the registered
+	// LIRProtoRunner (defaults to a "not-wired" stub returning
+	// ErrLIRProtoNotWired); on success the runner's bytes are
+	// returned directly. Any non-nil error is treated as a structured
+	// fall-back signal: warning attached, continue with whichever
+	// legacy path the existing dispatcher would have chosen
 	// (native-owned fast path or MIR-direct). Flipping the gate on
-	// stays safe before the runner lands — production output is
+	// stays safe before a real runner lands — production output is
 	// unchanged but the selection is visible in build logs.
 	if llvmgen.LIRProtoSelected() {
-		traceLLVMDispatch("lir-proto-gate selected package=%s source=%s — falling back: %v", entry.PackageName, entry.SourcePath, llvmgen.ErrLIRProtoNotWired)
-		warnings = append(warnings, llvmgen.ErrLIRProtoNotWired)
+		traceLLVMDispatch("lir-proto-gate selected package=%s source=%s", entry.PackageName, entry.SourcePath)
+		req := llvmgen.LIRProtoRequest{
+			PackageName: entry.PackageName,
+			SourcePath:  entry.SourcePath,
+			Source:      entry.Source,
+			Target:      target,
+		}
+		if out, err := llvmgen.InvokeLIRProtoRunner(req); err == nil && out != nil {
+			traceLLVMDispatch("lir-proto-runner covered package=%s source=%s", entry.PackageName, entry.SourcePath)
+			return out, warnings, nil
+		} else {
+			traceLLVMDispatch("lir-proto-runner declined package=%s source=%s — falling back: %v", entry.PackageName, entry.SourcePath, err)
+			warnings = append(warnings, err)
+		}
 	}
 	opts := llvmgen.Options{
 		PackageName: entry.PackageName,

--- a/internal/llvmgen/lir_proto_runner.go
+++ b/internal/llvmgen/lir_proto_runner.go
@@ -1,0 +1,85 @@
+package llvmgen
+
+// LIRProtoRunner is the contract any Go-side bridge into the
+// Osty-owned LIR Proto lowerer must satisfy. The dispatcher in
+// internal/backend/llvm.go routes through this interface when
+// LIRProtoSelected() is true and a non-nil runner has been set via
+// SetLIRProtoRunner.
+//
+// Today the only registered runner is `defaultLIRProtoRunner`, which
+// always returns ErrLIRProtoNotWired so production output is
+// unchanged. The runner stays decoupled from the dispatch site so a
+// future commit can register a real implementation (for example: a
+// JSON-RPC client that talks to a self-host osty-native-lirproto
+// binary built from toolchain/lir_proto.osty) without touching the
+// dispatcher at all.
+//
+// The contract is intentionally narrow: input is a request the
+// existing dispatcher already builds (package name, source path,
+// source bytes, target triple); output is either a complete LLVM
+// IR text artifact OR a structured error that the dispatcher
+// converts into a fall-back warning. No partial / streaming /
+// retry shape — the dispatcher's fall-back policy treats any error
+// as "use the legacy MIR-direct emitter and continue."
+type LIRProtoRunner interface {
+	// Run lowers the given source through the LIR Proto path and
+	// returns the rendered LLVM IR. Implementations MUST return
+	// either (nil, ErrLIRProtoNotWired) when no real runner is
+	// available, or a non-nil byte slice with no error on success.
+	// Any other (err != nil) result is treated as a structured
+	// fall-back signal — the dispatcher logs it and continues with
+	// the legacy MIR-direct emitter.
+	Run(req LIRProtoRequest) ([]byte, error)
+}
+
+// LIRProtoRequest is the single argument the dispatcher hands the
+// runner. Mirrors the Phase-7 plan doc's "shadow parity" shape:
+// everything the production MIR-direct emitter sees, packaged for
+// transport to a self-host process.
+type LIRProtoRequest struct {
+	PackageName string
+	SourcePath  string
+	Source      []byte
+	Target      string
+}
+
+var registeredLIRProtoRunner LIRProtoRunner = defaultLIRProtoRunner{}
+
+// SetLIRProtoRunner installs the runner the Phase-7 dispatcher will
+// invoke when the gate is enabled. Pass nil to revert to the default
+// "not-wired" behavior. Intended for the eventual self-host bridge
+// (registered from cmd-side init) and tests that want to swap in a
+// fake runner.
+func SetLIRProtoRunner(runner LIRProtoRunner) {
+	if runner == nil {
+		registeredLIRProtoRunner = defaultLIRProtoRunner{}
+		return
+	}
+	registeredLIRProtoRunner = runner
+}
+
+// CurrentLIRProtoRunner returns the currently-registered runner,
+// always non-nil. Test helpers use this to peek at the active
+// implementation; production code goes through InvokeLIRProtoRunner.
+func CurrentLIRProtoRunner() LIRProtoRunner {
+	return registeredLIRProtoRunner
+}
+
+// InvokeLIRProtoRunner is the single entry point dispatcher code
+// uses to attempt a LIR Proto lowering. It is a thin wrapper around
+// the registered runner that exists so the dispatcher does not have
+// to know whether a runner is registered or not — the default
+// "not-wired" runner returns ErrLIRProtoNotWired which the
+// dispatcher already treats as a fall-back signal.
+func InvokeLIRProtoRunner(req LIRProtoRequest) ([]byte, error) {
+	return registeredLIRProtoRunner.Run(req)
+}
+
+// defaultLIRProtoRunner is the always-installed fallback. Returns
+// (nil, ErrLIRProtoNotWired) for every call. Replaced via
+// SetLIRProtoRunner once the self-host bridge lands.
+type defaultLIRProtoRunner struct{}
+
+func (defaultLIRProtoRunner) Run(_ LIRProtoRequest) ([]byte, error) {
+	return nil, ErrLIRProtoNotWired
+}

--- a/internal/llvmgen/lir_proto_runner_test.go
+++ b/internal/llvmgen/lir_proto_runner_test.go
@@ -1,0 +1,71 @@
+package llvmgen
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDefaultLIRProtoRunnerReturnsNotWired(t *testing.T) {
+	t.Parallel()
+	out, err := InvokeLIRProtoRunner(LIRProtoRequest{
+		PackageName: "main",
+		SourcePath:  "/tmp/x.osty",
+		Source:      []byte("fn main() {}"),
+	})
+	if out != nil {
+		t.Fatalf("default runner returned non-nil output %q", out)
+	}
+	if !errors.Is(err, ErrLIRProtoNotWired) {
+		t.Fatalf("default runner err = %v, want ErrLIRProtoNotWired", err)
+	}
+}
+
+type fakeLIRProtoRunner struct {
+	out []byte
+	err error
+}
+
+func (f *fakeLIRProtoRunner) Run(req LIRProtoRequest) ([]byte, error) {
+	return f.out, f.err
+}
+
+func TestSetLIRProtoRunnerSwapsImpl(t *testing.T) {
+	prev := CurrentLIRProtoRunner()
+	defer SetLIRProtoRunner(prev)
+
+	fake := &fakeLIRProtoRunner{out: []byte("; fake LLVM IR\n")}
+	SetLIRProtoRunner(fake)
+
+	out, err := InvokeLIRProtoRunner(LIRProtoRequest{PackageName: "main", SourcePath: "/tmp/y.osty"})
+	if err != nil {
+		t.Fatalf("fake runner unexpectedly errored: %v", err)
+	}
+	if string(out) != "; fake LLVM IR\n" {
+		t.Fatalf("fake runner returned wrong bytes: %q", out)
+	}
+}
+
+func TestSetLIRProtoRunnerNilRevertsToDefault(t *testing.T) {
+	prev := CurrentLIRProtoRunner()
+	defer SetLIRProtoRunner(prev)
+
+	SetLIRProtoRunner(&fakeLIRProtoRunner{out: []byte("x")})
+	SetLIRProtoRunner(nil)
+
+	if _, err := InvokeLIRProtoRunner(LIRProtoRequest{}); !errors.Is(err, ErrLIRProtoNotWired) {
+		t.Fatalf("after SetLIRProtoRunner(nil) expected ErrLIRProtoNotWired, got %v", err)
+	}
+}
+
+func TestLIRProtoRunnerErrorTreatedAsFallback(t *testing.T) {
+	prev := CurrentLIRProtoRunner()
+	defer SetLIRProtoRunner(prev)
+
+	custom := errors.New("self-host bridge unreachable")
+	SetLIRProtoRunner(&fakeLIRProtoRunner{err: custom})
+
+	_, err := InvokeLIRProtoRunner(LIRProtoRequest{PackageName: "main"})
+	if !errors.Is(err, custom) {
+		t.Fatalf("custom runner err not propagated: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 7 의 첫 단계 본체. Production 출력 변경 없음 (default runner 가 \`ErrLIRProtoNotWired\` 반환 → 기존 fall-back 경로 사용).
- 새 \`LIRProtoRunner\` interface — self-host 브리지가 land 할 때 dispatcher 변경 없이 \`SetLIRProtoRunner(impl)\` 한 줄로 즉시 활성화 가능.
- 4 신규 테스트 (default / set / nil revert / error propagation).

## 다음 단계
- 이 PR 다음에 필요한 건 LIR Proto 실 호출이 가능한 \`LIRProtoRunner\` 구현체. 예: self-host osty-native-lirproto binary + JSON-RPC. 그건 별도 다일 단위 인프라.

## Test plan
- [x] \`go test -count=1 -vet=off ./internal/llvmgen/ -run 'LIRProto'\` 통과 (기존 + 4 신규).
- [x] \`go build ./...\` 통과.
- [ ] CI 그린 확인 (sandbox에 \`std.strings.fromChar\` 자체호스트 회귀가 main과 동일하게 발생 — 내 변경 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)