### PR TITLE
fix(format): add BytesLit serialization to canonical source printer

### DIFF
--- a/internal/format/bytes_lit_test.go
+++ b/internal/format/bytes_lit_test.go
@@ -1,0 +1,48 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/token"
+)
+
+func TestFormatBytesLit(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"empty", "", "b\"\""},
+		{"single_quote_bug", "\"", "b\"\\\"\""},
+		{"hello", "hello", "b\"hello\""},
+		{"with_null", "\x00", "b\"\\0\""},
+		{"with_bytes", "\x00\x01\xff", "b\"\\0\\x01\\xFF\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lit := &ast.BytesLit{Value: tc.value, PosV: token.Pos{Offset: 0}, EndV: token.Pos{Offset: 10}}
+			got := string(File(&ast.File{Decls: []ast.Decl{&ast.FnDecl{
+				Name: "test",
+				Body: &ast.Block{Stmts: []ast.Stmt{&ast.ExprStmt{X: lit}}},
+			}}}))
+			if !contains(got, tc.want) {
+				t.Errorf("got %q, want to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(len(s) > 0 && len(sub) > 0 && findSub(s, sub)))
+}
+
+func findSub(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/format/escapes.go
+++ b/internal/format/escapes.go
@@ -98,6 +98,13 @@ func escapeForByte(b byte) string {
 	return string(b)
 }
 
+func escapeForBytesLit(b byte) string {
+	if b == '"' {
+		return `\"`
+	}
+	return escapeForByte(b)
+}
+
 // writeDefaultRune is the shared tail of the string escapers: an
 // escapeCommon match wins, otherwise unicode.IsPrint gates whether the
 // rune goes out literally or as `\u{...}`. IsPrint catches the invisible

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -986,6 +986,12 @@ func (p *printer) printExprInner(e ast.Expr) {
 		p.write("'" + escapeForChar(n.Value) + "'")
 	case *ast.ByteLit:
 		p.write("b'" + escapeForByte(n.Value) + "'")
+	case *ast.BytesLit:
+		p.write("b\"")
+		for _, b := range []byte(n.Value) {
+			p.write(escapeForBytesLit(b))
+		}
+		p.write("\"")
 	case *ast.BoolLit:
 		if n.Value {
 			p.write("true")


### PR DESCRIPTION
## Summary
- Added `*ast.BytesLit` case to `printExprInner` in `format/printer.go` — was missing entirely, causing `/* unknown expr *ast.BytesLit */` in canonical source output
- Added `escapeForBytesLit` helper that escapes `"` → `\"` (in addition to the existing `escapeForByte` logic) since bytes literals use double-quote delimiters
- This fix resolves `std.http` module resolution failure (`PkgScope nil`) caused by the selfhost parser choking on the unserialised nodes in canonical source

## Test plan
- [x] `just fmt-check` + `go vet` pass
- [x] `TestStdlibSupportMatrixModulesResolve/http` now passes
- [x] 537 tests across stdlib/format/canonical/resolve/selfhost — zero regressions
- [x] New `TestFormatBytesLit` covering empty, quote, null-byte, multi-byte cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)