### PR TITLE
feat(backend/stage0): String concat + recursive call (P13)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -174,7 +174,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P10 | struct field accessor — `fn name(p: Struct) -> T { p.field }` + module-level `%Struct = type {...}` 정의 | struct_field_read_x / struct_field_read_y real-MIR — **구현 완료** |
 | P11 | println(String) — `%s\n` format + main 본문 안 intrinsic 호출 받기 | println_string_literal real-MIR — **구현 완료** |
 | P12 | List<Int> 리터럴 + len() — runtime ABI 호출 (osty_rt_list_new / push_i64 / len) | list_literal_len real-MIR — **구현 완료** |
-| P13+ | 더 많은 intrinsic family / list ops / Optional / Result / closure 등 | toolchain/main.osty 부분 빌드 |
+| P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
+| P14+ | list ops (get/iter) / Optional / Result / pattern match / tuple / struct constructor / closure | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -745,6 +745,28 @@ func classifyAssignSrc(src mir.RValue, destType scalarType, bindings map[mir.Loc
 		return pendingInstr{kind: instrInline}, expr, true
 	}
 	if bin, ok := src.(*mir.BinaryRV); ok {
+		// Special-case String + Add: lowers to a runtime ABI call
+		// (`osty_rt_strings_Concat`) rather than a native LLVM
+		// binary instruction.
+		if bin.Op == mir.BinAdd && destType == scalarString {
+			left, leftTy, ok := resolveOperand(bin.Left, bindings, mctx)
+			if !ok || leftTy != scalarString {
+				return pendingInstr{}, "", false
+			}
+			right, rightTy, ok := resolveOperand(bin.Right, bindings, mctx)
+			if !ok || rightTy != scalarString {
+				return pendingInstr{}, "", false
+			}
+			declareStringConcatRuntime(mctx)
+			return pendingInstr{
+				kind:       instrCall,
+				callSymbol: "osty_rt_strings_Concat",
+				callArgs: []callArg{
+					{expr: left, ty: "ptr"},
+					{expr: right, ty: "ptr"},
+				},
+			}, "", true
+		}
 		llvmOp, resultType, operandType := classifyBinary(bin.Op)
 		if llvmOp == "" || resultType != destType {
 			return pendingInstr{}, "", false
@@ -766,6 +788,20 @@ func classifyAssignSrc(src mir.RValue, destType scalarType, bindings map[mir.Loc
 		}, "", true
 	}
 	return pendingInstr{}, "", false
+}
+
+// declareStringConcatRuntime appends the runtime ABI declaration for
+// `osty_rt_strings_Concat` to extraDecls (idempotent — sentinel
+// stored alongside other emit-once flags in `emittedStructs`).
+func declareStringConcatRuntime(mctx *moduleCtx) {
+	if mctx.emittedStructs == nil {
+		mctx.emittedStructs = map[string]bool{}
+	}
+	if mctx.emittedStructs["__stage0.strings_concat"] {
+		return
+	}
+	mctx.emittedStructs["__stage0.strings_concat"] = true
+	mctx.extraDecls.WriteString("declare ptr @osty_rt_strings_Concat(ptr, ptr)\n")
 }
 
 // resolveOperand returns (expression, type) for one MIR Operand using

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -317,6 +317,41 @@ fn main() {}`,
 				"ret i64 %1",
 			},
 		},
+		{
+			name: "string_concat_const_param",
+			src: `fn greeting(name: String) -> String { "hello, " + name }
+fn main() {}`,
+			wantIR: []string{
+				"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+				`@.str.0 = private unnamed_addr constant [8 x i8] c"hello, \00"`,
+				"define ptr @greeting(ptr %name)",
+				"%0 = call ptr @osty_rt_strings_Concat(ptr @.str.0, ptr %name)",
+				"ret ptr %0",
+			},
+		},
+		{
+			name: "string_concat_two_params",
+			src: `fn join(a: String, b: String) -> String { a + b }
+fn main() {}`,
+			wantIR: []string{
+				"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+				"define ptr @join(ptr %a, ptr %b)",
+				"%0 = call ptr @osty_rt_strings_Concat(ptr %a, ptr %b)",
+			},
+		},
+		{
+			name: "recursive_factorial",
+			src: `fn fact(n: Int) -> Int {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() {}`,
+			wantIR: []string{
+				"define i64 @fact(i64 %n)",
+				"icmp sle i64 %n, 1",
+				"call i64 @fact(i64",
+				"phi i64",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Summary

P12 까지 명시적 gap probe 가 비어 있었음. P13 은 새 probe 배터리를 돌려 추가 갭 식별 + 작은 win 두 개 봉합.

### 새 probe 결과 (P13 진입 시점)

PASS — 코드 변경 없이 이미 동작:
- `println_in_helper_fn` (P8 의 sequential 매처가 이미 받음)
- `recursive_fn` (knownSymbols 가 모듈-레벨이라 자기 호출 OK)

FAIL — 추가 작업 필요:
- list_get / list_iterate / if_let_some / tuple_return / string_concat / struct_constructor

### 이 PR 에서 추가

#### 1) String concat (`a + b` 또는 `"x" + name`)

```osty
fn greeting(name: String) -> String { "hello, " + name }
```

→
```llvm
declare ptr @osty_rt_strings_Concat(ptr, ptr)
@.str.0 = private unnamed_addr constant [8 x i8] c"hello, \00"

define ptr @greeting(ptr %name) {
entry:
  %0 = call ptr @osty_rt_strings_Concat(ptr @.str.0, ptr %name)
  ret ptr %0
}
```

- `classifyAssignSrc` 가 `BinaryRV{Op: BinAdd, T: String}` 을 special-case 처리. `classifyBinary` 표 외부에서 분기해서 `instrCall` 로 pendingInstr 만들고 `osty_rt_strings_Concat(ptr, ptr)` 한 줄 emit.
- `declareStringConcatRuntime(mctx)` — runtime ABI declare 를 idempotent 하게 `extraDecls` 에 추가.

#### 2) 재귀 함수 호출 — 코드 변경 0

기존 P3b 의 `knownSymbols` 가 모듈 pre-pass 로 만들어지므로 `fact(n-1)` 같은 자기 호출이 자연스럽게 허용됨. real-MIR 테스트 케이스 추가로 명시적 보장.

### 테스트

- `string_concat_const_param`: `"hello, " + name` (literal + param)
- `string_concat_two_params`: `a + b` (param + param)
- `recursive_factorial`: `fn fact(n) { if n<=1 {1} else {n*fact(n-1)} }` → `call i64 @fact(...)` + `phi i64` 검증
- **24/24 baseline 통과**.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 24/24 통과

## Notes

- 디스패처 wiring 영향 0.
- 다음 (P14+): probe 에서 식별된 list_get / list_iterate / if_let_some / tuple_return / struct_constructor 중 하나. 각각 별도 architectural 단계.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_