### PR TITLE
route env.require through shared ptr Result builder

### DIFF
--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -274,16 +274,9 @@ func (g *generator) emitStdEnvRequireCall(call *ast.CallExpr) (value, bool, erro
 	if arg == nil || arg.Name != "" || arg.Value == nil {
 		return value{}, true, unsupported("call", "env.require requires one positional String argument")
 	}
-	info, ok := builtinResultTypeFromAST(stdEnvRequireResultSourceTypeSingleton, g.typeEnv())
-	if !ok {
-		return value{}, true, unsupported("type-system", "env.require Result<String, Error> type is unavailable")
-	}
-	if g.resultTypes == nil {
-		g.resultTypes = map[string]builtinResultType{}
-	}
-	g.resultTypes[info.typ] = info
-	if info.okTyp != "ptr" || info.errTyp != "ptr" {
-		return value{}, true, unsupportedf("type-system", "env.require currently needs ptr-backed Result<String, Error>, got ok=%s err=%s", info.okTyp, info.errTyp)
+	info, err := g.ptrBackedResultInfo("env.require", stdEnvRequireResultSourceTypeSingleton)
+	if err != nil {
+		return value{}, true, err
 	}
 	name, err := g.emitExpr(arg.Value)
 	if err != nil {
@@ -302,40 +295,11 @@ func (g *generator) emitStdEnvRequireCall(call *ast.CallExpr) (value, bool, erro
 	emitter := g.toOstyEmitter()
 	g.emitCallSafepointIfNeeded(emitter)
 	found := llvmCall(emitter, "ptr", ostyRtEnvGetSymbol, []*LlvmValue{toOstyValue(name)})
-	missing := llvmCompare(emitter, "eq", found, toOstyValue(value{typ: "ptr", ref: "null"}))
-	missingLabel := llvmNextLabel(emitter, "env.require.missing")
-	okLabel := llvmNextLabel(emitter, "env.require.ok")
-	contLabel := llvmNextLabel(emitter, "env.require.cont")
-	emitter.body = append(emitter.body, "  br i1 "+missing.name+", label %"+missingLabel+", label %"+okLabel)
-
-	emitter.body = append(emitter.body, missingLabel+":")
-	prefix := llvmStringLiteral(emitter, "environment variable not set: ")
-	message := llvmStringConcat(emitter, prefix, toOstyValue(name))
-	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "1"}),
-		toOstyValue(llvmZeroValue(info.okTyp)),
-		message,
+	v := g.emitPtrBackedResultFromNullablePtr(emitter, "env.require", stdEnvRequireResultSourceTypeSingleton, info, found, func(emitter *LlvmEmitter) *LlvmValue {
+		prefix := llvmStringLiteral(emitter, "environment variable not set: ")
+		return llvmStringConcat(emitter, prefix, toOstyValue(name))
 	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, okLabel+":")
-	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
-		toOstyValue(value{typ: "i64", ref: "0"}),
-		found,
-		toOstyValue(llvmZeroValue(info.errTyp)),
-	})
-	emitter.body = append(emitter.body, "  br label %"+contLabel)
-
-	emitter.body = append(emitter.body, contLabel+":")
-	phi := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+missingLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
 	g.takeOstyEmitter(emitter)
-	v := value{
-		typ:        info.typ,
-		ref:        phi,
-		sourceType: stdEnvRequireResultSourceTypeSingleton,
-	}
-	v.rootPaths = g.rootPathsForType(v.typ)
 	return v, true, nil
 }
 

--- a/internal/llvmgen/stdlib_ptr_result_shim.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim.go
@@ -2,23 +2,39 @@ package llvmgen
 
 import "github.com/osty/osty/internal/ast"
 
-func (g *generator) emitPtrBackedResultFromRuntimeCall(prefix string, sourceType ast.Type, valueSymbol, errorSymbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+func (g *generator) ptrBackedResultInfo(prefix string, sourceType ast.Type) (builtinResultType, error) {
 	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
 	if !ok {
-		return value{}, true, unsupportedf("type-system", "%s result type unavailable", prefix)
+		return builtinResultType{}, unsupportedf("type-system", "%s result type unavailable", prefix)
 	}
 	if g.resultTypes == nil {
 		g.resultTypes = map[string]builtinResultType{}
 	}
 	g.resultTypes[info.typ] = info
 	if info.okTyp != "ptr" || info.errTyp != "ptr" {
-		return value{}, true, unsupportedf("type-system", "%s currently needs ptr-backed Result, got ok=%s err=%s", prefix, info.okTyp, info.errTyp)
+		return builtinResultType{}, unsupportedf("type-system", "%s currently needs ptr-backed Result, got ok=%s err=%s", prefix, info.okTyp, info.errTyp)
+	}
+	return info, nil
+}
+
+func (g *generator) emitPtrBackedResultFromRuntimeCall(prefix string, sourceType ast.Type, valueSymbol, errorSymbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+	info, err := g.ptrBackedResultInfo(prefix, sourceType)
+	if err != nil {
+		return value{}, true, err
 	}
 	g.declareRuntimeSymbol(valueSymbol, "ptr", params)
 	g.declareRuntimeSymbol(errorSymbol, "ptr", nil)
 	emitter := g.toOstyEmitter()
 	g.emitCallSafepointIfNeeded(emitter)
 	out := llvmCall(emitter, "ptr", valueSymbol, args)
+	v := g.emitPtrBackedResultFromNullablePtr(emitter, prefix, sourceType, info, out, func(emitter *LlvmEmitter) *LlvmValue {
+		return llvmCall(emitter, "ptr", errorSymbol, nil)
+	})
+	g.takeOstyEmitter(emitter)
+	return v, true, nil
+}
+
+func (g *generator) emitPtrBackedResultFromNullablePtr(emitter *LlvmEmitter, prefix string, sourceType ast.Type, info builtinResultType, out *LlvmValue, emitErrText func(*LlvmEmitter) *LlvmValue) value {
 	failed := llvmCompare(emitter, "eq", out, toOstyValue(value{typ: "ptr", ref: "null"}))
 	errLabel := llvmNextLabel(emitter, prefix+".err")
 	okLabel := llvmNextLabel(emitter, prefix+".ok")
@@ -26,7 +42,7 @@ func (g *generator) emitPtrBackedResultFromRuntimeCall(prefix string, sourceType
 	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
 
 	emitter.body = append(emitter.body, errLabel+":")
-	errText := llvmCall(emitter, "ptr", errorSymbol, nil)
+	errText := emitErrText(emitter)
 	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
 		toOstyValue(value{typ: "i64", ref: "1"}),
 		toOstyValue(llvmZeroValue(info.okTyp)),
@@ -45,8 +61,7 @@ func (g *generator) emitPtrBackedResultFromRuntimeCall(prefix string, sourceType
 	emitter.body = append(emitter.body, contLabel+":")
 	phi := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
-	g.takeOstyEmitter(emitter)
 	v := value{typ: info.typ, ref: phi, sourceType: sourceType}
 	v.rootPaths = g.rootPathsForType(v.typ)
-	return v, true, nil
+	return v
 }

--- a/internal/llvmgen/stdlib_ptr_result_shim_test.go
+++ b/internal/llvmgen/stdlib_ptr_result_shim_test.go
@@ -56,6 +56,31 @@ func TestStdEnvCurrentDirUsesSharedPtrBackedResultHelper(t *testing.T) {
 	}
 }
 
+func TestStdEnvRequireUsesSharedPtrBackedResultBuilder(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(root, "internal", "llvmgen", "stdlib_env_shim.go"))
+	if err != nil {
+		t.Fatalf("read stdlib_env_shim.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "emitPtrBackedResultFromNullablePtr(emitter, \"env.require\"") {
+		t.Fatalf("env.require no longer routes through the shared ptr-backed Result builder")
+	}
+	for _, forbidden := range []string{
+		"env.require.missing",
+		"env.require.ok",
+		"env.require.cont",
+		"env.require currently needs ptr-backed Result",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("env.require still carries manual Result marker %q", forbidden)
+		}
+	}
+}
+
 func TestStdRegexCompileUsesSharedPtrBackedResultHelper(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
@@ -147,11 +172,7 @@ func TestManualPtrBackedResultBlocksStayInventoried(t *testing.T) {
 		t.Fatalf("read internal/llvmgen: %v", err)
 	}
 
-	allowed := map[string][]string{
-		"stdlib_env_shim.go": []string{
-			"env.require currently needs ptr-backed Result<String, Error>",
-		},
-	}
+	allowed := map[string][]string{}
 	seen := map[string]bool{}
 
 	for _, entry := range entries {


### PR DESCRIPTION
## Summary

- Splits the ptr-backed Result helper into reusable type validation and nullable-ptr Result construction pieces
- Routes `env.require()` through the shared nullable-ptr Result builder while keeping its missing-variable error string lazy on the error branch
- Removes the last AST-side manual ptr-backed Result backlog entry and tightens the structural inventory to fail on any new manual marker

## Test plan

- Not run locally: this automation thread's local shell still cannot start processes, so verification is delegated to GitHub CI.