### PR TITLE
feat(stdlib): url Phase E — Option<Int> port + Option<String> fragment field access

### DIFF
--- a/examples/url_e2e/url_phaseE_test.osty
+++ b/examples/url_e2e/url_phaseE_test.osty
@@ -1,0 +1,45 @@
+// url Phase E — Option<Int> port + Option<String> fragment field access.
+// Builds on Phase A+B+C+D (PRs #1368, #1369, #1370).
+
+use std.testing
+use std.url
+
+fn testPortPresent() {
+    match url.parse("https://example.com:8080/x") {
+        Ok(u) -> match u.port {
+            Some(_) -> testing.assertTrue(true),
+            None -> testing.assertTrue(false),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testPortAbsent() {
+    match url.parse("https://example.com/x") {
+        Ok(u) -> match u.port {
+            Some(_) -> testing.assertTrue(false),
+            None -> testing.assertTrue(true),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testFragmentPresent() {
+    match url.parse("https://example.com/x#top") {
+        Ok(u) -> match u.fragment {
+            Some(_) -> testing.assertTrue(true),
+            None -> testing.assertTrue(false),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testFragmentAbsent() {
+    match url.parse("https://example.com/x") {
+        Ok(u) -> match u.fragment {
+            Some(_) -> testing.assertTrue(false),
+            None -> testing.assertTrue(true),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1672,7 +1672,12 @@ func (g *mirGen) emitTypeDefs() {
 	}
 	if g.stdUrlUrlTouched {
 		// scheme(ptr) host(ptr) port(Option<Int>) path(ptr) query(ptr) fragment(Option<String>)
-		block.WriteString(mirLlvmStructTypeDefLine(stdUrlSyntheticUrlTypeName, "ptr, ptr, { i64, i64 }, ptr, ptr, { i64, i64 }"))
+		// The two Option flavours need their layouts registered so the
+		// enum-layout-defs block emits them; otherwise the
+		// `%Option.string` reference here references an unsized type.
+		g.registerEnumLayout("Option.i64")
+		g.registerEnumLayout("Option.string")
+		block.WriteString(mirLlvmStructTypeDefLine(stdUrlSyntheticUrlTypeName, "ptr, ptr, %Option.i64, ptr, ptr, %Option.string"))
 	}
 	if g.stdOsOutputTouched {
 		block.WriteString(mirLlvmStructTypeDefLine(stdOsSyntheticOutputTypeName, "i64, ptr, ptr"))

--- a/internal/llvmgen/stdlib_url_shim.go
+++ b/internal/llvmgen/stdlib_url_shim.go
@@ -157,7 +157,7 @@ func ensureStdUrlSyntheticUrlStruct(g *generator) *structInfo {
 		},
 		{
 			name:       "port",
-			typ:        "{ i64, i64 }",
+			typ:        "%Option.i64",
 			index:      2,
 			sourceType: optionIntSourceType,
 		},
@@ -175,7 +175,7 @@ func ensureStdUrlSyntheticUrlStruct(g *generator) *structInfo {
 		},
 		{
 			name:       "fragment",
-			typ:        "{ i64, i64 }",
+			typ:        "%Option.string",
 			index:      5,
 			sourceType: optionStringSourceType,
 		},
@@ -267,7 +267,7 @@ func (g *mirGen) emitUrlParseMIR(c *mir.CallInstr, text mirRuntimeArg) error {
 	hasFragment := g.fresh()
 	g.fnBuf.WriteString(mirCallValueLine(hasFragment, "i1", ostyRtUrlHasFragmentSymbol, mirArgSlotPtr(parsed)))
 
-	// Build Option<Int> port: -1 → None, else Some.
+	// Build Option<Int> port: -1 → None, else Some. Layout %Option.i64.
 	portCmp := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = icmp eq i64 %s, -1\n", portCmp, port))
 	portTag := g.fresh()
@@ -275,11 +275,11 @@ func (g *mirGen) emitUrlParseMIR(c *mir.CallInstr, text mirRuntimeArg) error {
 	portPayload := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = select i1 %s, i64 0, i64 %s\n", portPayload, portCmp, port))
 	portStep := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue { i64, i64 } undef, i64 %s, 0\n", portStep, portTag))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %%Option.i64 undef, i64 %s, 0\n", portStep, portTag))
 	portOpt := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue { i64, i64 } %s, i64 %s, 1\n", portOpt, portStep, portPayload))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %%Option.i64 %s, i64 %s, 1\n", portOpt, portStep, portPayload))
 
-	// Build Option<String> fragment.
+	// Build Option<String> fragment. Layout %Option.string.
 	fragTag := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = select i1 %s, i64 1, i64 0\n", fragTag, hasFragment))
 	fragPayload := g.fresh()
@@ -287,9 +287,9 @@ func (g *mirGen) emitUrlParseMIR(c *mir.CallInstr, text mirRuntimeArg) error {
 	fragGated := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = select i1 %s, i64 %s, i64 0\n", fragGated, hasFragment, fragPayload))
 	fragStep := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue { i64, i64 } undef, i64 %s, 0\n", fragStep, fragTag))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %%Option.string undef, i64 %s, 0\n", fragStep, fragTag))
 	fragOpt := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue { i64, i64 } %s, i64 %s, 1\n", fragOpt, fragStep, fragGated))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %%Option.string %s, i64 %s, 1\n", fragOpt, fragStep, fragGated))
 
 	// Build the Url struct.
 	url0 := g.fresh()
@@ -297,13 +297,13 @@ func (g *mirGen) emitUrlParseMIR(c *mir.CallInstr, text mirRuntimeArg) error {
 	url1 := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, ptr %s, 1\n", url1, urlLLVM, url0, host))
 	url2 := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, { i64, i64 } %s, 2\n", url2, urlLLVM, url1, portOpt))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, %%Option.i64 %s, 2\n", url2, urlLLVM, url1, portOpt))
 	url3 := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, ptr %s, 3\n", url3, urlLLVM, url2, pathReg))
 	url4 := g.fresh()
 	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, ptr %s, 4\n", url4, urlLLVM, url3, queryReg))
 	url5 := g.fresh()
-	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, { i64, i64 } %s, 5\n", url5, urlLLVM, url4, fragOpt))
+	g.fnBuf.WriteString(fmt.Sprintf("  %s = insertvalue %s %s, %%Option.string %s, 5\n", url5, urlLLVM, url4, fragOpt))
 
 	// Box the struct via toI64Slot — same pattern os.exec uses for
 	// returning Result<Output, Error>: the Url struct is allocated

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 470 `.osty` file(s)  
-**Captured:** 259 residual case(s) — **0** AI-slip(s) airepair rewrote, **259** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 471 `.osty` file(s)  
+**Captured:** 260 residual case(s) — **0** AI-slip(s) airepair rewrote, **260** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
Completes url 5★ field-access surface. Phase A-D ([#1368](https://github.com/choiceoh/osty/pull/1368), [#1369](https://github.com/choiceoh/osty/pull/1369), [#1370](https://github.com/choiceoh/osty/pull/1370)) landed parse → Result<Url, Error> with string fields (scheme/host/path); this PR wires the Option-typed fields.

## Two fixes
- [\`stdlib_url_shim.go\`](internal/llvmgen/stdlib_url_shim.go): synthetic struct field types changed from anonymous \`{ i64, i64 }\` to named \`%Option.i64\` / \`%Option.string\` so LLVM's strict-typing match finds them.
- [\`mir_generator.go\`](internal/llvmgen/mir_generator.go): register \`Option.i64\` / \`Option.string\` layouts when emitting the synthetic Url type def — without this the names are forward-referenced but never defined (\"Cannot allocate unsized type\").
- MIR shim port/fragment Option construction uses named \`%Option.i64\` / \`%Option.string\` in insertvalue instead of the anonymous shape.

## E2E
[\`examples/url_e2e/url_phaseE_test.osty\`](examples/url_e2e/url_phaseE_test.osty) 4 new tests pass (8/8 total across A-E):
- \`u.port\` Some on \`:8080\`, None on no-port URL
- \`u.fragment\` Some on \`#top\`, None on no-fragment URL

## Remaining
\`u.query\` (Map<String, String>) field read patterns — separate cycle (Map iteration on synthetic struct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)