### PR TITLE
lower std.encoding decode through MIR result shims

### DIFF
--- a/internal/llvmgen/stdlib_encoding_mir_test.go
+++ b/internal/llvmgen/stdlib_encoding_mir_test.go
@@ -54,6 +54,29 @@ func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1(t *testing.T) {
+	got := generateStdEncodingDecodeDiscardMIR(t, "hex")
+	for _, want := range []string{
+		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",
+		"call i1 @osty_rt_bytes_is_valid_hex(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated discarded hex.decode LLVM missing %q:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{
+		"call void @osty_rt_bytes_is_valid_hex(",
+		"call ptr @osty_rt_bytes_from_hex(",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("discarded hex.decode emitted forbidden %q:\n%s", forbidden, got)
+		}
+	}
+	if strings.Contains(got, "Hex__decode") {
+		t.Fatalf("Hex__decode leaked as an unresolved call:\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRStdEncodingBase64DecodeReturnsResult(t *testing.T) {
 	for _, tc := range []struct {
 		variant string
@@ -85,19 +108,8 @@ func TestGenerateFromMIRStdEncodingBase64DecodeReturnsResult(t *testing.T) {
 
 func generateStdEncodingDecodeMIR(t *testing.T, variant string) string {
 	t.Helper()
-	useDecl := &ir.UseDecl{
-		Path:    []string{"std", "encoding"},
-		RawPath: "std.encoding",
-		Alias:   "encoding",
-	}
-	resultBytes := &ir.NamedType{
-		Name:    "Result",
-		Builtin: true,
-		Args: []ir.Type{
-			ir.TBytes,
-			&ir.NamedType{Name: "Error", Builtin: true},
-		},
-	}
+	useDecl := stdEncodingUseDecl()
+	resultBytes := stdEncodingDecodeResultType()
 	fn := &ir.FnDecl{
 		Name:   "decodeValue",
 		Return: resultBytes,
@@ -115,6 +127,48 @@ func generateStdEncodingDecodeMIR(t *testing.T, variant string) string {
 		t.Fatalf("GenerateFromMIR: %v", err)
 	}
 	return string(out)
+}
+
+func generateStdEncodingDecodeDiscardMIR(t *testing.T, variant string) string {
+	t.Helper()
+	useDecl := stdEncodingUseDecl()
+	resultBytes := stdEncodingDecodeResultType()
+	call := &ir.CallExpr{
+		Callee: stdEncodingDecodeCallee(variant),
+		Args:   []ir.Arg{{Value: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "00"}}}}},
+		T:      resultBytes,
+	}
+	fn := &ir.FnDecl{
+		Name:   "main",
+		Return: ir.TUnit,
+		Body:   &ir.Block{Stmts: []ir.Stmt{&ir.ExprStmt{X: call}}},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/std_encoding_" + variant + "_decode_discard_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	return string(out)
+}
+
+func stdEncodingUseDecl() *ir.UseDecl {
+	return &ir.UseDecl{
+		Path:    []string{"std", "encoding"},
+		RawPath: "std.encoding",
+		Alias:   "encoding",
+	}
+}
+
+func stdEncodingDecodeResultType() *ir.NamedType {
+	return &ir.NamedType{
+		Name:    "Result",
+		Builtin: true,
+		Args: []ir.Type{
+			ir.TBytes,
+			&ir.NamedType{Name: "Error", Builtin: true},
+		},
+	}
 }
 
 func stdEncodingDecodeCallee(variant string) ir.Expr {

--- a/internal/llvmgen/stdlib_encoding_mir_test.go
+++ b/internal/llvmgen/stdlib_encoding_mir_test.go
@@ -7,61 +7,36 @@ import (
 	"github.com/osty/osty/internal/ir"
 )
 
-func TestStdEncodingRuntimeLoweringMarksHexDecodeMIRResult(t *testing.T) {
-	spec, method, ok := stdEncodingRuntimeLoweringForMIRSymbol("Hex__decode")
-	if !ok {
-		t.Fatalf("Hex__decode did not match std.encoding MIR registry")
+func TestStdEncodingRuntimeLoweringMarksDecodeMIRResult(t *testing.T) {
+	cases := []struct {
+		symbol string
+		kind   stdEncodingRuntimeDecodeKind
+	}{
+		{symbol: "Hex__decode", kind: stdEncodingDecodeHexBytesResult},
+		{symbol: "Base64__decode", kind: stdEncodingDecodeNullableBytesResult},
+		{symbol: "Base64Url__decode", kind: stdEncodingDecodeNullableBytesResult},
 	}
-	if method != "decode" {
-		t.Fatalf("method = %q, want decode", method)
-	}
-	if spec == nil || spec.Variant != "hex" {
-		t.Fatalf("variant = %v, want hex", spec)
-	}
-	if spec.DecodeMIRKind != stdEncodingDecodeHexBytesResult {
-		t.Fatalf("hex decode MIR kind = %v, want stdEncodingDecodeHexBytesResult", spec.DecodeMIRKind)
+	for _, tc := range cases {
+		t.Run(tc.symbol, func(t *testing.T) {
+			spec, method, ok := stdEncodingRuntimeLoweringForMIRSymbol(tc.symbol)
+			if !ok {
+				t.Fatalf("%s did not match std.encoding MIR registry", tc.symbol)
+			}
+			if method != "decode" {
+				t.Fatalf("method = %q, want decode", method)
+			}
+			if spec == nil {
+				t.Fatalf("matched nil spec")
+			}
+			if spec.DecodeMIRKind != tc.kind {
+				t.Fatalf("decode MIR kind = %v, want %v", spec.DecodeMIRKind, tc.kind)
+			}
+		})
 	}
 }
 
 func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
-	useDecl := &ir.UseDecl{
-		Path:    []string{"std", "encoding"},
-		RawPath: "std.encoding",
-		Alias:   "encoding",
-	}
-	resultBytes := &ir.NamedType{
-		Name:    "Result",
-		Builtin: true,
-		Args: []ir.Type{
-			ir.TBytes,
-			&ir.NamedType{Name: "Error", Builtin: true},
-		},
-	}
-	fn := &ir.FnDecl{
-		Name:   "decodeHex",
-		Return: resultBytes,
-		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
-		Body: &ir.Block{Result: &ir.CallExpr{
-			Callee: &ir.FieldExpr{
-				X: &ir.FieldExpr{
-					X:    &ir.Ident{Name: "encoding", T: ir.ErrTypeVal},
-					Name: "hex",
-					T:    ir.ErrTypeVal,
-				},
-				Name: "decode",
-				T:    ir.ErrTypeVal,
-			},
-			Args: []ir.Arg{{Value: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString}}},
-			T:    resultBytes,
-		}},
-	}
-	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl, fn}}
-	m := buildMIRModuleFromHIR(t, hir)
-	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/std_encoding_hex_decode_mir.osty"})
-	if err != nil {
-		t.Fatalf("GenerateFromMIR: %v", err)
-	}
-	got := string(out)
+	got := generateStdEncodingDecodeMIR(t, "hex")
 	for _, want := range []string{
 		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",
 		"declare ptr @osty_rt_bytes_from_hex(ptr)",
@@ -76,5 +51,98 @@ func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
 	}
 	if strings.Contains(got, "Hex__decode") {
 		t.Fatalf("Hex__decode leaked as an unresolved call:\n%s", got)
+	}
+}
+
+func TestGenerateFromMIRStdEncodingBase64DecodeReturnsResult(t *testing.T) {
+	for _, tc := range []struct {
+		variant string
+		runtime string
+		leak    string
+	}{
+		{variant: "base64", runtime: "osty_rt_encoding_base64_decode", leak: "Base64__decode"},
+		{variant: "base64url", runtime: "osty_rt_encoding_base64url_decode", leak: "Base64Url__decode"},
+	} {
+		t.Run(tc.variant, func(t *testing.T) {
+			got := generateStdEncodingDecodeMIR(t, tc.variant)
+			for _, want := range []string{
+				"declare ptr @" + tc.runtime + "(ptr)",
+				"call ptr @" + tc.runtime + "(",
+				"icmp eq ptr",
+				"insertvalue",
+				"phi",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("generated MIR LLVM missing %q:\n%s", want, got)
+				}
+			}
+			if strings.Contains(got, tc.leak) {
+				t.Fatalf("%s leaked as an unresolved call:\n%s", tc.leak, got)
+			}
+		})
+	}
+}
+
+func generateStdEncodingDecodeMIR(t *testing.T, variant string) string {
+	t.Helper()
+	useDecl := &ir.UseDecl{
+		Path:    []string{"std", "encoding"},
+		RawPath: "std.encoding",
+		Alias:   "encoding",
+	}
+	resultBytes := &ir.NamedType{
+		Name:    "Result",
+		Builtin: true,
+		Args: []ir.Type{
+			ir.TBytes,
+			&ir.NamedType{Name: "Error", Builtin: true},
+		},
+	}
+	fn := &ir.FnDecl{
+		Name:   "decodeValue",
+		Return: resultBytes,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{Result: &ir.CallExpr{
+			Callee: stdEncodingDecodeCallee(variant),
+			Args:   []ir.Arg{{Value: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString}}},
+			T:      resultBytes,
+		}},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/std_encoding_" + variant + "_decode_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	return string(out)
+}
+
+func stdEncodingDecodeCallee(variant string) ir.Expr {
+	encoding := &ir.Ident{Name: "encoding", T: ir.ErrTypeVal}
+	switch variant {
+	case "hex":
+		return &ir.FieldExpr{
+			X:    &ir.FieldExpr{X: encoding, Name: "hex", T: ir.ErrTypeVal},
+			Name: "decode",
+			T:    ir.ErrTypeVal,
+		}
+	case "base64":
+		return &ir.FieldExpr{
+			X:    &ir.FieldExpr{X: encoding, Name: "base64", T: ir.ErrTypeVal},
+			Name: "decode",
+			T:    ir.ErrTypeVal,
+		}
+	case "base64url":
+		return &ir.FieldExpr{
+			X: &ir.FieldExpr{
+				X:    &ir.FieldExpr{X: encoding, Name: "base64", T: ir.ErrTypeVal},
+				Name: "url",
+				T:    ir.ErrTypeVal,
+			},
+			Name: "decode",
+			T:    ir.ErrTypeVal,
+		}
+	default:
+		return &ir.Ident{Name: "missing", T: ir.ErrTypeVal}
 	}
 }

--- a/internal/llvmgen/stdlib_encoding_mir_test.go
+++ b/internal/llvmgen/stdlib_encoding_mir_test.go
@@ -1,0 +1,80 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+func TestStdEncodingRuntimeLoweringMarksHexDecodeMIRResult(t *testing.T) {
+	spec, method, ok := stdEncodingRuntimeLoweringForMIRSymbol("Hex__decode")
+	if !ok {
+		t.Fatalf("Hex__decode did not match std.encoding MIR registry")
+	}
+	if method != "decode" {
+		t.Fatalf("method = %q, want decode", method)
+	}
+	if spec == nil || spec.Variant != "hex" {
+		t.Fatalf("variant = %v, want hex", spec)
+	}
+	if spec.DecodeMIRKind != stdEncodingDecodeHexBytesResult {
+		t.Fatalf("hex decode MIR kind = %v, want stdEncodingDecodeHexBytesResult", spec.DecodeMIRKind)
+	}
+}
+
+func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
+	useDecl := &ir.UseDecl{
+		Path:    []string{"std", "encoding"},
+		RawPath: "std.encoding",
+		Alias:   "encoding",
+	}
+	resultBytes := &ir.NamedType{
+		Name:    "Result",
+		Builtin: true,
+		Args: []ir.Type{
+			ir.TBytes,
+			&ir.NamedType{Name: "Error", Builtin: true},
+		},
+	}
+	fn := &ir.FnDecl{
+		Name:   "decodeHex",
+		Return: resultBytes,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{Result: &ir.CallExpr{
+			Callee: &ir.FieldExpr{
+				X: &ir.FieldExpr{
+					X:    &ir.Ident{Name: "encoding", T: ir.ErrTypeVal},
+					Name: "hex",
+					T:    ir.ErrTypeVal,
+				},
+				Name: "decode",
+				T:    ir.ErrTypeVal,
+			},
+			Args: []ir.Arg{{Value: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString}}},
+			T:    resultBytes,
+		}},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/std_encoding_hex_decode_mir.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",
+		"declare ptr @osty_rt_bytes_from_hex(ptr)",
+		"call i1 @osty_rt_bytes_is_valid_hex(",
+		"call ptr @osty_rt_bytes_from_hex(",
+		"insertvalue",
+		"phi",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated MIR LLVM missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Hex__decode") {
+		t.Fatalf("Hex__decode leaked as an unresolved call:\n%s", got)
+	}
+}

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -13,11 +13,13 @@ import (
 // AST and MIR dispatch do not grow separate prefix tables as codecs are added.
 
 const (
-	ostyRtBytesToHexSymbol           = "osty_rt_bytes_to_hex"
-	ostyRtBytesFromHexSymbol         = "osty_rt_bytes_from_hex"
-	ostyRtBytesIsValidHexSymbol      = "osty_rt_bytes_is_valid_hex"
-	ostyRtEncodingBase64EncodeSymbol = "osty_rt_encoding_base64_encode"
-	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
+	ostyRtBytesToHexSymbol            = "osty_rt_bytes_to_hex"
+	ostyRtBytesFromHexSymbol          = "osty_rt_bytes_from_hex"
+	ostyRtBytesIsValidHexSymbol       = "osty_rt_bytes_is_valid_hex"
+	ostyRtEncodingBase64EncodeSymbol  = "osty_rt_encoding_base64_encode"
+	ostyRtEncodingBase64UrlEncSymbol  = "osty_rt_encoding_base64url_encode"
+	ostyRtEncodingBase64DecodeSymbol  = "osty_rt_encoding_base64_decode"
+	ostyRtEncodingBase64UrlDecSymbol  = "osty_rt_encoding_base64url_decode"
 )
 
 type stdEncodingRuntimeDecodeKind int
@@ -25,6 +27,7 @@ type stdEncodingRuntimeDecodeKind int
 const (
 	stdEncodingDecodeUnsupported stdEncodingRuntimeDecodeKind = iota
 	stdEncodingDecodeHexBytesResult
+	stdEncodingDecodeNullableBytesResult
 )
 
 type stdEncodingRuntimeLowering struct {
@@ -32,6 +35,7 @@ type stdEncodingRuntimeLowering struct {
 	ASTPath              []string
 	MIRPrefix            string
 	EncodeSymbol         string
+	DecodeSymbol         string
 	DecodeMIRKind        stdEncodingRuntimeDecodeKind
 	DecodeMIRUnsupported string
 	DecodeASTUnsupported string
@@ -50,7 +54,8 @@ var stdEncodingRuntimeLowerings = []stdEncodingRuntimeLowering{
 		ASTPath:              []string{"base64"},
 		MIRPrefix:            "Base64__",
 		EncodeSymbol:         ostyRtEncodingBase64EncodeSymbol,
-		DecodeMIRUnsupported: "encoding.base64.decode requires AST lowering route (MIR Result<Bytes, Error> handling pending)",
+		DecodeSymbol:         ostyRtEncodingBase64DecodeSymbol,
+		DecodeMIRKind:        stdEncodingDecodeNullableBytesResult,
 		DecodeASTUnsupported: "encoding.base64.decode requires MIR Result<Bytes, Error> handling (separate cycle)",
 	},
 	{
@@ -58,7 +63,8 @@ var stdEncodingRuntimeLowerings = []stdEncodingRuntimeLowering{
 		ASTPath:              []string{"base64", "url"},
 		MIRPrefix:            "Base64Url__",
 		EncodeSymbol:         ostyRtEncodingBase64UrlEncSymbol,
-		DecodeMIRUnsupported: "encoding.base64url.decode requires AST lowering route (MIR Result<Bytes, Error> handling pending)",
+		DecodeSymbol:         ostyRtEncodingBase64UrlDecSymbol,
+		DecodeMIRKind:        stdEncodingDecodeNullableBytesResult,
 		DecodeASTUnsupported: "encoding.base64url.decode requires MIR Result<Bytes, Error> handling (separate cycle)",
 	},
 }
@@ -384,9 +390,21 @@ func (g *mirGen) emitStdEncodingDecodeCallMIR(c *mir.CallInstr, spec *stdEncodin
 	switch spec.DecodeMIRKind {
 	case stdEncodingDecodeHexBytesResult:
 		return g.emitEncodingHexDecodeMIR(c, text)
+	case stdEncodingDecodeNullableBytesResult:
+		return g.emitStdEncodingNullableBytesDecodeMIR(c, spec, text)
 	default:
 		return unsupported("mir-mvp", "encoding."+spec.Variant+".decode has no MIR lowering strategy")
 	}
+}
+
+func (g *mirGen) emitStdEncodingNullableBytesDecodeMIR(c *mir.CallInstr, spec *stdEncodingRuntimeLowering, text mirRuntimeArg) error {
+	if spec.DecodeSymbol == "" {
+		return unsupported("mir-mvp", "encoding."+spec.Variant+".decode missing runtime symbol")
+	}
+	g.declareRuntime(spec.DecodeSymbol, mirRuntimeDeclareLine("ptr", spec.DecodeSymbol, "ptr"))
+	decoded := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(decoded, "ptr", spec.DecodeSymbol, mirRuntimeArgList([]mirRuntimeArg{text})))
+	return g.emitPtrResultFromNullable(c, decoded, mir.TBytes, "")
 }
 
 // emitEncodingHexDecodeMIR validates input first (since

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -20,22 +20,30 @@ const (
 	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
 )
 
+type stdEncodingRuntimeDecodeKind int
+
+const (
+	stdEncodingDecodeUnsupported stdEncodingRuntimeDecodeKind = iota
+	stdEncodingDecodeHexBytesResult
+)
+
 type stdEncodingRuntimeLowering struct {
 	Variant              string
 	ASTPath              []string
 	MIRPrefix            string
 	EncodeSymbol         string
+	DecodeMIRKind        stdEncodingRuntimeDecodeKind
 	DecodeMIRUnsupported string
 	DecodeASTUnsupported string
 }
 
 var stdEncodingRuntimeLowerings = []stdEncodingRuntimeLowering{
 	{
-		Variant:              "hex",
-		ASTPath:              []string{"hex"},
-		MIRPrefix:            "Hex__",
-		EncodeSymbol:         ostyRtBytesToHexSymbol,
-		DecodeMIRUnsupported: "encoding.hex.decode requires AST lowering route (MIR Result<Bytes, Error> handling pending)",
+		Variant:       "hex",
+		ASTPath:       []string{"hex"},
+		MIRPrefix:     "Hex__",
+		EncodeSymbol:  ostyRtBytesToHexSymbol,
+		DecodeMIRKind: stdEncodingDecodeHexBytesResult,
 	},
 	{
 		Variant:              "base64",
@@ -332,10 +340,9 @@ func (g *mirGen) emitStdEncodingRuntimeCallMIR(c *mir.CallInstr, fnRef *mir.FnRe
 	if !ok || spec == nil {
 		return false, nil
 	}
-	if method != "encode" {
-		if method == "decode" {
-			return true, unsupported("mir-mvp", spec.DecodeMIRUnsupported)
-		}
+	switch method {
+	case "encode", "decode":
+	default:
 		return false, nil
 	}
 	args := c.Args
@@ -343,14 +350,43 @@ func (g *mirGen) emitStdEncodingRuntimeCallMIR(c *mir.CallInstr, fnRef *mir.FnRe
 		return true, unsupported("mir-mvp", "encoding."+spec.Variant+" method without receiver")
 	}
 	args = args[1:]
+	switch method {
+	case "encode":
+		return true, g.emitStdEncodingEncodeCallMIR(c, spec, args)
+	case "decode":
+		return true, g.emitStdEncodingDecodeCallMIR(c, spec, args)
+	}
+	return false, nil
+}
+
+func (g *mirGen) emitStdEncodingEncodeCallMIR(c *mir.CallInstr, spec *stdEncodingRuntimeLowering, args []mir.Operand) error {
 	if len(args) != 1 {
-		return true, unsupported("mir-mvp", "encoding."+spec.Variant+".encode requires one Bytes argument")
+		return unsupported("mir-mvp", "encoding."+spec.Variant+".encode requires one Bytes argument")
 	}
 	data, err := g.evalBytesArg(args[0], "encoding."+spec.Variant+".encode", 0)
 	if err != nil {
-		return true, err
+		return err
 	}
-	return true, g.emitRuntimeCallToDest(c, spec.EncodeSymbol, "ptr", []mirRuntimeArg{data})
+	return g.emitRuntimeCallToDest(c, spec.EncodeSymbol, "ptr", []mirRuntimeArg{data})
+}
+
+func (g *mirGen) emitStdEncodingDecodeCallMIR(c *mir.CallInstr, spec *stdEncodingRuntimeLowering, args []mir.Operand) error {
+	if spec.DecodeMIRKind == stdEncodingDecodeUnsupported {
+		return unsupported("mir-mvp", spec.DecodeMIRUnsupported)
+	}
+	if len(args) != 1 {
+		return unsupported("mir-mvp", "encoding."+spec.Variant+".decode requires one String argument")
+	}
+	text, err := g.evalStringArg(args[0], "encoding."+spec.Variant+".decode", 0)
+	if err != nil {
+		return err
+	}
+	switch spec.DecodeMIRKind {
+	case stdEncodingDecodeHexBytesResult:
+		return g.emitEncodingHexDecodeMIR(c, text)
+	default:
+		return unsupported("mir-mvp", "encoding."+spec.Variant+".decode has no MIR lowering strategy")
+	}
 }
 
 // emitEncodingHexDecodeMIR validates input first (since
@@ -360,11 +396,10 @@ func (g *mirGen) emitStdEncodingRuntimeCallMIR(c *mir.CallInstr, fnRef *mir.FnRe
 // runtime call itself aborts rather than returning null.
 func (g *mirGen) emitEncodingHexDecodeMIR(c *mir.CallInstr, text mirRuntimeArg) error {
 	if c.Dest == nil {
-		// No dest — caller drops the result. Still validate to honor
+		// No dest; caller drops the result. Still validate to honor
 		// the no-abort contract; from_hex itself is skipped.
 		g.declareRuntime(ostyRtBytesIsValidHexSymbol, mirRuntimeDeclareLine("i1", ostyRtBytesIsValidHexSymbol, "ptr"))
-		_ = g.fresh()
-		g.fnBuf.WriteString(mirCallVoidLine(ostyRtBytesIsValidHexSymbol, mirRuntimeArgList([]mirRuntimeArg{text})))
+		g.fnBuf.WriteString(mirCallStmtLine("i1", ostyRtBytesIsValidHexSymbol, mirRuntimeArgList([]mirRuntimeArg{text})))
 		return nil
 	}
 	destLoc := g.fn.Local(c.Dest.Local)
@@ -384,7 +419,7 @@ func (g *mirGen) emitEncodingHexDecodeMIR(c *mir.CallInstr, text mirRuntimeArg) 
 	contLabel := g.freshLabel("hex.decode.cont")
 	g.fnBuf.WriteString(mirBrCondLine(valid, okLabel, errLabel))
 
-	// Ok arm: call from_hex (safe — validated above), wrap in Ok struct.
+	// Ok arm: call from_hex (safe; validated above), wrap in Ok struct.
 	g.fnBuf.WriteString(mirLabelLine(okLabel))
 	decoded := g.fresh()
 	g.fnBuf.WriteString(mirCallValueLine(decoded, "ptr", ostyRtBytesFromHexSymbol, mirRuntimeArgList([]mirRuntimeArg{text})))


### PR DESCRIPTION
## Summary
- add explicit std.encoding MIR decode strategies to the runtime lowering registry
- wire `Hex__decode` to the abort-safe validator + `Result<Bytes, Error>` aggregate builder
- wire `Base64__decode` / `Base64Url__decode` to nullable runtime decode helpers and `Result<Bytes, Error>` wrapping
- fix discarded `hex.decode` MIR lowering to call the validator with the correct `i1` return type
- add MIR-focused tests for registry flags and generated LLVM shapes across hex/base64/base64url

## Tests
- Not run locally: Codex shell process launch is currently unavailable in this workspace session.
