### PR TITLE
fix(mir): correct inverted Option/Result variant indices in variantIndexByName

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -7089,15 +7089,19 @@ func builtinEnumHasVariant(t ir.Type, name string) bool {
 
 func (l *lowerer) variantIndexByName(t ir.Type, name string) int {
 	// Well-known builtins first.
+	// NOTE: these indices must match the variant declaration order in
+	// the stdlib source (stdlib/modules/{option,result}.osty):
+	//   Option<T> { Some(T), None }  → Some=0, None=1
+	//   Result<T,E> { Ok(T), Err(E) } → Ok=0, Err=1
 	switch name {
 	case "None":
-		return 0
+		return 1
 	case "Some":
-		return 1
-	case "Err":
 		return 0
-	case "Ok":
+	case "Err":
 		return 1
+	case "Ok":
+		return 0
 	}
 	typeName := typeNameOf(t)
 	if typeName == "" {


### PR DESCRIPTION
The hardcoded variant discriminant values in variantIndexByName were
inverted relative to the actual enum declaration order in the stdlib
source (option.osty, result.osty). Both Option and Result are generic
enums and get skipped during MIR enum registration, so the fallback
enum lookup is never reached — the inverted hardcoded values were used
directly.

Bug: match on Result/Option through the MIR decision tree path emitted
wrong SwitchVariant discriminant values, causing arm swaps
(e.g. Ok arm running Err's body).
