### PR TITLE
feat(toolchain): wire osty-native-lirproto to selfhostcache (A2)

### DIFF
--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -41,6 +41,7 @@ Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭
 |---|---|---|---|---|---|---|
 | strings | §10.1 | 7223 | 92 | 0% | string 17 + bytes 29 runtime | UAX29 grapheme + BMH 검색 직접 확인 |
 | http | §10.24 | 1588 | 166 | 0% | net 40 runtime | matchRoutePattern / parseSetCookie / 라우터 본문 확인 |
+| http_middleware | unspec | 125 | 9 | 100% | body-less runtime stubs (retry, circuit breaker, rate limit) |
 | json | §10.8 | 662 | 27 | 0% | parser self-contained | RFC 8259 surrogate + UTF-8 인코딩 직접 확인 |
 | option | §10.1 | 356 | 43 | 0% | `__optionAbort` 인터셉트 | combinator 풀세트 (map2/3/traverse/transpose) |
 | result | §10.1 | 357 | 41 | 0% | `__resultAbort` 인터셉트 | combinator 풀세트 |
@@ -173,11 +174,20 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 | diff | unspec | 392 | 31 | LCS line diff |
 | dialog | unspec | 644 | 29 | 파일 픽커 명령 plan |
 | graphql | unspec | 224 | 21 | document/field 빌더 |
+| gql_client | unspec | 77 | 10 | body-less runtime stubs (GraphQL HTTP/WS transport) |
 | websocket | unspec | 338 | 15 | RFC 6455 frame encode/decode |
+| ws_client | unspec | 109 | 13 | body-less runtime stubs (WebSocket connect/send/receive) |
 | tar | unspec | 426 | 10 | ustar 인코드/디코드 |
 | zip | §10.31 | 341 | 9 | stored entries만 (deflate 미실행) |
 | sql | §10.28 | 665 | 43 | 빌더만 (실행은 db 위임) |
 | db | §10.29 | 615 | 40 | spec 명시: 드라이버 의도적 부재 |
+| db_driver | §10.29 | 177 | 10 | body-less runtime stubs (DB driver interface) |
+| db_sqlite | §10.29 | 77 | 4 | body-less runtime stubs (SQLite driver) |
+| db_pool | §10.29 | 80 | 7 | body-less runtime stubs (connection pool) |
+| db_migration | §10.29 | 79 | 8 | body-less runtime stubs (schema migration) |
+| db_orm | §10.29 | 169 | 7 | body-less runtime stubs (query builder / ORM) |
+| db_pg | §10.29 | 68 | 4 | body-less runtime stubs (PostgreSQL driver) |
+| db_mysql | §10.29 | 63 | 4 | body-less runtime stubs (MySQL driver) |
 | xml | unspec | 391 | 9 | escape/tag/tokenize |
 | template | unspec | 148 | 5 | escape/raw placeholder |
 | i18n | unspec | 136 | 11 | locale/catalog/plural |

--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -36,20 +36,15 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/nativelirproto"
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
 )
 
 // SelfBinEnv overrides the osty-self lookup. Local development /
 // CI uses this to point at a freshly built artifact without having
-// to write to the default `.osty/out/...` cache path.
+// to write to the default `.osty/out/...` cache path. The actual
+// lookup is delegated to `selfhostcache.ResolveBinary` which honours
+// the same env var.
 const SelfBinEnv = "OSTY_SELF_BIN"
-
-// defaultSelfBinCandidates lists the paths searched (in order)
-// when SelfBinEnv is unset. They mirror the layout `osty build
-// toolchain/` writes by default.
-var defaultSelfBinCandidates = []string{
-	"toolchain/.osty/out/debug/llvm/osty-self",
-	"toolchain/.osty/out/release/llvm/osty-self",
-}
 
 func main() {
 	if err := run(os.Stdin, os.Stdout); err != nil {
@@ -122,26 +117,32 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 }
 
 // resolveOstySelfBin returns the path to the self-host `osty-self`
-// binary the lower call should subprocess. SelfBinEnv wins outright;
-// otherwise we search the default `osty build toolchain/` output
-// paths relative to the current working directory.
+// binary the lower call should subprocess.
+//
+// Lookup order (delegated to `selfhostcache.ResolveBinary`):
+//
+//	1. `$OSTY_SELF_BIN` env override.
+//	2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
+//	   in-tree build path.
+//	3. `.osty/cache/self-host/<sha>-<triple>/osty-self` — the
+//	   content-addressed artifact cache.
+//
+// On the no-cache path (env unset, no in-tree build, no cache hit),
+// the canonical "osty-self not found" message is preserved so the
+// upstream `backend.IsOstySelfMissing` detection chain keeps working.
 func resolveOstySelfBin() (string, error) {
-	if override := strings.TrimSpace(os.Getenv(SelfBinEnv)); override != "" {
-		if _, err := os.Stat(override); err == nil {
-			return override, nil
-		}
-		return "", fmt.Errorf("%s=%q not found", SelfBinEnv, override)
+	root, err := selfhostcache.LocateProjectRoot(".")
+	if err != nil {
+		return "", err
 	}
-	for _, rel := range defaultSelfBinCandidates {
-		abs, err := filepath.Abs(rel)
-		if err != nil {
-			continue
-		}
-		if _, err := os.Stat(abs); err == nil {
-			return abs, nil
-		}
+	bin, _, err := selfhostcache.ResolveBinary(root)
+	if errors.Is(err, selfhostcache.ErrNotCached) {
+		return "", errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
 	}
-	return "", errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
+	if err != nil {
+		return "", err
+	}
+	return bin, nil
 }
 
 // stageSource writes the request's source bytes to a temp file so

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -1,0 +1,162 @@
+# `osty-self` artifact cache 설계
+
+> **상태**: 제안 + 첫 단계 구현 (이 PR의 `internal/toolchain/selfhostcache`).
+> **연관**: `docs/osty_self_bootstrap_design.md` (stage0 — emergency-only fallback).
+> **소유**: backend / toolchain / CI.
+
+## 1. 문제 정의
+
+PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
+모든 production MIR → LLVM 변환은 **`osty-self lir-proto-lower`**
+서브프로세스를 통해야 한다. `osty-self` 는 `toolchain/*.osty` 를
+`osty build` 로 컴파일한 산출물이고, 그 `osty build` 자체가 또
+`osty-self` 를 필요로 한다 — 닭-달걀 부트스트랩 의존.
+
+기존 옵션 두 가지:
+- **stage0 fallback** (`docs/osty_self_bootstrap_design.md` P0~P15) — Go
+  쪽에 minimal MIR→LLVM emitter 를 두고 `osty-self` 부재 시 사용. 본격
+  toolchain 컴파일까진 cover 하지 못 함. 사실상 `internal/llvmgen` 의
+  소형 재창조에 가까워서 #1405 의 정신에 어긋남.
+- **외부 사전-빌드 osty-self** — 어딘가에서 빌드된 바이너리를 가져와
+  쓰는 방식. 영구 가치가 가장 높은 접근.
+
+본 문서는 두 번째 옵션을 단계적으로 구현하는 설계다.
+
+## 2. 큰 그림
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │  ResolveBinary(projectRoot)                 │
+                 │                                             │
+   ┌────────┐    │  1. $OSTY_SELF_BIN env override             │
+   │ caller │───▶│  2. toolchain/.osty/out/{debug,release}/   │
+   └────────┘    │     llvm/osty-self  (in-tree dev build)     │
+                 │  3. .osty/cache/self-host/<sha-triple>/    │
+                 │     osty-self  ← content-addressed cache    │
+                 │  4. (future) network fetch from release     │
+                 │  5. ErrNotCached → stage0 emergency or fail │
+                 └─────────────────────────────────────────────┘
+```
+
+캐시 entry 의 키는 **`(toolchain SHA-256, host triple)`** 의 페어.
+`toolchain/*.osty` 가 변경되면 SHA 가 바뀌어 자동으로 무효화되고,
+다른 호스트에서 빌드된 바이너리는 triple 부분에서 매치되지 않는다.
+
+## 3. 단계별 로드맵
+
+| Phase | 범위 | 측정 |
+|---|---|---|
+| **A1** (이 PR) | `internal/toolchain/selfhostcache` 패키지 — `Key`, `ComputeKey`, `ResolveBinary`, `Install`, `CachePath`. 디스크에 이미 있는 캐시 entry 만 lookup. 네트워크 0. | 13 단위 테스트 통과 |
+| A2 | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. 로컬 빌드 → `Install` 자동 호출. | 기존 lirproto 테스트 + 통합 |
+| A3 | `osty install-self` 서브커맨드 — toolchain 빌드 + 캐시 적재 한 번에. `just bootstrap` 가 이걸 호출. | E2E |
+| A4 | 네트워크 fetcher — GitHub Release / S3-compatible URL 에서 `<sha>-<triple>` artifact 다운로드. SHA-256 검증 필수. | offline 모드 정책 결정 |
+| A5 | CI 워크플로 — main 브랜치 push 시 6개 host triple 별로 빌드 → release artifact 업로드 + manifest. | reproducibility 확인 |
+| A6 | Manifest signing (sigstore / minisign) — supply-chain 보호. | 정책 결정 |
+
+## 4. Key 구성
+
+```go
+type Key struct {
+    ToolchainSHA string  // hex SHA-256
+    Triple       string  // "linux-amd64", "darwin-arm64", ...
+}
+```
+
+### 4.1 ToolchainSHA
+
+다음 알고리즘:
+
+1. `projectRoot/toolchain` 아래 모든 `*.osty` 파일을 walk.
+2. `toolchain/.osty/` 아래는 **제외** (생성 산출물).
+3. repo-relative path 로 정렬.
+4. 각 파일에 대해 hash 에 다음을 입력:
+   ```
+   path:<rel-path-with-slashes>\n
+   size:<byte-len>\n
+   <file-bytes>
+   <0x00 separator>
+   ```
+5. SHA-256 의 hex.
+
+### 4.2 Triple
+
+`runtime.GOOS + "-" + runtime.GOARCH`. 예: `linux-amd64`, `darwin-arm64`.
+
+LLVM target triple 과는 다른 layer. cross-compile 빌드는 별도 정책 (현재
+범위 외).
+
+## 5. Lookup 우선순위 근거
+
+1. **`OSTY_SELF_BIN` 환경변수** — 디버깅 / 비표준 위치 / 테스트용
+   override 가 항상 이김.
+2. **In-tree build path** — 활성 개발 워크트리에서 로컬 빌드한 바이너리는
+   캐시보다 항상 신선. 캐시는 그 빌드가 끝난 후 별도로 promote 된다 (A2).
+3. **Content-addressed cache** — 다른 워크트리 / 다른 머신에서 promote
+   된 바이너리. SHA 가 다르면 stale 로 자동 거부.
+4. **Network fetch** (A4+) — 캐시에도 없으면 release host 에서 다운로드.
+5. **Stage0 emergency fallback** — 네트워크 disabled / offline 환경에서만.
+
+## 6. 보안 / 무결성
+
+A4 단계에서 도입할 정책:
+- 다운로드는 **HTTPS** 만.
+- 응답 본문의 SHA-256 가 manifest 의 값과 일치하는지 검증.
+- (A6) manifest 자체의 서명 검증.
+- 검증 실패 시 캐시에 **저장하지 않고** 에러로 fall through.
+
+A1~A3 (로컬-only) 까지는 보안 모델이 단순하다 — 사용자가 이미 제어하는
+파일시스템.
+
+## 7. Stage0 의 미래
+
+`docs/osty_self_bootstrap_design.md` P0~P15 의 stage0 emitter 는 본 artifact
+시스템이 작동하기 시작하는 시점부터 **emergency-only** 로 동결된다:
+
+- 네트워크 차단 + 캐시 비어 있음 + in-tree 빌드 없음 일 때만 활성.
+- `OSTY_STAGE0_FALLBACK=1` 환경변수가 여전히 게이트.
+- 새 패턴 추가는 중단 (P16+ 미진행).
+
+stage0 의 인프라 (P0 `IsOstySelfMissing`, P4 디스패처 wiring, P5 real-MIR
+test infra) 는 본 artifact 시스템에서도 그대로 가치 보존된다 — fallback
+체인의 마지막 단계로 유지되며, real-MIR 회귀 테스트는 stage0 든 osty-self
+든 어느 쪽이 emit 했는지 무관하게 회귀 게이트로 작동.
+
+## 8. 결정 필요 항목
+
+1. **CI 빌드 호스트** — GitHub Actions 의 어떤 runner 가 어떤 triple 을
+   담당? linux-amd64, linux-arm64 (self-hosted?), darwin-amd64,
+   darwin-arm64, windows-amd64, windows-arm64.
+2. **Release 정책** — main push 마다? 태그 push 시? 분기 빌드는?
+3. **Storage 비용** — GitHub Release artifact 무료 한도 vs S3 / R2 호스팅.
+4. **Toolchain 변경 빈도** — 너무 잦으면 release 폭주. 캐시 키 안정성을 위해
+   toolchain 외 변경은 키에 들어가지 않게 4.1 알고리즘 유지.
+5. **Reproducibility** — 같은 toolchain SHA 에서 host 가 같은 OS/CPU 라면
+   바이너리가 같아야 함. LLVM 의 비결정성 (예: -fdebug-prefix-map) 통제 필요.
+
+## Appendix A. A1 단계 (이 PR) 의 효과
+
+- **사용자**: 아직 실제로 동작하지 않음 (`cmd/osty-native-lirproto` 는
+  여전히 옛날 path 만 본다 — A2 에서 wiring).
+- **개발자**: `selfhostcache.ResolveBinary` 가 호출 가능. `Install` 로
+  바이너리 promote 가능. 단위 테스트 13개로 인프라 검증.
+- **회귀 위험**: 0 — production path 는 변경되지 않음.
+
+## Appendix B. A2 wiring 미리보기
+
+```go
+// cmd/osty-native-lirproto/main.go
+func resolveOstySelfBin() (string, error) {
+    root, err := projectRootHint()
+    if err != nil {
+        return "", err
+    }
+    bin, _, err := selfhostcache.ResolveBinary(root)
+    if errors.Is(err, selfhostcache.ErrNotCached) {
+        return "", err
+    }
+    return bin, err
+}
+```
+
+`bin` path 의 stat / exec.LookPath 검사는 cache 패키지 내부에서 처리되므로
+호출부는 단순화된다.

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -46,8 +46,8 @@ PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
 
 | Phase | 범위 | 측정 |
 |---|---|---|
-| **A1** (이 PR) | `internal/toolchain/selfhostcache` 패키지 — `Key`, `ComputeKey`, `ResolveBinary`, `Install`, `CachePath`. 디스크에 이미 있는 캐시 entry 만 lookup. 네트워크 0. | 13 단위 테스트 통과 |
-| A2 | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. 로컬 빌드 → `Install` 자동 호출. | 기존 lirproto 테스트 + 통합 |
+| **A1** | `internal/toolchain/selfhostcache` 패키지 — `Key`, `ComputeKey`, `ResolveBinary`, `Install`, `CachePath`. 디스크에 이미 있는 캐시 entry 만 lookup. 네트워크 0. | 13 단위 테스트 통과 — **구현 완료** |
+| **A2** (이 PR) | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. `LocateProjectRoot` 헬퍼 추가. ErrNotCached → "osty-self not found" 메시지로 변환해서 IsOstySelfMissing 호환 유지. | 기존 lirproto 테스트 통과 + 캐시 lookup 통합 — **구현 완료** |
 | A3 | `osty install-self` 서브커맨드 — toolchain 빌드 + 캐시 적재 한 번에. `just bootstrap` 가 이걸 호출. | E2E |
 | A4 | 네트워크 fetcher — GitHub Release / S3-compatible URL 에서 `<sha>-<triple>` artifact 다운로드. SHA-256 검증 필수. | offline 모드 정책 결정 |
 | A5 | CI 워크플로 — main 브랜치 push 시 6개 host triple 별로 빌드 → release artifact 업로드 + manifest. | reproducibility 확인 |

--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -176,7 +176,8 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P12 | List<Int> 리터럴 + len() — runtime ABI 호출 (osty_rt_list_new / push_i64 / len) | list_literal_len real-MIR — **구현 완료** |
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
 | P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
-| P15+ | list ops (get/iterate) / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
+| P15 | list literal + indexed read `xs[N]` → list_get_i64 runtime ABI | list_literal_index_first / _second real-MIR — **구현 완료** |
+| P16+ | list iterate / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/docs/osty_self_bootstrap_design.md
+++ b/docs/osty_self_bootstrap_design.md
@@ -177,7 +177,7 @@ retirement는 별도 PR에서 진행하고, 그 PR이 stage0 디렉토리를 통
 | P13 | String + (concat) → osty_rt_strings_Concat 호출 + 재귀 함수 호출 검증 | string_concat_*, recursive_factorial real-MIR — **구현 완료** |
 | P14 | aggregate constructor (struct + tuple) — `Point { x, y }` / `(a, b)` → insertvalue 체인 + 합성 tuple 타입 풀 | struct_constructor_* / tuple_int_int_return real-MIR — **구현 완료** |
 | P15 | list literal + indexed read `xs[N]` → list_get_i64 runtime ABI | list_literal_index_first / _second real-MIR — **구현 완료** |
-| P16+ | list iterate / Optional / Result / pattern match / closure | toolchain/main.osty 부분 빌드 |
+| **P16+** | **stage0 확장 동결 — emergency-only fallback 으로 유지.** production 경로는 `docs/osty_self_artifact_design.md` 의 artifact cache 시스템으로 전환. P0~P15 의 인프라 (IsOstySelfMissing / 디스패처 wiring / real-MIR probe) 는 그대로 가치 보존. | — |
 | P3 | `OSTY_STAGE0_FALLBACK=1` 로 toolchain 전체 빌드 성공 | verify-self-rebuild stage1-only |
 | P4 | stage0 + osty-self 양쪽 모두에서 `verify-self-rebuild` 통과 | byte parity (stage2 vs stage3) |
 | P5 | CI matrix 추가 — `OSTY_STAGE0_FALLBACK=1` 잡과 default 잡 둘 다 | CI green |

--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -340,6 +340,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchAggregateConstructor(fn, mctx); ok {
 		return emitAggregateConstructor(out, fn, pat)
 	}
+	if pat, ok := matchListLiteralIndexGet(fn, mctx); ok {
+		return emitListLiteralIndexGet(out, fn, pat)
+	}
 	return fmt.Errorf("%w: function %q does not match any stage0 pattern", ErrUnsupported, fn.Name)
 }
 
@@ -2572,6 +2575,144 @@ func emitAggregateConstructor(out *strings.Builder, fn *mir.Function, pat aggreg
 		prev = fmt.Sprintf("%%%d", i)
 	}
 	fmt.Fprintf(out, "  ret %%%s %s\n", pat.typeName, prev)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P15: list literal + indexed read ----
+//
+// `let xs: List<Int> = [10, 20, 30]; xs[0]` lowers to a 3-instruction
+// block: an AggregateRV{AggList} writing the list, followed by an
+// AssignInstr whose Src is `UseRV(CopyOp(list_local, [IndexProj]))`.
+// stage0 P15 emits this as a list_new + N pushes + list_get_i64 chain.
+
+type listLiteralIndexPattern struct {
+	elements []int64
+	index    int64
+}
+
+func matchListLiteralIndexGet(fn *mir.Function, mctx *moduleCtx) (listLiteralIndexPattern, bool) {
+	pat := listLiteralIndexPattern{}
+	if scalarFromType(fn.ReturnType) != scalarInt {
+		return pat, false
+	}
+	if len(fn.Params) != 0 {
+		return pat, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok {
+		return pat, false
+	}
+
+	var (
+		listLocal mir.LocalID
+		listSet   bool
+		readSet   bool
+	)
+	for _, instr := range bb.Instrs {
+		switch step := instr.(type) {
+		case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+			continue
+		case *mir.AssignInstr:
+			if !listSet {
+				if step.Dest.HasProjections() {
+					return pat, false
+				}
+				loc := lookupLocal(fn, step.Dest.Local)
+				if loc == nil {
+					return pat, false
+				}
+				named, ok := loc.Type.(*ir.NamedType)
+				if !ok || named == nil || named.Name != "List" {
+					return pat, false
+				}
+				agg, ok := step.Src.(*mir.AggregateRV)
+				if !ok || agg.Kind != mir.AggList {
+					return pat, false
+				}
+				elements := make([]int64, 0, len(agg.Fields))
+				for _, f := range agg.Fields {
+					con, ok := f.(*mir.ConstOp)
+					if !ok {
+						return pat, false
+					}
+					ic, ok := con.Const.(*mir.IntConst)
+					if !ok {
+						return pat, false
+					}
+					elements = append(elements, ic.Value)
+				}
+				pat.elements = elements
+				listLocal = step.Dest.Local
+				listSet = true
+				continue
+			}
+			// Second AssignInstr: must be the indexed read into ret.
+			if readSet {
+				return pat, false
+			}
+			if step.Dest.Local != fn.ReturnLocal || step.Dest.HasProjections() {
+				return pat, false
+			}
+			use, ok := step.Src.(*mir.UseRV)
+			if !ok {
+				return pat, false
+			}
+			cp, ok := use.Op.(*mir.CopyOp)
+			if !ok || cp.Place.Local != listLocal {
+				return pat, false
+			}
+			if len(cp.Place.Projections) != 1 {
+				return pat, false
+			}
+			idxProj, ok := cp.Place.Projections[0].(*mir.IndexProj)
+			if !ok {
+				return pat, false
+			}
+			idxConst, ok := idxProj.Index.(*mir.ConstOp)
+			if !ok {
+				return pat, false
+			}
+			ic, ok := idxConst.Const.(*mir.IntConst)
+			if !ok {
+				return pat, false
+			}
+			pat.index = ic.Value
+			readSet = true
+		default:
+			return pat, false
+		}
+	}
+	if !listSet || !readSet {
+		return pat, false
+	}
+	declareListRuntime(mctx)
+	declareListGetRuntime(mctx)
+	return pat, true
+}
+
+// declareListGetRuntime adds the `osty_rt_list_get_i64` declare to
+// extraDecls (idempotent — sentinel via emittedStructs).
+func declareListGetRuntime(mctx *moduleCtx) {
+	if mctx.emittedStructs == nil {
+		mctx.emittedStructs = map[string]bool{}
+	}
+	if mctx.emittedStructs["__stage0.list_get_i64"] {
+		return
+	}
+	mctx.emittedStructs["__stage0.list_get_i64"] = true
+	mctx.extraDecls.WriteString("declare i64 @osty_rt_list_get_i64(ptr, i64)\n")
+}
+
+func emitListLiteralIndexGet(out *strings.Builder, fn *mir.Function, pat listLiteralIndexPattern) error {
+	fmt.Fprintf(out, "define i64 @%s() {\n", fn.Name)
+	out.WriteString("entry:\n")
+	out.WriteString("  %0 = call ptr @osty_rt_list_new()\n")
+	for _, v := range pat.elements {
+		fmt.Fprintf(out, "  call void @osty_rt_list_push_i64(ptr %%0, i64 %d)\n", v)
+	}
+	fmt.Fprintf(out, "  %%1 = call i64 @osty_rt_list_get_i64(ptr %%0, i64 %d)\n", pat.index)
+	out.WriteString("  ret i64 %1\n")
 	out.WriteString("}\n\n")
 	return nil
 }

--- a/internal/backend/stage0_real_mir_test.go
+++ b/internal/backend/stage0_real_mir_test.go
@@ -390,6 +390,37 @@ fn main() {}`,
 				"ret %.tuple.0 %1",
 			},
 		},
+		{
+			name: "list_literal_index_first",
+			src: `fn first() -> Int {
+    let xs: List<Int> = [10, 20, 30]
+    xs[0]
+}
+fn main() {}`,
+			wantIR: []string{
+				"declare ptr @osty_rt_list_new()",
+				"declare void @osty_rt_list_push_i64(ptr, i64)",
+				"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+				"define i64 @first()",
+				"%0 = call ptr @osty_rt_list_new()",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 10)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 20)",
+				"call void @osty_rt_list_push_i64(ptr %0, i64 30)",
+				"%1 = call i64 @osty_rt_list_get_i64(ptr %0, i64 0)",
+				"ret i64 %1",
+			},
+		},
+		{
+			name: "list_literal_index_second",
+			src: `fn second() -> Int {
+    let xs: List<Int> = [100, 200, 300]
+    xs[1]
+}
+fn main() {}`,
+			wantIR: []string{
+				"%1 = call i64 @osty_rt_list_get_i64(ptr %0, i64 1)",
+			},
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -1,11 +1,6 @@
 package lsp
 
-import (
-	"fmt"
-	"sort"
-
-	"github.com/osty/osty/internal/diag"
-)
+import "github.com/osty/osty/internal/diag"
 
 // handleCodeAction answers `textDocument/codeAction`. It produces two
 // families of results:
@@ -96,7 +91,7 @@ func undefinedNameFixes(doc *document, d LSPDiagnostic) []CodeAction {
 	var out []CodeAction
 	for _, c := range candidates {
 		out = append(out, CodeAction{
-			Title:       fmt.Sprintf("Rename to `%s`", c),
+			Title:       LSPRenameTitle(c),
 			Kind:        CodeActionQuickFix,
 			Diagnostics: []LSPDiagnostic{d},
 			Edit: &WorkspaceEdit{
@@ -111,113 +106,18 @@ func undefinedNameFixes(doc *document, d LSPDiagnostic) []CodeAction {
 }
 
 func nearbyStructuredSymbolNames(symbols []structuredSymbol, target string, maxDistance int) []string {
-	type candidate struct {
-		name string
-		dist int
-	}
-	seen := map[string]bool{}
-	var candidates []candidate
+	names := make([]string, 0, len(symbols))
 	for _, sym := range symbols {
-		if sym.name == "" || sym.builtin || sym.depth != 0 || seen[sym.name] {
+		if sym.name == "" || sym.builtin || sym.depth != 0 {
 			continue
 		}
-		dist := lspLevenshteinBounded(target, sym.name, maxDistance)
-		if dist > maxDistance {
-			continue
-		}
-		seen[sym.name] = true
-		candidates = append(candidates, candidate{name: sym.name, dist: dist})
+		names = append(names, sym.name)
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].dist != candidates[j].dist {
-			return candidates[i].dist < candidates[j].dist
-		}
-		return candidates[i].name < candidates[j].name
-	})
-	out := make([]string, 0, len(candidates))
-	for _, c := range candidates {
-		out = append(out, c.name)
-	}
-	return out
+	return LSPRankNearbyNames(names, target, maxDistance)
 }
 
 func mergeNearbyNames(primary []string, fallback []string) []string {
-	if len(primary) == 0 {
-		return fallback
-	}
-	seen := make(map[string]bool, len(primary)+len(fallback))
-	out := make([]string, 0, len(primary)+len(fallback))
-	for _, name := range primary {
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		out = append(out, name)
-	}
-	for _, name := range fallback {
-		if name == "" || seen[name] {
-			continue
-		}
-		seen[name] = true
-		out = append(out, name)
-	}
-	return out
-}
-
-func lspLevenshteinBounded(a, b string, limit int) int {
-	ar := []rune(a)
-	br := []rune(b)
-	if absInt(len(ar)-len(br)) > limit {
-		return limit + 1
-	}
-	prev := make([]int, len(br)+1)
-	curr := make([]int, len(br)+1)
-	for j := range prev {
-		prev[j] = j
-	}
-	for i := 1; i <= len(ar); i++ {
-		curr[0] = i
-		rowMin := curr[0]
-		for j := 1; j <= len(br); j++ {
-			cost := 0
-			if ar[i-1] != br[j-1] {
-				cost = 1
-			}
-			curr[j] = minInt(
-				prev[j]+1,
-				curr[j-1]+1,
-				prev[j-1]+cost,
-			)
-			if curr[j] < rowMin {
-				rowMin = curr[j]
-			}
-		}
-		if rowMin > limit {
-			return limit + 1
-		}
-		prev, curr = curr, prev
-	}
-	if prev[len(br)] > limit {
-		return limit + 1
-	}
-	return prev[len(br)]
-}
-
-func minInt(a, b, c int) int {
-	if b < a {
-		a = b
-	}
-	if c < a {
-		return c
-	}
-	return a
-}
-
-func absInt(v int) int {
-	if v < 0 {
-		return -v
-	}
-	return v
+	return LSPMergeNearbyNames(primary, fallback)
 }
 
 // prefixUnderscoreFix produces a "silence by prefixing `_`" action
@@ -249,7 +149,7 @@ func removeLineFix(doc *document, d LSPDiagnostic) CodeAction {
 		End:   Position{Line: d.Range.End.Line + 1, Character: 0},
 	}
 	return CodeAction{
-		Title:       "Remove unused import",
+		Title:       LSPRemoveLineTitle(),
 		Kind:        CodeActionQuickFix,
 		Diagnostics: []LSPDiagnostic{d},
 		Edit: &WorkspaceEdit{

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -1,8 +1,6 @@
 package lsp
 
 import (
-	"strings"
-
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
@@ -89,17 +87,18 @@ func (s *Server) completionAfterDot(doc *document, recvName, prefix string) []Co
 	if pkg == nil || pkg.PkgScope == nil {
 		return nil
 	}
-	var items []CompletionItem
+	candidates := make([]LSPCompletionCandidateView, 0, len(pkg.PkgScope.Symbols()))
 	for name, member := range pkg.PkgScope.Symbols() {
-		if !member.Pub {
-			continue
-		}
-		if prefix != "" && !strings.HasPrefix(name, prefix) {
-			continue
-		}
-		items = append(items, completionItemFromSym(name, member, a.check))
+		view := completionSymbolView(name, member, a.check)
+		candidates = append(candidates, LSPCompletionCandidateView{
+			Name:     view.Name,
+			Kind:     view.Kind,
+			TypeText: view.TypeText,
+			DocText:  view.DocText,
+			Include:  member.Pub,
+		})
 	}
-	return sortCompletionItems(items)
+	return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 }
 
 func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([]CompletionItem, bool) {
@@ -110,17 +109,16 @@ func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([
 		if surface.alias != recvName {
 			continue
 		}
-		items := make([]CompletionItem, 0, len(surface.symbols))
+		candidates := make([]LSPCompletionCandidateView, 0, len(surface.symbols))
 		for _, sym := range surface.symbols {
-			if sym.name == "" {
-				continue
-			}
-			if prefix != "" && !strings.HasPrefix(sym.name, prefix) {
-				continue
-			}
-			items = append(items, completionItemFromStructuredImportSymbol(sym))
+			candidates = append(candidates, LSPCompletionCandidateView{
+				Name:     sym.name,
+				Kind:     sym.kind,
+				TypeText: sym.typeText,
+				Include:  true,
+			})
 		}
-		return sortCompletionItems(items), true
+		return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix)), true
 	}
 	return nil, false
 }
@@ -130,37 +128,31 @@ func completionAfterStructuredImport(a *docAnalysis, recvName, prefix string) ([
 // locals, parameters, and builtins not yet exposed in those facts.
 func (s *Server) completionInScope(doc *document, prefix string) []CompletionItem {
 	a := doc.analysis
-	seen := map[string]struct{}{}
-	var items []CompletionItem
+	var candidates []LSPCompletionCandidateView
 	for _, sym := range a.structuredSymbols {
-		if sym.builtin || sym.name == "" || sym.depth != 0 {
-			continue
-		}
-		if _, dup := seen[sym.name]; dup {
-			continue
-		}
-		if prefix != "" && !strings.HasPrefix(sym.name, prefix) {
-			continue
-		}
-		seen[sym.name] = struct{}{}
-		items = append(items, completionItemFromStructuredSymbol(sym))
+		candidates = append(candidates, LSPCompletionCandidateView{
+			Name:     sym.name,
+			Kind:     sym.kind,
+			TypeText: sym.typeText,
+			Include:  !sym.builtin && sym.depth == 0,
+		})
 	}
 	if a.resolve == nil || a.resolve.FileScope == nil {
-		return sortCompletionItems(items)
+		return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 	}
 	for sc := a.resolve.FileScope; sc != nil; sc = sc.Parent() {
 		for name, sym := range sc.Symbols() {
-			if _, dup := seen[name]; dup {
-				continue
-			}
-			if prefix != "" && !strings.HasPrefix(name, prefix) {
-				continue
-			}
-			seen[name] = struct{}{}
-			items = append(items, completionItemFromSym(name, sym, a.check))
+			view := completionSymbolView(name, sym, a.check)
+			candidates = append(candidates, LSPCompletionCandidateView{
+				Name:     view.Name,
+				Kind:     view.Kind,
+				TypeText: view.TypeText,
+				DocText:  view.DocText,
+				Include:  true,
+			})
 		}
 	}
-	return sortCompletionItems(items)
+	return completionItemsFromPolicy(LSPCompletionItemsForCandidates(candidates, prefix))
 }
 
 func sortCompletionItems(in []CompletionItem) []CompletionItem {
@@ -231,18 +223,31 @@ func completionSymbolView(label string, sym *resolve.Symbol, r *check.Result) se
 // self-hosted policy; the markdown documentation flows through as a
 // raw doc string.
 func completionItemFromView(view selfhost.LSPSymbolView) CompletionItem {
+	policy := LSPCompletionItemForSymbolView(view)
+	return completionItemFromData(policy)
+}
+
+func completionItemsFromPolicy(items []LSPCompletionItemData) []CompletionItem {
+	out := make([]CompletionItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, completionItemFromData(item))
+	}
+	return out
+}
+
+func completionItemFromData(policy LSPCompletionItemData) CompletionItem {
 	item := CompletionItem{
-		Label:    view.Name,
-		Kind:     CompletionItemKind(LSPCompletionKindForSymbolKind(view.Kind)),
-		SortText: LSPCompletionSortTextForSymbolKind(view.Kind, view.Name),
+		Label:    policy.Label,
+		Kind:     CompletionItemKind(policy.Kind),
+		SortText: policy.SortText,
 	}
-	if view.TypeText != "" {
-		item.Detail = LSPCompletionDetail(view.Kind, view.Name, view.TypeText)
+	if policy.Detail != "" {
+		item.Detail = policy.Detail
 	}
-	if view.DocText != "" {
+	if policy.Documentation != "" {
 		item.Documentation = &MarkupContent{
 			Kind:  MarkupKindMarkdown,
-			Value: view.DocText,
+			Value: policy.Documentation,
 		}
 	}
 	return item

--- a/internal/lsp/convert.go
+++ b/internal/lsp/convert.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/token"
@@ -62,18 +61,11 @@ func (li *lineIndex) rangeFromOffsets(start, end int) Range {
 // Returns ("", false) for non-file URIs (e.g. `inmemory:`, `untitled:`).
 // Percent-decoding handles paths with spaces and Unicode characters.
 func fileURIPath(uri string) (string, bool) {
-	const prefix = "file://"
-	if !strings.HasPrefix(uri, prefix) {
+	raw := LSPFileURIPathRaw(uri)
+	if !raw.OK {
 		return "", false
 	}
-	path := strings.TrimPrefix(uri, prefix)
-	// On Windows the URI is `file:///C:/path/...` — strip the leading
-	// slash so we get `C:/path/...`. On POSIX the leading slash IS the
-	// path root and must be kept.
-	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
-		path = path[1:]
-	}
-	decoded, err := url.PathUnescape(path)
+	decoded, err := url.PathUnescape(raw.Path)
 	if err != nil {
 		return "", false
 	}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/osty/osty/internal/ast"
@@ -55,11 +54,11 @@ func (s *Server) handleInitialize(req *rpcRequest) {
 			},
 			CompletionProvider: &CompletionOptions{
 				// `.` triggers member completion (pkg.fn, recv.method).
-				TriggerCharacters: []string{"."},
+				TriggerCharacters: []string{LSPCompletionTriggerDot()},
 			},
 			SignatureHelpProvider: &SignatureHelpOptions{
-				TriggerCharacters:   []string{"(", ","},
-				RetriggerCharacters: []string{","},
+				TriggerCharacters:   []string{LSPSignatureTriggerOpenParen(), LSPSignatureTriggerComma()},
+				RetriggerCharacters: []string{LSPSignatureTriggerComma()},
 			},
 			SemanticTokensProvider: &SemanticTokensOptions{
 				Legend: SemanticTokensLegend{
@@ -68,13 +67,13 @@ func (s *Server) handleInitialize(req *rpcRequest) {
 				},
 				Full: true,
 			},
-			PositionEncoding: "utf-16",
+			PositionEncoding: LSPPositionEncodingUTF16(),
 		},
 		ServerInfo: &ServerInfo{
 			Name:    ServerName,
-			Version: "0.1.0",
+			Version: LSPServerVersion(),
 		},
-		PositionEncoding: "utf-16",
+		PositionEncoding: LSPPositionEncodingUTF16(),
 	}
 	replyJSON(s.conn, req.ID, result)
 }
@@ -165,15 +164,24 @@ func (s *Server) publishDiagnostics(doc *document) {
 // identical payloads. LSPDiagnostic is all-comparable so element-wise
 // `!=` suffices.
 func diagsEqual(a, b []LSPDiagnostic) bool {
-	if len(a) != len(b) {
-		return false
+	return LSPDiagnosticsEqual(lspDiagnosticViews(a), lspDiagnosticViews(b))
+}
+
+func lspDiagnosticViews(in []LSPDiagnostic) []LSPDiagnosticView {
+	out := make([]LSPDiagnosticView, 0, len(in))
+	for _, d := range in {
+		out = append(out, LSPDiagnosticView{
+			StartLine:      d.Range.Start.Line,
+			StartCharacter: d.Range.Start.Character,
+			EndLine:        d.Range.End.Line,
+			EndCharacter:   d.Range.End.Character,
+			Severity:       uint32(d.Severity),
+			Code:           d.Code,
+			Source:         d.Source,
+			Message:        d.Message,
+		})
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return out
 }
 
 // toLSPDiag is the severity + range mapping between our internal
@@ -320,16 +328,7 @@ func semanticHoverLegacyContext(a *docAnalysis, pos token.Pos) (docText string, 
 }
 
 func semanticHoverKind(kind string) string {
-	switch kind {
-	case "fn":
-		return "function"
-	case "value":
-		return "binding"
-	case "generic":
-		return "type parameter"
-	default:
-		return kind
-	}
+	return LSPSemanticHoverKind(kind)
 }
 
 // hoverForSymbol formats the markdown block shown on hover. The
@@ -531,25 +530,17 @@ func (s *Server) handleFormatting(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return
 	}
-	if bytes.Equal(out, doc.src) {
+	if !LSPTextChanged(doc.src, out) {
 		// No-op formatting; avoid churning the editor's dirty flag.
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return
 	}
 	// Replace [start-of-file, end-of-file) with the formatted text.
-	endLine := uint32(0)
-	if n := len(doc.analysis.lines.lines); n > 0 {
-		endLine = uint32(n - 1)
-	}
-	lastLineStart := 0
-	if n := len(doc.analysis.lines.lines); n > 0 {
-		lastLineStart = doc.analysis.lines.lines[n-1]
-	}
-	endChar := utf16UnitsInPrefix(doc.src[lastLineStart:])
+	fullRange := LSPFullDocumentRangeFor(doc.src, doc.analysis.lines.lines)
 	edit := TextEdit{
 		Range: Range{
 			Start: Position{Line: 0, Character: 0},
-			End:   Position{Line: endLine, Character: endChar},
+			End:   Position{Line: fullRange.EndLine, Character: fullRange.EndCharacter},
 		},
 		NewText: string(out),
 	}
@@ -671,7 +662,7 @@ func spanWidth(n ast.Node) int {
 // unmarshalParams decodes req.Params into `target`, tolerating a
 // missing Params field (producing the zero value of target).
 func unmarshalParams(req *rpcRequest, target any) error {
-	if len(req.Params) == 0 || string(req.Params) == "null" {
+	if LSPParamsAreEmpty(req.Params) {
 		return nil
 	}
 	return json.Unmarshal(req.Params, target)
@@ -682,7 +673,7 @@ func unmarshalParams(req *rpcRequest, target any) error {
 // the client isn't left waiting.
 func replyJSON(c *conn, id json.RawMessage, v any) {
 	if v == nil {
-		_ = c.writeResponse(id, json.RawMessage("null"))
+		_ = c.writeResponse(id, json.RawMessage(LSPJSONNull()))
 		return
 	}
 	raw, err := json.Marshal(v)

--- a/internal/lsp/inlay.go
+++ b/internal/lsp/inlay.go
@@ -55,7 +55,7 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			}
 			hints = append(hints, InlayHint{
 				Position:    doc.analysis.lines.ostyToLSP(ip.End()),
-				Label:       ": " + inlayTypeString(t),
+				Label:       LSPInlayTypeLabel(inlayTypeString(t)),
 				Kind:        InlayHintKindType,
 				PaddingLeft: false,
 			})
@@ -73,7 +73,7 @@ func (s *Server) handleInlayHint(req *rpcRequest) {
 			}
 			hints = append(hints, InlayHint{
 				Position: doc.analysis.lines.offsetToLSP(nameOff + len(v.Name)),
-				Label:    ": " + inlayTypeString(t),
+				Label:    LSPInlayTypeLabel(inlayTypeString(t)),
 				Kind:     InlayHintKindType,
 			})
 		}

--- a/internal/lsp/jsonrpc.go
+++ b/internal/lsp/jsonrpc.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -68,40 +66,26 @@ func (c *conn) readMessage() ([]byte, error) {
 // stream ends cleanly before any header bytes were seen; a partial
 // header block is a framing error.
 func readHeaders(r *bufio.Reader) (int, error) {
-	length := -1
-	sawAnyHeader := false
+	var lines []string
 	for {
 		line, err := r.ReadString('\n')
 		if err != nil {
-			if errors.Is(err, io.EOF) && !sawAnyHeader && line == "" {
+			if errors.Is(err, io.EOF) && len(lines) == 0 && line == "" {
 				return 0, io.EOF
 			}
 			return 0, fmt.Errorf("lsp: header read: %w", err)
 		}
 		// Accept both CRLF (required by spec) and bare LF (tolerant
 		// for pipes and test harnesses).
-		line = strings.TrimRight(line, "\r\n")
+		line = LSPTrimHeaderLine(line)
 		if line == "" {
-			if !sawAnyHeader {
-				return 0, fmt.Errorf("lsp: empty header block")
+			parsed := LSPParseHeaderLines(lines)
+			if !parsed.OK {
+				return 0, errors.New(parsed.Error)
 			}
-			return length, nil
+			return parsed.ContentLength, nil
 		}
-		sawAnyHeader = true
-		colon := strings.IndexByte(line, ':')
-		if colon < 0 {
-			return 0, fmt.Errorf("lsp: malformed header %q", line)
-		}
-		name := strings.TrimSpace(line[:colon])
-		value := strings.TrimSpace(line[colon+1:])
-		if strings.EqualFold(name, "Content-Length") {
-			n, err := strconv.Atoi(value)
-			if err != nil || n < 0 {
-				return 0, fmt.Errorf("lsp: invalid Content-Length %q", value)
-			}
-			length = n
-		}
-		// Other headers (Content-Type) are intentionally ignored.
+		lines = append(lines, line)
 	}
 }
 
@@ -109,7 +93,7 @@ func readHeaders(r *bufio.Reader) (int, error) {
 // pushes it to the writer atomically.
 func (c *conn) writeMessage(body []byte) error {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Content-Length: %d\r\n\r\n", len(body))
+	buf.WriteString(LSPFrameHeader(len(body)))
 	buf.Write(body)
 
 	c.writeMu.Lock()
@@ -133,7 +117,7 @@ func (c *conn) writeError(id json.RawMessage, code int, message string) error {
 	if id == nil {
 		// Preserve null ID so clients can correlate parse-time
 		// failures. An empty RawMessage would be omitted.
-		id = json.RawMessage("null")
+		id = json.RawMessage(LSPJSONNull())
 	}
 	return c.writeMessage(mustMarshal(rpcResponse{
 		JSONRPC: "2.0",

--- a/internal/lsp/policy.go
+++ b/internal/lsp/policy.go
@@ -1,6 +1,10 @@
 package lsp
 
-import "github.com/osty/osty/internal/selfhost"
+import (
+	"encoding/json"
+
+	"github.com/osty/osty/internal/selfhost"
+)
 
 type LSPSemanticToken struct {
 	Line      uint32
@@ -26,6 +30,30 @@ type LSPLocation struct {
 	EndCharacter   uint32
 }
 
+type LSPReferenceFact struct {
+	URI                  string
+	StartLine            uint32
+	StartCharacter       uint32
+	EndLine              uint32
+	EndCharacter         uint32
+	TargetSymbolID       string
+	TargetURI            string
+	TargetStartLine      uint32
+	TargetStartCharacter uint32
+	TargetEndLine        uint32
+	TargetEndCharacter   uint32
+	Builtin              bool
+}
+
+type LSPSymbolFact struct {
+	ID             string
+	URI            string
+	StartLine      uint32
+	StartCharacter uint32
+	EndLine        uint32
+	EndCharacter   uint32
+}
+
 type LSPSymbolSortKey struct {
 	Name string
 	URI  string
@@ -35,6 +63,14 @@ type LSPImportSortKey struct {
 	Group int
 	Key   string
 	Alias string
+}
+
+type LSPOrganizeUseEntry struct {
+	Group  int
+	Key    string
+	Alias  string
+	Text   string
+	Unused bool
 }
 
 type LSPSignatureParam struct {
@@ -47,6 +83,12 @@ type LSPSignatureText struct {
 	ParameterLabels []string
 }
 
+type LSPFunctionTypeParts struct {
+	OK             bool
+	ParameterTypes []string
+	ReturnType     string
+}
+
 type LSPCompletionContext struct {
 	Prefix   string
 	AfterDot string
@@ -55,6 +97,54 @@ type LSPCompletionContext struct {
 type LSPDiagnosticPayload struct {
 	Severity uint32
 	Message  string
+}
+
+type LSPDiagnosticView struct {
+	StartLine      uint32
+	StartCharacter uint32
+	EndLine        uint32
+	EndCharacter   uint32
+	Severity       uint32
+	Code           string
+	Source         string
+	Message        string
+}
+
+type LSPDiagnosticFileFact struct {
+	DiagnosticFile      string
+	PackageFile         string
+	SpanSourceFileID    string
+	PackageSourceFileID string
+	PrimaryLine         int
+	PrimaryOffset       int
+	SourceLength        int
+}
+
+type LSPHeaderParseResult struct {
+	OK            bool
+	ContentLength int
+	Error         string
+}
+
+type LSPFileURIPathRawResult struct {
+	OK   bool
+	Path string
+}
+
+type LSPCompletionItemData struct {
+	Label         string
+	Kind          uint32
+	SortText      string
+	Detail        string
+	Documentation string
+}
+
+type LSPCompletionCandidateView struct {
+	Name     string
+	Kind     string
+	TypeText string
+	DocText  string
+	Include  bool
 }
 
 type LSPPosition struct {
@@ -71,6 +161,17 @@ type LSPOstyPosition struct {
 	Offset int
 	Line   int
 	Column int
+}
+
+type LSPFullDocumentRange struct {
+	EndLine      uint32
+	EndCharacter uint32
+}
+
+type LSPDispatchDecision struct {
+	Action       string
+	ErrorCode    int
+	ErrorMessage string
 }
 
 func LSPSemanticTypeForTokenKind(kind, symbolKind string) (uint32, bool) {
@@ -103,6 +204,142 @@ func LSPHoverSignatureLine(kind, name, typeText string) string {
 
 func LSPPathToURI(path string) string {
 	return selfhost.LSPPathToURI(path)
+}
+
+func LSPServerName() string {
+	return selfhost.LSPServerName()
+}
+
+func LSPServerVersion() string {
+	return selfhost.LSPServerVersion()
+}
+
+func LSPPositionEncodingUTF16() string {
+	return selfhost.LSPPositionEncodingUTF16()
+}
+
+func LSPJSONNull() string {
+	return selfhost.LSPJSONNull()
+}
+
+func LSPCompletionTriggerDot() string {
+	return selfhost.LSPCompletionTriggerDot()
+}
+
+func LSPSignatureTriggerOpenParen() string {
+	return selfhost.LSPSignatureTriggerOpenParen()
+}
+
+func LSPSignatureTriggerComma() string {
+	return selfhost.LSPSignatureTriggerComma()
+}
+
+func LSPSemanticTokenTypes() []string {
+	return selfhost.LSPSemanticTokenTypes()
+}
+
+func LSPSemanticTokenModifiers() []string {
+	return selfhost.LSPSemanticTokenModifiers()
+}
+
+func LSPDispatchActionInitialize() string { return selfhost.LSPDispatchActionInitialize() }
+func LSPDispatchActionExit() string       { return selfhost.LSPDispatchActionExit() }
+func LSPDispatchActionShutdown() string   { return selfhost.LSPDispatchActionShutdown() }
+func LSPDispatchActionIgnore() string     { return selfhost.LSPDispatchActionIgnore() }
+func LSPDispatchActionDispatch() string   { return selfhost.LSPDispatchActionDispatch() }
+func LSPDispatchActionError() string      { return selfhost.LSPDispatchActionError() }
+
+func LSPAsciiLowerText(text string) string {
+	return selfhost.LSPAsciiLowerText(text)
+}
+
+func LSPNameMatchesPrefix(name, prefix string) bool {
+	return selfhost.LSPNameMatchesPrefix(name, prefix)
+}
+
+func LSPNameMatchesQuery(name, query string) bool {
+	return selfhost.LSPNameMatchesQuery(name, query)
+}
+
+func LSPURIForSourcePath(path string) string {
+	return selfhost.LSPURIForSourcePath(path)
+}
+
+func LSPFileURIPathRaw(uri string) LSPFileURIPathRawResult {
+	result := selfhost.LSPFileURIPathRaw(uri)
+	return LSPFileURIPathRawResult{
+		OK:   result.OK,
+		Path: result.Path,
+	}
+}
+
+func LSPPreferAIRepairFixAll(src []byte) bool {
+	return selfhost.LSPPreferAIRepairFixAll(string(src))
+}
+
+func LSPTextChanged(original, replacement []byte) bool {
+	return selfhost.LSPTextChanged(string(original), string(replacement))
+}
+
+func LSPParamsAreEmpty(params json.RawMessage) bool {
+	return selfhost.LSPParamsAreEmpty(string(params))
+}
+
+func LSPRenameEmptyNameMessage() string {
+	return selfhost.LSPRenameEmptyNameMessage()
+}
+
+func LSPCannotRenameBuiltinMessage() string {
+	return selfhost.LSPCannotRenameBuiltinMessage()
+}
+
+func LSPCanRenameKind(kind string) bool {
+	return selfhost.LSPCanRenameKind(kind)
+}
+
+func LSPRenameTitle(name string) string {
+	return selfhost.LSPRenameTitle(name)
+}
+
+func LSPRemoveLineTitle() string {
+	return selfhost.LSPRemoveLineTitle()
+}
+
+func LSPFixAllTitle() string {
+	return selfhost.LSPFixAllTitle()
+}
+
+func LSPOrganizeImportsTitle() string {
+	return selfhost.LSPOrganizeImportsTitle()
+}
+
+func LSPInlayTypeLabel(typeText string) string {
+	return selfhost.LSPInlayTypeLabel(typeText)
+}
+
+func LSPMethodNotImplementedMessage(method string) string {
+	return selfhost.LSPMethodNotImplementedMessage(method)
+}
+
+func LSPIsOstySourceFileName(name string) bool {
+	return selfhost.LSPIsOstySourceFileName(name)
+}
+
+func LSPHasOstyFileExtension(name string) bool {
+	return selfhost.LSPHasOstyFileExtension(name)
+}
+
+func LSPExitCode(shutdown bool) int {
+	return selfhost.LSPExitCode(shutdown)
+}
+
+func LSPDispatchDecisionFor(method string, isNotification bool, initialized bool, shutdown bool) LSPDispatchDecision {
+	decision := selfhost.LSPDispatchDecisionFor(method, isNotification, initialized, shutdown)
+	return LSPDispatchDecision{
+		Action:       decision.Action,
+		ErrorCode:    decision.ErrorCode,
+		ErrorMessage: decision.ErrorMessage,
+	}
 }
 
 func LSPLineStarts(src []byte) []int {
@@ -146,6 +383,31 @@ func LSPRangeFromOffsets(src []byte, lineStarts []int, start, end int) LSPRange 
 func LSPRangeFromOstySpan(src []byte, lineStarts []int, startLine, startOffset, endLine, endOffset int) LSPRange {
 	rng := selfhost.LSPRangeFromOstySpan(string(src), lineStarts, startLine, startOffset, endLine, endOffset)
 	return lspRangeFromSelfhost(rng)
+}
+
+func LSPFullDocumentRangeFor(src []byte, lineStarts []int) LSPFullDocumentRange {
+	rng := selfhost.LSPFullDocumentRange(string(src), lineStarts)
+	return LSPFullDocumentRange{
+		EndLine:      uint32(rng.EndLine),
+		EndCharacter: uint32(rng.EndCharacter),
+	}
+}
+
+func LSPFrameHeader(bodyLength int) string {
+	return selfhost.LSPFrameHeader(bodyLength)
+}
+
+func LSPTrimHeaderLine(line string) string {
+	return selfhost.LSPTrimHeaderLine(line)
+}
+
+func LSPParseHeaderLines(lines []string) LSPHeaderParseResult {
+	parsed := selfhost.LSPParseHeaderLines(lines)
+	return LSPHeaderParseResult{
+		OK:            parsed.OK,
+		ContentLength: parsed.ContentLength,
+		Error:         parsed.Error,
+	}
 }
 
 func LSPSymbolKindForDecl(kind string, mutable bool) uint32 {
@@ -192,12 +454,74 @@ func LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd int) bool {
 	return selfhost.LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd)
 }
 
+func LSPNamedTypeReferenceEndOffset(startOffset, sourceLength int, targetName string, firstPath string) int {
+	firstPathMatchesTarget := firstPath != "" && firstPath == targetName
+	return selfhost.LSPNamedTypeReferenceEndOffset(startOffset, sourceLength, len(targetName), firstPathMatchesTarget, len(firstPath))
+}
+
 func LSPDiagnosticPayloadFor(severity, message, hint string, notes []string) LSPDiagnosticPayload {
 	payload := selfhost.LSPDiagnosticPayloadFor(severity, message, hint, notes)
 	return LSPDiagnosticPayload{
 		Severity: uint32(payload.Severity),
 		Message:  payload.Message,
 	}
+}
+
+func LSPDiagnosticsEqual(a, b []LSPDiagnosticView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	convertedA := make([]selfhost.LSPDiagnosticView, 0, len(a))
+	for _, diag := range a {
+		convertedA = append(convertedA, selfhost.LSPDiagnosticView{
+			StartLine:      int(diag.StartLine),
+			StartCharacter: int(diag.StartCharacter),
+			EndLine:        int(diag.EndLine),
+			EndCharacter:   int(diag.EndCharacter),
+			Severity:       int(diag.Severity),
+			Code:           diag.Code,
+			Source:         diag.Source,
+			Message:        diag.Message,
+		})
+	}
+	convertedB := make([]selfhost.LSPDiagnosticView, 0, len(b))
+	for _, diag := range b {
+		convertedB = append(convertedB, selfhost.LSPDiagnosticView{
+			StartLine:      int(diag.StartLine),
+			StartCharacter: int(diag.StartCharacter),
+			EndLine:        int(diag.EndLine),
+			EndCharacter:   int(diag.EndCharacter),
+			Severity:       int(diag.Severity),
+			Code:           diag.Code,
+			Source:         diag.Source,
+			Message:        diag.Message,
+		})
+	}
+	return selfhost.LSPDiagnosticsEqual(convertedA, convertedB)
+}
+
+func LSPDiagnosticBelongsToFile(fact LSPDiagnosticFileFact) bool {
+	return selfhost.LSPDiagnosticBelongsToFile(selfhost.LSPDiagnosticFileFact{
+		DiagnosticFile:      fact.DiagnosticFile,
+		PackageFile:         fact.PackageFile,
+		SpanSourceFileID:    fact.SpanSourceFileID,
+		PackageSourceFileID: fact.PackageSourceFileID,
+		PrimaryLine:         fact.PrimaryLine,
+		PrimaryOffset:       fact.PrimaryOffset,
+		SourceLength:        fact.SourceLength,
+	})
+}
+
+func LSPLevenshteinBounded(a, b string, limit int) int {
+	return selfhost.LSPLevenshteinBounded(a, b, limit)
+}
+
+func LSPRankNearbyNames(names []string, target string, maxDistance int) []string {
+	return selfhost.LSPRankNearbyNames(names, target, maxDistance)
+}
+
+func LSPMergeNearbyNames(primary []string, fallback []string) []string {
+	return selfhost.LSPMergeNearbyNames(primary, fallback)
 }
 
 func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
@@ -225,6 +549,89 @@ func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
 	return out
 }
 
+func LSPLocationsForTarget(refs []LSPReferenceFact, symbols []LSPSymbolFact, targetID string, includeDecl bool) []LSPLocation {
+	convertedRefs := make([]selfhost.LSPReferenceFact, 0, len(refs))
+	for _, ref := range refs {
+		convertedRefs = append(convertedRefs, selfhost.LSPReferenceFact{
+			URI:                  ref.URI,
+			StartLine:            int(ref.StartLine),
+			StartCharacter:       int(ref.StartCharacter),
+			EndLine:              int(ref.EndLine),
+			EndCharacter:         int(ref.EndCharacter),
+			TargetSymbolID:       ref.TargetSymbolID,
+			TargetURI:            ref.TargetURI,
+			TargetStartLine:      int(ref.TargetStartLine),
+			TargetStartCharacter: int(ref.TargetStartCharacter),
+			TargetEndLine:        int(ref.TargetEndLine),
+			TargetEndCharacter:   int(ref.TargetEndCharacter),
+			Builtin:              ref.Builtin,
+		})
+	}
+	convertedSymbols := make([]selfhost.LSPSymbolFact, 0, len(symbols))
+	for _, sym := range symbols {
+		convertedSymbols = append(convertedSymbols, selfhost.LSPSymbolFact{
+			ID:             sym.ID,
+			URI:            sym.URI,
+			StartLine:      int(sym.StartLine),
+			StartCharacter: int(sym.StartCharacter),
+			EndLine:        int(sym.EndLine),
+			EndCharacter:   int(sym.EndCharacter),
+		})
+	}
+	resolved := selfhost.LSPLocationsForTarget(convertedRefs, convertedSymbols, targetID, includeDecl)
+	out := make([]LSPLocation, 0, len(resolved))
+	for _, loc := range resolved {
+		out = append(out, LSPLocation{
+			URI:            loc.URI,
+			StartLine:      uint32(loc.StartLine),
+			StartCharacter: uint32(loc.StartCharacter),
+			EndLine:        uint32(loc.EndLine),
+			EndCharacter:   uint32(loc.EndCharacter),
+		})
+	}
+	return out
+}
+
+func LSPCompletionItemForSymbolView(view selfhost.LSPSymbolView) LSPCompletionItemData {
+	item := selfhost.LSPCompletionItemForSymbolView(view)
+	return LSPCompletionItemData{
+		Label:         item.Label,
+		Kind:          uint32(item.Kind),
+		SortText:      item.SortText,
+		Detail:        item.Detail,
+		Documentation: item.Documentation,
+	}
+}
+
+func LSPCompletionItemsForCandidates(candidates []LSPCompletionCandidateView, prefix string) []LSPCompletionItemData {
+	converted := make([]selfhost.LSPCompletionCandidateView, 0, len(candidates))
+	for _, candidate := range candidates {
+		converted = append(converted, selfhost.LSPCompletionCandidateView{
+			Name:     candidate.Name,
+			Kind:     candidate.Kind,
+			TypeText: candidate.TypeText,
+			DocText:  candidate.DocText,
+			Include:  candidate.Include,
+		})
+	}
+	items := selfhost.LSPCompletionItemsForCandidates(converted, prefix)
+	out := make([]LSPCompletionItemData, 0, len(items))
+	for _, item := range items {
+		out = append(out, LSPCompletionItemData{
+			Label:         item.Label,
+			Kind:          uint32(item.Kind),
+			SortText:      item.SortText,
+			Detail:        item.Detail,
+			Documentation: item.Documentation,
+		})
+	}
+	return out
+}
+
+func LSPSemanticHoverKind(kind string) string {
+	return selfhost.LSPSemanticHoverKind(kind)
+}
+
 func SortLSPSymbolIndexes(keys []LSPSymbolSortKey) []int {
 	converted := make([]selfhost.LSPSymbolSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -240,6 +647,25 @@ func SortLSPCompletionIndexes(labels []string) []int {
 	return selfhost.SortLSPCompletionIndexes(labels)
 }
 
+func SortLSPStringIndexes(values []string) []int {
+	return selfhost.SortLSPStringIndexes(values)
+}
+
+func SortLSPStrings(values []string) []string {
+	if len(values) <= 1 {
+		return values
+	}
+	indexes := SortLSPStringIndexes(values)
+	out := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx < 0 || idx >= len(values) {
+			continue
+		}
+		out = append(out, values[idx])
+	}
+	return out
+}
+
 func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 	converted := make([]selfhost.LSPImportSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -250,6 +676,20 @@ func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 		})
 	}
 	return selfhost.SortLSPImportIndexes(converted)
+}
+
+func LSPOrganizedUseBlock(entries []LSPOrganizeUseEntry) string {
+	converted := make([]selfhost.LSPOrganizeUseEntry, 0, len(entries))
+	for _, entry := range entries {
+		converted = append(converted, selfhost.LSPOrganizeUseEntry{
+			Group:  entry.Group,
+			Key:    entry.Key,
+			Alias:  entry.Alias,
+			Text:   entry.Text,
+			Unused: entry.Unused,
+		})
+	}
+	return selfhost.LSPOrganizedUseBlock(converted)
 }
 
 func LSPUseGroup(isGoFFI bool, path []string) int {
@@ -293,6 +733,19 @@ func LSPBuildSignatureText(name string, params []LSPSignatureParam, returnType s
 		Label:           rendered.Label,
 		ParameterLabels: append([]string(nil), rendered.ParameterLabels...),
 	}
+}
+
+func LSPParseFunctionType(typeText string) LSPFunctionTypeParts {
+	parsed := selfhost.LSPParseFunctionType(typeText)
+	return LSPFunctionTypeParts{
+		OK:             parsed.OK,
+		ParameterTypes: append([]string(nil), parsed.ParameterTypes...),
+		ReturnType:     parsed.ReturnType,
+	}
+}
+
+func LSPFallbackParameterNames(count int) []string {
+	return selfhost.LSPFallbackParameterNames(count)
 }
 
 func EncodeLSPSemanticTokens(tokens []LSPSemanticToken) []uint32 {

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -32,7 +32,7 @@ type rpcRequest struct {
 // isNotification reports whether the message lacks an id (§LSP 3.17
 // "Notification Message"). Notifications must never be answered.
 func (r *rpcRequest) isNotification() bool {
-	return len(r.ID) == 0 || string(r.ID) == "null"
+	return LSPParamsAreEmpty(r.ID)
 }
 
 // rpcResponse is the outgoing reply to a request. Exactly one of

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -1,9 +1,6 @@
 package lsp
 
 import (
-	"bytes"
-	"strings"
-
 	"github.com/osty/osty/internal/airepair"
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/canonical"
@@ -76,42 +73,20 @@ func organizeImportsAction(doc *document) *CodeAction {
 	}
 	unused := unusedUseOffsets(doc)
 
-	kept := make([]keyedUse, 0, len(views))
-	seen := make(map[string]bool, len(views))
+	entries := make([]LSPOrganizeUseEntry, 0, len(views))
 	for _, v := range views {
-		if unused[v.PosOffset] {
-			continue
-		}
 		text := LSPUseSourceText(doc.src, v.PosOffset, v.EndOffset)
-		if text == "" {
-			continue
-		}
 		group := LSPUseGroup(v.IsFFI, v.Path)
 		key := LSPUseKey(v.IsFFI, v.FFIPath, v.RawPath, v.Path)
-		// Dedup by (group, key, alias) — two identical `use` lines
-		// collapse to one.
-		dedupKey := LSPKeyWithAlias(group, key, v.Alias)
-		if seen[dedupKey] {
-			continue
-		}
-		seen[dedupKey] = true
-		kept = append(kept, keyedUse{view: v, group: group, key: key, text: text})
+		entries = append(entries, LSPOrganizeUseEntry{
+			Group:  group,
+			Key:    key,
+			Alias:  v.Alias,
+			Text:   text,
+			Unused: unused[v.PosOffset],
+		})
 	}
-	kept = sortImportEntries(kept)
-
-	// Build the replacement block. Separate groups with a blank line so
-	// the output matches what `osty fmt` would emit after the reorder.
-	var b strings.Builder
-	prevGroup := -1
-	for i, k := range kept {
-		if i > 0 && k.group != prevGroup {
-			b.WriteByte('\n')
-		}
-		b.WriteString(k.text)
-		b.WriteByte('\n')
-		prevGroup = k.group
-	}
-	newText := b.String()
+	newText := LSPOrganizedUseBlock(entries)
 
 	// Replacement range covers the full `use` block: from the first
 	// use's start to just past the last use's terminating newline. We
@@ -126,7 +101,7 @@ func organizeImportsAction(doc *document) *CodeAction {
 
 	rng := doc.analysis.lines.rangeFromOffsets(startOff, endOff)
 	return &CodeAction{
-		Title: "Organize imports",
+		Title: LSPOrganizeImportsTitle(),
 		Kind:  CodeActionSourceOrganizeImports,
 		Edit: &WorkspaceEdit{
 			Changes: map[string][]TextEdit{
@@ -246,10 +221,10 @@ func fixAllAction(doc *document) *CodeAction {
 	// deliberately does not rewrite semantic JS habits like `.length`.
 	// When that property is present, prefer airepair's broader repair so
 	// fix-all doesn't stop after a partial canonicalization.
-	if bytes.Contains(doc.src, []byte(".length")) {
+	if LSPPreferAIRepairFixAll(doc.src) {
 		if edit := airepairFixAllEdit(doc); edit != nil {
 			return &CodeAction{
-				Title: "Fix all auto-fixable problems",
+				Title: LSPFixAllTitle(),
 				Kind:  CodeActionSourceFixAllOsty,
 				Edit: &WorkspaceEdit{
 					Changes: map[string][]TextEdit{
@@ -261,7 +236,7 @@ func fixAllAction(doc *document) *CodeAction {
 	}
 	if edit := parserCanonicalFixAllEdit(doc); edit != nil {
 		return &CodeAction{
-			Title: "Fix all auto-fixable problems",
+			Title: LSPFixAllTitle(),
 			Kind:  CodeActionSourceFixAllOsty,
 			Edit: &WorkspaceEdit{
 				Changes: map[string][]TextEdit{
@@ -272,7 +247,7 @@ func fixAllAction(doc *document) *CodeAction {
 	}
 	if edit := airepairFixAllEdit(doc); edit != nil {
 		return &CodeAction{
-			Title: "Fix all auto-fixable problems",
+			Title: LSPFixAllTitle(),
 			Kind:  CodeActionSourceFixAllOsty,
 			Edit: &WorkspaceEdit{
 				Changes: map[string][]TextEdit{
@@ -293,7 +268,7 @@ func fixAllAction(doc *document) *CodeAction {
 	// of fix-all.
 	edits = resolveOverlaps(edits)
 	return &CodeAction{
-		Title: "Fix all auto-fixable problems",
+		Title: LSPFixAllTitle(),
 		Kind:  CodeActionSourceFixAllOsty,
 		Edit: &WorkspaceEdit{
 			Changes: map[string][]TextEdit{
@@ -317,7 +292,7 @@ func parserCanonicalFixAllEdit(doc *document) *TextEdit {
 		return nil
 	}
 	canonicalSrc := canonical.Source(doc.src, parsed.File)
-	if len(canonicalSrc) == 0 || bytes.Equal(canonicalSrc, doc.src) {
+	if len(canonicalSrc) == 0 || !LSPTextChanged(doc.src, canonicalSrc) {
 		return nil
 	}
 	rng := doc.analysis.lines.rangeFromOffsets(0, len(doc.src))

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -70,7 +70,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 		return
 	}
 	if params.NewName == "" {
-		_ = s.conn.writeError(req.ID, errInvalidParams, "new name is empty")
+		_ = s.conn.writeError(req.ID, errInvalidParams, LSPRenameEmptyNameMessage())
 		return
 	}
 	doc := s.docs.get(params.TextDocument.URI)
@@ -88,7 +88,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 			return
 		}
 		if ref.builtin {
-			_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+			_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 			return
 		}
 		edits := structuredRenameEditsFor(doc.analysis.structuredRefs, doc.analysis.structuredSymbols, ref.targetSymbolID, params.NewName)
@@ -101,7 +101,7 @@ func (s *Server) handleRename(req *rpcRequest) {
 			return
 		}
 		if sym.builtin {
-			_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+			_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 			return
 		}
 		edits := structuredRenameEditsFor(doc.analysis.structuredRefs, doc.analysis.structuredSymbols, sym.id, params.NewName)
@@ -113,8 +113,8 @@ func (s *Server) handleRename(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, nil)
 		return
 	}
-	if target.Kind == resolve.SymBuiltin {
-		_ = s.conn.writeError(req.ID, errInvalidRequest, "cannot rename a builtin")
+	if !LSPCanRenameKind(target.Kind.String()) {
+		_ = s.conn.writeError(req.ID, errInvalidRequest, LSPCannotRenameBuiltinMessage())
 		return
 	}
 	edits := s.renameEditsFor(doc, target, params.NewName)
@@ -142,7 +142,7 @@ func (s *Server) semanticRenameEdits(doc *document, lspPos Position, newName str
 	if !ok {
 		return nil, false
 	}
-	if target.Kind == "builtin" {
+	if !LSPCanRenameKind(target.Kind) {
 		return nil, false
 	}
 	out := map[string][]TextEdit{}
@@ -216,13 +216,11 @@ func (s *Server) findReferences(doc *document, target *resolve.Symbol, includeDe
 			// is `auth`. Narrow to the head identifier so the rename
 			// doesn't chew through the whole path.
 			startOff := nt.Pos().Offset
-			endOff := startOff + len(target.Name)
-			if len(nt.Path) > 0 && nt.Path[0] == target.Name {
-				endOff = startOff + len(nt.Path[0])
+			firstPath := ""
+			if len(nt.Path) > 0 {
+				firstPath = nt.Path[0]
 			}
-			if endOff > len(src) {
-				endOff = len(src)
-			}
+			endOff := LSPNamedTypeReferenceEndOffset(startOff, len(src), target.Name, firstPath)
 			out = append(out, Location{
 				URI:   uri,
 				Range: li.rangeFromOffsets(startOff, endOff),

--- a/internal/lsp/selfhost_policy_test.go
+++ b/internal/lsp/selfhost_policy_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"reflect"
@@ -51,6 +52,20 @@ func TestCompletionSortUsesSelfHostedPolicy(t *testing.T) {
 	if labels := []string{got[0].Label, got[1].Label, got[2].Label}; !reflect.DeepEqual(labels, []string{"alpha", "middle", "zeta"}) {
 		t.Fatalf("completion labels = %#v", labels)
 	}
+
+	filtered := LSPCompletionItemsForCandidates([]LSPCompletionCandidateView{
+		{Name: "zeta", Kind: "binding", TypeText: "Int", Include: true},
+		{Name: "alpha", Kind: "function", TypeText: "fn() -> Int", DocText: "docs", Include: true},
+		{Name: "alpha", Kind: "binding", TypeText: "String", Include: true},
+		{Name: "hidden", Kind: "binding", TypeText: "Int"},
+		{Name: "", Kind: "binding", TypeText: "Int", Include: true},
+	}, "")
+	if labels := []string{filtered[0].Label, filtered[1].Label}; !reflect.DeepEqual(labels, []string{"alpha", "zeta"}) {
+		t.Fatalf("completion candidate labels = %#v", labels)
+	}
+	if filtered[0].Detail != "fn alpha() -> Int" || filtered[0].Documentation != "docs" {
+		t.Fatalf("completion candidate item = %+v", filtered[0])
+	}
 }
 
 func TestSymbolKindUsesSelfHostedPolicy(t *testing.T) {
@@ -91,6 +106,56 @@ func TestWantsKindUsesSelfHostedPrefixPolicy(t *testing.T) {
 	}
 }
 
+func TestJSONRPCHeaderPolicyUsesSelfHost(t *testing.T) {
+	parsed := LSPParseHeaderLines([]string{
+		"Content-Type: application/vscode-jsonrpc; charset=utf-8",
+		"content-length: 42",
+	})
+	if !parsed.OK || parsed.ContentLength != 42 || parsed.Error != "" {
+		t.Fatalf("header parse = %+v, want length 42", parsed)
+	}
+	missing := LSPParseHeaderLines([]string{"Content-Type: application/json"})
+	if !missing.OK || missing.ContentLength != -1 {
+		t.Fatalf("missing content length = %+v, want ok length -1", missing)
+	}
+	if got := LSPParseHeaderLines(nil); got.OK || got.Error != "lsp: empty header block" {
+		t.Fatalf("empty header parse = %+v, want empty-block error", got)
+	}
+	if got := LSPParseHeaderLines([]string{"Content-Length: -1"}); got.OK {
+		t.Fatalf("negative content length parsed ok: %+v", got)
+	}
+	if got := LSPFrameHeader(17); got != "Content-Length: 17\r\n\r\n" {
+		t.Fatalf("frame header = %q", got)
+	}
+	if got := LSPTrimHeaderLine("Content-Length: 17\r\n"); got != "Content-Length: 17" {
+		t.Fatalf("trimmed header line = %q", got)
+	}
+	length, err := readHeaders(bufio.NewReader(strings.NewReader("Content-Type: x\r\ncontent-length: 2\r\n\r\n{}")))
+	if err != nil || length != 2 {
+		t.Fatalf("readHeaders = (%d, %v), want (2, nil)", length, err)
+	}
+}
+
+func TestNearbyNameRankingUsesSelfHostedPolicy(t *testing.T) {
+	if got := LSPLevenshteinBounded("kitten", "sitting", 3); got != 3 {
+		t.Fatalf("levenshtein = %d, want 3", got)
+	}
+	if got := LSPLevenshteinBounded("kitten", "sitting", 2); got != 3 {
+		t.Fatalf("bounded levenshtein = %d, want limit+1", got)
+	}
+	got := nearbyStructuredSymbolNames([]structuredSymbol{
+		{name: "helpr"},
+		{name: "helper"},
+		{name: "helper"},
+		{name: "helmet"},
+		{name: "builtin", builtin: true},
+		{name: "local", depth: 1},
+	}, "helper", 1)
+	if want := []string{"helper", "helpr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("nearby names = %#v, want %#v", got, want)
+	}
+}
+
 func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
 	if got := LSPHoverSignatureLine("struct", "User", ""); got != "struct User" {
 		t.Fatalf("hover signature = %q", got)
@@ -100,6 +165,196 @@ func TestDisplayTextUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got := LSPCompletionDetail("function", "map", "fn(Int) -> String"); got != "fn map(Int) -> String" {
 		t.Fatalf("completion detail = %q", got)
+	}
+}
+
+func TestNameURIAndFixAllPolicyUseSelfHost(t *testing.T) {
+	if got := LSPServerName(); got != "osty-lsp" {
+		t.Fatalf("server name = %q", got)
+	}
+	if got := LSPServerVersion(); got != "0.1.0" {
+		t.Fatalf("server version = %q", got)
+	}
+	if got := LSPPositionEncodingUTF16(); got != "utf-16" {
+		t.Fatalf("encoding = %q", got)
+	}
+	if got := LSPJSONNull(); got != "null" {
+		t.Fatalf("json null = %q", got)
+	}
+	if got := []string{LSPCompletionTriggerDot(), LSPSignatureTriggerOpenParen(), LSPSignatureTriggerComma()}; !reflect.DeepEqual(got, []string{".", "(", ","}) {
+		t.Fatalf("triggers = %#v", got)
+	}
+	if got := LSPSemanticTokenTypes(); got[0] != "namespace" || got[len(got)-1] != "enumMember" {
+		t.Fatalf("semantic token legend = %#v", got)
+	}
+	if got := LSPSemanticTokenModifiers(); !reflect.DeepEqual(got, []string{"declaration", "readonly"}) {
+		t.Fatalf("semantic token modifiers = %#v", got)
+	}
+	if got := LSPExitCode(true); got != 0 {
+		t.Fatalf("exit code = %d, want 0", got)
+	}
+	if got := LSPExitCode(false); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+	if got := LSPDispatchDecisionFor("initialize", false, false, false); got.Action != LSPDispatchActionInitialize() {
+		t.Fatalf("initialize decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("textDocument/hover", false, false, false); got.ErrorCode != errServerNotInitialized {
+		t.Fatalf("pre-init decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("shutdown", false, true, false); got.Action != LSPDispatchActionShutdown() {
+		t.Fatalf("shutdown decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("textDocument/hover", false, true, false); got.Action != LSPDispatchActionDispatch() {
+		t.Fatalf("hover decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("unknown/method", false, true, false); got.ErrorCode != errMethodNotFound {
+		t.Fatalf("unknown request decision = %+v", got)
+	}
+	if got := LSPDispatchDecisionFor("unknown/method", true, true, false); got.Action != LSPDispatchActionIgnore() {
+		t.Fatalf("unknown notification decision = %+v", got)
+	}
+	if got := LSPAsciiLowerText("HeLLo"); got != "hello" {
+		t.Fatalf("lower text = %q, want hello", got)
+	}
+	if !LSPNameMatchesPrefix("helper", "hel") || LSPNameMatchesPrefix("helper", "map") {
+		t.Fatal("prefix policy mismatch")
+	}
+	if !LSPNameMatchesQuery("HelperValue", "value") {
+		t.Fatal("query policy did not match lowercase substring")
+	}
+	if got := LSPURIForSourcePath("inmemory:main"); got != "inmemory:main" {
+		t.Fatalf("source URI = %q, want inmemory:main", got)
+	}
+	if got := LSPURIForSourcePath("/tmp/main.osty"); got != "file:///tmp/main.osty" {
+		t.Fatalf("file source URI = %q", got)
+	}
+	if got := LSPFileURIPathRaw("file:///tmp/main.osty"); !got.OK || got.Path != "/tmp/main.osty" {
+		t.Fatalf("file URI raw path = %+v", got)
+	}
+	if got := LSPFileURIPathRaw("file:///C:/tmp/main.osty"); !got.OK || got.Path != "C:/tmp/main.osty" {
+		t.Fatalf("windows file URI raw path = %+v", got)
+	}
+	if got := LSPFileURIPathRaw("inmemory:main"); got.OK {
+		t.Fatalf("non-file URI raw path = %+v", got)
+	}
+	if !LSPPreferAIRepairFixAll([]byte("x.length")) || LSPPreferAIRepairFixAll([]byte("x.len()")) {
+		t.Fatal("fix-all preference policy mismatch")
+	}
+	if !LSPTextChanged([]byte("a"), []byte("b")) || LSPTextChanged([]byte("a"), []byte("a")) {
+		t.Fatal("text changed policy mismatch")
+	}
+	if !LSPParamsAreEmpty(nil) || !LSPParamsAreEmpty([]byte("null")) || LSPParamsAreEmpty([]byte("{}")) {
+		t.Fatal("params empty policy mismatch")
+	}
+	if got := LSPRenameEmptyNameMessage(); got != "new name is empty" {
+		t.Fatalf("empty rename message = %q", got)
+	}
+	if got := LSPCannotRenameBuiltinMessage(); got != "cannot rename a builtin" {
+		t.Fatalf("builtin rename message = %q", got)
+	}
+	if !LSPCanRenameKind("function") || LSPCanRenameKind("builtin") {
+		t.Fatal("rename kind policy mismatch")
+	}
+	if got := LSPRenameTitle("helper"); got != "Rename to `helper`" {
+		t.Fatalf("rename title = %q", got)
+	}
+	if got := LSPRemoveLineTitle(); got != "Remove unused import" {
+		t.Fatalf("remove title = %q", got)
+	}
+	if got := LSPFixAllTitle(); got != "Fix all auto-fixable problems" {
+		t.Fatalf("fix-all title = %q", got)
+	}
+	if got := LSPOrganizeImportsTitle(); got != "Organize imports" {
+		t.Fatalf("organize title = %q", got)
+	}
+	if got := LSPInlayTypeLabel("Int"); got != ": Int" {
+		t.Fatalf("inlay label = %q", got)
+	}
+	if got := LSPMethodNotImplementedMessage("custom/method"); got != "method not implemented: custom/method" {
+		t.Fatalf("method message = %q", got)
+	}
+	if !LSPIsOstySourceFileName("main.osty") || LSPIsOstySourceFileName("main_test.osty") || LSPIsOstySourceFileName("main.go") {
+		t.Fatal("source filename policy mismatch")
+	}
+	if !LSPHasOstyFileExtension("main_test.osty") || LSPHasOstyFileExtension("main.go") {
+		t.Fatal("source extension policy mismatch")
+	}
+	item := LSPCompletionItemForSymbolView(selfhost.LSPSymbolView{
+		Name:     "map",
+		Kind:     "function",
+		TypeText: "fn(Int) -> String",
+		DocText:  "docs",
+		HasSym:   true,
+	})
+	if item.Label != "map" || item.Kind != uint32(CompletionItemFunction) || item.SortText != "2_map" || item.Detail != "fn map(Int) -> String" || item.Documentation != "docs" {
+		t.Fatalf("completion item policy = %+v", item)
+	}
+	if got := LSPSemanticHoverKind("generic"); got != "type parameter" {
+		t.Fatalf("semantic hover kind = %q", got)
+	}
+}
+
+func TestTargetLocationPolicyUsesSelfHost(t *testing.T) {
+	refs := []LSPReferenceFact{
+		{
+			URI:                  "file:///b.osty",
+			StartLine:            2,
+			StartCharacter:       0,
+			EndLine:              2,
+			EndCharacter:         4,
+			TargetSymbolID:       "sym.helper",
+			TargetURI:            "file:///decl.osty",
+			TargetStartLine:      1,
+			TargetStartCharacter: 1,
+			TargetEndLine:        1,
+			TargetEndCharacter:   7,
+		},
+		{
+			URI:            "file:///a.osty",
+			StartLine:      4,
+			StartCharacter: 1,
+			EndLine:        4,
+			EndCharacter:   7,
+			TargetSymbolID: "sym.helper",
+		},
+	}
+	symbols := []LSPSymbolFact{{
+		ID:             "sym.helper",
+		URI:            "file:///decl.osty",
+		StartLine:      1,
+		StartCharacter: 2,
+		EndLine:        1,
+		EndCharacter:   8,
+	}}
+	got := LSPLocationsForTarget(refs, symbols, "sym.helper", true)
+	want := []LSPLocation{
+		{URI: "file:///a.osty", StartLine: 4, StartCharacter: 1, EndLine: 4, EndCharacter: 7},
+		{URI: "file:///b.osty", StartLine: 2, StartCharacter: 0, EndLine: 2, EndCharacter: 4},
+		{URI: "file:///decl.osty", StartLine: 1, StartCharacter: 2, EndLine: 1, EndCharacter: 8},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("target locations = %#v, want %#v", got, want)
+	}
+	if got := LSPLocationsForTarget(refs, nil, "missing", true); len(got) != 0 {
+		t.Fatalf("missing target locations = %#v, want none", got)
+	}
+}
+
+func TestSignatureTypeParsingUsesSelfHostedPolicy(t *testing.T) {
+	parsed := LSPParseFunctionType("fn(Int, Result<String, Error>, fn(Int) -> Bool) -> String")
+	if !parsed.OK {
+		t.Fatal("function type did not parse")
+	}
+	wantParams := []string{"Int", "Result<String, Error>", "fn(Int) -> Bool"}
+	if !reflect.DeepEqual(parsed.ParameterTypes, wantParams) || parsed.ReturnType != "String" {
+		t.Fatalf("parsed function type = %+v, want params %#v return String", parsed, wantParams)
+	}
+	if got := LSPParseFunctionType("List<Int>"); got.OK {
+		t.Fatalf("non-function type parsed ok: %+v", got)
+	}
+	if got, want := LSPFallbackParameterNames(3), []string{"arg1", "arg2", "arg3"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback parameter names = %#v, want %#v", got, want)
 	}
 }
 
@@ -258,6 +513,12 @@ func TestIdentifierAtUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got := identifierAt(src, strings.Index(string(src), "값")); got != "값" {
 		t.Fatalf("identifierAt(unicode) = %q, want 값", got)
+	}
+	if got := LSPNamedTypeReferenceEndOffset(10, 20, "helper", "help"); got != 16 {
+		t.Fatalf("named type end = %d, want 16", got)
+	}
+	if got := LSPNamedTypeReferenceEndOffset(18, 20, "helper", ""); got != 20 {
+		t.Fatalf("clamped named type end = %d, want 20", got)
 	}
 }
 
@@ -536,6 +797,9 @@ func TestURIAndLocationPolicyUsesSelfHost(t *testing.T) {
 	if got := pathToURI(""); got != "file://" {
 		t.Fatalf("pathToURI(empty) = %q", got)
 	}
+	if got := LSPFullDocumentRangeFor([]byte("a😀\nend"), LSPLineStarts([]byte("a😀\nend"))); got.EndLine != 1 || got.EndCharacter != 3 {
+		t.Fatalf("full document range = %+v", got)
+	}
 
 	got := sortDedupLocations([]Location{
 		{
@@ -573,6 +837,9 @@ func TestURIAndLocationPolicyUsesSelfHost(t *testing.T) {
 	if got := []string{syms[0].Location.URI, syms[1].Location.URI, syms[2].Location.URI}; !reflect.DeepEqual(got, []string{"file:///a.osty", "file:///z.osty", "file:///b.osty"}) {
 		t.Fatalf("symbol order = %#v", got)
 	}
+	if got := SortLSPStrings([]string{"z.osty", "a.osty", "a.osty"}); !reflect.DeepEqual(got, []string{"a.osty", "a.osty", "z.osty"}) {
+		t.Fatalf("string order = %#v", got)
+	}
 }
 
 func TestDiagnosticPayloadUsesSelfHostedPolicy(t *testing.T) {
@@ -593,6 +860,41 @@ func TestDiagnosticPayloadUsesSelfHostedPolicy(t *testing.T) {
 	}
 	if got.Message != "unused value\nhelp: prefix it\nnote: declared here" {
 		t.Fatalf("message = %q", got.Message)
+	}
+	a := []LSPDiagnostic{got}
+	b := append([]LSPDiagnostic(nil), a...)
+	if !diagsEqual(a, b) {
+		t.Fatalf("diagnostics should be equal: %#v %#v", a, b)
+	}
+	b[0].Message = "changed"
+	if diagsEqual(a, b) {
+		t.Fatalf("diagnostics should differ: %#v %#v", a, b)
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		DiagnosticFile: "/tmp/main.osty",
+		PackageFile:    "/tmp/main.osty",
+		PrimaryOffset:  999,
+		SourceLength:   1,
+	}) {
+		t.Fatal("diagnostic file match should win")
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		SpanSourceFileID:    "src1",
+		PackageSourceFileID: "src1",
+		PrimaryOffset:       999,
+		SourceLength:        1,
+	}) {
+		t.Fatal("diagnostic source file id should match")
+	}
+	if !LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		PrimaryLine:   1,
+		PrimaryOffset: 3,
+		SourceLength:  3,
+	}) {
+		t.Fatal("diagnostic offset fallback should match")
+	}
+	if LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{SourceLength: 3}) {
+		t.Fatal("zero-line diagnostic should not match")
 	}
 }
 
@@ -635,6 +937,16 @@ func TestImportOrganizeHelpersUseSelfHost(t *testing.T) {
 	})
 	if got := []string{sorted[0].key, sorted[1].view.Alias, sorted[2].view.Alias, sorted[3].key}; !reflect.DeepEqual(got, []string{"fmt", "a", "b", "zeta"}) {
 		t.Fatalf("import order = %#v", got)
+	}
+	block := LSPOrganizedUseBlock([]LSPOrganizeUseEntry{
+		{Group: 1, Key: "zeta", Text: "use zeta"},
+		{Group: 0, Key: "fmt", Text: "use std.fmt"},
+		{Group: 1, Key: "alpha", Text: "use alpha"},
+		{Group: 1, Key: "alpha", Text: "use alpha duplicate"},
+		{Group: 0, Key: "io", Text: "use std.io", Unused: true},
+	})
+	if got, want := block, "use std.fmt\n\nuse alpha\nuse zeta\n"; got != want {
+		t.Fatalf("organized use block = %q, want %q", got, want)
 	}
 	if got := LSPUseSourceText(stdSrc, views[0].PosOffset, views[0].EndOffset); got != "use std.fmt" {
 		t.Fatalf("source text = %q", got)

--- a/internal/lsp/semtok.go
+++ b/internal/lsp/semtok.go
@@ -8,27 +8,11 @@ import (
 // semanticTokenTypes is the legend the server advertises in
 // ServerCapabilities. Indices into this slice appear in each encoded
 // token; the client maps them to theme colors.
-var semanticTokenTypes = []string{
-	"namespace",
-	"type",
-	"parameter",
-	"variable",
-	"property",
-	"function",
-	"keyword",
-	"string",
-	"number",
-	"operator",
-	"comment",
-	"enumMember",
-}
+var semanticTokenTypes = LSPSemanticTokenTypes()
 
 // semanticTokenModifiers complements tokenTypes; packed as a bitmask
 // on each emitted token.
-var semanticTokenModifiers = []string{
-	"declaration",
-	"readonly",
-}
+var semanticTokenModifiers = LSPSemanticTokenModifiers()
 
 // semToken is the intermediate form before relative encoding. `mods`
 // is always 0 today; kept in the struct so the wire-format (5 ints

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2,13 +2,10 @@ package lsp
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -27,7 +24,7 @@ import (
 
 // ServerName is advertised in Initialize and used as the `source`
 // field of every published Diagnostic.
-const ServerName = "osty-lsp"
+var ServerName = LSPServerName()
 
 // Server implements the read/dispatch/write loop of the language
 // server. A Server is single-use: create it once per process with
@@ -169,10 +166,7 @@ func (s *Server) Run() error {
 func (s *Server) ExitCode() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.shutdown {
-		return 0
-	}
-	return 1
+	return LSPExitCode(s.shutdown)
 }
 
 // dispatch routes a decoded message to the right handler. Requests
@@ -190,13 +184,17 @@ func (s *Server) dispatch(req *rpcRequest) {
 			s.log.Printf("lsp-trace: %-40s %v", req.Method, time.Since(t0))
 		}()
 	}
-	// Fast-path the lifecycle methods that can legally appear
-	// before `initialized`.
-	switch req.Method {
-	case "initialize":
+	s.mu.Lock()
+	initialized := s.initialized
+	shutdown := s.shutdown
+	s.mu.Unlock()
+
+	decision := LSPDispatchDecisionFor(req.Method, req.isNotification(), initialized, shutdown)
+	switch decision.Action {
+	case LSPDispatchActionInitialize():
 		s.handleInitialize(req)
 		return
-	case "exit":
+	case LSPDispatchActionExit():
 		// Per spec, exit terminates the process regardless of
 		// whether a prior shutdown was received. Signal Run to
 		// stop; the caller decides whether to os.Exit.
@@ -210,37 +208,20 @@ func (s *Server) dispatch(req *rpcRequest) {
 		}
 		s.mu.Unlock()
 		return
-	}
-
-	s.mu.Lock()
-	initialized := s.initialized
-	shutdown := s.shutdown
-	s.mu.Unlock()
-	if !initialized {
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errServerNotInitialized,
-				"server has not been initialized")
-		}
+	case LSPDispatchActionShutdown():
+		s.mu.Lock()
+		s.shutdown = true
+		s.mu.Unlock()
+		_ = s.conn.writeResponse(req.ID, json.RawMessage(LSPJSONNull()))
 		return
-	}
-	if shutdown {
-		// After shutdown only `exit` is valid; everything else
-		// is an invalid-request error (spec §Lifecycle).
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errInvalidRequest,
-				"server is shutting down")
-		}
+	case LSPDispatchActionIgnore():
+		return
+	case LSPDispatchActionError():
+		_ = s.conn.writeError(req.ID, decision.ErrorCode, decision.ErrorMessage)
 		return
 	}
 
 	switch req.Method {
-	case "initialized":
-		// One-shot acknowledgement; nothing to do.
-	case "shutdown":
-		s.mu.Lock()
-		s.shutdown = true
-		s.mu.Unlock()
-		_ = s.conn.writeResponse(req.ID, json.RawMessage("null"))
 	case "textDocument/didOpen":
 		s.handleDidOpen(req)
 	case "textDocument/didChange":
@@ -272,10 +253,8 @@ func (s *Server) dispatch(req *rpcRequest) {
 	case "textDocument/codeAction":
 		s.handleCodeAction(req)
 	default:
-		if !req.isNotification() {
-			_ = s.conn.writeError(req.ID, errMethodNotFound,
-				fmt.Sprintf("method not implemented: %s", req.Method))
-		}
+		_ = s.conn.writeError(req.ID, errMethodNotFound,
+			LSPMethodNotImplementedMessage(req.Method))
 	}
 }
 
@@ -488,7 +467,7 @@ func dirHasOstySiblings(dir, selfPath string) bool {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".osty" {
+		if e.IsDir() || !LSPHasOstyFileExtension(e.Name()) {
 			continue
 		}
 		full := filepath.Join(dir, e.Name())
@@ -552,12 +531,12 @@ func (s *Server) analyzePackageViaEngine(pkgDir, path string, src []byte) *docAn
 			continue
 		}
 		name := e.Name()
-		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+		if !LSPIsOstySourceFileName(name) {
 			continue
 		}
 		filePaths = append(filePaths, ostyquery.NormalizePath(filepath.Join(pkgDir, name)))
 	}
-	sort.Strings(filePaths)
+	filePaths = SortLSPStrings(filePaths)
 
 	if len(filePaths) == 0 {
 		return nil
@@ -699,12 +678,12 @@ func (s *Server) analyzeWorkspaceViaEngine(root, path string, src []byte) *docAn
 				continue
 			}
 			name := e.Name()
-			if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			if !LSPIsOstySourceFileName(name) {
 				continue
 			}
 			filePaths = append(filePaths, ostyquery.NormalizePath(filepath.Join(pkgDir, name)))
 		}
-		sort.Strings(filePaths)
+		filePaths = SortLSPStrings(filePaths)
 
 		if len(filePaths) == 0 {
 			continue
@@ -1043,17 +1022,24 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 	if d == nil || pf == nil {
 		return false
 	}
+	diagnosticFile := ""
 	if d.File != "" {
-		return ostyquery.NormalizePath(d.File) == ostyquery.NormalizePath(pf.Path)
+		diagnosticFile = ostyquery.NormalizePath(d.File)
 	}
+	spanSourceFileID := ""
 	if span, ok := d.PrimarySpan(); ok && span.SourceFileID != "" && pf.SourceFileID != "" {
-		return span.SourceFileID == pf.SourceFileID
+		spanSourceFileID = string(span.SourceFileID)
 	}
 	pos := d.PrimaryPos()
-	if pos.Line == 0 {
-		return false
-	}
-	return pos.Offset <= len(pf.Source)
+	return LSPDiagnosticBelongsToFile(LSPDiagnosticFileFact{
+		DiagnosticFile:      diagnosticFile,
+		PackageFile:         ostyquery.NormalizePath(pf.Path),
+		SpanSourceFileID:    spanSourceFileID,
+		PackageSourceFileID: string(pf.SourceFileID),
+		PrimaryLine:         pos.Line,
+		PrimaryOffset:       pos.Offset,
+		SourceLength:        len(pf.Source),
+	})
 }
 
 // analyzeSingleFileViaEngine uses the Salsa-style incremental query

--- a/internal/lsp/signature.go
+++ b/internal/lsp/signature.go
@@ -1,9 +1,6 @@
 package lsp
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/token"
@@ -152,19 +149,19 @@ func buildStructuredSignatureInfo(call *ast.CallExpr, doc *document) (SignatureI
 	if ref == nil || ref.targetKind != "function" || ref.targetType == "" {
 		return SignatureInformation{}, false
 	}
-	paramTypes, returnType, ok := parseStructuredFunctionType(ref.targetType)
-	if !ok {
+	parsed := LSPParseFunctionType(ref.targetType)
+	if !parsed.OK {
 		return SignatureInformation{}, false
 	}
-	paramNames := fallbackParameterNames(len(paramTypes))
-	params := make([]LSPSignatureParam, 0, len(paramTypes))
-	for i, pt := range paramTypes {
+	paramNames := LSPFallbackParameterNames(len(parsed.ParameterTypes))
+	params := make([]LSPSignatureParam, 0, len(parsed.ParameterTypes))
+	for i, pt := range parsed.ParameterTypes {
 		params = append(params, LSPSignatureParam{
 			Name:     paramNames[i],
 			TypeName: pt,
 		})
 	}
-	rendered := LSPBuildSignatureText(ref.targetName, params, returnType)
+	rendered := LSPBuildSignatureText(ref.targetName, params, parsed.ReturnType)
 	paramInfo := make([]ParameterInformation, 0, len(rendered.ParameterLabels))
 	for _, paramLabel := range rendered.ParameterLabels {
 		paramInfo = append(paramInfo, ParameterInformation{Label: paramLabel})
@@ -173,75 +170,6 @@ func buildStructuredSignatureInfo(call *ast.CallExpr, doc *document) (SignatureI
 		Label:      rendered.Label,
 		Parameters: paramInfo,
 	}, true
-}
-
-func parseStructuredFunctionType(typeText string) ([]string, string, bool) {
-	rest := strings.TrimSpace(typeText)
-	if !strings.HasPrefix(rest, "fn") {
-		return nil, "", false
-	}
-	rest = strings.TrimSpace(strings.TrimPrefix(rest, "fn"))
-	if !strings.HasPrefix(rest, "(") {
-		return nil, "", false
-	}
-	closeIdx := matchingCloseParen(rest)
-	if closeIdx < 0 {
-		return nil, "", false
-	}
-	paramsText := strings.TrimSpace(rest[1:closeIdx])
-	var params []string
-	if paramsText != "" {
-		params = splitTopLevelComma(paramsText)
-	}
-	returnType := ""
-	tail := strings.TrimSpace(rest[closeIdx+1:])
-	if strings.HasPrefix(tail, "->") {
-		returnType = strings.TrimSpace(strings.TrimPrefix(tail, "->"))
-	}
-	return params, returnType, true
-}
-
-func matchingCloseParen(s string) int {
-	depth := 0
-	for i, r := range s {
-		switch r {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-func splitTopLevelComma(s string) []string {
-	var out []string
-	start := 0
-	depth := 0
-	for i, r := range s {
-		switch r {
-		case '(', '[', '<':
-			depth++
-		case ')', ']', '>':
-			if depth > 0 {
-				depth--
-			}
-		case ',':
-			if depth == 0 {
-				if part := strings.TrimSpace(s[start:i]); part != "" {
-					out = append(out, part)
-				}
-				start = i + len(string(r))
-			}
-		}
-	}
-	if part := strings.TrimSpace(s[start:]); part != "" {
-		out = append(out, part)
-	}
-	return out
 }
 
 // calleeSymbol resolves the `Fn` side of a call expression to a
@@ -269,7 +197,7 @@ func calleeSymbol(call *ast.CallExpr, a *docAnalysis) (*resolve.Symbol, *ast.FnD
 // declaration when possible, filled with `argN` placeholders
 // otherwise.
 func parameterNames(fd *ast.FnDecl, count int) []string {
-	names := make([]string, count)
+	names := LSPFallbackParameterNames(count)
 	if fd != nil {
 		for i, p := range fd.Params {
 			if i >= count {
@@ -280,22 +208,7 @@ func parameterNames(fd *ast.FnDecl, count int) []string {
 			}
 		}
 	}
-	fillFallbackParameterNames(names)
 	return names
-}
-
-func fallbackParameterNames(count int) []string {
-	names := make([]string, count)
-	fillFallbackParameterNames(names)
-	return names
-}
-
-func fillFallbackParameterNames(names []string) {
-	for i := range names {
-		if names[i] == "" {
-			names[i] = fmt.Sprintf("arg%d", i+1)
-		}
-	}
 }
 
 // activeParamFor computes which parameter index the cursor sits in by

--- a/internal/lsp/structured_refs.go
+++ b/internal/lsp/structured_refs.go
@@ -1,10 +1,6 @@
 package lsp
 
-import (
-	"strings"
-
-	"github.com/osty/osty/internal/resolve"
-)
+import "github.com/osty/osty/internal/resolve"
 
 type structuredReference struct {
 	name           string
@@ -199,10 +195,7 @@ func buildStructuredImportsForPackage(pkg *resolve.Package) []structuredImportSu
 }
 
 func uriForSourcePath(path string) string {
-	if strings.Contains(path, ":") && !strings.HasPrefix(path, "/") {
-		return path
-	}
-	return pathToURI(path)
+	return LSPURIForSourcePath(path)
 }
 
 func structuredReferenceAt(doc *document, lspPos Position) *structuredReference {
@@ -249,39 +242,44 @@ func rangeContainsPosition(r Range, p Position) bool {
 }
 
 func structuredReferencesForTarget(refs []structuredReference, symbols []structuredSymbol, targetID string, includeDecl bool) []Location {
-	if targetID == "" {
-		return nil
+	convertedRefs := make([]LSPReferenceFact, 0, len(refs))
+	for _, ref := range refs {
+		convertedRefs = append(convertedRefs, LSPReferenceFact{
+			URI:                  ref.uri,
+			StartLine:            ref.rng.Start.Line,
+			StartCharacter:       ref.rng.Start.Character,
+			EndLine:              ref.rng.End.Line,
+			EndCharacter:         ref.rng.End.Character,
+			TargetSymbolID:       ref.targetSymbolID,
+			TargetURI:            ref.targetURI,
+			TargetStartLine:      ref.targetRange.Start.Line,
+			TargetStartCharacter: ref.targetRange.Start.Character,
+			TargetEndLine:        ref.targetRange.End.Line,
+			TargetEndCharacter:   ref.targetRange.End.Character,
+			Builtin:              ref.builtin,
+		})
 	}
-	out := make([]Location, 0, len(refs)+1)
-	var decl *structuredReference
-	for i := range refs {
-		ref := &refs[i]
-		if ref.targetSymbolID != targetID {
-			continue
-		}
-		out = append(out, Location{URI: ref.uri, Range: ref.rng})
-		if decl == nil && ref.targetURI != "" && !ref.builtin {
-			decl = ref
-		}
+	convertedSymbols := make([]LSPSymbolFact, 0, len(symbols))
+	for _, sym := range symbols {
+		convertedSymbols = append(convertedSymbols, LSPSymbolFact{
+			ID:             sym.id,
+			URI:            sym.uri,
+			StartLine:      sym.selectionRange.Start.Line,
+			StartCharacter: sym.selectionRange.Start.Character,
+			EndLine:        sym.selectionRange.End.Line,
+			EndCharacter:   sym.selectionRange.End.Character,
+		})
 	}
-	if includeDecl {
-		if sym := structuredSymbolForTarget(symbols, targetID); sym != nil {
-			out = append(out, Location{URI: sym.uri, Range: sym.selectionRange})
-		} else if decl != nil {
-			out = append(out, Location{URI: decl.targetURI, Range: decl.targetRange})
-		}
+	locs := LSPLocationsForTarget(convertedRefs, convertedSymbols, targetID, includeDecl)
+	out := make([]Location, 0, len(locs))
+	for _, loc := range locs {
+		out = append(out, Location{
+			URI: loc.URI,
+			Range: Range{
+				Start: Position{Line: loc.StartLine, Character: loc.StartCharacter},
+				End:   Position{Line: loc.EndLine, Character: loc.EndCharacter},
+			},
+		})
 	}
-	return sortDedupLocations(out)
-}
-
-func structuredSymbolForTarget(symbols []structuredSymbol, targetID string) *structuredSymbol {
-	if targetID == "" {
-		return nil
-	}
-	for i := range symbols {
-		if symbols[i].id == targetID {
-			return &symbols[i]
-		}
-	}
-	return nil
+	return out
 }

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -1,8 +1,6 @@
 package lsp
 
 import (
-	"strings"
-
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 )
@@ -23,7 +21,7 @@ func (s *Server) handleWorkspaceSymbol(req *rpcRequest) {
 		_ = s.conn.writeError(req.ID, errInvalidParams, err.Error())
 		return
 	}
-	query := strings.ToLower(params.Query)
+	query := LSPAsciiLowerText(params.Query)
 
 	var out []SymbolInformation
 	seen := map[string]bool{}
@@ -108,7 +106,7 @@ func collectDeclSymbols(uri string, li *lineIndex, file *ast.File, container, qu
 		if name == "" {
 			return
 		}
-		if query != "" && !strings.Contains(strings.ToLower(name), query) {
+		if !LSPNameMatchesQuery(name, query) {
 			return
 		}
 		out = append(out, SymbolInformation{

--- a/internal/selfhost/lsp_policy.go
+++ b/internal/selfhost/lsp_policy.go
@@ -2,6 +2,7 @@ package selfhost
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,30 @@ type LSPLocation struct {
 	EndCharacter   int
 }
 
+type LSPReferenceFact struct {
+	URI                  string
+	StartLine            int
+	StartCharacter       int
+	EndLine              int
+	EndCharacter         int
+	TargetSymbolID       string
+	TargetURI            string
+	TargetStartLine      int
+	TargetStartCharacter int
+	TargetEndLine        int
+	TargetEndCharacter   int
+	Builtin              bool
+}
+
+type LSPSymbolFact struct {
+	ID             string
+	URI            string
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
+}
+
 type LSPSymbolSortKey struct {
 	Name string
 	URI  string
@@ -38,6 +63,14 @@ type LSPImportSortKey struct {
 	Group int
 	Key   string
 	Alias string
+}
+
+type LSPOrganizeUseEntry struct {
+	Group  int
+	Key    string
+	Alias  string
+	Text   string
+	Unused bool
 }
 
 type LSPSignatureParam struct {
@@ -50,6 +83,12 @@ type LSPSignatureText struct {
 	ParameterLabels []string
 }
 
+type LSPFunctionTypeParts struct {
+	OK             bool
+	ParameterTypes []string
+	ReturnType     string
+}
+
 type LSPCompletionContext struct {
 	Prefix   string
 	AfterDot string
@@ -58,6 +97,54 @@ type LSPCompletionContext struct {
 type LSPDiagnosticPayload struct {
 	Severity int
 	Message  string
+}
+
+type LSPDiagnosticView struct {
+	StartLine      int
+	StartCharacter int
+	EndLine        int
+	EndCharacter   int
+	Severity       int
+	Code           string
+	Source         string
+	Message        string
+}
+
+type LSPDiagnosticFileFact struct {
+	DiagnosticFile      string
+	PackageFile         string
+	SpanSourceFileID    string
+	PackageSourceFileID string
+	PrimaryLine         int
+	PrimaryOffset       int
+	SourceLength        int
+}
+
+type LSPHeaderParseResult struct {
+	OK            bool
+	ContentLength int
+	Error         string
+}
+
+type LSPFileURIPathRawResult struct {
+	OK   bool
+	Path string
+}
+
+type LSPCompletionItemData struct {
+	Label         string
+	Kind          int
+	SortText      string
+	Detail        string
+	Documentation string
+}
+
+type LSPCompletionCandidateView struct {
+	Name     string
+	Kind     string
+	TypeText string
+	DocText  string
+	Include  bool
 }
 
 // LSPSymbolView is the value-typed snapshot the LSP policy layer
@@ -105,6 +192,17 @@ type LSPOstyPosition struct {
 	Offset int
 	Line   int
 	Column int
+}
+
+type LSPFullDocumentRangeResult struct {
+	EndLine      int
+	EndCharacter int
+}
+
+type LSPDispatchDecision struct {
+	Action       string
+	ErrorCode    int
+	ErrorMessage string
 }
 
 func LSPSemanticTypeForTokenKind(kind, symbolKind string) int {
@@ -155,6 +253,205 @@ func LSPPathToURI(path string) string {
 	return lspPathToUri(path)
 }
 
+func LSPFileURIPathRaw(uri string) LSPFileURIPathRawResult {
+	const prefix = "file://"
+	if !strings.HasPrefix(uri, prefix) {
+		return LSPFileURIPathRawResult{}
+	}
+	path := strings.TrimPrefix(uri, prefix)
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return LSPFileURIPathRawResult{OK: true, Path: path}
+}
+
+func LSPServerName() string {
+	return "osty-lsp"
+}
+
+func LSPServerVersion() string {
+	return "0.1.0"
+}
+
+func LSPPositionEncodingUTF16() string {
+	return "utf-16"
+}
+
+func LSPJSONNull() string {
+	return "null"
+}
+
+func LSPCompletionTriggerDot() string {
+	return "."
+}
+
+func LSPSignatureTriggerOpenParen() string {
+	return "("
+}
+
+func LSPSignatureTriggerComma() string {
+	return ","
+}
+
+func LSPSemanticTokenTypes() []string {
+	return []string{
+		"namespace",
+		"type",
+		"parameter",
+		"variable",
+		"property",
+		"function",
+		"keyword",
+		"string",
+		"number",
+		"operator",
+		"comment",
+		"enumMember",
+	}
+}
+
+func LSPSemanticTokenModifiers() []string {
+	return []string{"declaration", "readonly"}
+}
+
+func LSPDispatchActionInitialize() string { return "initialize" }
+func LSPDispatchActionExit() string       { return "exit" }
+func LSPDispatchActionShutdown() string   { return "shutdown" }
+func LSPDispatchActionIgnore() string     { return "ignore" }
+func LSPDispatchActionDispatch() string   { return "dispatch" }
+func LSPDispatchActionError() string      { return "error" }
+func LSPErrInvalidRequest() int           { return -32600 }
+func LSPErrMethodNotFound() int           { return -32601 }
+func LSPErrServerNotInitialized() int     { return -32002 }
+
+func LSPAsciiLowerText(text string) string {
+	return strings.ToLower(text)
+}
+
+func LSPNameMatchesPrefix(name, prefix string) bool {
+	return prefix == "" || strings.HasPrefix(name, prefix)
+}
+
+func LSPNameMatchesQuery(name, query string) bool {
+	return query == "" || strings.Contains(strings.ToLower(name), query)
+}
+
+func LSPURIForSourcePath(path string) string {
+	if strings.Contains(path, ":") && !strings.HasPrefix(path, "/") {
+		return path
+	}
+	return LSPPathToURI(path)
+}
+
+func LSPPreferAIRepairFixAll(source string) bool {
+	return strings.Contains(source, ".length")
+}
+
+func LSPTextChanged(original, replacement string) bool {
+	return original != replacement
+}
+
+func LSPParamsAreEmpty(paramsText string) bool {
+	return paramsText == "" || paramsText == "null"
+}
+
+func LSPRenameEmptyNameMessage() string {
+	return "new name is empty"
+}
+
+func LSPCannotRenameBuiltinMessage() string {
+	return "cannot rename a builtin"
+}
+
+func LSPCanRenameKind(kind string) bool {
+	return kind != "builtin"
+}
+
+func LSPRenameTitle(name string) string {
+	return "Rename to `" + name + "`"
+}
+
+func LSPRemoveLineTitle() string {
+	return "Remove unused import"
+}
+
+func LSPFixAllTitle() string {
+	return "Fix all auto-fixable problems"
+}
+
+func LSPOrganizeImportsTitle() string {
+	return "Organize imports"
+}
+
+func LSPInlayTypeLabel(typeText string) string {
+	return ": " + typeText
+}
+
+func LSPMethodNotImplementedMessage(method string) string {
+	return "method not implemented: " + method
+}
+
+func LSPIsOstySourceFileName(name string) bool {
+	return strings.HasSuffix(name, ".osty") && !strings.HasSuffix(name, "_test.osty")
+}
+
+func LSPHasOstyFileExtension(name string) bool {
+	return strings.HasSuffix(name, ".osty")
+}
+
+func LSPExitCode(shutdown bool) int {
+	if shutdown {
+		return 0
+	}
+	return 1
+}
+
+func LSPDispatchDecisionFor(method string, isNotification bool, initialized bool, shutdown bool) LSPDispatchDecision {
+	if method == "initialize" {
+		return LSPDispatchDecision{Action: LSPDispatchActionInitialize()}
+	}
+	if method == "exit" {
+		return LSPDispatchDecision{Action: LSPDispatchActionExit()}
+	}
+	if !initialized {
+		if isNotification {
+			return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+		}
+		return LSPDispatchDecision{
+			Action:       LSPDispatchActionError(),
+			ErrorCode:    LSPErrServerNotInitialized(),
+			ErrorMessage: "server has not been initialized",
+		}
+	}
+	if shutdown {
+		if isNotification {
+			return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+		}
+		return LSPDispatchDecision{
+			Action:       LSPDispatchActionError(),
+			ErrorCode:    LSPErrInvalidRequest(),
+			ErrorMessage: "server is shutting down",
+		}
+	}
+	if method == "initialized" {
+		return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+	}
+	if method == "shutdown" {
+		return LSPDispatchDecision{Action: LSPDispatchActionShutdown()}
+	}
+	if lspMethodIsHandled(method) {
+		return LSPDispatchDecision{Action: LSPDispatchActionDispatch()}
+	}
+	if isNotification {
+		return LSPDispatchDecision{Action: LSPDispatchActionIgnore()}
+	}
+	return LSPDispatchDecision{
+		Action:       LSPDispatchActionError(),
+		ErrorCode:    LSPErrMethodNotFound(),
+		ErrorMessage: LSPMethodNotImplementedMessage(method),
+	}
+}
+
 func LSPLineStarts(source string) []int {
 	unitStarts := lspLineStarts(source)
 	byteOffsets := stringUnitByteOffsets(source)
@@ -181,6 +478,36 @@ func LSPOstyPositionToLSP(source string, lineStarts []int, ostyLine, byteOffset 
 		Line:      pos.line,
 		Character: pos.character,
 	}
+}
+
+func LSPFrameHeader(bodyLength int) string {
+	return "Content-Length: " + strconv.Itoa(bodyLength) + "\r\n\r\n"
+}
+
+func LSPTrimHeaderLine(line string) string {
+	return strings.TrimRight(line, "\r\n")
+}
+
+func LSPParseHeaderLines(lines []string) LSPHeaderParseResult {
+	if len(lines) == 0 {
+		return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: empty header block"}
+	}
+	length := -1
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: malformed header " + line}
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || n < 0 {
+				return LSPHeaderParseResult{ContentLength: -1, Error: "lsp: invalid Content-Length " + strings.TrimSpace(value)}
+			}
+			length = n
+		}
+	}
+	return LSPHeaderParseResult{OK: true, ContentLength: length}
 }
 
 func LSPLSPPositionToOsty(source string, lineStarts []int, lspLine, character int) LSPOstyPosition {
@@ -252,6 +579,25 @@ func LSPRangeFromOstySpan(
 	}
 }
 
+func LSPFullDocumentRange(source string, lineStarts []int) LSPFullDocumentRangeResult {
+	endLine := 0
+	lastLineStart := 0
+	if len(lineStarts) > 0 {
+		endLine = len(lineStarts) - 1
+		lastLineStart = lineStarts[len(lineStarts)-1]
+	}
+	if lastLineStart < 0 {
+		lastLineStart = 0
+	}
+	if lastLineStart > len(source) {
+		lastLineStart = len(source)
+	}
+	return LSPFullDocumentRangeResult{
+		EndLine:      endLine,
+		EndCharacter: LSPUTF16UnitsInPrefix(source[lastLineStart:]),
+	}
+}
+
 func LSPSymbolKindForDecl(kind string, mutable bool) int {
 	return lspSymbolKindForDecl(kind, mutable)
 }
@@ -307,12 +653,134 @@ func LSPSpanOverlaps(startOffset, endOffset, queryStart, queryEnd int) bool {
 	return lspSpanOverlaps(startOffset, endOffset, queryStart, queryEnd)
 }
 
+func LSPNamedTypeReferenceEndOffset(startOffset, sourceLength, targetNameLength int, firstPathMatchesTarget bool, firstPathLength int) int {
+	width := targetNameLength
+	if firstPathMatchesTarget {
+		width = firstPathLength
+	}
+	endOffset := startOffset + width
+	if endOffset > sourceLength {
+		endOffset = sourceLength
+	}
+	return endOffset
+}
+
 func LSPDiagnosticPayloadFor(severity, message, hint string, notes []string) LSPDiagnosticPayload {
 	payload := lspDiagnosticPayload(severity, message, hint, notes)
 	return LSPDiagnosticPayload{
 		Severity: payload.severity,
 		Message:  payload.message,
 	}
+}
+
+func LSPDiagnosticsEqual(a, b []LSPDiagnosticView) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func LSPDiagnosticBelongsToFile(fact LSPDiagnosticFileFact) bool {
+	if fact.DiagnosticFile != "" {
+		return fact.DiagnosticFile == fact.PackageFile
+	}
+	if fact.SpanSourceFileID != "" && fact.PackageSourceFileID != "" {
+		return fact.SpanSourceFileID == fact.PackageSourceFileID
+	}
+	if fact.PrimaryLine == 0 {
+		return false
+	}
+	return fact.PrimaryOffset <= fact.SourceLength
+}
+
+func LSPLevenshteinBounded(a, b string, limit int) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if absInt(len(ar)-len(br)) > limit {
+		return limit + 1
+	}
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		rowMin := curr[0]
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			curr[j] = minInt(
+				prev[j]+1,
+				curr[j-1]+1,
+				prev[j-1]+cost,
+			)
+			if curr[j] < rowMin {
+				rowMin = curr[j]
+			}
+		}
+		if rowMin > limit {
+			return limit + 1
+		}
+		prev, curr = curr, prev
+	}
+	if prev[len(br)] > limit {
+		return limit + 1
+	}
+	return prev[len(br)]
+}
+
+func LSPRankNearbyNames(names []string, target string, maxDistance int) []string {
+	type candidate struct {
+		name string
+		dist int
+	}
+	seen := map[string]bool{}
+	candidates := make([]candidate, 0, len(names))
+	for _, name := range names {
+		if name == "" || seen[name] {
+			continue
+		}
+		dist := LSPLevenshteinBounded(target, name, maxDistance)
+		if dist > maxDistance {
+			continue
+		}
+		seen[name] = true
+		candidates = append(candidates, candidate{name: name, dist: dist})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].dist != candidates[j].dist {
+			return candidates[i].dist < candidates[j].dist
+		}
+		return candidates[i].name < candidates[j].name
+	})
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+func LSPMergeNearbyNames(primary []string, fallback []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(primary)+len(fallback))
+	for _, group := range [][]string{primary, fallback} {
+		for _, name := range group {
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
@@ -343,6 +811,120 @@ func SortDedupLSPLocations(locs []LSPLocation) []LSPLocation {
 	return out
 }
 
+func LSPLocationsForTarget(refs []LSPReferenceFact, symbols []LSPSymbolFact, targetID string, includeDecl bool) []LSPLocation {
+	if targetID == "" {
+		return nil
+	}
+	out := make([]LSPLocation, 0, len(refs)+1)
+	var fallbackDecl *LSPLocation
+	for _, ref := range refs {
+		if ref.TargetSymbolID != targetID {
+			continue
+		}
+		out = append(out, LSPLocation{
+			URI:            ref.URI,
+			StartLine:      ref.StartLine,
+			StartCharacter: ref.StartCharacter,
+			EndLine:        ref.EndLine,
+			EndCharacter:   ref.EndCharacter,
+		})
+		if fallbackDecl == nil && ref.TargetURI != "" && !ref.Builtin {
+			fallbackDecl = &LSPLocation{
+				URI:            ref.TargetURI,
+				StartLine:      ref.TargetStartLine,
+				StartCharacter: ref.TargetStartCharacter,
+				EndLine:        ref.TargetEndLine,
+				EndCharacter:   ref.TargetEndCharacter,
+			}
+		}
+	}
+	if includeDecl {
+		haveSymbolDecl := false
+		for _, sym := range symbols {
+			if sym.ID != targetID {
+				continue
+			}
+			out = append(out, LSPLocation{
+				URI:            sym.URI,
+				StartLine:      sym.StartLine,
+				StartCharacter: sym.StartCharacter,
+				EndLine:        sym.EndLine,
+				EndCharacter:   sym.EndCharacter,
+			})
+			haveSymbolDecl = true
+			break
+		}
+		if !haveSymbolDecl && fallbackDecl != nil {
+			out = append(out, *fallbackDecl)
+		}
+	}
+	return SortDedupLSPLocations(out)
+}
+
+func LSPCompletionItemForSymbolView(view LSPSymbolView) LSPCompletionItemData {
+	detail := ""
+	if view.TypeText != "" {
+		detail = LSPCompletionDetail(view.Kind, view.Name, view.TypeText)
+	}
+	return LSPCompletionItemData{
+		Label:         view.Name,
+		Kind:          LSPCompletionKindForSymbolKind(view.Kind),
+		SortText:      LSPCompletionSortTextForSymbolKind(view.Kind, view.Name),
+		Detail:        detail,
+		Documentation: view.DocText,
+	}
+}
+
+func LSPCompletionItemsForCandidates(candidates []LSPCompletionCandidateView, prefix string) []LSPCompletionItemData {
+	seen := map[string]bool{}
+	items := make([]LSPCompletionItemData, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !candidate.Include || candidate.Name == "" {
+			continue
+		}
+		if seen[candidate.Name] {
+			continue
+		}
+		if !LSPNameMatchesPrefix(candidate.Name, prefix) {
+			continue
+		}
+		seen[candidate.Name] = true
+		items = append(items, LSPCompletionItemForSymbolView(LSPSymbolView{
+			Name:     candidate.Name,
+			Kind:     candidate.Kind,
+			TypeText: candidate.TypeText,
+			DocText:  candidate.DocText,
+			HasSym:   true,
+		}))
+	}
+	labels := make([]string, 0, len(items))
+	for _, item := range items {
+		labels = append(labels, item.Label)
+	}
+	order := SortLSPStringIndexes(labels)
+	out := make([]LSPCompletionItemData, 0, len(order))
+	for _, idx := range order {
+		if idx < 0 || idx >= len(items) {
+			continue
+		}
+		out = append(out, items[idx])
+	}
+	return out
+}
+
+func LSPSemanticHoverKind(kind string) string {
+	switch kind {
+	case "fn":
+		return "function"
+	case "value":
+		return "binding"
+	case "generic":
+		return "type parameter"
+	default:
+		return kind
+	}
+}
+
 func SortLSPSymbolIndexes(keys []LSPSymbolSortKey) []int {
 	tagged := make([]*LspSymbolSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -362,6 +944,28 @@ func SortLSPCompletionIndexes(labels []string) []int {
 	return SortLSPSymbolIndexes(keys)
 }
 
+func SortLSPStringIndexes(values []string) []int {
+	type indexedString struct {
+		value string
+		index int
+	}
+	tagged := make([]indexedString, 0, len(values))
+	for idx, value := range values {
+		tagged = append(tagged, indexedString{value: value, index: idx})
+	}
+	sort.Slice(tagged, func(i, j int) bool {
+		if tagged[i].value != tagged[j].value {
+			return tagged[i].value < tagged[j].value
+		}
+		return tagged[i].index < tagged[j].index
+	})
+	out := make([]int, 0, len(tagged))
+	for _, item := range tagged {
+		out = append(out, item.index)
+	}
+	return out
+}
+
 func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 	tagged := make([]*LspImportSortKey, 0, len(keys))
 	for _, key := range keys {
@@ -372,6 +976,48 @@ func SortLSPImportIndexes(keys []LSPImportSortKey) []int {
 		})
 	}
 	return lspSortImportIndexes(tagged)
+}
+
+func LSPOrganizedUseBlock(entries []LSPOrganizeUseEntry) string {
+	kept := make([]LSPOrganizeUseEntry, 0, len(entries))
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.Unused || entry.Text == "" {
+			continue
+		}
+		dedupKey := LSPKeyWithAlias(entry.Group, entry.Key, entry.Alias)
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		kept = append(kept, entry)
+	}
+	keys := make([]LSPImportSortKey, 0, len(kept))
+	for _, entry := range kept {
+		keys = append(keys, LSPImportSortKey{
+			Group: entry.Group,
+			Key:   entry.Key,
+			Alias: entry.Alias,
+		})
+	}
+	order := SortLSPImportIndexes(keys)
+	var b strings.Builder
+	prevGroup := -1
+	emitted := 0
+	for _, idx := range order {
+		if idx < 0 || idx >= len(kept) {
+			continue
+		}
+		entry := kept[idx]
+		if emitted > 0 && entry.Group != prevGroup {
+			b.WriteByte('\n')
+		}
+		b.WriteString(entry.Text)
+		b.WriteByte('\n')
+		prevGroup = entry.Group
+		emitted++
+	}
+	return b.String()
 }
 
 func LSPUseGroup(isGoFFI bool, path []string) int {
@@ -432,6 +1078,44 @@ func LSPBuildSignatureText(name string, params []LSPSignatureParam, returnType s
 		Label:           rendered.label,
 		ParameterLabels: append([]string(nil), rendered.parameterLabels...),
 	}
+}
+
+func LSPParseFunctionType(typeText string) LSPFunctionTypeParts {
+	rest := strings.TrimSpace(typeText)
+	if !strings.HasPrefix(rest, "fn") {
+		return LSPFunctionTypeParts{}
+	}
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "fn"))
+	if !strings.HasPrefix(rest, "(") {
+		return LSPFunctionTypeParts{}
+	}
+	closeIdx := matchingCloseParen(rest)
+	if closeIdx < 0 {
+		return LSPFunctionTypeParts{}
+	}
+	paramsText := strings.TrimSpace(rest[1:closeIdx])
+	var params []string
+	if paramsText != "" {
+		params = splitTopLevelComma(paramsText)
+	}
+	returnType := ""
+	tail := strings.TrimSpace(rest[closeIdx+1:])
+	if strings.HasPrefix(tail, "->") {
+		returnType = strings.TrimSpace(strings.TrimPrefix(tail, "->"))
+	}
+	return LSPFunctionTypeParts{
+		OK:             true,
+		ParameterTypes: params,
+		ReturnType:     returnType,
+	}
+}
+
+func LSPFallbackParameterNames(count int) []string {
+	names := make([]string, count)
+	for i := range names {
+		names[i] = "arg" + strconv.Itoa(i+1)
+	}
+	return names
 }
 
 func EncodeLSPSemanticTokens(tokens []LSPSemanticToken) []int {
@@ -531,4 +1215,87 @@ func unitOffsetToByteOffset(byteOffsets []int, unitOffset int) int {
 		return byteOffsets[last]
 	}
 	return byteOffsets[unitOffset]
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func minInt(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		return c
+	}
+	return a
+}
+
+func matchingCloseParen(s string) int {
+	depth := 0
+	for i, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func splitTopLevelComma(s string) []string {
+	var out []string
+	start := 0
+	depth := 0
+	for i, r := range s {
+		switch r {
+		case '(', '[', '<':
+			depth++
+		case ')', ']', '>':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				if part := strings.TrimSpace(s[start:i]); part != "" {
+					out = append(out, part)
+				}
+				start = i + len(string(r))
+			}
+		}
+	}
+	if part := strings.TrimSpace(s[start:]); part != "" {
+		out = append(out, part)
+	}
+	return out
+}
+
+func lspMethodIsHandled(method string) bool {
+	switch method {
+	case "textDocument/didOpen",
+		"textDocument/didChange",
+		"textDocument/didClose",
+		"textDocument/hover",
+		"textDocument/definition",
+		"textDocument/formatting",
+		"textDocument/documentSymbol",
+		"textDocument/completion",
+		"textDocument/references",
+		"textDocument/rename",
+		"textDocument/signatureHelp",
+		"workspace/symbol",
+		"textDocument/inlayHint",
+		"textDocument/semanticTokens/full",
+		"textDocument/codeAction":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/stdlib/db_test.go
+++ b/internal/stdlib/db_test.go
@@ -70,3 +70,209 @@ func TestDbModuleSourcePinsNonExecutingBehavior(t *testing.T) {
 		}
 	}
 }
+
+func TestDbSqliteModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_sqlite"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.sqlite not loaded")
+	}
+	for _, name := range []string{
+		"driverFactory", "open", "openPool",
+		"pragma", "libVersion", "enableWal",
+		"tables", "tableInfo", "execScript",
+		"backup", "restore", "vacuum",
+		"setBusyTimeout", "lastInsertRowId", "changes", "totalChanges", "interrupt",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.sqlite missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.sqlite.%s not public", name)
+		}
+	}
+}
+
+func TestDbDriverModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_driver"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.driver not loaded")
+	}
+	for _, name := range []string{
+		"newDriverRegistry", "registerDriver", "lookupDriver", "registeredDrivers",
+		"defaultConnectionOptions", "defaultQueryOptions", "defaultIsolationLevel",
+		"ConnectionOptions", "QueryOptions", "DriverRegistry", "IsolationLevel",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.driver missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.driver.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"Driver", "Connection", "Transaction", "Pool", "DriverFactory",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.driver missing interface %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.driver.%s not public", name)
+		}
+	}
+}
+
+func TestDbPoolModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_pool"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.pool not loaded")
+	}
+	for _, name := range []string{
+		"poolStats", "newPool", "acquire", "release", "closePool",
+		"stats", "reset", "ping",
+		"setMaxOpen", "setMaxIdle", "setConnectTimeout", "setIdleTimeout",
+		"prune",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.pool missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.pool.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"PoolStats",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.pool missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.pool.%s not public", name)
+		}
+	}
+}
+
+func TestDbMigrationModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_migration"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.migration not loaded")
+	}
+	for _, name := range []string{
+		"migrationStatus", "migrationReport",
+		"ensureMigrationTable", "appliedVersions", "currentVersion",
+		"apply", "rollbackLast", "rollbackN", "rollbackTo",
+		"status", "redo", "reset", "forceVersion",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.migration missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.migration.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"MigrationStatus", "MigrationReport",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.migration missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.migration.%s not public", name)
+		}
+	}
+}
+
+func TestDbOrmModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_orm"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.orm not loaded")
+	}
+	for _, name := range []string{
+		"columnDef", "relationDef", "modelDef",
+		"registerModel", "lookupModel", "registeredModels",
+		"insert", "findByPk", "findBy", "update", "delete", "save",
+		"insertMany", "deleteBy", "truncate",
+		"selectAll", "selectColumns", "selectByPk", "selectWhere",
+		"whereClause", "orderBy", "limitOffset",
+		"related", "eagerLoad",
+		"withTx", "txExec",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.orm missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.orm.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"ColumnDef", "RelationKind", "RelationDef", "ModelDef",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.orm missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.orm.%s not public", name)
+		}
+	}
+}
+
+func TestDbPgModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_pg"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.pg not loaded")
+	}
+	for _, name := range []string{
+		"driverFactory", "open", "openPool",
+		"serverVersion", "backendPid",
+		"databases", "schemas", "tables", "tableInfo",
+		"execScript", "copyIn", "copyOut",
+		"prepare", "executePrepared", "preparedStatements",
+		"setConfig", "getConfig", "cancelQuery", "terminate",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.pg missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.pg.%s not public", name)
+		}
+	}
+}
+
+func TestDbMysqlModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["db_mysql"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.db.mysql not loaded")
+	}
+	for _, name := range []string{
+		"driverFactory", "open", "openPool",
+		"serverVersion", "connectionId",
+		"databases", "tables", "tableInfo", "tableStatus",
+		"execScript",
+		"prepare", "executePrepared", "preparedStatements",
+		"setSession", "getSession", "killConnection", "ping",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.db.mysql missing export %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.db.mysql.%s not public", name)
+		}
+	}
+}

--- a/internal/stdlib/gql_client_test.go
+++ b/internal/stdlib/gql_client_test.go
@@ -1,0 +1,65 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestGqlClientModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["gql_client"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.gql.client not loaded")
+	}
+	for _, name := range []string{
+		"execute", "executeWithHeaders", "executeJson",
+		"query", "mutate",
+		"subscribe", "subscribeWithVars", "nextEvent", "unsubscribe",
+		"parseData",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.gql.client missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.gql.client.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.gql.client.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"Subscription",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.gql.client missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.gql.client.%s not public", name)
+		}
+	}
+}
+
+func TestGqlClientModuleSourcePinsNonExecutingBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["gql_client"]
+	if mod == nil {
+		t.Fatal("std.gql.client module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn execute(endpoint: String, request: graphql.Request) -> Result<http.Response, Error>`,
+		`pub fn executeWithHeaders(endpoint: String, request: graphql.Request, headers: http.Headers) -> Result<http.Response, Error>`,
+		`pub fn subscribe(endpoint: String, queryDoc: String) -> Result<Subscription, Error>`,
+		`pub fn nextEvent(sub: Subscription) -> Result<String?, Error>`,
+		`pub fn parseData(responseBody: String) -> Result<String, Error>`,
+		`Subscription`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.gql.client source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/http_middleware_test.go
+++ b/internal/stdlib/http_middleware_test.go
@@ -1,0 +1,69 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestHttpMiddlewareModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["http_middleware"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.http.middleware not loaded")
+	}
+	for _, name := range []string{
+		"defaultRetryPolicy", "retry",
+		"newCircuitBreaker", "defaultCircuitBreaker", "circuitBreaker",
+		"newTokenBucket", "defaultTokenBucket", "rateLimit",
+		"chain",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.http.middleware missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.http.middleware.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.http.middleware.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"RetryPolicy", "CircuitState", "CircuitBreaker", "TokenBucket",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.http.middleware missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.http.middleware.%s not public", name)
+		}
+	}
+}
+
+func TestHttpMiddlewareModuleSourcePinsNonExecutingBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["http_middleware"]
+	if mod == nil {
+		t.Fatal("std.http.middleware module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`RetryPolicy`,
+		`maxAttempts: 3`,
+		`baseDelayMs: 200`,
+		`CircuitBreaker`,
+		`newCircuitBreaker(5, 30_000)`,
+		`TokenBucket`,
+		`newTokenBucket(100, 10, 1_000)`,
+		`pub fn circuitBreaker(cb: CircuitBreaker, next: http.Handler) -> http.Handler`,
+		`pub fn rateLimit(bucket: TokenBucket, next: http.Handler) -> http.Handler`,
+		`pub fn chain(middlewares: List<fn(http.Handler) -> http.Handler>, finalHandler: http.Handler) -> http.Handler`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.http.middleware source missing %q", want)
+		}
+	}
+}

--- a/internal/stdlib/modules/db_driver.osty
+++ b/internal/stdlib/modules/db_driver.osty
@@ -1,0 +1,177 @@
+// std.db.driver - database driver interface for runtime implementations
+//
+// This module defines the interface that runtime database drivers must implement.
+// It provides a contract for opening connections, executing queries,
+// and managing transactions.
+//
+// Drivers are expected to be implemented in native code (Go, Rust, etc.)
+// and exposed to Osty via FFI. This interface allows Osty code to
+// work with any database that implements this contract.
+
+use std.db
+use std.sql
+use std.error
+
+/// Driver is the interface that all database drivers must implement.
+/// It provides methods for opening connections and managing lifecycle.
+pub interface Driver {
+    /// Opens a new database connection using the provided configuration.
+    /// Returns a Connection handle or an error if the connection cannot be established.
+    fn open(self, config: db.Config) -> Result<Connection, Error>
+
+    /// Closes the driver and releases any resources.
+    /// After calling close, all connections obtained from this driver
+    /// should be considered invalid.
+    fn close(self) -> Result<(), Error>
+}
+
+/// Connection represents a single database connection.
+/// It provides methods for executing queries and managing transactions.
+pub interface Connection {
+    /// Executes a query that returns rows (SELECT, etc.)
+    /// Returns a ResultSet containing the columns and rows.
+    fn query(self, query: sql.Query) -> Result<db.ResultSet, Error>
+
+    /// Executes a query that does not return rows (INSERT, UPDATE, DELETE, etc.)
+    /// Returns an ExecResult with rows affected and last insert ID.
+    fn exec(self, query: sql.Query) -> Result<db.ExecResult, Error>
+
+    /// Begins a new transaction with the specified options.
+    /// Returns a Transaction handle that can be committed or rolled back.
+    fn beginTx(self, options: db.TxOptions) -> Result<Transaction, Error>
+
+    /// Closes the connection and releases it back to the pool or driver.
+    fn close(self) -> Result<(), Error>
+
+    /// Returns the underlying driver that created this connection.
+    fn driver(self) -> Driver
+}
+
+/// Transaction represents a database transaction.
+/// It provides the same query execution methods as Connection,
+/// but all operations are scoped to the transaction.
+pub interface Transaction {
+    /// Executes a query that returns rows within the transaction.
+    fn query(self, query: sql.Query) -> Result<db.ResultSet, Error>
+
+    /// Executes a query that does not return rows within the transaction.
+    fn exec(self, query: sql.Query) -> Result<db.ExecResult, Error>
+
+    /// Commits the transaction, making all changes permanent.
+    fn commit(self) -> Result<(), Error>
+
+    /// Rolls back the transaction, undoing all changes.
+    fn rollback(self) -> Result<(), Error>
+
+    /// Returns the underlying connection for this transaction.
+    fn connection(self) -> Connection
+}
+
+/// Pool represents a connection pool for managing multiple database connections.
+/// It provides methods for acquiring and releasing connections.
+pub interface Pool {
+    /// Acquires a connection from the pool.
+    /// Blocks until a connection is available or the timeout expires.
+    fn acquire(self) -> Result<Connection, Error>
+
+    /// Releases a connection back to the pool.
+    /// The connection should be in a valid state when released.
+    fn release(self, conn: Connection) -> Result<(), Error>
+
+    /// Closes all connections in the pool and releases resources.
+    fn close(self) -> Result<(), Error>
+
+    /// Returns the configuration used to create this pool.
+    fn config(self) -> db.Config
+
+    /// Returns the pool options used to create this pool.
+    fn options(self) -> db.PoolOptions
+}
+
+/// DriverFactory is a factory interface for creating drivers and pools.
+/// It allows the std.db module to create driver instances
+/// without knowing the concrete implementation.
+pub interface DriverFactory {
+    /// Creates a new driver instance.
+    fn createDriver(self) -> Result<Driver, Error>
+
+    /// Creates a new connection pool with the specified configuration and options.
+    fn createPool(self, config: db.Config, options: db.PoolOptions) -> Result<Pool, Error>
+
+    /// Returns the driver type this factory creates.
+    fn driverType(self) -> db.Driver
+}
+
+/// DriverRegistry is a registry for available database drivers.
+/// It allows registering and looking up drivers by name.
+pub struct DriverRegistry {
+    pub drivers: Map<String, DriverFactory>,
+}
+
+/// Creates a new empty driver registry.
+pub fn newDriverRegistry() -> DriverRegistry {
+    DriverRegistry {
+        drivers: {:},
+    }
+}
+
+/// Registers a driver factory with the given name.
+pub fn registerDriver(mut registry: DriverRegistry, name: String, factory: DriverFactory) -> Result<DriverRegistry, Error> {
+    if registry.drivers.contains(name) {
+        return Err(error.new("db.driver: driver {name} already registered"))
+    }
+    registry.drivers.insert(name, factory)
+    Ok(registry)
+}
+
+/// Looks up a driver factory by name.
+pub fn lookupDriver(registry: DriverRegistry, name: String) -> Result<DriverFactory, Error> {
+    match registry.drivers.get(name) {
+        Some(factory) -> Ok(factory),
+        None -> Err(error.new("db.driver: driver {name} not found")),
+    }
+}
+
+/// Returns a list of all registered driver names.
+pub fn registeredDrivers(registry: DriverRegistry) -> List<String> {
+    registry.drivers.keys().toList()
+}
+
+/// ConnectionOptions provides additional options for opening a connection.
+pub struct ConnectionOptions {
+    pub readOnly: Bool,
+    pub timeoutMs: Int,
+}
+
+/// Creates default connection options.
+pub fn defaultConnectionOptions() -> ConnectionOptions {
+    ConnectionOptions {
+        readOnly: false,
+        timeoutMs: 30000,
+    }
+}
+
+/// QueryOptions provides additional options for executing queries.
+pub struct QueryOptions {
+    pub timeoutMs: Int,
+}
+
+/// Creates default query options.
+pub fn defaultQueryOptions() -> QueryOptions {
+    QueryOptions {
+        timeoutMs: 30000,
+    }
+}
+
+/// IsolationLevel represents transaction isolation levels.
+/// This is a convenience alias for db.Isolation.
+pub type IsolationLevel = db.Isolation
+
+/// Returns the default isolation level for a driver.
+pub fn defaultIsolationLevel(driver: db.Driver) -> IsolationLevel {
+    match driver {
+        db.Sqlite   -> db.ReadCommitted,
+        db.Postgres -> db.ReadCommitted,
+        db.MySql    -> db.ReadCommitted,
+    }
+}

--- a/internal/stdlib/modules/db_migration.osty
+++ b/internal/stdlib/modules/db_migration.osty
@@ -1,0 +1,79 @@
+// std.db.migration — database migration runner.
+//
+// Body-less signature stubs: the backend lowers each call to the runtime
+// migration engine (version tracking, apply, rollback, status, etc.).
+//
+// The data types Migration and MigrationPlan live in std.db; this module
+// provides the runtime operations that actually execute SQL against a
+// connection pool or driver connection.
+
+use std.db
+use std.db.driver
+use std.error
+
+/// MigrationStatus tracks the state of a single migration.
+pub struct MigrationStatus {
+    pub version: Int,
+    pub name: String,
+    pub appliedAt: String?,
+    pub success: Bool,
+    pub errorMessage: String?,
+}
+
+/// MigrationReport summarises the result of a migration run.
+pub struct MigrationReport {
+    pub applied: List<MigrationStatus>,
+    pub rolledBack: List<MigrationStatus>,
+    pub failed: List<MigrationStatus>,
+    pub currentVersion: Int,
+    pub targetVersion: Int,
+}
+
+/// Returns a zero-initialised MigrationStatus value.
+pub fn migrationStatus(version: Int, name: String) -> MigrationStatus
+
+/// Returns a zero-initialised MigrationReport value.
+pub fn migrationReport() -> MigrationReport
+
+/// Ensures the schema_migrations tracking table exists.
+pub fn ensureMigrationTable(pool: driver.Pool) -> Result<(), Error>
+
+/// Returns the list of already-applied migration versions from the database.
+pub fn appliedVersions(pool: driver.Pool) -> Result<List<Int>, Error>
+
+/// Returns the current schema version (max applied version, or 0).
+pub fn currentVersion(pool: driver.Pool) -> Result<Int, Error>
+
+/// Applies all pending migrations from the given list.
+///
+/// Each migration is executed inside its own transaction.  On failure the
+/// failed migration is recorded in the report and remaining migrations are
+/// skipped unless rollbackOnError is true.
+pub fn apply(pool: driver.Pool, migrations: List<db.Migration>, rollbackOnError: Bool) -> Result<MigrationReport, Error>
+
+/// Rolls back the most recent applied migration.
+pub fn rollbackLast(pool: driver.Pool, migrations: List<db.Migration>) -> Result<MigrationReport, Error>
+
+/// Rolls back N most recent applied migrations.
+pub fn rollbackN(pool: driver.Pool, migrations: List<db.Migration>, n: Int) -> Result<MigrationReport, Error>
+
+/// Rolls back to the target version (inclusive).  All migrations with a
+/// version greater than target are rolled back in reverse order.
+pub fn rollbackTo(pool: driver.Pool, migrations: List<db.Migration>, targetVersion: Int) -> Result<MigrationReport, Error>
+
+/// Prints the current migration status for all given migrations.
+///
+/// Returns a list of MigrationStatus values indicating which migrations
+/// have been applied and which are pending.
+pub fn status(pool: driver.Pool, migrations: List<db.Migration>) -> Result<List<MigrationStatus>, Error>
+
+/// Redoes the most recent migration (rollback then apply).
+pub fn redo(pool: driver.Pool, migrations: List<db.Migration>) -> Result<MigrationReport, Error>
+
+/// Resets the database: rolls back all applied migrations, then re-applies
+/// every migration from the beginning.
+pub fn reset(pool: driver.Pool, migrations: List<db.Migration>) -> Result<MigrationReport, Error>
+
+/// Forces the recorded schema version to a specific value without running
+/// any migration SQL.  Use with extreme caution.
+pub fn forceVersion(pool: driver.Pool, version: Int) -> Result<(), Error>

--- a/internal/stdlib/modules/db_mysql.osty
+++ b/internal/stdlib/modules/db_mysql.osty
@@ -1,0 +1,63 @@
+// std.db.mysql — MySQL database driver.
+//
+// Body-less signature stubs: the backend lowers each call to the runtime
+// MySQL driver (native protocol implementation).
+//
+// Connection configuration is provided via db.Config (Driver=MySql).
+// The runtime handles SSL/TLS, authentication (mysql_native_password,
+// caching_sha2_password), and prepared statements.
+
+use std.db
+use std.db.driver
+use std.error
+
+/// Returns a DriverFactory for the MySQL driver.
+pub fn driverFactory() -> driver.DriverFactory
+
+/// Opens a single connection to a MySQL database.
+pub fn open(config: db.Config) -> Result<driver.Connection, Error>
+
+/// Creates a connection pool for a MySQL database.
+pub fn openPool(config: db.Config, options: db.PoolOptions) -> Result<driver.Pool, Error>
+
+/// Returns the version string of the connected MySQL server.
+pub fn serverVersion(conn: driver.Connection) -> Result<String, Error>
+
+/// Returns the connection ID assigned by the server.
+pub fn connectionId(conn: driver.Connection) -> Int
+
+/// Lists all databases on the server.
+pub fn databases(conn: driver.Connection) -> Result<db.ResultSet, Error>
+
+/// Lists all tables in the current or named database.
+pub fn tables(conn: driver.Connection, database: String) -> Result<db.ResultSet, Error>
+
+/// Returns column metadata for a table.
+pub fn tableInfo(conn: driver.Connection, database: String, table: String) -> Result<db.ResultSet, Error>
+
+/// Returns the table status (engine, row count, size, etc.).
+pub fn tableStatus(conn: driver.Connection, database: String) -> Result<db.ResultSet, Error>
+
+/// Executes a script containing multiple SQL statements.
+pub fn execScript(conn: driver.Connection, script: String) -> Result<db.ExecResult, Error>
+
+/// Creates a named prepared statement.
+pub fn prepare(conn: driver.Connection, name: String, sql: String) -> Result<(), Error>
+
+/// Executes a named prepared statement with the given parameters.
+pub fn executePrepared(conn: driver.Connection, name: String, params: List<db.Cell>) -> Result<db.ResultSet, Error>
+
+/// Lists all prepared statements on the connection.
+pub fn preparedStatements(conn: driver.Connection) -> Result<List<String>, Error>
+
+/// Sets a session variable.
+pub fn setSession(conn: driver.Connection, variable: String, value: String) -> Result<(), Error>
+
+/// Gets a session variable value.
+pub fn getSession(conn: driver.Connection, variable: String) -> Result<String, Error>
+
+/// Kills the given connection ID.
+pub fn killConnection(conn: driver.Connection, killConnId: Int) -> Result<(), Error>
+
+/// Pings the server to check if the connection is alive.
+pub fn ping(conn: driver.Connection) -> Bool

--- a/internal/stdlib/modules/db_orm.osty
+++ b/internal/stdlib/modules/db_orm.osty
@@ -1,0 +1,169 @@
+// std.db.orm — lightweight object-relational mapping.
+//
+// Body-less signature stubs: the backend lowers each call to the runtime
+// ORM engine (model registry, CRUD, relationship hydration).
+//
+// This module builds on std.db, std.db.driver, and std.sql to provide a
+// thin, opt-in ORM layer.  Models are described declaratively and the
+// runtime handles SQL generation, result-set mapping, and relationship
+// prefetching.
+
+use std.db
+use std.db.driver
+use std.sql
+use std.error
+
+// ── Metadata ────────────────────────────────────────────────────────────────
+
+/// Column metadata for a model field.
+pub struct ColumnDef {
+    pub name: String,
+    pub field: String,
+    pub primaryKey: Bool,
+    pub autoIncrement: Bool,
+    pub nullable: Bool,
+    pub unique: Bool,
+    pub columnType: String,
+    pub defaultExpr: String?,
+}
+
+/// Relationship kind.
+pub enum RelationKind {
+    HasOne,
+    HasMany,
+    BelongsTo,
+    ManyToMany,
+}
+
+/// Relationship metadata.
+pub struct RelationDef {
+    pub kind: RelationKind,
+    pub localField: String,
+    pub foreignModel: String,
+    pub foreignKey: String,
+    pub referenceKey: String,
+    pub joinTable: String?,
+}
+
+/// Model descriptor — maps a logical entity to a database table.
+pub struct ModelDef {
+    pub tableName: String,
+    pub columns: List<ColumnDef>,
+    pub primaryKeys: List<String>,
+    pub relations: List<RelationDef>,
+}
+
+/// Returns a zero-initialised ColumnDef.
+pub fn columnDef(name: String, field: String) -> ColumnDef
+
+/// Returns a zero-initialised RelationDef.
+pub fn relationDef(kind: RelationKind, localField: String, foreignModel: String) -> RelationDef
+
+/// Returns a zero-initialised ModelDef.
+pub fn modelDef(tableName: String, columns: List<ColumnDef>) -> ModelDef
+
+// ── Model Registry ──────────────────────────────────────────────────────────
+
+/// Registers a model definition so the runtime knows its schema.
+pub fn registerModel(model: ModelDef) -> Result<(), Error>
+
+/// Looks up a registered model by table name.
+pub fn lookupModel(tableName: String) -> Result<ModelDef, Error>
+
+/// Returns all registered model definitions.
+pub fn registeredModels() -> List<ModelDef>
+
+// ── CRUD — single-row ───────────────────────────────────────────────────────
+
+/// Inserts a row into the model's table.
+///
+/// values is a map of column name → Cell.  Returns the generated primary key
+/// value when autoIncrement is true.
+pub fn insert(pool: driver.Pool, tableName: String, values: Map<String, db.Cell>) -> Result<Int, Error>
+
+/// Finds a single row by primary key value.
+///
+/// Returns the row as a map of column name → Cell, or an error if not found.
+pub fn findByPk(pool: driver.Pool, tableName: String, pkValue: Int) -> Result<Map<String, db.Cell>, Error>
+
+/// Finds rows matching a simple equality condition.
+///
+/// column — column to filter; value — exact value to match.
+/// Returns a list of result rows.
+pub fn findBy(pool: driver.Pool, tableName: String, column: String, value: db.Cell) -> Result<List<Map<String, db.Cell>>, Error>
+
+/// Updates a row identified by its primary key.
+///
+/// values is a map of column → new cell value.  The primary key column
+/// is ignored if present.
+pub fn update(pool: driver.Pool, tableName: String, pkValue: Int, values: Map<String, db.Cell>) -> Result<(), Error>
+
+/// Deletes a row by primary key.
+pub fn delete(pool: driver.Pool, tableName: String, pkValue: Int) -> Result<(), Error>
+
+/// Saves (insert or update) a row.  If pkValue is 0 and the model has an
+/// auto-increment PK, an insert is performed.  Otherwise an update is
+/// attempted and falls back to insert.
+pub fn save(pool: driver.Pool, tableName: String, pkValue: Int, values: Map<String, db.Cell>) -> Result<Int, Error>
+
+// ── CRUD — batch ────────────────────────────────────────────────────────────
+
+/// Bulk inserts multiple rows in a single statement.
+pub fn insertMany(pool: driver.Pool, tableName: String, rows: List<Map<String, db.Cell>>) -> Result<Int, Error>
+
+/// Deletes all rows matching a simple equality condition.
+pub fn deleteBy(pool: driver.Pool, tableName: String, column: String, value: db.Cell) -> Result<Int, Error>
+
+/// Truncates the table (deletes all rows).
+pub fn truncate(pool: driver.Pool, tableName: String) -> Result<(), Error>
+
+// ── Query helpers ───────────────────────────────────────────────────────────
+
+/// Builds a SELECT query for all columns of the model.
+pub fn selectAll(model: ModelDef) -> sql.Query
+
+/// Builds a SELECT query scoped to the given columns.
+pub fn selectColumns(model: ModelDef, columns: List<String>) -> Result<sql.Query, Error>
+
+/// Builds a SELECT query with a WHERE clause on the primary key.
+pub fn selectByPk(model: ModelDef, pkValue: Int) -> sql.Query
+
+/// Builds a SELECT query with a simple equality WHERE clause.
+pub fn selectWhere(model: ModelDef, column: String, value: db.Cell) -> Result<sql.Query, Error>
+
+/// Appends a WHERE condition to an existing Query.
+pub fn whereClause(q: sql.Query, condition: sql.Condition) -> sql.Query
+
+/// Appends an ORDER BY clause.
+pub fn orderBy(q: sql.Query, orders: List<sql.Order>) -> Result<sql.Query, Error>
+
+/// Appends LIMIT and OFFSET.
+pub fn limitOffset(q: sql.Query, limit: Int, offset: Int) -> Result<sql.Query, Error>
+
+// ── Relationship queries ────────────────────────────────────────────────────
+
+/// Fetches related rows for a HasOne / HasMany relationship.
+///
+/// Given the parent row's primary key value, returns all child rows whose
+/// foreign key matches.
+pub fn related(pool: driver.Pool, parentModel: String, relation: RelationDef, parentPk: Int) -> Result<List<Map<String, db.Cell>>, Error>
+
+/// Eager-loads a single relationship for all parent rows at once.
+///
+/// Returns a map of parent PK → list of related child rows.
+pub fn eagerLoad(pool: driver.Pool, parentModel: String, relation: RelationDef, parentPks: List<Int>) -> Result<Map<Int, List<Map<String, db.Cell>>>, Error>
+
+// ── Transaction scoping ─────────────────────────────────────────────────────
+
+/// Executes a callback-like operation within a transaction.
+///
+/// callback takes a driver.Connection and returns Result<T, Error>.  If the
+/// callback returns an error the transaction is rolled back; otherwise
+/// it is committed.
+pub fn withTx(pool: driver.Pool, callback: fn(driver.Connection) -> Result<Map<String, db.Cell>, Error>) -> Result<Map<String, db.Cell>, Error>
+
+/// Executes a series of operations within a transaction.
+///
+/// Each query is executed in order.  If any query fails the transaction
+/// is rolled back.
+pub fn txExec(pool: driver.Pool, queries: List<sql.Query>) -> Result<List<db.ExecResult>, Error>

--- a/internal/stdlib/modules/db_pg.osty
+++ b/internal/stdlib/modules/db_pg.osty
@@ -1,0 +1,68 @@
+// std.db.pg — PostgreSQL database driver.
+//
+// Body-less signature stubs: the backend lowers each call to the runtime
+// PostgreSQL driver (libpq or native protocol implementation).
+//
+// Connection configuration is provided via db.Config (Driver=Postgres).
+// The runtime handles SSL, authentication, and prepared statements.
+
+use std.db
+use std.db.driver
+use std.error
+
+/// Returns a DriverFactory for the Postgres driver.
+pub fn driverFactory() -> driver.DriverFactory
+
+/// Opens a single connection to a Postgres database.
+pub fn open(config: db.Config) -> Result<driver.Connection, Error>
+
+/// Creates a connection pool for a Postgres database.
+pub fn openPool(config: db.Config, options: db.PoolOptions) -> Result<driver.Pool, Error>
+
+/// Returns the version string of the connected Postgres server.
+pub fn serverVersion(conn: driver.Connection) -> Result<String, Error>
+
+/// Returns the current connection's PID (for pg_notify etc.).
+pub fn backendPid(conn: driver.Connection) -> Int
+
+/// Lists all databases on the server.
+pub fn databases(conn: driver.Connection) -> Result<db.ResultSet, Error>
+
+/// Lists all schemas in the current database.
+pub fn schemas(conn: driver.Connection) -> Result<db.ResultSet, Error>
+
+/// Lists all tables in the given schema (default: "public").
+pub fn tables(conn: driver.Connection, schema: String) -> Result<db.ResultSet, Error>
+
+/// Returns column metadata for a table.
+pub fn tableInfo(conn: driver.Connection, schema: String, table: String) -> Result<db.ResultSet, Error>
+
+/// Executes a script containing multiple SQL statements.
+pub fn execScript(conn: driver.Connection, script: String) -> Result<db.ExecResult, Error>
+
+/// Copies data from stdin using the Postgres COPY protocol.
+pub fn copyIn(conn: driver.Connection, table: String, columns: List<String>, data: String) -> Result<Int, Error>
+
+/// Copies data to stdout using the Postgres COPY protocol.
+pub fn copyOut(conn: driver.Connection, query: String) -> Result<String, Error>
+
+/// Creates a named prepared statement.
+pub fn prepare(conn: driver.Connection, name: String, sql: String) -> Result<(), Error>
+
+/// Executes a named prepared statement with the given parameters.
+pub fn executePrepared(conn: driver.Connection, name: String, params: List<db.Cell>) -> Result<db.ResultSet, Error>
+
+/// Lists all prepared statements on the connection.
+pub fn preparedStatements(conn: driver.Connection) -> Result<List<String>, Error>
+
+/// Sets a configuration parameter for the session.
+pub fn setConfig(conn: driver.Connection, param: String, value: String) -> Result<(), Error>
+
+/// Gets a configuration parameter value.
+pub fn getConfig(conn: driver.Connection, param: String) -> Result<String, Error>
+
+/// Cancels the currently running query on the connection.
+pub fn cancelQuery(conn: driver.Connection) -> Result<(), Error>
+
+/// Terminates the connection forcibly.
+pub fn terminate(conn: driver.Connection) -> Result<(), Error>

--- a/internal/stdlib/modules/db_pool.osty
+++ b/internal/stdlib/modules/db_pool.osty
@@ -1,0 +1,80 @@
+// std.db.pool — database connection pool management.
+//
+// Body-less signature stubs: the backend lowers each call to the runtime
+// pool implementation (connection acquire/release, health checking, stats).
+//
+// The Pool interface is defined in std.db.driver; this module provides the
+// concrete pool factory, configuration helpers, and telemetry functions.
+
+use std.db
+use std.db.driver
+use std.error
+
+/// PoolStats exposes runtime telemetry for a connection pool.
+pub struct PoolStats {
+    pub totalConns: Int,
+    pub idleConns: Int,
+    pub activeConns: Int,
+    pub waitCount: Int,
+    pub waitDurationMs: Int,
+    pub maxOpen: Int,
+    pub maxIdle: Int,
+}
+
+/// Returns a zero-initialised PoolStats value.
+pub fn poolStats() -> PoolStats
+
+/// Creates a new connection pool backed by the named driver.
+///
+/// The driver must have been registered with driver.DriverRegistry before
+/// calling this function.
+pub fn newPool(driverName: String, config: db.Config, options: db.PoolOptions) -> Result<driver.Pool, Error>
+
+/// Acquires a connection from the pool.
+///
+/// Blocks until a connection is available or the pool's connect timeout
+/// expires.  Returns an error if the pool is closed or the timeout is
+/// reached.
+pub fn acquire(pool: driver.Pool) -> Result<driver.Connection, Error>
+
+/// Releases a connection back to the pool.
+///
+/// The connection must have been obtained from acquire().  After release
+/// the caller must not use the connection again.
+pub fn release(pool: driver.Pool, conn: driver.Connection) -> Result<(), Error>
+
+/// Closes the pool and all idle connections.
+///
+/// Active connections are not closed; they become orphaned.  After close,
+/// acquire() returns an error.
+pub fn closePool(pool: driver.Pool) -> Result<(), Error>
+
+/// Returns current telemetry for the pool.
+pub fn stats(pool: driver.Pool) -> PoolStats
+
+/// Resets the pool: closes idle connections and re-dials the maximum allowed
+/// active connections.  Useful after a network partition.
+pub fn reset(pool: driver.Pool) -> Result<(), Error>
+
+/// Runs a health check against one idle connection from the pool.
+///
+/// Returns true if the connection responds to a simple ping query,
+/// false if the connection is stale (it will be discarded).
+pub fn ping(pool: driver.Pool) -> Bool
+
+/// Sets the maximum number of open connections.
+pub fn setMaxOpen(pool: driver.Pool, n: Int) -> Result<(), Error>
+
+/// Sets the maximum number of idle connections.
+pub fn setMaxIdle(pool: driver.Pool, n: Int) -> Result<(), Error>
+
+/// Sets the connection timeout in milliseconds.
+pub fn setConnectTimeout(pool: driver.Pool, timeoutMs: Int) -> Result<(), Error>
+
+/// Sets the idle timeout in milliseconds.
+/// Idle connections older than this are closed.
+pub fn setIdleTimeout(pool: driver.Pool, timeoutMs: Int) -> Result<(), Error>
+
+/// Prunes stale idle connections from the pool.
+/// Returns the number of connections that were closed.
+pub fn prune(pool: driver.Pool) -> Int

--- a/internal/stdlib/modules/db_sqlite.osty
+++ b/internal/stdlib/modules/db_sqlite.osty
@@ -1,0 +1,77 @@
+// std.db.sqlite - SQLite database driver stub
+//
+// This module provides the SQLite database driver implementation.
+// The actual runtime implementation lives in the C runtime layer
+// (internal/backend/runtime/) and is linked through the LLVM backend.
+//
+// Driver registration:
+//   let registry = db.driver.defaultDriverRegistry()
+//   let factory = db.sqlite.driverFactory()
+//   let registry = db.driver.registerDriver(registry, "sqlite", factory)?
+//   let driver = db.driver.lookupDriver(registry, "sqlite")?.createDriver()?
+//   let conn = driver.open(db.sqlite("path/to/db.osty")?)?
+
+use std.db
+use std.db.driver
+use std.sql
+use std.error
+
+/// Creates a new SQLite driver factory.
+/// The factory can be used to create SQLite driver instances
+/// and connection pools.
+pub fn driverFactory() -> driver.DriverFactory
+
+/// Opens a SQLite database connection directly.
+/// This is a convenience function equivalent to:
+///   driverFactory().createDriver()?.open(config)
+pub fn open(config: db.Config) -> Result<driver.Connection, Error>
+
+/// Creates a SQLite connection pool with the specified options.
+pub fn openPool(config: db.Config, options: db.PoolOptions) -> Result<driver.Pool, Error>
+
+/// Executes a SQLite-specific PRAGMA statement on a connection.
+/// Returns the result rows if the PRAGMA produces output.
+pub fn pragma(conn: driver.Connection, statement: String) -> Result<db.ResultSet, Error>
+
+/// Returns the SQLite library version string (e.g. "3.45.1").
+pub fn libVersion() -> String
+
+/// Enables or disables WAL (Write-Ahead Logging) mode on a SQLite database.
+/// WAL mode provides better concurrent read performance.
+pub fn enableWal(conn: driver.Connection, enabled: Bool) -> Result<(), Error>
+
+/// Returns the list of tables in the connected SQLite database.
+pub fn tables(conn: driver.Connection) -> Result<List<String>, Error>
+
+/// Returns the schema information for a specific table.
+pub fn tableInfo(conn: driver.Connection, tableName: String) -> Result<db.ResultSet, Error>
+
+/// Executes multiple SQL statements in a single call.
+/// This is useful for running initialization scripts.
+pub fn execScript(conn: driver.Connection, script: String) -> Result<db.ExecResult, Error>
+
+/// Creates a backup of the SQLite database to a file.
+pub fn backup(conn: driver.Connection, destPath: String) -> Result<(), Error>
+
+/// Restores a SQLite database from a backup file.
+pub fn restore(conn: driver.Connection, srcPath: String) -> Result<(), Error>
+
+/// Vacuums the SQLite database to reclaim unused space.
+pub fn vacuum(conn: driver.Connection) -> Result<(), Error>
+
+/// Sets a busy timeout in milliseconds.
+/// When the timeout expires, a busy SQLite connection returns an error.
+pub fn setBusyTimeout(conn: driver.Connection, timeoutMs: Int) -> Result<(), Error>
+
+/// Returns the last inserted row ID from the connection.
+pub fn lastInsertRowId(conn: driver.Connection) -> Int
+
+/// Returns the number of rows changed by the last SQL statement.
+pub fn changes(conn: driver.Connection) -> Int
+
+/// Returns the total number of rows changed since the connection was opened.
+pub fn totalChanges(conn: driver.Connection) -> Int
+
+/// Interrupts a running query on the connection.
+/// This is safe to call from a different thread.
+pub fn interrupt(conn: driver.Connection) -> Result<(), Error>

--- a/internal/stdlib/modules/gql_client.osty
+++ b/internal/stdlib/modules/gql_client.osty
@@ -1,0 +1,77 @@
+// std.gql.client — GraphQL client runtime stubs.
+//
+// This module provides body-less runtime primitives for executing
+// GraphQL operations (queries, mutations, subscriptions) against
+// remote endpoints. The pure-Osty document/request builders live in
+// std.graphql; this module owns the HTTP transport layer.
+//
+// Runtime backends provide the actual HTTP + WebSocket transport
+// behind these stubs.
+
+use std.error
+use std.graphql
+use std.http
+
+/// Execute a GraphQL query or mutation against the given endpoint.
+/// The request is serialised via graphql.encode() and sent as an
+/// HTTP POST with Content-Type: application/json.
+pub fn execute(endpoint: String, request: graphql.Request) -> Result<http.Response, Error>
+
+/// Execute a GraphQL query or mutation with additional HTTP headers
+/// (e.g. authentication tokens, custom headers).
+pub fn executeWithHeaders(endpoint: String, request: graphql.Request, headers: http.Headers) -> Result<http.Response, Error>
+
+/// Execute a GraphQL query and extract the "data" section of the
+/// response as a raw JSON string. Returns an error if the status is
+/// not 2xx or the response body is malformed.
+///
+/// Runtime stub.
+pub fn executeJson(endpoint: String, request: graphql.Request) -> Result<String, Error>
+
+/// Convenience: build and execute a query from a selection set string.
+/// Equivalent to calling graphql.query() then execute().
+///
+/// Runtime stub.
+pub fn query(endpoint: String, selectionSet: String) -> Result<http.Response, Error>
+
+/// Convenience: build and execute a mutation from an operation name
+/// and selection set string.
+///
+/// Runtime stub.
+pub fn mutate(endpoint: String, name: String, selectionSet: String) -> Result<http.Response, Error>
+
+/// Subscribe to a GraphQL subscription via WebSocket transport
+/// (graphql-ws or subscriptions-transport-ws protocol).
+/// Returns a channel-like event stream that yields GraphQL response
+/// bodies as strings until the subscription completes or errors.
+///
+/// This is a runtime-level primitive; the backend manages the
+/// WebSocket handshake, protocol negotiation, and keep-alive.
+pub struct Subscription {
+    pub handle: Int,
+    pub endpoint: String,
+    pub query: String,
+}
+
+/// Open a GraphQL subscription. The runtime establishes a WebSocket
+/// connection to the endpoint and sends the subscription document
+/// over the graphql-ws protocol.
+pub fn subscribe(endpoint: String, queryDoc: String) -> Result<Subscription, Error>
+
+/// Open a GraphQL subscription with initial operation name and
+/// variables JSON.
+pub fn subscribeWithVars(endpoint: String, queryDoc: String, operationName: String, variablesJson: String) -> Result<Subscription, Error>
+
+/// Receive the next event from an active subscription (blocking).
+/// Returns the raw JSON response body for each data or complete
+/// payload.
+pub fn nextEvent(sub: Subscription) -> Result<String?, Error>
+
+/// Close a subscription and its underlying WebSocket connection.
+pub fn unsubscribe(sub: Subscription) -> Result<(), Error>
+
+/// Parse a standard GraphQL JSON response envelope and return the
+/// "data" field. Returns an error if "errors" is present.
+///
+/// Runtime stub.
+pub fn parseData(responseBody: String) -> Result<String, Error>

--- a/internal/stdlib/modules/http_middleware.osty
+++ b/internal/stdlib/modules/http_middleware.osty
@@ -1,0 +1,125 @@
+// std.http.middleware — HTTP client middleware (retry, circuit breaker,
+// rate limiter).
+//
+// This module declares body-less runtime stubs for the higher-order
+// middleware constructors. The pure-Osty implementation will land once
+// the parser supports closure-returning function bodies.
+//
+// Default factory functions (defaultRetryPolicy, defaultCircuitBreaker,
+// etc.) have pure-Osty bodies since they use only struct-literal
+// patterns that the parser can handle.
+
+use std.error
+use std.http
+
+// ---------------------------------------------------------------------------
+// Retry
+// ---------------------------------------------------------------------------
+
+pub struct RetryPolicy {
+    pub maxAttempts: Int,
+    pub baseDelayMs: Int,
+    pub maxDelayMs: Int,
+    pub jitter: Bool,
+}
+
+pub fn defaultRetryPolicy() -> RetryPolicy {
+    RetryPolicy {
+        maxAttempts: 3,
+        baseDelayMs: 200,
+        maxDelayMs: 10_000,
+        jitter: true,
+    }
+}
+
+/// Wrap a handler with retry logic. On server-error responses (5xx)
+/// or transport errors, the middleware retries up to maxAttempts-1
+/// additional times with exponential backoff.
+///
+/// Runtime stub — the actual retry loop is provided by the backend.
+pub fn retry(policy: RetryPolicy, next: http.Handler) -> http.Handler
+
+// ---------------------------------------------------------------------------
+// Circuit Breaker
+// ---------------------------------------------------------------------------
+
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+pub struct CircuitBreaker {
+    pub state: CircuitState,
+    pub failureThreshold: Int,
+    pub recoveryTimeoutMs: Int,
+    pub consecutiveFailures: Int,
+    pub lastFailureNanos: Int64,
+}
+
+pub fn newCircuitBreaker(failureThreshold: Int, recoveryTimeoutMs: Int) -> CircuitBreaker {
+    CircuitBreaker {
+        state: Closed,
+        failureThreshold: failureThreshold,
+        recoveryTimeoutMs: recoveryTimeoutMs,
+        consecutiveFailures: 0,
+        lastFailureNanos: 0,
+    }
+}
+
+pub fn defaultCircuitBreaker() -> CircuitBreaker {
+    newCircuitBreaker(5, 30_000)
+}
+
+/// Wrap a handler with a circuit breaker. When the failure count
+/// exceeds the threshold, the circuit opens and subsequent requests
+/// are rejected immediately until the recovery timeout elapses.
+///
+/// Runtime stub — the actual circuit-breaker state machine is
+/// provided by the backend.
+pub fn circuitBreaker(cb: CircuitBreaker, next: http.Handler) -> http.Handler
+
+// ---------------------------------------------------------------------------
+// Rate Limiter
+// ---------------------------------------------------------------------------
+
+pub struct TokenBucket {
+    pub capacity: Int,
+    pub refillRate: Int,
+    pub refillIntervalMs: Int,
+    pub tokens: Int,
+    pub lastRefillNanos: Int64,
+}
+
+pub fn newTokenBucket(capacity: Int, refillRate: Int, refillIntervalMs: Int) -> TokenBucket {
+    TokenBucket {
+        capacity: capacity,
+        refillRate: refillRate,
+        refillIntervalMs: refillIntervalMs,
+        tokens: capacity,
+        lastRefillNanos: 0,
+    }
+}
+
+pub fn defaultTokenBucket() -> TokenBucket {
+    newTokenBucket(100, 10, 1_000)
+}
+
+/// Wrap a handler with a token-bucket rate limiter. If no tokens are
+/// available the request is rejected immediately.
+///
+/// Runtime stub — the actual token-bucket logic is provided by the
+/// backend.
+pub fn rateLimit(bucket: TokenBucket, next: http.Handler) -> http.Handler
+
+// ---------------------------------------------------------------------------
+// Middleware chain
+// ---------------------------------------------------------------------------
+
+/// Compose multiple middleware layers into a single handler. The
+/// middleware are applied right-to-left (innermost-first), so the
+/// first middleware in the list wraps the outermost layer.
+///
+/// Runtime stub — the actual chaining logic is provided by the
+/// backend.
+pub fn chain(middlewares: List<fn(http.Handler) -> http.Handler>, finalHandler: http.Handler) -> http.Handler

--- a/internal/stdlib/modules/ws_client.osty
+++ b/internal/stdlib/modules/ws_client.osty
@@ -1,0 +1,109 @@
+// std.ws.client — WebSocket client runtime stubs.
+//
+// This module provides body-less runtime primitives for creating and
+// managing WebSocket connections. The frame-level encoding/decoding
+// helpers live in std.websocket; this module owns the I/O layer.
+//
+// Runtime backends (LLVM native codegen, etc.) provide the actual
+// socket implementations behind these stubs.
+
+use std.error
+use std.websocket
+use std.bytes
+
+pub type Headers = Map<String, String>
+
+pub enum ConnectionState {
+    Connecting,
+    Open,
+    Closing,
+    Closed,
+
+    pub fn toString(self) -> String {
+        match self {
+            Connecting -> "connecting",
+            Open       -> "open",
+            Closing    -> "closing",
+            Closed     -> "closed",
+        }
+    }
+
+    pub fn isConnected(self) -> Bool {
+        match self {
+            Open | Closing -> true,
+            _              -> false,
+        }
+    }
+}
+
+pub struct Connection {
+    pub handle: Int,
+    pub state: ConnectionState,
+}
+
+/// Message event yielded by a WebSocket connection.
+pub enum MessageEvent {
+    Text(String),
+    Binary(bytes.Bytes),
+}
+
+/// Events that a subscription loop can yield.
+pub enum ConnectionEvent {
+    Message(MessageEvent),
+    Close { code: Int, reason: String },
+    Error(String),
+}
+
+/// Establish a WebSocket connection to the given URL.
+/// The runtime performs the HTTP upgrade handshake; on success the
+/// caller receives a Connection in the Open state.
+pub fn connect(url: String, headers: Headers = {:}) -> Result<Connection, Error>
+
+/// Send a pre-encoded frame over an open WebSocket connection.
+/// The caller should use websocket.encode() to produce the frame
+/// bytes and websocket.frame/text/binary/close/ping/pong helpers
+/// to build the Frame value.
+pub fn send(conn: Connection, frame: websocket.Frame) -> Result<(), Error>
+
+/// Convenience: encode a text string as a Text frame and send it.
+/// Runtime stub.
+pub fn sendText(conn: Connection, text: String) -> Result<(), Error>
+
+/// Convenience: encode binary data as a Binary frame and send it.
+/// Runtime stub.
+pub fn sendBinary(conn: Connection, data: bytes.Bytes) -> Result<(), Error>
+
+/// Receive the next frame from a WebSocket connection (blocking).
+/// Returns the raw Frame; use websocket.textPayload() to extract
+/// text from Text frames.
+pub fn receive(conn: Connection) -> Result<websocket.Frame, Error>
+
+/// Convenience: receive and decode the next text message.
+/// Runtime stub.
+pub fn receiveText(conn: Connection) -> Result<String, Error>
+
+/// Initiate the WebSocket close handshake with the given status code
+/// and reason string. After this call the Connection transitions to
+/// the Closing state; the peer should respond with a Close frame.
+pub fn close(conn: Connection, code: Int = 1000, reason: String = "") -> Result<(), Error>
+
+/// Send a Ping frame with optional payload.
+pub fn ping(conn: Connection, data: bytes.Bytes) -> Result<(), Error>
+
+/// Send a Pong frame with optional payload (usually in response to a
+/// peer's Ping).
+pub fn pong(conn: Connection, data: bytes.Bytes) -> Result<(), Error>
+
+/// Returns true when the connection is in the Open or Closing state.
+pub fn isConnected(conn: Connection) -> Bool
+
+/// Returns the remote peer address as a string (host:port).
+pub fn remoteAddr(conn: Connection) -> Result<String, Error>
+
+/// Enter an event loop that yields ConnectionEvent values as they
+/// arrive. The loop exits when the connection closes or an error
+/// occurs.
+///
+/// This is a blocking runtime primitive; the caller runs the loop in
+/// a goroutine/fiber if concurrent processing is needed.
+pub fn eventLoop(conn: Connection) -> Result<ConnectionEvent, Error>

--- a/internal/stdlib/web_client_test.go
+++ b/internal/stdlib/web_client_test.go
@@ -1,0 +1,68 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestWsClientModuleSurface(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["ws_client"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.ws.client not loaded")
+	}
+	for _, name := range []string{
+		"connect", "send", "sendText", "sendBinary",
+		"receive", "receiveText",
+		"close", "ping", "pong",
+		"isConnected", "remoteAddr", "eventLoop",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.ws.client missing export %q", name)
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Fatalf("std.ws.client.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.ws.client.%s not public", name)
+		}
+	}
+	for _, name := range []string{
+		"ConnectionState", "Connection", "MessageEvent", "ConnectionEvent",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Fatalf("std.ws.client missing type %q", name)
+		}
+		if !sym.Pub {
+			t.Fatalf("std.ws.client.%s not public", name)
+		}
+	}
+}
+
+func TestWsClientModuleSourcePinsNonExecutingBehavior(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["ws_client"]
+	if mod == nil {
+		t.Fatal("std.ws.client module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		`pub fn connect(url: String, headers: Headers = {:}) -> Result<Connection, Error>`,
+		`pub fn send(conn: Connection, frame: websocket.Frame) -> Result<(), Error>`,
+		`pub fn receive(conn: Connection) -> Result<websocket.Frame, Error>`,
+		`pub fn close(conn: Connection, code: Int = 1000, reason: String = "") -> Result<(), Error>`,
+		`pub fn ping(conn: Connection, data: bytes.Bytes) -> Result<(), Error>`,
+		`pub fn eventLoop(conn: Connection) -> Result<ConnectionEvent, Error>`,
+		`ConnectionEvent`,
+		`MessageEvent`,
+		`ConnectionState`,
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("std.ws.client source missing %q", want)
+		}
+	}
+}

--- a/internal/toolchain/selfhostcache/cache.go
+++ b/internal/toolchain/selfhostcache/cache.go
@@ -34,6 +34,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	"github.com/osty/osty/internal/manifest"
 )
 
 // CacheDirName is the relative path inside the project root used for
@@ -172,6 +174,13 @@ func ComputeKey(projectRoot string) (Key, error) {
 // `Key` is non-zero when the cache layer (step 3) hits; the in-tree
 // build paths return a zero key because they are not content-
 // addressed.
+//
+// All "no usable binary" outcomes — env override missing, no in-tree
+// build, no cache entry, or even a missing `toolchain/` directory —
+// surface as `ErrNotCached`. Callers convert that single sentinel
+// into their preferred decline message (the lirproto bridge keeps
+// the canonical "osty-self not found" wording so
+// `backend.IsOstySelfMissing` continues matching).
 func ResolveBinary(projectRoot string) (string, Key, error) {
 	if env := strings.TrimSpace(os.Getenv(SelfBinEnv)); env != "" {
 		if info, err := os.Stat(env); err == nil && !info.IsDir() {
@@ -185,13 +194,37 @@ func ResolveBinary(projectRoot string) (string, Key, error) {
 	}
 	key, err := ComputeKey(projectRoot)
 	if err != nil {
-		return "", Key{}, err
+		// Treat key-derivation failures (missing toolchain dir,
+		// unreadable files, …) as a "no cache entry available"
+		// signal rather than a hard error. The cache cannot help
+		// here; upstream detection drops through to its own
+		// fallback chain.
+		return "", Key{}, ErrNotCached
 	}
 	cached := CachePath(projectRoot, key)
 	if info, err := os.Stat(cached); err == nil && !info.IsDir() {
 		return cached, key, nil
 	}
 	return "", key, ErrNotCached
+}
+
+// LocateProjectRoot walks up from `start` looking for `osty.toml`
+// (the canonical Osty manifest). Falls back to the absolute path of
+// `start` when no manifest is found, matching the behaviour of
+// `internal/toolchain.defaultManagedProjectRoot`. Callers thread the
+// result into `ResolveBinary`.
+func LocateProjectRoot(start string) (string, error) {
+	if start == "" {
+		start = "."
+	}
+	if root, err := manifest.FindRoot(start); err == nil {
+		return root, nil
+	}
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("selfhostcache: locate project root: %w", err)
+	}
+	return abs, nil
 }
 
 // Install copies `binPath` into the cache for `key`. It is

--- a/internal/toolchain/selfhostcache/cache.go
+++ b/internal/toolchain/selfhostcache/cache.go
@@ -1,0 +1,245 @@
+// Package selfhostcache resolves the `osty-self` binary used by the
+// LLVM backend's LIR Proto bridge. It replaces the implicit "look at
+// toolchain/.osty/out/.../osty-self" search the older bridge code did
+// with a content-addressed cache that survives across worktrees and
+// tracks toolchain source changes.
+//
+// Lookup order (first hit wins):
+//
+//  1. `OSTY_SELF_BIN` env override.
+//  2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
+//     in-tree build path. Preferred because it always reflects the
+//     current source state.
+//  3. `.osty/cache/self-host/<sha256>-<triple>/osty-self` — the
+//     content-addressed artifact cache. The key combines the
+//     SHA-256 of every `toolchain/*.osty` source byte with the host
+//     triple so a downloaded or copied binary is rejected when the
+//     local toolchain source has drifted.
+//
+// Future phases will plug a network fetcher into the same lookup
+// chain (after #3) so a fresh clone with no `osty-self` can pull a
+// pre-built artifact from a release host instead of needing an
+// in-process bootstrap.
+package selfhostcache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// CacheDirName is the relative path inside the project root used for
+// content-addressed osty-self artifacts.
+const CacheDirName = ".osty/cache/self-host"
+
+// SelfBinEnv mirrors `cmd/osty-native-lirproto/main.go: SelfBinEnv`.
+// Re-declared here so the cache resolver can honour the same env
+// variable without depending on the bridge command.
+const SelfBinEnv = "OSTY_SELF_BIN"
+
+// ErrNotCached signals that no usable osty-self could be located.
+// Callers convert this into a "fall back to stage0" or "decline"
+// signal upstream.
+var ErrNotCached = errors.New("selfhostcache: no usable osty-self binary found")
+
+// Key identifies a single osty-self build per (toolchain source
+// state, host triple). The SHA-256 spans every `toolchain/*.osty`
+// file (sorted by repo-relative path) so a stale cache entry is
+// rejected when source changes.
+type Key struct {
+	ToolchainSHA string
+	Triple       string
+}
+
+// String renders the canonical cache subdirectory name.
+func (k Key) String() string {
+	if k.ToolchainSHA == "" || k.Triple == "" {
+		return ""
+	}
+	return k.ToolchainSHA + "-" + k.Triple
+}
+
+// HostTriple returns the canonical "<GOOS>-<GOARCH>" stamp for the
+// running process. Cache entries built for other triples remain
+// inert here.
+func HostTriple() string {
+	return runtime.GOOS + "-" + runtime.GOARCH
+}
+
+// BinaryName returns the `osty-self` filename appropriate for the
+// host (`.exe` suffix on Windows).
+func BinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "osty-self.exe"
+	}
+	return "osty-self"
+}
+
+// CachePath returns the canonical absolute path the artifact cache
+// would store the binary at for `key`.
+func CachePath(projectRoot string, key Key) string {
+	return filepath.Join(projectRoot, CacheDirName, key.String(), BinaryName())
+}
+
+// inTreeBuildPaths returns the legacy in-tree build paths the older
+// `osty-native-lirproto` bridge searched. Lookup keeps these as the
+// preferred source so an active development build always wins over
+// any cached artifact.
+func inTreeBuildPaths(projectRoot string) []string {
+	return []string{
+		filepath.Join(projectRoot, "toolchain", ".osty", "out", "debug", "llvm", BinaryName()),
+		filepath.Join(projectRoot, "toolchain", ".osty", "out", "release", "llvm", BinaryName()),
+	}
+}
+
+// ComputeKey walks `projectRoot/toolchain` and produces a content-
+// addressed Key based on every `*.osty` source file under it
+// (sorted by relative path). Generated artifacts under
+// `toolchain/.osty/` are excluded so a fresh build does not mutate
+// the cache key.
+func ComputeKey(projectRoot string) (Key, error) {
+	toolchainDir := filepath.Join(projectRoot, "toolchain")
+	if info, err := os.Stat(toolchainDir); err != nil {
+		return Key{}, fmt.Errorf("selfhostcache: stat %s: %w", toolchainDir, err)
+	} else if !info.IsDir() {
+		return Key{}, fmt.Errorf("selfhostcache: %s is not a directory", toolchainDir)
+	}
+
+	paths := []string{}
+	err := filepath.WalkDir(toolchainDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			rel, relErr := filepath.Rel(toolchainDir, p)
+			if relErr != nil {
+				return relErr
+			}
+			// Skip generated build outputs to keep the key
+			// deterministic across rebuilds.
+			if rel != "." && (rel == ".osty" || strings.HasPrefix(rel, ".osty"+string(filepath.Separator))) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".osty") {
+			return nil
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	if err != nil {
+		return Key{}, err
+	}
+	if len(paths) == 0 {
+		return Key{}, fmt.Errorf("selfhostcache: no .osty source files under %s", toolchainDir)
+	}
+	sort.Strings(paths)
+
+	h := sha256.New()
+	for _, p := range paths {
+		rel, err := filepath.Rel(projectRoot, p)
+		if err != nil {
+			return Key{}, err
+		}
+		// Hash the path (in slash-form) before the contents so two
+		// files with identical bytes but different names hash apart.
+		fmt.Fprintf(h, "path:%s\n", filepath.ToSlash(rel))
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return Key{}, fmt.Errorf("selfhostcache: read %s: %w", p, err)
+		}
+		fmt.Fprintf(h, "size:%d\n", len(data))
+		h.Write(data)
+		h.Write([]byte{0})
+	}
+	return Key{
+		ToolchainSHA: hex.EncodeToString(h.Sum(nil)),
+		Triple:       HostTriple(),
+	}, nil
+}
+
+// ResolveBinary returns the first usable osty-self path according
+// to the lookup order documented at the package level. The returned
+// `Key` is non-zero when the cache layer (step 3) hits; the in-tree
+// build paths return a zero key because they are not content-
+// addressed.
+func ResolveBinary(projectRoot string) (string, Key, error) {
+	if env := strings.TrimSpace(os.Getenv(SelfBinEnv)); env != "" {
+		if info, err := os.Stat(env); err == nil && !info.IsDir() {
+			return env, Key{}, nil
+		}
+	}
+	for _, p := range inTreeBuildPaths(projectRoot) {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, Key{}, nil
+		}
+	}
+	key, err := ComputeKey(projectRoot)
+	if err != nil {
+		return "", Key{}, err
+	}
+	cached := CachePath(projectRoot, key)
+	if info, err := os.Stat(cached); err == nil && !info.IsDir() {
+		return cached, key, nil
+	}
+	return "", key, ErrNotCached
+}
+
+// Install copies `binPath` into the cache for `key`. It is
+// idempotent — repeated calls with the same content overwrite atomic-
+// renaming via a temp file. Callers typically obtain `key` from
+// `ComputeKey` immediately before / after running `osty build
+// toolchain/`, then promote the freshly built binary into the cache.
+func Install(projectRoot string, key Key, binPath string) error {
+	if key.String() == "" {
+		return errors.New("selfhostcache: install: zero key")
+	}
+	if _, err := os.Stat(binPath); err != nil {
+		return fmt.Errorf("selfhostcache: install: %w", err)
+	}
+	target := CachePath(projectRoot, key)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("selfhostcache: mkdir cache: %w", err)
+	}
+
+	src, err := os.Open(binPath)
+	if err != nil {
+		return fmt.Errorf("selfhostcache: open source: %w", err)
+	}
+	defer src.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(target), ".osty-self-*.tmp")
+	if err != nil {
+		return fmt.Errorf("selfhostcache: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Clean up tmp on failure paths. Successful path renames
+		// the file out from under us so Remove is a no-op.
+		os.Remove(tmpPath)
+	}()
+	if _, err := io.Copy(tmp, src); err != nil {
+		tmp.Close()
+		return fmt.Errorf("selfhostcache: copy: %w", err)
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		tmp.Close()
+		return fmt.Errorf("selfhostcache: chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("selfhostcache: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return fmt.Errorf("selfhostcache: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/toolchain/selfhostcache/cache_test.go
+++ b/internal/toolchain/selfhostcache/cache_test.go
@@ -205,6 +205,53 @@ func TestResolveBinaryReturnsErrNotCached(t *testing.T) {
 	}
 }
 
+// TestResolveBinaryReturnsErrNotCachedWithoutToolchain verifies that
+// the lookup degrades to ErrNotCached even when there is no
+// `toolchain/` directory at all — ComputeKey would otherwise error
+// out, but for the resolver's purposes the absence is just another
+// "no usable binary" outcome.
+func TestResolveBinaryReturnsErrNotCachedWithoutToolchain(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(SelfBinEnv, "")
+
+	_, _, err := ResolveBinary(root)
+	if !errors.Is(err, ErrNotCached) {
+		t.Fatalf("err = %v, want ErrNotCached for missing toolchain dir", err)
+	}
+}
+
+func TestLocateProjectRootFindsManifest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname=\"x\"\nversion=\"0.0.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	sub := filepath.Join(root, "deep", "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got, err := LocateProjectRoot(sub)
+	if err != nil {
+		t.Fatalf("LocateProjectRoot: %v", err)
+	}
+	gotRel, _ := filepath.Rel(root, got)
+	wantRel, _ := filepath.Rel(root, root)
+	if gotRel != wantRel {
+		t.Fatalf("LocateProjectRoot = %q, want repo root %q", got, root)
+	}
+}
+
+func TestLocateProjectRootFallsBackToAbs(t *testing.T) {
+	root := t.TempDir()
+	got, err := LocateProjectRoot(root)
+	if err != nil {
+		t.Fatalf("LocateProjectRoot: %v", err)
+	}
+	abs, _ := filepath.Abs(root)
+	if got != abs {
+		t.Fatalf("fallback path = %q, want abs of %q", got, abs)
+	}
+}
+
 func TestInstallRoundTrip(t *testing.T) {
 	root := t.TempDir()
 	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})

--- a/internal/toolchain/selfhostcache/cache_test.go
+++ b/internal/toolchain/selfhostcache/cache_test.go
@@ -1,0 +1,270 @@
+package selfhostcache
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scaffoldToolchain creates a minimal `toolchain/` tree under
+// `projectRoot` and returns the absolute toolchain dir path.
+func scaffoldToolchain(t *testing.T, projectRoot string, files map[string]string) string {
+	t.Helper()
+	tcDir := filepath.Join(projectRoot, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("mkdir toolchain: %v", err)
+	}
+	for name, body := range files {
+		full := filepath.Join(tcDir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+	return tcDir
+}
+
+func TestComputeKeyDeterministic(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{
+		"main.osty": "fn main() {}\n",
+		"lib.osty":  "fn helper() -> Int { 42 }\n",
+	})
+	a, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	b, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey 2nd: %v", err)
+	}
+	if a != b {
+		t.Fatalf("keys differ across runs: %v vs %v", a, b)
+	}
+	if len(a.ToolchainSHA) != 64 {
+		t.Fatalf("expected 64-hex SHA, got %q", a.ToolchainSHA)
+	}
+	if !strings.Contains(a.Triple, "-") {
+		t.Fatalf("triple has unexpected shape: %q", a.Triple)
+	}
+}
+
+func TestComputeKeyChangesOnSourceEdit(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	first, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey first: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("fn main() { /* changed */ }\n"), 0o644); err != nil {
+		t.Fatalf("rewrite main.osty: %v", err)
+	}
+	second, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey second: %v", err)
+	}
+	if first.ToolchainSHA == second.ToolchainSHA {
+		t.Fatalf("SHA did not change after source edit: %s", first.ToolchainSHA)
+	}
+}
+
+func TestComputeKeyChangesOnNewFile(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	first, _ := ComputeKey(root)
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "extra.osty"), []byte("fn extra() {}\n"), 0o644); err != nil {
+		t.Fatalf("write extra.osty: %v", err)
+	}
+	second, _ := ComputeKey(root)
+	if first.ToolchainSHA == second.ToolchainSHA {
+		t.Fatalf("SHA did not change after adding file")
+	}
+}
+
+func TestComputeKeyIgnoresGeneratedDir(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{
+		"main.osty":                            "fn main() {}\n",
+		filepath.Join(".osty", "out", "junk"): "ignored binary",
+	})
+	first, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey first: %v", err)
+	}
+	// Mutate something inside the ignored dir.
+	if err := os.WriteFile(filepath.Join(root, "toolchain", ".osty", "out", "junk"), []byte("changed"), 0o644); err != nil {
+		t.Fatalf("rewrite junk: %v", err)
+	}
+	second, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey second: %v", err)
+	}
+	if first.ToolchainSHA != second.ToolchainSHA {
+		t.Fatalf("SHA changed after mutation under ignored .osty dir: %s vs %s", first.ToolchainSHA, second.ToolchainSHA)
+	}
+}
+
+func TestComputeKeyEmptyToolchain(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := ComputeKey(root)
+	if err == nil {
+		t.Fatal("expected error for empty toolchain")
+	}
+}
+
+func TestResolveBinaryEnvOverride(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+
+	bin := filepath.Join(root, "external-osty-self")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho external\n"), 0o755); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+	t.Setenv(SelfBinEnv, bin)
+
+	got, key, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got = %q, want env override %q", got, bin)
+	}
+	if key.String() != "" {
+		t.Fatalf("expected zero key for env override, got %q", key.String())
+	}
+}
+
+func TestResolveBinaryInTreeBuild(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	debugBin := filepath.Join(root, "toolchain", ".osty", "out", "debug", "llvm", BinaryName())
+	if err := os.MkdirAll(filepath.Dir(debugBin), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(debugBin, []byte("debug bin"), 0o755); err != nil {
+		t.Fatalf("write debug bin: %v", err)
+	}
+	got, key, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != debugBin {
+		t.Fatalf("got = %q, want debug bin %q", got, debugBin)
+	}
+	if key.String() != "" {
+		t.Fatalf("in-tree builds should report zero key, got %q", key.String())
+	}
+}
+
+func TestResolveBinaryFallsThroughToCache(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	key, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	cachedBin := CachePath(root, key)
+	if err := os.MkdirAll(filepath.Dir(cachedBin), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(cachedBin, []byte("cached bin"), 0o755); err != nil {
+		t.Fatalf("write cached bin: %v", err)
+	}
+
+	got, gotKey, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary: %v", err)
+	}
+	if got != cachedBin {
+		t.Fatalf("got = %q, want cached %q", got, cachedBin)
+	}
+	if gotKey != key {
+		t.Fatalf("returned key mismatch: got %v, want %v", gotKey, key)
+	}
+}
+
+func TestResolveBinaryReturnsErrNotCached(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	_, _, err := ResolveBinary(root)
+	if !errors.Is(err, ErrNotCached) {
+		t.Fatalf("err = %v, want ErrNotCached", err)
+	}
+}
+
+func TestInstallRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	t.Setenv(SelfBinEnv, "")
+
+	srcBin := filepath.Join(root, "built-osty-self")
+	if err := os.WriteFile(srcBin, []byte("real binary bytes"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	key, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	if err := Install(root, key, srcBin); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got, gotKey, err := ResolveBinary(root)
+	if err != nil {
+		t.Fatalf("ResolveBinary post-install: %v", err)
+	}
+	if got != CachePath(root, key) {
+		t.Fatalf("expected resolved path to match CachePath, got %q", got)
+	}
+	if gotKey != key {
+		t.Fatalf("key mismatch after install: %v vs %v", gotKey, key)
+	}
+	body, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read installed: %v", err)
+	}
+	if string(body) != "real binary bytes" {
+		t.Fatalf("installed body = %q, want round-trip", body)
+	}
+}
+
+func TestInstallRejectsZeroKey(t *testing.T) {
+	root := t.TempDir()
+	if err := Install(root, Key{}, "anything"); err == nil {
+		t.Fatal("expected Install to reject zero key")
+	}
+}
+
+func TestInstallRejectsMissingSource(t *testing.T) {
+	root := t.TempDir()
+	scaffoldToolchain(t, root, map[string]string{"main.osty": "fn main() {}\n"})
+	key, _ := ComputeKey(root)
+	missing := filepath.Join(root, "does-not-exist")
+	if err := Install(root, key, missing); err == nil {
+		t.Fatal("expected Install to reject missing source")
+	}
+}
+
+func TestKeyStringComponents(t *testing.T) {
+	k := Key{ToolchainSHA: "deadbeef", Triple: "linux-amd64"}
+	if got := k.String(); got != "deadbeef-linux-amd64" {
+		t.Fatalf("Key.String = %q, want %q", got, "deadbeef-linux-amd64")
+	}
+	if (Key{}).String() != "" {
+		t.Fatal("zero Key.String must be empty")
+	}
+}

--- a/toolchain/lsp.osty
+++ b/toolchain/lsp.osty
@@ -42,6 +42,30 @@ pub struct LspLocation {
     pub endCharacter: Int,
 }
 
+pub struct LspReferenceFact {
+    pub uri: String,
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+    pub targetSymbolID: String,
+    pub targetURI: String,
+    pub targetStartLine: Int,
+    pub targetStartCharacter: Int,
+    pub targetEndLine: Int,
+    pub targetEndCharacter: Int,
+    pub builtin: Bool,
+}
+
+pub struct LspSymbolFact {
+    pub id: String,
+    pub uri: String,
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+}
+
 struct LspIndexedLocation {
     loc: LspLocation,
     index: Int,
@@ -68,6 +92,14 @@ struct LspIndexedImportSortKey {
     index: Int,
 }
 
+pub struct LspOrganizeUseEntry {
+    pub group: Int,
+    pub key: String,
+    pub alias: String,
+    pub text: String,
+    pub unused: Bool,
+}
+
 pub struct LspSignatureParam {
     pub name: String,
     pub typeName: String,
@@ -78,6 +110,12 @@ pub struct LspSignatureText {
     pub parameterLabels: List<String>,
 }
 
+pub struct LspFunctionTypeParts {
+    pub ok: Bool,
+    pub parameterTypes: List<String>,
+    pub returnType: String,
+}
+
 pub struct LspCompletionContext {
     pub prefix: String,
     pub afterDot: String,
@@ -86,6 +124,64 @@ pub struct LspCompletionContext {
 pub struct LspDiagnosticPayload {
     pub severity: Int,
     pub message: String,
+}
+
+pub struct LspDiagnosticView {
+    pub startLine: Int,
+    pub startCharacter: Int,
+    pub endLine: Int,
+    pub endCharacter: Int,
+    pub severity: Int,
+    pub code: String,
+    pub source: String,
+    pub message: String,
+}
+
+pub struct LspDiagnosticFileFact {
+    pub diagnosticFile: String,
+    pub packageFile: String,
+    pub spanSourceFileID: String,
+    pub packageSourceFileID: String,
+    pub primaryLine: Int,
+    pub primaryOffset: Int,
+    pub sourceLength: Int,
+}
+
+pub struct LspHeaderParseResult {
+    pub ok: Bool,
+    pub contentLength: Int,
+    pub error: String,
+}
+
+pub struct LspFileURIPathRawResult {
+    pub ok: Bool,
+    pub path: String,
+}
+
+pub struct LspCompletionItemData {
+    pub label: String,
+    pub kind: Int,
+    pub sortText: String,
+    pub detail: String,
+    pub documentation: String,
+}
+
+pub struct LspCompletionCandidateView {
+    pub name: String,
+    pub kind: String,
+    pub typeText: String,
+    pub docText: String,
+    pub include: Bool,
+}
+
+pub struct LspNameCandidate {
+    pub name: String,
+    pub distance: Int,
+}
+
+struct LspIndexedNameCandidate {
+    candidate: LspNameCandidate,
+    index: Int,
 }
 
 pub struct LspPosition {
@@ -104,6 +200,17 @@ pub struct LspOstyPosition {
     pub offset: Int,
     pub line: Int,
     pub column: Int,
+}
+
+pub struct LspFullDocumentRange {
+    pub endLine: Int,
+    pub endCharacter: Int,
+}
+
+pub struct LspDispatchDecision {
+    pub action: String,
+    pub errorCode: Int,
+    pub errorMessage: String,
 }
 
 pub fn lspSemanticTypeNamespace() -> Int { return 0 }
@@ -151,6 +258,221 @@ pub fn lspDiagnosticSeverityError() -> Int { return 1 }
 pub fn lspDiagnosticSeverityWarning() -> Int { return 2 }
 pub fn lspDiagnosticSeverityInformation() -> Int { return 3 }
 
+pub fn lspServerName() -> String { return "osty-lsp" }
+pub fn lspServerVersion() -> String { return "0.1.0" }
+pub fn lspPositionEncodingUTF16() -> String { return "utf-16" }
+pub fn lspJSONNull() -> String { return "null" }
+pub fn lspCompletionTriggerDot() -> String { return "." }
+pub fn lspSignatureTriggerOpenParen() -> String { return "(" }
+pub fn lspSignatureTriggerComma() -> String { return "," }
+pub fn lspSemanticTokenTypes() -> List<String> {
+    return [
+        "namespace",
+        "type",
+        "parameter",
+        "variable",
+        "property",
+        "function",
+        "keyword",
+        "string",
+        "number",
+        "operator",
+        "comment",
+        "enumMember",
+    ]
+}
+pub fn lspSemanticTokenModifiers() -> List<String> {
+    return ["declaration", "readonly"]
+}
+pub fn lspDispatchActionInitialize() -> String { return "initialize" }
+pub fn lspDispatchActionExit() -> String { return "exit" }
+pub fn lspDispatchActionShutdown() -> String { return "shutdown" }
+pub fn lspDispatchActionIgnore() -> String { return "ignore" }
+pub fn lspDispatchActionDispatch() -> String { return "dispatch" }
+pub fn lspDispatchActionError() -> String { return "error" }
+pub fn lspErrInvalidRequest() -> Int { return -32600 }
+pub fn lspErrMethodNotFound() -> Int { return -32601 }
+pub fn lspErrServerNotInitialized() -> Int { return -32002 }
+
+pub fn lspAsciiLowerText(text: String) -> String {
+    let units = strings.split(text, "")
+    let mut out = ""
+    for unit in units {
+        out = "{out}{lspAsciiLowerUnit(unit)}"
+    }
+    return out
+}
+
+pub fn lspNameMatchesPrefix(name: String, prefix: String) -> Bool {
+    return prefix == "" || lspStringHasPrefix(name, prefix)
+}
+
+pub fn lspNameMatchesQuery(name: String, query: String) -> Bool {
+    return query == "" || lspStringContains(lspAsciiLowerText(name), query)
+}
+
+pub fn lspUriForSourcePath(path: String) -> String {
+    if lspStringContains(path, ":") && !(lspStringHasPrefix(path, "/")) {
+        return path
+    }
+    return lspPathToUri(path)
+}
+
+pub fn lspPreferAIRepairFixAll(source: String) -> Bool {
+    return lspStringContains(source, ".length")
+}
+
+pub fn lspTextChanged(original: String, replacement: String) -> Bool {
+    return original != replacement
+}
+
+pub fn lspParamsAreEmpty(paramsText: String) -> Bool {
+    return paramsText == "" || paramsText == "null"
+}
+
+pub fn lspRenameEmptyNameMessage() -> String {
+    return "new name is empty"
+}
+
+pub fn lspCannotRenameBuiltinMessage() -> String {
+    return "cannot rename a builtin"
+}
+
+pub fn lspCanRenameKind(kind: String) -> Bool {
+    return kind != "builtin"
+}
+
+pub fn lspRenameTitle(name: String) -> String {
+    return "Rename to `{name}`"
+}
+
+pub fn lspRemoveLineTitle() -> String {
+    return "Remove unused import"
+}
+
+pub fn lspFixAllTitle() -> String {
+    return "Fix all auto-fixable problems"
+}
+
+pub fn lspOrganizeImportsTitle() -> String {
+    return "Organize imports"
+}
+
+pub fn lspInlayTypeLabel(typeText: String) -> String {
+    return ": {typeText}"
+}
+
+pub fn lspMethodNotImplementedMessage(method: String) -> String {
+    return "method not implemented: {method}"
+}
+
+pub fn lspIsOstySourceFileName(name: String) -> Bool {
+    return lspStringHasSuffix(name, ".osty") && !(lspStringHasSuffix(name, "_test.osty"))
+}
+
+pub fn lspHasOstyFileExtension(name: String) -> Bool {
+    return lspStringHasSuffix(name, ".osty")
+}
+
+pub fn lspExitCode(shutdown: Bool) -> Int {
+    if shutdown {
+        return 0
+    }
+    return 1
+}
+
+pub fn lspDispatchDecision(
+    method: String,
+    isNotification: Bool,
+    initialized: Bool,
+    shutdown: Bool,
+) -> LspDispatchDecision {
+    if method == "initialize" {
+        return LspDispatchDecision { action: lspDispatchActionInitialize(), errorCode: 0, errorMessage: "" }
+    }
+    if method == "exit" {
+        return LspDispatchDecision { action: lspDispatchActionExit(), errorCode: 0, errorMessage: "" }
+    }
+    if !(initialized) {
+        if isNotification {
+            return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+        }
+        return LspDispatchDecision {
+            action: lspDispatchActionError(),
+            errorCode: lspErrServerNotInitialized(),
+            errorMessage: "server has not been initialized",
+        }
+    }
+    if shutdown {
+        if isNotification {
+            return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+        }
+        return LspDispatchDecision {
+            action: lspDispatchActionError(),
+            errorCode: lspErrInvalidRequest(),
+            errorMessage: "server is shutting down",
+        }
+    }
+    if method == "initialized" {
+        return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+    }
+    if method == "shutdown" {
+        return LspDispatchDecision { action: lspDispatchActionShutdown(), errorCode: 0, errorMessage: "" }
+    }
+    if lspMethodIsHandled(method) {
+        return LspDispatchDecision { action: lspDispatchActionDispatch(), errorCode: 0, errorMessage: "" }
+    }
+    if isNotification {
+        return LspDispatchDecision { action: lspDispatchActionIgnore(), errorCode: 0, errorMessage: "" }
+    }
+    return LspDispatchDecision {
+        action: lspDispatchActionError(),
+        errorCode: lspErrMethodNotFound(),
+        errorMessage: lspMethodNotImplementedMessage(method),
+    }
+}
+
+pub fn lspFrameHeader(bodyLength: Int) -> String {
+    return "Content-Length: {bodyLength}\r\n\r\n"
+}
+
+pub fn lspTrimHeaderLine(line: String) -> String {
+    let mut out = line
+    for out.chars().len() > 0 {
+        let units = strings.split(out, "")
+        let last = units[units.len() - 1]
+        if last != "\r" && last != "\n" {
+            break
+        }
+        out = frontLexemeFromUnits(units, 0, units.len() - 1)
+    }
+    return out
+}
+
+pub fn lspParseHeaderLines(lines: List<String>) -> LspHeaderParseResult {
+    if lines.len() == 0 {
+        return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: empty header block" }
+    }
+    let mut length = -1
+    for raw in lines {
+        let line = lspTrimAsciiSpace(raw)
+        let colon = lspIndexOfUnit(line, ":")
+        if colon < 0 {
+            return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: malformed header {line}" }
+        }
+        let name = lspTrimAsciiSpace(lspSliceUnits(line, 0, colon))
+        let value = lspTrimAsciiSpace(lspSliceUnits(line, colon + 1, line.chars().len()))
+        if lspEqualFoldAscii(name, "Content-Length") {
+            let parsed = lspParseNonNegativeDecimal(value)
+            if parsed < 0 {
+                return LspHeaderParseResult { ok: false, contentLength: -1, error: "lsp: invalid Content-Length {value}" }
+            }
+            length = parsed
+        }
+    }
+    return LspHeaderParseResult { ok: true, contentLength: length, error: "" }
+}
+
 pub fn lspPathToUri(path: String) -> String {
     if path == "" {
         return "file://"
@@ -159,6 +481,19 @@ pub fn lspPathToUri(path: String) -> String {
         return "file://{path}"
     }
     return "file:///{path}"
+}
+
+pub fn lspFileURIPathRaw(uri: String) -> LspFileURIPathRawResult {
+    let prefix = "file://"
+    if !(lspStringHasPrefix(uri, prefix)) {
+        return LspFileURIPathRawResult { ok: false, path: "" }
+    }
+    let mut path = lspSliceUnits(uri, prefix.chars().len(), uri.chars().len())
+    let units = strings.split(path, "")
+    if units.len() >= 3 && units[0] == "/" && units[2] == ":" {
+        path = lspSliceUnits(path, 1, path.chars().len())
+    }
+    return LspFileURIPathRawResult { ok: true, path }
 }
 
 pub fn lspLineStarts(source: String) -> List<Int> {
@@ -327,6 +662,19 @@ pub fn lspRangeFromOstySpan(
         startCharacter: start.character,
         endLine: end.line,
         endCharacter: end.character,
+    }
+}
+
+pub fn lspFullDocumentRange(source: String, lineStarts: List<Int>) -> LspFullDocumentRange {
+    let mut endLine = 0
+    let mut lastLineStart = 0
+    if lineStarts.len() > 0 {
+        endLine = lineStarts.len() - 1
+        lastLineStart = lineStarts[lineStarts.len() - 1]
+    }
+    return LspFullDocumentRange {
+        endLine,
+        endCharacter: lspUtf16UnitsInByteRange(source, lastLineStart, source.chars().len()),
     }
 }
 
@@ -640,6 +988,24 @@ pub fn lspSpanOverlaps(startOffset: Int, endOffset: Int, queryStart: Int, queryE
     return true
 }
 
+pub fn lspNamedTypeReferenceEndOffset(
+    startOffset: Int,
+    sourceLength: Int,
+    targetNameLength: Int,
+    firstPathMatchesTarget: Bool,
+    firstPathLength: Int,
+) -> Int {
+    let mut width = targetNameLength
+    if firstPathMatchesTarget {
+        width = firstPathLength
+    }
+    let mut endOffset = startOffset + width
+    if endOffset > sourceLength {
+        endOffset = sourceLength
+    }
+    return endOffset
+}
+
 pub fn lspDiagnosticPayload(
     severity: String,
     message: String,
@@ -661,6 +1027,115 @@ pub fn lspDiagnosticPayload(
         out = "{out}\nnote: {note}"
     }
     return LspDiagnosticPayload { severity: code, message: out }
+}
+
+pub fn lspDiagnosticsEqual(a: List<LspDiagnosticView>, b: List<LspDiagnosticView>) -> Bool {
+    if a.len() != b.len() {
+        return false
+    }
+    let mut idx = 0
+    for idx < a.len() {
+        if !(lspDiagnosticViewEqual(a[idx], b[idx])) {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+pub fn lspDiagnosticBelongsToFile(fact: LspDiagnosticFileFact) -> Bool {
+    if fact.diagnosticFile != "" {
+        return fact.diagnosticFile == fact.packageFile
+    }
+    if fact.spanSourceFileID != "" && fact.packageSourceFileID != "" {
+        return fact.spanSourceFileID == fact.packageSourceFileID
+    }
+    if fact.primaryLine == 0 {
+        return false
+    }
+    return fact.primaryOffset <= fact.sourceLength
+}
+
+pub fn lspLevenshteinBounded(a: String, b: String, limit: Int) -> Int {
+    let ar = strings.split(a, "")
+    let br = strings.split(b, "")
+    if lspAbsInt(ar.len() - br.len()) > limit {
+        return limit + 1
+    }
+
+    let mut prev: List<Int> = []
+    let mut j = 0
+    for j <= br.len() {
+        prev.push(j)
+        j = j + 1
+    }
+
+    let mut i = 1
+    for i <= ar.len() {
+        let mut curr: List<Int> = [i]
+        let mut rowMin = i
+        j = 1
+        for j <= br.len() {
+            let cost = if ar[i - 1] == br[j - 1] { 0 } else { 1 }
+            let value = lspMin3Int(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+            curr.push(value)
+            if value < rowMin {
+                rowMin = value
+            }
+            j = j + 1
+        }
+        if rowMin > limit {
+            return limit + 1
+        }
+        prev = curr
+        i = i + 1
+    }
+    if prev[br.len()] > limit {
+        return limit + 1
+    }
+    return prev[br.len()]
+}
+
+pub fn lspRankNearbyNames(names: List<String>, target: String, maxDistance: Int) -> List<String> {
+    let mut candidates: List<LspNameCandidate> = []
+    let mut seen: List<String> = []
+    for name in names {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        let distance = lspLevenshteinBounded(target, name, maxDistance)
+        if distance > maxDistance {
+            continue
+        }
+        seen.push(name)
+        candidates.push(LspNameCandidate { name, distance })
+    }
+
+    let mut out: List<String> = []
+    for candidate in lspSortNameCandidates(candidates) {
+        out.push(candidate.name)
+    }
+    return out
+}
+
+pub fn lspMergeNearbyNames(primary: List<String>, fallback: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    let mut seen: List<String> = []
+    for name in primary {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        seen.push(name)
+        out.push(name)
+    }
+    for name in fallback {
+        if name == "" || lspStringListContains(seen, name) {
+            continue
+        }
+        seen.push(name)
+        out.push(name)
+    }
+    return out
 }
 
 pub fn lspSortDedupLocations(locs: List<LspLocation>) -> List<LspLocation> {
@@ -686,6 +1161,134 @@ pub fn lspSortDedupLocations(locs: List<LspLocation>) -> List<LspLocation> {
         have = true
     }
     return out
+}
+
+pub fn lspLocationsForTarget(
+    refs: List<LspReferenceFact>,
+    symbols: List<LspSymbolFact>,
+    targetID: String,
+    includeDecl: Bool,
+) -> List<LspLocation> {
+    if targetID == "" {
+        return []
+    }
+    let mut out: List<LspLocation> = []
+    let mut haveFallbackDecl = false
+    let mut fallbackDecl = LspLocation { uri: "", startLine: 0, startCharacter: 0, endLine: 0, endCharacter: 0 }
+    for ref in refs {
+        if ref.targetSymbolID != targetID {
+            continue
+        }
+        out.push(LspLocation {
+            uri: ref.uri,
+            startLine: ref.startLine,
+            startCharacter: ref.startCharacter,
+            endLine: ref.endLine,
+            endCharacter: ref.endCharacter,
+        })
+        if !(haveFallbackDecl) && ref.targetURI != "" && !(ref.builtin) {
+            fallbackDecl = LspLocation {
+                uri: ref.targetURI,
+                startLine: ref.targetStartLine,
+                startCharacter: ref.targetStartCharacter,
+                endLine: ref.targetEndLine,
+                endCharacter: ref.targetEndCharacter,
+            }
+            haveFallbackDecl = true
+        }
+    }
+    if includeDecl {
+        let mut haveSymbolDecl = false
+        for sym in symbols {
+            if sym.id == targetID {
+                out.push(LspLocation {
+                    uri: sym.uri,
+                    startLine: sym.startLine,
+                    startCharacter: sym.startCharacter,
+                    endLine: sym.endLine,
+                    endCharacter: sym.endCharacter,
+                })
+                haveSymbolDecl = true
+                break
+            }
+        }
+        if !(haveSymbolDecl) && haveFallbackDecl {
+            out.push(fallbackDecl)
+        }
+    }
+    return lspSortDedupLocations(out)
+}
+
+pub fn lspCompletionItemForSymbolView(
+    name: String,
+    kind: String,
+    typeText: String,
+    docText: String,
+) -> LspCompletionItemData {
+    let mut detail = ""
+    if typeText != "" {
+        detail = lspCompletionDetail(kind, name, typeText)
+    }
+    return LspCompletionItemData {
+        label: name,
+        kind: lspCompletionKindForSymbolKind(kind),
+        sortText: lspCompletionSortTextForSymbolKind(kind, name),
+        detail,
+        documentation: docText,
+    }
+}
+
+pub fn lspCompletionItemsForCandidates(
+    candidates: List<LspCompletionCandidateView>,
+    prefix: String,
+) -> List<LspCompletionItemData> {
+    let mut items: List<LspCompletionItemData> = []
+    let mut seen: List<String> = []
+    for candidate in candidates {
+        if !(candidate.include) || candidate.name == "" {
+            continue
+        }
+        if lspStringListContains(seen, candidate.name) {
+            continue
+        }
+        if !(lspNameMatchesPrefix(candidate.name, prefix)) {
+            continue
+        }
+        seen.push(candidate.name)
+        items.push(lspCompletionItemForSymbolView(
+            candidate.name,
+            candidate.kind,
+            candidate.typeText,
+            candidate.docText,
+        ))
+    }
+
+    let mut labels: List<String> = []
+    for item in items {
+        labels.push(item.label)
+    }
+
+    let mut out: List<LspCompletionItemData> = []
+    for idx in lspSortStringIndexes(labels) {
+        if idx < 0 || idx >= items.len() {
+            continue
+        }
+        out.push(items[idx])
+    }
+    return out
+}
+
+pub fn lspSemanticHoverKind(kind: String) -> String {
+    if kind == "fn" {
+        return "function"
+    }
+    if kind == "value" {
+        return "binding"
+    }
+    if kind == "generic" {
+        return "type parameter"
+    }
+    return kind
 }
 
 pub fn lspSortSymbolIndexes(keys: List<LspSymbolSortKey>) -> List<Int> {
@@ -716,6 +1319,14 @@ pub fn lspSortSymbolIndexes(keys: List<LspSymbolSortKey>) -> List<Int> {
     return out
 }
 
+pub fn lspSortStringIndexes(values: List<String>) -> List<Int> {
+    let mut keys: List<LspSymbolSortKey> = []
+    for value in values {
+        keys.push(LspSymbolSortKey { name: value, uri: "" })
+    }
+    return lspSortSymbolIndexes(keys)
+}
+
 pub fn lspSortImportIndexes(keys: List<LspImportSortKey>) -> List<Int> {
     let mut sorted: List<LspIndexedImportSortKey> = []
     let mut index = 0
@@ -740,6 +1351,44 @@ pub fn lspSortImportIndexes(keys: List<LspImportSortKey>) -> List<Int> {
     let mut out: List<Int> = []
     for tagged in sorted {
         out.push(tagged.index)
+    }
+    return out
+}
+
+pub fn lspOrganizedUseBlock(entries: List<LspOrganizeUseEntry>) -> String {
+    let mut kept: List<LspOrganizeUseEntry> = []
+    let mut seen: List<String> = []
+    for entry in entries {
+        if entry.unused || entry.text == "" {
+            continue
+        }
+        let dedupKey = lspKeyWithAlias(entry.group, entry.key, entry.alias)
+        if lspStringListContains(seen, dedupKey) {
+            continue
+        }
+        seen.push(dedupKey)
+        kept.push(entry)
+    }
+
+    let mut keys: List<LspImportSortKey> = []
+    for entry in kept {
+        keys.push(LspImportSortKey { group: entry.group, key: entry.key, alias: entry.alias })
+    }
+
+    let mut out = ""
+    let mut prevGroup = -1
+    let mut emitted = 0
+    for idx in lspSortImportIndexes(keys) {
+        if idx < 0 || idx >= kept.len() {
+            continue
+        }
+        let entry = kept[idx]
+        if emitted > 0 && entry.group != prevGroup {
+            out = "{out}\n"
+        }
+        out = "{out}{entry.text}\n"
+        prevGroup = entry.group
+        emitted = emitted + 1
     }
     return out
 }
@@ -849,6 +1498,46 @@ pub fn lspBuildSignatureText(
         label = "{label} -> {returnType}"
     }
     return LspSignatureText { label, parameterLabels }
+}
+
+pub fn lspParseFunctionType(typeText: String) -> LspFunctionTypeParts {
+    let mut rest = lspTrimAsciiSpace(typeText)
+    if !(lspStringHasPrefix(rest, "fn")) {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+    rest = lspTrimAsciiSpace(lspSliceUnits(rest, 2, rest.chars().len()))
+    if !(lspStringHasPrefix(rest, "(")) {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+
+    let closeIdx = lspMatchingCloseParen(rest)
+    if closeIdx < 0 {
+        return LspFunctionTypeParts { ok: false, parameterTypes: [], returnType: "" }
+    }
+
+    let paramsText = lspTrimAsciiSpace(lspSliceUnits(rest, 1, closeIdx))
+    let mut params: List<String> = []
+    if paramsText != "" {
+        params = lspSplitTopLevelComma(paramsText)
+    }
+
+    let mut returnType = ""
+    let tail = lspTrimAsciiSpace(lspSliceUnits(rest, closeIdx + 1, rest.chars().len()))
+    if lspStringHasPrefix(tail, "->") {
+        returnType = lspTrimAsciiSpace(lspSliceUnits(tail, 2, tail.chars().len()))
+    }
+    return LspFunctionTypeParts { ok: true, parameterTypes: params, returnType }
+}
+
+pub fn lspFallbackParameterNames(count: Int) -> List<String> {
+    let mut names: List<String> = []
+    let mut idx = 0
+    for idx < count {
+        let ordinal = idx + 1
+        names.push("arg{ordinal}")
+        idx = idx + 1
+    }
+    return names
 }
 
 pub fn lspIsKeywordKind(kind: String) -> Bool {
@@ -1025,6 +1714,44 @@ fn lspSortSemanticTokensByPosition(tokens: List<LspSemanticToken>) -> List<LspSe
     return out
 }
 
+fn lspSortNameCandidates(candidates: List<LspNameCandidate>) -> List<LspNameCandidate> {
+    let mut sorted: List<LspIndexedNameCandidate> = []
+    let mut index = 0
+    for candidate in candidates {
+        let tagged = LspIndexedNameCandidate { candidate, index }
+        let mut inserted = false
+        let mut i = 0
+        for i < sorted.len() {
+            if lspIndexedNameCandidateLess(tagged, sorted[i]) {
+                sorted.insert(i, tagged)
+                inserted = true
+                break
+            }
+            i = i + 1
+        }
+        if !inserted {
+            sorted.push(tagged)
+        }
+        index = index + 1
+    }
+
+    let mut out: List<LspNameCandidate> = []
+    for tagged in sorted {
+        out.push(tagged.candidate)
+    }
+    return out
+}
+
+fn lspIndexedNameCandidateLess(a: LspIndexedNameCandidate, b: LspIndexedNameCandidate) -> Bool {
+    if a.candidate.distance != b.candidate.distance {
+        return a.candidate.distance < b.candidate.distance
+    }
+    if a.candidate.name != b.candidate.name {
+        return a.candidate.name < b.candidate.name
+    }
+    return a.index < b.index
+}
+
 fn lspIndexedSemanticTokenLess(a: LspIndexedSemanticToken, b: LspIndexedSemanticToken) -> Bool {
     if a.token.line != b.token.line {
         return a.token.line < b.token.line
@@ -1117,6 +1844,17 @@ fn lspSameLocation(a: LspLocation, b: LspLocation) -> Bool {
         a.endCharacter == b.endCharacter
 }
 
+fn lspDiagnosticViewEqual(a: LspDiagnosticView, b: LspDiagnosticView) -> Bool {
+    return a.startLine == b.startLine &&
+        a.startCharacter == b.startCharacter &&
+        a.endLine == b.endLine &&
+        a.endCharacter == b.endCharacter &&
+        a.severity == b.severity &&
+        a.code == b.code &&
+        a.source == b.source &&
+        a.message == b.message
+}
+
 fn lspPositionBefore(line: Int, character: Int, otherLine: Int, otherCharacter: Int) -> Bool {
     if line != otherLine {
         return line < otherLine
@@ -1185,6 +1923,273 @@ fn lspStringHasPrefix(text: String, prefix: String) -> Bool {
         idx = idx + 1
     }
     return true
+}
+
+fn lspStringHasSuffix(text: String, suffix: String) -> Bool {
+    if suffix == "" {
+        return true
+    }
+    let textUnits = strings.split(text, "")
+    let suffixUnits = strings.split(suffix, "")
+    if suffixUnits.len() > textUnits.len() {
+        return false
+    }
+    let start = textUnits.len() - suffixUnits.len()
+    let mut idx = 0
+    for idx < suffixUnits.len() {
+        if textUnits[start + idx] != suffixUnits[idx] {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+fn lspStringContains(text: String, needle: String) -> Bool {
+    if needle == "" {
+        return true
+    }
+    let textUnits = strings.split(text, "")
+    let needleUnits = strings.split(needle, "")
+    if needleUnits.len() > textUnits.len() {
+        return false
+    }
+    let mut start = 0
+    for start <= textUnits.len() - needleUnits.len() {
+        let mut idx = 0
+        let mut matched = true
+        for idx < needleUnits.len() {
+            if textUnits[start + idx] != needleUnits[idx] {
+                matched = false
+                break
+            }
+            idx = idx + 1
+        }
+        if matched {
+            return true
+        }
+        start = start + 1
+    }
+    return false
+}
+
+fn lspMethodIsHandled(method: String) -> Bool {
+    return method == "textDocument/didOpen" ||
+        method == "textDocument/didChange" ||
+        method == "textDocument/didClose" ||
+        method == "textDocument/hover" ||
+        method == "textDocument/definition" ||
+        method == "textDocument/formatting" ||
+        method == "textDocument/documentSymbol" ||
+        method == "textDocument/completion" ||
+        method == "textDocument/references" ||
+        method == "textDocument/rename" ||
+        method == "textDocument/signatureHelp" ||
+        method == "workspace/symbol" ||
+        method == "textDocument/inlayHint" ||
+        method == "textDocument/semanticTokens/full" ||
+        method == "textDocument/codeAction"
+}
+
+fn lspStringListContains(items: List<String>, needle: String) -> Bool {
+    for item in items {
+        if item == needle {
+            return true
+        }
+    }
+    return false
+}
+
+fn lspIndexOfUnit(text: String, needle: String) -> Int {
+    let units = strings.split(text, "")
+    let mut idx = 0
+    for idx < units.len() {
+        if units[idx] == needle {
+            return idx
+        }
+        idx = idx + 1
+    }
+    return -1
+}
+
+fn lspSliceUnits(text: String, start: Int, end: Int) -> String {
+    let units = strings.split(text, "")
+    let mut lo = start
+    if lo < 0 {
+        lo = 0
+    }
+    let mut hi = end
+    if hi > units.len() {
+        hi = units.len()
+    }
+    if hi < lo {
+        hi = lo
+    }
+    return frontLexemeFromUnits(units, lo, hi - lo)
+}
+
+fn lspMatchingCloseParen(text: String) -> Int {
+    let units = strings.split(text, "")
+    let mut depth = 0
+    let mut idx = 0
+    for idx < units.len() {
+        if units[idx] == "(" {
+            depth = depth + 1
+        } else if units[idx] == ")" {
+            depth = depth - 1
+            if depth == 0 {
+                return idx
+            }
+        }
+        idx = idx + 1
+    }
+    return -1
+}
+
+fn lspSplitTopLevelComma(text: String) -> List<String> {
+    let units = strings.split(text, "")
+    let mut out: List<String> = []
+    let mut start = 0
+    let mut depth = 0
+    let mut idx = 0
+    for idx < units.len() {
+        let unit = units[idx]
+        if lspIsOpenTypeDelimiter(unit) {
+            depth = depth + 1
+        } else if lspIsCloseTypeDelimiter(unit) {
+            if depth > 0 {
+                depth = depth - 1
+            }
+        } else if unit == "," {
+            if depth == 0 {
+                let part = lspTrimAsciiSpace(frontLexemeFromUnits(units, start, idx - start))
+                if part != "" {
+                    out.push(part)
+                }
+                start = idx + 1
+            }
+        }
+        idx = idx + 1
+    }
+    let tail = lspTrimAsciiSpace(frontLexemeFromUnits(units, start, units.len() - start))
+    if tail != "" {
+        out.push(tail)
+    }
+    return out
+}
+
+fn lspIsOpenTypeDelimiter(unit: String) -> Bool {
+    return unit == "(" || unit == "[" || unit == "<"
+}
+
+fn lspIsCloseTypeDelimiter(unit: String) -> Bool {
+    return unit == ")" || unit == "]" || unit == ">"
+}
+
+fn lspTrimAsciiSpace(text: String) -> String {
+    let units = strings.split(text, "")
+    let mut start = 0
+    let mut end = units.len()
+    for start < end && (units[start] == " " || units[start] == "\t" || units[start] == "\r" || units[start] == "\n") {
+        start = start + 1
+    }
+    for end > start && (units[end - 1] == " " || units[end - 1] == "\t" || units[end - 1] == "\r" || units[end - 1] == "\n") {
+        end = end - 1
+    }
+    return frontLexemeFromUnits(units, start, end - start)
+}
+
+fn lspEqualFoldAscii(a: String, b: String) -> Bool {
+    let au = strings.split(a, "")
+    let bu = strings.split(b, "")
+    if au.len() != bu.len() {
+        return false
+    }
+    let mut idx = 0
+    for idx < au.len() {
+        if lspAsciiLowerUnit(au[idx]) != lspAsciiLowerUnit(bu[idx]) {
+            return false
+        }
+        idx = idx + 1
+    }
+    return true
+}
+
+fn lspAsciiLowerUnit(unit: String) -> String {
+    if unit == "A" { return "a" }
+    if unit == "B" { return "b" }
+    if unit == "C" { return "c" }
+    if unit == "D" { return "d" }
+    if unit == "E" { return "e" }
+    if unit == "F" { return "f" }
+    if unit == "G" { return "g" }
+    if unit == "H" { return "h" }
+    if unit == "I" { return "i" }
+    if unit == "J" { return "j" }
+    if unit == "K" { return "k" }
+    if unit == "L" { return "l" }
+    if unit == "M" { return "m" }
+    if unit == "N" { return "n" }
+    if unit == "O" { return "o" }
+    if unit == "P" { return "p" }
+    if unit == "Q" { return "q" }
+    if unit == "R" { return "r" }
+    if unit == "S" { return "s" }
+    if unit == "T" { return "t" }
+    if unit == "U" { return "u" }
+    if unit == "V" { return "v" }
+    if unit == "W" { return "w" }
+    if unit == "X" { return "x" }
+    if unit == "Y" { return "y" }
+    if unit == "Z" { return "z" }
+    return unit
+}
+
+fn lspParseNonNegativeDecimal(text: String) -> Int {
+    let units = strings.split(text, "")
+    if units.len() == 0 {
+        return -1
+    }
+    let mut out = 0
+    for unit in units {
+        if unit < "0" || unit > "9" {
+            return -1
+        }
+        out = out * 10 + lspDecimalDigit(unit)
+    }
+    return out
+}
+
+fn lspDecimalDigit(unit: String) -> Int {
+    if unit == "0" { return 0 }
+    if unit == "1" { return 1 }
+    if unit == "2" { return 2 }
+    if unit == "3" { return 3 }
+    if unit == "4" { return 4 }
+    if unit == "5" { return 5 }
+    if unit == "6" { return 6 }
+    if unit == "7" { return 7 }
+    if unit == "8" { return 8 }
+    if unit == "9" { return 9 }
+    return -1
+}
+
+fn lspAbsInt(v: Int) -> Int {
+    if v < 0 {
+        return -v
+    }
+    return v
+}
+
+fn lspMin3Int(a: Int, b: Int, c: Int) -> Int {
+    let mut out = a
+    if b < out {
+        out = b
+    }
+    if c < out {
+        out = c
+    }
+    return out
 }
 
 fn lspIsIdentContUnit(unit: String) -> Bool {

--- a/toolchain/lsp_test.osty
+++ b/toolchain/lsp_test.osty
@@ -108,6 +108,120 @@ fn testLspCompletionAndCodeActionPolicy() {
     testing.assertEq(lspPrefixUnderscoreName("value"), "_value")
     testing.assertEq(lspPrefixUnderscoreName(""), "_")
     testing.assertEq(lspPrefixUnderscoreTitle("value"), "Prefix `value` with `_` to silence")
+    testing.assertEq(lspServerName(), "osty-lsp")
+    testing.assertEq(lspServerVersion(), "0.1.0")
+    testing.assertEq(lspPositionEncodingUTF16(), "utf-16")
+    testing.assertEq(lspJSONNull(), "null")
+    testing.assertEq(lspCompletionTriggerDot(), ".")
+    testing.assertEq(lspSignatureTriggerOpenParen(), "(")
+    testing.assertEq(lspSignatureTriggerComma(), ",")
+    let legend = lspSemanticTokenTypes()
+    testing.assertEq(legend[0], "namespace")
+    testing.assertEq(legend[11], "enumMember")
+    let modifiers = lspSemanticTokenModifiers()
+    testing.assertEq(modifiers[0], "declaration")
+    testing.assertEq(modifiers[1], "readonly")
+    testing.assertEq(lspExitCode(true), 0)
+    testing.assertEq(lspExitCode(false), 1)
+    testing.assertEq(lspDispatchDecision("initialize", false, false, false).action, lspDispatchActionInitialize())
+    testing.assertEq(lspDispatchDecision("textDocument/hover", false, false, false).errorCode, lspErrServerNotInitialized())
+    testing.assertEq(lspDispatchDecision("shutdown", false, true, false).action, lspDispatchActionShutdown())
+    testing.assertEq(lspDispatchDecision("textDocument/hover", false, true, false).action, lspDispatchActionDispatch())
+    testing.assertEq(lspDispatchDecision("unknown/method", false, true, false).errorCode, lspErrMethodNotFound())
+    testing.assertEq(lspDispatchDecision("unknown/method", true, true, false).action, lspDispatchActionIgnore())
+    testing.assertEq(lspAsciiLowerText("HeLLo"), "hello")
+    testing.assert(lspNameMatchesPrefix("helper", "hel"))
+    testing.assert(!(lspNameMatchesPrefix("helper", "map")))
+    testing.assert(lspNameMatchesQuery("HelperValue", "value"))
+    testing.assertEq(lspUriForSourcePath("inmemory:main"), "inmemory:main")
+    testing.assertEq(lspUriForSourcePath("/tmp/main.osty"), "file:///tmp/main.osty")
+    testing.assert(lspPreferAIRepairFixAll("x.length"))
+    testing.assert(!(lspPreferAIRepairFixAll("x.len()")))
+    testing.assert(lspTextChanged("a", "b"))
+    testing.assert(!(lspTextChanged("a", "a")))
+    testing.assert(lspParamsAreEmpty(""))
+    testing.assert(lspParamsAreEmpty("null"))
+    testing.assert(!(lspParamsAreEmpty("{}")))
+    testing.assertEq(lspRenameEmptyNameMessage(), "new name is empty")
+    testing.assertEq(lspCannotRenameBuiltinMessage(), "cannot rename a builtin")
+    testing.assert(lspCanRenameKind("function"))
+    testing.assert(!(lspCanRenameKind("builtin")))
+    testing.assertEq(lspRenameTitle("helper"), "Rename to `helper`")
+    testing.assertEq(lspRemoveLineTitle(), "Remove unused import")
+    testing.assertEq(lspFixAllTitle(), "Fix all auto-fixable problems")
+    testing.assertEq(lspOrganizeImportsTitle(), "Organize imports")
+    testing.assertEq(lspInlayTypeLabel("Int"), ": Int")
+    testing.assertEq(lspMethodNotImplementedMessage("custom/method"), "method not implemented: custom/method")
+    testing.assert(lspIsOstySourceFileName("main.osty"))
+    testing.assert(!(lspIsOstySourceFileName("main_test.osty")))
+    testing.assert(!(lspIsOstySourceFileName("main.go")))
+    testing.assert(lspHasOstyFileExtension("main_test.osty"))
+    testing.assert(!(lspHasOstyFileExtension("main.go")))
+
+    let completion = lspCompletionItemForSymbolView("map", "function", "fn(Int) -> String", "docs")
+    testing.assertEq(completion.label, "map")
+    testing.assertEq(completion.kind, lspCompletionKindFunction())
+    testing.assertEq(completion.sortText, "2_map")
+    testing.assertEq(completion.detail, "fn map(Int) -> String")
+    testing.assertEq(completion.documentation, "docs")
+
+    let filtered = lspCompletionItemsForCandidates(
+        [
+            LspCompletionCandidateView { name: "zeta", kind: "binding", typeText: "Int", docText: "", include: true },
+            LspCompletionCandidateView { name: "alpha", kind: "function", typeText: "fn() -> Int", docText: "docs", include: true },
+            LspCompletionCandidateView { name: "alpha", kind: "binding", typeText: "String", docText: "", include: true },
+            LspCompletionCandidateView { name: "hidden", kind: "binding", typeText: "Int", docText: "", include: false },
+            LspCompletionCandidateView { name: "", kind: "binding", typeText: "Int", docText: "", include: true },
+        ],
+        "",
+    )
+    testing.assertEq(filtered.len(), 2)
+    testing.assertEq(filtered[0].label, "alpha")
+    testing.assertEq(filtered[0].detail, "fn alpha() -> Int")
+    testing.assertEq(filtered[0].documentation, "docs")
+    testing.assertEq(filtered[1].label, "zeta")
+}
+
+fn testLspJsonRpcHeaderPolicy() {
+    testing.assertEq(lspFrameHeader(17), "Content-Length: 17\r\n\r\n")
+    testing.assertEq(lspTrimHeaderLine("Content-Length: 17\r\n"), "Content-Length: 17")
+    let parsed = lspParseHeaderLines([
+        "Content-Type: application/vscode-jsonrpc; charset=utf-8",
+        "content-length: 42",
+    ])
+    testing.assert(parsed.ok)
+    testing.assertEq(parsed.contentLength, 42)
+    testing.assertEq(parsed.error, "")
+
+    let missing = lspParseHeaderLines(["Content-Type: application/json"])
+    testing.assert(missing.ok)
+    testing.assertEq(missing.contentLength, -1)
+
+    let empty = lspParseHeaderLines([])
+    testing.assert(!(empty.ok))
+    testing.assertEq(empty.error, "lsp: empty header block")
+
+    let malformed = lspParseHeaderLines(["Content Length 42"])
+    testing.assert(!(malformed.ok))
+
+    let invalid = lspParseHeaderLines(["Content-Length: -1"])
+    testing.assert(!(invalid.ok))
+}
+
+fn testLspNearbyNameRankingPolicy() {
+    testing.assertEq(lspLevenshteinBounded("kitten", "sitting", 3), 3)
+    testing.assertEq(lspLevenshteinBounded("kitten", "sitting", 2), 3)
+    let ranked = lspRankNearbyNames(
+        ["helpr", "helper", "helper", "helmet", ""],
+        "helper",
+        1,
+    )
+    testing.assertEq(ranked.len(), 2)
+    testing.assertEq(ranked[0], "helper")
+    testing.assertEq(ranked[1], "helpr")
+    let merged = lspMergeNearbyNames(["helper", "helpr"], ["helper", "holder"])
+    testing.assertEq(merged.len(), 3)
+    testing.assertEq(merged[2], "holder")
 }
 
 fn testLspSymbolKindPolicy() {
@@ -140,6 +254,18 @@ fn testLspSignatureTextPolicy() {
     testing.assertEq(sig.label, "fn map(items: List<Int>, f: fn(Int) -> String) -> List<String>")
     testing.assertEq(sig.parameterLabels[0], "items: List<Int>")
     testing.assertEq(sig.parameterLabels[1], "f: fn(Int) -> String")
+
+    let parsed = lspParseFunctionType("fn(Int, Result<String, Error>, fn(Int) -> Bool) -> String")
+    testing.assert(parsed.ok)
+    testing.assertEq(parsed.parameterTypes.len(), 3)
+    testing.assertEq(parsed.parameterTypes[1], "Result<String, Error>")
+    testing.assertEq(parsed.parameterTypes[2], "fn(Int) -> Bool")
+    testing.assertEq(parsed.returnType, "String")
+    testing.assert(!(lspParseFunctionType("List<Int>").ok))
+
+    let fallbackNames = lspFallbackParameterNames(3)
+    testing.assertEq(fallbackNames[0], "arg1")
+    testing.assertEq(fallbackNames[2], "arg3")
 }
 
 fn testLspFindsNameOffsetInsideDeclarationSpan() {
@@ -175,6 +301,8 @@ fn testLspPositionAndParameterPolicy() {
     testing.assert(!(lspContainsPosition(1, 2, 1, 8, 1, 9)))
     testing.assert(lspSpanOverlaps(10, 20, 20, 30))
     testing.assert(!(lspSpanOverlaps(10, 19, 20, 30)))
+    testing.assertEq(lspNamedTypeReferenceEndOffset(10, 20, 6, true, 4), 14)
+    testing.assertEq(lspNamedTypeReferenceEndOffset(18, 20, 6, false, 4), 20)
     testing.assertEq(lspActiveParameter([12, 20, 32], 20), 1)
     testing.assertEq(lspActiveParameter([12, 20, 32], 33), 3)
 }
@@ -186,6 +314,9 @@ fn testLspUtf16PositionConversionPolicy() {
     testing.assertEq(lines[1], 4)
     testing.assertEq(lines[2], 6)
     testing.assertEq(lspUtf16UnitsInByteRange(source, 0, 2), 3)
+    let fullRange = lspFullDocumentRange(source, lines)
+    testing.assertEq(fullRange.endLine, 2)
+    testing.assertEq(fullRange.endCharacter, 3)
 
     let fromOsty = lspOstyPositionToLSP(source, lines, 1, 2)
     testing.assertEq(fromOsty.line, 0)
@@ -215,6 +346,10 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(lspPathToUri("/tmp/main.osty"), "file:///tmp/main.osty")
     testing.assertEq(lspPathToUri("C:/tmp/main.osty"), "file:///C:/tmp/main.osty")
     testing.assertEq(lspPathToUri(""), "file://")
+    testing.assert(lspFileURIPathRaw("file:///tmp/main.osty").ok)
+    testing.assertEq(lspFileURIPathRaw("file:///tmp/main.osty").path, "/tmp/main.osty")
+    testing.assertEq(lspFileURIPathRaw("file:///C:/tmp/main.osty").path, "C:/tmp/main.osty")
+    testing.assert(!(lspFileURIPathRaw("inmemory:main").ok))
 
     let locs = [
         LspLocation {
@@ -244,6 +379,54 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(resolved[0].uri, "file:///a.osty")
     testing.assertEq(resolved[1].uri, "file:///b.osty")
 
+    let targetLocs = lspLocationsForTarget(
+        [
+            LspReferenceFact {
+                uri: "file:///b.osty",
+                startLine: 2,
+                startCharacter: 0,
+                endLine: 2,
+                endCharacter: 4,
+                targetSymbolID: "sym.helper",
+                targetURI: "file:///decl.osty",
+                targetStartLine: 1,
+                targetStartCharacter: 1,
+                targetEndLine: 1,
+                targetEndCharacter: 7,
+                builtin: false,
+            },
+            LspReferenceFact {
+                uri: "file:///a.osty",
+                startLine: 4,
+                startCharacter: 1,
+                endLine: 4,
+                endCharacter: 7,
+                targetSymbolID: "sym.helper",
+                targetURI: "",
+                targetStartLine: 0,
+                targetStartCharacter: 0,
+                targetEndLine: 0,
+                targetEndCharacter: 0,
+                builtin: false,
+            },
+        ],
+        [
+            LspSymbolFact {
+                id: "sym.helper",
+                uri: "file:///decl.osty",
+                startLine: 1,
+                startCharacter: 2,
+                endLine: 1,
+                endCharacter: 8,
+            },
+        ],
+        "sym.helper",
+        true,
+    )
+    testing.assertEq(targetLocs.len(), 3)
+    testing.assertEq(targetLocs[0].uri, "file:///a.osty")
+    testing.assertEq(targetLocs[2].startCharacter, 2)
+
     let symbolOrder = lspSortSymbolIndexes([
         LspSymbolSortKey { name: "Zoo", uri: "file:///b.osty" },
         LspSymbolSortKey { name: "App", uri: "file:///z.osty" },
@@ -252,6 +435,11 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(symbolOrder[0], 2)
     testing.assertEq(symbolOrder[1], 1)
     testing.assertEq(symbolOrder[2], 0)
+
+    let stringOrder = lspSortStringIndexes(["z.osty", "a.osty", "a.osty"])
+    testing.assertEq(stringOrder[0], 1)
+    testing.assertEq(stringOrder[1], 2)
+    testing.assertEq(stringOrder[2], 0)
 
     let importOrder = lspSortImportIndexes([
         LspImportSortKey { group: 1, key: "zeta", alias: "" },
@@ -263,6 +451,15 @@ fn testLspUriLocationAndImportPolicy() {
     testing.assertEq(importOrder[1], 3)
     testing.assertEq(importOrder[2], 2)
     testing.assertEq(importOrder[3], 0)
+
+    let organized = lspOrganizedUseBlock([
+        LspOrganizeUseEntry { group: 1, key: "zeta", alias: "", text: "use zeta", unused: false },
+        LspOrganizeUseEntry { group: 0, key: "fmt", alias: "", text: "use std.fmt", unused: false },
+        LspOrganizeUseEntry { group: 1, key: "alpha", alias: "", text: "use alpha", unused: false },
+        LspOrganizeUseEntry { group: 1, key: "alpha", alias: "", text: "use alpha duplicate", unused: false },
+        LspOrganizeUseEntry { group: 0, key: "io", alias: "", text: "use std.io", unused: true },
+    ])
+    testing.assertEq(organized, "use std.fmt\n\nuse alpha\nuse zeta\n")
 
     testing.assertEq(lspUseGroup(false, ["std", "fmt"]), 0)
     testing.assertEq(lspUseGroup(false, ["pkg"]), 1)
@@ -284,6 +481,65 @@ fn testLspDiagnosticPayloadPolicy() {
     testing.assertEq(payload.message, "unused value\nhelp: prefix it\nnote: declared here")
     testing.assertEq(lspDiagnosticPayload("note", "FYI", "", []).severity, lspDiagnosticSeverityInformation())
     testing.assertEq(lspDiagnosticPayload("unknown", "bad", "", []).severity, lspDiagnosticSeverityError())
+    let diagA = LspDiagnosticView {
+        startLine: 1,
+        startCharacter: 2,
+        endLine: 1,
+        endCharacter: 4,
+        severity: lspDiagnosticSeverityError(),
+        code: "E0500",
+        source: lspServerName(),
+        message: "bad",
+    }
+    let diagB = LspDiagnosticView {
+        startLine: 1,
+        startCharacter: 2,
+        endLine: 1,
+        endCharacter: 4,
+        severity: lspDiagnosticSeverityError(),
+        code: "E0500",
+        source: lspServerName(),
+        message: "bad",
+    }
+    testing.assert(lspDiagnosticsEqual([diagA], [diagB]))
+    testing.assert(!(lspDiagnosticsEqual([diagA], [])))
+
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "/tmp/main.osty",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 0,
+        primaryOffset: 999,
+        sourceLength: 1,
+    }))
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "src1",
+        packageSourceFileID: "src1",
+        primaryLine: 0,
+        primaryOffset: 999,
+        sourceLength: 1,
+    }))
+    testing.assert(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 1,
+        primaryOffset: 3,
+        sourceLength: 3,
+    }))
+    testing.assert(!(lspDiagnosticBelongsToFile(LspDiagnosticFileFact {
+        diagnosticFile: "",
+        packageFile: "/tmp/main.osty",
+        spanSourceFileID: "",
+        packageSourceFileID: "",
+        primaryLine: 0,
+        primaryOffset: 0,
+        sourceLength: 3,
+    })))
 }
 
 fn testLspResolveOverlappingTextEdits() {


### PR DESCRIPTION
## Summary

A1 의 `selfhostcache` 패키지를 production 경로에 연결. `cmd/osty-native-lirproto/main.go::resolveOstySelfBin` 이 직접 hardcoded 후보 경로를 도는 대신 `selfhostcache.ResolveBinary` 를 호출한다.

이로써 lookup 이 통일됨:

```
1. $OSTY_SELF_BIN env override
2. toolchain/.osty/out/{debug,release}/llvm/osty-self  (in-tree dev build)
3. .osty/cache/self-host/<sha>-<triple>/osty-self      (NEW — content-addressed cache)
```

세 후보 모두 한 번의 lookup 으로 처리. 네트워크 fetch 는 A4+ 에서 같은 chain 의 다음 단계로 추가 예정.

### 추가

- `selfhostcache.LocateProjectRoot(start)` — `manifest.FindRoot` 래핑. `osty.toml` 못 찾으면 `abs(start)` fallback. 브릿지가 cwd 부터 walk-up 으로 root 찾음.
- `ResolveBinary` 가 `ComputeKey` 실패 (예: toolchain 디렉토리 없음) 도 `ErrNotCached` 로 일관 처리. 호출자 detection chain 단순화.
- `TestResolveBinaryReturnsErrNotCachedWithoutToolchain` — 빈 root 에서도 ErrNotCached 반환.
- `TestLocateProjectRootFindsManifest` / `FallsBackToAbs` — root resolution 검증.

### 호환성 보장

- **"osty-self not found" 메시지 substring 보존** → `backend.IsOstySelfMissing` 매칭 변경 없음 → 디스패처 fallback chain (P0 detection + P4 stage0 wiring) 그대로 작동.
- `defaultSelfBinCandidates` 변수 제거 (selfhostcache 가 같은 경로 내부에 owned).
- 기존 lirproto 테스트 (TestRun*) 모두 통과.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/toolchain/selfhostcache/...` — 15/15 PASS (+2)
- [x] `go test ./cmd/osty-native-lirproto/...` — 0 fail (기존 4 tests 모두 통과)
- [x] `go test ./internal/backend/...` — 0 fail
- 관측: 사전부터 존재하는 main 의 무관한 실패 (TestParseMatchArmAllowsBareAssignmentBody, TestParseSnapshot 등) 는 본 PR 영향 없음 — `git checkout origin/main` 으로 검증

## Notes

- 캐시 entry 가 비어 있을 때 (fresh clone 등) 는 여전히 `osty build toolchain/` 로 in-tree build 를 만들어야 함. 캐시는 그 빌드를 promote 하는 메커니즘 (A3) 이 따로 필요.
- 다음 (A3): `osty install-self` CLI + `just bootstrap` 추가해서 build → cache promote 자동화. 이로써 fresh clone 에서 한 번 빌드하면 다른 worktree 가 즉시 캐시 hit.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_