### PR TITLE
feat(mir): lower `for x in set { ... }` via SetToList snapshot

### DIFF
--- a/internal/backend/llvm_for_in_set_test.go
+++ b/internal/backend/llvm_for_in_set_test.go
@@ -1,0 +1,72 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitForInSet locks in `for x in set { ... }`
+// support. Before this fix, the program walled with
+// `for-in over non-List/Map/Channel iterable is not lowered to MIR
+// yet: _ZTSN4main3SetIlEE` because `lowerForIn` (`internal/mir/lower.go`)
+// only special-cased Channel / Map / Range / List iterables.
+//
+// Fix: added `lowerForInSet` — same shape as `lowerForInMap` but
+// uses `IntrinsicSetToList` to materialise the set as a `List<T>`
+// snapshot, then iterates by index. Two helper predicates
+// (`isSetType`, `setElementType`) round out the symmetry with the
+// existing List/Map helpers.
+func TestLLVMBackendEmitForInSet(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"int_set",
+			`fn main() {
+    let mut s: Set<Int> = {}
+    s.insert(1)
+    s.insert(2)
+    for x in s {
+        println(x)
+    }
+}`,
+		},
+		{
+			"string_set",
+			`fn main() {
+    let mut s: Set<String> = {}
+    s.insert("a")
+    s.insert("b")
+    for x in s {
+        println(x)
+    }
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &fakeLLVMToolchain{}
+			backend := LLVMBackend{toolchain: tc}
+			req := newBackendRequest(t, EmitBinary, c.src)
+			res, err := backend.Emit(context.Background(), req)
+			if err != nil {
+				if res != nil {
+					for i, w := range res.Warnings {
+						t.Logf("warning[%d]: %v", i, w)
+					}
+				}
+				t.Fatalf("Emit failed: %v", err)
+			}
+			if res != nil {
+				for _, w := range res.Warnings {
+					if strings.Contains(w.Error(), "non-List/Map/Channel iterable") {
+						t.Errorf("regression: Set for-in not handled: %s", w.Error())
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1610,6 +1610,10 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		bs.lowerForInMap(f, iterT)
 		return
 	}
+	if bs.l.isSetType(iterT) {
+		bs.lowerForInSet(f, iterT)
+		return
+	}
 	// Range pseudo-binding fast path: `for i in r` where r was bound
 	// from a Range<Int> literal at let time. Reads the recorded
 	// start/end locals and emits the same counter-loop shape
@@ -1684,6 +1688,116 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	// load current element: elem = iter[idx]
 	elemLocal := bs.newLocal("_elem", elemT, false, f.SpanV)
 	elemPlace := Place{Local: iter, Projections: []Projection{
+		&IndexProj{
+			Index:    &CopyOp{Place: Place{Local: idx}, T: TInt},
+			ElemType: elemT,
+		},
+	}}
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: elemLocal},
+		Src:   &UseRV{Op: &CopyOp{Place: elemPlace, T: elemT}},
+		SpanV: f.SpanV,
+	})
+	if f.Pattern != nil {
+		bs.bindPattern(f.Pattern, Place{Local: elemLocal}, elemT, f.SpanV)
+	} else if f.Var != "" {
+		bs.bind(f.Var, elemLocal)
+	}
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
+	bs.cur = step
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: idx},
+		Src: &BinaryRV{
+			Op:    BinAdd,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+			T:     TInt,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = exit
+}
+
+// lowerForInSet lowers `for x in s { ... }` over a Set<T>. The
+// runtime exposes `osty_rt_set_to_list` (via the
+// `IntrinsicSetToList` intrinsic) which materialises the set as a
+// `List<T>`; we then run the existing list-iteration shape on that.
+// Sets aren't naturally indexable so the snapshot pattern
+// (toList → iterate by index) is the same approach the language
+// reference recommends.
+func (bs *bodyState) lowerForInSet(f *ir.ForStmt, iterT Type) {
+	elemT := bs.l.setElementType(iterT)
+	if elemT == nil || isPoisonType(elemT) {
+		bs.l.noteIssue("for-in over Set with unresolved element type is not lowered to MIR yet: %s", typeString(iterT))
+		return
+	}
+	iter := bs.newLocal("_iter", iterT, false, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: iter, SpanV: f.SpanV})
+	bs.lowerExprInto(f.Iter, iter, iterT)
+
+	listT := &ir.NamedType{Name: "List", Args: []ir.Type{elemT}, Builtin: true}
+	listLocal := bs.newLocal("_set_items", listT, false, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: listLocal, SpanV: f.SpanV})
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: listLocal},
+		Kind:  IntrinsicSetToList,
+		Args:  []Operand{&CopyOp{Place: Place{Local: iter}, T: iterT}},
+		SpanV: f.SpanV,
+	})
+
+	lenLocal := bs.newLocal("_len", TInt, false, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: lenLocal},
+		Src:   &LenRV{Place: Place{Local: listLocal}, T: TInt},
+		SpanV: f.SpanV,
+	})
+	idx := bs.newLocal("_idx", TInt, true, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: idx},
+		Src:   &UseRV{Op: &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt}},
+		SpanV: f.SpanV,
+	})
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	step := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	cmp := bs.freshTemp(TBool, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: cmp},
+		Src: &BinaryRV{
+			Op:    BinLt,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &CopyOp{Place: Place{Local: lenLocal}, T: TInt},
+			T:     TBool,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&BranchTerm{
+		Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
+		Then:  body,
+		Else:  exit,
+		SpanV: f.SpanV,
+	})
+	bs.cur = body
+	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		label:      f.Label,
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
+	})
+
+	elemLocal := bs.newLocal("_elem", elemT, false, f.SpanV)
+	elemPlace := Place{Local: listLocal, Projections: []Projection{
 		&IndexProj{
 			Index:    &CopyOp{Place: Place{Local: idx}, T: TInt},
 			ElemType: elemT,
@@ -5986,6 +6100,19 @@ func (l *lowerer) isListType(t ir.Type) bool {
 func (l *lowerer) isMapType(t ir.Type) bool {
 	source, _ := l.builtinTypeShape(t)
 	return source == "Map"
+}
+
+func (l *lowerer) isSetType(t ir.Type) bool {
+	source, _ := l.builtinTypeShape(t)
+	return source == "Set"
+}
+
+func (l *lowerer) setElementType(t ir.Type) ir.Type {
+	source, args := l.builtinTypeShape(t)
+	if source == "Set" && len(args) >= 1 {
+		return args[0]
+	}
+	return nil
 }
 
 func (l *lowerer) listElementType(t ir.Type) Type {


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on \`for-in\` over a Set<T>. Before
this PR, programs like:

\`\`\`osty
fn main() {
    let mut s: Set<Int> = {}
    s.insert(1)
    s.insert(2)
    for x in s {
        println(x)
    }
}
\`\`\`

walled with \`for-in over non-List/Map/Channel iterable is not
lowered to MIR yet: _ZTSN4main3SetIlEE\` because \`lowerForIn\`
only special-cased Channel / Map / Range / List iterables.

## Fix

- New \`lowerForInSet\` — same shape as \`lowerForInMap\` but uses
  \`IntrinsicSetToList\` to materialise the set as a \`List<T>\`
  snapshot, then iterates by index. The runtime symbol
  (\`osty_rt_set_to_list\`) was already present.
- New \`isSetType\` / \`setElementType\` helpers — rounds out the
  symmetry with existing List/Map predicates.
- \`lowerForIn\` dispatch picks up Set before falling through to
  the unsupported sentinel.

## Test plan

- [x] New \`TestLLVMBackendEmitForInSet\` covers \`Set<Int>\` and
      \`Set<String>\` for-in iteration end-to-end.
- [x] \`go test -short ./internal/ir/... ./internal/mir/...
      ./internal/backend/...\` green.

## Notes

The list-snapshot approach mirrors the language reference's
recommended pattern for unordered iteration: convert to a list
once, iterate by index. Sets aren't naturally indexable so
direct cursor-style iteration would need a runtime contract
that doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)