### PR TITLE
[codex] LIR Proto Phase A module lowering

### DIFF
--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -3,6 +3,8 @@
 > **목적**: PR #1405 (2026-05-05) 이후 새 architecture (`internal/llvmgen` → `osty-self lir-proto-lower` 서브프로세스)에서 LLVM 백엔드의 실제 coverage 빈 칸을 문서화하고, phase별 PR 분할안을 제시한다. 이 문서는 audit 결과이며 상세 lowering 설계는 각 phase PR에서 별도로.
 >
 > **상태**: 2026-05-07 audit. 현재 실패 테스트 9건 + 빌드 실패 6건 (Security framework link). `LLVM_MIGRATION_PLAN.md`의 Tier A 항목 (Map.update / optional aggregate / generic turbofish / interface dispatch / nested binding pattern) 이 모두 같은 root에 매달려 있음을 발견.
+>
+> **Phase A 진행**: module-context type lowering 폴스루는 명시적 `unsupported module type` 진단으로 바뀌었고, MIR `uses/imports`는 resolved trace-only metadata로 낮아져 더 이상 LIR Proto 모듈 전체를 decline시키지 않는다.
 
 ## 1. 새 architecture 요약
 
@@ -52,7 +54,7 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 
 | ID | 코드 위치 | 메시지 | 영향 |
 |---|---|---|---|
-| GAP-MOD-001 | lir_proto.osty:1787 | `MIR uses/imports are not implemented in LIR Proto lowering` | 모든 multi-file/cross-package source가 native-owned 경로 못 탐 |
+| GAP-MOD-001 | lir_proto.osty | ✅ Phase A에서 trace-only lowering | resolved `use` edge가 native-owned 경로를 막지 않음 |
 
 #### 2.2.2 Type-level
 
@@ -61,7 +63,7 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 | GAP-TYP-001 | 1855 | `unsupported param type \`T\`` | Interface 타입, Closure type, Tuple, 미등록 generic struct |
 | GAP-TYP-002 | 1974 | `unsupported local type \`T\`` | 위와 동일 + 임시 closure local |
 | GAP-TYP-003 | 2081 | `unsupported assign destination type \`T\`` | 위와 같은 사유 |
-| GAP-TYP-004 | 1748 | `lirTypeInvalid()` 반환 (silent) | `lirLowerMirType_module` 폴스루 — interface/tuple 등 |
+| GAP-TYP-004 | lir_proto.osty | ✅ Phase A에서 명시 진단 | `lirLowerMirType_module` 폴스루가 `unsupported module type`으로 보고됨 |
 
 #### 2.2.3 Instruction-level fallthrough
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -1697,17 +1697,20 @@ pub struct LirMirFunctionLowerer {
 //   3. `@llvm.global_ctors = appending global [...]` registration so
 //      the ctor runs before main.
 // When `mir.globals` is empty nothing is emitted — same as production.
-fn lirEmitMirGlobals(out: LirModule, mir: MirModule) {
+fn lirEmitMirGlobals(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>) {
     if mir.globals.len() == 0 {
         return
     }
     for glob in mir.globals {
-        let typ = lirLowerMirType_module(out, mir, glob.typ)
+        let typ = lirLowerMirType_module(out, mir, glob.typ, "global." + glob.name, diags)
+        if lirTypeIsZero(typ) || lirTypeIsVoid(typ) {
+            continue
+        }
         out.globals.push(lirGlobal("@" + glob.name, typ, ""))
     }
     let mut hasInit = false
     for glob in mir.globals {
-        if glob.hasInit && glob.initSymbol != "" {
+        if glob.hasInit && glob.initSymbol != "" && lirModuleHasGlobal(out, "@" + glob.name) {
             hasInit = true
         }
     }
@@ -1717,7 +1720,7 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule) {
         // without a ctor (LLVM zeros them at module load).
         return
     }
-    let ctor = lirBuildInitGlobalsCtor(out, mir)
+    let ctor = lirBuildInitGlobalsCtor(out, mir, diags)
     out.functions.push(ctor)
     out.globals.push(lirGlobalWithLinkage("@llvm.global_ctors", lirRawType("[1 x \{ i32, ptr, ptr \}]"), "[\{ i32, ptr, ptr \} \{ i32 65535, ptr @__osty_init_globals, ptr null \}]", "appending"))
 }
@@ -1725,7 +1728,7 @@ fn lirEmitMirGlobals(out: LirModule, mir: MirModule) {
 // `lirLowerMirType` requires a `LirMirFunctionLowerer`; for
 // module-level globals we don't have one. Reproduce the relevant
 // portion (primitives + Option/Result/struct/tuple shape).
-fn lirLowerMirType_module(out: LirModule, mir: MirModule, name: String) -> LirType {
+fn lirLowerMirType_module(out: LirModule, mir: MirModule, name: String, path: String, diags: List<LirDiagnostic>) -> LirType {
     let primitive = lirLowerPrimitiveTypeName(name)
     if !(lirTypeIsZero(primitive)) {
         return primitive
@@ -1745,6 +1748,7 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, name: String) -> LirTy
             return lirAggregateType(typeName)
         }
     }
+    diags.push(lirDiagnosticError(LirDiagUnsupported, "unsupported module type `" + name + "`", path))
     lirTypeInvalid()
 }
 // `lirBuildInitGlobalsCtor` synthesises the
@@ -1752,7 +1756,7 @@ fn lirLowerMirType_module(out: LirModule, mir: MirModule, name: String) -> LirTy
 // each global with `hasInit`, calls the init fn and stores into the
 // global. Mirrors production `mirInitGlobalsCtorHeader / Footer /
 // StoreSequence` (mir_generator_snapshot.go).
-fn lirBuildInitGlobalsCtor(out: LirModule, mir: MirModule) -> LirFunction {
+fn lirBuildInitGlobalsCtor(out: LirModule, mir: MirModule, diags: List<LirDiagnostic>) -> LirFunction {
     let mut fn_ = lirFunction("__osty_init_globals", lirVoidType())
     fn_.linkage = "private"
     let mut entry = lirBlock("entry", lirRetVoid())
@@ -1760,13 +1764,27 @@ fn lirBuildInitGlobalsCtor(out: LirModule, mir: MirModule) -> LirFunction {
         if !(glob.hasInit) || glob.initSymbol == "" {
             continue
         }
-        let initRet = lirLowerMirType_module(out, mir, glob.typ)
+        if !(lirModuleHasGlobal(out, "@" + glob.name)) {
+            continue
+        }
+        let initRet = lirLowerMirType_module(out, mir, glob.typ, "global." + glob.name + ".init", diags)
+        if lirTypeIsZero(initRet) || lirTypeIsVoid(initRet) {
+            continue
+        }
         let tmp = "%v" + glob.name
         entry.instrs.push(lirCall(tmp, initRet, "@" + glob.initSymbol, []))
         entry.instrs.push(lirStore(lirOperand(initRet, tmp), "@" + glob.name, 0))
     }
     fn_.blocks.push(entry)
     fn_
+}
+fn lirModuleHasGlobal(m: LirModule, name: String) -> Bool {
+    for g in m.globals {
+        if g.name == name {
+            return true
+        }
+    }
+    false
 }
 pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult {
     let packageName = if cfg.packageName == "" {
@@ -1782,10 +1800,8 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
     // `@llvm.global_ctors`. Mirrors production `emitGlobalVars`
     // (mir_generator.go:1508). When MIR has no globals nothing is
     // emitted — same as production.
-    lirEmitMirGlobals(out, mir)
-    if mir.uses.len() > 0 {
-        diags.push(lirDiagnosticError(LirDiagUnsupported, "MIR uses/imports are not implemented in LIR Proto lowering", "module.uses"))
-    }
+    lirEmitMirGlobals(out, mir, diags)
+    lirLowerMirUses(out, mir)
     for fn_ in mir.functions {
         let lowered = lirLowerMirFunction(cfg, mir, out, fn_)
         for d in lowered.diagnostics {
@@ -1810,6 +1826,28 @@ pub fn lirLowerMirModule(cfg: LirLowerConfig, mir: MirModule) -> LirLowerResult 
         diags.push(d)
     }
     LirLowerResult {module: out, diagnostics: diags}
+}
+
+// MIR `use` declarations are already resolved before MIR reaches this
+// lowerer. Non-FFI package imports therefore need no LLVM artifact, while
+// FFI surfaces arrive as external MIR functions and are declared by the
+// normal call/function lowering path. Keep the edges visible as comments
+// for traceability but do not decline the module.
+fn lirLowerMirUses(out: LirModule, mir: MirModule) {
+    for u in mir.uses {
+        let mut text = "; MIR use "
+        if u.isGoFFI {
+            text = text + "go \"" + u.goPath + "\""
+        } else if u.isRuntimeFFI {
+            text = text + "runtime \"" + u.runtimePath + "\""
+        } else {
+            text = text + u.rawPath
+        }
+        if u.alias != "" {
+            text = text + " as " + u.alias
+        }
+        out.metadata.push(text)
+    }
 }
 pub fn lirLowerMirFunction(cfg: LirLowerConfig, mir: MirModule, module: LirModule, fn_: MirFunction) -> LirLowerResult {
     let mut l = LirMirFunctionLowerer {cfg, mirModule: mir, fn_, out: lirModule(module.packageName, module.sourcePath, module.target), diagnostics: [], prologue: [], instrs: [], slots: [], labels: [], temp: 0, safepointSerial: 0, currentBlockLabel: "", extraBlocks: [], auxLabel: 0, gcRootSlots: [], parallelAccessGroupRef: ""}

--- a/toolchain/lir_proto_test.osty
+++ b/toolchain/lir_proto_test.osty
@@ -480,12 +480,22 @@ fn testLirProtoLowerMirProjectedCallAndIntrinsicResultsOstyOwned() {
     m.layouts.structs.push(lirTestStructLayout("Cell", [lirTestField(0, "value", "Int"), lirTestField(1, "other", "Int")]))
     assertLirLoweredContains(m, ["%Cell = type \{ i64, i64 \}", "define i64 @makeValue() \{", "define i64 @fill(i8 %p2) \{", "call i64 @makeValue()", "zext i8", "insertvalue %Cell", "store %Cell", "extractvalue %Cell"])
 }
-fn testLirProtoLowerMirDiagnosticsForUnsupportedModuleShapeOstyOwned() {
+fn testLirProtoLowerMirUsesAreTraceOnlyOstyOwned() {
     let mut m = mirModule("main")
     m.globals.push(mirGlobal("g", "Int", false, mirNoSpan()))
     m.uses.push(mirUse("std.io", "io", mirNoSpan()))
-    assertLirLoweredDiagnosticsContain(m, "MIR globals are not implemented")
-    assertLirLoweredDiagnosticsContain(m, "MIR uses/imports are not implemented")
+    assertLirLoweredContains(m, ["@g = global i64 zeroinitializer", "; MIR use std.io as io"])
+}
+fn testLirProtoLowerMirReportsUnsupportedModuleTypeOstyOwned() {
+    let mut m = mirModule("main")
+    let mut g = mirGlobal("g", "OpaqueThing", false, mirNoSpan())
+    g.hasInit = true
+    g.initSymbol = "init_g"
+    m.globals.push(g)
+    let result = lirLowerMirModule(lirLowerConfig("main", "/tmp/lir_proto_fixture.osty", ""), m)
+    testing.assert(lirLowerHasErrors(result))
+    assertLirDiagnosticsContain(result.diagnostics, "unsupported module type `OpaqueThing`")
+    testing.assertEq(result.diagnostics.len(), 1)
 }
 fn testLirProtoParityCatalogIsOstyOwned() {
     let manual = lirParityManualMIRFixtures()
@@ -553,7 +563,7 @@ fn testLirProtoLowererEnvelopeAndPackageFallbackOstyOwned() {
     assertLirContains(ir, "source_filename = \"/tmp/empty.osty\"")
     assertLirContains(ir, "target triple = \"arm64-apple-macosx\"")
     let mut unsupported = mirModule("pkg")
-    unsupported.globals.push(mirGlobal("g", "Int", false, mirNoSpan()))
+    unsupported.globals.push(mirGlobal("g", "OpaqueThing", false, mirNoSpan()))
     let first = lirLowererLowerMIR(lowerer, unsupported)
     testing.assert(!(lirLowerOK(first)))
     testing.assert(lirLowerHasErrors(first))


### PR DESCRIPTION
## What changed

- Converts module-context MIR type lowering fallthrough from a silent invalid type into an explicit `unsupported module type` diagnostic.
- Lowers MIR `uses/imports` as trace-only LLVM comments instead of declining the whole LIR Proto module.
- Skips init-ctor lowering for globals whose module-level type already failed, so unsupported global types produce one focused diagnostic instead of a duplicate global/init pair.
- Updates the LIR Proto tests and Tier A gap plan to reflect the Phase A foundation change.

## Why

Phase A of the Tier A backend plan needs clearer type-lowering diagnostics and must stop resolved import edges from blocking native-owned multi-file/module paths.

## Validation

- `.bin/osty parse toolchain/lir_proto.osty`
- `go test -count=1 -vet=off -run 'SnapshotParity|CoreSnapshotParity' ./internal/ci ./internal/runner`
- `go test -count=1 -vet=off ./cmd/osty-native-lirproto ./cmd/osty-native-llvmgen ./internal/toolchain`
- `go test -count=1 -vet=off ./internal/backend -run 'TestNativeToolchainMergedMIRPipelineIsClean|TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered|TestLLVMBackendDispatchTraceReportsSelectedRoute'`

## Notes

- `.bin/osty test --seed 0x1 --serial toolchain lir_proto` still hits existing string-interpolation parser fixture errors in `toolchain/parser_string_interp_test.osty` and `toolchain/resolve_string_interp_test.osty`, unrelated to this patch.
- Fresh-worktree `just bootstrap` fails before this patch is exercised because no cached `osty-self` seed exists. Retrying with `OSTY_STAGE0_FALLBACK=1 .bin/osty install-self` was stopped after it stayed in a long-running `osty-native-llvmgen` child for roughly 40 minutes.