### PR TITLE
feat: extend Range pseudo-binding to Range<Char>

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1509,6 +1509,88 @@ func TestGenerateFromMIRDivergingBuiltinsLowerThroughPanic(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRForInRangePseudoBindingCharLowers pins the
+// `Range<Char>` extension of the pseudo-binding fast path. The
+// checker accepts `..` over Char (codepoints), and the lowerer
+// reuses the same Int counter loop the inline `for c in 'a'..='z'`
+// shape produces. Both ends are lowered into Int locals (Char
+// codepoints widen via the existing `lowerExprInto` path), so the
+// loop body sees the counter as Int — same as the existing
+// `lowerForRange` behavior for inline char ranges.
+func TestGenerateFromMIRForInRangePseudoBindingCharLowers(t *testing.T) {
+	rangeCharT := &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TChar}}
+	// fn check() -> Int {
+	//     let r = 'a'..='c'
+	//     let mut count = 0
+	//     for _c in r { count = count + 1 }
+	//     count
+	// }
+	body := &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.LetStmt{
+				Name: "r",
+				Type: rangeCharT,
+				Value: &ir.RangeLit{
+					Start:     &ir.CharLit{Value: 'a'},
+					End:       &ir.CharLit{Value: 'c'},
+					Inclusive: true,
+					T:         rangeCharT,
+				},
+			},
+			&ir.LetStmt{
+				Name:  "count",
+				Type:  ir.TInt,
+				Mut:   true,
+				Value: &ir.IntLit{Text: "0", T: ir.TInt},
+			},
+			&ir.ForStmt{
+				Kind: ir.ForIn,
+				Var:  "_c",
+				Iter: &ir.Ident{Name: "r", Kind: ir.IdentLocal, T: rangeCharT},
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.AssignStmt{
+							Op:      ir.AssignEq,
+							Targets: []ir.Expr{&ir.Ident{Name: "count", Kind: ir.IdentLocal, T: ir.TInt}},
+							Value: &ir.BinaryExpr{
+								Op:    ir.BinAdd,
+								Left:  &ir.Ident{Name: "count", Kind: ir.IdentLocal, T: ir.TInt},
+								Right: &ir.IntLit{Text: "1", T: ir.TInt},
+								T:     ir.TInt,
+							},
+						},
+					},
+				},
+			},
+		},
+		Result: &ir.Ident{Name: "count", Kind: ir.IdentLocal, T: ir.TInt},
+	}
+	fn := &ir.FnDecl{Name: "check", Return: ir.TInt, Body: body}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/range_char.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "range literal in value position") {
+		t.Fatalf("emitter still surfaces the range-in-value-position diagnostic:\n%s", got)
+	}
+	if strings.Contains(got, "for-in over non-List/Map/Channel iterable") {
+		t.Fatalf("emitter still surfaces the for-in-over-Range fallback:\n%s", got)
+	}
+	for _, want := range []string{
+		"define i64 @check()",
+		"icmp sle i64", // inclusive bound
+		"add i64",
+		"ret i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIRForInRangePseudoBindingLowers pins the
 // `let r = 0..n; for i in r { ... }` Range-pseudo-binding fast path.
 // Without it, RangeLit in value position used to surface as

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -848,7 +848,7 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 		// (and only the for-in lowerer) reads back through that map —
 		// other uses of `r` will surface as the existing
 		// "range literal in value position" diagnostic, unchanged.
-		if rng, ok := let.Value.(*ir.RangeLit); ok && isRangeIntType(t) && rng.Start != nil && rng.End != nil {
+		if rng, ok := let.Value.(*ir.RangeLit); ok && isRangeIntOrCharType(t) && rng.Start != nil && rng.End != nil {
 			startLocal := bs.newLocal("_rstart", TInt, false, let.SpanV)
 			bs.emit(&StorageLiveInstr{Local: startLocal, SpanV: let.SpanV})
 			bs.lowerExprInto(rng.Start, startLocal, TInt)
@@ -876,18 +876,23 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	}
 }
 
-// isRangeIntType reports whether `t` is a `Range<Int>` (the only
-// instantiation the pseudo-binding fast path supports today).
-// Other Range<T> shapes still hit the standard "range literal in
-// value position" fallback until Range becomes a first-class MIR
-// value.
-func isRangeIntType(t Type) bool {
+// isRangeIntOrCharType reports whether `t` is a `Range<Int>` or
+// `Range<Char>`. The checker only accepts `..` over Int and Char
+// today, so those are the two instantiations the pseudo-binding
+// fast path can encounter. Both flow through the same Int counter
+// loop (Char ranges convert codepoints to Int at construction —
+// matches the behavior of the inline `for c in 'a'..='z'` shape
+// that `lowerForRange` already produces).
+func isRangeIntOrCharType(t Type) bool {
 	nt, ok := t.(*ir.NamedType)
 	if !ok || nt.Name != "Range" || len(nt.Args) != 1 {
 		return false
 	}
 	pt, ok := nt.Args[0].(*ir.PrimType)
-	return ok && pt.Kind == ir.PrimInt
+	if !ok {
+		return false
+	}
+	return pt.Kind == ir.PrimInt || pt.Kind == ir.PrimChar
 }
 
 func isPoisonType(t Type) bool {

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -2153,7 +2153,7 @@ pub fn mirLowerLetStmt(bs: MirLowerBodyState, s: HirStmt) {
     // `rangeBindings` to emit a counter loop instead of failing on
     // "range literal in value position". Mirror of the same fast
     // path in `internal/mir/lower.go::lowerLet`.
-    if s.letHasValue && s.letValue.kind == HirExprRange && mirLowerIsRangeIntType(t)
+    if s.letHasValue && s.letValue.kind == HirExprRange && mirLowerIsRangeIntOrCharType(t)
         && s.letValue.rangeStart.len() > 0 && s.letValue.rangeEnd.len() > 0 {
         let intT = hirTInt()
         let startLocal = mirLowerNewLocal(bs, "_rstart", intT, false, span)
@@ -2732,10 +2732,15 @@ fn mirLowerForRangePseudoBinding(
     bs.cur = exit
 }
 
-/// mirLowerIsRangeIntType reports whether `t` is `Range<Int>` (the
-/// only instantiation the pseudo-binding fast path supports today).
-/// Mirror of `isRangeIntType` in `internal/mir/lower.go`.
-fn mirLowerIsRangeIntType(t: HirType) -> Bool {
+/// mirLowerIsRangeIntOrCharType reports whether `t` is `Range<Int>`
+/// or `Range<Char>`. The checker only accepts `..` over Int and
+/// Char today, so those are the two instantiations the pseudo-
+/// binding fast path can encounter. Both flow through the same Int
+/// counter loop (Char ranges convert codepoints to Int at
+/// construction — matches the inline `for c in 'a'..='z'` shape
+/// that `mirLowerForRange` already produces). Mirror of
+/// `isRangeIntOrCharType` in `internal/mir/lower.go`.
+fn mirLowerIsRangeIntOrCharType(t: HirType) -> Bool {
     if t.kind != HirTypeNamed {
         return false
     }
@@ -2746,7 +2751,10 @@ fn mirLowerIsRangeIntType(t: HirType) -> Bool {
         return false
     }
     let inner = t.namedArgs[0]
-    inner.kind == HirTypePrim && inner.primKind == HirPrimInt
+    if inner.kind != HirTypePrim {
+        return false
+    }
+    inner.primKind == HirPrimInt || inner.primKind == HirPrimChar
 }
 
 fn mirLowerForInList(


### PR DESCRIPTION
## Summary
Generalises #1317 from `Range<Int>` only to `Range<Int> | Range<Char>`.

**Survey result**: those are the only two `Range<T>` instantiations the checker accepts today. `Range<Float>` / `Range<Byte>` / `Range<UInt>` etc. fail at type-check (with `type mismatch: expected Int, found UntypedFloat`) because `..` isn't registered for them.

Char ranges already worked **inline** (`for c in 'a'..='z'` flows through `lowerForRange` which spills both bounds into Int locals — Char codepoints widen via the existing `lowerExprInto` path). The **let-bound** shape (`let r = 'a'..='z'; for c in r`) just needed the same fast-path gate to admit `Range<Char>`.

## What changed

- `isRangeIntType` → `isRangeIntOrCharType` (Go) and `mirLowerIsRangeIntType` → `mirLowerIsRangeIntOrCharType` (Osty). Both accept `PrimChar` alongside `PrimInt`.
- Loop body otherwise unchanged — the counter stays `Int` either way, matching the existing `lowerForRange` behavior.

## Before / after

```osty
fn check() -> Int {
    let r = 'a'..='c'
    let mut count = 0
    for _c in r { count = count + 1 }
    count
}
```

**Before**: `range literal in value position not lowered to MIR / for-in over non-List/Map/Channel iterable: Range<Char>`

**After**: built binary returns `3`. Same counter-loop shape as `Range<Int>` — the only difference is the bound values come from Char codepoints (97, 99 for `'a'..='c'`).

## Test plan
- [x] New `TestGenerateFromMIRForInRangePseudoBindingCharLowers` asserts `icmp sle i64` (inclusive bound) + expected counter loop
- [x] `TestGenerateFromMIRForInRangePseudoBindingLowers` (Int) still green
- [x] `just front` + `TestLIRProto*` / `TestGenerateFromMIR*` / `TestMIR*` slices green
- [x] `osty build` end-to-end on both `'a'..='c'` (returns 3) and `0..10` (returns 45 — regression check)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)