### PR TITLE
feat: ONB Phase A2 Week 11 — DWARF B.5 infra (struct/member DIEs)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,29 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 11 (DWARF B.5 infra — struct/member DIEs, 2026-05-02)** —
+> 인코더 인프라만 추가. ONB가 struct를 lower하지 않으므로 dead code지만,
+> 향후 struct lowering 슬라이스가 들어올 때 DWARF 측은 더 이상 막히지 않음.
+> 구체적으로:
+> - `DW_TAG_structure_type` (abbrev 6, has children) + `DW_TAG_member`
+>   (abbrev 7) 추가
+> - `DW_AT_data_member_location` 속성 + `DW_FORM_udata` form
+> - `dwarfStructTypeInput` / `dwarfStructMemberInput` 입력 타입
+> - `emitDwarfInfo`가 `structs []dwarfStructTypeInput` 인자 추가 (callers
+>   pass nil 으로 변동 없음)
+> - 구조체 멤버가 base 타입을 참조하면 같은 CU의 base_type DIE를 공유
+>   (`collectUsedTypeKinds`가 멤버까지 union)
+> - `dwarfVariableInput.StructTypeIndex int` (–1 = base type 사용,
+>   ≥0 = struct list 인덱스 — `variableTypeOffset` helper로 분기)
+>
+> 검증: 단위 테스트 3개 — abbrev 테이블에 struct/member 코드 존재,
+> 인코더가 struct 입력을 받으면 DIE 바이트가 늘어남, variable이
+> StructTypeIndex로 struct DIE를 가리킬 수 있음.
+>
+> 한계: dwarfdump round-trip은 macho.go가 struct를 받지 않아 ScaleHole.
+> 실제 사용은 lowering 들어올 때 (struct AggregateRV + place projection
+> + AAPCS64 small-struct passing).
+>
 > **Slice A2 Week 10 (DWARF B.4 — Bool/String var inspection, 2026-05-02)** —
 > Phase B.3의 variable inspection을 Int 외 ABI-scalar 두 종류로 확장. Bool은
 > `byte_size 1` + `DW_ATE_boolean` (lldb는 byte_size 8 + boolean을 거부하고

--- a/internal/onb/dwarf.go
+++ b/internal/onb/dwarf.go
@@ -72,26 +72,29 @@ const dwarfLineBaseByte byte = 0xFB
 // actually writes are listed here — adding more later is fine, but every
 // new attribute also needs a slot in the abbreviation table below.
 const (
-	dwarfTagCompileUnit = 0x11
-	dwarfTagBaseType    = 0x24
-	dwarfTagSubprogram  = 0x2e
-	dwarfTagVariable    = 0x34
+	dwarfTagCompileUnit   = 0x11
+	dwarfTagBaseType      = 0x24
+	dwarfTagSubprogram    = 0x2e
+	dwarfTagVariable      = 0x34
+	dwarfTagStructureType = 0x13
+	dwarfTagMember        = 0x0d
 
 	dwarfChildrenNo  byte = 0
 	dwarfChildrenYes byte = 1
 
-	dwarfAtName      = 0x03
-	dwarfAtByteSize  = 0x0b
-	dwarfAtStmtList  = 0x10
-	dwarfAtLowPC     = 0x11
-	dwarfAtHighPC    = 0x12
-	dwarfAtLanguage  = 0x13
-	dwarfAtCompDir   = 0x1b
-	dwarfAtEncoding  = 0x3e
-	dwarfAtProducer  = 0x25
-	dwarfAtFrameBase = 0x40
-	dwarfAtLocation  = 0x02
-	dwarfAtType      = 0x49
+	dwarfAtName               = 0x03
+	dwarfAtByteSize           = 0x0b
+	dwarfAtStmtList           = 0x10
+	dwarfAtLowPC              = 0x11
+	dwarfAtHighPC             = 0x12
+	dwarfAtLanguage           = 0x13
+	dwarfAtCompDir            = 0x1b
+	dwarfAtEncoding           = 0x3e
+	dwarfAtProducer           = 0x25
+	dwarfAtFrameBase          = 0x40
+	dwarfAtLocation           = 0x02
+	dwarfAtType               = 0x49
+	dwarfAtDataMemberLocation = 0x38
 
 	dwarfFormAddr      = 0x01
 	dwarfFormData8     = 0x07
@@ -100,6 +103,7 @@ const (
 	dwarfFormRef4      = 0x13
 	dwarfFormSecOffset = 0x17
 	dwarfFormExprloc   = 0x18
+	dwarfFormUdata     = 0x0f
 
 	// DW_LANG_C99 is the closest spec-blessed language code for "C-like
 	// imperative with statement-line attribution semantics that match
@@ -125,12 +129,17 @@ const (
 	// DW_TAG_subprogram child encoded with abbrev code 2; locals get
 	// DW_TAG_variable as code 3; primitive types use abbrev 4
 	// (DW_TAG_base_type) and String adds 5 (DW_TAG_pointer_type that
-	// references a `char` base type).
-	dwarfAbbrevCompileUnit uint64 = 1
-	dwarfAbbrevSubprogram  uint64 = 2
-	dwarfAbbrevVariable    uint64 = 3
-	dwarfAbbrevBaseType    uint64 = 4
-	dwarfAbbrevPointerType uint64 = 5
+	// references a `char` base type). Composite types (Phase B.5
+	// infrastructure) use 6 for DW_TAG_structure_type and 7 for
+	// DW_TAG_member — the variable wiring is wired but no caller
+	// emits structs yet because ONB doesn't lower struct programs.
+	dwarfAbbrevCompileUnit   uint64 = 1
+	dwarfAbbrevSubprogram    uint64 = 2
+	dwarfAbbrevVariable      uint64 = 3
+	dwarfAbbrevBaseType      uint64 = 4
+	dwarfAbbrevPointerType   uint64 = 5
+	dwarfAbbrevStructureType uint64 = 6
+	dwarfAbbrevMember        uint64 = 7
 )
 
 // dwarfStdOpcodeLengths is the per-opcode operand-count table the line
@@ -605,6 +614,32 @@ func emitDwarfAbbrev() []byte {
 	writeULEB128(&b, 0)
 	writeULEB128(&b, 0)
 
+	// Code 6: DW_TAG_structure_type, has children (member DIEs). Phase
+	// B.5 infrastructure — no caller emits these today because ONB
+	// doesn't lower struct programs yet, but the abbrev sits in every
+	// .o anyway because dsymutil parses the abbrev table eagerly and
+	// having the entry ready costs only a handful of bytes.
+	writeULEB128(&b, dwarfAbbrevStructureType)
+	writeULEB128(&b, dwarfTagStructureType)
+	b.WriteByte(dwarfChildrenYes)
+	writeULEB128AttrPair(&b, dwarfAtName, dwarfFormStrp)
+	writeULEB128AttrPair(&b, dwarfAtByteSize, dwarfFormUdata)
+	writeULEB128(&b, 0)
+	writeULEB128(&b, 0)
+
+	// Code 7: DW_TAG_member, no children. One per struct field. The
+	// member's DW_AT_data_member_location uses DW_FORM_udata so the
+	// emitter can write the byte offset as a single uleb128, which
+	// also handles offsets >127 without bumping to a 4-byte form.
+	writeULEB128(&b, dwarfAbbrevMember)
+	writeULEB128(&b, dwarfTagMember)
+	b.WriteByte(dwarfChildrenNo)
+	writeULEB128AttrPair(&b, dwarfAtName, dwarfFormStrp)
+	writeULEB128AttrPair(&b, dwarfAtType, dwarfFormRef4)
+	writeULEB128AttrPair(&b, dwarfAtDataMemberLocation, dwarfFormUdata)
+	writeULEB128(&b, 0)
+	writeULEB128(&b, 0)
+
 	// End of abbreviation table.
 	writeULEB128(&b, 0)
 	return b.Bytes()
@@ -639,10 +674,38 @@ type dwarfSubprogramInput struct {
 // `frame variable` command. SlotOffset is the byte offset from the
 // function's frame base (which Phase B.3 sets to the current sp value)
 // where the value lives.
+//
+// StructTypeIndex >= 0 means the variable's type is the N-th entry in
+// the program's struct list (see emitDwarfInfo). When set, TypeKind is
+// ignored — the variable DIE references the struct DIE's offset instead
+// of any base-type DIE. -1 / unset = the variable uses TypeKind path.
 type dwarfVariableInput struct {
+	NameStrOffset   uint32
+	SlotOffset      int64
+	TypeKind        dwarfBaseTypeKind
+	StructTypeIndex int
+}
+
+// dwarfStructTypeInput describes one user-defined struct type the CU
+// publishes via DW_TAG_structure_type with one DW_TAG_member child per
+// field. Phase B.5 ships this infrastructure but no caller populates
+// it yet — ONB still rejects struct programs at the lowering stage.
+//
+// Members reference the same dwarfBaseTypeKind enum the variable path
+// uses, which keeps the encoder logic uniform: a struct field of type
+// `Int` shares the CU's single Int base_type DIE rather than minting a
+// fresh one.
+type dwarfStructTypeInput struct {
 	NameStrOffset uint32
-	SlotOffset    int64
+	ByteSize      uint64
+	Members       []dwarfStructMemberInput
+}
+
+// dwarfStructMemberInput is one field inside a struct.
+type dwarfStructMemberInput struct {
+	NameStrOffset uint32
 	TypeKind      dwarfBaseTypeKind
+	Offset        uint64 // byte offset within the enclosing struct
 }
 
 // dwarfBaseTypeKind enumerates the primitive ABI-level types the DWARF
@@ -680,7 +743,7 @@ const (
 // The base_type comes first so subsequent DW_AT_type ref4 fields can use
 // its CU-relative offset. Each tree level with DW_CHILDREN_yes ends with
 // a 0-byte sentinel.
-func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarfInfoEncoded {
+func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput, structs []dwarfStructTypeInput) dwarfInfoEncoded {
 	const headerLen = 11 // 4 + 2 + 4 + 1
 	var die bytes.Buffer
 
@@ -698,8 +761,16 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 	// Type DIEs first so variable DIEs can reference them by stable
 	// CU-relative offset. We register every kind a variable in this CU
 	// references; unused kinds stay out so the .o doesn't carry dead
-	// debug info.
+	// debug info. Struct fields can reference base types too, so the
+	// `used` set unions reads from variables and struct members both.
 	used := collectUsedTypeKinds(subs)
+	for _, s := range structs {
+		for _, m := range s.Members {
+			if m.TypeKind != dwarfBaseTypeNone {
+				used[m.TypeKind] = true
+			}
+		}
+	}
 	typeOff := map[dwarfBaseTypeKind]uint32{}
 
 	emitBaseType := func(kind dwarfBaseTypeKind, name string, byteSize byte, encoding byte) {
@@ -741,6 +812,34 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 		die.WriteByte(8) // pointer width on aarch64
 	}
 
+	// Struct type DIEs sit after the base types so DW_AT_type ref4 from
+	// any DW_TAG_member can resolve to a base type that is already
+	// registered. structOff is indexed by position in `structs` and
+	// retained so dwarfVariableInput.StructTypeIndex can resolve to a
+	// CU-relative offset later.
+	structOff := make([]uint32, len(structs))
+	for i, s := range structs {
+		structOff[i] = headerLen + uint32(die.Len())
+		writeULEB128(&die, dwarfAbbrevStructureType)
+		binary.Write(&die, binary.LittleEndian, s.NameStrOffset)
+		writeULEB128(&die, s.ByteSize)
+		for _, m := range s.Members {
+			memberTypeOff, ok := typeOff[m.TypeKind]
+			if !ok {
+				// Skip members whose type wasn't registered (e.g.
+				// composite-of-composite, which Phase B.5 v1 doesn't
+				// surface). The struct DIE stays well-formed because
+				// DW_TAG_member is optional under DW_TAG_structure_type.
+				continue
+			}
+			writeULEB128(&die, dwarfAbbrevMember)
+			binary.Write(&die, binary.LittleEndian, m.NameStrOffset)
+			binary.Write(&die, binary.LittleEndian, memberTypeOff)
+			writeULEB128(&die, m.Offset)
+		}
+		die.WriteByte(0) // close struct's member list
+	}
+
 	subLowPCDieOffs := make([]uint32, 0, len(subs))
 	for _, sub := range subs {
 		writeULEB128(&die, dwarfAbbrevSubprogram)
@@ -756,10 +855,11 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 
 		// Variable DIE children — one per local whose type the encoder
 		// has registered above. Unsupported kinds (DebugTypeNone or
-		// composite) are silently skipped so they don't confuse lldb
-		// with half-described variables.
+		// composite without a registered struct entry) are silently
+		// skipped so they don't confuse lldb with half-described
+		// variables.
 		for _, v := range sub.Variables {
-			off, ok := typeOff[v.TypeKind]
+			off, ok := variableTypeOffset(v, typeOff, structOff)
 			if !ok {
 				continue
 			}
@@ -791,6 +891,20 @@ func emitDwarfInfo(cu dwarfCompileUnitInputs, subs []dwarfSubprogramInput) dwarf
 		lowPCs = append(lowPCs, headerLen+off)
 	}
 	return dwarfInfoEncoded{Bytes: unit.Bytes(), LowPCOffsets: lowPCs}
+}
+
+// variableTypeOffset resolves a variable input to the CU-relative byte
+// offset of its type DIE. Struct refs win over base-type kinds: a
+// caller that sets StructTypeIndex >= 0 wants the struct DIE even if
+// TypeKind happens to be set, which keeps the common base-type path
+// (StructTypeIndex defaults to 0) unaffected since callers using base
+// types initialise `StructTypeIndex` to -1 explicitly.
+func variableTypeOffset(v dwarfVariableInput, baseOffs map[dwarfBaseTypeKind]uint32, structOffs []uint32) (uint32, bool) {
+	if v.StructTypeIndex >= 0 && v.StructTypeIndex < len(structOffs) {
+		return structOffs[v.StructTypeIndex], true
+	}
+	off, ok := baseOffs[v.TypeKind]
+	return off, ok
 }
 
 // collectUsedTypeKinds walks every variable across every subprogram and

--- a/internal/onb/dwarf_test.go
+++ b/internal/onb/dwarf_test.go
@@ -183,6 +183,116 @@ func TestEmitObjectIncludesDwarfLineSection(t *testing.T) {
 	}
 }
 
+// TestEmitDwarfAbbrevContainsStructAndMemberCodes verifies the
+// abbreviation table publishes codes 6 (DW_TAG_structure_type) and 7
+// (DW_TAG_member) so future struct-aware lowering doesn't have to
+// re-emit the abbrev shape per .o.
+func TestEmitDwarfAbbrevContainsStructAndMemberCodes(t *testing.T) {
+	t.Parallel()
+
+	out := emitDwarfAbbrev()
+
+	// Walk the abbrev table by uleb128 codes. We don't fully parse it —
+	// just confirm both struct + member codes appear with the expected
+	// tag bytes.
+	if !bytes.Contains(out, []byte{byte(dwarfAbbrevStructureType), dwarfTagStructureType, dwarfChildrenYes}) {
+		t.Fatalf("abbrev table missing DW_TAG_structure_type entry:\n% x", out)
+	}
+	if !bytes.Contains(out, []byte{byte(dwarfAbbrevMember), dwarfTagMember, dwarfChildrenNo}) {
+		t.Fatalf("abbrev table missing DW_TAG_member entry:\n% x", out)
+	}
+}
+
+// TestEmitDwarfInfoEmitsStructTypeDIE verifies that when emitDwarfInfo
+// is called with a non-empty struct list, the encoded `__debug_info`
+// contains a structure_type DIE for each struct, each with its members.
+// Phase B.5 v1 ships this path with no caller — the test pins the byte
+// shape so the encoder doesn't drift before lower.go grows struct
+// support.
+func TestEmitDwarfInfoEmitsStructTypeDIE(t *testing.T) {
+	t.Parallel()
+
+	strs := newDwarfStringTable()
+	cu := dwarfCompileUnitInputs{
+		ProducerStrOffset: strs.Add("p"),
+		Language:          dwarfLangC99,
+		NameStrOffset:     strs.Add("main.osty"),
+		CompDirStrOffset:  strs.Add("/tmp"),
+		LowPC:             0,
+		HighPCSize:        0x40,
+		StmtListOffset:    0,
+		StringTable:       strs,
+	}
+	structs := []dwarfStructTypeInput{
+		{
+			NameStrOffset: strs.Add("Point"),
+			ByteSize:      16,
+			Members: []dwarfStructMemberInput{
+				{NameStrOffset: strs.Add("x"), TypeKind: dwarfBaseTypeInt, Offset: 0},
+				{NameStrOffset: strs.Add("y"), TypeKind: dwarfBaseTypeInt, Offset: 8},
+			},
+		},
+	}
+	enc := emitDwarfInfo(cu, nil, structs)
+	if len(enc.Bytes) < 30 {
+		t.Fatalf("debug_info too small (%d bytes); struct DIE missing", len(enc.Bytes))
+	}
+	// The struct DIE comes after the CU DIE + Int base type DIE. We
+	// verify the encoded stream contains the abbrev codes for struct
+	// (6) and member (7) at non-zero positions — a stronger assertion
+	// would parse the DIE tree, which is overkill for an infra slice.
+	body := enc.Bytes[11:] // skip 11-byte unit header
+	if !bytes.Contains(body, []byte{byte(dwarfAbbrevStructureType)}) {
+		t.Fatalf("debug_info missing struct abbrev code (% x)", body)
+	}
+	if !bytes.Contains(body, []byte{byte(dwarfAbbrevMember)}) {
+		t.Fatalf("debug_info missing member abbrev code (% x)", body)
+	}
+}
+
+// TestEmitDwarfInfoVariableCanReferenceStruct exercises the
+// StructTypeIndex path: a variable DIE whose StructTypeIndex points
+// into the struct list should resolve to the struct DIE's offset
+// rather than fall back to the base-type lookup. Today no caller sets
+// StructTypeIndex >= 0, but the encoder needs to honour it once they
+// start.
+func TestEmitDwarfInfoVariableCanReferenceStruct(t *testing.T) {
+	t.Parallel()
+
+	strs := newDwarfStringTable()
+	cu := dwarfCompileUnitInputs{
+		ProducerStrOffset: strs.Add("p"),
+		Language:          dwarfLangC99,
+		NameStrOffset:     strs.Add("main.osty"),
+		CompDirStrOffset:  strs.Add("/tmp"),
+		StringTable:       strs,
+	}
+	structs := []dwarfStructTypeInput{{
+		NameStrOffset: strs.Add("Point"),
+		ByteSize:      16,
+	}}
+	subs := []dwarfSubprogramInput{{
+		NameStrOffset: strs.Add("origin"),
+		LowPC:         0,
+		SizeBytes:     0x10,
+		Variables: []dwarfVariableInput{{
+			NameStrOffset:   strs.Add("p"),
+			SlotOffset:      0,
+			TypeKind:        dwarfBaseTypeNone, // ignored when StructTypeIndex is set
+			StructTypeIndex: 0,
+		}},
+	}}
+	enc := emitDwarfInfo(cu, subs, structs)
+	// If the variable DIE were skipped (because TypeKind is None and the
+	// encoder didn't honour StructTypeIndex), the body would be smaller
+	// — no DW_TAG_variable abbrev code 3 would appear under the
+	// subprogram. The presence of code 3 in the body proves the path.
+	body := enc.Bytes[11:]
+	if !bytes.Contains(body, []byte{byte(dwarfAbbrevVariable)}) {
+		t.Fatalf("variable DIE missing — StructTypeIndex path broken (% x)", body)
+	}
+}
+
 // TestEmitDwarfInfoEmitsVariableDIEs verifies that each subprogram with
 // named Int locals carries one variable DIE per local. The locations
 // reference the function's frame_base via `DW_OP_fbreg <slot>`, which
@@ -212,7 +322,7 @@ func TestEmitDwarfInfoEmitsVariableDIEs(t *testing.T) {
 			},
 		},
 	}
-	enc := emitDwarfInfo(cu, subs)
+	enc := emitDwarfInfo(cu, subs, nil)
 	// 1 CU low_pc + 1 subprogram low_pc — variable DIEs use form_ref4 to
 	// the type, not addr-form, so they don't show up in LowPCOffsets.
 	if got, want := len(enc.LowPCOffsets), 2; got != want {
@@ -250,7 +360,7 @@ func TestEmitDwarfInfoEmitsSubprogramDIEPerFunction(t *testing.T) {
 		{NameStrOffset: 4, LowPC: 0x00, SizeBytes: 0x20},
 		{NameStrOffset: 5, LowPC: 0x20, SizeBytes: 0x20},
 	}
-	enc := emitDwarfInfo(cu, subs)
+	enc := emitDwarfInfo(cu, subs, nil)
 	if len(enc.LowPCOffsets) != 1+len(subs) {
 		t.Fatalf("low_pc offsets count = %d, want %d (CU + 2 subprograms)", len(enc.LowPCOffsets), 1+len(subs))
 	}

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -221,9 +221,10 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 						continue
 					}
 					vars = append(vars, dwarfVariableInput{
-						NameStrOffset: meta.Strings.Add(dl.Name),
-						SlotOffset:    dl.SlotOffset,
-						TypeKind:      kind,
+						NameStrOffset:   meta.Strings.Add(dl.Name),
+						SlotOffset:      dl.SlotOffset,
+						TypeKind:        kind,
+						StructTypeIndex: -1,
 					})
 				}
 				subs = append(subs, dwarfSubprogramInput{
@@ -234,7 +235,11 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 				})
 			}
 			debugAbbrev = emitDwarfAbbrev()
-			infoEnc = emitDwarfInfo(meta.CU, subs)
+			// Phase B.5: struct list passes empty until lower.go starts
+			// surfacing struct programs. The encoder still wires the
+			// path so a future caller can pass dwarfStructTypeInput
+			// entries without changing callers.
+			infoEnc = emitDwarfInfo(meta.CU, subs, nil)
 			debugInfo = infoEnc.Bytes
 			debugStr = meta.Strings.buf
 		}


### PR DESCRIPTION
## Summary

DWARF struct emission **infrastructure only**. ONB가 아직 struct를 lower하지 않으므로 모든 caller가 빈 struct 리스트를 전달 — 즉 **dead code**. 다만 향후 struct lowering 슬라이스(AggregateRV(struct) + place projection + AAPCS64 small-struct passing)가 들어올 때 DWARF 측 미구현으로 막힐 일이 없도록 미리 깔아두는 작업.

## 변경

**`internal/onb/dwarf.go`**:
- `DW_TAG_structure_type` (abbrev 6, has children) + `DW_TAG_member` (abbrev 7) 상수
- `DW_AT_data_member_location` 속성 + `DW_FORM_udata` form
- `dwarfStructTypeInput` / `dwarfStructMemberInput` 입력 타입
- `emitDwarfInfo(cu, subs, structs)` — 새 `structs` 인자 (기존 caller는 nil 전달)
- 구조체 멤버가 base 타입을 참조하면 같은 CU의 base_type DIE를 공유 — `collectUsedTypeKinds`가 멤버까지 union
- `dwarfVariableInput.StructTypeIndex int` — `-1` = base 타입 사용, `≥0` = struct list 인덱스
- `variableTypeOffset` helper가 분기 처리

**`internal/onb/macho.go`**:
- 기존 caller (`buildDwarfInfo` 경로)에 `nil` 명시적 전달
- `dwarfVariableInput`에 `StructTypeIndex: -1` 명시 (zero-value 모호성 제거)

## Test plan

- [x] `TestEmitDwarfAbbrevContainsStructAndMemberCodes` — abbrev 테이블에 코드 6/7 + 태그 + child 플래그 정확
- [x] `TestEmitDwarfInfoEmitsStructTypeDIE` — struct 입력 → DIE 바이트에 struct/member abbrev 코드 등장
- [x] `TestEmitDwarfInfoVariableCanReferenceStruct` — variable이 `StructTypeIndex` 통해 struct DIE 참조
- [x] 기존 16개 dwarf 관련 테스트 모두 통과
- [x] `gofmt` / `go vet` 클린
- [ ] CI 그린 확인

## 한계 / 후속

- **dwarfdump round-trip 미검증**: macho.go가 struct 인자를 받지 않아 .o → dwarfdump 흐름 plumbing 없이는 어려움. 단위 테스트로 형식만 검증.
- **실 사용 시점**: struct lowering 슬라이스 (별도 작업, 1-2주). 그때 macho.go가 program metadata에서 struct 정보를 추출해 emitDwarfInfo로 전달하면 lldb `frame variable`이 struct local 값까지 표시 가능.

## 다음 의제

| 옵션 | 효과 | LOC |
|---|---|---|
| **A — Linear scan RA** | hot path 2-3× 가속 | ~600 |
| **B — Float ABI lowering** | D-reg arg/return → DebugTypeFloat 활성화 | ~600 |
| **C-Lower — struct lowering** (이번 인프라 활용) | AggregateRV(struct) + place projection + AAPCS64 small-struct passing | ~1200 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)