### PR TITLE
feat(backend/stage0): single-Int-param passthrough (P2b)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -158,7 +158,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P0 | `osty-self not found` 에러 분류 / `isOstySelfMissing(err)` 도입 | unit test — **구현 완료**: `internal/backend/bootstrap.go::IsOstySelfMissing` |
 | P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld — **구현 완료**: `internal/backend/stage0/emit.go::EmitMIR` |
 | P2a | non-main fn → Int { N } (literal return) | TestStage0EmitsIntLiteralFunctionAlongsideMain — **구현 완료** |
-| P2b+ | toolchain 의 첫 10개 함수 lowering 통과 (params / non-Int / 산술 / call …) | toolchain/main.osty 부분 빌드 |
+| P2b | non-main fn(x: Int) -> Int { x } (param passthrough) | TestStage0EmitsIntParamPassthrough — **구현 완료** |
+| P2c+ | toolchain 의 첫 10개 함수 lowering 통과 (산술 / call / if-else / locals …) | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -22,15 +22,18 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 // builds with a working `osty-self` route through the LIR Proto
 // subprocess instead and never reach this entry.
 //
-// Currently supported function shapes (each gated by an explicit check
-// that returns ErrUnsupported with a precise reason):
+// Currently supported function shapes (each gated by an explicit
+// `match*` predicate; non-matching shapes return ErrUnsupported):
 //
 //   - P1: `fn main() {}` — single block, zero instructions, ReturnTerm.
 //   - P2a: `fn name() -> Int { N }` — non-main, single block, one
 //     AssignInstr writing IntConst to the return local, ReturnTerm.
+//   - P2b: `fn name(x: Int) -> Int { x }` — non-main, single Int
+//     parameter, single block, one AssignInstr writing CopyOp(param)
+//     to the return local, ReturnTerm.
 //
-// Any other shape is rejected. Each P2x extension adds one case +
-// regression test; surface drift is held back by the stage0 coverage
+// Each P2x extension adds one match predicate + emit closure +
+// regression test. Surface drift is held back by the stage0 coverage
 // gate planned for P3.
 func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	if module == nil {
@@ -75,8 +78,16 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	if fn.Name == "main" {
 		return emitTrivialMain(out, fn)
 	}
-	return emitIntLiteralReturn(out, fn)
+	if pat, ok := matchIntLiteralReturn(fn); ok {
+		return emitIntLiteralReturn(out, fn, pat)
+	}
+	if pat, ok := matchIntParamPassthrough(fn); ok {
+		return emitIntParamPassthrough(out, fn, pat)
+	}
+	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
+
+// ---- P1: trivial main ----
 
 func emitTrivialMain(out *strings.Builder, fn *mir.Function) error {
 	if reason := trivialMainViolation(fn); reason != "" {
@@ -89,9 +100,6 @@ func emitTrivialMain(out *strings.Builder, fn *mir.Function) error {
 	return nil
 }
 
-// trivialMainViolation returns an empty string when `fn` matches the
-// stage0 P1 subset (`fn main() {}`), otherwise a short reason string
-// suitable for an ErrUnsupported diagnostic.
 func trivialMainViolation(fn *mir.Function) string {
 	if fn.Name != "main" {
 		return "stage0 expected `main`; saw " + fn.Name
@@ -115,68 +123,172 @@ func trivialMainViolation(fn *mir.Function) string {
 	return ""
 }
 
-// emitIntLiteralReturn handles `fn name() -> Int { N }` for non-main
-// functions. The MIR shape is one block with a single AssignInstr
-// writing an IntConst to the return local, followed by ReturnTerm.
-func emitIntLiteralReturn(out *strings.Builder, fn *mir.Function) error {
-	if reason, _ := intLiteralReturnViolation(fn); reason != "" {
-		return fmt.Errorf("%w: function %q: %s", ErrUnsupported, fn.Name, reason)
+// ---- P2a: int literal return ----
+
+type intLiteralPattern struct {
+	value int64
+}
+
+func matchIntLiteralReturn(fn *mir.Function) (intLiteralPattern, bool) {
+	if !isPrimType(fn.ReturnType, ir.PrimInt) {
+		return intLiteralPattern{}, false
 	}
-	_, value := intLiteralReturnViolation(fn)
+	if len(fn.Params) != 0 {
+		return intLiteralPattern{}, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return intLiteralPattern{}, false
+	}
+	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
+	if !ok {
+		return intLiteralPattern{}, false
+	}
+	use, ok := assign.Src.(*mir.UseRV)
+	if !ok {
+		return intLiteralPattern{}, false
+	}
+	con, ok := use.Op.(*mir.ConstOp)
+	if !ok {
+		return intLiteralPattern{}, false
+	}
+	intc, ok := con.Const.(*mir.IntConst)
+	if !ok || !isPrimType(intc.Type(), ir.PrimInt) {
+		return intLiteralPattern{}, false
+	}
+	return intLiteralPattern{value: intc.Value}, true
+}
+
+func emitIntLiteralReturn(out *strings.Builder, fn *mir.Function, pat intLiteralPattern) error {
 	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
 	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  ret i64 %d\n", value)
+	fmt.Fprintf(out, "  ret i64 %d\n", pat.value)
 	out.WriteString("}\n\n")
 	return nil
 }
 
-// intLiteralReturnViolation returns "" + the constant value when `fn`
-// matches the P2a subset; otherwise it returns a reason string and a
-// zero value. Returning value alongside reason avoids re-walking the
-// MIR after the validation pass.
-func intLiteralReturnViolation(fn *mir.Function) (string, int64) {
+// ---- P2b: single Int param passthrough ----
+
+type intParamPassthroughPattern struct {
+	paramName string
+}
+
+func matchIntParamPassthrough(fn *mir.Function) (intParamPassthroughPattern, bool) {
 	if !isPrimType(fn.ReturnType, ir.PrimInt) {
-		return fmt.Sprintf("return type %s is not Int", primName(fn.ReturnType)), 0
+		return intParamPassthroughPattern{}, false
 	}
-	if len(fn.Params) != 0 {
-		return "function has parameters; stage0 P2a expects zero", 0
+	if len(fn.Params) != 1 {
+		return intParamPassthroughPattern{}, false
 	}
-	if len(fn.Blocks) != 1 {
-		return fmt.Sprintf("function has %d blocks; stage0 P2a expects exactly 1", len(fn.Blocks)), 0
+	paramID := fn.Params[0]
+	paramLocal := lookupLocal(fn, paramID)
+	if paramLocal == nil || !paramLocal.IsParam || !isPrimType(paramLocal.Type, ir.PrimInt) {
+		return intParamPassthroughPattern{}, false
 	}
-	bb := fn.Blocks[0]
-	if bb == nil {
-		return "entry block is nil", 0
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return intParamPassthroughPattern{}, false
 	}
-	if len(bb.Instrs) != 1 {
-		return fmt.Sprintf("entry block has %d instructions; stage0 P2a expects exactly 1", len(bb.Instrs)), 0
-	}
-	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
-		return fmt.Sprintf("terminator is %T; stage0 P2a expects ReturnTerm", bb.Term), 0
-	}
-	assign, ok := bb.Instrs[0].(*mir.AssignInstr)
+	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
 	if !ok {
-		return fmt.Sprintf("instruction[0] is %T; stage0 P2a expects AssignInstr", bb.Instrs[0]), 0
-	}
-	if assign.Dest.Local != fn.ReturnLocal || assign.Dest.HasProjections() {
-		return "AssignInstr destination is not the return local without projections", 0
+		return intParamPassthroughPattern{}, false
 	}
 	use, ok := assign.Src.(*mir.UseRV)
 	if !ok {
-		return fmt.Sprintf("AssignInstr.Src is %T; stage0 P2a expects UseRV", assign.Src), 0
+		return intParamPassthroughPattern{}, false
 	}
-	con, ok := use.Op.(*mir.ConstOp)
+	cp, ok := use.Op.(*mir.CopyOp)
 	if !ok {
-		return fmt.Sprintf("UseRV.Op is %T; stage0 P2a expects ConstOp", use.Op), 0
+		return intParamPassthroughPattern{}, false
 	}
-	intc, ok := con.Const.(*mir.IntConst)
+	if cp.Place.Local != paramID || cp.Place.HasProjections() {
+		return intParamPassthroughPattern{}, false
+	}
+	return intParamPassthroughPattern{paramName: sanitizeLLVMName(paramLocal.Name, "p")}, true
+}
+
+func emitIntParamPassthrough(out *strings.Builder, fn *mir.Function, pat intParamPassthroughPattern) error {
+	fmt.Fprintf(out, "define i64 @%s(i64 %%%s) {\n", fn.Name, pat.paramName)
+	out.WriteString("entry:\n")
+	fmt.Fprintf(out, "  ret i64 %%%s\n", pat.paramName)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- shared helpers ----
+
+func singleBlockReturning(fn *mir.Function) (*mir.BasicBlock, bool) {
+	if len(fn.Blocks) != 1 {
+		return nil, false
+	}
+	bb := fn.Blocks[0]
+	if bb == nil {
+		return nil, false
+	}
+	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
+		return nil, false
+	}
+	return bb, true
+}
+
+func writeToReturnLocal(instr mir.Instr, ret mir.LocalID) (*mir.AssignInstr, bool) {
+	assign, ok := instr.(*mir.AssignInstr)
 	if !ok {
-		return fmt.Sprintf("ConstOp.Const is %T; stage0 P2a expects IntConst", con.Const), 0
+		return nil, false
 	}
-	if !isPrimType(intc.Type(), ir.PrimInt) {
-		return fmt.Sprintf("IntConst type %s is not Int", primName(intc.Type())), 0
+	if assign.Dest.Local != ret || assign.Dest.HasProjections() {
+		return nil, false
 	}
-	return "", intc.Value
+	return assign, true
+}
+
+func lookupLocal(fn *mir.Function, id mir.LocalID) *mir.Local {
+	for _, l := range fn.Locals {
+		if l != nil && l.ID == id {
+			return l
+		}
+	}
+	return nil
+}
+
+// sanitizeLLVMName returns `name` if it is a non-empty valid LLVM
+// identifier (`[A-Za-z._][A-Za-z._0-9]*`), otherwise `fallback`.
+// Stage0 only emits SSA registers from clean Osty parameter names; the
+// guard exists so synthetic locals (`""`, generated suffixes) cannot
+// produce malformed IR.
+func sanitizeLLVMName(name, fallback string) string {
+	if name == "" {
+		return fallback
+	}
+	for i, r := range name {
+		if i == 0 {
+			if !isLLVMIdentStart(r) {
+				return fallback
+			}
+			continue
+		}
+		if !isLLVMIdentRest(r) {
+			return fallback
+		}
+	}
+	return name
+}
+
+func isLLVMIdentStart(r rune) bool {
+	switch {
+	case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		return true
+	case r == '_' || r == '.':
+		return true
+	}
+	return false
+}
+
+func isLLVMIdentRest(r rune) bool {
+	if isLLVMIdentStart(r) {
+		return true
+	}
+	return r >= '0' && r <= '9'
 }
 
 func isPrimType(t mir.Type, want ir.PrimKind) bool {
@@ -185,16 +297,6 @@ func isPrimType(t mir.Type, want ir.PrimKind) bool {
 		return false
 	}
 	return prim.Kind == want
-}
-
-func primName(t mir.Type) string {
-	if t == nil {
-		return "<nil>"
-	}
-	if prim, ok := t.(*ir.PrimType); ok && prim != nil {
-		return prim.String()
-	}
-	return fmt.Sprintf("%T", t)
 }
 
 func packageNameFor(module *mir.Module, opts llvmabi.Options) string {

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -54,6 +54,39 @@ func intLiteralFn(name string, value int64) *mir.Function {
 	}
 }
 
+// intParamPassthroughFn builds the canonical
+// `fn name(<paramName>: Int) -> Int { <paramName> }` MIR shape: one
+// block, one AssignInstr that copies the param local to the return
+// local.
+func intParamPassthroughFn(name, paramName string) *mir.Function {
+	const paramID mir.LocalID = 1
+	return &mir.Function{
+		Name:        name,
+		Params:      []mir.LocalID{paramID},
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+			{ID: paramID, Name: paramName, Type: ir.TInt, IsParam: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					&mir.AssignInstr{
+						Dest: mir.Place{Local: 0},
+						Src: &mir.UseRV{
+							Op: &mir.CopyOp{Place: mir.Place{Local: paramID}, T: ir.TInt},
+						},
+					},
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+}
+
 func moduleWith(fns ...*mir.Function) *mir.Module {
 	return &mir.Module{
 		Package:   "main",
@@ -171,18 +204,7 @@ func TestStage0EmitsIntLiteralFunctionAlongsideMain(t *testing.T) {
 	}
 }
 
-func TestStage0RejectsIntFunctionWithParams(t *testing.T) {
-	t.Parallel()
-	fn := intLiteralFn("identity", 0)
-	fn.Params = []mir.LocalID{1}
-	fn.Locals = append(fn.Locals, &mir.Local{ID: 1, Name: "x", Type: ir.TInt, IsParam: true})
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-}
-
-func TestStage0RejectsIntFunctionWithBoolReturn(t *testing.T) {
+func TestStage0RejectsBoolReturnFunction(t *testing.T) {
 	t.Parallel()
 	fn := intLiteralFn("flag", 1)
 	fn.ReturnType = ir.TBool
@@ -192,10 +214,9 @@ func TestStage0RejectsIntFunctionWithBoolReturn(t *testing.T) {
 	}
 }
 
-func TestStage0RejectsIntFunctionWithExtraInstr(t *testing.T) {
+func TestStage0RejectsMultiInstructionFunction(t *testing.T) {
 	t.Parallel()
 	fn := intLiteralFn("two_step", 7)
-	// Adding a second AssignInstr leaves the block with 2 instrs.
 	fn.Blocks[0].Instrs = append(fn.Blocks[0].Instrs, &mir.AssignInstr{
 		Dest: mir.Place{Local: 0},
 		Src: &mir.UseRV{
@@ -206,35 +227,89 @@ func TestStage0RejectsIntFunctionWithExtraInstr(t *testing.T) {
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
 	}
-	if !strings.Contains(err.Error(), "expects exactly 1") {
-		t.Fatalf("err = %q, want instr-count reason", err.Error())
-	}
 }
 
-func TestStage0RejectsIntFunctionWithBinaryRV(t *testing.T) {
+func TestStage0RejectsBinaryRVFunction(t *testing.T) {
 	t.Parallel()
 	fn := intLiteralFn("sum", 0)
 	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
 		Dest: mir.Place{Local: 0},
 		Src: &mir.BinaryRV{
-			Op: mir.BinAdd,
-			Left: &mir.ConstOp{Const: &mir.IntConst{Value: 1, T: ir.TInt}, T: ir.TInt},
+			Op:    mir.BinAdd,
+			Left:  &mir.ConstOp{Const: &mir.IntConst{Value: 1, T: ir.TInt}, T: ir.TInt},
 			Right: &mir.ConstOp{Const: &mir.IntConst{Value: 2, T: ir.TInt}, T: ir.TInt},
-			T:    ir.TInt,
+			T:     ir.TInt,
 		},
 	}
 	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
 	}
-	if !strings.Contains(err.Error(), "expects UseRV") {
-		t.Fatalf("err = %q, want UseRV reason", err.Error())
+}
+
+// ---- P2b: int param passthrough ----
+
+func TestStage0EmitsIntParamPassthrough(t *testing.T) {
+	t.Parallel()
+	got, err := EmitMIR(moduleWith(trivialMainFn(), intParamPassthroughFn("identity", "x"), intParamPassthroughFn("forward", "value")), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		"define i64 @identity(i64 %x)",
+		"ret i64 %x",
+		"define i64 @forward(i64 %value)",
+		"ret i64 %value",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		}
 	}
 }
 
-func TestStage0RejectsIntFunctionWithCopyOp(t *testing.T) {
+func TestStage0SanitizesEmptyParamName(t *testing.T) {
 	t.Parallel()
-	fn := intLiteralFn("dup", 0)
+	// Synthetic temporaries reach MIR with empty Name; we fall back
+	// to `%p` rather than emit malformed IR.
+	got, err := EmitMIR(moduleWith(trivialMainFn(), intParamPassthroughFn("identity", "")), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	if !strings.Contains(string(got), "define i64 @identity(i64 %p)") {
+		t.Fatalf("expected fallback param name `%%p`:\n%s", got)
+	}
+}
+
+func TestStage0RejectsTwoParamFunction(t *testing.T) {
+	t.Parallel()
+	fn := intParamPassthroughFn("add", "x")
+	fn.Params = append(fn.Params, 2)
+	fn.Locals = append(fn.Locals, &mir.Local{ID: 2, Name: "y", Type: ir.TInt, IsParam: true})
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsBoolParamPassthrough(t *testing.T) {
+	t.Parallel()
+	fn := intParamPassthroughFn("flag", "b")
+	fn.ReturnType = ir.TBool
+	for _, l := range fn.Locals {
+		l.Type = ir.TBool
+	}
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsPassthroughCopyingNonParam(t *testing.T) {
+	t.Parallel()
+	fn := intParamPassthroughFn("mistake", "x")
+	// CopyOp source = ret local (not the param) — even with the
+	// right signature shape, this isn't the passthrough pattern.
 	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
 		Dest: mir.Place{Local: 0},
 		Src: &mir.UseRV{
@@ -244,8 +319,5 @@ func TestStage0RejectsIntFunctionWithCopyOp(t *testing.T) {
 	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-	if !strings.Contains(err.Error(), "expects ConstOp") {
-		t.Fatalf("err = %q, want ConstOp reason", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

부트스트랩 P2의 두 번째 패턴 — non-main 함수가 단일 Int 파라미터를 그대로 리턴.

```osty
fn name(x: Int) -> Int { x }
```

→ MIR: 1 param + 1-block + AssignInstr(UseRV→CopyOp{param}) + ReturnTerm
→ LLVM: `define i64 @name(i64 %x) { ret i64 %x }`

### 디스패처 리팩토링

violation-string 방식 → **pattern-matcher 방식** 으로 변경:

```go
// emitFunction:
//   if main { emitTrivialMain }
//   for each registered pattern matcher:
//     if pat, ok := matchXxx(fn); ok { return emitXxx(out, fn, pat) }
//   return ErrUnsupported  // generic "no pattern matched"
```

각 패턴은 `match*(fn) (pattern, ok)` 시그니처. 성공 시 매칭된 데이터 (literal value / param name 등)를 담은 struct + true 반환. 매치 실패 = false. 패턴 간 공통 검사는 `singleBlockReturning` / `writeToReturnLocal` / `lookupLocal` 빌딩 블록으로 추출.

이로 인해 P2x 확장은 새 `match*` + `emit*` 한 쌍 추가 + matcher 슬라이스에 등록만 하면 됨.

### 안전 가드

`sanitizeLLVMName(name, fallback)` 추가 — Osty 파라미터 이름이 LLVM SSA identifier 규칙 (`[A-Za-z._][A-Za-z._0-9]*`) 을 만족하지 않으면 fallback. 합성 임시 (Name="") 가 들어와도 malformed IR 발생 안 함.

### 테스트 (총 16, +4)

성공:
- `TestStage0EmitsIntParamPassthrough` — `identity(x)` + `forward(value)` 두 함수 한 모듈에서 emit.
- `TestStage0SanitizesEmptyParamName` — 빈 이름 → `%p` fallback.

거부 (ErrUnsupported):
- 두 파라미터
- Bool 리턴 / Bool 파라미터
- CopyOp 가 param 아닌 ret local 을 카피

기존 P1/P2a 테스트는 메시지-string 단언이 매칭 패턴 부재 시 generic 메시지로 바뀌므로 `errors.Is(err, ErrUnsupported)` 일반 검사로 정리.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test -count=1 -short ./internal/backend/stage0/...` — 16개 PASS, 0 fail
- [x] `go test -count=1 -short ./internal/backend/...` — backend 전체 0 fail

## Notes

- 디스패처 surface 는 동일. 호출자 (디스패처 wiring 은 P3) 영향 없음.
- 다음 (P2c): 산술 (`fn add(a, b) -> Int { a + b }`) 또는 `if-else` 또는 `let` 중 하나.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_