### PR TITLE
feat: route LLVM MIR payloads through native generator

### DIFF
--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,9 @@ import (
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/mirjson"
+	"github.com/osty/osty/internal/nativelirproto"
 	"github.com/osty/osty/internal/nativellvmgen"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
@@ -17,6 +21,7 @@ import (
 type llvmgenRequest = nativellvmgen.Request
 type llvmgenPackageInput = nativellvmgen.PackageInput
 type llvmgenPackageFile = nativellvmgen.PackageFile
+type llvmgenMIRInput = nativellvmgen.MIRInput
 type llvmgenResponse = nativellvmgen.Response
 
 func main() {
@@ -30,6 +35,9 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	var req llvmgenRequest
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode llvmgen request: %w", err)
+	}
+	if req.MIR != nil {
+		return runMIRRequest(req, stdout)
 	}
 	var (
 		entry backend.Entry
@@ -55,6 +63,62 @@ func run(stdin io.Reader, stdout io.Writer) error {
 		resp.LLVMIR = string(ir)
 	}
 	return json.NewEncoder(stdout).Encode(resp)
+}
+
+func runMIRRequest(req llvmgenRequest, stdout io.Writer) error {
+	if req.MIR.Module == nil {
+		return fmt.Errorf("decode MIR llvmgen request: missing module")
+	}
+	mod, err := mirjson.ToModule(req.MIR.Module)
+	if err != nil {
+		return fmt.Errorf("decode MIR llvmgen request: %w", err)
+	}
+	warnings := []string(nil)
+	if ir, lirWarnings, ok := tryMIRRequestViaLIRProto(req); ok {
+		return json.NewEncoder(stdout).Encode(llvmgenResponse{Covered: true, LLVMIR: string(ir), Warnings: lirWarnings})
+	} else {
+		warnings = append(warnings, lirWarnings...)
+	}
+	ir, err := llvmgen.GenerateFromMIR(mod, llvmgen.Options{
+		PackageName: req.MIR.PackageName,
+		SourcePath:  req.MIR.SourcePath,
+		Source:      []byte(req.MIR.Source),
+		Target:      req.MIR.Target,
+		EmitGC:      true,
+	})
+	resp := llvmgenResponse{Covered: err == nil}
+	if err != nil {
+		if errors.Is(err, llvmgen.ErrUnsupported) {
+			resp.Warnings = append(warnings, err.Error())
+			return json.NewEncoder(stdout).Encode(resp)
+		}
+		return fmt.Errorf("emit MIR llvm-ir: %w", err)
+	}
+	resp.LLVMIR = string(ir)
+	resp.Warnings = warnings
+	return json.NewEncoder(stdout).Encode(resp)
+}
+
+func tryMIRRequestViaLIRProto(req llvmgenRequest) ([]byte, []string, bool) {
+	if !llvmgen.LIRProtoSelected() || req.MIR == nil || req.MIR.Source == "" {
+		return nil, nil, false
+	}
+	resp, err := nativelirproto.Run(req.MIR.SourcePath, nativelirproto.Request{
+		PackageName: req.MIR.PackageName,
+		SourcePath:  req.MIR.SourcePath,
+		Source:      req.MIR.Source,
+		Target:      req.MIR.Target,
+	})
+	if err != nil {
+		return nil, []string{err.Error()}, false
+	}
+	if resp.Error != "" {
+		return nil, []string{resp.Error}, false
+	}
+	if resp.Declined || resp.LLVMIR == "" {
+		return nil, nil, false
+	}
+	return []byte(resp.LLVMIR), nil, true
 }
 
 func prepareSourceEntry(req llvmgenRequest) (backend.Entry, error) {

--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -3,10 +3,22 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/check"
 	ostyir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mirjson"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 func runLLVMGenSource(t *testing.T, path string, source string) llvmgenResponse {
@@ -79,6 +91,225 @@ func TestRunEmitsNativeOwnedLLVMIRForPackage(t *testing.T) {
 		t.Fatalf("llvmIr missing main symbol:\n%s", resp.LLVMIR)
 	}
 }
+
+func TestRunEmitsLLVMIRForMIRPayload(t *testing.T) {
+	entry := prepareMIRPayloadEntry(t, "fn main() -> Int { 7 }\n")
+	payload, err := mirjson.FromModule(entry.MIR)
+	if err != nil {
+		t.Fatalf("encode MIR: %v", err)
+	}
+	reqBody, err := json.Marshal(llvmgenRequest{
+		Path: entry.SourcePath,
+		MIR: &llvmgenMIRInput{
+			PackageName: entry.PackageName,
+			SourcePath:  entry.SourcePath,
+			Source:      string(entry.Source),
+			Module:      payload,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true; warnings=%v", resp.Warnings)
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @main()") || !strings.Contains(resp.LLVMIR, "store i64 7") {
+		t.Fatalf("llvmIr missing MIR-emitted main return:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunMIRPayloadPrefersLIRProtoWhenSelected(t *testing.T) {
+	bin := buildFakeNativeLIRProto(t)
+	capture := filepath.Join(t.TempDir(), "lir-request.json")
+	t.Setenv("OSTY_LLVM_LIR_PROTO", "1")
+	t.Setenv("OSTY_NATIVE_LIRPROTO_BIN", bin)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_CAPTURE", capture)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_RESPONSE", `{"llvmIr":"; lir-proto\ndefine i64 @main() { ret i64 99 }\n"}`)
+
+	entry := prepareMIRPayloadEntry(t, "fn main() -> Int { 7 }\n")
+	payload, err := mirjson.FromModule(entry.MIR)
+	if err != nil {
+		t.Fatalf("encode MIR: %v", err)
+	}
+	reqBody, err := json.Marshal(llvmgenRequest{
+		Path: entry.SourcePath,
+		MIR: &llvmgenMIRInput{
+			PackageName: entry.PackageName,
+			SourcePath:  entry.SourcePath,
+			Source:      string(entry.Source),
+			Target:      "x86_64-unknown-linux-gnu",
+			Module:      payload,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered || !strings.Contains(resp.LLVMIR, "ret i64 99") {
+		t.Fatalf("response did not use LIR Proto IR: %#v", resp)
+	}
+	var lirReq struct {
+		PackageName string `json:"packageName"`
+		SourcePath  string `json:"sourcePath"`
+		Source      string `json:"source"`
+		Target      string `json:"target"`
+	}
+	decodeCapturedLIRRequest(t, capture, &lirReq)
+	if lirReq.PackageName != "main" || lirReq.SourcePath != entry.SourcePath || lirReq.Source == "" || lirReq.Target != "x86_64-unknown-linux-gnu" {
+		t.Fatalf("captured LIR request = %#v", lirReq)
+	}
+}
+
+func TestRunMIRPayloadFallsBackWhenLIRProtoDeclines(t *testing.T) {
+	bin := buildFakeNativeLIRProto(t)
+	t.Setenv("OSTY_LLVM_LIR_PROTO", "1")
+	t.Setenv("OSTY_NATIVE_LIRPROTO_BIN", bin)
+	t.Setenv("FAKE_NATIVE_LIRPROTO_RESPONSE", `{"declined":true,"error":"not ready"}`)
+
+	entry := prepareMIRPayloadEntry(t, "fn main() -> Int { 7 }\n")
+	payload, err := mirjson.FromModule(entry.MIR)
+	if err != nil {
+		t.Fatalf("encode MIR: %v", err)
+	}
+	reqBody, err := json.Marshal(llvmgenRequest{
+		Path: entry.SourcePath,
+		MIR: &llvmgenMIRInput{
+			PackageName: entry.PackageName,
+			SourcePath:  entry.SourcePath,
+			Source:      string(entry.Source),
+			Module:      payload,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered || !strings.Contains(resp.LLVMIR, "store i64 7") {
+		t.Fatalf("fallback did not emit Go MIR IR: %#v", resp)
+	}
+	if len(resp.Warnings) == 0 || !strings.Contains(resp.Warnings[0], "not ready") {
+		t.Fatalf("fallback warnings = %#v, want decline reason", resp.Warnings)
+	}
+}
+
+func prepareMIRPayloadEntry(t *testing.T, src string) backend.Entry {
+	t.Helper()
+	file, diags := parser.ParseDiagnostics([]byte(src))
+	if len(diags) != 0 {
+		t.Fatalf("parse diagnostics: %v", diags)
+	}
+	reg := stdlib.LoadCached()
+	res := resolve.ResolveFileSourceDefault([]byte(src), file, reg)
+	chk := check.SelfhostFile(file, res, check.Opts{
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	entry, err := backend.PrepareEntry("main", "/tmp/mir_payload.osty", file, res, chk)
+	if err != nil {
+		t.Fatalf("PrepareEntry: %v", err)
+	}
+	entry.Source = []byte(src)
+	return entry
+}
+
+var (
+	fakeNativeLIRProtoOnce sync.Once
+	fakeNativeLIRProtoPath string
+	fakeNativeLIRProtoErr  error
+)
+
+func buildFakeNativeLIRProto(t *testing.T) string {
+	t.Helper()
+	fakeNativeLIRProtoOnce.Do(func() {
+		fakeNativeLIRProtoPath, fakeNativeLIRProtoErr = buildFakeNativeLIRProtoOnce()
+	})
+	if fakeNativeLIRProtoErr != nil {
+		t.Fatal(fakeNativeLIRProtoErr)
+	}
+	return fakeNativeLIRProtoPath
+}
+
+func buildFakeNativeLIRProtoOnce() (string, error) {
+	dir, err := os.MkdirTemp("", "fake-native-lirproto-*")
+	if err != nil {
+		return "", fmt.Errorf("mktemp: %w", err)
+	}
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(fakeNativeLIRProtoProgram), 0o644); err != nil {
+		return "", fmt.Errorf("write fake native lirproto: %w", err)
+	}
+	name := "fake-native-lirproto"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("go build fake native lirproto: %w\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func decodeCapturedLIRRequest(t *testing.T, path string, out any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+const fakeNativeLIRProtoProgram = `package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	if capture := os.Getenv("FAKE_NATIVE_LIRPROTO_CAPTURE"); capture != "" {
+		if err := os.WriteFile(capture, data, 0o644); err != nil {
+			panic(err)
+		}
+	}
+	resp := os.Getenv("FAKE_NATIVE_LIRPROTO_RESPONSE")
+	if resp == "" {
+		resp = ` + "`" + `{"declined":true,"error":"fake response missing"}` + "`" + `
+	}
+	os.Stdout.WriteString(resp)
+}
+`
 
 func TestRunEmitsNativeOwnedLLVMIRForStructFieldAssign(t *testing.T) {
 	var stdout bytes.Buffer

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -168,7 +168,9 @@ func TestPrepareGenBackendEntryUsesPackageLoweringForSingleFile(t *testing.T) {
 	}
 }
 
-func TestEmitGenArtifactUsesNativeOwnedFastPathWhenCovered(t *testing.T) {
+func TestEmitGenArtifactUsesMIRPayloadBackendForPrimitiveLoop(t *testing.T) {
+	t.Setenv("OSTY_LLVM_LIR_PROTO", "0")
+
 	dir := t.TempDir()
 	target := writeGenTestFile(t, dir, "main.osty", `fn pick(flag: Bool) -> Int {
     if flag {
@@ -198,30 +200,26 @@ fn main() {
 		return nil, false, nil, nil
 	}
 	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
-	backendEntry, err := prepareGenBackendEntry("main", entry)
-	if err != nil {
-		t.Fatalf("prepareGenBackendEntry() error = %v", err)
-	}
-	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for primitive slice")
-	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
 	if err != nil {
 		t.Fatalf("emitGenArtifact() error = %v", err)
 	}
-	if string(got) != string(want) {
-		t.Fatalf("gen llvm-ir did not use native fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	for _, want := range []string{
+		"osty LLVM MIR backend",
+		"define i64 @pick",
+		"define i32 @main",
+		"call i64 @pick",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("MIR payload llvm-ir missing %q:\n%s", want, got)
+		}
 	}
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if len(result.Warnings) != len(warnings) {
-		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", result.Warnings)
 	}
 }
 
@@ -252,7 +250,9 @@ func TestEmitGenArtifactUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
 	}
 }
 
-func TestEmitGenArtifactUsesNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
+func TestEmitGenArtifactUsesMIRPayloadBackendForStructFieldAssign(t *testing.T) {
+	t.Setenv("OSTY_LLVM_LIR_PROTO", "0")
+
 	dir := t.TempDir()
 	target := writeGenTestFile(t, dir, "main.osty", `struct Pair { left: Int, right: Int }
 
@@ -272,17 +272,6 @@ fn main() {
 		return nil, false, nil, nil
 	}
 	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
-	backendEntry, err := prepareGenBackendEntry("main", entry)
-	if err != nil {
-		t.Fatalf("prepareGenBackendEntry() error = %v", err)
-	}
-	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for struct field assignment")
-	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
 	if err != nil {
@@ -291,15 +280,24 @@ fn main() {
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if string(got) != string(want) {
-		t.Fatalf("gen llvm-ir did not use native struct-field fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	for _, want := range []string{
+		"osty LLVM MIR backend",
+		"%Pair = type",
+		"insertvalue %Pair",
+		"extractvalue %Pair",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("MIR payload llvm-ir missing %q:\n%s", want, got)
+		}
 	}
-	if len(result.Warnings) != len(warnings) {
-		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", result.Warnings)
 	}
 }
 
-func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
+func TestEmitGenArtifactUsesMIRPayloadBackendForListIndex(t *testing.T) {
+	t.Setenv("OSTY_LLVM_LIR_PROTO", "0")
+
 	dir := t.TempDir()
 	target := writeGenTestFile(t, dir, "main.osty", `fn main() {
     let xs = [1, 2]
@@ -316,17 +314,6 @@ func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
 		return nil, false, nil, nil
 	}
 	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
-	backendEntry, err := prepareGenBackendEntry("main", entry)
-	if err != nil {
-		t.Fatalf("prepareGenBackendEntry() error = %v", err)
-	}
-	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for list index")
-	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
 	if err != nil {
@@ -335,11 +322,18 @@ func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if string(got) != string(want) {
-		t.Fatalf("gen llvm-ir did not use native list fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	for _, want := range []string{
+		"osty LLVM MIR backend",
+		"@osty_rt_list_new",
+		"@osty_rt_list_push_i64",
+		"@osty_rt_list_get_i64",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("MIR payload llvm-ir missing %q:\n%s", want, got)
+		}
 	}
-	if len(result.Warnings) != len(warnings) {
-		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", result.Warnings)
 	}
 }
 

--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -68,7 +68,7 @@ source
   → mir.Lower        (HIR → MIR)              ⟵ Stage 1 landed
   → mir.Validate     (MIR invariants)         ⟵ Stage 1 landed
   → backend dispatch (Stage 4 full-coverage contract):
-      native-owned fast path may emit directly from Entry.IR
+      native-owned fast path may emit from Entry.MIR via managed subprocess
       otherwise llvmgen.GenerateFromMIR(Entry.MIR, opts)
       MIR lowering / validation issues fail PrepareEntry
       GenerateFromMIR unsupported shapes render the normal unsupported skeleton
@@ -129,7 +129,7 @@ for local diagnosis.
 | Route | When it is selected | Expected result | Guard |
 |-------|---------------------|-----------------|-------|
 | `unsupported-preflight` | `UnsupportedDiagnosticForModule` rejects source-level backend gaps before concrete emitter selection | Skeleton LLVM IR + `ErrLLVMNotImplemented`; no legacy retry | `TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug` |
-| `native-owned` | default LLVM emit modes when the feature set allows it and no injected stdlib bodies are present | Full LLVM IR from `TryGenerateNativeOwnedModule`; decline falls through to MIR-direct | `TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered`, `TestTryEmitNativeOwnedLLVMIRText*` |
+| `native-owned` | default LLVM emit modes when the feature set allows it, MIR is available, and no injected stdlib bodies are present | Full LLVM IR from managed `nativellvmgen.TryMIR` payload emission; decline falls through to MIR-direct | `TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered`, `TestTryEmitNativeOwnedLLVMIRText*` |
 | `mir-direct` | every remaining normal backend request after native-owned declines, including malformed entries with missing MIR | Full LLVM IR from `GenerateFromMIR`, or skeleton + `backend-route: mir-direct` on unsupported shape | `TestLLVMBackendDispatchTraceReportsSelectedRoute`, `TestLLVMBackendMissingMIRDoesNotRetryLegacyIRBridge`, `TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics`, `TestNativeToolchainMergedMIRPipelineIsClean` |
 
 Route changes must update this table, `internal/backend/doc.go`, and any

--- a/internal/backend/capability.go
+++ b/internal/backend/capability.go
@@ -256,19 +256,19 @@ func appendMIRLoweringCapabilities(rows []CapabilityRow, entry Entry) []Capabili
 
 func appendLLVMRouteCapabilities(rows []CapabilityRow, entry Entry, opts llvmgen.Options, features []string, emit EmitMode, includeNativeRoute bool) []CapabilityRow {
 	hirReady := entry.IR != nil
+	mirReady := entry.MIR != nil
 	if includeNativeRoute {
-		nativeReady := hirReady && useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR)
+		nativeReady := hirReady && mirReady && useNativeOwnedLLVMIR(features, emit) && !hasInjectedStdlibBodies(entry.IR)
 		rows = append(rows, CapabilityRow{
 			ID:              CapabilityNativeOwned,
 			Subject:         string(llvmDispatchNativeOwned),
 			HIRSupported:    hirReady,
-			MIRLowerable:    false,
+			MIRLowerable:    mirReady,
 			LLVMEmittable:   nativeReady,
 			FallbackAllowed: true,
 			Route:           string(llvmDispatchNativeOwned),
 		})
 	}
-	mirReady := entry.MIR != nil
 	rows = append(rows, CapabilityRow{
 		ID:                 CapabilityMIRDirect,
 		Subject:            string(llvmDispatchMIRDirect),

--- a/internal/backend/capability_test.go
+++ b/internal/backend/capability_test.go
@@ -257,8 +257,8 @@ func TestLLVMCapabilityMatrixRecordsNativeOwnedRoute(t *testing.T) {
 	if !ok {
 		t.Fatal("native-owned row missing")
 	}
-	if !row.HIRSupported || row.MIRLowerable || !row.LLVMEmittable || !row.FallbackAllowed {
-		t.Fatalf("native-owned row = %+v, want HIR-only route with fallback allowed", row)
+	if !row.HIRSupported || !row.MIRLowerable || !row.LLVMEmittable || !row.FallbackAllowed {
+		t.Fatalf("native-owned row = %+v, want HIR+MIR route with fallback allowed", row)
 	}
 	if !matrix.CanRoute(llvmDispatchNativeOwned) {
 		t.Fatal("CanRoute(native-owned) = false, want true")

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -17,8 +17,9 @@
 //   - `unsupported-preflight`: capability preflight rejects backend gaps
 //     such as Go FFI or unknown runtime FFI before any concrete emitter is
 //     selected.
-//   - `native-owned`: the native-owned llvmgen slice gets the first chance
-//     when the feature set allows it and no injected stdlib bodies are present.
+//   - `native-owned`: the managed native LLVM generator gets the first chance
+//     with a MIR payload when the feature set allows it, MIR is available, and
+//     no injected stdlib bodies are present.
 //   - `mir-direct`: every remaining normal backend request routes through
 //     MIR-direct emission; MIR route blockers are read from the same
 //     capability matrix before emission.

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/nativellvmgen"
 )
 
 // ErrLLVMNotImplemented marks source shapes that the early LLVM lowering slice
@@ -83,6 +84,10 @@ func TryEmitNativeOwnedLLVMIRText(entry Entry, target string) ([]byte, bool, []e
 		return out, ok, warnings, err
 	}
 	return out, true, warnings, nil
+}
+
+var tryNativeOwnedMIRPayloadLLVMIRText = func(entry Entry, target string) ([]byte, bool, []error, error) {
+	return nativellvmgen.TryMIR(".", entry.PackageName, entry.SourcePath, entry.Source, entry.MIR, target)
 }
 
 // EmitPrebuiltLLVMIR materializes already-generated LLVM IR into the standard
@@ -200,9 +205,8 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	}
 	if capabilities.CanRoute(llvmDispatchNativeOwned) {
 		traceLLVMDispatch("%s try package=%s source=%s emit=%s target=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath, emit, target)
-		if out, ok, nativeWarnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
+		if out, ok, nativeWarnings, err := tryNativeOwnedMIRPayloadLLVMIRText(entry, target); err != nil {
 			traceLLVMDispatch("%s error: %v", llvmDispatchNativeOwned, err)
-			return nil, append(warnings, nativeWarnings...), err
 		} else if ok {
 			traceLLVMDispatch("%s covered package=%s source=%s", llvmDispatchNativeOwned, entry.PackageName, entry.SourcePath)
 			// Carry both the outer warnings (entry IRIssues + Phase-7

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -349,8 +349,9 @@ func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
     println(1)
 }
 `)
+	req.Features = []string{"mir-backend"}
 
-	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", req.Features)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
@@ -368,6 +369,63 @@ func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
 	if len(warnings) != len(result.Warnings) {
 		t.Fatalf("warning count = %d, want %d", len(warnings), len(result.Warnings))
 	}
+}
+
+func TestEmitLLVMIRTextUsesNativeMIRPayloadWhenCovered(t *testing.T) {
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		if entry.PackageName != "main" || entry.SourcePath != req.Entry.SourcePath || target != "wasm32-unknown-unknown" {
+			t.Fatalf("native-owned route metadata = (%q, %q, %q), want request metadata", entry.PackageName, entry.SourcePath, target)
+		}
+		return []byte("; native mir payload llvm ir\n"), true, []error{errors.New("native warning")}, nil
+	})
+
+	got, warnings, err := EmitLLVMIRText(req.Entry, "wasm32-unknown-unknown", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if string(got) != "; native mir payload llvm ir\n" {
+		t.Fatalf("EmitLLVMIRText did not use native MIR payload output: %q", got)
+	}
+	if len(warnings) != 1 || warnings[0].Error() != "native warning" {
+		t.Fatalf("warnings = %#v, want native warning", warnings)
+	}
+}
+
+func TestEmitLLVMIRTextFallsBackWhenNativeMIRPayloadDeclines(t *testing.T) {
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("declined")}, nil
+	})
+
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !strings.Contains(string(got), "osty LLVM MIR backend") {
+		t.Fatalf("native MIR payload decline did not fall back to MIR-direct:\n%s", got)
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want entry warning count %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func withNativeMIRPayloadEmitter(t *testing.T, fn func(Entry, string) ([]byte, bool, []error, error)) {
+	t.Helper()
+	oldTry := tryNativeOwnedMIRPayloadLLVMIRText
+	tryNativeOwnedMIRPayloadLLVMIRText = fn
+	t.Cleanup(func() { tryNativeOwnedMIRPayloadLLVMIRText = oldTry })
 }
 
 func TestEmitPrebuiltLLVMIRBuildsArtifactsFromProvidedIR(t *testing.T) {
@@ -551,8 +609,6 @@ fn dot(xs: List<Int>, ys: List<Int>) -> Int {
 }
 
 func TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered(t *testing.T) {
-	t.Parallel()
-
 	req := newBackendRequest(t, EmitLLVMIR, `fn pick(flag: Bool) -> Int {
     if flag {
         42
@@ -571,14 +627,16 @@ fn main() {
     println(sum)
 }
 `)
+	want := []byte("; native primitive-slice mir payload llvm ir\n")
+	warnings := []error{errors.New("native primitive-slice warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
@@ -592,8 +650,6 @@ fn main() {
 }
 
 func TestEmitLLVMIRTextPrefersNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
-	t.Parallel()
-
 	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
 
 fn main() {
@@ -602,14 +658,16 @@ fn main() {
     println(pair.left)
 }
 `)
+	want := []byte("; native struct-field mir payload llvm ir\n")
+	warnings := []error{errors.New("native struct-field warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for struct field assignment")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
@@ -623,21 +681,21 @@ fn main() {
 }
 
 func TestEmitLLVMIRTextPrefersNativeOwnedFastPathForListIndex(t *testing.T) {
-	t.Parallel()
-
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
     let xs = [1, 2]
     println(xs[0])
 }
 `)
+	want := []byte("; native list-index mir payload llvm ir\n")
+	warnings := []error{errors.New("native list-index warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for list index")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
@@ -651,8 +709,6 @@ func TestEmitLLVMIRTextPrefersNativeOwnedFastPathForListIndex(t *testing.T) {
 }
 
 func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathWhenCovered(t *testing.T) {
-	t.Parallel()
-
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitBinary, `fn pick(flag: Bool) -> Int {
@@ -673,14 +729,16 @@ fn main() {
     println(sum)
 }
 `)
+	want := []byte("; native binary primitive-slice mir payload llvm ir\n")
+	warnings := []error{errors.New("native binary primitive-slice warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Emit returned error: %v", err)
@@ -698,8 +756,6 @@ fn main() {
 }
 
 func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
-	t.Parallel()
-
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitBinary, `struct Pair { left: Int, right: Int }
@@ -710,14 +766,16 @@ fn main() {
     println(pair.left)
 }
 `)
+	want := []byte("; native binary struct-field mir payload llvm ir\n")
+	warnings := []error{errors.New("native binary struct-field warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for struct field assignment")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Emit returned error: %v", err)
@@ -735,8 +793,6 @@ fn main() {
 }
 
 func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForListIndex(t *testing.T) {
-	t.Parallel()
-
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -744,14 +800,16 @@ func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForListIndex(t *testing.
     println(xs[0])
 }
 `)
+	want := []byte("; native binary list-index mir payload llvm ir\n")
+	warnings := []error{errors.New("native binary list-index warning")}
 
-	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
-	if err != nil {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for list index")
-	}
+	withNativeMIRPayloadEmitter(t, func(entry Entry, target string) ([]byte, bool, []error, error) {
+		if entry.MIR == nil {
+			t.Fatal("native-owned route did not receive MIR payload")
+		}
+		return want, true, warnings, nil
+	})
+
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Emit returned error: %v", err)
@@ -1119,7 +1177,7 @@ func TestLLVMBackendDocsMentionDispatchRoutes(t *testing.T) {
 			"TestLLVMBackendUnsupportedSkeletonIncludesDispatchDebug",
 		},
 		string(llvmDispatchNativeOwned): {
-			"TryGenerateNativeOwnedModule",
+			"nativellvmgen.TryMIR",
 			"TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered",
 			"TestTryEmitNativeOwnedLLVMIRText*",
 		},

--- a/internal/mirjson/json.go
+++ b/internal/mirjson/json.go
@@ -1,0 +1,1473 @@
+// Package mirjson defines the JSON boundary for shipping MIR modules to
+// managed backend subprocesses without re-running the frontend.
+package mirjson
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+)
+
+const Version = 1
+
+type Module struct {
+	Version     int         `json:"version"`
+	PackageName string      `json:"packageName,omitempty"`
+	Functions   []Function  `json:"functions,omitempty"`
+	Globals     []Global    `json:"globals,omitempty"`
+	Uses        []Use       `json:"uses,omitempty"`
+	Layouts     LayoutTable `json:"layouts,omitempty"`
+	Span        Span        `json:"span,omitempty"`
+}
+
+type Span struct {
+	Start int `json:"start,omitempty"`
+	End   int `json:"end,omitempty"`
+}
+
+type Type struct {
+	Kind    string `json:"kind"`
+	Display string `json:"display,omitempty"`
+
+	Prim    string `json:"prim,omitempty"`
+	Package string `json:"package,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Builtin bool   `json:"builtin,omitempty"`
+	Owner   string `json:"owner,omitempty"`
+
+	Args   []Type `json:"args,omitempty"`
+	Inner  *Type  `json:"inner,omitempty"`
+	Elems  []Type `json:"elems,omitempty"`
+	Params []Type `json:"params,omitempty"`
+	Return *Type  `json:"return,omitempty"`
+}
+
+type Global struct {
+	Name       string `json:"name,omitempty"`
+	Type       *Type  `json:"type,omitempty"`
+	Mut        bool   `json:"mut,omitempty"`
+	HasInit    bool   `json:"hasInit,omitempty"`
+	InitSymbol string `json:"initSymbol,omitempty"`
+	Span       Span   `json:"span,omitempty"`
+}
+
+type Use struct {
+	Path         []string `json:"path,omitempty"`
+	RawPath      string   `json:"rawPath,omitempty"`
+	Alias        string   `json:"alias,omitempty"`
+	IsGoFFI      bool     `json:"isGoFFI,omitempty"`
+	IsRuntimeFFI bool     `json:"isRuntimeFFI,omitempty"`
+	GoPath       string   `json:"goPath,omitempty"`
+	RuntimePath  string   `json:"runtimePath,omitempty"`
+	Span         Span     `json:"span,omitempty"`
+}
+
+type Function struct {
+	Name        string  `json:"name,omitempty"`
+	Params      []int   `json:"params,omitempty"`
+	ReturnType  *Type   `json:"returnType,omitempty"`
+	ReturnLocal int     `json:"returnLocal,omitempty"`
+	Locals      []Local `json:"locals,omitempty"`
+	Blocks      []Block `json:"blocks,omitempty"`
+	Entry       int     `json:"entry,omitempty"`
+	IsExternal  bool    `json:"isExternal,omitempty"`
+	IsIntrinsic bool    `json:"isIntrinsic,omitempty"`
+	Exported    bool    `json:"exported,omitempty"`
+	Span        Span    `json:"span,omitempty"`
+
+	ExportSymbol string `json:"exportSymbol,omitempty"`
+	CABI         bool   `json:"cAbi,omitempty"`
+
+	Vectorize          bool     `json:"vectorize,omitempty"`
+	NoVectorize        bool     `json:"noVectorize,omitempty"`
+	VectorizeWidth     int      `json:"vectorizeWidth,omitempty"`
+	VectorizeScalable  bool     `json:"vectorizeScalable,omitempty"`
+	VectorizePredicate bool     `json:"vectorizePredicate,omitempty"`
+	Parallel           bool     `json:"parallel,omitempty"`
+	Unroll             bool     `json:"unroll,omitempty"`
+	UnrollCount        int      `json:"unrollCount,omitempty"`
+	InlineMode         int      `json:"inlineMode,omitempty"`
+	Hot                bool     `json:"hot,omitempty"`
+	Cold               bool     `json:"cold,omitempty"`
+	TargetFeatures     []string `json:"targetFeatures,omitempty"`
+	NoaliasAll         bool     `json:"noaliasAll,omitempty"`
+	NoaliasParams      []string `json:"noaliasParams,omitempty"`
+	Pure               bool     `json:"pure,omitempty"`
+}
+
+type Local struct {
+	ID       int    `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     *Type  `json:"type,omitempty"`
+	Mut      bool   `json:"mut,omitempty"`
+	IsParam  bool   `json:"isParam,omitempty"`
+	IsReturn bool   `json:"isReturn,omitempty"`
+	Span     Span   `json:"span,omitempty"`
+}
+
+type Block struct {
+	ID     int     `json:"id,omitempty"`
+	Instrs []Instr `json:"instrs,omitempty"`
+	Term   *Term   `json:"term,omitempty"`
+	Span   Span    `json:"span,omitempty"`
+}
+
+type Instr struct {
+	Kind string `json:"kind"`
+	Span Span   `json:"span,omitempty"`
+
+	Dest         *Place    `json:"dest,omitempty"`
+	Src          *RValue   `json:"src,omitempty"`
+	Callee       *Callee   `json:"callee,omitempty"`
+	Args         []Operand `json:"args,omitempty"`
+	Intrinsic    int       `json:"intrinsic,omitempty"`
+	StorageLocal int       `json:"storageLocal,omitempty"`
+}
+
+type Callee struct {
+	Kind    string   `json:"kind"`
+	Symbol  string   `json:"symbol,omitempty"`
+	Type    *Type    `json:"type,omitempty"`
+	Operand *Operand `json:"operand,omitempty"`
+}
+
+type Term struct {
+	Kind    string       `json:"kind"`
+	Target  int          `json:"target,omitempty"`
+	Cond    *Operand     `json:"cond,omitempty"`
+	Then    int          `json:"then,omitempty"`
+	Else    int          `json:"else,omitempty"`
+	Cases   []SwitchCase `json:"cases,omitempty"`
+	Default int          `json:"default,omitempty"`
+	Span    Span         `json:"span,omitempty"`
+}
+
+type SwitchCase struct {
+	Value  int64  `json:"value,omitempty"`
+	Target int    `json:"target,omitempty"`
+	Label  string `json:"label,omitempty"`
+}
+
+type Place struct {
+	Local       int          `json:"local"`
+	Projections []Projection `json:"projections,omitempty"`
+}
+
+type Projection struct {
+	Kind     string   `json:"kind"`
+	Index    int      `json:"index,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	FieldIdx int      `json:"fieldIdx,omitempty"`
+	IndexOp  *Operand `json:"indexOp,omitempty"`
+	Type     *Type    `json:"type,omitempty"`
+}
+
+type Operand struct {
+	Kind  string `json:"kind"`
+	Place *Place `json:"place,omitempty"`
+	Const *Const `json:"const,omitempty"`
+	Type  *Type  `json:"type,omitempty"`
+}
+
+type Const struct {
+	Kind   string  `json:"kind"`
+	Type   *Type   `json:"type,omitempty"`
+	Int    int64   `json:"int,omitempty"`
+	Bool   bool    `json:"bool,omitempty"`
+	Float  float64 `json:"float,omitempty"`
+	String string  `json:"string,omitempty"`
+	Char   int32   `json:"char,omitempty"`
+	Byte   byte    `json:"byte,omitempty"`
+	Symbol string  `json:"symbol,omitempty"`
+}
+
+type RValue struct {
+	Kind string `json:"kind"`
+
+	Op     *Operand `json:"op,omitempty"`
+	Unary  int      `json:"unary,omitempty"`
+	Arg    *Operand `json:"arg,omitempty"`
+	Binary int      `json:"binary,omitempty"`
+	Left   *Operand `json:"left,omitempty"`
+	Right  *Operand `json:"right,omitempty"`
+	Type   *Type    `json:"type,omitempty"`
+
+	AggregateKind int       `json:"aggregateKind,omitempty"`
+	Fields        []Operand `json:"fields,omitempty"`
+	VariantIdx    int       `json:"variantIdx,omitempty"`
+	VariantTag    string    `json:"variantTag,omitempty"`
+
+	Place *Place `json:"place,omitempty"`
+
+	CastKind int    `json:"castKind,omitempty"`
+	From     *Type  `json:"from,omitempty"`
+	To       *Type  `json:"to,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Nullary  int    `json:"nullary,omitempty"`
+}
+
+type LayoutTable struct {
+	Structs    []StructLayout    `json:"structs,omitempty"`
+	Enums      []EnumLayout      `json:"enums,omitempty"`
+	Tuples     []TupleLayout     `json:"tuples,omitempty"`
+	Interfaces []InterfaceLayout `json:"interfaces,omitempty"`
+}
+
+type StructLayout struct {
+	Key               string  `json:"key,omitempty"`
+	Name              string  `json:"name,omitempty"`
+	Mangled           string  `json:"mangled,omitempty"`
+	Fields            []Field `json:"fields,omitempty"`
+	BuiltinSource     string  `json:"builtinSource,omitempty"`
+	BuiltinSourceArgs []Type  `json:"builtinSourceArgs,omitempty"`
+	Size              int     `json:"size,omitempty"`
+	Align             int     `json:"align,omitempty"`
+}
+
+type Field struct {
+	Index int    `json:"index,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Type  *Type  `json:"type,omitempty"`
+}
+
+type EnumLayout struct {
+	Key               string          `json:"key,omitempty"`
+	Name              string          `json:"name,omitempty"`
+	Mangled           string          `json:"mangled,omitempty"`
+	BuiltinSource     string          `json:"builtinSource,omitempty"`
+	BuiltinSourceArgs []Type          `json:"builtinSourceArgs,omitempty"`
+	Discriminant      *Type           `json:"discriminant,omitempty"`
+	Variants          []VariantLayout `json:"variants,omitempty"`
+}
+
+type VariantLayout struct {
+	Index   int     `json:"index,omitempty"`
+	Name    string  `json:"name,omitempty"`
+	Payload []Field `json:"payload,omitempty"`
+}
+
+type TupleLayout struct {
+	Key     string  `json:"key,omitempty"`
+	Mangled string  `json:"mangled,omitempty"`
+	Fields  []Field `json:"fields,omitempty"`
+}
+
+type InterfaceLayout struct {
+	Key     string            `json:"key,omitempty"`
+	Name    string            `json:"name,omitempty"`
+	Methods []InterfaceMethod `json:"methods,omitempty"`
+	Impls   []InterfaceImpl   `json:"impls,omitempty"`
+}
+
+type InterfaceMethod struct {
+	Name string `json:"name,omitempty"`
+	Slot int    `json:"slot,omitempty"`
+}
+
+type InterfaceImpl struct {
+	ImplName  string `json:"implName,omitempty"`
+	VtableSym string `json:"vtableSym,omitempty"`
+}
+
+func FromModule(m *mir.Module) (*Module, error) {
+	if m == nil {
+		return nil, fmt.Errorf("nil MIR module")
+	}
+	out := &Module{
+		Version:     Version,
+		PackageName: m.Package,
+		Span:        fromSpan(m.SpanV),
+	}
+	for _, u := range m.Uses {
+		if u == nil {
+			continue
+		}
+		out.Uses = append(out.Uses, Use{
+			Path:         append([]string(nil), u.Path...),
+			RawPath:      u.RawPath,
+			Alias:        u.Alias,
+			IsGoFFI:      u.IsGoFFI,
+			IsRuntimeFFI: u.IsRuntimeFFI,
+			GoPath:       u.GoPath,
+			RuntimePath:  u.RuntimePath,
+			Span:         fromSpan(u.SpanV),
+		})
+	}
+	seenFunctions := map[string]bool{}
+	for _, fn := range m.Functions {
+		if fn == nil {
+			continue
+		}
+		out.Functions = append(out.Functions, fromFunction(fn))
+		seenFunctions[fn.Name] = true
+	}
+	for _, g := range m.Globals {
+		if g == nil {
+			continue
+		}
+		j := Global{
+			Name: g.Name,
+			Type: fromType(g.Type),
+			Mut:  g.Mut,
+			Span: fromSpan(g.SpanV),
+		}
+		if g.Init != nil {
+			j.HasInit = true
+			j.InitSymbol = g.Init.Name
+			if !seenFunctions[g.Init.Name] {
+				out.Functions = append(out.Functions, fromFunction(g.Init))
+				seenFunctions[g.Init.Name] = true
+			}
+		}
+		out.Globals = append(out.Globals, j)
+	}
+	out.Layouts = fromLayoutTable(m.Layouts)
+	return out, nil
+}
+
+func ToModule(in *Module) (*mir.Module, error) {
+	if in == nil {
+		return nil, fmt.Errorf("nil MIR JSON module")
+	}
+	if in.Version != 0 && in.Version != Version {
+		return nil, fmt.Errorf("unsupported MIR JSON version %d", in.Version)
+	}
+	out := &mir.Module{
+		Package: in.PackageName,
+		SpanV:   toSpan(in.Span),
+	}
+	layouts, err := toLayoutTable(in.Layouts)
+	if err != nil {
+		return nil, err
+	}
+	out.Layouts = layouts
+	for _, u := range in.Uses {
+		out.Uses = append(out.Uses, &mir.Use{
+			Path:         append([]string(nil), u.Path...),
+			RawPath:      u.RawPath,
+			Alias:        u.Alias,
+			IsGoFFI:      u.IsGoFFI,
+			IsRuntimeFFI: u.IsRuntimeFFI,
+			GoPath:       u.GoPath,
+			RuntimePath:  u.RuntimePath,
+			SpanV:        toSpan(u.Span),
+		})
+	}
+	functions := map[string]*mir.Function{}
+	for i := range in.Functions {
+		fn, err := toFunction(in.Functions[i])
+		if err != nil {
+			return nil, err
+		}
+		functions[fn.Name] = fn
+		out.Functions = append(out.Functions, fn)
+	}
+	initSymbols := map[string]bool{}
+	for _, g := range in.Globals {
+		glob, err := toGlobal(g, functions)
+		if err != nil {
+			return nil, err
+		}
+		if glob.Init != nil {
+			initSymbols[glob.Init.Name] = true
+		}
+		out.Globals = append(out.Globals, glob)
+	}
+	if len(initSymbols) > 0 {
+		kept := out.Functions[:0]
+		for _, fn := range out.Functions {
+			if fn != nil && initSymbols[fn.Name] {
+				continue
+			}
+			kept = append(kept, fn)
+		}
+		out.Functions = kept
+	}
+	return out, nil
+}
+
+func fromSpan(s mir.Span) Span {
+	return Span{Start: s.Start.Offset, End: s.End.Offset}
+}
+
+func toSpan(s Span) mir.Span {
+	return mir.Span{
+		Start: ir.Pos{Offset: s.Start},
+		End:   ir.Pos{Offset: s.End},
+	}
+}
+
+func fromType(t ir.Type) *Type {
+	if t == nil {
+		return nil
+	}
+	out := &Type{Display: t.String()}
+	switch x := t.(type) {
+	case *ir.PrimType:
+		out.Kind = "prim"
+		out.Prim = x.String()
+	case *ir.NamedType:
+		out.Kind = "named"
+		out.Package = x.Package
+		out.Name = x.Name
+		out.Builtin = x.Builtin
+		out.Args = fromTypes(x.Args)
+	case *ir.OptionalType:
+		out.Kind = "optional"
+		out.Inner = fromType(x.Inner)
+	case *ir.TupleType:
+		out.Kind = "tuple"
+		out.Elems = fromTypes(x.Elems)
+	case *ir.FnType:
+		out.Kind = "fn"
+		out.Params = fromTypes(x.Params)
+		out.Return = fromType(x.Return)
+	case *ir.TypeVar:
+		out.Kind = "typevar"
+		out.Name = x.Name
+		out.Owner = x.Owner
+	case *ir.ErrType:
+		out.Kind = "error"
+	default:
+		out.Kind = "unknown"
+	}
+	return out
+}
+
+func fromTypes(ts []ir.Type) []Type {
+	if len(ts) == 0 {
+		return nil
+	}
+	out := make([]Type, 0, len(ts))
+	for _, t := range ts {
+		jt := fromType(t)
+		if jt == nil {
+			out = append(out, Type{Kind: "nil"})
+			continue
+		}
+		out = append(out, *jt)
+	}
+	return out
+}
+
+func toType(t *Type) (ir.Type, error) {
+	if t == nil || t.Kind == "" || t.Kind == "nil" {
+		return nil, nil
+	}
+	switch t.Kind {
+	case "prim":
+		return primType(t.Prim)
+	case "named":
+		args, err := toTypes(t.Args)
+		if err != nil {
+			return nil, err
+		}
+		return &ir.NamedType{Package: t.Package, Name: t.Name, Args: args, Builtin: t.Builtin}, nil
+	case "optional":
+		inner, err := toType(t.Inner)
+		if err != nil {
+			return nil, err
+		}
+		return &ir.OptionalType{Inner: inner}, nil
+	case "tuple":
+		elems, err := toTypes(t.Elems)
+		if err != nil {
+			return nil, err
+		}
+		return &ir.TupleType{Elems: elems}, nil
+	case "fn":
+		params, err := toTypes(t.Params)
+		if err != nil {
+			return nil, err
+		}
+		ret, err := toType(t.Return)
+		if err != nil {
+			return nil, err
+		}
+		return &ir.FnType{Params: params, Return: ret}, nil
+	case "typevar":
+		return &ir.TypeVar{Name: t.Name, Owner: t.Owner}, nil
+	case "error":
+		return ir.ErrTypeVal, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON type kind %q", t.Kind)
+	}
+}
+
+func toTypes(in []Type) ([]ir.Type, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]ir.Type, 0, len(in))
+	for i := range in {
+		t, err := toType(&in[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func primType(name string) (ir.Type, error) {
+	switch name {
+	case "Int":
+		return ir.TInt, nil
+	case "Int8":
+		return ir.TInt8, nil
+	case "Int16":
+		return ir.TInt16, nil
+	case "Int32":
+		return ir.TInt32, nil
+	case "Int64":
+		return ir.TInt64, nil
+	case "UInt8":
+		return ir.TUInt8, nil
+	case "UInt16":
+		return ir.TUInt16, nil
+	case "UInt32":
+		return ir.TUInt32, nil
+	case "UInt64":
+		return ir.TUInt64, nil
+	case "Byte":
+		return ir.TByte, nil
+	case "Float":
+		return ir.TFloat, nil
+	case "Float32":
+		return ir.TFloat32, nil
+	case "Float64":
+		return ir.TFloat64, nil
+	case "Bool":
+		return ir.TBool, nil
+	case "Char":
+		return ir.TChar, nil
+	case "String":
+		return ir.TString, nil
+	case "Bytes":
+		return ir.TBytes, nil
+	case "RawPtr":
+		return ir.TRawPtr, nil
+	case "()", "Unit":
+		return ir.TUnit, nil
+	case "Never":
+		return ir.TNever, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON primitive type %q", name)
+	}
+}
+
+func fromFunction(fn *mir.Function) Function {
+	out := Function{
+		Name:               fn.Name,
+		ReturnType:         fromType(fn.ReturnType),
+		ReturnLocal:        int(fn.ReturnLocal),
+		Entry:              int(fn.Entry),
+		IsExternal:         fn.IsExternal,
+		IsIntrinsic:        fn.IsIntrinsic,
+		Exported:           fn.Exported,
+		Span:               fromSpan(fn.SpanV),
+		ExportSymbol:       fn.ExportSymbol,
+		CABI:               fn.CABI,
+		Vectorize:          fn.Vectorize,
+		NoVectorize:        fn.NoVectorize,
+		VectorizeWidth:     fn.VectorizeWidth,
+		VectorizeScalable:  fn.VectorizeScalable,
+		VectorizePredicate: fn.VectorizePredicate,
+		Parallel:           fn.Parallel,
+		Unroll:             fn.Unroll,
+		UnrollCount:        fn.UnrollCount,
+		InlineMode:         fn.InlineMode,
+		Hot:                fn.Hot,
+		Cold:               fn.Cold,
+		TargetFeatures:     append([]string(nil), fn.TargetFeatures...),
+		NoaliasAll:         fn.NoaliasAll,
+		NoaliasParams:      append([]string(nil), fn.NoaliasParams...),
+		Pure:               fn.Pure,
+	}
+	for _, p := range fn.Params {
+		out.Params = append(out.Params, int(p))
+	}
+	for _, l := range fn.Locals {
+		if l == nil {
+			continue
+		}
+		out.Locals = append(out.Locals, Local{
+			ID:       int(l.ID),
+			Name:     l.Name,
+			Type:     fromType(l.Type),
+			Mut:      l.Mut,
+			IsParam:  l.IsParam,
+			IsReturn: l.IsReturn,
+			Span:     fromSpan(l.SpanV),
+		})
+	}
+	for _, b := range fn.Blocks {
+		if b == nil {
+			continue
+		}
+		out.Blocks = append(out.Blocks, fromBlock(b))
+	}
+	return out
+}
+
+func toFunction(in Function) (*mir.Function, error) {
+	ret, err := toType(in.ReturnType)
+	if err != nil {
+		return nil, err
+	}
+	fn := &mir.Function{
+		Name:               in.Name,
+		ReturnType:         ret,
+		ReturnLocal:        mir.LocalID(in.ReturnLocal),
+		Entry:              mir.BlockID(in.Entry),
+		IsExternal:         in.IsExternal,
+		IsIntrinsic:        in.IsIntrinsic,
+		Exported:           in.Exported,
+		SpanV:              toSpan(in.Span),
+		ExportSymbol:       in.ExportSymbol,
+		CABI:               in.CABI,
+		Vectorize:          in.Vectorize,
+		NoVectorize:        in.NoVectorize,
+		VectorizeWidth:     in.VectorizeWidth,
+		VectorizeScalable:  in.VectorizeScalable,
+		VectorizePredicate: in.VectorizePredicate,
+		Parallel:           in.Parallel,
+		Unroll:             in.Unroll,
+		UnrollCount:        in.UnrollCount,
+		InlineMode:         in.InlineMode,
+		Hot:                in.Hot,
+		Cold:               in.Cold,
+		TargetFeatures:     append([]string(nil), in.TargetFeatures...),
+		NoaliasAll:         in.NoaliasAll,
+		NoaliasParams:      append([]string(nil), in.NoaliasParams...),
+		Pure:               in.Pure,
+	}
+	for _, p := range in.Params {
+		fn.Params = append(fn.Params, mir.LocalID(p))
+	}
+	for _, l := range in.Locals {
+		local, err := toLocal(l)
+		if err != nil {
+			return nil, err
+		}
+		fn.Locals = append(fn.Locals, local)
+	}
+	for _, b := range in.Blocks {
+		block, err := toBlock(b)
+		if err != nil {
+			return nil, err
+		}
+		fn.Blocks = append(fn.Blocks, block)
+	}
+	return fn, nil
+}
+
+func toLocal(in Local) (*mir.Local, error) {
+	t, err := toType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &mir.Local{
+		ID:       mir.LocalID(in.ID),
+		Name:     in.Name,
+		Type:     t,
+		Mut:      in.Mut,
+		IsParam:  in.IsParam,
+		IsReturn: in.IsReturn,
+		SpanV:    toSpan(in.Span),
+	}, nil
+}
+
+func fromBlock(b *mir.BasicBlock) Block {
+	out := Block{ID: int(b.ID), Span: fromSpan(b.SpanV)}
+	for _, instr := range b.Instrs {
+		out.Instrs = append(out.Instrs, fromInstr(instr))
+	}
+	if b.Term != nil {
+		term := fromTerm(b.Term)
+		out.Term = &term
+	}
+	return out
+}
+
+func toBlock(in Block) (*mir.BasicBlock, error) {
+	b := &mir.BasicBlock{ID: mir.BlockID(in.ID), SpanV: toSpan(in.Span)}
+	for _, ji := range in.Instrs {
+		instr, err := toInstr(ji)
+		if err != nil {
+			return nil, err
+		}
+		b.Instrs = append(b.Instrs, instr)
+	}
+	if in.Term != nil {
+		term, err := toTerm(*in.Term)
+		if err != nil {
+			return nil, err
+		}
+		b.Term = term
+	}
+	return b, nil
+}
+
+func fromInstr(i mir.Instr) Instr {
+	switch x := i.(type) {
+	case *mir.AssignInstr:
+		dest := fromPlace(x.Dest)
+		src := fromRValue(x.Src)
+		return Instr{Kind: "assign", Dest: &dest, Src: &src, Span: fromSpan(x.SpanV)}
+	case *mir.CallInstr:
+		out := Instr{Kind: "call", Callee: fromCallee(x.Callee), Args: fromOperands(x.Args), Span: fromSpan(x.SpanV)}
+		if x.Dest != nil {
+			dest := fromPlace(*x.Dest)
+			out.Dest = &dest
+		}
+		return out
+	case *mir.IntrinsicInstr:
+		out := Instr{Kind: "intrinsic", Intrinsic: int(x.Kind), Args: fromOperands(x.Args), Span: fromSpan(x.SpanV)}
+		if x.Dest != nil {
+			dest := fromPlace(*x.Dest)
+			out.Dest = &dest
+		}
+		return out
+	case *mir.StorageLiveInstr:
+		return Instr{Kind: "storage_live", StorageLocal: int(x.Local), Span: fromSpan(x.SpanV)}
+	case *mir.StorageDeadInstr:
+		return Instr{Kind: "storage_dead", StorageLocal: int(x.Local), Span: fromSpan(x.SpanV)}
+	default:
+		return Instr{Kind: "invalid"}
+	}
+}
+
+func toInstr(in Instr) (mir.Instr, error) {
+	switch in.Kind {
+	case "assign":
+		if in.Dest == nil || in.Src == nil {
+			return nil, fmt.Errorf("assign instruction missing dest or src")
+		}
+		dest, err := toPlace(*in.Dest)
+		if err != nil {
+			return nil, err
+		}
+		src, err := toRValue(*in.Src)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.AssignInstr{Dest: dest, Src: src, SpanV: toSpan(in.Span)}, nil
+	case "call":
+		callee, err := toCallee(in.Callee)
+		if err != nil {
+			return nil, err
+		}
+		args, err := toOperands(in.Args)
+		if err != nil {
+			return nil, err
+		}
+		var dest *mir.Place
+		if in.Dest != nil {
+			p, err := toPlace(*in.Dest)
+			if err != nil {
+				return nil, err
+			}
+			dest = &p
+		}
+		return &mir.CallInstr{Dest: dest, Callee: callee, Args: args, SpanV: toSpan(in.Span)}, nil
+	case "intrinsic":
+		args, err := toOperands(in.Args)
+		if err != nil {
+			return nil, err
+		}
+		var dest *mir.Place
+		if in.Dest != nil {
+			p, err := toPlace(*in.Dest)
+			if err != nil {
+				return nil, err
+			}
+			dest = &p
+		}
+		return &mir.IntrinsicInstr{Dest: dest, Kind: mir.IntrinsicKind(in.Intrinsic), Args: args, SpanV: toSpan(in.Span)}, nil
+	case "storage_live":
+		return &mir.StorageLiveInstr{Local: mir.LocalID(in.StorageLocal), SpanV: toSpan(in.Span)}, nil
+	case "storage_dead":
+		return &mir.StorageDeadInstr{Local: mir.LocalID(in.StorageLocal), SpanV: toSpan(in.Span)}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON instruction kind %q", in.Kind)
+	}
+}
+
+func fromCallee(c mir.Callee) *Callee {
+	switch x := c.(type) {
+	case *mir.FnRef:
+		return &Callee{Kind: "fn", Symbol: x.Symbol, Type: fromType(x.Type)}
+	case *mir.IndirectCall:
+		op := fromOperand(x.Callee)
+		return &Callee{Kind: "indirect", Operand: &op}
+	default:
+		return &Callee{Kind: "invalid"}
+	}
+}
+
+func toCallee(in *Callee) (mir.Callee, error) {
+	if in == nil {
+		return nil, fmt.Errorf("call instruction missing callee")
+	}
+	switch in.Kind {
+	case "fn":
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.FnRef{Symbol: in.Symbol, Type: t}, nil
+	case "indirect":
+		if in.Operand == nil {
+			return nil, fmt.Errorf("indirect call missing operand")
+		}
+		op, err := toOperand(*in.Operand)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.IndirectCall{Callee: op}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON callee kind %q", in.Kind)
+	}
+}
+
+func fromTerm(t mir.Terminator) Term {
+	switch x := t.(type) {
+	case *mir.GotoTerm:
+		return Term{Kind: "goto", Target: int(x.Target), Span: fromSpan(x.SpanV)}
+	case *mir.BranchTerm:
+		cond := fromOperand(x.Cond)
+		return Term{Kind: "branch", Cond: &cond, Then: int(x.Then), Else: int(x.Else), Span: fromSpan(x.SpanV)}
+	case *mir.SwitchIntTerm:
+		cond := fromOperand(x.Scrutinee)
+		out := Term{Kind: "switch_int", Cond: &cond, Default: int(x.Default), Span: fromSpan(x.SpanV)}
+		for _, c := range x.Cases {
+			out.Cases = append(out.Cases, SwitchCase{Value: c.Value, Target: int(c.Target), Label: c.Label})
+		}
+		return out
+	case *mir.ReturnTerm:
+		return Term{Kind: "return", Span: fromSpan(x.SpanV)}
+	case *mir.UnreachableTerm:
+		return Term{Kind: "unreachable", Span: fromSpan(x.SpanV)}
+	default:
+		return Term{Kind: "invalid"}
+	}
+}
+
+func toTerm(in Term) (mir.Terminator, error) {
+	switch in.Kind {
+	case "goto":
+		return &mir.GotoTerm{Target: mir.BlockID(in.Target), SpanV: toSpan(in.Span)}, nil
+	case "branch":
+		if in.Cond == nil {
+			return nil, fmt.Errorf("branch terminator missing condition")
+		}
+		cond, err := toOperand(*in.Cond)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.BranchTerm{Cond: cond, Then: mir.BlockID(in.Then), Else: mir.BlockID(in.Else), SpanV: toSpan(in.Span)}, nil
+	case "switch_int":
+		if in.Cond == nil {
+			return nil, fmt.Errorf("switch_int terminator missing scrutinee")
+		}
+		cond, err := toOperand(*in.Cond)
+		if err != nil {
+			return nil, err
+		}
+		cases := make([]mir.SwitchCase, 0, len(in.Cases))
+		for _, c := range in.Cases {
+			cases = append(cases, mir.SwitchCase{Value: c.Value, Target: mir.BlockID(c.Target), Label: c.Label})
+		}
+		return &mir.SwitchIntTerm{Scrutinee: cond, Cases: cases, Default: mir.BlockID(in.Default), SpanV: toSpan(in.Span)}, nil
+	case "return":
+		return &mir.ReturnTerm{SpanV: toSpan(in.Span)}, nil
+	case "unreachable":
+		return &mir.UnreachableTerm{SpanV: toSpan(in.Span)}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON terminator kind %q", in.Kind)
+	}
+}
+
+func fromPlace(p mir.Place) Place {
+	out := Place{Local: int(p.Local)}
+	for _, proj := range p.Projections {
+		out.Projections = append(out.Projections, fromProjection(proj))
+	}
+	return out
+}
+
+func toPlace(in Place) (mir.Place, error) {
+	out := mir.Place{Local: mir.LocalID(in.Local)}
+	for _, proj := range in.Projections {
+		decoded, err := toProjection(proj)
+		if err != nil {
+			return mir.Place{}, err
+		}
+		out.Projections = append(out.Projections, decoded)
+	}
+	return out, nil
+}
+
+func fromProjection(p mir.Projection) Projection {
+	switch x := p.(type) {
+	case *mir.FieldProj:
+		return Projection{Kind: "field", Index: x.Index, Name: x.Name, Type: fromType(x.Type)}
+	case *mir.TupleProj:
+		return Projection{Kind: "tuple", Index: x.Index, Type: fromType(x.Type)}
+	case *mir.VariantProj:
+		return Projection{Kind: "variant", Index: x.Variant, Name: x.Name, FieldIdx: x.FieldIdx, Type: fromType(x.Type)}
+	case *mir.IndexProj:
+		op := fromOperand(x.Index)
+		return Projection{Kind: "index", IndexOp: &op, Type: fromType(x.ElemType)}
+	case *mir.DerefProj:
+		return Projection{Kind: "deref", Type: fromType(x.Type)}
+	default:
+		return Projection{Kind: "invalid"}
+	}
+}
+
+func toProjection(in Projection) (mir.Projection, error) {
+	t, err := toType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	switch in.Kind {
+	case "field":
+		return &mir.FieldProj{Index: in.Index, Name: in.Name, Type: t}, nil
+	case "tuple":
+		return &mir.TupleProj{Index: in.Index, Type: t}, nil
+	case "variant":
+		return &mir.VariantProj{Variant: in.Index, Name: in.Name, FieldIdx: in.FieldIdx, Type: t}, nil
+	case "index":
+		var op mir.Operand = &mir.ConstOp{Const: &mir.IntConst{Value: int64(in.Index), T: mir.TInt}, T: mir.TInt}
+		if in.IndexOp != nil {
+			decoded, err := toOperand(*in.IndexOp)
+			if err != nil {
+				return nil, err
+			}
+			op = decoded
+		}
+		return &mir.IndexProj{Index: op, ElemType: t}, nil
+	case "deref":
+		return &mir.DerefProj{Type: t}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON projection kind %q", in.Kind)
+	}
+}
+
+func fromOperand(op mir.Operand) Operand {
+	switch x := op.(type) {
+	case *mir.CopyOp:
+		p := fromPlace(x.Place)
+		return Operand{Kind: "copy", Place: &p, Type: fromType(x.T)}
+	case *mir.MoveOp:
+		p := fromPlace(x.Place)
+		return Operand{Kind: "move", Place: &p, Type: fromType(x.T)}
+	case *mir.ConstOp:
+		c := fromConst(x.Const)
+		return Operand{Kind: "const", Const: &c, Type: fromType(x.Type())}
+	default:
+		return Operand{Kind: "invalid"}
+	}
+}
+
+func fromOperands(in []mir.Operand) []Operand {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Operand, 0, len(in))
+	for _, op := range in {
+		out = append(out, fromOperand(op))
+	}
+	return out
+}
+
+func toOperand(in Operand) (mir.Operand, error) {
+	t, err := toType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	switch in.Kind {
+	case "copy":
+		if in.Place == nil {
+			return nil, fmt.Errorf("copy operand missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.CopyOp{Place: place, T: t}, nil
+	case "move":
+		if in.Place == nil {
+			return nil, fmt.Errorf("move operand missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.MoveOp{Place: place, T: t}, nil
+	case "const":
+		if in.Const == nil {
+			return nil, fmt.Errorf("const operand missing const payload")
+		}
+		c, err := toConst(*in.Const)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.ConstOp{Const: c, T: t}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON operand kind %q", in.Kind)
+	}
+}
+
+func toOperands(in []Operand) ([]mir.Operand, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]mir.Operand, 0, len(in))
+	for _, op := range in {
+		decoded, err := toOperand(op)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, decoded)
+	}
+	return out, nil
+}
+
+func fromConst(c mir.Const) Const {
+	switch x := c.(type) {
+	case *mir.IntConst:
+		return Const{Kind: "int", Int: x.Value, Type: fromType(x.Type())}
+	case *mir.BoolConst:
+		return Const{Kind: "bool", Bool: x.Value, Type: fromType(x.Type())}
+	case *mir.FloatConst:
+		return Const{Kind: "float", Float: x.Value, Type: fromType(x.Type())}
+	case *mir.StringConst:
+		return Const{Kind: "string", String: x.Value, Type: fromType(x.Type())}
+	case *mir.CharConst:
+		return Const{Kind: "char", Char: x.Value, Type: fromType(x.Type())}
+	case *mir.ByteConst:
+		return Const{Kind: "byte", Byte: x.Value, Type: fromType(x.Type())}
+	case *mir.UnitConst:
+		return Const{Kind: "unit", Type: fromType(x.Type())}
+	case *mir.NullConst:
+		return Const{Kind: "null", Type: fromType(x.Type())}
+	case *mir.FnConst:
+		return Const{Kind: "fn", Symbol: x.Symbol, Type: fromType(x.Type())}
+	default:
+		return Const{Kind: "invalid"}
+	}
+}
+
+func toConst(in Const) (mir.Const, error) {
+	t, err := toType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	switch in.Kind {
+	case "int":
+		return &mir.IntConst{Value: in.Int, T: t}, nil
+	case "bool":
+		return &mir.BoolConst{Value: in.Bool}, nil
+	case "float":
+		return &mir.FloatConst{Value: in.Float, T: t}, nil
+	case "string":
+		return &mir.StringConst{Value: in.String}, nil
+	case "char":
+		return &mir.CharConst{Value: in.Char}, nil
+	case "byte":
+		return &mir.ByteConst{Value: in.Byte}, nil
+	case "unit":
+		return &mir.UnitConst{}, nil
+	case "null":
+		return &mir.NullConst{T: t}, nil
+	case "fn":
+		return &mir.FnConst{Symbol: in.Symbol, T: t}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON const kind %q", in.Kind)
+	}
+}
+
+func fromRValue(rv mir.RValue) RValue {
+	switch x := rv.(type) {
+	case *mir.UseRV:
+		op := fromOperand(x.Op)
+		return RValue{Kind: "use", Op: &op}
+	case *mir.UnaryRV:
+		arg := fromOperand(x.Arg)
+		return RValue{Kind: "unary", Unary: int(x.Op), Arg: &arg, Type: fromType(x.T)}
+	case *mir.BinaryRV:
+		left := fromOperand(x.Left)
+		right := fromOperand(x.Right)
+		return RValue{Kind: "binary", Binary: int(x.Op), Left: &left, Right: &right, Type: fromType(x.T)}
+	case *mir.AggregateRV:
+		return RValue{Kind: "aggregate", AggregateKind: int(x.Kind), Fields: fromOperands(x.Fields), Type: fromType(x.T), VariantIdx: x.VariantIdx, VariantTag: x.VariantTag}
+	case *mir.DiscriminantRV:
+		p := fromPlace(x.Place)
+		return RValue{Kind: "discriminant", Place: &p, Type: fromType(x.T)}
+	case *mir.LenRV:
+		p := fromPlace(x.Place)
+		return RValue{Kind: "len", Place: &p, Type: fromType(x.T)}
+	case *mir.CastRV:
+		arg := fromOperand(x.Arg)
+		return RValue{Kind: "cast", CastKind: int(x.Kind), Arg: &arg, From: fromType(x.From), To: fromType(x.To)}
+	case *mir.AddressOfRV:
+		p := fromPlace(x.Place)
+		return RValue{Kind: "address_of", Place: &p, Type: fromType(x.T)}
+	case *mir.RefRV:
+		p := fromPlace(x.Place)
+		return RValue{Kind: "ref", Place: &p, Type: fromType(x.T)}
+	case *mir.GlobalRefRV:
+		return RValue{Kind: "global_ref", Name: x.Name, Type: fromType(x.T)}
+	case *mir.NullaryRV:
+		return RValue{Kind: "nullary", Nullary: int(x.Kind), Type: fromType(x.T)}
+	default:
+		return RValue{Kind: "invalid"}
+	}
+}
+
+func toRValue(in RValue) (mir.RValue, error) {
+	switch in.Kind {
+	case "use":
+		if in.Op == nil {
+			return nil, fmt.Errorf("use rvalue missing operand")
+		}
+		op, err := toOperand(*in.Op)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.UseRV{Op: op}, nil
+	case "unary":
+		if in.Arg == nil {
+			return nil, fmt.Errorf("unary rvalue missing arg")
+		}
+		arg, err := toOperand(*in.Arg)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.UnaryRV{Op: mir.UnaryOp(in.Unary), Arg: arg, T: t}, nil
+	case "binary":
+		if in.Left == nil || in.Right == nil {
+			return nil, fmt.Errorf("binary rvalue missing operand")
+		}
+		left, err := toOperand(*in.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := toOperand(*in.Right)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.BinaryRV{Op: mir.BinaryOp(in.Binary), Left: left, Right: right, T: t}, nil
+	case "aggregate":
+		fields, err := toOperands(in.Fields)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.AggregateRV{Kind: mir.AggregateKind(in.AggregateKind), Fields: fields, T: t, VariantIdx: in.VariantIdx, VariantTag: in.VariantTag}, nil
+	case "discriminant":
+		if in.Place == nil {
+			return nil, fmt.Errorf("discriminant rvalue missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.DiscriminantRV{Place: place, T: t}, nil
+	case "len":
+		if in.Place == nil {
+			return nil, fmt.Errorf("len rvalue missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.LenRV{Place: place, T: t}, nil
+	case "cast":
+		if in.Arg == nil {
+			return nil, fmt.Errorf("cast rvalue missing arg")
+		}
+		arg, err := toOperand(*in.Arg)
+		if err != nil {
+			return nil, err
+		}
+		from, err := toType(in.From)
+		if err != nil {
+			return nil, err
+		}
+		to, err := toType(in.To)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.CastRV{Kind: mir.CastKind(in.CastKind), Arg: arg, From: from, To: to}, nil
+	case "address_of":
+		if in.Place == nil {
+			return nil, fmt.Errorf("address_of rvalue missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.AddressOfRV{Place: place, T: t}, nil
+	case "ref":
+		if in.Place == nil {
+			return nil, fmt.Errorf("ref rvalue missing place")
+		}
+		place, err := toPlace(*in.Place)
+		if err != nil {
+			return nil, err
+		}
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.RefRV{Place: place, T: t}, nil
+	case "global_ref":
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.GlobalRefRV{Name: in.Name, T: t}, nil
+	case "nullary":
+		t, err := toType(in.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &mir.NullaryRV{Kind: mir.NullaryRVKind(in.Nullary), T: t}, nil
+	default:
+		return nil, fmt.Errorf("unknown MIR JSON rvalue kind %q", in.Kind)
+	}
+}
+
+func fromLayoutTable(l *mir.LayoutTable) LayoutTable {
+	if l == nil {
+		return LayoutTable{}
+	}
+	var out LayoutTable
+	for _, key := range sortedKeys(l.Structs) {
+		sl := l.Structs[key]
+		if sl == nil {
+			continue
+		}
+		out.Structs = append(out.Structs, StructLayout{
+			Key:               key,
+			Name:              sl.Name,
+			Mangled:           sl.Mangled,
+			Fields:            fromFields(sl.Fields),
+			BuiltinSource:     sl.BuiltinSource,
+			BuiltinSourceArgs: fromTypes(sl.BuiltinSourceArgs),
+			Size:              sl.Size,
+			Align:             sl.Align,
+		})
+	}
+	for _, key := range sortedKeys(l.Enums) {
+		en := l.Enums[key]
+		if en == nil {
+			continue
+		}
+		out.Enums = append(out.Enums, EnumLayout{
+			Key:               key,
+			Name:              en.Name,
+			Mangled:           en.Mangled,
+			BuiltinSource:     en.BuiltinSource,
+			BuiltinSourceArgs: fromTypes(en.BuiltinSourceArgs),
+			Discriminant:      fromType(en.Discriminant),
+			Variants:          fromVariants(en.Variants),
+		})
+	}
+	for _, key := range sortedKeys(l.Tuples) {
+		tl := l.Tuples[key]
+		if tl == nil {
+			continue
+		}
+		out.Tuples = append(out.Tuples, TupleLayout{Key: tl.Key, Mangled: tl.Mangled, Fields: fromFields(tl.Fields)})
+	}
+	for _, key := range sortedKeys(l.Interfaces) {
+		il := l.Interfaces[key]
+		if il == nil {
+			continue
+		}
+		out.Interfaces = append(out.Interfaces, InterfaceLayout{Key: key, Name: il.Name, Methods: fromInterfaceMethods(il.Methods), Impls: fromInterfaceImpls(il.Impls)})
+	}
+	return out
+}
+
+type keyed[T any] interface{ ~map[string]T }
+
+func sortedKeys[M keyed[T], T any](m M) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func toLayoutTable(in LayoutTable) (*mir.LayoutTable, error) {
+	out := mir.NewLayoutTable()
+	for _, sl := range in.Structs {
+		args, err := toTypes(sl.BuiltinSourceArgs)
+		if err != nil {
+			return nil, err
+		}
+		fields, err := toFields(sl.Fields)
+		if err != nil {
+			return nil, err
+		}
+		key := sl.Key
+		if key == "" {
+			key = sl.Name
+		}
+		out.Structs[key] = &mir.StructLayout{Name: sl.Name, Mangled: sl.Mangled, Fields: fields, BuiltinSource: sl.BuiltinSource, BuiltinSourceArgs: args, Size: sl.Size, Align: sl.Align}
+	}
+	for _, en := range in.Enums {
+		args, err := toTypes(en.BuiltinSourceArgs)
+		if err != nil {
+			return nil, err
+		}
+		disc, err := toType(en.Discriminant)
+		if err != nil {
+			return nil, err
+		}
+		variants, err := toVariants(en.Variants)
+		if err != nil {
+			return nil, err
+		}
+		key := en.Key
+		if key == "" {
+			key = en.Name
+		}
+		out.Enums[key] = &mir.EnumLayout{Name: en.Name, Mangled: en.Mangled, BuiltinSource: en.BuiltinSource, BuiltinSourceArgs: args, Discriminant: disc, Variants: variants}
+	}
+	for _, tl := range in.Tuples {
+		fields, err := toFields(tl.Fields)
+		if err != nil {
+			return nil, err
+		}
+		out.Tuples[tl.Key] = &mir.TupleLayout{Key: tl.Key, Mangled: tl.Mangled, Fields: fields}
+	}
+	for _, il := range in.Interfaces {
+		key := il.Key
+		if key == "" {
+			key = il.Name
+		}
+		out.Interfaces[key] = &mir.InterfaceLayout{Name: il.Name, Methods: toInterfaceMethods(il.Methods), Impls: toInterfaceImpls(il.Impls)}
+	}
+	return out, nil
+}
+
+func fromFields(fields []mir.FieldLayout) []Field {
+	out := make([]Field, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, Field{Index: f.Index, Name: f.Name, Type: fromType(f.Type)})
+	}
+	return out
+}
+
+func toFields(in []Field) ([]mir.FieldLayout, error) {
+	out := make([]mir.FieldLayout, 0, len(in))
+	for _, f := range in {
+		t, err := toType(f.Type)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mir.FieldLayout{Index: f.Index, Name: f.Name, Type: t})
+	}
+	return out, nil
+}
+
+func fromVariants(in []mir.VariantLayout) []VariantLayout {
+	out := make([]VariantLayout, 0, len(in))
+	for _, v := range in {
+		out = append(out, VariantLayout{Index: v.Index, Name: v.Name, Payload: fromFields(v.Payload)})
+	}
+	return out
+}
+
+func toVariants(in []VariantLayout) ([]mir.VariantLayout, error) {
+	out := make([]mir.VariantLayout, 0, len(in))
+	for _, v := range in {
+		payload, err := toFields(v.Payload)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mir.VariantLayout{Index: v.Index, Name: v.Name, Payload: payload})
+	}
+	return out, nil
+}
+
+func fromInterfaceMethods(in []mir.InterfaceMethod) []InterfaceMethod {
+	out := make([]InterfaceMethod, 0, len(in))
+	for _, m := range in {
+		out = append(out, InterfaceMethod{Name: m.Name, Slot: m.Slot})
+	}
+	return out
+}
+
+func toInterfaceMethods(in []InterfaceMethod) []mir.InterfaceMethod {
+	out := make([]mir.InterfaceMethod, 0, len(in))
+	for _, m := range in {
+		out = append(out, mir.InterfaceMethod{Name: m.Name, Slot: m.Slot})
+	}
+	return out
+}
+
+func fromInterfaceImpls(in []mir.InterfaceImpl) []InterfaceImpl {
+	out := make([]InterfaceImpl, 0, len(in))
+	for _, impl := range in {
+		out = append(out, InterfaceImpl{ImplName: impl.ImplName, VtableSym: impl.VtableSym})
+	}
+	return out
+}
+
+func toInterfaceImpls(in []InterfaceImpl) []mir.InterfaceImpl {
+	out := make([]mir.InterfaceImpl, 0, len(in))
+	for _, impl := range in {
+		out = append(out, mir.InterfaceImpl{ImplName: impl.ImplName, VtableSym: impl.VtableSym})
+	}
+	return out
+}
+
+func toGlobal(in Global, functions map[string]*mir.Function) (*mir.Global, error) {
+	t, err := toType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	out := &mir.Global{Name: in.Name, Type: t, Mut: in.Mut, SpanV: toSpan(in.Span)}
+	if in.HasInit || in.InitSymbol != "" {
+		fn := functions[in.InitSymbol]
+		if fn == nil {
+			return nil, fmt.Errorf("global %q references missing init function %q", in.Name, in.InitSymbol)
+		}
+		out.Init = fn
+	}
+	return out, nil
+}

--- a/internal/mirjson/json_test.go
+++ b/internal/mirjson/json_test.go
@@ -1,0 +1,55 @@
+package mirjson
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+)
+
+func TestModuleRoundTripPreservesMIREmissionShape(t *testing.T) {
+	orig := roundTripFixtureMIR()
+	encoded, err := FromModule(orig)
+	if err != nil {
+		t.Fatalf("FromModule: %v", err)
+	}
+	decoded, err := ToModule(encoded)
+	if err != nil {
+		t.Fatalf("ToModule: %v", err)
+	}
+	if got, want := mir.Print(decoded), mir.Print(orig); got != want {
+		t.Fatalf("round-trip MIR print mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+	if got := decoded.Functions[0].Locals[0].Type.String(); got != "Int" {
+		t.Fatalf("return local type = %q, want Int", got)
+	}
+	if !strings.Contains(decoded.Functions[0].Name, "main") {
+		t.Fatalf("function name not preserved: %q", decoded.Functions[0].Name)
+	}
+	if decoded.Layouts.Structs["pkg.Point"] == nil {
+		t.Fatalf("qualified struct layout key was not preserved: %#v", decoded.Layouts.Structs)
+	}
+}
+
+func roundTripFixtureMIR() *mir.Module {
+	fn := &mir.Function{Name: "main", ReturnType: ir.TInt}
+	ret := fn.NewLocal("_return", ir.TInt, true, mir.Span{})
+	fn.ReturnLocal = ret
+	fn.Locals[ret].IsReturn = true
+	entry := fn.NewBlock(mir.Span{})
+	fn.Entry = entry
+	bb := fn.Block(entry)
+	bb.Append(&mir.AssignInstr{
+		Dest: mir.Place{Local: ret},
+		Src:  &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: 7, T: ir.TInt}, T: ir.TInt}},
+	})
+	bb.SetTerminator(&mir.ReturnTerm{})
+	layouts := mir.NewLayoutTable()
+	layouts.Structs["pkg.Point"] = &mir.StructLayout{
+		Name:    "Point",
+		Mangled: "Point",
+		Fields:  []mir.FieldLayout{{Index: 0, Name: "x", Type: ir.TInt}},
+	}
+	return &mir.Module{Package: "main", Functions: []*mir.Function{fn}, Layouts: layouts}
+}

--- a/internal/nativellvmgen/exec.go
+++ b/internal/nativellvmgen/exec.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/mirjson"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/toolchain"
 )
@@ -20,6 +22,15 @@ type Request struct {
 	Path    string        `json:"path,omitempty"`
 	Source  string        `json:"source,omitempty"`
 	Package *PackageInput `json:"package,omitempty"`
+	MIR     *MIRInput     `json:"mir,omitempty"`
+}
+
+type MIRInput struct {
+	PackageName string          `json:"packageName,omitempty"`
+	SourcePath  string          `json:"sourcePath,omitempty"`
+	Source      string          `json:"source,omitempty"`
+	Target      string          `json:"target,omitempty"`
+	Module      *mirjson.Module `json:"module,omitempty"`
 }
 
 type PackageInput struct {
@@ -97,6 +108,35 @@ func TryPackage(start, entryPath string, pkg *resolve.Package) ([]byte, bool, []
 		return nil, false, nil, err
 	}
 	return []byte(resp.LLVMIR), resp.Covered, warningErrors(resp.Warnings), nil
+}
+
+func TryMIR(start, packageName, sourcePath string, source []byte, module *mir.Module, target string) ([]byte, bool, []error, error) {
+	req, err := RequestFromMIR(packageName, sourcePath, source, module, target)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	resp, err := Run(start, req)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	return []byte(resp.LLVMIR), resp.Covered, warningErrors(resp.Warnings), nil
+}
+
+func RequestFromMIR(packageName, sourcePath string, source []byte, module *mir.Module, target string) (Request, error) {
+	payload, err := mirjson.FromModule(module)
+	if err != nil {
+		return Request{}, fmt.Errorf("encode MIR for native llvmgen: %w", err)
+	}
+	return Request{
+		Path: sourcePath,
+		MIR: &MIRInput{
+			PackageName: packageName,
+			SourcePath:  sourcePath,
+			Source:      string(source),
+			Target:      target,
+			Module:      payload,
+		},
+	}, nil
 }
 
 func RequestFromPackage(entryPath string, pkg *resolve.Package) (Request, error) {

--- a/internal/nativellvmgen/exec_test.go
+++ b/internal/nativellvmgen/exec_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -114,6 +116,48 @@ func TestTryPackageUsesManagedBinaryWhenEnvUnset(t *testing.T) {
 	if !req.Package.RuntimeCapability {
 		t.Fatal("runtime capability was not forwarded")
 	}
+}
+
+func TestRequestFromMIREncodesPayload(t *testing.T) {
+	sourcePath := "/tmp/mir_main.osty"
+	req, err := RequestFromMIR("main", sourcePath, []byte("fn main() -> Int { 7 }\n"), simpleReturnIntMIR(), "x86_64-unknown-linux-gnu")
+	if err != nil {
+		t.Fatalf("RequestFromMIR error: %v", err)
+	}
+	if req.Path != sourcePath {
+		t.Fatalf("request path = %q, want source path", req.Path)
+	}
+	if req.Package != nil || req.Source != "" {
+		t.Fatalf("request carried source/package path: %#v", req)
+	}
+	if req.MIR == nil || req.MIR.Module == nil {
+		t.Fatalf("request MIR payload missing: %#v", req.MIR)
+	}
+	if req.MIR.PackageName != "main" || req.MIR.Target != "x86_64-unknown-linux-gnu" {
+		t.Fatalf("MIR metadata = %#v", req.MIR)
+	}
+	if got := req.MIR.Module.Functions[0].Name; got != "main" {
+		t.Fatalf("MIR function = %q, want main", got)
+	}
+	if got := req.MIR.Module.Functions[0].Blocks[0].Instrs[0].Kind; got != "assign" {
+		t.Fatalf("MIR instr kind = %q, want assign", got)
+	}
+}
+
+func simpleReturnIntMIR() *mir.Module {
+	fn := &mir.Function{Name: "main", ReturnType: ir.TInt}
+	ret := fn.NewLocal("_return", ir.TInt, true, mir.Span{})
+	fn.ReturnLocal = ret
+	fn.Locals[ret].IsReturn = true
+	entry := fn.NewBlock(mir.Span{})
+	fn.Entry = entry
+	bb := fn.Block(entry)
+	bb.Append(&mir.AssignInstr{
+		Dest: mir.Place{Local: ret},
+		Src:  &mir.UseRV{Op: &mir.ConstOp{Const: &mir.IntConst{Value: 7, T: ir.TInt}, T: ir.TInt}},
+	})
+	bb.SetTerminator(&mir.ReturnTerm{})
+	return &mir.Module{Package: "main", Functions: []*mir.Function{fn}, Layouts: mir.NewLayoutTable()}
 }
 
 func buildFakeNativeLLVMGen(t *testing.T) string {

--- a/internal/toolchain/native_llvmgen.go
+++ b/internal/toolchain/native_llvmgen.go
@@ -20,6 +20,8 @@ var nativeLLVMGenSourceInputs = []string{
 	"cmd/osty-native-llvmgen",
 	"internal/backend",
 	"internal/llvmgen",
+	"internal/mirjson",
+	"internal/nativelirproto",
 	"internal/nativellvmgen",
 	"go.mod",
 	"go.sum",


### PR DESCRIPTION
## Summary
- Add a stable MIR JSON payload boundary for native LLVM generator subprocesses.
- Route backend native-owned LLVM dispatch through MIR payload subprocess execution with MIR-direct fallback.
- Update generator/backend/docs coverage for LIR Proto-first and MIR payload behavior.

## Test plan
- [x] Focused backend/native-generator tests passed
- [x] `go test -count=1 -vet=off ./cmd/osty` passed
- [ ] `just prepush` timed out locally before completion