### PR TITLE
fix: mir-direct std.strings.fromChar native binding

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3555,6 +3555,8 @@ func (g *mirGen) emitStdStringsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, e
 	switch name {
 	case "compare", "Compare":
 		return true, g.emitStdStringsRuntimeCall(c, llvmStringRuntimeCompareSymbol(), "i64", []mir.Type{ir.TString, ir.TString})
+	case "fromChar":
+		return true, g.emitStdStringsRuntimeCall(c, mirRtCharToStringSymbol(), "ptr", []mir.Type{ir.TChar})
 	}
 	return false, nil
 }

--- a/internal/onb/lower.go
+++ b/internal/onb/lower.go
@@ -48,17 +48,17 @@ const regX8 Reg = "x8"
 // exactly. The Mach-O `bl` encoder prepends the leading underscore for
 // darwin's symbol mangling.
 const (
-	runtimeSymStringConcat       = "osty_rt_strings_Concat"
-	runtimeSymListNew            = "osty_rt_list_new"
-	runtimeSymListPushI64        = "osty_rt_list_push_i64"
-	runtimeSymListPushI1         = "osty_rt_list_push_i1"
-	runtimeSymListPushF64        = "osty_rt_list_push_f64"
-	runtimeSymListPushString     = "osty_rt_list_push_string"
-	runtimeSymListLen            = "osty_rt_list_len"
-	runtimeSymListGetI64         = "osty_rt_list_get_i64"
-	runtimeSymListGetI1          = "osty_rt_list_get_i1"
-	runtimeSymListGetF64         = "osty_rt_list_get_f64"
-	runtimeSymListGetString      = "osty_rt_list_get_string"
+	runtimeSymStringConcat   = "osty_rt_strings_Concat"
+	runtimeSymListNew        = "osty_rt_list_new"
+	runtimeSymListPushI64    = "osty_rt_list_push_i64"
+	runtimeSymListPushI1     = "osty_rt_list_push_i1"
+	runtimeSymListPushF64    = "osty_rt_list_push_f64"
+	runtimeSymListPushString = "osty_rt_list_push_string"
+	runtimeSymListLen        = "osty_rt_list_len"
+	runtimeSymListGetI64     = "osty_rt_list_get_i64"
+	runtimeSymListGetI1      = "osty_rt_list_get_i1"
+	runtimeSymListGetF64     = "osty_rt_list_get_f64"
+	runtimeSymListGetString  = "osty_rt_list_get_string"
 	// closure_env_alloc_v2 is exported by the runtime under the dotted
 	// (LLVM-shaped) name via __asm__("osty.rt..."). Mach-O symbol
 	// encoding prepends the leading underscore, matching the call site.
@@ -1775,7 +1775,6 @@ func (s *lowerState) indirectArgAddress(arg mir.Operand, dst Reg) ([]Instr, erro
 	}
 	return []Instr{&LoadStackAddress{Dst: dst, Offset: slot}}, nil
 }
-
 
 // destType returns the MIR type of a local in the current function. The
 // caller already knows the local is a Dest of a CallInstr, so a missing

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,17 +2,15 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 402 `.osty` file(s)  
-**Captured:** 217 residual case(s) — **1** AI-slip(s) airepair rewrote, **216** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 418 `.osty` file(s)  
+**Captured:** 217 residual case(s) — **0** AI-slip(s) airepair rewrote, **217** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)
 
-```
-learning priorities:
-  1. javascript_for_of_loop -> E0703  score=135 cases=1 residual_errors=1 stage=check action=promote_and_fix_check representative=webview2 corpus=uncovered
-     next: promote webview2 into the corpus, then investigate the check-stage residual for javascript_for_of_loop -> E0703
-```
+_No new AI slips this run — airepair didn't need to rewrite anything._
+
+If `Captured` is non-zero above, it's domain code that fails the checker for unrelated reasons (self-host / backend coverage).
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- mir-direct 백엔드의 `emitStdStringsCall`에 `fromChar` 케이스 추가. 기존 `osty_rt_char_to_string` 런타임 helper 재사용 (compare 패턴 미러링).
- toolchain 빌드가 self-host MIR 깊은 lowering 진입 시 `LLVM000 unresolved symbol std.strings.fromChar`로 멈추던 회귀 해소.
- 부수 chore: 사전에 들어와 있던 `internal/onb/lower.go` gofmt drift, prepush가 갱신한 `todo-airepair.md` 동반 커밋.

## Test plan
- [x] `just prepush` (fmt-check + vet + repair-check + airepair-capture + ci) 그린
- [x] `osty build toolchain` 가 `fromChar` unresolved 지점을 통과하는지 재현 확인 (다음 갭 `string_concat arg type` 별건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)