### PR TITLE
fix(check): strip ? prefix from defaulted-param names before body bind

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -196,35 +196,22 @@ builtin 의 method/field table 을 `internal/stdlib/modules/time.osty`
 패턴이 참고가 될 수 있음. 또는 prelude 등록을 제거하고 사용자 코드는
 `use std.time` 명시.
 
-### `default-arg-resolve` — defaulted parameter 가 함수 scope 에 등록 안 됨
+### ~~`default-arg-resolve`~~ — defaulted parameter 가 함수 scope 에 등록 안 됨 — **해소됨 (2026-05-05)**
 
-**상태:** spec §3 (declarations) 에 명시된 default-arg surface
-(`fn fetch(url: String, timeout: Int = 30, retries: Int = 3)`) 의
-parser/resolver 결함. **default 가 붙은 파라미터가 함수 body 의
-scope 에 등록되지 않아 `E0745 cannot find <param>` 발화**.
+**진단**: resolver 가 아니라 **체커**의 결함이었다.
+`toolchain/check.osty::collectFnDecl` 이 default 를 가진 파라미터
+이름을 `?`-prefix 메타데이터로 `paramNames` 에 저장 (arity-tracking
+용; `paramDefaultCount` 가 trailing default 개수 카운트). 그런데
+`elabFnDecl` 의 body-scope 바인딩 루프가 그 prefix 를 strip 하지 않고
+그대로 `checkBindSpan(env, "?timeout", ...)` 으로 등록 — body 가
+`timeout` 을 찾으면 `?timeout` 만 바운드되어 있어서 E0745. 진단의
+`hint: did you mean ?timeout?` 도 같은 누설.
 
-**재현 (현재 HEAD):**
-```osty
-fn fetch(url: String, timeout: Int = 30) -> Int {
-    timeout + 1   // error[E0745]: cannot find `timeout` in this scope
-}
-```
+**픽스**: `?` prefix 를 strip 한 후 body scope 에 바인드. 다른 곳에서
+`?` prefix 를 보는 사이트는 `paramDefaultCount` 한 곳뿐이라 strip 의
+부작용 없음.
 
-CLAUDE.md A.7 / §10.10 default 시그니처 / `internal/stdlib/modules/`
-다수 모듈 (`fmt.osty`, `log.osty` 등) 이 모두 영향받음. stdlib
-loader 는 diagnostic 누적만 하고 fail 하지 않아서 모듈 로딩은
-통과하지만, 사용자가 `osty check` 로 모듈 파일을 직접 검증하면
-대량의 E0745 발화. `.bin/osty check` 사용자 코드도 default-arg
-정의된 함수 본문 작성 시 영향.
-
-**진단:** `internal/resolve` 에서 default expression 처리가 파라미터
-binding 보다 먼저 시도되어 scope 진입이 누락되는 것으로 추정. 또는
-default 가 있는 case 만 다른 declare-pass 경로를 타고 있음.
-
-**구현 규모.** resolver 의 function declaration 처리에서 파라미터
-binding 순서 점검. default expression 은 caller scope 에서 평가
-(default 가 다른 파라미터 참조 불가; 리터럴 only 가 spec 결정).
-파라미터 자체는 항상 함수 body scope 에 등록되어야 함.
+**관련 PR**: TBD (이번 작업).
 
 **운영 정책.** 새 gap 은 기존 처리 절차대로 G 번호를 부여해 `Open Gaps`
 섹션에서 추적. 버그 수정 / 명확화 / 성능 최적화 / 의미 중립 변경은

--- a/internal/selfhost/default_param_body_scope_test.go
+++ b/internal/selfhost/default_param_body_scope_test.go
@@ -1,0 +1,36 @@
+package selfhost
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefaultArgParamBindsToBodyScope pins the SPEC_GAPS
+// `default-arg-resolve` fix: a parameter declared with a default
+// value (`fn fetch(url: String, timeout: Int = 30) -> Int { ... }`)
+// must be visible by its source name inside the function body. The
+// checker prefixes `paramNames` entries with `?` for arity-tracking
+// (see paramDefaultCount), so historically the body-scope binder
+// registered `?timeout` and a body reference to `timeout` fired
+// E0745 with a leaking `did you mean ?timeout?` hint.
+func TestDefaultArgParamBindsToBodyScope(t *testing.T) {
+	src := `fn fetch(url: String, timeout: Int = 30) -> Int {
+    timeout + 1
+}
+
+fn main() {
+    println(fetch("hi"))
+}
+`
+	file := astParse(src)
+	cx := newElabCx(file, nil)
+	elabFile(cx)
+	for _, d := range cx.env.local.diagnostics {
+		if d.code == "E0745" {
+			t.Fatalf("default-arg param should not trigger E0745: %s", d.message)
+		}
+		if strings.Contains(d.message, "?timeout") {
+			t.Fatalf("internal `?` prefix leaked into diagnostic: %s", d.message)
+		}
+	}
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -48943,8 +48943,18 @@ func elaborateFnBody(cx *ElabCx, node *AstNode, owner string) {
 			}
 		}()
 		_ = pty
+		// `?`-prefix on `pname` is internal arity-tracking metadata
+		// (see paramDefaultCount); strip before binding so the body
+		// can reference the param by its source name. Without this,
+		// `fn fetch(x: String, timeout: Int = 30) { timeout + 1 }`
+		// fires E0745 because the body looks up `timeout` but only
+		// `?timeout` is bound.
+		bindName := pname
+		if len(bindName) > 0 && bindName[0] == '?' {
+			bindName = bindName[1:]
+		}
 		// Osty: /tmp/selfhost_merged.osty:24069:9
-		checkBindSpan(cx.env, pname, pty, true, node.start, node.end)
+		checkBindSpan(cx.env, bindName, pty, true, node.start, node.end)
 		// Osty: /tmp/selfhost_merged.osty:24070:9
 		func() {
 			var _cur2326 int = i

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -1349,11 +1349,18 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
         checkBindSpan(cx.env, "self", sig.receiverTy, true, node.start, node.end)
     }
 
-    // Bind parameters.
+    // Bind parameters. `?`-prefix on `pname` is internal arity-
+    // tracking metadata injected by `collectFnDecl` so
+    // `paramDefaultCount` can count trailing defaults — strip it
+    // before binding so the body can reference the param by its
+    // source name. Without this, `fn fetch(x: String, timeout: Int =
+    // 30) { timeout + 1 }` fires E0745 because the body looks up
+    // `timeout` but only `?timeout` is bound.
     let mut i = 0
     for pname in sig.paramNames {
         let pty = if i < checkIntListLenLocal(sig.paramTys) { checkIntListAtLocal(sig.paramTys, i) } else { tErr(cx.env.tys) }
-        checkBindSpan(cx.env, pname, pty, true, node.start, node.end)
+        let bindName = if pname.startsWith("?") { strings.trimPrefix(pname, "?") } else { pname }
+        checkBindSpan(cx.env, bindName, pty, true, node.start, node.end)
         i = i + 1
     }
 


### PR DESCRIPTION
## Summary
Closes SPEC_GAPS `default-arg-resolve`. Bug was in the **checker**, not the resolver:

- `collectFnDecl` prefixes defaulted paramNames with `?` for arity tracking (`paramDefaultCount` counts trailing `?`-prefixed entries).
- `elabFnDecl`'s body-scope binding loop fed `pname` verbatim to `checkBindSpan`, registering `?timeout` instead of `timeout`.
- Body lookup of `timeout` fired E0745, with the leak surfacing in the hint as `did you mean \`?timeout\`?`.

Fix: strip the `?` prefix before binding. Only other prefix consumer is `paramDefaultCount` which sees the raw list.

## Repro / verification
```osty
fn fetch(url: String, timeout: Int = 30) -> Int {
    timeout + 1   // pre-fix: error[E0745]
}
fn main() { println(fetch("hi")) }
```
Pre-fix: `error[E0745]: cannot find timeout in this scope`. Post-fix: prints `31`.

## Touch surface
- `internal/selfhost/generated.go` — production CLI (frozen seed)
- `toolchain/check.osty` — Osty mirror
- `internal/selfhost/default_param_body_scope_test.go` — regression pin
- `SPEC_GAPS.md` — Open → Resolved

## Test plan
- [x] Reproduce on pre-fix HEAD
- [x] Post-fix run prints `31`
- [x] go test ./internal/check ./internal/resolve ./internal/selfhost 통과
- [x] just fmt-check + go vet + just ci 통과
- [ ] CI 그린 확인

🤖 Generated with Claude Code