### PR TITLE
std.term: implement readKey/pollKey with runtime + fix MIR Result ABI

### DIFF
--- a/LANG_SPEC_v0.5/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.5/10-standard-library/25-term.md
@@ -38,5 +38,5 @@ one-based row/column convention used by ANSI terminals.
 raw mode, hide the cursor, or switch to the alternate screen.
 
 Current LLVM backend coverage includes `isTerminal`, `size`, `write`, `flush`,
-and `setRawMode`. Key and resize event decoding is part of the next host-backed
-terminal increment.
+`setRawMode`, `readKey`, and `pollKey`. Resize event decoding is part of the
+next host-backed terminal increment.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -24590,7 +24590,35 @@ void *osty_rt_io_read_line(void) {
  * - size() always succeeds, using the TTY size when available and
  *   COLUMNS/LINES or 80x24 as a deterministic fallback.
  * - write(), flush(), and setRawMode() return NULL on success or a managed
- *   String containing a human-readable error message on failure. */
+ *   String containing a human-readable error message on failure.
+ * - readKey() / pollKey() publish the decoded key in thread-local slots and
+ *   return a small status code consumed by the LLVM shim. */
+enum {
+    OSTY_RT_TERM_KEY_CHAR = 0,
+    OSTY_RT_TERM_KEY_ENTER = 1,
+    OSTY_RT_TERM_KEY_ESCAPE = 2,
+    OSTY_RT_TERM_KEY_BACKSPACE = 3,
+    OSTY_RT_TERM_KEY_TAB = 4,
+    OSTY_RT_TERM_KEY_BACKTAB = 5,
+    OSTY_RT_TERM_KEY_UP = 6,
+    OSTY_RT_TERM_KEY_DOWN = 7,
+    OSTY_RT_TERM_KEY_LEFT = 8,
+    OSTY_RT_TERM_KEY_RIGHT = 9,
+    OSTY_RT_TERM_KEY_HOME = 10,
+    OSTY_RT_TERM_KEY_END = 11,
+    OSTY_RT_TERM_KEY_PAGE_UP = 12,
+    OSTY_RT_TERM_KEY_PAGE_DOWN = 13,
+    OSTY_RT_TERM_KEY_INSERT = 14,
+    OSTY_RT_TERM_KEY_DELETE = 15,
+    OSTY_RT_TERM_KEY_FUNCTION = 16,
+    OSTY_RT_TERM_KEY_UNKNOWN = 17,
+};
+
+static OSTY_RT_TLS int64_t osty_rt_term_last_key_code = OSTY_RT_TERM_KEY_UNKNOWN;
+static OSTY_RT_TLS int64_t osty_rt_term_last_key_function = 0;
+static OSTY_RT_TLS void *osty_rt_term_last_key_text = NULL;
+static OSTY_RT_TLS void *osty_rt_term_last_error_text = NULL;
+
 static void *osty_rt_term_error_message(const char *prefix, const char *detail, const char *site) {
     const char *lhs = prefix == NULL ? "terminal error" : prefix;
     const char *rhs = (detail != NULL && detail[0] != '\0') ? detail : "unknown error";
@@ -24606,6 +24634,61 @@ static void *osty_rt_term_error_message(const char *prefix, const char *detail, 
     void *out = osty_rt_string_dup_site(buf, total, site);
     free(buf);
     return out;
+}
+
+static void osty_rt_term_set_last_error(const char *prefix, const char *detail, const char *site) {
+    osty_rt_term_last_error_text = osty_rt_term_error_message(prefix, detail, site);
+}
+
+static void osty_rt_term_set_last_errno(const char *prefix, const char *site) {
+    const char *detail = errno == 0 ? "unknown error" : strerror(errno);
+    osty_rt_term_set_last_error(prefix, detail, site);
+}
+
+void *osty_rt_term_last_error(void) {
+    if (osty_rt_term_last_error_text != NULL) {
+        return osty_rt_term_last_error_text;
+    }
+    return osty_rt_term_error_message("terminal input error", "unknown error", "runtime.term.input.unknown_error");
+}
+
+static void osty_rt_term_clear_input_status(void) {
+    osty_rt_term_last_error_text = NULL;
+    osty_rt_term_last_key_code = OSTY_RT_TERM_KEY_UNKNOWN;
+    osty_rt_term_last_key_function = 0;
+    osty_rt_term_last_key_text = NULL;
+}
+
+static void osty_rt_term_set_key_text(int64_t code, const char *text, size_t len, const char *site) {
+    osty_rt_term_last_key_code = code;
+    osty_rt_term_last_key_function = 0;
+    osty_rt_term_last_key_text = osty_rt_string_dup_site(text, len, site);
+}
+
+static void osty_rt_term_set_key_bare(int64_t code) {
+    osty_rt_term_last_key_code = code;
+    osty_rt_term_last_key_function = 0;
+    osty_rt_term_last_key_text = NULL;
+}
+
+static void osty_rt_term_set_key_function(int64_t n) {
+    osty_rt_term_last_key_code = OSTY_RT_TERM_KEY_FUNCTION;
+    osty_rt_term_last_key_function = n;
+    osty_rt_term_last_key_text = NULL;
+}
+
+int64_t osty_rt_term_key_code(void) {
+    return osty_rt_term_last_key_code;
+}
+
+void *osty_rt_term_key_text(void) {
+    return osty_rt_term_last_key_text != NULL
+        ? osty_rt_term_last_key_text
+        : osty_rt_string_dup_site("", 0, "runtime.term.key.empty");
+}
+
+int64_t osty_rt_term_key_function(void) {
+    return osty_rt_term_last_key_function;
 }
 
 static void *osty_rt_term_errno_error(const char *prefix, const char *site) {
@@ -24712,6 +24795,279 @@ void *osty_rt_term_flush(void) {
         return osty_rt_term_errno_error("failed to flush terminal", "runtime.term.flush.error");
     }
     return NULL;
+}
+
+static int osty_rt_term_stdin_ready(int64_t timeout_ms) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD wait_ms = timeout_ms < 0 ? INFINITE : (DWORD)timeout_ms;
+    DWORD wait_result;
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL) {
+        osty_rt_term_set_last_error("failed to poll terminal input", "stdin is not a console", "runtime.term.poll.error");
+        return -1;
+    }
+    wait_result = WaitForSingleObject(handle, wait_ms);
+    if (wait_result == WAIT_TIMEOUT) {
+        return 0;
+    }
+    if (wait_result == WAIT_OBJECT_0) {
+        return 1;
+    }
+    osty_rt_term_set_last_error("failed to poll terminal input", "WaitForSingleObject failed", "runtime.term.poll.error");
+    return -1;
+#else
+    struct pollfd pfd;
+    int rc;
+    int timeout = -1;
+    if (timeout_ms >= 0) {
+        timeout = timeout_ms > INT_MAX ? INT_MAX : (int)timeout_ms;
+    }
+    pfd.fd = STDIN_FILENO;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    do {
+        errno = 0;
+        rc = poll(&pfd, 1, timeout);
+    } while (rc < 0 && errno == EINTR);
+    if (rc == 0) {
+        return 0;
+    }
+    if (rc < 0) {
+        osty_rt_term_set_last_errno("failed to poll terminal input", "runtime.term.poll.error");
+        return -1;
+    }
+    if ((pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+        osty_rt_term_set_last_error("failed to poll terminal input", "stdin is not readable", "runtime.term.poll.error");
+        return -1;
+    }
+    return (pfd.revents & POLLIN) != 0 ? 1 : 0;
+#endif
+}
+
+static int osty_rt_term_read_byte(unsigned char *out) {
+#if defined(OSTY_RT_PLATFORM_WIN32)
+    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+    char ch = 0;
+    DWORD got = 0;
+    if (out == NULL) {
+        return -1;
+    }
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL) {
+        osty_rt_term_set_last_error("failed to read terminal input", "stdin is not a console", "runtime.term.read.error");
+        return -1;
+    }
+    if (!ReadFile(handle, &ch, 1, &got, NULL) || got == 0) {
+        osty_rt_term_set_last_error("failed to read terminal input", "ReadFile failed", "runtime.term.read.error");
+        return -1;
+    }
+    *out = (unsigned char)ch;
+    return 0;
+#else
+    ssize_t n;
+    if (out == NULL) {
+        return -1;
+    }
+    do {
+        errno = 0;
+        n = read(STDIN_FILENO, out, 1);
+    } while (n < 0 && errno == EINTR);
+    if (n == 1) {
+        return 0;
+    }
+    if (n == 0) {
+        osty_rt_term_set_last_error("failed to read terminal input", "end of input", "runtime.term.read.eof");
+        return -1;
+    }
+    osty_rt_term_set_last_errno("failed to read terminal input", "runtime.term.read.error");
+    return -1;
+#endif
+}
+
+static int osty_rt_term_read_byte_timeout(unsigned char *out, int64_t timeout_ms) {
+    int ready = osty_rt_term_stdin_ready(timeout_ms);
+    if (ready <= 0) {
+        return ready;
+    }
+    return osty_rt_term_read_byte(out) == 0 ? 1 : -1;
+}
+
+static void osty_rt_term_set_ascii_key(unsigned char ch) {
+    char text[2];
+    switch (ch) {
+    case '\r':
+    case '\n':
+        osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_ENTER);
+        return;
+    case '\t':
+        osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_TAB);
+        return;
+    case 0x7f:
+    case 0x08:
+        osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_BACKSPACE);
+        return;
+    default:
+        break;
+    }
+    text[0] = (char)ch;
+    text[1] = '\0';
+    osty_rt_term_set_key_text(OSTY_RT_TERM_KEY_CHAR, text, 1, "runtime.term.key.char");
+}
+
+static void osty_rt_term_set_csi_key(char final, const int64_t *nums, int count, bool shifted) {
+    int64_t first = count > 0 ? nums[0] : 0;
+    switch (final) {
+    case 'A': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_UP); return;
+    case 'B': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_DOWN); return;
+    case 'C': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_RIGHT); return;
+    case 'D': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_LEFT); return;
+    case 'H': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_HOME); return;
+    case 'F': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_END); return;
+    case 'Z': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_BACKTAB); return;
+    case '~':
+        switch (first) {
+        case 1:
+        case 7:
+            osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_HOME); return;
+        case 2: osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_INSERT); return;
+        case 3: osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_DELETE); return;
+        case 4:
+        case 8:
+            osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_END); return;
+        case 5: osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_PAGE_UP); return;
+        case 6: osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_PAGE_DOWN); return;
+        case 11: osty_rt_term_set_key_function(1); return;
+        case 12: osty_rt_term_set_key_function(2); return;
+        case 13: osty_rt_term_set_key_function(3); return;
+        case 14: osty_rt_term_set_key_function(4); return;
+        case 15: osty_rt_term_set_key_function(5); return;
+        case 17: osty_rt_term_set_key_function(6); return;
+        case 18: osty_rt_term_set_key_function(7); return;
+        case 19: osty_rt_term_set_key_function(8); return;
+        case 20: osty_rt_term_set_key_function(9); return;
+        case 21: osty_rt_term_set_key_function(10); return;
+        case 23: osty_rt_term_set_key_function(11); return;
+        case 24: osty_rt_term_set_key_function(12); return;
+        default: break;
+        }
+        break;
+    default:
+        break;
+    }
+    (void)shifted;
+}
+
+static int osty_rt_term_decode_escape_sequence(void) {
+    unsigned char ch = 0;
+    int got = osty_rt_term_read_byte_timeout(&ch, 25);
+    if (got == 0) {
+        osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_ESCAPE);
+        return 0;
+    }
+    if (got < 0) {
+        return -1;
+    }
+    if (ch == 'O') {
+        got = osty_rt_term_read_byte_timeout(&ch, 25);
+        if (got <= 0) {
+            return got < 0 ? -1 : (osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_ESCAPE), 0);
+        }
+        switch (ch) {
+        case 'P': osty_rt_term_set_key_function(1); return 0;
+        case 'Q': osty_rt_term_set_key_function(2); return 0;
+        case 'R': osty_rt_term_set_key_function(3); return 0;
+        case 'S': osty_rt_term_set_key_function(4); return 0;
+        case 'H': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_HOME); return 0;
+        case 'F': osty_rt_term_set_key_bare(OSTY_RT_TERM_KEY_END); return 0;
+        default: break;
+        }
+    } else if (ch == '[') {
+        char seq[32];
+        size_t len = 0;
+        int64_t nums[3] = {0, 0, 0};
+        int count = 0;
+        int64_t current = 0;
+        bool have_digit = false;
+        bool shifted = false;
+        char final = '\0';
+        while (len + 1 < sizeof(seq)) {
+            got = osty_rt_term_read_byte_timeout(&ch, 25);
+            if (got <= 0) {
+                break;
+            }
+            seq[len++] = (char)ch;
+            if (ch >= 0x40 && ch <= 0x7e) {
+                final = (char)ch;
+                break;
+            }
+        }
+        seq[len] = '\0';
+        for (size_t i = 0; i < len; i++) {
+            unsigned char c = (unsigned char)seq[i];
+            if (c >= '0' && c <= '9') {
+                have_digit = true;
+                current = current * 10 + (int64_t)(c - '0');
+                continue;
+            }
+            if (c == ';' || c == final) {
+                if (have_digit && count < 3) {
+                    nums[count++] = current;
+                    if (count == 2 && current == 2) {
+                        shifted = true;
+                    }
+                }
+                current = 0;
+                have_digit = false;
+            }
+        }
+        if (final != '\0') {
+            osty_rt_term_set_csi_key(final, nums, count, shifted);
+            if (osty_rt_term_last_key_code != OSTY_RT_TERM_KEY_UNKNOWN) {
+                return 0;
+            }
+        }
+        if (len > 0) {
+            osty_rt_term_set_key_text(OSTY_RT_TERM_KEY_UNKNOWN, seq, len, "runtime.term.key.unknown.csi");
+            return 0;
+        }
+    }
+    {
+        char text[2] = {(char)ch, '\0'};
+        osty_rt_term_set_key_text(OSTY_RT_TERM_KEY_UNKNOWN, text, 1, "runtime.term.key.unknown.escape");
+    }
+    return 0;
+}
+
+static int osty_rt_term_decode_key_blocking(void) {
+    unsigned char ch = 0;
+    if (osty_rt_term_read_byte(&ch) != 0) {
+        return -1;
+    }
+    if (ch == 0x1b) {
+        return osty_rt_term_decode_escape_sequence();
+    }
+    osty_rt_term_set_ascii_key(ch);
+    return 0;
+}
+
+int64_t osty_rt_term_read_key_status(void) {
+    osty_rt_term_clear_input_status();
+    return osty_rt_term_decode_key_blocking() == 0 ? 0 : 1;
+}
+
+int64_t osty_rt_term_poll_key_status(int64_t timeout_ms) {
+    int ready;
+    osty_rt_term_clear_input_status();
+    if (timeout_ms < 0) {
+        timeout_ms = 0;
+    }
+    ready = osty_rt_term_stdin_ready(timeout_ms);
+    if (ready == 0) {
+        return 1;
+    }
+    if (ready < 0) {
+        return 2;
+    }
+    return osty_rt_term_decode_key_blocking() == 0 ? 0 : 2;
 }
 
 #if defined(OSTY_RT_PLATFORM_WIN32)

--- a/internal/llvmgen/coalesce_test.go
+++ b/internal/llvmgen/coalesce_test.go
@@ -189,7 +189,7 @@ fn main() {}
 		"%Option.string = type { i64, i64 }",
 		"define ptr @resolve(%Option.string %arg0)",
 		"switch i64",
-		"i64 1, label",
+		"i64 0, label",
 		"inttoptr i64",
 		"store ptr @.str.0",
 		"ret ptr",

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -533,12 +533,14 @@ func (g *generator) render(defs []string) []byte {
 	allDefs = append(allDefs, g.globalDefs...)
 	allDefs = append(allDefs, defs...)
 	typeDefs := make([]string, 0, len(g.structs)+len(g.enumsByType)+len(g.tupleTypes)+len(g.resultTypes)+len(g.rangeTypes))
+	emittedStructTypeDefs := map[string]bool{}
 	for _, info := range g.structs {
 		fieldTypes := make([]string, 0, len(info.fields))
 		for _, field := range info.fields {
 			fieldTypes = append(fieldTypes, field.typ)
 		}
 		typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fieldTypes))
+		emittedStructTypeDefs[info.name] = true
 	}
 	for _, info := range g.enums {
 		if info.hasPayload {
@@ -564,7 +566,10 @@ func (g *generator) render(defs []string) []byte {
 					fields = append(fields, slotTyp)
 				}
 			}
-			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fields))
+			if !emittedStructTypeDefs[info.name] {
+				typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fields))
+				emittedStructTypeDefs[info.name] = true
+			}
 		}
 	}
 	if len(g.tupleTypes) != 0 {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -4447,10 +4447,10 @@ func (g *mirGen) emitTestingExpectMIR(c *mir.CallInstr, method string) error {
 	if err != nil {
 		return err
 	}
-	wantTag := int64(1)
+	wantTag := int64(0)
 	payloadT := resultT.ok
 	if method == "expectError" {
-		wantTag = 0
+		wantTag = 1
 		payloadT = resultT.err
 	}
 	resultLLVM := g.llvmType(c.Args[0].Type())
@@ -5096,7 +5096,7 @@ func (g *mirGen) emitBenchErrorCheck(retRef, prefix string) {
 	tag := g.fresh()
 	g.fnBuf.WriteString(mirExtractValueLine(tag, "%Result.unit.Error", retRef, "0"))
 	isErr := g.fresh()
-	g.fnBuf.WriteString(mirICmpEqI64Line(isErr, tag, "0"))
+	g.fnBuf.WriteString(mirICmpEqI64Line(isErr, tag, "1"))
 	errLabel := g.freshLabel(prefix + ".err")
 	okLabel := g.freshLabel(prefix + ".ok")
 	g.fnBuf.WriteString(mirBranchToErrorTrapLines(isErr, errLabel, okLabel))

--- a/internal/llvmgen/mir_generator_snapshot.go
+++ b/internal/llvmgen/mir_generator_snapshot.go
@@ -3060,15 +3060,12 @@ func mirNoneAggregateLines(stepReg, valueReg, optLLVM string) string {
 // insertvalue construction.
 // Osty: mirOkAggregateLines
 func mirOkAggregateLines(stepReg, valueReg, resultLLVM, payloadI64 string) string {
-	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "1", "0") +
+	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", mirDiscriminantOk(), "0") +
 		mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
 }
 
-// mirErrAggregateLines renders the canonical Err(payload) two-
-// insertvalue construction.
-// Osty: mirErrAggregateLines
 func mirErrAggregateLines(stepReg, valueReg, resultLLVM, payloadI64 string) string {
-	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "0", "0") +
+	return mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", mirDiscriminantErr(), "0") +
 		mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
 }
 
@@ -5866,8 +5863,8 @@ func mirElementKindStruct() string { return "7" }
 // Osty: mirDiscriminant{None,Some,Ok,Err}
 func mirDiscriminantNone() string { return "0" }
 func mirDiscriminantSome() string { return "1" }
-func mirDiscriminantOk() string   { return "1" }
-func mirDiscriminantErr() string  { return "0" }
+func mirDiscriminantOk() string   { return "0" }
+func mirDiscriminantErr() string  { return "1" }
 
 // §6 boolean-literal tokens.
 

--- a/internal/llvmgen/stdlib_mir_runtime_shim.go
+++ b/internal/llvmgen/stdlib_mir_runtime_shim.go
@@ -799,6 +799,8 @@ func (g *mirGen) emitStdTermCall(c *mir.CallInstr, fnRef *mir.FnRef) (bool, erro
 			return true, err
 		}
 		return true, g.emitUnitResultFromNullableError(c, ostyRtTermSetRawModeSymbol, []mirRuntimeArg{enabled})
+	case "readKey", "pollKey", "readEvent":
+		return true, unsupported("mir-mvp", "std.term."+method+" is only wired through the AST LLVM shim")
 	}
 	return false, nil
 }

--- a/internal/llvmgen/stdlib_term_shim.go
+++ b/internal/llvmgen/stdlib_term_shim.go
@@ -8,17 +8,48 @@ const ostyRtTermHeightSymbol = "osty_rt_term_height"
 const ostyRtTermWriteSymbol = "osty_rt_term_write"
 const ostyRtTermFlushSymbol = "osty_rt_term_flush"
 const ostyRtTermSetRawModeSymbol = "osty_rt_term_set_raw_mode"
+const ostyRtTermReadKeyStatusSymbol = "osty_rt_term_read_key_status"
+const ostyRtTermPollKeyStatusSymbol = "osty_rt_term_poll_key_status"
+const ostyRtTermKeyCodeSymbol = "osty_rt_term_key_code"
+const ostyRtTermKeyTextSymbol = "osty_rt_term_key_text"
+const ostyRtTermKeyFunctionSymbol = "osty_rt_term_key_function"
+const ostyRtTermLastErrorSymbol = "osty_rt_term_last_error"
 
 const stdTermSyntheticSizeTypeName = "__osty_std_term_Size"
+const stdTermSyntheticKeyTypeName = "__osty_std_term_Key"
 
 var stdTermSizeSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{stdTermSyntheticSizeTypeName},
+}
+
+var stdTermKeySourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{stdTermSyntheticKeyTypeName},
 }
 
 var stdTermSizeResultSourceTypeSingleton ast.Type = &ast.NamedType{
 	Path: []string{"Result"},
 	Args: []ast.Type{
 		stdTermSizeSourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdTermKeyResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdTermKeySourceTypeSingleton,
+		errorSourceTypeSingleton,
+	},
+}
+
+var stdTermKeyOptionSourceTypeSingleton ast.Type = &ast.OptionalType{
+	Inner: stdTermKeySourceTypeSingleton,
+}
+
+var stdTermKeyOptionResultSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"Result"},
+	Args: []ast.Type{
+		stdTermKeyOptionSourceTypeSingleton,
 		errorSourceTypeSingleton,
 	},
 }
@@ -94,6 +125,58 @@ func ensureStdTermSyntheticSizeStruct(g *generator) *structInfo {
 	return info
 }
 
+func ensureStdTermSyntheticKeyEnum(g *generator) *enumInfo {
+	if g == nil {
+		return nil
+	}
+	if info := g.enumsByName[stdTermSyntheticKeyTypeName]; info != nil {
+		return info
+	}
+	if g.enumsByName == nil {
+		g.enumsByName = map[string]*enumInfo{}
+	}
+	if g.enumsByType == nil {
+		g.enumsByType = map[string]*enumInfo{}
+	}
+	info := &enumInfo{
+		name:       stdTermSyntheticKeyTypeName,
+		typ:        llvmStructTypeName(stdTermSyntheticKeyTypeName),
+		decl:       &ast.EnumDecl{Name: stdTermSyntheticKeyTypeName},
+		hasPayload: true,
+		isBoxed:    true,
+		variants:   map[string]variantInfo{},
+	}
+	addBare := func(tag int, name string) {
+		info.decl.Variants = append(info.decl.Variants, &ast.Variant{Name: name})
+		info.variants[name] = variantInfo{name: name, tag: tag}
+	}
+	info.decl.Variants = append(info.decl.Variants, &ast.Variant{Name: "Char", Fields: []ast.Type{stringSourceTypeSingleton}})
+	info.variants["Char"] = variantInfo{name: "Char", tag: 0, payloads: []string{"ptr"}, payloadSourceTypes: []ast.Type{stringSourceTypeSingleton}}
+	addBare(1, "Enter")
+	addBare(2, "EscapeKey")
+	addBare(3, "Backspace")
+	addBare(4, "Tab")
+	addBare(5, "BackTab")
+	addBare(6, "Up")
+	addBare(7, "Down")
+	addBare(8, "Left")
+	addBare(9, "Right")
+	addBare(10, "Home")
+	addBare(11, "End")
+	addBare(12, "PageUp")
+	addBare(13, "PageDown")
+	addBare(14, "Insert")
+	addBare(15, "Delete")
+	info.decl.Variants = append(info.decl.Variants, &ast.Variant{Name: "Function", Fields: []ast.Type{intSourceTypeSingleton}})
+	info.variants["Function"] = variantInfo{name: "Function", tag: 16, payloads: []string{"i64"}, payloadSourceTypes: []ast.Type{intSourceTypeSingleton}}
+	info.decl.Variants = append(info.decl.Variants, &ast.Variant{Name: "Unknown", Fields: []ast.Type{stringSourceTypeSingleton}})
+	info.variants["Unknown"] = variantInfo{name: "Unknown", tag: 17, payloads: []string{"ptr"}, payloadSourceTypes: []ast.Type{stringSourceTypeSingleton}}
+	g.enums = append(g.enums, info)
+	g.enumsByName[info.name] = info
+	g.enumsByType[info.typ] = info
+	return info
+}
+
 func (g *generator) emitStdTermCall(call *ast.CallExpr) (value, bool, error) {
 	field, ok := g.stdTermCallField(call)
 	if !ok {
@@ -110,7 +193,11 @@ func (g *generator) emitStdTermCall(call *ast.CallExpr) (value, bool, error) {
 		return g.emitStdTermFlushCall(call)
 	case "setRawMode":
 		return g.emitStdTermSetRawModeCall(call)
-	case "readKey", "pollKey", "readEvent":
+	case "readKey":
+		return g.emitStdTermReadKeyCall(call)
+	case "pollKey":
+		return g.emitStdTermPollKeyCall(call)
+	case "readEvent":
 		return value{}, true, unsupportedf("call", "std.term.%s is not supported by LLVM yet", field.Name)
 	default:
 		return value{}, false, nil
@@ -146,6 +233,20 @@ func (g *generator) stdTermCallStaticResult(call *ast.CallExpr) (value, bool) {
 			sourceType: stdTermUnitErrorResultSourceTypeSingleton,
 			rootPaths:  g.rootPathsForType(info.typ),
 		}, true
+	case "readKey":
+		ensureStdTermSyntheticKeyEnum(g)
+		info, ok := builtinResultTypeFromAST(stdTermKeyResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdTermKeyResultSourceTypeSingleton, rootPaths: g.rootPathsForType(info.typ)}, true
+	case "pollKey":
+		ensureStdTermSyntheticKeyEnum(g)
+		info, ok := builtinResultTypeFromAST(stdTermKeyOptionResultSourceTypeSingleton, g.typeEnv())
+		if !ok {
+			return value{}, false
+		}
+		return value{typ: info.typ, sourceType: stdTermKeyOptionResultSourceTypeSingleton, rootPaths: g.rootPathsForType(info.typ)}, true
 	default:
 		return value{}, false
 	}
@@ -164,6 +265,12 @@ func (g *generator) staticStdTermCallSourceType(call *ast.CallExpr) (ast.Type, b
 		return stdTermSizeResultSourceTypeSingleton, true
 	case "write", "flush", "setRawMode":
 		return stdTermUnitErrorResultSourceTypeSingleton, true
+	case "readKey":
+		ensureStdTermSyntheticKeyEnum(g)
+		return stdTermKeyResultSourceTypeSingleton, true
+	case "pollKey":
+		ensureStdTermSyntheticKeyEnum(g)
+		return stdTermKeyOptionResultSourceTypeSingleton, true
 	default:
 		return nil, false
 	}
@@ -304,4 +411,220 @@ func (g *generator) emitStdTermSetRawModeCall(call *ast.CallExpr) (value, bool, 
 		[]paramInfo{{typ: "i1"}},
 		[]*LlvmValue{toOstyValue(enabled)},
 	)
+}
+
+func (g *generator) emitStdTermReadKeyCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "term.readKey takes no arguments, got %d", len(call.Args))
+	}
+	return g.emitStdTermKeyResultFromStatus("term.readKey", stdTermKeyResultSourceTypeSingleton, ostyRtTermReadKeyStatusSymbol, nil, nil)
+}
+
+func (g *generator) emitStdTermPollKeyCall(call *ast.CallExpr) (value, bool, error) {
+	if len(call.Args) != 1 {
+		return value{}, true, unsupportedf("call", "term.pollKey expects 1 argument, got %d", len(call.Args))
+	}
+	arg := call.Args[0]
+	if arg == nil || (arg.Name != "" && arg.Name != "timeoutMillis") || arg.Value == nil {
+		return value{}, true, unsupported("call", "term.pollKey requires one positional or `timeoutMillis:` Int argument")
+	}
+	timeout, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	timeout, err = g.loadIfPointer(timeout)
+	if err != nil {
+		return value{}, true, err
+	}
+	if timeout.typ != "i64" {
+		return value{}, true, unsupportedf("type-system", "term.pollKey arg 1 type %s, want Int", timeout.typ)
+	}
+	return g.emitStdTermPollKeyResultFromStatus(timeout)
+}
+
+func (g *generator) emitStdTermKeyResultFromStatus(prefix string, sourceType ast.Type, statusSymbol string, params []paramInfo, args []*LlvmValue) (value, bool, error) {
+	keyInfo := ensureStdTermSyntheticKeyEnum(g)
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupportedf("type-system", "%s Result<Key, Error> type is unavailable", prefix)
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if keyInfo == nil || info.okTyp != keyInfo.typ || info.errTyp != "ptr" {
+		want := "<nil>"
+		if keyInfo != nil {
+			want = keyInfo.typ
+		}
+		return value{}, true, unsupportedf("type-system", "%s currently needs Result<%s, ptr>, got ok=%s err=%s", prefix, want, info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(statusSymbol, "i64", params)
+	g.declareRuntimeSymbol(ostyRtTermLastErrorSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	status := llvmCall(emitter, "i64", statusSymbol, args)
+	failed := llvmCompare(emitter, "ne", status, toOstyValue(value{typ: "i64", ref: "0"}))
+	errLabel := llvmNextLabel(emitter, prefix+".err")
+	okLabel := llvmNextLabel(emitter, prefix+".ok")
+	contLabel := llvmNextLabel(emitter, prefix+".cont")
+	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, errLabel+":")
+	errText := llvmCall(emitter, "ptr", ostyRtTermLastErrorSymbol, nil)
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	keyValue, err := g.emitStdTermKeyValueFromRuntime(emitter)
+	if err != nil {
+		g.takeOstyEmitter(emitter)
+		return value{}, true, err
+	}
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		toOstyValue(keyValue),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+okResult.name+", %"+okLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{typ: info.typ, ref: phi, sourceType: sourceType}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdTermPollKeyResultFromStatus(timeout value) (value, bool, error) {
+	keyInfo := ensureStdTermSyntheticKeyEnum(g)
+	info, ok := builtinResultTypeFromAST(stdTermKeyOptionResultSourceTypeSingleton, g.typeEnv())
+	if !ok {
+		return value{}, true, unsupported("type-system", "term.pollKey Result<Key?, Error> type is unavailable")
+	}
+	if g.resultTypes == nil {
+		g.resultTypes = map[string]builtinResultType{}
+	}
+	g.resultTypes[info.typ] = info
+	if keyInfo == nil || info.okTyp != "ptr" || info.errTyp != "ptr" {
+		return value{}, true, unsupportedf("type-system", "term.pollKey currently needs Result<ptr, ptr>, got ok=%s err=%s", info.okTyp, info.errTyp)
+	}
+	g.declareRuntimeSymbol(ostyRtTermPollKeyStatusSymbol, "i64", []paramInfo{{typ: "i64"}})
+	g.declareRuntimeSymbol(ostyRtTermLastErrorSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitCallSafepointIfNeeded(emitter)
+	status := llvmCall(emitter, "i64", ostyRtTermPollKeyStatusSymbol, []*LlvmValue{toOstyValue(timeout)})
+	failed := llvmCompare(emitter, "eq", status, toOstyValue(value{typ: "i64", ref: "2"}))
+	errLabel := llvmNextLabel(emitter, "term.pollKey.err")
+	okLabel := llvmNextLabel(emitter, "term.pollKey.ok")
+	someLabel := llvmNextLabel(emitter, "term.pollKey.some")
+	noneLabel := llvmNextLabel(emitter, "term.pollKey.none")
+	contLabel := llvmNextLabel(emitter, "term.pollKey.cont")
+	emitter.body = append(emitter.body, "  br i1 "+failed.name+", label %"+errLabel+", label %"+okLabel)
+
+	emitter.body = append(emitter.body, errLabel+":")
+	errText := llvmCall(emitter, "ptr", ostyRtTermLastErrorSymbol, nil)
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		errText,
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, okLabel+":")
+	hasKey := llvmCompare(emitter, "eq", status, toOstyValue(value{typ: "i64", ref: "0"}))
+	emitter.body = append(emitter.body, "  br i1 "+hasKey.name+", label %"+someLabel+", label %"+noneLabel)
+
+	emitter.body = append(emitter.body, someLabel+":")
+	keyValue, err := g.emitStdTermKeyValueFromRuntime(emitter)
+	if err != nil {
+		g.takeOstyEmitter(emitter)
+		return value{}, true, err
+	}
+	boxedKey, err := g.emitOptionPayloadBox(emitter, keyValue, "term.pollKey.some")
+	if err != nil {
+		g.takeOstyEmitter(emitter)
+		return value{}, true, err
+	}
+	someResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		toOstyValue(boxedKey),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, noneLabel+":")
+	noneResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+info.typ+" [ "+errResult.name+", %"+errLabel+" ], [ "+someResult.name+", %"+someLabel+" ], [ "+noneResult.name+", %"+noneLabel+" ]")
+	g.takeOstyEmitter(emitter)
+	v := value{typ: info.typ, ref: phi, sourceType: stdTermKeyOptionResultSourceTypeSingleton}
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) emitStdTermKeyValueFromRuntime(emitter *LlvmEmitter) (value, error) {
+	keyInfo := ensureStdTermSyntheticKeyEnum(g)
+	if keyInfo == nil {
+		return value{}, unsupported("type-system", "term.Key type is unavailable")
+	}
+	g.declareRuntimeSymbol(ostyRtTermKeyCodeSymbol, "i64", nil)
+	g.declareRuntimeSymbol(ostyRtTermKeyTextSymbol, "ptr", nil)
+	g.declareRuntimeSymbol(ostyRtTermKeyFunctionSymbol, "i64", nil)
+	code := llvmCall(emitter, "i64", ostyRtTermKeyCodeSymbol, nil)
+	text := llvmCall(emitter, "ptr", ostyRtTermKeyTextSymbol, nil)
+	fn := llvmCall(emitter, "i64", ostyRtTermKeyFunctionSymbol, nil)
+	charCond := llvmCompare(emitter, "eq", code, toOstyValue(value{typ: "i64", ref: "0"}))
+	charLabel := llvmNextLabel(emitter, "term.key.char")
+	fnCheckLabel := llvmNextLabel(emitter, "term.key.function.check")
+	fnLabel := llvmNextLabel(emitter, "term.key.function")
+	unknownCheckLabel := llvmNextLabel(emitter, "term.key.unknown.check")
+	unknownLabel := llvmNextLabel(emitter, "term.key.unknown")
+	bareLabel := llvmNextLabel(emitter, "term.key.bare")
+	contLabel := llvmNextLabel(emitter, "term.key.cont")
+	emitter.body = append(emitter.body, "  br i1 "+charCond.name+", label %"+charLabel+", label %"+fnCheckLabel)
+
+	emitter.body = append(emitter.body, charLabel+":")
+	charKey := llvmEnumBoxedPayloadVariant(emitter, keyInfo.typ, 0, text, "term.key.char")
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, fnCheckLabel+":")
+	fnCond := llvmCompare(emitter, "eq", code, toOstyValue(value{typ: "i64", ref: "16"}))
+	emitter.body = append(emitter.body, "  br i1 "+fnCond.name+", label %"+fnLabel+", label %"+unknownCheckLabel)
+
+	emitter.body = append(emitter.body, fnLabel+":")
+	fnKey := llvmEnumBoxedPayloadVariant(emitter, keyInfo.typ, 16, fn, "term.key.function")
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, unknownCheckLabel+":")
+	unknownCond := llvmCompare(emitter, "eq", code, toOstyValue(value{typ: "i64", ref: "17"}))
+	emitter.body = append(emitter.body, "  br i1 "+unknownCond.name+", label %"+unknownLabel+", label %"+bareLabel)
+
+	emitter.body = append(emitter.body, unknownLabel+":")
+	unknownKey := llvmEnumBoxedPayloadVariant(emitter, keyInfo.typ, 17, text, "term.key.unknown")
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, bareLabel+":")
+	bareKey := llvmStructLiteral(emitter, keyInfo.typ, []*LlvmValue{code, toOstyValue(llvmZeroValue("ptr"))})
+	emitter.body = append(emitter.body, "  br label %"+contLabel)
+
+	emitter.body = append(emitter.body, contLabel+":")
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, "  "+phi+" = phi "+keyInfo.typ+" [ "+charKey.name+", %"+charLabel+" ], [ "+fnKey.name+", %"+fnLabel+" ], [ "+unknownKey.name+", %"+unknownLabel+" ], [ "+bareKey.name+", %"+bareLabel+" ]")
+	g.needsGCRuntime = true
+	out := value{typ: keyInfo.typ, ref: phi, sourceType: stdTermKeySourceTypeSingleton}
+	out.rootPaths = g.rootPathsForType(out.typ)
+	return out, nil
 }

--- a/internal/llvmgen/stdlib_term_shim_test.go
+++ b/internal/llvmgen/stdlib_term_shim_test.go
@@ -61,3 +61,47 @@ fn main() {
 		}
 	}
 }
+
+func TestStdTermInputRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.term as term
+
+fn main() {
+    match term.readKey() {
+        Ok(key) -> println(key.toString()),
+        Err(err) -> println(err.message()),
+    }
+    match term.pollKey(0) {
+        Ok(key) -> println("ok"),
+        Err(err) -> println(err.message()),
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_term_input.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%__osty_std_term_Key = type { i64, ptr }",
+		"declare i64 @osty_rt_term_read_key_status()",
+		"call i64 @osty_rt_term_read_key_status()",
+		"declare i64 @osty_rt_term_poll_key_status(i64)",
+		"call i64 @osty_rt_term_poll_key_status(i64 0)",
+		"declare i64 @osty_rt_term_key_code()",
+		"declare ptr @osty_rt_term_key_text()",
+		"declare i64 @osty_rt_term_key_function()",
+		"declare ptr @osty_rt_term_last_error()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "std.term.readKey is not supported") || strings.Contains(got, "std.term.pollKey is not supported") {
+		t.Fatalf("input functions still emit unsupported diagnostic:\n%s", got)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -4450,10 +4450,10 @@ func (l *lowerer) questionOkPayloadType(t Type) Type {
 }
 
 // errTagOf returns the discriminant value for the error arm of a `?`-
-// able enum (Err / None). For Option/Maybe the error arm is None == 0;
-// for Result, Err == 0.
+// able enum (Err / None). For Option/Maybe the error arm is None (idx 1);
+// for Result, Err (idx 1).
 func errTagOf(t Type) int64 {
-	return 0
+	return 1
 }
 
 // typesMatch is a cheap structural check used to decide when a `?`
@@ -7591,17 +7591,17 @@ func exprSpan(e ir.Expr) Span {
 // ==== Option / Result tag helpers ====
 
 // someTagOf returns the discriminant value of the "present" arm of an
-// optional or Maybe/Option enum. Defaults to 1 which matches the
-// convention in internal/llvmgen (None=0, Some=1).
+// optional or Maybe/Option enum. Option enum declares Some first (idx 0);
+// matches the declaration-order convention (None=1, Some=0).
 func someTagOf(t ir.Type) int64 {
-	return 1
+	return 0
 }
 
 // okTagOf returns the discriminant value of the "happy" arm of a
-// `?`-able enum. For Option it's 1 (Some); for Result it's also 1
-// (Ok) in the current LLVM layout.
+// `?`-able enum. Follows declaration order: Ok is first in Result (idx 0),
+// Some is first in Option (idx 0).
 func okTagOf(t ir.Type) int64 {
-	return 1
+	return 0
 }
 
 // okVariantName returns the name of the happy arm for `?`.

--- a/toolchain/mir_generator.osty
+++ b/toolchain/mir_generator.osty
@@ -3993,14 +3993,11 @@ pub fn mirNoneAggregateLines(stepReg: String, valueReg: String, optLLVM: String)
 }
 
 /// mirOkAggregateLines renders the canonical Ok(payload) two-
-/// insertvalue construction:
-///   `  <step> = insertvalue <resultTy> undef, i64 1, 0\n`
-///   `  <value> = insertvalue <resultTy> <step>, i64 <payload>, 1\n`
-/// Sibling of `mirSomeAggregateLines` but for `Result<Ok, Err>`
-/// where `Ok` shares the disc=1 tag with Some. Used by the bench
-/// harness `Ok(())` synthesis and the `?` propagation Ok-arm.
+/// insertvalue construction.
+/// Matches enum declaration order: Result declares Ok first (idx 0),
+/// Err second (idx 1). Uses mirDiscriminantOk() which returns "0".
 pub fn mirOkAggregateLines(stepReg: String, valueReg: String, resultLLVM: String, payloadI64: String) -> String {
-    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "1", "0") +
+    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", mirDiscriminantOk(), "0") +
     mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
 }
 
@@ -4010,10 +4007,10 @@ pub fn mirOkAggregateLines(stepReg: String, valueReg: String, resultLLVM: String
 ///   `  <value> = insertvalue <resultTy> <step>, i64 <payload>, 1\n`
 /// Sibling of `mirOkAggregateLines` for the Err arm of Result.
 /// Note that for Result, disc=0 is Err (not None as in Option) —
-/// the discriminant convention is shared between Result and Option
-/// at the i64-tag level but the variant assignment differs.
+/// Matches enum declaration order: Err is second (idx 1).
+/// Uses mirDiscriminantErr() which returns "1".
 pub fn mirErrAggregateLines(stepReg: String, valueReg: String, resultLLVM: String, payloadI64: String) -> String {
-    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", "0", "0") +
+    mirInsertValueAggLine(stepReg, resultLLVM, "undef", "i64", mirDiscriminantErr(), "0") +
     mirInsertValueAggLine(valueReg, resultLLVM, stepReg, "i64", payloadI64, "1")
 }
 
@@ -9065,14 +9062,14 @@ pub fn mirDiscriminantSome() -> String {
     "1"
 }
 
-/// mirDiscriminantOk returns `1` — Result's Ok discriminant.
+/// mirDiscriminantOk returns `0` — Result's Ok discriminant (matches enum declaration order).
 pub fn mirDiscriminantOk() -> String {
-    "1"
+    "0"
 }
 
-/// mirDiscriminantErr returns `0` — Result's Err discriminant.
+/// mirDiscriminantErr returns `1` — Result's Err discriminant (matches enum declaration order).
 pub fn mirDiscriminantErr() -> String {
-    "0"
+    "1"
 }
 
 /// §6 boolean-literal tokens (LLVM-style i1).


### PR DESCRIPTION
## Summary

- Implement `std.term.readKey` / `pollKey` AST LLVM shim with runtime terminal input decode
- Add synthetic `Key` enum (18 variants, boxed) with runtime TLS slots
- Fix MIR Result ABI: Ok=0, Err=1 (matches enum declaration order)
  - `mirDiscriminantOk`/Err, `mirDiscriminantOkAggregateLines`/Err, `okTagOf`/`errTagOf`/`someTagOf`
  - Backend binary smoke test now passes (was silently broken)

## Tests
- `TestStdTermInputRoutesToRuntime` ✅
- `TestLLVMBackendBinaryRunsStdTermBasicSurface` ✅ (fixed by ABI correction)
- `TestGenerateCoalesceFullPipeline` ✅
- `go vet` on all changed packages ✅