### PR TITLE
fix(ir): substitute V on Map<K,V> method calls + add Map.* recovery shapes

### DIFF
--- a/internal/backend/llvm_int_map_method_test.go
+++ b/internal/backend/llvm_int_map_method_test.go
@@ -1,0 +1,106 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitIntMapMethodCalls covers method calls on
+// untyped Int-keyed map literals where the result type is generic
+// in V (Map<K, V>.get → V?, .remove → V?, .keys → List<K>, etc.).
+//
+// Before this fix, programs like:
+//
+//	fn main() {
+//	    let m = {1: "one"}
+//	    let v = m.get(1)
+//	    println(v.unwrapOr("?"))
+//	}
+//
+// walled with `LLVM000 println of non-primitive V` because the
+// checker left `m.get(1)` typed as `V?` (the generic signature's
+// TypeVar). Substitution from the receiver's type
+// (`Map<Int, String>`) wasn't applied at the call site, so `V`
+// leaked into the let binding's local and then into println.
+//
+// Fix in `internal/ir/lower.go`:
+//
+//   1. `recoverMethodReturnTypeFromType` — added Map<K, V> case
+//      covering `.get`, `.remove`, `.keys`, `.values`,
+//      `.containsKey`, `.insert`. Each pulls the substituted
+//      arg straight off the receiver's type.
+//   2. `lowerMethodCall` — fall through to the recovery path also
+//      when the recorded type contains a TypeVar leak (not just
+//      poisoned types). Uses `containsTypeVar` to detect, which
+//      already exists for the monomorph subst pass.
+//
+// Companion to PR #1381 (untyped map K/V inference): together,
+// `let m = {1: "one"}` followed by `m.get(1).unwrapOr("?")` now
+// lowers cleanly without an explicit `Map<Int, String>`
+// annotation.
+func TestLLVMBackendEmitIntMapMethodCalls(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"get_unwrap_or",
+			`fn main() {
+    let m = {1: "one"}
+    let v = m.get(1)
+    println(v.unwrapOr("?"))
+}`,
+		},
+		{
+			"remove_unwrap_or",
+			`fn main() {
+    let mut m = {1: "one"}
+    let r = m.remove(1)
+    println(r.unwrapOr("?"))
+}`,
+		},
+		{
+			"keys_len",
+			`fn main() {
+    let m = {1: "one", 2: "two"}
+    println(m.keys().len())
+}`,
+		},
+		{
+			"contains_key",
+			`fn main() {
+    let m = {1: "one"}
+    println(m.containsKey(1))
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &fakeLLVMToolchain{}
+			backend := LLVMBackend{toolchain: tc}
+			req := newBackendRequest(t, EmitBinary, c.src)
+			res, err := backend.Emit(context.Background(), req)
+			if err != nil {
+				if res != nil {
+					for i, w := range res.Warnings {
+						t.Logf("warning[%d]: %v", i, w)
+					}
+				}
+				t.Fatalf("Emit failed: %v", err)
+			}
+			if res != nil {
+				for _, w := range res.Warnings {
+					msg := w.Error()
+					if strings.Contains(msg, "non-primitive V") {
+						t.Errorf("regression: V TypeVar leaked: %s", msg)
+					}
+					if strings.Contains(msg, "non-primitive K") {
+						t.Errorf("regression: K TypeVar leaked: %s", msg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2458,6 +2458,9 @@ func hasPoisonedTypeArg(t Type) bool {
 		if x.Inner == ErrTypeVal {
 			return true
 		}
+		if pt, ok := x.Inner.(*PrimType); ok && pt.Kind == PrimInvalid {
+			return true
+		}
 		return hasPoisonedTypeArg(x.Inner)
 	case *TupleType:
 		for _, e := range x.Elems {
@@ -2788,7 +2791,20 @@ func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs [
 	}
 	recv := l.lowerExpr(fx.X)
 	t := l.exprType(e)
-	if t == ErrTypeVal || t == nil || hasPoisonedTypeArg(t) {
+	// TypeVar-leaked method-result types ride a separate recovery
+	// arm. They're not "poisoned" in the broader sense — the body of
+	// a generic fn legitimately carries TypeVars before
+	// monomorphization — but at a *user-side* method call site, a
+	// result like `m.get(1)` returning `V?` instead of the
+	// substituted `String?` means the call's substitution slipped
+	// past the checker. Routing those through the same recovery as
+	// poisoned types lets us pull the concrete arg off the
+	// receiver's type without disturbing the legitimate generic-
+	// body case (TypeVars in injected stdlib bodies are not method
+	// call sites — they're FnDecl-level signatures handled by the
+	// monomorpher).
+	leaksTypeVar := containsTypeVar(t)
+	if t == ErrTypeVal || t == nil || hasPoisonedTypeArg(t) || leaksTypeVar {
 		if recovered := recoverMethodCallType(fx.Name, typeArgs); recovered != ErrTypeVal {
 			t = recovered
 		}
@@ -2803,7 +2819,7 @@ func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs [
 		// receiver poisons every enclosing expression and blocks
 		// MIR / propagates `<error>` into Match scrutinee shapes.
 		if recovered := recoverMethodReturnType(fx.Name, recv); recovered != nil {
-			if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) {
+			if t == nil || t == ErrTypeVal || hasPoisonedTypeArg(t) || containsTypeVar(t) {
 				t = recovered
 			}
 		}
@@ -2927,6 +2943,27 @@ func recoverMethodReturnTypeFromType(name string, rt Type) Type {
 			return TUnit
 		case "sorted":
 			return nt
+		}
+	}
+	// Map<K, V> method returns: .get(k) → V?, .keys() → List<K>,
+	// .values() → List<V>, .insert / .remove → V?, .containsKey →
+	// Bool. Without this, untyped map literals (`let m = {1: "a"}`)
+	// landed at MIR with `m.get(1).Type() = V?` (the generic
+	// signature's TypeVar leaked) and downstream `println` walled
+	// on `non-primitive V`.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "Map" && len(nt.Args) == 2 {
+		k, v := nt.Args[0], nt.Args[1]
+		switch name {
+		case "get", "remove":
+			return &OptionalType{Inner: v}
+		case "keys":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{k}}
+		case "values":
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{v}}
+		case "containsKey":
+			return TBool
+		case "insert":
+			return TUnit
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on \`m.get(1).unwrapOr(\"?\")\` for
untyped int-keyed maps. Programs like:

\`\`\`osty
fn main() {
    let m = {1: \"one\"}
    let v = m.get(1)
    println(v.unwrapOr(\"?\"))
}
\`\`\`

walled with \`LLVM000 println of non-primitive V\` because
\`m.get(1)\` was typed as \`V?\` (the generic signature's TypeVar)
even though the receiver was correctly inferred as
\`Map<Int, String>\` (#1381 closed the receiver-side gap). The
substitution wasn't applied at the method call site, so \`V\`
leaked into the let binding's local.

## Fix (\`internal/ir/lower.go\`)

1. \`recoverMethodReturnTypeFromType\` — added Map<K, V> case
   covering \`.get\`, \`.remove\`, \`.keys\`, \`.values\`,
   \`.containsKey\`, \`.insert\`. Each pulls the substituted arg
   off the receiver's type, mirroring the existing List<T> arm.
2. \`lowerMethodCall\` — when the checker-recorded type contains a
   TypeVar (\`containsTypeVar(t)\`), fall through to the recovery
   path. Limited to the method-call site; legitimate generic-body
   TypeVars (FnDecl signatures pre-monomorph) aren't disturbed.

An earlier attempt to widen \`hasPoisonedTypeArg\` to catch
TypeVars proved too broad — it tripped
\`TestPhase2cDiagnoseTurbofishSource\` and
\`TestInjectReachableStdlibBodiesQualifiesSmtpEmailLLVMTypes\`
where TypeVar-bearing types are correct mid-pipeline. The
targeted call-site check sidesteps that.

## Test plan

- [x] New \`TestLLVMBackendEmitIntMapMethodCalls\` — 4 sub-cases:
  \`m.get(1).unwrapOr(\"?\")\`, \`m.remove(1).unwrapOr(\"?\")\`,
  \`m.keys().len()\`, \`m.containsKey(1)\`.
- [x] \`go test -short ./internal/ir/... ./internal/mir/...
      ./internal/backend/...\` green.

## Companion

PR #1381 closed the untyped map K/V inference (receiver-side).
This PR closes the method-result substitution gap. Together,
\`let m = {1: \"one\"}\` + \`m.get(1).unwrapOr(\"?\")\` now
lowers cleanly without an explicit annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)