### PR TITLE
feat: ONB Phase A2 Week 19 — struct >16B sret-style indirect passing

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,60 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 19 (struct >16B sret-style indirect passing, 2026-05-02)** —
+> ONB가 16B 초과 (3-4 필드) all-scalar struct를 AAPCS64 indirect ABI로
+> 처리. `make() -> V3` 같은 함수가 fallback 없이 통과.
+>
+> 작동:
+>
+> ```osty
+> struct V3 { x: Int, y: Int, z: Int }     // 24B
+> fn make() -> V3 { V3 { 10, 20, 30 } }    // sret via x8
+> fn sum(v: V3) -> Int { v.x + v.y + v.z } // indirect arg via x0
+> fn main() {
+>     let v = make()                       // x8 = &v_slot, callee writes through it
+>     println(sum(v))                       // x0 = &v_slot, callee copies into local
+> }
+> ```
+>
+> ABI:
+> - **반환** (sret): caller가 dest slot 할당 → `add x8, sp, #destSlot`
+>   → `bl _callee` → callee가 x8 통해 결과 stamp → caller는 capture 안 함
+> - **인자** (indirect): caller가 `add Xn, sp, #srcSlot` → `bl _callee`
+>   → callee의 prologue가 `[Xn + i*8] → [sp + slot + i*8]`로 필드별 복사
+>
+> 추가:
+> - `abiUsesIndirectStruct(t)` predicate — 3-4 필드 all-scalar struct
+>   에서 true
+> - `abiRegSlots`이 indirect struct에 대해 1을 반환 (포인터 1 reg)
+> - `abiIndirectStructFieldLimit = 4` — 5+ 필드는 여전히 fallback
+> - 새 LIR opcodes: `LoadStackAddress` (`add Xt, sp, #imm`),
+>   `LoadFromReg` (`ldr Xt, [Xn, #imm]`), `StoreToReg` (`str Xt, [Xn, #imm]`)
+> - `paramShuffle` indirect 분기 — argReg를 포인터로 보고 x9 경유 복사
+> - `lowerCall` sret/indirect 분기 — destSlot 자동 할당 + x8 / argReg 세팅
+> - `epilogue` sret 분기 — local $ret slot을 `[x8 + offset]`로 복사
+> - `regX8` 상수 + `xRegisterNumber`이 x8 인식
+> - 새 Mach-O encoder: `encodeLoadStoreReg`
+>
+> 검증:
+> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64`):
+>   make_v3 (24B sret return), sum_v3 (indirect arg), roundtrip_v3
+>   (make→sum 결합 — caller dest slot이 sret 버퍼 + indirect arg
+>   소스로 양쪽 역할), make_v4 (32B 4-필드 상한 케이스)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - 5+ 필드 / 32B 초과 struct — `abiIndirectStructFieldLimit` 캡
+> - struct payload를 가진 enum (Some(V3) 같은) — payload 자체가 indirect
+> - sret 함수 body가 중간에 다른 함수를 호출하는 경우 — x8 save/restore
+>   미구현 (`make()` 같은 leaf 패턴에는 해당 없음)
+> - struct/enum의 indirect 필드 (외부 struct 안에 큰 struct 중첩)
+> - DWARF struct DIE for >16B struct — 작동은 하지만 lldb로
+>   `frame variable v` 출력은 검증 안 함 (small struct 경로와 동일
+>   layout이라 likely OK이지만 회귀 테스트 미작성)
+>
+> 다음 슬라이스 후보: list_set_* (`xs[i] = v`), Float 비교 / 캐스트
+> (fcmpe / fcvtzs / scvtf), 또는 callee-side x8 save/restore.
+>
 > **Slice A2 Week 18 (struct field mutation, 2026-05-02)** —
 > ONB가 `p.x = 5` 같은 projection-as-Dest 어사인을 native lowering.
 > Week 12에서 `p.x` read는 통과했지만 write는 fallback 사유였음. 이번

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1142,6 +1142,101 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64 covers Phase
+// A2 Week 19: structs >16B (3- to 4-field all-scalar) ride the
+// AAPCS64 indirect (sret) ABI. The caller allocates the return
+// buffer and passes its address in x8; the callee writes each field
+// through x8 at epilogue. Indirect arguments use the same model on
+// the integer register cursor — the caller passes `add Xt, sp,
+// #slot` and the callee's prologue copies field-by-field into the
+// param's local slot.
+//
+// Cases:
+//   - **make_v3**: `make() -> V3 { V3 { 10, 20, 30 } }` returns 24B
+//     via x8.
+//   - **sum_v3**: `sum(v: V3) -> Int { v.x + v.y + v.z }` reads all
+//     three fields after the prologue copy.
+//   - **roundtrip_v3**: composes the two — confirms the caller's
+//     dest slot doubles as the sret buffer and is consumed by the
+//     subsequent indirect-arg call without an extra copy.
+//   - **make_v4**: 4-field struct (32B) — exercises the upper end
+//     of the abiIndirectStructFieldLimit cap.
+func TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB sret executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "make_v3",
+			src: `struct V3 { x: Int, y: Int, z: Int }
+fn make() -> V3 { V3 { x: 10, y: 20, z: 30 } }
+fn main() {
+    let v = make()
+    println(v.x)
+    println(v.y)
+    println(v.z)
+}`,
+			want: "10\n20\n30\n",
+		},
+		{
+			name: "sum_v3",
+			src: `struct V3 { x: Int, y: Int, z: Int }
+fn sum(v: V3) -> Int { v.x + v.y + v.z }
+fn main() {
+    let v = V3 { x: 4, y: 5, z: 6 }
+    println(sum(v))
+}`,
+			want: "15\n",
+		},
+		{
+			name: "roundtrip_v3",
+			src: `struct V3 { x: Int, y: Int, z: Int }
+fn make() -> V3 { V3 { x: 100, y: 200, z: 300 } }
+fn sum(v: V3) -> Int { v.x + v.y + v.z }
+fn main() {
+    let v = make()
+    println(sum(v))
+}`,
+			want: "600\n",
+		},
+		{
+			name: "make_v4",
+			src: `struct V4 { a: Int, b: Int, c: Int, d: Int }
+fn make() -> V4 { V4 { a: 1, b: 2, c: 3, d: 4 } }
+fn main() {
+    let v = make()
+    println(v.a + v.b + v.c + v.d)
+}`,
+			want: "10\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -138,6 +138,12 @@ func renderInstrAssembly(b *strings.Builder, target Target, fn Function, instr I
 		b.WriteString("\tret\n")
 	case *Brk:
 		fmt.Fprintf(b, "\tbrk #%d\n", i.Imm)
+	case *LoadStackAddress:
+		fmt.Fprintf(b, "\tadd %s, sp, #%d\n", i.Dst, i.Offset)
+	case *LoadFromReg:
+		fmt.Fprintf(b, "\tldr %s, [%s, #%d]\n", i.Dst, i.Src, i.Offset)
+	case *StoreToReg:
+		fmt.Fprintf(b, "\tstr %s, [%s, #%d]\n", i.Src, i.Base, i.Offset)
 	case *LoadFloat64Stack:
 		fmt.Fprintf(b, "\tldr %s, [sp, #%d]\n", i.Dst, i.Offset)
 	case *StoreFloat64Stack:
@@ -271,6 +277,8 @@ func xRegisterNumber(reg Reg) (uint32, bool) {
 		return 6, true
 	case RegX7:
 		return 7, true
+	case regX8:
+		return 8, true
 	case RegX9:
 		return 9, true
 	case RegX10:

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -339,6 +339,42 @@ type Brk struct {
 
 func (*Brk) instrNode() {}
 
+// LoadStackAddress materialises the address of a stack slot into an
+// x-register: `add Xd, sp, #imm`. The dev backend uses this for the
+// AAPCS64 indirect (sret) ABI — the caller stages the address of the
+// caller-allocated return buffer or the address of an
+// indirect-by-reference argument slot here before branching.
+type LoadStackAddress struct {
+	Dst    Reg
+	Offset int64
+}
+
+func (*LoadStackAddress) instrNode() {}
+
+// LoadFromReg loads a 64-bit word from `[Src + Offset]` into Dst
+// (`ldr Xt, [Xn, #imm]`). The dev backend uses this for the indirect
+// ABI's caller-side memcpy: the prologue receives a pointer in an arg
+// register, then loads each field through it before storing back into
+// the local slot.
+type LoadFromReg struct {
+	Dst    Reg
+	Src    Reg
+	Offset int64
+}
+
+func (*LoadFromReg) instrNode() {}
+
+// StoreToReg stores a 64-bit word from Src into `[Base + Offset]`
+// (`str Xt, [Xn, #imm]`). Used by sret epilogues to write each
+// return-slot half through the caller's buffer pointer in x8.
+type StoreToReg struct {
+	Src    Reg
+	Base   Reg
+	Offset int64
+}
+
+func (*StoreToReg) instrNode() {}
+
 // LoadFloat64Stack loads a Float64 (8-byte slot) from the call frame
 // into a d-register. The encoder picks the `ldr d, [sp, #N]` form
 // when N is 8-byte aligned and ≤ 32760.

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -26,8 +26,22 @@ var fpArgRegs = []Reg{RegD0, RegD1, RegD2, RegD3, RegD4, RegD5, RegD6, RegD7}
 // abiSmallStructRegLimit is the AAPCS64 cutoff for "small struct" handling:
 // up to two integer registers. Sizes ≤ 8 bytes consume one register, sizes
 // 9–16 bytes consume two adjacent registers, anything bigger goes through
-// indirect (sret-style) passing which Phase A2 doesn't lower yet.
+// indirect (sret-style) passing.
 const abiSmallStructRegLimit = 2
+
+// abiIndirectStructFieldLimit caps the size of structs the dev backend
+// will pass / return by reference. The MVP supports 3- and 4-field
+// all-scalar structs (24B / 32B); broader sizes need a memcpy-class
+// approach the slice doesn't ship. Larger structs fall back to the
+// LLVM backend.
+const abiIndirectStructFieldLimit = 4
+
+// regX8 is the AAPCS64 indirect-result register. The caller stores
+// the address of the caller-allocated return buffer here before
+// branching to the callee, and the callee writes the return value
+// through it. ONB's epilogue copies the local `$ret` slot's bytes
+// into [x8 + offset] for sret-returning functions.
+const regX8 Reg = "x8"
 
 // Runtime symbol names. ONB calls into the same `osty_runtime.c` the LLVM
 // backend bundles, so these strings have to match the C function names
@@ -385,8 +399,12 @@ func (s *lowerState) lowerBranchTerm(term *mir.BranchTerm) ([]Instr, error) {
 // landing at slot+N*8 to match the field-projection offsets the rest
 // of the body expects. Float params consume one FP register (d0..d7)
 // from the independent FP cursor — AAPCS64 doesn't merge integer and
-// FP register usage. Parameters that are never read still advance the
-// cursor so subsequent params see the right register.
+// FP register usage. Indirect-passed structs (>16B all-scalar) take
+// one integer register — a *pointer* to a caller-allocated buffer —
+// and the prologue copies the struct's bytes through x9 into the
+// param's local slot so the rest of the body sees the value as if
+// it were locally constructed. Parameters that are never read still
+// advance the cursor so subsequent params see the right register.
 func (s *lowerState) paramShuffle(fn *mir.Function) []Instr {
 	var out []Instr
 	regCursor := 0
@@ -402,6 +420,20 @@ func (s *lowerState) paramShuffle(fn *mir.Function) []Instr {
 				out = append(out, &StoreFloat64Stack{Src: fpArgRegs[fpCursor], Offset: slot})
 			}
 			fpCursor++
+			continue
+		}
+		if s.abiUsesIndirectStruct(loc.Type) {
+			if hasSlot && regCursor < len(argRegs) {
+				size := s.indirectStructByteSize(loc.Type)
+				ptrReg := argRegs[regCursor]
+				for off := int64(0); off < size; off += 8 {
+					out = append(out,
+						&LoadFromReg{Dst: RegX9, Src: ptrReg, Offset: off},
+						&Store64Stack{Src: RegX9, Offset: slot + off},
+					)
+				}
+			}
+			regCursor++
 			continue
 		}
 		slots, ok := s.abiRegSlots(loc.Type)
@@ -448,6 +480,24 @@ func (s *lowerState) epilogue(fn *mir.Function) []Instr {
 			&LoadFloat64Stack{Dst: RegD0, Offset: slot},
 			&Ret{},
 		}
+	}
+	if s.abiUsesIndirectStruct(fn.ReturnType) {
+		// Sret return: the body wrote $ret into its local slot;
+		// copy each 8-byte half through the caller's buffer
+		// pointer in x8. The MVP assumes x8 wasn't clobbered by
+		// the body — make()-style constructors with no
+		// intermediate calls satisfy that. A follow-up that adds
+		// save/restore at the prologue will lift the restriction.
+		size := s.indirectStructByteSize(fn.ReturnType)
+		out := make([]Instr, 0, int(size/8)*2+1)
+		for off := int64(0); off < size; off += 8 {
+			out = append(out,
+				&Load64Stack{Dst: RegX9, Offset: slot + off},
+				&StoreToReg{Src: RegX9, Base: regX8, Offset: off},
+			)
+		}
+		out = append(out, &Ret{})
+		return out
 	}
 	slots, _ := s.abiRegSlots(fn.ReturnType)
 	if slots == 0 {
@@ -846,18 +896,30 @@ func (s *lowerState) abiRegSlots(t mir.Type) (int, bool) {
 		return 1, true
 	}
 	if layout := s.lookupStructLayout(t); layout != nil {
-		// Confirm every field is scalar; mixed structs need a different
-		// strategy (HFA / sret) the dev backend doesn't implement.
 		for _, f := range layout.Fields {
 			if !isABIScalarType(f.Type) {
 				return 0, false
 			}
 		}
 		n := len(layout.Fields)
-		if n == 0 || n > abiSmallStructRegLimit {
+		if n == 0 {
 			return 0, false
 		}
-		return n, true
+		// Small structs (≤2 regs) ride the direct register path
+		// established in Week 13. Larger all-scalar structs go
+		// through the indirect (sret) path: the caller passes a
+		// pointer in one integer register (or x8 for returns) and
+		// the callee dereferences. Indirect uses 1 regular arg
+		// register slot (the pointer), so we report 1 here. The
+		// caller distinguishes direct vs indirect via
+		// abiUsesIndirectStruct(t).
+		if n <= abiSmallStructRegLimit {
+			return n, true
+		}
+		if n <= abiIndirectStructFieldLimit {
+			return 1, true
+		}
+		return 0, false
 	}
 	if layout := s.lookupEnumLayout(t); layout != nil {
 		size := s.enumSlotSize(layout)
@@ -883,6 +945,36 @@ func (s *lowerState) isABIPassableType(t mir.Type) bool {
 	}
 	_, ok := s.abiRegSlots(t)
 	return ok
+}
+
+// abiUsesIndirectStruct reports whether a struct/enum type t passes
+// or returns through the AAPCS64 indirect (sret) ABI: the value is
+// laid out in a caller-allocated buffer whose address rides in a
+// regular argument register (for params) or x8 (for returns). Phase
+// A2 supports 3- to 4-field all-scalar structs this way; up to 16B
+// (1- or 2-field) takes the direct register path.
+func (s *lowerState) abiUsesIndirectStruct(t mir.Type) bool {
+	layout := s.lookupStructLayout(t)
+	if layout == nil {
+		return false
+	}
+	for _, f := range layout.Fields {
+		if !isABIScalarType(f.Type) {
+			return false
+		}
+	}
+	n := len(layout.Fields)
+	return n > abiSmallStructRegLimit && n <= abiIndirectStructFieldLimit
+}
+
+// indirectStructByteSize returns the byte size of an indirect-passed
+// struct slot — n × 8. Caller pre-checks abiUsesIndirectStruct.
+func (s *lowerState) indirectStructByteSize(t mir.Type) int64 {
+	layout := s.lookupStructLayout(t)
+	if layout == nil {
+		return 0
+	}
+	return int64(len(layout.Fields)) * 8
 }
 
 // lookupStructLayout resolves a NamedType to its `mod.Layouts.Structs`
@@ -1384,6 +1476,19 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 	var out []Instr
 	regCursor := 0
 	fpCursor := 0
+	// Sret-style return: callee writes the return value through
+	// x8 into a buffer the caller allocates. The dest local's slot
+	// is that buffer — we just stage `add x8, sp, #destSlot` before
+	// the bl and skip the post-call capture entirely.
+	sretDestSlot := int64(-1)
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		destType := s.destType(instr.Dest.Local)
+		if s.abiUsesIndirectStruct(destType) {
+			if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+				sretDestSlot = slot
+			}
+		}
+	}
 	for _, arg := range instr.Args {
 		argType := arg.Type()
 		if isFloatABIType(argType) {
@@ -1396,6 +1501,19 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 			}
 			out = append(out, mat...)
 			fpCursor++
+			continue
+		}
+		if s.abiUsesIndirectStruct(argType) {
+			// Pass &(srcLocal_slot) in argRegs[regCursor]. The arg
+			// is always a Copy / Move of a local — front-end never
+			// emits struct literals as call arguments — so we
+			// resolve to a slot and emit `add Xt, sp, #slot`.
+			ptrInstrs, err := s.indirectArgAddress(arg, argRegs[regCursor])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, ptrInstrs...)
+			regCursor++
 			continue
 		}
 		slots, ok := s.abiRegSlots(argType)
@@ -1424,8 +1542,16 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 		}
 		regCursor += slots
 	}
+	// Stage x8 = &destSlot last so the address materialisation
+	// happens after every other arg-reg setup — this matches the
+	// AAPCS64 convention and avoids accidentally clobbering x8 with
+	// an arg materialiser that happens to use it as scratch (none
+	// today, but keeps the slot order future-proof).
+	if sretDestSlot >= 0 {
+		out = append(out, &LoadStackAddress{Dst: regX8, Offset: sretDestSlot})
+	}
 	out = append(out, &BranchLink{Symbol: ref.Symbol})
-	if instr.Dest != nil && !instr.Dest.HasProjections() {
+	if instr.Dest != nil && !instr.Dest.HasProjections() && sretDestSlot < 0 {
 		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
 			destType := s.destType(instr.Dest.Local)
 			if isFloatABIType(destType) {
@@ -1444,6 +1570,32 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 	}
 	return out, nil
 }
+
+// indirectArgAddress produces the instructions that land &(src_slot)
+// in the destination argument register. Indirect args are always
+// passed as a Copy or Move of a stack-allocated local; struct
+// literals in argument position would need a pre-materialise pass we
+// don't ship yet.
+func (s *lowerState) indirectArgAddress(arg mir.Operand, dst Reg) ([]Instr, error) {
+	var place mir.Place
+	switch o := arg.(type) {
+	case *mir.CopyOp:
+		place = o.Place
+	case *mir.MoveOp:
+		place = o.Place
+	default:
+		return nil, fmt.Errorf("%w: indirect struct arg operand %T", ErrUnsupportedShape, arg)
+	}
+	if place.HasProjections() {
+		return nil, fmt.Errorf("%w: indirect struct arg with projection", ErrUnsupportedShape)
+	}
+	slot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: indirect struct arg from local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	return []Instr{&LoadStackAddress{Dst: dst, Offset: slot}}, nil
+}
+
 
 // destType returns the MIR type of a local in the current function. The
 // caller already knows the local is a Dest of a CallInstr, so a missing

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -984,6 +984,24 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 					return fmt.Errorf("onb: brk encoding: %w", err)
 				}
 				enc.code = appendU32LE(enc.code, word)
+			case *LoadStackAddress:
+				word, err := encodeAddSubImm(0x91000000, i.Dst, RegSP, uint64(i.Offset))
+				if err != nil {
+					return fmt.Errorf("onb: stack-address add: %w", err)
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *LoadFromReg:
+				word, err := encodeLoadStoreReg(0xf9400000, i.Dst, i.Src, i.Offset)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
+			case *StoreToReg:
+				word, err := encodeLoadStoreReg(0xf9000000, i.Src, i.Base, i.Offset)
+				if err != nil {
+					return err
+				}
+				enc.code = appendU32LE(enc.code, word)
 			case *LoadFloat64Stack:
 				word, err := encodeFPStack(0xfd400000, i.Dst, i.Offset)
 				if err != nil {
@@ -1387,6 +1405,30 @@ func encodeFmovXFromD(dst, src Reg) (uint32, error) {
 		return 0, fmt.Errorf("%w: fmov src %s", ErrNotImplemented, src)
 	}
 	return 0x9e660000 | (n << 5) | d, nil
+}
+
+// encodeLoadStoreReg encodes `LDR Xt, [Xn, #imm]` (base 0xf9400000)
+// or `STR Xt, [Xn, #imm]` (base 0xf9000000) for 64-bit register-
+// relative loads and stores. Used by the indirect-ABI prologue and
+// epilogue to memcpy through caller-provided pointers. The immediate
+// is 8-byte scaled (so the addressable range is 0..32760).
+func encodeLoadStoreReg(base uint32, t, n Reg, offset int64) (uint32, error) {
+	if offset < 0 || offset%8 != 0 {
+		return 0, fmt.Errorf("%w: load/store reg offset %d", ErrNotImplemented, offset)
+	}
+	tNum, ok := xRegisterNumber(t)
+	if !ok {
+		return 0, fmt.Errorf("%w: load/store reg target %s", ErrNotImplemented, t)
+	}
+	nNum, ok := xRegisterNumber(n)
+	if !ok {
+		return 0, fmt.Errorf("%w: load/store reg base %s", ErrNotImplemented, n)
+	}
+	scaled := uint32(offset / 8)
+	if scaled > 0xfff {
+		return 0, fmt.Errorf("%w: load/store offset %d too large", ErrNotImplemented, offset)
+	}
+	return base | (scaled << 10) | (nNum << 5) | tNum, nil
 }
 
 // encodeFPArith encodes the FP binary arithmetic family


### PR DESCRIPTION
## Summary

ONB now handles 3- and 4-field all-scalar structs (24B / 32B) at the function boundary via the AAPCS64 indirect ABI. The two patterns this unlocks:

```osty
struct V3 { x: Int, y: Int, z: Int }
fn make() -> V3 { V3 { 10, 20, 30 } }       // sret return via x8
fn sum(v: V3) -> Int { v.x + v.y + v.z }    // indirect arg via x0
fn main() {
    let v = make()
    println(sum(v))                          // 60
}
```

## ABI

- **Return (sret)**: caller allocates dest slot → `add x8, sp, #destSlot` → `bl _callee` → callee writes through x8 → caller does NOT capture.
- **Argument (indirect)**: caller passes `add Xn, sp, #srcSlot` → `bl _callee` → callee's prologue copies `[Xn + i*8] → [sp + slot + i*8]` field by field.

## Mechanics

`internal/onb/lower.go`:
- `abiUsesIndirectStruct(t)` predicate — 3- to 4-field all-scalar struct → true
- `abiRegSlots` returns 1 for indirect (the pointer reg)
- `abiIndirectStructFieldLimit = 4` cap
- `paramShuffle` indirect branch: argReg as pointer, x9 as load scratch
- `lowerCall` sret + indirect branches: stages `add x8, sp, #destSlot` for sret returns; `add Xn, sp, #srcSlot` for indirect args
- `epilogue` sret branch: copies `$ret` slot bytes to `[x8 + offset]`

LIR + encoders:
- `LoadStackAddress` (`add Xd, sp, #imm`) — produces `&slot`
- `LoadFromReg` / `StoreToReg` — `ldr/str Xt, [Xn, #imm]` for prologue/epilogue memcpy
- `regX8` constant; `xRegisterNumber` recognises x8
- New Mach-O encoder: `encodeLoadStoreReg`
- Asm renderer covers all three new opcodes

## Out of scope

- 5+ field structs (>32B) — `abiIndirectStructFieldLimit` cap
- Sret functions with intermediate calls (no x8 save/restore — the MVP assumes leaf-style constructors like `make()`)
- struct payload in enum variants (`Some(V3)`)
- `xs[i] = v` (IndexProj-as-Dest)
- DWARF struct DIE regression test for big structs (likely works since the slot layout is identical to the small-struct path, but unverified)

## Test plan

- [x] `internal/backend/onb_test.go` — 4 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsLargeStructSretOnDarwinARM64`):
  - `make_v3`: 24B sret return → `"10\n20\n30\n"`
  - `sum_v3`: indirect arg, scalar Int return → `"15"`
  - `roundtrip_v3`: make() + sum(v) — caller's dest slot doubles as sret buffer AND indirect-arg source → `"600"`
  - `make_v4`: 32B 4-field upper-cap case → `"10"`
- [x] All pre-existing ONB + backend (`-short`) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)