### PR TITLE
share MIR nullable pointer result runtime helper

### DIFF
--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -401,10 +401,7 @@ func (g *mirGen) emitStdEncodingNullableBytesDecodeMIR(c *mir.CallInstr, spec *s
 	if spec.DecodeSymbol == "" {
 		return unsupported("mir-mvp", "encoding."+spec.Variant+".decode missing runtime symbol")
 	}
-	g.declareRuntime(spec.DecodeSymbol, mirRuntimeDeclareLine("ptr", spec.DecodeSymbol, "ptr"))
-	decoded := g.fresh()
-	g.fnBuf.WriteString(mirCallValueLine(decoded, "ptr", spec.DecodeSymbol, mirRuntimeArgList([]mirRuntimeArg{text})))
-	return g.emitPtrResultFromNullable(c, decoded, mir.TBytes, "")
+	return g.emitPtrResultFromNullableRuntimeCall(c, spec.DecodeSymbol, mir.TBytes, []mirRuntimeArg{text}, "")
 }
 
 // emitEncodingHexDecodeMIR validates input first (since

--- a/internal/llvmgen/stdlib_mir_result_shim.go
+++ b/internal/llvmgen/stdlib_mir_result_shim.go
@@ -1,0 +1,12 @@
+package llvmgen
+
+import (
+	"github.com/osty/osty/internal/mir"
+)
+
+func (g *mirGen) emitPtrResultFromNullableRuntimeCall(c *mir.CallInstr, symbol string, valueT mir.Type, args []mirRuntimeArg, errReg string) error {
+	g.declareRuntime(symbol, mirRuntimeDeclareLine("ptr", symbol, mirRuntimeParamList(args)))
+	out := g.fresh()
+	g.fnBuf.WriteString(mirCallValueLine(out, "ptr", symbol, mirRuntimeArgList(args)))
+	return g.emitPtrResultFromNullable(c, out, valueT, errReg)
+}

--- a/internal/llvmgen/stdlib_mir_result_shim_test.go
+++ b/internal/llvmgen/stdlib_mir_result_shim_test.go
@@ -1,0 +1,37 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateFromMIRStdEncodingNullableDecodeDiscardCallsRuntimeAsPtr(t *testing.T) {
+	for _, tc := range []struct {
+		variant string
+		runtime string
+		leak    string
+	}{
+		{variant: "base64", runtime: "osty_rt_encoding_base64_decode", leak: "Base64__decode"},
+		{variant: "base64url", runtime: "osty_rt_encoding_base64url_decode", leak: "Base64Url__decode"},
+	} {
+		t.Run(tc.variant, func(t *testing.T) {
+			got := generateStdEncodingDecodeDiscardMIR(t, tc.variant)
+			for _, want := range []string{
+				"declare ptr @" + tc.runtime + "(ptr)",
+				"call ptr @" + tc.runtime + "(",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("discarded nullable decode LLVM missing %q:\n%s", want, got)
+				}
+			}
+			for _, forbidden := range []string{
+				"call void @" + tc.runtime + "(",
+				tc.leak,
+			} {
+				if strings.Contains(got, forbidden) {
+					t.Fatalf("discarded nullable decode emitted forbidden %q:\n%s", forbidden, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared MIR helper for nullable pointer runtime calls that return Result-shaped values
- route std.encoding base64/base64url decode through the shared helper
- add a discarded-result MIR regression test so the helper keeps calling nullable runtimes as `ptr`, not `void`

## Tests
- Not run locally: local shell process launch is unavailable in this workspace session.