### PR TITLE
feat(backend/stage0): `||` short-circuit + if-else struct return (P18)

### DIFF
--- a/internal/backend/stage0/emit.go
+++ b/internal/backend/stage0/emit.go
@@ -328,6 +328,9 @@ func emitFunction(out *strings.Builder, fn *mir.Function, mctx *moduleCtx) error
 	if pat, ok := matchIfElseAggregateReturn(fn, mctx); ok {
 		return emitIfElseAggregateReturn(out, fn, pat, mctx)
 	}
+	if pat, ok := matchOrShortCircuitIfElseAggregate(fn, mctx); ok {
+		return emitOrShortCircuitIfElseAggregate(out, fn, pat, mctx)
+	}
 	if pat, ok := matchWhileLoopReturn(fn, mctx); ok {
 		return emitWhileLoopReturn(out, fn, pat)
 	}
@@ -1492,6 +1495,331 @@ func emitIfElseAggregateReturn(out *strings.Builder, fn *mir.Function, pat ifEls
 	out.WriteString("\n")
 
 	// Merge block: phi + ret.
+	fmt.Fprintf(out, "%s:\n", pat.mergeLabel)
+	fmt.Fprintf(out, "  %%retval = phi %%%s [ %s, %%%s ], [ %s, %%%s ]\n",
+		pat.typeName,
+		pat.thenBranch.resultExpr, pat.thenBranch.predLabelOut,
+		pat.elseBranch.resultExpr, pat.elseBranch.predLabelOut,
+	)
+	fmt.Fprintf(out, "  ret %%%s %%retval\n", pat.typeName)
+	out.WriteString("}\n\n")
+	return nil
+}
+
+// ---- P18: `||` short-circuit + if-else struct/tuple return ----
+//
+// stage0 P18 covers the canonical "if A || B { S{..} } else { S{..} }"
+// shape — the front-end lowers `||` as a 3-block boolean phi so the
+// resulting CFG is 7 blocks (3 for the OR, 4 for the if-else):
+//
+//	bb0(entry):       AssignInstr Bool L = leftCond ; BranchTerm(L → bb1, bb2)
+//	bb1(short_true):  AssignInstr Bool R = UseRV(BoolConst{true}) ; GotoTerm(bb3)
+//	bb2(right_eval):  AssignInstr Bool R = rightCond              ; GotoTerm(bb3)
+//	bb3(or_merge):    BranchTerm(R → bb4, bb5)                     [empty body]
+//	bb4(then):        AssignInstr ReturnLocal = AggregateRV ; GotoTerm(bb6)
+//	bb5(else):        AssignInstr ReturnLocal = AggregateRV ; GotoTerm(bb6)
+//	bb6(merge):       ReturnTerm                            [empty body]
+//
+// bb0 owns the leftCond computation (any scalar P3a-style instructions
+// + a final AssignInstr to the same Bool local that bb1 / bb2 also
+// write). bb2 owns the rightCond computation (same shape). bb3 must
+// be empty so the merged Bool flows directly from the implicit phi.
+//
+// Output:
+//
+//	define %T @name(<params>) {
+//	entry:
+//	  ; leftCond instructions
+//	  br i1 %L, label %or_short.K, label %or_right.M
+//	or_short.K:
+//	  br label %or_merge.N
+//	or_right.M:
+//	  ; rightCond instructions
+//	  br label %or_merge.N
+//	or_merge.N:
+//	  %or = phi i1 [ true, %or_short.K ], [ %R, %or_right.M ]
+//	  br i1 %or, label %then.X, label %else.Y
+//	then.X:
+//	  ; insertvalue chain for then's aggregate
+//	  br label %merge.Z
+//	else.Y:
+//	  ; insertvalue chain for else's aggregate
+//	  br label %merge.Z
+//	merge.Z:
+//	  %retval = phi %T [ %thenAgg, %then.X ], [ %elseAgg, %else.Y ]
+//	  ret %T %retval
+//	}
+
+type orShortCircuitPattern struct {
+	typeName   string
+	fieldTypes []scalarType
+	paramIDs   []mir.LocalID
+	paramTypes []scalarType
+	paramNames []string
+
+	entry        blockEmit
+	leftCondExpr string
+	leftCondType string
+
+	orShortLabel  string
+	orRightLabel  string
+	orMergeLabel  string
+	rightEvalEmit blockEmit
+	rightCondExpr string
+
+	thenLabel  string
+	elseLabel  string
+	mergeLabel string
+
+	thenBranch ifElseAggregateBranch
+	elseBranch ifElseAggregateBranch
+}
+
+func matchOrShortCircuitIfElseAggregate(fn *mir.Function, mctx *moduleCtx) (orShortCircuitPattern, bool) {
+	pat := orShortCircuitPattern{}
+
+	typeName, fieldTypes, ok := classifyAggregateReturnType(fn.ReturnType, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.typeName = typeName
+	pat.fieldTypes = fieldTypes
+
+	if len(fn.Params) > 2 {
+		return pat, false
+	}
+	if len(fn.Blocks) != 7 {
+		return pat, false
+	}
+
+	pat.paramIDs = fn.Params
+	pat.paramTypes = make([]scalarType, len(fn.Params))
+	pat.paramNames = make([]string, len(fn.Params))
+	fallbackNames := []string{"a", "b"}
+	for i, pid := range fn.Params {
+		loc := lookupLocal(fn, pid)
+		if loc == nil || !loc.IsParam {
+			return pat, false
+		}
+		pt := scalarFromType(loc.Type)
+		if pt == scalarUnknown {
+			return pat, false
+		}
+		pat.paramTypes[i] = pt
+		pat.paramNames[i] = sanitizeLLVMName(loc.Name, fallbackNames[i])
+	}
+	disambiguateParamNames(pat.paramNames)
+
+	entryBindings := map[mir.LocalID]localBinding{}
+	for i, pid := range fn.Params {
+		entryBindings[pid] = localBinding{
+			expr:    "%" + pat.paramNames[i],
+			ty:      pat.paramTypes[i],
+			defined: true,
+		}
+	}
+
+	entryBlock := blockByID(fn, fn.Entry)
+	if entryBlock == nil {
+		return pat, false
+	}
+	leftBranch, ok := entryBlock.Term.(*mir.BranchTerm)
+	if !ok {
+		return pat, false
+	}
+	shortBlock := blockByID(fn, leftBranch.Then)
+	rightEvalBlock := blockByID(fn, leftBranch.Else)
+	if shortBlock == nil || rightEvalBlock == nil || shortBlock.ID == rightEvalBlock.ID {
+		return pat, false
+	}
+	shortGoto, ok := shortBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	rightGoto, ok := rightEvalBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	if shortGoto.Target != rightGoto.Target {
+		return pat, false
+	}
+	orMergeBlock := blockByID(fn, shortGoto.Target)
+	if orMergeBlock == nil || len(orMergeBlock.Instrs) != 0 {
+		return pat, false
+	}
+	orMergeBranch, ok := orMergeBlock.Term.(*mir.BranchTerm)
+	if !ok {
+		return pat, false
+	}
+	thenBlock := blockByID(fn, orMergeBranch.Then)
+	elseBlock := blockByID(fn, orMergeBranch.Else)
+	if thenBlock == nil || elseBlock == nil || thenBlock.ID == elseBlock.ID {
+		return pat, false
+	}
+	thenGoto, ok := thenBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	elseGoto, ok := elseBlock.Term.(*mir.GotoTerm)
+	if !ok {
+		return pat, false
+	}
+	if thenGoto.Target != elseGoto.Target {
+		return pat, false
+	}
+	mergeBlock := blockByID(fn, thenGoto.Target)
+	if mergeBlock == nil || len(mergeBlock.Instrs) != 0 {
+		return pat, false
+	}
+	if _, ok := mergeBlock.Term.(*mir.ReturnTerm); !ok {
+		return pat, false
+	}
+
+	// Reject overlapping IDs.
+	ids := []mir.BlockID{entryBlock.ID, shortBlock.ID, rightEvalBlock.ID, orMergeBlock.ID, thenBlock.ID, elseBlock.ID, mergeBlock.ID}
+	seen := map[mir.BlockID]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			return pat, false
+		}
+		seen[id] = true
+	}
+
+	nextSSA := 0
+
+	// Walk entry: left-cond instructions ending in BranchTerm.
+	entryEmit, leftCondExpr, leftCondTy, ok := classifyEntryBlock(fn, entryBlock, entryBindings, mctx, &nextSSA)
+	if !ok || leftCondTy != scalarBool {
+		return pat, false
+	}
+	pat.entry = entryEmit
+	pat.leftCondExpr = leftCondExpr
+	pat.leftCondType = leftCondTy.llvm()
+
+	// short-circuit-true block must contain a single AssignInstr writing
+	// `true` to a Bool local — that local is the merged Bool the or_merge
+	// block branches on.
+	if len(shortBlock.Instrs) != 1 {
+		return pat, false
+	}
+	shortAi, ok := shortBlock.Instrs[0].(*mir.AssignInstr)
+	if !ok || shortAi.Dest.HasProjections() {
+		return pat, false
+	}
+	shortUse, ok := shortAi.Src.(*mir.UseRV)
+	if !ok {
+		return pat, false
+	}
+	shortConst, ok := shortUse.Op.(*mir.ConstOp)
+	if !ok {
+		return pat, false
+	}
+	shortBool, ok := shortConst.Const.(*mir.BoolConst)
+	if !ok || !shortBool.Value {
+		return pat, false
+	}
+	mergedLocal := shortAi.Dest.Local
+	mergedLocalRec := lookupLocal(fn, mergedLocal)
+	if mergedLocalRec == nil || scalarFromType(mergedLocalRec.Type) != scalarBool {
+		return pat, false
+	}
+
+	// or_merge.Cond must Copy the same merged Bool local.
+	orMergeCond, ok := orMergeBranch.Cond.(*mir.CopyOp)
+	if !ok || orMergeCond.Place.HasProjections() || orMergeCond.Place.Local != mergedLocal {
+		return pat, false
+	}
+
+	// right-eval block: walk instructions producing the merged Bool
+	// local. The final AssignInstr must write to mergedLocal; only its
+	// value contributes to the OR phi.
+	rightBindings := copyBindings(entryBindings)
+	rightEmit := blockEmit{}
+	for _, instr := range rightEvalBlock.Instrs {
+		if !applyStep(fn, instr, rightBindings, mctx, &nextSSA, &rightEmit) {
+			return pat, false
+		}
+	}
+	rightBinding, ok := rightBindings[mergedLocal]
+	if !ok || !rightBinding.defined || rightBinding.ty != scalarBool {
+		return pat, false
+	}
+	pat.rightEvalEmit = rightEmit
+	pat.rightCondExpr = rightBinding.expr
+
+	pat.orShortLabel = blockLabelName(shortBlock.ID, "or_short")
+	pat.orRightLabel = blockLabelName(rightEvalBlock.ID, "or_right")
+	pat.orMergeLabel = blockLabelName(orMergeBlock.ID, "or_merge")
+	pat.thenLabel = blockLabelName(thenBlock.ID, "then")
+	pat.elseLabel = blockLabelName(elseBlock.ID, "else")
+	pat.mergeLabel = blockLabelName(mergeBlock.ID, "merge")
+	pat.entry.label = "entry"
+	pat.rightEvalEmit.label = pat.orRightLabel
+
+	thenBranch, ok := classifyAggregateBranch(fn, thenBlock, pat.thenLabel, pat.fieldTypes, &nextSSA, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.thenBranch = thenBranch
+
+	elseBranch, ok := classifyAggregateBranch(fn, elseBlock, pat.elseLabel, pat.fieldTypes, &nextSSA, mctx)
+	if !ok {
+		return pat, false
+	}
+	pat.elseBranch = elseBranch
+
+	return pat, true
+}
+
+func emitOrShortCircuitIfElseAggregate(out *strings.Builder, fn *mir.Function, pat orShortCircuitPattern, mctx *moduleCtx) error {
+	mctx.emitStructDef(pat.typeName, pat.fieldTypes)
+	fmt.Fprintf(out, "define %%%s @%s(", pat.typeName, fn.Name)
+	for i, name := range pat.paramNames {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(out, "%s %%%s", pat.paramTypes[i].llvm(), name)
+	}
+	out.WriteString(") {\n")
+
+	// entry: left-cond + branch to short_true / right_eval
+	emitBlock(out, pat.entry)
+	fmt.Fprintf(out, "  br %s %s, label %%%s, label %%%s\n", pat.leftCondType, pat.leftCondExpr, pat.orShortLabel, pat.orRightLabel)
+	out.WriteString("\n")
+
+	// or_short: just goto or_merge (the `true` constant flows through phi)
+	fmt.Fprintf(out, "%s:\n", pat.orShortLabel)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.orMergeLabel)
+	out.WriteString("\n")
+
+	// or_right: right-cond instructions + goto or_merge
+	emitBlock(out, pat.rightEvalEmit)
+	fmt.Fprintf(out, "  br label %%%s\n", pat.orMergeLabel)
+	out.WriteString("\n")
+
+	// or_merge: phi i1 + branch to then / else
+	fmt.Fprintf(out, "%s:\n", pat.orMergeLabel)
+	fmt.Fprintf(out, "  %%or = phi i1 [ true, %%%s ], [ %s, %%%s ]\n", pat.orShortLabel, pat.rightCondExpr, pat.orRightLabel)
+	fmt.Fprintf(out, "  br i1 %%or, label %%%s, label %%%s\n", pat.thenLabel, pat.elseLabel)
+	out.WriteString("\n")
+
+	// then / else aggregate insertvalue chains
+	emitArm := func(arm ifElseAggregateBranch) {
+		fmt.Fprintf(out, "%s:\n", arm.label)
+		prev := "poison"
+		for i, fieldExpr := range arm.fieldExprs {
+			reg := fmt.Sprintf("%%%d", arm.startSSA+i)
+			fmt.Fprintf(out, "  %s = insertvalue %%%s %s, %s %s, %d\n", reg, pat.typeName, prev, pat.fieldTypes[i].llvm(), fieldExpr, i)
+			prev = reg
+		}
+		fmt.Fprintf(out, "  br label %%%s\n", pat.mergeLabel)
+	}
+	emitArm(pat.thenBranch)
+	out.WriteString("\n")
+	emitArm(pat.elseBranch)
+	out.WriteString("\n")
+
+	// merge: phi %T + ret
 	fmt.Fprintf(out, "%s:\n", pat.mergeLabel)
 	fmt.Fprintf(out, "  %%retval = phi %%%s [ %s, %%%s ], [ %s, %%%s ]\n",
 		pat.typeName,

--- a/internal/backend/stage0_p18_test.go
+++ b/internal/backend/stage0_p18_test.go
@@ -1,0 +1,97 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStage0P18OrShortCircuitIfElseAggregate verifies stage0 lowers
+// the 7-block "`||` short-circuit + if-else struct return" shape that
+// `parseAiRepairMode`-class toolchain helpers use:
+//
+//	fn name(value: String) -> Result {
+//	    if value == "" || value == "auto" {
+//	        Result { ... }
+//	    } else {
+//	        Result { ... }
+//	    }
+//	}
+func TestStage0P18OrShortCircuitIfElseAggregate(t *testing.T) {
+	src := `pub struct R {
+    pub mode: String,
+    pub ok: Bool,
+}
+
+pub fn parseMode(value: String) -> R {
+    if value == "" || value == "auto" {
+        R { mode: "auto", ok: true }
+    } else {
+        R { mode: "", ok: false }
+    }
+}
+
+fn main() {}
+`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	wants := []string{
+		"%R = type { ptr, i1 }",
+		"define %R @parseMode(ptr %value) {",
+		// left cond evaluation in entry
+		"call i1 @osty_rt_strings_Equal",
+		// short-circuit branch
+		"br i1 %0, label %or_short.",
+		// or_short block just brs to or_merge
+		"or_short.",
+		"or_right.",
+		"or_merge.",
+		// phi over the merged Bool
+		"%or = phi i1 [ true, %or_short.",
+		// branch to if-else arms
+		"br i1 %or, label %then.",
+		// final struct phi
+		"%retval = phi %R",
+		"ret %R %retval",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// Tuple variant — same `||` short-circuit but tuple return instead of
+// struct.
+func TestStage0P18OrShortCircuitTupleReturn(t *testing.T) {
+	src := `pub fn classify(value: String) -> (String, Bool) {
+    if value == "" || value == "auto" {
+        ("auto", true)
+    } else {
+        ("", false)
+    }
+}
+
+fn main() {}
+`
+	out, err := realStage0Run(t, src)
+	if err != nil {
+		t.Fatalf("stage0 declined: %v", err)
+	}
+	got := string(out)
+	wants := []string{
+		"= type { ptr, i1 }",
+		"@classify(ptr %value)",
+		"%or = phi i1",
+		"insertvalue",
+		"%retval = phi",
+		"ret",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("stage0 output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
stage0 P18 — 7-block CFG `if A || B { Struct{..} } else { Struct{..} }`. front-end가 `||`를 3-block boolean phi로 lower하므로 P17 의 4-block if-else 앞에 short-circuit 머지 3 블록이 붙은 형태.

**base: PR #1459 (P17)** — stack.

## Block topology
```
bb0(entry):       leftCond + BranchTerm(L → short_true, right_eval)
bb1(short_true):  AssignInstr Bool R = true ; GotoTerm(or_merge)
bb2(right_eval):  rightCond ; GotoTerm(or_merge)
bb3(or_merge):    BranchTerm(R → then, else)             [empty body]
bb4(then):        AssignInstr ReturnLocal = AggregateRV ; GotoTerm(merge)
bb5(else):        AssignInstr ReturnLocal = AggregateRV ; GotoTerm(merge)
bb6(merge):       ReturnTerm                              [empty body]
```

bb1/bb2 둘 다 같은 Bool 로컬에 쓰고, bb3 이 그 로컬로 분기 → implicit phi. LLVM 측에서는 명시 `phi i1` 으로 풀어냄.

## Emit
```llvm
define %T @name(<params>) {
entry:
  ; leftCond
  br i1 %L, label %or_short.K, label %or_right.M
or_short.K:
  br label %or_merge.N
or_right.M:
  ; rightCond
  br label %or_merge.N
or_merge.N:
  %or = phi i1 [ true, %or_short.K ], [ %R, %or_right.M ]
  br i1 %or, label %then.X, label %else.Y
then.X:
  ; insertvalue chain
  br label %merge.Z
else.Y:
  ; insertvalue chain
  br label %merge.Z
merge.Z:
  %retval = phi %T [ ... ]
  ret %T %retval
}
```

## Tests
- `TestStage0P18OrShortCircuitIfElseAggregate` — struct + String == cond
- `TestStage0P18OrShortCircuitTupleReturn` — TupleType 반환

## Toolchain build progress
P15 (#1449) + P16 (main) + P17 (#1459) + P18 (이번). 실제 `parseAiRepairMode` 는 4-arm else-if 체인 (16 블록) 이라 P18 단독으로는 매치 안 됨 — **P19 (else-if chain)** 별 PR 에서 처리. P18 만으로도 `||` 만 사용하는 toolchain helper 들 unblock.

## Test plan
- [x] `go test -run TestStage0P18 ./internal/backend/` 통과
- [x] `gofmt -l` clean, `go vet` silent
- [x] 기존 stage0 회귀 테스트 영향 없음
- [ ] CI 그린 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)