### PR TITLE
refactor(stdlib): drop strings PascalCase aliases (Tier 0 #4)

### DIFF
--- a/examples/url_e2e/url_phaseF_test.osty
+++ b/examples/url_e2e/url_phaseF_test.osty
@@ -10,7 +10,7 @@ fn testQueryIterationFindsBothKeys() {
     match url.parse("https://example.com/x?a=1&b=2") {
         Ok(u) -> {
             let mut count = 0
-            for (k, v) in u.query {
+            for (_k, _v) in u.query {
                 count = count + 1
             }
             testing.assertEq(count, 2)

--- a/internal/selfhost/ast_lower.osty
+++ b/internal/selfhost/ast_lower.osty
@@ -710,10 +710,10 @@ fn astLowerStringContent(s: String) -> String {
 
 fn astLowerDecodedLiteral(s: String) -> String {
     let mut raw = s
-    if strings.HasPrefix(raw, "b'") {
+    if strings.hasPrefix(raw, "b'") {
         raw = strings.TrimPrefix(raw, "b")
     }
-    if strings.HasPrefix(raw, "'") && strings.HasSuffix(raw, "'") {
+    if strings.hasPrefix(raw, "'") && strings.hasSuffix(raw, "'") {
         raw = strings.TrimSuffix(strings.TrimPrefix(raw, "'"), "'")
     }
     astLowerDecodeEscapes(raw)
@@ -1102,7 +1102,7 @@ fn astLowerLetDecl(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> 
         name = patNode.text
     } else if patNode.kind == AstNPattern && patNode.extra == astPatternIdentKind() {
         name = patNode.text
-    } else if strings.HasPrefix(patNode.text, "ident:") {
+    } else if strings.hasPrefix(patNode.text, "ident:") {
         name = strings.TrimPrefix(patNode.text, "ident:")
     }
     astbridge.LetDeclNode(
@@ -1746,13 +1746,13 @@ fn astLowerStructuredPattern(arena: AstArena, toks: List<astbridge.Token>, n: As
 }
 
 fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> astbridge.Pattern {
-    if strings.HasPrefix(n.text, "ident:") {
+    if strings.hasPrefix(n.text, "ident:") {
         return astbridge.IdentPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), strings.TrimPrefix(n.text, "ident:"))
     }
     if n.text == "wildcard" {
         return astbridge.WildcardPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n))
     }
-    if strings.HasPrefix(n.text, "literal:") {
+    if strings.hasPrefix(n.text, "literal:") {
         return astbridge.LiteralPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerLiteralPatternExpr(toks, n))
     }
     if n.text == "negLiteral" {
@@ -1765,7 +1765,7 @@ fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode)
     if n.text == "tuple" {
         return astLowerTuplePat(arena, toks, n)
     }
-    if strings.HasPrefix(n.text, "variant:") {
+    if strings.hasPrefix(n.text, "variant:") {
         let mut args = astbridge.EmptyPatternList()
         for child in n.children {
             let p = astLowerPattern(arena, toks, child)
@@ -1775,7 +1775,7 @@ fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode)
         }
         return astbridge.VariantPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerSplitPath(strings.TrimPrefix(n.text, "variant:")), args)
     }
-    if strings.HasPrefix(n.text, "struct:") {
+    if strings.hasPrefix(n.text, "struct:") {
         let mut fields = astbridge.EmptyStructPatFieldList()
         for child in n.children {
             let cn = astArenaNodeAt(arena, child)
@@ -1786,7 +1786,7 @@ fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode)
                 let childNode = astArenaNodeAt(arena, child)
                 if childNode.kind == AstNIdent {
                     fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), childNode.text, astbridge.NilPattern()))
-                } else if strings.HasPrefix(childNode.text, "ident:") {
+                } else if strings.hasPrefix(childNode.text, "ident:") {
                     fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), strings.TrimPrefix(childNode.text, "ident:"), astbridge.NilPattern()))
                 } else if !(astbridge.IsNilPattern(pat)) {
                     fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), "", pat))
@@ -1795,7 +1795,7 @@ fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode)
         }
         return astbridge.StructPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerSplitPath(strings.TrimPrefix(n.text, "struct:")), fields, n.flags == 1)
     }
-    if strings.HasPrefix(n.text, "binding:") {
+    if strings.hasPrefix(n.text, "binding:") {
         return astbridge.BindingPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), strings.TrimPrefix(n.text, "binding:"), astLowerPattern(arena, toks, n.left))
     }
     if n.text == "range" {

--- a/internal/stdlib/modules/strings.osty
+++ b/internal/stdlib/modules/strings.osty
@@ -1004,13 +1004,6 @@ pub fn contains(s: String, substr: String) -> Bool {
     indexOfChars(s.chars(), substr.chars()) >= 0
 }
 
-// Bootstrap aliases for self-hosted MIR→LLVM snapshot sources. These
-// mirror Go's strings package names where the snapshot transpiler
-// deliberately routes directly to Go helpers.
-pub fn Contains(s: String, substr: String) -> Bool {
-    contains(s, substr)
-}
-
 pub fn indexOf(s: String, substr: String) -> Int? {
     let at = indexOfChars(s.chars(), substr.chars())
     if at < 0 {
@@ -1020,10 +1013,6 @@ pub fn indexOf(s: String, substr: String) -> Int? {
     }
 }
 
-pub fn Index(s: String, substr: String) -> Int {
-    indexOfChars(s.chars(), substr.chars())
-}
-
 pub fn lastIndexOf(s: String, substr: String) -> Int? {
     let at = lastIndexOfChars(s.chars(), substr.chars())
     if at < 0 {
@@ -1031,10 +1020,6 @@ pub fn lastIndexOf(s: String, substr: String) -> Int? {
     } else {
         Some(at)
     }
-}
-
-pub fn LastIndex(s: String, substr: String) -> Int {
-    lastIndexOfChars(s.chars(), substr.chars())
 }
 
 pub fn count(s: String, substr: String) -> Int {
@@ -1064,10 +1049,6 @@ pub fn hasPrefix(s: String, prefix: String) -> Bool {
     startsWith(s, prefix)
 }
 
-pub fn HasPrefix(s: String, prefix: String) -> Bool {
-    hasPrefix(s, prefix)
-}
-
 pub fn endsWith(s: String, suffix: String) -> Bool {
     let chars = s.chars()
     let needle = suffix.chars()
@@ -1076,10 +1057,6 @@ pub fn endsWith(s: String, suffix: String) -> Bool {
 
 pub fn hasSuffix(s: String, suffix: String) -> Bool {
     endsWith(s, suffix)
-}
-
-pub fn HasSuffix(s: String, suffix: String) -> Bool {
-    hasSuffix(s, suffix)
 }
 
 pub fn trim(s: String) -> String {

--- a/todo-airepair.md
+++ b/todo-airepair.md
@@ -2,8 +2,8 @@
 
 _Auto-generated. Refresh with `just airepair-capture` (or rerun in CI)._
 
-**Scanned:** 473 `.osty` file(s)  
-**Captured:** 262 residual case(s) — **0** AI-slip(s) airepair rewrote, **262** untouched (toolchain self-host / backend gap, not airepair's job)  
+**Scanned:** 474 `.osty` file(s)  
+**Captured:** 263 residual case(s) — **0** AI-slip(s) airepair rewrote, **263** untouched (toolchain self-host / backend gap, not airepair's job)  
 **Corpus coverage:** 16 promoted case(s)
 
 ## AI-slip backlog (changed=true)


### PR DESCRIPTION
## Summary
Spec §10.1 mandates lowercase strings surface; the bootstrap PascalCase aliases (\`Contains\` / \`Index\` / \`LastIndex\` / \`HasPrefix\` / \`HasSuffix\`) leaked through user-facing imports. **Closes Tier 0** of STDLIB_MATRIX.md.

- [\`internal/stdlib/modules/strings.osty\`](internal/stdlib/modules/strings.osty): delete 5 aliases (~25 LOC).
- [\`internal/selfhost/ast_lower.osty\`](internal/selfhost/ast_lower.osty): 9 \`strings.HasPrefix\` + 1 \`strings.HasSuffix\` → lowercase equivalents (same signature, same return type — straight rename).
- [\`examples/url_e2e/url_phaseF_test.osty\`](examples/url_e2e/url_phaseF_test.osty): simplify pickup — \`for (k, v)\` → \`for (_k, _v)\` since the test only counts entries.

\`Index\` / \`LastIndex\` returned \`Int\` (Go-style sentinel); the Osty replacements \`indexOf\` / \`lastIndexOf\` return \`Int?\`. The aliases had no in-tree callers (only mentions were doc comments in \`toolchain/mir_generator.osty\`), so deletion is safe.

\`examples/ffi/main.osty\` stays — it imports Go's strings package via \`use go "strings"\` and is unrelated to the Osty stdlib surface.

## Test plan
- [x] \`just prepush\` 통과
- [x] \`just front\` 33 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)