### PR TITLE
refactor(toolchain): convert 81 match exprs across 9 files (B2)

### DIFF
--- a/toolchain/hir.osty
+++ b/toolchain/hir.osty
@@ -497,28 +497,25 @@ pub fn hirTNever() -> HirType { hirTypePrim(HirPrimNever) }
 
 /// hirTypeIsValid reports whether `t` has a non-invalid kind.
 pub fn hirTypeIsValid(t: HirType) -> Bool {
-    match t.kind {
-        HirTypeInvalid -> false,
-        _ -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeInvalid { return false }
+    true
 }
 
 /// hirTypeIsErr reports whether `t` is the poisoned ErrType.
 pub fn hirTypeIsErr(t: HirType) -> Bool {
-    match t.kind {
-        HirTypeErr -> true,
-        _ -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeErr { return true }
+    false
 }
 
 /// hirTypeIsUnit reports whether `t` is the `()` primitive.
 pub fn hirTypeIsUnit(t: HirType) -> Bool {
     match t.kind {
         HirTypePrim -> {
-            match t.primKind {
-                HirPrimUnit -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if t.primKind == HirPrimUnit { return true }
+            false
         },
         _ -> false,
     }
@@ -528,10 +525,9 @@ pub fn hirTypeIsUnit(t: HirType) -> Bool {
 pub fn hirTypeIsNever(t: HirType) -> Bool {
     match t.kind {
         HirTypePrim -> {
-            match t.primKind {
-                HirPrimNever -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if t.primKind == HirPrimNever { return true }
+            false
         },
         _ -> false,
     }
@@ -539,10 +535,9 @@ pub fn hirTypeIsNever(t: HirType) -> Bool {
 
 /// hirTypeIsOptional reports whether `t` is a `T?` wrapper.
 pub fn hirTypeIsOptional(t: HirType) -> Bool {
-    match t.kind {
-        HirTypeOptional -> true,
-        _ -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeOptional { return true }
+    false
 }
 
 /// hirTypeOptionalInner returns the inner type of a `T?` or an invalid
@@ -596,29 +591,29 @@ pub fn hirTypeQualifiedName(t: HirType) -> String {
 /// hirPrimKindString returns the canonical source-level name for a
 /// primitive kind. Mirrors PrimType.String in Go.
 pub fn hirPrimKindString(k: HirPrimKind) -> String {
-    match k {
-        HirPrimInt -> "Int",
-        HirPrimInt8 -> "Int8",
-        HirPrimInt16 -> "Int16",
-        HirPrimInt32 -> "Int32",
-        HirPrimInt64 -> "Int64",
-        HirPrimUInt8 -> "UInt8",
-        HirPrimUInt16 -> "UInt16",
-        HirPrimUInt32 -> "UInt32",
-        HirPrimUInt64 -> "UInt64",
-        HirPrimByte -> "Byte",
-        HirPrimFloat -> "Float",
-        HirPrimFloat32 -> "Float32",
-        HirPrimFloat64 -> "Float64",
-        HirPrimBool -> "Bool",
-        HirPrimChar -> "Char",
-        HirPrimString -> "String",
-        HirPrimBytes -> "Bytes",
-        HirPrimRawPtr -> "RawPtr",
-        HirPrimUnit -> "()",
-        HirPrimNever -> "Never",
-        HirPrimInvalid -> "?",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirPrimInt { return "Int" }
+    if k == HirPrimInt8 { return "Int8" }
+    if k == HirPrimInt16 { return "Int16" }
+    if k == HirPrimInt32 { return "Int32" }
+    if k == HirPrimInt64 { return "Int64" }
+    if k == HirPrimUInt8 { return "UInt8" }
+    if k == HirPrimUInt16 { return "UInt16" }
+    if k == HirPrimUInt32 { return "UInt32" }
+    if k == HirPrimUInt64 { return "UInt64" }
+    if k == HirPrimByte { return "Byte" }
+    if k == HirPrimFloat { return "Float" }
+    if k == HirPrimFloat32 { return "Float32" }
+    if k == HirPrimFloat64 { return "Float64" }
+    if k == HirPrimBool { return "Bool" }
+    if k == HirPrimChar { return "Char" }
+    if k == HirPrimString { return "String" }
+    if k == HirPrimBytes { return "Bytes" }
+    if k == HirPrimRawPtr { return "RawPtr" }
+    if k == HirPrimUnit { return "()" }
+    if k == HirPrimNever { return "Never" }
+    if k == HirPrimInvalid { return "?" }
+    "Int"
 }
 
 /// hirTypeString returns a source-level rendering of `t`. Safe for
@@ -763,10 +758,9 @@ pub fn hirParamDestructured(pattern: HirPattern, typ: HirType, span: HirSpan) ->
 
 /// hirParamIsDestructured reports whether the param uses a pattern.
 pub fn hirParamIsDestructured(p: HirParam) -> Bool {
-    match p.pattern.kind {
-        HirPatInvalid -> false,
-        _ -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if p.pattern.kind == HirPatInvalid { return false }
+    true
 }
 
 /// HirField is one struct field. JSON-related flags are lifted off
@@ -2089,10 +2083,9 @@ pub fn hirExprInvalid() -> HirExpr {
 /// hirExprIsValid reports whether `e` is a real expression (not the
 /// default-zero placeholder).
 pub fn hirExprIsValid(e: HirExpr) -> Bool {
-    match e.kind {
-        HirExprInvalid -> false,
-        _ -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprInvalid { return false }
+    true
 }
 
 // ---- Expression constructors ---------------------------------------
@@ -2768,10 +2761,9 @@ pub fn hirPatternInvalid() -> HirPattern {
 /// hirPatternIsValid reports whether `p` is a real pattern (not the
 /// default-zero placeholder).
 pub fn hirPatternIsValid(p: HirPattern) -> Bool {
-    match p.kind {
-        HirPatInvalid -> false,
-        _ -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if p.kind == HirPatInvalid { return false }
+    true
 }
 
 // ---- Pattern constructors ------------------------------------------
@@ -2931,192 +2923,192 @@ pub fn hirErrorPat(note: String, span: HirSpan) -> HirPattern {
 /// hirStmtKindName returns the source-level name of a stmt kind. Used
 /// by the HIR printer (Stage 3b) and diagnostics.
 pub fn hirStmtKindName(k: HirStmtKind) -> String {
-    match k {
-        HirStmtInvalid -> "<invalid>",
-        HirStmtBlock -> "Block",
-        HirStmtLet -> "Let",
-        HirStmtExpr -> "ExprStmt",
-        HirStmtAssign -> "Assign",
-        HirStmtReturn -> "Return",
-        HirStmtBreak -> "Break",
-        HirStmtContinue -> "Continue",
-        HirStmtIf -> "If",
-        HirStmtFor -> "For",
-        HirStmtMatch -> "Match",
-        HirStmtDefer -> "Defer",
-        HirStmtChanSend -> "ChanSend",
-        HirStmtError -> "<error>",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirStmtInvalid { return "<invalid>" }
+    if k == HirStmtBlock { return "Block" }
+    if k == HirStmtLet { return "Let" }
+    if k == HirStmtExpr { return "ExprStmt" }
+    if k == HirStmtAssign { return "Assign" }
+    if k == HirStmtReturn { return "Return" }
+    if k == HirStmtBreak { return "Break" }
+    if k == HirStmtContinue { return "Continue" }
+    if k == HirStmtIf { return "If" }
+    if k == HirStmtFor { return "For" }
+    if k == HirStmtMatch { return "Match" }
+    if k == HirStmtDefer { return "Defer" }
+    if k == HirStmtChanSend { return "ChanSend" }
+    if k == HirStmtError { return "<error>" }
+    "<invalid>"
 }
 
 pub fn hirExprKindName(k: HirExprKind) -> String {
-    match k {
-        HirExprInvalid -> "<invalid>",
-        HirExprIntLit -> "IntLit",
-        HirExprFloatLit -> "FloatLit",
-        HirExprBoolLit -> "BoolLit",
-        HirExprCharLit -> "CharLit",
-        HirExprByteLit -> "ByteLit",
-        HirExprStringLit -> "StringLit",
-        HirExprBytesLit -> "BytesLit",
-        HirExprUnitLit -> "UnitLit",
-        HirExprIdent -> "Ident",
-        HirExprUnary -> "Unary",
-        HirExprBinary -> "Binary",
-        HirExprCall -> "Call",
-        HirExprIntrinsic -> "Intrinsic",
-        HirExprList -> "List",
-        HirExprBlock -> "BlockExpr",
-        HirExprIf -> "IfExpr",
-        HirExprField -> "Field",
-        HirExprIndex -> "Index",
-        HirExprMethod -> "Method",
-        HirExprStructLit -> "StructLit",
-        HirExprTupleLit -> "TupleLit",
-        HirExprMapLit -> "MapLit",
-        HirExprRange -> "Range",
-        HirExprQuestion -> "Question",
-        HirExprCoalesce -> "Coalesce",
-        HirExprClosure -> "Closure",
-        HirExprVariantLit -> "VariantLit",
-        HirExprMatch -> "MatchExpr",
-        HirExprIfLet -> "IfLet",
-        HirExprTupleAccess -> "TupleAccess",
-        HirExprError -> "<error>",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirExprInvalid { return "<invalid>" }
+    if k == HirExprIntLit { return "IntLit" }
+    if k == HirExprFloatLit { return "FloatLit" }
+    if k == HirExprBoolLit { return "BoolLit" }
+    if k == HirExprCharLit { return "CharLit" }
+    if k == HirExprByteLit { return "ByteLit" }
+    if k == HirExprStringLit { return "StringLit" }
+    if k == HirExprBytesLit { return "BytesLit" }
+    if k == HirExprUnitLit { return "UnitLit" }
+    if k == HirExprIdent { return "Ident" }
+    if k == HirExprUnary { return "Unary" }
+    if k == HirExprBinary { return "Binary" }
+    if k == HirExprCall { return "Call" }
+    if k == HirExprIntrinsic { return "Intrinsic" }
+    if k == HirExprList { return "List" }
+    if k == HirExprBlock { return "BlockExpr" }
+    if k == HirExprIf { return "IfExpr" }
+    if k == HirExprField { return "Field" }
+    if k == HirExprIndex { return "Index" }
+    if k == HirExprMethod { return "Method" }
+    if k == HirExprStructLit { return "StructLit" }
+    if k == HirExprTupleLit { return "TupleLit" }
+    if k == HirExprMapLit { return "MapLit" }
+    if k == HirExprRange { return "Range" }
+    if k == HirExprQuestion { return "Question" }
+    if k == HirExprCoalesce { return "Coalesce" }
+    if k == HirExprClosure { return "Closure" }
+    if k == HirExprVariantLit { return "VariantLit" }
+    if k == HirExprMatch { return "MatchExpr" }
+    if k == HirExprIfLet { return "IfLet" }
+    if k == HirExprTupleAccess { return "TupleAccess" }
+    if k == HirExprError { return "<error>" }
+    "<invalid>"
 }
 
 pub fn hirPatternKindName(k: HirPatternKind) -> String {
-    match k {
-        HirPatInvalid -> "<invalid>",
-        HirPatWild -> "Wild",
-        HirPatIdent -> "Ident",
-        HirPatLit -> "Lit",
-        HirPatTuple -> "Tuple",
-        HirPatStruct -> "Struct",
-        HirPatVariant -> "Variant",
-        HirPatRange -> "Range",
-        HirPatOr -> "Or",
-        HirPatBinding -> "Binding",
-        HirPatError -> "<error>",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirPatInvalid { return "<invalid>" }
+    if k == HirPatWild { return "Wild" }
+    if k == HirPatIdent { return "Ident" }
+    if k == HirPatLit { return "Lit" }
+    if k == HirPatTuple { return "Tuple" }
+    if k == HirPatStruct { return "Struct" }
+    if k == HirPatVariant { return "Variant" }
+    if k == HirPatRange { return "Range" }
+    if k == HirPatOr { return "Or" }
+    if k == HirPatBinding { return "Binding" }
+    if k == HirPatError { return "<error>" }
+    "<invalid>"
 }
 
 pub fn hirUnOpName(k: HirUnOp) -> String {
-    match k {
-        HirUnInvalid -> "<invalid>",
-        HirUnNeg -> "-",
-        HirUnPlus -> "+",
-        HirUnNot -> "!",
-        HirUnBitNot -> "~",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirUnInvalid { return "<invalid>" }
+    if k == HirUnNeg { return "-" }
+    if k == HirUnPlus { return "+" }
+    if k == HirUnNot { return "!" }
+    if k == HirUnBitNot { return "~" }
+    "<invalid>"
 }
 
 pub fn hirBinOpName(k: HirBinOp) -> String {
-    match k {
-        HirBinInvalid -> "<invalid>",
-        HirBinAdd -> "+",
-        HirBinSub -> "-",
-        HirBinMul -> "*",
-        HirBinDiv -> "/",
-        HirBinMod -> "%",
-        HirBinEq -> "==",
-        HirBinNeq -> "!=",
-        HirBinLt -> "<",
-        HirBinLeq -> "<=",
-        HirBinGt -> ">",
-        HirBinGeq -> ">=",
-        HirBinAnd -> "&&",
-        HirBinOr -> "||",
-        HirBinBitAnd -> "&",
-        HirBinBitOr -> "|",
-        HirBinBitXor -> "^",
-        HirBinShl -> "<<",
-        HirBinShr -> ">>",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirBinInvalid { return "<invalid>" }
+    if k == HirBinAdd { return "+" }
+    if k == HirBinSub { return "-" }
+    if k == HirBinMul { return "*" }
+    if k == HirBinDiv { return "/" }
+    if k == HirBinMod { return "%" }
+    if k == HirBinEq { return "==" }
+    if k == HirBinNeq { return "!=" }
+    if k == HirBinLt { return "<" }
+    if k == HirBinLeq { return "<=" }
+    if k == HirBinGt { return ">" }
+    if k == HirBinGeq { return ">=" }
+    if k == HirBinAnd { return "&&" }
+    if k == HirBinOr { return "||" }
+    if k == HirBinBitAnd { return "&" }
+    if k == HirBinBitOr { return "|" }
+    if k == HirBinBitXor { return "^" }
+    if k == HirBinShl { return "<<" }
+    if k == HirBinShr { return ">>" }
+    "<invalid>"
 }
 
 pub fn hirAssignOpName(k: HirAssignOp) -> String {
-    match k {
-        HirAssignInvalid -> "<invalid>",
-        HirAssignEq -> "=",
-        HirAssignAdd -> "+=",
-        HirAssignSub -> "-=",
-        HirAssignMul -> "*=",
-        HirAssignDiv -> "/=",
-        HirAssignMod -> "%=",
-        HirAssignAnd -> "&=",
-        HirAssignOr -> "|=",
-        HirAssignXor -> "^=",
-        HirAssignShl -> "<<=",
-        HirAssignShr -> ">>=",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirAssignInvalid { return "<invalid>" }
+    if k == HirAssignEq { return "=" }
+    if k == HirAssignAdd { return "+=" }
+    if k == HirAssignSub { return "-=" }
+    if k == HirAssignMul { return "*=" }
+    if k == HirAssignDiv { return "/=" }
+    if k == HirAssignMod { return "%=" }
+    if k == HirAssignAnd { return "&=" }
+    if k == HirAssignOr { return "|=" }
+    if k == HirAssignXor { return "^=" }
+    if k == HirAssignShl { return "<<=" }
+    if k == HirAssignShr { return ">>=" }
+    "<invalid>"
 }
 
 pub fn hirForKindName(k: HirForKind) -> String {
-    match k {
-        HirForInvalid -> "<invalid>",
-        HirForInfinite -> "Infinite",
-        HirForWhile -> "While",
-        HirForRange -> "Range",
-        HirForIn -> "In",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirForInvalid { return "<invalid>" }
+    if k == HirForInfinite { return "Infinite" }
+    if k == HirForWhile { return "While" }
+    if k == HirForRange { return "Range" }
+    if k == HirForIn { return "In" }
+    "<invalid>"
 }
 
 pub fn hirIdentKindName(k: HirIdentKind) -> String {
-    match k {
-        HirIdentUnknown -> "unknown",
-        HirIdentLocal -> "local",
-        HirIdentParam -> "param",
-        HirIdentFn -> "fn",
-        HirIdentVariant -> "variant",
-        HirIdentTypeName -> "typeName",
-        HirIdentGlobal -> "global",
-        HirIdentBuiltin -> "builtin",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirIdentUnknown { return "unknown" }
+    if k == HirIdentLocal { return "local" }
+    if k == HirIdentParam { return "param" }
+    if k == HirIdentFn { return "fn" }
+    if k == HirIdentVariant { return "variant" }
+    if k == HirIdentTypeName { return "typeName" }
+    if k == HirIdentGlobal { return "global" }
+    if k == HirIdentBuiltin { return "builtin" }
+    "unknown"
 }
 
 pub fn hirCaptureKindName(k: HirCaptureKind) -> String {
-    match k {
-        HirCaptureUnknown -> "unknown",
-        HirCaptureLocal -> "local",
-        HirCaptureParam -> "param",
-        HirCaptureGlobal -> "global",
-        HirCaptureFn -> "fn",
-        HirCaptureSelf -> "self",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirCaptureUnknown { return "unknown" }
+    if k == HirCaptureLocal { return "local" }
+    if k == HirCaptureParam { return "param" }
+    if k == HirCaptureGlobal { return "global" }
+    if k == HirCaptureFn { return "fn" }
+    if k == HirCaptureSelf { return "self" }
+    "unknown"
 }
 
 pub fn hirIntrinsicKindName(k: HirIntrinsicKind) -> String {
-    match k {
-        HirIntrinsicInvalid -> "<invalid>",
-        HirIntrinsicPrint -> "print",
-        HirIntrinsicPrintln -> "println",
-        HirIntrinsicEprint -> "eprint",
-        HirIntrinsicEprintln -> "eprintln",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirIntrinsicInvalid { return "<invalid>" }
+    if k == HirIntrinsicPrint { return "print" }
+    if k == HirIntrinsicPrintln { return "println" }
+    if k == HirIntrinsicEprint { return "eprint" }
+    if k == HirIntrinsicEprintln { return "eprintln" }
+    "<invalid>"
 }
 
 pub fn hirInlineModeName(k: HirInlineMode) -> String {
-    match k {
-        HirInlineNone -> "none",
-        HirInlineSoft -> "soft",
-        HirInlineAlways -> "always",
-        HirInlineNever -> "never",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirInlineNone { return "none" }
+    if k == HirInlineSoft { return "soft" }
+    if k == HirInlineAlways { return "always" }
+    if k == HirInlineNever { return "never" }
+    "none"
 }
 
 pub fn hirTypeKindName(k: HirTypeKind) -> String {
-    match k {
-        HirTypeInvalid -> "<invalid>",
-        HirTypePrim -> "Prim",
-        HirTypeNamed -> "Named",
-        HirTypeOptional -> "Optional",
-        HirTypeTuple -> "Tuple",
-        HirTypeFn -> "Fn",
-        HirTypeVar -> "Var",
-        HirTypeErr -> "<error>",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirTypeInvalid { return "<invalid>" }
+    if k == HirTypePrim { return "Prim" }
+    if k == HirTypeNamed { return "Named" }
+    if k == HirTypeOptional { return "Optional" }
+    if k == HirTypeTuple { return "Tuple" }
+    if k == HirTypeFn { return "Fn" }
+    if k == HirTypeVar { return "Var" }
+    if k == HirTypeErr { return "<error>" }
+    "<invalid>"
 }
 
 // ====================================================================
@@ -3408,43 +3400,42 @@ pub fn hirDecisionSwitch(
 /// (not the default-zero placeholder used when match arms lack a
 /// pre-compiled tree).
 pub fn hirDecisionIsValid(n: HirDecisionNode) -> Bool {
-    match n.kind {
-        HirDecisionInvalid -> false,
-        _ -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if n.kind == HirDecisionInvalid { return false }
+    true
 }
 
 // ---- Enum-kind stringification ------------------------------------
 
 pub fn hirDecisionNodeKindName(k: HirDecisionNodeKind) -> String {
-    match k {
-        HirDecisionInvalid -> "<invalid>",
-        HirDecisionLeaf -> "Leaf",
-        HirDecisionFail -> "Fail",
-        HirDecisionBind -> "Bind",
-        HirDecisionGuard -> "Guard",
-        HirDecisionSwitch -> "Switch",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirDecisionInvalid { return "<invalid>" }
+    if k == HirDecisionLeaf { return "Leaf" }
+    if k == HirDecisionFail { return "Fail" }
+    if k == HirDecisionBind { return "Bind" }
+    if k == HirDecisionGuard { return "Guard" }
+    if k == HirDecisionSwitch { return "Switch" }
+    "<invalid>"
 }
 
 pub fn hirSwitchKindName(k: HirSwitchKind) -> String {
-    match k {
-        HirSwitchUnknown -> "?",
-        HirSwitchVariant -> "variant",
-        HirSwitchLit -> "lit",
-        HirSwitchBool -> "bool",
-        HirSwitchTuple -> "tuple",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirSwitchUnknown { return "?" }
+    if k == HirSwitchVariant { return "variant" }
+    if k == HirSwitchLit { return "lit" }
+    if k == HirSwitchBool { return "bool" }
+    if k == HirSwitchTuple { return "tuple" }
+    "?"
 }
 
 pub fn hirProjectionKindName(k: HirProjectionKind) -> String {
-    match k {
-        HirProjScrutinee -> "scrutinee",
-        HirProjTuple -> "tuple",
-        HirProjField -> "field",
-        HirProjVariant -> "variant",
-        HirProjVariantN -> "variantN",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirProjScrutinee { return "scrutinee" }
+    if k == HirProjTuple { return "tuple" }
+    if k == HirProjField { return "field" }
+    if k == HirProjVariant { return "variant" }
+    if k == HirProjVariantN { return "variantN" }
+    "scrutinee"
 }
 
 // ====================================================================

--- a/toolchain/hir_lower.osty
+++ b/toolchain/hir_lower.osty
@@ -327,30 +327,30 @@ pub fn hirLowerPrimByName(name: String) -> HirType {
 /// `Float` — matches Go's `types.Untyped.Default()` convention so
 /// downstream passes never see an untyped carrier.
 pub fn hirLowerPrimByPk(pk: PrimKind) -> HirType {
-    match pk {
-        PkInvalid -> hirTypeErr(),
-        PkInt -> hirTInt(),
-        PkInt8 -> hirTInt8(),
-        PkInt16 -> hirTInt16(),
-        PkInt32 -> hirTInt32(),
-        PkInt64 -> hirTInt64(),
-        PkUInt8 -> hirTUInt8(),
-        PkUInt16 -> hirTUInt16(),
-        PkUInt32 -> hirTUInt32(),
-        PkUInt64 -> hirTUInt64(),
-        PkByte -> hirTByte(),
-        PkFloat -> hirTFloat(),
-        PkFloat32 -> hirTFloat32(),
-        PkFloat64 -> hirTFloat64(),
-        PkBool -> hirTBool(),
-        PkChar -> hirTChar(),
-        PkString -> hirTString(),
-        PkBytes -> hirTBytes(),
-        PkUnit -> hirTUnit(),
-        PkNever -> hirTNever(),
-        PkUntypedInt -> hirTInt(),
-        PkUntypedFloat -> hirTFloat(),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if pk == PkInvalid { return hirTypeErr() }
+    if pk == PkInt { return hirTInt() }
+    if pk == PkInt8 { return hirTInt8() }
+    if pk == PkInt16 { return hirTInt16() }
+    if pk == PkInt32 { return hirTInt32() }
+    if pk == PkInt64 { return hirTInt64() }
+    if pk == PkUInt8 { return hirTUInt8() }
+    if pk == PkUInt16 { return hirTUInt16() }
+    if pk == PkUInt32 { return hirTUInt32() }
+    if pk == PkUInt64 { return hirTUInt64() }
+    if pk == PkByte { return hirTByte() }
+    if pk == PkFloat { return hirTFloat() }
+    if pk == PkFloat32 { return hirTFloat32() }
+    if pk == PkFloat64 { return hirTFloat64() }
+    if pk == PkBool { return hirTBool() }
+    if pk == PkChar { return hirTChar() }
+    if pk == PkString { return hirTString() }
+    if pk == PkBytes { return hirTBytes() }
+    if pk == PkUnit { return hirTUnit() }
+    if pk == PkNever { return hirTNever() }
+    if pk == PkUntypedInt { return hirTInt() }
+    if pk == PkUntypedFloat { return hirTFloat() }
+    hirTypeErr()
 }
 
 // ====================================================================
@@ -1660,19 +1660,18 @@ fn hirLowerPrimKindEq(a: HirPrimKind, b: HirPrimKind) -> Bool {
 pub fn hirLowerIsIntegralType(t: HirType) -> Bool {
     match t.kind {
         HirTypePrim -> {
-            match t.primKind {
-                HirPrimInt -> true,
-                HirPrimInt8 -> true,
-                HirPrimInt16 -> true,
-                HirPrimInt32 -> true,
-                HirPrimInt64 -> true,
-                HirPrimUInt8 -> true,
-                HirPrimUInt16 -> true,
-                HirPrimUInt32 -> true,
-                HirPrimUInt64 -> true,
-                HirPrimByte -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if t.primKind == HirPrimInt { return true }
+            if t.primKind == HirPrimInt8 { return true }
+            if t.primKind == HirPrimInt16 { return true }
+            if t.primKind == HirPrimInt32 { return true }
+            if t.primKind == HirPrimInt64 { return true }
+            if t.primKind == HirPrimUInt8 { return true }
+            if t.primKind == HirPrimUInt16 { return true }
+            if t.primKind == HirPrimUInt32 { return true }
+            if t.primKind == HirPrimUInt64 { return true }
+            if t.primKind == HirPrimByte { return true }
+            false
         },
         _ -> false,
     }
@@ -1683,12 +1682,11 @@ pub fn hirLowerIsIntegralType(t: HirType) -> Bool {
 pub fn hirLowerIsFloatType(t: HirType) -> Bool {
     match t.kind {
         HirTypePrim -> {
-            match t.primKind {
-                HirPrimFloat -> true,
-                HirPrimFloat32 -> true,
-                HirPrimFloat64 -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if t.primKind == HirPrimFloat { return true }
+            if t.primKind == HirPrimFloat32 { return true }
+            if t.primKind == HirPrimFloat64 { return true }
+            false
         },
         _ -> false,
     }
@@ -1774,11 +1772,10 @@ pub fn hirLowerRecoverIndexType(baseT: HirType) -> HirType {
     }
     match baseT.kind {
         HirTypePrim -> {
-            match baseT.primKind {
-                HirPrimBytes -> hirTByte(),
-                HirPrimString -> hirTChar(),
-                _ -> hirTypeErr(),
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if baseT.primKind == HirPrimBytes { return hirTByte() }
+            if baseT.primKind == HirPrimString { return hirTChar() }
+            hirTypeErr()
         },
         HirTypeNamed -> {
             if baseT.namedName == "List" && baseT.namedArgs.len() >= 1 {
@@ -1875,12 +1872,12 @@ pub fn hirLowerClassifyRange(hasStart: Bool, hasEnd: Bool) -> HirLowerRangeShape
 }
 
 pub fn hirLowerRangeShapeName(s: HirLowerRangeShape) -> String {
-    match s {
-        HirRangeShapeEmpty -> "empty",
-        HirRangeShapeBounded -> "bounded",
-        HirRangeShapeFrom -> "from",
-        HirRangeShapeTo -> "to",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if s == HirRangeShapeEmpty { return "empty" }
+    if s == HirRangeShapeBounded { return "bounded" }
+    if s == HirRangeShapeFrom { return "from" }
+    if s == HirRangeShapeTo { return "to" }
+    "empty"
 }
 
 // ====================================================================
@@ -4126,50 +4123,47 @@ fn hirLowerAssignOpFromFrontToken(op: FrontTokenKind) -> HirAssignOp {
 }
 
 fn hirLowerUnaryOpFromCore(op: UnOp) -> HirUnOp {
-    match op {
-        UoNeg -> HirUnNeg,
-        UoPlus -> HirUnPlus,
-        UoNot -> HirUnNot,
-        UoBitNot -> HirUnBitNot,
-        _ -> HirUnInvalid,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if op == UoNeg { return HirUnNeg }
+    if op == UoPlus { return HirUnPlus }
+    if op == UoNot { return HirUnNot }
+    if op == UoBitNot { return HirUnBitNot }
+    HirUnInvalid
 }
 
 fn hirLowerBinaryOpFromCore(op: BinOp) -> HirBinOp {
-    match op {
-        BoAdd -> HirBinAdd,
-        BoSub -> HirBinSub,
-        BoMul -> HirBinMul,
-        BoDiv -> HirBinDiv,
-        BoMod -> HirBinMod,
-        BoEq -> HirBinEq,
-        BoNe -> HirBinNeq,
-        BoLt -> HirBinLt,
-        BoLe -> HirBinLeq,
-        BoGt -> HirBinGt,
-        BoGe -> HirBinGeq,
-        BoAnd -> HirBinAnd,
-        BoOr -> HirBinOr,
-        BoBitAnd -> HirBinBitAnd,
-        BoBitOr -> HirBinBitOr,
-        BoBitXor -> HirBinBitXor,
-        BoShl -> HirBinShl,
-        BoShr -> HirBinShr,
-        _ -> HirBinInvalid,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if op == BoAdd { return HirBinAdd }
+    if op == BoSub { return HirBinSub }
+    if op == BoMul { return HirBinMul }
+    if op == BoDiv { return HirBinDiv }
+    if op == BoMod { return HirBinMod }
+    if op == BoEq { return HirBinEq }
+    if op == BoNe { return HirBinNeq }
+    if op == BoLt { return HirBinLt }
+    if op == BoLe { return HirBinLeq }
+    if op == BoGt { return HirBinGt }
+    if op == BoGe { return HirBinGeq }
+    if op == BoAnd { return HirBinAnd }
+    if op == BoOr { return HirBinOr }
+    if op == BoBitAnd { return HirBinBitAnd }
+    if op == BoBitOr { return HirBinBitOr }
+    if op == BoBitXor { return HirBinBitXor }
+    if op == BoShl { return HirBinShl }
+    if op == BoShr { return HirBinShr }
+    HirBinInvalid
 }
 
 fn hirLowerIdentKindFromCore(kind: IdentKind) -> HirIdentKind {
-    match kind {
-        IkLocal -> HirIdentLocal,
-        IkParam -> HirIdentParam,
-        IkFn -> HirIdentFn,
-        IkVariant -> HirIdentVariant,
-        IkTypeName -> HirIdentTypeName,
-        IkGlobal -> HirIdentGlobal,
-        IkBuiltin -> HirIdentBuiltin,
-        _ -> HirIdentUnknown,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if kind == IkLocal { return HirIdentLocal }
+    if kind == IkParam { return HirIdentParam }
+    if kind == IkFn { return HirIdentFn }
+    if kind == IkVariant { return HirIdentVariant }
+    if kind == IkTypeName { return HirIdentTypeName }
+    if kind == IkGlobal { return HirIdentGlobal }
+    if kind == IkBuiltin { return HirIdentBuiltin }
+    HirIdentUnknown
 }
 
 fn hirLowerCoreIdentCaptureKind(

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -1154,12 +1154,12 @@ pub enum MirInlineMode {
 /// mirInlineModeName renders a MirInlineMode for diagnostic /
 /// debug-print callers. Matches hirInlineModeName verbatim.
 pub fn mirInlineModeName(mode: MirInlineMode) -> String {
-    match mode {
-        MirInlineNone -> "none",
-        MirInlineSoft -> "soft",
-        MirInlineAlways -> "always",
-        MirInlineNever -> "never",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if mode == MirInlineNone { return "none" }
+    if mode == MirInlineSoft { return "soft" }
+    if mode == MirInlineAlways { return "always" }
+    if mode == MirInlineNever { return "never" }
+    "none"
 }
 
 pub fn mirFunction(name: String, returnType: String, span: MirSpan) -> MirFunction {
@@ -1581,11 +1581,10 @@ fn mirPrintInstr(i: MirInstr, func: MirFunction) -> String {
 }
 
 fn mirPrintCallee(i: MirInstr, func: MirFunction) -> String {
-    match i.calleeKind {
-        MirCalleeFn -> i.calleeSymbol,
-        MirCalleeIndirect -> "*" + mirPrintOperand(i.calleeOperand, func),
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if i.calleeKind == MirCalleeFn { return i.calleeSymbol }
+    if i.calleeKind == MirCalleeIndirect { return "*" + mirPrintOperand(i.calleeOperand, func) }
+    "(?)"
 }
 
 fn mirPrintTerm(t: MirTerm, func: MirFunction) -> String {
@@ -1649,12 +1648,11 @@ fn mirPrintProjection(proj: MirProjection, func: MirFunction) -> String {
 }
 
 fn mirPrintOperand(op: MirOperand, func: MirFunction) -> String {
-    match op.kind {
-        MirOpCopy -> mirPrintPlace(op.place, func),
-        MirOpMove -> "move " + mirPrintPlace(op.place, func),
-        MirOpConst -> mirPrintConst(op.const),
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if op.kind == MirOpCopy { return mirPrintPlace(op.place, func) }
+    if op.kind == MirOpMove { return "move " + mirPrintPlace(op.place, func) }
+    if op.kind == MirOpConst { return mirPrintConst(op.const) }
+    "(?)"
 }
 
 fn mirPrintOperandList(ops: List<MirOperand>, func: MirFunction) -> String {
@@ -1720,69 +1718,64 @@ fn mirPrintRValue(rv: MirRValue, func: MirFunction) -> String {
 // ====================================================================
 
 fn mirUnaryOpName(op: MirUnaryOp) -> String {
-    match op {
-        MirUnNeg -> "-",
-        MirUnPlus -> "+",
-        MirUnNot -> "!",
-        MirUnBitNot -> "~",
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if op == MirUnNeg { return "-" }
+    if op == MirUnPlus { return "+" }
+    if op == MirUnNot { return "!" }
+    if op == MirUnBitNot { return "~" }
+    "(?)"
 }
 
 fn mirBinaryOpName(op: MirBinaryOp) -> String {
-    match op {
-        MirBinAdd -> "+",
-        MirBinSub -> "-",
-        MirBinMul -> "*",
-        MirBinDiv -> "/",
-        MirBinMod -> "%",
-        MirBinEq -> "==",
-        MirBinNeq -> "!=",
-        MirBinLt -> "<",
-        MirBinLeq -> "<=",
-        MirBinGt -> ">",
-        MirBinGeq -> ">=",
-        MirBinAnd -> "&&",
-        MirBinOr -> "||",
-        MirBinBitAnd -> "&",
-        MirBinBitOr -> "|",
-        MirBinBitXor -> "^",
-        MirBinShl -> "<<",
-        MirBinShr -> ">>",
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if op == MirBinAdd { return "+" }
+    if op == MirBinSub { return "-" }
+    if op == MirBinMul { return "*" }
+    if op == MirBinDiv { return "/" }
+    if op == MirBinMod { return "%" }
+    if op == MirBinEq { return "==" }
+    if op == MirBinNeq { return "!=" }
+    if op == MirBinLt { return "<" }
+    if op == MirBinLeq { return "<=" }
+    if op == MirBinGt { return ">" }
+    if op == MirBinGeq { return ">=" }
+    if op == MirBinAnd { return "&&" }
+    if op == MirBinOr { return "||" }
+    if op == MirBinBitAnd { return "&" }
+    if op == MirBinBitOr { return "|" }
+    if op == MirBinBitXor { return "^" }
+    if op == MirBinShl { return "<<" }
+    if op == MirBinShr { return ">>" }
+    "(?)"
 }
 
 fn mirAggregateKindName(k: MirAggregateKind) -> String {
-    match k {
-        MirAggTuple -> "Tuple",
-        MirAggStruct -> "Struct",
-        MirAggEnumVariant -> "EnumVariant",
-        MirAggList -> "List",
-        MirAggMap -> "Map",
-        MirAggClosure -> "Closure",
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirAggTuple { return "Tuple" }
+    if k == MirAggStruct { return "Struct" }
+    if k == MirAggEnumVariant { return "EnumVariant" }
+    if k == MirAggList { return "List" }
+    if k == MirAggMap { return "Map" }
+    if k == MirAggClosure { return "Closure" }
+    "(?)"
 }
 
 fn mirCastKindName(k: MirCastKind) -> String {
-    match k {
-        MirCastIntResize -> "int_resize",
-        MirCastIntToFloat -> "int_to_float",
-        MirCastFloatToInt -> "float_to_int",
-        MirCastFloatResize -> "float_resize",
-        MirCastOptionalWrap -> "optional_wrap",
-        MirCastOptionalUnwrap -> "optional_unwrap",
-        MirCastBitcast -> "bitcast",
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirCastIntResize { return "int_resize" }
+    if k == MirCastIntToFloat { return "int_to_float" }
+    if k == MirCastFloatToInt { return "float_to_int" }
+    if k == MirCastFloatResize { return "float_resize" }
+    if k == MirCastOptionalWrap { return "optional_wrap" }
+    if k == MirCastOptionalUnwrap { return "optional_unwrap" }
+    if k == MirCastBitcast { return "bitcast" }
+    "(?)"
 }
 
 fn mirNullaryKindName(k: MirNullaryRVKind) -> String {
-    match k {
-        MirNullaryNone -> "none",
-        _ -> "(?)",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirNullaryNone { return "none" }
+    "(?)"
 }
 
 /// mirIntrinsicName returns the canonical printable name of a MIR
@@ -1790,146 +1783,145 @@ fn mirNullaryKindName(k: MirNullaryRVKind) -> String {
 /// IntrinsicKind; callers that need a stable on-disk encoding should
 /// use this rather than the raw enum tag.
 pub fn mirIntrinsicName(k: MirIntrinsicKind) -> String {
-    match k {
-        MirIntrinsicPrint -> "print",
-        MirIntrinsicPrintln -> "println",
-        MirIntrinsicEprint -> "eprint",
-        MirIntrinsicEprintln -> "eprintln",
-        MirIntrinsicAbort -> "abort",
-        MirIntrinsicStringConcat -> "string_concat",
-        MirIntrinsicBytesConcat -> "bytes_concat",
-        MirIntrinsicChanMake -> "chan_make",
-        MirIntrinsicChanSend -> "chan_send",
-        MirIntrinsicChanRecv -> "chan_recv",
-        MirIntrinsicChanClose -> "chan_close",
-        MirIntrinsicChanIsClosed -> "chan_is_closed",
-        MirIntrinsicTaskGroup -> "task_group",
-        MirIntrinsicSpawn -> "spawn",
-        MirIntrinsicHandleJoin -> "handle_join",
-        MirIntrinsicGroupCancel -> "group_cancel",
-        MirIntrinsicGroupIsCancelled -> "group_is_cancelled",
-        MirIntrinsicParallel -> "parallel",
-        MirIntrinsicRace -> "race",
-        MirIntrinsicCollectAll -> "collect_all",
-        MirIntrinsicSelect -> "select",
-        MirIntrinsicSelectRecv -> "select_recv",
-        MirIntrinsicSelectSend -> "select_send",
-        MirIntrinsicSelectTimeout -> "select_timeout",
-        MirIntrinsicSelectDefault -> "select_default",
-        MirIntrinsicIsCancelled -> "is_cancelled",
-        MirIntrinsicCheckCancelled -> "check_cancelled",
-        MirIntrinsicYield -> "yield",
-        MirIntrinsicSleep -> "sleep",
-        MirIntrinsicListPush -> "list_push",
-        MirIntrinsicListLen -> "list_len",
-        MirIntrinsicListGet -> "list_get",
-        MirIntrinsicListIsEmpty -> "list_is_empty",
-        MirIntrinsicListFirst -> "list_first",
-        MirIntrinsicListLast -> "list_last",
-        MirIntrinsicListSorted -> "list_sorted",
-        MirIntrinsicListContains -> "list_contains",
-        MirIntrinsicListIndexOf -> "list_index_of",
-        MirIntrinsicListToSet -> "list_to_set",
-        MirIntrinsicListRemoveAt -> "list_remove_at",
-        MirIntrinsicListReverse -> "list_reverse",
-        MirIntrinsicListReversed -> "list_reversed",
-        MirIntrinsicListToString -> "list_to_string",
-        MirIntrinsicMapNew -> "map_new",
-        MirIntrinsicMapGet -> "map_get",
-        MirIntrinsicMapSet -> "map_set",
-        MirIntrinsicMapContains -> "map_contains",
-        MirIntrinsicMapLen -> "map_len",
-        MirIntrinsicMapKeys -> "map_keys",
-        MirIntrinsicMapValues -> "map_values",
-        MirIntrinsicMapRemove -> "map_remove",
-        MirIntrinsicMapKeysSorted -> "map_keys_sorted",
-        MirIntrinsicMapToString -> "map_to_string",
-        MirIntrinsicSetNew -> "set_new",
-        MirIntrinsicSetInsert -> "set_insert",
-        MirIntrinsicSetContains -> "set_contains",
-        MirIntrinsicSetLen -> "set_len",
-        MirIntrinsicSetToList -> "set_to_list",
-        MirIntrinsicSetRemove -> "set_remove",
-        MirIntrinsicSetToString -> "set_to_string",
-        MirIntrinsicStringLen -> "string_len",
-        MirIntrinsicStringIsEmpty -> "string_is_empty",
-        MirIntrinsicStringContains -> "string_contains",
-        MirIntrinsicStringCount -> "string_count",
-        MirIntrinsicStringStartsWith -> "string_starts_with",
-        MirIntrinsicStringEndsWith -> "string_ends_with",
-        MirIntrinsicStringIndexOf -> "string_index_of",
-        MirIntrinsicStringSplit -> "string_split",
-        MirIntrinsicStringTrim -> "string_trim",
-        MirIntrinsicStringToUpper -> "string_to_upper",
-        MirIntrinsicStringToLower -> "string_to_lower",
-        MirIntrinsicStringToInt -> "string_to_int",
-        MirIntrinsicStringToFloat -> "string_to_float",
-        MirIntrinsicStringReplace -> "string_replace",
-        MirIntrinsicStringChars -> "string_chars",
-        MirIntrinsicStringBytes -> "string_bytes",
-        MirIntrinsicBytesLen -> "bytes_len",
-        MirIntrinsicBytesIsEmpty -> "bytes_is_empty",
-        MirIntrinsicBytesGet -> "bytes_get",
-        MirIntrinsicBytesContains -> "bytes_contains",
-        MirIntrinsicBytesStartsWith -> "bytes_starts_with",
-        MirIntrinsicBytesEndsWith -> "bytes_ends_with",
-        MirIntrinsicBytesIndexOf -> "bytes_index_of",
-        MirIntrinsicBytesLastIndexOf -> "bytes_last_index_of",
-        MirIntrinsicBytesSplit -> "bytes_split",
-        MirIntrinsicBytesJoin -> "bytes_join",
-        MirIntrinsicBytesRepeat -> "bytes_repeat",
-        MirIntrinsicBytesReplace -> "bytes_replace",
-        MirIntrinsicBytesReplaceAll -> "bytes_replace_all",
-        MirIntrinsicBytesTrimLeft -> "bytes_trim_left",
-        MirIntrinsicBytesTrimRight -> "bytes_trim_right",
-        MirIntrinsicBytesTrim -> "bytes_trim",
-        MirIntrinsicBytesTrimSpace -> "bytes_trim_space",
-        MirIntrinsicBytesToUpper -> "bytes_to_upper",
-        MirIntrinsicBytesToLower -> "bytes_to_lower",
-        MirIntrinsicBytesToHex -> "bytes_to_hex",
-        MirIntrinsicBytesSlice -> "bytes_slice",
-        MirIntrinsicOptionIsSome -> "option_is_some",
-        MirIntrinsicOptionIsNone -> "option_is_none",
-        MirIntrinsicOptionUnwrap -> "option_unwrap",
-        MirIntrinsicOptionUnwrapOr -> "option_unwrap_or",
-        MirIntrinsicResultIsOk -> "result_is_ok",
-        MirIntrinsicResultIsErr -> "result_is_err",
-        MirIntrinsicResultUnwrap -> "result_unwrap",
-        MirIntrinsicResultUnwrapOr -> "result_unwrap_or",
-        MirIntrinsicRawNull -> "raw_null",
-        MirIntrinsicStringJoin -> "string_join",
-        MirIntrinsicListPop -> "list_pop",
-        MirIntrinsicStringSubstring -> "string_substring",
-        MirIntrinsicByteToInt -> "byte_to_int",
-        MirIntrinsicCharToInt -> "char_to_int",
-        MirIntrinsicListSlice -> "list_slice",
-        MirIntrinsicMapGetOr -> "map_get_or",
-        MirIntrinsicStringSplitInto -> "string_split_into",
-        MirIntrinsicStringNthSegment -> "string_nth_segment",
-        MirIntrinsicMapIncr -> "map_incr",
-        MirIntrinsicStringRepeat -> "string_repeat",
-        MirIntrinsicStringTrimPrefix -> "string_trim_prefix",
-        MirIntrinsicStringTrimSuffix -> "string_trim_suffix",
-        MirIntrinsicStringTrimStart -> "string_trim_start",
-        MirIntrinsicStringTrimEnd -> "string_trim_end",
-        MirIntrinsicStringReplaceAll -> "string_replace_all",
-        MirIntrinsicStringSplitN -> "string_split_n",
-        MirIntrinsicStringFields -> "string_fields",
-        MirIntrinsicStringLastIndexOf -> "string_last_index_of",
-        MirIntrinsicBytesFromList -> "bytes_from_list",
-        MirIntrinsicBytesFromString -> "bytes_from_string",
-        MirIntrinsicBytesToString -> "bytes_to_string",
-        MirIntrinsicBytesFromHex -> "bytes_from_hex",
-        MirIntrinsicIntToByte -> "int_to_byte",
-        MirIntrinsicIntToChar -> "int_to_char",
-        MirIntrinsicByteToChar -> "byte_to_char",
-        MirIntrinsicCharToByte -> "char_to_byte",
-        MirIntrinsicListInsert -> "list_insert",
-        MirIntrinsicListClear -> "list_clear",
-        MirIntrinsicMapClear -> "map_clear",
-        MirIntrinsicSetClear -> "set_clear",
-        _ -> "invalid",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirIntrinsicPrint { return "print" }
+    if k == MirIntrinsicPrintln { return "println" }
+    if k == MirIntrinsicEprint { return "eprint" }
+    if k == MirIntrinsicEprintln { return "eprintln" }
+    if k == MirIntrinsicAbort { return "abort" }
+    if k == MirIntrinsicStringConcat { return "string_concat" }
+    if k == MirIntrinsicBytesConcat { return "bytes_concat" }
+    if k == MirIntrinsicChanMake { return "chan_make" }
+    if k == MirIntrinsicChanSend { return "chan_send" }
+    if k == MirIntrinsicChanRecv { return "chan_recv" }
+    if k == MirIntrinsicChanClose { return "chan_close" }
+    if k == MirIntrinsicChanIsClosed { return "chan_is_closed" }
+    if k == MirIntrinsicTaskGroup { return "task_group" }
+    if k == MirIntrinsicSpawn { return "spawn" }
+    if k == MirIntrinsicHandleJoin { return "handle_join" }
+    if k == MirIntrinsicGroupCancel { return "group_cancel" }
+    if k == MirIntrinsicGroupIsCancelled { return "group_is_cancelled" }
+    if k == MirIntrinsicParallel { return "parallel" }
+    if k == MirIntrinsicRace { return "race" }
+    if k == MirIntrinsicCollectAll { return "collect_all" }
+    if k == MirIntrinsicSelect { return "select" }
+    if k == MirIntrinsicSelectRecv { return "select_recv" }
+    if k == MirIntrinsicSelectSend { return "select_send" }
+    if k == MirIntrinsicSelectTimeout { return "select_timeout" }
+    if k == MirIntrinsicSelectDefault { return "select_default" }
+    if k == MirIntrinsicIsCancelled { return "is_cancelled" }
+    if k == MirIntrinsicCheckCancelled { return "check_cancelled" }
+    if k == MirIntrinsicYield { return "yield" }
+    if k == MirIntrinsicSleep { return "sleep" }
+    if k == MirIntrinsicListPush { return "list_push" }
+    if k == MirIntrinsicListLen { return "list_len" }
+    if k == MirIntrinsicListGet { return "list_get" }
+    if k == MirIntrinsicListIsEmpty { return "list_is_empty" }
+    if k == MirIntrinsicListFirst { return "list_first" }
+    if k == MirIntrinsicListLast { return "list_last" }
+    if k == MirIntrinsicListSorted { return "list_sorted" }
+    if k == MirIntrinsicListContains { return "list_contains" }
+    if k == MirIntrinsicListIndexOf { return "list_index_of" }
+    if k == MirIntrinsicListToSet { return "list_to_set" }
+    if k == MirIntrinsicListRemoveAt { return "list_remove_at" }
+    if k == MirIntrinsicListReverse { return "list_reverse" }
+    if k == MirIntrinsicListReversed { return "list_reversed" }
+    if k == MirIntrinsicListToString { return "list_to_string" }
+    if k == MirIntrinsicMapNew { return "map_new" }
+    if k == MirIntrinsicMapGet { return "map_get" }
+    if k == MirIntrinsicMapSet { return "map_set" }
+    if k == MirIntrinsicMapContains { return "map_contains" }
+    if k == MirIntrinsicMapLen { return "map_len" }
+    if k == MirIntrinsicMapKeys { return "map_keys" }
+    if k == MirIntrinsicMapValues { return "map_values" }
+    if k == MirIntrinsicMapRemove { return "map_remove" }
+    if k == MirIntrinsicMapKeysSorted { return "map_keys_sorted" }
+    if k == MirIntrinsicMapToString { return "map_to_string" }
+    if k == MirIntrinsicSetNew { return "set_new" }
+    if k == MirIntrinsicSetInsert { return "set_insert" }
+    if k == MirIntrinsicSetContains { return "set_contains" }
+    if k == MirIntrinsicSetLen { return "set_len" }
+    if k == MirIntrinsicSetToList { return "set_to_list" }
+    if k == MirIntrinsicSetRemove { return "set_remove" }
+    if k == MirIntrinsicSetToString { return "set_to_string" }
+    if k == MirIntrinsicStringLen { return "string_len" }
+    if k == MirIntrinsicStringIsEmpty { return "string_is_empty" }
+    if k == MirIntrinsicStringContains { return "string_contains" }
+    if k == MirIntrinsicStringCount { return "string_count" }
+    if k == MirIntrinsicStringStartsWith { return "string_starts_with" }
+    if k == MirIntrinsicStringEndsWith { return "string_ends_with" }
+    if k == MirIntrinsicStringIndexOf { return "string_index_of" }
+    if k == MirIntrinsicStringSplit { return "string_split" }
+    if k == MirIntrinsicStringTrim { return "string_trim" }
+    if k == MirIntrinsicStringToUpper { return "string_to_upper" }
+    if k == MirIntrinsicStringToLower { return "string_to_lower" }
+    if k == MirIntrinsicStringToInt { return "string_to_int" }
+    if k == MirIntrinsicStringToFloat { return "string_to_float" }
+    if k == MirIntrinsicStringReplace { return "string_replace" }
+    if k == MirIntrinsicStringChars { return "string_chars" }
+    if k == MirIntrinsicStringBytes { return "string_bytes" }
+    if k == MirIntrinsicBytesLen { return "bytes_len" }
+    if k == MirIntrinsicBytesIsEmpty { return "bytes_is_empty" }
+    if k == MirIntrinsicBytesGet { return "bytes_get" }
+    if k == MirIntrinsicBytesContains { return "bytes_contains" }
+    if k == MirIntrinsicBytesStartsWith { return "bytes_starts_with" }
+    if k == MirIntrinsicBytesEndsWith { return "bytes_ends_with" }
+    if k == MirIntrinsicBytesIndexOf { return "bytes_index_of" }
+    if k == MirIntrinsicBytesLastIndexOf { return "bytes_last_index_of" }
+    if k == MirIntrinsicBytesSplit { return "bytes_split" }
+    if k == MirIntrinsicBytesJoin { return "bytes_join" }
+    if k == MirIntrinsicBytesRepeat { return "bytes_repeat" }
+    if k == MirIntrinsicBytesReplace { return "bytes_replace" }
+    if k == MirIntrinsicBytesReplaceAll { return "bytes_replace_all" }
+    if k == MirIntrinsicBytesTrimLeft { return "bytes_trim_left" }
+    if k == MirIntrinsicBytesTrimRight { return "bytes_trim_right" }
+    if k == MirIntrinsicBytesTrim { return "bytes_trim" }
+    if k == MirIntrinsicBytesTrimSpace { return "bytes_trim_space" }
+    if k == MirIntrinsicBytesToUpper { return "bytes_to_upper" }
+    if k == MirIntrinsicBytesToLower { return "bytes_to_lower" }
+    if k == MirIntrinsicBytesToHex { return "bytes_to_hex" }
+    if k == MirIntrinsicBytesSlice { return "bytes_slice" }
+    if k == MirIntrinsicOptionIsSome { return "option_is_some" }
+    if k == MirIntrinsicOptionIsNone { return "option_is_none" }
+    if k == MirIntrinsicOptionUnwrap { return "option_unwrap" }
+    if k == MirIntrinsicOptionUnwrapOr { return "option_unwrap_or" }
+    if k == MirIntrinsicResultIsOk { return "result_is_ok" }
+    if k == MirIntrinsicResultIsErr { return "result_is_err" }
+    if k == MirIntrinsicResultUnwrap { return "result_unwrap" }
+    if k == MirIntrinsicResultUnwrapOr { return "result_unwrap_or" }
+    if k == MirIntrinsicRawNull { return "raw_null" }
+    if k == MirIntrinsicStringJoin { return "string_join" }
+    if k == MirIntrinsicListPop { return "list_pop" }
+    if k == MirIntrinsicStringSubstring { return "string_substring" }
+    if k == MirIntrinsicByteToInt { return "byte_to_int" }
+    if k == MirIntrinsicCharToInt { return "char_to_int" }
+    if k == MirIntrinsicListSlice { return "list_slice" }
+    if k == MirIntrinsicMapGetOr { return "map_get_or" }
+    if k == MirIntrinsicStringSplitInto { return "string_split_into" }
+    if k == MirIntrinsicStringNthSegment { return "string_nth_segment" }
+    if k == MirIntrinsicMapIncr { return "map_incr" }
+    if k == MirIntrinsicStringRepeat { return "string_repeat" }
+    if k == MirIntrinsicStringTrimPrefix { return "string_trim_prefix" }
+    if k == MirIntrinsicStringTrimSuffix { return "string_trim_suffix" }
+    if k == MirIntrinsicStringTrimStart { return "string_trim_start" }
+    if k == MirIntrinsicStringTrimEnd { return "string_trim_end" }
+    if k == MirIntrinsicStringReplaceAll { return "string_replace_all" }
+    if k == MirIntrinsicStringSplitN { return "string_split_n" }
+    if k == MirIntrinsicStringFields { return "string_fields" }
+    if k == MirIntrinsicStringLastIndexOf { return "string_last_index_of" }
+    if k == MirIntrinsicBytesFromList { return "bytes_from_list" }
+    if k == MirIntrinsicBytesFromString { return "bytes_from_string" }
+    if k == MirIntrinsicBytesToString { return "bytes_to_string" }
+    if k == MirIntrinsicBytesFromHex { return "bytes_from_hex" }
+    if k == MirIntrinsicIntToByte { return "int_to_byte" }
+    if k == MirIntrinsicIntToChar { return "int_to_char" }
+    if k == MirIntrinsicByteToChar { return "byte_to_char" }
+    if k == MirIntrinsicCharToByte { return "char_to_byte" }
+    if k == MirIntrinsicListInsert { return "list_insert" }
+    if k == MirIntrinsicListClear { return "list_clear" }
+    if k == MirIntrinsicMapClear { return "map_clear" }
+    if k == MirIntrinsicSetClear { return "set_clear" }
+    "invalid"
 }
 
 // ====================================================================
@@ -1981,19 +1973,18 @@ fn mirIntToString(n: Int) -> String {
 }
 
 fn mirDigitChar(d: Int) -> String {
-    match d {
-        0 -> "0",
-        1 -> "1",
-        2 -> "2",
-        3 -> "3",
-        4 -> "4",
-        5 -> "5",
-        6 -> "6",
-        7 -> "7",
-        8 -> "8",
-        9 -> "9",
-        _ -> "?",
-    }
+    // B2: Int dispatch as if-else chain (stage0 P0–P15).
+    if d == 0 { return "0" }
+    if d == 1 { return "1" }
+    if d == 2 { return "2" }
+    if d == 3 { return "3" }
+    if d == 4 { return "4" }
+    if d == 5 { return "5" }
+    if d == 6 { return "6" }
+    if d == 7 { return "7" }
+    if d == 8 { return "8" }
+    if d == 9 { return "9" }
+    "?"
 }
 
 // ====================================================================
@@ -2001,55 +1992,51 @@ fn mirDigitChar(d: Int) -> String {
 // ====================================================================
 
 pub fn mirInstrKindName(k: MirInstrKind) -> String {
-    match k {
-        MirInstrAssign -> "assign",
-        MirInstrCall -> "call",
-        MirInstrIntrinsic -> "intrinsic",
-        MirInstrStorageLive -> "storage_live",
-        MirInstrStorageDead -> "storage_dead",
-        _ -> "invalid",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirInstrAssign { return "assign" }
+    if k == MirInstrCall { return "call" }
+    if k == MirInstrIntrinsic { return "intrinsic" }
+    if k == MirInstrStorageLive { return "storage_live" }
+    if k == MirInstrStorageDead { return "storage_dead" }
+    "invalid"
 }
 
 pub fn mirTermKindName(k: MirTermKind) -> String {
-    match k {
-        MirTermGoto -> "goto",
-        MirTermBranch -> "branch",
-        MirTermSwitchInt -> "switch_int",
-        MirTermReturn -> "return",
-        MirTermUnreachable -> "unreachable",
-        _ -> "invalid",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirTermGoto { return "goto" }
+    if k == MirTermBranch { return "branch" }
+    if k == MirTermSwitchInt { return "switch_int" }
+    if k == MirTermReturn { return "return" }
+    if k == MirTermUnreachable { return "unreachable" }
+    "invalid"
 }
 
 pub fn mirRValueKindName(k: MirRValueKind) -> String {
-    match k {
-        MirRVUse -> "use",
-        MirRVUnary -> "unary",
-        MirRVBinary -> "binary",
-        MirRVAggregate -> "aggregate",
-        MirRVDiscriminant -> "discriminant",
-        MirRVLen -> "len",
-        MirRVCast -> "cast",
-        MirRVRef -> "ref",
-        MirRVAddressOf -> "address_of",
-        MirRVGlobalRef -> "global_ref",
-        MirRVNullary -> "nullary",
-        _ -> "invalid",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirRVUse { return "use" }
+    if k == MirRVUnary { return "unary" }
+    if k == MirRVBinary { return "binary" }
+    if k == MirRVAggregate { return "aggregate" }
+    if k == MirRVDiscriminant { return "discriminant" }
+    if k == MirRVLen { return "len" }
+    if k == MirRVCast { return "cast" }
+    if k == MirRVRef { return "ref" }
+    if k == MirRVAddressOf { return "address_of" }
+    if k == MirRVGlobalRef { return "global_ref" }
+    if k == MirRVNullary { return "nullary" }
+    "invalid"
 }
 
 pub fn mirConstKindName(k: MirConstKind) -> String {
-    match k {
-        MirConstInt -> "int",
-        MirConstBool -> "bool",
-        MirConstFloat -> "float",
-        MirConstString -> "string",
-        MirConstChar -> "char",
-        MirConstByte -> "byte",
-        MirConstUnit -> "unit",
-        MirConstNull -> "null",
-        MirConstFn -> "fn",
-        _ -> "invalid",
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if k == MirConstInt { return "int" }
+    if k == MirConstBool { return "bool" }
+    if k == MirConstFloat { return "float" }
+    if k == MirConstString { return "string" }
+    if k == MirConstChar { return "char" }
+    if k == MirConstByte { return "byte" }
+    if k == MirConstUnit { return "unit" }
+    if k == MirConstNull { return "null" }
+    if k == MirConstFn { return "fn" }
+    "invalid"
 }

--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -522,19 +522,18 @@ pub fn mirLowerIntToString(n: Int) -> String {
 }
 
 fn mirLowerDigitChar(d: Int) -> String {
-    match d {
-        0 -> "0",
-        1 -> "1",
-        2 -> "2",
-        3 -> "3",
-        4 -> "4",
-        5 -> "5",
-        6 -> "6",
-        7 -> "7",
-        8 -> "8",
-        9 -> "9",
-        _ -> "?",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if d == 0 { return "0" }
+    if d == 1 { return "1" }
+    if d == 2 { return "2" }
+    if d == 3 { return "3" }
+    if d == 4 { return "4" }
+    if d == 5 { return "5" }
+    if d == 6 { return "6" }
+    if d == 7 { return "7" }
+    if d == 8 { return "8" }
+    if d == 9 { return "9" }
+    "?"
 }
 
 // ====================================================================
@@ -889,10 +888,9 @@ pub fn mirLowerGlobal(l: MirLowerer, let_: HirLetDecl) -> MirGlobal {
 /// call-site dispatch (e.g. distinguishing stdlib intrinsics from
 /// user calls).
 pub fn hirTypeNameOf(t: HirType) -> String {
-    match t.kind {
-        HirTypeNamed -> t.namedName,
-        _ -> "",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeNamed { return t.namedName }
+    ""
 }
 
 /// hirTypeIsList reports whether `t` is a `List<_>` builtin type.
@@ -993,58 +991,58 @@ pub fn hirTypeSecondArg(t: HirType) -> HirType {
 /// hirUnOpToMir maps HIR unary-op kinds to MIR's enum. Returns
 /// `MirUnInvalid` for the Osty-side `HirUnInvalid`.
 pub fn hirUnOpToMir(op: HirUnOp) -> MirUnaryOp {
-    match op {
-        HirUnInvalid -> MirUnInvalid,
-        HirUnNeg -> MirUnNeg,
-        HirUnPlus -> MirUnPlus,
-        HirUnNot -> MirUnNot,
-        HirUnBitNot -> MirUnBitNot,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if op == HirUnInvalid { return MirUnInvalid }
+    if op == HirUnNeg { return MirUnNeg }
+    if op == HirUnPlus { return MirUnPlus }
+    if op == HirUnNot { return MirUnNot }
+    if op == HirUnBitNot { return MirUnBitNot }
+    MirUnInvalid
 }
 
 /// hirBinOpToMir maps HIR binary-op kinds to MIR's enum.
 pub fn hirBinOpToMir(op: HirBinOp) -> MirBinaryOp {
-    match op {
-        HirBinInvalid -> MirBinInvalid,
-        HirBinAdd -> MirBinAdd,
-        HirBinSub -> MirBinSub,
-        HirBinMul -> MirBinMul,
-        HirBinDiv -> MirBinDiv,
-        HirBinMod -> MirBinMod,
-        HirBinEq -> MirBinEq,
-        HirBinNeq -> MirBinNeq,
-        HirBinLt -> MirBinLt,
-        HirBinLeq -> MirBinLeq,
-        HirBinGt -> MirBinGt,
-        HirBinGeq -> MirBinGeq,
-        HirBinAnd -> MirBinAnd,
-        HirBinOr -> MirBinOr,
-        HirBinBitAnd -> MirBinBitAnd,
-        HirBinBitOr -> MirBinBitOr,
-        HirBinBitXor -> MirBinBitXor,
-        HirBinShl -> MirBinShl,
-        HirBinShr -> MirBinShr,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if op == HirBinInvalid { return MirBinInvalid }
+    if op == HirBinAdd { return MirBinAdd }
+    if op == HirBinSub { return MirBinSub }
+    if op == HirBinMul { return MirBinMul }
+    if op == HirBinDiv { return MirBinDiv }
+    if op == HirBinMod { return MirBinMod }
+    if op == HirBinEq { return MirBinEq }
+    if op == HirBinNeq { return MirBinNeq }
+    if op == HirBinLt { return MirBinLt }
+    if op == HirBinLeq { return MirBinLeq }
+    if op == HirBinGt { return MirBinGt }
+    if op == HirBinGeq { return MirBinGeq }
+    if op == HirBinAnd { return MirBinAnd }
+    if op == HirBinOr { return MirBinOr }
+    if op == HirBinBitAnd { return MirBinBitAnd }
+    if op == HirBinBitOr { return MirBinBitOr }
+    if op == HirBinBitXor { return MirBinBitXor }
+    if op == HirBinShl { return MirBinShl }
+    if op == HirBinShr { return MirBinShr }
+    MirBinInvalid
 }
 
 /// hirAssignOpToBinOp maps a compound-assign operator to its
 /// equivalent binary op for lowering `x op= y` into `x = x op y`.
 /// Returns `MirBinInvalid` for plain `=` (no underlying binary op).
 pub fn hirAssignOpToBinOp(op: HirAssignOp) -> MirBinaryOp {
-    match op {
-        HirAssignInvalid -> MirBinInvalid,
-        HirAssignEq -> MirBinInvalid,
-        HirAssignAdd -> MirBinAdd,
-        HirAssignSub -> MirBinSub,
-        HirAssignMul -> MirBinMul,
-        HirAssignDiv -> MirBinDiv,
-        HirAssignMod -> MirBinMod,
-        HirAssignAnd -> MirBinBitAnd,
-        HirAssignOr -> MirBinBitOr,
-        HirAssignXor -> MirBinBitXor,
-        HirAssignShl -> MirBinShl,
-        HirAssignShr -> MirBinShr,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if op == HirAssignInvalid { return MirBinInvalid }
+    if op == HirAssignEq { return MirBinInvalid }
+    if op == HirAssignAdd { return MirBinAdd }
+    if op == HirAssignSub { return MirBinSub }
+    if op == HirAssignMul { return MirBinMul }
+    if op == HirAssignDiv { return MirBinDiv }
+    if op == HirAssignMod { return MirBinMod }
+    if op == HirAssignAnd { return MirBinBitAnd }
+    if op == HirAssignOr { return MirBinBitOr }
+    if op == HirAssignXor { return MirBinBitXor }
+    if op == HirAssignShl { return MirBinShl }
+    if op == HirAssignShr { return MirBinShr }
+    MirBinInvalid
 }
 
 // ====================================================================
@@ -1555,21 +1553,20 @@ pub fn mirLowerExprAsOperand(bs: MirLowerBodyState, e: HirExpr) -> MirOperand {
     if !hirExprIsValid(e) {
         return mirOperandConst(mirConstUnit())
     }
-    match e.kind {
-        HirExprIntLit -> mirLowerIntLitOperand(e),
-        HirExprFloatLit -> mirLowerFloatLitOperand(e),
-        HirExprBoolLit -> mirOperandConst(mirConstBool(e.boolValue)),
-        HirExprCharLit -> mirOperandConst(mirConstChar(e.charValue)),
-        HirExprByteLit -> mirOperandConst(mirConstByte(e.byteValue)),
-        HirExprUnitLit -> mirOperandConst(mirConstUnit()),
-        HirExprStringLit -> mirLowerStringLitOperand(bs, e),
-        HirExprBytesLit -> mirLowerBytesLitOperand(bs, e),
-        HirExprIdent -> mirLowerIdentOperand(bs, e),
-        HirExprField -> mirLowerFieldExprOperand(bs, e),
-        HirExprTupleAccess -> mirLowerTupleAccessOperand(bs, e),
-        HirExprIndex -> mirLowerIndexExprOperand(bs, e),
-        _ -> mirLowerExprAsOperandFallback(bs, e),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprIntLit { return mirLowerIntLitOperand(e) }
+    if e.kind == HirExprFloatLit { return mirLowerFloatLitOperand(e) }
+    if e.kind == HirExprBoolLit { return mirOperandConst(mirConstBool(e.boolValue)) }
+    if e.kind == HirExprCharLit { return mirOperandConst(mirConstChar(e.charValue)) }
+    if e.kind == HirExprByteLit { return mirOperandConst(mirConstByte(e.byteValue)) }
+    if e.kind == HirExprUnitLit { return mirOperandConst(mirConstUnit()) }
+    if e.kind == HirExprStringLit { return mirLowerStringLitOperand(bs, e) }
+    if e.kind == HirExprBytesLit { return mirLowerBytesLitOperand(bs, e) }
+    if e.kind == HirExprIdent { return mirLowerIdentOperand(bs, e) }
+    if e.kind == HirExprField { return mirLowerFieldExprOperand(bs, e) }
+    if e.kind == HirExprTupleAccess { return mirLowerTupleAccessOperand(bs, e) }
+    if e.kind == HirExprIndex { return mirLowerIndexExprOperand(bs, e) }
+    mirLowerExprAsOperandFallback(bs, e)
 }
 
 /// mirLowerExprAsOperandFallback handles every expression kind that
@@ -1618,10 +1615,9 @@ pub fn mirLowerRecoveredExprType(bs: MirLowerBodyState, e: HirExpr) -> HirType {
     if hirTypeIsValid(e.typ) && !hirTypeIsErr(e.typ) {
         return e.typ
     }
-    match e.kind {
-        HirExprCall -> mirLowerCallExprRecoveredType(bs, e),
-        _ -> e.typ,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprCall { return mirLowerCallExprRecoveredType(bs, e) }
+    e.typ
 }
 
 fn mirLowerIdentRecoveredType(bs: MirLowerBodyState, e: HirExpr) -> HirType {
@@ -2288,13 +2284,12 @@ pub fn mirLowerFreshTemp(bs: MirLowerBodyState, t: HirType, span: MirSpan) -> In
 /// Since Osty doesn't have tuple returns in our style yet, we return a
 /// MirPlace with `local == -1` on failure and callers check the local.
 pub fn mirLowerExprToPlace(bs: MirLowerBodyState, e: HirExpr) -> MirPlace {
-    match e.kind {
-        HirExprIdent -> mirLowerIdentPlace(bs, e),
-        HirExprField -> mirLowerFieldExprPlace(bs, e),
-        HirExprTupleAccess -> mirLowerTupleAccessPlace(bs, e),
-        HirExprIndex -> mirLowerIndexExprPlace(bs, e),
-        _ -> mirPlace(-1),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprIdent { return mirLowerIdentPlace(bs, e) }
+    if e.kind == HirExprField { return mirLowerFieldExprPlace(bs, e) }
+    if e.kind == HirExprTupleAccess { return mirLowerTupleAccessPlace(bs, e) }
+    if e.kind == HirExprIndex { return mirLowerIndexExprPlace(bs, e) }
+    mirPlace(-1)
 }
 
 fn mirLowerIdentPlace(bs: MirLowerBodyState, e: HirExpr) -> MirPlace {
@@ -2406,10 +2401,9 @@ fn mirLowerMakeIndexProj(
 ) -> MirProjection {
     match idxOp.kind {
         MirOpConst -> {
-            match idxOp.const.kind {
-                MirConstInt -> mirIndexProjConst(idxOp.const.intValue, elemTypeText),
-                _ -> mirLowerSpillIndexOperand(bs, idxOp, idxT, elemTypeText, span),
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if idxOp.const.kind == MirConstInt { return mirIndexProjConst(idxOp.const.intValue, elemTypeText) }
+            mirLowerSpillIndexOperand(bs, idxOp, idxT, elemTypeText, span)
         },
         _ -> mirLowerSpillIndexOperand(bs, idxOp, idxT, elemTypeText, span),
     }
@@ -3441,18 +3435,17 @@ pub fn mirLowerExprToRValue(
     if !hirExprIsValid(e) {
         return mirRVUse(mirOperandConst(mirConstUnit()))
     }
-    match e.kind {
-        HirExprUnary -> mirLowerUnaryRValue(bs, e),
-        HirExprBinary -> mirLowerBinaryRValue(bs, e),
-        HirExprField -> mirLowerFieldRValue(bs, e),
-        HirExprTupleAccess -> mirLowerTupleAccessRValue(bs, e),
-        HirExprIndex -> mirLowerIndexRValue(bs, e),
-        HirExprTupleLit -> mirLowerTupleLitRValue(bs, e),
-        HirExprList -> mirLowerListLitRValue(bs, e, hint),
-        HirExprClosure -> mirLowerClosureRValue(bs, e, hint),
-        HirExprError -> mirLowerErrorExprRValue(bs, e),
-        _ -> mirRVUse(mirLowerExprAsOperand(bs, e)),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprUnary { return mirLowerUnaryRValue(bs, e) }
+    if e.kind == HirExprBinary { return mirLowerBinaryRValue(bs, e) }
+    if e.kind == HirExprField { return mirLowerFieldRValue(bs, e) }
+    if e.kind == HirExprTupleAccess { return mirLowerTupleAccessRValue(bs, e) }
+    if e.kind == HirExprIndex { return mirLowerIndexRValue(bs, e) }
+    if e.kind == HirExprTupleLit { return mirLowerTupleLitRValue(bs, e) }
+    if e.kind == HirExprList { return mirLowerListLitRValue(bs, e, hint) }
+    if e.kind == HirExprClosure { return mirLowerClosureRValue(bs, e, hint) }
+    if e.kind == HirExprError { return mirLowerErrorExprRValue(bs, e) }
+    mirRVUse(mirLowerExprAsOperand(bs, e))
 }
 
 fn mirLowerUnaryRValue(bs: MirLowerBodyState, e: HirExpr) -> MirRValue {
@@ -4004,10 +3997,9 @@ pub fn mirLowerCallExprInto(
         }
     }
     // 3. Ident fallback path (direct fn, indirect call, variant ctor).
-    match callee.kind {
-        HirExprIdent -> mirLowerCallIdent(bs, e, callee, dest, destT, span),
-        _ -> mirLowerCallUnsupported(bs, e, dest, destT, span, "non-ident callee"),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if callee.kind == HirExprIdent { return mirLowerCallIdent(bs, e, callee, dest, destT, span) }
+    mirLowerCallUnsupported(bs, e, dest, destT, span, "non-ident callee")
 }
 
 /// mirLowerCallExprQualifiedIntrinsic handles `pkg.fn(args)` shaped
@@ -4501,10 +4493,9 @@ fn mirLowerParamIndex(sig: MirLowerFnSignature, name: String) -> Int {
 }
 
 fn mirLowerParamTypesOf(t: HirType) -> List<HirType> {
-    match t.kind {
-        HirTypeFn -> t.fnParams,
-        _ -> [],
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeFn { return t.fnParams }
+    []
 }
 
 /// mirLowerIntrinsicCallInto lowers an `IntrinsicCall` HIR node into
@@ -4538,13 +4529,13 @@ pub fn mirLowerIntrinsicCallInto(
 }
 
 fn hirIntrinsicToMir(k: HirIntrinsicKind) -> MirIntrinsicKind {
-    match k {
-        HirIntrinsicInvalid -> MirIntrinsicInvalid,
-        HirIntrinsicPrint -> MirIntrinsicPrint,
-        HirIntrinsicPrintln -> MirIntrinsicPrintln,
-        HirIntrinsicEprint -> MirIntrinsicEprint,
-        HirIntrinsicEprintln -> MirIntrinsicEprintln,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == HirIntrinsicInvalid { return MirIntrinsicInvalid }
+    if k == HirIntrinsicPrint { return MirIntrinsicPrint }
+    if k == HirIntrinsicPrintln { return MirIntrinsicPrintln }
+    if k == HirIntrinsicEprint { return MirIntrinsicEprint }
+    if k == HirIntrinsicEprintln { return MirIntrinsicEprintln }
+    MirIntrinsicInvalid
 }
 
 // ====================================================================
@@ -5279,10 +5270,9 @@ pub fn mirLowerIfLetExprInto(
         mirLowerExprInto(bs, e.ifLetScrutinee[0], scrutLocal, scrutT)
     }
 
-    match e.ifLetPattern.kind {
-        HirPatVariant -> mirLowerIfLetVariant(bs, e, scrutLocal, scrutT, dest, destT, span),
-        _ -> mirLowerIfLetNonVariant(bs, e, scrutLocal, scrutT, dest, destT, span),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.ifLetPattern.kind == HirPatVariant { return mirLowerIfLetVariant(bs, e, scrutLocal, scrutT, dest, destT, span) }
+    mirLowerIfLetNonVariant(bs, e, scrutLocal, scrutT, dest, destT, span)
 
     mirLowerPopScope(bs)
 }
@@ -5730,10 +5720,9 @@ pub fn mirLowerMethodCallInto(
 /// `l.useAliases` when `recv` is a bare Ident referencing an imported
 /// package alias, or -1 otherwise. Matches Go's `useAliasFor`.
 fn mirLowerUseAliasIndexForReceiver(l: MirLowerer, recv: HirExpr) -> Int {
-    match recv.kind {
-        HirExprIdent -> mirLowerLookupUseAlias(l, recv.identName),
-        _ -> -1,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if recv.kind == HirExprIdent { return mirLowerLookupUseAlias(l, recv.identName) }
+    -1
 }
 
 /// mirLowerBodyUseAliasIndexForReceiver is the body-aware variant of
@@ -6025,17 +6014,16 @@ pub fn mirLowerConcurrencyIntrinsicForMethod(
 /// produces no MIR-visible value. Used so calls in expression
 /// position do not carry a stale dest.
 pub fn mirLowerIsVoidConcurrencyIntrinsic(k: MirIntrinsicKind) -> Bool {
-    match k {
-        MirIntrinsicChanSend -> true,
-        MirIntrinsicChanClose -> true,
-        MirIntrinsicGroupCancel -> true,
-        MirIntrinsicYield -> true,
-        MirIntrinsicSelectRecv -> true,
-        MirIntrinsicSelectSend -> true,
-        MirIntrinsicSelectTimeout -> true,
-        MirIntrinsicSelectDefault -> true,
-        _ -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == MirIntrinsicChanSend { return true }
+    if k == MirIntrinsicChanClose { return true }
+    if k == MirIntrinsicGroupCancel { return true }
+    if k == MirIntrinsicYield { return true }
+    if k == MirIntrinsicSelectRecv { return true }
+    if k == MirIntrinsicSelectSend { return true }
+    if k == MirIntrinsicSelectTimeout { return true }
+    if k == MirIntrinsicSelectDefault { return true }
+    false
 }
 
 // ---- Runtime (std.runtime.raw) ------------------------------------
@@ -6315,16 +6303,15 @@ pub fn mirLowerBuiltinFreeCallIntrinsicForReceiver(
 /// produces no MIR-visible value. Keeps call sites in expression
 /// position from carrying a stale dest through to the backend.
 pub fn mirLowerIsVoidStdlibIntrinsic(k: MirIntrinsicKind) -> Bool {
-    match k {
-        MirIntrinsicListPush -> true,
-        MirIntrinsicListInsert -> true,
-        MirIntrinsicListClear -> true,
-        MirIntrinsicMapSet -> true,
-        MirIntrinsicMapClear -> true,
-        MirIntrinsicSetInsert -> true,
-        MirIntrinsicSetClear -> true,
-        _ -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if k == MirIntrinsicListPush { return true }
+    if k == MirIntrinsicListInsert { return true }
+    if k == MirIntrinsicListClear { return true }
+    if k == MirIntrinsicMapSet { return true }
+    if k == MirIntrinsicMapClear { return true }
+    if k == MirIntrinsicSetInsert { return true }
+    if k == MirIntrinsicSetClear { return true }
+    false
 }
 
 // ---- String / Bytes method intrinsics -----------------------------

--- a/toolchain/mir_optimize.osty
+++ b/toolchain/mir_optimize.osty
@@ -565,11 +565,10 @@ fn mirRewritePlaceProjections(p: MirPlace, known: List<MirConst>) -> Bool {
 /// or a SwitchInt's scrutinee when possible. Returns true on
 /// substitution.
 fn mirRewriteTerminatorCond(t: MirTerm, known: List<MirConst>) -> Bool {
-    match t.kind {
-        MirTermBranch -> mirSubstituteOperandInPlace(t.cond, known),
-        MirTermSwitchInt -> mirSubstituteOperandInPlace(t.cond, known),
-        _ -> false,
-    }
+    // B2: payload-less enum dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == MirTermBranch { return mirSubstituteOperandInPlace(t.cond, known) }
+    if t.kind == MirTermSwitchInt { return mirSubstituteOperandInPlace(t.cond, known) }
+    false
 }
 
 /// mirSubstituteOperandInPlace checks whether `op` is a bare

--- a/toolchain/monomorph_pass.osty
+++ b/toolchain/monomorph_pass.osty
@@ -1762,11 +1762,10 @@ fn monoIsBuiltinStdlibName(name: String) -> Bool {
 }
 
 fn monoExtractOwnerNominal(t: HirType) -> String {
-    match t.kind {
-        HirTypeNamed -> t.namedName,
-        HirTypeOptional -> "Option",
-        _ -> "",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeNamed { return t.namedName }
+    if t.kind == HirTypeOptional { return "Option" }
+    ""
 }
 
 pub struct MonoResolvedOwner {

--- a/toolchain/monomorph_rewrite.osty
+++ b/toolchain/monomorph_rewrite.osty
@@ -33,11 +33,10 @@ use std.strings as strings
 /// gave up; try to recover from context". Matches Go's
 /// `isUnresolvedType` predicate.
 pub fn hirIsUnresolvedType(t: HirType) -> Bool {
-    match t.kind {
-        HirTypeInvalid -> true,
-        HirTypeErr -> true,
-        _ -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if t.kind == HirTypeInvalid { return true }
+    if t.kind == HirTypeErr { return true }
+    false
 }
 
 // ====================================================================

--- a/toolchain/pkgmgr_sat.osty
+++ b/toolchain/pkgmgr_sat.osty
@@ -116,11 +116,11 @@ pub fn vsIsFull(vs: SatVersionSet) -> Bool {
 }
 
 fn satBoundIsUnbounded(b: SatBound) -> Bool {
-    match b.kind {
-        SatUnbounded -> true,
-        SatInclusive -> false,
-        SatExclusive -> false,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if b.kind == SatUnbounded { return true }
+    if b.kind == SatInclusive { return false }
+    if b.kind == SatExclusive { return false }
+    true
 }
 
 /// satCompareLowBounds compares two low-side bounds. Lower bound is
@@ -138,11 +138,11 @@ fn satCompareLowBounds(a: SatBound, b: SatBound) -> Int {
 }
 
 fn satLowInclusiveRank(b: SatBound) -> Int {
-    match b.kind {
-        SatUnbounded -> 0,
-        SatInclusive -> 0,
-        SatExclusive -> 1,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if b.kind == SatUnbounded { return 0 }
+    if b.kind == SatInclusive { return 0 }
+    if b.kind == SatExclusive { return 1 }
+    0
 }
 
 /// satCompareHighBounds compares two high-side bounds. Higher is
@@ -160,11 +160,11 @@ fn satCompareHighBounds(a: SatBound, b: SatBound) -> Int {
 }
 
 fn satHighInclusiveRank(b: SatBound) -> Int {
-    match b.kind {
-        SatUnbounded -> 1,
-        SatInclusive -> 1,
-        SatExclusive -> 0,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if b.kind == SatUnbounded { return 1 }
+    if b.kind == SatInclusive { return 1 }
+    if b.kind == SatExclusive { return 0 }
+    1
 }
 
 /// satIntervalContains reports whether `v` lies inside interval `iv`.
@@ -241,11 +241,11 @@ fn satBoundLessThanLow(high: SatBound, low: SatBound) -> Bool {
 }
 
 fn isSatBoundExclusive(b: SatBound) -> Bool {
-    match b.kind {
-        SatUnbounded -> false,
-        SatInclusive -> false,
-        SatExclusive -> true,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if b.kind == SatUnbounded { return false }
+    if b.kind == SatInclusive { return false }
+    if b.kind == SatExclusive { return true }
+    false
 }
 
 /// satIntervalIntersect returns the overlap of two intervals, or an
@@ -380,19 +380,19 @@ pub fn vsComplement(vs: SatVersionSet) -> SatVersionSet {
 fn satFlipBoundHigh(low: SatBound) -> SatBound {
     // For complement: a low endpoint becomes the opposite-inclusivity
     // high endpoint of the preceding hole. `[v, ...)` becomes `..., v)`.
-    match low.kind {
-        SatUnbounded -> satBoundUnbounded(),
-        SatInclusive -> satBoundExclusive(low.version),
-        SatExclusive -> satBoundInclusive(low.version),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if low.kind == SatUnbounded { return satBoundUnbounded() }
+    if low.kind == SatInclusive { return satBoundExclusive(low.version) }
+    if low.kind == SatExclusive { return satBoundInclusive(low.version) }
+    satBoundUnbounded()
 }
 
 fn satFlipBoundLow(high: SatBound) -> SatBound {
-    match high.kind {
-        SatUnbounded -> satBoundUnbounded(),
-        SatInclusive -> satBoundExclusive(high.version),
-        SatExclusive -> satBoundInclusive(high.version),
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if high.kind == SatUnbounded { return satBoundUnbounded() }
+    if high.kind == SatInclusive { return satBoundExclusive(high.version) }
+    if high.kind == SatExclusive { return satBoundInclusive(high.version) }
+    satBoundUnbounded()
 }
 
 fn satCompareLowBoundAgainstHigh(lo: SatBound, hi: SatBound) -> Int {
@@ -1445,12 +1445,12 @@ fn satLearnedSeed(state: SatState, incIdx: Int) -> String {
     // from next. Fallback: root.
     let inc = state.incompats[incIdx]
     let rel = satRelation(state, inc)
-    match rel.rel {
-        SatIncAlmost -> inc.terms[rel.unsatisfied].pkg,
-        SatIncSat -> state.rootName,
-        SatIncContra -> state.rootName,
-        SatIncInconc -> state.rootName,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if rel.rel == SatIncAlmost { return inc.terms[rel.unsatisfied].pkg }
+    if rel.rel == SatIncSat { return state.rootName }
+    if rel.rel == SatIncContra { return state.rootName }
+    if rel.rel == SatIncInconc { return state.rootName }
+    inc.terms[rel.unsatisfied].pkg
 }
 
 // ---------------------------------------------------------------------

--- a/toolchain/pmcompile.osty
+++ b/toolchain/pmcompile.osty
@@ -297,15 +297,14 @@ pub fn pmTryCompileLitSwitch(
 /// land on SwitchLit too even though the Go side's MIR lit-switch
 /// fast path only handles Int — the slow eq-chain still works.
 pub fn pmSwitchKindOfLit(e: HirExpr) -> HirSwitchKind {
-    match e.kind {
-        HirExprBoolLit -> HirSwitchBool,
-        HirExprIntLit -> HirSwitchLit,
-        HirExprCharLit -> HirSwitchLit,
-        HirExprByteLit -> HirSwitchLit,
-        HirExprFloatLit -> HirSwitchLit,
-        HirExprStringLit -> HirSwitchLit,
-        _ -> HirSwitchUnknown,
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if e.kind == HirExprBoolLit { return HirSwitchBool }
+    if e.kind == HirExprIntLit { return HirSwitchLit }
+    if e.kind == HirExprCharLit { return HirSwitchLit }
+    if e.kind == HirExprByteLit { return HirSwitchLit }
+    if e.kind == HirExprFloatLit { return HirSwitchLit }
+    if e.kind == HirExprStringLit { return HirSwitchLit }
+    HirSwitchUnknown
 }
 
 /// pmSwitchKindEq is a structural equality check for HirSwitchKind.
@@ -315,34 +314,29 @@ pub fn pmSwitchKindOfLit(e: HirExpr) -> HirSwitchKind {
 fn pmSwitchKindEq(a: HirSwitchKind, b: HirSwitchKind) -> Bool {
     match a {
         HirSwitchUnknown -> {
-            match b {
-                HirSwitchUnknown -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if b == HirSwitchUnknown { return true }
+            false
         },
         HirSwitchVariant -> {
-            match b {
-                HirSwitchVariant -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if b == HirSwitchVariant { return true }
+            false
         },
         HirSwitchLit -> {
-            match b {
-                HirSwitchLit -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if b == HirSwitchLit { return true }
+            false
         },
         HirSwitchBool -> {
-            match b {
-                HirSwitchBool -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if b == HirSwitchBool { return true }
+            false
         },
         HirSwitchTuple -> {
-            match b {
-                HirSwitchTuple -> true,
-                _ -> false,
-            }
+            // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+            if b == HirSwitchTuple { return true }
+            false
         },
     }
 }
@@ -413,11 +407,18 @@ fn pmIntToString(n: Int) -> String {
 }
 
 fn pmDigitChar(d: Int) -> String {
-    match d {
-        0 -> "0", 1 -> "1", 2 -> "2", 3 -> "3", 4 -> "4",
-        5 -> "5", 6 -> "6", 7 -> "7", 8 -> "8", 9 -> "9",
-        _ -> "?",
-    }
+    // B2: payload-less dispatch as if-else chain (stage0 P0–P15).
+    if d == 0 { return "0" }
+    if d == 1 { return "1" }
+    if d == 2 { return "2" }
+    if d == 3 { return "3" }
+    if d == 4 { return "4" }
+    if d == 5 { return "5" }
+    if d == 6 { return "6" }
+    if d == 7 { return "7" }
+    if d == 8 { return "8" }
+    if d == 9 { return "9" }
+    "?"
 }
 
 /// pmFindInList returns the first index at which `needle` appears in


### PR DESCRIPTION
## Summary

Largest B2 batch yet. **81 match → if-else conversions across 9 files** (~1600 lines diff). Audit count **384 → 303** — 19.4% drop in this PR, **27.5% cumulative** since the B-series started.

| File | Matches |
|---|---|
| `hir.osty` | 25 (HirTypeIs* family, hirStmtKindName, hirExprKindName, hirBinOpName, hirInlineModeName, ...) |
| `mir.osty` | 14 (incl. `mirIntrinsicName` 137 arms via dedicated regex pass) |
| `mir_lower.osty` | 17 |
| `hir_lower.osty` | 8 |
| `pmcompile.osty` | 7 |
| `pkgmgr_sat.osty` | 7 |
| `mir_optimize.osty`, `monomorph_pass.osty`, `monomorph_rewrite.osty` | 1 each |

## Methodology

Built `convert_simple_match.py` (used locally, not committed) that walks Osty source for single-line match arms with balanced-paren bodies and rewrites each as an if-else chain. Bails out on:

- multi-line arm bodies
- struct-literal expressions (`{` in body)
- payload patterns (`Some(x)`, `Ok(_)`, `Err(_)`)

`mir.osty:mirIntrinsicName` (137 arms) drove a separate dedicated regex pass first.

`pmcompile.osty:pmDigitChar` had multiple arms-per-line which the converter mis-parsed; fixed by hand.

## Progress

| PR | match exprs | dropped | % |
|---|---|---|---|
| start | 418 | 0 | 0% |
| B2 | 417 | 1 | 0.2% |
| B2b | 408 | 10 | 2.4% |
| B2c | 402 | 16 | 3.8% |
| B2d | 384 | 34 | 8.1% |
| **B2e (this)** | **303** | **115** | **27.5%** |

## Test plan

- [x] `osty check toolchain/` exit 0 — all 81 rewrites type-check
- [x] `scripts/audit-stage0-coverage.sh` confirms 384 → 303 transition
- [x] All 9 modified files verified individually via the converter's structural balance checks (paren depth, no `{` in body)

https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJS58BBuc6WSfyeGmPFKBG)_