### PR TITLE
feat(backend/stage0): if-else with phi-merged struct return (P17)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -325,6 +325,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchIfElseReturn(fn, mctx); ok {
 		return emitIfElseReturn(out, fn, pat)
 	}
+	if pat, ok := matchIfElseAggregateReturn(fn, mctx); ok {
+		return emitIfElseAggregateReturn(out, fn, pat, mctx)
+	}
 	if pat, ok := matchWhileLoopReturn(fn, mctx); ok {
 		return emitWhileLoopReturn(out, fn, pat)
 	}
@@ -1224,6 +1227,280 @@ func emitBlock(out *strings.Builder, blk blockEmit) {
 			out.WriteString(pi.intrinsicLine)
 		}
 	}
+}
+
+// ---- P17: if-else with phi-merged struct/tuple return ----
+//
+// stage0 P17 covers the canonical "branch returns one of two struct
+// literals" shape — the front-end emits this for code like:
+//
+//	fn parseAiRepairMode(value: String) -> AiRepairModeResult {
+//	    if value == "auto" {
+//	        AiRepairModeResult { mode: "auto", ok: true }
+//	    } else {
+//	        AiRepairModeResult { mode: "", ok: false }
+//	    }
+//	}
+//
+// MIR shape (4-block if-else identical to P3c, struct/tuple return):
+//
+//	bb0(entry):  scalar instructions producing Bool cond + BranchTerm
+//	bb1(then):   AssignInstr ReturnLocal = AggregateRV{Struct|Tuple} + GotoTerm(merge)
+//	bb2(else):   AssignInstr ReturnLocal = AggregateRV{Struct|Tuple} + GotoTerm(merge)
+//	bb3(merge):  zero instrs + ReturnTerm
+//
+// Each branch arm contains exactly one AssignInstr whose Src is a
+// struct- or tuple-kind AggregateRV. Each Aggregate's field operands
+// are scalar ConstOps or non-projection CopyOps of params (reuse
+// classifyAggregateField). The two arms agree on the aggregate's type
+// name + field layout (enforced by classifyAggregateReturnType against
+// the function's declared return type).
+//
+// Output:
+//
+//	define %T @name(<params>) {
+//	entry:
+//	  ; entry-block scalar instructions
+//	  br i1 %cond, label %then.B, label %else.C
+//	then.B:
+//	  ; insertvalue chain for then's aggregate
+//	  br label %merge.D
+//	else.C:
+//	  ; insertvalue chain for else's aggregate
+//	  br label %merge.D
+//	merge.D:
+//	  %retval = phi %T [ %thenAgg, %then.B ], [ %elseAgg, %else.C ]
+//	  ret %T %retval
+//	}
+
+type ifElseAggregateBranch struct {
+	label        string
+	fieldExprs   []string
+	startSSA     int    // SSA index of the first insertvalue in this branch
+	resultExpr   string // SSA register that holds the fully-built aggregate
+	predLabelOut string // label name used in the merge phi (matches `label`)
+}
+
+type ifElseAggregatePattern struct {
+	typeName   string
+	fieldTypes []scalarType
+	paramIDs   []mir.LocalID
+	paramTypes []scalarType
+	paramNames []string
+
+	entry      blockEmit
+	condExpr   string
+	condType   string
+	thenLabel  string
+	elseLabel  string
+	mergeLabel string
+
+	thenBranch ifElseAggregateBranch
+	elseBranch ifElseAggregateBranch
+}
+
+func matchIfElseAggregateReturn(fn *mir.Function, mctx *moduleCtx) (ifElseAggregatePattern, bool) {
+	pat := ifElseAggregatePattern{}
+
+	typeName, fieldTypes, ok := classifyAggregateReturnType(fn.ReturnType, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.typeName = typeName
+	pat.fieldTypes = fieldTypes
+
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	if len(fn.Blocks) != 4 {
+		return pat, false
+	}
+
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		pt := scalarFromType(loc.Type)
+		if pt == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = pt
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	entryBindings := map[mir.LocalID]localBinding{}
+	for i, pid := range fn.Params {
+		entryBindings[pid] = localBinding{
+			expr:    "%" + pat.paramNames[i],
+			ty:      pat.paramTypes[i],
+			defined: true,
+		}
+	}
+
+	entryBlock := blockByID(fn, fn.Entry)
+	if entryBlock == nil {
+		return pat, false
+	}
+	branch, ok := entryBlock.Term.(*mir.BranchTerm)
+	if !ok {
+		return pat, false
+	}
+	thenBlock := blockByID(fn, branch.Then)
+	elseBlock := blockByID(fn, branch.Else)
+	if thenBlock == nil || elseBlock == nil || thenBlock.ID == elseBlock.ID {
+		return pat, false
+	}
+	thenGoto, ok := thenBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	elseGoto, ok := elseBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	if thenGoto.Target != elseGoto.Target {
+		return pat, false
+	}
+	mergeBlock := blockByID(fn, thenGoto.Target)
+	if mergeBlock == nil || mergeBlock.ID == entryBlock.ID || mergeBlock.ID == thenBlock.ID || mergeBlock.ID == elseBlock.ID {
+		return pat, false
+	}
+	if len(mergeBlock.Instrs) != 0 {
+		return pat, false
+	}
+	if _, ok := mergeBlock.Term.(*mir.ReturnTerm); !ok {
+		return pat, false
+	}
+
+	nextSSA := 0
+
+	// Walk entry block; produce scalar Bool cond.
+	entryEmit, condExpr, condTy, ok := classifyEntryBlock(fn, entryBlock, entryBindings, mctx, &nextSSA)
+	if !ok || condTy != scalarBool {
+		return pat, false
+	}
+	pat.entry = entryEmit
+	pat.condExpr = condExpr
+	pat.condType = condTy.llvm()
+
+	pat.thenLabel = blockLabelName(thenBlock.ID, "then")
+	pat.elseLabel = blockLabelName(elseBlock.ID, "else")
+	pat.mergeLabel = blockLabelName(mergeBlock.ID, "merge")
+	pat.entry.label = "entry"
+
+	thenBranch, ok := classifyAggregateBranch(fn, thenBlock, pat.thenLabel, pat.fieldTypes, &nextSSA, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.thenBranch = thenBranch
+
+	elseBranch, ok := classifyAggregateBranch(fn, elseBlock, pat.elseLabel, pat.fieldTypes, &nextSSA, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.elseBranch = elseBranch
+
+	return pat, true
+}
+
+// classifyAggregateBranch validates one branch arm of P17:
+// exactly one AssignInstr writing AggregateRV{Struct|Tuple} to the
+// return local, then GotoTerm to the merge block. Reserves SSA numbers
+// for the insertvalue chain and remembers the final aggregate register
+// name for the merge-phi emission.
+func classifyAggregateBranch(fn *mir.Function, bb *mir.BasicBlock, label string, fieldTypes []scalarType, nextSSA *int, mctx *moduleCtx) (ifElseAggregateBranch, bool) {
+	out := ifElseAggregateBranch{label: label, predLabelOut: label}
+	if len(bb.Instrs) != 1 {
+		return out, false
+	}
+	ai, ok := bb.Instrs[0].(*mir.AssignInstr)
+	if !ok {
+		return out, false
+	}
+	if ai.Dest.Local != fn.ReturnLocal || ai.Dest.HasProjections() {
+		return out, false
+	}
+	agg, ok := ai.Src.(*mir.AggregateRV)
+	if !ok {
+		return out, false
+	}
+	if agg.Kind != mir.AggStruct && agg.Kind != mir.AggTuple {
+		return out, false
+	}
+	if len(agg.Fields) != len(fieldTypes) {
+		return out, false
+	}
+	paramRegs := map[mir.LocalID]string{}
+	for _, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil {
+			return out, false
+		}
+		paramRegs[pid] = "%" + sanitizeLLVMName(loc.Name, "a")
+	}
+	out.fieldExprs = make([]string, len(agg.Fields))
+	for i, f := range agg.Fields {
+		expr, ty, ok := classifyAggregateField(f, paramRegs, fn, mctx)
+		if !ok || ty != fieldTypes[i] {
+			return out, false
+		}
+		out.fieldExprs[i] = expr
+	}
+	out.startSSA = *nextSSA
+	*nextSSA += len(fieldTypes)
+	out.resultExpr = fmt.Sprintf("%%%d", out.startSSA+len(fieldTypes)-1)
+	return out, true
+}
+
+func emitIfElseAggregateReturn(out *strings.Builder, fn *mir.Function, pat ifElseAggregatePattern, mctx *moduleCtx) error {
+	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
+	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+
+	// Entry block.
+	emitBlock(out, pat.entry)
+	fmt.Fprintf(out, "  br %s %s, label %%%s, label %%%s\n", pat.condType, pat.condExpr, pat.thenLabel, pat.elseLabel)
+	out.WriteString("\n")
+
+	// Branch arm emit helpers.
+	emitArm := func(arm ifElseAggregateBranch) {
+		fmt.Fprintf(out, "%s:\n", arm.label)
+		prev := "poison"
+		for i, fieldExpr := range arm.fieldExprs {
+			reg := fmt.Sprintf("%%%d", arm.startSSA+i)
+			fmt.Fprintf(out, "  %s = insertvalue %%%s %s, %s %s, %d\n", reg, pat.typeName, prev, pat.fieldTypes[i].llvm(), fieldExpr, i)
+			prev = reg
+		}
+		fmt.Fprintf(out, "  br label %%%s\n", pat.mergeLabel)
+	}
+
+	emitArm(pat.thenBranch)
+	out.WriteString("\n")
+	emitArm(pat.elseBranch)
+	out.WriteString("\n")
+
+	// Merge block: phi + ret.
+	fmt.Fprintf(out, "%s:\n", pat.mergeLabel)
+	fmt.Fprintf(out, "  %%retval = phi %%%s [ %s, %%%s ], [ %s, %%%s ]\n",
+		pat.typeName,
+		pat.thenBranch.resultExpr, pat.thenBranch.predLabelOut,
+		pat.elseBranch.resultExpr, pat.elseBranch.predLabelOut,
+	)
+	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	out.WriteString("}\n\n")
+	return nil
 }
 
 // classifyEntryBlock walks the entry block of an if-else: zero or more

--- a/internal/backend/stage0_p17_test.go
+++ b/internal/backend/stage0_p17_test.go
@@ -1,0 +1,120 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStage0P17IfElseAggregateReturnStruct verifies stage0 lowers the
+// 4-block if-else-with-struct-AggregateRV-arms shape produced by the
+// front-end for `fn name(p) -> Struct { if cond { S{..} } else { S{..} } }`.
+//
+// This is the next toolchain self-build blocker after P15/P16 — many
+// `parse*` helpers in `toolchain/airepair_flags.osty` and friends use
+// exactly this shape.
+func TestStage0P17IfElseAggregateReturnStruct(t *testing.T) {
+	src := `pub struct Result {
+    pub mode: String,
+    pub ok: Bool,
+}
+
+pub fn parseMode(value: String) -> Result {
+    if value == "auto" {
+        Result { mode: "auto", ok: true }
+    } else {
+        Result { mode: "", ok: false }
+    }
+}
+
+fn main() {}
+`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	wants := []string{
+		"%Result = type { ptr, i1 }",
+		"define %Result @parseMode(",
+		"call i1 @osty_rt_strings_Equal(",
+		"br i1",
+		"insertvalue %Result poison",
+		"insertvalue %Result %",
+		`%retval = phi %Result [`,
+		"ret %Result %retval",
+	}
+	got := string(out)
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// Tuple variant of P17 — same 4-block shape but with TupleType return.
+func TestStage0P17IfElseAggregateReturnTuple(t *testing.T) {
+	src := `pub fn split(value: String) -> (String, Bool) {
+    if value == "yes" {
+        ("yes", true)
+    } else {
+        ("", false)
+    }
+}
+
+fn main() {}
+`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	wants := []string{
+		"= type { ptr, i1 }",
+		"define ",
+		"@split(",
+		"insertvalue",
+		"phi",
+		"ret",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// Param-passthrough variant: one struct field uses the function param
+// directly (CopyOp) rather than a constant. Verifies classifyAggregateField
+// resolves param locals from inside an if-else branch arm.
+func TestStage0P17IfElseAggregateBranchUsesParam(t *testing.T) {
+	src := `pub struct Pair {
+    pub label: String,
+    pub flag: Bool,
+}
+
+pub fn label(value: String) -> Pair {
+    if value == "" {
+        Pair { label: "(empty)", flag: false }
+    } else {
+        Pair { label: value, flag: true }
+    }
+}
+
+fn main() {}
+`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	wants := []string{
+		"%Pair = type { ptr, i1 }",
+		"define %Pair @label(ptr %value)",
+		// else arm should reference the param register directly
+		"insertvalue %Pair poison, ptr %value, 0",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
stage0 P17 — 4-block if-else 에서 각 arm 이 struct/tuple AggregateRV 를 return 로컬에 쓰고 phi 로 merge 하는 shape. `parseAiRepairMode`-class toolchain helper 의 핵심.

P3c (스칼라 phi 머지) + P14 (단일 블록 struct constructor) 의 자연 결합. P15/P16 위에 stack.

## Matcher surface
- 0~2 스칼라 파라미터
- 4 블록: entry(BranchTerm) + then(GotoTerm) + else(GotoTerm) + merge(empty + ReturnTerm)
- entry: classifyEntryBlock 그대로 — 임의 스칼라 instr + Bool cond
- then/else: 정확히 한 AssignInstr 가 `ReturnLocal = AggregateRV{Struct|Tuple}` + GotoTerm
- merge: empty + ReturnTerm

## Emit
```llvm
define %T @name(<params>) {
entry:
  ; cond 산출 instructions
  br i1 %cond, label %then.B, label %else.C
then.B:
  ; insertvalue chain
  br label %merge.D
else.C:
  ; insertvalue chain
  br label %merge.D
merge.D:
  %retval = phi %T [%thenAgg, %then.B], [%elseAgg, %else.C]
  ret %T %retval
}
```

## Tests
- `TestStage0P17IfElseAggregateReturnStruct` — 핵심: String == cond + struct AggregateRV 양 arm
- `TestStage0P17IfElseAggregateReturnTuple` — TupleType 반환
- `TestStage0P17IfElseAggregateBranchUsesParam` — branch arm 의 필드 operand 이 param

## Toolchain build progress
P15 (#1449) + P16 (#1455) 위에 P17 추가. 다음 blocker: `parseAiRepairMode` 의 실제 7-block CFG (`||` short-circuit + else-if 체인) — P18 에서 multi-arm if-elif chain + `||`/`&&` short-circuit lowering 으로 처리 예정.

## Test plan
- [x] `go test -run TestStage0P17 ./internal/backend/` 통과
- [x] `gofmt -l` clean
- [x] `go vet` silent
- [x] 기존 stage0 회귀 테스트 영향 없음
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)