### PR TITLE
feat: ONB Phase A2 Week 13 — AAPCS64 small-struct passing + DWARF struct wiring

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,62 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 13 (AAPCS64 small-struct passing + DWARF struct
+> wiring, 2026-05-02)** — ONB가 처음으로 struct를 함수 경계에서 사용 가능.
+> `≤16B` 모든-스칼라 struct가 AAPCS64 small-struct ABI로 2-reg pair에 실려
+> 전달되며, lldb의 `frame variable`이 struct 필드를 풀어서 보여준다.
+>
+> 작동 (canonical 예제):
+>
+> ```osty
+> struct Point { x: Int, y: Int }
+> fn make() -> Point { Point { x: 5, y: 6 } }
+> fn px(p: Point) -> Int { p.x }
+> fn main() {
+>     let p = make()           // {x0, x1} → slot+0 / slot+8
+>     println(px(p))           // slot+0 / slot+8 → {x0, x1}
+> }
+> ```
+>
+> 추가:
+> - `abiRegSlots(t)` / `isABIPassableType(t)` — ABI 슬롯 카운트 (스칼라 1,
+>   ≤16B all-scalar struct N=ceil(size/8), 그 외 0/false)
+> - `paramShuffle`이 register-cursor 모델로 multi-reg struct param을 처리:
+>   regs[i..i+N) → slot+0 / slot+8 / …
+> - `lowerCall`이 struct 인자를 `materialiseStructOperand`로 슬롯에서 N개의
+>   인자 레지스터에 적재; 반환 값이 struct이면 x0, x1을 dest+0 / dest+8에 캡처
+> - `epilogue`가 struct 반환 시 `_return` 슬롯에서 x0/x1을 로드
+> - `assignLocalSlots`가 struct 반환 함수에서 `$ret`를 강제로 read 셋에
+>   추가 (스칼라/Unit는 기존대로 x0 직통)
+> - `lowerFunction` ABI guard가 struct 파라미터 / 반환을 허용 (>16B 또는
+>   composite 필드는 여전히 fallback)
+> - DWARF: `DebugTypeStruct` enum 값과 `DebugLocal.{StructName, StructFields}`
+>   추가; `macho.go`의 `collectStructTypeInputs`가 distinct struct 타입을
+>   첫-등장 순서로 수집해 `dwarfStructTypeInput` 리스트로 `emitDwarfInfo`에
+>   전달; 변수 DIE는 `StructTypeIndex`로 struct DIE를 가리킴
+>
+> 검증:
+> - 단위 테스트 4개 (`TestLowerMIRStruct*`, `TestEmitObjectIncludesStructDIE*`)
+>   — paramShuffle multi-reg, epilogue multi-reg, call site materialise +
+>   capture, DebugLocal에 struct 필드 노출, `__debug_info`에 struct/member DIE
+> - E2E binary smoke (`TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64`)
+>   — `make() -> Point` + `px(p)` / `py(p)` 호출 체인이 darwin/arm64에서
+>   `5\n6\n` 출력
+> - LLDB integration (`TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64`)
+>   — `frame variable`이 `(Point) p = (x = 7, y = 11)` 표시
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - >16B struct (3+ scalar 필드) — indirect/sret-style passing 미구현
+> - 비-스칼라 필드를 가진 struct (List/String 포함) — HFA / 복합 분류 필요
+> - struct 필드 mutation (`p.x = 5`) — projection-as-write 미지원, 여전히
+>   fallback
+> - 중첩 struct
+> - struct 생성을 인자로 직접 (`px(Point { x: 1, y: 2 })`) — Aggregate-as-arg
+>   는 fallback
+>
+> 다음 슬라이스 후보: enum lowering v1 (struct payload 없는 단순 enum
+> variant), 또는 list element 일반화 (List<Bool> / List<Float64>).
+>
 > **Slice A2 Week 12 (struct lowering v1 — literals + field reads, 2026-05-02)** —
 > ONB가 처음으로 struct를 lower. `struct Point { x: Int, y: Int }` 같은
 > 모든-스칼라 struct 한정. 작동:

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -524,6 +524,118 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64 exercises the
+// AAPCS64 small-struct ABI both directions: a function returns a struct
+// in {x0, x1}, the caller captures it into a stack slot, then passes
+// that whole struct to a second function that consumes it via two
+// argument registers. The end-to-end output drives both the
+// `materialiseStructOperand` (load slot → 2 arg regs) and the
+// struct-return epilogue (load slot → x0/x1) paths through real
+// generated code that gets executed.
+//
+// Source program:
+//
+//	struct Point { x: Int, y: Int }
+//	fn make() -> Point { Point { x: 5, y: 6 } }
+//	fn px(p: Point) -> Int { p.x }
+//	fn py(p: Point) -> Int { p.y }
+//	fn main() {
+//	    let p = make()
+//	    println(px(p))
+//	    println(py(p))
+//	}
+func TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB struct ABI executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	t.Setenv(onb.EnvStrict, "1")
+	src := `struct Point { x: Int, y: Int }
+fn make() -> Point { Point { x: 5, y: 6 } }
+fn px(p: Point) -> Int { p.x }
+fn py(p: Point) -> Int { p.y }
+fn main() {
+    let p = make()
+    println(px(p))
+    println(py(p))
+}`
+	req := newBackendRequest(t, EmitBinary, src)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit returned error: %v", err)
+	}
+	if result == nil || result.Artifacts.Binary == "" {
+		t.Fatalf("missing binary artifact: %+v", result)
+	}
+	out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("binary returned error: %v\n%s", err, out)
+	}
+	if got, want := string(out), "5\n6\n"; got != want {
+		t.Fatalf("binary output = %q, want %q", got, want)
+	}
+}
+
+// TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64 verifies the
+// DWARF wiring half of small-struct support: a struct local appears in
+// `frame variable` with its field names and values rendered through a
+// DW_TAG_structure_type DIE plus DW_TAG_member children. Without the
+// member DIEs lldb would fall back to "(Point) p =" with no field
+// breakdown, which is what regressions on the type-DIE wiring look
+// like. The breakpoint is set on the println line so the param shuffle
+// in `px` has run and the struct slot is fully populated.
+func TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("lldb struct DWARF integration smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+	if _, err := exec.LookPath("lldb"); err != nil {
+		t.Skip("lldb not found on PATH")
+	}
+	if _, err := exec.LookPath("dsymutil"); err != nil {
+		t.Skip("dsymutil not found on PATH")
+	}
+
+	t.Setenv(onb.EnvStrict, "1")
+	src := `struct Point { x: Int, y: Int }
+fn px(p: Point) -> Int { p.x }
+fn main() {
+    let p = Point { x: 7, y: 11 }
+    println(px(p))
+}`
+	req := newBackendRequest(t, EmitBinary, src)
+	req.Layout.Target = "aarch64-apple-darwin"
+	result, err := ONBBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ONBBackend.Emit returned error: %v", err)
+	}
+	if out, err := exec.Command("dsymutil", result.Artifacts.Binary).CombinedOutput(); err != nil {
+		t.Fatalf("dsymutil failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command("lldb",
+		"-o", "br set -f main.osty -l 2",
+		"-o", "run",
+		"-o", "frame variable",
+		"-o", "exit",
+		"--", result.Artifacts.Binary,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("lldb returned error: %v\n%s", err, out)
+	}
+	text := string(out)
+	for _, want := range []string{"(Point)", "x = 7", "y = 11"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("lldb frame variable missing %q:\n%s", want, text)
+		}
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -46,10 +46,27 @@ type Function struct {
 // DebugLocal binds a user-readable name to an stack-slot offset and a
 // primitive type kind. Anonymous compiler temps are excluded — they
 // would clutter `frame variable` output without helping the user.
+//
+// StructName / StructFields populate when TypeKind == DebugTypeStruct;
+// the DWARF emitter de-duplicates struct types by StructName across
+// every function in a CU. StructFields lists each field's name and
+// primitive kind in source order — only all-scalar structs are
+// describable today, which matches what the lowerer accepts.
 type DebugLocal struct {
-	Name       string
-	SlotOffset int64
-	TypeKind   DebugTypeKind
+	Name         string
+	SlotOffset   int64
+	TypeKind     DebugTypeKind
+	StructName   string
+	StructFields []DebugStructField
+}
+
+// DebugStructField is one entry inside DebugLocal.StructFields.
+// FieldKind enumerates the same primitive kinds DebugTypeKind covers; a
+// nested struct field would need an additional path that points back at
+// another struct type, which the lowerer doesn't lower today.
+type DebugStructField struct {
+	Name      string
+	FieldKind DebugTypeKind
 }
 
 // DebugTypeKind enumerates the primitive types the DWARF emitter can
@@ -63,6 +80,7 @@ const (
 	DebugTypeBool
 	DebugTypeFloat  // Float / Float64 (IEEE 754 double)
 	DebugTypeString // String — pointer to UTF-8 bytes at the ABI boundary
+	DebugTypeStruct // user-defined small struct described via DebugLocal.StructName/Fields
 )
 
 // Block is a linear basic block.

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -9,9 +9,17 @@ import (
 )
 
 // argRegs is the AAPCS64 integer-argument register sequence. Phase A2 caps
-// at 8 arguments — anything beyond that needs stack passing which the dev
-// backend defers to a later slice.
+// at 8 register slots — anything beyond that needs stack passing which the
+// dev backend defers to a later slice. Small structs (≤16B) consume two
+// adjacent register slots (e.g. {x0, x1}), so a function that takes a
+// `Point` plus a scalar uses three slots, not two.
 var argRegs = []Reg{RegX0, RegX1, RegX2, RegX3, RegX4, RegX5, RegX6, RegX7}
+
+// abiSmallStructRegLimit is the AAPCS64 cutoff for "small struct" handling:
+// up to two integer registers. Sizes ≤ 8 bytes consume one register, sizes
+// 9–16 bytes consume two adjacent registers, anything bigger goes through
+// indirect (sret-style) passing which Phase A2 doesn't lower yet.
+const abiSmallStructRegLimit = 2
 
 // Runtime symbol names. ONB calls into the same `osty_runtime.c` the LLVM
 // backend bundles, so these strings have to match the C function names
@@ -97,16 +105,28 @@ func (s *lowerState) lowerFunction(fn *mir.Function) (Function, error) {
 			return Function{}, fmt.Errorf("%w: main return type %s is outside phase 1", ErrUnsupportedShape, fn.ReturnType)
 		}
 	} else {
-		if len(fn.Params) > len(argRegs) {
-			return Function{}, fmt.Errorf("%w: %s takes %d params (max %d)", ErrUnsupportedShape, fn.Name, len(fn.Params), len(argRegs))
-		}
+		// Walk the parameter list with a register-cursor: each scalar
+		// param consumes one register, each small struct consumes one
+		// or two. Anything beyond x7 fails the guard until stack-arg
+		// passing lands in a future slice. abiRegSlots reads the
+		// module's StructLayout via s.mod, so the guard works even
+		// before s.fn is set below.
+		regCursor := 0
 		for _, paramID := range fn.Params {
 			loc := lookupLocal(fn, paramID)
-			if loc == nil || !isABIScalarType(loc.Type) {
-				return Function{}, fmt.Errorf("%w: %s parameter %v has non-scalar type", ErrUnsupportedShape, fn.Name, paramID)
+			if loc == nil {
+				return Function{}, fmt.Errorf("%w: %s parameter %v missing local entry", ErrUnsupportedShape, fn.Name, paramID)
 			}
+			slots, ok := s.abiRegSlots(loc.Type)
+			if !ok || slots == 0 {
+				return Function{}, fmt.Errorf("%w: %s parameter %s has type %s outside ABI", ErrUnsupportedShape, fn.Name, loc.Name, loc.Type)
+			}
+			if regCursor+slots > len(argRegs) {
+				return Function{}, fmt.Errorf("%w: %s parameter %s would overflow argument registers", ErrUnsupportedShape, fn.Name, loc.Name)
+			}
+			regCursor += slots
 		}
-		if !isABIScalarType(fn.ReturnType) && fn.ReturnType != mir.TUnit {
+		if fn.ReturnType != mir.TUnit && !s.isABIPassableType(fn.ReturnType) {
 			return Function{}, fmt.Errorf("%w: %s return type %s is outside phase 1", ErrUnsupportedShape, fn.Name, fn.ReturnType)
 		}
 	}
@@ -179,7 +199,18 @@ func (s *lowerState) assignLocalSlots(fn *mir.Function) error {
 	for _, paramID := range fn.Params {
 		read[paramID] = true
 	}
-	delete(read, fn.ReturnLocal)
+	// Scalar / Unit returns travel through x0 — no stack slot needed
+	// for `$ret` in the common case, and skipping it keeps leaf helpers
+	// frame-less. Small struct returns are different: even though no
+	// instruction *reads* $ret (it's purely a write target), the
+	// AggregateRV writer needs a slot to stamp each field into, and
+	// the epilogue needs that same slot to load slot+0 → x0 and
+	// slot+8 → x1. Force the slot in by inserting $ret into `read`.
+	if fn.ReturnType == mir.TUnit || isABIScalarType(fn.ReturnType) {
+		delete(read, fn.ReturnLocal)
+	} else {
+		read[fn.ReturnLocal] = true
+	}
 	s.localSlots = map[mir.LocalID]int64{}
 	varargBase := int64(0)
 	if s.needsVararg {
@@ -325,25 +356,42 @@ func (s *lowerState) lowerBranchTerm(term *mir.BranchTerm) ([]Instr, error) {
 	return out, nil
 }
 
-// paramShuffle copies every read parameter from its AAPCS64 argument register
-// into its assigned stack slot. Parameters that are never read get no slot
-// and no shuffle — their argument register is simply left untouched.
+// paramShuffle copies every read parameter from its AAPCS64 argument
+// register(s) into its assigned stack slot. Scalar params consume one
+// register; small structs consume one or two adjacent registers, with
+// register N landing at slot+N*8 to match the field-projection offsets
+// the rest of the body expects. Parameters that are never read get no
+// slot, but the register cursor still advances so subsequent params
+// see the right register.
 func (s *lowerState) paramShuffle(fn *mir.Function) []Instr {
 	var out []Instr
-	for i, paramID := range fn.Params {
-		slot, ok := s.localSlots[paramID]
+	regCursor := 0
+	for _, paramID := range fn.Params {
+		loc := lookupLocal(fn, paramID)
+		if loc == nil {
+			continue
+		}
+		slots, ok := s.abiRegSlots(loc.Type)
 		if !ok {
 			continue
 		}
-		out = append(out, &Store64Stack{Src: argRegs[i], Offset: slot})
+		slot, hasSlot := s.localSlots[paramID]
+		for i := 0; i < slots; i++ {
+			if hasSlot {
+				out = append(out, &Store64Stack{Src: argRegs[regCursor+i], Offset: slot + int64(i)*8})
+			}
+		}
+		regCursor += slots
 	}
 	return out
 }
 
-// epilogue emits the function exit sequence. main returns process exit code
-// 0 in w0; user functions load their _return slot into x0 (Int return) or
-// nothing (Unit return) before falling through to Ret, which itself emits
-// the FP/LR restore + ret.
+// epilogue emits the function exit sequence. main returns process exit
+// code 0 in w0; user functions load their _return slot into x0 (and x1
+// for small struct returns) or nothing (Unit return) before falling
+// through to Ret, which itself emits the FP/LR restore + ret. Small
+// structs (≤ 16B) follow AAPCS64's 2-register return convention: slot+0
+// → x0, slot+8 → x1.
 func (s *lowerState) epilogue(fn *mir.Function) []Instr {
 	if fn.Name == "main" {
 		return []Instr{&MovImm32{Dst: RegW0, Imm: 0}, &Ret{}}
@@ -351,21 +399,29 @@ func (s *lowerState) epilogue(fn *mir.Function) []Instr {
 	if fn.ReturnType == mir.TUnit {
 		return []Instr{&Ret{}}
 	}
-	if slot, ok := s.localSlots[fn.ReturnLocal]; ok {
+	slot, ok := s.localSlots[fn.ReturnLocal]
+	if !ok {
+		// _return was never read locally. This path is rarely exercised
+		// today — the front end usually emits Assign _return := <expr>
+		// followed by ReturnTerm, which marks the local as both written
+		// and read — but we keep a safe default so the regression is
+		// loud if it changes.
 		return []Instr{
-			&Load64Stack{Dst: RegX0, Offset: slot},
+			&MovImm64{Dst: RegX0, Imm: 0},
 			&Ret{},
 		}
 	}
-	// _return was never read locally (e.g. body is a single Bin assigned to
-	// _return — which is itself a write, not a read). Allocate a slot
-	// retroactively and load it. This path is unreachable today because
-	// every Int-returning helper writes to _return and then ReturnTerm —
-	// but we keep an explicit error so the regression is loud if it changes.
-	return []Instr{
-		&MovImm64{Dst: RegX0, Imm: 0}, // safe default; caller will see 0
-		&Ret{},
+	slots, _ := s.abiRegSlots(fn.ReturnType)
+	if slots == 0 {
+		slots = 1
 	}
+	retRegs := []Reg{RegX0, RegX1}
+	out := make([]Instr, 0, slots+1)
+	for i := 0; i < slots && i < len(retRegs); i++ {
+		out = append(out, &Load64Stack{Dst: retRegs[i], Offset: slot + int64(i)*8})
+	}
+	out = append(out, &Ret{})
+	return out
 }
 
 func blockLabel(id mir.BlockID) string {
@@ -482,6 +538,46 @@ func isABIScalarType(t mir.Type) bool {
 	return t == mir.TInt || t == mir.TBool || t == mir.TString
 }
 
+// abiRegSlots reports how many AAPCS64 integer-argument registers an ABI
+// value of type t consumes. Scalars are 1, small structs (≤ 16B with all
+// scalar fields) are ceil(size/8), Unit is 0 (callers should skip), and
+// anything else returns 0 with ok=false to signal the lowerer should bail.
+func (s *lowerState) abiRegSlots(t mir.Type) (int, bool) {
+	if t == mir.TUnit {
+		return 0, true
+	}
+	if isABIScalarType(t) {
+		return 1, true
+	}
+	if layout := s.lookupStructLayout(t); layout != nil {
+		// Confirm every field is scalar; mixed structs need a different
+		// strategy (HFA / sret) the dev backend doesn't implement.
+		for _, f := range layout.Fields {
+			if !isABIScalarType(f.Type) {
+				return 0, false
+			}
+		}
+		n := len(layout.Fields)
+		if n == 0 || n > abiSmallStructRegLimit {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+// isABIPassableType reports whether t is something the ABI guards can
+// accept as a parameter or return type. Scalars and small structs are in;
+// builtin generics (List<T>, Map<K,V>, etc.) and large structs stay out
+// until a follow-up slice teaches the lowerer about indirect passing.
+func (s *lowerState) isABIPassableType(t mir.Type) bool {
+	if isABIScalarType(t) {
+		return true
+	}
+	_, ok := s.abiRegSlots(t)
+	return ok
+}
+
 // lookupStructLayout resolves a NamedType to its `mod.Layouts.Structs`
 // entry. Returns nil for non-named types or layouts the front end didn't
 // register. The lowerer uses this to size struct slots and to compute
@@ -578,10 +674,13 @@ func mirTypeToDebugKind(t mir.Type) DebugTypeKind {
 // and locals without slots are omitted so DWARF doesn't expose synthetic
 // MIR plumbing to the developer's `frame variable` view.
 //
-// Today only Int locals get DebugTypeInt — String / Bool are surfaced as
-// DebugTypeNone and the DWARF encoder skips them. Adding richer type
-// support is a follow-up that grows the DebugTypeKind enum and the type
-// DIE list in `dwarf.go` together.
+// Scalars (Int, Bool, String) get their primitive DebugTypeKind. Small
+// structs (≤ 16B with all-scalar fields) get DebugTypeStruct plus the
+// struct's name and field list, which the macho writer threads into a
+// DW_TAG_structure_type + DW_TAG_member tree so lldb can pretty-print
+// `frame variable` rows like `(Point) p = (x = 3, y = 4)`. Mixed or
+// composite structs collapse to DebugTypeNone so they stay invisible
+// rather than confusing the debugger with half-described aggregates.
 func (s *lowerState) debugLocals(fn *mir.Function) []DebugLocal {
 	if fn == nil || s.localSlots == nil {
 		return nil
@@ -595,6 +694,10 @@ func (s *lowerState) debugLocals(fn *mir.Function) []DebugLocal {
 		if !ok {
 			continue
 		}
+		if dl, ok := s.debugLocalForStruct(loc, slot); ok {
+			out = append(out, dl)
+			continue
+		}
 		kind := mirTypeToDebugKind(loc.Type)
 		if kind == DebugTypeNone {
 			continue
@@ -602,6 +705,37 @@ func (s *lowerState) debugLocals(fn *mir.Function) []DebugLocal {
 		out = append(out, DebugLocal{Name: loc.Name, SlotOffset: slot, TypeKind: kind})
 	}
 	return out
+}
+
+// debugLocalForStruct produces a DebugLocal entry for a small struct
+// local. Returns ok=false when the local isn't a recognised small
+// struct so the caller can fall through to the scalar path. Only
+// all-scalar small structs surface — anything with a non-scalar field
+// would need either a recursive struct DIE or pointer-DIE plumbing
+// neither of which the dev backend ships yet.
+func (s *lowerState) debugLocalForStruct(loc *mir.Local, slot int64) (DebugLocal, bool) {
+	layout := s.lookupStructLayout(loc.Type)
+	if layout == nil {
+		return DebugLocal{}, false
+	}
+	if len(layout.Fields) == 0 {
+		return DebugLocal{}, false
+	}
+	fields := make([]DebugStructField, 0, len(layout.Fields))
+	for _, f := range layout.Fields {
+		kind := mirTypeToDebugKind(f.Type)
+		if kind == DebugTypeNone {
+			return DebugLocal{}, false
+		}
+		fields = append(fields, DebugStructField{Name: f.Name, FieldKind: kind})
+	}
+	return DebugLocal{
+		Name:         loc.Name,
+		SlotOffset:   slot,
+		TypeKind:     DebugTypeStruct,
+		StructName:   layout.Name,
+		StructFields: fields,
+	}, true
 }
 
 // allocateReturnSlot makes room for the return local on functions that didn't
@@ -724,29 +858,97 @@ func (s *lowerState) lowerComparisonAssign(rv *mir.BinaryRV, cond Cond, destSlot
 
 // lowerCall emits an AAPCS64 direct call: each argument materialises into
 // x0..x7 in order, then `bl _<name>`, then (if the call has a destination
-// place backed by a slot) the return value in x0 is stored into that slot.
-// FnRef-only — indirect calls and non-Int parameter types fall back.
+// place backed by a slot) the return value(s) in x0/x1 are stored into
+// that slot. Small structs (≤ 16B) consume two adjacent argument registers
+// and, on return, the receiver captures both x0 and x1 into slot+0/+8.
+// FnRef-only — indirect calls and parameter types outside ABI fall back.
 func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr, error) {
 	ref, ok := instr.Callee.(*mir.FnRef)
 	if !ok {
 		return nil, fmt.Errorf("%w: indirect call", ErrUnsupportedShape)
 	}
-	if len(instr.Args) > len(argRegs) {
-		return nil, fmt.Errorf("%w: %d args (max %d)", ErrUnsupportedShape, len(instr.Args), len(argRegs))
-	}
 	var out []Instr
-	for i, arg := range instr.Args {
-		mat, err := s.materialiseOperand(arg, argRegs[i])
-		if err != nil {
-			return nil, err
+	regCursor := 0
+	for _, arg := range instr.Args {
+		argType := arg.Type()
+		slots, ok := s.abiRegSlots(argType)
+		if !ok {
+			return nil, fmt.Errorf("%w: call argument has type %s outside ABI", ErrUnsupportedShape, argType)
 		}
-		out = append(out, mat...)
+		if regCursor+slots > len(argRegs) {
+			return nil, fmt.Errorf("%w: call to %s needs more than %d argument registers", ErrUnsupportedShape, ref.Symbol, len(argRegs))
+		}
+		if slots > 1 {
+			// Multi-register struct argument. Today's slow-path only
+			// supports a whole-struct Copy/Move out of a stack slot —
+			// FieldProj-of-struct-arg or struct-literal-as-arg are
+			// not lowered yet.
+			mat, err := s.materialiseStructOperand(arg, argRegs[regCursor:regCursor+slots])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mat...)
+		} else {
+			mat, err := s.materialiseOperand(arg, argRegs[regCursor])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mat...)
+		}
+		regCursor += slots
 	}
 	out = append(out, &BranchLink{Symbol: ref.Symbol})
 	if instr.Dest != nil && !instr.Dest.HasProjections() {
 		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
-			out = append(out, &Store64Stack{Src: RegX0, Offset: slot})
+			retSlots, _ := s.abiRegSlots(s.destType(instr.Dest.Local))
+			if retSlots == 0 {
+				retSlots = 1
+			}
+			retRegs := []Reg{RegX0, RegX1}
+			for i := 0; i < retSlots && i < len(retRegs); i++ {
+				out = append(out, &Store64Stack{Src: retRegs[i], Offset: slot + int64(i)*8})
+			}
 		}
+	}
+	return out, nil
+}
+
+// destType returns the MIR type of a local in the current function. The
+// caller already knows the local is a Dest of a CallInstr, so a missing
+// entry is only possible for malformed MIR — we fall back to TInt so the
+// 1-register capture path keeps working.
+func (s *lowerState) destType(id mir.LocalID) mir.Type {
+	if loc := lookupLocal(s.fn, id); loc != nil {
+		return loc.Type
+	}
+	return mir.TInt
+}
+
+// materialiseStructOperand loads a whole-struct operand into N consecutive
+// argument registers. Slot+0 lands in regs[0], slot+8 in regs[1], etc.
+// Only Copy/Move from a stack-slot-backed local with no projection are
+// handled; FieldProj-of-struct or struct-literal-as-arg patterns return
+// the unsupported sentinel so the LLVM fallback owns them.
+func (s *lowerState) materialiseStructOperand(op mir.Operand, regs []Reg) ([]Instr, error) {
+	var place mir.Place
+	switch o := op.(type) {
+	case *mir.CopyOp:
+		place = o.Place
+	case *mir.MoveOp:
+		place = o.Place
+	default:
+		return nil, fmt.Errorf("%w: struct argument operand %T", ErrUnsupportedShape, op)
+	}
+	if place.HasProjections() {
+		return nil, fmt.Errorf("%w: struct argument with projection", ErrUnsupportedShape)
+	}
+	slot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: struct argument from local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	out := make([]Instr, 0, len(regs))
+	for i, r := range regs {
+		out = append(out, &Load64Stack{Dst: r, Offset: slot + int64(i)*8})
 	}
 	return out, nil
 }

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -209,6 +209,11 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 			meta.CU.StmtListOffset = 0 // single CU; line program starts at section offset 0
 			meta.CU.StringTable = meta.Strings
 			fnSizes := computeFnSizes(enc, uint64(len(enc.code)))
+			// Pre-pass: collect distinct struct types so the variable
+			// loop can resolve StructName → struct list index. Order
+			// is the first-seen order across functions, which keeps
+			// the section deterministic for golden testing.
+			structInputs, structIndex := collectStructTypeInputs(program, meta.Strings)
 			subs := make([]dwarfSubprogramInput, 0, len(program.Functions))
 			for i, fn := range program.Functions {
 				if i >= len(enc.fnOffsets) || i >= len(fnSizes) {
@@ -216,6 +221,19 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 				}
 				vars := make([]dwarfVariableInput, 0, len(fn.DebugLocals))
 				for _, dl := range fn.DebugLocals {
+					if dl.TypeKind == DebugTypeStruct {
+						idx, ok := structIndex[dl.StructName]
+						if !ok {
+							continue
+						}
+						vars = append(vars, dwarfVariableInput{
+							NameStrOffset:   meta.Strings.Add(dl.Name),
+							SlotOffset:      dl.SlotOffset,
+							TypeKind:        dwarfBaseTypeNone,
+							StructTypeIndex: idx,
+						})
+						continue
+					}
 					kind := debugTypeToDwarfKind(dl.TypeKind)
 					if kind == dwarfBaseTypeNone {
 						continue
@@ -235,11 +253,7 @@ func emitMachOObjectWithCStringRelocs(program *Program) ([]byte, error) {
 				})
 			}
 			debugAbbrev = emitDwarfAbbrev()
-			// Phase B.5: struct list passes empty until lower.go starts
-			// surfacing struct programs. The encoder still wires the
-			// path so a future caller can pass dwarfStructTypeInput
-			// entries without changing callers.
-			infoEnc = emitDwarfInfo(meta.CU, subs, nil)
+			infoEnc = emitDwarfInfo(meta.CU, subs, structInputs)
 			debugInfo = infoEnc.Bytes
 			debugStr = meta.Strings.buf
 		}
@@ -704,6 +718,50 @@ func debugTypeToDwarfKind(k DebugTypeKind) dwarfBaseTypeKind {
 	default:
 		return dwarfBaseTypeNone
 	}
+}
+
+// collectStructTypeInputs walks every function's DebugLocals and builds
+// the per-CU struct DIE list. Each struct name appears at most once;
+// subsequent locals of the same struct point at the first occurrence's
+// index. The companion `index` map gives the variable loop an O(1)
+// StructName → list-index lookup. Field types are resolved through
+// debugTypeToDwarfKind so the struct DIE shares the CU's primitive
+// base-type DIEs rather than minting fresh ones per struct.
+func collectStructTypeInputs(program *Program, strs *dwarfStringTable) ([]dwarfStructTypeInput, map[string]int) {
+	if program == nil || strs == nil {
+		return nil, nil
+	}
+	index := map[string]int{}
+	var inputs []dwarfStructTypeInput
+	for _, fn := range program.Functions {
+		for _, dl := range fn.DebugLocals {
+			if dl.TypeKind != DebugTypeStruct || dl.StructName == "" {
+				continue
+			}
+			if _, seen := index[dl.StructName]; seen {
+				continue
+			}
+			members := make([]dwarfStructMemberInput, 0, len(dl.StructFields))
+			for i, f := range dl.StructFields {
+				kind := debugTypeToDwarfKind(f.FieldKind)
+				if kind == dwarfBaseTypeNone {
+					continue
+				}
+				members = append(members, dwarfStructMemberInput{
+					NameStrOffset: strs.Add(f.Name),
+					TypeKind:      kind,
+					Offset:        uint64(i) * 8,
+				})
+			}
+			index[dl.StructName] = len(inputs)
+			inputs = append(inputs, dwarfStructTypeInput{
+				NameStrOffset: strs.Add(dl.StructName),
+				ByteSize:      uint64(len(dl.StructFields)) * 8,
+				Members:       members,
+			})
+		}
+	}
+	return inputs, index
 }
 
 func hasAnySourceLine(program *Program) bool {

--- a/internal/onb/onb_test.go
+++ b/internal/onb/onb_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/mir"
 )
 
@@ -976,5 +977,379 @@ func TestEmitObjectWritesMachOArithRelocations(t *testing.T) {
 	}
 	if !sawPrintf {
 		t.Fatalf("Mach-O symbols = %+v, want _printf for vararg println", f.Symtab.Syms)
+	}
+}
+
+// pointModule builds a MIR module with three functions exercising
+// AAPCS64 small-struct passing:
+//
+//   - `make() -> Point` — small struct return, populates {x0, x1}.
+//   - `px(p: Point) -> Int` — small struct param, reads field via
+//     FieldProj on the param local.
+//   - `main()` — calls `make` to capture a Point return value into a
+//     local, then passes that local to `px` to drive both the struct
+//     return capture and struct argument materialisation paths.
+//
+// The fixture mirrors the MIR shape the front end produces for:
+//
+//	struct Point { x: Int, y: Int }
+//	fn make() -> Point { Point { x: 5, y: 6 } }
+//	fn px(p: Point) -> Int { p.x }
+//	fn main() { let p = make(); println(px(p)) }
+func pointModule() *mir.Module {
+	pointT := &ir.NamedType{Name: "Point"}
+	pointLayout := &mir.StructLayout{
+		Name: "Point",
+		Fields: []mir.FieldLayout{
+			{Index: 0, Name: "x", Type: mir.TInt},
+			{Index: 1, Name: "y", Type: mir.TInt},
+		},
+	}
+
+	makeFn := &mir.Function{
+		Name:        "make",
+		ReturnType:  pointT,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: pointT, IsReturn: true},
+		},
+	}
+	makeBlock := makeFn.NewBlock(mir.Span{})
+	makeFn.Block(makeBlock).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 0},
+			Src: &mir.AggregateRV{
+				Kind: mir.AggStruct,
+				T:    pointT,
+				Fields: []mir.Operand{
+					&mir.ConstOp{Const: &mir.IntConst{Value: 5, T: mir.TInt}, T: mir.TInt},
+					&mir.ConstOp{Const: &mir.IntConst{Value: 6, T: mir.TInt}, T: mir.TInt},
+				},
+			},
+		},
+	}
+	makeFn.Block(makeBlock).SetTerminator(&mir.ReturnTerm{})
+
+	pxFn := &mir.Function{
+		Name:        "px",
+		ReturnType:  mir.TInt,
+		ReturnLocal: 0,
+		Entry:       0,
+		Params:      []mir.LocalID{1},
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TInt, IsReturn: true},
+			{ID: 1, Name: "p", Type: pointT},
+		},
+	}
+	pxBlock := pxFn.NewBlock(mir.Span{})
+	pxFn.Block(pxBlock).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 0},
+			Src: &mir.UseRV{
+				Op: &mir.CopyOp{
+					Place: mir.Place{
+						Local:       1,
+						Projections: []mir.Projection{&mir.FieldProj{Index: 0, Type: mir.TInt}},
+					},
+					T: mir.TInt,
+				},
+			},
+		},
+	}
+	pxFn.Block(pxBlock).SetTerminator(&mir.ReturnTerm{})
+
+	mainFn := &mir.Function{
+		Name:        "main",
+		ReturnType:  mir.TUnit,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TUnit, IsReturn: true},
+			{ID: 1, Name: "p", Type: pointT},
+			{ID: 2, Name: "n", Type: mir.TInt},
+		},
+	}
+	mainBlock := mainFn.NewBlock(mir.Span{})
+	mainFn.Block(mainBlock).Instrs = []mir.Instr{
+		&mir.CallInstr{
+			Dest:   &mir.Place{Local: 1},
+			Callee: &mir.FnRef{Symbol: "make", Type: pointT},
+		},
+		&mir.CallInstr{
+			Dest:   &mir.Place{Local: 2},
+			Callee: &mir.FnRef{Symbol: "px", Type: mir.TInt},
+			Args: []mir.Operand{
+				&mir.CopyOp{Place: mir.Place{Local: 1}, T: pointT},
+			},
+		},
+		&mir.IntrinsicInstr{
+			Kind: mir.IntrinsicPrintln,
+			Args: []mir.Operand{&mir.CopyOp{Place: mir.Place{Local: 2}, T: mir.TInt}},
+		},
+	}
+	mainFn.Block(mainBlock).SetTerminator(&mir.ReturnTerm{})
+
+	mod := &mir.Module{
+		Functions: []*mir.Function{makeFn, pxFn, mainFn},
+		Layouts:   mir.NewLayoutTable(),
+	}
+	mod.Layouts.Structs["Point"] = pointLayout
+	return mod
+}
+
+func TestLowerMIRStructParamPassesTwoRegistersIntoSlot(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(pointModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(pointModule) returned error: %v", err)
+	}
+	var pxFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "px" {
+			pxFn = &program.Functions[i]
+			break
+		}
+	}
+	if pxFn == nil {
+		t.Fatalf("expected px function in lowered program, got %+v", program.Functions)
+	}
+	instrs := pxFn.Blocks[0].Instrs
+	if len(instrs) < 2 {
+		t.Fatalf("expected at least 2 prologue stores, got %+v", instrs)
+	}
+	first, ok := instrs[0].(*Store64Stack)
+	if !ok || first.Src != RegX0 {
+		t.Fatalf("expected first instr to be Store64Stack{Src=x0}, got %+v", instrs[0])
+	}
+	second, ok := instrs[1].(*Store64Stack)
+	if !ok || second.Src != RegX1 {
+		t.Fatalf("expected second instr to be Store64Stack{Src=x1}, got %+v", instrs[1])
+	}
+	if second.Offset-first.Offset != 8 {
+		t.Fatalf("expected struct param halves to land 8 bytes apart, got first=%d second=%d", first.Offset, second.Offset)
+	}
+}
+
+func TestLowerMIRStructReturnEpilogueLoadsTwoRegisters(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(pointModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(pointModule) returned error: %v", err)
+	}
+	var makeFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "make" {
+			makeFn = &program.Functions[i]
+			break
+		}
+	}
+	if makeFn == nil {
+		t.Fatalf("expected make function, got %+v", program.Functions)
+	}
+	instrs := makeFn.Blocks[0].Instrs
+	var loadX0, loadX1 *Load64Stack
+	for _, instr := range instrs {
+		ld, ok := instr.(*Load64Stack)
+		if !ok {
+			continue
+		}
+		switch ld.Dst {
+		case RegX0:
+			loadX0 = ld
+		case RegX1:
+			loadX1 = ld
+		}
+	}
+	if loadX0 == nil || loadX1 == nil {
+		t.Fatalf("expected struct return epilogue to load x0/x1; instrs=%+v", instrs)
+	}
+	if loadX1.Offset-loadX0.Offset != 8 {
+		t.Fatalf("expected struct return halves 8 bytes apart, got x0@%d x1@%d", loadX0.Offset, loadX1.Offset)
+	}
+}
+
+func TestLowerMIRCallStructArgLoadsTwoRegisters(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(pointModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(pointModule) returned error: %v", err)
+	}
+	var mainFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "main" {
+			mainFn = &program.Functions[i]
+			break
+		}
+	}
+	if mainFn == nil {
+		t.Fatalf("expected main function, got %+v", program.Functions)
+	}
+	instrs := mainFn.Blocks[0].Instrs
+	// Sequence we care about (in order):
+	//   bl _make
+	//   str x0, [sp, #pSlot+0]
+	//   str x1, [sp, #pSlot+8]
+	//   ldr x0, [sp, #pSlot+0]
+	//   ldr x1, [sp, #pSlot+8]
+	//   bl _px
+	//   str x0, [sp, #nSlot]
+	var sawMake, sawPx bool
+	var capX0, capX1 *Store64Stack
+	var loadArg0, loadArg1 *Load64Stack
+	state := "before-make"
+	for _, instr := range instrs {
+		switch v := instr.(type) {
+		case *BranchLink:
+			if v.Symbol == "make" {
+				sawMake = true
+				state = "after-make"
+			}
+			if v.Symbol == "px" {
+				sawPx = true
+			}
+		case *Store64Stack:
+			if state == "after-make" {
+				if v.Src == RegX0 && capX0 == nil {
+					capX0 = v
+					continue
+				}
+				if v.Src == RegX1 && capX1 == nil {
+					capX1 = v
+					state = "before-px"
+				}
+			}
+		case *Load64Stack:
+			if state == "before-px" {
+				if v.Dst == RegX0 && loadArg0 == nil {
+					loadArg0 = v
+					continue
+				}
+				if v.Dst == RegX1 && loadArg1 == nil {
+					loadArg1 = v
+				}
+			}
+		}
+	}
+	if !sawMake || !sawPx {
+		t.Fatalf("expected bl _make and bl _px in main; instrs=%+v", instrs)
+	}
+	if capX0 == nil || capX1 == nil {
+		t.Fatalf("expected struct return capture to store x0/x1 after bl _make; instrs=%+v", instrs)
+	}
+	if loadArg0 == nil || loadArg1 == nil {
+		t.Fatalf("expected struct argument materialisation to load x0/x1 before bl _px; instrs=%+v", instrs)
+	}
+	if capX1.Offset-capX0.Offset != 8 || loadArg1.Offset-loadArg0.Offset != 8 {
+		t.Fatalf("expected 8-byte stride for struct halves; capture x0@%d x1@%d, load x0@%d x1@%d", capX0.Offset, capX1.Offset, loadArg0.Offset, loadArg1.Offset)
+	}
+	if capX0.Offset != loadArg0.Offset {
+		t.Fatalf("struct slot drift between capture and load: capture@%d load@%d", capX0.Offset, loadArg0.Offset)
+	}
+}
+
+func TestLowerMIRStructLocalEmitsDebugStruct(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(pointModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(pointModule) returned error: %v", err)
+	}
+	var pxFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "px" {
+			pxFn = &program.Functions[i]
+			break
+		}
+	}
+	if pxFn == nil {
+		t.Fatalf("expected px function, got %+v", program.Functions)
+	}
+	var pLocal *DebugLocal
+	for i := range pxFn.DebugLocals {
+		if pxFn.DebugLocals[i].Name == "p" {
+			pLocal = &pxFn.DebugLocals[i]
+			break
+		}
+	}
+	if pLocal == nil {
+		t.Fatalf("expected DebugLocal entry for `p`, got %+v", pxFn.DebugLocals)
+	}
+	if pLocal.TypeKind != DebugTypeStruct {
+		t.Fatalf("p TypeKind = %v, want DebugTypeStruct", pLocal.TypeKind)
+	}
+	if pLocal.StructName != "Point" {
+		t.Fatalf("p StructName = %q, want Point", pLocal.StructName)
+	}
+	if len(pLocal.StructFields) != 2 {
+		t.Fatalf("p StructFields = %+v, want 2 fields", pLocal.StructFields)
+	}
+	if pLocal.StructFields[0].Name != "x" || pLocal.StructFields[1].Name != "y" {
+		t.Fatalf("p StructFields names = %+v, want [x y]", pLocal.StructFields)
+	}
+}
+
+func TestEmitObjectIncludesStructDIEForPointModule(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(pointModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(pointModule) returned error: %v", err)
+	}
+	// Source attribution ensures the DWARF emitter is engaged. Without
+	// a non-zero LineSpan in any block, hasAnySourceLine returns false
+	// and the emitter skips __debug_info entirely.
+	for i := range program.Functions {
+		fn := &program.Functions[i]
+		for j := range fn.Blocks {
+			blk := &fn.Blocks[j]
+			if blk.LineSpans == nil {
+				blk.LineSpans = make([]LineSpan, len(blk.Instrs))
+			}
+			for k := range blk.LineSpans {
+				if blk.LineSpans[k].Line == 0 {
+					blk.LineSpans[k] = LineSpan{Line: 1, Column: 1}
+				}
+			}
+		}
+	}
+	program.SourcePath = "main.osty"
+	obj, err := EmitObject(program)
+	if err != nil {
+		t.Fatalf("EmitObject() returned error: %v", err)
+	}
+	f, err := macho.NewFile(bytes.NewReader(obj))
+	if err != nil {
+		t.Fatalf("macho.NewFile() returned error: %v", err)
+	}
+	infoSec := f.Section("__debug_info")
+	if infoSec == nil {
+		t.Fatal("Mach-O object missing __debug_info section")
+	}
+	infoBytes, err := infoSec.Data()
+	if err != nil {
+		t.Fatalf("infoSec.Data() returned error: %v", err)
+	}
+	strSec := f.Section("__debug_str")
+	if strSec == nil {
+		t.Fatal("Mach-O object missing __debug_str section")
+	}
+	strBytes, err := strSec.Data()
+	if err != nil {
+		t.Fatalf("strSec.Data() returned error: %v", err)
+	}
+	if !bytes.Contains(strBytes, []byte("Point\x00")) {
+		t.Fatalf("expected __debug_str to contain Point\\0; got % x", strBytes)
+	}
+	// dwarfAbbrevStructureType byte appears at the start of a struct
+	// DIE; presence guarantees the encoder reached the struct list path.
+	if !bytes.Contains(infoBytes, []byte{byte(dwarfAbbrevStructureType)}) {
+		t.Fatalf("expected __debug_info to contain DW_TAG_structure_type abbrev marker (% x)", infoBytes)
+	}
+	if !bytes.Contains(infoBytes, []byte{byte(dwarfAbbrevMember)}) {
+		t.Fatalf("expected __debug_info to contain DW_TAG_member abbrev marker (% x)", infoBytes)
 	}
 }


### PR DESCRIPTION
## Summary

- ONB now passes small structs (≤16B, all-scalar fields) through function boundaries via the AAPCS64 small-struct convention: 2-register pairs for both params and returns
- DWARF struct DIE wiring lights up: lldb `frame variable` renders `(Point) p = (x = 7, y = 11)` with field breakdown
- Builds on Week 12 (struct literals + field reads) — first slice where structs cross fn boundaries natively rather than falling back to LLVM

## Mechanics

**Lowering (`internal/onb/lower.go`)**:
- `abiRegSlots(t)` / `isABIPassableType(t)` — ABI slot count helpers (scalar 1, ≤16B all-scalar struct N=ceil(size/8), else 0/false)
- `paramShuffle` walks params with a register cursor; multi-reg structs land at slot+0/+8
- `lowerCall` materialises struct args via `materialiseStructOperand` (slot+0/+8 → 2 arg regs) and captures struct returns into dest+0/+8
- `epilogue` loads `_return` slot into x0/x1 for struct returns
- `assignLocalSlots` keeps `$ret` in the read set when the return type is a struct (scalar/Unit still elide)
- `lowerFunction` ABI guard accepts struct params/returns when `abiRegSlots` accepts them

**DWARF (`internal/onb/lir.go`, `macho.go`)**:
- `DebugTypeStruct` enum value + `DebugLocal.{StructName, StructFields}`
- `macho.go` adds `collectStructTypeInputs` — distinct struct types collected in first-seen order, mapped to the existing `dwarfStructTypeInput` (B.5 infra from Week 11)
- Variable DIE references struct DIE via `StructTypeIndex` (already supported in encoder)

## Out of scope (future slices)

- >16B structs (3+ scalar fields) — indirect/sret passing
- Non-scalar fields inside structs — HFA / composite classification
- Struct field mutation (`p.x = 5`) — projection-as-write still falls back
- Aggregate-as-arg (`px(Point { x: 1, y: 2 })`) — caller passes struct literal directly
- Nested structs

## Test plan

- [x] `internal/onb/onb_test.go` — 5 unit tests:
  - `TestLowerMIRStructParamPassesTwoRegistersIntoSlot`
  - `TestLowerMIRStructReturnEpilogueLoadsTwoRegisters`
  - `TestLowerMIRCallStructArgLoadsTwoRegisters`
  - `TestLowerMIRStructLocalEmitsDebugStruct`
  - `TestEmitObjectIncludesStructDIEForPointModule`
- [x] `internal/backend/onb_test.go` — E2E darwin/arm64 binary smoke:
  - `TestONBBackendBinaryRunsStructParamAndReturnOnDarwinARM64` — `make() -> Point` + `px(p)/py(p)` chain prints `5\n6\n`
- [x] LLDB integration (darwin/arm64):
  - `TestONBBackendLldbFrameVariableShowsStructOnDarwinARM64` — verifies `(Point)`, `x = 7`, `y = 11` appear in `frame variable`
- [x] All pre-existing ONB + backend tests (`-short`) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)