### PR TITLE
feat: ONB self-host port Phase 2d — branch family + fixup pass

### DIFF
--- a/ONB_DESIGN.md
+++ b/ONB_DESIGN.md
@@ -37,6 +37,81 @@
 > dead-store는 자동 elide (slot 할당이 read 기준). Linear scan RA 도입은
 > 후속 의제로 유예.
 >
+> **Slice A2 Week 27 (ONB self-host port — Phase 2d branch family +
+> fixup pass, 2026-05-03)** — Block-relative 분기 encoder + placeholder
+> + fixup resolve pass 일체. Branch instruction의 알고리즘적 핵심
+> (placeholder 작성 → 블록 byte offset 계산 → displacement 패치) 가
+> 한 슬라이스에 묶임. `b` / `b.cond` / `cbnz` 모두 커버.
+>
+> 추가:
+>
+> - `toolchain/onb_encoding.osty` 확장:
+>   - `onbEncodeBranchDisplacement(disp) -> Int?` — `b imm26`,
+>     signed 26-bit (range ±2^25 words)
+>   - `onbEncodeBranchCondDisplacement(cond, disp) -> Int?` —
+>     `b.cond imm19`, signed 19-bit
+>   - `onbEncodeCbnzDisplacement(src, disp) -> Int?` — `cbnz Xt, imm19`
+>   - `onbEncodeBranchPlaceholder/CondPlaceholder/CbnzPlaceholder` —
+>     emit-time placeholder (imm = 0)
+>   - `onbPatchBranchUnconditional/Cond/Cbnz(placeholder, disp)` —
+>     fixup pass의 패치 헬퍼
+>   - `onbBranchImm26Min/Max`, `onbBranchImm19Min/Max` 상수
+>
+> - `toolchain/onb_fixups.osty` (새 파일):
+>   - `OnbBranchFixupKind` enum (Uncond / Cond / Cbnz)
+>   - `OnbBranchFixup` struct (codeOffset / targetBlock / kind)
+>   - `OnbResolveOutcome` struct (words + ok flag)
+>   - `onbResolveBranchFixups(words, fixups, blockOffsets)` —
+>     fixup 리스트를 walk, 각 fixup의 displacement 계산, placeholder
+>     워드를 patched 워드로 교체
+>   - `onbPatchBranchByKind` — kind별 dispatch
+>
+> - `toolchain/onb_lir.osty` 확장:
+>   - `OnbInstrKind`에 `OnbInstrBranch`, `OnbInstrBranchCond`,
+>     `OnbInstrBranchCondNotZero` 추가
+>   - `OnbInstr.targetBlock: Int` 필드 (-1 default for non-branch)
+>   - constructors: `onbInstrBranch`, `onbInstrBranchCond`,
+>     `onbInstrBranchCondNotZero`
+>   - `OnbBranchEmit` struct (words + fixups)
+>   - `onbEmitInstr(instr, codeOffset) -> OnbBranchEmit` — 모든
+>     opcode를 통합한 emitter. 분기는 placeholder + fixup record를
+>     반환, non-branch는 빈 fixups 리스트
+>   - `onbEncodeInstr` 분기 가지: 분기는 None 반환 (multi-step path
+>     표시; 단일 워드 fast path 유지)
+>
+> - `toolchain/onb_fixups_test.osty` (새 파일):
+>   - 5 round-trip 케이스: forward branch (b +4), backward loop
+>     (b -4), conditional (b.eq +8), cbnz (+4), 그리고 out-of-range
+>     blockId 실패 케이스
+>   - `emitBlocks(blocks)` 헬퍼 — block 리스트를 walk해 word stream +
+>     fixups + blockOffsets 만듦 (byte 단위)
+>   - 각 case: emit → resolve → expected hex 비교
+>
+> - `internal/onb/onb_lir_parity_test.go` 확장:
+>   - `TestLirBranchParityVsOstyTable` — Go의 `patchMachOBranch`가
+>     b/+4, b/-4, b.eq/+8, cbnz/+4 4 케이스에서 Osty 테스트가
+>     주장하는 동일한 hex 워드를 produce하는지 검증
+>
+> 검증:
+> - `osty check toolchain` exit 0
+> - 4개 parity 테스트 (Encoder + LirOpcode + LirMultiWord + LirBranch)
+>   모두 통과
+> - `go test ./internal/onb -short` 0 회귀
+>
+> 한계 (Phase 2c+로 분리):
+> - **BranchLink (`bl symbol`)** — 분기 displacement가 아닌 Mach-O
+>   reloc 표 의존. Phase 2c가 adrp+add와 함께 처리
+> - **Block walker / Function emitter** — 현재 emit 헬퍼는 단일 instr
+>   레벨. 전체 함수를 emit하는 walker (line span tracking, prologue/
+>   epilogue placement, reloc collection 포함) 는 Phase 2e와 함께
+> - **Branch optimization** — fall-through 후속 블록으로의 무조건
+>   분기 elide, mutual rewriting (b → b.cond) 같은 최적화는 lowering
+>   레이어 (Phase 4-5) 의 책임
+>
+> **다음 phase 후보**: Phase 2c (BranchLink + adrp+add + Mach-O reloc
+> 표 model), Phase 2e (Function/Block/Program container types), 또는
+> Phase 3a (MIR Type 의존 ABI predicates).
+>
 > **Slice A2 Week 26 (ONB self-host port — Phase 2b multi-word
 > constant materialisation, 2026-05-03)** — Variable-length
 > encoding 도입. `MovImm64`가 1–4개의 32-bit word를 produce하는

--- a/internal/onb/onb_lir_parity_test.go
+++ b/internal/onb/onb_lir_parity_test.go
@@ -99,6 +99,75 @@ func TestLirOpcodeParityVsOstyTable(t *testing.T) {
 	}
 }
 
+// TestLirBranchParityVsOstyTable pins the patched 32-bit word the
+// Go-side branch fixup pass produces against the canonical hex
+// values asserted in `toolchain/onb_fixups_test.osty`. Each case
+// covers a different branch family member (b / b.cond / cbnz)
+// and a representative displacement.
+//
+// BranchLink (`bl`, calls into runtime/local symbols) routes
+// through the Mach-O reloc table rather than this block-relative
+// fixup pass; Phase 2c handles it together with adrp+add.
+func TestLirBranchParityVsOstyTable(t *testing.T) {
+	t.Parallel()
+
+	check := func(name string, got uint32, want uint32) {
+		t.Helper()
+		if got != want {
+			t.Errorf("%s: Go = 0x%08x; Osty = 0x%08x", name, got, want)
+		}
+	}
+
+	// b +4 (imm26 = 1) — forward branch by one instruction word.
+	{
+		fx := machoBranchFixup{codeOffset: 0, kind: machoBranchUncond}
+		code := make([]byte, 8)
+		writeU32LE(code, 0, 0x14000000) // placeholder
+		if err := patchMachOBranch(code, fx, 4); err != nil {
+			t.Fatalf("b +4 patch: %v", err)
+		}
+		check("b +4", readU32LE(code, 0), 0x14000001)
+	}
+
+	// b -4 (imm26 = -1) — backward loop branch.
+	{
+		fx := machoBranchFixup{codeOffset: 4, kind: machoBranchUncond}
+		code := make([]byte, 8)
+		writeU32LE(code, 4, 0x14000000)
+		if err := patchMachOBranch(code, fx, -4); err != nil {
+			t.Fatalf("b -4 patch: %v", err)
+		}
+		check("b -4", readU32LE(code, 4), 0x17ffffff)
+	}
+
+	// b.eq +8 (imm19 = 2, cond = 0).
+	{
+		placeholder := encodeMachOBcondPlaceholder(CondEq)
+		code := make([]byte, 4)
+		writeU32LE(code, 0, placeholder)
+		fx := machoBranchFixup{codeOffset: 0, kind: machoBranchCond, cond: CondEq}
+		if err := patchMachOBranch(code, fx, 8); err != nil {
+			t.Fatalf("b.eq +8 patch: %v", err)
+		}
+		check("b.eq +8", readU32LE(code, 0), 0x54000040)
+	}
+
+	// cbnz x9, +4 (imm19 = 1, Rt = 9).
+	{
+		placeholder, err := encodeMachOCbnzPlaceholder(RegX9)
+		if err != nil {
+			t.Fatalf("cbnz placeholder: %v", err)
+		}
+		code := make([]byte, 4)
+		writeU32LE(code, 0, placeholder)
+		fx := machoBranchFixup{codeOffset: 0, kind: machoBranchCondNotZero}
+		if err := patchMachOBranch(code, fx, 4); err != nil {
+			t.Fatalf("cbnz +4 patch: %v", err)
+		}
+		check("cbnz x9 +4", readU32LE(code, 0), 0xb5000029)
+	}
+}
+
 // TestLirMultiWordParityVsOstyTable pins the variable-length encoder
 // outputs (Phase 2b) against the Osty-side `onbEncodeMovImm64Words`
 // table. Each MovImm64 case verifies both the word count and the

--- a/toolchain/onb_encoding.osty
+++ b/toolchain/onb_encoding.osty
@@ -448,6 +448,147 @@ pub fn onbEncodeMovImm32Word(dst: String, imm: Int) -> Int? {
     onbEncodeMovzW(dst, 0, imm)
 }
 
+// === Branch family — displacement, placeholder, and patch =============
+//
+// The branch family takes PC-relative immediates. ONB's encoder
+// emits placeholder words at branch sites (imm = 0) and records a
+// fixup. After every block has been laid out, a resolve pass
+// converts each fixup's `(branch_byte_offset, target_block_id)`
+// pair into a 4-aligned displacement and patches the placeholder.
+//
+// Range / encoding cheat-sheet (mirror of `patchMachOBranch`):
+//
+//   b   imm26        : 0x14000000 | (imm26 & 0x3ffffff)
+//                      imm26 is signed, range [-2^25, 2^25)
+//   b.cond imm19     : 0x54000000 | ((imm19 & 0x7ffff) << 5) | cond
+//                      imm19 is signed, range [-2^18, 2^18)
+//   cbnz Xt, imm19   : 0xb5000000 | ((imm19 & 0x7ffff) << 5) | Rt
+//
+// The signed immediate is the byte-displacement divided by 4.
+
+// onbBranchImm26Min / Max are the inclusive lower and exclusive
+// upper bounds of imm26 (scaled by 4 = displacement bytes / 4).
+pub fn onbBranchImm26Min() -> Int { 0 - (1 << 25) }
+pub fn onbBranchImm26Max() -> Int { 1 << 25 }
+pub fn onbBranchImm19Min() -> Int { 0 - (1 << 18) }
+pub fn onbBranchImm19Max() -> Int { 1 << 18 }
+
+// onbEncodeBranchDisplacement encodes `b imm26` for an already-known
+// 4-aligned byte displacement. Returns None on misalignment or
+// out-of-range. Used by the fixup resolve pass after blocks are
+// laid out.
+pub fn onbEncodeBranchDisplacement(displacement: Int) -> Int? {
+    if (displacement % 4) != 0 {
+        return None
+    }
+    let imm = displacement / 4
+    if imm < onbBranchImm26Min() || imm >= onbBranchImm26Max() {
+        return None
+    }
+    Some(0x14000000 | (imm & 0x3ffffff))
+}
+
+// onbEncodeBranchCondDisplacement encodes `b.<cond> imm19`. The
+// condition is the aarch64 4-bit code (use `onbCondCode*()` for
+// well-known conditions).
+pub fn onbEncodeBranchCondDisplacement(cond: Int, displacement: Int) -> Int? {
+    if (displacement % 4) != 0 {
+        return None
+    }
+    if cond < 0 || cond > 15 {
+        return None
+    }
+    let imm = displacement / 4
+    if imm < onbBranchImm19Min() || imm >= onbBranchImm19Max() {
+        return None
+    }
+    Some(0x54000000 | ((imm & 0x7ffff) << 5) | cond)
+}
+
+// onbEncodeCbnzDisplacement encodes `cbnz Xt, imm19`. The src
+// register lives in bits [4:0]; imm19 in bits [23:5].
+pub fn onbEncodeCbnzDisplacement(src: String, displacement: Int) -> Int? {
+    let t = onbXRegisterNumber(src)
+    if t < 0 {
+        return None
+    }
+    if (displacement % 4) != 0 {
+        return None
+    }
+    let imm = displacement / 4
+    if imm < onbBranchImm19Min() || imm >= onbBranchImm19Max() {
+        return None
+    }
+    Some(0xb5000000 | ((imm & 0x7ffff) << 5) | t)
+}
+
+// onbEncodeBranchPlaceholder produces the displacement-zero `b 0`
+// word the emit-time encoder lays down before fixups resolve.
+// Equivalent to `onbEncodeBranchDisplacement(0)` but kept distinct
+// so the call site documents intent.
+pub fn onbEncodeBranchPlaceholder() -> Int { 0x14000000 }
+
+// onbEncodeBranchCondPlaceholder produces `b.cond #0` with the
+// caller-supplied condition baked in. Mirror of
+// `encodeMachOBcondPlaceholder` in `internal/onb/macho.go`.
+pub fn onbEncodeBranchCondPlaceholder(cond: Int) -> Int? {
+    if cond < 0 || cond > 15 {
+        return None
+    }
+    Some(0x54000000 | cond)
+}
+
+// onbEncodeCbnzPlaceholder produces `cbnz Xt, #0` with imm19 as
+// zero. The fixup pass overwrites bits [23:5] later; the Rt and
+// header bits stay intact.
+pub fn onbEncodeCbnzPlaceholder(src: String) -> Int? {
+    let t = onbXRegisterNumber(src)
+    if t < 0 {
+        return None
+    }
+    Some(0xb5000000 | t)
+}
+
+// onbPatchBranchUnconditional rewrites a `b 0` placeholder with the
+// final displacement. Returns the patched 32-bit word.
+pub fn onbPatchBranchUnconditional(displacement: Int) -> Int? {
+    onbEncodeBranchDisplacement(displacement)
+}
+
+// onbPatchBranchCond rewrites a `b.cond` placeholder with the
+// final displacement. Preserves the cond field (lower 4 bits + bit
+// 4 reserved zero) carried in the placeholder word.
+//
+// The placeholder is built with imm19 = 0, so OR-ing the new
+// value into the imm19 slot is sufficient — no clear pass needed.
+// This invariant matches `onbEncodeBranchCondPlaceholder` and
+// keeps the patch logic free of bitwise-NOT (Osty doesn't have a
+// `~` operator surface today).
+pub fn onbPatchBranchCond(placeholder: Int, displacement: Int) -> Int? {
+    if (displacement % 4) != 0 {
+        return None
+    }
+    let imm = displacement / 4
+    if imm < onbBranchImm19Min() || imm >= onbBranchImm19Max() {
+        return None
+    }
+    Some(placeholder | ((imm & 0x7ffff) << 5))
+}
+
+// onbPatchCbnz rewrites a `cbnz Xt, #0` placeholder. Same shape as
+// onbPatchBranchCond — only the imm19 bits change; Rt at bits [4:0]
+// is preserved by the input placeholder.
+pub fn onbPatchCbnz(placeholder: Int, displacement: Int) -> Int? {
+    if (displacement % 4) != 0 {
+        return None
+    }
+    let imm = displacement / 4
+    if imm < onbBranchImm19Min() || imm >= onbBranchImm19Max() {
+        return None
+    }
+    Some(placeholder | ((imm & 0x7ffff) << 5))
+}
+
 // onbEncodeAddImm encodes `ADD Xd, Xn, #imm12` for an unshifted
 // immediate (so imm <= 0xfff). Used by `LoadStackAddress`
 // (`add Xd, sp, #N`). Layout: 0x91000000 | (imm12 << 10) | (Rn << 5) | Rd.

--- a/toolchain/onb_fixups.osty
+++ b/toolchain/onb_fixups.osty
@@ -1,0 +1,114 @@
+// onb_fixups.osty — block-relative branch fixup model and resolve
+// pass. Mirror of `machoBranchFixup` + `patchMachOBranch` in
+// `internal/onb/macho.go`. Phase 2d of the ONB self-host port.
+//
+// Branch instructions emit placeholder words (with imm19 / imm26
+// = 0) at their byte offset and append a fixup record to a
+// per-function fixup list. Once every block in the function has
+// been laid out — so each block ID has a known byte offset — the
+// resolve pass walks the fixup list, computes
+// `displacement = block_byte_offset[fx.targetBlock] - fx.codeOffset`,
+// and patches the placeholder via the encoder helpers in
+// `onb_encoding.osty`.
+//
+// Failure modes (any of which produces a `None` return from the
+// resolve pass and surfaces in tests as a guard violation):
+//   - target block ID outside `blockOffsets`'s range
+//   - displacement out of imm19 / imm26 range
+//   - placeholder offset isn't a multiple of 4 (fixup misaligned)
+
+// === Fixup record ====================================================
+
+// OnbBranchFixupKind enumerates the placeholder shapes the fixup
+// pass knows how to patch. Add a new kind only when a new
+// placeholder encoder lands in `onb_encoding.osty`; the resolve
+// pass's match must stay exhaustive.
+pub enum OnbBranchFixupKind {
+    OnbBranchFixupUncond,
+    OnbBranchFixupCond,
+    OnbBranchFixupCbnz,
+}
+
+// OnbBranchFixup records a single pending placeholder.
+//   - codeOffset: byte offset of the placeholder word inside the
+//     function's emitted code (always 4-aligned)
+//   - targetBlock: 0-based block index in the function's block list
+//   - kind: which placeholder shape to patch
+pub struct OnbBranchFixup {
+    pub codeOffset: Int,
+    pub targetBlock: Int,
+    pub kind: OnbBranchFixupKind,
+}
+
+pub fn onbBranchFixup(codeOffset: Int, targetBlock: Int, kind: OnbBranchFixupKind) -> OnbBranchFixup {
+    OnbBranchFixup { codeOffset: codeOffset, targetBlock: targetBlock, kind: kind }
+}
+
+// === Resolve pass ===================================================
+
+// OnbResolveOutcome bundles the patched word stream with a flag
+// distinguishing "all fixups applied" from "some fixup failed
+// (range / unknown block / misalignment)". Returning a struct
+// rather than `Option<List<Int>>` lets future versions surface
+// per-fixup error indices for diagnostics without breaking the
+// signature.
+pub struct OnbResolveOutcome {
+    pub words: List<Int>,
+    pub ok: Bool,
+}
+
+// onbResolveBranchFixups walks the fixup list and patches each
+// placeholder word in-place (well, in the returned list — the
+// original `words` is consumed but Osty's List<Int> is mutable).
+//
+// `words` is the function's code as a flat list of 32-bit words,
+// in emit order. `blockOffsets` maps a block index to its byte
+// offset within `words` (must be 4-aligned). Both lists outlive
+// the call; the returned `outcome.words` is a fresh list.
+//
+// On failure (out-of-range displacement, unknown block, etc.) the
+// pass returns the in-progress word list with `ok = false` so
+// callers can render a diagnostic and bail. Successive fixups
+// after the failure are skipped.
+pub fn onbResolveBranchFixups(words: List<Int>, fixups: List<OnbBranchFixup>, blockOffsets: List<Int>) -> OnbResolveOutcome {
+    let mut out: List<Int> = []
+    for w in words {
+        out.push(w)
+    }
+    for fx in fixups {
+        if fx.targetBlock < 0 || fx.targetBlock >= blockOffsets.len() {
+            return OnbResolveOutcome { words: out, ok: false }
+        }
+        if (fx.codeOffset % 4) != 0 {
+            return OnbResolveOutcome { words: out, ok: false }
+        }
+        let targetByte = blockOffsets[fx.targetBlock]
+        let displacement = targetByte - fx.codeOffset
+        let wordIndex = fx.codeOffset / 4
+        if wordIndex < 0 || wordIndex >= out.len() {
+            return OnbResolveOutcome { words: out, ok: false }
+        }
+        let placeholder = out[wordIndex]
+        let patched = onbPatchBranchByKind(placeholder, fx.kind, displacement)
+        match patched {
+            Some(w) -> {
+                out[wordIndex] = w
+            },
+            None -> {
+                return OnbResolveOutcome { words: out, ok: false }
+            },
+        }
+    }
+    OnbResolveOutcome { words: out, ok: true }
+}
+
+// onbPatchBranchByKind dispatches to the right encoder helper.
+// Pulled out so the resolve pass stays linear and the per-kind
+// patch story lives in one switch.
+pub fn onbPatchBranchByKind(placeholder: Int, kind: OnbBranchFixupKind, displacement: Int) -> Int? {
+    match kind {
+        OnbBranchFixupKind.OnbBranchFixupUncond -> onbPatchBranchUnconditional(displacement),
+        OnbBranchFixupKind.OnbBranchFixupCond -> onbPatchBranchCond(placeholder, displacement),
+        OnbBranchFixupKind.OnbBranchFixupCbnz -> onbPatchCbnz(placeholder, displacement),
+    }
+}

--- a/toolchain/onb_fixups_test.osty
+++ b/toolchain/onb_fixups_test.osty
@@ -1,0 +1,180 @@
+// onb_fixups_test.osty — branch placeholder + fixup resolve
+// round-trip tests for Phase 2d. Each case:
+//
+//   1. Builds a tiny block graph (sequence of OnbInstr lists).
+//   2. Walks blocks emitting words via `onbEmitInstr`, tracking
+//      per-block byte offsets.
+//   3. Concatenates words + fixups into per-function lists.
+//   4. Calls `onbResolveBranchFixups` to patch placeholders.
+//   5. Asserts the patched word stream matches the expected hex.
+//
+// The harness is small enough to inline — we build the block graph
+// as `List<List<OnbInstr>>` and the byte-offset table by walking
+// it once. A full block walker (with newline-anchored block labels,
+// loop targets, etc.) lands in Phase 2e along with the Function /
+// Program container types.
+use std.testing
+
+fn assertWordsEq(actual: List<Int>, expected: List<Int>) {
+    testing.assertEq(actual.len(), expected.len())
+    for i in 0..expected.len() {
+        testing.assertEq(actual[i], expected[i])
+    }
+}
+
+// emitBlocks walks the block list, producing a flat word stream + a
+// fixup list + the byte offset of each block's first word. Mirror of
+// the block-walking loop in `internal/onb/macho.go`'s
+// `encodeMachOTextWithRelocs`, scoped to single-word instructions
+// (every emitted word is 4 bytes). Multi-word ops in this harness
+// would need to multiply by their actual word count; we skip that
+// detail since the test fixtures use only single-word ops.
+fn emitBlocks(blocks: List<List<OnbInstr>>) -> EmitResult {
+    let mut words: List<Int> = []
+    let mut fixups: List<OnbBranchFixup> = []
+    let mut blockOffsets: List<Int> = []
+    for blk in blocks {
+        blockOffsets.push(words.len() * 4)
+        for instr in blk {
+            let pc = words.len() * 4
+            let emit = onbEmitInstr(instr, pc)
+            for w in emit.words {
+                words.push(w)
+            }
+            for fx in emit.fixups {
+                fixups.push(fx)
+            }
+        }
+    }
+    EmitResult { words: words, fixups: fixups, blockOffsets: blockOffsets }
+}
+
+struct EmitResult {
+    words: List<Int>,
+    fixups: List<OnbBranchFixup>,
+    blockOffsets: List<Int>,
+}
+
+// === Forward branch — `b bb1` followed by `bb1: ret` =================
+
+fn testFixupForwardBranch() {
+    // bb0: b bb1
+    // bb1: ret
+    let mut bb0: List<OnbInstr> = []
+    bb0.push(onbInstrBranch(1))
+    let mut bb1: List<OnbInstr> = []
+    bb1.push(onbInstrRet())
+    let mut blocks: List<List<OnbInstr>> = []
+    blocks.push(bb0)
+    blocks.push(bb1)
+
+    let emitted = emitBlocks(blocks)
+    // Pre-resolve: placeholder b 0 + ret
+    let mut prePlaceholder: List<Int> = []
+    prePlaceholder.push(0x14000000)
+    prePlaceholder.push(0xd65f03c0)
+    assertWordsEq(emitted.words, prePlaceholder)
+    testing.assertEq(emitted.fixups.len(), 1)
+
+    let outcome = onbResolveBranchFixups(emitted.words, emitted.fixups, emitted.blockOffsets)
+    testing.assert(outcome.ok)
+    // bb0 byte 0; bb1 byte 4. Displacement = 4 - 0 = 4. imm26 = 1.
+    // b imm26=1 → 0x14000000 | 1 = 0x14000001
+    let mut expected: List<Int> = []
+    expected.push(0x14000001)
+    expected.push(0xd65f03c0)
+    assertWordsEq(outcome.words, expected)
+}
+
+// === Backward branch — looping `b bb0` from bb1 =====================
+
+fn testFixupBackwardBranch() {
+    // bb0: ret              (placeholder; we never hit this in flow,
+    //                        but it gives bb0 a byte offset != 0)
+    // bb1: b bb0
+    let mut bb0: List<OnbInstr> = []
+    bb0.push(onbInstrRet())
+    let mut bb1: List<OnbInstr> = []
+    bb1.push(onbInstrBranch(0))
+    let mut blocks: List<List<OnbInstr>> = []
+    blocks.push(bb0)
+    blocks.push(bb1)
+
+    let emitted = emitBlocks(blocks)
+    let outcome = onbResolveBranchFixups(emitted.words, emitted.fixups, emitted.blockOffsets)
+    testing.assert(outcome.ok)
+    // bb0 at byte 0; bb1 at byte 4. Branch sits at byte 4, displacement
+    // = 0 - 4 = -4. imm26 = -1 → encoded as 0x3ffffff (26-bit two's
+    // complement). 0x14000000 | 0x3ffffff = 0x17ffffff.
+    let mut expected: List<Int> = []
+    expected.push(0xd65f03c0)
+    expected.push(0x17ffffff)
+    assertWordsEq(outcome.words, expected)
+}
+
+// === Conditional branch — b.eq + ret + ret pattern ================
+
+fn testFixupBranchCond() {
+    // bb0: b.eq bb2
+    // bb1: ret             (fall-through path)
+    // bb2: ret
+    let mut bb0: List<OnbInstr> = []
+    bb0.push(onbInstrBranchCond(OnbCond.OnbCondEq, 2))
+    let mut bb1: List<OnbInstr> = []
+    bb1.push(onbInstrRet())
+    let mut bb2: List<OnbInstr> = []
+    bb2.push(onbInstrRet())
+    let mut blocks: List<List<OnbInstr>> = []
+    blocks.push(bb0)
+    blocks.push(bb1)
+    blocks.push(bb2)
+
+    let emitted = emitBlocks(blocks)
+    let outcome = onbResolveBranchFixups(emitted.words, emitted.fixups, emitted.blockOffsets)
+    testing.assert(outcome.ok)
+    // bb0 byte 0; bb2 byte 8. Displacement = 8. imm19 = 2.
+    // b.eq imm19=2, cond=0 → 0x54000000 | (2 << 5) | 0 = 0x54000040
+    let mut expected: List<Int> = []
+    expected.push(0x54000040)
+    expected.push(0xd65f03c0)
+    expected.push(0xd65f03c0)
+    assertWordsEq(outcome.words, expected)
+}
+
+// === Conditional-not-zero — cbnz x9, bb_target =======================
+
+fn testFixupCbnz() {
+    // bb0: cbnz x9, bb1
+    // bb1: ret
+    let mut bb0: List<OnbInstr> = []
+    bb0.push(onbInstrBranchCondNotZero("x9", 1))
+    let mut bb1: List<OnbInstr> = []
+    bb1.push(onbInstrRet())
+    let mut blocks: List<List<OnbInstr>> = []
+    blocks.push(bb0)
+    blocks.push(bb1)
+
+    let emitted = emitBlocks(blocks)
+    let outcome = onbResolveBranchFixups(emitted.words, emitted.fixups, emitted.blockOffsets)
+    testing.assert(outcome.ok)
+    // Displacement = 4. imm19 = 1. Rt = 9.
+    // cbnz Xt, imm19=1 → 0xb5000000 | (1 << 5) | 9 = 0xb5000029
+    let mut expected: List<Int> = []
+    expected.push(0xb5000029)
+    expected.push(0xd65f03c0)
+    assertWordsEq(outcome.words, expected)
+}
+
+// === Failure — out-of-range target block ==========================
+
+fn testFixupOutOfRangeBlock() {
+    let mut bb0: List<OnbInstr> = []
+    // targetBlock 99 doesn't exist → resolve should fail.
+    bb0.push(onbInstrBranch(99))
+    let mut blocks: List<List<OnbInstr>> = []
+    blocks.push(bb0)
+
+    let emitted = emitBlocks(blocks)
+    let outcome = onbResolveBranchFixups(emitted.words, emitted.fixups, emitted.blockOffsets)
+    testing.assert(!outcome.ok)
+}

--- a/toolchain/onb_lir.osty
+++ b/toolchain/onb_lir.osty
@@ -98,6 +98,12 @@ pub enum OnbInstrKind {
     // `onbEncodeInstr` dispatcher.
     OnbInstrMovImm32,
     OnbInstrMovImm64,
+    // Phase 2d: block-relative branches. Encoded as placeholder
+    // words at emit time + a fixup record that the per-function
+    // resolve pass patches once block byte offsets are known.
+    OnbInstrBranch,
+    OnbInstrBranchCond,
+    OnbInstrBranchCondNotZero,
 }
 
 // === LIR instruction record ============================================
@@ -117,6 +123,10 @@ pub struct OnbInstr {
     pub imm: Int,
     pub offset: Int,
     pub cond: OnbCond,
+    // targetBlock is the destination block index for branch
+    // opcodes (Phase 2d). -1 for non-branch instructions, where
+    // the field is ignored.
+    pub targetBlock: Int,
 }
 
 // emptyOnbInstr returns a zero-valued instruction record. Internal
@@ -133,6 +143,7 @@ fn emptyOnbInstr() -> OnbInstr {
         imm: 0,
         offset: 0,
         cond: OnbCond.OnbCondEq,
+        targetBlock: -1,
     }
 }
 
@@ -234,6 +245,91 @@ pub fn onbInstrMovImm64(dst: String, imm: Int) -> OnbInstr {
     OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrMovImm64, dst: dst, imm: imm }
 }
 
+// === Phase 2d branch constructors ===================================
+//
+// Branch instructions store their target block index in
+// `targetBlock`. The src/cond/imm fields carry the opcode-specific
+// payload (cbnz's register; b.cond's condition). The encoder
+// helpers below produce the placeholder word + fixup record pair
+// that the per-function resolve pass needs.
+
+pub fn onbInstrBranch(targetBlock: Int) -> OnbInstr {
+    OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrBranch, targetBlock: targetBlock }
+}
+
+pub fn onbInstrBranchCond(cond: OnbCond, targetBlock: Int) -> OnbInstr {
+    OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrBranchCond, cond: cond, targetBlock: targetBlock }
+}
+
+pub fn onbInstrBranchCondNotZero(src: String, targetBlock: Int) -> OnbInstr {
+    OnbInstr { ..emptyOnbInstr(), kind: OnbInstrKind.OnbInstrBranchCondNotZero, src: src, targetBlock: targetBlock }
+}
+
+// === Phase 2d emit helpers ==========================================
+
+// OnbBranchEmit bundles a placeholder word with the fixup record
+// the resolve pass needs. Non-branch opcodes return an empty fixup
+// list via `onbEmitInstr`'s `fixups` field — the structure stays
+// uniform across opcode kinds.
+pub struct OnbBranchEmit {
+    pub words: List<Int>,
+    pub fixups: List<OnbBranchFixup>,
+}
+
+// onbEmitInstr produces the encoded word(s) plus any fixup records
+// for a single instruction at byte offset `codeOffset` (the offset
+// where the first word will land). For branch instructions the
+// returned `words` is the placeholder skeleton and `fixups`
+// contains exactly one record. For non-branch instructions
+// `fixups` is empty.
+//
+// Returning a struct rather than re-using `onbEncodeInstrWords`
+// means downstream block walkers can handle every opcode through
+// one signature, then concatenate `words` into the function's
+// code stream and `fixups` into the per-function fixup list.
+pub fn onbEmitInstr(instr: OnbInstr, codeOffset: Int) -> OnbBranchEmit {
+    match instr.kind {
+        OnbInstrKind.OnbInstrBranch -> onbEmitBranchPlaceholder(instr, codeOffset),
+        OnbInstrKind.OnbInstrBranchCond -> onbEmitBranchCondPlaceholder(instr, codeOffset),
+        OnbInstrKind.OnbInstrBranchCondNotZero -> onbEmitCbnzPlaceholder(instr, codeOffset),
+        _ -> OnbBranchEmit { words: onbEncodeInstrWords(instr), fixups: [] },
+    }
+}
+
+fn onbEmitBranchPlaceholder(instr: OnbInstr, codeOffset: Int) -> OnbBranchEmit {
+    let mut words: List<Int> = []
+    words.push(onbEncodeBranchPlaceholder())
+    let mut fixups: List<OnbBranchFixup> = []
+    fixups.push(onbBranchFixup(codeOffset, instr.targetBlock, OnbBranchFixupKind.OnbBranchFixupUncond))
+    OnbBranchEmit { words: words, fixups: fixups }
+}
+
+fn onbEmitBranchCondPlaceholder(instr: OnbInstr, codeOffset: Int) -> OnbBranchEmit {
+    let mut words: List<Int> = []
+    let mut fixups: List<OnbBranchFixup> = []
+    match onbEncodeBranchCondPlaceholder(onbCondToCode(instr.cond)) {
+        Some(w) -> {
+            words.push(w)
+            fixups.push(onbBranchFixup(codeOffset, instr.targetBlock, OnbBranchFixupKind.OnbBranchFixupCond))
+        },
+        None -> {},
+    }
+    OnbBranchEmit { words: words, fixups: fixups }
+}
+
+fn onbEmitCbnzPlaceholder(instr: OnbInstr, codeOffset: Int) -> OnbBranchEmit {
+    let mut words: List<Int> = []
+    let mut fixups: List<OnbBranchFixup> = []
+    match onbEncodeCbnzPlaceholder(instr.src) {
+        Some(w) -> {
+            words.push(w)
+            fixups.push(onbBranchFixup(codeOffset, instr.targetBlock, OnbBranchFixupKind.OnbBranchFixupCbnz))
+        },
+        None -> {},
+    }
+    OnbBranchEmit { words: words, fixups: fixups }
+}
+
 // === Single-word encoder dispatch =====================================
 //
 // `onbEncodeInstr` mirrors the encoder switch in
@@ -271,6 +367,15 @@ pub fn onbEncodeInstr(instr: OnbInstr) -> Int? {
         OnbInstrKind.OnbInstrBranchLinkReg -> onbEncodeBlr(instr.src),
         OnbInstrKind.OnbInstrMovImm32 -> onbEncodeMovImm32Word(instr.dst, instr.imm),
         OnbInstrKind.OnbInstrMovImm64 -> None,
+        // Branch family is multi-step (placeholder word + fixup
+        // record) so the single-word path can't represent it. The
+        // higher-level emitter routes branches through
+        // `onbEmitInstr` which produces both a placeholder word
+        // and a fixup. Returning None here keeps the fast path
+        // closed.
+        OnbInstrKind.OnbInstrBranch -> None,
+        OnbInstrKind.OnbInstrBranchCond -> None,
+        OnbInstrKind.OnbInstrBranchCondNotZero -> None,
         OnbInstrKind.OnbInstrInvalid -> None,
     }
 }

--- a/toolchain/onb_lir_test.osty
+++ b/toolchain/onb_lir_test.osty
@@ -134,6 +134,7 @@ fn testOnbInstrInvalidReturnsNone() {
         imm: 0,
         offset: 0,
         cond: OnbCond.OnbCondEq,
+        targetBlock: -1,
     }
     testing.assert(onbEncodeInstr(bogus).isNone())
 }


### PR DESCRIPTION
## Summary

Block-relative branch encoder + placeholder + fixup resolve pass in one slice. The algorithmic core of branch lowering — emit placeholder words, collect fixup records, walk blocks to compute byte offsets, patch placeholders with displacements — lives in Osty now.

Covers \`b\` (imm26), \`b.cond\` (imm19), and \`cbnz\` (imm19). \`bl\` calls go through the Mach-O reloc table and ride along with adrp+add in Phase 2c.

## Mechanics

**\`toolchain/onb_encoding.osty\`** — displacement encoders, placeholders, and patch helpers for the three branch shapes. The patch helpers are simple OR ops because placeholders carry \`imm = 0\` by construction (so no bitwise NOT needed — Osty doesn't have \`~\` today).

**\`toolchain/onb_fixups.osty\`** (new):
- \`OnbBranchFixupKind\` enum (Uncond / Cond / Cbnz)
- \`OnbBranchFixup{codeOffset, targetBlock, kind}\` record
- \`OnbResolveOutcome{words, ok}\`
- \`onbResolveBranchFixups\` walks fixups, computes \`displacement = target_byte - codeOffset\`, patches each placeholder via \`onbPatchBranchByKind\`. Returns the patched word stream + an \`ok\` flag (false on out-of-range / unknown block / misalignment).

**\`toolchain/onb_lir.osty\`**:
- 3 new opcodes (\`OnbInstrBranch/Cond/CondNotZero\`)
- New field \`OnbInstr.targetBlock: Int\`
- Constructors + \`OnbBranchEmit{words, fixups}\` + \`onbEmitInstr(instr, codeOffset)\` unified emitter. Branches return placeholder + fixup pair; non-branches return words with empty fixups.

**\`toolchain/onb_fixups_test.osty\`** (new):
- 5 round-trip cases covering forward, backward (loop), conditional, cbnz, and out-of-range error
- \`emitBlocks\` test helper walks blocks, threading byte offsets to build word stream + fixups + blockOffsets in one pass

**\`internal/onb/onb_lir_parity_test.go::TestLirBranchParityVsOstyTable\`** — Go's \`patchMachOBranch\` produces the same 4 hex words the Osty test asserts (b +4 = \`0x14000001\`, b -4 = \`0x17ffffff\`, b.eq +8 = \`0x54000040\`, cbnz x9 +4 = \`0xb5000029\`).

## Out of scope

- **BranchLink** (\`bl symbol\`) — depends on Mach-O reloc table; Phase 2c bundles it with adrp+add
- **Function-level block walker** (line spans, prologue/epilogue placement, reloc collection) — Phase 2e with container types
- **Branch optimization** (fall-through elide, b → b.cond rewrite) — belongs to the lowering layer (Phase 4-5)

## Test plan

- [x] \`go run ./cmd/osty check ./toolchain\` exit 0
- [x] All 4 Osty parity tests pass (Encoder, LirOpcode, LirMultiWord, LirBranch)
- [x] \`go test ./internal/onb ./internal/backend -short\` — 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)