### PR TITLE
feat: ONB self-host port Slice H — lowerAssign + RV dispatch

### DIFF
--- a/toolchain/onb_aggregate.osty
+++ b/toolchain/onb_aggregate.osty
@@ -1,0 +1,128 @@
+// onb_aggregate.osty — aggregate rvalue lowering for the ONB
+// self-host port. Slice H of the port. Mirror of
+// `lowerAggregateAssign / lowerStructLiteralAssign /
+// lowerEnumVariantAssign` from `internal/onb/lower.go`.
+//
+// Aggregate rvalues construct compound values directly into the
+// destination slot:
+//
+//   - Empty `List<T>` literal — runtime call to `osty_rt_list_new`.
+//     Non-empty list literals fall back to LLVM (slow-path
+//     element-by-element push isn't worth the dev backend's
+//     complexity budget yet).
+//   - All-scalar struct literal — per-field operand materialise +
+//     store at the field's slot offset.
+//   - Small enum variant — write the discriminant tag at offset 0
+//     then each payload field at `8 + i*8`.
+//   - Closure literal — deferred to Slice I (closure_env_alloc_v2 +
+//     fn-pointer + capture writes; needs the runtime symbol +
+//     adrp/add for the lifted-fn address).
+//   - Map literal — out of scope for the ONB dev backend; falls
+//     back to LLVM.
+
+// === Top-level dispatch =============================================
+
+// onbLowerAggregateAssign routes by aggregate kind. Mirror of
+// `lowerAggregateAssign`.
+pub fn onbLowerAggregateAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    match rv.aggKind {
+        MirAggregateKind.MirAggList -> onbLowerListLiteralAssign(state, rv, destSlot),
+        MirAggregateKind.MirAggStruct -> onbLowerStructLiteralAssign(state, rv, destSlot),
+        MirAggregateKind.MirAggEnumVariant -> onbLowerEnumVariantAssign(state, rv, destSlot),
+        _ -> onbMaterialiseErr(state, "aggregate kind outside slice H"),
+    }
+}
+
+// === Empty list literal =============================================
+
+// onbLowerListLiteralAssign covers `dest = []` — runtime
+// `osty_rt_list_new` returns a fresh empty list pointer in x0
+// which we store into the dest slot. Non-empty list literals
+// (`[1, 2, 3]`) require a per-element push loop and route to
+// the LLVM fallback.
+pub fn onbLowerListLiteralAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    if rv.aggFields.len() != 0 {
+        return onbMaterialiseErr(state, "non-empty list literal outside slice H")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrBranchLink(onbRuntimeSymListNew()))
+    out.push(onbInstrStore64Stack("x0", destSlot))
+    onbMaterialiseOk(state, out)
+}
+
+// === Struct literal =================================================
+
+// onbLowerStructLiteralAssign writes each scalar field of a struct
+// literal into its slot offset. Phase B.5 v1 only supports
+// all-scalar structs; the slot allocator already sized the
+// destination to fit. Fields are materialised one at a time
+// through x9 to avoid burning x10 on a temp — there's no
+// register-pressure issue because each field write is independent.
+// Mirror of `lowerStructLiteralAssign`.
+pub fn onbLowerStructLiteralAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let head = onbExtractTypeName(rv.typ)
+    match onbLookupStructLayout(state.layouts, head) {
+        Some(layout) -> {
+            if rv.aggFields.len() != layout.fields.len() {
+                return onbMaterialiseErr(state, "struct field count mismatch")
+            }
+            let mut working = state
+            let mut out: List<OnbInstr> = []
+            let mut i = 0
+            for field in rv.aggFields {
+                if !onbIsAbiScalarType(layout.fields[i].typ) {
+                    return onbMaterialiseErr(working, "struct field has non-scalar type")
+                }
+                let r = onbMaterialiseOperand(working, field, "x9")
+                if !r.ok { return r }
+                working = r.state
+                for instr in r.instrs { out.push(instr) }
+                out.push(onbInstrStore64Stack("x9", destSlot + i * 8))
+                i = i + 1
+            }
+            onbMaterialiseOk(working, out)
+        },
+        None -> onbMaterialiseErr(state, "unknown struct layout"),
+    }
+}
+
+// === Enum variant ===================================================
+
+// onbLowerEnumVariantAssign writes the discriminant tag at offset 0
+// then each payload field at `8 + i*8`. Mirror of
+// `lowerEnumVariantAssign`. Variants with non-scalar payload fall
+// back; the front end already gates this on the payload-shape
+// check during MIR construction.
+pub fn onbLowerEnumVariantAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let head = onbExtractTypeName(rv.typ)
+    match onbLookupEnumLayout(state.layouts, head) {
+        Some(layout) -> {
+            if rv.aggVariantIdx < 0 || rv.aggVariantIdx >= layout.variants.len() {
+                return onbMaterialiseErr(state, "variant index out of range")
+            }
+            let variant = layout.variants[rv.aggVariantIdx]
+            if !onbEnumPayloadAllScalar(variant.payload) {
+                return onbMaterialiseErr(state, "variant has non-scalar payload")
+            }
+            if rv.aggFields.len() != variant.payload.len() {
+                return onbMaterialiseErr(state, "variant field count mismatch")
+            }
+            let tag = onbEnumDiscriminantValue(layout, rv.aggVariantIdx)
+            let mut working = state
+            let mut out: List<OnbInstr> = []
+            out.push(onbInstrMovImm64("x9", tag))
+            out.push(onbInstrStore64Stack("x9", destSlot))
+            let mut i = 0
+            for field in rv.aggFields {
+                let r = onbMaterialiseOperand(working, field, "x9")
+                if !r.ok { return r }
+                working = r.state
+                for instr in r.instrs { out.push(instr) }
+                out.push(onbInstrStore64Stack("x9", destSlot + onbEnumPayloadOffset(i)))
+                i = i + 1
+            }
+            onbMaterialiseOk(working, out)
+        },
+        None -> onbMaterialiseErr(state, "unknown enum layout"),
+    }
+}

--- a/toolchain/onb_assign.osty
+++ b/toolchain/onb_assign.osty
@@ -1,0 +1,335 @@
+// onb_assign.osty — instruction dispatch + Assign rvalue lowering
+// for the Osty Native Backend self-host port. Slice H of the port.
+// Mirror of `lowerInstr / lowerAssign / lowerAssignToProjection /
+// lowerUseAssign / lowerUseAssignMulti / lowerLenAssign /
+// lowerNullaryAssign / lowerDiscriminantAssign` from
+// `internal/onb/lower.go`.
+//
+// `lowerInstr` is a one-line dispatcher; the body weight lives in
+// `lowerAssign`'s rvalue switch — every supported MIR rvalue
+// shape gets its own assign helper. Slice H ports the structural
+// shapes (Use / Len / Nullary / Discriminant); Binary and
+// Aggregate live in the sister `onb_binary.osty` /
+// `onb_aggregate.osty` modules so the file budget per slice stays
+// near 1k lines.
+
+// === Top-level dispatch =============================================
+
+// onbLowerInstr returns the LIR sequence for a single MIR
+// instruction. StorageLive / StorageDead are no-ops; Assign /
+// Intrinsic / Call dispatch to the right branch. Mirror of
+// `lowerInstr` in lower.go.
+//
+// Intrinsic dispatch lives in Slice I (`onb_intrinsic.osty`) —
+// here we return the unsupported sentinel so callers can route
+// the unhandled case to the LLVM fallback. Once Slice I lands,
+// this function gets the dispatch arm wired in.
+pub fn onbLowerInstr(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    match instr.kind {
+        MirInstrKind.MirInstrStorageLive -> onbMaterialiseOk(state, []),
+        MirInstrKind.MirInstrStorageDead -> onbMaterialiseOk(state, []),
+        MirInstrKind.MirInstrAssign -> onbLowerAssign(state, instr),
+        MirInstrKind.MirInstrCall -> onbLowerInstrCall(state, instr),
+        _ -> onbMaterialiseErr(state, "instruction outside slice H"),
+    }
+}
+
+// onbLowerInstrCall routes Call instructions to the direct or
+// indirect call lowering depending on the callee shape. The
+// underlying functions live in Slice G (`onb_call.osty`).
+fn onbLowerInstrCall(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if instr.calleeKind == MirCalleeKind.MirCalleeIndirect {
+        return onbLowerIndirectCall(state, instr)
+    }
+    onbLowerCall(state, instr)
+}
+
+// === isUnitReturnAssignment =========================================
+
+// onbIsUnitReturnAssignment reports whether `instr` is an
+// `Assign _return := unit` produced by the front end at the end
+// of every Unit-returning function. The lowerer drops these — the
+// epilogue's `ret` is enough; storing a Unit doesn't carry any
+// information.
+pub fn onbIsUnitReturnAssignment(func: MirFunction, instr: MirInstr) -> Bool {
+    if mirPlaceHasProjections(instr.dest) { return false }
+    if instr.dest.local != func.returnLocal { return false }
+    if instr.src.kind != MirRValueKind.MirRVUse { return false }
+    if instr.src.arg.kind != MirOperandKind.MirOpConst { return false }
+    instr.src.arg.const.kind == MirConstKind.MirConstUnit
+}
+
+// === Assign top-level ===============================================
+
+// onbLowerAssign dispatches an Assign instruction by RV kind. The
+// dest slot is resolved up front; an Assign without a slot but
+// targeting `_return` of a scalar return type allocates a synthetic
+// slot at frame's tail (mirror of `allocateReturnSlot`). Anything
+// else is a dead store and yields the empty instruction list.
+pub fn onbLowerAssign(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if onbIsUnitReturnAssignment(state.func, instr) {
+        return onbMaterialiseOk(state, [])
+    }
+    if mirPlaceHasProjections(instr.dest) {
+        return onbLowerAssignToProjection(state, instr)
+    }
+    let slot = onbLocalSlotLookup(state, instr.dest.local)
+    let mut working = state
+    let mut destSlot = slot.offset
+    if !slot.found {
+        if instr.dest.local == state.func.returnLocal && onbIsAbiScalarType(state.func.returnType) {
+            let alloc = onbAllocateReturnSlot(working)
+            working = alloc.state
+            destSlot = alloc.offset
+        } else {
+            return onbMaterialiseOk(working, [])
+        }
+    }
+    match instr.src.kind {
+        MirRValueKind.MirRVUse -> onbLowerUseAssign(working, instr.src, instr.dest.local, destSlot),
+        MirRValueKind.MirRVBinary -> onbLowerBinaryAssign(working, instr.src, destSlot),
+        MirRValueKind.MirRVAggregate -> onbLowerAggregateAssign(working, instr.src, destSlot),
+        MirRValueKind.MirRVNullary -> onbLowerNullaryAssign(working, instr.src, destSlot),
+        MirRValueKind.MirRVDiscriminant -> onbLowerDiscriminantAssign(working, instr.src, destSlot),
+        MirRValueKind.MirRVLen -> onbLowerLenAssign(working, instr.src, destSlot),
+        _ -> onbMaterialiseErr(working, "rvalue outside slice H"),
+    }
+}
+
+// === Synthetic return-slot allocator ================================
+
+// OnbAllocateResult bundles the rebuilt state with the new slot.
+pub struct OnbAllocateResult {
+    pub state: OnbLowerState,
+    pub offset: Int,
+}
+
+// onbAllocateReturnSlot reserves an 8-byte slot at the frame's
+// tail for the return local. Mirror of `allocateReturnSlot` —
+// the Go side rounds the frame size up to 16 here too, but we
+// leave that to the caller (frame planner) for now since this
+// slice doesn't track frameSize as part of state.
+pub fn onbAllocateReturnSlot(state: OnbLowerState) -> OnbAllocateResult {
+    let mut maxOff = 0
+    for entry in state.localSlots {
+        let next = entry.offset + 8
+        if next > maxOff {
+            maxOff = next
+        }
+    }
+    let nextState = onbLocalSlotInsert(state, state.func.returnLocal, maxOff)
+    OnbAllocateResult { state: nextState, offset: maxOff }
+}
+
+// === projectionEndType ==============================================
+
+// onbProjectionEndType returns the type at the end of a place's
+// projection chain. FieldProj.typ / VariantProj.typ carry the
+// field's declared type; empty chains return `()`. Mirror of
+// `projectionEndType`.
+pub fn onbProjectionEndType(place: MirPlace) -> String {
+    if place.projections.len() == 0 { return "()" }
+    let last = place.projections[place.projections.len() - 1]
+    match last.kind {
+        MirProjectionKind.MirProjField -> last.typ,
+        MirProjectionKind.MirProjVariant -> last.typ,
+        _ -> "()",
+    }
+}
+
+// === lowerAssignToProjection ========================================
+
+// onbLowerAssignToProjection covers `dest.field = rvalue` writes.
+// Today's coverage: FieldProj / VariantProj on a struct or enum
+// local. IndexProj writes (`xs[i] = v`) and dest-side
+// VariantProj-with-discriminant-check don't lower yet.
+pub fn onbLowerAssignToProjection(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    for proj in instr.dest.projections {
+        if proj.kind != MirProjectionKind.MirProjField && proj.kind != MirProjectionKind.MirProjVariant {
+            return onbMaterialiseErr(state, "assign-to-projection of unsupported kind")
+        }
+    }
+    let baseSlot = onbLocalSlotLookup(state, instr.dest.local)
+    if !baseSlot.found {
+        return onbMaterialiseErr(state, "assign-to-projection on local without slot")
+    }
+    let off = onbPlaceProjectionOffset(state, instr.dest)
+    let slot = baseSlot.offset + off
+    match instr.src.kind {
+        MirRValueKind.MirRVUse -> {
+            let fieldT = onbProjectionEndType(instr.dest)
+            if onbIsFloatAbiType(fieldT) {
+                let r = onbMaterialiseFloatOperand(state, instr.src.arg, "d8")
+                if !r.ok { return r }
+                let mut out: List<OnbInstr> = []
+                for i in r.instrs { out.push(i) }
+                out.push(onbInstrStoreFloat64Stack("d8", slot))
+                return onbMaterialiseOk(r.state, out)
+            }
+            let r = onbMaterialiseOperand(state, instr.src.arg, "x9")
+            if !r.ok { return r }
+            let mut out: List<OnbInstr> = []
+            for i in r.instrs { out.push(i) }
+            out.push(onbInstrStore64Stack("x9", slot))
+            onbMaterialiseOk(r.state, out)
+        },
+        MirRValueKind.MirRVBinary -> onbLowerBinaryAssign(state, instr.src, slot),
+        _ -> onbMaterialiseErr(state, "assign-to-projection rvalue outside slice H"),
+    }
+}
+
+// === placeProjectionOffset ==========================================
+
+// onbPlaceProjectionOffset reduces a place's projection chain to a
+// single byte offset relative to the local's slot. Field projections
+// add `index * 8`; variant projections add `8 + fieldIdx * 8` (the
+// discriminant lives at offset 0). DerefProj / IndexProj fall
+// through to 0 — the caller is supposed to route those types
+// through the runtime intrinsic path before reaching here.
+pub fn onbPlaceProjectionOffset(state: OnbLowerState, place: MirPlace) -> Int {
+    if !mirPlaceHasProjections(place) { return 0 }
+    let mut off = 0
+    for proj in place.projections {
+        match proj.kind {
+            MirProjectionKind.MirProjField -> { off = off + onbStructFieldByteOffset(proj.index) },
+            MirProjectionKind.MirProjVariant -> { off = off + onbEnumPayloadOffset(proj.variantField) },
+            _ -> {},
+        }
+    }
+    off
+}
+
+// === lowerUseAssign =================================================
+
+// onbLowerUseAssign handles `Assign dest := Use(operand)`. Single
+// 8B slot copy through x9 is the common case; multi-slot copies
+// (struct / small enum) walk through `onbLowerUseAssignMulti`.
+// Float locals route through the d-register path so the bit
+// pattern survives the integer scratch.
+pub fn onbLowerUseAssign(state: OnbLowerState, rv: MirRValue, destId: Int, destSlot: Int) -> OnbMaterialiseResult {
+    let destLoc = onbLookupLocal(state.func, destId)
+    if destLoc.id >= 0 {
+        if onbIsFloatAbiType(destLoc.typ) {
+            let r = onbMaterialiseFloatOperand(state, rv.arg, "d8")
+            if !r.ok { return r }
+            let mut out: List<OnbInstr> = []
+            for i in r.instrs { out.push(i) }
+            out.push(onbInstrStoreFloat64Stack("d8", destSlot))
+            return onbMaterialiseOk(r.state, out)
+        }
+        let slots = onbAbiRegSlots(state.layouts, destLoc.typ)
+        if slots.ok && slots.slots > 1 {
+            return onbLowerUseAssignMulti(state, rv, slots.slots, destSlot)
+        }
+    }
+    let r = onbMaterialiseOperand(state, rv.arg, "x9")
+    if !r.ok { return r }
+    let mut out: List<OnbInstr> = []
+    for i in r.instrs { out.push(i) }
+    out.push(onbInstrStore64Stack("x9", destSlot))
+    onbMaterialiseOk(r.state, out)
+}
+
+// onbLowerUseAssignMulti copies an N-slot value (struct / small
+// enum) from a Copy/Move source slot to the destination slot a
+// half at a time. Const operands aren't valid for multi-slot
+// copies — front-end constructs them via AggregateRV instead.
+pub fn onbLowerUseAssignMulti(state: OnbLowerState, rv: MirRValue, slots: Int, destSlot: Int) -> OnbMaterialiseResult {
+    if rv.arg.kind != MirOperandKind.MirOpCopy && rv.arg.kind != MirOperandKind.MirOpMove {
+        return onbMaterialiseErr(state, "multi-slot use operand")
+    }
+    if mirPlaceHasProjections(rv.arg.place) {
+        return onbMaterialiseErr(state, "multi-slot use with projection")
+    }
+    let srcSlot = onbLocalSlotLookup(state, rv.arg.place.local)
+    if !srcSlot.found {
+        return onbMaterialiseErr(state, "multi-slot use of local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    for i in 0..slots {
+        out.push(onbInstrLoad64Stack("x9", srcSlot.offset + i * 8))
+        out.push(onbInstrStore64Stack("x9", destSlot + i * 8))
+    }
+    onbMaterialiseOk(state, out)
+}
+
+// === lowerLenAssign =================================================
+
+// onbLowerLenAssign lowers `dest = len <place>` for List
+// operands. The runtime call returns the length in x0; we capture
+// it into the destination slot. Mirror of `lowerLenAssign`.
+pub fn onbLowerLenAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    if mirPlaceHasProjections(rv.place) {
+        return onbMaterialiseErr(state, "len of projected place")
+    }
+    let srcSlot = onbLocalSlotLookup(state, rv.place.local)
+    if !srcSlot.found {
+        return onbMaterialiseErr(state, "len of local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoad64Stack("x0", srcSlot.offset))
+    out.push(onbInstrBranchLink(onbRuntimeSymListLen()))
+    out.push(onbInstrStore64Stack("x0", destSlot))
+    onbMaterialiseOk(state, out)
+}
+
+// === lowerNullaryAssign =============================================
+
+// onbLowerNullaryAssign covers `dest = none T?` — write the None
+// tag (0) to slot+0 and leave the payload undefined. Mirror of
+// `lowerNullaryAssign`.
+pub fn onbLowerNullaryAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    if rv.nullaryKind != MirNullaryRVKind.MirNullaryNone {
+        return onbMaterialiseErr(state, "nullary kind")
+    }
+    let head = onbExtractTypeName(rv.typ)
+    match onbLookupEnumLayout(state.layouts, head) {
+        Some(layout) -> {
+            // Find the "None" variant; for synthetic Option layouts
+            // it's at index 0 by construction.
+            let mut noneIdx = 0
+            for v in layout.variants {
+                if v.name == "None" {
+                    noneIdx = v.index
+                }
+            }
+            let tag = onbEnumDiscriminantValue(layout, noneIdx)
+            let mut out: List<OnbInstr> = []
+            out.push(onbInstrMovImm64("x9", tag))
+            out.push(onbInstrStore64Stack("x9", destSlot))
+            onbMaterialiseOk(state, out)
+        },
+        None -> onbMaterialiseErr(state, "nullary none on non-enum type"),
+    }
+}
+
+// onbEnumDiscriminantValue returns the integer tag for a variant.
+// Synthetic Option / Result layouts use the variant's `index`
+// field; user enums fall back to the variant index in the list.
+// Mirror of `enumDiscriminantValue`.
+pub fn onbEnumDiscriminantValue(layout: MirEnumLayout, variantIdx: Int) -> Int {
+    if variantIdx < 0 || variantIdx >= layout.variants.len() {
+        return variantIdx
+    }
+    layout.variants[variantIdx].index
+}
+
+// === lowerDiscriminantAssign ========================================
+
+// onbLowerDiscriminantAssign reads the discriminant tag of an enum
+// local into the destination slot. The discriminant always sits
+// at offset 0 of the source slot, so this is just `ldr x9 + str
+// x9`. Mirror of `lowerDiscriminantAssign`.
+pub fn onbLowerDiscriminantAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    if mirPlaceHasProjections(rv.place) {
+        return onbMaterialiseErr(state, "discriminant of projected place")
+    }
+    let srcSlot = onbLocalSlotLookup(state, rv.place.local)
+    if !srcSlot.found {
+        return onbMaterialiseErr(state, "discriminant of local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoad64Stack("x9", srcSlot.offset))
+    out.push(onbInstrStore64Stack("x9", destSlot))
+    onbMaterialiseOk(state, out)
+}

--- a/toolchain/onb_assign_test.osty
+++ b/toolchain/onb_assign_test.osty
@@ -1,0 +1,429 @@
+// onb_assign_test.osty — assign / binary / aggregate lowering tests.
+use std.testing
+
+// === Layout fixtures ================================================
+
+fn aFieldI64(idx: Int, name: String) -> MirFieldLayout {
+    MirFieldLayout { index: idx, name: name, typ: "Int" }
+}
+
+fn aPoint() -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    fields.push(aFieldI64(0, "x"))
+    fields.push(aFieldI64(1, "y"))
+    MirStructLayout { name: "Point", mangled: "Point", fields: fields, size: 16, align: 8 }
+}
+
+fn aOptionInt() -> MirEnumLayout {
+    let mut variants: List<MirVariantLayout> = []
+    variants.push(MirVariantLayout { index: 0, name: "None", payload: [] })
+    let mut someFields: List<MirFieldLayout> = []
+    someFields.push(aFieldI64(0, "value"))
+    variants.push(MirVariantLayout { index: 1, name: "Some", payload: someFields })
+    MirEnumLayout { name: "Option", mangled: "Option", discriminant: "Int", variants: variants }
+}
+
+fn aLayouts() -> MirLayoutTable {
+    let mut t = mirLayoutTable()
+    t.structs.push(aPoint())
+    t.enums.push(aOptionInt())
+    t
+}
+
+fn aFunc(name: String, returnType: String) -> MirFunction {
+    mirFunction(name, returnType, mirNoSpan())
+}
+
+fn aState(func: MirFunction) -> OnbLowerState {
+    onbNewLowerState(func, aLayouts())
+}
+
+// === lowerInstr dispatch ============================================
+
+fn testOnbLowerInstrStorageNoOp() {
+    let s = aState(aFunc("f", "()"))
+    let r = onbLowerInstr(s, mirStorageLiveInstr(0, mirNoSpan()))
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 0)
+    let r2 = onbLowerInstr(s, mirStorageDeadInstr(0, mirNoSpan()))
+    testing.assert(r2.ok)
+    testing.assertEq(r2.instrs.len(), 0)
+}
+
+// === isUnitReturnAssignment =========================================
+
+fn testOnbIsUnitReturnAssignmentMatch() {
+    let func = aFunc("f", "()")
+    func.returnLocal = mirFunctionNewLocal(func, "_return", "()", true, mirNoSpan())
+    let unit = mirOperandConst(mirConstUnit())
+    let instr = mirAssignInstr(mirPlace(func.returnLocal), mirRVUse(unit), mirNoSpan())
+    testing.assert(onbIsUnitReturnAssignment(func, instr))
+}
+
+fn testOnbIsUnitReturnAssignmentRejectIntReturn() {
+    let func = aFunc("f", "Int")
+    func.returnLocal = mirFunctionNewLocal(func, "_return", "Int", true, mirNoSpan())
+    let one = mirOperandConst(mirConstInt(1, "Int"))
+    let instr = mirAssignInstr(mirPlace(func.returnLocal), mirRVUse(one), mirNoSpan())
+    testing.assert(!onbIsUnitReturnAssignment(func, instr))
+}
+
+fn testOnbLowerAssignUnitReturnIsNoOp() {
+    let func = aFunc("f", "()")
+    func.returnLocal = mirFunctionNewLocal(func, "_return", "()", true, mirNoSpan())
+    let s = aState(func)
+    let unit = mirOperandConst(mirConstUnit())
+    let instr = mirAssignInstr(mirPlace(func.returnLocal), mirRVUse(unit), mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 0)
+}
+
+// === Use rvalue =====================================================
+
+fn testOnbLowerUseAssignIntConst() {
+    let func = aFunc("f", "Int")
+    let dest = mirFunctionNewLocal(func, "x", "Int", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let rv = mirRVUse(mirOperandConst(mirConstInt(42, "Int")))
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrMovImm64)
+    testing.assertEq(r.instrs[0].dst, "x9")
+    testing.assertEq(r.instrs[0].imm, 42)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[1].src, "x9")
+    testing.assertEq(r.instrs[1].offset, 0)
+}
+
+fn testOnbLowerUseAssignFloatLocal() {
+    let func = aFunc("f", "Float")
+    let src = mirFunctionNewLocal(func, "a", "Float", false, mirNoSpan())
+    let dest = mirFunctionNewLocal(func, "b", "Float", true, mirNoSpan())
+    let mut s = aState(func)
+    s = onbLocalSlotInsert(s, src, 0)
+    s = onbLocalSlotInsert(s, dest, 8)
+    let rv = mirRVUse(mirOperandCopy(mirPlace(src), "Float"))
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadFloat64Stack)
+    testing.assertEq(r.instrs[0].dst, "d8")
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStoreFloat64Stack)
+    testing.assertEq(r.instrs[1].src, "d8")
+}
+
+fn testOnbLowerUseAssignMultiSlot() {
+    // dest: Point ← Copy src — 2 × (ldr x9 + str x9)
+    let func = aFunc("f", "Int")
+    let src = mirFunctionNewLocal(func, "a", "Point", false, mirNoSpan())
+    let dest = mirFunctionNewLocal(func, "b", "Point", true, mirNoSpan())
+    let mut s = aState(func)
+    s = onbLocalSlotInsert(s, src, 0)
+    s = onbLocalSlotInsert(s, dest, 16)
+    let rv = mirRVUse(mirOperandCopy(mirPlace(src), "Point"))
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].offset, 0)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[1].offset, 16)
+    testing.assertEq(r.instrs[2].offset, 8)
+    testing.assertEq(r.instrs[3].offset, 24)
+}
+
+// === Binary rvalue ==================================================
+
+fn testOnbLowerBinaryAddInt() {
+    let func = aFunc("f", "Int")
+    let dest = mirFunctionNewLocal(func, "r", "Int", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let lhs = mirOperandConst(mirConstInt(1, "Int"))
+    let rhs = mirOperandConst(mirConstInt(2, "Int"))
+    let rv = mirRVBinary(MirBinAdd, lhs, rhs, "Int")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // mov x9, #1; mov x10, #2; add x9, x9, x10; str x9, [sp]
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].dst, "x9")
+    testing.assertEq(r.instrs[0].imm, 1)
+    testing.assertEq(r.instrs[1].dst, "x10")
+    testing.assertEq(r.instrs[1].imm, 2)
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrAddReg)
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrStore64Stack)
+}
+
+fn testOnbLowerBinarySubMulInt() {
+    let func = aFunc("f", "Int")
+    let dest = mirFunctionNewLocal(func, "r", "Int", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let lhs = mirOperandConst(mirConstInt(7, "Int"))
+    let rhs = mirOperandConst(mirConstInt(3, "Int"))
+    let rvSub = mirRVBinary(MirBinSub, lhs, rhs, "Int")
+    let rSub = onbLowerInstr(s, mirAssignInstr(mirPlace(dest), rvSub, mirNoSpan()))
+    testing.assert(rSub.ok)
+    testing.assertEq(rSub.instrs[2].kind, OnbInstrKind.OnbInstrSubReg)
+    let rvMul = mirRVBinary(MirBinMul, lhs, rhs, "Int")
+    let rMul = onbLowerInstr(s, mirAssignInstr(mirPlace(dest), rvMul, mirNoSpan()))
+    testing.assert(rMul.ok)
+    testing.assertEq(rMul.instrs[2].kind, OnbInstrKind.OnbInstrMulReg)
+}
+
+fn testOnbLowerBinaryComparison() {
+    let func = aFunc("f", "Bool")
+    let dest = mirFunctionNewLocal(func, "r", "Bool", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let lhs = mirOperandConst(mirConstInt(1, "Int"))
+    let rhs = mirOperandConst(mirConstInt(2, "Int"))
+    let rv = mirRVBinary(MirBinLt, lhs, rhs, "Bool")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // mov x9, #1; mov x10, #2; cmp x9, x10; cset x9, lt; str x9, [sp]
+    testing.assertEq(r.instrs.len(), 5)
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrCmp)
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrCset)
+    testing.assertEq(r.instrs[3].cond, OnbCond.OnbCondLt)
+}
+
+fn testOnbLowerBinaryStringConcat() {
+    let func = aFunc("f", "String")
+    let dest = mirFunctionNewLocal(func, "r", "String", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let lhs = mirOperandConst(mirConstString("a"))
+    let rhs = mirOperandConst(mirConstString("b"))
+    let rv = mirRVBinary(MirBinAdd, lhs, rhs, "String")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // adrp+add x0; adrp+add x1; bl strconcat; str x0
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadCStringAddress)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[2].symbol, "osty_rt_strings_Concat")
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrStore64Stack)
+}
+
+fn testOnbLowerBinaryFloatAdd() {
+    let func = aFunc("f", "Float")
+    let a = mirFunctionNewLocal(func, "a", "Float", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Float", false, mirNoSpan())
+    let dest = mirFunctionNewLocal(func, "r", "Float", true, mirNoSpan())
+    let mut s = aState(func)
+    s = onbLocalSlotInsert(s, a, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    s = onbLocalSlotInsert(s, dest, 16)
+    let lhs = mirOperandCopy(mirPlace(a), "Float")
+    let rhs = mirOperandCopy(mirPlace(b), "Float")
+    let rv = mirRVBinary(MirBinAdd, lhs, rhs, "Float")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // ldr d8; ldr d9; fadd d8; str d8
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].dst, "d8")
+    testing.assertEq(r.instrs[1].dst, "d9")
+    testing.assertEq(r.instrs[2].kind, OnbInstrKind.OnbInstrFaddReg)
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrStoreFloat64Stack)
+}
+
+// === Aggregate rvalue ===============================================
+
+fn testOnbLowerEmptyListLiteral() {
+    let func = aFunc("f", "List<Int>")
+    let dest = mirFunctionNewLocal(func, "xs", "List<Int>", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let rv = mirRVAggregate(MirAggList, [], "List<Int>")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[0].symbol, "osty_rt_list_new")
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+}
+
+fn testOnbLowerStructLiteral() {
+    let func = aFunc("f", "Point")
+    let dest = mirFunctionNewLocal(func, "p", "Point", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let mut fields: List<MirOperand> = []
+    fields.push(mirOperandConst(mirConstInt(3, "Int")))
+    fields.push(mirOperandConst(mirConstInt(4, "Int")))
+    let rv = mirRVAggregate(MirAggStruct, fields, "Point")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // mov x9, #3; str x9, [sp]; mov x9, #4; str x9, [sp, #8]
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].imm, 3)
+    testing.assertEq(r.instrs[1].offset, 0)
+    testing.assertEq(r.instrs[2].imm, 4)
+    testing.assertEq(r.instrs[3].offset, 8)
+}
+
+fn testOnbLowerEnumVariantNoPayload() {
+    // Option None — write tag 0 to slot+0
+    let func = aFunc("f", "Option<Int>")
+    let dest = mirFunctionNewLocal(func, "o", "Option<Int>", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let rv = mirRVVariant(0, "None", [], "Option<Int>")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrMovImm64)
+    testing.assertEq(r.instrs[0].imm, 0)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[1].offset, 0)
+}
+
+fn testOnbLowerEnumVariantSome() {
+    // Option Some(42) — tag 1 + payload 42 at offset 8
+    let func = aFunc("f", "Option<Int>")
+    let dest = mirFunctionNewLocal(func, "o", "Option<Int>", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let mut fields: List<MirOperand> = []
+    fields.push(mirOperandConst(mirConstInt(42, "Int")))
+    let rv = mirRVVariant(1, "Some", fields, "Option<Int>")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // mov x9, #1; str x9, [sp]; mov x9, #42; str x9, [sp, #8]
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[0].imm, 1)
+    testing.assertEq(r.instrs[1].offset, 0)
+    testing.assertEq(r.instrs[2].imm, 42)
+    testing.assertEq(r.instrs[3].offset, 8)
+}
+
+// === Discriminant + Len rvalues =====================================
+
+fn testOnbLowerDiscriminantAssign() {
+    let func = aFunc("f", "Int")
+    let opt = mirFunctionNewLocal(func, "o", "Option<Int>", false, mirNoSpan())
+    let dest = mirFunctionNewLocal(func, "d", "Int", true, mirNoSpan())
+    let mut s = aState(func)
+    s = onbLocalSlotInsert(s, opt, 0)
+    s = onbLocalSlotInsert(s, dest, 16)
+    let rv = mirRVDiscriminant(mirPlace(opt), "Int")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].offset, 0)
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrStore64Stack)
+    testing.assertEq(r.instrs[1].offset, 16)
+}
+
+fn testOnbLowerLenAssign() {
+    let func = aFunc("f", "Int")
+    let xs = mirFunctionNewLocal(func, "xs", "List<Int>", false, mirNoSpan())
+    let dest = mirFunctionNewLocal(func, "n", "Int", true, mirNoSpan())
+    let mut s = aState(func)
+    s = onbLocalSlotInsert(s, xs, 0)
+    s = onbLocalSlotInsert(s, dest, 8)
+    let rv = mirRVLen(mirPlace(xs), "Int")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // ldr x0, [sp]; bl _osty_rt_list_len; str x0, [sp, #8]
+    testing.assertEq(r.instrs.len(), 3)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_list_len")
+    testing.assertEq(r.instrs[2].src, "x0")
+    testing.assertEq(r.instrs[2].offset, 8)
+}
+
+// === Nullary rvalue =================================================
+
+fn testOnbLowerNullaryNone() {
+    let func = aFunc("f", "Option<Int>")
+    let dest = mirFunctionNewLocal(func, "o", "Option<Int>", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), dest, 0)
+    let rv = mirRVNullary(MirNullaryNone, "Option<Int>")
+    let instr = mirAssignInstr(mirPlace(dest), rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].imm, 0) // None tag
+    testing.assertEq(r.instrs[1].offset, 0)
+}
+
+// === Assign-to-projection ===========================================
+
+fn testOnbLowerAssignToProjectionField() {
+    // p.y = 10 — write x9 = 10 to slot+8
+    let func = aFunc("f", "()")
+    let p = mirFunctionNewLocal(func, "p", "Point", true, mirNoSpan())
+    let s = onbLocalSlotInsert(aState(func), p, 0)
+    let mut place = mirPlace(p)
+    place = mirPlaceProject(place, mirFieldProj(1, "y", "Int"))
+    let rv = mirRVUse(mirOperandConst(mirConstInt(10, "Int")))
+    let instr = mirAssignInstr(place, rv, mirNoSpan())
+    let r = onbLowerInstr(s, instr)
+    testing.assert(r.ok)
+    // mov x9, #10; str x9, [sp, #8]
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].imm, 10)
+    testing.assertEq(r.instrs[1].offset, 8)
+}
+
+fn testOnbProjectionEndType() {
+    let mut place = mirPlace(0)
+    testing.assertEq(onbProjectionEndType(place), "()")
+    place = mirPlaceProject(place, mirFieldProj(0, "x", "Int"))
+    testing.assertEq(onbProjectionEndType(place), "Int")
+    place = mirPlaceProject(place, mirVariantProj(1, "Some", 0, "Float"))
+    testing.assertEq(onbProjectionEndType(place), "Float")
+}
+
+// === Synthetic return slot ==========================================
+
+fn testOnbAllocateReturnSlot() {
+    let func = aFunc("f", "Int")
+    func.returnLocal = mirFunctionNewLocal(func, "_return", "Int", true, mirNoSpan())
+    let mut s = aState(func)
+    let other = mirFunctionNewLocal(func, "x", "Int", false, mirNoSpan())
+    s = onbLocalSlotInsert(s, other, 0)
+    let alloc = onbAllocateReturnSlot(s)
+    // Existing slot at 0 → next available is 8.
+    testing.assertEq(alloc.offset, 8)
+    let lookup = onbLocalSlotLookup(alloc.state, func.returnLocal)
+    testing.assert(lookup.found)
+    testing.assertEq(lookup.offset, 8)
+}
+
+// === Comparison cond mapping ========================================
+
+fn testOnbBinaryComparisonCond() {
+    testing.assert(onbBinaryComparisonCond(MirBinEq).ok)
+    testing.assertEq(onbBinaryComparisonCond(MirBinEq).cond, OnbCond.OnbCondEq)
+    testing.assertEq(onbBinaryComparisonCond(MirBinNeq).cond, OnbCond.OnbCondNe)
+    testing.assertEq(onbBinaryComparisonCond(MirBinLt).cond, OnbCond.OnbCondLt)
+    testing.assertEq(onbBinaryComparisonCond(MirBinLeq).cond, OnbCond.OnbCondLe)
+    testing.assertEq(onbBinaryComparisonCond(MirBinGt).cond, OnbCond.OnbCondGt)
+    testing.assertEq(onbBinaryComparisonCond(MirBinGeq).cond, OnbCond.OnbCondGe)
+    testing.assert(!onbBinaryComparisonCond(MirBinAdd).ok)
+}
+
+// === Discriminant value =============================================
+
+fn testOnbEnumDiscriminantValue() {
+    let layout = aOptionInt()
+    testing.assertEq(onbEnumDiscriminantValue(layout, 0), 0) // None
+    testing.assertEq(onbEnumDiscriminantValue(layout, 1), 1) // Some
+    // Out of range falls through.
+    testing.assertEq(onbEnumDiscriminantValue(layout, 99), 99)
+}

--- a/toolchain/onb_binary.osty
+++ b/toolchain/onb_binary.osty
@@ -1,0 +1,167 @@
+// onb_binary.osty — binary rvalue lowering for the ONB self-host
+// port. Slice H of the port. Mirror of `lowerBinaryAssign /
+// lowerComparisonAssign / lowerStringConcatAssign /
+// lowerFloatBinaryAssign / comparisonCond` from
+// `internal/onb/lower.go`.
+//
+// Binary rvalues divide into four shapes:
+//
+//   - Comparisons (==, !=, <, ≤, >, ≥) — `cmp lhs, rhs; cset Xd, <cond>`
+//     with the result stored as a 0/1 boolean in the dest slot.
+//   - String concat (`a + b` where T = String) — runtime call to
+//     `osty_rt_strings_Concat` with both operands in x0/x1.
+//   - Float arithmetic (T = Float / Float64) — d8/d9 scratch + per-op
+//     `f<op>` instruction.
+//   - Integer arithmetic (Add / Sub / Mul today) — x9/x10 scratch +
+//     per-op `<op> Xd, Xn, Xm` instruction.
+
+// === Comparison cond mapping =======================================
+
+// onbBinaryComparisonCond maps a MIR binary op to its aarch64
+// condition code. Returns the condition + an `ok` flag — non-comparison
+// ops yield ok=false.
+pub struct OnbBinaryCondResult {
+    pub cond: OnbCond,
+    pub ok: Bool,
+}
+
+pub fn onbBinaryComparisonCond(op: MirBinaryOp) -> OnbBinaryCondResult {
+    match op {
+        MirBinaryOp.MirBinEq -> OnbBinaryCondResult { cond: OnbCond.OnbCondEq, ok: true },
+        MirBinaryOp.MirBinNeq -> OnbBinaryCondResult { cond: OnbCond.OnbCondNe, ok: true },
+        MirBinaryOp.MirBinLt -> OnbBinaryCondResult { cond: OnbCond.OnbCondLt, ok: true },
+        MirBinaryOp.MirBinLeq -> OnbBinaryCondResult { cond: OnbCond.OnbCondLe, ok: true },
+        MirBinaryOp.MirBinGt -> OnbBinaryCondResult { cond: OnbCond.OnbCondGt, ok: true },
+        MirBinaryOp.MirBinGeq -> OnbBinaryCondResult { cond: OnbCond.OnbCondGe, ok: true },
+        _ -> OnbBinaryCondResult { cond: OnbCond.OnbCondEq, ok: false },
+    }
+}
+
+// === Top-level binary dispatch ======================================
+
+// onbLowerBinaryAssign routes by RV shape: comparison → cset path,
+// String + → runtime call, Float arith → d-register path, Int
+// arith → x9/x10 path. Mirror of `lowerBinaryAssign`.
+pub fn onbLowerBinaryAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let cmp = onbBinaryComparisonCond(rv.binaryOp)
+    if cmp.ok {
+        return onbLowerComparisonAssign(state, rv, cmp.cond, destSlot)
+    }
+    if rv.binaryOp == MirBinaryOp.MirBinAdd && rv.typ == "String" {
+        return onbLowerStringConcatAssign(state, rv, destSlot)
+    }
+    if onbIsFloatAbiType(rv.typ) {
+        return onbLowerFloatBinaryAssign(state, rv, destSlot)
+    }
+    onbLowerIntBinaryAssign(state, rv, destSlot)
+}
+
+// === Comparison path ================================================
+
+// onbLowerComparisonAssign emits `cmp lhs, rhs; cset Xd, <cond>;
+// str Xd, [sp, #destSlot]`. Mirror of `lowerComparisonAssign`.
+pub fn onbLowerComparisonAssign(state: OnbLowerState, rv: MirRValue, cond: OnbCond, destSlot: Int) -> OnbMaterialiseResult {
+    let lhs = onbMaterialiseOperand(state, rv.arg, "x9")
+    if !lhs.ok { return lhs }
+    let rhs = onbMaterialiseOperand(lhs.state, rv.right, "x10")
+    if !rhs.ok { return rhs }
+    let mut out: List<OnbInstr> = []
+    for i in lhs.instrs { out.push(i) }
+    for i in rhs.instrs { out.push(i) }
+    out.push(onbInstrCmp("x9", "x10"))
+    out.push(onbInstrCset("x9", cond))
+    out.push(onbInstrStore64Stack("x9", destSlot))
+    onbMaterialiseOk(rhs.state, out)
+}
+
+// === String concat path =============================================
+
+// onbLowerStringConcatAssign lowers `dest = lhs + rhs` for two
+// String operands into an AAPCS64 call to the runtime's two-arg
+// concat helper. Both operands materialise into x0/x1 (a string
+// is a heap pointer at the ABI boundary), the runtime returns a
+// fresh ptr in x0, and we store that into the destination slot.
+// Mirror of `lowerStringConcatAssign`.
+pub fn onbLowerStringConcatAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let lhs = onbMaterialiseOperand(state, rv.arg, "x0")
+    if !lhs.ok { return lhs }
+    let rhs = onbMaterialiseOperand(lhs.state, rv.right, "x1")
+    if !rhs.ok { return rhs }
+    let mut out: List<OnbInstr> = []
+    for i in lhs.instrs { out.push(i) }
+    for i in rhs.instrs { out.push(i) }
+    out.push(onbInstrBranchLink(onbRuntimeSymStringConcat()))
+    out.push(onbInstrStore64Stack("x0", destSlot))
+    onbMaterialiseOk(rhs.state, out)
+}
+
+// === Float arithmetic path ==========================================
+
+// onbLowerFloatBinaryAssign lowers `dest = lhs <op> rhs` for two
+// Float operands. Operands materialise into d8/d9, then `f<op>`
+// produces the result, which `str d8` commits back. d8/d9 are
+// AAPCS64 callee-saved — using them as the scratch pair means a
+// register-allocator follow-up can keep them live across calls.
+// Mirror of `lowerFloatBinaryAssign`.
+pub fn onbLowerFloatBinaryAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let lhs = onbMaterialiseFloatOperand(state, rv.arg, "d8")
+    if !lhs.ok { return lhs }
+    let rhs = onbMaterialiseFloatOperand(lhs.state, rv.right, "d9")
+    if !rhs.ok { return rhs }
+    let mut out: List<OnbInstr> = []
+    for i in lhs.instrs { out.push(i) }
+    for i in rhs.instrs { out.push(i) }
+    let opInstrResult = onbFloatBinaryOpInstr(rv.binaryOp)
+    if !opInstrResult.ok {
+        return onbMaterialiseErr(rhs.state, "float binary op outside slice H")
+    }
+    out.push(opInstrResult.instr)
+    out.push(onbInstrStoreFloat64Stack("d8", destSlot))
+    onbMaterialiseOk(rhs.state, out)
+}
+
+// onbFloatBinaryOpInstr maps a MIR binary op to the aarch64 FP
+// instruction. Returns ok=false for ops outside Add/Sub/Mul/Div.
+pub struct OnbFloatOpResult {
+    pub instr: OnbInstr,
+    pub ok: Bool,
+}
+
+pub fn onbFloatBinaryOpInstr(op: MirBinaryOp) -> OnbFloatOpResult {
+    match op {
+        MirBinaryOp.MirBinAdd -> OnbFloatOpResult { instr: onbInstrFaddReg("d8", "d8", "d9"), ok: true },
+        MirBinaryOp.MirBinSub -> OnbFloatOpResult { instr: onbInstrFsubReg("d8", "d8", "d9"), ok: true },
+        MirBinaryOp.MirBinMul -> OnbFloatOpResult { instr: onbInstrFmulReg("d8", "d8", "d9"), ok: true },
+        MirBinaryOp.MirBinDiv -> OnbFloatOpResult { instr: onbInstrFdivReg("d8", "d8", "d9"), ok: true },
+        _ -> OnbFloatOpResult { instr: onbInstrRet(), ok: false },
+    }
+}
+
+// === Integer arithmetic path ========================================
+
+// onbLowerIntBinaryAssign lowers `dest = lhs <op> rhs` for two
+// integer operands. Phase 1 supports Add/Sub/Mul; Div / Mod / bit
+// ops fall back. Mirror of `lowerBinaryAssign`'s integer arm.
+pub fn onbLowerIntBinaryAssign(state: OnbLowerState, rv: MirRValue, destSlot: Int) -> OnbMaterialiseResult {
+    let opOk = rv.binaryOp == MirBinaryOp.MirBinAdd
+        || rv.binaryOp == MirBinaryOp.MirBinSub
+        || rv.binaryOp == MirBinaryOp.MirBinMul
+    if !opOk {
+        return onbMaterialiseErr(state, "binary op outside phase 1")
+    }
+    let lhs = onbMaterialiseOperand(state, rv.arg, "x9")
+    if !lhs.ok { return lhs }
+    let rhs = onbMaterialiseOperand(lhs.state, rv.right, "x10")
+    if !rhs.ok { return rhs }
+    let mut out: List<OnbInstr> = []
+    for i in lhs.instrs { out.push(i) }
+    for i in rhs.instrs { out.push(i) }
+    match rv.binaryOp {
+        MirBinaryOp.MirBinAdd -> out.push(onbInstrAddReg("x9", "x9", "x10")),
+        MirBinaryOp.MirBinSub -> out.push(onbInstrSubReg("x9", "x9", "x10")),
+        MirBinaryOp.MirBinMul -> out.push(onbInstrMulReg("x9", "x9", "x10")),
+        _ -> {},
+    }
+    out.push(onbInstrStore64Stack("x9", destSlot))
+    onbMaterialiseOk(rhs.state, out)
+}


### PR DESCRIPTION
## Summary

Slice H of the ONB self-host port. Mirrors the Assign / RV dispatch
cluster from \`internal/onb/lower.go\` into the
\`toolchain/onb_*.osty\` self-host mirror.

- \`lowerInstr\` → \`onbLowerInstr\`: Storage no-ops, Assign / Call
  routing
- \`lowerAssign\` → \`onbLowerAssign\`: Unit-return drop, projection
  routing, synthetic return-slot allocation, RV-kind switch into
  Use / Binary / Aggregate / Nullary / Discriminant / Len
- Use rvalue → \`onbLowerUseAssign\` + \`onbLowerUseAssignMulti\`
  (single 8B / float / multi-slot copies)
- Binary rvalue → \`onbLowerBinaryAssign\` routing across comparison
  (\`cmp + cset\`), String concat (runtime call), Float arith
  (\`d8/d9\` + \`f<op>\`), and Int Add/Sub/Mul (\`x9/x10\`)
- Aggregate rvalue → \`onbLowerAggregateAssign\` routing across
  empty List literal (\`osty_rt_list_new\`), struct literal (per-
  field stores), enum variant (discriminant tag + payload stores)
- Discriminant / Len / Nullary direct-lower paths
- Projection-end Assign (\`p.field = rvalue\` for FieldProj /
  VariantProj)

## Test plan

- [x] \`osty check ./toolchain\` green
- [x] \`go test ./internal/onb -short\` green
- [x] 22 Osty tests covering each rvalue path: Use / multi-slot
      copy / float local Use / Int Add+Sub+Mul / Bool comparison /
      String concat / Float Add / empty list / struct literal /
      Option None+Some / Discriminant / Len / Nullary None /
      FieldProj assign / projection-end type / synthetic return
      slot / comparison cond mapping / discriminant value

## Notes

1059 LOC (335 assign + 167 binary + 128 aggregate + 429 test).

Closure literal aggregate, non-empty list literal, projection-bearing
operand materialiser (IndexProj for \`xs[i]\`, ClosureEnv-deref), and
intrinsic dispatch wait for Slice I — they all need either runtime-
symbol-aware paths (List/Map intrinsics) or the closure-env runtime
allocation glue.

\`internal/onb/lower.go\` remains the production runtime per Slice A's
frozen-mirror pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)