### PR TITLE
feat(stdlib): encoding.url.encode 5★ (Phase 3)

### DIFF
--- a/examples/encoding_url_e2e/encoding_url_test.osty
+++ b/examples/encoding_url_e2e/encoding_url_test.osty
@@ -1,0 +1,16 @@
+// encoding_url_e2e — Phase 3 RFC 3986 percent-encoding E2E.
+
+use std.testing
+use std.encoding
+
+fn testUrlEncodeSpace() {
+    testing.assertEq(encoding.url.encode("hello world"), "hello%20world")
+}
+
+fn testUrlEncodeReservedChars() {
+    testing.assertEq(encoding.url.encode("a/b?c=d&e=f"), "a%2Fb%3Fc%3Dd%26e%3Df")
+}
+
+fn testUrlEncodeUnreservedPassthrough() {
+    testing.assertEq(encoding.url.encode("ABC-_.~"), "ABC-_.~")
+}

--- a/examples/encoding_url_e2e/osty.toml
+++ b/examples/encoding_url_e2e/osty.toml
@@ -1,0 +1,4 @@
+[package]
+name = "encoding_url_e2e"
+version = "0.1.0"
+edition = "0.3"

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4949,6 +4949,8 @@ const char *osty_rt_encoding_base64_encode(void *raw_bytes);
 const char *osty_rt_encoding_base64url_encode(void *raw_bytes);
 void *osty_rt_encoding_base64_decode(const char *value);
 void *osty_rt_encoding_base64url_decode(const char *value);
+const char *osty_rt_encoding_url_encode(const char *value);
+const char *osty_rt_encoding_url_decode(const char *value);
 void *osty_rt_crypto_sha256(void *raw_data);
 void *osty_rt_crypto_sha512(void *raw_data);
 void *osty_rt_crypto_sha1(void *raw_data);
@@ -12534,6 +12536,101 @@ void *osty_rt_encoding_base64_decode(const char *value) {
 
 void *osty_rt_encoding_base64url_decode(const char *value) {
     return osty_rt_encoding_base64_decode_impl(value, 1);
+}
+
+/* ── std.encoding url percent-encoding (RFC 3986) ─────────────────
+ * Encode: unreserved (A-Z a-z 0-9 - _ . ~) → as-is; everything else
+ * → "%XX". Decode: reverse, with "+" treated as literal '+' (note:
+ * application/x-www-form-urlencoded would map "+" → space — that's
+ * a separate codec). Decode returns NULL on invalid sequences. */
+
+static const char osty_rt_encoding_url_hex_upper[] = "0123456789ABCDEF";
+
+static int osty_rt_encoding_url_unreserved(unsigned char c) {
+    if (c >= 'A' && c <= 'Z') return 1;
+    if (c >= 'a' && c <= 'z') return 1;
+    if (c >= '0' && c <= '9') return 1;
+    if (c == '-' || c == '_' || c == '.' || c == '~') return 1;
+    return 0;
+}
+
+const char *osty_rt_encoding_url_encode(const char *value) {
+    size_t in_len;
+    size_t out_len = 0;
+    size_t i;
+    char *out;
+    size_t j = 0;
+
+    if (value == NULL) {
+        value = "";
+    }
+    in_len = strlen(value);
+
+    for (i = 0; i < in_len; i++) {
+        unsigned char c = (unsigned char)value[i];
+        if (osty_rt_encoding_url_unreserved(c)) {
+            out_len++;
+        } else {
+            out_len += 3;
+        }
+    }
+    out = (char *)osty_gc_allocate_managed(out_len + 1, OSTY_GC_KIND_STRING,
+                                           "runtime.encoding.url.encode", NULL, NULL);
+    for (i = 0; i < in_len; i++) {
+        unsigned char c = (unsigned char)value[i];
+        if (osty_rt_encoding_url_unreserved(c)) {
+            out[j++] = (char)c;
+        } else {
+            out[j++] = '%';
+            out[j++] = osty_rt_encoding_url_hex_upper[(c >> 4) & 0x0F];
+            out[j++] = osty_rt_encoding_url_hex_upper[c & 0x0F];
+        }
+    }
+    out[j] = '\0';
+    return out;
+}
+
+static int osty_rt_encoding_url_hex_value(unsigned char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    return -1;
+}
+
+const char *osty_rt_encoding_url_decode(const char *value) {
+    size_t in_len;
+    size_t i;
+    char *out;
+    size_t j = 0;
+
+    if (value == NULL) {
+        value = "";
+    }
+    in_len = strlen(value);
+
+    /* Worst-case (no escapes) is in_len. Allocate that. */
+    out = (char *)osty_gc_allocate_managed(in_len + 1, OSTY_GC_KIND_STRING,
+                                           "runtime.encoding.url.decode", NULL, NULL);
+    for (i = 0; i < in_len; i++) {
+        unsigned char c = (unsigned char)value[i];
+        if (c == '%') {
+            int hi, lo;
+            if (i + 2 >= in_len) {
+                return NULL;
+            }
+            hi = osty_rt_encoding_url_hex_value((unsigned char)value[i + 1]);
+            lo = osty_rt_encoding_url_hex_value((unsigned char)value[i + 2]);
+            if (hi < 0 || lo < 0) {
+                return NULL;
+            }
+            out[j++] = (char)((hi << 4) | lo);
+            i += 2;
+        } else {
+            out[j++] = (char)c;
+        }
+    }
+    out[j] = '\0';
+    return out;
 }
 
 void *osty_rt_bytes_from_list(void *raw_list) {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3357,6 +3357,11 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 			return err
 		}
 	}
+	if strings.HasPrefix(fnRef.Symbol, "UrlEncoding__") {
+		if handled, err := g.emitStdEncodingUrlCallMIR(c, fnRef); handled {
+			return err
+		}
+	}
 	if handled, err := g.emitStdProcessFacadeCall(c, fnRef); handled {
 		return err
 	}

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -13,13 +13,15 @@ import (
 // AST and MIR dispatch do not grow separate prefix tables as codecs are added.
 
 const (
-	ostyRtBytesToHexSymbol            = "osty_rt_bytes_to_hex"
-	ostyRtBytesFromHexSymbol          = "osty_rt_bytes_from_hex"
-	ostyRtBytesIsValidHexSymbol       = "osty_rt_bytes_is_valid_hex"
-	ostyRtEncodingBase64EncodeSymbol  = "osty_rt_encoding_base64_encode"
-	ostyRtEncodingBase64UrlEncSymbol  = "osty_rt_encoding_base64url_encode"
-	ostyRtEncodingBase64DecodeSymbol  = "osty_rt_encoding_base64_decode"
-	ostyRtEncodingBase64UrlDecSymbol  = "osty_rt_encoding_base64url_decode"
+	ostyRtBytesToHexSymbol           = "osty_rt_bytes_to_hex"
+	ostyRtBytesFromHexSymbol         = "osty_rt_bytes_from_hex"
+	ostyRtBytesIsValidHexSymbol      = "osty_rt_bytes_is_valid_hex"
+	ostyRtEncodingBase64EncodeSymbol = "osty_rt_encoding_base64_encode"
+	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
+	ostyRtEncodingBase64DecodeSymbol = "osty_rt_encoding_base64_decode"
+	ostyRtEncodingBase64UrlDecSymbol = "osty_rt_encoding_base64url_decode"
+	ostyRtEncodingUrlEncodeSymbol    = "osty_rt_encoding_url_encode"
+	ostyRtEncodingUrlDecodeSymbol    = "osty_rt_encoding_url_decode"
 )
 
 type stdEncodingRuntimeDecodeKind int
@@ -115,6 +117,13 @@ func (g *generator) stdEncodingHexCallInfo(call *ast.CallExpr) (*ast.FieldExpr, 
 	return field, ok && spec != nil && spec.Variant == "hex"
 }
 
+// stdEncodingUrlCallInfo matches `<encoding-alias>.url.<method>(...)`.
+// Note this is the top-level percent-encoding helper — distinct from
+// the `encoding.base64.url` URL-safe alphabet alias.
+func (g *generator) stdEncodingUrlCallInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	return g.stdEncodingMethodInfo(call, "url")
+}
+
 func (g *generator) stdEncodingBase64CallInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool) {
 	field, spec, ok := g.stdEncodingRuntimeCallInfo(call)
 	if !ok || spec == nil || (spec.Variant != "base64" && spec.Variant != "base64url") {
@@ -202,6 +211,23 @@ func (g *generator) emitStdEncodingCall(call *ast.CallExpr) (value, bool, error)
 		out, err := g.emitEncodingHexDecodeResult(text)
 		return out, true, err
 	}
+	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			if len(call.Args) != 1 {
+				return value{}, true, unsupportedf("call", "encoding.url.encode expects 1 argument, got %d", len(call.Args))
+			}
+			text, err := g.emitStdStringsArg(call.Args[0], "encoding.url.encode", 0)
+			if err != nil {
+				return value{}, true, err
+			}
+			out, err := g.emitEncodingUrlSimpleRuntime(text, ostyRtEncodingUrlEncodeSymbol)
+			return out, true, err
+		case "decode":
+			// AST-route decode awaits MIR Result<String, Error> wrapping.
+			return value{}, true, unsupportedf("call", "encoding.url.decode requires MIR Result<String, Error> handling (separate cycle)")
+		}
+	}
 	return value{}, false, nil
 }
 
@@ -219,7 +245,28 @@ func (g *generator) stdEncodingCallStaticResult(call *ast.CallExpr) (value, bool
 		}
 		return value{}, false
 	}
+	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
+		case "decode":
+			if info, ok := builtinResultTypeFromAST(urlDecodeResultSourceType(), g.typeEnv()); ok {
+				return value{typ: info.typ, sourceType: urlDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+			}
+			return value{}, false
+		}
+	}
 	return value{}, false
+}
+
+func urlDecodeResultSourceType() ast.Type {
+	return &ast.NamedType{
+		Path: []string{"Result"},
+		Args: []ast.Type{
+			&ast.NamedType{Path: []string{"String"}},
+			&ast.NamedType{Path: []string{"Error"}},
+		},
+	}
 }
 
 func (g *generator) staticStdEncodingCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
@@ -232,6 +279,14 @@ func (g *generator) staticStdEncodingCallSourceType(call *ast.CallExpr) (ast.Typ
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case "decode":
 		return hexDecodeResultSourceType(), true
+	}
+	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
+		switch field.Name {
+		case "encode":
+			return &ast.NamedType{Path: []string{"String"}}, true
+		case "decode":
+			return urlDecodeResultSourceType(), true
+		}
 	}
 	return nil, false
 }
@@ -249,6 +304,20 @@ func (g *generator) emitStdEncodingEncodeRuntime(data value, symbol string) (val
 
 func (g *generator) emitEncodingHexEncodeRuntime(data value) (value, error) {
 	return g.emitStdEncodingEncodeRuntime(data, ostyRtBytesToHexSymbol)
+}
+
+// emitEncodingUrlSimpleRuntime lowers a String-in / String-out
+// percent-coding call (`encoding.url.encode`). Decode-with-Result
+// goes through a separate path.
+func (g *generator) emitEncodingUrlSimpleRuntime(text value, sym string) (value, error) {
+	g.declareRuntimeSymbol(sym, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", sym, []*LlvmValue{toOstyValue(text)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return v, nil
 }
 
 func (g *generator) emitEncodingBase64EncodeRuntime(data value, urlSafe bool) (value, error) {
@@ -330,8 +399,34 @@ func (g *generator) emitEncodingHexDecodeResult(text value) (value, error) {
 	return out, nil
 }
 
-// emitStdEncodingBase64CallMIR is kept as the base64-specific entry point used
-// by mir_generator.go; the actual ABI selection is table-driven.
+// emitStdEncodingUrlCallMIR routes `UrlEncoding__encode(self, text)`
+// to `osty_rt_encoding_url_encode`. Decode awaits the MIR
+// Result<String, Error> wrapping (separate cycle).
+func (g *mirGen) emitStdEncodingUrlCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	method := strings.TrimPrefix(fnRef.Symbol, "UrlEncoding__")
+	if method != "encode" && method != "decode" {
+		return false, nil
+	}
+	if method == "decode" {
+		return true, unsupported("mir-mvp", "encoding.url.decode requires AST lowering route (MIR Result<String, Error> handling pending)")
+	}
+	args := c.Args
+	if len(args) == 0 {
+		return true, unsupported("mir-mvp", "encoding.url method without receiver")
+	}
+	args = args[1:]
+	if len(args) != 1 {
+		return true, unsupported("mir-mvp", "encoding.url.encode requires one String argument")
+	}
+	text, err := g.evalStringArg(args[0], "encoding.url.encode", 0)
+	if err != nil {
+		return true, err
+	}
+	return true, g.emitRuntimeCallToDest(c, ostyRtEncodingUrlEncodeSymbol, "ptr", []mirRuntimeArg{text})
+}
+
+// emitStdEncodingBase64CallMIR is kept as the base64-specific entry point
+// used by mir_generator.go; the actual ABI selection is table-driven.
 func (g *mirGen) emitStdEncodingBase64CallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	return g.emitStdEncodingRuntimeCallMIR(c, fnRef)
 }

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 466 `.osty` file(s)  
-**Captured:** 254 residual case(s) — **0** AI-slip(s) airepair rewrote, **254** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 467 `.osty` file(s)  
+**Captured:** 255 residual case(s) — **0** AI-slip(s) airepair rewrote, **255** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
- **C runtime**: `osty_rt_encoding_url_{encode,decode}` 추가 (RFC 3986). Encode: unreserved `A-Z a-z 0-9 - _ . ~` 외 모두 `%XX`. UTF-8 multi-byte 는 byte 단위 인코딩 (예: `한` → `%ED%95%9C`). Decode 는 invalid sequence 시 NULL.
- **LLVM shim**: [`stdlib_encoding_shim.go`](internal/llvmgen/stdlib_encoding_shim.go) AST + MIR dispatch 확장 (`UrlEncoding__encode` 인식).
- **E2E**: [`examples/encoding_url_e2e/`](examples/encoding_url_e2e/) 3/3 통과 (space / reserved chars / unreserved passthrough).

## Phase
- ~~Phase 1 (#1346): hex.encode~~
- ~~Phase 2 (#1347): base64.encode + 4 C runtime~~
- **Phase 3 (this PR): url percent-encode**
- Phase 4 (남음): MIR Result<*, Error> 갭 해소 — hex/base64/url decode 모두 통합 활성화

## Test plan
- [x] `just prepush` 통과
- [x] `examples/encoding_url_e2e/` 3/3 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)