### PR TITLE
feat(backend/stage0): struct field accessor (P10)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -171,7 +171,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P7 | for-in-range loop (5-block entry/header/body/post/exit) — while alloca 인프라 재사용 | for_in_range_sum real-MIR — **구현 완료** |
 | P8 | println(Int) intrinsic — printf declare + format string global + IntrinsicInstr 처리 | println_int_param / println_const_in_loop real-MIR — **구현 완료** |
 | P9 | String literal return + moduleCtx refactor (string-pool / extraDecls 인프라) | string_literal_return real-MIR — **구현 완료** |
-| P10+ | struct field access / list literal / 더 많은 intrinsic family | toolchain/main.osty 부분 빌드 |
+| P10 | struct field accessor — `fn name(p: Struct) -> T { p.field }` + module-level `%Struct = type {...}` 정의 | struct_field_read_x / struct_field_read_y real-MIR — **구현 완료** |
+| P11+ | list literal / 더 많은 intrinsic family / 더 큰 toolchain 빌드 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -110,16 +110,21 @@ func EmitMIR(module *mir.Module, opts llvmabi.Options) ([]byte, error) {
 // struct layouts, runtime declarations …) can attach without forcing
 // another sweep through all matcher signatures.
 type moduleCtx struct {
+	module       *mir.Module
 	knownSymbols map[string]bool
-	// extraDecls collects module-level lines (declares + globals)
-	// the matchers emit on demand. Concatenated into the final
-	// output before function bodies.
+	// extraDecls collects module-level lines (declares + globals +
+	// struct type defs) the matchers emit on demand. Concatenated
+	// into the final output before function bodies.
 	extraDecls *strings.Builder
 	// stringPool maps string-constant value → assigned global
 	// symbol (without the leading `@`). Lookups are write-once: the
 	// first reference allocates a fresh `@.str.<N>` global.
 	stringPool   map[string]string
 	nextStringID int
+	// emittedStructs records which struct names have been written
+	// to extraDecls already, so multiple functions referencing the
+	// same struct don't duplicate the type definition.
+	emittedStructs map[string]bool
 }
 
 func newModuleCtx(module *mir.Module) *moduleCtx {
@@ -131,10 +136,55 @@ func newModuleCtx(module *mir.Module) *moduleCtx {
 		syms[fn.Name] = true
 	}
 	return &moduleCtx{
-		knownSymbols: syms,
-		extraDecls:   &strings.Builder{},
-		stringPool:   map[string]string{},
+		module:         module,
+		knownSymbols:   syms,
+		extraDecls:     &strings.Builder{},
+		stringPool:     map[string]string{},
+		emittedStructs: map[string]bool{},
 	}
+}
+
+// lookupStructFields returns the scalar field types for the named
+// struct or (nil, false) if the struct isn't in the module's layout
+// table or any field is non-scalar (Int / Bool / String only).
+// Stage0's struct support is intentionally narrow — anything outside
+// the scalar-only subset declines so future phases can decide how to
+// handle aggregates inside structs.
+func (m *moduleCtx) lookupStructFields(name string) ([]scalarType, bool) {
+	if m == nil || m.module == nil || m.module.Layouts == nil {
+		return nil, false
+	}
+	layout, ok := m.module.Layouts.Structs[name]
+	if !ok || layout == nil {
+		return nil, false
+	}
+	tys := make([]scalarType, len(layout.Fields))
+	for i, f := range layout.Fields {
+		st := scalarFromType(f.Type)
+		if st == scalarUnknown {
+			return nil, false
+		}
+		tys[i] = st
+	}
+	return tys, true
+}
+
+// emitStructDef ensures `%<name> = type { ... }` lands in
+// extraDecls exactly once. Subsequent calls with the same name are
+// no-ops.
+func (m *moduleCtx) emitStructDef(name string, fields []scalarType) {
+	if m.emittedStructs[name] {
+		return
+	}
+	m.emittedStructs[name] = true
+	fmt.Fprintf(m.extraDecls, "%%%s = type { ", name)
+	for i, ft := range fields {
+		if i > 0 {
+			m.extraDecls.WriteString(", ")
+		}
+		m.extraDecls.WriteString(ft.llvm())
+	}
+	m.extraDecls.WriteString(" }\n")
 }
 
 // internStringConst interns `value` and returns the LLVM operand
@@ -223,6 +273,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	}
 	if pat, ok := matchForInRangeReturn(fn, mctx); ok {
 		return emitForInRangeReturn(out, fn, pat)
+	}
+	if pat, ok := matchStructFieldRead(fn, mctx); ok {
+		return emitStructFieldRead(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
@@ -1940,6 +1993,108 @@ func emitForInRangeReturn(out *strings.Builder, fn *mir.Function, pat forInRange
 	fmt.Fprintf(out, "%s:\n", pat.exitLabel)
 	out.WriteString(pat.exitBody)
 	fmt.Fprintf(out, "  ret %s %s\n", retLLVM, pat.finalRetExpr)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P10: struct field accessor ----
+//
+// stage0 P10 handles a tightly-restricted "field reader" function:
+//
+//	fn name(p: SomeStruct) -> Int { p.<field> }
+//
+// MIR shape: 1 struct param (NamedType registered in
+// `module.Layouts.Structs`), single block, one AssignInstr writing
+// UseRV{CopyOp{Place: paramID, Projections: [FieldProj]}} to the
+// return local, ReturnTerm. All struct fields must be scalar
+// (Int / Bool / String) — anything outside that subset declines.
+//
+// Output:
+//
+//	%StructName = type { i64, i64, ... }
+//
+//	define i64 @name(%StructName %p) {
+//	entry:
+//	  %0 = extractvalue %StructName %p, <fieldIndex>
+//	  ret i64 %0
+//	}
+
+type structFieldReadPattern struct {
+	structName string
+	fieldTypes []scalarType
+	paramName  string
+	fieldIndex int
+	resultType scalarType
+}
+
+func matchStructFieldRead(fn *mir.Function, mctx *moduleCtx) (structFieldReadPattern, bool) {
+	pat := structFieldReadPattern{}
+	pat.resultType = scalarFromType(fn.ReturnType)
+	if pat.resultType == scalarUnknown {
+		return pat, false
+	}
+	if len(fn.Params) != 1 {
+		return pat, false
+	}
+	paramID := fn.Params[0]
+	paramLocal := lookupLocal(fn, paramID)
+	if paramLocal == nil || !paramLocal.IsParam {
+		return pat, false
+	}
+	named, ok := paramLocal.Type.(*ir.NamedType)
+	if !ok || named == nil || named.Name == "" {
+		return pat, false
+	}
+	fieldTypes, ok := mctx.lookupStructFields(named.Name)
+	if !ok {
+		return pat, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return pat, false
+	}
+	ai, ok := bb.Instrs[0].(*mir.AssignInstr)
+	if !ok {
+		return pat, false
+	}
+	if ai.Dest.Local != fn.ReturnLocal || ai.Dest.HasProjections() {
+		return pat, false
+	}
+	use, ok := ai.Src.(*mir.UseRV)
+	if !ok {
+		return pat, false
+	}
+	cp, ok := use.Op.(*mir.CopyOp)
+	if !ok {
+		return pat, false
+	}
+	if cp.Place.Local != paramID || len(cp.Place.Projections) != 1 {
+		return pat, false
+	}
+	fieldProj, ok := cp.Place.Projections[0].(*mir.FieldProj)
+	if !ok {
+		return pat, false
+	}
+	if fieldProj.Index < 0 || fieldProj.Index >= len(fieldTypes) {
+		return pat, false
+	}
+	if fieldTypes[fieldProj.Index] != pat.resultType {
+		return pat, false
+	}
+	pat.structName = named.Name
+	pat.fieldTypes = fieldTypes
+	pat.paramName = sanitizeLLVMName(paramLocal.Name, "p")
+	pat.fieldIndex = fieldProj.Index
+	mctx.emitStructDef(named.Name, fieldTypes)
+	return pat, true
+}
+
+func emitStructFieldRead(out *strings.Builder, fn *mir.Function, pat structFieldReadPattern) error {
+	resultLLVM := pat.resultType.llvm()
+	fmt.Fprintf(out, "define %s @%s(%%%s %%%s) {\n", resultLLVM, fn.Name, pat.structName, pat.paramName)
+	out.WriteString("entry:\n")
+	fmt.Fprintf(out, "  %%0 = extractvalue %%%s %%%s, %d\n", pat.structName, pat.paramName, pat.fieldIndex)
+	fmt.Fprintf(out, "  ret %s %%0\n", resultLLVM)
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -266,6 +266,28 @@ fn main() {}`,
 				"ret ptr @.str.0",
 			},
 		},
+		{
+			name: "struct_field_read_x",
+			src: `struct Point { x: Int, y: Int }
+fn first(p: Point) -> Int { p.x }
+fn main() {}`,
+			wantIR: []string{
+				"%Point = type { i64, i64 }",
+				"define i64 @first(%Point %p)",
+				"%0 = extractvalue %Point %p, 0",
+				"ret i64 %0",
+			},
+		},
+		{
+			name: "struct_field_read_y",
+			src: `struct Pair { a: Int, b: Int }
+fn second(p: Pair) -> Int { p.b }
+fn main() {}`,
+			wantIR: []string{
+				"%Pair = type { i64, i64 }",
+				"%0 = extractvalue %Pair %p, 1",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -296,13 +318,6 @@ func TestStage0RealMIRGapProbe(t *testing.T) {
 			// runtime ABI yet.
 			name:    "println_string_arg",
 			src:     `fn main() { println("hi") }`,
-			skipNow: true,
-		},
-		{
-			name: "struct_field_access",
-			src: `struct Point { x: Int, y: Int }
-fn first(p: Point) -> Int { p.x }
-fn main() {}`,
 			skipNow: true,
 		},
 		{


### PR DESCRIPTION
## Summary

front-end 가 `struct Point { x: Int, y: Int }` + `fn first(p: Point) -> Int { p.x }` 를 lowering 할 때, `p` 는 `NamedType{Point}` 타입의 param 이고 body 는 `CopyOp{Place: paramID, Projections: [FieldProj]}` 한 줄로 lowering. stage0 P10 은 이 "field reader" 모양 함수를 `extractvalue` 로 emit.

```osty
struct Point { x: Int, y: Int }
fn first(p: Point) -> Int { p.x }
```

→
```llvm
%Point = type { i64, i64 }

define i64 @first(%Point %p) {
entry:
  %0 = extractvalue %Point %p, 0
  ret i64 %0
}
```

### Module-level 인프라

- `moduleCtx` 에 `module *mir.Module` + `emittedStructs map[string]bool` 추가.
- `lookupStructFields(name)` — `module.Layouts.Structs` 에서 layout 가져와 모든 필드가 scalar (Int / Bool / String) 인지 검사. 한 필드라도 비-scalar 면 declined.
- `emitStructDef(name, fields)` — `extraDecls` 에 `%<name> = type { ... }` 를 한 번만 emit (idempotent).

### Pattern

- `matchStructFieldRead` — 정확히 1 struct param + 단일 AssignInstr + ReturnTerm 모양만 받음. `CopyOp` 의 Projection 이 정확히 1개의 `FieldProj` 이고 dest local 의 타입과 field 타입이 일치해야 함. 매치 시 `emitStructDef` 호출로 module-level type def 등록.
- `emitStructFieldRead` — function header 가 `%<Struct> %<param>` 으로 struct param 받고, body 한 줄 `extractvalue` + `ret`.

### 의도된 좁힘

- 정확히 1개의 struct param. 추가 scalar param 은 P11+.
- 단일 AssignInstr (multi-instruction body 는 P11+).
- 모든 field 가 scalar (중첩 struct / list 등은 declined).

### 테스트

- real-MIR baseline 에 +2 케이스:
  - `struct_field_read_x`: index 0 access.
  - `struct_field_read_y`: index 1 access (struct 이름 변형).
- gap probe 에서 `struct_field_access` 항목 제거.
- 19/19 baseline 통과.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 19/19 통과 (gap probe 2 SKIP — println String / list literal)

## Notes

- 디스패처 wiring 영향 0. `OSTY_STAGE0_FALLBACK` 게이트 그대로.
- 다음 (P11+): list literal — runtime ABI (osty_rt_list_*) + intrinsic family. 또는 struct field 의 multi-instruction 본문 / 추가 param 확장.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_