### PR TITLE
feat(stdlib-inject): pull in stdlib globals reachable from injected bodies

### DIFF
--- a/internal/backend/llvm_strings_compare_test.go
+++ b/internal/backend/llvm_strings_compare_test.go
@@ -143,3 +143,67 @@ fn main() {
 		t.Fatalf("user callsite not rewritten: still have strings.%v in IR", leftover)
 	}
 }
+
+// TestPrepareEntryInjectsStdlibGlobalsWhenFlagOn verifies that the
+// body-injection pipeline pulls in stdlib `pub let` definitions
+// (top-level globals) referenced by injected fn bodies. Concrete case:
+// `strings.graphemes` chains through `graphemeBreakProperty` which
+// reads `graphemeBreakCR` (a `pub let`) — without this pass the
+// emitted `.ll` references `@graphemeBreakCR` undefined and clang
+// fails at link time.
+//
+// The verification is structural: after PrepareEntry, the user
+// module's IR must contain at least one mangled
+// `osty_std_strings__graphemeBreak*` LetDecl, and no injected fn
+// body may still carry a bare `Ident{Kind: IdentGlobal, Name:
+// "graphemeBreakCR"}` — every reference must resolve to the
+// mangled name.
+func TestPrepareEntryInjectsStdlibGlobalsWhenFlagOn(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	req := newBackendRequest(t, EmitBinary, `use std.strings
+
+fn main() {
+    let n = strings.graphemes("hi").len()
+    println(n)
+}
+`)
+	if req.Entry.IR == nil {
+		t.Fatalf("entry.IR is nil")
+	}
+	letNames := map[string]bool{}
+	for _, d := range req.Entry.IR.Decls {
+		ld, ok := d.(*ir.LetDecl)
+		if !ok || ld == nil {
+			continue
+		}
+		letNames[ld.Name] = true
+	}
+	foundMangledLet := false
+	for n := range letNames {
+		if strings.HasPrefix(n, "osty_std_strings__graphemeBreak") {
+			foundMangledLet = true
+			break
+		}
+	}
+	if !foundMangledLet {
+		names := make([]string, 0, len(letNames))
+		for n := range letNames {
+			names = append(names, n)
+		}
+		t.Fatalf("expected at least one osty_std_strings__graphemeBreak* LetDecl in entry.IR; have lets: %v", names)
+	}
+	var unmangled []string
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		id, ok := n.(*ir.Ident)
+		if !ok || id == nil || id.Kind != ir.IdentGlobal {
+			return true
+		}
+		if strings.HasPrefix(id.Name, "graphemeBreak") && !strings.HasPrefix(id.Name, "osty_std_strings__graphemeBreak") {
+			unmangled = append(unmangled, id.Name)
+		}
+		return true
+	}), req.Entry.IR)
+	if len(unmangled) > 0 {
+		t.Fatalf("injected bodies still carry unmangled global Idents: %v", unmangled)
+	}
+}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -402,6 +402,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			out = append(out, lowered)
 			rewriteBareIdentCalls(next.fn, callName, lowered.Name)
 			queue = append(queue, loweredFromModule{module: next.module, fn: lowered})
+			loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: next.module, fn: lowered})
 		}
 		for _, ref := range sortedQualifiedStdlibCallRefs(next.fn) {
 			calleeModule := stdlibModuleNameFromQualifier(ref.Qualifier)
@@ -434,6 +435,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			out = append(out, lowered)
 			rewriteQualifiedStdlibCalls(next.fn, ref.Qualifier, ref.Name, lowered.Name)
 			queue = append(queue, loweredFromModule{module: calleeModule, fn: lowered})
+			loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: calleeModule, fn: lowered})
 		}
 		for _, m := range reachableStdlibMethodsInFn(next.fn, reg) {
 			if m.Fn == nil || m.Fn.Body == nil {
@@ -457,10 +459,83 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			out = append(out, freeFn)
 			rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
 			queue = append(queue, loweredFromModule{module: m.Module, fn: freeFn})
+			loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: m.Module, fn: freeFn})
+		}
+	}
+	// Globals closure: every injected fn body that reads a stdlib
+	// top-level `let` (e.g. std.strings' `graphemeBreakCR` Int
+	// constant referenced by `graphemeBreakProperty`) needs the
+	// matching definition in the user module — otherwise the LLVM
+	// emitter emits an unresolved `@<name>` reference and clang fails
+	// at link time. The pass mirrors the fn closure: walk each
+	// injected body, find IdentGlobal references whose Name maps to a
+	// stdlib `pub let`, lower the let, mangle to
+	// `osty_std_<module>__<name>`, append, and rewrite the body's
+	// reference. Globals can transitively reference other globals
+	// through their initialiser, so the discovery loops to a fixed
+	// point.
+	type letKey struct{ module, name string }
+	injectedLet := map[letKey]bool{}
+	letQueue := append([]loweredFromModule(nil), loweredFreeFns...)
+	for len(letQueue) > 0 {
+		next := letQueue[0]
+		letQueue = letQueue[1:]
+		for _, name := range sortedBareIdentGlobalReadNames(next.fn) {
+			letDecl := reg.LookupLetDecl(next.module, name)
+			if letDecl == nil {
+				continue
+			}
+			k := letKey{module: next.module, name: name}
+			mangled := StdlibSymbol(next.module, name)
+			if injectedLet[k] {
+				rewriteBareIdentGlobalReads(next.fn, name, mangled)
+				continue
+			}
+			injectedLet[k] = true
+			res := stdlibResolveResult(reg, next.module)
+			chk := stdlibCheckResult(reg, next.module)
+			lowered, ldIssues := ir.LowerLetDecl(mod.Package, letDecl, res, chk)
+			issues = append(issues, ldIssues...)
+			if lowered == nil {
+				continue
+			}
+			lowered.Name = mangled
+			out = append(out, lowered)
+			rewriteBareIdentGlobalReads(next.fn, name, mangled)
+			// Globals' initialisers can reference other lets in the
+			// same module — wrap the LetDecl in a synthetic FnDecl
+			// shape just enough to drive the same scanner.
+			if lowered.Value != nil {
+				letQueue = append(letQueue, loweredFromModule{
+					module: next.module,
+					fn:     letInitAsFnShim(lowered),
+				})
+			}
 		}
 	}
 	qualifyStdlibCallsiteTypes(mod, out)
 	return out, issues
+}
+
+// letInitAsFnShim wraps a LetDecl's initialiser in a synthetic FnDecl
+// so the existing fn-shaped scanners (sortedBareIdentGlobalReadNames /
+// rewriteBareIdentGlobalReads) can walk it. The wrapper isn't appended
+// to the user module — it only exists so the discovery loop can
+// transitively scan a global's initialiser the same way it scans
+// injected fn bodies.
+func letInitAsFnShim(ld *ir.LetDecl) *ir.FnDecl {
+	if ld == nil || ld.Value == nil {
+		return nil
+	}
+	return &ir.FnDecl{
+		Name: ld.Name,
+		Body: &ir.Block{
+			Stmts:  []ir.Stmt{&ir.ExprStmt{X: ld.Value}},
+			Result: ld.Value,
+			SpanV:  ld.SpanV,
+		},
+		SpanV: ld.SpanV,
+	}
 }
 
 func bodyfulStdlibFns(in []ReachableStdlibFn) []ReachableStdlibFn {
@@ -832,6 +907,56 @@ func rewriteBareIdentCalls(fn *ir.FnDecl, oldName, newName string) {
 		}
 		ident.Name = newName
 		ident.Kind = ir.IdentFn
+		return true
+	}), fn.Body)
+}
+
+// sortedBareIdentGlobalReadNames returns the set of distinct names
+// referenced by `Ident{Kind: IdentGlobal}` reads inside a function
+// body, in deterministic order. Idents in call-callee position are
+// excluded — those are the fn-closure path. The result drives the
+// globals-closure step: each name is checked against
+// `Registry.LookupLetDecl` to confirm it's a stdlib top-level let
+// before injection.
+func sortedBareIdentGlobalReadNames(fn *ir.FnDecl) []string {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		ident, ok := n.(*ir.Ident)
+		if !ok || ident == nil || ident.Kind != ir.IdentGlobal || ident.Name == "" {
+			return true
+		}
+		seen[ident.Name] = struct{}{}
+		return true
+	}), fn.Body)
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// rewriteBareIdentGlobalReads renames every `Ident{Kind: IdentGlobal,
+// Name: oldName}` inside fn.Body to newName. Mirrors
+// `rewriteBareIdentCalls` but for value reads instead of call
+// callees. The Kind stays IdentGlobal so the MIR lowerer keeps
+// emitting GlobalRefRV for the rewritten name.
+func rewriteBareIdentGlobalReads(fn *ir.FnDecl, oldName, newName string) {
+	if fn == nil || fn.Body == nil || oldName == "" || newName == "" || oldName == newName {
+		return
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		ident, ok := n.(*ir.Ident)
+		if !ok || ident == nil || ident.Kind != ir.IdentGlobal || ident.Name != oldName {
+			return true
+		}
+		ident.Name = newName
 		return true
 	}), fn.Body)
 }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -33,6 +33,21 @@ func LowerFnDecl(pkgName string, fn *ast.FnDecl, res *resolve.Result, chk *check
 	return out, l.issues
 }
 
+// LowerLetDecl lowers a single `pub let NAME = value` declaration.
+// Mirrors LowerFnDecl in shape — the body-injection pipeline uses it
+// to pull in stdlib globals that injected fn bodies reference.
+//
+// Returns the lowered LetDecl plus any non-fatal lowering issues. A
+// nil input returns (nil, nil).
+func LowerLetDecl(pkgName string, ld *ast.LetDecl, res *resolve.Result, chk *check.Result) (*LetDecl, []error) {
+	if ld == nil {
+		return nil, nil
+	}
+	l := &lowerer{pkgName: pkgName, res: res, chk: chk}
+	out := l.lowerLetDecl(ld)
+	return out, l.issues
+}
+
 // Lower converts a type-checked Osty file into an independent IR Module.
 //
 // pkgName is the module's package name (e.g. "main"). res and chk may be

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -488,6 +488,31 @@ func (r *Registry) LookupFnDecl(module, name string) *ast.FnDecl {
 	return nil
 }
 
+// LookupLetDecl returns the top-level `pub let NAME = ...` declaration
+// inside the stdlib module, or nil if the module or let is missing.
+// Mirrors LookupFnDecl. The body-injection pipeline uses this to pull
+// in stdlib globals that injected fn bodies reference (e.g. std.strings'
+// `graphemeBreakCR` Int constant referenced by `graphemeBreakProperty`).
+func (r *Registry) LookupLetDecl(module, name string) *ast.LetDecl {
+	if r == nil || module == "" || name == "" {
+		return nil
+	}
+	mod, ok := r.Modules[module]
+	if !ok || mod == nil || mod.File == nil {
+		return nil
+	}
+	for _, decl := range mod.File.Decls {
+		ld, ok := decl.(*ast.LetDecl)
+		if !ok || ld == nil {
+			continue
+		}
+		if ld.Name == name {
+			return ld
+		}
+	}
+	return nil
+}
+
 // LookupMethodDecl returns the method declaration named methodName on
 // the type typeName inside the stdlib module, or nil if any of the
 // module / type / method is missing.


### PR DESCRIPTION
## Summary
The body-injection pipeline lowered transitively-reachable stdlib free fns and methods, but stopped at globals. An injected body that read a stdlib \`pub let\` (e.g. std.strings' \`graphemeBreakProperty\` reads \`graphemeBreakCR\`) left the IR with a bare \`Ident{Kind: IdentGlobal, Name: "graphemeBreakCR"}\`. clang then failed at link time with \`use of undefined value '@graphemeBreakCR'\`.

This was the **third wall** every fmt_e2e test hit under \`OSTY_STDLIB_BODY_LOWER=1\`, after [#1326](https://github.com/choiceoh/osty/pull/1326) (open-ended slice) and [#1329](https://github.com/choiceoh/osty/pull/1329) (toString recovery).

## Approach
Globals closure pass mirroring the existing fn closure:

1. After fn closure converges, walk every injected body for \`Ident{Kind: IdentGlobal}\` reads.
2. Each name that resolves via \`Registry.LookupLetDecl(module, name)\` is lowered through new \`ir.LowerLetDecl\`, mangled to \`osty_std_<module>__<name>\` (reuses \`StdlibSymbol\`), and appended.
3. Body reference rewritten via \`rewriteBareIdentGlobalReads\` so the mangled name flows through MIR / LLVM.
4. Global initialisers can reference other lets — wrapped in a synthetic FnDecl shim so the same scanner walks them to a fixed point.

Side change: existing fn closure appended new fns only to the work \`queue\`, not to \`loweredFreeFns\`. Globals pass needs the full set as seed, so the 3 queue appends now also grow \`loweredFreeFns\`.

## New API
- \`Registry.LookupLetDecl(module, name) *ast.LetDecl\`
- \`ir.LowerLetDecl(pkgName, ld, res, chk) (*LetDecl, []error)\`
- \`sortedBareIdentGlobalReadNames(fn)\` / \`rewriteBareIdentGlobalReads\`

## Wall progression
- **Before**: clang link error \`use of undefined value '@graphemeBreakCR'\`.
- **After**: \`fmt.thousands(1234567)\` runs end-to-end on \`OSTY_STDLIB_BODY_LOWER=1\` and prints \`1,234,567\`. \`fmt.padLeft\` compiles and links clean; deeper failure is now a runtime \`list index out of range\` in the graphemes path (separate issue).

## Test plan
- [x] \`TestPrepareEntryInjectsStdlibGlobalsWhenFlagOn\` (new)
- [x] \`TestLLVMBackendEmitStringsCompareFlagOn\` + \`TestPrepareEntryInjectsStdlibWhenFlagOn\` still pass
- [x] \`internal/backend\`, \`internal/ir\` short suites
- [x] \`just front\`
- [x] Manual smoke: \`fmt.thousands(1234567)\` → \`1,234,567\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)