### PR TITLE
feat: dbg(expr) prefix carries line number + reconstructed expression text

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1510,13 +1510,13 @@ func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
 }
 
 // TestGenerateFromMIRDbgPrintsAndPassesThrough pins the prelude
-// diagnostic builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10). For
-// stringifiable primitives (Int / Float / Bool / Char / Byte / String)
-// the lowerer emits `eprint("[dbg] " + value + "\n")` — using the
-// existing string_concat path which auto-boxes scalars via
-// `emitStringConcatBoxed` — and identity-passes the value into the
-// destination so callers see it unchanged. No `@dbg` call survives;
-// the value reaches the destination directly.
+// diagnostic builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10).
+// Stringifiable primitives flow through `string_concat` boxing →
+// eprint, then identity-pass into the destination. The static
+// prefix encodes the call-site line and reconstructed expression
+// text (`[dbg:LINE] expr = ` for Ident/literal/field shapes,
+// `[dbg] expr = ` when no span is available, plain `[dbg] ` when
+// neither is recoverable).
 func TestGenerateFromMIRDbgPrintsAndPassesThrough(t *testing.T) {
 	// fn check(n: Int) -> Int {
 	//     let x = dbg(n)
@@ -1533,8 +1533,13 @@ func TestGenerateFromMIRDbgPrintsAndPassesThrough(t *testing.T) {
 					Type: ir.TInt,
 					Value: &ir.CallExpr{
 						Callee: &ir.Ident{Name: "dbg", Kind: ir.IdentBuiltin, T: &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}},
-						Args:   []ir.Arg{{Value: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt}}},
-						T:      ir.TInt,
+						Args: []ir.Arg{{Value: &ir.Ident{
+							Name:  "n",
+							Kind:  ir.IdentParam,
+							T:     ir.TInt,
+							SpanV: ir.Span{Start: ir.Pos{Line: 7}},
+						}}},
+						T: ir.TInt,
 					},
 				},
 			},
@@ -1560,7 +1565,7 @@ func TestGenerateFromMIRDbgPrintsAndPassesThrough(t *testing.T) {
 		t.Fatalf("output still contains unresolved-symbol diagnostic:\n%s", got)
 	}
 	for _, want := range []string{
-		"c\"[dbg] \\00\"",                  // prefix in string pool
+		"c\"[dbg:7] n = \\00\"",            // prefix carries call-site line + reconstructed Ident name
 		"c\"\\0A\\00\"",                    // newline literal in string pool
 		"call ptr @osty_rt_int_to_string(", // Int boxed via toString
 		"@osty_rt_strings_ConcatN(",        // 3-piece concat

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4204,13 +4204,14 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 			bs.emit(&StorageLiveInstr{Local: valueLocal, SpanV: c.SpanV})
 			bs.lowerExprInto(arg, valueLocal, argT)
 			msgLocal := bs.freshTemp(TString, c.SpanV)
+			prefix, suffix := dbgMessageBookends(arg)
 			bs.emit(&IntrinsicInstr{
 				Dest: &Place{Local: msgLocal},
 				Kind: IntrinsicStringConcat,
 				Args: []Operand{
-					&ConstOp{Const: &StringConst{Value: "[dbg] "}, T: TString},
+					&ConstOp{Const: &StringConst{Value: prefix}, T: TString},
 					&CopyOp{Place: Place{Local: valueLocal}, T: argT},
-					&ConstOp{Const: &StringConst{Value: "\n"}, T: TString},
+					&ConstOp{Const: &StringConst{Value: suffix}, T: TString},
 				},
 				SpanV: c.SpanV,
 			})
@@ -4447,6 +4448,66 @@ func (bs *bodyState) builtinFreeCallIntrinsic(name string, args []ir.Arg) Intrin
 		return IntrinsicInvalid
 	}
 	return builtinFreeCallIntrinsicForReceiver(bs.recoveredTypeOf(args[0].Value), name)
+}
+
+// dbgMessageBookends returns the static prefix and suffix that
+// surround the runtime-rendered value in a `dbg(expr)` eprint message.
+// Format follows LANG_SPEC §A.10 (`[file:line] expr = value\n`) as
+// closely as the lowerer can without source bytes — file path is
+// elided (Options.SourcePath isn't threaded into mir.Lower today),
+// expression text is reconstructed via `dbgExprSourceText` for the
+// shapes the IR can render losslessly.
+func dbgMessageBookends(arg ir.Expr) (prefix, suffix string) {
+	line := arg.At().Start.Line
+	exprText := dbgExprSourceText(arg)
+	switch {
+	case line > 0 && exprText != "":
+		prefix = fmt.Sprintf("[dbg:%d] %s = ", line, exprText)
+	case line > 0:
+		prefix = fmt.Sprintf("[dbg:%d] ", line)
+	case exprText != "":
+		prefix = fmt.Sprintf("[dbg] %s = ", exprText)
+	default:
+		prefix = "[dbg] "
+	}
+	suffix = "\n"
+	return prefix, suffix
+}
+
+// dbgExprSourceText reconstructs a short textual form of `expr` for
+// the [dbg] message prefix. The IR drops the original source bytes,
+// so the lowerer pieces things back together from the field values
+// that survive — Idents return their name, literals their text form,
+// FieldExpr / TupleAccess / IndexExpr recurse into their receiver.
+// Returns "" for shapes the lowerer can't render losslessly; callers
+// fall back to the no-expr-text prefix.
+func dbgExprSourceText(expr ir.Expr) string {
+	switch x := expr.(type) {
+	case *ir.Ident:
+		return x.Name
+	case *ir.IntLit:
+		return x.Text
+	case *ir.FloatLit:
+		return x.Text
+	case *ir.BoolLit:
+		if x.Value {
+			return "true"
+		}
+		return "false"
+	case *ir.FieldExpr:
+		if base := dbgExprSourceText(x.X); base != "" {
+			sep := "."
+			if x.Optional {
+				sep = "?."
+			}
+			return base + sep + x.Name
+		}
+	case *ir.TupleAccess:
+		if base := dbgExprSourceText(x.X); base != "" {
+			return base + "." + strconv.Itoa(x.Index)
+		}
+	}
+	return ""
 }
 
 // dbgCanStringify reports whether `dbg(value)` can render the

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -3781,8 +3781,9 @@ pub fn mirLowerCallExprInto(
             mirLowerEmitInstr(bs, mirStorageLiveInstr(valueLocal, span))
             mirLowerExprInto(bs, arg, valueLocal, arg.typ)
             let valueTypeText = hirTypeString(arg.typ)
+            let prefixText = mirLowerDbgMessagePrefix(arg)
             let mut concatArgs: List<MirOperand> = []
-            concatArgs.push(mirOperandConst(mirConstString("[dbg] ")))
+            concatArgs.push(mirOperandConst(mirConstString(prefixText)))
             concatArgs.push(mirOperandCopy(mirPlace(valueLocal), valueTypeText))
             concatArgs.push(mirOperandConst(mirConstString("\n")))
             let msgLocal = mirLowerNewLocal(bs, "_dbg_msg", hirTString(), false, span)
@@ -5951,6 +5952,68 @@ pub fn mirLowerDivergingBuiltinMessage(name: String) -> String {
         return "abort called"
     }
     ""
+}
+
+/// mirLowerDbgMessagePrefix returns the static prefix that surrounds
+/// the runtime-rendered value in a `dbg(expr)` eprint message. Tracks
+/// LANG_SPEC §A.10 (`[file:line] expr = value\n`) as closely as the
+/// lowerer can without source bytes — file path is elided (no
+/// SourcePath threaded through MIR lowering today), expression text
+/// reconstructed via `mirLowerDbgExprSourceText` for shapes the IR
+/// can render losslessly. Mirror of `dbgMessageBookends` in
+/// `internal/mir/lower.go`.
+pub fn mirLowerDbgMessagePrefix(arg: HirExpr) -> String {
+    let line = arg.span.start.line
+    let exprText = mirLowerDbgExprSourceText(arg)
+    if line > 0 && exprText != "" {
+        return "[dbg:" + mirLowerIntToString(line) + "] " + exprText + " = "
+    }
+    if line > 0 {
+        return "[dbg:" + mirLowerIntToString(line) + "] "
+    }
+    if exprText != "" {
+        return "[dbg] " + exprText + " = "
+    }
+    "[dbg] "
+}
+
+/// mirLowerDbgExprSourceText reconstructs a short textual form of
+/// `expr` for the [dbg] message prefix. The IR drops original source
+/// bytes, so the lowerer pieces things back together from the field
+/// values that survive — Idents return their name, literals their
+/// text form, FieldExpr / TupleAccess recurse into their receiver.
+/// Returns "" for shapes the lowerer can't render losslessly.
+pub fn mirLowerDbgExprSourceText(e: HirExpr) -> String {
+    match e.kind {
+        HirExprIdent -> e.identName,
+        HirExprIntLit -> e.numText,
+        HirExprFloatLit -> e.numText,
+        HirExprBoolLit -> {
+            if e.boolValue { "true" } else { "false" }
+        },
+        HirExprField -> {
+            if e.fieldTarget.len() == 0 {
+                return ""
+            }
+            let base = mirLowerDbgExprSourceText(e.fieldTarget[0])
+            if base == "" {
+                return ""
+            }
+            let sep = if e.fieldOptional { "?." } else { "." }
+            base + sep + e.fieldName
+        },
+        HirExprTupleAccess -> {
+            if e.tupleAccessTarget.len() == 0 {
+                return ""
+            }
+            let base = mirLowerDbgExprSourceText(e.tupleAccessTarget[0])
+            if base == "" {
+                return ""
+            }
+            base + "." + mirLowerIntToString(e.tupleAccessIndex)
+        },
+        _ -> "",
+    }
 }
 
 /// mirLowerDbgCanStringify reports whether `dbg(value)` can render the


### PR DESCRIPTION
## Summary
Pushes #1305 / #1308 closer to the LANG_SPEC §A.10 shape (`[file:line] expr_text = value\n`).

File path is still elided (Options.SourcePath isn't threaded into `mir.Lower` today — non-trivial API change), but the lowerer can already pull **line number** from the arg's span and reconstruct **expression text** from surviving IR fields.

## Format matrix
Selected at MIR-lowering time, baked into the `string_concat` prefix const:

| condition | prefix |
|---|---|
| line + expr both recoverable | `[dbg:LINE] EXPR = ` |
| only line | `[dbg:LINE] ` |
| only expr | `[dbg] EXPR = ` |
| neither (fallback) | `[dbg] ` |

## Expression-text reconstruction

`dbgExprSourceText` (Go) / `mirLowerDbgExprSourceText` (Osty) handle the common debug surfaces:

- `Ident` → name
- `IntLit` / `FloatLit` → original text
- `BoolLit` → "true" / "false"
- `FieldExpr` → recurse + `.` or `?.` + name
- `TupleAccess` → recurse + `.` + index
- everything else → `""` (falls back to no-expr-text prefix)

Both sides mirrored per CLAUDE.md **"Osty 우선"**. New helpers `dbgMessageBookends` / `mirLowerDbgMessagePrefix` centralize the format selection.

## Examples (verified via `osty gen`)

```osty
fn check() -> Int {
    let p = P { x: 10, y: 20 }
    let a = dbg(p.x)     // [dbg:5] p.x = 10
    let b = dbg(42)      // [dbg:6] 42 = 42
    let c = dbg(true)    // [dbg:7] true = true
    ...
}
```

Resulting string-pool entries:
```llvm
@.str.0 = ... c"[dbg:5] p.x = \00"
@.str.2 = ... c"[dbg:6] 42 = \00"
@.str.3 = ... c"[dbg:7] true = \00"
```

## Test plan
- [x] `TestGenerateFromMIRDbgPrintsAndPassesThrough` updated: arg now has `SpanV{Line:7}`, asserts `c"[dbg:7] n = \00"` in the string pool — pins both line extraction and Ident-name reconstruction.
- [x] `just front` green
- [x] `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green
- [x] `.bin/osty check toolchain/` clean
- [x] `osty gen` end-to-end probe: Ident / IntLit / BoolLit / FieldExpr all reconstruct correctly; non-stringifiable types / exotic exprs degrade cleanly
- [ ] CI 그린 확인

## Future refinement (out of scope)
- **File path**: requires threading `SourcePath` through `mir.Lower(mod)` — touches every call site (16+ test files). Defer to a separate PR if needed.
- **Source-bytes-faithful expr text**: would require carrying source bytes onto `ir.Module` so the lowerer can slice the original span. The current reconstruction is a pragmatic 80% — covers the common `dbg(x)` / `dbg(x.field)` / `dbg(42)` patterns but not e.g. `dbg(x + 1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)