### PR TITLE
selfhost: port panic / unreachable / todo / abort to toolchain MIR

### DIFF
--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -19503,16 +19503,18 @@ fn mirEmitFreshTempName(blockId: Int, instrIdx: Int) -> String {
     "%t.b" + mirGenIntToString(blockId) + ".i" + mirGenIntToString(instrIdx)
 }
 
-/// mirEmitAbortIntrinsic emits `call void @osty_rt_abort(ptr <msg>)`
+/// mirEmitAbortIntrinsic emits `call void @osty_rt_panic(ptr <msg>)`
 /// followed by `unreachable` so the verifier knows control flow ends.
-/// Mirrors the Go-side emitter's pairing.
+/// Mirrors the Go-side `emitAbortIntrinsic` shape — the runtime
+/// helper symbol is `osty_rt_panic` (LANG_SPEC §A.6 prelude
+/// `panic / unreachable / todo / abort` all route here).
 fn mirEmitAbortIntrinsic(instr: MirInstr) -> String {
     let msg = if instr.args.len() >= 1 {
         mirEmitOperand(instr.args[0])
     } else {
         "null"
     }
-    let mut out = "  call void @osty_rt_abort(ptr " + msg + ")\n"
+    let mut out = "  call void @osty_rt_panic(ptr " + msg + ")\n"
     out = out + "  unreachable\n"
     out
 }

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3738,6 +3738,31 @@ pub fn mirLowerCallExprInto(
                 return
             },
         }
+        // 1a. Diverging prelude builtins (LANG_SPEC §A.6):
+        //   - `panic(message: String) -> Never` carries the source-supplied
+        //     message through directly.
+        //   - `unreachable() / todo() / abort()` synthesize canonical
+        //     messages and route through the same `MirIntrinsicAbort`
+        //     path so backends share `osty_rt_panic`.
+        if callee.identName == "panic" && e.callArgs.len() == 1 {
+            let mut args: List<MirOperand> = []
+            args.push(mirLowerExprAsOperand(bs, e.callArgs[0].value))
+            mirLowerEmitInstr(
+                bs,
+                mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicAbort, args, span),
+            )
+            return
+        }
+        let divergingMsg = mirLowerDivergingBuiltinMessage(callee.identName)
+        if divergingMsg != "" && e.callArgs.len() == 0 {
+            let mut args: List<MirOperand> = []
+            args.push(mirOperandConst(mirConstString(divergingMsg)))
+            mirLowerEmitInstr(
+                bs,
+                mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicAbort, args, span),
+            )
+            return
+        }
         let bk = mirLowerBuiltinFreeCallIntrinsic(bs, callee.identName, e.callArgs)
         match bk {
             MirIntrinsicInvalid -> {},
@@ -5867,6 +5892,26 @@ fn mirLowerResultStdlibMethod(name: String) -> MirIntrinsicKind {
     if name == "unwrap" { return MirIntrinsicResultUnwrap }
     if name == "unwrapOr" { return MirIntrinsicResultUnwrapOr }
     MirIntrinsicInvalid
+}
+
+/// mirLowerDivergingBuiltinMessage returns the canonical runtime
+/// message for the no-arg diverging prelude builtins
+/// (`unreachable() / todo() / abort()`, LANG_SPEC §A.6). Returns the
+/// empty string when the name doesn't match — callers treat that as
+/// "not a diverging builtin" and continue routing. Mirrors the
+/// production-side `divergingBuiltinMessage` in
+/// `internal/mir/lower.go`.
+pub fn mirLowerDivergingBuiltinMessage(name: String) -> String {
+    if name == "unreachable" {
+        return "entered unreachable code"
+    }
+    if name == "todo" {
+        return "not yet implemented"
+    }
+    if name == "abort" {
+        return "abort called"
+    }
+    ""
 }
 
 /// mirLowerBuiltinFreeCallIntrinsic recognises prelude-shaped free


### PR DESCRIPTION
## Summary

Mirrors PR #1277 + #1282 (Go-side `internal/mir/lower.go` + `internal/llvmgen/mir_generator.go`) onto the self-host Osty path. Per CLAUDE.md **"Osty 우선"** — those PRs added Go-only feature work and left the self-host port behind; this PR closes that drift.

When the Phase-7 self-host LIR Proto runner gets wired (`internal/llvmgen/lir_proto_runner.go`), it'll produce identical LLVM IR to the legacy MIR-direct path for these four surfaces.

## What changed

- **`toolchain/mir_lower.osty::mirLowerCallExprInto`** — adds bare-Ident `panic` / `unreachable` / `todo` / `abort` dispatch in the same slot the production lowerer uses (between concurrency intrinsic check and `builtinFreeCallIntrinsic`). `panic(msg)` passes the source operand through; the no-arg trio synthesises a canonical String message via the new `mirLowerDivergingBuiltinMessage` helper. All four route through `MirIntrinsicAbort`.

- **`toolchain/mir_generator.osty::mirEmitAbortIntrinsic`** — flips emitted runtime symbol from `osty_rt_abort` (never existed as a public helper) to `osty_rt_panic` (added by #1277's runtime change). Now matches the Go production emitter exactly.

## Test plan

- [x] `just front` green
- [x] `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` green
- [x] `.bin/osty check toolchain/` clean
- [x] No production behavior change today (Phase-7 self-host runner still returns `ErrLIRProtoNotWired`)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)