### PR TITLE
inventory remaining manual ptr Result shim

### DIFF
--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -85,3 +85,64 @@ func TestStdFsPtrBackedResultHelperStaysFsLocal(t *testing.T) {
 		}
 	}
 }
+
+func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "internal", "llvmgen")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read internal/llvmgen: %v", err)
+	}
+
+	allowed := map[string][]string{
+		"stdlib_regex_shim.go": {
+			"regex.compile Result must be ptr-backed",
+		},
+	}
+	seen := map[string]bool{}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		if entry.Name() == "stdlib_ptr_result_shim.go" || entry.Name() == "stdlib_fs_shim.go" {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		text := string(src)
+		count := strings.Count(text, "Result must be ptr-backed")
+		if count == 0 {
+			continue
+		}
+
+		markers := allowed[entry.Name()]
+		if len(markers) == 0 {
+			t.Fatalf("%s has an uninventoried manual ptr-backed Result block", entry.Name())
+		}
+		if count != len(markers) {
+			t.Fatalf("%s has %d manual ptr-backed Result markers, want %d inventoried markers", entry.Name(), count, len(markers))
+		}
+		for _, marker := range markers {
+			if !strings.Contains(text, marker) {
+				t.Fatalf("%s lost inventoried manual ptr-backed Result marker %q", entry.Name(), marker)
+			}
+			seen[entry.Name()+"\x00"+marker] = true
+		}
+	}
+
+	for filename, markers := range allowed {
+		for _, marker := range markers {
+			if !seen[filename+"\x00"+marker] {
+				t.Fatalf("inventoried manual ptr-backed Result marker %q in %s was not found", marker, filename)
+			}
+		}
+	}
+}

--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -98,7 +98,7 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 	}
 
 	allowed := map[string][]string{
-		"stdlib_regex_shim.go": {
+		"stdlib_regex_shim.go": []string{
 			"regex.compile Result must be ptr-backed",
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds a structural inventory for stdlib LLVM shims that still hand-roll ptr-backed `Result` blocks
- Locks the current backlog to `regex.compile`, so new manual Result duplication fails loudly instead of spreading
- Keeps the fs-specific and shared ptr Result helpers out of the scan because they are the central implementations

## Test plan

- Not run locally: this automation thread's local shell cannot start processes, so verification is delegated to GitHub CI.