### PR TITLE
feat(check): register String.toBytes spec §2.4.1 method

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -37359,6 +37359,10 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "chars", owner: "String", receiverTy: tString_, retTy: tListChar, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17042:5
 	checkRegisterFn(env, &CheckFnSig{name: "bytes", owner: "String", receiverTy: tString_, retTy: tListByte, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// `String.toBytes(self) -> Bytes` — spec §2.4.1 zero-copy reinterpret.
+	// Runtime symbol `osty_rt_strings_ToBytes` already exists; this just
+	// surfaces the method to the checker so call sites resolve.
+	checkRegisterFn(env, &CheckFnSig{name: "toBytes", owner: "String", receiverTy: tString_, retTy: tBytes(env.tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17047:5
 	checkRegisterFn(env, &CheckFnSig{name: "startsWith", owner: "String", receiverTy: tString_, retTy: tBool(tys), paramNames: []string{"prefix"}, paramTys: []int{tString_}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:17052:5

--- a/internal/selfhost/string_to_bytes_test.go
+++ b/internal/selfhost/string_to_bytes_test.go
@@ -1,0 +1,33 @@
+package selfhost
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStringToBytesMethodResolves pins the spec §2.4.1
+// `String.toBytes(self) -> Bytes` method registration. The
+// runtime symbol `osty_rt_strings_ToBytes` has been there since
+// the first stdlib loader landed, but the method was never
+// registered with the checker — every `s.toBytes()` surfaced as
+// E0703 even though the byte string literal `b"..."` (the spec's
+// other path to a Bytes value from text) also doesn't lex. This
+// fix unblocks the simplest workaround: `"hello".toBytes()`
+// returns a 5-byte Bytes value.
+func TestStringToBytesMethodResolves(t *testing.T) {
+	src := `fn main() {
+    let s = "hello"
+    let b = s.toBytes()
+    let n = b.len()
+    let _ = n
+}
+`
+	file := astParse(src)
+	cx := newElabCx(file, nil)
+	elabFile(cx)
+	for _, d := range cx.env.local.diagnostics {
+		if d.code == "E0703" && strings.Contains(d.message, "toBytes") {
+			t.Fatalf("String.toBytes should resolve: %s", d.message)
+		}
+	}
+}

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -3204,6 +3204,14 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         paramNames: [], paramTys: [],
         generics: [], genericBounds: [],
     })
+    // `String.toBytes(self) -> Bytes` — spec §2.4.1 zero-copy reinterpret.
+    // Runtime symbol `osty_rt_strings_ToBytes` already exists; this just
+    // surfaces the method so call sites resolve.
+    checkRegisterFn(env, CheckFnSig {
+        name: "toBytes", owner: "String", receiverTy: tString_, hasReceiver: true, retTy: tBytes(tys),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
     checkRegisterFn(env, CheckFnSig {
         name: "startsWith", owner: "String", receiverTy: tString_, hasReceiver: true, retTy: tBool(tys),
         paramNames: ["prefix"], paramTys: [tString_],


### PR DESCRIPTION
## Summary
`String.toBytes(self) -> Bytes` is in spec §2.4.1 and the runtime symbol `osty_rt_strings_ToBytes` has been there since the first stdlib loader. But the checker never registered the method, so every call to `s.toBytes()` surfaced as E0703.

This is doubly painful because spec §2.4.1's other path to a Bytes-from-text value, the `b"..."` byte string literal, also doesn't lex.

## Repro / verification
```osty
fn main() {
    let s = "hello"
    let b = s.toBytes()  // pre: E0703
    println("{b.len()}") // post: 5
}
```

## Touch surface
- `internal/selfhost/generated.go` — production CLI seed
- `toolchain/check_env.osty` — Osty mirror
- `internal/selfhost/string_to_bytes_test.go` — regression pin

## Test plan
- [x] Pre-fix: E0703 on `s.toBytes()`
- [x] Post-fix: prints `5`
- [x] go test ./internal/check ./internal/resolve ./internal/selfhost ./internal/stdlib 통과
- [x] just fmt-check + go vet + just ci 통과
- [ ] CI 그린 확인

🤖 Generated with Claude Code