### PR TITLE
feat(toolchain): manifest-self CLI + lirproto network fetch + CI scaffold (A5)

### DIFF
--- a/.github/workflows/build-osty-self.yml
+++ b/.github/workflows/build-osty-self.yml
@@ -1,0 +1,190 @@
+# Build per-host `osty-self` artifacts and produce the manifest pair
+# consumed by `selfhostcache.HTTPFetcher`.
+#
+# Status: scaffold (A5). The workflow runs on a manual dispatch only —
+# the artifact upload step is deliberately gated behind a runtime
+# `OSTY_SELF_REGISTRY_URL` so a maintainer can flip publishing on
+# without merging additional code. Until A6 (manifest signing) lands
+# the produced artifacts are advisory; resolvers will still verify
+# the manifest SHA-256 before promoting into the local cache.
+#
+# Layout produced per matrix entry (linux-amd64 etc.):
+#
+#   artifacts/<key>.json     ← published as <base>/<key>.json
+#   artifacts/<key>/osty-self  ← referenced by manifest.BinaryURL
+#
+# The matrix mirrors the `cross-compile` job in `.github/workflows/ci.yml`
+# but layers `osty install-self` + `osty manifest-self` over the
+# native build so each runner emits a real, content-addressed entry.
+
+name: Build osty-self
+
+on:
+  workflow_dispatch:
+    inputs:
+      osty_version:
+        description: "Provenance string baked into manifest.ostyVersion"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-osty-self-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.goos }}-${{ matrix.goarch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            runner: self-hosted
+          - goos: linux
+            goarch: arm64
+            runner: self-hosted
+          - goos: darwin
+            goarch: amd64
+            runner: self-hosted
+          - goos: darwin
+            goarch: arm64
+            runner: self-hosted
+          - goos: windows
+            goarch: amd64
+            runner: self-hosted
+          - goos: windows
+            goarch: arm64
+            runner: self-hosted
+    env:
+      GOFLAGS: -mod=readonly
+      OSTY_VERSION: ${{ inputs.osty_version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build host osty CLI
+        run: |
+          mkdir -p .bin
+          go build -o .bin/osty ./cmd/osty
+
+      - name: Build osty-native-checker + lirproto
+        run: |
+          mkdir -p .osty/bin
+          go build -o .osty/bin/osty-native-checker ./cmd/osty-native-checker
+          go build -o .osty/bin/osty-native-lirproto ./cmd/osty-native-lirproto
+
+      - name: Install self-host artifact into cache
+        run: |
+          .bin/osty install-self --force
+
+      - name: Locate cached osty-self
+        id: locate
+        run: |
+          set -euo pipefail
+          triple="${{ matrix.goos }}-${{ matrix.goarch }}"
+          # `install-self` printed the cache path as the last token of
+          # `installed:`; re-derive it from the cache layout for
+          # robustness.
+          shopt -s nullglob
+          candidates=(.osty/cache/self-host/*-"$triple"/osty-self*)
+          if [ "${#candidates[@]}" -eq 0 ]; then
+            echo "no cache entry under .osty/cache/self-host/ matching triple $triple" >&2
+            ls -R .osty/cache/self-host/ || true
+            exit 1
+          fi
+          if [ "${#candidates[@]}" -gt 1 ]; then
+            echo "multiple cache entries; picking newest:" >&2
+            ls -lt "${candidates[@]}" >&2
+          fi
+          # Pick the lexicographically last one (alpha-stable across
+          # repeated runs); collisions are unexpected since toolchain SHA
+          # is deterministic per source state.
+          IFS=$'\n' sorted=($(printf '%s\n' "${candidates[@]}" | sort))
+          unset IFS
+          bin="${sorted[-1]}"
+          echo "bin=$bin"  >> "$GITHUB_OUTPUT"
+          echo "triple=$triple" >> "$GITHUB_OUTPUT"
+
+      - name: Generate manifest
+        run: |
+          set -euo pipefail
+          triple="${{ steps.locate.outputs.triple }}"
+          bin="${{ steps.locate.outputs.bin }}"
+          mkdir -p artifacts
+          # Bring the binary alongside the manifest so the artifact
+          # bundle is self-contained.
+          cp "$bin" "artifacts/osty-self-$triple"
+          .bin/osty manifest-self \
+            --bin "$bin" \
+            --binary-url "osty-self-$triple" \
+            --triple "$triple" \
+            --osty-version "${OSTY_VERSION:-${GITHUB_SHA:0:12}}" \
+            --out "artifacts/$triple.json"
+
+      - name: Upload artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: osty-self-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: artifacts/
+          retention-days: 14
+          if-no-files-found: error
+
+  publish:
+    name: Publish manifests
+    runs-on: self-hosted
+    needs: build
+    timeout-minutes: 10
+    # Publishing is opt-in — set the secret to enable. Without it the
+    # job is a no-op so the matrix above can run on every dispatch
+    # without producing live artifacts.
+    if: ${{ vars.OSTY_SELF_REGISTRY_URL != '' }}
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: registry/
+
+      - name: Layout for upload
+        run: |
+          set -euo pipefail
+          # Each downloaded subdir holds one (manifest, binary) pair.
+          # Flatten into the layout HTTPFetcher expects:
+          #   <base>/<key>.json
+          #   <base>/<binary-url>
+          mkdir -p upload
+          shopt -s nullglob
+          for dir in registry/*/; do
+            for json in "$dir"*.json; do
+              # Drop into upload/ keyed by the manifest's `key` field.
+              key=$(jq -r .key "$json")
+              cp "$json" "upload/$key.json"
+            done
+            for bin in "$dir"osty-self-*; do
+              cp "$bin" "upload/$(basename "$bin")"
+            done
+          done
+          ls -la upload/
+
+      # Actual upload step is deferred to the maintainer's chosen
+      # backend (S3 / R2 / Pages). The scaffold stops here so the
+      # workflow remains visible/reviewable without binding the repo
+      # to a specific storage vendor.
+      - name: Summary
+        run: |
+          echo "Prepared upload payload under upload/" >&2
+          echo "Configure the maintainer-side step that POSTs to ${{ vars.OSTY_SELF_REGISTRY_URL }}." >&2

--- a/cmd/osty-native-lirproto/main.go
+++ b/cmd/osty-native-lirproto/main.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -119,23 +120,28 @@ func lower(req nativelirproto.Request) (nativelirproto.Response, error) {
 // resolveOstySelfBin returns the path to the self-host `osty-self`
 // binary the lower call should subprocess.
 //
-// Lookup order (delegated to `selfhostcache.ResolveBinary`):
+// Lookup order (delegated to `selfhostcache.ResolveBinaryWithFetch`):
 //
-//	1. `$OSTY_SELF_BIN` env override.
-//	2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
-//	   in-tree build path.
-//	3. `.osty/cache/self-host/<sha>-<triple>/osty-self` — the
-//	   content-addressed artifact cache.
+//  1. `$OSTY_SELF_BIN` env override.
+//  2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
+//     in-tree build path.
+//  3. `.osty/cache/self-host/<sha>-<triple>/osty-self` — the
+//     content-addressed artifact cache.
+//  4. Network fetch from `$OSTY_SELF_REGISTRY_URL` — only consulted
+//     when the env var is set and `$OSTY_SELF_REGISTRY_OFFLINE` is
+//     unset. A successful fetch promotes the binary into the local
+//     cache so subsequent invocations short-circuit at step 3.
 //
-// On the no-cache path (env unset, no in-tree build, no cache hit),
-// the canonical "osty-self not found" message is preserved so the
-// upstream `backend.IsOstySelfMissing` detection chain keeps working.
+// On the no-cache path (env unset, no in-tree build, no cache hit,
+// no registry / network failure), the canonical "osty-self not found"
+// message is preserved so the upstream `backend.IsOstySelfMissing`
+// detection chain keeps working.
 func resolveOstySelfBin() (string, error) {
 	root, err := selfhostcache.LocateProjectRoot(".")
 	if err != nil {
 		return "", err
 	}
-	bin, _, err := selfhostcache.ResolveBinary(root)
+	bin, _, err := selfhostcache.ResolveBinaryWithFetch(context.Background(), root, selfhostcache.EnvFetcher())
 	if errors.Is(err, selfhostcache.ErrNotCached) {
 		return "", errors.New("osty-self not found; run `osty build toolchain/` or set OSTY_SELF_BIN")
 	}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -196,6 +196,13 @@ func main() {
 		runInstallSelf(args[1:], flags)
 		return
 	}
+	// manifest-self emits a JSON manifest describing a built osty-self
+	// binary so a CI workflow can publish the (manifest, binary) pair
+	// to a registry consumed by `selfhostcache.HTTPFetcher`.
+	if cmd == "manifest-self" {
+		runManifestSelf(args[1:], flags)
+		return
+	}
 	// `osty lint --explain CODE` prints the rule's description and
 	// exits. `osty lint --list` prints every rule. Both short-circuit
 	// before the normal file-arg handling below.

--- a/cmd/osty/manifest_self.go
+++ b/cmd/osty/manifest_self.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+// runManifestSelf emits a JSON manifest describing a built osty-self
+// binary so a CI pipeline can publish the (manifest, binary) pair to
+// the artifact registry consumed by `selfhostcache.HTTPFetcher`.
+//
+// Inputs (flags):
+//
+//	--bin PATH          required; the freshly built osty-self binary.
+//	--triple TRIPLE     defaults to the running host triple.
+//	--osty-version VER  optional; embedded into the manifest as a
+//	                    human-readable provenance hint.
+//	--binary-url URL    required for upload; the resolver follows the
+//	                    URL relative to OSTY_SELF_REGISTRY_URL.
+//	--out PATH          where to write the manifest JSON; defaults to
+//	                    stdout when unset.
+//
+// The CLI does not upload anything itself — that is the CI workflow's
+// responsibility. The published manifest path inside the registry
+// must follow the `<key>.json` layout that `HTTPFetcher.Fetch`
+// derives from the Key.
+func runManifestSelf(args []string, _ cliFlags) {
+	fs := flag.NewFlagSet("manifest-self", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, manifestSelfUsage())
+		fs.PrintDefaults()
+	}
+	var (
+		binPath     string
+		triple      string
+		ostyVersion string
+		binaryURL   string
+		outPath     string
+	)
+	fs.StringVar(&binPath, "bin", "", "path to the osty-self binary to describe")
+	fs.StringVar(&triple, "triple", selfhostcache.HostTriple(), "host triple stamped into the manifest Key")
+	fs.StringVar(&ostyVersion, "osty-version", "", "optional human-readable provenance string")
+	fs.StringVar(&binaryURL, "binary-url", "", "URL the resolver should GET to fetch the binary; relative URLs resolve against OSTY_SELF_REGISTRY_URL")
+	fs.StringVar(&outPath, "out", "", "write manifest JSON to PATH; defaults to stdout")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	if binPath == "" {
+		fmt.Fprintln(os.Stderr, "osty manifest-self: --bin is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+	if binaryURL == "" {
+		fmt.Fprintln(os.Stderr, "osty manifest-self: --binary-url is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	root, err := selfhostcache.LocateProjectRoot(".")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: locate project root: %v\n", err)
+		os.Exit(1)
+	}
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: compute key: %v\n", err)
+		os.Exit(1)
+	}
+	// Override the auto-detected triple when the caller wants to
+	// describe a cross-built artifact (Linux runner stamping a
+	// darwin-arm64 manifest).
+	if strings.TrimSpace(triple) != "" {
+		key.Triple = triple
+	}
+
+	sum, err := hashFile(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: hash binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	manifest := selfhostcache.Manifest{
+		Version:      selfhostcache.ManifestVersion,
+		Key:          key.String(),
+		BinarySHA256: sum,
+		BinaryURL:    binaryURL,
+		OstyVersion:  ostyVersion,
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: encode manifest: %v\n", err)
+		os.Exit(1)
+	}
+	body = append(body, '\n')
+
+	if outPath == "" {
+		_, _ = os.Stdout.Write(body)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: mkdir: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(outPath, body, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "osty manifest-self: write: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("manifest:    %s\n", outPath)
+	fmt.Printf("key:         %s\n", manifest.Key)
+	fmt.Printf("sha256:      %s\n", manifest.BinarySHA256)
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func manifestSelfUsage() string {
+	return strings.TrimSpace(fmt.Sprintf(`
+osty manifest-self --bin PATH --binary-url URL [--triple TRIPLE] [--osty-version VER] [--out PATH]
+    Emit a JSON manifest describing a built osty-self binary so a CI
+    workflow can publish it to an OSTY_SELF_REGISTRY_URL backend
+    consumed by selfhostcache.HTTPFetcher (manifest schema v%d).
+    Defaults --triple to the running host (%s).
+`, selfhostcache.ManifestVersion, runtime.GOOS+"-"+runtime.GOARCH))
+}

--- a/cmd/osty/manifest_self_test.go
+++ b/cmd/osty/manifest_self_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+// TestManifestSelfUsageMessage verifies the CLI usage string lists
+// the canonical flags so future help-text generation stays in sync
+// with the `osty manifest-self` interface.
+func TestManifestSelfUsageMessage(t *testing.T) {
+	got := manifestSelfUsage()
+	for _, want := range []string{
+		"osty manifest-self",
+		"--bin",
+		"--binary-url",
+		"--triple",
+		"--out",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// buildOstyBinaryForTest produces a host osty binary into the test's
+// tempdir. Returns its absolute path. Cached via t.TempDir so each
+// test run gets an isolated copy without polluting the workspace.
+func buildOstyBinaryForTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "osty")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/osty")
+	cmd.Dir = mustRepoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build osty: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// mustRepoRoot walks up from the test file to the repo root by
+// looking for go.mod — keeps the helper independent of the
+// `go test` working directory which differs between invocations.
+func mustRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found from cwd")
+		}
+		dir = parent
+	}
+}
+
+// TestRunManifestSelfWritesValidManifest invokes the CLI end-to-end
+// with a synthetic toolchain layout, an arbitrary binary body, and
+// confirms the produced manifest matches the layout consumed by
+// `selfhostcache.HTTPFetcher`.
+func TestRunManifestSelfWritesValidManifest(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	// Synthetic project root with a non-empty toolchain dir + a fake
+	// `osty-self` body. The CLI runs in this directory.
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	tcDir := filepath.Join(projectRoot, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tcDir, "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+
+	binPath := filepath.Join(projectRoot, "fake-osty-self")
+	body := []byte("fake osty-self body bytes")
+	if err := os.WriteFile(binPath, body, 0o755); err != nil {
+		t.Fatalf("write fake bin: %v", err)
+	}
+
+	outPath := filepath.Join(projectRoot, "manifest.json")
+	cmd := exec.Command(ostyBin,
+		"manifest-self",
+		"--bin", binPath,
+		"--binary-url", "/linux-amd64/osty-self",
+		"--triple", "linux-amd64",
+		"--osty-version", "test-0.0.0",
+		"--out", outPath,
+	)
+	cmd.Dir = projectRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("osty manifest-self: %v\n%s", err, out)
+	}
+
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var got selfhostcache.Manifest
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode manifest: %v\n%s", err, raw)
+	}
+	if got.Version != selfhostcache.ManifestVersion {
+		t.Errorf("Version = %d, want %d", got.Version, selfhostcache.ManifestVersion)
+	}
+	if !strings.HasSuffix(got.Key, "-linux-amd64") {
+		t.Errorf("Key = %q, want suffix -linux-amd64", got.Key)
+	}
+	wantSHA := sha256.Sum256(body)
+	if got.BinarySHA256 != hex.EncodeToString(wantSHA[:]) {
+		t.Errorf("BinarySHA256 = %q, want %q", got.BinarySHA256, hex.EncodeToString(wantSHA[:]))
+	}
+	if got.BinaryURL != "/linux-amd64/osty-self" {
+		t.Errorf("BinaryURL = %q", got.BinaryURL)
+	}
+	if got.OstyVersion != "test-0.0.0" {
+		t.Errorf("OstyVersion = %q", got.OstyVersion)
+	}
+}
+
+// TestRunManifestSelfRoundTripsThroughHTTPFetcher publishes the
+// manifest produced by the CLI to a httptest registry, points
+// `HTTPFetcher` at it, and verifies the (manifest, body) pair fetches
+// + verifies cleanly. Closes the loop on the producer/consumer
+// contract.
+func TestRunManifestSelfRoundTripsThroughHTTPFetcher(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	tcDir := filepath.Join(projectRoot, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tcDir, "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+
+	binPath := filepath.Join(projectRoot, "fake-osty-self")
+	body := []byte("round-trip body")
+	if err := os.WriteFile(binPath, body, 0o755); err != nil {
+		t.Fatalf("write fake bin: %v", err)
+	}
+
+	// Run the CLI with a relative binary URL — HTTPFetcher resolves
+	// it against the registry base URL.
+	outPath := filepath.Join(projectRoot, "manifest.json")
+	cmd := exec.Command(ostyBin,
+		"manifest-self",
+		"--bin", binPath,
+		"--binary-url", "osty-self",
+		"--triple", selfhostcache.HostTriple(),
+		"--out", outPath,
+	)
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("osty manifest-self: %v\n%s", err, out)
+	}
+
+	manifestRaw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var pub selfhostcache.Manifest
+	if err := json.Unmarshal(manifestRaw, &pub); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	// Stand up a registry that serves the manifest + binary at the
+	// canonical paths the CLI assumed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ".json"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(manifestRaw)
+		case strings.HasSuffix(r.URL.Path, "osty-self"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Write(body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	fetcher := selfhostcache.HTTPFetcher{BaseURL: srv.URL}
+	gotManifest, gotBody, err := fetcher.Fetch(context.Background(), selfhostcache.Key{
+		ToolchainSHA: strings.TrimSuffix(pub.Key, "-"+selfhostcache.HostTriple()),
+		Triple:       selfhostcache.HostTriple(),
+	})
+	if err != nil {
+		t.Fatalf("fetcher.Fetch: %v", err)
+	}
+	defer gotBody.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(gotBody); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), body) {
+		t.Errorf("body mismatch: got %q want %q", buf.Bytes(), body)
+	}
+	if gotManifest.BinarySHA256 != pub.BinarySHA256 {
+		t.Errorf("manifest sha mismatch: got %q want %q", gotManifest.BinarySHA256, pub.BinarySHA256)
+	}
+}
+
+// TestRunManifestSelfRequiresFlags makes sure the CLI rejects
+// invocations missing the required arguments instead of silently
+// emitting a malformed manifest.
+func TestRunManifestSelfRequiresFlags(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	tcDir := filepath.Join(projectRoot, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tcDir, "x.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("x.osty: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing bin", []string{"manifest-self", "--binary-url", "x"}, "--bin is required"},
+		{"missing url", []string{"manifest-self", "--bin", "x"}, "--binary-url is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(ostyBin, tc.args...)
+			cmd.Dir = projectRoot
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected exit error; got success\n%s", out)
+			}
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("expected ExitError; got %v", err)
+			}
+			if ee.ExitCode() != 2 {
+				t.Errorf("exit code = %d, want 2", ee.ExitCode())
+			}
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("output missing %q:\n%s", tc.want, out)
+			}
+		})
+	}
+}

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -49,8 +49,8 @@ PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
 | **A1** | `internal/toolchain/selfhostcache` 패키지 — `Key`, `ComputeKey`, `ResolveBinary`, `Install`, `CachePath`. 디스크에 이미 있는 캐시 entry 만 lookup. 네트워크 0. | 13 단위 테스트 통과 — **구현 완료** |
 | **A2** | `cmd/osty-native-lirproto` 가 `selfhostcache.ResolveBinary` 사용. `LocateProjectRoot` 헬퍼 추가. ErrNotCached → "osty-self not found" 메시지로 변환해서 IsOstySelfMissing 호환 유지. | 기존 lirproto 테스트 통과 + 캐시 lookup 통합 — **구현 완료** |
 | **A3** | `osty install-self` 서브커맨드 — toolchain 빌드 + 캐시 적재 한 번에. `just bootstrap` 레시피가 build-all + install-self 호출. | TestInstallSelfUsageMessage / TestBuildOstySelf — **구현 완료** |
-| **A4** (이 PR) | 네트워크 fetcher — `<base>/<sha>-<triple>.json` manifest + binary 다운로드, SHA-256 검증 필수. `OSTY_SELF_REGISTRY_URL` / `OSTY_SELF_REGISTRY_OFFLINE` env var 게이트. `ResolveBinaryWithFetch` 가 캐시 miss 시 호출. | 17 tests (httptest server 기반) — **구현 완료** |
-| A5 | CI 워크플로 — main push 시 6개 host triple 별로 빌드 → release artifact 업로드 + manifest. `osty-native-lirproto` 가 `EnvFetcher()` 로 자동 활성. | reproducibility 확인 |
+| **A4** | 네트워크 fetcher — `<base>/<sha>-<triple>.json` manifest + binary 다운로드, SHA-256 검증 필수. `OSTY_SELF_REGISTRY_URL` / `OSTY_SELF_REGISTRY_OFFLINE` env var 게이트. `ResolveBinaryWithFetch` 가 캐시 miss 시 호출. | 17 tests (httptest server 기반) — **구현 완료** |
+| **A5** (이 PR) | `cmd/osty-native-lirproto` 가 `ResolveBinaryWithFetch` + `EnvFetcher()` 호출. `osty manifest-self` 서브커맨드 — 빌드된 binary → manifest JSON. `.github/workflows/build-osty-self.yml` 6개 triple matrix scaffold (manual dispatch). | manifest round-trip 4 tests + 기존 lirproto/selfhostcache 회귀 — **구현 완료** |
 | A6 | Manifest signing (sigstore / minisign) — supply-chain 보호. | 정책 결정 |
 
 ## 4. Key 구성


### PR DESCRIPTION
## Summary

Phase A5 of the `osty-self` artifact cache (`docs/osty_self_artifact_design.md`). Three pieces close the producer/consumer loop the A1–A4 work staged.

- **lirproto network fetch.** `cmd/osty-native-lirproto/main.go::resolveOstySelfBin` now calls `selfhostcache.ResolveBinaryWithFetch(ctx, root, selfhostcache.EnvFetcher())`. Cache miss falls through to the HTTP fetcher gated by `OSTY_SELF_REGISTRY_URL` / `OSTY_SELF_REGISTRY_OFFLINE`. The canonical `osty-self not found` decline message is preserved so `backend.IsOstySelfMissing` keeps matching.
- **`osty manifest-self` subcommand.** Producer side of the registry contract — emits the JSON manifest schema consumed by `selfhostcache.HTTPFetcher` (`Version`, `Key`, `BinarySHA256`, `BinaryURL`, `OstyVersion`, `CreatedAt`). Keyed off `selfhostcache.ComputeKey` so producer/consumer share the cache layout without duplication. Tests round-trip a synthetic (manifest, binary) pair through `httptest` to lock the wire shape.
- **`.github/workflows/build-osty-self.yml`.** Manual-dispatch matrix across the 6 supported triples. Each runner runs `osty install-self` then `osty manifest-self` to produce the (manifest, binary) artifact bundle. Publish job is gated on a `OSTY_SELF_REGISTRY_URL` repo variable so live publishing stays opt-in until A6 (signing) lands.

## Test plan

- [x] `go test ./internal/toolchain/selfhostcache/` — 17 fetcher tests still pass
- [x] `go test ./cmd/osty-native-lirproto/` — wire-shape tests still pass
- [x] `go test -run 'InstallSelf|ManifestSelf|RunInstallSelf|RunManifestSelf|BuildOstySelf' ./cmd/osty/` — 4 new manifest-self tests pass alongside install-self
- [x] `gofmt -l` clean, `go vet ./...` clean
- [ ] Workflow dispatch (manual, post-merge) — verify each matrix runner produces a valid (manifest, binary) bundle

## Roadmap

- A5 (this PR) — wiring + manifest CLI + CI scaffold ✅
- A6 — manifest signing (sigstore / minisign) for supply-chain integrity
- A7 — `verify-self-rebuild` cache awareness
- A8 — cache GC
- A9 — README / user guide for bootstrap

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_