### PR TITLE
fix: stdlib abort 인자 버그, Bytes 인덱싱/Set in 연산자 미지원

### DIFF
--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -1,3 +1,5 @@
+use std.process
+
 // std.collections — List<T>, Map<K, V>, Set<T>.
 //
 // These names are already auto-imported via the prelude, so user code
@@ -164,7 +166,7 @@ pub struct List<T> {
     /// `size <= 0` aborts.
     pub fn chunked(self, size: Int) -> List<List<T>> {
         if size <= 0 {
-            abort("List.chunked: size must be positive, got {size}")
+            process.abort("List.chunked: size must be positive, got {size}")
         }
         let mut out: List<List<T>> = []
         let mut bucket: List<T> = []
@@ -187,10 +189,10 @@ pub struct List<T> {
     /// result is empty.
     pub fn windowed(self, size: Int, step: Int) -> List<List<T>> {
         if size <= 0 {
-            abort("List.windowed: size must be positive, got {size}")
+            process.abort("List.windowed: size must be positive, got {size}")
         }
         if step <= 0 {
-            abort("List.windowed: step must be positive, got {step}")
+            process.abort("List.windowed: step must be positive, got {step}")
         }
         let mut out: List<List<T>> = []
         let n = self.len()

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1008,6 +1008,7 @@ fn elabForIterableElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
         }
     }
     if tyIsNamedHead(tys, resolved, "List")
+        || tyIsNamedHead(tys, resolved, "Set")
         || tyIsNamedHead(tys, resolved, "Range")
         || tyIsNamedHead(tys, resolved, "Chan")
         || tyIsNamedHead(tys, resolved, "Channel")
@@ -2829,6 +2830,14 @@ fn elabInferIndex(cx: ElabCx, node: AstNode) -> ElabResult {
             let coreIdx = coreIndex(cx.core, recv.node, idx.node, valTy, node.start, node.end)
             return ElabResult { node: coreIdx, ty: valTy }
         }
+    }
+    // Bytes[Int] → Byte
+    if tyIsPrim(tys, recvTy, PkBytes) {
+        if !(checkIsAssignable(cx.env, tInt(tys), idx.ty)) {
+            cx.env.local.diagnostics.push(diagMismatch("Int", tyToString(tys, idx.ty), node.start, node.end))
+        }
+        let coreIdx = coreIndex(cx.core, recv.node, idx.node, tByte(tys), node.start, node.end)
+        return ElabResult { node: coreIdx, ty: tByte(tys) }
     }
     // String[Int] → Char, String[Range<Int>] → String (slice)
     if tyIsPrim(tys, recvTy, PkString) {


### PR DESCRIPTION
## Summary
- `collections.osty`: `abort(msg)` → `process.abort(msg)` (내장 abort는 인자 없음, 3곳 수정 + `use std.process` 추가)
- `toolchain/elab.osty`: `elabInferIndex`에 `Bytes[Int] → Byte` 케이스 추가 (기존 List/Map/String만 지원)
- `toolchain/elab.osty`: `elabForIterableElemTy`에 `Set` 추가하여 `for item in set` / `item in set` 지원

## Test plan
- [x] `gofmt` / `go vet` / `go build` 통과
- [x] 변경 파일 `osty repair --check` 통과
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)