### PR TITLE
feat: ONB Phase A2 Week 14 — enum lowering v1 (Color / Option / Result + ?)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,79 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 14 (Enum lowering v1 — Color / Option / Result + `?`,
+> 2026-05-02)** — ONB가 처음으로 enum을 native lowering. Option/Result가
+> prelude라 거의 모든 의미 있는 Osty 코드가 fallback에서 풀려나옴.
+>
+> 작동 (canonical 예제):
+>
+> ```osty
+> enum Color { Red, Green, Blue }                // no-payload enum
+> fn pick() -> Color { Color.Green }
+>
+> fn first(n: Int) -> Int? {                      // Option<scalar>
+>     if n > 0 { Some(n) } else { None }
+> }
+>
+> enum MyError { Empty, BadInt }
+> fn parseSign(n: Int) -> Result<Int, MyError> {  // Result + ? operator
+>     if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+> }
+> fn parseAndDouble(n: Int) -> Result<Int, MyError> {
+>     let v = parseSign(n)?
+>     Ok(v * 2)
+> }
+> ```
+>
+> 슬롯 레이아웃: `[disc 8B][payload N×8B]`, 16B로 캡 (1 disc reg +
+> 1 payload reg, AAPCS64 small-struct ABI 재사용). no-payload enum은
+> 8바이트, Option<scalar>·Result<scalar, scalar>·Result<scalar, no-payload-enum>
+> 은 16바이트.
+>
+> 추가:
+> - `lookupEnumLayout(t)` — user enum (`mod.Layouts.Enums[name]`) +
+>   합성 레이아웃 (`OptionalType`, `NamedType{Option/Maybe/Result, Builtin}`)
+> - `syntheticOptionLayout` (None=0/Some=1) + `syntheticResultLayout`
+>   (Err=0/Ok=1) — 컨벤션은 `internal/llvmgen` + `mir/lower.go`와 동일
+> - `enumSlotSize(layout)` / `enumPayloadOffset(fieldIdx)` /
+>   `enumDiscriminantValue(layout, idx)` 헬퍼
+> - `payloadAllScalar`이 `isABIWordType`로 일반화 — scalar OR
+>   1-register-slot 타입 (no-payload enum 같은) 허용 → `Result<Int,
+>   MyError>` 가능
+> - `lowerAggregateAssign`이 `AggEnumVariant` 처리 — discriminant를
+>   slot+0에, payload를 slot+8+i*8에 stamp
+> - 새 rvalue lowering: `*mir.NullaryRV` (None tag write),
+>   `*mir.DiscriminantRV` (slot+0 → dest slot)
+> - `placeProjectionOffset`이 `*mir.VariantProj` 처리 — payload는
+>   slot+8 부터 (FieldIdx=-1은 "전체 payload tuple" → slot+8 시작)
+> - `collectRValueLocals`가 `AggregateRV.Fields` + `DiscriminantRV.Place`
+>   를 스캔해 enum scrutinee local이 slot을 받도록 보장
+> - `lowerUseAssignMulti` — multi-slot copy (`_q = use _result`처럼
+>   `?` 연산자가 fallback 분기에서 전체 enum을 복사할 때 필요).
+>   destination type이 2-reg일 때 자동 선택; 1-byte clipping 회피
+> - 새 LIR opcode `Brk{Imm}` + Mach-O 인코딩 (`brk #1`) — match
+>   exhaustiveness가 추가하는 `mir.UnreachableTerm`을 안전하게 trap
+>
+> 검증:
+> - 단위 테스트 3개 (`internal/onb/onb_test.go`) — Color enum 태그
+>   write, UnreachableTerm → Brk lowering, Option<Int> Some 분기의
+>   tag+payload 8B 간격
+> - E2E binary smoke 7개 (`TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64`,
+>   darwin/arm64): no-payload enum, Option Some, Option None, Result
+>   Ok, Result Err, `?` Ok 전파, `?` Err 전파 — 모두 native path 통과
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - struct payload를 가진 enum variant — payload 1-reg 캡 때문에
+>   `Some(Point)` 같은 형태는 fallback (Point가 2-reg)
+> - 2개 이상 payload field를 가진 variant — `Some((a, b))` 같은 튜플 페이로드
+> - `match` arm에서 `_4@Some.0` 같은 nested projection 외 (struct
+>   payload + field projection 조합)
+> - enum DWARF DIE — `frame variable` 출력에는 여전히 안 잡힘
+>   (B.5 abbrev infra는 이미 있음, lower→encoder 와이어링은 별도 슬라이스)
+>
+> 다음 슬라이스 후보: Float64 + IEEE 산술 (Week 15) → List<T>
+> 일반화 → for-in 루프 native lowering.
+>
 > **Slice A2 Week 13 (AAPCS64 small-struct passing + DWARF struct
 > wiring, 2026-05-02)** — ONB가 처음으로 struct를 함수 경계에서 사용 가능.
 > `≤16B` 모든-스칼라 struct가 AAPCS64 small-struct ABI로 2-reg pair에 실려

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -636,6 +636,184 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64 exercises Phase A2
+// Week 14's enum lowering. Three shapes exercise the relevant paths:
+//
+//   - **No-payload enum**: `enum Color { Red, Green, Blue }` plus a
+//     `match` that picks an Int per arm. Drives `AggEnumVariant`
+//     (no payload) + `DiscriminantRV` + `SwitchIntTerm`.
+//   - **Option<Int>**: `Some(n)` / `None` construction + match
+//     destructuring `Some(x)`. Drives `AggEnumVariant` (1 scalar
+//     payload) + `NullaryRV(None)` + `VariantProj` payload read.
+//   - **Result<Int, String>**: `Ok(v)` / `Err(msg)` construction + match
+//     destructuring on both arms. Drives the same machinery with a
+//     real user-defined enum (no Optional shortcut), and verifies
+//     the discriminant convention (Err=0, Ok=1) survives end-to-end.
+//
+// Each case runs the produced binary and checks stdout. Failures point
+// at one of the three lowering paths above without needing dwarfdump.
+func TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB enum executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "no_payload_enum",
+			src: `enum Color { Red, Green, Blue }
+fn pick() -> Color { Color.Green }
+fn main() {
+    let c = pick()
+    let n = match c {
+        Color.Red -> 0,
+        Color.Green -> 1,
+        Color.Blue -> 2,
+    }
+    println(n)
+}`,
+			want: "1\n",
+		},
+		{
+			name: "option_some",
+			src: `fn first(n: Int) -> Int? { if n > 0 { Some(n) } else { None } }
+fn main() {
+    let r = first(5)
+    let v = match r {
+        Some(x) -> x,
+        None -> -1,
+    }
+    println(v)
+}`,
+			want: "5\n",
+		},
+		{
+			name: "option_none",
+			src: `fn first(n: Int) -> Int? { if n > 0 { Some(n) } else { None } }
+fn main() {
+    let r = first(0)
+    let v = match r {
+        Some(x) -> x,
+        None -> -1,
+    }
+    println(v)
+}`,
+			want: "-1\n",
+		},
+		{
+			// Result with a scalar Ok payload and a no-payload enum
+			// Err payload. Exercises the synthetic Result layout
+			// (Err=0/Ok=1) and an enum-typed payload — `MyError` is
+			// itself an enum so the Err slot copies its 8-byte
+			// discriminant into the Result's payload register. The
+			// match destructures Ok(v) and reads v through
+			// VariantProj{FieldIdx:0}.
+			name: "result_ok",
+			src: `enum MyError { Empty, BadInt }
+fn parseSign(n: Int) -> Result<Int, MyError> {
+    if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+}
+fn main() {
+    let r = parseSign(7)
+    let v = match r {
+        Ok(x) -> x,
+        Err(_) -> -1,
+    }
+    println(v)
+}`,
+			want: "7\n",
+		},
+		{
+			name: "result_err",
+			src: `enum MyError { Empty, BadInt }
+fn parseSign(n: Int) -> Result<Int, MyError> {
+    if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+}
+fn main() {
+    let r = parseSign(0)
+    let v = match r {
+        Ok(x) -> x,
+        Err(_) -> -1,
+    }
+    println(v)
+}`,
+			want: "-1\n",
+		},
+		{
+			// `?` propagation. The front end lowers `parseSign(n)?` to
+			// SwitchIntTerm{Ok => take payload; default => return Err
+			// as-is}. The Err arm's `_0 = use _3` is the multi-slot
+			// copy the new lowerUseAssignMulti path handles; without
+			// it, only the discriminant byte would survive and the
+			// caller's match would crash.
+			name: "result_question_op_ok",
+			src: `enum MyError { Empty, BadInt }
+fn parseSign(n: Int) -> Result<Int, MyError> {
+    if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+}
+fn parseAndDouble(n: Int) -> Result<Int, MyError> {
+    let v = parseSign(n)?
+    Ok(v * 2)
+}
+fn main() {
+    let r = parseAndDouble(5)
+    let v = match r {
+        Ok(x) -> x,
+        Err(_) -> -1,
+    }
+    println(v)
+}`,
+			want: "10\n",
+		},
+		{
+			name: "result_question_op_err",
+			src: `enum MyError { Empty, BadInt }
+fn parseSign(n: Int) -> Result<Int, MyError> {
+    if n == 0 { Err(MyError.Empty) } else { Ok(n) }
+}
+fn parseAndDouble(n: Int) -> Result<Int, MyError> {
+    let v = parseSign(n)?
+    Ok(v * 2)
+}
+fn main() {
+    let r = parseAndDouble(0)
+    let v = match r {
+        Ok(x) -> x,
+        Err(_) -> -1,
+    }
+    println(v)
+}`,
+			want: "-1\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			if result == nil || result.Artifacts.Binary == "" {
+				t.Fatalf("missing binary artifact: %+v", result)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -136,6 +136,8 @@ func renderInstrAssembly(b *strings.Builder, target Target, fn Function, instr I
 			}
 		}
 		b.WriteString("\tret\n")
+	case *Brk:
+		fmt.Fprintf(b, "\tbrk #%d\n", i.Imm)
 	default:
 		return fmt.Errorf("onb: assembly renderer does not support %T", instr)
 	}

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -313,6 +313,17 @@ type Ret struct{}
 
 func (*Ret) instrNode() {}
 
+// Brk emits the aarch64 `brk #imm16` software breakpoint. The lowerer
+// uses this for `mir.UnreachableTerm` — match exhaustiveness adds an
+// unreachable default arm whose PC must abort rather than fall through
+// into the next function. `brk #1` is the conventional "trap" value;
+// userspace receives SIGTRAP / SIGILL depending on the platform.
+type Brk struct {
+	Imm int64 // 16-bit unsigned immediate (0..65535)
+}
+
+func (*Brk) instrNode() {}
+
 func functionNeedsFrame(fn Function) bool {
 	if fn.FrameSize > 0 {
 		return true

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -298,6 +298,13 @@ func (s *lowerState) lowerBlock(fn *mir.Function, block *mir.BasicBlock, isEntry
 			return Block{}, err
 		}
 		emit(switchInstrs, termSpan)
+	case *mir.UnreachableTerm:
+		// `match` exhaustiveness adds an unreachable trap as the
+		// switch default. Reaching this PC is a compiler bug or UB,
+		// so the safest lowering is `brk #1` (aarch64 software
+		// breakpoint) — the process aborts immediately rather than
+		// fall through into the next function.
+		emit([]Instr{&Brk{Imm: 1}}, termSpan)
 	default:
 		return Block{}, fmt.Errorf("%w: terminator %T is outside phase 1", ErrUnsupportedShape, block.Term)
 	}
@@ -466,24 +473,84 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 	}
 	switch rv := instr.Src.(type) {
 	case *mir.UseRV:
-		mat, err := s.materialiseOperand(rv.Op, RegX9)
-		if err != nil {
-			return nil, err
-		}
-		return append(mat, &Store64Stack{Src: RegX9, Offset: slot}), nil
+		// Whole-enum / whole-struct copy through `use _local`: the
+		// scrutinee in `match m { … }` lowers to `_scrut = use m`,
+		// and that local is later read by `discriminant _scrut` and
+		// `_scrut@Some` projections. A 1-register copy would clip
+		// the payload byte for an Option<scalar>; route multi-slot
+		// reads through a per-half copy so every byte ends up in
+		// the destination slot.
+		return s.lowerUseAssign(fn, rv, instr.Dest.Local, slot)
 	case *mir.BinaryRV:
 		return s.lowerBinaryAssign(rv, slot)
 	case *mir.AggregateRV:
 		return s.lowerAggregateAssign(rv, slot)
+	case *mir.NullaryRV:
+		return s.lowerNullaryAssign(rv, slot)
+	case *mir.DiscriminantRV:
+		return s.lowerDiscriminantAssign(rv, slot)
 	default:
 		return nil, fmt.Errorf("%w: rvalue %T is outside phase 1", ErrUnsupportedShape, instr.Src)
 	}
 }
 
-// lowerAggregateAssign currently covers only the empty-list literal
-// (`let v: List<Int> = []`). The runtime allocates the list eagerly via
-// `osty_rt_list_new`; future slices will extend this to non-empty lists,
-// tuples, structs, and enum variants.
+// lowerUseAssign handles `Assign dest := Use(operand)`. The common case
+// is a single 8-byte slot copy through x9, but assignments where the
+// destination local takes more than one ABI register (struct / enum
+// passed via the AAPCS64 small-struct rule) need a per-slot copy so
+// the payload byte isn't clipped. The destination's local type drives
+// the slot count; the operand's type matches by construction (the
+// front end never emits cross-shape Use rvalues).
+func (s *lowerState) lowerUseAssign(fn *mir.Function, rv *mir.UseRV, destID mir.LocalID, destSlot int64) ([]Instr, error) {
+	destLoc := lookupLocal(fn, destID)
+	if destLoc != nil {
+		if slots, ok := s.abiRegSlots(destLoc.Type); ok && slots > 1 {
+			return s.lowerUseAssignMulti(rv, slots, destSlot)
+		}
+	}
+	mat, err := s.materialiseOperand(rv.Op, RegX9)
+	if err != nil {
+		return nil, err
+	}
+	return append(mat, &Store64Stack{Src: RegX9, Offset: destSlot}), nil
+}
+
+// lowerUseAssignMulti copies an N-slot value (struct / small enum)
+// from a Copy/Move source slot to the destination slot a half at a
+// time. Const operands aren't valid for multi-slot copies — the front
+// end constructs them via AggregateRV instead — so we reject them
+// with the unsupported sentinel.
+func (s *lowerState) lowerUseAssignMulti(rv *mir.UseRV, slots int, destSlot int64) ([]Instr, error) {
+	var place mir.Place
+	switch o := rv.Op.(type) {
+	case *mir.CopyOp:
+		place = o.Place
+	case *mir.MoveOp:
+		place = o.Place
+	default:
+		return nil, fmt.Errorf("%w: multi-slot use operand %T", ErrUnsupportedShape, rv.Op)
+	}
+	if place.HasProjections() {
+		return nil, fmt.Errorf("%w: multi-slot use with projection", ErrUnsupportedShape)
+	}
+	srcSlot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: multi-slot use of local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	out := make([]Instr, 0, slots*2)
+	for i := 0; i < slots; i++ {
+		out = append(out,
+			&Load64Stack{Dst: RegX9, Offset: srcSlot + int64(i)*8},
+			&Store64Stack{Src: RegX9, Offset: destSlot + int64(i)*8},
+		)
+	}
+	return out, nil
+}
+
+// lowerAggregateAssign currently covers the empty-list literal,
+// all-scalar struct literals, and small enum variants. The runtime
+// allocates the list eagerly via `osty_rt_list_new`; struct + enum
+// literals are stamped directly into the destination slot.
 func (s *lowerState) lowerAggregateAssign(rv *mir.AggregateRV, destSlot int64) ([]Instr, error) {
 	switch rv.Kind {
 	case mir.AggList:
@@ -496,9 +563,95 @@ func (s *lowerState) lowerAggregateAssign(rv *mir.AggregateRV, destSlot int64) (
 		}, nil
 	case mir.AggStruct:
 		return s.lowerStructLiteralAssign(rv, destSlot)
+	case mir.AggEnumVariant:
+		return s.lowerEnumVariantAssign(rv, destSlot)
 	default:
 		return nil, fmt.Errorf("%w: aggregate kind %v", ErrUnsupportedShape, rv.Kind)
 	}
+}
+
+// lowerEnumVariantAssign writes an enum literal: discriminant value
+// to slot+0, then each payload field to slot+8 + i*8. Backends with
+// a niche optimisation could fold the discriminant into the payload
+// for some shapes, but the dev backend always uses the same layout
+// to keep `frame variable` predictable.
+func (s *lowerState) lowerEnumVariantAssign(rv *mir.AggregateRV, destSlot int64) ([]Instr, error) {
+	layout := s.lookupEnumLayout(rv.T)
+	if layout == nil {
+		return nil, fmt.Errorf("%w: unknown enum layout for %s", ErrUnsupportedShape, rv.T)
+	}
+	if rv.VariantIdx < 0 || rv.VariantIdx >= len(layout.Variants) {
+		return nil, fmt.Errorf("%w: variant index %d out of range for %s", ErrUnsupportedShape, rv.VariantIdx, rv.T)
+	}
+	variant := layout.Variants[rv.VariantIdx]
+	if !s.payloadAllScalar(variant.Payload) {
+		return nil, fmt.Errorf("%w: variant %s.%s has non-scalar payload", ErrUnsupportedShape, rv.T, variant.Name)
+	}
+	if len(rv.Fields) != len(variant.Payload) {
+		return nil, fmt.Errorf("%w: variant %s.%s field count mismatch (%d vs %d)", ErrUnsupportedShape, rv.T, variant.Name, len(rv.Fields), len(variant.Payload))
+	}
+	tag := s.enumDiscriminantValue(layout, rv.VariantIdx)
+	out := []Instr{
+		&MovImm64{Dst: RegX9, Imm: tag},
+		&Store64Stack{Src: RegX9, Offset: destSlot},
+	}
+	for i, field := range rv.Fields {
+		mat, err := s.materialiseOperand(field, RegX9)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &Store64Stack{Src: RegX9, Offset: destSlot + s.enumPayloadOffset(i)})
+	}
+	return out, nil
+}
+
+// lowerNullaryAssign covers `dest = none T?` — write the None tag (0)
+// to slot+0 and leave the payload undefined. Other nullary rvalues
+// don't exist in MIR today; new entries land here as the enum extends.
+func (s *lowerState) lowerNullaryAssign(rv *mir.NullaryRV, destSlot int64) ([]Instr, error) {
+	if rv.Kind != mir.NullaryNone {
+		return nil, fmt.Errorf("%w: nullary kind %v", ErrUnsupportedShape, rv.Kind)
+	}
+	layout := s.lookupEnumLayout(rv.T)
+	if layout == nil {
+		return nil, fmt.Errorf("%w: nullary none on non-enum type %s", ErrUnsupportedShape, rv.T)
+	}
+	// Find the None variant; for synthetic Option layouts it's at
+	// index 0 by construction. For user enums that re-use `none`
+	// (none today) this would walk Variants for Name == "None".
+	noneIdx := 0
+	for i, v := range layout.Variants {
+		if v.Name == "None" {
+			noneIdx = i
+			break
+		}
+	}
+	tag := s.enumDiscriminantValue(layout, noneIdx)
+	return []Instr{
+		&MovImm64{Dst: RegX9, Imm: tag},
+		&Store64Stack{Src: RegX9, Offset: destSlot},
+	}, nil
+}
+
+// lowerDiscriminantAssign reads the discriminant tag of an enum local
+// into the destination slot. The discriminant always sits at offset 0
+// of the source slot, so this is just `ldr x9, [sp+src]; str x9,
+// [sp+dest]`. Place projections on the source aren't supported — the
+// front end always emits `discriminant <local>` rather than
+// `discriminant <local>.field`.
+func (s *lowerState) lowerDiscriminantAssign(rv *mir.DiscriminantRV, destSlot int64) ([]Instr, error) {
+	if rv.Place.HasProjections() {
+		return nil, fmt.Errorf("%w: discriminant of projected place", ErrUnsupportedShape)
+	}
+	srcSlot, ok := s.localSlots[rv.Place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: discriminant of local%d without slot", ErrUnsupportedShape, rv.Place.Local)
+	}
+	return []Instr{
+		&Load64Stack{Dst: RegX9, Offset: srcSlot},
+		&Store64Stack{Src: RegX9, Offset: destSlot},
+	}, nil
 }
 
 // lowerStructLiteralAssign writes each scalar field of a struct literal
@@ -563,6 +716,17 @@ func (s *lowerState) abiRegSlots(t mir.Type) (int, bool) {
 		}
 		return n, true
 	}
+	if layout := s.lookupEnumLayout(t); layout != nil {
+		size := s.enumSlotSize(layout)
+		if size == 0 {
+			return 0, false
+		}
+		// Discriminant (1 reg) + at most one payload reg fits the
+		// AAPCS64 small-struct convention. enumSlotSize already
+		// caps at 16B so the divide here can't exceed
+		// abiSmallStructRegLimit.
+		return int(size / 8), true
+	}
 	return 0, false
 }
 
@@ -611,11 +775,175 @@ func structLayoutSupported(nt *ir.NamedType) bool {
 	return true
 }
 
+// lookupEnumLayout resolves a MIR type to the enum layout the front end
+// registered. User-defined enums (`enum Color { Red, Green, Blue }`)
+// live in `mod.Layouts.Enums` keyed by the enum's name. Optional types
+// (`T?`) use a synthetic layout the lowerer fabricates on the fly so
+// the rest of the enum codegen path can speak in the same vocabulary
+// — there's no separate Option entry in the layout table because the
+// surface form is `OptionalType` rather than a NamedType.
+//
+// The synthetic Option layout uses the canonical convention from
+// `internal/llvmgen` and `internal/mir/lower.go`: discriminant 0 ==
+// None, 1 == Some, with the inner type as the Some payload. Result
+// types are surfaced as `NamedType{Name: "Result"}` and do live in
+// `mod.Layouts.Enums` after the front end's `buildLayouts` pass, so
+// they take the user-defined branch.
+func (s *lowerState) lookupEnumLayout(t mir.Type) *mir.EnumLayout {
+	if s.mod == nil {
+		return nil
+	}
+	if opt, ok := t.(*ir.OptionalType); ok && opt != nil {
+		return s.syntheticOptionLayout(opt.Inner)
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt == nil {
+		return nil
+	}
+	// Builtin Option / Maybe / Result types use synthetic layouts
+	// (None=0/Some=1, Err=0/Ok=1) the front end doesn't bother
+	// registering into `mod.Layouts.Enums`. The MIR layer canonicalises
+	// `T?` references to `NamedType{Name: "Option", Args: [T],
+	// Builtin: true}` (notably AggregateRV.T for `Some(...)` calls)
+	// so the lowerer must recognise both shapes.
+	if nt.Builtin {
+		switch nt.Name {
+		case "Option", "Maybe":
+			if len(nt.Args) >= 1 {
+				return s.syntheticOptionLayout(nt.Args[0])
+			}
+		case "Result":
+			if len(nt.Args) >= 2 {
+				return s.syntheticResultLayout(nt.Args[0], nt.Args[1])
+			}
+		}
+	}
+	if s.mod.Layouts == nil {
+		return nil
+	}
+	return s.mod.Layouts.Enums[nt.Name]
+}
+
+// syntheticOptionLayout builds the canonical 2-variant enum layout
+// (None=0 / Some(inner)=1) used wherever the front end emits an
+// optional type without registering it into `mod.Layouts.Enums`. Kept
+// out of `lookupEnumLayout` so the OptionalType and NamedType paths
+// share the same shape.
+func (s *lowerState) syntheticOptionLayout(inner mir.Type) *mir.EnumLayout {
+	return &mir.EnumLayout{
+		Name:         "Option",
+		Discriminant: mir.TInt,
+		Variants: []mir.VariantLayout{
+			{Index: 0, Name: "None"},
+			{Index: 1, Name: "Some", Payload: []mir.FieldLayout{{Index: 0, Name: "value", Type: inner}}},
+		},
+	}
+}
+
+// syntheticResultLayout builds the 2-variant enum layout (Err=0 /
+// Ok=1) for `Result<T, E>`. The Err arm carries one E-typed payload
+// field; the Ok arm carries one T-typed field. Each variant has a
+// single payload register so the whole Result fits in 16 bytes (1
+// disc + 1 payload), which keeps it eligible for AAPCS64
+// small-struct passing. The Err and Ok payload types live in
+// different variants — `enumSlotSize` reports the maximum payload
+// reg count across all variants, so a Result whose Err half needs
+// 2 regs would stop being eligible.
+func (s *lowerState) syntheticResultLayout(okT, errT mir.Type) *mir.EnumLayout {
+	return &mir.EnumLayout{
+		Name:         "Result",
+		Discriminant: mir.TInt,
+		Variants: []mir.VariantLayout{
+			{Index: 0, Name: "Err", Payload: []mir.FieldLayout{{Index: 0, Name: "error", Type: errT}}},
+			{Index: 1, Name: "Ok", Payload: []mir.FieldLayout{{Index: 0, Name: "value", Type: okT}}},
+		},
+	}
+}
+
+// enumSlotSize returns the on-stack byte size for an enum-typed local.
+// The layout is `[disc 8B][payload N×8B]` where N is the maximum
+// payload field count across all variants. Discriminant lives at slot
+// offset 0, payload starts at slot offset 8. Phase A2 caps total size
+// at 16B (1 disc reg + 1 payload reg) so the value fits the AAPCS64
+// small-struct ABI; larger payloads return 0 to signal "fall back".
+func (s *lowerState) enumSlotSize(layout *mir.EnumLayout) int64 {
+	if layout == nil {
+		return 0
+	}
+	maxPayload := 0
+	for _, v := range layout.Variants {
+		if !s.payloadAllScalar(v.Payload) {
+			return 0
+		}
+		if len(v.Payload) > maxPayload {
+			maxPayload = len(v.Payload)
+		}
+	}
+	// Discriminant + payload, capped at 2 registers total.
+	total := int64(8 + maxPayload*8)
+	if total > 16 {
+		return 0
+	}
+	return total
+}
+
+// payloadAllScalar reports whether every payload field fits in one
+// 8-byte ABI register. Scalars (Int / Bool / String) qualify
+// directly; no-payload enums (`MyError` etc.) also pass because their
+// slot is just the discriminant. Multi-register payloads (large
+// struct, deep enum) bail out so the lowerer keeps the whole enum
+// inside a 16-byte 2-register window.
+//
+// Naming kept for git-blame continuity — the predicate now accepts
+// any 1-register type, not strictly scalars.
+func (s *lowerState) payloadAllScalar(fields []mir.FieldLayout) bool {
+	for _, f := range fields {
+		if !s.isABIWordType(f.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+// isABIWordType reports whether t consumes exactly one 8-byte ABI
+// register (and therefore can sit in an enum payload slot). Scalars
+// and no-payload enums qualify; structs always need ≥1 register
+// per field so a struct with 1 scalar field also passes.
+func (s *lowerState) isABIWordType(t mir.Type) bool {
+	if isABIScalarType(t) {
+		return true
+	}
+	slots, ok := s.abiRegSlots(t)
+	return ok && slots == 1
+}
+
+// enumPayloadOffset returns the byte offset of the FieldIdx-th payload
+// element relative to the enum's slot. Discriminant lives at offset 0,
+// payload starts at offset 8.
+func (s *lowerState) enumPayloadOffset(fieldIdx int) int64 {
+	if fieldIdx < 0 {
+		return 8 // "whole payload tuple" — start of payload region
+	}
+	return int64(8 + fieldIdx*8)
+}
+
+// enumDiscriminantValue returns the integer tag for a variant. Most
+// enums simply use the variant index, but the synthetic Option layout
+// keeps None=0 / Some=1 explicit so the sequence matches the rest of
+// the toolchain's convention.
+func (s *lowerState) enumDiscriminantValue(layout *mir.EnumLayout, variantIdx int) int64 {
+	if layout == nil || variantIdx < 0 || variantIdx >= len(layout.Variants) {
+		return int64(variantIdx)
+	}
+	return int64(layout.Variants[variantIdx].Index)
+}
+
 // localTypeSize returns the on-stack byte size for a local. Scalars and
-// builtin pointer-shaped types (List<T>, Map<K,V>, Option<T>, Result<T,E>)
-// share one 8-byte slot. User-defined structs with all-scalar fields get
-// one slot per field. Unit-typed locals report 0 — the slot allocator
-// skips them entirely.
+// builtin pointer-shaped types (List<T>, Map<K,V>) share one 8-byte
+// slot. User-defined structs with all-scalar fields get one slot per
+// field. Enum-typed locals (user enums + Option<scalar> + Result with
+// scalar arms) get `[disc 8B][payload N×8B]` layout up to 16B total.
+// Unit-typed locals report 0 — the slot allocator skips them entirely.
 func (s *lowerState) localTypeSize(t mir.Type) int64 {
 	if t == mir.TUnit {
 		return 0
@@ -635,6 +963,11 @@ func (s *lowerState) localTypeSize(t mir.Type) int64 {
 			}
 		}
 		return int64(len(sl.Fields)) * 8
+	}
+	if el := s.lookupEnumLayout(t); el != nil {
+		if size := s.enumSlotSize(el); size > 0 {
+			return size
+		}
 	}
 	// Anything else (builtin generics, raw pointer wrappers, opaque
 	// runtime handles) lives at the ABI as a single 8-byte pointer.
@@ -997,11 +1330,12 @@ func (s *lowerState) loadPlaceIntoReg(place mir.Place, dst Reg) ([]Instr, error)
 }
 
 // placeProjectionOffset reduces a Place's projection chain to a single
-// byte offset relative to the local's slot. Phase B.5 v1 only handles
-// FieldProj over scalar-typed fields — index/deref projections still
-// fall through to the unsupported-shape sentinel so the LLVM fallback
-// picks them up. The offset is independent of which field type lives
-// at that position because every scalar field consumes 8 bytes.
+// byte offset relative to the local's slot. Handles FieldProj
+// (struct-shaped) and VariantProj (enum payload) over scalar-typed
+// fields. Index/deref projections still fall through to the
+// unsupported-shape sentinel so the LLVM fallback picks them up. The
+// offset is independent of which scalar type lives at that position
+// because every scalar field consumes 8 bytes.
 func (s *lowerState) placeProjectionOffset(place mir.Place) (int64, error) {
 	if !place.HasProjections() {
 		return 0, nil
@@ -1013,16 +1347,20 @@ func (s *lowerState) placeProjectionOffset(place mir.Place) (int64, error) {
 	currentType := loc.Type
 	off := int64(0)
 	for _, p := range place.Projections {
-		fp, ok := p.(*mir.FieldProj)
-		if !ok {
+		switch proj := p.(type) {
+		case *mir.FieldProj:
+			fieldOff := s.fieldByteOffset(currentType, proj.Index)
+			if fieldOff < 0 {
+				return 0, fmt.Errorf("%w: field projection on non-struct %s", ErrUnsupportedShape, currentType)
+			}
+			off += fieldOff
+			currentType = proj.Type
+		case *mir.VariantProj:
+			off += s.enumPayloadOffset(proj.FieldIdx)
+			currentType = proj.Type
+		default:
 			return 0, fmt.Errorf("%w: projection %T", ErrUnsupportedShape, p)
 		}
-		fieldOff := s.fieldByteOffset(currentType, fp.Index)
-		if fieldOff < 0 {
-			return 0, fmt.Errorf("%w: field projection on non-struct %s", ErrUnsupportedShape, currentType)
-		}
-		off += fieldOff
-		currentType = fp.Type
 	}
 	return off, nil
 }
@@ -1302,6 +1640,19 @@ func collectRValueLocals(rv mir.RValue, out map[mir.LocalID]bool) {
 	case *mir.BinaryRV:
 		collectOperandLocals(r.Left, out)
 		collectOperandLocals(r.Right, out)
+	case *mir.AggregateRV:
+		// Each payload field is an operand; struct / enum / list /
+		// tuple literals all flow through here. Without this, locals
+		// captured into struct/enum literals would lose their slot
+		// when no other instruction also reads them.
+		for _, f := range r.Fields {
+			collectOperandLocals(f, out)
+		}
+	case *mir.DiscriminantRV:
+		// The scrutinee local is read by `discriminant _scrut` even
+		// though the place itself isn't an Operand. Force it in so
+		// the slot allocator reserves a slot for the enum value.
+		out[r.Place.Local] = true
 	}
 }
 

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -978,6 +978,12 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 					}
 				}
 				enc.code = append(enc.code, 0xc0, 0x03, 0x5f, 0xd6)
+			case *Brk:
+				word, err := encodeBrk(i.Imm)
+				if err != nil {
+					return fmt.Errorf("onb: brk encoding: %w", err)
+				}
+				enc.code = appendU32LE(enc.code, word)
 			default:
 				return fmt.Errorf("%w: Mach-O encoder does not support %T", ErrNotImplemented, instr)
 			}
@@ -1240,6 +1246,18 @@ func encodeLdpFPLR(fpOffset uint32) (uint32, error) {
 		return 0, fmt.Errorf("%w: ldp offset %d exceeds signed-7-bit range", ErrNotImplemented, fpOffset)
 	}
 	return 0xa9407bfd | (imm << 15), nil
+}
+
+// encodeBrk produces the 32-bit aarch64 word for `brk #imm16`. The
+// instruction encoding is `1101 0100 001<imm16> 000 00`. The dev
+// backend uses this for `mir.UnreachableTerm` lowering — match
+// exhaustiveness inserts an unreachable default arm whose PC must
+// trap rather than fall through.
+func encodeBrk(imm int64) (uint32, error) {
+	if imm < 0 || imm > 0xffff {
+		return 0, fmt.Errorf("%w: brk imm %d out of 16-bit range", ErrNotImplemented, imm)
+	}
+	return 0xd4200000 | (uint32(imm) << 5), nil
 }
 
 func encodeMachOMovImm64(dst Reg, imm uint64) ([]uint32, error) {

--- a/internal/onb/onb_test.go
+++ b/internal/onb/onb_test.go
@@ -1292,6 +1292,303 @@ func TestLowerMIRStructLocalEmitsDebugStruct(t *testing.T) {
 	}
 }
 
+// colorEnumModule builds a MIR module mirroring:
+//
+//	enum Color { Red, Green, Blue }
+//	fn pick() -> Color { Color.Green }
+//	fn main() {
+//	    let c = pick()
+//	    let n = match c {
+//	        Color.Red -> 0,
+//	        Color.Green -> 1,
+//	        Color.Blue -> 2,
+//	    }
+//	    println(n)
+//	}
+//
+// The fixture pins the MIR shape the front end emits so unit tests
+// can assert specific lowering decisions (no-payload variant write,
+// discriminant read, switchInt dispatch) without round-tripping
+// through the full pipeline.
+func colorEnumModule() *mir.Module {
+	colorT := &ir.NamedType{Name: "Color"}
+	colorLayout := &mir.EnumLayout{
+		Name:         "Color",
+		Discriminant: mir.TInt,
+		Variants: []mir.VariantLayout{
+			{Index: 0, Name: "Red"},
+			{Index: 1, Name: "Green"},
+			{Index: 2, Name: "Blue"},
+		},
+	}
+
+	pickFn := &mir.Function{
+		Name:        "pick",
+		ReturnType:  colorT,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: colorT, IsReturn: true},
+		},
+	}
+	pickBlock := pickFn.NewBlock(mir.Span{})
+	pickFn.Block(pickBlock).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 0},
+			Src: &mir.AggregateRV{
+				Kind:       mir.AggEnumVariant,
+				T:          colorT,
+				VariantIdx: 1,
+				VariantTag: "Green",
+			},
+		},
+	}
+	pickFn.Block(pickBlock).SetTerminator(&mir.ReturnTerm{})
+
+	mainFn := &mir.Function{
+		Name:        "main",
+		ReturnType:  mir.TUnit,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TUnit, IsReturn: true},
+			{ID: 1, Name: "c", Type: colorT},
+			{ID: 2, Name: "n", Type: mir.TInt},
+			{ID: 3, Name: "_scrut", Type: colorT},
+			{ID: 4, Name: "_disc", Type: mir.TInt},
+		},
+	}
+	bb0 := mainFn.NewBlock(mir.Span{})
+	bbRed := mainFn.NewBlock(mir.Span{})
+	bbGreen := mainFn.NewBlock(mir.Span{})
+	bbBlue := mainFn.NewBlock(mir.Span{})
+	bbDefault := mainFn.NewBlock(mir.Span{})
+	bbPrint := mainFn.NewBlock(mir.Span{})
+
+	mainFn.Block(bb0).Instrs = []mir.Instr{
+		&mir.CallInstr{Dest: &mir.Place{Local: 1}, Callee: &mir.FnRef{Symbol: "pick", Type: colorT}},
+		&mir.AssignInstr{Dest: mir.Place{Local: 3}, Src: &mir.UseRV{Op: &mir.CopyOp{Place: mir.Place{Local: 1}, T: colorT}}},
+		&mir.AssignInstr{Dest: mir.Place{Local: 4}, Src: &mir.DiscriminantRV{Place: mir.Place{Local: 3}, T: mir.TInt}},
+	}
+	mainFn.Block(bb0).SetTerminator(&mir.SwitchIntTerm{
+		Scrutinee: &mir.CopyOp{Place: mir.Place{Local: 4}, T: mir.TInt},
+		Cases: []mir.SwitchCase{
+			{Value: 0, Target: bbRed, Label: "Red"},
+			{Value: 1, Target: bbGreen, Label: "Green"},
+			{Value: 2, Target: bbBlue, Label: "Blue"},
+		},
+		Default: bbDefault,
+	})
+	mainFn.Block(bbRed).Instrs = []mir.Instr{
+		&mir.AssignInstr{Dest: mir.Place{Local: 2}, Src: &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: 0, T: mir.TInt}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbRed).SetTerminator(&mir.GotoTerm{Target: bbPrint})
+	mainFn.Block(bbGreen).Instrs = []mir.Instr{
+		&mir.AssignInstr{Dest: mir.Place{Local: 2}, Src: &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: 1, T: mir.TInt}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbGreen).SetTerminator(&mir.GotoTerm{Target: bbPrint})
+	mainFn.Block(bbBlue).Instrs = []mir.Instr{
+		&mir.AssignInstr{Dest: mir.Place{Local: 2}, Src: &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: 2, T: mir.TInt}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbBlue).SetTerminator(&mir.GotoTerm{Target: bbPrint})
+	mainFn.Block(bbDefault).SetTerminator(&mir.UnreachableTerm{})
+	mainFn.Block(bbPrint).Instrs = []mir.Instr{
+		&mir.IntrinsicInstr{Kind: mir.IntrinsicPrintln, Args: []mir.Operand{&mir.CopyOp{Place: mir.Place{Local: 2}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbPrint).SetTerminator(&mir.ReturnTerm{})
+
+	mod := &mir.Module{
+		Functions: []*mir.Function{pickFn, mainFn},
+		Layouts:   mir.NewLayoutTable(),
+	}
+	mod.Layouts.Enums["Color"] = colorLayout
+	return mod
+}
+
+func TestLowerMIRColorEnumStoresDiscriminantTag(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(colorEnumModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(colorEnumModule) returned error: %v", err)
+	}
+	var pickFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "pick" {
+			pickFn = &program.Functions[i]
+			break
+		}
+	}
+	if pickFn == nil {
+		t.Fatalf("expected pick function, got %+v", program.Functions)
+	}
+	// Look for `MovImm64{Imm: 1}` (Green tag) followed by Store64Stack
+	// — the literal write of the discriminant value to slot+0.
+	var sawTag bool
+	instrs := pickFn.Blocks[0].Instrs
+	for i := 0; i+1 < len(instrs); i++ {
+		mov, isMov := instrs[i].(*MovImm64)
+		if !isMov || mov.Imm != 1 {
+			continue
+		}
+		_, isStore := instrs[i+1].(*Store64Stack)
+		if isStore {
+			sawTag = true
+			break
+		}
+	}
+	if !sawTag {
+		t.Fatalf("expected MovImm64{Imm:1} + Store64Stack pair (Green tag write); instrs=%+v", instrs)
+	}
+}
+
+func TestLowerMIREnumSwitchEmitsBrkForUnreachableDefault(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(colorEnumModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(colorEnumModule) returned error: %v", err)
+	}
+	var mainFn *Function
+	for i := range program.Functions {
+		if program.Functions[i].Name == "main" {
+			mainFn = &program.Functions[i]
+			break
+		}
+	}
+	if mainFn == nil {
+		t.Fatalf("expected main function, got %+v", program.Functions)
+	}
+	var sawBrk bool
+	for _, blk := range mainFn.Blocks {
+		for _, instr := range blk.Instrs {
+			if _, ok := instr.(*Brk); ok {
+				sawBrk = true
+				break
+			}
+		}
+	}
+	if !sawBrk {
+		t.Fatalf("expected Brk in main blocks (UnreachableTerm lowering); got %+v", mainFn.Blocks)
+	}
+}
+
+// optionIntModule mirrors `Some(5)` / `None` construction + match.
+// The fixture covers the Option synthetic layout (None=0, Some=1)
+// and the VariantProj{FieldIdx:0} payload read.
+func optionIntModule() *mir.Module {
+	optT := &ir.OptionalType{Inner: mir.TInt}
+
+	mainFn := &mir.Function{
+		Name:        "main",
+		ReturnType:  mir.TUnit,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TUnit, IsReturn: true},
+			{ID: 1, Name: "r", Type: optT},
+			{ID: 2, Name: "v", Type: mir.TInt},
+			{ID: 3, Name: "_disc", Type: mir.TInt},
+		},
+	}
+	bb0 := mainFn.NewBlock(mir.Span{})
+	bbSome := mainFn.NewBlock(mir.Span{})
+	bbNone := mainFn.NewBlock(mir.Span{})
+	bbDefault := mainFn.NewBlock(mir.Span{})
+	bbPrint := mainFn.NewBlock(mir.Span{})
+
+	mainFn.Block(bb0).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 1},
+			Src: &mir.AggregateRV{
+				Kind:       mir.AggEnumVariant,
+				T:          optT,
+				VariantIdx: 1,
+				VariantTag: "Some",
+				Fields:     []mir.Operand{&mir.ConstOp{Const: &mir.IntConst{Value: 5, T: mir.TInt}, T: mir.TInt}},
+			},
+		},
+		&mir.AssignInstr{Dest: mir.Place{Local: 3}, Src: &mir.DiscriminantRV{Place: mir.Place{Local: 1}, T: mir.TInt}},
+	}
+	mainFn.Block(bb0).SetTerminator(&mir.SwitchIntTerm{
+		Scrutinee: &mir.CopyOp{Place: mir.Place{Local: 3}, T: mir.TInt},
+		Cases: []mir.SwitchCase{
+			{Value: 1, Target: bbSome, Label: "Some"},
+		},
+		Default: bbNone,
+	})
+	mainFn.Block(bbSome).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 2},
+			Src: &mir.UseRV{
+				Op: &mir.CopyOp{
+					Place: mir.Place{
+						Local:       1,
+						Projections: []mir.Projection{&mir.VariantProj{Variant: 1, Name: "Some", FieldIdx: 0, Type: mir.TInt}},
+					},
+					T: mir.TInt,
+				},
+			},
+		},
+	}
+	mainFn.Block(bbSome).SetTerminator(&mir.GotoTerm{Target: bbPrint})
+	mainFn.Block(bbNone).Instrs = []mir.Instr{
+		&mir.AssignInstr{Dest: mir.Place{Local: 2}, Src: &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: -1, T: mir.TInt}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbNone).SetTerminator(&mir.GotoTerm{Target: bbPrint})
+	mainFn.Block(bbDefault).SetTerminator(&mir.UnreachableTerm{})
+	mainFn.Block(bbPrint).Instrs = []mir.Instr{
+		&mir.IntrinsicInstr{Kind: mir.IntrinsicPrintln, Args: []mir.Operand{&mir.CopyOp{Place: mir.Place{Local: 2}, T: mir.TInt}}},
+	}
+	mainFn.Block(bbPrint).SetTerminator(&mir.ReturnTerm{})
+
+	return &mir.Module{
+		Functions: []*mir.Function{mainFn},
+		Layouts:   mir.NewLayoutTable(),
+	}
+}
+
+func TestLowerMIROptionVariantStoresTagAndPayload(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(optionIntModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(optionIntModule) returned error: %v", err)
+	}
+	mainFn := &program.Functions[0]
+	instrs := mainFn.Blocks[0].Instrs
+	// Look for two stores 8 bytes apart originating from MovImm64 with
+	// Imm=1 (Some tag) and Imm=5 (payload).
+	var tagSlot int64 = -1
+	var payloadSlot int64 = -1
+	for i := 0; i+1 < len(instrs); i++ {
+		mov, isMov := instrs[i].(*MovImm64)
+		if !isMov {
+			continue
+		}
+		store, isStore := instrs[i+1].(*Store64Stack)
+		if !isStore {
+			continue
+		}
+		switch mov.Imm {
+		case 1:
+			if tagSlot < 0 {
+				tagSlot = store.Offset
+			}
+		case 5:
+			if payloadSlot < 0 {
+				payloadSlot = store.Offset
+			}
+		}
+	}
+	if tagSlot < 0 || payloadSlot < 0 {
+		t.Fatalf("expected both Some tag (Imm=1) and payload (Imm=5) writes; instrs=%+v", instrs)
+	}
+	if payloadSlot-tagSlot != 8 {
+		t.Fatalf("payload should land 8 bytes past tag; tag=%d payload=%d", tagSlot, payloadSlot)
+	}
+}
+
 func TestEmitObjectIncludesStructDIEForPointModule(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

ONB now lowers enums natively. With Option/Result in the prelude, almost every meaningful Osty program now stays on the native fast path instead of falling back to LLVM:

- No-payload enums (`enum Color { Red, Green, Blue }`)
- `Option<scalar>` via both surface forms (`T?` and `Option<T>`)
- `Result<T, E>` where T and E each fit in one ABI register
- `?` operator propagation through `Result<...>` returns

## Mechanics

**Slot layout**: `[discriminant 8B][payload N×8B]`, capped at 16B so the whole value rides the AAPCS64 small-struct ABI from Week 13 (1 disc reg + 1 payload reg). No-payload enums use 8B (discriminant only); `Option<Int>` / `Result<Int, Int>` / `Result<Int, MyError>` all fit in 16B.

**Lowering** (`internal/onb/lower.go`):
- `lookupEnumLayout(t)` resolves user enums (`mod.Layouts.Enums`) and synthesises Option/Result layouts on the fly (None=0/Some=1, Err=0/Ok=1 — same convention as `internal/llvmgen` and `mir/lower.go`)
- `enumSlotSize` / `enumPayloadOffset` / `enumDiscriminantValue` helpers
- `payloadAllScalar` widened via new `isABIWordType` — admits any 1-register type (so `Result<Int, MyError>` works because MyError is 8B)
- `lowerAggregateAssign` handles `AggEnumVariant` — discriminant to slot+0, payload fields to slot+8 + i*8
- New rvalue lowering: `*mir.NullaryRV` (None), `*mir.DiscriminantRV` (read slot+0)
- `placeProjectionOffset` handles `*mir.VariantProj` (FieldIdx ≥ 0 → slot+8 + FieldIdx*8; -1 → slot+8)
- `collectRValueLocals` walks `AggregateRV.Fields` and `DiscriminantRV.Place` so enum scrutinees get slots
- `lowerUseAssignMulti` — multi-slot copy when the destination needs more than one ABI register; the `?` operator's Err re-emit (`_0 = use _result`) needs all 16B copied, not just the discriminant byte
- New `Brk{Imm}` LIR opcode + Mach-O encoding for `mir.UnreachableTerm` (match exhaustiveness's default arm)

## Out of scope

- Enum variant with a struct payload (`Some(Point)` — Point is 2-reg, exceeds the 1-reg payload cap)
- Multi-field variant payload (`Some((a, b))`)
- Enum DWARF DIE — Week 11 B.5 abbrev infra is in place but the lower→encoder wiring is deferred to a follow-up

## Test plan

- [x] `internal/onb/onb_test.go` — 3 unit tests:
  - `TestLowerMIRColorEnumStoresDiscriminantTag`
  - `TestLowerMIREnumSwitchEmitsBrkForUnreachableDefault`
  - `TestLowerMIROptionVariantStoresTagAndPayload`
- [x] `internal/backend/onb_test.go` — 7 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsEnumPatternsOnDarwinARM64`):
  - `no_payload_enum`: `enum Color { ... }` + match → 1
  - `option_some` / `option_none`: `Some(5)` + match destructure
  - `result_ok` / `result_err`: `Result<Int, MyError>` round-trip
  - `result_question_op_ok` / `result_question_op_err`: `?` propagation in both arms
- [x] All pre-existing ONB + backend (`-short`) tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)