### PR TITLE
feat(backend/stage0): if-else with phi-merged return (P3c)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -164,7 +164,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P2e | single-instruction batch — 비교 / 비트 / 시프트 / 논리 / Bool / mixed const+var / 0~2 파라미터 / 자유로운 피연산자 순서 | 47 tests — **구현 완료** |
 | P3a | multi-instruction sequential (let / 임시 변수) — 단일 블록 안에서 N개 AssignInstr; UseRV 는 inline, BinaryRV 는 SSA register | 59 tests — **구현 완료** |
 | P3b | 함수 호출 (CallInstr → LLVM `call`) — direct FnRef, scalar args/return, in-module symbol | 70 tests — **구현 완료** |
-| P3c+ | if-else (BranchTerm + multi-block + phi) / 더 큰 toolchain 부분 빌드 | toolchain/main.osty 부분 빌드 |
+| P3c | if-else (4-block: entry/then/else/merge + BranchTerm + GotoTerm + phi for ret) | 80 tests — **구현 완료** |
+| P4+ | toolchain 의 첫 N개 함수 lowering 통과 / 디스패처 wiring (OSTY_STAGE0_FALLBACK) | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -106,6 +106,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, knownSymbols map[strin
 	if pat, ok := matchSequentialReturn(fn, knownSymbols); ok {
 		return emitSequentialReturn(out, fn, pat)
 	}
+	if pat, ok := matchIfElseReturn(fn, knownSymbols); ok {
+		return emitIfElseReturn(out, fn, pat)
+	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
 
@@ -206,6 +209,9 @@ type pendingInstr struct {
 	kind       instrKind
 	destLocal  mir.LocalID
 	resultType scalarType
+	// SSA register pre-assigned at match time. Always set for
+	// instrBinary / instrCall; empty for instrInline.
+	binDestReg string
 	// binary fields
 	binOp      string
 	binArgType string
@@ -323,6 +329,7 @@ func matchSequentialReturn(fn *mir.Function, knownSymbols map[string]bool) (sequ
 		case instrBinary, instrCall:
 			reg := fmt.Sprintf("%%%d", nextSSA)
 			nextSSA++
+			pending.binDestReg = reg
 			bindings[destID] = localBinding{expr: reg, ty: destType, defined: true}
 		default:
 			bindings[destID] = localBinding{expr: expr, ty: destType, defined: true}
@@ -505,14 +512,12 @@ func emitSequentialReturn(out *strings.Builder, fn *mir.Function, pat sequential
 	out.WriteString(") {\n")
 	out.WriteString("entry:\n")
 
-	ssa := 0
 	for _, pi := range pat.pending {
 		switch pi.kind {
 		case instrBinary:
-			fmt.Fprintf(out, "  %%%d = %s %s %s, %s\n", ssa, pi.binOp, pi.binArgType, pi.leftExpr, pi.rightExpr)
-			ssa++
+			fmt.Fprintf(out, "  %s = %s %s %s, %s\n", pi.binDestReg, pi.binOp, pi.binArgType, pi.leftExpr, pi.rightExpr)
 		case instrCall:
-			fmt.Fprintf(out, "  %%%d = call %s @%s(", ssa, pi.resultType.llvm(), pi.callSymbol)
+			fmt.Fprintf(out, "  %s = call %s @%s(", pi.binDestReg, pi.resultType.llvm(), pi.callSymbol)
 			for i, a := range pi.callArgs {
 				if i > 0 {
 					out.WriteString(", ")
@@ -520,7 +525,6 @@ func emitSequentialReturn(out *strings.Builder, fn *mir.Function, pat sequential
 				fmt.Fprintf(out, "%s %s", a.ty, a.expr)
 			}
 			out.WriteString(")\n")
-			ssa++
 		}
 	}
 	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.returnExpr)
@@ -584,6 +588,312 @@ func disambiguateParamNames(names []string) {
 			}
 		}
 	}
+}
+
+// ---- P3c: if-else with phi-merged return ----
+//
+// stage0 P3c handles a tightly-restricted four-block if-else shape:
+//
+//	entry  : (P3a-style instructions) + BranchTerm{cond, then, else}
+//	then   : (P3a-style instructions; last AssignInstr writes ret) + GotoTerm(merge)
+//	else   : (P3a-style instructions; last AssignInstr writes ret) + GotoTerm(merge)
+//	merge  : zero instructions + ReturnTerm
+//
+// Cross-block bindings: only locals that are assigned in `entry` (and
+// thus already bound when the branch fires) are visible to `then` /
+// `else`. Intermediate locals defined inside `then` are not visible
+// in `else`, and vice versa — they live and die in their branch.
+// The return local is the only value that crosses the merge; stage0
+// emits a `phi` node at the start of `merge` to combine the values
+// produced by the two branches.
+
+type ifElsePattern struct {
+	retType    scalarType
+	paramIDs   []mir.LocalID
+	paramTypes []scalarType
+	paramNames []string
+	entry      blockEmit
+	thenBlk    blockEmit
+	elseBlk    blockEmit
+	condExpr   string
+	condType   string // always "i1" today
+	thenLabel  string
+	elseLabel  string
+	mergeLabel string
+	thenRet    string
+	elseRet    string
+}
+
+type blockEmit struct {
+	label   string
+	pending []pendingInstr
+}
+
+func matchIfElseReturn(fn *mir.Function, knownSymbols map[string]bool) (ifElsePattern, bool) {
+	pat := ifElsePattern{}
+	pat.retType = scalarFromType(fn.ReturnType)
+	if pat.retType == scalarUnknown {
+		return pat, false
+	}
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	if len(fn.Blocks) != 4 {
+		return pat, false
+	}
+
+	// Seed param bindings.
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		pt := scalarFromType(loc.Type)
+		if pt == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = pt
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	entryBindings := map[mir.LocalID]localBinding{}
+	for i, pid := range fn.Params {
+		entryBindings[pid] = localBinding{
+			expr:    "%" + pat.paramNames[i],
+			ty:      pat.paramTypes[i],
+			defined: true,
+		}
+	}
+
+	// Identify entry / then / else / merge by structural shape.
+	entryBlock := blockByID(fn, fn.Entry)
+	if entryBlock == nil {
+		return pat, false
+	}
+	branch, ok := entryBlock.Term.(*mir.BranchTerm)
+	if !ok {
+		return pat, false
+	}
+	thenBlock := blockByID(fn, branch.Then)
+	elseBlock := blockByID(fn, branch.Else)
+	if thenBlock == nil || elseBlock == nil || thenBlock.ID == elseBlock.ID {
+		return pat, false
+	}
+	thenGoto, ok := thenBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	elseGoto, ok := elseBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	if thenGoto.Target != elseGoto.Target {
+		return pat, false
+	}
+	mergeBlock := blockByID(fn, thenGoto.Target)
+	if mergeBlock == nil || mergeBlock.ID == entryBlock.ID || mergeBlock.ID == thenBlock.ID || mergeBlock.ID == elseBlock.ID {
+		return pat, false
+	}
+	if len(mergeBlock.Instrs) != 0 {
+		return pat, false
+	}
+	if _, ok := mergeBlock.Term.(*mir.ReturnTerm); !ok {
+		return pat, false
+	}
+
+	// SSA register counter spans the whole function.
+	nextSSA := 0
+
+	// Walk entry block.
+	entryEmit, condExpr, condTy, ok := classifyEntryBlock(fn, entryBlock, entryBindings, knownSymbols, &nextSSA)
+	if !ok || condTy != scalarBool {
+		return pat, false
+	}
+	pat.entry = entryEmit
+	pat.condExpr = condExpr
+	pat.condType = condTy.llvm()
+
+	// Walk then / else, each forks a copy of entryBindings.
+	thenEmit, thenRet, ok := classifyBranchBlock(fn, thenBlock, copyBindings(entryBindings), knownSymbols, &nextSSA, fn.ReturnLocal, pat.retType)
+	if !ok {
+		return pat, false
+	}
+	elseEmit, elseRet, ok := classifyBranchBlock(fn, elseBlock, copyBindings(entryBindings), knownSymbols, &nextSSA, fn.ReturnLocal, pat.retType)
+	if !ok {
+		return pat, false
+	}
+	pat.thenBlk = thenEmit
+	pat.elseBlk = elseEmit
+	pat.thenRet = thenRet
+	pat.elseRet = elseRet
+
+	pat.thenLabel = blockLabelName(thenBlock.ID, "then")
+	pat.elseLabel = blockLabelName(elseBlock.ID, "else")
+	pat.mergeLabel = blockLabelName(mergeBlock.ID, "merge")
+	pat.entry.label = "entry"
+	pat.thenBlk.label = pat.thenLabel
+	pat.elseBlk.label = pat.elseLabel
+	return pat, true
+}
+
+func emitIfElseReturn(out *strings.Builder, fn *mir.Function, pat ifElsePattern) error {
+	retLLVM := pat.retType.llvm()
+	fmt.Fprintf(out, "define %s @%s(", retLLVM, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+
+	emitBlock(out, pat.entry)
+	fmt.Fprintf(out, "  br %s %s, label %%%s, label %%%s\n", pat.condType, pat.condExpr, pat.thenLabel, pat.elseLabel)
+
+	out.WriteString("\n")
+	emitBlock(out, pat.thenBlk)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.mergeLabel)
+
+	out.WriteString("\n")
+	emitBlock(out, pat.elseBlk)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.mergeLabel)
+
+	out.WriteString("\n")
+	fmt.Fprintf(out, "%s:\n", pat.mergeLabel)
+	// phi node combines the return-local values produced by the two branches.
+	fmt.Fprintf(out, "  %%retval = phi %s [ %s, %%%s ], [ %s, %%%s ]\n", retLLVM, pat.thenRet, pat.thenLabel, pat.elseRet, pat.elseLabel)
+	fmt.Fprintf(out, "  ret %s %%retval\n", retLLVM)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+func emitBlock(out *strings.Builder, blk blockEmit) {
+	fmt.Fprintf(out, "%s:\n", blk.label)
+	for _, pi := range blk.pending {
+		switch pi.kind {
+		case instrBinary:
+			fmt.Fprintf(out, "  %s = %s %s %s, %s\n", pi.binDestReg, pi.binOp, pi.binArgType, pi.leftExpr, pi.rightExpr)
+		case instrCall:
+			fmt.Fprintf(out, "  %s = call %s @%s(", pi.binDestReg, pi.resultType.llvm(), pi.callSymbol)
+			for i, a := range pi.callArgs {
+				if i > 0 {
+					out.WriteString(", ")
+				}
+				fmt.Fprintf(out, "%s %s", a.ty, a.expr)
+			}
+			out.WriteString(")\n")
+		}
+	}
+}
+
+// classifyEntryBlock walks the entry block of an if-else: zero or more
+// AssignInstr/CallInstr followed by a BranchTerm whose Cond is a
+// resolvable Bool operand. Returns the resolved condition expression
+// + scalar type so the caller can emit the `br`.
+func classifyEntryBlock(fn *mir.Function, bb *mir.BasicBlock, bindings map[mir.LocalID]localBinding, knownSymbols map[string]bool, nextSSA *int) (blockEmit, string, scalarType, bool) {
+	emit := blockEmit{label: "entry"}
+	for _, instr := range bb.Instrs {
+		if !applyStep(fn, instr, bindings, knownSymbols, nextSSA, &emit) {
+			return blockEmit{}, "", scalarUnknown, false
+		}
+	}
+	branch, ok := bb.Term.(*mir.BranchTerm)
+	if !ok {
+		return blockEmit{}, "", scalarUnknown, false
+	}
+	condExpr, condTy, ok := resolveOperand(branch.Cond, bindings)
+	if !ok {
+		return blockEmit{}, "", scalarUnknown, false
+	}
+	return emit, condExpr, condTy, true
+}
+
+// classifyBranchBlock walks a `then` / `else` block: zero or more
+// AssignInstr/CallInstr followed by GotoTerm. The block's last
+// AssignInstr to the return local provides the value contributed to
+// the merge phi; the helper returns that value's LLVM expression.
+func classifyBranchBlock(fn *mir.Function, bb *mir.BasicBlock, bindings map[mir.LocalID]localBinding, knownSymbols map[string]bool, nextSSA *int, retLocal mir.LocalID, retType scalarType) (blockEmit, string, bool) {
+	emit := blockEmit{}
+	for _, instr := range bb.Instrs {
+		if !applyStep(fn, instr, bindings, knownSymbols, nextSSA, &emit) {
+			return blockEmit{}, "", false
+		}
+	}
+	if _, ok := bb.Term.(*mir.GotoTerm); !ok {
+		return blockEmit{}, "", false
+	}
+	retBinding, ok := bindings[retLocal]
+	if !ok || !retBinding.defined || retBinding.ty != retType {
+		return blockEmit{}, "", false
+	}
+	return emit, retBinding.expr, true
+}
+
+// applyStep advances one MIR instruction inside a block during P3c
+// matching: it threads the binding map + SSA counter and appends a
+// pending entry to the block emit when the instruction needs an LLVM
+// line.
+func applyStep(fn *mir.Function, instr mir.Instr, bindings map[mir.LocalID]localBinding, knownSymbols map[string]bool, nextSSA *int, emit *blockEmit) bool {
+	var (
+		pending  pendingInstr
+		expr     string
+		destID   mir.LocalID
+		destType scalarType
+		okStep   bool
+	)
+	switch step := instr.(type) {
+	case *mir.AssignInstr:
+		pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
+	case *mir.CallInstr:
+		pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+	default:
+		return false
+	}
+	if !okStep {
+		return false
+	}
+	if existing, found := bindings[destID]; found && existing.defined {
+		return false
+	}
+	pending.destLocal = destID
+	pending.resultType = destType
+	switch pending.kind {
+	case instrBinary, instrCall:
+		reg := fmt.Sprintf("%%%d", *nextSSA)
+		*nextSSA++
+		pending.binDestReg = reg
+		bindings[destID] = localBinding{expr: reg, ty: destType, defined: true}
+	default:
+		bindings[destID] = localBinding{expr: expr, ty: destType, defined: true}
+	}
+	emit.pending = append(emit.pending, pending)
+	return true
+}
+
+func blockByID(fn *mir.Function, id mir.BlockID) *mir.BasicBlock {
+	for _, bb := range fn.Blocks {
+		if bb != nil && bb.ID == id {
+			return bb
+		}
+	}
+	return nil
+}
+
+func blockLabelName(id mir.BlockID, prefix string) string {
+	return fmt.Sprintf("%s.%d", prefix, id)
+}
+
+func copyBindings(src map[mir.LocalID]localBinding) map[mir.LocalID]localBinding {
+	dst := make(map[mir.LocalID]localBinding, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 // ---- shared helpers ----

--- a/internal/backend/stage0/emit_test.go
+++ b/internal/backend/stage0/emit_test.go
@@ -1212,6 +1212,320 @@ func TestStage0RejectsCallWithoutDest(t *testing.T) {
 	mustReject(t, trivialMainFn(), other, caller)
 }
 
+// ---- P3c: if-else with phi-merged return ----
+
+// makeIfElseFn assembles the canonical 4-block if-else MIR shape.
+//   entry: cond = entryInstrs...; branch cond -> then, else
+//   then : thenInstrs (last AssignInstr writes ret); goto merge
+//   else : elseInstrs (last AssignInstr writes ret); goto merge
+//   merge: ret
+func makeIfElseFn(name string, retT mir.Type, params []paramSpec, extraLocals []paramSpec, entryInstrs []mir.Instr, cond mir.Operand, thenInstrs []mir.Instr, elseInstrs []mir.Instr) *mir.Function {
+	locals := []*mir.Local{
+		{ID: 0, Name: "ret", Type: retT, IsReturn: true},
+	}
+	paramIDs := make([]mir.LocalID, 0, len(params))
+	nextID := mir.LocalID(1)
+	for _, p := range params {
+		paramIDs = append(paramIDs, nextID)
+		locals = append(locals, &mir.Local{ID: nextID, Name: p.name, Type: p.ty, IsParam: true})
+		nextID++
+	}
+	for _, l := range extraLocals {
+		locals = append(locals, &mir.Local{ID: nextID, Name: l.name, Type: l.ty})
+		nextID++
+	}
+	return &mir.Function{
+		Name:        name,
+		Params:      paramIDs,
+		ReturnType:  retT,
+		ReturnLocal: 0,
+		Locals:      locals,
+		Entry:       0,
+		Blocks: []*mir.BasicBlock{
+			{ID: 0, Instrs: entryInstrs, Term: &mir.BranchTerm{Cond: cond, Then: 1, Else: 2}},
+			{ID: 1, Instrs: thenInstrs, Term: &mir.GotoTerm{Target: 3}},
+			{ID: 2, Instrs: elseInstrs, Term: &mir.GotoTerm{Target: 3}},
+			{ID: 3, Instrs: nil, Term: &mir.ReturnTerm{}},
+		},
+	}
+}
+
+func TestStage0EmitsIfElseConstReturns(t *testing.T) {
+	t.Parallel()
+	// `fn sign(x: Int) -> Int { if x > 0 { 1 } else { -1 } }`
+	// MIR: entry has cond temp; then assigns 1 to ret; else assigns -1.
+	fn := makeIfElseFn(
+		"sign",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		[]paramSpec{{name: "cond", ty: ir.TBool}},
+		[]mir.Instr{
+			assign(2, binaryRV(mir.BinGt, paramCopy(1, ir.TInt), intConst(0), ir.TBool)),
+		},
+		paramCopy(2, ir.TBool),
+		[]mir.Instr{
+			assign(0, useRV(intConst(1))),
+		},
+		[]mir.Instr{
+			assign(0, useRV(intConst(-1))),
+		},
+	)
+	got := emit(t, trivialMainFn(), fn)
+	for _, want := range []string{
+		"define i64 @sign(i64 %x)",
+		"entry:",
+		"%0 = icmp sgt i64 %x, 0",
+		"br i1 %0, label %then.1, label %else.2",
+		"then.1:",
+		"br label %merge.3",
+		"else.2:",
+		"br label %merge.3",
+		"merge.3:",
+		"%retval = phi i64 [ 1, %then.1 ], [ -1, %else.2 ]",
+		"ret i64 %retval",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsIfElseWithBranchArith(t *testing.T) {
+	t.Parallel()
+	// `fn abs(x: Int) -> Int { if x < 0 { 0 - x } else { x } }`
+	fn := makeIfElseFn(
+		"abs",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		[]paramSpec{
+			{name: "cond", ty: ir.TBool},
+			{name: "neg", ty: ir.TInt},
+		},
+		[]mir.Instr{
+			assign(2, binaryRV(mir.BinLt, paramCopy(1, ir.TInt), intConst(0), ir.TBool)),
+		},
+		paramCopy(2, ir.TBool),
+		[]mir.Instr{
+			assign(3, binaryRV(mir.BinSub, intConst(0), paramCopy(1, ir.TInt), ir.TInt)),
+			assign(0, useRV(paramCopy(3, ir.TInt))),
+		},
+		[]mir.Instr{
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	got := emit(t, trivialMainFn(), fn)
+	for _, want := range []string{
+		"%0 = icmp slt i64 %x, 0",
+		"br i1 %0, label %then.1, label %else.2",
+		"then.1:",
+		"%1 = sub i64 0, %x",
+		"%retval = phi i64 [ %1, %then.1 ], [ %x, %else.2 ]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsIfElseBoolReturn(t *testing.T) {
+	t.Parallel()
+	// `fn flip(b: Bool) -> Bool { if b { false } else { true } }`
+	fn := makeIfElseFn(
+		"flip",
+		ir.TBool,
+		[]paramSpec{{name: "b", ty: ir.TBool}},
+		nil,
+		nil, // no entry instructions; cond reads param directly
+		paramCopy(1, ir.TBool),
+		[]mir.Instr{
+			assign(0, useRV(boolConst(false))),
+		},
+		[]mir.Instr{
+			assign(0, useRV(boolConst(true))),
+		},
+	)
+	got := emit(t, trivialMainFn(), fn)
+	for _, want := range []string{
+		"define i1 @flip(i1 %b)",
+		"br i1 %b, label %then.1, label %else.2",
+		"%retval = phi i1 [ false, %then.1 ], [ true, %else.2 ]",
+		"ret i1 %retval",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsIfElseWithCallInBranch(t *testing.T) {
+	t.Parallel()
+	doubleFn := makeFn(fnSpec{
+		name:   "double",
+		retT:   ir.TInt,
+		params: []paramSpec{{name: "x", ty: ir.TInt}},
+		src:    binaryRV(mir.BinMul, paramCopy(1, ir.TInt), intConst(2), ir.TInt),
+	})
+	// `fn maybe_double(x: Int, flag: Bool) -> Int { if flag { double(x) } else { x } }`
+	fn := makeIfElseFn(
+		"maybe_double",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}, {name: "flag", ty: ir.TBool}},
+		[]paramSpec{{name: "d", ty: ir.TInt}},
+		nil,
+		paramCopy(2, ir.TBool),
+		[]mir.Instr{
+			callInstr(3, "double", fnTy(ir.TInt, ir.TInt), paramCopy(1, ir.TInt)),
+			assign(0, useRV(paramCopy(3, ir.TInt))),
+		},
+		[]mir.Instr{
+			assign(0, useRV(paramCopy(1, ir.TInt))),
+		},
+	)
+	got := emit(t, trivialMainFn(), doubleFn, fn)
+	for _, want := range []string{
+		"br i1 %flag, label %then.1, label %else.2",
+		"%0 = call i64 @double(i64 %x)",
+		"%retval = phi i64 [ %0, %then.1 ], [ %x, %else.2 ]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStage0EmitsIfElseWithEntryArith(t *testing.T) {
+	t.Parallel()
+	// `fn classify(x: Int, y: Int) -> Int { let s = x + y; if s > 0 { s } else { 0 } }`
+	fn := makeIfElseFn(
+		"classify",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}, {name: "y", ty: ir.TInt}},
+		[]paramSpec{
+			{name: "s", ty: ir.TInt},
+			{name: "cond", ty: ir.TBool},
+		},
+		[]mir.Instr{
+			assign(3, binaryRV(mir.BinAdd, paramCopy(1, ir.TInt), paramCopy(2, ir.TInt), ir.TInt)),
+			assign(4, binaryRV(mir.BinGt, paramCopy(3, ir.TInt), intConst(0), ir.TBool)),
+		},
+		paramCopy(4, ir.TBool),
+		[]mir.Instr{
+			assign(0, useRV(paramCopy(3, ir.TInt))),
+		},
+		[]mir.Instr{
+			assign(0, useRV(intConst(0))),
+		},
+	)
+	got := emit(t, trivialMainFn(), fn)
+	for _, want := range []string{
+		"%0 = add i64 %x, %y",
+		"%1 = icmp sgt i64 %0, 0",
+		"br i1 %1, label %then.1, label %else.2",
+		// `s` is the entry-block result %0; then branch reads it.
+		"%retval = phi i64 [ %0, %then.1 ], [ 0, %else.2 ]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("emitted IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// ---- P3c rejection paths ----
+
+func TestStage0RejectsThreeBlockShape(t *testing.T) {
+	t.Parallel()
+	// 3 blocks instead of 4 — declines.
+	fn := &mir.Function{
+		Name:        "bad",
+		Params:      []mir.LocalID{1},
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+			{ID: 1, Name: "x", Type: ir.TInt, IsParam: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{ID: 0, Term: &mir.BranchTerm{Cond: paramCopy(1, ir.TInt), Then: 1, Else: 1}},
+			{ID: 1, Instrs: []mir.Instr{assign(0, useRV(paramCopy(1, ir.TInt)))}, Term: &mir.ReturnTerm{}},
+		},
+	}
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsIfElseWhereOneBranchSkipsRet(t *testing.T) {
+	t.Parallel()
+	// else branch never assigns to ret — declines.
+	fn := makeIfElseFn(
+		"bad",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		nil,
+		nil,
+		paramCopy(1, ir.TInt), // bad — Int as cond
+		[]mir.Instr{assign(0, useRV(intConst(1)))},
+		nil, // no ret assign in else
+	)
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsIfElseWithIntCondition(t *testing.T) {
+	t.Parallel()
+	fn := makeIfElseFn(
+		"bad",
+		ir.TInt,
+		[]paramSpec{{name: "x", ty: ir.TInt}},
+		nil,
+		nil,
+		paramCopy(1, ir.TInt), // Int condition
+		[]mir.Instr{assign(0, useRV(intConst(1)))},
+		[]mir.Instr{assign(0, useRV(intConst(0)))},
+	)
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsIfElseWhereThenElseTargetsDiffer(t *testing.T) {
+	t.Parallel()
+	// Manually construct: then goes to block 3, else goes to block 4. No common merge.
+	fn := &mir.Function{
+		Name:        "bad",
+		Params:      []mir.LocalID{1},
+		ReturnType:  ir.TInt,
+		ReturnLocal: 0,
+		Locals: []*mir.Local{
+			{ID: 0, Name: "ret", Type: ir.TInt, IsReturn: true},
+			{ID: 1, Name: "b", Type: ir.TBool, IsParam: true},
+		},
+		Entry: 0,
+		Blocks: []*mir.BasicBlock{
+			{ID: 0, Term: &mir.BranchTerm{Cond: paramCopy(1, ir.TBool), Then: 1, Else: 2}},
+			{ID: 1, Instrs: []mir.Instr{assign(0, useRV(intConst(1)))}, Term: &mir.GotoTerm{Target: 3}},
+			{ID: 2, Instrs: []mir.Instr{assign(0, useRV(intConst(2)))}, Term: &mir.GotoTerm{Target: 4}}, // different target
+			{ID: 3, Term: &mir.ReturnTerm{}},
+			{ID: 4, Term: &mir.ReturnTerm{}},
+		},
+	}
+	mustReject(t, trivialMainFn(), fn)
+}
+
+func TestStage0RejectsIfElseWithMergeInstructions(t *testing.T) {
+	t.Parallel()
+	// Merge block has instructions — stage0 expects empty merge.
+	fn := makeIfElseFn(
+		"bad",
+		ir.TInt,
+		[]paramSpec{{name: "b", ty: ir.TBool}},
+		nil,
+		nil,
+		paramCopy(1, ir.TBool),
+		[]mir.Instr{assign(0, useRV(intConst(1)))},
+		[]mir.Instr{assign(0, useRV(intConst(2)))},
+	)
+	// Inject an instruction into the merge block (id 3).
+	fn.Blocks[3].Instrs = []mir.Instr{assign(0, useRV(intConst(99)))}
+	mustReject(t, trivialMainFn(), fn)
+}
+
 func TestStage0RejectsCallParamTypeMismatch(t *testing.T) {
 	t.Parallel()
 	doubleFn := makeFn(fnSpec{


### PR DESCRIPTION
## Summary

Stage0 가 처음으로 **multi-block CFG** 를 다룬다. 4-블록 if-else 표준 형태에 phi-merged return.

`+631 / -6`, 80 tests PASS (+10).

```osty
fn abs(x: Int) -> Int {
    if x < 0 { 0 - x } else { x }
}
```

→
```llvm
define i64 @abs(i64 %x) {
entry:
  %0 = icmp slt i64 %x, 0
  br i1 %0, label %then.1, label %else.2

then.1:
  %1 = sub i64 0, %x
  br label %merge.3

else.2:
  br label %merge.3

merge.3:
  %retval = phi i64 [ %1, %then.1 ], [ %x, %else.2 ]
  ret i64 %retval
}
```

### 4-block 형태

```
entry  : (P3a-style instructions) + BranchTerm{cond, then, else}
then   : (P3a-style instructions; 마지막 AssignInstr 가 ret 에 기록) + GotoTerm(merge)
else   : (대칭)
merge  : 0 instructions + ReturnTerm
```

### 핵심 추가

- `pendingInstr.binDestReg` — match 시점에 SSA register 이름을 pre-bake. 기존 sequential 매처도 같은 필드를 쓰도록 정리해서 `emitBlock` 한 곳에서 binary/call 모두 처리.
- `ifElsePattern` + `matchIfElseReturn` + `emitIfElseReturn` — 새 매처/이미터 쌍.
- 헬퍼 `classifyEntryBlock` / `classifyBranchBlock` / `applyStep` — 블록당 순회. SSA counter 와 bindings map 을 포인터로 전달.
- `copyBindings` — entry 끝 시점의 bindings 를 then/else 가 각각 fork. intermediate 변수가 한 branch 안에 갇혀 있어 SSA 정합성 유지.
- 매치 결과는 `thenRet` / `elseRet` (각 분기의 return-local 최종 값) + 사전 결정된 `then.<id>` / `else.<id>` / `merge.<id>` 라벨. emit 시 merge 시작에 phi 한 줄 + ret.

### 테스트 +10 (총 80)

성공:
- `EmitsIfElseConstReturns` — `if x > 0 { 1 } else { -1 }`.
- `EmitsIfElseWithBranchArith` — `if x < 0 { 0 - x } else { x }`.
- `EmitsIfElseBoolReturn` — `if b { false } else { true }`.
- `EmitsIfElseWithCallInBranch` — `if flag { double(x) } else { x }`.
- `EmitsIfElseWithEntryArith` — `let s = x + y; if s > 0 { s } else { 0 }` (entry-block 에서 정의된 local 을 then 분기가 참조).

거부:
- `RejectsThreeBlockShape`.
- `RejectsIfElseWhereOneBranchSkipsRet`.
- `RejectsIfElseWithIntCondition`.
- `RejectsIfElseWhereThenElseTargetsDiffer`.
- `RejectsIfElseWithMergeInstructions`.

기존 P1 ~ P3b 70개 테스트 모두 그대로 통과 (sequential pattern 도 새 `binDestReg` shape 사용).

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 80 PASS, 0 fail
- [x] `go test ./internal/backend/...` — 전체 backend 0 fail

## Notes

- 디스패처 wiring 은 P4. stage0 본체는 거의 완성 단계 — toolchain 의 첫 N개 함수에 도달할 만한 surface 가 갖춰짐.
- 다음 (P4): toolchain MIR 일부를 stage0 로 직접 컴파일해서 어떤 패턴이 추가로 필요한지 식별. 또는 `OSTY_STAGE0_FALLBACK=1` 디스패처 wiring 으로 활성화.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_