### PR TITLE
refactor(toolchain): convert 6 more match exprs to if-else chains (B2)

### DIFF
--- a/toolchain/diagnostic.osty
+++ b/toolchain/diagnostic.osty
@@ -57,12 +57,12 @@ pub fn diagnosticSeverity(code: String) -> DiagnosticSeverity {
 
 /// diagnosticSeverityName returns the stable CLI label for a severity.
 pub fn diagnosticSeverityName(severity: DiagnosticSeverity) -> String {
-    match severity {
-        SeverityError -> "error",
-        SeverityWarning -> "warning",
-        SeverityLint -> "lint",
-        SeverityUnknown -> "unknown",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if severity == SeverityError { return "error" }
+    if severity == SeverityWarning { return "warning" }
+    if severity == SeverityLint { return "lint" }
+    if severity == SeverityUnknown { return "unknown" }
+    "unknown"
 }
 
 /// diagnosticFamily classifies a stable code into the phase family that
@@ -94,22 +94,22 @@ pub fn diagnosticFamily(code: String) -> DiagnosticFamily {
 
 /// diagnosticFamilyName returns a stable label for docs and reports.
 pub fn diagnosticFamilyName(family: DiagnosticFamily) -> String {
-    match family {
-        FamilyLexical -> "lexical",
-        FamilyDeclaration -> "declaration",
-        FamilyExpression -> "expression",
-        FamilyTypePattern -> "type-pattern",
-        FamilyAnnotation -> "annotation",
-        FamilyResolution -> "resolution",
-        FamilyControlFlow -> "control-flow",
-        FamilyTypeChecking -> "type-checking",
-        FamilyManifest -> "manifest",
-        FamilyScaffold -> "scaffold",
-        FamilyLint -> "lint",
-        FamilyWarning -> "warning",
-        FamilyBackend -> "backend",
-        FamilyUnknown -> "unknown",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if family == FamilyLexical { return "lexical" }
+    if family == FamilyDeclaration { return "declaration" }
+    if family == FamilyExpression { return "expression" }
+    if family == FamilyTypePattern { return "type-pattern" }
+    if family == FamilyAnnotation { return "annotation" }
+    if family == FamilyResolution { return "resolution" }
+    if family == FamilyControlFlow { return "control-flow" }
+    if family == FamilyTypeChecking { return "type-checking" }
+    if family == FamilyManifest { return "manifest" }
+    if family == FamilyScaffold { return "scaffold" }
+    if family == FamilyLint { return "lint" }
+    if family == FamilyWarning { return "warning" }
+    if family == FamilyBackend { return "backend" }
+    if family == FamilyUnknown { return "unknown" }
+    "unknown"
 }
 
 /// diagnosticIsCompilerError reports whether a code blocks compilation.
@@ -125,10 +125,8 @@ pub fn diagnosticFamilyName(family: DiagnosticFamily) -> String {
 /// testing.assert(!(diagnosticIsCompilerError("")))
 /// ```
 pub fn diagnosticIsCompilerError(code: String) -> Bool {
-    match diagnosticSeverity(code) {
-        SeverityError -> true,
-        _ -> false,
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    diagnosticSeverity(code) == SeverityError
 }
 
 /// DiagnosticLocation maps analyzer token spans back to lexer source positions.

--- a/toolchain/formatter_ast.osty
+++ b/toolchain/formatter_ast.osty
@@ -160,16 +160,15 @@ pub fn ostyAstFormatSource(source: String) -> OstyFormatResult {
 
 fn ostyAstDecl(f: OstyAstFormatter, idx: Int) -> String {
     let node = ostyAstNode(f, idx)
-    match node.kind {
-        AstNFnDecl -> ostyAstFnDecl(f, node),
-        AstNStructDecl -> ostyAstAggregateDecl(f, node, "struct"),
-        AstNEnumDecl -> ostyAstAggregateDecl(f, node, "enum"),
-        AstNInterfaceDecl -> ostyAstInterfaceDecl(f, node),
-        AstNTypeAlias -> ostyAstTypeAliasDecl(f, node),
-        AstNUseDecl -> ostyAstRawTokenRange(f, node.start, node.end),
-        AstNLet -> ostyAstStmt(f, idx),
-        _ -> ostyAstRawTokenRange(f, node.start, node.end),
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if node.kind == AstNFnDecl { return ostyAstFnDecl(f, node) }
+    if node.kind == AstNStructDecl { return ostyAstAggregateDecl(f, node, "struct") }
+    if node.kind == AstNEnumDecl { return ostyAstAggregateDecl(f, node, "enum") }
+    if node.kind == AstNInterfaceDecl { return ostyAstInterfaceDecl(f, node) }
+    if node.kind == AstNTypeAlias { return ostyAstTypeAliasDecl(f, node) }
+    if node.kind == AstNUseDecl { return ostyAstRawTokenRange(f, node.start, node.end) }
+    if node.kind == AstNLet { return ostyAstStmt(f, idx) }
+    ostyAstRawTokenRange(f, node.start, node.end)
 }
 
 fn ostyAstVisibility(node: AstNode) -> String {

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -3047,21 +3047,59 @@ fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) -> List
 }
 
 pub fn astNodeKindName(kind: AstNodeKind) -> String {
-    match kind {
-        AstNIdent -> "Ident", AstNIntLit -> "IntLit", AstNFloatLit -> "FloatLit", AstNStringLit -> "StringLit",
-        AstNBoolLit -> "BoolLit", AstNCharLit -> "CharLit", AstNByteLit -> "ByteLit", AstNBytesLit -> "BytesLit", AstNBinary -> "Binary",
-        AstNUnary -> "Unary", AstNCall -> "Call", AstNField -> "Field", AstNIndex -> "Index", AstNRange -> "Range",
-        AstNIf -> "If", AstNMatch -> "Match", AstNClosure -> "Closure", AstNList -> "List", AstNTuple -> "Tuple",
-        AstNMap -> "Map", AstNStructLit -> "StructLit", AstNBlock -> "Block", AstNParen -> "Paren",
-        AstNQuestion -> "Question", AstNTurbofish -> "Turbofish", AstNLet -> "Let", AstNReturn -> "Return",
-        AstNBreak -> "Break", AstNContinue -> "Continue", AstNDefer -> "Defer", AstNFor -> "For",
-        AstNAssign -> "Assign", AstNChanSend -> "ChanSend", AstNExprStmt -> "ExprStmt", AstNFnDecl -> "FnDecl",
-        AstNStructDecl -> "StructDecl", AstNEnumDecl -> "EnumDecl", AstNInterfaceDecl -> "InterfaceDecl",
-        AstNTypeAlias -> "TypeAlias", AstNUseDecl -> "UseDecl", AstNLetDecl -> "LetDecl", AstNFile -> "File",
-        AstNParam -> "Param", AstNField_ -> "Field_", AstNVariant -> "Variant", AstNMatchArm -> "MatchArm",
-        AstNType -> "Type", AstNPattern -> "Pattern", AstNAnnotation -> "Annotation",
-        AstNGenericParam -> "GenericParam", AstNError -> "Error",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if kind == AstNIdent { return "Ident" }
+    if kind == AstNIntLit { return "IntLit" }
+    if kind == AstNFloatLit { return "FloatLit" }
+    if kind == AstNStringLit { return "StringLit" }
+    if kind == AstNBoolLit { return "BoolLit" }
+    if kind == AstNCharLit { return "CharLit" }
+    if kind == AstNByteLit { return "ByteLit" }
+    if kind == AstNBytesLit { return "BytesLit" }
+    if kind == AstNBinary { return "Binary" }
+    if kind == AstNUnary { return "Unary" }
+    if kind == AstNCall { return "Call" }
+    if kind == AstNField { return "Field" }
+    if kind == AstNIndex { return "Index" }
+    if kind == AstNRange { return "Range" }
+    if kind == AstNIf { return "If" }
+    if kind == AstNMatch { return "Match" }
+    if kind == AstNClosure { return "Closure" }
+    if kind == AstNList { return "List" }
+    if kind == AstNTuple { return "Tuple" }
+    if kind == AstNMap { return "Map" }
+    if kind == AstNStructLit { return "StructLit" }
+    if kind == AstNBlock { return "Block" }
+    if kind == AstNParen { return "Paren" }
+    if kind == AstNQuestion { return "Question" }
+    if kind == AstNTurbofish { return "Turbofish" }
+    if kind == AstNLet { return "Let" }
+    if kind == AstNReturn { return "Return" }
+    if kind == AstNBreak { return "Break" }
+    if kind == AstNContinue { return "Continue" }
+    if kind == AstNDefer { return "Defer" }
+    if kind == AstNFor { return "For" }
+    if kind == AstNAssign { return "Assign" }
+    if kind == AstNChanSend { return "ChanSend" }
+    if kind == AstNExprStmt { return "ExprStmt" }
+    if kind == AstNFnDecl { return "FnDecl" }
+    if kind == AstNStructDecl { return "StructDecl" }
+    if kind == AstNEnumDecl { return "EnumDecl" }
+    if kind == AstNInterfaceDecl { return "InterfaceDecl" }
+    if kind == AstNTypeAlias { return "TypeAlias" }
+    if kind == AstNUseDecl { return "UseDecl" }
+    if kind == AstNLetDecl { return "LetDecl" }
+    if kind == AstNFile { return "File" }
+    if kind == AstNParam { return "Param" }
+    if kind == AstNField_ { return "Field_" }
+    if kind == AstNVariant { return "Variant" }
+    if kind == AstNMatchArm { return "MatchArm" }
+    if kind == AstNType { return "Type" }
+    if kind == AstNPattern { return "Pattern" }
+    if kind == AstNAnnotation { return "Annotation" }
+    if kind == AstNGenericParam { return "GenericParam" }
+    if kind == AstNError { return "Error" }
+    "Unknown"
 }
 
 pub fn astFormatErrors(file: AstFile) -> String {

--- a/toolchain/pkgmgr.osty
+++ b/toolchain/pkgmgr.osty
@@ -254,17 +254,16 @@ pub fn selfPkgCanonicalName(dep: SelfPkgDependency) -> String {
 
 /// selfPkgSourceURI renders the lockfile-stable source identifier.
 pub fn selfPkgSourceURI(dep: SelfPkgDependency) -> String {
-    match dep.sourceKind {
-        SelfPkgSourceRegistry -> {
-            if dep.registry == "" {
-                "registry+default"
-            } else {
-                "registry+{dep.registry}"
-            }
-        },
-        SelfPkgSourcePath -> "path+{dep.sourceRef}",
-        SelfPkgSourceGit -> "git+{dep.sourceRef}",
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if dep.sourceKind == SelfPkgSourceRegistry {
+        if dep.registry == "" {
+            return "registry+default"
+        }
+        return "registry+{dep.registry}"
     }
+    if dep.sourceKind == SelfPkgSourcePath { return "path+{dep.sourceRef}" }
+    if dep.sourceKind == SelfPkgSourceGit { return "git+{dep.sourceRef}" }
+    "registry+default"
 }
 
 /// selfPkgGitURI renders git+URL plus the stable query selector.


### PR DESCRIPTION
## Summary

Continues B2's incremental match → if-else conversion. Four files, six functions, all payload-less enum dispatches.

| File | Function(s) |
|---|---|
| `diagnostic.osty` | `diagnosticSeverityName`, `diagnosticFamilyName` (14 arms), `diagnosticIsCompilerError` |
| `parser.osty` | `astNodeKindName` (50 arms) |
| `pkgmgr.osty` | `selfPkgSourceURI` |
| `formatter_ast.osty` | `ostyAstDecl` |

**`astNodeKindName`** is the largest conversion to date (50 arms, originally packed 4-per-line, expanded to one-arm-per-line for diff readability).

**`diagnosticIsCompilerError`** collapses to a one-liner — the match checked a single variant, so `severity == SeverityError` returns the bool directly.

## Progress

`scripts/audit-stage0-coverage.sh` count: **408 → 402** match exprs.

| | B2 start | B2b end | B2c end |
|---|---|---|---|
| match exprs | 418 | 408 | 402 |
| net % done | 0% | 2.4% | 3.8% |

## Test plan

- [x] `osty check toolchain/` exit 0 (~90s, two passes — first batch + late-addition formatter_ast/pkgmgr)
- [x] Audit confirms 408 → 402 transition
- [x] Per-file diffs preserve exhaustive coverage

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_