### PR TITLE
[codex] std.process streaming commands

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -119,6 +119,7 @@ partial 모듈 4개 (bytes / crypto / option / result) 는 **호출 패턴 한�
 | secrets | §10.41 | 20 | 8 | 100% | keychain 위임 | keychain 백엔드 따라감 |
 | cli | §10.1 | 260 | 11 | 0% | env 위임 | flag/option spec/parse 본문 |
 | cmd | unspec | 214 | 24 | 0% | os shim + cmd runtime 8 | command builder + POSIX shell escape |
+| process | §10.1 + unspec | 277 | 32 | 74% | os shim + process runtime 9 | `ProcessCommand` / `ProcessPipeline` facade, stdin text, captured stdout/stderr, shell pipeline composition. abort/todo/unreachable는 backend-owned primitive 유지 |
 | path | §10.15 | 191 | 9 | 22% | runtime path 2 | join/split/extension 본문, absolute/canonical은 백엔드 |
 
 ### 2.3 ⭐⭐⭐ Surface-rich (스펙 외 또는 부분 백엔드)
@@ -212,7 +213,6 @@ partial 모듈 4개 (bytes / crypto / option / result) 는 **호출 패턴 한�
 | cmp | §10.1 | 27 | Equal / Ordered / Hashable interface 정의. 컴파일러 인지 |
 | error | §10.1 / §7 | 96 | Error interface + BasicError + WrappedError + wrap/chain/rootCause |
 | ref | §10.1 | 9 | `same<T>(a, b)` 단일 함수, declaration-only — 컴파일러 intrinsic 가정 |
-| process | §10.1 | 24 | abort/unreachable/todo/ignoreError/logError. 60% bodyless — 컴파일러 인지 |
 | debug | §10.1 | 10 | `dbg(value)` — 컴파일러가 source-text 캡처 |
 | hint | unspec | 25 | `black_box` 벤치 헬퍼 |
 | runtime/raw | §19 | 55 | runtime sublanguage (privileged package only) |
@@ -223,7 +223,7 @@ partial 모듈 4개 (bytes / crypto / option / result) 는 **호출 패턴 한�
 |---|---|---|
 | ⭐⭐⭐⭐⭐ Production (LLVM E2E 통과) | 15 | 14% |
 | ⭐⭐⭐⭐⭐ Production (declared, 매트릭스 5★ 미검증) | 10 | 9% |
-| ⭐⭐⭐⭐ Functional | 12 | 12% |
+| ⭐⭐⭐⭐ Functional | 13 | 13% |
 | ⭐⭐⭐ Surface-rich | 62 | 60% |
 | ⭐⭐ Spec-stub (백엔드 부재) | 0 | 0% |
 | ⭐ Broken / Placeholder | 0 | 0% |
@@ -294,7 +294,7 @@ unspec 모듈 62개는 stdlib에 들어갔지만 LANG_SPEC에 등재 안 됨. su
 uuid/regex는 declaration-only인데 백엔드도 없음. **모든 declaration-only 모듈은 `osty_rt_<name>_*` 또는 shim 직접 grep으로 검증 필수**.
 
 ### 5.5 이름 함정 (이전 함정, 유효)
-`process.osty` (exception helper) vs `cmd.osty` (command builder) vs `os.osty` (real OS). 이름만 보고 카테고리 추정 금지.
+`process.osty`는 이제 exception helper + OS process facade이고, `cmd.osty`는 낮은 단계 command builder, `os.osty`는 실제 OS syscall wrapper다. 이름만 보고 카테고리 추정 금지.
 
 ### 5.6 spec 위반 중복 정의 (신규 발견)
 ~~`thread.Duration{}` 빈 struct가 `time.Duration`과 동시 존재~~ → 2026-05-02 재확인 결과 commit `23f4568c` (`refactor: thread.Duration stub 제거, std.time 단일 타입으로 통일`)에서 이미 제거됨. 매트릭스가 stale했던 사례. **다른 모듈도 같은 stale 가능성 — 매트릭스 작성 시점 vs 현재 git HEAD 차이 항상 검증 필요**.

--- a/internal/backend/llvm_os_process_test.go
+++ b/internal/backend/llvm_os_process_test.go
@@ -225,6 +225,58 @@ fn main() {
 	}
 }
 
+func TestLLVMBackendBinaryRunsStdProcessStreamingSurface(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("std.process shell pipeline uses POSIX shell escaping in this test")
+	}
+	src := `use std.process
+
+fn main() {
+    match process.command("cat").withStdin("alpha\nbeta\n").run() {
+        Ok(out) -> {
+            println(out.exitCode == 0)
+            println(out.stdout == "alpha\nbeta\n")
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+        },
+    }
+
+    match process.pipe(
+        process.command("tr").arg("a-z").arg("A-Z"),
+        process.command("grep").arg("BETA"),
+    ).withStdin("alpha\nbeta\n").run() {
+        Ok(out) -> {
+            println(out.ok())
+            println(out.stdout.contains("BETA"))
+        },
+        Err(err) -> {
+            println(false)
+            println(err.message())
+        },
+    }
+}
+`
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, src)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "true\ntrue\ntrue\ntrue\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q\nsource:\n%s", got, want, src)
+	}
+}
+
 func TestLLVMBackendBinaryStdOsExitUsesRequestedCode(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -10235,6 +10235,55 @@ const char *osty_rt_cmd_pipeline_shell_line(void *raw_stages) {
     return out;
 }
 
+typedef struct osty_rt_process_command {
+    const char *program;
+    void *args;
+    const char *cwd;
+    void *env;
+    int64_t timeout_millis;
+    bool use_shell;
+    const char *stdin_text;
+    bool has_stdin;
+} osty_rt_process_command;
+
+const char *osty_rt_process_pipeline_shell_line(void *raw_stages) {
+    osty_rt_list *stages;
+    osty_rt_process_command *commands;
+    int64_t i;
+    int64_t count;
+    size_t total;
+    char *out;
+    char *cursor;
+
+    stages = osty_rt_list_cast(raw_stages);
+    if (stages == NULL || stages->len == 0) {
+        out = (char *)osty_gc_allocate_managed(1, OSTY_GC_KIND_STRING, "runtime.process.pipeline.empty", NULL, NULL);
+        out[0] = '\0';
+        return out;
+    }
+    commands = (osty_rt_process_command *)stages->data;
+    count = stages->len;
+    total = 0;
+    for (i = 0; i < count; i++) {
+        total += osty_rt_cmd_shell_line_len(commands[i].program, commands[i].args, commands[i].use_shell);
+        if (i + 1 < count) {
+            total += 3;
+        }
+    }
+    out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.process.pipeline", NULL, NULL);
+    cursor = out;
+    for (i = 0; i < count; i++) {
+        cursor = osty_rt_cmd_write_shell_line(cursor, commands[i].program, commands[i].args, commands[i].use_shell);
+        if (i + 1 < count) {
+            *cursor++ = ' ';
+            *cursor++ = '|';
+            *cursor++ = ' ';
+        }
+    }
+    *cursor = '\0';
+    return out;
+}
+
 const char *osty_rt_strings_Repeat(const char *value, int64_t n) {
     size_t value_len;
     size_t total;
@@ -26960,12 +27009,32 @@ static char *osty_rt_os_build_windows_command_line(const char *cmd, void *args, 
     return buf;
 }
 
-static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
+static bool osty_rt_os_write_all_handle_win(HANDLE handle, const char *text) {
+    const char *cursor = text == NULL ? "" : text;
+    size_t remaining = strlen(cursor);
+    while (remaining > 0) {
+        DWORD chunk = remaining > 0x7fffffffU ? 0x7fffffffU : (DWORD)remaining;
+        DWORD wrote = 0;
+        if (!WriteFile(handle, cursor, chunk, &wrote, NULL)) {
+            return false;
+        }
+        if (wrote == 0) {
+            return false;
+        }
+        cursor += wrote;
+        remaining -= (size_t)wrote;
+    }
+    return true;
+}
+
+static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms, const char *stdin_text) {
     char *stdout_path = NULL;
     char *stderr_path = NULL;
+    char *stdin_path = NULL;
     char *cmdline = NULL;
     char *cwd_text = NULL;
     char *env_block = NULL;
+    char *stdin_data = NULL;
     void *stdout_text = NULL;
     void *stderr_text = NULL;
     HANDLE stdout_handle = INVALID_HANDLE_VALUE;
@@ -26999,7 +27068,42 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
         free(env_block);
         return osty_rt_os_exec_error_result("failed to launch process", "could not create stderr temp file", "runtime.os.exec.error");
     }
-    {
+    if (stdin_text != NULL) {
+        if (!osty_rt_os_open_tempfile_win(&stdin_path, &stdin_handle)) {
+            CloseHandle(stdout_handle);
+            CloseHandle(stderr_handle);
+            DeleteFileA(stdout_path);
+            DeleteFileA(stderr_path);
+            free(stdout_path);
+            free(stderr_path);
+            free(cwd_text);
+            free(env_block);
+            return osty_rt_os_exec_error_result("failed to launch process", "could not create stdin temp file", "runtime.os.exec.error");
+        }
+        stdin_data = osty_rt_os_cstr_dup(stdin_text, "runtime.os.exec.stdin");
+        if (!osty_rt_os_write_all_handle_win(stdin_handle, stdin_data) ||
+            SetFilePointer(stdin_handle, 0, NULL, FILE_BEGIN) == INVALID_SET_FILE_POINTER) {
+            DWORD code = GetLastError();
+            char buf[96];
+            int written = snprintf(buf, sizeof(buf), "win32 error %lu", (unsigned long)code);
+            CloseHandle(stdin_handle);
+            CloseHandle(stdout_handle);
+            CloseHandle(stderr_handle);
+            DeleteFileA(stdin_path);
+            DeleteFileA(stdout_path);
+            DeleteFileA(stderr_path);
+            free(stdin_path);
+            free(stdout_path);
+            free(stderr_path);
+            free(stdin_data);
+            free(cwd_text);
+            free(env_block);
+            if (written < 0) {
+                return osty_rt_os_exec_error_result("failed to prepare process stdin", "WriteFile failed", "runtime.os.exec.error");
+            }
+            return osty_rt_os_exec_error_result("failed to prepare process stdin", buf, "runtime.os.exec.error");
+        }
+    } else {
         SECURITY_ATTRIBUTES sa;
         sa.nLength = sizeof(sa);
         sa.lpSecurityDescriptor = NULL;
@@ -27032,8 +27136,13 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
         CloseHandle(stdin_handle);
         CloseHandle(stdout_handle);
         CloseHandle(stderr_handle);
+        if (stdin_path != NULL) {
+            DeleteFileA(stdin_path);
+            free(stdin_path);
+        }
         DeleteFileA(stdout_path);
         DeleteFileA(stderr_path);
+        free(stdin_data);
         free(stdout_path);
         free(stderr_path);
         free(cmdline);
@@ -27047,6 +27156,11 @@ static osty_rt_os_exec_result *osty_rt_os_exec_windows(const char *cmd, void *ar
     CloseHandle(stdin_handle);
     CloseHandle(stdout_handle);
     CloseHandle(stderr_handle);
+    if (stdin_path != NULL) {
+        DeleteFileA(stdin_path);
+        free(stdin_path);
+        free(stdin_data);
+    }
     free(cmdline);
     if (timeout_ms > 0) {
         DWORD wait_ms = timeout_ms > (int64_t)0xFFFFFFFF ? 0xFFFFFFFF : (DWORD)timeout_ms;
@@ -27268,12 +27382,42 @@ static int osty_rt_os_open_tempfile_posix(const char *prefix, char **out_path) {
     return fd;
 }
 
-static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
+static int osty_rt_os_write_all_fd_posix(int fd, const char *text) {
+    const char *cursor;
+    size_t remaining;
+    if (fd < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    cursor = text == NULL ? "" : text;
+    remaining = strlen(cursor);
+    while (remaining > 0) {
+        ssize_t wrote = write(fd, cursor, remaining);
+        if (wrote < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (wrote == 0) {
+            errno = EIO;
+            return -1;
+        }
+        cursor += wrote;
+        remaining -= (size_t)wrote;
+    }
+    return 0;
+}
+
+static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms, const char *stdin_text) {
     char *stdout_path = NULL;
     char *stderr_path = NULL;
+    char *stdin_path = NULL;
     char *cwd_text = NULL;
+    char *stdin_data = NULL;
     int stdout_fd = -1;
     int stderr_fd = -1;
+    int stdin_fd = -1;
     int exec_pipe[2] = {-1, -1};
     char **argv = NULL;
     char **envp = NULL;
@@ -27318,13 +27462,50 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
     }
+    if (stdin_text != NULL) {
+        stdin_fd = osty_rt_os_open_tempfile_posix("osty-in.", &stdin_path);
+        if (stdin_fd < 0) {
+            close(stdout_fd);
+            close(stderr_fd);
+            unlink(stdout_path);
+            unlink(stderr_path);
+            free(stdout_path);
+            free(stderr_path);
+            free(cwd_text);
+            osty_rt_os_envp_free(envp);
+            return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
+        }
+        stdin_data = osty_rt_os_cstr_dup(stdin_text, "runtime.os.exec.stdin");
+        if (osty_rt_os_write_all_fd_posix(stdin_fd, stdin_data) != 0 || lseek(stdin_fd, 0, SEEK_SET) < 0) {
+            int err = errno;
+            close(stdout_fd);
+            close(stderr_fd);
+            close(stdin_fd);
+            unlink(stdout_path);
+            unlink(stderr_path);
+            unlink(stdin_path);
+            free(stdout_path);
+            free(stderr_path);
+            free(stdin_path);
+            free(stdin_data);
+            free(cwd_text);
+            osty_rt_os_envp_free(envp);
+            return osty_rt_os_exec_error_result("failed to prepare process stdin", strerror(err), "runtime.os.exec.error");
+        }
+    }
     if (pipe(exec_pipe) != 0) {
         close(stdout_fd);
         close(stderr_fd);
+        if (stdin_fd >= 0) {
+            close(stdin_fd);
+            unlink(stdin_path);
+        }
         unlink(stdout_path);
         unlink(stderr_path);
         free(stdout_path);
         free(stderr_path);
+        free(stdin_path);
+        free(stdin_data);
         free(cwd_text);
         osty_rt_os_envp_free(envp);
         return osty_rt_os_exec_error_result("failed to launch process", strerror(errno), "runtime.os.exec.error");
@@ -27347,12 +27528,18 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
         }
         close(stdout_fd);
         close(stderr_fd);
+        if (stdin_fd >= 0) {
+            close(stdin_fd);
+            unlink(stdin_path);
+        }
         close(exec_pipe[0]);
         close(exec_pipe[1]);
         unlink(stdout_path);
         unlink(stderr_path);
         free(stdout_path);
         free(stderr_path);
+        free(stdin_path);
+        free(stdin_data);
         free(cwd_text);
         osty_rt_os_argv_free(argv);
         osty_rt_os_envp_free(envp);
@@ -27360,13 +27547,18 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     }
     if (pid == 0) {
         close(exec_pipe[0]);
-        if (dup2(stdout_fd, STDOUT_FILENO) < 0 || dup2(stderr_fd, STDERR_FILENO) < 0) {
+        if ((stdin_fd >= 0 && dup2(stdin_fd, STDIN_FILENO) < 0) ||
+            dup2(stdout_fd, STDOUT_FILENO) < 0 ||
+            dup2(stderr_fd, STDERR_FILENO) < 0) {
             int err = errno;
             (void)write(exec_pipe[1], &err, sizeof(err));
             _exit(127);
         }
         close(stdout_fd);
         close(stderr_fd);
+        if (stdin_fd >= 0) {
+            close(stdin_fd);
+        }
         if (cwd_text != NULL && chdir(cwd_text) != 0) {
             int err = errno;
             (void)write(exec_pipe[1], &err, sizeof(err));
@@ -27391,6 +27583,12 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
     }
     close(stdout_fd);
     close(stderr_fd);
+    if (stdin_fd >= 0) {
+        close(stdin_fd);
+        unlink(stdin_path);
+        free(stdin_path);
+        free(stdin_data);
+    }
     close(exec_pipe[1]);
     sigemptyset(&sigurg_mask);
     sigaddset(&sigurg_mask, SIGURG);
@@ -27482,14 +27680,26 @@ static osty_rt_os_exec_result *osty_rt_os_exec_posix(const char *cmd, void *args
 
 osty_rt_os_exec_result *osty_rt_os_exec_options(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms) {
 #if defined(_WIN32)
-    return osty_rt_os_exec_windows(cmd, args, shell, cwd, env_overrides, timeout_ms);
+    return osty_rt_os_exec_windows(cmd, args, shell, cwd, env_overrides, timeout_ms, NULL);
 #else
-    return osty_rt_os_exec_posix(cmd, args, shell, cwd, env_overrides, timeout_ms);
+    return osty_rt_os_exec_posix(cmd, args, shell, cwd, env_overrides, timeout_ms, NULL);
 #endif
 }
 
 osty_rt_os_exec_result *osty_rt_os_exec(const char *cmd, void *args, bool shell) {
     return osty_rt_os_exec_options(cmd, args, shell, NULL, NULL, 0);
+}
+
+osty_rt_os_exec_result *osty_rt_os_exec_input_options(const char *cmd, void *args, bool shell, const char *cwd, void *env_overrides, int64_t timeout_ms, const char *stdin_text) {
+#if defined(_WIN32)
+    return osty_rt_os_exec_windows(cmd, args, shell, cwd, env_overrides, timeout_ms, stdin_text);
+#else
+    return osty_rt_os_exec_posix(cmd, args, shell, cwd, env_overrides, timeout_ms, stdin_text);
+#endif
+}
+
+osty_rt_os_exec_result *osty_rt_os_exec_input(const char *cmd, void *args, bool shell, const char *stdin_text) {
+    return osty_rt_os_exec_input_options(cmd, args, shell, NULL, NULL, 0, stdin_text);
 }
 
 osty_rt_os_string_result *osty_rt_os_hostname(void) {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -63,9 +63,12 @@ func fastPathListWriteEnabled() bool {
 }
 
 const (
-	stdCmdSyntheticCommandTypeName   = "__osty_std_cmd_Command"
-	stdCmdSyntheticRunOutputTypeName = "__osty_std_cmd_RunOutput"
-	stdCmdSyntheticPipelineTypeName  = "__osty_std_cmd_Pipeline"
+	stdCmdSyntheticCommandTypeName      = "__osty_std_cmd_Command"
+	stdCmdSyntheticRunOutputTypeName    = "__osty_std_cmd_RunOutput"
+	stdCmdSyntheticPipelineTypeName     = "__osty_std_cmd_Pipeline"
+	stdProcessSyntheticCommandTypeName  = "__osty_std_process_ProcessCommand"
+	stdProcessSyntheticOutputTypeName   = "__osty_std_process_ProcessOutput"
+	stdProcessSyntheticPipelineTypeName = "__osty_std_process_ProcessPipeline"
 )
 
 // GenerateFromMIR emits textual LLVM IR from a MIR module. It is the
@@ -208,13 +211,16 @@ type mirGen struct {
 	layoutCache MirLayoutCache        // §14 enum / tuple order cache (Osty mirror)
 	tupleDefs   map[string][]mir.Type // mangled tuple name → element types
 
-	stdTermSizeTouched     bool // synthetic std.term Size payload used by MIR
-	stdOsOutputTouched     bool // synthetic std.os Output payload used by MIR
-	stdOsExecOutputTouched bool // synthetic std.os ExecOutput payload used by MIR
-	stdCmdCommandTouched   bool // synthetic std.cmd Command payload used by MIR
-	stdCmdRunOutputTouched bool // synthetic std.cmd RunOutput payload used by MIR
-	stdCmdPipelineTouched  bool // synthetic std.cmd Pipeline payload used by MIR
-	stdRegexMatchTouched   bool // synthetic std.regex Match payload used by MIR
+	stdTermSizeTouched        bool // synthetic std.term Size payload used by MIR
+	stdOsOutputTouched        bool // synthetic std.os Output payload used by MIR
+	stdOsExecOutputTouched    bool // synthetic std.os ExecOutput payload used by MIR
+	stdCmdCommandTouched      bool // synthetic std.cmd Command payload used by MIR
+	stdCmdRunOutputTouched    bool // synthetic std.cmd RunOutput payload used by MIR
+	stdCmdPipelineTouched     bool // synthetic std.cmd Pipeline payload used by MIR
+	stdRegexMatchTouched      bool // synthetic std.regex Match payload used by MIR
+	stdProcessCommandTouched  bool // synthetic std.process ProcessCommand payload used by MIR
+	stdProcessOutputTouched   bool // synthetic std.process ProcessOutput payload used by MIR
+	stdProcessPipelineTouched bool // synthetic std.process ProcessPipeline payload used by MIR
 
 	// Closure-env thunks generated on demand when a bare `FnConst`
 	// (top-level fn used as a value) reaches an indirect-call site.
@@ -729,7 +735,10 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			g.isStdCmdCommandType(x) ||
 			g.isStdCmdRunOutputType(x) ||
 			g.isStdCmdPipelineType(x) ||
-			g.isStdRegexMatchType(x) {
+			g.isStdRegexMatchType(x) ||
+			g.isStdProcessCommandType(x) ||
+			g.isStdProcessOutputType(x) ||
+			g.isStdProcessPipelineType(x) {
 			return true
 		}
 		if strings.Contains(x.QualifiedName(), ".") {
@@ -1631,7 +1640,10 @@ func (g *mirGen) emitTypeDefs() {
 		!g.stdCmdCommandTouched &&
 		!g.stdCmdRunOutputTouched &&
 		!g.stdCmdPipelineTouched &&
-		!g.stdRegexMatchTouched {
+		!g.stdRegexMatchTouched &&
+		!g.stdProcessCommandTouched &&
+		!g.stdProcessOutputTouched &&
+		!g.stdProcessPipelineTouched {
 		return
 	}
 
@@ -1673,6 +1685,15 @@ func (g *mirGen) emitTypeDefs() {
 	}
 	if g.stdCmdPipelineTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdCmdSyntheticPipelineTypeName, "ptr, ptr, ptr, i64"))
+	}
+	if g.stdProcessCommandTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdProcessSyntheticCommandTypeName, "ptr, ptr, ptr, ptr, i64, i1, ptr, i1"))
+	}
+	if g.stdProcessOutputTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdProcessSyntheticOutputTypeName, "i64, ptr, ptr, i1"))
+	}
+	if g.stdProcessPipelineTouched {
+		block.WriteString(mirLlvmStructTypeDefLine(stdProcessSyntheticPipelineTypeName, "ptr, ptr, ptr, i64, ptr, i1"))
 	}
 	for _, name := range g.layoutCache.EnumLayoutOrder {
 		block.WriteString(mirLlvmEnumLayoutTypeDefLine(name))
@@ -3336,6 +3357,9 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 			return err
 		}
 	}
+	if handled, err := g.emitStdProcessFacadeCall(c, fnRef); handled {
+		return err
+	}
 	if handled, err := g.emitStdCmdCall(c, fnRef); handled {
 		return err
 	}
@@ -3573,7 +3597,7 @@ func (g *mirGen) emitStdProcessCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, e
 		g.emitAbortStringPtrAndExit(g.stringLiteral("entered unreachable code"))
 		return true, nil
 	}
-	return false, nil
+	return g.emitStdProcessFacadeCall(c, fnRef)
 }
 
 func splitRuntimeFFICallee(symbol string) (path string, name string, ok bool) {
@@ -9651,6 +9675,14 @@ func stdCmdCommandListType() mir.Type {
 	return &ir.NamedType{Name: "List", Args: []ir.Type{stdCmdCommandNamedType()}, Builtin: true}
 }
 
+func stdProcessCommandNamedType() mir.Type {
+	return &ir.NamedType{Name: "ProcessCommand"}
+}
+
+func stdProcessCommandListType() mir.Type {
+	return &ir.NamedType{Name: "List", Args: []ir.Type{stdProcessCommandNamedType()}, Builtin: true}
+}
+
 func (g *mirGen) syntheticStdlibStructElementTypes(nt *ir.NamedType) ([]mir.Type, bool) {
 	switch {
 	case g.isStdCmdCommandType(nt):
@@ -9661,6 +9693,12 @@ func (g *mirGen) syntheticStdlibStructElementTypes(nt *ir.NamedType) ([]mir.Type
 		return []mir.Type{stdCmdCommandListType(), ir.TString, stdCmdStringMapType(), ir.TInt}, true
 	case g.isStdRegexMatchType(nt):
 		return []mir.Type{ir.TString, ir.TInt, ir.TInt}, true
+	case g.isStdProcessCommandType(nt):
+		return []mir.Type{ir.TString, stdCmdStringListType(), ir.TString, stdCmdStringMapType(), ir.TInt, ir.TBool, ir.TString, ir.TBool}, true
+	case g.isStdProcessOutputType(nt):
+		return []mir.Type{ir.TInt, ir.TString, ir.TString, ir.TBool}, true
+	case g.isStdProcessPipelineType(nt):
+		return []mir.Type{stdProcessCommandListType(), ir.TString, stdCmdStringMapType(), ir.TInt, ir.TString, ir.TBool}, true
 	default:
 		return nil, false
 	}
@@ -10215,6 +10253,54 @@ func (g *mirGen) projectionIndexForType(base mir.Type, p mir.Projection) (int, b
 					return 2, true
 				}
 			}
+			if g.isStdProcessCommandType(nt) {
+				switch fp.Name {
+				case "program":
+					return 0, true
+				case "args":
+					return 1, true
+				case "cwd":
+					return 2, true
+				case "env":
+					return 3, true
+				case "timeoutMillis":
+					return 4, true
+				case "useShell":
+					return 5, true
+				case "stdin":
+					return 6, true
+				case "hasStdin":
+					return 7, true
+				}
+			}
+			if g.isStdProcessOutputType(nt) {
+				switch fp.Name {
+				case "exitCode":
+					return 0, true
+				case "stdout":
+					return 1, true
+				case "stderr":
+					return 2, true
+				case "timedOut":
+					return 3, true
+				}
+			}
+			if g.isStdProcessPipelineType(nt) {
+				switch fp.Name {
+				case "stages":
+					return 0, true
+				case "cwd":
+					return 1, true
+				case "env":
+					return 2, true
+				case "timeoutMillis":
+					return 3, true
+				case "stdin":
+					return 4, true
+				case "hasStdin":
+					return 5, true
+				}
+			}
 		}
 	}
 	return projectionIndex(p)
@@ -10728,6 +10814,18 @@ func (g *mirGen) llvmType(t mir.Type) string {
 			g.stdRegexMatchTouched = true
 			return "%" + stdRegexSyntheticMatchTypeName
 		}
+		if g.isStdProcessCommandType(x) {
+			g.stdProcessCommandTouched = true
+			return "%" + stdProcessSyntheticCommandTypeName
+		}
+		if g.isStdProcessOutputType(x) {
+			g.stdProcessOutputTouched = true
+			return "%" + stdProcessSyntheticOutputTypeName
+		}
+		if g.isStdProcessPipelineType(x) {
+			g.stdProcessPipelineTouched = true
+			return "%" + stdProcessSyntheticPipelineTypeName
+		}
 		// Prelude Option / Maybe / Result. Mint an anonymous
 		// `%Option.<T>` / `%Result.<T>.<E>` so the IR carries the
 		// element type in its name — mimicking how the legacy
@@ -10864,6 +10962,45 @@ func (g *mirGen) isStdRegexMatchType(t *ir.NamedType) bool {
 	}
 	q := t.QualifiedName()
 	return q == "Match" || q == "std.regex.Match" || q == "regex.Match"
+}
+
+func (g *mirGen) isStdProcessCommandType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "ProcessCommand" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "ProcessCommand" || q == "std.process.ProcessCommand" || q == "process.ProcessCommand"
+}
+
+func (g *mirGen) isStdProcessOutputType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "ProcessOutput" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "ProcessOutput" || q == "std.process.ProcessOutput" || q == "process.ProcessOutput"
+}
+
+func (g *mirGen) isStdProcessPipelineType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "ProcessPipeline" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "ProcessPipeline" || q == "std.process.ProcessPipeline" || q == "process.ProcessPipeline"
 }
 
 // ==== enum layout helpers ====

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -532,13 +532,21 @@ func (g *mirGen) emitStdOsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 	method := strings.TrimPrefix(fnRef.Symbol, "std.os.")
 	switch method {
 	case "exec":
-		return true, g.emitStdOsExecMIR(c, false, false)
+		return true, g.emitStdOsExecMIR(c, false, false, false)
 	case "execShell":
-		return true, g.emitStdOsExecMIR(c, true, false)
+		return true, g.emitStdOsExecMIR(c, true, false, false)
+	case "execInput":
+		return true, g.emitStdOsExecMIR(c, false, false, true)
+	case "execShellInput":
+		return true, g.emitStdOsExecMIR(c, true, false, true)
 	case "execWith":
-		return true, g.emitStdOsExecMIR(c, false, true)
+		return true, g.emitStdOsExecMIR(c, false, true, false)
 	case "execShellWith":
-		return true, g.emitStdOsExecMIR(c, true, true)
+		return true, g.emitStdOsExecMIR(c, true, true, false)
+	case "execInputWith":
+		return true, g.emitStdOsExecMIR(c, false, true, true)
+	case "execShellInputWith":
+		return true, g.emitStdOsExecMIR(c, true, true, true)
 	case "pid":
 		if len(c.Args) != 0 {
 			return true, unsupported("mir-mvp", "std.os.pid requires no arguments")
@@ -563,9 +571,11 @@ func (g *mirGen) emitStdOsCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error)
 	return false, nil
 }
 
-func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool) error {
-	if len(c.Args) == 0 || (!withOptions && ((!shell && len(c.Args) > 2) || (shell && len(c.Args) != 1))) ||
-		(withOptions && ((!shell && len(c.Args) != 5) || (shell && len(c.Args) != 4))) {
+func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool, withInput bool) error {
+	if len(c.Args) == 0 || (!withOptions && !withInput && ((!shell && len(c.Args) > 2) || (shell && len(c.Args) != 1))) ||
+		(!withOptions && withInput && ((!shell && len(c.Args) != 3) || (shell && len(c.Args) != 2))) ||
+		(withOptions && !withInput && ((!shell && len(c.Args) != 5) || (shell && len(c.Args) != 4))) ||
+		(withOptions && withInput && ((!shell && len(c.Args) != 6) || (shell && len(c.Args) != 5))) {
 		return unsupported("mir-mvp", "std.os.exec/execShell argument shape")
 	}
 	cmdArg, err := g.evalStringArg(c.Args[0], "std.os.exec", 0)
@@ -573,13 +583,24 @@ func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool
 		return err
 	}
 	argsArg := mirRuntimeArg{typ: "ptr", val: "null"}
-	if !shell && len(c.Args) == 2 {
+	if !shell && !withOptions && len(c.Args) >= 2 {
 		argsArg, err = g.evalTypedArg(c.Args[1], c.Args[1].Type())
 		if err != nil {
 			return err
 		}
 		if argsArg.typ != "ptr" {
 			return unsupported("mir-mvp", "std.os.exec args must be List<String>")
+		}
+	}
+	inputArg := mirRuntimeArg{typ: "ptr", val: "null"}
+	if withInput {
+		inputIndex := 1
+		if !shell {
+			inputIndex = 2
+		}
+		inputArg, err = g.evalStringArg(c.Args[inputIndex], "std.os.execInput", inputIndex)
+		if err != nil {
+			return err
 		}
 	}
 	cwdArg := mirRuntimeArg{typ: "ptr", val: "null"}
@@ -596,6 +617,9 @@ func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool
 				return unsupported("mir-mvp", "std.os.execWith args must be List<String>")
 			}
 			argsIndex = 2
+		}
+		if withInput {
+			argsIndex++
 		}
 		cwdArg, err = g.evalStringArg(c.Args[argsIndex], "std.os.execWith", argsIndex)
 		if err != nil {
@@ -617,15 +641,23 @@ func (g *mirGen) emitStdOsExecMIR(c *mir.CallInstr, shell bool, withOptions bool
 	if shell {
 		shellArg.val = "true"
 	}
-	if withOptions {
+	if withOptions && withInput {
+		g.declareRuntime(ostyRtOsExecInputOptionsSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecInputOptionsSymbol, "ptr, ptr, i1, ptr, ptr, i64, ptr"))
+	} else if withOptions {
 		g.declareRuntime(ostyRtOsExecOptionsSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecOptionsSymbol, "ptr, ptr, i1, ptr, ptr, i64"))
+	} else if withInput {
+		g.declareRuntime(ostyRtOsExecInputSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecInputSymbol, "ptr, ptr, i1, ptr"))
 	} else {
 		g.declareRuntime(ostyRtOsExecSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecSymbol, "ptr, ptr, i1"))
 	}
 	g.declareRuntime(ostyRtOsExecResultFreeSymbol, mirRuntimeDeclareLine("void", ostyRtOsExecResultFreeSymbol, "ptr"))
 	raw := g.fresh()
-	if withOptions {
+	if withOptions && withInput {
+		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecInputOptionsSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg, cwdArg, envArg, timeoutArg, inputArg})))
+	} else if withOptions {
 		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecOptionsSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg, cwdArg, envArg, timeoutArg})))
+	} else if withInput {
+		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecInputSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg, inputArg})))
 	} else {
 		g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecSymbol, mirRuntimeArgList([]mirRuntimeArg{cmdArg, argsArg, shellArg})))
 	}

--- a/internal/llvmgen/stdlib_os_shim.go
+++ b/internal/llvmgen/stdlib_os_shim.go
@@ -8,6 +8,8 @@ import (
 
 const ostyRtOsExecSymbol = "osty_rt_os_exec"
 const ostyRtOsExecOptionsSymbol = "osty_rt_os_exec_options"
+const ostyRtOsExecInputSymbol = "osty_rt_os_exec_input"
+const ostyRtOsExecInputOptionsSymbol = "osty_rt_os_exec_input_options"
 const ostyRtOsHostnameSymbol = "osty_rt_os_hostname"
 const ostyRtOsPidSymbol = "osty_rt_os_pid"
 const ostyRtOsExitSymbol = "osty_rt_os_exit"
@@ -197,10 +199,18 @@ func (g *generator) emitStdOsCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdOsExecCall(call)
 	case "execShell":
 		return g.emitStdOsExecShellCall(call)
+	case "execInput":
+		return g.emitStdOsExecInputCall(call)
+	case "execShellInput":
+		return g.emitStdOsExecShellInputCall(call)
 	case "execWith":
 		return g.emitStdOsExecWithCall(call)
 	case "execShellWith":
 		return g.emitStdOsExecShellWithCall(call)
+	case "execInputWith":
+		return g.emitStdOsExecInputWithCall(call)
+	case "execShellInputWith":
+		return g.emitStdOsExecShellInputWithCall(call)
 	case "pid":
 		return g.emitStdOsPidCall(call)
 	case "hostname":
@@ -218,7 +228,7 @@ func (g *generator) stdOsCallStaticResult(call *ast.CallExpr) (value, bool) {
 		return value{}, false
 	}
 	switch field.Name {
-	case "exec", "execShell":
+	case "exec", "execShell", "execInput", "execShellInput":
 		ensureStdOsSyntheticOutputStruct(g)
 		info, ok := builtinResultTypeFromAST(stdOsExecResultSourceTypeSingleton, g.typeEnv())
 		if !ok {
@@ -229,7 +239,7 @@ func (g *generator) stdOsCallStaticResult(call *ast.CallExpr) (value, bool) {
 			sourceType: stdOsExecResultSourceTypeSingleton,
 			rootPaths:  g.rootPathsForType(info.typ),
 		}, true
-	case "execWith", "execShellWith":
+	case "execWith", "execShellWith", "execInputWith", "execShellInputWith":
 		ensureStdOsSyntheticExecOutputStruct(g)
 		info, ok := builtinResultTypeFromAST(stdOsExecOptionsResultSourceTypeSingleton, g.typeEnv())
 		if !ok {
@@ -263,10 +273,10 @@ func (g *generator) staticStdOsCallSourceType(call *ast.CallExpr) (ast.Type, boo
 		return nil, false
 	}
 	switch field.Name {
-	case "exec", "execShell":
+	case "exec", "execShell", "execInput", "execShellInput":
 		ensureStdOsSyntheticOutputStruct(g)
 		return stdOsExecResultSourceTypeSingleton, true
-	case "execWith", "execShellWith":
+	case "execWith", "execShellWith", "execInputWith", "execShellInputWith":
 		ensureStdOsSyntheticExecOutputStruct(g)
 		return stdOsExecOptionsResultSourceTypeSingleton, true
 	case "pid":
@@ -294,22 +304,38 @@ func (g *generator) stdOsCallField(call *ast.CallExpr) (*ast.FieldExpr, bool) {
 }
 
 func (g *generator) emitStdOsExecCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, false, false)
+	return g.emitStdOsExecLikeCall(call, false, false, false)
 }
 
 func (g *generator) emitStdOsExecShellCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, true, false)
+	return g.emitStdOsExecLikeCall(call, true, false, false)
+}
+
+func (g *generator) emitStdOsExecInputCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, false, false, true)
+}
+
+func (g *generator) emitStdOsExecShellInputCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, true, false, true)
 }
 
 func (g *generator) emitStdOsExecWithCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, false, true)
+	return g.emitStdOsExecLikeCall(call, false, true, false)
 }
 
 func (g *generator) emitStdOsExecShellWithCall(call *ast.CallExpr) (value, bool, error) {
-	return g.emitStdOsExecLikeCall(call, true, true)
+	return g.emitStdOsExecLikeCall(call, true, true, false)
 }
 
-func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOptions bool) (value, bool, error) {
+func (g *generator) emitStdOsExecInputWithCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, false, true, true)
+}
+
+func (g *generator) emitStdOsExecShellInputWithCall(call *ast.CallExpr) (value, bool, error) {
+	return g.emitStdOsExecLikeCall(call, true, true, true)
+}
+
+func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOptions bool, withInput bool) (value, bool, error) {
 	resultSourceType := stdOsExecResultSourceTypeSingleton
 	ensureStdOsSyntheticOutputStruct(g)
 	if withOptions {
@@ -329,21 +355,36 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 	if shell {
 		wantArgs = 1
 	}
+	if withInput {
+		if shell {
+			wantArgs = 2
+		} else {
+			wantArgs = 3
+		}
+		minArgs = wantArgs
+	}
 	if withOptions {
 		if shell {
 			wantArgs = 4
 		} else {
 			wantArgs = 5
 		}
+		if withInput {
+			if shell {
+				wantArgs = 5
+			} else {
+				wantArgs = 6
+			}
+		}
 		minArgs = wantArgs
 	}
 	if len(call.Args) < minArgs || len(call.Args) > wantArgs {
-		name := stdOsExecCallName(shell, withOptions)
+		name := stdOsExecCallName(shell, withOptions, withInput)
 		return value{}, true, unsupportedf("call", "%s received %d arguments", name, len(call.Args))
 	}
 	cmdArg := call.Args[0]
 	if cmdArg == nil || (cmdArg.Name != "" && cmdArg.Name != "cmd" && cmdArg.Name != "command") || cmdArg.Value == nil {
-		name := stdOsExecCallName(shell, withOptions)
+		name := stdOsExecCallName(shell, withOptions, withInput)
 		return value{}, true, unsupported("call", name+" requires a String command argument")
 	}
 	cmd, err := g.emitExpr(cmdArg.Value)
@@ -359,7 +400,7 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 		return value{}, true, unsupportedf("type-system", "os.exec command type %s, want String", cmd.typ)
 	}
 	argsValue := value{typ: "ptr", ref: "null"}
-	if !shell && len(call.Args) == 2 {
+	if !shell && !withOptions && len(call.Args) >= 2 {
 		argsArg := call.Args[1]
 		if argsArg == nil || (argsArg.Name != "" && argsArg.Name != "args") || argsArg.Value == nil {
 			return value{}, true, unsupported("call", "os.exec requires args as a positional or `args:` List<String> argument")
@@ -375,6 +416,17 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 		}
 		if argsValue.typ != "ptr" {
 			return value{}, true, unsupportedf("type-system", "os.exec args type %s, want List<String>", argsValue.typ)
+		}
+	}
+	inputValue := value{typ: "ptr", ref: "null"}
+	if withInput {
+		inputIndex := 1
+		if !shell {
+			inputIndex = 2
+		}
+		inputValue, err = g.emitStdOsExecStringArg(call.Args[inputIndex], []string{"stdin", "input"}, stdOsExecCallName(shell, withOptions, withInput)+".stdin")
+		if err != nil {
+			return value{}, true, err
 		}
 	}
 	cwdValue := value{typ: "ptr", ref: "null"}
@@ -401,6 +453,9 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 			}
 			argsIndex = 2
 		}
+		if withInput {
+			argsIndex++
+		}
 		cwdValue, err = g.emitStdOsExecPtrArg(call.Args[argsIndex], "cwd", "String", "os.execWith.cwd")
 		if err != nil {
 			return value{}, true, err
@@ -425,8 +480,12 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 			return value{}, true, unsupportedf("type-system", "os.execWith timeoutMillis type %s, want Int", timeoutValue.typ)
 		}
 	}
-	if withOptions {
+	if withOptions && withInput {
+		g.declareRuntimeSymbol(ostyRtOsExecInputOptionsSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}, {typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+	} else if withOptions {
 		g.declareRuntimeSymbol(ostyRtOsExecOptionsSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}, {typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
+	} else if withInput {
+		g.declareRuntimeSymbol(ostyRtOsExecInputSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}, {typ: "ptr"}})
 	} else {
 		g.declareRuntimeSymbol(ostyRtOsExecSymbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i1"}})
 	}
@@ -434,7 +493,17 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 	emitter := g.toOstyEmitter()
 	g.emitCallSafepointIfNeeded(emitter)
 	var raw *LlvmValue
-	if withOptions {
+	if withOptions && withInput {
+		raw = llvmCall(emitter, "ptr", ostyRtOsExecInputOptionsSymbol, []*LlvmValue{
+			toOstyValue(cmd),
+			toOstyValue(argsValue),
+			llvmStdIoBoolValue(shell),
+			toOstyValue(cwdValue),
+			toOstyValue(envValue),
+			toOstyValue(timeoutValue),
+			toOstyValue(inputValue),
+		})
+	} else if withOptions {
 		raw = llvmCall(emitter, "ptr", ostyRtOsExecOptionsSymbol, []*LlvmValue{
 			toOstyValue(cmd),
 			toOstyValue(argsValue),
@@ -442,6 +511,13 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 			toOstyValue(cwdValue),
 			toOstyValue(envValue),
 			toOstyValue(timeoutValue),
+		})
+	} else if withInput {
+		raw = llvmCall(emitter, "ptr", ostyRtOsExecInputSymbol, []*LlvmValue{
+			toOstyValue(cmd),
+			toOstyValue(argsValue),
+			llvmStdIoBoolValue(shell),
+			toOstyValue(inputValue),
 		})
 	} else {
 		raw = llvmCall(emitter, "ptr", ostyRtOsExecSymbol, []*LlvmValue{
@@ -510,8 +586,16 @@ func (g *generator) emitStdOsExecLikeCall(call *ast.CallExpr, shell bool, withOp
 	return v, true, nil
 }
 
-func stdOsExecCallName(shell bool, withOptions bool) string {
+func stdOsExecCallName(shell bool, withOptions bool, withInput bool) string {
 	switch {
+	case shell && withOptions && withInput:
+		return "os.execShellInputWith"
+	case withOptions && withInput:
+		return "os.execInputWith"
+	case shell && withInput:
+		return "os.execShellInput"
+	case withInput:
+		return "os.execInput"
 	case shell && withOptions:
 		return "os.execShellWith"
 	case shell:
@@ -521,6 +605,37 @@ func stdOsExecCallName(shell bool, withOptions bool) string {
 	default:
 		return "os.exec"
 	}
+}
+
+func (g *generator) emitStdOsExecStringArg(arg *ast.Arg, names []string, label string) (value, error) {
+	if arg == nil || arg.Value == nil {
+		return value{}, unsupported("call", label+" requires a String argument")
+	}
+	if arg.Name != "" {
+		ok := false
+		for _, name := range names {
+			if arg.Name == name {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return value{}, unsupported("call", label+" requires a String argument")
+		}
+	}
+	out, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	out = g.protectManagedTemporary(label, out)
+	out, err = g.loadIfPointer(out)
+	if err != nil {
+		return value{}, err
+	}
+	if out.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "%s type %s, want String", label, out.typ)
+	}
+	return out, nil
 }
 
 func (g *generator) emitStdOsExecPtrArg(arg *ast.Arg, name string, want string, label string) (value, error) {

--- a/internal/llvmgen/stdlib_os_shim_test.go
+++ b/internal/llvmgen/stdlib_os_shim_test.go
@@ -87,6 +87,44 @@ fn main() {
 	}
 }
 
+func TestStdOsExecInputRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.os as os
+
+fn main() {
+    let env: Map<String, String> = {:}
+    match os.execInputWith("sh", ["-c", "cat"], "hello", "/tmp", env, 0) {
+        Ok(out) -> println(out.stdout),
+        Err(err) -> println(err.message()),
+    }
+
+    match os.execShellInput("cat", "shell") {
+        Ok(out) -> println(out.stdout),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_os_exec_input.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_os_exec_input_options(ptr, ptr, i1, ptr, ptr, i64, ptr)",
+		"declare ptr @osty_rt_os_exec_input(ptr, ptr, i1, ptr)",
+		"call ptr @osty_rt_os_exec_input_options(ptr",
+		"call ptr @osty_rt_os_exec_input(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
 func TestStdOsPidHostnameAndExitRouteToRuntime(t *testing.T) {
 	file := parseLLVMGenFile(t, `use std.os as os
 

--- a/internal/llvmgen/stdlib_process_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_process_mir_runtime_shim.go
@@ -1,0 +1,483 @@
+package llvmgen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+)
+
+const ostyRtProcessPipelineShellLineSymbol = "osty_rt_process_pipeline_shell_line"
+
+func (g *mirGen) emitStdProcessFacadeCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	if fnRef == nil {
+		return false, nil
+	}
+	switch fnRef.Symbol {
+	case "std.process.command", "process.command":
+		return true, g.emitStdProcessCommandConstruct(c, false, false)
+	case "std.process.commandArgs", "process.commandArgs":
+		return true, g.emitStdProcessCommandConstruct(c, false, true)
+	case "std.process.shell", "process.shell":
+		return true, g.emitStdProcessCommandConstruct(c, true, false)
+	case "std.process.pipeline", "process.pipeline":
+		return true, g.emitStdProcessPipelineConstruct(c)
+	case "std.process.pipe", "process.pipe":
+		return true, g.emitStdProcessPipe(c)
+	case "std.process.run", "process.run":
+		return true, g.emitStdProcessRunFree(c, false)
+	case "std.process.runShell", "process.runShell":
+		return true, g.emitStdProcessRunFree(c, true)
+	case "std.process.shellEscape", "process.shellEscape":
+		return true, g.emitStdCmdShellEscape(c)
+	case "std.process.joinEscaped", "process.joinEscaped":
+		return true, g.emitStdCmdJoinEscaped(c)
+	}
+	if method, ok := g.stdProcessMethodName(fnRef.Symbol, "ProcessCommand", c); ok {
+		return true, g.emitStdProcessCommandMethod(c, method)
+	}
+	if method, ok := g.stdProcessMethodName(fnRef.Symbol, "ProcessOutput", c); ok {
+		return true, g.emitStdProcessOutputMethod(c, method)
+	}
+	if method, ok := g.stdProcessMethodName(fnRef.Symbol, "ProcessPipeline", c); ok {
+		return true, g.emitStdProcessPipelineMethod(c, method)
+	}
+	return false, nil
+}
+
+func (g *mirGen) stdProcessMethodName(symbol, typeName string, c *mir.CallInstr) (string, bool) {
+	marker := typeName + "__"
+	idx := strings.LastIndex(symbol, marker)
+	if idx < 0 {
+		return "", false
+	}
+	if idx > 0 && symbol[idx-1] != '.' {
+		return "", false
+	}
+	if len(c.Args) == 0 {
+		return "", false
+	}
+	nt, _ := c.Args[0].Type().(*ir.NamedType)
+	switch typeName {
+	case "ProcessCommand":
+		if !g.isStdProcessCommandType(nt) {
+			return "", false
+		}
+	case "ProcessOutput":
+		if !g.isStdProcessOutputType(nt) {
+			return "", false
+		}
+	case "ProcessPipeline":
+		if !g.isStdProcessPipelineType(nt) {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+	return symbol[idx+len(marker):], true
+}
+
+func (g *mirGen) emitStdProcessCommandConstruct(c *mir.CallInstr, useShell bool, hasArgs bool) error {
+	wantArgs := 1
+	if hasArgs {
+		wantArgs = 2
+	}
+	if len(c.Args) != wantArgs {
+		return unsupported("mir-mvp", "std.process command constructor argument shape")
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.process constructor dest into unknown local %d", c.Dest.Local)
+	}
+	program, err := g.evalStringArg(c.Args[0], "std.process.command", 0)
+	if err != nil {
+		return err
+	}
+	args := mirRuntimeArg{typ: "ptr", val: g.emitStdCmdEmptyStringList()}
+	if hasArgs {
+		args, err = g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		if args.typ != "ptr" {
+			return unsupported("mir-mvp", "std.process.commandArgs args must be List<String>")
+		}
+	}
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		program,
+		args,
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+		{typ: "i1", val: llvmStdIoI1Text(useShell)},
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "i1", val: "false"},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.process constructor")
+}
+
+func (g *mirGen) emitStdProcessPipelineConstruct(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.process.pipeline requires one List<ProcessCommand> argument")
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.process.pipeline dest into unknown local %d", c.Dest.Local)
+	}
+	stages, err := g.evalTypedArg(c.Args[0], c.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	if stages.typ != "ptr" {
+		return unsupported("mir-mvp", "std.process.pipeline stages must be List<ProcessCommand>")
+	}
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		stages,
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "i1", val: "false"},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.process.pipeline")
+}
+
+func (g *mirGen) emitStdProcessPipe(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.process.pipe requires two ProcessCommand arguments")
+	}
+	listReg := g.emitStdCmdEmptyStringList()
+	for _, arg := range c.Args {
+		cmdVal, err := g.evalOperand(arg, arg.Type())
+		if err != nil {
+			return err
+		}
+		g.emitStdCmdListPushCommand(listReg, cmdVal, g.llvmType(arg.Type()))
+	}
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.process.pipe dest into unknown local %d", c.Dest.Local)
+	}
+	value, err := g.buildAggregateValue(destLoc.Type, []mirRuntimeArg{
+		{typ: "ptr", val: listReg},
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "ptr", val: g.emitStdCmdEmptyStringMap()},
+		{typ: "i64", val: "0"},
+		{typ: "ptr", val: g.stringLiteral("")},
+		{typ: "i1", val: "false"},
+	})
+	if err != nil {
+		return err
+	}
+	return g.storeLLVMValueIntoPlace(*c.Dest, &LlvmValue{typ: g.llvmType(destLoc.Type), name: value}, "std.process.pipe")
+}
+
+func (g *mirGen) emitStdProcessCommandMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "arg":
+		return g.emitStdCmdCommandArg(c)
+	case "withArgs":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 1, 1)
+	case "withCwd":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 2, 1)
+	case "withEnv":
+		return g.emitStdCmdCommandWithEnv(c)
+	case "withEnvMap":
+		return g.emitStdCmdCommandReplacePtrField(c, method, 3, 1)
+	case "withTimeoutMillis":
+		return g.emitStdCmdCommandReplaceIntField(c, method, 4, 1)
+	case "withStdin":
+		return g.emitStdProcessCommandWithStdin(c)
+	case "pipe":
+		return g.emitStdProcessCommandPipe(c)
+	case "run":
+		return g.emitStdProcessCommandRun(c)
+	case "shellLine":
+		return g.emitStdCmdCommandShellLine(c)
+	default:
+		return unsupported("mir-mvp", "std.process ProcessCommand method "+method)
+	}
+}
+
+func (g *mirGen) emitStdProcessCommandWithStdin(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.process.ProcessCommand.withStdin arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return err
+	}
+	text, err := g.evalStringArg(c.Args[1], "std.process.ProcessCommand.withStdin", 1)
+	if err != nil {
+		return err
+	}
+	next := g.replaceStdCmdCommandField(self, selfLLVM, "ptr", text.val, 6)
+	next = g.replaceStdCmdCommandField(next, selfLLVM, "i1", "true", 7)
+	return g.storeStdCmdCommandResult(c, next, selfLLVM, "std.process.ProcessCommand.withStdin")
+}
+
+func (g *mirGen) emitStdProcessCommandPipe(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.process.ProcessCommand.pipe arity")
+	}
+	return g.emitStdProcessPipe(c)
+}
+
+func (g *mirGen) evalStdProcessCommandFields(c *mir.CallInstr) (stdProcessCommandFields, error) {
+	self, selfLLVM, err := g.evalStdCmdCommandArg(c)
+	if err != nil {
+		return stdProcessCommandFields{}, err
+	}
+	return stdProcessCommandFields{
+		program:  g.extractStdCmdCommandField(self, selfLLVM, 0),
+		args:     g.extractStdCmdCommandField(self, selfLLVM, 1),
+		cwd:      g.extractStdCmdCommandField(self, selfLLVM, 2),
+		env:      g.extractStdCmdCommandField(self, selfLLVM, 3),
+		timeout:  g.extractStdCmdCommandField(self, selfLLVM, 4),
+		useShell: g.extractStdCmdCommandField(self, selfLLVM, 5),
+		stdin:    g.extractStdCmdCommandField(self, selfLLVM, 6),
+		hasStdin: g.extractStdCmdCommandField(self, selfLLVM, 7),
+	}, nil
+}
+
+type stdProcessCommandFields struct {
+	program  string
+	args     string
+	cwd      string
+	env      string
+	timeout  string
+	useShell string
+	stdin    string
+	hasStdin string
+}
+
+func (g *mirGen) emitStdProcessCommandRun(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.process.ProcessCommand.run arity")
+	}
+	fields, err := g.evalStdProcessCommandFields(c)
+	if err != nil {
+		return err
+	}
+	return g.emitStdProcessRunWithFields(c, fields.program, fields.args, fields.useShell, fields.cwd, fields.env, fields.timeout, fields.stdin, fields.hasStdin, "std.process.ProcessCommand.run")
+}
+
+func (g *mirGen) emitStdProcessRunFree(c *mir.CallInstr, shell bool) error {
+	if shell {
+		if len(c.Args) != 1 {
+			return unsupported("mir-mvp", "std.process.runShell requires one String argument")
+		}
+		line, err := g.evalStringArg(c.Args[0], "std.process.runShell", 0)
+		if err != nil {
+			return err
+		}
+		return g.emitStdProcessRunWithFields(c, line.val, "null", "true", g.stringLiteral(""), g.emitStdCmdEmptyStringMap(), "0", g.stringLiteral(""), "false", "std.process.runShell")
+	}
+	if len(c.Args) < 1 || len(c.Args) > 2 {
+		return unsupported("mir-mvp", "std.process.run argument shape")
+	}
+	program, err := g.evalStringArg(c.Args[0], "std.process.run", 0)
+	if err != nil {
+		return err
+	}
+	args := g.emitStdCmdEmptyStringList()
+	if len(c.Args) == 2 {
+		argVal, err := g.evalTypedArg(c.Args[1], c.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		if argVal.typ != "ptr" {
+			return unsupported("mir-mvp", "std.process.run args must be List<String>")
+		}
+		args = argVal.val
+	}
+	return g.emitStdProcessRunWithFields(c, program.val, args, "false", g.stringLiteral(""), g.emitStdCmdEmptyStringMap(), "0", g.stringLiteral(""), "false", "std.process.run")
+}
+
+func (g *mirGen) emitStdProcessRunWithFields(c *mir.CallInstr, program, args, useShell, cwd, env, timeout, stdin, hasStdin, label string) error {
+	g.declareRuntime(ostyRtOsExecInputOptionsSymbol, mirRuntimeDeclareLine("ptr", ostyRtOsExecInputOptionsSymbol, "ptr, ptr, i1, ptr, ptr, i64, ptr"))
+	g.declareRuntime(ostyRtOsExecResultFreeSymbol, mirRuntimeDeclareLine("void", ostyRtOsExecResultFreeSymbol, "ptr"))
+	stdinArg := g.fresh()
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = select i1 %s, ptr %s, ptr null\n", stdinArg, hasStdin, stdin))
+	raw := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(raw, "ptr", ostyRtOsExecInputOptionsSymbol, mirRuntimeArgList([]mirRuntimeArg{
+		{typ: "ptr", val: program},
+		{typ: "ptr", val: args},
+		{typ: "i1", val: useShell},
+		{typ: "ptr", val: cwd},
+		{typ: "ptr", val: env},
+		{typ: "i64", val: timeout},
+		{typ: "ptr", val: stdinArg},
+	})))
+	tag := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 0)
+	exitCode := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i64", 1)
+	timedOut := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "i1", 2)
+	stdoutText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 3)
+	stderrText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 4)
+	errText := g.emitRecordFieldLoad(raw, stdOsExecRuntimeRecordLLVMType, "ptr", 5)
+	g.fnBuf.WriteString(mirCallVoidLine(ostyRtOsExecResultFreeSymbol, mirArgSlotPtr(raw)))
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: %s dest into unknown local %d", label, c.Dest.Local)
+	}
+	okT, _, ok := g.resultSubtypes(destLoc.Type)
+	if !ok {
+		return unsupported("mir-mvp", label+" dest is not Result<ProcessOutput, Error>")
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	failed := g.fresh()
+	g.fnBuf.WriteString(mirICmpEqI64Line(failed, tag, "1"))
+	errLabel := g.freshLabel("process.run.err")
+	okLabel := g.freshLabel("process.run.ok")
+	contLabel := g.freshLabel("process.run.cont")
+	g.fnBuf.WriteString(mirBrCondLine(failed, errLabel, okLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(errLabel))
+	errPayload := g.fresh()
+	g.fnBuf.WriteString(mirPtrToIntLine(errPayload, errText, "i64"))
+	errValue := g.emitResultValue(resultLLVM, false, errPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(okLabel))
+	output, err := g.buildAggregateValue(okT, []mirRuntimeArg{
+		{typ: "i64", val: exitCode},
+		{typ: "ptr", val: stdoutText},
+		{typ: "ptr", val: stderrText},
+		{typ: "i1", val: timedOut},
+	})
+	if err != nil {
+		return err
+	}
+	okPayload, err := g.toI64Slot(output, okT)
+	if err != nil {
+		return err
+	}
+	okValue := g.emitResultValue(resultLLVM, true, okPayload)
+	g.fnBuf.WriteString(mirBrUncondLine(contLabel))
+
+	g.fnBuf.WriteString(mirLabelLine(contLabel))
+	phi := g.fresh()
+	g.fnBuf.WriteString(mirPhiTwoLine(phi, resultLLVM, errValue, errLabel, okValue, okLabel))
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, phi, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdProcessPipelineMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "run":
+		return g.emitStdProcessPipelineRun(c)
+	case "shellLine":
+		return g.emitStdProcessPipelineShellLine(c)
+	case "withCwd":
+		return g.emitStdCmdPipelineReplacePtrField(c, method, 1, 1)
+	case "withEnvMap":
+		return g.emitStdCmdPipelineReplacePtrField(c, method, 2, 1)
+	case "withTimeoutMillis":
+		return g.emitStdCmdPipelineReplaceIntField(c, method, 3, 1)
+	case "withEnv":
+		return g.emitStdCmdPipelineWithEnv(c)
+	case "stage":
+		return g.emitStdCmdPipelineStage(c)
+	case "withStdin":
+		return g.emitStdProcessPipelineWithStdin(c)
+	default:
+		return unsupported("mir-mvp", "std.process ProcessPipeline method "+method)
+	}
+}
+
+func (g *mirGen) emitStdProcessPipelineRun(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.process.ProcessPipeline.run arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	stages := g.extractStdCmdPipelineField(self, selfLLVM, 0)
+	cwd := g.extractStdCmdPipelineField(self, selfLLVM, 1)
+	env := g.extractStdCmdPipelineField(self, selfLLVM, 2)
+	timeout := g.extractStdCmdPipelineField(self, selfLLVM, 3)
+	stdin := g.extractStdCmdPipelineField(self, selfLLVM, 4)
+	hasStdin := g.extractStdCmdPipelineField(self, selfLLVM, 5)
+	line := g.emitStdProcessPipelineShellLineValue(stages)
+	return g.emitStdProcessRunWithFields(c, line, "null", "true", cwd, env, timeout, stdin, hasStdin, "std.process.ProcessPipeline.run")
+}
+
+func (g *mirGen) emitStdProcessPipelineShellLine(c *mir.CallInstr) error {
+	if len(c.Args) != 1 {
+		return unsupported("mir-mvp", "std.process.ProcessPipeline.shellLine arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	stages := g.extractStdCmdPipelineField(self, selfLLVM, 0)
+	line := g.emitStdProcessPipelineShellLineValue(stages)
+	if c.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(c.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: std.process.ProcessPipeline.shellLine dest into unknown local %d", c.Dest.Local)
+	}
+	resultLLVM := g.llvmType(destLoc.Type)
+	payload, err := g.toI64Slot(line, ir.TString)
+	if err != nil {
+		return err
+	}
+	okValue := g.emitResultValue(resultLLVM, true, payload)
+	g.fnBuf.WriteString(mirStoreLine(resultLLVM, okValue, g.localSlots[c.Dest.Local]))
+	return nil
+}
+
+func (g *mirGen) emitStdProcessPipelineShellLineValue(stages string) string {
+	g.declareRuntime(ostyRtProcessPipelineShellLineSymbol, mirRuntimeDeclareLine("ptr", ostyRtProcessPipelineShellLineSymbol, "ptr"))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", ostyRtProcessPipelineShellLineSymbol, mirRuntimeArgList([]mirRuntimeArg{{typ: "ptr", val: stages}})))
+	return out
+}
+
+func (g *mirGen) emitStdProcessPipelineWithStdin(c *mir.CallInstr) error {
+	if len(c.Args) != 2 {
+		return unsupported("mir-mvp", "std.process.ProcessPipeline.withStdin arity")
+	}
+	self, selfLLVM, err := g.evalStdCmdPipelineArg(c)
+	if err != nil {
+		return err
+	}
+	text, err := g.evalStringArg(c.Args[1], "std.process.ProcessPipeline.withStdin", 1)
+	if err != nil {
+		return err
+	}
+	next := g.replaceStdCmdPipelineField(self, selfLLVM, "ptr", text.val, 4)
+	next = g.replaceStdCmdPipelineField(next, selfLLVM, "i1", "true", 5)
+	return g.storeStdCmdPipelineResult(c, next, selfLLVM, "std.process.ProcessPipeline.withStdin")
+}
+
+func (g *mirGen) emitStdProcessOutputMethod(c *mir.CallInstr, method string) error {
+	switch method {
+	case "ok":
+		return g.emitStdCmdRunOutputOk(c)
+	default:
+		return unsupported("mir-mvp", "std.process ProcessOutput method "+method)
+	}
+}

--- a/internal/stdlib/modules/cmd.osty
+++ b/internal/stdlib/modules/cmd.osty
@@ -1,9 +1,9 @@
 // std.cmd — automation-friendly command execution.
 //
-// `std.process` remains the abort/todo/result-helper module. OS process
-// execution lives here as a builder over the low-level `std.os` runtime
-// calls, with explicit cwd/env/timeout knobs and shell-safe pipeline
-// rendering.
+// `std.process` provides the newer high-level process facade. This
+// module keeps the automation-oriented command builder surface that
+// predates it, with explicit cwd/env/timeout knobs and shell-safe
+// pipeline rendering over the low-level `std.os` runtime calls.
 
 use std.error
 use std.os

--- a/internal/stdlib/modules/os.osty
+++ b/internal/stdlib/modules/os.osty
@@ -27,9 +27,17 @@ pub fn exec(cmd: String, args: List<String> = []) -> Result<Output, Error>
 
 pub fn execShell(cmd: String) -> Result<Output, Error>
 
+pub fn execInput(cmd: String, args: List<String>, stdin: String) -> Result<Output, Error>
+
+pub fn execShellInput(cmd: String, stdin: String) -> Result<Output, Error>
+
 pub fn execWith(cmd: String, args: List<String>, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
 
 pub fn execShellWith(cmd: String, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
+
+pub fn execInputWith(cmd: String, args: List<String>, stdin: String, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
+
+pub fn execShellInputWith(cmd: String, stdin: String, cwd: String, env: Map<String, String>, timeoutMillis: Int) -> Result<ExecOutput, Error>
 
 pub fn exit(code: Int) -> Never
 

--- a/internal/stdlib/modules/process.osty
+++ b/internal/stdlib/modules/process.osty
@@ -1,10 +1,18 @@
-// std.process — abort, unreachable, todo, ignoreError, logError.
+// std.process — process execution plus abort/result helpers.
 //
 // `abort`, `unreachable`, and `todo` return `Never` (the bottom type),
 // so calling any of them unifies with any expected result type. They
 // are body-less; the backend lowers each to the runtime panic entry
 // point. `ignoreError` and `logError` are the canonical helpers for
 // `defer` bodies that can't propagate a Result.
+//
+// OS process execution is a high-level wrapper over `std.os`: commands
+// can receive stdin text, capture stdout/stderr, and compose shell
+// pipelines where each stage's stdout streams into the next stage's
+// stdin.
+
+use std.error
+use std.os
 
 pub fn abort(msg: String) -> Never
 
@@ -20,5 +28,250 @@ pub fn logError<T>(result: Result<T, Error>, msg: String) {
     match result {
         Ok(_) -> {},
         Err(err) -> eprintln("{msg}: {err.message()}"),
+    }
+}
+
+pub struct ProcessOutput {
+    pub exitCode: Int,
+    pub stdout: String,
+    pub stderr: String,
+    pub timedOut: Bool,
+
+    pub fn ok(self) -> Bool {
+        self.exitCode == 0 && !self.timedOut
+    }
+
+    pub fn check(self) -> Result<ProcessOutput, Error> {
+        if self.ok() {
+            Ok(self)
+        } else if self.timedOut {
+            Err(error.new("process: timed out"))
+        } else {
+            Err(error.new("process: exit code {self.exitCode}"))
+        }
+    }
+}
+
+pub struct ProcessCommand {
+    pub program: String,
+    pub args: List<String>,
+    pub cwd: String,
+    pub env: Map<String, String>,
+    pub timeoutMillis: Int,
+    pub useShell: Bool,
+    pub stdin: String,
+    pub hasStdin: Bool,
+
+    pub fn arg(mut self, value: String) -> ProcessCommand {
+        self.args.push(value)
+        self
+    }
+
+    pub fn withArgs(mut self, values: List<String>) -> ProcessCommand {
+        self.args = values
+        self
+    }
+
+    pub fn withCwd(mut self, path: String) -> ProcessCommand {
+        self.cwd = path
+        self
+    }
+
+    pub fn withEnv(mut self, name: String, value: String) -> ProcessCommand {
+        self.env.insert(name, value)
+        self
+    }
+
+    pub fn withEnvMap(mut self, values: Map<String, String>) -> ProcessCommand {
+        self.env = values
+        self
+    }
+
+    pub fn withTimeoutMillis(mut self, millis: Int) -> ProcessCommand {
+        self.timeoutMillis = millis
+        self
+    }
+
+    pub fn withStdin(mut self, text: String) -> ProcessCommand {
+        self.stdin = text
+        self.hasStdin = true
+        self
+    }
+
+    pub fn pipe(self, next: ProcessCommand) -> ProcessPipeline {
+        pipe(self, next)
+    }
+
+    pub fn run(self) -> Result<ProcessOutput, Error> {
+        if self.hasStdin && self.useShell {
+            return fromOs(os.execShellInputWith(self.program, self.stdin, self.cwd, self.env, self.timeoutMillis))
+        }
+        if self.hasStdin {
+            return fromOs(os.execInputWith(self.program, self.args, self.stdin, self.cwd, self.env, self.timeoutMillis))
+        }
+        if self.useShell {
+            fromOs(os.execShellWith(self.program, self.cwd, self.env, self.timeoutMillis))
+        } else {
+            fromOs(os.execWith(self.program, self.args, self.cwd, self.env, self.timeoutMillis))
+        }
+    }
+
+    pub fn shellLine(self) -> String {
+        if self.useShell {
+            return self.program
+        }
+        joinEscaped(self.program, self.args)
+    }
+}
+
+pub struct ProcessPipeline {
+    pub stages: List<ProcessCommand>,
+    pub cwd: String,
+    pub env: Map<String, String>,
+    pub timeoutMillis: Int,
+    pub stdin: String,
+    pub hasStdin: Bool,
+
+    pub fn stage(mut self, next: ProcessCommand) -> ProcessPipeline {
+        self.stages.push(next)
+        self
+    }
+
+    pub fn withCwd(mut self, path: String) -> ProcessPipeline {
+        self.cwd = path
+        self
+    }
+
+    pub fn withEnv(mut self, name: String, value: String) -> ProcessPipeline {
+        self.env.insert(name, value)
+        self
+    }
+
+    pub fn withEnvMap(mut self, values: Map<String, String>) -> ProcessPipeline {
+        self.env = values
+        self
+    }
+
+    pub fn withTimeoutMillis(mut self, millis: Int) -> ProcessPipeline {
+        self.timeoutMillis = millis
+        self
+    }
+
+    pub fn withStdin(mut self, text: String) -> ProcessPipeline {
+        self.stdin = text
+        self.hasStdin = true
+        self
+    }
+
+    pub fn shellLine(self) -> Result<String, Error> {
+        renderPipeline(self.stages)
+    }
+
+    pub fn run(self) -> Result<ProcessOutput, Error> {
+        let line = renderPipeline(self.stages)?
+        if self.hasStdin {
+            fromOs(os.execShellInputWith(line, self.stdin, self.cwd, self.env, self.timeoutMillis))
+        } else {
+            fromOs(os.execShellWith(line, self.cwd, self.env, self.timeoutMillis))
+        }
+    }
+}
+
+pub fn command(program: String) -> ProcessCommand {
+    ProcessCommand {
+        program: program,
+        args: [],
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+        useShell: false,
+        stdin: "",
+        hasStdin: false,
+    }
+}
+
+pub fn commandArgs(program: String, args: List<String>) -> ProcessCommand {
+    command(program).withArgs(args)
+}
+
+pub fn shell(line: String) -> ProcessCommand {
+    ProcessCommand {
+        program: line,
+        args: [],
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+        useShell: true,
+        stdin: "",
+        hasStdin: false,
+    }
+}
+
+pub fn pipeline(stages: List<ProcessCommand>) -> ProcessPipeline {
+    ProcessPipeline {
+        stages: stages,
+        cwd: "",
+        env: {:},
+        timeoutMillis: 0,
+        stdin: "",
+        hasStdin: false,
+    }
+}
+
+pub fn pipe(left: ProcessCommand, right: ProcessCommand) -> ProcessPipeline {
+    pipeline([left, right])
+}
+
+pub fn run(program: String, args: List<String> = []) -> Result<ProcessOutput, Error> {
+    commandArgs(program, args).run()
+}
+
+pub fn runShell(line: String) -> Result<ProcessOutput, Error> {
+    shell(line).run()
+}
+
+pub fn shellEscape(arg: String) -> String {
+    if arg.isEmpty() {
+        return "''"
+    }
+    let mut out = "'"
+    for c in arg.chars() {
+        if c == '\'' {
+            out = "{out}'\\''"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    "{out}'"
+}
+
+pub fn joinEscaped(program: String, args: List<String>) -> String {
+    let mut parts = [shellEscape(program)]
+    for arg in args {
+        parts.push(shellEscape(arg))
+    }
+    " ".join(parts)
+}
+
+fn renderPipeline(stages: List<ProcessCommand>) -> Result<String, Error> {
+    if stages.len() == 0 {
+        return Err(error.new("process: pipeline requires at least one stage"))
+    }
+    let mut parts: List<String> = []
+    for stage in stages {
+        parts.push(stage.shellLine())
+    }
+    Ok(" | ".join(parts))
+}
+
+fn fromOs(result: Result<os.ExecOutput, Error>) -> Result<ProcessOutput, Error> {
+    match result {
+        Ok(out) -> Ok(ProcessOutput {
+            exitCode: out.exitCode,
+            stdout: out.stdout,
+            stderr: out.stderr,
+            timedOut: out.timedOut,
+        }),
+        Err(err) -> Err(err),
     }
 }

--- a/internal/stdlib/process_test.go
+++ b/internal/stdlib/process_test.go
@@ -1,0 +1,63 @@
+package stdlib
+
+import "testing"
+
+func TestProcessModuleExposesExecutionSurface(t *testing.T) {
+	reg := LoadCached()
+
+	for _, name := range []string{
+		"command", "commandArgs", "shell", "pipeline", "pipe", "run", "runShell", "shellEscape", "joinEscaped",
+	} {
+		fn := reg.LookupFnDecl("process", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(process, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("process.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{"abort", "unreachable", "todo"} {
+		fn := reg.LookupFnDecl("process", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(process, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body != nil {
+			t.Fatalf("process.%s body != nil, want backend-owned primitive", name)
+		}
+	}
+
+	for _, name := range []string{
+		"arg", "withArgs", "withCwd", "withEnv", "withEnvMap", "withTimeoutMillis", "withStdin", "pipe", "run", "shellLine",
+	} {
+		fn := reg.LookupMethodDecl("process", "ProcessCommand", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(process, ProcessCommand, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("process.ProcessCommand.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{"ok", "check"} {
+		fn := reg.LookupMethodDecl("process", "ProcessOutput", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(process, ProcessOutput, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("process.ProcessOutput.%s body = nil, want source wrapper body", name)
+		}
+	}
+
+	for _, name := range []string{
+		"stage", "withCwd", "withEnv", "withEnvMap", "withTimeoutMillis", "withStdin", "run", "shellLine",
+	} {
+		fn := reg.LookupMethodDecl("process", "ProcessPipeline", name)
+		if fn == nil {
+			t.Fatalf("LookupMethodDecl(process, ProcessPipeline, %s) = nil, want *ast.FnDecl", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("process.ProcessPipeline.%s body = nil, want source wrapper body", name)
+		}
+	}
+}

--- a/internal/stdlib/support_matrix_test.go
+++ b/internal/stdlib/support_matrix_test.go
@@ -13,6 +13,7 @@ import (
 type stdlibSupportMatrix struct {
 	production         []string
 	productionAdjacent []string
+	other              []string
 }
 
 // std.runtime.raw is intentionally internal support surface. It is bundled
@@ -28,6 +29,7 @@ func TestStdlibSupportMatrixCoversEmbeddedModules(t *testing.T) {
 	want := sortedStrings(combineStringSlices(
 		matrix.production,
 		matrix.productionAdjacent,
+		matrix.other,
 		stdlibSupportMatrixInternalModules,
 	))
 	if !reflect.DeepEqual(got, want) {
@@ -83,17 +85,27 @@ func parseStdlibSupportMatrix(markdown string) stdlibSupportMatrix {
 		sectionNone = iota
 		sectionProduction
 		sectionProductionAdjacent
+		sectionOther
 	)
 	var matrix stdlibSupportMatrix
 	section := sectionNone
 	for _, line := range strings.Split(markdown, "\n") {
 		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			section = sectionNone
+			continue
+		}
 		if strings.HasPrefix(trimmed, "### ") {
 			switch {
-			case strings.Contains(trimmed, "Production-adjacent"):
+			case strings.Contains(trimmed, "Production-adjacent"), strings.Contains(trimmed, "Functional"):
 				section = sectionProductionAdjacent
 			case strings.Contains(trimmed, "Production"):
 				section = sectionProduction
+			case strings.Contains(trimmed, "Surface-rich"),
+				strings.Contains(trimmed, "Spec-stub"),
+				strings.Contains(trimmed, "Broken"),
+				strings.Contains(trimmed, "코어 인터페이스"):
+				section = sectionOther
 			default:
 				section = sectionNone
 			}
@@ -108,6 +120,8 @@ func parseStdlibSupportMatrix(markdown string) stdlibSupportMatrix {
 			matrix.production = append(matrix.production, module)
 		case sectionProductionAdjacent:
 			matrix.productionAdjacent = append(matrix.productionAdjacent, module)
+		case sectionOther:
+			matrix.other = append(matrix.other, module)
 		}
 	}
 	return matrix
@@ -122,7 +136,14 @@ func stdlibSupportMatrixTableModule(line string) (string, bool) {
 		return "", false
 	}
 	module := strings.TrimSpace(cells[1])
-	module = strings.Trim(module, "`")
+	if strings.Contains(module, "~~") {
+		return "", false
+	}
+	module = strings.Trim(module, "`*_")
+	if strings.HasPrefix(module, "primitives/") || module == "runtime/raw" {
+		return "", false
+	}
+	module = strings.ReplaceAll(module, "/", ".")
 	if module == "" || module == "모듈" || strings.Contains(module, " ") {
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- expand std.process into a high-level ProcessCommand / ProcessPipeline facade with stdin text, captured stdout/stderr, cwd/env/timeout, and shell pipeline composition
- add std.os execInput / execShellInput runtime paths plus AST and MIR lowering for stdin-aware process execution
- add MIR synthetic std.process struct support, backend runtime coverage, stdlib matrix updates, and focused regression tests

## Checks
- go test -count=1 -vet=off ./internal/stdlib
- go test -count=1 -vet=off ./internal/llvmgen -run 'TestStdOs|TestGenerateFromMIRStdProcessAbort'
- go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsStdOsProcessSurface|TestLLVMBackendBinaryRunsStdOsExecWithSplitArgs|TestLLVMBackendBinaryRunsStdCmdBuilderSurface|TestLLVMBackendBinaryRunsStdProcessStreamingSurface'
- go run ./cmd/osty tokens internal/stdlib/modules/process.osty
- go run ./cmd/osty tokens internal/stdlib/modules/os.osty
- git diff --check