### PR TITLE
docs: README bootstrap section + justfile cache recipes (A9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,102 @@ Requires Go 1.26.2 or newer (matching `go.mod`).
 go build -o osty ./cmd/osty
 ```
 
+## Bootstrapping `osty-self`
+
+The native LLVM backend forks `osty-self lir-proto-lower` for every
+MIR → LLVM IR pass. `osty-self` is itself written in Osty
+(`toolchain/*.osty`) so a fresh clone has a chicken-and-egg moment:
+the host `osty` needs `osty-self` to compile, and `osty-self` needs
+`osty` to compile. The artifact cache resolves this with a
+content-addressed lookup chain so most workflows never have to
+think about it.
+
+### One-shot bootstrap
+
+After `git clone` + `go build -o .bin/osty ./cmd/osty`:
+
+```sh
+just bootstrap   # builds osty + native-checker + native-lirproto, then
+                 # `osty install-self` builds osty-self and promotes it
+                 # into .osty/cache/self-host/<sha>-<triple>/
+```
+
+Subsequent `osty build` / `osty run` / `osty test` invocations resolve
+the binary through the cache and skip the slow toolchain rebuild.
+The cache is keyed on the SHA-256 of every `toolchain/*.osty` file
+plus the host triple, so editing toolchain sources invalidates the
+entry automatically.
+
+### Lookup order
+
+`internal/toolchain/selfhostcache.ResolveBinaryWithFetch` consults,
+in order:
+
+1. `$OSTY_SELF_BIN` — explicit override for debugging or pinning a
+   specific binary.
+2. `toolchain/.osty/out/{debug,release}/llvm/osty-self` — the
+   in-tree build path. Always wins over the cache so an active
+   development build is never shadowed by a stale artifact.
+3. `.osty/cache/self-host/<sha>-<triple>/osty-self` — the
+   content-addressed cache. Populated by `osty install-self` and
+   `verify-self-rebuild --reuse-stage1`.
+4. **Network fetch** from `$OSTY_SELF_REGISTRY_URL` — only when set
+   and `$OSTY_SELF_REGISTRY_OFFLINE` is unset. Successful fetches
+   promote the binary into the local cache so step 3 hits next time.
+
+When all four miss, the resolver returns the canonical `osty-self
+not found` decline so the upstream backend dispatcher can fall back
+to its decline handler.
+
+### Network fetch + signing
+
+CI dispatches the [`build-osty-self`](.github/workflows/build-osty-self.yml)
+workflow per host triple. Each runner produces a manifest +
+binary pair via `osty manifest-self`, optionally signed via
+`osty sign-self` when the `OSTY_SELF_SIGNING_KEY` repo secret is
+available. The published layout is:
+
+```
+<base>/<sha>-<triple>.json       # manifest
+<base>/<sha>-<triple>.json.sig   # ed25519 signature (when signed)
+<base>/<binary-url>              # osty-self binary
+```
+
+Consumer-side env vars:
+
+| Var | Purpose |
+|---|---|
+| `OSTY_SELF_REGISTRY_URL` | Base URL the resolver GETs manifests / binaries from. Unset ⇒ network fetch disabled. |
+| `OSTY_SELF_REGISTRY_OFFLINE` | When truthy, hard-disables the fetcher even with a registry URL set. CI / air-gapped environments. |
+| `OSTY_SELF_TRUSTED_KEY` | 64-char hex ed25519 public key. When set, manifests must be signed under the matching private key or the fetcher rejects them. Unset ⇒ unsigned manifests are accepted (A4-class behaviour). |
+| `OSTY_SELF_BIN` | Bypass everything and use this binary path. |
+| `OSTY_STAGE0_FALLBACK` | Last-resort emergency-only Go MIR→LLVM emitter. See `docs/osty_self_bootstrap_design.md`. |
+
+The fetcher verifies the binary's SHA-256 against the manifest
+unconditionally. The signature check is opt-in via
+`OSTY_SELF_TRUSTED_KEY` — once set the fetcher fails closed on
+missing signatures (`ErrSignatureMissing`) so a registry compromise
+cannot silently downgrade clients.
+
+### Cache maintenance
+
+```sh
+osty cache-self            # print canonical cache path for current toolchain
+osty cache-self --check    # exit 1 if cache miss; useful in shell scripts
+osty cache-self --key      # print the <sha>-<triple> stem
+osty cache-self --triple   # print just the host triple
+
+osty gc-self               # prune stale entries (default: keep current SHA + 5 LRU)
+osty gc-self --dry-run     # print the plan without deleting
+osty gc-self --keep 10     # custom LRU cap
+osty gc-self --older-than 720h  # remove entries older than 30 days
+```
+
+`gc-self` always preserves entries whose SHA matches the current
+toolchain — a `--keep=0` immediately after `install-self` cannot
+delete the just-built artifact. Documented in
+`docs/osty_self_artifact_design.md` (A1–A8 roadmap).
+
 ## Native Checker
 
 `internal/check` prefers an external checker executable boundary when one is

--- a/docs/osty_self_artifact_design.md
+++ b/docs/osty_self_artifact_design.md
@@ -53,7 +53,8 @@ PR #1405 가 in-process Go MIR emitter (`internal/llvmgen`) 를 제거한 뒤,
 | **A5** | `cmd/osty-native-lirproto` 가 `ResolveBinaryWithFetch` + `EnvFetcher()` 호출. `osty manifest-self` 서브커맨드 — 빌드된 binary → manifest JSON. `.github/workflows/build-osty-self.yml` 6개 triple matrix scaffold (manual dispatch). | manifest round-trip 4 tests + 기존 lirproto/selfhostcache 회귀 — **구현 완료** |
 | **A6** | Manifest signing — ed25519 detached sig (`<key>.json.sig`). `OSTY_SELF_TRUSTED_KEY` env var로 verify. `osty sign-self` / `osty sign-self genkey` 서브커맨드. CI workflow 가 `OSTY_SELF_SIGNING_KEY` secret 있을 때만 서명. | 14 unit tests (signing.go) + 4 CLI round-trip tests — **구현 완료** |
 | **A7** | `verify-self-rebuild --reuse-stage1` 가 selfhostcache 인식. `osty cache-self [--check\|--key\|--triple]` 서브커맨드 — 컨텐트-어드레스드 캐시 path/key 조회. cache hit 시 stage1 빌드 skip; fresh 빌드는 자동 promote. `--no-selfhostcache` 로 legacy mtime 캐시 fallback. | 7 cache-self CLI 단위 테스트 — **구현 완료** |
-| **A8** (이 PR) | 캐시 GC — `osty gc-self [--keep N] [--older-than DUR] [--dry-run]`. 현재 toolchain SHA 매치 entry 는 항상 보존, 나머지는 mtime 기준 LRU + age cutoff. `selfhostcache.{ListEntries, Plan, RunGC}` 공개 API. | 9 GC unit tests + 5 CLI tests — **구현 완료** |
+| **A8** | 캐시 GC — `osty gc-self [--keep N] [--older-than DUR] [--dry-run]`. 현재 toolchain SHA 매치 entry 는 항상 보존, 나머지는 mtime 기준 LRU + age cutoff. `selfhostcache.{ListEntries, Plan, RunGC}` 공개 API. | 9 GC unit tests + 5 CLI tests — **구현 완료** |
+| **A9** (이 PR) | README "Bootstrapping `osty-self`" 섹션 — lookup order, env var 표, 네트워크 fetch + signing, cache maintenance. `just cache-self` / `just gc-self` 레시피. | 문서 — **구현 완료** |
 
 ## 4. Key 구성
 

--- a/justfile
+++ b/justfile
@@ -46,6 +46,18 @@ build-all: build build-checker build-lirproto
 bootstrap: build-all
     {{bin}} install-self
 
+# cache-self prints the canonical .osty/cache/self-host/<sha>-<triple>/
+# osty-self path for the current toolchain SHA + host triple. With
+# `--check` it doubles as a fast cache-hit probe for shell tooling.
+cache-self *args: build
+    {{bin}} cache-self {{args}}
+
+# gc-self prunes stale entries from .osty/cache/self-host/. Default
+# policy keeps the current toolchain SHA plus the 5 most recently
+# modified other entries. Pass `--dry-run` first to preview the plan.
+gc-self *args: build
+    {{bin}} gc-self {{args}}
+
 # Cross-compile osty (+ native-checker) for every supported host triple.
 # Targets: linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/{amd64,arm64}.
 # Artifacts land in .bin/cross/<goos>-<goarch>/.


### PR DESCRIPTION
## Summary

Phase A9 closes the artifact-cache A-series (A1–A8 implementation done; this PR documents it).

- **README "Bootstrapping `osty-self`" section.** Walks through the chicken-egg, the four-step lookup chain, the producer-side CI flow, and the cache-maintenance commands.
- **Env var table** consolidates `OSTY_SELF_BIN`, `OSTY_SELF_REGISTRY_URL`, `OSTY_SELF_REGISTRY_OFFLINE`, `OSTY_SELF_TRUSTED_KEY`, `OSTY_STAGE0_FALLBACK`. Cross-references `docs/osty_self_artifact_design.md` + `docs/osty_self_bootstrap_design.md`.
- **`just cache-self` / `just gc-self`** recipes mirror the new CLI so cache maintenance lands inside `just --list` discovery.

## Test plan

- [x] Manual review of inserted README section
- [x] Recipes parse with `grep -E '^[a-zA-Z][a-zA-Z0-9-]*[: ]'` — `just` not installed in this env so deferred to CI
- [x] Docs-only PR — no code touched, no test impact

## Roadmap

A1–A9 ✅ artifact cache done. Remaining open items in `docs/osty_self_artifact_design.md` (CI host policy, release cadence, storage cost decisions) require maintainer input before further code lands.

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_