### PR TITLE
route regex.compile through shared ptr Result helper

### DIFF
--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -56,6 +56,31 @@ func TestStdEnvCurrentDirUsesSharedPtrBackedResultHelper(t *testing.T) {
 	}
 }
 
+func TestStdRegexCompileUsesSharedPtrBackedResultHelper(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "internal", "llvmgen", "stdlib_regex_shim.go"))
+	if err != nil {
+		t.Fatalf("read stdlib_regex_shim.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "emitPtrBackedResultFromRuntimeCall(\n\t\t\"regex.compile\"") {
+		t.Fatalf("regex.compile no longer routes through the shared ptr-backed Result helper")
+	}
+	for _, forbidden := range []string{
+		"regex.compile.err",
+		"regex.compile.ok",
+		"regex.compile.cont",
+		"regex.compile Result must be ptr-backed",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("regex.compile still carries manual Result marker %q", forbidden)
+		}
+	}
+}
+
 func TestSharedPtrBackedResultHelperIsStdlibNeutral(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -125,9 +150,6 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 	allowed := map[string][]string{
 		"stdlib_env_shim.go": []string{
 			"env.require currently needs ptr-backed Result<String, Error>",
-		},
-		"stdlib_regex_shim.go": []string{
-			"regex.compile Result must be ptr-backed",
 		},
 	}
 	seen := map[string]bool{}

--- a/internal/llvmgen/stdlib_regex_shim.go
+++ b/internal/llvmgen/stdlib_regex_shim.go
@@ -183,54 +183,14 @@ func (g *generator) emitStdRegexCompileCall(call *ast.CallExpr) (value, bool, er
 	if loaded.typ != "ptr" {
 		return value{}, true, unsupportedf("type-system", "regex.compile arg 1 type %s, want String", loaded.typ)
 	}
-
-	info, ok := builtinResultTypeFromAST(stdRegexCompileResultSourceTypeSingleton, g.typeEnv())
-	if !ok {
-		return value{}, true, unsupported("type-system", "regex.compile Result<Regex, Error> type unavailable")
-	}
-	if g.resultTypes == nil {
-		g.resultTypes = map[string]builtinResultType{}
-	}
-	g.resultTypes[info.typ] = info
-	if info.okTyp != "ptr" || info.errTyp != "ptr" {
-		return value{}, true, unsupportedf("type-system", "regex.compile Result must be ptr-backed, got ok=%s err=%s", info.okTyp, info.errTyp)
-	}
-
-	g.declareRuntimeSymbol(ostyRtRegexCompileSymbol, "ptr", []paramInfo{{typ: "ptr"}})
-	g.declareRuntimeSymbol(ostyRtRegexCompileErrorSymbol, "ptr", nil)
-	emitter := g.toOstyEmitter()
-	g.emitCallSafepointIfNeeded(emitter)
-	out := llvmCall(emitter, "ptr", ostyRtRegexCompileSymbol, []*LlvmValue{toOstyValue(loaded)})
-	failed := llvmCompare(emitter, "eq", out, toOstyValue(value{typ: "ptr", ref: "null"}))
-	errLabel := llvmNextLabel(emitter, "regex.compile.err")
-	okLabel := llvmNextLabel(emitter, "regex.compile.ok")
-	contLabel := llvmNextLabel(emitter, "regex.compile.cont")
-	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
-
-	emitter.body = append(emitter.body, errLabel+":")
-	errText := llvmCall(emitter, "ptr", ostyRtRegexCompileErrorSymbol, nil)
-	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "1"}),
-		toOstyValue(llvmZeroValue(info.okTyp)),
-		errText,
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, okLabel+":")
-	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "0"}),
-		out,
-		toOstyValue(llvmZeroValue(info.errTyp)),
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, contLabel+":")
-	phi := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
-	g.takeOstyEmitter(emitter)
-	v := value{typ: info.typ, ref: phi, sourceType: stdRegexCompileResultSourceTypeSingleton}
-	v.rootPaths = g.rootPathsForType(v.typ)
-	return v, true, nil
+	return g.emitPtrBackedResultFromRuntimeCall(
+		"regex.compile",
+		stdRegexCompileResultSourceTypeSingleton,
+		ostyRtRegexCompileSymbol,
+		ostyRtRegexCompileErrorSymbol,
+		[]paramInfo{{typ: "ptr"}},
+		[]*LlvmValue{toOstyValue(loaded)},
+	)
 }
 
 func (g *generator) emitStdRegexMethodCall(call *ast.CallExpr) (value, bool, error) {


### PR DESCRIPTION
## Summary

- Routes AST-side `regex.compile()` through the shared ptr-backed Result runtime helper
- Removes the regex compile manual err/ok/cont Result block from `stdlib_regex_shim.go`
- Drops `regex.compile` from the manual ptr-backed Result backlog and adds a source guard against regression

## Test plan

- Not run locally: this automation thread's local shell still cannot start processes, so verification is delegated to GitHub CI.