### PR TITLE
feat: BytesLit, field-as-callable fallback, Optional variant propagation fix

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -889,6 +889,17 @@ func (*ByteLit) exprNode()        {}
 func (l *ByteLit) Pos() token.Pos { return l.PosV }
 func (l *ByteLit) End() token.Pos { return l.EndV }
 
+type BytesLit struct {
+	ID    NodeID
+	PosV  token.Pos
+	EndV  token.Pos
+	Value string
+}
+
+func (*BytesLit) exprNode()        {}
+func (l *BytesLit) Pos() token.Pos { return l.PosV }
+func (l *BytesLit) End() token.Pos { return l.EndV }
+
 // StringLit is a string literal, possibly interpolated.
 //
 //	"hello"        -> Parts: [Lit "hello"]

--- a/internal/ir/capture.go
+++ b/internal/ir/capture.go
@@ -223,7 +223,7 @@ func (a *captureAnalyzer) expr(e Expr) {
 	switch e := e.(type) {
 	case nil:
 		return
-	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *UnitLit, *ErrorExpr:
+	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *BytesLit, *UnitLit, *ErrorExpr:
 		return
 	case *StringLit:
 		for _, p := range e.Parts {

--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -598,6 +598,8 @@ func cloneExpr(e Expr) Expr {
 		return &CharLit{Value: e.Value, SpanV: e.SpanV}
 	case *ByteLit:
 		return &ByteLit{Value: e.Value, SpanV: e.SpanV}
+	case *BytesLit:
+		return &BytesLit{Value: e.Value, SpanV: e.SpanV}
 	case *StringLit:
 		return cloneStringLit(e)
 	case *UnitLit:

--- a/internal/ir/decision.go
+++ b/internal/ir/decision.go
@@ -400,7 +400,7 @@ func switchKindOfLit(e Expr) SwitchKind {
 	switch e.(type) {
 	case *BoolLit:
 		return SwitchBool
-	case *IntLit, *CharLit, *ByteLit, *FloatLit:
+	case *IntLit, *CharLit, *ByteLit, *BytesLit, *FloatLit:
 		return SwitchLit
 	case *StringLit:
 		return SwitchLit
@@ -423,6 +423,8 @@ func litLabel(e Expr) string {
 		return fmt.Sprintf("'%c'", v.Value)
 	case *ByteLit:
 		return fmt.Sprintf("b%d", v.Value)
+	case *BytesLit:
+		return fmt.Sprintf("b\"%s\"", v.Value)
 	case *StringLit:
 		var b strings.Builder
 		b.WriteByte('"')

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -858,6 +858,15 @@ func (*ByteLit) exprNode()    {}
 func (l *ByteLit) At() Span   { return l.SpanV }
 func (l *ByteLit) Type() Type { return TByte }
 
+type BytesLit struct {
+	Value string
+	SpanV Span
+}
+
+func (*BytesLit) exprNode()    {}
+func (l *BytesLit) At() Span   { return l.SpanV }
+func (l *BytesLit) Type() Type { return TBytes }
+
 // StringLit is a possibly interpolated string literal. Parts alternate
 // literal text and inner expressions; backends format the whole thing
 // via their own formatter.

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1103,6 +1103,8 @@ func (l *lowerer) bindingTypeFromAST(e ast.Expr) Type {
 		return TChar
 	case *ast.ByteLit:
 		return TByte
+	case *ast.BytesLit:
+		return TBytes
 	case *ast.StringLit:
 		return TString
 	case *ast.Ident:
@@ -1468,6 +1470,8 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 		return &CharLit{Value: e.Value, SpanV: nodeSpan(e)}
 	case *ast.ByteLit:
 		return &ByteLit{Value: e.Value, SpanV: nodeSpan(e)}
+	case *ast.BytesLit:
+		return &BytesLit{Value: e.Value, SpanV: nodeSpan(e)}
 	case *ast.StringLit:
 		return l.lowerStringLit(e)
 	case *ast.Ident:

--- a/internal/ir/pattern.go
+++ b/internal/ir/pattern.go
@@ -245,6 +245,8 @@ func exprLiteralText(e Expr) string {
 		return "'" + string(e.Value) + "'"
 	case *ByteLit:
 		return "b'?'"
+	case *BytesLit:
+		return "b\"...\""
 	case *StringLit:
 		var sb strings.Builder
 		sb.WriteByte('"')

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -348,6 +348,8 @@ func (p *printer) printExpr(e Expr) {
 		p.writef("'%c'", e.Value)
 	case *ByteLit:
 		p.writef("b%d", e.Value)
+	case *BytesLit:
+		p.writef("b\"%s\"", e.Value)
 	case *StringLit:
 		p.b.WriteByte('"')
 		for _, part := range e.Parts {

--- a/internal/ir/subst.go
+++ b/internal/ir/subst.go
@@ -207,7 +207,7 @@ func subst(n Node, env SubstEnv) {
 		n.T = substType(n.T, env)
 	case *FloatLit:
 		n.T = substType(n.T, env)
-	case *BoolLit, *CharLit, *ByteLit, *UnitLit:
+	case *BoolLit, *CharLit, *ByteLit, *BytesLit, *UnitLit:
 		// Primitive-only; no TypeVar possible.
 	case *StringLit:
 		for _, p := range n.Parts {

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -192,7 +192,7 @@ func walkChildren(v Visitor, n Node) {
 		// leaf
 
 	// ---- Exprs ----
-	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *UnitLit:
+	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *BytesLit, *UnitLit:
 		// leaves
 	case *StringLit:
 		for _, p := range n.Parts {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -177,6 +177,18 @@ func (g *generator) emitStringLiteral(lit *ast.StringLit) (value, error) {
 	return v, nil
 }
 
+func (g *generator) emitBytesLiteral(lit *ast.BytesLit) (value, error) {
+	if lit == nil {
+		return value{}, unsupported("expression", "nil Bytes literal")
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmStringLiteral(emitter, lit.Value)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
 func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
 	if len(lit.Parts) == 0 {
 		emitter := g.toOstyEmitter()
@@ -315,6 +327,8 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 		return value{typ: "i32", ref: strconv.FormatInt(int64(e.Value), 10)}, nil
 	case *ast.ByteLit:
 		return value{typ: "i8", ref: strconv.FormatInt(int64(e.Value), 10)}, nil
+	case *ast.BytesLit:
+		return g.emitBytesLiteral(e)
 	case *ast.StringLit:
 		return g.emitStringLiteral(e)
 	case *ast.Ident:

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1239,7 +1239,7 @@ func (g *generator) emitReturn(stmt *ast.ReturnStmt) error {
 
 func (g *generator) emitExprStmt(expr ast.Expr) error {
 	switch expr.(type) {
-	case *ast.BoolLit, *ast.IntLit, *ast.FloatLit, *ast.StringLit, *ast.CharLit, *ast.ByteLit:
+	case *ast.BoolLit, *ast.IntLit, *ast.FloatLit, *ast.StringLit, *ast.CharLit, *ast.ByteLit, *ast.BytesLit:
 		// Pure literal statements are semantic no-ops in statement position.
 		return nil
 	}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -422,6 +422,8 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		return &ast.NamedType{Path: []string{"Char"}}, true
 	case *ast.ByteLit:
 		return &ast.NamedType{Path: []string{"Byte"}}, true
+	case *ast.BytesLit:
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
 	case *ast.StringLit:
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case *ast.Ident:
@@ -895,6 +897,8 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		return value{typ: "i32"}, true
 	case *ast.ByteLit:
 		return value{typ: "i8"}, true
+	case *ast.BytesLit:
+		return value{typ: "ptr", gcManaged: true}, true
 	case *ast.StringLit:
 		return value{typ: "ptr"}, true
 	case *ast.Ident:

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2620,6 +2620,8 @@ func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
 		return &ConstOp{Const: &CharConst{Value: x.Value}, T: TChar}
 	case *ir.ByteLit:
 		return &ConstOp{Const: &ByteConst{Value: x.Value}, T: TByte}
+	case *ir.BytesLit:
+		return bs.lowerBytesLitAsOperand(x)
 	case *ir.UnitLit:
 		return &ConstOp{Const: &UnitConst{}, T: TUnit}
 	case *ir.StringLit:
@@ -3938,6 +3940,10 @@ func (bs *bodyState) lowerStringLit(s *ir.StringLit) Operand {
 		SpanV: s.SpanV,
 	})
 	return &CopyOp{Place: Place{Local: tmp}, T: TString}
+}
+
+func (bs *bodyState) lowerBytesLitAsOperand(x *ir.BytesLit) Operand {
+	return &ConstOp{Const: &BytesConst{Value: x.Value}, T: TBytes}
 }
 
 func (bs *bodyState) lowerStringInterpolationOperand(e ir.Expr) Operand {

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -1148,6 +1148,13 @@ type ByteConst struct {
 func (*ByteConst) constNode() {}
 func (*ByteConst) Type() Type { return TByte }
 
+type BytesConst struct {
+	Value string
+}
+
+func (*BytesConst) constNode() {}
+func (*BytesConst) Type() Type { return TBytes }
+
 // UnitConst is the `()` zero-value.
 type UnitConst struct{}
 

--- a/internal/mir/optimize.go
+++ b/internal/mir/optimize.go
@@ -288,6 +288,9 @@ func constValueEqual(a, b Const) bool {
 	case *ByteConst:
 		y, ok := b.(*ByteConst)
 		return ok && x.Value == y.Value
+	case *BytesConst:
+		y, ok := b.(*BytesConst)
+		return ok && x.Value == y.Value
 	case *UnitConst:
 		_, ok := b.(*UnitConst)
 		return ok

--- a/internal/mir/print.go
+++ b/internal/mir/print.go
@@ -405,6 +405,8 @@ func constString(c Const) string {
 		return fmt.Sprintf("const '%c'", x.Value)
 	case *ByteConst:
 		return fmt.Sprintf("const 0x%02x", x.Value)
+	case *BytesConst:
+		return fmt.Sprintf("const b\"%s\"", x.Value)
 	case *UnitConst:
 		return "const ()"
 	case *NullConst:

--- a/internal/parser/frontend_authority_test.go
+++ b/internal/parser/frontend_authority_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/selfhost"
 )
 
@@ -26,5 +27,50 @@ func TestParseDetailedKeepsFrontendRunAndUsesExplicitPublicCompatibility(t *test
 	}
 	if got := selfhost.AstbridgeLowerCount(); got != 0 {
 		t.Fatalf("ParseDetailed astbridge count = %d, want 0", got)
+	}
+}
+
+func TestParseMatchArmAllowsBareAssignmentBody(t *testing.T) {
+	src := []byte(`struct Cookie { path: String }
+
+fn update(value: String?) {
+    let mut out = Cookie { path: "" }
+    match value {
+        Some(v) -> out.path = v,
+        None -> {},
+    }
+}
+`)
+
+	result := ParseDetailed(src)
+	if len(result.Diagnostics) > 0 {
+		t.Fatalf("ParseDetailed diagnostics = %#v, want none", result.Diagnostics)
+	}
+	if result.File == nil || len(result.File.Decls) < 2 {
+		t.Fatalf("parsed file = %#v, want struct and function declarations", result.File)
+	}
+	fn, ok := result.File.Decls[1].(*ast.FnDecl)
+	if !ok || fn.Body == nil || len(fn.Body.Stmts) < 2 {
+		t.Fatalf("decl[1] = %#v, want function with match statement", result.File.Decls[1])
+	}
+	stmt, ok := fn.Body.Stmts[1].(*ast.ExprStmt)
+	if !ok {
+		t.Fatalf("stmt[1] = %#v, want expression statement", fn.Body.Stmts[1])
+	}
+	match, ok := stmt.X.(*ast.MatchExpr)
+	if !ok || len(match.Arms) == 0 {
+		t.Fatalf("stmt[1].X = %#v, want match expression with arms", stmt.X)
+	}
+	body, ok := match.Arms[0].Body.(*ast.Block)
+	if !ok || len(body.Stmts) != 1 {
+		t.Fatalf("arm body = %#v, want single-statement block", match.Arms[0].Body)
+	}
+	assign, ok := body.Stmts[0].(*ast.AssignStmt)
+	if !ok || len(assign.Targets) != 1 {
+		t.Fatalf("arm body stmt = %#v, want assignment statement", body.Stmts[0])
+	}
+	target, ok := assign.Targets[0].(*ast.FieldExpr)
+	if !ok || target.Name != "path" {
+		t.Fatalf("assignment target = %#v, want .path field assignment", assign.Targets[0])
 	}
 }

--- a/internal/selfhost/astbridge/generated.go
+++ b/internal/selfhost/astbridge/generated.go
@@ -556,6 +556,10 @@ func ByteLitExpr(pos, end Pos, value string) Expr {
 	return &ast.ByteLit{PosV: pos, EndV: end, Value: firstByte(value)}
 }
 
+func BytesLitExpr(pos, end Pos, value string) Expr {
+	return &ast.BytesLit{PosV: pos, EndV: end, Value: value}
+}
+
 func StringLitFromToken(pos, end Pos, tok Token) Expr {
 	return &ast.StringLit{PosV: pos, EndV: end, IsRaw: tok.Kind == token.RAWSTRING, IsTriple: tok.Triple, Parts: stringPartsToAST(tok.Parts)}
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -2688,7 +2688,7 @@ func frontendLexStream(source string) *FrontLexStream {
 					}
 					skip = _cur82 - _rhs83
 				}()
-			} else if unit == "b" && next == "'" {
+			} else if unit == "b" && (next == "'" || next == "\"") {
 				// Osty: /tmp/selfhost_merged.osty:1245:17
 				scan := frontStringLikeScan(units, idx, unitCount, FrontTokenKind(&FrontTokenKind_FrontByte{}))
 				_ = scan
@@ -3663,8 +3663,13 @@ func frontStringScanHitNewline(units []string, start int, unitCount int, kind Fr
 		}()
 	}
 	// Osty: /tmp/selfhost_merged.osty:1702:5
-	if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontByte{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontChar{})) {
-		// Osty: /tmp/selfhost_merged.osty:1703:9
+	if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontByte{})) {
+		if frontUnitAt(units, start+1) == "\"" {
+			close = "\""
+		} else {
+			close = "'"
+		}
+	} else if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontChar{})) {
 		close = "'"
 	}
 	// Osty: /tmp/selfhost_merged.osty:1705:5
@@ -5073,7 +5078,7 @@ func frontInterpolationTokenScan(units []string, start int, limit int) *FrontSca
 	return func() *FrontScanResult {
 		if unit == "r" && next == "\"" {
 			return frontStringLikeScan(units, start, limit, FrontTokenKind(&FrontTokenKind_FrontRawString{}))
-		} else if unit == "b" && next == "'" {
+		} else if unit == "b" && (next == "'" || next == "\"") {
 			return frontStringLikeScan(units, start, limit, FrontTokenKind(&FrontTokenKind_FrontByte{}))
 		} else if unit == "\"" {
 			return frontStringLikeScan(units, start, limit, FrontTokenKind(&FrontTokenKind_FrontString{}))
@@ -5825,7 +5830,7 @@ func frontendLexSummary(source string) *FrontLexSummary {
 					}
 					skip = _cur422 - _rhs423
 				}()
-			} else if unit == "b" && next == "'" {
+			} else if unit == "b" && (next == "'" || next == "\"") {
 				// Osty: /tmp/selfhost_merged.osty:2457:17
 				atFileStart = false
 				// Osty: /tmp/selfhost_merged.osty:2458:17
@@ -6515,7 +6520,11 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 			contentStart = _cur494 + _rhs495
 		}()
 		// Osty: /tmp/selfhost_merged.osty:2692:9
-		close = "'"
+		if frontUnitAt(units, start+1) == "\"" {
+			close = "\""
+		} else {
+			close = "'"
+		}
 	} else if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontChar{})) {
 		// Osty: /tmp/selfhost_merged.osty:2694:9
 		close = "'"
@@ -6709,7 +6718,7 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 					}
 					skip = _cur520 - _rhs521
 				}()
-			} else if unit == "b" && next == "'" {
+			} else if unit == "b" && (next == "'" || next == "\"") {
 				// Osty: /tmp/selfhost_merged.osty:2736:17
 				inner := frontStringLikeScan(units, idx, unitCount, FrontTokenKind(&FrontTokenKind_FrontByte{}))
 				_ = inner
@@ -18499,6 +18508,10 @@ type AstNodeKind_AstNByteLit struct{ _ref byte }
 
 func (AstNodeKind_AstNByteLit) _isAstNodeKind() {}
 
+type AstNodeKind_AstNBytesLit struct{ _ref byte }
+
+func (AstNodeKind_AstNBytesLit) _isAstNodeKind() {}
+
 type AstNodeKind_AstNBinary struct{ _ref byte }
 
 func (AstNodeKind_AstNBinary) _isAstNodeKind() {}
@@ -19244,7 +19257,7 @@ func opIsLiteralDefaultAt(p *OstyParser, idx int) bool {
 		return opIsLiteralDefaultAt(p, node.left)
 	}
 	// Osty: /tmp/selfhost_merged.osty:7189:5
-	if ostyEqual(k, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNStringLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNByteLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNBoolLit{})) {
+	if ostyEqual(k, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNStringLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNByteLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNBytesLit{})) || ostyEqual(k, AstNodeKind(&AstNodeKind_AstNBoolLit{})) {
 		// Osty: /tmp/selfhost_merged.osty:7190:9
 		return true
 	}
@@ -19934,6 +19947,9 @@ func opParsePrimary(p *OstyParser) int {
 		// Osty: /tmp/selfhost_merged.osty:7501:5
 		n := emptyAstNode(AstNodeKind(&AstNodeKind_AstNByteLit{}))
 		_ = n
+		if strings.HasPrefix(tok.text, "b\"") || strings.HasPrefix(tok.text, "B\"") {
+			n = emptyAstNode(AstNodeKind(&AstNodeKind_AstNBytesLit{}))
+		}
 		// Osty: /tmp/selfhost_merged.osty:7502:6
 		n.text = tok.text
 		// Osty: /tmp/selfhost_merged.osty:7503:6
@@ -20852,7 +20868,7 @@ func opParseMatchExpr(p *OstyParser) int {
 		// Osty: /tmp/selfhost_merged.osty:7772:9
 		_ = opExpect(p, FrontTokenKind(&FrontTokenKind_FrontArrow{}))
 		// Osty: /tmp/selfhost_merged.osty:7773:9
-		body := opParseExpr(p)
+		body := opParseMatchArmBody(p)
 		_ = body
 		// Osty: /tmp/selfhost_merged.osty:7774:9
 		armNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNMatchArm{}))
@@ -20893,6 +20909,42 @@ func opParseMatchExpr(p *OstyParser) int {
 	// Osty: /tmp/selfhost_merged.osty:7790:6
 	n.end = p.pos
 	return opAddNode(p, n)
+}
+
+func opParseMatchArmBody(p *OstyParser) int {
+	body := opParseExpr(p)
+	next := opPeek(p)
+	if !(frontIsAssignOp(next.kind)) {
+		return body
+	}
+
+	_ = opAdvance(p)
+	value := opParseExpr(p)
+	bodyNode := astArenaNodeAt(p.arena, body)
+	stmtIdx := -1
+	if ostyEqual(next.kind, FrontTokenKind(&FrontTokenKind_FrontAssign{})) {
+		lowered := opLowerAppendAssignmentStmt(p, body, value, bodyNode.start, p.pos)
+		if lowered >= 0 {
+			stmtIdx = lowered
+		}
+	}
+	if stmtIdx < 0 {
+		assign := emptyAstNode(AstNodeKind(&AstNodeKind_AstNAssign{}))
+		assign.left = body
+		assign.right = value
+		assign.op = next.kind
+		assign.start = bodyNode.start
+		assign.end = p.pos
+		stmtIdx = opAddNode(p, assign)
+	}
+
+	stmts := make([]int, 0, 1)
+	stmts = opAppendCanonicalStmt(p, stmts, stmtIdx)
+	block := emptyAstNode(AstNodeKind(&AstNodeKind_AstNBlock{}))
+	block.children = stmts
+	block.start = bodyNode.start
+	block.end = p.pos
+	return opAddNode(p, block)
 }
 
 // Osty: /tmp/selfhost_merged.osty:7794:1
@@ -23467,7 +23519,7 @@ func opParseStructDecl(p *OstyParser, isPub bool, anns []int) int {
 		if opAt(p, FrontTokenKind(&FrontTokenKind_FrontFn{})) {
 			// Osty: /tmp/selfhost_merged.osty:8985:31
 			func() struct{} { members = append(members, opParseFnDecl(p, memberPub, memberAnns)); return struct{}{} }()
-		} else if opAt(p, FrontTokenKind(&FrontTokenKind_FrontIdent{})) {
+		} else if opAt(p, FrontTokenKind(&FrontTokenKind_FrontIdent{})) || opAt(p, FrontTokenKind(&FrontTokenKind_FrontType{})) {
 			// Osty: /tmp/selfhost_merged.osty:8986:13
 			fs := p.pos
 			_ = fs
@@ -24310,6 +24362,9 @@ func astNodeKindName(kind AstNodeKind) string {
 		}
 		if func() bool { _, ok := _m1807.(*AstNodeKind_AstNByteLit); return ok }() {
 			return "ByteLit"
+		}
+		if func() bool { _, ok := _m1807.(*AstNodeKind_AstNBytesLit); return ok }() {
+			return "BytesLit"
 		}
 		if func() bool { _, ok := _m1807.(*AstNodeKind_AstNBinary); return ok }() {
 			return "Binary"
@@ -25307,6 +25362,16 @@ func astCountSummary(file *AstFile) *FrontParseSummary {
 						panic("integer overflow")
 					}
 					return _p1913 + _rhs1914
+				}()
+			}
+			if func() bool { _, ok := _m1810.(*AstNodeKind_AstNBytesLit); return ok }() {
+				s.literals = func() int {
+					var _p1913b int = s.literals
+					var _rhs1914b int = 1
+					if _rhs1914b > 0 && _p1913b > math.MaxInt-_rhs1914b {
+						panic("integer overflow")
+					}
+					return _p1913b + _rhs1914b
 				}()
 			}
 			if func() bool { _, ok := _m1810.(*AstNodeKind_AstNError); return ok }() {
@@ -26320,6 +26385,9 @@ func ostyAstExprBare(f *OstyAstFormatter, node *AstNode) string {
 			return node.text
 		}
 		if func() bool { _, ok := _m1943.(*AstNodeKind_AstNByteLit); return ok }() {
+			return node.text
+		}
+		if func() bool { _, ok := _m1943.(*AstNodeKind_AstNBytesLit); return ok }() {
 			return node.text
 		}
 		if func() bool { _, ok := _m1943.(*AstNodeKind_AstNUnary); return ok }() {
@@ -30588,6 +30656,10 @@ type CoreKind_CkByteLit struct{ _ref byte }
 
 func (CoreKind_CkByteLit) _isCoreKind() {}
 
+type CoreKind_CkBytesLit struct{ _ref byte }
+
+func (CoreKind_CkBytesLit) _isCoreKind() {}
+
 type CoreKind_CkStringLit struct{ _ref byte }
 
 func (CoreKind_CkStringLit) _isCoreKind() {}
@@ -31142,6 +31214,16 @@ func coreByteLit(arena *CoreArena, byte int, ty int, start int, end int) int {
 	// Osty: /tmp/selfhost_merged.osty:12722:6
 	n.start = start
 	// Osty: /tmp/selfhost_merged.osty:12723:6
+	n.end = end
+	return coreArenaAdd(arena, n)
+}
+
+func coreBytesLit(arena *CoreArena, text string, ty int, start int, end int) int {
+	n := emptyCoreNode(CoreKind(&CoreKind_CkBytesLit{}))
+	_ = n
+	n.text = text
+	n.ty = ty
+	n.start = start
 	n.end = end
 	return coreArenaAdd(arena, n)
 }
@@ -32907,6 +32989,9 @@ func coreKindName(kind CoreKind) string {
 		if func() bool { _, ok := _m2039.(*CoreKind_CkByteLit); return ok }() {
 			return "ByteLit"
 		}
+		if func() bool { _, ok := _m2039.(*CoreKind_CkBytesLit); return ok }() {
+			return "BytesLit"
+		}
 		if func() bool { _, ok := _m2039.(*CoreKind_CkStringLit); return ok }() {
 			return "StringLit"
 		}
@@ -33227,6 +33312,9 @@ func corePrintNodeBody(arena *CoreArena, tys *TyArena, node *CoreNode, depth int
 		}
 		if func() bool { _, ok := _m2040.(*CoreKind_CkByteLit); return ok }() {
 			return fmt.Sprintf("b#%s", ostyToString(node.value))
+		}
+		if func() bool { _, ok := _m2040.(*CoreKind_CkBytesLit); return ok }() {
+			return fmt.Sprintf("b\"%s\"", ostyToString(node.text))
 		}
 		if func() bool { _, ok := _m2040.(*CoreKind_CkStringLit); return ok }() {
 			return fmt.Sprintf("\"%s\"", ostyToString(node.text))
@@ -38227,6 +38315,9 @@ func elabInferImpl(cx *ElabCx, idx int) *ElabResult {
 		if func() bool { _, ok := _m2175.(*AstNodeKind_AstNByteLit); return ok }() {
 			return elabInferByteLit(cx, node)
 		}
+		if func() bool { _, ok := _m2175.(*AstNodeKind_AstNBytesLit); return ok }() {
+			return elabInferBytesLit(cx, node)
+		}
 		if func() bool { _, ok := _m2175.(*AstNodeKind_AstNIdent); return ok }() {
 			return elabInferIdent(cx, node)
 		}
@@ -38435,6 +38526,9 @@ func elabPropagateExpectedToVariantIdent(cx *ElabCx, idx int, inferred int, expe
 	// Osty: /tmp/selfhost_merged.osty:17888:5
 	inferredResolved := checkResolveAliasDeep(cx.env, inferred)
 	_ = inferredResolved
+	if ostyEqual(tyKindAt(tys, inferredResolved), TyKind(&TyKind_TkOptional{})) {
+		inferredResolved = tyNamed(tys, "Option", []int{tyInnerAt(tys, inferredResolved)})
+	}
 	// Osty: /tmp/selfhost_merged.osty:17889:5
 	expectedResolved := checkResolveAliasDeep(cx.env, expected)
 	_ = expectedResolved
@@ -38547,6 +38641,12 @@ func elabInferByteLit(cx *ElabCx, node *AstNode) *ElabResult {
 	// Osty: /tmp/selfhost_merged.osty:17956:5
 	coreIdx := coreByteLit(cx.core, 0, ty, node.start, node.end)
 	_ = coreIdx
+	return &ElabResult{node: coreIdx, ty: ty}
+}
+
+func elabInferBytesLit(cx *ElabCx, node *AstNode) *ElabResult {
+	ty := tBytes(cx.env.tys)
+	coreIdx := coreBytesLit(cx.core, node.text, ty, node.start, node.end)
 	return &ElabResult{node: coreIdx, ty: ty}
 }
 
@@ -39875,6 +39975,9 @@ func astIsExprKindAt(ast *AstFile, idx int) bool {
 			return true
 		}
 		if func() bool { _, ok := _m2189.(*AstNodeKind_AstNByteLit); return ok }() {
+			return true
+		}
+		if func() bool { _, ok := _m2189.(*AstNodeKind_AstNBytesLit); return ok }() {
 			return true
 		}
 		if func() bool { _, ok := _m2189.(*AstNodeKind_AstNIdent); return ok }() {
@@ -41572,6 +41675,9 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 	_ = sig
 	// Osty: /tmp/selfhost_merged.osty:19723:5
 	if sig.name == "" {
+		if fieldFnResult := elabFieldFnCallFallback(cx, recv.node, lookupRecvTy, ownerName, methodName, callNode, fieldNode, isOptionalChain); fieldFnResult != nil {
+			return fieldFnResult
+		}
 		// Osty: /tmp/selfhost_merged.osty:19724:9
 		hint := diagDidYouMean(checkSuggestSimilar(checkMethodNamesForReceiver(cx.env, lookupRecvTy, ownerName), methodName))
 		_ = hint
@@ -42476,6 +42582,60 @@ func elabNullaryMethodFallback(cx *ElabCx, recvNode int, owner, fieldName string
 	resultTy := elabWrapOptionalChain(cx, isOptionalChain, fnSig.retTy)
 	coreIdx := coreMethodCall(cx.core, recvNode, fieldName, owner, make([]int, 0, 1), make([]int, 0, 1), resultTy, start, end)
 	return &ElabResult{node: coreIdx, ty: resultTy}
+}
+
+// elabFieldFnCallFallback handles the case where `obj.field(args)` is
+// parsed as a method call but no method named `field` exists on the
+// receiver. When the receiver is a struct (or named type) that has a
+// field named `field` whose type is a function, the call desugars into
+// a field access followed by a function-value call. This matches the
+// intuition that `route.handler(req, params)` should work when
+// `handler` is a `RouteHandler` field on `Route`.
+//
+// Returns nil when the fallback does not apply, so the caller can
+// emit its E0703 diagnostic as before.
+func elabFieldFnCallFallback(cx *ElabCx, recvNode int, recvTy int, ownerName string, fieldName string, callNode *AstNode, fieldNode *AstNode, isOptionalChain bool) *ElabResult {
+	if ownerName == "" {
+		return nil
+	}
+	resolvedRecv := checkResolveAliasDeep(cx.env, recvTy)
+	if !ostyEqual(tyKindAt(cx.env.tys, resolvedRecv), TyKind(&TyKind_TkNamed{})) {
+		return nil
+	}
+	fieldSig := checkLookupField(cx.env, ownerName, fieldName)
+	if fieldSig.name == "" {
+		return nil
+	}
+	typeSig := checkLookupType(cx.env, ownerName)
+	ownerArgs := tyArgsAt(cx.env.tys, resolvedRecv)
+	var fieldTy int
+	if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
+		fieldTy = checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, ownerArgs)
+	} else {
+		fieldTy = fieldSig.ty
+	}
+	resolvedFieldTy := checkResolveAliasDeep(cx.env, fieldTy)
+	if !ostyEqual(tyKindAt(cx.env.tys, resolvedFieldTy), TyKind(&TyKind_TkFn{})) {
+		return nil
+	}
+	paramTys := tyArgsAt(cx.env.tys, resolvedFieldTy)
+	retTy := tyRetAt(cx.env.tys, resolvedFieldTy)
+	resultFieldTy := elabWrapOptionalChain(cx, isOptionalChain, fieldTy)
+	coreFieldNode := coreField(cx.core, recvNode, fieldName, resultFieldTy, fieldNode.start, fieldNode.end)
+	argIdxs := callNode.children
+	var coreArgs []int
+	for i, argIdx := range argIdxs {
+		if i < checkIntListLenHelper(paramTys) {
+			r := elabCheck(cx, argIdx, checkIntListAt(paramTys, i))
+			coreArgs = append(coreArgs, r.node)
+		} else {
+			r := elabInfer(cx, argIdx)
+			coreArgs = append(coreArgs, r.node)
+		}
+	}
+	resultRetTy := elabWrapOptionalChain(cx, isOptionalChain, retTy)
+	coreCallNode := coreCall(cx.core, coreFieldNode, coreArgs, make([]int, 0, 1), resultRetTy, callNode.start, callNode.end)
+	return &ElabResult{node: coreCallNode, ty: resultRetTy}
 }
 
 // Osty: /tmp/selfhost_merged.osty:20265:1
@@ -49224,6 +49384,9 @@ func typedExprKindNameAt(ast *AstFile, idx int) string {
 			return astNodeKindName(node.kind)
 		}
 		if func() bool { _, ok := _m2328.(*AstNodeKind_AstNByteLit); return ok }() {
+			return astNodeKindName(node.kind)
+		}
+		if func() bool { _, ok := _m2328.(*AstNodeKind_AstNBytesLit); return ok }() {
 			return astNodeKindName(node.kind)
 		}
 		if func() bool { _, ok := _m2328.(*AstNodeKind_AstNIdent); return ok }() {
@@ -58794,7 +58957,7 @@ func selfLintAstExprsEqual(file *AstFile, leftIdx int, rightIdx int, resolved *S
 		return left.flags == right.flags
 	}
 	// Osty: /tmp/selfhost_merged.osty:31193:5
-	if ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNByteLit{})) {
+	if ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNByteLit{})) || ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNBytesLit{})) {
 		// Osty: /tmp/selfhost_merged.osty:31194:9
 		return left.text == right.text
 	}
@@ -65465,6 +65628,9 @@ func inspectRuleForKind(kind string) string {
 		// Osty: /tmp/selfhost_merged.osty:35071:32
 		return "LIT-BYTE"
 	}
+	if kind == "AstNBytesLit" {
+		return "LIT-BYTES"
+	}
 	// Osty: /tmp/selfhost_merged.osty:35072:5
 	if kind == "AstNIdent" {
 		// Osty: /tmp/selfhost_merged.osty:35072:30
@@ -68854,6 +69020,10 @@ func astLowerExpr(arena *AstArena, toks []astbridge.Token, idx int) astbridge.Ex
 		// Osty: /tmp/selfhost_merged.osty:36756:9
 		return astbridge.ByteLitExpr(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerDecodedLiteral(astbridge.TokenValue(astLowerTok(toks, n.start))))
 	}
+	// Osty: bytes literal
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNBytesLit{})) {
+		return astbridge.BytesLitExpr(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerDecodedLiteral(astbridge.TokenValue(astLowerTok(toks, n.start))))
+	}
 	// Osty: /tmp/selfhost_merged.osty:36758:5
 	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNStringLit{})) {
 		// Osty: /tmp/selfhost_merged.osty:36759:9
@@ -69336,7 +69506,7 @@ func astLowerPattern(arena *AstArena, toks []astbridge.Token, idx int) astbridge
 		return astLowerTuplePat(arena, toks, n)
 	}
 	// Osty: /tmp/selfhost_merged.osty:37032:5
-	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNStringLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNByteLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNBoolLit{})) {
+	if ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNIntLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNFloatLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNStringLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNCharLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNByteLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNBytesLit{})) || ostyEqual(n.kind, AstNodeKind(&AstNodeKind_AstNBoolLit{})) {
 		// Osty: /tmp/selfhost_merged.osty:37033:9
 		return astbridge.LiteralPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerExpr(arena, toks, idx))
 	}

--- a/internal/selfhost/primitive_arith_register.go
+++ b/internal/selfhost/primitive_arith_register.go
@@ -76,6 +76,19 @@ func installPrimitiveArithMethods(env *CheckEnv) {
 	}
 	registerSupplementalStdlibSurface(env)
 
+	// Bytes primitive methods — mirrors the surface declared in
+	// `internal/stdlib/primitives/bytes.osty` behind
+	// `#[intrinsic_methods(Bytes)]`. The generic AST-based collector
+	// `collectIntrinsicMethodsFromAst` handles this when invoked on
+	// the bytes stub, but the prepopulated registration below ensures
+	// the methods are available even when the AST collector hasn't
+	// run yet (e.g. during early bootstrap).
+	{
+		bytesTy := tBytes(tys)
+		bytesOwner := "Bytes"
+		registerBytesIntrinsicMethods(env, bytesOwner, bytesTy, tys)
+	}
+
 	// Float family — same `#[intrinsic_methods(Float, Float32, Float64)]`
 	// shape as the integer loop above. Register the full stdlib-declared
 	// surface so selfhost checking matches the embedded primitive stub:
@@ -590,4 +603,60 @@ func registerIntrinsicMethodOn(cx *ElabCx, method *AstNode, targetName string, t
 		generics:      generics,
 		genericBounds: bounds,
 	})
+}
+
+func registerBytesIntrinsicMethods(env *CheckEnv, owner string, ty int, tys *TyArena) {
+	tInt_ := tInt(tys)
+	tBool_ := tBool(tys)
+	tString_ := tString(tys)
+	tBytes_ := tBytes(tys)
+	tOptByte := tyOptional(tys, tByte(tys))
+	tOptInt := tyOptional(tys, tInt_)
+	tListBytes := tyNamed(tys, "List", []int{tBytes_})
+	tResultStringError := tyNamed(tys, "Result", []int{tString_, tyNamed(tys, "Error", make([]int, 0, 1))})
+
+	type pm struct {
+		name       string
+		retTy      int
+		paramNames []string
+		paramTys   []int
+	}
+	methods := []pm{
+		{"len", tInt_, nil, nil},
+		{"isEmpty", tBool_, nil, nil},
+		{"get", tOptByte, []string{"i"}, []int{tInt_}},
+		{"contains", tBool_, []string{"sub"}, []int{tBytes_}},
+		{"startsWith", tBool_, []string{"prefix"}, []int{tBytes_}},
+		{"endsWith", tBool_, []string{"suffix"}, []int{tBytes_}},
+		{"indexOf", tOptInt, []string{"sub"}, []int{tBytes_}},
+		{"lastIndexOf", tOptInt, []string{"sub"}, []int{tBytes_}},
+		{"split", tListBytes, []string{"sep"}, []int{tBytes_}},
+		{"join", tBytes_, []string{"parts"}, []int{tListBytes}},
+		{"concat", tBytes_, []string{"other"}, []int{tBytes_}},
+		{"repeat", tBytes_, []string{"n"}, []int{tInt_}},
+		{"replace", tBytes_, []string{"old", "new"}, []int{tBytes_, tBytes_}},
+		{"replaceAll", tBytes_, []string{"old", "new"}, []int{tBytes_, tBytes_}},
+		{"trimLeft", tBytes_, []string{"strip"}, []int{tBytes_}},
+		{"trimRight", tBytes_, []string{"strip"}, []int{tBytes_}},
+		{"trim", tBytes_, []string{"strip"}, []int{tBytes_}},
+		{"trimSpace", tBytes_, nil, nil},
+		{"toUpper", tBytes_, nil, nil},
+		{"toLower", tBytes_, nil, nil},
+		{"toHex", tString_, nil, nil},
+		{"slice", tBytes_, []string{"start", "end"}, []int{tInt_, tInt_}},
+		{"toString", tResultStringError, nil, nil},
+	}
+	for _, m := range methods {
+		checkRegisterFn(env, &CheckFnSig{
+			name:          m.name,
+			owner:         owner,
+			receiverTy:    ty,
+			hasReceiver:   true,
+			retTy:         m.retTy,
+			paramNames:    m.paramNames,
+			paramTys:      m.paramTys,
+			generics:      make([]string, 0, 1),
+			genericBounds: make([]*CheckGenericBound, 0, 1),
+		})
+	}
 }

--- a/internal/selfhost/testdata/check_snapshots/basic-let.txt
+++ b/internal/selfhost/testdata/check_snapshots/basic-let.txt
@@ -5,6 +5,6 @@ typedNodes
 bindings
   id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=133 span=0:38 type=fn() -> ()
+  id=symbol:b682ed2ca7f2d nodeKey=node:b61dae7153803e3 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=135 span=0:38 type=fn() -> ()
 instantiations
 diagnostics

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-field-not-found.txt
@@ -3,16 +3,16 @@ errorsByContext E0702=1
 errorDetails E0702 no field `age` on type `User` @L4:C19=1
 typedNodes
   id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=133 kind=StructLit span=61:76 type=User
-  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=133 kind=Ident span=91:95 type=User
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
+  id=typed-node:b56e41f63 nodeKey=node:ab31c47955150d2 typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=135 kind=Ident span=91:95 type=User
   id=typed-node:fc919e5a0 nodeKey=node:4c84bd6cefe7767 typeKey=type:520c4bf26e2fabc node=13 nodeId=13 typeId=19 kind=Block span=39:101 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=133 span=49:53 type=User
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
   id=binding:cf88212b883f nodeKey=node:12aeb24100020eb typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=age mutable=false typeId=1 span=85:88 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=133 span=0:28 type=User
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 node=14 nodeId=14 kind=fn name=main owner= typeId=134 span=29:101 type=fn() -> ()
+  id=symbol:09e0892a953e6 nodeKey=node:3932e8355a8e183 typeKey=type:b4f942e1ed0777f symbolId=2 node=14 nodeId=14 kind=fn name=main owner= typeId=136 span=29:101 type=fn() -> ()
 instantiations
 diagnostics
   code=E0702 severity=error span=95:99 line=4:19-4:23 message=no field `age` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-generic-arity.txt
@@ -11,7 +11,7 @@ bindings
   id=binding:36a65d5fffc6 nodeKey=node:943860bfc5f7e91 typeKey=type:819354aa58f2166 bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=21 span=50:56 type=UntypedInt
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 node=17 nodeId=17 kind=fn name=main owner= typeId=133 span=34:81 type=fn() -> ()
+  id=symbol:ccd3fe9f277c8 nodeKey=node:2a72dc672708fa9 typeKey=type:b4f942e1ed0777f symbolId=1 node=17 nodeId=17 kind=fn name=main owner= typeId=135 span=34:81 type=fn() -> ()
 instantiations
   id=instantiation:0e805f nodeKey=node:c75801d39c9edaa resultTypeKey=type:819354aa58f2166 instantiationId=0 node=14 nodeId=14 callee=id span=76:79 typeArgIds=[21] typeArgKeys=[type:819354aa58f2166] typeArgs=[UntypedInt] resultTypeId=21 resultType=UntypedInt
 diagnostics

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-interface-bound.txt
@@ -6,21 +6,21 @@ typedNodes
   id=typed-node:3c357a296 nodeKey=node:9440cf586cde53e typeKey=type:27afd946bb3613d node=14 nodeId=14 typeId=17 kind=Call span=122:124 type=String
   id=typed-node:f9acd80ba nodeKey=node:e4abda096343b5c typeKey=type:27afd946bb3613d node=16 nodeId=16 typeId=17 kind=Block span=110:126 type=String
   id=typed-node:22c21819d nodeKey=node:09faed5a8f0e6ee typeKey=type:0cbe92b642f4e2f node=21 nodeId=21 typeId=2 kind=IntLit span=172:174 type=Int
-  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 node=23 nodeId=23 typeId=135 kind=StructLit span=165:176 type=User
-  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 node=28 nodeId=28 typeId=135 kind=Ident span=209:213 type=User
+  id=typed-node:ef9b548ba nodeKey=node:5bfa5a210ff801e typeKey=type:addc461d1f10d07 node=23 nodeId=23 typeId=137 kind=StructLit span=165:176 type=User
+  id=typed-node:bb04ebdbc nodeKey=node:8ff867d22716d38 typeKey=type:addc461d1f10d07 node=28 nodeId=28 typeId=137 kind=Ident span=209:213 type=User
   id=typed-node:985a6b5a7 nodeKey=node:3cc4b7378e4d535 typeKey=type:27afd946bb3613d node=29 nodeId=29 typeId=17 kind=Call span=208:214 type=String
   id=typed-node:eb39bd0b2 nodeKey=node:598cc8b8332a80c typeKey=type:520c4bf26e2fabc node=31 nodeId=31 typeId=19 kind=Block span=137:216 type=()
 bindings
-  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 node=18 nodeId=18 name=user mutable=false typeId=135 span=147:151 type=User
+  id=binding:ddf28dba2fe5 nodeKey=node:beda8c03414007c typeKey=type:addc461d1f10d07 bindingId=0 node=18 nodeId=18 name=user mutable=false typeId=137 span=147:151 type=User
   id=binding:0b0c94771576 nodeKey=node:7abebfc4521a235 typeKey=type:27afd946bb3613d bindingId=1 node=25 nodeId=25 name=label mutable=false typeId=17 span=185:190 type=String
 symbols
-  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 node=3 nodeId=3 kind=interface name=Named owner= typeId=133 span=0:43 type=Named
-  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 node=2 nodeId=2 kind=fn name=name owner=Named typeId=134 span=18:41 type=fn() -> String
-  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 node=6 nodeId=6 kind=struct name=User owner= typeId=135 span=44:68 type=User
+  id=symbol:89f31eaf230bd nodeKey=node:9ffc38d169fb3d4 typeKey=type:65086d14233556d symbolId=0 node=3 nodeId=3 kind=interface name=Named owner= typeId=135 span=0:43 type=Named
+  id=symbol:f5ec71b67ce18 nodeKey=node:571a54f97380c51 typeKey=type:1e90da063ee133a symbolId=1 node=2 nodeId=2 kind=fn name=name owner=Named typeId=136 span=18:41 type=fn() -> String
+  id=symbol:0ccf810404e77 nodeKey=node:8c94107f83ab34c typeKey=type:addc461d1f10d07 symbolId=2 node=6 nodeId=6 kind=struct name=User owner= typeId=137 span=44:68 type=User
   id=symbol:01d01384e52f6 nodeKey=node:48daa8c06dff3ae typeKey=type:0cbe92b642f4e2f symbolId=3 node=5 nodeId=5 kind=field name=age owner=User typeId=2 span=58:66 type=Int
-  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 node=17 nodeId=17 kind=fn name=display owner= typeId=136 span=69:126 type=fn(T) -> String
-  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 node=32 nodeId=32 kind=fn name=main owner= typeId=137 span=127:216 type=fn() -> ()
+  id=symbol:0a9f88b56493a nodeKey=node:7a741eb7444e054 typeKey=type:943d867c4f1392a symbolId=4 node=17 nodeId=17 kind=fn name=display owner= typeId=138 span=69:126 type=fn(T) -> String
+  id=symbol:ecda378af8c7c nodeKey=node:cdcb78ae39bfed2 typeKey=type:b4f942e1ed0777f symbolId=5 node=32 nodeId=32 kind=fn name=main owner= typeId=139 span=127:216 type=fn() -> ()
 instantiations
-  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 node=29 nodeId=29 callee=display span=208:214 typeArgIds=[135] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
+  id=instantiation:379f55 nodeKey=node:b34a4a91d02c6dd resultTypeKey=type:27afd946bb3613d instantiationId=0 node=29 nodeId=29 callee=display span=208:214 typeArgIds=[137] typeArgKeys=[type:addc461d1f10d07] typeArgs=[User] resultTypeId=17 resultType=String
 diagnostics
   code=E0749 severity=error span=208:214 line=6:32-6:38 message=type parameter `T` requires bound `Named`, but `User` does not satisfy it

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-intrinsic-violation.txt
@@ -8,7 +8,7 @@ typedNodes
   id=typed-node:d1cd82bc0 nodeKey=node:4013449fff6a7f8 typeKey=type:0cbe92b642f4e2f node=4 nodeId=4 typeId=2 kind=Block span=29:39 type=Int
 bindings
 symbols
-  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 node=5 nodeId=5 kind=fn name=bad owner= typeId=133 span=13:39 type=fn() -> Int
+  id=symbol:0866a9ff21ddc nodeKey=node:ddfbf48157208d0 typeKey=type:ff113f463eecce4 symbolId=0 node=5 nodeId=5 kind=fn name=bad owner= typeId=135 span=13:39 type=fn() -> Int
 instantiations
 diagnostics
   code=E0773 severity=error span=29:39 line=2:17-4:2 message=`#[intrinsic]` function `bad` must have an empty body

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-method-not-found.txt
@@ -3,16 +3,16 @@ errorsByContext E0703=1
 errorDetails E0703 no method `label` on type `User` @L4:C21=1
 typedNodes
   id=typed-node:b78cfb3ed nodeKey=node:53b25d7ecdff87a typeKey=type:27afd946bb3613d node=5 nodeId=5 typeId=17 kind=StringLit span=69:74 type=String
-  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=133 kind=StructLit span=61:76 type=User
-  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=133 kind=Ident span=93:97 type=User
+  id=typed-node:8cf4577ad nodeKey=node:376e28592af0dc9 typeKey=type:addc461d1f10d07 node=7 nodeId=7 typeId=135 kind=StructLit span=61:76 type=User
+  id=typed-node:71017d305 nodeKey=node:b4407dfff4e4dce typeKey=type:addc461d1f10d07 node=10 nodeId=10 typeId=135 kind=Ident span=93:97 type=User
   id=typed-node:afa66bade nodeKey=node:e5353e717457cf8 typeKey=type:520c4bf26e2fabc node=14 nodeId=14 typeId=19 kind=Block span=39:107 type=()
 bindings
-  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=133 span=49:53 type=User
+  id=binding:bce7801e15e8 nodeKey=node:b0049a2b702e748 typeKey=type:addc461d1f10d07 bindingId=0 node=3 nodeId=3 name=user mutable=false typeId=135 span=49:53 type=User
   id=binding:695f342d6c1a nodeKey=node:3a87cbd6fc03914 typeKey=type:50eaecf185276b1 bindingId=1 node=9 nodeId=9 name=label mutable=false typeId=1 span=85:90 type=Poison
 symbols
-  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=133 span=0:28 type=User
+  id=symbol:83a3a2ff347d8 nodeKey=node:95d51a212c26d2d typeKey=type:addc461d1f10d07 symbolId=0 node=2 nodeId=2 kind=struct name=User owner= typeId=135 span=0:28 type=User
   id=symbol:fa3a474531148 nodeKey=node:400970a6a9853d2 typeKey=type:27afd946bb3613d symbolId=1 node=1 nodeId=1 kind=field name=name owner=User typeId=17 span=14:26 type=String
-  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 node=15 nodeId=15 kind=fn name=main owner= typeId=134 span=29:107 type=fn() -> ()
+  id=symbol:e5420eab90bbb nodeKey=node:3842cd891441c4f typeKey=type:b4f942e1ed0777f symbolId=2 node=15 nodeId=15 kind=fn name=main owner= typeId=136 span=29:107 type=fn() -> ()
 instantiations
 diagnostics
   code=E0703 severity=error span=97:103 line=4:21-4:27 message=no method `label` on type `User`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-non-exhaustive-match.txt
@@ -2,14 +2,14 @@ summary assignments=0 accepted=0 errors=1
 errorsByContext E0731=1
 errorDetails E0731 match is not exhaustive: missing `Option.Some(_)` @L2:C5=1
 typedNodes
-  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a node=4 nodeId=4 typeId=133 kind=Ident span=43:44 type=Option<Int>
+  id=typed-node:bb45f0d2f nodeKey=node:e821fb1de8a7b54 typeKey=type:a2841dcf374046a node=4 nodeId=4 typeId=135 kind=Ident span=43:44 type=Option<Int>
   id=typed-node:68a6ad56e nodeKey=node:fd8a7b5bb1b9812 typeKey=type:0cbe92b642f4e2f node=7 nodeId=7 typeId=2 kind=IntLit span=67:68 type=Int
   id=typed-node:f658257e8 nodeKey=node:e113441d9af13f2 typeKey=type:0cbe92b642f4e2f node=10 nodeId=10 typeId=2 kind=IntLit span=86:87 type=Int
   id=typed-node:44bdcc86c nodeKey=node:0f2924b336195c7 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Match span=37:94 type=Int
   id=typed-node:6ae0146ac nodeKey=node:64e465f56c81267 typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=31:96 type=Int
 bindings
 symbols
-  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 node=15 nodeId=15 kind=fn name=code owner= typeId=134 span=0:96 type=fn(Option<Int>) -> Int
+  id=symbol:8f9c4d6ff5c6e nodeKey=node:05c11385a8c46d8 typeKey=type:b094483ff5bf7fd symbolId=0 node=15 nodeId=15 kind=fn name=code owner= typeId=136 span=0:96 type=fn(Option<Int>) -> Int
 instantiations
 diagnostics
   code=E0731 severity=error span=37:94 line=2:5-5:6 message=match is not exhaustive: missing `Option.Some(_)`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-pure-violation.txt
@@ -6,14 +6,14 @@ typedNodes
   id=typed-node:a08c373e0 nodeKey=node:9acea2dec56778f typeKey=type:0cbe92b642f4e2f node=1 nodeId=1 typeId=2 kind=IntLit span=21:22 type=Int
   id=typed-node:3841a2ccd nodeKey=node:eb04cb8f98779ee typeKey=type:0cbe92b642f4e2f node=3 nodeId=3 typeId=2 kind=Block span=19:24 type=Int
   id=typed-node:700baee84 nodeKey=node:c4e2dcbcd3d09ec typeKey=type:819354aa58f2166 node=8 nodeId=8 typeId=21 kind=IntLit span=65:66 type=UntypedInt
-  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 node=9 nodeId=9 typeId=134 kind=List span=64:67 type=List<UntypedInt>
+  id=typed-node:0b55f7e33 nodeKey=node:e7dbda617f05f05 typeKey=type:ff4343a0a88abb8 node=9 nodeId=9 typeId=136 kind=List span=64:67 type=List<UntypedInt>
   id=typed-node:7e899069d nodeKey=node:650466afaa8a5a9 typeKey=type:0cbe92b642f4e2f node=12 nodeId=12 typeId=2 kind=Call span=78:80 type=Int
   id=typed-node:bff73e1c9 nodeKey=node:06207226247d8ec typeKey=type:0cbe92b642f4e2f node=14 nodeId=14 typeId=2 kind=Block span=49:82 type=Int
 bindings
-  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 node=7 nodeId=7 name=xs mutable=false typeId=134 span=59:61 type=List<UntypedInt>
+  id=binding:2e6f5cce2dd9 nodeKey=node:468f9067f9e4bd4 typeKey=type:ff4343a0a88abb8 bindingId=0 node=7 nodeId=7 name=xs mutable=false typeId=136 span=59:61 type=List<UntypedInt>
 symbols
-  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 node=4 nodeId=4 kind=fn name=impure owner= typeId=133 span=0:24 type=fn() -> Int
-  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 node=15 nodeId=15 kind=fn name=bad owner= typeId=133 span=33:82 type=fn() -> Int
+  id=symbol:66a5491bf4c48 nodeKey=node:cebd2ca3b324195 typeKey=type:ff113f463eecce4 symbolId=0 node=4 nodeId=4 kind=fn name=impure owner= typeId=135 span=0:24 type=fn() -> Int
+  id=symbol:edca6562653ad nodeKey=node:da87a9c5de0b1c9 typeKey=type:ff113f463eecce4 symbolId=1 node=15 nodeId=15 kind=fn name=bad owner= typeId=135 span=33:82 type=fn() -> Int
 instantiations
 diagnostics
   code=E0775 severity=error span=64:67 line=4:14-4:17 message=`#[pure]` function `bad` cannot allocate a list literal

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-type-mismatch.txt
@@ -7,7 +7,7 @@ typedNodes
 bindings
   id=binding:11bbeb1b4560 nodeKey=node:7e55f7d5861d8dd typeKey=type:0cbe92b642f4e2f bindingId=0 node=0 nodeId=0 name=answer mutable=false typeId=2 span=20:26 type=Int
 symbols
-  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=133 span=0:42 type=fn() -> ()
+  id=symbol:da63c620bc2ef nodeKey=node:22ddf6ed93d17e1 typeKey=type:b4f942e1ed0777f symbolId=0 node=5 nodeId=5 kind=fn name=main owner= typeId=135 span=0:42 type=fn() -> ()
 instantiations
 diagnostics
   code=E0700 severity=error span=34:40 line=2:23-2:29 message=type mismatch: expected `Int`, found `String`

--- a/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
+++ b/internal/selfhost/testdata/check_snapshots/diagnostic-unknown-symbol.txt
@@ -5,7 +5,7 @@ typedNodes
   id=typed-node:ec3886d99 nodeKey=node:c936a377e1a93a2 typeKey=type:520c4bf26e2fabc node=2 nodeId=2 typeId=19 kind=Block span=10:25 type=()
 bindings
 symbols
-  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 node=3 nodeId=3 kind=fn name=main owner= typeId=133 span=0:25 type=fn() -> ()
+  id=symbol:a5aa59b65ce7c nodeKey=node:0669292999162b9 typeKey=type:b4f942e1ed0777f symbolId=0 node=3 nodeId=3 kind=fn name=main owner= typeId=135 span=0:25 type=fn() -> ()
 instantiations
 diagnostics
   code=E0745 severity=error span=16:23 line=2:5-2:12 message=cannot find `missing` in this scope

--- a/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
+++ b/internal/selfhost/testdata/check_snapshots/generic-instantiation.txt
@@ -9,7 +9,7 @@ bindings
   id=binding:46a24bc911e8 nodeKey=node:943860bfc5f7e91 typeKey=type:0cbe92b642f4e2f bindingId=0 node=8 nodeId=8 name=answer mutable=false typeId=2 span=50:56 type=Int
 symbols
   id=symbol:5f62d6da7a4ee nodeKey=node:5c0b26c77174404 typeKey=type:9addffd32952554 symbolId=0 node=7 nodeId=7 kind=fn name=id owner= typeId=108 span=0:33 type=fn(T) -> T
-  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 node=16 nodeId=16 kind=fn name=main owner= typeId=133 span=34:73 type=fn() -> ()
+  id=symbol:b8e98828503be nodeKey=node:3370ff521ebcb76 typeKey=type:b4f942e1ed0777f symbolId=1 node=16 nodeId=16 kind=fn name=main owner= typeId=135 span=34:73 type=fn() -> ()
 instantiations
   id=instantiation:7468aa nodeKey=node:81030ece726c8c2 resultTypeKey=type:0cbe92b642f4e2f instantiationId=0 node=13 nodeId=13 callee=id span=68:71 typeArgIds=[2] typeArgKeys=[type:0cbe92b642f4e2f] typeArgs=[Int] resultTypeId=2 resultType=Int
 diagnostics

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -838,7 +838,7 @@ pub fn frontendLexStream(source: String) -> FrontLexStream {
                 pendingDocLines = 0
                 insertTerm = frontKindInsertsTerm(scan.kind)
                 skip = scan.consumed - 1
-            } else if unit == "b" && next == "'" {
+            } else if unit == "b" && (next == "'" || next == "\"") {
                 let scan = frontStringLikeScan(units, idx, unitCount, FrontByte)
                 let leadingDocLines = frontAttachedDocLines(
                     pendingDocLines,
@@ -1306,7 +1306,13 @@ pub fn frontStringScanHitNewline(
     if kind == FrontRawString || kind == FrontByte {
         contentStart = start + 2
     }
-    if kind == FrontByte || kind == FrontChar {
+    if kind == FrontByte {
+        if frontUnitAt(units, start + 1) == "\"" {
+            close = "\""
+        } else {
+            close = "'"
+        }
+    } else if kind == FrontChar {
         close = "'"
     }
     for idx in contentStart..unitCount {
@@ -1829,7 +1835,7 @@ pub fn frontInterpolationTokenScan(units: List<String>, start: Int, limit: Int) 
     let next = frontUnitAt(units, start + 1)
     if unit == "r" && next == "\"" {
         frontStringLikeScan(units, start, limit, FrontRawString)
-    } else if unit == "b" && next == "'" {
+    } else if unit == "b" && (next == "'" || next == "\"") {
         frontStringLikeScan(units, start, limit, FrontByte)
     } else if unit == "\"" {
         frontStringLikeScan(units, start, limit, FrontString)
@@ -2116,7 +2122,7 @@ pub fn frontendLexSummary(source: String) -> FrontLexSummary {
                     summary.errors = summary.errors + 1
                 }
                 skip = raw.consumed - 1
-            } else if unit == "b" && next == "'" {
+            } else if unit == "b" && (next == "'" || next == "\"") {
                 atFileStart = false
                 let byteLit = frontStringLikeScan(units, idx, unitCount, FrontByte)
                 if byteLit.ok {
@@ -2352,7 +2358,11 @@ pub fn frontStringLikeScan(
     } else if kind == FrontByte {
         consumed = 2
         contentStart = start + 2
-        close = "'"
+        if frontUnitAt(units, start + 1) == "\"" {
+            close = "\""
+        } else {
+            close = "'"
+        }
     } else if kind == FrontChar {
         close = "'"
     } else if frontUnitAt(units, start + 1) == "\"" && frontUnitAt(units, start + 2) == "\"" {

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -12,6 +12,7 @@ pub enum AstNodeKind {
     AstNBoolLit,
     AstNCharLit,
     AstNByteLit,
+    AstNBytesLit,
     AstNBinary,
     AstNUnary,
     AstNCall,
@@ -407,7 +408,7 @@ fn opIsLiteralDefaultAt(p: OstyParser, idx: Int) -> Bool {
     let node = astArenaNodeAt(p.arena, idx)
     let k = node.kind
     if k == AstNParen { return opIsLiteralDefaultAt(p, node.left) }
-    if k == AstNIntLit || k == AstNFloatLit || k == AstNStringLit || k == AstNCharLit || k == AstNByteLit || k == AstNBoolLit {
+    if k == AstNIntLit || k == AstNFloatLit || k == AstNStringLit || k == AstNCharLit || k == AstNByteLit || k == AstNBytesLit || k == AstNBoolLit {
         return true
     }
     if k == AstNUnary && node.op == FrontMinus {
@@ -734,6 +735,9 @@ fn opParsePrimary(p: OstyParser) -> Int {
     return opAddNode(p, n) }
     if tok.kind == FrontByte { opAdvance(p)
     let mut n = emptyAstNode(AstNByteLit)
+    if strings.hasPrefix(tok.text, "b\"") || strings.hasPrefix(tok.text, "B\"") {
+        n = emptyAstNode(AstNBytesLit)
+    }
     n.text = tok.text
     n.start = start
     n.end = p.pos
@@ -1302,7 +1306,7 @@ fn opParseMatchExpr(p: OstyParser) -> Int {
             p.noStructLit = pv
         }
         let _ = opExpect(p, FrontArrow)
-        let body = opParseExpr(p)
+        let body = opParseMatchArmBody(p)
         let mut armNode = emptyAstNode(AstNMatchArm)
         armNode.left = pat
         armNode.right = body
@@ -1321,6 +1325,42 @@ fn opParseMatchExpr(p: OstyParser) -> Int {
     n.start = start
     n.end = p.pos
     opAddNode(p, n)
+}
+
+fn opParseMatchArmBody(p: OstyParser) -> Int {
+    let body = opParseExpr(p)
+    let next = opPeek(p)
+    if !(frontIsAssignOp(next.kind)) {
+        return body
+    }
+
+    let _ = opAdvance(p)
+    let value = opParseExpr(p)
+    let bodyNode = astArenaNodeAt(p.arena, body)
+    let mut stmtIdx = -1
+    if next.kind == FrontAssign {
+        let lowered = opLowerAppendAssignmentStmt(p, body, value, bodyNode.start, p.pos)
+        if lowered >= 0 {
+            stmtIdx = lowered
+        }
+    }
+    if stmtIdx < 0 {
+        let mut assign = emptyAstNode(AstNAssign)
+        assign.left = body
+        assign.right = value
+        assign.op = next.kind
+        assign.start = bodyNode.start
+        assign.end = p.pos
+        stmtIdx = opAddNode(p, assign)
+    }
+
+    let mut stmts: List<Int> = []
+    stmts = opAppendCanonicalStmt(p, stmts, stmtIdx)
+    let mut block = emptyAstNode(AstNBlock)
+    block.children = stmts
+    block.start = bodyNode.start
+    block.end = p.pos
+    opAddNode(p, block)
 }
 
 fn opParseClosure(p: OstyParser) -> Int {
@@ -2536,7 +2576,7 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
         let memberAnns = opParseAnnotations(p)
         let mut memberPub = false
         if opEat(p, FrontPub) { memberPub = true }
-        if opAt(p, FrontFn) { members.push(opParseFnDecl(p, memberPub, memberAnns)) } else if opAt(p, FrontIdent) {
+        if opAt(p, FrontFn) { members.push(opParseFnDecl(p, memberPub, memberAnns)) } else if opAt(p, FrontIdent) || opAt(p, FrontType) {
             let fs = p.pos
             let fn_ = opAdvance(p).text
             let _ = opExpect(p, FrontColon)
@@ -3001,7 +3041,7 @@ fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) -> List
 pub fn astNodeKindName(kind: AstNodeKind) -> String {
     match kind {
         AstNIdent -> "Ident", AstNIntLit -> "IntLit", AstNFloatLit -> "FloatLit", AstNStringLit -> "StringLit",
-        AstNBoolLit -> "BoolLit", AstNCharLit -> "CharLit", AstNByteLit -> "ByteLit", AstNBinary -> "Binary",
+        AstNBoolLit -> "BoolLit", AstNCharLit -> "CharLit", AstNByteLit -> "ByteLit", AstNBytesLit -> "BytesLit", AstNBinary -> "Binary",
         AstNUnary -> "Unary", AstNCall -> "Call", AstNField -> "Field", AstNIndex -> "Index", AstNRange -> "Range",
         AstNIf -> "If", AstNMatch -> "Match", AstNClosure -> "Closure", AstNList -> "List", AstNTuple -> "Tuple",
         AstNMap -> "Map", AstNStructLit -> "StructLit", AstNBlock -> "Block", AstNParen -> "Paren",
@@ -3126,6 +3166,7 @@ pub fn astCountSummary(file: AstFile) -> FrontParseSummary {
             AstNBoolLit -> { s.literals = s.literals + 1 },
             AstNCharLit -> { s.literals = s.literals + 1 },
             AstNByteLit -> { s.literals = s.literals + 1 },
+            AstNBytesLit -> { s.literals = s.literals + 1 },
             AstNError -> { s.errors = s.errors + 1 },
             _ -> { let _ = n },
         }


### PR DESCRIPTION
## Summary
- Add `BytesLit` (`b"..."`) byte string literal support end-to-end: lexer (3 scan sites), parser (`AstNBytesLit`), AST, IR (`BytesLit` + `TBytes`), MIR (`BytesConst`), llvmgen (`emitBytesLiteral`)
- Fix `elabPropagateExpectedToVariantIdent` to normalize `TkOptional` → `TkNamed("Option", ...)` so match arms with `None` infer the correct optional type (fixes `MediaType?`/`BasicAuth?`/`Cookie?` mismatches)
- Add `elabFieldFnCallFallback`: when `obj.field(args)` finds no method but the receiver has a callable struct field, desugar to field access + fn-value call (fixes `route.handler(req, params)`)
- Register `Bytes` primitive intrinsic methods (22 methods: `toString`, `len`, `isEmpty`, etc.) in selfhost checker
- Support match arm bare assignment bodies (`x = expr` without block wrapper) and `type` as struct field name

## Test plan
- [x] `go vet ./...` passes
- [x] `internal/parser` tests pass
- [x] `internal/selfhost` tests pass (snapshots updated)
- [x] `internal/ir` tests pass
- [x] `http.osty` checks with 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)