### PR TITLE
feat(backend/stage0): real-MIR integration probe + UnitConst/StorageLive gaps (P5)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -166,7 +166,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P3b | 함수 호출 (CallInstr → LLVM `call`) — direct FnRef, scalar args/return, in-module symbol | 70 tests — **구현 완료** |
 | P3c | if-else (4-block: entry/then/else/merge + BranchTerm + GotoTerm + phi for ret) | 80 tests — **구현 완료** |
 | P4 | 디스패처 wiring (`OSTY_STAGE0_FALLBACK=1` + `IsOstySelfMissing` 조건부 라우팅) | TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing — **구현 완료** |
-| P5+ | toolchain 의 첫 N개 함수 lowering 통과 | toolchain/main.osty 부분 빌드 |
+| P5 | real front-end → MIR 통합 probe + UnitConst / StorageLive / StorageDead 갭 봉합 | TestStage0RealMIRBaseline 12 cases — **구현 완료** |
+| P6+ | while / for / 호출 연쇄 / struct field / list / println 등 다음 패턴 batch | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -125,6 +125,11 @@ func emitTrivialMain(out *strings.Builder, fn *mir.Function) error {
 	return nil
 }
 
+// trivialMainViolation accepts the canonical empty-body shape produced
+// by the front-end for `fn main() {}`. The body may contain zero or
+// one AssignInstr that writes a UnitConst to the return local — the
+// front-end emits that exact instruction even when the source body is
+// empty, since `()` is the implicit return value.
 func trivialMainViolation(fn *mir.Function) string {
 	if fn.Name != "main" {
 		return "stage0 expected `main`; saw " + fn.Name
@@ -139,13 +144,42 @@ func trivialMainViolation(fn *mir.Function) string {
 	if bb == nil {
 		return "main entry block is nil"
 	}
-	if len(bb.Instrs) != 0 {
-		return fmt.Sprintf("main entry block has %d instructions; stage0 expects 0", len(bb.Instrs))
+	switch len(bb.Instrs) {
+	case 0:
+		// Bare empty body — accept.
+	case 1:
+		if !isUnitAssignToReturnLocal(bb.Instrs[0], fn.ReturnLocal) {
+			return fmt.Sprintf("main entry block has 1 instruction (%T); stage0 expects an empty body or a single Unit assignment", bb.Instrs[0])
+		}
+	default:
+		return fmt.Sprintf("main entry block has %d instructions; stage0 expects 0 or 1", len(bb.Instrs))
 	}
 	if _, ok := bb.Term.(*mir.ReturnTerm); !ok {
 		return fmt.Sprintf("main terminator is %T; stage0 expects ReturnTerm", bb.Term)
 	}
 	return ""
+}
+
+// isUnitAssignToReturnLocal reports whether `instr` is the canonical
+// `ret = ()` AssignInstr the front-end emits for empty-body main.
+func isUnitAssignToReturnLocal(instr mir.Instr, ret mir.LocalID) bool {
+	ai, ok := instr.(*mir.AssignInstr)
+	if !ok {
+		return false
+	}
+	if ai.Dest.Local != ret || ai.Dest.HasProjections() {
+		return false
+	}
+	use, ok := ai.Src.(*mir.UseRV)
+	if !ok {
+		return false
+	}
+	con, ok := use.Op.(*mir.ConstOp)
+	if !ok {
+		return false
+	}
+	_, ok = con.Const.(*mir.UnitConst)
+	return ok
 }
 
 // ---- sequential single-block return ----
@@ -311,6 +345,10 @@ func matchSequentialReturn(fn *mir.Function, knownSymbols map[string]bool) (sequ
 			pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
 		case *mir.CallInstr:
 			pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+		case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+			// Storage liveness markers carry no LLVM-visible semantics
+			// for stage0. Skip them and move to the next instruction.
+			continue
 		default:
 			return pat, false
 		}
@@ -851,6 +889,10 @@ func applyStep(fn *mir.Function, instr mir.Instr, bindings map[mir.LocalID]local
 		pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
 	case *mir.CallInstr:
 		pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+		// Storage liveness markers are opt-in metadata; stage0
+		// has nothing to emit for them.
+		return true
 	default:
 		return false
 	}

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -1,0 +1,271 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/backend/stage0"
+	"github.com/osty/osty/internal/llvmabi"
+)
+
+// realStage0Run compiles `src` through the full front-end (parse →
+// resolve → check → IR → MIR) and feeds the resulting MIR to the
+// stage0 emitter. The returned error is non-nil whenever stage0
+// declines so the test can either assert acceptance or log a
+// reproducible gap report for the next bootstrap phase.
+func realStage0Run(t *testing.T, src string) ([]byte, error) {
+	t.Helper()
+	req := newBackendRequest(t, EmitLLVMIR, src)
+	if req.Entry.MIR == nil {
+		t.Fatal("entry.MIR was nil — front-end did not lower")
+	}
+	return stage0.EmitMIR(req.Entry.MIR, llvmabi.Options{PackageName: req.Entry.PackageName})
+}
+
+// dumpMIRGap is the canonical "stage0 missed a real-MIR shape" log
+// helper. Each call prints the function-by-function MIR shape so the
+// next bootstrap phase has a copy-pasteable description of the gap.
+func dumpMIRGap(t *testing.T, src string, err error) {
+	t.Helper()
+	t.Logf("stage0 declined real MIR — bootstrap gap")
+	t.Logf("  source: %q", src)
+	t.Logf("  reason: %v", err)
+	req := newBackendRequest(t, EmitLLVMIR, src)
+	if req.Entry.MIR == nil {
+		return
+	}
+	for i, fn := range req.Entry.MIR.Functions {
+		if fn == nil {
+			continue
+		}
+		t.Logf("  fn[%d] %q params=%d locals=%d blocks=%d", i, fn.Name, len(fn.Params), len(fn.Locals), len(fn.Blocks))
+		for j, bb := range fn.Blocks {
+			if bb == nil {
+				continue
+			}
+			t.Logf("    bb[%d] id=%d instrs=%d term=%T", j, bb.ID, len(bb.Instrs), bb.Term)
+			for k, instr := range bb.Instrs {
+				t.Logf("      instr[%d] %T", k, instr)
+			}
+		}
+	}
+}
+
+// realProbeCase pairs a source snippet with the LLVM substring(s) we
+// expect when stage0 covers it. When `skipNow` is true the test logs
+// the gap rather than failing — useful as a discovery harness for
+// future bootstrap phases.
+type realProbeCase struct {
+	name    string
+	src     string
+	wantIR  []string
+	skipNow bool
+}
+
+func TestStage0RealMIRBaseline(t *testing.T) {
+	// These cases work today — they cover the P1~P3c surface against
+	// real front-end MIR output (rather than synthetic structs).
+	// Keep them green: any regression here means stage0 stopped
+	// matching what the front-end actually emits.
+	cases := []realProbeCase{
+		{
+			name: "main_empty_body",
+			src:  `fn main() {}`,
+			wantIR: []string{
+				"define i32 @main()",
+				"ret i32 0",
+			},
+		},
+		{
+			name: "int_literal_return",
+			src: `fn answer() -> Int { 42 }
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @answer()",
+				"ret i64 42",
+			},
+		},
+		{
+			name: "negative_int_literal",
+			src: `fn neg() -> Int { -1 }
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @neg()",
+				"ret i64 -1",
+			},
+		},
+		{
+			name: "bool_literal_true",
+			src: `fn yes() -> Bool { true }
+fn main() {}`,
+			wantIR: []string{
+				"define i1 @yes()",
+				"ret i1 true",
+			},
+		},
+		{
+			name: "param_passthrough",
+			src: `fn id(x: Int) -> Int { x }
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @id(i64 %x)",
+				"ret i64 %x",
+			},
+		},
+		{
+			name: "binary_add",
+			src: `fn add(a: Int, b: Int) -> Int { a + b }
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @add(i64 %a, i64 %b)",
+				"add i64",
+			},
+		},
+		{
+			name: "binary_sub",
+			src: `fn diff(a: Int, b: Int) -> Int { a - b }
+fn main() {}`,
+			wantIR: []string{
+				"sub i64",
+			},
+		},
+		{
+			name: "binary_mul",
+			src: `fn prod(a: Int, b: Int) -> Int { a * b }
+fn main() {}`,
+			wantIR: []string{
+				"mul i64",
+			},
+		},
+		{
+			name: "comparison_lt",
+			src: `fn lt(a: Int, b: Int) -> Bool { a < b }
+fn main() {}`,
+			wantIR: []string{
+				"icmp slt i64",
+				"ret i1",
+			},
+		},
+		{
+			name: "if_else_const",
+			src: `fn sign(x: Int) -> Int { if x > 0 { 1 } else { -1 } }
+fn main() {}`,
+			wantIR: []string{
+				"icmp sgt",
+				"phi i64",
+			},
+		},
+		{
+			name: "let_then_use",
+			src: `fn double(x: Int) -> Int {
+    let y = x
+    y + y
+}
+fn main() {}`,
+			wantIR: []string{
+				"add i64 %x, %x",
+			},
+		},
+		{
+			name: "function_call",
+			src: `fn add(a: Int, b: Int) -> Int { a + b }
+fn caller() -> Int { add(1, 2) }
+fn main() {}`,
+			wantIR: []string{
+				"call i64 @add(i64 1, i64 2)",
+			},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got, err := realStage0Run(t, c.src)
+			if err != nil {
+				dumpMIRGap(t, c.src, err)
+				t.Fatalf("stage0 declined %q: %v", c.name, err)
+			}
+			for _, want := range c.wantIR {
+				if !strings.Contains(string(got), want) {
+					t.Errorf("emitted IR for %q missing %q:\n%s", c.name, want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestStage0RealMIRGapProbe records known-gap shapes — patterns we
+// suspect stage0 cannot handle yet. When skipNow=true the test logs
+// the gap reason and skips. As future bootstrap phases extend
+// coverage, flip skipNow=false to lock in the new capability.
+func TestStage0RealMIRGapProbe(t *testing.T) {
+	cases := []realProbeCase{
+		{
+			name:    "while_loop",
+			src:     `fn count_down(n: Int) -> Int {
+    let mut i = n
+    let mut acc = 0
+    while i > 0 {
+        acc = acc + i
+        i = i - 1
+    }
+    acc
+}
+fn main() {}`,
+			skipNow: true,
+		},
+		{
+			name:    "for_in_range",
+			src:     `fn sum(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+fn main() {}`,
+			skipNow: true,
+		},
+		{
+			name:    "println_call",
+			src:     `fn main() { println("hi") }`,
+			skipNow: true,
+		},
+		{
+			name: "struct_field_access",
+			src: `struct Point { x: Int, y: Int }
+fn first(p: Point) -> Int { p.x }
+fn main() {}`,
+			skipNow: true,
+		},
+		{
+			name: "list_literal_len",
+			src: `fn answer() -> Int {
+    let xs: List<Int> = [1, 2, 3]
+    xs.len()
+}
+fn main() {}`,
+			skipNow: true,
+		},
+		{
+			name: "string_literal_return",
+			src: `fn greet() -> String { "hi" }
+fn main() {}`,
+			skipNow: true,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			_, err := realStage0Run(t, c.src)
+			if err == nil {
+				t.Fatalf("stage0 unexpectedly accepted %q — flip skipNow=false and add wantIR assertions", c.name)
+			}
+			if c.skipNow {
+				dumpMIRGap(t, c.src, err)
+				t.Skipf("known stage0 gap %q (recorded for future bootstrap phase)", c.name)
+				return
+			}
+			t.Fatalf("stage0 declined %q: %v", c.name, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

P1-P4 까지 stage0 는 **합성 MIR** (테스트가 손으로 만든 `mir.Function` 구조체) 로만 검증해 왔다. **P5 는 처음으로 front-end → MIR → stage0 전체 경로를 실제 Osty 소스로 검증** 한다.

### Real-MIR baseline (12 cases, 모두 통과)

```osty
fn main() {}
fn answer() -> Int { 42 }
fn neg() -> Int { -1 }
fn yes() -> Bool { true }
fn id(x: Int) -> Int { x }
fn add(a: Int, b: Int) -> Int { a + b }
fn diff(a: Int, b: Int) -> Int { a - b }
fn prod(a: Int, b: Int) -> Int { a * b }
fn lt(a: Int, b: Int) -> Bool { a < b }
fn sign(x: Int) -> Int { if x > 0 { 1 } else { -1 } }
fn double(x: Int) -> Int { let y = x; y + y }
fn caller() -> Int { add(1, 2) }
```

모두 stage0 가 emit 성공 + 기대 LLVM 패턴 (`define i64 @add(...)`, `icmp slt i64`, `phi i64`, `call i64 @add`, …) 출력 확인.

### Known-gap probe (6 cases, skipNow 처리)

While / for / println / struct field access / list literal / String literal — 다음 phase 가 cover 할 미구현 영역. 각 케이스마다 stage0 가 declined 했음을 명시적으로 어서트하고 (현재 동작 보존), MIR shape 을 로그에 dump 해서 다음 phase 가 가져갈 수 있도록 기록.

### Probe 가 발견한 두 개의 실제 갭 (같은 PR 에서 봉합)

**1. UnitConst-in-main**
- `fn main() {}` 의 front-end 출력은 빈 블록이 아니라 `AssignInstr{ret = UseRV{ConstOp{UnitConst}}}` 한 줄을 포함.
- `trivialMainViolation` 이 0 instructions 만 받아서 거부.
- 봉합: 0 또는 1 (Unit 대입) 모두 받도록 완화 + `isUnitAssignToReturnLocal` 헬퍼 추가.

**2. StorageLiveInstr / StorageDeadInstr**
- 변수 lifetime 마커. front-end 가 `let` 바인딩에 동반 emit.
- `mir.go` 주석상 "backends that do not care may ignore it" → stage0 도 무시하면 됨.
- 봉합: `matchSequentialReturn` instruction 루프와 `applyStep` (if-else 헬퍼) 둘 다에서 storage instructions 는 silent skip.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 80 PASS (기존), 0 fail
- [x] `go test ./internal/backend/...` 0 fail. real-MIR probe 통합 (baseline 12 PASS + gap probe 6 SKIP).

## Notes

- 디스패처 wiring 영향 0. real-MIR probe 는 stage0 emitter 를 직접 호출 (env-var 게이트 없이).
- Real-MIR probe 는 이후 phase 가 새 패턴 추가할 때 실제 front-end 출력에 대한 회귀 게이트로 작동.
- 다음 (P6+): gap probe 의 6개 카테고리 중 하나 (while loop / for-in-range / println / struct field / list ops / String literal). while + for 가 가장 큰 ROI 일 것으로 예상 — toolchain 코드가 광범위하게 사용.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_