### PR TITLE
feat(stdlib): encoding.base64.encode 5★ (Phase 2)

### DIFF
--- a/examples/encoding_base64_e2e/encoding_base64_test.osty
+++ b/examples/encoding_base64_e2e/encoding_base64_test.osty
@@ -1,0 +1,21 @@
+use std.testing
+use std.bytes
+use std.encoding
+
+fn testStandardEncodeHello() {
+    let inp = bytes.fromString("hello")
+    let out = encoding.base64.encode(inp)
+    testing.assertEq(out, "aGVsbG8=")
+}
+
+fn testStandardEncodeOneByte() {
+    let inp = bytes.fromString("a")
+    let out = encoding.base64.encode(inp)
+    testing.assertEq(out, "YQ==")
+}
+
+fn testStandardEncodeTwoBytes() {
+    let inp = bytes.fromString("ab")
+    let out = encoding.base64.encode(inp)
+    testing.assertEq(out, "YWI=")
+}

--- a/examples/encoding_base64_e2e/osty.toml
+++ b/examples/encoding_base64_e2e/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "encoding_base64_e2e"
+version = "0.1.0"
+edition = "0.3"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4945,6 +4945,10 @@ uint8_t osty_rt_bytes_get(void *raw_bytes, int64_t index);
 void *osty_rt_bytes_slice(void *raw_bytes, int64_t start, int64_t end);
 void *osty_rt_compress_gzip_encode(void *raw_bytes);
 void *osty_rt_compress_gzip_decode(void *raw_bytes);
+const char *osty_rt_encoding_base64_encode(void *raw_bytes);
+const char *osty_rt_encoding_base64url_encode(void *raw_bytes);
+void *osty_rt_encoding_base64_decode(const char *value);
+void *osty_rt_encoding_base64url_decode(const char *value);
 void *osty_rt_crypto_sha256(void *raw_data);
 void *osty_rt_crypto_sha512(void *raw_data);
 void *osty_rt_crypto_sha1(void *raw_data);
@@ -12283,6 +12287,204 @@ void *osty_rt_compress_gzip_decode(void *raw_bytes) {
         }
     }
 #endif
+}
+
+/* ── std.encoding base64 ──────────────────────────────────────────
+ * Standard (RFC 4648 §4) and URL-safe (§5) variants. Encode emits
+ * padded ('=') for the standard alphabet and unpadded for URL-safe,
+ * matching the body in `internal/stdlib/modules/encoding.osty`.
+ * Decode accepts either presence or absence of padding (decoder is
+ * lenient on trailing '=' per common practice). Returns NULL on
+ * invalid input — never aborts. */
+
+static const char osty_rt_encoding_base64_alphabet_std[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char osty_rt_encoding_base64_alphabet_url[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+static int osty_rt_encoding_base64_lookup(unsigned char c, int url_safe) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (url_safe) {
+        if (c == '-') return 62;
+        if (c == '_') return 63;
+    } else {
+        if (c == '+') return 62;
+        if (c == '/') return 63;
+    }
+    return -1;
+}
+
+static const char *osty_rt_encoding_base64_encode_impl(void *raw_bytes, int url_safe, int padded) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    const unsigned char *data;
+    size_t len;
+    size_t out_len;
+    char *out;
+    size_t i;
+    size_t j;
+    const char *alphabet = url_safe ? osty_rt_encoding_base64_alphabet_url
+                                    : osty_rt_encoding_base64_alphabet_std;
+
+    if (b == NULL || b->len == 0) {
+        return osty_rt_string_dup_site("", 0, "runtime.encoding.base64.encode.empty");
+    }
+    if (b->len < 0) {
+        osty_rt_abort("runtime.encoding.base64.encode: negative length");
+    }
+    data = b->data;
+    len = (size_t)b->len;
+
+    /* groups-of-3 → groups-of-4. Padded variant always rounds up. */
+    if (padded) {
+        out_len = ((len + 2) / 3) * 4;
+    } else {
+        out_len = (len / 3) * 4;
+        switch (len % 3) {
+            case 1: out_len += 2; break;
+            case 2: out_len += 3; break;
+            default: break;
+        }
+    }
+    out = (char *)osty_gc_allocate_managed(out_len + 1, OSTY_GC_KIND_STRING,
+                                           "runtime.encoding.base64.encode", NULL, NULL);
+
+    for (i = 0, j = 0; i < len;) {
+        unsigned int triple = (unsigned int)data[i++] << 16;
+        int has1 = i < len;
+        int has2 = i + 1 < len;
+        if (has1) {
+            triple |= (unsigned int)data[i++] << 8;
+        }
+        if (has2) {
+            triple |= (unsigned int)data[i++];
+        }
+        out[j++] = alphabet[(triple >> 18) & 0x3F];
+        out[j++] = alphabet[(triple >> 12) & 0x3F];
+        if (has1) {
+            out[j++] = alphabet[(triple >> 6) & 0x3F];
+        } else if (padded) {
+            out[j++] = '=';
+        }
+        if (has2) {
+            out[j++] = alphabet[triple & 0x3F];
+        } else if (padded) {
+            out[j++] = '=';
+        }
+    }
+    out[j] = '\0';
+    return out;
+}
+
+const char *osty_rt_encoding_base64_encode(void *raw_bytes) {
+    return osty_rt_encoding_base64_encode_impl(raw_bytes, 0, 1);
+}
+
+const char *osty_rt_encoding_base64url_encode(void *raw_bytes) {
+    return osty_rt_encoding_base64_encode_impl(raw_bytes, 1, 0);
+}
+
+static void *osty_rt_encoding_base64_decode_impl(const char *value, int url_safe) {
+    size_t in_len;
+    size_t cleaned_len = 0;
+    size_t i;
+    size_t out_cap;
+    size_t out_len = 0;
+    unsigned char *out;
+    int values[4];
+    int v_idx = 0;
+    void *result;
+    int saw_pad = 0;
+
+    if (value == NULL) {
+        value = "";
+    }
+    in_len = strlen(value);
+
+    /* Worst-case output is ceil(in_len * 3/4); allocate that and shrink. */
+    out_cap = (in_len / 4 + 1) * 3 + 3;
+    out = (unsigned char *)malloc(out_cap);
+    if (out == NULL) {
+        osty_rt_abort("runtime.encoding.base64.decode: out of memory");
+    }
+
+    for (i = 0; i < in_len; i++) {
+        unsigned char c = (unsigned char)value[i];
+        int v;
+        /* Skip ASCII whitespace (spec-compliant decoders are lenient). */
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            continue;
+        }
+        if (c == '=') {
+            saw_pad = 1;
+            values[v_idx++] = -1;
+        } else {
+            if (saw_pad) {
+                free(out);
+                return NULL; /* data after padding */
+            }
+            v = osty_rt_encoding_base64_lookup(c, url_safe);
+            if (v < 0) {
+                free(out);
+                return NULL;
+            }
+            values[v_idx++] = v;
+        }
+        cleaned_len++;
+        if (v_idx == 4) {
+            int v0 = values[0], v1 = values[1], v2 = values[2], v3 = values[3];
+            if (v0 < 0 || v1 < 0) {
+                free(out);
+                return NULL;
+            }
+            out[out_len++] = (unsigned char)((v0 << 2) | (v1 >> 4));
+            if (v2 >= 0) {
+                out[out_len++] = (unsigned char)(((v1 & 0x0F) << 4) | (v2 >> 2));
+                if (v3 >= 0) {
+                    out[out_len++] = (unsigned char)(((v2 & 0x03) << 6) | v3);
+                }
+            } else if (v3 >= 0) {
+                /* "Xx=Y" — invalid. */
+                free(out);
+                return NULL;
+            }
+            v_idx = 0;
+        }
+    }
+
+    /* Handle remaining values (URL-safe / unpadded form). */
+    if (v_idx != 0) {
+        if (v_idx == 1) {
+            free(out);
+            return NULL;
+        }
+        if (values[0] < 0 || values[1] < 0) {
+            free(out);
+            return NULL;
+        }
+        out[out_len++] = (unsigned char)((values[0] << 2) | (values[1] >> 4));
+        if (v_idx >= 3 && values[2] >= 0) {
+            out[out_len++] = (unsigned char)(((values[1] & 0x0F) << 4) | (values[2] >> 2));
+        } else if (v_idx == 2 && (values[1] & 0x0F) != 0) {
+            free(out);
+            return NULL; /* non-zero trailing bits */
+        }
+    }
+
+    result = osty_rt_bytes_dup_site(out_len == 0 ? NULL : out, out_len,
+                                     out_len == 0 ? "runtime.encoding.base64.decode.empty"
+                                                  : "runtime.encoding.base64.decode");
+    free(out);
+    return result;
+}
+
+void *osty_rt_encoding_base64_decode(const char *value) {
+    return osty_rt_encoding_base64_decode_impl(value, 0);
+}
+
+void *osty_rt_encoding_base64url_decode(const char *value) {
+    return osty_rt_encoding_base64_decode_impl(value, 1);
 }
 
 void *osty_rt_bytes_from_list(void *raw_list) {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3331,6 +3331,11 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 			return err
 		}
 	}
+	if strings.HasPrefix(fnRef.Symbol, "Base64__") || strings.HasPrefix(fnRef.Symbol, "Base64Url__") {
+		if handled, err := g.emitStdEncodingBase64CallMIR(c, fnRef); handled {
+			return err
+		}
+	}
 	if handled, err := g.emitStdCmdCall(c, fnRef); handled {
 		return err
 	}

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -18,9 +18,11 @@ import (
 // missing C runtime entries (Phase 2 / Phase 3).
 
 const (
-	ostyRtBytesToHexSymbol      = "osty_rt_bytes_to_hex"
-	ostyRtBytesFromHexSymbol    = "osty_rt_bytes_from_hex"
-	ostyRtBytesIsValidHexSymbol = "osty_rt_bytes_is_valid_hex"
+	ostyRtBytesToHexSymbol           = "osty_rt_bytes_to_hex"
+	ostyRtBytesFromHexSymbol         = "osty_rt_bytes_from_hex"
+	ostyRtBytesIsValidHexSymbol      = "osty_rt_bytes_is_valid_hex"
+	ostyRtEncodingBase64EncodeSymbol = "osty_rt_encoding_base64_encode"
+	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
 )
 
 func collectStdEncodingAliases(file *ast.File) map[string]bool {
@@ -46,6 +48,38 @@ func collectStdEncodingAliases(file *ast.File) map[string]bool {
 
 // stdEncodingHexCallInfo matches `<encoding-alias>.hex.<method>(...)`.
 func (g *generator) stdEncodingHexCallInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	return g.stdEncodingMethodInfo(call, "hex")
+}
+
+func (g *generator) stdEncodingBase64CallInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool) {
+	if field, ok := g.stdEncodingMethodInfo(call, "base64"); ok {
+		return field, "base64", true
+	}
+	// Nested form: `encoding.base64.url.<method>(...)`.
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return nil, "", false
+	}
+	urlField, ok := field.X.(*ast.FieldExpr)
+	if !ok || urlField == nil || urlField.IsOptional || urlField.Name != "url" {
+		return nil, "", false
+	}
+	base64Field, ok := urlField.X.(*ast.FieldExpr)
+	if !ok || base64Field == nil || base64Field.IsOptional || base64Field.Name != "base64" {
+		return nil, "", false
+	}
+	alias, ok := base64Field.X.(*ast.Ident)
+	if !ok || alias == nil || !g.stdEncodingAliases[alias.Name] {
+		return nil, "", false
+	}
+	switch field.Name {
+	case "encode", "decode":
+		return field, "base64url", true
+	}
+	return nil, "", false
+}
+
+func (g *generator) stdEncodingMethodInfo(call *ast.CallExpr, sub string) (*ast.FieldExpr, bool) {
 	if call == nil || len(g.stdEncodingAliases) == 0 {
 		return nil, false
 	}
@@ -53,11 +87,11 @@ func (g *generator) stdEncodingHexCallInfo(call *ast.CallExpr) (*ast.FieldExpr, 
 	if !ok || field.IsOptional {
 		return nil, false
 	}
-	hexField, ok := field.X.(*ast.FieldExpr)
-	if !ok || hexField == nil || hexField.IsOptional || hexField.Name != "hex" {
+	subField, ok := field.X.(*ast.FieldExpr)
+	if !ok || subField == nil || subField.IsOptional || subField.Name != sub {
 		return nil, false
 	}
-	alias, ok := hexField.X.(*ast.Ident)
+	alias, ok := subField.X.(*ast.Ident)
 	if !ok || alias == nil || !g.stdEncodingAliases[alias.Name] {
 		return nil, false
 	}
@@ -80,62 +114,93 @@ func hexDecodeResultSourceType() ast.Type {
 }
 
 func (g *generator) emitStdEncodingCall(call *ast.CallExpr) (value, bool, error) {
-	field, ok := g.stdEncodingHexCallInfo(call)
-	if !ok {
-		return value{}, false, nil
+	if field, ok := g.stdEncodingHexCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			if len(call.Args) != 1 {
+				return value{}, true, unsupportedf("call", "encoding.hex.encode expects 1 argument, got %d", len(call.Args))
+			}
+			data, err := g.emitStdBytesArg(call.Args[0], "encoding.hex.encode", 0)
+			if err != nil {
+				return value{}, true, err
+			}
+			out, err := g.emitEncodingHexEncodeRuntime(data)
+			return out, true, err
+		case "decode":
+			if len(call.Args) != 1 {
+				return value{}, true, unsupportedf("call", "encoding.hex.decode expects 1 argument, got %d", len(call.Args))
+			}
+			text, err := g.emitStdStringsArg(call.Args[0], "encoding.hex.decode", 0)
+			if err != nil {
+				return value{}, true, err
+			}
+			out, err := g.emitEncodingHexDecodeResult(text)
+			return out, true, err
+		}
 	}
-	switch field.Name {
-	case "encode":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "encoding.hex.encode expects 1 argument, got %d", len(call.Args))
+	if field, variant, ok := g.stdEncodingBase64CallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			if len(call.Args) != 1 {
+				return value{}, true, unsupportedf("call", "encoding.%s.encode expects 1 argument, got %d", variant, len(call.Args))
+			}
+			data, err := g.emitStdBytesArg(call.Args[0], "encoding."+variant+".encode", 0)
+			if err != nil {
+				return value{}, true, err
+			}
+			out, err := g.emitEncodingBase64EncodeRuntime(data, variant == "base64url")
+			return out, true, err
+		case "decode":
+			// AST-route decode for base64 awaits the same Result<Bytes,
+			// Error>-via-MIR fix as hex.decode (separate cycle).
+			return value{}, true, unsupportedf("call", "encoding.%s.decode requires MIR Result<Bytes, Error> handling (separate cycle)", variant)
 		}
-		data, err := g.emitStdBytesArg(call.Args[0], "encoding.hex.encode", 0)
-		if err != nil {
-			return value{}, true, err
-		}
-		out, err := g.emitEncodingHexEncodeRuntime(data)
-		return out, true, err
-	case "decode":
-		if len(call.Args) != 1 {
-			return value{}, true, unsupportedf("call", "encoding.hex.decode expects 1 argument, got %d", len(call.Args))
-		}
-		text, err := g.emitStdStringsArg(call.Args[0], "encoding.hex.decode", 0)
-		if err != nil {
-			return value{}, true, err
-		}
-		out, err := g.emitEncodingHexDecodeResult(text)
-		return out, true, err
 	}
 	return value{}, false, nil
 }
 
 func (g *generator) stdEncodingCallStaticResult(call *ast.CallExpr) (value, bool) {
-	field, ok := g.stdEncodingHexCallInfo(call)
-	if !ok {
-		return value{}, false
-	}
-	switch field.Name {
-	case "encode":
-		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
-	case "decode":
-		if info, ok := builtinResultTypeFromAST(hexDecodeResultSourceType(), g.typeEnv()); ok {
-			return value{typ: info.typ, sourceType: hexDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+	if field, ok := g.stdEncodingHexCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
+		case "decode":
+			if info, ok := builtinResultTypeFromAST(hexDecodeResultSourceType(), g.typeEnv()); ok {
+				return value{typ: info.typ, sourceType: hexDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+			}
+			return value{}, false
 		}
-		return value{}, false
+	}
+	if field, _, ok := g.stdEncodingBase64CallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
+		case "decode":
+			if info, ok := builtinResultTypeFromAST(hexDecodeResultSourceType(), g.typeEnv()); ok {
+				return value{typ: info.typ, sourceType: hexDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+			}
+			return value{}, false
+		}
 	}
 	return value{}, false
 }
 
 func (g *generator) staticStdEncodingCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
-	field, ok := g.stdEncodingHexCallInfo(call)
-	if !ok {
-		return nil, false
+	if field, ok := g.stdEncodingHexCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return &ast.NamedType{Path: []string{"String"}}, true
+		case "decode":
+			return hexDecodeResultSourceType(), true
+		}
 	}
-	switch field.Name {
-	case "encode":
-		return &ast.NamedType{Path: []string{"String"}}, true
-	case "decode":
-		return hexDecodeResultSourceType(), true
+	if field, _, ok := g.stdEncodingBase64CallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return &ast.NamedType{Path: []string{"String"}}, true
+		case "decode":
+			return hexDecodeResultSourceType(), true
+		}
 	}
 	return nil, false
 }
@@ -144,6 +209,21 @@ func (g *generator) emitEncodingHexEncodeRuntime(data value) (value, error) {
 	g.declareRuntimeSymbol(ostyRtBytesToHexSymbol, "ptr", []paramInfo{{typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", ostyRtBytesToHexSymbol, []*LlvmValue{toOstyValue(data)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return v, nil
+}
+
+func (g *generator) emitEncodingBase64EncodeRuntime(data value, urlSafe bool) (value, error) {
+	sym := ostyRtEncodingBase64EncodeSymbol
+	if urlSafe {
+		sym = ostyRtEncodingBase64UrlEncSymbol
+	}
+	g.declareRuntimeSymbol(sym, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", sym, []*LlvmValue{toOstyValue(data)})
 	g.takeOstyEmitter(emitter)
 	v := fromOstyValue(out)
 	v.gcManaged = true
@@ -216,6 +296,43 @@ func (g *generator) emitEncodingHexDecodeResult(text value) (value, error) {
 	out.sourceType = sourceType
 	out.rootPaths = g.rootPathsForType(info.typ)
 	return out, nil
+}
+
+// emitStdEncodingBase64CallMIR routes `Base64__encode(self, data)` /
+// `Base64Url__encode(self, data)` MIR symbols to the runtime. Decode
+// is intentionally left to the AST path (which is also currently
+// gated until the MIR Result<Bytes, Error> wrapping lands).
+func (g *mirGen) emitStdEncodingBase64CallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	var prefix, runtime string
+	switch {
+	case strings.HasPrefix(fnRef.Symbol, "Base64Url__"):
+		prefix, runtime = "Base64Url__", ostyRtEncodingBase64UrlEncSymbol
+	case strings.HasPrefix(fnRef.Symbol, "Base64__"):
+		prefix, runtime = "Base64__", ostyRtEncodingBase64EncodeSymbol
+	default:
+		return false, nil
+	}
+	method := strings.TrimPrefix(fnRef.Symbol, prefix)
+	if method != "encode" {
+		// decode -> AST path / pending
+		if method == "decode" {
+			return true, unsupported("mir-mvp", "encoding.base64.decode requires AST lowering route (MIR Result<Bytes, Error> handling pending)")
+		}
+		return false, nil
+	}
+	args := c.Args
+	if len(args) == 0 {
+		return true, unsupported("mir-mvp", "encoding.base64 method without receiver")
+	}
+	args = args[1:]
+	if len(args) != 1 {
+		return true, unsupported("mir-mvp", "encoding.base64.encode requires one Bytes argument")
+	}
+	data, err := g.evalBytesArg(args[0], "encoding.base64.encode", 0)
+	if err != nil {
+		return true, err
+	}
+	return true, g.emitRuntimeCallToDest(c, runtime, "ptr", []mirRuntimeArg{data})
 }
 
 // emitStdEncodingCallMIR is the MIR-level dispatch. The call site

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 465 `.osty` file(s)  
-**Captured:** 253 residual case(s) — **0** AI-slip(s) airepair rewrote, **253** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 466 `.osty` file(s)  
+**Captured:** 254 residual case(s) — **0** AI-slip(s) airepair rewrote, **254** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
- **C runtime**: `osty_rt_encoding_base64_{encode,url_encode,decode,url_decode}` 4 함수 추가 (RFC 4648 §4 standard + §5 URL-safe). Decode 는 invalid input 시 NULL 반환 — abort 없음.
- **LLVM shim**: [`stdlib_encoding_shim.go`](internal/llvmgen/stdlib_encoding_shim.go) AST + MIR dispatch 확장. `encoding.base64.encode(b)` 통과, decode 는 hex.decode 와 같은 MIR Result 갭 (별 cycle).
- **E2E**: [`examples/encoding_base64_e2e/`](examples/encoding_base64_e2e/) 3/3 통과 (hello / 1-byte / 2-byte padding).

## Phase
- ~~Phase 1 (#1346): hex.encode~~
- **Phase 2 (this PR): base64.encode**
- Phase 2.5: `encoding.base64.url.encode` (nested call MIR 갭)
- Phase 3: url percent-encode

## Test plan
- [x] `just prepush` 통과
- [x] `examples/encoding_base64_e2e/` 3/3 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)