### PR TITLE
feat: ONB Phase A2 Week 21 — stdlib intrinsics + builtin pointer ABI

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,64 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 21 (stdlib intrinsics + builtin pointer ABI, 2026-05-02)** —
+> 작은 lift, 큰 unlock. Builtin generic 컨테이너 (List/Map/Set/Channel
+> /Bytes/Handle)가 ABI에서 1-reg 포인터로 분류되도록 확장 + String /
+> List / Option의 `.len()` / `.isEmpty()` / `.isSome()` / `.isNone()`
+> 인트린식 lowering 추가. 결과적으로 **제네릭 함수가 fallback 없이
+> 통과** — 모노모피제이션은 이미 front end가 처리하고 있어서 ONB는
+> 그저 `List<T>` 인자를 받아주기만 하면 됨.
+>
+> 작동:
+>
+> ```osty
+> fn first<T>(xs: List<T>) -> T? {
+>     if xs.len() == 0 { None } else { Some(xs[0]) }
+> }
+> fn main() {
+>     let mut xs: List<Int> = []
+>     xs.push(42)
+>     let r = first(xs)               // List<Int>가 x0로 통과
+>     match r {
+>         Some(x) -> println(x),       // 42
+>         None -> println(-1),
+>     }
+> }
+> ```
+>
+> 추가:
+> - `isBuiltinPointerType(t)` — `NamedType{Builtin: true}` 중 `List` /
+>   `Map` / `Set` / `Channel` / `Bytes` / `Handle`을 1-reg 포인터로 인식
+> - `isABIScalarType`이 위 predicate를 포함하도록 확장 → `abiRegSlots`
+>   가 `List<Int>` / `Map<K,V>` 같은 타입을 fn arg/return으로 받음
+> - `runtimeSymStringByteLen = "osty_rt_strings_ByteLen"` — String
+>   .len()의 런타임 심볼
+> - `lowerStringLen` — `osty_rt_strings_ByteLen` 직접 호출
+> - `lowerStringIsEmpty` / `lowerListIsEmpty` — len 호출 + `cmp + cset eq`
+> - `lowerOptionIsSome` / `lowerOptionIsNone` — disc 슬롯 (옵션 슬롯 + 0)
+>   읽고 1과 비교 (`Some` 태그 = 1)
+> - `lowerOptionDiscriminantCompare` 헬퍼 — isSome/isNone 공유 본체
+>
+> 검증:
+> - E2E binary smoke 5개 (`TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64`):
+>   string_len ("hello".len() → 5), string_is_empty ("".isEmpty() → 1),
+>   list_is_empty (push 전후), option_is_some_none (Some(7) + None
+>   각각의 isSome/isNone), generic_fn_first (first<T> 호출 → 42)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - **Map intrinsics** 여전히 fallback — `osty_rt_map_new`은 `(key_kind,
+>   value_kind, value_size, trace_fn)` 4 인자가 필요하고 set/get은 value
+>   를 포인터로 전달 (스택 scratch 슬롯 필요). 별도 슬라이스로 보류
+> - String 메서드: `.split` / `.contains` / `.compare` / 슬라이싱 등 미구현
+> - Option 메서드: `.unwrap()` / `.unwrapOr(d)` 미구현
+> - List 메서드: `.pop()` / `.contains()` / `.indexOf()` 미구현
+> - Bool println은 여전히 0/1로 출력 (`%lld` 포맷). 사용자가 `true` /
+>   `false` 문자열을 원하면 명시적 toString 필요
+> - GC pointer_bitmap 정확도 (Week 20 그대로)
+>
+> 다음 슬라이스 후보: Map<K,V> 인트린식, 추가 String/Option/List 메서드,
+> Float 비교 / 캐스트.
+>
 > **Slice A2 Week 20 (closures — value + indirect call, 2026-05-02)** —
 > ONB가 처음으로 클로저를 native lowering. `let f = |x| x + n`,
 > `xs.filter(|x| x > 0)` 같은 패턴이 fallback 없이 통과 (filter 자체는

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1314,6 +1314,110 @@ func TestONBBackendBinaryRunsClosuresOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64 covers Phase
+// A2 Week 21 — a batch of stdlib intrinsics that the front end emits
+// for `.len()`, `.isEmpty()`, `.isSome()`, `.isNone()` on String /
+// List / Option, plus the implicit "builtin generic types pass as
+// pointers at the ABI" extension that lets `fn first<T>(xs:
+// List<T>)` compile to a native call (the monomorphized name is just
+// another FnRef once the pointer-shaped arg is accepted).
+//
+// Bool println currently routes through `printf "%lld\n"` so true /
+// false render as 1 / 0 — that's consistent with Week 4 and isn't
+// changed by this slice.
+func TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB stdlib-intrinsic smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "string_len",
+			src: `fn main() {
+    println("hello".len())
+    println("".len())
+}`,
+			want: "5\n0\n",
+		},
+		{
+			name: "string_is_empty",
+			src: `fn main() {
+    println("".isEmpty())
+    println("x".isEmpty())
+}`,
+			want: "1\n0\n",
+		},
+		{
+			name: "list_is_empty",
+			src: `fn main() {
+    let mut xs: List<Int> = []
+    println(xs.isEmpty())
+    xs.push(1)
+    println(xs.isEmpty())
+}`,
+			want: "1\n0\n",
+		},
+		{
+			name: "option_is_some_none",
+			src: `fn main() {
+    let a: Int? = Some(7)
+    let b: Int? = None
+    println(a.isSome())
+    println(a.isNone())
+    println(b.isSome())
+    println(b.isNone())
+}`,
+			want: "1\n0\n0\n1\n",
+		},
+		{
+			// Generic monomorphized fn — the body uses everything ONB
+			// already supports (LenRV, IndexProj, AggEnumVariant,
+			// NullaryRV); the call-site needed `List<Int>` to be
+			// accepted as a 1-reg pointer ABI param, which Week 21
+			// unlocks via `isBuiltinPointerType`.
+			name: "generic_fn_first",
+			src: `fn first<T>(xs: List<T>) -> T? {
+    if xs.len() == 0 { None } else { Some(xs[0]) }
+}
+fn main() {
+    let mut xs: List<Int> = []
+    xs.push(42)
+    let r = first(xs)
+    let v = match r {
+        Some(x) -> x,
+        None -> -1,
+    }
+    println(v)
+}`,
+			want: "42\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -63,6 +63,7 @@ const (
 	// (LLVM-shaped) name via __asm__("osty.rt..."). Mach-O symbol
 	// encoding prepends the leading underscore, matching the call site.
 	runtimeSymClosureEnvAllocV2 = "osty.rt.closure_env_alloc_v2"
+	runtimeSymStringByteLen     = "osty_rt_strings_ByteLen"
 )
 
 // closureEnvCapturesOffset is the byte offset within an
@@ -968,7 +969,10 @@ func isABIScalarType(t mir.Type) bool {
 	if isFloatABIType(t) {
 		return true
 	}
-	return isClosureScalarType(t)
+	if isClosureScalarType(t) {
+		return true
+	}
+	return isBuiltinPointerType(t)
 }
 
 // isClosureScalarType reports whether t is a closure-shaped pointer
@@ -983,6 +987,28 @@ func isClosureScalarType(t mir.Type) bool {
 		return false
 	}
 	return nt.Builtin && nt.Name == "ClosureEnv"
+}
+
+// isBuiltinPointerType reports whether t is a builtin generic
+// container that's represented as a heap pointer at the ABI
+// boundary. Lists, Maps, Sets, Channels, and similar runtime-
+// managed values all fit this shape — the local holds an 8-byte
+// pointer to the runtime data structure regardless of element
+// type. Lets `abiRegSlots` accept these as 1-reg pointer args /
+// returns without enumerating each builtin.
+func isBuiltinPointerType(t mir.Type) bool {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt == nil {
+		return false
+	}
+	if !nt.Builtin {
+		return false
+	}
+	switch nt.Name {
+	case "List", "Map", "Set", "Channel", "Bytes", "Handle":
+		return true
+	}
+	return false
 }
 
 // isFloatABIType reports whether t is a Float / Float64 — values that
@@ -2159,9 +2185,143 @@ func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) 
 		return s.lowerListPush(instr)
 	case mir.IntrinsicListLen:
 		return s.lowerListLen(instr)
+	case mir.IntrinsicStringLen:
+		return s.lowerStringLen(instr)
+	case mir.IntrinsicStringIsEmpty:
+		return s.lowerStringIsEmpty(instr)
+	case mir.IntrinsicListIsEmpty:
+		return s.lowerListIsEmpty(instr)
+	case mir.IntrinsicOptionIsSome:
+		return s.lowerOptionIsSome(instr)
+	case mir.IntrinsicOptionIsNone:
+		return s.lowerOptionIsNone(instr)
 	default:
 		return nil, fmt.Errorf("%w: intrinsic %s is outside phase 1", ErrUnsupportedShape, instr.Kind)
 	}
+}
+
+// lowerStringIsEmpty composes `osty_rt_strings_ByteLen(s) == 0` and
+// stores the bool result. The runtime returns the byte count in x0;
+// `cmp x0, #0` + `cset Xd, eq` materialises the bool without going
+// through a stack round-trip for the intermediate length.
+func (s *lowerState) lowerStringIsEmpty(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 1 {
+		return nil, fmt.Errorf("%w: string_is_empty expects 1 arg", ErrUnsupportedShape)
+	}
+	receiver, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), receiver...)
+	out = append(out,
+		&BranchLink{Symbol: runtimeSymStringByteLen},
+		&MovImm64{Dst: RegX9, Imm: 0},
+		&Cmp{Lhs: RegX0, Rhs: RegX9},
+		&Cset{Dst: RegX9, Cond: CondEq},
+	)
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX9, Offset: slot})
+		}
+	}
+	return out, nil
+}
+
+// lowerListIsEmpty composes `osty_rt_list_len(xs) == 0` similarly.
+func (s *lowerState) lowerListIsEmpty(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 1 {
+		return nil, fmt.Errorf("%w: list_is_empty expects 1 arg", ErrUnsupportedShape)
+	}
+	receiver, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), receiver...)
+	out = append(out,
+		&BranchLink{Symbol: runtimeSymListLen},
+		&MovImm64{Dst: RegX9, Imm: 0},
+		&Cmp{Lhs: RegX0, Rhs: RegX9},
+		&Cset{Dst: RegX9, Cond: CondEq},
+	)
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX9, Offset: slot})
+		}
+	}
+	return out, nil
+}
+
+// lowerOptionIsSome / lowerOptionIsNone read the option's
+// discriminant (slot+0 of the enum local) and compare to the Some
+// tag (= 1). The Option layout is the synthetic one from Week 14 so
+// these always look at offset 0 regardless of the inner type.
+func (s *lowerState) lowerOptionIsSome(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	return s.lowerOptionDiscriminantCompare(instr, CondEq)
+}
+
+func (s *lowerState) lowerOptionIsNone(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	return s.lowerOptionDiscriminantCompare(instr, CondNe)
+}
+
+// lowerOptionDiscriminantCompare emits the shared isSome/isNone body:
+// load the discriminant byte (option slot + 0) into x9, compare to
+// the Some tag (1), and `cset` with the caller-chosen condition.
+// CondEq → isSome (x9 == 1); CondNe → isNone (x9 != 1).
+func (s *lowerState) lowerOptionDiscriminantCompare(instr *mir.IntrinsicInstr, cond Cond) ([]Instr, error) {
+	if len(instr.Args) != 1 {
+		return nil, fmt.Errorf("%w: option discriminant compare expects 1 arg", ErrUnsupportedShape)
+	}
+	op := instr.Args[0]
+	var place mir.Place
+	switch o := op.(type) {
+	case *mir.CopyOp:
+		place = o.Place
+	case *mir.MoveOp:
+		place = o.Place
+	default:
+		return nil, fmt.Errorf("%w: option discriminant operand %T", ErrUnsupportedShape, op)
+	}
+	if place.HasProjections() {
+		return nil, fmt.Errorf("%w: option discriminant on projected place", ErrUnsupportedShape)
+	}
+	srcSlot, ok := s.localSlots[place.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: option discriminant of local%d without slot", ErrUnsupportedShape, place.Local)
+	}
+	out := []Instr{
+		&Load64Stack{Dst: RegX9, Offset: srcSlot},
+		&MovImm64{Dst: RegX10, Imm: 1}, // Some tag
+		&Cmp{Lhs: RegX9, Rhs: RegX10},
+		&Cset{Dst: RegX9, Cond: cond},
+	}
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX9, Offset: slot})
+		}
+	}
+	return out, nil
+}
+
+// lowerStringLen lowers `s.len()` on a String operand into a runtime
+// call to `osty_rt_strings_ByteLen`. Receiver lives in x0; the
+// runtime returns a byte count in x0 which we capture into the
+// destination slot.
+func (s *lowerState) lowerStringLen(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 1 {
+		return nil, fmt.Errorf("%w: string_len expects 1 arg, got %d", ErrUnsupportedShape, len(instr.Args))
+	}
+	receiver, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), receiver...)
+	out = append(out, &BranchLink{Symbol: runtimeSymStringByteLen})
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX0, Offset: slot})
+		}
+	}
+	return out, nil
 }
 
 // lowerListPush lowers `IntrinsicListPush(list, value)` into a runtime


### PR DESCRIPTION
## Summary

Two threads in one PR — small lift, big unlock:

1. **Builtin generic containers as 1-reg pointers.** `List<T>`, `Map<K,V>`, `Set<T>`, `Channel<T>`, `Bytes`, `Handle` all live as heap pointers at the ABI boundary. With this slice ONB accepts them as fn args/returns, which means **generic functions just work** — monomorphization is already a front-end pass, ONB only needed to take `List<Int>` (etc.) at the call boundary.

2. **`.len/.isEmpty/.isSome/.isNone` intrinsics** for String / List / Option. Compose-over-existing patterns: `len + cmp + cset` for the bools, direct runtime call for `len`.

```osty
fn first<T>(xs: List<T>) -> T? {
    if xs.len() == 0 { None } else { Some(xs[0]) }
}
fn main() {
    let mut xs: List<Int> = []
    xs.push(42)
    let r = first(xs)            // List<Int> rides x0 natively
    match r {
        Some(x) -> println(x),    // 42
        None -> println(-1),
    }
}
```

## Mechanics

`internal/onb/lower.go`:
- `isBuiltinPointerType(t)` — predicate for the six builtin generics
- `isABIScalarType` extended to include them
- `runtimeSymStringByteLen` constant
- `lowerStringLen` — direct runtime call to `osty_rt_strings_ByteLen`
- `lowerStringIsEmpty` / `lowerListIsEmpty` — len + `cmp #0 + cset eq`
- `lowerOptionIsSome` / `lowerOptionIsNone` — discriminant slot read + `cmp #1 + cset` (eq → isSome, ne → isNone)
- `lowerOptionDiscriminantCompare` shared body

## Out of scope

- **Map intrinsics** — `osty_rt_map_new` takes 4 args including a trace fn pointer, and insert/get pass values via pointer (stack scratch needed). Separate slice.
- String methods beyond len/isEmpty (`.split`, `.contains`, `.compare`, ...)
- Option `.unwrap` / `.unwrapOr`
- List `.pop` / `.contains` / `.indexOf`

## Test plan

- [x] 5 e2e darwin/arm64 binary smokes (`TestONBBackendBinaryRunsStdlibIntrinsicsOnDarwinARM64`):
  - `string_len`: `"hello".len()` / `"".len()` → `5` / `0`
  - `string_is_empty`: `"".isEmpty()` / `"x".isEmpty()` → `1` / `0`
  - `list_is_empty`: `List<Int>` before/after push
  - `option_is_some_none`: `Some(7)` / `None` × `isSome`/`isNone`
  - `generic_fn_first`: `first<T>(xs)` over `List<Int>` → `42`
- [x] All pre-existing ONB + backend (`-short`) tests green (152s wall-clock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)