### PR TITLE
feat(mir): synthesise missing bounds for open-ended slices

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -5983,6 +5983,90 @@ func TestGenerateFromMIRListSliceInclusive(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRListSliceOpenHigh — `xs[a..]` synthesises the
+// missing upper bound by emitting an IntrinsicListLen call before the
+// slice. Regression guard for the open-ended slice support that
+// unblocks std.fmt / std.strings bodies under
+// `OSTY_STDLIB_BODY_LOWER=1`.
+func TestGenerateFromMIRListSliceOpenHigh(t *testing.T) {
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "tail",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "xs", Type: listInt},
+			{Name: "a", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.RangeLit{
+					Start: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					T:     &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: listInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_slice_open_high_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_list_len(ptr)",
+		"call i64 @osty_rt_list_len(",
+		"call ptr @osty_rt_list_slice(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRStringSliceOpenHigh — `s[a..]` synthesises the
+// missing upper bound by emitting an IntrinsicStringLen call before
+// the substring intrinsic. Mirrors the List variant; together they
+// close the open-ended slice gap that fmt.osty's `body[1..]` /
+// `s[1..]` patterns hit.
+func TestGenerateFromMIRStringSliceOpenHigh(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "tail",
+		Return: ir.TString,
+		Params: []*ir.Param{
+			{Name: "s", Type: ir.TString},
+			{Name: "a", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+				Index: &ir.RangeLit{
+					Start: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+					T:     &ir.NamedType{Name: "Range", Args: []ir.Type{ir.TInt}, Builtin: true},
+				},
+				T: ir.TString,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_slice_open_high_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"@osty_rt_strings_ByteLen",
+		"@osty_rt_strings_Slice",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIRBytesSlice verifies Bytes.slice() dispatches
 // through `osty_rt_bytes_slice(ptr, i64, i64) -> ptr`.
 func TestGenerateFromMIRBytesSlice(t *testing.T) {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -6047,22 +6047,24 @@ func isStringReceiverType(t ir.Type) bool {
 }
 
 // lowerStringSliceRValue emits `s[a..b]` as an IntrinsicStringSubstring
-// call, returning the RValue that reads the resulting temp. Requires
-// both bounds to be concrete exprs on the RangeLit — the unbounded
-// `s[..b]` / `s[a..]` / `s[..]` shapes still fall through to the
-// generic IndexProj path (for now that routes through the same broken
-// Range-in-value lowering, so callers should emit explicit bounds).
-// `..=` inclusive ranges also fall through; the runtime API takes
-// half-open [start, end) offsets so supporting `..=` cleanly would
-// mean bumping `end` by one byte which conflicts with the multi-byte
-// char boundary invariant the runtime enforces.
+// call, returning the RValue that reads the resulting temp. Open-ended
+// shapes synthesise the missing bound:
+//
+//	s[..]   →  s[0..s.byteLen()]
+//	s[a..]  →  s[a..s.byteLen()]
+//	s[..b]  →  s[0..b]
+//
+// Inclusive `..=` ranges fall through unchanged: the runtime API takes
+// half-open [start, end) byte offsets and bumping `end` by one byte
+// conflicts with the multi-byte char boundary invariant the runtime
+// enforces for non-ASCII strings.
 func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
-	if rng.Start == nil || rng.End == nil || rng.Inclusive {
+	if rng.Inclusive {
 		return nil, false
 	}
 	recvOp := bs.lowerExprAsOperand(x.X)
-	startOp := bs.lowerExprAsOperand(rng.Start)
-	endOp := bs.lowerExprAsOperand(rng.End)
+	startOp := bs.synthSliceStart(rng, exprSpan(x))
+	endOp := bs.synthStringSliceEnd(rng, recvOp, exprSpan(x))
 	tmp := bs.freshTemp(ir.TString, exprSpan(x))
 	bs.emit(&IntrinsicInstr{
 		Dest:  &Place{Local: tmp},
@@ -6073,21 +6075,49 @@ func (bs *bodyState) lowerStringSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (
 	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: ir.TString}}, true
 }
 
+// synthSliceStart returns the start operand for a slice — the explicit
+// expression when present, or the integer literal 0 for `..b` / `..`.
+func (bs *bodyState) synthSliceStart(rng *ir.RangeLit, sp Span) Operand {
+	if rng.Start != nil {
+		return bs.lowerExprAsOperand(rng.Start)
+	}
+	return &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt}
+}
+
+// synthStringSliceEnd returns the end operand for a String slice. When
+// the RangeLit's End is missing (`a..` / `..`), emits an
+// IntrinsicStringLen on the receiver and returns its temp; the runtime
+// helper returns the byte count which is exactly what
+// `osty_rt_strings_Substring` expects as the upper bound.
+func (bs *bodyState) synthStringSliceEnd(rng *ir.RangeLit, recvOp Operand, sp Span) Operand {
+	if rng.End != nil {
+		return bs.lowerExprAsOperand(rng.End)
+	}
+	tmp := bs.freshTemp(TInt, sp)
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: tmp},
+		Kind:  IntrinsicStringLen,
+		Args:  []Operand{recvOp},
+		SpanV: sp,
+	})
+	return &CopyOp{Place: Place{Local: tmp}, T: TInt}
+}
+
 // lowerListSliceRValue emits `list[a..b]` / `list[a..=b]` as an
 // IntrinsicListSlice call, returning the RValue that reads the
-// freshly-allocated List<T>. Requires both bounds to be concrete
-// exprs; open-ended ranges are unsupported (MIR has no Range
-// first-class value). Inclusive `..=` ranges are normalised to a
-// half-open `[start, end+1)` at lowering time — unlike the String
-// path, lists have no multi-byte boundary concerns so the +1 is
-// unambiguous.
+// freshly-allocated List<T>. Open-ended shapes synthesise the
+// missing bound (`list[..]` → `list[0..list.len()]`, etc.).
+// Inclusive `..=` ranges are normalised to a half-open `[start,
+// end+1)` at lowering time — unlike the String path, lists have no
+// multi-byte boundary concerns so the +1 is unambiguous. `..=` with
+// a missing End is impossible (parser rejects it).
 func (bs *bodyState) lowerListSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RValue, bool) {
-	if rng.Start == nil || rng.End == nil {
+	if rng.Inclusive && rng.End == nil {
 		return nil, false
 	}
 	recvOp := bs.lowerExprAsOperand(x.X)
-	startOp := bs.lowerExprAsOperand(rng.Start)
-	endOp := bs.lowerExprAsOperand(rng.End)
+	startOp := bs.synthSliceStart(rng, exprSpan(x))
+	endOp := bs.synthListSliceEnd(rng, recvOp, exprSpan(x))
 	if rng.Inclusive {
 		endTmp := bs.freshTemp(ir.TInt, exprSpan(rng))
 		bs.emit(&AssignInstr{
@@ -6111,6 +6141,23 @@ func (bs *bodyState) lowerListSliceRValue(x *ir.IndexExpr, rng *ir.RangeLit) (RV
 		SpanV: exprSpan(x),
 	})
 	return &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: listT}}, true
+}
+
+// synthListSliceEnd returns the end operand for a List slice. When
+// the RangeLit's End is missing (`a..` / `..`), emits an
+// IntrinsicListLen on the receiver and returns its temp.
+func (bs *bodyState) synthListSliceEnd(rng *ir.RangeLit, recvOp Operand, sp Span) Operand {
+	if rng.End != nil {
+		return bs.lowerExprAsOperand(rng.End)
+	}
+	tmp := bs.freshTemp(TInt, sp)
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: tmp},
+		Kind:  IntrinsicListLen,
+		Args:  []Operand{recvOp},
+		SpanV: sp,
+	})
+	return &CopyOp{Place: Place{Local: tmp}, T: TInt}
 }
 
 // emitStringFreeFnIntrinsic lowers each arg in source order and


### PR DESCRIPTION
## Summary
`lowerStringSliceRValue` / `lowerListSliceRValue` refused RangeLits with `Start == nil` or `End == nil` and fell through to the generic IndexProj path, which then tripped \`range literal in value position not lowered to MIR\`. This was the first wall every fmt_e2e test hit under \`OSTY_STDLIB_BODY_LOWER=1\` — \`body[1..]\` / \`s[1..]\` patterns inside std.fmt couldn't lower.

Fix: synthesise the missing bound at lowering time.

| Source        | Lowers as                                              |
|---------------|--------------------------------------------------------|
| \`s[a..]\`    | \`s[a..s.byteLen()]\` via IntrinsicStringLen           |
| \`s[..b]\`    | \`s[0..b]\`                                            |
| \`s[..]\`     | \`s[0..s.byteLen()]\`                                  |
| \`list[a..]\` | \`list[a..list.len()]\` via IntrinsicListLen           |
| \`list[..b]\` | \`list[0..b]\`                                         |
| \`list[..]\`  | \`list[0..list.len()]\`                                |

\`..=\` inclusive open-ended is unreachable (parser rejects); \`..=\` with End is unchanged.

**Wall progression**:
- Before: \`range literal in value position\` on first stdlib body that used \`s[1..]\`.
- After: moved to \`unsupported local type <error> in osty_std_fmt__padLeft (written by call Char__toString)\` — the injection's method-rewrite path drops primitive-method intrinsic return types. Separate fix.

## Test plan
- [x] \`TestGenerateFromMIRListSliceOpenHigh\` (new)
- [x] \`TestGenerateFromMIRStringSliceOpenHigh\` (new)
- [x] Adjacent slice tests still pass (\`TestGenerateFromMIRListSlice\`, \`TestGenerateFromMIRListSliceInclusive\`, \`TestListSliceOpenHigh\`, \`TestStringSliceHalfOpenRange\`)
- [x] \`internal/mir\`, \`internal/llvmgen\`, \`internal/backend\` short suites
- [x] \`just front\`
- [x] Body injection regressions (\`TestLLVMBackendEmitStringsCompareFlagOn\`, \`TestPrepareEntryInjectsStdlibWhenFlagOn\`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)