### PR TITLE
feat(backend/stage0): struct field binary-op return (P15)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -334,6 +334,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchStructFieldRead(fn, mctx); ok {
 		return emitStructFieldRead(out, fn, pat)
 	}
+	if pat, ok := matchStructFieldBinaryOp(fn, mctx); ok {
+		return emitStructFieldBinaryOp(out, fn, pat)
+	}
 	if pat, ok := matchListLiteralLen(fn, mctx); ok {
 		return emitListLiteralLen(out, fn, pat)
 	}
@@ -2241,6 +2244,188 @@ func emitStructFieldRead(out *strings.Builder, fn *mir.Function, pat structField
 	return nil
 }
 
+// ---- P15: struct field binary-op return ----
+//
+// stage0 P15 handles the inlined "two-field arithmetic" shape produced
+// by the front-end for code like:
+//
+//	fn pointSum(p: Point) -> Int { p.x + p.y }
+//
+// MIR shape:
+//
+//	fn name(p: Struct) -> T {
+//	  bb0:
+//	    AssignInstr ReturnLocal = BinaryRV(op,
+//	        Copy(p.fieldI) | ConstOp,
+//	        Copy(p.fieldJ) | ConstOp)
+//	    ReturnTerm
+//	}
+//
+// One struct param, all-scalar fields, single block, single AssignInstr
+// to ReturnLocal whose Src is a BinaryRV. Each operand is independently
+// either a single FieldProj on the struct param or a scalar ConstOp.
+// Operator families: same as matchSequentialReturn (arithmetic,
+// comparison, bitwise, shift, logical).
+//
+// Output:
+//
+//	define <retT> @<name>(%<Struct> %<paramName>) {
+//	entry:
+//	  %0 = extractvalue %<Struct> %<paramName>, <I>     ; only when needed
+//	  %1 = extractvalue %<Struct> %<paramName>, <J>     ; only when needed
+//	  %2 = <llvmOp> <opT> %0, %1
+//	  ret <retT> %2
+//	}
+
+type p15FieldOperand struct {
+	isField    bool
+	fieldIndex int
+	constText  string // formatted scalar literal when !isField
+}
+
+type structFieldBinaryOpPattern struct {
+	structName  string
+	fieldTypes  []scalarType
+	paramName   string
+	left        p15FieldOperand
+	right       p15FieldOperand
+	llvmOp      string
+	resultType  scalarType
+	operandType scalarType
+}
+
+func matchStructFieldBinaryOp(fn *mir.Function, mctx *moduleCtx) (structFieldBinaryOpPattern, bool) {
+	pat := structFieldBinaryOpPattern{}
+	pat.resultType = scalarFromType(fn.ReturnType)
+	if pat.resultType == scalarUnknown {
+		return pat, false
+	}
+	if len(fn.Params) != 1 {
+		return pat, false
+	}
+	paramID := fn.Params[0]
+	paramLocal := lookupLocal(fn, paramID)
+	if paramLocal == nil || !paramLocal.IsParam {
+		return pat, false
+	}
+	named, ok := paramLocal.Type.(*ir.NamedType)
+	if !ok || named == nil || named.Name == "" {
+		return pat, false
+	}
+	fieldTypes, ok := mctx.lookupStructFields(named.Name)
+	if !ok {
+		return pat, false
+	}
+	bb, ok := singleBlockReturning(fn)
+	if !ok || len(bb.Instrs) != 1 {
+		return pat, false
+	}
+	ai, ok := bb.Instrs[0].(*mir.AssignInstr)
+	if !ok {
+		return pat, false
+	}
+	if ai.Dest.Local != fn.ReturnLocal || ai.Dest.HasProjections() {
+		return pat, false
+	}
+	bin, ok := ai.Src.(*mir.BinaryRV)
+	if !ok {
+		return pat, false
+	}
+	llvmOp, resultType, operandType := classifyBinary(bin.Op)
+	if llvmOp == "" || resultType != pat.resultType {
+		return pat, false
+	}
+	left, ok := classifyP15Operand(bin.Left, paramID, fieldTypes, operandType)
+	if !ok {
+		return pat, false
+	}
+	right, ok := classifyP15Operand(bin.Right, paramID, fieldTypes, operandType)
+	if !ok {
+		return pat, false
+	}
+	if !left.isField && !right.isField {
+		// At least one operand must reference the struct param —
+		// otherwise matchSequentialReturn already covers this shape.
+		return pat, false
+	}
+	pat.structName = named.Name
+	pat.fieldTypes = fieldTypes
+	pat.paramName = sanitizeLLVMName(paramLocal.Name, "p")
+	pat.left = left
+	pat.right = right
+	pat.llvmOp = llvmOp
+	pat.operandType = operandType
+	mctx.emitStructDef(named.Name, fieldTypes)
+	return pat, true
+}
+
+// classifyP15Operand accepts either a scalar ConstOp or a CopyOp with a
+// single FieldProj on the struct param. The field's type must equal
+// the binary op's required operand type.
+func classifyP15Operand(op mir.Operand, paramID mir.LocalID, fieldTypes []scalarType, operandType scalarType) (p15FieldOperand, bool) {
+	if con, ok := op.(*mir.ConstOp); ok {
+		switch c := con.Const.(type) {
+		case *mir.IntConst:
+			if operandType != scalarInt {
+				return p15FieldOperand{}, false
+			}
+			return p15FieldOperand{constText: fmt.Sprintf("%d", c.Value)}, true
+		case *mir.BoolConst:
+			if operandType != scalarBool {
+				return p15FieldOperand{}, false
+			}
+			if c.Value {
+				return p15FieldOperand{constText: "true"}, true
+			}
+			return p15FieldOperand{constText: "false"}, true
+		}
+		return p15FieldOperand{}, false
+	}
+	cp, ok := op.(*mir.CopyOp)
+	if !ok {
+		return p15FieldOperand{}, false
+	}
+	if cp.Place.Local != paramID || len(cp.Place.Projections) != 1 {
+		return p15FieldOperand{}, false
+	}
+	fp, ok := cp.Place.Projections[0].(*mir.FieldProj)
+	if !ok {
+		return p15FieldOperand{}, false
+	}
+	if fp.Index < 0 || fp.Index >= len(fieldTypes) {
+		return p15FieldOperand{}, false
+	}
+	if fieldTypes[fp.Index] != operandType {
+		return p15FieldOperand{}, false
+	}
+	return p15FieldOperand{isField: true, fieldIndex: fp.Index}, true
+}
+
+func emitStructFieldBinaryOp(out *strings.Builder, fn *mir.Function, pat structFieldBinaryOpPattern) error {
+	resultLLVM := pat.resultType.llvm()
+	operandLLVM := pat.operandType.llvm()
+	fmt.Fprintf(out, "define %s @%s(%%%s %%%s) {\n", resultLLVM, fn.Name, pat.structName, pat.paramName)
+	out.WriteString("entry:\n")
+	nextSSA := 0
+	leftExpr := pat.left.constText
+	if pat.left.isField {
+		leftExpr = fmt.Sprintf("%%%d", nextSSA)
+		fmt.Fprintf(out, "  %s = extractvalue %%%s %%%s, %d\n", leftExpr, pat.structName, pat.paramName, pat.left.fieldIndex)
+		nextSSA++
+	}
+	rightExpr := pat.right.constText
+	if pat.right.isField {
+		rightExpr = fmt.Sprintf("%%%d", nextSSA)
+		fmt.Fprintf(out, "  %s = extractvalue %%%s %%%s, %d\n", rightExpr, pat.structName, pat.paramName, pat.right.fieldIndex)
+		nextSSA++
+	}
+	resultReg := fmt.Sprintf("%%%d", nextSSA)
+	fmt.Fprintf(out, "  %s = %s %s %s, %s\n", resultReg, pat.llvmOp, operandLLVM, leftExpr, rightExpr)
+	fmt.Fprintf(out, "  ret %s %s\n", resultLLVM, resultReg)
+	out.WriteString("}\n\n")
+	return nil
+}
+
 // ---- P12: list literal + len ----
 //
 // stage0 P12 handles the canonical "build a List<Int> literal then
@@ -2399,12 +2584,12 @@ func emitListLiteralLen(out *strings.Builder, fn *mir.Function, pat listLiteralL
 // then a chain of `insertvalue` instructions inside the function.
 
 type aggregateConstructorPattern struct {
-	typeName    string         // LLVM type name without `%`
-	paramTypes  []scalarType   // function parameter scalar types
-	paramNames  []string       // sanitised parameter names
-	paramIDs    []mir.LocalID
-	fieldExprs  []string       // ordered LLVM operand expressions
-	fieldTypes  []scalarType   // matching scalar type per field
+	typeName   string       // LLVM type name without `%`
+	paramTypes []scalarType // function parameter scalar types
+	paramNames []string     // sanitised parameter names
+	paramIDs   []mir.LocalID
+	fieldExprs []string     // ordered LLVM operand expressions
+	fieldTypes []scalarType // matching scalar type per field
 }
 
 func matchAggregateConstructor(fn *mir.Function, mctx *moduleCtx) (aggregateConstructorPattern, bool) {

--- a/internal/backend/stage0_p15_test.go
+++ b/internal/backend/stage0_p15_test.go
@@ -1,0 +1,82 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStage0P15StructFieldBinaryOp verifies that stage0 covers the
+// inlined "two-field arithmetic" shape — the front-end emits this for
+// `fn name(p: Struct) -> T { p.fieldA op p.fieldB }` as a single
+// AssignInstr whose Src is BinaryRV with two CopyOp(param.fieldN)
+// operands. Without this matcher stage0 declines pointSum-style
+// cross-file callers and blocks toolchain self-build.
+func TestStage0P15StructFieldBinaryOpSum(t *testing.T) {
+	src := `struct Point { x: Int, y: Int }
+fn pointSum(p: Point) -> Int { p.x + p.y }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"%Point = type { i64, i64 }",
+		"define i64 @pointSum(%Point %p) {",
+		"%0 = extractvalue %Point %p, 0",
+		"%1 = extractvalue %Point %p, 1",
+		"%2 = add i64 %0, %1",
+		"ret i64 %2",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// Comparison op + two fields → Bool return.
+func TestStage0P15StructFieldBinaryOpCompare(t *testing.T) {
+	src := `struct Bounds { lo: Int, hi: Int }
+fn boundsOk(b: Bounds) -> Bool { b.lo < b.hi }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"define i1 @boundsOk(%Bounds %b) {",
+		"extractvalue %Bounds %b, 0",
+		"extractvalue %Bounds %b, 1",
+		"icmp slt i64",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// One field + one constant operand.
+func TestStage0P15StructFieldBinaryOpFieldPlusConst(t *testing.T) {
+	src := `struct Counter { n: Int }
+fn bump(c: Counter) -> Int { c.n + 1 }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"define i64 @bump(%Counter %c) {",
+		"extractvalue %Counter %c, 0",
+		"add i64",
+		", 1",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
stage0 P15 phase — front-end이 `fn name(p: Struct) -> T { p.fA op p.fB }` 를 inline BinaryRV(+, Copy(p.f0), Copy(p.f1)) 한 줄로 lower 한 형태를 stage0 가 받아 `extractvalue` + 해당 binary op + ret 으로 LLVM IR 발생.

`pointSum` 류 cross-file struct field 산술 — `examples/multi_file_e2e/lib.osty` 의 `pointSum/translate` shape — 의 첫 절반.

## Matcher surface
- 1 NamedType 파라미터 (struct, all-scalar 필드)
- 1 block, 1 AssignInstr to ReturnLocal
- Src = BinaryRV. 각 operand 독립적으로 `CopyOp(struct_param.fieldN)` (단일 FieldProj) 또는 스칼라 `ConstOp` (Int/Bool)
- 적어도 한 operand 은 field projection (양쪽 const는 matchSequentialReturn 이미 커버)
- 연산자 family: matchSequentialReturn과 동일 (산술/비교/비트/시프트/논리)

## Emit
```llvm
define <retT> @<name>(%<Struct> %<paramName>) {
entry:
  %0 = extractvalue %<Struct> %<paramName>, <I>
  %1 = extractvalue %<Struct> %<paramName>, <J>
  %2 = <llvmOp> <opT> %0, %1
  ret <retT> %2
}
```

## Tests
- `TestStage0P15StructFieldBinaryOpSum` — field + field, Int add
- `TestStage0P15StructFieldBinaryOpCompare` — field + field, Int compare → Bool
- `TestStage0P15StructFieldBinaryOpFieldPlusConst` — field + const, Int add

## Toolchain build progress
이 PR 적용 후 `OSTY_STAGE0_FALLBACK=1 osty build toolchain/` 의 첫 stage0 decline은 `pointSum/Field+Op` shape 에서 → **`parseAiRepairMode` shape** (multi-block CFG + String == 비교 + struct AggregateRV phi 머지) 로 advance. 별 P16~P18 PR 로 처리 예정.

## Test plan
- [x] `go test -run TestStage0P15 ./internal/backend/` 통과
- [x] `gofmt -l` clean
- [x] `go vet ./internal/backend/...` silent
- [x] 기존 stage0 회귀 (`TestStage0RealMIRBaseline` 등) 영향 없음
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)