### PR TITLE
feat(backend/stage0): list literal + indexed read xs[N] (P15)

### DIFF
--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -176,7 +176,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P12 | List<Int> 리터럴 + len() — runtime ABI 호출 (osty_rt_list_new / push_i64 / len) | list_literal_len real-MIR — **구현 완료** |
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
 | P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
-| P15+ | list ops (get/iterate) / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
+| P15 | list literal + indexed read `xs[N]` → list_get_i64 runtime ABI | list_literal_index_first / _second real-MIR — **구현 완료** |
+| P16+ | list iterate / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -340,6 +340,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchAggregateConstructor(fn, mctx); ok {
 		return emitAggregateConstructor(out, fn, pat)
 	}
+	if pat, ok := matchListLiteralIndexGet(fn, mctx); ok {
+		return emitListLiteralIndexGet(out, fn, pat)
+	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
 
@@ -2572,6 +2575,144 @@ func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggreg
 		prev = fmt.Sprintf("%%%d", i)
 	}
 	fmt.Fprintf(out, "  ret %%%s %s\n", pat.typeName, prev)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P15: list literal + indexed read ----
+//
+// `let xs: List<Int> = [10, 20, 30]; xs[0]` lowers to a 3-instruction
+// block: an AggregateRV{AggList} writing the list, followed by an
+// AssignInstr whose Src is `UseRV(CopyOp(list_local, [IndexProj]))`.
+// stage0 P15 emits this as a list_new + N pushes + list_get_i64 chain.
+
+type listLiteralIndexPattern struct {
+	elements []int64
+	index    int64
+}
+
+func matchListLiteralIndexGet(fn *mir.Function, mctx *moduleCtx) (listLiteralIndexPattern, bool) {
+	pat := listLiteralIndexPattern{}
+	if scalarFromType(fn.ReturnType) != scalarInt {
+		return pat, false
+	}
+	if len(fn.Params) != 0 {
+		return pat, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok {
+		return pat, false
+	}
+
+	var (
+		listLocal mir.LocalID
+		listSet   bool
+		readSet   bool
+	)
+	for _, instr := range bb.Instrs {
+		switch step := instr.(type) {
+		case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+			continue
+		case *mir.AssignInstr:
+			if !listSet {
+				if step.Dest.HasProjections() {
+					return pat, false
+				}
+				loc := lookupLocal(fn, step.Dest.Local)
+				if loc == nil {
+					return pat, false
+				}
+				named, ok := loc.Type.(*ir.NamedType)
+				if !ok || named == nil || named.Name != "List" {
+					return pat, false
+				}
+				agg, ok := step.Src.(*mir.AggregateRV)
+				if !ok || agg.Kind != mir.AggList {
+					return pat, false
+				}
+				elements := make([]int64, 0, len(agg.Fields))
+				for _, f := range agg.Fields {
+					con, ok := f.(*mir.ConstOp)
+					if !ok {
+						return pat, false
+					}
+					ic, ok := con.Const.(*mir.IntConst)
+					if !ok {
+						return pat, false
+					}
+					elements = append(elements, ic.Value)
+				}
+				pat.elements = elements
+				listLocal = step.Dest.Local
+				listSet = true
+				continue
+			}
+			// Second AssignInstr: must be the indexed read into ret.
+			if readSet {
+				return pat, false
+			}
+			if step.Dest.Local != fn.ReturnLocal || step.Dest.HasProjections() {
+				return pat, false
+			}
+			use, ok := step.Src.(*mir.UseRV)
+			if !ok {
+				return pat, false
+			}
+			cp, ok := use.Op.(*mir.CopyOp)
+			if !ok || cp.Place.Local != listLocal {
+				return pat, false
+			}
+			if len(cp.Place.Projections) != 1 {
+				return pat, false
+			}
+			idxProj, ok := cp.Place.Projections[0].(*mir.IndexProj)
+			if !ok {
+				return pat, false
+			}
+			idxConst, ok := idxProj.Index.(*mir.ConstOp)
+			if !ok {
+				return pat, false
+			}
+			ic, ok := idxConst.Const.(*mir.IntConst)
+			if !ok {
+				return pat, false
+			}
+			pat.index = ic.Value
+			readSet = true
+		default:
+			return pat, false
+		}
+	}
+	if !listSet || !readSet {
+		return pat, false
+	}
+	declareListRuntime(mctx)
+	declareListGetRuntime(mctx)
+	return pat, true
+}
+
+// declareListGetRuntime adds the `osty_rt_list_get_i64` declare to
+// extraDecls (idempotent — sentinel via emittedStructs).
+func declareListGetRuntime(mctx *moduleCtx) {
+	if mctx.emittedStructs == nil {
+		mctx.emittedStructs = map[string]bool{}
+	}
+	if mctx.emittedStructs["__stage0.list_get_i64"] {
+		return
+	}
+	mctx.emittedStructs["__stage0.list_get_i64"] = true
+	mctx.extraDecls.WriteString("declare i64 @osty_rt_list_get_i64(ptr, i64)\n")
+}
+
+func emitListLiteralIndexGet(out *strings.Builder, fn *mir.Function, pat listLiteralIndexPattern) error {
+	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
+	out.WriteString("entry:\n")
+	out.WriteString("  %0 = call ptr @osty_rt_list_new()\n")
+	for _, v := range pat.elements {
+		fmt.Fprintf(out, "  call void @osty_rt_list_push_i64(ptr %%0, i64 %d)\n", v)
+	}
+	fmt.Fprintf(out, "  %%1 = call i64 @osty_rt_list_get_i64(ptr %%0, i64 %d)\n", pat.index)
+	out.WriteString("  ret i64 %1\n")
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -390,6 +390,37 @@ fn main() {}`,
 				"ret %.tuple.0 %1",
 			},
 		},
+		{
+			name: "list_literal_index_first",
+			src: `fn first() -> Int {
+    let xs: List<Int> = [10, 20, 30]
+    xs[0]
+}
+fn main() {}`,
+			wantIR: []string{
+				"declare ptr @osty_rt_list_new()",
+				"declare void @osty_rt_list_push_i64(ptr, i64)",
+				"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+				"define i64 @first()",
+				"%0 = call ptr @osty_rt_list_new()",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 10)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 20)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 30)",
+				"%1 = call i64 @osty_rt_list_get_i64(ptr %0, i64 0)",
+				"ret i64 %1",
+			},
+		},
+		{
+			name: "list_literal_index_second",
+			src: `fn second() -> Int {
+    let xs: List<Int> = [100, 200, 300]
+    xs[1]
+}
+fn main() {}`,
+			wantIR: []string{
+				"%1 = call i64 @osty_rt_list_get_i64(ptr %0, i64 1)",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Summary

P12 의 list literal + len 패턴을 보완해서 **indexed read** 지원: `xs[N]` 으로 const-index 요소 접근.

```osty
fn first() -> Int {
    let xs: List<Int> = [10, 20, 30]
    xs[0]
}
```

→
```llvm
declare ptr  @osty_rt_list_new()
declare void @osty_rt_list_push_i64(ptr, i64)
declare i64  @osty_rt_list_get_i64(ptr, i64)

define i64 @first() {
entry:
  %0 = call ptr @osty_rt_list_new()
  call void @osty_rt_list_push_i64(ptr %0, i64 10)
  call void @osty_rt_list_push_i64(ptr %0, i64 20)
  call void @osty_rt_list_push_i64(ptr %0, i64 30)
  %1 = call i64 @osty_rt_list_get_i64(ptr %0, i64 0)
  ret i64 %1
}
```

### MIR shape

단일 블록 안에서:
- `(StorageLive)`
- `AssignInstr(list_local, AggregateRV{AggList, IntConst...})`
- `AssignInstr(ret, UseRV(CopyOp(list_local, [IndexProj{ConstOp(N)}])))`
- `ReturnTerm`

### 새 매처 / 이미터

- `listLiteralIndexPattern` (elements + index const).
- `matchListLiteralIndexGet` — 단일 블록 안에서 list literal 생성 + `CopyOp(list, [IndexProj])` 1회 + ReturnTerm 형태만 매치. 인덱스는 `ConstOp(IntConst)` 한정 (변수 인덱스는 P16+).
- `declareListGetRuntime` — `osty_rt_list_get_i64` declare idempotent 추가.
- `emitListLiteralIndexGet` — list_new + N pushes + list_get_i64 + ret 시퀀스.

### 테스트 +2 (총 29/29 baseline)

- `list_literal_index_first`: `xs[0]` (3-element list).
- `list_literal_index_second`: `xs[1]` (3-element list).

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/backend/stage0/...` — 0 fail
- [x] `go test ./internal/backend/...` — real-MIR baseline 29/29 통과

## Notes

- 디스패처 wiring 영향 0.
- 다음 (P16+): list iterate (5-block for-in-list with LenRV + IndexProj reads), Optional/Result/match.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_