### PR TITLE
refactor(mir/lower): always recompile decision tree, drop poison guard

### DIFF
--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2099,7 +2099,15 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 	// a specialised decision tree instead of the goto-armBlocks[0]
 	// fallback, which silently collapses every match on Result / enum
 	// payload bindings to "always take arm 0".
-	if tree == nil && scrutT != nil && !isPoisonType(scrutT) {
+	//
+	// CompileDecisionTree always returns a non-nil node — even for an
+	// ErrType / nil scrutinee it falls through to a `compileArmChain`
+	// of guard-cascades plus DecisionFail. Recompiling is therefore
+	// unconditional; ErrType bodies will stop at the type-checker
+	// gate before they ever reach a backend, but their MIR shape stays
+	// well-formed and the audit harness can fingerprint them instead
+	// of getting buried under "match without decision tree".
+	if tree == nil {
 		tree = ir.CompileDecisionTree(scrutT, decisionArms)
 	}
 


### PR DESCRIPTION
## Summary
`monomorph` clones drop `MatchStmt.Tree` / `MatchExpr.Tree`, and the post-mono lower pipeline already recompiles via `ir.CompileDecisionTree` when tree is nil. But the previous guard `if tree == nil && scrutT != nil && !isPoisonType(scrutT)` skipped recompilation for ErrType / nil scrutinees — funneling them through a hardcoded `bs.terminate(GotoTerm{armBlocks[0]})` fallback and emitting `"match without decision tree not lowered to MIR"` into `MIR.Issues`.

`CompileDecisionTree` is **robust to ErrType / nil scrutinees** — it falls through to `compileArmChain` of guard-cascades terminating in `DecisionFail`. Always recompiling is therefore safe and yields:

1. **Cleaner `MIR.Issues`** — back-end gating still blocks ErrType code at the type-checker layer (this PR doesn't loosen any safety), so removing the noise is pure win.
2. **Better audit signal** — `TestStage0ToolchainAudit` (PR #1458) now sees match arms with poison scrutinees lower into the same shape buckets as well-typed matches, instead of being hidden behind a uniform `always-arm-0` placeholder.

## Diff
```go
-	if tree == nil && scrutT != nil && !isPoisonType(scrutT) {
+	if tree == nil {
 		tree = ir.CompileDecisionTree(scrutT, decisionArms)
 	}
```

(Plus comment block updated.)

## Test plan
- [x] `internal/mir/...` regression (`TestLower*`, `TestMatch*`) passes
- [x] `internal/ir/...` regression passes
- [x] `TestStage0RealMIRBaseline`, `TestStage0P15`, `TestEmitLLVMFallback*` unaffected
- [x] Toolchain `MIR.Issues` reduced from 6 entries to 1 (`for-in over non-List/Map/Channel iterable…` 만 남음)
- [ ] CI green

## Companion PR
[#1458](https://github.com/choiceoh/osty/pull/1458) — audit infrastructure that surfaces this gap. This PR drops the noise that audit highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)