### PR TITLE
refactor: dbg lowering simplification (non-stringifiable identity-only, compact pattern)

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4182,40 +4182,43 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			})
 			return
 		}
-		// `dbg<T>(value: T) -> T` — diagnostic prelude builtin
-		// (LANG_SPEC §A.10). For stringifiable primitive types,
-		// emit `eprint("[dbg] " + value + "\n")` via the existing
-		// string_concat path (which auto-boxes Int/Float/Bool/...
-		// via emitStringConcatBoxed). Then identity-passthrough the
-		// value into the destination so callers see it unchanged.
-		// Non-stringifiable types skip the print and fall back to
-		// identity-only.
+		// `dbg<T>(value: T) -> T` — LANG_SPEC §A.10 diagnostic
+		// builtin. Stringifiable primitives flow through the existing
+		// `string_concat` boxing path; other shapes degrade silently
+		// to identity-only (no generic ToString protocol yet).
 		if id.Name == "dbg" && len(c.Args) == 1 && dest != nil {
 			arg := c.Args[0].Value
 			argT := arg.Type()
-			// Spill into a temp so the value is read once, then
-			// referenced from both the eprint chain and the identity
-			// assign without re-evaluating side effects.
+			if !dbgCanStringify(argT) {
+				bs.emit(&AssignInstr{
+					Dest:  *dest,
+					Src:   &UseRV{Op: bs.lowerExprAsOperand(arg)},
+					SpanV: c.SpanV,
+				})
+				return
+			}
+			// Spill once so the value reaches both the eprint chain
+			// and the identity assign without re-emitting any
+			// side-effecting subexpression.
 			valueLocal := bs.newLocal("_dbg_val", argT, false, c.SpanV)
 			bs.emit(&StorageLiveInstr{Local: valueLocal, SpanV: c.SpanV})
 			bs.lowerExprInto(arg, valueLocal, argT)
-			if dbgCanStringify(argT) {
-				prefix := &ConstOp{Const: &StringConst{Value: "[dbg] "}, T: TString}
-				suffix := &ConstOp{Const: &StringConst{Value: "\n"}, T: TString}
-				valueOp := &CopyOp{Place: Place{Local: valueLocal}, T: argT}
-				msgLocal := bs.freshTemp(TString, c.SpanV)
-				bs.emit(&IntrinsicInstr{
-					Dest:  &Place{Local: msgLocal},
-					Kind:  IntrinsicStringConcat,
-					Args:  []Operand{prefix, valueOp, suffix},
-					SpanV: c.SpanV,
-				})
-				bs.emit(&IntrinsicInstr{
-					Kind:  IntrinsicEprint,
-					Args:  []Operand{&CopyOp{Place: Place{Local: msgLocal}, T: TString}},
-					SpanV: c.SpanV,
-				})
-			}
+			msgLocal := bs.freshTemp(TString, c.SpanV)
+			bs.emit(&IntrinsicInstr{
+				Dest: &Place{Local: msgLocal},
+				Kind: IntrinsicStringConcat,
+				Args: []Operand{
+					&ConstOp{Const: &StringConst{Value: "[dbg] "}, T: TString},
+					&CopyOp{Place: Place{Local: valueLocal}, T: argT},
+					&ConstOp{Const: &StringConst{Value: "\n"}, T: TString},
+				},
+				SpanV: c.SpanV,
+			})
+			bs.emit(&IntrinsicInstr{
+				Kind:  IntrinsicEprint,
+				Args:  []Operand{&CopyOp{Place: Place{Local: msgLocal}, T: TString}},
+				SpanV: c.SpanV,
+			})
 			bs.emit(&AssignInstr{
 				Dest:  *dest,
 				Src:   &UseRV{Op: &CopyOp{Place: Place{Local: valueLocal}, T: argT}},
@@ -4447,11 +4450,9 @@ func (bs *bodyState) builtinFreeCallIntrinsic(name string, args []ir.Arg) Intrin
 }
 
 // dbgCanStringify reports whether `dbg(value)` can render the
-// argument via the existing `string_concat` boxing path
-// (`emitStringConcatBoxed`). Today that covers every primitive
-// scalar plus String — anything else falls back to identity-only so
-// `dbg(struct)` stays a safe no-op until a generic ToString
-// protocol lands. Mirror of `mirLowerDbgCanStringify` in
+// argument via `emitStringConcatBoxed`'s scalar-boxing path. Anything
+// else routes to identity-only until a generic ToString protocol
+// lands. Mirror of `mirLowerDbgCanStringify` in
 // `toolchain/mir_lower.osty`.
 func dbgCanStringify(t Type) bool {
 	pt, ok := t.(*ir.PrimType)

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3763,41 +3763,39 @@ pub fn mirLowerCallExprInto(
             )
             return
         }
-        // 1b. `dbg<T>(value: T) -> T` — diagnostic prelude builtin
-        //     (LANG_SPEC §A.10). For stringifiable primitive types,
-        //     emit `eprint("[dbg] " + value + "\n")` via the existing
-        //     string_concat path (which auto-boxes Int/Float/Bool/...
-        //     via `emitStringConcatBoxed`). Then identity-passthrough
-        //     the value into the destination so callers see it
-        //     unchanged. Non-stringifiable types skip the print and
-        //     fall back to identity-only — keeps dbg() a safe no-op
-        //     for shapes the runtime can't render.
+        // 1b. `dbg<T>(value: T) -> T` — LANG_SPEC §A.10 diagnostic
+        //     builtin. Stringifiable primitives flow through the
+        //     existing string_concat boxing path; other shapes
+        //     degrade silently to identity-only.
         if callee.identName == "dbg" && e.callArgs.len() == 1 {
             let arg = e.callArgs[0].value
-            // Spill into a temp so the value is read once, then
-            // referenced from both the eprint chain and the identity
-            // assign without re-evaluating side effects.
+            if !mirLowerDbgCanStringify(arg.typ) {
+                let identityOp = mirLowerExprAsOperand(bs, arg)
+                mirLowerEmitInstr(bs, mirAssignInstr(dest, mirRVUse(identityOp), span))
+                return
+            }
+            // Spill once so the value reaches both the eprint chain
+            // and the identity assign without re-emitting any
+            // side-effecting subexpression.
             let valueLocal = mirLowerNewLocal(bs, "_dbg_val", arg.typ, false, span)
             mirLowerEmitInstr(bs, mirStorageLiveInstr(valueLocal, span))
             mirLowerExprInto(bs, arg, valueLocal, arg.typ)
             let valueTypeText = hirTypeString(arg.typ)
-            if mirLowerDbgCanStringify(arg.typ) {
-                let mut concatArgs: List<MirOperand> = []
-                concatArgs.push(mirOperandConst(mirConstString("[dbg] ")))
-                concatArgs.push(mirOperandCopy(mirPlace(valueLocal), valueTypeText))
-                concatArgs.push(mirOperandConst(mirConstString("\n")))
-                let msgLocal = mirLowerNewLocal(bs, "_dbg_msg", hirTString(), false, span)
-                mirLowerEmitInstr(
-                    bs,
-                    mirIntrinsicInstr(true, mirPlace(msgLocal), MirIntrinsicStringConcat, concatArgs, span),
-                )
-                let mut eprintArgs: List<MirOperand> = []
-                eprintArgs.push(mirOperandCopy(mirPlace(msgLocal), "String"))
-                mirLowerEmitInstr(
-                    bs,
-                    mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicEprint, eprintArgs, span),
-                )
-            }
+            let mut concatArgs: List<MirOperand> = []
+            concatArgs.push(mirOperandConst(mirConstString("[dbg] ")))
+            concatArgs.push(mirOperandCopy(mirPlace(valueLocal), valueTypeText))
+            concatArgs.push(mirOperandConst(mirConstString("\n")))
+            let msgLocal = mirLowerNewLocal(bs, "_dbg_msg", hirTString(), false, span)
+            mirLowerEmitInstr(
+                bs,
+                mirIntrinsicInstr(true, mirPlace(msgLocal), MirIntrinsicStringConcat, concatArgs, span),
+            )
+            let mut eprintArgs: List<MirOperand> = []
+            eprintArgs.push(mirOperandCopy(mirPlace(msgLocal), "String"))
+            mirLowerEmitInstr(
+                bs,
+                mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicEprint, eprintArgs, span),
+            )
             mirLowerEmitInstr(
                 bs,
                 mirAssignInstr(dest, mirRVUse(mirOperandCopy(mirPlace(valueLocal), valueTypeText)), span),
@@ -5956,31 +5954,19 @@ pub fn mirLowerDivergingBuiltinMessage(name: String) -> String {
 }
 
 /// mirLowerDbgCanStringify reports whether `dbg(value)` can render the
-/// argument via the existing `string_concat` boxing path. Today that
-/// covers every primitive scalar plus String — anything else falls
-/// back to identity-only so `dbg(struct)` stays a safe no-op until a
-/// generic ToString protocol lands.
+/// argument via `emitStringConcatBoxed`'s scalar-boxing path. Anything
+/// else routes to identity-only until a generic ToString protocol
+/// lands.
 pub fn mirLowerDbgCanStringify(t: HirType) -> Bool {
     if t.kind != HirTypePrim {
         return false
     }
     match t.primKind {
-        HirPrimInt -> true,
-        HirPrimInt8 -> true,
-        HirPrimInt16 -> true,
-        HirPrimInt32 -> true,
-        HirPrimInt64 -> true,
-        HirPrimUInt8 -> true,
-        HirPrimUInt16 -> true,
-        HirPrimUInt32 -> true,
-        HirPrimUInt64 -> true,
-        HirPrimByte -> true,
-        HirPrimChar -> true,
-        HirPrimFloat -> true,
-        HirPrimFloat32 -> true,
-        HirPrimFloat64 -> true,
-        HirPrimBool -> true,
-        HirPrimString -> true,
+        HirPrimInt | HirPrimInt8 | HirPrimInt16 | HirPrimInt32 | HirPrimInt64
+        | HirPrimUInt8 | HirPrimUInt16 | HirPrimUInt32 | HirPrimUInt64
+        | HirPrimByte | HirPrimChar
+        | HirPrimFloat | HirPrimFloat32 | HirPrimFloat64
+        | HirPrimBool | HirPrimString -> true,
         _ -> false,
     }
 }


### PR DESCRIPTION
## Summary
Three small follow-ups to #1305 from a code-review pass.

### #1 Non-stringifiable identity-only — skip the spill

The non-stringifiable branch was paying a `_dbg_val` temp + StorageLive + `lowerExprInto` even though only the identity assign read the value. Now `dbg(struct)` / `dbg(enum)` / `dbg(list)` etc. emit as pure identity with zero extra MIR ops. The stringifiable path still spills (needed because the value is read twice — once for the eprint chain, once for identity).

**Before** (`dbg(p: P)` where P is a struct):
```llvm
%l2 = alloca %P
store %P %t0, ptr %l2          ; spill
%t1 = load %P, ptr %l2         ; load for identity
store %P %t1, ptr %dest
```

**After**:
```llvm
%t0 = load %P, ptr %p1         ; direct read
store %P %t0, ptr %dest        ; identity assign
```

### #2 Compact Osty helper to or-pattern

`mirLowerDbgCanStringify` had 16 one-arm match arms. Collapsed into a single or-pattern arm per LANG_SPEC §B.4 #36 — spec-supported syntax, −14 lines.

### #3 Trim duplicated WHAT-comments

The 8-line block comment on the dbg branch was duplicated across Go + Osty + helper docstrings. Trimmed to a 4-line LANG_SPEC §A.10 reference + the one non-obvious WHY ("no generic ToString protocol yet").

## Test plan
- [x] `TestGenerateFromMIRDbgPrintsAndPassesThrough` still green (stringifiable Int path unchanged)
- [x] `just front` + `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green
- [x] `.bin/osty check toolchain/` clean
- [x] `osty gen` end-to-end probe: `dbg(int)` still emits full eprint chain; `dbg(struct)` now emits zero-overhead identity
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)