### PR TITLE
feat: lower let-bound Range<Int> for-in via pseudo-binding fast path

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1509,6 +1509,87 @@ func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRForInRangePseudoBindingLowers pins the
+// `let r = 0..n; for i in r { ... }` Range-pseudo-binding fast path.
+// Without it, RangeLit in value position used to surface as
+// "range literal in value position not lowered to MIR" + a
+// downstream "for-in over Range<Int>" diagnostic. With the fast
+// path the let stores start/end into `_rstart` / `_rend` Int
+// locals and the `for-in` reads them through the same counter-loop
+// shape `for i in 0..n` would emit.
+func TestGenerateFromMIRForInRangePseudoBindingLowers(t *testing.T) {
+	rangeT := &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}}
+	// fn check() -> Int {
+	//     let r = 0..5
+	//     let mut sum = 0
+	//     for i in r { sum = sum + i }
+	//     sum
+	// }
+	body := &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.LetStmt{
+				Name: "r",
+				Type: rangeT,
+				Value: &ir.RangeLit{
+					Start: &ir.IntLit{Text: "0", T: ir.TInt},
+					End:   &ir.IntLit{Text: "5", T: ir.TInt},
+					T:     rangeT,
+				},
+			},
+			&ir.LetStmt{
+				Name:  "sum",
+				Type:  ir.TInt,
+				Mut:   true,
+				Value: &ir.IntLit{Text: "0", T: ir.TInt},
+			},
+			&ir.ForStmt{
+				Kind: ir.ForIn,
+				Var:  "i",
+				Iter: &ir.Ident{Name: "r", Kind: ir.IdentLocal, T: rangeT},
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.AssignStmt{
+							Op:      ir.AssignEq,
+							Targets: []ir.Expr{&ir.Ident{Name: "sum", Kind: ir.IdentLocal, T: ir.TInt}},
+							Value: &ir.BinaryExpr{
+								Op:    ir.BinAdd,
+								Left:  &ir.Ident{Name: "sum", Kind: ir.IdentLocal, T: ir.TInt},
+								Right: &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+								T:     ir.TInt,
+							},
+						},
+					},
+				},
+			},
+		},
+		Result: &ir.Ident{Name: "sum", Kind: ir.IdentLocal, T: ir.TInt},
+	}
+	fn := &ir.FnDecl{Name: "check", Return: ir.TInt, Body: body}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/range_pseudo.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "range literal in value position") {
+		t.Fatalf("emitter still surfaces the range-in-value-position diagnostic:\n%s", got)
+	}
+	if strings.Contains(got, "for-in over non-List/Map/Channel iterable") {
+		t.Fatalf("emitter still surfaces the for-in-over-Range fallback:\n%s", got)
+	}
+	for _, want := range []string{
+		"define i64 @check()",
+		"icmp slt i64", // exclusive upper-bound compare
+		"add i64",      // accumulator + step
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIRDbgPrintsAndPassesThrough pins the prelude
 // diagnostic builtin `dbg<T>(value: T) -> T` (LANG_SPEC §A.10).
 // Stringifiable primitives flow through `string_concat` boxing →

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -538,6 +538,23 @@ type bodyState struct {
 	// Each frame holds HIR blocks in *source* order; replay inlines
 	// them in LIFO at the appropriate exit point.
 	deferFrames [][]*ir.Block
+
+	// rangeBindings tracks `let r = START..END` (or `..=`) shaped
+	// lets where the RHS is a literal Range<Int>. Range isn't a
+	// first-class MIR value yet, but a let binding that's only ever
+	// iterated through `for-in` can be lowered as a pseudo-binding:
+	// the lit's start/end land in two real Int locals, and `for-in r`
+	// resolves through this map to the same counter loop a direct
+	// `for i in 0..n` would emit. Eliminates the "range literal in
+	// value position not lowered to MIR" diagnostic for this common
+	// shape.
+	rangeBindings map[LocalID]rangePseudoBinding
+}
+
+type rangePseudoBinding struct {
+	startLocal LocalID
+	endLocal   LocalID
+	inclusive  bool
 }
 
 type ownerContext struct {
@@ -566,7 +583,7 @@ type loopFrame struct {
 }
 
 func newBodyState(l *lowerer, fn *Function) *bodyState {
-	bs := &bodyState{l: l, fn: fn, cur: fn.Entry}
+	bs := &bodyState{l: l, fn: fn, cur: fn.Entry, rangeBindings: map[LocalID]rangePseudoBinding{}}
 	bs.pushScope()
 	// Function-level defer frame. Stays for the lifetime of the
 	// function and is replayed on every exit edge (return, `?`
@@ -824,6 +841,30 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	case let.Pattern != nil:
 		bs.lowerLetPattern(let.Pattern, let.Value, t, let.SpanV)
 	case let.Name != "":
+		// Range pseudo-binding fast path: `let r = start..end` keeps the
+		// bounds in two real Int locals + a unit sentinel. The sentinel
+		// preserves the user-visible name so `bind` works, but the
+		// actual bounds flow through `rangeBindings`. The for-in lowerer
+		// (and only the for-in lowerer) reads back through that map —
+		// other uses of `r` will surface as the existing
+		// "range literal in value position" diagnostic, unchanged.
+		if rng, ok := let.Value.(*ir.RangeLit); ok && isRangeIntType(t) && rng.Start != nil && rng.End != nil {
+			startLocal := bs.newLocal("_rstart", TInt, false, let.SpanV)
+			bs.emit(&StorageLiveInstr{Local: startLocal, SpanV: let.SpanV})
+			bs.lowerExprInto(rng.Start, startLocal, TInt)
+			endLocal := bs.newLocal("_rend", TInt, false, let.SpanV)
+			bs.emit(&StorageLiveInstr{Local: endLocal, SpanV: let.SpanV})
+			bs.lowerExprInto(rng.End, endLocal, TInt)
+			sentinel := bs.newLocal(let.Name, ir.TUnit, let.Mut, let.SpanV)
+			bs.emit(&StorageLiveInstr{Local: sentinel, SpanV: let.SpanV})
+			bs.rangeBindings[sentinel] = rangePseudoBinding{
+				startLocal: startLocal,
+				endLocal:   endLocal,
+				inclusive:  rng.Inclusive,
+			}
+			bs.bind(let.Name, sentinel)
+			return
+		}
 		id := bs.newLocal(let.Name, t, let.Mut, let.SpanV)
 		bs.emit(&StorageLiveInstr{Local: id, SpanV: let.SpanV})
 		if let.Value != nil {
@@ -833,6 +874,20 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	default:
 		bs.l.noteIssue("let stmt with neither name nor pattern")
 	}
+}
+
+// isRangeIntType reports whether `t` is a `Range<Int>` (the only
+// instantiation the pseudo-binding fast path supports today).
+// Other Range<T> shapes still hit the standard "range literal in
+// value position" fallback until Range becomes a first-class MIR
+// value.
+func isRangeIntType(t Type) bool {
+	nt, ok := t.(*ir.NamedType)
+	if !ok || nt.Name != "Range" || len(nt.Args) != 1 {
+		return false
+	}
+	pt, ok := nt.Args[0].(*ir.PrimType)
+	return ok && pt.Kind == ir.PrimInt
 }
 
 func isPoisonType(t Type) bool {
@@ -1454,6 +1509,78 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 	bs.cur = exit
 }
 
+// lowerForRangePseudoBinding emits the same counter-loop shape as
+// `lowerForRange`, but reads start/end from the locals stored on the
+// pseudo-binding instead of expressions on the ForStmt. Lets
+// `for i in r` where `r` was bound via the Range pseudo-binding fast
+// path lower exactly like a direct `for i in start..end`.
+func (bs *bodyState) lowerForRangePseudoBinding(f *ir.ForStmt, rb rangePseudoBinding) {
+	idx := bs.newLocal(f.Var, TInt, true, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: idx, SpanV: f.SpanV})
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: idx},
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: rb.startLocal}, T: TInt}},
+		SpanV: f.SpanV,
+	})
+	bs.bind(f.Var, idx)
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	step := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	cmpOp := BinLt
+	if rb.inclusive {
+		cmpOp = BinLeq
+	}
+	cmp := bs.freshTemp(TBool, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: cmp},
+		Src: &BinaryRV{
+			Op:    cmpOp,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &CopyOp{Place: Place{Local: rb.endLocal}, T: TInt},
+			T:     TBool,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&BranchTerm{
+		Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
+		Then:  body,
+		Else:  exit,
+		SpanV: f.SpanV,
+	})
+	bs.cur = body
+	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		label:      f.Label,
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
+	})
+	bs.bind(f.Var, idx)
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
+	bs.cur = step
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: idx},
+		Src: &BinaryRV{
+			Op:    BinAdd,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+			T:     TInt,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = exit
+}
+
 func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	iterT := bs.recoveredTypeOf(f.Iter)
 	if isChannelType(iterT) {
@@ -1463,6 +1590,18 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	if bs.l.isMapType(iterT) {
 		bs.lowerForInMap(f, iterT)
 		return
+	}
+	// Range pseudo-binding fast path: `for i in r` where r was bound
+	// from a Range<Int> literal at let time. Reads the recorded
+	// start/end locals and emits the same counter-loop shape
+	// `lowerForRange` produces for a direct `for i in 0..n`.
+	if id, ok := f.Iter.(*ir.Ident); ok {
+		if local, found := bs.lookup(id.Name); found {
+			if rb, ok := bs.rangeBindings[local]; ok {
+				bs.lowerForRangePseudoBinding(f, rb)
+				return
+			}
+		}
 	}
 	if !bs.l.isListType(iterT) {
 		bs.l.noteIssue("for-in over non-List/Map/Channel iterable is not lowered to MIR yet: %s", typeString(iterT))

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -1153,6 +1153,21 @@ pub struct MirLowerBodyState {
     // Defer frames. Index 0 is the function-level frame (seeded by
     // the constructor); each block push adds a new frame on top.
     pub deferFrames: List<List<HirBlock>>,
+
+    // Range pseudo-bindings. `let r = 0..n` shaped lets land here
+    // with their start / end stored in two real Int locals; the user-
+    // visible name is bound to a unit sentinel. `for-in r` looks up
+    // the binding to emit a counter loop instead of failing on
+    // "range literal in value position". Mirror of `rangeBindings`
+    // in `internal/mir/lower.go`.
+    pub rangeBindings: List<MirLowerRangePseudoBinding>,
+}
+
+pub struct MirLowerRangePseudoBinding {
+    pub sentinel: Int,
+    pub startLocal: Int,
+    pub endLocal: Int,
+    pub inclusive: Bool,
 }
 
 /// mirLowerBodyState constructs a bodyState seeded from `out`'s
@@ -1174,6 +1189,7 @@ pub fn mirLowerBodyState(
         self: mirLowerOwnerNone(),
         loopStack: [],
         deferFrames: [],
+        rangeBindings: [],
     }
     // Function-level scope.
     bs.scopes.push(mirLowerScopeFrame())
@@ -2131,6 +2147,32 @@ pub fn mirLowerLetStmt(bs: MirLowerBodyState, s: HirStmt) {
         mirLowerNoteIssue(bs.l, "mir_lower: let stmt with neither name nor pattern")
         return
     }
+    // Range pseudo-binding fast path: `let r = start..end` over
+    // Range<Int>. Stores start/end in two Int locals + a unit sentinel
+    // for the user-visible name; `for-in r` later reads through
+    // `rangeBindings` to emit a counter loop instead of failing on
+    // "range literal in value position". Mirror of the same fast
+    // path in `internal/mir/lower.go::lowerLet`.
+    if s.letHasValue && s.letValue.kind == HirExprRange && mirLowerIsRangeIntType(t)
+        && s.letValue.rangeStart.len() > 0 && s.letValue.rangeEnd.len() > 0 {
+        let intT = hirTInt()
+        let startLocal = mirLowerNewLocal(bs, "_rstart", intT, false, span)
+        mirLowerEmitInstr(bs, mirStorageLiveInstr(startLocal, span))
+        mirLowerExprInto(bs, s.letValue.rangeStart[0], startLocal, intT)
+        let endLocal = mirLowerNewLocal(bs, "_rend", intT, false, span)
+        mirLowerEmitInstr(bs, mirStorageLiveInstr(endLocal, span))
+        mirLowerExprInto(bs, s.letValue.rangeEnd[0], endLocal, intT)
+        let sentinel = mirLowerNewLocal(bs, s.letName, hirTUnit(), s.letMut, span)
+        mirLowerEmitInstr(bs, mirStorageLiveInstr(sentinel, span))
+        bs.rangeBindings.push(MirLowerRangePseudoBinding {
+            sentinel,
+            startLocal,
+            endLocal,
+            inclusive: s.letValue.rangeInclusive,
+        })
+        mirLowerBindName(bs, s.letName, sentinel)
+        return
+    }
     let id = mirLowerNewLocal(bs, s.letName, t, s.letMut, span)
     mirLowerEmitInstr(bs, mirStorageLiveInstr(id, span))
     if s.letHasValue {
@@ -2592,6 +2634,17 @@ fn mirLowerForIn(bs: MirLowerBodyState, s: HirStmt) {
         mirLowerForInChannel(bs, s, iterT, span)
         return
     }
+    // Range pseudo-binding fast path: `for i in r` where r was bound
+    // from a Range<Int> literal at let time. Reads start/end from the
+    // recorded locals and emits the same counter-loop shape
+    // mirLowerForRange produces for `for i in 0..n`.
+    if s.forIter.kind == HirExprIdent {
+        let rb = mirLowerLookupRangeBinding(bs, s.forIter.identName)
+        if rb.sentinel >= 0 {
+            mirLowerForRangePseudoBinding(bs, s, rb, span)
+            return
+        }
+    }
     if hirTypeIsList(iterT) {
         mirLowerForInList(bs, s, iterT, span)
         return
@@ -2606,6 +2659,94 @@ fn mirLowerForIn(bs: MirLowerBodyState, s: HirStmt) {
             + hirTypeString(iterT)
             + " is not lowered to MIR yet",
     )
+}
+
+/// mirLowerLookupRangeBinding finds the pseudo-binding for `name`, or
+/// returns a sentinel binding (with `sentinel == -1`) when no such
+/// binding exists. `for-in` resolves through this map before falling
+/// back to the List / Channel iterator paths.
+fn mirLowerLookupRangeBinding(bs: MirLowerBodyState, name: String) -> MirLowerRangePseudoBinding {
+    let id = mirLowerLookupName(bs, name)
+    if id < 0 {
+        return MirLowerRangePseudoBinding { sentinel: -1, startLocal: -1, endLocal: -1, inclusive: false }
+    }
+    for rb in bs.rangeBindings {
+        if rb.sentinel == id {
+            return rb
+        }
+    }
+    MirLowerRangePseudoBinding { sentinel: -1, startLocal: -1, endLocal: -1, inclusive: false }
+}
+
+/// mirLowerForRangePseudoBinding emits the same counter-loop shape as
+/// `mirLowerForRange`, but reads start/end from the locals stored on
+/// the pseudo-binding instead of expressions on the ForStmt. Lets
+/// `for i in r` where r was bound via the Range pseudo-binding fast
+/// path lower exactly like a direct `for i in start..end`.
+fn mirLowerForRangePseudoBinding(
+    bs: MirLowerBodyState,
+    s: HirStmt,
+    rb: MirLowerRangePseudoBinding,
+    span: MirSpan,
+) {
+    let intT = hirTInt()
+    let idx = mirLowerNewLocal(bs, s.forVar, intT, true, span)
+    mirLowerEmitInstr(bs, mirStorageLiveInstr(idx, span))
+    let startCopy = mirOperandCopy(mirPlace(rb.startLocal), "Int")
+    mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(idx), mirRVUse(startCopy), span))
+    mirLowerBindName(bs, s.forVar, idx)
+
+    let header = mirLowerNewBlock(bs, span)
+    let body = mirLowerNewBlock(bs, span)
+    let step = mirLowerNewBlock(bs, span)
+    let exit = mirLowerNewBlock(bs, span)
+
+    mirLowerTerminate(bs, mirGotoTerm(header, span))
+    bs.cur = header
+
+    let cmpOp = if rb.inclusive { MirBinLeq } else { MirBinLt }
+    let cmp = mirLowerFreshTemp(bs, hirTBool(), span)
+    let leftOp = mirOperandCopy(mirPlace(idx), "Int")
+    let rightOp = mirOperandCopy(mirPlace(rb.endLocal), "Int")
+    let rv = mirRVBinary(cmpOp, leftOp, rightOp, "Bool")
+    mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(cmp), rv, span))
+    let condOp = mirOperandCopy(mirPlace(cmp), "Bool")
+    mirLowerTerminate(bs, mirBranchTerm(condOp, body, exit, span))
+
+    bs.cur = body
+    mirLowerBindName(bs, s.forVar, idx)
+    mirLowerForBodyWithFramesStep(bs, s.forBody, step, exit)
+    mirLowerTerminate(bs, mirGotoTerm(step, span))
+
+    bs.cur = step
+    let oneOp = mirOperandConst(mirConstInt(1, "Int"))
+    let stepRV = mirRVBinary(
+        MirBinAdd,
+        mirOperandCopy(mirPlace(idx), "Int"),
+        oneOp,
+        "Int",
+    )
+    mirLowerEmitInstr(bs, mirAssignInstr(mirPlace(idx), stepRV, span))
+    mirLowerTerminate(bs, mirGotoBackEdgeTerm(header, span))
+
+    bs.cur = exit
+}
+
+/// mirLowerIsRangeIntType reports whether `t` is `Range<Int>` (the
+/// only instantiation the pseudo-binding fast path supports today).
+/// Mirror of `isRangeIntType` in `internal/mir/lower.go`.
+fn mirLowerIsRangeIntType(t: HirType) -> Bool {
+    if t.kind != HirTypeNamed {
+        return false
+    }
+    if t.namedName != "Range" {
+        return false
+    }
+    if t.namedArgs.len() != 1 {
+        return false
+    }
+    let inner = t.namedArgs[0]
+    inner.kind == HirTypePrim && inner.primKind == HirPrimInt
 }
 
 fn mirLowerForInList(


### PR DESCRIPTION
## Summary
Closes the gap that previously rejected programs binding a `Range<Int>` to a let then iterating it. The checker accepts the program but MIR lowering bailed with two errors:

```
range literal in value position not lowered to MIR
for-in over non-List/Map/Channel iterable: Range<Int>
```

Inline `for i in 0..n` already worked (ForStmt.Kind=ForRange path); the failure was specific to the let-bound shape (Kind=ForIn with Range<Int> Iter).

## Approach

Range isn't a first-class MIR value yet — full support needs a struct layout per instantiation, RangeLit aggregate construction, and Range method intrinsics. That's multi-day work tracked in the bench perf backlog.

This PR takes a narrower path: a **pseudo-binding** optimisation that covers the common pattern.

When a let's RHS is a `Range<Int>` literal with both bounds set, the lowerer:
- Stores `start` / `end` exprs into two real `Int` locals (`_rstart`, `_rend`) — same locals `lowerForRange` spills for an inline range.
- Allocates a unit sentinel local under the user-visible name so `bs.lookup(r)` still resolves.
- Records the binding in `bs.rangeBindings`.

Then `lowerForIn`, before its non-List/Map/Channel error path, checks if the iter is an `Ident` whose binding is in `rangeBindings`; if so, it dispatches to a sibling `lowerForRangePseudoBinding` that emits the same counter-loop shape as `lowerForRange` but reads the bounds from the recorded locals.

Both Go production (`internal/mir/lower.go`) and Osty self-host (`toolchain/mir_lower.osty`) get the same wiring per CLAUDE.md **"Osty 우선"**. New helpers: `isRangeIntType` / `mirLowerIsRangeIntType` (gate the fast path) and `lowerForRangePseudoBinding` / `mirLowerForRangePseudoBinding` (emit the loop).

## Before / after

```osty
fn check() -> Int {
    let r = 0..5
    let mut sum = 0
    for i in r {
        sum = sum + i
    }
    sum
}
```

**Before**: `osty gen: backend: MIR coverage incomplete / range literal in value position not lowered to MIR / for-in over non-List/Map/Channel iterable is not lowered to MIR yet: Range<Int>`

**After**: compiles end-to-end. Built binary prints `10` (= 0+1+2+3+4). Inclusive form `1..=5` prints `15`. Output IR shape matches inline `for i in 0..5` exactly.

## Test plan

- [x] New `TestGenerateFromMIRForInRangePseudoBindingLowers` asserts the pseudo-binding path: no leftover diagnostics, expected `icmp slt i64` (exclusive bound), `add i64`, `ret i64`.
- [x] `just front` green
- [x] `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green
- [x] `.bin/osty check toolchain/` clean
- [x] `osty build` end-to-end on both `0..5` (returns 10) and `1..=5` (returns 15)
- [ ] CI 그린 확인

## Out of scope

- `Range<T>` for T != Int (Range<Float>, Range<Char>, etc.) — same fast-path approach generalizes; defer until needed.
- Range as a true first-class value (struct layout + aggregate construction + method intrinsics) — needed for `fn make_range() -> Range<Int>` style returns and full Range method dispatch. Tracked in the bench perf backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)