### PR TITLE
feat: ONB Phase A2 Week 17 — `for x in list` native lowering

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,68 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 17 (`for x in list` native lowering, 2026-05-02)** —
+> ONB가 `for x in list` 루프를 native lowering. 이전에는 List 인덱스
+> read가 fallback 사유였는데, `LenRV` + `IndexProj` 두 vocab item을
+> 추가해서 모든 element type (Int/Bool/Float64/String) 의 list가 통과.
+>
+> 작동:
+>
+> ```osty
+> let mut v: List<Int> = []
+> v.push(10); v.push(20); v.push(30)
+> let mut sum = 0
+> for x in v {
+>     sum = sum + x
+> }
+> println(sum)                 // 60
+>
+> for i in 0..10 { sum = sum + i }    // Range는 카운터 루프로
+>                                      // lowering — Week 1부터 통과
+> ```
+>
+> Front end MIR 셰이프 (counter + bounded loop):
+>
+> ```
+> _len = len _iter           // LenRV → osty_rt_list_len
+> _idx = const 0
+> bb1: cond = _idx < _len
+> branch cond -> [bb2 (body), bb4 (exit)]
+> bb2: _elem = use _iter[_idx]   // IndexProj → osty_rt_list_get_*
+>      sum = sum + _elem
+> bb3: _idx = _idx + 1
+>      goto bb1
+> ```
+>
+> 추가:
+> - 새 runtime symbol 상수: `runtimeSymListGetI64` / `_I1` / `_F64` /
+>   `_String`
+> - `lowerLenAssign` (LenRV → osty_rt_list_len + capture x0)
+> - `loadIndexedPlaceIntoIntReg` / `loadIndexedPlaceIntoFloatReg` —
+>   IndexProj 감지 시 list_get_* 디스패치 (element type 기준)
+> - `indexCallPrefix` helper — list pointer → x0, index → x1
+> - `listGetSymbol(elem)` — Int/Bool/String/Float dispatch
+> - `materialiseOperand` / `materialiseFloatOperand`이 IndexProj가
+>   있으면 indexed-load 경로로 우회
+> - `collectRValueLocals`이 LenRV.Place를 read로 표시
+> - `collectOperandLocals`이 IndexProj.Index 안의 locals도 수집
+>   (인덱스 local이 slot을 못 받는 회귀 방지)
+>
+> 검증:
+> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsForInLoopOnDarwinARM64`):
+>   range_sum (0..10 sum=45), list_int_sum (10+20+30=60),
+>   list_string_count (4 strings → 4)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - `list[i] = v` write — IndexProj as Dest 미구현
+> - `list.pop()` — runtime symbol 다양 (Option<T> 반환), 미구현
+> - struct/enum element type을 가진 List — push/get_bytes 경로 필요
+> - `for (k, v) in map` — Map iterator 별도
+> - `for x in iter()` — 사용자 정의 Iterable 프로토콜 미구현
+>
+> 다음 슬라이스 후보: struct field mutation (`p.x = 5`) → struct >16B
+> sret-style passing.
+>
 > **Slice A2 Week 16 (List<T> 일반화 — Bool/Float64/String, 2026-05-02)** —
 > ONB가 List<Int> 외의 element type에 대해 push/len을 native lowering.
 > 런타임은 이미 `osty_rt_list_push_i64` 외에 `_i1`/`_f64`/`_string`을

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -978,6 +978,98 @@ func TestONBBackendBinaryRunsListGenericsOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendBinaryRunsForInLoopOnDarwinARM64 covers Phase A2 Week
+// 17: `for x in list` and `for i in range` lowered natively. Range
+// loops were already covered by Week 1 (counter + comparison + branch),
+// but list iteration required two new MIR vocab items: `LenRV` (the
+// loop's upper bound) and `IndexProj` (the per-iteration element
+// load). Both route through the type-specific runtime symbols added
+// in Week 16 (`osty_rt_list_len`, `osty_rt_list_get_*`).
+func TestONBBackendBinaryRunsForInLoopOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB for-in executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			// Range loop: 0+1+2+...+9 = 45. Front end lowers to a
+			// counter loop with BinaryRV comparisons and assignments
+			// — pure stack-everything arithmetic with no runtime
+			// calls. Acts as a sanity gate that the for-in regression
+			// only affects list iteration, not the simpler Range case.
+			name: "range_sum",
+			src: `fn main() {
+    let mut sum = 0
+    for i in 0..10 {
+        sum = sum + i
+    }
+    println(sum)
+}`,
+			want: "45\n",
+		},
+		{
+			// List<Int>: drives osty_rt_list_len + osty_rt_list_get_i64.
+			name: "list_int_sum",
+			src: `fn main() {
+    let mut v: List<Int> = []
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    let mut sum = 0
+    for x in v {
+        sum = sum + x
+    }
+    println(sum)
+}`,
+			want: "60\n",
+		},
+		{
+			// List<String>: drives osty_rt_list_get_string. The
+			// payload itself isn't summed — we only assert iteration
+			// happens by counting elements through a side-channel
+			// integer accumulator.
+			name: "list_string_count",
+			src: `fn main() {
+    let mut v: List<String> = []
+    v.push("a")
+    v.push("b")
+    v.push("c")
+    v.push("d")
+    let mut count = 0
+    for s in v {
+        count = count + 1
+    }
+    println(count)
+}`,
+			want: "4\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -41,6 +41,10 @@ const (
 	runtimeSymListPushF64    = "osty_rt_list_push_f64"
 	runtimeSymListPushString = "osty_rt_list_push_string"
 	runtimeSymListLen        = "osty_rt_list_len"
+	runtimeSymListGetI64     = "osty_rt_list_get_i64"
+	runtimeSymListGetI1      = "osty_rt_list_get_i1"
+	runtimeSymListGetF64     = "osty_rt_list_get_f64"
+	runtimeSymListGetString  = "osty_rt_list_get_string"
 )
 
 // LowerMIR lowers the supported MIR slice into ONB's own LIR. Phase 1.0
@@ -516,9 +520,30 @@ func (s *lowerState) lowerAssign(fn *mir.Function, instr *mir.AssignInstr) ([]In
 		return s.lowerNullaryAssign(rv, slot)
 	case *mir.DiscriminantRV:
 		return s.lowerDiscriminantAssign(rv, slot)
+	case *mir.LenRV:
+		return s.lowerLenAssign(rv, slot)
 	default:
 		return nil, fmt.Errorf("%w: rvalue %T is outside phase 1", ErrUnsupportedShape, instr.Src)
 	}
+}
+
+// lowerLenAssign lowers `dest = len <place>` for List operands. The
+// runtime call returns the length in x0; we capture it into the
+// destination slot. Used by the `for x in list` lowering, which
+// stages `_len = len _iter` as the upper bound of an indexed loop.
+func (s *lowerState) lowerLenAssign(rv *mir.LenRV, destSlot int64) ([]Instr, error) {
+	if rv.Place.HasProjections() {
+		return nil, fmt.Errorf("%w: len of projected place", ErrUnsupportedShape)
+	}
+	srcSlot, ok := s.localSlots[rv.Place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: len of local%d without slot", ErrUnsupportedShape, rv.Place.Local)
+	}
+	return []Instr{
+		&Load64Stack{Dst: RegX0, Offset: srcSlot},
+		&BranchLink{Symbol: runtimeSymListLen},
+		&Store64Stack{Src: RegX0, Offset: destSlot},
+	}, nil
 }
 
 // lowerUseAssign handles `Assign dest := Use(operand)`. The common case
@@ -1410,12 +1435,123 @@ func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error
 			return nil, fmt.Errorf("%w: const %T as operand", ErrUnsupportedShape, o.Const)
 		}
 	case *mir.CopyOp:
+		if hasIndexProjection(o.Place) {
+			return s.loadIndexedPlaceIntoIntReg(o.Place, dst)
+		}
 		return s.loadPlaceIntoReg(o.Place, dst)
 	case *mir.MoveOp:
+		if hasIndexProjection(o.Place) {
+			return s.loadIndexedPlaceIntoIntReg(o.Place, dst)
+		}
 		return s.loadPlaceIntoReg(o.Place, dst)
 	default:
 		return nil, fmt.Errorf("%w: operand %T", ErrUnsupportedShape, op)
 	}
+}
+
+// hasIndexProjection reports whether the place's projection chain
+// contains an IndexProj — `place[idx]`. Used by the operand
+// materialiser to switch from the static slot+offset path to a
+// runtime list_get_* call.
+func hasIndexProjection(place mir.Place) bool {
+	for _, p := range place.Projections {
+		if _, ok := p.(*mir.IndexProj); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// loadIndexedPlaceIntoIntReg lowers `local[idx]` into a runtime call
+// to `osty_rt_list_get_*`, capturing x0 (or the appropriate result
+// register) into `dst`. The destination must be an integer register;
+// Float reads route through `loadIndexedPlaceIntoFloatReg`. The
+// helper assumes the projection chain is exactly one IndexProj — no
+// nested struct/variant chasing — which matches every for-in lowering
+// and direct `list[i]` read the front end emits today.
+func (s *lowerState) loadIndexedPlaceIntoIntReg(place mir.Place, dst Reg) ([]Instr, error) {
+	prefix, idxProj, err := s.indexCallPrefix(place, mir.TInt)
+	if err != nil {
+		return nil, err
+	}
+	sym, err := listGetSymbol(idxProj.ElemType)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), prefix...)
+	out = append(out, &BranchLink{Symbol: sym})
+	if dst != RegX0 {
+		out = append(out, &MovRegReg{Dst: dst, Src: RegX0})
+	}
+	return out, nil
+}
+
+// loadIndexedPlaceIntoFloatReg is the FP twin of
+// loadIndexedPlaceIntoIntReg — it stages `osty_rt_list_get_f64` and
+// the result already arrives in d0, so we only need a final fmov if
+// the caller asked for a different d-register.
+func (s *lowerState) loadIndexedPlaceIntoFloatReg(place mir.Place, dst Reg) ([]Instr, error) {
+	prefix, idxProj, err := s.indexCallPrefix(place, mir.TInt)
+	if err != nil {
+		return nil, err
+	}
+	if !isFloatABIType(idxProj.ElemType) {
+		return nil, fmt.Errorf("%w: indexed float load on non-float list element %s", ErrUnsupportedShape, idxProj.ElemType)
+	}
+	out := append([]Instr(nil), prefix...)
+	out = append(out, &BranchLink{Symbol: runtimeSymListGetF64})
+	if dst != RegD0 {
+		// Bitcast d0 → x9 → dst keeps us within the existing opcode
+		// catalogue — full d-to-d moves aren't surfaced as a LIR
+		// node yet because no other code path needs them.
+		out = append(out,
+			&FmovXFromD{Dst: RegX9, Src: RegD0},
+			&FmovDFromX{Dst: dst, Src: RegX9},
+		)
+	}
+	return out, nil
+}
+
+// indexCallPrefix materialises the list pointer into x0 and the
+// index value into x1, then returns the IndexProj so the caller can
+// route to the right runtime symbol. Used by both the int and float
+// indexed-load paths so list/index plumbing only lives in one place.
+func (s *lowerState) indexCallPrefix(place mir.Place, indexExpected mir.Type) ([]Instr, *mir.IndexProj, error) {
+	if len(place.Projections) != 1 {
+		return nil, nil, fmt.Errorf("%w: indexed place with %d projections", ErrUnsupportedShape, len(place.Projections))
+	}
+	idxProj, ok := place.Projections[0].(*mir.IndexProj)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: expected IndexProj, got %T", ErrUnsupportedShape, place.Projections[0])
+	}
+	listSlot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: indexed read of local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	idxInstrs, err := s.materialiseOperand(idxProj.Index, RegX1)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := append([]Instr(nil), &Load64Stack{Dst: RegX0, Offset: listSlot})
+	out = append(out, idxInstrs...)
+	return out, idxProj, nil
+}
+
+// listGetSymbol picks the runtime list_get entry point for an element
+// type. Symmetric with the dispatch in lowerListPush; new element
+// types add an entry here together with their runtime symbol.
+func listGetSymbol(elem mir.Type) (string, error) {
+	switch {
+	case elem == mir.TInt:
+		return runtimeSymListGetI64, nil
+	case elem == mir.TBool:
+		return runtimeSymListGetI1, nil
+	case elem == mir.TString:
+		return runtimeSymListGetString, nil
+	case isFloatABIType(elem):
+		return runtimeSymListGetF64, nil
+	}
+	return "", fmt.Errorf("%w: list element type %s", ErrUnsupportedShape, elem)
 }
 
 // materialiseFloatOperand emits the instruction sequence that lands a
@@ -1438,8 +1574,14 @@ func (s *lowerState) materialiseFloatOperand(op mir.Operand, dst Reg) ([]Instr, 
 			return nil, fmt.Errorf("%w: float const %T as operand", ErrUnsupportedShape, o.Const)
 		}
 	case *mir.CopyOp:
+		if hasIndexProjection(o.Place) {
+			return s.loadIndexedPlaceIntoFloatReg(o.Place, dst)
+		}
 		return s.loadFloatPlaceIntoReg(o.Place, dst)
 	case *mir.MoveOp:
+		if hasIndexProjection(o.Place) {
+			return s.loadIndexedPlaceIntoFloatReg(o.Place, dst)
+		}
 		return s.loadFloatPlaceIntoReg(o.Place, dst)
 	default:
 		return nil, fmt.Errorf("%w: float operand %T", ErrUnsupportedShape, op)
@@ -1877,6 +2019,11 @@ func collectRValueLocals(rv mir.RValue, out map[mir.LocalID]bool) {
 		// though the place itself isn't an Operand. Force it in so
 		// the slot allocator reserves a slot for the enum value.
 		out[r.Place.Local] = true
+	case *mir.LenRV:
+		// `len _list` reads the list local. Same reasoning as
+		// DiscriminantRV — the place isn't an Operand, so we have
+		// to surface the local explicitly.
+		out[r.Place.Local] = true
 	}
 }
 
@@ -1884,8 +2031,24 @@ func collectOperandLocals(op mir.Operand, out map[mir.LocalID]bool) {
 	switch o := op.(type) {
 	case *mir.CopyOp:
 		out[o.Place.Local] = true
+		collectPlaceProjectionLocals(o.Place, out)
 	case *mir.MoveOp:
 		out[o.Place.Local] = true
+		collectPlaceProjectionLocals(o.Place, out)
+	}
+}
+
+// collectPlaceProjectionLocals walks a place's projection chain for
+// IndexProj entries and records their index operand's locals — the
+// index local has to live in a stack slot so the lowerer can load it
+// into x1 before the runtime list_get_* call.
+func collectPlaceProjectionLocals(place mir.Place, out map[mir.LocalID]bool) {
+	for _, p := range place.Projections {
+		ip, ok := p.(*mir.IndexProj)
+		if !ok {
+			continue
+		}
+		collectOperandLocals(ip.Index, out)
 	}
 }
 


### PR DESCRIPTION
## Summary

ONB now lowers `for x in list` natively for all element types (Int/Bool/Float64/String). The front end already emits a canonical counter-driven loop with `LenRV` + `IndexProj` — this slice teaches ONB to interpret those two MIR vocab items via the Week 16 list runtime symbols.

Range loops (`for i in 0..N`) have lowered to plain counter arithmetic since Week 1; the `range_sum` case acts as a regression sentinel.

## Mechanics

`internal/onb/lower.go`:
- New runtime symbol constants: `runtimeSymListGetI64` / `_I1` / `_F64` / `_String`
- `lowerLenAssign` — `LenRV` → `osty_rt_list_len` + capture x0
- `loadIndexedPlaceIntoIntReg` / `loadIndexedPlaceIntoFloatReg` — detect `IndexProj` and route to `osty_rt_list_get_*` by element type
- `indexCallPrefix` helper stages list ptr → x0, index → x1
- `listGetSymbol` element-type dispatch
- `materialiseOperand` / `materialiseFloatOperand` switch to the indexed path when the place has an IndexProj
- `collectRValueLocals` walks `LenRV.Place`
- `collectOperandLocals` walks `IndexProj.Index` so the loop's index local gets a stack slot

## Out of scope

- `list[i] = v` write (IndexProj-as-Dest)
- `list.pop()` (Option<T> return)
- Struct/enum element types in List
- Map iteration
- User-defined Iterable protocol

## Test plan

- [x] `internal/backend/onb_test.go` — 3 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsForInLoopOnDarwinARM64`):
  - `range_sum`: `for i in 0..10` → `45`
  - `list_int_sum`: `for x in [10, 20, 30]` → `60`
  - `list_string_count`: iterate 4 strings → `4`
- [x] All pre-existing ONB + backend (`-short`) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)