### PR TITLE
feat: ONB Phase A2 Week 23 — Map<K,V> get / containsKey / remove

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,60 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 23 (Map<K,V> — get / containsKey / remove, 2026-05-02)** —
+> Map의 핵심 lookup 3종을 native lowering. Week 22의 new/insert/len과
+> 결합하면 Map 일상 사용 (캐시, 인덱스, 빈도 카운트)이 fallback 없이
+> 통과.
+>
+> 작동:
+>
+> ```osty
+> let mut m: Map<String, Int> = {:}
+> m.insert("k", 42)
+> match m.get("k") {                  // V? 반환 — Some(42)
+>     Some(x) -> println(x),
+>     None -> println(-1),
+> }
+> println(m.containsKey("k"))         // 1 (Bool, true)
+> m.remove("k")                        // Bool 반환 (찾았는지)
+> println(m.len())                     // 0
+> ```
+>
+> 추가:
+> - 새 런타임 심볼: `runtimeSymMapGet/Contains/Remove` × 5 key kinds
+>   (i64/i1/f64/ptr/string)
+> - `lowerMapGet` — Week 22 scratch 슬롯을 `out_value`로 재사용 →
+>   런타임 호출 → x0 (None=0/Some=1 디스크리미넌트) → dest+0,
+>   scratch 값 → dest+8 (None일 땐 stale이지만 디스크리미넌트로 차단)
+> - `lowerMapContains` / `lowerMapRemove` — `lowerMapBoolReturn` 헬퍼로
+>   공유. 런타임이 bool을 x0로 반환, dest slot에 직접 capture
+> - `mapGet/Contains/RemoveSymbolForKeyKind` 디스패치 테이블
+> - `functionUsesMapValueScratch`이 `IntrinsicMapGet`도 감지해
+>   scratch 슬롯 예약
+>
+> 검증:
+> - E2E binary smoke 4개 (`TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64`):
+>   map_get_hit / map_get_miss (Some/None 분기), map_contains_int_keys
+>   (Int 키), map_remove_shrinks_len (insert→remove→len)
+> - 기존 fallback 테스트 4개의 sentinel을 `taskGroup(|g| g.spawn(|| 42))`
+>   로 변경 (Map.get은 이제 native라 더 이상 fallback 사유 아님)
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - `m.update(k, |v| ...)` — 클로저 + Map.get + Map.set 조합. front
+>   end가 어떻게 lowering하는지에 따라 추가 작업 필요할 수 있음
+> - `m.getOr(k, default)` — IntrinsicMapGetOr 별도
+> - `m.keys()` / `m.values()` — `List<K>` 반환, 미구현
+> - `for (k, v) in m` — Map iterator 미구현
+> - GC pointer_bitmap 정확도는 Week 22 그대로 — pointer-typed values
+>   는 GC false-retain 위험
+>
+> **Tier 1 마무리 상태**: ONB가 일반적인 Osty 코드 패턴의 대부분을
+> native path로 처리. 클로저 (Week 20), 제네릭 함수 (Week 21),
+> Map<K,V> CRUD + len + lookup (Week 22 + 23), 메서드 디스패치 (intrinsic
+> 경유, Week 22), String .len/.isEmpty + Option .isSome/.isNone +
+> List .isEmpty (Week 21) 모두 통과. 남은 Tier 1 잔여물은 작은 String
+> 메서드 (.split/.contains/.compare) 정도로 follow-up.
+>
 > **Slice A2 Week 22 (Map<K,V> — new + insert + len, 2026-05-02)** —
 > Map가 native path로 들어옴. 가장 흔한 패턴 `Map<String, Int>`,
 > `Map<Int, Int>` 의 생성·삽입·길이 쿼리가 fallback 없이 통과.

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -1494,6 +1494,100 @@ func TestONBBackendBinaryRunsMapNewInsertLenOnDarwinARM64(t *testing.T) {
 	}
 }
 
+// TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64 covers
+// Phase A2 Week 23: Map lookup (`m.get(k) -> V?`), membership
+// (`m.containsKey(k) -> Bool`), and removal (`m.remove(k) -> Bool`).
+// All three lean on the per-function map scratch slot from Week 22 —
+// `get` writes the value through it, `contains/remove` skip the
+// scratch but reuse the key-kind dispatch table.
+//
+// The Option<V> construction for `get` is straight-line: the runtime
+// returns 0/1 in x0 (which conveniently doubles as the None/Some
+// discriminant), and the value lands in scratch on Some hits — the
+// lowering stores both halves unconditionally. None-hits leave a
+// stale payload in dest+8 but readers gated by the discriminant
+// never observe it.
+func TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("ONB Map<K,V> get/contains/remove smoke is darwin/arm64-only")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "map_get_hit",
+			src: `fn main() {
+    let mut m: Map<String, Int> = {:}
+    m.insert("k", 42)
+    let v = m.get("k")
+    match v {
+        Some(x) -> println(x),
+        None -> println(-1),
+    }
+}`,
+			want: "42\n",
+		},
+		{
+			name: "map_get_miss",
+			src: `fn main() {
+    let mut m: Map<String, Int> = {:}
+    m.insert("k", 42)
+    let v = m.get("missing")
+    match v {
+        Some(x) -> println(x),
+        None -> println(-1),
+    }
+}`,
+			want: "-1\n",
+		},
+		{
+			name: "map_contains_int_keys",
+			src: `fn main() {
+    let mut m: Map<Int, Int> = {:}
+    m.insert(7, 70)
+    println(m.containsKey(7))
+    println(m.containsKey(99))
+}`,
+			want: "1\n0\n",
+		},
+		{
+			name: "map_remove_shrinks_len",
+			src: `fn main() {
+    let mut m: Map<Int, Int> = {:}
+    m.insert(1, 10)
+    m.insert(2, 20)
+    println(m.len())
+    m.remove(1)
+    println(m.len())
+}`,
+			want: "2\n1\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(onb.EnvStrict, "1")
+			req := newBackendRequest(t, EmitBinary, tc.src)
+			req.Layout.Target = "aarch64-apple-darwin"
+			result, err := ONBBackend{}.Emit(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ONBBackend.Emit returned error: %v", err)
+			}
+			out, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+			if err != nil {
+				t.Fatalf("binary returned error: %v\n%s", err, out)
+			}
+			if got := string(out); got != tc.want {
+				t.Fatalf("binary output = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestONBBackendBinaryRunsStringAndListOnDarwinARM64 exercises Phase A2's
 // runtime-call slice: String concatenation and `List<Int>` push/len. These
 // shapes lower to `bl _osty_rt_strings_Concat`, `bl _osty_rt_list_new`,
@@ -1881,10 +1975,11 @@ func TestONBBackendFallsBackToLLVMOnUnsupportedShape(t *testing.T) {
 	onbDevTestEnv(t, false, false)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut m: Map<String, Int> = {:}
-    m.insert("a", 1)
-    let v = m.get("a")
-    println(v.isSome())
+    let v = taskGroup(|g| {
+        let h = g.spawn(|| 42)
+        h.join()
+    })
+    println(v)
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fallbackArtifacts := req.Artifacts(NameLLVM)
@@ -1924,10 +2019,11 @@ func TestONBBackendStrictModeSurfacesShapeError(t *testing.T) {
 	onbDevTestEnv(t, true, false)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut m: Map<String, Int> = {:}
-    m.insert("a", 1)
-    let v = m.get("a")
-    println(v.isSome())
+    let v = taskGroup(|g| {
+        let h = g.spawn(|| 42)
+        h.join()
+    })
+    println(v)
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{name: NameLLVM}
@@ -1947,10 +2043,11 @@ func TestONBBackendASMEmitDoesNotFallback(t *testing.T) {
 	onbDevTestEnv(t, false, false)
 
 	req := newBackendRequest(t, EmitASM, `fn main() {
-    let mut m: Map<String, Int> = {:}
-    m.insert("a", 1)
-    let v = m.get("a")
-    println(v.isSome())
+    let v = taskGroup(|g| {
+        let h = g.spawn(|| 42)
+        h.join()
+    })
+    println(v)
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{name: NameLLVM}
@@ -1989,10 +2086,11 @@ func TestONBBackendTimingLogsFallback(t *testing.T) {
 	onbDevTestEnv(t, false, true)
 
 	req := newBackendRequest(t, EmitObject, `fn main() {
-    let mut m: Map<String, Int> = {:}
-    m.insert("a", 1)
-    let v = m.get("a")
-    println(v.isSome())
+    let v = taskGroup(|g| {
+        let h = g.spawn(|| 42)
+        h.join()
+    })
+    println(v)
 }`)
 	req.Layout.Target = "aarch64-apple-darwin"
 	fake := &recordingBackend{

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -71,6 +71,21 @@ const (
 	runtimeSymMapInsertF64      = "osty_rt_map_insert_f64"
 	runtimeSymMapInsertPtr      = "osty_rt_map_insert_ptr"
 	runtimeSymMapInsertString   = "osty_rt_map_insert_string"
+	runtimeSymMapGetI64         = "osty_rt_map_get_i64"
+	runtimeSymMapGetI1          = "osty_rt_map_get_i1"
+	runtimeSymMapGetF64         = "osty_rt_map_get_f64"
+	runtimeSymMapGetPtr         = "osty_rt_map_get_ptr"
+	runtimeSymMapGetString      = "osty_rt_map_get_string"
+	runtimeSymMapContainsI64    = "osty_rt_map_contains_i64"
+	runtimeSymMapContainsI1     = "osty_rt_map_contains_i1"
+	runtimeSymMapContainsF64    = "osty_rt_map_contains_f64"
+	runtimeSymMapContainsPtr    = "osty_rt_map_contains_ptr"
+	runtimeSymMapContainsString = "osty_rt_map_contains_string"
+	runtimeSymMapRemoveI64      = "osty_rt_map_remove_i64"
+	runtimeSymMapRemoveI1       = "osty_rt_map_remove_i1"
+	runtimeSymMapRemoveF64      = "osty_rt_map_remove_f64"
+	runtimeSymMapRemovePtr      = "osty_rt_map_remove_ptr"
+	runtimeSymMapRemoveString   = "osty_rt_map_remove_string"
 )
 
 // containerAbiKind enumerates the integer "kind" tag the runtime uses
@@ -2254,6 +2269,12 @@ func (s *lowerState) lowerIntrinsic(instr *mir.IntrinsicInstr) ([]Instr, error) 
 		return s.lowerMapSet(instr)
 	case mir.IntrinsicMapLen:
 		return s.lowerMapLen(instr)
+	case mir.IntrinsicMapGet:
+		return s.lowerMapGet(instr)
+	case mir.IntrinsicMapContains:
+		return s.lowerMapContains(instr)
+	case mir.IntrinsicMapRemove:
+		return s.lowerMapRemove(instr)
 	default:
 		return nil, fmt.Errorf("%w: intrinsic %s is outside phase 1", ErrUnsupportedShape, instr.Kind)
 	}
@@ -2363,6 +2384,153 @@ func (s *lowerState) lowerMapLen(instr *mir.IntrinsicInstr) ([]Instr, error) {
 		}
 	}
 	return out, nil
+}
+
+// lowerMapGet lowers `_v: V? = intrinsic map_get(m, k)` into:
+//
+//  1. `osty_rt_map_get_<keyKind>(map, key, &scratch)` returns 0/1 in x0
+//     and writes the value into scratch on hit.
+//  2. The dest local is `Option<V>` (16 bytes: disc 8B + payload 8B).
+//     Store x0 (the bool, which is conveniently the None=0/Some=1
+//     tag) at dest+0; load scratch into x9 and store at dest+8. We
+//     write the payload unconditionally — for None it's a stale
+//     value, but the discriminant 0 means readers shouldn't touch
+//     it anyway.
+func (s *lowerState) lowerMapGet(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	if len(instr.Args) != 2 {
+		return nil, fmt.Errorf("%w: map_get expects 2 args", ErrUnsupportedShape)
+	}
+	if !s.needsMapScratch {
+		return nil, fmt.Errorf("%w: map_get without scratch reservation", ErrUnsupportedShape)
+	}
+	if instr.Dest == nil || instr.Dest.HasProjections() {
+		return nil, fmt.Errorf("%w: map_get requires non-projected dest", ErrUnsupportedShape)
+	}
+	destSlot, ok := s.localSlots[instr.Dest.Local]
+	if !ok {
+		return nil, fmt.Errorf("%w: map_get dest local missing slot", ErrUnsupportedShape)
+	}
+	mapInstrs, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	keyT := instr.Args[1].Type()
+	keyKind := abiKindFor(keyT)
+	keySym, err := mapGetSymbolForKeyKind(keyKind)
+	if err != nil {
+		return nil, err
+	}
+	keyInstrs, err := s.materialiseOperand(instr.Args[1], RegX1)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), mapInstrs...)
+	out = append(out, keyInstrs...)
+	out = append(out,
+		&LoadStackAddress{Dst: RegX2, Offset: s.mapScratchOffset},
+		&BranchLink{Symbol: keySym},
+		// Discriminant: x0 already holds 0 (None) or 1 (Some).
+		&Store64Stack{Src: RegX0, Offset: destSlot},
+		// Payload: load whatever the runtime wrote into scratch.
+		&Load64Stack{Dst: RegX9, Offset: s.mapScratchOffset},
+		&Store64Stack{Src: RegX9, Offset: destSlot + 8},
+	)
+	return out, nil
+}
+
+// lowerMapContains lowers `_b: Bool = intrinsic map_contains(m, k)`
+// into `osty_rt_map_contains_<keyKind>(map, key)` capturing x0 (the
+// bool) directly into the dest slot.
+func (s *lowerState) lowerMapContains(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	return s.lowerMapBoolReturn(instr, mapContainsSymbolForKeyKind, "map_contains")
+}
+
+// lowerMapRemove lowers `_b: Bool = intrinsic map_remove(m, k)` —
+// same shape as map_contains.
+func (s *lowerState) lowerMapRemove(instr *mir.IntrinsicInstr) ([]Instr, error) {
+	return s.lowerMapBoolReturn(instr, mapRemoveSymbolForKeyKind, "map_remove")
+}
+
+// lowerMapBoolReturn shares the (map, key) → Bool plumbing for
+// contains and remove. Both runtime entries take the same arg
+// shape and return a `bool` in x0; the lowerer only needs to pick
+// the right symbol per key kind.
+func (s *lowerState) lowerMapBoolReturn(instr *mir.IntrinsicInstr, symFor func(int) (string, error), name string) ([]Instr, error) {
+	if len(instr.Args) != 2 {
+		return nil, fmt.Errorf("%w: %s expects 2 args", ErrUnsupportedShape, name)
+	}
+	mapInstrs, err := s.materialiseOperand(instr.Args[0], RegX0)
+	if err != nil {
+		return nil, err
+	}
+	keyKind := abiKindFor(instr.Args[1].Type())
+	sym, err := symFor(keyKind)
+	if err != nil {
+		return nil, err
+	}
+	keyInstrs, err := s.materialiseOperand(instr.Args[1], RegX1)
+	if err != nil {
+		return nil, err
+	}
+	out := append([]Instr(nil), mapInstrs...)
+	out = append(out, keyInstrs...)
+	out = append(out, &BranchLink{Symbol: sym})
+	if instr.Dest != nil && !instr.Dest.HasProjections() {
+		if slot, ok := s.localSlots[instr.Dest.Local]; ok {
+			out = append(out, &Store64Stack{Src: RegX0, Offset: slot})
+		}
+	}
+	return out, nil
+}
+
+// mapGetSymbolForKeyKind picks the runtime get symbol from a key
+// kind, mirroring mapInsertSymbolForKeyKind.
+func mapGetSymbolForKeyKind(kind int) (string, error) {
+	switch kind {
+	case abiKindI64:
+		return runtimeSymMapGetI64, nil
+	case abiKindI1:
+		return runtimeSymMapGetI1, nil
+	case abiKindF64:
+		return runtimeSymMapGetF64, nil
+	case abiKindString:
+		return runtimeSymMapGetString, nil
+	case abiKindPtr:
+		return runtimeSymMapGetPtr, nil
+	}
+	return "", fmt.Errorf("%w: map_get key kind %d", ErrUnsupportedShape, kind)
+}
+
+func mapContainsSymbolForKeyKind(kind int) (string, error) {
+	switch kind {
+	case abiKindI64:
+		return runtimeSymMapContainsI64, nil
+	case abiKindI1:
+		return runtimeSymMapContainsI1, nil
+	case abiKindF64:
+		return runtimeSymMapContainsF64, nil
+	case abiKindString:
+		return runtimeSymMapContainsString, nil
+	case abiKindPtr:
+		return runtimeSymMapContainsPtr, nil
+	}
+	return "", fmt.Errorf("%w: map_contains key kind %d", ErrUnsupportedShape, kind)
+}
+
+func mapRemoveSymbolForKeyKind(kind int) (string, error) {
+	switch kind {
+	case abiKindI64:
+		return runtimeSymMapRemoveI64, nil
+	case abiKindI1:
+		return runtimeSymMapRemoveI1, nil
+	case abiKindF64:
+		return runtimeSymMapRemoveF64, nil
+	case abiKindString:
+		return runtimeSymMapRemoveString, nil
+	case abiKindPtr:
+		return runtimeSymMapRemovePtr, nil
+	}
+	return "", fmt.Errorf("%w: map_remove key kind %d", ErrUnsupportedShape, kind)
 }
 
 // mapKeyValueTypes extracts the K, V parameterisation from a
@@ -2771,8 +2939,10 @@ func stringConstFromOperand(op mir.Operand) (string, bool) {
 
 // functionUsesMapValueScratch reports whether the function contains
 // any map intrinsic that needs an 8-byte stack scratch slot to pass a
-// value pointer to the runtime. Currently true when map_set appears;
-// map_get / map_contains will join once their lowering lands.
+// value pointer to the runtime. map_set passes the value through the
+// scratch (caller writes, runtime reads); map_get does the inverse
+// (runtime writes, caller reads after the call). Both lean on the
+// same per-function 8B reservation.
 func functionUsesMapValueScratch(fn *mir.Function) bool {
 	for _, block := range fn.Blocks {
 		for _, instr := range block.Instrs {
@@ -2781,7 +2951,7 @@ func functionUsesMapValueScratch(fn *mir.Function) bool {
 				continue
 			}
 			switch intr.Kind {
-			case mir.IntrinsicMapSet:
+			case mir.IntrinsicMapSet, mir.IntrinsicMapGet:
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

Map's lookup trio joins the native path. Combined with Week 22's new/insert/len, ordinary Map use (caches, indices, frequency counts) now stays on the dev fast path:

\`\`\`osty
let mut m: Map<String, Int> = {:}
m.insert(\"k\", 42)
match m.get(\"k\") {                  // V? → Some(42)
    Some(x) -> println(x),
    None -> println(-1),
}
println(m.containsKey(\"k\"))         // 1
m.remove(\"k\")
println(m.len())                      // 0
\`\`\`

## Mechanics

\`internal/onb/lower.go\`:
- New runtime symbols: \`runtimeSymMapGet/Contains/Remove\` × 5 key kinds (i64/i1/f64/ptr/string)
- \`lowerMapGet\` reuses Week 22's per-function scratch slot as the \`out_value\` parameter. The runtime returns 0/1 in x0 (which doubles as the None/Some discriminant); the lowering stores x0 to dest+0 and the scratch payload to dest+8 unconditionally. None-hit payload is stale but discriminant-gated readers never observe it.
- \`lowerMapContains\` / \`lowerMapRemove\` share \`lowerMapBoolReturn\` — both runtime entries take (map, key) and return Bool in x0
- \`mapGet/Contains/RemoveSymbolForKeyKind\` dispatch tables
- \`functionUsesMapValueScratch\` extended to detect \`IntrinsicMapGet\` so the scratch slot reservation triggers correctly

## Tier 1 wrap-up

With this slice ONB covers most everyday Osty patterns natively:
- Closures (Week 20)
- Generic functions (Week 21)
- Map<K,V> CRUD + len + lookup (Weeks 22 + 23)
- Method dispatch via intrinsics (Week 22)
- String.len/.isEmpty + Option.isSome/.isNone + List.isEmpty (Week 21)

## Out of scope

- \`m.update(k, |v| ...)\` — closure + Map.get + Map.set composition
- \`m.getOr(k, default)\` (IntrinsicMapGetOr separate)
- \`m.keys()\` / \`m.values()\` returning \`List<K>\` / \`List<V>\`
- Map iteration (\`for (k, v) in m\`)

## Test plan

- [x] 4 e2e darwin/arm64 binary smokes (\`TestONBBackendBinaryRunsMapGetContainsRemoveOnDarwinARM64\`):
  - \`map_get_hit\` / \`map_get_miss\`: Some / None branches
  - \`map_contains_int_keys\`: Int keys, hit + miss
  - \`map_remove_shrinks_len\`: insert → remove → len shrinks
- [x] Fallback-test sentinels updated to \`taskGroup(|g| g.spawn(|| 42))\` since Map.get is now native
- [x] All pre-existing ONB + backend (-short) tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)