### PR TITLE
feat: ONB Phase A2 Week 20 — closures (env alloc + indirect call)

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,65 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 20 (closures — value + indirect call, 2026-05-02)** —
+> ONB가 처음으로 클로저를 native lowering. `let f = |x| x + n`,
+> `xs.filter(|x| x > 0)` 같은 패턴이 fallback 없이 통과 (filter 자체는
+> 메서드 디스패치 별도). Tier 1의 단일-최대 unlock — Osty stdlib API의
+> 대부분이 클로저를 받기 때문.
+>
+> 작동:
+>
+> ```osty
+> fn main() {
+>     let n = 100
+>     let f = |x: Int| x + n           // env 할당, n을 capture[0]에 stamp
+>     println(f(10))                    // x0 = env, x1 = 10, blr [env+0] → 110
+> }
+> ```
+>
+> 추가:
+> - `runtimeSymClosureEnvAllocV2 = "osty.rt.closure_env_alloc_v2"` —
+>   런타임이 `__asm__("osty.rt....")`로 export한 dotted symbol
+> - `closureEnvCapturesOffset = 24` — 런타임 env 헤더 (`fn_ptr` 8B +
+>   `capture_count` 8B + `pointer_bitmap` 8B) 다음부터 captures 시작
+> - 새 LIR opcodes:
+>   - `BranchLinkReg{Reg}` — `blr Xn` 간접 호출
+>   - `LoadSymbolAddress{Dst, Symbol}` — `adrp + add` 함수/데이터 심볼
+>     주소 materialise (LoadCStringAddress의 일반화)
+> - `isClosureScalarType(t)` — `*ir.FnType` + `NamedType{ClosureEnv,
+>   Builtin}` 둘 다 1-reg 포인터로 분류
+> - `lowerClosureLiteralAssign` — alloc_v2 호출 → x10에 env stash →
+>   fn pointer를 [env+0]에 store → 각 capture를 [env+24+i*8]에 store →
+>   env pointer를 dest slot에 store
+> - `lowerIndirectCall` — closure local → x0, user args → x1.., d0..,
+>   `ldr x9, [x0, #0]` (fn ptr load) → `blr x9` → 반환 캡처
+> - `loadEnvProjection` — `_env.*.{i}` MIR 패턴 lowering. Field 0 →
+>   offset 0 (fn pointer), Field N (N≥1) → 24 + (N-1)*8 (capture N-1).
+>   FieldProj와 TupleProj 둘 다 받음 (front end가 capture에 대해
+>   TupleProj 사용)
+> - `collectReadLocals`이 `IndirectCall.Callee`를 walk해 closure local이
+>   slot을 받도록 보장
+>
+> 검증:
+> - E2E binary smoke 3개 (`TestONBBackendBinaryRunsClosuresOnDarwinARM64`):
+>   no_capture (`|x| x + 1` 두 번 호출), single_capture (`|x| x + n`
+>   with n=100), two_captures (`|x| x + a + b` with a=10, b=20)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - **pointer_bitmap = 0 고정** — GC가 capture를 모두 ptr로 trace하지
+>   못해 false retention 가능. LLVM 백엔드는 capture 타입을 보고 정확한
+>   bitmap을 계산. ONB는 dev path이므로 trade-off는 수용 가능하나,
+>   GC stress 테스트가 false root를 잡아내면 작업 필요
+> - **Float capture** — 코드 경로는 있지만 e2e 검증 안 함
+> - **String/List/struct/enum capture** — pointer 1-reg에 들어가지만
+>   정확한 GC tracing 미구현
+> - **고차 함수의 클로저 리턴** (`fn make_adder(n: Int) -> fn(Int) -> Int`)
+>   — 동작해야 하지만 미검증
+> - **클로저를 인자로 다른 클로저에 전달** — 미검증
+>
+> 다음 슬라이스 후보: Map<K,V> intrinsics, 메서드 디스패치, String
+> 메서드, 제네릭 함수 검증.
+>
 > **Slice A2 Week 19 (struct >16B sret-style indirect passing, 2026-05-02)** —
 > ONB가 16B 초과 (3-4 필드) all-scalar struct를 AAPCS64 indirect ABI로
 > 처리. `make() -> V3` 같은 함수가 fallback 없이 통과.

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1237,6 +1237,83 @@ fn main() {
 	}
 }
 
+// TestONBBackendBinaryRunsClosuresOnDarwinARM64 covers Phase A2 Week
+// 20: closure values and indirect call lowering. The runtime allocates
+// the env via `osty.rt.closure_env_alloc_v2`; the lowerer stores the
+// lifted-fn pointer at offset 0 and each capture at offset 24+i*8;
+// indirect call loads the fn pointer from the env's first slot and
+// `blr`s into it with the env riding x0 as the closure-env arg.
+//
+// Cases:
+//   - **no_capture**: a closure that reads only its user arg —
+//     drives the alloc + indirect-call paths without any env-deref
+//     reads.
+//   - **single_capture**: captures one Int — exercises the
+//     alloc/store/load chain through the env's capture region (offset
+//     24 → MIR's `_env.*.1` projection, lowered via `loadEnvProjection`).
+//   - **two_captures**: captures two Ints — verifies the per-capture
+//     stride matches the runtime layout (offset 32 for capture[1]).
+func TestONBBackendBinaryRunsClosuresOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB closure executable smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "no_capture",
+			src: `fn main() {
+    let f = |x: Int| x + 1
+    println(f(10))
+    println(f(99))
+}`,
+			want: "11\n100\n",
+		},
+		{
+			name: "single_capture",
+			src: `fn main() {
+    let n = 100
+    let f = |x: Int| x + n
+    println(f(10))
+}`,
+			want: "110\n",
+		},
+		{
+			name: "two_captures",
+			src: `fn main() {
+    let a = 10
+    let b = 20
+    let f = |x: Int| x + a + b
+    println(f(5))
+}`,
+			want: "35\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/asm.go
+++ b/internal/onb/asm.go
@@ -144,6 +144,11 @@ func renderInstrAssembly(b *strings.Builder, target Target, fn Function, instr I
 		fmt.Fprintf(b, "\tldr %s, [%s, #%d]\n", i.Dst, i.Src, i.Offset)
 	case *StoreToReg:
 		fmt.Fprintf(b, "\tstr %s, [%s, #%d]\n", i.Src, i.Base, i.Offset)
+	case *LoadSymbolAddress:
+		fmt.Fprintf(b, "\tadrp %s, %s@PAGE\n", i.Dst, asmSymbolName(target, i.Symbol))
+		fmt.Fprintf(b, "\tadd %s, %s, %s@PAGEOFF\n", i.Dst, i.Dst, asmSymbolName(target, i.Symbol))
+	case *BranchLinkReg:
+		fmt.Fprintf(b, "\tblr %s\n", i.Reg)
 	case *LoadFloat64Stack:
 		fmt.Fprintf(b, "\tldr %s, [sp, #%d]\n", i.Dst, i.Offset)
 	case *StoreFloat64Stack:

--- a/internal/onb/dwarf.go
+++ b/internal/onb/dwarf.go
@@ -458,6 +458,8 @@ func instructionByteSize(instr Instr) uint64 {
 		return uint64(movImm64WordCount(i.Imm)) * 4
 	case *LoadCStringAddress:
 		return 8 // adrp + add (Mach-O variant) / adrp + add (ELF)
+	case *LoadSymbolAddress:
+		return 8 // adrp + add — same shape as LoadCStringAddress
 	default:
 		return 4
 	}

--- a/internal/onb/lir.go
+++ b/internal/onb/lir.go
@@ -322,6 +322,33 @@ type BranchLink struct {
 
 func (*BranchLink) instrNode() {}
 
+// BranchLinkReg is the indirect call form: `blr Xn`. Reads the target
+// PC from the named register, pushes the return address into x30, and
+// branches. The dev backend uses this for closure dispatch — the env
+// pointer's first slot holds the lifted-fn address; we load it into a
+// scratch register and `blr` into it. The closure ABI also requires
+// the env pointer itself to be in x0 before the branch (per the Phase
+// A4 fn-value runtime contract); the lowerer stages that explicitly.
+type BranchLinkReg struct {
+	Reg Reg
+}
+
+func (*BranchLinkReg) instrNode() {}
+
+// LoadSymbolAddress materialises the runtime address of a symbol
+// (function or data) into an x-register via the platform's
+// PC-relative addressing form (`adrp` + `add` on Mach-O/ELF). Used
+// to land the lifted fn pointer at offset 0 of a freshly-allocated
+// closure env. Distinct from `LoadCStringAddress` because that one
+// is hard-wired to `__cstring` entries; symbols here can be local
+// fns or runtime exports.
+type LoadSymbolAddress struct {
+	Dst    Reg
+	Symbol string
+}
+
+func (*LoadSymbolAddress) instrNode() {}
+
 // Ret returns to the platform entry trampoline. For `main`, the return code is
 // already in w0.
 type Ret struct{}

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -48,18 +48,29 @@ const regX8 Reg = "x8"
 // exactly. The Mach-O `bl` encoder prepends the leading underscore for
 // darwin's symbol mangling.
 const (
-	runtimeSymStringConcat   = "osty_rt_strings_Concat"
-	runtimeSymListNew        = "osty_rt_list_new"
-	runtimeSymListPushI64    = "osty_rt_list_push_i64"
-	runtimeSymListPushI1     = "osty_rt_list_push_i1"
-	runtimeSymListPushF64    = "osty_rt_list_push_f64"
-	runtimeSymListPushString = "osty_rt_list_push_string"
-	runtimeSymListLen        = "osty_rt_list_len"
-	runtimeSymListGetI64     = "osty_rt_list_get_i64"
-	runtimeSymListGetI1      = "osty_rt_list_get_i1"
-	runtimeSymListGetF64     = "osty_rt_list_get_f64"
-	runtimeSymListGetString  = "osty_rt_list_get_string"
+	runtimeSymStringConcat       = "osty_rt_strings_Concat"
+	runtimeSymListNew            = "osty_rt_list_new"
+	runtimeSymListPushI64        = "osty_rt_list_push_i64"
+	runtimeSymListPushI1         = "osty_rt_list_push_i1"
+	runtimeSymListPushF64        = "osty_rt_list_push_f64"
+	runtimeSymListPushString     = "osty_rt_list_push_string"
+	runtimeSymListLen            = "osty_rt_list_len"
+	runtimeSymListGetI64         = "osty_rt_list_get_i64"
+	runtimeSymListGetI1          = "osty_rt_list_get_i1"
+	runtimeSymListGetF64         = "osty_rt_list_get_f64"
+	runtimeSymListGetString      = "osty_rt_list_get_string"
+	// closure_env_alloc_v2 is exported by the runtime under the dotted
+	// (LLVM-shaped) name via __asm__("osty.rt..."). Mach-O symbol
+	// encoding prepends the leading underscore, matching the call site.
+	runtimeSymClosureEnvAllocV2 = "osty.rt.closure_env_alloc_v2"
 )
+
+// closureEnvCapturesOffset is the byte offset within an
+// `osty_rt_closure_env` where the captures array begins. The runtime
+// header is `{ ptr fn (8B); i64 capture_count (8B); u64
+// pointer_bitmap (8B); ptr captures[] }`. Kept in sync with the LLVM
+// backend's matching constant by sharing the layout in C.
+const closureEnvCapturesOffset = 24
 
 // LowerMIR lowers the supported MIR slice into ONB's own LIR. Phase 1.0
 // handled hello world; Phase A2 Week 1 added local Int variables and binary
@@ -750,9 +761,85 @@ func (s *lowerState) lowerAggregateAssign(rv *mir.AggregateRV, destSlot int64) (
 		return s.lowerStructLiteralAssign(rv, destSlot)
 	case mir.AggEnumVariant:
 		return s.lowerEnumVariantAssign(rv, destSlot)
+	case mir.AggClosure:
+		return s.lowerClosureLiteralAssign(rv, destSlot)
 	default:
 		return nil, fmt.Errorf("%w: aggregate kind %v", ErrUnsupportedShape, rv.Kind)
 	}
+}
+
+// lowerClosureLiteralAssign lowers `dest = aggregate closure(<fnConst>,
+// <captures...>)`. Layout:
+//
+//  1. Allocate env via osty_rt_closure_env_alloc_v2(N, site, bitmap).
+//     Returns the env pointer in x0.
+//  2. Move env to x10 so we can stage the fn-pointer + captures
+//     without losing the base.
+//  3. Load lifted-fn address into x9 via adrp/add and store at
+//     [x10 + 0].
+//  4. For each capture i, materialise the value and store at
+//     [x10 + 24 + i*8]. Captures are scalar / pointer types; Float
+//     captures route through d8 + StoreToReg via x9 bitcast.
+//  5. Store the env pointer (still in x10) into the destination
+//     slot.
+//
+// The MVP keeps `pointer_bitmap` at 0 — the GC may then false-retain
+// integer-sized scalar captures that happen to look like pointers.
+// That's a known limitation; the LLVM backend computes a real
+// bitmap by inspecting capture types (see `internal/llvmgen/fn_value.go`).
+// For ONB's dev path this is acceptable trade-off; bitmap accuracy
+// becomes important when GC-stress tests start flagging false roots.
+func (s *lowerState) lowerClosureLiteralAssign(rv *mir.AggregateRV, destSlot int64) ([]Instr, error) {
+	if len(rv.Fields) == 0 {
+		return nil, fmt.Errorf("%w: closure literal needs at least the fn-const field", ErrUnsupportedShape)
+	}
+	fnConst, ok := rv.Fields[0].(*mir.ConstOp)
+	if !ok {
+		return nil, fmt.Errorf("%w: closure literal field 0 is %T, want ConstOp", ErrUnsupportedShape, rv.Fields[0])
+	}
+	fc, ok := fnConst.Const.(*mir.FnConst)
+	if !ok || fc.Symbol == "" {
+		return nil, fmt.Errorf("%w: closure literal field 0 is %T, want FnConst", ErrUnsupportedShape, fnConst.Const)
+	}
+	captureCount := int64(len(rv.Fields) - 1)
+	siteLabel := s.addCString("onb.closure.env")
+	out := []Instr{
+		// alloc_v2(capture_count, site, bitmap=0)
+		&MovImm64{Dst: RegX0, Imm: captureCount},
+		&LoadCStringAddress{Dst: RegX1, Label: siteLabel},
+		&MovImm64{Dst: RegX2, Imm: 0},
+		&BranchLink{Symbol: runtimeSymClosureEnvAllocV2},
+		// stash env pointer in x10 so subsequent stores can use a
+		// stable base — x9 is reused as the value scratch.
+		&MovRegReg{Dst: RegX10, Src: RegX0},
+		// fn pointer at [env + 0]
+		&LoadSymbolAddress{Dst: RegX9, Symbol: fc.Symbol},
+		&StoreToReg{Src: RegX9, Base: RegX10, Offset: 0},
+	}
+	for i, capture := range rv.Fields[1:] {
+		captureOffset := int64(closureEnvCapturesOffset + i*8)
+		captureT := capture.Type()
+		if isFloatABIType(captureT) {
+			mat, err := s.materialiseFloatOperand(capture, RegD8)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mat...)
+			out = append(out,
+				&FmovXFromD{Dst: RegX9, Src: RegD8},
+				&StoreToReg{Src: RegX9, Base: RegX10, Offset: captureOffset},
+			)
+			continue
+		}
+		mat, err := s.materialiseOperand(capture, RegX9)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		out = append(out, &StoreToReg{Src: RegX9, Base: RegX10, Offset: captureOffset})
+	}
+	out = append(out, &Store64Stack{Src: RegX10, Offset: destSlot})
+	return out, nil
 }
 
 // lowerEnumVariantAssign writes an enum literal: discriminant value
@@ -870,11 +957,32 @@ func (s *lowerState) lowerStructLiteralAssign(rv *mir.AggregateRV, destSlot int6
 
 // isABIScalarType reports whether a MIR type fits cleanly in one AAPCS64
 // integer register. Phase A2 accepts Int (i64), Bool (i1), String (ptr),
-// and Float (Float / Float64 — IEEE 754 double, lives in a d-register at
-// the call boundary but counts as a scalar for slot allocation). Lists
-// and structs need indirect passing and are deferred to a future slice.
+// Float (Float / Float64 — d-register at the call boundary, scalar for
+// slot allocation), and pointer-shaped types (FnType / ClosureEnv —
+// closure environments live on the heap; the local holds an 8-byte
+// pointer to them).
 func isABIScalarType(t mir.Type) bool {
-	return t == mir.TInt || t == mir.TBool || t == mir.TString || isFloatABIType(t)
+	if t == mir.TInt || t == mir.TBool || t == mir.TString {
+		return true
+	}
+	if isFloatABIType(t) {
+		return true
+	}
+	return isClosureScalarType(t)
+}
+
+// isClosureScalarType reports whether t is a closure-shaped pointer
+// — a function value (`fn(A) -> R`) or the lifted body's first-arg
+// `ClosureEnv` builtin. Both are 8 bytes at the ABI boundary.
+func isClosureScalarType(t mir.Type) bool {
+	if _, ok := t.(*ir.FnType); ok {
+		return true
+	}
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt == nil {
+		return false
+	}
+	return nt.Builtin && nt.Name == "ClosureEnv"
 }
 
 // isFloatABIType reports whether t is a Float / Float64 — values that
@@ -1469,9 +1577,12 @@ func (s *lowerState) lowerComparisonAssign(rv *mir.BinaryRV, cond Cond, destSlot
 // dest+0/+8. FnRef-only — indirect calls and parameter types outside
 // ABI fall back.
 func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr, error) {
+	if ind, ok := instr.Callee.(*mir.IndirectCall); ok {
+		return s.lowerIndirectCall(fn, instr, ind)
+	}
 	ref, ok := instr.Callee.(*mir.FnRef)
 	if !ok {
-		return nil, fmt.Errorf("%w: indirect call", ErrUnsupportedShape)
+		return nil, fmt.Errorf("%w: callee shape %T", ErrUnsupportedShape, instr.Callee)
 	}
 	var out []Instr
 	regCursor := 0
@@ -1571,6 +1682,75 @@ func (s *lowerState) lowerCall(fn *mir.Function, instr *mir.CallInstr) ([]Instr,
 	return out, nil
 }
 
+// lowerIndirectCall lowers `call *<closure_local>(args...)`. The
+// closure value is an env-pointer; per the Phase A4 fn-value runtime
+// contract the lifted body's signature is `(env, args...)`, so the
+// lowering stages the env in x0, the user args in x1.., d0..d7, and
+// loads the fn pointer from the env's first slot before `blr`.
+//
+// The fn pointer load goes into x9 — neither the caller nor the
+// callee can rely on x9 surviving across the call, so we don't need
+// to spill it. The env pointer in x0 is consumed by the call as the
+// ClosureEnv argument.
+func (s *lowerState) lowerIndirectCall(fn *mir.Function, instr *mir.CallInstr, ind *mir.IndirectCall) ([]Instr, error) {
+	if len(instr.Args) > len(argRegs)-1 {
+		return nil, fmt.Errorf("%w: indirect call user-arg count %d exceeds limit", ErrUnsupportedShape, len(instr.Args))
+	}
+	envInstrs, err := s.materialiseOperand(ind.Callee, RegX0)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), envInstrs...)
+	regCursor := 1 // x0 reserved for env
+	fpCursor := 0
+	for _, arg := range instr.Args {
+		argType := arg.Type()
+		if isFloatABIType(argType) {
+			if fpCursor >= len(fpArgRegs) {
+				return nil, fmt.Errorf("%w: indirect call needs more than %d FP arg regs", ErrUnsupportedShape, len(fpArgRegs))
+			}
+			mat, err := s.materialiseFloatOperand(arg, fpArgRegs[fpCursor])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, mat...)
+			fpCursor++
+			continue
+		}
+		if regCursor >= len(argRegs) {
+			return nil, fmt.Errorf("%w: indirect call needs more than %d int arg regs", ErrUnsupportedShape, len(argRegs)-1)
+		}
+		slots, ok := s.abiRegSlots(argType)
+		if !ok || slots != 1 {
+			return nil, fmt.Errorf("%w: indirect call arg type %s not supported", ErrUnsupportedShape, argType)
+		}
+		mat, err := s.materialiseOperand(arg, argRegs[regCursor])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mat...)
+		regCursor++
+	}
+	// Load fn pointer from env+0 into x9 then `blr x9`. The env
+	// pointer is already in x0 from the materialise above and stays
+	// there through the branch.
+	out = append(out,
+		&LoadFromReg{Dst: RegX9, Src: RegX0, Offset: 0},
+		&BranchLinkReg{Reg: RegX9},
+	)
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			destType := s.destType(instr.Dest.Local)
+			if isFloatABIType(destType) {
+				out = append(out, &StoreFloat64Stack{Src: RegD0, Offset: slot})
+			} else {
+				out = append(out, &Store64Stack{Src: RegX0, Offset: slot})
+			}
+		}
+	}
+	return out, nil
+}
+
 // indirectArgAddress produces the instructions that land &(src_slot)
 // in the destination argument register. Indirect args are always
 // passed as a Copy or Move of a stack-allocated local; struct
@@ -1664,10 +1844,16 @@ func (s *lowerState) materialiseOperand(op mir.Operand, dst Reg) ([]Instr, error
 		if hasIndexProjection(o.Place) {
 			return s.loadIndexedPlaceIntoIntReg(o.Place, dst)
 		}
+		if hasEnvDerefProjection(s, o.Place) {
+			return s.loadEnvProjection(o.Place, dst)
+		}
 		return s.loadPlaceIntoReg(o.Place, dst)
 	case *mir.MoveOp:
 		if hasIndexProjection(o.Place) {
 			return s.loadIndexedPlaceIntoIntReg(o.Place, dst)
+		}
+		if hasEnvDerefProjection(s, o.Place) {
+			return s.loadEnvProjection(o.Place, dst)
 		}
 		return s.loadPlaceIntoReg(o.Place, dst)
 	default:
@@ -1856,12 +2042,13 @@ func (s *lowerState) loadPlaceIntoReg(place mir.Place, dst Reg) ([]Instr, error)
 }
 
 // placeProjectionOffset reduces a Place's projection chain to a single
-// byte offset relative to the local's slot. Handles FieldProj
-// (struct-shaped) and VariantProj (enum payload) over scalar-typed
-// fields. Index/deref projections still fall through to the
-// unsupported-shape sentinel so the LLVM fallback picks them up. The
-// offset is independent of which scalar type lives at that position
-// because every scalar field consumes 8 bytes.
+// byte offset relative to the local's slot, but **only** when the
+// chain stays inside the slot. Closure-env projections (`*` then a
+// FieldProj on a ClosureEnv) need a runtime indirection: the slot
+// holds a pointer, so the lowerer dereferences before reading. Such
+// places are handled by `loadPlaceIntoReg` directly via
+// `loadEnvProjection` — this helper returns ok=false to signal
+// "this isn't a slot-local read" and the caller routes accordingly.
 func (s *lowerState) placeProjectionOffset(place mir.Place) (int64, error) {
 	if !place.HasProjections() {
 		return 0, nil
@@ -1889,6 +2076,79 @@ func (s *lowerState) placeProjectionOffset(place mir.Place) (int64, error) {
 		}
 	}
 	return off, nil
+}
+
+// hasEnvDerefProjection reports whether the place's first projection
+// is a Deref on a closure-shaped pointer (ClosureEnv / FnType). Such
+// places need to be loaded through a runtime indirection rather than
+// summed to a static slot offset.
+func hasEnvDerefProjection(s *lowerState, place mir.Place) bool {
+	if len(place.Projections) == 0 {
+		return false
+	}
+	if _, ok := place.Projections[0].(*mir.DerefProj); !ok {
+		return false
+	}
+	loc := lookupLocal(s.fn, place.Local)
+	if loc == nil {
+		return false
+	}
+	return isClosureScalarType(loc.Type)
+}
+
+// loadEnvProjection lowers `<env>.*.{i}` reads — the lifted body's
+// access to a closure capture or to the fn-pointer slot. The MIR
+// uses TupleProj (or occasionally FieldProj) on the second leg of
+// the chain; both index into the env layout. Layout:
+//
+//	field 0 → env+0     (the lifted fn pointer)
+//	field i → env+24 + (i-1)*8   (the (i-1)-th capture)
+//
+// Trailing chains beyond two entries are unsupported; the lifted
+// body never produces them today.
+func (s *lowerState) loadEnvProjection(place mir.Place, dst Reg) ([]Instr, error) {
+	if len(place.Projections) != 2 {
+		return nil, fmt.Errorf("%w: env projection chain length %d", ErrUnsupportedShape, len(place.Projections))
+	}
+	idx, ok := envProjectionIndex(place.Projections[1])
+	if !ok {
+		return nil, fmt.Errorf("%w: env projection second entry %T", ErrUnsupportedShape, place.Projections[1])
+	}
+	envSlot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: env local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	off := closureEnvFieldByteOffset(idx)
+	return []Instr{
+		&Load64Stack{Dst: RegX9, Offset: envSlot},
+		&LoadFromReg{Dst: dst, Src: RegX9, Offset: off},
+	}, nil
+}
+
+// envProjectionIndex extracts the MIR-level index from either a
+// FieldProj or a TupleProj — the front end uses TupleProj for
+// closure captures (the env captures array is conceptually a
+// tuple), while struct-shaped envs would emit FieldProj. Both shapes
+// reduce to the same env layout offset.
+func envProjectionIndex(p mir.Projection) (int, bool) {
+	switch v := p.(type) {
+	case *mir.FieldProj:
+		return v.Index, true
+	case *mir.TupleProj:
+		return v.Index, true
+	}
+	return 0, false
+}
+
+// closureEnvFieldByteOffset maps an MIR-level FieldProj index on a
+// ClosureEnv pointee to the runtime layout offset. Index 0 is the
+// fn-pointer slot (offset 0); index N>=1 is capture N-1 starting at
+// `closureEnvCapturesOffset`.
+func closureEnvFieldByteOffset(index int) int64 {
+	if index <= 0 {
+		return 0
+	}
+	return int64(closureEnvCapturesOffset) + int64(index-1)*8
 }
 
 func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) {
@@ -2221,6 +2481,13 @@ func collectReadLocals(instr mir.Instr, out map[mir.LocalID]bool) {
 	case *mir.CallInstr:
 		for _, arg := range i.Args {
 			collectOperandLocals(arg, out)
+		}
+		// Indirect-call closures read the closure local through the
+		// callee operand. Without surfacing it here, the slot
+		// allocator drops the local and the lowerer fails with a
+		// missing-slot error at the indirect-call site.
+		if ind, ok := i.Callee.(*mir.IndirectCall); ok {
+			collectOperandLocals(ind.Callee, out)
 		}
 	}
 }

--- a/internal/onb/macho.go
+++ b/internal/onb/macho.go
@@ -990,6 +990,40 @@ func encodeMachOFunction(enc *machoTextEncoding, fn Function, cstringIndex, loca
 					return fmt.Errorf("onb: stack-address add: %w", err)
 				}
 				enc.code = appendU32LE(enc.code, word)
+			case *LoadSymbolAddress:
+				dstReg, ok := xRegisterNumber(i.Dst)
+				if !ok {
+					return fmt.Errorf("%w: Mach-O symbol-address dst %s", ErrNotImplemented, i.Dst)
+				}
+				if i.Symbol == "" {
+					return fmt.Errorf("onb: Mach-O symbol-address without symbol")
+				}
+				sym, isLocal := localFnIndex[i.Symbol]
+				if !isLocal {
+					ext, ok := externalIndex[i.Symbol]
+					if !ok {
+						ext = uint32(len(cstringIndex) + 1 + totalFns + len(enc.externalSymbols))
+						externalIndex[i.Symbol] = ext
+						enc.externalSymbols = append(enc.externalSymbols, i.Symbol)
+					}
+					sym = ext
+				}
+				// adrp Xd, sym@PAGE + add Xd, Xd, sym@PAGEOFF — same
+				// reloc shape the cstring path uses, just pointed at
+				// a function/data symbol instead.
+				addr := uint32(len(enc.code))
+				enc.code = appendU32LE(enc.code, 0x90000000|dstReg)
+				enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, pcrel: true, length: 2, extern: true, typ: machoARM64RelocPage21})
+				addr = uint32(len(enc.code))
+				enc.code = appendU32LE(enc.code, 0x91000000|(dstReg<<5)|dstReg)
+				enc.relocs = append(enc.relocs, machoReloc{address: addr, symbolnum: sym, length: 2, extern: true, typ: machoARM64RelocPageOff12})
+			case *BranchLinkReg:
+				n, ok := xRegisterNumber(i.Reg)
+				if !ok {
+					return fmt.Errorf("%w: Mach-O blr reg %s", ErrNotImplemented, i.Reg)
+				}
+				// blr Xn — 0xd63f0000 | (n << 5)
+				enc.code = appendU32LE(enc.code, 0xd63f0000|(n<<5))
 			case *LoadFromReg:
 				word, err := encodeLoadStoreReg(0xf9400000, i.Dst, i.Src, i.Offset)
 				if err != nil {


### PR DESCRIPTION
## Summary

ONB now lowers closures natively. **Tier 1's single-largest unlock** — nearly every Osty stdlib API (`xs.filter(...)`, `m.update(k, |n| ...)`, `taskGroup(|g| ...)`) takes a closure, so this slice removes the most common fallback reason.

```osty
let n = 100
let f = |x: Int| x + n          // env alloc, n stamped at capture[0]
println(f(10))                   // x0 = env, x1 = 10, blr [env+0] → 110
```

## Mechanics

**Runtime contract**: `osty.rt.closure_env_alloc_v2(N, site, bitmap)` returns a heap env with layout `{fn_ptr (8B); capture_count (8B); pointer_bitmap (8B); captures[N×8B]}`. The env pointer doubles as the closure value; calling the closure passes the env in x0 (per the lifted body's `(env: ClosureEnv, args...)` signature) and loads the fn pointer from `[env + 0]`.

**LIR** (`internal/onb/lir.go`):
- `BranchLinkReg{Reg}` — `blr Xn` indirect call
- `LoadSymbolAddress{Dst, Symbol}` — `adrp + add` for fn/data symbols (generalises `LoadCStringAddress` past `__cstring`)

**Lowering** (`internal/onb/lower.go`):
- `runtimeSymClosureEnvAllocV2` uses the dotted runtime symbol form (`osty.rt....`) the runtime exports via `__asm__`
- `closureEnvCapturesOffset = 24`
- `isClosureScalarType(t)` — `*ir.FnType` + `NamedType{ClosureEnv, Builtin}` as 1-reg pointers
- `lowerClosureLiteralAssign` — alloc_v2 → stash env in x10 → store fn pointer at `[env+0]` → store captures at `[env+24 + i*8]` → store env pointer in dest slot. Float captures route through d8 + fmov bitcast
- `lowerIndirectCall` — env in x0, user args in x1.., d0.., load fn ptr from `[x0+0]` to x9, `blr x9`, capture return
- `loadEnvProjection` — handles MIR's `_env.*.{i}` reads. Field 0 → offset 0; field N (N≥1) → `24 + (N-1)*8`. Accepts FieldProj + TupleProj (front end uses TupleProj for captures)
- `collectReadLocals` walks `IndirectCall.Callee` so the closure local gets a stack slot

**Mach-O encoders** (`internal/onb/macho.go`):
- LoadSymbolAddress: PAGE21 + PAGEOFF12 relocs against either local fn or external symbol
- BranchLinkReg: `0xd63f0000 | (n << 5)`

## Out of scope

- `pointer_bitmap = 0` fixed — GC may false-retain pointer-shaped captures (LLVM backend computes a real bitmap; follow-up)
- Float / String / struct / enum captures lower but aren't verified end-to-end
- Closure-returning helpers (`fn make_adder(n) -> fn(Int) -> Int`)
- Closures-as-arg passed through other closures

## Test plan

- [x] `internal/backend/onb_test.go` — 3 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsClosuresOnDarwinARM64`):
  - `no_capture`: `|x| x + 1` called twice → `"11\n100\n"`
  - `single_capture`: `|x| x + n` with n=100 → `"110"`
  - `two_captures`: `|x| x + a + b` with a=10, b=20 → `"35"`
- [x] All pre-existing ONB + backend (`-short`) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)