### PR TITLE
feat(toolchain): selfhostcache foundation + artifact-cache design (A1)

### DIFF
--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -1,0 +1,162 @@
+# `osty-self` artifact cache 설계
+
+> **상태**: 제안 + 첫 단계 구현 (이 PR의 `internal/toolchain/selfhostcache`).
+> **연관**: `docs/osty_self_bootstrap_design.md` (stage0 — emergency-only fallback).
+> **소유**: backend / toolchain / CI.
+
+## 1. 문제 정의
+
+PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
+모든 production MIR → LLVM 변환은 **`osty-self lir-proto-lower`**
+서브프로세스를 통해야 한다. `osty-self` 는 `toolchain/*.osty` 를
+`osty build` 로 컴파일한 산출물이고, 그 `osty build` 자체가 또
+`osty-self` 를 필요로 한다 — 닭-달걀 부트스트랩 의존.
+
+기존 옵션 두 가지:
+- **stage0 fallback** (`docs/osty_self_bootstrap_design.md` P0~P15) — Go
+  쪽에 minimal MIR→LLVM emitter 를 두고 `osty-self` 부재 시 사용. 본격
+  toolchain 컴파일까진 cover 하지 못 함. 사실상 `internal/llvmgen` 의
+  소형 재창조에 가까워서 #1405 의 정신에 어긋남.
+- **외부 사전-빌드 osty-self** — 어딘가에서 빌드된 바이너리를 가져와
+  쓰는 방식. 영구 가치가 가장 높은 접근.
+
+본 문서는 두 번째 옵션을 단계적으로 구현하는 설계다.
+
+## 2. 큰 그림
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │  ResolveBinary(projectRoot)                 │
+                 │                                             │
+   ┌────────┐    │  1. $OSTY_SELF_BIN env override             │
+   │ caller │───▶│  2. toolchain/.osty/out/{debug,release}/   │
+   └────────┘    │     llvm/osty-self  (in-tree dev build)     │
+                 │  3. .osty/cache/self-host/<sha-triple>/    │
+                 │     osty-self  ← content-addressed cache    │
+                 │  4. (future) network fetch from release     │
+                 │  5. ErrNotCached → stage0 emergency or fail │
+                 └─────────────────────────────────────────────┘
+```
+
+캐시 entry 의 키는 **`(toolchain SHA-256, host triple)`** 의 페어.
+`toolchain/*.osty` 가 변경되면 SHA 가 바뀌어 자동으로 무효화되고,
+다른 호스트에서 빌드된 바이너리는 triple 부분에서 매치되지 않는다.
+
+## 3. 단계별 로드맵
+
+| Phase | 범위 | 측정 |
+|---|---|---|
+| **A1** (이 PR) | `internal/toolchain/selfhostcache` 패키지 — `Key`, `ComputeKey`, `ResolveBinary`, `Install`, `CachePath`. 디스크에 이미 있는 캐시 entry 만 lookup. 네트워크 0. | 13 단위 테스트 통과 |
+| A2 | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. 로컬 빌드 → `Install` 자동 호출. | 기존 lirproto 테스트 + 통합 |
+| A3 | `osty install-self` 서브커맨드 — toolchain 빌드 + 캐시 적재 한 번에. `just bootstrap` 가 이걸 호출. | E2E |
+| A4 | 네트워크 fetcher — GitHub Release / S3-compatible URL 에서 `<sha>-<triple>` artifact 다운로드. SHA-256 검증 필수. | offline 모드 정책 결정 |
+| A5 | CI 워크플로 — main 브랜치 push 시 6개 host triple 별로 빌드 → release artifact 업로드 + manifest. | reproducibility 확인 |
+| A6 | Manifest signing (sigstore / minisign) — supply-chain 보호. | 정책 결정 |
+
+## 4. Key 구성
+
+```go
+type Key struct {
+    ToolchainSHA string  // hex SHA-256
+    Triple       string  // "linux-amd64", "darwin-arm64", ...
+}
+```
+
+### 4.1 ToolchainSHA
+
+다음 알고리즘:
+
+1. `projectRoot/toolchain` 아래 모든 `*.osty` 파일을 walk.
+2. `toolchain/.osty/` 아래는 **제외** (생성 산출물).
+3. repo-relative path 로 정렬.
+4. 각 파일에 대해 hash 에 다음을 입력:
+   ```
+   path:<rel-path-with-slashes>\n
+   size:<byte-len>\n
+   <file-bytes>
+   <0x00 separator>
+   ```
+5. SHA-256 의 hex.
+
+### 4.2 Triple
+
+`runtime.GOOS + "-" + runtime.GOARCH`. 예: `linux-amd64`, `darwin-arm64`.
+
+LLVM target triple 과는 다른 layer. cross-compile 빌드는 별도 정책 (현재
+범위 외).
+
+## 5. Lookup 우선순위 근거
+
+1. **`OSTY_SELF_BIN` 환경변수** — 디버깅 / 비표준 위치 / 테스트용
+   override 가 항상 이김.
+2. **In-tree build path** — 활성 개발 워크트리에서 로컬 빌드한 바이너리는
+   캐시보다 항상 신선. 캐시는 그 빌드가 끝난 후 별도로 promote 된다 (A2).
+3. **Content-addressed cache** — 다른 워크트리 / 다른 머신에서 promote
+   된 바이너리. SHA 가 다르면 stale 로 자동 거부.
+4. **Network fetch** (A4+) — 캐시에도 없으면 release host 에서 다운로드.
+5. **Stage0 emergency fallback** — 네트워크 disabled / offline 환경에서만.
+
+## 6. 보안 / 무결성
+
+A4 단계에서 도입할 정책:
+- 다운로드는 **HTTPS** 만.
+- 응답 본문의 SHA-256 가 manifest 의 값과 일치하는지 검증.
+- (A6) manifest 자체의 서명 검증.
+- 검증 실패 시 캐시에 **저장하지 않고** 에러로 fall through.
+
+A1~A3 (로컬-only) 까지는 보안 모델이 단순하다 — 사용자가 이미 제어하는
+파일시스템.
+
+## 7. Stage0 의 미래
+
+`docs/osty_self_bootstrap_design.md` P0~P15 의 stage0 emitter 는 본 artifact
+시스템이 작동하기 시작하는 시점부터 **emergency-only** 로 동결된다:
+
+- 네트워크 차단 + 캐시 비어 있음 + in-tree 빌드 없음 일 때만 활성.
+- `OSTY_STAGE0_FALLBACK=1` 환경변수가 여전히 게이트.
+- 새 패턴 추가는 중단 (P16+ 미진행).
+
+stage0 의 인프라 (P0 `IsOstySelfMissing`, P4 디스패처 wiring, P5 real-MIR
+test infra) 는 본 artifact 시스템에서도 그대로 가치 보존된다 — fallback
+체인의 마지막 단계로 유지되며, real-MIR 회귀 테스트는 stage0 든 osty-self
+든 어느 쪽이 emit 했는지 무관하게 회귀 게이트로 작동.
+
+## 8. 결정 필요 항목
+
+1. **CI 빌드 호스트** — GitHub Actions 의 어떤 runner 가 어떤 triple 을
+   담당? linux-amd64, linux-arm64 (self-hosted?), darwin-amd64,
+   darwin-arm64, windows-amd64, windows-arm64.
+2. **Release 정책** — main push 마다? 태그 push 시? 분기 빌드는?
+3. **Storage 비용** — GitHub Release artifact 무료 한도 vs S3 / R2 호스팅.
+4. **Toolchain 변경 빈도** — 너무 잦으면 release 폭주. 캐시 키 안정성을 위해
+   toolchain 외 변경은 키에 들어가지 않게 4.1 알고리즘 유지.
+5. **Reproducibility** — 같은 toolchain SHA 에서 host 가 같은 OS/CPU 라면
+   바이너리가 같아야 함. LLVM 의 비결정성 (예: -fdebug-prefix-map) 통제 필요.
+
+## Appendix A. A1 단계 (이 PR) 의 효과
+
+- **사용자**: 아직 실제로 동작하지 않음 (`cmd/osty-native-lirproto` 는
+  여전히 옛날 path 만 본다 — A2 에서 wiring).
+- **개발자**: `selfhostcache.ResolveBinary` 가 호출 가능. `Install` 로
+  바이너리 promote 가능. 단위 테스트 13개로 인프라 검증.
+- **회귀 위험**: 0 — production path 는 변경되지 않음.
+
+## Appendix B. A2 wiring 미리보기
+
+```go
+// cmd/osty-native-lirproto/main.go
+func resolveOstySelfBin() (string, error) {
+    root, err := projectRootHint()
+    if err != nil {
+        return "", err
+    }
+    bin, _, err := selfhostcache.ResolveBinary(root)
+    if errors.Is(err, selfhostcache.ErrNotCached) {
+        return "", err
+    }
+    return bin, err
+}
+```
+
+`bin` path 의 stat / exec.LookPath 검사는 cache 패키지 내부에서 처리되므로
+호출부는 단순화된다.

--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -177,7 +177,7 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
 | P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
 | P15 | list literal + indexed read `xs[N]` → list_get_i64 runtime ABI | list_literal_index_first / _second real-MIR — **구현 완료** |
-| P16+ | list iterate / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
+| **P16+** | **stage0 확장 동결 — emergency-only fallback 으로 유지.** production 경로는 `docs/osty_self_artifact_design.md` 의 artifact cache 시스템으로 전환. P0~P15 의 인프라 (IsOstySelfMissing / 디스패처 wiring / real-MIR probe) 는 그대로 가치 보존. | — |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/toolchain/selfhostcache/cache.go
+++ b/internal/toolchain/selfhostcache/cache.go
@@ -1,0 +1,245 @@
+// Package selfhostcache resolves the `osty-self` binary used by the
+// LLVM backend's LIR Proto bridge. It replaces the implicit "look at
+// toolchain/.osty/out/.../osty-self" search the older bridge code did
+// with a content-addressed cache that survives across worktrees and
+// tracks toolchain source changes.
+//
+// Lookup order (first hit wins):
+//
+//  1. `OSTY_SELF_BIN` env override.
+//  2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
+//     in-tree build path. Preferred because it always reflects the
+//     current source state.
+//  3. `.osty/cache/self-host/<sha256>-<triple>/osty-self` — the
+//     content-addressed artifact cache. The key combines the
+//     SHA-256 of every `toolchain/*.osty` source byte with the host
+//     triple so a downloaded or copied binary is rejected when the
+//     local toolchain source has drifted.
+//
+// Future phases will plug a network fetcher into the same lookup
+// chain (after #3) so a fresh clone with no `osty-self` can pull a
+// pre-built artifact from a release host instead of needing an
+// in-process bootstrap.
+package selfhostcache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// CacheDirName is the relative path inside the project root used for
+// content-addressed osty-self artifacts.
+const CacheDirName = ".osty/cache/self-host"
+
+// SelfBinEnv mirrors `cmd/osty-native-lirproto/main.go: SelfBinEnv`.
+// Re-declared here so the cache resolver can honour the same env
+// variable without depending on the bridge command.
+const SelfBinEnv = "OSTY_SELF_BIN"
+
+// ErrNotCached signals that no usable osty-self could be located.
+// Callers convert this into a "fall back to stage0" or "decline"
+// signal upstream.
+var ErrNotCached = errors.New("selfhostcache: no usable osty-self binary found")
+
+// Key identifies a single osty-self build per (toolchain source
+// state, host triple). The SHA-256 spans every `toolchain/*.osty`
+// file (sorted by repo-relative path) so a stale cache entry is
+// rejected when source changes.
+type Key struct {
+	ToolchainSHA string
+	Triple       string
+}
+
+// String renders the canonical cache subdirectory name.
+func (k Key) String() string {
+	if k.ToolchainSHA == "" || k.Triple == "" {
+		return ""
+	}
+	return k.ToolchainSHA + "-" + k.Triple
+}
+
+// HostTriple returns the canonical "<GOOS>-<GOARCH>" stamp for the
+// running process. Cache entries built for other triples remain
+// inert here.
+func HostTriple() string {
+	return runtime.GOOS + "-" + runtime.GOARCH
+}
+
+// BinaryName returns the `osty-self` filename appropriate for the
+// host (`.exe` suffix on Windows).
+func BinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "osty-self.exe"
+	}
+	return "osty-self"
+}
+
+// CachePath returns the canonical absolute path the artifact cache
+// would store the binary at for `key`.
+func CachePath(projectRoot string, key Key) string {
+	return filepath.Join(projectRoot, CacheDirName, key.String(), BinaryName())
+}
+
+// inTreeBuildPaths returns the legacy in-tree build paths the older
+// `osty-native-lirproto` bridge searched. Lookup keeps these as the
+// preferred source so an active development build always wins over
+// any cached artifact.
+func inTreeBuildPaths(projectRoot string) []string {
+	return []string{
+		filepath.Join(projectRoot, "toolchain", ".osty", "out", "debug", "llvm", BinaryName()),
+		filepath.Join(projectRoot, "toolchain", ".osty", "out", "release", "llvm", BinaryName()),
+	}
+}
+
+// ComputeKey walks `projectRoot/toolchain` and produces a content-
+// addressed Key based on every `*.osty` source file under it
+// (sorted by relative path). Generated artifacts under
+// `toolchain/.osty/` are excluded so a fresh build does not mutate
+// the cache key.
+func ComputeKey(projectRoot string) (Key, error) {
+	toolchainDir := filepath.Join(projectRoot, "toolchain")
+	if info, err := os.Stat(toolchainDir); err != nil {
+		return Key{}, fmt.Errorf("selfhostcache: stat %s: %w", toolchainDir, err)
+	} else if !info.IsDir() {
+		return Key{}, fmt.Errorf("selfhostcache: %s is not a directory", toolchainDir)
+	}
+
+	paths := []string{}
+	err := filepath.WalkDir(toolchainDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			rel, relErr := filepath.Rel(toolchainDir, p)
+			if relErr != nil {
+				return relErr
+			}
+			// Skip generated build outputs to keep the key
+			// deterministic across rebuilds.
+			if rel != "." && (rel == ".osty" || strings.HasPrefix(rel, ".osty"+string(filepath.Separator))) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".osty") {
+			return nil
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	if err != nil {
+		return Key{}, err
+	}
+	if len(paths) == 0 {
+		return Key{}, fmt.Errorf("selfhostcache: no .osty source files under %s", toolchainDir)
+	}
+	sort.Strings(paths)
+
+	h := sha256.New()
+	for _, p := range paths {
+		rel, err := filepath.Rel(projectRoot, p)
+		if err != nil {
+			return Key{}, err
+		}
+		// Hash the path (in slash-form) before the contents so two
+		// files with identical bytes but different names hash apart.
+		fmt.Fprintf(h, "path:%s\n", filepath.ToSlash(rel))
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return Key{}, fmt.Errorf("selfhostcache: read %s: %w", p, err)
+		}
+		fmt.Fprintf(h, "size:%d\n", len(data))
+		h.Write(data)
+		h.Write([]byte{0})
+	}
+	return Key{
+		ToolchainSHA: hex.EncodeToString(h.Sum(nil)),
+		Triple:       HostTriple(),
+	}, nil
+}
+
+// ResolveBinary returns the first usable osty-self path according
+// to the lookup order documented at the package level. The returned
+// `Key` is non-zero when the cache layer (step 3) hits; the in-tree
+// build paths return a zero key because they are not content-
+// addressed.
+func ResolveBinary(projectRoot string) (string, Key, error) {
+	if env := strings.TrimSpace(os.Getenv(SelfBinEnv)); env != "" {
+		if info, err := os.Stat(env); err == nil && !info.IsDir() {
+			return env, Key{}, nil
+		}
+	}
+	for _, p := range inTreeBuildPaths(projectRoot) {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, Key{}, nil
+		}
+	}
+	key, err := ComputeKey(projectRoot)
+	if err != nil {
+		return "", Key{}, err
+	}
+	cached := CachePath(projectRoot, key)
+	if info, err := os.Stat(cached); err == nil && !info.IsDir() {
+		return cached, key, nil
+	}
+	return "", key, ErrNotCached
+}
+
+// Install copies `binPath` into the cache for `key`. It is
+// idempotent — repeated calls with the same content overwrite atomic-
+// renaming via a temp file. Callers typically obtain `key` from
+// `ComputeKey` immediately before / after running `osty build
+// toolchain/`, then promote the freshly built binary into the cache.
+func Install(projectRoot string, key Key, binPath string) error {
+	if key.String() == "" {
+		return errors.New("selfhostcache: install: zero key")
+	}
+	if _, err := os.Stat(binPath); err != nil {
+		return fmt.Errorf("selfhostcache: install: %w", err)
+	}
+	target := CachePath(projectRoot, key)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("selfhostcache: mkdir cache: %w", err)
+	}
+
+	src, err := os.Open(binPath)
+	if err != nil {
+		return fmt.Errorf("selfhostcache: open source: %w", err)
+	}
+	defer src.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(target), ".osty-self-*.tmp")
+	if err != nil {
+		return fmt.Errorf("selfhostcache: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Clean up tmp on failure paths. Successful path renames
+		// the file out from under us so Remove is a no-op.
+		os.Remove(tmpPath)
+	}()
+	if _, err := io.Copy(tmp, src); err != nil {
+		tmp.Close()
+		return fmt.Errorf("selfhostcache: copy: %w", err)
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		tmp.Close()
+		return fmt.Errorf("selfhostcache: chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("selfhostcache: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return fmt.Errorf("selfhostcache: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/toolchain/selfhostcache/cache_test.go
+++ b/internal/toolchain/selfhostcache/cache_test.go
@@ -1,0 +1,270 @@
+package selfhostcache
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scaffoldToolchain creates a minimal `toolchain/` tree under
+// `projectRoot` and returns the absolute toolchain dir path.
+func scaffoldToolchain(t *testing.T, projectRoot string, files map[string]string) string {
+	t.Helper()
+	tcDir := filepath.Join(projectRoot, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("mkdir toolchain: %v", err)
+	}
+	for name, body := range files {
+		full := filepath.Join(tcDir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+	return tcDir
+}
+
+func TestComputeKeyDeterministic(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{
+		"main.osty": "fn main() {}\n",
+		"lib.osty":  "fn helper() -> Int { 42 }\n",
+	})
+	a, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	b, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey 2nd: %v", err)
+	}
+	if a != b {
+		t.Fatalf("keys differ across runs: %v vs %v", a, b)
+	}
+	if len(a.ToolchainSHA) != 64 {
+		t.Fatalf("expected 64-hex SHA, got %q", a.ToolchainSHA)
+	}
+	if !strings.Contains(a.Triple, "-") {
+		t.Fatalf("triple has unexpected shape: %q", a.Triple)
+	}
+}
+
+func TestComputeKeyChangesOnSourceEdit(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	first, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey first: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("fn main() { /* changed */ }\n"), 0o644); err != nil {
+		t.Fatalf("rewrite main.osty: %v", err)
+	}
+	second, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey second: %v", err)
+	}
+	if first.ToolchainSHA == second.ToolchainSHA {
+		t.Fatalf("SHA did not change after source edit: %s", first.ToolchainSHA)
+	}
+}
+
+func TestComputeKeyChangesOnNewFile(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	first, _ := ComputeKey(root)
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "extra.osty"), []byte("fn extra() {}\n"), 0o644); err != nil {
+		t.Fatalf("write extra.osty: %v", err)
+	}
+	second, _ := ComputeKey(root)
+	if first.ToolchainSHA == second.ToolchainSHA {
+		t.Fatalf("SHA did not change after adding file")
+	}
+}
+
+func TestComputeKeyIgnoresGeneratedDir(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{
+		"main.osty":                            "fn main() {}\n",
+		filepath.Join(".osty", "out", "junk"): "ignored binary",
+	})
+	first, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey first: %v", err)
+	}
+	// Mutate something inside the ignored dir.
+	if err := os.WriteFile(filepath.Join(root, "toolchain", ".osty", "out", "junk"), []byte("changed"), 0o644); err != nil {
+		t.Fatalf("rewrite junk: %v", err)
+	}
+	second, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey second: %v", err)
+	}
+	if first.ToolchainSHA != second.ToolchainSHA {
+		t.Fatalf("SHA changed after mutation under ignored .osty dir: %s vs %s", first.ToolchainSHA, second.ToolchainSHA)
+	}
+}
+
+func TestComputeKeyEmptyToolchain(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := ComputeKey(root)
+	if err == nil {
+		t.Fatal("expected error for empty toolchain")
+	}
+}
+
+func TestResolveBinaryEnvOverride(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+
+	bin := filepath.Join(root, "external-osty-self")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho external\n"), 0o755); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+	t.Setenv(SelfBinEnv, bin)
+
+	got, key, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got = %q, want env override %q", got, bin)
+	}
+	if key.String() != "" {
+		t.Fatalf("expected zero key for env override, got %q", key.String())
+	}
+}
+
+func TestResolveBinaryInTreeBuild(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	debugBin := filepath.Join(root, "toolchain", ".osty", "out", "debug", "llvm", BinaryName())
+	if err := os.MkdirAll(filepath.Dir(debugBin), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(debugBin, []byte("debug bin"), 0o755); err != nil {
+		t.Fatalf("write debug bin: %v", err)
+	}
+	got, key, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != debugBin {
+		t.Fatalf("got = %q, want debug bin %q", got, debugBin)
+	}
+	if key.String() != "" {
+		t.Fatalf("in-tree builds should report zero key, got %q", key.String())
+	}
+}
+
+func TestResolveBinaryFallsThroughToCache(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	key, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	cachedBin := CachePath(root, key)
+	if err := os.MkdirAll(filepath.Dir(cachedBin), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(cachedBin, []byte("cached bin"), 0o755); err != nil {
+		t.Fatalf("write cached bin: %v", err)
+	}
+
+	got, gotKey, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != cachedBin {
+		t.Fatalf("got = %q, want cached %q", got, cachedBin)
+	}
+	if gotKey != key {
+		t.Fatalf("returned key mismatch: got %v, want %v", gotKey, key)
+	}
+}
+
+func TestResolveBinaryReturnsErrNotCached(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	_, _, err := ResolveBinary(root)
+	if !errors.Is(err, ErrNotCached) {
+		t.Fatalf("err = %v, want ErrNotCached", err)
+	}
+}
+
+func TestInstallRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	srcBin := filepath.Join(root, "built-osty-self")
+	if err := os.WriteFile(srcBin, []byte("real binary bytes"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	key, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	if err := Install(root, key, srcBin); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got, gotKey, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary post-install: %v", err)
+	}
+	if got != CachePath(root, key) {
+		t.Fatalf("expected resolved path to match CachePath, got %q", got)
+	}
+	if gotKey != key {
+		t.Fatalf("key mismatch after install: %v vs %v", gotKey, key)
+	}
+	body, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read installed: %v", err)
+	}
+	if string(body) != "real binary bytes" {
+		t.Fatalf("installed body = %q, want round-trip", body)
+	}
+}
+
+func TestInstallRejectsZeroKey(t *testing.T) {
+	root := t.TempDir()
+	if err := Install(root, Key{}, "anything"); err == nil {
+		t.Fatal("expected Install to reject zero key")
+	}
+}
+
+func TestInstallRejectsMissingSource(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	key, _ := ComputeKey(root)
+	missing := filepath.Join(root, "does-not-exist")
+	if err := Install(root, key, missing); err == nil {
+		t.Fatal("expected Install to reject missing source")
+	}
+}
+
+func TestKeyStringComponents(t *testing.T) {
+	k := Key{ToolchainSHA: "deadbeef", Triple: "linux-amd64"}
+	if got := k.String(); got != "deadbeef-linux-amd64" {
+		t.Fatalf("Key.String = %q, want %q", got, "deadbeef-linux-amd64")
+	}
+	if (Key{}).String() != "" {
+		t.Fatal("zero Key.String must be empty")
+	}
+}


### PR DESCRIPTION
## Summary

부트스트랩 전략을 **stage0 확장 → osty-self artifact 캐시** 로 전환. Stage0 P0~P15 의 인프라 (IsOstySelfMissing / 디스패처 wiring / real-MIR probe) 는 emergency-only fallback 으로 그대로 보존하되, 새 패턴 추가는 중단. Production 경로는 새 artifact cache 시스템으로 단계적 이전.

본 PR (A1) 은 그 시스템의 **foundation 패키지** + **단계별 로드맵 design doc**.

### 새 design doc: `docs/osty_self_artifact_design.md`

```
Lookup 우선순위:
  1. $OSTY_SELF_BIN env override
  2. toolchain/.osty/out/{debug,release}/llvm/osty-self  (in-tree dev build)
  3. .osty/cache/self-host/<sha>-<triple>/osty-self      (content-addressed cache)
  4. (future) network fetch from release host
  5. ErrNotCached → stage0 emergency fallback / hard fail
```

Key = `(toolchain SHA-256, host triple)`. `toolchain/*.osty` 의 모든 source bytes 의 해시. 생성 산출물 (`toolchain/.osty/`) 은 키에서 제외해서 빌드가 키를 무효화하지 않게.

### 단계별 로드맵

| Phase | 범위 |
|---|---|
| **A1** (이 PR) | `selfhostcache` 패키지 — Key/Compute/Resolve/Install. 디스크 lookup 만, 네트워크 0. |
| A2 | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. 로컬 빌드 → `Install` 자동. |
| A3 | `osty install-self` CLI + `just bootstrap`. |
| A4 | 네트워크 fetcher (HTTPS + SHA-256 검증). |
| A5 | CI 워크플로 — 6개 host triple 별 빌드 + release artifact 업로드. |
| A6 | Manifest signing. |

### 코드: `internal/toolchain/selfhostcache/`

- **`cache.go`** (~270 줄):
  - `Key { ToolchainSHA, Triple }`, `HostTriple()`, `BinaryName()`.
  - `ComputeKey(root)` — toolchain/*.osty walk + SHA-256. `.osty/` SkipDir.
  - `ResolveBinary(root)` — 4-단계 lookup. 캐시 hit 시 Key 반환.
  - `CachePath(root, key)` — `.osty/cache/self-host/<sha>-<triple>/osty-self`.
  - `Install(root, key, binPath)` — atomic rename 으로 캐시 적재.
  - `SelfBinEnv` constant, `ErrNotCached` sentinel.
- **`cache_test.go`** (13 tests):
  - ComputeKey 결정성 / source 변경 감지 / 새 파일 추가 / `.osty/` 무시 / 빈 toolchain 거부.
  - ResolveBinary env override / in-tree / cache fallthrough / 미존재.
  - Install round-trip / 빈 키 거부 / missing source 거부.
  - Key.String 포맷.

### Stage0 freeze

`docs/osty_self_bootstrap_design.md` P16+ 행을 **"확장 동결, emergency-only"** 로 갱신. P0~P15 코드는 그대로 유지 (production 경로 변경 0).

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/toolchain/selfhostcache/...` — 13/13 PASS
- [x] `go test ./internal/backend/...` — 0 fail (변경 없음)

## Notes

- 이 PR 자체는 **production 경로 변경 0**. `cmd/osty-native-lirproto` 는 여전히 옛날 path 만 사용. wiring 은 A2 에서.
- Stage0 인프라 보존: P0 IsOstySelfMissing 은 그대로, P4 디스패처 wiring 도 그대로. 새 시스템이 ErrNotCached 를 반환하면 기존 fallback chain 이 그대로 작동.
- 다음 (A2): `cmd/osty-native-lirproto/main.go::resolveOstySelfBin` 을 `selfhostcache.ResolveBinary` 로 교체 + 로컬 빌드 promote 자동화.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_