### PR TITLE
feat: ONB self-host port Slice F — layout lookups + ABI register-class

### DIFF
--- a/toolchain/onb_layouts_lookup.osty
+++ b/toolchain/onb_layouts_lookup.osty
@@ -1,0 +1,235 @@
+// onb_layouts_lookup.osty — struct / enum layout lookups + the
+// layout-aware ABI classification helpers. Slice F of the ONB
+// self-host port. Mirror of `lookupStructLayout` /
+// `lookupEnumLayout` / `enumSlotSize` / `abiRegSlots` /
+// `abiUsesIndirectStruct` / `isABIPassableType` /
+// `payloadAllScalar` from `internal/onb/lower.go`.
+//
+// MIR layouts already exist in `toolchain/mir.osty`
+// (`MirStructLayout`, `MirEnumLayout`). The lookup helpers walk
+// the layout table's lists by name; the ABI helpers compose the
+// result with the predicates from `onb_abi.osty` to decide which
+// register-class an arbitrary MIR type rides at the call boundary.
+
+// === Lookup =========================================================
+
+// onbLookupStructLayout finds the layout entry for `typeName`
+// in the module's layout table. Returns `None` for unknown names
+// or a malformed table. Mirror of `lookupStructLayout` —
+// performance-wise linear in the number of struct types, which
+// matches the Go side's map lookup amortised cost on small CUs.
+pub fn onbLookupStructLayout(table: MirLayoutTable, typeName: String) -> MirStructLayout? {
+    for s in table.structs {
+        if s.name == typeName {
+            return Some(s)
+        }
+    }
+    None
+}
+
+pub fn onbLookupEnumLayout(table: MirLayoutTable, typeName: String) -> MirEnumLayout? {
+    for e in table.enums {
+        if e.name == typeName {
+            return Some(e)
+        }
+    }
+    None
+}
+
+// onbExtractTypeName extracts the head name of a MIR type repr.
+// E.g. `"Point"` → `"Point"`, `"List<Int>"` → `"List"`,
+// `"Map<String, Int>"` → `"Map"`. Used by the layout lookup
+// helpers to bridge the type-repr string into the layout
+// table's `name` field.
+pub fn onbExtractTypeName(typ: String) -> String {
+    let mut head = ""
+    let mut done = false
+    for ch in typ.chars() {
+        if !done {
+            let s = "{ch}"
+            if s == "<" || s == " " {
+                done = true
+            } else {
+                head = head + s
+            }
+        }
+    }
+    head
+}
+
+// === Field / payload classification ================================
+
+// onbStructLayoutAllScalar reports whether every field of a
+// struct fits in one ABI register. Used by the small-struct path
+// to gate which structs ride the AAPCS64 register convention.
+pub fn onbStructLayoutAllScalar(layout: MirStructLayout) -> Bool {
+    for f in layout.fields {
+        if !onbIsAbiWordType(f.typ) {
+            return false
+        }
+    }
+    true
+}
+
+// onbEnumPayloadAllScalar reports whether every payload field of
+// a single enum variant is a 1-reg type. Mirror of
+// `payloadAllScalar` in lower.go.
+pub fn onbEnumPayloadAllScalar(payload: List<MirFieldLayout>) -> Bool {
+    for f in payload {
+        if !onbIsAbiWordType(f.typ) {
+            return false
+        }
+    }
+    true
+}
+
+// onbEnumLayoutAllScalar reports whether every variant of an
+// enum has all-scalar payloads. Required for the small-enum
+// register path; mixed payloads fall back to the LLVM backend.
+pub fn onbEnumLayoutAllScalar(layout: MirEnumLayout) -> Bool {
+    for v in layout.variants {
+        if !onbEnumPayloadAllScalar(v.payload) {
+            return false
+        }
+    }
+    true
+}
+
+// === Slot sizes ====================================================
+
+// onbStructLayoutByteSize returns the on-stack byte size for a
+// struct local. Each scalar field reserves one 8-byte slot; the
+// total is `len(fields) * 8`. Mirror of the relevant branch in
+// `localTypeSize`.
+pub fn onbStructLayoutByteSize(layout: MirStructLayout) -> Int {
+    layout.fields.len() * 8
+}
+
+// onbEnumSlotSize returns the on-stack byte size for an enum
+// local: 8 (discriminant) + maxPayload * 8. Capped at 16 — past
+// that the AAPCS64 small-struct ABI doesn't apply and the value
+// goes indirect.
+//
+// Returns 0 for an enum with non-scalar payload (caller falls
+// back to the LLVM backend). Mirror of `enumSlotSize`.
+pub fn onbEnumSlotSize(layout: MirEnumLayout) -> Int {
+    let mut maxPayload = 0
+    for v in layout.variants {
+        if !onbEnumPayloadAllScalar(v.payload) {
+            return 0
+        }
+        if v.payload.len() > maxPayload {
+            maxPayload = v.payload.len()
+        }
+    }
+    let total = 8 + (maxPayload * 8)
+    if total > 16 {
+        return 0
+    }
+    total
+}
+
+// === Layout-aware ABI register-slot count =========================
+
+// onbAbiRegSlotsResult is the (count, ok) pair `abiRegSlots`
+// returns. `ok = false` means "this type isn't ABI-passable
+// today"; the lowering layer routes such types through the LLVM
+// fallback.
+pub struct OnbAbiRegSlotsResult {
+    pub slots: Int,
+    pub ok: Bool,
+}
+
+pub fn onbAbiRegSlotsResult(slots: Int, ok: Bool) -> OnbAbiRegSlotsResult {
+    OnbAbiRegSlotsResult { slots: slots, ok: ok }
+}
+
+// onbAbiRegSlots returns how many registers an ABI value of type
+// `typ` consumes. Mirror of `abiRegSlots`. Resolution order:
+//
+//   1. Unit / Float / scalar / pointer-shaped → 1 reg (or 0 for
+//      Unit).
+//   2. Named struct in the layout table → either 1 / 2 (small
+//      struct via direct registers) or 1 (indirect via pointer
+//      to caller-allocated buffer).
+//   3. Named enum in the layout table → ceil(slot / 8) registers.
+//   4. Anything else → ok = false.
+pub fn onbAbiRegSlots(table: MirLayoutTable, typ: String) -> OnbAbiRegSlotsResult {
+    if typ == "()" {
+        return onbAbiRegSlotsResult(0, true)
+    }
+    if onbIsAbiScalarType(typ) {
+        return onbAbiRegSlotsResult(1, true)
+    }
+    let head = onbExtractTypeName(typ)
+    match onbLookupStructLayout(table, head) {
+        Some(layout) -> {
+            if !onbStructLayoutAllScalar(layout) {
+                return onbAbiRegSlotsResult(0, false)
+            }
+            let n = layout.fields.len()
+            if n == 0 {
+                return onbAbiRegSlotsResult(0, false)
+            }
+            if n <= onbAbiSmallStructRegLimit() {
+                return onbAbiRegSlotsResult(n, true)
+            }
+            if n <= onbAbiIndirectStructFieldLimit() {
+                return onbAbiRegSlotsResult(1, true)
+            }
+            return onbAbiRegSlotsResult(0, false)
+        },
+        None -> {},
+    }
+    match onbLookupEnumLayout(table, head) {
+        Some(layout) -> {
+            let size = onbEnumSlotSize(layout)
+            if size == 0 {
+                return onbAbiRegSlotsResult(0, false)
+            }
+            return onbAbiRegSlotsResult(size / 8, true)
+        },
+        None -> {},
+    }
+    onbAbiRegSlotsResult(0, false)
+}
+
+// onbAbiUsesIndirectStruct reports whether type `typ` rides the
+// AAPCS64 indirect (sret) ABI: a pointer to a caller-allocated
+// buffer in one regular argument register (params) or x8
+// (returns). Mirror of `abiUsesIndirectStruct`.
+pub fn onbAbiUsesIndirectStruct(table: MirLayoutTable, typ: String) -> Bool {
+    let head = onbExtractTypeName(typ)
+    match onbLookupStructLayout(table, head) {
+        Some(layout) -> {
+            if !onbStructLayoutAllScalar(layout) {
+                return false
+            }
+            let n = layout.fields.len()
+            n > onbAbiSmallStructRegLimit() && n <= onbAbiIndirectStructFieldLimit()
+        },
+        None -> false,
+    }
+}
+
+// onbAbiIndirectStructByteSize returns the byte size of an
+// indirect-passed struct's slot — `n * 8` where n is the field
+// count. Caller pre-checks `onbAbiUsesIndirectStruct`.
+pub fn onbAbiIndirectStructByteSize(table: MirLayoutTable, typ: String) -> Int {
+    let head = onbExtractTypeName(typ)
+    match onbLookupStructLayout(table, head) {
+        Some(layout) -> layout.fields.len() * 8,
+        None -> 0,
+    }
+}
+
+// onbAbiIsPassableType reports whether `typ` is something the
+// function-boundary ABI guards accept as a parameter or return
+// type. Mirror of `isABIPassableType`.
+pub fn onbAbiIsPassableType(table: MirLayoutTable, typ: String) -> Bool {
+    if onbIsAbiScalarType(typ) {
+        return true
+    }
+    let result = onbAbiRegSlots(table, typ)
+    result.ok
+}

--- a/toolchain/onb_layouts_lookup_test.osty
+++ b/toolchain/onb_layouts_lookup_test.osty
@@ -1,0 +1,191 @@
+// onb_layouts_lookup_test.osty — layout-aware ABI tests.
+use std.testing
+
+// === Helpers =======================================================
+
+fn fieldI64(idx: Int, name: String) -> MirFieldLayout {
+    MirFieldLayout { index: idx, name: name, typ: "Int" }
+}
+
+fn structPoint() -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    fields.push(fieldI64(0, "x"))
+    fields.push(fieldI64(1, "y"))
+    MirStructLayout { name: "Point", mangled: "Point", fields: fields, size: 16, align: 8 }
+}
+
+fn structV3() -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    fields.push(fieldI64(0, "x"))
+    fields.push(fieldI64(1, "y"))
+    fields.push(fieldI64(2, "z"))
+    MirStructLayout { name: "V3", mangled: "V3", fields: fields, size: 24, align: 8 }
+}
+
+fn enumColor() -> MirEnumLayout {
+    let mut variants: List<MirVariantLayout> = []
+    variants.push(MirVariantLayout { index: 0, name: "Red", payload: [] })
+    variants.push(MirVariantLayout { index: 1, name: "Green", payload: [] })
+    variants.push(MirVariantLayout { index: 2, name: "Blue", payload: [] })
+    MirEnumLayout { name: "Color", mangled: "Color", discriminant: "Int", variants: variants }
+}
+
+fn enumOptionInt() -> MirEnumLayout {
+    let mut variants: List<MirVariantLayout> = []
+    variants.push(MirVariantLayout { index: 0, name: "None", payload: [] })
+    let mut someFields: List<MirFieldLayout> = []
+    someFields.push(fieldI64(0, "value"))
+    variants.push(MirVariantLayout { index: 1, name: "Some", payload: someFields })
+    MirEnumLayout { name: "Option", mangled: "Option", discriminant: "Int", variants: variants }
+}
+
+fn buildTable() -> MirLayoutTable {
+    let mut table = mirLayoutTable()
+    table.structs.push(structPoint())
+    table.structs.push(structV3())
+    table.enums.push(enumColor())
+    table.enums.push(enumOptionInt())
+    table
+}
+
+// === Lookup ========================================================
+
+fn testOnbLookupStructLayoutHit() {
+    let table = buildTable()
+    match onbLookupStructLayout(table, "Point") {
+        Some(layout) -> testing.assertEq(layout.name, "Point"),
+        None -> testing.assert(false),
+    }
+}
+
+fn testOnbLookupStructLayoutMiss() {
+    let table = buildTable()
+    testing.assert(onbLookupStructLayout(table, "Unknown").isNone())
+}
+
+fn testOnbLookupEnumLayoutHit() {
+    let table = buildTable()
+    match onbLookupEnumLayout(table, "Color") {
+        Some(layout) -> testing.assertEq(layout.variants.len(), 3),
+        None -> testing.assert(false),
+    }
+}
+
+// === Type-name extraction =========================================
+
+fn testOnbExtractTypeNameSimple() {
+    testing.assertEq(onbExtractTypeName("Point"), "Point")
+    testing.assertEq(onbExtractTypeName("Int"), "Int")
+}
+
+fn testOnbExtractTypeNameGeneric() {
+    testing.assertEq(onbExtractTypeName("List<Int>"), "List")
+    testing.assertEq(onbExtractTypeName("Map<String, Int>"), "Map")
+    testing.assertEq(onbExtractTypeName("Option<List<Int>>"), "Option")
+}
+
+// === Slot size helpers =============================================
+
+fn testOnbStructLayoutByteSize() {
+    testing.assertEq(onbStructLayoutByteSize(structPoint()), 16)
+    testing.assertEq(onbStructLayoutByteSize(structV3()), 24)
+}
+
+fn testOnbEnumSlotSizeNoPayload() {
+    // Color: 3 no-payload variants → slot = 8 bytes (disc only).
+    testing.assertEq(onbEnumSlotSize(enumColor()), 8)
+}
+
+fn testOnbEnumSlotSizeOptionInt() {
+    // Option<Int>: max 1 payload field → slot = 16 bytes (8 disc
+    // + 8 payload). Fits within the small-struct cap.
+    testing.assertEq(onbEnumSlotSize(enumOptionInt()), 16)
+}
+
+fn testOnbEnumLayoutAllScalar() {
+    testing.assert(onbEnumLayoutAllScalar(enumColor()))
+    testing.assert(onbEnumLayoutAllScalar(enumOptionInt()))
+}
+
+fn testOnbStructLayoutAllScalar() {
+    testing.assert(onbStructLayoutAllScalar(structPoint()))
+    testing.assert(onbStructLayoutAllScalar(structV3()))
+}
+
+// === abiRegSlots =================================================
+
+fn testOnbAbiRegSlotsScalar() {
+    let table = buildTable()
+    let intResult = onbAbiRegSlots(table, "Int")
+    testing.assert(intResult.ok)
+    testing.assertEq(intResult.slots, 1)
+
+    let unitResult = onbAbiRegSlots(table, "()")
+    testing.assert(unitResult.ok)
+    testing.assertEq(unitResult.slots, 0)
+}
+
+fn testOnbAbiRegSlotsSmallStruct() {
+    let table = buildTable()
+    // Point is 2-field all-scalar → 2 regs (small-struct path).
+    let r = onbAbiRegSlots(table, "Point")
+    testing.assert(r.ok)
+    testing.assertEq(r.slots, 2)
+}
+
+fn testOnbAbiRegSlotsIndirectStruct() {
+    let table = buildTable()
+    // V3 is 3-field all-scalar → 1 reg (pointer; indirect).
+    let r = onbAbiRegSlots(table, "V3")
+    testing.assert(r.ok)
+    testing.assertEq(r.slots, 1)
+}
+
+fn testOnbAbiRegSlotsEnumNoPayload() {
+    let table = buildTable()
+    // Color slot = 8 → 1 reg.
+    let r = onbAbiRegSlots(table, "Color")
+    testing.assert(r.ok)
+    testing.assertEq(r.slots, 1)
+}
+
+fn testOnbAbiRegSlotsEnumWithPayload() {
+    let table = buildTable()
+    // Option slot = 16 → 2 regs.
+    let r = onbAbiRegSlots(table, "Option")
+    testing.assert(r.ok)
+    testing.assertEq(r.slots, 2)
+}
+
+fn testOnbAbiRegSlotsUnknown() {
+    let table = buildTable()
+    // Unknown type → ok = false.
+    let r = onbAbiRegSlots(table, "Unknown")
+    testing.assert(!r.ok)
+}
+
+// === abiUsesIndirectStruct =======================================
+
+fn testOnbAbiUsesIndirectStruct() {
+    let table = buildTable()
+    testing.assert(!onbAbiUsesIndirectStruct(table, "Point"))   // 2 fields → direct
+    testing.assert(onbAbiUsesIndirectStruct(table, "V3"))       // 3 fields → indirect
+}
+
+fn testOnbAbiIndirectStructByteSize() {
+    let table = buildTable()
+    testing.assertEq(onbAbiIndirectStructByteSize(table, "V3"), 24)
+}
+
+// === abiIsPassableType ==========================================
+
+fn testOnbAbiIsPassableType() {
+    let table = buildTable()
+    testing.assert(onbAbiIsPassableType(table, "Int"))
+    testing.assert(onbAbiIsPassableType(table, "Point"))
+    testing.assert(onbAbiIsPassableType(table, "V3"))
+    testing.assert(onbAbiIsPassableType(table, "Color"))
+    testing.assert(onbAbiIsPassableType(table, "Option"))
+    testing.assert(onbAbiIsPassableType(table, "List<Int>"))
+    testing.assert(!onbAbiIsPassableType(table, "Unknown"))
+}


### PR DESCRIPTION
## Summary

Slice F of the ONB self-host port. Mirrors the layout-aware ABI cluster
from `internal/onb/lower.go`:

- `lookupStructLayout` / `lookupEnumLayout` → `onbLookupStructLayout` /
  `onbLookupEnumLayout` over `MirLayoutTable`
- `enumSlotSize` → `onbEnumSlotSize` (8 disc + maxPayload * 8, capped at 16)
- `payloadAllScalar` → `onbEnumPayloadAllScalar` (+ `onbStructLayoutAllScalar`
  / `onbEnumLayoutAllScalar`)
- `abiRegSlots` → `onbAbiRegSlots` returning `OnbAbiRegSlotsResult { slots, ok }`
- `abiUsesIndirectStruct` → `onbAbiUsesIndirectStruct` (+
  `onbAbiIndirectStructByteSize`)
- `isABIPassableType` → `onbAbiIsPassableType`

Plus `onbExtractTypeName` for the generic-repr head extraction
(`"List<Int>"` → `"List"`) the lookup helpers need to bridge type
strings into the layout table's `name` field.

This bolts the layout-table view onto the Slice E ABI predicate
cluster: with struct/enum context now available, register-slot count
(small struct vs. indirect vs. enum) and the AAPCS64 sret path
classification become deterministic per type — exactly what the
Slice G call-boundary lowering needs.

## Test plan

- [x] `osty check ./toolchain` green
- [x] `go test ./internal/onb -short` green
- [x] 17 Osty tests covering: lookup hit/miss, generic type-name
      extraction, byte sizes (struct + enum), all five `abiRegSlots`
      paths (scalar / small struct / indirect struct / enum without
      payload / enum with payload / unknown), `abiUsesIndirectStruct`
      direct vs. indirect, and `abiIsPassableType` across
      scalars/structs/enums/builtins/unknowns.

## Notes

426 LOC (235 source + 191 test). No Go-side parity test — Go uses an
O(1) `module.StructLayouts` map so byte-for-byte parity isn't a
meaningful invariant; the semantic round-trip lives in the Osty test
suite. `internal/onb/lower.go` remains the production runtime per
Slice A's frozen-mirror pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)