### PR TITLE
feat: ONB Phase A2 Week 10 — DWARF B.4 (Bool + String var inspection)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,31 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 10 (DWARF B.4 — Bool/String var inspection, 2026-05-02)** —
+> Phase B.3의 variable inspection을 Int 외 ABI-scalar 두 종류로 확장. Bool은
+> `byte_size 1` + `DW_ATE_boolean` (lldb는 byte_size 8 + boolean을 거부하고
+> "void"로 표시), String은 `DW_TAG_pointer_type` → `DW_TAG_base_type "char"`
+> 체인 (lldb가 pointee를 C 문자열로 표시).
+>
+> 검증: `fn first(a: Int, b: Bool, c: String) -> Int { a }` 함수 진입 시점에
+> `frame variable`이 다음을 표시:
+> - `(long) a = 42`
+> - `(bool) b = true`
+> - `(char *) c = 0x... "hi"`
+>
+> 추가:
+> - `DebugTypeBool` / `DebugTypeString` / `DebugTypeFloat` enum entries
+>   (Float은 ONB lowering이 D-reg 미지원이라 dead code, future-ready)
+> - `dwarfBaseTypeBool` / `Float` / `String` + `dwarfAbbrevPointerType`
+> - `collectUsedTypeKinds`로 변수에서 참조된 타입만 emit (CU dead 타입 X)
+> - `emitDwarfInfo`가 String일 때 char base_type + pointer_type 두 DIE
+> - `mirTypeToDebugKind` helper로 MIR type → debug kind 단일 source
+> - **Param 슬롯이 read 여부와 무관하게 항상 할당** — unused param도
+>   `frame variable`에 표시되도록 (이전엔 unused면 슬롯 없어 invisible)
+>
+> 한계: Float은 ONB native가 아직 처리 못 함 (Float 인자/반환 → fallback to
+> LLVM). struct/list/Map composite 타입은 후속 슬라이스.
+>
 > **Slice A2 Week 9 (DWARF B.3 — variable inspection, 2026-05-02)** —
 > lldb `frame variable` 가 ONB 빌드 결과에서 named Int local의 현재 값을
 > 보여줌. 추가:

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -316,6 +316,59 @@ func TestONBBackendBinaryRunsArithOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendLldbFrameVariableShowsBoolAndStringOnDarwinARM64
+// extends Phase B.3 to non-Int scalars. Bool requires byte_size 1 in
+// the DWARF base type (lldb refuses byte_size 8 + DW_ATE_boolean) and
+// String is encoded as DW_TAG_pointer_type → DW_TAG_base_type "char"
+// so lldb prints the pointee. The test uses a function whose body
+// reads only one parameter, exercising the "param always gets a slot"
+// rule that keeps unused params visible to the debugger.
+func TestONBBackendLldbFrameVariableShowsBoolAndStringOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("lldb DWARF integration smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+	if _, err := exec.LookPath("lldb"); err != nil {
+		t.Skip("lldb not found on PATH")
+	}
+	if _, err := exec.LookPath("dsymutil"); err != nil {
+		t.Skip("dsymutil not found on PATH")
+	}
+
+	t.Setenv(onb.EnvStrict, "1")
+	src := `fn first(a: Int, b: Bool, c: String) -> Int { a }
+fn main() {
+    println(first(42, true, "hi"))
+}`
+	req := newBackendRequest(t, EmitBinary, src)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit returned error: %v", err)
+	}
+	if out, err := exec.Command("dsymutil", result.Artifacts.Binary).CombinedOutput(); err != nil {
+		t.Fatalf("dsymutil failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command("lldb",
+		"-o", "br set -f main.osty -l 1",
+		"-o", "run",
+		"-o", "frame variable",
+		"-o", "exit",
+		"--", result.Artifacts.Binary,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("lldb returned error: %v\n%s", err, out)
+	}
+	text := string(out)
+	for _, want := range []string{"a = 42", "b = true", `c = `, `"hi"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("lldb frame variable missing %q:\n%s", want, text)
+		}
+	}
+}
+
 // TestONBBackendLldbFrameVariableShowsLocalsOnDarwinARM64 covers Phase
 // B.3: the DWARF emitter publishes one DW_TAG_variable DIE per named
 // Int local with a DW_OP_fbreg location, and lldb's `frame variable`

--- a/internal/onb/dwarf.go
+++ b/internal/onb/dwarf.go
@@ -110,7 +110,12 @@ const (
 
 	// DW_ATE_* base-type encoding kinds — used by `__debug_info` to
 	// describe how a variable's bytes should be interpreted.
-	dwarfATESigned byte = 0x05
+	dwarfATEBoolean    byte = 0x02
+	dwarfATEFloat      byte = 0x04
+	dwarfATESigned     byte = 0x05
+	dwarfATESignedChar byte = 0x06
+
+	dwarfTagPointerType = 0x0f
 
 	// DW_OP_* expression opcodes.
 	dwarfOpBreg31 byte = 0x8f // sp-based frame address
@@ -118,12 +123,14 @@ const (
 
 	// abbrev codes. The compile unit is code 1; each function is a
 	// DW_TAG_subprogram child encoded with abbrev code 2; locals get
-	// DW_TAG_variable as code 3; their type sits at code 4 once per
-	// distinct base type (only `Int` for Phase B.3 v1).
+	// DW_TAG_variable as code 3; primitive types use abbrev 4
+	// (DW_TAG_base_type) and String adds 5 (DW_TAG_pointer_type that
+	// references a `char` base type).
 	dwarfAbbrevCompileUnit uint64 = 1
 	dwarfAbbrevSubprogram  uint64 = 2
 	dwarfAbbrevVariable    uint64 = 3
 	dwarfAbbrevBaseType    uint64 = 4
+	dwarfAbbrevPointerType uint64 = 5
 )
 
 // dwarfStdOpcodeLengths is the per-opcode operand-count table the line
@@ -588,6 +595,16 @@ func emitDwarfAbbrev() []byte {
 	writeULEB128(&b, 0)
 	writeULEB128(&b, 0)
 
+	// Code 5: DW_TAG_pointer_type, no children. Used for String, which
+	// sits at the ABI boundary as a pointer to UTF-8 char data.
+	writeULEB128(&b, dwarfAbbrevPointerType)
+	writeULEB128(&b, dwarfTagPointerType)
+	b.WriteByte(dwarfChildrenNo)
+	writeULEB128AttrPair(&b, dwarfAtType, dwarfFormRef4)
+	writeULEB128AttrPair(&b, dwarfAtByteSize, dwarfFormData1)
+	writeULEB128(&b, 0)
+	writeULEB128(&b, 0)
+
 	// End of abbreviation table.
 	writeULEB128(&b, 0)
 	return b.Bytes()
@@ -628,15 +645,19 @@ type dwarfVariableInput struct {
 	TypeKind      dwarfBaseTypeKind
 }
 
-// dwarfBaseTypeKind enumerates the primitive ABI-level types Phase B.3
-// can describe to lldb. Adding String / Bool / Float etc. is a follow-up
-// slice — each new kind needs an entry here plus a row in the type DIE
-// emitter below.
+// dwarfBaseTypeKind enumerates the primitive ABI-level types the DWARF
+// emitter can describe to lldb. Each kind owns a single DIE in the CU's
+// type list — except String, which is encoded as a `DW_TAG_pointer_type`
+// pointing at a `DW_TAG_base_type "char"` so lldb prints the contents
+// instead of just the address.
 type dwarfBaseTypeKind int
 
 const (
 	dwarfBaseTypeNone dwarfBaseTypeKind = iota
 	dwarfBaseTypeInt
+	dwarfBaseTypeBool
+	dwarfBaseTypeFloat
+	dwarfBaseTypeString
 )
 
 // emitDwarfInfo returns the byte stream for `__debug_info`. The unit
@@ -675,15 +696,50 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 	binary.Write(&die, binary.LittleEndian, cu.StmtListOffset)
 
 	// Type DIEs first so variable DIEs can reference them by stable
-	// CU-relative offset. Currently only `Int` is described — adding
-	// String/Bool/etc. is mechanical (extend dwarfBaseTypeKind enum,
-	// emit one more DIE here, return its offset alongside intTypeOff).
-	intTypeStrx := stringTableLookupOrAdd(cu.StringTable, "Int")
-	intTypeOff := headerLen + uint32(die.Len())
-	writeULEB128(&die, dwarfAbbrevBaseType)
-	binary.Write(&die, binary.LittleEndian, intTypeStrx)
-	die.WriteByte(8) // byte_size
-	die.WriteByte(dwarfATESigned)
+	// CU-relative offset. We register every kind a variable in this CU
+	// references; unused kinds stay out so the .o doesn't carry dead
+	// debug info.
+	used := collectUsedTypeKinds(subs)
+	typeOff := map[dwarfBaseTypeKind]uint32{}
+
+	emitBaseType := func(kind dwarfBaseTypeKind, name string, byteSize byte, encoding byte) {
+		strx := stringTableLookupOrAdd(cu.StringTable, name)
+		typeOff[kind] = headerLen + uint32(die.Len())
+		writeULEB128(&die, dwarfAbbrevBaseType)
+		binary.Write(&die, binary.LittleEndian, strx)
+		die.WriteByte(byteSize)
+		die.WriteByte(encoding)
+	}
+
+	if used[dwarfBaseTypeInt] {
+		emitBaseType(dwarfBaseTypeInt, "Int", 8, dwarfATESigned)
+	}
+	if used[dwarfBaseTypeBool] {
+		// DWARF spec encodes Bool as byte_size 1 with DW_ATE_boolean;
+		// lldb refuses any larger boolean and falls back to "void".
+		// Our slot is 8 bytes wide but the value lives in the low byte,
+		// so reading 1 byte from the slot's address is correct.
+		emitBaseType(dwarfBaseTypeBool, "Bool", 1, dwarfATEBoolean)
+	}
+	if used[dwarfBaseTypeFloat] {
+		emitBaseType(dwarfBaseTypeFloat, "Float", 8, dwarfATEFloat)
+	}
+	if used[dwarfBaseTypeString] {
+		// String is a pointer to UTF-8 char data. Two DIEs: a `char`
+		// base type (byte_size 1, signed_char) plus a pointer DIE that
+		// references it. lldb prints the pointee as a C string.
+		charStrx := stringTableLookupOrAdd(cu.StringTable, "char")
+		charOff := headerLen + uint32(die.Len())
+		writeULEB128(&die, dwarfAbbrevBaseType)
+		binary.Write(&die, binary.LittleEndian, charStrx)
+		die.WriteByte(1)
+		die.WriteByte(dwarfATESignedChar)
+
+		typeOff[dwarfBaseTypeString] = headerLen + uint32(die.Len())
+		writeULEB128(&die, dwarfAbbrevPointerType)
+		binary.Write(&die, binary.LittleEndian, charOff)
+		die.WriteByte(8) // pointer width on aarch64
+	}
 
 	subLowPCDieOffs := make([]uint32, 0, len(subs))
 	for _, sub := range subs {
@@ -698,14 +754,18 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 		die.WriteByte(dwarfOpBreg31)
 		writeSLEB128(&die, 0)
 
-		// Variable DIE children. Phase B.3 v1 only emits Int locals.
+		// Variable DIE children — one per local whose type the encoder
+		// has registered above. Unsupported kinds (DebugTypeNone or
+		// composite) are silently skipped so they don't confuse lldb
+		// with half-described variables.
 		for _, v := range sub.Variables {
-			if v.TypeKind != dwarfBaseTypeInt {
+			off, ok := typeOff[v.TypeKind]
+			if !ok {
 				continue
 			}
 			writeULEB128(&die, dwarfAbbrevVariable)
 			binary.Write(&die, binary.LittleEndian, v.NameStrOffset)
-			binary.Write(&die, binary.LittleEndian, intTypeOff)
+			binary.Write(&die, binary.LittleEndian, off)
 			// location: DW_OP_fbreg <sleb128 slotOffset>
 			var loc bytes.Buffer
 			loc.WriteByte(dwarfOpFbreg)
@@ -731,6 +791,23 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 		lowPCs = append(lowPCs, headerLen+off)
 	}
 	return dwarfInfoEncoded{Bytes: unit.Bytes(), LowPCOffsets: lowPCs}
+}
+
+// collectUsedTypeKinds walks every variable across every subprogram and
+// records the set of base-type kinds the CU's type DIE list needs to
+// publish. Skipping unused kinds keeps the .o lean and lets future
+// composite-type slices add new kinds without paying their cost on
+// programs that don't use them.
+func collectUsedTypeKinds(subs []dwarfSubprogramInput) map[dwarfBaseTypeKind]bool {
+	used := map[dwarfBaseTypeKind]bool{}
+	for _, sub := range subs {
+		for _, v := range sub.Variables {
+			if v.TypeKind != dwarfBaseTypeNone {
+				used[v.TypeKind] = true
+			}
+		}
+	}
+	return used
 }
 
 // stringTableLookupOrAdd returns the offset of `s` in the supplied table,

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -60,6 +60,9 @@ type DebugTypeKind int
 const (
 	DebugTypeNone DebugTypeKind = iota
 	DebugTypeInt
+	DebugTypeBool
+	DebugTypeFloat  // Float / Float64 (IEEE 754 double)
+	DebugTypeString // String — pointer to UTF-8 bytes at the ABI boundary
 )
 
 // Block is a linear basic block.

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -170,6 +170,12 @@ func (s *lowerState) assignLocalSlots(fn *mir.Function) error {
 		}
 		collectTerminatorReads(block.Term, read)
 	}
+	// Parameters always need a slot — even unread ones — so lldb's
+	// `frame variable` can show them and the param shuffle has somewhere
+	// to land the AAPCS64 argument registers.
+	for _, paramID := range fn.Params {
+		read[paramID] = true
+	}
 	delete(read, fn.ReturnLocal)
 	s.localSlots = map[mir.LocalID]int64{}
 	varargBase := int64(0)
@@ -439,6 +445,24 @@ func isABIScalarType(t mir.Type) bool {
 	return t == mir.TInt || t == mir.TBool || t == mir.TString
 }
 
+// mirTypeToDebugKind maps a MIR primitive type to the LIR-side debug kind
+// the DWARF emitter can describe. Unsupported types (List / Map / struct
+// / Option / etc.) collapse to DebugTypeNone so the encoder skips them.
+func mirTypeToDebugKind(t mir.Type) DebugTypeKind {
+	switch t {
+	case mir.TInt:
+		return DebugTypeInt
+	case mir.TBool:
+		return DebugTypeBool
+	case mir.TString:
+		return DebugTypeString
+	case mir.TFloat, mir.TFloat64:
+		return DebugTypeFloat
+	default:
+		return DebugTypeNone
+	}
+}
+
 // debugLocals returns one DebugLocal per user-named local that ended up
 // with a stack slot. Anonymous compiler temporaries (Name == "" or "$ret")
 // and locals without slots are omitted so DWARF doesn't expose synthetic
@@ -461,10 +485,7 @@ func (s *lowerState) debugLocals(fn *mir.Function) []DebugLocal {
 		if !ok {
 			continue
 		}
-		kind := DebugTypeNone
-		if loc.Type == mir.TInt {
-			kind = DebugTypeInt
-		}
+		kind := mirTypeToDebugKind(loc.Type)
 		if kind == DebugTypeNone {
 			continue
 		}

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -216,10 +216,7 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 				}
 				vars := make([]dwarfVariableInput, 0, len(fn.DebugLocals))
 				for _, dl := range fn.DebugLocals {
-					kind := dwarfBaseTypeNone
-					if dl.TypeKind == DebugTypeInt {
-						kind = dwarfBaseTypeInt
-					}
+					kind := debugTypeToDwarfKind(dl.TypeKind)
 					if kind == dwarfBaseTypeNone {
 						continue
 					}
@@ -684,6 +681,24 @@ func buildDwarfLine(program *Program, enc machoTextEncoding) dwarfLineEncoded {
 		return dwarfLineEncoded{}
 	}
 	return out
+}
+
+// debugTypeToDwarfKind translates the LIR-level kind to the DWARF
+// emitter's enum. Keeping the mapping in macho.go (the only caller)
+// avoids importing DWARF constants into lir.go.
+func debugTypeToDwarfKind(k DebugTypeKind) dwarfBaseTypeKind {
+	switch k {
+	case DebugTypeInt:
+		return dwarfBaseTypeInt
+	case DebugTypeBool:
+		return dwarfBaseTypeBool
+	case DebugTypeFloat:
+		return dwarfBaseTypeFloat
+	case DebugTypeString:
+		return dwarfBaseTypeString
+	default:
+		return dwarfBaseTypeNone
+	}
 }
 
 func hasAnySourceLine(program *Program) bool {


### PR DESCRIPTION
## Summary

Phase B.3의 variable inspection을 Int 외 ABI-scalar 두 종류로 확장. lldb `frame variable`이 모든 named param/local에서 정확한 타입과 값 표시:

```
(long) a = 42
(bool) b = true
(char *) c = 0x... "hi"
```

## 변경

**`internal/onb/dwarf.go`**:
- `DW_TAG_base_type Bool` (byte_size 1, `DW_ATE_boolean`) — lldb는 byte_size 8 + boolean을 거부하고 "void"로 표시. 우리 슬롯은 8바이트지만 값이 low 바이트에 있어 1바이트 read OK
- `DW_TAG_pointer_type` → `DW_TAG_base_type "char"` 체인 for String — lldb가 pointee를 C 문자열로 표시
- `collectUsedTypeKinds`: 변수에서 참조된 타입만 CU에 emit (사용 안 하는 base_type DIE 제거)
- `emitDwarfInfo`가 String일 때 char base_type + pointer_type 두 DIE 자동 emit

**`internal/onb/lir.go`**:
- `DebugTypeKind`: `Bool`, `Float`, `String` 추가
- `Float`은 ONB lowering이 아직 D-reg 미지원이라 dead code (future-ready)

**`internal/onb/lower.go`**:
- `mirTypeToDebugKind`: MIR type → debug kind single source
- **Param 슬롯이 read 여부와 무관하게 항상 할당** — unused param도 `frame variable`에 표시되도록 (이전엔 unused면 슬롯 없어 invisible)

**`internal/onb/macho.go`**:
- `debugTypeToDwarfKind`: LIR debug kind → DWARF kind 변환

## Test plan

- [x] `TestONBBackendLldbFrameVariableShowsBoolAndStringOnDarwinARM64` — end-to-end 3 type 검증
- [x] 기존 모든 테스트 통과 (onb 0.4s, backend 60s)
- [x] `gofmt` / `go vet` 클린
- [ ] CI 그린 확인

## ONB 디버그 경험 누적 (Phase B.4까지)

| 기능 | 상태 |
|---|---|
| Source-line breakpoint | ✅ |
| Backtrace에 source 위치 | ✅ |
| Source view (5라인 컨텍스트) | ✅ |
| `step` / `next` source-level | ✅ |
| Int local 값 inspection | ✅ B.3 |
| **Bool / String local 값 inspection** | **✅ B.4** |
| Float local | ❌ ONB lowering 미지원 (별도 슬라이스) |
| struct/list/Map composite | ❌ Phase B.5 후보 |

## 다음 의제

| 옵션 | 효과 | LOC |
|---|---|---|
| **A — Float ABI lowering + var inspection** | D-reg 인자/반환 + Float type DIE | ~600 |
| **B — Linear scan RA** | hot path 2-3× 가속 | ~600 |
| **C — Composite types** (struct/list) | DW_TAG_structure_type + member DIEs | ~700 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)