### PR TITLE
feat: ONB self-host port Slice I — intrinsic dispatch

### DIFF
--- a/toolchain/onb_intrinsic.osty
+++ b/toolchain/onb_intrinsic.osty
@@ -1,0 +1,439 @@
+// onb_intrinsic.osty — intrinsic dispatch for the ONB self-host
+// port. Slice I of the port. Mirror of `lowerIntrinsic /
+// lowerPrintln / lowerListPush / lowerListLen / lowerListIsEmpty /
+// lowerStringLen / lowerStringIsEmpty / lowerOptionIsSome /
+// lowerOptionIsNone / lowerOptionDiscriminantCompare / lowerMapNew /
+// lowerMapLen / lowerMapContains / lowerMapRemove /
+// lowerMapBoolReturn / mapKeyValueTypes` from
+// `internal/onb/lower.go`.
+//
+// MIR `IntrinsicInstr` carries one of ~30 well-known intrinsics
+// the front end emits in place of a regular function call —
+// println, list/string/option/map operations, channel/task glue,
+// etc. The ONB dev backend covers the scalar-element subset; the
+// rest fall through to the LLVM backend with the unsupported
+// sentinel.
+//
+// Coverage in this slice: print + List + String + Option + Map
+// (no-scratch path). The stateful map_set / map_get plus the
+// closure-aware list_get / Map<K, list> shapes need scratch-slot
+// reservation in the frame planner — wired in a follow-up slice
+// alongside the `needsMapScratch` infrastructure.
+
+// === Top-level dispatch =============================================
+
+// onbLowerIntrinsic routes by intrinsic kind. Mirror of
+// `lowerIntrinsic`. Unknown intrinsics return the unsupported
+// sentinel — the caller routes to the LLVM fallback.
+pub fn onbLowerIntrinsic(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    match instr.intrinsic {
+        MirIntrinsicKind.MirIntrinsicPrintln -> onbLowerPrintln(state, instr),
+        MirIntrinsicKind.MirIntrinsicListPush -> onbLowerListPush(state, instr),
+        MirIntrinsicKind.MirIntrinsicListLen -> onbLowerListLen(state, instr),
+        MirIntrinsicKind.MirIntrinsicListIsEmpty -> onbLowerListIsEmpty(state, instr),
+        MirIntrinsicKind.MirIntrinsicStringLen -> onbLowerStringLen(state, instr),
+        MirIntrinsicKind.MirIntrinsicStringIsEmpty -> onbLowerStringIsEmpty(state, instr),
+        MirIntrinsicKind.MirIntrinsicOptionIsSome -> onbLowerOptionIsSome(state, instr),
+        MirIntrinsicKind.MirIntrinsicOptionIsNone -> onbLowerOptionIsNone(state, instr),
+        MirIntrinsicKind.MirIntrinsicMapNew -> onbLowerMapNew(state, instr),
+        MirIntrinsicKind.MirIntrinsicMapLen -> onbLowerMapLen(state, instr),
+        MirIntrinsicKind.MirIntrinsicMapContains -> onbLowerMapContains(state, instr),
+        MirIntrinsicKind.MirIntrinsicMapRemove -> onbLowerMapRemove(state, instr),
+        _ -> onbMaterialiseErr(state, "intrinsic outside slice I"),
+    }
+}
+
+// === Print ==========================================================
+
+// onbLowerPrintln covers the string-literal and string-local cases
+// of `println(s)`. Other operand shapes (Int / Float locals) need
+// printf-format-string staging + the Mach-O vararg shuffle, which
+// we defer to a follow-up slice along with the target-aware Frame
+// glue.
+pub fn onbLowerPrintln(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if instr.args.len() != 1 {
+        return onbMaterialiseErr(state, "println requires one argument")
+    }
+    let arg = instr.args[0]
+    if arg.kind == MirOperandKind.MirOpConst && arg.const.kind == MirConstKind.MirConstString {
+        let added = onbAddCString(state, arg.const.strValue)
+        let mut out: List<OnbInstr> = []
+        out.push(onbInstrLoadCStringAddress("x0", added.label))
+        out.push(onbInstrBranchLink("puts"))
+        return onbMaterialiseOk(added.state, out)
+    }
+    if arg.typ == "String" && (arg.kind == MirOperandKind.MirOpCopy || arg.kind == MirOperandKind.MirOpMove) {
+        if mirPlaceHasProjections(arg.place) {
+            return onbMaterialiseErr(state, "println of projected string place")
+        }
+        let slot = onbLocalSlotLookup(state, arg.place.local)
+        if !slot.found {
+            return onbMaterialiseErr(state, "println of string local without slot")
+        }
+        let mut out: List<OnbInstr> = []
+        out.push(onbInstrLoad64Stack("x0", slot.offset))
+        out.push(onbInstrBranchLink("puts"))
+        return onbMaterialiseOk(state, out)
+    }
+    onbMaterialiseErr(state, "println of unsupported operand shape in slice I")
+}
+
+// === List ===========================================================
+
+// onbLowerListPush emits the type-dispatched runtime call. The
+// runtime ships type-specific entry points for the four scalar
+// element widths (i64 / i1 / f64 / string-pointer) — we route by
+// the value operand's MIR type and pass Float values through d0
+// (the AAPCS64 FP arg slot) instead of x1.
+pub fn onbLowerListPush(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if instr.args.len() != 2 {
+        return onbMaterialiseErr(state, "list_push expects 2 args")
+    }
+    let listR = onbMaterialiseOperand(state, instr.args[0], "x0")
+    if !listR.ok { return listR }
+    let value = instr.args[1]
+    let valueT = value.typ
+    let mut working = listR.state
+    let mut out: List<OnbInstr> = []
+    for i in listR.instrs { out.push(i) }
+    if onbIsFloatAbiType(valueT) {
+        let r = onbMaterialiseFloatOperand(working, value, "d0")
+        if !r.ok { return r }
+        working = r.state
+        for i in r.instrs { out.push(i) }
+        out.push(onbInstrBranchLink("osty_rt_list_push_f64"))
+        return onbMaterialiseOk(working, out)
+    }
+    let kind = onbAbiKindFor(valueT)
+    let symOpt = onbListPushSymbolForKind(kind)
+    match symOpt {
+        Some(sym) -> {
+            let r = onbMaterialiseOperand(working, value, "x1")
+            if !r.ok { return r }
+            working = r.state
+            for i in r.instrs { out.push(i) }
+            out.push(onbInstrBranchLink(sym))
+            onbMaterialiseOk(working, out)
+        },
+        None -> onbMaterialiseErr(working, "list_push value type outside ABI"),
+    }
+}
+
+// onbLowerListLen lowers `IntrinsicListLen(list) -> Int` by
+// calling the runtime helper and capturing x0 into the dest slot.
+pub fn onbLowerListLen(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerSimpleIntReturn(state, instr, onbRuntimeSymListLen(), "list_len")
+}
+
+// onbLowerListIsEmpty composes `osty_rt_list_len(xs) == 0` and
+// stores the bool result.
+pub fn onbLowerListIsEmpty(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerEmptyCheck(state, instr, onbRuntimeSymListLen(), "list_is_empty")
+}
+
+// === String =========================================================
+
+// onbLowerStringLen lowers `s.len()` on a String operand.
+pub fn onbLowerStringLen(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerSimpleIntReturn(state, instr, onbRuntimeSymStringByteLen(), "string_len")
+}
+
+// onbLowerStringIsEmpty composes `osty_rt_strings_ByteLen(s) == 0`.
+pub fn onbLowerStringIsEmpty(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerEmptyCheck(state, instr, onbRuntimeSymStringByteLen(), "string_is_empty")
+}
+
+// === Option =========================================================
+
+// onbLowerOptionIsSome reads the option's discriminant and compares
+// against the Some tag (= 1) with `cset eq`.
+pub fn onbLowerOptionIsSome(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerOptionDiscriminantCompare(state, instr, OnbCond.OnbCondEq)
+}
+
+// onbLowerOptionIsNone uses `cset ne`.
+pub fn onbLowerOptionIsNone(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerOptionDiscriminantCompare(state, instr, OnbCond.OnbCondNe)
+}
+
+// onbLowerOptionDiscriminantCompare emits the shared isSome / isNone
+// body: load discriminant byte (option slot + 0) into x9, compare
+// to Some tag (1), `cset` with the caller-chosen condition.
+pub fn onbLowerOptionDiscriminantCompare(state: OnbLowerState, instr: MirInstr, cond: OnbCond) -> OnbMaterialiseResult {
+    if instr.args.len() != 1 {
+        return onbMaterialiseErr(state, "option discriminant compare expects 1 arg")
+    }
+    let op = instr.args[0]
+    if op.kind != MirOperandKind.MirOpCopy && op.kind != MirOperandKind.MirOpMove {
+        return onbMaterialiseErr(state, "option discriminant operand")
+    }
+    if mirPlaceHasProjections(op.place) {
+        return onbMaterialiseErr(state, "option discriminant on projected place")
+    }
+    let srcSlot = onbLocalSlotLookup(state, op.place.local)
+    if !srcSlot.found {
+        return onbMaterialiseErr(state, "option discriminant of local without slot")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrLoad64Stack("x9", srcSlot.offset))
+    out.push(onbInstrMovImm64("x10", 1)) // Some tag
+    out.push(onbInstrCmp("x9", "x10"))
+    out.push(onbInstrCset("x9", cond))
+    if instr.hasDest && !mirPlaceHasProjections(instr.dest) {
+        let dest = onbLocalSlotLookup(state, instr.dest.local)
+        if dest.found {
+            out.push(onbInstrStore64Stack("x9", dest.offset))
+        }
+    }
+    onbMaterialiseOk(state, out)
+}
+
+// === Map ============================================================
+
+// onbLowerMapNew lowers `m = intrinsic map_new()` to a call to the
+// runtime's `osty_rt_map_new(key_kind, value_kind, value_size,
+// trace)` constructor. K/V types come from the destination local's
+// `Map<K, V>` parameterisation; `trace` stays NULL for the
+// scalar-element map slice.
+pub fn onbLowerMapNew(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    if !instr.hasDest || mirPlaceHasProjections(instr.dest) {
+        return onbMaterialiseErr(state, "map_new requires a non-projected dest")
+    }
+    let destLoc = onbLookupLocal(state.func, instr.dest.local)
+    if destLoc.id < 0 {
+        return onbMaterialiseErr(state, "map_new dest local missing")
+    }
+    let kv = onbMapKeyValueTypes(destLoc.typ)
+    if !kv.ok {
+        return onbMaterialiseErr(state, "map_new dest type isn't Map<K,V>")
+    }
+    let mut out: List<OnbInstr> = []
+    out.push(onbInstrMovImm64("x0", onbAbiKindFor(kv.key)))
+    out.push(onbInstrMovImm64("x1", onbAbiKindFor(kv.value)))
+    out.push(onbInstrMovImm64("x2", 8)) // value_size — every supported value is 8B
+    out.push(onbInstrMovImm64("x3", 0)) // trace fn pointer (NULL)
+    out.push(onbInstrBranchLink(onbRuntimeSymMapNew()))
+    let dest = onbLocalSlotLookup(state, instr.dest.local)
+    if dest.found {
+        out.push(onbInstrStore64Stack("x0", dest.offset))
+    }
+    onbMaterialiseOk(state, out)
+}
+
+// onbLowerMapLen — direct runtime call returning count in x0.
+pub fn onbLowerMapLen(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerSimpleIntReturn(state, instr, onbRuntimeSymMapLen(), "map_len")
+}
+
+// onbLowerMapContains lowers `_b = intrinsic map_contains(m, k)`.
+pub fn onbLowerMapContains(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerMapBoolReturn(state, instr, "map_contains", true)
+}
+
+// onbLowerMapRemove lowers `_b = intrinsic map_remove(m, k)`.
+pub fn onbLowerMapRemove(state: OnbLowerState, instr: MirInstr) -> OnbMaterialiseResult {
+    onbLowerMapBoolReturn(state, instr, "map_remove", false)
+}
+
+// onbLowerMapBoolReturn shares the (map, key) → Bool plumbing.
+// The `contains` discriminator picks between contains/remove
+// runtime symbols based on the key kind. Mirror of
+// `lowerMapBoolReturn`.
+pub fn onbLowerMapBoolReturn(state: OnbLowerState, instr: MirInstr, name: String, contains: Bool) -> OnbMaterialiseResult {
+    if instr.args.len() != 2 {
+        return onbMaterialiseErr(state, "map bool-return expects 2 args")
+    }
+    let mapR = onbMaterialiseOperand(state, instr.args[0], "x0")
+    if !mapR.ok { return mapR }
+    let keyKind = onbAbiKindFor(instr.args[1].typ)
+    let symOpt = if contains {
+        onbMapContainsSymbolForKeyKind(keyKind)
+    } else {
+        onbMapRemoveSymbolForKeyKind(keyKind)
+    }
+    match symOpt {
+        Some(sym) -> {
+            let keyR = onbMaterialiseOperand(mapR.state, instr.args[1], "x1")
+            if !keyR.ok { return keyR }
+            let mut out: List<OnbInstr> = []
+            for i in mapR.instrs { out.push(i) }
+            for i in keyR.instrs { out.push(i) }
+            out.push(onbInstrBranchLink(sym))
+            if instr.hasDest && !mirPlaceHasProjections(instr.dest) {
+                let dest = onbLocalSlotLookup(keyR.state, instr.dest.local)
+                if dest.found {
+                    out.push(onbInstrStore64Stack("x0", dest.offset))
+                }
+            }
+            onbMaterialiseOk(keyR.state, out)
+        },
+        None -> onbMaterialiseErr(mapR.state, "map bool-return key kind outside ABI"),
+    }
+}
+
+// === Shared helpers =================================================
+
+// onbLowerSimpleIntReturn covers the `(receiver) -> Int` runtime
+// shape: materialise the receiver into x0, `bl symbol`, capture
+// x0 into the dest slot. Used by list_len, string_len, map_len.
+pub fn onbLowerSimpleIntReturn(state: OnbLowerState, instr: MirInstr, sym: String, name: String) -> OnbMaterialiseResult {
+    if instr.args.len() != 1 {
+        return onbMaterialiseErr(state, "intrinsic expects 1 arg")
+    }
+    let recv = onbMaterialiseOperand(state, instr.args[0], "x0")
+    if !recv.ok { return recv }
+    let mut out: List<OnbInstr> = []
+    for i in recv.instrs { out.push(i) }
+    out.push(onbInstrBranchLink(sym))
+    if instr.hasDest && !mirPlaceHasProjections(instr.dest) {
+        let dest = onbLocalSlotLookup(recv.state, instr.dest.local)
+        if dest.found {
+            out.push(onbInstrStore64Stack("x0", dest.offset))
+        }
+    }
+    onbMaterialiseOk(recv.state, out)
+}
+
+// onbLowerEmptyCheck covers the `(receiver) -> Bool` "is empty"
+// shape: call the length-returning runtime symbol, then `cmp x0,
+// #0; cset Xd, eq` to materialise the bool. Used by list_is_empty
+// and string_is_empty.
+pub fn onbLowerEmptyCheck(state: OnbLowerState, instr: MirInstr, sym: String, name: String) -> OnbMaterialiseResult {
+    if instr.args.len() != 1 {
+        return onbMaterialiseErr(state, "intrinsic expects 1 arg")
+    }
+    let recv = onbMaterialiseOperand(state, instr.args[0], "x0")
+    if !recv.ok { return recv }
+    let mut out: List<OnbInstr> = []
+    for i in recv.instrs { out.push(i) }
+    out.push(onbInstrBranchLink(sym))
+    out.push(onbInstrMovImm64("x9", 0))
+    out.push(onbInstrCmp("x0", "x9"))
+    out.push(onbInstrCset("x9", OnbCond.OnbCondEq))
+    if instr.hasDest && !mirPlaceHasProjections(instr.dest) {
+        let dest = onbLocalSlotLookup(recv.state, instr.dest.local)
+        if dest.found {
+            out.push(onbInstrStore64Stack("x9", dest.offset))
+        }
+    }
+    onbMaterialiseOk(recv.state, out)
+}
+
+// === Map<K, V> type extractor =======================================
+
+// OnbMapKVResult bundles the extracted K and V type names plus an
+// `ok` flag for non-Map types.
+pub struct OnbMapKVResult {
+    pub key: String,
+    pub value: String,
+    pub ok: Bool,
+}
+
+// onbMapKeyValueTypes parses `Map<K, V>` (or `Map<K, list<...>>`)
+// into its K and V type names. Mirror of `mapKeyValueTypes`. The
+// Osty version walks the string char-by-char tracking nesting
+// depth so types like `Map<String, List<Int>>` resolve correctly
+// to ("String", "List<Int>").
+pub fn onbMapKeyValueTypes(typ: String) -> OnbMapKVResult {
+    // Must start with "Map<" and end with ">".
+    if !onbMapStartsWithMap(typ) {
+        return OnbMapKVResult { key: "", value: "", ok: false }
+    }
+    let inner = onbMapStripPrefix(typ, 4)  // strip "Map<"
+    let inner2 = onbMapStripTrailing(inner)
+    let parts = onbMapSplitTopLevelComma(inner2)
+    if parts.len() != 2 {
+        return OnbMapKVResult { key: "", value: "", ok: false }
+    }
+    OnbMapKVResult { key: parts[0], value: parts[1], ok: true }
+}
+
+// onbMapStartsWithMap reports whether the type string starts with
+// "Map<". We don't include `std.strings` in onb sources to keep
+// the dependency graph lean for the future LLVM self-host LLVMgen.
+fn onbMapStartsWithMap(typ: String) -> Bool {
+    let mut bytes: List<Int> = []
+    for b in typ.bytes() { bytes.push(b.toInt()) }
+    if bytes.len() < 4 { return false }
+    bytes[0] == 77 && bytes[1] == 97 && bytes[2] == 112 && bytes[3] == 60 // 'M' 'a' 'p' '<'
+}
+
+// onbMapStripPrefix drops the first `n` chars of `s`. The Osty
+// `String` API doesn't expose a slice helper, so we walk the chars
+// and skip the prefix. ASCII-only — fine for type-repr strings.
+fn onbMapStripPrefix(s: String, n: Int) -> String {
+    let mut out = ""
+    let mut i = 0
+    for ch in s.chars() {
+        if i >= n { out = out + "{ch}" }
+        i = i + 1
+    }
+    out
+}
+
+// onbMapStripTrailing drops the last char if it is '>'. Used after
+// the "Map<" prefix is gone — the remaining string ends with '>'
+// by construction (caller pre-checks the starts-with).
+fn onbMapStripTrailing(s: String) -> String {
+    let mut chars: List<String> = []
+    for ch in s.chars() { chars.push("{ch}") }
+    if chars.len() == 0 { return "" }
+    let last = chars[chars.len() - 1]
+    if last != ">" { return s }
+    let mut out = ""
+    for i in 0..chars.len() - 1 {
+        out = out + chars[i]
+    }
+    out
+}
+
+// onbMapSplitTopLevelComma splits the string at the first
+// top-level `,` (depth 0 with respect to `<` / `>`). Returns a
+// list of two trimmed parts on success, otherwise an empty list.
+fn onbMapSplitTopLevelComma(s: String) -> List<String> {
+    let mut depth = 0
+    let mut left = ""
+    let mut right = ""
+    let mut splitFound = false
+    for ch in s.chars() {
+        let cs = "{ch}"
+        if !splitFound && cs == "," && depth == 0 {
+            splitFound = true
+        } else {
+            if cs == "<" { depth = depth + 1 }
+            if cs == ">" { depth = depth - 1 }
+            if !splitFound { left = left + cs } else { right = right + cs }
+        }
+    }
+    let mut out: List<String> = []
+    if !splitFound { return out }
+    out.push(onbMapTrim(left))
+    out.push(onbMapTrim(right))
+    out
+}
+
+// onbMapTrim drops leading/trailing ASCII whitespace from a string.
+fn onbMapTrim(s: String) -> String {
+    let mut out = ""
+    let mut started = false
+    let mut buf = ""
+    for ch in s.chars() {
+        let cs = "{ch}"
+        if !started {
+            if cs == " " { continue }
+            started = true
+        }
+        buf = buf + cs
+    }
+    // Trim trailing whitespace.
+    let mut chars: List<String> = []
+    for ch in buf.chars() { chars.push("{ch}") }
+    let mut endIdx = chars.len()
+    for endIdx > 0 && chars[endIdx - 1] == " " {
+        endIdx = endIdx - 1
+    }
+    for i in 0..endIdx {
+        out = out + chars[i]
+    }
+    out
+}

--- a/toolchain/onb_intrinsic_test.osty
+++ b/toolchain/onb_intrinsic_test.osty
@@ -1,0 +1,292 @@
+// onb_intrinsic_test.osty — intrinsic dispatch tests.
+use std.testing
+
+// === Layout fixture =================================================
+
+fn iLayouts() -> MirLayoutTable { mirLayoutTable() }
+
+fn iFunc(name: String, returnType: String) -> MirFunction {
+    mirFunction(name, returnType, mirNoSpan())
+}
+
+fn iState(func: MirFunction) -> OnbLowerState {
+    onbNewLowerState(func, iLayouts())
+}
+
+// === Map<K,V> type extractor ========================================
+
+fn testOnbMapKeyValueTypesScalar() {
+    let r = onbMapKeyValueTypes("Map<Int, String>")
+    testing.assert(r.ok)
+    testing.assertEq(r.key, "Int")
+    testing.assertEq(r.value, "String")
+}
+
+fn testOnbMapKeyValueTypesNested() {
+    let r = onbMapKeyValueTypes("Map<String, List<Int>>")
+    testing.assert(r.ok)
+    testing.assertEq(r.key, "String")
+    testing.assertEq(r.value, "List<Int>")
+}
+
+fn testOnbMapKeyValueTypesNonMap() {
+    testing.assert(!onbMapKeyValueTypes("List<Int>").ok)
+    testing.assert(!onbMapKeyValueTypes("Int").ok)
+}
+
+// === Println ========================================================
+
+fn testOnbLowerPrintlnStringConst() {
+    let s = iState(iFunc("f", "()"))
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandConst(mirConstString("hello")))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicPrintln, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoadCStringAddress)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].label, "str0")
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrBranchLink)
+    testing.assertEq(r.instrs[1].symbol, "puts")
+}
+
+fn testOnbLowerPrintlnStringLocal() {
+    let func = iFunc("f", "()")
+    let id = mirFunctionNewLocal(func, "msg", "String", false, mirNoSpan())
+    let s = onbLocalSlotInsert(iState(func), id, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(id), "String"))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicPrintln, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 2)
+    testing.assertEq(r.instrs[0].kind, OnbInstrKind.OnbInstrLoad64Stack)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].offset, 8)
+    testing.assertEq(r.instrs[1].symbol, "puts")
+}
+
+// === ListPush / ListLen / ListIsEmpty ==============================
+
+fn testOnbLowerListPushI64() {
+    let func = iFunc("f", "()")
+    let lst = mirFunctionNewLocal(func, "xs", "List<Int>", false, mirNoSpan())
+    let s = onbLocalSlotInsert(iState(func), lst, 0)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(lst), "List<Int>"))
+    args.push(mirOperandConst(mirConstInt(7, "Int")))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicListPush, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    // ldr x0, [sp]; mov x1, #7; bl _list_push_i64
+    testing.assertEq(r.instrs.len(), 3)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[1].imm, 7)
+    testing.assertEq(r.instrs[2].symbol, "osty_rt_list_push_i64")
+}
+
+fn testOnbLowerListPushFloat() {
+    let func = iFunc("f", "()")
+    let lst = mirFunctionNewLocal(func, "xs", "List<Float>", false, mirNoSpan())
+    let v = mirFunctionNewLocal(func, "v", "Float", false, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, lst, 0)
+    s = onbLocalSlotInsert(s, v, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(lst), "List<Float>"))
+    args.push(mirOperandCopy(mirPlace(v), "Float"))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicListPush, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[2].symbol, "osty_rt_list_push_f64")
+    // Float arg lands in d0
+    testing.assertEq(r.instrs[1].kind, OnbInstrKind.OnbInstrLoadFloat64Stack)
+    testing.assertEq(r.instrs[1].dst, "d0")
+}
+
+fn testOnbLowerListLen() {
+    let func = iFunc("f", "Int")
+    let lst = mirFunctionNewLocal(func, "xs", "List<Int>", false, mirNoSpan())
+    let n = mirFunctionNewLocal(func, "n", "Int", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, lst, 0)
+    s = onbLocalSlotInsert(s, n, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(lst), "List<Int>"))
+    let instr = mirIntrinsicInstr(true, mirPlace(n), MirIntrinsicListLen, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs.len(), 3) // ldr x0; bl; str x0
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_list_len")
+    testing.assertEq(r.instrs[2].offset, 8)
+}
+
+fn testOnbLowerListIsEmpty() {
+    let func = iFunc("f", "Bool")
+    let lst = mirFunctionNewLocal(func, "xs", "List<Int>", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Bool", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, lst, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(lst), "List<Int>"))
+    let instr = mirIntrinsicInstr(true, mirPlace(b), MirIntrinsicListIsEmpty, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    // ldr x0; bl _list_len; mov x9, #0; cmp x0, x9; cset x9, eq; str x9, [sp, #8]
+    testing.assertEq(r.instrs.len(), 6)
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_list_len")
+    testing.assertEq(r.instrs[3].kind, OnbInstrKind.OnbInstrCmp)
+    testing.assertEq(r.instrs[4].kind, OnbInstrKind.OnbInstrCset)
+    testing.assertEq(r.instrs[4].cond, OnbCond.OnbCondEq)
+}
+
+// === StringLen / StringIsEmpty ======================================
+
+fn testOnbLowerStringLen() {
+    let func = iFunc("f", "Int")
+    let str = mirFunctionNewLocal(func, "s", "String", false, mirNoSpan())
+    let n = mirFunctionNewLocal(func, "n", "Int", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, str, 0)
+    s = onbLocalSlotInsert(s, n, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(str), "String"))
+    let instr = mirIntrinsicInstr(true, mirPlace(n), MirIntrinsicStringLen, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_strings_ByteLen")
+}
+
+fn testOnbLowerStringIsEmpty() {
+    let func = iFunc("f", "Bool")
+    let str = mirFunctionNewLocal(func, "s", "String", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Bool", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, str, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(str), "String"))
+    let instr = mirIntrinsicInstr(true, mirPlace(b), MirIntrinsicStringIsEmpty, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_strings_ByteLen")
+    testing.assertEq(r.instrs[4].cond, OnbCond.OnbCondEq)
+}
+
+// === Option ========================================================
+
+fn testOnbLowerOptionIsSome() {
+    let func = iFunc("f", "Bool")
+    let opt = mirFunctionNewLocal(func, "o", "Option<Int>", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Bool", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, opt, 0)
+    s = onbLocalSlotInsert(s, b, 16)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(opt), "Option<Int>"))
+    let instr = mirIntrinsicInstr(true, mirPlace(b), MirIntrinsicOptionIsSome, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    // ldr x9, [sp]; mov x10, #1; cmp x9, x10; cset x9, eq; str x9, [sp, #16]
+    testing.assertEq(r.instrs.len(), 5)
+    testing.assertEq(r.instrs[0].dst, "x9")
+    testing.assertEq(r.instrs[1].imm, 1)
+    testing.assertEq(r.instrs[3].cond, OnbCond.OnbCondEq)
+    testing.assertEq(r.instrs[4].offset, 16)
+}
+
+fn testOnbLowerOptionIsNone() {
+    let func = iFunc("f", "Bool")
+    let opt = mirFunctionNewLocal(func, "o", "Option<Int>", false, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, opt, 0)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(opt), "Option<Int>"))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicOptionIsNone, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[3].cond, OnbCond.OnbCondNe)
+}
+
+// === Map ============================================================
+
+fn testOnbLowerMapNew() {
+    let func = iFunc("f", "Map<String, Int>")
+    let dest = mirFunctionNewLocal(func, "m", "Map<String, Int>", true, mirNoSpan())
+    let s = onbLocalSlotInsert(iState(func), dest, 0)
+    let instr = mirIntrinsicInstr(true, mirPlace(dest), MirIntrinsicMapNew, [], mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    // mov x0, #5 (string); mov x1, #1 (i64); mov x2, #8; mov x3, #0;
+    // bl _osty_rt_map_new; str x0, [sp]
+    testing.assertEq(r.instrs.len(), 6)
+    testing.assertEq(r.instrs[0].dst, "x0")
+    testing.assertEq(r.instrs[0].imm, onbAbiKindString())  // 5
+    testing.assertEq(r.instrs[1].dst, "x1")
+    testing.assertEq(r.instrs[1].imm, onbAbiKindI64())     // 1
+    testing.assertEq(r.instrs[2].imm, 8)                    // value_size
+    testing.assertEq(r.instrs[3].imm, 0)                    // trace=NULL
+    testing.assertEq(r.instrs[4].symbol, "osty_rt_map_new")
+}
+
+fn testOnbLowerMapLen() {
+    let func = iFunc("f", "Int")
+    let m = mirFunctionNewLocal(func, "m", "Map<String, Int>", false, mirNoSpan())
+    let n = mirFunctionNewLocal(func, "n", "Int", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, m, 0)
+    s = onbLocalSlotInsert(s, n, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(m), "Map<String, Int>"))
+    let instr = mirIntrinsicInstr(true, mirPlace(n), MirIntrinsicMapLen, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[1].symbol, "osty_rt_map_len")
+}
+
+fn testOnbLowerMapContainsString() {
+    let func = iFunc("f", "Bool")
+    let m = mirFunctionNewLocal(func, "m", "Map<String, Int>", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Bool", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, m, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(m), "Map<String, Int>"))
+    args.push(mirOperandConst(mirConstString("k")))
+    let instr = mirIntrinsicInstr(true, mirPlace(b), MirIntrinsicMapContains, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    // ldr x0; adrp+add x1; bl _map_contains_string; str x0
+    testing.assertEq(r.instrs.len(), 4)
+    testing.assertEq(r.instrs[2].symbol, "osty_rt_map_contains_string")
+}
+
+fn testOnbLowerMapRemoveInt() {
+    let func = iFunc("f", "Bool")
+    let m = mirFunctionNewLocal(func, "m", "Map<Int, Int>", false, mirNoSpan())
+    let b = mirFunctionNewLocal(func, "b", "Bool", true, mirNoSpan())
+    let mut s = iState(func)
+    s = onbLocalSlotInsert(s, m, 0)
+    s = onbLocalSlotInsert(s, b, 8)
+    let mut args: List<MirOperand> = []
+    args.push(mirOperandCopy(mirPlace(m), "Map<Int, Int>"))
+    args.push(mirOperandConst(mirConstInt(42, "Int")))
+    let instr = mirIntrinsicInstr(true, mirPlace(b), MirIntrinsicMapRemove, args, mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(r.ok)
+    testing.assertEq(r.instrs[2].symbol, "osty_rt_map_remove_i64")
+}
+
+// === Unsupported intrinsic ==========================================
+
+fn testOnbLowerIntrinsicMapSetNotSupported() {
+    // map_set lives in a future slice (needs scratch reservation).
+    let s = iState(iFunc("f", "()"))
+    let instr = mirIntrinsicInstr(false, mirPlace(-1), MirIntrinsicMapSet, [], mirNoSpan())
+    let r = onbLowerIntrinsic(s, instr)
+    testing.assert(!r.ok)
+}


### PR DESCRIPTION
## Summary

Slice I of the ONB self-host port. Mirrors the intrinsic dispatch
cluster from \`internal/onb/lower.go\` into the
\`toolchain/onb_*.osty\` self-host mirror.

- \`lowerIntrinsic\` → \`onbLowerIntrinsic\`: top-level dispatch by
  \`MirIntrinsicKind\`
- println (string const + string local cases — Int/Float defer to
  a follow-up that adds Mach-O vararg shuffle)
- list_push (type-dispatched i64/i1/f64/string/ptr), list_len,
  list_is_empty
- string_len, string_is_empty
- option_is_some / option_is_none via shared
  \`onbLowerOptionDiscriminantCompare\` (load disc → cmp → cset)
- map_new (4-arg ctor with K/V kind + value_size + trace=NULL),
  map_len, map_contains, map_remove via shared
  \`onbLowerMapBoolReturn\`
- shared \`onbLowerSimpleIntReturn\` (receiver→x0, bl, capture x0)
  and \`onbLowerEmptyCheck\` (length+cset eq) helpers
- \`onbMapKeyValueTypes\` parses \`Map<K, V>\` strings with nested
  generic support (\`Map<String, List<Int>>\` →
  ("String", "List<Int>"))

## Test plan

- [x] \`osty check ./toolchain\` green
- [x] \`go test ./internal/onb -short\` green
- [x] 16 Osty tests covering each intrinsic path: println string
      const + string local, list_push i64 / f64, list_len,
      list_is_empty, string_len, string_is_empty, option_is_some,
      option_is_none, map_new with type dispatch verification,
      map_len, map_contains_string, map_remove_i64, plus
      Map<K,V> type extractor (scalar / nested / non-Map) and the
      unsupported-intrinsic sentinel for map_set.

## Notes

731 LOC (439 source + 292 test).

Deferred to a follow-up slice: \`map_set\` / \`map_get\` (need
scratch-slot reservation in the frame planner for the \`&value\`
runtime ABI), Int/Float println cases, IndexProj-based \`xs[i]\`
operand materialisation (operand-side, not intrinsic-side).

\`internal/onb/lower.go\` remains the production runtime per Slice A's
frozen-mirror pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)