### PR TITLE
fix(check): register Duration methods + nanoseconds field

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -168,33 +168,17 @@ spec 동급 동작.
 
 `log` 가 5★ 도달한 경로는 (2). 같은 패턴으로 compress / encoding / url / json / iter 도 차례로 5★ 가능.
 
-### `duration-builtin-methods` — `Duration` builtin 의 메서드/필드 미등록
+### ~~`duration-builtin-methods`~~ — `Duration` builtin 의 메서드/필드 미등록 — **해소됨 (2026-05-05)**
 
-**상태:** spec §10.20 line 78 mandates `Duration.toString(self) -> String`
-("1.23s" / "15ms" / "120µs" 적응형) and `Duration.nanoseconds: Int64`
-public field. 현재 `internal/resolve/prelude.go:58` 이 `Duration` 을
-prelude builtin 으로 등록하면서 정의 본체 (`internal/stdlib/modules/time.osty:12-35`)
-의 메서드 / 필드를 **체커가 인지하지 못함**:
+**픽스**: `internal/selfhost/primitive_arith_register.go` 의
+`registerSupplementalStdlibSurface` 에 `registerDurationMembers` 추가
+— `Int.s` 같은 prelude-route 에서 `Duration` 이 등장할 때 그 struct
+의 method/field 도 함께 checker 에 등록되도록 했다. 메서드는 `abs() →
+Duration`, `micros() / millis() / seconds() → Int`, `toString() →
+String` 다섯 개 + `nanoseconds: Int64` 필드 — 모두 `internal/stdlib/modules/time.osty`
+의 struct 정의에서 그대로 흡수.
 
-```osty
-let d: time.Duration = 5.s
-let _ = d.toString()       // E0703: no method `toString` on type `Duration`
-let _ = d.nanoseconds      // E0702: no field `nanoseconds` on type `Duration`
-```
-
-`Instant` 는 prelude 가 아니라 `std.time` 모듈 정의를 그대로 쓰는데
-`Instant.format(layout)` 가 정상 동작하는 것과 대비. **builtin 등록과
-모듈 본체 사이의 정합 갭**.
-
-`internal/stdlib/modules/log.osty` 의 `formatLogValue(LogValue.Duration(d))`
-가 이 갭 때문에 `<duration>` placeholder 를 출력. 해소되면 spec §10.20
-의 adaptive shape 출력 가능.
-
-**구현 규모.** prelude registration 시 (또는 stdlib 로드 후) `Duration`
-builtin 의 method/field table 을 `internal/stdlib/modules/time.osty`
-의 struct 정의에서 흡수. `primitive_arith_register.go` 의 fan-out
-패턴이 참고가 될 수 있음. 또는 prelude 등록을 제거하고 사용자 코드는
-`use std.time` 명시.
+**관련 PR**: TBD (이번 작업).
 
 ### ~~`default-arg-resolve`~~ — defaulted parameter 가 함수 scope 에 등록 안 됨 — **해소됨 (2026-05-05)**
 

--- a/internal/backend/llvm_untyped_map_lit_test.go
+++ b/internal/backend/llvm_untyped_map_lit_test.go
@@ -25,19 +25,19 @@ import (
 //
 // Fix in `internal/ir/lower.go`:
 //
-//   1. `lowerMapLit` — when the recorded MapLit type is missing or
-//      poisoned (PrimInvalid placeholders + ErrType args both),
-//      pull KeyT/ValT off the first entry's lowered Key/Value
-//      types.
-//   2. `hasPoisonedTypeArg` — extended to also catch
-//      `*PrimType{Kind: PrimInvalid}` (the checker's "unknown
-//      type" placeholder for type-args).
-//   3. `lowerIdent` — when the resolved type carries a poisoned
-//      type-arg, fall through to `identTypeFromDecl`.
-//   4. `identTypeFromDecl` — added an `*ast.IdentPat` case (the
-//      shape resolve.Symbol records for `let x = ...` bindings)
-//      that consults `bindingPatTypes`, which `lowerLetStmt`
-//      already populates with the entry-recovered type.
+//  1. `lowerMapLit` — when the recorded MapLit type is missing or
+//     poisoned (PrimInvalid placeholders + ErrType args both),
+//     pull KeyT/ValT off the first entry's lowered Key/Value
+//     types.
+//  2. `hasPoisonedTypeArg` — extended to also catch
+//     `*PrimType{Kind: PrimInvalid}` (the checker's "unknown
+//     type" placeholder for type-args).
+//  3. `lowerIdent` — when the resolved type carries a poisoned
+//     type-arg, fall through to `identTypeFromDecl`.
+//  4. `identTypeFromDecl` — added an `*ast.IdentPat` case (the
+//     shape resolve.Symbol records for `let x = ...` bindings)
+//     that consults `bindingPatTypes`, which `lowerLetStmt`
+//     already populates with the entry-recovered type.
 //
 // Coverage:
 //

--- a/internal/selfhost/duration_members_test.go
+++ b/internal/selfhost/duration_members_test.go
@@ -1,0 +1,43 @@
+package selfhost
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDurationMembersResolveOnPreludeBuiltin pins the SPEC_GAPS
+// `duration-builtin-methods` fix: prelude registers `Duration` as
+// a builtin name (so `Int.s` etc. constructors return a real type
+// without forcing every caller to `use std.time`), but the checker
+// also needs the struct's methods + field from
+// `internal/stdlib/modules/time.osty`. Pre-fix behavior was every
+// `d.toString()` / `d.nanoseconds` access surfaced as E0703 / E0702.
+func TestDurationMembersResolveOnPreludeBuiltin(t *testing.T) {
+	src := `fn main() {
+    let d = 5.s
+    let s: String = d.toString()
+    let n: Int64 = d.nanoseconds
+    let m: Int = d.millis()
+    let mc: Int = d.micros()
+    let sec: Int = d.seconds()
+    let abs_d: Duration = d.abs()
+    println(s)
+    println("{n}")
+    println("{m}")
+    println("{mc}")
+    println("{sec}")
+    println(abs_d.toString())
+}
+`
+	file := astParse(src)
+	cx := newElabCx(file, nil)
+	elabFile(cx)
+	for _, d := range cx.env.local.diagnostics {
+		switch d.code {
+		case "E0702", "E0703":
+			if strings.Contains(d.message, "Duration") {
+				t.Fatalf("Duration member access surfaced as %s: %s", d.code, d.message)
+			}
+		}
+	}
+}

--- a/internal/selfhost/primitive_arith_register.go
+++ b/internal/selfhost/primitive_arith_register.go
@@ -172,6 +172,52 @@ func registerSupplementalStdlibSurface(env *CheckEnv) {
 		genericBounds: make([]*CheckGenericBound, 0, 1),
 	})
 	checkMarkFnHasBody(env, "new", "Error")
+	registerDurationMembers(env)
+}
+
+// registerDurationMembers fills in the methods + field that
+// `internal/stdlib/modules/time.osty:12-35` declares on the `Duration`
+// struct. Without this, prelude registers `Duration` as a builtin name
+// (so `Int.s` / `Int.ms` etc. constructors return a real type), but
+// the checker can't see any of the struct's methods or fields — every
+// `d.toString()` / `d.nanoseconds` access surfaces as E0703 / E0702.
+// Tracked as `duration-builtin-methods` in SPEC_GAPS until this fix.
+func registerDurationMembers(env *CheckEnv) {
+	tys := env.tys
+	tDuration := tyNamed(tys, "Duration", make([]int, 0, 1))
+	tInt_ := tInt(tys)
+	tInt64_ := tInt64(tys)
+	tString_ := tString(tys)
+
+	for _, m := range []struct {
+		name  string
+		retTy int
+	}{
+		{"abs", tDuration},
+		{"micros", tInt_},
+		{"millis", tInt_},
+		{"seconds", tInt_},
+		{"toString", tString_},
+	} {
+		checkRegisterFn(env, &CheckFnSig{
+			name:          m.name,
+			owner:         "Duration",
+			receiverTy:    tDuration,
+			hasReceiver:   true,
+			retTy:         m.retTy,
+			paramNames:    make([]string, 0, 1),
+			paramTys:      make([]int, 0, 1),
+			generics:      make([]string, 0, 1),
+			genericBounds: make([]*CheckGenericBound, 0, 1),
+		})
+	}
+	checkRegisterField(env, &CheckFieldSig{
+		owner:      "Duration",
+		name:       "nanoseconds",
+		ty:         tInt64_,
+		exported:   true,
+		hasDefault: false,
+	})
 }
 
 func registerIntConversionMethods(env *CheckEnv, owner string, ty int, tys *TyArena) {


### PR DESCRIPTION
## Summary
Closes SPEC_GAPS `duration-builtin-methods` open gap.

`prelude.go:58` registers `Duration` as a builtin name (so `Int.s` / `Int.ms` constructors return a real type without forcing `use std.time`), but the struct's methods + field from `internal/stdlib/modules/time.osty:12-35` were never injected into the checker — any access surfaced as E0702/E0703.

## Repro / verification
```osty
fn main() {
    let d = 5.s
    println(d.toString())       // pre-fix: E0703
    println("{d.nanoseconds}")  // pre-fix: E0702
}
```

## Fix
Add `registerDurationMembers` to `registerSupplementalStdlibSurface` registering exactly what the source struct declares:
- `abs() -> Duration`
- `micros() / millis() / seconds() -> Int`
- `toString() -> String`
- `nanoseconds: Int64` (field)

`internal/stdlib/modules/log.osty`'s `formatLogValue(LogValue.Duration(d))` path which emitted `<duration>` placeholder should now produce the §10.20 adaptive shape.

## Touch surface
- `internal/selfhost/primitive_arith_register.go` — registration
- `internal/selfhost/duration_members_test.go` — regression pin
- `SPEC_GAPS.md` — Open → Resolved
- Incidental: gofmt drift in `internal/backend/llvm_untyped_map_lit_test.go` fixed

## Test plan
- [x] Reproduce on pre-fix HEAD (E0703 / E0702)
- [x] Post-fix `osty check` passes (verified at 5 method calls + field access)
- [x] `go test ./internal/check ./internal/resolve ./internal/selfhost ./internal/stdlib` 통과
- [x] `just fmt-check && go vet ./... && just ci` 통과
- [ ] CI 그린 확인

🤖 Generated with Claude Code