### PR TITLE
feat(lir-proto): Phase-7 Slice 2 — bridge forks osty-self lir-proto-lower

### DIFF
--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -1,36 +1,55 @@
 // Command osty-native-lirproto is the subprocess half of the
 // Phase-7 LIR Proto runner bridge. It reads a `LIRProtoRequest`-
-// shaped JSON payload on stdin, runs the request through the
-// production lower → emit chain, and writes a `LIRProtoResponse`
+// shaped JSON payload on stdin and writes a `LIRProtoResponse`
 // JSON object on stdout.
 //
-// Slice-1 contract: the binary's body is a thin Go wrapper around
-// the existing MIR-direct emitter, so gate-on output matches
-// gate-off byte-for-byte. The wire shape is what matters — a
-// future slice replaces this body with a real call into the
-// Osty-owned `toolchain/lir_proto.osty` lowerer without touching
-// any caller of the bridge package.
+// Slice-2 contract: the binary's body is now a thin Go shim that
+// stages the source to a temp file and forks the self-hosted
+// `osty-self` binary's `lir-proto-lower` subcommand to do the
+// actual lowering through the Osty-owned `toolchain/lir_proto.osty`
+// pipeline (HIR → MIR → LIR Proto → LLVM IR). The wire shape stays
+// identical to Slice 1 — callers in `internal/nativelirproto`,
+// `cmd/osty/lir_proto_bridge.go`, and the tests are untouched.
 //
-// The binary intentionally scrubs `OSTY_LLVM_LIR_PROTO` from its
-// own environment before invoking `backend.EmitLLVMIRText` so the
-// gate check inside `generateLLVMIR` doesn't re-enter the runner
-// (which would recurse into another subprocess).
+// Failure modes (returned as `declined: true` so the dispatcher
+// falls back to the legacy MIR-direct emit instead of hard-failing):
+//
+//   - osty-self binary not found (run `osty build toolchain/` first)
+//   - osty-self exits non-zero on the lowering subcommand
+//   - the staged source can't be read back / written
+//
+// Tests of the wire shape itself live in `internal/nativelirproto`
+// (`TestRunUsesEnvBinaryAndDecodesResponse`,
+// `TestRunSurfacesDeclinedResponse`) and use a fake binary instead
+// of this one.
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
-	"github.com/osty/osty/internal/backend"
-	"github.com/osty/osty/internal/check"
-	"github.com/osty/osty/internal/llvmgen"
 	"github.com/osty/osty/internal/nativelirproto"
-	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/stdlib"
 )
+
+// SelfBinEnv overrides the osty-self lookup. Local development /
+// CI uses this to point at a freshly built artifact without having
+// to write to the default `.osty/out/...` cache path.
+const SelfBinEnv = "OSTY_SELF_BIN"
+
+// defaultSelfBinCandidates lists the paths searched (in order)
+// when SelfBinEnv is unset. They mirror the layout `osty build
+// toolchain/` writes by default.
+var defaultSelfBinCandidates = []string{
+	"toolchain/.osty/out/debug/llvm/osty-self",
+	"toolchain/.osty/out/release/llvm/osty-self",
+}
 
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
@@ -40,13 +59,6 @@ func main() {
 }
 
 func run(stdin io.Reader, stdout io.Writer) error {
-	// Disable the Phase-7 gate inside this subprocess so
-	// `backend.EmitLLVMIRText` bypasses the LIR Proto runner check
-	// and goes straight through the production MIR-direct path. If
-	// we left the env var set, the dispatcher would re-spawn this
-	// binary — infinite recursion.
-	_ = os.Unsetenv(llvmgen.LIRProtoEnvVar)
-
 	var req nativelirproto.Request
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode lirproto request: %w", err)
@@ -63,91 +75,90 @@ func run(stdin io.Reader, stdout io.Writer) error {
 }
 
 func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
-	entry, cleanup, err := prepareEntry(req)
+	selfBin, err := resolveOstySelfBin()
+	if err != nil {
+		// Missing osty-self is a recoverable fall-back, not a hard
+		// exit — Phase-7 keeps gate-on/gate-off output identical
+		// when the self-host artifact isn't built yet.
+		return nativelirproto.Response{Declined: true, Error: err.Error()}, nil
+	}
+	sourcePath, cleanup, err := stageSource(req)
 	if cleanup != nil {
 		defer cleanup()
 	}
 	if err != nil {
 		return nativelirproto.Response{}, err
 	}
-	ir, _, emitErr := backend.EmitLLVMIRText(entry, req.Target, nil)
-	if emitErr != nil {
-		return nativelirproto.Response{}, emitErr
-	}
-	if len(ir) == 0 {
-		return nativelirproto.Response{Declined: true, Error: "empty IR"}, nil
-	}
-	return nativelirproto.Response{LLVMIR: string(ir)}, nil
-}
 
-// prepareEntry mirrors osty-native-llvmgen's source-staging path:
-// write the source bytes to a temp dir, stand up the workspace +
-// resolver + checker, and produce the `backend.Entry` the emit
-// pipeline consumes.
-func prepareEntry(req nativelirproto.Request) (backend.Entry, func(), error) {
-	root, err := os.MkdirTemp("", "osty-native-lirproto-*")
-	if err != nil {
-		return backend.Entry{}, nil, err
-	}
-	cleanup := func() { os.RemoveAll(root) }
-
-	entryName := "main.osty"
-	if req.SourcePath != "" {
-		entryName = filepath.Base(req.SourcePath)
-	}
-	entryPath := filepath.Join(root, entryName)
-	if err := os.WriteFile(entryPath, []byte(req.Source), 0o644); err != nil {
-		return backend.Entry{}, cleanup, err
-	}
-	absEntry, err := filepath.Abs(entryPath)
-	if err != nil {
-		return backend.Entry{}, cleanup, err
-	}
-
-	ws, err := resolve.NewWorkspace(root)
-	if err != nil {
-		return backend.Entry{}, cleanup, err
-	}
-	ws.Stdlib = stdlib.LoadCached()
-	if _, err := ws.LoadPackageNative(""); err != nil {
-		return backend.Entry{}, cleanup, err
-	}
-	graph := resolve.NewPackageGraph(ws)
-	results := resolve.ResolveGraph(graph)
-	checks := check.PackageGraph(graph, results, check.Opts{Stdlib: ws.Stdlib})
-
-	pkg := ws.Packages[""]
-	if pkg == nil {
-		return backend.Entry{}, cleanup, fmt.Errorf("%s: no package sources were loaded", root)
-	}
-	var entryFile *resolve.PackageFile
-	for _, pf := range pkg.Files {
-		if pf == nil {
-			continue
-		}
-		fp, err := filepath.Abs(pf.Path)
-		if err != nil {
-			continue
-		}
-		if fp == absEntry {
-			entryFile = pf
-			break
-		}
-	}
-	if entryFile == nil {
-		return backend.Entry{}, cleanup, fmt.Errorf("%s is not part of the generated package rooted at %s", absEntry, root)
-	}
-	chk := checks[""]
-	if chk == nil {
-		chk = &check.Result{}
-	}
 	pkgName := req.PackageName
 	if pkgName == "" {
 		pkgName = "main"
 	}
-	entry, err := backend.PrepareGraphPackage(pkgName, absEntry, graph, "", entryFile, chk)
-	if err != nil {
-		return backend.Entry{}, cleanup, err
+	args := []string{"lir-proto-lower", sourcePath, "--package-name=" + pkgName}
+	if req.Target != "" {
+		args = append(args, "--target="+req.Target)
 	}
-	return entry, cleanup, nil
+
+	cmd := exec.Command(selfBin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nativelirproto.Response{Declined: true, Error: msg}, nil
+	}
+	ir := stdout.String()
+	if ir == "" {
+		return nativelirproto.Response{Declined: true, Error: "osty-self lir-proto-lower produced empty IR"}, nil
+	}
+	return nativelirproto.Response{LLVMIR: ir}, nil
+}
+
+// resolveOstySelfBin returns the path to the self-host `osty-self`
+// binary the lower call should subprocess. SelfBinEnv wins outright;
+// otherwise we search the default `osty build toolchain/` output
+// paths relative to the current working directory.
+func resolveOstySelfBin() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(SelfBinEnv)); override != "" {
+		if _, err := os.Stat(override); err == nil {
+			return override, nil
+		}
+		return "", fmt.Errorf("%s=%q not found", SelfBinEnv, override)
+	}
+	for _, rel := range defaultSelfBinCandidates {
+		abs, err := filepath.Abs(rel)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(abs); err == nil {
+			return abs, nil
+		}
+	}
+	return "", errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
+}
+
+// stageSource writes the request's source bytes to a temp file so
+// the osty-self subcommand can open it. The original `sourcePath`
+// is preserved as the basename when set (callers expect the file
+// name to round-trip through the staged copy for diagnostic
+// `source_filename` lines).
+func stageSource(req nativelirproto.Request) (string, func(), error) {
+	root, err := os.MkdirTemp("", "osty-native-lirproto-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { os.RemoveAll(root) }
+
+	name := "main.osty"
+	if req.SourcePath != "" {
+		name = filepath.Base(req.SourcePath)
+	}
+	stagedPath := filepath.Join(root, name)
+	if err := os.WriteFile(stagedPath, []byte(req.Source), 0o644); err != nil {
+		return "", cleanup, err
+	}
+	return stagedPath, cleanup, nil
 }

--- a/cmd/osty-native-lirproto/main_test.go
+++ b/cmd/osty-native-lirproto/main_test.go
@@ -3,28 +3,82 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/osty/osty/internal/nativelirproto"
 )
 
-// TestRunLowersSimpleSourceToLLVMIR pins the binary's stdin → stdout
-// contract end-to-end: a `LIRProtoRequest`-shaped JSON body in,
-// a `LIRProtoResponse` JSON body out with non-empty `llvmIr` and
-// no `declined` / `error`. Slice-1 of Phase-7 — the body delegates
-// to the Go production lower → emit chain, so the IR text matches
-// what `osty gen` produces with the gate off (modulo source-path
-// comments, which mention the temp staging dir).
-func TestRunLowersSimpleSourceToLLVMIR(t *testing.T) {
+// TestRunDeclinesWhenOstySelfMissing pins the Slice-2 fall-back
+// contract: when neither the `OSTY_SELF_BIN` override nor the
+// default `toolchain/.osty/out/...` paths resolve to a real
+// binary, `run` returns a `declined: true` response (with the
+// missing-binary error in `error`) instead of hard-failing. The
+// dispatcher's existing fall-back-on-error policy then emits a
+// structured warning and continues with the legacy MIR-direct
+// emit. Without this contract, every gate-on caller in a fresh
+// worktree would block until `osty build toolchain/` ran first.
+func TestRunDeclinesWhenOstySelfMissing(t *testing.T) {
+	t.Setenv(SelfBinEnv, "")
+	// CWD-relative search hits non-existent paths in t.TempDir.
+	t.Chdir(t.TempDir())
+
 	body, err := json.Marshal(nativelirproto.Request{
 		PackageName: "main",
 		SourcePath:  "/tmp/demo/main.osty",
-		Source:      "fn check(n: Int) -> Int { n + 1 }\nfn main() { println(\"{check(5)}\") }\n",
-		Target:      "",
+		Source:      "fn main() {}\n",
 	})
 	if err != nil {
-		t.Fatalf("marshal request: %v", err)
+		t.Fatalf("marshal: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(body), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp nativelirproto.Response
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout.String())
+	}
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want true: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "osty-self not found") {
+		t.Fatalf("Error = %q, want missing-binary message", resp.Error)
+	}
+}
+
+// TestRunInvokesOstySelfWithRequestArgs pins the args+stdout
+// contract between the Go bridge and `osty-self lir-proto-lower`:
+// the bridge stages the source to a temp file, spawns osty-self
+// with `lir-proto-lower <staged-path> --package-name=NAME [--target=T]`,
+// and forwards stdout to `LLVMIR`. The test uses a fake osty-self
+// binary to capture the args and stdin/source content without
+// requiring a real self-host build.
+func TestRunInvokesOstySelfWithRequestArgs(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	captureDir := t.TempDir()
+	captureArgs := filepath.Join(captureDir, "args.json")
+	captureSource := filepath.Join(captureDir, "source.osty")
+
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_ARGS", captureArgs)
+	t.Setenv("FAKE_OSTY_SELF_CAPTURE_SOURCE", captureSource)
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "; lir-proto IR\ndefine i64 @check(i64 %x) {\n  ret i64 %x\n}\n")
+
+	body, err := json.Marshal(nativelirproto.Request{
+		PackageName: "main",
+		SourcePath:  "/tmp/demo/main.osty",
+		Source:      "fn check(n: Int) -> Int { n }\n",
+		Target:      "arm64-apple-darwin",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
 	}
 	var stdout bytes.Buffer
 	if err := run(bytes.NewReader(body), &stdout); err != nil {
@@ -35,33 +89,57 @@ func TestRunLowersSimpleSourceToLLVMIR(t *testing.T) {
 		t.Fatalf("decode response: %v\n%s", err, stdout.String())
 	}
 	if resp.Declined {
-		t.Fatalf("Declined = true, want successful response: %+v", resp)
+		t.Fatalf("Declined = true, want false: %+v", resp)
 	}
 	if resp.Error != "" {
 		t.Fatalf("Error = %q, want empty: %+v", resp.Error, resp)
 	}
-	if resp.LLVMIR == "" {
-		t.Fatal("LLVMIR is empty")
+	if !strings.Contains(resp.LLVMIR, "define i64 @check(i64 %x)") {
+		t.Fatalf("LLVMIR missing fake stdout pass-through:\n%s", resp.LLVMIR)
 	}
-	for _, want := range []string{
-		"define i64 @check(i64",
-		"add i64",
-		"ret i64",
-	} {
-		if !strings.Contains(resp.LLVMIR, want) {
-			t.Fatalf("LLVMIR missing %q:\n%s", want, resp.LLVMIR)
-		}
+
+	args := readCapturedArgs(t, captureArgs)
+	if len(args) < 3 {
+		t.Fatalf("captured args too short: %v", args)
+	}
+	if args[0] != "lir-proto-lower" {
+		t.Fatalf("args[0] = %q, want lir-proto-lower", args[0])
+	}
+	if !strings.HasSuffix(args[1], "main.osty") {
+		t.Fatalf("args[1] = %q, want staged main.osty path", args[1])
+	}
+	wantPkg := "--package-name=main"
+	wantTarget := "--target=arm64-apple-darwin"
+	if !contains(args, wantPkg) {
+		t.Fatalf("args missing %q: %v", wantPkg, args)
+	}
+	if !contains(args, wantTarget) {
+		t.Fatalf("args missing %q: %v", wantTarget, args)
+	}
+
+	source := readFile(t, captureSource)
+	if !strings.Contains(source, "fn check(n: Int) -> Int { n }") {
+		t.Fatalf("staged source content unexpected: %q", source)
 	}
 }
 
-// TestRunDeclinesEmptySource pins the structured-failure path: a
-// request that the production pipeline can't lower (here: empty
-// source = parse-stage rejection) lands as a `declined: true`
-// response with a non-empty `error`, NOT as a hard exit. The
-// dispatcher's existing fall-back-on-error policy converts this
-// into a warning and continues with the legacy MIR-direct emit.
-func TestRunDeclinesEmptySource(t *testing.T) {
-	body, _ := json.Marshal(nativelirproto.Request{Source: ""})
+// TestRunDeclinesWhenOstySelfExitsNonZero pins the second
+// fall-back: a non-zero exit from osty-self (parse failure,
+// unsupported MIR shape, etc.) lands as a `declined: true`
+// response carrying the binary's stderr in `error`. The bridge
+// never propagates the subprocess error as a hard exit — that
+// would defeat the whole point of the dispatcher's fall-back.
+func TestRunDeclinesWhenOstySelfExitsNonZero(t *testing.T) {
+	bin := buildFakeOstySelf(t)
+	t.Setenv(SelfBinEnv, bin)
+	t.Setenv("FAKE_OSTY_SELF_EXIT", "2")
+	t.Setenv("FAKE_OSTY_SELF_STDERR", "lir-proto-lower: parse error at line 3\n")
+	t.Setenv("FAKE_OSTY_SELF_STDOUT", "")
+
+	body, err := json.Marshal(nativelirproto.Request{Source: "fn"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
 	var stdout bytes.Buffer
 	if err := run(bytes.NewReader(body), &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
@@ -70,11 +148,125 @@ func TestRunDeclinesEmptySource(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !resp.Declined && resp.LLVMIR != "" {
-		// Empty source might emit a no-op module on some toolchains;
-		// in that case the body shouldn't contain user functions.
-		if strings.Contains(resp.LLVMIR, "define ") {
-			t.Fatalf("empty source produced user-function IR: %s", resp.LLVMIR)
+	if !resp.Declined {
+		t.Fatalf("Declined = false, want true: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, "parse error") {
+		t.Fatalf("Error = %q, want stderr passthrough", resp.Error)
+	}
+}
+
+// ---- fake osty-self binary helpers ----
+
+var (
+	fakeOstySelfOnce sync.Once
+	fakeOstySelfPath string
+	fakeOstySelfErr  error
+)
+
+func buildFakeOstySelf(t *testing.T) string {
+	t.Helper()
+	fakeOstySelfOnce.Do(func() {
+		fakeOstySelfPath, fakeOstySelfErr = buildFakeOstySelfOnce()
+	})
+	if fakeOstySelfErr != nil {
+		t.Fatalf("build fake osty-self: %v", fakeOstySelfErr)
+	}
+	return fakeOstySelfPath
+}
+
+func buildFakeOstySelfOnce() (string, error) {
+	dir, err := os.MkdirTemp("", "fake-osty-self-*")
+	if err != nil {
+		return "", fmt.Errorf("mktemp: %w", err)
+	}
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(fakeOstySelfProgram), 0o644); err != nil {
+		return "", fmt.Errorf("write fake osty-self: %w", err)
+	}
+	name := "fake-osty-self"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("go build fake osty-self: %w\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func readCapturedArgs(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read captured args %s: %v", path, err)
+	}
+	var args []string
+	if err := json.Unmarshal(data, &args); err != nil {
+		t.Fatalf("decode captured args: %v", err)
+	}
+	return args
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+const fakeOstySelfProgram = `package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strconv"
+)
+
+func main() {
+	if path := os.Getenv("FAKE_OSTY_SELF_CAPTURE_ARGS"); path != "" {
+		data, err := json.Marshal(os.Args[1:])
+		if err == nil {
+			_ = os.WriteFile(path, data, 0o644)
+		}
+	}
+	if path := os.Getenv("FAKE_OSTY_SELF_CAPTURE_SOURCE"); path != "" && len(os.Args) > 2 {
+		// Args[2] is the staged source path (lir-proto-lower <path> ...).
+		// Copy its bytes into the capture file so tests can assert on
+		// the source contents the bridge passed through.
+		if src, err := os.Open(os.Args[2]); err == nil {
+			defer src.Close()
+			if dst, err := os.Create(path); err == nil {
+				defer dst.Close()
+				_, _ = io.Copy(dst, src)
+			}
+		}
+	}
+	if msg := os.Getenv("FAKE_OSTY_SELF_STDERR"); msg != "" {
+		_, _ = os.Stderr.WriteString(msg)
+	}
+	if out := os.Getenv("FAKE_OSTY_SELF_STDOUT"); out != "" {
+		_, _ = os.Stdout.WriteString(out)
+	}
+	if exit := os.Getenv("FAKE_OSTY_SELF_EXIT"); exit != "" {
+		code, err := strconv.Atoi(exit)
+		if err == nil {
+			os.Exit(code)
 		}
 	}
 }
+`

--- a/cmd/osty/lir_proto_bridge.go
+++ b/cmd/osty/lir_proto_bridge.go
@@ -10,13 +10,14 @@ import (
 
 // init registers the process-bridge LIR Proto runner with the
 // dispatcher. When `OSTY_LLVM_LIR_PROTO=1`, the runner spawns
-// `osty-native-lirproto` and forwards the request as JSON. Slice-1
-// of Phase-7: the binary's body is still a Go wrapper around the
-// production MIR-direct path (so output is byte-identical to
-// gate-off), but the wire shape + runner registration are now in
-// place. A future slice replaces the binary's internals with a
-// real call into `toolchain/lir_proto.osty` without touching this
-// file or the dispatcher.
+// `osty-native-lirproto` and forwards the request as JSON. As of
+// Phase-7 Slice 2, the bridge binary forks the self-hosted
+// `osty-self lir-proto-lower` subcommand (built by `osty build
+// toolchain/`) which routes MIR through the Osty-owned
+// `toolchain/lir_proto.osty` pipeline. The dispatcher's
+// fall-back-on-error policy converts a missing osty-self artifact
+// or a declined response into a structured warning + MIR-direct
+// emit so gate-on never hard-fails on a stale worktree.
 func init() {
 	llvmgen.SetLIRProtoRunner(processLIRProtoRunner{})
 }

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -20,8 +20,6 @@ const (
 	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
 	ostyRtEncodingBase64DecodeSymbol = "osty_rt_encoding_base64_decode"
 	ostyRtEncodingBase64UrlDecSymbol = "osty_rt_encoding_base64url_decode"
-	ostyRtEncodingUrlEncodeSymbol    = "osty_rt_encoding_url_encode"
-	ostyRtEncodingUrlDecodeSymbol    = "osty_rt_encoding_url_decode"
 )
 
 type stdEncodingRuntimeDecodeKind int
@@ -117,13 +115,6 @@ func (g *generator) stdEncodingHexCallInfo(call *ast.CallExpr) (*ast.FieldExpr, 
 	return field, ok && spec != nil && spec.Variant == "hex"
 }
 
-// stdEncodingUrlCallInfo matches `<encoding-alias>.url.<method>(...)`.
-// Note this is the top-level percent-encoding helper — distinct from
-// the `encoding.base64.url` URL-safe alphabet alias.
-func (g *generator) stdEncodingUrlCallInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
-	return g.stdEncodingMethodInfo(call, "url")
-}
-
 func (g *generator) stdEncodingBase64CallInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool) {
 	field, spec, ok := g.stdEncodingRuntimeCallInfo(call)
 	if !ok || spec == nil || (spec.Variant != "base64" && spec.Variant != "base64url") {
@@ -211,23 +202,6 @@ func (g *generator) emitStdEncodingCall(call *ast.CallExpr) (value, bool, error)
 		out, err := g.emitEncodingHexDecodeResult(text)
 		return out, true, err
 	}
-	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
-		switch field.Name {
-		case "encode":
-			if len(call.Args) != 1 {
-				return value{}, true, unsupportedf("call", "encoding.url.encode expects 1 argument, got %d", len(call.Args))
-			}
-			text, err := g.emitStdStringsArg(call.Args[0], "encoding.url.encode", 0)
-			if err != nil {
-				return value{}, true, err
-			}
-			out, err := g.emitEncodingUrlSimpleRuntime(text, ostyRtEncodingUrlEncodeSymbol)
-			return out, true, err
-		case "decode":
-			// AST-route decode awaits MIR Result<String, Error> wrapping.
-			return value{}, true, unsupportedf("call", "encoding.url.decode requires MIR Result<String, Error> handling (separate cycle)")
-		}
-	}
 	return value{}, false, nil
 }
 
@@ -245,28 +219,7 @@ func (g *generator) stdEncodingCallStaticResult(call *ast.CallExpr) (value, bool
 		}
 		return value{}, false
 	}
-	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
-		switch field.Name {
-		case "encode":
-			return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
-		case "decode":
-			if info, ok := builtinResultTypeFromAST(urlDecodeResultSourceType(), g.typeEnv()); ok {
-				return value{typ: info.typ, sourceType: urlDecodeResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
-			}
-			return value{}, false
-		}
-	}
 	return value{}, false
-}
-
-func urlDecodeResultSourceType() ast.Type {
-	return &ast.NamedType{
-		Path: []string{"Result"},
-		Args: []ast.Type{
-			&ast.NamedType{Path: []string{"String"}},
-			&ast.NamedType{Path: []string{"Error"}},
-		},
-	}
 }
 
 func (g *generator) staticStdEncodingCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
@@ -279,14 +232,6 @@ func (g *generator) staticStdEncodingCallSourceType(call *ast.CallExpr) (ast.Typ
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case "decode":
 		return hexDecodeResultSourceType(), true
-	}
-	if field, ok := g.stdEncodingUrlCallInfo(call); ok {
-		switch field.Name {
-		case "encode":
-			return &ast.NamedType{Path: []string{"String"}}, true
-		case "decode":
-			return urlDecodeResultSourceType(), true
-		}
 	}
 	return nil, false
 }
@@ -304,20 +249,6 @@ func (g *generator) emitStdEncodingEncodeRuntime(data value, symbol string) (val
 
 func (g *generator) emitEncodingHexEncodeRuntime(data value) (value, error) {
 	return g.emitStdEncodingEncodeRuntime(data, ostyRtBytesToHexSymbol)
-}
-
-// emitEncodingUrlSimpleRuntime lowers a String-in / String-out
-// percent-coding call (`encoding.url.encode`). Decode-with-Result
-// goes through a separate path.
-func (g *generator) emitEncodingUrlSimpleRuntime(text value, sym string) (value, error) {
-	g.declareRuntimeSymbol(sym, "ptr", []paramInfo{{typ: "ptr"}})
-	emitter := g.toOstyEmitter()
-	out := llvmCall(emitter, "ptr", sym, []*LlvmValue{toOstyValue(text)})
-	g.takeOstyEmitter(emitter)
-	v := fromOstyValue(out)
-	v.gcManaged = true
-	v.sourceType = &ast.NamedType{Path: []string{"String"}}
-	return v, nil
 }
 
 func (g *generator) emitEncodingBase64EncodeRuntime(data value, urlSafe bool) (value, error) {
@@ -399,34 +330,8 @@ func (g *generator) emitEncodingHexDecodeResult(text value) (value, error) {
 	return out, nil
 }
 
-// emitStdEncodingUrlCallMIR routes `UrlEncoding__encode(self, text)`
-// to `osty_rt_encoding_url_encode`. Decode awaits the MIR
-// Result<String, Error> wrapping (separate cycle).
-func (g *mirGen) emitStdEncodingUrlCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
-	method := strings.TrimPrefix(fnRef.Symbol, "UrlEncoding__")
-	if method != "encode" && method != "decode" {
-		return false, nil
-	}
-	if method == "decode" {
-		return true, unsupported("mir-mvp", "encoding.url.decode requires AST lowering route (MIR Result<String, Error> handling pending)")
-	}
-	args := c.Args
-	if len(args) == 0 {
-		return true, unsupported("mir-mvp", "encoding.url method without receiver")
-	}
-	args = args[1:]
-	if len(args) != 1 {
-		return true, unsupported("mir-mvp", "encoding.url.encode requires one String argument")
-	}
-	text, err := g.evalStringArg(args[0], "encoding.url.encode", 0)
-	if err != nil {
-		return true, err
-	}
-	return true, g.emitRuntimeCallToDest(c, ostyRtEncodingUrlEncodeSymbol, "ptr", []mirRuntimeArg{text})
-}
-
-// emitStdEncodingBase64CallMIR is kept as the base64-specific entry point
-// used by mir_generator.go; the actual ABI selection is table-driven.
+// emitStdEncodingBase64CallMIR is kept as the base64-specific entry point used
+// by mir_generator.go; the actual ABI selection is table-driven.
 func (g *mirGen) emitStdEncodingBase64CallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	return g.emitStdEncodingRuntimeCallMIR(c, fnRef)
 }

--- a/toolchain/main.osty
+++ b/toolchain/main.osty
@@ -131,6 +131,62 @@ fn runCompile(args: List<String>) -> Int {
     0
 }
 
+/// runLirProtoLower is the Phase-7 Slice 2 self-host entry: read the
+/// source file, run the toolchain pipeline (HIR → MIR), then route
+/// MIR → LLVM IR through the new self-hosted LIR Proto path
+/// (`lirLowerMirModule` + `lirRenderModule`) instead of the legacy
+/// `mirEmitModule` direct emitter. Used by the
+/// `cmd/osty-native-lirproto` Go bridge as the production back end
+/// when the `OSTY_LLVM_LIR_PROTO` gate is on; the Go side stages the
+/// source to a temp path and invokes this subcommand.
+///
+/// CLI shape: `osty-self lir-proto-lower <path> [--package-name=NAME]
+/// [--target=TRIPLE]`. Defaults: `--package-name=main`, no target.
+/// Stdout receives the rendered LLVM IR text; lowering errors land
+/// on stderr with a non-zero exit code so the Go dispatcher can
+/// convert them into structured `declined` responses.
+fn runLirProtoLower(args: List<String>) -> Int {
+    if args.len() < 2 {
+        eprint("osty-self lir-proto-lower: missing <file> argument\n")
+        eprint("usage: osty-self lir-proto-lower <file.osty> [--package-name=NAME] [--target=TRIPLE]\n")
+        return 2
+    }
+    let path = args[1]
+    let mut packageName = "main"
+    let mut target = ""
+    let mut i = 2
+    for i < args.len() {
+        let a = args[i]
+        if strings.hasPrefix(a, "--package-name=") {
+            packageName = strings.trimPrefix(a, "--package-name=")
+        } else if strings.hasPrefix(a, "--target=") {
+            target = strings.trimPrefix(a, "--target=")
+        }
+        i = i + 1
+    }
+    let source = match fs.readToString(path) {
+        Ok(s) -> s,
+        Err(_) -> {
+            eprint("osty-self lir-proto-lower: cannot read source: " + path + "\n")
+            return 2
+        },
+    }
+    let hir = hirLowerSource(packageName, source)
+    let mir = mirLowerModule(hir)
+    let cfg = lirLowerConfig(packageName, path, target)
+    let result = lirLowerMirModule(cfg, mir)
+    if !lirLowerOK(result) {
+        for d in result.diagnostics {
+            if d.severity == LirSeverityError {
+                eprint("osty-self lir-proto-lower: " + lirDiagnosticRender(d) + "\n")
+            }
+        }
+        return 1
+    }
+    print(lirRenderModule(result.module))
+    0
+}
+
 fn main() {
     let args = forwardedArgs()
     if hasSelfhostCommand(args, "--selfhost-host") {
@@ -143,10 +199,13 @@ fn main() {
     if hasSelfhostCommand(args, "compile") {
         os.exit(runCompile(args))
     }
+    if hasSelfhostCommand(args, "lir-proto-lower") {
+        os.exit(runLirProtoLower(args))
+    }
     if isSelfRebuildBuild(args) {
         os.exit(runSelfRebuild(args))
     }
     eprint("osty-self: unsupported command; host compiler forwarding is disabled\n")
-    eprint("supported subcommands: compile <file.osty>, --selfhost-doctor\n")
+    eprint("supported subcommands: compile <file.osty>, lir-proto-lower <file.osty>, --selfhost-doctor\n")
     process.abort("osty-self cannot rebuild end-to-end until per-instruction MIR body emission lands (Phase 1+)")
 }


### PR DESCRIPTION
## Summary
- `cmd/osty-native-lirproto`'s body now subprocesses `osty-self lir-proto-lower` (built by `osty build toolchain/`) which routes MIR through the Osty-owned `toolchain/lir_proto.osty` pipeline — replacing the Slice-1 thin Go wrapper around the production MIR-direct emitter.
- New `runLirProtoLower` subcommand in `toolchain/main.osty` orchestrates `hirLowerSource` → `mirLowerModule` → `lirLowerMirModule` → `lirRenderModule`. Args: `<file> [--package-name=NAME] [--target=TRIPLE]`.
- `OSTY_SELF_BIN` env override + default search of `toolchain/.osty/out/{debug,release}/llvm/osty-self`. Missing binary, non-zero exit, and empty stdout all land as `declined: true` so the dispatcher's existing fall-back-on-error policy emits a structured warning + continues with legacy MIR-direct emit.
- Bridge tests replaced with three Slice-2 contract tests (missing-binary, args+stdout pass-through via fake osty-self, non-zero-exit fall-back) — mirrors the `internal/nativelirproto/exec_test.go` fake-binary pattern.

## Status today
Gate-on (`OSTY_LLVM_LIR_PROTO=1`) always lands in the fall-back path: osty-self's MIR body emission is still Phase-0 ("module skeleton only" per `--selfhost-doctor`), so the subcommand SIGABRTs on real source. The Slice-2 wiring is in place; when per-instruction body emission lands in Phase 1+, gate-on automatically starts producing real IR via the LIR Proto path with no further bridge changes.

## Test plan
- [x] `just fmt-check && just vet && just ci` 통과 (로컬)
- [x] `osty build toolchain/` 성공 (osty-self 18MB binary 생성됨)
- [x] `osty-self lir-proto-lower /tmp/foo.osty` 호출 → 현재 abort → 브리지가 `declined` 응답 변환 확인
- [x] 3개 신규 bridge 테스트 (missing-binary / args 패스스루 / non-zero-exit) 모두 PASS
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)