### PR TITLE
fix(llvmgen): MIR-direct dispatch for Int.toFloat / toFloat32 / toFloat64

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3854,6 +3854,27 @@ func (g *mirGen) emitPrimitiveMethodCall(c *mir.CallInstr, fnRef *mir.FnRef) (bo
 		resultReg = g.fresh()
 		body += "  " + resultReg + " = call ptr @" + mirRtIntToStringSymbol() + "(i64 " + extReg + ")\n"
 
+	case "toFloat", "toFloat32", "toFloat64":
+		// Integer → float cast. `toFloat` and `toFloat64` produce
+		// LLVM `double`; `toFloat32` produces `float`. Signed
+		// integers go through `sitofp`, unsigned through `uitofp`.
+		// The merged-MIR path previously fell through to
+		// `mangleMethodSymbol("Int", "toFloat")` → `Int__toFloat`,
+		// which has no definition; std.fmt's `bytes(n)` chain
+		// (`n.toFloat().abs()`) tripped that wall whenever bytes-like
+		// formatters were reached after #1342 unblocked the rounding
+		// family.
+		toLLVM := "double"
+		if method == "toFloat32" {
+			toLLVM = "float"
+		}
+		op := "sitofp"
+		if !isSigned {
+			op = "uitofp"
+		}
+		resultReg = g.fresh()
+		body = "  " + resultReg + " = " + op + " " + llvmTy + " " + recv + " to " + toLLVM + "\n"
+
 	case "ns", "us", "ms", "s", "minutes", "h", "days", "weeks":
 		// Duration constructors (§10.20). Receiver is an integer
 		// kind (Float receivers route through emitFloatPrimitiveMethodCall

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -112,6 +112,55 @@ func TestGenerateFromMIRConstReturn(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRIntToFloatLowersAsSItoFP — `n.toFloat()` /
+// `.toFloat32()` / `.toFloat64()` on integer receivers must lower
+// to a single LLVM `sitofp` (or `uitofp`) cast, not a runtime call
+// to `Int__toFloat` (which has no definition). std.fmt's `bytes(n)`
+// chain (`n.toFloat().abs()`) tripped this wall under
+// `OSTY_STDLIB_BODY_LOWER=1`.
+func TestGenerateFromMIRIntToFloatLowersAsSItoFP(t *testing.T) {
+	for _, tc := range []struct {
+		method string
+		toLLVM string
+	}{
+		{"toFloat", "double"},
+		{"toFloat32", "float"},
+		{"toFloat64", "double"},
+	} {
+		tc := tc
+		t.Run(tc.method, func(t *testing.T) {
+			fn := &ir.FnDecl{
+				Name:   "go",
+				Return: ir.TFloat,
+				Params: []*ir.Param{{Name: "n", Type: ir.TInt}},
+				Body: &ir.Block{
+					Result: &ir.MethodCall{
+						Receiver: &ir.Ident{Name: "n", Kind: ir.IdentParam, T: ir.TInt},
+						Name:     tc.method,
+						T:        ir.TFloat,
+					},
+				},
+			}
+			hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+			m := buildMIRModuleFromHIR(t, hir)
+			out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/int_to_float_" + tc.method + ".osty"})
+			if err != nil {
+				t.Fatalf("GenerateFromMIR: %v", err)
+			}
+			got := string(out)
+			want := "sitofp i64 "
+			if !strings.Contains(got, want) {
+				t.Fatalf("missing %q for %s in:\n%s", want, tc.method, got)
+			}
+			// Regression guard: a fallback to the unmangled symbol
+			// would emit `call ... @Int__toFloat` instead.
+			if strings.Contains(got, "@Int__toFloat") {
+				t.Fatalf("regressed to mangled-symbol call for %s:\n%s", tc.method, got)
+			}
+		})
+	}
+}
+
 // TestGenerateFromMIRFloatToIntCheckedReturnsResult — `f.toIntTrunc()` /
 // `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` must lower to the
 // matching `osty_rt_float_to_int_*` runtime helper plus a Result


### PR DESCRIPTION
## Summary
\`emitPrimitiveMethodCall\` covered every Int-receiver primitive method (toString, abs/min/max/clamp/signum, toByte/toChar, duration constructors) but not the integer→float conversion family. The merged MIR path routed \`n.toFloat()\` through \`mangleMethodSymbol("Int", "toFloat")\` → \`Int__toFloat\` (undefined).

Next wall reachable in fmt_e2e under \`OSTY_STDLIB_BODY_LOWER=1\` after [#1342](https://github.com/choiceoh/osty/pull/1342) unblocked \`fmt.fixed\`. std.fmt's \`bytes(n)\` body (\`n.toFloat().abs()\`) hit it.

## Approach
Add the three methods to the integer arm as a single LLVM cast each — no runtime call needed:

| Method      | LLVM op              | Result type |
|-------------|----------------------|-------------|
| \`toFloat\`     | \`sitofp\` / \`uitofp\` | double      |
| \`toFloat64\`   | \`sitofp\` / \`uitofp\` | double      |
| \`toFloat32\`   | \`sitofp\` / \`uitofp\` | float       |

Signedness already resolved upstream by the per-owner switch (Int/Int64/.../Char → signed; Byte/UInt* → unsigned).

## Wall progression
- **Before**: \`call to unresolved symbol Int__toFloat\`.
- **After**: \`n.toFloat()\` works end-to-end. fmt_e2e's \`testJoinWith\` is the next wall — generic closure IR validator failure (\`Closure: param[0] nil Type\`); that's a separate multi-day track called out in the harness header.

## Test plan
- [x] \`TestGenerateFromMIRIntToFloatLowersAsSItoFP\` (new, table-driven over toFloat / toFloat32 / toFloat64)
- [x] \`internal/llvmgen\`, \`internal/backend\` short suites
- [x] \`just front\`
- [x] Manual smoke: \`n.toFloat()\` → \`"5.000000"\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)