### PR TITLE
feat(backend/stage0): trivial main MIR→LLVM 부트스트랩 emitter (P1)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -156,7 +156,7 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | Phase | 범위 | 측정 |
 |---|---|---|
 | P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test — **구현 완료**: `internal/backend/bootstrap.go::IsOstySelfMissing` |
-| P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld |
+| P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld — **구현 완료**: `internal/backend/stage0/emit.go::EmitMIR` |
 | P2 | toolchain 의 첫 10개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |

--- a/internal/backend/stage0/doc.go
+++ b/internal/backend/stage0/doc.go
@@ -1,0 +1,20 @@
+// Package stage0 is the bootstrap-only MIR → LLVM IR emitter.
+//
+// stage0 catches one specific failure mode: the production LLVM emit
+// path forks `osty-self lir-proto-lower` (built by `osty build
+// toolchain/`), and on a fresh clone that artifact does not exist yet.
+// Without stage0 there is no way to bootstrap the toolchain compiler
+// itself — `osty-self` cannot build the program that builds `osty-self`.
+//
+// The emitter is intentionally narrow. Each new MIR pattern requires an
+// explicit unlock + regression test; surface drift is held back by
+// `TestStage0CoversToolchainMIR`-style coverage gates added at later
+// phases. Production builds — where `osty-self` is reachable — go
+// through the LIR Proto subprocess unchanged; stage0 is only consulted
+// when `IsOstySelfMissing` reports the canonical decline.
+//
+// See docs/osty_self_bootstrap_design.md for the bootstrap plan,
+// retirement conditions, and the roadmap from P1 (this skeleton)
+// through P5 (CI matrix). v0.5 spec surface is unchanged — stage0
+// operates entirely below the front-end.
+package stage0

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -1,0 +1,112 @@
+package stage0
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/llvmabi"
+	"github.com/osty/osty/internal/mir"
+)
+
+// ErrUnsupported marks a MIR shape outside the stage0 bootstrap subset.
+// Callers (the backend dispatcher) treat this as "stage0 declines"
+// rather than a hard build failure — the dispatcher then surfaces the
+// usual unsupported skeleton diagnostic with route `stage0`.
+var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
+
+// EmitMIR lowers `module` to textual LLVM IR for the small MVP subset
+// stage0 currently covers. It is invoked only when
+// `backend.IsOstySelfMissing` reported the canonical decline; production
+// builds with a working `osty-self` route through the LIR Proto
+// subprocess instead and never reach this entry.
+//
+// P1 subset: a single function `fn main() {}` (Unit return, single
+// block, no instructions, ReturnTerm). Anything else returns
+// ErrUnsupported with a precise reason so future phases (P2…) can
+// extend coverage one pattern at a time.
+func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
+	if module == nil {
+		return nil, fmt.Errorf("stage0: nil MIR module")
+	}
+	var out strings.Builder
+	pkg := packageNameFor(module, opts)
+	target := llvmabi.CanonicalLLVMTarget(opts.Target)
+
+	out.WriteString("; Osty stage0 bootstrap LLVM IR\n")
+	out.WriteString("; package: " + pkg + "\n")
+	if target != "" {
+		out.WriteString(fmt.Sprintf("target triple = %q\n", target))
+	}
+	out.WriteString("\n")
+
+	emittedMain := false
+	for _, fn := range module.Functions {
+		if fn == nil {
+			continue
+		}
+		if err := emitFunction(&out, fn); err != nil {
+			return nil, err
+		}
+		if fn.Name == "main" {
+			emittedMain = true
+		}
+	}
+	if !emittedMain {
+		return nil, fmt.Errorf("%w: module has no `main` function", ErrUnsupported)
+	}
+	return []byte(out.String()), nil
+}
+
+func emitFunction(out *strings.Builder, fn *mir.Function) error {
+	if fn.IsIntrinsic {
+		return fmt.Errorf("%w: intrinsic declaration %q", ErrUnsupported, fn.Name)
+	}
+	if fn.IsExternal {
+		return fmt.Errorf("%w: external declaration %q", ErrUnsupported, fn.Name)
+	}
+	if reason := trivialMainViolation(fn); reason != "" {
+		return fmt.Errorf("%w: function %q: %s", ErrUnsupported, fn.Name, reason)
+	}
+	out.WriteString("define i32 @main() {\n")
+	out.WriteString("entry:\n")
+	out.WriteString("  ret i32 0\n")
+	out.WriteString("}\n")
+	return nil
+}
+
+// trivialMainViolation returns an empty string when `fn` matches the
+// stage0 P1 subset (`fn main() {}`), otherwise a short reason string
+// suitable for an ErrUnsupported diagnostic.
+func trivialMainViolation(fn *mir.Function) string {
+	if fn.Name != "main" {
+		return "stage0 P1 only emits `main`; saw " + fn.Name
+	}
+	if len(fn.Params) != 0 {
+		return "main has parameters"
+	}
+	if len(fn.Blocks) != 1 {
+		return fmt.Sprintf("main has %d blocks; stage0 P1 expects exactly 1", len(fn.Blocks))
+	}
+	bb := fn.Blocks[0]
+	if bb == nil {
+		return "main entry block is nil"
+	}
+	if len(bb.Instrs) != 0 {
+		return fmt.Sprintf("main entry block has %d instructions; stage0 P1 expects 0", len(bb.Instrs))
+	}
+	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
+		return fmt.Sprintf("main terminator is %T; stage0 P1 expects ReturnTerm", bb.Term)
+	}
+	return ""
+}
+
+func packageNameFor(module *mir.Module, opts llvmabi.Options) string {
+	if module != nil && module.Package != "" {
+		return module.Package
+	}
+	if opts.PackageName != "" {
+		return opts.PackageName
+	}
+	return "main"
+}

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -1,0 +1,131 @@
+package stage0
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/llvmabi"
+	"github.com/osty/osty/internal/mir"
+)
+
+func trivialMainModule() *mir.Module {
+	return &mir.Module{
+		Package: "main",
+		Functions: []*mir.Function{
+			{
+				Name:        "main",
+				ReturnType:  ir.TUnit,
+				ReturnLocal: 0,
+				Locals: []*mir.Local{
+					{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
+				},
+				Entry: 0,
+				Blocks: []*mir.BasicBlock{
+					{ID: 0, Term: &mir.ReturnTerm{}},
+				},
+			},
+		},
+		Layouts: mir.NewLayoutTable(),
+	}
+}
+
+func TestStage0EmitsTrivialMain(t *testing.T) {
+	t.Parallel()
+	got, err := EmitMIR(trivialMainModule(), llvmabi.Options{PackageName: "main", Target: "x86_64-unknown-linux-gnu"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		"stage0 bootstrap LLVM IR",
+		"; package: main",
+		"target triple = \"x86_64-unknown-linux-gnu\"",
+		"define i32 @main()",
+		"ret i32 0",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestStage0RejectsNilModule(t *testing.T) {
+	t.Parallel()
+	_, err := EmitMIR(nil, llvmabi.Options{})
+	if err == nil {
+		t.Fatal("expected error for nil module")
+	}
+}
+
+func TestStage0RejectsModuleWithoutMain(t *testing.T) {
+	t.Parallel()
+	module := &mir.Module{
+		Package:   "main",
+		Functions: nil,
+		Layouts:   mir.NewLayoutTable(),
+	}
+	_, err := EmitMIR(module, llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsNonMainFunction(t *testing.T) {
+	t.Parallel()
+	module := trivialMainModule()
+	module.Functions[0].Name = "helper"
+	_, err := EmitMIR(module, llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "stage0 P1 only emits `main`") {
+		t.Fatalf("err message = %q, want stage0 P1 reason", err.Error())
+	}
+}
+
+func TestStage0RejectsMainWithParameters(t *testing.T) {
+	t.Parallel()
+	module := trivialMainModule()
+	module.Functions[0].Params = []mir.LocalID{0}
+	_, err := EmitMIR(module, llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsMainWithInstructions(t *testing.T) {
+	t.Parallel()
+	module := trivialMainModule()
+	module.Functions[0].Blocks[0].Instrs = []mir.Instr{
+		&mir.AssignInstr{},
+	}
+	_, err := EmitMIR(module, llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsIntrinsicDeclaration(t *testing.T) {
+	t.Parallel()
+	module := trivialMainModule()
+	module.Functions[0].IsIntrinsic = true
+	_, err := EmitMIR(module, llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0FallsBackPackageName(t *testing.T) {
+	t.Parallel()
+	module := trivialMainModule()
+	module.Package = ""
+	got, err := EmitMIR(module, llvmabi.Options{PackageName: "demo"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	if !strings.Contains(string(got), "; package: demo") {
+		t.Fatalf("expected fallback package name from opts:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

`docs/osty_self_bootstrap_design.md` 의 **P1** — stage0 skeleton 패키지 + 가장 단순한 `fn main() {}` 한 케이스의 MIR → LLVM IR 변환.

본 PR은 emitter 본체 + 단위 테스트만. 디스패처 wiring 은 P3 (`OSTY_STAGE0_FALLBACK` 환경변수) 에서 진행. 진입 조건 판정은 #1408 의 `backend.IsOstySelfMissing` 가 담당.

### 신규 패키지: `internal/backend/stage0/`

```
internal/backend/stage0/
    doc.go        // 부트스트랩 전용 + retirement 조건 명시
    emit.go       // EmitMIR(module, opts) → ([]byte, error)
    emit_test.go  // 8개 케이스
```

### Stage0 P1 subset

`fn main() {}` 한 가지만 수용:
- 함수명 `main`
- 파라미터 없음
- 단일 블록
- 인스트럭션 0개
- `ReturnTerm` 종결자

이 외 모든 shape는 `ErrUnsupported` sentinel 으로 거부. 거부 사유 문자열에 정확한 위반 항목을 담아서 P2 확장 시 unlock 대상을 추적 가능.

### 출력 형태

```
; Osty stage0 bootstrap LLVM IR
; package: main
target triple = "x86_64-unknown-linux-gnu"

define i32 @main() {
entry:
  ret i32 0
}
```

## Test plan

- [x] `TestStage0EmitsTrivialMain` — 성공 경로 (header / triple / `define i32 @main()` / `ret i32 0` 모두 검증)
- [x] `TestStage0RejectsNilModule`
- [x] `TestStage0RejectsModuleWithoutMain`
- [x] `TestStage0RejectsNonMainFunction` (이름 다름)
- [x] `TestStage0RejectsMainWithParameters`
- [x] `TestStage0RejectsMainWithInstructions`
- [x] `TestStage0RejectsIntrinsicDeclaration`
- [x] `TestStage0FallsBackPackageName` (module.Package 빈 경우 opts.PackageName 사용)
- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/...` 0 fail

## Notes

- 본 PR은 frontend / 디스패처 / wire 어디에도 손대지 않음. surface 영향 0.
- 다음 단계 (P2): `toolchain` 의 첫 N개 함수 lowering 통과 — 분량 크고 LLVM 시맨틱이 더 들어옴.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_