### PR TITLE
feat(llvmgen): MIR foundation for stdlib std.url.Url struct (Phase A)

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -212,6 +212,7 @@ type mirGen struct {
 	tupleDefs   map[string][]mir.Type // mangled tuple name → element types
 
 	stdTermSizeTouched        bool // synthetic std.term Size payload used by MIR
+	stdUrlUrlTouched          bool // synthetic std.url Url payload used by MIR
 	stdOsOutputTouched        bool // synthetic std.os Output payload used by MIR
 	stdOsExecOutputTouched    bool // synthetic std.os ExecOutput payload used by MIR
 	stdCmdCommandTouched      bool // synthetic std.cmd Command payload used by MIR
@@ -730,6 +731,7 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			return true
 		}
 		if g.isStdTermSizeType(x) ||
+			g.isStdUrlType(x) ||
 			g.isStdOsOutputType(x) ||
 			g.isStdOsExecOutputType(x) ||
 			g.isStdCmdCommandType(x) ||
@@ -1667,6 +1669,10 @@ func (g *mirGen) emitTypeDefs() {
 	}
 	if g.stdTermSizeTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdTermSyntheticSizeTypeName, "i64, i64"))
+	}
+	if g.stdUrlUrlTouched {
+		// scheme(ptr) host(ptr) port(Option<Int>) path(ptr) query(ptr) fragment(Option<String>)
+		block.WriteString(mirLlvmStructTypeDefLine(stdUrlSyntheticUrlTypeName, "ptr, ptr, { i64, i64 }, ptr, ptr, { i64, i64 }"))
 	}
 	if g.stdOsOutputTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdOsSyntheticOutputTypeName, "i64, ptr, ptr"))
@@ -10186,6 +10192,22 @@ func (g *mirGen) projectionIndexForType(base mir.Type, p mir.Projection) (int, b
 					return 1, true
 				}
 			}
+			if g.isStdUrlType(nt) {
+				switch fp.Name {
+				case "scheme":
+					return 0, true
+				case "host":
+					return 1, true
+				case "port":
+					return 2, true
+				case "path":
+					return 3, true
+				case "query":
+					return 4, true
+				case "fragment":
+					return 5, true
+				}
+			}
 			if g.isStdOsOutputType(nt) {
 				switch fp.Name {
 				case "exitCode":
@@ -10794,6 +10816,10 @@ func (g *mirGen) llvmType(t mir.Type) string {
 		if g.isStdTermSizeType(x) {
 			g.stdTermSizeTouched = true
 			return "%" + stdTermSyntheticSizeTypeName
+		}
+		if g.isStdUrlType(x) {
+			g.stdUrlUrlTouched = true
+			return "%" + stdUrlSyntheticUrlTypeName
 		}
 		if g.isStdOsOutputType(x) {
 			g.stdOsOutputTouched = true

--- a/internal/llvmgen/stdlib_url_shim.go
+++ b/internal/llvmgen/stdlib_url_shim.go
@@ -1,0 +1,187 @@
+package llvmgen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/ir"
+)
+
+// std.url shim — provides MIR + LLVM support for the spec §10.16 `Url`
+// struct so that `url.parse(text) -> Result<Url, Error>` end-to-end
+// works through the LLVM backend. The Osty body in
+// `internal/stdlib/modules/url.osty` parses RFC 3986 references but
+// the body cannot lower (List<String>, recursive helpers, Map writes
+// in a loop). This shim sidesteps the body by:
+//
+//   1. Registering a synthetic `__osty_std_url_Url` struct so user
+//      code may hold `Url` as a local type and access fields by name
+//      (`u.scheme`, `u.port`, …).
+//   2. Wiring `url.parse` to the C runtime parser
+//      (`osty_rt_url_parse_*`), then constructing the synthetic Url
+//      via the AST/MIR aggregate path.
+//
+// Phase 1 (this file): synthetic struct + isStdUrlType predicate.
+// Phase 2 / 3: C runtime + parse shim land in follow-up commits so
+// each piece has its own bisect surface.
+
+const (
+	stdUrlSyntheticUrlTypeName = "__osty_std_url_Url"
+
+	ostyRtUrlParseSymbol            = "osty_rt_url_parse"
+	ostyRtUrlGetSchemeSymbol        = "osty_rt_url_get_scheme"
+	ostyRtUrlGetHostSymbol          = "osty_rt_url_get_host"
+	ostyRtUrlGetPortSymbol          = "osty_rt_url_get_port"
+	ostyRtUrlGetPathSymbol          = "osty_rt_url_get_path"
+	ostyRtUrlGetFragmentSymbol      = "osty_rt_url_get_fragment"
+	ostyRtUrlHasFragmentSymbol      = "osty_rt_url_has_fragment"
+	ostyRtUrlGetQuerySymbol         = "osty_rt_url_get_query"
+)
+
+// stdUrlSyntheticUrlSourceType is the public AST `NamedType` used to
+// stamp `Url`-typed values produced by the shim. Field-access /
+// builder code threads this through `value.sourceType` so subsequent
+// field lookups recognise the synthetic struct.
+var stdUrlSyntheticUrlSourceType ast.Type = &ast.NamedType{
+	Path: []string{stdUrlSyntheticUrlTypeName},
+}
+
+// stdUrlParseResultSourceType is the `Result<Url, Error>` shape that
+// `url.parse` returns. Built lazily on first use.
+var stdUrlParseResultSourceType ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdUrlSyntheticUrlSourceType,
+		errorSourceTypeSingleton,
+	},
+}
+
+// isStdUrlType matches the spec §10.16 `Url` struct. It only fires
+// when the resolver hasn't already attached a real layout (a user
+// program redeclaring `Url` would take precedence) — same gate the
+// other synthetic stdlib structs use.
+func (g *mirGen) isStdUrlType(t *ir.NamedType) bool {
+	if t == nil || t.Name != "Url" {
+		return false
+	}
+	if g.mod != nil && g.mod.Layouts != nil {
+		if _, ok := g.mod.Layouts.Structs[mirNamedTypeLayoutKey(t)]; ok {
+			return false
+		}
+	}
+	q := t.QualifiedName()
+	return q == "Url" || q == "std.url.Url" || q == "url.Url"
+}
+
+func collectStdUrlAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "url" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "url"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+// ensureStdUrlSyntheticUrlStruct registers the synthetic `Url` struct
+// with the AST-level emitter so that field access (`u.scheme` etc.)
+// can find each field's offset and LLVM type. The layout matches
+// `pub struct Url { scheme: String, host: String, port: Int?, path:
+// String, query: Map<String, String>, fragment: String? }` from
+// `internal/stdlib/modules/url.osty`.
+//
+// `port` and `fragment` are `Option<X>` — at LLVM level the Option
+// shape is a 2-i64 aggregate `{i64 tag, i64 payload}` (matches
+// Result<T, E> emitted elsewhere; payload is bit-cast from the
+// concrete type). The synthetic struct embeds this aggregate inline
+// so the user-side `match u.port { Some(p) -> …, None -> … }`
+// dispatches through the existing Option-on-builtin path.
+func ensureStdUrlSyntheticUrlStruct(g *generator) *structInfo {
+	if g == nil {
+		return nil
+	}
+	if info := g.structsByName[stdUrlSyntheticUrlTypeName]; info != nil {
+		return info
+	}
+	if g.structsByName == nil {
+		g.structsByName = map[string]*structInfo{}
+	}
+	if g.structsByType == nil {
+		g.structsByType = map[string]*structInfo{}
+	}
+	info := &structInfo{
+		name:   stdUrlSyntheticUrlTypeName,
+		typ:    llvmStructTypeName(stdUrlSyntheticUrlTypeName),
+		byName: map[string]fieldInfo{},
+	}
+	optionIntSourceType := &ast.NamedType{
+		Path: []string{"Option"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"Int"}}},
+	}
+	optionStringSourceType := &ast.NamedType{
+		Path: []string{"Option"},
+		Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+	}
+	mapStringStringSourceType := &ast.NamedType{
+		Path: []string{"Map"},
+		Args: []ast.Type{
+			&ast.NamedType{Path: []string{"String"}},
+			&ast.NamedType{Path: []string{"String"}},
+		},
+	}
+	fields := []fieldInfo{
+		{
+			name:       "scheme",
+			typ:        "ptr",
+			index:      0,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "host",
+			typ:        "ptr",
+			index:      1,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "port",
+			typ:        "{ i64, i64 }",
+			index:      2,
+			sourceType: optionIntSourceType,
+		},
+		{
+			name:       "path",
+			typ:        "ptr",
+			index:      3,
+			sourceType: &ast.NamedType{Path: []string{"String"}},
+		},
+		{
+			name:       "query",
+			typ:        "ptr",
+			index:      4,
+			sourceType: mapStringStringSourceType,
+		},
+		{
+			name:       "fragment",
+			typ:        "{ i64, i64 }",
+			index:      5,
+			sourceType: optionStringSourceType,
+		},
+	}
+	info.fields = fields
+	for _, field := range fields {
+		info.byName[field.name] = field
+	}
+	g.structs = append(g.structs, info)
+	g.structsByName[info.name] = info
+	g.structsByType[info.typ] = info
+	return info
+}

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 467 `.osty` file(s)  
-**Captured:** 255 residual case(s) — **0** AI-slip(s) airepair rewrote, **255** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 468 `.osty` file(s)  
+**Captured:** 257 residual case(s) — **0** AI-slip(s) airepair rewrote, **257** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
Phase A of multi-cycle **url 5★** work. Adds synthetic Url payload plumbing so user code can hold `Url` as a local type and access fields by name (`u.scheme`, `u.port`, etc.) without tripping the MIR \"unsupported local type Url\" wall.

- New [`stdlib_url_shim.go`](internal/llvmgen/stdlib_url_shim.go): synthetic struct registration with 6 fields (scheme/host: ptr, port: Option<Int> {i64,i64}, path: ptr, query: Map ptr, fragment: Option<String> {i64,i64}); `isStdUrlType` predicate.
- mir_generator wiring: `stdUrlUrlTouched` flag, LLVM type def emission, `typeSupported` allow-list, field-projection index dispatch.

**Behavioural impact**: `match url.parse(s) { Ok(u) -> ..., Err(_) -> ... }` no longer trips the local-type wall. Still fails at "unresolved symbol std.url.parse" — Phase B (C runtime parser) + Phase C (build shim) land in follow-up PRs.

## Phase plan
- **Phase A (this PR)**: MIR foundation
- Phase B: C runtime RFC 3986 URL parser + 8 accessors
- Phase C: LLVM shim — call parser, build Url struct via insertvalue, wrap in Result
- Phase D: E2E test + matrix update

## Test plan
- [x] `just prepush` 통과
- [x] Probe: `osty gen --backend llvm` on `match url.parse(s) { ... }` switches from "unsupported local type Url" → "unresolved symbol std.url.parse" (foundation works, Phase B+C still pending)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)