### PR TITLE
test(onb): cross-compile guard + post-#1405 부트스트랩/coverage design

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -1,0 +1,186 @@
+# `osty-self` 부트스트랩 설계 — Post-#1405 follow-up
+
+> **상태**: 제안 (draft). 합의 후 별도 PR에서 구현.
+> **연관 PR**: #1405 (Go MIR emitter 제거), #1406 (MIR-direct 디스패처 복구).
+> **소유**: backend / toolchain.
+
+## 1. 문제 정의
+
+PR #1405가 `internal/llvmgen` (Go 측 MIR emitter mirror, ~112K 줄)를 제거하면서 LLVM 백엔드의 in-process emit 경로가 사라졌다. 모든 MIR → LLVM IR 변환은 이제 다음 체인을 통과한다:
+
+```
+host osty (Go 부트스트랩)
+   └─ LLVMBackend.Emit
+       └─ tryNativeOwnedMIRPayloadLLVMIRText
+           └─ exec(osty-native-llvmgen)               # internal/nativellvmgen
+               └─ tryMIRRequestViaLIRProto
+                   └─ exec(osty-native-lirproto)       # internal/nativelirproto
+                       └─ exec(osty-self lir-proto-lower)
+                           └─ toolchain/lir_proto.osty (Osty 자체)
+```
+
+체인 끝의 **`osty-self`는 `osty build --backend=llvm toolchain/`의 산출물**이고 — 그걸 만들려면 다시 `osty build` 가 필요하다. 즉 **닭-달걀 부트스트랩 의존이 만들어졌다**.
+
+#1405 머지 이전에는 같은 호출 시점에 `llvmgen.GenerateFromMIR(entry.MIR, opts)` (in-process Go 코드)이 fallback이었기 때문에 `osty-self`가 없어도 MIR→LLVM이 가능했다. #1405는 그 in-process 경로를 삭제하면서 fallback도 같이 제거했다.
+
+### 1.1 현재 관찰 가능한 결과
+
+- `osty build --backend=llvm toolchain/` 자체는 `osty-self` 부재 시 실패 (front-end E0703 류 외에도 emit-stage에서 `LLVM000 Go MIR emitter fallback has been removed`로 떨어짐 — #1406 적용 후엔 `native LIR Proto subprocess declined MIR coverage`로 메시지만 바뀜).
+- `verify-self-rebuild` 스크립트는 stage1 build 진입 시 host osty (`.bin/osty`) 를 호출 → 같은 체인을 돌며 declined → 첫 build 실패. 즉 **fresh clone에서 self-host 부트스트랩이 끊어졌을 가능성이 높다** (현재 트리에는 별도로 source-level E0703 errors도 있어 별개 차단 요인이 추가됨).
+- `osty-self` 가 미리 빌드돼 있으면 (e.g. CI 캐시, dev 머신) 모든 게 정상 작동하므로 **PR #1405 머지 시점의 머신에서는 회귀가 보이지 않았을 가능성이 크다**.
+
+### 1.2 설계 목표
+
+- 부트스트랩 경로 1개 — fresh clone에서 git checkout → 단일 명령으로 osty 컴파일러 + toolchain 산출물 생성 가능.
+- 산출물은 Reproducible (동일 입력 → 동일 byte). 이미 `verify-self-rebuild`가 stage2/3 byte parity를 강제 중.
+- 호스트 의존성 최소: Go toolchain + clang 외 추가 사전 산출물 요구하지 않음.
+- v0.5 baseline 규칙 준수: 새 surface 추가 없음, Osty로 작성 가능한 로직은 Go로 새로 작성하지 않음.
+
+## 2. 후보 옵션
+
+### 옵션 A: Go fallback emitter 부분 복원 (포기 권장)
+
+#1405 이전의 `llvmgen.GenerateFromMIR`을 부분적으로 되돌린다. MIR-direct 경로가 `osty-self` 없이도 동작.
+
+- 장점: 즉시 효과. 부트스트랩 닭-달걀 해소.
+- 단점: **CLAUDE.md "Osty 우선" 규칙 정면 위반**. #1405 의 정신을 부정. 112K 줄을 다시 들이는 셈은 절대 비례하지 않으므로 현실적으론 minimal subset만 복원해도 그 minimal이 다음 토큰부터 drift surface가 됨.
+- **권장하지 않음**.
+
+### 옵션 B: 사전 빌드된 `osty-self`를 git에 커밋 (포기 권장)
+
+`toolchain/.osty/out/...` 아래 stage1-equivalent 바이너리를 LFS 또는 GitHub release artifact로 제공.
+
+- 장점: fresh clone → 빠른 빌드.
+- 단점: 플랫폼별 바이너리 (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64, windows-arm64) 6개 모두 관리 필요. 보안/감사 부담. 현재 단일 시드 (`internal/selfhost/generated.go`, 68k 줄) 정책과 모순.
+- **권장하지 않음**.
+
+### 옵션 C: Go 호스트 측에 minimal MIR→LLVM "stage0" fallback 추가 (권장)
+
+`osty-self`가 없을 때만 켜지는, 의도적으로 좁은 stage0 emitter를 Go 측에 둔다. 범위:
+
+- **포함**: `toolchain/*.osty` 자기 자신을 한번 컴파일하기에 충분한 MIR 패턴 — 함수 정의, 분기, 산술, struct/enum 기본 lowering, runtime ABI 호출 (`osty.gc.*`, `osty_rt_*`).
+- **제외**: vectorize 힌트, parallel access groups, target_feature, hot/cold 섹션, advanced unroll. 즉 v0.5 spec의 **컴파일러를 컴파일할 수 있는 핵심만**.
+
+stage0 emitter는 명시적으로 **deprecated-on-arrival** — fast path가 아니라 부트스트랩용. Production 빌드 (`osty-self` 사용 가능 시)는 LIR Proto 경로 그대로.
+
+설계 패턴:
+
+```go
+// internal/backend/llvm.go
+func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options) ([]byte, []error, error) {
+    if entry.MIR == nil { ... }
+    // 1차 시도: native subprocess (osty-self 사용 가능)
+    if out, ok, ws, err := tryNativeOwnedMIRPayloadLLVMIRText(entry, opts.Target); err == nil && ok {
+        return out, ws, nil
+    } else if err != nil && !isOstySelfMissing(err) {
+        return nil, ws, err   // 진짜 에러는 그대로 surface
+    }
+    // 2차: stage0 fallback (osty-self 없을 때만)
+    if !stage0Enabled() {
+        return nil, nil, llvmabi.Unsupported("mir-emit", "...")
+    }
+    return stage0EmitMIR(entry.MIR, opts)
+}
+```
+
+`stage0EmitMIR` 본체는:
+- **새 패키지 `internal/backend/stage0/`** 에 격리. ~5K 줄을 넘지 않도록 v0.5 spec 핵심 구문만 다룸.
+- 매 회 `toolchain/*.osty`가 stage0 surface를 벗어나지 않는지 CI에서 검증 (`TestStage0CoversToolchainMIR` 같은 게이트).
+- 출력은 LIR Proto 경로와 byte-equivalent일 필요 **없음**. `verify-self-rebuild`의 stage2/3 parity는 stage1의 결과물 (`osty-self-1`)이 stage1을 사용해서 다시 빌드되는 것이므로, stage0 IR이 stage1 IR과 다른 건 정상.
+
+장점:
+- v0.5 spec ON, 부트스트랩 가능.
+- stage0이 모든 emit을 처리하지 않으므로 surface 폭주 위험 제어됨.
+- LIR Proto 경로가 default — stage0 retire는 osty-self 광범위 가용 시점에 가능.
+
+단점:
+- **소소한 코드 중복** — toolchain/lir_proto.osty 의 일부 패턴과 stage0 가 같은 일을 다른 언어로 구현. CI 게이트가 drift 막아주지만 0%는 아님.
+- 새 Go 코드가 들어가는 점은 CLAUDE.md "Osty 우선" 정신과 마찰. 단, **부트스트랩 경계는 기존 예외 카테고리 (호스트 / 부트스트랩 시드)에 해당**한다고 본다. 같은 카테고리에서 `internal/selfhost/generated.go` (68K 줄, 동결 시드) 가 이미 허용됨.
+
+### 옵션 D: `osty-self` 없을 때 부트스트랩-only Osty interpreter (포기 권장)
+
+`toolchain/lir_proto.osty` 를 Go 측 tree-walking interpreter로 실행.
+
+- 장점: 코드 중복 0. surface 변경 없음.
+- 단점: 성능 cliff (toolchain 빌드가 분 단위 소요로 늘어날 가능성). interpreter 자체가 새 surface — 옵션 C보다 도리어 invasive.
+
+## 3. 권장 설계 — 옵션 C (Stage0 fallback)
+
+### 3.1 패키지 레이아웃
+
+```
+internal/backend/stage0/
+    doc.go            // 부트스트랩 전용 명시 + retirement 조건 명문화
+    emitter.go        // MIR → LLVM IR 핵심 (function/block/instr 분기)
+    rvalue.go         // 산술 / 비교 / 캐스트 / 호출
+    place.go          // local/projection 주소 계산
+    types.go          // mir.Type → LLVM 타입
+    runtime.go        // osty.gc.* + osty_rt_* 선언
+    coverage_test.go  // toolchain/*.osty 가 stage0 안에 머무르는지 검사
+```
+
+### 3.2 활성화 조건
+
+- 환경변수 `OSTY_STAGE0_FALLBACK=1` (기본 OFF) 로 명시적 opt-in 시 stage0 사용.
+- **자동 fallback은 `tryNativeOwnedMIRPayloadLLVMIRText`가 "osty-self not found"으로 declined한 경우에만**. 다른 declined 사유 (예: `osty-self`는 있지만 lir-proto가 명시적으로 "이 shape 못 한다"고 선언한 경우)는 fall through 시키지 않고 그대로 unsupported로 surface.
+- CI 빌드는 `OSTY_STAGE0_FALLBACK=1` 명시 + `osty-self`도 빌드해서 양쪽 모두 검증 (stage0이 stale 안 나도록).
+
+### 3.3 surface 가드
+
+```go
+// internal/backend/stage0/coverage_test.go
+func TestStage0CoversToolchainMIR(t *testing.T) {
+    // toolchain/*.osty 전체를 MIR로 lowering 후 stage0가 받아들이는지 검증.
+    // 새 MIR 패턴이 toolchain에 들어갈 때 stage0 갱신 누락이 즉시 빨간불.
+}
+```
+
+이 게이트가 stage0 retirement까지 drift 잡아준다.
+
+### 3.4 retirement 경로
+
+다음 조건이 모두 충족되면 stage0 삭제:
+
+1. `osty-self` 가 모든 지원 호스트 트리플에서 reproducible 빌드 가능.
+2. `osty install` (또는 동등 부트스트랩 명령) 이 단일 명령으로 first-build 완료.
+3. CI/dev 환경 모두 osty-self 자동 캐시 메커니즘 보유 — fresh clone에서도 LIR Proto 경로가 곧바로 동작.
+
+retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통째로 삭제 + 본 design doc도 archive로 이동.
+
+### 3.5 v0.5 spec 영향
+
+없음. stage0는 emitter level에서만 작동하며 surface 추가 0건. `LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`는 변경 안 함.
+
+## 4. 구현 단계 (제안)
+
+| Phase | 범위 | 측정 |
+|---|---|---|
+| P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test |
+| P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld |
+| P2 | toolchain 의 첫 10개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
+| P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
+| P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
+| P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |
+
+각 Phase는 independent PR. P0은 수십 줄. P1~P3은 stage0 emitter 본체이므로 분량 큼. 
+
+## 5. 결정 필요 항목
+
+1. stage0 surface가 v0.5 spec 핵심 정도인지, v0.4 baseline 정도면 충분한지 — 컴파일러 자체가 어느 spec에 의존하는지 확인 후 결정.
+2. stage0를 `internal/backend/stage0/`에 둘지, `internal/llvmabi/stage0/` 등 다른 위치에 둘지.
+3. `OSTY_STAGE0_FALLBACK=1` 기본값 (CI 잡 / dev 환경별 / fresh clone first-run-detect) 정책.
+4. retirement 시점에 stage0 삭제 PR이 필요한가, 아니면 빌드 프로세스에서 자동 unreachable이라고 볼 것인지.
+
+---
+
+## Appendix A. 현재 verify-self-rebuild 흐름
+
+```
+host_osty (Go-built .bin/osty)
+    └─ stage1 build: host_osty build toolchain/  →  osty-self-1 (LLVM 백엔드 사용)
+    └─ stage2 build: osty-self-1 build toolchain/ →  osty-self-2
+    └─ stage3 build: osty-self-2 build toolchain/ →  osty-self-3
+    └─ assert byte_eq(osty-self-2, osty-self-3)
+```
+
+stage1이 host_osty를 쓰므로, host_osty 의 LLVM 백엔드가 osty-self 없이도 emit해야 stage1 build가 가능. 이게 #1405 이후 깨졌다고 본 design 문서가 가정한다.

--- a/docs/post_1405_coverage_audit_design.md
+++ b/docs/post_1405_coverage_audit_design.md
@@ -1,0 +1,218 @@
+# Post-#1405 Coverage Audit 설계
+
+> **상태**: 제안 (draft). 합의 후 audit 단계별 개별 PR.
+> **연관 PR**: #1405 (Go MIR emitter 제거; 124개 테스트 파일, ~36k줄 삭제), #1406 (디스패처 회귀 봉합 + 추가 12개 obsolete 테스트 삭제).
+> **소유**: backend / toolchain.
+
+## 1. 문제 정의
+
+PR #1405가 `internal/llvmgen` (~112K 줄) 제거 시 **124개 테스트 파일, ~36,020줄**의 코드 변환 테스트를 함께 삭제했다. PR 본문은 "MIR emission must be covered by the native LIR Proto subprocess"라고만 적었지만, 그 LIR Proto 측 (`toolchain/lir_proto*.osty`) 에 동등 커버리지가 옮겨졌는지에 대한 증거는 PR 안에 없다.
+
+PR #1406이 그 위에 추가로 12개 backend 테스트를 obsolete 처리 (delete 7건 + skip 5건). 이로써 누적 손실은:
+
+| 카테고리 | 삭제된 줄 수 | 비고 |
+|---|---|---|
+| `internal/llvmgen/*_test.go` 113 파일 | 약 33,200 | Go MIR emitter 산출물 단언 |
+| `internal/backend/stdlib_type_*_test.go` 2 파일 | 1,100 | stdlib body lowering 통합 테스트 |
+| `cmd/osty-native-llvmgen/main_test.go` 일부 | 264 | native subprocess 테스트 |
+| `cmd/osty/main_gen_test.go` 일부 | 170 | CLI gen 테스트 |
+| #1406 추가 삭제 | ~1,200 | 단언 obsolete 7개 + #1406이 추가로 추출 |
+
+**합계 약 36k줄.** 옮겨진 곳을 추정해 보면:
+
+| 후보 새 위치 | 현재 분량 |
+|---|---|
+| `toolchain/lir_proto.osty` | 6,052 |
+| `toolchain/lir_proto_test.osty` | 580 (test fn 28개 미만) |
+| `toolchain/lir_proto_parity.osty` | 2,990 |
+| `toolchain/mir_generator.osty` | 21,921 |
+| `internal/backend/*_test.go` 잔존 | 약 36개 파일 (Go side) |
+
+**관찰**: LIR Proto Osty 측 테스트 본문은 580줄. 삭제 분량의 1/60. 옵션은 두 가지:
+
+(a) 옮겨졌다 — `verify-self-rebuild` 에 의한 indirect end-to-end coverage가 sufficient.
+(b) 옮겨지지 않았다 — 단순 부재. 회귀 잡힐 가능성 매우 낮음.
+
+본 audit의 목표는 **(a)/(b)를 카테고리별로 판정**하고, (b)인 항목은 새 테스트로 복구하거나 — 의도된 손실이라면 명문화 — 한다.
+
+## 2. Audit 체크리스트
+
+각 카테고리에 대해:
+
+- [ ] **Owner**: 어디로 이전됐는가? (toolchain/*.osty / internal/backend / cmd/osty-native-* / cmd/osty / 기타)
+- [ ] **Coverage shape**: 같은 입력에 대한 같은 단언인가, 다른 입력 / 다른 단언인가?
+- [ ] **Activation**: 어떤 명령으로 실행되는가? (`go test`, `osty test`, `verify-self-rebuild`?)
+- [ ] **Regression detection**: 옛 테스트가 잡았던 회귀가 새 테스트에서도 잡히는가?
+- [ ] **Action**: keep (already covered) / port (move equivalent to new home) / archive (intentional loss + spec note)
+
+## 3. 카테고리별 사전 분석 (초안)
+
+### 3.1 GC instrumentation — `gc_integration_test.go` (440줄)
+
+테스트: safepoint poll, root_bind, pre-write barrier, shadow stack frame.
+
+- 이전 추정: `toolchain/lir_proto.osty` (직접) + `internal/runner` smoke (간접).
+- 현황: `toolchain/lir_proto_test.osty` 580줄 안에 GC 관련 fn 몇 개? — 추정 부족.
+- **Action 후보**: `toolchain/gc_lower_test.osty` 신설 또는 `internal/backend/llvm_gc_*_test.go` 부활 (skip-on-no-osty-self).
+
+### 3.2 Vectorize — `vectorize_test.go` + `_extended` + `_real_simd` (~1k줄 합)
+
+테스트: `#[vectorize]` / `#[vectorize(scalable, ...)]` / `#[no_vectorize]` 어노테이션이 LLVM `loop.vectorize.enable` metadata + safepoint skip + parallel access groups로 lowering.
+
+- v0.6 A5/A5.1/A5.2/A6/A7 — 핵심 spec. 표지석 테스트가 사라졌다는 건 큰 회귀 위험.
+- 현황: `toolchain/lir_proto.osty:` 안에 vectorize lowering 코드는 있지만 테스트는 별도 파일 없음.
+- **Action**: 우선순위 최고. 실제 LLVM IR 출력 단언 테스트를 `toolchain/vectorize_test.osty` 또는 backend Go-side 통합 테스트로 부활.
+
+### 3.3 Closure lift — `closure_lift_test.go` (296)
+
+테스트: 자유변수 캡처 → 환경 struct 생성 → indirect call.
+
+- v0.5 spec 핵심 (B.5).
+- 현황: 자기-호스트 컴파일 자체가 closure를 사용하므로 `verify-self-rebuild` 가 indirect로 잡음. 단 specific shape (재귀, mutable capture 등)는 미보장.
+- **Action**: backend 측 통합 테스트 5-10개 정도로 회복. skip-on-no-osty-self.
+
+### 3.4 Interface downcast — `iface_downcast_test.go` (230)
+
+테스트: `Error.downcast::<T>()` lowering, vtable lookup.
+
+- v0.5 spec 핵심 (A.6).
+- 현황: 자기-호스트 컴파일러가 downcast 안 쓰면 `verify-self-rebuild` 로 잡히지 않음.
+- **Action**: 회복 필요. 우선순위 중.
+
+### 3.5 Field call dispatch — `field_call_dispatch_test.go` (2,034)
+
+테스트: 메서드 호출 lowering (struct method, generic method, interface dispatch).
+
+- 가장 큰 단일 테스트 파일.
+- 자기-호스트가 method를 광범위하게 사용하므로 `verify-self-rebuild` indirect 잡음 비율 높음.
+- **Action**: 자기-호스트가 사용하지 않는 패턴 (예: `mut self` 변형 + Option payload 메서드) 중심으로 회복. 우선순위 중.
+
+### 3.6 Match patterns — `match_*_test.go`, `enum_*_test.go`, `option_match_*` (~1.5k줄 합)
+
+테스트: 모든 패턴 종류 (literal / range / or / binding / guard / payload destructure) lowering.
+
+- v0.5 spec A.5.
+- 자기-호스트가 일부 패턴만 사용 → 광범위 indirect coverage 불가.
+- **Action**: spec corpus 와 결합. 우선순위 중-높음.
+
+### 3.7 Defer — `defer_test.go` (165)
+
+테스트: defer LIFO + `?` propagation 시 실행 + cancel 시 실행 + `panic`/`unreachable`/`todo`/`abort` skip.
+
+- v0.5 spec A.6 (특히 panic 시 skip vs cancel 시 실행 — 미묘함).
+- 자기-호스트가 defer를 사용하지만 defer × cancel × panic 조합은 안 씀.
+- **Action**: 회복 필요. 우선순위 중.
+
+### 3.8 GC tail sweep — `large_tail_sweep_test.go` (490)
+
+테스트: 큰 모듈에서 GC root scan / tail safepoint.
+
+- 성능 / 정합성 핵심.
+- 자기-호스트 컴파일이 큰 모듈이긴 하지만 specific GC 동작 (예: tail-safepoint trigger 시점)을 단언하지 않음.
+- **Action**: 회복 필요. RUNTIME_GC.md / RUNTIME_SCHEDULER.md 참조 후 재설계.
+
+### 3.9 LIR Proto shadow parity — `lir_proto_shadow_parity_test.go` (619)
+
+테스트: Gate ON / OFF 일 때 IR 결과가 byte-identical.
+
+- **이미 의미 상실**: gate OFF 측이 (Go MIR emitter) 가 사라졌으므로 비교 대상이 없음.
+- **Action**: archive (의도된 손실).
+
+### 3.10 stdlib body lowering integration — `stdlib_type_e2e_test.go` (534) + `stdlib_type_inject_test.go` (566)
+
+테스트: stdlib `*.osty` body가 사용자 코드에 inject 되어 monomorphize 되는 흐름.
+
+- 매우 중요 — `internal/backend/stdlib_type_inject.go`는 살아있지만 그 통합 테스트가 사라짐.
+- 자기-호스트가 `List<T>.map` 류 helper를 사용하므로 부분 indirect coverage 있음.
+- **Action**: 우선순위 최고. backend 통합 테스트로 복원.
+
+### 3.11 nativellvmgen / nativelirproto wire shape — `cmd/osty-native-llvmgen/main_test.go` 264줄 일부
+
+테스트: subprocess JSON wire format, declined response handling.
+
+- `internal/nativellvmgen` / `internal/nativelirproto` 패키지에 일부 잔존 (현재 통과).
+- **Action**: 잔존분 점검만 필요. 대부분 보존된 것으로 추정.
+
+### 3.12 mir_generator self-tests — `mir_generator_test.go` (7,240)
+
+테스트: 가장 큰 단일 파일. 모든 MIR 패턴이 → LLVM IR 로 변환되는지 단언.
+
+- **이전됐을 후보**: `toolchain/lir_proto_parity.osty` (2,990) + `toolchain/lir_proto_test.osty` (580) — 합쳐도 1/2 미만.
+- 자기-호스트 컴파일이 광범위 indirect coverage 제공하지만, **단일 패턴 회귀의 신호**는 약화됨.
+- **Action**: spec corpus 측 강화. 자기-호스트가 사용하지 않는 패턴 (예: empty enum, large tuple, complex generic constraints) 식별 후 부분 복원. **본 audit의 가장 큰 work item**.
+
+## 4. 권장 audit 순서
+
+| 우선순위 | 카테고리 | 예상 work | 결과물 |
+|---|---|---|---|
+| P0 | 3.10 stdlib body integration | 1주 | backend 측 통합 테스트 ~10개 |
+| P0 | 3.2 vectorize (v0.6 A5/A6/A7 spec) | 1주 | vectorize 어노테이션별 테스트 ~15개 |
+| P1 | 3.12 mir_generator self-tests audit | 2-3주 | spec corpus 강화 + 빈 패턴 식별 |
+| P1 | 3.7 defer + 3.6 match patterns | 1주 | 패턴별 회복 ~20개 |
+| P2 | 3.1 GC, 3.3 closure, 3.4 iface, 3.5 field call | 1-2주 | 카테고리별 5-10개씩 |
+| P2 | 3.8 GC tail sweep | 1주 | RUNTIME_GC delta 분석 |
+| P3 | 3.9 shadow parity archive | 즉시 | doc note + 카탈로그 update |
+| P3 | 3.11 native wire shape 잔존 점검 | 1일 | 점검 보고서 |
+
+## 5. Audit 산출물 형태
+
+각 카테고리에 대해 별도 PR:
+1. **검증** — 옛 테스트 의도와 새 위치 매핑 표
+2. **gap 식별** — 옛 단언 중 새 위치에서 cover되지 않는 항목 목록
+3. **복구** — 새 테스트 추가 (backend Go-side 또는 toolchain Osty-side, 위치는 카테고리별 결정)
+4. **명문화** — 의도된 loss 인 경우 doc 추가 (`docs/post_1405_archive_*.md` 또는 `SPEC_GAPS.md`)
+
+진행 트래커는 본 design doc 의 "카테고리별 사전 분석" 섹션을 그대로 사용 (체크박스 갱신).
+
+## 6. 결정 필요 항목
+
+1. **새 테스트 위치** — backend 측 (`internal/backend/llvm_*_test.go` Go side) 인가, toolchain 측 (`toolchain/*_test.osty` Osty side) 인가?
+   - Go side 장점: 기존 `newBackendRequest`, `fakeLLVMToolchain` 인프라 재사용. 빠른 turnaround.
+   - Osty side 장점: CLAUDE.md "Osty 우선" 정신. self-host parity.
+   - **권장**: integration 테스트는 Go side (backend) 에, lowering shape 단언은 Osty side (`toolchain/*_test.osty`) 에 분산.
+
+2. **`requireRealLLVMEmission` skip 정책**: 새 테스트도 osty-self 부재 시 skip할지, 아니면 stub 가능한 형태로 설계할지.
+   - osty-self bootstrap 설계 (별도 doc) 와 연동.
+
+3. **archive vs 복원 경계** — `lir_proto_shadow_parity_test.go` 같이 의미 상실된 테스트는 archive. 그 외 어디까지 복원할지 (모든 카테고리? P0/P1만?).
+
+4. **CI 추가 부담** — 카테고리별 P0+P1 복구가 진행되면 backend test 시간 증가. 어떻게 수용할 지.
+
+---
+
+## Appendix A. 삭제된 테스트 카테고리 raw size
+
+```
+mir_generator_test.go             7240
+osty_generated_test.go            1630   (generated 시드 테스트 — likely archive)
+ir_native_entry_test.go           1414
+field_call_dispatch_test.go       2034
+ir_module_test.go                  862
+lir_proto_shadow_parity_test.go    619
+stdlib_type_inject_test.go         566
+stdlib_type_e2e_test.go            534
+large_tail_sweep_test.go           490
+gc_integration_test.go             440
+char_byte_lowering_test.go         334
+closure_lift_test.go               296
+multifile_probe_test.go            317
+match_stmt_test.go                 368
+optional_test.go                   387
+... (총 124 파일)
+=================================
+                                  36020  줄 합계
+```
+
+## Appendix B. 잔존 / 신규 새 위치 raw size
+
+```
+toolchain/lir_proto.osty          6052
+toolchain/lir_proto_parity.osty   2990
+toolchain/lir_proto_test.osty      580
+toolchain/mir_generator.osty     21921   (구현; 테스트 아님)
+internal/backend/llvm_*_test.go  ~36 파일 (Go side; 일부는 #1406이 stub/skip 처리)
+=================================
+잔존 단언 라인 수 추정             < 5000 (실제 테스트 fn 단언 코드만)
+```
+
+라인 수 비율 (~5000 / 36020 ≈ 14%) 만으로 단정하긴 어렵지만, **자릿수가 일치하지 않는다는 점은 audit의 출발점이 될 만하다**.

--- a/internal/backend/onb_test.go
+++ b/internal/backend/onb_test.go
@@ -142,6 +142,17 @@ func TestONBBackendEmitObjectWritesMachOArtifact(t *testing.T) {
 
 func TestONBBackendEmitBinaryInvokesHostLinker(t *testing.T) {
 	t.Parallel()
+	// EmitBinary materialises `osty_runtime.c` and feeds it to the host
+	// clang with `-target aarch64-apple-darwin`. The fake linker
+	// substitutes for the final link step but the runtime compile is
+	// real; without macOS SDK headers (i.e. on a non-darwin host) the
+	// cross-compile fails before we can assert linker wiring.
+	if runtime.GOOS != "darwin" {
+		t.Skip("ONB binary host-linker test compiles bundled runtime with -target aarch64-apple-darwin; needs macOS host SDK")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
 
 	req := newBackendRequest(t, EmitBinary, `fn main() {}`)
 	req.Layout.Target = "aarch64-apple-darwin"


### PR DESCRIPTION
## Summary

#1405/#1406 후속 잔여 4건 중 **(3) ONB 환경 의존성 봉합** + **(1) osty-self 부트스트랩** 및 **(2) coverage audit** design docs.

### (3) ONB 테스트 가드 — 코드 변경

`TestONBBackendEmitBinaryInvokesHostLinker`는 `fakeONBLinker{}`로 링크 단계는 mock하지만 직전 `EnsureRuntimeObject`가 host clang으로 `osty_runtime.c`를 `-target aarch64-apple-darwin` 으로 컴파일함. Linux 호스트에 macOS SDK 헤더가 없어 fail.

`runtime.GOOS != "darwin"` 이거나 `clang` 부재 시 skip. 같은 파일의 다른 ONB binary 테스트들과 동일한 관용구.

### (1) `docs/osty_self_bootstrap_design.md` — 설계 (코드 변경 없음)

PR #1405가 `internal/llvmgen` (in-process Go MIR emitter, 112K줄)을 제거하면서 LLVM 백엔드의 fallback이 사라졌고, `osty-self` 가 모든 MIR→LLVM 변환의 종착점이 됨. `osty-self` 자신을 빌드하려면 같은 체인이 필요하므로 **닭-달걀 부트스트랩 의존**이 생김.

옵션 4가지 비교 후 **옵션 C (Stage0 fallback)** 권장:
- `internal/backend/stage0/` 에 부트스트랩 전용 minimal MIR→LLVM emitter (~5K줄 cap).
- `osty-self` 부재로 declined된 경우에만 활성. `OSTY_STAGE0_FALLBACK=1` 환경변수.
- `TestStage0CoversToolchainMIR` 같은 surface 가드로 toolchain drift 방지.
- Retirement 조건 (osty-self가 모든 호스트에서 reproducible 빌드 + 단일 명령 first-build) 명문화.

P0 ~ P5 단계별 구현 로드맵 포함.

### (2) `docs/post_1405_coverage_audit_design.md` — 설계 (코드 변경 없음)

#1405가 124개 테스트 파일 ~36,020줄 삭제. 새 위치 (toolchain/*.osty + 잔존 backend Go-side) 분량 ~5,000줄. 자릿수 차이가 출발점.

12개 카테고리별 audit 체크리스트:
- P0: stdlib body integration (#1100), vectorize (v0.6 spec)
- P1: mir_generator self-tests, defer + match
- P2: GC, closure lift, iface downcast, field call dispatch
- P3: shadow parity archive, native wire shape

각 카테고리는 별도 PR로 진행. 새 테스트 위치 (Go side vs Osty side) 결정 필요 항목 4개 명시.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test -count=1 -short ./internal/backend/...` — 0 fail (이전 1건 → ONB 가드로 skip 처리)
- [x] `TestONBBackendEmitBinaryInvokesHostLinker` 가드 검증: Linux에서 SKIP, macOS에서 RUN (실 환경에서는 reviewer 측 확인 필요)

## Notes

- (1)+(2) 는 **합의 후 별도 PR로 구현**. 본 PR은 design 문서만.
- 잔여 항목 (4) `internal/backend/stdlib_type_{e2e,inject}_test.go` 1.1k줄 삭제 정당성 점검은 (2) audit doc의 카테고리 3.10에 포함 — 본 audit 진행 시 함께 검증.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_