### PR TITLE
feat: ONB Phase A2 Week 9 — DWARF B.3 (variable inspection)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,26 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 9 (DWARF B.3 — variable inspection, 2026-05-02)** —
+> lldb `frame variable` 가 ONB 빌드 결과에서 named Int local의 현재 값을
+> 보여줌. 추가:
+> - `DW_TAG_base_type` DIE for Int (byte_size 8, encoding DW_ATE_signed)
+> - `DW_TAG_variable` DIE per named Int local: `DW_AT_name` + `DW_AT_type`
+>   (ref4 to base_type) + `DW_AT_location` (DW_OP_fbreg sleb128(slot))
+> - Subprogram DIE에 `DW_AT_frame_base = DW_OP_breg31 0` (sp-relative)
+> - Abbrev table 4 entries: CU, subprogram(children), variable, base_type
+> - LIR Function에 `DebugLocals []DebugLocal` 필드 — 이름·slot·type 캐리
+> - lower.go가 named Int local만 (`_return` / 익명 temp 제외) 추출
+> - **Param shuffle instrs는 LineSpan zero**: shuffle PC가 source line으로
+>   매핑되면 lldb가 prologue 끝/shuffle 시작 사이에 stop해서 uninitialised
+>   슬롯을 읽는 문제 — line program이 shuffle 행을 skip하도록 수정
+>
+> 검증: `lldb -o "br set -f main.osty -l 1" ./app` → `frame variable`
+> → `(long) a = 10`, `(long) b = 32`. 변수 이름·값 모두 정확.
+>
+> 한계: 현재는 Int만 (DW_ATE_signed). String/Bool/Float/List 등은
+> DebugTypeKind 확장 + 대응 base_type/pointer_type DIE 추가가 필요.
+>
 > **Slice A2 Week 8 (DWARF B.2 — lldb integration, 2026-05-02)** — DWARF
 > 파이프라인이 lldb 자동 인식까지 도달. `dsymutil`이 .o의 DWARF를 .dSYM으로
 > 번들링하고, `lldb`가 `br set -f main.osty -l 4` 같은 source-level breakpoint

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -316,6 +316,64 @@ func TestONBBackendBinaryRunsArithOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendLldbFrameVariableShowsLocalsOnDarwinARM64 covers Phase
+// B.3: the DWARF emitter publishes one DW_TAG_variable DIE per named
+// Int local with a DW_OP_fbreg location, and lldb's `frame variable`
+// recovers the value from the stack slot the lowerer wrote it to.
+//
+// The test stops at the first source line of a helper function so the
+// param shuffle has run, then asks lldb for the parameter values. A
+// regression that misaligns frame_base or skips the variable DIEs
+// surfaces as wrong values rather than missing variables, so the assert
+// checks both presence AND content.
+func TestONBBackendLldbFrameVariableShowsLocalsOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("lldb DWARF integration smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+	if _, err := exec.LookPath("lldb"); err != nil {
+		t.Skip("lldb not found on PATH")
+	}
+	if _, err := exec.LookPath("dsymutil"); err != nil {
+		t.Skip("dsymutil not found on PATH")
+	}
+
+	t.Setenv(onb.EnvStrict, "1")
+	src := `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() {
+    let x = 10
+    let y = 32
+    println(add(x, y))
+}`
+	req := newBackendRequest(t, EmitBinary, src)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit returned error: %v", err)
+	}
+	if out, err := exec.Command("dsymutil", result.Artifacts.Binary).CombinedOutput(); err != nil {
+		t.Fatalf("dsymutil failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command("lldb",
+		"-o", "br set -f main.osty -l 1",
+		"-o", "run",
+		"-o", "frame variable",
+		"-o", "exit",
+		"--", result.Artifacts.Binary,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("lldb returned error: %v\n%s", err, out)
+	}
+	text := string(out)
+	for _, want := range []string{"a = 10", "b = 32"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("lldb frame variable missing %q:\n%s", want, text)
+		}
+	}
+}
+
 // TestONBBackendLldbResolvesSourceLineOnDarwinARM64 verifies the full
 // debugger integration: dsymutil bundles the .dSYM, lldb auto-loads it,
 // and `breakpoint set --file <src> --line N` resolves to a concrete PC

--- a/internal/onb/dwarf.go
+++ b/internal/onb/dwarf.go
@@ -73,24 +73,33 @@ const dwarfLineBaseByte byte = 0xFB
 // new attribute also needs a slot in the abbreviation table below.
 const (
 	dwarfTagCompileUnit = 0x11
+	dwarfTagBaseType    = 0x24
 	dwarfTagSubprogram  = 0x2e
+	dwarfTagVariable    = 0x34
 
 	dwarfChildrenNo  byte = 0
 	dwarfChildrenYes byte = 1
 
-	dwarfAtName     = 0x03
-	dwarfAtStmtList = 0x10
-	dwarfAtLowPC    = 0x11
-	dwarfAtHighPC   = 0x12
-	dwarfAtLanguage = 0x13
-	dwarfAtCompDir  = 0x1b
-	dwarfAtProducer = 0x25
+	dwarfAtName      = 0x03
+	dwarfAtByteSize  = 0x0b
+	dwarfAtStmtList  = 0x10
+	dwarfAtLowPC     = 0x11
+	dwarfAtHighPC    = 0x12
+	dwarfAtLanguage  = 0x13
+	dwarfAtCompDir   = 0x1b
+	dwarfAtEncoding  = 0x3e
+	dwarfAtProducer  = 0x25
+	dwarfAtFrameBase = 0x40
+	dwarfAtLocation  = 0x02
+	dwarfAtType      = 0x49
 
 	dwarfFormAddr      = 0x01
 	dwarfFormData8     = 0x07
 	dwarfFormData1     = 0x0b
 	dwarfFormStrp      = 0x0e
+	dwarfFormRef4      = 0x13
 	dwarfFormSecOffset = 0x17
+	dwarfFormExprloc   = 0x18
 
 	// DW_LANG_C99 is the closest spec-blessed language code for "C-like
 	// imperative with statement-line attribution semantics that match
@@ -99,10 +108,22 @@ const (
 	// own debugger UX.
 	dwarfLangC99 byte = 0x0c
 
+	// DW_ATE_* base-type encoding kinds — used by `__debug_info` to
+	// describe how a variable's bytes should be interpreted.
+	dwarfATESigned byte = 0x05
+
+	// DW_OP_* expression opcodes.
+	dwarfOpBreg31 byte = 0x8f // sp-based frame address
+	dwarfOpFbreg  byte = 0x91 // frame_base + sleb128
+
 	// abbrev codes. The compile unit is code 1; each function is a
-	// DW_TAG_subprogram child encoded with abbrev code 2.
+	// DW_TAG_subprogram child encoded with abbrev code 2; locals get
+	// DW_TAG_variable as code 3; their type sits at code 4 once per
+	// distinct base type (only `Int` for Phase B.3 v1).
 	dwarfAbbrevCompileUnit uint64 = 1
 	dwarfAbbrevSubprogram  uint64 = 2
+	dwarfAbbrevVariable    uint64 = 3
+	dwarfAbbrevBaseType    uint64 = 4
 )
 
 // dwarfStdOpcodeLengths is the per-opcode operand-count table the line
@@ -501,7 +522,9 @@ func (t *dwarfStringTable) Add(s string) uint32 {
 
 // dwarfCompileUnitInputs collects the metadata the CU DIE needs. Strings
 // are pre-resolved into `__debug_str` offsets so the encoder can write
-// raw uint32s without re-traversing the table.
+// raw uint32s without re-traversing the table — except the type-name
+// strings, which the encoder adds opportunistically as it discovers new
+// base types (so the caller hands over the live table via StringTable).
 type dwarfCompileUnitInputs struct {
 	NameStrOffset     uint32
 	CompDirStrOffset  uint32
@@ -510,16 +533,17 @@ type dwarfCompileUnitInputs struct {
 	HighPCSize        uint64 // DWARF 4 high_pc as constant offset from low_pc
 	StmtListOffset    uint32
 	Language          byte
+	StringTable       *dwarfStringTable
 }
 
-// emitDwarfAbbrev returns the byte stream for `__debug_abbrev`. Two
-// entries today — the compile unit DIE (code 1) and a subprogram DIE
-// (code 2) for each user function. Subprograms are children of the CU,
-// which is why the CU declares DW_CHILDREN_yes and the encoder writes a
-// 0-byte sentinel after the last subprogram to close the child list.
+// emitDwarfAbbrev returns the byte stream for `__debug_abbrev`. Four
+// entries today — CU (1), subprogram (2), variable (3), base type (4).
+// Subprograms own variable DIEs as children; types live as siblings of
+// subprograms under the CU. Each DIE list is closed by a 0-byte sentinel
+// when its abbrev declared DW_CHILDREN_yes.
 func emitDwarfAbbrev() []byte {
 	var b bytes.Buffer
-	// Code 1: DW_TAG_compile_unit, has children (the subprograms).
+	// Code 1: DW_TAG_compile_unit, has children (subprograms + types).
 	writeULEB128(&b, dwarfAbbrevCompileUnit)
 	writeULEB128(&b, dwarfTagCompileUnit)
 	b.WriteByte(dwarfChildrenYes)
@@ -533,13 +557,34 @@ func emitDwarfAbbrev() []byte {
 	writeULEB128(&b, 0)
 	writeULEB128(&b, 0)
 
-	// Code 2: DW_TAG_subprogram, no children.
+	// Code 2: DW_TAG_subprogram, has children (variable DIEs).
 	writeULEB128(&b, dwarfAbbrevSubprogram)
 	writeULEB128(&b, dwarfTagSubprogram)
-	b.WriteByte(dwarfChildrenNo)
+	b.WriteByte(dwarfChildrenYes)
 	writeULEB128AttrPair(&b, dwarfAtName, dwarfFormStrp)
 	writeULEB128AttrPair(&b, dwarfAtLowPC, dwarfFormAddr)
 	writeULEB128AttrPair(&b, dwarfAtHighPC, dwarfFormData8)
+	writeULEB128AttrPair(&b, dwarfAtFrameBase, dwarfFormExprloc)
+	writeULEB128(&b, 0)
+	writeULEB128(&b, 0)
+
+	// Code 3: DW_TAG_variable, no children.
+	writeULEB128(&b, dwarfAbbrevVariable)
+	writeULEB128(&b, dwarfTagVariable)
+	b.WriteByte(dwarfChildrenNo)
+	writeULEB128AttrPair(&b, dwarfAtName, dwarfFormStrp)
+	writeULEB128AttrPair(&b, dwarfAtType, dwarfFormRef4)
+	writeULEB128AttrPair(&b, dwarfAtLocation, dwarfFormExprloc)
+	writeULEB128(&b, 0)
+	writeULEB128(&b, 0)
+
+	// Code 4: DW_TAG_base_type, no children.
+	writeULEB128(&b, dwarfAbbrevBaseType)
+	writeULEB128(&b, dwarfTagBaseType)
+	b.WriteByte(dwarfChildrenNo)
+	writeULEB128AttrPair(&b, dwarfAtName, dwarfFormStrp)
+	writeULEB128AttrPair(&b, dwarfAtByteSize, dwarfFormData1)
+	writeULEB128AttrPair(&b, dwarfAtEncoding, dwarfFormData1)
 	writeULEB128(&b, 0)
 	writeULEB128(&b, 0)
 
@@ -570,7 +615,29 @@ type dwarfSubprogramInput struct {
 	NameStrOffset uint32
 	LowPC         uint64
 	SizeBytes     uint64 // DWARF 4 high_pc as constant offset from low_pc
+	Variables     []dwarfVariableInput
 }
+
+// dwarfVariableInput describes one local variable visible to lldb's
+// `frame variable` command. SlotOffset is the byte offset from the
+// function's frame base (which Phase B.3 sets to the current sp value)
+// where the value lives.
+type dwarfVariableInput struct {
+	NameStrOffset uint32
+	SlotOffset    int64
+	TypeKind      dwarfBaseTypeKind
+}
+
+// dwarfBaseTypeKind enumerates the primitive ABI-level types Phase B.3
+// can describe to lldb. Adding String / Bool / Float etc. is a follow-up
+// slice — each new kind needs an entry here plus a row in the type DIE
+// emitter below.
+type dwarfBaseTypeKind int
+
+const (
+	dwarfBaseTypeNone dwarfBaseTypeKind = iota
+	dwarfBaseTypeInt
+)
 
 // emitDwarfInfo returns the byte stream for `__debug_info`. The unit
 // header layout (DWARF 4 §7.5.1.1):
@@ -580,10 +647,23 @@ type dwarfSubprogramInput struct {
 //	debug_abbrev_offset (4 bytes, sec_offset into __debug_abbrev)
 //	address_size        (1 byte = 8 for aarch64)
 //
-// then DIEs in tree order. The CU DIE owns one DW_TAG_subprogram child
-// per user function, terminated by a 0-byte sentinel.
+// then DIEs in tree order:
+//
+//	CU
+//	├── base_type Int
+//	├── subprogram f
+//	│   ├── variable v1
+//	│   └── variable v2
+//	└── subprogram g
+//
+// The base_type comes first so subsequent DW_AT_type ref4 fields can use
+// its CU-relative offset. Each tree level with DW_CHILDREN_yes ends with
+// a 0-byte sentinel.
 func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarfInfoEncoded {
+	const headerLen = 11 // 4 + 2 + 4 + 1
 	var die bytes.Buffer
+
+	// CU DIE
 	writeULEB128(&die, dwarfAbbrevCompileUnit)
 	binary.Write(&die, binary.LittleEndian, cu.ProducerStrOffset)
 	die.WriteByte(cu.Language)
@@ -594,6 +674,17 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 	binary.Write(&die, binary.LittleEndian, cu.HighPCSize)
 	binary.Write(&die, binary.LittleEndian, cu.StmtListOffset)
 
+	// Type DIEs first so variable DIEs can reference them by stable
+	// CU-relative offset. Currently only `Int` is described — adding
+	// String/Bool/etc. is mechanical (extend dwarfBaseTypeKind enum,
+	// emit one more DIE here, return its offset alongside intTypeOff).
+	intTypeStrx := stringTableLookupOrAdd(cu.StringTable, "Int")
+	intTypeOff := headerLen + uint32(die.Len())
+	writeULEB128(&die, dwarfAbbrevBaseType)
+	binary.Write(&die, binary.LittleEndian, intTypeStrx)
+	die.WriteByte(8) // byte_size
+	die.WriteByte(dwarfATESigned)
+
 	subLowPCDieOffs := make([]uint32, 0, len(subs))
 	for _, sub := range subs {
 		writeULEB128(&die, dwarfAbbrevSubprogram)
@@ -601,26 +692,57 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 		subLowPCDieOffs = append(subLowPCDieOffs, uint32(die.Len()))
 		binary.Write(&die, binary.LittleEndian, sub.LowPC)
 		binary.Write(&die, binary.LittleEndian, sub.SizeBytes)
+		// frame_base = DW_OP_breg31 0 (current sp). Locals encode their
+		// own slot offsets via DW_OP_fbreg <slot>.
+		writeULEB128(&die, 2) // exprloc length
+		die.WriteByte(dwarfOpBreg31)
+		writeSLEB128(&die, 0)
+
+		// Variable DIE children. Phase B.3 v1 only emits Int locals.
+		for _, v := range sub.Variables {
+			if v.TypeKind != dwarfBaseTypeInt {
+				continue
+			}
+			writeULEB128(&die, dwarfAbbrevVariable)
+			binary.Write(&die, binary.LittleEndian, v.NameStrOffset)
+			binary.Write(&die, binary.LittleEndian, intTypeOff)
+			// location: DW_OP_fbreg <sleb128 slotOffset>
+			var loc bytes.Buffer
+			loc.WriteByte(dwarfOpFbreg)
+			writeSLEB128(&loc, v.SlotOffset)
+			writeULEB128(&die, uint64(loc.Len()))
+			die.Write(loc.Bytes())
+		}
+		die.WriteByte(0) // close subprogram children
 	}
-	// Terminate the CU's children list (DW_CHILDREN_yes was set in the
-	// abbrev, so we close with a 0-byte sentinel).
-	die.WriteByte(0)
+	die.WriteByte(0) // close CU children
 
 	var unit bytes.Buffer
-	unitLen := uint32(2 /*version*/ + 4 /*abbrev_offset*/ + 1 /*addr_size*/ + die.Len())
+	unitLen := uint32(2 + 4 + 1 + die.Len())
 	binary.Write(&unit, binary.LittleEndian, unitLen)
 	binary.Write(&unit, binary.LittleEndian, uint16(dwarfVersion))
 	binary.Write(&unit, binary.LittleEndian, uint32(0))
 	unit.WriteByte(dwarfAddressSize)
 	unit.Write(die.Bytes())
 
-	const headerLen = 11 // 4 + 2 + 4 + 1
 	lowPCs := make([]uint32, 0, 1+len(subLowPCDieOffs))
 	lowPCs = append(lowPCs, headerLen+cuLowPCDieOff)
 	for _, off := range subLowPCDieOffs {
 		lowPCs = append(lowPCs, headerLen+off)
 	}
 	return dwarfInfoEncoded{Bytes: unit.Bytes(), LowPCOffsets: lowPCs}
+}
+
+// stringTableLookupOrAdd returns the offset of `s` in the supplied table,
+// adding it if missing. We can't import dwarfStringTable from inside the
+// type definition above (Go's order-of-declaration rules) so this helper
+// shim keeps the encoder readable while the table itself stays in its
+// existing location.
+func stringTableLookupOrAdd(t *dwarfStringTable, s string) uint32 {
+	if t == nil {
+		return 0
+	}
+	return t.Add(s)
 }
 
 // dwarfCompileUnitMeta packages the three string-table inputs along with

--- a/internal/onb/dwarf_test.go
+++ b/internal/onb/dwarf_test.go
@@ -183,6 +183,53 @@ func TestEmitObjectIncludesDwarfLineSection(t *testing.T) {
 	}
 }
 
+// TestEmitDwarfInfoEmitsVariableDIEs verifies that each subprogram with
+// named Int locals carries one variable DIE per local. The locations
+// reference the function's frame_base via `DW_OP_fbreg <slot>`, which
+// lldb evaluates as `sp + slot` thanks to DW_AT_frame_base = breg31 0.
+func TestEmitDwarfInfoEmitsVariableDIEs(t *testing.T) {
+	t.Parallel()
+
+	strs := newDwarfStringTable()
+	cu := dwarfCompileUnitInputs{
+		ProducerStrOffset: strs.Add("p"),
+		Language:          dwarfLangC99,
+		NameStrOffset:     strs.Add("main.osty"),
+		CompDirStrOffset:  strs.Add("/tmp"),
+		LowPC:             0,
+		HighPCSize:        0x40,
+		StmtListOffset:    0,
+		StringTable:       strs,
+	}
+	subs := []dwarfSubprogramInput{
+		{
+			NameStrOffset: strs.Add("add"),
+			LowPC:         0,
+			SizeBytes:     0x40,
+			Variables: []dwarfVariableInput{
+				{NameStrOffset: strs.Add("a"), SlotOffset: 0, TypeKind: dwarfBaseTypeInt},
+				{NameStrOffset: strs.Add("b"), SlotOffset: 8, TypeKind: dwarfBaseTypeInt},
+			},
+		},
+	}
+	enc := emitDwarfInfo(cu, subs)
+	// 1 CU low_pc + 1 subprogram low_pc — variable DIEs use form_ref4 to
+	// the type, not addr-form, so they don't show up in LowPCOffsets.
+	if got, want := len(enc.LowPCOffsets), 2; got != want {
+		t.Fatalf("low_pc count = %d, want %d", got, want)
+	}
+	// The encoded bytes must contain `Int` type's encoding byte (signed).
+	// Searching for the literal byte sequence is brittle; instead verify
+	// the output is non-trivially larger than a no-variable CU. A CU with
+	// 0 vars + 1 subprogram is ~30 bytes; with 2 var DIEs it grows by
+	// roughly 2 × (1 abbrev + 4 name + 4 type + 1 expr-len + 2 expr-bytes)
+	// ≈ 24 bytes. The exact threshold isn't load-bearing — we just want
+	// to catch a regression that drops the variable DIEs entirely.
+	if len(enc.Bytes) < 50 {
+		t.Fatalf("debug_info too small (%d bytes); variable DIEs likely missing", len(enc.Bytes))
+	}
+}
+
 // TestEmitDwarfInfoEmitsSubprogramDIEPerFunction verifies the encoder
 // stamps one DW_TAG_subprogram low_pc relocation per function. dsymutil
 // silently rejects CUs without subprogram children, so this is a load-

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -31,11 +31,36 @@ type CStringLiteral struct {
 // the function uses no stack — a leaf function with no locals and no stack
 // arguments. The lowerer fills this in at the end of lowering once it knows
 // how many local slots and whether a printf vararg slot are needed.
+//
+// DebugLocals lists user-named locals (parameters + `let` bindings) that
+// the lowerer placed in stack slots. The DWARF emitter uses this to
+// produce one DW_TAG_variable DIE per local so lldb's `frame variable`
+// can recover the value.
 type Function struct {
-	Name      string
-	Blocks    []Block
-	FrameSize int64
+	Name        string
+	Blocks      []Block
+	FrameSize   int64
+	DebugLocals []DebugLocal
 }
+
+// DebugLocal binds a user-readable name to an stack-slot offset and a
+// primitive type kind. Anonymous compiler temps are excluded — they
+// would clutter `frame variable` output without helping the user.
+type DebugLocal struct {
+	Name       string
+	SlotOffset int64
+	TypeKind   DebugTypeKind
+}
+
+// DebugTypeKind enumerates the primitive types the DWARF emitter can
+// describe today. The order matches dwarfBaseTypeKind in dwarf.go and
+// keeps the LIR layer free of DWARF-spec constants.
+type DebugTypeKind int
+
+const (
+	DebugTypeNone DebugTypeKind = iota
+	DebugTypeInt
+)
 
 // Block is a linear basic block.
 //

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -112,7 +112,7 @@ func (s *lowerState) lowerFunction(fn *mir.Function) (Function, error) {
 	if err := s.assignLocalSlots(fn); err != nil {
 		return Function{}, err
 	}
-	out := Function{Name: fn.Name, FrameSize: s.frameSize}
+	out := Function{Name: fn.Name, FrameSize: s.frameSize, DebugLocals: s.debugLocals(fn)}
 	// Emit blocks with the entry block first so the encoded function starts
 	// at the right instruction. Branches reference target blocks by their
 	// fn.Blocks index, so we keep the index→Block mapping stable.
@@ -225,13 +225,12 @@ func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock, isEntry
 		}
 	}
 	if isEntry && fn.Name != "main" {
-		// Param shuffle inherits the function's first instruction span so
-		// debuggers don't show the prologue jump as an unmapped row.
-		var shuffleSpan LineSpan
-		if len(block.Instrs) > 0 {
-			shuffleSpan = spanFromMIR(block.Instrs[0].At())
-		}
-		emit(s.paramShuffle(fn), shuffleSpan)
+		// Param shuffle gets a zero LineSpan so the DWARF emitter skips
+		// these rows. With the shuffle attributed to the body's first
+		// source line, lldb would stop *before* the params hit their
+		// stack slots and `frame variable` would read uninitialised
+		// stack — see Phase B.3 notes.
+		emit(s.paramShuffle(fn), LineSpan{})
 	}
 	for _, instr := range block.Instrs {
 		lowered, err := s.lowerInstr(fn, instr)
@@ -438,6 +437,40 @@ func (s *lowerState) lowerAggregateAssign(rv *mir.AggregateRV, destSlot int64) (
 // future slice.
 func isABIScalarType(t mir.Type) bool {
 	return t == mir.TInt || t == mir.TBool || t == mir.TString
+}
+
+// debugLocals returns one DebugLocal per user-named local that ended up
+// with a stack slot. Anonymous compiler temporaries (Name == "" or "$ret")
+// and locals without slots are omitted so DWARF doesn't expose synthetic
+// MIR plumbing to the developer's `frame variable` view.
+//
+// Today only Int locals get DebugTypeInt — String / Bool are surfaced as
+// DebugTypeNone and the DWARF encoder skips them. Adding richer type
+// support is a follow-up that grows the DebugTypeKind enum and the type
+// DIE list in `dwarf.go` together.
+func (s *lowerState) debugLocals(fn *mir.Function) []DebugLocal {
+	if fn == nil || s.localSlots == nil {
+		return nil
+	}
+	var out []DebugLocal
+	for _, loc := range fn.Locals {
+		if loc == nil || loc.Name == "" || loc.Name == "$ret" {
+			continue
+		}
+		slot, ok := s.localSlots[loc.ID]
+		if !ok {
+			continue
+		}
+		kind := DebugTypeNone
+		if loc.Type == mir.TInt {
+			kind = DebugTypeInt
+		}
+		if kind == DebugTypeNone {
+			continue
+		}
+		out = append(out, DebugLocal{Name: loc.Name, SlotOffset: slot, TypeKind: kind})
+	}
+	return out
 }
 
 // allocateReturnSlot makes room for the return local on functions that didn't

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -207,16 +207,33 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 			meta.CU.LowPC = 0
 			meta.CU.HighPCSize = uint64(len(enc.code))
 			meta.CU.StmtListOffset = 0 // single CU; line program starts at section offset 0
+			meta.CU.StringTable = meta.Strings
 			fnSizes := computeFnSizes(enc, uint64(len(enc.code)))
 			subs := make([]dwarfSubprogramInput, 0, len(program.Functions))
 			for i, fn := range program.Functions {
 				if i >= len(enc.fnOffsets) || i >= len(fnSizes) {
 					break
 				}
+				vars := make([]dwarfVariableInput, 0, len(fn.DebugLocals))
+				for _, dl := range fn.DebugLocals {
+					kind := dwarfBaseTypeNone
+					if dl.TypeKind == DebugTypeInt {
+						kind = dwarfBaseTypeInt
+					}
+					if kind == dwarfBaseTypeNone {
+						continue
+					}
+					vars = append(vars, dwarfVariableInput{
+						NameStrOffset: meta.Strings.Add(dl.Name),
+						SlotOffset:    dl.SlotOffset,
+						TypeKind:      kind,
+					})
+				}
 				subs = append(subs, dwarfSubprogramInput{
 					NameStrOffset: meta.Strings.Add(fn.Name),
 					LowPC:         enc.fnOffsets[i],
 					SizeBytes:     fnSizes[i],
+					Variables:     vars,
 				})
 			}
 			debugAbbrev = emitDwarfAbbrev()


### PR DESCRIPTION
## Summary

lldb `frame variable` 가 ONB 빌드 결과에서 named Int local의 현재 값을 보여줌. DWARF debug 경험이 source-level breakpoint (B.2) → 변수 값 추적 (B.3) 까지 확장.

```
$ dsymutil ./app
$ lldb -o "br set -f main.osty -l 1" ./app
Breakpoint 1: where = app`add + 20 at main.osty:1:33, address = 0x10000056c
...
(lldb) frame variable
(long) a = 10
(long) b = 32
```

## 변경

**`internal/onb/dwarf.go`**:
- `DW_TAG_base_type` DIE for Int (byte_size 8, DW_ATE_signed)
- `DW_TAG_variable` DIE per named Int local — `DW_AT_name` + `DW_AT_type` (ref4) + `DW_AT_location` (DW_OP_fbreg sleb128(slot))
- Subprogram DIE에 `DW_AT_frame_base = DW_OP_breg31 0` (sp-relative)
- Abbrev table 4 entries: CU, subprogram(children), variable, base_type

**`internal/onb/lir.go`**:
- `Function.DebugLocals []DebugLocal` (이름·slot·type)
- `DebugTypeKind` enum (현재 None / Int)

**`internal/onb/lower.go`**:
- `debugLocals()`: named Int local만 추출 (`_return` / 익명 temp 제외)
- **Param shuffle instrs는 LineSpan zero** — shuffle PC가 source line으로 매핑되면 lldb가 shuffle 시작 전에 stop해서 uninitialised 슬롯 읽는 문제 해결

**`internal/onb/macho.go`**:
- DebugLocals → `dwarfVariableInput` 전달
- meta.CU.StringTable로 Int 같은 type name dedup

## Test plan

- [x] `TestEmitDwarfInfoEmitsVariableDIEs` — encoder unit
- [x] `TestONBBackendLldbFrameVariableShowsLocalsOnDarwinARM64` — end-to-end: `(long) a = 10`, `(long) b = 32`
- [x] 기존 테스트 모두 통과 (onb 0.4s, backend 173s)
- [x] `gofmt` / `go vet` 클린
- [ ] CI 그린 확인

## 누적 ONB 디버그 경험

이제 가능한 것:
- ✅ 소스 라인별 breakpoint
- ✅ `bt` (backtrace)에서 source 위치 표시
- ✅ source view (컨텍스트 5라인)
- ✅ `step` / `next` source-level
- ✅ **`frame variable` 로 Int local 값 확인** (Week 9)
- ❌ String/Bool/Float local — DebugTypeKind 확장 필요
- ❌ struct/list 같은 컴포지트 타입

## 다음 의제

| 옵션 | 효과 | LOC |
|---|---|---|
| **A — Linear scan RA** | 매 op load+store 제거. Hot path 2-3× 가속 | ~600 |
| **B — `v[0]` indexing** | place projection lowering. List 활용도 ↑ | ~400 |
| **C — Map<K,V> + struct literal** | runtime call 경로 확장 | ~500 |
| **D — String/Bool variable inspection** | DW_TAG_pointer_type + DW_TAG_base_type Bool — DebugTypeKind 확장 | ~200 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)