### PR TITLE
feat: dbg(value) actually prints (eprint + identity passthrough)

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1509,14 +1509,15 @@ func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
 	}
 }
 
-// TestGenerateFromMIRDbgLowersAsIdentity pins the prelude diagnostic
-// builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10). The current
-// implementation lowers `dbg(x)` as identity passthrough — the
-// destination receives the operand directly with no runtime call.
-// Closes the LLVM000 "unresolved symbol dbg" gap that previously
-// rejected any program calling `dbg(...)`. A future refinement adds
-// the eprintln (location + expr text + value) shape.
-func TestGenerateFromMIRDbgLowersAsIdentity(t *testing.T) {
+// TestGenerateFromMIRDbgPrintsAndPassesThrough pins the prelude
+// diagnostic builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10). For
+// stringifiable primitives (Int / Float / Bool / Char / Byte / String)
+// the lowerer emits `eprint("[dbg] " + value + "\n")` — using the
+// existing string_concat path which auto-boxes scalars via
+// `emitStringConcatBoxed` — and identity-passes the value into the
+// destination so callers see it unchanged. No `@dbg` call survives;
+// the value reaches the destination directly.
+func TestGenerateFromMIRDbgPrintsAndPassesThrough(t *testing.T) {
 	// fn check(n: Int) -> Int {
 	//     let x = dbg(n)
 	//     x + 1
@@ -1552,18 +1553,21 @@ func TestGenerateFromMIRDbgLowersAsIdentity(t *testing.T) {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
 	got := string(out)
-	// Identity passthrough means no `@dbg` call survives — the
-	// argument flows straight into the next instruction.
 	if strings.Contains(got, "@dbg(") {
-		t.Fatalf("dbg should lower as identity (no @dbg call), got:\n%s", got)
+		t.Fatalf("dbg should not produce a literal @dbg call, got:\n%s", got)
 	}
 	if strings.Contains(got, "unresolved symbol dbg") {
 		t.Fatalf("output still contains unresolved-symbol diagnostic:\n%s", got)
 	}
 	for _, want := range []string{
-		"define i64 @check(i64",
-		"add i64",
-		"ret i64",
+		"c\"[dbg] \\00\"",                  // prefix in string pool
+		"c\"\\0A\\00\"",                    // newline literal in string pool
+		"call ptr @osty_rt_int_to_string(", // Int boxed via toString
+		"@osty_rt_strings_ConcatN(",        // 3-piece concat
+		"call void @osty_rt_io_write(",     // eprint write
+		"define i64 @check(i64",            // function envelope preserved
+		"add i64",                          // identity-passthrough enables `+ 1`
+		"ret i64",                          // value returned unchanged
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4183,15 +4183,42 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			return
 		}
 		// `dbg<T>(value: T) -> T` — diagnostic prelude builtin
-		// (LANG_SPEC §A.10). Today: identity passthrough — assign
-		// the argument operand into the destination. A future
-		// refinement adds the eprintln (location + expr text + value)
-		// shape; the identity step keeps user programs compiling now.
+		// (LANG_SPEC §A.10). For stringifiable primitive types,
+		// emit `eprint("[dbg] " + value + "\n")` via the existing
+		// string_concat path (which auto-boxes Int/Float/Bool/...
+		// via emitStringConcatBoxed). Then identity-passthrough the
+		// value into the destination so callers see it unchanged.
+		// Non-stringifiable types skip the print and fall back to
+		// identity-only.
 		if id.Name == "dbg" && len(c.Args) == 1 && dest != nil {
-			valueOp := bs.lowerExprAsOperand(c.Args[0].Value)
+			arg := c.Args[0].Value
+			argT := arg.Type()
+			// Spill into a temp so the value is read once, then
+			// referenced from both the eprint chain and the identity
+			// assign without re-evaluating side effects.
+			valueLocal := bs.newLocal("_dbg_val", argT, false, c.SpanV)
+			bs.emit(&StorageLiveInstr{Local: valueLocal, SpanV: c.SpanV})
+			bs.lowerExprInto(arg, valueLocal, argT)
+			if dbgCanStringify(argT) {
+				prefix := &ConstOp{Const: &StringConst{Value: "[dbg] "}, T: TString}
+				suffix := &ConstOp{Const: &StringConst{Value: "\n"}, T: TString}
+				valueOp := &CopyOp{Place: Place{Local: valueLocal}, T: argT}
+				msgLocal := bs.freshTemp(TString, c.SpanV)
+				bs.emit(&IntrinsicInstr{
+					Dest:  &Place{Local: msgLocal},
+					Kind:  IntrinsicStringConcat,
+					Args:  []Operand{prefix, valueOp, suffix},
+					SpanV: c.SpanV,
+				})
+				bs.emit(&IntrinsicInstr{
+					Kind:  IntrinsicEprint,
+					Args:  []Operand{&CopyOp{Place: Place{Local: msgLocal}, T: TString}},
+					SpanV: c.SpanV,
+				})
+			}
 			bs.emit(&AssignInstr{
 				Dest:  *dest,
-				Src:   &UseRV{Op: valueOp},
+				Src:   &UseRV{Op: &CopyOp{Place: Place{Local: valueLocal}, T: argT}},
 				SpanV: c.SpanV,
 			})
 			return
@@ -4417,6 +4444,29 @@ func (bs *bodyState) builtinFreeCallIntrinsic(name string, args []ir.Arg) Intrin
 		return IntrinsicInvalid
 	}
 	return builtinFreeCallIntrinsicForReceiver(bs.recoveredTypeOf(args[0].Value), name)
+}
+
+// dbgCanStringify reports whether `dbg(value)` can render the
+// argument via the existing `string_concat` boxing path
+// (`emitStringConcatBoxed`). Today that covers every primitive
+// scalar plus String — anything else falls back to identity-only so
+// `dbg(struct)` stays a safe no-op until a generic ToString
+// protocol lands. Mirror of `mirLowerDbgCanStringify` in
+// `toolchain/mir_lower.osty`.
+func dbgCanStringify(t Type) bool {
+	pt, ok := t.(*ir.PrimType)
+	if !ok {
+		return false
+	}
+	switch pt.Kind {
+	case ir.PrimInt, ir.PrimInt8, ir.PrimInt16, ir.PrimInt32, ir.PrimInt64,
+		ir.PrimUInt8, ir.PrimUInt16, ir.PrimUInt32, ir.PrimUInt64,
+		ir.PrimByte, ir.PrimChar,
+		ir.PrimFloat, ir.PrimFloat32, ir.PrimFloat64,
+		ir.PrimBool, ir.PrimString:
+		return true
+	}
+	return false
 }
 
 // divergingBuiltinMessage returns the canonical runtime message for the

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3764,14 +3764,44 @@ pub fn mirLowerCallExprInto(
             return
         }
         // 1b. `dbg<T>(value: T) -> T` — diagnostic prelude builtin
-        //     (LANG_SPEC §A.10). Today: identity passthrough — assign
-        //     the argument operand into the destination so the value
-        //     flows through unchanged. A future refinement adds the
-        //     eprintln (location + expr text + value) shape; the
-        //     identity step keeps user programs compiling now.
+        //     (LANG_SPEC §A.10). For stringifiable primitive types,
+        //     emit `eprint("[dbg] " + value + "\n")` via the existing
+        //     string_concat path (which auto-boxes Int/Float/Bool/...
+        //     via `emitStringConcatBoxed`). Then identity-passthrough
+        //     the value into the destination so callers see it
+        //     unchanged. Non-stringifiable types skip the print and
+        //     fall back to identity-only — keeps dbg() a safe no-op
+        //     for shapes the runtime can't render.
         if callee.identName == "dbg" && e.callArgs.len() == 1 {
-            let valueOp = mirLowerExprAsOperand(bs, e.callArgs[0].value)
-            mirLowerEmitInstr(bs, mirAssignInstr(dest, mirRVUse(valueOp), span))
+            let arg = e.callArgs[0].value
+            // Spill into a temp so the value is read once, then
+            // referenced from both the eprint chain and the identity
+            // assign without re-evaluating side effects.
+            let valueLocal = mirLowerNewLocal(bs, "_dbg_val", arg.typ, false, span)
+            mirLowerEmitInstr(bs, mirStorageLiveInstr(valueLocal, span))
+            mirLowerExprInto(bs, arg, valueLocal, arg.typ)
+            let valueTypeText = hirTypeString(arg.typ)
+            if mirLowerDbgCanStringify(arg.typ) {
+                let mut concatArgs: List<MirOperand> = []
+                concatArgs.push(mirOperandConst(mirConstString("[dbg] ")))
+                concatArgs.push(mirOperandCopy(mirPlace(valueLocal), valueTypeText))
+                concatArgs.push(mirOperandConst(mirConstString("\n")))
+                let msgLocal = mirLowerNewLocal(bs, "_dbg_msg", hirTString(), false, span)
+                mirLowerEmitInstr(
+                    bs,
+                    mirIntrinsicInstr(true, mirPlace(msgLocal), MirIntrinsicStringConcat, concatArgs, span),
+                )
+                let mut eprintArgs: List<MirOperand> = []
+                eprintArgs.push(mirOperandCopy(mirPlace(msgLocal), "String"))
+                mirLowerEmitInstr(
+                    bs,
+                    mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicEprint, eprintArgs, span),
+                )
+            }
+            mirLowerEmitInstr(
+                bs,
+                mirAssignInstr(dest, mirRVUse(mirOperandCopy(mirPlace(valueLocal), valueTypeText)), span),
+            )
             return
         }
         let bk = mirLowerBuiltinFreeCallIntrinsic(bs, callee.identName, e.callArgs)
@@ -5923,6 +5953,36 @@ pub fn mirLowerDivergingBuiltinMessage(name: String) -> String {
         return "abort called"
     }
     ""
+}
+
+/// mirLowerDbgCanStringify reports whether `dbg(value)` can render the
+/// argument via the existing `string_concat` boxing path. Today that
+/// covers every primitive scalar plus String — anything else falls
+/// back to identity-only so `dbg(struct)` stays a safe no-op until a
+/// generic ToString protocol lands.
+pub fn mirLowerDbgCanStringify(t: HirType) -> Bool {
+    if t.kind != HirTypePrim {
+        return false
+    }
+    match t.primKind {
+        HirPrimInt -> true,
+        HirPrimInt8 -> true,
+        HirPrimInt16 -> true,
+        HirPrimInt32 -> true,
+        HirPrimInt64 -> true,
+        HirPrimUInt8 -> true,
+        HirPrimUInt16 -> true,
+        HirPrimUInt32 -> true,
+        HirPrimUInt64 -> true,
+        HirPrimByte -> true,
+        HirPrimChar -> true,
+        HirPrimFloat -> true,
+        HirPrimFloat32 -> true,
+        HirPrimFloat64 -> true,
+        HirPrimBool -> true,
+        HirPrimString -> true,
+        _ -> false,
+    }
 }
 
 /// mirLowerBuiltinFreeCallIntrinsic recognises prelude-shaped free


### PR DESCRIPTION
## Summary
#1294 stubbed `dbg<T>(value: T) -> T` as **identity-only** — programs compiled but the diagnostic builtin produced no observable output. This wires the real LANG_SPEC §A.10 behavior: print to stderr, then return the value unchanged.

Implementation reuses the existing `IntrinsicStringConcat` boxing path (`emitStringConcatBoxed`) instead of adding a new intrinsic — the concat call's argument list accepts non-String operands and the generator already type-dispatches scalars through `osty_rt_int_to_string` / `osty_rt_float_to_string` / `osty_rt_bool_to_string` / `osty_rt_char_to_string` / `osty_rt_byte_to_string`.

Lowering synthesises:
```
tmp = string_concat("[dbg] ", value, "\n")
eprint(tmp)
dest = value          // identity passthrough
```

For non-stringifiable types (structs / enums / collections / fn values) the print step is skipped — `dbg(struct)` falls back to identity-only and stays a safe no-op until a generic ToString protocol lands.

Mirrored in both the Osty self-host port (`toolchain/mir_lower.osty`) and Go production (`internal/mir/lower.go`), per CLAUDE.md **"Osty 우선"**. New `mirLowerDbgCanStringify` / `dbgCanStringify` helpers gate the print emit on supported primitive kinds.

## Before / after

```osty
fn check(n: Int) -> Int {
    let x = dbg(n)
    x + 1
}
```

**Before** (#1294 stub):
```llvm
; ... value loaded into l3, identity-stored to l2 ...
%t13 = load i64, ptr %l2
%t14 = add i64 %t13, 1
ret i64 ...
```
(No print — stdout/stderr completely silent.)

**After**:
```llvm
@.str.0 = private unnamed_addr constant [7 x i8] c"[dbg] \00"
@.str.1 = private unnamed_addr constant [2 x i8] c"\0A\00"
declare ptr @osty_rt_int_to_string(i64)
declare ptr @osty_rt_strings_ConcatN(i64, ptr)
declare void @osty_rt_io_write(ptr, i1, i1)
...
%t5 = call ptr @osty_rt_int_to_string(i64 %t4)         ; box Int → String
; ... build [3 x ptr] of [@.str.0, %t5, @.str.1] ...
%t10 = call ptr @osty_rt_strings_ConcatN(i64 3, ptr %t6)
call void @osty_rt_io_write(ptr %t11, i1 false, i1 true) ; eprint to stderr
%t12 = load i64, ptr %l3                                ; identity passthrough
store i64 %t12, ptr %l2
%t14 = add i64 %t13, 1
ret i64 ...
```

Running this prints `[dbg] 5\n` to stderr and returns 6 (5+1).

## Test plan
- [x] Test renamed `TestGenerateFromMIRDbgLowersAsIdentity` → `TestGenerateFromMIRDbgPrintsAndPassesThrough` with asserts on the new shape (prefix bytes, newline literal, `osty_rt_int_to_string`, ConcatN, `osty_rt_io_write`, plus the identity-driven `add i64` / `ret i64` proving value reached destination).
- [x] `just front` green
- [x] `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green
- [x] `.bin/osty check toolchain/` clean
- [x] `osty gen` end-to-end probe verified (Int / String / Bool primitives box correctly via existing toString runtime)
- [ ] CI 그린 확인

## Future refinement
Spec §A.10 also asks for **location + expression text** (`[file:line] expr = value`). Today emits just `[dbg] value` — getting the source-level expression text requires either a parser/HIR-side rewrite or a span→text lookup at MIR lowering time. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)