### PR TITLE
docs: v0.6 spec — full canonical body (G36-G49, drop G50)

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -9,7 +9,7 @@ authority on what v0.6 *is* right now. v0.5 의 분리 패턴
 ([`CHANGELOG_v0.5.md`](./CHANGELOG_v0.5.md)) 을 그대로 따른다.
 
 See [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md)
-for the full v0.5 → v0.6 decision log (15 resolved gaps, G36 – G50)
+for the full v0.5 → v0.6 decision log (14 resolved gaps, G36 – G49)
 and [`SPEC_GAPS.md`](./SPEC_GAPS.md) §"Resolved in v0.6" for per-gap
 rationale.
 
@@ -26,7 +26,7 @@ rationale.
 | Phase 3 | Reproducible + spec block v0 + golden | G39, G43 (v0), G45 |
 | Phase 4 | Sealed + ErrorContract + Evolution + Budget(static) | G40, G41, G44, G46 (static) |
 | Phase 5 | Taint + Budget(runtime) + spec block v1 | G37, G46 (runtime), G43 (v1) |
-| Pre-1.0 | While + Anonymous record | G49, G50 |
+| Pre-1.0 | While ergonomics | G49 |
 
 ## Shipped in the compiler
 
@@ -38,7 +38,6 @@ rationale.
 | Form | Status | Notes |
 |---|---|---|
 | `while cond { body }` | **planned** (G49) | `for cond { body }` 와 동등 lowering. 사용자 0 단계의 breaking change — 식별자 `while` 사용했던 코드는 rename. |
-| `{ x: Int, y: Int }` anonymous record | **planned** (G50) | structural type, nominal struct 와 별도 universe |
 | `spec { example: ... }` block | **planned** (G43, v0) | example: 만 v0 에 실행, law:/invariant: 는 doc only |
 | Parameter annotation `fn f(#[taint("...")] x: T)` | **planned** (G37) | parameter 위치 annotation 신규 허용 |
 
@@ -115,7 +114,7 @@ rationale.
 
 - `#[since]` / `#[stability]` / `#[match_compat]` — 옵션 어노테이션, 미사용
   코드 영향 없음
-- Anonymous record / `while` keyword — 신규 surface, 기존 코드 영향 없음
+- `while` keyword — 신규 surface, 기존 코드 영향 없음 (식별자 `while` 사용 코드만 rename)
 - `#[spec]` / `#[purpose]` / `#[example]` / `#[fixture]` — 메타데이터, 옵션
 - `#[reproducible]` / `#[golden]` / `#[budget]` — 옵션, 미사용 영향 없음
 

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1371,38 +1371,6 @@ Spec: v0.6 §3.14.4 / §3.14.2
 
 ---
 
-## G50 — Anonymous structural record (§2.5.4)
-
-### E0340 — `CodeAnonRecordAnnotation`
-
-CodeAnonRecordAnnotation: an attempt was made to attach an annotation, method, or `pub` modifier to a field of an `AnonymousRecordType`. Anonymous records are *structural* and metadata-free; promote to a nominal `struct` for these features.
-
-Spec: v0.6 §2.5.4.4
-
-**Fix**: declare a nominal `struct` if the field needs annotations.
-
-### E0341 — `CodeAnonRecordRecursive`
-
-CodeAnonRecordRecursive: an `AnonymousRecordType` references itself in one of its field types (directly or transitively). Anonymous records cannot be self-recursive — the resulting type would be infinite.
-
-recursive position.
-
-Spec: v0.6 §2.5.4.4
-
-**Fix**: declare a nominal `struct` and use it by name in the
-
-### E0342 — `CodeAnonRecordAmbiguous`
-
-CodeAnonRecordAmbiguous: a `{ ... }` literal cannot be disambiguated between block expression and anonymous record literal at this position. Most common cause: closure body where `: T` could parse either as record field type or as a statement- level annotation.
-
-or wrap in `(...)` to force expression context.
-
-Spec: v0.6 §2.5.4.6 / R29
-
-**Fix**: add a type ascription (`: { x: Int }`) on the value position
-
----
-
 ## G41 — Error contract (§7.5)
 
 ### E0410 — `CodeErrorContractMismatch`

--- a/LANG_SPEC_v0.6/00-revision.md
+++ b/LANG_SPEC_v0.6/00-revision.md
@@ -1,6 +1,6 @@
 # Osty v0.6 — Revision Document
 
-> **Status**: 제안 (draft). 15 개 결정 (G36–G50) 을 v0.5 baseline 위에 추가하는 spec 개정.
+> **Status**: 제안 (draft). 14 개 결정 (G36–G49) 을 v0.5 baseline 위에 추가하는 spec 개정.
 > v0.5 의 모든 결정은 v0.6 에서도 유효. 본 문서는 *delta* 만 기술하며, 변경 없는 챕터는
 > [`../LANG_SPEC_v0.5/`](../LANG_SPEC_v0.5/) 가 계속 권위.
 >
@@ -9,9 +9,12 @@
 ## 0. Overview
 
 v0.5 의 외부 사용 corpus 와 셀프호스트 운영 (100 PR / 4 일 sprint) 에서 도출된 13 개
-*hidden-dependency-surface* 결정 + 2 개 *ergonomics* 정정을 v0.6 에 batch 로 수용한다.
-사용자 0 인 단계의 마지막 큰 surface revision — 이후 v0.7 부터는 stable API rule
-(G44) 이 적용된다.
+*hidden-dependency-surface* 결정 + 1 개 *ergonomics* 정정 (`while` 키워드) 을 v0.6 에
+batch 로 수용한다. 사용자 0 인 단계의 마지막 큰 surface revision — 이후 v0.7 부터는
+stable API rule (G44) 이 적용된다.
+
+v0.5 의 §14 *anonymous structural record* 금지 정책은 그대로 유지된다 — ad-hoc
+labeled data 는 nominal `struct` 또는 tuple 로 표현한다.
 
 | G | 영역 | 한 줄 |
 |---|---|---|
@@ -29,13 +32,12 @@ v0.5 의 외부 사용 corpus 와 셀프호스트 운영 (100 PR / 4 일 sprint)
 | G47 | Machine-readable context (§13.6) | `osty context <symbol>` 구조화 추출 |
 | G48 | Annotation surface | 위 신규 어노테이션의 grammar 통합 |
 | **G49** | `while` keyword (§4.4) | `for cond {}` 와 동의어. mental-model 일치 |
-| **G50** | Anonymous structural record (§2.5) | `{ x: Int, y: Int }` ad-hoc record |
 
-> **G49 / G50 design review status**: G36–G48 (13 개) 는 직전 사용 corpus 분석에서
-> 합의된 결정인 반면, **G49 / G50 은 본 spec 작성 과정에서 추가 제안된 ergonomics
-> 정정**. v0.6 baseline 에 포함하기 전 별도 design review 권장. 빼도 v0.6 의
-> hidden-dependency-surface 정신은 유지된다. 본 문서는 편의상 *포함* 으로 작성 —
-> 결정에 따라 `SPEC_GAPS.md` 와 `OSTY_GRAMMAR_v0.6.md` 수정 필요.
+> **G49 design review note**: G36–G48 (13 개) 가 직전 사용 corpus 분석에서
+> 합의된 결정. **G49 는 본 spec 작성 과정에서 추가된 ergonomics 정정**으로
+> 작은 surface (1 keyword, 새 의미 0) 라 포함. 한때 같이 검토됐던 *G50 anonymous
+> structural record* 는 v0.5 §14 의 "named types are nominal" discipline 유지를
+> 위해 *제외*. ad-hoc labeled data 는 nominal `struct` 또는 tuple 로.
 
 ## 1. Design North Star — *Hidden Dependency Is Forbidden*
 
@@ -1756,91 +1758,6 @@ WhileStmt ::= 'while' Expr Block
 
 ---
 
-### §2.5.4 Anonymous structural record (G50)
-
-#### §2.5.4.1 동기
-
-v0.5 까지 모든 record 형 데이터는 nominal `struct` 선언 강제. ad-hoc labeled
-data (예: 함수 1 회용 반환, JSON 파싱 임시 결과, config option bundle) 마다
-struct 선언 작성은 cognitive overhead. Tuple 은 positional — 필드명 손실. v0.6 은
-*anonymous structural record* 를 추가한다.
-
-#### §2.5.4.2 Surface
-
-**Type literal**:
-```osty
-fn split(p: Point) -> { x: Int, y: Int } {
-    { x: p.x, y: p.y }
-}
-```
-
-**Value literal**: 컨텍스트에서 type 추론 가능하면 `{ x: 1, y: 2 }`. 명시
-type 은 `Type 추론 안되는 자리` 에 필요.
-
-**Field 접근 / destructure**: nominal struct 와 동일.
-```osty
-let r = split(p)
-println("{r.x}")
-let { x, y } = r
-```
-
-#### §2.5.4.3 의미
-
-- **Structural type** — 같은 필드 set 을 가진 record 는 같은 type.
-  `{ x: Int, y: Int }` 와 `{ y: Int, x: Int }` 도 같은 type (필드 순서 무관).
-- **Nominal struct 와 별도 universe** — `Point` (nominal) 과 `{ x: Int, y: Int }`
-  (anonymous) 는 *type-equivalent 아님*. 변환 위해 explicit field copy 필요.
-- **메서드 정의 불가** — anonymous record 에 메서드 첨부 안 됨. 메서드가 필요하면
-  nominal struct 사용.
-- **Mutation**: 필드는 모두 `let` 의미 (불변). mutable 이 필요하면 nominal struct.
-
-#### §2.5.4.4 제약
-
-- **Annotation 사용 불가** — anonymous record 필드에 `#[json]` / `#[taint]` 등
-  적용 불가. 필요하면 nominal struct 로 승급.
-- **Recursion 금지** — `{ next: { ... } }` 형식 self-reference 안 됨 — 무한 type.
-- **Generic 가능** — 함수가 generic 일 때 anonymous record 의 필드 type 도 generic
-  파라미터 사용 가능.
-
-```osty
-fn pair<A, B>(a: A, b: B) -> { fst: A, snd: B } {
-    { fst: a, snd: b }
-}
-```
-
-#### §2.5.4.5 nominal vs anonymous 가이드라인
-
-| 상황 | 권장 |
-|---|---|
-| 메서드 / interface 구현 | nominal `struct` |
-| `#[sealed_construct]` / 기타 어노테이션 필요 | nominal `struct` |
-| 1-2 회 사용 ad-hoc 반환 | anonymous record |
-| Tuple positional 이 헷갈리는 자리 | anonymous record |
-| Public API surface | nominal `struct` (이름이 있어야 deprecate / since 등록 가능) |
-
-#### §2.5.4.6 Grammar
-
-```ebnf
-AnonymousRecordType  ::= '{' RecordTypeField (',' RecordTypeField)* ','? '}'
-RecordTypeField      ::= IDENT ':' Type
-AnonymousRecordValue ::= '{' RecordValueField (',' RecordValueField)* ','? '}'
-RecordValueField     ::= IDENT (':' Expr)?    (* shorthand same as struct literal *)
-```
-
-Disambiguation: block expression `{ ... }` 와 충돌하지 않는 위치는 *type 위치*
-또는 *type-annotated let / fn return*. 모호한 위치에선 type ascription 필수
-(`: { x: Int, y: Int }`).
-
-#### §2.5.4.7 진단 코드
-
-| 코드 | 의미 |
-|---|---|
-| `E0340` | Anonymous record 에 method/annotation 시도 |
-| `E0341` | Anonymous record 의 self-recursive type |
-| `E0342` | Block expression 과 anonymous record literal 모호 (type ascription 권장) |
-
----
-
 ## 5. Grammar Changes (v0.5 → v0.6)
 
 ```ebnf
@@ -1854,12 +1771,6 @@ ForallClause   ::= 'forall' Ident (',' Ident)* 'in' Expr ':' Expr (LineEnd)
 
 (* §4.4 G49 — while as alias *)
 WhileStmt      ::= 'while' Expr Block
-
-(* §2.5.4 G50 — anonymous structural record *)
-AnonymousRecordType  ::= '{' RecordTypeField (',' RecordTypeField)* ','? '}'
-RecordTypeField      ::= IDENT ':' Type
-AnonymousRecordValue ::= '{' RecordValueField (',' RecordValueField)* ','? '}'
-RecordValueField     ::= IDENT (':' Expr)?
 
 (* §21 G37 — annotation on parameter (new position) *)
 ParamDecl      ::= Annotation* Pattern ':' Annotation* Type ('=' DefaultExpr)?
@@ -1875,7 +1786,7 @@ ParamDecl      ::= Annotation* Pattern ':' Annotation* Type ('=' DefaultExpr)?
 | Reserved keywords | 18 | 19 | +1 (`while` — G49) |
 | Contextual keywords | 10 | 14 | +4 (`spec`, `example`, `law`, `invariant`; `forall` 은 v1 단계) |
 | Fixed annotation set | 11 | 31 | +20 |
-| EBNF productions | 191 | 203 | +12 |
+| EBNF productions | 191 | 199 | +8 |
 | Lexer token classes | 36 | 36 | 0 |
 
 신규 어노테이션 20:
@@ -2458,9 +2369,6 @@ v0.6 의 결정들이 참조한 학술/산업 선행 사례:
 | **G47 Machine context** | LSP `textDocument/hover` | 동일 응용을 LLM 까지 확장 |
 | | `cargo metadata` JSON output | 메타데이터 export 정신 |
 | **G49 while** | C / Java / Rust / Swift | 가장 흔한 conditional loop. Osty 가 v0.5 에서 부재했던 부분 |
-| **G50 Anonymous record** | TypeScript `{ x: number, y: number }` | structural type 영감 |
-| | Swift tuple labeled fields | 부분 영향 |
-| | OCaml anonymous record | 학술 origin |
 
 ### 10.1 References
 
@@ -2486,7 +2394,7 @@ v0.6 baseline 동결 → public 1.0 alpha 출시 까지의 게이트:
 
 ### 9.1 Spec readiness (이 문서가 cover)
 
-- [x] G36–G50 (15 결정) 본 문서에 명시
+- [x] G36–G49 (15 결정) 본 문서에 명시
 - [x] SPEC_GAPS.md §"Resolved in v0.6" 에 entries 등재
 - [x] OSTY_GRAMMAR_v0.6.md grammar delta + R27–R30
 - [x] CHANGELOG_v0.6.md skeleton
@@ -2523,8 +2431,8 @@ v0.6 baseline 동결 → public 1.0 alpha 출시 까지의 게이트:
 
 ### 9.4 Spec corpus readiness
 
-- [ ] `testdata/spec/positive/` 에 G36-G50 별 통과 케이스 추가
-- [ ] `testdata/spec/negative/reject.osty` 에 신규 진단 코드 (E0340-E0451,
+- [ ] `testdata/spec/positive/` 에 G36-G49 별 통과 케이스 추가
+- [ ] `testdata/spec/negative/reject.osty` 에 신규 진단 코드 (E0405-E0451,
   E0780-E0796, E0900-E0903, E2100-E2101) 케이스
 - [ ] `STDLIB_MATRIX.md` 가 capability migration 후 모듈별 capability requirement
   컬럼 추가
@@ -2535,7 +2443,7 @@ v0.6 baseline 동결 → public 1.0 alpha 출시 까지의 게이트:
 - [ ] `README.md` v0.6 surface 표 갱신
 - [ ] `ARCHITECTURE.md` capability layer 추가
 - [ ] `CLAUDE.md` 부록 A (canonical 예시) 에 capability + sealed + taint 패턴 추가
-- [ ] `CLAUDE.md` 부록 B (생산성 기법 카탈로그) 에 G36-G50 행 추가
+- [ ] `CLAUDE.md` 부록 B (생산성 기법 카탈로그) 에 G36-G49 행 추가
 - [ ] *마이그레이션 가이드* 문서 — `MIGRATING_v0.5_to_v0.6.md`
 
 ### 9.6 Compatibility / breaking change audit

--- a/LANG_SPEC_v0.6/01-lexical-structure.md
+++ b/LANG_SPEC_v0.6/01-lexical-structure.md
@@ -1,0 +1,388 @@
+## 1. Lexical Structure
+
+### 1.1 Source Files
+
+- File extension: `.osty`
+- Encoding: UTF-8
+- Line terminator: `\n`. `\r\n` is accepted and normalized to `\n`.
+
+A file may begin with a shebang line (`#!`) which is consumed and ignored by
+the lexer:
+
+```osty
+#!/usr/bin/env osty
+println("hello")
+```
+
+This allows Osty scripts to be executed directly on Unix systems.
+
+A shebang is recognized **only at byte offset 0** of the source file and
+**only once**. Any `#` appearing elsewhere is the start of an annotation
+(§1.9) or, in any other context, a lex error.
+
+### 1.2 Keywords (18)
+
+```
+fn  struct  enum  interface  type
+let  mut  pub
+if  else  match
+for  while  break  continue  return
+use  defer
+```
+
+These are reserved and may not be used as identifiers.
+
+`while` (G49) is reserved. `while cond { body }` is equivalent in
+lowering and meaning to `for cond { body }` — provided as ergonomics
+for callers who expect a distinct conditional-loop keyword.
+
+### 1.3 Contextual Identifiers
+
+The following have special meaning in context but are not reserved words:
+
+- `self` — bound only inside method bodies
+- `Self` — refers to the enclosing type inside a `struct`, `enum`, or
+  `interface` body
+- `true`, `false` — `Bool` constants from prelude
+- `Some`, `None` — `Option` variants from prelude
+- `Ok`, `Err` — `Result` variants from prelude
+- `loop` — `loop { ... }` expression head (§4.4.1)
+- `const` — `const fn` declaration prefix (§3.1.1)
+- `by` — range step marker in range expressions (§4.4)
+- `spec` — spec block opener at function-body first-statement position
+  (§3.13). G43.
+- `example`, `law`, `invariant` — clause keywords inside `spec { ... }`
+  (§3.13). G43.
+- `forall` — *(reserved for v1, Phase 5)* property-test clause keyword
+  inside `spec { ... }` (§3.13.3).
+
+### 1.4 Identifiers
+
+```
+identifier := letter (letter | digit | '_')*
+letter     := [a-zA-Z_]
+digit      := [0-9]
+```
+
+Identifier case has no syntactic significance. Visibility is controlled
+exclusively by the `pub` keyword (§5.3).
+
+**Naming conventions.** The formatter (`osty fmt`) enforces a consistent
+casing convention across the codebase:
+
+| Category | Convention | Examples |
+|---|---|---|
+| Types (`struct`, `enum`, `interface`, type alias, generic parameters) | `PascalCase` | `User`, `ReadWriter`, `T`, `UserMap` |
+| Enum variants | `PascalCase` | `Some`, `None`, `Circle`, `RGB` |
+| Functions, methods, parameters, fields, local bindings | `camelCase` | `loadConfig`, `userName`, `maxSize` |
+| Top-level immutable scalar constants (literal-initialized) | `SCREAMING_SNAKE_CASE` | `MAX_USERS`, `DEFAULT_PORT` |
+| Packages / modules | `lowercase` (single word preferred) | `fs`, `http`, `json`, `taskgroup` |
+
+The formatter reports violations as warnings by default and as errors
+under `osty fmt --check`.
+
+Underscore-prefixed identifiers (e.g. `_unused`) are permitted for
+intentionally unused bindings and are not reported by linters.
+
+**`_` as a wildcard token.** A bare `_` (single underscore not followed
+by any identifier-continuation character) is a distinct token used as a
+pattern wildcard, a destructuring placeholder, and the type-arguments
+inference marker. Because the lexer applies maximal munch, `_foo` and
+`_1` are identifiers; only the lone `_` is the wildcard token.
+
+### 1.5 Comments
+
+```osty
+// Line comment
+
+/* Block
+   comment */
+
+/// Documentation comment.
+/// Attached to the following declaration.
+fn example() { }
+```
+
+`/* */` does not nest. `///` precedes a declaration and is extracted by
+tooling.
+
+### 1.6 Literals
+
+#### 1.6.1 Integer literals
+```
+42
+1_000_000        // underscore separators
+0xFF             // hexadecimal
+0b1010           // binary
+0o777            // octal
+```
+
+Base prefixes must be lowercase (`0x`, `0b`, `0o`). The uppercase forms
+`0X`, `0B`, `0O` are rejected as **E0002**.
+
+Underscores are permitted only **between two digits of the same base**.
+A numeric literal may not start with `_`, end with `_`, contain `__`, or
+place `_` immediately after a base prefix or adjacent to `.`, `e`/`E`,
+or the exponent sign. Violations are reported as **E0008**. Valid
+examples: `1_000`, `0xDEAD_BEEF`, `0b1010_1010`. Invalid: `1_`, `_1_000`
+(a leading `_` lexes as an identifier, not a number), `1__000`, `0x_FF`,
+`1_.5`, `1.5_e2`.
+
+#### 1.6.2 Float literals
+```
+3.14
+1.0e10
+2.5e-3
+```
+
+Both sides of the decimal point must be digits — neither `.5` nor `1.`
+is a float literal. The exponent marker (`e` or `E`) must be followed by
+at least one digit, optionally preceded by `+` or `-`. The same
+underscore-placement rule applies as for integers (§1.6.1).
+
+#### 1.6.3 String literals
+
+Standard string:
+```osty
+"hello"
+"escapes: \n \t \" \\"
+"unicode: \u{1F600}"
+```
+
+Interpolation: an unescaped `{` opens an interpolation expression,
+terminated by `}`. Escape with `\{`, `\}`.
+
+```osty
+"hi, {name}"
+"{user.name} is {user.age}"
+"items: {xs.join(", ")}"
+"literal \{ brace }"
+```
+
+Raw string (no escape processing, no interpolation):
+```osty
+r"\d+\.\d+"
+r"C:\Users\name"
+```
+
+Triple-quoted (multi-line) string:
+```osty
+let sql = """
+    SELECT *
+    FROM users
+    WHERE id = {id}
+    """
+```
+
+Indentation handling for triple-quoted strings:
+
+1. The opening `"""` must be followed by a newline.
+2. The closing `"""` must appear on its own line. The whitespace before it
+   defines the common indent prefix.
+3. Each content line must begin with at least the common indent prefix,
+   which is stripped from every content line.
+4. If any content line does not begin with the common indent prefix (and
+   is not blank), it is a compile error.
+5. The trailing newline before the closing `"""` is removed.
+6. Interpolation and escape sequences are processed as in standard
+   strings.
+7. `r"""..."""` disables escape and interpolation but still applies
+   indentation handling.
+
+#### 1.6.4 Char and Byte literals
+```osty
+'A'              // Char (Unicode scalar value)
+'\n'
+'\u{1F600}'
+b'A'             // Byte (UInt8); ASCII only
+```
+
+A char literal holds **exactly one** Unicode scalar value. A byte
+literal `b'X'` holds exactly one ASCII scalar (U+0000–U+007F). Empty
+literals (`''`, `b''`) are rejected by the lexer as **E0009**. Multiple
+scalars inside a char literal and non-ASCII scalars inside a byte
+literal are rejected during type checking (not at lex time).
+
+#### 1.6.5 Bool literals
+
+`true` and `false`.
+
+#### 1.6.6 Collection literals
+```osty
+[1, 2, 3]                  // List<Int>
+[]                         // empty List; type from context
+{"a": 1, "b": 2}           // Map<String, Int>
+{:}                        // empty Map; type from context
+(1, "two", 3.0)            // tuple (Int, String, Float)
+```
+
+There is no Set literal. Use `Set.from([...])`.
+
+### 1.7 Operators
+
+```
+Arithmetic:  +  -  *  /  %
+Comparison:  ==  !=  <  >  <=  >=
+Logical:     &&  ||  !
+Bitwise:     &  |  ^  ~  <<  >>
+Assignment:  =  +=  -=  *=  /=  %=  &=  |=  ^=  <<=  >>=
+Other:       ?    // Result/Option propagation; also Option<T> sugar in type position
+             ?.   // optional chaining
+             ??   // nil-coalescing (default for None)
+             ..   // exclusive range (and rest in patterns/struct update)
+             ..=  // inclusive range
+```
+
+Increment (`++`) and decrement (`--`) are not provided.
+User-defined operator overloading is limited to the explicit `#[op(+)]`,
+`#[op(-)]`, `#[op(*)]`, `#[op(/)]`, and `#[op(%)]` binary forms plus
+unary `#[op(-)]` (§3.8, §14.2). All other operators remain primitive-
+only or interface-defined and cannot be overloaded.
+
+**Punctuation and contextual tokens.** The following are not operators
+but serve as syntactic punctuation or context-specific markers:
+
+| Token | Role |
+|---|---|
+| `.`   | Member access (also in chained method calls) |
+| `::`  | Turbofish prefix; **must** be followed by `<` (§2.7.2) |
+| `->`  | Function return type, `match` arm separator |
+| `<-`  | Channel send (statement only — §8.5) |
+| `_`   | Wildcard (patterns, destructuring) |
+| `@`   | Binding in patterns |
+| `\|`  | Pattern alternation (only in pattern position) |
+| `#`   | Annotation prefix (`#[...]`) or shebang at byte 0 |
+
+**`=>` is not a token.** Match arms use `->`. Any occurrence of `=>` in
+source is a lex error. (This was open issue O7 in the v0.1 grammar; see
+§18.)
+
+Assignment operators (`=`, `+=`, …) are statement-only — assignment is
+not an expression, so `let x = (y = 1)` is a compile error. `<-`
+(channel send) is likewise statement-only.
+
+### 1.8 Statement Separators
+
+Newlines separate statements. There are no semicolons. The lexer promotes
+each physical newline to a statement terminator (`TERMINATOR`) **unless**
+one of the suppression rules below applies. There is no `\`-EOL line
+continuation; newlines inside triple-quoted strings or block comments are
+not tokens at all.
+
+**Suppression — preceding token.** The newline is discarded when the
+last non-whitespace token before it is any of:
+
+- A binary operator awaiting a right operand (`+`, `-`, `*`, `/`, `%`,
+  `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `&`, `|`, `^`, `<<`,
+  `>>`, `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`,
+  `>>=`, `??`)
+- `,`
+- `->`, `<-`
+- `::`, `@`
+- `|` in pattern context (pattern-or)
+- An opening `(`, `[`, or `{`
+
+The preceding tokens `.` and `?.` **do not** suppress newlines. In
+consequence, method-chain continuation must place the `.` (or `?.`) at
+the **start** of the continuation line, not at the end of the previous
+line:
+
+```osty
+let x = items
+    .filter(|x| x > 0)        // OK — leading dot
+    .map(|x| x * 2)
+    .sum()
+
+let y = items.                // ERROR — trailing dot terminates the
+    filter(|x| x > 0)         // statement; the next line is a new stmt
+```
+
+This was open issue O3 in the v0.1 grammar.
+
+**Suppression — following token.** The newline is also discarded when
+the next non-whitespace token is any of:
+
+- A closing `)`, `]`, or `}`
+- `.`, `?.`
+- `,`
+- `..`, `..=`
+- A binary operator that requires a left operand
+
+Notably, **`else` is not in this set.** A `}` followed by a newline and
+then `else` is a syntax error — `} else {` (and `} else if`) must appear
+on a single physical line. This was open issue O2.
+
+```osty
+if cond {
+    foo()
+} else {                      // OK — same line
+    bar()
+}
+
+if cond {
+    foo()
+}                             // ERROR — newline before else
+else {
+    bar()
+}
+```
+
+**Trailing commas.** Permitted in lists, tuples, match arms, function
+parameters, struct/enum/interface bodies, annotation arg lists, and
+similar comma-separated constructs. The single-element tuple `(x,)`
+**requires** a trailing comma to distinguish it from a parenthesized
+expression `(x)`.
+
+### 1.9 Annotations
+
+Annotations attach compile-time metadata to declarations. The syntax is
+Rust-style:
+
+```
+annotation := '#' '[' name ('(' argList? ')')? ']'
+argList    := arg (',' arg)* ','?
+arg        := argName ('=' literal)?      // flag form omits '=' literal
+argName    := identifier | keyword
+literal    := stringLit | intLit | floatLit | boolLit
+            | '-' (intLit | floatLit)
+name       := identifier
+```
+
+Two argument forms are accepted:
+
+- **Key/value:** `name = literal` (e.g. `key = "user_id"`).
+- **Flag:** a bare identifier (e.g. `skip`). The flag form means
+  "argument present, value `true`."
+
+Both forms may be mixed in the same argument list:
+
+```osty
+#[json(key = "user_id", skip)]
+pub legacyId: String?
+```
+
+An annotation precedes the declaration it applies to and occupies its
+own logical line. Multiple annotations may be stacked:
+
+```osty
+#[json(key = "user_id")]
+pub userId: String
+
+#[deprecated(since = "0.5", use = "loginV2")]
+pub fn login(user: String, pass: String) -> Result<Session, Error> { ... }
+```
+
+Annotation argument names are matched by name; reserved keywords
+(e.g. `use`, `type`) are permitted as argument names to keep the
+annotation vocabulary independent of language keywords. Argument
+values must be literals — there are no expressions, identifiers, or
+concatenations. A unary `-` prefix is accepted on numeric literals
+(consistent with default-argument syntax in §3.1).
+
+Annotations are not expressions, cannot be constructed dynamically,
+and cannot be declared by user code. The set of recognized annotations
+is fixed by the compiler (§3.8). Applying any unrecognized annotation,
+an annotation with unknown arguments, an annotation in an unsupported
+position, or with arguments of the wrong type, is a compile error.
+
+---

--- a/LANG_SPEC_v0.6/02-type-system.md
+++ b/LANG_SPEC_v0.6/02-type-system.md
@@ -1,0 +1,515 @@
+## 2. Type System
+
+### 2.1 Primitive Types
+
+```
+Int                                  // signed 64-bit
+Int8, Int16, Int32, Int64
+UInt8, UInt16, UInt32, UInt64
+Byte                                 // alias for UInt8
+Float                                // alias for Float64
+Float32, Float64
+Bool
+Char                                 // Unicode scalar value (32-bit)
+String                               // UTF-8 byte sequence, immutable
+Bytes                                // immutable byte array
+Never                                // bottom type; type of expressions that do not return
+```
+
+`Int` is fixed at 64 bits regardless of platform. There is no `UInt` type
+matching machine word size; use `Int` for sizes, counts, and indices.
+
+`Never` is the type of expressions that never produce a value.
+
+**`Char` — Unicode scalar value.** `Char` represents a single Unicode
+scalar value: any code point in the ranges `U+0000 – U+D7FF` or
+`U+E000 – U+10FFFF`. The surrogate range `U+D800 – U+DFFF` is **not**
+representable.
+
+- Character and `\u{...}` escapes that encode a surrogate are a
+  compile error:
+  ```osty
+  let c: Char = '\u{D800}'   // ERROR: surrogate code point
+  ```
+- `Int.toChar(self) -> Char` aborts when the value is out of range or
+  in the surrogate block.
+- `Char.fromInt(n: Int) -> Char?` is the safe converter; it returns
+  `None` for invalid code points.
+- `Char.toInt(self) -> Int` is total (the scalar value as a signed
+  integer).
+
+Zero-sized structs (e.g. `struct Marker {}`) are allowed. They occupy no
+storage; collections and struct fields treat them as ordinary values.
+
+**Runtime-only types.** `RawPtr` is a pointer-shaped opaque type used by
+the toolchain's runtime sublanguage. It is **not** part of the user
+prelude and is unreachable from ordinary user code. See §19.3.
+
+### 2.2 Numeric Conversions
+
+Osty allows only lossless implicit numeric widening. The widening lattice
+is `Int8 -> Int16 -> Int32 -> Int -> Float64`, `Int -> Float64`, and
+`Float32 -> Float64`. Narrowing, signedness-changing conversions, and
+lossy float/integer conversions require explicit methods; implicit
+narrowing is `E0765`.
+
+```osty
+let a: Int = 5
+let b: Float64 = a              // lossless widening
+let c: Int32 = big.toInt32()?           // Err if out of range
+let f: Float = a.toFloat()
+```
+
+Lossy conversions return `Result<T, Error>`; lossless return `T`.
+
+**Literal inference.** Numeric literals are polymorphic until their
+type is fixed by context. A literal without explicit suffix adopts the
+type required by its usage:
+
+```osty
+let a: Float = 5              // 5 is Float
+let b: Int32 = 100            // 100 is Int32
+let c: Int = narrow.toInt()?   // explicit narrowing from variable
+
+fn f(x: Int64) { ... }
+f(42)                         // 42 is Int64
+```
+
+A literal must fit in its inferred type; `let x: UInt8 = 300` is a
+compile error.
+
+If no context fixes the type, integer literals default to `Int` and
+float literals default to `Float`.
+
+### 2.3 Numeric Overflow
+
+Arithmetic operators check for overflow and abort the program on overflow:
+
+```osty
+a + b               // aborts on overflow
+a - b
+a * b
+```
+
+Explicit alternatives:
+
+```osty
+a.wrappingAdd(b)    // modular arithmetic
+a.checkedAdd(b)     // T?
+a.saturatingAdd(b)  // clamps to T.MIN or T.MAX
+```
+
+**Shifts.** `a << b` and `a >> b` abort when `b` is negative or
+`b ≥ bit-width(a)`. A shift by `0` is the identity. Explicit
+alternatives mirror arithmetic:
+
+```osty
+a.wrappingShl(b)    // b mod bit-width(a), then shift
+a.wrappingShr(b)
+a.checkedShl(b)     // T?
+a.checkedShr(b)
+```
+
+For unsigned types `>>` is logical (zero-fill); for signed types `>>`
+is arithmetic (sign-extend).
+
+**Division and modulo.** Integer division by zero aborts. Integer
+modulo by zero aborts. The `%` operator follows the **dividend**
+sign (C/Go convention): `-5 % 3 == -2`. For division-specific
+overflow handling:
+
+```osty
+a.wrappingDiv(b)    // aborts only on b = 0; other cases wrap
+a.wrappingMod(b)    // same
+a.checkedDiv(b)     // T? — None on b = 0 or overflow
+a.checkedMod(b)
+a.saturatingDiv(b)  // clamps to T.MIN / T.MAX on overflow; aborts on b = 0
+```
+
+`Int.MIN.abs()` overflows (there is no positive counterpart) and
+**aborts**. Use `MIN.checkedAbs()` (returns `None`) or
+`MIN.wrappingAbs()` (returns `MIN`) for recovery.
+
+**`pow`.** `Int.pow(exp: Int) -> Int` aborts when `exp < 0` (no integer
+result). Use `Float.pow` for fractional/negative exponents.
+
+### 2.4 Composite Types
+
+```osty
+struct Point { x: Int, y: Int }
+
+enum Shape {
+    Circle(Float),
+    Rect(Float, Float),
+    Empty,
+}
+
+interface Writer {
+    fn write(self, data: Bytes) -> Result<Int, Error>
+}
+
+(Int, String, Bool)         // tuple type
+(Int,)                      // 1-element tuple type; comma required
+fn(Int, Int) -> Int         // function type
+fn()                        // Unit-returning function type shorthand
+
+List<T>
+Map<K, V>
+Set<T>
+T?                          // syntactic sugar for Option<T>
+Option<T>                   // canonical form
+Result<T, E>
+```
+
+`Set<T>` is a standard collection type, but there is no set literal;
+construct one from an iterable, for example `Set.from([...])`.
+
+#### 2.4.1 The `Bytes` Type
+
+`Bytes` is an immutable sequence of bytes (`UInt8`). It complements
+`String` (an immutable sequence of UTF-8 encoded bytes) and is the
+canonical type for binary data, I/O buffers, and FFI byte transport.
+
+**Literals.** Two forms:
+
+```osty
+b'A'                  // single byte; ASCII only; Byte (= UInt8)
+b"hello"              // byte sequence; ASCII only; Bytes
+b"binary\x00data"     // \xNN escapes for non-printable bytes
+```
+
+The byte-string literal `b"..."` accepts only printable ASCII characters
+plus the escapes `\n`, `\r`, `\t`, `\\`, `\"`, `\0`, and `\xNN`. It does
+not interpolate. To embed non-ASCII data, use `\xNN` or build the value
+programmatically with `Bytes.from(...)`.
+
+**API.**
+
+```
+Bytes.len(self) -> Int
+Bytes.isEmpty(self) -> Bool
+Bytes.get(self, i: Int) -> Byte?
+Bytes[i] -> Byte                 // aborts on out-of-range
+Bytes[a..b] -> Bytes              // byte slicing; aborts on out-of-range
+Bytes.concat(self, other: Bytes) -> Bytes
+Bytes.toString(self) -> Result<String, Error>   // verifies UTF-8
+
+String.toBytes(self) -> Bytes                   // zero-copy reinterpret
+Bytes.from(items: List<Byte>) -> Bytes
+```
+
+`Bytes` implements `Equal`, `Ordered` (lexicographic), and `Hashable`.
+
+### 2.5 Optional Type Sugar
+
+`T?` is syntactic sugar for `Option<T>`. They are interchangeable at all
+type positions. The formatter normalizes to `T?`.
+
+### 2.6 Interfaces
+
+An `interface` declaration specifies a set of method signatures,
+optionally with default implementations. Any concrete type whose methods
+match the interface's signatures satisfies it automatically (structural
+typing).
+
+#### 2.6.1 Composition
+
+```osty
+interface Reader {
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
+}
+
+interface ReadWriter {
+    Reader
+    Writer
+}
+```
+
+#### 2.6.2 Default Methods
+
+```osty
+interface Error {
+    fn message(self) -> String
+    fn source(self) -> Error? { None }
+}
+```
+
+Default bodies may call other methods on the interface, use `self` and
+`Self`, but may not access fields.
+
+#### 2.6.3 The `Self` Type
+
+Inside an interface body, `Self` refers to the implementing type. Inside
+a `struct` or `enum` body, `Self` refers to the type being declared.
+
+#### 2.6.4 Built-in Interfaces
+
+```osty
+interface Equal {
+    fn eq(self, other: Self) -> Bool
+    fn ne(self, other: Self) -> Bool { !self.eq(other) }
+}
+
+interface Ordered {
+    Equal
+    fn lt(self, other: Self) -> Bool
+    fn le(self, other: Self) -> Bool { self.lt(other) || self.eq(other) }
+    fn gt(self, other: Self) -> Bool { !self.le(other) }
+    fn ge(self, other: Self) -> Bool { !self.lt(other) }
+}
+
+interface Hashable {
+    Equal
+    fn hash(self) -> Int
+}
+```
+
+Comparison operators desugar to `Equal`/`Ordered` calls on implementing
+types. Primitives use built-in comparison directly, **and** they are
+considered to implement the corresponding interfaces — so a generic
+function with bound `T: Ordered` accepts `Int`, `Float`, `String`, etc.
+
+#### 2.6.5 Built-in Instances
+
+The compiler treats the following types as implementing the interfaces
+listed:
+
+| Type | `Equal` | `Ordered` | `Hashable` | `ToString` (§17) |
+|---|:---:|:---:|:---:|:---:|
+| `Int`, `Int8…Int64`, `UInt8…UInt64`, `Byte` | ✓ | ✓ | ✓ | ✓ |
+| `Float`, `Float32`, `Float64` | ✓ | ✓ † | ✗ ‡ | ✓ |
+| `Bool` | ✓ | ✓ (false < true) | ✓ | ✓ |
+| `Char` | ✓ | ✓ (scalar order) | ✓ | ✓ |
+| `String` | ✓ | ✓ (lexicographic by byte) | ✓ | ✓ |
+| `Bytes` | ✓ | ✓ (lexicographic) | ✓ | ✓ (hex-escaped) |
+| Tuple `(T, U, …)` | ✓ if all components do | — | ✓ if all components do | ✓ if all components do |
+| `Option<T>` | ✓ if `T: Equal` | ✓ if `T: Ordered` (`None < Some`) | ✓ if `T: Hashable` | ✓ |
+| `Result<T, E>` | ✓ if both | — | ✓ if both | ✓ |
+
+† `Float` ordering follows IEEE-754 total ordering: `NaN` is greater
+than all finite and infinite values; `-0.0 < 0.0`.
+
+‡ `Float` is **not** `Hashable` because `==` and `hash` would disagree
+under `NaN` semantics. Convert via `f.toBits()` if you must hash.
+
+**Collections.** Auto-derivation:
+
+```
+List<T>:    T: Equal     ⇒ List<T>: Equal
+List<T>:    T: Hashable  ⇒ List<T>: Hashable
+Set<T>:     T: Equal     ⇒ Set<T>: Equal
+Set<T>:     T: Hashable  ⇒ Set<T>: Hashable
+Map<K,V>:   K: Equal    + V: Equal    ⇒ Map<K,V>: Equal
+Map<K,V>:   K: Hashable + V: Hashable ⇒ Map<K,V>: Hashable
+```
+
+`Ordered` is **not** auto-derived for collections.
+
+User code cannot override the built-in `Equal`/`Hashable` instances of
+collection types; they are structural by definition. (Resolves G1 from
+the v0.1 gap list.)
+
+**Runtime-only marker.** `Pod` is a built-in marker interface
+(no methods) used by the runtime sublanguage to constrain raw
+load/store/CAS intrinsics. The compiler decides `Pod` membership
+structurally; user code cannot `impl Pod`. `Pod` is not part of the
+user prelude. See §19.4.
+
+### 2.7 Generics
+
+```osty
+fn first<T>(xs: List<T>) -> T? { ... }
+
+struct Stack<T> {
+    items: List<T>,
+}
+```
+
+#### 2.7.1 Constraints
+
+Type parameters may be constrained by any interface:
+
+```osty
+fn max<T: Ordered>(a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+
+fn sortUnique<T: Ordered + Hashable>(xs: List<T>) -> List<T> { ... }
+```
+
+#### 2.7.2 Type Argument Specification
+
+Use turbofish `::<...>` for explicit type arguments at expression
+positions:
+
+```osty
+let cfg = json.parse::<Config>(text)?
+```
+
+The token following `::` **must** be `<`. Any other token is a parse
+error:
+
+```
+expected '<' after '::', got 'Foo'. Did you mean '.'?
+```
+
+This was open issue O6 — `::` is exclusively the turbofish prefix, never
+a path separator (path separator is `.`).
+
+In **type position** (e.g. `let xs: List<List<Int>>`), the `<...>` form
+is unambiguous and `::` is not required. The lexer emits `>>`, `>=`,
+`>>=` as single tokens via maximal munch; the type parser splits them
+back into `>` + `>` (or `>` + `=`) when a `>` is expected. This
+"splittable `>`" rule (open issue O4) lets nested generics like
+`List<List<Map<String, Int>>>` parse without explicit space between the
+closing `>`s.
+
+Turbofish on **enum variant construction** is not supported — the type
+context infers the instantiation:
+
+```osty
+let x: Option<Int> = Some(5)             // OK
+let x = Option::<Int>::Some(5)           // ERROR — turbofish not valid on variants
+```
+
+Generic **type parameters with default values** (e.g. `struct Pair<T, U = T>`)
+are not provided.
+
+#### 2.7.3 Compilation Model
+
+Osty generics are **monomorphized**. At each distinct instantiation
+(e.g. `List<Int>` and `List<String>`), the compiler emits a separate,
+fully specialized copy of the generic definition. Consequences:
+
+- **Zero runtime cost** per generic call — no type-parameter lookup,
+  no boxing of primitives, no dispatch through a table.
+- **Binary size grows** with the number of distinct instantiations.
+  Generic code used with many type arguments is a deliberate design
+  choice.
+- **Go FFI mapping is direct**: `List<Int>` maps to `[]int64`,
+  `Map<String, Int>` maps to `map[string]int64`, etc. (§12.2).
+- **Generic function bodies are visible across packages.** When an
+  imported generic function is called with a new type argument, the
+  compiler reinstantiates it at the call site. The generic body is
+  therefore effectively "header-like" — it must remain in the source
+  distribution for downstream packages to use it with new type
+  arguments. Non-generic functions retain the usual separate-
+  compilation model.
+
+**Interface values are a separate mechanism.** A function that names an
+interface in parameter position, e.g. `fn f(x: Ordered)`, does **not**
+trigger monomorphization. The parameter `x` is a fat pointer — a pair
+of (data pointer, vtable pointer). Dispatch to methods uses the vtable.
+This is the analogue of Rust's `dyn Trait`:
+
+```osty
+fn byGeneric<T: Ordered>(x: T) { ... }       // monomorphized per T
+fn byInterface(x: Ordered) { ... }           // single body, vtable dispatch
+```
+
+`Error` retains its nominal type tag (§7.4) across both forms — the
+runtime tag is orthogonal to the monomorph/vtable choice.
+
+**Recursive generic types** are allowed:
+
+```osty
+pub struct Node<T> {
+    pub value: T,
+    pub next: Node<T>?,
+}
+```
+
+**Generic methods on structs and enums** are independent of the
+enclosing type's generics:
+
+```osty
+pub struct Stack<T> {
+    items: List<T>,
+
+    pub fn pushMapped<U>(mut self, xs: List<U>, f: fn(U) -> T) { ... }
+}
+```
+
+**Variance is invariant** on all type parameters. `List<Cat>` and
+`List<Animal>` are unrelated types even when `Cat` structurally
+satisfies `Animal`. Osty does not provide declaration-site or use-site
+variance annotations (no `in`/`out`, no wildcards).
+
+### 2.8 Reference vs Value Semantics
+
+| Type category | Semantics |
+|---|---|
+| Primitives | Value |
+| `String`, `Bytes` | Value (immutable) |
+| Tuples | Value (recursively) |
+| `struct`, `enum` | Reference |
+| `List`, `Map`, `Set` | Reference |
+| Function types (closures) | Reference |
+
+### 2.9 Equality and Hashing
+
+`==` and `!=` for primitive types use built-in comparison. For `struct`,
+`enum`, tuple, and collection types, `==` invokes the `Equal` interface.
+
+**Automatic derivation.** The compiler provides automatic implementations
+for `struct`, `enum`, and tuple types:
+
+- `Equal` is derived when all components implement `Equal`.
+- `Hashable` is derived when all components implement `Hashable`.
+
+Automatic `Hashable` derivation combines hashes of fields in declaration
+order.
+
+User-provided implementations override automatic ones for `struct` and
+`enum` types. **Built-in instances on primitives, `Option`, `Result`,
+and the collection types `List`/`Map`/`Set` cannot be overridden** —
+their definitions are structural and global. See §2.6.5 for the full
+table.
+
+`Ordered` is never automatically derived for `struct`, `enum`, or
+collection types.
+
+**Float NaN and reflexivity.** The general `Equal` contract requires
+reflexivity (`a.eq(a)` is always true). `Float` is the one deliberate
+exception: `NaN.eq(NaN)` is `false`, matching IEEE-754. Users writing
+generic code over `T: Equal` must account for this when `T` can be
+`Float`. `Float` as `Ordered` does *not* inherit this asymmetry — the
+total-ordering defined in §2.6.5 places `NaN` above all finite values,
+so `<`, `<=`, `>`, `>=` are well-defined on NaN. `-0.0 == 0.0` is
+`true`; `-0.0 < 0.0` is `false` under `==` but `true` under the total
+ordering exposed by `Ordered` (§2.6.5 footnote).
+
+`Float` is not `Hashable` (§2.6.5).
+
+**String equality is byte-wise.** `String.eq` compares the underlying
+UTF-8 bytes. Osty does not apply Unicode normalization implicitly; use
+`std.strings.normalize(form)` (NFC, NFD, NFKC, NFKD) when normalization
+is required. `String` `Ordered` is lexicographic over those bytes.
+
+Function types do not implement `Equal` or `Hashable`.
+
+Reference identity: `std.ref.same(a, b) -> Bool`.
+
+### 2.10 Mutability
+
+All bindings are immutable by default. `mut` allows reassignment and
+field mutation through that binding:
+
+```osty
+let x = 5                // immutable
+let mut y = 5            // mutable
+y = y + 1
+```
+
+A `let` binding to a reference type prevents reassignment and field
+mutation through that binding.
+
+### 2.11 Nullability
+
+No `null`. Use `Option<T>` / `T?`:
+
+```osty
+fn find(id: Int) -> User? { ... }
+```
+
+---

--- a/LANG_SPEC_v0.6/02a-type-inference.md
+++ b/LANG_SPEC_v0.6/02a-type-inference.md
@@ -1,0 +1,280 @@
+## 2a. Type Inference Algorithm
+
+This section specifies the algorithm that assigns a type to every
+expression, binding, and declaration. It complements §2 (type system)
+and §3 (declarations): §2 tells you *what* types exist, §3 tells you
+*where* annotations appear, and this section tells you *how* types are
+deduced when no annotation is present.
+
+The rules here are mechanically executed by the self-hosted checker
+in [`toolchain/check.osty`](../toolchain/check.osty). Each rule in the
+tables below names a specific function or line range in that file;
+readers are expected to cross-reference the two. Runtime observation
+is provided by `osty check --inspect FILE.osty` (§13 Tooling and
+[`internal/check/inspect.go`](../internal/check/inspect.go)), which
+emits one record per expression annotated with the rule applied.
+
+### 2a.1 Algorithm class
+
+**Bidirectional typing with local unification and monomorphization on
+generic instantiation.**
+
+- **Bidirectional.** Judgments come in two modes:
+  - `Γ ⊢ e ⇒ T` — *synth*: with no expected type, compute `T` from
+    `e` alone.
+  - `Γ ⊢ e ⇐ T` — *check*: with expected type `T` (a "hint" flowing
+    from the enclosing context), verify or refine `e`'s type.
+  A context `Γ` is the set of in-scope bindings plus the current
+  return-type obligation.
+- **Local unification.** Unification runs eagerly at each binary /
+  list / match / call site where two types must agree. There is **no**
+  global constraint graph; each `frontCheckUnify(Γ, t₁, t₂)` call
+  resolves on the spot or produces `Invalid` (the poisoned sentinel).
+- **Monomorphization.** Generic type parameters are resolved at each
+  call site by unifying actual argument types against parameter types.
+  Each resolved substitution list is recorded for the backend to emit
+  one specialized copy per distinct instantiation.
+
+The choice is deliberate: unification-only (Hindley-Milner) would
+require a global solver and forbid mid-file annotations as hints;
+constraint-based typing (as in Rust/Scala) would require an inference
+variable domain and solver. Osty keeps neither because:
+
+- Every public fn/struct/enum signature is **fully annotated**
+  (§3.2, §3.3). Hints are plentiful and always available for
+  top-level synth.
+- Literal polymorphism (§2.2) is handled by a sentinel type
+  (`UntypedInt` / `UntypedFloat`) that collapses on the way up.
+- Generic inference is confined to call sites (§2.7), where one
+  pass over parameter/argument pairs suffices.
+
+### 2a.2 Judgment forms
+
+```
+                         (synth)         (check)
+                         ───────         ───────
+    Γ ⊢ e ⇒ T       Γ ⊢ e ⇐ T
+```
+
+`T` is a member of the semantic type language described in §2:
+primitive, `Untyped {Int|Float}`, `Tuple`, `Optional`, `FnType`,
+`Named(Sym, Args)`, `TypeVar(Sym, Bounds)`, `Builder`, or the
+poisoned sentinel `Invalid`.
+
+Direction switches happen only at the boundaries listed in §2a.3.
+Inside a mode, the algorithm traverses the AST structurally.
+
+`Invalid` is the **unit of absorption** for diagnostics: once a
+sub-expression yields `Invalid`, every enclosing rule that inspects
+it short-circuits to `Invalid` without emitting a second error. This
+is how the checker avoids cascade noise on malformed input.
+
+### 2a.3 Mode switching
+
+The algorithm is in *check* mode whenever one of these contexts
+supplies a hint:
+
+| Site                         | Hint provided                  | Reference |
+|------------------------------|--------------------------------|-----------|
+| `let x: T = e`               | `T`                            | `frontCheckLetDecl` @ [check.osty:809](../toolchain/check.osty) |
+| `fn f(...) -> T { e }`       | `T` at the body's tail         | `frontCheckFnDecl` @ [check.osty:854](../toolchain/check.osty) |
+| `f(..., e_i, ...)` (typed fn)| `params[i]` after substitution | `frontCheckCallSig` @ [check.osty:2420](../toolchain/check.osty) |
+| `if c { e₁ } else { e₂ }`    | parent hint flows to both      | `frontCheckIfHint` @ [check.osty:2131](../toolchain/check.osty) |
+| `match s { p => e, … }`      | parent hint flows to each arm  | `frontCheckMatchHint` @ [check.osty:2734](../toolchain/check.osty) |
+| `[e₁, e₂, …]` with `List<T>` | element hint `T`               | `frontCheckList` @ [check.osty:2052](../toolchain/check.osty) |
+| `(e₁, e₂, …)` with tuple hint| element `i`'s hint             | `frontCheckTuple` @ [check.osty:2094](../toolchain/check.osty) |
+| `S { f: e, … }` (struct lit) | field's declared type          | `frontCheckStructLitHint` @ [check.osty:2661](../toolchain/check.osty) |
+| `|params| body` with fn hint | params + return from fn type   | `frontCheckClosure` @ [check.osty:3868](../toolchain/check.osty) |
+| block tail expression        | block's hint                   | `frontCheckBlockHint` @ [check.osty:1664](../toolchain/check.osty) |
+| parenthesized expression     | parent hint passthrough        | `frontCheckExprHint` @ [check.osty:1872](../toolchain/check.osty) |
+
+Everywhere else the algorithm is in *synth* mode. The top-level
+dispatcher is [`frontCheckExprHint`](../toolchain/check.osty) at
+`check.osty:1840` — it accepts an optional hint and routes to the
+rule for the AST node kind.
+
+### 2a.4 Rules for expressions
+
+Each rule is keyed by AST node kind. Column **Rule** is the label
+emitted by `--inspect`. Column **Ref** points at `check.osty`.
+
+| Rule            | Node         | Synth / Check behavior                                                                                                                                                         | Ref |
+|-----------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----|
+| `LIT-INT`       | `IntLit`     | Synth `UntypedInt`. If hint is `Float`, coerce to `Float`.                                                                                                                     | 1845 |
+| `LIT-FLOAT`     | `FloatLit`   | Synth `UntypedFloat`. If hint is `Float`, coerce to `Float`.                                                                                                                   | 1851 |
+| `LIT-STRING`    | `StringLit`  | Synth `String`. Interpolation segments are each checked `⇐ Display` (§17).                                                                                                      | 1857 |
+| `LIT-BOOL`      | `BoolLit`    | Synth `Bool`.                                                                                                                                                                  | 1860 |
+| `LIT-CHAR`      | `CharLit`    | Synth `Char`.                                                                                                                                                                  | 1863 |
+| `LIT-BYTE`      | `ByteLit`    | Synth `Byte`.                                                                                                                                                                  | 1866 |
+| `VAR`           | `Ident`      | Synth = lookup of `name` in `Γ`. For enum variants, the hint disambiguates the owner when shadowed.                                                                            | 1869, 1930 |
+| `PAREN`         | `ParenExpr`  | Pass hint through, result = inner.                                                                                                                                             | 1872 |
+| `BLOCK`         | `Block`      | Recurse into statements; tail expr gets block's hint; block type = tail type or `()`.                                                                                           | 1875, 1664 |
+| `UNARY`         | `UnaryExpr`  | Synth operand; result from op (`!`→Bool, `-`→numeric, `~`→integer).                                                                                                            | 1878, 1961 |
+| `BINOP`         | `BinaryExpr` | Synth both operands; `frontCheckUnify` on them; result from op table.                                                                                                          | 1881, 1990 |
+| `IF`            | `IfExpr`     | Check `cond ⇐ Bool`. Check each branch under parent hint. Unify branch types for the whole-expr type.                                                                           | 1884, 2131 |
+| `IF-LET`        | `IfExpr`     | Same as `IF`, but additionally: synth RHS, bind pattern per §4.8, then check `then` under parent hint.                                                                          | 2131 |
+| `CALL`          | `CallExpr`   | Synth callee → obtain `FnSig`. Resolve generic substitution against argument types. Check each arg under its substituted parameter type. Record instantiation. Result = return type. | 1887, 2164, 2420 |
+| `METHOD-CALL`   | `CallExpr` on `FieldExpr` | Synth receiver → method lookup → treat as `CALL` with receiver as first arg.                                                                                        | 2164 |
+| `LIST`          | `ListExpr`   | Hint shape `List<T>`: check each elem `⇐ T`. Else synth first elem, then `frontCheckUnify` rest against it; element type = join.                                                | 1890, 2052 |
+| `TUPLE`         | `TupleExpr`  | Hint shape `(T₁,…)`: check elem `i` `⇐ Tᵢ`. Else synth each; result = tuple of synth'd elements.                                                                               | 1893, 2094 |
+| `MAP`           | `MapExpr`    | Hint `Map<K,V>`: check keys `⇐ K`, values `⇐ V`. Else synth first entry and unify.                                                                                               | 1896 |
+| `RANGE`         | `RangeExpr`  | Synth endpoints, unify to a numeric type, result = `Range<T>`.                                                                                                                 | 1899, 2108 |
+| `FIELD`         | `FieldExpr`  | Synth receiver → `frontCheckFieldLookup` on owner — result = field type with receiver substitutions applied. `?.` on `T?` unwraps Optional and re-wraps result.                 | 1902, 2603 |
+| `INDEX`         | `IndexExpr`  | Synth collection; branch by kind: `List<T>` → `T`, `Map<K,V>` → `V?`, `String` → `Char`.                                                                                         | 1905, 2631 |
+| `MATCH`         | `MatchExpr`  | Synth scrutinee. For each arm, bind pattern against scrutinee type, then check `body ⇐ hint`. Unify arm types. Diag on non-exhaustive patterns (E0731).                          | 1908, 2734 |
+| `STRUCT-LIT`    | `StructLit`  | Hint or spelled type → resolve Named. Check each field value `⇐ declared field type`. Diag on missing/duplicate fields.                                                         | 1911, 2661 |
+| `CLOSURE`       | `ClosureExpr`| Parameter types come from (1) annotation if present, else (2) `fn`-hint param types, else (3) left as `Invalid`. Body synth'd or checked against hint return.                    | 1914, 3868 |
+| `QUESTION`      | `QuestionExpr` | `e?` on `T?` → `T` after propagating `None` to caller. On `Result<T,E>` → `T` after propagating `Err` to caller.                                                                | 1917 |
+| `TURBOFISH`     | `TurbofishExpr`| Pass through base synth; explicit type args seeded into `RECORD-INSTANTIATION`.                                                                                               | 1920 |
+| `CAST`          | `as`-expr    | Check source is convertible per §2.2; result = target.                                                                                                                         | (in exprHint fallthrough) |
+| `BUILDER`       | `Type.builder()` chain | Auto-derived — see §3.4. `.field(v)` returns `Builder<T>` with field added to set. `.build()` returns `T` and diag on missing required.                               | field lookup @ 1020 |
+
+### 2a.5 Rules for statements and declarations
+
+Statement-level rules feed context into the expression rules above.
+Their entry is `frontCheckStmt` @ `check.osty:1707` and
+`frontCheckLetDecl` @ `check.osty:809`.
+
+| Rule        | Node           | Behavior                                                                                                                                | Ref |
+|-------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------|-----|
+| `LET`       | `LetStmt` / `LetDecl` | With annotation `T`: check `rhs ⇐ T`, bind `pattern: T`. Without: synth `rhs ⇒ T'`, default untyped literals, bind `pattern: T'`.  | 809  |
+| `ASSIGN`    | `AssignStmt`   | Synth LHS and RHS; require LHS is lvalue and mutable; `frontCheckIsAssignable` on (LHS, RHS).                                            | 1707 |
+| `RETURN`    | `ReturnStmt`   | Check value `⇐ env.returnType`. Empty return requires `env.returnType == ()`.                                                          | 1707 |
+| `FOR`       | `ForStmt`      | Synth iterable; bind loop variable; body is statement (no result type).                                                                  | 1707 |
+| `BREAK`, `CONTINUE` | —    | Produce `Never`; require enclosing loop.                                                                                                 | 1707 |
+| `FN-DECL`   | `FnDecl`       | Build `Γ` with params typed from signature; check body `⇐ returnType`.                                                                  | 854  |
+| `STRUCT-DECL`, `ENUM-DECL`, `INTERFACE-DECL`, `TYPE-ALIAS-DECL` | — | Pass 1 (`frontCheckCollectDecls` @ 369) registers shape; Pass 2 ignores (only signatures, no bodies). | 369  |
+
+### 2a.6 Untyped-literal defaulting
+
+Untyped literals are sentinel types that collapse on the way up:
+
+1. If a check-mode hint names a compatible concrete type, the literal
+   takes that type.
+2. If a binary op unifies `UntypedInt` with a concrete integer type
+   `T`, both sides become `T`.
+3. If nothing fixes the type before the enclosing statement completes,
+   default `UntypedInt` → `Int` and `UntypedFloat` → `Float` (§2.2
+   last paragraph).
+
+This is the only place the checker inserts a default. Everywhere else,
+an unresolved type at a statement boundary is a diagnostic.
+
+### 2a.7 Generic instantiation
+
+Synth of a `CALL` expression with a polymorphic callee:
+
+1. Extract the callee's `FnSig` including generic parameter list
+   `[X₁, …, Xₙ]` and bounds.
+2. For each positional argument `aᵢ`, synth its type `Aᵢ`, then unify
+   `Aᵢ` against the declared parameter type `Pᵢ` treating each `Xⱼ`
+   as a free variable. Extend the substitution `σ` with each `Xⱼ ↦ Tⱼ`
+   discovered.
+3. If the enclosing context provides a return-type hint, unify it
+   against the declared return type under `σ`, possibly fixing any
+   `Xⱼ` not pinned by arguments.
+4. If any `Xⱼ` is still unresolved, it is either underdetermined
+   (diag E0724) or intentionally left free when the call site does
+   not require concretization.
+5. Record `(callSite → [T₁, …, Tₙ])` in `Result.Instantiations`.
+   Backends read this map to emit one monomorphized copy per distinct
+   tuple of type arguments.
+
+Bounds (`T: Interface`) are checked structurally via
+`frontCheckSatisfiesInterface` @ `check.osty:1518`. No method-level
+dispatch: interfaces are satisfied by shape.
+
+### 2a.8 Unification
+
+`frontCheckUnify(Γ, a, b)` is a shallow, local routine (definition at
+`check.osty:1634`). It accepts two type strings and returns their
+meet:
+
+- Identical types: return the type.
+- One side `Invalid`: return `Invalid` (absorption).
+- One side `Untyped*`, the other compatible concrete: return concrete.
+- Both `Untyped*` of the same flavor: return the wider untyped.
+- `Never` on one side: return the other.
+- Otherwise: `Invalid` (the caller is expected to have emitted a
+  diagnostic).
+
+No substitution accumulation; no occurs check; no recursive
+constraint deferral. The algorithm is correct precisely because
+generic resolution (§2a.7) always happens at a single, well-scoped
+call site, and every other use of `frontCheckUnify` operates on
+already-substituted types.
+
+### 2a.9 Diagnostics interaction
+
+The checker never throws. Every type error produces a `Diagnostic`
+(§ERROR_CODES.md). `Invalid` is used to mark the erroneous node, and
+the absorption rule (§2a.2) ensures exactly one diagnostic per root
+cause — cascades are silenced by the sentinel.
+
+### 2a.10 Runtime observation (`osty check --inspect`)
+
+`osty check --inspect FILE.osty` runs the normal checker and then
+walks the AST a second time, emitting one record per expression:
+
+```
+LINE:COL-LINE:COL  RULE          Node            Type         [← hint=HINT]  [notes]
+```
+
+Flags:
+
+- `--json` (global) produces NDJSON — one record per line — suitable
+  for machine consumption.
+- `--explain` (global) is unrelated; that flag prints diagnostic code
+  documentation.
+
+The inspector does not re-run inference. It reads
+`Result.Types` / `LetTypes` / `SymTypes` / `Instantiations` already
+computed by the checker and classifies each AST node by the rule that
+produced its recorded type. Implementation:
+[`internal/check/inspect.go`](../internal/check/inspect.go).
+
+Example:
+
+```
+$ osty check --inspect examples/basic.osty
+1:5-1:10   LET           let             Int         (from annotation)
+1:13-1:14  LIT-INT       1               Int         ← hint=Int
+2:5-2:10   LET           let             Float       (synth)
+2:13-2:22  BINOP         2.0 + x         Float
+2:13-2:16  LIT-FLOAT     2.0             UntypedFloat → Float
+2:19-2:20  VAR           x               Int
+2:19-2:20  CALL          f(1, "hi")      List<String>
+                         instantiated T=String
+```
+
+Use this when:
+
+- You need to debug why a literal resolved to `Int` instead of
+  `Float`.
+- You want to see what type argument was chosen at a generic call.
+- You are verifying that the algorithm in §2a.3–§2a.7 is actually
+  what the checker does on your source.
+
+### 2a.11 Known limitations
+
+- **No row polymorphism.** Struct types are nominal; there is no
+  inference of anonymous record types.
+- **No higher-rank polymorphism.** Closures stored in fields must be
+  monomorphic at their declaration site.
+- **Untyped defaulting is local.** If a value flows out of a block
+  without a context, it defaults immediately — it cannot be pinned
+  retroactively by a later use. This is by design; it matches the
+  order in which the checker walks the AST and matches user intuition.
+
+These are deliberate trade-offs. Lifting any of them would require
+changing the algorithm class (for example, to constraint-based), and
+would propagate to every backend and to the LSP.
+
+### 2a.12 Pointers
+
+- Spec: this file.
+- Reference implementation: [`toolchain/check.osty`](../toolchain/check.osty).
+- Go-side adapter (no inference logic): [`internal/check/host_boundary.go`](../internal/check/host_boundary.go).
+- Observation tool: [`internal/check/inspect.go`](../internal/check/inspect.go), invoked via `osty check --inspect`.
+- Diagnostic codes produced: `E0300`–`E0399` (types/patterns), `E0700`–`E0799` (type-check).
+- Change history: see §18.

--- a/LANG_SPEC_v0.6/03-declarations.md
+++ b/LANG_SPEC_v0.6/03-declarations.md
@@ -1,0 +1,1163 @@
+## 3. Declarations
+
+### 3.1 Functions
+
+```osty
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn greet(name: String) {
+    println("hi, {name}")
+}
+
+fn connect(host: String, port: Int = 80, timeout: Int = 30) -> Result<Conn, Error> {
+    ...
+}
+
+pub fn loadConfig(path: String) -> Result<Config, Error> {
+    let text = fs.readToString(path)?
+    let cfg: Config = json.parse(text)?
+    Ok(cfg)
+}
+```
+
+- Parameter types required.
+- Return type required unless `()`.
+- The body is a block expression; the final expression is the return.
+- `return expr` for early return.
+- No function overloading, no named arguments.
+
+**Default arguments and keyword arguments.** Trailing parameters may
+have default values, and parameters with defaults may be passed by
+name:
+
+```osty
+fn connect(host: String, port: Int = 80, timeout: Int = 30) -> Result<Conn, Error>
+
+connect("api.com")                            // defaults
+connect("api.com", 443)                       // positional
+connect("api.com", 443, 60)                   // positional
+connect("api.com", timeout: 60)               // keyword skips port
+connect("api.com", port: 443, timeout: 60)    // both keyword
+connect("api.com", timeout: 60, port: 443)    // keywords in any order
+```
+
+Rules:
+- Only trailing parameters may have defaults; once defaulted, all
+  following parameters must also have defaults.
+- Defaults must be `DefaultLiteral`s: numeric, string, char, byte, bool,
+  `None`, `Ok(...)`, `Err(...)`, empty collection literals (`[]`, `{:}`),
+  `()`, struct literals whose fields are `DefaultLiteral`s, or `const fn`
+  calls allowed by §3.1.1.
+- Defaults are evaluated at call time at each call site.
+- Required parameters (no default) are **positional only**.
+- Parameters with defaults may be passed either **positionally** or
+  **by keyword**. Keyword form is `name: value`.
+- Positional arguments must precede all keyword arguments.
+- Each parameter may be supplied at most once.
+
+Style note: more than two trailing defaults usually reads better as an
+option struct, especially when callers would benefit from constructing
+and reusing configuration values.
+
+**Diagnostic template — positional after keyword.** The compiler emits
+a fixed-form diagnostic when a positional argument follows a keyword
+argument (resolves G7). Tooling (LSP, formatter) may rely on this
+shape:
+
+```
+error: positional argument after keyword argument
+  --> foo.osty:10:28
+   |
+10 |   connect("api.com", port: 443, 60)
+   |                                 ^^ positional argument here
+   |                      -------- previous keyword argument
+   = help: convert the trailing positional argument to keyword form,
+           or move all keyword arguments to the end of the call.
+```
+
+#### 3.1.1 `const fn` — Compile-Time Evaluable Functions
+
+A function declared `const fn` (optionally `pub const fn`) is evaluable at
+compile time. The sole motivating use case is composition of values
+usable as `DefaultLiteral` (G21): a `const fn` call whose arguments are
+themselves `DefaultLiteral`s may appear in a default-argument position.
+
+```osty
+const fn kb(n: Int) -> Int { n * 1024 }
+const fn defaultBuffer() -> Int { kb(8) }
+
+pub fn connect(host: String, buffer: Int = defaultBuffer()) -> Result<Conn, Error> {
+    ...
+}
+```
+
+The body of a `const fn` is restricted to the set below. A construct
+outside this set is `E0766`.
+
+**Capability matrix.**
+
+| Construct                                                | Allowed |
+|----------------------------------------------------------|---------|
+| Literal values (numeric, string, char, byte, bool, `None`, `()`) | yes |
+| Unary `-` on numeric literals                            | yes |
+| Arithmetic `+ - * / %` on `Int` / `Float` operands       | yes |
+| Comparison `< <= > >= == !=`                             | yes |
+| Boolean `&& \|\| !`                                      | yes |
+| `let` binding (immutable, single-assignment)             | yes |
+| Parameter reference (own formals)                        | yes |
+| Reference to a top-level `pub? let` of `DefaultLiteral` type | yes |
+| Direct call to another `const fn` (acyclic; see below)   | yes |
+| Struct literal with all-const fields                     | yes |
+| Enum variant construction with all-const payloads (incl. `Some`/`Ok`/`Err`) | yes |
+| Tuple literal with all-const elements                    | yes |
+| List / Map literal with all-const elements               | yes |
+| Parenthesized / block expression whose result is const   | yes |
+| `if` / `match` / `for` / `loop` / `while`                | **no** |
+| `return` statement                                       | **no** (use final-expression form) |
+| `?` operator                                             | **no** |
+| `defer`                                                  | **no** |
+| Recursion, direct or through a `const fn` cycle          | **no** |
+| String concatenation `+` or interpolation `"{expr}"`     | **no** |
+| Closure / lambda expression                              | **no** |
+| Method call, operator via `#[op(...)]`                   | **no** |
+| `let mut`, assignment, compound assignment               | **no** |
+| FFI symbols from `use go "..."` blocks                   | **no** |
+| `panic` / `todo` / `abort` / `unreachable`               | **no** |
+| Generic type parameters on the `const fn` itself         | **no** |
+| I/O (`println`, `std.fs.*`, etc.)                        | **no** |
+
+**Additional rules.**
+
+- The call graph of `const fn` declarations must be acyclic. A cycle
+  — direct or transitive — is `E0767`, reported at the resolver pass
+  before type checking.
+- `const fn` may not declare type parameters (`E0768`). If a type-
+  generic compile-time value is needed, declare per-type `const fn`s
+  or fall back to a runtime `pub let` (monomorphization of a generic
+  `const fn` would require a const-evaluation engine Osty does not
+  provide).
+- The return type of a `const fn` must be a concrete type whose values
+  are themselves `DefaultLiteral`-compatible under the extended
+  definition (numeric / string / char / byte / bool / `None` / `()` /
+  struct whose fields are such / enum variant whose payloads are such /
+  tuple / list / map of such).
+- A `const fn` call in any position other than a default-argument
+  expression is evaluated at the call site exactly like an ordinary
+  function call. The `const` prefix constrains the **body** and
+  enables **default-argument use**; it does not force constant-
+  folding in runtime call sites.
+
+**Forward compatibility.** The FORBID rows above are the stable set for
+v0.5. Relaxing any of them is an additive, semver-observable change —
+it enables source that previously did not compile. Such changes must
+ship under a normal minor version bump; no FORBID row silently flips
+to ALLOW inside a v0.5.x patch release.
+
+### 3.2 Variables
+
+```osty
+let x = 5                        // type inferred
+let y: Int = 5                   // type annotated
+let mut z = 0                    // mutable
+let (a, b) = makeTuple()         // tuple destructuring
+let (_, b) = makeTuple()         // wildcard
+let User { name, age } = getUser()   // struct destructuring
+let User { name, .. } = getUser()    // ignore rest
+```
+
+Patterns in `let`:
+- Identifier bindings
+- Tuple destructuring
+- Struct destructuring (field shorthand, `..` for rest)
+- Wildcard `_`
+
+Enum-variant patterns are not permitted in `let`; use `match` or
+`if let`.
+
+Top-level `let` may be marked `pub`:
+
+```osty
+pub let MAX_USERS = 10000
+```
+
+### 3.3 Multiple Assignment
+
+```osty
+let mut a = 1
+let mut b = 2
+
+(a, b) = (b, a)                  // swap
+(a, _) = makePair()              // assign first only
+```
+
+### 3.4 Structs
+
+```osty
+pub struct User {
+    pub name: String,
+    pub age: Int,
+    email: String,
+
+    pub fn new(name: String, email: String) -> User {
+        User { name, age: 0, email }
+    }
+
+    pub fn greet(self) -> String {
+        "hi, {self.name}"
+    }
+
+    fn setAge(mut self, age: Int) {
+        self.age = age
+    }
+}
+```
+
+A method whose first parameter is `self` or `mut self` is an instance
+method. Methods without `self` are associated functions.
+
+Fields, methods, and the struct itself may each be marked `pub`
+independently.
+
+**Field initialization shorthand:** `{ name }` means `{ name: name }`
+when a binding of that name is in scope.
+
+**Update syntax.** `..expr` copies fields from an existing value:
+
+```osty
+let user = User { name: "alice", age: 30, email: "a@x.com" }
+let older = User { ..user, age: 31 }
+let rebranded = User { ..user, email: "new@x.com", name: "Alice" }
+
+let renamed = user { name: "Alice" }       // shorthand for User { ..user, name: "Alice" }
+```
+
+The `..expr` form must appear once per struct literal. Fields explicitly
+listed override copied values. All fields must either be listed or
+supplied by the spread source.
+
+The receiver shorthand `value { field: newValue }` is accepted when
+`value` is an in-scope struct-typed binding; it desugars to
+`Type { ..value, field: newValue }`.
+
+**Partial declarations.** A struct may be declared across multiple files
+within the same package. Fields appear in exactly one declaration;
+methods may be spread across any number of declarations.
+
+```osty
+// user.osty
+pub struct User {
+    pub name: String,
+    pub age: Int,
+    email: String,
+
+    pub fn greet(self) -> String { ... }
+}
+
+// user_admin.osty (same package)
+pub struct User {
+    pub fn promote(mut self) { ... }
+    pub fn demote(mut self) { ... }
+}
+```
+
+Rules:
+- All declarations must agree on type parameters and visibility.
+- Exactly one declaration may contain fields.
+- Method names must be unique across all declarations.
+- Cross-package extension is not permitted.
+- **Annotations are scoped to the declaration that physically contains
+  them.** Because each field appears in exactly one declaration and each
+  method name appears in exactly one declaration, an annotation has a
+  single, unambiguous attachment site. The compiler does not synthesize
+  cross-file annotation merging.
+
+The same rules apply to `enum`.
+
+**Auto-derived members.** The compiler automatically provides on every
+`struct`:
+
+1. `Type.default() -> Type` — available when every field has either an
+   explicit default or a zero-value. `T?` defaults to `None`;
+   collections default to empty. If any field lacks both, `default()`
+   is not generated.
+
+2. `Type.builder() -> Builder<Type>` — available when every private
+   field has an explicit default. The generated builder exposes setters
+   only for `pub` fields; private fields are filled from their defaults
+   at `.build()` time.
+
+3. `value.toBuilder() -> Builder<Type>` — available on any struct where
+   `builder()` is generated. Returns a builder preloaded with all
+   current field values.
+
+The builder's `.build()` method requires that every `pub` field without
+a default has been set. This is **enforced at compile time** — an
+attempt to call `.build()` before all required fields are set produces
+a dedicated diagnostic that names the missing fields:
+
+```
+error: cannot call build(): required fields not set
+  --> foo.osty:42:22
+   |
+42 |   HttpConfig.builder().build()
+   |                        ^^^^^ missing: url
+   = help: set with `.url(<value>)` before calling `.build()`.
+```
+
+The compiler tracks set/unset status through internal type parameters
+on `Builder<T>`. These parameters are deliberately **not exposed** in
+the language surface: users see only `Builder<T>` in error messages and
+cannot construct, name, or destructure them manually. A `Builder<T>` is
+therefore usable only via the generated API — chained `.fieldName(...)`
+calls terminated by `.build()`. This design is the v0.3 resolution of
+gap G9.
+
+```osty
+pub struct HttpConfig {
+    pub url: String,                          // required pub
+    pub method: String = "GET",               // optional pub
+    pub timeout: Int = 30,                    // optional pub
+    headers: Map<String, String> = {:},       // private, has default
+}
+
+let cfg = HttpConfig.builder()
+    .url("api.com")
+    .build()
+
+let custom = HttpConfig.builder()
+    .url("api.com")
+    .method("POST")
+    .timeout(60)
+    .build()
+
+let variant = cfg.toBuilder()
+    .timeout(120)
+    .build()
+
+HttpConfig.builder().build()
+// ERROR: url was not set
+```
+
+Visibility rules:
+- Setters exist only for `pub` fields.
+- A struct whose private fields lack defaults has no auto-generated
+  builder.
+
+```osty
+pub struct AuthToken {
+    value: String,        // private, no default
+    issuer: String,       // private, no default
+
+    pub fn signAndCreate(payload: String, key: Key) -> Self {
+        Self { value: sign(payload, key), issuer: key.owner }
+    }
+}
+
+AuthToken.builder()   // ERROR: no builder generated
+```
+
+**Override.** If the user defines `default`, `builder`, or `toBuilder`
+on the type, the user's definition replaces the auto-generated one.
+
+### 3.5 Enums
+
+```osty
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
+
+    pub fn isOk(self) -> Bool {
+        match self {
+            Ok(_) -> true,
+            Err(_) -> false,
+        }
+    }
+}
+
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+    RGB(UInt8, UInt8, UInt8),
+}
+
+pub enum HttpStatus: Int {
+    OK = 200,
+    NotFound = 404,
+}
+```
+
+Variants:
+- Bare: `Red`
+- Tuple-like: `RGB(UInt8, UInt8, UInt8)`
+- Integer-discriminated: payload-free variants in an enum with an integer
+  representation may assign explicit integer values.
+
+Variant access: bare name within the same package, qualified from other
+packages (`Color.Red`).
+
+An enum with an explicit integer representation auto-derives
+`.discriminant() -> Int` and `.fromDiscriminant(n: Int) -> Self?`.
+Payload variants may not assign discriminants (`E0721`).
+
+### 3.6 Interfaces
+
+```osty
+pub interface Writer {
+    fn write(self, data: Bytes) -> Result<Int, Error>
+    fn flush(self) -> Result<(), Error>
+}
+```
+
+See §2.6.
+
+### 3.7 Type Aliases
+
+```osty
+type UserMap = Map<String, List<User>>
+type Handler = fn(Request) -> Result<Response, Error>
+
+pub type Pair<T> = (T, T)
+```
+
+Aliases are transparent; they create no new type.
+
+### 3.8 Annotations
+
+Osty has a fixed, compiler-recognized set of annotations. Applying any
+other annotation is a compile error; there is no user-extension
+mechanism. The complete set is:
+
+**User-facing annotations.**
+
+| Annotation | Applies to | Purpose |
+|---|---|---|
+| `#[json(...)]` | struct fields, enum variants | Customize JSON encoding/decoding (§10.8) |
+| `#[deprecated(...)]` | `fn`, `struct`, `enum`, `interface`, `type`, top-level `let`, struct/enum methods, struct fields, enum variants | Emit a warning when the item is referenced |
+| `#[op(...)]` | struct/enum methods | Opt-in overload for the bounded arithmetic operator set: `+ - * / %` binary and `-` unary (§14.2) |
+| `#[cfg(...)]` | top-level declarations, struct/enum methods, struct fields, enum variants | Conditional compilation pre-resolve filter; keys are `os`, `target`, `arch`, and `feature`, with `all` / `any` / `not` composition (§14.3, §18 G29) |
+| `#[test]` | top-level zero-arity `fn` declarations | Inline test function collected by `osty test` and excluded from production builds (§11) |
+| `#[vectorize]` | top-level `fn` declarations, struct/enum methods | **Default-on as of v0.6** — no annotation needed for the hint. Bare `#[vectorize]` is a no-op; `#[vectorize(scalable, predicate, width = N)]` refines strategy (§3.8.3) |
+| `#[no_vectorize]` | top-level `fn` declarations, struct/enum methods | Opt out of the default vectorize hint. Restores per-iteration safepoint polls (v0.6 A5.2) |
+| `#[parallel]` | top-level `fn` declarations, struct/enum methods | Hint: every load/store in the body tagged with `!llvm.access.group`, every loop's metadata references it via `llvm.loop.parallel_accesses` to bypass alias analysis (v0.6 A6) |
+| `#[unroll]` | top-level `fn` declarations, struct/enum methods | Hint: `llvm.loop.unroll.enable` on every loop in the body; `#[unroll(count = N)]` forces a specific unroll factor (v0.6 A7) |
+| `#[inline]` / `#[inline(always)]` / `#[inline(never)]` | top-level `fn` declarations, struct/enum methods | LLVM `inlinehint` / `alwaysinline` / `noinline` fn attribute (v0.6 A8) |
+| `#[hot]` / `#[cold]` | top-level `fn` declarations, struct/enum methods | LLVM `hot` / `cold` fn attribute + `.text.hot` / `.text.unlikely` section placement (v0.6 A9) |
+| `#[target_feature(f1, f2, ...)]` | top-level `fn` declarations, struct/enum methods | LLVM `"target-features"="+f1,+f2"` fn attribute — per-function CPU feature override (v0.6 A10) |
+| `#[noalias]` / `#[noalias(p1, p2)]` | top-level `fn` declarations, struct/enum methods | Promise pointer params do not alias — emits LLVM `noalias` param attr (v0.6 A11) |
+| `#[pure]` | top-level `fn` declarations, struct/enum methods | Assert no side effects — emits LLVM `readnone` fn attr, unlocks CSE/hoisting (v0.6 A13) |
+
+`const fn` is a declaration prefix, not an annotation; see §3.1.1.
+
+**Runtime-only annotations** (privileged packages only — see §19.2 and §19.6).
+
+| Annotation | Applies to | Purpose |
+|---|---|---|
+| `#[intrinsic]` | `fn` declarations | Body is supplied by the lowering layer; source body must be empty (§19.5). Generic intrinsics participate in monomorphization. |
+| `#[pod]` | `struct` declarations | Requests the checker to verify the struct's `Pod` shape (§19.4); rejection is `E0771`. |
+| `#[repr(c)]` | `struct` declarations | Forces C ABI field order, padding, and alignment (§19.6). |
+| `#[export("name")]` | top-level `fn` declarations | Emit with the exact symbol name `name`, disabling Osty mangling (§19.6). |
+| `#[c_abi]` | top-level `fn` declarations | Use the platform C calling convention (§19.6). |
+| `#[no_alloc]` | `fn` and method declarations | Forbid managed allocation in the body, and forbid any direct or transitive call to a function that allocates (§19.6.1). |
+
+Applying any runtime-only annotation outside a privileged package is
+`E0770`, not the generic unknown-annotation error.
+
+Syntax is defined in §1.9. Both key/value (`name = value`) and bare-flag
+(`name`) argument forms are accepted.
+
+#### 3.8.1 `#[json]`
+
+Valid on `struct` fields and `enum` variants.
+
+| Arg | Form | Default | Effect |
+|---|---|---|---|
+| `key` | `key = "<name>"` | source-level name | Rename the JSON key used for this field or variant tag |
+| `skip` | flag (or `skip = true`) | absent | Exclude this field/variant from both encoding and decoding |
+| `optional` | flag (or `optional = true`) | absent | For `T?` fields only — omit the JSON key when the value is `None` (default behavior emits `"key": null`) |
+
+Multiple arguments may be combined:
+
+```osty
+pub struct User {
+    #[json(key = "user_id")]
+    pub userId: String,
+
+    #[json(key = "email_address")]
+    pub email: String,
+
+    #[json(key = "phone", optional)]
+    pub phone: String?,
+
+    #[json(skip)]
+    cachedHash: Int,
+}
+
+pub enum Shape {
+    #[json(key = "circle")]
+    Circle(Float),
+
+    #[json(key = "rect")]
+    Rectangle(Float, Float),
+}
+```
+
+Constraints:
+- `optional` is valid only on fields of type `T?`. Using it on a non-
+  optional field is a compile error.
+- `skip` is mutually exclusive with `key` and `optional` (skipped
+  fields/variants have no JSON identity).
+- Applying `#[json(...)]` outside a struct field or enum variant is a
+  compile error.
+
+#### 3.8.2 `#[deprecated]`
+
+Valid on any named declaration listed in the §3.8 table — including
+struct fields and enum variants.
+
+| Arg | Form | Default | Effect |
+|---|---|---|---|
+| `since` | `since = "<version>"` | none | Version string; shown in the warning |
+| `use`   | `use = "<name>"` | none | Name of the recommended replacement |
+| `message` | `message = "<text>"` | none | Free-form explanation shown in the warning |
+
+All arguments are optional; any combination is permitted. Referencing
+a deprecated item produces a compiler warning that reproduces the
+supplied arguments. The warning is anchored at the use-site; for
+deprecated **fields**, this means each read or write of the field;
+for deprecated **variants**, each construction or pattern match.
+
+```osty
+#[deprecated(since = "0.5", use = "loginV2")]
+pub fn login(user: String, pass: String) -> Result<Session, Error> { ... }
+
+#[deprecated(message = "replaced by ConfigV2")]
+pub type LegacyConfig = Map<String, String>
+
+#[deprecated]
+pub let API_BASE_URL = "https://old.example.com"
+
+pub struct User {
+    #[deprecated(since = "0.7", use = "primaryEmail")]
+    pub email: String,
+    pub primaryEmail: String,
+}
+
+pub enum Status {
+    Active,
+    #[deprecated(message = "use Inactive(reason: \"unknown\") instead")]
+    Inactive,
+    Banned(String),
+}
+```
+
+Deprecation warnings may be promoted to errors by build configuration;
+they are not errors by default. Deprecation does **not** propagate
+transitively: annotating a type as `#[deprecated]` does not deprecate
+its methods, its fields, or types that reference it. Each target
+carries its own annotation.
+
+#### 3.8.3 Vectorize (default on)
+
+**v0.6 A5.2 flip: vectorize is the default.** Every function's user-
+written `for` loops receive `!llvm.loop !N` metadata with
+`!"llvm.loop.vectorize.enable", i1 true`, and every function opts out
+of the per-iteration GC loop safepoint poll, *without* the user typing
+anything. This applies across the whole program — the stdlib, user
+code, even compiler-synthesized surface (see §3.8.6 for the GC
+contract that makes this safe).
+
+The user types an annotation only to deviate from the default:
+
+- `#[no_vectorize]` — opt out entirely. Restores per-iteration safepoint
+  polls and suppresses the loop metadata. For long-running worker
+  loops that must yield to GC mid-loop.
+- `#[vectorize(scalable, predicate, width = N)]` — keep the default
+  but refine the strategy. Bare `#[vectorize]` is accepted as a no-op
+  (documents intent) and is equivalent to typing nothing.
+
+Vectorize is a *hint*, not a guarantee. LLVM's loop vectorizer still
+performs legality and profitability analysis; loops the cost model
+rejects simply run scalar. The annotation set does not introduce new
+syntax, does not change function types, and does not affect observable
+behavior on correct programs — an unvectorized build produces the
+same outputs as a vectorized one.
+
+| Arg | Form | Default | LLVM property | Effect |
+|---|---|---|---|---|
+| `scalable` | flag | absent | `llvm.loop.vectorize.scalable.enable=true` | Prefer scalable vector ISAs (ARM SVE, RISC-V RVV) over fixed-width (NEON) on targets that support both. macOS/iOS aarch64 do not expose SVE, so Apple Silicon falls back to fixed-width NEON even when this hint is present |
+| `predicate` | flag | absent | `llvm.loop.vectorize.predicate.enable=true` | Enable tail folding — process trip counts that are not a multiple of the vector width via masked ops instead of a scalar tail loop. Biggest win on SVE / AVX-512 / RVV with native mask registers |
+| `width` | `width = <1..1024>` | compiler chooses | `llvm.loop.vectorize.width, i32 N` | Force a specific vectorization factor. Can unlock AVX-512 ZMM registers on Intel, where the default cost model otherwise prefers 256-bit YMM because of historical downclocking. The LLVM cost model may still override this hint; use `-mllvm -force-vector-width=N` at the build-time flag level when the override is required. Future target profiles may inject that flag for AVX-512 server presets |
+
+```osty
+// Default: no annotation needed. Every loop gets vectorize metadata
+// and the function opts out of per-iteration safepoints.
+pub fn sumTo(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+
+// Power-user override: prefer scalable ISA, fold the tail, and hint
+// a wide fixed factor for AVX-512 / wide SVE targets.
+#[vectorize(scalable, predicate, width = 8)]
+pub fn xorTo(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc ^ i
+    }
+    acc
+}
+
+// Explicit opt-out: long-running worker loop that needs to yield to
+// a concurrent STW request mid-loop.
+#[no_vectorize]
+pub fn drain(queue: Queue) {
+    for job in queue {
+        process(job)
+    }
+}
+```
+
+Unknown keys, duplicate keys, and out-of-range widths are rejected
+with `E0739` (`CodeAnnotationBadArg`).
+
+Scope rules:
+
+- The tuning arguments are **function-scoped**. Every function receives
+  the default vectorize metadata unless it carries `#[no_vectorize]`,
+  but `scalable`, `predicate`, and `width = N` apply only to loops in
+  the function where `#[vectorize(...)]` appears.
+- Only loops originating from a user-written `for` statement carry the
+  hint. Loops synthesized by the compiler (e.g. the per-iteration
+  scaffold inside `testing.benchmark`, or the key-snapshot traversal
+  inside map-mutating helpers) do not.
+- Iterator-protocol loops (`for x in iter` where `iter` is not a
+  `List<T>`, range, or `Map<K, V>`) currently lower through a
+  callback-driven shape that LLVM cannot prove countable; the hint is
+  attached but the vectorizer will reject them. This is documented in
+  `SPEC_GAPS.md` under `vectorize-hint`.
+
+**GC contract.** Shared by `#[vectorize]`, `#[parallel]`, and
+`#[unroll]`. See §3.8.6.
+
+#### 3.8.4 `#[parallel]`
+
+Valid on top-level `fn` declarations and on struct/enum methods. Bare
+flag. Status: **v0.6 A6**.
+
+Asserts that memory accesses inside every loop in the annotated
+function body are parallel — that is, iterations do not read and
+write the same memory location in a way that creates loop-carried
+dependencies. The LLVM backend materialises this promise as:
+
+1. One per-function `!llvm.access.group` metadata node: `!N = distinct !{}`.
+2. Every load and store instruction in the body tagged with
+   `!llvm.access.group !N`.
+3. A `!"llvm.loop.parallel_accesses", !N` property on every loop's
+   back-edge metadata, letting the vectorizer bypass its default
+   alias analysis for accesses tagged with the same group.
+
+Composes with `#[vectorize(...)]` — in fact `#[parallel]` is often the
+prerequisite for `#[vectorize]` to fire on real code, because the
+loop vectorizer conservatively refuses to vectorize when it can't
+prove absence of aliasing.
+
+```osty
+#[parallel]
+#[vectorize(scalable)]
+pub fn addInto(dst: List<Int>, src: List<Int>) {
+    for i in 0..dst.len() {
+        dst[i] = dst[i] + src[i]
+    }
+}
+```
+
+**Soundness is the programmer's responsibility.** If the loop body
+actually does have loop-carried dependencies, the resulting code may
+produce different values than the scalar version. The annotation is a
+contract with the compiler, not a check. Use it only on loops whose
+iteration order genuinely does not matter for the computed result.
+
+No arguments are permitted; any argument is rejected with `E0739`.
+
+#### 3.8.5 `#[unroll]`
+
+Valid on top-level `fn` declarations and on struct/enum methods.
+Status: **v0.6 A7**.
+
+Emits `llvm.loop.unroll.enable` on every loop in the body (bare form)
+or `llvm.loop.unroll.count, i32 N` with an explicit factor. Independent
+of `#[vectorize]` — unrolling controls how many original iterations
+are inlined into the body, separately from the vectorizer's
+vectorization factor. The two hints compose: an annotated function
+can be both vectorized and unrolled (effective throughput ≈ width ×
+unroll count).
+
+| Form | LLVM property | Effect |
+|---|---|---|
+| `#[unroll]` | `llvm.loop.unroll.enable=true` | Request unrolling; compiler picks factor based on target |
+| `#[unroll(count = N)]` | `llvm.loop.unroll.count, i32 N` | Force an exact unroll factor (1..1024) |
+
+```osty
+#[vectorize]
+#[unroll(count = 4)]
+pub fn sumSquares(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i * i
+    }
+    acc
+}
+```
+
+Unknown keys, negative or zero counts, and out-of-range values are
+rejected with `E0739` (`CodeAnnotationBadArg`).
+
+#### 3.8.6 GC contract for loop-optimization annotations
+
+`#[vectorize]`, `#[parallel]`, and `#[unroll]` all require that the
+loop latch be free of side-effecting calls for LLVM's loop analyses
+to see a well-formed countable loop. To honor this, **functions that
+carry any of these three annotations opt out of the per-iteration GC
+loop safepoint poll**. The function-entry safepoint still fires, and
+the caller resumes its own safepoint cadence on return — so the
+function is bracketed by polls on both sides. But inside the
+function, a long-running optimized loop does not yield to a
+concurrent STW request until it completes.
+
+This is an explicit tradeoff: optimized execution in exchange for
+GC latency across the function body. Callers that need mid-loop
+responsiveness should drive the work in smaller chunks from an
+unannotated outer loop. The author opts in knowingly; the compiler
+does not second-guess.
+
+#### 3.8.7 `#[inline]` family
+
+Valid on top-level `fn` declarations and on struct/enum methods.
+Status: **v0.6 A8**. Controls the LLVM inliner's decision for the
+annotated function.
+
+| Form | LLVM fn attribute | Effect |
+|---|---|---|
+| `#[inline]` | `inlinehint` | Soft hint — inliner prefers inlining but can still refuse on size / call-count grounds |
+| `#[inline(always)]` | `alwaysinline` | Hard force — inliner **must** inline at every call site. Compile error if inlining fails (e.g. recursion) |
+| `#[inline(never)]` | `noinline` | Inliner must **not** inline. Useful to preserve a stable symbol for profiling or for breaking LTO cycles |
+
+Composes freely with `#[hot]`, `#[cold]`, `#[vectorize(...)]`, and
+the rest of the v0.6 annotation set. Unknown sub-flags are `E0739`.
+
+```osty
+#[inline(always)]
+pub fn lenUnchecked<T>(xs: List<T>) -> Int { xs.rawLen() }
+
+#[inline(never)]
+pub fn logBreakpoint(msg: String) {
+    fmt.stderr.writeLine(msg)
+}
+```
+
+#### 3.8.8 `#[hot]` / `#[cold]`
+
+Bare-flag annotations on top-level `fn` declarations and struct/enum
+methods. Status: **v0.6 A9**. Control the LLVM frequency attributes
+and text-section placement.
+
+| Annotation | LLVM fn attribute | Effect |
+|---|---|---|
+| `#[hot]` | `hot` | Function is frequently executed. Aggressive optimization; placed in the `.text.hot.` section so the linker can group hot code for i-cache locality |
+| `#[cold]` | `cold` | Function is rarely executed (error paths, slow-path fallbacks). Size-optimized; placed in `.text.unlikely.`; call sites receive a branch-prediction-away hint |
+
+The two are mutually exclusive on a single declaration — both together
+is `E0609` (duplicate annotation) via the normal annotation rules.
+Any argument on either is `E0739`.
+
+```osty
+#[hot]
+pub fn fastPath(n: Int) -> Int { n * 2 }
+
+#[cold]
+pub fn errorReport(e: Error) -> Int {
+    log.record(e)
+    -1
+}
+```
+
+#### 3.8.9 `#[target_feature(...)]`
+
+Valid on top-level `fn` declarations and struct/enum methods. Status:
+**v0.6 A10**. Overrides the LLVM backend's target-feature baseline
+for just this one function, letting a library ship a SIMD-heavy routine
+compiled for AVX-512 / SVE2 without forcing the whole program onto
+that baseline.
+
+Each bare-identifier argument names a CPU feature. The LLVM emitter
+materialises them as a single `"target-features"="+f1,+f2"` fn
+attribute (positive enable only in v0.6). Duplicate names are
+rejected with `E0739`; positional values without a key and
+`feature = "value"` shapes are also `E0739`.
+
+```osty
+// Only this one function compiles for AVX-512, even when the rest
+// of the module targets baseline x86-64. Caller is responsible for
+// CPU feature detection before dispatching here.
+#[target_feature(avx512f, avx512bw)]
+pub fn dotProductAVX512(xs: List<Int>, ys: List<Int>) -> Int {
+    let mut acc = 0
+    for i in 0..xs.len() {
+        acc = acc + xs[i] * ys[i]
+    }
+    acc
+}
+```
+
+**Safety contract.** The programmer is responsible for ensuring the
+CPU running this function actually supports the declared features.
+Calling a `#[target_feature(avx512f)]` routine on a CPU without
+AVX-512 is undefined behavior at the hardware level (illegal
+instruction fault). The usual pattern is a runtime-dispatch helper
+that probes `cpuid` / `HWCAP` before calling the specialised variant.
+Runtime dispatch is not built into v0.6; it belongs in the user's
+application logic or a separate track.
+
+Feature-name spelling matches LLVM's target-features vocabulary
+(`avx2`, `avx512f`, `avx512bw`, `sve`, `sve2`, `neon`, `vfp4`, etc.).
+Typos pass the resolver but will be ignored by the LLVM backend with
+a warning at compile time — the resolver does not maintain a
+per-target feature allowlist because it would need to evolve with
+every LLVM release.
+
+#### 3.8.10 `#[noalias]`
+
+Valid on top-level `fn` declarations and on struct/enum methods.
+Status: **v0.6 A11**. Promises pointer-typed parameters do not alias.
+
+| Form | Effect |
+|---|---|
+| `#[noalias]` | Every `ptr`-typed parameter of this function gets the LLVM `noalias` parameter attribute |
+| `#[noalias(p1, p2)]` | Only the named parameters get `noalias`; other pointer params stay potentially-aliasing |
+
+Non-pointer parameters (Int, Bool, Float, ...) are silently skipped —
+LLVM rejects `noalias` on non-pointer types.
+
+**Why it matters.** LLVM's alias analyzer conservatively assumes two
+pointer parameters can point at overlapping memory, which blocks
+SROA, LICM, loop vectorization, and any transform that would reorder
+loads and stores across the two. `noalias` tells the analyzer "these
+pointers point at disjoint regions" and unlocks the full suite of
+memory-dependency-based optimizations.
+
+```osty
+// Bare — the two slices are disjoint buffers.
+#[noalias]
+pub fn addInto(dst: List<Int>, src: List<Int>) {
+    for i in 0..dst.len() {
+        dst[i] = dst[i] + src[i]
+    }
+}
+
+// Surgical — only `src` is guaranteed disjoint; `dst` and `scratch`
+// may alias (e.g., they point into the same arena).
+#[noalias(src)]
+pub fn combine(src: List<Int>, dst: List<Int>, scratch: List<Int>) {
+    for i in 0..src.len() {
+        dst[i] = src[i] + scratch[i]
+    }
+}
+```
+
+**Soundness is the programmer's responsibility.** Calling a
+`#[noalias]` function with aliasing pointers is undefined behavior
+at the LLVM optimization level — the backend is free to reorder
+loads/stores in ways that would be illegal under true aliasing.
+Unlike `#[parallel]`, which is coarser (whole-loop), `#[noalias]`
+scopes the promise to specific parameters and survives across
+inlining and LTO.
+
+Unknown keys, `key = value` shapes, and duplicate parameter names
+are rejected with `E0739`.
+
+#### 3.8.11 `#[pure]`
+
+Valid on top-level `fn` declarations and on struct/enum methods.
+Bare flag. Status: **v0.6 A13** (lenient — the compiler trusts the
+annotation; see SPEC_GAPS `pure-enforce`).
+
+Asserts the function has no observable side effects: no writes to
+memory the caller can see, no I/O, no calls to impure functions.
+The LLVM emitter sets the `readnone` fn attribute, which lets the
+optimizer:
+
+- **CSE** repeated calls with the same arguments — multiple
+  `f(a, b)` invocations collapse to one.
+- **Hoist** calls out of loops when their arguments are loop-
+  invariant.
+- **Inline aggressively** since there are no side-effect ordering
+  constraints to preserve.
+- **Dead-call elimination** if the return value is unused.
+
+```osty
+#[pure]
+pub fn mixKeys(a: Int, b: Int) -> Int { a * 31 + b }
+```
+
+**Soundness is the programmer's responsibility.** The v0.6 compiler
+does not verify that the annotated body is actually pure. A
+`#[pure]` function that mutates shared state or performs I/O is
+undefined behavior — the optimizer will drop, reorder, or duplicate
+calls in ways that expose the lie. A future release will add a
+checker pass that rejects non-pure bodies; the work is tracked under
+SPEC_GAPS `pure-enforce`.
+
+Any argument is rejected with `E0739`.
+
+#### 3.8.12 Positioning Rules
+
+- Annotations may appear only before a named declaration. They cannot
+  be attached to:
+  - Expressions (including closures and `if` branches)
+  - `use` statements
+  - Individual statements inside a function body
+  - `self`/`mut self` method receivers (annotate the method instead)
+- The same annotation name cannot appear more than once on the same
+  target. `#[json(key="a")] #[json(key="b")] pub x: String` is a
+  compile error — merge or pick one.
+- In partial struct/enum declarations (§3.4), each declaration's
+  annotations apply only to members named in that declaration; the
+  compiler does not merge annotations across declarations.
+
+---
+
+## v0.6 Annotation Extensions
+
+The following annotations were introduced in v0.6 (G36–G49). Each
+applies under the *Hidden dependency is forbidden* north star — every
+external dependency, intent, contract, or evolution rule is surfaced
+through the type signature or annotation.
+
+### 3.4.5 `#[sealed_construct]` — Parse-don't-validate primitive (G40)
+
+A `struct` may declare `#[sealed_construct(name)]` to restrict
+construction paths to a single named constructor. This makes
+"a value of this type exists" *equivalent* to "the validating
+constructor accepted the input."
+
+```osty
+#[sealed_construct(parse)]
+pub struct Email {
+    local: String,
+    domain: String,
+}
+
+impl Email {
+    pub fn parse(s: String) -> Email? { ... }
+    pub fn local(self) -> String { self.local }
+    pub fn domain(self) -> String { self.domain }
+}
+```
+
+**Forbidden construction paths.** The following all fail with `E0420`
+when applied to a sealed struct from outside the named constructor:
+
+1. External struct literal: `Email { local: "a", domain: "b" }`
+2. Spread update: `Email { ..existing, domain: "x" }`
+3. Direct field mutation (when the struct has `mut` fields)
+4. Generic deserialise / FFI default construction (must route through
+   the constructor — `#[json(constructor = parse)]` registers the path)
+5. Test helpers in production builds (use `#[test_construct]` to opt
+   into a test-only escape — production reachability is `E0421`)
+
+**Stdlib escape: `#[trusted_construct(reason = "...")]`.** Restricted
+to `std.*` and toolchain-internal packages (`E0422` from user code). All
+sites are enumerated by `osty audit --trusted-construct`.
+
+### 3.10 `#[spec("§X.Y")]` — Spec link (G38)
+
+A declaration may carry `#[spec("§X.Y")]` to register a checked link
+into the language specification. The compiler verifies the target
+markdown anchor exists; missing anchors produce `E0790`. The compiler
+includes the section's lead paragraph in `osty doc` output and LSP
+hover.
+
+```osty
+#[spec("§2.2")]
+fn checkNumericWidening(from: Type, to: Type) -> CheckResult { ... }
+
+#[spec("§10.30.user")]
+pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
+```
+
+`#[spec]` may be applied to functions, methods, structs, enums,
+interfaces, and impl blocks. Use is encouraged for compiler-internal
+code (`internal/check`, `toolchain/*.osty`) and stdlib modules; user
+code may use it for self-documentation.
+
+### 3.11 `#[reproducible(scope=...)]` — Determinism contract (G39)
+
+A function may declare `#[reproducible]` to assert that its output is
+fully determined by its input — suitable for cache keys, build hashes,
+migration IDs, content addressing.
+
+```osty
+#[reproducible(scope = "target")]
+fn computeKey(data: Bytes) -> Bytes32 {
+    sha256(data)
+}
+```
+
+**Scope levels.**
+
+| Scope | Meaning |
+|---|---|
+| `"run"` | Same output across one process execution. `Console` capability allowed. |
+| `"target"` *(default)* | Same output across the same Osty version + target triple. |
+| `"portable"` | Byte-equal across platforms (cross-compilation). Endianness-explicit, NaN-bit-pattern-stable. |
+
+**Compiler checks.** The function (and its transitive callees):
+
+- Must not receive non-deterministic capabilities (`Clock`, `Rng`,
+  `Env`, `Fs`, `Net`, `Process`) — see §20.4. `E0784`.
+- Must not iterate unordered collections (`Map.iter`, `Set.iter` —
+  use `Map.entriesSorted` / `Set.toListSorted`). `E0786`.
+- Must not depend on pointer identity comparisons.
+- Must call only callees with at least the same scope strength.
+  `E0787`.
+
+`scope = "portable"` adds endianness and NaN-bit constraints (`E0788`).
+
+`#[pure]` (v0.5) is strictly stronger — it forbids capability receipt
+entirely, even for deterministic capabilities like `Hash`. `E0785`.
+
+### 3.12 Structured Intent — `#[purpose]`, `#[example]`, `#[fixture]` (G42)
+
+Structured, machine-readable intent annotations complement free-text
+doc comments. They feed `osty doc`, `osty test --example`, LSP hover,
+property-test seed selection, and `osty context <symbol>`.
+
+```osty
+#[purpose("이메일 검증 후 DB에 사용자 저장")]
+#[example(input = ["alice@example.com", "<Db>"], output = "Ok(42)")]
+#[example(input = ["invalid", "<Db>"], output = "Err(EmailError.Format)")]
+pub fn createUser(email: String, db: Db) -> Result<UserId, Error> { ... }
+
+#[fixture(name = "alice")]
+fn aliceUser() -> Email { Email.parse("alice@example.com")? }
+```
+
+| Annotation | Verified? | Consumed by |
+|---|---|---|
+| `#[purpose("...")]` | No (free text) | `osty doc`, LSP, `osty context` |
+| `#[example(input = ..., output = ..., uses = ...)]` | Yes (call+compare) | doc, test, context |
+| `#[fixture(name = "...")]` | Signature only | doc, test, property gen, golden |
+
+`#[fixture]` is restricted to zero-arity functions. `E0432`.
+
+### 3.13 `spec { ... }` — Executable Spec Block (G43)
+
+A function body may begin with a `spec { ... }` block stating
+executable specifications colocated with the implementation. The
+block has no runtime cost — `example:` clauses run as tests under
+`osty test --spec`, while `law:` and `invariant:` clauses are surfaced
+in `osty doc` and LSP hover.
+
+```osty
+fn normalizeEmail(s: String) -> String {
+    spec {
+        example: normalizeEmail(" Alice@EXAMPLE.COM ") == "alice@example.com"
+        example: normalizeEmail("") == ""
+        law: result == result.trim()
+        law: result == result.toLowerCase()
+        invariant: result.indexOf(" ") == -1
+    }
+    s.trim().toLowerCase()
+}
+```
+
+**Clauses.**
+
+| Clause | v0.6 (Phase 3) | v1 (Phase 5) |
+|---|---|---|
+| `example: expr` | Run as test under `osty test --spec`; expected `Bool` (`E0441`) | (same) |
+| `law: expr`, `invariant: expr` | Doc / LSP only; `result` is virtual binding for return value (`E0442`) | (same) |
+| `forall x, y in gen: expr` | Reserved (parser allows; runtime defers) | Auto property test |
+
+The `spec` block must be the function body's *first* statement
+(`E0440`). It is not an expression; it produces no value.
+
+### 3.14 API Evolution — `#[since]`, `#[stability]`, `#[match_compat]` (G44)
+
+Three annotations cooperate to make API versioning a first-class
+concern.
+
+```osty
+pub enum HttpEvent {
+    Get,
+    Post,
+    #[since("0.6")]
+    Patch,                       // v0.6 신규 variant
+}
+
+#[stability("stable")]
+#[since("0.6")]
+pub fn parseEmail(s: String) -> Email? { ... }
+
+#[stability("experimental", until = "0.7")]
+pub fn parseEmailLoose(s: String) -> Email? { ... }
+
+#[stability("deprecated", since = "0.6", remove = "0.8")]
+pub fn oldApi() -> Int { ... }
+
+#[match_compat("0.6", fallback = handlePatchAsPut)]
+fn dispatch(e: HttpEvent) -> Response {
+    match e {
+        HttpEvent.Get -> handleGet(),
+        HttpEvent.Post -> handlePost(),
+    }
+    // HttpEvent.Patch reaches `fallback`
+}
+```
+
+`#[stability]` levels: `"stable"`, `"experimental"`, `"deprecated"`,
+`"internal"`. `osty publish` enforces SemVer compatibility — breaking
+changes to `stable` APIs require a major bump (`E2100`); see
+`00-revision.md §3.14.3` for the surface diff algorithm.
+
+`#[match_compat]` pins a `match` expression to a historical enum
+shape so that adding a variant (with `#[since]`) does not silently
+break existing code. Either `fallback = name` or `unsafe_silent =
+true` is mandatory (`E0450`); the latter always emits `W0902`.
+
+### 3.15 `#[budget]` — Performance Contract (G46)
+
+A function may declare static and runtime performance budgets.
+
+```osty
+#[budget(allocs = 0, io_calls = 0, stack_depth = 100)]
+fn pureCompute(data: Bytes) -> Bytes32 { ... }
+
+#[budget(time_ms = 5, p99_ms = 20)]
+fn routeRequest(req: Request) -> Response { ... }
+```
+
+**Static keys** (compiler-proven; violation `E0795`):
+
+| Key | Meaning |
+|---|---|
+| `allocs = N` | Maximum GC allocation sites in transitive call graph |
+| `io_calls = N` | Maximum capability-method calls |
+| `stack_depth = N` | Maximum recursive depth |
+| `instructions = N` | LLVM-cost-model estimate |
+
+**Runtime keys** (measured by `osty bench --budget`; violation `W0795`):
+
+| Key | Meaning |
+|---|---|
+| `time_ms = X` | Mean wall-clock time |
+| `p99_ms = X` | p99 wall-clock time |
+
+Static and runtime keys may coexist on the same annotation —
+the compiler partitions them by category.

--- a/LANG_SPEC_v0.6/04-expressions.md
+++ b/LANG_SPEC_v0.6/04-expressions.md
@@ -1,0 +1,542 @@
+## 4. Expressions
+
+### 4.1 Block Expressions
+
+```osty
+let x = {
+    let tmp = compute()
+    tmp * 2
+}
+```
+
+A block evaluates to its final expression. `{}` evaluates to `()` in
+expression position. Empty map is `{:}`.
+
+Blocks introduce lexical scope. `defer` statements registered inside run
+on block exit (§4.12).
+
+#### 4.1.1 Restricted Expression Position
+
+Several constructs (`if`, `for`, `match`, `if let`, `for let`) take an
+expression as their head. In these positions, **a struct literal of the
+form `Type { ... }` is forbidden** because the trailing `{` would be
+ambiguous with the block that follows. Wrapping in parentheses lifts the
+restriction. The grammar refers to this as `RestrictedExpr`.
+
+```osty
+if (Point { x: 0, y: 0 }) == origin { ... }      // OK
+if Point { x: 0, y: 0 } == origin { ... }         // ERROR
+
+match (User { name: n, age: a }) { ... }          // OK
+match User { name: n, age: a } { ... }            // ERROR
+
+for x in (List { items: xs }).iter() { ... }      // OK
+```
+
+The same restriction applies to:
+- The condition of `if` (§4.2)
+- The scrutinee of `match` (§4.3)
+- The iterable of `for x in <expr>` and the condition of `for <expr>` (§4.4)
+- The right-hand side of `if let P = <expr>` and `for let P = <expr>`
+
+### 4.2 If Expressions
+
+```osty
+let label = if score >= 90 {
+    "A"
+} else if score >= 80 {
+    "B"
+} else {
+    "C"
+}
+```
+
+When used as an expression, all branches must produce the same type and
+`else` is required.
+
+**`if let` form.** Pattern-matching form that binds on success:
+
+```osty
+if let Some(u) = user {
+    println("hi, {u.name}")
+}
+
+if let Ok(cfg) = loadConfig() {
+    apply(cfg)
+} else {
+    useDefaults()
+}
+```
+
+Struct literals in the `if` head must be parenthesized — see §4.1.1
+(restricted expression position). The same rule applies to `for` and
+`match` heads.
+
+### 4.3 Match Expressions
+
+```osty
+let area = match shape {
+    Circle(r) -> 3.14 * r * r,
+    Rect(w, h) -> w * h,
+    Empty -> 0.0,
+}
+```
+
+Match is exhaustive. `_` matches anything. Arms may be expressions or
+blocks.
+
+#### 4.3.1 Patterns
+
+Supported patterns:
+
+- **Wildcard:** `_` matches anything without binding.
+- **Literal:** `42`, `"yes"`, `true`, `'\n'`.
+- **Identifier:** `x` binds the matched value.
+- **Tuple:** `(a, b)` destructures tuples.
+- **Struct:** `User { name, age }`, `User { name, .. }` (ignore rest),
+  `User { name: "alice", .. }` (match specific field value and bind
+  nothing), `User { name: n, age }` (match and rename binding).
+- **Variant:** `Some(x)`, `Ok(v)`, `Rect(w, h)`, `Empty`.
+- **Range:** `0..=9`, `10..20`, `..=0`, `100..` (half-open ranges).
+  Range patterns require an `Ordered` scrutinee. Numeric types and
+  `Char` (e.g. `'a'..='z'`) are permitted; `String` and other types
+  without a useful total order are a compile error.
+- **Or:** `A | B | C` matches any alternative. All alternatives must
+  bind the same names with the same types. Alternatives at different
+  nesting depths are allowed (`A(B(x)) | C(D(x))`) as long as the
+  bindings agree.
+- **Literal patterns** are type-strict: `42 -> ...` does not match a
+  `Float` scrutinee, and `'A' -> ...` does not match a `Byte`. There
+  is no implicit numeric coercion in patterns.
+- **Binding (`@`):** `name @ pattern` binds the whole matched value
+  while also matching against `pattern`:
+  ```osty
+  match n {
+      x @ 0..=9 -> "single digit: {x}",
+      x @ 10..=99 -> "two digits: {x}",
+      _ -> "more",
+  }
+  ```
+
+Patterns nest. `Ok(Some(x))`, `Circle(r @ 0.0..=1.0)`, and
+`User { name, age @ 18..=65 }` are all valid.
+
+#### 4.3.2 Guards
+
+A match arm may be conditioned on a boolean expression:
+
+```osty
+let label = match x {
+    Some(n) if n > 0 -> "positive",
+    Some(n) if n < 0 -> "negative",
+    Some(_) -> "zero",
+    None -> "missing",
+}
+```
+
+Arms are tried in order; both the pattern and the guard must succeed.
+Exhaustiveness treats guarded arms conservatively: a type is fully
+covered only by arms without guards (or catch-alls). An otherwise
+exhaustive match composed only of guarded arms requires a final
+catch-all.
+
+Guards may reference bindings introduced by the pattern — the guard
+and the arm body share the same scope, so `Some(n) if n > 0` works as
+expected. Guards may not introduce new bindings (no `if let` inside a
+guard).
+
+**v0.4 witness policy.** A non-exhaustive match diagnostic reports one
+minimal missing pattern. For tuple and struct shapes, the witness
+concretizes the leftmost missing component and uses `_` for the rest.
+For closed enum, `Option`, and `Result` payloads, the witness recurses
+into the missing payload shape; for open or scalar domains, the payload
+is `_`. Guarded arms do not contribute to coverage.
+
+### 4.4 Loops
+
+```osty
+for i in 0..10 { ... }
+for i in 0..=10 { ... }
+for i in 0..100 by 2 { ... }
+for item in xs { ... }
+for (k, v) in map { ... }
+
+for cond { ... }                 // while-style (legacy form)
+while cond { ... }               // while-style (G49 — same lowering)
+for { ... }                      // infinite
+
+let winner = loop {
+    let item = nextItem()
+    if item.accepted { break item }
+}
+
+for x in xs {
+    if found(x) { break }
+}
+
+'outer: for row in rows {
+    for cell in row {
+        if done(cell) { break 'outer }
+        if skipRest(cell) { continue 'outer }
+    }
+}
+
+for item in items {
+    if !item.valid { continue }
+    process(item)
+}
+```
+
+**`for let` form.** Loop while a pattern match succeeds:
+
+```osty
+for let Some(x) = queue.pop() {
+    process(x)
+}
+
+for let Ok(line) = reader.readLine() {
+    handle(line)
+}
+```
+
+On each iteration, the expression is evaluated and matched. If it fails,
+the loop exits.
+
+There is no C-style `for (init; cond; step)`.
+
+**Range step.** `a..b by step` and `a..=b by step` set the iteration
+stride for a range expression. `by` is contextual: outside range suffix
+position it is an ordinary identifier.
+
+`break` exits the innermost enclosing loop; `continue` skips to the next
+iteration. A loop may be prefixed with a label (`'name: for ...` or
+`'name: loop ...`); `break 'name` and `continue 'name` target that loop.
+Unknown labels are `E0763`. Without a label, the target is the innermost
+enclosing loop.
+
+#### 4.4.1 Loop Expressions
+
+`loop { ... }` is the value-returning unbounded loop form. It is distinct
+from `for cond { ... }` and `for { ... }`, which are statement-style loops
+with `()` result.
+
+```osty
+let firstHit = loop {
+    let value = scanNext()
+    if value.matches { break value }
+}
+```
+
+The type of a `loop` expression is the common type of its `break value`
+exits. A bare `break` exits with `()`; `break value` is valid only when
+the target is a `loop` expression. For a labeled break, the value follows
+the label: `break 'search result`.
+
+### 4.5 Error Propagation
+
+```osty
+fn loadConfig(path: String) -> Result<Config, Error> {
+    let text = fs.readToString(path)?
+    let cfg: Config = json.parse(text)?
+    Ok(cfg)
+}
+
+fn findActive(id: Int) -> User? {
+    let user = lookupUser(id)?
+    if user.active { Some(user) } else { None }
+}
+```
+
+The postfix `?` operator applies to `Result<T, E>` and `Option<T>`:
+
+- On `Result<T, E>`: `Ok(v)` evaluates to `v`; `Err(e)` returns `Err(e)`
+  from the enclosing function. The error type must be `E`, or `e` must
+  satisfy `Error` with enclosing return `Result<_, Error>`.
+- On `Option<T>`: `Some(v)` evaluates to `v`; `None` returns `None` from
+  the enclosing function. The enclosing return must be `Option<_>`.
+
+Mixing `Option<T>?` in a `Result<_, _>` function (or vice versa) is a
+compile error. Convert explicitly with `Option.orError(msg)` or
+`Result.ok()`.
+
+The `?` operator chains freely with method calls:
+
+```osty
+let upper = fetchUser()?.getName()?.toUpper()
+```
+
+### 4.6 Optional Chaining and Nil-Coalescing
+
+The `?.` operator accesses a field or calls a method on an `Option<T>`.
+If `None`, the result is `None`; if `Some(v)`, the access is performed
+on `v`:
+
+```osty
+let name: String? = user?.name
+let city: String? = user?.address?.city
+let len: Int? = user?.name?.len()
+```
+
+Chained access short-circuits on the first `None`.
+
+The `??` operator supplies a default for `None`:
+
+```osty
+let name = user?.name ?? "anonymous"
+let count = countCache?.value ?? 0
+```
+
+The right operand is evaluated only when the left is `None`. `??` binds
+tighter than assignment but looser than comparison. `?.` binds at the
+same precedence as `.`.
+
+### 4.7 Closures
+
+```osty
+let double = |x| x * 2
+let add = |a, b| a + b
+list.map(|x| x * 2)
+
+list.map(|x| {
+    let doubled = x * 2
+    doubled + 1
+})
+
+let f = |x: Int| -> Int { x * 2 }
+```
+
+Closures capture by reference. Mutability is inherited from the captured
+binding's declaration. A closure that outlives the block in which it was
+created keeps the captured bindings alive (the GC roots them through the
+closure value).
+
+**Closure parameter patterns.** Any `LetPattern` (§3.2) is permitted as
+a closure parameter, with the same destructuring and wildcard rules
+applied at call time:
+
+```osty
+counts.entries().map(|(k, v)| "{k} = {v}")
+users.map(|User { name, age }| "{name}({age})")
+pairs.map(|(_, second)| second)
+```
+
+Only **irrefutable** patterns are allowed. Patterns that could fail to
+match (enum variants like `Some(x)`, range patterns, or struct patterns
+against multi-variant enums) are a compile error — call sites must
+supply a value the closure can always destructure.
+
+Annotations (`#[deprecated]`, `#[json]`, …) may not be applied to
+closure expressions; annotations are a declaration-level feature.
+
+> **v0.4 decision.** Patterned closure parameters are part of the
+> front-end baseline. Irrefutable tuple/struct/wildcard/binding patterns
+> bind as if the closure body began with a `let` destructure. Refutable
+> literal, range, variant, or or-pattern parameters are rejected with
+> `E0741`.
+
+### 4.8 String Interpolation
+
+See §1.6.3.
+
+### 4.9 Member Access and Method Calls
+
+```osty
+user.name
+user.greet()
+User.new(...)
+math.sqrt(2.0)
+```
+
+`.` for all member access. `::` only for turbofish.
+
+**v0.4 generic-method decision.** In `obj.method::<T>(args)`, explicit
+type arguments apply only to the method's own generic parameters. Generic
+parameters from the receiver's owner type are already fixed by the
+receiver type. Partial explicit method type arguments are not allowed:
+provide exactly the method-local arity or omit them for inference.
+
+`obj.method` as a function value is allowed only for non-generic
+methods. A generic method must be wrapped explicitly:
+
+```osty
+let f = |x: Int| obj.method::<Int>(x)
+```
+
+The same rule applies to top-level generic functions: Osty v0.4 does
+not have first-class polymorphic function values or partial generic
+application. `let f = identity` is legal only when `identity` is
+non-generic; use `let f = |x: Int| identity::<Int>(x)` to fix a generic
+callable's type arguments.
+
+**v0.4 erased-callable decision.** A direct function or package-member
+call uses declaration metadata, so default arguments and keyword
+arguments are available there. Once the callable is stored as
+`fn(...) -> ...`, that metadata is erased: calls through the function
+value are positional-only and must pass exactly the declared arity.
+
+### 4.10 Indexing
+
+```osty
+xs[0]                  // aborts on out-of-range
+m["key"]               // aborts on missing key
+xs.get(0)              // T?
+m.get("key")           // V?
+xs[2..5]               // slicing
+s[2..5]                // String byte slicing; aborts on invalid UTF-8 boundary
+```
+
+**String indexing is in bytes, not Unicode scalars.** This matches the
+Go and Rust convention: a `String` is an immutable UTF-8-encoded byte
+sequence. `s.len()` returns the number of bytes; `s[i]` returns the
+byte at index `i` as a `Byte`; `s[a..b]` returns a `String` slice (no
+copy) that aborts at runtime if either endpoint falls inside a multi-
+byte UTF-8 sequence.
+
+For byte, Unicode-scalar, or grapheme iteration, use the explicit
+`String` methods. These are intrinsic methods on `String`; higher-level
+string processing helpers live in `std.strings`.
+
+```osty
+for c in s.chars() { ... }         // Iterator<Char>
+for g in s.graphemes() { ... }     // Iterator<String> — extended grapheme clusters
+let n = s.charCount()              // O(n) scan
+```
+
+`Bytes` indexing follows the same rules but never aborts on UTF-8
+boundaries, since it carries no encoding contract.
+
+### 4.11 Block Scope
+
+Every `{ }` introduces a lexical scope. Scope exits occur when control
+flow leaves the block (end of block, `return`, `break`/`continue` out
+of loop, `?` propagation).
+
+### 4.12 Defer
+
+`defer` schedules an expression or block to run when the enclosing block
+exits.
+
+```osty
+fn process(path: String) -> Result<(), Error> {
+    let conn = net.connect("api.com")?
+    defer conn.close()
+
+    let data = fs.read(path)?
+    let result = conn.send(data)?
+    Ok(())
+}
+```
+
+Inside a loop, `defer` runs at the end of each iteration:
+
+```osty
+for path in paths {
+    let tmp = path + ".tmp"
+    defer {
+        ignoreError(fs.remove(tmp))
+    }
+    process(path)?
+}
+```
+
+Rules:
+
+1. `defer` is a statement.
+2. The argument is an expression or block.
+3. Multiple `defer`s in the same block run in LIFO order.
+4. `defer` is scoped to the enclosing block. It is not valid at the
+   top level of a script (§6); wrap top-level cleanup in an explicit
+   `{ ... }` block.
+5. Captured variables and expressions are evaluated at execution time.
+6. Errors raised inside a deferred expression do not propagate.
+7. `defer` runs on normal block exit, on `?`-propagated early return,
+   and on task **cancellation** (§8.4.3). It does **not** run when
+   the process terminates via `abort`, `unreachable`, `todo`, or
+   `os.exit`; those are immediate.
+8. Blocking calls inside a `defer` body are **not** cancellation
+   points — cleanup is uninterruptible. Authors who need bounded
+   cleanup must enforce their own timeout inside the `defer` body.
+9. A deferred expression whose type is `Result<_, _>` produces an
+   unused-result warning. Handle the result explicitly with one of the
+   helpers from `std.process` (§10.1):
+
+```osty
+defer ignoreError(conn.close())
+defer logError(f.close(), "file close failed")
+
+// Or handle manually
+defer {
+    match db.close() {
+        Ok(_) -> {},
+        Err(e) -> log.warn("db close failed: {e.message()}"),
+    }
+}
+```
+
+### 4.13 Assignment
+
+Assignment is a **statement**, not an expression. It never produces a
+value and may not appear in expression position (`let x = (y = 1)` is
+rejected by the grammar).
+
+```osty
+let mut n = 0
+n = n + 1
+n += 1
+```
+
+The left-hand side must be one of:
+
+- a **mutable identifier** (`x` declared with `let mut`, or a `mut self`
+  receiver parameter),
+- a **field access** on a mutable struct value (`obj.field`,
+  `self.field`),
+- an **indexed element** on a mutable collection (`xs[i]`, `m[k]`).
+
+The right-hand side is evaluated, then written to the place named by the
+left-hand side. For `=`, the RHS type must match the LHS type except for
+the lossless numeric widening allowed by §2.2.
+
+#### 4.13.1 Compound Assignment
+
+For each binary operator that produces a value of the same type as its
+left operand — `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>` —
+Osty provides a compound assignment form.
+
+| Compound | Desugars to       |
+|----------|-------------------|
+| `x += y` | `x = x + y`       |
+| `x -= y` | `x = x - y`       |
+| `x *= y` | `x = x * y`       |
+| `x /= y` | `x = x / y`       |
+| `x %= y` | `x = x % y`       |
+| `x &= y` | `x = x & y`       |
+| `x \|= y` | `x = x \| y`     |
+| `x ^= y` | `x = x ^ y`       |
+| `x <<= y`| `x = x << y`      |
+| `x >>= y`| `x = x >> y`      |
+
+Semantics:
+
+1. Compound assignment is a **statement** with the same precedence as
+   plain assignment (lowest, right-associative). It is grammar-level
+   statement-only — `(x += 1)` is rejected.
+2. The LHS place is evaluated **exactly once**. For an indexed target
+   `xs[i] += v`, the index expression `i` is evaluated once, not twice.
+3. Type rules follow the corresponding binary operator in §4 and §2:
+   `x op= y` is well-typed iff `x op y` is well-typed and its result
+   type is compatible with the LHS.
+4. The LHS must be a valid mutable place (same rules as §4.13).
+5. `+=` on `String` is equivalent to concatenation: `s += other` is
+   `s = s + other`. Numeric compound assignment follows the same
+   lossless-widening and narrowing-rejection rules as the corresponding
+   binary operator and final assignment (§2.2).
+6. Compound assignment on an immutable binding or field produces the
+   same diagnostic as plain assignment (`E0601` et al.); there is no
+   separate code.
+
+There are no compound forms for `&&`, `||`, `??`, or comparison
+operators. `++` and `--` are explicitly excluded (§14) and are not
+reintroduced by the compound family.
+
+---

--- a/LANG_SPEC_v0.6/05-modules-and-packages.md
+++ b/LANG_SPEC_v0.6/05-modules-and-packages.md
@@ -1,0 +1,96 @@
+## 5. Modules and Packages
+
+### 5.1 Package = Directory
+
+A directory is a package. All `.osty` files in a directory belong to the
+same package and share a namespace.
+
+```
+myapp/
+├── main.osty           // package myapp
+├── config.osty         // package myapp
+├── auth/
+│   ├── login.osty      // package myapp.auth
+│   └── token.osty      // package myapp.auth
+└── db/
+    └── postgres.osty   // package myapp.db
+```
+
+### 5.2 Import
+
+```osty
+use std.fs
+use std.http
+use std::{fs, http as web}
+use github.com/user/lib
+use github.com/user/lib as mylib
+pub use myapp.db.Conn
+use go "net/http" {
+    fn Get(url: String) -> Result<Response, Error>
+    struct Response {
+        StatusCode: Int,
+        Body: Reader,
+    }
+}
+```
+
+`use <path>` imports an Osty package. Scoped import form
+`use path::{A, B as C}` imports several names from the same package.
+`pub use <path>` re-exports the imported symbol from the current package;
+re-export cycles are `E0552`. `use go "<path>" { ... }` imports a Go
+package via FFI (see §12).
+
+### 5.3 Visibility
+
+Declarations are package-private by default. `pub` exports:
+
+```osty
+pub fn login(user: String) -> Result<Token, Error> { ... }
+fn hashPassword(p: String) -> String { ... }         // private
+
+pub struct User {
+    pub name: String,       // exported field
+    email: String,          // private field
+}
+
+pub let MAX_USERS = 10000
+```
+
+`pub` may appear on:
+- Top-level `fn`, `struct`, `enum`, `interface`, `type`, `let`
+- Fields inside `struct`
+- Methods inside `struct` or `enum`
+
+Enum variants inherit the enum's visibility. Interface methods are
+visible wherever the interface is. It is a compile error to mark an
+enum variant `pub` when the enclosing enum is package-private — a
+variant's visibility cannot exceed its enum's.
+
+**Partial declarations** (§3.4). All declarations of the same type
+must agree on visibility: if one decl writes `pub struct U`, every
+other decl of `U` in the same package must also write `pub struct U`.
+Inconsistent visibility across decls is a compile error.
+
+**Type alias visibility.** A `type` alias is transparent: `pub type A = X`
+exports the name `A`, not any additional methods on `X`. The alias's
+`pub`-ness belongs to the alias declaration itself, independent of
+whether `X` is `pub`.
+
+### 5.4 Circular Imports
+
+Forbidden. The compiler enforces a strict DAG. Diamond imports through
+distinct paths (A→B→D and A→C→D) are allowed — each package is resolved
+once per version.
+
+Version conflicts for the same external package (two dependency paths
+bringing in different versions of the same package) are resolved by
+the package manager per `osty.lock` rules; semantics are implementation-
+defined beyond "one version of a given package is visible in a single
+build" — see §13.2.
+
+### 5.5 One Package Per Directory
+
+Each directory is exactly one package. Sub-packages live in
+subdirectories.
+
+---

--- a/LANG_SPEC_v0.6/06-scripts.md
+++ b/LANG_SPEC_v0.6/06-scripts.md
@@ -1,0 +1,45 @@
+## 6. Scripts
+
+A file is a **script file** if it contains top-level statements outside
+any function or type declaration. A file with only declarations is a
+**module file**.
+
+```osty
+#!/usr/bin/env osty
+// hello.osty — script file
+
+let args = env.args()
+let name = args.get(1) ?? "world"
+println("hello, {name}")
+```
+
+Rules:
+
+- A script file is compiled as if its top-level statements were wrapped
+  in `fn main() -> Result<(), Error>` with an implicit trailing
+  `Ok(())`.
+- Script files may not be imported from other packages.
+- `pub` declarations in a script file are meaningless; the formatter
+  warns.
+- Top-level `?` inside a script propagates to the implicit `main` and
+  causes process exit with a non-zero code, printing the error via
+  `eprintln`.
+- Top-level `fn`, `struct`, `enum`, `interface`, `type` declarations
+  are permitted alongside statements; they become local to the
+  script's `main`.
+- A top-level `return expr` is permitted; it is a `return` from the
+  implicit `main` and behaves as such. The exit code follows the
+  returned `Result<(), Error>` (zero on `Ok(())`, non-zero on
+  `Err(...)`). Scripts that need to pick a specific exit code should
+  call `os.exit(code)` from `std.os` (§10.15) instead. Resolves G5.
+- A bare `defer` at the top level of a script is a compile error —
+  `defer` requires an enclosing block. Wrap top-level cleanup in
+  `{ defer ... }` when it is needed.
+- Top-level `let` bindings and statements are evaluated strictly
+  top-to-bottom in source order. There is no hoisting of `let`
+  initialization.
+
+`osty run script.osty` compiles and executes a script. With the shebang
+line present, `chmod +x script.osty && ./script.osty` also works.
+
+---

--- a/LANG_SPEC_v0.6/07-the-error-interface.md
+++ b/LANG_SPEC_v0.6/07-the-error-interface.md
@@ -1,0 +1,119 @@
+## 7. The Error Interface
+
+### 7.1 Definition
+
+`Error` is an interface defined in `std.error` and re-exported by the
+prelude:
+
+```osty
+pub interface Error {
+    fn message(self) -> String
+    fn source(self) -> Error? { None }
+}
+```
+
+### 7.2 BasicError
+
+```osty
+return Err(Error.new("invalid input"))
+```
+
+`Error.new` constructs a `BasicError`.
+
+### 7.3 Custom Errors
+
+```osty
+pub enum FsError {
+    NotFound(String),
+    PermissionDenied(String),
+    IoError(String),
+
+    pub fn message(self) -> String {
+        match self {
+            NotFound(p) -> "not found: {p}",
+            PermissionDenied(p) -> "permission denied: {p}",
+            IoError(m) -> "io error: {m}",
+        }
+    }
+}
+```
+
+### 7.4 Propagation and Downcasting
+
+`?` up-casts concrete errors to the `Error` interface when the enclosing
+function returns `Result<_, Error>`.
+
+To recover the concrete type, use `downcast`:
+
+```osty
+fn handle(err: Error) -> Result<(), Error> {
+    match err.downcast::<FsError>() {
+        Some(fe) -> match fe {
+            FsError.NotFound(p) -> retry(p),
+            _ -> Err(err),
+        },
+        None -> Err(err),
+    }
+}
+```
+
+`Error.downcast::<T>()` returns `T?`. The postfix form `err as? T` is a
+shortcut for the same operation and is valid only on `Error` values.
+
+**Runtime mechanism.** Although Osty's interface satisfaction is
+otherwise structural (§2.6), values that flow through the `Error`
+interface carry a **nominal type tag** identifying the originating
+concrete type. The tag is set when a concrete error value is up-cast
+to `Error` (e.g. via `?`, return-type widening, or explicit assignment
+to an `Error`-typed binding) and is preserved across propagation.
+`downcast::<T>()` succeeds iff the stored tag equals `T`'s nominal
+identity; it does not perform structural matching.
+
+This nominal exception is intentional: error recovery code routinely
+needs to distinguish "this `Error` is really a `FsError`" from "this
+`Error` happens to share the same shape as `FsError`," and structural
+matching cannot do so safely. No other interface in Osty carries a
+runtime type tag.
+
+**Interaction with monomorphization.** The generic compilation model
+(§2.7.3) is monomorphization, which erases the source-level distinction
+between separate type arguments at runtime. `Error`'s nominal tag is a
+separate, orthogonal mechanism: it is attached per-concrete-error-type
+at up-cast time and does not depend on, nor interfere with, generic
+specialization. `downcast::<T>()` works identically regardless of
+whether the error propagated through generic code paths or fully
+concrete ones.
+
+**`?` and error type widening.** When a function returns
+`Result<_, Error>` and `?` is applied to a `Result<_, CustomError>`
+where `CustomError: Error`, the conversion is automatic — no explicit
+cast is required. When the function returns `Result<_, SomeConcrete>`
+and the `?` target has a different concrete error type, the conversion
+is a compile error: convert explicitly or widen the function's return
+type.
+
+**Multiple error types in one function.** The recommended pattern is
+either (a) widen to `Result<_, Error>` and let `?` upcast each concrete
+error, or (b) define a local `enum` implementing `Error` that wraps the
+concrete types and propagate that:
+
+```osty
+pub enum PipelineError {
+    Fetch(FetchError),
+    Parse(ParseError),
+    Write(IoError),
+
+    pub fn message(self) -> String {
+        match self {
+            Fetch(e) -> "fetch: {e.message()}",
+            Parse(e) -> "parse: {e.message()}",
+            Write(e) -> "write: {e.message()}",
+        }
+    }
+}
+```
+
+The wrapping enum must then be constructed explicitly at each error
+site; `?` does not synthesize wrappers.
+
+---

--- a/LANG_SPEC_v0.6/08-concurrency.md
+++ b/LANG_SPEC_v0.6/08-concurrency.md
@@ -1,0 +1,239 @@
+## 8. Concurrency
+
+### 8.0 Scheduler Model
+
+Osty specifies an **M:N scheduler**. Task-level units (`g.spawn(...)`, the
+helpers in §8.3, and the root task started by `taskGroup`) are **green
+tasks** multiplexed onto a pool of worker OS threads. The language does
+not expose the OS thread a task runs on, and implementations are free to
+migrate a task between workers between yield points.
+
+Programs **MUST NOT** rely on any of the following:
+
+- the identity of the OS thread executing a task (no thread-local
+  storage observable through the language surface; no `gettid`-style
+  introspection);
+- a specific task running concurrently with, or serialized against,
+  another task unless the synchronization is expressed through a
+  language primitive (`Handle.join`, a channel operation, or the
+  cancellation surface in §8.4);
+- the number of worker threads, a ratio of tasks to workers, or a
+  scheduling policy (FIFO vs work-stealing vs LIFO, fair vs unfair
+  among ready tasks). `race` tie-breaking in §8.3 is explicit about
+  this: deterministic within a run, unstable across runs.
+
+**Yield points.** A conforming runtime may treat the following as
+yield points (opportunities for the scheduler to run another task on
+the same worker): channel send/recv, `Handle.join`, `thread.yield`,
+`thread.sleep`, `thread.select` blocking arms, GC safepoints (§19.10),
+and cancellation checks (§8.4). Tight compute loops with no such
+points need not yield; programs that require progress on siblings
+must include an explicit yield, a channel op, or a cancellation
+check. A future revision may add compiler-inserted preemption at
+loop backedges; programs written to the yield-point contract keep
+working when that lands.
+
+**Parallelism.** Parallel execution across workers is **permitted but
+not guaranteed**. A single-worker implementation satisfies this
+chapter; so does a many-worker implementation. The observable
+contracts — structured lifetime (§8.1), failure propagation (§8.2),
+cancellation with cause (§8.4) — hold identically in both cases. The
+`RUNTIME_SCHEDULER.md` roadmap describes the delivery phases for the
+reference LLVM-backed runtime.
+
+**Thread-identity clause does not weaken FFI.** `use go` imports
+and the `#[c_abi]` surface in §19 still run on an OS thread with its
+own stack; blocking FFI calls do not freeze the whole scheduler, but
+they may pin a worker for the duration of the call. A runtime is free
+to grow its worker pool or hand off to a carrier thread to preserve
+progress on other tasks.
+
+### 8.1 Structured Concurrency
+
+All concurrent tasks belong to a `taskGroup` scope. There is no detached
+spawn. `taskGroup` and `parallel` are in the prelude.
+
+```osty
+let result = taskGroup(|g| {
+    let h1 = g.spawn(|| fetchA())
+    let h2 = g.spawn(|| fetchB())
+    let h3 = g.spawn(|| fetchC())
+    Ok((h1.join()?, h2.join()?, h3.join()?))
+})
+```
+
+`g.spawn(closure)` returns `Handle<T>`. `Handle<T>` and `TaskGroup` are
+**non-escaping capabilities**. They may be used inside the same
+`taskGroup` closure and may be passed to helper functions that do not
+store or return them, but they may not escape the group. Returning one,
+storing one in a struct field or long-lived collection, sending one over
+a channel, or capturing one in a closure that can outlive the group is a
+**compile error** (`E0743`). This preserves the invariant that every task
+completes before its parent returns.
+
+### 8.2 Failure Semantics
+
+**`taskGroup`** — if any child fails (returns `Err(e)`, panics via
+`abort`, or completes through `unreachable`/`todo`), the group enters
+cancellation: all remaining siblings receive a cancel signal (§8.4)
+and the first observed error is propagated to the group's caller.
+
+**`collectAll`** — all children run to completion; results are
+collected regardless of individual failures. The outer scope can still
+cancel the `collectAll` by cancelling the enclosing `taskGroup`, at
+which point children shut down via the normal cancel path.
+
+```osty
+fn collectAll<T>(body: fn(Group) -> List<Handle<T>>) -> List<Result<T, Error>>
+```
+
+**`abort(msg)` inside a task** terminates the process. It is not a
+recoverable failure: `abort` bypasses the `taskGroup` failure path and
+does not deliver `Err` to siblings or parents. Use `Err(Error.new(msg))`
+when recovery is intended.
+
+### 8.3 High-Level Helpers
+
+```osty
+fn parallel<T, R>(items: List<T>, concurrency: Int,
+                  f: fn(T) -> Result<R, Error>) -> List<Result<R, Error>>
+
+fn race<T>(body: fn(Group) -> List<Handle<T>>) -> Result<T, Error>
+```
+
+**`race` tie-breaking.** When two handles complete at indistinguishable
+times, `race` returns the one whose completion the scheduler observes
+first — i.e. the first completion registered in internal scheduler
+order. This is deterministic within a run but not stable across runs;
+do not depend on a specific tie-break.
+
+### 8.4 Cancellation
+
+Cancellation in Osty is **structured and automatic**. It is the v0.3
+resolution of gap G12.
+
+#### 8.4.1 Propagation Model
+
+A `taskGroup` defines a cancellation scope. If the group is cancelled
+(either explicitly or because a sibling failed per §8.2), **every
+descendant task** — including tasks spawned transitively by children —
+receives the cancel signal. The cancel signal carries a **cause**:
+
+```osty
+pub enum Cancelled {
+    cause: Error,     // the originating error, or Error.new("parent cancelled")
+}
+```
+
+The stdlib `Cancelled` value is constructed by the runtime. Callers
+encounter it as `Err(Cancelled { ... })` from any cancellation-aware
+call.
+
+#### 8.4.2 Cancellation Points
+
+Every standard-library blocking call is cancellation-aware and returns
+`Err(Cancelled { cause })` as soon as the cancel signal is observed —
+regardless of how much real time remains on the operation:
+
+```osty
+time.sleep(30.min)         // returns early with Err(Cancelled) on cancel
+net.read(conn, buf)        // likewise
+fs.read(f, buf)            // likewise
+ch.recv()                  // returns None and the enclosing call returns
+```
+
+CPU-bound code that does not make stdlib calls must check explicitly:
+
+```osty
+thread.isCancelled() -> Bool
+thread.checkCancelled() -> Result<(), Error>   // helper: Err(Cancelled) when cancelled
+```
+
+#### 8.4.3 Interaction with `defer`
+
+`defer`red blocks run on normal scope exit, on `Err(...)?` propagation,
+**and** on cancellation. Cleanup is always executed. A `defer` block
+is itself run to completion regardless of pending cancel state; a
+blocking call inside a `defer` does not honor the cancel signal (the
+cleanup path is intentionally uninterruptible). Authors who need
+bounded cleanup should enforce a timeout inside the `defer` body.
+
+`defer` does **not** run when the process terminates via `abort`,
+`unreachable`, `todo`, or `os.exit` — these are immediate terminations.
+
+#### 8.4.4 `collectAll` Under Cancel
+
+`collectAll` keeps its children alive through sibling failures, but a
+cancel signal from the **enclosing** `taskGroup` propagates into the
+`collectAll` children normally — the collected list then contains
+`Err(Cancelled { cause })` for any child that was mid-flight.
+
+### 8.5 Channels
+
+```osty
+let ch = thread.chan::<Int>(100)
+ch <- value                          // send statement
+let x = ch.recv()                    // T?
+for x in ch { ... }
+ch.close()
+```
+
+Channel send (`<-`) is a statement.
+
+**Buffering.** `thread.chan::<T>(capacity)` creates a channel with the
+given capacity. A capacity of `0` means a **synchronous rendezvous**
+channel: each send blocks until a matching receive is in progress (and
+vice versa). Positive capacity gives FIFO buffering; sends block only
+when the buffer is full.
+
+**Send atomicity.** A single `<-` operation is atomic with respect to
+other concurrent senders and receivers on the same channel. Values are
+delivered whole — never partially observed.
+
+**Close semantics** (v0.3 resolution of gap G8).
+
+- `ch.close()` signals that no further values will be sent.
+- **Any task may close a channel.** A second `close` on an already-
+  closed channel aborts. This is not idempotent by design — double
+  close indicates a coordination bug.
+- Sending on a closed channel aborts.
+- `ch.recv()` returns buffered values until the buffer is empty **and**
+  the channel is closed, at which point it returns `None`. `for x in ch`
+  therefore terminates naturally when the channel is closed and
+  drained.
+- `ch.isClosed() -> Bool` reports close state without consuming a
+  value.
+- `ch.recv()` is a cancellation point per §8.4.2 — it returns `None`
+  early when the surrounding task is cancelled (the caller distinguishes
+  cancel from drain by checking `thread.isCancelled()`).
+
+### 8.6 Select
+
+```osty
+let result = thread.select(|s| {
+    s.recv(ch1, |x| handle1(x))
+    s.recv(ch2, |x| handle2(x))
+    s.send(out, value, || sent())
+    s.timeout(5.s, || giveUp())
+    s.default(|| nonBlocking())
+})
+```
+
+Exactly one branch runs. When multiple non-`default` branches are ready
+at the same moment, the scheduler chooses among them non-
+deterministically. Branches registered on the `select` builder are
+**evaluated sequentially** in registration order when computing
+readiness; this sequential evaluation is observable only through side
+effects inside a branch's argument expressions.
+
+**`default` priority.** The `default` branch runs **only if no other
+branch is ready** at the moment the `select` is evaluated. A ready
+branch always wins over `default`. There is no race between `default`
+and a simultaneously-ready branch.
+
+**Closed channels in `select`.** A `recv` branch on a closed, drained
+channel is "ready" and fires once with `None` (matching the `recv`
+semantics of §8.5). A `send` branch on a closed channel aborts when
+selected.
+
+---

--- a/LANG_SPEC_v0.6/09-memory-management.md
+++ b/LANG_SPEC_v0.6/09-memory-management.md
@@ -1,0 +1,40 @@
+## 9. Memory Management
+
+Osty is garbage collected. There are no explicit memory primitives:
+no `new`, no `delete`, no destructors.
+
+Resource cleanup is done through `defer` (§4.12) or closure-based
+stdlib APIs (`fs.withFile`, `net.withConn`, etc.).
+
+`std.sync` provides `Mutex`, `RwLock`, and atomics.
+
+### 9.1 Scope of this specification
+
+This chapter intentionally stops at the language-level contract. The
+specification does **not** pin down:
+
+- GC algorithm (generational, mark-sweep, concurrent, ...)
+- Collection triggers (allocation pressure, timers, manual hints)
+- Stop-the-world vs concurrent reclamation
+- Heap sizing, tuning knobs, or runtime flags
+
+These are implementation choices. Future Osty runtimes are free to
+change them without a language-spec version bump. User code should not
+rely on observable GC timing for correctness.
+
+### 9.2 What is specified
+
+- **No finalizers.** Osty deliberately omits finalizer hooks. All
+  cleanup goes through `defer` or closure-scoped stdlib helpers, so
+  resource lifetimes are tied to lexical scope — not to GC timing.
+- **No weak references.** v0.4 has no `Weak<T>` type. Use explicit
+  data structures (e.g. a `Map` keyed on ID) when decoupling lifetime
+  from reachability is required.
+- **Allocation failure (OOM) aborts the process.** OOM is not a
+  recoverable condition in Osty. `abort(msg)` (§10.1) with a
+  descriptive message is invoked before termination.
+- **Reference cycles are reclaimed.** The GC must handle cycles. User
+  code cannot leak a cycle between `struct`/`enum`/closure references,
+  even via `mut` back-edges.
+
+---

--- a/LANG_SPEC_v0.6/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.6/10-standard-library/01-tier-1-core.md
@@ -1,0 +1,39 @@
+### 10.1 Tier 1 (Core)
+
+- `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`, the
+  `Reader`/`Writer` protocol, in-memory `BytesReader`/`Buffer`, and core
+  stream helpers such as `readAll`, `readExact`, `copy`, `writeString`
+- `std.fs` — whole-file and path operations:
+  `read`, `readToString`, `write`, `writeString`, `exists`,
+  `walk`, `glob`, `watch`, `create`, `remove`, `rename`, `copy`,
+  `copyDir`, `mkdir`, `mkdirAll`, `atomicWrite`, `atomicWriteString`,
+  `lockFile`, `hashFile`, `diffFiles`
+- `std.strings` — string manipulation
+- `std.collections` — `List`, `Map`, `Set`
+- `std.option` — `Option`, `Some`, `None` (auto-imported), plus rich
+  combinators (`count`, `forEach`, `toList`, `zipWith`, `reduce`) and
+  nested-shape, composition, and batch helpers `flatten`, `transpose`,
+  `unzip`, `values`, `any`, `all`, `traverse`, `filterMap`, `findMap`,
+  `map2`, `map3`
+- `std.result` — `Result`, `Ok`, `Err` (auto-imported), plus rich
+  combinators (`count`, `forEach`, `toList`, `zip`, `zipWith`) and
+  nested-shape, composition, and batch helpers `flatten`, `transpose`,
+  `values`, `errors`, `partition`, `all`, `traverse`, `map2`, `map3`,
+  `allErrors`, `traverseErrors`
+- `std.error` — `Error`, `BasicError`, `Error.new` (auto-imported)
+- `std.cmp` — `Equal`, `Ordered`, `Hashable` (auto-imported)
+- `std.ref` — `same(a, b)`
+- `std.process` — `abort(msg: String) -> Never`,
+  `unreachable() -> Never`, `todo(msg: String) -> Never`,
+  `ignoreError`, `logError`. Signatures of the latter two:
+
+  ```
+  fn ignoreError<T, E>(result: Result<T, E>)
+  fn logError<T>(result: Result<T, Error>, msg: String)
+  ```
+
+  `ignoreError` consumes the result and discards both the value and any
+  error. `logError` consumes the result; on `Err(e)`, emits a warning
+  via `std.log` (§10.10) of the form `"{msg}: {e.message()}"`. Both are
+  the canonical helpers for use inside `defer` (§4.12).
+- `std.debug` — `dbg(value)`

--- a/LANG_SPEC_v0.6/10-standard-library/02-tier-2-production-essentials.md
+++ b/LANG_SPEC_v0.6/10-standard-library/02-tier-2-production-essentials.md
@@ -1,0 +1,60 @@
+### 10.2 Tier 2 (Production essentials)
+
+- `std.json` — JSON encode/decode (reflection-based)
+- `std.http` — HTTP client and server
+- `std.time` — instants, durations, formatting, parsing, timezones
+- `std.thread` — `taskGroup`, `collectAll`, `parallel`, `race`, `chan`,
+  `select`, `isCancelled`
+- `std.sync` — `Mutex`, `RwLock`, atomics
+- `std.testing` — test framework (see §11)
+- `std.env` — environment variables, command-line arguments
+- `std.iter` — lazy iterator chains
+- `std.regex` — regular expressions (RE2-based)
+- `std.log` — structured logging
+- `std.encoding` — base64, hex, URL encoding
+- `std.crypto` — hashes, HMAC, secure random
+- `std.uuid` — UUID generation and parsing
+- `std.random` — pseudorandom number generation
+- `std.os` — paths, process, signals
+- `std.url` — URL parsing and building
+- `std.math` — mathematical functions and constants
+- `std.csv` — CSV read/write
+- `std.table` — small dataframe helpers for CSV/TSV-scale table work:
+  type inference, schema validation/coercion, typed sort, aggregation, join
+- `std.xlsx` — stored-entry XLSX workbook encode/decode helpers with
+  row/table adapters
+- `std.compress` — gzip compression
+- `std.term` — terminal mode, ANSI control, size, and key input
+- `std.tui` — retained terminal frame buffers and diff rendering
+- `std.grid` — `Point`, `Size`, `Rect`, `Direction`, and `Grid<T>` for
+  board, map, and turn-based layouts
+- `std.clipboard` — host clipboard text read/write for small workflow tools,
+  implemented through the common platform clipboard commands
+- `std.ai` — provider-neutral AI API request builders, headers, response
+  parsers, structured tool call/result loops, model listing, embeddings, and SSE
+  data-line helpers for OpenAI-compatible, OpenRouter, Anthropic, Gemini, and
+  local runtimes
+- `std.aiagents` — dependency-light agent/session/message, tool preset,
+  safety-boundary, and compaction-policy primitives
+- `std.redact` — dependency-free secret redaction for logs, transcripts, URLs,
+  headers, JSON/env assignments, DB connection strings, JWTs, Telegram/Discord
+  text, phone numbers, and private-key blocks
+- `std.security` — SSRF-safe URL classification, safe link extraction, HTML
+  escaping, and session-key validation
+- `std.search` — explicit in-memory index plus stateless Unicode text search
+  with AND→OR fallback, BM25-style scoring, and snippets
+- `std.markdown` — Markdown block/fence extraction and Deneb-style safe
+  HTML-to-Markdown conversion with title/noise/table/list/code handling
+- `std.media` — magic-byte media sniffing, ftyp/OOXML ZIP detection,
+  binary/text sampling, archive path cleaning, YouTube URL helpers, and
+  `MEDIA:` token parsing
+- `std.httpretry` — retry/backoff decisions, provider-code/message
+  classification, quota/context disambiguation, and LLM-specific retry flags
+- `std.webhook` — verified external callback intake for Stripe, GitHub, Slack,
+  Supabase-style HMAC hooks, and Discord externally verified/Ed25519-modeled
+  hooks, with replay-window checks, idempotency keys, and retry-safe dispatch
+- `std.jsonl` — JSON Lines parsing and append-only record helpers
+- `std.tokenest` — model-family-aware multilingual token estimation with
+  explicit calibration state
+- `std.shortid` — deterministic short id formatting
+- `std.metrics` — lightweight labeled counters

--- a/LANG_SPEC_v0.6/10-standard-library/03-excluded-from-stdlib.md
+++ b/LANG_SPEC_v0.6/10-standard-library/03-excluded-from-stdlib.md
@@ -1,0 +1,8 @@
+### 10.3 Excluded from stdlib
+
+Asymmetric cryptography (RSA, Ed25519, etc.), compression formats other
+than gzip (zstd, brotli, lz4), OS-specific APIs (systemd, Windows
+registry, etc.; portable credential storage is exposed through
+`std.keychain` / `std.secrets`), database drivers, message queue clients, serialization
+formats other than JSON/CSV/TSV table text (protobuf, msgpack, avro) — obtained from
+community packages or Go FFI.

--- a/LANG_SPEC_v0.6/10-standard-library/04-prelude.md
+++ b/LANG_SPEC_v0.6/10-standard-library/04-prelude.md
@@ -1,0 +1,11 @@
+### 10.4 Prelude
+
+Auto-imported in every file:
+
+- Types: all primitives, `Option`, `Result`, `Error`, `List`, `Map`,
+  `Set`, `Never`
+- Interfaces: `Equal`, `Ordered`, `Hashable`
+- Variants: `Some`, `None`, `Ok`, `Err`
+- Functions: `print`, `println`, `eprint`, `eprintln`, `dbg`,
+  `taskGroup`, `parallel`
+- Constants: `true`, `false`

--- a/LANG_SPEC_v0.6/10-standard-library/05-standard-numeric-methods.md
+++ b/LANG_SPEC_v0.6/10-standard-library/05-standard-numeric-methods.md
@@ -1,0 +1,78 @@
+### 10.5 Standard Numeric Methods
+
+**Common to every integer type `T` (`Int`, `Int8..Int64`, `UInt8..UInt64`, `Byte`):**
+
+```
+abs() -> T                           // aborts on T.MIN for signed types
+checkedAbs() -> T?
+wrappingAbs() -> T
+min(other: T) -> T
+max(other: T) -> T
+clamp(lo: T, hi: T) -> T
+pow(exp: Int) -> T                   // aborts when exp < 0 or on overflow
+
+wrappingAdd(other: T) -> T
+wrappingSub(other: T) -> T
+wrappingMul(other: T) -> T
+wrappingDiv(other: T) -> T           // aborts only on other = 0
+wrappingMod(other: T) -> T           // aborts only on other = 0
+wrappingShl(other: Int) -> T
+wrappingShr(other: Int) -> T
+
+checkedAdd(other: T) -> T?
+checkedSub(other: T) -> T?
+checkedMul(other: T) -> T?
+checkedDiv(other: T) -> T?           // None on other = 0 or overflow
+checkedMod(other: T) -> T?
+checkedShl(other: Int) -> T?
+checkedShr(other: Int) -> T?
+
+saturatingAdd(other: T) -> T
+saturatingSub(other: T) -> T
+saturatingMul(other: T) -> T
+saturatingDiv(other: T) -> T         // aborts on other = 0
+
+toFloat() -> Float                   // lossy beyond 2^53
+toIntN() -> IntN?                    // lossless conversion to wider Int types
+toChar() -> Char                     // aborts on out-of-range or surrogate
+```
+
+**Common to every float type `T` (`Float`, `Float32`, `Float64`):**
+
+```
+abs() -> T
+min(other: T) -> T
+max(other: T) -> T
+clamp(lo: T, hi: T) -> T
+pow(exp: T) -> T                     // fractional / negative OK
+
+sqrt() -> T
+floor() -> T
+ceil() -> T
+round() -> T                         // half-to-even (banker's rounding)
+trunc() -> T
+toFixed(n: Int) -> String            // "{n}"-digit decimal form
+isNaN() -> Bool
+isInfinite() -> Bool
+toBits() -> UInt64                   // IEEE-754 bit pattern (for hashing)
+
+toIntTrunc() -> Result<Int, Error>   // truncates toward zero; Err on NaN/±Inf/overflow
+toIntRound() -> Result<Int, Error>   // banker's rounding
+toIntFloor() -> Result<Int, Error>
+toIntCeil()  -> Result<Int, Error>
+```
+
+Osty does not provide a plain `Float.toInt()` — the four explicit
+variants above eliminate the ambiguity about rounding mode. NaN and
+±Inf are `Err(Error.new(...))` rather than abort, because they are
+commonly produced by external inputs.
+
+**`Char` conversions** (§2.1):
+
+```
+Char.toInt() -> Int
+Char.fromInt(n: Int) -> Char?        // None on invalid scalar or surrogate
+```
+
+`Int.toChar()` aborts on invalid input (out of range or surrogate);
+`Char.fromInt` is the safe form that returns `None`.

--- a/LANG_SPEC_v0.6/10-standard-library/06-collection-methods.md
+++ b/LANG_SPEC_v0.6/10-standard-library/06-collection-methods.md
@@ -1,0 +1,100 @@
+### 10.6 Collection Methods
+
+All standard collections satisfy `Iterable<T>` (§15) and may be used
+directly with `for x in xs`.
+
+Naming convention:
+- **Verb form** (`push`, `sort`) — mutates in place; requires `mut self`.
+- **Past-participle / `-ed`** (`sorted`, `appended`) — returns new
+  collection.
+
+#### `List<T>`
+
+```
+len() -> Int
+isEmpty() -> Bool
+first() -> T?
+last() -> T?
+get(index: Int) -> T?
+
+contains(item: T) -> Bool                    // T: Equal
+indexOf(item: T) -> Int?                     // T: Equal
+find(pred: fn(T) -> Bool) -> T?
+
+map<R>(f: fn(T) -> R) -> List<R>
+filter(pred: fn(T) -> Bool) -> List<T>
+fold<A>(init: A, f: fn(A, T) -> A) -> A
+reduce(f: fn(T, T) -> T) -> T?
+scan<A>(init: A, f: fn(A, T) -> A) -> List<A>
+flatMap<R>(f: fn(T) -> List<R>) -> List<R>
+sorted() -> List<T>                          // T: Ordered
+sortedBy(key: fn(T) -> K) -> List<T>         // K: Ordered
+reversed() -> List<T>
+take(n: Int) -> List<T>
+drop(n: Int) -> List<T>
+appended(item: T) -> List<T>
+concat(other: List<T>) -> List<T>
+zip<U>(other: List<U>) -> List<(T, U)>
+zip3<U, V>(other1: List<U>, other2: List<V>) -> List<(T, U, V)>
+enumerate() -> List<(Int, T)>
+groupBy<K>(key: fn(T) -> K) -> Map<K, List<T>>  // K: Hashable
+chunked(size: Int) -> List<List<T>>          // aborts when size <= 0
+windowed(size: Int, step: Int) -> List<List<T>> // aborts when size/step <= 0
+partition(pred: fn(T) -> Bool) -> (List<T>, List<T>)
+
+push(item: T)
+pop() -> T?
+insert(index: Int, item: T)
+removeAt(index: Int) -> T
+sort()
+reverse()
+clear()
+```
+
+#### `Map<K, V>`
+
+```
+len() -> Int
+isEmpty() -> Bool
+get(key: K) -> V?
+getOr(key: K, default: V) -> V
+getOrInsert(key: K, default: V) -> V             // eager default; inserts on miss
+getOrInsertWith(key: K, make: fn() -> V) -> V    // lazy supplier; inserts on miss
+containsKey(key: K) -> Bool
+keys() -> List<K>
+values() -> List<V>
+entries() -> List<(K, V)>
+
+forEach(f: fn(K, V))
+any(pred: fn(K, V) -> Bool) -> Bool
+all(pred: fn(K, V) -> Bool) -> Bool
+count(pred: fn(K, V) -> Bool) -> Int
+find(pred: fn(K, V) -> Bool) -> (K, V)?
+
+filter(pred: fn(K, V) -> Bool) -> Map<K, V>
+mapValues<R>(f: fn(V) -> R) -> Map<K, R>
+merge(other: Map<K, V>) -> Map<K, V>             // other wins on conflict
+mergeWith(other: Map<K, V>, combine: fn(V, V) -> V) -> Map<K, V>
+
+insert(key: K, value: V)
+remove(key: K) -> V?
+clear()
+update(key: K, f: fn(V?) -> V)                   // upsert with function
+insertAll(other: Map<K, V>)                      // bulk overwrite
+retainIf(pred: fn(K, V) -> Bool)                 // drop entries where pred is false
+```
+
+#### `Set<T>`
+
+```
+len() -> Int
+isEmpty() -> Bool
+contains(item: T) -> Bool
+union(other: Set<T>) -> Set<T>
+intersect(other: Set<T>) -> Set<T>
+difference(other: Set<T>) -> Set<T>
+
+insert(item: T)
+remove(item: T) -> Bool
+clear()
+```

--- a/LANG_SPEC_v0.6/10-standard-library/07-lazy-iterators.md
+++ b/LANG_SPEC_v0.6/10-standard-library/07-lazy-iterators.md
@@ -1,0 +1,74 @@
+### 10.7 Lazy Iterators (`std.iter`)
+
+For pipeline-style transformations over sequences:
+
+```osty
+use std.iter
+
+let result = iter.from(xs)
+    .map(|x| x * 2)
+    .filter(|x| x > 10)
+    .take(5)
+    .toList()
+```
+
+The current v0.4 stdlib implementation is eager over a backing
+`List<T>`: adapters allocate a new `Iter<T>` immediately. The API is
+kept fluent so user code can move to a lazy pull-based implementation
+later without changing call sites.
+
+API:
+
+```
+iter.from<T>(items: List<T>) -> Iter<T>
+iter.empty<T>() -> Iter<T>
+iter.range(start: Int, stop: Int) -> Iter<Int>
+
+Iter.map<U>(f: fn(T) -> U) -> Iter<U>
+Iter.filter(f: fn(T) -> Bool) -> Iter<T>
+Iter.inspect(f: fn(T) -> ()) -> Iter<T>
+Iter.filterMap<U>(f: fn(T) -> U?) -> Iter<U>
+Iter.mapWhile<U>(f: fn(T) -> U?) -> Iter<U>
+Iter.flatMap<U>(f: fn(T) -> Iter<U>) -> Iter<U>
+Iter.take(n: Int) -> Iter<T>
+Iter.takeLast(n: Int) -> Iter<T>
+Iter.takeWhile(f: fn(T) -> Bool) -> Iter<T>
+Iter.skip(n: Int) -> Iter<T>
+Iter.skipLast(n: Int) -> Iter<T>
+Iter.skipWhile(f: fn(T) -> Bool) -> Iter<T>
+Iter.stepBy(step: Int) -> Iter<T>
+Iter.chain(other: Iter<T>) -> Iter<T>
+Iter.intersperse(separator: T) -> Iter<T>
+Iter.reversed() -> Iter<T>
+Iter.rev() -> Iter<T>
+Iter.enumerate() -> Iter<(Int, T)>
+Iter.zip<U>(other: Iter<U>) -> Iter<(T, U)>
+Iter.zip3<U, V>(other1: Iter<U>, other2: Iter<V>) -> Iter<(T, U, V)>
+Iter.chunked(size: Int) -> Iter<List<T>>
+Iter.chunks(size: Int) -> Iter<List<T>>
+Iter.windowed(size: Int, step: Int) -> Iter<List<T>>
+Iter.windows(size: Int, step: Int) -> Iter<List<T>>
+
+Iter.toList() -> List<T>
+Iter.collect() -> List<T>
+Iter.count() -> Int
+Iter.countWhere(f: fn(T) -> Bool) -> Int
+Iter.isEmpty() -> Bool
+Iter.first() -> T?
+Iter.last() -> T?
+Iter.single() -> T?
+Iter.nth(n: Int) -> T?
+Iter.contains(item: T) -> Bool
+Iter.find(f: fn(T) -> Bool) -> T?
+Iter.lastWhere(f: fn(T) -> Bool) -> T?
+Iter.findMap<U>(f: fn(T) -> U?) -> U?
+Iter.indexWhere(f: fn(T) -> Bool) -> Int?
+Iter.lastIndexWhere(f: fn(T) -> Bool) -> Int?
+Iter.any(f: fn(T) -> Bool) -> Bool
+Iter.all(f: fn(T) -> Bool) -> Bool
+Iter.forEach(f: fn(T) -> ())
+Iter.fold<U>(init: U, f: fn(U, T) -> U) -> U
+Iter.reduce(f: fn(T, T) -> T) -> T?
+Iter.scan<U>(init: U, f: fn(U, T) -> U) -> Iter<U>
+Iter.partition(f: fn(T) -> Bool) -> (List<T>, List<T>)
+```

--- a/LANG_SPEC_v0.6/10-standard-library/08-json.md
+++ b/LANG_SPEC_v0.6/10-standard-library/08-json.md
@@ -1,0 +1,70 @@
+### 10.8 JSON (`std.json`)
+
+Reflection-based encode/decode for primitives, `struct`, and `enum`:
+
+```osty
+struct Config {
+    host: String,
+    port: Int,
+    tags: List<String>,
+}
+
+let text = json.encode(cfg)
+let cfg: Config = json.decode(text)?
+```
+
+Mapping:
+- Field names map verbatim to JSON keys unless overridden by
+  `#[json(key = "...")]` (§3.8.1).
+- Enum variants encode as tagged objects:
+  `{"tag": "Circle", "value": 1.5}`. The tag string is the variant
+  name unless overridden by `#[json(key = "...")]` (§3.8.1). Two
+  variants of the same enum with the same effective tag are a compile
+  error.
+- `T?` maps to nullable JSON (`None` → `null`). During decode, a
+  missing key and an explicit `null` both decode to `None`. To
+  distinguish them, use a wrapper type or a custom `Decode` impl.
+- Collections map to arrays/objects.
+- Non-representable types (e.g. function types, generic type parameters
+  that do not implement `Encode`) are compile errors.
+
+**Decode behavior on errors.**
+
+- **Unknown keys are silently ignored.** A JSON object may contain keys
+  not named by the target struct; the decoder skips them. This is the
+  forward-compatible default (Go/Rust convention). The `#[json(strict)]`
+  annotation is *not* part of the v0.4 set — use a custom `Decode`
+  implementation if strict rejection is required.
+- **Type mismatches are fatal.** When an incoming value's JSON type
+  does not match the target (e.g. string where integer expected),
+  `json.decode` returns `Err` immediately. There is no partial recovery
+  and no field-level skipping.
+- **Lone surrogates in strings** (e.g. `"\uD800"`) are a decode `Err`.
+  Osty's `String` is strict UTF-8 (§2.1) and does not represent
+  surrogate code points.
+- **Non-finite or out-of-range numbers are rejected.** JSON has no
+  representation for `NaN` or infinities, and numbers that overflow the
+  implementation's `Float` range decode as `Err`.
+
+Custom serialization via `Encode`/`Decode` interfaces:
+
+```osty
+interface Encode {
+    fn toJson(self) -> Json
+}
+
+interface Decode {
+    fn fromJson(value: Json) -> Result<Self, Error>
+}
+```
+
+`Json` is an enum of `Object`, `Array`, `String`, `Number`, `Bool`,
+`Null`.
+
+Value-level helpers:
+
+- `json.parseValue(text)` parses UTF-8 JSON text into `Json`.
+- `json.stringifyValue(value)` serializes a `Json` tree as compact JSON.
+  Object keys are emitted in sorted order so output is deterministic.
+  String contents preserve their UTF-8 bytes and escape only JSON-required
+  characters/control bytes.

--- a/LANG_SPEC_v0.6/10-standard-library/09-regular-expressions.md
+++ b/LANG_SPEC_v0.6/10-standard-library/09-regular-expressions.md
@@ -1,0 +1,53 @@
+### 10.9 Regular Expressions (`std.regex`)
+
+RE2-based regular expressions. Linear-time matching; no catastrophic
+backtracking, no ReDoS. Does not support backreferences or lookaround
+(RE2 limitations).
+
+```osty
+use std.regex
+
+let re = regex.compile(r"^\d{3}-\d{4}$")?
+
+if re.matches("123-4567") { ... }
+
+match re.captures("phone: 123-4567 ext 8") {
+    Some(caps) -> println("full: {caps.get(0)}"),
+    None -> {},
+}
+
+let cleaned = regex.compile(r"\s+")?.replace(text, " ")
+
+for m in regex.compile(r"\b\w+\b")?.findAll(text) {
+    process(m.text)
+}
+```
+
+API:
+
+```
+regex.compile(pattern: String) -> Result<Regex, RegexError>
+
+Regex.matches(text: String) -> Bool
+Regex.find(text: String) -> Match?
+Regex.findAll(text: String) -> List<Match>
+Regex.captures(text: String) -> Captures?
+Regex.capturesAll(text: String) -> List<Captures>
+Regex.replace(text: String, replacement: String) -> String
+Regex.replaceAll(text: String, replacement: String) -> String
+Regex.split(text: String) -> List<String>
+
+regex.matches(text: String, pattern: String) -> Result<Bool, RegexError>
+regex.find(text: String, pattern: String) -> Result<Match?, RegexError>
+regex.findAll(text: String, pattern: String) -> Result<List<Match>, RegexError>
+regex.captures(text: String, pattern: String) -> Result<Captures?, RegexError>
+regex.capturesAll(text: String, pattern: String) -> Result<List<Captures>, RegexError>
+regex.replace(text: String, pattern: String, replacement: String) -> Result<String, RegexError>
+regex.replaceAll(text: String, pattern: String, replacement: String) -> Result<String, RegexError>
+regex.split(text: String, pattern: String) -> Result<List<String>, RegexError>
+```
+
+`Match` provides `.text: String`, `.start: Int`, `.end: Int`.
+`Captures` provides `.get(i: Int) -> String?` and
+`.named(name: String) -> String?` for named groups `(?P<name>...)`.
+`RegexError` provides `.message: String` and `.message() -> String`.

--- a/LANG_SPEC_v0.6/10-standard-library/10-logging.md
+++ b/LANG_SPEC_v0.6/10-standard-library/10-logging.md
@@ -1,0 +1,77 @@
+### 10.10 Logging (`std.log`)
+
+Structured logging with levels and pluggable handlers. Inspired by
+Go's `slog`.
+
+```osty
+use std.log
+
+log.info("user logged in", Fields { "userId": 42, "ip": "1.2.3.4" })
+log.warn("rate limit approached", Fields { "remaining": 10 })
+log.error("db connection failed", Fields { "error": err.message() })
+```
+
+API:
+
+```
+pub enum Level { Debug, Info, Warn, Error }
+
+pub struct Fields { ... }            // String -> LogValue map
+
+pub fn debug(msg: String, fields: Fields = Fields {:})
+pub fn info(msg: String, fields: Fields = Fields {:})
+pub fn warn(msg: String, fields: Fields = Fields {:})
+pub fn error(msg: String, fields: Fields = Fields {:})
+
+pub fn setLevel(level: Level)
+pub fn setHandler(handler: Handler)
+
+pub interface Handler {
+    fn handle(self, record: Record)
+}
+
+pub struct TextHandler { ... }       // human-readable, default
+pub struct JsonHandler { ... }       // structured JSON, one line per record
+```
+
+Defaults: output to stderr, `TextHandler`, `Info` level. Handler is
+process-global; replace at startup.
+
+**`LogValue`** is a concrete sum type (resolves G3):
+
+```osty
+pub enum LogValue {
+    Null,
+    Bool(Bool),
+    Int(Int),
+    Float(Float),
+    String(String),
+    Time(Instant),
+    Duration(Duration),
+    Bytes(Bytes),
+    List(List<LogValue>),
+    Map(Map<String, LogValue>),
+}
+```
+
+The `Fields { "k": v }` map literal accepts heterogeneous values
+because the compiler inserts an implicit `.toLogValue()` conversion at
+the literal site for each value position. The `ToLogValue` trait is
+internal:
+
+```osty
+interface ToLogValue {
+    fn toLogValue(self) -> LogValue
+}
+```
+
+It is auto-implemented for: every primitive (§2.6.5), `String`,
+`Bytes`, `Instant`, `Duration`, `Option<T> where T: ToLogValue`,
+`List<T> where T: ToLogValue`, and `Map<String, V> where V: ToLogValue`.
+For struct/enum, an instance is auto-derived using the same scheme as
+`#[json]` encoding (§10.8). User types may implement `ToLogValue`
+explicitly.
+
+`Fields {"k": v}` outside a `log.{debug,info,warn,error,...}` call is
+just an ordinary `Map<String, LogValue>` literal — the implicit
+conversion is what makes the heterogeneous value notation valid.

--- a/LANG_SPEC_v0.6/10-standard-library/11-encoding.md
+++ b/LANG_SPEC_v0.6/10-standard-library/11-encoding.md
@@ -1,0 +1,23 @@
+### 10.11 Encoding (`std.encoding`)
+
+Binary-to-text encodings.
+
+```osty
+use std.encoding
+
+let encoded = encoding.base64.encode(bytes)
+let decoded = encoding.base64.decode(text)?
+
+let hex = encoding.hex.encode(bytes)
+let raw = encoding.hex.decode(text)?
+
+let safe = encoding.url.encode("hello world&foo=bar")
+let back = encoding.url.decode(safe)?
+```
+
+Submodules:
+
+- `encoding.base64` — standard alphabet with padding. `base64.url`
+  for URL-safe alphabet.
+- `encoding.hex` — lowercase output.
+- `encoding.url` — percent-encoding for URL components.

--- a/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
+++ b/LANG_SPEC_v0.6/10-standard-library/12-cryptography.md
@@ -1,0 +1,33 @@
+### 10.12 Cryptography (`std.crypto`)
+
+Hashing, message authentication, and cryptographically secure random
+bytes. Asymmetric cryptography (RSA, Ed25519) is out of scope.
+
+```osty
+use std.crypto
+
+let digest = crypto.sha256(bytes)                    // Bytes (32 bytes)
+let hex = encoding.hex.encode(digest)
+
+let mac = crypto.hmac.sha256(key, message)
+
+let secret = crypto.randomBytes(32)                  // CSPRNG
+```
+
+API:
+
+```
+crypto.sha256(data: Bytes) -> Bytes
+crypto.sha512(data: Bytes) -> Bytes
+crypto.sha1(data: Bytes) -> Bytes         // legacy compatibility only
+crypto.md5(data: Bytes) -> Bytes          // legacy compatibility only
+
+crypto.hmac.sha256(key: Bytes, message: Bytes) -> Bytes
+crypto.hmac.sha512(key: Bytes, message: Bytes) -> Bytes
+
+crypto.randomBytes(n: Int) -> Bytes
+crypto.constantTimeEq(a: Bytes, b: Bytes) -> Bool
+```
+
+Use `crypto.randomBytes` for tokens, keys, and IVs. Use `std.random`
+(§10.14) for simulation, games, and non-security use.

--- a/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
+++ b/LANG_SPEC_v0.6/10-standard-library/13-uuid.md
@@ -1,0 +1,25 @@
+### 10.13 UUID (`std.uuid`)
+
+```osty
+use std.uuid
+
+let id = uuid.v4()                                   // random
+let sortable = uuid.v7()                             // time-ordered
+
+let text = id.toString()
+let parsed: Uuid = uuid.parse(text)?
+```
+
+API:
+
+```
+uuid.v4() -> Uuid
+uuid.v7() -> Uuid                         // preferred for database keys
+uuid.parse(text: String) -> Result<Uuid, Error>
+uuid.nil() -> Uuid
+
+Uuid.toString(self) -> String
+Uuid.toBytes(self) -> Bytes               // 16 bytes
+```
+
+`Uuid` implements `Equal`, `Hashable`, `Ordered`.

--- a/LANG_SPEC_v0.6/10-standard-library/14-random.md
+++ b/LANG_SPEC_v0.6/10-standard-library/14-random.md
@@ -1,0 +1,29 @@
+### 10.14 Random (`std.random`)
+
+Non-cryptographic pseudorandom numbers.
+
+```osty
+use std.random
+
+let rng = random.default()                           // thread-local, auto-seeded
+let n = rng.int(0, 100)
+let f = rng.float()                                  // [0.0, 1.0)
+let picked = rng.choice(items)?
+
+let seeded = random.seeded(42)                       // reproducible
+```
+
+API:
+
+```
+random.default() -> Rng
+random.seeded(seed: Int64) -> Rng
+
+Rng.int(self, min: Int, max: Int) -> Int              // [min, max)
+Rng.intInclusive(self, min: Int, max: Int) -> Int
+Rng.float(self) -> Float                              // [0.0, 1.0)
+Rng.bool(self) -> Bool
+Rng.bytes(self, n: Int) -> Bytes
+Rng.choice<T>(self, items: List<T>) -> T?
+Rng.shuffle<T>(self, items: mut List<T>)
+```

--- a/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
+++ b/LANG_SPEC_v0.6/10-standard-library/15-operating-system.md
@@ -1,0 +1,47 @@
+### 10.15 Operating System (`std.os`)
+
+Paths, process control, and signal handling. File I/O is in `std.fs`;
+environment variables and arguments are in `std.env`.
+
+```osty
+use std.os
+
+let joined = os.path.join(["data", "users", "alice.json"])
+let ext = os.path.extension("report.pdf")            // "pdf"
+let parent = os.path.dirname("/a/b/c.txt")           // "/a/b"
+
+let result = os.exec("git", ["status"])?
+println(result.stdout)
+
+os.exit(0)
+```
+
+API:
+
+```
+os.path.join(parts: List<String>) -> String
+os.path.split(path: String) -> (String, String)      // (dirname, basename)
+os.path.extension(path: String) -> String
+os.path.dirname(path: String) -> String
+os.path.basename(path: String) -> String
+os.path.absolute(path: String) -> Result<String, Error>
+os.path.canonical(path: String) -> Result<String, Error>
+os.path.isAbsolute(path: String) -> Bool
+os.path.separator() -> String                         // "/" or "\\"
+
+os.exec(cmd: String, args: List<String>) -> Result<Output, Error>
+os.execShell(command: String) -> Result<Output, Error>
+
+pub struct Output {
+    pub exitCode: Int,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+os.exit(code: Int) -> Never
+os.pid() -> Int
+os.hostname() -> String
+
+os.onSignal(sig: Signal, handler: fn())
+pub enum Signal { Interrupt, Terminate, Hangup }
+```

--- a/LANG_SPEC_v0.6/10-standard-library/16-url.md
+++ b/LANG_SPEC_v0.6/10-standard-library/16-url.md
@@ -1,0 +1,43 @@
+### 10.16 URL (`std.url`)
+
+URL parsing and building.
+
+```osty
+use std.url
+
+let u = url.parse("https://example.com:8080/path?q=1&r=2#top")?
+
+u.scheme       // "https"
+u.host         // "example.com"
+u.port         // Some(8080)
+u.path         // "/path"
+u.query        // Map<String, String>
+u.fragment     // Some("top")
+
+let built = Url.builder()
+    .scheme("https")
+    .host("api.example.com")
+    .path("/v1/users")
+    .queryParam("limit", "10")
+    .build()
+    .toString()
+```
+
+API:
+
+```
+url.parse(text: String) -> Result<Url, Error>
+url.join(base: String, relative: String) -> Result<String, Error>
+
+pub struct Url {
+    pub scheme: String,
+    pub host: String,
+    pub port: Int?,
+    pub path: String,
+    pub query: Map<String, String>,
+    pub fragment: String?,
+
+    fn toString(self) -> String
+    fn queryValues(self, key: String) -> List<String>
+}
+```

--- a/LANG_SPEC_v0.6/10-standard-library/17-math.md
+++ b/LANG_SPEC_v0.6/10-standard-library/17-math.md
@@ -1,0 +1,42 @@
+### 10.17 Math (`std.math`)
+
+Mathematical functions and constants.
+
+```osty
+use std.math
+
+let area = math.PI * r * r
+let angle = math.sin(math.PI / 4.0)
+let n = math.log(100.0, 10.0)
+```
+
+Constants:
+
+```
+math.PI, math.E, math.TAU
+math.INFINITY, math.NAN
+```
+
+Functions (all operate on `Float`):
+
+```
+math.sin(x), math.cos(x), math.tan(x)
+math.asin(x), math.acos(x), math.atan(x)
+math.atan2(y, x)
+math.sinh(x), math.cosh(x), math.tanh(x)
+
+math.exp(x)
+math.log(x)                           // natural log
+math.log(x, base)
+math.log2(x), math.log10(x)
+
+math.sqrt(x), math.cbrt(x)
+math.pow(x, y)
+
+math.floor(x), math.ceil(x), math.round(x), math.trunc(x)
+math.abs(x)
+math.min(a, b), math.max(a, b)
+math.hypot(a, b)
+```
+
+Integer math lives on the integer methods (§10.5).

--- a/LANG_SPEC_v0.6/10-standard-library/18-csv.md
+++ b/LANG_SPEC_v0.6/10-standard-library/18-csv.md
@@ -1,0 +1,60 @@
+### 10.18 CSV (`std.csv`)
+
+RFC 4180-compliant CSV.
+
+```osty
+use std.csv
+
+let text = csv.encode([
+    ["name", "age", "city"],
+    ["alice", "30", "seoul"],
+    ["bob", "25", "busan"],
+])
+
+let rows: List<List<String>> = csv.decode(text)?
+let tsvRows: List<List<String>> = csv.decodeTsv("name\tage\nalice\t30")?
+
+// With headers
+let records: List<Map<String, String>> = csv.decodeHeaders(text)?
+for r in records {
+    println("{r.get(\"name\")}: {r.get(\"age\")}")
+}
+```
+
+API:
+
+```
+csv.encode(rows: List<List<String>>) -> String
+csv.encodeTsv(rows: List<List<String>>) -> String
+csv.encodeWith(rows: List<List<String>>, options: CsvOptions) -> String
+
+csv.decode(text: String) -> Result<List<List<String>>, Error>
+csv.decodeTsv(text: String) -> Result<List<List<String>>, Error>
+csv.decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error>
+csv.decodeTsvHeaders(text: String) -> Result<List<Map<String, String>>, Error>
+csv.decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error>
+csv.tsvOptions() -> CsvOptions
+
+pub struct CsvOptions {
+    pub delimiter: Char = ',',
+    pub quote: Char = '"',
+    pub trimSpace: Bool = false,
+}
+```
+
+Behavior:
+
+- `encode` emits CRLF row separators. Fields containing the delimiter,
+  quote, CR, or LF are quoted, and embedded quotes are doubled.
+- `encodeWith` aborts on invalid options. `decodeWith` returns an error
+  for the same invalid options. `delimiter` and `quote` must differ, and
+  neither may be CR or LF.
+- `decode` accepts CRLF and bare LF row terminators, accepts a final row
+  without a trailing terminator, and returns `[]` for empty input.
+- `trimSpace` trims ASCII space and tab from unquoted fields. It also
+  permits quoted fields to be surrounded by ASCII space or tab, and
+  `encodeWith(..., trimSpace = true)` quotes fields whose leading or
+  trailing space/tab would otherwise be lost on decode.
+- `decodeHeaders` treats the first row as column names. Header names must
+  be non-empty and unique, and every data row must have exactly the same
+  field count as the header row.

--- a/LANG_SPEC_v0.6/10-standard-library/19-compression.md
+++ b/LANG_SPEC_v0.6/10-standard-library/19-compression.md
@@ -1,0 +1,25 @@
+### 10.19 Compression (`std.compress`)
+
+gzip compression. Other formats (zstd, brotli, lz4) are available as
+community packages.
+
+```osty
+use std.compress
+
+let compressed = compress.gzip.encode(bytes)
+let decompressed = compress.gzip.decode(compressed)?
+
+// Streaming
+let reader = compress.gzip.reader(sourceReader)
+let writer = compress.gzip.writer(destWriter)
+```
+
+API:
+
+```
+compress.gzip.encode(data: Bytes) -> Bytes
+compress.gzip.decode(data: Bytes) -> Result<Bytes, Error>
+
+compress.gzip.reader(source: Reader) -> Reader
+compress.gzip.writer(dest: Writer) -> Writer
+```

--- a/LANG_SPEC_v0.6/10-standard-library/20-time-extensions.md
+++ b/LANG_SPEC_v0.6/10-standard-library/20-time-extensions.md
@@ -1,0 +1,119 @@
+### 10.20 Time Extensions (`std.time`)
+
+Beyond basic instants and durations, `std.time` provides formatting,
+parsing, and timezone handling.
+
+```osty
+use std.time
+
+let now = time.now()                               // Instant
+let iso = now.format(time.ISO_8601)                // "2024-01-15T10:30:00Z"
+let custom = now.format("yyyy-MM-dd HH:mm:ss")
+
+let parsed: Instant = time.parse(iso, time.ISO_8601)?
+
+let later = now.add(5.minutes)
+let diff: Duration = later - now
+
+time.sleep(100.ms)            // returns Err(Cancelled) if task cancelled
+
+let tz = time.zone("Asia/Seoul")?
+let local: ZonedTime = now.inZone(tz)
+```
+
+**Cancellation.** `time.sleep(d)` is a cancellation point per §8.4.2.
+If the surrounding task's cancel signal fires, the sleep returns
+`Err(Cancelled { cause })` immediately — no matter how much of the
+duration is left. The signature is therefore
+`time.sleep(d: Duration) -> Result<(), Error>`; use `time.sleep(d).ok()`
+or `_ = time.sleep(d)` when cancellation is irrelevant.
+
+API additions:
+
+```
+Instant.format(self, layout: String) -> String
+Instant.inZone(self, zone: Zone) -> ZonedTime
+time.parse(text: String, layout: String) -> Result<Instant, Error>
+
+time.zone(name: String) -> Result<Zone, Error>     // IANA timezone
+time.local() -> Zone
+time.utc() -> Zone
+
+time.ISO_8601
+time.RFC_3339
+time.RFC_2822
+```
+
+**Types.**
+
+```osty
+pub struct Zone {
+    pub name: String,           // e.g. "Asia/Seoul", "UTC"
+    pub offset: Duration,       // signed offset from UTC
+    pub isFixed: Bool,          // true for fixed-offset zones (UTC, +09:00),
+                                // false for IANA-rule zones (DST-aware)
+}
+
+pub struct ZonedTime {
+    pub instant: Instant,
+    pub zone: Zone,
+
+    pub fn year(self) -> Int
+    pub fn month(self) -> Int
+    pub fn day(self) -> Int
+    pub fn hour(self) -> Int
+    pub fn minute(self) -> Int
+    pub fn second(self) -> Int
+    pub fn nanosecond(self) -> Int
+    pub fn weekday(self) -> Weekday
+    pub fn format(self, layout: String) -> String
+}
+
+pub enum Weekday { Mon, Tue, Wed, Thu, Fri, Sat, Sun }
+```
+
+**`Duration` is `ToString`** (resolves G2):
+
+```osty
+Duration.toString(self) -> String
+// Adaptive output: "1.23s", "15ms", "120µs", "2m30s", "1h05m".
+```
+
+Whole-unit conversion helpers return truncated integer counts:
+
+```osty
+Duration.abs(self) -> Duration
+Duration.micros(self) -> Int
+Duration.millis(self) -> Int
+Duration.seconds(self) -> Int
+Instant.since(self, earlier: Instant) -> Duration
+```
+
+`Duration` is `Equal`, `Ordered`, `Hashable`. It supports `+`, `-`,
+`*` (by `Int`), `/` (by `Int`).
+
+**Duration literals.** The forms `5.s`, `100.ms`, `1.h`, `30.minutes`,
+`7.days` are **not special syntax**. They are ordinary method calls on
+integer literals. The compiler recognizes the following methods on the
+`Int` type as Duration-producing constructors (defined in `std.time`):
+
+| Method | Returns |
+|---|---|
+| `Int.ns(self)` | `Duration` (nanoseconds) |
+| `Int.us(self)` | `Duration` (microseconds) |
+| `Int.ms(self)` | `Duration` (milliseconds) |
+| `Int.s(self)`  | `Duration` (seconds) |
+| `Int.minutes(self)` | `Duration` (minutes) |
+| `Int.h(self)`  | `Duration` (hours) |
+| `Int.days(self)` | `Duration` (days, 24h) |
+| `Int.weeks(self)` | `Duration` (weeks, 7d) |
+
+The minutes constructor is named `minutes` rather than `min` to avoid
+shadowing `Int.min(self, other) -> Self` from §10.5.
+
+These are compile-time recognized so they do not require an explicit
+`use std.time` to appear in source — but they desugar to method calls
+that the type checker sees normally. The float forms (`1.5.s`) are
+analogous methods on `Float`.
+
+---

--- a/LANG_SPEC_v0.6/10-standard-library/21-bytes.md
+++ b/LANG_SPEC_v0.6/10-standard-library/21-bytes.md
@@ -1,0 +1,70 @@
+### 10.21 Bytes (`std.bytes`)
+
+Byte-sequence manipulation, mirroring `std.strings` for `Bytes` values.
+`Bytes` is an immutable byte sequence (§2.4.1); all operations return new
+values and never mutate in place.
+
+```osty
+use std.bytes
+
+let data: Bytes = b"Hello, World!"
+let upper = bytes.toUpper(data)
+
+if bytes.startsWith(data, b"Hello") {
+    let rest = bytes.slice(data, 7, data.len())
+}
+
+let parts = bytes.split(data, b",")
+let joined = bytes.join(parts, b" | ")
+
+let idx = bytes.indexOf(data, b"World")   // Some(7)
+let replaced = bytes.replace(data, b"World", b"Osty")
+```
+
+API:
+
+```
+bytes.len(b: Bytes) -> Int
+bytes.isEmpty(b: Bytes) -> Bool
+bytes.get(b: Bytes, i: Int) -> Byte?
+bytes.slice(b: Bytes, start: Int, end: Int) -> Bytes
+
+bytes.equal(a: Bytes, b: Bytes) -> Bool
+bytes.contains(b: Bytes, sub: Bytes) -> Bool
+bytes.startsWith(b: Bytes, prefix: Bytes) -> Bool
+bytes.endsWith(b: Bytes, suffix: Bytes) -> Bool
+bytes.indexOf(b: Bytes, sub: Bytes) -> Int?
+bytes.lastIndexOf(b: Bytes, sub: Bytes) -> Int?
+
+bytes.split(b: Bytes, sep: Bytes) -> List<Bytes>
+bytes.join(parts: List<Bytes>, sep: Bytes) -> Bytes
+bytes.concat(a: Bytes, b: Bytes) -> Bytes
+bytes.repeat(b: Bytes, n: Int) -> Bytes
+bytes.replace(b: Bytes, old: Bytes, new: Bytes) -> Bytes
+bytes.replaceAll(b: Bytes, old: Bytes, new: Bytes) -> Bytes
+
+bytes.trimLeft(b: Bytes, strip: Bytes) -> Bytes
+bytes.trimRight(b: Bytes, strip: Bytes) -> Bytes
+bytes.trim(b: Bytes, strip: Bytes) -> Bytes
+
+bytes.toUpper(b: Bytes) -> Bytes         // ASCII only
+bytes.toLower(b: Bytes) -> Bytes         // ASCII only
+
+bytes.fromString(s: String) -> Bytes
+bytes.toString(b: Bytes) -> Result<String, Error>   // validates UTF-8
+bytes.toHex(b: Bytes) -> String          // lowercase hex
+bytes.fromHex(s: String) -> Result<Bytes, Error>
+```
+
+**Notes.**
+
+- `slice(b, start, end)` uses half-open byte indices `[start, end)`.
+  Out-of-range indices abort. Negative indices are not supported.
+- `toUpper` / `toLower` operate on ASCII bytes only (0x41–0x5A,
+  0x61–0x7A). Non-ASCII bytes are passed through unchanged.
+- `toString` validates that the byte sequence is valid UTF-8 and
+  returns `Err` otherwise; this is the safe reinterpretation path.
+  For lossy conversion use `bytes.toHex` and display the hex form.
+- `toHex` / `fromHex` are convenience wrappers over `std.encoding.hex`.
+  Importing `std.encoding` directly is preferred when both encode and
+  decode are needed in the same file.

--- a/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
+++ b/LANG_SPEC_v0.6/10-standard-library/22-fmt.md
@@ -1,0 +1,139 @@
+### 10.22 Formatting (`std.fmt`)
+
+String formatting utilities beyond `{}` interpolation: number base
+conversion, padding and alignment, fixed-precision printing, escaped
+string rendering, compact human-readable numbers, and composite value
+rendering.
+
+```osty
+use std.fmt
+
+// Number bases
+fmt.hex(255)             // "ff"
+fmt.hex(255, upper: true)  // "FF"
+fmt.hexPrefixed(-255)    // "-0xff"
+fmt.octal(8)             // "10"
+fmt.binary(10)           // "1010"
+
+// Padding and alignment
+fmt.padLeft("hi", 6)         // "    hi"
+fmt.padLeft("hi", 6, '0')    // "0000hi"
+fmt.padRight("hi", 6)        // "hi    "
+fmt.center("hi", 6)          // "  hi  "
+fmt.align("hi", 6, "right")  // "    hi"
+
+// Fixed precision (mirrors Float.toFixed)
+fmt.toFixed(3.14159, 2)      // "3.14"
+fmt.toFixed(3.1,    4)       // "3.1000"
+
+// Scientific notation
+fmt.scientific(0.000123)     // "1.23e-4"
+fmt.scientific(0.000123, precision: 1)  // "1.2e-4"
+
+// Template formatting
+fmt.format(r"{} scored {1:>4}", ["Ada", "42"])  // "Ada scored   42"
+fmt.format(r"{0:.5}", ["abcdef"])               // "abcde"
+
+// Escaped strings and compact numbers
+fmt.quote("a\nb")         // "\"a\\nb\""
+fmt.compact(1234000)      // "1.2M"
+fmt.bytesFixed(1536, 1)   // "1.5 KiB"
+fmt.metricBytes(1500, 1)  // "1.5 KB"
+
+// Composite rendering
+fmt.join(["a", "b", "c"], sep: ", ")          // "a, b, c"
+fmt.join(["a", "b", "c"], sep: ", ", last: " and ")  // "a, b and c"
+fmt.repeat("ab", 3)          // "ababab"
+fmt.truncate("hello world", 8)          // "hello..."
+fmt.truncate("hello world", 8, suffix: "…")  // "hello w…"
+fmt.truncateMiddle("abcdef", 5)         // "a...f"
+```
+
+API:
+
+```
+// Integer base formatting
+fmt.intToBase(n: Int, base: Int) -> String
+fmt.hex(n: Int, upper: Bool = false) -> String
+fmt.hexUpper(n: Int) -> String
+fmt.octal(n: Int) -> String
+fmt.binary(n: Int) -> String
+fmt.bin(n: Int) -> String
+fmt.oct(n: Int) -> String
+fmt.inBase(n: Int, base: Int) -> String   // base in 2..36
+fmt.prefixedBase(n: Int, base: Int, prefix: String, upper: Bool = false) -> String
+fmt.hexPrefixed(n: Int, upper: Bool = false) -> String
+fmt.binaryPrefixed(n: Int) -> String
+fmt.octalPrefixed(n: Int) -> String
+fmt.zeroPad(n: Int, width: Int) -> String
+
+// Floating-point formatting
+fmt.fixed(n: Float, precision: Int) -> String
+fmt.toFixed(n: Float, precision: Int) -> String
+fmt.scientific(n: Float, precision: Int = 6) -> String
+fmt.percentage(n: Float, precision: Int = 0) -> String
+fmt.signFloat(n: Float, precision: Int = -1) -> String
+
+// Padding and alignment (pad character defaults to ' ')
+fmt.padLeft(s: String, width: Int, pad: Char = ' ') -> String
+fmt.padRight(s: String, width: Int, pad: Char = ' ') -> String
+fmt.center(s: String, width: Int, pad: Char = ' ') -> String
+fmt.align(s: String, width: Int, mode: String = "left", pad: Char = ' ') -> String
+fmt.visibleWidth(s: String) -> Int
+
+// String utilities
+fmt.repeat(s: String, n: Int) -> String
+fmt.truncate(s: String, maxLen: Int, suffix: String = "...") -> String
+fmt.truncateStart(s: String, maxLen: Int, suffix: String = "...") -> String
+fmt.truncateMiddle(s: String, maxLen: Int, suffix: String = "...") -> String
+fmt.escape(s: String) -> String
+fmt.quote(s: String) -> String
+fmt.indent(text: String, prefix: String) -> String
+fmt.trimTrailingZeros(s: String) -> String
+
+// Template formatting
+fmt.format(template: String, args: List<String>) -> String
+
+// Human-readable number formatting
+fmt.thousands(n: Int, sep: String = ",") -> String
+fmt.ordinal(n: Int) -> String
+fmt.sign(n: Int) -> String
+fmt.compact(n: Int, precision: Int = 1) -> String
+fmt.bytes(n: Int) -> String
+fmt.bytesFixed(n: Int, precision: Int = 2) -> String
+fmt.metricBytes(n: Int, precision: Int = 2) -> String
+
+// List formatting
+fmt.joinWith<T>(items: List<T>, sep: String, mapper: fn(T) -> String) -> String
+fmt.join(parts: List<String>, sep: String, last: String = "") -> String
+fmt.bullet(items: List<String>, marker: String = "- ") -> String
+fmt.numbered(items: List<String>) -> String
+fmt.table(headers: List<String>, rows: List<List<String>>, sep: String = " | ") -> String
+fmt.tableAligned(headers: List<String>, rows: List<List<String>>, alignments: List<String>, sep: String = " | ") -> String
+```
+
+**Notes.**
+
+- `hex`, `octal`, `binary`, and `inBase` operate on non-negative
+  integers. For negative values the sign is preserved:
+  `fmt.hex(-1)` → `"-1"`. Use wrapping casts to format the raw bit
+  pattern of negative signed integers.
+- `inBase` accepts `base` in the range 2–36. Values outside this range
+  abort.
+- Padding, alignment, truncation, and template width/precision count
+  Unicode grapheme clusters so combining marks are not split.
+- `center` distributes extra padding with one more fill character on the
+  right when `width - visibleWidth(s)` is odd.
+- `truncate` returns `s` unchanged when `visibleWidth(s) <= maxLen`.
+  When the suffix itself is longer than `maxLen`, the suffix is returned
+  as-is without truncating it further.
+- `format` supports automatic placeholders (`{}`), positional
+  placeholders (`{0}`), alignment (`<`, `>`, `^`), custom fill
+  (`{0:0>4}`), width, and string precision (`{0:.5}`). Invalid or
+  out-of-range placeholders are preserved literally. Use raw strings or
+  escaped braces so Osty's normal interpolation does not consume the
+  template first.
+- `join` with `last` produces Oxford-comma-style output. When
+  `parts.len() <= 1` the `last` separator is not used.
+- `tableAligned` accepts `"left"`, `"right"`, and `"center"`; unknown or
+  missing alignment entries default to `"left"`.

--- a/LANG_SPEC_v0.6/10-standard-library/23-net.md
+++ b/LANG_SPEC_v0.6/10-standard-library/23-net.md
@@ -1,0 +1,107 @@
+### 10.23 Network (`std.net`)
+
+Low-level TCP and UDP networking. Higher-level HTTP is in `std.http`
+(§10.24). All blocking operations are cancellation-aware (§8.4.2).
+
+```osty
+use std.net
+use std.io
+
+// TCP client
+let conn = net.connect("example.com:443")?
+defer conn.close()
+io.writeAll(conn, b"GET / HTTP/1.0\r\n\r\n")?
+let response = io.readAll(conn)?
+
+// TCP server
+let listener = net.listen("0.0.0.0:8080")?
+defer listener.close()
+
+for {
+    let conn = listener.accept()?
+    thread.spawn(|| {
+        defer conn.close()
+        handleConn(conn)
+    })
+}
+
+// UDP
+let sock = net.udpBind("0.0.0.0:9000")?
+defer sock.close()
+let (data, from) = sock.recvFrom(4096)?
+sock.sendTo(b"pong", from)?
+
+// Address utilities
+let addr = net.resolve("localhost:80")?      // Result<Addr, Error>
+addr.host        // "127.0.0.1"
+addr.port        // 80
+addr.toString()  // "127.0.0.1:80"
+```
+
+API:
+
+```
+// TCP
+net.connect(addr: String) -> Result<TcpConn, Error>
+net.connectTimeout(addr: String, timeout: Duration) -> Result<TcpConn, Error>
+net.listen(addr: String) -> Result<TcpListener, Error>
+
+pub struct TcpConn {
+    // implements Reader, Writer, Closer (§16)
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
+    fn write(self, data: Bytes) -> Result<Int, Error>
+    fn flush(self) -> Result<(), Error>
+    fn close(self) -> Result<(), Error>
+
+    fn localAddr(self) -> Addr
+    fn remoteAddr(self) -> Addr
+    fn setReadTimeout(self, d: Duration) -> Result<(), Error>
+    fn setWriteTimeout(self, d: Duration) -> Result<(), Error>
+}
+
+pub struct TcpListener {
+    // implements Closer (§16)
+    fn accept(self) -> Result<TcpConn, Error>
+    fn close(self) -> Result<(), Error>
+    fn localAddr(self) -> Addr
+}
+
+// UDP
+net.udpBind(addr: String) -> Result<UdpSocket, Error>
+net.udpConnect(addr: String) -> Result<UdpSocket, Error>   // connected mode
+
+pub struct UdpSocket {
+    // implements Closer (§16)
+    fn send(self, data: Bytes) -> Result<Int, Error>        // connected mode
+    fn recv(self, maxBytes: Int) -> Result<Bytes, Error>    // connected mode
+    fn sendTo(self, data: Bytes, addr: Addr) -> Result<Int, Error>
+    fn recvFrom(self, maxBytes: Int) -> Result<(Bytes, Addr), Error>
+    fn close(self) -> Result<(), Error>
+    fn localAddr(self) -> Addr
+}
+
+// Address resolution
+net.resolve(addr: String) -> Result<Addr, Error>
+net.resolveAll(host: String) -> Result<List<Addr>, Error>
+
+pub struct Addr {
+    pub host: String,
+    pub port: Int,
+
+    fn toString(self) -> String    // "host:port"
+}
+```
+
+**Cancellation.** All blocking operations (`connect`, `listen`, `accept`,
+`read`, `write`, `recv`, `recvFrom`) return `Err(Cancelled { cause })`
+when the surrounding task-group's cancel signal fires (§8.4). Setting a
+timeout with `setReadTimeout` / `setWriteTimeout` returns
+`Err(TimedOut { … })` on expiry; the connection remains open.
+
+**TLS.** Encrypted transports (TLS/DTLS) are not part of `std.net` and
+are excluded from the standard library (§10.3). Use Go FFI with
+`crypto/tls` or a community package.
+
+**`TcpConn` as `Reader`/`Writer`.** `TcpConn` satisfies both `Reader`
+and `Writer` (§16), so `io.copy`, `io.readAll`, and `io.writeAll` work
+directly on connections.

--- a/LANG_SPEC_v0.6/10-standard-library/24-http.md
+++ b/LANG_SPEC_v0.6/10-standard-library/24-http.md
@@ -1,0 +1,279 @@
+### 10.24 HTTP (`std.http`)
+
+HTTP client/server ergonomics built on top of three runtime-owned
+transport primitives:
+
+- `http.request(req)` — full client request
+- `http.get(url, headers)` — convenience GET primitive
+- `http.serve(addr, handler)` — server entry point
+
+Everything else in `std.http` is pure Osty convenience code layered on
+those primitives: request and response builders, query/form codecs,
+cookie and auth helpers, media-type parsing, problem responses, and a
+router with path parameters.
+
+```osty
+use std.http
+
+// Client
+let req = http.newRequest(http.Post, "https://api.example.com/users")
+    .withBearerToken(token)
+    .withQueryValue("expand", "profile")
+    .withJson(UserCreate { name: "Ada" })
+
+let created = http.request(req)?
+    .requireStatus(201)?
+let user: User = created.json()?
+
+// Forms and cookies
+let login = http.postForm("https://example.com/login", {
+    "username": ["ada"],
+    "password": ["secret"],
+})?
+
+let csrf = login.setCookie()?.unwrap()
+
+// Server
+let mut router = http.newRouter()
+router.get("/health", |req, params| {
+    let _ = req
+    let _ = params
+    Ok(http.okText("ok"))
+})
+router.get("/users/:id", |req, params| {
+    let _ = req
+    Ok(http.okJson(UserView {
+        id: params.get("id").unwrap(),
+    }))
+})
+
+http.serve(":8080", |req| http.dispatch(router, req))
+```
+
+API:
+
+```osty
+pub type Headers = Map<String, String>
+pub type QueryValues = Map<String, List<String>>
+pub type FormValues = QueryValues
+pub type CookieJar = Map<String, String>
+pub type Params = Map<String, String>
+pub type Handler = fn(Request) -> Result<Response, Error>
+pub type RouteHandler = fn(Request, Params) -> Result<Response, Error>
+
+// Runtime-owned primitives
+http.request(req: Request) -> Result<Response, Error>
+http.get(url: String, headers: Headers = {:}) -> Result<Response, Error>
+http.serve(addr: String, handler: Handler) -> Result<(), Error>
+
+// Client helpers
+http.newRequest(method: Method, url: String) -> Request
+http.dispatch(router: Router, req: Request) -> Result<Response, Error>
+http.send(method: Method, url: String, body: Bytes, headers: Headers = {:}) -> Result<Response, Error>
+http.head(...) / post(...) / put(...) / patch(...) / delete(...) / options(...) / trace(...) / connect(...)
+http.sendText(...) / sendJson(...) / sendForm(...)
+http.postText(...) / putText(...) / patchText(...)
+http.postJson(...) / putJson(...) / patchJson(...)
+http.postForm(...) / putForm(...) / patchForm(...)
+
+// Query/form codecs
+http.parseQuery(text: String) -> Result<QueryValues, Error>
+http.formatQuery(values: QueryValues) -> String
+http.parseForm(text: String) -> Result<FormValues, Error>
+http.formatForm(values: FormValues) -> String
+
+// Media types / auth / cookies
+http.parseMediaType(text: String) -> MediaType?
+http.parseSameSite(text: String) -> Result<SameSite, Error>
+http.parseSetCookie(text: String) -> Result<Cookie, Error>
+http.cookie(name: String, value: String) -> Cookie
+
+pub struct MediaType {
+    pub value: String,
+    pub params: Map<String, String>,
+
+    fn toString(self) -> String
+    fn parameter(self, name: String) -> String?
+    fn is(self, value: String) -> Bool
+}
+
+pub struct BasicAuth {
+    pub username: String,
+    pub password: String,
+
+    fn toHeaderValue(self) -> String
+}
+
+pub enum SameSite {
+    Strict,
+    Lax,
+    NoneSite,
+
+    fn toString(self) -> String
+}
+
+pub struct Cookie {
+    pub name: String,
+    pub value: String,
+    pub path: String,
+    pub domain: String,
+    pub maxAge: Int,
+    pub secure: Bool,
+    pub httpOnly: Bool,
+    pub sameSite: SameSite?,
+
+    fn toString(self) -> String
+}
+
+// Request / response
+pub struct Request {
+    pub method: Method,
+    pub url: String,
+    pub headers: Headers,
+    pub body: Bytes,
+
+    fn header(self, name: String) -> String?
+    fn contentType(self) -> String?
+    fn mediaType(self) -> MediaType?
+    fn accepts(self, value: String) -> Bool
+    fn path(self) -> String
+    fn query(self) -> Result<QueryValues, Error>
+    fn queryValue(self, key: String) -> Result<String?, Error>
+    fn queryValues(self, key: String) -> Result<List<String>, Error>
+    fn text(self) -> Result<String, Error>
+    fn json<T>(self) -> Result<T, Error>
+    fn form(self) -> Result<FormValues, Error>
+    fn cookies(self) -> CookieJar
+    fn cookie(self, name: String) -> String?
+    fn bearerToken(self) -> String?
+    fn basicAuth(self) -> Result<BasicAuth?, Error>
+
+    fn withHeader(self, name: String, value: String) -> Request
+    fn withBody(self, body: Bytes) -> Request
+    fn withText(self, body: String) -> Request
+    fn withJson<T>(self, value: T) -> Request
+    fn withForm(self, values: FormValues) -> Request
+    fn withQueryValue(self, name: String, value: String) -> Request
+    fn withQuery(self, values: QueryValues) -> Request
+    fn withCookie(self, name: String, value: String) -> Request
+    fn withBearerToken(self, token: String) -> Request
+    fn withBasicAuth(self, username: String, password: String) -> Request
+}
+
+pub struct Response {
+    pub status: Int,
+    pub headers: Headers,
+    pub body: Bytes,
+
+    fn statusText(self) -> String
+    fn contentType(self) -> String?
+    fn mediaType(self) -> MediaType?
+    fn isSuccess(self) -> Bool
+    fn isRedirect(self) -> Bool
+    fn isClientError(self) -> Bool
+    fn isServerError(self) -> Bool
+    fn location(self) -> String?
+    fn etag(self) -> String?
+    fn setCookie(self) -> Result<Cookie?, Error>
+    fn requireSuccess(self) -> Result<Response, Error>
+    fn requireStatus(self, status: Int) -> Result<Response, Error>
+    fn text(self) -> Result<String, Error>
+    fn json<T>(self) -> Result<T, Error>
+
+    fn withStatus(self, status: Int) -> Response
+    fn withHeader(self, name: String, value: String) -> Response
+    fn withText(self, body: String) -> Response
+    fn withJson<T>(self, value: T) -> Response
+    fn withCookie(self, cookie: Cookie) -> Response
+    fn withLocation(self, location: String) -> Response
+}
+
+// Response constructors
+http.response(status: Int, body: Bytes, headers: Headers = {:}) -> Response
+http.textResponse(status: Int, body: String, headers: Headers = {:}) -> Response
+http.jsonResponse<T>(status: Int, value: T, headers: Headers = {:}) -> Response
+
+http.ok(...) / okText(...) / okJson(...)
+http.created(...) / createdAt(...)
+http.accepted(...)
+http.noContent(...)
+http.badRequest(...) / unauthorized(...) / forbidden(...) / notFound(...) / methodNotAllowed(...)
+http.conflict(...) / gone(...) / unprocessableContent(...) / tooManyRequests(...)
+http.internalServerError(...) / serviceUnavailable(...)
+http.redirect(...) / movedPermanently(...) / found(...) / seeOther(...)
+http.temporaryRedirect(...) / permanentRedirect(...)
+
+pub struct Problem {
+    pub type: String,
+    pub title: String,
+    pub status: Int,
+    pub detail: String,
+    pub instance: String,
+
+    fn toResponse(self, headers: Headers = {:}) -> Response
+}
+
+http.problem(status: Int, title: String, detail: String = "", headers: Headers = {:}) -> Response
+
+// Router
+pub struct Route {
+    pub methods: List<Method>,
+    pub pattern: String,
+    pub handler: RouteHandler,
+}
+
+pub struct RouteMatch {
+    pub route: Route,
+    pub params: Params,
+}
+
+pub struct Router {
+    pub routes: List<Route>,
+
+    fn route(self, methods: List<Method>, pattern: String, handler: RouteHandler)
+    fn handle(self, method: Method, pattern: String, handler: RouteHandler)
+    fn handleAny(self, pattern: String, handler: RouteHandler)
+    fn get(self, pattern: String, handler: RouteHandler)
+    fn post(self, pattern: String, handler: RouteHandler)
+    fn put(self, pattern: String, handler: RouteHandler)
+    fn patch(self, pattern: String, handler: RouteHandler)
+    fn delete(self, pattern: String, handler: RouteHandler)
+    fn head(self, pattern: String, handler: RouteHandler)
+    fn options(self, pattern: String, handler: RouteHandler)
+    fn trace(self, pattern: String, handler: RouteHandler)
+    fn connect(self, pattern: String, handler: RouteHandler)
+    fn find(self, req: Request) -> RouteMatch?
+}
+
+http.newRouter() -> Router
+```
+
+**Behavior.**
+
+- `Headers` remains `Map<String, String>` for compatibility with the
+  current runtime bridge. Header names are canonicalized (`content-type`
+  and `Content-Type` collapse to the same logical key), but only one
+  logical value is stored per name.
+- `parseQuery` and `parseForm` preserve repeated keys by using
+  `Map<String, List<String>>`. Query formatting is percent-encoded; form
+  formatting uses the usual `+`-for-space convention.
+- `Request.path()` accepts both absolute URLs and origin-form paths
+  (`/users/1?expand=true`). `Router` patterns support literal segments,
+  `:param` captures, and final `*rest` catch-alls.
+- `Router.dispatch` returns `404 Not Found` when no route pattern matches
+  and `405 Method Not Allowed` with an `Allow` header when the path
+  matches but the method does not.
+- `problem(...)` and `Problem.toResponse()` emit
+  `application/problem+json` bodies.
+- Server code dispatches routers through `http.dispatch(router, req)`. The
+  transport primitive remains `http.serve(addr, handler)`.
+
+**Current runtime limits.**
+
+- `std.http` does **not** invent transport capabilities beyond the
+  existing runtime primitives. There are no standard-library-level retry,
+  timeout, redirect-following, streaming-body, or connection-pool knobs
+  yet because the current runtime bridge cannot honor them.
+- `Response.withCookie` and `Response.setCookie` model a single
+  `Set-Cookie` header line because `Headers` is single-valued. Higher
+  multiplicity will require a future runtime/header representation change.

--- a/LANG_SPEC_v0.6/10-standard-library/25-term.md
+++ b/LANG_SPEC_v0.6/10-standard-library/25-term.md
@@ -1,0 +1,42 @@
+### 10.25 Terminal (`std.term`)
+
+`std.term` is the low-level terminal boundary used by text UIs and simple
+terminal games.
+
+Host-backed primitives:
+
+```osty
+term.open() -> Result<Terminal, Error>
+term.isTerminal() -> Bool
+term.size() -> Result<Size, Error>
+term.setRawMode(enabled: Bool) -> Result<(), Error>
+term.readKey() -> Result<Key, Error>
+term.pollKey(timeoutMillis: Int) -> Result<Key?, Error>
+term.readEvent() -> Result<Event, Error>
+term.write(text: String) -> Result<(), Error>
+term.flush() -> Result<(), Error>
+```
+
+Pure ANSI helpers:
+
+```osty
+term.clearScreenSeq() -> String
+term.clearLineSeq() -> String
+term.moveToSeq(Position { x, y }) -> String
+term.hideCursorSeq() -> String
+term.showCursorSeq() -> String
+term.enterAltScreenSeq() -> String
+term.exitAltScreenSeq() -> String
+term.styleSeq(style: Style) -> String
+term.styled(text: String, style: Style) -> String
+```
+
+Coordinates are zero-based in the Osty API. `moveToSeq` converts to the
+one-based row/column convention used by ANSI terminals.
+
+`Terminal.restore()` is the canonical cleanup point for programs that enter
+raw mode, hide the cursor, or switch to the alternate screen.
+
+Current LLVM backend coverage includes `isTerminal`, `size`, `write`, `flush`,
+`setRawMode`, `readKey`, and `pollKey`. Resize event decoding is part of the
+next host-backed terminal increment.

--- a/LANG_SPEC_v0.6/10-standard-library/26-tui.md
+++ b/LANG_SPEC_v0.6/10-standard-library/26-tui.md
@@ -1,0 +1,30 @@
+### 10.26 Text UI (`std.tui`)
+
+`std.tui` provides retained frame buffers for terminal UI code. A `Frame`
+contains fixed-size `Cell` values, each with text and style. Rendering can
+emit a whole frame or only the cells that changed compared with a previous
+frame.
+
+Core API:
+
+```osty
+tui.frame(size: grid.Size) -> Frame
+tui.sized(width: Int, height: Int) -> Frame
+tui.screen(size: grid.Size) -> Screen
+
+Frame.put(point: grid.Point, text: String, style: Style) -> Bool
+Frame.drawText(point: grid.Point, text: String, style: Style) -> Int
+Frame.drawHLine(y: Int, x1: Int, x2: Int, text: String, style: Style) -> Int
+Frame.drawVLine(x: Int, y1: Int, y2: Int, text: String, style: Style) -> Int
+Frame.drawRect(rect: grid.Rect, glyph: String, style: Style)
+Frame.renderAnsi() -> String
+Frame.diffAnsi(previous: Frame?) -> String
+
+Screen.next(frame: Frame) -> String
+Screen.present(frame: Frame) -> Result<(), Error>
+Screen.reset()
+```
+
+`std.tui` intentionally renders to strings first. That keeps frame diffing
+testable and lets callers choose whether to write through `std.term`,
+capture output, or compare snapshots.

--- a/LANG_SPEC_v0.6/10-standard-library/27-grid.md
+++ b/LANG_SPEC_v0.6/10-standard-library/27-grid.md
@@ -1,0 +1,31 @@
+### 10.27 Grid (`std.grid`)
+
+`std.grid` contains small spatial types shared by text UIs, board games,
+roguelikes, simulations, and pathfinding libraries.
+
+Core types:
+
+```osty
+pub struct Point { pub x: Int, pub y: Int }
+pub struct Size { pub width: Int, pub height: Int }
+pub struct Rect { pub origin: Point, pub size: Size }
+pub enum Direction { Up, Down, Left, Right, UpLeft, UpRight, DownLeft, DownRight, Wait }
+pub struct Grid<T>
+```
+
+Constructors:
+
+```osty
+grid.point(x, y) -> Point
+grid.size(width, height) -> Size
+grid.rect(x, y, width, height) -> Rect
+grid.grid<T>(width, height, fill) -> Grid<T>
+grid.fromRows<T>(rows) -> Grid<T>?
+```
+
+`Grid<T>` is row-major. `Grid.index(point)` returns `None` outside bounds,
+and all neighbor helpers filter out points outside the grid.
+
+`std.grid` is deliberately not a pathfinding or roguelike engine. Higher
+level packages can build A*, field of view, dungeon generation, and turn
+scheduling on top of this stable geometry layer.

--- a/LANG_SPEC_v0.6/10-standard-library/28-sql.md
+++ b/LANG_SPEC_v0.6/10-standard-library/28-sql.md
@@ -1,0 +1,94 @@
+### 10.28 SQL (`std.sql`)
+
+`std.sql` provides safe SQL fragment and statement builders. It does not
+open database connections or execute queries; drivers such as SQLite or
+Postgres should accept the `Query` value produced by this module.
+
+```osty
+use std.sql
+
+let active = sql.eq("users.active", sql.boolean(true))?
+let base = sql.selectWhere("users", ["id", "email"], active)?
+let ordered = sql.orderBy(base, [sql.asc("email")?])?
+let q = sql.limit(ordered, 100)?
+
+let postgresText = sql.render(q, sql.postgresDialect())
+let debugText = sql.debugSql(q)
+```
+
+Core types:
+
+```osty
+pub enum Dialect { Generic, Postgres, MySql, Sqlite }
+
+pub enum Value {
+    SqlNull,
+    SqlString(String),
+    SqlInt(Int),
+    SqlFloat(Float),
+    SqlBool(Bool),
+    SqlRaw(String),
+}
+
+pub struct Query { pub sql: String, pub params: List<Value> }
+pub struct Condition { pub sql: String, pub params: List<Value> }
+pub struct Assignment { pub column: String, pub value: Value }
+pub struct Order { pub column: String, pub descending: Bool }
+```
+
+Builders:
+
+```osty
+sql.select(table, columns) -> Result<Query, Error>
+sql.selectWhere(table, columns, condition) -> Result<Query, Error>
+sql.insert(table, assignments) -> Result<Query, Error>
+sql.update(table, assignments, condition) -> Result<Query, Error>
+sql.deleteFrom(table, condition) -> Result<Query, Error>
+sql.orderBy(query, orders) -> Result<Query, Error>
+sql.limit(query, n) -> Result<Query, Error>
+sql.offset(query, n) -> Result<Query, Error>
+```
+
+Conditions:
+
+```osty
+sql.eq(column, value) -> Result<Condition, Error>
+sql.ne(column, value) -> Result<Condition, Error>
+sql.gt(column, value) -> Result<Condition, Error>
+sql.gte(column, value) -> Result<Condition, Error>
+sql.lt(column, value) -> Result<Condition, Error>
+sql.lte(column, value) -> Result<Condition, Error>
+sql.like(column, value) -> Result<Condition, Error>
+sql.isNull(column) -> Result<Condition, Error>
+sql.isNotNull(column) -> Result<Condition, Error>
+sql.inList(column, values) -> Result<Condition, Error>
+sql.allOf(conditions) -> Condition
+sql.anyOf(conditions) -> Condition
+```
+
+Identifier and value helpers:
+
+```osty
+sql.quoteIdent(name) -> Result<String, Error>
+sql.quotePath(path) -> Result<String, Error>
+sql.literal(value) -> String
+sql.placeholder(dialect, index) -> String
+sql.genericDialect() -> Dialect
+sql.postgresDialect() -> Dialect
+sql.mysqlDialect() -> Dialect
+sql.sqliteDialect() -> Dialect
+sql.render(query, dialect) -> String
+sql.debugSql(query) -> String
+```
+
+Behavior:
+
+- Identifiers must be ASCII SQL identifiers: `[A-Za-z_][A-Za-z0-9_]*`.
+  `quotePath` accepts dot-separated paths and final `*`, such as
+  `users.email` or `users.*`.
+- Builders quote identifiers and use `?` placeholders internally. `render`
+  rewrites placeholders for dialects; Postgres uses `$1`, `$2`, and the
+  generic/MySQL/SQLite modes keep `?`.
+- `literal` and `debugSql` are for diagnostics, migrations, or generated SQL
+  text. Runtime query execution should prefer `Query.params` over string
+  interpolation.

--- a/LANG_SPEC_v0.6/10-standard-library/29-db.md
+++ b/LANG_SPEC_v0.6/10-standard-library/29-db.md
@@ -1,0 +1,97 @@
+### 10.29 DB (`std.db`)
+
+`std.db` contains the database pieces that can be implemented without a
+runtime driver: connection configuration, DSN rendering, pool and transaction
+options, row/result containers, and migration planning helpers.
+
+It intentionally does not open SQLite files, sockets, TLS sessions, or execute
+queries. Runtime-backed drivers should consume `db.Config` and `sql.Query`.
+
+```osty
+use std.db
+use std.sql
+
+let base = db.postgres("localhost", db.defaultPort(Postgres), "app", "osty", "secret")?
+let cfg = db.withParam(base, "sslmode", "disable")?
+
+let where = sql.eq("users.active", sql.boolean(true))?
+let query = sql.selectWhere("users", ["id", "email"], where)?
+let driverSql = db.queryText(query, cfg)
+let safeLogDsn = db.redactedDsn(cfg)?
+```
+
+Core types:
+
+```osty
+pub enum Driver { Sqlite, Postgres, MySql }
+pub enum Isolation { DefaultIsolation, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable }
+pub enum Cell { CellNull, CellString(String), CellInt(Int), CellFloat(Float), CellBool(Bool) }
+
+pub struct Config
+pub struct PoolOptions
+pub struct TxOptions
+pub struct Row
+pub struct ResultSet
+pub struct ExecResult
+pub struct Migration
+pub struct MigrationPlan
+```
+
+Configuration:
+
+```osty
+db.sqlite(path) -> Result<Config, Error>
+db.postgres(host, port, database, user, password) -> Result<Config, Error>
+db.mysql(host, port, database, user, password) -> Result<Config, Error>
+db.withParam(config, key, value) -> Result<Config, Error>
+db.dsn(config) -> Result<String, Error>
+db.redactedDsn(config) -> Result<String, Error>
+db.driverName(driver) -> String
+db.defaultPort(driver) -> Int
+db.dialect(driver) -> sql.Dialect
+```
+
+Pool and transactions:
+
+```osty
+db.poolOptions() -> PoolOptions
+db.withMaxOpen(options, n) -> Result<PoolOptions, Error>
+db.withMaxIdle(options, n) -> Result<PoolOptions, Error>
+db.withConnectTimeout(options, ms) -> Result<PoolOptions, Error>
+db.withIdleTimeout(options, ms) -> Result<PoolOptions, Error>
+
+db.txOptions() -> TxOptions
+db.readOnlyTx() -> TxOptions
+db.withIsolation(options, isolation) -> TxOptions
+db.isolationName(isolation) -> String
+```
+
+Rows and results:
+
+```osty
+db.row(values) -> Row
+db.rowGet(row, column) -> Cell?
+db.rowText(row, column) -> String?
+db.resultSet(columns, rows) -> Result<ResultSet, Error>
+db.emptyResultSet(columns) -> Result<ResultSet, Error>
+db.first(resultSet) -> Row?
+db.execResult(rowsAffected, lastInsertId) -> ExecResult
+```
+
+Migrations:
+
+```osty
+db.migration(version, name, up, down) -> Result<Migration, Error>
+db.migrationTableSql() -> sql.Query
+db.recordMigrationSql(migration) -> sql.Query
+db.pendingMigrations(appliedVersions, migrations) -> List<Migration>
+db.plan(currentVersion, migrations) -> MigrationPlan
+```
+
+Behavior:
+
+- DSNs percent-encode user, password, database, SQLite path, and query
+  parameter components.
+- `redactedDsn` preserves shape while replacing the password with `redacted`.
+- Migration helpers sort pending migrations by version and do not execute SQL.
+- Actual database I/O remains a runtime-driver responsibility.

--- a/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
+++ b/LANG_SPEC_v0.6/10-standard-library/30-smtp.md
@@ -1,0 +1,38 @@
+### 10.30 SMTP (`std.smtp`)
+
+`std.smtp` builds SMTP protocol commands and parses server replies. It uses
+`std.email.Envelope` for message data, but does not claim TLS/socket execution
+until the runtime grows that transport layer.
+
+```osty
+use std.smtp
+
+let cfg = smtp.config("smtp.example.com", smtp.defaultPort(StartTls), "client.local")?
+let authed = smtp.withAuth(cfg, smtp.plainAuth("user", "secret"))
+let tx = smtp.transaction(authed, envelope)
+let commands = smtp.commands(tx)?
+```
+
+Core API:
+
+```osty
+smtp.config(host, port, hostname) -> Result<ClientConfig, Error>
+smtp.withSecurity(config, security) -> ClientConfig
+smtp.withAuth(config, auth) -> ClientConfig
+smtp.commands(transaction) -> Result<List<String>, Error>
+smtp.renderCommands(commands) -> String
+
+smtp.authPlain(username, password) -> String
+smtp.authLogin(username, password) -> List<String>
+smtp.parseReply(line) -> Result<Reply, Error>
+smtp.parseReplies(text) -> Result<List<Reply>, Error>
+smtp.capabilities(replies) -> List<Capability>
+```
+
+Behavior:
+
+- AUTH PLAIN and AUTH LOGIN payloads are base64 encoded.
+- Multi-line SMTP replies are represented as individual `Reply` values with
+  `continuation = true` for dashed reply lines.
+- STARTTLS is represented in the command plan; TLS upgrade is runtime-driver
+  work.

--- a/LANG_SPEC_v0.6/10-standard-library/31-zip.md
+++ b/LANG_SPEC_v0.6/10-standard-library/31-zip.md
@@ -1,0 +1,36 @@
+### 10.31 ZIP (`std.zip`)
+
+`std.zip` creates and reads ZIP archives using the standard "store" method.
+This needs no deflate runtime and produces interoperable ZIP files with local
+headers, central directory records, EOCD, and CRC32 checks.
+
+```osty
+use std.bytes
+use std.zip
+
+let entry = zip.file("hello.txt", bytes.fromString("hello"))?
+let archive = zip.encode([entry])?
+let names = zip.list(archive)?
+let payload = zip.extract(archive, "hello.txt")?
+```
+
+Core API:
+
+```osty
+zip.file(name, data) -> Result<Entry, Error>
+zip.encode(entries) -> Result<Bytes, Error>
+zip.decode(archive) -> Result<List<Entry>, Error>
+zip.list(archive) -> Result<List<String>, Error>
+zip.extract(archive, name) -> Result<Bytes?, Error>
+zip.contains(archive, name) -> Bool
+zip.isArchive(data) -> Bool
+zip.crc32(data) -> Int
+```
+
+Behavior:
+
+- Entry names must be relative paths and must not contain parent path
+  segments.
+- Stored entries are fully supported. Deflated entries are detected and return
+  an error until `std.compress` grows a deflate runtime.
+- Decode validates CRC32 and stored payload sizes.

--- a/LANG_SPEC_v0.6/10-standard-library/32-image.md
+++ b/LANG_SPEC_v0.6/10-standard-library/32-image.md
@@ -1,0 +1,34 @@
+### 10.32 Image (`std.image`)
+
+`std.image` detects common image formats and parses header metadata. Full
+pixel decoding is intentionally left for a future runtime-backed codec layer.
+
+Supported metadata formats:
+
+- PNG
+- JPEG
+- GIF
+- BMP
+- WebP
+
+Core API:
+
+```osty
+image.identify(data) -> Format
+image.formatName(format) -> String
+image.parse(data) -> Result<Metadata, Error>
+image.dimensions(data) -> Result<Size, Error>
+image.isImage(data) -> Bool
+image.isPng(data) -> Bool
+image.isJpeg(data) -> Bool
+image.isGif(data) -> Bool
+image.isBmp(data) -> Bool
+image.isWebp(data) -> Bool
+```
+
+Behavior:
+
+- `parse` returns width, height, approximate bits-per-pixel, alpha flag, and
+  animation flag where the container exposes it cheaply.
+- PNG APNG and GIF multi-image files are marked animated by header scanning.
+- Unknown or truncated images return `Error`.

--- a/LANG_SPEC_v0.6/10-standard-library/33-aiagents.md
+++ b/LANG_SPEC_v0.6/10-standard-library/33-aiagents.md
@@ -1,0 +1,83 @@
+### 10.33 AI Agents (`std.aiagents`)
+
+`std.aiagents` contains dependency-light primitives for building agent
+applications. It deliberately starts with the parts that can be implemented as
+pure Osty data shapes and helper logic: message/session models, tool presets,
+trust boundaries, and compaction policy.
+
+The module does not define a model provider, transport, database, Telegram
+client, RPC server, or filesystem workflow. Those belong in host runtimes or
+application packages. The stdlib surface gives those packages a stable common
+vocabulary.
+
+```osty
+use std.aiagents
+
+let opts = aiagents.denebChatOptions()
+let req = aiagents.runRequestWithOptions("telegram:42", "summarize this", opts)
+let policy = aiagents.toolPolicy(aiagents.DenebChat)
+let _ = aiagents.ensureToolAllowed(policy, "web")?
+```
+
+#### Core Shapes
+
+- `Role` — `System`, `User`, `Assistant`, `Tool`
+- `TrustLevel` — `Trusted`, `UserProvided`, `Extracted`, `ToolOutput`,
+  `CompactionSummary`
+- `ContentKind` — `Text`, `Image`, `Audio`, `Video`, `Document`, `Link`,
+  `ToolResult`
+- `ContentBlock` — typed text/media/tool-result block plus source/trust
+  metadata
+- `Message` — role plus a list of content blocks
+- `Session` — key, kind, label, message list, timestamps, and active tool
+  preset
+- `RunOptions`, `RunRequest`, `RunResult`, `RunStatus` — common run envelope
+
+#### Tool Presets
+
+`ToolPreset` standardizes named allow-lists:
+
+- `AllTools` — unrestricted host-defined tools
+- `Conversation` — read/web/wiki/fetch-tools style chat mode
+- `DenebChat` — web-only assistant mode, with media/link extraction expected to
+  happen before the run
+- `Boot` — minimal persistent key-value startup mode
+- `Researcher`, `Implementer`, `Verifier` — role presets for subagents
+
+`toolPolicy`, `allowedTools`, `knownToolPresets`, `parseToolPreset`, and
+`ensureToolAllowed` provide the pure validation layer. Host runtimes are still
+responsible for actually filtering tool schemas and rejecting disallowed calls.
+
+#### Safety And Compaction
+
+`SafetyPolicy` records the baseline trust boundary:
+
+- user input and attachments are untrusted by default
+- hidden prompts, compaction memory, secrets, and routing details stay private
+- the latest user message wins over older memory summaries when they conflict
+
+`CompactPolicy` mirrors the practical thresholds used by dependency-free agent
+runtimes:
+
+- soft compaction at 70 percent of budget
+- hard compaction at 85 percent of budget
+- previous-turn tool results compact to 4096 characters
+- emergency input threshold at 30000 estimated tokens
+
+`shouldCompact`, `estimateTextTokens`, `estimateMessagesTokens`,
+`shouldCompactToolResult`, `truncateHeadTail`, `rankLines`, `scoreOutputLine`,
+and `isPanicAnchor` are pure helpers that let host runtimes make compaction
+decisions without pulling in a model or storage engine.
+
+`truncateHeadTail` preserves the beginning and end of long content and replaces
+the middle with a truncation marker. `rankLines` is the smarter path for logs,
+test output, and tool results: it scores panic/fatal/error/warning lines,
+expands nearby context around high-scoring anchors, then reassembles selected
+lines with omission markers.
+
+#### Trust-Boundary Helpers
+
+`denebChatSystemPrompt` and `denebChatOptions` provide a compact private-chat
+default. `neutralizeSystemTags` removes or downgrades common injected system
+markers such as `<system-reminder>`, `[System Message]`, and line-prefixed
+`System:` labels.

--- a/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
+++ b/LANG_SPEC_v0.6/10-standard-library/34-deneb-utilities.md
@@ -1,0 +1,143 @@
+### 10.34 Deneb-Derived Utilities
+
+These modules port Deneb subsystems that were intentionally implemented
+without external dependencies. The goal is not a thin wrapper around Deneb
+names; each module preserves the behavior that made the original useful.
+
+#### `std.redact`
+
+Best-effort secret redaction for data leaving an application boundary: logs,
+chat transcripts, tool output, crash text, and HTTP metadata. It recognizes
+vendor token prefixes, JWT-like tokens, sensitive key/value names, JSON fields,
+bearer headers, URL userinfo, database connection strings, Telegram bot tokens,
+Discord mentions, E.164-style phone numbers, and private-key blocks.
+`RedactPolicy` controls masking shape while keeping redaction enabled by
+default.
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope. The Osty
+version keeps the original vendor/JWT/DB/header/query/form/JSON/env/private
+key/Telegram/Discord/phone coverage, but implements it as explicit scanners
+instead of regex tables. It also preserves Deneb's important distinction
+between URL/form key-value secrets and ordinary prose such as
+`password=is_not_form`.
+
+#### `std.security`
+
+Small security helpers that do not require a web framework:
+
+- `checkUrl` / `isSafeUrl` block dangerous schemes, localhost, private
+  networks, cloud metadata hosts, IPv4-mapped IPv6 private ranges, and numeric
+  IPv4 bypasses such as decimal, hex, and octal forms
+- `extractSafeLinks` strips Markdown links, finds bare URLs, deduplicates them,
+  and keeps only SSRF-safe targets
+- `sanitizeHtml` escapes HTML-significant characters
+- `validateSessionKey` rejects empty, overlong, or control-character-bearing
+  session keys
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope. It covers
+the original session-key, HTML escaping, dangerous-scheme, localhost/private
+network, cloud metadata, IPv4-mapped IPv6, numeric IPv4, IPv6 zone, file URL,
+UNC path, Markdown-link stripping, dedupe, and balanced URL-tail cases.
+
+#### `std.search`
+
+Pure in-memory text search for small-to-medium local document sets. It performs
+Unicode-aware tokenization, Hangul/CJK token handling, AND-first search with OR
+fallback, BM25-style corpus scoring, title boosts, and snippet extraction.
+The module exposes both a stateless `search` API and a Deneb-style explicit
+`Index` with `upsert`, `remove`, `clear`, `searchIndex`, and `searchIndexOR`.
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope. The original
+thread-safe Go index becomes an explicit immutable-ish value in Osty, which is
+more testable and avoids hidden global state while preserving search behavior.
+
+#### `std.markdown`
+
+Lightweight Markdown and HTML text extraction: block classification, fenced
+code extraction, inline-markup stripping, entity decoding, tag stripping, and a
+Deneb-style HTML-to-Markdown converter for chat/document ingestion paths.
+`HtmlResult` carries both extracted text and `<title>`, while `HtmlOptions`
+enables Deneb's noise-stripping mode for `nav`, `aside`, `svg`, `iframe`, and
+`form` elements. The converter strips script/style/noscript/head bodies,
+preserves multibyte text, converts links/images/emphasis/inline-code/pre-code
+blocks/blockquote/table/ordered-list/list/heading shapes, escapes Markdown
+table cells, and decodes the typography and symbol entities Deneb commonly
+normalized.
+
+Parity audit: now near-full Deneb `htmlmd` surface parity for dependency-free
+stdlib use. It does not copy Deneb's exact tokenizer/emitter implementation,
+but it covers the practical behavior set from the full converter tests:
+title extraction, script/style/noise suppression, malformed/truncated-tag
+resilience, links, images with filename fallback, headings, unordered and
+ordered lists, blockquotes, inline/pre code with language extraction, simple
+tables with header separators and escaping, extended entities, and multibyte
+alignment safety.
+
+#### `std.media`
+
+Magic-byte media detection and file-safety helpers. The detector covers common
+image/audio/video/archive/document formats, ISO BMFF `ftyp` brands, OOXML ZIP
+markers for DOCX/XLSX/PPTX, JSON/XML/HTML starts, binary sampling, archive-path
+cleaning, human-size formatting, YouTube URL/id helpers, and `MEDIA:` token
+parsing with fenced-code awareness, `file://` path normalization,
+`[[audio_as_voice]]` detection, and generic `[[key=value]]` directive
+stripping.
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope. It includes
+the original PNG/JPEG/GIF/WEBP/WAVE/BMP/MP3/TIFF/Ogg/FLAC/WebM/PDF/ZIP/GZIP,
+icon, ftyp MP4/M4A/AVIF/HEIC, OOXML, JSON/XML/HTML, fenced MEDIA, local path,
+quoted path, backtick, dedupe, and directive cases.
+
+#### `std.httpretry`
+
+HTTP/LLM failure classification and retry decisions. It maps status codes and
+provider-style codes/messages to `FailureReason`, then to retry actions such as
+`RetryLater`, `RefreshCredentials`, `CompactContext`, `ReducePayload`,
+`SwitchModel`, or `UpgradePlan`. The classifier includes the Deneb-style edge
+cases for thinking-signature retries, long-context tiers, 402 quota/billing
+disambiguation, generic 400 large-session context overflow, provider error
+codes, large-session disconnect overflow, transient transport/TLS failures,
+and action flags such as `rotate`, `refresh`, `compress`, `stripThinking`,
+`retryOnce`, and `abort`.
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope, minus Go
+error wrapping and JSON-body extraction which belong to host/runtime layers.
+Provider codes are accepted directly through `classifyWithCode`.
+
+#### `std.jsonl`
+
+JSON Lines helpers for append-only local records: line parsing, multi-line
+parsing, value/record encoding, append helpers, quick validation, and
+head/tail compaction for long logs.
+
+#### `std.tokenest`
+
+Model-family-aware token estimation. It classifies Unicode scalar values into
+Latin, Hangul, CJK, digit, space, punctuation, and other buckets, then applies
+conservative per-family ratios for Claude, OpenAI, Gemini, and unknown models.
+`Calibration`, `recordFeedback`, `correctionFactor`, and
+`estimateWithCalibration` port Deneb's self-calibration idea without global
+state or filesystem persistence.
+
+Parity audit: ported at Deneb-equivalent or stronger stdlib scope. The
+estimator keeps Deneb's script ratios, model-family resolution, byte divisor,
+and EMA/clamped correction-factor behavior; persistence remains an application
+or host-runtime concern.
+
+#### `std.shortid`
+
+Deterministic short id formatting using the Deneb-style `prefix_0000` shape.
+The stdlib version keeps generator state explicit so callers can test and
+thread it without hidden globals.
+
+Parity audit: behavior-equivalent for formatting and wraparound, stronger for
+stdlib use because state is explicit instead of package-global.
+
+#### `std.metrics`
+
+Lightweight labeled counters backed by a map. This mirrors Deneb's small
+counter/snapshot utility without assuming Prometheus, histograms, or a scrape
+pipeline.
+
+Parity audit: behavior-equivalent for increment/add/get/snapshot/key joining,
+with explicit value threading instead of lock-backed package globals.

--- a/LANG_SPEC_v0.6/10-standard-library/35-table.md
+++ b/LANG_SPEC_v0.6/10-standard-library/35-table.md
@@ -1,0 +1,188 @@
+### 10.35 Tables (`std.table`)
+
+`std.table` is a small dataframe layer for command-line tools and data
+cleanup jobs. It keeps cells as strings for lossless CSV/TSV round-trips,
+then layers typed access and column inference on top.
+
+```osty
+use std.table
+
+let people = table.fromCsv("name,age,city\nalice,30,seoul\nbob,25,busan")?
+let adults = people
+    .select(["name", "age"])?
+    .sortBy("age", false)?
+
+let counts = people.countBy("city", "count")?
+let text = counts.toTsv()
+```
+
+Typed sort, validation, and aggregation are available when the table is
+being used as a practical dataframe rather than only a CSV wrapper:
+
+```osty
+let sales = table.fromCsv("city,amount\nseoul,10\nbusan,7\nseoul,5")?
+let schema = table.schemaFrom(["city", "amount"], [table.TextColumn, table.FloatColumn])?
+let clean = sales.coerce(schema)?
+let ranked = clean.sortByFloat("amount", true)?
+let byCity = clean.summarizeBy("city", "amount")?
+```
+
+Core API:
+
+```osty
+pub enum ColumnType {
+    EmptyColumn,
+    BoolColumn,
+    IntColumn,
+    FloatColumn,
+    TextColumn,
+    MixedColumn,
+}
+
+pub struct ColumnSchema {
+    pub name: String,
+    pub kind: ColumnType,
+}
+
+pub struct Row {
+    pub values: Map<String, String>,
+
+    pub fn get(self, column: String) -> String?
+    pub fn getOr(self, column: String, fallback: String) -> String
+    pub fn int(self, column: String) -> Int?
+    pub fn float(self, column: String) -> Float?
+    pub fn bool(self, column: String) -> Bool?
+}
+
+pub struct TableGroup {
+    pub key: String,
+    pub rows: List<Row>,
+}
+
+pub struct NumericSummary {
+    pub count: Int,
+    pub sum: Float,
+    pub avg: Float,
+    pub min: Float,
+    pub max: Float,
+}
+
+pub struct JoinIndex {
+    pub columns: List<String>,
+    pub column: String,
+    pub keys: List<String>,
+    pub buckets: Map<String, List<Row>>,
+}
+
+pub struct Table {
+    pub columns: List<String>,
+    pub rows: List<Row>,
+
+    pub fn len(self) -> Int
+    pub fn isEmpty(self) -> Bool
+    pub fn width(self) -> Int
+    pub fn hasColumn(self, column: String) -> Bool
+    pub fn get(self, row: Int, column: String) -> String?
+
+    pub fn select(self, columns: List<String>) -> Result<Table, Error>
+    pub fn drop(self, columns: List<String>) -> Result<Table, Error>
+    pub fn filter(self, pred: fn(Row) -> Bool) -> Table
+    pub fn sortBy(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByType(self, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error>
+    pub fn sortByInt(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByFloat(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn sortByBool(self, column: String, descending: Bool) -> Result<Table, Error>
+    pub fn groupBy(self, column: String) -> Result<List<TableGroup>, Error>
+    pub fn countBy(self, column: String, countColumn: String) -> Result<Table, Error>
+    pub fn innerJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+    pub fn leftJoin(self, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+    pub fn innerJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+    pub fn leftJoinIndex(self, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+    pub fn inferTypes(self) -> List<ColumnSchema>
+    pub fn validateSchema(self, schema: List<ColumnSchema>) -> Result<(), Error>
+    pub fn coerce(self, schema: List<ColumnSchema>) -> Result<Table, Error>
+    pub fn summarize(self, column: String) -> Result<NumericSummary, Error>
+    pub fn summarizeBy(self, groupColumn: String, valueColumn: String) -> Result<Table, Error>
+    pub fn sum(self, column: String) -> Result<Float, Error>
+    pub fn avg(self, column: String) -> Result<Float, Error>
+    pub fn min(self, column: String) -> Result<Float, Error>
+    pub fn max(self, column: String) -> Result<Float, Error>
+    pub fn indexBy(self, column: String) -> Result<JoinIndex, Error>
+
+    pub fn dataRows(self) -> List<List<String>>
+    pub fn toRows(self) -> List<List<String>>
+    pub fn records(self) -> List<Map<String, String>>
+    pub fn toCsv(self) -> String
+    pub fn toTsv(self) -> String
+}
+
+pub fn empty() -> Table
+pub fn row(values: Map<String, String>) -> Row
+pub fn schema(name: String, kind: ColumnType) -> ColumnSchema
+pub fn schemaFrom(columns: List<String>, kinds: List<ColumnType>) -> Result<List<ColumnSchema>, Error>
+
+pub fn fromRows(columns: List<String>, rows: List<List<String>>) -> Result<Table, Error>
+pub fn fromRecords(columns: List<String>, rows: List<Map<String, String>>) -> Result<Table, Error>
+pub fn fromCsv(text: String) -> Result<Table, Error>
+pub fn fromTsv(text: String) -> Result<Table, Error>
+pub fn fromDelimited(text: String, options: csv.CsvOptions) -> Result<Table, Error>
+
+pub fn toCsv(table: Table) -> String
+pub fn toTsv(table: Table) -> String
+pub fn toDelimited(table: Table, options: csv.CsvOptions) -> String
+
+pub fn select(table: Table, columns: List<String>) -> Result<Table, Error>
+pub fn drop(table: Table, columns: List<String>) -> Result<Table, Error>
+pub fn sortBy(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByType(table: Table, column: String, kind: ColumnType, descending: Bool) -> Result<Table, Error>
+pub fn sortByInt(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByFloat(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn sortByBool(table: Table, column: String, descending: Bool) -> Result<Table, Error>
+pub fn groupBy(table: Table, column: String) -> Result<List<TableGroup>, Error>
+pub fn countBy(table: Table, column: String, countColumn: String) -> Result<Table, Error>
+pub fn innerJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+pub fn leftJoin(left: Table, right: Table, leftColumn: String, rightColumn: String) -> Result<Table, Error>
+pub fn innerJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+pub fn leftJoinIndex(left: Table, right: JoinIndex, leftColumn: String) -> Result<Table, Error>
+pub fn inferTypes(table: Table) -> List<ColumnSchema>
+pub fn validateSchema(table: Table, schema: List<ColumnSchema>) -> Result<(), Error>
+pub fn coerce(table: Table, schema: List<ColumnSchema>) -> Result<Table, Error>
+pub fn summarize(table: Table, column: String) -> Result<NumericSummary, Error>
+pub fn summarizeBy(table: Table, groupColumn: String, valueColumn: String) -> Result<Table, Error>
+pub fn sum(table: Table, column: String) -> Result<Float, Error>
+pub fn avg(table: Table, column: String) -> Result<Float, Error>
+pub fn min(table: Table, column: String) -> Result<Float, Error>
+pub fn max(table: Table, column: String) -> Result<Float, Error>
+pub fn indexBy(table: Table, column: String) -> Result<JoinIndex, Error>
+pub fn columnTypeName(kind: ColumnType) -> String
+```
+
+Behavior:
+
+- `fromCsv` and `fromTsv` treat the first row as headers. Header names
+  must be non-empty and unique; data rows must have the same width.
+- `toCsv` and `toTsv` include the header row and delegate escaping to
+  `std.csv`.
+- `select`, `drop`, `sortBy`, `groupBy`, and joins return `Error` for
+  unknown columns instead of silently producing sparse output.
+- `sortBy` is stable enough for small tool data and compares cell text
+  lexicographically.
+- `sortByType` and its `Int`/`Float`/`Bool` wrappers parse cells before
+  comparison and return `Error` for non-conforming values.
+- `validateSchema` accepts empty cells as missing values but checks every
+  non-empty cell against the requested type. `coerce` normalizes typed
+  columns to canonical strings while preserving unspecified columns.
+- `groupBy` preserves first-seen group order. `countBy` is the common
+  aggregation shortcut.
+- `summarize` computes numeric count/sum/avg/min/max for one column.
+  `summarizeBy` returns those statistics as a table grouped by a key
+  column.
+- `innerJoin` and `leftJoin` keep all left columns and include right-side
+  non-key columns. They build a right-side `JoinIndex` internally, so
+  repeated key lookup is linear in the number of rows instead of a nested
+  scan. Reused joins can build the index explicitly with `indexBy`.
+  Conflicting right column names are prefixed with `right.` and suffixed
+  when needed.
+- `inferTypes` ignores empty cells, promotes `IntColumn` plus
+  `FloatColumn` to `FloatColumn`, treats any text cell as `TextColumn`,
+  and returns `MixedColumn` for incompatible non-text mixes.

--- a/LANG_SPEC_v0.6/10-standard-library/36-ai.md
+++ b/LANG_SPEC_v0.6/10-standard-library/36-ai.md
@@ -1,0 +1,173 @@
+### 10.36 AI API (`std.ai`)
+
+`std.ai` provides the provider-neutral API layer for model calls. It is not a
+model SDK and it does not store credentials. Instead, it turns common chat,
+model-listing, and embedding shapes into `std.http.Request` values, then parses
+provider responses back into small Osty structs.
+
+```osty
+use std.ai
+
+let cfg = ai.openRouter(env.require("OPENROUTER_API_KEY")?)
+    .withApp("https://example.app", "Example App")
+let opts = ai.options()
+    .withMaxOutputTokens(512)
+    .withJsonResponse()
+let req = ai.chat("openai/gpt-4.1-mini", [
+    ai.system("Return concise JSON."),
+    ai.user("Summarize this ticket."),
+]).withOptions(opts)
+
+let text = ai.sendChatText(cfg, req)?
+```
+
+#### Providers
+
+`Provider` covers:
+
+- `OpenAI`
+- `OpenAICompatible`
+- `OpenRouter`
+- `Anthropic`
+- `Gemini`
+- `Ollama`
+- `LMStudio`
+- `Custom`
+
+Constructor helpers create a `ProviderConfig` with the expected base URL and
+authentication style:
+
+- `openAI(apiKey)`
+- `openAICompatible(baseUrl, apiKey)`
+- `openAICompatibleLocal(baseUrl)`
+- `openRouter(apiKey)`
+- `anthropic(apiKey)`
+- `gemini(apiKey)`
+- `ollama()`
+- `lmStudio()`
+- `custom(baseUrl, apiKey)`
+- `customNoAuth(baseUrl)`
+
+`ProviderConfig` supports `withBaseUrl`, `withApiKey`, `withOrganization`,
+`withProject`, `withApp`, `withApiVersion`, `withBeta`, and `withHeader`.
+`headers(config)` renders JSON headers plus provider-specific authentication:
+Bearer auth for OpenAI-compatible providers, Anthropic `x-api-key` /
+`anthropic-version`, Gemini `x-goog-api-key`, and OpenRouter application
+metadata headers.
+
+#### Chat
+
+`Message` and `Role` model common chat turns:
+
+- `System`
+- `Developer`
+- `User`
+- `Assistant`
+- `Tool`
+
+Helpers are `system`, `developer`, `user`, `assistant`, and `tool`.
+
+`ChatRequest` contains `model`, `messages`, and `ChatOptions`. `ChatOptions`
+supports:
+
+- `temperature`
+- `topP`
+- `maxOutputTokens`
+- `stop`
+- `stream`
+- `responseFormat`
+- `user`
+- `seed`
+- `reasoningEffort`
+- structured `ToolDefinition` / `ToolChoice` values
+- raw `toolsJson`, `toolChoiceJson`, and `extraJson` escape hatches for
+  provider features that are not promoted yet
+
+#### Tools
+
+`ToolDefinition`, `ToolChoice`, `ToolCall`, and `ToolResult` model the common
+function-calling loop without making callers build provider request JSON
+directly. JSON schema, arguments, and results may be supplied either as JSON
+text (`functionTool`, `toolCall`, `toolResultJson`) or as `std.json.Json`
+values (`functionToolValue`, `toolCallValue`, `toolResultValue`).
+
+```osty
+use std.json
+
+let schema = json.parseValue("{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}")?
+let weather = ai.functionToolValue(
+    "weather_lookup",
+    "Look up weather by city.",
+    schema,
+)
+
+let opts = ai.options()
+    .withTool(weather)
+    .withToolChoice(ai.toolChoiceAuto())
+
+let first = ai.sendChat(cfg, req.withOptions(opts))?
+for call in first.toolCalls() {
+    let result = runTool(call.name, call.argumentsJson)?
+    req = req
+        .append(ai.assistantToolCalls([call]))
+        .append(ai.toolResultMessage(ai.toolResultJson(call.id, call.name, result)))
+}
+```
+
+Provider encoders translate these shared structs into:
+
+- OpenAI-compatible `tools`, `tool_choice`, assistant `tool_calls`, and `tool`
+  result messages.
+- Anthropic `tools`, `tool_choice`, assistant `tool_use` blocks, and user
+  `tool_result` blocks.
+- Gemini `functionDeclarations`, `toolConfig`, `functionCall`, and
+  `functionResponse` parts.
+
+The raw JSON escape hatches remain available, but structured tool definitions,
+choices, calls, and results are the preferred surface.
+
+`encodeChat(config, req)` emits the provider-specific JSON body:
+
+- OpenAI uses `max_completion_tokens`.
+- OpenAI-compatible, OpenRouter, Ollama, LM Studio, and `Custom` use
+  `/chat/completions` and `max_tokens`.
+- Anthropic uses `/v1/messages`, top-level `system`, and required
+  `max_tokens`.
+- Gemini uses `/v1beta/models/{model}:generateContent`, `systemInstruction`,
+  `contents`, and `generationConfig`.
+
+`chatHttpRequest(config, req)` returns the ready `std.http.Request`.
+`sendChat` executes it via `std.http.request`; `sendChatText` returns the joined
+assistant text.
+
+#### Responses
+
+`ChatResponse` normalizes response IDs, model IDs, choices, finish reasons, raw
+JSON, and `Usage`:
+
+- OpenAI-compatible: `choices[].message.content` and
+  `usage.prompt_tokens/completion_tokens/total_tokens`
+- Anthropic: `content[].text` and `usage.input_tokens/output_tokens`
+- Gemini: `candidates[].content.parts[].text` and
+  `usageMetadata.*TokenCount`
+
+When the model requests tool execution, `Choice.toolCalls` and
+`ChatResponse.toolCalls()` expose normalized `ToolCall` values. Tool call
+arguments are preserved as JSON text because providers generate them as JSON and
+application code must still validate them before execution.
+
+`responseErrorMessage` extracts common provider error messages from JSON error
+envelopes before falling back to the raw body.
+
+#### Models, Embeddings, And Streaming
+
+`modelsHttpRequest` and `sendModels` cover provider model listing where the
+transport exposes it.
+
+`EmbeddingRequest`, `embedding`, `embeddingText`, `encodeEmbedding`,
+`embeddingHttpRequest`, and `sendEmbedding` cover OpenAI-compatible embedding
+requests. `supportsEmbeddings` reports whether a provider uses that endpoint
+shape.
+
+For streaming APIs that emit server-sent event lines, `streamDataPayload`
+extracts `data:` payloads and `isDonePayload` recognizes `[DONE]`.

--- a/LANG_SPEC_v0.6/10-standard-library/37-scan.md
+++ b/LANG_SPEC_v0.6/10-standard-library/37-scan.md
@@ -1,0 +1,41 @@
+### 10.37 Scanner Automation (`std.scan`)
+
+`std.scan` provides a typed automation layer for document scanners. Scanner
+drivers remain host-specific, so the module plans and runs host commands rather
+than embedding a driver stack. The built-in backend targets SANE `scanimage`;
+other tools can be wrapped with `CustomCommand` and placeholder arguments.
+
+Core surface:
+
+```osty
+scan.scanimageOptions(outputDir) -> Options
+scan.adfOptions(outputDir) -> Options
+scan.duplexAdfOptions(outputDir) -> Options
+scan.customCommandOptions(command, outputDir) -> Options
+scan.plan(options) -> Result<CommandPlan, Error>
+scan.run(options) -> Result<ScanResult, Error>
+scan.scanAndOcr(options, ocrOptions, maxChunkChars, reviewThreshold) -> Result<OcrScanResult, Error>
+scan.parseScanimageDevices(text) -> List<Device>
+scan.listDevices(command) -> Result<List<Device>, Error>
+scan.listDefaultDevices() -> Result<List<Device>, Error>
+scan.manifest(result) -> String
+```
+
+`Options` covers device id, source (`Flatbed`, `Adf`, `DuplexAdf`), color mode,
+format (`Png`, `Jpeg`, `Tiff`, `Pnm`, `Pdf`), output directory, filename prefix,
+page count, DPI, page size, timeout, and extra host arguments. `Scanimage`
+rejects `Pdf` because `scanimage` emits image streams; use `CustomCommand` for
+PDF-producing tools.
+
+Custom command placeholders:
+
+- `\{output\}`: first planned page path
+- `\{outputs\}`: all planned page paths joined by spaces
+- `\{outputDir\}`: output directory
+- `\{batchPattern\}`: scanimage-style batch pattern
+- `\{device\}`: configured device id
+- `\{format\}`: lower-case format name
+- `\{dpi\}`: configured resolution
+
+The OCR handoff uses `std.ocr.run` for each scanned page, returns a scan-local
+`OcrBatch`, and builds indexed documents with `ocr.indexDocument`.

--- a/LANG_SPEC_v0.6/10-standard-library/38-print.md
+++ b/LANG_SPEC_v0.6/10-standard-library/38-print.md
@@ -1,0 +1,50 @@
+### 10.38 Print (`std.print`)
+
+`std.print` sends existing PDF and image files to the host print spooler. It
+does not implement page rendering in the language runtime; applications should
+produce a PDF or image first, then ask the host printer stack to print it.
+
+Core types:
+
+```osty
+print.DocumentKind
+print.Backend
+print.Orientation
+print.Duplex
+print.ColorMode
+print.Document
+print.Options
+print.Printer
+print.CommandPlan
+print.Job
+```
+
+Core API:
+
+```osty
+print.options() -> Options
+print.file(path) -> Document
+print.pdf(path) -> Document
+print.image(path) -> Document
+print.pageRange(from, to) -> Result<PageRange, Error>
+print.plan(doc, opts) -> Result<CommandPlan, Error>
+print.print(doc, opts) -> Result<Job, Error>
+print.printFile(path) -> Result<Job, Error>
+print.printPdf(path) -> Result<Job, Error>
+print.printImage(path) -> Result<Job, Error>
+print.defaultPrinterName() -> Result<String, Error>
+print.printers() -> Result<List<Printer>, Error>
+```
+
+Behavior:
+
+- `AutoBackend` uses CUPS `lp`, which is available on macOS and common Linux
+  desktops. `Lpr`, `WindowsShell`, and `CustomCommand` expose explicit
+  fallback paths.
+- `plan` validates the requested document kind, copies, page ranges, and
+  command backend without requiring the file to exist.
+- `print` additionally checks that the file exists, runs the command plan, and
+  returns the command output plus a best-effort spooler job id.
+- PDF and image printing are path-based. Byte-to-file rendering, PDF creation,
+  and image pixel conversion remain responsibilities of `std.fs`, `std.gui`,
+  `std.report`, or future codec/runtime layers.

--- a/LANG_SPEC_v0.6/10-standard-library/39-clipboard.md
+++ b/LANG_SPEC_v0.6/10-standard-library/39-clipboard.md
@@ -1,0 +1,27 @@
+### 10.39 Clipboard (`std.clipboard`)
+
+`std.clipboard` provides small-tool clipboard text I/O. It is intentionally
+text-only; binary clipboard formats, MIME negotiation, and platform-native
+pasteboard metadata remain host/runtime concerns.
+
+```osty
+use std.clipboard
+
+clipboard.writeText("ready")?
+let current = clipboard.readText()?
+```
+
+API:
+
+```osty
+clipboard.readText() -> Result<String, Error>
+clipboard.writeText(text: String) -> Result<(), Error>
+clipboard.read() -> Result<String, Error>
+clipboard.write(text: String) -> Result<(), Error>
+clipboard.clear() -> Result<(), Error>
+```
+
+`read` and `write` are short aliases for `readText` and `writeText`.
+Implementations may delegate to host clipboard commands such as `pbpaste`,
+`pbcopy`, Wayland/X11 clipboard tools, AppleScript, or PowerShell. Failure to
+find or run a supported host command returns `Err`.

--- a/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
+++ b/LANG_SPEC_v0.6/10-standard-library/40-xlsx.md
@@ -1,0 +1,31 @@
+### 10.40 XLSX (`std.xlsx`)
+
+`std.xlsx` builds simple Excel-compatible `.xlsx` workbooks on top of
+stored ZIP packaging and `std.table` row adapters.
+
+The first supported format is intentionally conservative: workbooks are ZIP
+packages whose entries use the ZIP "store" method, worksheet cells use inline
+strings or scalar numeric/bool values, and decode supports those same stored
+packages plus shared-string tables when present. Deflated third-party XLSX
+archives become readable once `std.compress` grows deflate support for
+`std.zip`.
+
+```osty
+use std.xlsx
+
+let bytes = xlsx.encodeRows("Report", [
+    ["name", "score"],
+    ["Ada", "42"],
+    ["Grace", "99"],
+])?
+
+let rows = xlsx.decodeRows(bytes, "Report")?
+```
+
+Primary surface:
+
+- `CellKind`, `Cell`, `Sheet`, and `Workbook`
+- `text`, `number`, `int`, `bool`, `blank`, `cell`
+- `sheet`, `workbook`, `fromRows`, `fromTable`, `toTable`, `rows`
+- `encode`, `decode`, `encodeRows`, `decodeRows`, `encodeTable`
+- `sheetNames`, `isWorkbook`, `kindName`

--- a/LANG_SPEC_v0.6/10-standard-library/41-keychain-secrets.md
+++ b/LANG_SPEC_v0.6/10-standard-library/41-keychain-secrets.md
@@ -1,0 +1,36 @@
+### 10.41 Keychain / Secrets (`std.keychain`, `std.secrets`)
+
+`std.keychain` is the portable credential-store facade for API keys, tokens,
+and other small application secrets. It stores secrets by `(service, account)`
+in the OS credential store instead of in project files.
+
+```osty
+use std.keychain
+
+keychain.setApiKey("openrouter", "sk-...")?
+let apiKey = keychain.getApiKey("openrouter")?
+```
+
+The runtime backend is platform-specific:
+
+- macOS: Keychain Services (`Security.framework`)
+- Windows: Credential Manager
+- Other targets: backend is reported as unavailable and read/write operations
+  return `Err`
+
+Core surface:
+
+```osty
+pub fn backend() -> String
+pub fn isAvailable() -> Bool
+pub fn get(service: String, account: String) -> Result<String, Error>
+pub fn set(service: String, account: String, secret: String) -> Result<(), Error>
+pub fn delete(service: String, account: String) -> Result<(), Error>
+pub fn getApiKey(provider: String) -> Result<String, Error>
+pub fn setApiKey(provider: String, secret: String) -> Result<(), Error>
+pub fn deleteApiKey(provider: String) -> Result<(), Error>
+```
+
+`std.secrets` is a convenience facade over `std.keychain` for the common
+API-key/token case. It uses the default service name `osty.api` and treats the
+caller-provided `name` or `provider` as the credential account.

--- a/LANG_SPEC_v0.6/10-standard-library/42-pdf.md
+++ b/LANG_SPEC_v0.6/10-standard-library/42-pdf.md
@@ -1,0 +1,42 @@
+### 10.42 PDF (`std.pdf`)
+
+`std.pdf` provides dependency-free PDF inspection helpers. It does not render
+pages or decode compressed streams; those require host/runtime-backed PDF
+engines. The stdlib surface focuses on portable checks that are useful in CLI
+tools, document search, ingestion pipelines, and diagnostics.
+
+```osty
+use std.bytes
+use std.pdf
+
+let raw = bytes.fromString("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n")
+let doc = pdf.parse(raw)?
+let ok = pdf.isPdf(raw)
+```
+
+Core API:
+
+```osty
+pdf.mime() -> String
+pdf.isPdf(data) -> Bool
+pdf.version(data) -> Result<Version, Error>
+pdf.parse(data) -> Result<Document, Error>
+pdf.metadata(data) -> Result<Info, Error>
+pdf.pageCount(data) -> Result<Int, Error>
+pdf.objects(data) -> Result<List<ObjectHeader>, Error>
+pdf.extractText(data) -> Result<String, Error>
+pdf.extractTextWithOptions(data, options) -> Result<String, Error>
+pdf.hasText(data) -> Bool
+```
+
+Behavior:
+
+- The PDF header may appear within the first 1024 bytes.
+- `parse` reports version, page count, encryption marker, linearization marker,
+  XRef stream marker, object count, and Info dictionary fields.
+- `objects` scans classic `N N obj ... endobj` headers and classifies common
+  object kinds such as catalog, pages, page, font, image, metadata, XRef, and
+  content stream.
+- `extractText` decodes literal and hex strings used by `Tj` / `TJ` text
+  operators in uncompressed non-image streams. Streams with `/Filter` are
+  skipped until a compression runtime is available.

--- a/LANG_SPEC_v0.6/10-standard-library/43-supabase.md
+++ b/LANG_SPEC_v0.6/10-standard-library/43-supabase.md
@@ -1,0 +1,200 @@
+### 10.43 Supabase (`std.supabase`)
+
+`std.supabase` is a lightweight Supabase API layer on top of `std.http`. It
+does not embed a database driver or storage client runtime. Instead, it builds
+ready-to-send HTTP requests for Supabase's stable gateway paths:
+
+- PostgREST data API under `/rest/v1`
+- Auth under `/auth/v1`
+- Storage under `/storage/v1`
+- Edge Functions under `/functions/v1`
+- GraphQL under `/graphql/v1`
+
+```osty
+use std.supabase
+
+let sb = supabase.fromEnv()?
+let q = supabase.from("todos")?
+    .select("id,title,completed")
+    .eq("completed", "false")?
+    .orderDesc("created_at")?
+    .withCount(supabase.CountExact)
+    .range(0, 19)?
+
+let page = supabase.sendSelectPage::<List<Todo>>(sb, q)?
+let rows = page.value
+let total = page.count()
+```
+
+Core types:
+
+```osty
+pub struct Client
+pub struct TableQuery
+pub struct Prefer
+pub struct StorageSort
+pub struct PageInfo
+pub struct Page<T>
+pub struct ApiError
+
+pub enum CountMode { CountNone, CountExact, CountPlanned, CountEstimated }
+pub enum ReturningMode { ReturnDefault, ReturnMinimal, ReturnRepresentation }
+pub enum ResolutionMode { ResolveDefault, MergeDuplicates, IgnoreDuplicates }
+pub enum OrderDirection { Asc, Desc }
+pub enum NullOrdering { NullsDefault, NullsFirst, NullsLast }
+```
+
+Configuration:
+
+```osty
+supabase.client(baseUrl, apiKey) -> Result<Client, Error>
+supabase.project(projectRef, apiKey) -> Result<Client, Error>
+supabase.local(apiKey) -> Result<Client, Error>
+supabase.fromEnv() -> Result<Client, Error>
+supabase.serviceRoleFromEnv() -> Result<Client, Error>
+supabase.fromEnvNames(urlName, keyName) -> Result<Client, Error>
+
+client.withAccessToken(jwt)
+client.withServiceRoleKey(key)
+client.withSchema(schema)
+client.withClientInfo(value)
+client.withHeader(name, value)
+```
+
+`headers(client)` emits the `apikey` header and `Authorization: Bearer ...`.
+When no session token is configured, the bearer value is the API key itself so
+the value exactly matches the `apikey` header. Non-`public` schemas add
+`Accept-Profile` and `Content-Profile`.
+
+`fromEnv()` reads `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
+`serviceRoleFromEnv()` reads `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY`, and configures the service role key as both the
+`apikey` and bearer token. `fromEnvNames()` is the same pattern with custom
+environment variable names.
+
+PostgREST query helpers:
+
+```osty
+supabase.from(table) -> Result<TableQuery, Error>
+
+query.select(columns)
+query.eq(column, value)
+query.neq(column, value)
+query.gt(column, value)
+query.gte(column, value)
+query.lt(column, value)
+query.lte(column, value)
+query.like(column, pattern)
+query.ilike(column, pattern)
+query.isNull(column)
+query.inList(column, values)
+query.contains(column, value)
+query.containedBy(column, value)
+query.overlaps(column, value)
+query.textSearch(column, query)
+query.order(column, direction, nulls)
+query.orderAsc(column)
+query.orderDesc(column)
+query.limit(n)
+query.offset(n)
+query.range(from, to)
+query.withCount(mode)
+query.returning(mode)
+query.resolveDuplicates(mode)
+query.single()
+query.csv()
+```
+
+Pagination metadata:
+
+```osty
+supabase.parseContentRange(value) -> Result<PageInfo, Error>
+supabase.pageInfo(response) -> Result<PageInfo?, Error>
+supabase.responseCount(response) -> Result<Int?, Error>
+
+page.returned()
+page.isEmpty()
+page.hasTotal()
+page.hasNext()
+```
+
+`PageInfo` parses PostgREST `Content-Range` headers such as `0-19/123`
+or `0-19/*`. It is intended to pair with `query.withCount(CountExact)`,
+`CountPlanned`, or `CountEstimated`.
+
+Requests:
+
+```osty
+supabase.selectHttpRequest(client, query)
+supabase.insertHttpRequest(client, table, value)
+supabase.insertWithPreferHttpRequest(client, table, value, prefer)
+supabase.upsertHttpRequest(client, table, value)
+supabase.upsertWithPreferHttpRequest(client, table, value, prefer)
+supabase.updateHttpRequest(client, query, value)
+supabase.deleteHttpRequest(client, query)
+supabase.rpcHttpRequest(client, functionName, args)
+supabase.rpcWithPreferHttpRequest(client, functionName, args, prefer)
+supabase.rpcValueHttpRequest(client, functionName, jsonValue)
+supabase.rpcValueWithPreferHttpRequest(client, functionName, jsonValue, prefer)
+```
+
+Convenience senders execute those requests through `std.http.request`, require
+2xx responses, and decode JSON:
+
+```osty
+supabase.sendSelect<T>(client, query)
+supabase.sendSelectPage<T>(client, query)
+supabase.sendInsert<T, U>(client, table, value)
+supabase.sendInsertWithPrefer<T, U>(client, table, value, prefer)
+supabase.sendUpdate<T, U>(client, query, value)
+supabase.sendDelete<T>(client, query)
+supabase.sendRpc<T, U>(client, functionName, args)
+supabase.sendRpcWithPrefer<T, U>(client, functionName, args, prefer)
+```
+
+Auth:
+
+```osty
+supabase.signUpHttpRequest(client, email, password)
+supabase.passwordTokenHttpRequest(client, email, password)
+supabase.refreshTokenHttpRequest(client, refreshToken)
+supabase.logoutHttpRequest(client)
+```
+
+Storage and functions:
+
+```osty
+supabase.publicObjectUrl(client, bucket, path)
+supabase.authenticatedObjectUrl(client, bucket, path)
+supabase.objectUrl(client, bucket, path)
+supabase.authenticatedObjectHttpRequest(client, bucket, path)
+supabase.downloadObjectHttpRequest(client, bucket, path)
+supabase.uploadObjectHttpRequest(client, bucket, path, body, contentType, upsert)
+supabase.updateObjectHttpRequest(client, bucket, path, body, contentType)
+supabase.removeObjectHttpRequest(client, bucket, paths)
+supabase.signedObjectUrlHttpRequest(client, bucket, path, expiresInSeconds)
+supabase.signedObjectUrlWithTransformHttpRequest(client, bucket, path, expiresInSeconds, transformJson)
+supabase.signedObjectsHttpRequest(client, bucket, paths, expiresInSeconds)
+supabase.storageSort(column, direction)
+supabase.listObjectsHttpRequest(client, bucket, prefix, limit, offset)
+supabase.listObjectsSortedHttpRequest(client, bucket, prefix, limit, offset, sort)
+supabase.searchObjectsHttpRequest(client, bucket, prefix, search, limit, offset)
+
+supabase.invokeFunctionHttpRequest(client, functionName, payload)
+supabase.graphqlHttpRequest(client, bodyJson)
+```
+
+Signed download requests follow Supabase Storage's `/object/sign/...`
+endpoints. List/search requests target `/object/list/{bucket}` and emit the
+documented `prefix`, `limit`, `offset`, optional `sortBy`, and optional
+`search` JSON fields.
+
+Errors:
+
+```osty
+supabase.parseApiError(response) -> ApiError
+supabase.requireSuccess(response) -> Result<http.Response, Error>
+```
+
+`ApiError` extracts the common Supabase/PostgREST JSON fields `code`,
+`message`, `details`, and `hint`, while preserving the raw body for logs.

--- a/LANG_SPEC_v0.6/10-standard-library/44-github.md
+++ b/LANG_SPEC_v0.6/10-standard-library/44-github.md
@@ -1,0 +1,176 @@
+### 10.44 GitHub (`std.github`)
+
+`std.github` is a GitHub automation layer over `std.http`, `std.json`, and
+`std.crypto`. It builds ready-to-send REST requests for day-to-day developer
+automation and verifies GitHub webhook signatures without taking ownership of
+token storage, HTTP hosting, or background job scheduling.
+
+```osty
+use std.env
+use std.github
+
+let gh = github.client(env.require("GITHUB_TOKEN")?)
+let repo = github.repo("choiceoh", "osty")?
+
+let mut issues = github.issueQuery()
+issues.state = github.IssueAll
+let req = github.listIssuesWithQueryHttpRequest(gh, repo, issues)?
+
+let pr = github.pullRequestDraft("fix std.github docs", "codex/std-github", "main")
+let create = github.createPullRequestHttpRequest(gh, repo, pr)?
+```
+
+Core types:
+
+```osty
+pub struct Client
+pub struct Repository
+pub struct Pagination
+pub struct IssueQuery
+pub struct IssueDraft
+pub struct IssuePatch
+pub struct PullRequestQuery
+pub struct PullRequestDraft
+pub struct PullRequestPatch
+pub struct ReviewDraft
+pub struct MergeOptions
+pub struct WorkflowRunQuery
+pub struct WorkflowDispatch
+pub struct ReleaseDraft
+pub struct ReleaseNotesOptions
+pub struct WebhookDelivery
+pub struct WebhookDecision
+pub struct ApiError
+
+pub enum IssueState { IssueOpen, IssueClosed, IssueAll }
+pub enum PullState { PullOpen, PullClosed, PullAll }
+pub enum ReviewEvent { ReviewComment, ReviewApprove, ReviewRequestChanges }
+pub enum MergeMethod { MergeCommit, MergeSquash, MergeRebase }
+```
+
+Configuration:
+
+```osty
+github.anonymous() -> Client
+github.client(token) -> Client
+github.enterprise(baseUrl, uploadBaseUrl, token) -> Result<Client, Error>
+github.repo(owner, name) -> Result<Repository, Error>
+github.parseRepo("owner/name") -> Result<Repository, Error>
+
+client.withToken(token)
+client.withApiVersion(version)
+client.withUserAgent(value)
+client.withHeader(name, value)
+```
+
+`headers(client)` emits `Accept: application/vnd.github+json`,
+`X-GitHub-Api-Version`, `User-Agent`, and `Authorization: Bearer ...` when a
+token is present. Extra headers are applied last so hosts can tune previews or
+enterprise gateway behavior.
+
+Issues:
+
+```osty
+github.issueQuery()
+github.issueDraft(title)
+github.issuePatch()
+
+github.listIssuesHttpRequest(client, repo)
+github.listIssuesWithQueryHttpRequest(client, repo, query)
+github.getIssueHttpRequest(client, repo, number)
+github.createIssueHttpRequest(client, repo, draft)
+github.updateIssueHttpRequest(client, repo, number, patch)
+github.closeIssueHttpRequest(client, repo, number)
+github.commentIssueHttpRequest(client, repo, number, body)
+```
+
+Pull requests:
+
+```osty
+github.pullRequestQuery()
+github.pullRequestDraft(title, head, base)
+github.pullRequestPatch()
+github.review(event, body)
+github.mergeOptions()
+github.mergeOptionsWithMethod(method)
+
+github.listPullRequestsHttpRequest(client, repo)
+github.listPullRequestsWithQueryHttpRequest(client, repo, query)
+github.getPullRequestHttpRequest(client, repo, number)
+github.createPullRequestHttpRequest(client, repo, draft)
+github.updatePullRequestHttpRequest(client, repo, number, patch)
+github.listPullRequestFilesHttpRequest(client, repo, number)
+github.listPullRequestFilesPageHttpRequest(client, repo, number, pagination)
+github.createPullRequestReviewHttpRequest(client, repo, number, review)
+github.requestPullRequestReviewersHttpRequest(client, repo, number, reviewers, teamReviewers)
+github.mergePullRequestHttpRequest(client, repo, number)
+github.mergePullRequestWithOptionsHttpRequest(client, repo, number, options)
+```
+
+Actions:
+
+```osty
+github.workflowRunQuery()
+github.workflowDispatch(ref)
+
+github.listWorkflowRunsHttpRequest(client, repo)
+github.listWorkflowRunsWithQueryHttpRequest(client, repo, query)
+github.listWorkflowRunsForWorkflowHttpRequest(client, repo, workflowId)
+github.listWorkflowRunsForWorkflowWithQueryHttpRequest(client, repo, workflowId, query)
+github.getWorkflowRunHttpRequest(client, repo, runId)
+github.listWorkflowJobsHttpRequest(client, repo, runId)
+github.listWorkflowJobsPageHttpRequest(client, repo, runId, pagination)
+github.workflowDispatchHttpRequest(client, repo, workflowId, dispatch)
+github.rerunWorkflowRunHttpRequest(client, repo, runId)
+github.cancelWorkflowRunHttpRequest(client, repo, runId)
+github.listArtifactsHttpRequest(client, repo)
+github.listArtifactsPageHttpRequest(client, repo, pagination)
+github.downloadArtifactHttpRequest(client, repo, artifactId, archiveFormat)
+```
+
+Releases:
+
+```osty
+github.releaseDraft(tagName)
+github.releaseNotesOptions(tagName)
+
+github.listReleasesHttpRequest(client, repo)
+github.listReleasesPageHttpRequest(client, repo, pagination)
+github.latestReleaseHttpRequest(client, repo)
+github.getReleaseHttpRequest(client, repo, releaseId)
+github.getReleaseByTagHttpRequest(client, repo, tagName)
+github.createReleaseHttpRequest(client, repo, draft)
+github.updateReleaseHttpRequest(client, repo, releaseId, draft)
+github.deleteReleaseHttpRequest(client, repo, releaseId)
+github.generateReleaseNotesHttpRequest(client, repo, options)
+github.uploadReleaseAssetHttpRequest(client, repo, releaseId, name, body, contentType)
+```
+
+Webhooks:
+
+```osty
+github.webhookSignature(secret, body) -> String
+github.verifyWebhookSignature(secret, body, signatureHeader) -> Bool
+github.webhookDelivery(request) -> WebhookDelivery
+github.verifyWebhookRequest(request, secret) -> WebhookDecision
+github.parseWebhookPayload(request) -> Result<json.Json, Error>
+github.webhookAction(body) -> String?
+github.isWebhookEvent(request, eventName) -> Bool
+github.webhookAck(message) -> http.Response
+```
+
+`webhookSignature` renders the `sha256=` value GitHub sends in
+`X-Hub-Signature-256`. Verification uses HMAC-SHA256 and constant-time byte
+comparison through `std.crypto`.
+
+Execution helpers:
+
+```osty
+github.execute(request) -> Result<http.Response, Error>
+github.executeJson<T>(request) -> Result<T, Error>
+github.parseApiError(response) -> ApiError
+github.requireSuccess(response) -> Result<http.Response, Error>
+```
+
+`ApiError` extracts GitHub's common `message` and `documentation_url` fields
+while preserving the raw body for logs and agent transcripts.

--- a/LANG_SPEC_v0.6/10-standard-library/45-webhook.md
+++ b/LANG_SPEC_v0.6/10-standard-library/45-webhook.md
@@ -1,0 +1,133 @@
+### 10.45 Webhooks (`std.webhook`)
+
+`std.webhook` is the safe intake layer for HTTP callbacks from external
+systems. It composes with `std.http`, `std.crypto`, `std.encoding`,
+`std.json`, and `std.time` instead of owning a server runtime. The module
+standardizes four things that should happen before business logic runs:
+
+- verify the raw request body against the provider signature
+- reject stale signed timestamps where the provider supplies one
+- derive a stable delivery id for idempotency
+- dispatch through a retry-safe outcome that separates duplicates, in-flight
+  deliveries, handler failures, and intentional retry responses
+
+```osty
+use std.env
+use std.http
+use std.webhook
+
+let policy = webhook.stripe(env.require("STRIPE_WEBHOOK_SECRET")?)
+let store = webhook.emptyStore()
+
+let outcome = webhook.dispatch(request, policy, store, fn(event) {
+    // Business logic runs only after signature and replay checks pass.
+    webhook.ack()
+})
+
+return outcome.response
+```
+
+Core types:
+
+```osty
+pub enum Provider { Stripe, GitHub, Supabase, Slack, Discord, Custom }
+
+pub enum SignatureScheme {
+    StripeV1,
+    GitHubSha256,
+    SlackV0,
+    SupabaseSha256,
+    HmacSha256Hex,
+    HmacSha256Base64,
+    DiscordEd25519,
+    ExternallyVerified,
+}
+
+pub enum VerificationCode {
+    Verified,
+    MissingSecret,
+    MissingSignature,
+    InvalidSignature,
+    MissingTimestamp,
+    InvalidTimestamp,
+    ReplayWindowExceeded,
+    UnsupportedSignature,
+}
+
+pub enum DispatchStatus { Handled, Duplicate, InFlight, Rejected, RetryLater, Failed }
+
+pub struct Policy
+pub struct Verification
+pub struct Event
+pub struct Store
+pub struct DispatchDecision
+pub struct DispatchOutcome
+```
+
+Provider policies:
+
+```osty
+webhook.stripe(secret)
+webhook.github(secret)
+webhook.supabase(secret)
+webhook.slack(secret)
+webhook.discord(publicKey)
+webhook.hmacSha256Hex(secret, header)
+webhook.hmacSha256Base64(secret, header)
+webhook.unsigned(provider)
+```
+
+The built-in provider policies use the provider's raw-body signature shape:
+
+- Stripe: `Stripe-Signature`, signed payload `t.raw_body`, HMAC-SHA256 hex
+  `v1`, default 5-minute tolerance.
+- GitHub: `X-Hub-Signature-256`, `sha256=` + HMAC-SHA256 hex of the raw body,
+  with `X-GitHub-Delivery` and `X-GitHub-Event` as id/type headers.
+- Slack: `X-Slack-Signature`, signed payload `v0:timestamp:raw_body`,
+  `X-Slack-Request-Timestamp`, default 5-minute tolerance.
+- Supabase: configurable HMAC-SHA256 hex convention using
+  `x-supabase-signature`; callers can override headers with `Policy` methods.
+- Discord: models the required `X-Signature-Ed25519` and
+  `X-Signature-Timestamp` headers but returns `UnsupportedSignature` until the
+  runtime exposes Ed25519 verification. Use `policy.externallyVerified()` only
+  when a host layer has already verified the request.
+
+Verification and extraction:
+
+```osty
+webhook.verify(policy, headers, body) -> Verification
+webhook.verifyRequest(request, policy) -> Verification
+webhook.eventFromRequest(request, policy, verification) -> Event
+webhook.header(headers, name) -> String?
+webhook.bodyFingerprint(body) -> String
+```
+
+Dispatch:
+
+```osty
+webhook.dispatch(request, policy, store, handler) -> DispatchOutcome
+webhook.ack() -> DispatchDecision
+webhook.retryLater(message) -> DispatchDecision
+webhook.reject(status, message) -> DispatchDecision
+```
+
+`dispatch` returns `200` for already processed deliveries so provider retries do
+not re-run business logic. In-flight duplicates return `202`, handler errors
+return `500` and clear the in-flight marker, and retry decisions preserve the
+delivery as unprocessed so a later provider retry can run again.
+
+Idempotency helpers:
+
+```osty
+webhook.emptyStore() -> Store
+webhook.idempotencyKey(event) -> String
+webhook.wasProcessed(store, key) -> Bool
+webhook.isInFlight(store, key) -> Bool
+webhook.markInFlight(store, key) -> Store
+webhook.markProcessed(store, key) -> Store
+webhook.clearInFlight(store, key) -> Store
+```
+
+`Store` is intentionally value-shaped. Small applications can keep it in memory;
+larger services should persist the same `idempotencyKey(event)` in a database or
+queue table before performing side effects.

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -1,0 +1,62 @@
+## 10. Standard Library
+
+This chapter is split into one file per subsection for easier navigation. The introduction below states the structuring principles; each `std.*` package then lives in its own file.
+
+## 10. Standard Library
+
+**v0.4 stub policy.** Standard-library protocol signatures are tracked
+as checked `.osty` stubs before runtime parity. A stub may use a dummy
+body, but it must parse, resolve, and type-check. If moving prose from
+§10, §15, §16, or §17 into stubs exposes a signature ambiguity, that
+ambiguity becomes a new language-decision gap; missing backend/runtime
+lowering remains implementation backlog.
+
+## Sections
+
+- [§10.1 Tier 1 (Core)](./01-tier-1-core.md)
+- [§10.2 Tier 2 (Production essentials)](./02-tier-2-production-essentials.md)
+- [§10.3 Excluded from stdlib](./03-excluded-from-stdlib.md)
+- [§10.4 Prelude](./04-prelude.md)
+- [§10.5 Standard Numeric Methods](./05-standard-numeric-methods.md)
+- [§10.6 Collection Methods](./06-collection-methods.md)
+- [§10.7 Lazy Iterators (`std.iter`)](./07-lazy-iterators.md)
+- [§10.8 JSON (`std.json`)](./08-json.md)
+- [§10.9 Regular Expressions (`std.regex`)](./09-regular-expressions.md)
+- [§10.10 Logging (`std.log`)](./10-logging.md)
+- [§10.11 Encoding (`std.encoding`)](./11-encoding.md)
+- [§10.12 Cryptography (`std.crypto`)](./12-cryptography.md)
+- [§10.13 UUID (`std.uuid`)](./13-uuid.md)
+- [§10.14 Random (`std.random`)](./14-random.md)
+- [§10.15 Operating System (`std.os`)](./15-operating-system.md)
+- [§10.16 URL (`std.url`)](./16-url.md)
+- [§10.17 Math (`std.math`)](./17-math.md)
+- [§10.18 CSV (`std.csv`)](./18-csv.md)
+- [§10.19 Compression (`std.compress`)](./19-compression.md)
+- [§10.20 Time Extensions (`std.time`)](./20-time-extensions.md)
+- [§10.21 Bytes (`std.bytes`)](./21-bytes.md)
+- [§10.22 Formatting (`std.fmt`)](./22-fmt.md)
+- [§10.23 Network (`std.net`)](./23-net.md)
+- [§10.24 HTTP (`std.http`)](./24-http.md)
+- [§10.25 Terminal (`std.term`)](./25-term.md)
+- [§10.26 Text UI (`std.tui`)](./26-tui.md)
+- [§10.27 Grid (`std.grid`)](./27-grid.md)
+- [§10.28 SQL (`std.sql`)](./28-sql.md)
+- [§10.29 DB (`std.db`)](./29-db.md)
+- [§10.30 SMTP (`std.smtp`)](./30-smtp.md)
+- [§10.31 ZIP (`std.zip`)](./31-zip.md)
+- [§10.32 Image (`std.image`)](./32-image.md)
+- [§10.33 AI Agents (`std.aiagents`)](./33-aiagents.md)
+- [§10.34 Deneb-Derived Utilities (`std.redact`, `std.security`,
+  `std.search`, `std.markdown`, `std.media`, `std.httpretry`, `std.jsonl`,
+  `std.tokenest`, `std.shortid`, `std.metrics`)](./34-deneb-utilities.md)
+- [§10.35 Tables (`std.table`)](./35-table.md)
+- [§10.36 AI API (`std.ai`)](./36-ai.md)
+- [§10.37 Scanner Automation (`std.scan`)](./37-scan.md)
+- [§10.38 Print (`std.print`)](./38-print.md)
+- [§10.39 Clipboard (`std.clipboard`)](./39-clipboard.md)
+- [§10.40 XLSX (`std.xlsx`)](./40-xlsx.md)
+- [§10.41 Keychain / Secrets (`std.keychain`, `std.secrets`)](./41-keychain-secrets.md)
+- [§10.42 PDF (`std.pdf`)](./42-pdf.md)
+- [§10.43 Supabase (`std.supabase`)](./43-supabase.md)
+- [§10.44 GitHub (`std.github`)](./44-github.md)
+- [§10.45 Webhooks (`std.webhook`)](./45-webhook.md)

--- a/LANG_SPEC_v0.6/11-testing.md
+++ b/LANG_SPEC_v0.6/11-testing.md
@@ -1,0 +1,248 @@
+## 11. Testing
+
+Test files use the `_test.osty` suffix and live alongside code in the
+same package. Functions whose names begin with lowercase `test` and
+take no arguments are discovered and run by `osty test`. A top-level
+zero-arity function annotated with `#[test]` is also discovered, even in
+a production source file; annotated test functions are excluded from
+production builds.
+
+```osty
+// auth/login_test.osty
+use std.testing
+
+fn testLoginSuccess() {
+    let result = login("alice", "valid_pass")
+    testing.assert(result.isOk())
+}
+
+fn testLoginRejectsBlankUser() {
+    let result = login("", "anything")
+    testing.assertEq(result, Err(InvalidInput))
+}
+```
+
+Test files are excluded from production builds.
+
+### 11.1 Assertion API
+
+```
+testing.assert(cond: Bool)
+testing.assertEq<T: Equal>(actual: T, expected: T)
+testing.assertNe<T: Equal>(actual: T, expected: T)
+testing.expectOk<T, E>(result: Result<T, E>) -> T
+testing.expectError<T, E>(result: Result<T, E>) -> E
+testing.fail(msg: String) -> Never
+testing.context(msg: String, body: fn())
+```
+
+### 11.2 Detailed Failure Output
+
+The compiler recognizes the above `testing` functions specifically and
+generates detailed failure output including:
+
+- Source location (file and line)
+- Textual form of the argument expressions (captured at compile time)
+- Runtime values (formatted structurally)
+- A structural diff for composite values
+
+**Structural diff (shipped).** When both sides of `assertEq` share
+a diffable shape, the failure message appends a trim-prefix /
+trim-suffix line diff with up to 3 lines of shared context. Lines
+that differ are prefixed with `- left` or `+ right`; shared context
+lines are prefixed with two spaces. The diff is only computed on the
+failure path — passing asserts pay zero. Today's diff coverage:
+
+- Two `String` values — compared directly, line by line.
+- Two `List<T>` values with the same primitive `T` (`Int`, `Float`,
+  `Bool`, `String`) — each list is rendered as a multi-line literal
+  (`[\n  elem,\n  ...\n]`) via `osty_rt_list_primitive_to_string`
+  before the diff runs, so an element-level divergence surfaces as
+  a single-line `-`/`+` pair.
+
+**Still deferred.** Structs, enums, Maps, Sets, Lists of composite
+elements (`List<Struct>`, `List<Map<K, V>>`), and Lists parameterised
+by `Char` or `Byte` fall back to source-text-only rendering. A full
+solution needs `ToString` protocol dispatch and per-shape format
+rules in the backend.
+
+For example:
+
+```osty
+let user = getUser("alice")
+testing.assertEq(user, User { name: "alice", age: 30, email: "a@x.com" })
+```
+
+On failure produces:
+
+```
+assertion failed at user_test.osty:42
+  testing.assertEq(user, User { name: "alice", age: 30, email: "a@x.com" })
+
+  actual:
+    User {
+      name: "alice",
+      age: 25,          // differs
+      email: "a@x.com",
+    }
+
+  expected:
+    User {
+      name: "alice",
+      age: 30,
+      email: "a@x.com",
+    }
+```
+
+This is not a general-purpose macro facility. The compiler has built-in
+knowledge of the `std.testing` assertion functions only. User-defined
+functions cannot access argument source text.
+
+### 11.3 Context
+
+`testing.context(msg, body)` attaches a prefix to any assertion failures
+in the callback. Useful for table-driven tests:
+
+```osty
+fn testAdd() {
+    let cases = [
+        (1, 2, 3),
+        (0, 0, 0),
+        (-1, -1, -2),
+    ]
+    for (i, (a, b, expected)) in cases.enumerate() {
+        testing.context("case {i}: add({a}, {b})", || {
+            testing.assertEq(add(a, b), expected)
+        })
+    }
+}
+```
+
+### 11.4 Benchmarks
+
+Functions whose names begin with `bench` and take no arguments are
+benchmark functions, run by `osty test --bench`:
+
+```osty
+fn benchParseJson() {
+    testing.benchmark(1000, || {
+        let _: Config = json.decode(sampleText)?
+        Ok(())
+    })
+}
+```
+
+`testing.benchmark(iterations, body)` runs the closure and prints two
+lines per call site:
+
+```
+bench <abs-path>:<line> iter=<N> total=<T>ns avg=<A>ns
+  min=<Mn>ns p50=<M50>ns p99=<M99>ns max=<Mx>ns
+```
+
+`T` is the monotonic-clock elapsed time around the loop, `A` is
+`T / N` (or `0` when `N <= 0`). Values are nanoseconds throughout.
+The distribution line is computed from per-iteration samples.
+`<abs-path>` is the source file containing the `testing.benchmark(...)`
+call (`<bench>` when the compiler has no source path), and `<line>` is
+that call's 1-based line number.
+
+Before the timed loop the compiler inserts a warmup pass of
+`clamp(N/10, 1, 1000)` iterations that is **not** counted in `iter=`;
+this reduces cold-cache / branch-predictor noise on short bodies.
+
+`?` inside the closure body is allowed. If it sees `Err(e)` or `None`
+on any iteration the benchmark prints `bench \`?\` propagated failure
+at <abs-path>:<line>` to stdout and exits the bench with failure
+status; the summary line is not emitted for that benchmark.
+
+In bench mode:
+
+- Only `bench*`-named, zero-arity functions are discovered. `#[test]`
+  annotations have no effect on bench discovery, and `test*` functions
+  are skipped.
+- `--bench` and `--doc` are mutually exclusive.
+- Assertion failures inside the closure abort the bench with the
+  normal `testing.*` diagnostic; no summary line is printed for a
+  failed bench.
+- `osty test --bench --benchtime <duration>` activates auto-tuning:
+  the declared `N` is replaced by the output of a 10-iteration probe
+  scaled to hit `<duration>` (clamped to `[10, 100_000_000]` with 20%
+  headroom). Without the flag the declared `N` is authoritative. The
+  flag uses Go-style durations (`500ms`, `2s`, `1m`) and requires
+  `--bench`.
+
+### 11.5 Snapshots
+
+`std.testing.snapshot` provides golden-file testing:
+
+```osty
+fn testRenderOutput() {
+    let output = render(input)
+    testing.snapshot("render_basic", output)
+}
+```
+
+**Location.** The golden file lives at
+`<source_dir>/__snapshots__/<sanitize(name)>.snap`, where
+`source_dir` is the directory of the test source file and `sanitize`
+follows the rule from [§11.7](#117-test-order) (letters, digits,
+underscore pass through; everything else collapses to `_`; empty or
+all-sanitized names fall back to the stem `snapshot`). The source
+path is pinned at compile time so snapshot resolution is independent
+of the process working directory.
+
+**Lifecycle.**
+
+| Golden state | Result |
+|---|---|
+| Missing | Write `output` to the golden; pass with `snapshot: created <path>` on stdout. |
+| Matches `output` byte-for-byte | Pass silently. |
+| Differs from `output` | Print `testing.snapshot(<name>) mismatch: <path>` + a line-level diff (same shape as §11.2) to stdout and exit 1 — same observable outcome as any failing assertion. |
+
+**Accepting new output.** `osty test --update-snapshots` (which sets
+`OSTY_UPDATE_SNAPSHOTS=1` for the emitted test binaries) overwrites
+every golden encountered during the run and prints
+`snapshot: updated <path>` for each — tests still pass.
+
+**Test-harness override.** The runtime honors
+`OSTY_SNAPSHOT_DIR=<path>` as a drop-in replacement for the source
+directory when resolving the golden's location. This is only intended
+for test harnesses that exercise the snapshot machinery itself and
+want to isolate writes into a tempdir; production `osty test` runs
+leave it unset.
+
+### 11.6 Parallel Execution
+
+Tests run in parallel by default. Use `--serial` to force sequential
+execution. Tests depending on shared mutable state should use
+`std.sync` primitives or opt into serial execution.
+
+### 11.7 Test Order
+
+Within each execution mode (parallel or serial), `osty test` chooses a
+**randomized** start order. The random seed is printed at the start of
+every run (and at the head of any failure output) so failures are
+reproducible:
+
+```
+$ osty test
+running 42 tests (seed 0x8F3A2B71)
+...
+
+$ osty test --seed 0x8F3A2B71   # reproduce the exact same order
+```
+
+Declaration-order or alphabetical execution is not provided. Tests
+that accidentally share state are surfaced by the randomization; fix
+the dependency rather than pinning the order.
+
+### 11.8 Setup / Teardown
+
+Osty does not expose `beforeEach`/`afterEach` hooks. Shared setup
+belongs in helper functions called from each test, or in a
+`testing.context` block. Test-local cleanup uses `defer`. Because tests
+may run in parallel (§11.6), any shared fixture must be constructed
+per-test or guarded with `std.sync` primitives.
+
+---

--- a/LANG_SPEC_v0.6/12-foreign-function-interface.md
+++ b/LANG_SPEC_v0.6/12-foreign-function-interface.md
@@ -1,0 +1,180 @@
+## 12. Foreign Function Interface
+
+### 12.1 Importing Go Packages
+
+```osty
+use go "net/http" {
+    fn Get(url: String) -> Result<Response, Error>
+    fn Post(url: String, contentType: String, body: Reader) -> Result<Response, Error>
+
+    struct Response {
+        StatusCode: Int,
+        Body: Reader,
+    }
+}
+
+use go "github.com/foo/bar" as bar {
+    fn DoThing(x: Int) -> Int
+}
+```
+
+The imported package is bound to the last path segment (or the alias).
+
+### 12.2 Type Mapping
+
+| Osty | Go |
+|---|---|
+| `Int` | `int64` |
+| `Int32` | `int32` |
+| `UInt8` | `uint8` |
+| `Float` | `float64` |
+| `Bool` | `bool` |
+| `String` | `string` |
+| `Bytes` | `[]byte` |
+| `List<T>` | `[]T` |
+| `Map<K, V>` | `map[K]V` |
+| `T?` | `*T` (`nil` ↔ `None`) |
+| `Result<T, Error>` | Go function returning `(T, error)` |
+| Osty `struct` in `use go` block | Go `struct` (field-by-field) |
+
+### 12.3 Nullability
+
+Go's nullable types are exposed as `T?` if and only if the declaration
+uses the optional form. Non-optional declarations abort the FFI bridge
+on `nil`.
+
+### 12.4 Error Mapping
+
+`(T, error)` → `Result<T, Error>`. A non-nil Go `error` wraps as a
+`BasicError` whose `message()` returns `error.Error()`. The wrapping
+is **best-effort**: the returned `Error` preserves the top-level
+message string but does not walk Go's `errors.Unwrap` chain, and
+concrete Go error types cannot be recovered via
+`Error.downcast::<T>()` (T must be an Osty type). If structured error
+information from Go is required, expose an explicit accessor on the
+FFI declaration (e.g. `fn StatusCode(err: error) -> Int`).
+
+### 12.5 Goroutines and Channels
+
+Go goroutines and channels obtained via FFI are not integrated with
+Osty's structured concurrency or channel types.
+
+### 12.6 Panics
+
+A Go function invoked via FFI that triggers a Go `panic` **aborts the
+Osty process**. Panics do not cross the FFI boundary as recoverable
+errors: Go's panic/recover model is incompatible with Osty's Result-
+based handling, and silently translating panics would hide bugs in the
+Go code. Author FFI wrappers that always return `error` for recoverable
+failures.
+
+### 12.7 Constraints on FFI Declarations
+
+The following Osty features may **not** appear in `use go "..."` blocks:
+
+- **Generic type parameters.** Osty generics are monomorphized (§2.7.3);
+  the bridge needs a concrete Go symbol at link time. A generic Osty
+  function can wrap an FFI call, but the declaration itself must be
+  monomorphic. Calling a generic Osty function from Go is not
+  supported.
+- **Closures.** Osty closures capture Osty-side bindings and cannot
+  cross the FFI boundary as Go `func` values. Expose the wanted
+  behavior as a named `fn` instead.
+- **`interface{}` and empty Go interfaces.** Osty requires concrete
+  types on both sides. If the Go API expects `interface{}`, write a
+  typed wrapper on the Go side.
+- **Go channels typed in the declaration.** Use message-passing via
+  function calls instead; see §12.5 for the policy.
+
+### 12.8 Runtime FFI Surface (`use runtime.*`, `use c "..."`)
+
+The native (LLVM) backend exposes a parallel FFI surface keyed off the
+`runtime.*` import path. This is the only FFI form supported when
+compiling with `--backend llvm`; `use go "..."` is rejected with
+`LLVM001` because the native backend cannot embed the Go runtime.
+
+Three surface forms are recognised:
+
+```osty
+// 1. Runtime ABI symbols (osty_rt_* namespace, provided by the Osty
+//    C runtime). Callable from non-privileged code.
+use runtime.strings as strings {
+    fn HasPrefix(s: String, prefix: String) -> Bool
+}
+
+// 2. Native C ABI imports — surface form. Each function name is
+//    bound to the literal extern C symbol; the library name is a
+//    descriptive tag for the linker.
+use c "osty_demo" as demo {
+    fn osty_demo_double(x: Int) -> Int
+}
+
+// 3. Native C ABI imports — canonical form. Equivalent to (2);
+//    `use c "<lib>" { ... }` is the surface sugar that desugars
+//    to this path at parse time.
+use runtime.cabi.osty_demo as demo {
+    fn osty_demo_double(x: Int) -> Int
+}
+```
+
+Forms (2) and (3) produce the same AST — `IsRuntimeFFI = true`,
+`RuntimePath = "runtime.cabi.<lib>"`. The canonical printer normalises
+both to form (2). The lookahead in form (2) requires a string literal
+immediately after `c`, so an ordinary `use c.foo` import path is
+unaffected.
+
+Symbol resolution:
+
+| Path prefix | Emitted LLVM symbol | Linker contract |
+|---|---|---|
+| `runtime.strings`, `runtime.path.filepath`, `runtime.package.*` | `osty_rt_<path>_<name>` | Provided by `internal/backend/runtime/osty_runtime.c` |
+| `runtime.cabi`, `runtime.cabi.<lib>` (incl. `use c "<lib>"`) | `<name>` (literal) | Caller's responsibility — link the providing object/library |
+
+The constraints in §12.7 apply unchanged: no generics, no closures, no
+defaults/keywords, monomorphic signatures only. Type mapping uses the
+runtime ABI rules:
+
+| Osty | LLVM | C equivalent (typical) |
+|---|---|---|
+| `Int` | `i64` | `int64_t` |
+| `Float` | `double` | `double` |
+| `Bool` | `i1` | `_Bool` (passed as `i1`) |
+| `Char` | `i32` | `int32_t` (Unicode codepoint) — usable for C `int` |
+| `Byte` | `i8` | `uint8_t` — usable for C `char` / `unsigned char` |
+| `String`, `Bytes`, `Error`, `T?`, `(...)`, `fn(...) -> R` | `ptr` | opaque pointer |
+
+`Int32` / `UInt8` / `Float32` and other narrow-width primitives are
+**not yet** part of the runtime ABI — for `int abs(int)` style libc
+calls the working bridge today is `Char` (i32). String marshalling
+between Osty `String` (length-prefixed, GC-managed) and `const char*`
+(NUL-terminated) requires an explicit `runtime.strings` helper at the
+call site; passing an Osty `String` directly to a C symbol declared as
+`String -> ptr` is **not** equivalent to passing a `const char*`.
+
+`runtime.cabi.*` does not relax §12.6 panic semantics: a foreign symbol
+that aborts the process aborts Osty too. Recoverable errors must surface
+through return values, not host-side exceptions.
+
+#### 12.8.1 Linking C Libraries
+
+`use c "..."` only declares the symbols — the providing library must
+be linked at the final native build step. The manifest's
+`[target.<triple>]` table carries a `link` array of system library
+names (passed to the linker as `-l<name>`, in source order):
+
+```toml
+[target.amd64-linux]
+link = ["m", "pthread", "osty_demo"]
+```
+
+Library names follow the platform's linker convention (no `lib`
+prefix, no extension on Unix; the linker resolves `libfoo.{a,so}` /
+`foo.lib` / `foo.dylib` per platform). Source order is preserved so
+authors can express link order when it matters (typical only with
+static archives that have inter-archive symbol references).
+
+The manifest never embeds full paths or `-L` directories; project-wide
+search paths come from the build environment. CI / package authors
+keep cross-platform link lists per `[target.<triple>]` table.
+
+---

--- a/LANG_SPEC_v0.6/13-tooling.md
+++ b/LANG_SPEC_v0.6/13-tooling.md
@@ -1,0 +1,209 @@
+## 13. Tooling
+
+### 13.1 CLI
+
+```
+osty new <name>           Scaffold a new project directory
+                          (--lib | --bin | --workspace)
+osty init                 Scaffold into the current directory in place
+                          (--lib | --bin | --workspace)
+osty build [PATH]         Manifest + deps + front-end + backend emit/build
+osty run [-- ARGS...]     Build and execute the root binary on the host
+osty test [PATH|FILTER...] Discover, build, and run *_test.osty tests
+osty fmt FILE             Format source files (--check, --write)
+osty airepair FILE        Repair common syntax/idiom slips before parsing
+                          (legacy alias: osty repair)
+osty check FILE|DIR       Type-check without building
+osty lint FILE|DIR        Style + correctness lint (--strict for CI)
+osty gen FILE             Emit a single file through the native backend
+osty doc PATH             Generate API docs (markdown or html)
+osty ci [PATH]            Run format/lint/policy/lockfile/API checks
+osty ci snapshot [PATH]   Capture the exported API baseline
+osty add <pkg>            Add a dependency to osty.toml + osty.lock
+osty update [NAMES...]    Refresh dependencies (lockfile re-resolve)
+osty remove <name>...     Remove dependencies from osty.toml (alias: rm)
+osty fetch                Resolve and vendor without building
+osty publish              Pack and upload the package to a registry
+osty search QUERY         Search a registry
+osty info PKG             Show registry metadata
+osty yank / unyank        Mark or clear a yanked package version
+osty login / logout       Manage registry credentials
+osty registry serve       Run a file-backed package registry
+osty profiles             List build profiles
+osty targets              List cross-compilation targets
+osty features             List declared feature flags
+osty cache [ls|clean|info] Inspect or prune backend build caches
+osty pipeline FILE|DIR    Run each front-end phase; --gen emits artifacts
+osty lsp                  Run the language server on stdio
+osty explain [CODE]       Explain compiler or lint diagnostics
+```
+
+`build`, `run`, and `test` accept profile/target/feature flags:
+`--profile`, `--release`, `--target`, `--features`, and
+`--no-default-features`. `build`, `run`, `test`, `add`, `update`, and
+`fetch` accept dependency-resolution guards: `--offline`, `--locked`,
+and `--frozen`. Public backend-producing commands accept `--backend llvm`
+and `--emit llvm-ir|object|binary`. Historical Go-backend/bootstrap
+switches are not part of the public CLI contract. `run` requires a host
+binary and rejects cross-target execution. Native `osty test`
+execution is still pending.
+
+Front-end-bearing commands (`check`, `resolve`, `typecheck`, `lint`,
+`build`, `run`, `test`, and `gen`) apply the in-memory `airepair`
+adaptation pass by default before parsing so AI-authored foreign syntax
+is normalized without requiring an explicit opt-in flag. Debugging flags
+may narrow or disable that behavior, but the default user contract is
+best-effort automatic adaptation.
+
+### 13.2 Manifest
+
+A project is described by `osty.toml` at its root. `osty.lock` records
+exact resolved versions and content hashes.
+
+**Schema (v0.4).** The following TOML shape is accepted by the v0.4
+toolchain. Stable configuration tables such as dependencies, lint,
+profiles, and targets reject unknown keys (`E2012`) so typos surface
+early; unknown top-level tables and extra `[package]` metadata are
+tolerated for forward-compatibility with future additions.
+
+```toml
+[package]                        # required unless [workspace] is present
+name        = "myapp"            # required; [A-Za-z_][A-Za-z0-9_-]*
+version     = "0.1.0"            # required; strict semver X.Y.Z[-pre][+build]
+edition     = "0.5"              # required; must be a known spec version
+description = "A short blurb."   # optional
+authors     = ["Alice <a@x>"]    # optional
+license     = "MIT"              # optional (SPDX identifier recommended)
+repository  = "https://..."      # optional
+homepage    = "https://..."      # optional
+keywords    = ["cli", "demo"]    # optional
+
+[dependencies]                   # optional
+simple    = "1.0"                                # registry, version req
+local-dep = { path = "../local-dep" }            # filesystem
+git-dep   = { git = "https://github.com/x/y", tag = "v1" }
+# { git = "...", branch = "main" } and { git = "...", rev = "sha" }
+# are also accepted; at most one of tag/branch/rev may be set.
+renamed   = { version = "1", package = "upstream-name" }
+full      = { version = "^1.2", registry = "custom",
+              optional = true, features = ["json"],
+              default-features = false }
+
+[dev-dependencies]               # optional; only visible to `osty test`
+test-helper = "0.4"
+
+[bin]                            # optional; override the default entry
+name = "mytool"
+path = "src/tool.osty"
+
+[lib]                            # optional; override the default lib root
+path = "src/lib.osty"
+
+[registries.custom]              # optional; non-default registries
+url = "https://custom.example"
+token = "..."                    # optional; credentials may also live in ~/.osty
+
+[workspace]                      # optional; defines a virtual workspace
+members = ["packages/core", "packages/util"]
+
+[lint]                           # optional; project-wide lint policy
+allow = ["L0004"]                # suppress these codes for the whole project
+deny  = ["L0003"]                # elevate these codes to error (CI-failing)
+exclude = ["vendor/**"]          # skip matching files during `osty lint`
+
+[profile.release]                # optional; override a built-in profile
+opt-level = 3                    # valid range: 0..3
+debug = false
+strip = true
+overflow-checks = false
+inlining = true
+lto = true
+go-flags = ["-trimpath"]
+env = { CGO_ENABLED = "0" }
+
+[profile.bench]                  # optional; define a custom profile
+inherits = "release"             # built-ins: debug, release, profile, test
+debug = true
+
+[target.amd64-linux]             # optional; <arch>-<os> target triple
+cgo = false
+env = { GOAMD64 = "v3" }
+
+[features]                       # optional; local feature closure
+default = ["cli"]
+cli = []
+tls = ["crypto"]
+full = ["cli", "tls", "dep/feature"]
+```
+
+**Coexistence of `[package]` and `[workspace]`.** A manifest may
+define both: the root directory is itself a package *and* the
+workspace root. A manifest that defines only `[workspace]` is a
+**virtual workspace** — the root has no package identity; its only
+purpose is to group members.
+
+**Version requirements.** Registry dependencies accept the usual
+operator forms: `"1.0.0"` (exact), `"^1.0"` (compatible-update),
+`">=1.0, <2"` (range). `"*"` means "latest available." Path and git
+dependencies do not take a version requirement — their source pins
+the version directly.
+
+**Dependency identity.** A dependency's left-hand-side name is the
+local alias used in `use <name>` statements. When the remote package
+has a different canonical name, set `package = "<remote>"` to
+record it; the resolver uses the canonical name for version
+matching and stores the remote-to-local mapping in `osty.lock`.
+
+**Diagnostic codes.** Manifest errors emit `E2000–E2099` codes
+(listed in `ERROR_CODES.md`), rendered through the shared formatter
+with caret underlines and the same source-snippet treatment as
+compile-time errors.
+
+**`[lint]` entries.** `allow` and `deny` accept the lint codes
+listed under `L0xxx` in `ERROR_CODES.md`, rule-family aliases (e.g.
+`unused`, `naming`), and the wildcards `lint` / `all`. Each project
+applies its policy after running the default lint pass — `allow`
+drops matching diagnostics entirely, `deny` converts matching
+warnings to errors. `osty lint --strict` still elevates everything
+to error on top of these per-project settings.
+
+**Profiles and targets.** Four profiles are built in: `debug`,
+`release`, `profile`, and `test`. A manifest may override any of
+them or define a new profile that inherits from a built-in or another
+manifest profile. `--profile NAME` selects one explicitly;
+`--release` is shorthand for `--profile release`. Targets are named
+by `<arch>-<os>` triples such as `amd64-linux` or `arm64-darwin`.
+When selected with `--target`, target values populate the backend
+environment (`GOARCH`, `GOOS`, optional `CGO_ENABLED`, and any
+target-specific `env` entries). `osty run` refuses non-host targets
+because it must execute the produced binary locally.
+
+**Features.** `[features]` declares local feature names and their
+transitive closure. `default` names features enabled unless
+`--no-default-features` is present; `--features a,b` unions additional
+feature names. Cross-dependency references use `dep/feature` and are
+preserved for the dependency resolver. A source file may require
+features with a top-of-file pragma:
+
+```osty
+// @feature: tls
+```
+
+Files whose required features are inactive are skipped by the build
+driver before backend emission.
+
+**Artifacts and cache.** Backend outputs live under
+`.osty/out/<profile>[-<target>]/{go,llvm}/`; fingerprints live under
+`.osty/cache/<profile>[-<target>]/{go,llvm}.json`. `osty cache ls`
+lists those records, `osty cache info` prints one fingerprint, and
+`osty cache clean` removes `.osty/cache/` plus `.osty/out/`.
+
+### 13.3 Formatter
+
+`osty fmt` is the canonical formatter. It accepts no configuration.
+Among other normalizations:
+- Rewrites `Option<T>` to `T?`
+- Enforces naming conventions (§1.4)
+- Normalizes trailing commas
+
+---

--- a/LANG_SPEC_v0.6/14-excluded-features.md
+++ b/LANG_SPEC_v0.6/14-excluded-features.md
@@ -1,0 +1,138 @@
+## 14. Excluded Features
+
+The items below are excluded from v0.5. Items are grouped by reason so
+readers can see the argument without consulting the change history.
+Re-opening any of them requires a design proposal, a new minor or major
+version, and a migration story for existing code.
+
+### 14.1 Current Exclusions
+
+**Safety / correctness by construction.**
+
+- `null` / `nil` — Osty uses `Option<T>` and forces explicit handling.
+- Exceptions, `try` / `catch`, `panic` / `recover` as user control flow
+  — errors are values (`Result<T, E>`, `?`, `defer`). `panic` /
+  `unreachable` / `todo` / `abort` are programmer-error aborts, not a
+  recoverable control flow.
+- Silent arithmetic overflow — use explicit `wrapping*` /
+  `checked*` / `saturating*` methods on `Int` / `IntN`.
+- Finalizers and weak references — GC trace graph is object-local;
+  introducing finalizers would add unobservable ordering.
+- `unsafe` block (user-facing) — the runtime sublanguage in §19 is
+  implementation-private and rejected outside privileged packages
+  with `E0770`. User code has no `unsafe` escape hatch.
+- User-visible raw pointer — the `RawPtr` type in §19 is gated the
+  same way; there is no user-facing address-of or dereference.
+
+**Type system simplicity.**
+
+- Inheritance — compose via structs and satisfy structural interfaces.
+- Classes — `struct` + methods + interfaces cover the same ground.
+- Lifetime annotations — GC eliminates the need; structured-concurrency
+  `Handle<T>` / `TaskGroup` are non-escaping by a finite front-end
+  rule (G13), not a lifetime system.
+- Declaration-site or use-site variance (`in` / `out`, Java wildcards)
+  — monomorphization makes variance a non-issue for concrete types.
+- Generic type-parameter default values (e.g. `<T, U = T>`) — use a
+  new type alias instead.
+- `where` clauses — write `T: I1 + I2` directly in the type parameter
+  list.
+- Anonymous structs / structural records — a named `struct` is
+  required. Tuples cover the remaining use cases.
+- `UInt` (machine-word unsigned integer type) — `Int` is fixed at 64
+  bits; sizes / counts / indices are `Int`.
+
+**Grammar discipline.**
+
+- Macros (declarative or procedural) — the compiler does not take
+  user-defined syntax extensions.
+- User-defined annotations / attributes — the annotation set is fixed
+  by the compiler (§1.9, §3.8). As of v0.5 this set is
+  `#[json(...)]`, `#[deprecated(...)]`, `#[op(...)]`, `#[cfg(...)]`,
+  `#[test]`, `#[intrinsic]`, `#[pod]`, `#[repr(...)]`,
+  `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`.
+- Function overloading — distinct names for distinct operations.
+- C-style `for` loops — use `for x in xs` / `for cond { }` /
+  `while cond { }` / `loop { break v }`.
+- `impl` blocks — methods live inside `struct` / `enum` bodies.
+- `spawn` keyword — use `g.spawn(|| ...)` from `taskGroup`.
+- Detached concurrency — every task is owned by a `taskGroup`.
+- `async` / `await` — structured concurrency via `taskGroup` replaces
+  per-call-site async.
+- `yield` / generators — compose iterators via §15 and lazy
+  combinators in `std.iter`.
+- `as` keyword for general type conversion — specific converter
+  methods (`.toInt32()`, `.toFloat()`, `.toString()`, etc.) make the
+  rounding / truncation / failure contract explicit. `as?` is a
+  narrow exception, reserved for `Error` downcast (§7.4).
+- Turbofish on enum variant construction (`Option::<Int>::Some(5)` —
+  use inference or annotate the receiver).
+- `Set` literal syntax — construct via `Set.from(...)` or from an
+  iterable.
+- Annotations on expressions or `use` statements — annotations apply
+  only to declarations.
+
+**Operator surface.**
+
+- Operator overloading **beyond** the six arithmetic operators
+  documented in §3.8 / §14.2 — `==` / `!=` / `<` / `<=` / `>` / `>=` use the
+  `Equal` / `Ordered` interfaces; `[]` (indexing), `()` (call), `<<` /
+  `>>` / `&` / `|` / `^` (bitwise) are primitive-only and cannot be
+  overloaded. `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` /
+  `#[op(%)]` (binary) and `#[op(-)]` (unary) are the complete allowed
+  set; an attempt to overload any other operator is `E0725`.
+- Named arguments **for required parameters** — required parameters
+  are positional only. Defaulted parameters may use keyword-call form
+  (§3.1).
+
+**Testing / tooling hooks.**
+
+- `beforeEach` / `afterEach` test hooks — use helpers or
+  `testing.context`.
+- `WaitGroup` — `taskGroup` covers all structured-concurrency waiting.
+- Garbage collector tuning knobs — the runtime picks policy; tuning
+  is not a user surface.
+- `const` as a **run-time** immutable binding keyword — the `let`
+  binding (which is immutable by default) already covers that
+  meaning. `const fn` (§3.1.1) names a compile-time evaluable function,
+  not a binding form; its body is constrained by the capability matrix
+  in §3.1.1.
+
+### 14.2 Accepted in v0.5 (previously excluded)
+
+Two v0.4 exclusions were replaced with scoped forms in v0.5 because
+the total ban blocked numerical code readability in realistic
+programs:
+
+- **Implicit numeric conversions** — replaced by **lossless widening
+  only** (§2.2): `Int8 → Int16 → Int32 → Int → Float64`, `Int →
+  Float64`, `Float32 → Float64`. Narrowing remains explicit via
+  rounding-mode-suffixed converters (`.toIntTrunc()` /
+  `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` / `.toInt32()` /
+  `.toInt16()` / `.toInt8()` / `.toFloat32()`). Implicit narrowing is
+  `E0765`.
+- **Operator overloading** — replaced by **six-operator opt-in** via
+  `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]`
+  (binary) and `#[op(-)]` (unary) on structural methods (§3.8 / §14.2). All
+  other operators remain primitive-only (see §14.1 above).
+
+### 14.3 Newly accepted syntax (v0.5)
+
+These forms were listed as excluded in v0.4 and were accepted in v0.5
+as scoped additions:
+
+- **`loop` keyword** — excluded in v0.4 as "subsumed by `for`". v0.5
+  distinguishes `for cond { }` (Unit-returning while-style, unchanged
+  since v0.3) from `loop { break value }` (value-returning unbounded
+  loop, §4.4). The distinction is intentional.
+- **Labeled `break` / `continue`** — `'label: for/loop ... break
+  'label` (§4.4). Nested loops no longer require sentinel flags.
+- **`const`** — `const fn` only. Compile-time evaluable function
+  (§3.1.1), not a run-time binding form. `let` remains the sole
+  binding form. The evaluable body is defined by the capability
+  matrix in §3.1.1; constructs outside the matrix are `E0766`.
+- **`#[cfg(...)]` annotation and `pub use` re-exports** — §5. Neither
+  keyword is new; the surface is annotation-based and `use`-based
+  respectively.
+
+---

--- a/LANG_SPEC_v0.6/15-iteration-protocol.md
+++ b/LANG_SPEC_v0.6/15-iteration-protocol.md
@@ -1,0 +1,80 @@
+## 15. Iteration Protocol
+
+`for x in xs { ... }` is defined in terms of two interfaces:
+
+```osty
+pub interface Iterator<T> {
+    fn next(mut self) -> T?
+}
+
+pub interface Iterable<T> {
+    fn iter(self) -> Iterator<T>
+}
+```
+
+A `for x in <expr>` loop desugars to:
+
+```osty
+{
+    let mut __it = (<expr>).iter()
+    for let Some(x) = __it.next() {
+        // body
+    }
+}
+```
+
+Equivalently, a type used as the right-hand side of `for ... in` must
+satisfy `Iterable<T>` for some `T`. The element type `T` is inferred
+from the implementing `iter` return type.
+
+**Built-in iterables.** The following standard types implement
+`Iterable<T>`:
+
+| Type | Element type `T` |
+|---|---|
+| `List<T>` | `T` |
+| `Set<T>` | `T` |
+| `Map<K, V>` | `(K, V)` |
+| `Range` (`a..b`, `a..=b`, optional `by step`) | `Int` |
+| `Channel<T>` (§8.5) | `T` (loop ends when channel is closed and drained) |
+| `Iter<T>` (§10.7) | `T` |
+| `String.chars()` | `Char` |
+| `String.graphemes()` | `String` |
+| `String.bytes()` | `Byte` |
+| `Bytes` | `Byte` |
+
+**User-defined iterables.** Any type with an `iter(self) -> Iterator<T>`
+method satisfies `Iterable<T>` automatically (structural typing,
+§2.6). A custom `Iterator<T>` need only provide `next`:
+
+```osty
+pub struct Countdown {
+    n: Int,
+
+    pub fn next(mut self) -> Int? {
+        if self.n <= 0 {
+            None
+        } else {
+            self.n = self.n - 1
+            Some(self.n + 1)
+        }
+    }
+}
+
+// Countdown already satisfies Iterator<Int>; wrap it in an Iterable.
+pub struct CountdownFrom {
+    start: Int,
+
+    pub fn iter(self) -> Countdown {
+        Countdown { n: self.start }
+    }
+}
+
+for x in (CountdownFrom { start: 3 }) {
+    println("{x}")     // 3, 2, 1
+}
+```
+
+(The parentheses around the struct literal are required by §4.1.1.)
+
+---

--- a/LANG_SPEC_v0.6/16-io-protocol.md
+++ b/LANG_SPEC_v0.6/16-io-protocol.md
@@ -1,0 +1,146 @@
+## 16. I/O Protocol
+
+The `Reader` and `Writer` interfaces define the streaming I/O contract
+shared across `std.io`, stream-oriented standard-library modules, and
+FFI byte-stream bridges. `std.fs` currently exposes whole-file and
+path-mutation helpers; future handle-based filesystem APIs plug into
+this same protocol surface.
+
+```osty
+pub interface Reader {
+    /// Reads up to `maxBytes` from the stream and returns the bytes
+    /// that were produced. An empty result indicates end of stream.
+    /// Implementations may return fewer bytes than requested even when
+    /// more data remains.
+    fn read(self, maxBytes: Int) -> Result<Bytes, Error>
+}
+
+pub interface Writer {
+    /// Writes `data` to the stream. Returns the number of bytes
+    /// written, which is in the range [0, data.len()]. Short writes
+    /// are permitted; callers wanting full-buffer semantics should
+    /// loop or use the `writeAll` helper from `std.io`.
+    fn write(self, data: Bytes) -> Result<Int, Error>
+
+    /// Flushes any buffered output to the underlying sink. A no-op for
+    /// unbuffered writers.
+    fn flush(self) -> Result<(), Error>
+}
+
+pub interface Closer {
+    /// Releases the resource. Subsequent operations return
+    /// Err(Closed). Idempotent — closing twice returns Ok(()).
+    fn close(self) -> Result<(), Error>
+}
+
+pub interface ReadWriter {
+    Reader
+    Writer
+}
+
+pub interface ReadCloser {
+    Reader
+    Closer
+}
+
+pub interface WriteCloser {
+    Writer
+    Closer
+}
+
+pub interface ByteReader {
+    Reader
+    fn peek(self, maxBytes: Int) -> Result<Bytes, Error>
+    fn readByte(self) -> Result<Byte?, Error>
+    fn unreadByte(self) -> Result<(), Error>
+}
+
+pub interface LineReader {
+    Reader
+    fn readLineBytes(self) -> Result<Bytes?, Error>
+    fn readLine(self) -> Result<String?, Error>
+}
+
+pub interface ByteWriter {
+    Writer
+    fn writeByte(self, b: Byte) -> Result<Int, Error>
+    fn writeString(self, s: String) -> Result<Int, Error>
+    fn writeLine(self, s: String) -> Result<Int, Error>
+}
+
+pub interface ReaderFrom {
+    fn readFrom(self, r: Reader) -> Result<Int, Error>
+}
+
+pub interface WriterTo {
+    fn writeTo(self, w: Writer) -> Result<Int, Error>
+}
+
+pub interface BufferedReader {
+    ByteReader
+    LineReader
+}
+
+pub interface BufferedWriter {
+    ByteWriter
+    ReaderFrom
+    WriterTo
+}
+```
+
+**EOF.** A `Reader` signals end-of-stream with `Ok(b"")`. There is no
+distinguished `EOF` error.
+
+**Cancellation.** Standard library `Reader`/`Writer` implementations
+that perform blocking I/O check the task-group cancellation token
+(§8.4) and return `Err(Cancelled)` when the surrounding `taskGroup`
+is being torn down.
+
+**Helpers.** `std.io` provides:
+
+```
+io.copy(dst: Writer, src: Reader) -> Result<Int, Error>
+io.copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error>
+io.readAll(r: Reader) -> Result<Bytes, Error>
+io.readExact(r: Reader, n: Int) -> Result<Bytes, Error>
+io.readString(r: Reader) -> Result<String, Error>
+io.readLines(r: Reader) -> Result<List<String>, Error>
+io.readAllLines(r: LineReader) -> Result<List<String>, Error>
+io.discard(r: Reader) -> Result<Int, Error>
+io.writeAll(w: Writer, data: Bytes) -> Result<(), Error>
+io.writeString(w: Writer, s: String) -> Result<(), Error>
+io.writeLine(w: Writer, s: String) -> Result<(), Error>
+io.writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error>
+```
+
+`io.readAll` accumulates a whole stream into a single `Bytes` value.
+`io.readExact` and `io.copyN` require exactly `n` bytes and return
+`Err` on early EOF. `io.readString` validates UTF-8 after `readAll`;
+`io.readLines` splits that text into lines and normalizes trailing `\r`
+from CRLF input, while `io.readAllLines` targets incremental
+`LineReader` implementations directly. `io.discard` drains a reader and
+reports how many bytes were skipped. `io.writeAll` retries short writes
+until the full buffer is accepted, then flushes the writer.
+`io.writeLines` targets the richer `ByteWriter` capability surface.
+`io.copy` repeatedly reads chunks from `src`, writes them fully to
+`dst`, flushes once at the end, and returns the total byte count copied.
+
+**In-memory implementations.** `std.io` also ships small concrete types
+for pure-Osty tests, adapters, and pipelines:
+
+```
+io.bytesReader(data: Bytes) -> io.BytesReader
+io.stringReader(s: String) -> io.BytesReader
+io.buffer() -> io.Buffer
+```
+
+`BytesReader` is a `Reader`/`Closer` over an in-memory `Bytes` payload
+with cursor-style methods such as `remaining()`, `peek(n)`,
+`readByte()`, `unreadByte()`, `skip(n)`, `readLineBytes()`,
+`readLine()`, and `remainingBytes()`.
+`Buffer` is an append-only in-memory writer that satisfies `Writer` and
+adds inspection helpers such as `bytes()` and `toString()`, plus
+buffer-management / piping helpers such as `clear()`, `truncate(n)`,
+`reader()`, `readFrom(r)`, and `writeTo(w)`.
+
+---

--- a/LANG_SPEC_v0.6/17-display-and-format-protocol.md
+++ b/LANG_SPEC_v0.6/17-display-and-format-protocol.md
@@ -1,0 +1,67 @@
+## 17. Display and Format Protocol
+
+String interpolation and the `print*` family are defined in terms of a
+single interface:
+
+```osty
+pub interface ToString {
+    fn toString(self) -> String
+}
+```
+
+**`{expr}` interpolation.** In a string literal, `{expr}` is rewritten
+to `expr.toString()` and the result spliced in. Format specifiers
+(width, precision, base) are not part of the v0.2 interpolation grammar;
+use explicit method calls for non-default formatting (e.g.
+`{n.toFixed(2)}`, `{n.toString(base: 16)}`).
+
+**Built-in instances.** Every primitive listed in §2.6.5 implements
+`ToString` with its standard textual form:
+
+```
+42.toString()           // "42"
+3.14.toString()          // "3.14"
+true.toString()          // "true"
+'A'.toString()           // "A"
+"hi".toString()          // "hi"  (identity)
+b"hi".toString()         // see §2.4.1; returns Result, separate from ToString
+```
+
+For `Bytes`, `ToString` produces a hex-escaped form (e.g. `"\\x68\\x69"`
+for `b"hi"`); the UTF-8 reinterpretation is the explicit `Bytes.toString
+() -> Result<String, Error>` (which shadows the interface name —
+disambiguate by inference at the call site).
+
+**Auto-derivation for `struct` and `enum`.** The compiler synthesizes
+a `toString` implementation when the user does not provide one:
+
+- `struct User { name: String, age: Int }` →
+  `"User { name: \"alice\", age: 30 }"`
+- `enum Shape { Circle(Float), Empty }` →
+  `"Circle(1.5)"`, `"Empty"`
+
+The auto-derived form is intended for debugging and log output. It
+quotes string fields, recursively calls `toString` on each component,
+and omits any field annotated `#[json(skip)]` (which is interpreted as
+"do not expose externally"). User implementations override the
+auto-derived one.
+
+**Collections.**
+
+```
+List<T>:    T: ToString  ⇒ List<T>: ToString    // "[1, 2, 3]"
+Set<T>:     T: ToString  ⇒ Set<T>: ToString
+Map<K,V>:   K: ToString + V: ToString ⇒ Map<K,V>: ToString
+Tuple:      all components ToString ⇒ tuple ToString
+Option/Result: as in §2.6.5
+```
+
+**`println(x)` and friends.** `print(x)`, `println(x)`, `eprint(x)`,
+`eprintln(x)` accept any `T: ToString` and emit `x.toString()` to the
+respective stream (`println` adds a trailing `\n`).
+
+**Relationship to `dbg`.** `dbg(x)` (§10.1) prints a developer-oriented
+form including source location and the unprocessed expression text. It
+is built on top of `ToString` for the value portion.
+
+---

--- a/LANG_SPEC_v0.6/18-change-history.md
+++ b/LANG_SPEC_v0.6/18-change-history.md
@@ -1,0 +1,339 @@
+## 18. Change History
+
+This chapter records the evolution of the specification across released
+versions. The latest release is at the top.
+
+### 18.-1 v0.4 → v0.5
+
+v0.5 is the release in which the accumulated v0.4 pain points are
+resolved in a single batch, rather than incrementally over multiple
+minors. Grammar / prelude / `§14` excluded list / stdlib public
+signatures in this release are intended to be stable for an extended
+period; when future changes are necessary they follow the normal
+versioning process.
+
+**Principle.** Close every observed v0.4 pain point in one release so
+users do not need to learn a new grammar or prelude for each minor.
+Everything added is chosen because it eliminated a concrete pain in a
+real program.
+
+**Additions — syntax (additive; all v0.4 programs compile unchanged).**
+
+| Form | Purpose | §ref |
+|---|---|---|
+| `loop { ... break value }` | value-returning unbounded loop | §4.4 |
+| `'label: for / loop ... break 'label` | labeled break/continue across nested loops | §4.4 |
+| `0..100 by 2` | range step (contextual `by`) | §4.4 |
+| `receiver { field: value }` | struct update shorthand (receiver-typed literal; equivalent to `Type { ..receiver, field: value }`) | §3.4 |
+| `f(x) \|y\| { body }` | trailing closure — last function-typed arg moves outside parentheses | §4.9 |
+| `err as? T` | downcast shortcut (equivalent to `err.downcast::<T>()`) | §7.4 |
+| `pub? const fn` | compile-time evaluable function; body constrained by §3.1.1 capability matrix (literals, arithmetic, acyclic const-fn calls, construction); recursion / control flow / string concat / generics forbidden | §3.1.1 |
+| `pub enum Status: Int { OK = 200, ... }` | enum with explicit integer discriminants (payload-free variants only) | §3.5 |
+| `use std.fs::{open, exists}` | scoped / grouped imports | §5 |
+| `pub use sub.Foo` | cross-module re-export | §5 |
+| `#[cfg(os = "linux")]` | conditional compilation (keys: `os` / `target` / `arch` / `feature`) | §5, §3.8 |
+| `#[op(+)] fn add(self, o: Self) -> Self` | opt-in operator overload (`+ - * / %` binary, `-` unary) | §3.8 / §14.2 |
+| `#[test] fn ...` | inline test function — no separate `_test.osty` required | §11 |
+
+**Additions — semantics (checker / lowering).**
+
+- **Lossless numeric widening** (§2.2). Implicit: `Int8 → Int16 → Int32 → Int → Float64`, `Int → Float64`, `Float32 → Float64`. Narrowing still requires explicit `.toInt32()` / `.toInt16()` / `.toInt8()` / `.toIntTrunc()` / `.toIntRound()` / `.toIntFloor()` / `.toIntCeil()` / `.toFloat32()` — `E0765` on implicit narrowing.
+- **Bounded operator overloading** (§3.8, §14.2). `#[op(+)]` / `#[op(-)]` / `#[op(*)]` / `#[op(/)]` / `#[op(%)]` binary + `#[op(-)]` unary only. `== / < / > / <= / >= / != / [] / () / << / >> / & / | / ^` remain primitive-only. Duplicate `#[op]` for same operator on same type is `E0724`; non-allowed operator is `E0725`.
+- **Function value keyword-name preservation** (G20). `fn(...) -> ...` carries parameter names as type-equality-neutral metadata. Keyword calls through function values allowed when names match; default-value capture still erased per G15.
+
+**Additions — stdlib.**
+
+- **`Option<T>`** combinators: `isSome / isNone / isSomeAnd / isNoneOr / contains / count / take / replace / unwrap / expect / unwrapOr / unwrapOrElse / and / andThen / or / orElse / xor / filter / inspect / forEach / map / mapOr / mapOrElse / zip / zipWith / reduce / okOr / okOrElse / toList`; module helpers `flatten / transpose / unzip / values / any / all / traverse / filterMap / findMap / map2 / map3`.
+- **`Result<T, E>`** combinators: `isOk / isErr / isOkAnd / isErrAnd / contains / containsErr / count / unwrap / expect / unwrapErr / expectErr / unwrapOr / unwrapOrElse / ok / err / and / andThen / or / orElse / inspect / inspectErr / forEach / map / mapErr / mapOr / mapOrElse / zip / zipWith / toList`; module helpers `flatten / transpose / values / errors / partition / all / traverse / map2 / map3 / allErrors / traverseErrors`.
+- **`List<T>`** extensions: `groupBy / chunked / windowed / partition / reduce / scan / flatMap / zip3` in addition to the existing `map / filter / fold / sorted / sortedBy / reversed / take / drop / appended / concat / zip / enumerate / push / pop / insert / removeAt / sort / reverse / clear`.
+- **`Map<K, V>`** extensions: `getOrInsert / getOrInsertWith / merge / mapValues / filter` on top of `get / containsKey / keys / values / entries / insert / remove / clear`.
+- **§10/24 `std.strings`** — full Unicode-aware chapter (previously referenced by name only).
+- **`Error.wrap(context)` / `Error.chain()`** + `WrappedError` type (§7).
+- **`std.testing.gen`** — `Gen<T>` + combinators (`oneOf / map / filter / pair / list / record`), shrinking for primitives / lists / structs, `testing.property(name, gen, pred)` runner.
+- **Doctest** — ``` ```osty ``` blocks inside `///` comments extracted and run by `osty test --doc`.
+
+**Resolved gaps (all decided in v0.5).**
+
+| ID | Subject | Outcome |
+|---|---|---|
+| **G20** | Function value parameter-name preservation | Names survive as metadata; keyword-call through fn-values allowed when names match; type equality ignores names. |
+| **G21** | Default argument literal definition extension | `DefaultLiteral` now includes struct literals whose fields are themselves literals, plus `const fn` return values. `const fn` body is constrained by the §3.1.1 capability matrix; the `const fn` call graph must be acyclic (`E0767`); `const fn` may not be generic (`E0768`); out-of-matrix construct is `E0766`. |
+| **G22** | `loop` expression | Value-returning unbounded loop; `break value` typed from all exit sites. |
+| **G23** | Trailing closure call | Last function-typed arg may move outside `(...)`; closure may follow a full or empty arg list. |
+| **G24** | Labeled break/continue | `'label:` prefixes loops; `break 'label` / `continue 'label`; unknown label is `E0763`. |
+| **G25** | Range step `by` | Contextual keyword inside range expressions; elsewhere an ordinary identifier. |
+| **G26** | Struct update shorthand | `receiver { field: value }` where `receiver` is a local identifier of struct type; desugars to `Type { ..receiver, field: value }`. |
+| **G27** | `as?` downcast syntax | Typed postfix form over `Error` values only; equivalent to `err.downcast::<T>()`. |
+| **G28** | Scoped / grouped imports | `use path::{a, b as c}` extends existing UseDecl. |
+| **G29** | Conditional compilation `#[cfg(...)]` | Pre-resolve filter; keys `os`, `target`, `arch`, `feature`; composition via `all` / `any` / `not`; unknown key is `E0405`. |
+| **G30** | `pub use` re-export | Re-exports inherit the declared visibility of the source symbol; cycles are `E0552`. |
+| **G31** | Enum integer discriminants | `pub enum X: Int { A = 1, ... }` with payload-free variants; `.discriminant()` / `.fromDiscriminant(n)` auto-derived. |
+| **G32** | Inline `#[test]` + doctest | Test functions may sit next to production code; doctests extracted from `///` blocks. |
+| **G33** | Property-based testing | `std.testing.gen` new submodule; `testing.property` runner; built-in shrinkers for core types. |
+| **G34** | Lossless numeric widening | Narrowing remains explicit with rounding-mode-suffixed converters; widening follows a total lattice. |
+| **G35** | Bounded operator overloading | Exactly six operators allowed via `#[op(...)]`; all other operators remain primitive-only. |
+
+**Changes to `§14` (excluded features).**
+
+- Removed (now allowed): "implicit numeric conversions" (replaced by lossless widening only, §2.2), "operator overloading" (replaced by six-operator `#[op(...)]` opt-in, §3.8 / §14.2).
+- Reaffirmed permanent exclusions (total 9 after v0.5): `null` / `nil`, exceptions & `try`/`catch`, inheritance, macros, user-defined annotation set, `unsafe` (user-facing), user-visible raw pointer, `[]` / `()` / bitwise operator overload, generic type-parameter defaults.
+- Removed from excluded list (now part of language): `while`/`loop` keyword (the `for cond { }` while-style existed since v0.3; `loop { break v }` is new in v0.5), labeled `break`/`continue` (new in v0.5), `const` (new in v0.5 for compile-time functions only — still no run-time immutable binding form beyond `let`).
+
+**Grammar delta.** New contextual keywords `by`, `const`, `loop`. New syntactic markers `as?`, label prefix `'ident:`, trailing-closure call shape. Extended productions: `UseDecl`, `EnumDecl`, `StructLiteral`, `DefaultLiteral`, `CallExpr`, `FnDecl`. New annotations `#[op(...)]`, `#[cfg(...)]`, `#[test]`. New diagnostic codes span E0405, E0552–E0554, E0754–E0759, E0763–E0765, E0766–E0768. The
+E0760–E0762 control-flow slots (`CodeUnreachableCode`, `CodeMissingReturn`,
+`CodeDefaultNotLiteral`) remain as already defined in v0.4. E0766–E0768
+cover `const fn` body validation, const-fn call-graph cycles, and
+generic `const fn` rejection respectively (§3.1.1).
+
+**Implementation guidance.** The implementation order is (i) additive stdlib (Option / Result / List / Map extensions, `std.strings`, `Error.wrap`), (ii) small syntax (labels, `loop`, range `by`, `as?`, scoped imports, `pub use`, enum discriminants, `#[cfg]`), (iii) medium syntax (struct update shorthand, trailing closure, struct-literal defaults, `const fn` with §3.1.1 capability matrix and acyclic-call-graph check), (iv) type system (numeric widening, operator dispatch, function-value name preservation), (v) test infrastructure (inline `#[test]`, doctest, property framework). Each feature ships a positive spec example, a negative reject case, and a golden-snapshot diagnostic test.
+
+### 18.0 v0.4 minor: runtime primitives (additive)
+
+§19 (runtime primitives) was added in the v0.4 additive minor, introducing
+a package-gated runtime sublanguage. The change is strictly additive:
+
+- **No grammar change.** No new tokens, no new keywords, no EBNF
+  modification. The annotation form `#[name(args?)]` from §1.9 is
+  reused.
+- **No change to user-reachable surface.** `RawPtr`, the `Pod` marker
+  trait, and all six runtime annotations (`#[intrinsic]`, `#[pod]`,
+  `#[repr(...)]`, `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`) are
+  rejected outside privileged packages with `E0770`. Programs that do
+  not opt in observe no behavior change.
+- **`unsafe` exclusion preserved.** §14 still excludes user-facing
+  `unsafe`. The runtime sublanguage is implementation-private; it is
+  reachable only by the toolchain itself, not by registry packages.
+- **New diagnostics.** `E0770` (privilege violation), `E0771`
+  (`#[pod]` shape rejection or unbounded generic), `E0772` (managed
+  allocation in `#[no_alloc]` body, or invalid type size for
+  `raw.cas`). All in the `E0770–E0779` typecheck-extension band; the
+  control-flow band `E0760–E0769` is already in use.
+- **Manifest schema dependency.** §19.2 introduces a `[capabilities]
+  runtime = true` table key in `osty.toml`. The manifest reference
+  (§10/§11/§13) gains this key in the same release.
+
+Recorded in `SPEC_GAPS.md` as **G19 — runtime sublanguage capability
+surface, decided**.
+
+### 18.1 v0.3 → v0.4
+
+v0.4 closes the v0.3 edge-case decision queue without adding a large new
+surface area. The goal is a tighter baseline: finite front-end rules,
+stable diagnostics, and implementation status that matches the spec.
+**No known open gaps remain** at the time of this release.
+
+| Gap | Resolution | Location |
+|---|---|---|
+| **G13** Structured-concurrency escape rules | `Handle<T>` and `TaskGroup` are non-escaping capabilities. Returning them, storing them in fields/collections for use outside the group, sending them over channels, or capturing them in escaping closures is `E0743`. | §8 |
+| **G14** Generic method turbofish and method references | `obj.method::<T>(args)` names method-local generics only; owner generics come from the receiver. Partial explicit type args are illegal. Generic methods cannot be extracted as `obj.method` function values; use a wrapper closure. | §4.9 |
+| **G15** Callable arity after erasure | Function values of type `fn(...) -> ...` do not preserve declaration default/keyword metadata. Calls through a function value are positional-only and exact arity (`E0701`). | §3.1, §4.9 |
+| **G16** Closure parameter patterns | Closure params accept `LetPattern (':' Type)?` but only irrefutable patterns. Refutable literal/range/variant/or patterns are rejected with `E0741`. | §4.7 |
+| **G17** Nested pattern witness diagnostics | Exhaustiveness diagnostics report one minimal missing pattern. Tuple/struct witnesses refine the leftmost missing component; closed enum/Option/Result payloads recurse; open types use `_`; guarded arms do not contribute coverage. | §4.3 |
+| **G18** Stdlib protocol executable stubs | Protocol signatures in §10/§15/§16/§17 are tracked as checked `.osty` stubs first. Runtime/gen parity is implementation backlog unless a signature ambiguity is found. | §10, §15-§17 |
+
+Additional grammar hardening:
+
+- Empty turbofish (`foo::<>`) is a syntax error.
+- Empty generic/type argument lists (`fn f<>()`, `List<>`) are syntax
+  errors; every generic parameter or type-argument list is non-empty.
+- Generic top-level functions and generic methods are not first-class
+  function values; callers must instantiate them through a call or a
+  wrapper closure.
+- Erased function values reject keyword arguments even when the original
+  declaration had parameter names.
+- `(T,)` is a one-element tuple type, not a parenthesized `T`; `fn()`
+  is the Unit-returning function type shorthand.
+
+### 18.2 v0.2 → v0.3
+
+v0.3 closes every remaining open gap from v0.2 and nails down the
+ambiguities surfaced by a full audit of the v0.2 text. **No known open
+gaps remain** at the time of this release.
+
+#### Gap resolutions
+
+| Gap | Resolution | Location |
+|---|---|---|
+| **G4** Closure parameter patterns | `ClosureParam ::= LetPattern (':' Type)?` — tuple/struct destructure allowed. Only irrefutable patterns. v0.3 specified the surface ahead of parser parity; v0.4 implements parser/checker support. | §4.7 |
+| **G8** Channel `close()` semantics | Any task may close. Second close aborts. `recv` returns buffered values then `None`. `for x in ch` terminates naturally. | §8.5 |
+| **G9** `Builder<T>` phantom type | Fully abstracted — `Builder<T>` surface only; internal phantom parameter names missing fields in the compile error. Users cannot construct or destructure. | §3.4 |
+| **G10** `Char` / surrogate | Surrogate code points are not representable. Literal/escape errors at compile time. `Int.toChar()` aborts; safe `Char.fromInt(n) -> Char?`. | §2.1, §10.5 |
+| **G11** Generic compilation model | **Monomorphization** (Rust-style). Interface values use fat-pointer + vtable. Error nominal tag (§7.4) remains orthogonal. | §2.7.3 |
+| **G12** Cancellation propagation | **Task-group auto-propagation** (Kotlin scope-style). Cancel signal carries `Cancelled { cause: Error }`. All stdlib blocking calls are cancel-aware and return `Err(Cancelled)` immediately. Defer bodies run on cancel (uninterruptible). | §8.4 |
+
+#### Additional decisions (from the v0.2 audit)
+
+**Concurrency**
+- `Handle<T>` may not escape its `taskGroup` block (compile error).
+- `abort(msg)` terminates the process; it is not a recoverable error.
+- `race` tie-breaking is scheduler-order-deterministic within a run.
+- Channel buffer=0 is a synchronous rendezvous.
+- `select` with `default`: `default` fires **only** when no other branch is ready.
+- `select` branches are evaluated sequentially in registration order.
+- `WaitGroup` is **removed** from the stdlib listing (§10.2) — `taskGroup` covers every use case.
+
+**Numerics**
+- Integer division / modulo by zero: **abort**.
+- `%` follows the dividend sign (C/Go convention): `-5 % 3 == -2`.
+- `Int.MIN.abs()`: abort. `checkedAbs`/`wrappingAbs` added.
+- Shift by ≥ bit-width: abort. Shift by 0: identity.
+- `Int.pow(exp)` with `exp < 0`: abort (use `Float.pow`).
+- `wrappingDiv`/`wrappingMod`/`checkedDiv`/`checkedMod`/`saturatingDiv` added.
+- **`Float → Int` conversion** is through explicit rounding-mode methods: `toIntTrunc`, `toIntRound` (banker's), `toIntFloor`, `toIntCeil`, each returning `Result<Int, Error>` (NaN/±Inf → `Err`). The ambiguous `Float.toInt()` is removed.
+- `Float.round()` uses banker's rounding (half-to-even).
+- Float `NaN`: `NaN.eq(NaN) == false` — documented exception to `Equal` reflexivity. `Float` is **not** `Hashable`.
+- `-0.0 == 0.0` is true; `-0.0 < 0.0` false under `==`, true under the total ordering exposed by `Ordered`.
+- Float literal exponent overflow (`1e1000`) parses to ±Infinity (IEEE).
+
+**Strings**
+- `String == String` is byte-wise. Normalization is explicit via `std.strings.normalize(form)`.
+- `String` ordering is byte-lexicographic.
+- String concatenation: `concat` method only — no `+` operator.
+- `String` read from a file with invalid UTF-8: the bytes are retained as `Bytes`; `Bytes.toString()` returns `Err` at the conversion boundary.
+
+**Generics**
+- Invariant on all type parameters. No declaration-site or use-site variance.
+- Recursive generic types (`struct Node<T> { next: Node<T>? }`) are allowed.
+- Generic methods on structs/enums are allowed independently of the enclosing type's generics.
+- No type-parameter default values (`<T, U = T>`).
+- Turbofish is not used on enum variant construction.
+
+**Interfaces**
+- Default methods may call other default methods.
+- Interface methods may themselves be generic.
+- Partial implementation (missing required methods) is a compile error.
+- Interface composition with name collisions is a compile error; explicit override is required.
+- `Self` is permitted in parameter position (already used by `Equal`).
+
+**Errors**
+- `abort(msg)` inside `taskGroup` terminates the process; it does not deliver `Err` to siblings.
+- A user type may be both `Error` and `Hashable` without restriction.
+- `?` auto-widens concrete errors to `Error` only when the enclosing function returns `Result<_, Error>`. Otherwise explicit conversion is required.
+- Recommended pattern for multiple error types: local enum wrapper implementing `Error`.
+
+**Memory / GC**
+- GC algorithm and triggers are **out of scope** for the spec (implementation-defined).
+- No finalizers.
+- No weak references.
+- OOM aborts the process.
+- Cycle collection is guaranteed.
+
+**Patterns**
+- Or-pattern alternatives must agree on binding names and types; different nesting depths allowed.
+- Guards may reference pattern bindings; guards may not introduce new bindings.
+- Range patterns require `Ordered` scrutinee; `Char` ranges (`'a'..='z'`) permitted, `String` ranges rejected.
+- Literal patterns are type-strict (no numeric coercion).
+
+**Modules**
+- Partial declarations must agree on `pub`-ness.
+- Type alias's visibility is of the alias declaration, not the aliased type.
+- Diamond imports (A→B→D, A→C→D) are allowed.
+- Version conflicts are resolved by `osty.lock`; spec defers to package manager.
+
+**Defer**
+- Runs on normal exit, `?`-propagated early return, and cancellation.
+- Does **not** run on `abort`/`unreachable`/`todo`/`os.exit`.
+- Blocking calls inside `defer` ignore cancellation (cleanup is uninterruptible).
+- Bare `defer` at top level of a script is a compile error.
+
+**FFI**
+- Go `panic` crossing the bridge **aborts** the Osty process.
+- Generic Osty functions cannot be declared in a `use go` block.
+- Osty closures cannot cross the FFI boundary.
+- Go `interface{}` is not representable in FFI declarations.
+- Go `error → Osty Error` is best-effort — `message()` is preserved; `downcast::<T>()` is not supported for Go-origin errors.
+
+**Testing**
+- Test execution order is randomized with a printed reproducible seed; `--seed <hex>` replays a run.
+- No `beforeEach`/`afterEach` hooks — use helpers or `testing.context`.
+
+**JSON**
+- Unknown object keys during decode are **silently ignored** (forward-compat default).
+- Type mismatches fail fast with `Err`; no partial recovery.
+- Duplicate effective variant tags are a compile error.
+- Missing key vs `null` for `T?` both decode to `None`.
+
+**Annotations**
+- Cannot appear on `use` statements, expressions (including closures), or individual in-body statements.
+- Same annotation name cannot be repeated on a single target.
+- Partial-decl annotations are scoped to the declaration they appear in; the compiler does not merge across declarations.
+- `#[deprecated]` does not propagate transitively.
+
+**Miscellaneous**
+- Zero-sized structs (`struct Marker {}`) are allowed.
+- Recursive struct `auto-derive` (`Equal`, `Hashable`, `ToString`) is supported inductively.
+- `??` precedence is grammar-authoritative (§1.7 cross-references the grammar).
+- Closure capture of `mut` bindings is by mutable reference (existing §4.7).
+
+### 18.3 v0.1 → v0.2
+
+v0.2 reconciled every conflict between `LANG_SPEC_v0.1.md` and
+`OSTY_GRAMMAR_v0.2.md` and resolved gaps G1, G2, G3, G5, G6, G7 from
+`SPEC_GAPS.md`. The spec was also split into the per-section folder
+that v0.3 inherits.
+
+#### Conflict resolutions (LANG_SPEC v0.1 ↔ GRAMMAR v0.2)
+
+| # | Topic | v0.1 | v0.2 |
+|---|---|---|---|
+| C1 | Annotation argument form | `name = value` only | `name = value` **or** bare `name` flag (§1.9) |
+| C2 | `#[json]` arguments | `key` only | `key`, `skip`, `optional` (§3.8.1) |
+| C3 | `#[json]` targets | struct fields + enum variants | struct fields + enum variants (unchanged; GRAMMAR text saying "struct fields only" was incorrect) |
+| C4 | `#[deprecated]` arg name | `note` | `message` (§3.8.2) |
+| C5 | `#[deprecated]` targets | fn/struct/enum/interface/type/let/fields/variants | fn/struct/enum/interface/type/let/methods/fields/variants |
+| C6 | `=>` token | implied absent | explicitly **not a token**; match arms use `->` (§1.7, O7) |
+
+#### Lexical / syntactic decisions imported from GRAMMAR
+
+| Decision | Section |
+|---|---|
+| O2: `}` and `else` must be on one line | §1.8 |
+| O3: leading `.` for chain continuation; trailing `.` is a syntax error | §1.8 |
+| O4: splittable `>` for nested generics (`List<List<T>>`) | §2.7.2 |
+| O5: `_` is a distinct `UNDERSCORE` token; `_foo` is an `IDENT` | §1.4 |
+| O6: `::` must be followed by `<` (turbofish strict) | §2.7.2 |
+| O7: `=>` is removed from the token set | §1.7 |
+| R3: formal "RestrictedExpr" rule | §4.1.1 |
+| R10: shebang at byte 0 only, once | §1.1 |
+| Full ASI suppression rules from R2 | §1.8 |
+
+#### Gap resolutions
+
+| Gap | Resolution | Location |
+|---|---|---|
+| **G1** Collection `Equal`/`Hashable` derivation | Built-in instances table + collection derivation rules | §2.6.5 |
+| **G2** `Duration.toString`, `Duration` as log value | `Duration.toString()` added; `LogValue::Duration` documented | §10.20, §10.10 |
+| **G3** `LogValue` concrete enum + auto-promotion | Defined as a sum type with auto `ToLogValue` promotion | §10.10 |
+| **G5** Script `return` semantics | Documented as return from implicit `main` | §6 |
+| **G6** Annotations on partial declarations | Scoped per-declaration; no merging | §3.4 |
+| **G7** Diagnostic template for positional-after-keyword | Fixed-form error box | §3.1 |
+
+#### New sections (introduced in v0.2)
+
+| § | Title | Purpose |
+|---|---|---|
+| §15 | Iteration Protocol | `Iterator<T>`, `Iterable<T>`, `for`-loop desugaring. |
+| §16 | I/O Protocol | Method signatures for `Reader`, `Writer`, `Closer`, `ReadWriter`. |
+| §17 | Display and Format Protocol | `ToString` interface, auto-derivation rules, string interpolation semantics. |
+
+#### Additional v0.2 decisions
+
+- `Bytes` literal `b"..."` (§2.4.1).
+- `String` indexing is byte-based (§4.10).
+- struct/enum `ToString` auto-derivation (§17).
+- Bit shift overflow policy and `wrapping*`/`checked*` shift methods (§2.3, §10.5).
+- `Error.downcast::<T>()` documented as the one nominal-typing exception (§7.4).
+- Built-in-instances table (§2.6.5) enumerates primitive `Equal`/`Ordered`/`Hashable`/`ToString` membership.
+
+### 18.4 Migration notes
+
+**v0.2 → v0.3 breaking changes to watch for:**
+
+- `'\u{D800}'` and similar surrogate literals now fail to compile (§2.1).
+- `Float.toInt()` is removed; use `toIntTrunc`/`toIntRound`/`toIntFloor`/`toIntCeil`, all returning `Result<Int, Error>` (§10.5).
+- `WaitGroup` references in user code must be migrated to `taskGroup` (§8.1).
+- `time.sleep(d)` now returns `Result<(), Error>` instead of `()` (§10.20).
+- Top-level `defer` in scripts is now an error — wrap in `{ ... }` (§6).
+
+**v0.1 → v0.3 migration** follows both §18.1 and §18.2. Users moving
+directly should read §18.2 first, then §18.1.

--- a/LANG_SPEC_v0.6/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.6/19-runtime-primitives.md
@@ -1,0 +1,632 @@
+## 19. Runtime Primitives
+
+This chapter specifies the **runtime sublanguage** — a small, package-gated
+surface that lets the Osty toolchain implement the GC, allocator, and other
+runtime services in Osty itself. None of this surface is reachable from
+ordinary user code; the entire chapter is invisible to programs that do not
+opt into the runtime gate.
+
+The user-facing language guarantees of §9 (Memory Management) are
+unchanged. There is no `unsafe` block, no raw pointer in the user prelude,
+no manual deallocation API on `T`. §14 still excludes `unsafe`; that
+exclusion is about *user* code. This chapter exists so the GC promise of
+§9 has a concrete implementation strategy without requiring that strategy
+to be written in C.
+
+### 19.1 Scope and Non-Goals
+
+**In scope.**
+
+- A single opaque integer-shaped pointer type, `RawPtr`.
+- A compile-time marker trait, `Pod`, that proves a type contains no
+  managed references.
+- Six new annotations: `#[intrinsic]`, `#[pod]`, `#[repr(...)]`,
+  `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`.
+- A package-level gate (§19.2) that restricts the surface to the runtime
+  packages.
+- Lowering rules (§19.7) that connect intrinsics to LLVM IR and to the
+  C ABI used by the runtime symbol set (`osty.gc.*`).
+- The compiler-to-runtime safepoint contract (§19.10) that lets an
+  Osty-side `safepoint_v1` see the same root array the C runtime sees
+  today.
+
+**Out of scope.**
+
+- A general `unsafe` block. There isn't one.
+- Address-of (`&x`) for managed references. Managed references remain
+  GC handles in the language model; their representation is not
+  observable.
+- Stackmap *introspection* intrinsics. The runtime never reads stackmap
+  metadata directly; instead, the compiler-emitted call site for
+  `safepoint_v1` (§19.10) materializes the root array and passes it in.
+  The runtime walks an array, not the stack.
+- Volatile, atomic-fence, or inline-assembly primitives. The first GC
+  delivered through this surface is single-threaded stop-the-world.
+  The `cas` intrinsic (§19.5) is provided for forward compatibility
+  with later concurrent algorithms; the v0.4 single-threaded GC is not
+  required to exercise it.
+
+**GC × scheduler interaction.** §8 specifies an M:N scheduler; §19
+specifies a single-threaded STW collector. These compose as follows:
+
+- A collection cycle is initiated from a worker that reaches a
+  safepoint (§19.10) and finds the `stop_requested` flag set.
+- Every other worker must reach a safepoint before the collector
+  proceeds. Tasks parked at a language-level yield point (§8.0:
+  channel send/recv, `Handle.join`, `thread.yield`, `thread.sleep`,
+  `thread.select` blocking arms, cancellation checks) are treated as
+  having **passed** a safepoint; the runtime registers their live
+  root set when parking so the collector walks it in place.
+- FFI calls declared through §19 or `use go` are **not** implicit
+  safepoints; a worker stuck in a long blocking FFI call delays
+  collection for the whole process. A future revision may add a
+  `#[gc_safe]` annotation for FFI hand-off; v0.4 does not.
+- When all workers are parked at safepoints, the collector runs
+  single-threaded over the union of (a) the root array passed by the
+  initiating safepoint and (b) the per-task parked-root arrays. It
+  then releases the workers.
+
+The v0.4 collector **does not** walk fiber-saved register state or
+unregistered stack memory. Programs that allocate a value and hold it
+as a local across a yield point are safe only if the compiler-emitted
+safepoint at the yield point lists that local in the root array. The
+MIR lowering for `IntrinsicSpawn`, `IntrinsicHandleJoin`,
+`IntrinsicChanSend`, and `IntrinsicChanRecv` is required to emit a
+safepoint with the caller's live roots before dispatching to the
+corresponding `osty_rt_*` symbol. Runtime phases that do not yet
+satisfy this contract are called out in `RUNTIME_SCHEDULER.md` with
+their narrowing restriction (e.g., Phase 1A runs all tasks
+sequentially on a single worker, so the parked-root concern is vacuous
+but the contract is documented for Phase 1B and later).
+
+### 19.2 Privileged Packages
+
+The runtime surface is **gated by package path**. A package is privileged
+if and only if either:
+
+1. Its fully qualified path begins with the prefix `std.runtime.`
+   (the public namespace for runtime intrinsics), or
+2. Its `osty.toml` manifest contains `[capabilities] runtime = true`
+   **and** the manifest is loaded from a path under the toolchain
+   workspace root. The compiler refuses this capability bit when the
+   manifest is loaded from a registry-fetched dependency, regardless of
+   the bit's value in the published manifest.
+
+The `[capabilities]` table is part of the manifest schema; the v0.4
+runtime spec is the first chapter to require it. Manifest loaders that
+do not yet recognize the table treat any unknown key as a parse error
+(per §10/§11/§13 manifest conventions), so older toolchains refuse to
+compile a package that depends on this surface — which is the desired
+fail-closed behavior.
+
+A non-privileged package that:
+
+- declares a function with `#[intrinsic]`, `#[no_alloc]`, `#[c_abi]`, or
+  `#[export(...)]`, or
+- declares a type with `#[pod]` or `#[repr(c)]`, or
+- imports `std.runtime.*` (any subpath), or
+- names `RawPtr` or the `Pod` trait,
+
+is rejected at resolution time with `E0770 runtime primitive used outside
+privileged package`. The diagnostic preferentially points at the import
+when one is present, otherwise at the offending annotation or identifier.
+
+### 19.3 The `RawPtr` Type
+
+```osty
+opaque type RawPtr        // declared in std.runtime
+```
+
+`RawPtr` is an opaque integer-shaped type with the following contract:
+
+- It occupies the target's pointer width. v0.4 supports 64-bit targets
+  only, so `RawPtr` is 8 bytes.
+- It is `Pod` (it contains no managed reference).
+- It implements `Equal` and `Hashable`. It does **not** implement
+  `Ordered`; the runtime uses tag bits, not numeric comparison, when it
+  needs ordering on raw addresses.
+- Pattern matching on `RawPtr` supports identifier and equality patterns
+  (via `Equal`); range patterns are rejected with `E0723` (range
+  pattern requires `Ordered`).
+- The garbage collector does **not** trace `RawPtr` values. A `RawPtr`
+  may dangle, alias, or refer to uninitialized memory. Its semantics
+  are the C `uintptr_t` semantics, not a managed handle.
+
+The literal sugar `T?` is *not* available on `RawPtr` directly — code
+that wants a "maybe-null" representation in the runtime ABI uses
+`RawPtr` and tests against `raw.null()`, because the allocator-failure
+path returns its result in a single register matching the C ABI and an
+`Option` tag would change the calling convention. `Option<RawPtr>`
+*is* permitted in ordinary `#[no_alloc]` code (§19.4 allows
+`Option<T: Pod>` as `Pod`); it just cannot appear as the return type of
+a `#[c_abi]` function.
+
+`RawPtr` values are constructed only by the §19.5 intrinsics
+(`raw.alloc`, `raw.offset`, `raw.read::<RawPtr>`, `raw.null`,
+`raw.fromBits`). They are observed as integers via `raw.bits`.
+
+### 19.4 The `Pod` Marker Trait
+
+```osty
+interface Pod {}          // declared in std.runtime; compiler-derived
+```
+
+`Pod` is a compile-time marker that means: "values of this type contain
+no managed reference, no closure capture, and no padding bits whose
+value the compiler may choose freely". `Pod` membership is decided by
+the checker, not by user impl. There is no `impl Pod for ...` syntax.
+
+A type satisfies `Pod` exactly when one of the following derivation
+rules applies:
+
+1. **Primitives.** `Bool`, `Char`, `Byte`, `Int`, `Int8`–`Int64`,
+   `UInt8`–`UInt64`, `Float` (alias for `Float64`), `Float32`,
+   `Float64`, and `RawPtr` are `Pod`.
+2. **Annotated structs.** A `struct` declaration is `Pod` if it carries
+   both `#[pod]` and `#[repr(c)]` and every field type is `Pod`. The
+   checker verifies the field shape; an offending field is reported as
+   `E0771 type cannot be marked #[pod]`, naming the first non-`Pod`
+   field.
+3. **Generic annotated structs.** A generic `#[pod] #[repr(c)] struct
+   S<T1, …, Tn>` requires every type parameter to carry the bound
+   `Tk: Pod` at the declaration site. The resulting `Pod` instance is
+   unconditional. Per-instantiation `Pod` (membership computed
+   per-use) is **not** supported in v0.4; an unbound generic struct
+   marked `#[pod]` is `E0771`.
+4. **Tuples.** A tuple type `(T1, …, Tn)` is `Pod` if every component
+   is `Pod`. Because struct values have reference semantics in the
+   user-facing language (§2.8), a tuple component of type `S` is `Pod`
+   *only* when `S` is a `#[pod] #[repr(c)]` struct, in which case the
+   tuple stores `S` by value (the runtime sublanguage is the only
+   place this by-value treatment is observable; in user-facing code the
+   reference semantics of §2.8 still hold because user code never sees
+   `Pod` types).
+5. **`Option<T>` of `Pod`.** `Option<T>` is `Pod` when `T: Pod`. The
+   lowering uses a tagged representation whose payload is exactly
+   `sizeOf::<T>()` plus an aligned tag byte; no managed allocation
+   participates.
+6. **Nothing else.** `String`, `Bytes`, `List<T>`, `Map<K, V>`,
+   `Set<T>`, closure values, function values, interface values,
+   `Result<T, E>`, ordinary user-defined enums, and any type that
+   transitively contains one of these are *not* `Pod`. `Result` is
+   excluded because its error arm carries `Error`, an interface.
+   Runtime code that wants result-style propagation returns `RawPtr`
+   sentinels or aborts.
+
+The trait has no methods. It exists only as a constraint:
+
+```osty
+fn raw.read<T: Pod>(p: RawPtr) -> T
+fn raw.write<T: Pod>(p: RawPtr, v: T)
+fn raw.cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
+```
+
+Calling `raw.read::<List<Int>>(p)` is `E0727` (constraint not
+satisfied), not a runtime crash.
+
+**Footgun note.** `RawPtr` is `Pod` because the GC tracer does not
+follow it. A `#[pod] #[repr(c)] struct Header { next: RawPtr, … }`
+therefore satisfies `Pod` even though it stores an address into managed
+memory. The privileged-package author is responsible for ensuring such
+pointers do not become the only handle to a live object — the tracer
+will not preserve them. This is exactly the pattern the current C
+runtime uses for its `osty_gc_header.next` linked list, and the spec
+permits it intentionally.
+
+### 19.5 Intrinsic Functions
+
+The runtime surface declares the following intrinsics inside the
+package `std.runtime.raw`. Each declaration is body-less and carries
+`#[intrinsic]`. Generic intrinsics participate in monomorphization
+exactly like any other generic; the lowering layer (§19.7) supplies the
+specialized body at each instantiation site, so the intrinsic is never
+present as a real symbol in the final object file.
+
+```osty
+package std.runtime.raw
+
+#[intrinsic] pub fn null() -> RawPtr
+#[intrinsic] pub fn fromBits(n: Int) -> RawPtr
+#[intrinsic] pub fn bits(p: RawPtr) -> Int
+#[intrinsic] pub fn alloc(bytes: Int, align: Int) -> RawPtr
+#[intrinsic] pub fn free(p: RawPtr)
+#[intrinsic] pub fn zero(p: RawPtr, bytes: Int)
+#[intrinsic] pub fn copy(dst: RawPtr, src: RawPtr, bytes: Int)
+#[intrinsic] pub fn offset(p: RawPtr, bytes: Int) -> RawPtr
+#[intrinsic] pub fn read<T: Pod>(p: RawPtr) -> T
+#[intrinsic] pub fn write<T: Pod>(p: RawPtr, v: T)
+#[intrinsic] pub fn cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
+#[intrinsic] pub fn sizeOf<T: Pod>() -> Int
+#[intrinsic] pub fn alignOf<T: Pod>() -> Int
+```
+
+Privileged callers reach them through their fully-qualified path:
+
+```osty
+use std.runtime.raw
+
+let header = raw.alloc(64, 8)
+if raw.bits(header) == 0 { abort("oom") }
+raw.write::<Int>(raw.offset(header, 8), 0)
+```
+
+**Behavior contract.**
+
+- `null()` returns a `RawPtr` whose integer value is 0.
+- `fromBits(n)` reinterprets a signed 64-bit integer as a pointer.
+  `bits(p)` is the inverse. Both are total; arithmetic on `Int`
+  follows §2.3.
+- `alloc(bytes, align)` requests a fresh, naturally-aligned block of
+  `bytes` bytes from the host allocator. The block is **not** zeroed;
+  callers that need zero-initialized memory follow `alloc` with
+  `zero` (or use the `alloc_zeroed` helper that the privileged `std.runtime`
+  package layers on top — see §19.7 lowering for the rationale). On
+  failure `alloc` returns the value of `null()`. `align` must be a
+  power of two and at least 1; `bytes` must be non-negative; both
+  preconditions abort on violation. The caller is responsible for
+  matching every successful `alloc` with exactly one `free`.
+- `free(p)` releases a block previously returned by `alloc`. `free`
+  of `null()` is a no-op. `free` of a non-`null`, non-`alloc`-returned
+  pointer aborts.
+- `zero` and `copy` perform `memset` and `memmove` semantics
+  respectively. `bytes` must be non-negative; negative values abort.
+  Overlap is permitted in `copy` (it is `memmove`, not `memcpy`).
+- `offset(p, n)` returns a `RawPtr` whose integer value is `bits(p) +
+  n`. There is no overflow check; raw arithmetic overflow is the
+  caller's problem and matches C `uintptr_t` semantics.
+- `read::<T>(p)` performs an aligned load of `sizeOf::<T>()` bytes
+  from `p`, reinterpreting them as `T`. The caller is responsible for
+  alignment and for `p` pointing at a live, properly-typed location.
+  **Reading from freed or uninitialized memory is undefined behavior**
+  in the LLVM IR sense — the optimizer may transform surrounding code
+  accordingly. The lowering applies an LLVM `freeze` so the resulting
+  value is a fixed-but-unspecified bit pattern rather than `poison`,
+  but this does not retroactively make the surrounding control flow
+  defined. Privileged code that reads possibly-uninitialized memory
+  must mask, check, or otherwise sanitize the result before branching
+  on it.
+- `write::<T>(p, v)` performs the matching aligned store.
+- `cas::<T>(p, old, new)` is a sequentially-consistent
+  compare-and-swap. The type argument is constrained to
+  `sizeOf::<T>() ∈ {1, 2, 4, 8, 16}` and `alignOf::<T>() ==
+  sizeOf::<T>()`. Other sizes are rejected at the call site with
+  `E0772 cas type size invalid` (a checker-side rule, not a link
+  error). The intrinsic is provided for forward compatibility with
+  future concurrent collectors; the v0.4 single-threaded STW GC may
+  leave it unused.
+- `sizeOf::<T>()` and `alignOf::<T>()` are compile-time constants
+  computed by the lowering layer. Calls with a non-`Pod` type
+  argument are rejected statically with `E0727`.
+
+These intrinsics are **not** exported by the standard prelude. User
+code cannot `use std.runtime.raw`; resolution rejects the import with
+`E0770`.
+
+### 19.6 New Annotations
+
+The `#[...]` annotation syntax is unchanged (§1.9). The recognized
+annotation set in §3.8 grows by six entries. None require new tokens
+or grammar rules.
+
+| Annotation | Applies to | Purpose |
+|---|---|---|
+| `#[intrinsic]` | `fn` declarations in privileged packages | Marks a function whose body is supplied by the lowering layer. The source body must be empty (`fn foo() -> T;` or `fn foo() -> T {}`). Generic intrinsics participate in monomorphization (§19.5). |
+| `#[pod]` | `struct` declarations in privileged packages | Requests the checker to verify the struct's `Pod` shape (§19.4); rejection is `E0771`. |
+| `#[repr(c)]` | `struct` declarations in privileged packages | Forces C ABI field order, padding, and alignment. Required on any struct used with `raw.read`/`raw.write` or passed across a `#[c_abi]` boundary. |
+| `#[export("name")]` | top-level `fn` declarations in privileged packages | Emits the function with the exact symbol name `name`, disabling Osty name mangling. The argument is a string literal (§1.9). |
+| `#[c_abi]` | top-level `fn` declarations in privileged packages | Use the platform C calling convention rather than the Osty calling convention. Almost always paired with `#[export("...")]`. The annotation name is `c_abi`, not `ccc`, to keep the surface readable for toolchain authors who do not work in LLVM IR daily. |
+| `#[no_alloc]` | `fn` and method declarations in privileged packages | Forbids managed allocation in the function body, **and** any direct or transitive call to a function that allocates (§19.6.1). |
+
+Annotation order on the same declaration is not significant; the
+following stacking is canonical:
+
+```osty
+#[export("osty.gc.alloc_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn alloc_v1(bytes: Int, kind: Int) -> RawPtr { ... }
+```
+
+The `#[deprecated]` annotation may also appear on these functions.
+`#[json(...)]` may not — privileged types are never serialized through
+the stdlib json codec.
+
+#### 19.6.1 The `#[no_alloc]` Check
+
+A `fn` carrying `#[no_alloc]` must contain no expression whose
+evaluation requires the managed allocator, and must not call any
+function that does. The checker computes a least-fixed-point over the
+call graph restricted to privileged packages. Self-recursion and mutual
+recursion among `#[no_alloc]` functions are permitted.
+
+The checker rejects, with `E0772 managed allocation in #[no_alloc]
+body`, any of the following constructs reachable from the function
+body:
+
+- string interpolation (`"x = {x}"`) and string concatenation that
+  produces a fresh `String`;
+- triple-quoted and raw string literals that produce a fresh `String`
+  at runtime (compile-time-interned static literals — see below — are
+  permitted);
+- list, map, or set literals (`[1, 2, 3]`, `[a: 1]`, `{1, 2, 3}`);
+- struct literals whose declared type is **not** `Pod`;
+- enum variant construction whose enum is not `Option<T: Pod>`
+  (permitted) and not declared in `std.runtime.*` (also permitted).
+  All other enum constructions, including `Result<…, …>`, are
+  rejected;
+- `Builder<T>` use of any kind;
+- direct or transitive call to a function that is not `#[no_alloc]`
+  and lives in the privileged-package call graph;
+- any call into ordinary stdlib (which is non-privileged), regardless
+  of whether that callee actually allocates;
+- **call through a function-pointer parameter or `fn(...)` value** —
+  the body cannot be analyzed, so the call is rejected. Privileged
+  callers that need indirect dispatch use a `match` over a closed enum
+  of `Pod` discriminators;
+- **call through an interface value (vtable dispatch, §2.7.3)** —
+  the dynamic dispatch boundary makes the callee's `#[no_alloc]`-ness
+  unknowable. Privileged callers do not use interface values;
+- **call to a default interface method** unless that default body is
+  itself `#[no_alloc]` and lives in a privileged package.
+
+Permitted constructs include:
+
+- all `Pod`-only arithmetic, comparison, and bit-ops;
+- all `raw.*` intrinsics from §19.5;
+- control flow (`if`, `for`, `match`, `defer`);
+- pattern matching on `Pod` values;
+- calls to other `#[no_alloc]` functions in privileged packages,
+  including self-recursion and mutual recursion;
+- construction of `Option<T: Pod>` and pattern matching on it;
+- construction of variants of enums declared in `std.runtime.*`
+  (the privileged enum hierarchy);
+- struct literals whose declared type is `Pod`;
+- reads from and writes to top-level `let mut` bindings of `Pod` type,
+  and to `Pod` fields of such bindings reached through `Pod` field
+  access;
+- **plain string literals** (`"abort"`, `"oom"`) with no
+  interpolation, no triple-quoting, and no raw form. These are
+  compile-time-interned into `.rodata`-equivalent storage; passing
+  one to a `#[c_abi]` function as an `i8*`-shaped argument is
+  allocation-free. The lowering details are in §19.7.
+
+This check is what makes the GC implementable in Osty: it is impossible
+for `collect_v1` to recursively re-enter the allocator through a
+forgotten string interpolation in a debug log line, and it is
+impossible for the runtime to call into ordinary stdlib (which would
+itself need a working allocator).
+
+### 19.7 Lowering
+
+LLVM lowering of the intrinsics is fixed by this specification. The
+backend is permitted to specialize but not to weaken the contract.
+Lowering syntax below is shown in pre-opaque-pointer LLVM (typed
+pointers) for readability; on the toolchain's required LLVM version
+(opaque pointers, ≥15) every `bitcast i8* p to T*` collapses and `load`
+/ `store` use `ptr` directly.
+
+| Intrinsic | LLVM lowering |
+|---|---|
+| `raw.null()` | `inttoptr i64 0 to i8*` |
+| `raw.fromBits(n)` | `inttoptr i64 %n to i8*` |
+| `raw.bits(p)` | `ptrtoint i8* %p to i64` |
+| `raw.alloc(b, a)` | `call i8* @osty_rt_alloc_aligned(i64 %a, i64 %b)` — see "shim" below. |
+| `raw.free(p)` | `call void @free(i8* %p)` |
+| `raw.zero(p, n)` | `call void @llvm.memset.p0i8.i64(i8* %p, i8 0, i64 %n, i1 false)` |
+| `raw.copy(d, s, n)` | `call void @llvm.memmove.p0i8.p0i8.i64(i8* %d, i8* %s, i64 %n, i1 false)` |
+| `raw.offset(p, n)` | `getelementptr i8, i8* %p, i64 %n` |
+| `raw.read::<T>(p)` | `bitcast i8* %p to T*; %v = load T, T* %1, align alignof(T); freeze T %v` |
+| `raw.write::<T>(p, v)` | `store T %v, T* %1, align alignof(T)` (after the matching bitcast) |
+| `raw.cas::<T>(p, old, new)` | `cmpxchg T* %p, T %old, T %new seq_cst seq_cst`, then extract the success bit. Only emitted when `sizeOf::<T>()` is in `{1, 2, 4, 8, 16}` and `alignOf::<T>() == sizeOf::<T>()`; other shapes are caught at §19.5 by `E0772`. |
+| `raw.sizeOf::<T>()` | constant folded from the data layout (no runtime call). |
+| `raw.alignOf::<T>()` | constant folded from the data layout. |
+
+**`raw.alloc` shim.** The symbol `osty_rt_alloc_aligned` is provided by
+a single-translation-unit C shim at
+`internal/backend/runtime/raw_alloc_shim.c`, unconditionally linked
+into any binary that contains a `raw.alloc` call. Its definition is
+exactly:
+
+```c
+#include <stdlib.h>
+void *osty_rt_alloc_aligned(size_t align, size_t bytes) {
+    void *p = NULL;
+    if (posix_memalign(&p, align < sizeof(void*) ? sizeof(void*) : align, bytes) != 0) {
+        return NULL;
+    }
+    return p;
+}
+```
+
+The shim does **not** zero memory; per §19.5 the contract for
+`raw.alloc` is uninitialized memory. Privileged callers that need a
+zero-initialized block compose `raw.alloc` with `raw.zero`, or use the
+`alloc_zeroed` helper that the privileged `std.runtime` package wraps
+on top:
+
+```osty
+#[no_alloc]
+pub fn alloc_zeroed(bytes: Int, align: Int) -> RawPtr {
+    let p = raw.alloc(bytes, align)
+    if raw.bits(p) != 0 { raw.zero(p, bytes) }
+    p
+}
+```
+
+**Plain string literals.** A bare `"…"` literal in a `#[no_alloc]`
+body is emitted as an LLVM `private unnamed_addr constant` of type
+`[N x i8]` and referenced by a constant `getelementptr` to its first
+byte. When passed to a `#[c_abi]` function declared with an `i8*`-
+shaped parameter (Osty `RawPtr` or, in v0.4 minor, the future
+`CStr` opaque), the value crosses the ABI boundary as a pointer to
+this constant. No allocation, no copy.
+
+**`#[c_abi]`** causes the function declaration to be emitted with
+LLVM's `ccc` calling convention.
+
+**`#[export("name")]`** causes the function to be emitted with
+`external` linkage, the `dso_local` preemption hint, and the exact
+symbol name `name`. The combination of `#[c_abi]` and
+`#[export(...)]` is what lets `osty_runtime.c` and the Osty-side
+runtime export the same `osty.gc.*_v1` ABI symbols interchangeably.
+
+**`#[no_alloc]`** does not produce a runtime check; it is purely a
+front-end discipline. The body, once accepted, lowers like any other
+function.
+
+### 19.8 Interaction with Other Chapters
+
+- **§1.9, §3.8 — Annotations.** The annotation grammar is unchanged.
+  The recognized-annotation table grows by six entries. Applying any
+  of the six in a non-privileged package is `E0770`, not the generic
+  unknown-annotation diagnostic (`E0607`).
+- **§2.1 — Primitive Types.** `RawPtr` is added to the table with a
+  pointer to §19.3. It is not a member of the user prelude.
+- **§2.6 — Interfaces.** `Pod` is added to the built-in instances
+  table with a pointer to §19.4.
+- **§9 — Memory Management.** Unchanged. The chapter still does not
+  pin the GC algorithm; it just becomes possible for the chosen
+  algorithm to be written in Osty.
+- **§10 / §11 / §13 — Manifest schema.** The `[capabilities]` table is
+  introduced by this chapter; the manifest chapter must surface it in
+  the next minor of the manifest reference. Until then the schema
+  reference is §19.2.
+- **§12 — FFI.** Unchanged. `use go "..."` continues to be the only
+  way for *user* code to reach a foreign symbol. The runtime
+  primitives are not an FFI mechanism; they are a code-generation
+  hook for the toolchain itself.
+- **§14 — Excluded Features.** The exclusion of `unsafe` stands.
+  §19 does not introduce an `unsafe` keyword, an `unsafe` block, or a
+  user-reachable raw pointer. The package gate (§19.2) is what makes
+  the surface implementation-private rather than user-facing.
+
+### 19.9 Diagnostics Added by This Chapter
+
+Codes are allocated in the `E0770–E0779` typecheck-extension band.
+The control-flow band `E0760–E0769` is already in use by
+`internal/diag/codes.go` (`CodeUnreachableCode`, `CodeMissingReturn`,
+`CodeDefaultNotLiteral`); the runtime sublanguage uses the next free
+band to avoid collision.
+
+| Code | Meaning |
+|---|---|
+| `E0770` | Runtime primitive (annotation, type, intrinsic, or `std.runtime.*` import) used outside a privileged package. |
+| `E0771` | A struct marked `#[pod]` violates the §19.4 shape rule. The diagnostic names the first offending field, or — for unbounded generic structs — the first type parameter that lacks a `T: Pod` bound. |
+| `E0772` | Either (a) a managed allocation was found inside a `#[no_alloc]` body, with a span pointing at the offending expression and (when transitive) the first non-`#[no_alloc]` callee on the chain; or (b) a `raw.cas::<T>` call where `sizeOf::<T>()` is not in `{1, 2, 4, 8, 16}` or alignment does not match. |
+
+The `Wxxxx` and `Lxxxx` bands are not used by this chapter; runtime-
+primitive misuse is always a hard error.
+
+### 19.10 Compiler-to-Runtime Safepoint Contract
+
+The runtime's safepoint entry point cannot identify roots by reading
+the stack itself (§19.1 makes that out of scope). Instead, the
+compiler emits, at every safepoint call site, a call sequence that
+materializes the live root array and passes it to the runtime
+explicitly. The runtime walks an array, not the stack.
+
+The contract for the C ABI symbol `osty.gc.safepoint_v1` is:
+
+```osty
+// signature, exported from the privileged runtime package
+#[export("osty.gc.safepoint_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn safepoint_v1(
+    site_id: Int,         // statically assigned per call site
+    roots: RawPtr,        // pointer to a contiguous array of N RawPtr slot addresses
+    root_count: Int,      // N
+)
+```
+
+At each safepoint, the LLVM lowering layer:
+
+1. Computes the set of live managed slots at that program point from
+   the LLVM stackmap.
+2. Materializes their addresses into a stack-allocated
+   `[root_count x i8*]` array.
+3. Emits a call to the exported `safepoint_v1` symbol with that
+   array's address and length.
+
+The runtime treats `roots` as a `RawPtr` to the start of an array;
+slot `k` is `raw.read::<RawPtr>(raw.offset(roots, k * 8))`. Each slot
+address points at a managed pointer. The runtime is free to **read**
+those slots (to mark) and to **overwrite** them (for a future moving
+collector); it must not free the addresses themselves.
+
+The matching contract for the existing C runtime ABI symbols
+`osty.gc.root_bind_v1`, `osty.gc.root_release_v1`, `osty.gc.post_write_v1`,
+`osty.gc.load_v1`, `osty.gc.mark_slot_v1`, and `osty.gc.alloc_v1` is
+preserved bit-for-bit. The Osty-side reimplementation of any of these
+declares the same C ABI signature with `#[c_abi]` and the matching
+`#[export("...")]`, and is link-compatible with the existing
+`internal/backend/runtime/osty_runtime.c` so that switching from the C
+runtime to the Osty runtime is purely a build-system decision.
+
+### 19.11 Implementation Status
+
+This chapter ships in slices: the full surface is specified, but
+each piece is delivered by its own PR with focused tests. The
+table below records what is wired today vs. deferred. Update it
+in the same PR that lands a new piece.
+
+**Front-end (parser / resolver / checker / stdlib).** Closed.
+
+| Piece | Status | PR |
+|---|---|---|
+| Spec chapter (this file) | landed | #284 |
+| `#[no_alloc]` body walker (`E0772`) | landed | #288 |
+| Privilege gate (`E0770`) — annotations + `use std.runtime.*` + RawPtr/Pod type refs | landed | #292 |
+| `#[pod]` shape checker (`E0771`) | landed | #295 |
+| `RawPtr` registered as `types.PRawPtr` + prelude `SymBuiltin` | landed | #312 |
+| `Pod` in prelude as `SymBuiltin` + privilege gate covers generic bound clauses | landed | #314 |
+| Annotation arg validators (`#[repr(c)]`, `#[export("name")]`, no-arg flags) | landed | #316 |
+| `std.runtime.raw` stdlib module + nested-stub-path loader | landed | #319 |
+| Privilege gate body walker (let-types / turbofish / closure params inside fn bodies) | landed | #322 |
+| End-to-end fixture + regression test | landed | #325 |
+| `#[intrinsic]` body must be empty (`E0773`) | landed | #347 |
+
+**IR layer.** Every §19.6 annotation is now representable on
+`ir.FnDecl` / `ir.StructDecl`. No codegen attached yet for most.
+
+| Piece | Status | PR |
+|---|---|---|
+| `ir.FnDecl.ExportSymbol string` from `#[export("name")]` | landed | #329 |
+| `ir.FnDecl.CABI bool` from `#[c_abi]` | landed | #330 |
+| `ir.FnDecl.IsIntrinsic bool` from `#[intrinsic]` | landed | #334 |
+| `ir.FnDecl.NoAlloc bool` from `#[no_alloc]` | landed | #336 |
+| `ir.StructDecl.Pod bool` from `#[pod]` | landed | #336 |
+| `ir.StructDecl.ReprC bool` from `#[repr(c)]` | landed | #336 |
+
+**MIR / LLVM emit.** Both backend paths now honor `#[export]`. The
+MIR pipeline (`GenerateFromMIR`, opt-in via `Options.UseMIR`)
+overrides the emitted `@<name>` directly; the legacy
+`GenerateModule` (default) preserves the original define and
+appends an `alias` line so in-module callers continue to resolve
+while the export symbol is link-reachable.
+
+| Piece | Status | PR |
+|---|---|---|
+| MIR `Function.ExportSymbol` + `define @<symbol>` override | landed (MIR path) | #329 |
+| MIR `Function.CABI` + `define ccc <ret> @<sym>(...)` emission | landed (MIR path) | #330 |
+| MIR `Function.IsIntrinsic` propagation + backend-bail safety net | landed (MIR path) | #334 |
+| Legacy `GenerateModule(IR)` emits `@<symbol> = dso_local alias ptr, ptr @<fn>` per `#[export]`-tagged fn | landed (legacy path) | #341 |
+| Legacy `GenerateModule(IR)` honoring `#[c_abi]` | n/a — LLVM's default cc is `ccc`, so the legacy path is already correct semantically. The MIR path emits the `ccc ` keyword for documentation; if Osty later switches its native cc to a non-`ccc` form the legacy path will need a post-process inject. | — |
+| Per-intrinsic LLVM emit for the 13 §19.5 `raw.*` intrinsics | **deferred** | — |
+| §19.7 lowering table (`raw.null` → `inttoptr i64 0`, etc.) | **deferred** | — |
+| §19.10 safepoint compiler-emitted root array | **deferred** | — |
+
+**Type system / native checker / IR lowering.** Closed.
+
+| Piece | Status | Notes |
+|---|---|---|
+| Native checker types `raw.null()` / `raw.alloc(b, a)` / `raw.bits(p)` correctly | **landed** | The native checker's `chk.Types[CallExpr]` and `chk.LetTypes[LetStmt]` already return `RawPtr` / `Int` for non-generic intrinsics. The IR-side fix (`PrimRawPtr` added to `ir.PrimKind` + `TRawPtr` singleton + missing case arms in `primitiveByKind` / `primitiveByName`) made the native-checker output reach `let.Type` instead of dropping to `ErrTypeVal`. (PR #345 originally misdiagnosed this as a native-checker gap; PR #349 corrected the diagnosis and landed the IR fix.) |
+| Generic intrinsic typing — `raw.read::<T>` / `raw.write::<T>` / `raw.cas::<T>` / `raw.sizeOf::<T>` / `raw.alignOf::<T>` | **landed** | Two fixes in PR `claude/boundary-preserve-generics`: (a) `host_boundary.writeSelfhostPackageImport` now emits `<T: Pod>` via the new `selfhostGenericParams` helper so the native checker sees the stub's generic params; (b) `frontCheckTurbofishCall` (in `toolchain/check.osty` + `internal/selfhost/generated.go`) now tries `frontCheckSigLookup(env, packageName)` on package-qualified turbofish calls before falling through to method lookup, mirroring the non-turbofish dispatch. The cached `osty-native-checker` binary at `<projectRoot>/.osty/toolchain/<version>/` must be deleted so `EnsureNativeChecker` rebuilds. The contract suite at `internal/llvmgen/runtime_intrinsic_typing_test.go` now has 9/9 PASS. |
+
+**Out-of-scope (per §19.1) — never planned.**
+
+- A user-facing `unsafe` block (§14 still excludes it).
+- Stackmap *introspection* intrinsics (the runtime walks the
+  compiler-emitted root array per §19.10, not the stack).
+- Volatile / atomic-fence / inline-assembly primitives. The first
+  GC delivered through this surface is single-threaded STW.

--- a/LANG_SPEC_v0.6/ABRIDGED.md
+++ b/LANG_SPEC_v0.6/ABRIDGED.md
@@ -62,7 +62,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - `Int`는 항상 64-bit signed. machine-word `UInt`는 없다.
 - `String`은 immutable UTF-8 bytes. `Bytes`는 immutable byte sequence.
 - composite: `struct`, `enum`, `interface`, tuple, function type, `List<T>`,
-  `Map<K, V>`, `Set<T>`, `Option<T>`, `Result<T, E>`, **anonymous record**.
+  `Map<K, V>`, `Set<T>`, `Option<T>`, `Result<T, E>`.
 - `Set<T>`는 있지만 set literal은 없다. `Set.from([...])`를 사용한다.
 - `T?`는 `Option<T>` sugar. formatter는 `Option<T>`를 `T?`로 정규화한다.
 - `null`/`nil`은 없다. 부재는 `Option<T>`/`T?`.
@@ -74,13 +74,8 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 - arithmetic overflow, invalid shift, integer div/mod by zero는 abort한다.
   복구 동작은 checked/wrapping/saturating method를 사용한다.
 - value semantics: primitives, `String`, `Bytes`, tuple.
-- reference semantics: `struct`, `enum`, collections, function/closure values,
-  anonymous record.
+- reference semantics: `struct`, `enum`, collections, function/closure values.
 - binding은 기본 immutable. 재할당과 field mutation에는 `mut` binding이 필요하다.
-- **anonymous record (G50)**: `{ x: Int, y: Int }` type, `{ x: 1, y: 2 }` value.
-  structural type — 같은 필드 set = 같은 type. nominal struct 와는 별도 universe.
-  메서드 정의 불가, annotation 불가, self-recursive 금지. `#[sealed_construct]`
-  필요하면 nominal struct.
 
 ## 4. Interfaces and Generics
 
@@ -147,7 +142,7 @@ AI 에이전트가 짧게 읽고 바로 Osty 코드를 생성·수정하기 위�
 
 - pattern 위치: `match`, `let`, `if let`, `for let`, closure parameter 일부.
 - pattern 종류: wildcard, literal, identifier binding, tuple, struct, variant,
-  range, or, `name @ pattern`. anonymous record destructuring 도 같은 syntax.
+  range, or, `name @ pattern`.
 - `let` pattern은 irrefutable destructuring만 사용한다. enum variant는 `let`
   대신 `match` 또는 `if let`.
 - pattern precedence: atomic, range, binding, or.

--- a/LANG_SPEC_v0.6/README.md
+++ b/LANG_SPEC_v0.6/README.md
@@ -1,0 +1,120 @@
+# Osty Language Specification v0.6
+
+Osty is a general-purpose, statically-typed, garbage-collected programming language.
+This directory holds the specification, split into per-section files for easier navigation and editing.
+
+**Status.** v0.6 — current spec baseline. Supersedes v0.5. Closes 14 gaps
+(G36–G49) accumulated during the v0.5 use corpus and the 100-PR
+self-host sprint: capability parameters, information flow tracking,
+spec link, reproducibility, sealed construction, error contract,
+structured intent, executable spec block, API evolution rules, golden
+tests, performance contract, machine-readable context export, plus a
+single ergonomics fix (`while` keyword).
+
+The v0.6 design north star is *Hidden dependency is forbidden* —
+time, randomness, environment, security flow, evolution rules,
+performance contracts, intent, and specification are all surfaced
+explicitly through the type system or the annotation surface.
+
+See [`18-change-history.md`](./18-change-history.md) for the full
+v0.1 → v0.2 → v0.3 → v0.4 → v0.5 → v0.6 evolution and per-version
+gap closure tables.
+
+**Companion documents.**
+
+- [`ABRIDGED.md`](./ABRIDGED.md) — short, example-free quick spec for AI
+  agents generating or editing Osty code.
+- [`00-revision.md`](./00-revision.md) — comprehensive decision log for
+  the v0.5 → v0.6 batch. Cross-references all 15 gaps with diff
+  algorithms, formal IFC inference rules, worked examples, migration
+  notes, and the v0.6 cut readiness checklist. Each chapter file in
+  this directory is the *normative* source; `00-revision.md` is the
+  *one-document overview*.
+- `../OSTY_GRAMMAR_v0.6.md` — formal grammar (R1–R30 + EBNF). The
+  lexer/parser ground truth.
+- `../OSTY_GRAMMAR_v0.5.md` and earlier — historical grammar snapshots.
+- `../SPEC_GAPS.md` — archive of resolved gaps per version.
+- `../CHANGELOG_v0.6.md` — implementation status (what is *shipped*
+  vs what is *spec*).
+
+## `?`-family cheat sheet
+
+Four punctuation operators share the `?` glyph. They look related — three
+of them are — but each has a distinct role. Read this table before §4.
+
+| Form | Role | Operand → Result | Example | Spec |
+|---|---|---|---|---|
+| `expr?` | **Propagate** `Err`/`None` out of the enclosing function | `Result<T,E> → T` or `Option<T> → T` | `let cfg = parse(text)?` | §4.5 |
+| `expr?.m` | **Chain** on `Option`; short-circuit to `None` on the first missing step | `Option<T> → Option<U>` | `user?.address?.city` | §4.6 |
+| `lhs ?? rhs` | **Unwrap-or-default**; right side is lazy | `Option<T>, T → T` | `user?.name ?? "anon"` | §4.6 |
+| `err as? T` | **Downcast** an `Error` to its concrete nominal type (shortcut for `err.downcast::<T>()`) | `Error → T?` | `err as? FsError` | §7.4 |
+
+**Disambiguations (read once, save hours).**
+
+- `?` is legal on both `Result` and `Option`, but the enclosing function
+  must return the matching shape; mixing is a compile error — convert
+  with `Option.orError(msg)` or `Result.ok()`.
+- `?.` stays inside `Option`. It does **not** return from the function.
+  To exit a chain, end with `?` (`user?.address?.city?` in a fn
+  returning `Option<_>`).
+- `??` is `Option`-only. For `Result`, use `.unwrapOr(d)` / `match`.
+- `as?` is **not** a general type test. It works only on `Error`
+  values, using the nominal tag attached at up-cast time (§7.4). For
+  other "is it this variant?" questions, use pattern matching.
+- None of the four introduces null/nil. `?` in a type (`T?`) is sugar
+  for `Option<T>` (§2.5) — a separate surface.
+
+## Table of Contents
+
+- [1. Lexical Structure](./01-lexical-structure.md)
+- [2. Type System](./02-type-system.md)
+- [3. Declarations](./03-declarations.md)
+- [4. Expressions](./04-expressions.md)
+- [5. Modules and Packages](./05-modules-and-packages.md)
+- [6. Scripts](./06-scripts.md)
+- [7. The Error Interface](./07-the-error-interface.md)
+- [8. Concurrency](./08-concurrency.md)
+- [9. Memory Management](./09-memory-management.md)
+- **10. Standard Library** — see [`10-standard-library/`](./10-standard-library/README.md)
+- [11. Testing](./11-testing.md)
+- [12. Foreign Function Interface](./12-foreign-function-interface.md)
+- [13. Tooling](./13-tooling.md)
+- [14. Excluded Features](./14-excluded-features.md)
+- [15. Iteration Protocol](./15-iteration-protocol.md)
+- [16. I/O Protocol](./16-io-protocol.md)
+- [17. Display and Format Protocol](./17-display-and-format-protocol.md)
+- [18. Change History](./18-change-history.md)
+- [19. Runtime Primitives](./19-runtime-primitives.md) — toolchain-only sublanguage; not part of the user prelude
+- [**20. Capabilities**](./20-capabilities.md) — environment effects as values (v0.6 G36)
+- [**21. Information Flow Tracking**](./21-information-flow.md) — static taint / sanitize / sink (v0.6 G37)
+
+## Reading order
+
+The chapters are mostly self-contained, but new readers benefit from this order:
+
+1. **Lexical & types** (§1, §2) — establishes vocabulary.
+2. **Declarations & expressions** (§3, §4) — the everyday surface.
+3. **Modules, scripts, errors** (§5–§7) — program structure.
+4. **Concurrency, memory, capabilities** (§8, §9, §20) — the runtime model.
+5. **Standard library** (§10) — read on demand by package.
+6. **Testing, FFI, tooling** (§11–§13) — workflow concerns.
+7. **Excluded features** (§14) — what is intentionally absent.
+8. **Protocols** (§15–§17) — the interface contracts that bind §10 together.
+9. **Information flow** (§21) — security-flow tracking, capabilities (§20) prerequisite.
+10. **Change history** (§18) — upgrade notes for v0.1 → v0.6 users.
+
+## v0.6 design north star
+
+> **Hidden dependency is forbidden.** Time, randomness, environment,
+> filesystem, network, security flow, API evolution rules, performance
+> contracts, intent, and specification — all surfaced through type
+> signatures or annotations, never implicit.
+
+Four annotation families implement this principle:
+
+| Family | Surface | Chapters |
+|---|---|---|
+| **Effectful** (env / IO) | Capability parameters, `#[ambient]`, `#[reproducible]`, `#[pure]` | §20, §3.11 |
+| **Security** (sources → sinks) | `#[taint]`, `#[sanitizes]`, `#[requires]` | §21 |
+| **Temporal** (versioning) | `#[since]`, `#[stability]`, `#[match_compat]`, `osty publish` | §3.14 |
+| **Intent + Determinism** | `#[spec]`, `#[purpose]`, `#[example]`, `#[fixture]`, `spec { }`, `#[error_contract]`, `#[sealed_construct]`, `#[golden]`, `#[budget]`, `osty context` | §3.10, §3.12, §3.13, §3.15, §3.4.5, §7.5, §11.5, §13.6 |

--- a/OSTY_GRAMMAR_v0.6.md
+++ b/OSTY_GRAMMAR_v0.6.md
@@ -4,7 +4,7 @@ v0.5 의 R1–R26 결정과 EBNF 를 baseline 으로, v0.6 에서 추가/변경�
 만 본 문서에 명시한다. v0.5 grammar 의 본문은
 [`OSTY_GRAMMAR_v0.5.md`](./OSTY_GRAMMAR_v0.5.md) 가 계속 권위.
 
-> **Status**: v0.6 spec revision 동기 (G36–G50). spec 본문은
+> **Status**: v0.6 spec revision 동기 (G36–G49). spec 본문은
 > [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md).
 
 ---
@@ -36,7 +36,7 @@ v0.5 의 R1–R26 결정과 EBNF 를 baseline 으로, v0.6 에서 추가/변경�
 §5 of [`LANG_SPEC_v0.6/00-revision.md`](./LANG_SPEC_v0.6/00-revision.md)
 참조 — 31 개 fixed annotation 으로 확장. `#[name(args)]` 형식 그대로.
 
-### Annotation parameter position (R30)
+### Annotation parameter position (R29)
 
 `ParamDecl` 의 두 위치에 `Annotation*` 신규 허용:
 - Pattern 앞 (caller-facing intent: source 표시)
@@ -84,31 +84,6 @@ WhileStmt      ::= 'while' Expr Block
 ```
 
 `'while'` 은 fully reserved (R27). 식별자 자리에 사용 불가.
-
-### G50 — anonymous structural record
-
-```ebnf
-AnonymousRecordType  ::= '{' RecordTypeField (',' RecordTypeField)* ','? '}'
-RecordTypeField      ::= IDENT ':' Type
-
-AnonymousRecordValue ::= '{' RecordValueField (',' RecordValueField)* ','? '}'
-RecordValueField     ::= IDENT (':' Expr)?       (* shorthand, struct literal 과 같음 *)
-```
-
-R29 의 disambiguation 규칙:
-
-```
-1. Type 위치 (let `: T`, fn return type, fn param type) — 항상 record type
-2. Value 위치, type ascription 있음 — 항상 record value (struct literal 우선
-   적용 안 됨, AnonymousRecordValue 로 파싱)
-3. Value 위치, type ascription 없음 — lookahead:
-   `'{' IDENT ':'` 패턴이면 record value
-   그 외 (e.g., `'{' Stmt`) 는 block expression
-4. 모호 시 `: T` ascription 추가 권장 (E0342 hint)
-```
-
-`AnonymousRecordType` / `AnonymousRecordValue` 의 *필드 안에는 annotation
-허용 안 함* (E0340) — annotation 이 필요하면 nominal struct 사용.
 
 ### G37 — annotation on parameter
 
@@ -281,31 +256,12 @@ expression 평가 안 됨. spec block 본문은 *순수 메타데이터*: `examp
 `'spec'` keyword 는 그 위치에서만 keyword 로 lex. 그 외 위치 (예: 변수
 이름, struct field 이름) 에서는 식별자.
 
-### R29. anonymous record vs block 모호성 (G50)
-
-`{ x: 1, y: 2 }` 가 block expression 인지 anonymous record literal
-인지의 모호성 해소 규칙:
-
-1. **Type 위치**: 항상 `AnonymousRecordType`. e.g. `let r: { x: Int, y:
-   Int } = ...`.
-2. **함수 반환 type 위치**: 항상 `AnonymousRecordType`.
-3. **Value 위치, type ascription 있음**: 항상 `AnonymousRecordValue`.
-   e.g. `let r: { x: Int, y: Int } = { x: 1, y: 2 }`.
-4. **Value 위치, type ascription 없음**: parser 가 *lookahead* — `{`
-   다음 `IDENT ':'` 패턴이면 record value, 그 외는 block.
-5. **모호한 경우** (예: lambda `|| { x: 1 }` 가 block 인지 record 반환
-   인지): block 으로 파싱 — `: Int` 가 statement-level annotation 아님.
-   Record 의도를 강제하려면 type ascription 추가.
-6. **mismatched 위치는 명확한 진단**: type ascription 없이 모호한 자리
-   에서 record value 의도였으면 `E0342` (suggestion: `: T` 추가).
-
-### R30. annotation 위치 확장 (G37)
+### R29. annotation 위치 확장 (G37)
 
 `Annotation*` 가 새로 허용되는 위치:
 
 - Function parameter `Pattern` 앞 (v0.5 까지는 declaration-only)
 - Function parameter `Type` 앞 (동일)
-- Anonymous record field 에는 annotation **불허** (`E0340`)
 - Tuple 요소에는 annotation **불허** (모호성)
 
 기존 declaration 위치 (top-level fn/struct/enum/interface, struct
@@ -341,7 +297,7 @@ R7 에 다음 추가:
 | Reserved keywords | 17 | 18 | **19** | +1 (`while`) |
 | Contextual keywords | 7 | 10 | **14** | +4 (`forall` 은 v1 단계 추가 시 15) |
 | Fixed annotation set | 8 | 11 | **31** | +20 |
-| EBNF productions | 180 | 191 | **203** | +12 |
+| EBNF productions | 180 | 191 | **199** | +8 |
 | Lexer token classes | 34 | 36 | **36** | 0 |
 | Diagnostic bands used | E0001-E0779 + E0405 | 동일 | E0001-E0949 + E2149 + W0949 | +5 bands |
 
@@ -354,8 +310,7 @@ R7 에 다음 추가:
 | R1–R26 | (v0.5 와 동일) | — |
 | R27 | `while` 키워드 | G49 |
 | R28 | spec block 위치 + `spec`/`example`/`law`/`invariant` 컨텍스트 | G43 |
-| R29 | anonymous record vs block 모호성 | G50 |
-| R30 | annotation 위치 확장 (parameter 두 위치) | G37 |
+| R29 | annotation 위치 확장 (parameter 두 위치) | G37 |
 
 ---
 
@@ -363,9 +318,6 @@ R7 에 다음 추가:
 
 | 코드 | 의미 |
 |---|---|
-| `E0340` | Anonymous record field 에 annotation/method 시도 |
-| `E0341` | Anonymous record self-recursive type |
-| `E0342` | Block expression 과 anonymous record literal 모호 |
 | `E0405` | Annotation 이 잘못된 위치 (annotation matrix 기반) |
 | `E0440` | `spec` block 이 함수 본문 첫 위치가 아님 |
 | `E0441` | `spec { example: }` 가 boolean 으로 평가되지 않음 |

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -259,9 +259,8 @@ v0.6.x 에서만 제공 후 v0.7 에서 제거. 자세한 spec 본문은
 | **G47** | Machine-readable context (§13.6) | `osty context <symbol> [--format=json] [--recursive]` — purpose / examples / spec_refs / error_contract / fixtures / stability / since 단일 JSON 으로 추출. LSP `textDocument/hover` 통합. AI agent 첫 시민. | decided |
 | **G48** | Annotation surface 통합 | 신규 어노테이션 14 개 (G36-G47 합계) 가 기존 fixed annotation set 에 추가, `#[name(args)]` form 그대로 — 신규 grammar 0. parameter 위치 annotation (`#[taint]` / `#[requires]`) 은 v0.6 grammar 변경. spec block 만 신규 syntax. 추가 contextual keyword 4 (v0): `spec`, `example`, `law`, `invariant`. | decided |
 | **G49** | `while` keyword (§4.4) | `for cond {}` 외에 `while cond {}` 동의어 추가. v0.5 의 keyword economy taste 는 유지하되 *mental model 일치*를 위해 더 흔한 surface 도 받아들임. `for cond` 도 deprecate 안 함 — 양쪽 모두 컴파일러가 같은 lowering. | decided |
-| **G50** | Anonymous structural record (§2.5) | `{ x: Int, y: Int }` 형식의 type literal + `{ x: 1, y: 2 }` value literal. ad-hoc labeled tuple 케이스 충당. nominal struct 와는 *별도 universe* — 자동 변환 없음. 메서드 정의 불가. 함수 반환 / 인자 / let binding 가능. nominal struct destructuring 과 같은 pattern syntax. | decided |
 
-이 15 개 결정 (G36-G50) 은 [`LANG_SPEC_v0.6/00-revision.md`](LANG_SPEC_v0.6/00-revision.md)
+이 14 개 결정 (G36-G49) 은 [`LANG_SPEC_v0.6/00-revision.md`](LANG_SPEC_v0.6/00-revision.md)
 가 권위. 구현 phase 는 동 문서 §2 참조. 호환성 영향이 있는 항목 — G36 (capability
 migration, breaking in v0.7), G37 (taint sink rollout, breaking for unsanitized
 code), G40 (stdlib sealed types) — 은 `--legacy-globals` 또는 `--legacy-construct`

--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -727,7 +727,7 @@ var headingFamily = map[string]string{
 	"Runtime sublanguage":       "FamilyTypeChecking", // TODO: dedicated FamilyRuntime once generated.go accommodates it
 	"Scaffolding":               "FamilyScaffold",
 
-	// v0.6 — Hidden-Dependency-Surface (G36 – G50)
+	// v0.6 — Hidden-Dependency-Surface (G36 – G49)
 	// Note: stripRangeSuffix removes " (...)" suffix, so map uses stripped form.
 	"v0.6 — Hidden-Dependency-Surface": "FamilyAnnotation",
 	"G36 — Capabilities":               "FamilyTypeChecking",
@@ -737,7 +737,6 @@ var headingFamily = map[string]string{
 
 	// v0.6 — Annotation / declaration extensions
 	"v0.6 — Annotation / declaration extensions": "FamilyAnnotation",
-	"G50 — Anonymous structural record":          "FamilyTypePattern",
 	"G41 — Error contract":                       "FamilyAnnotation",
 	"G40 — Sealed construct":                     "FamilyDeclaration",
 	"G42 — Structured intent":                    "FamilyAnnotation",

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1041,7 +1041,7 @@ const (
 	CodePureViolation = "E0775"
 
 	// =====================================================================
-	// v0.6 — Hidden-Dependency-Surface (G36 – G50)
+	// v0.6 — Hidden-Dependency-Surface (G36 – G49)
 	// =====================================================================
 
 	// G36 — Capabilities (§20)
@@ -1258,38 +1258,6 @@ const (
 	// =====================================================================
 	// v0.6 — Annotation / declaration extensions
 	// =====================================================================
-
-	// G50 — Anonymous structural record (§2.5.4)
-
-	// CodeAnonRecordAnnotation: an attempt was made to attach an
-	// annotation, method, or `pub` modifier to a field of an
-	// `AnonymousRecordType`. Anonymous records are *structural* and
-	// metadata-free; promote to a nominal `struct` for these features.
-	//
-	// Spec: v0.6 §2.5.4.4
-	// Fix: declare a nominal `struct` if the field needs annotations.
-	CodeAnonRecordAnnotation = "E0340"
-
-	// CodeAnonRecordRecursive: an `AnonymousRecordType` references
-	// itself in one of its field types (directly or transitively).
-	// Anonymous records cannot be self-recursive — the resulting type
-	// would be infinite.
-	//
-	// Spec: v0.6 §2.5.4.4
-	// Fix: declare a nominal `struct` and use it by name in the
-	//      recursive position.
-	CodeAnonRecordRecursive = "E0341"
-
-	// CodeAnonRecordAmbiguous: a `{ ... }` literal cannot be
-	// disambiguated between block expression and anonymous record
-	// literal at this position. Most common cause: closure body where
-	// `: T` could parse either as record field type or as a statement-
-	// level annotation.
-	//
-	// Spec: v0.6 §2.5.4.6 / R29
-	// Fix: add a type ascription (`: { x: Int }`) on the value position
-	//      or wrap in `(...)` to force expression context.
-	CodeAnonRecordAmbiguous = "E0342"
 
 	// G41 — Error contract (§7.5)
 

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -174,10 +174,6 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "E0903" { return FamilyTypeChecking }
     if code == "W0901" { return FamilyTypeChecking }
     if code == "W0902" { return FamilyTypeChecking }
-    // G50 — Anonymous structural record (§2.5.4)
-    if code == "E0340" { return FamilyTypePattern }
-    if code == "E0341" { return FamilyTypePattern }
-    if code == "E0342" { return FamilyTypePattern }
     // G41 — Error contract (§7.5)
     if code == "E0410" { return FamilyAnnotation }
     if code == "E0411" { return FamilyAnnotation }


### PR DESCRIPTION
## Summary

PR #1469 후속. v0.5 baseline 의존 framing 제거 → v0.6 가 *self-contained 정본*.

### 1. v0.6 spec 을 full canonical body 로

기존 (PR #1469): `LANG_SPEC_v0.6/00-revision.md` 만 존재 → "v0.5 baseline 위에 delta" framing.

이번 PR: v0.5 의 19 main + 46 stdlib subchapter 전체를 v0.6 으로 복사 + v0.6 변경 inline 통합. v0.6 가 곧 정본 — *"see v0.5 §X"* 없음.

| 변경 | 챕터 |
|---|---|
| §1 lexical | keyword 18 (`while` 추가), contextual `spec`/`example`/`law`/`invariant` 추가 |
| §3 declarations | v0.6 Annotation Extensions 섹션 신규 (§3.4.5 sealed_construct, §3.10 spec, §3.11 reproducible, §3.12 structured intent, §3.13 spec block, §3.14 evolution, §3.15 budget) |
| §4 expressions | §4.4 에 `while` 동의어 명시 |
| §14 excluded-features | C-style for 대안에 `while` 추가 |
| README.md (신규) | design north star, ToC, reading order, 4 annotation families |
| §2, §5–§17, §19, 46 stdlib subchapters | v0.5 본문 그대로 (변경 없음) |

### 2. G50 (anonymous structural record) 제거

- 13 hidden-dependency-surface 결정 외에 본 작성 중 추가됐던 *옵션*
- v0.5 §14 의 nominal-only discipline 유지로 결정

영향:
- `00-revision.md` 의 §2.5.4 / R29 / EBNF 제거
- `OSTY_GRAMMAR_v0.6.md` 의 R29 anonymous record → annotation parameter position 으로 재배치
- `SPEC_GAPS.md` / `CHANGELOG_v0.6.md` / `README.md` / `ABRIDGED.md` 에서 G50 entry 제거
- `internal/diag/codes.go` 에서 E0340-E0342 (anon record diagnostics) 제거
- `cmd/codesdoc/main.go` 의 G50 heading map entry 제거

### 3. v0.6 baseline = 14 결정 (G36-G49)

- 13 hidden-dependency-surface (G36–G48): capabilities, taint, spec link, reproducible, sealed_construct, error_contract, structured intent, spec block, evolution, golden, budget, context, annotation surface
- 1 ergonomics fix (G49 `while`)
- v0.5 의 anonymous record 금지 정책 *유지*

## Files

- 75 files changed, 9015 insertions, 247 deletions
- 신규: `LANG_SPEC_v0.6/{README.md, 01-...19, 02a-...md}` + 46 stdlib subchapters
- 수정: `LANG_SPEC_v0.6/{00-revision.md, ABRIDGED.md}`, `OSTY_GRAMMAR_v0.6.md`, `CHANGELOG_v0.6.md`, `SPEC_GAPS.md`, `ERROR_CODES.md`, `internal/diag/codes.go`, `cmd/codesdoc/main.go`, `toolchain/diag_manifest.osty`

## Test plan

본 PR 은 spec/docs only — 코드 변경 없음.

- [x] `go generate ./internal/diag/...` 통과 (ERROR_CODES.md / diag_manifest.osty / diag_examples.osty regenerate)
- [x] `go build ./internal/diag/... ./cmd/codesdoc/...` 통과
- [x] G50 흔적 0 — 모든 v0.6 문서 + 코드 / catalog
- [x] §14 excluded features 의 anonymous record 금지 복원
- [x] 14 결정 (G36-G49) 일관성 — SPEC_GAPS / 00-revision / ABRIDGED / README / OSTY_GRAMMAR / CHANGELOG 에서 동일 표기
- [ ] 후속 PR 에서 §20 capabilities + §21 information flow 별도 챕터 분리, §18 change-history 갱신

## 후속

- §20-21 챕터 분리 + §18 v0.5→v0.6 entry 추가 (다음 PR)
- 정식 챕터 본문에서 v0.6 변경을 풀어 쓰기 (현재는 §3 끝에 "v0.6 Annotation Extensions" 로 묶어 둠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_