### PR TITLE
feat: std.time.now() backend lowering

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -22317,6 +22317,60 @@ void osty_rt_thread_sleep(int64_t nanos) {
     osty_rt_sleep_ns((uint64_t)nanos);
 }
 
+/* std.time.now wall-clock source. Returns nanoseconds since the Unix
+ * epoch, the i64 payload of an Osty `Instant`. `clock_gettime` /
+ * `GetSystemTimeAsFileTime` give whole-nanosecond precision on all
+ * supported targets; the saturating fallback when the platform call
+ * fails keeps the contract "result is monotonic-ish, never negative". */
+int64_t osty_rt_time_now_nanos(void) {
+#if defined(_WIN32)
+    FILETIME ft;
+    ULARGE_INTEGER li;
+    GetSystemTimeAsFileTime(&ft);
+    li.LowPart = ft.dwLowDateTime;
+    li.HighPart = ft.dwHighDateTime;
+    /* FILETIME is 100ns ticks since 1601-01-01; subtract the offset to
+     * 1970-01-01 (11644473600 seconds = 116444736000000000 ticks). */
+    if (li.QuadPart < 116444736000000000ULL) {
+        return 0;
+    }
+    return (int64_t)((li.QuadPart - 116444736000000000ULL) * 100ULL);
+#else
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        return 0;
+    }
+    return (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
+#endif
+}
+
+/* std.time.local local-zone offset in seconds east of UTC. Captures
+ * DST as observed at call time so callers can rebuild a `Zone` with
+ * the right wall-clock skew. POSIX `localtime_r` populates `tm_gmtoff`
+ * directly; on Windows we derive it from `GetTimeZoneInformation`
+ * (Bias is in minutes west of UTC, so we negate to seconds east). */
+int64_t osty_rt_time_local_offset_seconds(void) {
+#if defined(_WIN32)
+    TIME_ZONE_INFORMATION tz;
+    DWORD r = GetTimeZoneInformation(&tz);
+    LONG bias = tz.Bias;
+    if (r == TIME_ZONE_ID_DAYLIGHT) {
+        bias += tz.DaylightBias;
+    } else if (r == TIME_ZONE_ID_STANDARD) {
+        bias += tz.StandardBias;
+    }
+    /* Bias is minutes west of UTC; offset east is -bias * 60. */
+    return -(int64_t)bias * 60LL;
+#else
+    time_t now = time(NULL);
+    struct tm tm_local;
+    if (localtime_r(&now, &tm_local) == NULL) {
+        return 0;
+    }
+    return (int64_t)tm_local.tm_gmtoff;
+#endif
+}
+
 /* ---- Channels: bounded ring buffer, mutex + two condition variables.
  *
  * Every channel slot is an int64_t holding either a scalar (i64/i1/f64

--- a/internal/llvmgen/duration_constructors_test.go
+++ b/internal/llvmgen/duration_constructors_test.go
@@ -180,3 +180,27 @@ fn main() {
 		}
 	}
 }
+
+// `time.now()` returns an Instant, the spec-canonical wall-clock entry
+// point (LANG_SPEC §10.20). The LLVM lowering threads through
+// IntrinsicTimeNow → `osty_rt_time_now_nanos` (i64) → `inttoptr` into
+// the opaque-ptr Instant ABI (same shape Duration uses for its
+// Int64-payload value type). Without the intrinsic the call falls
+// through to "call to unresolved symbol std.time.now".
+func TestTimeNowLowersToRuntimeCallAndInstantPtrWrap(t *testing.T) {
+	got := emitDurationLLVM(t, `use std.time
+
+fn main() {
+    let x = time.now()
+}
+`)
+	for _, want := range []string{
+		"declare i64 @osty_rt_time_now_nanos()",
+		"call i64 @osty_rt_time_now_nanos()",
+		"inttoptr i64 ",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("time.now() missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -683,8 +683,12 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		// Concurrency runtime types are opaque pointers — the emitter
 		// doesn't need a declared layout for them. These match what
 		// the runtime ABI hands back from chan_make / spawn / etc.
+		// `Instant` joins the list because std.time models it as a
+		// single-Int64 wrapper (§10.20) — same shape as Duration —
+		// and `time.now()` lowers to a `osty_rt_time_now_nanos` i64
+		// wrapped via `inttoptr`.
 		switch x.Name {
-		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration", "Rng", "Gen", "Uuid", "Regex", "Captures", "Never":
+		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration", "Instant", "Rng", "Gen", "Uuid", "Regex", "Captures", "Never":
 			return true
 		case "Range":
 			// Range<T> is a prelude type but the Go-side resolver
@@ -1422,7 +1426,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicSelectTimeout, mir.IntrinsicSelectDefault:
 		return true
 	case mir.IntrinsicIsCancelled, mir.IntrinsicCheckCancelled,
-		mir.IntrinsicYield, mir.IntrinsicSleep:
+		mir.IntrinsicYield, mir.IntrinsicSleep, mir.IntrinsicTimeNow:
 		return true
 	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
 		return true
@@ -5236,7 +5240,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicSelectTimeout, mir.IntrinsicSelectDefault:
 		return g.emitSelectIntrinsic(i)
 	case mir.IntrinsicIsCancelled, mir.IntrinsicCheckCancelled,
-		mir.IntrinsicYield, mir.IntrinsicSleep:
+		mir.IntrinsicYield, mir.IntrinsicSleep, mir.IntrinsicTimeNow:
 		return g.emitCancelIntrinsic(i)
 	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
 		return g.emitConcurrencyHelperIntrinsic(i)
@@ -8378,6 +8382,25 @@ func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
 		sym := mirRtThreadSleepSymbol()
 		g.declareRuntime(sym, mirRuntimeDeclareVoidFromPtrLine(sym))
 		g.fnBuf.WriteString(mirCallVoidPtrLine(sym, dur))
+		return nil
+	case mir.IntrinsicTimeNow:
+		if len(i.Args) != 0 {
+			return unsupported("mir-mvp", "time.now arity")
+		}
+		sym := mirRtTimeNowNanosSymbol()
+		g.declareRuntime(sym, mirRuntimeDeclareI64NoArgsLine(sym))
+		nanos := g.fresh()
+		g.fnBuf.WriteString(mirCallValueNoArgsLine(nanos, "i64", sym))
+		if i.Dest == nil {
+			return nil
+		}
+		// Instant shares Duration's opaque-ptr ABI (single Int64
+		// payload, §10.20) — wrap the runtime i64 with `inttoptr`
+		// before storing into the dest slot so the value flows like
+		// any other Instant produced by Osty source.
+		instReg := g.fresh()
+		g.fnBuf.WriteString(mirIntToPtrLine(instReg, "i64", nanos))
+		g.fnBuf.WriteString(mirStoreLine("ptr", instReg, g.localSlots[i.Dest.Local]))
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("cancel intrinsic kind %d", i.Kind))

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -83,7 +83,7 @@ func mirLlvmTypeForOpaqueNamed(name string) string {
 		return "ptr"
 	}
 	// Osty: toolchain/mir_generator.osty:83:5
-	if name == "Channel" || name == "Handle" || name == "Group" || name == "TaskGroup" || name == "Select" || name == "Duration" {
+	if name == "Channel" || name == "Handle" || name == "Group" || name == "TaskGroup" || name == "Select" || name == "Duration" || name == "Instant" {
 		// Osty: toolchain/mir_generator.osty:85:9
 		return "ptr"
 	}
@@ -161,7 +161,7 @@ func mirTupleTagForNamed(name string, builtin bool) string {
 		}
 	}
 	// Osty: toolchain/mir_generator.osty:160:5
-	if name == "Channel" || name == "Handle" || name == "Group" || name == "TaskGroup" || name == "Select" || name == "Duration" {
+	if name == "Channel" || name == "Handle" || name == "Group" || name == "TaskGroup" || name == "Select" || name == "Duration" || name == "Instant" {
 		// Osty: toolchain/mir_generator.osty:162:9
 		return "ptr"
 	}
@@ -6068,6 +6068,10 @@ func mirRtThreadYieldSymbol() string { return mirRtThreadSymbol("yield") }
 func mirRtThreadSleepSymbol() string { return mirRtThreadSymbol("sleep") }
 func mirRtThreadSpawnSymbol() string { return mirRtThreadSymbol("spawn") }
 
+// Osty: mirRtTime* fixed-symbols
+func mirRtTimeSymbol(suffix string) string { return "osty_rt_time_" + suffix }
+func mirRtTimeNowNanosSymbol() string      { return mirRtTimeSymbol("now_nanos") }
+
 // Osty: mirRtBench* fixed-symbols
 func mirRtBenchNowNanosSymbol() string { return mirRtBenchSymbol("now_nanos") }
 func mirRtBenchTargetNsSymbol() string { return mirRtBenchSymbol("target_ns") }
@@ -9392,6 +9396,8 @@ func mirIntrinsicKindLabelFull(kind int, kindFallback string) string {
 		return "map.clear"
 	case 137:
 		return "set.clear"
+	case 138:
+		return "time_now"
 	}
 	return kindFallback
 }

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -5236,6 +5236,14 @@ func concurrencyIntrinsicForFree(qualifier, name string) IntrinsicKind {
 		if threadNs || qualifier == "time" || qualifier == "std.time" {
 			return IntrinsicSleep
 		}
+	case "now":
+		// `time.now()` returns an `Instant` (struct `{ i64 unixNanos }`).
+		// Lowered to the runtime helper `osty_rt_time_now_nanos`, then
+		// wrapped as the Instant aggregate at the LLVM emit site so the
+		// public Osty API stays a regular value type.
+		if qualifier == "time" || qualifier == "std.time" {
+			return IntrinsicTimeNow
+		}
 	}
 	return IntrinsicInvalid
 }

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -834,6 +834,13 @@ const (
 	// Dest nil. Appended at the tail to preserve historical enum
 	// values for every previously-emitted intrinsic.
 	IntrinsicSetClear
+	// IntrinsicTimeNow reads the current wall-clock time. Args: [].
+	// Dest receives an Instant (single-Int64 wrapper, §10.20). The
+	// LLVM lowering calls `osty_rt_time_now_nanos` and `inttoptr`s
+	// the i64 nanoseconds into Instant's opaque-ptr ABI (the same
+	// shape Duration uses). Appended at the tail to preserve every
+	// historical enum integer value.
+	IntrinsicTimeNow
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1658,6 +1665,8 @@ func (k IntrinsicKind) String() string {
 		return "yield"
 	case IntrinsicSleep:
 		return "sleep"
+	case IntrinsicTimeNow:
+		return "time_now"
 	case IntrinsicListPush:
 		return "list_push"
 	case IntrinsicListLen:

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -67,8 +67,12 @@ pub fn mirLlvmTypeForOpaqueNamed(name: String) -> String {
         return "ptr"
     }
     // Concurrency runtime values: same deal — opaque handles.
+    // `Instant` (std.time §10.20) joins the list as the single-Int64
+    // wall-clock value type — same opaque-ptr ABI as Duration so
+    // `time.now()` can return a runtime i64 via `inttoptr`.
     if name == "Channel" || name == "Handle" || name == "Group" ||
-       name == "TaskGroup" || name == "Select" || name == "Duration" {
+       name == "TaskGroup" || name == "Select" || name == "Duration" ||
+       name == "Instant" {
         return "ptr"
     }
     // Closure environment struct — always passed as a pointer to the
@@ -143,9 +147,12 @@ pub fn mirTupleTagForNamed(name: String, builtin: Bool) -> String {
     }
     // Concurrency runtime handle types are always opaque pointers,
     // regardless of the Builtin flag — the Go source also skips the
-    // guard here, so we keep the same relaxation.
+    // guard here, so we keep the same relaxation. `Instant` joins
+    // the same opaque-ptr club so it composes inside `Tuple`/`Result`
+    // mangled names.
     if name == "Channel" || name == "Handle" || name == "Group" ||
-       name == "TaskGroup" || name == "Select" || name == "Duration" {
+       name == "TaskGroup" || name == "Select" || name == "Duration" ||
+       name == "Instant" {
         return "ptr"
     }
     name


### PR DESCRIPTION
## Summary

- Wires `time.now()` through the LLVM backend so it actually reads the wall clock instead of falling through to "unresolved symbol std.time.now"
- New C runtime helpers: `osty_rt_time_now_nanos` (POSIX `clock_gettime(CLOCK_REALTIME)` + Windows `GetSystemTimeAsFileTime`) and `osty_rt_time_local_offset_seconds` (queued for upcoming `time.local()`/`time.zone()` work)
- `Instant` joins the opaque-ptr whitelist (matches Duration's single-Int64 ABI per §10.20); `time.now()` lowers to an i64 runtime call wrapped via `inttoptr`

## Pipeline path

```
time.now()  →  concurrencyIntrinsicForFree("time", "now")
            →  IntrinsicTimeNow                  (mir/mir.go, mir/lower.go)
            →  call i64 @osty_rt_time_now_nanos()
            →  inttoptr i64 to ptr               (llvmgen/mir_generator.go)
            →  store ptr, %dest
```

`IntrinsicTimeNow` is appended at the tail of the `IntrinsicKind` enum so every previously-emitted intrinsic keeps its historical integer value — matches the `IntrinsicMapClear`/`IntrinsicSetClear` policy. The `mirIntrinsicKindLabelFull` table gets a new `case 138`, and `toolchain/mir_generator.osty` is kept in sync with the Go snapshot for the opaque-ptr whitelist.

## Test plan

- [x] `go test ./internal/llvmgen/ -run "TestDuration|TestTime|TestSleep" -count=1` — added `TestTimeNowLowersToRuntimeCallAndInstantPtrWrap`, asserts the `declare i64 @osty_rt_time_now_nanos()` + `inttoptr` IR shape; existing duration constructor + `time.sleep` tests still pass
- [x] `go test ./internal/mir/ ./internal/ir/ ./internal/check/ ./internal/resolve/` — green
- [x] `go test ./internal/llvmgen/ -short` — green
- Pre-existing failures (`TestNativeToolchainMergedMIRPipelineIsClean`, `TestStdlibSupportMatrix*`) reproduce on `main` and are unrelated

## Out of scope (follow-ups)

- `time.utc()` / `time.local()` / `time.zone(name)` — runtime hook is in place (`osty_rt_time_local_offset_seconds`); pure-Osty bodies left for a separate change
- `Instant.format(layout)` / `time.parse(text, layout)` — still body-less; need either a Go-style layout parser in Osty or runtime helpers
- `ZonedTime.year/month/day/...` calendar accessors — pure-Osty `days_from_civil` algorithm, follow-up
- `Duration.toString()` — pure-Osty body, follow-up

https://claude.ai/code/session_01U2PoqB71TZNffvXkbbFb34

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2PoqB71TZNffvXkbbFb34)_