### PR TITLE
feat: ONB self-host port Slice E — ABI classification predicates

### DIFF
--- a/toolchain/onb_abi.osty
+++ b/toolchain/onb_abi.osty
@@ -1,0 +1,147 @@
+// onb_abi.osty — ABI classification predicates for the ONB
+// lowering. Slice E of the ONB self-host port. Mirror of the
+// `isABIScalarType / isFloatABIType / isClosureScalarType /
+// isBuiltinPointerType / abiKindFor / abiRegSlots` cluster in
+// `internal/onb/lower.go`.
+//
+// Style: Osty-side MIR types are carried as `String` (the
+// canonical type repr the front end emits — e.g. "Int", "Bool",
+// "Float64", "List<Int>", "fn(Int) -> Int", "Point",
+// "ClosureEnv"). Predicates pattern-match those strings.
+//
+// Layout-dependent predicates (`abiRegSlots` for structs/enums,
+// `abiUsesIndirectStruct`) live in Slice F alongside the layout
+// lookup tables — they need struct/enum layout context that the
+// MirModule view will surface.
+
+// === Direct scalars ================================================
+
+// onbIsFloatAbiType reports whether `typ` is a Float-class type
+// (Float / Float64 — IEEE 754 double, lives in a d-register at
+// the call boundary). Mirror of `isFloatABIType`.
+pub fn onbIsFloatAbiType(typ: String) -> Bool {
+    typ == "Float" || typ == "Float64"
+}
+
+// onbIsScalarPrimitive reports whether `typ` is one of the four
+// primary scalar types ONB emits in a single 8-byte slot (Int,
+// Bool, String, or a Float). Internal helper — `onbIsAbiScalarType`
+// includes pointer-shaped types as well.
+pub fn onbIsScalarPrimitive(typ: String) -> Bool {
+    typ == "Int" || typ == "Bool" || typ == "String" || onbIsFloatAbiType(typ)
+}
+
+// === Closure-shaped pointer types =================================
+
+// onbIsClosureEnvType reports whether `typ` is the lifted body's
+// first-arg ClosureEnv builtin. Stable string `"ClosureEnv"`.
+pub fn onbIsClosureEnvType(typ: String) -> Bool {
+    typ == "ClosureEnv"
+}
+
+// onbIsFnTypeRepr reports whether `typ` represents a function
+// value (`fn(...) -> R`). The MIR repr starts with `fn(` —
+// generic over the argument signature.
+pub fn onbIsFnTypeRepr(typ: String) -> Bool {
+    onbStringStartsWith(typ, "fn(")
+}
+
+// onbIsClosureScalarType bundles FnType + ClosureEnv. Mirror of
+// `isClosureScalarType` in lower.go. Both classes live as 8-byte
+// pointers at the ABI boundary.
+pub fn onbIsClosureScalarType(typ: String) -> Bool {
+    onbIsClosureEnvType(typ) || onbIsFnTypeRepr(typ)
+}
+
+// === Builtin generic containers ===================================
+//
+// `List<T>` / `Map<K,V>` / `Set<T>` / `Channel<T>` / `Bytes` /
+// `Handle` are runtime-managed heap pointers regardless of element
+// type. Mirror of `isBuiltinPointerType`.
+
+pub fn onbIsBuiltinPointerType(typ: String) -> Bool {
+    onbStringStartsWith(typ, "List<")
+        || onbStringStartsWith(typ, "Map<")
+        || onbStringStartsWith(typ, "Set<")
+        || onbStringStartsWith(typ, "Channel<")
+        || typ == "Bytes"
+        || typ == "Handle"
+}
+
+// === ABI-scalar superset =========================================
+
+// onbIsAbiScalarType reports whether `typ` fits cleanly in a
+// single AAPCS64 register slot — covering scalar primitives,
+// closure-shaped pointers, and builtin generic containers.
+// Mirror of `isABIScalarType`.
+pub fn onbIsAbiScalarType(typ: String) -> Bool {
+    onbIsScalarPrimitive(typ)
+        || onbIsClosureScalarType(typ)
+        || onbIsBuiltinPointerType(typ)
+}
+
+// === ABI kind tags ===============================================
+//
+// Mirror of `abiKindFor` in lower.go. Maps a MIR type string to
+// the runtime's `OSTY_RT_ABI_*` enum value (used by Map / List /
+// Set runtime calls to dispatch on key/value type).
+
+pub fn onbAbiKindFor(typ: String) -> Int {
+    if typ == "String" {
+        onbAbiKindString()
+    } else if typ == "Int" {
+        onbAbiKindI64()
+    } else if typ == "Bool" {
+        onbAbiKindI1()
+    } else if onbIsFloatAbiType(typ) {
+        onbAbiKindF64()
+    } else {
+        onbAbiKindPtr()
+    }
+}
+
+// === Word-size predicate =========================================
+
+// onbIsAbiWordType reports whether `typ` consumes exactly one
+// 8-byte register at the ABI boundary. Used by enum-payload and
+// struct-field validation: every "scalar" or pointer-shaped
+// type qualifies; multi-register types (large struct, enum with
+// 2-reg payload) do not.
+//
+// Without struct/enum layout context, this predicate
+// approximates: scalar primitives + closure scalars + builtin
+// pointer types are 1 reg; user-defined named types fall through
+// to false until Slice F adds layout-aware classification.
+pub fn onbIsAbiWordType(typ: String) -> Bool {
+    onbIsAbiScalarType(typ)
+}
+
+// === String-prefix helper ========================================
+//
+// Osty's `String` API today doesn't expose a `startsWith` directly
+// — the toolchain uses `strings.startsWith` from `std.strings` —
+// but using std.strings would force this file to import the
+// stdlib. The encoder layer is meant to stay free of stdlib
+// imports so the future LLVM-self-host LLVMgen has a leaner
+// dependency graph. Inline implementation below.
+fn onbStringStartsWith(s: String, prefix: String) -> Bool {
+    let mut sIter = s.bytes()
+    let mut pIter = prefix.bytes()
+    let mut sBytes: List<Int> = []
+    for b in sIter {
+        sBytes.push(b.toInt())
+    }
+    let mut pBytes: List<Int> = []
+    for b in pIter {
+        pBytes.push(b.toInt())
+    }
+    if pBytes.len() > sBytes.len() {
+        return false
+    }
+    for i in 0..pBytes.len() {
+        if sBytes[i] != pBytes[i] {
+            return false
+        }
+    }
+    true
+}

--- a/toolchain/onb_abi_test.osty
+++ b/toolchain/onb_abi_test.osty
@@ -1,0 +1,76 @@
+// onb_abi_test.osty — ABI predicate round-trip tests.
+use std.testing
+
+fn testOnbIsFloatAbiType() {
+    testing.assert(onbIsFloatAbiType("Float"))
+    testing.assert(onbIsFloatAbiType("Float64"))
+    testing.assert(!onbIsFloatAbiType("Int"))
+    testing.assert(!onbIsFloatAbiType("Float32"))  // Phase A2 only handles 64-bit
+}
+
+fn testOnbIsScalarPrimitive() {
+    testing.assert(onbIsScalarPrimitive("Int"))
+    testing.assert(onbIsScalarPrimitive("Bool"))
+    testing.assert(onbIsScalarPrimitive("String"))
+    testing.assert(onbIsScalarPrimitive("Float"))
+    testing.assert(onbIsScalarPrimitive("Float64"))
+    testing.assert(!onbIsScalarPrimitive("List<Int>"))
+    testing.assert(!onbIsScalarPrimitive("Point"))
+}
+
+fn testOnbIsClosureScalarType() {
+    testing.assert(onbIsClosureEnvType("ClosureEnv"))
+    testing.assert(onbIsFnTypeRepr("fn(Int) -> Int"))
+    testing.assert(onbIsFnTypeRepr("fn() -> ()"))
+    testing.assert(!onbIsFnTypeRepr("Function"))
+    testing.assert(onbIsClosureScalarType("ClosureEnv"))
+    testing.assert(onbIsClosureScalarType("fn(Int, Float) -> Bool"))
+    testing.assert(!onbIsClosureScalarType("Int"))
+}
+
+fn testOnbIsBuiltinPointerType() {
+    testing.assert(onbIsBuiltinPointerType("List<Int>"))
+    testing.assert(onbIsBuiltinPointerType("List<String>"))
+    testing.assert(onbIsBuiltinPointerType("Map<String, Int>"))
+    testing.assert(onbIsBuiltinPointerType("Set<Int>"))
+    testing.assert(onbIsBuiltinPointerType("Channel<Int>"))
+    testing.assert(onbIsBuiltinPointerType("Bytes"))
+    testing.assert(onbIsBuiltinPointerType("Handle"))
+    testing.assert(!onbIsBuiltinPointerType("Int"))
+    testing.assert(!onbIsBuiltinPointerType("Point"))
+    // No exact-match edge: "List" without args isn't a List<T>.
+    testing.assert(!onbIsBuiltinPointerType("List"))
+}
+
+fn testOnbIsAbiScalarType() {
+    testing.assert(onbIsAbiScalarType("Int"))
+    testing.assert(onbIsAbiScalarType("Bool"))
+    testing.assert(onbIsAbiScalarType("String"))
+    testing.assert(onbIsAbiScalarType("Float"))
+    testing.assert(onbIsAbiScalarType("Float64"))
+    testing.assert(onbIsAbiScalarType("ClosureEnv"))
+    testing.assert(onbIsAbiScalarType("fn(Int) -> Int"))
+    testing.assert(onbIsAbiScalarType("List<Int>"))
+    testing.assert(onbIsAbiScalarType("Map<String, Int>"))
+    testing.assert(!onbIsAbiScalarType("Point"))
+}
+
+fn testOnbAbiKindFor() {
+    testing.assertEq(onbAbiKindFor("Int"), onbAbiKindI64())
+    testing.assertEq(onbAbiKindFor("Bool"), onbAbiKindI1())
+    testing.assertEq(onbAbiKindFor("Float"), onbAbiKindF64())
+    testing.assertEq(onbAbiKindFor("Float64"), onbAbiKindF64())
+    testing.assertEq(onbAbiKindFor("String"), onbAbiKindString())
+    // List / Map / closure are pointer-class.
+    testing.assertEq(onbAbiKindFor("List<Int>"), onbAbiKindPtr())
+    testing.assertEq(onbAbiKindFor("ClosureEnv"), onbAbiKindPtr())
+    testing.assertEq(onbAbiKindFor("Point"), onbAbiKindPtr())
+}
+
+fn testOnbIsAbiWordType() {
+    // Phase E approximation: scalar/pointer types are 1-word; user
+    // structs fall through (Slice F adds layout-aware refinement).
+    testing.assert(onbIsAbiWordType("Int"))
+    testing.assert(onbIsAbiWordType("List<Int>"))
+    testing.assert(!onbIsAbiWordType("Point"))
+}


### PR DESCRIPTION
First MIR-dependent slice. ABI predicates pattern-match the MIR type repr ("Int", "List<Int>", "fn(Int) -> Int", ...) — no structured Type mirror needed.

`toolchain/onb_abi.osty` (147 LOC) — onbIsFloatAbiType / onbIsScalarPrimitive / onbIsClosureScalarType / onbIsBuiltinPointerType / onbIsAbiScalarType / onbAbiKindFor / onbIsAbiWordType.

`toolchain/onb_abi_test.osty` (76 LOC) — 7 round-trip cases.

Cumulative Osty self-host LOC: ~5,750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)