### PR TITLE
feat(ir): auto-`.toString()` for non-primitive print intrinsic args

### DIFF
--- a/internal/backend/llvm_println_struct_test.go
+++ b/internal/backend/llvm_println_struct_test.go
@@ -1,0 +1,102 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitPrintlnStructAutoToString covers auto-dispatch
+// of `.toString()` for non-primitive print arguments. Programs like:
+//
+//	struct P {
+//	    x: Int; y: Int
+//	    fn toString(self) -> String { "({self.x}, {self.y})" }
+//	}
+//	fn main() {
+//	    let p = P { x: 1, y: 2 }
+//	    println(p)
+//	}
+//
+// previously walled with `LLVM000 println of non-primitive P`
+// because `emitPrintlnLike` (the LLVM-side single-value print path)
+// only handles primitives natively. The user-visible `println(p)`
+// was effectively unsupported even though the corresponding
+// interpolation form `"{p}"` already routed through the
+// string-concat boxing chain.
+//
+// Fix in `internal/ir/lower.go` — `lowerCall`:
+//
+//   - When a print-family intrinsic (`print`/`println`/`eprint`/
+//     `eprintln`) sees a non-primitive arg whose type isn't
+//     poisoned and isn't a builtin container, wrap the arg in an
+//     explicit `MethodCall{Name: "toString", T: TString}`.
+//   - The wrapped call routes to the user-defined / auto-derived
+//     `toString` impl through the existing method-dispatch path,
+//     and the resulting String hits `emitPrintlnLike`'s String
+//     arm naturally.
+//
+// Test cases:
+//   - User struct with explicit toString → cleanly compiles.
+//   - Stdlib Uuid (returned by `uuid.v4()`) — has its own toString,
+//     same path triggers auto-wrap and resolves to the stdlib impl.
+//
+// Structs without a toString method now produce a sharper
+// `call to unresolved symbol P__toString` diagnostic instead of
+// the opaque `non-primitive P` wall — actionable for the user.
+// Auto-derived ToString implementations are tracked separately;
+// covered by a follow-up.
+func TestLLVMBackendEmitPrintlnStructAutoToString(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"user_struct_with_toString",
+			`struct P {
+    x: Int
+    y: Int
+
+    fn toString(self) -> String {
+        "({self.x}, {self.y})"
+    }
+}
+fn main() {
+    let p = P { x: 1, y: 2 }
+    println(p)
+}`,
+		},
+		{
+			"uuid_stdlib_struct",
+			`use std.uuid
+fn main() {
+    let id = uuid.v4()
+    println(id)
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &fakeLLVMToolchain{}
+			backend := LLVMBackend{toolchain: tc}
+			req := newBackendRequest(t, EmitBinary, c.src)
+			res, err := backend.Emit(context.Background(), req)
+			if err != nil {
+				if res != nil {
+					for i, w := range res.Warnings {
+						t.Logf("warning[%d]: %v", i, w)
+					}
+				}
+				t.Fatalf("Emit failed: %v", err)
+			}
+			if res != nil {
+				for _, w := range res.Warnings {
+					if strings.Contains(w.Error(), "non-primitive") {
+						t.Errorf("regression: non-primitive println not wrapped: %s", w.Error())
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2027,7 +2027,25 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 		if k, isIntrinsic := intrinsicByName(id.Name); isIntrinsic {
 			out := &IntrinsicCall{Kind: k, SpanV: nodeSpan(e)}
 			for _, a := range e.Args {
-				out.Args = append(out.Args, l.lowerArg(a))
+				lowered := l.lowerArg(a)
+				// Auto-`.toString()` for non-primitive print args.
+				// `println(p)` for a struct / enum value walls at
+				// the LLVM emit path with `LLVM000 println of
+				// non-primitive <Type>` because emitPrintlnLike
+				// only knows about primitives. Wrap the arg in an
+				// explicit toString() method call so the user-side
+				// or auto-derived toString impl handles the boxing
+				// — same shape as the existing string-interp
+				// boxing path that already works for `"{p}"`.
+				if printlnLikeKind(k) && shouldAutoToString(lowered.Value) {
+					lowered.Value = &MethodCall{
+						Receiver: lowered.Value,
+						Name:     "toString",
+						T:        TString,
+						SpanV:    lowered.Value.At(),
+					}
+				}
+				out.Args = append(out.Args, lowered)
 			}
 			return out
 		}
@@ -3004,6 +3022,63 @@ func (l *lowerer) lowerVariantCall(e *ast.CallExpr, enum, variant string) Expr {
 		out.Args = append(out.Args, l.lowerArg(a))
 	}
 	return out
+}
+
+// printlnLikeKind reports whether the IntrinsicKind is one of the
+// print-family intrinsics that consume a single value through
+// emitPrintlnLike (which only handles primitives natively).
+func printlnLikeKind(k IntrinsicKind) bool {
+	switch k {
+	case IntrinsicPrint, IntrinsicPrintln, IntrinsicEprint, IntrinsicEprintln:
+		return true
+	}
+	return false
+}
+
+// shouldAutoToString reports whether a print-arg expression's type
+// is non-primitive enough that the LLVM backend's emitPrintlnLike
+// would wall on it without a `.toString()` wrapper. Excludes
+// nil/poisoned types (the existing recovery path handles those)
+// and excludes types that already produce a String at the call
+// boundary (avoids a redundant identity wrap).
+func shouldAutoToString(e Expr) bool {
+	if e == nil {
+		return false
+	}
+	t := e.Type()
+	if t == nil || t == ErrTypeVal {
+		return false
+	}
+	if hasPoisonedTypeArg(t) {
+		return false
+	}
+	if pt, ok := t.(*PrimType); ok {
+		switch pt.Kind {
+		case PrimString:
+			return false
+		case PrimInvalid:
+			return false
+		}
+		// Other primitives (Int, Bool, Float, Char, Byte, ...) are
+		// emitPrintlnLike-native: leave them alone.
+		return false
+	}
+	// Don't double-wrap an already-toString-shaped MethodCall.
+	if mc, ok := e.(*MethodCall); ok && mc.Name == "toString" {
+		return false
+	}
+	// Built-in containers (List<T>, Map<K, V>, Set<T>, Bytes,
+	// Channel<T>, Handle<T>) skip auto-wrap; they have their own
+	// runtime println paths or aren't meant to be printed directly.
+	if nt, ok := t.(*NamedType); ok && nt.Builtin {
+		switch nt.Name {
+		case "List", "Map", "Set", "Bytes", "Channel", "Handle":
+			return false
+		}
+	}
+	// Everything else — user struct / enum, stdlib opaque types —
+	// route through `.toString()`.
+	return true
 }
 
 func intrinsicByName(name string) (IntrinsicKind, bool) {


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on \`println(p)\` for user-defined
structs and stdlib opaque types. Programs like:

\`\`\`osty
struct P {
    x: Int
    y: Int

    fn toString(self) -> String {
        \"({self.x}, {self.y})\"
    }
}
fn main() {
    let p = P { x: 1, y: 2 }
    println(p)
}
\`\`\`

previously walled with \`LLVM000 println of non-primitive P\`
because \`emitPrintlnLike\` only handles primitives natively. The
user-visible \`println(p)\` was unsupported even though
\`\"{p}\"\` interpolation already routed through string-concat
boxing.

## Fix (\`internal/ir/lower.go\`)

When a print-family intrinsic (\`print\`/\`println\`/\`eprint\`/
\`eprintln\`) sees a non-primitive arg whose type isn't poisoned
and isn't a builtin container (\`List<T>\`/\`Map<K,V>\`/etc.),
wrap the arg in an explicit \`MethodCall{Name: \"toString\", T:
TString}\`. The wrapped call routes through method dispatch to
the user-defined / stdlib toString impl, and the resulting String
hits \`emitPrintlnLike\`'s String arm naturally.

Two helpers added:
- \`printlnLikeKind\` — gates the rewrite on the four print
  intrinsic kinds.
- \`shouldAutoToString\` — predicate excluding poisoned types,
  primitives, builtin containers, and already-toString-shaped
  MethodCalls.

## Test plan

- [x] New \`TestLLVMBackendEmitPrintlnStructAutoToString\`:
  - User struct with explicit toString → compiles cleanly.
  - Stdlib Uuid (\`uuid.v4()\`) — auto-wrap resolves to stdlib impl.
- [x] \`go test -short ./internal/ir/... ./internal/mir/...
      ./internal/backend/...\` green.

## Notes

Structs without an explicit toString now produce a sharper
\`call to unresolved symbol P__toString\` diagnostic instead of
the opaque \`non-primitive P\` wall — actionable for the user.
Auto-derived ToString impls are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)