### PR TITLE
feat: ONB self-host port Phase 2b — multi-word constant materialisation

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,59 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 26 (ONB self-host port — Phase 2b multi-word
+> constant materialisation, 2026-05-03)** — Variable-length
+> encoding 도입. `MovImm64`가 1–4개의 32-bit word를 produce하는
+> movz/movk chain으로 lower되며, `onbEncodeInstrWords` dispatcher가
+> single-word / multi-word를 통합한 `List<Int>` 출력으로 노출.
+>
+> 추가:
+>
+> - `toolchain/onb_encoding.osty` 확장:
+>   - `onbEncodeMovz(dst, hw, imm16)` — 64-bit MOVZ
+>   - `onbEncodeMovk(dst, hw, imm16)` — 64-bit MOVK
+>   - `onbEncodeMovzW(dst, hw, imm16)` — W-register MOVZ + 내부
+>     `onbWToXAlias` (w0..w7 → x0..x7 인덱스 공유)
+>   - `onbEncodeMovImm64Words(dst, imm) -> List<Int>` — 4개 hw
+>     position을 unconditional iteration으로 walk, 첫 chunk는
+>     MOVZ로 강제 (다른 비트 zero 화), 이후 chunk가 0이면 MOVK 생략
+>   - `onbEncodeMovImm32Word(dst, imm) -> Int?` — `mov w0, #0`
+>     스타일의 단일 word
+>
+> - `toolchain/onb_lir.osty`:
+>   - `OnbInstrKind`에 `OnbInstrMovImm32`, `OnbInstrMovImm64` 추가
+>   - 대응 constructors `onbInstrMovImm32`, `onbInstrMovImm64`
+>   - `onbEncodeInstr` dispatcher가 MovImm32 단일 word 처리,
+>     MovImm64는 None (multi-word path 표시)
+>   - 새 `onbEncodeInstrWords(instr) -> List<Int>` — 모든 opcode 통합.
+>     단일 word는 1-element list로 wrap, MovImm64는 chain 그대로
+>
+> - `toolchain/onb_lir_test.osty` 확장:
+>   - `assertOnbInstrWordsEq` helper — word count + per-position 비교
+>   - mov x0/x9 #0 / #100 / #65535 / #0x12345678 케이스 (1-2 word
+>     chains)
+>
+> - `internal/onb/onb_lir_parity_test.go` 확장:
+>   - `TestLirMultiWordParityVsOstyTable` — Go `encodeMachOMovImm64`
+>     출력을 Osty 테이블과 word-by-word 비교
+>
+> 한계 (Phase 2c+로 분리):
+> - **adrp + add 페어** (`LoadCStringAddress`, `LoadSymbolAddress`)
+>   는 reloc 표 의존이라 Mach-O writer 진입까지 미룸
+> - **Branch family** (`Branch`, `BranchCond`, `BranchCondNotZero`,
+>   `BranchLink`) — link-time fixup pass 필요. Phase 2d
+> - **Container types** — Phase 2e
+>
+> 검증:
+> - `osty check toolchain` exit 0
+> - `go test ./internal/onb -run TestLirMultiWordParity` — 4
+>   MovImm64 케이스가 word-by-word 일치
+> - `go test ./internal/onb -short` — 0 회귀
+>
+> **다음 phase 후보**: Phase 2c (adrp+add skeletons, Mach-O reloc
+> hooks), Phase 2d (branch fixups), 또는 Phase 3a (MIR Type 의존성
+> 도입).
+>
 > **Slice A2 Week 25 (ONB self-host port — Phase 2a single-word LIR
 > mirror, 2026-05-03)** — LIR opcode 21종을 Osty 측 enum + flat
 > struct + per-opcode constructor + dispatch encoder로 미러. Phase 1

--- a/internal/onb/onb_lir_parity_test.go
+++ b/internal/onb/onb_lir_parity_test.go
@@ -98,3 +98,50 @@ func TestLirOpcodeParityVsOstyTable(t *testing.T) {
 		t.Errorf("ret literal mismatch")
 	}
 }
+
+// TestLirMultiWordParityVsOstyTable pins the variable-length encoder
+// outputs (Phase 2b) against the Osty-side `onbEncodeMovImm64Words`
+// table. Each MovImm64 case verifies both the word count and the
+// per-position hex values — drift in either dimension surfaces as
+// a reviewable diff.
+//
+// MovImm32 isn't covered here because Go's `internal/onb/macho.go`
+// only encodes the hard-wired `mov w0, #0` form (process exit-code
+// stamp). When that path generalises, mirror the new shape on both
+// sides and add the matching assertions.
+func TestLirMultiWordParityVsOstyTable(t *testing.T) {
+	t.Parallel()
+
+	checkWords := func(name string, got []uint32, err error, want []uint32) {
+		t.Helper()
+		if err != nil {
+			t.Errorf("%s: Go encode err %v", name, err)
+			return
+		}
+		if len(got) != len(want) {
+			t.Errorf("%s: word count Go=%d Osty=%d", name, len(got), len(want))
+			return
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%s[%d]: Go = 0x%08x; Osty = 0x%08x", name, i, got[i], want[i])
+			}
+		}
+	}
+
+	// mov x0, #0 — single MOVZ, register clears.
+	w, err := encodeMachOMovImm64(RegX0, 0)
+	checkWords("mov x0, #0", w, err, []uint32{0xd2800000})
+
+	// mov x9, #100 — single chunk in low 16 bits.
+	w, err = encodeMachOMovImm64(RegX9, 100)
+	checkWords("mov x9, #100", w, err, []uint32{0xd2800c89})
+
+	// mov x9, #65535 — boundary of the low chunk.
+	w, err = encodeMachOMovImm64(RegX9, 0xffff)
+	checkWords("mov x9, #65535", w, err, []uint32{0xd29fffe9})
+
+	// mov x9, #0x12345678 — two chunks (low + mid). MOVZ then MOVK.
+	w, err = encodeMachOMovImm64(RegX9, 0x12345678)
+	checkWords("mov x9, #0x12345678", w, err, []uint32{0xd28acf09, 0xf2a24689})
+}

--- a/toolchain/onb_encoding.osty
+++ b/toolchain/onb_encoding.osty
@@ -297,6 +297,157 @@ pub fn onbEncodeStackStore(t: String, offset: Int) -> Int? {
     Some(0xf90003e0 | (scaled << 10) | r)
 }
 
+// === Multi-word constant materialisation ============================
+//
+// Movz/Movk chains and the W-register movz form. These produce
+// **lists of 32-bit words** rather than a single Int — variable
+// length encoding is the price of materialising arbitrary 64-bit
+// immediates without a literal pool.
+
+// onbEncodeMovz encodes `MOVZ Xd, #imm16, lsl #(hw*16)`. Layout:
+// 0xd2800000 | (hw << 21) | (imm16 << 5) | Rd. hw is 0..3 for a
+// 64-bit register; the caller's chunking pass decides where in the
+// destination register the immediate lands.
+pub fn onbEncodeMovz(dst: String, hw: Int, imm16: Int) -> Int? {
+    if hw < 0 || hw > 3 {
+        return None
+    }
+    if imm16 < 0 || imm16 > 0xffff {
+        return None
+    }
+    let r = onbXRegisterNumber(dst)
+    if r < 0 {
+        return None
+    }
+    Some(0xd2800000 | (hw << 21) | (imm16 << 5) | r)
+}
+
+// onbEncodeMovk encodes `MOVK Xd, #imm16, lsl #(hw*16)`. Same field
+// layout as MOVZ with bit 30 flipped (op=11 vs op=10) — so the
+// base mask is 0xf2800000 instead of 0xd2800000. MOVK preserves
+// the existing register bits outside its 16-bit slot, so the
+// chunking pass uses MOVK after the first MOVZ has cleared the
+// register.
+pub fn onbEncodeMovk(dst: String, hw: Int, imm16: Int) -> Int? {
+    if hw < 0 || hw > 3 {
+        return None
+    }
+    if imm16 < 0 || imm16 > 0xffff {
+        return None
+    }
+    let r = onbXRegisterNumber(dst)
+    if r < 0 {
+        return None
+    }
+    Some(0xf2800000 | (hw << 21) | (imm16 << 5) | r)
+}
+
+// onbEncodeMovzW encodes `MOVZ Wd, #imm16, lsl #(hw*16)` — the
+// W-register variant. Same layout as the X form with bit 31
+// cleared (sf=0): base 0x52800000 instead of 0xd2800000. ONB
+// today only emits the `mov w0, #0` flavour (process exit code)
+// but a general MOVZ surface keeps this future-proof.
+pub fn onbEncodeMovzW(dst: String, hw: Int, imm16: Int) -> Int? {
+    if hw < 0 || hw > 1 {
+        return None
+    }
+    if imm16 < 0 || imm16 > 0xffff {
+        return None
+    }
+    // W-registers share their numeric encoding with the X
+    // counterpart at the same index.
+    let r = onbXRegisterNumber(onbWToXAlias(dst))
+    if r < 0 {
+        return None
+    }
+    Some(0x52800000 | (hw << 21) | (imm16 << 5) | r)
+}
+
+// onbWToXAlias rewrites a w-register name ("w0" / "w1" / ...) into
+// the matching x-name so xRegisterNumber can encode it. This
+// matches the aarch64 convention where `Wn` and `Xn` share the
+// same 5-bit register index. Unknown names pass through; xRegister
+// returns -1 so the caller still sees the failure.
+fn onbWToXAlias(name: String) -> String {
+    if name == "w0" {
+        "x0"
+    } else if name == "w1" {
+        "x1"
+    } else if name == "w2" {
+        "x2"
+    } else if name == "w3" {
+        "x3"
+    } else if name == "w4" {
+        "x4"
+    } else if name == "w5" {
+        "x5"
+    } else if name == "w6" {
+        "x6"
+    } else if name == "w7" {
+        "x7"
+    } else {
+        name
+    }
+}
+
+// onbEncodeMovImm64Words materialises an arbitrary 64-bit
+// immediate into Xd via a movz/movk chain. Returns a list of 1..4
+// 32-bit words covering the non-zero 16-bit chunks, with the
+// first chunk emitted as MOVZ (zeroing the register) and
+// subsequent chunks as MOVK (preserving prior bits).
+//
+// `imm == 0` collapses to a single `MOVZ Xd, #0, lsl 0`. Negative
+// inputs come from sign-extended Int values; the caller-side mask
+// preserves only the low 64 bits when chunking.
+//
+// Mirror of `encodeMachOMovImm64` in `internal/onb/macho.go`. The
+// loop walks all four 16-bit chunks unconditionally so the
+// iteration count is fixed (4 hw positions); chunks that come up
+// zero after the first emitted MOVZ are skipped via the
+// `chunkIsZeroSkip` predicate rather than a `continue` statement.
+pub fn onbEncodeMovImm64Words(dst: String, imm: Int) -> List<Int> {
+    let mut out: List<Int> = []
+    for hw in 0..4 {
+        let shift = hw * 16
+        let chunk = (imm >> shift) & 0xffff
+        let isFirst = out.isEmpty()
+        if isFirst {
+            // First chunk MUST be emitted (as MOVZ) so the
+            // register's other bits get cleared. Subsequent zero
+            // chunks are skipped because MOVK would leave the
+            // register's existing bits intact.
+            match onbEncodeMovz(dst, hw, chunk) {
+                Some(w) -> out.push(w),
+                None -> {},
+            }
+        } else if chunk != 0 {
+            match onbEncodeMovk(dst, hw, chunk) {
+                Some(w) -> out.push(w),
+                None -> {},
+            }
+        }
+    }
+    if out.isEmpty() {
+        // Defensive fallback when the destination register name
+        // wasn't recognised — every encode call returned None.
+        // Producing an empty list signals failure to the dispatcher.
+    }
+    out
+}
+
+// onbEncodeMovImm32Word emits a single MOVZ-flavoured word for a
+// 16-bit immediate destined for a W-register. ONB's only call
+// site is `mov w0, #0` (the process exit-code stamp at the top of
+// every `main` epilogue) — a more general 32-bit immediate would
+// need its own movk chain, which we defer until a real call site
+// requires it.
+pub fn onbEncodeMovImm32Word(dst: String, imm: Int) -> Int? {
+    if imm < 0 || imm > 0xffff {
+        return None
+    }
+    onbEncodeMovzW(dst, 0, imm)
+}
+
 // onbEncodeAddImm encodes `ADD Xd, Xn, #imm12` for an unshifted
 // immediate (so imm <= 0xfff). Used by `LoadStackAddress`
 // (`add Xd, sp, #N`). Layout: 0x91000000 | (imm12 << 10) | (Rn << 5) | Rd.

--- a/toolchain/onb_lir.osty
+++ b/toolchain/onb_lir.osty
@@ -92,6 +92,12 @@ pub enum OnbInstrKind {
     OnbInstrFmulReg,
     OnbInstrFdivReg,
     OnbInstrBranchLinkReg,
+    // Phase 2b: multi-word constant materialisation. These produce
+    // 1..4 32-bit words rather than a single Int, and route through
+    // `onbEncodeInstrWords` instead of the single-word
+    // `onbEncodeInstr` dispatcher.
+    OnbInstrMovImm32,
+    OnbInstrMovImm64,
 }
 
 // === LIR instruction record ============================================
@@ -220,6 +226,14 @@ pub fn onbInstrBranchLinkReg(reg: String) -> OnbInstr {
     OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrBranchLinkReg, src: reg }
 }
 
+pub fn onbInstrMovImm32(dst: String, imm: Int) -> OnbInstr {
+    OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrMovImm32, dst: dst, imm: imm }
+}
+
+pub fn onbInstrMovImm64(dst: String, imm: Int) -> OnbInstr {
+    OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrMovImm64, dst: dst, imm: imm }
+}
+
 // === Single-word encoder dispatch =====================================
 //
 // `onbEncodeInstr` mirrors the encoder switch in
@@ -227,10 +241,10 @@ pub fn onbInstrBranchLinkReg(reg: String) -> OnbInstr {
 // reads the same fields the Go counterpart reads and returns the
 // produced 4-byte word.
 //
-// Returns `None` for opcodes outside Phase 2a's coverage. The
-// encoded word is `Int` (i64) — callers that need a concrete u32
-// truncate at the I/O boundary, mirroring the Go convention of
-// holding raw aarch64 words in `uint32`.
+// Returns `None` for opcodes outside the single-word path
+// (multi-word instructions route through `onbEncodeInstrWords`).
+// The encoded word is `Int` (i64) — callers that need a concrete
+// u32 truncate at the I/O boundary, mirroring the Go convention.
 pub fn onbEncodeInstr(instr: OnbInstr) -> Int? {
     match instr.kind {
         OnbInstrKind.OnbInstrBrk -> onbEncodeBrk(instr.imm),
@@ -255,6 +269,30 @@ pub fn onbEncodeInstr(instr: OnbInstr) -> Int? {
         OnbInstrKind.OnbInstrFmulReg -> onbEncodeFPArith(0x1e600800, instr.dst, instr.lhs, instr.rhs),
         OnbInstrKind.OnbInstrFdivReg -> onbEncodeFPArith(0x1e601800, instr.dst, instr.lhs, instr.rhs),
         OnbInstrKind.OnbInstrBranchLinkReg -> onbEncodeBlr(instr.src),
+        OnbInstrKind.OnbInstrMovImm32 -> onbEncodeMovImm32Word(instr.dst, instr.imm),
+        OnbInstrKind.OnbInstrMovImm64 -> None,
         OnbInstrKind.OnbInstrInvalid -> None,
+    }
+}
+
+// === Multi-word encoder dispatch ======================================
+//
+// `onbEncodeInstrWords` returns the full word stream for any
+// supported opcode — single-word instructions produce a 1-element
+// list, multi-word ones (MovImm64) produce up to 4 words. The
+// motivation is to let downstream code emit instructions through
+// a single function regardless of length, mirroring the Go
+// encoder's switch which appends to a shared byte buffer.
+pub fn onbEncodeInstrWords(instr: OnbInstr) -> List<Int> {
+    match instr.kind {
+        OnbInstrKind.OnbInstrMovImm64 -> onbEncodeMovImm64Words(instr.dst, instr.imm),
+        _ -> {
+            let mut out: List<Int> = []
+            match onbEncodeInstr(instr) {
+                Some(word) -> out.push(word),
+                None -> {},
+            }
+            out
+        },
     }
 }

--- a/toolchain/onb_lir_test.osty
+++ b/toolchain/onb_lir_test.osty
@@ -83,6 +83,46 @@ fn testOnbInstrBranchLinkReg() {
     assertOnbInstrEncodedEq("blr x9", onbInstrBranchLinkReg("x9"), 0xd63f0120)
 }
 
+// === Phase 2b: multi-word constant materialisation ===================
+
+fn assertOnbInstrWordsEq(label: String, instr: OnbInstr, expected: List<Int>) {
+    let actual = onbEncodeInstrWords(instr)
+    testing.assertEq(actual.len(), expected.len())
+    for i in 0..expected.len() {
+        testing.assertEq(actual[i], expected[i])
+    }
+}
+
+fn testOnbInstrMovImm32() {
+    // mov w0, #0 — the canonical main-fn exit-code stamp. ONB
+    // emits this as the first word of every `main` epilogue.
+    assertOnbInstrEncodedEq("mov w0, #0", onbInstrMovImm32("w0", 0), 0x52800000)
+    // mov w1, #1
+    assertOnbInstrEncodedEq("mov w1, #1", onbInstrMovImm32("w1", 1), 0x52800021)
+}
+
+fn testOnbInstrMovImm64Zero() {
+    // mov x0, #0 — single MOVZ word. The first chunk emits MOVZ
+    // unconditionally so the register's other 48 bits get cleared.
+    assertOnbInstrWordsEq("mov x0, #0", onbInstrMovImm64("x0", 0), [0xd2800000])
+}
+
+fn testOnbInstrMovImm64Small() {
+    // mov x9, #100 — single chunk, fits in the low 16 bits.
+    // 0xd2800000 | (100 << 5) | 9 = 0xd2800c89
+    assertOnbInstrWordsEq("mov x9, #100", onbInstrMovImm64("x9", 100), [0xd2800c89])
+    // mov x9, #65535 — boundary of the low chunk.
+    // 0xd2800000 | (0xffff << 5) | 9 = 0xd29fffe9
+    assertOnbInstrWordsEq("mov x9, #65535", onbInstrMovImm64("x9", 0xffff), [0xd29fffe9])
+}
+
+fn testOnbInstrMovImm64MultiChunk() {
+    // mov x9, #0x1234_5678 — two non-zero chunks (low + mid).
+    // chunk0 = 0x5678 → MOVZ x9, #0x5678, lsl 0 = 0xd2800000 | (0x5678 << 5) | 9 = 0xd28acf09
+    // chunk1 = 0x1234 → MOVK x9, #0x1234, lsl 16 = 0xf2800000 | (1 << 21) | (0x1234 << 5) | 9 = 0xf2a24689
+    assertOnbInstrWordsEq("mov x9, #0x12345678", onbInstrMovImm64("x9", 0x12345678), [0xd28acf09, 0xf2a24689])
+}
+
 fn testOnbInstrInvalidReturnsNone() {
     let bogus = OnbInstr {
         kind: OnbInstrKind.OnbInstrInvalid,


### PR DESCRIPTION
## Summary

Variable-length encoding lands. \`MovImm64\` produces a movz/movk chain of 1–4 words depending on which 16-bit chunks of the 64-bit immediate are non-zero. The new \`onbEncodeInstrWords\` dispatcher unifies single-word and multi-word output into one \`OnbInstr -> List<Int>\` surface, matching the Go encoder's \"append-to-buffer\" shape.

## Mechanics

\`toolchain/onb_encoding.osty\`:
- \`onbEncodeMovz/Movk(dst, hw, imm16)\` — 64-bit register variants
- \`onbEncodeMovzW\` + \`onbWToXAlias\` — W-register MOVZ (reuses the X table since wN and xN share the 5-bit index)
- \`onbEncodeMovImm64Words(dst, imm) -> List<Int>\` — chunking pass over \`0..4\` hw positions. First chunk emits MOVZ unconditionally (clears the register); later chunks emit MOVK only when non-zero
- \`onbEncodeMovImm32Word\` — single-word form for the \`mov w0, #0\` exit-code stamp

\`toolchain/onb_lir.osty\`:
- New opcodes \`OnbInstrMovImm32\`, \`OnbInstrMovImm64\`
- \`onbEncodeInstr\` returns the single MovImm32 word; MovImm64 returns None (signals \"use the multi-word dispatcher\")
- New \`onbEncodeInstrWords(instr) -> List<Int>\` — single API for every opcode. Single-word ops wrap to 1-element lists; MovImm64 returns the chain.

## Out of scope

- adrp+add pairs (\`LoadCStringAddress\`, \`LoadSymbolAddress\`) — depend on Mach-O reloc table; Phase 2c
- Branch family (\`Branch\`, \`BranchCond\`, \`BranchCondNotZero\`, \`BranchLink\`) — link-time fixup pass; Phase 2d
- Container types (\`Function\`, \`Block\`, \`Program\`, ...) — Phase 2e

## Test plan

- [x] \`go run ./cmd/osty check ./toolchain\` exit 0
- [x] \`go test ./internal/onb -run TestLirMultiWordParityVsOstyTable\` — Go encoder produces every MovImm64 chain word-by-word matching the Osty table (mov x0/#0 → 1 word, mov x9/#100 → 1 word, mov x9/#0xffff → 1 word boundary, mov x9/#0x12345678 → 2 words)
- [x] \`go test ./internal/onb -short\` — 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)