### PR TITLE
feat: ONB Phase A2 Week 16 — List<T> generalization (Bool / Float64 / String)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,47 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 16 (List<T> 일반화 — Bool/Float64/String, 2026-05-02)** —
+> ONB가 List<Int> 외의 element type에 대해 push/len을 native lowering.
+> 런타임은 이미 `osty_rt_list_push_i64` 외에 `_i1`/`_f64`/`_string`을
+> 노출하고 있어서 dispatch만 추가하면 됨.
+>
+> 작동:
+>
+> ```osty
+> let mut bools: List<Bool> = []
+> bools.push(true)             // osty_rt_list_push_i1
+>
+> let mut floats: List<Float64> = []
+> floats.push(3.14)            // osty_rt_list_push_f64 — value in d0
+>
+> let mut strs: List<String> = []
+> strs.push("hi")              // osty_rt_list_push_string
+> ```
+>
+> 추가:
+> - 새 runtime symbol 상수: `runtimeSymListPushI1`, `runtimeSymListPushF64`,
+>   `runtimeSymListPushString`
+> - `lowerListPush`이 `value.Type()`로 디스패치 — Int/Bool/String은
+>   x1, Float은 d0 (AAPCS64 FP arg cursor)
+>
+> 검증:
+> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsListGenericsOnDarwinARM64`):
+>   list_bool (3 push → len 3), list_float (2 push → len 2),
+>   list_string (4 push → len 4)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - `list[i]` 인덱스 read/write — `osty_rt_list_get_*` / `_set_*`
+>   디스패치 미구현
+> - `list_pop()` — runtime symbol 다양함, 미구현
+> - 비-empty list literal `[1, 2, 3]` — `AggregateRV(list)` non-empty
+>   case 미구현 (현재 빈 리스트만)
+> - `for x in list` — iterator protocol 미구현
+> - struct/enum element type — `osty_rt_list_push_bytes` 경로 필요
+>
+> 다음 슬라이스 후보: for-in 루프 native lowering (List<T> + 인덱스 read
+> 결합), 또는 struct field mutation.
+>
 > **Slice A2 Week 15 (Float64 + IEEE 산술 + AAPCS64 FP ABI, 2026-05-02)** —
 > ONB가 처음으로 Float64를 native lowering. `let x: Float64 = 3.14` /
 > `(a + b) * 3.0` / `fn double(x: Float64) -> Float64` 같은 코드가

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -905,6 +905,79 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsListGenericsOnDarwinARM64 covers Phase A2
+// Week 16: `List<T>` runtime-call dispatch for T ∈ {Bool, Float64,
+// String}. Every case calls `_osty_rt_list_new`, pushes two scalar
+// values via the type-specific runtime symbol, then prints the list
+// length. Failures point at the wrong runtime symbol or a register
+// mis-routing: a List<Float64> push that goes through x1 instead of
+// d0 would crash the runtime as it reads garbage bits.
+func TestONBBackendBinaryRunsListGenericsOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB List<T> executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "list_bool",
+			src: `fn main() {
+    let mut v: List<Bool> = []
+    v.push(true)
+    v.push(false)
+    v.push(true)
+    println(v.len())
+}`,
+			want: "3\n",
+		},
+		{
+			name: "list_float",
+			src: `fn main() {
+    let mut v: List<Float64> = []
+    v.push(3.14)
+    v.push(2.71)
+    println(v.len())
+}`,
+			want: "2\n",
+		},
+		{
+			name: "list_string",
+			src: `fn main() {
+    let mut v: List<String> = []
+    v.push("hi")
+    v.push("yo")
+    v.push("hey")
+    v.push("bye")
+    println(v.len())
+}`,
+			want: "4\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -34,10 +34,13 @@ const abiSmallStructRegLimit = 2
 // exactly. The Mach-O `bl` encoder prepends the leading underscore for
 // darwin's symbol mangling.
 const (
-	runtimeSymStringConcat = "osty_rt_strings_Concat"
-	runtimeSymListNew      = "osty_rt_list_new"
-	runtimeSymListPushI64  = "osty_rt_list_push_i64"
-	runtimeSymListLen      = "osty_rt_list_len"
+	runtimeSymStringConcat   = "osty_rt_strings_Concat"
+	runtimeSymListNew        = "osty_rt_list_new"
+	runtimeSymListPushI64    = "osty_rt_list_push_i64"
+	runtimeSymListPushI1     = "osty_rt_list_push_i1"
+	runtimeSymListPushF64    = "osty_rt_list_push_f64"
+	runtimeSymListPushString = "osty_rt_list_push_string"
+	runtimeSymListLen        = "osty_rt_list_len"
 )
 
 // LowerMIR lowers the supported MIR slice into ONB's own LIR. Phase 1.0
@@ -1534,8 +1537,11 @@ func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) 
 }
 
 // lowerListPush lowers `IntrinsicListPush(list, value)` into a runtime
-// call. The current slice only handles `List<Int>` — push on i1/f64 lists
-// would call different runtime symbols and is left for the next slice.
+// call. The runtime ships type-specific entry points for the four
+// scalar element widths Osty lists encounter today — i64, i1, f64,
+// and string-pointer — so we dispatch by the value operand's MIR
+// type and route Float values through d0 (the AAPCS64 FP arg slot)
+// instead of x1.
 func (s *lowerState) lowerListPush(instr *mir.IntrinsicInstr) ([]Instr, error) {
 	if len(instr.Args) != 2 {
 		return nil, fmt.Errorf("%w: list_push expects 2 args, got %d", ErrUnsupportedShape, len(instr.Args))
@@ -1544,13 +1550,41 @@ func (s *lowerState) lowerListPush(instr *mir.IntrinsicInstr) ([]Instr, error) {
 	if err != nil {
 		return nil, err
 	}
-	value, err := s.materialiseOperand(instr.Args[1], RegX1)
-	if err != nil {
-		return nil, err
-	}
+	value := instr.Args[1]
+	valueT := value.Type()
 	out := append([]Instr(nil), list...)
-	out = append(out, value...)
-	out = append(out, &BranchLink{Symbol: runtimeSymListPushI64})
+	switch {
+	case valueT == mir.TInt:
+		mat, err := s.materialiseOperand(value, RegX1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &BranchLink{Symbol: runtimeSymListPushI64})
+	case valueT == mir.TBool:
+		mat, err := s.materialiseOperand(value, RegX1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &BranchLink{Symbol: runtimeSymListPushI1})
+	case isFloatABIType(valueT):
+		mat, err := s.materialiseFloatOperand(value, RegD0)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &BranchLink{Symbol: runtimeSymListPushF64})
+	case valueT == mir.TString:
+		mat, err := s.materialiseOperand(value, RegX1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &BranchLink{Symbol: runtimeSymListPushString})
+	default:
+		return nil, fmt.Errorf("%w: list_push value type %s", ErrUnsupportedShape, valueT)
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

ONB now dispatches `IntrinsicListPush` to the right runtime symbol per element type. Previously only `List<Int>` ran natively; everything else fell back to LLVM:

- `List<Int>` → `osty_rt_list_push_i64` (existing)
- `List<Bool>` → `osty_rt_list_push_i1`
- `List<Float64>` → `osty_rt_list_push_f64` (value goes through d0 per AAPCS64 FP cursor, not x1)
- `List<String>` → `osty_rt_list_push_string`

The runtime already exposed all four entry points — this PR is purely a dispatch table on the lowering side.

## Mechanics

`internal/onb/lower.go`:
- New constants: `runtimeSymListPushI1`, `runtimeSymListPushF64`, `runtimeSymListPushString`
- `lowerListPush` switches on `value.Type()` — Int/Bool/String through x1, Float through d0 via `materialiseFloatOperand` (Week 15)

## Out of scope (next slices)

- `list[i]` read/write (`osty_rt_list_get_*` / `_set_*`)
- `list.pop()` (runtime has multiple variants)
- Non-empty list literals `[1, 2, 3]` — `AggregateRV(list)` non-empty case still falls back
- `for x in list` iterator protocol
- Struct/enum element types (`osty_rt_list_push_bytes` with GC offsets)

## Test plan

- [x] `internal/backend/onb_test.go` — 3 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsListGenericsOnDarwinARM64`):
  - `list_bool`: 3 pushes → `len()` == 3
  - `list_float`: 2 pushes → `len()` == 2
  - `list_string`: 4 pushes → `len()` == 4
- [x] All pre-existing ONB + backend (`-short`) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)