### PR TITLE
feat: ONB Phase A2 Week 6 — String concat + List<Int> via runtime

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,32 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 6 (String concat + List<Int>, 2026-05-02)** — ONB native
+> path가 처음으로 런타임 호출 경로를 사용. `osty_runtime.c` 가 link 단계에
+> 같이 들어오며 다음 패턴이 native로 통과:
+>
+>   - `let name = "world"; println("hello, " + name)` (String concat with local)
+>   - `fn greet(name: String) -> String { "hello, " + name }` (String param/return)
+>   - `let mut v: List<Int> = []; v.push(10); println(v.len())` (list ops)
+>   - `for i in 0..5 { v.push(i) }` (list build via loop)
+>
+> 추가:
+>   - 런타임 심볼: `osty_rt_strings_Concat`, `osty_rt_list_new`,
+>     `osty_rt_list_push_i64`, `osty_rt_list_len` — 모두 `BranchLink`로 호출
+>   - `materialiseOperand`가 `StringConst` → `LoadCStringAddress` 경로 추가
+>   - `lowerStringConcatAssign`: `BinaryAdd` + `T == TString` → 두 args를
+>     x0/x1에 띄우고 runtime concat 호출, 결과 ptr를 dest slot에 저장
+>   - `lowerAggregateAssign`: 빈 list literal → `osty_rt_list_new`
+>   - `lowerListPush` / `lowerListLen`: 새 intrinsic dispatch
+>   - `lowerPrintln`이 String local도 처리 (`puts(string ptr)` 경로)
+>   - `LoadCStringAddress`가 임의 X register dst 지원 (이전엔 x0 only)
+>   - `isABIScalarType` helper로 user fn param/return을 Int/Bool/String 모두 허용
+>   - Backend가 매 빌드에 `EnsureRuntimeObject` 호출해서 runtime.o를 link 인자로 추가
+>
+> 부수 (직전 Week 5 cleanup): `_ = fnStart` / `_ = dwarfSegmentSections` 제거,
+> `functionPrologueWords`를 lir.go로 이동 (single source of truth),
+> Mach-O 세그먼트/섹션 이름 상수화.
+>
 > **Slice A2 Week 5 (DWARF .debug_line, 2026-05-02)** — ONB가 처음으로 디버그
 > 메타데이터를 emit. `__debug_line` 섹션이 Mach-O `__DWARF` 세그먼트로 들어감.
 > `dwarfdump --debug-line foo.o`가 정상 파싱하며 PC→source `<file>:<line>:<col>`

--- a/internal/backend/onb.go
+++ b/internal/backend/onb.go
@@ -138,7 +138,21 @@ func (b ONBBackend) emitNative(ctx context.Context, req Request) (*Result, error
 	if artifacts.Binary == "" {
 		return result, fmt.Errorf("onb backend: missing binary artifact path")
 	}
-	if err := b.onbLinker().LinkBinary(ctx, []string{artifacts.Object}, artifacts.Binary, req.Layout.Target, req.LinkLibraries); err != nil {
+	objects := []string{artifacts.Object}
+	// String concat / List ops lower to calls into `osty_runtime.c`, so
+	// the linker needs the runtime object on its command line. We pull it
+	// in unconditionally — even hello-world binaries that don't reference
+	// any runtime symbol pay only a small link-time cost (the runtime is
+	// already cached after the first build), and unconditional linkage
+	// keeps the dev loop predictable.
+	runtimeObject, err := EnsureRuntimeObject(ctx, artifacts, req.Layout.Target)
+	if err != nil {
+		return result, err
+	}
+	if runtimeObject != "" {
+		objects = append(objects, runtimeObject)
+	}
+	if err := b.onbLinker().LinkBinary(ctx, objects, artifacts.Binary, req.Layout.Target, req.LinkLibraries); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -162,8 +162,12 @@ func TestONBBackendEmitBinaryInvokesHostLinker(t *testing.T) {
 	if len(linker.links) != 1 {
 		t.Fatalf("link calls = %d, want 1", len(linker.links))
 	}
-	if got := linker.links[0].objectPaths; len(got) != 1 || got[0] != result.Artifacts.Object {
-		t.Fatalf("link object paths = %v, want [%s]", got, result.Artifacts.Object)
+	got := linker.links[0].objectPaths
+	if len(got) != 2 || got[0] != result.Artifacts.Object {
+		t.Fatalf("link object paths = %v, want [%s, <runtime>]", got, result.Artifacts.Object)
+	}
+	if !strings.HasSuffix(got[1], "osty_runtime.o") {
+		t.Fatalf("second link object = %q, want runtime .o (osty_runtime.o suffix)", got[1])
 	}
 }
 
@@ -287,6 +291,88 @@ func TestONBBackendBinaryRunsArithOnDarwinARM64(t *testing.T) {
     println(a - b * 2)
 }`,
 			want: "4\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			if result == nil || result.Artifacts.Binary == "" {
+				t.Fatalf("missing binary artifact: %+v", result)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("binary output = %q, want %q", out, tc.want)
+			}
+		})
+	}
+}
+
+// TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
+// runtime-call slice: String concatenation and `List<Int>` push/len. These
+// shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,
+// `bl _osty_rt_list_push_i64`, `bl _osty_rt_list_len`, all of which need
+// the bundled runtime object on the linker command line.
+func TestONBBackendBinaryRunsStringAndListOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB string/list executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "string_concat_with_local",
+			src: `fn main() {
+    let name = "world"
+    println("hello, " + name)
+}`,
+			want: "hello, world\n",
+		},
+		{
+			name: "string_concat_via_helper",
+			src: `fn greet(name: String) -> String {
+    "hello, " + name
+}
+fn main() {
+    println(greet("alice"))
+}`,
+			want: "hello, alice\n",
+		},
+		{
+			name: "list_push_len",
+			src: `fn main() {
+    let mut v: List<Int> = []
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    println(v.len())
+}`,
+			want: "3\n",
+		},
+		{
+			name: "list_built_in_loop",
+			src: `fn main() {
+    let mut v: List<Int> = []
+    for i in 0..5 {
+        v.push(i)
+    }
+    println(v.len())
+}`,
+			want: "5\n",
 		},
 	}
 	for _, tc := range cases {
@@ -617,9 +703,9 @@ func TestONBBackendFallsBackToLLVMOnUnsupportedShape(t *testing.T) {
 	onbDevTestEnv(t, false, false)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut v: List<Int> = []
-    v.push(1)
-    println(v.len())
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    println(m.len())
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fallbackArtifacts := req.Artifacts(NameLLVM)
@@ -659,9 +745,9 @@ func TestONBBackendStrictModeSurfacesShapeError(t *testing.T) {
 	onbDevTestEnv(t, true, false)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut v: List<Int> = []
-    v.push(1)
-    println(v.len())
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    println(m.len())
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{name: NameLLVM}
@@ -681,9 +767,9 @@ func TestONBBackendASMEmitDoesNotFallback(t *testing.T) {
 	onbDevTestEnv(t, false, false)
 
 	req := newBackendRequest(t, EmitASM, `fn main() {
-    let mut v: List<Int> = []
-    v.push(1)
-    println(v.len())
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    println(m.len())
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{name: NameLLVM}
@@ -722,9 +808,9 @@ func TestONBBackendTimingLogsFallback(t *testing.T) {
 	onbDevTestEnv(t, false, true)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut v: List<Int> = []
-    v.push(1)
-    println(v.len())
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    println(m.len())
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{

--- a/internal/onb/dwarf.go
+++ b/internal/onb/dwarf.go
@@ -377,20 +377,6 @@ func movImm64WordCount(imm int64) int {
 	return count
 }
 
-// functionPrologueWords returns the number of 4-byte prologue instructions
-// the encoder inserts at the start of a function. The line emitter steps
-// past these so the first MIR-derived row points at the function body, not
-// the stack-setup boilerplate.
-func functionPrologueWords(fn Function) int {
-	if functionFrameSize(fn) == 0 {
-		return 0
-	}
-	if functionFPOffset(fn) < 0 {
-		return 2 // stp x29, x30, [sp, #-16]!  +  mov x29, sp
-	}
-	return 3 // sub sp, sp, #N  +  stp x29, x30, [sp, #N-16]  +  add x29, sp, #N-16
-}
-
 // dwarfFileEntry returns one Mach-O-suitable file table entry for the
 // program. Empty SourcePath becomes "<unknown>" — debuggers will still
 // load the section, just with no file resolution.

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -323,3 +323,19 @@ func functionNeedsStackArgs(fn Function) bool {
 	}
 	return false
 }
+
+// functionPrologueWords returns the number of 4-byte prologue instructions
+// the encoder inserts at the start of a function. Lives next to its
+// frame-size siblings so any future change to the prologue layout is
+// expressed in one place — both the Mach-O encoder (which emits the
+// prologue) and the DWARF line emitter (which has to step past it for
+// PC→source rows) read this single source of truth.
+func functionPrologueWords(fn Function) int {
+	if functionFrameSize(fn) == 0 {
+		return 0
+	}
+	if functionFPOffset(fn) < 0 {
+		return 2 // stp x29, x30, [sp, #-16]!  +  mov x29, sp
+	}
+	return 3 // sub sp, sp, #N  +  stp x29, x30, [sp, #N-16]  +  add x29, sp, #N-16
+}

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -11,6 +11,17 @@ import (
 // backend defers to a later slice.
 var argRegs = []Reg{RegX0, RegX1, RegX2, RegX3, RegX4, RegX5, RegX6, RegX7}
 
+// Runtime symbol names. ONB calls into the same `osty_runtime.c` the LLVM
+// backend bundles, so these strings have to match the C function names
+// exactly. The Mach-O `bl` encoder prepends the leading underscore for
+// darwin's symbol mangling.
+const (
+	runtimeSymStringConcat = "osty_rt_strings_Concat"
+	runtimeSymListNew      = "osty_rt_list_new"
+	runtimeSymListPushI64  = "osty_rt_list_push_i64"
+	runtimeSymListLen      = "osty_rt_list_len"
+)
+
 // LowerMIR lowers the supported MIR slice into ONB's own LIR. Phase 1.0
 // handled hello world; Phase A2 Week 1 added local Int variables and binary
 // arithmetic; Phase A2 Week 2 introduces user-defined functions with up to
@@ -88,11 +99,11 @@ func (s *lowerState) lowerFunction(fn *mir.Function) (Function, error) {
 		}
 		for _, paramID := range fn.Params {
 			loc := lookupLocal(fn, paramID)
-			if loc == nil || loc.Type != mir.TInt {
-				return Function{}, fmt.Errorf("%w: %s parameter %v is not Int", ErrUnsupportedShape, fn.Name, paramID)
+			if loc == nil || !isABIScalarType(loc.Type) {
+				return Function{}, fmt.Errorf("%w: %s parameter %v has non-scalar type", ErrUnsupportedShape, fn.Name, paramID)
 			}
 		}
-		if fn.ReturnType != mir.TInt && fn.ReturnType != mir.TUnit {
+		if !isABIScalarType(fn.ReturnType) && fn.ReturnType != mir.TUnit {
 			return Function{}, fmt.Errorf("%w: %s return type %s is outside phase 1", ErrUnsupportedShape, fn.Name, fn.ReturnType)
 		}
 	}
@@ -379,7 +390,7 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 	// take the slot if there is one.
 	slot, hasSlot := s.localSlots[instr.Dest.Local]
 	if !hasSlot {
-		if instr.Dest.Local == fn.ReturnLocal && fn.ReturnType == mir.TInt {
+		if instr.Dest.Local == fn.ReturnLocal && isABIScalarType(fn.ReturnType) {
 			// allocate a synthetic slot at frame's tail
 			slot = s.allocateReturnSlot(fn)
 			hasSlot = true
@@ -397,9 +408,36 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 		return append(mat, &Store64Stack{Src: RegX9, Offset: slot}), nil
 	case *mir.BinaryRV:
 		return s.lowerBinaryAssign(rv, slot)
+	case *mir.AggregateRV:
+		return s.lowerAggregateAssign(rv, slot)
 	default:
 		return nil, fmt.Errorf("%w: rvalue %T is outside phase 1", ErrUnsupportedShape, instr.Src)
 	}
+}
+
+// lowerAggregateAssign currently covers only the empty-list literal
+// (`let v: List<Int> = []`). The runtime allocates the list eagerly via
+// `osty_rt_list_new`; future slices will extend this to non-empty lists,
+// tuples, structs, and enum variants.
+func (s *lowerState) lowerAggregateAssign(rv *mir.AggregateRV, destSlot int64) ([]Instr, error) {
+	if rv.Kind != mir.AggList {
+		return nil, fmt.Errorf("%w: aggregate kind %v", ErrUnsupportedShape, rv.Kind)
+	}
+	if len(rv.Fields) != 0 {
+		return nil, fmt.Errorf("%w: non-empty list literal", ErrUnsupportedShape)
+	}
+	return []Instr{
+		&BranchLink{Symbol: runtimeSymListNew},
+		&Store64Stack{Src: RegX0, Offset: destSlot},
+	}, nil
+}
+
+// isABIScalarType reports whether a MIR type fits cleanly in one AAPCS64
+// integer register. Phase A2 accepts Int (i64), Bool (i1), and String
+// (ptr). Lists and structs need indirect passing and are deferred to a
+// future slice.
+func isABIScalarType(t mir.Type) bool {
+	return t == mir.TInt || t == mir.TBool || t == mir.TString
 }
 
 // allocateReturnSlot makes room for the return local on functions that didn't
@@ -424,6 +462,9 @@ func (s *lowerState) allocateReturnSlot(fn *mir.Function) int64 {
 func (s *lowerState) lowerBinaryAssign(rv *mir.BinaryRV, destSlot int64) ([]Instr, error) {
 	if cond, isCmp := comparisonCond(rv.Op); isCmp {
 		return s.lowerComparisonAssign(rv, cond, destSlot)
+	}
+	if rv.Op == mir.BinAdd && rv.T == mir.TString {
+		return s.lowerStringConcatAssign(rv, destSlot)
 	}
 	switch rv.Op {
 	case mir.BinAdd, mir.BinSub, mir.BinMul:
@@ -471,6 +512,29 @@ func comparisonCond(op mir.BinaryOp) (Cond, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// lowerStringConcatAssign lowers `dest = lhs + rhs` for two String operands
+// into an AAPCS64 call to the bundled runtime's two-arg concat helper.
+// Both operands materialise into x0/x1 (a string is a heap pointer at the
+// ABI boundary), the runtime returns a fresh ptr in x0, and we store that
+// ptr into the destination slot.
+func (s *lowerState) lowerStringConcatAssign(rv *mir.BinaryRV, destSlot int64) ([]Instr, error) {
+	lhs, err := s.materialiseOperand(rv.Left, RegX0)
+	if err != nil {
+		return nil, err
+	}
+	rhs, err := s.materialiseOperand(rv.Right, RegX1)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), lhs...)
+	out = append(out, rhs...)
+	out = append(out,
+		&BranchLink{Symbol: runtimeSymStringConcat},
+		&Store64Stack{Src: RegX0, Offset: destSlot},
+	)
+	return out, nil
 }
 
 // lowerComparisonAssign emits `cmp lhs, rhs; cset Xd, <cond>` storing the
@@ -524,8 +588,9 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 }
 
 // materialiseOperand emits the instruction sequence that lands the operand's
-// value in dst. Supports Int constants and Copy/Move of locals that have a
-// stack slot.
+// value in dst. Supports Int / Bool / String constants and Copy/Move of
+// locals that have a stack slot. String constants land in dst as a pointer
+// to their `__cstring` entry.
 func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error) {
 	switch o := op.(type) {
 	case *mir.ConstOp:
@@ -538,6 +603,9 @@ func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error
 				imm = 1
 			}
 			return []Instr{&MovImm64{Dst: dst, Imm: imm}}, nil
+		case *mir.StringConst:
+			label := s.addCString(c.Value)
+			return []Instr{&LoadCStringAddress{Dst: dst, Label: label}}, nil
 		default:
 			return nil, fmt.Errorf("%w: const %T as operand", ErrUnsupportedShape, o.Const)
 		}
@@ -565,9 +633,54 @@ func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) 
 	switch instr.Kind {
 	case mir.IntrinsicPrintln:
 		return s.lowerPrintln(instr)
+	case mir.IntrinsicListPush:
+		return s.lowerListPush(instr)
+	case mir.IntrinsicListLen:
+		return s.lowerListLen(instr)
 	default:
 		return nil, fmt.Errorf("%w: intrinsic %s is outside phase 1", ErrUnsupportedShape, instr.Kind)
 	}
+}
+
+// lowerListPush lowers `IntrinsicListPush(list, value)` into a runtime
+// call. The current slice only handles `List<Int>` — push on i1/f64 lists
+// would call different runtime symbols and is left for the next slice.
+func (s *lowerState) lowerListPush(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 2 {
+		return nil, fmt.Errorf("%w: list_push expects 2 args, got %d", ErrUnsupportedShape, len(instr.Args))
+	}
+	list, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	value, err := s.materialiseOperand(instr.Args[1], RegX1)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), list...)
+	out = append(out, value...)
+	out = append(out, &BranchLink{Symbol: runtimeSymListPushI64})
+	return out, nil
+}
+
+// lowerListLen lowers `IntrinsicListLen(list) -> Int` by calling the
+// runtime helper and capturing x0 into the destination slot.
+func (s *lowerState) lowerListLen(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 1 {
+		return nil, fmt.Errorf("%w: list_len expects 1 arg, got %d", ErrUnsupportedShape, len(instr.Args))
+	}
+	list, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), list...)
+	out = append(out, &BranchLink{Symbol: runtimeSymListLen})
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX0, Offset: slot})
+		}
+	}
+	return out, nil
 }
 
 func (s *lowerState) lowerPrintln(instr *mir.IntrinsicInstr) ([]Instr, error) {
@@ -582,12 +695,20 @@ func (s *lowerState) lowerPrintln(instr *mir.IntrinsicInstr) ([]Instr, error) {
 			&BranchLink{Symbol: "puts"},
 		}, nil
 	}
+	if mat, ok, err := s.loadStringPrintArg(arg); err != nil || ok {
+		if err != nil {
+			return nil, err
+		}
+		out := append([]Instr(nil), mat...)
+		out = append(out, &BranchLink{Symbol: "puts"})
+		return out, nil
+	}
 	loadValue, ok, err := s.loadIntPrintArg(arg)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("%w: println currently requires a string, int literal, or Int local", ErrUnsupportedShape)
+		return nil, fmt.Errorf("%w: println currently requires a string, int literal, Int local, or String local", ErrUnsupportedShape)
 	}
 	label := s.addCString("%lld\n")
 	out := []Instr{&LoadCStringAddress{Dst: RegX0, Label: label}}
@@ -597,6 +718,46 @@ func (s *lowerState) lowerPrintln(instr *mir.IntrinsicInstr) ([]Instr, error) {
 	}
 	out = append(out, &BranchLink{Symbol: "printf"})
 	return out, nil
+}
+
+// loadStringPrintArg materialises a string-typed operand into x0 so a
+// subsequent `bl _puts` can print it. Returns ok=false when the operand
+// isn't a String — the caller falls through to the int-print path.
+func (s *lowerState) loadStringPrintArg(op mir.Operand) ([]Instr, bool, error) {
+	switch o := op.(type) {
+	case *mir.CopyOp:
+		if !s.localIsString(o.Place.Local) {
+			return nil, false, nil
+		}
+		instrs, err := s.loadPlaceIntoReg(o.Place, RegX0)
+		if err != nil {
+			return nil, false, err
+		}
+		return instrs, true, nil
+	case *mir.MoveOp:
+		if !s.localIsString(o.Place.Local) {
+			return nil, false, nil
+		}
+		instrs, err := s.loadPlaceIntoReg(o.Place, RegX0)
+		if err != nil {
+			return nil, false, err
+		}
+		return instrs, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func (s *lowerState) localIsString(id mir.LocalID) bool {
+	if s.fn == nil {
+		return false
+	}
+	for _, loc := range s.fn.Locals {
+		if loc != nil && loc.ID == id {
+			return loc.Type == mir.TString
+		}
+	}
+	return false
 }
 
 // loadIntPrintArg materialises the integer argument for printf into x1.
@@ -668,7 +829,9 @@ func stringConstFromOperand(op mir.Operand) (string, bool) {
 }
 
 // functionUsesIntPrintln reports whether the function calls println with an
-// integer-valued argument.
+// integer-valued argument — which on darwin/aarch64 lands the value on the
+// printf vararg slot at [sp+0]. String prints go through `puts` instead and
+// don't need the vararg slot, so they shouldn't force one.
 func functionUsesIntPrintln(fn *mir.Function) bool {
 	for _, block := range fn.Blocks {
 		for _, instr := range block.Instrs {
@@ -676,10 +839,40 @@ func functionUsesIntPrintln(fn *mir.Function) bool {
 			if !ok || intr.Kind != mir.IntrinsicPrintln || len(intr.Args) != 1 {
 				continue
 			}
-			if _, isString := stringConstFromOperand(intr.Args[0]); isString {
+			arg := intr.Args[0]
+			if _, isString := stringConstFromOperand(arg); isString {
+				continue
+			}
+			if isStringTypedOperand(fn, arg) {
 				continue
 			}
 			return true
+		}
+	}
+	return false
+}
+
+// isStringTypedOperand reports whether op refers to a String-typed local
+// (via Copy or Move). Const string operands are handled by the caller via
+// stringConstFromOperand. Used by functionUsesIntPrintln to keep the
+// printf vararg slot from being reserved when only `puts(stringLocal)`
+// fires.
+func isStringTypedOperand(fn *mir.Function, op mir.Operand) bool {
+	if fn == nil {
+		return false
+	}
+	var id mir.LocalID
+	switch o := op.(type) {
+	case *mir.CopyOp:
+		id = o.Place.Local
+	case *mir.MoveOp:
+		id = o.Place.Local
+	default:
+		return false
+	}
+	for _, loc := range fn.Locals {
+		if loc != nil && loc.ID == id {
+			return loc.Type == mir.TString
 		}
 	}
 	return false

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -38,6 +38,16 @@ const (
 	machoTextAlignPower         uint32 = 2
 	machoCStringSectionNumber   uint8  = 2
 	machoTextSectionNumber      uint8  = 1
+
+	// Mach-O segment / section names. Centralised so future renames
+	// (e.g., `__debug_info` when DWARF B.1 lands) don't accidentally
+	// drift between the segment LC and its section header.
+	machoSegnameText     = "__TEXT"
+	machoSegnameDWARF    = "__DWARF"
+	machoSegnameLinkedit = "__LINKEDIT"
+	machoSectnameText    = "__text"
+	machoSectnameCString = "__cstring"
+	machoSectnameLine    = "__debug_line"
 )
 
 func emitMachOObject(program *Program) ([]byte, error) {
@@ -90,8 +100,8 @@ func emitMinimalMachOObject(program *Program) ([]byte, error) {
 	writeU32(&b, 1)
 	writeU32(&b, 0)
 
-	writeName16(&b, "__text")
-	writeName16(&b, "__TEXT")
+	writeName16(&b, machoSectnameText)
+	writeName16(&b, machoSegnameText)
 	writeU64(&b, 0)
 	writeU64(&b, uint64(len(code)))
 	writeU32(&b, textOffset)
@@ -232,7 +242,6 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 	strtabEnd := stroff + uint32(len(strtab.data))
 	linkeditOffset := relocOffset
 	linkeditSize := strtabEnd - relocOffset
-	_ = dwarfSegmentSections // referenced below when writing the LC
 
 	var b bytes.Buffer
 	writeU32(&b, machoMagic64)
@@ -262,8 +271,8 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 	writeU32(&b, 2)
 	writeU32(&b, 0)
 
-	writeName16(&b, "__text")
-	writeName16(&b, "__TEXT")
+	writeName16(&b, machoSectnameText)
+	writeName16(&b, machoSegnameText)
 	writeU64(&b, 0)
 	writeU64(&b, uint64(len(enc.code)))
 	writeU32(&b, textOffset)
@@ -275,8 +284,8 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 	writeU32(&b, 0)
 	writeU32(&b, 0)
 
-	writeName16(&b, "__cstring")
-	writeName16(&b, "__TEXT")
+	writeName16(&b, machoSectnameCString)
+	writeName16(&b, machoSegnameText)
 	writeU64(&b, uint64(len(enc.code)))
 	writeU64(&b, uint64(len(cstringData)))
 	writeU32(&b, cstringOffset)
@@ -297,7 +306,7 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 		// the arithmetic.
 		writeU32(&b, machoLCSegment64)
 		writeU32(&b, dwarfSegmentSize)
-		writeName16(&b, "__DWARF")
+		writeName16(&b, machoSegnameDWARF)
 		writeU64(&b, dwarfVmaddr)
 		writeU64(&b, dwarfVmsize)
 		writeU64(&b, uint64(debugLineOffset))
@@ -307,8 +316,8 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 		writeU32(&b, dwarfSegmentSections)
 		writeU32(&b, 0) // segment flags
 
-		writeName16(&b, "__debug_line")
-		writeName16(&b, "__DWARF")
+		writeName16(&b, machoSectnameLine)
+		writeName16(&b, machoSegnameDWARF)
 		writeU64(&b, dwarfVmaddr)
 		writeU64(&b, uint64(len(debugLine)))
 		writeU32(&b, debugLineOffset)
@@ -330,7 +339,7 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 	}
 	writeU32(&b, machoLCSegment64)
 	writeU32(&b, machoSegment64Size)
-	writeName16(&b, "__LINKEDIT")
+	writeName16(&b, machoSegnameLinkedit)
 	writeU64(&b, linkeditVmaddr)
 	writeU64(&b, uint64(linkeditSize))
 	writeU64(&b, uint64(linkeditOffset))
@@ -387,14 +396,13 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 		writeMachONlist64(&b, symStrx[symIdx], machoNSect, machoCStringSectionNumber, 0, cstringAddrs[cstr.Label])
 		symIdx++
 	}
-	for i, fn := range program.Functions {
+	for i := range program.Functions {
 		var fnOffset uint64
 		if i < len(enc.fnOffsets) {
 			fnOffset = enc.fnOffsets[i]
 		}
 		writeMachONlist64(&b, symStrx[symIdx], machoNExt|machoNSect, machoTextSectionNumber, 0, fnOffset)
 		symIdx++
-		_ = fn
 	}
 	for range enc.externalSymbols {
 		writeMachONlist64(&b, symStrx[symIdx], machoNExt, 0, 0, 0)
@@ -571,18 +579,22 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 		for _, instr := range block.Instrs {
 			switch i := instr.(type) {
 			case *LoadCStringAddress:
-				if i.Dst != RegX0 {
-					return fmt.Errorf("%w: Mach-O encoder only supports cstring loads into x0", ErrNotImplemented)
+				dstReg, ok := xRegisterNumber(i.Dst)
+				if !ok {
+					return fmt.Errorf("%w: Mach-O cstring load dst %s", ErrNotImplemented, i.Dst)
 				}
 				sym, ok := cstringIndex[i.Label]
 				if !ok {
 					return fmt.Errorf("onb: unknown Mach-O string literal label %q", i.Label)
 				}
+				// adrp Xd, label@PAGE — 0x90000000 | (immlo<<29) | (immhi<<5) | Xd
+				// add  Xd, Xd, label@PAGEOFF — 0x91000000 | (imm12<<10) | (Xn<<5) | Xd
+				// Both relocations carry the immediate; we only fill in Rd here.
 				addr := uint32(len(enc.code))
-				enc.code = appendU32LE(enc.code, 0x90000000)
+				enc.code = appendU32LE(enc.code, 0x90000000|dstReg)
 				enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, pcrel: true, length: 2, extern: true, typ: machoARM64RelocPage21})
 				addr = uint32(len(enc.code))
-				enc.code = appendU32LE(enc.code, 0x91000000)
+				enc.code = appendU32LE(enc.code, 0x91000000|(dstReg<<5)|dstReg)
 				enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, length: 2, extern: true, typ: machoARM64RelocPageOff12})
 			case *BranchLink:
 				if i.Symbol == "" {


### PR DESCRIPTION
## Summary

ONB native path가 처음으로 `osty_runtime.c` 의 런타임 함수를 호출. 다음 패턴이 모두 native로 통과 (`OSTY_ONB_STRICT=1`, fallback 없이):

```osty
fn main() {
    let name = "world"
    println("hello, " + name)   # → hello, world
}

fn greet(name: String) -> String { "hello, " + name }
fn main() { println(greet("alice")) }   # → hello, alice

fn main() {
    let mut v: List<Int> = []
    v.push(10); v.push(20); v.push(30)
    println(v.len())   # → 3
}

fn main() {
    let mut v: List<Int> = []
    for i in 0..5 { v.push(i) }
    println(v.len())   # → 5
}
```

## 런타임 심볼

- `osty_rt_strings_Concat (lhs ptr, rhs ptr) -> ptr`
- `osty_rt_list_new () -> ptr`
- `osty_rt_list_push_i64 (list ptr, int64) -> void`
- `osty_rt_list_len (list ptr) -> int64`

## 변경

**Lowering** (`internal/onb/lower.go`):
- `materialiseOperand` 가 `StringConst` 를 cstring + `LoadCStringAddress` 로 처리
- `lowerStringConcatAssign`: `BinaryAdd` + `T == TString` → x0/x1 args + 런타임 concat call + 결과 ptr 를 dest slot 에 저장
- `lowerAggregateAssign`: 빈 list literal → `osty_rt_list_new`
- `lowerListPush` / `lowerListLen`: 새 intrinsic dispatch
- `lowerPrintln` 이 String local 도 처리 (`puts(string ptr)` 경로)
- `isABIScalarType` 로 user fn param/return 이 Int/Bool/String 모두 허용
- `functionUsesIntPrintln` 이 String-typed local println은 vararg 슬롯 안 잡음

**Mach-O** (`internal/onb/macho.go`):
- `LoadCStringAddress` 가 임의 X register dst 지원 (이전엔 x0 only)

**Backend** (`internal/backend/onb.go`):
- 매 빌드에 `EnsureRuntimeObject` 호출 → `runtime.o` 를 linker 인자로 추가

## Week 5 Simplify-review cleanups (같은 영역)

- `_ = fnStart` / `_ = dwarfSegmentSections` 미사용 변수 제거
- `functionPrologueWords` 를 `lir.go` 로 이동 (dwarf.go ↔ macho.go single source of truth)
- Mach-O segment/section 이름 상수화 (`machoSegnameText` / DWARF / Linkedit 등)

## Test plan

- [x] `TestONBBackendBinaryRunsStringAndListOnDarwinARM64` — 4 sub-cases (string concat with local, via helper, list push/len, list build in loop)
- [x] 기존 fallback 테스트 source 를 List<Int> → Map<String, Int> 로 교체 (여전히 unsupported)
- [x] `TestONBBackendEmitBinaryInvokesHostLinker` 가 runtime.o link arg 검증
- [x] `gofmt` / `go vet` 클린
- [x] 모든 기존 테스트 그린
- [ ] CI 그린 확인

## 누적 ONB native coverage

| 패턴 | 슬라이스 |
|---|---|
| `fn main() {}`, hello world | Phase 1 |
| `let mut n; n = n + M` 산술 | Week 1 |
| 표현식 체인 (`a - b * 2`) | Week 1 |
| 사용자 함수 호출 (AAPCS64, Int/Bool/String 8 param) | Week 2 + Week 6 |
| `if/else` + 6개 비교 op | Week 3 |
| `while` / `for` / 중첩 / `match` | Week 4 |
| DWARF `.debug_line` PC→source 매핑 | Week 5 |
| **String concat + `List<Int>` push/len** | **Week 6** |

여전히 fallback인 패턴: `Map<K,V>`, struct/enum, `v[0]` indexing, generic, closure, panic/`?`, async/concurrency.

## 다음 의제

- **Week 7 후보 A**: `List<Int>` get/index — `v[0]` (place projection lowering)
- **Week 7 후보 B**: DWARF B.1 — `__debug_info` + `__debug_abbrev` + `__debug_str` (lldb 자동 인식)
- **Week 7 후보 C**: Linear scan RA (Poletto) — hot path 2-3× 가속

🤖 Generated with [Claude Code](https://claude.com/claude-code)