### PR TITLE
test(stdlib): url Phase F — query Map<String,String> field coverage

### DIFF
--- a/examples/url_e2e/url_phaseF_test.osty
+++ b/examples/url_e2e/url_phaseF_test.osty
@@ -1,0 +1,50 @@
+// url Phase F — u.query Map<String, String> field iteration + lookup.
+// No backend changes needed: synthetic Url struct's `query: ptr` field
+// is the Map opaque pointer, and Map intrinsics (iteration / get)
+// work directly on that pointer.
+
+use std.testing
+use std.url
+
+fn testQueryIterationFindsBothKeys() {
+    match url.parse("https://example.com/x?a=1&b=2") {
+        Ok(u) -> {
+            let mut count = 0
+            for (k, v) in u.query {
+                count = count + 1
+            }
+            testing.assertEq(count, 2)
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testQueryGetSomeForExistingKey() {
+    match url.parse("https://example.com/x?key=value") {
+        Ok(u) -> match u.query.get("key") {
+            Some(_) -> testing.assertTrue(true),
+            None -> testing.assertTrue(false),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testQueryGetNoneForMissingKey() {
+    match url.parse("https://example.com/x?present=1") {
+        Ok(u) -> match u.query.get("absent") {
+            Some(_) -> testing.assertTrue(false),
+            None -> testing.assertTrue(true),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}
+
+fn testNoQueryYieldsEmptyMap() {
+    match url.parse("https://example.com/x") {
+        Ok(u) -> match u.query.get("anything") {
+            Some(_) -> testing.assertTrue(false),
+            None -> testing.assertTrue(true),
+        },
+        Err(_) -> testing.assertTrue(false),
+    }
+}

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 471 `.osty` file(s)  
-**Captured:** 260 residual case(s) — **0** AI-slip(s) airepair rewrote, **260** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 473 `.osty` file(s)  
+**Captured:** 262 residual case(s) — **0** AI-slip(s) airepair rewrote, **262** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
No backend changes needed. The synthetic Url struct's \`query: ptr\` field already holds the Map opaque pointer the C runtime returns, and Map intrinsics (iteration / get) work directly on that pointer. This PR adds E2E coverage to confirm and lock in the surface.

## E2E
[\`examples/url_e2e/url_phaseF_test.osty\`](examples/url_e2e/url_phaseF_test.osty) 4 new tests pass (12/12 total across A-F):
- iteration \`for (k, v) in u.query { ... }\` yields all entries
- \`u.query.get(present)\` returns Some
- \`u.query.get(missing)\` returns None
- empty query (no \`?\`) → all gets return None

url module spec §10.16 surface **complete** — scheme / host / port / path / query / fragment all reachable via field access through the LLVM backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)