### PR TITLE
fix(ir): recover toString return type for primitive receivers

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2829,6 +2829,24 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 				},
 			}
 		}
+	case "toString":
+		// Primitive `.toString()` returns String for every numeric kind,
+		// Bool, Char, and Byte. The MIR-direct backend's
+		// `emitPrimitiveMethodCall` routes the lowered `Type__toString`
+		// symbol to the matching `osty_rt_*_to_string` runtime helper,
+		// but that lowering only fires once the call's destination
+		// local has a concrete String type. Without this arm, an
+		// injected stdlib body that calls e.g. `fill.toString()` (where
+		// `fill: Char`) ended up with an ErrType local that the LLVM
+		// emitter rejected with "unsupported local type <error>".
+		if isPrim(rt, PrimChar) || isPrim(rt, PrimByte) || isPrim(rt, PrimInt) ||
+			isPrim(rt, PrimFloat) || isPrim(rt, PrimBool) {
+			return TString
+		}
+		// String.toString is identity.
+		if isPrim(rt, PrimString) {
+			return TString
+		}
 	}
 	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -744,3 +744,34 @@ func TestLowerUseDeclRecoversBuiltinGenericTypesWithoutResolverTypeRefs(t *testi
 		t.Fatalf("return inner = %v, want TString", ret.Args[0])
 	}
 }
+
+// TestRecoverMethodReturnTypeToStringOnPrimitives — `Char.toString()`,
+// `Int.toString()`, `Float.toString()`, `Byte.toString()`,
+// `Bool.toString()` must all recover to `String`. Without this arm,
+// a stdlib body injected under `OSTY_STDLIB_BODY_LOWER=1` that calls
+// e.g. `fill.toString()` (Char receiver) ends up with an ErrType
+// destination local that the LLVM emitter rejects with
+// "unsupported local type <error> ... written by call Char__toString".
+// The MIR backend's `emitPrimitiveMethodCall` already routes the
+// mangled `Type__toString` symbol to the matching runtime helper —
+// it just needs the call's destination local to carry the right type
+// so the function can be checkFunctionSupported-clean.
+func TestRecoverMethodReturnTypeToStringOnPrimitives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Type
+	}{
+		{"Char", TChar},
+		{"Byte", TByte},
+		{"Int", TInt},
+		{"Float", TFloat},
+		{"Bool", TBool},
+		{"String", TString},
+	}
+	for _, tc := range cases {
+		got := recoverMethodReturnTypeFromType("toString", tc.in)
+		if got != TString {
+			t.Errorf("recoverMethodReturnTypeFromType(toString, %s) = %v, want TString", tc.name, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
`recoverMethodReturnTypeFromType` was missing a \`toString\` arm, so \`fill.toString()\` (Char) inside an injected stdlib body landed with ErrType on the destination local. The MIR emitter then rejected the function with \`unsupported local type <error> in osty_std_fmt__padLeft (written by call Char__toString)\` — the second wall every fmt_e2e test hit under \`OSTY_STDLIB_BODY_LOWER=1\` after the open-ended slice gate fell ([#1326](https://github.com/choiceoh/osty/pull/1326)).

The MIR backend's \`emitPrimitiveMethodCall\` already routes the mangled \`Type__toString\` symbol to the matching \`osty_rt_*_to_string\` runtime helper for every numeric width plus Char and Byte ([mir_generator.go:3781-3831](internal/llvmgen/mir_generator.go:3781)). It just needed the destination local to carry a concrete String type so the function passes \`checkFunctionSupported\`.

Recovers to String for: Char, Byte, Int, Float, Bool, String (identity).

**Wall progression:**
- Before: \`unsupported local type <error> in osty_std_fmt__padLeft (written by call Char__toString)\`.
- After: \`use of undefined value @graphemeBreakCR\` in the LLVM link step — \`padLeft\` → \`strings.repeat\` → \`textWidth\` → \`strings.graphemes\` reaches the \`graphemeBreakCRRanges\` global in std.strings, which the body-injection pipeline doesn't pull into the user module yet. Separate fix.

## Test plan
- [x] \`TestRecoverMethodReturnTypeToStringOnPrimitives\` (new, table-driven)
- [x] Body injection regressions (\`TestLLVMBackendEmitStringsCompareFlagOn\`, \`TestPrepareEntryInjectsStdlibWhenFlagOn\`)
- [x] \`internal/ir\`, \`internal/mir\`, \`internal/llvmgen\` short suites
- [x] \`just front\`
- [x] Manual smoke under \`OSTY_STDLIB_BODY_LOWER=1\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)