### PR TITLE
feat(backend/stage0): Sub/Mul/Div/Mod arithmetic ops (P2d)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -160,7 +160,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P2a | non-main fn → Int { N } (literal return) | TestStage0EmitsIntLiteralFunctionAlongsideMain — **구현 완료** |
 | P2b | non-main fn(x: Int) -> Int { x } (param passthrough) | TestStage0EmitsIntParamPassthrough — **구현 완료** |
 | P2c | non-main fn(a, b: Int) -> Int { a + b } (binary add) | TestStage0EmitsIntBinaryAdd — **구현 완료** |
-| P2d+ | toolchain 의 첫 10개 함수 lowering 통과 (Sub/Mul/Div / call / if-else / locals …) | toolchain/main.osty 부분 빌드 |
+| P2d | non-main fn(a, b: Int) -> Int { a OP b } — Sub/Mul/Div/Mod 확장 | TestStage0EmitsIntBinaryArithOps — **구현 완료** |
+| P2e+ | toolchain 의 첫 10개 함수 lowering 통과 (call / if-else / locals / 비교 / 비트 …) | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -31,10 +31,10 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 //   - P2b: `fn name(x: Int) -> Int { x }` — non-main, single Int
 //     parameter, single block, one AssignInstr writing CopyOp(param)
 //     to the return local, ReturnTerm.
-//   - P2c: `fn name(a: Int, b: Int) -> Int { a + b }` — non-main,
+//   - P2c/P2d: `fn name(a: Int, b: Int) -> Int { a OP b }` — non-main,
 //     two Int parameters, single block, one AssignInstr writing
-//     BinaryRV{BinAdd, CopyOp(p0), CopyOp(p1)} to the return local,
-//     ReturnTerm.
+//     BinaryRV{op, CopyOp(p0), CopyOp(p1)} to the return local,
+//     ReturnTerm. OP is one of Add (P2c) / Sub / Mul / Div / Mod (P2d).
 //
 // Each P2x extension adds one match predicate + emit closure +
 // regression test. Surface drift is held back by the stage0 coverage
@@ -88,8 +88,8 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	if pat, ok := matchIntParamPassthrough(fn); ok {
 		return emitIntParamPassthrough(out, fn, pat)
 	}
-	if pat, ok := matchIntBinaryAdd(fn); ok {
-		return emitIntBinaryAdd(out, fn, pat)
+	if pat, ok := matchIntBinaryArith(fn); ok {
+		return emitIntBinaryArith(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
@@ -222,74 +222,101 @@ func emitIntParamPassthrough(out *strings.Builder, fn *mir.Function, pat intPara
 	return nil
 }
 
-// ---- P2c: two-Int-param add ----
+// ---- P2c/P2d: two-Int-param binary arithmetic ----
 
-type intBinaryAddPattern struct {
+type intBinaryArithPattern struct {
+	op        mir.BinaryOp
 	leftName  string
 	rightName string
 }
 
-// matchIntBinaryAdd matches `fn name(a: Int, b: Int) -> Int { a + b }`.
-// MIR shape: 2 Int params, single block, single AssignInstr writing
-// BinaryRV{BinAdd, CopyOp(p0), CopyOp(p1)} to the return local,
-// ReturnTerm. Operand order must match Params order — `b + a` is a
-// distinct expression that lowers to swapped CopyOps and currently
-// declines.
-func matchIntBinaryAdd(fn *mir.Function) (intBinaryAddPattern, bool) {
+// matchIntBinaryArith matches `fn name(a: Int, b: Int) -> Int { a OP b }`
+// where OP is one of the supported integer arithmetic operators (Add /
+// Sub / Mul / Div / Mod — see `intArithLLVMOp`). MIR shape: 2 Int
+// params, single block, single AssignInstr writing BinaryRV{op,
+// CopyOp(p0), CopyOp(p1)} to the return local, ReturnTerm. Operand
+// order must match Params order — `b + a` lowers to swapped CopyOps
+// and currently declines.
+func matchIntBinaryArith(fn *mir.Function) (intBinaryArithPattern, bool) {
 	if !isPrimType(fn.ReturnType, ir.PrimInt) {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	if len(fn.Params) != 2 {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	leftID, rightID := fn.Params[0], fn.Params[1]
 	leftLocal, rightLocal := lookupLocal(fn, leftID), lookupLocal(fn, rightID)
 	if leftLocal == nil || rightLocal == nil {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	if !leftLocal.IsParam || !rightLocal.IsParam {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	if !isPrimType(leftLocal.Type, ir.PrimInt) || !isPrimType(rightLocal.Type, ir.PrimInt) {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	bb, ok := singleBlockReturning(fn)
 	if !ok || len(bb.Instrs) != 1 {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
 	if !ok {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
 	bin, ok := assign.Src.(*mir.BinaryRV)
-	if !ok || bin.Op != mir.BinAdd {
-		return intBinaryAddPattern{}, false
+	if !ok {
+		return intBinaryArithPattern{}, false
 	}
 	if !isPrimType(bin.T, ir.PrimInt) {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
+	}
+	if intArithLLVMOp(bin.Op) == "" {
+		return intBinaryArithPattern{}, false
 	}
 	if !copiesParam(bin.Left, leftID) || !copiesParam(bin.Right, rightID) {
-		return intBinaryAddPattern{}, false
+		return intBinaryArithPattern{}, false
 	}
-	return intBinaryAddPattern{
+	return intBinaryArithPattern{
+		op:        bin.Op,
 		leftName:  sanitizeLLVMName(leftLocal.Name, "a"),
 		rightName: sanitizeLLVMName(rightLocal.Name, "b"),
 	}, true
 }
 
-func emitIntBinaryAdd(out *strings.Builder, fn *mir.Function, pat intBinaryAddPattern) error {
+func emitIntBinaryArith(out *strings.Builder, fn *mir.Function, pat intBinaryArithPattern) error {
 	left, right := pat.leftName, pat.rightName
 	if left == right {
 		// Sanitiser hands back the same fallback when both source
 		// names are unrenderable; disambiguate so SSA stays valid.
 		right = right + ".1"
 	}
+	llvmOp := intArithLLVMOp(pat.op)
 	fmt.Fprintf(out, "define i64 @%s(i64 %%%s, i64 %%%s) {\n", fn.Name, left, right)
 	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  %%0 = add i64 %%%s, %%%s\n", left, right)
+	fmt.Fprintf(out, "  %%0 = %s i64 %%%s, %%%s\n", llvmOp, left, right)
 	out.WriteString("  ret i64 %0\n")
 	out.WriteString("}\n\n")
 	return nil
+}
+
+// intArithLLVMOp returns the LLVM signed-integer instruction mnemonic
+// for `op`, or "" when the operator is outside the stage0 arithmetic
+// subset. Comparison / logical / bitwise ops decline so the matcher
+// gives the next pattern (when one is added) a chance.
+func intArithLLVMOp(op mir.BinaryOp) string {
+	switch op {
+	case mir.BinAdd:
+		return "add"
+	case mir.BinSub:
+		return "sub"
+	case mir.BinMul:
+		return "mul"
+	case mir.BinDiv:
+		return "sdiv"
+	case mir.BinMod:
+		return "srem"
+	}
+	return ""
 }
 
 // copiesParam reports whether `op` is a CopyOp reading the entire

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -305,9 +305,11 @@ func TestStage0RejectsBoolParamPassthrough(t *testing.T) {
 	}
 }
 
-// intBinaryAddFn builds the canonical
-// `fn name(a: Int, b: Int) -> Int { a + b }` MIR shape.
-func intBinaryAddFn(name, leftName, rightName string) *mir.Function {
+// intBinaryArithFn builds the canonical
+// `fn name(a: Int, b: Int) -> Int { a OP b }` MIR shape, parameterised
+// over the operator so P2c (Add) and P2d (Sub/Mul/Div/Mod) can share a
+// fixture.
+func intBinaryArithFn(name string, op mir.BinaryOp, leftName, rightName string) *mir.Function {
 	const leftID, rightID mir.LocalID = 1, 2
 	return &mir.Function{
 		Name:        name,
@@ -327,7 +329,7 @@ func intBinaryAddFn(name, leftName, rightName string) *mir.Function {
 					&mir.AssignInstr{
 						Dest: mir.Place{Local: 0},
 						Src: &mir.BinaryRV{
-							Op:    mir.BinAdd,
+							Op:    op,
 							Left:  &mir.CopyOp{Place: mir.Place{Local: leftID}, T: ir.TInt},
 							Right: &mir.CopyOp{Place: mir.Place{Local: rightID}, T: ir.TInt},
 							T:     ir.TInt,
@@ -342,7 +344,7 @@ func intBinaryAddFn(name, leftName, rightName string) *mir.Function {
 
 func TestStage0EmitsIntBinaryAdd(t *testing.T) {
 	t.Parallel()
-	got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryAddFn("add", "a", "b"), intBinaryAddFn("sum", "left", "right")), llvmabi.Options{PackageName: "main"})
+	got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryArithFn("add", mir.BinAdd, "a", "b"), intBinaryArithFn("sum", mir.BinAdd, "left", "right")), llvmabi.Options{PackageName: "main"})
 	if err != nil {
 		t.Fatalf("EmitMIR: %v", err)
 	}
@@ -360,15 +362,45 @@ func TestStage0EmitsIntBinaryAdd(t *testing.T) {
 	}
 }
 
-func TestStage0BinaryAddDisambiguatesCollidingParamNames(t *testing.T) {
+func TestStage0EmitsIntBinaryArithOps(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		op      mir.BinaryOp
+		llvmOp  string
+	}{
+		{"sub", mir.BinSub, "sub"},
+		{"mul", mir.BinMul, "mul"},
+		{"div", mir.BinDiv, "sdiv"},
+		{"mod", mir.BinMod, "srem"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryArithFn(c.name, c.op, "a", "b")), llvmabi.Options{PackageName: "main"})
+			if err != nil {
+				t.Fatalf("EmitMIR: %v", err)
+			}
+			s := string(got)
+			fnHeader := "define i64 @" + c.name + "(i64 %a, i64 %b)"
+			body := "%0 = " + c.llvmOp + " i64 %a, %b"
+			for _, want := range []string{fnHeader, body, "ret i64 %0"} {
+				if !strings.Contains(s, want) {
+					t.Fatalf("emitted IR missing %q:\n%s", want, s)
+				}
+			}
+		})
+	}
+}
+
+func TestStage0BinaryArithDisambiguatesCollidingParamNames(t *testing.T) {
 	t.Parallel()
 	// Both param names empty → both sanitise to `a`/`b` (the
-	// per-position fallbacks). Here we force them to BOTH sanitise
-	// to the same value to confirm the post-sanitise collision
-	// guard runs: sanitiser maps non-ASCII names to fallback "a"
-	// (left position), so set left=valid, right=non-ASCII to force
-	// collision through the fallback.
-	fn := intBinaryAddFn("collide", "", "")
+	// per-position fallbacks). The collision-guard inside
+	// emitIntBinaryArith only triggers when fallbacks coincide
+	// (left and right both produce identical sanitised names).
+	fn := intBinaryArithFn("collide", mir.BinAdd, "", "")
 	got, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
 	if err != nil {
 		t.Fatalf("EmitMIR: %v", err)
@@ -378,9 +410,9 @@ func TestStage0BinaryAddDisambiguatesCollidingParamNames(t *testing.T) {
 	}
 }
 
-func TestStage0RejectsBinaryAddWithBoolReturn(t *testing.T) {
+func TestStage0RejectsBinaryArithWithBoolReturn(t *testing.T) {
 	t.Parallel()
-	fn := intBinaryAddFn("flag", "a", "b")
+	fn := intBinaryArithFn("flag", mir.BinAdd, "a", "b")
 	fn.ReturnType = ir.TBool
 	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
@@ -388,12 +420,11 @@ func TestStage0RejectsBinaryAddWithBoolReturn(t *testing.T) {
 	}
 }
 
-func TestStage0RejectsBinaryAddWithSwappedOperands(t *testing.T) {
+func TestStage0RejectsBinaryArithWithSwappedOperands(t *testing.T) {
 	t.Parallel()
-	// `b + a` instead of `a + b`. Stage0 P2c is intentionally strict
-	// about operand order — swapped operands lower to a different
-	// MIR shape and decline.
-	fn := intBinaryAddFn("swap", "a", "b")
+	// `b + a` instead of `a + b`. Stage0 is intentionally strict about
+	// operand order — swapped operands lower to a different MIR shape.
+	fn := intBinaryArithFn("swap", mir.BinAdd, "a", "b")
 	bin := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.BinaryRV)
 	bin.Left, bin.Right = bin.Right, bin.Left
 	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
@@ -402,14 +433,24 @@ func TestStage0RejectsBinaryAddWithSwappedOperands(t *testing.T) {
 	}
 }
 
-func TestStage0RejectsBinarySubOperator(t *testing.T) {
+func TestStage0RejectsComparisonBinaryOp(t *testing.T) {
 	t.Parallel()
-	fn := intBinaryAddFn("minus", "a", "b")
-	bin := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.BinaryRV)
-	bin.Op = mir.BinSub
+	// BinEq is outside the arithmetic subset (P2d covers Add/Sub/Mul/
+	// Div/Mod only). Comparison results are Bool, but even with the
+	// right shape the operator declines.
+	fn := intBinaryArithFn("eq", mir.BinEq, "a", "b")
 	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
 	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinSub not in P2c)", err)
+		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinEq not in P2d)", err)
+	}
+}
+
+func TestStage0RejectsBitwiseBinaryOp(t *testing.T) {
+	t.Parallel()
+	fn := intBinaryArithFn("bit_and", mir.BinBitAnd, "a", "b")
+	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinBitAnd not in P2d)", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

P2c 의 binary add 패턴을 일반화 — 같은 MIR shape (2 Int param + BinaryRV + ReturnTerm) 에서 5개 정수 산술 연산자를 모두 수용.

| MIR `BinaryOp` | LLVM mnemonic |
|---|---|
| `BinAdd` | `add` |
| `BinSub` | `sub` |
| `BinMul` | `mul` |
| `BinDiv` | `sdiv` (signed integer division) |
| `BinMod` | `srem` (signed remainder) |

```osty
fn sub(a: Int, b: Int) -> Int { a - b }
```

→
```llvm
define i64 @sub(i64 %a, i64 %b) {
entry:
  %0 = sub i64 %a, %b
  ret i64 %0
}
```

### 설계 키 포인트

- **단일 dispatch**: 새 헬퍼 `intArithLLVMOp(op) string` 가 op → LLVM mnemonic 변환 한 곳에서. 비지원 op (`BinEq`, `BinLt`, `BinAnd`, `BinBitAnd` 등) 는 빈 문자열을 반환해서 matcher 가 다음 패턴에 양보.
- **리네이밍**: `intBinaryAddPattern` → `intBinaryArithPattern` (+ `op` 필드). 픽스처 헬퍼도 `intBinaryAddFn` → `intBinaryArithFn(name, op, ...)`.
- 기존 P2c 단언은 그대로 통과 — `BinAdd` 도 같은 일반화된 matcher 를 거침.

### 테스트 (총 27, +6)

성공:
- 기존 `TestStage0EmitsIntBinaryAdd` (BinAdd 호출 형태로 갱신)
- `TestStage0EmitsIntBinaryArithOps/{sub,mul,div,mod}` (subtests 4개)
- `TestStage0BinaryArithDisambiguatesCollidingParamNames` (P2c 의 충돌 fallback 그대로 검증)

거부:
- Bool 리턴
- 피연산자 swap
- `BinEq` (비교는 P2d 밖)
- `BinBitAnd` (비트는 P2d 밖)

기존 `TestStage0RejectsBinarySubOperator` 는 P2d 가 Sub 를 받으므로 제거.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 27개 PASS, 0 fail
- [x] `go test ./internal/backend/...` — 전체 backend 0 fail

## Notes

- 디스패처 surface 영향 0. P3 wiring 까지 stage0 는 누구도 호출하지 않음.
- 다음 (P2e): 가장 작은 단위는 (a) 비교 연산자 (icmp + i1 결과), (b) const + var 혼합 (`a + 1`), (c) `let` 바인딩, (d) 호출 (`f(x)`), (e) if-else. 진행 시 토론 후 결정.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_