### PR TITLE
docs(spec-gaps): mark pure-enforce resolved + pin E0775 contract

### DIFF
--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -68,22 +68,32 @@ SVE fallback 은 §3.8.3 에 문서화 완료. 남은 gap 은 iterator-protocol
 
 향후 gap 을 닫을 때 같은 entry 에 해결 요지 + 관련 PR 을 기록한다.
 
-### `pure-enforce` — `#[pure]` checker enforcement (v0.6 A13)
+### ~~`pure-enforce`~~ — `#[pure]` checker enforcement (v0.6 A13) — **이미 해소됨 (2026-05-05 doc fix)**
 
-**상태:** `#[pure]` 는 v0.6 에 lenient 로 착륙했다 (§3.8.11). 현재
-컴파일러는 annotation 을 **신뢰만 하고 검증하지 않는다** — LLVM 이 `readnone`
-attribute 를 받아서 CSE / hoist / dead-call elim 을 수행하지만, 본문이
-실제로 pure 한지는 체커가 확인하지 않는다. 거짓말하면 undefined behavior.
+**상태:** 갭 문서가 stale. `#[pure]` checker enforcement 는 이미
+구현되어 있고 E0775 코드로 발화한다 — `toolchain/check_gates.osty::runPureGate`
+(seed mirror at `internal/selfhost/generated.go`).
 
-해소 경로: `internal/check` 에 purity analyzer 추가. 금지 목록:
-(a) non-local write (field/global/ref-parameter 의 store), (b) I/O
-(`println`, `fmt.*`, filesystem), (c) impure call (다른 `#[pure]` 나
-known-pure intrinsic 이 아닌 fn 호출), (d) volatile / atomic ops,
-(e) allocation (GC 는 관찰 가능). `#[pure]` 어노테이션 있는 함수 본문
-walk 해서 위 중 하나라도 발견하면 새 에러 코드 (예: E0780) 발화.
+`runPureGate` 가 `#[pure]` 어노테이션 함수 / 메서드 본문을 walk 해서
+다음 카테고리를 모두 거부:
 
-언어 surface 변경 없음 — 어노테이션 의미는 이미 §3.8.11 에 정의됨. 검증
-도입은 기존 `#[pure]` 코드를 깨지 않는다 (정확히 쓰였다면).
+  (a) non-local write — `AstNAssign` 타깃이 fn-local binding 이 아닐 때
+  (b) I/O — `println` / `print` / `eprint` / `eprintln` / `fmt.*` / fs.* 등
+      `pureCalleeLooksLikeIO` 가 잡는 패턴
+  (c) impure call — callee 가 같은 파일의 `#[pure]` fn 이 아닐 때
+  (d) volatile/atomic — Osty 가 해당 primitive 를 노출하지 않으므로 N/A
+  (e) allocation — `AstNList` / `AstNMap` / `AstNStructLit` /
+      `AstNClosure` / 보간 / 문자열 concat (관리되는 GC 할당)
+
+추가로 잡히는 것:
+  - `AstNChanSend` — 채널 send (관찰 가능 부작용)
+  - `AstNDefer` — 함수 반환 후 실행, pure 본문에 부적절
+
+진정 pure 한 본문은 통과. 회귀 테스트는
+`internal/selfhost/pure_enforcement_test.go::TestPureAnnotationEnforcedByE0775`
+가 4개 카테고리를 모두 핀.
+
+**관련 PR**: TBD (이번 작업 — 문서 fix + 회귀 픽스).
 
 ### ~~`a12-branch-hints`~~ — `likely(x)` / `unlikely(x)` 빌트인 (v0.6 A12 후속) — **해소됨 (2026-05-05)**
 

--- a/internal/backend/llvm_int_map_method_test.go
+++ b/internal/backend/llvm_int_map_method_test.go
@@ -26,14 +26,14 @@ import (
 //
 // Fix in `internal/ir/lower.go`:
 //
-//   1. `recoverMethodReturnTypeFromType` — added Map<K, V> case
-//      covering `.get`, `.remove`, `.keys`, `.values`,
-//      `.containsKey`, `.insert`. Each pulls the substituted
-//      arg straight off the receiver's type.
-//   2. `lowerMethodCall` — fall through to the recovery path also
-//      when the recorded type contains a TypeVar leak (not just
-//      poisoned types). Uses `containsTypeVar` to detect, which
-//      already exists for the monomorph subst pass.
+//  1. `recoverMethodReturnTypeFromType` — added Map<K, V> case
+//     covering `.get`, `.remove`, `.keys`, `.values`,
+//     `.containsKey`, `.insert`. Each pulls the substituted
+//     arg straight off the receiver's type.
+//  2. `lowerMethodCall` — fall through to the recovery path also
+//     when the recorded type contains a TypeVar leak (not just
+//     poisoned types). Uses `containsTypeVar` to detect, which
+//     already exists for the monomorph subst pass.
 //
 // Companion to PR #1381 (untyped map K/V inference): together,
 // `let m = {1: "one"}` followed by `m.get(1).unwrapOr("?")` now

--- a/internal/selfhost/pure_enforcement_test.go
+++ b/internal/selfhost/pure_enforcement_test.go
@@ -1,0 +1,86 @@
+package selfhost
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPureAnnotationEnforcedByE0775 pins the SPEC_GAPS
+// `pure-enforce` contract: `#[pure]` is not just an LLVM
+// `readnone` hint — the checker walks the body and emits E0775
+// for any of the categories listed in §3.8.11 / SPEC_GAPS:
+//   (a) non-local write — assigning to a non-local binding
+//   (b) I/O — println / print / etc.
+//   (c) impure call — calling a non-`#[pure]` function
+//   (e) allocation — list / map / struct / closure literals
+//
+// (d) volatile/atomic is N/A: Osty doesn't expose those primitives.
+//
+// A genuinely pure body must compile clean. The
+// implementation lives in `toolchain/check_gates.osty::runPureGate`
+// (mirrored in the seed at the same name).
+func TestPureAnnotationEnforcedByE0775(t *testing.T) {
+	src := `let mut globalState: Int = 0
+
+#[pure]
+fn impureWrite() {
+    globalState = 100
+}
+
+#[pure]
+fn impureIO(x: Int) -> Int {
+    println("io")
+    x + 1
+}
+
+fn helper(x: Int) -> Int { x * 2 }
+
+#[pure]
+fn impureCall(x: Int) -> Int {
+    helper(x)
+}
+
+#[pure]
+fn impureAlloc() -> List<Int> {
+    [1, 2, 3]
+}
+
+#[pure]
+fn pureOk(x: Int) -> Int {
+    x + 1
+}
+
+fn main() {}
+`
+	file := astParse(src)
+	cx := newElabCx(file, nil)
+	elabFile(cx)
+
+	wantViolations := map[string]string{
+		"impureWrite": "write non-local state",
+		"impureIO":    "perform I/O",
+		"impureCall":  "call a function that is not `#[pure]`",
+		"impureAlloc": "allocate a list literal",
+	}
+	got := map[string]string{}
+	for _, d := range cx.env.local.diagnostics {
+		if d.code != "E0775" {
+			continue
+		}
+		for fnName, what := range wantViolations {
+			if strings.Contains(d.message, fnName) && strings.Contains(d.message, what) {
+				got[fnName] = d.message
+			}
+		}
+	}
+	for fnName, what := range wantViolations {
+		if _, ok := got[fnName]; !ok {
+			t.Errorf("expected E0775 on %s mentioning %q, none found", fnName, what)
+		}
+	}
+	for _, d := range cx.env.local.diagnostics {
+		if d.code == "E0775" && strings.Contains(d.message, "pureOk") {
+			t.Errorf("genuinely-pure pureOk should not trigger E0775: %s", d.message)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
SPEC_GAPS `pure-enforce` open gap was stale. The checker already enforces `#[pure]` via E0775 for all categories in the gap doc. Verified all 4: non-local write / I/O / impure call / allocation. Genuinely-pure bodies compile clean.

(d) volatile/atomic from the gap doc is N/A — Osty doesn't expose those primitives.

## Touch surface
- `SPEC_GAPS.md` — Open → Resolved with the implementation pointer
- `internal/selfhost/pure_enforcement_test.go` — regression pin so future seed regenerations can't silently lose enforcement
- Incidental: gofmt drift in `internal/backend/llvm_int_map_method_test.go`

## Test plan
- [x] Pre-existing implementation verified end-to-end with all 4 categories
- [x] New TestPureAnnotationEnforcedByE0775 passes
- [x] just fmt-check + go vet + just ci 통과
- [ ] CI verification

🤖 Generated with Claude Code