### PR TITLE
feat(backend/stage0): println(Int) intrinsic via printf (P8)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -169,7 +169,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P5 | real front-end → MIR 통합 probe + UnitConst / StorageLive / StorageDead 갭 봉합 | TestStage0RealMIRBaseline 12 cases — **구현 완료** |
 | P6 | while loop (4-block entry/header/body/exit + back-edge) + alloca/store/load 가변 local | TestStage0EmitsCountToWhileLoop / while_loop_count real-MIR — **구현 완료** |
 | P7 | for-in-range loop (5-block entry/header/body/post/exit) — while alloca 인프라 재사용 | for_in_range_sum real-MIR — **구현 완료** |
-| P8+ | println / struct field / list / String literal | toolchain/main.osty 부분 빌드 |
+| P8 | println(Int) intrinsic — printf declare + format string global + IntrinsicInstr 처리 | println_int_param / println_const_in_loop real-MIR — **구현 완료** |
+| P9+ | struct field access / list literal / String literal / 더 많은 intrinsic family | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -75,6 +75,14 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 		knownSymbols[fn.Name] = true
 	}
 
+	// Scan every instruction for intrinsic usage so we know which
+	// runtime declarations / globals to emit at module top.
+	needsPrintlnInt := scanNeedsPrintlnInt(module)
+	if needsPrintlnInt {
+		out.WriteString("@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"\n")
+		out.WriteString("declare i32 @printf(ptr, ...)\n\n")
+	}
+
 	emittedMain := false
 	for _, fn := range module.Functions {
 		if fn == nil {
@@ -91,6 +99,36 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 		return nil, fmt.Errorf("%w: module has no `main` function", ErrUnsupported)
 	}
 	return []byte(out.String()), nil
+}
+
+// scanNeedsPrintlnInt reports whether any function in `module`
+// invokes `println(Int)` (the IntrinsicPrintln intrinsic with a
+// single Int-typed argument). The result drives whether stage0
+// emits the `@printf` declaration + format string at module top.
+func scanNeedsPrintlnInt(module *mir.Module) bool {
+	for _, fn := range module.Functions {
+		if fn == nil {
+			continue
+		}
+		for _, bb := range fn.Blocks {
+			if bb == nil {
+				continue
+			}
+			for _, instr := range bb.Instrs {
+				intr, ok := instr.(*mir.IntrinsicInstr)
+				if !ok || intr.Kind != mir.IntrinsicPrintln {
+					continue
+				}
+				if len(intr.Args) != 1 {
+					continue
+				}
+				if scalarFromType(intr.Args[0].Type()) == scalarInt {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func emitFunction(out *strings.Builder, fn *mir.Function, knownSymbols map[string]bool) error {
@@ -254,7 +292,7 @@ type pendingInstr struct {
 	destLocal  mir.LocalID
 	resultType scalarType
 	// SSA register pre-assigned at match time. Always set for
-	// instrBinary / instrCall; empty for instrInline.
+	// instrBinary / instrCall; empty for instrInline / instrIntrinsic.
 	binDestReg string
 	// binary fields
 	binOp      string
@@ -264,6 +302,9 @@ type pendingInstr struct {
 	// call fields
 	callSymbol string
 	callArgs   []callArg
+	// intrinsic fields — pre-rendered LLVM line that the emitter
+	// writes verbatim. Used for IntrinsicPrintln (and future kinds).
+	intrinsicLine string
 }
 
 type callArg struct {
@@ -277,7 +318,32 @@ const (
 	instrInline instrKind = iota
 	instrBinary
 	instrCall
+	instrIntrinsic
 )
+
+// classifyIntrinsicLine pre-renders the LLVM line for an
+// IntrinsicInstr that doesn't bind a local (e.g., println). Returns
+// (line, true) on success; declines for unsupported intrinsics or
+// shape mismatches. Operand resolution uses the SSA-only `bindings`
+// path — stack-backed locals are not visible here (they live in the
+// while-loop matcher).
+func classifyIntrinsicLine(ii *mir.IntrinsicInstr, bindings map[mir.LocalID]localBinding) (string, bool) {
+	if ii.Dest != nil {
+		return "", false
+	}
+	switch ii.Kind {
+	case mir.IntrinsicPrintln:
+		if len(ii.Args) != 1 {
+			return "", false
+		}
+		expr, ty, ok := resolveOperand(ii.Args[0], bindings)
+		if !ok || ty != scalarInt {
+			return "", false
+		}
+		return fmt.Sprintf("  call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64 %s)\n", expr), true
+	}
+	return "", false
+}
 
 // sequentialPattern is what `matchSequentialReturn` produces.
 type sequentialPattern struct {
@@ -355,6 +421,13 @@ func matchSequentialReturn(fn *mir.Function, knownSymbols map[string]bool) (sequ
 			pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
 		case *mir.CallInstr:
 			pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+		case *mir.IntrinsicInstr:
+			line, okIntr := classifyIntrinsicLine(step, bindings)
+			if !okIntr {
+				return pat, false
+			}
+			pat.pending = append(pat.pending, pendingInstr{kind: instrIntrinsic, intrinsicLine: line})
+			continue
 		case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
 			// Storage liveness markers carry no LLVM-visible semantics
 			// for stage0. Skip them and move to the next instruction.
@@ -573,6 +646,8 @@ func emitSequentialReturn(out *strings.Builder, fn *mir.Function, pat sequential
 				fmt.Fprintf(out, "%s %s", a.ty, a.expr)
 			}
 			out.WriteString(")\n")
+		case instrIntrinsic:
+			out.WriteString(pi.intrinsicLine)
 		}
 	}
 	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.returnExpr)
@@ -835,6 +910,8 @@ func emitBlock(out *strings.Builder, blk blockEmit) {
 				fmt.Fprintf(out, "%s %s", a.ty, a.expr)
 			}
 			out.WriteString(")\n")
+		case instrIntrinsic:
+			out.WriteString(pi.intrinsicLine)
 		}
 	}
 }
@@ -899,6 +976,13 @@ func applyStep(fn *mir.Function, instr mir.Instr, bindings map[mir.LocalID]local
 		pending, expr, destID, destType, okStep = classifyAssignStep(fn, step, bindings)
 	case *mir.CallInstr:
 		pending, destID, destType, okStep = classifyCallStep(fn, step, bindings, knownSymbols)
+	case *mir.IntrinsicInstr:
+		line, okIntr := classifyIntrinsicLine(step, bindings)
+		if !okIntr {
+			return false
+		}
+		emit.pending = append(emit.pending, pendingInstr{kind: instrIntrinsic, intrinsicLine: line})
+		return true
 	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
 		// Storage liveness markers are opt-in metadata; stage0
 		// has nothing to emit for them.
@@ -1291,7 +1375,34 @@ func emitWhileStep(ctx *whileLoopEmitCtx, out *strings.Builder, instr mir.Instr)
 		return emitWhileAssign(ctx, out, step)
 	case *mir.CallInstr:
 		return emitWhileCall(ctx, out, step)
+	case *mir.IntrinsicInstr:
+		return emitWhileIntrinsic(ctx, out, step)
 	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+		return true
+	}
+	return false
+}
+
+// emitWhileIntrinsic handles the small set of intrinsics stage0
+// understands inside any block (entry / header / body / post / exit).
+// Currently the only supported intrinsic is `IntrinsicPrintln` with a
+// single Int-typed argument; everything else declines.
+func emitWhileIntrinsic(ctx *whileLoopEmitCtx, out *strings.Builder, ii *mir.IntrinsicInstr) bool {
+	if ii.Dest != nil {
+		// Stage0 only handles intrinsics whose result is unit
+		// (no destination). Println / abort / etc. fit this shape.
+		return false
+	}
+	switch ii.Kind {
+	case mir.IntrinsicPrintln:
+		if len(ii.Args) != 1 {
+			return false
+		}
+		expr, ty, ok := resolveOperandWithLoad(ctx, out, ii.Args[0])
+		if !ok || ty != scalarInt {
+			return false
+		}
+		fmt.Fprintf(out, "  call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64 %s)\n", expr)
 		return true
 	}
 	return false

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -225,6 +225,37 @@ fn main() {}`,
 				"ret i64",
 			},
 		},
+		{
+			name: "println_int_param",
+			src: `fn show(n: Int) -> Int {
+    println(n)
+    n
+}
+fn main() {}`,
+			wantIR: []string{
+				"declare i32 @printf(ptr, ...)",
+				`@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c"%lld\0A\00"`,
+				"define i64 @show(i64 %n)",
+				"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64 %n)",
+				"ret i64 %n",
+			},
+		},
+		{
+			name: "println_const_in_loop",
+			src: `fn shout(n: Int) -> Int {
+    let mut acc = 0
+    while acc < n {
+        println(acc)
+        acc = acc + 1
+    }
+    acc
+}
+fn main() {}`,
+			wantIR: []string{
+				"declare i32 @printf(ptr, ...)",
+				"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64 ",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -250,7 +281,10 @@ fn main() {}`,
 func TestStage0RealMIRGapProbe(t *testing.T) {
 	cases := []realProbeCase{
 		{
-			name:    "println_call",
+			// Stage0 P8 only handles `println(Int)`. String-arg
+			// println still declines because there's no String
+			// runtime ABI yet.
+			name:    "println_string_arg",
 			src:     `fn main() { println("hi") }`,
 			skipNow: true,
 		},


### PR DESCRIPTION
## Summary

front-end 가 `println(n)` 을 `IntrinsicInstr{Dest: nil, Kind: IntrinsicPrintln, Args: [<arg>]}` 로 lowering. stage0 P8 은 **Int 인자 한정** 으로 이를 받아서 LLVM `printf` 호출 한 줄로 emit.

```osty
fn show(n: Int) -> Int {
    println(n)
    n
}
```

→
```llvm
@.fmt.stage0.println.int = private unnamed_addr constant [6 x i8] c"%lld\0A\00"
declare i32 @printf(ptr, ...)

define i64 @show(i64 %n) {
entry:
  call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.int, i64 %n)
  ret i64 %n
}
```

### Module-level 인프라

- `EmitMIR` pre-scan: 모든 IntrinsicInstr 를 훑어 Println(Int) 사용 여부 판정 (`scanNeedsPrintlnInt`).
- 사용 시점에만 module top 에 format string 글로벌 + printf declare 를 emit. 사용 안 하면 깨끗.

### Matcher 통합

- `pendingInstr` 에 새 kind `instrIntrinsic` + `intrinsicLine` (사전 렌더된 LLVM 줄). emitter 가 verbatim 으로 출력.
- `classifyIntrinsicLine` — IntrinsicInstr → LLVM 줄 (Dest=nil + Kind=Println + 단일 Int 인자). 다른 intrinsic / Dest != nil / arg type mismatch 는 decline 으로 다음 phase 에 양보.
- 4가지 매처 모두 IntrinsicInstr 분기 추가:
  - `matchSequentialReturn` 의 인스트럭션 루프
  - `applyStep` (if-else)
  - `emitWhileStep` (while + for-in-range, alloca 컨텍스트)
- `emitBlock` + 시퀀셜 emit 둘 다 instrIntrinsic 케이스 추가.

### Real-MIR 테스트 +2

성공:
- `println_int_param` — `fn show(n: Int) -> Int { println(n); n }` → printf 호출 + ret 검증.
- `println_const_in_loop` — while loop 안에서 println(acc) — alloca/store/load + intrinsic 결합 검증.

Gap probe 의 `println_call` 항목은 `println_string_arg` 로 이름만 갱신 (String 인자는 P9+ 영역).

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 16/16 통과 (gap probe 4 SKIP)

## Notes

- 디스패처 wiring 영향 0. `OSTY_STAGE0_FALLBACK` 게이트 그대로.
- 다음 (P9+): String literal / list literal / struct field access. 각각 별도 intrinsic / 새 타입 surface 가 필요.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_