### PR TITLE
fix(llvmgen): MIR-direct dispatch for std.encoding.{hex,base64,base64url}

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3363,6 +3363,11 @@ func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 			return err
 		}
 	}
+	if strings.HasPrefix(fnRef.Symbol, "std.encoding.") {
+		if handled, err := g.emitStdEncodingDottedCallMIR(c, fnRef); handled {
+			return err
+		}
+	}
 	if strings.HasPrefix(fnRef.Symbol, "UrlEncoding__") {
 		if handled, err := g.emitStdEncodingUrlCallMIR(c, fnRef); handled {
 			return err

--- a/internal/llvmgen/stdlib_encoding_mir_test.go
+++ b/internal/llvmgen/stdlib_encoding_mir_test.go
@@ -35,19 +35,7 @@ func TestStdEncodingRuntimeLoweringMarksDecodeMIRResult(t *testing.T) {
 	}
 }
 
-// Verified failing on every commit since #1349 introduced these
-// fixtures. The MIR builder lowers `encoding.hex.decode(s)` to a
-// chain of UseRV stores into ErrType-typed locals (because
-// `useAliasFieldPath` only recognises `crypto.hmac.*` and
-// `compress.gzip.*` namespaces, not `encoding.*`), and the LLVM
-// emitter rejects the resulting `<error>` locals up front. The
-// MIR-direct dispatch in `mir_generator.go::emitDirectCall` was
-// wired to expect already-mangled `Hex__decode` / `Base64__decode`
-// symbols that the MIR builder never produces. Skipping for now
-// to take these out of silent-failure status; tracked in
-// `project_encoding_mir_namespace_gap` memory note.
 func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
-	t.Skip("merged broken in #1349; see project_encoding_mir_namespace_gap")
 	got := generateStdEncodingDecodeMIR(t, "hex")
 	for _, want := range []string{
 		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",
@@ -66,8 +54,17 @@ func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
 	}
 }
 
+// Discard contract: in ExprStmt context the from_hex call must be
+// skipped (only is_valid_hex validates). Currently fails because the
+// MIR builder allocates a dest temp for every CallExpr result, so
+// `emitEncodingHexDecodeMIR`'s `c.Dest == nil` shortcut never fires.
+// Fixing requires the MIR builder to omit dest-alloca for discarded
+// calls, which is a broader change than this PR's scope. The
+// nullable-decode discard case (Base64 / Base64Url) sidesteps the
+// issue because its emitter goes through `emitPtrResultFromNullableRuntimeCall`,
+// which copes with a dest that's never read.
 func TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1(t *testing.T) {
-	t.Skip("merged broken in #1349; see project_encoding_mir_namespace_gap")
+	t.Skip("hex.decode discard requires MIR builder to skip dest-alloca for ExprStmt calls; see project_encoding_mir_namespace_gap")
 	got := generateStdEncodingDecodeDiscardMIR(t, "hex")
 	for _, want := range []string{
 		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",
@@ -91,7 +88,6 @@ func TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1(t *testing.T) {
 }
 
 func TestGenerateFromMIRStdEncodingBase64DecodeReturnsResult(t *testing.T) {
-	t.Skip("merged broken in #1349; see project_encoding_mir_namespace_gap")
 	for _, tc := range []struct {
 		variant string
 		runtime string

--- a/internal/llvmgen/stdlib_encoding_shim.go
+++ b/internal/llvmgen/stdlib_encoding_shim.go
@@ -372,6 +372,56 @@ func (g *mirGen) emitStdEncodingCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (boo
 	return g.emitStdEncodingRuntimeCallMIR(c, fnRef)
 }
 
+// emitStdEncodingDottedCallMIR handles `std.encoding.{variant}[.{sub}].{method}`
+// MIR symbols. Produced by the use-alias-field-path dispatch in
+// `internal/mir/lower.go` once `stdlibNestedNamespacePath` accepts the
+// `encoding` namespace — `qualifiedSymbol` joins the path with dots
+// rather than mangling to `Hex__decode` / `Base64__decode`. Mirrors
+// `emitStdEncodingRuntimeCallMIR` but the args list is the user's
+// argument list as-is (no synthetic receiver to strip), since the
+// field-path dispatch never prepends a receiver for free-fn calls.
+func (g *mirGen) emitStdEncodingDottedCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
+	const prefix = "std.encoding."
+	if !strings.HasPrefix(fnRef.Symbol, prefix) {
+		return false, nil
+	}
+	parts := strings.Split(strings.TrimPrefix(fnRef.Symbol, prefix), ".")
+	if len(parts) < 2 {
+		return false, nil
+	}
+	method := parts[len(parts)-1]
+	pathParts := parts[:len(parts)-1]
+	var spec *stdEncodingRuntimeLowering
+	for i := range stdEncodingRuntimeLowerings {
+		if astPathEqual(stdEncodingRuntimeLowerings[i].ASTPath, pathParts) {
+			spec = &stdEncodingRuntimeLowerings[i]
+			break
+		}
+	}
+	if spec == nil {
+		return false, nil
+	}
+	switch method {
+	case "encode":
+		return true, g.emitStdEncodingEncodeCallMIR(c, spec, c.Args)
+	case "decode":
+		return true, g.emitStdEncodingDecodeCallMIR(c, spec, c.Args)
+	}
+	return false, nil
+}
+
+func astPathEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func (g *mirGen) emitStdEncodingRuntimeCallMIR(c *mir.CallInstr, fnRef *mir.FnRef) (bool, error) {
 	spec, method, ok := stdEncodingRuntimeLoweringForMIRSymbol(fnRef.Symbol)
 	if !ok || spec == nil {

--- a/internal/llvmgen/stdlib_mir_result_shim_test.go
+++ b/internal/llvmgen/stdlib_mir_result_shim_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestGenerateFromMIRStdEncodingNullableDecodeDiscardCallsRuntimeAsPtr(t *testing.T) {
-	t.Skip("merged broken in #1349/#1351; see project_encoding_mir_namespace_gap")
 	for _, tc := range []struct {
 		variant string
 		runtime string

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -5121,12 +5121,16 @@ func stdlibNestedNamespacePath(use *ir.UseDecl, parts []string) bool {
 		return parts[0] == "hmac"
 	case "compress", "std.compress":
 		return parts[0] == "gzip"
+	case "encoding", "std.encoding":
+		return parts[0] == "hex" || parts[0] == "base64"
 	}
 	switch pathQualifier(use) {
 	case "std.crypto":
 		return parts[0] == "hmac"
 	case "std.compress":
 		return parts[0] == "gzip"
+	case "std.encoding":
+		return parts[0] == "hex" || parts[0] == "base64"
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Closes the namespace gap tracked in #1374. 3 of 4 broken-merged TestGenerateFromMIRStdEncoding* tests now pass; the 4th (Hex discard) still skipped pending MIR-builder dest-alloca policy.

## What changed
1. `internal/mir/lower.go::stdlibNestedNamespacePath` accepts `encoding`/`std.encoding` namespaces (parts[0] ∈ {hex, base64}).
2. `internal/llvmgen/stdlib_encoding_shim.go` adds `emitStdEncodingDottedCallMIR` — handles `std.encoding.{variant}[.{sub}].{method}` symbols.
3. `internal/llvmgen/mir_generator.go::emitDirectCall` adds the `std.encoding.` prefix dispatch.

## Test plan
- [x] All llvmgen + mir tests pass
- [x] just fmt-check + go vet + just ci all green
- [ ] CI verification

🤖 Generated with Claude Code