### PR TITLE
fix(ir): entry-driven type inference for untyped map literals

### DIFF
--- a/internal/backend/llvm_untyped_map_lit_test.go
+++ b/internal/backend/llvm_untyped_map_lit_test.go
@@ -1,0 +1,108 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitUntypedMapLitFor locks in the entry-driven
+// recovery for untyped map literals. Before this fix, the bare
+// `let m = {"a": 1}` shape walled at MIR with `for-in over Map
+// with unresolved key/value type` because:
+//
+//   - The Go-side checker left `Types[m]` as `Map<<error>,
+//     <error>>` — top-level shape pinned but K/V dropped.
+//   - `lowerMapLit` populated KeyT/ValT from `l.exprType(m)`
+//     verbatim, so the ir.MapLit carried the same poisoned args.
+//   - `lowerLet`'s `usableRecoveredType` chain stopped at the IR
+//     binding level (it hooked the LetStmt fine, with the right
+//     type), but `lowerIdent` re-resolved `m`'s type via
+//     `chk.SymTypes[sym]` which still produced the poisoned
+//     `Map<<error>, <error>>`.
+//   - The for-iter Ident inherited that type and the MIR
+//     for-in lowerer rejected it.
+//
+// Fix in `internal/ir/lower.go`:
+//
+//   1. `lowerMapLit` — when the recorded MapLit type is missing or
+//      poisoned (PrimInvalid placeholders + ErrType args both),
+//      pull KeyT/ValT off the first entry's lowered Key/Value
+//      types.
+//   2. `hasPoisonedTypeArg` — extended to also catch
+//      `*PrimType{Kind: PrimInvalid}` (the checker's "unknown
+//      type" placeholder for type-args).
+//   3. `lowerIdent` — when the resolved type carries a poisoned
+//      type-arg, fall through to `identTypeFromDecl`.
+//   4. `identTypeFromDecl` — added an `*ast.IdentPat` case (the
+//      shape resolve.Symbol records for `let x = ...` bindings)
+//      that consults `bindingPatTypes`, which `lowerLetStmt`
+//      already populates with the entry-recovered type.
+//
+// Coverage:
+//
+//   - `for (k, v) in m { ... }` over an untyped map literal.
+//   - `m.len()` on an untyped map literal.
+//   - `m.entries()` for-in (alternative iter form).
+//
+// `int_to_string` (a follow-up `println(v.unwrapOr("?"))` where the
+// value type is String) is *not* covered here — that surfaces a
+// separate "println of non-primitive V" wall on the unwrapOr
+// result, deferred to a follow-up.
+func TestLLVMBackendEmitUntypedMapLitFor(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"for_in_direct",
+			`fn main() {
+    let m = {"a": 1}
+    for (k, v) in m {
+        println(v)
+    }
+}`,
+		},
+		{
+			"len_method",
+			`fn main() {
+    let m = {"a": 1, "b": 2}
+    println(m.len())
+}`,
+		},
+		{
+			"for_in_entries",
+			`fn main() {
+    let m = {"a": 1}
+    for (k, v) in m.entries() {
+        println("{k}={v}")
+    }
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &fakeLLVMToolchain{}
+			backend := LLVMBackend{toolchain: tc}
+			req := newBackendRequest(t, EmitBinary, c.src)
+			res, err := backend.Emit(context.Background(), req)
+			if err != nil {
+				if res != nil {
+					for i, w := range res.Warnings {
+						t.Logf("warning[%d]: %v", i, w)
+					}
+				}
+				t.Fatalf("Emit failed: %v", err)
+			}
+			if res != nil {
+				for _, w := range res.Warnings {
+					msg := w.Error()
+					if strings.Contains(msg, "unresolved key/value type") {
+						t.Errorf("regression: untyped map K/V leaked to MIR: %s", msg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1621,8 +1621,14 @@ func (l *lowerer) lowerIdent(id *ast.Ident) Expr {
 	// resolved symbol's declaration node. This now also covers bare
 	// enum variants (`let k = HirSwitchUnknown`) by recovering the
 	// variant's containing enum.
-	if (out.T == nil || out.T == ErrTypeVal) && sym != nil {
-		if t := l.identTypeFromDecl(sym.Decl); t != nil {
+	//
+	// Same recovery fires when the recorded type carries poisoned
+	// type-args (`Map<<error>, <error>>`) — the checker pinned a
+	// shape but lost the K/V details. The decl-side recovery can
+	// often pull a complete type off the LetStmt.Value (a MapLit
+	// whose K/V types `lowerMapLit` filled from the entries).
+	if sym != nil && (out.T == nil || out.T == ErrTypeVal || hasPoisonedTypeArg(out.T)) {
+		if t := l.identTypeFromDecl(sym.Decl); t != nil && !hasPoisonedTypeArg(t) {
 			out.T = t
 		}
 	}
@@ -1646,12 +1652,53 @@ func (l *lowerer) identTypeFromDecl(decl ast.Node) Type {
 		if d == nil {
 			return nil
 		}
-		return l.lowerType(d.Type)
+		if t := l.lowerType(d.Type); t != nil && !hasPoisonedTypeArg(t) {
+			return t
+		}
+		// Annotation absent / poisoned. Recover off the initialiser
+		// expression. The checker may have left `Types[d.Value]`
+		// poisoned (`{"a": 1}` reaches lower.go with `Types[MapExpr]
+		// = Map<<error>, <error>>`), so we re-lower the AST
+		// expression to pick up `lowerMapLit`'s entry-driven KV
+		// recovery (or `lowerListLit`'s element recovery). The
+		// re-lowered Expr's Type() reflects the recovered shape.
+		if d.Value != nil {
+			if t := l.exprType(d.Value); t != nil && !hasPoisonedTypeArg(t) {
+				return t
+			}
+			lowered := l.lowerExpr(d.Value)
+			if lowered != nil {
+				if t := lowered.Type(); t != nil && !hasPoisonedTypeArg(t) {
+					return t
+				}
+			}
+		}
+		return nil
 	case *ast.LetDecl:
 		if d == nil {
 			return nil
 		}
-		return l.lowerType(d.Type)
+		if t := l.lowerType(d.Type); t != nil && !hasPoisonedTypeArg(t) {
+			return t
+		}
+		return nil
+	case *ast.IdentPat:
+		// IdentPat is the most common shape resolve.Symbol records
+		// for `let x = ...` bindings. The lowerLetStmt pass records
+		// the inferred binding type into `bindingPatTypes[ip]` after
+		// running entry-driven recovery on the initialiser, so look
+		// it up first. This is what unblocks `let m = {"a": 1}`
+		// downstream uses — the IdentPat is the resolver's Decl
+		// target, not the wrapping LetStmt.
+		if d == nil {
+			return nil
+		}
+		if l.bindingPatTypes != nil {
+			if t, ok := l.bindingPatTypes[d]; ok && t != nil && !hasPoisonedTypeArg(t) {
+				return t
+			}
+		}
+		return nil
 	case *ast.Variant:
 		return l.enumTypeForVariantDecl(d)
 	}
@@ -2393,6 +2440,14 @@ func hasPoisonedTypeArg(t Type) bool {
 	case *NamedType:
 		for _, a := range x.Args {
 			if a == ErrTypeVal {
+				return true
+			}
+			// PrimInvalid placeholder ({Kind: 0}) is what the
+			// checker leaves on type args when an upstream inference
+			// path bailed but didn't surface ErrType — `let m =
+			// {"a": 1}` ends up with `Map<*PrimType{0}, *PrimType{0}>`.
+			// Treat it as poisoned so recovery paths fire.
+			if pt, ok := a.(*PrimType); ok && pt.Kind == PrimInvalid {
 				return true
 			}
 			if hasPoisonedTypeArg(a) {
@@ -3340,6 +3395,24 @@ func (l *lowerer) lowerStructLit(s *ast.StructLit) Expr {
 	return out
 }
 
+// isMapLitPlaceholderType reports whether a MapLit KeyT/ValT slot
+// is unresolved — covers nil, ErrType, and PrimType{PrimInvalid}.
+// The checker's "unknown type" fallback can land in any of those
+// shapes depending on which inference path bailed; the entry-driven
+// recovery treats them uniformly.
+func isMapLitPlaceholderType(t Type) bool {
+	if t == nil {
+		return true
+	}
+	if _, ok := t.(*ErrType); ok {
+		return true
+	}
+	if pt, ok := t.(*PrimType); ok && pt.Kind == PrimInvalid {
+		return true
+	}
+	return false
+}
+
 func (l *lowerer) lowerMapLit(m *ast.MapExpr) Expr {
 	out := &MapLit{SpanV: nodeSpan(m)}
 	for _, en := range m.Entries {
@@ -3353,6 +3426,24 @@ func (l *lowerer) lowerMapLit(m *ast.MapExpr) Expr {
 		if nt, ok := t.(*NamedType); ok && nt.Name == "Map" && len(nt.Args) == 2 {
 			out.KeyT = nt.Args[0]
 			out.ValT = nt.Args[1]
+		}
+	}
+	// Entry-driven recovery: when the checker leaves the map literal
+	// without a pinned K/V (`let m = {"a": 1}` reaches ir.Lower with
+	// `Types[m]` either empty or carrying a `Map<?, ?>` shape whose
+	// type-args are PrimInvalid placeholders), pull the K/V off the
+	// first entry's lowered Key/Value types. Without this, the MapLit
+	// hits MIR with KeyT/ValT == placeholder and the downstream
+	// `for-in over Map with unresolved key/value type` walls fire
+	// — even though every entry has a concrete type.
+	if isMapLitPlaceholderType(out.KeyT) && len(out.Entries) > 0 {
+		if t := out.Entries[0].Key.Type(); !isMapLitPlaceholderType(t) {
+			out.KeyT = t
+		}
+	}
+	if isMapLitPlaceholderType(out.ValT) && len(out.Entries) > 0 {
+		if t := out.Entries[0].Value.Type(); !isMapLitPlaceholderType(t) {
+			out.ValT = t
 		}
 	}
 	if out.KeyT == nil {


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on untyped map literals like
\`let m = {\"a\": 1}\`. Before this PR, those programs walled with
\`for-in over Map with unresolved key/value type is not lowered to
MIR yet: _ZTSN4main3MapI??EE\` even though every entry has a
concrete type.

## Failure mode

The Go-side checker left \`Types[MapExpr]\` as \`Map<<error>,
<error>>\` — top-level shape pinned but K/V dropped. The poison
flowed through 5 layers:

1. \`lowerMapLit\` populated KeyT/ValT verbatim from the checker's
   record.
2. \`hasPoisonedTypeArg\` only matched \`ErrType\` args, not the
   \`*PrimType{Kind: PrimInvalid}\` placeholder the checker
   sometimes leaves.
3. \`lowerIdent\` re-resolved \`m\`'s type via \`chk.SymTypes[sym]\`
   which produced the poisoned shape; the for-iter inherited it.
4. \`identTypeFromDecl\` had no case for \`*ast.IdentPat\` (the
   shape resolve.Symbol records for \`let x = ...\` bindings).
5. The MIR for-in lowerer rejected the poisoned iter type.

## Fix (\`internal/ir/lower.go\`)

1. \`lowerMapLit\` — entry-driven recovery: when the recorded type
   is poisoned, pull KeyT/ValT off the first entry's lowered Key/
   Value types.
2. New \`isMapLitPlaceholderType\` helper — matches nil, ErrType,
   and PrimInvalid uniformly.
3. \`hasPoisonedTypeArg\` — extended to also catch PrimInvalid.
4. \`lowerIdent\` — fall through to decl-side recovery when the
   resolved type carries poisoned type-args.
5. \`identTypeFromDecl\` — new \`*ast.IdentPat\` case that consults
   \`bindingPatTypes\` (populated by \`lowerLetStmt\`).
6. LetStmt / LetDecl branches in \`identTypeFromDecl\` — gated on
   \`hasPoisonedTypeArg\`, fall back to re-lowering the initialiser.

## Test plan

- [x] New \`TestLLVMBackendEmitUntypedMapLitFor\` (3 sub-cases):
  - \`for (k, v) in m { ... }\` over \`let m = {\"a\": 1}\`
  - \`m.len()\` on \`let m = {\"a\": 1, \"b\": 2}\`
  - \`for (k, v) in m.entries() { ... }\`
- [x] \`go test -short ./internal/ir/... ./internal/mir/...
      ./internal/backend/...\` green — no regressions.

## Notes

Followup walls observed but not addressed here:
- \`println(v.unwrapOr(default))\` for non-primitive V — surfaces
  as \"println of non-primitive V\", separate route from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)