### PR TITLE
feat: lower prelude dbg(value) as identity passthrough

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1509,6 +1509,68 @@ func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRDbgLowersAsIdentity pins the prelude diagnostic
+// builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10). The current
+// implementation lowers `dbg(x)` as identity passthrough — the
+// destination receives the operand directly with no runtime call.
+// Closes the LLVM000 "unresolved symbol dbg" gap that previously
+// rejected any program calling `dbg(...)`. A future refinement adds
+// the eprintln (location + expr text + value) shape.
+func TestGenerateFromMIRDbgLowersAsIdentity(t *testing.T) {
+	// fn check(n: Int) -> Int {
+	//     let x = dbg(n)
+	//     x + 1
+	// }
+	fn := &ir.FnDecl{
+		Name:   "check",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "x",
+					Type: ir.TInt,
+					Value: &ir.CallExpr{
+						Callee: &ir.Ident{Name: "dbg", Kind: ir.IdentBuiltin, T: &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}},
+						Args:   []ir.Arg{{Value: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt}}},
+						T:      ir.TInt,
+					},
+				},
+			},
+			Result: &ir.BinaryExpr{
+				Op:    ir.BinAdd,
+				Left:  &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt},
+				Right: &ir.IntLit{Text: "1", T: ir.TInt},
+				T:     ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/dbg_lower.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// Identity passthrough means no `@dbg` call survives — the
+	// argument flows straight into the next instruction.
+	if strings.Contains(got, "@dbg(") {
+		t.Fatalf("dbg should lower as identity (no @dbg call), got:\n%s", got)
+	}
+	if strings.Contains(got, "unresolved symbol dbg") {
+		t.Fatalf("output still contains unresolved-symbol diagnostic:\n%s", got)
+	}
+	for _, want := range []string{
+		"define i64 @check(i64",
+		"add i64",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIROptionUnwrapLowers pins the MIR emitter for the four
 // Option<T> method intrinsics (isSome, isNone, unwrap, unwrapOr). The
 // underlying lowering keeps Option<T> as `{ i64 disc, i64 payload }`

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4182,6 +4182,20 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			})
 			return
 		}
+		// `dbg<T>(value: T) -> T` — diagnostic prelude builtin
+		// (LANG_SPEC §A.10). Today: identity passthrough — assign
+		// the argument operand into the destination. A future
+		// refinement adds the eprintln (location + expr text + value)
+		// shape; the identity step keeps user programs compiling now.
+		if id.Name == "dbg" && len(c.Args) == 1 && dest != nil {
+			valueOp := bs.lowerExprAsOperand(c.Args[0].Value)
+			bs.emit(&AssignInstr{
+				Dest:  *dest,
+				Src:   &UseRV{Op: valueOp},
+				SpanV: c.SpanV,
+			})
+			return
+		}
 		if module, name, ok := loweredStdlibFreeSymbol(id.Name); ok {
 			switch module {
 			case "bytes":

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -36651,6 +36651,14 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "unreachable", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	checkRegisterFn(env, &CheckFnSig{name: "todo", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	checkRegisterFn(env, &CheckFnSig{name: "abort", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// `dbg<T>(value: T) -> T` — diagnostic builtin (LANG_SPEC §A.10
+	// `dbg(expr)`). The MIR lowerer treats it as an identity
+	// passthrough today; a future refinement adds the eprintln
+	// (location + expr text + value) shape.
+	{
+		tDbgT := tyNamed(env.tys, "T", make([]int, 0, 1))
+		checkRegisterFn(env, &CheckFnSig{name: "dbg", owner: "", receiverTy: -1, retTy: tDbgT, paramNames: []string{"value"}, paramTys: []int{tDbgT}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	}
 	// Osty: /tmp/selfhost_merged.osty:16088:5
 	tUnit_ := tUnit(env.tys)
 	_ = tUnit_

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3763,6 +3763,17 @@ pub fn mirLowerCallExprInto(
             )
             return
         }
+        // 1b. `dbg<T>(value: T) -> T` — diagnostic prelude builtin
+        //     (LANG_SPEC §A.10). Today: identity passthrough — assign
+        //     the argument operand into the destination so the value
+        //     flows through unchanged. A future refinement adds the
+        //     eprintln (location + expr text + value) shape; the
+        //     identity step keeps user programs compiling now.
+        if callee.identName == "dbg" && e.callArgs.len() == 1 {
+            let valueOp = mirLowerExprAsOperand(bs, e.callArgs[0].value)
+            mirLowerEmitInstr(bs, mirAssignInstr(dest, mirRVUse(valueOp), span))
+            return
+        }
         let bk = mirLowerBuiltinFreeCallIntrinsic(bs, callee.identName, e.callArgs)
         match bk {
             MirIntrinsicInvalid -> {},


### PR DESCRIPTION
## Summary
Closes the LLVM000 / E0745 gap that previously rejected programs using `dbg(...)`: the resolver had it in the prelude but the self-host checker only knew `<alias>.dbg` (qualified call via `std.debug`), so bare `dbg(n)` raised **"cannot find `dbg` in this scope"** with a misleading "did you mean `debug`?" hint.

Both Osty self-host and Go production paths kept in sync this time (per CLAUDE.md **"Osty 우선"**).

## What changed

- **`internal/selfhost/generated.go`** — adds free `dbg<T>(value: T) -> T` `CheckFnSig` registration alongside the existing `panic` / `unreachable` / `todo` / `abort` entries.

- **`toolchain/mir_lower.osty::mirLowerCallExprInto`** — bare-Ident `dbg(arg)` lowers as identity passthrough: `Assign(dest, Use(arg))`. No runtime call, no side effects today; a future refinement adds the eprintln (location + expr text + value) shape `dbg(expr)` is documented to produce in LANG_SPEC §A.10.

- **`internal/mir/lower.go::lowerCallExprInto`** — same identity passthrough so the production MIR-direct path matches the self-host port byte-for-byte.

## Before / after

```osty
fn check(n: Int) -> Int {
    let x = dbg(n)
    x + 1
}
```

**Before**:
```
error[E0745]: cannot find `dbg` in this scope
  --> /tmp/d/main.osty:2:13
    |
  2 |     let x = dbg(n)
    |             ^^^
    |
  = note: hint: did you mean `debug`?
```

**After**:
```llvm
define i64 @check(i64 %arg0) {
  ; ... store n into local ...
  %t1 = load i64, ptr %l2
  %t2 = add i64 %t1, 1
  ret i64 ...
}
```

(The `dbg(n)` literally vanishes from the IR — identity passthrough means the operand flows straight into the next instruction.)

## Test plan
- [x] New `TestGenerateFromMIRDbgLowersAsIdentity` asserts no `@dbg` call survives + envelope shape preserved.
- [x] `just front` green.
- [x] `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green.
- [x] `osty gen` end-to-end probe verified.
- [ ] CI 그린 확인.

## Future refinement
A follow-up can extend `dbg` to actually print location + expression text + value (per LANG_SPEC §A.10). Today's identity passthrough keeps the door open for that without breaking call-site code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)