### PR TITLE
cover env ptr Result blocks in inventory

### DIFF
--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -119,7 +119,7 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 		path := filepath.Join(dir, entry.Name())
 		src, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("read %s: %v", entry.Name())
+			t.Fatalf("read %s: %v", entry.Name(), err)
 		}
 		text := string(src)
 		count := strings.Count(text, "Result must be ptr-backed")

--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -98,6 +98,10 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 	}
 
 	allowed := map[string][]string{
+		"stdlib_env_shim.go": []string{
+			"env.require currently needs ptr-backed Result<String, Error>",
+			"env.currentDir currently needs ptr-backed Result<String, Error>",
+		},
 		"stdlib_regex_shim.go": []string{
 			"regex.compile Result must be ptr-backed",
 		},
@@ -115,10 +119,11 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 		path := filepath.Join(dir, entry.Name())
 		src, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("read %s: %v", entry.Name(), err)
+			t.Fatalf("read %s: %v", entry.Name())
 		}
 		text := string(src)
 		count := strings.Count(text, "Result must be ptr-backed")
+		count += strings.Count(text, "currently needs ptr-backed Result")
 		if count == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Extends the manual ptr-backed Result inventory to catch both wording variants used by stdlib LLVM shims
- Adds the existing `env.require` and `env.currentDir` manual Result blocks to the known backlog alongside `regex.compile`
- Keeps the central shared/fs helper implementations excluded from the inventory scan

## Test plan

- Not run locally: this automation thread's local shell cannot start processes, so verification is delegated to GitHub CI.