### PR TITLE
feat: lower prelude panic(message) to osty_rt_panic + unreachable

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1782,6 +1782,19 @@ void osty_rt_option_unwrap_none(void) {
     osty_rt_abort("called unwrap on None");
 }
 
+// Public panic helper called from LLVM IR when source code invokes
+// the prelude `panic(message: String) -> Never`. The MIR `IntrinsicAbort`
+// lowerer emits `call void @osty_rt_panic(ptr msg) + unreachable`.
+// `message` arrives as a NUL-terminated UTF-8 String pool entry —
+// see `osty_rt_abort` for the actual stderr + abort() sequence.
+void osty_rt_panic(const char *message) {
+    if (message == NULL) {
+        osty_rt_abort("panic with null message");
+        return;
+    }
+    osty_rt_abort(message);
+}
+
 // Noreturn OOB helper used by the List<scalar> fast-path writer. The
 // fast-path emits `icmp ult idx, snapshot_len` and only hits this on
 // verified out-of-range indices; calling a dedicated noreturn helper

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1371,6 +1371,8 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	switch k {
 	case mir.IntrinsicPrintln, mir.IntrinsicPrint, mir.IntrinsicEprint, mir.IntrinsicEprintln:
 		return true
+	case mir.IntrinsicAbort:
+		return true
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
@@ -5188,6 +5190,8 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStdIoWriteIntrinsic(i, "eprint")
 	case mir.IntrinsicEprintln:
 		return g.emitStdIoWriteIntrinsic(i, "eprintln")
+	case mir.IntrinsicAbort:
+		return g.emitAbortIntrinsic(i)
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
 		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
 		mir.IntrinsicListPop, mir.IntrinsicListFirst, mir.IntrinsicListLast,
@@ -10958,6 +10962,28 @@ func (g *mirGen) emitRuntimeRawNull(i *mir.IntrinsicInstr) error {
 		return unsupported("mir-mvp", "raw.null() takes no arguments")
 	}
 	return g.storeIntrinsicResult(i, &LlvmValue{typ: "ptr", name: "null"})
+}
+
+// emitAbortIntrinsic lowers `panic(message: String)` from the prelude.
+// `IntrinsicAbort` carries a single String operand; we evaluate it,
+// declare `osty_rt_panic` as a noreturn cold helper, then emit
+// `call void @osty_rt_panic(ptr msg)` followed by `unreachable` so
+// LLVM treats everything after the panic as dead code. Mirrors the
+// same call-then-unreachable shape `emitOptionIntrinsic` uses on the
+// None branch of `Option.unwrap()`.
+func (g *mirGen) emitAbortIntrinsic(i *mir.IntrinsicInstr) error {
+	if len(i.Args) != 1 {
+		return unsupported("mir-mvp", "panic intrinsic requires a single message arg")
+	}
+	msg, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	panicSym := mirRtPanicSymbol()
+	g.declareRuntime(panicSym, mirRuntimeDeclareNoReturn("void", panicSym, "ptr", true))
+	g.fnBuf.WriteString(mirCallVoidPanicMessageLine(msg))
+	g.fnBuf.WriteString(mirUnreachableLine())
+	return nil
 }
 
 // ==== helpers ====

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1408,6 +1408,52 @@ func TestGenerateFromMIROptionalNoneConstruction(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRPanicLowers pins the MIR emitter for the prelude
+// `panic(message: String) -> Never` builtin. Source `panic("...")`
+// lowers to `IntrinsicAbort` carrying the message operand, which the
+// generator emits as a `osty_rt_panic` noreturn call followed by
+// `unreachable`. This closes the LLVM000 "unresolved symbol panic"
+// gap that previously rejected any program calling `panic(...)`.
+func TestGenerateFromMIRPanicLowers(t *testing.T) {
+	// fn boom() -> Int {
+	//     panic("nope")
+	// }
+	fn := &ir.FnDecl{
+		Name:   "boom",
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.CallExpr{
+					Callee: &ir.Ident{Name: "panic", Kind: ir.IdentBuiltin, T: &ir.FnType{Params: []ir.Type{ir.TString}, Return: ir.TNever}},
+					Args:   []ir.Arg{{Value: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "nope"}}}}},
+					T:      ir.TNever,
+				}},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/panic_lower.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"@.str.0 = private unnamed_addr constant [5 x i8] c\"nope\\00\"",
+		"declare void @osty_rt_panic(ptr) noreturn cold",
+		"call void @osty_rt_panic(ptr @.str.0)",
+		"unreachable",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Sanity: no unresolved-symbol diagnostic should appear.
+	if strings.Contains(got, "unresolved symbol panic") {
+		t.Fatalf("output still contains unresolved-symbol diagnostic:\n%s", got)
+	}
+}
+
 // TestGenerateFromMIROptionUnwrapLowers pins the MIR emitter for the four
 // Option<T> method intrinsics (isSome, isNone, unwrap, unwrapOr). The
 // underlying lowering keeps Option<T> as `{ i64 disc, i64 payload }`

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4156,6 +4156,19 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 			return
 		}
+		// `panic(message: String) -> Never` — prelude-visible diverging
+		// builtin. Lowers to `IntrinsicAbort` with the message operand;
+		// the MIR generator emits `call void @osty_rt_panic(ptr msg) +
+		// unreachable`.
+		if id.Name == "panic" && len(c.Args) == 1 {
+			args := []Operand{bs.lowerExprAsOperand(c.Args[0].Value)}
+			bs.emit(&IntrinsicInstr{
+				Kind:  IntrinsicAbort,
+				Args:  args,
+				SpanV: c.SpanV,
+			})
+			return
+		}
 		if module, name, ok := loweredStdlibFreeSymbol(id.Name); ok {
 			switch module {
 			case "bytes":


### PR DESCRIPTION
## Summary
Closes a real production gap: any program calling the prelude `panic(message: String) -> Never` was rejected with `LLVM000 unsupported-source: call to unresolved symbol panic`.

The checker already registers the signature, the runtime symbol existed in `mir_generator_snapshot.go` (`osty_rt_panic`), but no path actually emitted the call — bare-Ident `panic(...)` flowed through the regular call dispatcher which can't resolve a non-defined `@panic` symbol.

## What changed

Four pieces wired end-to-end:

1. **`internal/mir/lower.go::lowerCallExprInto`** — bare-Ident `panic` with one arg now emits `IntrinsicInstr{Kind: IntrinsicAbort}` with the message operand. The block's terminator stays as the natural fall-through (UnreachableTerm for Never-returning fns).

2. **`internal/llvmgen/mir_generator.go::isSupportedIntrinsic`** — recognises `mir.IntrinsicAbort` (previously defined but unsupported, which blocked the new lowering).

3. **`internal/llvmgen/mir_generator.go::emitAbortIntrinsic`** — new emit helper. Declares `osty_rt_panic` as a noreturn cold helper, emits `call void @osty_rt_panic(ptr msg) + unreachable`. Mirrors the call+unreachable shape `emitOptionIntrinsic` uses on the None branch of `Option.unwrap`.

4. **`internal/backend/runtime/osty_runtime.c`** — adds public `osty_rt_panic(const char *message)` helper that delegates to the existing static `osty_rt_abort` (`fprintf` + `abort()`). Includes a null-message guard.

## Before / after

```osty
fn boom() -> Int {
    panic("nope")
}
```

**Before** (LLVM000 rejection):
```
; unsupported: LLVM000 unsupported-source: call to unresolved symbol panic
```

**After**:
```llvm
@.str.0 = private unnamed_addr constant [5 x i8] c"nope\00"
declare void @osty_rt_panic(ptr) noreturn cold nounwind
define i64 @boom() {
  ...
entry:
  call void @osty_rt_panic(ptr @.str.0)
  unreachable
}
```

## Test plan
- [x] New `TestGenerateFromMIRPanicLowers` asserts the full string-pool entry, runtime decl, call site, and the absence of the old "unresolved symbol" diagnostic.
- [x] `just front` green
- [x] `go test ./internal/llvmgen ./internal/mir ./internal/check` green (the pre-existing `TestNativeToolchainMergedMIRPipelineIsClean` failure on main is unrelated — it's about `std.strings.fromChar`, not panic)
- [x] `osty gen` end-to-end probe verified
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)