### PR TITLE
feat(backend): wire stage0 fallback under OSTY_STAGE0_FALLBACK (P4)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -165,7 +165,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P3a | multi-instruction sequential (let / 임시 변수) — 단일 블록 안에서 N개 AssignInstr; UseRV 는 inline, BinaryRV 는 SSA register | 59 tests — **구현 완료** |
 | P3b | 함수 호출 (CallInstr → LLVM `call`) — direct FnRef, scalar args/return, in-module symbol | 70 tests — **구현 완료** |
 | P3c | if-else (4-block: entry/then/else/merge + BranchTerm + GotoTerm + phi for ret) | 80 tests — **구현 완료** |
-| P4+ | toolchain 의 첫 N개 함수 lowering 통과 / 디스패처 wiring (OSTY_STAGE0_FALLBACK) | toolchain/main.osty 부분 빌드 |
+| P4 | 디스패처 wiring (`OSTY_STAGE0_FALLBACK=1` + `IsOstySelfMissing` 조건부 라우팅) | TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing — **구현 완료** |
+| P5+ | toolchain 의 첫 N개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/bootstrap.go
+++ b/internal/backend/bootstrap.go
@@ -1,6 +1,37 @@
 package backend
 
-import "strings"
+import (
+	"os"
+	"strings"
+
+	"github.com/osty/osty/internal/backend/stage0"
+	"github.com/osty/osty/internal/llvmabi"
+)
+
+// Stage0FallbackEnv is the env-var name that opts a build into the
+// stage0 bootstrap fallback emitter. The dispatcher consults it inside
+// `emitLLVMFallback` only when the native LIR Proto subprocess
+// declined because `osty-self` is missing — the canonical first-build
+// symptom on a fresh clone. Production runs (osty-self built) never
+// observe stage0 even when the variable is set.
+const Stage0FallbackEnv = "OSTY_STAGE0_FALLBACK"
+
+// Stage0FallbackEnabled reports whether the stage0 fallback emitter
+// should be considered when the LIR Proto subprocess declines due to
+// `osty-self` not being built yet.
+func Stage0FallbackEnabled() bool {
+	switch strings.TrimSpace(os.Getenv(Stage0FallbackEnv)) {
+	case "1", "true", "TRUE", "True", "on", "ON", "On", "yes", "YES", "Yes":
+		return true
+	}
+	return false
+}
+
+// tryStage0Fallback invokes the stage0 emitter with the entry's MIR.
+// Indirection so tests can stub it without touching the live emitter.
+var tryStage0Fallback = func(entry Entry, opts llvmabi.Options) ([]byte, error) {
+	return stage0.EmitMIR(entry.MIR, opts)
+}
 
 // ostySelfMissingSignal matches the canonical "osty-self not found" message
 // produced by `cmd/osty-native-lirproto/main.go:resolveOstySelfBin`. The

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -242,7 +242,12 @@ func llvmFallbackDispatchRoute(opts llvmabi.Options, entry Entry) llvmDispatchRo
 // emitLLVMFallback dispatches the resolved route to the native LIR Proto
 // subprocess. The Go MIR emitter is gone, so MIR-direct emission rides the
 // same `tryNativeOwnedMIRPayloadLLVMIRText` boundary the native-owned route
-// uses; declines surface as a structured "unsupported" diagnostic upstream.
+// uses. When the subprocess declines because `osty-self` is not built yet
+// (the canonical bootstrap symptom), an opt-in stage0 fallback can step in
+// and emit a small bootstrap-only subset; see
+// `docs/osty_self_bootstrap_design.md`. Without the env-var opt-in the
+// dispatcher still declines so production builds never silently route
+// through the bootstrap emitter.
 func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options) ([]byte, []error, error) {
 	if entry.MIR == nil {
 		return nil, nil, llvmabi.Unsupported("source-layout", "nil MIR module")
@@ -251,10 +256,18 @@ func emitLLVMFallback(route llvmDispatchRoute, entry Entry, opts llvmabi.Options
 	if err != nil {
 		return nil, nativeWarnings, err
 	}
-	if !ok {
-		return nil, nativeWarnings, llvmabi.Unsupported("mir-emit", "native LIR Proto subprocess declined MIR coverage for route "+string(route))
+	if ok {
+		return out, nativeWarnings, nil
 	}
-	return out, nativeWarnings, nil
+	if Stage0FallbackEnabled() && IsOstySelfMissing(nativeWarnings) {
+		s0Out, s0Err := tryStage0Fallback(entry, opts)
+		if s0Err == nil {
+			nativeWarnings = append(nativeWarnings, errors.New("stage0 fallback: emitted MIR through bootstrap-only path"))
+			return s0Out, nativeWarnings, nil
+		}
+		nativeWarnings = append(nativeWarnings, fmt.Errorf("stage0 fallback declined: %w", s0Err))
+	}
+	return nil, nativeWarnings, llvmabi.Unsupported("mir-emit", "native LIR Proto subprocess declined MIR coverage for route "+string(route))
 }
 
 func renderUnsupportedLLVMIR(entry Entry, target string, emit EmitMode, warnings []error, diag llvmabi.UnsupportedDiagnostic, route llvmDispatchRoute) ([]byte, []error, error) {

--- a/internal/backend/stage0_dispatch_test.go
+++ b/internal/backend/stage0_dispatch_test.go
@@ -1,0 +1,226 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/llvmabi"
+)
+
+// withStage0FallbackOverride installs a hook for `tryStage0Fallback`
+// scoped to one test. Tests can return a successful IR or simulate
+// stage0 declining.
+func withStage0FallbackOverride(t *testing.T, fn func(Entry, llvmabi.Options) ([]byte, error)) {
+	t.Helper()
+	old := tryStage0Fallback
+	tryStage0Fallback = fn
+	t.Cleanup(func() { tryStage0Fallback = old })
+}
+
+func TestStage0FallbackDisabledByDefault(t *testing.T) {
+	if Stage0FallbackEnabled() {
+		t.Fatalf("OSTY_STAGE0_FALLBACK must default to off; saw enabled")
+	}
+}
+
+func TestStage0FallbackEnabledRespectsEnvVar(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"off", false},
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"On", true},
+		{"yes", true},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.value, func(t *testing.T) {
+			t.Setenv(Stage0FallbackEnv, c.value)
+			if got := Stage0FallbackEnabled(); got != c.want {
+				t.Fatalf("Stage0FallbackEnabled with %q = %v, want %v", c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing(t *testing.T) {
+	t.Setenv(Stage0FallbackEnv, "1")
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("osty-self not found; run `osty build toolchain/`")}, nil
+	})
+	stage0Called := false
+	withStage0FallbackOverride(t, func(entry Entry, opts llvmabi.Options) ([]byte, error) {
+		stage0Called = true
+		if entry.MIR == nil {
+			t.Fatal("stage0 fallback received nil MIR")
+		}
+		return []byte("; stage0 fallback IR for test\n"), nil
+	})
+
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !stage0Called {
+		t.Fatal("expected stage0 fallback to be invoked")
+	}
+	if !strings.Contains(string(got), "stage0 fallback IR for test") {
+		t.Fatalf("expected stage0 IR in output:\n%s", got)
+	}
+	if !findWarning(warnings, "stage0 fallback: emitted MIR through bootstrap-only path") {
+		t.Fatalf("expected fallback breadcrumb in warnings: %v", warnings)
+	}
+}
+
+func TestEmitLLVMFallbackSkipsStage0WhenEnvNotSet(t *testing.T) {
+	// No env var set — stage0 must not be reached even when the
+	// native subprocess declined with the osty-self signal.
+	if v := Stage0FallbackEnabled(); v {
+		t.Fatalf("env should be unset before this test")
+	}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("osty-self not found")}, nil
+	})
+	withStage0FallbackOverride(t, func(Entry, llvmabi.Options) ([]byte, error) {
+		t.Fatal("stage0 fallback must not run without OSTY_STAGE0_FALLBACK")
+		return nil, nil
+	})
+
+	_, _, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err == nil {
+		t.Fatal("expected ErrLLVMNotImplemented when stage0 is gated off")
+	}
+}
+
+func TestEmitLLVMFallbackSkipsStage0WhenDeclineNotOstySelf(t *testing.T) {
+	// Env var set, but the decline reason is unrelated — stage0
+	// should NOT run; the dispatcher should pass the decline up.
+	t.Setenv(Stage0FallbackEnv, "1")
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("MIR payload requires the Osty-owned LIR Proto backend")}, nil
+	})
+	withStage0FallbackOverride(t, func(Entry, llvmabi.Options) ([]byte, error) {
+		t.Fatal("stage0 fallback must not run when decline is not osty-self-missing")
+		return nil, nil
+	})
+
+	_, _, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err == nil {
+		t.Fatal("expected ErrLLVMNotImplemented when stage0 is not eligible")
+	}
+}
+
+func TestEmitLLVMFallbackBubblesUpStage0Decline(t *testing.T) {
+	// Env on, native declined with osty-self-missing, stage0 declines too.
+	t.Setenv(Stage0FallbackEnv, "1")
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("osty-self not found")}, nil
+	})
+	stage0Reason := errors.New("stage0: MIR shape outside bootstrap subset: synthetic test reason")
+	withStage0FallbackOverride(t, func(Entry, llvmabi.Options) ([]byte, error) {
+		return nil, stage0Reason
+	})
+
+	_, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err == nil {
+		t.Fatal("expected ErrLLVMNotImplemented when stage0 also declines")
+	}
+	if !findWarning(warnings, "stage0 fallback declined") {
+		t.Fatalf("expected stage0 decline breadcrumb in warnings: %v", warnings)
+	}
+}
+
+func TestEmitLLVMFallbackPrefersNativeWhenItCovers(t *testing.T) {
+	// Env on but native subprocess succeeds — stage0 must not run.
+	t.Setenv(Stage0FallbackEnv, "1")
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return []byte("; native IR\n"), true, nil, nil
+	})
+	withStage0FallbackOverride(t, func(Entry, llvmabi.Options) ([]byte, error) {
+		t.Fatal("stage0 must not run when native subprocess succeeded")
+		return nil, nil
+	})
+
+	got, _, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !strings.Contains(string(got), "; native IR") {
+		t.Fatalf("expected native IR in output:\n%s", got)
+	}
+}
+
+// findWarning is a tiny helper that checks whether any warning
+// contains the given substring. Used by the wiring tests above.
+func findWarning(warnings []error, sub string) bool {
+	for _, w := range warnings {
+		if w == nil {
+			continue
+		}
+		if strings.Contains(w.Error(), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// newBackendRequest is exercised through the existing llvm_test.go
+// helpers. Adding a per-test wrapper here keeps the wiring tests
+// self-contained.
+
+// Ensure the dispatcher path is exercised end-to-end via Emit (not
+// just EmitLLVMIRText) to catch regressions in the binary / object
+// branches.
+func TestStage0FallbackSurvivesBinaryEmitPath(t *testing.T) {
+	t.Setenv(Stage0FallbackEnv, "1")
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `fn main() {}`)
+
+	withNativeMIRPayloadEmitter(t, func(Entry, string) ([]byte, bool, []error, error) {
+		return nil, false, []error{errors.New("osty-self not found")}, nil
+	})
+	withStage0FallbackOverride(t, func(entry Entry, opts llvmabi.Options) ([]byte, error) {
+		return []byte("; stage0 IR; package: " + entry.PackageName + "\n"), nil
+	})
+
+	res, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	if len(tc.irCompiles) != 1 {
+		t.Fatalf("expected toolchain compile call from stage0 IR; got %d", len(tc.irCompiles))
+	}
+}


### PR DESCRIPTION
## Summary

부트스트랩 설계의 **P4** — P1~P3c 에 걸쳐 만든 stage0 emitter 를 마침내 디스패처에 연결.

```
환경변수 OSTY_STAGE0_FALLBACK=1
+ native LIR Proto 서브프로세스가 osty-self 부재 (IsOstySelfMissing) 로 declined
                              ↓
                  stage0.EmitMIR(entry.MIR, opts)
                              ↓
         성공 → IR 반환 + warning breadcrumb
         declined → reason 을 warning 으로 propagate, 기존 unsupported skeleton
```

### 추가

- `backend.Stage0FallbackEnv = "OSTY_STAGE0_FALLBACK"` 상수.
- `backend.Stage0FallbackEnabled()` — `1` / `true` / `yes` / `on` (대소문자 변형 허용).
- 패키지-level `tryStage0Fallback` 변수 (테스트가 stub 가능).
- `emitLLVMFallback` 의 declined 분기에서 `IsOstySelfMissing(nativeWarnings)` 검사 후 stage0 호출.
  - 성공 시: IR 반환 + `"stage0 fallback: emitted MIR through bootstrap-only path"` warning 첨부.
  - 거부 시: `"stage0 fallback declined: <reason>"` 를 warnings 로 propagate, 기존 `Unsupported("mir-emit", ...)` 진단으로 떨어짐.

### 게이트 조건 (모두 만족해야 stage0 실행)

1. `OSTY_STAGE0_FALLBACK` 환경변수가 truthy.
2. native LIR Proto 가 declined (`ok=false`).
3. native 의 warnings 가 `"osty-self not found"` 신호 포함.

세 조건 중 하나라도 빠지면 stage0 는 호출 안 됨. **production 빌드 (osty-self 빌드 완료) 는 native 가 성공하므로 stage0 unreachable**.

### 테스트 +7

- `Stage0FallbackDisabledByDefault` — env 미설정 → false.
- `Stage0FallbackEnabledRespectsEnvVar` — 9개 변형 테이블 (subtests).
- `EmitLLVMFallbackUsesStage0WhenOstySelfMissing` — 환경 ON + osty-self-missing → stage0 호출 + IR 출력 + breadcrumb.
- `EmitLLVMFallbackSkipsStage0WhenEnvNotSet` — 환경 OFF → stage0 미호출.
- `EmitLLVMFallbackSkipsStage0WhenDeclineNotOstySelf` — 환경 ON 이지만 decline 사유가 다름 → stage0 미호출.
- `EmitLLVMFallbackBubblesUpStage0Decline` — 환경 ON + osty-self-missing 인데 stage0 도 declined → reason breadcrumb.
- `EmitLLVMFallbackPrefersNativeWhenItCovers` — native 성공 시 stage0 미호출.
- `Stage0FallbackSurvivesBinaryEmitPath` — `Emit(EmitBinary)` 경로 통해 stage0 IR 이 toolchain compile 까지 도달.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/...` — 0 fail (stage0 80 + 새 wiring 7 + 기존 backend 통과)

## Notes

- 본 PR 로 stage0 가 처음으로 실제 디스패처에서 호출 가능. 다만 **default 동작 변경 없음** — 환경변수가 OFF 인 한 production 빌드는 동일.
- 다음 (P5): 실제 `toolchain/*.osty` MIR 일부를 stage0 로 컴파일해서 어떤 패턴이 stage0 surface 에서 추가로 필요한지 식별. P2~P3 의 패턴이 충분한지 실측.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_