### PR TITLE
docs(toolchain): B1 real toolchain build attempt + install-self UX

### DIFF
--- a/cmd/osty/install_self.go
+++ b/cmd/osty/install_self.go
@@ -93,6 +93,24 @@ func runInstallSelf(args []string, _ cliFlags) {
 	builtBin, err := buildOstySelf(context.Background(), hostOsty, root, tcAbs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty install-self: build: %v\n", err)
+		// The chicken-egg: a fresh clone has no osty-self in cache,
+		// no in-tree build, and (by default) no registry URL. The
+		// host osty's LLVM backend forks `osty-self lir-proto-lower`
+		// for emit, which declines without an osty-self to fork.
+		// `OSTY_STAGE0_FALLBACK=1` activates the bootstrap-only
+		// emitter (`docs/osty_self_bootstrap_design.md`) which can
+		// emit a small subset of MIR patterns — enough for the
+		// emergency path but not yet for the full toolchain. Surface
+		// the workflow options so the user does not have to hunt
+		// through the resolver chain in the dark.
+		if os.Getenv("OSTY_STAGE0_FALLBACK") == "" {
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "hint: bootstrap from a fresh clone needs an osty-self source. Pick one:")
+			fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,")
+			fmt.Fprintln(os.Stderr, "  - point OSTY_SELF_BIN at an existing osty-self binary, or")
+			fmt.Fprintln(os.Stderr, "  - retry with OSTY_STAGE0_FALLBACK=1 to use the emergency bootstrap emitter")
+			fmt.Fprintln(os.Stderr, "    (subset coverage; see docs/osty_self_bootstrap_design.md).")
+		}
 		os.Exit(1)
 	}
 	if err := selfhostcache.Install(root, key, builtBin); err != nil {

--- a/cmd/osty/install_self_test.go
+++ b/cmd/osty/install_self_test.go
@@ -125,6 +125,100 @@ func main() { os.Exit(7) }
 	}
 }
 
+// TestRunInstallSelfPrintsBootstrapHintOnFailure exercises the
+// fresh-clone diagnostic added in B1: when `install-self` fails
+// without `OSTY_STAGE0_FALLBACK` already set, the user gets
+// pointed at the three workflow options (registry / OSTY_SELF_BIN /
+// stage0) instead of having to read the resolver source to figure
+// out what's wrong.
+func TestRunInstallSelfPrintsBootstrapHintOnFailure(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	// Stage a synthetic project root pointing at a host-osty stub
+	// that exits non-zero — emulates the chicken-egg failure
+	// without needing the real toolchain.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	stub := filepath.Join(t.TempDir(), "stub-osty")
+	src := stub + ".go"
+	if err := os.WriteFile(src, []byte(`package main
+import "os"
+func main() { os.Exit(1) }
+`), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if out, err := exec.Command("go", "build", "-o", stub, src).CombinedOutput(); err != nil {
+		t.Fatalf("build stub: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=") // explicitly unset
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected install-self to fail\n%s", out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"hint: bootstrap from a fresh clone",
+		"OSTY_SELF_REGISTRY_URL",
+		"OSTY_SELF_BIN",
+		"OSTY_STAGE0_FALLBACK=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestRunInstallSelfSuppressesHintWhenStage0Set confirms the new
+// diagnostic does not double-up on users who have already opted
+// into the stage0 path.
+func TestRunInstallSelfSuppressesHintWhenStage0Set(t *testing.T) {
+	ostyBin := buildOstyBinaryForTest(t)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "osty.toml"), []byte("[package]\nname = \"fake\"\n"), 0o644); err != nil {
+		t.Fatalf("osty.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {
+		t.Fatalf("toolchain mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "toolchain", "main.osty"), []byte("// stub\n"), 0o644); err != nil {
+		t.Fatalf("main.osty: %v", err)
+	}
+	stub := filepath.Join(t.TempDir(), "stub-osty")
+	src := stub + ".go"
+	if err := os.WriteFile(src, []byte(`package main
+import "os"
+func main() { os.Exit(1) }
+`), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if out, err := exec.Command("go", "build", "-o", stub, src).CombinedOutput(); err != nil {
+		t.Fatalf("build stub: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(ostyBin, "install-self", "--osty-bin", stub)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "OSTY_STAGE0_FALLBACK=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected install-self to fail\n%s", out)
+	}
+	if strings.Contains(string(out), "hint: bootstrap from a fresh clone") {
+		t.Errorf("hint should be suppressed when stage0 already set:\n%s", out)
+	}
+}
+
 func TestBuildOstySelfFailsWhenNoBinaryProduced(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "toolchain"), 0o755); err != nil {

--- a/docs/osty_self_b1_findings.md
+++ b/docs/osty_self_b1_findings.md
@@ -1,0 +1,114 @@
+# B1 — Real toolchain build attempt
+
+> **상태**: 발견 사항 + UX 개선 (이 PR).
+> **연관**: `docs/osty_self_artifact_design.md` (A1–A9 — 인프라).
+> **소유**: backend / toolchain.
+
+## 1. 목표
+
+A1–A9 가 만든 artifact cache 인프라를 실제 `toolchain/*.osty` (157 파일,
+~50K 라인) 빌드에 적용해 봐서:
+
+- 부트스트랩 흐름이 실제로 작동하는지
+- 어떤 단계에서 막히는지
+- A1–A9 가 풀어야 할 문제와 다른, 본질적 갭이 어디인지
+
+## 2. 실측 결과
+
+### 2.1 빈 캐시 + 무 osty-self 상태
+
+신선한 클론 시뮬레이션:
+
+```sh
+rm -rf toolchain/.osty/out
+.bin/osty install-self            # OSTY_STAGE0_FALLBACK 미설정
+```
+
+결과 (6:18 후):
+
+```
+Profile: debug  Target: host  Features: none
+osty build: llvm backend: code generation is not implemented yet
+  detail: LLVM000 unsupported-source: native LIR Proto subprocess
+          declined MIR coverage for route mir-direct;
+          hint: route through the Osty-owned MIR/LIR Proto backend
+          path; backend-route: mir-direct
+  artifact: /home/user/osty/toolchain/.osty/out/debug/llvm/main.ll
+  runtime: /home/user/osty/toolchain/.osty/out/debug/llvm/runtime
+osty install-self: build: osty build toolchain/: exit status 1
+```
+
+**핵심 관찰**:
+
+1. **Front-end 는 통과**. 157 파일 + 6052-라인 `lir_proto.osty` 가 parse +
+   resolve + check + lint 까지 클린 (72 packages, checker cache 생성됨).
+2. **MIR → LLVM IR 단계에서 실패**. `osty-native-lirproto` 가 osty-self 를
+   찾지 못해 `declined: true` 응답. 백엔드 디스패처는 stage0 fallback
+   대상 (`IsOstySelfMissing`) 으로 인식했지만, `OSTY_STAGE0_FALLBACK` 미설정
+   상태라 그냥 declines 처리.
+3. **시간 비용**: front-end 만 6분. cache 인프라가 없으면 매 빌드마다 이
+   비용 발생.
+
+### 2.2 Stage0 fallback 활성화
+
+```sh
+OSTY_STAGE0_FALLBACK=1 .bin/osty install-self
+```
+
+실측 결과: **§2.1 과 동일한 LLVM000 사용자-가시 진단** (5:18 실행 후).
+stage0 이 attempt 했더라도 lir_proto.osty 의 MIR 패턴 (158 개 `pub fn`)
+중 stage0 P0–P15 가 cover 하지 않는 패턴에서 declines. P0–P15 의 커버리지는
+trivial main / 산술 / if-else / while / for-in-range / struct field / list /
+string concat / aggregate constructor 까지로, toolchain 의 closure /
+interface dispatch / 복잡한 generics 는 미지원.
+
+→ **fresh clone 에서 OSTY_STAGE0_FALLBACK=1 만으로 osty-self 부트스트랩이
+완성되지 않는다**. P16+ (closure / interface / monomorph) 가 필요하나
+A6 의 결정 (stage0 동결, emergency-only) 이 새 패턴 추가를 막아둠.
+
+## 3. 결론: 부트스트랩 워크플로
+
+A1–A9 인프라가 풀어야 할 케이스:
+
+- **재빌드 / 워크트리 간 공유** → A1–A8 모두 작동. 캐시 hit 시 재빌드 skip.
+- **Fresh clone (cache empty)** → 다음 셋 중 하나 필요:
+  1. **`OSTY_SELF_REGISTRY_URL`** 설정 (CI 가 발행한 pre-built osty-self
+     다운로드) — A4 인프라, A5 CI workflow 가 활성화되면 작동.
+  2. **`OSTY_SELF_BIN`** 으로 기존 binary 직접 가리키기 — backup / 디버그.
+  3. **`OSTY_STAGE0_FALLBACK=1`** — 현재 P0–P15 커버리지로는 toolchain
+     전체를 빌드 못 함. 향후 P16+ 가 추가되거나, toolchain 이 단순화되어야
+     완성.
+
+## 4. UX 개선 (이 PR)
+
+`osty install-self` 가 빌드 실패 시 위 워크플로 옵션 셋을 명시적으로 안내:
+
+```
+osty install-self: build: osty build toolchain/: exit status 1
+
+hint: bootstrap from a fresh clone needs an osty-self source. Pick one:
+  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,
+  - point OSTY_SELF_BIN at an existing osty-self binary, or
+  - retry with OSTY_STAGE0_FALLBACK=1 to use the emergency bootstrap emitter
+    (subset coverage; see docs/osty_self_bootstrap_design.md).
+```
+
+`OSTY_STAGE0_FALLBACK` 가 이미 set 되어 있으면 이 hint 는 출력하지 않음
+(redundant guidance 회피).
+
+## 5. 다음 작업
+
+A 시리즈가 만든 인프라는 cache hit / 워크트리 공유 / CI publish 시나리오
+모두 커버한다. fresh-clone 부트스트랩의 마지막 1 마일은 다음 중 하나로
+풀어야 한다:
+
+- **B2** — `toolchain/lir_proto.osty` 단순화로 stage0 P0–P15 안에 들어오게.
+- **B3** — stage0 retire 결정 (CI 가 매 main push 마다 publish 하면 fresh
+  clone 도 항상 registry hit). A8 의 결정 항목 (CI 호스트 정책 / release
+  cadence) 가 풀려야 시행 가능.
+- **B4** — `internal/llvmabi` cleanup (제거된 Go MIR emitter 잔재 정리).
+  부트스트랩과는 직교하나 코드 품질 개선.
+
+이 PR 은 A 시리즈 인프라가 **실제로 어디에 닿는지** 와 **갭이 어디 남았는지**
+를 명문화하고, fresh-clone 사용자가 올바른 경로를 빠르게 찾도록 install-self
+의 진단 메시지를 개선한다.


### PR DESCRIPTION
## Summary

B1 — actually exercise the A1–A9 artifact cache infrastructure against the real `toolchain/*.osty` (157 files, ~50K lines) to discover where the fresh-clone bootstrap actually ends.

**Findings** (`docs/osty_self_b1_findings.md`):

- Two `osty install-self` runs (with and without `OSTY_STAGE0_FALLBACK=1`) both stop at the same wall: front-end + checker pass cleanly (5–6 min), but the LLVM backend can't emit because `osty-self lir-proto-lower` has no `osty-self` to fork.
- Stage0 (P0–P15 coverage) does not handle the toolchain's full MIR shape (closures, interface dispatch, complex generics). A6 froze stage0 expansion at P15, so this is a known boundary.
- The artifact cache works as designed for cache-hit / worktree-share / CI-publish; the fresh-clone last mile requires one of: registry URL, OSTY_SELF_BIN, or B2 (toolchain simplification) / future P16+ stage0 work.

**UX improvement**: `osty install-self` now surfaces the three workflow options when the build fails and `OSTY_STAGE0_FALLBACK` is unset. Previously the user got only the generic `LLVM000 native LIR Proto subprocess declined MIR coverage` and had to read the resolver source. Hint is suppressed when stage0 is already enabled.

```
hint: bootstrap from a fresh clone needs an osty-self source. Pick one:
  - point OSTY_SELF_REGISTRY_URL at a registry serving a pre-built osty-self,
  - point OSTY_SELF_BIN at an existing osty-self binary, or
  - retry with OSTY_STAGE0_FALLBACK=1 to use the emergency bootstrap emitter
    (subset coverage; see docs/osty_self_bootstrap_design.md).
```

## Test plan

- [x] 2 new tests cover the hint-on-failure and hint-suppression paths through a stub host osty
- [x] Existing install-self / build-osty-self tests still pass
- [x] Manual: ran `osty install-self` against real `toolchain/` twice (clean clone + with stage0); confirmed the failure mode and the new hint output
- [x] `gofmt -l` clean, `go vet ./cmd/osty/` clean

## Roadmap

- **B1** (this PR) — real toolchain build attempt + UX ✅
- **B2** — `toolchain/lir_proto.osty` simplification to fit stage0 P0–P15 patterns
- **B3** — stage0 retire decision (depends on §8 maintainer decisions)
- **B4** — `internal/llvmabi` cleanup (orthogonal to bootstrap)

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_