### PR TITLE
feat: lower unreachable() / todo() / abort() through IntrinsicAbort

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1454,6 +1454,61 @@ func TestGenerateFromMIRPanicLowers(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic pins the
+// no-arg diverging prelude builtins (`unreachable() / todo() / abort()`,
+// LANG_SPEC §A.6). Each one synthesises a canonical message string and
+// reuses the panic emit path — same `osty_rt_panic` runtime decl,
+// same `call + unreachable` shape. Regression guard against a future
+// refactor that splits them onto separate intrinsics or symbols.
+func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
+	cases := []struct {
+		name    string
+		callee  string
+		message string
+	}{
+		{"unreachable", "unreachable", "entered unreachable code"},
+		{"todo", "todo", "not yet implemented"},
+		{"abort", "abort", "abort called"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fn := &ir.FnDecl{
+				Name:   "boom",
+				Return: ir.TInt,
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.ExprStmt{X: &ir.CallExpr{
+							Callee: &ir.Ident{Name: tc.callee, Kind: ir.IdentBuiltin, T: &ir.FnType{Return: ir.TNever}},
+							T:      ir.TNever,
+						}},
+					},
+				},
+			}
+			hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+			m := buildMIRModuleFromHIR(t, hir)
+			out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/diverge_" + tc.name + ".osty"})
+			if err != nil {
+				t.Fatalf("GenerateFromMIR: %v", err)
+			}
+			got := string(out)
+			for _, want := range []string{
+				"c\"" + tc.message + "\\00\"",
+				"declare void @osty_rt_panic(ptr) noreturn cold",
+				"call void @osty_rt_panic(ptr @.str.0)",
+				"unreachable",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("missing %q in:\n%s", want, got)
+				}
+			}
+			if strings.Contains(got, "unresolved symbol "+tc.callee) {
+				t.Fatalf("output still contains unresolved-symbol diagnostic for %s:\n%s", tc.callee, got)
+			}
+		})
+	}
+}
+
 // TestGenerateFromMIROptionUnwrapLowers pins the MIR emitter for the four
 // Option<T> method intrinsics (isSome, isNone, unwrap, unwrapOr). The
 // underlying lowering keeps Option<T> as `{ i64 disc, i64 payload }`

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4169,6 +4169,19 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			})
 			return
 		}
+		// `unreachable() / todo() / abort()` — diverging prelude builtins
+		// (LANG_SPEC §A.6) with no source-level message. Synthesize a
+		// canonical message string and route through `IntrinsicAbort` so
+		// backends share the panic emit path.
+		if msg, ok := divergingBuiltinMessage(id.Name); ok && len(c.Args) == 0 {
+			args := []Operand{&ConstOp{Const: &StringConst{Value: msg}, T: TString}}
+			bs.emit(&IntrinsicInstr{
+				Kind:  IntrinsicAbort,
+				Args:  args,
+				SpanV: c.SpanV,
+			})
+			return
+		}
 		if module, name, ok := loweredStdlibFreeSymbol(id.Name); ok {
 			switch module {
 			case "bytes":
@@ -4390,6 +4403,24 @@ func (bs *bodyState) builtinFreeCallIntrinsic(name string, args []ir.Arg) Intrin
 		return IntrinsicInvalid
 	}
 	return builtinFreeCallIntrinsicForReceiver(bs.recoveredTypeOf(args[0].Value), name)
+}
+
+// divergingBuiltinMessage returns the canonical runtime message for the
+// no-arg diverging prelude builtins (`unreachable() / todo() / abort()`,
+// LANG_SPEC §A.6). Each one routes through `IntrinsicAbort` with this
+// constant string so the LLVM backend can share `osty_rt_panic`.
+// `panic(msg)` does NOT use this — it carries its source-supplied
+// message through directly.
+func divergingBuiltinMessage(name string) (string, bool) {
+	switch name {
+	case "unreachable":
+		return "entered unreachable code", true
+	case "todo":
+		return "not yet implemented", true
+	case "abort":
+		return "abort called", true
+	}
+	return "", false
 }
 
 func builtinFreeCallIntrinsicForReceiver(receiverType Type, name string) IntrinsicKind {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36645,6 +36645,12 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "eprintln", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16074:5
 	checkRegisterFn(env, &CheckFnSig{name: "panic", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: []string{"message"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// unreachable() / todo() / abort() — diverging prelude builtins
+	// (LANG_SPEC §A.6). Like panic, they return Never and skip defers.
+	// No source-level message arg; the runtime helper synthesizes one.
+	checkRegisterFn(env, &CheckFnSig{name: "unreachable", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "todo", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "abort", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:16088:5
 	tUnit_ := tUnit(env.tys)
 	_ = tUnit_
@@ -54716,7 +54722,7 @@ func srSymbolFound(sym *SelfSymbol) bool {
 
 // Osty: /tmp/selfhost_merged.osty:28147:1
 func srIsBuiltinName(name string) bool {
-	return name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "print" || name == "println" || name == "eprint" || name == "eprintln" || name == "dbg" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Duration" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
+	return name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "print" || name == "println" || name == "eprint" || name == "eprintln" || name == "dbg" || name == "panic" || name == "unreachable" || name == "todo" || name == "abort" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Int8" || name == "Int16" || name == "Int32" || name == "Int64" || name == "UInt8" || name == "UInt16" || name == "UInt32" || name == "UInt64" || name == "Byte" || name == "Float" || name == "Float32" || name == "Float64" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "RawPtr" || name == "List" || name == "Map" || name == "Set" || name == "Chan" || name == "Channel" || name == "Handle" || name == "TaskGroup" || name == "Option" || name == "Result" || name == "Error" || name == "Duration" || name == "Unit" || name == "Equal" || name == "Ordered" || name == "Hashable" || name == "ToString" || name == "Pod"
 }
 
 // Osty: /tmp/selfhost_merged.osty:28151:1


### PR DESCRIPTION
## Summary
Completes the diverging-prelude-builtin family started by panic in #1277. Spec §A.6 lists `panic`, `unreachable`, `todo`, `abort` together as Never-returning, defer-skipping builtins; only `panic` was wired previously. The other three reached the resolver as **"cannot find ... in this scope"** because they weren't in the prelude.

> **Stacked on #1277** — base branch is `mir-mvp-gap-fix`. Once #1277 lands, change base to `main` (or merge directly).

## What changed

- **`internal/selfhost/generated.go::srIsBuiltinName`** — adds `unreachable`, `todo`, `abort` to the resolver's prelude visibility list. Also registers matching no-arg `CheckFnSig` entries returning `Never` next to the existing `panic` registration.

- **`internal/mir/lower.go::lowerCallExprInto`** — bare-Ident `unreachable() / todo() / abort()` now route through the same `IntrinsicAbort` path as `panic`, but with a synthesised String message:
  - `unreachable()` → `"entered unreachable code"`
  - `todo()` → `"not yet implemented"`
  - `abort()` → `"abort called"`
  
  New `divergingBuiltinMessage` helper centralises the message table.

- The MIR generator already emits `call void @osty_rt_panic(ptr msg) + unreachable` for `IntrinsicAbort` (#1277), so all three reuse that path verbatim — no separate runtime helper / no separate emit path.

## Before / after

```osty
fn boom() -> Int {
    unreachable()
}
```

**Before** (resolver reject):
```
error[E0745]: cannot find `unreachable` in this scope
```

**After**:
```llvm
@.str.0 = private unnamed_addr constant [25 x i8] c"entered unreachable code\00"
declare void @osty_rt_panic(ptr) noreturn cold nounwind
define i64 @boom() {
  ...
entry:
  call void @osty_rt_panic(ptr @.str.0)
  unreachable
}
```

Same shape applies to `todo()` and `abort()` with their respective messages.

## Test plan
- [x] New `TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic` covers all three callees via a table-driven sub-test.
- [x] `TestGenerateFromMIRPanicLowers` (from #1277) still green.
- [x] `just front` + LIR proto / MIR / check slices green.
- [x] `osty gen` end-to-end probe verified for all three.
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)