### PR TITLE
fix: duplicate lastIdx declaration in mirEmitAssignIntoMultiProjection

### DIFF
--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -20559,8 +20559,8 @@ fn mirEmitAssignIntoProjection(func: MirFunction, instr: MirInstr) -> String {
     out = out + mirEmitRValue(valueDest, instr.src)
     let valueTy = mirEmitRValueLLVMType(instr.src)
     // Pass 2: insertvalue back from deepest to outermost.
-    let lastIdx = instr.dest.projections[n - 1].index
-    let mut writeBack = "  " + baseReg + ".w" + mirGenIntToString(n - 1) + " = insertvalue \{ i64, i64 \} " + prev + ", " + valueTy + " " + valueDest + ", " + mirGenIntToString(lastIdx) + "\n"
+    let lastFieldIdx = instr.dest.projections[n - 1].index
+    let mut writeBack = "  " + baseReg + ".w" + mirGenIntToString(n - 1) + " = insertvalue \{ i64, i64 \} " + prev + ", " + valueTy + " " + valueDest + ", " + mirGenIntToString(lastFieldIdx) + "\n"
     out = out + writeBack
     let mut nested = baseReg + ".w" + mirGenIntToString(n - 1)
     let mut j = n - 2


### PR DESCRIPTION
## Summary
Native checker (Osty self-host) was rejecting `toolchain/mir_generator.osty` with E0501 — `lastIdx` was declared twice in the same function body of `mirEmitAssignIntoMultiProjection`:

- L20523: `let lastIdx = instr.dest.projections.len() - 1` (boundary index)
- L20562: `let lastIdx = instr.dest.projections[n - 1].index` (field-projection index)

Go's resolver missed this (different walk path) but the native checker is strict. Renames the second binding to `lastFieldIdx` — matches the intent (it's the field-projection index baked into the `insertvalue` line) and lets the Pass-2 write-back loop read its correct value without shadowing the Pass-1 boundary index.

## Context

Discovered while probing what's needed to make `osty build toolchain/` clean — the prerequisite for replacing the Phase-7 Slice-1 process-bridge body with a real self-host invocation (`toolchain/lir_proto.osty` driven). Front-end / native checker now pass; the remaining blocker is the MIR-direct emitter rejecting `std.bytes.push` (stdlib body injection scope), tracked separately.

## Test plan
- [x] `osty check toolchain/` (Go + native) clean
- [x] `just front` green
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)