### PR TITLE
route uuid.parse through shared ptr Result helper

### DIFF
--- a/internal/llvmgen/stdlib_ptr_result_shim.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim.go
@@ -1,0 +1,7 @@
+package llvmgen
+
+import "github.com/osty/osty/internal/ast"
+
+func (g *generator) emitPtrBackedResultFromRuntimeCall(prefix string, sourceType ast.Type, valueSymbol, errorSymbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+	return g.emitStdFsPtrResultFromRuntimeCall(prefix, sourceType, valueSymbol, errorSymbol, params, args)
+}

--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -1,0 +1,32 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStdUuidParseUsesSharedPtrBackedResultHelper(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "internal", "llvmgen", "stdlib_uuid_shim.go"))
+	if err != nil {
+		t.Fatalf("read stdlib_uuid_shim.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "emitPtrBackedResultFromRuntimeCall(") {
+		t.Fatalf("uuid.parse no longer routes through the shared ptr-backed Result helper")
+	}
+	for _, forbidden := range []string{
+		"uuid.parse.err",
+		"uuid.parse.ok",
+		"uuid.parse.cont",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("uuid.parse still carries manual Result block label %q", forbidden)
+		}
+	}
+}

--- a/internal/llvmgen/stdlib_uuid_shim.go
+++ b/internal/llvmgen/stdlib_uuid_shim.go
@@ -168,53 +168,14 @@ func (g *generator) emitStdUuidParseCall(call *ast.CallExpr) (value, bool, error
 		return value{}, true, unsupportedf("type-system", "uuid.parse arg 1 type %s, want String", loaded.typ)
 	}
 
-	info, ok := builtinResultTypeFromAST(stdUuidParseResultSourceTypeSingleton, g.typeEnv())
-	if !ok {
-		return value{}, true, unsupported("type-system", "uuid.parse Result<Uuid, Error> type unavailable")
-	}
-	if g.resultTypes == nil {
-		g.resultTypes = map[string]builtinResultType{}
-	}
-	g.resultTypes[info.typ] = info
-	if info.okTyp != "ptr" || info.errTyp != "ptr" {
-		return value{}, true, unsupportedf("type-system", "uuid.parse Result must be ptr-backed, got ok=%s err=%s", info.okTyp, info.errTyp)
-	}
-
-	g.declareRuntimeSymbol(ostyRtUuidParseSymbol, "ptr", []paramInfo{{typ: "ptr"}})
-	g.declareRuntimeSymbol(ostyRtUuidParseErrorSymbol, "ptr", nil)
-	emitter := g.toOstyEmitter()
-	g.emitCallSafepointIfNeeded(emitter)
-	out := llvmCall(emitter, "ptr", ostyRtUuidParseSymbol, []*LlvmValue{toOstyValue(loaded)})
-	failed := llvmCompare(emitter, "eq", out, toOstyValue(value{typ: "ptr", ref: "null"}))
-	errLabel := llvmNextLabel(emitter, "uuid.parse.err")
-	okLabel := llvmNextLabel(emitter, "uuid.parse.ok")
-	contLabel := llvmNextLabel(emitter, "uuid.parse.cont")
-	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
-
-	emitter.body = append(emitter.body, errLabel+":")
-	errText := llvmCall(emitter, "ptr", ostyRtUuidParseErrorSymbol, nil)
-	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "1"}),
-		toOstyValue(llvmZeroValue(info.okTyp)),
-		errText,
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, okLabel+":")
-	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "0"}),
-		out,
-		toOstyValue(llvmZeroValue(info.errTyp)),
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, contLabel+":")
-	phi := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
-	g.takeOstyEmitter(emitter)
-	v := value{typ: info.typ, ref: phi, sourceType: stdUuidParseResultSourceTypeSingleton}
-	v.rootPaths = g.rootPathsForType(v.typ)
-	return v, true, nil
+	return g.emitPtrBackedResultFromRuntimeCall(
+		"uuid.parse",
+		stdUuidParseResultSourceTypeSingleton,
+		ostyRtUuidParseSymbol,
+		ostyRtUuidParseErrorSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(loaded)},
+	)
 }
 
 func (g *generator) emitStdUuidMethodCall(call *ast.CallExpr) (value, bool, error) {


### PR DESCRIPTION
## Summary
- add a generic AST-side ptr-backed Result runtime helper wrapper
- route `uuid.parse` through the shared helper instead of hand-emitting err/ok/cont blocks
- add a source guard so `uuid.parse` does not regain manual Result block construction

## Tests
- Not run locally: local shell process launch is unavailable in this workspace session.