### PR TITLE
test(llvm): Day 4 — applyTwice interp regression + plan status update

### DIFF
--- a/STRING_INTERP_RESOLVE_GAP.md
+++ b/STRING_INTERP_RESOLVE_GAP.md
@@ -1,7 +1,18 @@
 # String Interpolation Resolver Gap — Multi-Day Plan
 
-**Status (2026-05-04):** Open. Identified during the fmt_e2e wall-progression
-sweep after [#1326](https://github.com/choiceoh/osty/pull/1326),
+**Status (2026-05-05):** User-facing path closed via #1361 (MIR-layer
+recovery). Canonical-side parser + resolver + applyTwice regression
+shipped via #1360 (Day 1 lexer ranges), #1364 (Day 2 parser
+sub-parse), #1376 (Day 3 resolver verification). Architectural fix
+(Go-side `astbridge` consumes arena children, drops
+`interp_adapter.go` re-parse) blocked on
+`internal/selfhost/generated.go` regeneration — the seed has the
+pre-#1364 parser; the canonical Osty parser is ahead. Until LLVM
+self-host LLVMgen catches up, the runtime MIR fallback from #1361
+handles the visible cases.
+
+**Original status (2026-05-04):** Open. Identified during the fmt_e2e
+wall-progression sweep after [#1326](https://github.com/choiceoh/osty/pull/1326),
 [#1329](https://github.com/choiceoh/osty/pull/1329),
 [#1339](https://github.com/choiceoh/osty/pull/1339),
 [#1341](https://github.com/choiceoh/osty/pull/1341),

--- a/internal/backend/llvm_apply_twice_interp_test.go
+++ b/internal/backend/llvm_apply_twice_interp_test.go
@@ -1,0 +1,75 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitApplyTwiceInterp locks in the canonical
+// user-facing repro from STRING_INTERP_RESOLVE_GAP.md (#1359):
+//
+//	fn applyTwice(mapper: fn(Int) -> String) -> String {
+//	    "{mapper(1)}-{mapper(2)}"
+//	}
+//
+// The plan calls this out specifically — the bug shows up only
+// when a fn-typed parameter is called *inside* a string interpolation.
+// `let r = mapper(1)` outside the interp lowered cleanly even before
+// the fix; the wall fired on calls nested inside `"{...}"`.
+//
+// Coverage layers (each shipped independently, all kept by this test):
+//
+//   - #1360 (Day 1) — lexer exposes interp source byte ranges
+//     (`OstyLexStringPart.srcStart` / `srcEnd`) so future parsers
+//     can re-lex without depending on Go-side `interpolationTokens`.
+//   - #1361 — MIR-side recovery: `recoverFnTypedLocalReturn` +
+//     IdentUnknown→IndirectCall fallback so the joinWith family
+//     compiles even when the IR Ident lost its annotation.
+//   - #1364 (Day 2) — canonical Osty parser sub-parses interp
+//     expressions into `AstNStringLit.children`.
+//   - #1376 (Day 3) — verifies resolver's generic walker recurses
+//     into `AstNStringLit.children`.
+//
+// Day 4's full architectural fix (Go-side `astbridge` consumes arena
+// children directly, drops `interp_adapter.go`'s text re-parse path,
+// preserves NodeIDs end-to-end) is blocked on regenerating
+// `internal/selfhost/generated.go` from the canonical Osty source —
+// the seed has the old parser. The MIR-layer recovery from #1361
+// handles the user-facing case in the meantime, which is what this
+// test verifies.
+func TestLLVMBackendEmitApplyTwiceInterp(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	src := `fn applyTwice(mapper: fn(Int) -> String) -> String {
+    "{mapper(1)}-{mapper(2)}"
+}
+
+fn main() {
+    let r = applyTwice(|n| "v")
+    println(r)
+}
+`
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, src)
+	res, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		if res != nil {
+			for i, w := range res.Warnings {
+				t.Logf("warning[%d]: %v", i, w)
+			}
+		}
+		t.Fatalf("Emit failed: %v", err)
+	}
+	if res != nil {
+		for _, w := range res.Warnings {
+			msg := w.Error()
+			if strings.Contains(msg, "<error>") {
+				t.Errorf("warning surfaces <error>-typed local: %s", msg)
+			}
+			if strings.Contains(msg, "unresolved symbol mapper") {
+				t.Errorf("indirect call to mapper routed as FnRef: %s", msg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Day 4 of [STRING_INTERP_RESOLVE_GAP.md](STRING_INTERP_RESOLVE_GAP.md)
(#1359). The plan calls out the canonical user-facing repro:

\`\`\`osty
fn applyTwice(mapper: fn(Int) -> String) -> String {
    \"{mapper(1)}-{mapper(2)}\"
}
\`\`\`

This PR locks in \`TestLLVMBackendEmitApplyTwiceInterp\` as a
permanent Go-side regression covering the runtime path.

## Coverage map

| PR | Layer | Status |
|----|-------|--------|
| #1360 | Day 1 — lexer interp source byte ranges | shipped |
| #1361 | MIR-layer recovery (recoverFnTypedLocalReturn + IdentUnknown→IndirectCall) | shipped |
| #1364 | Day 2 — canonical Osty parser sub-parses interp | shipped |
| #1376 | Day 3 — verifies resolver walks interp children | shipped |
| **this PR** | Day 4 — applyTwice runtime regression test | shipping |

## Test plan

- [x] \`TestLLVMBackendEmitApplyTwiceInterp\` (new, 5.1s) — applyTwice
      lowers cleanly under \`OSTY_STDLIB_BODY_LOWER=1\`, no
      \`<error>\` and no \`unresolved symbol mapper\` warnings.
- [x] Existing \`TestLLVMBackendEmitFmtJoinWithGenericClosure\`
      (#1361) still green.
- [x] \`go test -short ./internal/backend/...\` green.

## Notes

The plan's **full architectural fix** (Go-side \`astbridge\`
consumes arena children directly, drops \`interp_adapter.go\`'s
text re-parse path, preserves NodeIDs end-to-end) is **blocked**:

The canonical Osty parser shipped in #1364 produces children,
but \`internal/selfhost/generated.go\` is the frozen seed reflecting
the pre-#1364 parser. The bridge can't consume children that don't
exist in the seed's arena. Until LLVM self-host LLVMgen catches up
and re-generates the seed, the MIR-layer recovery from #1361
handles the visible cases.

\`STRING_INTERP_RESOLVE_GAP.md\` updated to record the resolved
status, the seed-regen blocker, and the runtime fallback bridging
the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)