### PR TITLE
feat(self-host): mirEmitModule walks blocks + terminators (Phase 1a)

### DIFF
--- a/internal/selfhost/phase0_wiring_test.go
+++ b/internal/selfhost/phase0_wiring_test.go
@@ -44,6 +44,20 @@ func TestPhase0SelfHostWiringExists(t *testing.T) {
 				"pub fn mirEmitModule(",
 				"pub fn mirEmitOpts(",
 				"pub struct MirEmitOpts ",
+				// Phase 1a — multi-block walk + terminator dispatch.
+				// The earlier Phase 0 emitter handled only a single
+				// `entry:` stub; Phase 1a iterates `func.blocks` and
+				// translates each MirTermKind. Loss of either the
+				// per-block iteration or the terminator dispatch
+				// would silently fall back to the old stub and
+				// produce malformed IR for any function with > 1
+				// block (loops, branches, …).
+				"for block in func.blocks {",
+				"mirEmitTerminatorLine(",
+				"mirEmitBlockTargetLabel(",
+				"MirTermReturn ->",
+				"MirTermGoto ->",
+				"MirTermUnreachable ->",
 			},
 		},
 		{

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -18899,17 +18899,82 @@ pub fn mirEmitModule(m: MirModule, opts: MirEmitOpts) -> String {
     out
 }
 
-/// mirEmitFunctionStub emits a structurally-valid `define` block with
-/// a single `entry:` label and a return stub. Phase 1 will replace
-/// the stub with real per-block instruction lowering driven by
-/// `func.blocks` + `func.locals`; today the stub keeps the IR verifier
-/// happy while the body-lowering helpers come online incrementally.
+/// mirEmitFunctionStub emits a structurally-valid `define` block.
+///
+/// Phase 1a (this iteration): walks `func.blocks`, emits each block's
+/// label (`entry:` for the entry block, `bb<N>:` for the rest), then
+/// emits the block's terminator. Instruction bodies stay empty —
+/// per-instruction emission lands in Phase 1b. Block label names use
+/// `mirBlockLabelName` so they round-trip through the same scheme the
+/// per-instruction emitters will use later.
+///
+/// Terminator coverage today:
+///   - `MirTermReturn` → `ret void` (or `ret <ty> 0` stub; Phase 1b
+///     loads the actual returnLocal value).
+///   - `MirTermGoto` → `br label %<targetName>`.
+///   - `MirTermUnreachable` → `unreachable`.
+///   - `MirTermBranch` / `MirTermSwitchInt` / `MirTermInvalid` →
+///     `unreachable` with a TODO comment so the verifier flags Phase
+///     1c-and-beyond emissions instead of silently producing a
+///     malformed `br`.
+///
+/// When `func.blocks` is empty (e.g. a synthetic decl that never got
+/// a body), falls back to the Phase 0 single-`entry:`+stub form.
 fn mirEmitFunctionStub(func: MirFunction) -> String {
     let paramListJoined = mirEmitParamListJoined(func)
     let mut out = mirFunctionDefineHeader("", func.returnType, func.name, paramListJoined, "")
-    out = out + "entry:\n"
-    out = out + mirEmitReturnStub(func.returnType)
+    if func.blocks.len() == 0 {
+        out = out + "entry:\n"
+        out = out + mirEmitReturnStub(func.returnType)
+        return out + mirFunctionDefineFooter()
+    }
+    for block in func.blocks {
+        let isEntry = block.id == func.entry
+        let label = mirBlockLabelName(isEntry, mirGenIntToString(block.id))
+        out = out + mirBlockHeaderLine(label)
+        out = out + mirEmitTerminatorLine(func, block.term, block.hasTerm)
+    }
     out + mirFunctionDefineFooter()
+}
+
+/// mirEmitTerminatorLine renders one MIR terminator as an LLVM
+/// terminator instruction. Phase 1a covers the operand-free shapes
+/// (Return-void, Goto, Unreachable) and stubs the rest with
+/// `unreachable + ; TODO Phase 1b` so the verifier surfaces the gap
+/// rather than emitting malformed IR.
+///
+/// The `MirTermReturn` case ignores `func.returnLocal` for now — Phase
+/// 1b will load the slot and emit `ret <ty> %v`. Today non-void
+/// returns become `ret <ty> 0` (or zero-equivalent), which produces
+/// valid IR but leaks no actual return value into the caller. Trivial
+/// `fn main() {}` and `fn f() -> Int { 0 }` both compile structurally;
+/// only the latter behaves incorrectly at runtime.
+fn mirEmitTerminatorLine(func: MirFunction, term: MirTerm, hasTerm: Bool) -> String {
+    if hasTerm == false {
+        return "  unreachable ; TODO Phase 1b: missing terminator\n"
+    }
+    match term.kind {
+        MirTermReturn -> mirEmitReturnStub(func.returnType),
+        MirTermGoto -> mirBrUncondLine(mirEmitBlockTargetLabel(func, term.target)),
+        MirTermUnreachable -> mirUnreachableLine(),
+        MirTermBranch -> "  unreachable ; TODO Phase 1b: branch terminator needs operand resolution\n",
+        MirTermSwitchInt -> "  unreachable ; TODO Phase 1c: switch terminator\n",
+        MirTermInvalid -> "  unreachable ; TODO: invalid terminator (lowering bug)\n",
+    }
+}
+
+/// mirEmitBlockTargetLabel resolves a MIR block-ID target into its
+/// LLVM label name by scanning `func.blocks` for a matching `id`.
+/// Falls back to `bb<targetID>` when no block matches (defensive —
+/// keeps the IR syntactically valid even on a stale terminator).
+fn mirEmitBlockTargetLabel(func: MirFunction, target: Int) -> String {
+    for block in func.blocks {
+        if block.id == target {
+            let isEntry = block.id == func.entry
+            return mirBlockLabelName(isEntry, mirGenIntToString(block.id))
+        }
+    }
+    "bb" + mirGenIntToString(target)
 }
 
 /// mirEmitParamListJoined renders the comma-separated `<ty> %p<i>`


### PR DESCRIPTION
## Summary

Phase 0 (#1268) wired the self-host monomorph chain end-to-end but emitted a single hard-coded `entry:` block with a return stub per function — fine for trivial `fn f() {}` shapes, useless for anything with control flow (loops, branches, multiple blocks). Phase 1a walks `func.blocks` and translates each `MirTerm` into the matching LLVM terminator instruction.

## What lands

- `mirEmitFunctionStub` now iterates `func.blocks`, emits each block's label via `mirBlockLabelName` (`entry:` for `func.entry`, `bb<N>:` for the rest), and dispatches the terminator through a new `mirEmitTerminatorLine` helper.
- `mirEmitTerminatorLine` covers the operand-free shapes today:
  - `MirTermReturn` → `ret void` (or scalar/null/zero stub when the return type is non-void; Phase 1b will load `func.returnLocal`).
  - `MirTermGoto` → `br label %<targetName>` (target label resolved via `mirEmitBlockTargetLabel`).
  - `MirTermUnreachable` → `unreachable`.
  - `MirTermBranch` / `MirTermSwitchInt` / `MirTermInvalid` → `unreachable` with a TODO comment so the verifier flags the Phase 1b/1c gap rather than silently emitting malformed IR.
- `mirEmitBlockTargetLabel` resolves a MIR block-ID into its LLVM label name with a defensive `bb<N>` fallback when no matching block exists in the function (stale-terminator safety).
- Empty-`func.blocks` functions still fall back to the Phase 0 single-`entry:` shape so synthetic decls without bodies don't regress.

The instruction body of each block remains empty — per-instruction emit is Phase 1b. A program like `fn f() -> Int { return 0 }` now renders structurally correct CFG (entry block + ret) but the actual return value is still the stub `0`; Phase 1b lowers `MirOperand` and the `MirInstr` set so real values flow through.

## Test plan

- [x] `osty check toolchain` exits 0 (unchanged).
- [x] `just front` passes (33 selfhost tests).
- [x] `TestPhase0SelfHostWiringExists` extended with Phase 1a needles (`for block in func.blocks {`, `mirEmitTerminatorLine`, the three match arms) passes.
- [x] `go test ./internal/selfhost/ ./internal/runner/ -short` passes.

## Phase 1b / 1c roadmap

- 1b: `MirOperand` resolution + `MirInstr` per-block emit so `MirTermReturn` loads from `func.returnLocal`, `MirTermBranch` reads its `cond` operand, and basic int/bool arithmetic flows.
- 1c: `MirTermSwitchInt` (match-lowered enum dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)