### PR TITLE
feat(llvmgen): MIR-direct dispatch for Float.toIntTrunc/Round/Floor/Ceil

### DIFF
--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -112,6 +112,70 @@ func TestGenerateFromMIRConstReturn(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRFloatToIntCheckedReturnsResult — `f.toIntTrunc()` /
+// `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` must lower to the
+// matching `osty_rt_float_to_int_*` runtime helper plus a Result
+// `{i64 disc, i64 payload}` aggregate. The runtime helper takes
+// `(double v, int64_t *out) -> ptr err` (NULL on success); the
+// emit allocates a slot, branches on err == null, builds Ok / Err
+// aggregates and phis them. Without this dispatch the merged MIR
+// path emitted `call to unresolved symbol Float__toIntTrunc` which
+// blocked std.fmt's `fmt.fixed` chain end-to-end.
+func TestGenerateFromMIRFloatToIntCheckedReturnsResult(t *testing.T) {
+	resultIntError := &ir.NamedType{
+		Name:    "Result",
+		Builtin: true,
+		Args: []ir.Type{
+			ir.TInt,
+			&ir.NamedType{Name: "Error", Builtin: true},
+		},
+	}
+	for _, tc := range []struct {
+		method     string
+		runtimeSym string
+	}{
+		{"toIntTrunc", "osty_rt_float_to_int_trunc"},
+		{"toIntRound", "osty_rt_float_to_int_round"},
+		{"toIntFloor", "osty_rt_float_to_int_floor"},
+		{"toIntCeil", "osty_rt_float_to_int_ceil"},
+	} {
+		tc := tc
+		t.Run(tc.method, func(t *testing.T) {
+			fn := &ir.FnDecl{
+				Name:   "go",
+				Return: resultIntError,
+				Params: []*ir.Param{{Name: "f", Type: ir.TFloat}},
+				Body: &ir.Block{
+					Result: &ir.MethodCall{
+						Receiver: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: ir.TFloat},
+						Name:     tc.method,
+						T:        resultIntError,
+					},
+				},
+			}
+			hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+			m := buildMIRModuleFromHIR(t, hir)
+			out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/float_to_int_" + tc.method + ".osty"})
+			if err != nil {
+				t.Fatalf("GenerateFromMIR: %v", err)
+			}
+			got := string(out)
+			for _, want := range []string{
+				"declare ptr @" + tc.runtimeSym + "(double, ptr)",
+				"call ptr @" + tc.runtimeSym + "(double",
+				"alloca i64",
+				"icmp eq ptr",
+				"insertvalue",
+				"phi",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("missing %q for %s in:\n%s", want, tc.method, got)
+				}
+			}
+		})
+	}
+}
+
 // TestGenerateFromMIRShortCircuitAndDoesNotEvalRHS — `a && b` must
 // route through a CFG branch, not an eager `and i1`. The two output
 // blocks correspond to "LHS true → evaluate RHS" and "LHS false →

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -1078,6 +1078,24 @@ func (g *mirGen) emitFloatPrimitiveMethodCall(c *mir.CallInstr, method, recv, re
 			return true, err
 		}
 		return true, g.emitFloatRuntimeCallToDest(c, ostyRtFloatToFixedSymbol, "ptr", []mirRuntimeArg{{typ: "double", val: recvDouble}, precision})
+	case "toIntTrunc", "toIntRound", "toIntFloor", "toIntCeil":
+		// Float `.toIntTrunc()` / `.toIntRound()` / `.toIntFloor()` /
+		// `.toIntCeil()` return `Result<Int, Error>`. Runtime helper
+		// signature: `(double v, int64_t *out) -> const char* err`
+		// (NULL on success). Lower as alloca + call + branch on
+		// errPtr to assemble the canonical
+		// `{i64 disc, i64 payload}` Result aggregate the rest of the
+		// MIR pipeline expects. Mirrors `math_shim.go`'s
+		// `emitFloatCheckedIntResultCall` (AST path) but emits MIR's
+		// 2-field Result layout instead of the 3-field shape that
+		// path uses.
+		sym := map[string]string{
+			"toIntTrunc": ostyRtFloatToIntTruncSymbol,
+			"toIntRound": ostyRtFloatToIntRoundSymbol,
+			"toIntFloor": ostyRtFloatToIntFloorSymbol,
+			"toIntCeil":  ostyRtFloatToIntCeilSymbol,
+		}[method]
+		return true, g.emitFloatCheckedIntResultMIR(c, sym, recvDouble)
 	case "toInt":
 		return true, g.emitFloatRuntimeCallToDest(c, ostyRtFloatToIntLossySymbol, "i64", []mirRuntimeArg{{typ: "double", val: recvDouble}})
 	case "toInt32":
@@ -1118,6 +1136,64 @@ func (g *mirGen) emitFloatPrimitiveMethodCall(c *mir.CallInstr, method, recv, re
 
 func (g *mirGen) emitFloatRuntimeCallToDest(c *mir.CallInstr, symbol, retLLVM string, args []mirRuntimeArg) error {
 	return g.emitRuntimeCallToDest(c, symbol, retLLVM, args)
+}
+
+// emitFloatCheckedIntResultMIR lowers Float `.toIntTrunc()` /
+// `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` — runtime
+// signature `(double v, int64_t *out) -> const char* err` — into the
+// canonical MIR Result `{i64 disc, i64 payload}`:
+//   - disc=1 (Ok), payload=loaded i64 slot value.
+//   - disc=0 (Err), payload=ptrtoint of the error-message pointer.
+//
+// The runtime helper writes to the alloca on success and returns
+// NULL; on failure it returns a managed error-string ptr and leaves
+// the slot untouched. Branch on err == null + phi the Result.
+func (g *mirGen) emitFloatCheckedIntResultMIR(c *mir.CallInstr, symbol, recvDouble string) error {
+	if c.Dest == nil {
+		// No destination — runtime call still has the side effect of
+		// validating the value, but there's nowhere to store the
+		// Result. Just emit the call against a throwaway slot.
+		g.declareRuntime(symbol, mirRuntimeDeclareLine("ptr", symbol, "double, ptr"))
+		slot := g.fresh()
+		g.fnBuf.WriteString(mirAllocaLine(slot, "i64"))
+		g.fnBuf.WriteString(mirCallStmtLine("ptr", symbol, "double "+recvDouble+", ptr "+slot))
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: float-checked-int dest into unknown local %d", c.Dest.Local)
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	g.declareRuntime(symbol, mirRuntimeDeclareLine("ptr", symbol, "double, ptr"))
+	slot := g.fresh()
+	g.fnBuf.WriteString(mirAllocaLine(slot, "i64"))
+	g.fnBuf.WriteString(mirStoreLine("i64", "0", slot))
+	errReg := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(errReg, "ptr", symbol, "double "+recvDouble+", ptr "+slot))
+	isNil := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqLine(isNil, "ptr", errReg, "null"))
+	okLabel := g.freshLabel("float.toint.ok")
+	errLabel := g.freshLabel("float.toint.err")
+	contLabel := g.freshLabel("float.toint.cont")
+	g.fnBuf.WriteString(mirBrCondLine(isNil, okLabel, errLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	okPayload := g.fresh()
+	g.fnBuf.WriteString(mirLoadLine(okPayload, "i64", slot))
+	okValue := g.emitResultValue(resultLLVM, true, okPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	errPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(errPayload, errReg, "i64"))
+	errValue := g.emitResultValue(resultLLVM, false, errPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, resultLLVM, okValue, okLabel, errValue, errLabel))
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, phi, g.localSlots[c.Dest.Local]))
+	return nil
 }
 
 func (g *mirGen) evalFloatAsDouble(op mir.Operand) (string, error) {


### PR DESCRIPTION
## Summary
\`emitFloatPrimitiveMethodCall\` covered \`toInt\` / \`toInt32\` / \`toInt64\` (lossy) but not the four checked rounding methods (\`toIntTrunc\`, \`toIntRound\`, \`toIntFloor\`, \`toIntCeil\`) that return \`Result<Int, Error>\`. The merged MIR path therefore routed \`(abs * power + 0.5).floor().toIntTrunc()\` (std.fmt's \`fmt.fixed\` body) through \`mangleMethodSymbol("Float", "toIntTrunc")\` → \`Float__toIntTrunc\`, which has no definition.

This was the **fifth wall** fmt_e2e tests hit under \`OSTY_STDLIB_BODY_LOWER=1\` after [#1326](https://github.com/choiceoh/osty/pull/1326), [#1329](https://github.com/choiceoh/osty/pull/1329), [#1339](https://github.com/choiceoh/osty/pull/1339), [#1341](https://github.com/choiceoh/osty/pull/1341).

## Approach
Runtime helpers \`osty_rt_float_to_int_trunc/round/floor/ceil\` already exist with signature \`(double v, int64_t *out) -> const char* err\` (NULL on success); symbol constants already declared for the AST path. This PR adds the equivalent MIR emit:

1. Allocate i64 slot.
2. Call helper with \`(recv, slot)\` → ptr err.
3. Branch on \`err == null\`.
4. Ok arm: load i64 from slot, build \`{i64 1, i64 payload}\` aggregate.
5. Err arm: ptrtoint err to i64, build \`{i64 0, i64 payload}\`.
6. Phi the result, store to dest.

Layout follows MIR's canonical 2-field \`{i64 disc, i64 payload}\` Result shape, distinct from the AST path's 3-field shape. No runtime change.

## Wall progression
- **Before**: \`call to unresolved symbol Float__toIntTrunc\`.
- **After**: \`fmt.fixed(3.14159, 2)\` returns \`"3.14"\`. \`fmt.fixed(0.0, 2)\` → \`"0.00"\`, \`fmt.fixed(-1.5, 1)\` → \`"-1.5"\`, \`fmt.fixed(1.0, 0)\` → \`"1"\`.

## Test plan
- [x] \`TestGenerateFromMIRFloatToIntCheckedReturnsResult\` (new, table-driven over all 4 methods)
- [x] \`internal/llvmgen\`, \`internal/backend\` short suites
- [x] \`just front\`
- [x] Manual smoke under \`OSTY_STDLIB_BODY_LOWER=1\`: \`fmt.fixed(3.14159, 2)\` → \`"3.14"\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)