### PR TITLE
feat(check): process #[intrinsic_methods] annotations in self-hosted checker

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -48648,6 +48648,7 @@ func collectStructDecl(cx *ElabCx, declIdx int, node *AstNode) {
 			}
 		}
 	}
+	collectIntrinsicMethodsFromAst(cx, node)
 }
 
 // Osty: /tmp/selfhost_merged.osty:23890:1

--- a/internal/selfhost/primitive_arith_register.go
+++ b/internal/selfhost/primitive_arith_register.go
@@ -501,3 +501,93 @@ func registerResultReturnNullary(env *CheckEnv, owner string, ty int, name strin
 		genericBounds: make([]*CheckGenericBound, 0, 1),
 	})
 }
+
+// collectIntrinsicMethodsFromAst fans out methods from a
+// `#[intrinsic_methods(Int, Int8, …)]`-annotated struct to the named
+// primitive types so the self-hosted checker resolves `42.abs()` etc.
+// without relying on the Go-side Primitives map.
+//
+// Mirrored in toolchain/check.osty so the future LLVM-compiled native
+// checker processes the same surface.
+func collectIntrinsicMethodsFromAst(cx *ElabCx, node *AstNode) {
+	if cx == nil || node == nil {
+		return
+	}
+	anns := srCollectAnnotationNodes(cx.ast, node.extra)
+	for _, ann := range anns {
+		if ann.text != "intrinsic_methods" {
+			continue
+		}
+		for _, argIdx := range ann.children {
+			arg := astArenaNodeAt(cx.ast.arena, argIdx)
+			targetName := arg.text
+			if targetName == "" {
+				continue
+			}
+			targetTy := tyNamed(cx.env.tys, targetName, make([]int, 0, 1))
+			if targetTy < 0 || tyIsBad(cx.env.tys, targetTy) {
+				continue
+			}
+			for _, memberIdx := range node.children {
+				member := astArenaNodeAt(cx.ast.arena, memberIdx)
+				if _, ok := member.kind.(*AstNodeKind_AstNFnDecl); !ok {
+					continue
+				}
+				registerIntrinsicMethodOn(cx, member, targetName, targetTy)
+			}
+		}
+	}
+}
+
+// registerIntrinsicMethodOn builds a CheckFnSig for one method and
+// registers it on targetName. Self references stay intact — they are
+// resolved by checkSpecializeMethodSelf at the call site.
+func registerIntrinsicMethodOn(cx *ElabCx, method *AstNode, targetName string, targetTy int) {
+	fnName := method.text
+	generics := collectGenericNames(cx, method.children2)
+	bounds := collectGenericBounds(cx, method.children2)
+
+	paramNames := make([]string, 0, len(method.children))
+	paramTys := make([]int, 0, len(method.children))
+	hasReceiver := false
+	for _, paramIdx := range method.children {
+		paramNode := astArenaNodeAt(cx.ast.arena, paramIdx)
+		if _, ok := paramNode.kind.(*AstNodeKind_AstNParam); !ok {
+			continue
+		}
+		if paramNode.text == "self" {
+			hasReceiver = true
+		} else {
+			hasDefault := paramNode.left >= 0
+			rawName := paramNode.text
+			storedName := rawName
+			if hasDefault {
+				storedName = "?" + rawName
+			}
+			paramNames = append(paramNames, storedName)
+			declared := astTypeToTyInCollect(cx, paramNode.right)
+			if declared >= 0 {
+				paramTys = append(paramTys, declared)
+			} else {
+				paramTys = append(paramTys, tErr(cx.env.tys))
+			}
+		}
+	}
+
+	retTy := astTypeToTyInCollect(cx, method.left)
+	if retTy < 0 {
+		retTy = tUnit(cx.env.tys)
+	}
+
+	checkRegisterFn(cx.env, &CheckFnSig{
+		name:          fnName,
+		owner:         targetName,
+		receiverTy:    targetTy,
+		hasReceiver:   hasReceiver,
+		retTy:         retTy,
+		paramNames:    paramNames,
+		paramTys:      paramTys,
+		generics:      generics,
+		genericBounds: bounds,
+	})
+}

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -1172,6 +1172,84 @@ fn collectStructDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
             _ -> {},
         }
     }
+
+    collectIntrinsicMethods(cx, node)
+}
+
+/// collectIntrinsicMethods fans out each fn-decl member of a
+/// #[intrinsic_methods(Int, Int8, …)]-annotated struct to the named
+/// primitive types so checker method lookup resolves `42.abs()` etc.
+/// without relying on the Go-side Primitives map.
+fn collectIntrinsicMethods(cx: ElabCx, node: AstNode) {
+    let anns = srCollectAnnotationNodes(cx.ast, node.extra)
+    for ann in anns {
+        if ann.text != "intrinsic_methods" {
+            continue
+        }
+        for argIdx in ann.children {
+            let arg = astArenaNodeAt(cx.ast.arena, argIdx)
+            let targetName = arg.text
+            if targetName == "" {
+                continue
+            }
+            let targetTy = tyNamed(cx.env.tys, targetName, [])
+            if targetTy < 0 || tyIsBad(cx.env.tys, targetTy) {
+                continue
+            }
+            for memberIdx in node.children {
+                let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+                if member.kind != AstNFnDecl {
+                    continue
+                }
+                registerIntrinsicMethodOn(cx, member, targetName, targetTy)
+            }
+        }
+    }
+}
+
+/// registerIntrinsicMethodOn builds a CheckFnSig for one method and
+/// registers it on `targetName`. The signature keeps its original Self
+/// references — checkSpecializeMethodSelf resolves them against the
+/// concrete receiver at the call site.
+fn registerIntrinsicMethodOn(cx: ElabCx, method: AstNode, targetName: String, targetTy: Int) {
+    let fnName = method.text
+    let generics = collectGenericNames(cx, method.children2)
+    let bounds = collectGenericBounds(cx, method.children2)
+
+    let mut paramNames: List<String> = []
+    let mut paramTys: List<Int> = []
+    let mut hasReceiver = false
+    for paramIdx in method.children {
+        let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
+        if paramNode.kind != AstNParam {
+            continue
+        }
+        if paramNode.text == "self" {
+            hasReceiver = true
+        } else {
+            let hasDefault = paramNode.left >= 0
+            let rawName = paramNode.text
+            let storedName = if hasDefault { "?" + rawName } else { rawName }
+            paramNames.push(storedName)
+            let declared = astTypeToTyInCollect(cx, paramNode.right)
+            paramTys.push(if declared >= 0 { declared } else { tErr(cx.env.tys) })
+        }
+    }
+
+    let retTy = astTypeToTyInCollect(cx, method.left)
+    let retEffective = if retTy >= 0 { retTy } else { tUnit(cx.env.tys) }
+
+    checkRegisterFn(cx.env, CheckFnSig {
+        name: fnName,
+        owner: targetName,
+        receiverTy: targetTy,
+        hasReceiver,
+        retTy: retEffective,
+        paramNames,
+        paramTys,
+        generics,
+        genericBounds: bounds,
+    })
 }
 
 fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {


### PR DESCRIPTION
## Summary
- `collectStructDecl` now fans out methods from `#[intrinsic_methods(T, ...)]`-annotated structs to the named primitive types
- Works on both Go-side (generated.go) and Osty-side (check.osty) checker paths
- Method signatures keep `Self` references resolved at the call site via `checkSpecializeMethodSelf`

## Test plan
- [x] `fmt-check` / `vet` pass
- [x] `go test ./internal/check/... ./internal/selfhost/... ./cmd/osty/...` pass
- [x] Snapshot parity pass
- [x] Manual e2e: `#[intrinsic_methods(Int)] → n.double()` resolves, no annot → E0703

🤖 Generated with [Claude Code](https://claude.com/claude-code)