### PR TITLE
feat(backend/stage0): list literal + len() (P12)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -173,7 +173,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P9 | String literal return + moduleCtx refactor (string-pool / extraDecls 인프라) | string_literal_return real-MIR — **구현 완료** |
 | P10 | struct field accessor — `fn name(p: Struct) -> T { p.field }` + module-level `%Struct = type {...}` 정의 | struct_field_read_x / struct_field_read_y real-MIR — **구현 완료** |
 | P11 | println(String) — `%s\n` format + main 본문 안 intrinsic 호출 받기 | println_string_literal real-MIR — **구현 완료** |
-| P12+ | list literal / 더 많은 intrinsic family / 더 큰 toolchain 빌드 | toolchain/main.osty 부분 빌드 |
+| P12 | List<Int> 리터럴 + len() — runtime ABI 호출 (osty_rt_list_new / push_i64 / len) | list_literal_len real-MIR — **구현 완료** |
+| P13+ | 더 많은 intrinsic family / list ops / Optional / Result / closure 등 | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -292,6 +292,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchStructFieldRead(fn, mctx); ok {
 		return emitStructFieldRead(out, fn, pat)
 	}
+	if pat, ok := matchListLiteralLen(fn, mctx); ok {
+		return emitListLiteralLen(out, fn, pat)
+	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
 
@@ -2150,6 +2153,145 @@ func emitStructFieldRead(out *strings.Builder, fn *mir.Function, pat structField
 	out.WriteString("entry:\n")
 	fmt.Fprintf(out, "  %%0 = extractvalue %%%s %%%s, %d\n", pat.structName, pat.paramName, pat.fieldIndex)
 	fmt.Fprintf(out, "  ret %s %%0\n", resultLLVM)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P12: list literal + len ----
+//
+// stage0 P12 handles the canonical "build a List<Int> literal then
+// read its length" shape:
+//
+//	fn name() -> Int {
+//	    let xs: List<Int> = [N1, N2, ...]
+//	    xs.len()
+//	}
+//
+// MIR shape: 0 params, single block, instructions = (StorageLive +
+// AssignInstr writing AggregateRV{AggList} to a List<Int> local +
+// IntrinsicInstr{IntrinsicListLen} reading that local), ReturnTerm.
+//
+// Output: declare the runtime ABI (list_new / list_push_i64 / list_len)
+// at module top, emit a call sequence that allocates the list, pushes
+// each element, and returns the length.
+
+type listLiteralLenPattern struct {
+	elements []int64 // currently only IntConst literals supported
+}
+
+func matchListLiteralLen(fn *mir.Function, mctx *moduleCtx) (listLiteralLenPattern, bool) {
+	pat := listLiteralLenPattern{}
+	if scalarFromType(fn.ReturnType) != scalarInt {
+		return pat, false
+	}
+	if len(fn.Params) != 0 {
+		return pat, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok {
+		return pat, false
+	}
+
+	// Walk the instructions, skipping storage markers, recording
+	// the first AssignInstr (must be AggregateRV{AggList} writing
+	// IntConsts to a List<Int> local) and the IntrinsicListLen that
+	// reads the same local into the return local.
+	var (
+		listLocal mir.LocalID
+		listSet   bool
+		lenSet    bool
+	)
+	for _, instr := range bb.Instrs {
+		switch step := instr.(type) {
+		case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+			continue
+		case *mir.AssignInstr:
+			if listSet {
+				return pat, false
+			}
+			if step.Dest.HasProjections() {
+				return pat, false
+			}
+			loc := lookupLocal(fn, step.Dest.Local)
+			if loc == nil {
+				return pat, false
+			}
+			named, ok := loc.Type.(*ir.NamedType)
+			if !ok || named == nil || named.Name != "List" {
+				return pat, false
+			}
+			agg, ok := step.Src.(*mir.AggregateRV)
+			if !ok || agg.Kind != mir.AggList {
+				return pat, false
+			}
+			elements := make([]int64, 0, len(agg.Fields))
+			for _, f := range agg.Fields {
+				con, ok := f.(*mir.ConstOp)
+				if !ok {
+					return pat, false
+				}
+				ic, ok := con.Const.(*mir.IntConst)
+				if !ok {
+					return pat, false
+				}
+				elements = append(elements, ic.Value)
+			}
+			pat.elements = elements
+			listLocal = step.Dest.Local
+			listSet = true
+		case *mir.IntrinsicInstr:
+			if !listSet || lenSet {
+				return pat, false
+			}
+			if step.Kind != mir.IntrinsicListLen || len(step.Args) != 1 || step.Dest == nil {
+				return pat, false
+			}
+			if step.Dest.Local != fn.ReturnLocal || step.Dest.HasProjections() {
+				return pat, false
+			}
+			cp, ok := step.Args[0].(*mir.CopyOp)
+			if !ok || cp.Place.Local != listLocal || cp.Place.HasProjections() {
+				return pat, false
+			}
+			lenSet = true
+		default:
+			return pat, false
+		}
+	}
+	if !listSet || !lenSet {
+		return pat, false
+	}
+	declareListRuntime(mctx)
+	return pat, true
+}
+
+// declareListRuntime appends the small runtime ABI declarations
+// stage0's list-literal pattern depends on. Idempotent — the
+// declarations are guarded by a sentinel in mctx.emittedStructs (the
+// flag map already exists for struct types and serves equally well
+// here for "have the list runtime decls been emitted").
+func declareListRuntime(mctx *moduleCtx) {
+	if mctx.emittedStructs == nil {
+		mctx.emittedStructs = map[string]bool{}
+	}
+	if mctx.emittedStructs["__stage0.list_runtime"] {
+		return
+	}
+	mctx.emittedStructs["__stage0.list_runtime"] = true
+	mctx.extraDecls.WriteString("declare ptr @osty_rt_list_new()\n")
+	mctx.extraDecls.WriteString("declare void @osty_rt_list_push_i64(ptr, i64)\n")
+	mctx.extraDecls.WriteString("declare i64 @osty_rt_list_len(ptr)\n")
+}
+
+func emitListLiteralLen(out *strings.Builder, fn *mir.Function, pat listLiteralLenPattern) error {
+	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
+	out.WriteString("entry:\n")
+	out.WriteString("  %0 = call ptr @osty_rt_list_new()\n")
+	for _, v := range pat.elements {
+		fmt.Fprintf(out, "  call void @osty_rt_list_push_i64(ptr %%0, i64 %d)\n", v)
+	}
+	fmt.Fprintf(out, "  %%1 = call i64 @osty_rt_list_len(ptr %%0)\n")
+	out.WriteString("  ret i64 %1\n")
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -297,6 +297,26 @@ fn main() {}`,
 				"call i32 (ptr, ...) @printf(ptr @.fmt.stage0.println.str, ptr @.str.0)",
 			},
 		},
+		{
+			name: "list_literal_len",
+			src: `fn answer() -> Int {
+    let xs: List<Int> = [1, 2, 3]
+    xs.len()
+}
+fn main() {}`,
+			wantIR: []string{
+				"declare ptr @osty_rt_list_new()",
+				"declare void @osty_rt_list_push_i64(ptr, i64)",
+				"declare i64 @osty_rt_list_len(ptr)",
+				"define i64 @answer()",
+				"%0 = call ptr @osty_rt_list_new()",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 1)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 2)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 3)",
+				"%1 = call i64 @osty_rt_list_len(ptr %0)",
+				"ret i64 %1",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -321,15 +341,6 @@ fn main() {}`,
 // coverage, flip skipNow=false to lock in the new capability.
 func TestStage0RealMIRGapProbe(t *testing.T) {
 	cases := []realProbeCase{
-		{
-			name: "list_literal_len",
-			src: `fn answer() -> Int {
-    let xs: List<Int> = [1, 2, 3]
-    xs.len()
-}
-fn main() {}`,
-			skipNow: true,
-		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Summary

front-end 가 `let xs: List<Int> = [1, 2, 3]; xs.len()` 를 다음 MIR shape 로 lowering:
- AssignInstr 가 `AggregateRV{Kind: AggList, Fields: [IntConst...]}` 를 List<Int> 로컬에 대입.
- IntrinsicInstr{Kind: `IntrinsicListLen`, Args: [CopyOp(list local)]} 가 길이를 ret 로컬로.

stage0 P12 는 이 정확한 패턴을 받아 LLVM 으로 lowering. **모든 gap probe 케이스가 이제 baseline 으로 이동.**

```osty
fn answer() -> Int {
    let xs: List<Int> = [1, 2, 3]
    xs.len()
}
```

→
```llvm
declare ptr  @osty_rt_list_new()
declare void @osty_rt_list_push_i64(ptr, i64)
declare i64  @osty_rt_list_len(ptr)

define i64 @answer() {
entry:
  %0 = call ptr @osty_rt_list_new()
  call void @osty_rt_list_push_i64(ptr %0, i64 1)
  call void @osty_rt_list_push_i64(ptr %0, i64 2)
  call void @osty_rt_list_push_i64(ptr %0, i64 3)
  %1 = call i64 @osty_rt_list_len(ptr %0)
  ret i64 %1
}
```

### 추가

- `listLiteralLenPattern` / `matchListLiteralLen` / `emitListLiteralLen` — 정확히 `let xs: List<Int> = [literals...]; xs.len()` 한 형태.
- `declareListRuntime(mctx)` — runtime ABI declare 를 idempotent 하게 `extraDecls` 에 추가. `emittedStructs` map 을 sentinel 로 재사용.

### 매처 제약

- 0 params.
- Int 리턴.
- 단일 블록.
- 시퀀스: Storage* / AssignInstr(AggList of IntConst → List 로컬) / IntrinsicListLen(list 로컬 → ret 로컬) / ReturnTerm.
- 그 외 모든 instruction 은 decline.

### 의도된 좁음

P12 는 **literal-only list + len() 만**. List 의 다른 ops (push/get/map 등), 변수 list, 비-Int element type 은 P13+.

### 테스트

- real-MIR baseline 에 `list_literal_len` 케이스 추가.
- gap probe 슬라이스에서 항목 제거 — **이제 비어 있음**.
- 21/21 baseline 통과.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 21/21 통과 + gap probe empty

## Notes

- 디스패처 wiring 영향 0. `OSTY_STAGE0_FALLBACK` 게이트 그대로.
- 다음 (P13+): toolchain 의 실제 함수 시도 — 어떤 surface 가 더 필요한지 측정 후 batch 추가. 또는 Optional / Result / pattern matching 등 더 큰 architectural 단계.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_