### PR TITLE
feat(stdlib-inject): inject List<T> bodied methods (map / filter / fold / reduce)

### DIFF
--- a/internal/backend/llvm_list_higher_order_test.go
+++ b/internal/backend/llvm_list_higher_order_test.go
@@ -1,0 +1,116 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestLLVMBackendEmitListHigherOrder covers `List<T>.map`,
+// `List<T>.filter`, `List<T>.fold`, `List<T>.reduce`. Before this
+// fix, these programs walled with `LLVM000 call to unresolved
+// symbol _ZTSN4main4ListIlEE__map` (etc.) because:
+//
+//  1. `ir.ReachMethods`'s `methodReachVisitor` filtered MethodCalls
+//     to types whose receiver `NamedType.Package` was non-empty,
+//     but builtin generic types (`List<T>`, `Map<K,V>`, …) reach
+//     IR with `Builtin: true` and `Package: ""`. The body-injector
+//     never saw the call site, so the bodied stdlib helper
+//     (`internal/stdlib/modules/collections.osty`) wasn't injected.
+//  2. `RewriteStdlibMethodCallsites` carried the same gate, so
+//     even if injection had run, the user-side call wouldn't have
+//     been rewritten to the mangled symbol.
+//  3. `methodToFreeFn` synthesised a free fn with `selfTy:
+//     NamedType{Name: "List"}` — no type-args — and never moved
+//     the owner struct's generics (`T` from `List<T>`) onto the
+//     free fn's generics list. Even after fixing (1)/(2), the
+//     monomorpher rejected the call site with
+//     `arity mismatch: 2 type args vs 1 generics`.
+//
+// Fix:
+//   - `ir.BuiltinTypeOwningModule(name)` — exported helper mapping
+//     builtin generic names to the canonical module that owns
+//     their bodied helpers. Today only `List` is whitelisted; Map
+//     / Set primitive ops route through the runtime intrinsic
+//     path, and Option / Result are dispatched per-intrinsic in
+//     mir_generator.go.
+//   - `methodReachVisitor` + `RewriteStdlibMethodCallsites` —
+//     fall through `BuiltinTypeOwningModule` when `named.Package`
+//     is empty.
+//   - `methodToFreeFn` — looks up the owner type's generics via
+//     the new `Registry.LookupTypeGenerics`, prepends them to the
+//     free fn's generics list, and pins the self-param's
+//     `NamedType.Args` to the matching `TypeVar` chain so the
+//     body's `for item in self` substitutes correctly at
+//     monomorph time.
+//
+// Note: `List<T>.any` / `List<T>.all` / `List<T>.forEach` still
+// trip a separate "Closure: param[0] nil Type" wall — that's a
+// closure-inference issue downstream and is tracked separately.
+func TestLLVMBackendEmitListHigherOrder(t *testing.T) {
+	t.Setenv("OSTY_STDLIB_BODY_LOWER", "1")
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"map",
+			`fn main() {
+    let xs = [1, 2, 3]
+    let doubled = xs.map(|x| x * 2)
+    println(doubled.len())
+}`,
+		},
+		{
+			"filter",
+			`fn main() {
+    let xs = [1, 2, 3, 4]
+    let evens = xs.filter(|x| x % 2 == 0)
+    println(evens.len())
+}`,
+		},
+		{
+			"fold",
+			`fn main() {
+    let xs = [1, 2, 3, 4]
+    let sum = xs.fold(0, |acc, x| acc + x)
+    println(sum)
+}`,
+		},
+		{
+			"reduce",
+			`fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    let r = xs.reduce(|a, b| a + b)
+    println(r.unwrapOr(0))
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &fakeLLVMToolchain{}
+			backend := LLVMBackend{toolchain: tc}
+			req := newBackendRequest(t, EmitBinary, c.src)
+			res, err := backend.Emit(context.Background(), req)
+			if err != nil {
+				if res != nil {
+					for i, w := range res.Warnings {
+						t.Logf("warning[%d]: %v", i, w)
+					}
+				}
+				t.Fatalf("Emit failed: %v", err)
+			}
+			if res != nil {
+				for _, w := range res.Warnings {
+					msg := w.Error()
+					if strings.Contains(msg, "unresolved symbol _ZTSN") {
+						t.Errorf("regression: stdlib body wasn't injected: %s", msg)
+					}
+					if strings.Contains(msg, "arity mismatch") {
+						t.Errorf("regression: free-fn generics mismatch: %s", msg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -350,7 +350,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 		if lowered == nil {
 			continue
 		}
-		freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+		freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method, reg.LookupTypeGenerics(m.Module, m.Type))
 		qualifyLoweredStdlibFnTypes(freeFn, reg, m.Module)
 		out = append(out, freeFn)
 		// Methods can call same-module free fns too; route them
@@ -454,7 +454,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 			if lowered == nil {
 				continue
 			}
-			freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+			freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method, reg.LookupTypeGenerics(m.Module, m.Type))
 			qualifyLoweredStdlibFnTypes(freeFn, reg, m.Module)
 			out = append(out, freeFn)
 			rewriteStdlibMethodCallsitesInFn(next.fn, []ReachableStdlibMethod{m})
@@ -1006,14 +1006,38 @@ func rewriteQualifiedStdlibCalls(fn *ir.FnDecl, qualifier, name, newName string)
 // generics) are out of scope here — that path needs the type-parameter
 // list propagated from the owning struct, which today's stdlib
 // injection set deliberately excludes.
-func methodToFreeFn(lowered *ir.FnDecl, module, typeName, method string) *ir.FnDecl {
-	selfTy := &ir.NamedType{Package: module, Name: typeName}
+func methodToFreeFn(lowered *ir.FnDecl, module, typeName, method string, ownerGenerics []*ast.GenericParam) *ir.FnDecl {
+	// Propagate the owner type's generics onto the free fn so the
+	// receiver param's NamedType carries the right Args and the body
+	// can substitute them at monomorph time. Without this, `List<T>.
+	// map<R>` becomes a free fn `osty_std_collections__List__map(self:
+	// List, f)` — the body's `for item in self` then has nothing to
+	// bind `T` to, and the call-site arity check rejects the [T, R]
+	// type-arg pair against a [R]-only generics list.
+	var ownerTypeArgs []ir.Type
+	for _, g := range ownerGenerics {
+		if g == nil || g.Name == "" {
+			continue
+		}
+		ownerTypeArgs = append(ownerTypeArgs, &ir.TypeVar{Name: g.Name})
+	}
+	selfTy := &ir.NamedType{Package: module, Name: typeName, Args: ownerTypeArgs, Builtin: ir.BuiltinTypeOwningModule(typeName) != ""}
 	selfParam := &ir.Param{
 		Name:  "self",
 		Type:  selfTy,
 		SpanV: lowered.SpanV,
 	}
 	lowered.Params = append([]*ir.Param{selfParam}, lowered.Params...)
+	if len(ownerTypeArgs) > 0 {
+		ownerTypeParams := make([]*ir.TypeParam, 0, len(ownerGenerics))
+		for _, g := range ownerGenerics {
+			if g == nil || g.Name == "" {
+				continue
+			}
+			ownerTypeParams = append(ownerTypeParams, &ir.TypeParam{Name: g.Name, SpanV: lowered.SpanV})
+		}
+		lowered.Generics = append(ownerTypeParams, lowered.Generics...)
+	}
 	lowered.Name = StdlibMethodSymbol(module, typeName, method)
 	lowered.ReceiverMut = false
 	return lowered

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -217,10 +217,22 @@ func RewriteStdlibMethodCallsites(mod *ir.Module, reached []ReachableStdlibMetho
 			}
 		}
 		named, ok := mc.Receiver.Type().(*ir.NamedType)
-		if !ok || named == nil || named.Package == "" || named.Name == "" {
+		if !ok || named == nil || named.Name == "" {
 			return true
 		}
-		mangled, hit := set[key{module: named.Package, typeName: named.Name, method: mc.Name}]
+		// Builtin generic types (`List<T>`, `Map<K, V>`, `Set<T>`,
+		// `Option<T>`, `Result<T, E>`) reach the IR with `Builtin:
+		// true` but `Package: ""`. Discovery in `ir.ReachMethods`
+		// patches the package to the canonical owning module; do
+		// the same here so the rewrite finds its match.
+		module := named.Package
+		if module == "" && named.Builtin {
+			module = ir.BuiltinTypeOwningModule(named.Name)
+		}
+		if module == "" {
+			return true
+		}
+		mangled, hit := set[key{module: module, typeName: named.Name, method: mc.Name}]
 		if !hit {
 			return true
 		}

--- a/internal/ir/reach.go
+++ b/internal/ir/reach.go
@@ -84,17 +84,54 @@ type methodReachVisitor map[MethodRef]struct{}
 // receiver's named symbol resolves to a stdlib module — so this
 // visitor naturally filters to stdlib-owned types without having to
 // consult a registry.
+//
+// Builtin generic types (`List<T>`, `Map<K, V>`, `Set<T>`,
+// `Option<T>`, `Result<T, E>`) reach the IR with `Builtin: true` but
+// `Package: ""`: the user-visible names are prelude-bound rather
+// than module-qualified, so `fromCheckerType` doesn't get a stdlib
+// module string to attach. We patch the package to the canonical
+// owning module here so the body-injector can find the method body.
 func (r methodReachVisitor) Visit(n Node) Visitor {
 	call, ok := n.(*MethodCall)
 	if !ok || call == nil || call.Receiver == nil || call.Name == "" {
 		return r
 	}
 	named, ok := call.Receiver.Type().(*NamedType)
-	if !ok || named == nil || named.Package == "" || named.Name == "" {
+	if !ok || named == nil || named.Name == "" {
 		return r
 	}
-	r[MethodRef{Module: named.Package, Type: named.Name, Method: call.Name}] = struct{}{}
+	module := named.Package
+	if module == "" && named.Builtin {
+		module = BuiltinTypeOwningModule(named.Name)
+	}
+	if module == "" {
+		return r
+	}
+	r[MethodRef{Module: module, Type: named.Name, Method: call.Name}] = struct{}{}
 	return r
+}
+
+// BuiltinTypeOwningModule returns the stdlib module that owns the
+// bodied method declarations for a builtin generic type. Names not
+// in this table fall through and contribute no method references —
+// the body-injector treats them like user-defined types.
+//
+// Today only `List<T>` is whitelisted: its higher-order methods
+// (`map`, `filter`, `fold`, `reduce`, etc.) are bodied helpers that
+// the LLVM backend can lower end-to-end through the standard
+// injection path. `Map<K,V>` / `Set<T>` are intentionally left out
+// because their primitive operations (`get`, `insert`, `remove`,
+// `len`) route through dedicated runtime intrinsics
+// (`osty_rt_map_*`, `osty_rt_set_*`); pulling their bodied helpers
+// (`containsKey` calls `get(...).isSome()`, etc.) into injection
+// double-lowers the same call site and trips the monomorph
+// substitution. `Option`/`Result` already have working
+// per-intrinsic dispatch in `mir_generator.go`.
+func BuiltinTypeOwningModule(name string) string {
+	if name == "List" {
+		return "collections"
+	}
+	return ""
 }
 
 // Visit records qualifier.name pairs from two equivalent IR shapes:

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -525,6 +525,38 @@ func (r *Registry) LookupLetDecl(module, name string) *ast.LetDecl {
 // Returns the shared immutable registry copy; callers must not mutate
 // it. Mirrors LookupFnDecl in style and lookup contract so a future
 // stdlib body injector can drive both surfaces uniformly.
+// LookupTypeGenerics returns the generic-parameter list declared on a
+// stdlib struct / enum / interface. Returns nil for unknown types and
+// for types without generics. Used by the method-to-free-fn lowering
+// in `internal/backend/stdlib_inject.go` to propagate the owner's
+// type-vars onto the synthesised free fn.
+func (r *Registry) LookupTypeGenerics(module, typeName string) []*ast.GenericParam {
+	if r == nil || module == "" || typeName == "" {
+		return nil
+	}
+	mod, ok := r.Modules[module]
+	if !ok || mod == nil || mod.File == nil {
+		return nil
+	}
+	for _, decl := range mod.File.Decls {
+		switch d := decl.(type) {
+		case *ast.StructDecl:
+			if d.Name == typeName {
+				return d.Generics
+			}
+		case *ast.EnumDecl:
+			if d.Name == typeName {
+				return d.Generics
+			}
+		case *ast.InterfaceDecl:
+			if d.Name == typeName {
+				return d.Generics
+			}
+		}
+	}
+	return nil
+}
+
 func (r *Registry) LookupMethodDecl(module, typeName, methodName string) *ast.FnDecl {
 	if r == nil || module == "" || typeName == "" || methodName == "" {
 		return nil


### PR DESCRIPTION
## Summary

Closes the LLVM backend wall on \`List<T>\` higher-order methods.
Programs like:

\`\`\`osty
fn main() {
    let xs = [1, 2, 3]
    let doubled = xs.map(|x| x * 2)
    println(doubled.len())
}
\`\`\`

walled with \`LLVM000 call to unresolved symbol
_ZTSN4main4ListIlEE__map\`. The bodied helper exists in
\`internal/stdlib/modules/collections.osty\` but wasn't being
injected — a multi-layer gap.

## Failure mode

1. \`ir.ReachMethods\`'s \`methodReachVisitor\` filtered MethodCalls
   to receivers with non-empty \`NamedType.Package\`. Builtin
   generic types (\`List<T>\`, \`Map<K,V>\`, …) reach IR with
   \`Builtin: true\` / \`Package: \"\"\`. The body-injector never
   saw the call sites.
2. \`RewriteStdlibMethodCallsites\` carried the same gate.
3. \`methodToFreeFn\` synthesised a free fn with \`selfTy:
   NamedType{Name: \"List\"}\` and didn't propagate the owner
   struct's generics. Even with (1)/(2) fixed, monomorph
   rejected calls with \`arity mismatch: 2 type args vs 1 generics\`.

## Fix

- \`ir.BuiltinTypeOwningModule(name)\` — exported helper mapping
  builtin generic names to the canonical module. Today only
  \`List\` is whitelisted; Map / Set primitive ops route through
  the runtime intrinsic path, and Option / Result are dispatched
  per-intrinsic in \`mir_generator.go\`.
- \`methodReachVisitor\` + \`RewriteStdlibMethodCallsites\` —
  fall through \`BuiltinTypeOwningModule\` when \`named.Package\`
  is empty.
- \`Registry.LookupTypeGenerics(module, typeName)\` — new helper
  returning a stdlib type's \`Generics\` declaration.
- \`methodToFreeFn(..., ownerGenerics)\` — prepends owner generics
  to the free fn's generics list and pins the self-param's
  \`NamedType.Args\` to a matching TypeVar chain. The body's
  \`for item in self\` then substitutes correctly at monomorph.

## Test plan

- [x] New \`TestLLVMBackendEmitListHigherOrder\` — \`map\`,
      \`filter\`, \`fold\`, \`reduce\` end-to-end under
      \`OSTY_STDLIB_BODY_LOWER=1\`.
- [x] \`go test -short ./internal/ir/... ./internal/mir/...
      ./internal/backend/...\` green — no regressions in existing
      Map / Option / Result paths.

## Out of scope

- \`List<T>.any\` / \`.all\` / \`.forEach\` trip a separate
  \"Closure: param[0] nil Type\" wall — closure inference,
  tracked separately.
- Map / Set bodied helpers — left on the runtime intrinsic path
  to avoid double-lowering against the \`osty_rt_map_*\` /
  \`osty_rt_set_*\` primitive entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)