### PR TITLE
refactor: remove dead unreachable / todo / abort runtime helpers

### DIFF
--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -5544,22 +5544,18 @@ func mirCallValueGCAllocatedBytesLine(reg string) string {
 	return "  " + reg + " = " + mirInstrCall() + " i64 @osty_rt_gc_allocated_bytes()\n"
 }
 
-// §6 panic / abort runtime helper call shapes.
+// §6 panic / abort runtime helper call shapes. The
+// `unreachable` / `todo` / `abort` prelude builtins all route through
+// the same `MirIntrinsicAbort` lowering as `panic` since #1282, so
+// the only call shape the emitter actually produces is the
+// `osty_rt_panic(ptr msg)` one. The dedicated `_unreachable` /
+// `_todo` / `_abort` line + symbol helpers were dead code (their
+// targets aren't even defined as public symbols in the runtime —
+// see `static void osty_rt_abort` in `osty_runtime.c`).
 
-// Osty: mirCallVoidPanicMessageLine / mirCallVoidUnreachableUncheckedLine /
-//
-//	mirCallVoidTodoLine / mirCallVoidAbortLine
+// Osty: mirCallVoidPanicMessageLine
 func mirCallVoidPanicMessageLine(messagePtr string) string {
 	return "  " + mirInstrCallVoid() + " void @osty_rt_panic(ptr " + messagePtr + ")\n"
-}
-func mirCallVoidUnreachableUncheckedLine() string {
-	return "  " + mirInstrCallVoid() + " void @osty_rt_unreachable()\n"
-}
-func mirCallVoidTodoLine() string {
-	return "  " + mirInstrCallVoid() + " void @osty_rt_todo()\n"
-}
-func mirCallVoidAbortLine() string {
-	return "  " + mirInstrCallVoid() + " void @osty_rt_abort()\n"
 }
 
 // §6 standard math runtime call shapes.
@@ -6080,11 +6076,11 @@ func mirRtTestContextExitSymbol() string  { return mirRtTestSymbol("context_exit
 func mirRtTestExpectOkSymbol() string     { return mirRtTestSymbol("expect_ok") }
 func mirRtTestExpectErrorSymbol() string  { return mirRtTestSymbol("expect_error") }
 
-// Osty: bare runtime symbols
-func mirRtPanicSymbol() string       { return mirRtSymbol("panic") }
-func mirRtUnreachableSymbol() string { return mirRtSymbol("unreachable") }
-func mirRtTodoSymbol() string        { return mirRtSymbol("todo") }
-func mirRtAbortSymbol() string       { return mirRtSymbol("abort") }
+// Osty: bare runtime symbols.
+// `panic` / `unreachable` / `todo` / `abort` all route through
+// `MirIntrinsicAbort` → `osty_rt_panic`, so only the panic symbol
+// helper survives.
+func mirRtPanicSymbol() string { return mirRtSymbol("panic") }
 
 // Osty: option / result panic-helper symbols
 func mirRtOptionUnwrapNoneSymbol() string { return mirRtSymbol("option_unwrap_none") }
@@ -8033,20 +8029,11 @@ func mirCallTaskRaceLine(reg, bodyReg string) string {
 	return mirCallValuePtrFromPtrLine(reg, mirRtTaskRaceSymbol(), bodyReg)
 }
 
-// §17 LLVM-text typed runtime-callable panic / abort helpers.
+// §17 LLVM-text typed runtime-callable panic helper.
 
-// Osty: mirCall{Panic,Unreachable,Todo,Abort}Line / mirCall{OptionUnwrapNone,ResultUnwrapErr,ExpectFailed}Line
+// Osty: mirCallPanicLine / mirCall{OptionUnwrapNone,ResultUnwrapErr,ExpectFailed}Line
 func mirCallPanicLine(messagePtr string) string {
 	return mirCallVoidPtrLine(mirRtPanicSymbol(), messagePtr)
-}
-func mirCallUnreachableLine() string {
-	return mirCallVoidNoArgsLine(mirRtUnreachableSymbol())
-}
-func mirCallTodoLine() string {
-	return mirCallVoidNoArgsLine(mirRtTodoSymbol())
-}
-func mirCallAbortLine() string {
-	return mirCallVoidNoArgsLine(mirRtAbortSymbol())
 }
 func mirCallOptionUnwrapNoneLine() string {
 	return mirCallVoidNoArgsLine(mirRtOptionUnwrapNoneSymbol())

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -8477,26 +8477,12 @@ pub fn mirCallVoidPanicMessageLine(messagePtr: String) -> String {
     "  " + mirInstrCallVoid() + " void @osty_rt_panic(ptr " + messagePtr + ")\n"
 }
 
-/// mirCallVoidUnreachableUnchecked renders the canonical
-/// unreachable-unchecked call (when the user explicitly asks for
-/// it via `unreachable!`).
-pub fn mirCallVoidUnreachableUncheckedLine() -> String {
-    "  " + mirInstrCallVoid() + " void @osty_rt_unreachable()\n"
-}
-
-/// mirCallVoidTodoLine renders the canonical todo!() call.
-pub fn mirCallVoidTodoLine() -> String {
-    "  " + mirInstrCallVoid() + " void @osty_rt_todo()\n"
-}
-
-/// mirCallVoidAbortLine renders the canonical abort!() call (LLVM
-/// noreturn helper, used when the program decides to terminate).
-pub fn mirCallVoidAbortLine() -> String {
-    "  " + mirInstrCallVoid() + " void @osty_rt_abort()\n"
-}
-
 /// §6 standard math runtime call shapes (libm / runtime helpers
-/// that aren't direct LLVM intrinsics).
+/// that aren't direct LLVM intrinsics). The dedicated
+/// `unreachable_unchecked` / `todo` / `abort` line helpers were
+/// removed — `panic` / `unreachable` / `todo` / `abort` all route
+/// through `MirIntrinsicAbort` → `osty_rt_panic` since #1282, so
+/// only `mirCallVoidPanicMessageLine` is exercised in production.
 
 /// mirCallValueStdMathFloorLine / Ceil / Round / Trunc / Mod render
 /// the canonical libm-style math runtime shapes.
@@ -9561,22 +9547,14 @@ pub fn mirRtTestExpectErrorSymbol() -> String {
     mirRtTestSymbol("expect_error")
 }
 
-/// mirRtPanicSymbol / mirRtUnreachableSymbol / mirRtTodoSymbol /
-/// mirRtAbortSymbol — bare runtime symbols.
+/// mirRtPanicSymbol — the only bare diverging runtime symbol the
+/// emitter still produces. `unreachable` / `todo` / `abort` route
+/// through the same `MirIntrinsicAbort` → `osty_rt_panic` path
+/// since #1282, so dedicated symbol helpers were dead code (their
+/// targets aren't even defined as public symbols in the runtime —
+/// see `static void osty_rt_abort` in `osty_runtime.c`).
 pub fn mirRtPanicSymbol() -> String {
     mirRtSymbol("panic")
-}
-
-pub fn mirRtUnreachableSymbol() -> String {
-    mirRtSymbol("unreachable")
-}
-
-pub fn mirRtTodoSymbol() -> String {
-    mirRtSymbol("todo")
-}
-
-pub fn mirRtAbortSymbol() -> String {
-    mirRtSymbol("abort")
 }
 
 /// mirRtOptionUnwrapNoneSymbol / mirRtResultUnwrapErrSymbol /
@@ -13095,26 +13073,16 @@ pub fn mirCallTaskRaceLine(reg: String, bodyReg: String) -> String {
     mirCallValuePtrFromPtrLine(reg, mirRtTaskRaceSymbol(), bodyReg)
 }
 
-/// §17 LLVM-text typed runtime-callable panic / abort helpers.
+/// §17 LLVM-text typed runtime-callable panic helper.
 
-/// mirCallPanicLine renders the canonical panic call.
+/// mirCallPanicLine renders the canonical panic call. The
+/// `mirCallUnreachableLine` / `mirCallTodoLine` / `mirCallAbortLine`
+/// siblings were dead code — none of those bare runtime symbols
+/// are defined in the C runtime, and #1282 routed all four
+/// diverging prelude builtins through `MirIntrinsicAbort` →
+/// `osty_rt_panic` instead.
 pub fn mirCallPanicLine(messagePtr: String) -> String {
     mirCallVoidPtrLine(mirRtPanicSymbol(), messagePtr)
-}
-
-/// mirCallUnreachableLine renders the canonical unreachable call.
-pub fn mirCallUnreachableLine() -> String {
-    mirCallVoidNoArgsLine(mirRtUnreachableSymbol())
-}
-
-/// mirCallTodoLine renders the canonical todo!() call.
-pub fn mirCallTodoLine() -> String {
-    mirCallVoidNoArgsLine(mirRtTodoSymbol())
-}
-
-/// mirCallAbortLine renders the canonical abort!() call.
-pub fn mirCallAbortLine() -> String {
-    mirCallVoidNoArgsLine(mirRtAbortSymbol())
 }
 
 /// mirCallOptionUnwrapNoneLine renders the canonical Option-unwrap-None


### PR DESCRIPTION
## Summary
Survey of MIR-emitter `@osty_rt_*` symbols vs the C runtime's exported names found 9 helper functions that emit symbols **not defined** in `osty_runtime.c`:

| Helper | Emits |
|---|---|
| `mirCallVoidUnreachableUncheckedLine` | `@osty_rt_unreachable` |
| `mirCallVoidTodoLine` | `@osty_rt_todo` |
| `mirCallVoidAbortLine` | `@osty_rt_abort` |
| `mirCallUnreachableLine` | (wrapper of above) |
| `mirCallTodoLine` | (wrapper) |
| `mirCallAbortLine` | (wrapper) |
| `mirRtUnreachableSymbol` | (used only by wrappers) |
| `mirRtTodoSymbol` | (") |
| `mirRtAbortSymbol` | (") |

None are referenced from production code paths — `grep` outside test files and the snapshot itself comes back empty. They're leftovers from before #1282, which routed all four diverging prelude builtins (`panic` / `unreachable` / `todo` / `abort`) through the same `MirIntrinsicAbort` → `osty_rt_panic` lowering.

The `osty_rt_abort` / `osty_rt_unreachable` / `osty_rt_todo` **public** symbols don't exist in `osty_runtime.c` — the only internal `osty_rt_abort` is `static`, used via `osty_rt_panic` which IS public. So if any future caller wired up these dead helpers, programs would link-fail with the same "Undefined symbols for architecture arm64" #1323 just fixed for the bytes-v1 set path.

Removing them now closes that booby trap. Mirrored in both `toolchain/mir_generator.osty` (the self-host source) and `internal/llvmgen/mir_generator_snapshot.go` (the Go snapshot) per CLAUDE.md **"Osty 우선"**.

## Test plan
- [x] `just front` + LIR-proto / MIR / generator / backend test slices green
- [x] `.bin/osty check toolchain/` clean
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)