### PR TITLE
feat: ONB self-host port Slice G — call-boundary lowering

### DIFF
--- a/toolchain/onb_call.osty
+++ b/toolchain/onb_call.osty
@@ -1,0 +1,403 @@
+// onb_call.osty — call-boundary lowering for the ONB self-host
+// port. Slice G of the port. Mirror of `paramShuffle / epilogue /
+// lowerCall / lowerIndirectCall / indirectArgAddress /
+// materialiseStructOperand` from `internal/onb/lower.go`.
+//
+// AAPCS64 calling convention specialised for the dev backend's
+// stack-everything model:
+//
+//   - Integer args ride x0..x7 (8 slots). Excess fall back to LLVM.
+//   - Float args ride d0..d7. Excess fall back to LLVM.
+//   - Small structs (≤ 16B, all-scalar, ≤ 2 fields) ride 1-2 adjacent
+//     argRegs directly.
+//   - 3-4 field all-scalar structs ride indirectly: caller passes
+//     `&local_slot` in argRegs[regCursor]; callee writes through that
+//     pointer for sret-style returns (x8 on the caller side).
+//   - Bigger / non-scalar structs: callee bails with the unsupported
+//     sentinel and the LLVM backend takes over.
+//
+// `paramShuffle` is the prologue's argRegs → stack-slot sweep. The
+// frame planner has already computed where each param's slot is;
+// paramShuffle just stages the loads. `epilogue` is the inverse:
+// loads return-value bytes from the return slot into x0/x1 (or d0,
+// or x8-relative writes for sret) and emits the closing `ret`.
+//
+// `lowerCall` is the per-call-site driver. It walks instr.args,
+// materialises each operand into the right argReg, optionally
+// stages x8 = &dest_slot for sret returns, emits `bl symbol`, and
+// captures the return into the dest local's slot.
+
+// === Param shuffle ==================================================
+
+// onbParamShuffle emits the function prologue's argReg → slot
+// sweep. Iterates params in declaration order; each param consumes
+// 0, 1, 2, or N register slots depending on its type:
+//
+//   - `()` (Unit) — 0 slots, skipped silently.
+//   - Scalar / pointer / closure-shaped — 1 int or 1 fp reg.
+//   - Small struct (≤ 2 fields, all-scalar) — 2 adjacent int regs.
+//   - Indirect struct (3-4 fields) — 1 int reg holds `&buffer`; the
+//     prologue copies each 8B half through that pointer into the
+//     param's slot.
+//
+// Mirror of `paramShuffle`. Returns the LIR sequence — caller
+// concatenates it with the instruction list of entry block 0.
+pub fn onbParamShuffle(state: OnbLowerState) -> List<OnbInstr> {
+    let mut out: List<OnbInstr> = []
+    let mut regCursor = 0
+    let mut fpCursor = 0
+    let argRegs = onbArgRegs()
+    let fpArgRegs = onbFpArgRegs()
+    for paramId in state.func.params {
+        let local = onbLookupLocal(state.func, paramId)
+        if local.id < 0 {
+            continue
+        }
+        let slot = onbLocalSlotLookup(state, paramId)
+        if onbIsFloatAbiType(local.typ) {
+            if slot.found && fpCursor < fpArgRegs.len() {
+                out.push(onbInstrStoreFloat64Stack(fpArgRegs[fpCursor], slot.offset))
+            }
+            fpCursor = fpCursor + 1
+            continue
+        }
+        if onbAbiUsesIndirectStruct(state.layouts, local.typ) {
+            if slot.found && regCursor < argRegs.len() {
+                let size = onbAbiIndirectStructByteSize(state.layouts, local.typ)
+                let ptrReg = argRegs[regCursor]
+                let scratch = onbScratchReg()
+                let mut off = 0
+                for _ in 0..size / 8 {
+                    out.push(onbInstrLoadFromReg(scratch, ptrReg, off))
+                    out.push(onbInstrStore64Stack(scratch, slot.offset + off))
+                    off = off + 8
+                }
+            }
+            regCursor = regCursor + 1
+            continue
+        }
+        let slots = onbAbiRegSlots(state.layouts, local.typ)
+        if !slots.ok {
+            continue
+        }
+        if slot.found {
+            for i in 0..slots.slots {
+                out.push(onbInstrStore64Stack(argRegs[regCursor + i], slot.offset + i * 8))
+            }
+        }
+        regCursor = regCursor + slots.slots
+    }
+    out
+}
+
+// === Epilogue =======================================================
+
+// onbEpilogue emits the function-exit sequence. main returns
+// process exit 0 in w0; user functions load their `_return` slot
+// into x0 (and x1 for 2-reg returns) or d0 (Float) before falling
+// through to ret. Sret returns walk each 8B half through x8.
+//
+// Mirror of `epilogue` in lower.go.
+pub fn onbEpilogue(state: OnbLowerState) -> List<OnbInstr> {
+    let mut out: List<OnbInstr> = []
+    if state.func.name == "main" {
+        out.push(onbInstrMovImm32("w0", 0))
+        out.push(onbInstrRet())
+        return out
+    }
+    if state.func.returnType == "()" {
+        out.push(onbInstrRet())
+        return out
+    }
+    let slot = onbLocalSlotLookup(state, state.func.returnLocal)
+    if !slot.found {
+        // The _return slot was never allocated. The front end usually
+        // allocates one (`Assign _return := <expr>; ReturnTerm`),
+        // but we keep a safe default for malformed MIR.
+        out.push(onbInstrMovImm64("x0", 0))
+        out.push(onbInstrRet())
+        return out
+    }
+    if onbIsFloatAbiType(state.func.returnType) {
+        out.push(onbInstrLoadFloat64Stack("d0", slot.offset))
+        out.push(onbInstrRet())
+        return out
+    }
+    if onbAbiUsesIndirectStruct(state.layouts, state.func.returnType) {
+        // The body wrote $ret into its local slot; copy each 8B
+        // half through the caller's buffer pointer in x8. The MVP
+        // assumes x8 wasn't clobbered by the body — a follow-up
+        // saves/restores at the prologue.
+        let size = onbAbiIndirectStructByteSize(state.layouts, state.func.returnType)
+        let scratch = onbScratchReg()
+        let x8 = onbIndirectResultReg()
+        let mut off = 0
+        for _ in 0..size / 8 {
+            out.push(onbInstrLoad64Stack(scratch, slot.offset + off))
+            out.push(onbInstrStoreToReg(scratch, x8, off))
+            off = off + 8
+        }
+        out.push(onbInstrRet())
+        return out
+    }
+    let slotsResult = onbAbiRegSlots(state.layouts, state.func.returnType)
+    let mut slots = slotsResult.slots
+    if slots == 0 {
+        slots = 1
+    }
+    let retRegs = onbReturnRegs()
+    let mut i = 0
+    let limit = if slots > retRegs.len() { retRegs.len() } else { slots }
+    for _ in 0..limit {
+        out.push(onbInstrLoad64Stack(retRegs[i], slot.offset + i * 8))
+        i = i + 1
+    }
+    out.push(onbInstrRet())
+    out
+}
+
+// === Indirect struct address ========================================
+
+// onbIndirectArgAddress lands `&local_slot` in `dst`. Indirect
+// args are always Copy/Move of a stack-allocated local — struct
+// literals as args would need a pre-materialise pass we don't
+// ship yet. Mirror of `indirectArgAddress`.
+pub fn onbIndirectArgAddress(state: OnbLowerState, arg: MirOperand, dst: String) -> OnbMaterialiseResult {
+    if arg.kind != MirOperandKind.MirOpCopy && arg.kind != MirOperandKind.MirOpMove {
+        return onbMaterialiseErr(state, "indirect struct arg operand")
+    }
+    if mirPlaceHasProjections(arg.place) {
+        return onbMaterialiseErr(state, "indirect struct arg with projection")
+    }
+    let slot = onbLocalSlotLookup(state, arg.place.local)
+    if !slot.found {
+        return onbMaterialiseErr(state, "indirect struct arg from local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoadStackAddress(dst, slot.offset))
+    onbMaterialiseOk(state, out)
+}
+
+// === Multi-register struct operand ==================================
+
+// onbMaterialiseStructOperand loads a whole-struct operand into N
+// consecutive arg registers. Slot+0 lands in regs[0], slot+8 in
+// regs[1], etc. Only Copy/Move of a non-projected stack-slot
+// local is handled — struct literals or FieldProj into a struct
+// arg take the LLVM fallback. Mirror of `materialiseStructOperand`.
+pub fn onbMaterialiseStructOperand(state: OnbLowerState, op: MirOperand, regs: List<String>) -> OnbMaterialiseResult {
+    if op.kind != MirOperandKind.MirOpCopy && op.kind != MirOperandKind.MirOpMove {
+        return onbMaterialiseErr(state, "struct argument operand")
+    }
+    if mirPlaceHasProjections(op.place) {
+        return onbMaterialiseErr(state, "struct argument with projection")
+    }
+    let slot = onbLocalSlotLookup(state, op.place.local)
+    if !slot.found {
+        return onbMaterialiseErr(state, "struct argument from local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    let mut i = 0
+    for reg in regs {
+        out.push(onbInstrLoad64Stack(reg, slot.offset + i * 8))
+        i = i + 1
+    }
+    onbMaterialiseOk(state, out)
+}
+
+// === Direct call lowering ===========================================
+
+// onbDetectSretDestSlot returns the dest local's stack slot if
+// the call's return uses sret (indirect struct return), or -1
+// otherwise. The caller stages `add x8, sp, #slot` before the bl
+// when this returns ≥ 0 and skips the post-call return capture.
+fn onbDetectSretDestSlot(state: OnbLowerState, instr: MirInstr) -> Int {
+    if !instr.hasDest { return -1 }
+    if mirPlaceHasProjections(instr.dest) { return -1 }
+    let destType = onbDestType(state, instr.dest.local)
+    if !onbAbiUsesIndirectStruct(state.layouts, destType) { return -1 }
+    let slot = onbLocalSlotLookup(state, instr.dest.local)
+    if !slot.found { return -1 }
+    slot.offset
+}
+
+// onbLowerCall lowers a direct call (`bl symbol`) — the most
+// common shape. Walks instr.args, materialises each into the
+// right arg register, optionally stages x8 = &dest_slot for sret,
+// emits `bl callee`, and captures the return into the dest slot.
+//
+// Mirror of `lowerCall`'s direct-call branch (the indirect branch
+// lives in `onbLowerIndirectCall` below).
+pub fn onbLowerCall(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if instr.calleeKind != MirCalleeKind.MirCalleeFn {
+        return onbMaterialiseErr(state, "non-direct callee in lowerCall")
+    }
+    let mut working = state
+    let mut out: List<OnbInstr> = []
+    let mut regCursor = 0
+    let mut fpCursor = 0
+    let argRegs = onbArgRegs()
+    let fpArgRegs = onbFpArgRegs()
+    let sretSlot = onbDetectSretDestSlot(state, instr)
+
+    for arg in instr.args {
+        let argType = arg.typ
+        if onbIsFloatAbiType(argType) {
+            if fpCursor >= fpArgRegs.len() {
+                return onbMaterialiseErr(working, "call needs more than 8 FP arg regs")
+            }
+            let r = onbMaterialiseFloatOperand(working, arg, fpArgRegs[fpCursor])
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+            fpCursor = fpCursor + 1
+            continue
+        }
+        if onbAbiUsesIndirectStruct(working.layouts, argType) {
+            if regCursor >= argRegs.len() {
+                return onbMaterialiseErr(working, "indirect arg exhausted argRegs")
+            }
+            let r = onbIndirectArgAddress(working, arg, argRegs[regCursor])
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+            regCursor = regCursor + 1
+            continue
+        }
+        let slots = onbAbiRegSlots(working.layouts, argType)
+        if !slots.ok {
+            return onbMaterialiseErr(working, "call argument has type outside ABI")
+        }
+        if regCursor + slots.slots > argRegs.len() {
+            return onbMaterialiseErr(working, "call needs more than 8 int arg regs")
+        }
+        if slots.slots > 1 {
+            let mut targetRegs: List<String> = []
+            for i in 0..slots.slots {
+                targetRegs.push(argRegs[regCursor + i])
+            }
+            let r = onbMaterialiseStructOperand(working, arg, targetRegs)
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+        } else {
+            let r = onbMaterialiseOperand(working, arg, argRegs[regCursor])
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+        }
+        regCursor = regCursor + slots.slots
+    }
+
+    // Stage x8 = &destSlot last so the address materialisation
+    // happens after every other arg-reg setup. Matches the AAPCS64
+    // convention and avoids accidentally clobbering x8 with a
+    // future arg materialiser that uses it as scratch.
+    if sretSlot >= 0 {
+        out.push(onbInstrLoadStackAddress(onbIndirectResultReg(), sretSlot))
+    }
+
+    out.push(onbInstrBranchLink(instr.calleeSymbol))
+
+    // Post-call return capture for non-sret returns.
+    if instr.hasDest && !mirPlaceHasProjections(instr.dest) && sretSlot < 0 {
+        let destSlot = onbLocalSlotLookup(working, instr.dest.local)
+        if destSlot.found {
+            let destType = onbDestType(working, instr.dest.local)
+            if onbIsFloatAbiType(destType) {
+                out.push(onbInstrStoreFloat64Stack("d0", destSlot.offset))
+            } else {
+                let retSlots = onbAbiRegSlots(working.layouts, destType)
+                let mut count = retSlots.slots
+                if count == 0 { count = 1 }
+                let retRegs = onbReturnRegs()
+                let limit = if count > retRegs.len() { retRegs.len() } else { count }
+                for i in 0..limit {
+                    out.push(onbInstrStore64Stack(retRegs[i], destSlot.offset + i * 8))
+                }
+            }
+        }
+    }
+
+    onbMaterialiseOk(working, out)
+}
+
+// === Indirect call lowering =========================================
+
+// onbLowerIndirectCall lowers `call *<closure_local>(args...)`. The
+// closure value is an env-pointer; per the Phase A4 fn-value
+// runtime contract, the lifted body's signature is `(env, args...)`,
+// so the lowering stages the env in x0, the user args in x1.., d0..,
+// and loads the fn pointer from `*(env + 0)` into x9 before `blr x9`.
+//
+// Mirror of `lowerIndirectCall`. Float args supported; indirect
+// struct args / multi-reg struct args fall back with the
+// unsupported sentinel — the closure-arg case is rare enough that
+// we keep the path narrow.
+pub fn onbLowerIndirectCall(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if instr.calleeKind != MirCalleeKind.MirCalleeIndirect {
+        return onbMaterialiseErr(state, "non-indirect callee in lowerIndirectCall")
+    }
+    let argRegs = onbArgRegs()
+    let fpArgRegs = onbFpArgRegs()
+    if instr.args.len() > argRegs.len() - 1 {
+        return onbMaterialiseErr(state, "indirect call user-arg count exceeds limit")
+    }
+    let mut working = state
+    let mut out: List<OnbInstr> = []
+    // Env pointer → x0.
+    let envR = onbMaterialiseOperand(working, instr.calleeOperand, "x0")
+    if !envR.ok { return envR }
+    working = envR.state
+    for i in envR.instrs { out.push(i) }
+
+    let mut regCursor = 1
+    let mut fpCursor = 0
+    for arg in instr.args {
+        let argType = arg.typ
+        if onbIsFloatAbiType(argType) {
+            if fpCursor >= fpArgRegs.len() {
+                return onbMaterialiseErr(working, "indirect call needs more than 8 FP arg regs")
+            }
+            let r = onbMaterialiseFloatOperand(working, arg, fpArgRegs[fpCursor])
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+            fpCursor = fpCursor + 1
+            continue
+        }
+        if regCursor >= argRegs.len() {
+            return onbMaterialiseErr(working, "indirect call needs more than 8 int arg regs")
+        }
+        let slots = onbAbiRegSlots(working.layouts, argType)
+        if !slots.ok || slots.slots != 1 {
+            return onbMaterialiseErr(working, "indirect call arg type not supported")
+        }
+        let r = onbMaterialiseOperand(working, arg, argRegs[regCursor])
+        if !r.ok { return r }
+        working = r.state
+        for i in r.instrs { out.push(i) }
+        regCursor = regCursor + 1
+    }
+
+    // Load fn pointer from env+0 into x9 then blr x9. The env
+    // pointer is already in x0 from the materialise above and stays
+    // there through the branch.
+    let scratch = onbScratchReg()
+    out.push(onbInstrLoadFromReg(scratch, "x0", 0))
+    out.push(onbInstrBranchLinkReg(scratch))
+
+    if instr.hasDest && !mirPlaceHasProjections(instr.dest) {
+        let destSlot = onbLocalSlotLookup(working, instr.dest.local)
+        if destSlot.found {
+            let destType = onbDestType(working, instr.dest.local)
+            if onbIsFloatAbiType(destType) {
+                out.push(onbInstrStoreFloat64Stack("d0", destSlot.offset))
+            } else {
+                out.push(onbInstrStore64Stack("x0", destSlot.offset))
+            }
+        }
+    }
+
+    onbMaterialiseOk(working, out)
+}

--- a/toolchain/onb_call_test.osty
+++ b/toolchain/onb_call_test.osty
@@ -1,0 +1,453 @@
+// onb_call_test.osty — call-boundary lowering tests.
+use std.testing
+
+// === Layout helpers (shared with onb_layouts_lookup_test) ==========
+
+fn callFieldI64(idx: Int, name: String) -> MirFieldLayout {
+    MirFieldLayout { index: idx, name: name, typ: "Int" }
+}
+
+fn callStructPoint() -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    fields.push(callFieldI64(0, "x"))
+    fields.push(callFieldI64(1, "y"))
+    MirStructLayout { name: "Point", mangled: "Point", fields: fields, size: 16, align: 8 }
+}
+
+fn callStructV3() -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    fields.push(callFieldI64(0, "x"))
+    fields.push(callFieldI64(1, "y"))
+    fields.push(callFieldI64(2, "z"))
+    MirStructLayout { name: "V3", mangled: "V3", fields: fields, size: 24, align: 8 }
+}
+
+fn callBuildLayouts() -> MirLayoutTable {
+    let mut t = mirLayoutTable()
+    t.structs.push(callStructPoint())
+    t.structs.push(callStructV3())
+    t
+}
+
+// === Function builders ==============================================
+
+fn callBuildFunc(name: String, returnType: String) -> MirFunction {
+    mirFunction(name, returnType, mirNoSpan())
+}
+
+// === Lowering state setup ===========================================
+
+fn newState(func: MirFunction) -> OnbLowerState {
+    onbNewLowerState(func, callBuildLayouts())
+}
+
+// === Local-slot map tests ===========================================
+
+fn testOnbLocalSlotInsertAndLookup() {
+    let func = callBuildFunc("f", "Int")
+    let s0 = newState(func)
+    let s1 = onbLocalSlotInsert(s0, 0, 16)
+    let s2 = onbLocalSlotInsert(s1, 1, 24)
+    let r0 = onbLocalSlotLookup(s2, 0)
+    testing.assert(r0.found)
+    testing.assertEq(r0.offset, 16)
+    let r1 = onbLocalSlotLookup(s2, 1)
+    testing.assert(r1.found)
+    testing.assertEq(r1.offset, 24)
+    let rMiss = onbLocalSlotLookup(s2, 99)
+    testing.assert(!rMiss.found)
+}
+
+fn testOnbLocalSlotReplace() {
+    let func = callBuildFunc("f", "Int")
+    let s0 = newState(func)
+    let s1 = onbLocalSlotInsert(s0, 0, 16)
+    let s2 = onbLocalSlotInsert(s1, 0, 32) // replace
+    let r = onbLocalSlotLookup(s2, 0)
+    testing.assert(r.found)
+    testing.assertEq(r.offset, 32)
+    testing.assertEq(s2.localSlots.len(), 1)
+}
+
+// === CString intern tests ===========================================
+
+fn testOnbAddCStringAssignsLabels() {
+    let func = callBuildFunc("f", "Int")
+    let s0 = newState(func)
+    let r1 = onbAddCString(s0, "hello")
+    testing.assertEq(r1.label, "str0")
+    let r2 = onbAddCString(r1.state, "world")
+    testing.assertEq(r2.label, "str1")
+    let r3 = onbAddCString(r2.state, "hello")  // dedup
+    testing.assertEq(r3.label, "str0")
+    testing.assertEq(r3.state.cstrings.len(), 2)
+}
+
+// === paramShuffle tests =============================================
+
+fn buildScalarParam(typ: String) -> OnbLowerState {
+    let func = callBuildFunc("f", "Int")
+    let id = mirFunctionNewLocal(func, "x", typ, false, mirNoSpan())
+    func.params.push(id)
+    let s = newState(func)
+    onbLocalSlotInsert(s, id, 0)
+}
+
+fn testOnbParamShuffleScalarInt() {
+    let s = buildScalarParam("Int")
+    let out = onbParamShuffle(s)
+    testing.assertEq(out.len(), 1)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(out[0].src, "x0")
+    testing.assertEq(out[0].offset, 0)
+}
+
+fn testOnbParamShuffleScalarFloat() {
+    let s = buildScalarParam("Float")
+    let out = onbParamShuffle(s)
+    testing.assertEq(out.len(), 1)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrStoreFloat64Stack)
+    testing.assertEq(out[0].src, "d0")
+    testing.assertEq(out[0].offset, 0)
+}
+
+fn testOnbParamShuffleSmallStruct() {
+    // fn f(p: Point) → str x0, [sp]; str x1, [sp, #8]
+    let func = callBuildFunc("f", "Int")
+    let id = mirFunctionNewLocal(func, "p", "Point", false, mirNoSpan())
+    func.params.push(id)
+    let s = onbLocalSlotInsert(newState(func), id, 0)
+    let out = onbParamShuffle(s)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(out[0].src, "x0")
+    testing.assertEq(out[0].offset, 0)
+    testing.assertEq(out[1].src, "x1")
+    testing.assertEq(out[1].offset, 8)
+}
+
+fn testOnbParamShuffleIndirectStruct() {
+    // fn f(v: V3) → 3 × (ldr x9, [x0, #i*8]; str x9, [sp, #i*8])
+    let func = callBuildFunc("f", "Int")
+    let id = mirFunctionNewLocal(func, "v", "V3", false, mirNoSpan())
+    func.params.push(id)
+    let s = onbLocalSlotInsert(newState(func), id, 0)
+    let out = onbParamShuffle(s)
+    testing.assertEq(out.len(), 6) // 3 fields × (load + store)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrLoadFromReg)
+    testing.assertEq(out[0].src, "x0")
+    testing.assertEq(out[0].offset, 0)
+    testing.assertEq(out[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(out[1].offset, 0)
+    testing.assertEq(out[4].kind, OnbInstrKind.OnbInstrLoadFromReg)
+    testing.assertEq(out[4].offset, 16)
+    testing.assertEq(out[5].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(out[5].offset, 16)
+}
+
+fn testOnbParamShuffleMixedIntFloat() {
+    // fn f(a: Int, b: Float, c: Int) → x0/d0/x1, slots 0/8/16
+    let func = callBuildFunc("f", "Int")
+    let a = mirFunctionNewLocal(func, "a", "Int", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Float", false, mirNoSpan())
+    let c = mirFunctionNewLocal(func, "c", "Int", false, mirNoSpan())
+    func.params.push(a)
+    func.params.push(b)
+    func.params.push(c)
+    let mut s = newState(func)
+    s = onbLocalSlotInsert(s, a, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    s = onbLocalSlotInsert(s, c, 16)
+    let out = onbParamShuffle(s)
+    testing.assertEq(out.len(), 3)
+    testing.assertEq(out[0].src, "x0")  // a
+    testing.assertEq(out[0].offset, 0)
+    testing.assertEq(out[1].src, "d0")  // b
+    testing.assertEq(out[1].offset, 8)
+    testing.assertEq(out[2].src, "x1")  // c — second integer arg
+    testing.assertEq(out[2].offset, 16)
+}
+
+// === epilogue tests =================================================
+
+fn testOnbEpilogueMain() {
+    let func = callBuildFunc("main", "()")
+    let s = newState(func)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrMovImm32)
+    testing.assertEq(out[0].dst, "w0")
+    testing.assertEq(out[0].imm, 0)
+    testing.assertEq(out[1].kind, OnbInstrKind.OnbInstrRet)
+}
+
+fn testOnbEpilogueUnit() {
+    let func = callBuildFunc("f", "()")
+    let s = newState(func)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 1)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrRet)
+}
+
+fn testOnbEpilogueIntReturn() {
+    let func = callBuildFunc("f", "Int")
+    let r = mirFunctionNewLocal(func, "_return", "Int", true, mirNoSpan())
+    func.returnLocal = r
+    let s = onbLocalSlotInsert(newState(func), r, 24)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(out[0].dst, "x0")
+    testing.assertEq(out[0].offset, 24)
+    testing.assertEq(out[1].kind, OnbInstrKind.OnbInstrRet)
+}
+
+fn testOnbEpilogueFloatReturn() {
+    let func = callBuildFunc("f", "Float")
+    let r = mirFunctionNewLocal(func, "_return", "Float", true, mirNoSpan())
+    func.returnLocal = r
+    let s = onbLocalSlotInsert(newState(func), r, 16)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 2)
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrLoadFloat64Stack)
+    testing.assertEq(out[0].dst, "d0")
+    testing.assertEq(out[0].offset, 16)
+}
+
+fn testOnbEpilogueSmallStructReturn() {
+    let func = callBuildFunc("f", "Point")
+    let r = mirFunctionNewLocal(func, "_return", "Point", true, mirNoSpan())
+    func.returnLocal = r
+    let s = onbLocalSlotInsert(newState(func), r, 0)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 3) // ldr x0; ldr x1; ret
+    testing.assertEq(out[0].dst, "x0")
+    testing.assertEq(out[0].offset, 0)
+    testing.assertEq(out[1].dst, "x1")
+    testing.assertEq(out[1].offset, 8)
+    testing.assertEq(out[2].kind, OnbInstrKind.OnbInstrRet)
+}
+
+fn testOnbEpilogueIndirectStructReturn() {
+    // V3 → for each 8B: ldr x9, [sp, #N+i]; str x9, [x8, #i]; then ret
+    let func = callBuildFunc("f", "V3")
+    let r = mirFunctionNewLocal(func, "_return", "V3", true, mirNoSpan())
+    func.returnLocal = r
+    let s = onbLocalSlotInsert(newState(func), r, 0)
+    let out = onbEpilogue(s)
+    testing.assertEq(out.len(), 7) // 3 × (ldr + str) + ret
+    testing.assertEq(out[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(out[0].offset, 0)
+    testing.assertEq(out[1].kind, OnbInstrKind.OnbInstrStoreToReg)
+    testing.assertEq(out[1].base, "x8")
+    testing.assertEq(out[1].offset, 0)
+    testing.assertEq(out[6].kind, OnbInstrKind.OnbInstrRet)
+}
+
+// === materialiseOperand tests =======================================
+
+fn testOnbMaterialiseConstInt() {
+    let s = newState(callBuildFunc("f", "Int"))
+    let op = mirOperandConst(mirConstInt(42, "Int"))
+    let r = onbMaterialiseOperand(s, op, "x0")
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 1)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrMovImm64)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].imm, 42)
+}
+
+fn testOnbMaterialiseConstBool() {
+    let s = newState(callBuildFunc("f", "Int"))
+    let r = onbMaterialiseOperand(s, mirOperandConst(mirConstBool(true)), "x0")
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[0].imm, 1)
+    let r2 = onbMaterialiseOperand(s, mirOperandConst(mirConstBool(false)), "x0")
+    testing.assertEq(r2.instrs[0].imm, 0)
+}
+
+fn testOnbMaterialiseConstString() {
+    let s = newState(callBuildFunc("f", "Int"))
+    let r = onbMaterialiseOperand(s, mirOperandConst(mirConstString("hi")), "x0")
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 1)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadCStringAddress)
+    testing.assertEq(r.instrs[0].label, "str0")
+    testing.assertEq(r.state.cstrings.len(), 1)
+}
+
+fn testOnbMaterialiseCopyLocal() {
+    let func = callBuildFunc("f", "Int")
+    let id = mirFunctionNewLocal(func, "x", "Int", false, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), id, 16)
+    let op = mirOperandCopy(mirPlace(id), "Int")
+    let r = onbMaterialiseOperand(s, op, "x0")
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 1)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].offset, 16)
+}
+
+fn testOnbMaterialiseFloatCopyLocal() {
+    let func = callBuildFunc("f", "Float")
+    let id = mirFunctionNewLocal(func, "x", "Float", false, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), id, 0)
+    let op = mirOperandCopy(mirPlace(id), "Float")
+    let r = onbMaterialiseFloatOperand(s, op, "d0")
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 1)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadFloat64Stack)
+    testing.assertEq(r.instrs[0].dst, "d0")
+}
+
+// === lowerCall tests ================================================
+
+fn testOnbLowerCallTwoIntArgs() {
+    // f(1, 2) — no dest, two int consts
+    let func = callBuildFunc("caller", "()")
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandConst(mirConstInt(1, "Int")))
+    args.push(mirOperandConst(mirConstInt(2, "Int")))
+    let instr = mirCallInstr(false, mirPlace(-1), "f", "fn(Int, Int) -> ()", args, mirNoSpan())
+    let s = newState(func)
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 3) // mov x0; mov x1; bl _f
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].imm, 1)
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[1].imm, 2)
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[2].symbol, "f")
+}
+
+fn testOnbLowerCallSretIndirectStruct() {
+    // dest = makeV3() — V3 is 3-field indirect → x8 = &dest_slot; bl _makeV3
+    let func = callBuildFunc("caller", "()")
+    let destId = mirFunctionNewLocal(func, "v", "V3", true, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), destId, 32)
+    let args: List<MirOperand> = []
+    let instr = mirCallInstr(true, mirPlace(destId), "makeV3", "fn() -> V3", args, mirNoSpan())
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2) // add x8, sp, #32; bl _makeV3
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadStackAddress)
+    testing.assertEq(r.instrs[0].dst, "x8")
+    testing.assertEq(r.instrs[0].offset, 32)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrBranchLink)
+}
+
+fn testOnbLowerCallReturnCaptureInt() {
+    // dest = f() → bl _f; str x0, [sp, #destSlot]
+    let func = callBuildFunc("caller", "()")
+    let destId = mirFunctionNewLocal(func, "r", "Int", true, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), destId, 8)
+    let instr = mirCallInstr(true, mirPlace(destId), "f", "fn() -> Int", [], mirNoSpan())
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[1].src, "x0")
+    testing.assertEq(r.instrs[1].offset, 8)
+}
+
+fn testOnbLowerCallReturnCaptureFloat() {
+    let func = callBuildFunc("caller", "()")
+    let destId = mirFunctionNewLocal(func, "r", "Float", true, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), destId, 16)
+    let instr = mirCallInstr(true, mirPlace(destId), "f", "fn() -> Float", [], mirNoSpan())
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStoreFloat64Stack)
+    testing.assertEq(r.instrs[1].src, "d0")
+    testing.assertEq(r.instrs[1].offset, 16)
+}
+
+fn testOnbLowerCallSmallStructArg() {
+    // f(p: Point) where p is local — multi-reg load
+    let func = callBuildFunc("caller", "()")
+    let pId = mirFunctionNewLocal(func, "p", "Point", false, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), pId, 0)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(pId), "Point"))
+    let instr = mirCallInstr(false, mirPlace(-1), "f", "fn(Point) -> ()", args, mirNoSpan())
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 3) // ldr x0; ldr x1; bl _f
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[1].offset, 8)
+}
+
+fn testOnbLowerCallIndirectArg() {
+    // f(v: V3) where v is local — pass &v_slot
+    let func = callBuildFunc("caller", "()")
+    let vId = mirFunctionNewLocal(func, "v", "V3", false, mirNoSpan())
+    let s = onbLocalSlotInsert(newState(func), vId, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(vId), "V3"))
+    let instr = mirCallInstr(false, mirPlace(-1), "f", "fn(V3) -> ()", args, mirNoSpan())
+    let r = onbLowerCall(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2) // add x0, sp, #8; bl _f
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadStackAddress)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].offset, 8)
+}
+
+// === lowerIndirectCall tests ========================================
+
+fn testOnbLowerIndirectCallSimple() {
+    // dest = (env)(1) — env in x0, arg 1 in x1, ldr x9, [x0]; blr x9
+    let func = callBuildFunc("caller", "()")
+    let envId = mirFunctionNewLocal(func, "env", "ClosureEnv", false, mirNoSpan())
+    let destId = mirFunctionNewLocal(func, "r", "Int", true, mirNoSpan())
+    let mut s = newState(func)
+    s = onbLocalSlotInsert(s, envId, 0)
+    s = onbLocalSlotInsert(s, destId, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandConst(mirConstInt(1, "Int")))
+    let instr = mirIndirectCallInstr(
+        true,
+        mirPlace(destId),
+        mirOperandCopy(mirPlace(envId), "ClosureEnv"),
+        args,
+        mirNoSpan(),
+    )
+    let r = onbLowerIndirectCall(s, instr)
+    testing.assert(r.ok)
+    // Sequence: ldr x0, [sp, #0]      (env)
+    //           mov x1, #1            (arg)
+    //           ldr x9, [x0, #0]      (fn ptr)
+    //           blr x9
+    //           str x0, [sp, #8]      (capture return)
+    testing.assertEq(r.instrs.len(), 5)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrMovImm64)
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrLoadFromReg)
+    testing.assertEq(r.instrs[2].dst, "x9")
+    testing.assertEq(r.instrs[2].src, "x0")
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrBranchLinkReg)
+    testing.assertEq(r.instrs[3].src, "x9")
+    testing.assertEq(r.instrs[4].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[4].src, "x0")
+    testing.assertEq(r.instrs[4].offset, 8)
+}
+
+// === Misc ===========================================================
+
+fn testOnbDestType() {
+    let func = callBuildFunc("f", "Int")
+    let id = mirFunctionNewLocal(func, "x", "Bool", false, mirNoSpan())
+    let s = newState(func)
+    testing.assertEq(onbDestType(s, id), "Bool")
+    // Missing local → "Int" fallback.
+    testing.assertEq(onbDestType(s, 99), "Int")
+}

--- a/toolchain/onb_lower_state.osty
+++ b/toolchain/onb_lower_state.osty
@@ -1,0 +1,250 @@
+// onb_lower_state.osty — lowering-pass state record for the Osty
+// Native Backend self-host port. Slice G of the ONB self-host
+// port. Mirror of `lowerState` in `internal/onb/lower.go`.
+//
+// The lowering pass walks one MIR function and produces a list of
+// `OnbInstr` per basic block. State the pass threads through:
+//
+//   - the function being lowered (its locals + types)
+//   - the module's layout table (struct/enum field offsets)
+//   - the per-local stack-slot map (computed by the frame planner
+//     before lowering starts; here we just record + read entries)
+//   - the cstring intern table (string literal value → `__cstring`
+//     label)
+//
+// The Go side uses `map[mir.LocalID]int64` and `map[string]string`
+// for the per-local slot and cstring intern caches. The Osty mirror
+// uses lists of pair records — same semantics, a bit more verbose,
+// no hash dependency. Lookup is linear in the number of locals /
+// cstrings, which is fine for small CUs (typical function has < 64
+// locals; per-CU cstring intern is < 256 entries).
+
+// === Per-local stack slot ===========================================
+
+// OnbLocalSlot records the byte offset (relative to sp) where one
+// MIR local's value is stored on the function's stack frame. The
+// frame planner emits these before lowering; the lowerer reads
+// them when materialising load/store of locals.
+pub struct OnbLocalSlot {
+    pub local: Int,
+    pub offset: Int,
+}
+
+pub fn onbLocalSlot(local: Int, offset: Int) -> OnbLocalSlot {
+    OnbLocalSlot { local: local, offset: offset }
+}
+
+// === Per-cstring intern entry =======================================
+
+// OnbCStringEntry pairs a string literal value with its assigned
+// `__cstring` label. The lowering pass interns each unique value
+// once; subsequent loads of the same literal reuse the existing
+// label.
+pub struct OnbCStringEntry {
+    pub value: String,
+    pub label: String,
+}
+
+pub fn onbCStringEntry(value: String, label: String) -> OnbCStringEntry {
+    OnbCStringEntry { value: value, label: label }
+}
+
+// === Lowering state ==================================================
+
+// OnbLowerState is the mutable state thread through the lowering
+// pass. The Go `lowerState` carries pointers; this Osty mirror
+// carries owned record fields and rebuilds itself when fields are
+// updated. `mut` is required at the call site because the lowering
+// pass mutates `cstrings` / `cstringCounter` whenever a string
+// literal is encountered for the first time.
+pub struct OnbLowerState {
+    pub func: MirFunction,
+    pub layouts: MirLayoutTable,
+    pub localSlots: List<OnbLocalSlot>,
+    pub cstrings: List<OnbCStringEntry>,
+    pub cstringCounter: Int,
+}
+
+// onbNewLowerState builds an empty state for one function. Slot
+// entries are added per-local by the frame planner before
+// lowering; cstring entries are added on demand during operand
+// materialisation.
+pub fn onbNewLowerState(func: MirFunction, layouts: MirLayoutTable) -> OnbLowerState {
+    OnbLowerState {
+        func: func,
+        layouts: layouts,
+        localSlots: [],
+        cstrings: [],
+        cstringCounter: 0,
+    }
+}
+
+// === Local lookups ==================================================
+
+// onbLookupLocal returns the MIR local with id `id`, or a sentinel
+// (id = -1) if it doesn't exist. Mirror of `lookupLocal` in
+// lower.go — the Go version returns `*mir.Local` / `nil`; the
+// Osty version returns the value with a `-1` id sentinel since
+// we don't have null pointers.
+pub fn onbLookupLocal(func: MirFunction, id: Int) -> MirLocal {
+    if id < 0 || id >= func.locals.len() {
+        return mirLocal(-1, "", "", false, mirNoSpan())
+    }
+    func.locals[id]
+}
+
+// onbLocalExists reports whether a local exists in the function
+// for reverse-direction lookups that don't want the sentinel.
+pub fn onbLocalExists(func: MirFunction, id: Int) -> Bool {
+    id >= 0 && id < func.locals.len()
+}
+
+// onbDestType returns the MIR type of the local that holds the
+// dest of a Call/Assign. Mirror of `destType` in lower.go — falls
+// back to `Int` when the local is missing so the 1-register
+// capture path keeps working in the face of malformed MIR.
+pub fn onbDestType(state: OnbLowerState, id: Int) -> String {
+    let local = onbLookupLocal(state.func, id)
+    if local.id < 0 { return "Int" }
+    local.typ
+}
+
+// === Stack slot accessors ===========================================
+
+// onbLocalSlotResult reports both the offset and a found flag.
+// Mirror of the Go `slot, ok := s.localSlots[id]` pattern.
+pub struct OnbLocalSlotResult {
+    pub offset: Int,
+    pub found: Bool,
+}
+
+pub fn onbLocalSlotLookup(state: OnbLowerState, id: Int) -> OnbLocalSlotResult {
+    for entry in state.localSlots {
+        if entry.local == id {
+            return OnbLocalSlotResult { offset: entry.offset, found: true }
+        }
+    }
+    OnbLocalSlotResult { offset: 0, found: false }
+}
+
+// onbLocalSlotInsert records `local → offset`. The frame planner
+// calls this once per allocated local before lowering starts.
+// Subsequent inserts of the same local replace the existing entry
+// (mirror of Go's map assignment semantics).
+pub fn onbLocalSlotInsert(state: OnbLowerState, id: Int, offset: Int) -> OnbLowerState {
+    let mut next: List<OnbLocalSlot> = []
+    let mut replaced = false
+    for entry in state.localSlots {
+        if entry.local == id {
+            next.push(onbLocalSlot(id, offset))
+            replaced = true
+        } else {
+            next.push(entry)
+        }
+    }
+    if !replaced {
+        next.push(onbLocalSlot(id, offset))
+    }
+    OnbLowerState { ..state, localSlots: next }
+}
+
+// === CString intern =================================================
+
+// onbCStringLookup returns the existing label for a value, or the
+// empty string if the value hasn't been interned yet.
+pub fn onbCStringLookup(state: OnbLowerState, value: String) -> String {
+    for entry in state.cstrings {
+        if entry.value == value {
+            return entry.label
+        }
+    }
+    ""
+}
+
+// OnbAddCStringResult bundles the rebuilt state with the assigned
+// label. Mirror of Go's `addCString` which returns just the label
+// while mutating the receiver — Osty rebuilds the state record so
+// the caller picks up the new entry.
+pub struct OnbAddCStringResult {
+    pub state: OnbLowerState,
+    pub label: String,
+}
+
+// onbAddCString interns `value` if it isn't already present and
+// returns the assigned `__cstring` label. Mirror of `addCString`
+// in lower.go. Labels are `strN` where N is a 0-based counter —
+// this matches the Go side's `strN` naming convention so emitted
+// asm + Mach-O cstring sections are byte-identical.
+pub fn onbAddCString(state: OnbLowerState, value: String) -> OnbAddCStringResult {
+    let existing = onbCStringLookup(state, value)
+    if existing != "" {
+        return OnbAddCStringResult { state: state, label: existing }
+    }
+    let label = "str{state.cstringCounter}"
+    let mut nextEntries: List<OnbCStringEntry> = []
+    for entry in state.cstrings {
+        nextEntries.push(entry)
+    }
+    nextEntries.push(onbCStringEntry(value, label))
+    let nextState = OnbLowerState {
+        ..state,
+        cstrings: nextEntries,
+        cstringCounter: state.cstringCounter + 1,
+    }
+    OnbAddCStringResult { state: nextState, label: label }
+}
+
+// === ABI-reg arrays =================================================
+//
+// AAPCS64 calling convention's argument registers. The lowering
+// pass cycles through these in order — the first integer arg goes
+// in x0, the second in x1, ..., capping at 8 each. Returned by
+// helper functions so the Osty `for i in 0..n` index loops can
+// pick up the right name without baking the constant array
+// in-place.
+
+pub fn onbArgRegs() -> List<String> {
+    let mut regs: List<String> = []
+    regs.push("x0")
+    regs.push("x1")
+    regs.push("x2")
+    regs.push("x3")
+    regs.push("x4")
+    regs.push("x5")
+    regs.push("x6")
+    regs.push("x7")
+    regs
+}
+
+pub fn onbFpArgRegs() -> List<String> {
+    let mut regs: List<String> = []
+    regs.push("d0")
+    regs.push("d1")
+    regs.push("d2")
+    regs.push("d3")
+    regs.push("d4")
+    regs.push("d5")
+    regs.push("d6")
+    regs.push("d7")
+    regs
+}
+
+// onbReturnRegs returns the integer return-value registers. AAPCS64
+// uses x0/x1 for direct returns up to 16 bytes; we ship just those
+// two — anything wider takes the indirect (sret) path.
+pub fn onbReturnRegs() -> List<String> {
+    let mut regs: List<String> = []
+    regs.push("x0")
+    regs.push("x1")
+    regs
+}
+
+// onbIndirectResultReg is x8, the AAPCS64 indirect-result register.
+// Caller stores `&dest` here before the call; sret-returning
+// callees read it and write through it.
+pub fn onbIndirectResultReg() -> String { "x8" }
+
+// onbScratchReg is x9, the dev backend's all-purpose integer
+// scratch. Used by indirect-struct copy loops, FP immediate
+// staging, and indirect-call fn-pointer loads.
+pub fn onbScratchReg() -> String { "x9" }

--- a/toolchain/onb_operand.osty
+++ b/toolchain/onb_operand.osty
@@ -1,0 +1,150 @@
+// onb_operand.osty — operand materialiser for the ONB self-host
+// port. Slice G of the port. Mirror of `materialiseOperand /
+// materialiseFloatOperand / loadPlaceIntoReg / loadFloatPlaceIntoReg`
+// from `internal/onb/lower.go`.
+//
+// "Materialise" means: take a MIR operand (Const / Copy / Move) and
+// emit the LIR sequence that lands its value in `dst`. This slice
+// covers the simple cases the call boundary needs:
+//
+//   - Const Int / Bool / String — single mov / mov + mov+adrp+add
+//   - Copy / Move of a non-projected local — single ldr off sp
+//   - Copy / Move of a Float-typed non-projected local — single ldr d
+//
+// The complex projection cases (`hasIndexProjection`, struct/enum
+// FieldProj, ClosureEnv deref, FloatConst → bits encoding) are
+// deferred to Slice H along with `lowerInstr` / `lowerAssign` / the
+// rvalue dispatcher — they have non-trivial dependencies on
+// runtime-symbol lookup (List/Map intrinsics) and field-offset
+// resolution that pull the slice's surface area past the 1k-line
+// budget.
+
+// === Result type ====================================================
+
+// OnbMaterialiseResult bundles every output of one operand
+// materialisation: the emitted instructions, the new state (the
+// cstring intern table may have grown), an `ok` flag, and an
+// error message for unsupported operand shapes. Mirror of Go's
+// `([]Instr, error)` return — Osty keeps the state-rebuild
+// explicit so call sites thread the new state forward.
+pub struct OnbMaterialiseResult {
+    pub instrs: List<OnbInstr>,
+    pub state: OnbLowerState,
+    pub ok: Bool,
+    pub err: String,
+}
+
+pub fn onbMaterialiseOk(state: OnbLowerState, instrs: List<OnbInstr>) -> OnbMaterialiseResult {
+    OnbMaterialiseResult { instrs: instrs, state: state, ok: true, err: "" }
+}
+
+pub fn onbMaterialiseErr(state: OnbLowerState, err: String) -> OnbMaterialiseResult {
+    OnbMaterialiseResult { instrs: [], state: state, ok: false, err: err }
+}
+
+// === Const materialisation ==========================================
+
+// onbMaterialiseIntConst lands a 64-bit integer immediate in `dst`
+// via the multi-word `MovImm64` opcode. The encoder later expands
+// it to a `movz/movk` chain.
+pub fn onbMaterialiseIntConst(dst: String, value: Int) -> List<OnbInstr> {
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrMovImm64(dst, value))
+    out
+}
+
+// onbMaterialiseBoolConst lands 0 or 1 in `dst`. Bool is one
+// 8-byte slot at the ABI level; the runtime treats nonzero as
+// true.
+pub fn onbMaterialiseBoolConst(dst: String, value: Bool) -> List<OnbInstr> {
+    let imm = if value { 1 } else { 0 }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrMovImm64(dst, imm))
+    out
+}
+
+// onbMaterialiseStringConst interns the literal value (or reuses
+// an existing entry) and emits the `adrp + add` pair that lands
+// `&__cstring[label]` in `dst`. Returns the rebuilt state along
+// with the instruction list — the cstring intern table grows for
+// every novel literal.
+pub fn onbMaterialiseStringConst(state: OnbLowerState, dst: String, value: String) -> OnbMaterialiseResult {
+    let added = onbAddCString(state, value)
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoadCStringAddress(dst, added.label))
+    onbMaterialiseOk(added.state, out)
+}
+
+// === Place loads (no projections) ==================================
+
+// onbLoadPlaceIntoReg emits `ldr dst, [sp, #slot]` for a local
+// without projections. Mirror of the no-projection branch of
+// `loadPlaceIntoReg`. Projection-bearing places fall through to
+// the unsupported sentinel — Slice H wires up the
+// `placeProjectionOffset` walker.
+pub fn onbLoadPlaceIntoReg(state: OnbLowerState, place: MirPlace, dst: String) -> OnbMaterialiseResult {
+    if mirPlaceHasProjections(place) {
+        return onbMaterialiseErr(state, "place projection in slice G")
+    }
+    let slot = onbLocalSlotLookup(state, place.local)
+    if !slot.found {
+        return onbMaterialiseErr(state, "read of local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoad64Stack(dst, slot.offset))
+    onbMaterialiseOk(state, out)
+}
+
+// onbLoadFloatPlaceIntoReg emits `ldr dst, [sp, #slot]` into a
+// d-register for a Float-typed local without projections. Mirror
+// of `loadFloatPlaceIntoReg`'s no-projection branch.
+pub fn onbLoadFloatPlaceIntoReg(state: OnbLowerState, place: MirPlace, dst: String) -> OnbMaterialiseResult {
+    if mirPlaceHasProjections(place) {
+        return onbMaterialiseErr(state, "float place projection in slice G")
+    }
+    let slot = onbLocalSlotLookup(state, place.local)
+    if !slot.found {
+        return onbMaterialiseErr(state, "read of float local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoadFloat64Stack(dst, slot.offset))
+    onbMaterialiseOk(state, out)
+}
+
+// === Operand dispatch ===============================================
+
+// onbMaterialiseOperand routes a MirOperand to the right
+// materialisation branch. Mirror of `materialiseOperand` —
+// handles Const Int/Bool/String + Copy/Move of non-projected
+// locals. Other Const kinds (Float, Char, Byte, Unit, Null, Fn)
+// and projection-bearing places return the unsupported sentinel;
+// Slice H expands the surface.
+pub fn onbMaterialiseOperand(state: OnbLowerState, op: MirOperand, dst: String) -> OnbMaterialiseResult {
+    match op.kind {
+        MirOperandKind.MirOpConst -> {
+            match op.const.kind {
+                MirConstKind.MirConstInt -> onbMaterialiseOk(state, onbMaterialiseIntConst(dst, op.const.intValue)),
+                MirConstKind.MirConstBool -> onbMaterialiseOk(state, onbMaterialiseBoolConst(dst, op.const.boolValue)),
+                MirConstKind.MirConstString -> onbMaterialiseStringConst(state, dst, op.const.strValue),
+                _ -> onbMaterialiseErr(state, "const kind not in slice G"),
+            }
+        },
+        MirOperandKind.MirOpCopy -> onbLoadPlaceIntoReg(state, op.place, dst),
+        MirOperandKind.MirOpMove -> onbLoadPlaceIntoReg(state, op.place, dst),
+        _ -> onbMaterialiseErr(state, "operand kind invalid"),
+    }
+}
+
+// onbMaterialiseFloatOperand routes Float-typed operands to a
+// d-register. Const FloatConst is deferred to Slice H (needs
+// floatText → IEEE 754 bit-pattern conversion); Copy/Move of a
+// Float local without projections is supported via
+// `onbLoadFloatPlaceIntoReg`.
+pub fn onbMaterialiseFloatOperand(state: OnbLowerState, op: MirOperand, dst: String) -> OnbMaterialiseResult {
+    match op.kind {
+        MirOperandKind.MirOpConst -> onbMaterialiseErr(state, "float const not in slice G"),
+        MirOperandKind.MirOpCopy -> onbLoadFloatPlaceIntoReg(state, op.place, dst),
+        MirOperandKind.MirOpMove -> onbLoadFloatPlaceIntoReg(state, op.place, dst),
+        _ -> onbMaterialiseErr(state, "float operand kind invalid"),
+    }
+}


### PR DESCRIPTION
## Summary

Slice G of the ONB self-host port. Mirrors the call-boundary
lowering cluster from \`internal/onb/lower.go\` into the
\`toolchain/onb_*.osty\` self-host mirror.

- \`paramShuffle\` → \`onbParamShuffle\`: argRegs / fpArgRegs → param
  stack slots, with the small-struct (≤ 2 fields) / indirect
  (3-4 fields, copy through pointer arg) / scalar / float branches
- \`epilogue\` → \`onbEpilogue\`: main → \`mov w0, #0; ret\`, Unit →
  \`ret\`, scalar → \`ldr x0, [sp, #N]; ret\`, Float → \`ldr d0\`,
  small struct → \`ldr x0/x1\`, sret → loop \`ldr x9, [sp, #N+i];
  str x9, [x8, #i]\`
- \`lowerCall\` → \`onbLowerCall\`: per-arg materialiser dispatch on
  scalar / float / small struct / indirect, optional \`add x8, sp,
  #destSlot\` for sret, \`bl symbol\`, post-call return capture into
  the dest slot
- \`lowerIndirectCall\` → \`onbLowerIndirectCall\`: env in x0, args in
  x1.., \`ldr x9, [x0]\` for fn-pointer, \`blr x9\`
- \`materialiseOperand\` (basic) → \`onbMaterialiseOperand\`: Int /
  Bool / String constants + Copy / Move of non-projected local
- supporting state record \`OnbLowerState\` with slot map, cstring
  intern table, layout-table reference

## Test plan

- [x] \`osty check ./toolchain\` green
- [x] \`go test ./internal/onb -short\` green (no production-side
      regression — the .osty mirror runs alongside the Go runtime)
- [x] 24 Osty tests covering: slot-map insert/replace, cstring
      intern + dedup, every paramShuffle param class, every
      epilogue return class, every materialiseOperand const + local
      path, lowerCall direct / sret / return-capture / small-struct-
      arg / indirect-arg, lowerIndirectCall closure-arg path

## Notes

1256 LOC (250 state + 150 operand + 403 call + 453 test).

Float-const encoding (\`floatText → IEEE754 bits\`) and the projection
walker (\`hasIndexProjection\` / FieldProj / VariantProj /
ClosureEnv-deref) are deferred to Slice H along with \`lowerInstr\` /
\`lowerAssign\` / the rvalue dispatch — they have non-trivial
dependencies on runtime-symbol lookup and field-offset resolution
that pull the slice surface past the 1k-line budget.

\`internal/onb/lower.go\` remains the production runtime per Slice A's
frozen-mirror pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)