### PR TITLE
feat: ONB Phase A2 Week 15 — Float64 + IEEE arithmetic + AAPCS64 FP ABI

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,72 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 15 (Float64 + IEEE 산술 + AAPCS64 FP ABI, 2026-05-02)** —
+> ONB가 처음으로 Float64를 native lowering. `let x: Float64 = 3.14` /
+> `(a + b) * 3.0` / `fn double(x: Float64) -> Float64` 같은 코드가
+> fallback 없이 통과.
+>
+> 작동:
+>
+> ```osty
+> fn double(x: Float64) -> Float64 { x * 2.0 }       // d0 in / d0 out
+> fn add(n: Int, f: Float64) -> Float64 { f + 1.0 }  // n in x0, f in d0
+> fn main() {
+>     let a: Float64 = 1.5
+>     let b: Float64 = 2.5
+>     let c = (a + b) * 3.0
+>     println(c)                                      // %g format
+>     println(double(3.5))
+>     println(add(10, 2.5))
+> }
+> ```
+>
+> 모델: scalar-everything 모델 유지 + d-register 클래스 추가. d8/d9를
+> FP scratch (mirroring x9/x10), d0-d7을 AAPCS64 FP-arg cursor로 사용.
+> Float64 const는 `movz/movk x9 + fmov d, x9` 시퀀스로 materialise.
+> Mixed Int+Float fn signature은 두 개의 독립 cursor (regCursor +
+> fpCursor)로 처리 — `fn(n: Int, f: Float64)`는 n→x0, f→d0 (자주
+> 잘못 매핑되는 x0/x1이 아님).
+>
+> 추가:
+> - 새 LIR opcodes: `LoadFloat64Stack`, `StoreFloat64Stack`,
+>   `FmovDFromX` / `FmovXFromD`, `FaddReg` / `FsubReg` / `FmulReg` /
+>   `FdivReg`, d0–d9 register names
+> - `isFloatABIType(t)` predicate (Float / Float64), `isABIScalarType`
+>   가 이를 포함하도록 확장
+> - `materialiseFloatOperand` — FloatConst 또는 Float local → d 레지스터
+>   (FloatConst는 `floatConstInstrs` helper로 movz/movk + fmov 시퀀스)
+> - `lowerFloatBinaryAssign` — d8/d9 페어로 fadd/fsub/fmul/fdiv
+> - `lowerUseAssign` Float 분기 — Float local 복사는 d 레지스터 경유
+> - `lowerPrintln`이 Float 인자에 `%g\n` + fmov x1, d9 + str x1, [sp]
+>   (darwin 변동인자 ABI는 모든 vararg가 stack)
+> - `paramShuffle` / `lowerCall` / `epilogue`가 fpCursor로 d0-d7 사용
+> - 새 Mach-O encoders: `dRegisterNumber`, `encodeFPStack` (str/ldr d),
+>   `encodeFmovDFromX` / `encodeFmovXFromD`, `encodeFPArith` (fadd 외)
+> - 자동 surface: `DebugTypeFloat`은 dwarf.go에 이미 있었던 dead path
+>   였는데 이번 슬라이스에서 첫 사용자 등장
+>
+> 검증:
+> - 단위 테스트 2개 (`internal/onb/onb_test.go`) — 1.5 + 2.5 패턴이
+>   FmovDFromX + FaddReg + StoreFloat64Stack + FmovXFromD를 모두 emit
+>   하는지, Float local이 DWARF DebugLocal로 surface되는지
+> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsFloat64OnDarwinARM64`):
+>   const_print (3.14), arith ((1.5+2.5)*3.0=12), fn_param_ret
+>   (double(3.5)=7), mixed_int_float_args (add(10,2.5)=3.5 — Int/Float
+>   cursor 분리 회귀 테스트)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - Float 비교 연산 (`a < b`, `a == b`) — fcmpe + cset / b.cond 미구현
+> - Float32 — 모든 경로가 d 레지스터 (Float64) 가정
+> - Int↔Float 변환 (`n.toFloat64()`, `f.toInt()`) — fcvtzs / scvtf 미구현
+> - Float을 struct/enum payload로 — abiRegSlots는 1-reg로 분류하지만
+>   field write/read 코드 경로는 d 레지스터를 인식 못 함
+> - Float DWARF (`frame variable c` 시 값 표시) — DebugTypeFloat은
+>   surface되나 lldb 통합 테스트는 별도 슬라이스
+>
+> 다음 슬라이스 후보: List<T> 일반화 (`List<Bool>` / `List<Float64>` /
+>  `List<String>` 런타임 디스패치) → for-in 루프 native.
+>
 > **Slice A2 Week 14 (Enum lowering v1 — Color / Option / Result + `?`,
 > 2026-05-02)** — ONB가 처음으로 enum을 native lowering. Option/Result가
 > prelude라 거의 모든 의미 있는 Osty 코드가 fallback에서 풀려나옴.

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -814,6 +814,97 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsFloat64OnDarwinARM64 covers Phase A2 Week 15:
+// Float64 const materialisation, IEEE arithmetic, println via printf
+// "%g\n", and the AAPCS64 d0..d7 / d0 FP-arg + return convention.
+//
+// Cases:
+//   - **const_print**: tests `let x: Float64 = 3.14; println(x)` —
+//     drives floatConstInstrs (movz/movk + fmov d, x) + the printf
+//     vararg slot Float path.
+//   - **arith**: `(1.5 + 2.5) * 3.0` — exercises FAdd + FMul +
+//     intermediate float local store/load.
+//   - **fn_param_ret**: `fn double(x: Float64) -> Float64 { x * 2.0 }`
+//     drives the d0 param shuffle + d0 return epilogue and proves
+//     the AAPCS64 FP cursor works at call boundaries.
+//   - **mixed_int_float**: `fn scale(n: Int, f: Float64) -> Float64
+//     { f * n.toFloat64() }` — actually we keep this simpler: just
+//     pass an Int and a Float to verify the two cursors stay
+//     independent. The Int local goes to x0 and the Float local
+//     to d0, not x0/x1 (a regression on cursor isolation would
+//     mis-route the Float through x1).
+func TestONBBackendBinaryRunsFloat64OnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB Float64 executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "const_print",
+			src: `fn main() {
+    let x: Float64 = 3.14
+    println(x)
+}`,
+			want: "3.14\n",
+		},
+		{
+			name: "arith",
+			src: `fn main() {
+    let a: Float64 = 1.5
+    let b: Float64 = 2.5
+    let c = (a + b) * 3.0
+    println(c)
+}`,
+			want: "12\n",
+		},
+		{
+			name: "fn_param_ret",
+			src: `fn double(x: Float64) -> Float64 { x * 2.0 }
+fn main() {
+    let v = double(3.5)
+    println(v)
+}`,
+			want: "7\n",
+		},
+		{
+			name: "mixed_int_float_args",
+			src: `fn add(n: Int, f: Float64) -> Float64 { f + 1.0 }
+fn main() {
+    let v = add(10, 2.5)
+    println(v)
+}`,
+			want: "3.5\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			if result == nil || result.Artifacts.Binary == "" {
+				t.Fatalf("missing binary artifact: %+v", result)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -138,6 +138,25 @@ func renderInstrAssembly(b *strings.Builder, target Target, fn Function, instr I
 		b.WriteString("\tret\n")
 	case *Brk:
 		fmt.Fprintf(b, "\tbrk #%d\n", i.Imm)
+	case *LoadFloat64Stack:
+		fmt.Fprintf(b, "\tldr %s, [sp, #%d]\n", i.Dst, i.Offset)
+	case *StoreFloat64Stack:
+		fmt.Fprintf(b, "\tstr %s, [sp, #%d]\n", i.Src, i.Offset)
+	case *FmovDFromX, *FmovXFromD:
+		switch v := instr.(type) {
+		case *FmovDFromX:
+			fmt.Fprintf(b, "\tfmov %s, %s\n", v.Dst, v.Src)
+		case *FmovXFromD:
+			fmt.Fprintf(b, "\tfmov %s, %s\n", v.Dst, v.Src)
+		}
+	case *FaddReg:
+		fmt.Fprintf(b, "\tfadd %s, %s, %s\n", i.Dst, i.Lhs, i.Rhs)
+	case *FsubReg:
+		fmt.Fprintf(b, "\tfsub %s, %s, %s\n", i.Dst, i.Lhs, i.Rhs)
+	case *FmulReg:
+		fmt.Fprintf(b, "\tfmul %s, %s, %s\n", i.Dst, i.Lhs, i.Rhs)
+	case *FdivReg:
+		fmt.Fprintf(b, "\tfdiv %s, %s, %s\n", i.Dst, i.Lhs, i.Rhs)
 	default:
 		return fmt.Errorf("onb: assembly renderer does not support %T", instr)
 	}

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -130,6 +130,21 @@ const (
 	RegX30 Reg = "x30"
 	RegSP  Reg = "sp"
 	RegW0  Reg = "w0"
+
+	// AAPCS64 floating-point argument registers d0..d7 are used for
+	// Float64 arguments and return values. d8/d9 act as the
+	// stack-everything model's FP scratch slot, mirroring x9/x10 on
+	// the integer side.
+	RegD0 Reg = "d0"
+	RegD1 Reg = "d1"
+	RegD2 Reg = "d2"
+	RegD3 Reg = "d3"
+	RegD4 Reg = "d4"
+	RegD5 Reg = "d5"
+	RegD6 Reg = "d6"
+	RegD7 Reg = "d7"
+	RegD8 Reg = "d8"
+	RegD9 Reg = "d9"
 )
 
 // MovImm32 lowers a small integer immediate into a 32-bit destination
@@ -323,6 +338,81 @@ type Brk struct {
 }
 
 func (*Brk) instrNode() {}
+
+// LoadFloat64Stack loads a Float64 (8-byte slot) from the call frame
+// into a d-register. The encoder picks the `ldr d, [sp, #N]` form
+// when N is 8-byte aligned and ≤ 32760.
+type LoadFloat64Stack struct {
+	Dst    Reg
+	Offset int64
+}
+
+func (*LoadFloat64Stack) instrNode() {}
+
+// StoreFloat64Stack stores a d-register's 8 bytes into the call frame.
+// Mirrors `Store64Stack` for FP values.
+type StoreFloat64Stack struct {
+	Src    Reg
+	Offset int64
+}
+
+func (*StoreFloat64Stack) instrNode() {}
+
+// FmovDFromX bitcasts a 64-bit integer register into a d-register
+// (`fmov d, x`). Used to materialise an arbitrary Float64 immediate:
+// the encoder emits a movz/movk chain into x9 followed by `fmov d9, x9`.
+type FmovDFromX struct {
+	Dst Reg // a d register
+	Src Reg // an x register
+}
+
+func (*FmovDFromX) instrNode() {}
+
+// FmovXFromD bitcasts a d-register into a 64-bit integer register
+// (`fmov x, d`). Used to land a Float64 value into the printf vararg
+// slot, which on darwin/aarch64 reads from the integer x register
+// stored at [sp+0].
+type FmovXFromD struct {
+	Dst Reg
+	Src Reg
+}
+
+func (*FmovXFromD) instrNode() {}
+
+// FaddReg / FsubReg / FmulReg / FdivReg are the four IEEE 754 binary
+// ops the dev backend covers today: `f<op> Dd, Dn, Dm`. Operands are
+// already in d-registers via LoadFloat64Stack or FmovDFromX.
+type FaddReg struct {
+	Dst Reg
+	Lhs Reg
+	Rhs Reg
+}
+
+func (*FaddReg) instrNode() {}
+
+type FsubReg struct {
+	Dst Reg
+	Lhs Reg
+	Rhs Reg
+}
+
+func (*FsubReg) instrNode() {}
+
+type FmulReg struct {
+	Dst Reg
+	Lhs Reg
+	Rhs Reg
+}
+
+func (*FmulReg) instrNode() {}
+
+type FdivReg struct {
+	Dst Reg
+	Lhs Reg
+	Rhs Reg
+}
+
+func (*FdivReg) instrNode() {}
 
 func functionNeedsFrame(fn Function) bool {
 	if fn.FrameSize > 0 {

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -2,6 +2,7 @@ package onb
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/osty/osty/internal/ir"
@@ -14,6 +15,13 @@ import (
 // adjacent register slots (e.g. {x0, x1}), so a function that takes a
 // `Point` plus a scalar uses three slots, not two.
 var argRegs = []Reg{RegX0, RegX1, RegX2, RegX3, RegX4, RegX5, RegX6, RegX7}
+
+// fpArgRegs is the AAPCS64 floating-point-argument register sequence.
+// AAPCS64 keeps two independent register cursors (integer + FP), so a
+// `fn mix(a: Int, x: Float64, b: Int)` takes a in x0, x in d0, b in
+// x1 — not the often-mistaken x0 / x1 / x2 mapping. The dev backend
+// follows that rule for both `paramShuffle` and `lowerCall`.
+var fpArgRegs = []Reg{RegD0, RegD1, RegD2, RegD3, RegD4, RegD5, RegD6, RegD7}
 
 // abiSmallStructRegLimit is the AAPCS64 cutoff for "small struct" handling:
 // up to two integer registers. Sizes ≤ 8 bytes consume one register, sizes
@@ -364,25 +372,35 @@ func (s *lowerState) lowerBranchTerm(term *mir.BranchTerm) ([]Instr, error) {
 }
 
 // paramShuffle copies every read parameter from its AAPCS64 argument
-// register(s) into its assigned stack slot. Scalar params consume one
-// register; small structs consume one or two adjacent registers, with
-// register N landing at slot+N*8 to match the field-projection offsets
-// the rest of the body expects. Parameters that are never read get no
-// slot, but the register cursor still advances so subsequent params
-// see the right register.
+// register(s) into its assigned stack slot. Scalar Int / Bool / String
+// / pointer params consume one integer register; small structs and
+// enums consume one or two adjacent integer registers, with register N
+// landing at slot+N*8 to match the field-projection offsets the rest
+// of the body expects. Float params consume one FP register (d0..d7)
+// from the independent FP cursor — AAPCS64 doesn't merge integer and
+// FP register usage. Parameters that are never read still advance the
+// cursor so subsequent params see the right register.
 func (s *lowerState) paramShuffle(fn *mir.Function) []Instr {
 	var out []Instr
 	regCursor := 0
+	fpCursor := 0
 	for _, paramID := range fn.Params {
 		loc := lookupLocal(fn, paramID)
 		if loc == nil {
+			continue
+		}
+		slot, hasSlot := s.localSlots[paramID]
+		if isFloatABIType(loc.Type) {
+			if hasSlot && fpCursor < len(fpArgRegs) {
+				out = append(out, &StoreFloat64Stack{Src: fpArgRegs[fpCursor], Offset: slot})
+			}
+			fpCursor++
 			continue
 		}
 		slots, ok := s.abiRegSlots(loc.Type)
 		if !ok {
 			continue
 		}
-		slot, hasSlot := s.localSlots[paramID]
 		for i := 0; i < slots; i++ {
 			if hasSlot {
 				out = append(out, &Store64Stack{Src: argRegs[regCursor+i], Offset: slot + int64(i)*8})
@@ -415,6 +433,12 @@ func (s *lowerState) epilogue(fn *mir.Function) []Instr {
 		// loud if it changes.
 		return []Instr{
 			&MovImm64{Dst: RegX0, Imm: 0},
+			&Ret{},
+		}
+	}
+	if isFloatABIType(fn.ReturnType) {
+		return []Instr{
+			&LoadFloat64Stack{Dst: RegD0, Offset: slot},
 			&Ret{},
 		}
 	}
@@ -500,10 +524,19 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 // passed via the AAPCS64 small-struct rule) need a per-slot copy so
 // the payload byte isn't clipped. The destination's local type drives
 // the slot count; the operand's type matches by construction (the
-// front end never emits cross-shape Use rvalues).
+// front end never emits cross-shape Use rvalues). Float locals route
+// through the d-register path so the bit pattern survives any
+// future store-byte fusing the integer path might pick up.
 func (s *lowerState) lowerUseAssign(fn *mir.Function, rv *mir.UseRV, destID mir.LocalID, destSlot int64) ([]Instr, error) {
 	destLoc := lookupLocal(fn, destID)
 	if destLoc != nil {
+		if isFloatABIType(destLoc.Type) {
+			mat, err := s.materialiseFloatOperand(rv.Op, RegD8)
+			if err != nil {
+				return nil, err
+			}
+			return append(mat, &StoreFloat64Stack{Src: RegD8, Offset: destSlot}), nil
+		}
 		if slots, ok := s.abiRegSlots(destLoc.Type); ok && slots > 1 {
 			return s.lowerUseAssignMulti(rv, slots, destSlot)
 		}
@@ -684,11 +717,19 @@ func (s *lowerState) lowerStructLiteralAssign(rv *mir.AggregateRV, destSlot int6
 }
 
 // isABIScalarType reports whether a MIR type fits cleanly in one AAPCS64
-// integer register. Phase A2 accepts Int (i64), Bool (i1), and String
-// (ptr). Lists and structs need indirect passing and are deferred to a
-// future slice.
+// integer register. Phase A2 accepts Int (i64), Bool (i1), String (ptr),
+// and Float (Float / Float64 — IEEE 754 double, lives in a d-register at
+// the call boundary but counts as a scalar for slot allocation). Lists
+// and structs need indirect passing and are deferred to a future slice.
 func isABIScalarType(t mir.Type) bool {
-	return t == mir.TInt || t == mir.TBool || t == mir.TString
+	return t == mir.TInt || t == mir.TBool || t == mir.TString || isFloatABIType(t)
+}
+
+// isFloatABIType reports whether t is a Float / Float64 — values that
+// occupy a d-register on AAPCS64 calls and need fmov / fadd opcodes
+// rather than the integer-side str / add lowerings.
+func isFloatABIType(t mir.Type) bool {
+	return t == mir.TFloat || t == mir.TFloat64
 }
 
 // abiRegSlots reports how many AAPCS64 integer-argument registers an ABI
@@ -1097,6 +1138,9 @@ func (s *lowerState) lowerBinaryAssign(rv *mir.BinaryRV, destSlot int64) ([]Inst
 	if rv.Op == mir.BinAdd && rv.T == mir.TString {
 		return s.lowerStringConcatAssign(rv, destSlot)
 	}
+	if isFloatABIType(rv.T) {
+		return s.lowerFloatBinaryAssign(rv, destSlot)
+	}
 	switch rv.Op {
 	case mir.BinAdd, mir.BinSub, mir.BinMul:
 	default:
@@ -1121,6 +1165,39 @@ func (s *lowerState) lowerBinaryAssign(rv *mir.BinaryRV, destSlot int64) ([]Inst
 		out = append(out, &MulReg{Dst: RegX9, Lhs: RegX9, Rhs: RegX10})
 	}
 	out = append(out, &Store64Stack{Src: RegX9, Offset: destSlot})
+	return out, nil
+}
+
+// lowerFloatBinaryAssign lowers `dest = lhs <op> rhs` for two Float
+// operands. The two operands materialise into d8/d9, then `f<op> d8,
+// d8, d9` produces the result, which a `str d8, [sp, #destSlot]`
+// commits back. d8/d9 are AAPCS64 callee-saved — using them as the
+// scratch pair means a follow-up that adds a register allocator can
+// keep them around across calls without extra spills.
+func (s *lowerState) lowerFloatBinaryAssign(rv *mir.BinaryRV, destSlot int64) ([]Instr, error) {
+	lhs, err := s.materialiseFloatOperand(rv.Left, RegD8)
+	if err != nil {
+		return nil, err
+	}
+	rhs, err := s.materialiseFloatOperand(rv.Right, RegD9)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), lhs...)
+	out = append(out, rhs...)
+	switch rv.Op {
+	case mir.BinAdd:
+		out = append(out, &FaddReg{Dst: RegD8, Lhs: RegD8, Rhs: RegD9})
+	case mir.BinSub:
+		out = append(out, &FsubReg{Dst: RegD8, Lhs: RegD8, Rhs: RegD9})
+	case mir.BinMul:
+		out = append(out, &FmulReg{Dst: RegD8, Lhs: RegD8, Rhs: RegD9})
+	case mir.BinDiv:
+		out = append(out, &FdivReg{Dst: RegD8, Lhs: RegD8, Rhs: RegD9})
+	default:
+		return nil, fmt.Errorf("%w: float binary op %v is outside phase 1", ErrUnsupportedShape, rv.Op)
+	}
+	out = append(out, &StoreFloat64Stack{Src: RegD8, Offset: destSlot})
 	return out, nil
 }
 
@@ -1189,12 +1266,14 @@ func (s *lowerState) lowerComparisonAssign(rv *mir.BinaryRV, cond Cond, destSlot
 	return out, nil
 }
 
-// lowerCall emits an AAPCS64 direct call: each argument materialises into
-// x0..x7 in order, then `bl _<name>`, then (if the call has a destination
-// place backed by a slot) the return value(s) in x0/x1 are stored into
-// that slot. Small structs (≤ 16B) consume two adjacent argument registers
-// and, on return, the receiver captures both x0 and x1 into slot+0/+8.
-// FnRef-only — indirect calls and parameter types outside ABI fall back.
+// lowerCall emits an AAPCS64 direct call. Integer / pointer / struct
+// args land in x0..x7 (with structs consuming two adjacent x slots);
+// Float64 args land in d0..d7 from the independent FP cursor. After
+// `bl _<name>`, the return value moves into the destination slot:
+// scalar integer returns capture x0, scalar Float returns capture d0
+// via `str d0`, small struct returns capture {x0, x1} into
+// dest+0/+8. FnRef-only — indirect calls and parameter types outside
+// ABI fall back.
 func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr, error) {
 	ref, ok := instr.Callee.(*mir.FnRef)
 	if !ok {
@@ -1202,8 +1281,21 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 	}
 	var out []Instr
 	regCursor := 0
+	fpCursor := 0
 	for _, arg := range instr.Args {
 		argType := arg.Type()
+		if isFloatABIType(argType) {
+			if fpCursor >= len(fpArgRegs) {
+				return nil, fmt.Errorf("%w: call to %s needs more than %d FP argument registers", ErrUnsupportedShape, ref.Symbol, len(fpArgRegs))
+			}
+			mat, err := s.materialiseFloatOperand(arg, fpArgRegs[fpCursor])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mat...)
+			fpCursor++
+			continue
+		}
 		slots, ok := s.abiRegSlots(argType)
 		if !ok {
 			return nil, fmt.Errorf("%w: call argument has type %s outside ABI", ErrUnsupportedShape, argType)
@@ -1233,13 +1325,18 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 	out = append(out, &BranchLink{Symbol: ref.Symbol})
 	if instr.Dest != nil && !instr.Dest.HasProjections() {
 		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
-			retSlots, _ := s.abiRegSlots(s.destType(instr.Dest.Local))
-			if retSlots == 0 {
-				retSlots = 1
-			}
-			retRegs := []Reg{RegX0, RegX1}
-			for i := 0; i < retSlots && i < len(retRegs); i++ {
-				out = append(out, &Store64Stack{Src: retRegs[i], Offset: slot + int64(i)*8})
+			destType := s.destType(instr.Dest.Local)
+			if isFloatABIType(destType) {
+				out = append(out, &StoreFloat64Stack{Src: RegD0, Offset: slot})
+			} else {
+				retSlots, _ := s.abiRegSlots(destType)
+				if retSlots == 0 {
+					retSlots = 1
+				}
+				retRegs := []Reg{RegX0, RegX1}
+				for i := 0; i < retSlots && i < len(retRegs); i++ {
+					out = append(out, &Store64Stack{Src: retRegs[i], Offset: slot + int64(i)*8})
+				}
 			}
 		}
 	}
@@ -1289,7 +1386,8 @@ func (s *lowerState) materialiseStructOperand(op mir.Operand, regs []Reg) ([]Ins
 // materialiseOperand emits the instruction sequence that lands the operand's
 // value in dst. Supports Int / Bool / String constants and Copy/Move of
 // locals that have a stack slot. String constants land in dst as a pointer
-// to their `__cstring` entry.
+// to their `__cstring` entry. Float operands take a separate path via
+// materialiseFloatOperand because they need d-register destinations.
 func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error) {
 	switch o := op.(type) {
 	case *mir.ConstOp:
@@ -1315,6 +1413,63 @@ func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error
 	default:
 		return nil, fmt.Errorf("%w: operand %T", ErrUnsupportedShape, op)
 	}
+}
+
+// materialiseFloatOperand emits the instruction sequence that lands a
+// Float64-typed operand in `dst` (a d-register). Supports FloatConst
+// (movz/movk into a scratch x register + fmov d, x) and Copy/Move of
+// Float-typed locals (ldr d, [sp, #N]). The IntConst path covers the
+// MIR shape `const 2 Float` that the front end emits when an integer
+// literal appears in a float context — we promote the integer to a
+// Float64 bit pattern at compile time.
+func (s *lowerState) materialiseFloatOperand(op mir.Operand, dst Reg) ([]Instr, error) {
+	switch o := op.(type) {
+	case *mir.ConstOp:
+		switch c := o.Const.(type) {
+		case *mir.FloatConst:
+			return floatConstInstrs(dst, c.Value), nil
+		case *mir.IntConst:
+			// `const 2 Float` form — promote to float bit pattern.
+			return floatConstInstrs(dst, float64(c.Value)), nil
+		default:
+			return nil, fmt.Errorf("%w: float const %T as operand", ErrUnsupportedShape, o.Const)
+		}
+	case *mir.CopyOp:
+		return s.loadFloatPlaceIntoReg(o.Place, dst)
+	case *mir.MoveOp:
+		return s.loadFloatPlaceIntoReg(o.Place, dst)
+	default:
+		return nil, fmt.Errorf("%w: float operand %T", ErrUnsupportedShape, op)
+	}
+}
+
+// floatConstInstrs emits `movz/movk` into x9 followed by `fmov dst,
+// x9` to deposit a Float64 immediate into a d-register. The dev
+// backend always uses x9 as the FP-immediate scratch — choosing the
+// same register every time keeps the lowering simple and lets the
+// asm renderer print a uniform sequence.
+func floatConstInstrs(dst Reg, value float64) []Instr {
+	bits := int64(math.Float64bits(value))
+	return []Instr{
+		&MovImm64{Dst: RegX9, Imm: bits},
+		&FmovDFromX{Dst: dst, Src: RegX9},
+	}
+}
+
+// loadFloatPlaceIntoReg materialises a Float-typed local into a
+// d-register via `ldr d, [sp, #slot+offset]`. Uses the same
+// projection machinery as scalars so future struct-of-Float lowerings
+// keep working without special casing.
+func (s *lowerState) loadFloatPlaceIntoReg(place mir.Place, dst Reg) ([]Instr, error) {
+	slot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: read of float local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	off, err := s.placeProjectionOffset(place)
+	if err != nil {
+		return nil, err
+	}
+	return []Instr{&LoadFloat64Stack{Dst: dst, Offset: slot + off}}, nil
 }
 
 func (s *lowerState) loadPlaceIntoReg(place mir.Place, dst Reg) ([]Instr, error) {
@@ -1439,12 +1594,33 @@ func (s *lowerState) lowerPrintln(instr *mir.IntrinsicInstr) ([]Instr, error) {
 		out = append(out, &BranchLink{Symbol: "puts"})
 		return out, nil
 	}
+	if mat, ok, err := s.loadFloatPrintArg(arg); err != nil || ok {
+		if err != nil {
+			return nil, err
+		}
+		// Darwin/aarch64 vararg ABI: every variadic argument lands
+		// on the stack regardless of register class. We materialise
+		// the Float64 in d9, bitcast it to x1 via `fmov`, then drop
+		// it at [sp+0] alongside the format-string pointer in x0.
+		// `%g` is the printf format that matches Osty's println for
+		// floats so trailing zeros stay quiet (matches LLVM
+		// backend's choice).
+		label := s.addCString("%g\n")
+		out := []Instr{&LoadCStringAddress{Dst: RegX0, Label: label}}
+		out = append(out, mat...)
+		out = append(out, &FmovXFromD{Dst: RegX1, Src: RegD9})
+		if s.target.ObjectFormat == "mach-o" {
+			out = append(out, &Store64Stack{Src: RegX1, Offset: 0})
+		}
+		out = append(out, &BranchLink{Symbol: "printf"})
+		return out, nil
+	}
 	loadValue, ok, err := s.loadIntPrintArg(arg)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("%w: println currently requires a string, int literal, Int local, or String local", ErrUnsupportedShape)
+		return nil, fmt.Errorf("%w: println currently requires a string, int literal, Int local, String local, or Float local", ErrUnsupportedShape)
 	}
 	label := s.addCString("%lld\n")
 	out := []Instr{&LoadCStringAddress{Dst: RegX0, Label: label}}
@@ -1454,6 +1630,20 @@ func (s *lowerState) lowerPrintln(instr *mir.IntrinsicInstr) ([]Instr, error) {
 	}
 	out = append(out, &BranchLink{Symbol: "printf"})
 	return out, nil
+}
+
+// loadFloatPrintArg materialises a Float-typed operand into d9 so the
+// caller can finish the printf shuffle. Returns ok=false when the
+// operand isn't a Float — the caller falls through to the int path.
+func (s *lowerState) loadFloatPrintArg(op mir.Operand) ([]Instr, bool, error) {
+	if !isFloatABIType(op.Type()) {
+		return nil, false, nil
+	}
+	instrs, err := s.materialiseFloatOperand(op, RegD9)
+	if err != nil {
+		return nil, false, err
+	}
+	return instrs, true, nil
 }
 
 // loadStringPrintArg materialises a string-typed operand into x0 so a

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -984,6 +984,54 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 					return fmt.Errorf("onb: brk encoding: %w", err)
 				}
 				enc.code = appendU32LE(enc.code, word)
+			case *LoadFloat64Stack:
+				word, err := encodeFPStack(0xfd400000, i.Dst, i.Offset)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *StoreFloat64Stack:
+				word, err := encodeFPStack(0xfd000000, i.Src, i.Offset)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FmovDFromX:
+				word, err := encodeFmovDFromX(i.Dst, i.Src)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FmovXFromD:
+				word, err := encodeFmovXFromD(i.Dst, i.Src)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FaddReg:
+				word, err := encodeFPArith(0x1e602800, i.Dst, i.Lhs, i.Rhs)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FsubReg:
+				word, err := encodeFPArith(0x1e603800, i.Dst, i.Lhs, i.Rhs)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FmulReg:
+				word, err := encodeFPArith(0x1e600800, i.Dst, i.Lhs, i.Rhs)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *FdivReg:
+				word, err := encodeFPArith(0x1e601800, i.Dst, i.Lhs, i.Rhs)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
 			default:
 				return fmt.Errorf("%w: Mach-O encoder does not support %T", ErrNotImplemented, instr)
 			}
@@ -1258,6 +1306,107 @@ func encodeBrk(imm int64) (uint32, error) {
 		return 0, fmt.Errorf("%w: brk imm %d out of 16-bit range", ErrNotImplemented, imm)
 	}
 	return 0xd4200000 | (uint32(imm) << 5), nil
+}
+
+// dRegisterNumber returns the 0..31 encoding of a d-register name and
+// ok=false for non-d-register inputs. Mirrors `xRegisterNumber` for
+// the FP side. Phase A2 only uses d0..d9 today, but the encoder
+// accepts the full range so a future arrangement (loop variables,
+// callee-saved spills) doesn't have to revisit this helper.
+func dRegisterNumber(r Reg) (uint32, bool) {
+	switch r {
+	case RegD0:
+		return 0, true
+	case RegD1:
+		return 1, true
+	case RegD2:
+		return 2, true
+	case RegD3:
+		return 3, true
+	case RegD4:
+		return 4, true
+	case RegD5:
+		return 5, true
+	case RegD6:
+		return 6, true
+	case RegD7:
+		return 7, true
+	case RegD8:
+		return 8, true
+	case RegD9:
+		return 9, true
+	}
+	return 0, false
+}
+
+// encodeFPStack encodes `STR Dt, [SP, #imm12]` (base 0xfd000000) and
+// `LDR Dt, [SP, #imm12]` (base 0xfd400000) for double-precision
+// scalar transfers. The immediate is scaled by 8 (the access size),
+// matching the integer Store/Load encoders' offset rules.
+func encodeFPStack(base uint32, reg Reg, offset int64) (uint32, error) {
+	if offset < 0 || offset%8 != 0 {
+		return 0, fmt.Errorf("%w: FP stack offset %d", ErrNotImplemented, offset)
+	}
+	r, ok := dRegisterNumber(reg)
+	if !ok {
+		return 0, fmt.Errorf("%w: FP stack register %s", ErrNotImplemented, reg)
+	}
+	scaled := uint32(offset / 8)
+	if scaled > 0xfff {
+		return 0, fmt.Errorf("%w: FP stack offset %d too large", ErrNotImplemented, offset)
+	}
+	// SP is encoded as register 31 in the Rn field (bits 5-9).
+	return base | (scaled << 10) | (31 << 5) | r, nil
+}
+
+// encodeFmovDFromX encodes `FMOV Dd, Xn` — bitcast a 64-bit integer
+// register into a double-precision FP register without changing
+// bits. `1001 1110 0110 0111 0000 00<Rn> Rd`.
+func encodeFmovDFromX(dst, src Reg) (uint32, error) {
+	d, ok := dRegisterNumber(dst)
+	if !ok {
+		return 0, fmt.Errorf("%w: fmov dst %s", ErrNotImplemented, dst)
+	}
+	n, ok := xRegisterNumber(src)
+	if !ok {
+		return 0, fmt.Errorf("%w: fmov src %s", ErrNotImplemented, src)
+	}
+	return 0x9e670000 | (n << 5) | d, nil
+}
+
+// encodeFmovXFromD encodes `FMOV Xd, Dn` — the inverse of
+// encodeFmovDFromX. Same opcode family with op = 110 (general → FP)
+// vs 111 (FP → general). `1001 1110 0110 0110 0000 00<Rn> Rd`.
+func encodeFmovXFromD(dst, src Reg) (uint32, error) {
+	d, ok := xRegisterNumber(dst)
+	if !ok {
+		return 0, fmt.Errorf("%w: fmov dst %s", ErrNotImplemented, dst)
+	}
+	n, ok := dRegisterNumber(src)
+	if !ok {
+		return 0, fmt.Errorf("%w: fmov src %s", ErrNotImplemented, src)
+	}
+	return 0x9e660000 | (n << 5) | d, nil
+}
+
+// encodeFPArith encodes the FP binary arithmetic family
+// `F<op> Dd, Dn, Dm` (FADD/FSUB/FMUL/FDIV) for double precision.
+// Base values are FADD=0x1e602800, FSUB=0x1e603800, FMUL=0x1e600800,
+// FDIV=0x1e601800. Layout: base | (Rm << 16) | (Rn << 5) | Rd.
+func encodeFPArith(base uint32, dst, lhs, rhs Reg) (uint32, error) {
+	d, ok := dRegisterNumber(dst)
+	if !ok {
+		return 0, fmt.Errorf("%w: FP arith dst %s", ErrNotImplemented, dst)
+	}
+	n, ok := dRegisterNumber(lhs)
+	if !ok {
+		return 0, fmt.Errorf("%w: FP arith lhs %s", ErrNotImplemented, lhs)
+	}
+	m, ok := dRegisterNumber(rhs)
+	if !ok {
+		return 0, fmt.Errorf("%w: FP arith rhs %s", ErrNotImplemented, rhs)
+	}
+	return base | (m << 16) | (n << 5) | d, nil
 }
 
 func encodeMachOMovImm64(dst Reg, imm uint64) ([]uint32, error) {

--- a/internal/onb/onb_test.go
+++ b/internal/onb/onb_test.go
@@ -1589,6 +1589,100 @@ func TestLowerMIROptionVariantStoresTagAndPayload(t *testing.T) {
 	}
 }
 
+// floatArithModule mirrors `let c = 1.5 + 2.5; println(c)` so the
+// Float64 lowering paths can be exercised in a unit test without
+// bringing the full pipeline. The fixture pins the BinaryRV with
+// FloatConst operands path the front end emits, so a lowering
+// regression (e.g. FAdd routed to integer AddReg) shows up as a
+// concrete instruction-class mismatch.
+func floatArithModule() *mir.Module {
+	mainFn := &mir.Function{
+		Name:        "main",
+		ReturnType:  mir.TUnit,
+		ReturnLocal: 0,
+		Entry:       0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "$ret", Type: mir.TUnit, IsReturn: true},
+			{ID: 1, Name: "c", Type: mir.TFloat64},
+		},
+	}
+	bb := mainFn.NewBlock(mir.Span{})
+	mainFn.Block(bb).Instrs = []mir.Instr{
+		&mir.AssignInstr{
+			Dest: mir.Place{Local: 1},
+			Src: &mir.BinaryRV{
+				Op:    mir.BinAdd,
+				Left:  &mir.ConstOp{Const: &mir.FloatConst{Value: 1.5, T: mir.TFloat64}, T: mir.TFloat64},
+				Right: &mir.ConstOp{Const: &mir.FloatConst{Value: 2.5, T: mir.TFloat64}, T: mir.TFloat64},
+				T:     mir.TFloat64,
+			},
+		},
+		&mir.IntrinsicInstr{Kind: mir.IntrinsicPrintln, Args: []mir.Operand{&mir.CopyOp{Place: mir.Place{Local: 1}, T: mir.TFloat64}}},
+	}
+	mainFn.Block(bb).SetTerminator(&mir.ReturnTerm{})
+	return &mir.Module{Functions: []*mir.Function{mainFn}, Layouts: mir.NewLayoutTable()}
+}
+
+func TestLowerMIRFloatAdditionEmitsFaddReg(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(floatArithModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(floatArithModule) returned error: %v", err)
+	}
+	mainFn := &program.Functions[0]
+	var sawFmovD, sawFadd, sawStoreFloat, sawFmovX bool
+	for _, blk := range mainFn.Blocks {
+		for _, instr := range blk.Instrs {
+			switch instr.(type) {
+			case *FmovDFromX:
+				sawFmovD = true
+			case *FaddReg:
+				sawFadd = true
+			case *StoreFloat64Stack:
+				sawStoreFloat = true
+			case *FmovXFromD:
+				sawFmovX = true
+			}
+		}
+	}
+	if !sawFmovD {
+		t.Fatalf("expected FmovDFromX (float const materialisation); instrs=%+v", mainFn.Blocks[0].Instrs)
+	}
+	if !sawFadd {
+		t.Fatalf("expected FaddReg for float +; instrs=%+v", mainFn.Blocks[0].Instrs)
+	}
+	if !sawStoreFloat {
+		t.Fatalf("expected StoreFloat64Stack for binary result; instrs=%+v", mainFn.Blocks[0].Instrs)
+	}
+	if !sawFmovX {
+		t.Fatalf("expected FmovXFromD for printf vararg slot; instrs=%+v", mainFn.Blocks[0].Instrs)
+	}
+}
+
+func TestLowerMIRFloatLocalSurfacesAsDebugFloat(t *testing.T) {
+	t.Parallel()
+
+	program, err := LowerMIR(floatArithModule(), Target{Triple: "aarch64-apple-darwin", OS: "darwin", Arch: "aarch64", ObjectFormat: "mach-o"})
+	if err != nil {
+		t.Fatalf("LowerMIR(floatArithModule) returned error: %v", err)
+	}
+	mainFn := &program.Functions[0]
+	var cLocal *DebugLocal
+	for i := range mainFn.DebugLocals {
+		if mainFn.DebugLocals[i].Name == "c" {
+			cLocal = &mainFn.DebugLocals[i]
+			break
+		}
+	}
+	if cLocal == nil {
+		t.Fatalf("expected DebugLocal for `c`; got %+v", mainFn.DebugLocals)
+	}
+	if cLocal.TypeKind != DebugTypeFloat {
+		t.Fatalf("c TypeKind = %v, want DebugTypeFloat", cLocal.TypeKind)
+	}
+}
+
 func TestEmitObjectIncludesStructDIEForPointModule(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

ONB now lowers Float64 natively. End-to-end coverage of the canonical Osty float patterns — const, arithmetic, println, fn boundary — runs on the native fast path:

- Float64 const materialisation (`movz/movk x9 + fmov d, x9`)
- IEEE binary arithmetic (`fadd/fsub/fmul/fdiv`)
- `println(Float64)` via `printf "%g\n"`
- AAPCS64 d0..d7 / d0 FP-arg + return convention
- Mixed Int/Float function signatures with **independent** integer + FP cursors (`fn(n: Int, f: Float64)` → n in x0, f in d0)

## Mechanics

**Register strategy**: stack-everything stays. Adds the d-register class with d8/d9 as FP scratch (mirroring x9/x10 on the integer side) and d0..d7 as the AAPCS64 FP-arg sequence.

**Lowering** (`internal/onb/lower.go`):
- `isFloatABIType(t)`; `isABIScalarType` extended to include Float
- `materialiseFloatOperand` — FloatConst / Float local → d register
- `floatConstInstrs` — movz/movk into x9 + fmov d, x9
- `lowerFloatBinaryAssign` — d8/d9 pair for fadd/fsub/fmul/fdiv
- `lowerUseAssign` Float branch routes through d8
- `lowerPrintln` Float branch — `%g\n` + fmov x1, d9 + str x1, [sp] (darwin vararg ABI)
- `paramShuffle` / `lowerCall` / `epilogue` track an independent fpCursor

**LIR + encoders**:
- New opcodes: `LoadFloat64Stack`, `StoreFloat64Stack`, `FmovDFromX/FmovXFromD`, `Fadd/Fsub/Fmul/FdivReg`, d0–d9 register names
- Mach-O encoders: `dRegisterNumber`, `encodeFPStack`, `encodeFmov*`, `encodeFPArith`
- Asm renderer covers all FP opcodes
- DWARF `DebugTypeFloat` (already defined as dead path) gets its first user

## Out of scope

- Float comparisons (`a < b`) — needs `fcmpe + b.cond`
- Float32 — everything assumes Float64 / 8-byte slot
- Int↔Float casts — `fcvtzs` / `scvtf` not lowered
- Float as struct/enum payload — `abiRegSlots` reports 1 reg but the field write/read paths still emit integer `str/ldr`
- Float DWARF lldb integration (`frame variable c` will show stale bytes)

## Test plan

- [x] `internal/onb/onb_test.go` — 2 unit tests:
  - `TestLowerMIRFloatAdditionEmitsFaddReg` — verifies the FP opcode sequence (FmovDFromX + FaddReg + StoreFloat64Stack + FmovXFromD)
  - `TestLowerMIRFloatLocalSurfacesAsDebugFloat` — verifies Float locals appear with `DebugTypeFloat`
- [x] `internal/backend/onb_test.go` — 4 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsFloat64OnDarwinARM64`):
  - `const_print`: `let x = 3.14; println(x)` → `3.14`
  - `arith`: `(1.5 + 2.5) * 3.0` → `12`
  - `fn_param_ret`: `double(3.5)` → `7`
  - `mixed_int_float_args`: cursor isolation regression — `add(10, 2.5)` → `3.5` (Int in x0, Float in d0)
- [x] All pre-existing ONB + backend (`-short`) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)