### PR TITLE
feat(backend/stage0): non-main fn → Int { N } literal return (P2a)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -157,7 +157,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 |---|---|---|
 | P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test — **구현 완료**: `internal/backend/bootstrap.go::IsOstySelfMissing` |
 | P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld — **구현 완료**: `internal/backend/stage0/emit.go::EmitMIR` |
-| P2 | toolchain 의 첫 10개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
+| P2a | non-main fn → Int { N } (literal return) | TestStage0EmitsIntLiteralFunctionAlongsideMain — **구현 완료** |
+| P2b+ | toolchain 의 첫 10개 함수 lowering 통과 (params / non-Int / 산술 / call …) | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/llvmabi"
 	"github.com/osty/osty/internal/mir"
 )
@@ -21,10 +22,16 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 // builds with a working `osty-self` route through the LIR Proto
 // subprocess instead and never reach this entry.
 //
-// P1 subset: a single function `fn main() {}` (Unit return, single
-// block, no instructions, ReturnTerm). Anything else returns
-// ErrUnsupported with a precise reason so future phases (P2…) can
-// extend coverage one pattern at a time.
+// Currently supported function shapes (each gated by an explicit check
+// that returns ErrUnsupported with a precise reason):
+//
+//   - P1: `fn main() {}` — single block, zero instructions, ReturnTerm.
+//   - P2a: `fn name() -> Int { N }` — non-main, single block, one
+//     AssignInstr writing IntConst to the return local, ReturnTerm.
+//
+// Any other shape is rejected. Each P2x extension adds one case +
+// regression test; surface drift is held back by the stage0 coverage
+// gate planned for P3.
 func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	if module == nil {
 		return nil, fmt.Errorf("stage0: nil MIR module")
@@ -65,13 +72,20 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	if fn.IsExternal {
 		return fmt.Errorf("%w: external declaration %q", ErrUnsupported, fn.Name)
 	}
+	if fn.Name == "main" {
+		return emitTrivialMain(out, fn)
+	}
+	return emitIntLiteralReturn(out, fn)
+}
+
+func emitTrivialMain(out *strings.Builder, fn *mir.Function) error {
 	if reason := trivialMainViolation(fn); reason != "" {
 		return fmt.Errorf("%w: function %q: %s", ErrUnsupported, fn.Name, reason)
 	}
 	out.WriteString("define i32 @main() {\n")
 	out.WriteString("entry:\n")
 	out.WriteString("  ret i32 0\n")
-	out.WriteString("}\n")
+	out.WriteString("}\n\n")
 	return nil
 }
 
@@ -80,25 +94,107 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 // suitable for an ErrUnsupported diagnostic.
 func trivialMainViolation(fn *mir.Function) string {
 	if fn.Name != "main" {
-		return "stage0 P1 only emits `main`; saw " + fn.Name
+		return "stage0 expected `main`; saw " + fn.Name
 	}
 	if len(fn.Params) != 0 {
 		return "main has parameters"
 	}
 	if len(fn.Blocks) != 1 {
-		return fmt.Sprintf("main has %d blocks; stage0 P1 expects exactly 1", len(fn.Blocks))
+		return fmt.Sprintf("main has %d blocks; stage0 expects exactly 1", len(fn.Blocks))
 	}
 	bb := fn.Blocks[0]
 	if bb == nil {
 		return "main entry block is nil"
 	}
 	if len(bb.Instrs) != 0 {
-		return fmt.Sprintf("main entry block has %d instructions; stage0 P1 expects 0", len(bb.Instrs))
+		return fmt.Sprintf("main entry block has %d instructions; stage0 expects 0", len(bb.Instrs))
 	}
 	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
-		return fmt.Sprintf("main terminator is %T; stage0 P1 expects ReturnTerm", bb.Term)
+		return fmt.Sprintf("main terminator is %T; stage0 expects ReturnTerm", bb.Term)
 	}
 	return ""
+}
+
+// emitIntLiteralReturn handles `fn name() -> Int { N }` for non-main
+// functions. The MIR shape is one block with a single AssignInstr
+// writing an IntConst to the return local, followed by ReturnTerm.
+func emitIntLiteralReturn(out *strings.Builder, fn *mir.Function) error {
+	if reason, _ := intLiteralReturnViolation(fn); reason != "" {
+		return fmt.Errorf("%w: function %q: %s", ErrUnsupported, fn.Name, reason)
+	}
+	_, value := intLiteralReturnViolation(fn)
+	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
+	out.WriteString("entry:\n")
+	fmt.Fprintf(out, "  ret i64 %d\n", value)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// intLiteralReturnViolation returns "" + the constant value when `fn`
+// matches the P2a subset; otherwise it returns a reason string and a
+// zero value. Returning value alongside reason avoids re-walking the
+// MIR after the validation pass.
+func intLiteralReturnViolation(fn *mir.Function) (string, int64) {
+	if !isPrimType(fn.ReturnType, ir.PrimInt) {
+		return fmt.Sprintf("return type %s is not Int", primName(fn.ReturnType)), 0
+	}
+	if len(fn.Params) != 0 {
+		return "function has parameters; stage0 P2a expects zero", 0
+	}
+	if len(fn.Blocks) != 1 {
+		return fmt.Sprintf("function has %d blocks; stage0 P2a expects exactly 1", len(fn.Blocks)), 0
+	}
+	bb := fn.Blocks[0]
+	if bb == nil {
+		return "entry block is nil", 0
+	}
+	if len(bb.Instrs) != 1 {
+		return fmt.Sprintf("entry block has %d instructions; stage0 P2a expects exactly 1", len(bb.Instrs)), 0
+	}
+	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
+		return fmt.Sprintf("terminator is %T; stage0 P2a expects ReturnTerm", bb.Term), 0
+	}
+	assign, ok := bb.Instrs[0].(*mir.AssignInstr)
+	if !ok {
+		return fmt.Sprintf("instruction[0] is %T; stage0 P2a expects AssignInstr", bb.Instrs[0]), 0
+	}
+	if assign.Dest.Local != fn.ReturnLocal || assign.Dest.HasProjections() {
+		return "AssignInstr destination is not the return local without projections", 0
+	}
+	use, ok := assign.Src.(*mir.UseRV)
+	if !ok {
+		return fmt.Sprintf("AssignInstr.Src is %T; stage0 P2a expects UseRV", assign.Src), 0
+	}
+	con, ok := use.Op.(*mir.ConstOp)
+	if !ok {
+		return fmt.Sprintf("UseRV.Op is %T; stage0 P2a expects ConstOp", use.Op), 0
+	}
+	intc, ok := con.Const.(*mir.IntConst)
+	if !ok {
+		return fmt.Sprintf("ConstOp.Const is %T; stage0 P2a expects IntConst", con.Const), 0
+	}
+	if !isPrimType(intc.Type(), ir.PrimInt) {
+		return fmt.Sprintf("IntConst type %s is not Int", primName(intc.Type())), 0
+	}
+	return "", intc.Value
+}
+
+func isPrimType(t mir.Type, want ir.PrimKind) bool {
+	prim, ok := t.(*ir.PrimType)
+	if !ok || prim == nil {
+		return false
+	}
+	return prim.Kind == want
+}
+
+func primName(t mir.Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	if prim, ok := t.(*ir.PrimType); ok && prim != nil {
+		return prim.String()
+	}
+	return fmt.Sprintf("%T", t)
 }
 
 func packageNameFor(module *mir.Module, opts llvmabi.Options) string {

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -10,30 +10,63 @@ import (
 	"github.com/osty/osty/internal/mir"
 )
 
-func trivialMainModule() *mir.Module {
-	return &mir.Module{
-		Package: "main",
-		Functions: []*mir.Function{
-			{
-				Name:        "main",
-				ReturnType:  ir.TUnit,
-				ReturnLocal: 0,
-				Locals: []*mir.Local{
-					{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
-				},
-				Entry: 0,
-				Blocks: []*mir.BasicBlock{
-					{ID: 0, Term: &mir.ReturnTerm{}},
-				},
-			},
+func trivialMainFn() *mir.Function {
+	return &mir.Function{
+		Name:        "main",
+		ReturnType:  ir.TUnit,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TUnit, IsReturn: true},
 		},
-		Layouts: mir.NewLayoutTable(),
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{ID: 0, Term: &mir.ReturnTerm{}},
+		},
 	}
 }
 
+func intLiteralFn(name string, value int64) *mir.Function {
+	return &mir.Function{
+		Name:        name,
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					&mir.AssignInstr{
+						Dest: mir.Place{Local: 0},
+						Src: &mir.UseRV{
+							Op: &mir.ConstOp{
+								Const: &mir.IntConst{Value: value, T: ir.TInt},
+								T:     ir.TInt,
+							},
+						},
+					},
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+}
+
+func moduleWith(fns ...*mir.Function) *mir.Module {
+	return &mir.Module{
+		Package:   "main",
+		Functions: fns,
+		Layouts:   mir.NewLayoutTable(),
+	}
+}
+
+// ---- P1: trivial main ----
+
 func TestStage0EmitsTrivialMain(t *testing.T) {
 	t.Parallel()
-	got, err := EmitMIR(trivialMainModule(), llvmabi.Options{PackageName: "main", Target: "x86_64-unknown-linux-gnu"})
+	got, err := EmitMIR(moduleWith(trivialMainFn()), llvmabi.Options{PackageName: "main", Target: "x86_64-unknown-linux-gnu"})
 	if err != nil {
 		t.Fatalf("EmitMIR: %v", err)
 	}
@@ -61,33 +94,18 @@ func TestStage0RejectsNilModule(t *testing.T) {
 
 func TestStage0RejectsModuleWithoutMain(t *testing.T) {
 	t.Parallel()
-	module := &mir.Module{
-		Package:   "main",
-		Functions: nil,
-		Layouts:   mir.NewLayoutTable(),
-	}
-	_, err := EmitMIR(module, llvmabi.Options{})
+	_, err := EmitMIR(moduleWith(intLiteralFn("zero", 0)), llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
 	}
-}
-
-func TestStage0RejectsNonMainFunction(t *testing.T) {
-	t.Parallel()
-	module := trivialMainModule()
-	module.Functions[0].Name = "helper"
-	_, err := EmitMIR(module, llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-	if !strings.Contains(err.Error(), "stage0 P1 only emits `main`") {
-		t.Fatalf("err message = %q, want stage0 P1 reason", err.Error())
+	if !strings.Contains(err.Error(), "module has no `main` function") {
+		t.Fatalf("err = %q, want missing-main reason", err.Error())
 	}
 }
 
 func TestStage0RejectsMainWithParameters(t *testing.T) {
 	t.Parallel()
-	module := trivialMainModule()
+	module := moduleWith(trivialMainFn())
 	module.Functions[0].Params = []mir.LocalID{0}
 	_, err := EmitMIR(module, llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
@@ -97,10 +115,8 @@ func TestStage0RejectsMainWithParameters(t *testing.T) {
 
 func TestStage0RejectsMainWithInstructions(t *testing.T) {
 	t.Parallel()
-	module := trivialMainModule()
-	module.Functions[0].Blocks[0].Instrs = []mir.Instr{
-		&mir.AssignInstr{},
-	}
+	module := moduleWith(trivialMainFn())
+	module.Functions[0].Blocks[0].Instrs = []mir.Instr{&mir.AssignInstr{}}
 	_, err := EmitMIR(module, llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
@@ -109,7 +125,7 @@ func TestStage0RejectsMainWithInstructions(t *testing.T) {
 
 func TestStage0RejectsIntrinsicDeclaration(t *testing.T) {
 	t.Parallel()
-	module := trivialMainModule()
+	module := moduleWith(trivialMainFn())
 	module.Functions[0].IsIntrinsic = true
 	_, err := EmitMIR(module, llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
@@ -119,7 +135,7 @@ func TestStage0RejectsIntrinsicDeclaration(t *testing.T) {
 
 func TestStage0FallsBackPackageName(t *testing.T) {
 	t.Parallel()
-	module := trivialMainModule()
+	module := moduleWith(trivialMainFn())
 	module.Package = ""
 	got, err := EmitMIR(module, llvmabi.Options{PackageName: "demo"})
 	if err != nil {
@@ -127,5 +143,109 @@ func TestStage0FallsBackPackageName(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "; package: demo") {
 		t.Fatalf("expected fallback package name from opts:\n%s", got)
+	}
+}
+
+// ---- P2a: non-main int literal return ----
+
+func TestStage0EmitsIntLiteralFunctionAlongsideMain(t *testing.T) {
+	t.Parallel()
+	got, err := EmitMIR(moduleWith(trivialMainFn(), intLiteralFn("zero", 0), intLiteralFn("forty_two", 42), intLiteralFn("neg_one", -1)), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		"define i32 @main()",
+		"ret i32 0",
+		"define i64 @zero()",
+		"ret i64 0",
+		"define i64 @forty_two()",
+		"ret i64 42",
+		"define i64 @neg_one()",
+		"ret i64 -1",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestStage0RejectsIntFunctionWithParams(t *testing.T) {
+	t.Parallel()
+	fn := intLiteralFn("identity", 0)
+	fn.Params = []mir.LocalID{1}
+	fn.Locals = append(fn.Locals, &mir.Local{ID: 1, Name: "x", Type: ir.TInt, IsParam: true})
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsIntFunctionWithBoolReturn(t *testing.T) {
+	t.Parallel()
+	fn := intLiteralFn("flag", 1)
+	fn.ReturnType = ir.TBool
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsIntFunctionWithExtraInstr(t *testing.T) {
+	t.Parallel()
+	fn := intLiteralFn("two_step", 7)
+	// Adding a second AssignInstr leaves the block with 2 instrs.
+	fn.Blocks[0].Instrs = append(fn.Blocks[0].Instrs, &mir.AssignInstr{
+		Dest: mir.Place{Local: 0},
+		Src: &mir.UseRV{
+			Op: &mir.ConstOp{Const: &mir.IntConst{Value: 9, T: ir.TInt}, T: ir.TInt},
+		},
+	})
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "expects exactly 1") {
+		t.Fatalf("err = %q, want instr-count reason", err.Error())
+	}
+}
+
+func TestStage0RejectsIntFunctionWithBinaryRV(t *testing.T) {
+	t.Parallel()
+	fn := intLiteralFn("sum", 0)
+	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
+		Dest: mir.Place{Local: 0},
+		Src: &mir.BinaryRV{
+			Op: mir.BinAdd,
+			Left: &mir.ConstOp{Const: &mir.IntConst{Value: 1, T: ir.TInt}, T: ir.TInt},
+			Right: &mir.ConstOp{Const: &mir.IntConst{Value: 2, T: ir.TInt}, T: ir.TInt},
+			T:    ir.TInt,
+		},
+	}
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "expects UseRV") {
+		t.Fatalf("err = %q, want UseRV reason", err.Error())
+	}
+}
+
+func TestStage0RejectsIntFunctionWithCopyOp(t *testing.T) {
+	t.Parallel()
+	fn := intLiteralFn("dup", 0)
+	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
+		Dest: mir.Place{Local: 0},
+		Src: &mir.UseRV{
+			Op: &mir.CopyOp{Place: mir.Place{Local: 0}, T: ir.TInt},
+		},
+	}
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	if !strings.Contains(err.Error(), "expects ConstOp") {
+		t.Fatalf("err = %q, want ConstOp reason", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

부트스트랩 P2를 작은 단위로 쪼갠 첫 PR — non-main 함수가 정수 리터럴 하나를 리턴하는 단순 케이스만.

```osty
fn name() -> Int { N }
```

→ MIR 형태: 1-block, 1 AssignInstr (UseRV→ConstOp→IntConst), ReturnTerm.
→ LLVM IR:

```
define i64 @name() {
entry:
  ret i64 N
}
```

### 변경 사항

- `emitFunction` 을 main / non-main 두 경로로 분기.
- 새 헬퍼 `emitIntLiteralReturn` + `intLiteralReturnViolation`: 위반 사유를 문자열로 노출해서 P2b+ 확장 시 무엇을 unlock할지 추적 가능.
- 타입 검사 유틸 `isPrimType` / `primName` (ir.PrimType 비교).
- 헬퍼 `intLiteralFn(name, value)` 로 테스트 fixture 통일.

### 추가 테스트 (+6)

성공:
- `TestStage0EmitsIntLiteralFunctionAlongsideMain` — main + zero/forty_two/neg_one 4함수 한 모듈.

거부 (각각 다른 위반 사유):
- params 있음
- return 타입이 Bool
- 인스트럭션 2개
- BinaryRV (산술)
- CopyOp (변수 읽기)

기존 P1 테스트들은 새 `intLiteralFn` / `moduleWith` 헬퍼 signature 에 맞게 정리.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test -count=1 -short ./internal/backend/stage0/...` — 14개 테스트 (P1 7개 + P2a 7개) 모두 PASS
- [x] `go test -count=1 -short ./internal/backend/...` — 전체 backend 0 fail

## Notes

- P2를 **P2a / P2b+** 로 명시적 분할. 설계 doc 의 P2 행을 두 행으로 쪼개고 P2a 는 "구현 완료" 표시.
- 다음 (P2b): 함수 파라미터 / 산술 (Add/Sub/Mul) / 단순 if-else 중 하나부터.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_