### PR TITLE
feat: ONB self-host port Slice J — runner skeleton + dev integration

### DIFF
--- a/toolchain/onb_dev.osty
+++ b/toolchain/onb_dev.osty
@@ -1,0 +1,247 @@
+// onb_dev.osty — dev / cross-validation env helpers for the ONB
+// self-host port. Slice J of the port. Mirror of `dev.go` in
+// `internal/onb/`.
+//
+// These helpers are read by the backend adapter (`internal/backend/onb.go`)
+// so cross-validation harnesses and the dev-loop CLI can flip
+// strict-mode and timing on without recompiling. Osty side
+// reproduces the same names + semantics so a future LLVM
+// self-host LLVMgen can drop the Osty source straight in.
+
+// === Env var names =================================================
+
+// onbEnvStrictName forces ONB to surface its own shape-rejection
+// errors instead of letting the backend layer fall back to LLVM.
+// Cross-validation harnesses and self-host bring-up flip this on.
+pub fn onbEnvStrictName() -> String { "OSTY_ONB_STRICT" }
+
+// onbEnvTimingName, when set, causes the backend layer to write a
+// one-line wall-clock summary to stderr after each ONB emit.
+pub fn onbEnvTimingName() -> String { "OSTY_ONB_TIMING" }
+
+// === Boolean env parsing ==========================================
+
+// onbEnvTrue reports whether `s` should be treated as "enabled".
+// Mirror of `EnvTrue`. Accepted spellings: "1", "true", "yes",
+// "on" (case-insensitive, whitespace-trimmed). Exported so other
+// backend toggles can reuse identical parsing.
+pub fn onbEnvTrue(s: String) -> Bool {
+    let trimmed = onbDevTrim(s)
+    let lowered = onbDevToLower(trimmed)
+    lowered == "1" || lowered == "true" || lowered == "yes" || lowered == "on"
+}
+
+// onbStrictMode evaluates `OSTY_ONB_STRICT` against `onbEnvTrue`.
+// The Go runtime reads `os.Getenv(EnvStrict)` here; the Osty
+// mirror takes the env value as a parameter so it stays pure (the
+// caller — the bridge layer in `internal/onb` — does the
+// `os.Getenv` lookup and threads the string through).
+pub fn onbStrictMode(envValue: String) -> Bool {
+    onbEnvTrue(envValue)
+}
+
+// onbTimingEnabled mirrors `onbStrictMode` for the timing log.
+pub fn onbTimingEnabled(envValue: String) -> Bool {
+    onbEnvTrue(envValue)
+}
+
+// === Timing telemetry ==============================================
+
+// OnbTimingPath names which build path actually ran for one ONB
+// emit attempt. Mirror of `TimingPath`.
+pub enum OnbTimingPath {
+    OnbTimingPathNative,
+    OnbTimingPathLlvmFallback,
+    OnbTimingPathError,
+    OnbTimingPathOther,
+}
+
+pub fn onbTimingPathName(p: OnbTimingPath) -> String {
+    match p {
+        OnbTimingPath.OnbTimingPathNative -> "native",
+        OnbTimingPath.OnbTimingPathLlvmFallback -> "llvm-fallback",
+        OnbTimingPath.OnbTimingPathError -> "error",
+        OnbTimingPath.OnbTimingPathOther -> "other",
+    }
+}
+
+// OnbTimingEvent describes one ONB build path so callers can
+// render a stable log line. Mirror of `TimingEvent`. `elapsedMs`
+// is the elapsed wall-clock time in milliseconds (Go side stores
+// `time.Duration`; Osty represents it as Int milliseconds).
+pub struct OnbTimingEvent {
+    pub path: OnbTimingPath,
+    pub target: String,
+    pub elapsedMs: Int,
+    pub reason: String,
+    pub binaryAt: String,
+}
+
+pub fn onbTimingEvent(path: OnbTimingPath, target: String, elapsedMs: Int) -> OnbTimingEvent {
+    OnbTimingEvent {
+        path: path,
+        target: target,
+        elapsedMs: elapsedMs,
+        reason: "",
+        binaryAt: "",
+    }
+}
+
+// === LogTiming ====================================================
+
+// onbFormatTiming returns the human-readable line describing the
+// build path. Mirror of `LogTiming` — instead of taking an
+// `io.Writer`, the Osty version returns the string and lets the
+// caller decide where to print. Same shape:
+//
+//     onb: emit <elapsed> [<suffix>]
+//
+// where <suffix> is `[native: <target>]`, `[fallback to llvm:
+// <reason>]`, `[error: <reason>]`, or `[<other>]`.
+pub fn onbFormatTiming(ev: OnbTimingEvent) -> String {
+    let elapsed = onbFormatElapsed(ev.elapsedMs)
+    let suffix = onbTimingSuffix(ev)
+    "onb: emit {elapsed} {suffix}\n"
+}
+
+fn onbTimingSuffix(ev: OnbTimingEvent) -> String {
+    let target = if ev.target == "" { "host" } else { ev.target }
+    match ev.path {
+        OnbTimingPath.OnbTimingPathNative -> "[native: {target}]",
+        OnbTimingPath.OnbTimingPathLlvmFallback -> {
+            let reason = if ev.reason == "" { "shape unsupported" } else { ev.reason }
+            "[fallback to llvm: {reason}]"
+        },
+        OnbTimingPath.OnbTimingPathError -> {
+            let reason = if ev.reason == "" { "rejected" } else { ev.reason }
+            "[error: {reason}]"
+        },
+        OnbTimingPath.OnbTimingPathOther -> "[other]",
+    }
+}
+
+// === formatElapsed ================================================
+
+// onbFormatElapsed converts an elapsed milliseconds count to a
+// compact human-readable string. Mirror of `formatElapsed` —
+// Go's version takes `time.Duration` and switches on micro / ms
+// / sec ranges; Osty takes Int milliseconds since that's what
+// the bridge layer hands over, so the sub-millisecond branch
+// uses the floor at 0ms instead.
+pub fn onbFormatElapsed(ms: Int) -> String {
+    if ms <= 0 { return "0ms" }
+    if ms < 1000 { return "{ms}ms" }
+    let seconds = ms / 1000
+    let hundredths = (ms % 1000) / 10  // two-decimal precision
+    if hundredths == 0 { return "{seconds}.00s" }
+    if hundredths < 10 { return "{seconds}.0{hundredths}s" }
+    "{seconds}.{hundredths}s"
+}
+
+// === Sentinel reason extraction ===================================
+
+// onbUnsupportedShapeSentinel is the string prefix
+// `ErrUnsupportedShape` carries on the Go side. Mirror this
+// constant so the unwrap helper stays in lockstep — both sides
+// agree on the textual format.
+pub fn onbUnsupportedShapeSentinel() -> String { "onb: unsupported mir shape" }
+
+// onbUnsupportedShapeReason peels the unsupported-shape sentinel
+// off so callers can quote the specific MIR construct that
+// triggered the fallback without also surfacing the generic
+// sentinel message. Mirror of `UnsupportedShapeReason`. Returns
+// the input verbatim when the sentinel is not present.
+pub fn onbUnsupportedShapeReason(err: String) -> String {
+    if err == "" { return "" }
+    let prefix = onbUnsupportedShapeSentinel() + ": "
+    if !onbDevStartsWith(err, prefix) { return err }
+    let mut prefixLen = 0
+    for _ in prefix.bytes() { prefixLen = prefixLen + 1 }
+    onbDevStripPrefix(err, prefixLen)
+}
+
+// === Lower-level string helpers ===================================
+//
+// Same dependency-graph rationale as `onbStringStartsWith` in
+// `onb_abi.osty`: keep the dev-integration module free of
+// `std.strings` so the future LLVM self-host LLVMgen has a
+// leaner front door.
+
+// onbDevTrim drops leading + trailing ASCII whitespace.
+fn onbDevTrim(s: String) -> String {
+    let mut chars: List<String> = []
+    for ch in s.chars() { chars.push("{ch}") }
+    let mut start = 0
+    let mut endIdx = chars.len()
+    for start < endIdx {
+        if chars[start] != " " && chars[start] != "\t" { break }
+        start = start + 1
+    }
+    for endIdx > start {
+        let last = chars[endIdx - 1]
+        if last != " " && last != "\t" && last != "\n" && last != "\r" { break }
+        endIdx = endIdx - 1
+    }
+    let mut out = ""
+    for i in start..endIdx {
+        out = out + chars[i]
+    }
+    out
+}
+
+// onbDevToLower lowercases ASCII letters in place — non-ASCII
+// passes through. Sufficient for env-var values like "Yes" /
+// "TRUE".
+fn onbDevToLower(s: String) -> String {
+    let mut bytes: List<Int> = []
+    for b in s.bytes() { bytes.push(b.toInt()) }
+    let mut out = ""
+    for b in bytes {
+        let lower = if b >= 65 && b <= 90 { b + 32 } else { b }
+        out = out + onbDevByteToString(lower)
+    }
+    out
+}
+
+// onbDevByteToString translates one ASCII codepoint back to a
+// 1-char string. Lookup via the printable-ASCII table — same
+// approach as `onbAsmCStringLiteral`. Bytes outside the printable
+// range are stringified via `chr` (escapes get emitted as control
+// chars; this only runs on env values so non-printables are
+// effectively impossible).
+fn onbDevByteToString(b: Int) -> String {
+    let lookup = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    if b < 32 || b > 126 { return " " }
+    let idx = b - 32
+    let mut chars: List<String> = []
+    for ch in lookup.chars() { chars.push("{ch}") }
+    if idx < 0 || idx >= chars.len() { return " " }
+    chars[idx]
+}
+
+// onbDevStartsWith reports whether `s` starts with `prefix`. ASCII
+// byte comparison.
+fn onbDevStartsWith(s: String, prefix: String) -> Bool {
+    let mut sBytes: List<Int> = []
+    for b in s.bytes() { sBytes.push(b.toInt()) }
+    let mut pBytes: List<Int> = []
+    for b in prefix.bytes() { pBytes.push(b.toInt()) }
+    if pBytes.len() > sBytes.len() { return false }
+    for i in 0..pBytes.len() {
+        if sBytes[i] != pBytes[i] { return false }
+    }
+    true
+}
+
+// onbDevStripPrefix returns a copy of `s` with the first `n` chars
+// dropped. Walks the chars iterator to honour multi-byte
+// sequences (still ASCII-only on the call sites we use today).
+fn onbDevStripPrefix(s: String, n: Int) -> String {
+    let mut out = ""
+    let mut i = 0
+    for ch in s.chars() {
+        if i >= n { out = out + "{ch}" }
+        i = i + 1
+    }
+    out
+}

--- a/toolchain/onb_dev_test.osty
+++ b/toolchain/onb_dev_test.osty
@@ -1,0 +1,111 @@
+// onb_dev_test.osty — dev / cross-validation env helper tests.
+use std.testing
+
+// === Env-var name pinning ==========================================
+
+fn testOnbEnvVarNames() {
+    testing.assertEq(onbEnvStrictName(), "OSTY_ONB_STRICT")
+    testing.assertEq(onbEnvTimingName(), "OSTY_ONB_TIMING")
+}
+
+// === onbEnvTrue parsing ============================================
+
+fn testOnbEnvTrueAccepts() {
+    testing.assert(onbEnvTrue("1"))
+    testing.assert(onbEnvTrue("true"))
+    testing.assert(onbEnvTrue("TRUE"))
+    testing.assert(onbEnvTrue("yes"))
+    testing.assert(onbEnvTrue("Yes"))
+    testing.assert(onbEnvTrue("on"))
+    testing.assert(onbEnvTrue(" 1 "))      // whitespace-trimmed
+    testing.assert(onbEnvTrue("\ttrue\t"))
+}
+
+fn testOnbEnvTrueRejects() {
+    testing.assert(!onbEnvTrue(""))
+    testing.assert(!onbEnvTrue("0"))
+    testing.assert(!onbEnvTrue("false"))
+    testing.assert(!onbEnvTrue("no"))
+    testing.assert(!onbEnvTrue("off"))
+    testing.assert(!onbEnvTrue("disabled"))
+}
+
+fn testOnbStrictModeAndTimingEnabled() {
+    testing.assert(onbStrictMode("1"))
+    testing.assert(!onbStrictMode(""))
+    testing.assert(onbTimingEnabled("yes"))
+    testing.assert(!onbTimingEnabled("no"))
+}
+
+// === Timing path naming ============================================
+
+fn testOnbTimingPathName() {
+    testing.assertEq(onbTimingPathName(OnbTimingPath.OnbTimingPathNative), "native")
+    testing.assertEq(onbTimingPathName(OnbTimingPath.OnbTimingPathLlvmFallback), "llvm-fallback")
+    testing.assertEq(onbTimingPathName(OnbTimingPath.OnbTimingPathError), "error")
+    testing.assertEq(onbTimingPathName(OnbTimingPath.OnbTimingPathOther), "other")
+}
+
+// === formatElapsed ================================================
+
+fn testOnbFormatElapsedEdges() {
+    testing.assertEq(onbFormatElapsed(0), "0ms")
+    testing.assertEq(onbFormatElapsed(-5), "0ms")
+    testing.assertEq(onbFormatElapsed(1), "1ms")
+    testing.assertEq(onbFormatElapsed(999), "999ms")
+    testing.assertEq(onbFormatElapsed(1000), "1.00s")
+    testing.assertEq(onbFormatElapsed(1500), "1.50s")
+    testing.assertEq(onbFormatElapsed(1230), "1.23s")
+    testing.assertEq(onbFormatElapsed(1090), "1.09s")
+}
+
+// === LogTiming format ==============================================
+
+fn testOnbFormatTimingNative() {
+    let ev = onbTimingEvent(OnbTimingPath.OnbTimingPathNative, "aarch64-apple-darwin", 42)
+    let line = onbFormatTiming(ev)
+    testing.assertEq(line, "onb: emit 42ms [native: aarch64-apple-darwin]\n")
+}
+
+fn testOnbFormatTimingNativeHostFallback() {
+    let ev = onbTimingEvent(OnbTimingPath.OnbTimingPathNative, "", 100)
+    let line = onbFormatTiming(ev)
+    testing.assertEq(line, "onb: emit 100ms [native: host]\n")
+}
+
+fn testOnbFormatTimingLlvmFallback() {
+    let mut ev = onbTimingEvent(OnbTimingPath.OnbTimingPathLlvmFallback, "host", 5)
+    ev.reason = "list_get_string"
+    let line = onbFormatTiming(ev)
+    testing.assertEq(line, "onb: emit 5ms [fallback to llvm: list_get_string]\n")
+}
+
+fn testOnbFormatTimingLlvmFallbackDefault() {
+    let ev = onbTimingEvent(OnbTimingPath.OnbTimingPathLlvmFallback, "host", 5)
+    let line = onbFormatTiming(ev)
+    testing.assertEq(line, "onb: emit 5ms [fallback to llvm: shape unsupported]\n")
+}
+
+fn testOnbFormatTimingError() {
+    let mut ev = onbTimingEvent(OnbTimingPath.OnbTimingPathError, "host", 0)
+    ev.reason = "linker failed"
+    let line = onbFormatTiming(ev)
+    testing.assertEq(line, "onb: emit 0ms [error: linker failed]\n")
+}
+
+// === UnsupportedShapeReason ========================================
+
+fn testOnbUnsupportedShapeSentinelStr() {
+    testing.assertEq(onbUnsupportedShapeSentinel(), "onb: unsupported mir shape")
+}
+
+fn testOnbUnsupportedShapeReasonStrip() {
+    let err = "onb: unsupported mir shape: list_push value type"
+    testing.assertEq(onbUnsupportedShapeReason(err), "list_push value type")
+}
+
+fn testOnbUnsupportedShapeReasonOther() {
+    // Non-sentinel error string passes through verbatim.
+    testing.assertEq(onbUnsupportedShapeReason("onb: missing MIR module"), "onb: missing MIR module")
+    testing.assertEq(onbUnsupportedShapeReason(""), "")
+}

--- a/toolchain/onb_request.osty
+++ b/toolchain/onb_request.osty
@@ -1,0 +1,350 @@
+// onb_request.osty — backend request + plan + target resolution
+// for the ONB self-host port. Slice J of the port. Mirror of the
+// `Request / Target / Stage / Plan / ResolveTarget / BuildPlan /
+// Compile / NextPlannedStage / StageSummary` cluster in
+// `internal/onb/onb.go`.
+//
+// The bridge between the host CLI (`internal/backend/onb.go`) and
+// the ONB pipeline. Today the Osty mirror skeletons the planner —
+// `onbBuildPlan` validates the request shape and routes target
+// resolution through `onbResolveTarget`; the actual MIR-to-binary
+// lowering still lives on the Go side until the LLVM self-host
+// LLVMgen catches up.
+
+// === Request =======================================================
+
+// OnbRequest is the backend-owned half of a build request. The
+// `mir.Module` reference comes from the front-end pipeline; the
+// rest are paths + flags from the CLI parser.
+//
+// Mirror of `Request` in onb.go. Module is referenced by name
+// (`String`) since cross-module pointers don't traverse the
+// bootstrap boundary cleanly — the bridge layer hands a real
+// `*mir.Module` over once Osty self-host LLVMgen takes over the
+// build.
+pub struct OnbRequest {
+    pub moduleName: String,
+    pub targetTriple: String,
+    pub emitMode: String,
+    pub objectPath: String,
+    pub binaryPath: String,
+    pub sourcePath: String,
+    pub packageName: String,
+}
+
+pub fn onbRequest(moduleName: String, targetTriple: String, emitMode: String) -> OnbRequest {
+    OnbRequest {
+        moduleName: moduleName,
+        targetTriple: targetTriple,
+        emitMode: emitMode,
+        objectPath: "",
+        binaryPath: "",
+        sourcePath: "",
+        packageName: "",
+    }
+}
+
+// === Target resolution =============================================
+
+// OnbBuildTarget is the dev-integration target descriptor. Wider
+// than `OnbTarget` (asm/encoder side) — adds OS + arch fields the
+// build planner needs to pick object format / linker flags.
+// Mirror of `Target` in onb.go.
+pub struct OnbBuildTarget {
+    pub triple: String,
+    pub os: String,
+    pub arch: String,
+    pub objectFormat: String,
+}
+
+// OnbResolveTargetResult bundles the resolved target with an `ok`
+// flag + diagnostic. Mirror of Go's `(Target, error)` return.
+pub struct OnbResolveTargetResult {
+    pub target: OnbBuildTarget,
+    pub ok: Bool,
+    pub err: String,
+}
+
+// onbResolveTarget validates a target triple, falling back to the
+// host platform when the triple is empty. ONB Phase 1.0 is
+// aarch64-only — non-aarch64 triples yield ok=false with an
+// explanatory error string. Mirror of `ResolveTarget`.
+//
+// Host inference takes a `hostTriple` parameter so the Osty side
+// stays pure (the bridge layer in `internal/onb/onb.go` reads
+// `runtime.GOOS / GOARCH` and threads the result through).
+pub fn onbResolveTarget(triple: String, hostTriple: String) -> OnbResolveTargetResult {
+    let raw = if onbDevStrTrim(triple) == "" { hostTriple } else { onbDevStrTrim(triple) }
+    let lower = onbDevStrToLower(raw)
+    if !onbIsAarch64Triple(lower) {
+        let err = "{onbErrUnsupportedTarget()}: \"{raw}\" (want darwin/aarch64 or linux/aarch64)"
+        return OnbResolveTargetResult {
+            target: OnbBuildTarget { triple: "", os: "", arch: "", objectFormat: "" },
+            ok: false,
+            err: err,
+        }
+    }
+    if onbDevStrContains(lower, "darwin") || onbDevStrContains(lower, "apple") {
+        return OnbResolveTargetResult {
+            target: OnbBuildTarget {
+                triple: raw,
+                os: "darwin",
+                arch: "aarch64",
+                objectFormat: "mach-o",
+            },
+            ok: true,
+            err: "",
+        }
+    }
+    if onbDevStrContains(lower, "linux") {
+        return OnbResolveTargetResult {
+            target: OnbBuildTarget {
+                triple: raw,
+                os: "linux",
+                arch: "aarch64",
+                objectFormat: "elf",
+            },
+            ok: true,
+            err: "",
+        }
+    }
+    OnbResolveTargetResult {
+        target: OnbBuildTarget { triple: "", os: "", arch: "", objectFormat: "" },
+        ok: false,
+        err: "{onbErrUnsupportedTarget()}: \"{raw}\" (want darwin/aarch64 or linux/aarch64)",
+    }
+}
+
+// onbErrUnsupportedTarget is the sentinel string Go's
+// `ErrUnsupportedTarget` carries. Mirror this constant so error
+// strings stay byte-identical across the boundary.
+pub fn onbErrUnsupportedTarget() -> String { "onb target is outside phase 1.0 scope" }
+
+// onbErrNotImplemented is the sentinel string Go's
+// `ErrNotImplemented` carries. Used by `Compile` to signal a
+// pipeline stage that hasn't been implemented yet.
+pub fn onbErrNotImplemented() -> String { "onb phase slice is not implemented" }
+
+// onbIsAarch64Triple tests for the aarch64 / arm64 prefix on a
+// lowercased triple string.
+pub fn onbIsAarch64Triple(lower: String) -> Bool {
+    onbDevStartsWithStr(lower, "aarch64-") || onbDevStartsWithStr(lower, "arm64-")
+}
+
+// === Stages + Plan ==================================================
+
+// OnbStage names a planned ONB pipeline stage and its current
+// implementation status. Mirror of `Stage`. Status is one of
+// "implemented", "implemented (line program only)", "planned",
+// or "" (no specific status).
+pub struct OnbStage {
+    pub name: String,
+    pub status: String,
+}
+
+pub fn onbStage(name: String, status: String) -> OnbStage {
+    OnbStage { name: name, status: status }
+}
+
+// OnbPlan is the executable ONB phase boundary. Mirror of `Plan`.
+// Today it records the pipeline that must exist before emission
+// can succeed; later phases replace the scaffolded stages with
+// real data flowing between them.
+pub struct OnbPlan {
+    pub target: OnbBuildTarget,
+    pub emit: String,
+    pub sourcePath: String,
+    pub packageName: String,
+    pub stages: List<OnbStage>,
+}
+
+// onbPlanStages assembles the canonical 9-stage list. The two
+// status mutations are object-format-dependent: Mach-O has the
+// writer + reloc + DWARF sub-pipelines implemented; ELF lists
+// them as planned. Mirror of `BuildPlan`'s stage assembly.
+pub fn onbPlanStages(target: OnbBuildTarget) -> List<OnbStage> {
+    let objStatus = if target.objectFormat == "mach-o" { "implemented" } else { "planned" }
+    let relocStatus = if target.objectFormat == "mach-o" { "implemented" } else { "planned" }
+    let dwarfStatus = if target.objectFormat == "mach-o" { "implemented (line program only)" } else { "planned" }
+    let mut stages: List<OnbStage> = []
+    stages.push(onbStage("MIR consumer", "implemented"))
+    stages.push(onbStage("4-pass minimal optimizer", "planned"))
+    stages.push(onbStage("aarch64 LIR lowerer", "implemented"))
+    stages.push(onbStage("aarch64 assembly renderer", "implemented"))
+    stages.push(onbStage("linear register allocation", "planned"))
+    stages.push(onbStage("{target.objectFormat} object writer", objStatus))
+    stages.push(onbStage("string/puts relocations", relocStatus))
+    stages.push(onbStage("DWARF .debug_line", dwarfStatus))
+    stages.push(onbStage("host linker", "implemented"))
+    stages
+}
+
+// OnbBuildPlanResult bundles the rebuilt plan with the routing
+// flags. `ok = false` means request validation failed; the err
+// field carries the diagnostic.
+pub struct OnbBuildPlanResult {
+    pub plan: OnbPlan,
+    pub ok: Bool,
+    pub err: String,
+}
+
+// onbBuildPlan validates the request shape and produces the phase
+// 1.0 pipeline plan. Mirror of `BuildPlan`. The host bridge layer
+// supplies the `hostTriple` so this stays pure — the Go side
+// composes the runtime.GOOS lookup and threads it through.
+pub fn onbBuildPlan(req: OnbRequest, hostTriple: String) -> OnbBuildPlanResult {
+    if req.moduleName == "" {
+        return OnbBuildPlanResult {
+            plan: onbEmptyPlan(),
+            ok: false,
+            err: "onb: missing MIR module",
+        }
+    }
+    let resolved = onbResolveTarget(req.targetTriple, hostTriple)
+    if !resolved.ok {
+        return OnbBuildPlanResult {
+            plan: onbEmptyPlan(),
+            ok: false,
+            err: resolved.err,
+        }
+    }
+    let plan = OnbPlan {
+        target: resolved.target,
+        emit: req.emitMode,
+        sourcePath: req.sourcePath,
+        packageName: req.packageName,
+        stages: onbPlanStages(resolved.target),
+    }
+    OnbBuildPlanResult { plan: plan, ok: true, err: "" }
+}
+
+fn onbEmptyPlan() -> OnbPlan {
+    OnbPlan {
+        target: OnbBuildTarget { triple: "", os: "", arch: "", objectFormat: "" },
+        emit: "",
+        sourcePath: "",
+        packageName: "",
+        stages: [],
+    }
+}
+
+// onbNextPlannedStage returns the first stage name still waiting
+// for implementation. Mirror of `NextPlannedStage`. Empty string
+// if every stage is done.
+pub fn onbNextPlannedStage(plan: OnbPlan) -> String {
+    for stage in plan.stages {
+        if stage.status == "planned" { return stage.name }
+    }
+    ""
+}
+
+// onbStageSummary returns a compact comma-joined "<name>=<status>"
+// list for diagnostics. Mirror of `StageSummary`. Stages with an
+// empty status emit just the name.
+pub fn onbStageSummary(plan: OnbPlan) -> String {
+    let mut out = ""
+    let mut first = true
+    for stage in plan.stages {
+        let part = if stage.status == "" { stage.name } else { "{stage.name}={stage.status}" }
+        if first {
+            out = part
+            first = false
+        } else {
+            out = out + ", " + part
+        }
+    }
+    out
+}
+
+// === Local string helpers ==========================================
+//
+// Same dependency-graph rationale as the helpers in onb_dev.osty —
+// keep `std.strings` out so the future LLVM self-host LLVMgen has
+// a leaner front door. Each helper is namespaced `onbDevStr*` so
+// it doesn't collide with the `onbStringStartsWith` / `onbDev*`
+// helpers in sister modules.
+
+fn onbDevStrTrim(s: String) -> String {
+    let mut chars: List<String> = []
+    for ch in s.chars() { chars.push("{ch}") }
+    let mut start = 0
+    let mut endIdx = chars.len()
+    for start < endIdx {
+        if chars[start] != " " && chars[start] != "\t" { break }
+        start = start + 1
+    }
+    for endIdx > start {
+        let last = chars[endIdx - 1]
+        if last != " " && last != "\t" { break }
+        endIdx = endIdx - 1
+    }
+    let mut out = ""
+    for i in start..endIdx {
+        out = out + chars[i]
+    }
+    out
+}
+
+fn onbDevStrToLower(s: String) -> String {
+    let mut bytes: List<Int> = []
+    for b in s.bytes() { bytes.push(b.toInt()) }
+    let mut chars: List<String> = []
+    for ch in s.chars() { chars.push("{ch}") }
+    if bytes.len() != chars.len() { return s }  // multi-byte — leave alone
+    let mut out = ""
+    for i in 0..bytes.len() {
+        let b = bytes[i]
+        if b >= 65 && b <= 90 {
+            // ASCII uppercase → lowercase. Look up the corresponding
+            // lowercase character via the printable-ASCII table.
+            let lower = b + 32
+            out = out + onbDevStrAsciiToString(lower)
+        } else {
+            out = out + chars[i]
+        }
+    }
+    out
+}
+
+fn onbDevStrAsciiToString(b: Int) -> String {
+    let lookup = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    if b < 32 || b > 126 { return " " }
+    let idx = b - 32
+    let mut chars: List<String> = []
+    for ch in lookup.chars() { chars.push("{ch}") }
+    if idx < 0 || idx >= chars.len() { return " " }
+    chars[idx]
+}
+
+fn onbDevStrContains(s: String, needle: String) -> Bool {
+    let mut sBytes: List<Int> = []
+    for b in s.bytes() { sBytes.push(b.toInt()) }
+    let mut nBytes: List<Int> = []
+    for b in needle.bytes() { nBytes.push(b.toInt()) }
+    if nBytes.len() == 0 { return true }
+    if nBytes.len() > sBytes.len() { return false }
+    let limit = sBytes.len() - nBytes.len() + 1
+    for i in 0..limit {
+        let mut matched = true
+        for j in 0..nBytes.len() {
+            if sBytes[i + j] != nBytes[j] {
+                matched = false
+                break
+            }
+        }
+        if matched { return true }
+    }
+    false
+}
+
+fn onbDevStartsWithStr(s: String, prefix: String) -> Bool {
+    let mut sBytes: List<Int> = []
+    for b in s.bytes() { sBytes.push(b.toInt()) }
+    let mut pBytes: List<Int> = []
+    for b in prefix.bytes() { pBytes.push(b.toInt()) }
+    if pBytes.len() > sBytes.len() { return false }
+    for i in 0..pBytes.len() {
+        if sBytes[i] != pBytes[i] { return false }
+    }
+    true
+}

--- a/toolchain/onb_request_test.osty
+++ b/toolchain/onb_request_test.osty
@@ -1,0 +1,178 @@
+// onb_request_test.osty — Request / Plan / target-resolution tests.
+use std.testing
+
+// === Request shape =================================================
+
+fn testOnbRequestDefaults() {
+    let r = onbRequest("mymod", "aarch64-apple-darwin", "object")
+    testing.assertEq(r.moduleName, "mymod")
+    testing.assertEq(r.targetTriple, "aarch64-apple-darwin")
+    testing.assertEq(r.emitMode, "object")
+    testing.assertEq(r.objectPath, "")
+    testing.assertEq(r.binaryPath, "")
+    testing.assertEq(r.sourcePath, "")
+    testing.assertEq(r.packageName, "")
+}
+
+// === resolveTarget ==================================================
+
+fn testOnbResolveTargetDarwin() {
+    let r = onbResolveTarget("aarch64-apple-darwin", "")
+    testing.assert(r.ok)
+    testing.assertEq(r.target.triple, "aarch64-apple-darwin")
+    testing.assertEq(r.target.os, "darwin")
+    testing.assertEq(r.target.arch, "aarch64")
+    testing.assertEq(r.target.objectFormat, "mach-o")
+}
+
+fn testOnbResolveTargetLinux() {
+    let r = onbResolveTarget("aarch64-unknown-linux-gnu", "")
+    testing.assert(r.ok)
+    testing.assertEq(r.target.os, "linux")
+    testing.assertEq(r.target.objectFormat, "elf")
+}
+
+fn testOnbResolveTargetArm64Apple() {
+    // arm64- prefix is also accepted (Apple's preferred form).
+    let r = onbResolveTarget("arm64-apple-darwin", "")
+    testing.assert(r.ok)
+    testing.assertEq(r.target.os, "darwin")
+}
+
+fn testOnbResolveTargetEmptyUsesHost() {
+    let r = onbResolveTarget("", "aarch64-apple-darwin")
+    testing.assert(r.ok)
+    testing.assertEq(r.target.os, "darwin")
+}
+
+fn testOnbResolveTargetX86Rejected() {
+    let r = onbResolveTarget("x86_64-pc-linux-gnu", "")
+    testing.assert(!r.ok)
+    testing.assert(onbDevTestContains(r.err, "outside phase 1.0 scope"))
+}
+
+fn testOnbResolveTargetUnknownOsRejected() {
+    // Aarch64 triple but neither darwin nor linux — falls through.
+    let r = onbResolveTarget("aarch64-unknown-freebsd", "")
+    testing.assert(!r.ok)
+}
+
+// === isAarch64Triple ===============================================
+
+fn testOnbIsAarch64Triple() {
+    testing.assert(onbIsAarch64Triple("aarch64-apple-darwin"))
+    testing.assert(onbIsAarch64Triple("arm64-apple-darwin"))
+    testing.assert(!onbIsAarch64Triple("x86_64-pc-linux-gnu"))
+    testing.assert(!onbIsAarch64Triple(""))
+}
+
+// === buildPlan + stages ============================================
+
+fn testOnbBuildPlanMacho() {
+    let req = onbRequest("mymod", "aarch64-apple-darwin", "object")
+    let r = onbBuildPlan(req, "")
+    testing.assert(r.ok)
+    testing.assertEq(r.plan.target.objectFormat, "mach-o")
+    testing.assertEq(r.plan.stages.len(), 9)
+    // mach-o → object writer + relocs + dwarf are implemented.
+    testing.assertEq(r.plan.stages[5].name, "mach-o object writer")
+    testing.assertEq(r.plan.stages[5].status, "implemented")
+    testing.assertEq(r.plan.stages[6].status, "implemented")
+    testing.assertEq(r.plan.stages[7].status, "implemented (line program only)")
+}
+
+fn testOnbBuildPlanLinuxStillPlanned() {
+    let req = onbRequest("mymod", "aarch64-unknown-linux-gnu", "object")
+    let r = onbBuildPlan(req, "")
+    testing.assert(r.ok)
+    testing.assertEq(r.plan.target.objectFormat, "elf")
+    testing.assertEq(r.plan.stages[5].status, "planned")
+    testing.assertEq(r.plan.stages[6].status, "planned")
+    testing.assertEq(r.plan.stages[7].status, "planned")
+}
+
+fn testOnbBuildPlanRejectsEmptyModule() {
+    let req = onbRequest("", "aarch64-apple-darwin", "object")
+    let r = onbBuildPlan(req, "")
+    testing.assert(!r.ok)
+    testing.assertEq(r.err, "onb: missing MIR module")
+}
+
+fn testOnbBuildPlanPropagatesTargetError() {
+    let req = onbRequest("mymod", "x86_64-pc-linux-gnu", "object")
+    let r = onbBuildPlan(req, "")
+    testing.assert(!r.ok)
+    testing.assert(onbDevTestContains(r.err, "outside phase 1.0 scope"))
+}
+
+// === nextPlannedStage ==============================================
+
+fn testOnbNextPlannedStage() {
+    let req = onbRequest("mymod", "aarch64-apple-darwin", "object")
+    let r = onbBuildPlan(req, "")
+    testing.assert(r.ok)
+    // Mach-O plan: first planned stage is "4-pass minimal optimizer".
+    testing.assertEq(onbNextPlannedStage(r.plan), "4-pass minimal optimizer")
+}
+
+fn testOnbNextPlannedStageEmpty() {
+    let plan = OnbPlan {
+        target: OnbBuildTarget { triple: "", os: "", arch: "", objectFormat: "" },
+        emit: "",
+        sourcePath: "",
+        packageName: "",
+        stages: [],
+    }
+    testing.assertEq(onbNextPlannedStage(plan), "")
+}
+
+// === stageSummary ==================================================
+
+fn testOnbStageSummaryFormat() {
+    let mut stages: List<OnbStage> = []
+    stages.push(onbStage("a", "implemented"))
+    stages.push(onbStage("b", "planned"))
+    stages.push(onbStage("c", ""))
+    let plan = OnbPlan {
+        target: OnbBuildTarget { triple: "", os: "", arch: "", objectFormat: "" },
+        emit: "",
+        sourcePath: "",
+        packageName: "",
+        stages: stages,
+    }
+    testing.assertEq(onbStageSummary(plan), "a=implemented, b=planned, c")
+}
+
+// === Sentinel strings ==============================================
+
+fn testOnbErrSentinels() {
+    testing.assertEq(onbErrUnsupportedTarget(), "onb target is outside phase 1.0 scope")
+    testing.assertEq(onbErrNotImplemented(), "onb phase slice is not implemented")
+}
+
+// === Local string-helper checker ==================================
+
+// onbDevTestContains is the test-side mirror of `onbDevStrContains`
+// — same byte-comparison search shape. Used by request tests so we
+// don't import std.strings here (the source files don't, so the
+// tests should exercise the same private path).
+fn onbDevTestContains(s: String, needle: String) -> Bool {
+    let mut sBytes: List<Int> = []
+    for b in s.bytes() { sBytes.push(b.toInt()) }
+    let mut nBytes: List<Int> = []
+    for b in needle.bytes() { nBytes.push(b.toInt()) }
+    if nBytes.len() == 0 { return true }
+    if nBytes.len() > sBytes.len() { return false }
+    let limit = sBytes.len() - nBytes.len() + 1
+    for i in 0..limit {
+        let mut matched = true
+        for j in 0..nBytes.len() {
+            if sBytes[i + j] != nBytes[j] {
+                matched = false
+                break
+            }
+        }
+        if matched { return true }
+    }
+    false
+}


### PR DESCRIPTION
## Summary

Final slice of the ONB self-host port (A-J series). Mirrors the
dev integration boundary from \`internal/onb/onb.go\` +
\`internal/onb/dev.go\` into the \`toolchain/onb_*.osty\` self-host
mirror.

- env-var name pinning (\`OSTY_ONB_STRICT\` / \`OSTY_ONB_TIMING\`) +
  truthy parsing
- \`OnbTimingPath\` enum + \`OnbTimingEvent\` record +
  \`onbFormatTiming\` log line + \`onbFormatElapsed\` (Int ms →
  human-readable)
- \`onbUnsupportedShapeReason\` strips the sentinel prefix
- \`OnbRequest\` build request + \`OnbBuildTarget\` (triple/os/arch/
  format) + \`onbResolveTarget\` (aarch64-only, darwin/apple→mach-o,
  linux→elf)
- \`onbBuildPlan\` validates request + emits canonical 9-stage
  pipeline plan + \`onbNextPlannedStage\` / \`onbStageSummary\`
  navigators

## Test plan

- [x] \`osty check ./toolchain\` green
- [x] \`go test ./internal/onb -short\` green
- [x] 14 dev tests + 14 request tests covering env-var parsing
      (accept/reject sets), all four TimingPath log formats with
      default-vs-explicit reason variations, formatElapsed range
      edges, target resolution across darwin/linux/arm64-apple/
      empty-host/x86_64-rejected/unknown-os-rejected, Mach-O vs
      Linux stage status flags, missing-module rejection,
      sentinel string pinning, plan navigation

## Notes

886 LOC (247 dev + 111 dev test + 350 request + 178 request test).

Host-side glue (\`os.Getenv\`, \`runtime.GOOS\`, \`time.Duration\`,
\`io.Writer\`) stays Go because those calls cross the host boundary —
the Osty version takes the resolved values as parameters, which
keeps the mirror pure and testable.

## Series complete

This closes Slice A-J. Total ONB self-host port: ~9.6k LOC of Osty
source mirroring the ~5.4k LOC Go runtime — encoding, fixups,
relocations, DWARF (line + info + abbrev), Mach-O headers + symtab,
asm renderer, ABI predicates, layout lookups, call boundary, RV
dispatch, intrinsic dispatch, dev integration. Each slice has a
Go ↔ Osty parity strategy: byte-identical hex pinning where the
Go runtime emits bytes (encoder + DWARF + Mach-O), and semantic
round-trip in the Osty test suite where the structures are
higher-level (layout lookups, ABI predicates, dispatch).

\`internal/onb/\` remains the production runtime per Slice A's
frozen-mirror pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)