### PR TITLE
[codex] LIR Proto B1 map_new ABI

### DIFF
--- a/LLVM_BACKEND_GAP_PLAN.md
+++ b/LLVM_BACKEND_GAP_PLAN.md
@@ -5,6 +5,8 @@
 > **상태**: 2026-05-07 audit. 현재 실패 테스트 9건 + 빌드 실패 6건 (Security framework link). `LLVM_MIGRATION_PLAN.md`의 Tier A 항목 (Map.update / optional aggregate / generic turbofish / interface dispatch / nested binding pattern) 이 모두 같은 root에 매달려 있음을 발견.
 >
 > **Phase A 진행**: module-context type lowering 폴스루는 명시적 `unsupported module type` 진단으로 바뀌었고, MIR `uses/imports`는 resolved trace-only metadata로 낮아져 더 이상 LIR Proto 모듈 전체를 decline시키지 않는다.
+>
+> **Phase B 진행**: B1의 첫 조각으로 `MirIntrinsicMapNew`가 destination `Map<K, V>` 타입에서 key/value ABI kind와 `value_size`를 계산해 `osty_rt_map_new(i64, i64, i64, ptr)`를 호출하도록 복구했다. 로컬 실행 회귀는 `osty-self` 캐시 부재로 아직 end-to-end binary까지는 닫지 못했고, LIR Proto 패리티 fixture가 ABI shape를 고정한다.
 
 ## 1. 새 architecture 요약
 
@@ -138,6 +140,7 @@ Go MIR emitter 미러는 PR #1405에서 제거됐다 (`internal/llvmgen` 112K LO
 
 **B1 — `Map<String, Int>` 기본 insert/len/containsKey 회귀 회복** (GAP-RECV-001..004)
 - 가설: receiver type string parsing이 정확히 어디서 실패하는지 진단 후 fix.
+- 진행: `map_new`은 receiver arg가 없는 MIR shape이므로 receiver parser가 아니라 destination `Map<String, Int>` 타입에서 ABI tuple `(key=string, value=i64, size=8, trace=null)`을 합성해야 했다. LIR Proto가 4-arg runtime constructor를 내도록 고정.
 - 회귀 대상: `TestLLVMBackendBinaryRunsMapLiteralInMain` (4초 test).
 - 의존성: A1 권장 (진단 가시화).
 

--- a/toolchain/lir_proto.osty
+++ b/toolchain/lir_proto.osty
@@ -2486,7 +2486,7 @@ fn lirLowerMirIntrinsic(l: LirMirFunctionLowerer, instr: MirInstr) {
         MirIntrinsicCheckCancelled -> lirLowerMirCheckCancelled(l, instr),
         MirIntrinsicListSorted -> lirLowerMirListSorted(l, instr),
         MirIntrinsicListInsert -> lirLowerMirListInsert(l, instr),
-        MirIntrinsicMapNew -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeNewSymbol(), lirPtrType(), [], "map.new"),
+        MirIntrinsicMapNew -> lirLowerMirMapNew(l, instr),
         MirIntrinsicMapLen -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeLenSymbol(), lirIntType(64), [lirPtrType()], "map.len"),
         MirIntrinsicMapKeys -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeKeysSymbol(), lirPtrType(), [lirPtrType()], "map.keys"),
         MirIntrinsicMapValues -> lirLowerMirStringRuntimeCall(l, instr, llvmMapRuntimeValuesSymbol(), lirPtrType(), [lirPtrType()], "map.values"),
@@ -3484,6 +3484,64 @@ fn lirLowerMirListIsEmpty(l: LirMirFunctionLowerer, instr: MirInstr) {
     }
 }
 // ----- Map intrinsic lowerings (typed key lane) -----
+fn lirLowerMirMapNew(l: LirMirFunctionLowerer, instr: MirInstr) {
+    if instr.args.len() != 0 {
+        lirLowerError(l, LirDiagInvalidInput, "map.new expects no arguments", "map.new")
+        return
+    }
+    if !(instr.hasDest) {
+        lirLowerError(l, LirDiagInvalidInput, "map.new requires a destination", "map.new")
+        return
+    }
+    if mirPlaceHasProjections(instr.dest) {
+        lirLowerError(l, LirDiagUnsupported, "map.new requires a non-projected destination", "map.new")
+        return
+    }
+    let loc = mirFunctionLocal(l.fn_, instr.dest.local)
+    if loc.id < 0 {
+        lirLowerError(l, LirDiagInvalidInput, "map.new destination local out of range", "map.new")
+        return
+    }
+    let keyName = lirMapKeyTypeName(loc.typ)
+    let valueName = lirMapValueTypeName(loc.typ)
+    if keyName == "" || valueName == "" {
+        lirLowerError(l, LirDiagUnsupported, "map.new destination type `" + loc.typ + "` is not Map<K, V>", "map.new")
+        return
+    }
+    let keyLir = lirContainerElemLaneType(keyName)
+    if lirTypeIsZero(keyLir) || lirTypeIsVoid(keyLir) {
+        lirLowerError(l, LirDiagUnsupported, "map.new key type `" + keyName + "` has no runtime ABI lane", "map.new")
+        return
+    }
+    let keyKind = llvmContainerAbiKind(keyLir.llvm, lirContainerElemIsString(keyName))
+    if keyKind == 6 {
+        lirLowerError(l, LirDiagUnsupported, "map.new key type `" + keyName + "` is not a supported runtime key", "map.new")
+        return
+    }
+    let valueLir = lirContainerElemLaneType(valueName)
+    let mut valueKind = 6
+    let mut valueSize = ""
+    if !(lirTypeIsZero(valueLir)) && !(lirTypeIsVoid(valueLir)) {
+        valueKind = llvmContainerAbiKind(valueLir.llvm, lirContainerElemIsString(valueName))
+        let fixedSize = mirMapValueSizeBytes(valueLir.llvm)
+        if fixedSize > 0 {
+            valueSize = lirIntToString(fixedSize)
+        }
+    }
+    if valueSize == "" {
+        let loweredValue = lirLowerMirType(l, valueName)
+        if lirTypeIsZero(loweredValue) || lirTypeIsVoid(loweredValue) {
+            lirLowerError(l, LirDiagUnsupported, "map.new value type `" + valueName + "` has no MIR layout", "map.new")
+            return
+        }
+        valueSize = lirEmitSizeOf(l, loweredValue)
+    }
+    let symbol = llvmMapRuntimeNewSymbol()
+    lirRuntimeDeclsDeclare(l.out.runtimeDecls, lirRuntimeDecl(symbol, lirPtrType(), [lirIntType(64), lirIntType(64), lirIntType(64), lirPtrType()], false))
+    let dest = lirFresh(l)
+    l.instrs.push(lirCall(dest, lirPtrType(), "@" + symbol, [lirOperand(lirIntType(64), lirIntToString(keyKind)), lirOperand(lirIntType(64), lirIntToString(valueKind)), lirOperand(lirIntType(64), valueSize), lirOperand(lirPtrType(), "null")]))
+    lirStoreMirResult(l, instr.dest, lirOperand(lirPtrType(), dest), loc.typ, "map.new result")
+}
 // Map.set always passes the value by spilled-slot pointer regardless
 // of value type. Production declares
 // `osty_rt_map_insert_<keysuf>(ptr, <keyLLVM>, ptr) -> void` so the

--- a/toolchain/lir_proto_parity.osty
+++ b/toolchain/lir_proto_parity.osty
@@ -1245,7 +1245,7 @@ pub fn lirParityManualListClearFixture() -> LirParityFixture {
     lirParityFixture("list_clear", LirParityManualMIR, "/tmp/lir_proto_parity_list_clear.osty", "", "phase4b-list", ["list", "runtime"], [lirParityNeedle("declare void @osty_rt_list_clear(ptr)", "clear runtime"), lirParityNeedle("call void @osty_rt_list_clear(", "clear call site")])
 }
 pub fn lirParityManualMapNewFixture() -> LirParityFixture {
-    lirParityFixture("map_new", LirParityManualMIR, "/tmp/lir_proto_parity_map_new.osty", "", "phase4b-map", ["map", "runtime"], [lirParityNeedle("declare ptr @osty_rt_map_new()", "map new runtime"), lirParityNeedle("call ptr @osty_rt_map_new()", "map new call")])
+    lirParityFixture("map_new", LirParityManualMIR, "/tmp/lir_proto_parity_map_new.osty", "", "phase4b-map", ["map", "runtime"], [lirParityNeedle("declare ptr @osty_rt_map_new(i64, i64, i64, ptr)", "map new runtime"), lirParityNeedle("call ptr @osty_rt_map_new(i64 5, i64 1, i64 8, ptr null)", "map new call")])
 }
 pub fn lirParityManualMapInsertStringIntFixture() -> LirParityFixture {
     lirParityFixture("map_insert_string_int", LirParityManualMIR, "/tmp/lir_proto_parity_map_insert_string_int.osty", "", "phase4b-map", ["map", "runtime", "key-string"], [lirParityNeedle("declare void @osty_rt_map_insert_string(ptr, ptr, ptr)", "string-key insert runtime (value-by-spilled-slot)"), lirParityNeedle("alloca i64", "value spill slot"), lirParityNeedle("call void @osty_rt_map_insert_string(", "insert call site")])


### PR DESCRIPTION
## Summary
- lower `MirIntrinsicMapNew` through a dedicated LIR Proto path that reads destination `Map<K, V>` type parameters
- emit `osty_rt_map_new(i64 key_kind, i64 value_kind, i64 value_size, ptr trace)` instead of the stale zero-arg call
- update the manual LIR Proto parity fixture and gap plan note for Phase B/B1

## Validation
- `.bin/osty check toolchain/lir_proto.osty toolchain/lir_proto_parity.osty`
- `go test -count=1 -vet=off -run 'SnapshotParity|CoreSnapshotParity' ./internal/ci ./internal/runner`\n- `go test -count=1 -vet=off ./cmd/osty-native-lirproto ./cmd/osty-native-llvmgen ./internal/toolchain`\n- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsMapLiteralInMain' -v` currently blocked by missing `osty-self` cache\n- `OSTY_STAGE0_FALLBACK=1 go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendBinaryRunsMapLiteralInMain' -v` still declines because stage0 does not support zero-arg `map_new` MIR\n- `just front` currently fails for the same missing `osty-self` cache during example tests, after build/snapshot/ci steps pass\n