### PR TITLE
fix(mir-lower): respect local shadowing of stdlib use aliases

### DIFF
--- a/internal/llvmgen/use_alias_shadowing_test.go
+++ b/internal/llvmgen/use_alias_shadowing_test.go
@@ -1,0 +1,86 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLocalShadowsBytesUseAliasIRPipeline pins the body-aware
+// `useAliasFor` gate in the MIR lowerer: when a function imports
+// `std.bytes as bytes` but a local binding named `bytes` shadows the
+// alias, method calls on that local must lower as List intrinsics
+// (the local's actual type) — not as bytes-module free-fns. Without
+// the gate, MIR emits `IntrinsicBytesLen` with no receiver because
+// `bytesIntrinsicForMethod` matches "len" by name regardless of the
+// receiver type, and the LLVM backend rejects the instruction with
+// "bytes intrinsic with no receiver".
+func TestLocalShadowsBytesUseAliasIRPipeline(t *testing.T) {
+	src := `use std.bytes as bytes
+
+fn check() -> Int {
+    let mut bytes: List<Int> = []
+    bytes.push(0)
+    bytes.push(42)
+    bytes.len()
+}
+
+fn main() {
+    let n = check()
+    println(n)
+}
+`
+	mod := lowerSrcLLVM(t, src)
+	ir, err := GenerateModule(mod, Options{PackageName: "main", SourcePath: "/tmp/use_alias_shadow_bytes.osty"})
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i64 @osty_rt_list_len",
+		"call void @osty_rt_list_push",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"@osty_rt_bytes_len",
+		"@osty_rt_bytes_push",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("generated IR contains unwanted %q (shadowing should keep it on the List path):\n%s", unwanted, got)
+		}
+	}
+}
+
+// TestLocalShadowsStringsUseAliasIRPipeline is the strings-side
+// companion: a `use std.strings as strings` import shadowed by a
+// local `strings` binding routes method calls through the local's
+// type, not the stdlib strings free-fn intrinsics.
+func TestLocalShadowsStringsUseAliasIRPipeline(t *testing.T) {
+	src := `use std.strings as strings
+
+fn check() -> Int {
+    let mut strings: List<Int> = []
+    strings.push(1)
+    strings.len()
+}
+
+fn main() {
+    let n = check()
+    println(n)
+}
+`
+	mod := lowerSrcLLVM(t, src)
+	ir, err := GenerateModule(mod, Options{PackageName: "main", SourcePath: "/tmp/use_alias_shadow_strings.osty"})
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, "call i64 @osty_rt_list_len") {
+		t.Fatalf("generated IR missing list_len call:\n%s", got)
+	}
+	if strings.Contains(got, "@osty_rt_strings_") {
+		t.Fatalf("shadowed strings local should not route through std.strings intrinsics:\n%s", got)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2687,7 +2687,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// (std.strings.*) which is the dispatch path the MIR emitter
 		// already uses for these calls at lowerCallExprInto.
 		if fx, ok := x.Callee.(*ir.FieldExpr); ok {
-			if use := bs.l.useAliasFor(fx.X); use != nil {
+			if use := bs.useAliasFor(fx.X); use != nil {
 				if rt := stdlibFreeFnReturnType(qualifierOf(use), fx.Name); rt != nil {
 					return rt
 				}
@@ -2732,7 +2732,7 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 		// as MethodCall{Receiver: Ident("strings"), Name: "join"}. The
 		// receiver is a use alias, not a value, so look up via the alias
 		// table instead of x.Receiver.Type().
-		if use := bs.l.useAliasFor(x.Receiver); use != nil {
+		if use := bs.useAliasFor(x.Receiver); use != nil {
 			if rt := stdlibFreeFnReturnType(qualifierOf(use), x.Name); rt != nil {
 				return rt
 			}
@@ -4456,33 +4456,38 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 	}
 	if fx, ok := c.Callee.(*ir.FieldExpr); ok {
 		if id, ok := fx.X.(*ir.Ident); ok && id != nil {
-			switch id.Name {
-			case "Bytes", "bytes":
-				if kind := stdlibBytesFreeFnToIntrinsic("bytes", fx.Name); kind != IntrinsicInvalid {
-					bs.emitBytesFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+			// Same shadowing escape as `lowerMethodCallInto`: don't
+			// route `bytes.foo(...)` (etc.) through the stdlib-module
+			// fast path when `bytes` names a local binding.
+			if _, shadowed := bs.lookup(id.Name); !shadowed {
+				switch id.Name {
+				case "Bytes", "bytes":
+					if kind := stdlibBytesFreeFnToIntrinsic("bytes", fx.Name); kind != IntrinsicInvalid {
+						bs.emitBytesFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+						return
+					}
+				case "String", "strings":
+					if kind := stdlibStringFreeFnToIntrinsic("strings", fx.Name); kind != IntrinsicInvalid {
+						bs.emitStringFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+						return
+					}
+				case "Error", "error":
+					args := bs.orderArgs(c.Args, nil)
+					destPtr := dest
+					if destPtr != nil && isUnit(destT) {
+						destPtr = nil
+					}
+					bs.emit(&CallInstr{
+						Dest:   destPtr,
+						Callee: &FnRef{Symbol: "std.error." + fx.Name, Type: c.T},
+						Args:   args,
+						SpanV:  c.SpanV,
+					})
 					return
 				}
-			case "String", "strings":
-				if kind := stdlibStringFreeFnToIntrinsic("strings", fx.Name); kind != IntrinsicInvalid {
-					bs.emitStringFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
-					return
-				}
-			case "Error", "error":
-				args := bs.orderArgs(c.Args, nil)
-				destPtr := dest
-				if destPtr != nil && isUnit(destT) {
-					destPtr = nil
-				}
-				bs.emit(&CallInstr{
-					Dest:   destPtr,
-					Callee: &FnRef{Symbol: "std.error." + fx.Name, Type: c.T},
-					Args:   args,
-					SpanV:  c.SpanV,
-				})
-				return
 			}
 		}
-		if use := bs.l.useAliasFor(fx.X); use != nil {
+		if use := bs.useAliasFor(fx.X); use != nil {
 			if kind := concurrencyIntrinsicForFree(qualifierOf(use), fx.Name); kind != IntrinsicInvalid {
 				bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 				return
@@ -4531,7 +4536,7 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 				return
 			}
 		}
-		if use, parts, ok := bs.l.useAliasFieldPath(fx); ok && stdlibNestedNamespacePath(use, parts) {
+		if use, parts, ok := bs.useAliasFieldPath(fx); ok && stdlibNestedNamespacePath(use, parts) {
 			name := strings.Join(parts, ".")
 			args := bs.orderArgsByTypes(c.Args, stdlibFreeFnParamTypes(pathQualifier(use), name))
 			destPtr := dest
@@ -4870,7 +4875,7 @@ func (bs *bodyState) resolveCall(c *ir.CallExpr) ([]Operand, Callee) {
 		// Treating `x` as a receiver for the first case would produce
 		// `Split(strings, s, ",")`, which is the wrong ABI and loses
 		// the qualifier identity. So: classify before lowering.
-		if use := bs.l.useAliasFor(cal.X); use != nil {
+		if use := bs.useAliasFor(cal.X); use != nil {
 			return bs.resolveQualifiedCall(use, cal.Name, cal.T, c.Args)
 		}
 		// Not a package alias — fall back to an indirect call through
@@ -4941,6 +4946,11 @@ func qualifiedSymbol(use *ir.UseDecl, name string) string {
 
 // useAliasFor returns the use decl whose alias matches the ident, or
 // nil if expr is not a bare alias reference.
+//
+// NOTE: this is the package-level resolution and does NOT consider
+// lexical scope. Callers inside a body context should use
+// `bodyState.useAliasFor` instead — that variant first checks whether
+// the ident has been shadowed by a local binding.
 func (l *lowerer) useAliasFor(e ir.Expr) *ir.UseDecl {
 	id, ok := e.(*ir.Ident)
 	if !ok {
@@ -4950,6 +4960,71 @@ func (l *lowerer) useAliasFor(e ir.Expr) *ir.UseDecl {
 		return nil
 	}
 	return l.useAliases[id.Name]
+}
+
+// useAliasFor mirrors `lowerer.useAliasFor` but skips the lookup when
+// the ident has been shadowed by a local binding in the current body
+// scope. Toolchain-shaped programs do this routinely:
+//
+//	use std.bytes as bytes
+//	...
+//	fn build() {
+//	    let mut bytes: List<Int> = []   // shadows the import alias
+//	    bytes.push(0)                   // List<Int>.push, not std.bytes.push
+//	}
+//
+// The package-level `useAliasFor` would mis-route the receiver,
+// emitting `@std.bytes.push` instead of `List.push` and link-failing
+// in the MIR-direct emitter ("call to unresolved symbol
+// std.bytes.push"). Routing through this scope-aware variant fixes
+// the shadowing case.
+func (bs *bodyState) useAliasFor(e ir.Expr) *ir.UseDecl {
+	id, ok := e.(*ir.Ident)
+	if !ok {
+		return nil
+	}
+	if id.Name == "" {
+		return nil
+	}
+	if _, shadowed := bs.lookup(id.Name); shadowed {
+		return nil
+	}
+	return bs.l.useAliases[id.Name]
+}
+
+// useAliasFieldPath mirrors `lowerer.useAliasFieldPath` with the same
+// local-shadowing escape: walks the receiver chain and refuses to
+// treat the leaf ident as a use alias when a local binding already
+// owns that name in the current body scope.
+func (bs *bodyState) useAliasFieldPath(e ir.Expr) (*ir.UseDecl, []string, bool) {
+	field, ok := e.(*ir.FieldExpr)
+	if !ok || field == nil {
+		return nil, nil, false
+	}
+	var parts []string
+	cur := field
+	for cur != nil {
+		parts = append([]string{cur.Name}, parts...)
+		if id, ok := cur.X.(*ir.Ident); ok {
+			if id.Name == "" {
+				return nil, nil, false
+			}
+			if _, shadowed := bs.lookup(id.Name); shadowed {
+				return nil, nil, false
+			}
+			use := bs.l.useAliases[id.Name]
+			if use == nil {
+				return nil, nil, false
+			}
+			return use, parts, true
+		}
+		next, ok := cur.X.(*ir.FieldExpr)
+		if !ok {
+			return nil, nil, false
+		}
+		cur = next
+	}
+	return nil, nil, false
 }
 
 // useAliasFieldPath recognizes nested package-namespace expressions
@@ -5082,17 +5157,29 @@ func (bs *bodyState) orderArgs(args []ir.Arg, sig *fnSignature) []Operand {
 
 func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Type) {
 	recvType := bs.recoveredTypeOf(mc.Receiver)
+	// The hardcoded `bytes` / `Bytes` / `strings` / `String` receiver
+	// match below assumes the ident names a stdlib module qualifier,
+	// not a local value. When a local binding shadows the alias (e.g.
+	// `let mut bytes: List<Int> = []` followed by `bytes.len()`), the
+	// receiver is the List, and routing to the bytes free-fn intrinsic
+	// produces a no-receiver bytes intrinsic — `bytes.len()` lowered as
+	// IntrinsicBytesLen with empty args, which the LLVM backend rejects
+	// with "bytes intrinsic with no receiver". Skip the shortcut when
+	// the ident resolves to a local — fall through to the regular
+	// stdlibIntrinsicForMethod path which dispatches by recvType.
 	if id, ok := mc.Receiver.(*ir.Ident); ok && id != nil {
-		switch id.Name {
-		case "bytes", "Bytes":
-			if kind := stdlibBytesFreeFnToIntrinsic("bytes", mc.Name); kind != IntrinsicInvalid {
-				bs.emitBytesFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
-				return
-			}
-		case "strings", "String":
-			if kind := stdlibStringFreeFnToIntrinsic("strings", mc.Name); kind != IntrinsicInvalid {
-				bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
-				return
+		if _, shadowed := bs.lookup(id.Name); !shadowed {
+			switch id.Name {
+			case "bytes", "Bytes":
+				if kind := stdlibBytesFreeFnToIntrinsic("bytes", mc.Name); kind != IntrinsicInvalid {
+					bs.emitBytesFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+					return
+				}
+			case "strings", "String":
+				if kind := stdlibStringFreeFnToIntrinsic("strings", mc.Name); kind != IntrinsicInvalid {
+					bs.emitStringFreeFnIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+					return
+				}
 			}
 		}
 	}
@@ -5101,7 +5188,7 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	// a use alias, not a value — fast-path to a concurrency intrinsic
 	// when the qualifier targets `thread`, or emit a direct qualified
 	// call with no synthetic `self` argument otherwise.
-	if use, parts, ok := bs.l.useAliasFieldPath(mc.Receiver); ok && stdlibNestedNamespacePath(use, append(parts, mc.Name)) {
+	if use, parts, ok := bs.useAliasFieldPath(mc.Receiver); ok && stdlibNestedNamespacePath(use, append(parts, mc.Name)) {
 		name := strings.Join(append(parts, mc.Name), ".")
 		args := bs.orderArgsByTypes(mc.Args, stdlibFreeFnParamTypes(pathQualifier(use), name))
 		destPtr := &dest
@@ -5116,7 +5203,7 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 		})
 		return
 	}
-	if use := bs.l.useAliasFor(mc.Receiver); use != nil {
+	if use := bs.useAliasFor(mc.Receiver); use != nil {
 		if kind := concurrencyIntrinsicForFree(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
 			bs.emitConcurrencyIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
 			return

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 448 `.osty` file(s)  
-**Captured:** 238 residual case(s) — **0** AI-slip(s) airepair rewrote, **238** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 465 `.osty` file(s)  
+**Captured:** 253 residual case(s) — **0** AI-slip(s) airepair rewrote, **253** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -1709,7 +1709,7 @@ fn mirLowerCallExprRecoveredType(bs: MirLowerBodyState, e: HirExpr) -> HirType {
     }
     if callee.kind == HirExprField && callee.fieldTarget.len() > 0 {
         let recv = callee.fieldTarget[0]
-        let useIdx = mirLowerUseAliasIndexForReceiver(bs.l, recv)
+        let useIdx = mirLowerBodyUseAliasIndexForReceiver(bs, recv)
         if useIdx >= 0 {
             let use_ = bs.l.useAliases[useIdx]
             let rt = mirLowerStdlibStringFreeFnReturnType(
@@ -3988,7 +3988,7 @@ fn mirLowerCallExprQualifiedIntrinsic(
     destT: HirType,
     span: MirSpan,
 ) -> Bool {
-    let nested = mirLowerUseAliasFieldPath(bs.l, callee)
+    let nested = mirLowerBodyUseAliasFieldPath(bs, callee)
     if nested.ok {
         let use_ = bs.l.useAliases[nested.useIdx]
         if mirLowerStdlibNestedNamespacePath(use_, nested.parts) {
@@ -4010,7 +4010,7 @@ fn mirLowerCallExprQualifiedIntrinsic(
         return false
     }
     let recv = callee.fieldTarget[0]
-    let useIdx = mirLowerUseAliasIndexForReceiver(bs.l, recv)
+    let useIdx = mirLowerBodyUseAliasIndexForReceiver(bs, recv)
     if useIdx < 0 {
         return false
     }
@@ -5585,7 +5585,10 @@ pub fn mirLowerMethodCallInto(
     // 1. Use-alias qualifier fast path. Before routing through a
     //    direct FnRef, probe the intrinsic tables: `thread.spawn(f)`,
     //    `std.strings.split(s, ",")`, `std.runtime.raw.null()`.
-    let useIdx = mirLowerUseAliasIndexForReceiver(bs.l, recv)
+    //    Use the body-aware variant so a local binding shadows the
+    //    package alias (avoids lowering `bytes.len()` on a List<Int>
+    //    local through the std.bytes intrinsic table).
+    let useIdx = mirLowerBodyUseAliasIndexForReceiver(bs, recv)
     if useIdx >= 0 {
         let use_ = bs.l.useAliases[useIdx]
         let qualifier = mirLowerUseQualifier(use_)
@@ -5624,7 +5627,7 @@ pub fn mirLowerMethodCallInto(
         mirLowerMethodCallQualified(bs, e, use_, dest, destT, span)
         return
     }
-    let nested = mirLowerUseAliasFieldPath(bs.l, recv)
+    let nested = mirLowerBodyUseAliasFieldPath(bs, recv)
     if nested.ok {
         let use_ = bs.l.useAliases[nested.useIdx]
         let mut parts = nested.parts
@@ -5697,6 +5700,51 @@ fn mirLowerUseAliasIndexForReceiver(l: MirLowerer, recv: HirExpr) -> Int {
         HirExprIdent -> mirLowerLookupUseAlias(l, recv.identName),
         _ -> -1,
     }
+}
+
+/// mirLowerBodyUseAliasIndexForReceiver is the body-aware variant of
+/// mirLowerUseAliasIndexForReceiver. When a local binding shadows a
+/// package alias (e.g. `let mut bytes: List<Int> = []` in a function
+/// that also imports `std.bytes as bytes`), the receiver is the local
+/// value, not the package qualifier — routing through the alias path
+/// would emit a stdlib-bytes intrinsic with the wrong arg shape. Skip
+/// the alias lookup whenever a local of the same name exists in any
+/// enclosing body scope. Mirrors Go's `bodyState.useAliasFor`.
+fn mirLowerBodyUseAliasIndexForReceiver(bs: MirLowerBodyState, recv: HirExpr) -> Int {
+    if recv.kind != HirExprIdent {
+        return -1
+    }
+    if recv.identName == "" {
+        return -1
+    }
+    if mirLowerLookupName(bs, recv.identName) >= 0 {
+        return -1
+    }
+    mirLowerLookupUseAlias(bs.l, recv.identName)
+}
+
+/// mirLowerBodyUseAliasFieldPath mirrors mirLowerUseAliasFieldPath
+/// with the same body-scope shadowing escape: the leaf ident is
+/// rejected as a use alias whenever a local already owns that name.
+fn mirLowerBodyUseAliasFieldPath(bs: MirLowerBodyState, e: HirExpr) -> MirLowerUseAliasFieldPath {
+    if e.kind != HirExprField || e.fieldTarget.len() == 0 {
+        return mirLowerUseAliasFieldPathInvalid()
+    }
+    let recv = e.fieldTarget[0]
+    let mut nested = mirLowerBodyUseAliasFieldPath(bs, recv)
+    if nested.ok {
+        nested.parts.push(e.fieldName)
+        return nested
+    }
+    let useIdx = mirLowerBodyUseAliasIndexForReceiver(bs, recv)
+    if useIdx >= 0 {
+        return MirLowerUseAliasFieldPath {
+            useIdx,
+            parts: [e.fieldName],
+            ok: true,
+        }
+    }
+    mirLowerUseAliasFieldPathInvalid()
 }
 
 /// mirLowerMethodCallQualified handles `pkg.fn(args)` shaped as a


### PR DESCRIPTION
## Summary
- MIR lowerer was routing `bytes.len()` through `IntrinsicBytesLen` with no receiver when a local `bytes: List<Int>` shadowed `use std.bytes as bytes`, blocking `osty build toolchain/` (Phase-7 Slice 2 prep).
- Add body-aware `useAliasFor` / `useAliasFieldPath` variants in both `internal/mir/lower.go` and `toolchain/mir_lower.osty`; gate the hardcoded `case "bytes" / "Bytes" / "strings" / "String":` shortcuts on `bs.lookup` so a local binding always wins.
- Regression test in `internal/llvmgen/use_alias_shadowing_test.go` covers both the bytes and strings shadowing cases through the IR pipeline.

## Test plan
- [x] `just prepush` 로컬 통과
- [x] `osty build toolchain/` 성공
- [x] `osty run /tmp/shadow_test/` (let mut bytes: List<Int> + bytes.push/len) 출력 `2`
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)