### PR TITLE
fix(llvmgen): restore emitStdEncodingUrlCallMIR dropped by #1362 squash-merge

### DIFF
--- a/internal/backend/llvm_fmt_joinwith_test.go
+++ b/internal/backend/llvm_fmt_joinwith_test.go
@@ -26,12 +26,12 @@ import (
 //
 // The fix lives in two places (internal/mir/lower.go):
 //
-//   1. recoverFnTypedLocalReturn — when CallExpr.Callee is a bare
-//      Ident and global signature lookup fails, scan fn.Locals for a
-//      same-named fn-typed slot and pull the FnType.Return.
-//   2. resolveCall — IdentUnknown callees that resolve to a fn-typed
-//      local route as IndirectCall instead of falling through to a
-//      "call to unresolved symbol" FnRef.
+//  1. recoverFnTypedLocalReturn — when CallExpr.Callee is a bare
+//     Ident and global signature lookup fails, scan fn.Locals for a
+//     same-named fn-typed slot and pull the FnType.Return.
+//  2. resolveCall — IdentUnknown callees that resolve to a fn-typed
+//     local route as IndirectCall instead of falling through to a
+//     "call to unresolved symbol" FnRef.
 //
 // Without either half, the joinWith program rejects with one of the
 // two LLVM000 walls; with both, the LLVM backend emits cleanly. We

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -20,6 +20,8 @@ const (
 	ostyRtEncodingBase64UrlEncSymbol = "osty_rt_encoding_base64url_encode"
 	ostyRtEncodingBase64DecodeSymbol = "osty_rt_encoding_base64_decode"
 	ostyRtEncodingBase64UrlDecSymbol = "osty_rt_encoding_base64url_decode"
+	ostyRtEncodingUrlEncodeSymbol    = "osty_rt_encoding_url_encode"
+	ostyRtEncodingUrlDecodeSymbol    = "osty_rt_encoding_url_decode"
 )
 
 type stdEncodingRuntimeDecodeKind int
@@ -334,6 +336,35 @@ func (g *generator) emitEncodingHexDecodeResult(text value) (value, error) {
 // by mir_generator.go; the actual ABI selection is table-driven.
 func (g *mirGen) emitStdEncodingBase64CallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	return g.emitStdEncodingRuntimeCallMIR(c, fnRef)
+}
+
+// emitStdEncodingUrlCallMIR is the MIR dispatch for std.encoding.url.* —
+// the top-level percent-encoding helper, distinct from the
+// `encoding.base64.url` URL-safe alphabet alias dispatched by
+// emitStdEncodingBase64CallMIR. Restored after PR #1362's squash-merge
+// dropped this method while keeping its call site in mir_generator.go,
+// which left main with an undefined-method build break.
+func (g *mirGen) emitStdEncodingUrlCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	method := strings.TrimPrefix(fnRef.Symbol, "UrlEncoding__")
+	if method != "encode" && method != "decode" {
+		return false, nil
+	}
+	if method == "decode" {
+		return true, unsupported("mir-mvp", "encoding.url.decode requires AST lowering route (MIR Result<String, Error> handling pending)")
+	}
+	args := c.Args
+	if len(args) == 0 {
+		return true, unsupported("mir-mvp", "encoding.url method without receiver")
+	}
+	args = args[1:]
+	if len(args) != 1 {
+		return true, unsupported("mir-mvp", "encoding.url.encode requires one String argument")
+	}
+	text, err := g.evalStringArg(args[0], "encoding.url.encode", 0)
+	if err != nil {
+		return true, err
+	}
+	return true, g.emitRuntimeCallToDest(c, ostyRtEncodingUrlEncodeSymbol, "ptr", []mirRuntimeArg{text})
 }
 
 // emitStdEncodingCallMIR is the MIR-level dispatch for std.encoding methods.


### PR DESCRIPTION
## Summary
- PR #1362's squash-merge dropped the `emitStdEncodingUrlCallMIR` method body while keeping its call site in `internal/llvmgen/mir_generator.go:3361` — main currently fails to build (`undefined method`). This restores the method (and missing `ostyRtEncodingUrl{En,De}codeSymbol` constants) verbatim from PR #1362's diff.
- Runtime symbols (`osty_rt_encoding_url_{encode,decode}`) already exist in `internal/backend/runtime/osty_runtime.c`; no runtime change.
- Incidental: gofmt drift in `internal/backend/llvm_fmt_joinwith_test.go` (from PR #1361 squash) fixed so `just fmt-check` stays green.

## Test plan
- [x] `go build ./...` 통과
- [x] `just fmt-check && go vet ./... && just ci` 모두 통과
- [ ] CI 그린 확인

> Note: `TestGenerateFromMIRStdEncodingNullableDecodeDiscardCallsRuntimeAsPtr` fails on this commit ("unsupported local type \<error\>"), but verified failing at #1351 too — pre-existing breakage in main unrelated to this build-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)