### PR TITLE
feat(backend/stage0): aggregate constructor — struct + tuple (P14)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -175,7 +175,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P11 | println(String) — `%s\n` format + main 본문 안 intrinsic 호출 받기 | println_string_literal real-MIR — **구현 완료** |
 | P12 | List<Int> 리터럴 + len() — runtime ABI 호출 (osty_rt_list_new / push_i64 / len) | list_literal_len real-MIR — **구현 완료** |
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
-| P14+ | list ops (get/iter) / Optional / Result / pattern match / tuple / struct constructor / closure | toolchain/main.osty 부분 빌드 |
+| P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
+| P15+ | list ops (get/iterate) / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -132,6 +132,12 @@ type moduleCtx struct {
 	// to extraDecls already, so multiple functions referencing the
 	// same struct don't duplicate the type definition.
 	emittedStructs map[string]bool
+	// tuplePool maps a tuple's canonical key (the comma-separated
+	// list of LLVM scalar mnemonics) to its synthetic LLVM type
+	// name. Tuples don't carry a user-visible Osty name so stage0
+	// invents `.tuple.<N>` IDs on first use.
+	tuplePool   map[string]string
+	nextTupleID int
 }
 
 func newModuleCtx(module *mir.Module) *moduleCtx {
@@ -148,7 +154,42 @@ func newModuleCtx(module *mir.Module) *moduleCtx {
 		extraDecls:     &strings.Builder{},
 		stringPool:     map[string]string{},
 		emittedStructs: map[string]bool{},
+		tuplePool:      map[string]string{},
 	}
+}
+
+// internTupleType returns the synthetic LLVM type name (with leading
+// `%`) for the tuple `(elems...)`. Repeated calls with the same field
+// list return the cached name. The type definition is emitted into
+// extraDecls on first use.
+func (m *moduleCtx) internTupleType(elems []scalarType) string {
+	key := tupleKey(elems)
+	if name, ok := m.tuplePool[key]; ok {
+		return name
+	}
+	name := fmt.Sprintf(".tuple.%d", m.nextTupleID)
+	m.nextTupleID++
+	m.tuplePool[key] = name
+	fmt.Fprintf(m.extraDecls, "%%%s = type { ", name)
+	for i, ft := range elems {
+		if i > 0 {
+			m.extraDecls.WriteString(", ")
+		}
+		m.extraDecls.WriteString(ft.llvm())
+	}
+	m.extraDecls.WriteString(" }\n")
+	return name
+}
+
+func tupleKey(elems []scalarType) string {
+	var b strings.Builder
+	for i, e := range elems {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(e.llvm())
+	}
+	return b.String()
 }
 
 // lookupStructFields returns the scalar field types for the named
@@ -295,6 +336,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	}
 	if pat, ok := matchListLiteralLen(fn, mctx); ok {
 		return emitListLiteralLen(out, fn, pat)
+	}
+	if pat, ok := matchAggregateConstructor(fn, mctx); ok {
+		return emitAggregateConstructor(out, fn, pat)
 	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
@@ -2329,6 +2373,205 @@ func emitListLiteralLen(out *strings.Builder, fn *mir.Function, pat listLiteralL
 	}
 	fmt.Fprintf(out, "  %%1 = call i64 @osty_rt_list_len(ptr %%0)\n")
 	out.WriteString("  ret i64 %1\n")
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P14: aggregate constructor (struct + tuple) ----
+//
+// stage0 P14 handles the simplest "build aggregate, return it" shape:
+//
+//	struct Point { x: Int, y: Int }
+//	fn origin() -> Point { Point { x: 0, y: 0 } }
+//	fn make(x: Int, y: Int) -> Point { Point { x: x, y: y } }
+//	fn pair() -> (Int, Int) { (1, 2) }
+//
+// MIR shape: 0~2 scalar params, single block, single AssignInstr
+// writing AggregateRV{AggStruct or AggTuple} to the return local,
+// ReturnTerm. Each field is a ConstOp (Int / Bool / String) or a
+// CopyOp on a function parameter.
+//
+// Output: emit the aggregate's type definition once at module top
+// (struct uses its source name; tuple gets a synthetic `.tuple.<N>`),
+// then a chain of `insertvalue` instructions inside the function.
+
+type aggregateConstructorPattern struct {
+	typeName    string         // LLVM type name without `%`
+	paramTypes  []scalarType   // function parameter scalar types
+	paramNames  []string       // sanitised parameter names
+	paramIDs    []mir.LocalID
+	fieldExprs  []string       // ordered LLVM operand expressions
+	fieldTypes  []scalarType   // matching scalar type per field
+}
+
+func matchAggregateConstructor(fn *mir.Function, mctx *moduleCtx) (aggregateConstructorPattern, bool) {
+	pat := aggregateConstructorPattern{}
+
+	// Determine the aggregate type the function returns.
+	typeName, fieldTypes, ok := classifyAggregateReturnType(fn.ReturnType, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.typeName = typeName
+	pat.fieldTypes = fieldTypes
+
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		st := scalarFromType(loc.Type)
+		if st == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = st
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return pat, false
+	}
+	ai, ok := bb.Instrs[0].(*mir.AssignInstr)
+	if !ok {
+		return pat, false
+	}
+	if ai.Dest.Local != fn.ReturnLocal || ai.Dest.HasProjections() {
+		return pat, false
+	}
+	agg, ok := ai.Src.(*mir.AggregateRV)
+	if !ok {
+		return pat, false
+	}
+	if agg.Kind != mir.AggStruct && agg.Kind != mir.AggTuple {
+		return pat, false
+	}
+	if len(agg.Fields) != len(fieldTypes) {
+		return pat, false
+	}
+
+	// Param-id → LLVM register (fast lookup for CopyOp resolution).
+	paramRegs := map[mir.LocalID]string{}
+	for i, pid := range fn.Params {
+		paramRegs[pid] = "%" + pat.paramNames[i]
+	}
+
+	pat.fieldExprs = make([]string, len(agg.Fields))
+	for i, f := range agg.Fields {
+		expr, ty, ok := classifyAggregateField(f, paramRegs, fn, mctx)
+		if !ok {
+			return pat, false
+		}
+		if ty != fieldTypes[i] {
+			return pat, false
+		}
+		pat.fieldExprs[i] = expr
+	}
+	return pat, true
+}
+
+// classifyAggregateReturnType maps the function's return type to a
+// (typeName, fieldTypes) pair when the type is an aggregate stage0
+// can lower. Struct types use the source name and emit their type
+// definition through emitStructDef; tuple types use a synthetic
+// `.tuple.<N>` id allocated by mctx.internTupleType.
+func classifyAggregateReturnType(retT mir.Type, mctx *moduleCtx) (string, []scalarType, bool) {
+	switch t := retT.(type) {
+	case *ir.NamedType:
+		if t == nil || t.Name == "" {
+			return "", nil, false
+		}
+		fields, ok := mctx.lookupStructFields(t.Name)
+		if !ok {
+			return "", nil, false
+		}
+		mctx.emitStructDef(t.Name, fields)
+		return t.Name, fields, true
+	case *ir.TupleType:
+		if t == nil {
+			return "", nil, false
+		}
+		fields := make([]scalarType, len(t.Elems))
+		for i, e := range t.Elems {
+			st := scalarFromType(e)
+			if st == scalarUnknown {
+				return "", nil, false
+			}
+			fields[i] = st
+		}
+		name := mctx.internTupleType(fields)
+		return name, fields, true
+	}
+	return "", nil, false
+}
+
+// classifyAggregateField resolves one operand inside an aggregate
+// constructor. Constants (Int / Bool / String) inline directly; a
+// CopyOp must reference a parameter local without projections.
+func classifyAggregateField(op mir.Operand, paramRegs map[mir.LocalID]string, fn *mir.Function, mctx *moduleCtx) (string, scalarType, bool) {
+	if con, ok := op.(*mir.ConstOp); ok {
+		switch c := con.Const.(type) {
+		case *mir.IntConst:
+			return fmt.Sprintf("%d", c.Value), scalarInt, true
+		case *mir.BoolConst:
+			if c.Value {
+				return "true", scalarBool, true
+			}
+			return "false", scalarBool, true
+		case *mir.StringConst:
+			if mctx == nil {
+				return "", scalarUnknown, false
+			}
+			return mctx.internStringConst(c.Value), scalarString, true
+		}
+		return "", scalarUnknown, false
+	}
+	if cp, ok := op.(*mir.CopyOp); ok {
+		if cp.Place.HasProjections() {
+			return "", scalarUnknown, false
+		}
+		reg, found := paramRegs[cp.Place.Local]
+		if !found {
+			return "", scalarUnknown, false
+		}
+		loc := lookupLocal(fn, cp.Place.Local)
+		if loc == nil {
+			return "", scalarUnknown, false
+		}
+		return reg, scalarFromType(loc.Type), true
+	}
+	return "", scalarUnknown, false
+}
+
+func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggregateConstructorPattern) error {
+	// Function signature.
+	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+	out.WriteString("entry:\n")
+
+	// `insertvalue` chain. Start from `poison` (LLVM's "undefined"
+	// sentinel) and write each field in order. Final register holds
+	// the fully populated aggregate.
+	prev := "poison"
+	for i, fieldExpr := range pat.fieldExprs {
+		fmt.Fprintf(out, "  %%%d = insertvalue %%%s %s, %s %s, %d\n", i, pat.typeName, prev, pat.fieldTypes[i].llvm(), fieldExpr, i)
+		prev = fmt.Sprintf("%%%d", i)
+	}
+	fmt.Fprintf(out, "  ret %%%s %s\n", pat.typeName, prev)
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -352,6 +352,44 @@ fn main() {}`,
 				"phi i64",
 			},
 		},
+		{
+			name: "struct_constructor_const_fields",
+			src: `struct Point { x: Int, y: Int }
+fn origin() -> Point { Point { x: 0, y: 0 } }
+fn main() {}`,
+			wantIR: []string{
+				"%Point = type { i64, i64 }",
+				"define %Point @origin()",
+				"%0 = insertvalue %Point poison, i64 0, 0",
+				"%1 = insertvalue %Point %0, i64 0, 1",
+				"ret %Point %1",
+			},
+		},
+		{
+			name: "struct_constructor_param_fields",
+			src: `struct Point { x: Int, y: Int }
+fn make(x: Int, y: Int) -> Point { Point { x: x, y: y } }
+fn main() {}`,
+			wantIR: []string{
+				"%Point = type { i64, i64 }",
+				"define %Point @make(i64 %x, i64 %y)",
+				"%0 = insertvalue %Point poison, i64 %x, 0",
+				"%1 = insertvalue %Point %0, i64 %y, 1",
+				"ret %Point %1",
+			},
+		},
+		{
+			name: "tuple_int_int_return",
+			src: `fn pair() -> (Int, Int) { (1, 2) }
+fn main() {}`,
+			wantIR: []string{
+				"%.tuple.0 = type { i64, i64 }",
+				"define %.tuple.0 @pair()",
+				"%0 = insertvalue %.tuple.0 poison, i64 1, 0",
+				"%1 = insertvalue %.tuple.0 %0, i64 2, 1",
+				"ret %.tuple.0 %1",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Summary

front-end 가 `Point { x: 0, y: 0 }` 또는 `(1, 2)` 를 단일 AssignInstr 로 lowering — Src 가 `AggregateRV{Kind: AggStruct or AggTuple}` 이고 필드는 ConstOp / CopyOp(param). stage0 P14 는 이를 LLVM `insertvalue` 체인으로 lowering.

```osty
struct Point { x: Int, y: Int }
fn origin() -> Point { Point { x: 0, y: 0 } }
fn make(x: Int, y: Int) -> Point { Point { x: x, y: y } }
fn pair() -> (Int, Int) { (1, 2) }
```

→
```llvm
%Point = type { i64, i64 }
%.tuple.0 = type { i64, i64 }

define %Point @origin() { entry:
  %0 = insertvalue %Point poison, i64 0, 0
  %1 = insertvalue %Point %0, i64 0, 1
  ret %Point %1
}

define %Point @make(i64 %x, i64 %y) { entry:
  %0 = insertvalue %Point poison, i64 %x, 0
  %1 = insertvalue %Point %0, i64 %y, 1
  ret %Point %1
}

define %.tuple.0 @pair() { entry:
  %0 = insertvalue %.tuple.0 poison, i64 1, 0
  %1 = insertvalue %.tuple.0 %0, i64 2, 1
  ret %.tuple.0 %1
}
```

### 새 인프라

- `moduleCtx` 에 `tuplePool` (canonical key → 합성 LLVM type name) + `nextTupleID`. 같은 tuple shape 가 여러 함수에 나타나면 한 번만 type def emit.
- `internTupleType(elems)` — write-once tuple 타입 등록.
- `tupleKey(elems)` — 정렬된 LLVM 타입 mnemonic 의 콤마 결합.

### 새 매처 / 이미터

- `aggregateConstructorPattern` — typeName / paramTypes / paramNames / paramIDs / fieldExprs / fieldTypes.
- `matchAggregateConstructor` — return type 이 NamedType (struct) 또는 TupleType 이고, 단일 AssignInstr 가 AggregateRV{Struct or Tuple} 를 ret 로컬에 쓰는 함수만 매치.
- `classifyAggregateReturnType` — NamedType → `mctx.lookupStructFields` + `emitStructDef`; TupleType → `mctx.internTupleType`.
- `classifyAggregateField` — 각 필드 operand 를 LLVM 표현으로 (Int / Bool / String const, 또는 param CopyOp).
- `emitAggregateConstructor` — `define %T @fn(...) { entry: insertvalue 체인 + ret %T %final }`.

### 테스트 +3 (총 27/27 baseline)

- `struct_constructor_const_fields`: `Point { x: 0, y: 0 }`.
- `struct_constructor_param_fields`: `Point { x: x, y: y }`.
- `tuple_int_int_return`: `(1, 2) -> (Int, Int)`.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 27/27 통과

## Notes

- 디스패처 wiring 영향 0.
- 다음 (P15+): list ops (get/iterate) / Optional / Result / pattern match / closure. 다음 batch 에 묶음.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_