### PR TITLE
fix(mir): recover indirect-call return type + IdentUnknown dispatch in joinWith<T>

### DIFF
--- a/internal/backend/llvm_fmt_joinwith_test.go
+++ b/internal/backend/llvm_fmt_joinwith_test.go
@@ -1,0 +1,72 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitFmtJoinWithGenericClosure locks in the fix for
+// monomorphized `fmt.joinWith<T>` end-to-end emission. The wall this
+// covered:
+//
+//   - After ir.Monomorphize specializes joinWith<T> to T=Int, the
+//     `mapper(items[i])` call inside the StringLit interpolation
+//     `"{result}{sep}{mapper(items[i])}"` lost its checker-side type
+//     annotations: the IR Ident kept Kind=IdentUnknown / Type=<error>
+//     and the surrounding CallExpr inherited <error> as its T.
+//
+//   - That poisoned the MIR temp the emitter allocated for the call's
+//     return value, and the lowerer routed the indirect call as a
+//     direct FnRef{Symbol: "mapper"}.
+//
+//   - The two halves combined to produce two cascading walls:
+//     `unsupported local type <error>` and
+//     `call to unresolved symbol mapper`.
+//
+// The fix lives in two places (internal/mir/lower.go):
+//
+//   1. recoverFnTypedLocalReturn — when CallExpr.Callee is a bare
+//      Ident and global signature lookup fails, scan fn.Locals for a
+//      same-named fn-typed slot and pull the FnType.Return.
+//   2. resolveCall — IdentUnknown callees that resolve to a fn-typed
+//      local route as IndirectCall instead of falling through to a
+//      "call to unresolved symbol" FnRef.
+//
+// Without either half, the joinWith program rejects with one of the
+// two LLVM000 walls; with both, the LLVM backend emits cleanly. We
+// scan all warnings — the goal is to catch any regression that
+// surfaces either pattern again.
+func TestLLVMBackendEmitFmtJoinWithGenericClosure(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	src := `use std.fmt
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    let s = fmt.joinWith(xs, ", ", |i| "{i}")
+    println(s)
+}
+`
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, src)
+	res, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		if res != nil {
+			for i, w := range res.Warnings {
+				t.Logf("warning[%d]: %v", i, w)
+			}
+		}
+		t.Fatalf("Emit failed: %v", err)
+	}
+	if res != nil {
+		for _, w := range res.Warnings {
+			msg := w.Error()
+			if strings.Contains(msg, "<error>") {
+				t.Errorf("warning surfaces <error>-typed local: %s", msg)
+			}
+			if strings.Contains(msg, "unresolved symbol mapper") {
+				t.Errorf("indirect call to mapper routed as FnRef: %s", msg)
+			}
+		}
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2638,6 +2638,37 @@ func (bs *bodyState) recoveredTypeOf(e ir.Expr) ir.Type {
 	return t
 }
 
+// recoverFnTypedLocalReturn looks up `name` in the MIR function's
+// locals (params + scope-bound). When the local's type is a concrete
+// FnType, returns its Return so the caller can use it as the recovered
+// CallExpr result type. Used to un-poison `<error>` temps that back
+// indirect-call returns inside string interpolation — the closure
+// parameter's MIR-level Type was substituted at monomorph time even
+// when the IR Ident node lost its annotation.
+func (bs *bodyState) recoverFnTypedLocalReturn(name string) ir.Type {
+	if name == "" {
+		return nil
+	}
+	if id, ok := bs.lookup(name); ok {
+		if loc := bs.fn.Local(id); loc != nil {
+			if f, ok := loc.Type.(*ir.FnType); ok && f.Return != nil && !isPoisonType(f.Return) {
+				return f.Return
+			}
+		}
+	}
+	// Fallback: params that haven't been pushed into the lookup scope
+	// yet are still in fn.Locals with the substituted FnType.
+	for _, loc := range bs.fn.Locals {
+		if loc == nil || loc.Name != name {
+			continue
+		}
+		if f, ok := loc.Type.(*ir.FnType); ok && f.Return != nil && !isPoisonType(f.Return) {
+			return f.Return
+		}
+	}
+	return nil
+}
+
 func (bs *bodyState) recoveredIdentStorageType(id *ir.Ident) ir.Type {
 	if id == nil {
 		return nil
@@ -2678,6 +2709,15 @@ func (bs *bodyState) recoverOperandType(e ir.Expr) ir.Type {
 			}
 			if sig := bs.l.signatureForFn(id.Name); sig != nil && !isPoisonType(sig.retType) {
 				return sig.retType
+			}
+			// Indirect call through a fn-typed local / param (e.g.
+			// `mapper(item)` inside `fmt.joinWith<T>`). The Ident's
+			// own Type may have been poisoned by an earlier pass, but
+			// the MIR function's locals were created with substituted
+			// types post-monomorph — so a name match against fn.Locals
+			// recovers the FnType when the IR Ident lost it.
+			if rt := bs.recoverFnTypedLocalReturn(id.Name); rt != nil {
+				return rt
 			}
 		}
 		// Qualified call through a `use X as alias` — `alias.fn(...)`.
@@ -4856,6 +4896,26 @@ func (bs *bodyState) resolveCall(c *ir.CallExpr) ([]Operand, Callee) {
 			// closure's `%Option.i64` param ABI).
 			args := bs.orderArgsByTypes(c.Args, paramTypesOf(cal.T))
 			return args, &IndirectCall{Callee: calleeOp}
+		}
+		// IdentUnknown fallback: the checker/native-checker pair skips
+		// some Ident nodes (notably ones nested inside StringLit
+		// interpolations after monomorph), leaving Kind == IdentUnknown
+		// and Type == <error> on the IR side. If the name resolves to
+		// a fn-typed local/param in MIR scope, route as an indirect
+		// call instead of treating it as a module symbol — otherwise
+		// the FnRef fallback below produces "call to unresolved symbol
+		// <name>" at MIR generator time. Mirror of the same recovery
+		// the operand path does via recoverFnTypedLocalReturn.
+		if cal.Kind == ir.IdentUnknown {
+			if id, ok := bs.lookup(cal.Name); ok {
+				if loc := bs.fn.Local(id); loc != nil {
+					if _, isFn := loc.Type.(*ir.FnType); isFn {
+						calleeOp := &CopyOp{Place: Place{Local: id}, T: loc.Type}
+						args := bs.orderArgsByTypes(c.Args, paramTypesOf(loc.Type))
+						return args, &IndirectCall{Callee: calleeOp}
+					}
+				}
+			}
 		}
 		sig := bs.l.signatureForFn(cal.Name)
 		args := bs.orderArgs(c.Args, sig)


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on \`fmt.joinWith<T>\` and similar generic
free fns that take a closure-typed parameter and call it inside a
\`StringLit\` interpolation (\`\"{result}{sep}{mapper(items[i])}\"\`).

### Failure mode

- \`ir.Monomorphize\` specializes \`joinWith<T>\` to \`T=Int\` → cloned
  body has a fully-typed first call \`mapper(items[0])\` (Kind=
  IdentParam, Type=fn(Int)→String) but the second call inside the
  StringLit interpolation kept Kind=IdentUnknown / Type=\`<error>\`
  because the checker/native-checker pair skip Idents nested inside
  StringLit parts.
- MIR lowering allocated an \`<error>\` temp for that call's return
  value and routed the call as a \`FnRef{Symbol: \"mapper\"}\` (Kind
  was Unknown, not Local/Param).
- The MIR emitter walled with two cascading LLVM000s:
  - \`unsupported local type <error>\`
  - \`call to unresolved symbol mapper\`

### Fix

\`internal/mir/lower.go\`:

1. \`recoverFnTypedLocalReturn(name)\` — when \`CallExpr.Callee\` is a
   bare Ident and existing recovery (builtinFreeCallReturn +
   signatureForFn) returns nil, scan \`fn.Locals\` for a same-named
   fn-typed slot. Returns its Return type. The MIR locals were
   created with substituted types post-monomorph, so this works even
   when the IR Ident lost its annotation.
2. \`resolveCall\` — IdentUnknown callees that resolve to a fn-typed
   local in scope route as \`IndirectCall\` instead of falling
   through to the \"unresolved symbol\" FnRef path.

## Test plan

- [x] \`TestLLVMBackendEmitFmtJoinWithGenericClosure\` (new) — runs
      \`fmt.joinWith\` end-to-end under \`OSTY_STDLIB_BODY_LOWER=1\` and
      asserts no \`<error>\` and no \`unresolved symbol mapper\`
- [x] \`go test -short ./internal/mir/... ./internal/llvmgen/...
      ./internal/backend/...\` green (no regressions)

## Notes

The underlying checker bug — Idents nested inside StringLit
interpolation parts retain IdentUnknown/\`<error>\` after
specialization — is worth tackling separately in \`internal/check\`.
This PR's scope is the MIR-side recovery so the LLVM backend stops
walling on the visible call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)