### PR TITLE
route env.currentDir through shared ptr Result helper

### DIFF
--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -362,56 +362,14 @@ func (g *generator) emitStdEnvCurrentDirCall(call *ast.CallExpr) (value, bool, e
 	if len(call.Args) != 0 {
 		return value{}, true, unsupportedf("call", "env.currentDir takes no arguments, got %d", len(call.Args))
 	}
-	info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
-	if !ok {
-		return value{}, true, unsupported("type-system", "env.currentDir Result<String, Error> type is unavailable")
-	}
-	if g.resultTypes == nil {
-		g.resultTypes = map[string]builtinResultType{}
-	}
-	g.resultTypes[info.typ] = info
-	if info.okTyp != "ptr" || info.errTyp != "ptr" {
-		return value{}, true, unsupportedf("type-system", "env.currentDir currently needs ptr-backed Result<String, Error>, got ok=%s err=%s", info.okTyp, info.errTyp)
-	}
-	g.declareRuntimeSymbol(ostyRtEnvCurrentDirSymbol, "ptr", nil)
-	g.declareRuntimeSymbol(ostyRtEnvCurrentDirErrorSymbol, "ptr", nil)
-	emitter := g.toOstyEmitter()
-	g.emitCallSafepointIfNeeded(emitter)
-	dir := llvmCall(emitter, "ptr", ostyRtEnvCurrentDirSymbol, nil)
-	missing := llvmCompare(emitter, "eq", dir, toOstyValue(value{typ: "ptr", ref: "null"}))
-	missingLabel := llvmNextLabel(emitter, "env.current_dir.err")
-	okLabel := llvmNextLabel(emitter, "env.current_dir.ok")
-	contLabel := llvmNextLabel(emitter, "env.current_dir.cont")
-	emitter.body = append(emitter.body, "  br i1 "+missing.name+", label %"+missingLabel+", label %"+okLabel)
-
-	emitter.body = append(emitter.body, missingLabel+":")
-	errText := llvmCall(emitter, "ptr", ostyRtEnvCurrentDirErrorSymbol, nil)
-	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "1"}),
-		toOstyValue(llvmZeroValue(info.okTyp)),
-		errText,
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, okLabel+":")
-	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "0"}),
-		dir,
-		toOstyValue(llvmZeroValue(info.errTyp)),
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, contLabel+":")
-	phi := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+missingLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
-	g.takeOstyEmitter(emitter)
-	v := value{
-		typ:        info.typ,
-		ref:        phi,
-		sourceType: stdEnvRequireResultSourceTypeSingleton,
-	}
-	v.rootPaths = g.rootPathsForType(v.typ)
-	return v, true, nil
+	return g.emitPtrBackedResultFromRuntimeCall(
+		"env.current_dir",
+		stdEnvRequireResultSourceTypeSingleton,
+		ostyRtEnvCurrentDirSymbol,
+		ostyRtEnvCurrentDirErrorSymbol,
+		nil,
+		nil,
+	)
 }
 
 func (g *generator) emitStdEnvSetCurrentDirCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -31,6 +31,31 @@ func TestStdUuidParseUsesSharedPtrBackedResultHelper(t *testing.T) {
 	}
 }
 
+func TestStdEnvCurrentDirUsesSharedPtrBackedResultHelper(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "internal", "llvmgen", "stdlib_env_shim.go"))
+	if err != nil {
+		t.Fatalf("read stdlib_env_shim.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "emitPtrBackedResultFromRuntimeCall(\n\t\t\"env.current_dir\"") {
+		t.Fatalf("env.currentDir no longer routes through the shared ptr-backed Result helper")
+	}
+	for _, forbidden := range []string{
+		"env.current_dir.err",
+		"env.current_dir.ok",
+		"env.current_dir.cont",
+		"env.currentDir currently needs ptr-backed Result",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("env.currentDir still carries manual Result marker %q", forbidden)
+		}
+	}
+}
+
 func TestSharedPtrBackedResultHelperIsStdlibNeutral(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -100,7 +125,6 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 	allowed := map[string][]string{
 		"stdlib_env_shim.go": []string{
 			"env.require currently needs ptr-backed Result<String, Error>",
-			"env.currentDir currently needs ptr-backed Result<String, Error>",
 		},
 		"stdlib_regex_shim.go": []string{
 			"regex.compile Result must be ptr-backed",


### PR DESCRIPTION
## Summary

- Routes `env.currentDir()` through the shared ptr-backed Result runtime helper instead of hand-emitting err/ok/cont blocks
- Removes `env.currentDir` from the manual ptr-backed Result backlog inventory
- Adds a source guard so `env.currentDir` keeps using the shared helper and does not regain manual Result block labels

## Test plan

- Not run locally: this automation thread's local shell still cannot start processes, so verification is delegated to GitHub CI.