### PR TITLE
feat(backend/stage0): for-in-range loop (5-block shape) (P7)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -168,7 +168,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P4 | 디스패처 wiring (`OSTY_STAGE0_FALLBACK=1` + `IsOstySelfMissing` 조건부 라우팅) | TestEmitLLVMFallbackUsesStage0WhenOstySelfMissing — **구현 완료** |
 | P5 | real front-end → MIR 통합 probe + UnitConst / StorageLive / StorageDead 갭 봉합 | TestStage0RealMIRBaseline 12 cases — **구현 완료** |
 | P6 | while loop (4-block entry/header/body/exit + back-edge) + alloca/store/load 가변 local | TestStage0EmitsCountToWhileLoop / while_loop_count real-MIR — **구현 완료** |
-| P7+ | for / println / struct field / list / String literal | toolchain/main.osty 부분 빌드 |
+| P7 | for-in-range loop (5-block entry/header/body/post/exit) — while alloca 인프라 재사용 | for_in_range_sum real-MIR — **구현 완료** |
+| P8+ | println / struct field / list / String literal | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -112,6 +112,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, knownSymbols map[strin
 	if pat, ok := matchWhileLoopReturn(fn, knownSymbols); ok {
 		return emitWhileLoopReturn(out, fn, pat)
 	}
+	if pat, ok := matchForInRangeReturn(fn, knownSymbols); ok {
+		return emitForInRangeReturn(out, fn, pat)
+	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
 
@@ -1505,6 +1508,238 @@ func emitWhileLoopReturn(out *strings.Builder, fn *mir.Function, pat whileLoopPa
 	fmt.Fprintf(out, "  br label %%%s\n", pat.headerLabel)
 
 	// Exit.
+	out.WriteString("\n")
+	fmt.Fprintf(out, "%s:\n", pat.exitLabel)
+	out.WriteString(pat.exitBody)
+	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.finalRetExpr)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P7: for-in-range loop (5-block shape) ----
+//
+// The front-end lowers `for i in 0..n { body }` to a 5-block CFG:
+//
+//	entry    : pre-loop init (acc/i/_end) + GotoTerm(header)
+//	header   : cond = i < _end + BranchTerm(cond, body, exit)
+//	body     : loop body + GotoTerm(post)
+//	post     : i = i + 1 + GotoTerm(header)         ← back-edge
+//	exit     : post-loop instructions + ReturnTerm
+//
+// Stage0 P7 reuses the alloca/store/load machinery introduced in P6;
+// all mutable locals (the iterator + any user mut-bindings touched by
+// the body) become alloca slots. The pattern differs from `while`
+// only in the extra `post` block sitting between body and back-edge.
+
+type forInRangePattern struct {
+	retType    scalarType
+	paramIDs   []mir.LocalID
+	paramTypes []scalarType
+	paramNames []string
+	stackDecls []stackDecl
+
+	entryBody  string
+	headerBody string
+	bodyBody   string
+	postBody   string
+	exitBody   string
+
+	headerCondExpr string
+	finalRetExpr   string
+
+	headerLabel string
+	bodyLabel   string
+	postLabel   string
+	exitLabel   string
+}
+
+func matchForInRangeReturn(fn *mir.Function, knownSymbols map[string]bool) (forInRangePattern, bool) {
+	pat := forInRangePattern{}
+	pat.retType = scalarFromType(fn.ReturnType)
+	if pat.retType == scalarUnknown {
+		return pat, false
+	}
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	if len(fn.Blocks) != 5 {
+		return pat, false
+	}
+
+	// Param SSA registers.
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		pt := scalarFromType(loc.Type)
+		if pt == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = pt
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	// Block layout: entry → header → (body → post → header | exit).
+	entry := blockByID(fn, fn.Entry)
+	if entry == nil {
+		return pat, false
+	}
+	entryGoto, ok := entry.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	header := blockByID(fn, entryGoto.Target)
+	if header == nil || header.ID == entry.ID {
+		return pat, false
+	}
+	branch, ok := header.Term.(*mir.BranchTerm)
+	if !ok {
+		return pat, false
+	}
+	body := blockByID(fn, branch.Then)
+	exit := blockByID(fn, branch.Else)
+	if body == nil || exit == nil {
+		return pat, false
+	}
+	bodyGoto, ok := body.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	post := blockByID(fn, bodyGoto.Target)
+	if post == nil {
+		return pat, false
+	}
+	if post.ID == header.ID || post.ID == body.ID || post.ID == exit.ID || post.ID == entry.ID {
+		return pat, false
+	}
+	postGoto, ok := post.Term.(*mir.GotoTerm)
+	if !ok || postGoto.Target != header.ID {
+		return pat, false
+	}
+	if _, ok := exit.Term.(*mir.ReturnTerm); !ok {
+		return pat, false
+	}
+
+	// Stack-allocate every Mut local that isn't param/return.
+	stack := map[mir.LocalID]stackDecl{}
+	for _, l := range fn.Locals {
+		if l == nil || l.IsParam || l.IsReturn || !l.Mut {
+			continue
+		}
+		ty := scalarFromType(l.Type)
+		if ty == scalarUnknown {
+			return pat, false
+		}
+		decl := stackDecl{id: l.ID, name: sanitizeLLVMName(l.Name, fmt.Sprintf("local%d", l.ID)) + ".slot", ty: ty}
+		stack[l.ID] = decl
+		pat.stackDecls = append(pat.stackDecls, decl)
+	}
+
+	bindings := map[mir.LocalID]localBinding{}
+	for i, pid := range fn.Params {
+		bindings[pid] = localBinding{
+			expr:    "%" + pat.paramNames[i],
+			ty:      pat.paramTypes[i],
+			defined: true,
+		}
+	}
+	for _, sd := range pat.stackDecls {
+		bindings[sd.id] = localBinding{
+			expr:    "%" + sd.name,
+			ty:      sd.ty,
+			defined: true,
+			isStack: true,
+		}
+	}
+
+	nextSSA := 0
+	ctx := &whileLoopEmitCtx{
+		fn:           fn,
+		bindings:     bindings,
+		stack:        stack,
+		knownSymbols: knownSymbols,
+		nextSSA:      &nextSSA,
+	}
+
+	// entry
+	if body, ok := emitWhileBlock(ctx, entry, false); ok {
+		pat.entryBody = body
+	} else {
+		return pat, false
+	}
+	// header
+	condExpr, headerBody, ok := emitWhileHeader(ctx, header, branch.Cond)
+	if !ok {
+		return pat, false
+	}
+	pat.headerBody = headerBody
+	pat.headerCondExpr = condExpr
+	// body
+	if body, ok := emitWhileBlock(ctx, body, false); ok {
+		pat.bodyBody = body
+	} else {
+		return pat, false
+	}
+	// post (increment)
+	if post, ok := emitWhileBlock(ctx, post, false); ok {
+		pat.postBody = post
+	} else {
+		return pat, false
+	}
+	// exit
+	if exitBody, finalExpr, ok := emitWhileExit(ctx, exit, fn.ReturnLocal, pat.retType); ok {
+		pat.exitBody = exitBody
+		pat.finalRetExpr = finalExpr
+	} else {
+		return pat, false
+	}
+
+	pat.headerLabel = blockLabelName(header.ID, "header")
+	pat.bodyLabel = blockLabelName(body.ID, "body")
+	pat.postLabel = blockLabelName(post.ID, "post")
+	pat.exitLabel = blockLabelName(exit.ID, "exit")
+	return pat, true
+}
+
+func emitForInRangeReturn(out *strings.Builder, fn *mir.Function, pat forInRangePattern) error {
+	retLLVM := pat.retType.llvm()
+	fmt.Fprintf(out, "define %s @%s(", retLLVM, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+
+	out.WriteString("entry:\n")
+	for _, sd := range pat.stackDecls {
+		fmt.Fprintf(out, "  %%%s = alloca %s\n", sd.name, sd.ty.llvm())
+	}
+	out.WriteString(pat.entryBody)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.headerLabel)
+
+	out.WriteString("\n")
+	fmt.Fprintf(out, "%s:\n", pat.headerLabel)
+	out.WriteString(pat.headerBody)
+	fmt.Fprintf(out, "  br i1 %s, label %%%s, label %%%s\n", pat.headerCondExpr, pat.bodyLabel, pat.exitLabel)
+
+	out.WriteString("\n")
+	fmt.Fprintf(out, "%s:\n", pat.bodyLabel)
+	out.WriteString(pat.bodyBody)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.postLabel)
+
+	out.WriteString("\n")
+	fmt.Fprintf(out, "%s:\n", pat.postLabel)
+	out.WriteString(pat.postBody)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.headerLabel)
+
 	out.WriteString("\n")
 	fmt.Fprintf(out, "%s:\n", pat.exitLabel)
 	out.WriteString(pat.exitBody)

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -197,6 +197,34 @@ fn main() {}`,
 				"ret i64",
 			},
 		},
+		{
+			name: "for_in_range_sum",
+			src: `fn sum(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @sum(i64 %n)",
+				"%acc.slot = alloca i64",
+				"%i.slot = alloca i64",
+				"store i64 0, ptr %acc.slot",
+				"store i64 0, ptr %i.slot",
+				"br label %header.1",
+				"icmp slt i64",
+				"br i1",
+				"add i64",
+				"br label %post.3",
+				"post.3:",
+				"add i64",
+				"store i64",
+				"br label %header.1",
+				"ret i64",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -221,18 +249,6 @@ fn main() {}`,
 // coverage, flip skipNow=false to lock in the new capability.
 func TestStage0RealMIRGapProbe(t *testing.T) {
 	cases := []realProbeCase{
-		{
-			name:    "for_in_range",
-			src:     `fn sum(n: Int) -> Int {
-    let mut acc = 0
-    for i in 0..n {
-        acc = acc + i
-    }
-    acc
-}
-fn main() {}`,
-			skipNow: true,
-		},
 		{
 			name:    "println_call",
 			src:     `fn main() { println("hi") }`,


### PR DESCRIPTION
## Summary

front-end 가 `for i in 0..n { body }` 를 5-블록 CFG 로 lowering. P6 의 while-loop alloca 인프라를 그대로 재사용해서 한 블록 더 (`post`) 다루는 매처를 추가.

```osty
fn sum(n: Int) -> Int {
    let mut acc = 0
    for i in 0..n {
        acc = acc + i
    }
    acc
}
```

→
```llvm
define i64 @sum(i64 %n) {
entry:
  %acc.slot = alloca i64
  %i.slot = alloca i64
  store i64 0, ptr %acc.slot
  store i64 0, ptr %i.slot
  ; ... (also stores n into _end.slot)
  br label %header.1

header.1:
  ; cond = i < _end
  %0 = load i64, ptr %i.slot
  %1 = load i64, ptr %_end.slot
  %2 = icmp slt i64 %0, %1
  br i1 %2, label %body.2, label %exit.4

body.2:
  ; acc = acc + i
  ...
  br label %post.3

post.3:
  ; i = i + 1
  ...
  br label %header.1                ← back-edge

exit.4:
  ; ret = acc
  ...
  ret i64 ...
}
```

### 5-block shape

```
entry  : pre-loop init (acc / i / _end) + GotoTerm(header)
header : cond = i < _end + BranchTerm(cond, body, exit)
body   : loop body + GotoTerm(post)
post   : i = i + 1 + GotoTerm(header)         ← back-edge
exit   : post-loop instructions + ReturnTerm
```

P6 의 while-loop 매처와 다른 점:
- body 가 GotoTerm(post) 로 끝남 (while 은 GotoTerm(header)).
- 새 `post` 블록이 increment 를 담당하고 GotoTerm(header) 로 back-edge.

### 구현

- 새 타입 `forInRangePattern`, 새 함수 `matchForInRangeReturn` / `emitForInRangeReturn`.
- alloca/store/load 인프라 (`whileLoopEmitCtx`, `emitWhileBlock`, `emitWhileHeader`, `emitWhileExit`, `resolveOperandWithLoad`) 는 P6 그대로 재사용.
- `post` 블록은 일반 `emitWhileBlock` 으로 처리 (header / body 와 동등).

### 테스트

- real-MIR baseline 에 `for_in_range_sum` 케이스 추가. front-end MIR → stage0 → 기대 LLVM 패턴 직접 검증.
- known-gap probe 에서 `for_in_range` 제거.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 14/14 통과 (gap probe 4 SKIP)

## Notes

- 디스패처 wiring 영향 0. P4 의 `OSTY_STAGE0_FALLBACK` 게이트 그대로.
- 다음 (P8): println intrinsic / struct field access / list literal / String literal — runtime ABI 호출이 필요해서 declare 처리부터 시작.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_