### PR TITLE
docs: align v0.5 spec grammar

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1041,7 +1041,7 @@ CodeEnumDiscriminantDuplicate: two variants of the same enum are assigned the sa
 
 ### E0765 — `CodeImplicitNarrowingConversion`
 
-CodeImplicitNarrowingConversion: an expression site required an implicit numeric narrowing (e.g. `Int64 -> Int32`, `Float64 -> Int`). v0.5 allows lossless widening only; narrowing must be spelled explicitly. v0.5 (G34) §2.2a.
+CodeImplicitNarrowingConversion: an expression site required an implicit numeric narrowing (e.g. `Int64 -> Int32`, `Float64 -> Int`). v0.5 allows lossless widening only; narrowing must be spelled explicitly. v0.5 (G34) §2.2.
 
 `.toIntTrunc()`, `.toIntRound()`, `.toIntFloor()`, `.toIntCeil()`, or `.toFloat32()` to make the intent explicit.
 

--- a/LANG_SPEC_v0.5/01-lexical-structure.md
+++ b/LANG_SPEC_v0.5/01-lexical-structure.md
@@ -42,6 +42,9 @@ The following have special meaning in context but are not reserved words:
 - `true`, `false` — `Bool` constants from prelude
 - `Some`, `None` — `Option` variants from prelude
 - `Ok`, `Err` — `Result` variants from prelude
+- `loop` — `loop { ... }` expression head (§4.4.1)
+- `const` — `const fn` declaration prefix (§3.1.1)
+- `by` — range step marker in range expressions (§4.4)
 
 ### 1.4 Identifiers
 
@@ -221,7 +224,10 @@ Other:       ?    // Result/Option propagation; also Option<T> sugar in type pos
 ```
 
 Increment (`++`) and decrement (`--`) are not provided.
-User-defined operator overloading is not provided.
+User-defined operator overloading is limited to the explicit `#[op(+)]`,
+`#[op(-)]`, `#[op(*)]`, `#[op(/)]`, and `#[op(%)]` binary forms plus
+unary `#[op(-)]` (§3.8, §14.2). All other operators remain primitive-
+only or interface-defined and cannot be overloaded.
 
 **Punctuation and contextual tokens.** The following are not operators
 but serve as syntactic punctuation or context-specific markers:

--- a/LANG_SPEC_v0.5/02-type-system.md
+++ b/LANG_SPEC_v0.5/02-type-system.md
@@ -47,12 +47,15 @@ prelude and is unreachable from ordinary user code. See §19.3.
 
 ### 2.2 Numeric Conversions
 
-No implicit numeric conversions between variables. Conversions via
-methods:
+Osty allows only lossless implicit numeric widening. The widening lattice
+is `Int8 -> Int16 -> Int32 -> Int -> Float64`, `Int -> Float64`, and
+`Float32 -> Float64`. Narrowing, signedness-changing conversions, and
+lossy float/integer conversions require explicit methods; implicit
+narrowing is `E0765`.
 
 ```osty
 let a: Int = 5
-let b: Int64 = a.toInt64()
+let b: Float64 = a              // lossless widening
 let c: Int32 = big.toInt32()?           // Err if out of range
 let f: Float = a.toFloat()
 ```
@@ -66,7 +69,7 @@ type required by its usage:
 ```osty
 let a: Float = 5              // 5 is Float
 let b: Int32 = 100            // 100 is Int32
-let c: Int = a.toInt()        // no auto-conversion from variable
+let c: Int = narrow.toInt()?   // explicit narrowing from variable
 
 fn f(x: Int64) { ... }
 f(42)                         // 42 is Int64
@@ -157,6 +160,9 @@ T?                          // syntactic sugar for Option<T>
 Option<T>                   // canonical form
 Result<T, E>
 ```
+
+`Set<T>` is a standard collection type, but there is no set literal;
+construct one from an iterable, for example `Set.from([...])`.
 
 #### 2.4.1 The `Bytes` Type
 

--- a/LANG_SPEC_v0.5/03-declarations.md
+++ b/LANG_SPEC_v0.5/03-declarations.md
@@ -46,9 +46,10 @@ connect("api.com", timeout: 60, port: 443)    // keywords in any order
 Rules:
 - Only trailing parameters may have defaults; once defaulted, all
   following parameters must also have defaults.
-- Defaults must be literals: numeric, string, char, byte, bool, `None`,
-  `Ok(literal)`, `Err(literal)`, empty collection literals (`[]`,
-  `{:}`), or `()`.
+- Defaults must be `DefaultLiteral`s: numeric, string, char, byte, bool,
+  `None`, `Ok(...)`, `Err(...)`, empty collection literals (`[]`, `{:}`),
+  `()`, struct literals whose fields are `DefaultLiteral`s, or `const fn`
+  calls allowed by §3.1.1.
 - Defaults are evaluated at call time at each call site.
 - Required parameters (no default) are **positional only**.
 - Parameters with defaults may be passed either **positionally** or
@@ -228,11 +229,17 @@ when a binding of that name is in scope.
 let user = User { name: "alice", age: 30, email: "a@x.com" }
 let older = User { ..user, age: 31 }
 let rebranded = User { ..user, email: "new@x.com", name: "Alice" }
+
+let renamed = user { name: "Alice" }       // shorthand for User { ..user, name: "Alice" }
 ```
 
 The `..expr` form must appear once per struct literal. Fields explicitly
 listed override copied values. All fields must either be listed or
 supplied by the spread source.
+
+The receiver shorthand `value { field: newValue }` is accepted when
+`value` is an in-scope struct-typed binding; it desugars to
+`Type { ..value, field: newValue }`.
 
 **Partial declarations.** A struct may be declared across multiple files
 within the same package. Fields appear in exactly one declaration;
@@ -375,14 +382,25 @@ pub enum Color {
     Blue,
     RGB(UInt8, UInt8, UInt8),
 }
+
+pub enum HttpStatus: Int {
+    OK = 200,
+    NotFound = 404,
+}
 ```
 
 Variants:
 - Bare: `Red`
 - Tuple-like: `RGB(UInt8, UInt8, UInt8)`
+- Integer-discriminated: payload-free variants in an enum with an integer
+  representation may assign explicit integer values.
 
 Variant access: bare name within the same package, qualified from other
 packages (`Color.Red`).
+
+An enum with an explicit integer representation auto-derives
+`.discriminant() -> Int` and `.fromDiscriminant(n: Int) -> Self?`.
+Payload variants may not assign discriminants (`E0721`).
 
 ### 3.6 Interfaces
 
@@ -418,6 +436,9 @@ mechanism. The complete set is:
 |---|---|---|
 | `#[json(...)]` | struct fields, enum variants | Customize JSON encoding/decoding (§10.8) |
 | `#[deprecated(...)]` | `fn`, `struct`, `enum`, `interface`, `type`, top-level `let`, struct/enum methods, struct fields, enum variants | Emit a warning when the item is referenced |
+| `#[op(...)]` | struct/enum methods | Opt-in overload for the bounded arithmetic operator set: `+ - * / %` binary and `-` unary (§14.2) |
+| `#[cfg(...)]` | top-level declarations, struct/enum methods, struct fields, enum variants | Conditional compilation pre-resolve filter; keys are `os`, `target`, `arch`, and `feature`, with `all` / `any` / `not` composition (§14.3, §18 G29) |
+| `#[test]` | top-level zero-arity `fn` declarations | Inline test function collected by `osty test` and excluded from production builds (§11) |
 | `#[vectorize]` | top-level `fn` declarations, struct/enum methods | **Default-on as of v0.6** — no annotation needed for the hint. Bare `#[vectorize]` is a no-op; `#[vectorize(scalable, predicate, width = N)]` refines strategy (§3.8.3) |
 | `#[no_vectorize]` | top-level `fn` declarations, struct/enum methods | Opt out of the default vectorize hint. Restores per-iteration safepoint polls (v0.6 A5.2) |
 | `#[parallel]` | top-level `fn` declarations, struct/enum methods | Hint: every load/store in the body tagged with `!llvm.access.group`, every loop's metadata references it via `llvm.loop.parallel_accesses` to bypass alias analysis (v0.6 A6) |
@@ -427,6 +448,8 @@ mechanism. The complete set is:
 | `#[target_feature(f1, f2, ...)]` | top-level `fn` declarations, struct/enum methods | LLVM `"target-features"="+f1,+f2"` fn attribute — per-function CPU feature override (v0.6 A10) |
 | `#[noalias]` / `#[noalias(p1, p2)]` | top-level `fn` declarations, struct/enum methods | Promise pointer params do not alias — emits LLVM `noalias` param attr (v0.6 A11) |
 | `#[pure]` | top-level `fn` declarations, struct/enum methods | Assert no side effects — emits LLVM `readnone` fn attr, unlocks CSE/hoisting (v0.6 A13) |
+
+`const fn` is a declaration prefix, not an annotation; see §3.1.1.
 
 **Runtime-only annotations** (privileged packages only — see §19.2 and §19.6).
 

--- a/LANG_SPEC_v0.5/04-expressions.md
+++ b/LANG_SPEC_v0.5/04-expressions.md
@@ -157,14 +157,27 @@ is `_`. Guarded arms do not contribute to coverage.
 ```osty
 for i in 0..10 { ... }
 for i in 0..=10 { ... }
+for i in 0..100 by 2 { ... }
 for item in xs { ... }
 for (k, v) in map { ... }
 
 for cond { ... }                 // while-style
 for { ... }                      // infinite
 
+let winner = loop {
+    let item = nextItem()
+    if item.accepted { break item }
+}
+
 for x in xs {
     if found(x) { break }
+}
+
+'outer: for row in rows {
+    for cell in row {
+        if done(cell) { break 'outer }
+        if skipRest(cell) { continue 'outer }
+    }
 }
 
 for item in items {
@@ -190,8 +203,33 @@ the loop exits.
 
 There is no C-style `for (init; cond; step)`.
 
+**Range step.** `a..b by step` and `a..=b by step` set the iteration
+stride for a range expression. `by` is contextual: outside range suffix
+position it is an ordinary identifier.
+
 `break` exits the innermost enclosing loop; `continue` skips to the next
-iteration. Labelled `break` / `continue` are not provided.
+iteration. A loop may be prefixed with a label (`'name: for ...` or
+`'name: loop ...`); `break 'name` and `continue 'name` target that loop.
+Unknown labels are `E0763`. Without a label, the target is the innermost
+enclosing loop.
+
+#### 4.4.1 Loop Expressions
+
+`loop { ... }` is the value-returning unbounded loop form. It is distinct
+from `for cond { ... }` and `for { ... }`, which are statement-style loops
+with `()` result.
+
+```osty
+let firstHit = loop {
+    let value = scanNext()
+    if value.matches { break value }
+}
+```
+
+The type of a `loop` expression is the common type of its `break value`
+exits. A bare `break` exits with `()`; `break value` is valid only when
+the target is a `loop` expression. For a labeled break, the value follows
+the label: `break 'search result`.
 
 ### 4.5 Error Propagation
 
@@ -353,8 +391,9 @@ byte at index `i` as a `Byte`; `s[a..b]` returns a `String` slice (no
 copy) that aborts at runtime if either endpoint falls inside a multi-
 byte UTF-8 sequence.
 
-For Unicode-scalar or grapheme iteration, use the explicit converters
-exposed by `std.strings`:
+For byte, Unicode-scalar, or grapheme iteration, use the explicit
+`String` methods. These are intrinsic methods on `String`; higher-level
+string processing helpers live in `std.strings`.
 
 ```osty
 for c in s.chars() { ... }         // Iterator<Char>
@@ -454,8 +493,8 @@ The left-hand side must be one of:
 - an **indexed element** on a mutable collection (`xs[i]`, `m[k]`).
 
 The right-hand side is evaluated, then written to the place named by the
-left-hand side. For `=`, the RHS type must match the LHS type; no
-implicit numeric conversion occurs.
+left-hand side. For `=`, the RHS type must match the LHS type except for
+the lossless numeric widening allowed by §2.2.
 
 #### 4.13.1 Compound Assignment
 
@@ -488,8 +527,9 @@ Semantics:
    type is compatible with the LHS.
 4. The LHS must be a valid mutable place (same rules as §4.13).
 5. `+=` on `String` is equivalent to concatenation: `s += other` is
-   `s = s + other`. Numeric mixing between `Int` and `Float64` is
-   rejected, same as `+` (no implicit conversion).
+   `s = s + other`. Numeric compound assignment follows the same
+   lossless-widening and narrowing-rejection rules as the corresponding
+   binary operator and final assignment (§2.2).
 6. Compound assignment on an immutable binding or field produces the
    same diagnostic as plain assignment (`E0601` et al.); there is no
    separate code.

--- a/LANG_SPEC_v0.5/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.5/05-modules-and-packages.md
@@ -21,8 +21,10 @@ myapp/
 ```osty
 use std.fs
 use std.http
+use std::{fs, http as web}
 use github.com/user/lib
 use github.com/user/lib as mylib
+pub use myapp.db.Conn
 use go "net/http" {
     fn Get(url: String) -> Result<Response, Error>
     struct Response {
@@ -32,8 +34,11 @@ use go "net/http" {
 }
 ```
 
-`use <path>` imports an Osty package. `use go "<path>" { ... }` imports
-a Go package via FFI (see §12).
+`use <path>` imports an Osty package. Scoped import form
+`use path::{A, B as C}` imports several names from the same package.
+`pub use <path>` re-exports the imported symbol from the current package;
+re-export cycles are `E0552`. `use go "<path>" { ... }` imports a Go
+package via FFI (see §12).
 
 ### 5.3 Visibility
 

--- a/LANG_SPEC_v0.5/07-the-error-interface.md
+++ b/LANG_SPEC_v0.5/07-the-error-interface.md
@@ -57,7 +57,8 @@ fn handle(err: Error) -> Result<(), Error> {
 }
 ```
 
-`Error.downcast::<T>()` returns `T?`.
+`Error.downcast::<T>()` returns `T?`. The postfix form `err as? T` is a
+shortcut for the same operation and is valid only on `Error` values.
 
 **Runtime mechanism.** Although Osty's interface satisfaction is
 otherwise structural (§2.6), values that flow through the `Error`

--- a/LANG_SPEC_v0.5/11-testing.md
+++ b/LANG_SPEC_v0.5/11-testing.md
@@ -2,7 +2,10 @@
 
 Test files use the `_test.osty` suffix and live alongside code in the
 same package. Functions whose names begin with lowercase `test` and
-take no arguments are discovered and run by `osty test`.
+take no arguments are discovered and run by `osty test`. A top-level
+zero-arity function annotated with `#[test]` is also discovered, even in
+a production source file; annotated test functions are excluded from
+production builds.
 
 ```osty
 // auth/login_test.osty

--- a/LANG_SPEC_v0.5/14-excluded-features.md
+++ b/LANG_SPEC_v0.5/14-excluded-features.md
@@ -64,10 +64,10 @@ version, and a migration story for existing code.
 - `as` keyword for general type conversion — specific converter
   methods (`.toInt32()`, `.toFloat()`, `.toString()`, etc.) make the
   rounding / truncation / failure contract explicit. `as?` is a
-  narrow exception, reserved for `Error` downcast (§4.9).
+  narrow exception, reserved for `Error` downcast (§7.4).
 - Turbofish on enum variant construction (`Option::<Int>::Some(5)` —
   use inference or annotate the receiver).
-- `Set` literal syntax — construct via `Set.of(...)` or from an
+- `Set` literal syntax — construct via `Set.from(...)` or from an
   iterable.
 - Annotations on expressions or `use` statements — annotations apply
   only to declarations.
@@ -75,7 +75,7 @@ version, and a migration story for existing code.
 **Operator surface.**
 
 - Operator overloading **beyond** the six arithmetic operators
-  documented in §3.1 — `==` / `!=` / `<` / `<=` / `>` / `>=` use the
+  documented in §3.8 / §14.2 — `==` / `!=` / `<` / `<=` / `>` / `>=` use the
   `Equal` / `Ordered` interfaces; `[]` (indexing), `()` (call), `<<` /
   `>>` / `&` / `|` / `^` (bitwise) are primitive-only and cannot be
   overloaded. `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` /
@@ -105,7 +105,7 @@ the total ban blocked numerical code readability in realistic
 programs:
 
 - **Implicit numeric conversions** — replaced by **lossless widening
-  only** (§2.2a): `Int8 → Int16 → Int32 → Int → Float64`, `Int →
+  only** (§2.2): `Int8 → Int16 → Int32 → Int → Float64`, `Int →
   Float64`, `Float32 → Float64`. Narrowing remains explicit via
   rounding-mode-suffixed converters (`.toIntTrunc()` /
   `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` / `.toInt32()` /
@@ -113,7 +113,7 @@ programs:
   `E0765`.
 - **Operator overloading** — replaced by **six-operator opt-in** via
   `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]`
-  (binary) and `#[op(-)]` (unary) on structural methods (§3.1). All
+  (binary) and `#[op(-)]` (unary) on structural methods (§3.8 / §14.2). All
   other operators remain primitive-only (see §14.1 above).
 
 ### 14.3 Newly accepted syntax (v0.5)

--- a/LANG_SPEC_v0.5/15-iteration-protocol.md
+++ b/LANG_SPEC_v0.5/15-iteration-protocol.md
@@ -35,7 +35,7 @@ from the implementing `iter` return type.
 | `List<T>` | `T` |
 | `Set<T>` | `T` |
 | `Map<K, V>` | `(K, V)` |
-| `Range` (`a..b`, `a..=b`) | `Int` |
+| `Range` (`a..b`, `a..=b`, optional `by step`) | `Int` |
 | `Channel<T>` (§8.5) | `T` (loop ends when channel is closed and drained) |
 | `Iter<T>` (§10.7) | `T` |
 | `String.chars()` | `Char` |

--- a/LANG_SPEC_v0.5/18-change-history.md
+++ b/LANG_SPEC_v0.5/18-change-history.md
@@ -24,21 +24,21 @@ real program.
 | `loop { ... break value }` | value-returning unbounded loop | §4.4 |
 | `'label: for / loop ... break 'label` | labeled break/continue across nested loops | §4.4 |
 | `0..100 by 2` | range step (contextual `by`) | §4.4 |
-| `receiver { field: value }` | struct update shorthand (receiver-typed literal; equivalent to `Type { ..receiver, field: value }`) | §4.6 |
-| `f(x) \|y\| { body }` | trailing closure — last function-typed arg moves outside parentheses | §4.5 |
-| `err as? T` | downcast shortcut (equivalent to `err.downcast::<T>()`) | §4.9 |
+| `receiver { field: value }` | struct update shorthand (receiver-typed literal; equivalent to `Type { ..receiver, field: value }`) | §3.4 |
+| `f(x) \|y\| { body }` | trailing closure — last function-typed arg moves outside parentheses | §4.9 |
+| `err as? T` | downcast shortcut (equivalent to `err.downcast::<T>()`) | §7.4 |
 | `pub? const fn` | compile-time evaluable function; body constrained by §3.1.1 capability matrix (literals, arithmetic, acyclic const-fn calls, construction); recursion / control flow / string concat / generics forbidden | §3.1.1 |
 | `pub enum Status: Int { OK = 200, ... }` | enum with explicit integer discriminants (payload-free variants only) | §3.5 |
 | `use std.fs::{open, exists}` | scoped / grouped imports | §5 |
 | `pub use sub.Foo` | cross-module re-export | §5 |
 | `#[cfg(os = "linux")]` | conditional compilation (keys: `os` / `target` / `arch` / `feature`) | §5, §3.8 |
-| `#[op(+)] fn add(self, o: Self) -> Self` | opt-in operator overload (`+ - * / %` binary, `-` unary) | §3.1 |
+| `#[op(+)] fn add(self, o: Self) -> Self` | opt-in operator overload (`+ - * / %` binary, `-` unary) | §3.8 / §14.2 |
 | `#[test] fn ...` | inline test function — no separate `_test.osty` required | §11 |
 
 **Additions — semantics (checker / lowering).**
 
-- **Lossless numeric widening** (§2.2a). Implicit: `Int8 → Int16 → Int32 → Int → Float64`, `Int → Float64`, `Float32 → Float64`. Narrowing still requires explicit `.toInt32() / .toInt16() / .toInt8() / .toIntTrunc() / .toIntRound() / .toIntFloor() / .toIntCeil() / .toFloat32()` — `E0765` on implicit narrowing.
-- **Bounded operator overloading** (§3.1, §4.5). `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]` binary + `#[op(-)]` unary only. `== / < / > / <= / >= / != / [] / () / << / >> / & / | / ^` remain primitive-only. Duplicate `#[op]` for same operator on same type is `E0724`; non-allowed operator is `E0725`.
+- **Lossless numeric widening** (§2.2). Implicit: `Int8 → Int16 → Int32 → Int → Float64`, `Int → Float64`, `Float32 → Float64`. Narrowing still requires explicit `.toInt32()` / `.toInt16()` / `.toInt8()` / `.toIntTrunc()` / `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` / `.toFloat32()` — `E0765` on implicit narrowing.
+- **Bounded operator overloading** (§3.8, §14.2). `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]` binary + `#[op(-)]` unary only. `== / < / > / <= / >= / != / [] / () / << / >> / & / | / ^` remain primitive-only. Duplicate `#[op]` for same operator on same type is `E0724`; non-allowed operator is `E0725`.
 - **Function value keyword-name preservation** (G20). `fn(...) -> ...` carries parameter names as type-equality-neutral metadata. Keyword calls through function values allowed when names match; default-value capture still erased per G15.
 
 **Additions — stdlib.**
@@ -75,7 +75,7 @@ real program.
 
 **Changes to `§14` (excluded features).**
 
-- Removed (now allowed): "implicit numeric conversions" (replaced by lossless widening only, §2.2a), "operator overloading" (replaced by six-operator `#[op(...)]` opt-in, §3.1).
+- Removed (now allowed): "implicit numeric conversions" (replaced by lossless widening only, §2.2), "operator overloading" (replaced by six-operator `#[op(...)]` opt-in, §3.8 / §14.2).
 - Reaffirmed permanent exclusions (total 9 after v0.5): `null` / `nil`, exceptions & `try`/`catch`, inheritance, macros, user-defined annotation set, `unsafe` (user-facing), user-visible raw pointer, `[]` / `()` / bitwise operator overload, generic type-parameter defaults.
 - Removed from excluded list (now part of language): `while`/`loop` keyword (the `for cond { }` while-style existed since v0.3; `loop { break v }` is new in v0.5), labeled `break`/`continue` (new in v0.5), `const` (new in v0.5 for compile-time functions only — still no run-time immutable binding form beyond `let`).
 

--- a/LANG_SPEC_v0.5/ABRIDGED.md
+++ b/LANG_SPEC_v0.5/ABRIDGED.md
@@ -10,7 +10,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - shebang은 byte offset 0에서만 한 번 허용된다.
 - 예약어: `fn struct enum interface type let mut pub if else match for break
   continue return use defer`.
-- 문맥 식별자: `self Self true false Some None Ok Err`.
+- 문맥 식별자: `self Self true false Some None Ok Err loop const by`.
 - identifier는 ASCII letter 또는 `_`로 시작한다. 단독 `_`는 wildcard이다.
 - 세미콜론은 없다. newline이 statement separator이다.
 - `} else`와 `} else if`는 같은 물리적 줄에 둔다.
@@ -26,10 +26,13 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - function parameter type은 필수. unit return은 return type 생략 가능.
 - function body는 block expression이고 마지막 expression이 반환값이다.
 - early return은 `return`.
-- overloading은 없다.
+- function overloading은 없다. operator overloading은 `#[op(+)]`, `#[op(-)]`,
+  `#[op(*)]`, `#[op(/)]`, `#[op(%)]` binary와 unary `#[op(-)]`만 허용된다.
+- `const fn`은 default argument용 compile-time evaluable function이다. 본문은
+  §3.1.1 capability matrix 안의 literal/산술/구성/acyclic const-fn call만 쓴다.
 - default parameter는 trailing parameter에만 허용된다.
-- default value는 literal 계열, `None`, literal payload의 `Ok`/`Err`, empty
-  collection, unit만 가능하다.
+- default value는 `DefaultLiteral`: literal 계열, `None`, `Ok`/`Err`, empty
+  collection, unit, fields가 literal인 struct literal, 허용된 `const fn` call만 가능하다.
 - required parameter는 positional-only.
 - defaulted parameter는 positional 또는 keyword argument로 전달 가능.
 - positional argument는 keyword argument 뒤에 올 수 없다.
@@ -41,7 +44,8 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
   visibility와 type parameter는 모두 일치해야 한다.
 - 같은 partial type의 field/variant는 한 declaration에만 있어야 한다. method
   이름은 중복될 수 없다.
-- compiler annotation은 고정 집합이다. v0.4는 `#[json]`, `#[deprecated]`.
+- compiler annotation은 고정 집합이다: `#[json]`, `#[deprecated]`, `#[op]`,
+  `#[cfg]`, `#[test]`, optimization annotations, runtime-only annotations.
   annotation은 named declaration 앞에만 둔다.
 
 ## 3. Types
@@ -52,10 +56,12 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - `String`은 immutable UTF-8 bytes. `Bytes`는 immutable byte sequence.
 - composite: `struct`, `enum`, `interface`, tuple, function type, `List<T>`,
   `Map<K, V>`, `Set<T>`, `Option<T>`, `Result<T, E>`.
+- `Set<T>`는 있지만 set literal은 없다. `Set.from([...])`를 사용한다.
 - `T?`는 `Option<T>` sugar. formatter는 `Option<T>`를 `T?`로 정규화한다.
 - `null`/`nil`은 없다. 부재는 `Option<T>`/`T?`.
 - alias는 transparent하다. 새 nominal type이 아니다.
-- 변수 사이 numeric conversion은 암묵적으로 일어나지 않는다.
+- 변수 사이 numeric conversion은 lossless widening만 암묵적으로 허용된다. narrowing과
+  lossy conversion은 명시 method를 쓴다.
 - numeric literal만 문맥 타입으로 추론된다. 문맥이 없으면 integer는 `Int`,
   float는 `Float`.
 - arithmetic overflow, invalid shift, integer div/mod by zero는 abort한다.
@@ -95,8 +101,11 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - `for pattern in expr`은 iterable loop.
 - `for expr`은 while-style loop.
 - bare `for`는 infinite loop.
+- `loop { ... break value }`는 value-returning unbounded loop이다.
+- range step은 `a..b by step` / `a..=b by step`이다.
 - `for let pattern = expr`은 match 성공 동안 반복한다.
-- `break`/`continue`는 innermost loop에만 적용된다. label은 없다.
+- `break`/`continue`는 기본적으로 innermost loop에 적용된다. `'label: for/loop`와
+  `break 'label` / `continue 'label`이 허용된다.
 - `Type { ... }` struct literal은 `if`/`match`/`for`/`if let`/`for let` head에서
   괄호로 감싼다.
 - assignment는 statement이다. expression으로 쓰지 않는다.
@@ -106,11 +115,15 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
   family를 직접 섞지 않는다.
 - `?.`는 `Option<T>` field/method access를 short-circuit한다.
 - `??`는 left가 `None`일 때만 right를 평가한다.
+- `err as? T`는 `Error.downcast::<T>()` shortcut이다. 일반 type test가 아니다.
 - closure는 capture by reference이다. capture mutability는 binding 선언을 따른다.
+- trailing closure는 마지막 function-typed argument에만 쓴다: `f(x) |y| { ... }`.
 - closure parameter pattern은 irrefutable `LetPattern`만 허용된다. refutable
   literal/range/variant/or pattern은 `E0741`.
 - member access와 method call은 `.`만 사용한다.
 - string indexing/slicing은 Unicode scalar가 아니라 byte 단위이다.
+- Unicode scalar iteration은 built-in `String.chars()`를 쓰고, 복잡한 문자열 처리는
+  `std.strings` helper를 쓴다.
 - unsafe lookup 대신 가능하면 `get` 계열로 `Option`을 받는다.
 - `defer`는 enclosing block exit에서 LIFO 실행된다.
 - `defer`는 normal exit, `return`, loop exit, `?`, cancellation에서 실행된다.
@@ -135,6 +148,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - subpackage는 subdirectory이다.
 - import cycle은 금지된다. diamond import는 허용된다.
 - `use path`는 Osty package import.
+- `use path::{A, B as C}`와 `pub use path.Symbol`은 허용된다.
 - dotted path와 URL-like path를 혼합하지 않는다.
 - script file은 top-level statement가 있는 파일이다.
 - script top-level statement는 implicit `main() -> Result<(), Error>` 안에 있는
@@ -192,6 +206,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 
 - test file suffix는 `_test.osty`.
 - lowercase `test`로 시작하고 argument가 없는 function은 test.
+- inline `#[test] fn`도 test로 수집되고 production build에서는 제외된다.
 - lowercase `bench`로 시작하고 argument가 없는 function은 benchmark.
 - test는 production build에서 제외된다.
 - `std.testing` assertion은 compiler-known이다. 일반 macro 기능은 아니다.
@@ -204,14 +219,13 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 
 - `null`, `nil`, exceptions, `try`, `catch`, panic recovery.
 - inheritance, class, `impl`, macro, user-defined annotation.
-- operator/function overloading.
-- `while`, `loop`, C-style `for`.
-- labelled `break`/`continue`.
+- function overloading, `[]`/`()`/bitwise/comparison operator overloading.
+- `while`, C-style `for`.
 - detached spawn, `async`, `await`, `WaitGroup`.
 - lifetime annotation, variance annotation, generic parameter default.
-- implicit numeric conversion, `as` conversion keyword.
+- implicit narrowing/lossy numeric conversion, `as` conversion keyword.
 - set literal, anonymous record/struct.
-- `const`; use top-level `let`.
+- run-time `const` binding; use top-level `let`. `const fn` is allowed.
 - `unsafe`; use FFI declarations.
 - `where` clause; put constraints directly on type parameters.
 - expression annotation or `use` annotation.

--- a/OSTY_GRAMMAR_v0.5.md
+++ b/OSTY_GRAMMAR_v0.5.md
@@ -123,7 +123,7 @@ v0.5.x 패치 안에서 조용히 바뀌지 않는다.
 | O5: `_` 토큰 | **`UNDERSCORE` 별도 토큰**. maximal munch로 `_foo`는 `IDENT`. |
 | O6: `::` 엄격성 | **turbofish 전용**. `::` 다음 `<` 없으면 에러. |
 | O7: `=>` 토큰 | **완전 제거**. |
-| O1: 어노테이션 | **제한적 집합**, Rust 스타일 `#[...]`, v0.9 세트 = `#[json]` + `#[deprecated]`. |
+| O1: 어노테이션 | **제한적 집합**, Rust 스타일 `#[...]`. 초기 세트는 `#[json]` + `#[deprecated]`; v0.5 이후 확장은 R26 참조. |
 
 ---
 
@@ -135,7 +135,7 @@ v0.5.x 패치 안에서 조용히 바뀌지 않는다.
 
 | 레벨 | 연산자 | 결합성 | 비고 |
 |---|---|---|---|
-| 14 | `.` `?.` `?`(postfix) `()` `[]` `::<T>` | 좌 | postfix |
+| 14 | `.` `?.` `?`(postfix) `()` trailing closure `[]` `::<T>` `as?` | 좌 | postfix |
 | 13 | `-` `!` `~` (단항) | — | prefix |
 | 12 | `*` `/` `%` | 좌 | |
 | 11 | `+` `-` | 좌 | |
@@ -230,6 +230,9 @@ use defer
 **문맥 식별자**: 렉서 관점에서 일반 `IDENT`, 파서가 문맥에서 해석.
 - `self`, `mut self`: 메서드 첫 파라미터 위치 전용.
 - `Self`: 타입 위치에서 둘러싼 타입.
+- `loop`: `loop Block` 표현식 머리 위치 전용.
+- `const`: `const fn` 선언 prefix 위치 전용.
+- `by`: range step suffix 위치 전용 (`a..b by step`).
 - `true`, `false`, `Some`, `None`, `Ok`, `Err`: prelude 값 참조.
 
 ### R8. 문자열 보간 렉싱
@@ -331,17 +334,29 @@ UsePath := DottedPath | UrlishPath
 ### R18. 기본 인자 제약
 
 ```ebnf
-DefaultExpr ::= Literal
-              | '-' (INT_LIT | FLOAT_LIT)
-              | 'None'
-              | 'Ok' '(' Literal ')'
-              | 'Err' '(' Literal ')'
-              | '[' ']'
-              | '{' ':' '}'
-              | '(' ')'
+DefaultExpr ::= DefaultLiteral
+DefaultLiteral ::= Literal
+                 | '-' (INT_LIT | FLOAT_LIT)
+                 | 'None'
+                 | 'Ok' '(' DefaultLiteral ')'
+                 | 'Err' '(' DefaultLiteral ')'
+                 | '[' DefaultLiteralList? ']'
+                 | '{' ':' '}'
+                 | '{' DefaultMapEntries '}'
+                 | '(' ')'
+                 | '(' DefaultLiteral (',' DefaultLiteral)+ ','? ')'
+                 | DefaultStructLit
+                 | ConstFnCall
+DefaultLiteralList ::= DefaultLiteral (',' DefaultLiteral)* ','?
+DefaultMapEntries ::= DefaultLiteral ':' DefaultLiteral
+                    (',' DefaultLiteral ':' DefaultLiteral)* ','?
+DefaultStructLit ::= TypePath '{' DefaultFieldInit (',' DefaultFieldInit)* ','? '}'
+DefaultFieldInit ::= IDENT ':' DefaultLiteral
+ConstFnCall ::= TypePath '(' DefaultLiteralList? ')'
 ```
 
-임의 표현식 거부. 파서 수준에서 즉시.
+임의 표현식 거부. `ConstFnCall` 은 §3.1.1 capability matrix 와 acyclic
+call graph 검증을 통과한 `const fn` 만 허용한다.
 
 ### R19. 파셜 선언
 
@@ -407,7 +422,7 @@ ClosureParam ::= LetPattern (':' Type)?
 
 문법: `#[Name AnnotArgs?]`. 선언 앞에 0개 이상.
 
-**v0.9 허용 집합** (컴파일러 고정 세트, 사용자 정의 불가):
+**v0.5/v0.6 허용 집합** (컴파일러 고정 세트, 사용자 정의 불가):
 
 **`#[json(...)]`** — 구조체 필드 전용.
 - `key = "<name>"` — JSON 키명 재매핑.
@@ -416,15 +431,34 @@ ClosureParam ::= LetPattern (':' Type)?
 - 여러 인자 조합 가능.
 
 **`#[deprecated(...)]`** — top-level `fn`/`struct`/`enum`/`interface`/
-`type`/`let`, 그리고 struct/enum 내부 메서드.
+`type`/`let`, struct/enum 내부 메서드, struct field, enum variant.
 - `since = "<version>"` (선택).
 - `use = "<replacement>"` (선택, 대체 API 힌트).
 - `message = "<text>"` (선택).
 
+**`#[op(...)]`** — struct/enum method 전용. 허용 operator literal 은
+`+`, `-`, `*`, `/`, `%`; `-` 는 unary/binary 양쪽 의미를 가질 수 있다.
+
+**`#[cfg(...)]`** — conditional compilation. `os`, `target`, `arch`,
+`feature` key 와 `all(...)` / `any(...)` / `not(...)` 조합만 허용한다.
+
+**`#[test]`** — top-level zero-arity `fn` 전용. `osty test` 에서만 수집되고
+production build 에서는 제외된다.
+
+**Optimization annotations** — top-level `fn` 또는 struct/enum method 전용:
+`#[vectorize]`, `#[no_vectorize]`, `#[parallel]`, `#[unroll]`, `#[inline]`,
+`#[hot]`, `#[cold]`, `#[target_feature(...)]`, `#[noalias]`, `#[pure]`.
+
+**Runtime-only annotations** — privileged package 전용:
+`#[intrinsic]`, `#[pod]`, `#[repr(...)]`, `#[export("name")]`, `#[c_abi]`,
+`#[no_alloc]`.
+
 **에러 처리**: 허용 목록 외 어노테이션은 컴파일 에러:
 ```
-error: unknown annotation '#[inline]'.
-       permitted annotations: json, deprecated.
+error: unknown annotation '#[memoize]'.
+       permitted annotations: json, deprecated, op, cfg, test, vectorize,
+       no_vectorize, parallel, unroll, inline, hot, cold, target_feature,
+       noalias, pure, intrinsic, pod, repr, export, c_abi, no_alloc.
 ```
 
 **위치 검증**: `#[json]`을 함수 앞에 붙이는 등 잘못된 대상은 컴파일 에러:
@@ -455,6 +489,7 @@ TERMINATOR    ::= NEWLINE                          (* R2 ASI 후 *)
 (* 식별자 & 와일드카드 *)
 IDENT         ::= /[A-Za-z_][A-Za-z0-9_]*/         (* maximal munch *)
 UNDERSCORE    ::= '_'                              (* 단독만, IDENT와 배타 *)
+LABEL         ::= "'" IDENT                        (* loop label reference *)
 
 KEYWORD       ::= 'fn' | 'struct' | 'enum' | 'interface' | 'type'
                 | 'let' | 'mut' | 'pub'
@@ -480,7 +515,7 @@ STRING_LIT    ::= InterpStringStream               (* §R8 *)
 (* 연산자 & 구두점 *)
 PUNCT         ::= '(' | ')' | '[' | ']' | '{' | '}'
                 | ',' | ':' | '::' | '.' | '?.' | '?' | '@'
-                | '->' | '<-'
+                | '->' | '<-' | 'as?'
                 | '..' | '..='
                 | '+' | '-' | '*' | '/' | '%'
                 | '==' | '!=' | '<' | '>' | '<=' | '>='
@@ -521,16 +556,28 @@ TopLevelStmt  ::= Stmt
 (* 어노테이션 *)
 Annotation    ::= '#' '[' IDENT AnnotationArgs? ']'
 AnnotationArgs ::= '(' AnnotationArg (',' AnnotationArg)* ','? ')'
-AnnotationArg ::= IDENT                            (* flag *)
-                | IDENT '=' Literal                (* 키=값 *)
+AnnotationArg ::= CfgCall                          (* #[cfg(all(...))] 등 *)
+                | OperatorLit                      (* #[op(+)] 등 *)
+                | IDENT '=' Literal                (* 키=값; cfg leaf 포함 *)
+                | IDENT                            (* flag *)
+                | Literal                          (* #[export("name")] 등 *)
+OperatorLit   ::= '+' | '-' | '*' | '/' | '%'
+CfgCall       ::= 'all' '(' CfgExpr (',' CfgExpr)* ','? ')'
+                | 'any' '(' CfgExpr (',' CfgExpr)* ','? ')'
+                | 'not' '(' CfgExpr ')'
+CfgExpr       ::= IDENT '=' STRING_LIT
+                | CfgCall
 ```
 
 ### 2.3 Use 선언
 
 ```ebnf
-UseDecl       ::= 'use' (OstyUse | GoUse)
+UseDecl       ::= 'pub'? 'use' OstyUse
+                | 'use' (GoUse | CUse)
 
 OstyUse       ::= UsePath ('as' IDENT)?
+                | UsePath '::' '{' UseSpec (',' UseSpec)* ','? '}'
+UseSpec       ::= IDENT ('as' IDENT)?
 UsePath       ::= DottedPath | UrlishPath
 DottedPath    ::= IDENT ('.' IDENT)*
 UrlishPath    ::= DomainSeg '/' PathSeg ('/' PathSeg)*
@@ -538,6 +585,9 @@ DomainSeg     ::= IDENT ('.' IDENT)+
 PathSeg       ::= IDENT
 
 GoUse         ::= 'go' STRING_LIT ('as' IDENT)? '{' TERM*
+                    (GoDecl (TERM+ GoDecl)*)? TERM*
+                  '}'
+CUse          ::= 'c' STRING_LIT ('as' IDENT)? '{' TERM*
                     (GoDecl (TERM+ GoDecl)*)? TERM*
                   '}'
 GoDecl        ::= GoFnDecl | GoStructDecl
@@ -574,7 +624,7 @@ TypeList      ::= Type (',' Type)* ','?
 ### 2.5 함수 선언
 
 ```ebnf
-FnDecl        ::= 'pub'? 'fn' IDENT GenericParams?
+FnDecl        ::= 'pub'? 'const'? 'fn' IDENT GenericParams?
                   '(' ParamList? ')' ('->' Type)? Block
 
 GenericParams ::= '<' GenericParam (',' GenericParam)* ','? '>'
@@ -586,14 +636,25 @@ ParamList     ::= SelfParam (',' Param)* ','?
 SelfParam     ::= 'mut'? 'self'
 Param         ::= IDENT ':' Type ('=' DefaultExpr)?
 
-DefaultExpr   ::= Literal
-                | '-' (INT_LIT | FLOAT_LIT)
-                | 'None'
-                | 'Ok' '(' Literal ')'
-                | 'Err' '(' Literal ')'
-                | '[' ']'
-                | '{' ':' '}'
-                | '(' ')'
+DefaultExpr   ::= DefaultLiteral
+DefaultLiteral ::= Literal
+                 | '-' (INT_LIT | FLOAT_LIT)
+                 | 'None'
+                 | 'Ok' '(' DefaultLiteral ')'
+                 | 'Err' '(' DefaultLiteral ')'
+                 | '[' DefaultLiteralList? ']'
+                 | '{' ':' '}'
+                 | '{' DefaultMapEntries '}'
+                 | '(' ')'
+                 | '(' DefaultLiteral (',' DefaultLiteral)+ ','? ')'
+                 | DefaultStructLit
+                 | ConstFnCall
+DefaultLiteralList ::= DefaultLiteral (',' DefaultLiteral)* ','?
+DefaultMapEntries ::= DefaultLiteral ':' DefaultLiteral
+                    (',' DefaultLiteral ':' DefaultLiteral)* ','?
+DefaultStructLit ::= TypePath '{' DefaultFieldInit (',' DefaultFieldInit)* ','? '}'
+DefaultFieldInit ::= IDENT ':' DefaultLiteral
+ConstFnCall ::= TypePath '(' DefaultLiteralList? ')'
 ```
 
 ### 2.6 Struct / Enum / Interface
@@ -611,13 +672,13 @@ FieldDecl     ::= 'pub'? IDENT ':' Type ('=' DefaultExpr)?
 MethodDecl    ::= 'pub'? 'fn' IDENT GenericParams?
                   '(' ParamList? ')' ('->' Type)? Block
 
-EnumDecl      ::= 'pub'? 'enum' IDENT GenericParams? '{' TERM*
+EnumDecl      ::= 'pub'? 'enum' IDENT GenericParams? (':' TypePath)? '{' TERM*
                     EnumMembers? TERM*
                   '}'
 EnumMembers   ::= EnumMember (MemberSep EnumMember)*
 EnumMember    ::= Annotation* VariantDecl
                 | Annotation* MethodDecl
-VariantDecl   ::= IDENT ('(' TypeList ')')?
+VariantDecl   ::= IDENT ('(' TypeList ')')? ('=' INT_LIT)?
 
 InterfaceDecl ::= 'pub'? 'interface' IDENT GenericParams? '{' TERM*
                     IfaceMembers? TERM*
@@ -668,8 +729,9 @@ AssignOp      ::= '=' | '+=' | '-=' | '*=' | '/=' | '%='
 SendStmt      ::= Expr '<-' Expr
 DeferStmt     ::= 'defer' (Expr | Block)
 ReturnStmt    ::= 'return' Expr?
-BreakStmt     ::= 'break'
-ContinueStmt  ::= 'continue'
+BreakStmt     ::= 'break' LabelRef? Expr?
+ContinueStmt  ::= 'continue' LabelRef?
+LabelRef      ::= LABEL
 ExprStmt      ::= Expr
 ```
 
@@ -686,9 +748,10 @@ LogicalOrExpr    ::= LogicalAndExpr ('||' LogicalAndExpr)*
 LogicalAndExpr   ::= CompareExpr ('&&' CompareExpr)*
 CompareExpr      ::= RangeExpr (CompareOp RangeExpr)?       (* non-assoc *)
 CompareOp        ::= '==' | '!=' | '<' | '>' | '<=' | '>='
-RangeExpr        ::= BitOrExpr (('..' | '..=') BitOrExpr)?  (* non-assoc *)
-                   | ('..' | '..=') BitOrExpr               (* prefix open *)
-                   | BitOrExpr ('..' | '..=')               (* postfix open *)
+RangeExpr        ::= BitOrExpr RangeTail?                   (* non-assoc *)
+                   | ('..' | '..=') BitOrExpr RangeStep?    (* prefix open *)
+RangeTail        ::= ('..' | '..=') BitOrExpr? RangeStep?
+RangeStep        ::= 'by' BitOrExpr
 BitOrExpr        ::= BitXorExpr ('|' BitXorExpr)*
 BitXorExpr       ::= BitAndExpr ('^' BitAndExpr)*
 BitAndExpr       ::= ShiftExpr ('&' ShiftExpr)*
@@ -701,10 +764,11 @@ PostfixExpr      ::= PrimaryExpr PostfixOp*
 PostfixOp        ::= '.' IDENT                    (* field/method name *)
                    | '?.' IDENT
                    | '?'                           (* propagate *)
-                   | '(' ArgList? ')'              (* call *)
+                   | '(' ArgList? ')' ClosureExpr? (* call + optional trailing closure *)
                    | '[' Expr ']'                  (* index *)
                    | '[' RangeExpr ']'             (* slice *)
                    | '::' TypeArgs                 (* turbofish — '<' 필수 *)
+                   | 'as?' Type                    (* checked downcast *)
 
 PrimaryExpr      ::= Literal
                    | IDENT
@@ -716,6 +780,7 @@ PrimaryExpr      ::= Literal
                    | IfExpr
                    | MatchExpr
                    | ForExpr
+                   | LoopExpr
                    | Block
                    | ClosureExpr
 
@@ -755,11 +820,13 @@ MatchExpr     ::= 'match' RestrictedExpr '{' TERM*
 ArmSep        ::= ',' TERM*
 MatchArm      ::= Pattern ('if' Expr)? '->' (Expr | Block)
 
-ForExpr       ::= 'for' ForHead Block
-                | 'for' 'let' LetPattern '=' RestrictedExpr Block
-                | 'for' Block                      (* infinite *)
+ForExpr       ::= LabelPrefix? 'for' ForHead Block
+                | LabelPrefix? 'for' 'let' LetPattern '=' RestrictedExpr Block
+                | LabelPrefix? 'for' Block         (* infinite, Unit result *)
 ForHead       ::= LetPattern 'in' RestrictedExpr
                 | RestrictedExpr                   (* while-style *)
+LoopExpr      ::= LabelPrefix? 'loop' Block        (* value-returning *)
+LabelPrefix   ::= LABEL ':'
 
 (* R3: StructLit이 금지된 식 위치. 파서가 flag로 관리 *)
 RestrictedExpr ::= Expr                            (* StructLit 거부 *)


### PR DESCRIPTION
## Summary
- Align v0.5 spec text, ABRIDGED, and grammar EBNF for accepted loop labels, const fn, cfg/test/op annotations, and related syntax.
- Clarify Set construction, String.chars, lossless widening references, and error-code section refs.

## Test plan
- [x] git diff --check
- [ ] just prepush (aborted by request before completion)