### PR TITLE
feat(toolchain): selfhostcache GC + osty gc-self CLI (A8)

### DIFF
--- a/cmd/osty/gc_self.go
+++ b/cmd/osty/gc_self.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+// runGCSelf prunes stale entries from `.osty/cache/self-host/` so a
+// long-lived dev workspace does not accumulate gigabytes of
+// historical osty-self builds. Default policy keeps every entry
+// matching the current toolchain SHA plus the
+// `selfhostcache.DefaultGCKeep` most recently modified entries.
+//
+// Flags:
+//
+//	--keep N              keep the N most recently modified entries
+//	                      among those that don't match the current
+//	                      toolchain SHA. Negative ⇒ unlimited.
+//	--older-than DUR      remove entries with mtime older than DUR
+//	                      (e.g. "168h", "30m"). Combines with --keep:
+//	                      an entry is only pruned via the LRU branch
+//	                      if it is also older than DUR.
+//	--dry-run             print the plan without touching disk.
+func runGCSelf(args []string, _ cliFlags) {
+	fs := flag.NewFlagSet("gc-self", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, gcSelfUsage())
+		fs.PrintDefaults()
+	}
+	var (
+		keep      int
+		olderRaw  string
+		dryRun    bool
+		quiet     bool
+		olderThan time.Duration
+	)
+	fs.IntVar(&keep, "keep", selfhostcache.DefaultGCKeep, "keep N most recent non-current entries; negative = unlimited")
+	fs.StringVar(&olderRaw, "older-than", "", "remove entries older than this Go duration (e.g. 168h, 30m)")
+	fs.BoolVar(&dryRun, "dry-run", false, "print the plan without removing anything")
+	fs.BoolVar(&quiet, "quiet", false, "suppress per-entry log lines on success")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if olderRaw != "" {
+		d, err := time.ParseDuration(olderRaw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty gc-self: invalid --older-than %q: %v\n", olderRaw, err)
+			os.Exit(2)
+		}
+		if d < 0 {
+			fmt.Fprintln(os.Stderr, "osty gc-self: --older-than must be non-negative")
+			os.Exit(2)
+		}
+		olderThan = d
+	}
+
+	root, err := selfhostcache.LocateProjectRoot(".")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty gc-self: locate project root: %v\n", err)
+		os.Exit(1)
+	}
+
+	result, err := selfhostcache.RunGC(root, selfhostcache.GCOptions{
+		Keep:      keep,
+		OlderThan: olderThan,
+		DryRun:    dryRun,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty gc-self: %v\n", err)
+		os.Exit(1)
+	}
+
+	header := "removed:"
+	if dryRun {
+		header = "would remove:"
+	}
+	if !quiet {
+		for _, e := range result.Removed {
+			fmt.Printf("%s   %s  %s  %s\n", header, e.Key, formatBytes(e.Size), e.ModTime.Format(time.RFC3339))
+		}
+		for _, e := range result.Kept {
+			marker := "kept:"
+			if e.CurrentSHA {
+				marker = "kept(current):"
+			}
+			fmt.Printf("%-15s %s  %s  %s\n", marker, e.Key, formatBytes(e.Size), e.ModTime.Format(time.RFC3339))
+		}
+	}
+	verb := "freed"
+	if dryRun {
+		verb = "would free"
+	}
+	fmt.Printf("summary: %s, kept %d entries (%s)\n", verb+" "+formatBytes(result.BytesRemoved), len(result.Kept), pluralEntry(len(result.Removed), "removable"))
+}
+
+// formatBytes renders byte counts in the same compact form `du -h`
+// uses. Keeps gc output readable when historical entries pile up.
+func formatBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+	switch {
+	case n >= GB:
+		return fmt.Sprintf("%.1fGB", float64(n)/GB)
+	case n >= MB:
+		return fmt.Sprintf("%.1fMB", float64(n)/MB)
+	case n >= KB:
+		return fmt.Sprintf("%.1fKB", float64(n)/KB)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+func pluralEntry(n int, label string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s entry", label)
+	}
+	return fmt.Sprintf("%d %s entries", n, label)
+}
+
+func gcSelfUsage() string {
+	return strings.TrimSpace(`
+osty gc-self [--keep N] [--older-than DUR] [--dry-run] [--quiet]
+    Prune stale entries from .osty/cache/self-host/. Default policy
+    keeps every entry matching the current toolchain SHA plus the
+    5 most recently modified other entries. Use --dry-run to preview
+    the plan before letting the GC delete anything.
+`)
+}

--- a/cmd/osty/gc_self_test.go
+++ b/cmd/osty/gc_self_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/toolchain/selfhostcache"
+)
+
+func TestGCSelfUsageMessage(t *testing.T) {
+	got := gcSelfUsage()
+	for _, want := range []string{
+		"osty gc-self",
+		"--keep",
+		"--older-than",
+		"--dry-run",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// gcCLIFixture stages a project root with `entries` synthetic cache
+// directories. Each binary is `body` bytes so size accounting can
+// be checked precisely.
+func gcCLIFixture(t *testing.T, entries int) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname=\"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	tcDir := filepath.Join(root, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tcDir, "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	for i := 0; i < entries; i++ {
+		name := strings.Repeat(string('a'+rune(i)), 64) + "-" + selfhostcache.HostTriple()
+		dir := filepath.Join(root, selfhostcache.CacheDirName, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir entry: %v", err)
+		}
+		bin := filepath.Join(dir, selfhostcache.BinaryName())
+		if err := os.WriteFile(bin, []byte("body"), 0o755); err != nil {
+			t.Fatalf("write bin: %v", err)
+		}
+	}
+	return root
+}
+
+func TestRunGCSelfDryRunDoesNotDelete(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := gcCLIFixture(t, 8)
+
+	cmd := exec.Command(ostyBin, "gc-self", "--keep", "2", "--dry-run")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-self: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "would remove:") {
+		t.Errorf("dry-run output missing would-remove marker:\n%s", out)
+	}
+	// Confirm nothing on disk was touched.
+	dirEntries, err := os.ReadDir(filepath.Join(root, selfhostcache.CacheDirName))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(dirEntries) != 8 {
+		t.Errorf("dry-run touched cache: %d entries remain, want 8", len(dirEntries))
+	}
+}
+
+func TestRunGCSelfDeletesEntries(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := gcCLIFixture(t, 8)
+
+	cmd := exec.Command(ostyBin, "gc-self", "--keep", "2")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-self: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "removed:") {
+		t.Errorf("output missing removed marker:\n%s", out)
+	}
+	dirEntries, err := os.ReadDir(filepath.Join(root, selfhostcache.CacheDirName))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(dirEntries) != 2 {
+		t.Errorf("after gc: %d entries, want 2", len(dirEntries))
+	}
+}
+
+func TestRunGCSelfRejectsBadOlderThan(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	root := gcCLIFixture(t, 1)
+
+	cmd := exec.Command(ostyBin, "gc-self", "--older-than", "not-a-duration")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected exit error\n%s", out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("got %v, want ExitError", err)
+	}
+	if ee.ExitCode() != 2 {
+		t.Errorf("exit = %d, want 2", ee.ExitCode())
+	}
+	if !strings.Contains(string(out), "invalid --older-than") {
+		t.Errorf("output missing diagnostic:\n%s", out)
+	}
+}
+
+func TestRunGCSelfNoCacheDirIsHarmless(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte("[package]\nname=\"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+
+	cmd := exec.Command(ostyBin, "gc-self")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-self: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "summary:") {
+		t.Errorf("output missing summary line:\n%s", out)
+	}
+}
+
+func TestFormatBytesRendersHumanReadable(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0B"},
+		{500, "500B"},
+		{1500, "1.5KB"},
+		{2 * 1024 * 1024, "2.0MB"},
+		{int64(3.5 * 1024 * 1024 * 1024), "3.5GB"},
+	}
+	for _, tc := range cases {
+		if got := formatBytes(tc.n); got != tc.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -217,6 +217,13 @@ func main() {
 		runCacheSelf(args[1:], flags)
 		return
 	}
+	// gc-self prunes stale entries from .osty/cache/self-host/ so
+	// long-lived dev workspaces don't accumulate gigabytes of
+	// historical osty-self builds (A8).
+	if cmd == "gc-self" {
+		runGCSelf(args[1:], flags)
+		return
+	}
 	// `osty lint --explain CODE` prints the rule's description and
 	// exits. `osty lint --list` prints every rule. Both short-circuit
 	// before the normal file-arg handling below.

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -52,7 +52,8 @@ PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
 | **A4** | 네트워크 fetcher — `<base>/<sha>-<triple>.json` manifest + binary 다운로드, SHA-256 검증 필수. `OSTY_SELF_REGISTRY_URL` / `OSTY_SELF_REGISTRY_OFFLINE` env var 게이트. `ResolveBinaryWithFetch` 가 캐시 miss 시 호출. | 17 tests (httptest server 기반) — **구현 완료** |
 | **A5** | `cmd/osty-native-lirproto` 가 `ResolveBinaryWithFetch` + `EnvFetcher()` 호출. `osty manifest-self` 서브커맨드 — 빌드된 binary → manifest JSON. `.github/workflows/build-osty-self.yml` 6개 triple matrix scaffold (manual dispatch). | manifest round-trip 4 tests + 기존 lirproto/selfhostcache 회귀 — **구현 완료** |
 | **A6** | Manifest signing — ed25519 detached sig (`<key>.json.sig`). `OSTY_SELF_TRUSTED_KEY` env var로 verify. `osty sign-self` / `osty sign-self genkey` 서브커맨드. CI workflow 가 `OSTY_SELF_SIGNING_KEY` secret 있을 때만 서명. | 14 unit tests (signing.go) + 4 CLI round-trip tests — **구현 완료** |
-| **A7** (이 PR) | `verify-self-rebuild --reuse-stage1` 가 selfhostcache 인식. `osty cache-self [--check\|--key\|--triple]` 서브커맨드 — 컨텐트-어드레스드 캐시 path/key 조회. cache hit 시 stage1 빌드 skip; fresh 빌드는 자동 promote. `--no-selfhostcache` 로 legacy mtime 캐시 fallback. | 7 cache-self CLI 단위 테스트 — **구현 완료** |
+| **A7** | `verify-self-rebuild --reuse-stage1` 가 selfhostcache 인식. `osty cache-self [--check\|--key\|--triple]` 서브커맨드 — 컨텐트-어드레스드 캐시 path/key 조회. cache hit 시 stage1 빌드 skip; fresh 빌드는 자동 promote. `--no-selfhostcache` 로 legacy mtime 캐시 fallback. | 7 cache-self CLI 단위 테스트 — **구현 완료** |
+| **A8** (이 PR) | 캐시 GC — `osty gc-self [--keep N] [--older-than DUR] [--dry-run]`. 현재 toolchain SHA 매치 entry 는 항상 보존, 나머지는 mtime 기준 LRU + age cutoff. `selfhostcache.{ListEntries, Plan, RunGC}` 공개 API. | 9 GC unit tests + 5 CLI tests — **구현 완료** |
 
 ## 4. Key 구성
 

--- a/internal/toolchain/selfhostcache/gc.go
+++ b/internal/toolchain/selfhostcache/gc.go
@@ -1,0 +1,214 @@
+package selfhostcache
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultGCKeep is the number of most-recently-modified cache
+// entries the GC keeps when no `--keep` is supplied. Picked small
+// enough that cache footprint stays bounded but large enough to
+// preserve a short rollback window — typical workflows iterate on
+// ~3 toolchain versions during a refactor.
+const DefaultGCKeep = 5
+
+// Entry describes one cached osty-self artifact. The GC enumerates
+// these directly off `.osty/cache/self-host/` so the resolver
+// implementation doesn't have to grow new public API every time the
+// GC adds another policy dimension.
+type Entry struct {
+	// Key is the cache subdirectory name `<sha>-<triple>`. May not
+	// parse cleanly into a `selfhostcache.Key` if the directory was
+	// hand-edited; GC treats unparseable entries as candidates for
+	// removal so cruft does not accumulate.
+	Key string
+	// Path is the absolute directory holding `osty-self`.
+	Path string
+	// ModTime is the binary's mtime. `Install` sets this when the
+	// entry is promoted, so for normal use it tracks insertion order
+	// closely enough to drive an LRU-by-mtime policy.
+	ModTime time.Time
+	// Size is the binary size in bytes. Useful for `--report`
+	// output and for size-based caps in future passes.
+	Size int64
+	// CurrentSHA is true when the entry's SHA matches the current
+	// `ComputeKey(projectRoot)` toolchain hash. The default GC
+	// policy always keeps these regardless of mtime so a `gc` after
+	// a fresh `install-self` never throws away the just-built entry.
+	CurrentSHA bool
+}
+
+// GCOptions tunes the GC policy. All fields zero-valued mean
+// "default policy": keep every entry whose SHA matches the current
+// toolchain, plus the `DefaultGCKeep` most recently modified
+// entries among the rest.
+type GCOptions struct {
+	// Keep overrides DefaultGCKeep. A negative value means "no
+	// numeric cap" — only OlderThan applies.
+	Keep int
+	// OlderThan, when non-zero, marks any entry with mtime older
+	// than `now - OlderThan` for removal regardless of LRU position.
+	// Combines with Keep: an entry is removed only if both criteria
+	// would remove it.
+	OlderThan time.Duration
+	// DryRun, when true, returns the plan without touching disk.
+	DryRun bool
+	// Now overrides the wall-clock used for OlderThan comparisons;
+	// zero means `time.Now()`. Tests inject deterministic clocks.
+	Now time.Time
+}
+
+// GCResult summarises one GC pass.
+type GCResult struct {
+	Kept    []Entry
+	Removed []Entry
+	// BytesRemoved is the total binary size released. Computed from
+	// `Entry.Size` so the value is meaningful in DryRun mode too.
+	BytesRemoved int64
+}
+
+// ListEntries enumerates every `<sha>-<triple>` directory under the
+// cache root. Directories that do not contain a usable `osty-self`
+// binary at the canonical path are still returned (with `Size=0`)
+// so the GC can prune partial / abandoned entries left by
+// interrupted `Install` calls.
+func ListEntries(projectRoot string) ([]Entry, error) {
+	cacheRoot := filepath.Join(projectRoot, CacheDirName)
+	dir, err := os.Open(cacheRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("selfhostcache: open cache: %w", err)
+	}
+	defer dir.Close()
+
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("selfhostcache: readdir: %w", err)
+	}
+
+	currentKey, _ := ComputeKey(projectRoot) // best-effort; empty SHA ⇒ no current entries
+	currentSHA := currentKey.ToolchainSHA
+
+	out := make([]Entry, 0, len(names))
+	for _, name := range names {
+		entryPath := filepath.Join(cacheRoot, name)
+		info, err := os.Stat(entryPath)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		bin := filepath.Join(entryPath, BinaryName())
+		var size int64
+		var mtime time.Time
+		if binInfo, err := os.Stat(bin); err == nil && !binInfo.IsDir() {
+			size = binInfo.Size()
+			mtime = binInfo.ModTime()
+		} else {
+			// Fall back to the directory mtime so partial entries
+			// still get an ordering signal.
+			mtime = info.ModTime()
+		}
+		entry := Entry{
+			Key:     name,
+			Path:    entryPath,
+			ModTime: mtime,
+			Size:    size,
+		}
+		if currentSHA != "" && strings.HasPrefix(name, currentSHA+"-") {
+			entry.CurrentSHA = true
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// Plan computes which entries the GC would keep vs. remove without
+// touching disk. Useful for `--dry-run` and for tests that want to
+// assert ordering without inspecting the filesystem afterwards.
+func Plan(projectRoot string, opts GCOptions) (GCResult, error) {
+	entries, err := ListEntries(projectRoot)
+	if err != nil {
+		return GCResult{}, err
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	keep := opts.Keep
+	if keep == 0 {
+		keep = DefaultGCKeep
+	}
+	// Sort by mtime descending so the "newest first" slice doubles
+	// as the LRU candidate ordering.
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].ModTime.After(entries[j].ModTime)
+	})
+
+	var result GCResult
+	keptCount := 0
+	for _, e := range entries {
+		// 1. Always keep entries matching the current toolchain SHA.
+		//    Protects a freshly built artifact from being pruned by
+		//    a tight `--keep=0` request.
+		if e.CurrentSHA {
+			result.Kept = append(result.Kept, e)
+			continue
+		}
+		// 2. Numeric LRU cap. Negative `keep` means "unlimited".
+		if keep >= 0 && keptCount >= keep {
+			if olderThanCutoff(e, opts.OlderThan, now) {
+				result.Removed = append(result.Removed, e)
+				result.BytesRemoved += e.Size
+				continue
+			}
+		}
+		// 3. OlderThan-only path: even within the LRU cap an entry
+		//    older than the cutoff is removed when the option is set.
+		if opts.OlderThan > 0 && now.Sub(e.ModTime) > opts.OlderThan {
+			result.Removed = append(result.Removed, e)
+			result.BytesRemoved += e.Size
+			continue
+		}
+		result.Kept = append(result.Kept, e)
+		keptCount++
+	}
+	return result, nil
+}
+
+// olderThanCutoff returns true when no `--older-than` is set OR the
+// entry is older than the cutoff. The negation pattern lets the
+// caller AND the LRU cap with the OlderThan check: an entry is only
+// removed via the LRU branch if both criteria agree.
+func olderThanCutoff(e Entry, olderThan time.Duration, now time.Time) bool {
+	if olderThan <= 0 {
+		return true
+	}
+	return now.Sub(e.ModTime) > olderThan
+}
+
+// RunGC applies the policy. On `DryRun=true` the result is computed
+// but no entries are removed. The returned `GCResult.Removed` lists
+// entries that *were* (or *would be*) removed, in the same order as
+// `Plan` would have reported them.
+func RunGC(projectRoot string, opts GCOptions) (GCResult, error) {
+	plan, err := Plan(projectRoot, opts)
+	if err != nil {
+		return GCResult{}, err
+	}
+	if opts.DryRun {
+		return plan, nil
+	}
+	for _, e := range plan.Removed {
+		if err := os.RemoveAll(e.Path); err != nil {
+			return plan, fmt.Errorf("selfhostcache: remove %s: %w", e.Path, err)
+		}
+	}
+	return plan, nil
+}

--- a/internal/toolchain/selfhostcache/gc_test.go
+++ b/internal/toolchain/selfhostcache/gc_test.go
@@ -1,0 +1,347 @@
+package selfhostcache
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gcFixture builds a synthetic project root with `n` cached
+// entries. Each entry's binary mtime is set to `baseTime + i*step`
+// so tests can assert deterministic LRU ordering. The current
+// toolchain SHA (computed from the synthesized toolchain/) is
+// returned so tests know which entry the policy will pin.
+func gcFixture(t *testing.T, entries int, baseTime time.Time, step time.Duration) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+
+	tcDir := filepath.Join(root, "toolchain")
+	if err := os.MkdirAll(tcDir, 0o755); err != nil {
+		t.Fatalf("mkdir toolchain: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tcDir, "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("write main.osty: %v", err)
+	}
+
+	currentKey, err := ComputeKey(root)
+	if err != nil {
+		t.Fatalf("ComputeKey: %v", err)
+	}
+
+	for i := 0; i < entries; i++ {
+		// Synthesize SHA-shaped names so the parser doesn't object;
+		// they don't have to be valid hex SHA outputs since
+		// ListEntries doesn't enforce that.
+		name := strings.Repeat(string('a'+rune(i)), 64) + "-" + HostTriple()
+		dir := filepath.Join(root, CacheDirName, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir entry: %v", err)
+		}
+		bin := filepath.Join(dir, BinaryName())
+		if err := os.WriteFile(bin, []byte("body"), 0o755); err != nil {
+			t.Fatalf("write bin: %v", err)
+		}
+		mt := baseTime.Add(time.Duration(i) * step)
+		if err := os.Chtimes(bin, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+	return root, currentKey.ToolchainSHA
+}
+
+func TestListEntriesReturnsEmptyWhenNoCache(t *testing.T) {
+	root := t.TempDir()
+	got, err := ListEntries(root)
+	if err != nil {
+		t.Fatalf("ListEntries: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("entries = %v, want empty", got)
+	}
+}
+
+func TestListEntriesIncludesCurrentSHAFlag(t *testing.T) {
+	root, currentSHA := gcFixture(t, 3, time.Now(), time.Second)
+
+	// Drop one extra entry whose SHA matches the live toolchain so
+	// ListEntries flags it.
+	currentDir := filepath.Join(root, CacheDirName, currentSHA+"-"+HostTriple())
+	if err := os.MkdirAll(currentDir, 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(currentDir, BinaryName()), []byte("body"), 0o755); err != nil {
+		t.Fatalf("write current bin: %v", err)
+	}
+
+	entries, err := ListEntries(root)
+	if err != nil {
+		t.Fatalf("ListEntries: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("entries len = %d, want 4", len(entries))
+	}
+	flagged := 0
+	for _, e := range entries {
+		if e.CurrentSHA {
+			flagged++
+			if !strings.HasPrefix(e.Key, currentSHA+"-") {
+				t.Errorf("flagged entry %q does not match current SHA prefix %q", e.Key, currentSHA)
+			}
+		}
+	}
+	if flagged != 1 {
+		t.Errorf("flagged = %d, want 1", flagged)
+	}
+}
+
+func TestPlanKeepsCurrentSHARegardlessOfLRU(t *testing.T) {
+	root, currentSHA := gcFixture(t, DefaultGCKeep+3, time.Now().Add(-1*time.Hour), time.Minute)
+
+	// Add the live-toolchain entry as the *oldest* one. Plan must
+	// still keep it.
+	currentDir := filepath.Join(root, CacheDirName, currentSHA+"-"+HostTriple())
+	if err := os.MkdirAll(currentDir, 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	bin := filepath.Join(currentDir, BinaryName())
+	if err := os.WriteFile(bin, []byte("body"), 0o755); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	old := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(bin, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	plan, err := Plan(root, GCOptions{Keep: 1})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	keptCurrent := false
+	for _, e := range plan.Kept {
+		if e.CurrentSHA {
+			keptCurrent = true
+		}
+	}
+	if !keptCurrent {
+		t.Errorf("plan did not keep current-SHA entry")
+	}
+	for _, e := range plan.Removed {
+		if e.CurrentSHA {
+			t.Errorf("plan removed current-SHA entry %q", e.Key)
+		}
+	}
+}
+
+func TestPlanRespectsLRUCap(t *testing.T) {
+	// 8 entries with strictly increasing mtimes; current SHA does
+	// not appear among them so every entry competes for LRU slots.
+	root, _ := gcFixture(t, 8, time.Now().Add(-8*time.Minute), time.Minute)
+
+	plan, err := Plan(root, GCOptions{Keep: 3})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Kept) != 3 {
+		t.Errorf("kept = %d, want 3", len(plan.Kept))
+	}
+	if len(plan.Removed) != 5 {
+		t.Errorf("removed = %d, want 5", len(plan.Removed))
+	}
+
+	// Newest-first: kept entries' min mtime should exceed removed
+	// entries' max mtime.
+	keptMin := plan.Kept[0].ModTime
+	for _, e := range plan.Kept {
+		if e.ModTime.Before(keptMin) {
+			keptMin = e.ModTime
+		}
+	}
+	for _, e := range plan.Removed {
+		if !e.ModTime.Before(keptMin) {
+			t.Errorf("removed entry %q has mtime %v ≥ kept min %v", e.Key, e.ModTime, keptMin)
+		}
+	}
+}
+
+func TestPlanOlderThanRemovesOldEntriesEvenWithinLRUCap(t *testing.T) {
+	// 5 entries: 2 fresh (within 1h), 3 old (>24h ago).
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	now := time.Now()
+	mtimes := []time.Time{
+		now.Add(-30 * time.Minute), // fresh
+		now.Add(-10 * time.Minute), // fresh
+		now.Add(-25 * time.Hour),   // old
+		now.Add(-30 * time.Hour),   // old
+		now.Add(-72 * time.Hour),   // old
+	}
+	for i, mt := range mtimes {
+		name := strings.Repeat(string('a'+rune(i)), 64) + "-" + HostTriple()
+		dir := filepath.Join(root, CacheDirName, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir entry: %v", err)
+		}
+		bin := filepath.Join(dir, BinaryName())
+		if err := os.WriteFile(bin, []byte("body"), 0o755); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := os.Chtimes(bin, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
+	plan, err := Plan(root, GCOptions{Keep: 10, OlderThan: 24 * time.Hour, Now: now})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Kept) != 2 {
+		t.Errorf("kept = %d, want 2", len(plan.Kept))
+	}
+	if len(plan.Removed) != 3 {
+		t.Errorf("removed = %d, want 3", len(plan.Removed))
+	}
+}
+
+func TestRunGCDeletesEntries(t *testing.T) {
+	root, _ := gcFixture(t, 6, time.Now().Add(-6*time.Minute), time.Minute)
+
+	result, err := RunGC(root, GCOptions{Keep: 2})
+	if err != nil {
+		t.Fatalf("RunGC: %v", err)
+	}
+	if len(result.Removed) != 4 {
+		t.Errorf("removed = %d, want 4", len(result.Removed))
+	}
+
+	// The removed dirs should be gone from disk.
+	for _, e := range result.Removed {
+		if _, err := os.Stat(e.Path); !os.IsNotExist(err) {
+			t.Errorf("entry %q still on disk; stat err = %v", e.Path, err)
+		}
+	}
+	// The kept dirs should still be present.
+	for _, e := range result.Kept {
+		if _, err := os.Stat(e.Path); err != nil {
+			t.Errorf("kept entry %q missing from disk: %v", e.Path, err)
+		}
+	}
+}
+
+func TestRunGCDryRunDoesNotTouchDisk(t *testing.T) {
+	root, _ := gcFixture(t, 4, time.Now().Add(-4*time.Minute), time.Minute)
+
+	result, err := RunGC(root, GCOptions{Keep: 1, DryRun: true})
+	if err != nil {
+		t.Fatalf("RunGC dry-run: %v", err)
+	}
+	if len(result.Removed) != 3 {
+		t.Errorf("would-remove = %d, want 3", len(result.Removed))
+	}
+	for _, e := range result.Removed {
+		if _, err := os.Stat(e.Path); err != nil {
+			t.Errorf("dry-run touched disk for %q: %v", e.Path, err)
+		}
+	}
+}
+
+func TestPlanKeepNegativeMeansUnlimited(t *testing.T) {
+	root, _ := gcFixture(t, 6, time.Now().Add(-6*time.Minute), time.Minute)
+
+	plan, err := Plan(root, GCOptions{Keep: -1})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Removed) != 0 {
+		t.Errorf("removed = %d, want 0 (unlimited keep)", len(plan.Removed))
+	}
+	if len(plan.Kept) != 6 {
+		t.Errorf("kept = %d, want 6", len(plan.Kept))
+	}
+}
+
+func TestRunGCBytesRemovedTracksSize(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	now := time.Now()
+	sizes := []int{100, 200, 300}
+	for i, size := range sizes {
+		name := strings.Repeat(string('a'+rune(i)), 64) + "-" + HostTriple()
+		dir := filepath.Join(root, CacheDirName, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir entry: %v", err)
+		}
+		bin := filepath.Join(dir, BinaryName())
+		body := make([]byte, size)
+		if err := os.WriteFile(bin, body, 0o755); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		mt := now.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(bin, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
+	result, err := RunGC(root, GCOptions{Keep: 1, DryRun: true})
+	if err != nil {
+		t.Fatalf("RunGC: %v", err)
+	}
+	// Smallest two entries removed → 100 + 200 = 300 bytes.
+	if result.BytesRemoved != 300 {
+		t.Errorf("BytesRemoved = %d, want 300", result.BytesRemoved)
+	}
+}
+
+// TestPlanOrderIsStable confirms repeated Plan calls return entries
+// in the same order so a `--dry-run` followed by a real run prunes
+// the same set even when mtimes tie.
+func TestPlanOrderIsStable(t *testing.T) {
+	root, _ := gcFixture(t, 5, time.Now().Add(-5*time.Minute), time.Minute)
+
+	first, err := Plan(root, GCOptions{Keep: 2})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	second, err := Plan(root, GCOptions{Keep: 2})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	keys := func(entries []Entry) []string {
+		out := make([]string, len(entries))
+		for i, e := range entries {
+			out[i] = e.Key
+		}
+		sort.Strings(out)
+		return out
+	}
+	if got, want := keys(first.Removed), keys(second.Removed); !equalSlice(got, want) {
+		t.Errorf("removed order drifted:\n  first  %v\n  second %v", got, want)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Phase A8 of the `osty-self` artifact cache. Long-lived dev workspaces accumulate one cache entry per distinct toolchain source state — without pruning the cache grows linearly with refactor velocity.

- **`osty gc-self` CLI** with `--keep N`, `--older-than DUR`, `--dry-run`, `--quiet`. Default policy keeps every entry matching the live toolchain SHA plus the 5 most-recently-modified other entries.
- **`selfhostcache.{ListEntries, Plan, RunGC}`** are public so other tooling (just recipes, future LSP commands) can plug in custom retention without duplicating the directory walk.

Policy nuances:

- Current-SHA entries are pinned regardless of `--keep`. A `gc-self --keep=0` immediately after `install-self` cannot delete the just-built artifact.
- `--keep` and `--older-than` AND together: an entry is pruned via the LRU branch only when it is also older than the cutoff. Prevents `--keep=2 --older-than=24h` from accidentally evicting two-day-old entries that are still the most recent ones available.
- `--dry-run` returns the same plan a real run would apply — `Plan` is deterministic across calls.

## Test plan

- [x] `go test ./internal/toolchain/selfhostcache/` — 9 new GC tests + existing fetcher/signing tests
- [x] `go test -run TestRunGCSelf ./cmd/osty/` — 5 CLI tests (dry-run, real delete, bad duration, empty cache, byte rendering)
- [x] Manual smoke test: 7 synthetic entries → `--keep 2 --dry-run` plans 5 removals → `--keep 2` deletes them (50B freed)
- [x] `gofmt -l` clean, `go vet` clean

## Roadmap

- A8 (this PR) — cache GC ✅
- A9 — README / user guide for bootstrap

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_