### PR TITLE
feat(toolchain): verify-self-rebuild consults selfhostcache (A7)

### DIFF
--- a/cmd/osty/cache_self.go
+++ b/cmd/osty/cache_self.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+// runCacheSelf prints the canonical content-addressed cache entry
+// for the current `(toolchain SHA, host triple)` tuple. Used by
+// shell tooling (`scripts/verify-self-rebuild`, `just bootstrap`)
+// to consult the cache without spawning a Go process per query
+// or duplicating the SHA logic in bash.
+//
+// Modes:
+//
+//	osty cache-self                     # print absolute path; exit 0
+//	                                      regardless of whether the
+//	                                      file exists (path-only).
+//	osty cache-self --check             # print path; exit 0 only when
+//	                                      the file exists. Exit 1 +
+//	                                      diagnostic to stderr on miss.
+//	osty cache-self --key               # print the cache key
+//	                                      `<sha>-<triple>` instead of
+//	                                      the full path. Useful for
+//	                                      manifest filename derivation.
+//	osty cache-self --triple            # print only the host triple.
+//
+// Flag combinations are mutually exclusive — passing more than one
+// is a usage error.
+func runCacheSelf(args []string, _ cliFlags) {
+	fs := flag.NewFlagSet("cache-self", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, cacheSelfUsage())
+		fs.PrintDefaults()
+	}
+	var (
+		check  bool
+		keyOut bool
+		triple bool
+	)
+	fs.BoolVar(&check, "check", false, "exit non-zero when the cached binary is absent")
+	fs.BoolVar(&keyOut, "key", false, "print the cache key (<sha>-<triple>) instead of the path")
+	fs.BoolVar(&triple, "triple", false, "print only the host triple stamp")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if countTrue(keyOut, triple) > 1 {
+		fmt.Fprintln(os.Stderr, "osty cache-self: --key and --triple are mutually exclusive")
+		os.Exit(2)
+	}
+
+	if triple {
+		fmt.Println(selfhostcache.HostTriple())
+		return
+	}
+
+	root, err := selfhostcache.LocateProjectRoot(".")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty cache-self: locate project root: %v\n", err)
+		os.Exit(1)
+	}
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty cache-self: compute key: %v\n", err)
+		os.Exit(1)
+	}
+	if keyOut {
+		fmt.Println(key.String())
+		return
+	}
+
+	path := selfhostcache.CachePath(root, key)
+	if check {
+		info, err := os.Stat(path)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			fmt.Fprintf(os.Stderr, "osty cache-self: no cached binary at %s\n", path)
+			os.Exit(1)
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "osty cache-self: stat %s: %v\n", path, err)
+			os.Exit(1)
+		case info.IsDir():
+			fmt.Fprintf(os.Stderr, "osty cache-self: %s is a directory, not a binary\n", path)
+			os.Exit(1)
+		}
+	}
+	fmt.Println(path)
+}
+
+func countTrue(bs ...bool) int {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+func cacheSelfUsage() string {
+	return strings.TrimSpace(`
+osty cache-self [--check] [--key | --triple]
+    Print the canonical .osty/cache/self-host/<sha>-<triple>/osty-self
+    path for the current toolchain source state and host triple.
+    --check exits non-zero when the cached binary is missing so
+    shell scripts can branch on cache hit/miss without parsing the
+    output. --key prints just the <sha>-<triple> stem; --triple
+    prints just the host triple stamp.
+`)
+}

--- a/cmd/osty/cache_self_test.go
+++ b/cmd/osty/cache_self_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+func TestCacheSelfUsageMessage(t *testing.T) {
+	got := cacheSelfUsage()
+	for _, want := range []string{
+		"osty cache-self",
+		"--check",
+		"--key",
+		"--triple",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// fixtureRoot stages a synthetic project with a toolchain dir so
+// `osty cache-self` can compute a real Key without depending on the
+// repository's own toolchain/.
+func fixtureRoot(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	tc := filepath.Join(dir, "toolchain")
+	if err := os.MkdirAll(tc, 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tc, "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	return dir
+}
+
+func TestCacheSelfPathPrintsCanonicalLocation(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := fixtureRoot(t)
+
+	cmd := exec.Command(ostyBin, "cache-self")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cache-self: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, ".osty/cache/self-host/") {
+		t.Errorf("path missing canonical prefix: %s", got)
+	}
+	if !strings.HasSuffix(got, selfhostcache.BinaryName()) {
+		t.Errorf("path missing binary name suffix: %s", got)
+	}
+	// Path-only mode succeeds even when the file does not exist.
+	if _, err := os.Stat(got); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected path to be absent, got stat err=%v", err)
+	}
+}
+
+func TestCacheSelfCheckExitsNonZeroOnMiss(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := fixtureRoot(t)
+
+	cmd := exec.Command(ostyBin, "cache-self", "--check")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected exit error when cache empty\n%s", out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("got %v, want ExitError", err)
+	}
+	if ee.ExitCode() != 1 {
+		t.Errorf("exit = %d, want 1", ee.ExitCode())
+	}
+	if !strings.Contains(string(out), "no cached binary") {
+		t.Errorf("output missing diagnostic:\n%s", out)
+	}
+}
+
+func TestCacheSelfCheckExitsZeroOnHit(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := fixtureRoot(t)
+
+	// Pre-populate the cache the way `osty install-self` would —
+	// compute the key, write the binary at the canonical path.
+	key, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	target := selfhostcache.CachePath(root, key)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("fake binary"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmd := exec.Command(ostyBin, "cache-self", "--check")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cache-self --check: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != target {
+		t.Errorf("path = %q, want %q", got, target)
+	}
+}
+
+func TestCacheSelfKeyPrintsShaTriple(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := fixtureRoot(t)
+
+	cmd := exec.Command(ostyBin, "cache-self", "--key")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cache-self --key: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, "-"+selfhostcache.HostTriple()) {
+		t.Errorf("key missing triple suffix: %s", got)
+	}
+	// Cross-check by recomputing the key in-process.
+	want, err := selfhostcache.ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+	if got != want.String() {
+		t.Errorf("key = %q, want %q", got, want.String())
+	}
+}
+
+func TestCacheSelfTripleNeedsNoToolchainDir(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	dir := t.TempDir()
+
+	// No `osty.toml`, no toolchain/. --triple must work anyway —
+	// it's purely runtime metadata.
+	cmd := exec.Command(ostyBin, "cache-self", "--triple")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cache-self --triple: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != selfhostcache.HostTriple() {
+		t.Errorf("triple = %q, want %q", got, selfhostcache.HostTriple())
+	}
+}
+
+func TestCacheSelfRejectsKeyAndTripleTogether(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := fixtureRoot(t)
+
+	cmd := exec.Command(ostyBin, "cache-self", "--key", "--triple")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected exit error\n%s", out)
+	}
+	if !strings.Contains(string(out), "mutually exclusive") {
+		t.Errorf("output missing exclusion note:\n%s", out)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -209,6 +209,14 @@ func main() {
 		runSignSelf(args[1:], flags)
 		return
 	}
+	// cache-self prints the content-addressed cache path for the
+	// current toolchain SHA + host triple. Shell tooling
+	// (`verify-self-rebuild`, `just bootstrap`) consults this to
+	// branch on cache hit/miss without recomputing the SHA in bash.
+	if cmd == "cache-self" {
+		runCacheSelf(args[1:], flags)
+		return
+	}
 	// `osty lint --explain CODE` prints the rule's description and
 	// exits. `osty lint --list` prints every rule. Both short-circuit
 	// before the normal file-arg handling below.

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -51,7 +51,8 @@ PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
 | **A3** | `osty install-self` 서브커맨드 — toolchain 빌드 + 캐시 적재 한 번에. `just bootstrap` 레시피가 build-all + install-self 호출. | TestInstallSelfUsageMessage / TestBuildOstySelf — **구현 완료** |
 | **A4** | 네트워크 fetcher — `<base>/<sha>-<triple>.json` manifest + binary 다운로드, SHA-256 검증 필수. `OSTY_SELF_REGISTRY_URL` / `OSTY_SELF_REGISTRY_OFFLINE` env var 게이트. `ResolveBinaryWithFetch` 가 캐시 miss 시 호출. | 17 tests (httptest server 기반) — **구현 완료** |
 | **A5** | `cmd/osty-native-lirproto` 가 `ResolveBinaryWithFetch` + `EnvFetcher()` 호출. `osty manifest-self` 서브커맨드 — 빌드된 binary → manifest JSON. `.github/workflows/build-osty-self.yml` 6개 triple matrix scaffold (manual dispatch). | manifest round-trip 4 tests + 기존 lirproto/selfhostcache 회귀 — **구현 완료** |
-| **A6** (이 PR) | Manifest signing — ed25519 detached sig (`<key>.json.sig`). `OSTY_SELF_TRUSTED_KEY` env var로 verify. `osty sign-self` / `osty sign-self genkey` 서브커맨드. CI workflow 가 `OSTY_SELF_SIGNING_KEY` secret 있을 때만 서명. | 14 unit tests (signing.go) + 4 CLI round-trip tests — **구현 완료** |
+| **A6** | Manifest signing — ed25519 detached sig (`<key>.json.sig`). `OSTY_SELF_TRUSTED_KEY` env var로 verify. `osty sign-self` / `osty sign-self genkey` 서브커맨드. CI workflow 가 `OSTY_SELF_SIGNING_KEY` secret 있을 때만 서명. | 14 unit tests (signing.go) + 4 CLI round-trip tests — **구현 완료** |
+| **A7** (이 PR) | `verify-self-rebuild --reuse-stage1` 가 selfhostcache 인식. `osty cache-self [--check\|--key\|--triple]` 서브커맨드 — 컨텐트-어드레스드 캐시 path/key 조회. cache hit 시 stage1 빌드 skip; fresh 빌드는 자동 promote. `--no-selfhostcache` 로 legacy mtime 캐시 fallback. | 7 cache-self CLI 단위 테스트 — **구현 완료** |
 
 ## 4. Key 구성
 

--- a/scripts/verify-self-rebuild
+++ b/scripts/verify-self-rebuild
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
 	cat <<'USAGE'
-usage: scripts/verify-self-rebuild [--gates-only|--ir-only|--stage1-only] [--skip-gates] [--reuse-stage1] [HOST_OSTY_BIN]
+usage: scripts/verify-self-rebuild [--gates-only|--ir-only|--stage1-only] [--skip-gates] [--reuse-stage1] [--no-selfhostcache] [HOST_OSTY_BIN]
 
 Runs the self-rebuild ratchet:
 
@@ -24,12 +24,19 @@ Environment overrides:
 --stage1-only builds osty-self-1 only.
 --skip-gates reuses the current tree and jumps straight to the selected build loop.
 --reuse-stage1 reuses/caches osty-self-1 so repeated stage2/parity loops skip the slow first build.
+                When the content-addressed selfhostcache (.osty/cache/self-host/<sha>-<triple>/)
+                holds a fresh entry, --reuse-stage1 short-circuits the slow stage1 build and
+                also promotes any freshly built stage1 binary into the cache for
+                cross-worktree reuse (A7).
+--no-selfhostcache disables the selfhostcache integration; --reuse-stage1 falls back
+                to the legacy mtime-based stage1 cache only.
 USAGE
 }
 
 mode="full"
 skip_gates=0
 reuse_stage1=0
+no_selfhostcache=0
 while [[ $# -gt 0 ]]; do
 	case "${1:-}" in
 	--help | -h)
@@ -54,6 +61,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--reuse-stage1)
 		reuse_stage1=1
+		shift
+		;;
+	--no-selfhostcache)
+		no_selfhostcache=1
 		shift
 		;;
 	--)
@@ -179,6 +190,42 @@ stage1_cache_fresh() {
 		fi
 	done < <(find "$toolchain_dir" -type f ! -path "$toolchain_dir/.osty/*")
 	return 0
+}
+
+# selfhostcache_path prints the canonical
+# `.osty/cache/self-host/<sha>-<triple>/osty-self` path for the
+# current toolchain source state. Empty stdout + non-zero exit means
+# the host osty does not yet support `cache-self` (running against a
+# pre-A7 binary) so callers fall through to the legacy mtime cache.
+selfhostcache_path() {
+	[[ "$no_selfhostcache" == "0" ]] || return 1
+	"$host_bin" cache-self 2>/dev/null
+}
+
+# selfhostcache_check exits 0 iff the content-addressed cache holds
+# a binary for the current key. Stdout is the cache path on success.
+selfhostcache_check() {
+	[[ "$no_selfhostcache" == "0" ]] || return 1
+	"$host_bin" cache-self --check 2>/dev/null
+}
+
+# install_into_selfhostcache copies a freshly built stage1 binary
+# into `.osty/cache/self-host/<sha>-<triple>/`. Idempotent — repeated
+# promotion of the same `(toolchain SHA, triple)` overwrites the
+# entry. Direct copy avoids re-running `install-self` (which would
+# rebuild toolchain/ from scratch — wasteful when the caller already
+# has a fresh stage1 binary in hand). Pre-A7 host osty binaries
+# (no `cache-self` subcommand) silently fall through.
+install_into_selfhostcache() {
+	local src="$1"
+	[[ "$no_selfhostcache" == "0" ]] || return 0
+	local target
+	target="$(selfhostcache_path 2>/dev/null)" || return 0
+	[[ -n "$target" ]] || return 0
+	mkdir -p "$(dirname "$target")"
+	cp "$src" "$target"
+	chmod +x "$target"
+	log "stage1: promoted into selfhostcache $target"
 }
 
 build_self_binary() {
@@ -309,20 +356,31 @@ if [[ "$mode" == "ir" ]]; then
 	exit 0
 fi
 
-if [[ "$reuse_stage1" == "1" && -x "$stage1_cache" ]]; then
-	if stage1_cache_fresh; then
+# A7: prefer the content-addressed selfhostcache when --reuse-stage1
+# is requested. The cache key encodes the SHA-256 of every
+# `toolchain/*.osty` file plus the host triple, so a hit is guaranteed
+# fresh by construction (no mtime races, no cross-worktree drift).
+# A miss falls through to the legacy mtime-based stage1 cache, which
+# still helps in environments where `osty cache-self` is unavailable
+# (older host osty binaries). On a fresh build we promote the result
+# into both caches so the next ratchet hits the fast path.
+selfhostcache_hit=""
+if [[ "$reuse_stage1" == "1" ]]; then
+	if selfhostcache_hit="$(selfhostcache_check)" && [[ -n "$selfhostcache_hit" ]]; then
+		log "stage1: reuse selfhostcache $selfhostcache_hit"
+		copy_override_binary "$selfhostcache_hit" "$stage1" "osty-self-1 selfhostcache"
+	elif [[ -x "$stage1_cache" ]] && stage1_cache_fresh; then
 		log "stage1: reuse cache $stage1_cache"
 		copy_override_binary "$stage1_cache" "$stage1" "osty-self-1 cache"
 	else
-		log "stage1: cache stale; rebuild $stage1_cache"
+		[[ -x "$stage1_cache" ]] && log "stage1: cache stale; rebuild $stage1_cache"
 		build_self_binary "$host_bin" "stage1" "$stage1"
 		cache_stage1_binary "$stage1"
+		install_into_selfhostcache "$stage1"
 	fi
 else
 	build_self_binary "$host_bin" "stage1" "$stage1"
-	if [[ "$reuse_stage1" == "1" ]]; then
-		cache_stage1_binary "$stage1"
-	fi
+	install_into_selfhostcache "$stage1"
 fi
 
 smoke_self_driver "$stage1" "stage1"


### PR DESCRIPTION
## Summary

Phase A7 of the `osty-self` artifact cache (`docs/osty_self_artifact_design.md`). Closes the loop between the content-addressed cache (A1–A6) and the developer-facing `verify-self-rebuild` ratchet — `--reuse-stage1` now reuses cache entries built in other worktrees and skips the slow stage1 build when toolchain sources match.

- **`osty cache-self` subcommand.** Single primitive shell tooling needs to consult the cache. Modes: bare path (always exit 0), `--check` (exit 1 on miss), `--key` (just the `<sha>-<triple>` stem), `--triple` (just the host triple — works without a toolchain dir).
- **`scripts/verify-self-rebuild` lookup chain** is now selfhostcache → legacy mtime cache → fresh build. A fresh build promotes the result into both caches so subsequent runs hit the fast path.
- **`--no-selfhostcache` escape hatch** retains the pre-A7 mtime-only behaviour for operators running against an older host osty without `cache-self`.

Why selfhostcache > legacy mtime: cache key encodes the SHA-256 of every `toolchain/*.osty` file, so a hit is guaranteed fresh regardless of file mtimes — fixes the stale-mtime false positives that bit cross-worktree workflows.

## Test plan

- [x] `go test -run TestCacheSelf ./cmd/osty/` — 7 tests covering path/check/key/triple modes + flag conflict rejection
- [x] Manual smoke test: cache-self prints `<root>/.osty/cache/self-host/<64-hex>-linux-amd64/osty-self`; `--check` exits 1 on miss, 0 on hit
- [x] `bash -n scripts/verify-self-rebuild` — syntax clean
- [x] No regressions in `./internal/toolchain/selfhostcache/` or `./cmd/osty-native-lirproto/`
- [ ] Full `just verify-self-rebuild --reuse-stage1` run (manual, requires LLVM toolchain)

## Roadmap

- A7 (this PR) — verify-self-rebuild cache awareness ✅
- A8 — cache GC (prevent `.osty/cache/self-host/` from growing unbounded)
- A9 — README / user guide for bootstrap

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_