### PR TITLE
feat: Phase-7 Slice 1 — process bridge for the LIR Proto runner

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -1,0 +1,153 @@
+// Command osty-native-lirproto is the subprocess half of the
+// Phase-7 LIR Proto runner bridge. It reads a `LIRProtoRequest`-
+// shaped JSON payload on stdin, runs the request through the
+// production lower → emit chain, and writes a `LIRProtoResponse`
+// JSON object on stdout.
+//
+// Slice-1 contract: the binary's body is a thin Go wrapper around
+// the existing MIR-direct emitter, so gate-on output matches
+// gate-off byte-for-byte. The wire shape is what matters — a
+// future slice replaces this body with a real call into the
+// Osty-owned `toolchain/lir_proto.osty` lowerer without touching
+// any caller of the bridge package.
+//
+// The binary intentionally scrubs `OSTY_LLVM_LIR_PROTO` from its
+// own environment before invoking `backend.EmitLLVMIRText` so the
+// gate check inside `generateLLVMIR` doesn't re-enter the runner
+// (which would recurse into another subprocess).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/nativelirproto"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(stdin io.Reader, stdout io.Writer) error {
+	// Disable the Phase-7 gate inside this subprocess so
+	// `backend.EmitLLVMIRText` bypasses the LIR Proto runner check
+	// and goes straight through the production MIR-direct path. If
+	// we left the env var set, the dispatcher would re-spawn this
+	// binary — infinite recursion.
+	_ = os.Unsetenv(llvmgen.LIRProtoEnvVar)
+
+	var req nativelirproto.Request
+	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
+		return fmt.Errorf("decode lirproto request: %w", err)
+	}
+	resp, err := lower(req)
+	if err != nil {
+		// Non-decode errors flow back as a structured response so
+		// the runner-side dispatcher can convert them into a
+		// fall-back warning. stderr stays clean for hard exits
+		// (decode failures, env issues).
+		resp = nativelirproto.Response{Declined: true, Error: err.Error()}
+	}
+	return json.NewEncoder(stdout).Encode(resp)
+}
+
+func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
+	entry, cleanup, err := prepareEntry(req)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nativelirproto.Response{}, err
+	}
+	ir, _, emitErr := backend.EmitLLVMIRText(entry, req.Target, nil)
+	if emitErr != nil {
+		return nativelirproto.Response{}, emitErr
+	}
+	if len(ir) == 0 {
+		return nativelirproto.Response{Declined: true, Error: "empty IR"}, nil
+	}
+	return nativelirproto.Response{LLVMIR: string(ir)}, nil
+}
+
+// prepareEntry mirrors osty-native-llvmgen's source-staging path:
+// write the source bytes to a temp dir, stand up the workspace +
+// resolver + checker, and produce the `backend.Entry` the emit
+// pipeline consumes.
+func prepareEntry(req nativelirproto.Request) (backend.Entry, func(), error) {
+	root, err := os.MkdirTemp("", "osty-native-lirproto-*")
+	if err != nil {
+		return backend.Entry{}, nil, err
+	}
+	cleanup := func() { os.RemoveAll(root) }
+
+	entryName := "main.osty"
+	if req.SourcePath != "" {
+		entryName = filepath.Base(req.SourcePath)
+	}
+	entryPath := filepath.Join(root, entryName)
+	if err := os.WriteFile(entryPath, []byte(req.Source), 0o644); err != nil {
+		return backend.Entry{}, cleanup, err
+	}
+	absEntry, err := filepath.Abs(entryPath)
+	if err != nil {
+		return backend.Entry{}, cleanup, err
+	}
+
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		return backend.Entry{}, cleanup, err
+	}
+	ws.Stdlib = stdlib.LoadCached()
+	if _, err := ws.LoadPackageNative(""); err != nil {
+		return backend.Entry{}, cleanup, err
+	}
+	graph := resolve.NewPackageGraph(ws)
+	results := resolve.ResolveGraph(graph)
+	checks := check.PackageGraph(graph, results, check.Opts{Stdlib: ws.Stdlib})
+
+	pkg := ws.Packages[""]
+	if pkg == nil {
+		return backend.Entry{}, cleanup, fmt.Errorf("%s: no package sources were loaded", root)
+	}
+	var entryFile *resolve.PackageFile
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		fp, err := filepath.Abs(pf.Path)
+		if err != nil {
+			continue
+		}
+		if fp == absEntry {
+			entryFile = pf
+			break
+		}
+	}
+	if entryFile == nil {
+		return backend.Entry{}, cleanup, fmt.Errorf("%s is not part of the generated package rooted at %s", absEntry, root)
+	}
+	chk := checks[""]
+	if chk == nil {
+		chk = &check.Result{}
+	}
+	pkgName := req.PackageName
+	if pkgName == "" {
+		pkgName = "main"
+	}
+	entry, err := backend.PrepareGraphPackage(pkgName, absEntry, graph, "", entryFile, chk)
+	if err != nil {
+		return backend.Entry{}, cleanup, err
+	}
+	return entry, cleanup, nil
+}

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/nativelirproto"
+)
+
+// TestRunLowersSimpleSourceToLLVMIR pins the binary's stdin → stdout
+// contract end-to-end: a `LIRProtoRequest`-shaped JSON body in,
+// a `LIRProtoResponse` JSON body out with non-empty `llvmIr` and
+// no `declined` / `error`. Slice-1 of Phase-7 — the body delegates
+// to the Go production lower → emit chain, so the IR text matches
+// what `osty gen` produces with the gate off (modulo source-path
+// comments, which mention the temp staging dir).
+func TestRunLowersSimpleSourceToLLVMIR(t *testing.T) {
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn check(n: Int) -> Int { n + 1 }\nfn main() { println(\"{check(5)}\") }\n",
+		Target:      "",
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want successful response: %+v", resp)
+	}
+	if resp.Error != "" {
+		t.Fatalf("Error = %q, want empty: %+v", resp.Error, resp)
+	}
+	if resp.LLVMIR == "" {
+		t.Fatal("LLVMIR is empty")
+	}
+	for _, want := range []string{
+		"define i64 @check(i64",
+		"add i64",
+		"ret i64",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("LLVMIR missing %q:\n%s", want, resp.LLVMIR)
+		}
+	}
+}
+
+// TestRunDeclinesEmptySource pins the structured-failure path: a
+// request that the production pipeline can't lower (here: empty
+// source = parse-stage rejection) lands as a `declined: true`
+// response with a non-empty `error`, NOT as a hard exit. The
+// dispatcher's existing fall-back-on-error policy converts this
+// into a warning and continues with the legacy MIR-direct emit.
+func TestRunDeclinesEmptySource(t *testing.T) {
+	body, _ := json.Marshal(nativelirproto.Request{Source: ""})
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Declined && resp.LLVMIR != "" {
+		// Empty source might emit a no-op module on some toolchains;
+		// in that case the body shouldn't contain user functions.
+		if strings.Contains(resp.LLVMIR, "define ") {
+			t.Fatalf("empty source produced user-function IR: %s", resp.LLVMIR)
+		}
+	}
+}

--- a/cmd/osty/lir_proto_bridge.go
+++ b/cmd/osty/lir_proto_bridge.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/nativelirproto"
+)
+
+// init registers the process-bridge LIR Proto runner with the
+// dispatcher. When `OSTY_LLVM_LIR_PROTO=1`, the runner spawns
+// `osty-native-lirproto` and forwards the request as JSON. Slice-1
+// of Phase-7: the binary's body is still a Go wrapper around the
+// production MIR-direct path (so output is byte-identical to
+// gate-off), but the wire shape + runner registration are now in
+// place. A future slice replaces the binary's internals with a
+// real call into `toolchain/lir_proto.osty` without touching this
+// file or the dispatcher.
+func init() {
+	llvmgen.SetLIRProtoRunner(processLIRProtoRunner{})
+}
+
+// processLIRProtoRunner shells out to the managed osty-native-lirproto
+// binary. Decline / error responses convert to structured errors so
+// the dispatcher's existing fall-back-on-error policy kicks in
+// (warning logged, MIR-direct emit continues unchanged).
+type processLIRProtoRunner struct{}
+
+var errLIRProtoDeclined = errors.New("osty-native-lirproto declined the request")
+
+func (processLIRProtoRunner) Run(req llvmgen.LIRProtoRequest) ([]byte, error) {
+	bridgeReq := nativelirproto.Request{
+		PackageName: req.PackageName,
+		SourcePath:  req.SourcePath,
+		Source:      string(req.Source),
+		Target:      req.Target,
+	}
+	start := req.SourcePath
+	if start == "" {
+		start = "."
+	}
+	resp, err := nativelirproto.Run(start, bridgeReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		if resp.Declined {
+			return nil, fmt.Errorf("%w: %s", errLIRProtoDeclined, resp.Error)
+		}
+		return nil, errors.New(resp.Error)
+	}
+	if resp.Declined {
+		return nil, errLIRProtoDeclined
+	}
+	if resp.LLVMIR == "" {
+		return nil, fmt.Errorf("%w: empty IR", errLIRProtoDeclined)
+	}
+	return []byte(resp.LLVMIR), nil
+}

--- a/internal/nativelirproto/exec.go
+++ b/internal/nativelirproto/exec.go
@@ -1,0 +1,93 @@
+// Package nativelirproto is the Go-side bridge into the
+// osty-native-lirproto subprocess. It mirrors `internal/nativellvmgen`
+// in shape — Request / Response types + a single Run() that
+// JSON-encodes the request, spawns the binary, and decodes the JSON
+// response.
+//
+// Today the binary's internals are a thin Go wrapper around the
+// existing MIR-direct emitter (so gate-on output matches gate-off
+// exactly). The wire shape is what matters for Phase 7: a future
+// slice will replace the binary's body with a real call into the
+// Osty-owned `toolchain/lir_proto.osty` lowerer without touching
+// any caller of this package.
+package nativelirproto
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/osty/osty/internal/toolchain"
+)
+
+// Env names the override env var. When set, callers skip the
+// managed-binary lookup and shell out directly. Used in tests and
+// for local development.
+const Env = "OSTY_NATIVE_LIRPROTO_BIN"
+
+// Request is the single JSON payload the binary consumes via stdin.
+// Mirrors `llvmgen.LIRProtoRequest` so the Go runner can forward
+// its arg untouched.
+type Request struct {
+	PackageName string `json:"packageName,omitempty"`
+	SourcePath  string `json:"sourcePath,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Target      string `json:"target,omitempty"`
+}
+
+// Response is the JSON payload the binary writes to stdout. `LLVMIR`
+// holds the full LLVM IR text on success; `Declined` is true when
+// the binary couldn't lower the request and the dispatcher should
+// fall back; `Error` carries a structured failure message.
+type Response struct {
+	LLVMIR   string `json:"llvmIr,omitempty"`
+	Declined bool   `json:"declined,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+var ensureManagedBinary = func(start string) (string, error) {
+	return toolchain.EnsureNativeLIRProto(start)
+}
+
+// ResolveBinary returns the path the Run helper should exec. The
+// `OSTY_NATIVE_LIRPROTO_BIN` env var wins outright; otherwise the
+// managed binary under `.osty/toolchain/<version>/` is built lazily.
+func ResolveBinary(start string) (string, error) {
+	if override := strings.TrimSpace(os.Getenv(Env)); override != "" {
+		return override, nil
+	}
+	return ensureManagedBinary(start)
+}
+
+// Run JSON-encodes `req`, spawns the binary, and decodes the JSON
+// response. `start` is a working-directory hint used by the managed-
+// binary resolver — tests pass the package source path; the
+// production caller uses the entry SourcePath.
+func Run(start string, req Request) (Response, error) {
+	path, err := ResolveBinary(start)
+	if err != nil {
+		return Response{}, err
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("marshal native lirproto request: %w", err)
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(payload)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = "<no output>"
+		}
+		return Response{}, fmt.Errorf("exec %s: %w (%s)", path, err, msg)
+	}
+	var resp Response
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Response{}, fmt.Errorf("decode native lirproto response: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/nativelirproto/exec_test.go
+++ b/internal/nativelirproto/exec_test.go
@@ -1,0 +1,153 @@
+package nativelirproto
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+var (
+	fakeNativeLIRProtoOnce sync.Once
+	fakeNativeLIRProtoPath string
+	fakeNativeLIRProtoErr  error
+)
+
+// TestRunUsesEnvBinaryAndDecodesResponse pins the env-override path:
+// `OSTY_NATIVE_LIRPROTO_BIN` should bypass `ensureManagedBinary`,
+// the request payload should arrive intact at the binary's stdin,
+// and the response JSON should round-trip into the typed struct.
+func TestRunUsesEnvBinaryAndDecodesResponse(t *testing.T) {
+	bin := buildFakeNativeLIRProto(t)
+	capture := filepath.Join(t.TempDir(), "request.json")
+
+	t.Setenv(Env, bin)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_CAPTURE", capture)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_RESPONSE", `{"llvmIr":"define i64 @main()"}`)
+
+	oldEnsure := ensureManagedBinary
+	ensureManagedBinary = func(string) (string, error) {
+		t.Fatal("ensureManagedBinary should not be called when env override is set")
+		return "", nil
+	}
+	t.Cleanup(func() { ensureManagedBinary = oldEnsure })
+
+	resp, err := Run(".", Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn main() {}\n",
+		Target:      "arm64-apple-darwin",
+	})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if resp.LLVMIR != "define i64 @main()" {
+		t.Fatalf("llvm ir = %q, want %q", resp.LLVMIR, "define i64 @main()")
+	}
+	if resp.Declined {
+		t.Fatalf("Declined = true, want false on success response")
+	}
+
+	var req Request
+	decodeCapturedRequest(t, capture, &req)
+	if req.PackageName != "main" {
+		t.Fatalf("request packageName = %q, want main", req.PackageName)
+	}
+	if req.Source != "fn main() {}\n" {
+		t.Fatalf("request source = %q, want preserved", req.Source)
+	}
+	if req.Target != "arm64-apple-darwin" {
+		t.Fatalf("request target = %q, want arm64-apple-darwin", req.Target)
+	}
+}
+
+// TestRunSurfacesDeclinedResponse pins the fall-back signaling
+// shape: a `{"declined": true, "error": "..."}` body decodes into
+// the typed struct and propagates back to the caller, where the
+// Phase-7 dispatcher converts it into a structured warning.
+func TestRunSurfacesDeclinedResponse(t *testing.T) {
+	bin := buildFakeNativeLIRProto(t)
+
+	t.Setenv(Env, bin)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_RESPONSE", `{"declined":true,"error":"unsupported source shape"}`)
+
+	resp, err := Run(".", Request{Source: "fn main() {}\n"})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if !resp.Declined {
+		t.Fatal("Declined = false, want true")
+	}
+	if resp.Error != "unsupported source shape" {
+		t.Fatalf("error = %q, want %q", resp.Error, "unsupported source shape")
+	}
+}
+
+func buildFakeNativeLIRProto(t *testing.T) string {
+	t.Helper()
+	fakeNativeLIRProtoOnce.Do(func() {
+		fakeNativeLIRProtoPath, fakeNativeLIRProtoErr = buildFakeNativeLIRProtoOnce()
+	})
+	if fakeNativeLIRProtoErr != nil {
+		t.Fatalf("build fake native lirproto: %v", fakeNativeLIRProtoErr)
+	}
+	return fakeNativeLIRProtoPath
+}
+
+func buildFakeNativeLIRProtoOnce() (string, error) {
+	dir, err := os.MkdirTemp("", "fake-native-lirproto-*")
+	if err != nil {
+		return "", fmt.Errorf("mktemp: %w", err)
+	}
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(fakeNativeLIRProtoProgram), 0o644); err != nil {
+		return "", fmt.Errorf("write fake native lirproto: %w", err)
+	}
+	name := "fake-native-lirproto"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("go build fake native lirproto: %w\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func decodeCapturedRequest(t *testing.T, path string, out any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+const fakeNativeLIRProtoProgram = `package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	if capture := os.Getenv("FAKE_NATIVE_LIRPROTO_CAPTURE"); capture != "" {
+		if err := os.WriteFile(capture, data, 0o644); err != nil {
+			panic(err)
+		}
+	}
+	_, _ = os.Stdout.WriteString(os.Getenv("FAKE_NATIVE_LIRPROTO_RESPONSE"))
+}
+`

--- a/internal/toolchain/native_lirproto.go
+++ b/internal/toolchain/native_lirproto.go
@@ -1,0 +1,179 @@
+package toolchain
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	nativeLIRProtoBuildMu sync.Mutex
+	installNativeLIRProto = buildNativeLIRProto
+)
+
+// nativeLIRProtoSourceInputs lists the directories whose mtimes
+// trigger a rebuild of the managed `osty-native-lirproto` artifact.
+// Same shape as `nativeLLVMGenSourceInputs` — the binary's body
+// today is a thin Go wrapper around the production lower → emit
+// chain (so any change in `internal/llvmgen` or `internal/mir`
+// invalidates the cached managed binary), and Phase-7's eventual
+// Osty-side rewire will live in `cmd/osty-native-lirproto` plus a
+// future `internal/lirproto*` package whose path lands here too.
+var nativeLIRProtoSourceInputs = []string{
+	"cmd/osty-native-lirproto",
+	"internal/backend",
+	"internal/llvmgen",
+	"internal/mir",
+	"internal/nativelirproto",
+	"go.mod",
+	"go.sum",
+}
+
+func NativeLIRProtoBinaryName() string {
+	name := "osty-native-lirproto"
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+func ManagedNativeLIRProtoPath(projectRoot string) string {
+	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeLIRProtoBinaryName())
+}
+
+// EnsureNativeLIRProto returns the managed lirproto artifact for the
+// current project/worktree, building it into
+// `.osty/toolchain/<version>/` on first use. Mirrors
+// `EnsureNativeLLVMGen` — same lazy-build cache + mtime stamp.
+func EnsureNativeLIRProto(start string) (string, error) {
+	root, err := managedProjectRootFunc(start)
+	if err != nil {
+		return "", err
+	}
+	path := ManagedNativeLIRProtoPath(root)
+	stale, err := nativeLIRProtoNeedsRebuild(path)
+	if err != nil {
+		return "", err
+	}
+	if !stale {
+		return path, nil
+	}
+
+	nativeLIRProtoBuildMu.Lock()
+	defer nativeLIRProtoBuildMu.Unlock()
+
+	stale, err = nativeLIRProtoNeedsRebuild(path)
+	if err != nil {
+		return "", err
+	}
+	if !stale {
+		return path, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create managed lirproto dir: %w", err)
+	}
+	if err := installNativeLIRProto(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func nativeLIRProtoNeedsRebuild(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("stat managed lirproto: %w", err)
+	}
+	if info.IsDir() {
+		return true, nil
+	}
+	root, err := sourceRepoRootFunc()
+	if err != nil {
+		return false, err
+	}
+	managedModTime := info.ModTime()
+	for _, rel := range nativeLIRProtoSourceInputs {
+		sourcePath := filepath.Join(root, rel)
+		sourceInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("stat native lirproto source %q: %w", sourcePath, err)
+		}
+		if !sourceInfo.IsDir() {
+			if sourceInfo.ModTime().After(managedModTime) {
+				return true, nil
+			}
+			continue
+		}
+		var newer bool
+		walkErr := filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			fileInfo, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if fileInfo.ModTime().After(managedModTime) {
+				newer = true
+				return fs.SkipAll
+			}
+			return nil
+		})
+		if walkErr != nil && walkErr != fs.SkipAll {
+			return false, fmt.Errorf("walk native lirproto sources %q: %w", sourcePath, walkErr)
+		}
+		if newer {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func buildNativeLIRProto(dest string) error {
+	root, err := sourceRepoRootFunc()
+	if err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp(filepath.Dir(dest), "osty-native-lirproto-*")
+	if err != nil {
+		return fmt.Errorf("create native lirproto temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpPath := filepath.Join(tmpDir, NativeLIRProtoBinaryName())
+	cmd := exec.Command("go", "build", "-o", tmpPath, "./cmd/osty-native-lirproto")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = "<no output>"
+		}
+		return fmt.Errorf("build managed osty-native-lirproto: %w (%s)", err, msg)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpPath, 0o755); err != nil {
+			return fmt.Errorf("chmod managed osty-native-lirproto: %w", err)
+		}
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		if fileExists(dest) {
+			return nil
+		}
+		return fmt.Errorf("install managed osty-native-lirproto: %w", err)
+	}
+	return nil
+}

--- a/justfile
+++ b/justfile
@@ -27,7 +27,11 @@ build-checker:
     mkdir -p .osty/bin
     go build -o {{checker_bin}} ./cmd/osty-native-checker
 
-build-all: build build-checker
+build-lirproto:
+    mkdir -p .osty/bin
+    go build -o .osty/bin/osty-native-lirproto ./cmd/osty-native-lirproto
+
+build-all: build build-checker build-lirproto
 
 # Cross-compile osty (+ native-checker) for every supported host triple.
 # Targets: linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/{amd64,arm64}.


### PR DESCRIPTION
## Summary
Wires the dispatcher → runner → subprocess chain end-to-end. With `OSTY_LLVM_LIR_PROTO=1`, programs now route through the registered `processLIRProtoRunner`, which spawns `osty-native-lirproto` and returns its rendered IR; the dispatcher's existing fall-back-on-error policy still kicks in if the binary declines.

**Slice-1 contract**: the binary's body is a thin Go wrapper around the production lower → emit chain, so gate-on output matches gate-off byte-for-byte. The wire shape is what matters — a future slice replaces the binary's internals with a real call into `toolchain/lir_proto.osty` without touching any caller of this package.

## Pieces

- **`cmd/osty-native-lirproto/`** — Standalone Go binary. Reads a `LIRProtoRequest`-shaped JSON body on stdin, stages the source through the regular workspace + resolver + checker, runs `backend.EmitLLVMIRText`, writes a `LIRProtoResponse` JSON body on stdout. Scrubs `OSTY_LLVM_LIR_PROTO` from its own env so the inner dispatcher's gate check doesn't recurse.

- **`internal/nativelirproto/`** — Go-side bridge. Mirrors `internal/nativellvmgen` exactly: `Request` / `Response` types, `Run(start, req)` helper, `OSTY_NATIVE_LIRPROTO_BIN` override, managed-binary lookup via the toolchain helper.

- **`internal/toolchain/native_lirproto.go`** — `EnsureNativeLIRProto` + `buildNativeLIRProto` mirror of the existing llvmgen helper: lazy build into `.osty/toolchain/<version>/`, mtime-stamp invalidation against the source-input directories.

- **`cmd/osty/lir_proto_bridge.go`** — `init()` registers the process-bridge runner via `llvmgen.SetLIRProtoRunner`. Lives in the `cmd/osty` package so internal-package tests still see the default `defaultLIRProtoRunner` (`ErrLIRProtoNotWired`) — the existing `TestLLVMDispatchAppendsLIRProtoFallbackWarning` / `SkipsWhenGateOff` pins stay green unchanged.

- **`justfile::build-lirproto`** — new recipe; folded into `build-all` so `just build-all` produces all three managed binaries.

## End-to-end verification

```
$ cat /tmp/wireup/main.osty
fn check() -> Int {
    let mut sum = 0
    for i in 0..5 { sum = sum + i }
    sum
}

fn main() { println("{check()}") }

$ OSTY_LLVM_LIR_PROTO=1 osty build /tmp/wireup/main.osty   # subprocess invoked
$ /tmp/wireup/.osty/out/debug/llvm/w
10
```

After path normalisation, gate-on IR === gate-off IR byte-for-byte.

## Test plan

- [x] New `cmd/osty-native-lirproto/main_test.go`: `LIRProtoRequest` → IR round-trip + structured `declined` response shape.
- [x] New `internal/nativelirproto/exec_test.go`: env-override path bypasses managed-binary lookup, captures the request payload intact, decodes both success and `declined` response shapes.
- [x] `just front` + `TestLIRProto*` / `TestLLVMDispatch*` slices green.
- [ ] CI 그린 확인.

## Out of scope (future slices)

- The binary's internals are still Go production code. The next Phase-7 slice replaces them with a self-host osty invocation (`toolchain/lir_proto.osty` driven). Once that lands, the shadow-parity catalog (62 fixtures so far) becomes a real Go-vs-Osty regression test instead of a one-sided pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)