### PR TITLE
feat(backend): IsOstySelfMissing helper (bootstrap P0)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -155,7 +155,7 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 
 | Phase | 범위 | 측정 |
 |---|---|---|
-| P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test |
+| P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test — **구현 완료**: `internal/backend/bootstrap.go::IsOstySelfMissing` |
 | P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld |
 | P2 | toolchain 의 첫 10개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |

--- a/internal/backend/bootstrap.go
+++ b/internal/backend/bootstrap.go
@@ -1,0 +1,42 @@
+package backend
+
+import "strings"
+
+// ostySelfMissingSignal matches the canonical "osty-self not found" message
+// produced by `cmd/osty-native-lirproto/main.go:resolveOstySelfBin`. The
+// substring is intentionally short so it survives the warning chain
+// (`osty-native-lirproto` → `osty-native-llvmgen` → `nativellvmgen.TryMIR`
+// → `tryNativeOwnedMIRPayloadLLVMIRText`) where each hop can prepend its
+// own context.
+const ostySelfMissingSignal = "osty-self not found"
+
+// IsOstySelfMissing reports whether any of the supplied subprocess warnings
+// carry the "osty-self not found" signal originating from
+// `cmd/osty-native-lirproto`.
+//
+// The native LIR Proto subprocess forks `osty-self lir-proto-lower`; if
+// that binary has not been built yet (`osty build toolchain/` not run),
+// the subprocess declines and propagates the message up through the
+// warning chain. This helper fixes the call-site shape for future stage0
+// fallback dispatch — callers can ask "would emission have succeeded with
+// a built osty-self?" without parsing strings themselves.
+//
+// Today the signal is matched by substring against `error.Error()`. A
+// future wire-format revision will replace this with a structured
+// `Reason` field on the subprocess response so the detection mechanism
+// can drop the substring scan; consumers of `IsOstySelfMissing` will not
+// need to update.
+//
+// See `docs/osty_self_bootstrap_design.md` for the bootstrap design and
+// the planned stage0 fallback that will consume this helper.
+func IsOstySelfMissing(warnings []error) bool {
+	for _, w := range warnings {
+		if w == nil {
+			continue
+		}
+		if strings.Contains(w.Error(), ostySelfMissingSignal) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backend/bootstrap_test.go
+++ b/internal/backend/bootstrap_test.go
@@ -1,0 +1,36 @@
+package backend
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsOstySelfMissingDetectsSubprocessSignal(t *testing.T) {
+	t.Parallel()
+	canonical := errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
+
+	cases := []struct {
+		name string
+		ws   []error
+		want bool
+	}{
+		{"empty", nil, false},
+		{"empty-slice", []error{}, false},
+		{"unrelated", []error{errors.New("MIR payload requires the Osty-owned LIR Proto backend")}, false},
+		{"nil-entry", []error{nil, errors.New("noise")}, false},
+		{"canonical", []error{canonical}, true},
+		{"with-prefix", []error{fmt.Errorf("declined: %s", canonical.Error())}, true},
+		{"wrapped", []error{fmt.Errorf("native llvmgen: %w", canonical)}, true},
+		{"mixed", []error{errors.New("noise"), nil, canonical, errors.New("more noise")}, true},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsOstySelfMissing(c.ws); got != c.want {
+				t.Fatalf("IsOstySelfMissing(%v) = %v, want %v", c.ws, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`docs/osty_self_bootstrap_design.md` 의 **P0** — 향후 stage0 fallback 디스패치가 `osty-self` 부재를 인지하기 위한 detection helper. 본 PR은 helper + unit test만. stage0 emitter 본체는 P1 이후.

### 신호 흐름

```
cmd/osty-native-lirproto/main.go:resolveOstySelfBin
    → errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
    → nativelirproto.Response{Declined: true, Error: <msg>}
osty-native-llvmgen runMIRRequest
    → llvmgenResponse{Covered: false, Warnings: [<msg>, "MIR payload requires..."]}
nativellvmgen.TryMIR
    → ([]error wrapping warnings)
internal/backend tryNativeOwnedMIRPayloadLLVMIRText
    → warnings reach emitLLVMFallback caller
```

`IsOstySelfMissing(warnings []error) bool`는 이 체인의 어느 지점에서든 substring 매칭으로 감지.

### 왜 substring 매칭부터인가

설계 의도: **호출부 shape를 먼저 고정**해서 stage0 작업이 detection 메커니즘에 묶이지 않게 함. 향후 wire-format 개정 (구조화된 `Reason` 필드 추가 — 별도 PR) 시점에 `IsOstySelfMissing` 내부 구현만 `errors.Is(w, ErrOstySelfMissing)` 으로 교체. 호출자 (stage0 dispatcher) 는 변경 없음.

## Test plan

- [x] `TestIsOstySelfMissingDetectsSubprocessSignal` 8개 케이스 (empty, unrelated, nil entry, canonical, prefix, %w-wrapped, mixed) 통과
- [x] `go build ./...` 통과
- [x] `go test -count=1 -short ./internal/backend/...` 0 fail

## Notes

- 설계 P0 항목에 "**구현 완료**: `internal/backend/bootstrap.go::IsOstySelfMissing`" 앵커 갱신.
- 다음 단계 (P1): `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개. 분량 큼 — 별도 PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_