### PR TITLE
lsp: move pure policy to osty

### DIFF
--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -1,11 +1,6 @@
 package lsp
 
-import (
-	"fmt"
-	"sort"
-
-	"github.com/osty/osty/internal/diag"
-)
+import "github.com/osty/osty/internal/diag"
 
 // handleCodeAction answers `textDocument/codeAction`. It produces two
 // families of results:
@@ -96,7 +91,7 @@ func undefinedNameFixes(doc *document, d LSPDiagnostic) []CodeAction {
 	var out []CodeAction
 	for _, c := range candidates {
 		out = append(out, CodeAction{
-			Title:       fmt.Sprintf("Rename to `%s`", c),
+			Title:       LSPRenameTitle(c),
 			Kind:        CodeActionQuickFix,
 			Diagnostics: []LSPDiagnostic{d},
 			Edit: &WorkspaceEdit{
@@ -111,113 +106,18 @@ func undefinedNameFixes(doc *document, d LSPDiagnostic) []CodeAction {
 }
 
 func nearbyStructuredSymbolNames(symbols []structuredSymbol, target string, maxDistance int) []string {
-	type candidate struct {
-		name string
-		dist int
-	}
-	seen := map[string]bool{}
-	var candidates []candidate
+	names := make([]string, 0, len(symbols))
 	for _, sym := range symbols {
-		if sym.name == "" || sym.builtin || sym.depth != 0 || seen[sym.name] {
+		if sym.name == "" || sym.builtin || sym.depth != 0 {
 			continue
 		}
-		dist := lspLevenshteinBounded(target, sym.name, maxDistance)
-		if dist > maxDistance {
-			continue
-		}
-		seen[sym.name] = true
-		candidates = append(candidates, candidate{name: sym.name, dist: dist})
+		names = append(names, sym.name)
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].dist != candidates[j].dist {
-			return candidates[i].dist < candidates[j].dist
-		}
-		return candidates[i].name < candidates[j].name
-	})
-	out := make([]string, 0, len(candidates))
-	for _, c := range candidates {
-		out = append(out, c.name)
-	}
-	return out
+	return LSPRankNearbyNames(names, target, maxDistance)
 }
 
 func mergeNearbyNames(primary []string, fallback []string) []string {
-	if len(primary) == 0 {
-		return fallback
-	}
-	seen := make(map[string]bool, len(primary)+len(fallback))
-	out := make([]string, 0, len(primary)+len(fallback))
-	for _, name := range primary {
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		out = append(out, name)
-	}
-	for _, name := range fallback {
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		out = append(out, name)
-	}
-	return out
-}
-
-func lspLevenshteinBounded(a, b string, limit int) int {
-	ar := []rune(a)
-	br := []rune(b)
-	if absInt(len(ar)-len(br)) > limit {
-		return limit + 1
-	}
-	prev := make([]int, len(br)+1)
-	curr := make([]int, len(br)+1)
-	for j := range prev {
-		prev[j] = j
-	}
-	for i := 1; i <= len(ar); i++ {
-		curr[0] = i
-		rowMin := curr[0]
-		for j := 1; j <= len(br); j++ {
-			cost := 0
-			if ar[i-1] != br[j-1] {
-				cost = 1
-			}
-			curr[j] = minInt(
-				prev[j]+1,
-				curr[j-1]+1,
-				prev[j-1]+cost,
-			)
-			if curr[j] < rowMin {
-				rowMin = curr[j]
-			}
-		}
-		if rowMin > limit {
-			return limit + 1
-		}
-		prev, curr = curr, prev
-	}
-	if prev[len(br)] > limit {
-		return limit + 1
-	}
-	return prev[len(br)]
-}
-
-func minInt(a, b, c int) int {
-	if b < a {
-		a = b
-	}
-	if c < a {
-		return c
-	}
-	return a
-}
-
-func absInt(v int) int {
-	if v < 0 {
-		return -v
-	}
-	return v
+	return LSPMergeNearbyNames(primary, fallback)
 }
 
 // prefixUnderscoreFix produces a "silence by prefixing `_`" action
@@ -249,7 +149,7 @@ func removeLineFix(doc *document, d LSPDiagnostic) CodeAction {
 		End:   Position{Line: d.Range.End.Line + 1, Character: 0},
 	}
 	return CodeAction{
-		Title:       "Remove unused import",
+		Title:       LSPRemoveLineTitle(),
 		Kind:        CodeActionQuickFix,
 		Diagnostics: []LSPDiagnostic{d},
 		Edit: &WorkspaceEdit{

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -1,8 +1,6 @@
 package lsp
 
 import (
-	"strings"
-
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
@@ -89,17 +87,18 @@ func (s *Server) completionAfterDot(doc *document, recvName, prefix string) []Co
 	if pkg == nil || pkg.PkgScope == nil {
 		return nil
 	}
-	var items []CompletionItem
+	candidates := make([]LSPCompletionCandidateView, 0, len(pkg.PkgScope.Symbols()))
 	for name, member := range pkg.PkgScope.Symbols() {
-		if !member.Pub {
-			continue
-		}
-		if prefix != "" && !strings.HasPrefix(name, prefix) {
-			continue
-		}
-		items = append(items, completionItemFromSym(name, member, a.check))
+		view := completionSymbolView(name, member, a.check)
+		candidates = append(candidates, LSPCompletionCandidateView{
+			Name:     view.Name,
+			Kind:     view.Kind,
+			TypeText: view.TypeText,
+			DocText:  view.DocText,
+			Include:  member.Pub,
+		})
 	}
-	return sortCompletionItems(items)
+	return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 }
 
 func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([]CompletionItem, bool) {
@@ -110,17 +109,16 @@ func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([
 		if surface.alias != recvName {
 			continue
 		}
-		items := make([]CompletionItem, 0, len(surface.symbols))
+		candidates := make([]LSPCompletionCandidateView, 0, len(surface.symbols))
 		for _, sym := range surface.symbols {
-			if sym.name == "" {
-				continue
-			}
-			if prefix != "" && !strings.HasPrefix(sym.name, prefix) {
-				continue
-			}
-			items = append(items, completionItemFromStructuredImportSymbol(sym))
+			candidates = append(candidates, LSPCompletionCandidateView{
+				Name:     sym.name,
+				Kind:     sym.kind,
+				TypeText: sym.typeText,
+				Include:  true,
+			})
 		}
-		return sortCompletionItems(items), true
+		return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix)), true
 	}
 	return nil, false
 }
@@ -130,37 +128,31 @@ func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([
 // locals, parameters, and builtins not yet exposed in those facts.
 func (s *Server) completionInScope(doc *document, prefix string) []CompletionItem {
 	a := doc.analysis
-	seen := map[string]struct{}{}
-	var items []CompletionItem
+	var candidates []LSPCompletionCandidateView
 	for _, sym := range a.structuredSymbols {
-		if sym.builtin || sym.name == "" || sym.depth != 0 {
-			continue
-		}
-		if _, dup := seen[sym.name]; dup {
-			continue
-		}
-		if prefix != "" && !strings.HasPrefix(sym.name, prefix) {
-			continue
-		}
-		seen[sym.name] = struct{}{}
-		items = append(items, completionItemFromStructuredSymbol(sym))
+		candidates = append(candidates, LSPCompletionCandidateView{
+			Name:     sym.name,
+			Kind:     sym.kind,
+			TypeText: sym.typeText,
+			Include:  !sym.builtin && sym.depth == 0,
+		})
 	}
 	if a.resolve == nil || a.resolve.FileScope == nil {
-		return sortCompletionItems(items)
+		return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 	}
 	for sc := a.resolve.FileScope; sc != nil; sc = sc.Parent() {
 		for name, sym := range sc.Symbols() {
-			if _, dup := seen[name]; dup {
-				continue
-			}
-			if prefix != "" && !strings.HasPrefix(name, prefix) {
-				continue
-			}
-			seen[name] = struct{}{}
-			items = append(items, completionItemFromSym(name, sym, a.check))
+			view := completionSymbolView(name, sym, a.check)
+			candidates = append(candidates, LSPCompletionCandidateView{
+				Name:     view.Name,
+				Kind:     view.Kind,
+				TypeText: view.TypeText,
+				DocText:  view.DocText,
+				Include:  true,
+			})
 		}
 	}
-	return sortCompletionItems(items)
+	return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 }
 
 func sortCompletionItems(in []CompletionItem) []CompletionItem {
@@ -231,18 +223,31 @@ func completionSymbolView(label string, sym *resolve.Symbol, r *check.Result) se
 // self-hosted policy; the markdown documentation flows through as a
 // raw doc string.
 func completionItemFromView(view selfhost.LSPSymbolView) CompletionItem {
+	policy := LSPCompletionItemForSymbolView(view)
+	return completionItemFromData(policy)
+}
+
+func completionItemsFromPolicy(items []LSPCompletionItemData) []CompletionItem {
+	out := make([]CompletionItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, completionItemFromData(item))
+	}
+	return out
+}
+
+func completionItemFromData(policy LSPCompletionItemData) CompletionItem {
 	item := CompletionItem{
-		Label:    view.Name,
-		Kind:     CompletionItemKind(LSPCompletionKindForSymbolKind(view.Kind)),
-		SortText: LSPCompletionSortTextForSymbolKind(view.Kind, view.Name),
+		Label:    policy.Label,
+		Kind:     CompletionItemKind(policy.Kind),
+		SortText: policy.SortText,
 	}
-	if view.TypeText != "" {
-		item.Detail = LSPCompletionDetail(view.Kind, view.Name, view.TypeText)
+	if policy.Detail != "" {
+		item.Detail = policy.Detail
 	}
-	if view.DocText != "" {
+	if policy.Documentation != "" {
 		item.Documentation = &MarkupContent{
 			Kind:  MarkupKindMarkdown,
-			Value: view.DocText,
+			Value: policy.Documentation,
 		}
 	}
 	return item

--- a/internal/lsp/convert.go
+++ b/internal/lsp/convert.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/token"
@@ -62,18 +61,11 @@ func (li *lineIndex) rangeFromOffsets(start, end int) Range {
 // Returns ("", false) for non-file URIs (e.g. `inmemory:`, `untitled:`).
 // Percent-decoding handles paths with spaces and Unicode characters.
 func fileURIPath(uri string) (string, bool) {
-	const prefix = "file://"
-	if !strings.HasPrefix(uri, prefix) {
+	raw := LSPFileURIPathRaw(uri)
+	if !raw.OK {
 		return "", false
 	}
-	path := strings.TrimPrefix(uri, prefix)
-	// On Windows the URI is `file:///C:/path/...` — strip the leading
-	// slash so we get `C:/path/...`. On POSIX the leading slash IS the
-	// path root and must be kept.
-	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
-		path = path[1:]
-	}
-	decoded, err := url.PathUnescape(path)
+	decoded, err := url.PathUnescape(raw.Path)
 	if err != nil {
 		return "", false
 	}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/osty/osty/internal/ast"
@@ -55,11 +54,11 @@ func (s *Server) handleInitialize(req *rpcRequest) {
 			},
 			CompletionProvider: &CompletionOptions{
 				// `.` triggers member completion (pkg.fn, recv.method).
-				TriggerCharacters: []string{"."},
+				TriggerCharacters: []string{LSPCompletionTriggerDot()},
 			},
 			SignatureHelpProvider: &SignatureHelpOptions{
-				TriggerCharacters:   []string{"(", ","},
-				RetriggerCharacters: []string{","},
+				TriggerCharacters:   []string{LSPSignatureTriggerOpenParen(), LSPSignatureTriggerComma()},
+				RetriggerCharacters: []string{LSPSignatureTriggerComma()},
 			},
 			SemanticTokensProvider: &SemanticTokensOptions{
 				Legend: SemanticTokensLegend{
@@ -68,13 +67,13 @@ func (s *Server) handleInitialize(req *rpcRequest) {
 				},
 				Full: true,
 			},
-			PositionEncoding: "utf-16",
+			PositionEncoding: LSPPositionEncodingUTF16(),
 		},
 		ServerInfo: &ServerInfo{
 			Name:    ServerName,
-			Version: "0.1.0",
+			Version: LSPServerVersion(),
 		},
-		PositionEncoding: "utf-16",
+		PositionEncoding: LSPPositionEncodingUTF16(),
 	}
 	replyJSON(s.conn, req.ID, result)
 }
@@ -165,15 +164,24 @@ func (s *Server) publishDiagnostics(doc *document) {
 // identical payloads. LSPDiagnostic is all-comparable so element-wise
 // `!=` suffices.
 func diagsEqual(a, b []LSPDiagnostic) bool {
-	if len(a) != len(b) {
-		return false
+	return LSPDiagnosticsEqual(lspDiagnosticViews(a), lspDiagnosticViews(b))
+}
+
+func lspDiagnosticViews(in []LSPDiagnostic) []LSPDiagnosticView {
+	out := make([]LSPDiagnosticView, 0, len(in))
+	for _, d := range in {
+		out = append(out, LSPDiagnosticView{
+			StartLine:      d.Range.Start.Line,
+			StartCharacter: d.Range.Start.Character,
+			EndLine:        d.Range.End.Line,
+			EndCharacter:   d.Range.End.Character,
+			Severity:       uint32(d.Severity),
+			Code:           d.Code,
+			Source:         d.Source,
+			Message:        d.Message,
+		})
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return out
 }
 
 // toLSPDiag is the severity + range mapping between our internal
@@ -320,16 +328,7 @@ func semanticHoverLegacyContext(a *docAnalysis, pos token.Pos) (docText string, 
 }
 
 func semanticHoverKind(kind string) string {
-	switch kind {
-	case "fn":
-		return "function"
-	case "value":
-		return "binding"
-	case "generic":
-		return "type parameter"
-	default:
-		return kind
-	}
+	return LSPSemanticHoverKind(kind)
 }
 
 // hoverForSymbol formats the markdown block shown on hover. The
@@ -531,25 +530,17 @@ func (s *Server) handleFormatting(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return
 	}
-	if bytes.Equal(out, doc.src) {
+	if !LSPTextChanged(doc.src, out) {
 		// No-op formatting; avoid churning the editor's dirty flag.
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return
 	}
 	// Replace [start-of-file, end-of-file) with the formatted text.
-	endLine := uint32(0)
-	if n := len(doc.analysis.lines.lines); n > 0 {
-		endLine = uint32(n - 1)
-	}
-	lastLineStart := 0
-	if n := len(doc.analysis.lines.lines); n > 0 {
-		lastLineStart = doc.analysis.lines.lines[n-1]
-	}
-	endChar := utf16UnitsInPrefix(doc.src[lastLineStart:])
+	fullRange := LSPFullDocumentRangeFor(doc.src, doc.analysis.lines.lines)
 	edit := TextEdit{
 		Range: Range{
 			Start: Position{Line: 0, Character: 0},
-			End:   Position{Line: endLine, Character: endChar},
+			End:   Position{Line: fullRange.EndLine, Character: fullRange.EndCharacter},
 		},
 		NewText: string(out),
 	}
@@ -671,7 +662,7 @@ func spanWidth(n ast.Node) int {
 // unmarshalParams decodes req.Params into `target`, tolerating a
 // missing Params field (producing the zero value of target).
 func unmarshalParams(req *rpcRequest, target any) error {
-	if len(req.Params) == 0 || string(req.Params) == "null" {
+	if LSPParamsAreEmpty(req.Params) {
 		return nil
 	}
 	return json.Unmarshal(req.Params, target)
@@ -682,7 +673,7 @@ func unmarshalParams(req *rpcRequest, target any) error {
 // the client isn't left waiting.
 func replyJSON(c *conn, id json.RawMessage, v any) {
 	if v == nil {
-		_ = c.writeResponse(id, json.RawMessage("null"))
+		_ = c.writeResponse(id, json.RawMessage(LSPJSONNull()))
 		return
 	}
 	raw, err := json.Marshal(v)

--- a/internal/lsp/inlay.go
+++ b/internal/lsp/inlay.go
@@ -55,7 +55,7 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			}
 			hints = append(hints, InlayHint{
 				Position:    doc.analysis.lines.ostyToLSP(ip.End()),
-				Label:       ": " + inlayTypeString(t),
+				Label:       LSPInlayTypeLabel(inlayTypeString(t)),
 				Kind:        InlayHintKindType,
 				PaddingLeft: false,
 			})
@@ -73,7 +73,7 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			}
 			hints = append(hints, InlayHint{
 				Position: doc.analysis.lines.offsetToLSP(nameOff + len(v.Name)),
-				Label:    ": " + inlayTypeString(t),
+				Label:    LSPInlayTypeLabel(inlayTypeString(t)),
 				Kind:     InlayHintKindType,
 			})
 		}

--- a/internal/lsp/jsonrpc.go
+++ b/internal/lsp/jsonrpc.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -68,40 +66,26 @@ func (c *conn) readMessage() ([]byte, error) {
 // stream ends cleanly before any header bytes were seen; a partial
 // header block is a framing error.
 func readHeaders(r *bufio.Reader) (int, error) {
-	length := -1
-	sawAnyHeader := false
+	var lines []string
 	for {
 		line, err := r.ReadString('\n')
 		if err != nil {
-			if errors.Is(err, io.EOF) && !sawAnyHeader && line == "" {
+			if errors.Is(err, io.EOF) && len(lines) == 0 && line == "" {
 				return 0, io.EOF
 			}
 			return 0, fmt.Errorf("lsp: header read: %w", err)
 		}
 		// Accept both CRLF (required by spec) and bare LF (tolerant
 		// for pipes and test harnesses).
-		line = strings.TrimRight(line, "\r\n")
+		line = LSPTrimHeaderLine(line)
 		if line == "" {
-			if !sawAnyHeader {
-				return 0, fmt.Errorf("lsp: empty header block")
+			parsed := LSPParseHeaderLines(lines)
+			if !parsed.OK {
+				return 0, errors.New(parsed.Error)
 			}
-			return length, nil
+			return parsed.ContentLength, nil
 		}
-		sawAnyHeader = true
-		colon := strings.IndexByte(line, ':')
-		if colon < 0 {
-			return 0, fmt.Errorf("lsp: malformed header %q", line)
-		}
-		name := strings.TrimSpace(line[:colon])
-		value := strings.TrimSpace(line[colon+1:])
-		if strings.EqualFold(name, "Content-Length") {
-			n, err := strconv.Atoi(value)
-			if err != nil || n < 0 {
-				return 0, fmt.Errorf("lsp: invalid Content-Length %q", value)
-			}
-			length = n
-		}
-		// Other headers (Content-Type) are intentionally ignored.
+		lines = append(lines, line)
 	}
 }
 
@@ -109,7 +93,7 @@ func readHeaders(r *bufio.Reader) (int, error) {
 // pushes it to the writer atomically.
 func (c *conn) writeMessage(body []byte) error {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Content-Length: %d\r\n\r\n", len(body))
+	buf.WriteString(LSPFrameHeader(len(body)))
 	buf.Write(body)
 
 	c.writeMu.Lock()
@@ -133,7 +117,7 @@ func (c *conn) writeError(id json.RawMessage, code int, message string) error {
 	if id == nil {
 		// Preserve null ID so clients can correlate parse-time
 		// failures. An empty RawMessage would be omitted.
-		id = json.RawMessage("null")
+		id = json.RawMessage(LSPJSONNull())
 	}
 	return c.writeMessage(mustMarshal(rpcResponse{
 		JSONRPC: "2.0",

--- a/internal/lsp/policy.go
+++ b/internal/lsp/policy.go
@@ -1,6 +1,10 @@
 package lsp
 
-import "github.com/osty/osty/internal/selfhost"
+import (
+	"encoding/json"
+
+	"github.com/osty/osty/internal/selfhost"
+)
 
 type LSPSemanticToken struct {
 	Line      uint32
@@ -26,6 +30,30 @@ type LSPLocation struct {
 	EndCharacter   uint32
 }
 
+type LSPReferenceFact struct {
+	URI                  string
+	StartLine            uint32
+	StartCharacter       uint32
+	EndLine              uint32
+	EndCharacter         uint32
+	TargetSymbolID       string
+	TargetURI            string
+	TargetStartLine      uint32
+	TargetStartCharacter uint32
+	TargetEndLine        uint32
+	TargetEndCharacter   uint32
+	Builtin              bool
+}
+
+type LSPSymbolFact struct {
+	ID             string
+	URI            string
+	StartLine      uint32
+	StartCharacter uint32
+	EndLine        uint32
+	EndCharacter   uint32
+}
+
 type LSPSymbolSortKey struct {
 	Name string
 	URI  string
@@ -35,6 +63,14 @@ type LSPImportSortKey struct {
 	Group int
 	Key   string
 	Alias string
+}
+
+type LSPOrganizeUseEntry struct {
+	Group  int
+	Key    string
+	Alias  string
+	Text   string
+	Unused bool
 }
 
 type LSPSignatureParam struct {
@@ -47,6 +83,12 @@ type LSPSignatureText struct {
 	ParameterLabels []string
 }
 
+type LSPFunctionTypeParts struct {
+	OK             bool
+	ParameterTypes []string
+	ReturnType     string
+}
+
 type LSPCompletionContext struct {
 	Prefix   string
 	AfterDot string
@@ -55,6 +97,54 @@ type LSPCompletionContext struct {
 type LSPDiagnosticPayload struct {
 	Severity uint32
 	Message  string
+}
+
+type LSPDiagnosticView struct {
+	StartLine      uint32
+	StartCharacter uint32
+	EndLine        uint32
+	EndCharacter   uint32
+	Severity       uint32
+	Code           string
+	Source         string
+	Message        string
+}
+
+type LSPDiagnosticFileFact struct {
+	DiagnosticFile      string
+	PackageFile         string
+	SpanSourceFileID    string
+	PackageSourceFileID string
+	PrimaryLine         int
+	PrimaryOffset       int
+	SourceLength        int
+}
+
+type LSPHeaderParseResult struct {
+	OK            bool
+	ContentLength int
+	Error         string
+}
+
+type LSPFileURIPathRawResult struct {
+	OK   bool
+	Path string
+}
+
+type LSPCompletionItemData struct {
+	Label         string
+	Kind          uint32
+	SortText      string
+	Detail        string
+	Documentation string
+}
+
+type LSPCompletionCandidateView struct {
+	Name     string
+	Kind     string
+	TypeText string
+	DocText  string
+	Include  bool
 }
 
 type LSPPosition struct {
@@ -71,6 +161,17 @@ type LSPOstyPosition struct {
 	Offset int
 	Line   int
 	Column int
+}
+
+type LSPFullDocumentRange struct {
+	EndLine      uint32
+	EndCharacter uint32
+}
+
+type LSPDispatchDecision struct {
+	Action       string
+	ErrorCode    int
+	ErrorMessage string
 }
 
 func LSPSemanticTypeForTokenKind(kind, symbolKind string) (uint32, bool) {
@@ -103,6 +204,142 @@ func LSPHoverSignatureLine(kind, name, typeText string) string {
 
 func LSPPathToURI(path string) string {
 	return selfhost.LSPPathToURI(path)
+}
+
+func LSPServerName() string {
+	return selfhost.LSPServerName()
+}
+
+func LSPServerVersion() string {
+	return selfhost.LSPServerVersion()
+}
+
+func LSPPositionEncodingUTF16() string {
+	return selfhost.LSPPositionEncodingUTF16()
+}
+
+func LSPJSONNull() string {
+	return selfhost.LSPJSONNull()
+}
+
+func LSPCompletionTriggerDot() string {
+	return selfhost.LSPCompletionTriggerDot()
+}
+
+func LSPSignatureTriggerOpenParen() string {
+	return selfhost.LSPSignatureTriggerOpenParen()
+}
+
+func LSPSignatureTriggerComma() string {
+	return selfhost.LSPSignatureTriggerComma()
+}
+
+func LSPSemanticTokenTypes() []string {
+	return selfhost.LSPSemanticTokenTypes()
+}
+
+func LSPSemanticTokenModifiers() []string {
+	return selfhost.LSPSemanticTokenModifiers()
+}
+
+func LSPDispatchActionInitialize() string { return selfhost.LSPDispatchActionInitialize() }
+func LSPDispatchActionExit() string       { return selfhost.LSPDispatchActionExit() }
+func LSPDispatchActionShutdown() string   { return selfhost.LSPDispatchActionShutdown() }
+func LSPDispatchActionIgnore() string     { return selfhost.LSPDispatchActionIgnore() }
+func LSPDispatchActionDispatch() string   { return selfhost.LSPDispatchActionDispatch() }
+func LSPDispatchActionError() string      { return selfhost.LSPDispatchActionError() }
+
+func LSPAsciiLowerText(text string) string {
+	return selfhost.LSPAsciiLowerText(text)
+}
+
+func LSPNameMatchesPrefix(name, prefix string) bool {
+	return selfhost.LSPNameMatchesPrefix(name, prefix)
+}
+
+func LSPNameMatchesQuery(name, query string) bool {
+	return selfhost.LSPNameMatchesQuery(name, query)
+}
+
+func LSPURIForSourcePath(path string) string {
+	return selfhost.LSPURIForSourcePath(path)
+}
+
+func LSPFileURIPathRaw(uri string) LSPFileURIPathRawResult {
+	result := selfhost.LSPFileURIPathRaw(uri)
+	return LSPFileURIPathRawResult{
+		OK:   result.OK,
+		Path: result.Path,
+	}
+}
+
+func LSPPreferAIRepairFixAll(src []byte) bool {
+	return selfhost.LSPPreferAIRepairFixAll(string(src))
+}
+
+func LSPTextChanged(original, replacement []byte) bool {
+	return selfhost.LSPTextChanged(string(original), string(replacement))
+}
+
+func LSPParamsAreEmpty(params json.RawMessage) bool {
+	return selfhost.LSPParamsAreEmpty(string(params))
+}
+
+func LSPRenameEmptyNameMessage() string {
+	return selfhost.LSPRenameEmptyNameMessage()
+}
+
+func LSPCannotRenameBuiltinMessage() string {
+	return selfhost.LSPCannotRenameBuiltinMessage()
+}
+
+func LSPCanRenameKind(kind string) bool {
+	return selfhost.LSPCanRenameKind(kind)
+}
+
+func LSPRenameTitle(name string) string {
+	return selfhost.LSPRenameTitle(name)
+}
+
+func LSPRemoveLineTitle() string {
+	return selfhost.LSPRemoveLineTitle()
+}
+
+func LSPFixAllTitle() string {
+	return selfhost.LSPFixAllTitle()
+}
+
+func LSPOrganizeImportsTitle() string {
+	return selfhost.LSPOrganizeImportsTitle()
+}
+
+func LSPInlayTypeLabel(typeText string) string {
+	return selfhost.LSPInlayTypeLabel(typeText)
+}
+
+func LSPMethodNotImplementedMessage(method string) string {
+	return selfhost.LSPMethodNotImplementedMessage(method)
+}
+
+func LSPIsOstySourceFileName(name string) bool {
+	return selfhost.LSPIsOstySourceFileName(name)
+}
+
+func LSPHasOstyFileExtension(name string) bool {
+	return selfhost.LSPHasOstyFileExtension(name)
+}
+
+func LSPExitCode(shutdown bool) int {
+	return selfhost.LSPExitCode(shutdown)
+}
+
+func LSPDispatchDecisionFor(method string, isNotification bool, initialized bool, shutdown bool) LSPDispatchDecision {
+	decision := selfhost.LSPDispatchDecisionFor(method, isNotification, initialized, shutdown)
+	return LSPDispatchDecision{
+		Action:       decision.Action,
+		ErrorCode:    decision.ErrorCode,
+		ErrorMessage: decision.ErrorMessage,
+	}
 }
 
 func LSPLineStarts(src []byte) []int {
@@ -146,6 +383,31 @@ func LSPRangeFromOffsets(src []byte, lineStarts []int, start, end int) LSPRange 
 func LSPRangeFromOstySpan(src []byte, lineStarts []int, startLine, startOffset, endLine, endOffset int) LSPRange {
 	rng := selfhost.LSPRangeFromOstySpan(string(src), lineStarts, startLine, startOffset, endLine, endOffset)
 	return lspRangeFromSelfhost(rng)
+}
+
+func LSPFullDocumentRangeFor(src []byte, lineStarts []int) LSPFullDocumentRange {
+	rng := selfhost.LSPFullDocumentRange(string(src), lineStarts)
+	return LSPFullDocumentRange{
+		EndLine:      uint32(rng.EndLine),
+		EndCharacter: uint32(rng.EndCharacter),
+	}
+}
+
+func LSPFrameHeader(bodyLength int) string {
+	return selfhost.LSPFrameHeader(bodyLength)
+}
+
+func LSPTrimHeaderLine(line string) string {
+	return selfhost.LSPTrimHeaderLine(line)
+}
+
+func LSPParseHeaderLines(lines []string) LSPHeaderParseResult {
+	parsed := selfhost.LSPParseHeaderLines(lines)
+	return LSPHeaderParseResult{
+		OK:            parsed.OK,
+		ContentLength: parsed.ContentLength,
+		Error:         parsed.Error,
+	}
 }
 
 func LSPSymbolKindForDecl(kind string, mutable bool) uint32 {
@@ -192,12 +454,74 @@ func LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd int) bool {
 	return selfhost.LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd)
 }
 
+func LSPNamedTypeReferenceEndOffset(startOffset, sourceLength int, targetName string, firstPath string) int {
+	firstPathMatchesTarget := firstPath != "" && firstPath == targetName
+	return selfhost.LSPNamedTypeReferenceEndOffset(startOffset, sourceLength, len(targetName), firstPathMatchesTarget, len(firstPath))
+}
+
 func LSPDiagnosticPayloadFor(severity, message, hint string, notes []string) LSPDiagnosticPayload {
 	payload := selfhost.LSPDiagnosticPayloadFor(severity, message, hint, notes)
 	return LSPDiagnosticPayload{
 		Severity: uint32(payload.Severity),
 		Message:  payload.Message,
 	}
+}
+
+func LSPDiagnosticsEqual(a, b []LSPDiagnosticView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	convertedA := make([]selfhost.LSPDiagnosticView, 0, len(a))
+	for _, diag := range a {
+		convertedA = append(convertedA, selfhost.LSPDiagnosticView{
+			StartLine:      int(diag.StartLine),
+			StartCharacter: int(diag.StartCharacter),
+			EndLine:        int(diag.EndLine),
+			EndCharacter:   int(diag.EndCharacter),
+			Severity:       int(diag.Severity),
+			Code:           diag.Code,
+			Source:         diag.Source,
+			Message:        diag.Message,
+		})
+	}
+	convertedB := make([]selfhost.LSPDiagnosticView, 0, len(b))
+	for _, diag := range b {
+		convertedB = append(convertedB, selfhost.LSPDiagnosticView{
+			StartLine:      int(diag.StartLine),
+			StartCharacter: int(diag.StartCharacter),
+			EndLine:        int(diag.EndLine),
+			EndCharacter:   int(diag.EndCharacter),
+			Severity:       int(diag.Severity),
+			Code:           diag.Code,
+			Source:         diag.Source,
+			Message:        diag.Message,
+		})
+	}
+	return selfhost.LSPDiagnosticsEqual(convertedA, convertedB)
+}
+
+func LSPDiagnosticBelongsToFile(fact LSPDiagnosticFileFact) bool {
+	return selfhost.LSPDiagnosticBelongsToFile(selfhost.LSPDiagnosticFileFact{
+		DiagnosticFile:      fact.DiagnosticFile,
+		PackageFile:         fact.PackageFile,
+		SpanSourceFileID:    fact.SpanSourceFileID,
+		PackageSourceFileID: fact.PackageSourceFileID,
+		PrimaryLine:         fact.PrimaryLine,
+		PrimaryOffset:       fact.PrimaryOffset,
+		SourceLength:        fact.SourceLength,
+	})
+}
+
+func LSPLevenshteinBounded(a, b string, limit int) int {
+	return selfhost.LSPLevenshteinBounded(a, b, limit)
+}
+
+func LSPRankNearbyNames(names []string, target string, maxDistance int) []string {
+	return selfhost.LSPRankNearbyNames(names, target, maxDistance)
+}
+
+func LSPMergeNearbyNames(primary []string, fallback []string) []string {
+	return selfhost.LSPMergeNearbyNames(primary, fallback)
 }
 
 func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
@@ -225,6 +549,89 @@ func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
 	return out
 }
 
+func LSPLocationsForTarget(refs []LSPReferenceFact, symbols []LSPSymbolFact, targetID string, includeDecl bool) []LSPLocation {
+	convertedRefs := make([]selfhost.LSPReferenceFact, 0, len(refs))
+	for _, ref := range refs {
+		convertedRefs = append(convertedRefs, selfhost.LSPReferenceFact{
+			URI:                  ref.URI,
+			StartLine:            int(ref.StartLine),
+			StartCharacter:       int(ref.StartCharacter),
+			EndLine:              int(ref.EndLine),
+			EndCharacter:         int(ref.EndCharacter),
+			TargetSymbolID:       ref.TargetSymbolID,
+			TargetURI:            ref.TargetURI,
+			TargetStartLine:      int(ref.TargetStartLine),
+			TargetStartCharacter: int(ref.TargetStartCharacter),
+			TargetEndLine:        int(ref.TargetEndLine),
+			TargetEndCharacter:   int(ref.TargetEndCharacter),
+			Builtin:              ref.Builtin,
+		})
+	}
+	convertedSymbols := make([]selfhost.LSPSymbolFact, 0, len(symbols))
+	for _, sym := range symbols {
+		convertedSymbols = append(convertedSymbols, selfhost.LSPSymbolFact{
+			ID:             sym.ID,
+			URI:            sym.URI,
+			StartLine:      int(sym.StartLine),
+			StartCharacter: int(sym.StartCharacter),
+			EndLine:        int(sym.EndLine),
+			EndCharacter:   int(sym.EndCharacter),
+		})
+	}
+	resolved := selfhost.LSPLocationsForTarget(convertedRefs, convertedSymbols, targetID, includeDecl)
+	out := make([]LSPLocation, 0, len(resolved))
+	for _, loc := range resolved {
+		out = append(out, LSPLocation{
+			URI:            loc.URI,
+			StartLine:      uint32(loc.StartLine),
+			StartCharacter: uint32(loc.StartCharacter),
+			EndLine:        uint32(loc.EndLine),
+			EndCharacter:   uint32(loc.EndCharacter),
+		})
+	}
+	return out
+}
+
+func LSPCompletionItemForSymbolView(view selfhost.LSPSymbolView) LSPCompletionItemData {
+	item := selfhost.LSPCompletionItemForSymbolView(view)
+	return LSPCompletionItemData{
+		Label:         item.Label,
+		Kind:          uint32(item.Kind),
+		SortText:      item.SortText,
+		Detail:        item.Detail,
+		Documentation: item.Documentation,
+	}
+}
+
+func LSPCompletionItemsForCandidates(candidates []LSPCompletionCandidateView, prefix string) []LSPCompletionItemData {
+	converted := make([]selfhost.LSPCompletionCandidateView, 0, len(candidates))
+	for _, candidate := range candidates {
+		converted = append(converted, selfhost.LSPCompletionCandidateView{
+			Name:     candidate.Name,
+			Kind:     candidate.Kind,
+			TypeText: candidate.TypeText,
+			DocText:  candidate.DocText,
+			Include:  candidate.Include,
+		})
+	}
+	items := selfhost.LSPCompletionItemsForCandidates(converted, prefix)
+	out := make([]LSPCompletionItemData, 0, len(items))
+	for _, item := range items {
+		out = append(out, LSPCompletionItemData{
+			Label:         item.Label,
+			Kind:          uint32(item.Kind),
+			SortText:      item.SortText,
+			Detail:        item.Detail,
+			Documentation: item.Documentation,
+		})
+	}
+	return out
+}
+
+func LSPSemanticHoverKind(kind string) string {
+	return selfhost.LSPSemanticHoverKind(kind)
+}
+
 func SortLSPSymbolIndexes(keys []LSPSymbolSortKey) []int {
 	converted := make([]selfhost.LSPSymbolSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -240,6 +647,25 @@ func SortLSPCompletionIndexes(labels []string) []int {
 	return selfhost.SortLSPCompletionIndexes(labels)
 }
 
+func SortLSPStringIndexes(values []string) []int {
+	return selfhost.SortLSPStringIndexes(values)
+}
+
+func SortLSPStrings(values []string) []string {
+	if len(values) <= 1 {
+		return values
+	}
+	indexes := SortLSPStringIndexes(values)
+	out := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx < 0 || idx >= len(values) {
+			continue
+		}
+		out = append(out, values[idx])
+	}
+	return out
+}
+
 func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 	converted := make([]selfhost.LSPImportSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -250,6 +676,20 @@ func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 		})
 	}
 	return selfhost.SortLSPImportIndexes(converted)
+}
+
+func LSPOrganizedUseBlock(entries []LSPOrganizeUseEntry) string {
+	converted := make([]selfhost.LSPOrganizeUseEntry, 0, len(entries))
+	for _, entry := range entries {
+		converted = append(converted, selfhost.LSPOrganizeUseEntry{
+			Group:  entry.Group,
+			Key:    entry.Key,
+			Alias:  entry.Alias,
+			Text:   entry.Text,
+			Unused: entry.Unused,
+		})
+	}
+	return selfhost.LSPOrganizedUseBlock(converted)
 }
 
 func LSPUseGroup(isGoFFI bool, path []string) int {
@@ -293,6 +733,19 @@ func LSPBuildSignatureText(name string, params []LSPSignatureParam, returnType s
 		Label:           rendered.Label,
 		ParameterLabels: append([]string(nil), rendered.ParameterLabels...),
 	}
+}
+
+func LSPParseFunctionType(typeText string) LSPFunctionTypeParts {
+	parsed := selfhost.LSPParseFunctionType(typeText)
+	return LSPFunctionTypeParts{
+		OK:             parsed.OK,
+		ParameterTypes: append([]string(nil), parsed.ParameterTypes...),
+		ReturnType:     parsed.ReturnType,
+	}
+}
+
+func LSPFallbackParameterNames(count int) []string {
+	return selfhost.LSPFallbackParameterNames(count)
 }
 
 func EncodeLSPSemanticTokens(tokens []LSPSemanticToken) []uint32 {

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -32,7 +32,7 @@ type rpcRequest struct {
 // isNotification reports whether the message lacks an id (§LSP 3.17
 // "Notification Message"). Notifications must never be answered.
 func (r *rpcRequest) isNotification() bool {
-	return len(r.ID) == 0 || string(r.ID) == "null"
+	return LSPParamsAreEmpty(r.ID)
 }
 
 // rpcResponse is the outgoing reply to a request. Exactly one of

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -1,9 +1,6 @@
 package lsp
 
 import (
-	"bytes"
-	"strings"
-
 	"github.com/osty/osty/internal/airepair"
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/canonical"
@@ -76,42 +73,20 @@ func organizeImportsAction(doc *document) *CodeAction {
 	}
 	unused := unusedUseOffsets(doc)
 
-	kept := make([]keyedUse, 0, len(views))
-	seen := make(map[string]bool, len(views))
+	entries := make([]LSPOrganizeUseEntry, 0, len(views))
 	for _, v := range views {
-		if unused[v.PosOffset] {
-			continue
-		}
 		text := LSPUseSourceText(doc.src, v.PosOffset, v.EndOffset)
-		if text == "" {
-			continue
-		}
 		group := LSPUseGroup(v.IsFFI, v.Path)
 		key := LSPUseKey(v.IsFFI, v.FFIPath, v.RawPath, v.Path)
-		// Dedup by (group, key, alias) — two identical `use` lines
-		// collapse to one.
-		dedupKey := LSPKeyWithAlias(group, key, v.Alias)
-		if seen[dedupKey] {
-			continue
-		}
-		seen[dedupKey] = true
-		kept = append(kept, keyedUse{view: v, group: group, key: key, text: text})
+		entries = append(entries, LSPOrganizeUseEntry{
+			Group:  group,
+			Key:    key,
+			Alias:  v.Alias,
+			Text:   text,
+			Unused: unused[v.PosOffset],
+		})
 	}
-	kept = sortImportEntries(kept)
-
-	// Build the replacement block. Separate groups with a blank line so
-	// the output matches what `osty fmt` would emit after the reorder.
-	var b strings.Builder
-	prevGroup := -1
-	for i, k := range kept {
-		if i > 0 && k.group != prevGroup {
-			b.WriteByte('\n')
-		}
-		b.WriteString(k.text)
-		b.WriteByte('\n')
-		prevGroup = k.group
-	}
-	newText := b.String()
+	newText := LSPOrganizedUseBlock(entries)
 
 	// Replacement range covers the full `use` block: from the first
 	// use's start to just past the last use's terminating newline. We
@@ -126,7 +101,7 @@ func organizeImportsAction(doc *document) *CodeAction {
 
 	rng := doc.analysis.lines.rangeFromOffsets(startOff, endOff)
 	return &CodeAction{
-		Title: "Organize imports",
+		Title: LSPOrganizeImportsTitle(),
 		Kind:  CodeActionSourceOrganizeImports,
 		Edit: &WorkspaceEdit{
 			Changes: map[string][]TextEdit{
@@ -246,10 +221,10 @@ func fixAllAction(doc *document) *CodeAction {
 	// deliberately does not rewrite semantic JS habits like `.length`.
 	// When that property is present, prefer airepair's broader repair so
 	// fix-all doesn't stop after a partial canonicalization.
-	if bytes.Contains(doc.src, []byte(".length")) {
+	if LSPPreferAIRepairFixAll(doc.src) {
 		if edit := airepairFixAllEdit(doc); edit != nil {
 			return &CodeAction{
-				Title: "Fix all auto-fixable problems",
+				Title: LSPFixAllTitle(),
 				Kind:  CodeActionSourceFixAllOsty,
 				Edit: &WorkspaceEdit{
 					Changes: map[string][]TextEdit{
@@ -261,7 +236,7 @@ func fixAllAction(doc *document) *CodeAction {
 	}
 	if edit := parserCanonicalFixAllEdit(doc); edit != nil {
 		return &CodeAction{
-			Title: "Fix all auto-fixable problems",
+			Title: LSPFixAllTitle(),
 			Kind:  CodeActionSourceFixAllOsty,
 			Edit: &WorkspaceEdit{
 				Changes: map[string][]TextEdit{
@@ -272,7 +247,7 @@ func fixAllAction(doc *document) *CodeAction {
 	}
 	if edit := airepairFixAllEdit(doc); edit != nil {
 		return &CodeAction{
-			Title: "Fix all auto-fixable problems",
+			Title: LSPFixAllTitle(),
 			Kind:  CodeActionSourceFixAllOsty,
 			Edit: &WorkspaceEdit{
 				Changes: map[string][]TextEdit{
@@ -293,7 +268,7 @@ func fixAllAction(doc *document) *CodeAction {
 	// of fix-all.
 	edits = resolveOverlaps(edits)
 	return &CodeAction{
-		Title: "Fix all auto-fixable problems",
+		Title: LSPFixAllTitle(),
 		Kind:  CodeActionSourceFixAllOsty,
 		Edit: &WorkspaceEdit{
 			Changes: map[string][]TextEdit{
@@ -317,7 +292,7 @@ func parserCanonicalFixAllEdit(doc *document) *TextEdit {
 		return nil
 	}
 	canonicalSrc := canonical.Source(doc.src, parsed.File)
-	if len(canonicalSrc) == 0 || bytes.Equal(canonicalSrc, doc.src) {
+	if len(canonicalSrc) == 0 || !LSPTextChanged(doc.src, canonicalSrc) {
 		return nil
 	}
 	rng := doc.analysis.lines.rangeFromOffsets(0, len(doc.src))

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -70,7 +70,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 		return
 	}
 	if params.NewName == "" {
-		_ = s.conn.writeError(req.ID, errInvalidParams, "new name is empty")
+		_ = s.conn.writeError(req.ID, errInvalidParams, LSPRenameEmptyNameMessage())
 		return
 	}
 	doc := s.docs.get(params.TextDocument.URI)
@@ -88,7 +88,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 			return
 		}
 		if ref.builtin {
-			_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+			_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 			return
 		}
 		edits := structuredRenameEditsFor(doc.analysis.structuredRefs, doc.analysis.structuredSymbols, ref.targetSymbolID, params.NewName)
@@ -101,7 +101,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 			return
 		}
 		if sym.builtin {
-			_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+			_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 			return
 		}
 		edits := structuredRenameEditsFor(doc.analysis.structuredRefs, doc.analysis.structuredSymbols, sym.id, params.NewName)
@@ -113,8 +113,8 @@ func (s *Server) handleRename(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, nil)
 		return
 	}
-	if target.Kind == resolve.SymBuiltin {
-		_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+	if !LSPCanRenameKind(target.Kind.String()) {
+		_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 		return
 	}
 	edits := s.renameEditsFor(doc, target, params.NewName)
@@ -142,7 +142,7 @@ func (s *Server) semanticRenameEdits(doc *document, lspPos Position, newName str
 	if !ok {
 		return nil, false
 	}
-	if target.Kind == "builtin" {
+	if !LSPCanRenameKind(target.Kind) {
 		return nil, false
 	}
 	out := map[string][]TextEdit{}
@@ -216,13 +216,11 @@ func (s *Server) findReferences(doc *document, target *resolve.Symbol, includeDe
 			// is `auth`. Narrow to the head identifier so the rename
 			// doesn't chew through the whole path.
 			startOff := nt.Pos().Offset
-			endOff := startOff + len(target.Name)
-			if len(nt.Path) > 0 && nt.Path[0] == target.Name {
-				endOff = startOff + len(nt.Path[0])
+			firstPath := ""
+			if len(nt.Path) > 0 {
+				firstPath = nt.Path[0]
 			}
-			if endOff > len(src) {
-				endOff = len(src)
-			}
+			endOff := LSPNamedTypeReferenceEndOffset(startOff, len(src), target.Name, firstPath)
 			out = append(out, Location{
 				URI:   uri,
 				Range: li.rangeFromOffsets(startOff, endOff),

--- a/internal/lsp/selfhost_policy_test.go
+++ b/internal/lsp/selfhost_policy_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"reflect"
@@ -51,6 +52,20 @@ func TestCompletionSortUsesSelfHostedPolicy(t *testing.T) {
 	if labels := []string{got[0].Label, got[1].Label, got[2].Label}; !reflect.DeepEqual(labels, []string{"alpha", "middle", "zeta"}) {
 		t.Fatalf("completion labels = %#v", labels)
 	}
+
+	filtered := LSPCompletionItemsForCandidates([]LSPCompletionCandidateView{
+		{Name: "zeta", Kind: "binding", TypeText: "Int", Include: true},
+		{Name: "alpha", Kind: "function", TypeText: "fn() -> Int", DocText: "docs", Include: true},
+		{Name: "alpha", Kind: "binding", TypeText: "String", Include: true},
+		{Name: "hidden", Kind: "binding", TypeText: "Int"},
+		{Name: "", Kind: "binding", TypeText: "Int", Include: true},
+	}, "")
+	if labels := []string{filtered[0].Label, filtered[1].Label}; !reflect.DeepEqual(labels, []string{"alpha", "zeta"}) {
+		t.Fatalf("completion candidate labels = %#v", labels)
+	}
+	if filtered[0].Detail != "fn alpha() -> Int" || filtered[0].Documentation != "docs" {
+		t.Fatalf("completion candidate item = %+v", filtered[0])
+	}
 }
 
 func TestSymbolKindUsesSelfHostedPolicy(t *testing.T) {
@@ -91,6 +106,56 @@ func TestWantsKindUsesSelfHostedPrefixPolicy(t *testing.T) {
 	}
 }
 
+func TestJSONRPCHeaderPolicyUsesSelfHost(t *testing.T) {
+	parsed := LSPParseHeaderLines([]string{
+		"Content-Type: application/vscode-jsonrpc; charset=utf-8",
+		"content-length: 42",
+	})
+	if !parsed.OK || parsed.ContentLength != 42 || parsed.Error != "" {
+		t.Fatalf("header parse = %+v, want length 42", parsed)
+	}
+	missing := LSPParseHeaderLines([]string{"Content-Type: application/json"})
+	if !missing.OK || missing.ContentLength != -1 {
+		t.Fatalf("missing content length = %+v, want ok length -1", missing)
+	}
+	if got := LSPParseHeaderLines(nil); got.OK || got.Error != "lsp: empty header block" {
+		t.Fatalf("empty header parse = %+v, want empty-block error", got)
+	}
+	if got := LSPParseHeaderLines([]string{"Content-Length: -1"}); got.OK {
+		t.Fatalf("negative content length parsed ok: %+v", got)
+	}
+	if got := LSPFrameHeader(17); got != "Content-Length: 17\r\n\r\n" {
+		t.Fatalf("frame header = %q", got)
+	}
+	if got := LSPTrimHeaderLine("Content-Length: 17\r\n"); got != "Content-Length: 17" {
+		t.Fatalf("trimmed header line = %q", got)
+	}
+	length, err := readHeaders(bufio.NewReader(strings.NewReader("Content-Type: x\r\ncontent-length: 2\r\n\r\n{}")))
+	if err != nil || length != 2 {
+		t.Fatalf("readHeaders = (%d, %v), want (2, nil)", length, err)
+	}
+}
+
+func TestNearbyNameRankingUsesSelfHostedPolicy(t *testing.T) {
+	if got := LSPLevenshteinBounded("kitten", "sitting", 3); got != 3 {
+		t.Fatalf("levenshtein = %d, want 3", got)
+	}
+	if got := LSPLevenshteinBounded("kitten", "sitting", 2); got != 3 {
+		t.Fatalf("bounded levenshtein = %d, want limit+1", got)
+	}
+	got := nearbyStructuredSymbolNames([]structuredSymbol{
+		{name: "helpr"},
+		{name: "helper"},
+		{name: "helper"},
+		{name: "helmet"},
+		{name: "builtin", builtin: true},
+		{name: "local", depth: 1},
+	}, "helper", 1)
+	if want := []string{"helper", "helpr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("nearby names = %#v, want %#v", got, want)
+	}
+}
+
 func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
 	if got := LSPHoverSignatureLine("struct", "User", ""); got != "struct User" {
 		t.Fatalf("hover signature = %q", got)
@@ -100,6 +165,196 @@ func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got := LSPCompletionDetail("function", "map", "fn(Int) -> String"); got != "fn map(Int) -> String" {
 		t.Fatalf("completion detail = %q", got)
+	}
+}
+
+func TestNameURIAndFixAllPolicyUseSelfHost(t *testing.T) {
+	if got := LSPServerName(); got != "osty-lsp" {
+		t.Fatalf("server name = %q", got)
+	}
+	if got := LSPServerVersion(); got != "0.1.0" {
+		t.Fatalf("server version = %q", got)
+	}
+	if got := LSPPositionEncodingUTF16(); got != "utf-16" {
+		t.Fatalf("encoding = %q", got)
+	}
+	if got := LSPJSONNull(); got != "null" {
+		t.Fatalf("json null = %q", got)
+	}
+	if got := []string{LSPCompletionTriggerDot(), LSPSignatureTriggerOpenParen(), LSPSignatureTriggerComma()}; !reflect.DeepEqual(got, []string{".", "(", ","}) {
+		t.Fatalf("triggers = %#v", got)
+	}
+	if got := LSPSemanticTokenTypes(); got[0] != "namespace" || got[len(got)-1] != "enumMember" {
+		t.Fatalf("semantic token legend = %#v", got)
+	}
+	if got := LSPSemanticTokenModifiers(); !reflect.DeepEqual(got, []string{"declaration", "readonly"}) {
+		t.Fatalf("semantic token modifiers = %#v", got)
+	}
+	if got := LSPExitCode(true); got != 0 {
+		t.Fatalf("exit code = %d, want 0", got)
+	}
+	if got := LSPExitCode(false); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+	if got := LSPDispatchDecisionFor("initialize", false, false, false); got.Action != LSPDispatchActionInitialize() {
+		t.Fatalf("initialize decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("textDocument/hover", false, false, false); got.ErrorCode != errServerNotInitialized {
+		t.Fatalf("pre-init decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("shutdown", false, true, false); got.Action != LSPDispatchActionShutdown() {
+		t.Fatalf("shutdown decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("textDocument/hover", false, true, false); got.Action != LSPDispatchActionDispatch() {
+		t.Fatalf("hover decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("unknown/method", false, true, false); got.ErrorCode != errMethodNotFound {
+		t.Fatalf("unknown request decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("unknown/method", true, true, false); got.Action != LSPDispatchActionIgnore() {
+		t.Fatalf("unknown notification decision = %+v", got)
+	}
+	if got := LSPAsciiLowerText("HeLLo"); got != "hello" {
+		t.Fatalf("lower text = %q, want hello", got)
+	}
+	if !LSPNameMatchesPrefix("helper", "hel") || LSPNameMatchesPrefix("helper", "map") {
+		t.Fatal("prefix policy mismatch")
+	}
+	if !LSPNameMatchesQuery("HelperValue", "value") {
+		t.Fatal("query policy did not match lowercase substring")
+	}
+	if got := LSPURIForSourcePath("inmemory:main"); got != "inmemory:main" {
+		t.Fatalf("source URI = %q, want inmemory:main", got)
+	}
+	if got := LSPURIForSourcePath("/tmp/main.osty"); got != "file:///tmp/main.osty" {
+		t.Fatalf("file source URI = %q", got)
+	}
+	if got := LSPFileURIPathRaw("file:///tmp/main.osty"); !got.OK || got.Path != "/tmp/main.osty" {
+		t.Fatalf("file URI raw path = %+v", got)
+	}
+	if got := LSPFileURIPathRaw("file:///C:/tmp/main.osty"); !got.OK || got.Path != "C:/tmp/main.osty" {
+		t.Fatalf("windows file URI raw path = %+v", got)
+	}
+	if got := LSPFileURIPathRaw("inmemory:main"); got.OK {
+		t.Fatalf("non-file URI raw path = %+v", got)
+	}
+	if !LSPPreferAIRepairFixAll([]byte("x.length")) || LSPPreferAIRepairFixAll([]byte("x.len()")) {
+		t.Fatal("fix-all preference policy mismatch")
+	}
+	if !LSPTextChanged([]byte("a"), []byte("b")) || LSPTextChanged([]byte("a"), []byte("a")) {
+		t.Fatal("text changed policy mismatch")
+	}
+	if !LSPParamsAreEmpty(nil) || !LSPParamsAreEmpty([]byte("null")) || LSPParamsAreEmpty([]byte("{}")) {
+		t.Fatal("params empty policy mismatch")
+	}
+	if got := LSPRenameEmptyNameMessage(); got != "new name is empty" {
+		t.Fatalf("empty rename message = %q", got)
+	}
+	if got := LSPCannotRenameBuiltinMessage(); got != "cannot rename a builtin" {
+		t.Fatalf("builtin rename message = %q", got)
+	}
+	if !LSPCanRenameKind("function") || LSPCanRenameKind("builtin") {
+		t.Fatal("rename kind policy mismatch")
+	}
+	if got := LSPRenameTitle("helper"); got != "Rename to `helper`" {
+		t.Fatalf("rename title = %q", got)
+	}
+	if got := LSPRemoveLineTitle(); got != "Remove unused import" {
+		t.Fatalf("remove title = %q", got)
+	}
+	if got := LSPFixAllTitle(); got != "Fix all auto-fixable problems" {
+		t.Fatalf("fix-all title = %q", got)
+	}
+	if got := LSPOrganizeImportsTitle(); got != "Organize imports" {
+		t.Fatalf("organize title = %q", got)
+	}
+	if got := LSPInlayTypeLabel("Int"); got != ": Int" {
+		t.Fatalf("inlay label = %q", got)
+	}
+	if got := LSPMethodNotImplementedMessage("custom/method"); got != "method not implemented: custom/method" {
+		t.Fatalf("method message = %q", got)
+	}
+	if !LSPIsOstySourceFileName("main.osty") || LSPIsOstySourceFileName("main_test.osty") || LSPIsOstySourceFileName("main.go") {
+		t.Fatal("source filename policy mismatch")
+	}
+	if !LSPHasOstyFileExtension("main_test.osty") || LSPHasOstyFileExtension("main.go") {
+		t.Fatal("source extension policy mismatch")
+	}
+	item := LSPCompletionItemForSymbolView(selfhost.LSPSymbolView{
+		Name:     "map",
+		Kind:     "function",
+		TypeText: "fn(Int) -> String",
+		DocText:  "docs",
+		HasSym:   true,
+	})
+	if item.Label != "map" || item.Kind != uint32(CompletionItemFunction) || item.SortText != "2_map" || item.Detail != "fn map(Int) -> String" || item.Documentation != "docs" {
+		t.Fatalf("completion item policy = %+v", item)
+	}
+	if got := LSPSemanticHoverKind("generic"); got != "type parameter" {
+		t.Fatalf("semantic hover kind = %q", got)
+	}
+}
+
+func TestTargetLocationPolicyUsesSelfHost(t *testing.T) {
+	refs := []LSPReferenceFact{
+		{
+			URI:                  "file:///b.osty",
+			StartLine:            2,
+			StartCharacter:       0,
+			EndLine:              2,
+			EndCharacter:         4,
+			TargetSymbolID:       "sym.helper",
+			TargetURI:            "file:///decl.osty",
+			TargetStartLine:      1,
+			TargetStartCharacter: 1,
+			TargetEndLine:        1,
+			TargetEndCharacter:   7,
+		},
+		{
+			URI:            "file:///a.osty",
+			StartLine:      4,
+			StartCharacter: 1,
+			EndLine:        4,
+			EndCharacter:   7,
+			TargetSymbolID: "sym.helper",
+		},
+	}
+	symbols := []LSPSymbolFact{{
+		ID:             "sym.helper",
+		URI:            "file:///decl.osty",
+		StartLine:      1,
+		StartCharacter: 2,
+		EndLine:        1,
+		EndCharacter:   8,
+	}}
+	got := LSPLocationsForTarget(refs, symbols, "sym.helper", true)
+	want := []LSPLocation{
+		{URI: "file:///a.osty", StartLine: 4, StartCharacter: 1, EndLine: 4, EndCharacter: 7},
+		{URI: "file:///b.osty", StartLine: 2, StartCharacter: 0, EndLine: 2, EndCharacter: 4},
+		{URI: "file:///decl.osty", StartLine: 1, StartCharacter: 2, EndLine: 1, EndCharacter: 8},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("target locations = %#v, want %#v", got, want)
+	}
+	if got := LSPLocationsForTarget(refs, nil, "missing", true); len(got) != 0 {
+		t.Fatalf("missing target locations = %#v, want none", got)
+	}
+}
+
+func TestSignatureTypeParsingUsesSelfHostedPolicy(t *testing.T) {
+	parsed := LSPParseFunctionType("fn(Int, Result<String, Error>, fn(Int) -> Bool) -> String")
+	if !parsed.OK {
+		t.Fatal("function type did not parse")
+	}
+	wantParams := []string{"Int", "Result<String, Error>", "fn(Int) -> Bool"}
+	if !reflect.DeepEqual(parsed.ParameterTypes, wantParams) || parsed.ReturnType != "String" {
+		t.Fatalf("parsed function type = %+v, want params %#v return String", parsed, wantParams)
+	}
+	if got := LSPParseFunctionType("List<Int>"); got.OK {
+		t.Fatalf("non-function type parsed ok: %+v", got)
+	}
+	if got, want := LSPFallbackParameterNames(3), []string{"arg1", "arg2", "arg3"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback parameter names = %#v, want %#v", got, want)
 	}
 }
 
@@ -258,6 +513,12 @@ func TestIdentifierAtUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got := identifierAt(src, strings.Index(string(src), "값")); got != "값" {
 		t.Fatalf("identifierAt(unicode) = %q, want 값", got)
+	}
+	if got := LSPNamedTypeReferenceEndOffset(10, 20, "helper", "help"); got != 16 {
+		t.Fatalf("named type end = %d, want 16", got)
+	}
+	if got := LSPNamedTypeReferenceEndOffset(18, 20, "helper", ""); got != 20 {
+		t.Fatalf("clamped named type end = %d, want 20", got)
 	}
 }
 
@@ -536,6 +797,9 @@ func TestURIAndLocationPolicyUsesSelfHost(t *testing.T) {
 	if got := pathToURI(""); got != "file://" {
 		t.Fatalf("pathToURI(empty) = %q", got)
 	}
+	if got := LSPFullDocumentRangeFor([]byte("a😀\nend"), LSPLineStarts([]byte("a😀\nend"))); got.EndLine != 1 || got.EndCharacter != 3 {
+		t.Fatalf("full document range = %+v", got)
+	}
 
 	got := sortDedupLocations([]Location{
 		{
@@ -573,6 +837,9 @@ func TestURIAndLocationPolicyUsesSelfHost(t *testing.T) {
 	if got := []string{syms[0].Location.URI, syms[1].Location.URI, syms[2].Location.URI}; !reflect.DeepEqual(got, []string{"file:///a.osty", "file:///z.osty", "file:///b.osty"}) {
 		t.Fatalf("symbol order = %#v", got)
 	}
+	if got := SortLSPStrings([]string{"z.osty", "a.osty", "a.osty"}); !reflect.DeepEqual(got, []string{"a.osty", "a.osty", "z.osty"}) {
+		t.Fatalf("string order = %#v", got)
+	}
 }
 
 func TestDiagnosticPayloadUsesSelfHostedPolicy(t *testing.T) {
@@ -593,6 +860,41 @@ func TestDiagnosticPayloadUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got.Message != "unused value\nhelp: prefix it\nnote: declared here" {
 		t.Fatalf("message = %q", got.Message)
+	}
+	a := []LSPDiagnostic{got}
+	b := append([]LSPDiagnostic(nil), a...)
+	if !diagsEqual(a, b) {
+		t.Fatalf("diagnostics should be equal: %#v %#v", a, b)
+	}
+	b[0].Message = "changed"
+	if diagsEqual(a, b) {
+		t.Fatalf("diagnostics should differ: %#v %#v", a, b)
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		DiagnosticFile: "/tmp/main.osty",
+		PackageFile:    "/tmp/main.osty",
+		PrimaryOffset:  999,
+		SourceLength:   1,
+	}) {
+		t.Fatal("diagnostic file match should win")
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		SpanSourceFileID:    "src1",
+		PackageSourceFileID: "src1",
+		PrimaryOffset:       999,
+		SourceLength:        1,
+	}) {
+		t.Fatal("diagnostic source file id should match")
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		PrimaryLine:   1,
+		PrimaryOffset: 3,
+		SourceLength:  3,
+	}) {
+		t.Fatal("diagnostic offset fallback should match")
+	}
+	if LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{SourceLength: 3}) {
+		t.Fatal("zero-line diagnostic should not match")
 	}
 }
 
@@ -635,6 +937,16 @@ func TestImportOrganizeHelpersUseSelfHost(t *testing.T) {
 	})
 	if got := []string{sorted[0].key, sorted[1].view.Alias, sorted[2].view.Alias, sorted[3].key}; !reflect.DeepEqual(got, []string{"fmt", "a", "b", "zeta"}) {
 		t.Fatalf("import order = %#v", got)
+	}
+	block := LSPOrganizedUseBlock([]LSPOrganizeUseEntry{
+		{Group: 1, Key: "zeta", Text: "use zeta"},
+		{Group: 0, Key: "fmt", Text: "use std.fmt"},
+		{Group: 1, Key: "alpha", Text: "use alpha"},
+		{Group: 1, Key: "alpha", Text: "use alpha duplicate"},
+		{Group: 0, Key: "io", Text: "use std.io", Unused: true},
+	})
+	if got, want := block, "use std.fmt\n\nuse alpha\nuse zeta\n"; got != want {
+		t.Fatalf("organized use block = %q, want %q", got, want)
 	}
 	if got := LSPUseSourceText(stdSrc, views[0].PosOffset, views[0].EndOffset); got != "use std.fmt" {
 		t.Fatalf("source text = %q", got)

--- a/internal/lsp/semtok.go
+++ b/internal/lsp/semtok.go
@@ -8,27 +8,11 @@ import (
 // semanticTokenTypes is the legend the server advertises in
 // ServerCapabilities. Indices into this slice appear in each encoded
 // token; the client maps them to theme colors.
-var semanticTokenTypes = []string{
-	"namespace",
-	"type",
-	"parameter",
-	"variable",
-	"property",
-	"function",
-	"keyword",
-	"string",
-	"number",
-	"operator",
-	"comment",
-	"enumMember",
-}
+var semanticTokenTypes = LSPSemanticTokenTypes()
 
 // semanticTokenModifiers complements tokenTypes; packed as a bitmask
 // on each emitted token.
-var semanticTokenModifiers = []string{
-	"declaration",
-	"readonly",
-}
+var semanticTokenModifiers = LSPSemanticTokenModifiers()
 
 // semToken is the intermediate form before relative encoding. `mods`
 // is always 0 today; kept in the struct so the wire-format (5 ints

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2,13 +2,10 @@ package lsp
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -27,7 +24,7 @@ import (
 
 // ServerName is advertised in Initialize and used as the `source`
 // field of every published Diagnostic.
-const ServerName = "osty-lsp"
+var ServerName = LSPServerName()
 
 // Server implements the read/dispatch/write loop of the language
 // server. A Server is single-use: create it once per process with
@@ -169,10 +166,7 @@ func (s *Server) Run() error {
 func (s *Server) ExitCode() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.shutdown {
-		return 0
-	}
-	return 1
+	return LSPExitCode(s.shutdown)
 }
 
 // dispatch routes a decoded message to the right handler. Requests
@@ -190,13 +184,17 @@ func (s *Server) dispatch(req *rpcRequest) {
 			s.log.Printf("lsp-trace: %-40s %v", req.Method, time.Since(t0))
 		}()
 	}
-	// Fast-path the lifecycle methods that can legally appear
-	// before `initialized`.
-	switch req.Method {
-	case "initialize":
+	s.mu.Lock()
+	initialized := s.initialized
+	shutdown := s.shutdown
+	s.mu.Unlock()
+
+	decision := LSPDispatchDecisionFor(req.Method, req.isNotification(), initialized, shutdown)
+	switch decision.Action {
+	case LSPDispatchActionInitialize():
 		s.handleInitialize(req)
 		return
-	case "exit":
+	case LSPDispatchActionExit():
 		// Per spec, exit terminates the process regardless of
 		// whether a prior shutdown was received. Signal Run to
 		// stop; the caller decides whether to os.Exit.
@@ -210,37 +208,20 @@ func (s *Server) dispatch(req *rpcRequest) {
 		}
 		s.mu.Unlock()
 		return
-	}
-
-	s.mu.Lock()
-	initialized := s.initialized
-	shutdown := s.shutdown
-	s.mu.Unlock()
-	if !initialized {
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errServerNotInitialized,
-				"server has not been initialized")
-		}
+	case LSPDispatchActionShutdown():
+		s.mu.Lock()
+		s.shutdown = true
+		s.mu.Unlock()
+		_ = s.conn.writeResponse(req.ID, json.RawMessage(LSPJSONNull()))
 		return
-	}
-	if shutdown {
-		// After shutdown only `exit` is valid; everything else
-		// is an invalid-request error (spec §Lifecycle).
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errInvalidRequest,
-				"server is shutting down")
-		}
+	case LSPDispatchActionIgnore():
+		return
+	case LSPDispatchActionError():
+		_ = s.conn.writeError(req.ID, decision.ErrorCode, decision.ErrorMessage)
 		return
 	}
 
 	switch req.Method {
-	case "initialized":
-		// One-shot acknowledgement; nothing to do.
-	case "shutdown":
-		s.mu.Lock()
-		s.shutdown = true
-		s.mu.Unlock()
-		_ = s.conn.writeResponse(req.ID, json.RawMessage("null"))
 	case "textDocument/didOpen":
 		s.handleDidOpen(req)
 	case "textDocument/didChange":
@@ -272,10 +253,8 @@ func (s *Server) dispatch(req *rpcRequest) {
 	case "textDocument/codeAction":
 		s.handleCodeAction(req)
 	default:
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errMethodNotFound,
-				fmt.Sprintf("method not implemented: %s", req.Method))
-		}
+		_ = s.conn.writeError(req.ID, errMethodNotFound,
+			LSPMethodNotImplementedMessage(req.Method))
 	}
 }
 
@@ -488,7 +467,7 @@ func dirHasOstySiblings(dir, selfPath string) bool {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".osty" {
+		if e.IsDir() || !LSPHasOstyFileExtension(e.Name()) {
 			continue
 		}
 		full := filepath.Join(dir, e.Name())
@@ -552,12 +531,12 @@ func (s *Server) analyzePackageViaEngine(pkgDir, path string, src []byte) *docAn
 			continue
 		}
 		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+		if !LSPIsOstySourceFileName(name) {
 			continue
 		}
 		filePaths = append(filePaths, ostyquery.NormalizePath(filepath.Join(pkgDir, name)))
 	}
-	sort.Strings(filePaths)
+	filePaths = SortLSPStrings(filePaths)
 
 	if len(filePaths) == 0 {
 		return nil
@@ -699,12 +678,12 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 				continue
 			}
 			name := e.Name()
-			if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			if !LSPIsOstySourceFileName(name) {
 				continue
 			}
 			filePaths = append(filePaths, ostyquery.NormalizePath(filepath.Join(pkgDir, name)))
 		}
-		sort.Strings(filePaths)
+		filePaths = SortLSPStrings(filePaths)
 
 		if len(filePaths) == 0 {
 			continue
@@ -1043,17 +1022,24 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 	if d == nil || pf == nil {
 		return false
 	}
+	diagnosticFile := ""
 	if d.File != "" {
-		return ostyquery.NormalizePath(d.File) == ostyquery.NormalizePath(pf.Path)
+		diagnosticFile = ostyquery.NormalizePath(d.File)
 	}
+	spanSourceFileID := ""
 	if span, ok := d.PrimarySpan(); ok && span.SourceFileID != "" && pf.SourceFileID != "" {
-		return span.SourceFileID == pf.SourceFileID
+		spanSourceFileID = string(span.SourceFileID)
 	}
 	pos := d.PrimaryPos()
-	if pos.Line == 0 {
-		return false
-	}
-	return pos.Offset <= len(pf.Source)
+	return LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		DiagnosticFile:      diagnosticFile,
+		PackageFile:         ostyquery.NormalizePath(pf.Path),
+		SpanSourceFileID:    spanSourceFileID,
+		PackageSourceFileID: string(pf.SourceFileID),
+		PrimaryLine:         pos.Line,
+		PrimaryOffset:       pos.Offset,
+		SourceLength:        len(pf.Source),
+	})
 }
 
 // analyzeSingleFileViaEngine uses the Salsa-style incremental query

--- a/internal/lsp/signature.go
+++ b/internal/lsp/signature.go
@@ -1,9 +1,6 @@
 package lsp
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/token"
@@ -152,19 +149,19 @@ func buildStructuredSignatureInfo(call *ast.CallExpr, doc *document) (SignatureI
 	if ref == nil || ref.targetKind != "function" || ref.targetType == "" {
 		return SignatureInformation{}, false
 	}
-	paramTypes, returnType, ok := parseStructuredFunctionType(ref.targetType)
-	if !ok {
+	parsed := LSPParseFunctionType(ref.targetType)
+	if !parsed.OK {
 		return SignatureInformation{}, false
 	}
-	paramNames := fallbackParameterNames(len(paramTypes))
-	params := make([]LSPSignatureParam, 0, len(paramTypes))
-	for i, pt := range paramTypes {
+	paramNames := LSPFallbackParameterNames(len(parsed.ParameterTypes))
+	params := make([]LSPSignatureParam, 0, len(parsed.ParameterTypes))
+	for i, pt := range parsed.ParameterTypes {
 		params = append(params, LSPSignatureParam{
 			Name:     paramNames[i],
 			TypeName: pt,
 		})
 	}
-	rendered := LSPBuildSignatureText(ref.targetName, params, returnType)
+	rendered := LSPBuildSignatureText(ref.targetName, params, parsed.ReturnType)
 	paramInfo := make([]ParameterInformation, 0, len(rendered.ParameterLabels))
 	for _, paramLabel := range rendered.ParameterLabels {
 		paramInfo = append(paramInfo, ParameterInformation{Label: paramLabel})
@@ -173,75 +170,6 @@ func buildStructuredSignatureInfo(call *ast.CallExpr, doc *document) (SignatureI
 		Label:      rendered.Label,
 		Parameters: paramInfo,
 	}, true
-}
-
-func parseStructuredFunctionType(typeText string) ([]string, string, bool) {
-	rest := strings.TrimSpace(typeText)
-	if !strings.HasPrefix(rest, "fn") {
-		return nil, "", false
-	}
-	rest = strings.TrimSpace(strings.TrimPrefix(rest, "fn"))
-	if !strings.HasPrefix(rest, "(") {
-		return nil, "", false
-	}
-	closeIdx := matchingCloseParen(rest)
-	if closeIdx < 0 {
-		return nil, "", false
-	}
-	paramsText := strings.TrimSpace(rest[1:closeIdx])
-	var params []string
-	if paramsText != "" {
-		params = splitTopLevelComma(paramsText)
-	}
-	returnType := ""
-	tail := strings.TrimSpace(rest[closeIdx+1:])
-	if strings.HasPrefix(tail, "->") {
-		returnType = strings.TrimSpace(strings.TrimPrefix(tail, "->"))
-	}
-	return params, returnType, true
-}
-
-func matchingCloseParen(s string) int {
-	depth := 0
-	for i, r := range s {
-		switch r {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-func splitTopLevelComma(s string) []string {
-	var out []string
-	start := 0
-	depth := 0
-	for i, r := range s {
-		switch r {
-		case '(', '[', '<':
-			depth++
-		case ')', ']', '>':
-			if depth > 0 {
-				depth--
-			}
-		case ',':
-			if depth == 0 {
-				if part := strings.TrimSpace(s[start:i]); part != "" {
-					out = append(out, part)
-				}
-				start = i + len(string(r))
-			}
-		}
-	}
-	if part := strings.TrimSpace(s[start:]); part != "" {
-		out = append(out, part)
-	}
-	return out
 }
 
 // calleeSymbol resolves the `Fn` side of a call expression to a
@@ -269,7 +197,7 @@ func calleeSymbol(call *ast.CallExpr, a *docAnalysis) (*resolve.Symbol, *ast.FnD
 // declaration when possible, filled with `argN` placeholders
 // otherwise.
 func parameterNames(fd *ast.FnDecl, count int) []string {
-	names := make([]string, count)
+	names := LSPFallbackParameterNames(count)
 	if fd != nil {
 		for i, p := range fd.Params {
 			if i >= count {
@@ -280,22 +208,7 @@ func parameterNames(fd *ast.FnDecl, count int) []string {
 			}
 		}
 	}
-	fillFallbackParameterNames(names)
 	return names
-}
-
-func fallbackParameterNames(count int) []string {
-	names := make([]string, count)
-	fillFallbackParameterNames(names)
-	return names
-}
-
-func fillFallbackParameterNames(names []string) {
-	for i := range names {
-		if names[i] == "" {
-			names[i] = fmt.Sprintf("arg%d", i+1)
-		}
-	}
 }
 
 // activeParamFor computes which parameter index the cursor sits in by

--- a/internal/lsp/structured_refs.go
+++ b/internal/lsp/structured_refs.go
@@ -1,10 +1,6 @@
 package lsp
 
-import (
-	"strings"
-
-	"github.com/osty/osty/internal/resolve"
-)
+import "github.com/osty/osty/internal/resolve"
 
 type structuredReference struct {
 	name           string
@@ -199,10 +195,7 @@ func buildStructuredImportsForPackage(pkg *resolve.Package) []structuredImportSu
 }
 
 func uriForSourcePath(path string) string {
-	if strings.Contains(path, ":") && !strings.HasPrefix(path, "/") {
-		return path
-	}
-	return pathToURI(path)
+	return LSPURIForSourcePath(path)
 }
 
 func structuredReferenceAt(doc *document, lspPos Position) *structuredReference {
@@ -249,39 +242,44 @@ func rangeContainsPosition(r Range, p Position) bool {
 }
 
 func structuredReferencesForTarget(refs []structuredReference, symbols []structuredSymbol, targetID string, includeDecl bool) []Location {
-	if targetID == "" {
-		return nil
+	convertedRefs := make([]LSPReferenceFact, 0, len(refs))
+	for _, ref := range refs {
+		convertedRefs = append(convertedRefs, LSPReferenceFact{
+			URI:                  ref.uri,
+			StartLine:            ref.rng.Start.Line,
+			StartCharacter:       ref.rng.Start.Character,
+			EndLine:              ref.rng.End.Line,
+			EndCharacter:         ref.rng.End.Character,
+			TargetSymbolID:       ref.targetSymbolID,
+			TargetURI:            ref.targetURI,
+			TargetStartLine:      ref.targetRange.Start.Line,
+			TargetStartCharacter: ref.targetRange.Start.Character,
+			TargetEndLine:        ref.targetRange.End.Line,
+			TargetEndCharacter:   ref.targetRange.End.Character,
+			Builtin:              ref.builtin,
+		})
 	}
-	out := make([]Location, 0, len(refs)+1)
-	var decl *structuredReference
-	for i := range refs {
-		ref := &refs[i]
-		if ref.targetSymbolID != targetID {
-			continue
-		}
-		out = append(out, Location{URI: ref.uri, Range: ref.rng})
-		if decl == nil && ref.targetURI != "" && !ref.builtin {
-			decl = ref
-		}
+	convertedSymbols := make([]LSPSymbolFact, 0, len(symbols))
+	for _, sym := range symbols {
+		convertedSymbols = append(convertedSymbols, LSPSymbolFact{
+			ID:             sym.id,
+			URI:            sym.uri,
+			StartLine:      sym.selectionRange.Start.Line,
+			StartCharacter: sym.selectionRange.Start.Character,
+			EndLine:        sym.selectionRange.End.Line,
+			EndCharacter:   sym.selectionRange.End.Character,
+		})
 	}
-	if includeDecl {
-		if sym := structuredSymbolForTarget(symbols, targetID); sym != nil {
-			out = append(out, Location{URI: sym.uri, Range: sym.selectionRange})
-		} else if decl != nil {
-			out = append(out, Location{URI: decl.targetURI, Range: decl.targetRange})
-		}
+	locs := LSPLocationsForTarget(convertedRefs, convertedSymbols, targetID, includeDecl)
+	out := make([]Location, 0, len(locs))
+	for _, loc := range locs {
+		out = append(out, Location{
+			URI: loc.URI,
+			Range: Range{
+				Start: Position{Line: loc.StartLine, Character: loc.StartCharacter},
+				End:   Position{Line: loc.EndLine, Character: loc.EndCharacter},
+			},
+		})
 	}
-	return sortDedupLocations(out)
-}
-
-func structuredSymbolForTarget(symbols []structuredSymbol, targetID string) *structuredSymbol {
-	if targetID == "" {
-		return nil
-	}
-	for i := range symbols {
-		if symbols[i].id == targetID {
-			return &symbols[i]
-		}
-	}
-	return nil
+	return out
 }

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -1,8 +1,6 @@
 package lsp
 
 import (
-	"strings"
-
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 )
@@ -23,7 +21,7 @@ func (s *Server) handleWorkspaceSymbol(req *rpcRequest) {
 		_ = s.conn.writeError(req.ID, errInvalidParams, err.Error())
 		return
 	}
-	query := strings.ToLower(params.Query)
+	query := LSPAsciiLowerText(params.Query)
 
 	var out []SymbolInformation
 	seen := map[string]bool{}
@@ -108,7 +106,7 @@ func collectDeclSymbols(uri string, li *lineIndex, file *ast.File, container, qu
 		if name == "" {
 			return
 		}
-		if query != "" && !strings.Contains(strings.ToLower(name), query) {
+		if !LSPNameMatchesQuery(name, query) {
 			return
 		}
 		out = append(out, SymbolInformation{

--- a/internal/selfhost/lsp_policy.go
+++ b/internal/selfhost/lsp_policy.go
@@ -2,6 +2,7 @@ package selfhost
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,30 @@ type LSPLocation struct {
 	EndCharacter   int
 }
 
+type LSPReferenceFact struct {
+	URI                  string
+	StartLine            int
+	StartCharacter       int
+	EndLine              int
+	EndCharacter         int
+	TargetSymbolID       string
+	TargetURI            string
+	TargetStartLine      int
+	TargetStartCharacter int
+	TargetEndLine        int
+	TargetEndCharacter   int
+	Builtin              bool
+}
+
+type LSPSymbolFact struct {
+	ID             string
+	URI            string
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
+}
+
 type LSPSymbolSortKey struct {
 	Name string
 	URI  string
@@ -38,6 +63,14 @@ type LSPImportSortKey struct {
 	Group int
 	Key   string
 	Alias string
+}
+
+type LSPOrganizeUseEntry struct {
+	Group  int
+	Key    string
+	Alias  string
+	Text   string
+	Unused bool
 }
 
 type LSPSignatureParam struct {
@@ -50,6 +83,12 @@ type LSPSignatureText struct {
 	ParameterLabels []string
 }
 
+type LSPFunctionTypeParts struct {
+	OK             bool
+	ParameterTypes []string
+	ReturnType     string
+}
+
 type LSPCompletionContext struct {
 	Prefix   string
 	AfterDot string
@@ -58,6 +97,54 @@ type LSPCompletionContext struct {
 type LSPDiagnosticPayload struct {
 	Severity int
 	Message  string
+}
+
+type LSPDiagnosticView struct {
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
+	Severity       int
+	Code           string
+	Source         string
+	Message        string
+}
+
+type LSPDiagnosticFileFact struct {
+	DiagnosticFile      string
+	PackageFile         string
+	SpanSourceFileID    string
+	PackageSourceFileID string
+	PrimaryLine         int
+	PrimaryOffset       int
+	SourceLength        int
+}
+
+type LSPHeaderParseResult struct {
+	OK            bool
+	ContentLength int
+	Error         string
+}
+
+type LSPFileURIPathRawResult struct {
+	OK   bool
+	Path string
+}
+
+type LSPCompletionItemData struct {
+	Label         string
+	Kind          int
+	SortText      string
+	Detail        string
+	Documentation string
+}
+
+type LSPCompletionCandidateView struct {
+	Name     string
+	Kind     string
+	TypeText string
+	DocText  string
+	Include  bool
 }
 
 // LSPSymbolView is the value-typed snapshot the LSP policy layer
@@ -105,6 +192,17 @@ type LSPOstyPosition struct {
 	Offset int
 	Line   int
 	Column int
+}
+
+type LSPFullDocumentRangeResult struct {
+	EndLine      int
+	EndCharacter int
+}
+
+type LSPDispatchDecision struct {
+	Action       string
+	ErrorCode    int
+	ErrorMessage string
 }
 
 func LSPSemanticTypeForTokenKind(kind, symbolKind string) int {
@@ -155,6 +253,205 @@ func LSPPathToURI(path string) string {
 	return lspPathToUri(path)
 }
 
+func LSPFileURIPathRaw(uri string) LSPFileURIPathRawResult {
+	const prefix = "file://"
+	if !strings.HasPrefix(uri, prefix) {
+		return LSPFileURIPathRawResult{}
+	}
+	path := strings.TrimPrefix(uri, prefix)
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return LSPFileURIPathRawResult{OK: true, Path: path}
+}
+
+func LSPServerName() string {
+	return "osty-lsp"
+}
+
+func LSPServerVersion() string {
+	return "0.1.0"
+}
+
+func LSPPositionEncodingUTF16() string {
+	return "utf-16"
+}
+
+func LSPJSONNull() string {
+	return "null"
+}
+
+func LSPCompletionTriggerDot() string {
+	return "."
+}
+
+func LSPSignatureTriggerOpenParen() string {
+	return "("
+}
+
+func LSPSignatureTriggerComma() string {
+	return ","
+}
+
+func LSPSemanticTokenTypes() []string {
+	return []string{
+		"namespace",
+		"type",
+		"parameter",
+		"variable",
+		"property",
+		"function",
+		"keyword",
+		"string",
+		"number",
+		"operator",
+		"comment",
+		"enumMember",
+	}
+}
+
+func LSPSemanticTokenModifiers() []string {
+	return []string{"declaration", "readonly"}
+}
+
+func LSPDispatchActionInitialize() string { return "initialize" }
+func LSPDispatchActionExit() string       { return "exit" }
+func LSPDispatchActionShutdown() string   { return "shutdown" }
+func LSPDispatchActionIgnore() string     { return "ignore" }
+func LSPDispatchActionDispatch() string   { return "dispatch" }
+func LSPDispatchActionError() string      { return "error" }
+func LSPErrInvalidRequest() int           { return -32600 }
+func LSPErrMethodNotFound() int           { return -32601 }
+func LSPErrServerNotInitialized() int     { return -32002 }
+
+func LSPAsciiLowerText(text string) string {
+	return strings.ToLower(text)
+}
+
+func LSPNameMatchesPrefix(name, prefix string) bool {
+	return prefix == "" || strings.HasPrefix(name, prefix)
+}
+
+func LSPNameMatchesQuery(name, query string) bool {
+	return query == "" || strings.Contains(strings.ToLower(name), query)
+}
+
+func LSPURIForSourcePath(path string) string {
+	if strings.Contains(path, ":") && !strings.HasPrefix(path, "/") {
+		return path
+	}
+	return LSPPathToURI(path)
+}
+
+func LSPPreferAIRepairFixAll(source string) bool {
+	return strings.Contains(source, ".length")
+}
+
+func LSPTextChanged(original, replacement string) bool {
+	return original != replacement
+}
+
+func LSPParamsAreEmpty(paramsText string) bool {
+	return paramsText == "" || paramsText == "null"
+}
+
+func LSPRenameEmptyNameMessage() string {
+	return "new name is empty"
+}
+
+func LSPCannotRenameBuiltinMessage() string {
+	return "cannot rename a builtin"
+}
+
+func LSPCanRenameKind(kind string) bool {
+	return kind != "builtin"
+}
+
+func LSPRenameTitle(name string) string {
+	return "Rename to `" + name + "`"
+}
+
+func LSPRemoveLineTitle() string {
+	return "Remove unused import"
+}
+
+func LSPFixAllTitle() string {
+	return "Fix all auto-fixable problems"
+}
+
+func LSPOrganizeImportsTitle() string {
+	return "Organize imports"
+}
+
+func LSPInlayTypeLabel(typeText string) string {
+	return ": " + typeText
+}
+
+func LSPMethodNotImplementedMessage(method string) string {
+	return "method not implemented: " + method
+}
+
+func LSPIsOstySourceFileName(name string) bool {
+	return strings.HasSuffix(name, ".osty") && !strings.HasSuffix(name, "_test.osty")
+}
+
+func LSPHasOstyFileExtension(name string) bool {
+	return strings.HasSuffix(name, ".osty")
+}
+
+func LSPExitCode(shutdown bool) int {
+	if shutdown {
+		return 0
+	}
+	return 1
+}
+
+func LSPDispatchDecisionFor(method string, isNotification bool, initialized bool, shutdown bool) LSPDispatchDecision {
+	if method == "initialize" {
+		return LSPDispatchDecision{Action: LSPDispatchActionInitialize()}
+	}
+	if method == "exit" {
+		return LSPDispatchDecision{Action: LSPDispatchActionExit()}
+	}
+	if !initialized {
+		if isNotification {
+			return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+		}
+		return LSPDispatchDecision{
+			Action:       LSPDispatchActionError(),
+			ErrorCode:    LSPErrServerNotInitialized(),
+			ErrorMessage: "server has not been initialized",
+		}
+	}
+	if shutdown {
+		if isNotification {
+			return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+		}
+		return LSPDispatchDecision{
+			Action:       LSPDispatchActionError(),
+			ErrorCode:    LSPErrInvalidRequest(),
+			ErrorMessage: "server is shutting down",
+		}
+	}
+	if method == "initialized" {
+		return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+	}
+	if method == "shutdown" {
+		return LSPDispatchDecision{Action: LSPDispatchActionShutdown()}
+	}
+	if lspMethodIsHandled(method) {
+		return LSPDispatchDecision{Action: LSPDispatchActionDispatch()}
+	}
+	if isNotification {
+		return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+	}
+	return LSPDispatchDecision{
+		Action:       LSPDispatchActionError(),
+		ErrorCode:    LSPErrMethodNotFound(),
+		ErrorMessage: LSPMethodNotImplementedMessage(method),
+	}
+}
+
 func LSPLineStarts(source string) []int {
 	unitStarts := lspLineStarts(source)
 	byteOffsets := stringUnitByteOffsets(source)
@@ -181,6 +478,36 @@ func LSPOstyPositionToLSP(source string, lineStarts []int, ostyLine, byteOffset 
 		Line:      pos.line,
 		Character: pos.character,
 	}
+}
+
+func LSPFrameHeader(bodyLength int) string {
+	return "Content-Length: " + strconv.Itoa(bodyLength) + "\r\n\r\n"
+}
+
+func LSPTrimHeaderLine(line string) string {
+	return strings.TrimRight(line, "\r\n")
+}
+
+func LSPParseHeaderLines(lines []string) LSPHeaderParseResult {
+	if len(lines) == 0 {
+		return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: empty header block"}
+	}
+	length := -1
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: malformed header " + line}
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || n < 0 {
+				return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: invalid Content-Length " + strings.TrimSpace(value)}
+			}
+			length = n
+		}
+	}
+	return LSPHeaderParseResult{OK: true, ContentLength: length}
 }
 
 func LSPLSPPositionToOsty(source string, lineStarts []int, lspLine, character int) LSPOstyPosition {
@@ -252,6 +579,25 @@ func LSPRangeFromOstySpan(
 	}
 }
 
+func LSPFullDocumentRange(source string, lineStarts []int) LSPFullDocumentRangeResult {
+	endLine := 0
+	lastLineStart := 0
+	if len(lineStarts) > 0 {
+		endLine = len(lineStarts) - 1
+		lastLineStart = lineStarts[len(lineStarts)-1]
+	}
+	if lastLineStart < 0 {
+		lastLineStart = 0
+	}
+	if lastLineStart > len(source) {
+		lastLineStart = len(source)
+	}
+	return LSPFullDocumentRangeResult{
+		EndLine:      endLine,
+		EndCharacter: LSPUTF16UnitsInPrefix(source[lastLineStart:]),
+	}
+}
+
 func LSPSymbolKindForDecl(kind string, mutable bool) int {
 	return lspSymbolKindForDecl(kind, mutable)
 }
@@ -307,12 +653,134 @@ func LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd int) bool {
 	return lspSpanOverlaps(startOffset, endOffset, queryStart, queryEnd)
 }
 
+func LSPNamedTypeReferenceEndOffset(startOffset, sourceLength, targetNameLength int, firstPathMatchesTarget bool, firstPathLength int) int {
+	width := targetNameLength
+	if firstPathMatchesTarget {
+		width = firstPathLength
+	}
+	endOffset := startOffset + width
+	if endOffset > sourceLength {
+		endOffset = sourceLength
+	}
+	return endOffset
+}
+
 func LSPDiagnosticPayloadFor(severity, message, hint string, notes []string) LSPDiagnosticPayload {
 	payload := lspDiagnosticPayload(severity, message, hint, notes)
 	return LSPDiagnosticPayload{
 		Severity: payload.severity,
 		Message:  payload.message,
 	}
+}
+
+func LSPDiagnosticsEqual(a, b []LSPDiagnosticView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func LSPDiagnosticBelongsToFile(fact LSPDiagnosticFileFact) bool {
+	if fact.DiagnosticFile != "" {
+		return fact.DiagnosticFile == fact.PackageFile
+	}
+	if fact.SpanSourceFileID != "" && fact.PackageSourceFileID != "" {
+		return fact.SpanSourceFileID == fact.PackageSourceFileID
+	}
+	if fact.PrimaryLine == 0 {
+		return false
+	}
+	return fact.PrimaryOffset <= fact.SourceLength
+}
+
+func LSPLevenshteinBounded(a, b string, limit int) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if absInt(len(ar)-len(br)) > limit {
+		return limit + 1
+	}
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		rowMin := curr[0]
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			curr[j] = minInt(
+				prev[j]+1,
+				curr[j-1]+1,
+				prev[j-1]+cost,
+			)
+			if curr[j] < rowMin {
+				rowMin = curr[j]
+			}
+		}
+		if rowMin > limit {
+			return limit + 1
+		}
+		prev, curr = curr, prev
+	}
+	if prev[len(br)] > limit {
+		return limit + 1
+	}
+	return prev[len(br)]
+}
+
+func LSPRankNearbyNames(names []string, target string, maxDistance int) []string {
+	type candidate struct {
+		name string
+		dist int
+	}
+	seen := map[string]bool{}
+	candidates := make([]candidate, 0, len(names))
+	for _, name := range names {
+		if name == "" || seen[name] {
+			continue
+		}
+		dist := LSPLevenshteinBounded(target, name, maxDistance)
+		if dist > maxDistance {
+			continue
+		}
+		seen[name] = true
+		candidates = append(candidates, candidate{name: name, dist: dist})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].dist != candidates[j].dist {
+			return candidates[i].dist < candidates[j].dist
+		}
+		return candidates[i].name < candidates[j].name
+	})
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+func LSPMergeNearbyNames(primary []string, fallback []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(primary)+len(fallback))
+	for _, group := range [][]string{primary, fallback} {
+		for _, name := range group {
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
@@ -343,6 +811,120 @@ func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
 	return out
 }
 
+func LSPLocationsForTarget(refs []LSPReferenceFact, symbols []LSPSymbolFact, targetID string, includeDecl bool) []LSPLocation {
+	if targetID == "" {
+		return nil
+	}
+	out := make([]LSPLocation, 0, len(refs)+1)
+	var fallbackDecl *LSPLocation
+	for _, ref := range refs {
+		if ref.TargetSymbolID != targetID {
+			continue
+		}
+		out = append(out, LSPLocation{
+			URI:            ref.URI,
+			StartLine:      ref.StartLine,
+			StartCharacter: ref.StartCharacter,
+			EndLine:        ref.EndLine,
+			EndCharacter:   ref.EndCharacter,
+		})
+		if fallbackDecl == nil && ref.TargetURI != "" && !ref.Builtin {
+			fallbackDecl = &LSPLocation{
+				URI:            ref.TargetURI,
+				StartLine:      ref.TargetStartLine,
+				StartCharacter: ref.TargetStartCharacter,
+				EndLine:        ref.TargetEndLine,
+				EndCharacter:   ref.TargetEndCharacter,
+			}
+		}
+	}
+	if includeDecl {
+		haveSymbolDecl := false
+		for _, sym := range symbols {
+			if sym.ID != targetID {
+				continue
+			}
+			out = append(out, LSPLocation{
+				URI:            sym.URI,
+				StartLine:      sym.StartLine,
+				StartCharacter: sym.StartCharacter,
+				EndLine:        sym.EndLine,
+				EndCharacter:   sym.EndCharacter,
+			})
+			haveSymbolDecl = true
+			break
+		}
+		if !haveSymbolDecl && fallbackDecl != nil {
+			out = append(out, *fallbackDecl)
+		}
+	}
+	return SortDedupLSPLocations(out)
+}
+
+func LSPCompletionItemForSymbolView(view LSPSymbolView) LSPCompletionItemData {
+	detail := ""
+	if view.TypeText != "" {
+		detail = LSPCompletionDetail(view.Kind, view.Name, view.TypeText)
+	}
+	return LSPCompletionItemData{
+		Label:         view.Name,
+		Kind:          LSPCompletionKindForSymbolKind(view.Kind),
+		SortText:      LSPCompletionSortTextForSymbolKind(view.Kind, view.Name),
+		Detail:        detail,
+		Documentation: view.DocText,
+	}
+}
+
+func LSPCompletionItemsForCandidates(candidates []LSPCompletionCandidateView, prefix string) []LSPCompletionItemData {
+	seen := map[string]bool{}
+	items := make([]LSPCompletionItemData, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !candidate.Include || candidate.Name == "" {
+			continue
+		}
+		if seen[candidate.Name] {
+			continue
+		}
+		if !LSPNameMatchesPrefix(candidate.Name, prefix) {
+			continue
+		}
+		seen[candidate.Name] = true
+		items = append(items, LSPCompletionItemForSymbolView(LSPSymbolView{
+			Name:     candidate.Name,
+			Kind:     candidate.Kind,
+			TypeText: candidate.TypeText,
+			DocText:  candidate.DocText,
+			HasSym:   true,
+		}))
+	}
+	labels := make([]string, 0, len(items))
+	for _, item := range items {
+		labels = append(labels, item.Label)
+	}
+	order := SortLSPStringIndexes(labels)
+	out := make([]LSPCompletionItemData, 0, len(order))
+	for _, idx := range order {
+		if idx < 0 || idx >= len(items) {
+			continue
+		}
+		out = append(out, items[idx])
+	}
+	return out
+}
+
+func LSPSemanticHoverKind(kind string) string {
+	switch kind {
+	case "fn":
+		return "function"
+	case "value":
+		return "binding"
+	case "generic":
+		return "type parameter"
+	default:
+		return kind
+	}
+}
+
 func SortLSPSymbolIndexes(keys []LSPSymbolSortKey) []int {
 	tagged := make([]*LspSymbolSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -362,6 +944,28 @@ func SortLSPCompletionIndexes(labels []string) []int {
 	return SortLSPSymbolIndexes(keys)
 }
 
+func SortLSPStringIndexes(values []string) []int {
+	type indexedString struct {
+		value string
+		index int
+	}
+	tagged := make([]indexedString, 0, len(values))
+	for idx, value := range values {
+		tagged = append(tagged, indexedString{value: value, index: idx})
+	}
+	sort.Slice(tagged, func(i, j int) bool {
+		if tagged[i].value != tagged[j].value {
+			return tagged[i].value < tagged[j].value
+		}
+		return tagged[i].index < tagged[j].index
+	})
+	out := make([]int, 0, len(tagged))
+	for _, item := range tagged {
+		out = append(out, item.index)
+	}
+	return out
+}
+
 func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 	tagged := make([]*LspImportSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -372,6 +976,48 @@ func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 		})
 	}
 	return lspSortImportIndexes(tagged)
+}
+
+func LSPOrganizedUseBlock(entries []LSPOrganizeUseEntry) string {
+	kept := make([]LSPOrganizeUseEntry, 0, len(entries))
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.Unused || entry.Text == "" {
+			continue
+		}
+		dedupKey := LSPKeyWithAlias(entry.Group, entry.Key, entry.Alias)
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		kept = append(kept, entry)
+	}
+	keys := make([]LSPImportSortKey, 0, len(kept))
+	for _, entry := range kept {
+		keys = append(keys, LSPImportSortKey{
+			Group: entry.Group,
+			Key:   entry.Key,
+			Alias: entry.Alias,
+		})
+	}
+	order := SortLSPImportIndexes(keys)
+	var b strings.Builder
+	prevGroup := -1
+	emitted := 0
+	for _, idx := range order {
+		if idx < 0 || idx >= len(kept) {
+			continue
+		}
+		entry := kept[idx]
+		if emitted > 0 && entry.Group != prevGroup {
+			b.WriteByte('\n')
+		}
+		b.WriteString(entry.Text)
+		b.WriteByte('\n')
+		prevGroup = entry.Group
+		emitted++
+	}
+	return b.String()
 }
 
 func LSPUseGroup(isGoFFI bool, path []string) int {
@@ -432,6 +1078,44 @@ func LSPBuildSignatureText(name string, params []LSPSignatureParam, returnType s
 		Label:           rendered.label,
 		ParameterLabels: append([]string(nil), rendered.parameterLabels...),
 	}
+}
+
+func LSPParseFunctionType(typeText string) LSPFunctionTypeParts {
+	rest := strings.TrimSpace(typeText)
+	if !strings.HasPrefix(rest, "fn") {
+		return LSPFunctionTypeParts{}
+	}
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "fn"))
+	if !strings.HasPrefix(rest, "(") {
+		return LSPFunctionTypeParts{}
+	}
+	closeIdx := matchingCloseParen(rest)
+	if closeIdx < 0 {
+		return LSPFunctionTypeParts{}
+	}
+	paramsText := strings.TrimSpace(rest[1:closeIdx])
+	var params []string
+	if paramsText != "" {
+		params = splitTopLevelComma(paramsText)
+	}
+	returnType := ""
+	tail := strings.TrimSpace(rest[closeIdx+1:])
+	if strings.HasPrefix(tail, "->") {
+		returnType = strings.TrimSpace(strings.TrimPrefix(tail, "->"))
+	}
+	return LSPFunctionTypeParts{
+		OK:             true,
+		ParameterTypes: params,
+		ReturnType:     returnType,
+	}
+}
+
+func LSPFallbackParameterNames(count int) []string {
+	names := make([]string, count)
+	for i := range names {
+		names[i] = "arg" + strconv.Itoa(i+1)
+	}
+	return names
 }
 
 func EncodeLSPSemanticTokens(tokens []LSPSemanticToken) []int {
@@ -531,4 +1215,87 @@ func unitOffsetToByteOffset(byteOffsets []int, unitOffset int) int {
 		return byteOffsets[last]
 	}
 	return byteOffsets[unitOffset]
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func minInt(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		return c
+	}
+	return a
+}
+
+func matchingCloseParen(s string) int {
+	depth := 0
+	for i, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func splitTopLevelComma(s string) []string {
+	var out []string
+	start := 0
+	depth := 0
+	for i, r := range s {
+		switch r {
+		case '(', '[', '<':
+			depth++
+		case ')', ']', '>':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				if part := strings.TrimSpace(s[start:i]); part != "" {
+					out = append(out, part)
+				}
+				start = i + len(string(r))
+			}
+		}
+	}
+	if part := strings.TrimSpace(s[start:]); part != "" {
+		out = append(out, part)
+	}
+	return out
+}
+
+func lspMethodIsHandled(method string) bool {
+	switch method {
+	case "textDocument/didOpen",
+		"textDocument/didChange",
+		"textDocument/didClose",
+		"textDocument/hover",
+		"textDocument/definition",
+		"textDocument/formatting",
+		"textDocument/documentSymbol",
+		"textDocument/completion",
+		"textDocument/references",
+		"textDocument/rename",
+		"textDocument/signatureHelp",
+		"workspace/symbol",
+		"textDocument/inlayHint",
+		"textDocument/semanticTokens/full",
+		"textDocument/codeAction":
+		return true
+	default:
+		return false
+	}
 }

--- a/toolchain/lsp.osty
+++ b/toolchain/lsp.osty
@@ -42,6 +42,30 @@ pub struct LspLocation {
     pub endCharacter: Int,
 }
 
+pub struct LspReferenceFact {
+    pub uri: String,
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+    pub targetSymbolID: String,
+    pub targetURI: String,
+    pub targetStartLine: Int,
+    pub targetStartCharacter: Int,
+    pub targetEndLine: Int,
+    pub targetEndCharacter: Int,
+    pub builtin: Bool,
+}
+
+pub struct LspSymbolFact {
+    pub id: String,
+    pub uri: String,
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+}
+
 struct LspIndexedLocation {
     loc: LspLocation,
     index: Int,
@@ -68,6 +92,14 @@ struct LspIndexedImportSortKey {
     index: Int,
 }
 
+pub struct LspOrganizeUseEntry {
+    pub group: Int,
+    pub key: String,
+    pub alias: String,
+    pub text: String,
+    pub unused: Bool,
+}
+
 pub struct LspSignatureParam {
     pub name: String,
     pub typeName: String,
@@ -78,6 +110,12 @@ pub struct LspSignatureText {
     pub parameterLabels: List<String>,
 }
 
+pub struct LspFunctionTypeParts {
+    pub ok: Bool,
+    pub parameterTypes: List<String>,
+    pub returnType: String,
+}
+
 pub struct LspCompletionContext {
     pub prefix: String,
     pub afterDot: String,
@@ -86,6 +124,64 @@ pub struct LspCompletionContext {
 pub struct LspDiagnosticPayload {
     pub severity: Int,
     pub message: String,
+}
+
+pub struct LspDiagnosticView {
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+    pub severity: Int,
+    pub code: String,
+    pub source: String,
+    pub message: String,
+}
+
+pub struct LspDiagnosticFileFact {
+    pub diagnosticFile: String,
+    pub packageFile: String,
+    pub spanSourceFileID: String,
+    pub packageSourceFileID: String,
+    pub primaryLine: Int,
+    pub primaryOffset: Int,
+    pub sourceLength: Int,
+}
+
+pub struct LspHeaderParseResult {
+    pub ok: Bool,
+    pub contentLength: Int,
+    pub error: String,
+}
+
+pub struct LspFileURIPathRawResult {
+    pub ok: Bool,
+    pub path: String,
+}
+
+pub struct LspCompletionItemData {
+    pub label: String,
+    pub kind: Int,
+    pub sortText: String,
+    pub detail: String,
+    pub documentation: String,
+}
+
+pub struct LspCompletionCandidateView {
+    pub name: String,
+    pub kind: String,
+    pub typeText: String,
+    pub docText: String,
+    pub include: Bool,
+}
+
+pub struct LspNameCandidate {
+    pub name: String,
+    pub distance: Int,
+}
+
+struct LspIndexedNameCandidate {
+    candidate: LspNameCandidate,
+    index: Int,
 }
 
 pub struct LspPosition {
@@ -104,6 +200,17 @@ pub struct LspOstyPosition {
     pub offset: Int,
     pub line: Int,
     pub column: Int,
+}
+
+pub struct LspFullDocumentRange {
+    pub endLine: Int,
+    pub endCharacter: Int,
+}
+
+pub struct LspDispatchDecision {
+    pub action: String,
+    pub errorCode: Int,
+    pub errorMessage: String,
 }
 
 pub fn lspSemanticTypeNamespace() -> Int { return 0 }
@@ -151,6 +258,221 @@ pub fn lspDiagnosticSeverityError() -> Int { return 1 }
 pub fn lspDiagnosticSeverityWarning() -> Int { return 2 }
 pub fn lspDiagnosticSeverityInformation() -> Int { return 3 }
 
+pub fn lspServerName() -> String { return "osty-lsp" }
+pub fn lspServerVersion() -> String { return "0.1.0" }
+pub fn lspPositionEncodingUTF16() -> String { return "utf-16" }
+pub fn lspJSONNull() -> String { return "null" }
+pub fn lspCompletionTriggerDot() -> String { return "." }
+pub fn lspSignatureTriggerOpenParen() -> String { return "(" }
+pub fn lspSignatureTriggerComma() -> String { return "," }
+pub fn lspSemanticTokenTypes() -> List<String> {
+    return [
+        "namespace",
+        "type",
+        "parameter",
+        "variable",
+        "property",
+        "function",
+        "keyword",
+        "string",
+        "number",
+        "operator",
+        "comment",
+        "enumMember",
+    ]
+}
+pub fn lspSemanticTokenModifiers() -> List<String> {
+    return ["declaration", "readonly"]
+}
+pub fn lspDispatchActionInitialize() -> String { return "initialize" }
+pub fn lspDispatchActionExit() -> String { return "exit" }
+pub fn lspDispatchActionShutdown() -> String { return "shutdown" }
+pub fn lspDispatchActionIgnore() -> String { return "ignore" }
+pub fn lspDispatchActionDispatch() -> String { return "dispatch" }
+pub fn lspDispatchActionError() -> String { return "error" }
+pub fn lspErrInvalidRequest() -> Int { return -32600 }
+pub fn lspErrMethodNotFound() -> Int { return -32601 }
+pub fn lspErrServerNotInitialized() -> Int { return -32002 }
+
+pub fn lspAsciiLowerText(text: String) -> String {
+    let units = strings.split(text, "")
+    let mut out = ""
+    for unit in units {
+        out = "{out}{lspAsciiLowerUnit(unit)}"
+    }
+    return out
+}
+
+pub fn lspNameMatchesPrefix(name: String, prefix: String) -> Bool {
+    return prefix == "" || lspStringHasPrefix(name, prefix)
+}
+
+pub fn lspNameMatchesQuery(name: String, query: String) -> Bool {
+    return query == "" || lspStringContains(lspAsciiLowerText(name), query)
+}
+
+pub fn lspUriForSourcePath(path: String) -> String {
+    if lspStringContains(path, ":") && !(lspStringHasPrefix(path, "/")) {
+        return path
+    }
+    return lspPathToUri(path)
+}
+
+pub fn lspPreferAIRepairFixAll(source: String) -> Bool {
+    return lspStringContains(source, ".length")
+}
+
+pub fn lspTextChanged(original: String, replacement: String) -> Bool {
+    return original != replacement
+}
+
+pub fn lspParamsAreEmpty(paramsText: String) -> Bool {
+    return paramsText == "" || paramsText == "null"
+}
+
+pub fn lspRenameEmptyNameMessage() -> String {
+    return "new name is empty"
+}
+
+pub fn lspCannotRenameBuiltinMessage() -> String {
+    return "cannot rename a builtin"
+}
+
+pub fn lspCanRenameKind(kind: String) -> Bool {
+    return kind != "builtin"
+}
+
+pub fn lspRenameTitle(name: String) -> String {
+    return "Rename to `{name}`"
+}
+
+pub fn lspRemoveLineTitle() -> String {
+    return "Remove unused import"
+}
+
+pub fn lspFixAllTitle() -> String {
+    return "Fix all auto-fixable problems"
+}
+
+pub fn lspOrganizeImportsTitle() -> String {
+    return "Organize imports"
+}
+
+pub fn lspInlayTypeLabel(typeText: String) -> String {
+    return ": {typeText}"
+}
+
+pub fn lspMethodNotImplementedMessage(method: String) -> String {
+    return "method not implemented: {method}"
+}
+
+pub fn lspIsOstySourceFileName(name: String) -> Bool {
+    return lspStringHasSuffix(name, ".osty") && !(lspStringHasSuffix(name, "_test.osty"))
+}
+
+pub fn lspHasOstyFileExtension(name: String) -> Bool {
+    return lspStringHasSuffix(name, ".osty")
+}
+
+pub fn lspExitCode(shutdown: Bool) -> Int {
+    if shutdown {
+        return 0
+    }
+    return 1
+}
+
+pub fn lspDispatchDecision(
+    method: String,
+    isNotification: Bool,
+    initialized: Bool,
+    shutdown: Bool,
+) -> LspDispatchDecision {
+    if method == "initialize" {
+        return LspDispatchDecision { action: lspDispatchActionInitialize(), errorCode: 0, errorMessage: "" }
+    }
+    if method == "exit" {
+        return LspDispatchDecision { action: lspDispatchActionExit(), errorCode: 0, errorMessage: "" }
+    }
+    if !(initialized) {
+        if isNotification {
+            return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+        }
+        return LspDispatchDecision {
+            action: lspDispatchActionError(),
+            errorCode: lspErrServerNotInitialized(),
+            errorMessage: "server has not been initialized",
+        }
+    }
+    if shutdown {
+        if isNotification {
+            return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+        }
+        return LspDispatchDecision {
+            action: lspDispatchActionError(),
+            errorCode: lspErrInvalidRequest(),
+            errorMessage: "server is shutting down",
+        }
+    }
+    if method == "initialized" {
+        return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+    }
+    if method == "shutdown" {
+        return LspDispatchDecision { action: lspDispatchActionShutdown(), errorCode: 0, errorMessage: "" }
+    }
+    if lspMethodIsHandled(method) {
+        return LspDispatchDecision { action: lspDispatchActionDispatch(), errorCode: 0, errorMessage: "" }
+    }
+    if isNotification {
+        return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+    }
+    return LspDispatchDecision {
+        action: lspDispatchActionError(),
+        errorCode: lspErrMethodNotFound(),
+        errorMessage: lspMethodNotImplementedMessage(method),
+    }
+}
+
+pub fn lspFrameHeader(bodyLength: Int) -> String {
+    return "Content-Length: {bodyLength}\r\n\r\n"
+}
+
+pub fn lspTrimHeaderLine(line: String) -> String {
+    let mut out = line
+    for out.chars().len() > 0 {
+        let units = strings.split(out, "")
+        let last = units[units.len() - 1]
+        if last != "\r" && last != "\n" {
+            break
+        }
+        out = frontLexemeFromUnits(units, 0, units.len() - 1)
+    }
+    return out
+}
+
+pub fn lspParseHeaderLines(lines: List<String>) -> LspHeaderParseResult {
+    if lines.len() == 0 {
+        return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: empty header block" }
+    }
+    let mut length = -1
+    for raw in lines {
+        let line = lspTrimAsciiSpace(raw)
+        let colon = lspIndexOfUnit(line, ":")
+        if colon < 0 {
+            return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: malformed header {line}" }
+        }
+        let name = lspTrimAsciiSpace(lspSliceUnits(line, 0, colon))
+        let value = lspTrimAsciiSpace(lspSliceUnits(line, colon + 1, line.chars().len()))
+        if lspEqualFoldAscii(name, "Content-Length") {
+            let parsed = lspParseNonNegativeDecimal(value)
+            if parsed < 0 {
+                return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: invalid Content-Length {value}" }
+            }
+            length = parsed
+        }
+    }
+    return LspHeaderParseResult { ok: true, contentLength: length, error: "" }
+}
+
 pub fn lspPathToUri(path: String) -> String {
     if path == "" {
         return "file://"
@@ -159,6 +481,19 @@ pub fn lspPathToUri(path: String) -> String {
         return "file://{path}"
     }
     return "file:///{path}"
+}
+
+pub fn lspFileURIPathRaw(uri: String) -> LspFileURIPathRawResult {
+    let prefix = "file://"
+    if !(lspStringHasPrefix(uri, prefix)) {
+        return LspFileURIPathRawResult { ok: false, path: "" }
+    }
+    let mut path = lspSliceUnits(uri, prefix.chars().len(), uri.chars().len())
+    let units = strings.split(path, "")
+    if units.len() >= 3 && units[0] == "/" && units[2] == ":" {
+        path = lspSliceUnits(path, 1, path.chars().len())
+    }
+    return LspFileURIPathRawResult { ok: true, path }
 }
 
 pub fn lspLineStarts(source: String) -> List<Int> {
@@ -327,6 +662,19 @@ pub fn lspRangeFromOstySpan(
         startCharacter: start.character,
         endLine: end.line,
         endCharacter: end.character,
+    }
+}
+
+pub fn lspFullDocumentRange(source: String, lineStarts: List<Int>) -> LspFullDocumentRange {
+    let mut endLine = 0
+    let mut lastLineStart = 0
+    if lineStarts.len() > 0 {
+        endLine = lineStarts.len() - 1
+        lastLineStart = lineStarts[lineStarts.len() - 1]
+    }
+    return LspFullDocumentRange {
+        endLine,
+        endCharacter: lspUtf16UnitsInByteRange(source, lastLineStart, source.chars().len()),
     }
 }
 
@@ -640,6 +988,24 @@ pub fn lspSpanOverlaps(startOffset: Int, endOffset: Int, queryStart: Int, queryE
     return true
 }
 
+pub fn lspNamedTypeReferenceEndOffset(
+    startOffset: Int,
+    sourceLength: Int,
+    targetNameLength: Int,
+    firstPathMatchesTarget: Bool,
+    firstPathLength: Int,
+) -> Int {
+    let mut width = targetNameLength
+    if firstPathMatchesTarget {
+        width = firstPathLength
+    }
+    let mut endOffset = startOffset + width
+    if endOffset > sourceLength {
+        endOffset = sourceLength
+    }
+    return endOffset
+}
+
 pub fn lspDiagnosticPayload(
     severity: String,
     message: String,
@@ -661,6 +1027,115 @@ pub fn lspDiagnosticPayload(
         out = "{out}\nnote: {note}"
     }
     return LspDiagnosticPayload { severity: code, message: out }
+}
+
+pub fn lspDiagnosticsEqual(a: List<LspDiagnosticView>, b: List<LspDiagnosticView>) -> Bool {
+    if a.len() != b.len() {
+        return false
+    }
+    let mut idx = 0
+    for idx < a.len() {
+        if !(lspDiagnosticViewEqual(a[idx], b[idx])) {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+pub fn lspDiagnosticBelongsToFile(fact: LspDiagnosticFileFact) -> Bool {
+    if fact.diagnosticFile != "" {
+        return fact.diagnosticFile == fact.packageFile
+    }
+    if fact.spanSourceFileID != "" && fact.packageSourceFileID != "" {
+        return fact.spanSourceFileID == fact.packageSourceFileID
+    }
+    if fact.primaryLine == 0 {
+        return false
+    }
+    return fact.primaryOffset <= fact.sourceLength
+}
+
+pub fn lspLevenshteinBounded(a: String, b: String, limit: Int) -> Int {
+    let ar = strings.split(a, "")
+    let br = strings.split(b, "")
+    if lspAbsInt(ar.len() - br.len()) > limit {
+        return limit + 1
+    }
+
+    let mut prev: List<Int> = []
+    let mut j = 0
+    for j <= br.len() {
+        prev.push(j)
+        j = j + 1
+    }
+
+    let mut i = 1
+    for i <= ar.len() {
+        let mut curr: List<Int> = [i]
+        let mut rowMin = i
+        j = 1
+        for j <= br.len() {
+            let cost = if ar[i - 1] == br[j - 1] { 0 } else { 1 }
+            let value = lspMin3Int(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+            curr.push(value)
+            if value < rowMin {
+                rowMin = value
+            }
+            j = j + 1
+        }
+        if rowMin > limit {
+            return limit + 1
+        }
+        prev = curr
+        i = i + 1
+    }
+    if prev[br.len()] > limit {
+        return limit + 1
+    }
+    return prev[br.len()]
+}
+
+pub fn lspRankNearbyNames(names: List<String>, target: String, maxDistance: Int) -> List<String> {
+    let mut candidates: List<LspNameCandidate> = []
+    let mut seen: List<String> = []
+    for name in names {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        let distance = lspLevenshteinBounded(target, name, maxDistance)
+        if distance > maxDistance {
+            continue
+        }
+        seen.push(name)
+        candidates.push(LspNameCandidate { name, distance })
+    }
+
+    let mut out: List<String> = []
+    for candidate in lspSortNameCandidates(candidates) {
+        out.push(candidate.name)
+    }
+    return out
+}
+
+pub fn lspMergeNearbyNames(primary: List<String>, fallback: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    let mut seen: List<String> = []
+    for name in primary {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        seen.push(name)
+        out.push(name)
+    }
+    for name in fallback {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        seen.push(name)
+        out.push(name)
+    }
+    return out
 }
 
 pub fn lspSortDedupLocations(locs: List<LspLocation>) -> List<LspLocation> {
@@ -686,6 +1161,134 @@ pub fn lspSortDedupLocations(locs: List<LspLocation>) -> List<LspLocation> {
         have = true
     }
     return out
+}
+
+pub fn lspLocationsForTarget(
+    refs: List<LspReferenceFact>,
+    symbols: List<LspSymbolFact>,
+    targetID: String,
+    includeDecl: Bool,
+) -> List<LspLocation> {
+    if targetID == "" {
+        return []
+    }
+    let mut out: List<LspLocation> = []
+    let mut haveFallbackDecl = false
+    let mut fallbackDecl = LspLocation { uri: "", startLine: 0, startCharacter: 0, endLine: 0, endCharacter: 0 }
+    for ref in refs {
+        if ref.targetSymbolID != targetID {
+            continue
+        }
+        out.push(LspLocation {
+            uri: ref.uri,
+            startLine: ref.startLine,
+            startCharacter: ref.startCharacter,
+            endLine: ref.endLine,
+            endCharacter: ref.endCharacter,
+        })
+        if !(haveFallbackDecl) && ref.targetURI != "" && !(ref.builtin) {
+            fallbackDecl = LspLocation {
+                uri: ref.targetURI,
+                startLine: ref.targetStartLine,
+                startCharacter: ref.targetStartCharacter,
+                endLine: ref.targetEndLine,
+                endCharacter: ref.targetEndCharacter,
+            }
+            haveFallbackDecl = true
+        }
+    }
+    if includeDecl {
+        let mut haveSymbolDecl = false
+        for sym in symbols {
+            if sym.id == targetID {
+                out.push(LspLocation {
+                    uri: sym.uri,
+                    startLine: sym.startLine,
+                    startCharacter: sym.startCharacter,
+                    endLine: sym.endLine,
+                    endCharacter: sym.endCharacter,
+                })
+                haveSymbolDecl = true
+                break
+            }
+        }
+        if !(haveSymbolDecl) && haveFallbackDecl {
+            out.push(fallbackDecl)
+        }
+    }
+    return lspSortDedupLocations(out)
+}
+
+pub fn lspCompletionItemForSymbolView(
+    name: String,
+    kind: String,
+    typeText: String,
+    docText: String,
+) -> LspCompletionItemData {
+    let mut detail = ""
+    if typeText != "" {
+        detail = lspCompletionDetail(kind, name, typeText)
+    }
+    return LspCompletionItemData {
+        label: name,
+        kind: lspCompletionKindForSymbolKind(kind),
+        sortText: lspCompletionSortTextForSymbolKind(kind, name),
+        detail,
+        documentation: docText,
+    }
+}
+
+pub fn lspCompletionItemsForCandidates(
+    candidates: List<LspCompletionCandidateView>,
+    prefix: String,
+) -> List<LspCompletionItemData> {
+    let mut items: List<LspCompletionItemData> = []
+    let mut seen: List<String> = []
+    for candidate in candidates {
+        if !(candidate.include) || candidate.name == "" {
+            continue
+        }
+        if lspStringListContains(seen, candidate.name) {
+            continue
+        }
+        if !(lspNameMatchesPrefix(candidate.name, prefix)) {
+            continue
+        }
+        seen.push(candidate.name)
+        items.push(lspCompletionItemForSymbolView(
+            candidate.name,
+            candidate.kind,
+            candidate.typeText,
+            candidate.docText,
+        ))
+    }
+
+    let mut labels: List<String> = []
+    for item in items {
+        labels.push(item.label)
+    }
+
+    let mut out: List<LspCompletionItemData> = []
+    for idx in lspSortStringIndexes(labels) {
+        if idx < 0 || idx >= items.len() {
+            continue
+        }
+        out.push(items[idx])
+    }
+    return out
+}
+
+pub fn lspSemanticHoverKind(kind: String) -> String {
+    if kind == "fn" {
+        return "function"
+    }
+    if kind == "value" {
+        return "binding"
+    }
+    if kind == "generic" {
+        return "type parameter"
+    }
+    return kind
 }
 
 pub fn lspSortSymbolIndexes(keys: List<LspSymbolSortKey>) -> List<Int> {
@@ -716,6 +1319,14 @@ pub fn lspSortSymbolIndexes(keys: List<LspSymbolSortKey>) -> List<Int> {
     return out
 }
 
+pub fn lspSortStringIndexes(values: List<String>) -> List<Int> {
+    let mut keys: List<LspSymbolSortKey> = []
+    for value in values {
+        keys.push(LspSymbolSortKey { name: value, uri: "" })
+    }
+    return lspSortSymbolIndexes(keys)
+}
+
 pub fn lspSortImportIndexes(keys: List<LspImportSortKey>) -> List<Int> {
     let mut sorted: List<LspIndexedImportSortKey> = []
     let mut index = 0
@@ -740,6 +1351,44 @@ pub fn lspSortImportIndexes(keys: List<LspImportSortKey>) -> List<Int> {
     let mut out: List<Int> = []
     for tagged in sorted {
         out.push(tagged.index)
+    }
+    return out
+}
+
+pub fn lspOrganizedUseBlock(entries: List<LspOrganizeUseEntry>) -> String {
+    let mut kept: List<LspOrganizeUseEntry> = []
+    let mut seen: List<String> = []
+    for entry in entries {
+        if entry.unused || entry.text == "" {
+            continue
+        }
+        let dedupKey = lspKeyWithAlias(entry.group, entry.key, entry.alias)
+        if lspStringListContains(seen, dedupKey) {
+            continue
+        }
+        seen.push(dedupKey)
+        kept.push(entry)
+    }
+
+    let mut keys: List<LspImportSortKey> = []
+    for entry in kept {
+        keys.push(LspImportSortKey { group: entry.group, key: entry.key, alias: entry.alias })
+    }
+
+    let mut out = ""
+    let mut prevGroup = -1
+    let mut emitted = 0
+    for idx in lspSortImportIndexes(keys) {
+        if idx < 0 || idx >= kept.len() {
+            continue
+        }
+        let entry = kept[idx]
+        if emitted > 0 && entry.group != prevGroup {
+            out = "{out}\n"
+        }
+        out = "{out}{entry.text}\n"
+        prevGroup = entry.group
+        emitted = emitted + 1
     }
     return out
 }
@@ -849,6 +1498,46 @@ pub fn lspBuildSignatureText(
         label = "{label} -> {returnType}"
     }
     return LspSignatureText { label, parameterLabels }
+}
+
+pub fn lspParseFunctionType(typeText: String) -> LspFunctionTypeParts {
+    let mut rest = lspTrimAsciiSpace(typeText)
+    if !(lspStringHasPrefix(rest, "fn")) {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+    rest = lspTrimAsciiSpace(lspSliceUnits(rest, 2, rest.chars().len()))
+    if !(lspStringHasPrefix(rest, "(")) {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+
+    let closeIdx = lspMatchingCloseParen(rest)
+    if closeIdx < 0 {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+
+    let paramsText = lspTrimAsciiSpace(lspSliceUnits(rest, 1, closeIdx))
+    let mut params: List<String> = []
+    if paramsText != "" {
+        params = lspSplitTopLevelComma(paramsText)
+    }
+
+    let mut returnType = ""
+    let tail = lspTrimAsciiSpace(lspSliceUnits(rest, closeIdx + 1, rest.chars().len()))
+    if lspStringHasPrefix(tail, "->") {
+        returnType = lspTrimAsciiSpace(lspSliceUnits(tail, 2, tail.chars().len()))
+    }
+    return LspFunctionTypeParts { ok: true, parameterTypes: params, returnType }
+}
+
+pub fn lspFallbackParameterNames(count: Int) -> List<String> {
+    let mut names: List<String> = []
+    let mut idx = 0
+    for idx < count {
+        let ordinal = idx + 1
+        names.push("arg{ordinal}")
+        idx = idx + 1
+    }
+    return names
 }
 
 pub fn lspIsKeywordKind(kind: String) -> Bool {
@@ -1025,6 +1714,44 @@ fn lspSortSemanticTokensByPosition(tokens: List<LspSemanticToken>) -> List<LspSe
     return out
 }
 
+fn lspSortNameCandidates(candidates: List<LspNameCandidate>) -> List<LspNameCandidate> {
+    let mut sorted: List<LspIndexedNameCandidate> = []
+    let mut index = 0
+    for candidate in candidates {
+        let tagged = LspIndexedNameCandidate { candidate, index }
+        let mut inserted = false
+        let mut i = 0
+        for i < sorted.len() {
+            if lspIndexedNameCandidateLess(tagged, sorted[i]) {
+                sorted.insert(i, tagged)
+                inserted = true
+                break
+            }
+            i = i + 1
+        }
+        if !inserted {
+            sorted.push(tagged)
+        }
+        index = index + 1
+    }
+
+    let mut out: List<LspNameCandidate> = []
+    for tagged in sorted {
+        out.push(tagged.candidate)
+    }
+    return out
+}
+
+fn lspIndexedNameCandidateLess(a: LspIndexedNameCandidate, b: LspIndexedNameCandidate) -> Bool {
+    if a.candidate.distance != b.candidate.distance {
+        return a.candidate.distance < b.candidate.distance
+    }
+    if a.candidate.name != b.candidate.name {
+        return a.candidate.name < b.candidate.name
+    }
+    return a.index < b.index
+}
+
 fn lspIndexedSemanticTokenLess(a: LspIndexedSemanticToken, b: LspIndexedSemanticToken) -> Bool {
     if a.token.line != b.token.line {
         return a.token.line < b.token.line
@@ -1117,6 +1844,17 @@ fn lspSameLocation(a: LspLocation, b: LspLocation) -> Bool {
         a.endCharacter == b.endCharacter
 }
 
+fn lspDiagnosticViewEqual(a: LspDiagnosticView, b: LspDiagnosticView) -> Bool {
+    return a.startLine == b.startLine &&
+        a.startCharacter == b.startCharacter &&
+        a.endLine == b.endLine &&
+        a.endCharacter == b.endCharacter &&
+        a.severity == b.severity &&
+        a.code == b.code &&
+        a.source == b.source &&
+        a.message == b.message
+}
+
 fn lspPositionBefore(line: Int, character: Int, otherLine: Int, otherCharacter: Int) -> Bool {
     if line != otherLine {
         return line < otherLine
@@ -1185,6 +1923,273 @@ fn lspStringHasPrefix(text: String, prefix: String) -> Bool {
         idx = idx + 1
     }
     return true
+}
+
+fn lspStringHasSuffix(text: String, suffix: String) -> Bool {
+    if suffix == "" {
+        return true
+    }
+    let textUnits = strings.split(text, "")
+    let suffixUnits = strings.split(suffix, "")
+    if suffixUnits.len() > textUnits.len() {
+        return false
+    }
+    let start = textUnits.len() - suffixUnits.len()
+    let mut idx = 0
+    for idx < suffixUnits.len() {
+        if textUnits[start + idx] != suffixUnits[idx] {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+fn lspStringContains(text: String, needle: String) -> Bool {
+    if needle == "" {
+        return true
+    }
+    let textUnits = strings.split(text, "")
+    let needleUnits = strings.split(needle, "")
+    if needleUnits.len() > textUnits.len() {
+        return false
+    }
+    let mut start = 0
+    for start <= textUnits.len() - needleUnits.len() {
+        let mut idx = 0
+        let mut matched = true
+        for idx < needleUnits.len() {
+            if textUnits[start + idx] != needleUnits[idx] {
+                matched = false
+                break
+            }
+            idx = idx + 1
+        }
+        if matched {
+            return true
+        }
+        start = start + 1
+    }
+    return false
+}
+
+fn lspMethodIsHandled(method: String) -> Bool {
+    return method == "textDocument/didOpen" ||
+        method == "textDocument/didChange" ||
+        method == "textDocument/didClose" ||
+        method == "textDocument/hover" ||
+        method == "textDocument/definition" ||
+        method == "textDocument/formatting" ||
+        method == "textDocument/documentSymbol" ||
+        method == "textDocument/completion" ||
+        method == "textDocument/references" ||
+        method == "textDocument/rename" ||
+        method == "textDocument/signatureHelp" ||
+        method == "workspace/symbol" ||
+        method == "textDocument/inlayHint" ||
+        method == "textDocument/semanticTokens/full" ||
+        method == "textDocument/codeAction"
+}
+
+fn lspStringListContains(items: List<String>, needle: String) -> Bool {
+    for item in items {
+        if item == needle {
+            return true
+        }
+    }
+    return false
+}
+
+fn lspIndexOfUnit(text: String, needle: String) -> Int {
+    let units = strings.split(text, "")
+    let mut idx = 0
+    for idx < units.len() {
+        if units[idx] == needle {
+            return idx
+        }
+        idx = idx + 1
+    }
+    return -1
+}
+
+fn lspSliceUnits(text: String, start: Int, end: Int) -> String {
+    let units = strings.split(text, "")
+    let mut lo = start
+    if lo < 0 {
+        lo = 0
+    }
+    let mut hi = end
+    if hi > units.len() {
+        hi = units.len()
+    }
+    if hi < lo {
+        hi = lo
+    }
+    return frontLexemeFromUnits(units, lo, hi - lo)
+}
+
+fn lspMatchingCloseParen(text: String) -> Int {
+    let units = strings.split(text, "")
+    let mut depth = 0
+    let mut idx = 0
+    for idx < units.len() {
+        if units[idx] == "(" {
+            depth = depth + 1
+        } else if units[idx] == ")" {
+            depth = depth - 1
+            if depth == 0 {
+                return idx
+            }
+        }
+        idx = idx + 1
+    }
+    return -1
+}
+
+fn lspSplitTopLevelComma(text: String) -> List<String> {
+    let units = strings.split(text, "")
+    let mut out: List<String> = []
+    let mut start = 0
+    let mut depth = 0
+    let mut idx = 0
+    for idx < units.len() {
+        let unit = units[idx]
+        if lspIsOpenTypeDelimiter(unit) {
+            depth = depth + 1
+        } else if lspIsCloseTypeDelimiter(unit) {
+            if depth > 0 {
+                depth = depth - 1
+            }
+        } else if unit == "," {
+            if depth == 0 {
+                let part = lspTrimAsciiSpace(frontLexemeFromUnits(units, start, idx - start))
+                if part != "" {
+                    out.push(part)
+                }
+                start = idx + 1
+            }
+        }
+        idx = idx + 1
+    }
+    let tail = lspTrimAsciiSpace(frontLexemeFromUnits(units, start, units.len() - start))
+    if tail != "" {
+        out.push(tail)
+    }
+    return out
+}
+
+fn lspIsOpenTypeDelimiter(unit: String) -> Bool {
+    return unit == "(" || unit == "[" || unit == "<"
+}
+
+fn lspIsCloseTypeDelimiter(unit: String) -> Bool {
+    return unit == ")" || unit == "]" || unit == ">"
+}
+
+fn lspTrimAsciiSpace(text: String) -> String {
+    let units = strings.split(text, "")
+    let mut start = 0
+    let mut end = units.len()
+    for start < end && (units[start] == " " || units[start] == "\t" || units[start] == "\r" || units[start] == "\n") {
+        start = start + 1
+    }
+    for end > start && (units[end - 1] == " " || units[end - 1] == "\t" || units[end - 1] == "\r" || units[end - 1] == "\n") {
+        end = end - 1
+    }
+    return frontLexemeFromUnits(units, start, end - start)
+}
+
+fn lspEqualFoldAscii(a: String, b: String) -> Bool {
+    let au = strings.split(a, "")
+    let bu = strings.split(b, "")
+    if au.len() != bu.len() {
+        return false
+    }
+    let mut idx = 0
+    for idx < au.len() {
+        if lspAsciiLowerUnit(au[idx]) != lspAsciiLowerUnit(bu[idx]) {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+fn lspAsciiLowerUnit(unit: String) -> String {
+    if unit == "A" { return "a" }
+    if unit == "B" { return "b" }
+    if unit == "C" { return "c" }
+    if unit == "D" { return "d" }
+    if unit == "E" { return "e" }
+    if unit == "F" { return "f" }
+    if unit == "G" { return "g" }
+    if unit == "H" { return "h" }
+    if unit == "I" { return "i" }
+    if unit == "J" { return "j" }
+    if unit == "K" { return "k" }
+    if unit == "L" { return "l" }
+    if unit == "M" { return "m" }
+    if unit == "N" { return "n" }
+    if unit == "O" { return "o" }
+    if unit == "P" { return "p" }
+    if unit == "Q" { return "q" }
+    if unit == "R" { return "r" }
+    if unit == "S" { return "s" }
+    if unit == "T" { return "t" }
+    if unit == "U" { return "u" }
+    if unit == "V" { return "v" }
+    if unit == "W" { return "w" }
+    if unit == "X" { return "x" }
+    if unit == "Y" { return "y" }
+    if unit == "Z" { return "z" }
+    return unit
+}
+
+fn lspParseNonNegativeDecimal(text: String) -> Int {
+    let units = strings.split(text, "")
+    if units.len() == 0 {
+        return -1
+    }
+    let mut out = 0
+    for unit in units {
+        if unit < "0" || unit > "9" {
+            return -1
+        }
+        out = out * 10 + lspDecimalDigit(unit)
+    }
+    return out
+}
+
+fn lspDecimalDigit(unit: String) -> Int {
+    if unit == "0" { return 0 }
+    if unit == "1" { return 1 }
+    if unit == "2" { return 2 }
+    if unit == "3" { return 3 }
+    if unit == "4" { return 4 }
+    if unit == "5" { return 5 }
+    if unit == "6" { return 6 }
+    if unit == "7" { return 7 }
+    if unit == "8" { return 8 }
+    if unit == "9" { return 9 }
+    return -1
+}
+
+fn lspAbsInt(v: Int) -> Int {
+    if v < 0 {
+        return -v
+    }
+    return v
+}
+
+fn lspMin3Int(a: Int, b: Int, c: Int) -> Int {
+    let mut out = a
+    if b < out {
+        out = b
+    }
+    if c < out {
+        out = c
+    }
+    return out
 }
 
 fn lspIsIdentContUnit(unit: String) -> Bool {

--- a/toolchain/lsp_test.osty
+++ b/toolchain/lsp_test.osty
@@ -108,6 +108,120 @@ fn testLspCompletionAndCodeActionPolicy() {
     testing.assertEq(lspPrefixUnderscoreName("value"), "_value")
     testing.assertEq(lspPrefixUnderscoreName(""), "_")
     testing.assertEq(lspPrefixUnderscoreTitle("value"), "Prefix `value` with `_` to silence")
+    testing.assertEq(lspServerName(), "osty-lsp")
+    testing.assertEq(lspServerVersion(), "0.1.0")
+    testing.assertEq(lspPositionEncodingUTF16(), "utf-16")
+    testing.assertEq(lspJSONNull(), "null")
+    testing.assertEq(lspCompletionTriggerDot(), ".")
+    testing.assertEq(lspSignatureTriggerOpenParen(), "(")
+    testing.assertEq(lspSignatureTriggerComma(), ",")
+    let legend = lspSemanticTokenTypes()
+    testing.assertEq(legend[0], "namespace")
+    testing.assertEq(legend[11], "enumMember")
+    let modifiers = lspSemanticTokenModifiers()
+    testing.assertEq(modifiers[0], "declaration")
+    testing.assertEq(modifiers[1], "readonly")
+    testing.assertEq(lspExitCode(true), 0)
+    testing.assertEq(lspExitCode(false), 1)
+    testing.assertEq(lspDispatchDecision("initialize", false, false, false).action, lspDispatchActionInitialize())
+    testing.assertEq(lspDispatchDecision("textDocument/hover", false, false, false).errorCode, lspErrServerNotInitialized())
+    testing.assertEq(lspDispatchDecision("shutdown", false, true, false).action, lspDispatchActionShutdown())
+    testing.assertEq(lspDispatchDecision("textDocument/hover", false, true, false).action, lspDispatchActionDispatch())
+    testing.assertEq(lspDispatchDecision("unknown/method", false, true, false).errorCode, lspErrMethodNotFound())
+    testing.assertEq(lspDispatchDecision("unknown/method", true, true, false).action, lspDispatchActionIgnore())
+    testing.assertEq(lspAsciiLowerText("HeLLo"), "hello")
+    testing.assert(lspNameMatchesPrefix("helper", "hel"))
+    testing.assert(!(lspNameMatchesPrefix("helper", "map")))
+    testing.assert(lspNameMatchesQuery("HelperValue", "value"))
+    testing.assertEq(lspUriForSourcePath("inmemory:main"), "inmemory:main")
+    testing.assertEq(lspUriForSourcePath("/tmp/main.osty"), "file:///tmp/main.osty")
+    testing.assert(lspPreferAIRepairFixAll("x.length"))
+    testing.assert(!(lspPreferAIRepairFixAll("x.len()")))
+    testing.assert(lspTextChanged("a", "b"))
+    testing.assert(!(lspTextChanged("a", "a")))
+    testing.assert(lspParamsAreEmpty(""))
+    testing.assert(lspParamsAreEmpty("null"))
+    testing.assert(!(lspParamsAreEmpty("{}")))
+    testing.assertEq(lspRenameEmptyNameMessage(), "new name is empty")
+    testing.assertEq(lspCannotRenameBuiltinMessage(), "cannot rename a builtin")
+    testing.assert(lspCanRenameKind("function"))
+    testing.assert(!(lspCanRenameKind("builtin")))
+    testing.assertEq(lspRenameTitle("helper"), "Rename to `helper`")
+    testing.assertEq(lspRemoveLineTitle(), "Remove unused import")
+    testing.assertEq(lspFixAllTitle(), "Fix all auto-fixable problems")
+    testing.assertEq(lspOrganizeImportsTitle(), "Organize imports")
+    testing.assertEq(lspInlayTypeLabel("Int"), ": Int")
+    testing.assertEq(lspMethodNotImplementedMessage("custom/method"), "method not implemented: custom/method")
+    testing.assert(lspIsOstySourceFileName("main.osty"))
+    testing.assert(!(lspIsOstySourceFileName("main_test.osty")))
+    testing.assert(!(lspIsOstySourceFileName("main.go")))
+    testing.assert(lspHasOstyFileExtension("main_test.osty"))
+    testing.assert(!(lspHasOstyFileExtension("main.go")))
+
+    let completion = lspCompletionItemForSymbolView("map", "function", "fn(Int) -> String", "docs")
+    testing.assertEq(completion.label, "map")
+    testing.assertEq(completion.kind, lspCompletionKindFunction())
+    testing.assertEq(completion.sortText, "2_map")
+    testing.assertEq(completion.detail, "fn map(Int) -> String")
+    testing.assertEq(completion.documentation, "docs")
+
+    let filtered = lspCompletionItemsForCandidates(
+        [
+            LspCompletionCandidateView { name: "zeta", kind: "binding", typeText: "Int", docText: "", include: true },
+            LspCompletionCandidateView { name: "alpha", kind: "function", typeText: "fn() -> Int", docText: "docs", include: true },
+            LspCompletionCandidateView { name: "alpha", kind: "binding", typeText: "String", docText: "", include: true },
+            LspCompletionCandidateView { name: "hidden", kind: "binding", typeText: "Int", docText: "", include: false },
+            LspCompletionCandidateView { name: "", kind: "binding", typeText: "Int", docText: "", include: true },
+        ],
+        "",
+    )
+    testing.assertEq(filtered.len(), 2)
+    testing.assertEq(filtered[0].label, "alpha")
+    testing.assertEq(filtered[0].detail, "fn alpha() -> Int")
+    testing.assertEq(filtered[0].documentation, "docs")
+    testing.assertEq(filtered[1].label, "zeta")
+}
+
+fn testLspJsonRpcHeaderPolicy() {
+    testing.assertEq(lspFrameHeader(17), "Content-Length: 17\r\n\r\n")
+    testing.assertEq(lspTrimHeaderLine("Content-Length: 17\r\n"), "Content-Length: 17")
+    let parsed = lspParseHeaderLines([
+        "Content-Type: application/vscode-jsonrpc; charset=utf-8",
+        "content-length: 42",
+    ])
+    testing.assert(parsed.ok)
+    testing.assertEq(parsed.contentLength, 42)
+    testing.assertEq(parsed.error, "")
+
+    let missing = lspParseHeaderLines(["Content-Type: application/json"])
+    testing.assert(missing.ok)
+    testing.assertEq(missing.contentLength, -1)
+
+    let empty = lspParseHeaderLines([])
+    testing.assert(!(empty.ok))
+    testing.assertEq(empty.error, "lsp: empty header block")
+
+    let malformed = lspParseHeaderLines(["Content Length 42"])
+    testing.assert(!(malformed.ok))
+
+    let invalid = lspParseHeaderLines(["Content-Length: -1"])
+    testing.assert(!(invalid.ok))
+}
+
+fn testLspNearbyNameRankingPolicy() {
+    testing.assertEq(lspLevenshteinBounded("kitten", "sitting", 3), 3)
+    testing.assertEq(lspLevenshteinBounded("kitten", "sitting", 2), 3)
+    let ranked = lspRankNearbyNames(
+        ["helpr", "helper", "helper", "helmet", ""],
+        "helper",
+        1,
+    )
+    testing.assertEq(ranked.len(), 2)
+    testing.assertEq(ranked[0], "helper")
+    testing.assertEq(ranked[1], "helpr")
+    let merged = lspMergeNearbyNames(["helper", "helpr"], ["helper", "holder"])
+    testing.assertEq(merged.len(), 3)
+    testing.assertEq(merged[2], "holder")
 }
 
 fn testLspSymbolKindPolicy() {
@@ -140,6 +254,18 @@ fn testLspSignatureTextPolicy() {
     testing.assertEq(sig.label, "fn map(items: List<Int>, f: fn(Int) -> String) -> List<String>")
     testing.assertEq(sig.parameterLabels[0], "items: List<Int>")
     testing.assertEq(sig.parameterLabels[1], "f: fn(Int) -> String")
+
+    let parsed = lspParseFunctionType("fn(Int, Result<String, Error>, fn(Int) -> Bool) -> String")
+    testing.assert(parsed.ok)
+    testing.assertEq(parsed.parameterTypes.len(), 3)
+    testing.assertEq(parsed.parameterTypes[1], "Result<String, Error>")
+    testing.assertEq(parsed.parameterTypes[2], "fn(Int) -> Bool")
+    testing.assertEq(parsed.returnType, "String")
+    testing.assert(!(lspParseFunctionType("List<Int>").ok))
+
+    let fallbackNames = lspFallbackParameterNames(3)
+    testing.assertEq(fallbackNames[0], "arg1")
+    testing.assertEq(fallbackNames[2], "arg3")
 }
 
 fn testLspFindsNameOffsetInsideDeclarationSpan() {
@@ -175,6 +301,8 @@ fn testLspPositionAndParameterPolicy() {
     testing.assert(!(lspContainsPosition(1, 2, 1, 8, 1, 9)))
     testing.assert(lspSpanOverlaps(10, 20, 20, 30))
     testing.assert(!(lspSpanOverlaps(10, 19, 20, 30)))
+    testing.assertEq(lspNamedTypeReferenceEndOffset(10, 20, 6, true, 4), 14)
+    testing.assertEq(lspNamedTypeReferenceEndOffset(18, 20, 6, false, 4), 20)
     testing.assertEq(lspActiveParameter([12, 20, 32], 20), 1)
     testing.assertEq(lspActiveParameter([12, 20, 32], 33), 3)
 }
@@ -186,6 +314,9 @@ fn testLspUtf16PositionConversionPolicy() {
     testing.assertEq(lines[1], 4)
     testing.assertEq(lines[2], 6)
     testing.assertEq(lspUtf16UnitsInByteRange(source, 0, 2), 3)
+    let fullRange = lspFullDocumentRange(source, lines)
+    testing.assertEq(fullRange.endLine, 2)
+    testing.assertEq(fullRange.endCharacter, 3)
 
     let fromOsty = lspOstyPositionToLSP(source, lines, 1, 2)
     testing.assertEq(fromOsty.line, 0)
@@ -215,6 +346,10 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(lspPathToUri("/tmp/main.osty"), "file:///tmp/main.osty")
     testing.assertEq(lspPathToUri("C:/tmp/main.osty"), "file:///C:/tmp/main.osty")
     testing.assertEq(lspPathToUri(""), "file://")
+    testing.assert(lspFileURIPathRaw("file:///tmp/main.osty").ok)
+    testing.assertEq(lspFileURIPathRaw("file:///tmp/main.osty").path, "/tmp/main.osty")
+    testing.assertEq(lspFileURIPathRaw("file:///C:/tmp/main.osty").path, "C:/tmp/main.osty")
+    testing.assert(!(lspFileURIPathRaw("inmemory:main").ok))
 
     let locs = [
         LspLocation {
@@ -244,6 +379,54 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(resolved[0].uri, "file:///a.osty")
     testing.assertEq(resolved[1].uri, "file:///b.osty")
 
+    let targetLocs = lspLocationsForTarget(
+        [
+            LspReferenceFact {
+                uri: "file:///b.osty",
+                startLine: 2,
+                startCharacter: 0,
+                endLine: 2,
+                endCharacter: 4,
+                targetSymbolID: "sym.helper",
+                targetURI: "file:///decl.osty",
+                targetStartLine: 1,
+                targetStartCharacter: 1,
+                targetEndLine: 1,
+                targetEndCharacter: 7,
+                builtin: false,
+            },
+            LspReferenceFact {
+                uri: "file:///a.osty",
+                startLine: 4,
+                startCharacter: 1,
+                endLine: 4,
+                endCharacter: 7,
+                targetSymbolID: "sym.helper",
+                targetURI: "",
+                targetStartLine: 0,
+                targetStartCharacter: 0,
+                targetEndLine: 0,
+                targetEndCharacter: 0,
+                builtin: false,
+            },
+        ],
+        [
+            LspSymbolFact {
+                id: "sym.helper",
+                uri: "file:///decl.osty",
+                startLine: 1,
+                startCharacter: 2,
+                endLine: 1,
+                endCharacter: 8,
+            },
+        ],
+        "sym.helper",
+        true,
+    )
+    testing.assertEq(targetLocs.len(), 3)
+    testing.assertEq(targetLocs[0].uri, "file:///a.osty")
+    testing.assertEq(targetLocs[2].startCharacter, 2)
+
     let symbolOrder = lspSortSymbolIndexes([
         LspSymbolSortKey { name: "Zoo", uri: "file:///b.osty" },
         LspSymbolSortKey { name: "App", uri: "file:///z.osty" },
@@ -252,6 +435,11 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(symbolOrder[0], 2)
     testing.assertEq(symbolOrder[1], 1)
     testing.assertEq(symbolOrder[2], 0)
+
+    let stringOrder = lspSortStringIndexes(["z.osty", "a.osty", "a.osty"])
+    testing.assertEq(stringOrder[0], 1)
+    testing.assertEq(stringOrder[1], 2)
+    testing.assertEq(stringOrder[2], 0)
 
     let importOrder = lspSortImportIndexes([
         LspImportSortKey { group: 1, key: "zeta", alias: "" },
@@ -263,6 +451,15 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(importOrder[1], 3)
     testing.assertEq(importOrder[2], 2)
     testing.assertEq(importOrder[3], 0)
+
+    let organized = lspOrganizedUseBlock([
+        LspOrganizeUseEntry { group: 1, key: "zeta", alias: "", text: "use zeta", unused: false },
+        LspOrganizeUseEntry { group: 0, key: "fmt", alias: "", text: "use std.fmt", unused: false },
+        LspOrganizeUseEntry { group: 1, key: "alpha", alias: "", text: "use alpha", unused: false },
+        LspOrganizeUseEntry { group: 1, key: "alpha", alias: "", text: "use alpha duplicate", unused: false },
+        LspOrganizeUseEntry { group: 0, key: "io", alias: "", text: "use std.io", unused: true },
+    ])
+    testing.assertEq(organized, "use std.fmt\n\nuse alpha\nuse zeta\n")
 
     testing.assertEq(lspUseGroup(false, ["std", "fmt"]), 0)
     testing.assertEq(lspUseGroup(false, ["pkg"]), 1)
@@ -284,6 +481,65 @@ fn testLspDiagnosticPayloadPolicy() {
     testing.assertEq(payload.message, "unused value\nhelp: prefix it\nnote: declared here")
     testing.assertEq(lspDiagnosticPayload("note", "FYI", "", []).severity, lspDiagnosticSeverityInformation())
     testing.assertEq(lspDiagnosticPayload("unknown", "bad", "", []).severity, lspDiagnosticSeverityError())
+    let diagA = LspDiagnosticView {
+        startLine: 1,
+        startCharacter: 2,
+        endLine: 1,
+        endCharacter: 4,
+        severity: lspDiagnosticSeverityError(),
+        code: "E0500",
+        source: lspServerName(),
+        message: "bad",
+    }
+    let diagB = LspDiagnosticView {
+        startLine: 1,
+        startCharacter: 2,
+        endLine: 1,
+        endCharacter: 4,
+        severity: lspDiagnosticSeverityError(),
+        code: "E0500",
+        source: lspServerName(),
+        message: "bad",
+    }
+    testing.assert(lspDiagnosticsEqual([diagA], [diagB]))
+    testing.assert(!(lspDiagnosticsEqual([diagA], [])))
+
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "/tmp/main.osty",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 0,
+        primaryOffset: 999,
+        sourceLength: 1,
+    }))
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "src1",
+        packageSourceFileID: "src1",
+        primaryLine: 0,
+        primaryOffset: 999,
+        sourceLength: 1,
+    }))
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 1,
+        primaryOffset: 3,
+        sourceLength: 3,
+    }))
+    testing.assert(!(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 0,
+        primaryOffset: 0,
+        sourceLength: 3,
+    })))
 }
 
 fn testLspResolveOverlappingTextEdits() {


### PR DESCRIPTION
## Summary
- Move pure LSP policy decisions into `toolchain/lsp.osty`.
- Add Osty policy coverage in `toolchain/lsp_test.osty` and Go parity tests for the selfhost mirror.
- Keep Go LSP code focused on protocol glue, adapters, and workspace/query integration.

## Validation
- `go run ./cmd/osty tokens toolchain/lsp.osty`
- `go run ./cmd/osty tokens toolchain/lsp_test.osty`
- `go test -count=1 -vet=off ./internal/lsp`
- `go test -count=1 -vet=off ./internal/selfhost/bundle`
- `go test -count=1 -vet=off ./internal/ci ./internal/runner -run SnapshotParity`
- `git diff --check HEAD`
- `go run ./cmd/osty check --airepair=false toolchain/lsp.osty` currently fails in existing broader toolchain files (`core_clone.osty`, `hir_print.osty`, `mir.osty`, `mir_generator.osty`, `mir_optimize.osty`); no LSP-file errors were reported.