### PR TITLE
feat(backend/stage0): direct function calls (P3b)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -163,7 +163,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P2d | non-main fn(a, b: Int) -> Int { a OP b } — Sub/Mul/Div/Mod 확장 | TestStage0EmitsIntBinaryArithOps — **구현 완료** |
 | P2e | single-instruction batch — 비교 / 비트 / 시프트 / 논리 / Bool / mixed const+var / 0~2 파라미터 / 자유로운 피연산자 순서 | 47 tests — **구현 완료** |
 | P3a | multi-instruction sequential (let / 임시 변수) — 단일 블록 안에서 N개 AssignInstr; UseRV 는 inline, BinaryRV 는 SSA register | 59 tests — **구현 완료** |
-| P3b+ | 함수 호출 / if-else (multi-block) / 더 큰 toolchain 부분 빌드 | toolchain/main.osty 부분 빌드 |
+| P3b | 함수 호출 (CallInstr → LLVM `call`) — direct FnRef, scalar args/return, in-module symbol | 70 tests — **구현 완료** |
+| P3c+ | if-else (BranchTerm + multi-block + phi) / 더 큰 toolchain 부분 빌드 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -63,12 +63,24 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	}
 	out.WriteString("\n")
 
+	// Collect the set of in-module function symbols up front so call
+	// classifiers can validate their FnRef.Symbol references a known
+	// declaration. External calls (runtime / FFI) decline — stage0
+	// doesn't emit declare statements.
+	knownSymbols := map[string]bool{}
+	for _, fn := range module.Functions {
+		if fn == nil || fn.Name == "" {
+			continue
+		}
+		knownSymbols[fn.Name] = true
+	}
+
 	emittedMain := false
 	for _, fn := range module.Functions {
 		if fn == nil {
 			continue
 		}
-		if err := emitFunction(&out, fn); err != nil {
+		if err := emitFunction(&out, fn, knownSymbols); err != nil {
 			return nil, err
 		}
 		if fn.Name == "main" {
@@ -81,7 +93,7 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 	return []byte(out.String()), nil
 }
 
-func emitFunction(out *strings.Builder, fn *mir.Function) error {
+func emitFunction(out *strings.Builder, fn *mir.Function, knownSymbols map[string]bool) error {
 	if fn.IsIntrinsic {
 		return fmt.Errorf("%w: intrinsic declaration %q", ErrUnsupported, fn.Name)
 	}
@@ -91,7 +103,7 @@ func emitFunction(out *strings.Builder, fn *mir.Function) error {
 	if fn.Name == "main" {
 		return emitTrivialMain(out, fn)
 	}
-	if pat, ok := matchSequentialReturn(fn); ok {
+	if pat, ok := matchSequentialReturn(fn, knownSymbols); ok {
 		return emitSequentialReturn(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
@@ -188,16 +200,25 @@ type localBinding struct {
 // pendingInstr is one instruction the emitter will materialise.
 // For `inline` instructions (UseRV) nothing is emitted — the matcher
 // already recorded the expression in seqState.bindings. For `binary`
-// instructions the emitter assigns the next SSA register at emit time.
+// and `call` instructions the emitter assigns the next SSA register
+// at emit time.
 type pendingInstr struct {
-	kind        instrKind
-	destLocal   mir.LocalID
-	resultType  scalarType
+	kind       instrKind
+	destLocal  mir.LocalID
+	resultType scalarType
 	// binary fields
-	binOp       string
-	binArgType  string
-	leftExpr    string
-	rightExpr   string
+	binOp      string
+	binArgType string
+	leftExpr   string
+	rightExpr  string
+	// call fields
+	callSymbol string
+	callArgs   []callArg
+}
+
+type callArg struct {
+	expr string
+	ty   string // LLVM type ("i64" / "i1")
 }
 
 type instrKind int
@@ -205,6 +226,7 @@ type instrKind int
 const (
 	instrInline instrKind = iota
 	instrBinary
+	instrCall
 )
 
 // sequentialPattern is what `matchSequentialReturn` produces.
@@ -218,8 +240,11 @@ type sequentialPattern struct {
 }
 
 // matchSequentialReturn classifies `fn` against the multi-instruction
-// stage0 subset described in the package docstring.
-func matchSequentialReturn(fn *mir.Function) (sequentialPattern, bool) {
+// stage0 subset described in the package docstring. `knownSymbols`
+// names every function defined in the same MIR module so direct call
+// classifiers can decline references to external symbols (which
+// stage0 cannot declare).
+func matchSequentialReturn(fn *mir.Function, knownSymbols map[string]bool) (sequentialPattern, bool) {
 	pat := sequentialPattern{}
 	pat.retType = scalarFromType(fn.ReturnType)
 	if pat.retType == scalarUnknown {
@@ -268,20 +293,22 @@ func matchSequentialReturn(fn *mir.Function) (sequentialPattern, bool) {
 	nextSSA := 0
 
 	for _, instr := range bb.Instrs {
-		assign, ok := instr.(*mir.AssignInstr)
-		if !ok {
+		var (
+			pending pendingInstr
+			expr    string
+			destID  mir.LocalID
+			destType scalarType
+			okStep  bool
+		)
+		switch step := instr.(type) {
+		case *mir.AssignInstr:
+			pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
+		case *mir.CallInstr:
+			pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+		default:
 			return pat, false
 		}
-		if assign.Dest.HasProjections() {
-			return pat, false
-		}
-		destID := assign.Dest.Local
-		destLocal := lookupLocal(fn, destID)
-		if destLocal == nil {
-			return pat, false
-		}
-		destType := scalarFromType(destLocal.Type)
-		if destType == scalarUnknown {
+		if !okStep {
 			return pat, false
 		}
 		// Reassignment is unsupported — both for params and for
@@ -289,26 +316,18 @@ func matchSequentialReturn(fn *mir.Function) (sequentialPattern, bool) {
 		if existing, found := bindings[destID]; found && existing.defined {
 			return pat, false
 		}
-
-		pending, expr, okSrc := classifyAssignSrc(assign.Src, destType, bindings)
-		if !okSrc {
-			return pat, false
-		}
 		pending.destLocal = destID
 		pending.resultType = destType
 
-		if pending.kind == instrBinary {
+		switch pending.kind {
+		case instrBinary, instrCall:
 			reg := fmt.Sprintf("%%%d", nextSSA)
 			nextSSA++
-			pending.leftExpr = pending.leftExpr // already set
-			pending.rightExpr = pending.rightExpr
 			bindings[destID] = localBinding{expr: reg, ty: destType, defined: true}
-			expr = reg
-		} else {
+		default:
 			bindings[destID] = localBinding{expr: expr, ty: destType, defined: true}
 		}
 		pat.pending = append(pat.pending, pending)
-		_ = expr
 	}
 
 	retBinding, ok := bindings[fn.ReturnLocal]
@@ -320,6 +339,90 @@ func matchSequentialReturn(fn *mir.Function) (sequentialPattern, bool) {
 	}
 	pat.returnExpr = retBinding.expr
 	return pat, true
+}
+
+// classifyAssignStep adapts AssignInstr to the shared pending-step
+// signature used by the matcher's per-instruction loop. Returns
+// (pending, inline-expr, destID, destType, ok).
+func classifyAssignStep(fn *mir.Function, ai *mir.AssignInstr, bindings map[mir.LocalID]localBinding) (pendingInstr, string, mir.LocalID, scalarType, bool) {
+	if ai.Dest.HasProjections() {
+		return pendingInstr{}, "", 0, scalarUnknown, false
+	}
+	destID := ai.Dest.Local
+	destLocal := lookupLocal(fn, destID)
+	if destLocal == nil {
+		return pendingInstr{}, "", 0, scalarUnknown, false
+	}
+	destType := scalarFromType(destLocal.Type)
+	if destType == scalarUnknown {
+		return pendingInstr{}, "", 0, scalarUnknown, false
+	}
+	pending, expr, ok := classifyAssignSrc(ai.Src, destType, bindings)
+	if !ok {
+		return pendingInstr{}, "", 0, scalarUnknown, false
+	}
+	return pending, expr, destID, destType, true
+}
+
+// classifyCallStep validates and decodes a direct call (`FnRef`) into
+// a pending call instruction. Indirect calls / unit-result calls /
+// projection destinations / non-scalar args decline.
+func classifyCallStep(fn *mir.Function, ci *mir.CallInstr, bindings map[mir.LocalID]localBinding, knownSymbols map[string]bool) (pendingInstr, mir.LocalID, scalarType, bool) {
+	if ci.Dest == nil {
+		// Stage0 only handles calls whose result feeds a local.
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if ci.Dest.HasProjections() {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	destID := ci.Dest.Local
+	destLocal := lookupLocal(fn, destID)
+	if destLocal == nil {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	destType := scalarFromType(destLocal.Type)
+	if destType == scalarUnknown {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	ref, ok := ci.Callee.(*mir.FnRef)
+	if !ok {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if ref.Symbol == "" {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if !knownSymbols[ref.Symbol] {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	// Validate the callee's declared return type matches dest.
+	fnTy, ok := ref.Type.(*ir.FnType)
+	if !ok || fnTy == nil {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if scalarFromType(fnTy.Return) != destType {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	if len(fnTy.Params) != len(ci.Args) {
+		return pendingInstr{}, 0, scalarUnknown, false
+	}
+	args := make([]callArg, 0, len(ci.Args))
+	for i, op := range ci.Args {
+		argExpr, argTy, okOp := resolveOperand(op, bindings)
+		if !okOp {
+			return pendingInstr{}, 0, scalarUnknown, false
+		}
+		// Param type must agree with the callee's declared param.
+		paramTy := scalarFromType(fnTy.Params[i])
+		if paramTy == scalarUnknown || paramTy != argTy {
+			return pendingInstr{}, 0, scalarUnknown, false
+		}
+		args = append(args, callArg{expr: argExpr, ty: argTy.llvm()})
+	}
+	return pendingInstr{
+		kind:       instrCall,
+		callSymbol: ref.Symbol,
+		callArgs:   args,
+	}, destID, destType, true
 }
 
 // classifyAssignSrc reduces an AssignInstr.Src to either a pending
@@ -404,11 +507,21 @@ func emitSequentialReturn(out *strings.Builder, fn *mir.Function, pat sequential
 
 	ssa := 0
 	for _, pi := range pat.pending {
-		if pi.kind != instrBinary {
-			continue
+		switch pi.kind {
+		case instrBinary:
+			fmt.Fprintf(out, "  %%%d = %s %s %s, %s\n", ssa, pi.binOp, pi.binArgType, pi.leftExpr, pi.rightExpr)
+			ssa++
+		case instrCall:
+			fmt.Fprintf(out, "  %%%d = call %s @%s(", ssa, pi.resultType.llvm(), pi.callSymbol)
+			for i, a := range pi.callArgs {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				fmt.Fprintf(out, "%s %s", a.ty, a.expr)
+			}
+			out.WriteString(")\n")
+			ssa++
 		}
-		fmt.Fprintf(out, "  %%%d = %s %s %s, %s\n", ssa, pi.binOp, pi.binArgType, pi.leftExpr, pi.rightExpr)
-		ssa++
 	}
 	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.returnExpr)
 	out.WriteString("}\n\n")

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -948,3 +948,288 @@ func TestStage0RejectsTypeMismatchInChain(t *testing.T) {
 	)
 	mustReject(t, trivialMainFn(), fn)
 }
+
+// ---- P3b: function calls ----
+
+func callInstr(destID mir.LocalID, calleeSym string, calleeFnTy *ir.FnType, args ...mir.Operand) *mir.CallInstr {
+	return &mir.CallInstr{
+		Dest:   &mir.Place{Local: destID},
+		Callee: &mir.FnRef{Symbol: calleeSym, Type: calleeFnTy},
+		Args:   args,
+	}
+}
+
+func fnTy(ret mir.Type, params ...mir.Type) *ir.FnType {
+	return &ir.FnType{Params: params, Return: ret}
+}
+
+func TestStage0EmitsLeafCall(t *testing.T) {
+	t.Parallel()
+	// `fn add(a, b) -> Int { a + b }`
+	addFn := makeFn(fnSpec{
+		name:   "add",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+		src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+	})
+	// `fn caller() -> Int { add(1, 2) }`
+	caller := makeMultiInstrFn(
+		"caller",
+		ir.TInt,
+		nil,
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(1, "add", fnTy(ir.TInt, ir.TInt, ir.TInt), intConst(1), intConst(2)),
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	got := emit(t, trivialMainFn(), addFn, caller)
+	for _, want := range []string{
+		"define i64 @add(i64 %a, i64 %b)",
+		"define i64 @caller()",
+		"%0 = call i64 @add(i64 1, i64 2)",
+		"ret i64 %0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsCallWithVariableArgs(t *testing.T) {
+	t.Parallel()
+	addFn := makeFn(fnSpec{
+		name:   "add",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+		src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+	})
+	// `fn caller(x: Int, y: Int) -> Int { add(x, y) }`
+	caller := makeMultiInstrFn(
+		"caller",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}, {name: "y", ty: ir.TInt}},
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(3, "add", fnTy(ir.TInt, ir.TInt, ir.TInt), paramCopy(1, ir.TInt), paramCopy(2, ir.TInt)),
+			assign(0, useRV(paramCopy(3, ir.TInt))),
+		},
+	)
+	got := emit(t, trivialMainFn(), addFn, caller)
+	if !strings.Contains(got, "%0 = call i64 @add(i64 %x, i64 %y)") {
+		t.Fatalf("expected call with param args:\n%s", got)
+	}
+}
+
+func TestStage0EmitsCallChainedWithArith(t *testing.T) {
+	t.Parallel()
+	doubleFn := makeFn(fnSpec{
+		name:   "double",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "x", ty: ir.TInt}},
+		src:    binaryRV(mir.BinMul, paramCopy(1, ir.TInt), intConst(2), ir.TInt),
+	})
+	// `fn quad(x: Int) -> Int { let d = double(x); d + d }`
+	quad := makeMultiInstrFn(
+		"quad",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		[]paramSpec{{name: "d", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(2, "double", fnTy(ir.TInt, ir.TInt), paramCopy(1, ir.TInt)),
+			assign(0, binaryRV(mir.BinAdd, paramCopy(2, ir.TInt), paramCopy(2, ir.TInt), ir.TInt)),
+		},
+	)
+	got := emit(t, trivialMainFn(), doubleFn, quad)
+	for _, want := range []string{
+		"%0 = call i64 @double(i64 %x)",
+		"%1 = add i64 %0, %0",
+		"ret i64 %1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsBoolReturningCall(t *testing.T) {
+	t.Parallel()
+	isPos := makeFn(fnSpec{
+		name:   "is_positive",
+		retT:   ir.TBool,
+		params: []paramSpec{{name: "n", ty: ir.TInt}},
+		src:    binaryRV(mir.BinGt, paramCopy(1, ir.TInt), intConst(0), ir.TBool),
+	})
+	caller := makeMultiInstrFn(
+		"check",
+		ir.TBool,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		[]paramSpec{{name: "r", ty: ir.TBool}},
+		[]mir.Instr{
+			callInstr(2, "is_positive", fnTy(ir.TBool, ir.TInt), paramCopy(1, ir.TInt)),
+			assign(0, useRV(paramCopy(2, ir.TBool))),
+		},
+	)
+	got := emit(t, trivialMainFn(), isPos, caller)
+	for _, want := range []string{
+		"define i1 @is_positive(i64 %n)",
+		"%0 = call i1 @is_positive(i64 %x)",
+		"ret i1 %0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsZeroArgCall(t *testing.T) {
+	t.Parallel()
+	zero := makeFn(fnSpec{
+		name: "zero",
+		retT: ir.TInt,
+		src:  useRV(intConst(0)),
+	})
+	caller := makeMultiInstrFn(
+		"plus_zero",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		[]paramSpec{{name: "z", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(2, "zero", fnTy(ir.TInt)),
+			assign(0, binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt)),
+		},
+	)
+	got := emit(t, trivialMainFn(), zero, caller)
+	for _, want := range []string{"%0 = call i64 @zero()", "%1 = add i64 %x, %0"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// ---- P3b rejection paths ----
+
+func TestStage0RejectsCallToUnknownSymbol(t *testing.T) {
+	t.Parallel()
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TInt,
+		nil,
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(1, "external_symbol_not_in_module", fnTy(ir.TInt, ir.TInt), intConst(1)),
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	mustReject(t, trivialMainFn(), caller)
+}
+
+func TestStage0RejectsCallReturnTypeMismatch(t *testing.T) {
+	t.Parallel()
+	// callee declared to return Int, but local typed Bool.
+	addFn := makeFn(fnSpec{
+		name:   "add",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+		src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+	})
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TBool,
+		nil,
+		[]paramSpec{{name: "r", ty: ir.TBool}}, // Bool local
+		[]mir.Instr{
+			callInstr(1, "add", fnTy(ir.TInt, ir.TInt, ir.TInt), intConst(1), intConst(2)),
+			assign(0, useRV(paramCopy(1, ir.TBool))),
+		},
+	)
+	mustReject(t, trivialMainFn(), addFn, caller)
+}
+
+func TestStage0RejectsCallArityMismatch(t *testing.T) {
+	t.Parallel()
+	addFn := makeFn(fnSpec{
+		name:   "add",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "a", ty: ir.TInt}, {name: "b", ty: ir.TInt}},
+		src:    binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt),
+	})
+	// Pass only one arg but FnType says 2.
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TInt,
+		nil,
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(1, "add", fnTy(ir.TInt, ir.TInt, ir.TInt), intConst(1)),
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	mustReject(t, trivialMainFn(), addFn, caller)
+}
+
+func TestStage0RejectsIndirectCall(t *testing.T) {
+	t.Parallel()
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TInt,
+		nil,
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			&mir.CallInstr{
+				Dest:   &mir.Place{Local: 1},
+				Callee: &mir.IndirectCall{Callee: paramCopy(0, ir.TInt)},
+				Args:   nil,
+			},
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	mustReject(t, trivialMainFn(), caller)
+}
+
+func TestStage0RejectsCallWithoutDest(t *testing.T) {
+	t.Parallel()
+	// Discarded result — stage0 only handles calls bound to a local.
+	other := makeFn(fnSpec{
+		name: "other",
+		retT: ir.TInt,
+		src:  useRV(intConst(0)),
+	})
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TInt,
+		nil,
+		nil,
+		[]mir.Instr{
+			&mir.CallInstr{
+				Dest:   nil,
+				Callee: &mir.FnRef{Symbol: "other", Type: fnTy(ir.TInt)},
+				Args:   nil,
+			},
+			assign(0, useRV(intConst(7))),
+		},
+	)
+	mustReject(t, trivialMainFn(), other, caller)
+}
+
+func TestStage0RejectsCallParamTypeMismatch(t *testing.T) {
+	t.Parallel()
+	doubleFn := makeFn(fnSpec{
+		name:   "double",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "x", ty: ir.TInt}},
+		src:    binaryRV(mir.BinMul, paramCopy(1, ir.TInt), intConst(2), ir.TInt),
+	})
+	// Pass a Bool as the Int param.
+	caller := makeMultiInstrFn(
+		"bad",
+		ir.TInt,
+		[]paramSpec{{name: "flag", ty: ir.TBool}},
+		[]paramSpec{{name: "r", ty: ir.TInt}},
+		[]mir.Instr{
+			callInstr(2, "double", fnTy(ir.TInt, ir.TInt), paramCopy(1, ir.TBool)),
+			assign(0, useRV(paramCopy(2, ir.TInt))),
+		},
+	)
+	mustReject(t, trivialMainFn(), doubleFn, caller)
+}


### PR DESCRIPTION
## Summary

P3a 의 sequential 매처를 `CallInstr` 도 받도록 확장 — direct call (`FnRef`) + scalar args/return + 같은 모듈 내 symbol.

`+440 / -41`, 70 tests PASS (+11).

```osty
fn add(a: Int, b: Int) -> Int { a + b }
fn quad(x: Int) -> Int { let d = double(x); d + d }
```

→
```llvm
define i64 @add(i64 %a, i64 %b) { ... }
define i64 @quad(i64 %x) {
entry:
  %0 = call i64 @double(i64 %x)
  %1 = add i64 %0, %0
  ret i64 %1
}
```

### Architecture

- `pendingInstr` 에 `instrCall` 분기 추가. `callSymbol` + `callArgs []callArg` 필드. 매처가 LocalID → SSA reg 바인딩 시 binary 와 같은 경로로 next SSA register 예약.
- `classifyCallStep` 신설:
  - `CallInstr.Dest` nil → 거부 (discarded result).
  - `Callee` 가 `*mir.FnRef` 인지 (IndirectCall 거부).
  - `ref.Type` 이 `*ir.FnType` 인지.
  - return / arg arity / arg types 매칭 검사.
  - 각 arg 는 기존 `resolveOperand` 로 const / param-copy / earlier-local 추출.
- `knownSymbols` 모듈-level set 을 `EmitMIR` 가 만들어 `emitFunction` → `matchSequentialReturn` → `classifyCallStep` 로 forward. **외부 심볼 (runtime / FFI) 은 declare 미지원이므로 거부**.
- emitter 에서 `instrCall` 케이스: `%N = call <retTy> @<sym>(<argTy> <arg>, ...)` 를 binary 와 같은 SSA 카운터로 emit.

### 테스트 +11 (총 70)

성공:
- `EmitsLeafCall` — `add(1, 2)` 한 줄.
- `EmitsCallWithVariableArgs` — `add(x, y)`.
- `EmitsCallChainedWithArith` — `let d = double(x); d + d` (call result 가 다음 binary 의 operand).
- `EmitsBoolReturningCall` — `is_positive(x)` 가 i1 반환.
- `EmitsZeroArgCall`.

거부:
- `RejectsCallToUnknownSymbol`.
- `RejectsCallReturnTypeMismatch`.
- `RejectsCallArityMismatch`.
- `RejectsIndirectCall`.
- `RejectsCallWithoutDest`.
- `RejectsCallParamTypeMismatch`.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 70 PASS, 0 fail
- [x] `go test ./internal/backend/...` — 전체 backend 0 fail

## Notes

- 디스패처 wiring 영향 0. P3 wiring 까지 stage0 는 누구도 호출하지 않음.
- 다음 (P3c): if-else (BranchTerm + multi-block + phi). multi-block 추적과 phi 노드 합성이 필요해 별도 PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_