### PR TITLE
feat(backend/stage0): two-Int-param binary add (P2c)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -159,7 +159,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P1 | `internal/backend/stage0/` skeleton + 단순 `fn main()` 케이스 한 개 | TestStage0HelloWorld — **구현 완료**: `internal/backend/stage0/emit.go::EmitMIR` |
 | P2a | non-main fn → Int { N } (literal return) | TestStage0EmitsIntLiteralFunctionAlongsideMain — **구현 완료** |
 | P2b | non-main fn(x: Int) -> Int { x } (param passthrough) | TestStage0EmitsIntParamPassthrough — **구현 완료** |
-| P2c+ | toolchain 의 첫 10개 함수 lowering 통과 (산술 / call / if-else / locals …) | toolchain/main.osty 부분 빌드 |
+| P2c | non-main fn(a, b: Int) -> Int { a + b } (binary add) | TestStage0EmitsIntBinaryAdd — **구현 완료** |
+| P2d+ | toolchain 의 첫 10개 함수 lowering 통과 (Sub/Mul/Div / call / if-else / locals …) | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -31,6 +31,10 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 //   - P2b: `fn name(x: Int) -> Int { x }` — non-main, single Int
 //     parameter, single block, one AssignInstr writing CopyOp(param)
 //     to the return local, ReturnTerm.
+//   - P2c: `fn name(a: Int, b: Int) -> Int { a + b }` — non-main,
+//     two Int parameters, single block, one AssignInstr writing
+//     BinaryRV{BinAdd, CopyOp(p0), CopyOp(p1)} to the return local,
+//     ReturnTerm.
 //
 // Each P2x extension adds one match predicate + emit closure +
 // regression test. Surface drift is held back by the stage0 coverage
@@ -83,6 +87,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	}
 	if pat, ok := matchIntParamPassthrough(fn); ok {
 		return emitIntParamPassthrough(out, fn, pat)
+	}
+	if pat, ok := matchIntBinaryAdd(fn); ok {
+		return emitIntBinaryAdd(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
@@ -213,6 +220,89 @@ func emitIntParamPassthrough(out *strings.Builder, fn *mir.Function, pat intPara
 	fmt.Fprintf(out, "  ret i64 %%%s\n", pat.paramName)
 	out.WriteString("}\n\n")
 	return nil
+}
+
+// ---- P2c: two-Int-param add ----
+
+type intBinaryAddPattern struct {
+	leftName  string
+	rightName string
+}
+
+// matchIntBinaryAdd matches `fn name(a: Int, b: Int) -> Int { a + b }`.
+// MIR shape: 2 Int params, single block, single AssignInstr writing
+// BinaryRV{BinAdd, CopyOp(p0), CopyOp(p1)} to the return local,
+// ReturnTerm. Operand order must match Params order — `b + a` is a
+// distinct expression that lowers to swapped CopyOps and currently
+// declines.
+func matchIntBinaryAdd(fn *mir.Function) (intBinaryAddPattern, bool) {
+	if !isPrimType(fn.ReturnType, ir.PrimInt) {
+		return intBinaryAddPattern{}, false
+	}
+	if len(fn.Params) != 2 {
+		return intBinaryAddPattern{}, false
+	}
+	leftID, rightID := fn.Params[0], fn.Params[1]
+	leftLocal, rightLocal := lookupLocal(fn, leftID), lookupLocal(fn, rightID)
+	if leftLocal == nil || rightLocal == nil {
+		return intBinaryAddPattern{}, false
+	}
+	if !leftLocal.IsParam || !rightLocal.IsParam {
+		return intBinaryAddPattern{}, false
+	}
+	if !isPrimType(leftLocal.Type, ir.PrimInt) || !isPrimType(rightLocal.Type, ir.PrimInt) {
+		return intBinaryAddPattern{}, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return intBinaryAddPattern{}, false
+	}
+	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
+	if !ok {
+		return intBinaryAddPattern{}, false
+	}
+	bin, ok := assign.Src.(*mir.BinaryRV)
+	if !ok || bin.Op != mir.BinAdd {
+		return intBinaryAddPattern{}, false
+	}
+	if !isPrimType(bin.T, ir.PrimInt) {
+		return intBinaryAddPattern{}, false
+	}
+	if !copiesParam(bin.Left, leftID) || !copiesParam(bin.Right, rightID) {
+		return intBinaryAddPattern{}, false
+	}
+	return intBinaryAddPattern{
+		leftName:  sanitizeLLVMName(leftLocal.Name, "a"),
+		rightName: sanitizeLLVMName(rightLocal.Name, "b"),
+	}, true
+}
+
+func emitIntBinaryAdd(out *strings.Builder, fn *mir.Function, pat intBinaryAddPattern) error {
+	left, right := pat.leftName, pat.rightName
+	if left == right {
+		// Sanitiser hands back the same fallback when both source
+		// names are unrenderable; disambiguate so SSA stays valid.
+		right = right + ".1"
+	}
+	fmt.Fprintf(out, "define i64 @%s(i64 %%%s, i64 %%%s) {\n", fn.Name, left, right)
+	out.WriteString("entry:\n")
+	fmt.Fprintf(out, "  %%0 = add i64 %%%s, %%%s\n", left, right)
+	out.WriteString("  ret i64 %0\n")
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// copiesParam reports whether `op` is a CopyOp reading the entire
+// param local with id `paramID` (no projections).
+func copiesParam(op mir.Operand, paramID mir.LocalID) bool {
+	cp, ok := op.(*mir.CopyOp)
+	if !ok {
+		return false
+	}
+	if cp.Place.Local != paramID || cp.Place.HasProjections() {
+		return false
+	}
+	return true
 }
 
 // ---- shared helpers ----

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -305,6 +305,114 @@ func TestStage0RejectsBoolParamPassthrough(t *testing.T) {
 	}
 }
 
+// intBinaryAddFn builds the canonical
+// `fn name(a: Int, b: Int) -> Int { a + b }` MIR shape.
+func intBinaryAddFn(name, leftName, rightName string) *mir.Function {
+	const leftID, rightID mir.LocalID = 1, 2
+	return &mir.Function{
+		Name:        name,
+		Params:      []mir.LocalID{leftID, rightID},
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+			{ID: leftID, Name: leftName, Type: ir.TInt, IsParam: true},
+			{ID: rightID, Name: rightName, Type: ir.TInt, IsParam: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{
+				ID: 0,
+				Instrs: []mir.Instr{
+					&mir.AssignInstr{
+						Dest: mir.Place{Local: 0},
+						Src: &mir.BinaryRV{
+							Op:    mir.BinAdd,
+							Left:  &mir.CopyOp{Place: mir.Place{Local: leftID}, T: ir.TInt},
+							Right: &mir.CopyOp{Place: mir.Place{Local: rightID}, T: ir.TInt},
+							T:     ir.TInt,
+						},
+					},
+				},
+				Term: &mir.ReturnTerm{},
+			},
+		},
+	}
+}
+
+func TestStage0EmitsIntBinaryAdd(t *testing.T) {
+	t.Parallel()
+	got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryAddFn("add", "a", "b"), intBinaryAddFn("sum", "left", "right")), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		"define i64 @add(i64 %a, i64 %b)",
+		"%0 = add i64 %a, %b",
+		"ret i64 %0",
+		"define i64 @sum(i64 %left, i64 %right)",
+		"%0 = add i64 %left, %right",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestStage0BinaryAddDisambiguatesCollidingParamNames(t *testing.T) {
+	t.Parallel()
+	// Both param names empty → both sanitise to `a`/`b` (the
+	// per-position fallbacks). Here we force them to BOTH sanitise
+	// to the same value to confirm the post-sanitise collision
+	// guard runs: sanitiser maps non-ASCII names to fallback "a"
+	// (left position), so set left=valid, right=non-ASCII to force
+	// collision through the fallback.
+	fn := intBinaryAddFn("collide", "", "")
+	got, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	if !strings.Contains(string(got), "define i64 @collide(i64 %a, i64 %b)") {
+		t.Fatalf("expected per-position fallbacks `%%a`/`%%b`:\n%s", got)
+	}
+}
+
+func TestStage0RejectsBinaryAddWithBoolReturn(t *testing.T) {
+	t.Parallel()
+	fn := intBinaryAddFn("flag", "a", "b")
+	fn.ReturnType = ir.TBool
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsBinaryAddWithSwappedOperands(t *testing.T) {
+	t.Parallel()
+	// `b + a` instead of `a + b`. Stage0 P2c is intentionally strict
+	// about operand order — swapped operands lower to a different
+	// MIR shape and decline.
+	fn := intBinaryAddFn("swap", "a", "b")
+	bin := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.BinaryRV)
+	bin.Left, bin.Right = bin.Right, bin.Left
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+}
+
+func TestStage0RejectsBinarySubOperator(t *testing.T) {
+	t.Parallel()
+	fn := intBinaryAddFn("minus", "a", "b")
+	bin := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.BinaryRV)
+	bin.Op = mir.BinSub
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinSub not in P2c)", err)
+	}
+}
+
 func TestStage0RejectsPassthroughCopyingNonParam(t *testing.T) {
 	t.Parallel()
 	fn := intParamPassthroughFn("mistake", "x")


### PR DESCRIPTION
## Summary

부트스트랩 P2의 세 번째 패턴 — non-main 함수가 두 Int 파라미터의 합을 리턴.

```osty
fn name(a: Int, b: Int) -> Int { a + b }
```

→ MIR: 2 param + 1-block + AssignInstr(BinaryRV{BinAdd, CopyOp(p0), CopyOp(p1)}) + ReturnTerm
→ LLVM:

```llvm
define i64 @add(i64 %a, i64 %b) {
entry:
  %0 = add i64 %a, %b
  ret i64 %0
}
```

### 의도적 좁힘

- **BinAdd 만**. Sub/Mul/Div 는 P2d+에서 같은 shape 의 BinaryOp switch 추가만 하면 됨.
- **피연산자 순서가 Params 와 동일해야 함** — `b + a` 는 swapped CopyOps 로 lowering 돼 다른 패턴. P2c는 받지 않고 다음 패턴이 cover하도록 양보.
- **nsw/nuw 플래그 없는 plain add** — 부호 wrap 동작이 LLVM 정의상 명확.

### 헬퍼

- `copiesParam(op mir.Operand, paramID mir.LocalID) bool` — BinaryRV 검증 가독성 개선 + 향후 패턴 (Sub/Mul) 재사용.
- 파라미터 이름 sanitiser 가 left/right 포지션에 **위치별 fallback** (`a`, `b`) 을 주도록 변경. 두 입력이 모두 unrenderable 이어도 SSA 이름 충돌 0.

### 테스트 (총 21, +5)

성공:
- `TestStage0EmitsIntBinaryAdd` — `add(a,b)` + `sum(left,right)` 두 함수.
- `TestStage0BinaryAddDisambiguatesCollidingParamNames` — 빈 이름 두 개 → `%a`/`%b` 위치별 fallback.

거부 (각각 ErrUnsupported):
- Bool 리턴
- 피연산자 swap (`b + a`)
- BinSub (P2c 는 BinAdd 만)

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 21개 PASS, 0 fail
- [x] `go test ./internal/backend/...` — 전체 backend 0 fail

## Notes

- 디스패처 surface 영향 0. P3 wiring 까지는 stage0 가 누구도 호출하지 않음.
- 다음 (P2d): 후보는 (a) Sub/Mul/Div 확장, (b) const + var 혼합 (`a + 1`), (c) `let` 바인딩, (d) 단순 if-else. 가장 작은 단위로 잘라서 진행.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_