### PR TITLE
feat(backend/stage0): single-instruction operator batch — cmp/bitwise/logical/Bool/mixed (P2e)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -161,7 +161,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P2b | non-main fn(x: Int) -> Int { x } (param passthrough) | TestStage0EmitsIntParamPassthrough — **구현 완료** |
 | P2c | non-main fn(a, b: Int) -> Int { a + b } (binary add) | TestStage0EmitsIntBinaryAdd — **구현 완료** |
 | P2d | non-main fn(a, b: Int) -> Int { a OP b } — Sub/Mul/Div/Mod 확장 | TestStage0EmitsIntBinaryArithOps — **구현 완료** |
-| P2e+ | toolchain 의 첫 10개 함수 lowering 통과 (call / if-else / locals / 비교 / 비트 …) | toolchain/main.osty 부분 빌드 |
+| P2e | single-instruction batch — 비교 / 비트 / 시프트 / 논리 / Bool / mixed const+var / 0~2 파라미터 / 자유로운 피연산자 순서 | 47 tests — **구현 완료** |
+| P3a+ | multi-instruction (let / 임시 변수) / 함수 호출 / if-else (multi-block) / 더 큰 toolchain 부분 빌드 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -22,23 +22,27 @@ var ErrUnsupported = errors.New("stage0: MIR shape outside bootstrap subset")
 // builds with a working `osty-self` route through the LIR Proto
 // subprocess instead and never reach this entry.
 //
-// Currently supported function shapes (each gated by an explicit
-// `match*` predicate; non-matching shapes return ErrUnsupported):
+// Currently supported function shapes — the matcher tries each in
+// order and emits the first that fits; otherwise ErrUnsupported:
 //
-//   - P1: `fn main() {}` — single block, zero instructions, ReturnTerm.
-//   - P2a: `fn name() -> Int { N }` — non-main, single block, one
-//     AssignInstr writing IntConst to the return local, ReturnTerm.
-//   - P2b: `fn name(x: Int) -> Int { x }` — non-main, single Int
-//     parameter, single block, one AssignInstr writing CopyOp(param)
-//     to the return local, ReturnTerm.
-//   - P2c/P2d: `fn name(a: Int, b: Int) -> Int { a OP b }` — non-main,
-//     two Int parameters, single block, one AssignInstr writing
-//     BinaryRV{op, CopyOp(p0), CopyOp(p1)} to the return local,
-//     ReturnTerm. OP is one of Add (P2c) / Sub / Mul / Div / Mod (P2d).
+//   - `fn main() {}` — single block, zero instructions, ReturnTerm.
+//   - `fn name() -> T { value }` for T ∈ {Int, Bool} — single block,
+//     one AssignInstr writing a const / param-copy operand to the
+//     return local, ReturnTerm. Up to two Int / Bool parameters.
+//   - `fn name(a, b: T) -> R { a OP b }` — single block, one
+//     AssignInstr writing a binary op to the return local, ReturnTerm.
+//     Each operand is independently a const literal or a CopyOp on
+//     one of the params (no projections). Operator families:
 //
-// Each P2x extension adds one match predicate + emit closure +
-// regression test. Surface drift is held back by the stage0 coverage
-// gate planned for P3.
+//       arithmetic Int×Int → Int : Add Sub Mul Div Mod
+//       comparison Int×Int → Bool: Eq Neq Lt Leq Gt Geq
+//       bitwise    Int×Int → Int : BitAnd BitOr BitXor Shl Shr
+//       logical    Bool×Bool→ Bool: And Or
+//
+// Anything else (multi-instruction, calls, control flow, non-Int/Bool
+// types, projections, …) declines so the next stage0 phase can pick
+// the case up. Surface drift is held back by the stage0 coverage gate
+// planned for P3.
 func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	if module == nil {
 		return nil, fmt.Errorf("stage0: nil MIR module")
@@ -82,14 +86,8 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	if fn.Name == "main" {
 		return emitTrivialMain(out, fn)
 	}
-	if pat, ok := matchIntLiteralReturn(fn); ok {
-		return emitIntLiteralReturn(out, fn, pat)
-	}
-	if pat, ok := matchIntParamPassthrough(fn); ok {
-		return emitIntParamPassthrough(out, fn, pat)
-	}
-	if pat, ok := matchIntBinaryArith(fn); ok {
-		return emitIntBinaryArith(out, fn, pat)
+	if pat, ok := matchSingleInstrReturn(fn); ok {
+		return emitSingleInstrReturn(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
@@ -130,206 +128,358 @@ func trivialMainViolation(fn *mir.Function) string {
 	return ""
 }
 
-// ---- P2a: int literal return ----
+// ---- single-instruction return pattern ----
+//
+// Covers everything from `fn x() -> Int { N }` (P2a) through
+// `fn cmp(a, b: Int) -> Bool { a < b }` (P2e bitwise / comparison /
+// logical / mixed const+var). The matcher classifies each operand
+// independently as a const or a param copy, so any 0/1/2-param
+// function with a single AssignInstr that writes a supported scalar
+// expression to the return local is covered.
 
-type intLiteralPattern struct {
-	value int64
-}
+type scalarType int
 
-func matchIntLiteralReturn(fn *mir.Function) (intLiteralPattern, bool) {
-	if !isPrimType(fn.ReturnType, ir.PrimInt) {
-		return intLiteralPattern{}, false
-	}
-	if len(fn.Params) != 0 {
-		return intLiteralPattern{}, false
-	}
-	bb, ok := singleBlockReturning(fn)
-	if !ok || len(bb.Instrs) != 1 {
-		return intLiteralPattern{}, false
-	}
-	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
-	if !ok {
-		return intLiteralPattern{}, false
-	}
-	use, ok := assign.Src.(*mir.UseRV)
-	if !ok {
-		return intLiteralPattern{}, false
-	}
-	con, ok := use.Op.(*mir.ConstOp)
-	if !ok {
-		return intLiteralPattern{}, false
-	}
-	intc, ok := con.Const.(*mir.IntConst)
-	if !ok || !isPrimType(intc.Type(), ir.PrimInt) {
-		return intLiteralPattern{}, false
-	}
-	return intLiteralPattern{value: intc.Value}, true
-}
+const (
+	scalarUnknown scalarType = iota
+	scalarInt
+	scalarBool
+)
 
-func emitIntLiteralReturn(out *strings.Builder, fn *mir.Function, pat intLiteralPattern) error {
-	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
-	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  ret i64 %d\n", pat.value)
-	out.WriteString("}\n\n")
-	return nil
-}
-
-// ---- P2b: single Int param passthrough ----
-
-type intParamPassthroughPattern struct {
-	paramName string
-}
-
-func matchIntParamPassthrough(fn *mir.Function) (intParamPassthroughPattern, bool) {
-	if !isPrimType(fn.ReturnType, ir.PrimInt) {
-		return intParamPassthroughPattern{}, false
-	}
-	if len(fn.Params) != 1 {
-		return intParamPassthroughPattern{}, false
-	}
-	paramID := fn.Params[0]
-	paramLocal := lookupLocal(fn, paramID)
-	if paramLocal == nil || !paramLocal.IsParam || !isPrimType(paramLocal.Type, ir.PrimInt) {
-		return intParamPassthroughPattern{}, false
-	}
-	bb, ok := singleBlockReturning(fn)
-	if !ok || len(bb.Instrs) != 1 {
-		return intParamPassthroughPattern{}, false
-	}
-	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
-	if !ok {
-		return intParamPassthroughPattern{}, false
-	}
-	use, ok := assign.Src.(*mir.UseRV)
-	if !ok {
-		return intParamPassthroughPattern{}, false
-	}
-	cp, ok := use.Op.(*mir.CopyOp)
-	if !ok {
-		return intParamPassthroughPattern{}, false
-	}
-	if cp.Place.Local != paramID || cp.Place.HasProjections() {
-		return intParamPassthroughPattern{}, false
-	}
-	return intParamPassthroughPattern{paramName: sanitizeLLVMName(paramLocal.Name, "p")}, true
-}
-
-func emitIntParamPassthrough(out *strings.Builder, fn *mir.Function, pat intParamPassthroughPattern) error {
-	fmt.Fprintf(out, "define i64 @%s(i64 %%%s) {\n", fn.Name, pat.paramName)
-	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  ret i64 %%%s\n", pat.paramName)
-	out.WriteString("}\n\n")
-	return nil
-}
-
-// ---- P2c/P2d: two-Int-param binary arithmetic ----
-
-type intBinaryArithPattern struct {
-	op        mir.BinaryOp
-	leftName  string
-	rightName string
-}
-
-// matchIntBinaryArith matches `fn name(a: Int, b: Int) -> Int { a OP b }`
-// where OP is one of the supported integer arithmetic operators (Add /
-// Sub / Mul / Div / Mod — see `intArithLLVMOp`). MIR shape: 2 Int
-// params, single block, single AssignInstr writing BinaryRV{op,
-// CopyOp(p0), CopyOp(p1)} to the return local, ReturnTerm. Operand
-// order must match Params order — `b + a` lowers to swapped CopyOps
-// and currently declines.
-func matchIntBinaryArith(fn *mir.Function) (intBinaryArithPattern, bool) {
-	if !isPrimType(fn.ReturnType, ir.PrimInt) {
-		return intBinaryArithPattern{}, false
-	}
-	if len(fn.Params) != 2 {
-		return intBinaryArithPattern{}, false
-	}
-	leftID, rightID := fn.Params[0], fn.Params[1]
-	leftLocal, rightLocal := lookupLocal(fn, leftID), lookupLocal(fn, rightID)
-	if leftLocal == nil || rightLocal == nil {
-		return intBinaryArithPattern{}, false
-	}
-	if !leftLocal.IsParam || !rightLocal.IsParam {
-		return intBinaryArithPattern{}, false
-	}
-	if !isPrimType(leftLocal.Type, ir.PrimInt) || !isPrimType(rightLocal.Type, ir.PrimInt) {
-		return intBinaryArithPattern{}, false
-	}
-	bb, ok := singleBlockReturning(fn)
-	if !ok || len(bb.Instrs) != 1 {
-		return intBinaryArithPattern{}, false
-	}
-	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
-	if !ok {
-		return intBinaryArithPattern{}, false
-	}
-	bin, ok := assign.Src.(*mir.BinaryRV)
-	if !ok {
-		return intBinaryArithPattern{}, false
-	}
-	if !isPrimType(bin.T, ir.PrimInt) {
-		return intBinaryArithPattern{}, false
-	}
-	if intArithLLVMOp(bin.Op) == "" {
-		return intBinaryArithPattern{}, false
-	}
-	if !copiesParam(bin.Left, leftID) || !copiesParam(bin.Right, rightID) {
-		return intBinaryArithPattern{}, false
-	}
-	return intBinaryArithPattern{
-		op:        bin.Op,
-		leftName:  sanitizeLLVMName(leftLocal.Name, "a"),
-		rightName: sanitizeLLVMName(rightLocal.Name, "b"),
-	}, true
-}
-
-func emitIntBinaryArith(out *strings.Builder, fn *mir.Function, pat intBinaryArithPattern) error {
-	left, right := pat.leftName, pat.rightName
-	if left == right {
-		// Sanitiser hands back the same fallback when both source
-		// names are unrenderable; disambiguate so SSA stays valid.
-		right = right + ".1"
-	}
-	llvmOp := intArithLLVMOp(pat.op)
-	fmt.Fprintf(out, "define i64 @%s(i64 %%%s, i64 %%%s) {\n", fn.Name, left, right)
-	out.WriteString("entry:\n")
-	fmt.Fprintf(out, "  %%0 = %s i64 %%%s, %%%s\n", llvmOp, left, right)
-	out.WriteString("  ret i64 %0\n")
-	out.WriteString("}\n\n")
-	return nil
-}
-
-// intArithLLVMOp returns the LLVM signed-integer instruction mnemonic
-// for `op`, or "" when the operator is outside the stage0 arithmetic
-// subset. Comparison / logical / bitwise ops decline so the matcher
-// gives the next pattern (when one is added) a chance.
-func intArithLLVMOp(op mir.BinaryOp) string {
-	switch op {
-	case mir.BinAdd:
-		return "add"
-	case mir.BinSub:
-		return "sub"
-	case mir.BinMul:
-		return "mul"
-	case mir.BinDiv:
-		return "sdiv"
-	case mir.BinMod:
-		return "srem"
+func (s scalarType) llvm() string {
+	switch s {
+	case scalarInt:
+		return "i64"
+	case scalarBool:
+		return "i1"
 	}
 	return ""
 }
 
-// copiesParam reports whether `op` is a CopyOp reading the entire
-// param local with id `paramID` (no projections).
-func copiesParam(op mir.Operand, paramID mir.LocalID) bool {
-	cp, ok := op.(*mir.CopyOp)
+func scalarFromType(t mir.Type) scalarType {
+	prim, ok := t.(*ir.PrimType)
+	if !ok || prim == nil {
+		return scalarUnknown
+	}
+	switch prim.Kind {
+	case ir.PrimInt:
+		return scalarInt
+	case ir.PrimBool:
+		return scalarBool
+	}
+	return scalarUnknown
+}
+
+// operandSrc records how to materialise one operand in LLVM. Either
+// a literal constant (int or bool) or a reference to a parameter local
+// (resolved to its position-indexed sanitised SSA name at emit time).
+type operandSrc struct {
+	kind   operandKind
+	intVal int64
+	boolVal bool
+	paramID mir.LocalID
+}
+
+type operandKind int
+
+const (
+	operandUnknown operandKind = iota
+	operandIntConst
+	operandBoolConst
+	operandParamCopy
+)
+
+// singleInstrPattern carries everything emitSingleInstrReturn needs.
+// `body` is nil for use-only / passthrough, non-nil for binary ops.
+type singleInstrPattern struct {
+	retType    scalarType
+	paramIDs   []mir.LocalID
+	paramTypes []scalarType
+	paramNames []string // sanitised, position-disambiguated SSA names
+	source     valueSource
+}
+
+// valueSource is the right-hand side of the AssignInstr. Either a
+// single operand (UseRV) or a binary op.
+type valueSource struct {
+	binary bool
+	// Single-operand mode (UseRV).
+	single operandSrc
+	// Binary mode (BinaryRV).
+	op    mir.BinaryOp
+	left  operandSrc
+	right operandSrc
+	// llvmOp is the LLVM mnemonic resolved by classifyBinary; "" when binary=false.
+	llvmOp string
+	// resultType is the result type the binary op produces (Int or Bool).
+	resultType scalarType
+}
+
+// matchSingleInstrReturn matches the return-only single-instruction
+// pattern described in `EmitMIR`'s docstring.
+func matchSingleInstrReturn(fn *mir.Function) (singleInstrPattern, bool) {
+	pat := singleInstrPattern{}
+	pat.retType = scalarFromType(fn.ReturnType)
+	if pat.retType == scalarUnknown {
+		return pat, false
+	}
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		pt := scalarFromType(loc.Type)
+		if pt == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = pt
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return pat, false
+	}
+	assign, ok := writeToReturnLocal(bb.Instrs[0], fn.ReturnLocal)
 	if !ok {
-		return false
+		return pat, false
 	}
-	if cp.Place.Local != paramID || cp.Place.HasProjections() {
-		return false
+	src, ok := classifyAssignSrc(assign.Src, pat)
+	if !ok {
+		return pat, false
 	}
-	return true
+	pat.source = src
+	return pat, true
+}
+
+func emitSingleInstrReturn(out *strings.Builder, fn *mir.Function, pat singleInstrPattern) error {
+	retLLVM := pat.retType.llvm()
+
+	// Function header.
+	fmt.Fprintf(out, "define %s @%s(", retLLVM, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+	out.WriteString("entry:\n")
+
+	// Body.
+	if pat.source.binary {
+		opTypeLLVM := pat.source.resultType
+		// For comparison ops, operand type is Int even though result is Bool.
+		// Use the operand's actual scalar type instead.
+		opOperandType := operandScalarType(pat.source.left, pat).llvm()
+		left := operandLLVM(pat.source.left, pat)
+		right := operandLLVM(pat.source.right, pat)
+		fmt.Fprintf(out, "  %%0 = %s %s %s, %s\n", pat.source.llvmOp, opOperandType, left, right)
+		fmt.Fprintf(out, "  ret %s %%0\n", opTypeLLVM.llvm())
+	} else {
+		fmt.Fprintf(out, "  ret %s %s\n", retLLVM, operandLLVM(pat.source.single, pat))
+	}
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// classifyAssignSrc inspects an AssignInstr.Src and decodes it to a
+// valueSource the emitter can consume.
+func classifyAssignSrc(src mir.RValue, pat singleInstrPattern) (valueSource, bool) {
+	if use, ok := src.(*mir.UseRV); ok {
+		op, ok := classifyOperand(use.Op, pat)
+		if !ok {
+			return valueSource{}, false
+		}
+		// Operand result type must match the return type.
+		if operandScalarTypeFromKind(op.kind, pat, op) != pat.retType {
+			return valueSource{}, false
+		}
+		return valueSource{single: op}, true
+	}
+	if bin, ok := src.(*mir.BinaryRV); ok {
+		llvmOp, resultType, operandType := classifyBinary(bin.Op)
+		if llvmOp == "" || resultType != pat.retType {
+			return valueSource{}, false
+		}
+		left, ok := classifyOperand(bin.Left, pat)
+		if !ok || operandScalarTypeFromKind(left.kind, pat, left) != operandType {
+			return valueSource{}, false
+		}
+		right, ok := classifyOperand(bin.Right, pat)
+		if !ok || operandScalarTypeFromKind(right.kind, pat, right) != operandType {
+			return valueSource{}, false
+		}
+		return valueSource{
+			binary:     true,
+			op:         bin.Op,
+			left:       left,
+			right:      right,
+			llvmOp:     llvmOp,
+			resultType: resultType,
+		}, true
+	}
+	return valueSource{}, false
+}
+
+// classifyOperand decodes a single MIR Operand into an operandSrc.
+func classifyOperand(op mir.Operand, pat singleInstrPattern) (operandSrc, bool) {
+	if con, ok := op.(*mir.ConstOp); ok {
+		switch c := con.Const.(type) {
+		case *mir.IntConst:
+			if !isPrimType(c.Type(), ir.PrimInt) {
+				return operandSrc{}, false
+			}
+			return operandSrc{kind: operandIntConst, intVal: c.Value}, true
+		case *mir.BoolConst:
+			return operandSrc{kind: operandBoolConst, boolVal: c.Value}, true
+		}
+		return operandSrc{}, false
+	}
+	if cp, ok := op.(*mir.CopyOp); ok {
+		if cp.Place.HasProjections() {
+			return operandSrc{}, false
+		}
+		idx := paramIndex(pat, cp.Place.Local)
+		if idx < 0 {
+			return operandSrc{}, false
+		}
+		return operandSrc{kind: operandParamCopy, paramID: cp.Place.Local}, true
+	}
+	return operandSrc{}, false
+}
+
+// classifyBinary returns (llvmOp, resultType, operandType) for a MIR
+// binary operator the stage0 single-instruction pattern supports.
+// Operator families:
+//
+//	arith    Int×Int → Int : Add Sub Mul Div Mod
+//	cmp      Int×Int → Bool: Eq Neq Lt Leq Gt Geq
+//	bitwise  Int×Int → Int : BitAnd BitOr BitXor Shl Shr
+//	logical  Bool×Bool→Bool: And Or
+//
+// Returns ("", scalarUnknown, scalarUnknown) for unsupported ops.
+func classifyBinary(op mir.BinaryOp) (string, scalarType, scalarType) {
+	switch op {
+	// arithmetic
+	case mir.BinAdd:
+		return "add", scalarInt, scalarInt
+	case mir.BinSub:
+		return "sub", scalarInt, scalarInt
+	case mir.BinMul:
+		return "mul", scalarInt, scalarInt
+	case mir.BinDiv:
+		return "sdiv", scalarInt, scalarInt
+	case mir.BinMod:
+		return "srem", scalarInt, scalarInt
+	// comparison (signed Int)
+	case mir.BinEq:
+		return "icmp eq", scalarBool, scalarInt
+	case mir.BinNeq:
+		return "icmp ne", scalarBool, scalarInt
+	case mir.BinLt:
+		return "icmp slt", scalarBool, scalarInt
+	case mir.BinLeq:
+		return "icmp sle", scalarBool, scalarInt
+	case mir.BinGt:
+		return "icmp sgt", scalarBool, scalarInt
+	case mir.BinGeq:
+		return "icmp sge", scalarBool, scalarInt
+	// bitwise / shift on Int
+	case mir.BinBitAnd:
+		return "and", scalarInt, scalarInt
+	case mir.BinBitOr:
+		return "or", scalarInt, scalarInt
+	case mir.BinBitXor:
+		return "xor", scalarInt, scalarInt
+	case mir.BinShl:
+		return "shl", scalarInt, scalarInt
+	case mir.BinShr:
+		return "ashr", scalarInt, scalarInt
+	// logical on Bool
+	case mir.BinAnd:
+		return "and", scalarBool, scalarBool
+	case mir.BinOr:
+		return "or", scalarBool, scalarBool
+	}
+	return "", scalarUnknown, scalarUnknown
+}
+
+// operandScalarType / operandScalarTypeFromKind report the LLVM scalar
+// type of an operand. operandParamCopy resolves through pat.paramTypes;
+// constants carry their own type.
+func operandScalarType(op operandSrc, pat singleInstrPattern) scalarType {
+	return operandScalarTypeFromKind(op.kind, pat, op)
+}
+
+func operandScalarTypeFromKind(kind operandKind, pat singleInstrPattern, op operandSrc) scalarType {
+	switch kind {
+	case operandIntConst:
+		return scalarInt
+	case operandBoolConst:
+		return scalarBool
+	case operandParamCopy:
+		idx := paramIndex(pat, op.paramID)
+		if idx < 0 || idx >= len(pat.paramTypes) {
+			return scalarUnknown
+		}
+		return pat.paramTypes[idx]
+	}
+	return scalarUnknown
+}
+
+func operandLLVM(op operandSrc, pat singleInstrPattern) string {
+	switch op.kind {
+	case operandIntConst:
+		return formatInt(op.intVal)
+	case operandBoolConst:
+		if op.boolVal {
+			return "true"
+		}
+		return "false"
+	case operandParamCopy:
+		idx := paramIndex(pat, op.paramID)
+		if idx >= 0 && idx < len(pat.paramNames) {
+			return "%" + pat.paramNames[idx]
+		}
+	}
+	return "<invalid>"
+}
+
+func paramIndex(pat singleInstrPattern, id mir.LocalID) int {
+	for i, pid := range pat.paramIDs {
+		if pid == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// disambiguateParamNames mutates `names` in place so that no two
+// entries are identical, by suffixing collisions with `.<index>`.
+// Sanitiser fallbacks (`a`, `b`) are already position-distinct, but a
+// user could legitimately name two parameters the same after
+// sanitisation collapses them.
+func disambiguateParamNames(names []string) {
+	for i := 1; i < len(names); i++ {
+		for j := 0; j < i; j++ {
+			if names[i] == names[j] {
+				names[i] = fmt.Sprintf("%s.%d", names[i], i)
+				break
+			}
+		}
+	}
+}
+
+func formatInt(v int64) string {
+	return fmt.Sprintf("%d", v)
 }
 
 // ---- shared helpers ----

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/osty/osty/internal/mir"
 )
 
+// ---- fixture builders ----
+
 func trivialMainFn() *mir.Function {
 	return &mir.Function{
 		Name:        "main",
@@ -25,27 +27,50 @@ func trivialMainFn() *mir.Function {
 	}
 }
 
-func intLiteralFn(name string, value int64) *mir.Function {
+// fnSpec describes a synthetic function: return type + zero or more
+// params + the AssignInstr.Src to feed into the single-instruction
+// pattern. This keeps the call sites short.
+type fnSpec struct {
+	name   string
+	retT   mir.Type
+	params []paramSpec
+	src    mir.RValue
+}
+
+type paramSpec struct {
+	name string
+	ty   mir.Type
+}
+
+func makeFn(spec fnSpec) *mir.Function {
+	locals := []*mir.Local{
+		{ID: 0, Name: "ret", Type: spec.retT, IsReturn: true},
+	}
+	paramIDs := make([]mir.LocalID, 0, len(spec.params))
+	for i, p := range spec.params {
+		id := mir.LocalID(i + 1)
+		paramIDs = append(paramIDs, id)
+		locals = append(locals, &mir.Local{
+			ID:      id,
+			Name:    p.name,
+			Type:    p.ty,
+			IsParam: true,
+		})
+	}
 	return &mir.Function{
-		Name:        name,
-		ReturnType:  ir.TInt,
+		Name:        spec.name,
+		Params:      paramIDs,
+		ReturnType:  spec.retT,
 		ReturnLocal: 0,
-		Locals: []*mir.Local{
-			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
-		},
-		Entry: 0,
+		Locals:      locals,
+		Entry:       0,
 		Blocks: []*mir.BasicBlock{
 			{
 				ID: 0,
 				Instrs: []mir.Instr{
 					&mir.AssignInstr{
 						Dest: mir.Place{Local: 0},
-						Src: &mir.UseRV{
-							Op: &mir.ConstOp{
-								Const: &mir.IntConst{Value: value, T: ir.TInt},
-								T:     ir.TInt,
-							},
-						},
+						Src:  spec.src,
 					},
 				},
 				Term: &mir.ReturnTerm{},
@@ -54,37 +79,24 @@ func intLiteralFn(name string, value int64) *mir.Function {
 	}
 }
 
-// intParamPassthroughFn builds the canonical
-// `fn name(<paramName>: Int) -> Int { <paramName> }` MIR shape: one
-// block, one AssignInstr that copies the param local to the return
-// local.
-func intParamPassthroughFn(name, paramName string) *mir.Function {
-	const paramID mir.LocalID = 1
-	return &mir.Function{
-		Name:        name,
-		Params:      []mir.LocalID{paramID},
-		ReturnType:  ir.TInt,
-		ReturnLocal: 0,
-		Locals: []*mir.Local{
-			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
-			{ID: paramID, Name: paramName, Type: ir.TInt, IsParam: true},
-		},
-		Entry: 0,
-		Blocks: []*mir.BasicBlock{
-			{
-				ID: 0,
-				Instrs: []mir.Instr{
-					&mir.AssignInstr{
-						Dest: mir.Place{Local: 0},
-						Src: &mir.UseRV{
-							Op: &mir.CopyOp{Place: mir.Place{Local: paramID}, T: ir.TInt},
-						},
-					},
-				},
-				Term: &mir.ReturnTerm{},
-			},
-		},
-	}
+func intConst(v int64) *mir.ConstOp {
+	return &mir.ConstOp{Const: &mir.IntConst{Value: v, T: ir.TInt}, T: ir.TInt}
+}
+
+func boolConst(v bool) *mir.ConstOp {
+	return &mir.ConstOp{Const: &mir.BoolConst{Value: v}, T: ir.TBool}
+}
+
+func paramCopy(id mir.LocalID, ty mir.Type) *mir.CopyOp {
+	return &mir.CopyOp{Place: mir.Place{Local: id}, T: ty}
+}
+
+func useRV(op mir.Operand) *mir.UseRV {
+	return &mir.UseRV{Op: op}
+}
+
+func binaryRV(op mir.BinaryOp, left, right mir.Operand, t mir.Type) *mir.BinaryRV {
+	return &mir.BinaryRV{Op: op, Left: left, Right: right, T: t}
 }
 
 func moduleWith(fns ...*mir.Function) *mir.Module {
@@ -95,6 +107,24 @@ func moduleWith(fns ...*mir.Function) *mir.Module {
 	}
 }
 
+func emit(t *testing.T, fns ...*mir.Function) string {
+	t.Helper()
+	got, err := EmitMIR(moduleWith(fns...), llvmabi.Options{PackageName: "main"})
+	if err != nil {
+		t.Fatalf("EmitMIR: %v", err)
+	}
+	return string(got)
+}
+
+func mustReject(t *testing.T, fns ...*mir.Function) error {
+	t.Helper()
+	_, err := EmitMIR(moduleWith(fns...), llvmabi.Options{PackageName: "main"})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	}
+	return err
+}
+
 // ---- P1: trivial main ----
 
 func TestStage0EmitsTrivialMain(t *testing.T) {
@@ -103,7 +133,6 @@ func TestStage0EmitsTrivialMain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EmitMIR: %v", err)
 	}
-	s := string(got)
 	for _, want := range []string{
 		"stage0 bootstrap LLVM IR",
 		"; package: main",
@@ -111,8 +140,8 @@ func TestStage0EmitsTrivialMain(t *testing.T) {
 		"define i32 @main()",
 		"ret i32 0",
 	} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
 		}
 	}
 }
@@ -127,10 +156,8 @@ func TestStage0RejectsNilModule(t *testing.T) {
 
 func TestStage0RejectsModuleWithoutMain(t *testing.T) {
 	t.Parallel()
-	_, err := EmitMIR(moduleWith(intLiteralFn("zero", 0)), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
+	intLit := makeFn(fnSpec{name: "zero", retT: ir.TInt, src: useRV(intConst(0))})
+	err := mustReject(t, intLit)
 	if !strings.Contains(err.Error(), "module has no `main` function") {
 		t.Fatalf("err = %q, want missing-main reason", err.Error())
 	}
@@ -138,32 +165,23 @@ func TestStage0RejectsModuleWithoutMain(t *testing.T) {
 
 func TestStage0RejectsMainWithParameters(t *testing.T) {
 	t.Parallel()
-	module := moduleWith(trivialMainFn())
-	module.Functions[0].Params = []mir.LocalID{0}
-	_, err := EmitMIR(module, llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
+	main := trivialMainFn()
+	main.Params = []mir.LocalID{0}
+	mustReject(t, main)
 }
 
 func TestStage0RejectsMainWithInstructions(t *testing.T) {
 	t.Parallel()
-	module := moduleWith(trivialMainFn())
-	module.Functions[0].Blocks[0].Instrs = []mir.Instr{&mir.AssignInstr{}}
-	_, err := EmitMIR(module, llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
+	main := trivialMainFn()
+	main.Blocks[0].Instrs = []mir.Instr{&mir.AssignInstr{}}
+	mustReject(t, main)
 }
 
 func TestStage0RejectsIntrinsicDeclaration(t *testing.T) {
 	t.Parallel()
-	module := moduleWith(trivialMainFn())
-	module.Functions[0].IsIntrinsic = true
-	_, err := EmitMIR(module, llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
+	main := trivialMainFn()
+	main.IsIntrinsic = true
+	mustReject(t, main)
 }
 
 func TestStage0FallsBackPackageName(t *testing.T) {
@@ -179,196 +197,112 @@ func TestStage0FallsBackPackageName(t *testing.T) {
 	}
 }
 
-// ---- P2a: non-main int literal return ----
+// ---- single-instruction return: literal & passthrough ----
 
-func TestStage0EmitsIntLiteralFunctionAlongsideMain(t *testing.T) {
+func TestStage0EmitsIntLiteralReturn(t *testing.T) {
 	t.Parallel()
-	got, err := EmitMIR(moduleWith(trivialMainFn(), intLiteralFn("zero", 0), intLiteralFn("forty_two", 42), intLiteralFn("neg_one", -1)), llvmabi.Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("EmitMIR: %v", err)
-	}
-	s := string(got)
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{name: "zero", retT: ir.TInt, src: useRV(intConst(0))}),
+		makeFn(fnSpec{name: "answer", retT: ir.TInt, src: useRV(intConst(42))}),
+		makeFn(fnSpec{name: "neg_one", retT: ir.TInt, src: useRV(intConst(-1))}),
+	)
 	for _, want := range []string{
-		"define i32 @main()",
-		"ret i32 0",
-		"define i64 @zero()",
-		"ret i64 0",
-		"define i64 @forty_two()",
-		"ret i64 42",
-		"define i64 @neg_one()",
-		"ret i64 -1",
+		"define i64 @zero()", "ret i64 0",
+		"define i64 @answer()", "ret i64 42",
+		"define i64 @neg_one()", "ret i64 -1",
 	} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
 		}
 	}
 }
 
-func TestStage0RejectsBoolReturnFunction(t *testing.T) {
+func TestStage0EmitsBoolLiteralReturn(t *testing.T) {
 	t.Parallel()
-	fn := intLiteralFn("flag", 1)
-	fn.ReturnType = ir.TBool
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{name: "always_true", retT: ir.TBool, src: useRV(boolConst(true))}),
+		makeFn(fnSpec{name: "never", retT: ir.TBool, src: useRV(boolConst(false))}),
+	)
+	for _, want := range []string{
+		"define i1 @always_true()", "ret i1 true",
+		"define i1 @never()", "ret i1 false",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
 	}
 }
-
-func TestStage0RejectsMultiInstructionFunction(t *testing.T) {
-	t.Parallel()
-	fn := intLiteralFn("two_step", 7)
-	fn.Blocks[0].Instrs = append(fn.Blocks[0].Instrs, &mir.AssignInstr{
-		Dest: mir.Place{Local: 0},
-		Src: &mir.UseRV{
-			Op: &mir.ConstOp{Const: &mir.IntConst{Value: 9, T: ir.TInt}, T: ir.TInt},
-		},
-	})
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-}
-
-func TestStage0RejectsBinaryRVFunction(t *testing.T) {
-	t.Parallel()
-	fn := intLiteralFn("sum", 0)
-	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
-		Dest: mir.Place{Local: 0},
-		Src: &mir.BinaryRV{
-			Op:    mir.BinAdd,
-			Left:  &mir.ConstOp{Const: &mir.IntConst{Value: 1, T: ir.TInt}, T: ir.TInt},
-			Right: &mir.ConstOp{Const: &mir.IntConst{Value: 2, T: ir.TInt}, T: ir.TInt},
-			T:     ir.TInt,
-		},
-	}
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-}
-
-// ---- P2b: int param passthrough ----
 
 func TestStage0EmitsIntParamPassthrough(t *testing.T) {
 	t.Parallel()
-	got, err := EmitMIR(moduleWith(trivialMainFn(), intParamPassthroughFn("identity", "x"), intParamPassthroughFn("forward", "value")), llvmabi.Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("EmitMIR: %v", err)
-	}
-	s := string(got)
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "identity",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "x", ty: ir.TInt}},
+			src:    useRV(paramCopy(1, ir.TInt)),
+		}),
+		makeFn(fnSpec{
+			name:   "forward",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "value", ty: ir.TInt}},
+			src:    useRV(paramCopy(1, ir.TInt)),
+		}),
+	)
 	for _, want := range []string{
 		"define i64 @identity(i64 %x)",
 		"ret i64 %x",
 		"define i64 @forward(i64 %value)",
 		"ret i64 %value",
 	} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("emitted IR missing %q:\n%s", want, s)
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsBoolParamPassthrough(t *testing.T) {
+	t.Parallel()
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "echo",
+			retT:   ir.TBool,
+			params: []paramSpec{{name: "flag", ty: ir.TBool}},
+			src:    useRV(paramCopy(1, ir.TBool)),
+		}),
+	)
+	for _, want := range []string{"define i1 @echo(i1 %flag)", "ret i1 %flag"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
 		}
 	}
 }
 
 func TestStage0SanitizesEmptyParamName(t *testing.T) {
 	t.Parallel()
-	// Synthetic temporaries reach MIR with empty Name; we fall back
-	// to `%p` rather than emit malformed IR.
-	got, err := EmitMIR(moduleWith(trivialMainFn(), intParamPassthroughFn("identity", "")), llvmabi.Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("EmitMIR: %v", err)
-	}
-	if !strings.Contains(string(got), "define i64 @identity(i64 %p)") {
-		t.Fatalf("expected fallback param name `%%p`:\n%s", got)
-	}
-}
-
-func TestStage0RejectsTwoParamFunction(t *testing.T) {
-	t.Parallel()
-	fn := intParamPassthroughFn("add", "x")
-	fn.Params = append(fn.Params, 2)
-	fn.Locals = append(fn.Locals, &mir.Local{ID: 2, Name: "y", Type: ir.TInt, IsParam: true})
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "identity",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "", ty: ir.TInt}},
+			src:    useRV(paramCopy(1, ir.TInt)),
+		}),
+	)
+	if !strings.Contains(got, "define i64 @identity(i64 %a)") {
+		t.Fatalf("expected fallback param name `%%a`:\n%s", got)
 	}
 }
 
-func TestStage0RejectsBoolParamPassthrough(t *testing.T) {
-	t.Parallel()
-	fn := intParamPassthroughFn("flag", "b")
-	fn.ReturnType = ir.TBool
-	for _, l := range fn.Locals {
-		l.Type = ir.TBool
-	}
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
-	}
-}
+// ---- single-instruction return: arithmetic ops ----
 
-// intBinaryArithFn builds the canonical
-// `fn name(a: Int, b: Int) -> Int { a OP b }` MIR shape, parameterised
-// over the operator so P2c (Add) and P2d (Sub/Mul/Div/Mod) can share a
-// fixture.
-func intBinaryArithFn(name string, op mir.BinaryOp, leftName, rightName string) *mir.Function {
-	const leftID, rightID mir.LocalID = 1, 2
-	return &mir.Function{
-		Name:        name,
-		Params:      []mir.LocalID{leftID, rightID},
-		ReturnType:  ir.TInt,
-		ReturnLocal: 0,
-		Locals: []*mir.Local{
-			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
-			{ID: leftID, Name: leftName, Type: ir.TInt, IsParam: true},
-			{ID: rightID, Name: rightName, Type: ir.TInt, IsParam: true},
-		},
-		Entry: 0,
-		Blocks: []*mir.BasicBlock{
-			{
-				ID: 0,
-				Instrs: []mir.Instr{
-					&mir.AssignInstr{
-						Dest: mir.Place{Local: 0},
-						Src: &mir.BinaryRV{
-							Op:    op,
-							Left:  &mir.CopyOp{Place: mir.Place{Local: leftID}, T: ir.TInt},
-							Right: &mir.CopyOp{Place: mir.Place{Local: rightID}, T: ir.TInt},
-							T:     ir.TInt,
-						},
-					},
-				},
-				Term: &mir.ReturnTerm{},
-			},
-		},
-	}
-}
-
-func TestStage0EmitsIntBinaryAdd(t *testing.T) {
-	t.Parallel()
-	got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryArithFn("add", mir.BinAdd, "a", "b"), intBinaryArithFn("sum", mir.BinAdd, "left", "right")), llvmabi.Options{PackageName: "main"})
-	if err != nil {
-		t.Fatalf("EmitMIR: %v", err)
-	}
-	s := string(got)
-	for _, want := range []string{
-		"define i64 @add(i64 %a, i64 %b)",
-		"%0 = add i64 %a, %b",
-		"ret i64 %0",
-		"define i64 @sum(i64 %left, i64 %right)",
-		"%0 = add i64 %left, %right",
-	} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("emitted IR missing %q:\n%s", want, s)
-		}
-	}
-}
-
-func TestStage0EmitsIntBinaryArithOps(t *testing.T) {
+func TestStage0EmitsIntArithOps(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name    string
-		op      mir.BinaryOp
-		llvmOp  string
+		name   string
+		op     mir.BinaryOp
+		llvm   string
 	}{
+		{"add", mir.BinAdd, "add"},
 		{"sub", mir.BinSub, "sub"},
 		{"mul", mir.BinMul, "mul"},
 		{"div", mir.BinDiv, "sdiv"},
@@ -378,95 +312,332 @@ func TestStage0EmitsIntBinaryArithOps(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := EmitMIR(moduleWith(trivialMainFn(), intBinaryArithFn(c.name, c.op, "a", "b")), llvmabi.Options{PackageName: "main"})
-			if err != nil {
-				t.Fatalf("EmitMIR: %v", err)
-			}
-			s := string(got)
-			fnHeader := "define i64 @" + c.name + "(i64 %a, i64 %b)"
-			body := "%0 = " + c.llvmOp + " i64 %a, %b"
-			for _, want := range []string{fnHeader, body, "ret i64 %0"} {
-				if !strings.Contains(s, want) {
-					t.Fatalf("emitted IR missing %q:\n%s", want, s)
+			fn := makeFn(fnSpec{
+				name:   c.name,
+				retT:   ir.TInt,
+				params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+				src:    binaryRV(c.op, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+			})
+			got := emit(t, trivialMainFn(), fn)
+			body := "%0 = " + c.llvm + " i64 %a, %b"
+			for _, want := range []string{"define i64 @" + c.name + "(i64 %a, i64 %b)", body, "ret i64 %0"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("emitted IR missing %q:\n%s", want, got)
 				}
 			}
 		})
 	}
 }
 
-func TestStage0BinaryArithDisambiguatesCollidingParamNames(t *testing.T) {
+// ---- single-instruction return: comparison ops → Bool ----
+
+func TestStage0EmitsIntComparisonOps(t *testing.T) {
 	t.Parallel()
-	// Both param names empty → both sanitise to `a`/`b` (the
-	// per-position fallbacks). The collision-guard inside
-	// emitIntBinaryArith only triggers when fallbacks coincide
-	// (left and right both produce identical sanitised names).
-	fn := intBinaryArithFn("collide", mir.BinAdd, "", "")
-	got, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if err != nil {
-		t.Fatalf("EmitMIR: %v", err)
+	cases := []struct {
+		name string
+		op   mir.BinaryOp
+		llvm string
+	}{
+		{"eq", mir.BinEq, "icmp eq"},
+		{"ne", mir.BinNeq, "icmp ne"},
+		{"lt", mir.BinLt, "icmp slt"},
+		{"le", mir.BinLeq, "icmp sle"},
+		{"gt", mir.BinGt, "icmp sgt"},
+		{"ge", mir.BinGeq, "icmp sge"},
 	}
-	if !strings.Contains(string(got), "define i64 @collide(i64 %a, i64 %b)") {
-		t.Fatalf("expected per-position fallbacks `%%a`/`%%b`:\n%s", got)
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			fn := makeFn(fnSpec{
+				name:   c.name,
+				retT:   ir.TBool,
+				params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+				src:    binaryRV(c.op, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TBool),
+			})
+			got := emit(t, trivialMainFn(), fn)
+			body := "%0 = " + c.llvm + " i64 %a, %b"
+			for _, want := range []string{"define i1 @" + c.name + "(i64 %a, i64 %b)", body, "ret i1 %0"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("emitted IR missing %q:\n%s", want, got)
+				}
+			}
+		})
 	}
 }
 
-func TestStage0RejectsBinaryArithWithBoolReturn(t *testing.T) {
+// ---- single-instruction return: bitwise / shift ops ----
+
+func TestStage0EmitsIntBitwiseShiftOps(t *testing.T) {
 	t.Parallel()
-	fn := intBinaryArithFn("flag", mir.BinAdd, "a", "b")
-	fn.ReturnType = ir.TBool
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	cases := []struct {
+		name string
+		op   mir.BinaryOp
+		llvm string
+	}{
+		{"bit_and", mir.BinBitAnd, "and"},
+		{"bit_or", mir.BinBitOr, "or"},
+		{"bit_xor", mir.BinBitXor, "xor"},
+		{"shl", mir.BinShl, "shl"},
+		{"shr", mir.BinShr, "ashr"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			fn := makeFn(fnSpec{
+				name:   c.name,
+				retT:   ir.TInt,
+				params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+				src:    binaryRV(c.op, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+			})
+			got := emit(t, trivialMainFn(), fn)
+			body := "%0 = " + c.llvm + " i64 %a, %b"
+			for _, want := range []string{"define i64 @" + c.name + "(i64 %a, i64 %b)", body, "ret i64 %0"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("emitted IR missing %q:\n%s", want, got)
+				}
+			}
+		})
 	}
 }
 
-func TestStage0RejectsBinaryArithWithSwappedOperands(t *testing.T) {
+// ---- single-instruction return: logical Bool ops ----
+
+func TestStage0EmitsBoolLogicalOps(t *testing.T) {
 	t.Parallel()
-	// `b + a` instead of `a + b`. Stage0 is intentionally strict about
-	// operand order — swapped operands lower to a different MIR shape.
-	fn := intBinaryArithFn("swap", mir.BinAdd, "a", "b")
-	bin := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.BinaryRV)
-	bin.Left, bin.Right = bin.Right, bin.Left
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+	cases := []struct {
+		name string
+		op   mir.BinaryOp
+		llvm string
+	}{
+		{"both", mir.BinAnd, "and"},
+		{"either", mir.BinOr, "or"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			fn := makeFn(fnSpec{
+				name:   c.name,
+				retT:   ir.TBool,
+				params: []paramSpec{{name: "p", ty: ir.TBool}, {name: "q", ty: ir.TBool}},
+				src:    binaryRV(c.op, paramCopy(1, ir.TBool), paramCopy(2, ir.TBool), ir.TBool),
+			})
+			got := emit(t, trivialMainFn(), fn)
+			body := "%0 = " + c.llvm + " i1 %p, %q"
+			for _, want := range []string{"define i1 @" + c.name + "(i1 %p, i1 %q)", body, "ret i1 %0"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("emitted IR missing %q:\n%s", want, got)
+				}
+			}
+		})
 	}
 }
 
-func TestStage0RejectsComparisonBinaryOp(t *testing.T) {
+// ---- mixed const+var operands ----
+
+func TestStage0EmitsConstPlusVar(t *testing.T) {
 	t.Parallel()
-	// BinEq is outside the arithmetic subset (P2d covers Add/Sub/Mul/
-	// Div/Mod only). Comparison results are Bool, but even with the
-	// right shape the operator declines.
-	fn := intBinaryArithFn("eq", mir.BinEq, "a", "b")
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinEq not in P2d)", err)
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "inc",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "x", ty: ir.TInt}},
+			src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), intConst(1), ir.TInt),
+		}),
+		makeFn(fnSpec{
+			name:   "dec",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "x", ty: ir.TInt}},
+			src:    binaryRV(mir.BinSub, paramCopy(1, ir.TInt), intConst(1), ir.TInt),
+		}),
+		makeFn(fnSpec{
+			name:   "double",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "x", ty: ir.TInt}},
+			src:    binaryRV(mir.BinMul, intConst(2), paramCopy(1, ir.TInt), ir.TInt),
+		}),
+	)
+	for _, want := range []string{
+		"define i64 @inc(i64 %x)", "%0 = add i64 %x, 1",
+		"define i64 @dec(i64 %x)", "%0 = sub i64 %x, 1",
+		"define i64 @double(i64 %x)", "%0 = mul i64 2, %x",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
 	}
 }
 
-func TestStage0RejectsBitwiseBinaryOp(t *testing.T) {
+func TestStage0EmitsConstOnlyBinaryOp(t *testing.T) {
 	t.Parallel()
-	fn := intBinaryArithFn("bit_and", mir.BinBitAnd, "a", "b")
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported (BinBitAnd not in P2d)", err)
+	// `fn answer() -> Int { 1 + 2 }` — both operands are consts.
+	// Stage0 doesn't const-fold; LLVM downstream optimisers can.
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name: "answer",
+			retT: ir.TInt,
+			src:  binaryRV(mir.BinAdd, intConst(1), intConst(2), ir.TInt),
+		}),
+	)
+	for _, want := range []string{"define i64 @answer()", "%0 = add i64 1, 2", "ret i64 %0"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
 	}
 }
 
-func TestStage0RejectsPassthroughCopyingNonParam(t *testing.T) {
+func TestStage0EmitsSwappedParamOrder(t *testing.T) {
 	t.Parallel()
-	fn := intParamPassthroughFn("mistake", "x")
-	// CopyOp source = ret local (not the param) — even with the
-	// right signature shape, this isn't the passthrough pattern.
-	fn.Blocks[0].Instrs[0] = &mir.AssignInstr{
-		Dest: mir.Place{Local: 0},
-		Src: &mir.UseRV{
-			Op: &mir.CopyOp{Place: mir.Place{Local: 0}, T: ir.TInt},
-		},
+	// `fn diff(a: Int, b: Int) -> Int { b - a }` — param 2 is the
+	// left operand. Stage0 used to be strict about operand order
+	// matching params; the unified single-instruction matcher now
+	// emits whatever MIR provides.
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "diff",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+			src:    binaryRV(mir.BinSub, paramCopy(2, ir.TInt), paramCopy(1, ir.TInt), ir.TInt),
+		}),
+	)
+	if !strings.Contains(got, "%0 = sub i64 %b, %a") {
+		t.Fatalf("expected swapped operands `%%b, %%a`:\n%s", got)
 	}
-	_, err := EmitMIR(moduleWith(trivialMainFn(), fn), llvmabi.Options{})
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("err = %v, want wrapped ErrUnsupported", err)
+}
+
+func TestStage0EmitsComparisonAgainstConst(t *testing.T) {
+	t.Parallel()
+	got := emit(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "is_zero",
+			retT:   ir.TBool,
+			params: []paramSpec{{name: "x", ty: ir.TInt}},
+			src:    binaryRV(mir.BinEq, paramCopy(1, ir.TInt), intConst(0), ir.TBool),
+		}),
+	)
+	for _, want := range []string{"define i1 @is_zero(i64 %x)", "%0 = icmp eq i64 %x, 0", "ret i1 %0"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
 	}
+}
+
+// ---- rejection paths ----
+
+func TestStage0RejectsThreeParams(t *testing.T) {
+	t.Parallel()
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "three",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}, {name: "c", ty: ir.TInt}},
+			src:    useRV(paramCopy(1, ir.TInt)),
+		}),
+	)
+}
+
+func TestStage0RejectsFloatReturn(t *testing.T) {
+	t.Parallel()
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name: "pi",
+			retT: ir.TFloat,
+			src:  useRV(intConst(3)), // type mismatch — Float ret with Int operand
+		}),
+	)
+}
+
+func TestStage0RejectsTypeMismatchedLiteralReturn(t *testing.T) {
+	t.Parallel()
+	// Return Bool but body produces Int literal.
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name: "bad",
+			retT: ir.TBool,
+			src:  useRV(intConst(1)),
+		}),
+	)
+}
+
+func TestStage0RejectsTypeMismatchedComparisonReturn(t *testing.T) {
+	t.Parallel()
+	// Return Int but body is comparison (which is Bool).
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "bad",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+			src:    binaryRV(mir.BinEq, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+		}),
+	)
+}
+
+func TestStage0RejectsMixedOperandTypesInArith(t *testing.T) {
+	t.Parallel()
+	// Arith op with Bool operand. classifyBinary says Add expects
+	// Int operands → declines.
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "bad",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "p", ty: ir.TBool}},
+			src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TBool), ir.TInt),
+		}),
+	)
+}
+
+func TestStage0RejectsLogicalOnIntInputs(t *testing.T) {
+	t.Parallel()
+	// BinAnd on Int → expects Bool inputs.
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "bad",
+			retT:   ir.TBool,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+			src:    binaryRV(mir.BinAnd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TBool),
+		}),
+	)
+}
+
+func TestStage0RejectsProjectionInOperand(t *testing.T) {
+	t.Parallel()
+	// CopyOp with a field projection — stage0 doesn't lower
+	// aggregates. Decline.
+	fn := makeFn(fnSpec{
+		name:   "bad",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "p", ty: ir.TInt}},
+		src:    useRV(paramCopy(1, ir.TInt)),
+	})
+	cp := fn.Blocks[0].Instrs[0].(*mir.AssignInstr).Src.(*mir.UseRV).Op.(*mir.CopyOp)
+	cp.Place.Projections = []mir.Projection{&mir.FieldProj{Index: 0}}
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsCopyFromNonParam(t *testing.T) {
+	t.Parallel()
+	// CopyOp pointing at the return local — stage0 doesn't track
+	// non-param locals in single-instruction patterns.
+	fn := makeFn(fnSpec{
+		name: "bad",
+		retT: ir.TInt,
+		src:  useRV(paramCopy(0, ir.TInt)),
+	})
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsUnsupportedBinaryOp(t *testing.T) {
+	t.Parallel()
+	// BinInvalid is sentinel for "no op". classifyBinary returns
+	// "" → matcher declines.
+	mustReject(t, trivialMainFn(),
+		makeFn(fnSpec{
+			name:   "bad",
+			retT:   ir.TInt,
+			params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+			src:    binaryRV(mir.BinInvalid, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+		}),
+	)
 }


### PR DESCRIPTION
## Summary

Stage0 single-instruction return 패턴을 한 번에 크게 확장 — 모든 패턴이 같은 shape (1-block + 1 AssignInstr → return-local + ReturnTerm) 를 공유하므로 통일된 matcher 하나로 묶었습니다.

`+781 / -459`, 47개 테스트 PASS.

### 새로 지원하는 surface

| 카테고리 | MIR `BinaryOp` | LLVM | 결과 타입 |
|---|---|---|---|
| **비교** | Eq Neq Lt Leq Gt Geq | icmp eq/ne/slt/sle/sgt/sge | Bool |
| **비트/시프트** | BitAnd BitOr BitXor Shl Shr | and/or/xor/shl/ashr | Int |
| **논리 (Bool inputs)** | And Or | and/or on i1 | Bool |

추가 surface:
- **Bool 타입 전반** — 리턴 / 파라미터 / 리터럴 / passthrough
- **ConstOp + CopyOp 혼합 피연산자** — `x + 1`, `2 * y` 등
- **0/1/2 파라미터 모두** (이전 P2c/d 는 정확히 2개만)
- **자유로운 피연산자 순서** — `b - a` 도 정상 emit

### 리팩토링

- `intBinaryArith` / `intLiteralReturn` / `intParamPassthrough` 3개 매처를 하나의 `matchSingleInstrReturn` 으로 통합.
- `operandSrc` / `valueSource` 내부 표현으로 const ↔ param 추상화. paramID 로 추적 → emitter 가 paramName 으로 resolve.
- `classifyBinary(op)` → `(LLVM mnemonic, 결과 타입, 피연산자 타입)` triple. 매칭 / emit 양쪽이 같은 분류 사용.
- 타입 검증 강화: 피연산자 / 결과 타입이 예상과 다르면 decline (예: Int + Bool / Int return 인데 비교 결과 / Bool input 으로 arith / Int input 으로 logical).

### 테스트 (총 47)

성공 경로 (operator family 별 subtest 포함):
- `EmitsTrivialMain` / `EmitsIntLiteralReturn` / `EmitsBoolLiteralReturn`
- `EmitsIntParamPassthrough` / `EmitsBoolParamPassthrough`
- `EmitsIntArithOps/{add,sub,mul,div,mod}` (5)
- `EmitsIntComparisonOps/{eq,ne,lt,le,gt,ge}` (6)
- `EmitsIntBitwiseShiftOps/{bit_and,bit_or,bit_xor,shl,shr}` (5)
- `EmitsBoolLogicalOps/{both,either}` (2)
- `EmitsConstPlusVar` / `EmitsConstOnlyBinaryOp` / `EmitsSwappedParamOrder`
- `EmitsComparisonAgainstConst`
- `SanitizesEmptyParamName` / `FallsBackPackageName`

거부 경로:
- `RejectsNilModule` / `RejectsModuleWithoutMain`
- `RejectsMainWithParameters` / `RejectsMainWithInstructions`
- `RejectsIntrinsicDeclaration`
- `RejectsThreeParams` / `RejectsFloatReturn`
- `RejectsTypeMismatched{LiteralReturn,ComparisonReturn}`
- `RejectsMixedOperandTypesInArith` / `RejectsLogicalOnIntInputs`
- `RejectsProjectionInOperand` / `RejectsCopyFromNonParam`
- `RejectsUnsupportedBinaryOp`

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 47개 PASS, 0 fail
- [x] `go test ./internal/backend/...` — 전체 backend 0 fail

## Notes

- 디스패처 surface 영향 0. P3 wiring 까지 stage0 는 누구도 호출하지 않음.
- 다음 (P3a+): multi-instruction (let / 임시 변수) → 함수 호출 → if-else (multi-block). 각각 architectural 변경이라 별도 PR 권장.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_