### PR TITLE
fix(mir): skip dest-alloca for ExprStmt-discarded CallExprs

### DIFF
--- a/internal/llvmgen/stdlib_encoding_mir_test.go
+++ b/internal/llvmgen/stdlib_encoding_mir_test.go
@@ -54,17 +54,7 @@ func TestGenerateFromMIRStdEncodingHexDecodeReturnsResult(t *testing.T) {
 	}
 }
 
-// Discard contract: in ExprStmt context the from_hex call must be
-// skipped (only is_valid_hex validates). Currently fails because the
-// MIR builder allocates a dest temp for every CallExpr result, so
-// `emitEncodingHexDecodeMIR`'s `c.Dest == nil` shortcut never fires.
-// Fixing requires the MIR builder to omit dest-alloca for discarded
-// calls, which is a broader change than this PR's scope. The
-// nullable-decode discard case (Base64 / Base64Url) sidesteps the
-// issue because its emitter goes through `emitPtrResultFromNullableRuntimeCall`,
-// which copes with a dest that's never read.
 func TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1(t *testing.T) {
-	t.Skip("hex.decode discard requires MIR builder to skip dest-alloca for ExprStmt calls; see project_encoding_mir_namespace_gap")
 	got := generateStdEncodingDecodeDiscardMIR(t, "hex")
 	for _, want := range []string{
 		"declare i1 @osty_rt_bytes_is_valid_hex(ptr)",

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1056,6 +1056,20 @@ func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Typ
 }
 
 func (bs *bodyState) lowerExprStmt(e *ir.ExprStmt) {
+	// For side-effecting calls in statement context (`encoding.hex.decode(s)`
+	// without a let / assign on the LHS), routing through
+	// lowerExprAsOperand allocates a fresh temp for the result and
+	// emits an `AssignInstr{Dest: tmp, Src: <call>}`. Stdlib emitters
+	// that key on `c.Dest == nil` to skip side-by-side runtime calls
+	// (e.g. `emitEncodingHexDecodeMIR` validates with `is_valid_hex`
+	// but skips `from_hex` when the result is discarded) never see
+	// the nil-dest signal because the temp always exists. Route
+	// CallExpr / MethodCall through their dest=nil-aware lowering so
+	// the discard contract reaches the emitters intact.
+	if c, ok := e.X.(*ir.CallExpr); ok {
+		bs.lowerCallExprInto(c, nil, nil)
+		return
+	}
 	_ = bs.lowerExprAsOperand(e.X)
 }
 


### PR DESCRIPTION
## Summary
Closes the last skipped test from the encoding-namespace-gap arc (#1374 → #1375): `TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1`.

`lowerExprStmt` now special-cases `*ir.CallExpr` to call `lowerCallExprInto(c, nil, nil)` directly, bypassing the temp-allocating generic `lowerExprAsOperand` path. Stdlib emitters that key on `c.Dest == nil` (hex `is_valid_hex`-without-`from_hex`) now receive the nil-dest signal correctly.

## Test status — all 4 originally broken tests now pass
- TestGenerateFromMIRStdEncodingHexDecodeReturnsResult ✓
- **TestGenerateFromMIRStdEncodingHexDecodeDiscardValidatesAsI1** ✓ (newly passing)
- TestGenerateFromMIRStdEncodingBase64DecodeReturnsResult (base64 + base64url) ✓
- TestGenerateFromMIRStdEncodingNullableDecodeDiscardCallsRuntimeAsPtr (base64 + base64url) ✓

## Why narrow / safe
Only `*ir.CallExpr` in ExprStmt context skips temp-allocation. MethodCall not touched (signature change ripples). Non-ExprStmt CallExprs retain dest semantics.

## Test plan
- All 4 tests pass
- go test ./internal/llvmgen ./internal/mir 통과
- just fmt-check + go vet + just ci 통과
- go test -short ./... sweep: no other silent-red

🤖 Generated with Claude Code