### PR TITLE
feat: ONB self-host port Phase 1 — leaf modules in toolchain/onb_*.osty

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,74 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 24 (ONB self-host port — Phase 1 leaf modules,
+> 2026-05-02)** — ONB Go 구현의 Osty 포팅 첫 슬라이스. **Tier 1 native
+> 기능 확장은 일단락**, 이제부터 `internal/onb/`의 Go 코드를
+> `toolchain/onb_*.osty`로 옮기는 self-host 포팅 트랙으로 전환.
+>
+> 패턴 (lir_proto.osty 선례 따름):
+> - Osty source = future-canonical 단일 소스
+> - Go 구현 = 현재 production (LLVM self-host LLVMgen이 ONB를 컴파일할
+>   수 있을 때까지)
+> - Go-side 페어리티 테스트가 두 표현이 byte-for-byte 일치하도록 잠금
+> - `generated.go` 재생성 경로는 #854 이후 frozen이라 Osty 코드는
+>   현재 dev-time runtime에 직접 닿지 않음 — `osty check toolchain` smoke
+>   가 syntactic/typecheck만 검증
+>
+> Phase 1 (이번 슬라이스, MIR/LIR 의존성 없는 leaf 모듈 3개):
+>
+> 1. `toolchain/onb_encoding.osty` — pure aarch64 instruction encoders
+>    - `onbXRegisterNumber` / `onbDRegisterNumber` — 레지스터명 → 0..31 인코딩
+>    - `onbEncodeBrk` (UnreachableTerm trap)
+>    - `onbEncodeFmovDFromX` / `onbEncodeFmovXFromD` (FP↔Int 비트캐스트)
+>    - `onbEncodeFPArith(base, ...)` (fadd/fsub/fmul/fdiv 공통)
+>    - `onbEncodeBlr` (closure indirect call)
+>    - `onbEncodeRet`
+>    - `onbEncodeFPStack(base, reg, off)` (str/ldr d, [sp])
+>    - `onbEncodeLoadStoreReg(base, t, n, off)` (str/ldr x, [reg])
+>    - `onbEncodeMovRegReg`
+>
+> 2. `toolchain/onb_runtime_symbols.osty` — 런타임 심볼 테이블
+>    - `onbAbiKind*` 5종 상수 + `onbAbiKindFor`-슈도 헬퍼
+>    - `onbRuntimeSym*` String/List/Map/Closure 심볼 상수
+>    - `onbListPushSymbolForKind` / `onbListGetSymbolForKind`
+>    - `onbMapInsert/Get/Contains/RemoveSymbolForKeyKind` (5개 dispatch table)
+>
+> 3. `toolchain/onb_layouts.osty` — 슬롯/객체 layout 헬퍼
+>    - `onbClosureEnvCapturesOffset()` (= 24, 런타임 헤더 크기)
+>    - `onbClosureEnvFieldByteOffset(index)` — index 0 → 0 (fn ptr),
+>      index N≥1 → 24 + (N-1)*8 (capture N-1)
+>    - `onbEnumPayloadOffset(fieldIdx)` / `onbEnumDiscriminantOffset()`
+>    - `onbStructFieldByteOffset(index)`
+>    - `onbAbiSmallStructRegLimit()` / `onbAbiIndirectStructFieldLimit()`
+>      / `onbAbiPointerRegSlotBytes()`
+>
+> 4. `toolchain/onb_encoding_test.osty` — Osty-side parity 테이블 (14 케이스)
+>
+> 5. `internal/onb/onb_osty_parity_test.go` — Go-side parity gate. Go
+>    encoder가 produce하는 32-bit word를 Osty 테스트의 expected hex와
+>    한 줄씩 비교. 두 표현 사이 drift는 PR 리뷰에서 양쪽 expected
+>    column 수정으로 surface.
+>
+> 한계 (이번 슬라이스에서 명시적으로 보류):
+> - **runtime wire 없음** — Osty 함수는 dead code 상태. 실제 production은
+>   여전히 `internal/onb/{lower,macho,asm,dwarf}.go`. LLVM self-host
+>   LLVMgen이 ONB를 컴파일할 수 있게 되면 그때 `selfhost.ONBRunner` 같은
+>   인터페이스로 wire (lir_proto_runner.go 패턴 참조).
+> - MIR/LIR 타입 의존하는 함수 (abiRegSlots, lookupStructLayout, lower*Assign)
+>   는 Phase 2+. 먼저 LIR opcode + Reg를 Osty enum으로 미러해야 함.
+> - DWARF 인코더 / 라인 프로그램 / Mach-O 헤더는 Phase 6+ 별도 슬라이스.
+>
+> 검증:
+> - `go run ./cmd/osty check ./toolchain` — exit 0 (4 새 파일 syntactic
+>   + typecheck 통과)
+> - `go test ./internal/onb -run TestEncoderParityVsOstyTable` — Go encoder
+>   가 Osty 테이블의 14개 expected hex값과 byte-for-byte 일치
+>
+> **다음 phase 후보**: LIR Opcode + Reg를 Osty enum으로 (Phase 2),
+> 또는 ABI 헬퍼 (`abiRegSlots` 등)를 MIR Type 의존 minimal subset으로
+> 시작 (Phase 3a).
+>
 > **Slice A2 Week 23 (Map<K,V> — get / containsKey / remove, 2026-05-02)** —
 > Map의 핵심 lookup 3종을 native lowering. Week 22의 new/insert/len과
 > 결합하면 Map 일상 사용 (캐시, 인덱스, 빈도 카운트)이 fallback 없이

--- a/internal/onb/onb_osty_parity_test.go
+++ b/internal/onb/onb_osty_parity_test.go
@@ -1,0 +1,87 @@
+package onb
+
+import "testing"
+
+// TestEncoderParityVsOstyTable pins the canonical 32-bit aarch64
+// instruction word the Go-side `internal/onb/macho.go` encoder
+// produces for every entry in the Osty-side
+// `toolchain/onb_encoding.osty` parity table. The Osty file is the
+// future-canonical source of truth: when the LLVM self-host LLVMgen
+// can compile `toolchain/onb_*.osty`, this test guarantees the two
+// encoders agree byte-for-byte.
+//
+// Update protocol: if a Go encoder genuinely changes (new opcode
+// flavour, register-class shift, etc.), update both the Go body and
+// the matching `assertEncodedEq` line in
+// `toolchain/onb_encoding_test.osty` together. A drift in either
+// direction is a reviewable diff in this test's expected column.
+func TestEncoderParityVsOstyTable(t *testing.T) {
+	t.Parallel()
+
+	check := func(name string, got uint32, err error, want uint32) {
+		t.Helper()
+		if err != nil {
+			t.Errorf("%s: Go encode err %v", name, err)
+			return
+		}
+		if got != want {
+			t.Errorf("%s: Go encoder = 0x%08x; Osty parity table = 0x%08x", name, got, want)
+		}
+	}
+
+	// brk imm16 — UnreachableTerm trap. Three sentinel values cover
+	// the imm-zero, mid-range, and upper-bound encodings.
+	w, e := encodeBrk(1)
+	check("brk #1", w, e, 0xd4200020)
+	w, e = encodeBrk(0)
+	check("brk #0", w, e, 0xd4200000)
+	w, e = encodeBrk(0xffff)
+	check("brk #0xffff", w, e, 0xd43fffe0)
+
+	// fmov bridges between integer and FP register classes.
+	w, e = encodeFmovDFromX(RegD8, RegX9)
+	check("fmov d8, x9", w, e, 0x9e670128)
+	w, e = encodeFmovXFromD(RegX1, RegD9)
+	check("fmov x1, d9", w, e, 0x9e660121)
+
+	// fadd/fsub/fmul/fdiv — IEEE 754 double binary arithmetic.
+	w, e = encodeFPArith(0x1e602800, RegD8, RegD8, RegD9)
+	check("fadd d8,d8,d9", w, e, 0x1e692908)
+	w, e = encodeFPArith(0x1e603800, RegD8, RegD8, RegD9)
+	check("fsub d8,d8,d9", w, e, 0x1e693908)
+	w, e = encodeFPArith(0x1e600800, RegD8, RegD8, RegD9)
+	check("fmul d8,d8,d9", w, e, 0x1e690908)
+	w, e = encodeFPArith(0x1e601800, RegD8, RegD8, RegD9)
+	check("fdiv d8,d8,d9", w, e, 0x1e691908)
+
+	// FP stack store/load — float local spill and reload.
+	w, e = encodeFPStack(0xfd000000, RegD8, 0)
+	check("str d8 [sp,0]", w, e, 0xfd0003e8)
+	w, e = encodeFPStack(0xfd400000, RegD9, 16)
+	check("ldr d9 [sp,16]", w, e, 0xfd400be9)
+
+	// Reg-relative load/store — sret epilogue + indirect arg
+	// memcpy through caller-provided pointers.
+	w, e = encodeLoadStoreReg(0xf9400000, RegX9, RegX0, 0)
+	check("ldr x9 [x0,0]", w, e, 0xf9400009)
+	w, e = encodeLoadStoreReg(0xf9000000, RegX9, regX8, 16)
+	check("str x9 [x8,16]", w, e, 0xf9000909)
+
+	// mov reg, reg — env-pointer stash before staging captures.
+	w, e = encodeMachOMovRegReg(RegX10, RegX0)
+	check("mov x10, x0", w, e, 0xaa0003ea)
+
+	// blr Xn — closure indirect branch. Encoder lives inline in
+	// `macho.go`'s `case *BranchLinkReg` arm; mirror the same
+	// `0xd63f0000 | (n << 5)` formula here so the Osty parity
+	// table stays comparable.
+	if n, ok := xRegisterNumber(RegX9); ok {
+		got := uint32(0xd63f0000) | (n << 5)
+		const want uint32 = 0xd63f0120
+		if got != want {
+			t.Errorf("blr x9: Go = 0x%08x; Osty = 0x%08x", got, want)
+		}
+	} else {
+		t.Errorf("xRegisterNumber(x9) failed")
+	}
+}

--- a/toolchain/onb_encoding.osty
+++ b/toolchain/onb_encoding.osty
@@ -1,0 +1,187 @@
+// onb_encoding.osty — pure aarch64 instruction encoders for the Osty
+// Native Backend (ONB).
+//
+// Scope: bit-level encoding of every aarch64 word ONB emits. Each
+// helper takes already-resolved register numbers and immediates,
+// returns the 32-bit instruction word as Int. No MIR/LIR/AST
+// dependency — these are bottom-of-the-stack primitives that the
+// future LLVM-self-host port of `internal/onb/macho.go`'s encoder
+// will call into directly.
+//
+// Source of truth for the Go counterparts:
+//   - `internal/onb/macho.go` — Mach-O instruction encoding switch
+//   - `internal/onb/lower.go` — ABI helpers that compute offsets
+//
+// Style note: Osty has no UInt32 arithmetic facilities richer than
+// Int's. We keep every word as Int (i64) and trust the caller to
+// truncate when emitting bytes. Negative inputs trip the bounds
+// guards before any sign-bit corruption can leak into the encoded
+// word. Same convention `internal/onb/macho.go` follows.
+
+// === Common register encodings ===========================================
+
+// xRegisterNumber maps an x-register name to its 0..31 encoding.
+// Returns -1 on a name the encoder doesn't recognise; callers
+// distinguish that from the legitimate `x0` (== 0) by the sign.
+//
+// Mirror of `xRegisterNumber` in `internal/onb/asm.go`. Phase 1 of
+// the Osty port keeps the table identical so the Go encoder and the
+// future Osty encoder agree byte-for-byte on every program.
+pub fn onbXRegisterNumber(name: String) -> Int {
+    if name == "x0" { 0 } else if name == "x1" { 1 } else if name == "x2" { 2 } else if name == "x3" { 3 } else if name == "x4" { 4 } else if name == "x5" { 5 } else if name == "x6" { 6 } else if name == "x7" { 7 } else if name == "x8" { 8 } else if name == "x9" { 9 } else if name == "x10" { 10 } else if name == "x29" { 29 } else if name == "x30" { 30 } else if name == "sp" { 31 } else { -1 }
+}
+
+// onbDRegisterNumber maps a d-register name to its 0..31 encoding.
+// Phase A2 only uses d0..d9; the table keeps the higher names
+// reserved for follow-up callee-saved spills.
+pub fn onbDRegisterNumber(name: String) -> Int {
+    if name == "d0" { 0 } else if name == "d1" { 1 } else if name == "d2" { 2 } else if name == "d3" { 3 } else if name == "d4" { 4 } else if name == "d5" { 5 } else if name == "d6" { 6 } else if name == "d7" { 7 } else if name == "d8" { 8 } else if name == "d9" { 9 } else { -1 }
+}
+
+// === Instruction encoders ================================================
+
+// onbEncodeBrk produces the 32-bit aarch64 word for `brk #imm16`.
+// Layout: `1101 0100 001<imm16> 000 00`. ONB uses this for
+// `mir.UnreachableTerm` lowering — match exhaustiveness inserts an
+// unreachable default arm whose PC must trap rather than fall
+// through.
+pub fn onbEncodeBrk(imm: Int) -> Int? {
+    if imm < 0 || imm > 0xffff {
+        None
+    } else {
+        Some(0xd4200000 | (imm << 5))
+    }
+}
+
+// onbEncodeFmovDFromX encodes `FMOV Dd, Xn` — bitcast a 64-bit
+// integer register into a double-precision FP register without
+// changing bits. Returns None if either register name is invalid.
+pub fn onbEncodeFmovDFromX(dst: String, src: String) -> Int? {
+    let d = onbDRegisterNumber(dst)
+    let n = onbXRegisterNumber(src)
+    if d < 0 || n < 0 {
+        None
+    } else {
+        Some(0x9e670000 | (n << 5) | d)
+    }
+}
+
+// onbEncodeFmovXFromD encodes `FMOV Xd, Dn` — the inverse of
+// onbEncodeFmovDFromX. Same opcode family with op = 110 (general →
+// FP) vs 111 (FP → general).
+pub fn onbEncodeFmovXFromD(dst: String, src: String) -> Int? {
+    let d = onbXRegisterNumber(dst)
+    let n = onbDRegisterNumber(src)
+    if d < 0 || n < 0 {
+        None
+    } else {
+        Some(0x9e660000 | (n << 5) | d)
+    }
+}
+
+// onbEncodeFPArith encodes the FP binary arithmetic family
+// `F<op> Dd, Dn, Dm` (FADD/FSUB/FMUL/FDIV) for double precision.
+// Base values (mirror `internal/onb/macho.go`):
+//
+//   FADD = 0x1e602800
+//   FSUB = 0x1e603800
+//   FMUL = 0x1e600800
+//   FDIV = 0x1e601800
+//
+// Layout: base | (Rm << 16) | (Rn << 5) | Rd.
+pub fn onbEncodeFPArith(base: Int, dst: String, lhs: String, rhs: String) -> Int? {
+    let d = onbDRegisterNumber(dst)
+    let n = onbDRegisterNumber(lhs)
+    let m = onbDRegisterNumber(rhs)
+    if d < 0 || n < 0 || m < 0 {
+        None
+    } else {
+        Some(base | (m << 16) | (n << 5) | d)
+    }
+}
+
+// onbEncodeBlr encodes `blr Xn` — indirect branch with link. Used
+// for closure dispatch: the env's first slot holds the lifted-fn
+// address; the lowerer loads that into a scratch register and
+// `blr`s into it.
+pub fn onbEncodeBlr(reg: String) -> Int? {
+    let n = onbXRegisterNumber(reg)
+    if n < 0 {
+        None
+    } else {
+        Some(0xd63f0000 | (n << 5))
+    }
+}
+
+// onbEncodeRet encodes `ret` — the conventional `ret x30` form.
+// Always the same 4 bytes (0xd65f03c0) but expressed as an Int
+// so the caller's emit path stays uniform with the rest of this
+// table.
+pub fn onbEncodeRet() -> Int { 0xd65f03c0 }
+
+// onbEncodeFPStack encodes `STR Dt, [SP, #imm12]` (base
+// 0xfd000000) and `LDR Dt, [SP, #imm12]` (base 0xfd400000) for
+// double-precision scalar transfers. The immediate is scaled by 8
+// (the access size). Returns None on misalignment or out-of-range
+// offset.
+pub fn onbEncodeFPStack(base: Int, reg: String, offset: Int) -> Int? {
+    if offset < 0 {
+        return None
+    }
+    if (offset % 8) != 0 {
+        return None
+    }
+    let r = onbDRegisterNumber(reg)
+    if r < 0 {
+        return None
+    }
+    let scaled = offset / 8
+    if scaled > 0xfff {
+        return None
+    }
+    // SP encodes as register 31 in the Rn field (bits 5-9).
+    Some(base | (scaled << 10) | (31 << 5) | r)
+}
+
+// onbEncodeLoadStoreReg encodes `LDR Xt, [Xn, #imm]` (base
+// 0xf9400000) or `STR Xt, [Xn, #imm]` (base 0xf9000000) for
+// 64-bit register-relative loads/stores. Used by the indirect-ABI
+// prologue / epilogue to memcpy through caller-provided pointers.
+// imm is 8-byte scaled; valid range 0..32760.
+pub fn onbEncodeLoadStoreReg(base: Int, t: String, n: String, offset: Int) -> Int? {
+    if offset < 0 {
+        return None
+    }
+    if (offset % 8) != 0 {
+        return None
+    }
+    let tn = onbXRegisterNumber(t)
+    if tn < 0 {
+        return None
+    }
+    let nn = onbXRegisterNumber(n)
+    if nn < 0 {
+        return None
+    }
+    let scaled = offset / 8
+    if scaled > 0xfff {
+        return None
+    }
+    Some(base | (scaled << 10) | (nn << 5) | tn)
+}
+
+// onbEncodeMovRegReg encodes `MOV Xd, Xm` (alias for `ORR Xd, XZR,
+// Xm`). Used to move the env pointer between registers when staging
+// a closure call.
+pub fn onbEncodeMovRegReg(dst: String, src: String) -> Int? {
+    let d = onbXRegisterNumber(dst)
+    if d < 0 {
+        return None
+    }
+    let m = onbXRegisterNumber(src)
+    if m < 0 {
+        return None
+    }
+    // 0xaa0003e0 | (Xm << 16) | Xd. XZR encodes as 31 in the Rn slot.
+    Some(0xaa0003e0 | (m << 16) | d)
+}

--- a/toolchain/onb_encoding_test.osty
+++ b/toolchain/onb_encoding_test.osty
@@ -1,0 +1,103 @@
+// onb_encoding_test.osty — encoder parity checks for the
+// Osty Native Backend's pure aarch64 instruction primitives.
+//
+// Each assertion pins a specific 32-bit word produced by the
+// Osty encoder so a future divergence between this table and
+// `internal/onb/macho.go`'s Go encoder surfaces immediately.
+// Hex literals are taken from the Go encoder's tested output
+// so the two sides start in lockstep.
+use std.testing
+
+fn assertEncodedEq(label: String, actual: Int?, expected: Int) {
+    match actual {
+        Some(word) -> testing.assertEq(word, expected),
+        None -> testing.assert(false),
+    }
+}
+
+fn testOnbXRegisterNumberKnownNames() {
+    testing.assertEq(onbXRegisterNumber("x0"), 0)
+    testing.assertEq(onbXRegisterNumber("x7"), 7)
+    testing.assertEq(onbXRegisterNumber("x9"), 9)
+    testing.assertEq(onbXRegisterNumber("x29"), 29)
+    testing.assertEq(onbXRegisterNumber("x30"), 30)
+    testing.assertEq(onbXRegisterNumber("sp"), 31)
+}
+
+fn testOnbXRegisterNumberRejectsUnknown() {
+    testing.assertEq(onbXRegisterNumber("d0"), -1)
+    testing.assertEq(onbXRegisterNumber("garbage"), -1)
+    testing.assertEq(onbXRegisterNumber(""), -1)
+}
+
+fn testOnbDRegisterNumberKnownNames() {
+    testing.assertEq(onbDRegisterNumber("d0"), 0)
+    testing.assertEq(onbDRegisterNumber("d8"), 8)
+    testing.assertEq(onbDRegisterNumber("d9"), 9)
+    testing.assertEq(onbDRegisterNumber("x0"), -1)
+}
+
+fn testOnbEncodeBrkValid() {
+    // brk #1 — the canonical trap value emitted for
+    // `mir.UnreachableTerm` lowering. 0xd4200020 = base | (1 << 5).
+    assertEncodedEq("brk #1", onbEncodeBrk(1), 0xd4200020)
+    assertEncodedEq("brk #0", onbEncodeBrk(0), 0xd4200000)
+    assertEncodedEq("brk #0xffff", onbEncodeBrk(0xffff), 0xd43fffe0)
+}
+
+fn testOnbEncodeBrkOutOfRange() {
+    testing.assert(onbEncodeBrk(-1).isNone())
+    testing.assert(onbEncodeBrk(0x10000).isNone())
+}
+
+fn testOnbEncodeFmovDFromX() {
+    // fmov d8, x9 — the standard float-const materialisation step
+    // (movz/movk into x9, then bitcast to d8). 0x9e670000 base
+    // with n=9 → 0x9e670120, then | d=8 → 0x9e670128.
+    assertEncodedEq("fmov d8, x9", onbEncodeFmovDFromX("d8", "x9"), 0x9e670128)
+}
+
+fn testOnbEncodeFmovXFromD() {
+    // fmov x1, d9 — the printf vararg step for Float locals.
+    assertEncodedEq("fmov x1, d9", onbEncodeFmovXFromD("x1", "d9"), 0x9e660121)
+}
+
+fn testOnbEncodeFPArithFamily() {
+    // fadd d8, d8, d9 — the canonical Float local addition.
+    assertEncodedEq("fadd d8, d8, d9", onbEncodeFPArith(0x1e602800, "d8", "d8", "d9"), 0x1e692908)
+    assertEncodedEq("fsub d8, d8, d9", onbEncodeFPArith(0x1e603800, "d8", "d8", "d9"), 0x1e693908)
+    assertEncodedEq("fmul d8, d8, d9", onbEncodeFPArith(0x1e600800, "d8", "d8", "d9"), 0x1e690908)
+    assertEncodedEq("fdiv d8, d8, d9", onbEncodeFPArith(0x1e601800, "d8", "d8", "d9"), 0x1e691908)
+}
+
+fn testOnbEncodeBlrAndRet() {
+    // blr x9 — the indirect-call branch for closures.
+    assertEncodedEq("blr x9", onbEncodeBlr("x9"), 0xd63f0120)
+    testing.assertEq(onbEncodeRet(), 0xd65f03c0)
+}
+
+fn testOnbEncodeFPStackBoundsAndAlignment() {
+    // str d8, [sp, #0]
+    assertEncodedEq("str d8 [sp,0]", onbEncodeFPStack(0xfd000000, "d8", 0), 0xfd0003e8)
+    // ldr d9, [sp, #16]
+    assertEncodedEq("ldr d9 [sp,16]", onbEncodeFPStack(0xfd400000, "d9", 16), 0xfd400be9)
+    // misaligned and out-of-range rejected
+    testing.assert(onbEncodeFPStack(0xfd000000, "d8", 4).isNone())
+    testing.assert(onbEncodeFPStack(0xfd000000, "d8", -8).isNone())
+    testing.assert(onbEncodeFPStack(0xfd000000, "d8", 0x10000).isNone())
+}
+
+fn testOnbEncodeLoadStoreRegBoundsAndAlignment() {
+    // ldr x9, [x0, #0] — the indirect-arg unmarshal in paramShuffle.
+    assertEncodedEq("ldr x9 [x0,0]", onbEncodeLoadStoreReg(0xf9400000, "x9", "x0", 0), 0xf9400009)
+    // str x9, [x8, #16] — the sret epilogue's per-half store.
+    assertEncodedEq("str x9 [x8,16]", onbEncodeLoadStoreReg(0xf9000000, "x9", "x8", 16), 0xf9000909)
+    testing.assert(onbEncodeLoadStoreReg(0xf9400000, "d0", "x0", 0).isNone())
+    testing.assert(onbEncodeLoadStoreReg(0xf9400000, "x9", "x0", 1).isNone())
+}
+
+fn testOnbEncodeMovRegReg() {
+    // mov x10, x0 — used to stash the freshly-allocated env pointer
+    // before staging captures into [x10 + 24 + i*8].
+    assertEncodedEq("mov x10, x0", onbEncodeMovRegReg("x10", "x0"), 0xaa0003ea)
+}

--- a/toolchain/onb_layouts.osty
+++ b/toolchain/onb_layouts.osty
@@ -1,0 +1,81 @@
+// onb_layouts.osty — slot / object layout helpers for the Osty
+// Native Backend.
+//
+// Mirror of the layout-shaped helpers in `internal/onb/lower.go`.
+// Pure offset math: each helper takes integer indices and returns
+// integer byte offsets. No MIR/LIR dependency — these encode the
+// runtime's object layout (closure env, enum slot, struct slot)
+// rather than per-program decisions.
+
+// === Closure env layout =================================================
+//
+// `osty_rt_closure_env_alloc_v2` returns a heap struct shaped
+//
+//     { fn_ptr: ptr (8B); capture_count: i64 (8B);
+//       pointer_bitmap: u64 (8B); captures[]: ptr × N (8B each) }
+//
+// fn_ptr lives at offset 0 — the indirect-call site loads it
+// directly. Captures begin at offset 24, so MIR-level FieldProj
+// indices map non-uniformly: index 0 → 0, index N≥1 → 24+(N-1)*8.
+
+// onbClosureEnvCapturesOffset returns the byte offset where the
+// captures array begins inside the env. Mirror of
+// `closureEnvCapturesOffset` (== 24).
+pub fn onbClosureEnvCapturesOffset() -> Int { 24 }
+
+// onbClosureEnvFieldByteOffset maps an MIR-level FieldProj index on
+// a ClosureEnv pointee to the runtime layout offset. Phase A2 Week
+// 20: index 0 is the fn-pointer slot (offset 0); index N≥1 is
+// capture[N-1] starting at `onbClosureEnvCapturesOffset()`.
+pub fn onbClosureEnvFieldByteOffset(index: Int) -> Int {
+    if index <= 0 { 0 } else { onbClosureEnvCapturesOffset() + (index - 1) * 8 }
+}
+
+// === Enum slot layout ===================================================
+//
+// ONB lays every small enum out as `[disc 8B][payload N×8B]`. The
+// discriminant lives at slot offset 0; the payload starts at slot
+// offset 8. Variant payload's FieldIdx = -1 means "the whole
+// payload tuple" → start of the payload region.
+
+// onbEnumPayloadOffset returns the byte offset (relative to the
+// enum's slot base) of the FieldIdx-th payload element. Mirror of
+// `enumPayloadOffset`.
+pub fn onbEnumPayloadOffset(fieldIdx: Int) -> Int {
+    if fieldIdx < 0 { 8 } else { 8 + fieldIdx * 8 }
+}
+
+// onbEnumDiscriminantOffset is always 0 — kept as a named function
+// so the call site documents its intent rather than threading a
+// magic 0 through every load/store.
+pub fn onbEnumDiscriminantOffset() -> Int { 0 }
+
+// === Struct slot layout =================================================
+//
+// All-scalar structs (Phase A2 Week 12+): each field consumes a
+// single 8-byte slot in the local. The byte offset is just
+// `index * 8`.
+
+// onbStructFieldByteOffset is the static field offset for
+// all-scalar structs. Identical to `fieldByteOffset` in lower.go.
+pub fn onbStructFieldByteOffset(index: Int) -> Int { index * 8 }
+
+// === ABI register-class limits =========================================
+//
+// `abiSmallStructRegLimit = 2` — structs ≤16B (one or two scalar
+// fields) ride the AAPCS64 small-struct convention in adjacent
+// integer registers.
+//
+// `abiIndirectStructFieldLimit = 4` — 3- or 4-field all-scalar
+// structs are passed indirectly through a caller-allocated buffer
+// (sret on return, pointer arg on input). Bigger structs fall
+// back to the LLVM backend.
+pub fn onbAbiSmallStructRegLimit() -> Int { 2 }
+pub fn onbAbiIndirectStructFieldLimit() -> Int { 4 }
+
+// onbAbiPointerRegSlotBytes = 8 — every 1-reg ABI value (scalar,
+// pointer-shaped builtin, no-payload enum, single-scalar struct)
+// occupies 8 bytes on the stack. Surfaced as a function so future
+// targets with a different word size can override it without a
+// shotgun rename.
+pub fn onbAbiPointerRegSlotBytes() -> Int { 8 }

--- a/toolchain/onb_runtime_symbols.osty
+++ b/toolchain/onb_runtime_symbols.osty
@@ -1,0 +1,158 @@
+// onb_runtime_symbols.osty — runtime symbol names + key/value-kind
+// dispatch tables for the Osty Native Backend.
+//
+// Mirror of the `runtimeSym*` constants and `*SymbolForKeyKind`
+// dispatchers in `internal/onb/lower.go`. Keeping the table in Osty
+// means the eventual self-host port doesn't need to re-derive these
+// strings from runtime headers; they're a single source of truth.
+//
+// All exported helpers return `Option<String>` to encode "this kind
+// is outside the dev backend's runtime support" as None. Callers
+// that want a hard failure pair the lookup with a diagnostic site.
+
+// === ABI kind tags =======================================================
+//
+// Mirrors `OSTY_RT_ABI_*` in the C runtime + `containerAbiKind` in
+// the LLVM backend. ONB's `abiKindFor` returns one of these values
+// for a MIR type when dispatching list/map runtime calls.
+pub fn onbAbiKindI64() -> Int { 1 }
+pub fn onbAbiKindI1() -> Int { 2 }
+pub fn onbAbiKindF64() -> Int { 3 }
+pub fn onbAbiKindPtr() -> Int { 4 }
+pub fn onbAbiKindString() -> Int { 5 }
+
+// === String runtime ======================================================
+
+pub fn onbRuntimeSymStringConcat() -> String { "osty_rt_strings_Concat" }
+pub fn onbRuntimeSymStringByteLen() -> String { "osty_rt_strings_ByteLen" }
+
+// === List runtime =======================================================
+
+pub fn onbRuntimeSymListNew() -> String { "osty_rt_list_new" }
+pub fn onbRuntimeSymListLen() -> String { "osty_rt_list_len" }
+
+// onbListPushSymbolForKind picks the runtime push symbol for a list
+// element ABI kind. Element-type-aware dispatch is what unlocked
+// `List<Bool>` / `List<Float64>` / `List<String>` in Phase A2 Week
+// 16; the table is identical to the Go side.
+pub fn onbListPushSymbolForKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_list_push_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_list_push_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_list_push_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_list_push_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_list_push_ptr")
+    } else {
+        None
+    }
+}
+
+// onbListGetSymbolForKind picks the runtime indexed-read symbol —
+// `osty_rt_list_get_<kind>(list, idx) -> elem`. Used by `xs[i]`
+// IndexProj reads (Week 17).
+pub fn onbListGetSymbolForKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_list_get_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_list_get_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_list_get_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_list_get_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_list_get_ptr")
+    } else {
+        None
+    }
+}
+
+// === Map runtime ========================================================
+
+pub fn onbRuntimeSymMapNew() -> String { "osty_rt_map_new" }
+pub fn onbRuntimeSymMapLen() -> String { "osty_rt_map_len" }
+
+// onbMapInsertSymbolForKeyKind picks `osty_rt_map_insert_<key_kind>`
+// for `m.insert(k, v)`. The runtime takes (map, key, &value); the
+// caller's responsibility is to stage value into a stack scratch
+// slot and pass &scratch. Same dispatch shape as list_push.
+pub fn onbMapInsertSymbolForKeyKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_map_insert_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_map_insert_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_map_insert_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_map_insert_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_map_insert_ptr")
+    } else {
+        None
+    }
+}
+
+// onbMapGetSymbolForKeyKind picks `osty_rt_map_get_<key_kind>` for
+// `m.get(k) -> V?`. The runtime returns Bool (found) and writes the
+// payload through the caller-provided out pointer.
+pub fn onbMapGetSymbolForKeyKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_map_get_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_map_get_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_map_get_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_map_get_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_map_get_ptr")
+    } else {
+        None
+    }
+}
+
+// onbMapContainsSymbolForKeyKind picks `osty_rt_map_contains_<...>`
+// for `m.containsKey(k) -> Bool`.
+pub fn onbMapContainsSymbolForKeyKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_map_contains_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_map_contains_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_map_contains_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_map_contains_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_map_contains_ptr")
+    } else {
+        None
+    }
+}
+
+// onbMapRemoveSymbolForKeyKind picks `osty_rt_map_remove_<...>` for
+// `m.remove(k) -> Bool`.
+pub fn onbMapRemoveSymbolForKeyKind(kind: Int) -> String? {
+    if kind == onbAbiKindI64() {
+        Some("osty_rt_map_remove_i64")
+    } else if kind == onbAbiKindI1() {
+        Some("osty_rt_map_remove_i1")
+    } else if kind == onbAbiKindF64() {
+        Some("osty_rt_map_remove_f64")
+    } else if kind == onbAbiKindString() {
+        Some("osty_rt_map_remove_string")
+    } else if kind == onbAbiKindPtr() {
+        Some("osty_rt_map_remove_ptr")
+    } else {
+        None
+    }
+}
+
+// === Closure runtime ====================================================
+
+// onbRuntimeSymClosureEnvAllocV2 — the dotted form runtime exports
+// via `__asm__("osty.rt.closure_env_alloc_v2")`. Mach-O symbol
+// encoding adds the leading underscore at emit time.
+pub fn onbRuntimeSymClosureEnvAllocV2() -> String { "osty.rt.closure_env_alloc_v2" }


### PR DESCRIPTION
## Summary

Tier 1 native ONB expansion paused; **ONB Go → Osty self-host porting begins**. This slice ports the pure leaf modules (no MIR/LIR/AST dependency) and pins them with a byte-for-byte Go ↔ Osty parity test.

## Pattern

Mirrors \`toolchain/lir_proto.osty\`:
- Osty source = future-canonical authority
- Go = current production runtime
- Parity test locks the encoded output of every aarch64 word
- \`generated.go\` regen path is frozen post-#854 so Osty code is syntactic/typecheck-only until LLVM self-host LLVMgen catches up; \`osty check toolchain\` smoke is the validation gate

## New Osty files

**\`toolchain/onb_encoding.osty\`** — pure aarch64 instruction encoders. Mirror of \`internal/onb/macho.go\`'s \`encode*\` helpers plus \`asm.go\`'s register-name table.

**\`toolchain/onb_runtime_symbols.osty\`** — runtime symbol names + 5 dispatch tables (list_push/get, map_insert/get/contains/remove). ABI kind constants mirror \`OSTY_RT_ABI_*\`.

**\`toolchain/onb_layouts.osty\`** — slot/object layout offsets: closure env captures offset (24), \`onbClosureEnvFieldByteOffset\` (the non-uniform mapping where index 0 → 0 and N≥1 → 24+(N-1)*8), enum/struct field offsets, ABI register-class limits.

**\`toolchain/onb_encoding_test.osty\`** — 14 parity assertions pinning expected hex words.

## Go-side gate

\`internal/onb/onb_osty_parity_test.go::TestEncoderParityVsOstyTable\` enumerates the same 14 cases and asserts the Go encoder's output matches each Osty expected hex byte-for-byte. Drift in either direction surfaces as a failing diff during PR review.

## Out of scope (future phases)

- **Phase 2** — LIR opcode + Reg mirrored as Osty enums
- **Phase 3** — MIR-dependent ABI helpers (\`abiRegSlots\`, \`lookupStructLayout\`, ...)
- **Phase 4-5** — \`lowerCall\` / \`paramShuffle\` / \`epilogue\` / \`lowerInstr\` / intrinsic dispatch
- **Phase 6** — Mach-O encoder + DWARF emit
- **Phase 7** — Go-side \`ONBRunner\` interface + bundle integration (gated on LLVM self-host LLVMgen catching up)

## Test plan

- [x] \`go run ./cmd/osty check ./toolchain\` exit 0 — 4 new Osty files parse + typecheck
- [x] \`go test ./internal/onb -run TestEncoderParityVsOstyTable\` — 14 expected hex values match Go encoder byte-for-byte
- [x] \`go test ./internal/onb -short\` — 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)