### PR TITLE
feat(backend/stage0): String == String runtime call (P16)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -817,6 +817,27 @@ func classifyAssignSrc(src mir.RValue, destType scalarType, bindings map[mir.Loc
 				},
 			}, "", true
 		}
+		// P16 — Special-case String == String: lowers to a runtime
+		// call (`osty_rt_strings_Equal`) returning i1. Falls through
+		// to classifyBinary when the operand isn't String so Int ==
+		// Int continues through `icmp eq`.
+		if bin.Op == mir.BinEq && destType == scalarBool {
+			if left, leftTy, ok := resolveOperand(bin.Left, bindings, mctx); ok && leftTy == scalarString {
+				right, rightTy, ok := resolveOperand(bin.Right, bindings, mctx)
+				if !ok || rightTy != scalarString {
+					return pendingInstr{}, "", false
+				}
+				declareStringEqualRuntime(mctx)
+				return pendingInstr{
+					kind:       instrCall,
+					callSymbol: "osty_rt_strings_Equal",
+					callArgs: []callArg{
+						{expr: left, ty: "ptr"},
+						{expr: right, ty: "ptr"},
+					},
+				}, "", true
+			}
+		}
 		llvmOp, resultType, operandType := classifyBinary(bin.Op)
 		if llvmOp == "" || resultType != destType {
 			return pendingInstr{}, "", false
@@ -852,6 +873,20 @@ func declareStringConcatRuntime(mctx *moduleCtx) {
 	}
 	mctx.emittedStructs["__stage0.strings_concat"] = true
 	mctx.extraDecls.WriteString("declare ptr @osty_rt_strings_Concat(ptr, ptr)\n")
+}
+
+// declareStringEqualRuntime appends the runtime ABI declaration for
+// `osty_rt_strings_Equal` to extraDecls (idempotent). Mirrors the
+// concat helper above — used by the P16 String == String path.
+func declareStringEqualRuntime(mctx *moduleCtx) {
+	if mctx.emittedStructs == nil {
+		mctx.emittedStructs = map[string]bool{}
+	}
+	if mctx.emittedStructs["__stage0.strings_equal"] {
+		return
+	}
+	mctx.emittedStructs["__stage0.strings_equal"] = true
+	mctx.extraDecls.WriteString("declare i1 @osty_rt_strings_Equal(ptr, ptr)\n")
 }
 
 // resolveOperand returns (expression, type) for one MIR Operand using

--- a/internal/backend/stage0_p16_test.go
+++ b/internal/backend/stage0_p16_test.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStage0P16StringEqArgConst — `fn isAuto(s: String) -> Bool { s == "auto" }`
+// shape. Front-end lowers to single AssignInstr BinaryRV(==,
+// Cp(s), StringConst("auto")) writing to the Bool return local.
+// stage0 must route the compare through the runtime ABI rather than
+// emitting `icmp eq` (which would compare String pointers, not
+// content).
+func TestStage0P16StringEqArgConst(t *testing.T) {
+	src := `fn isAuto(s: String) -> Bool { s == "auto" }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"define i1 @isAuto(ptr %s) {",
+		"call i1 @osty_rt_strings_Equal(ptr %s, ptr",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// TestStage0P16StringEqTwoArgs — both sides are String params:
+// `fn eq(a: String, b: String) -> Bool { a == b }`.
+func TestStage0P16StringEqTwoArgs(t *testing.T) {
+	src := `fn eq(a: String, b: String) -> Bool { a == b }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"define i1 @eq(ptr %a, ptr %b) {",
+		"call i1 @osty_rt_strings_Equal(ptr %a, ptr %b)",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// TestStage0P16StringEqRuntimeDeclaredOnce verifies the runtime ABI
+// declaration is emitted exactly once even when multiple functions
+// use String ==.
+func TestStage0P16StringEqRuntimeDeclaredOnce(t *testing.T) {
+	src := `fn isFoo(s: String) -> Bool { s == "foo" }
+fn isBar(s: String) -> Bool { s == "bar" }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	if c := strings.Count(got, "declare i1 @osty_rt_strings_Equal"); c != 1 {
+		t.Errorf("declare i1 @osty_rt_strings_Equal count = %d, want 1\n--- output ---\n%s", c, got)
+	}
+}
+
+// TestStage0P16IntEqStillUsesIcmp — Int == Int must continue to use
+// `icmp eq` (the existing P2e path). Regression guard: the P16
+// special case must not swallow scalar Int comparisons.
+func TestStage0P16IntEqStillUsesIcmp(t *testing.T) {
+	src := `fn isZero(n: Int) -> Bool { n == 0 }
+fn main() {}`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "icmp eq i64") {
+		t.Errorf("expected `icmp eq i64` for Int==Int (not runtime call)\n--- output ---\n%s", got)
+	}
+	if strings.Contains(got, "osty_rt_strings_Equal") {
+		t.Errorf("Int==Int must not call String runtime\n--- output ---\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
stage0 P16 — `BinEq + scalarBool + 양 operand scalarString` 케이스를 `osty_rt_strings_Equal(ptr, ptr) -> i1` runtime call 로 lower. P15 (struct field binary-op) 와 같은 sequentialPattern 의 String concat special-case 옆에 동등성 special-case 추가.

토론체인의 `value == "auto"` 류 String 비교가 stage0 를 통과하기 시작 — `parseAiRepairMode` 같은 함수의 condition 평가 일부 unblock.

## Matcher surface
- `BinaryRV{op=BinEq, destType=scalarBool}`
- left / right 양쪽 모두 `scalarString` (CopyOp 또는 StringConst)
- 결과: i1 → if-cond 또는 Bool 변수 직접 사용

## Emit
```llvm
declare i1 @osty_rt_strings_Equal(ptr, ptr)
...
%N = call i1 @osty_rt_strings_Equal(ptr %left, ptr %right)
```

## Tests (4건)
- `TestStage0P16StringEqArgConst` — `s == "auto"` (String var + literal)
- `TestStage0P16StringEqTwoArgs` — `a == b` (두 String args)
- `TestStage0P16StringEqRuntimeDeclaredOnce` — 다중 사용 시 declare 1회
- `TestStage0P16IntEqStillUsesIcmp` — Int==Int 는 기존 `icmp eq` 유지 (P16 case 가 scalar Int 비교를 swallow 하지 않음을 봉쇄)

## Toolchain build progress
이 PR 적용 후 `OSTY_STAGE0_FALLBACK=1 osty build toolchain/` 의 첫 stage0 decline 은 여전히 `parseAiRepairMode` — multi-block CFG (OR short-circuit + chained if-elif-else returning struct AggregateRV) 가 P17 + P18 의 별 PR 분량.

## Test plan
- [x] `go test -run TestStage0P16 ./internal/backend/` 통과 (4/4)
- [x] `gofmt -l` clean
- [x] 기존 P14/P15 회귀 영향 없음 (`TestStage0` 전체 green)
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)