### PR TITLE
[codex] add v0.6 capability stdlib protocols and example

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -30,8 +30,8 @@ rationale.
 
 ## Shipped in the compiler
 
-> 본 섹션은 PR 머지 시점에 갱신. 현재 v0.6 cut 직후 / Phase 0
-> 진행 중 — 구체 항목 비어 있음.
+> 본 섹션은 PR 머지 시점에 갱신. v0.6 spec 전체가 landed 라는 뜻이
+> 아니라, 현재 컴파일러/stdlib이 실제로 받아들이는 조각만 적는다.
 
 ### Syntax
 
@@ -45,7 +45,7 @@ rationale.
 
 | Item | Status | Notes |
 |---|---|---|
-| `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface | **planned** | stdlib 측 7 capability 정의 |
+| `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface | **partial** | `std.capability` 에 7 canonical protocol surface 추가. `std.random.Rng.next/nextBytes` alias와 `examples/v06_capabilities` front-end proof 포함. |
 | `#[ambient(...)]` annotation | **planned** | script / main / test entry 에서만 |
 | `#[reproducible_capability]` annotation | **planned** | 사용자 정의 deterministic capability |
 | `--legacy-globals` 호환 모드 | **planned** | v0.6.x 에서만, v0.7 제거 |

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -60,3 +60,7 @@ lowering remains implementation backlog.
 - [§10.43 Supabase (`std.supabase`)](./43-supabase.md)
 - [§10.44 GitHub (`std.github`)](./44-github.md)
 - [§10.45 Webhooks (`std.webhook`)](./45-webhook.md)
+
+Capability protocols (`std.capability`) are specified in
+[§20 Capabilities](../20-capabilities.md) because they govern effect
+typing and ambient injection as well as stdlib shape.

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -68,6 +68,12 @@ pub interface Process {
 이 7 개 interface (`Clock`, `Rng`, `Env`, `Fs`, `Net`, `Process`, `Console`) 가 v0.6
 의 **canonical capability set**. 사용자 정의 capability 는 §20.5 참조.
 
+**Implementation note.** 현재 stdlib 는 이 canonical protocol set 을
+`std.capability` 에 compile-checked interface surface 로 노출한다. 기존
+`std.time`, `std.random`, `std.env`, `std.fs`, `std.net`, `std.process`, `std.io`
+전역 함수는 v0.6.x compatibility surface 로 유지되며, ambient desugar /
+`--legacy-globals` warning 은 별도 compiler phase 에서 닫는다.
+
 함수는 capability 를 **명시적 파라미터**로 받는다:
 
 ```osty
@@ -304,4 +310,3 @@ f(systemClock, defaultRng)         // OK
 | `E0785` | `#[pure]` 함수가 capability 수신 |
 
 ---
-

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -26,7 +26,7 @@ Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭
 - **⭐⭐ Spec-stub**: spec 있고 declaration-only인데 **백엔드 미구현** (호출 시 LLVM emit 실패 위험)
 - **⭐ Broken / Placeholder**: 본문이 무동작이거나 spec 위반
 
-## 2. 모듈 매트릭스 (98 + 8 sub = 106 파일)
+## 2. 모듈 매트릭스 (99 + 8 sub = 107 파일)
 
 표 항목:
 - **spec**: LANG_SPEC v0.5 챕터 (없으면 `—`)
@@ -219,6 +219,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 
 | 모듈 | spec | LOC | 비고 |
 |---|---|---|---|
+| capability | §20 | 102 | v0.6 canonical `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface surface. `examples/v06_capabilities` front-end/type-check proof. Ambient/legacy-global compiler semantics remain Phase 1 follow-up. |
 | cmp | §10.1 | 27 | Equal / Ordered / Hashable interface 정의. 컴파일러 인지 |
 | error | §10.1 / §7 | 96 | Error interface + BasicError + WrappedError + wrap/chain/rootCause |
 | ref | §10.1 | 9 | `same<T>(a, b)` 단일 함수, declaration-only — 컴파일러 intrinsic 가정 |
@@ -236,7 +237,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 | ⭐⭐⭐ Surface-rich | 62 | 58% |
 | ⭐⭐ Spec-stub (백엔드 부재) | 0 | 0% |
 | ⭐ Broken / Placeholder | 0 | 0% |
-| 코어 인터페이스 (별도) | 7 | 7% |
+| 코어 인터페이스 (별도) | 8 | 7% |
 
 **이전 매트릭스 주장**: 92/98 = 94% Production
 **2026-05-01 재평가 주장**: 22/106 = 21% Production

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,8 @@ the compiler evolves.
 - `url-health`: concurrent URL health checker — enum with methods,
   `Result`/`?` propagation, range patterns, `taskGroup`, `Map.update`,
   and property-based testing.
+- `v06_capabilities`: v0.6-style explicit `Clock` / `Rng` capability
+  parameters with deterministic fakes and stdlib protocol helpers.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `gui-webview2-inspector`: Windows WebView2 GUI example using

--- a/examples/v06_capabilities/lib.osty
+++ b/examples/v06_capabilities/lib.osty
@@ -1,0 +1,71 @@
+use std.bytes
+use std.capability as cap
+use std.time
+pub struct FixedClock {
+    pub current: time.Instant,
+    pub elapsed: time.Duration,
+    pub fn now(self) -> time.Instant {
+        self.current
+    }
+    pub fn monotonic(self) -> time.Duration {
+        self.elapsed
+    }
+    pub fn sleep(self, duration: time.Duration) -> Result<(), Error> {
+        let _ = duration
+        Ok(())
+    }
+}
+pub struct FixedRng {
+    pub seed: Int,
+    pub fn next(self) -> Int {
+        self.seed
+    }
+    pub fn nextBytes(self, n: Int) -> Bytes {
+        self.bytes(n)
+    }
+    pub fn int(self, min: Int, max: Int) -> Int {
+        if max <= min {
+            return min
+        }
+        min + positiveModulo(self.seed, max - min)
+    }
+    pub fn intInclusive(self, min: Int, max: Int) -> Int {
+        if max <= min {
+            return min
+        }
+        min + positiveModulo(self.seed, max - min + 1)
+    }
+    pub fn float(self) -> Float {
+        0.5
+    }
+    pub fn bool(self) -> Bool {
+        positiveModulo(self.seed, 2) == 1
+    }
+    pub fn bytes(self, n: Int) -> Bytes {
+        if n <= 0 {
+            return bytes.fromString("")
+        }
+        bytes.fromString("seed")
+    }
+}
+fn positiveModulo(value: Int, by: Int) -> Int {
+    let raw = value % by
+    if raw < 0 {
+        raw + by
+    } else {
+        raw
+    }
+}
+pub fn requestId(clock: cap.Clock, rng: cap.Rng) -> String {
+    let millis = clock.now().unixNanos / 1000000
+    let suffix = rng.int(1000, 9999)
+    "{millis}-{suffix}"
+}
+pub fn measuredLabel(clock: cap.Clock, label: String) -> String {
+    let elapsed = clock.monotonic().millis()
+    "{label}:{elapsed}ms"
+}
+pub fn defaultCapabilitySummary() -> String {
+    let names = cap.canonicalNames()
+    "{names.len()} capability protocols; default ambient={cap.defaultAmbientNames().len()}"
+}

--- a/examples/v06_capabilities/lib_test.osty
+++ b/examples/v06_capabilities/lib_test.osty
@@ -1,0 +1,25 @@
+use std.testing
+use std.time
+fn instant(nanos: Int64) -> time.Instant {
+    time.Instant
+    {unixNanos: nanos}
+}
+fn duration(nanos: Int64) -> time.Duration {
+    time.Duration
+    {nanoseconds: nanos}
+}
+fn fakeClock() -> FixedClock {
+    FixedClock {current: instant(123000000), elapsed: duration(250000000)}
+}
+fn fakeRng() -> FixedRng {
+    FixedRng {seed: 41}
+}
+fn testRequestIdUsesInjectedCapabilities() {
+    testing.assertEq(requestId(fakeClock(), fakeRng()), "123-1041")
+}
+fn testMeasuredLabelUsesClockCapability() {
+    testing.assertEq(measuredLabel(fakeClock(), "db"), "db:250ms")
+}
+fn testCapabilitySummaryTracksCanonicalSet() {
+    testing.assertEq(defaultCapabilitySummary(), "7 capability protocols; default ambient=4")
+}

--- a/examples/v06_capabilities/osty.toml
+++ b/examples/v06_capabilities/osty.toml
@@ -1,0 +1,9 @@
+[package]
+name = "v06-capabilities"
+version = "0.1.0"
+edition = "0.5"
+description = "v0.6 explicit capability migration example."
+license = "MIT"
+keywords = ["v0.6", "capabilities", "stdlib"]
+
+[dependencies]

--- a/internal/stdlib/capability_test.go
+++ b/internal/stdlib/capability_test.go
@@ -1,0 +1,71 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCapabilityModuleExposesV06Protocols(t *testing.T) {
+	reg := LoadCached()
+	mod := reg.Modules["capability"]
+	if mod == nil {
+		t.Fatal("stdlib capability module missing")
+	}
+	src := string(mod.Source)
+	for _, want := range []string{
+		"pub interface Clock",
+		"pub interface Rng",
+		"pub interface Env",
+		"pub interface Fs",
+		"pub interface Net",
+		"pub interface Process",
+		"pub interface Console",
+		"pub fn canonicalNames() -> List<String>",
+		"pub fn defaultAmbientNames() -> List<String>",
+		"pub fn legacyGlobalModules() -> List<String>",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("capability module source missing %q", want)
+		}
+	}
+
+	for _, tc := range []struct {
+		typeName string
+		methods  []string
+	}{
+		{"Clock", []string{"now", "monotonic", "sleep"}},
+		{"Rng", []string{"next", "nextBytes", "int", "intInclusive", "float", "bool", "bytes"}},
+		{"Env", []string{"args", "get", "require", "set", "unset", "vars", "currentDir", "setCurrentDir"}},
+		{"Fs", []string{"read", "readToString", "write", "writeString", "exists", "walk", "glob", "create", "remove", "rename", "copy", "mkdir", "mkdirAll"}},
+		{"Net", []string{"resolve", "resolveAll", "lookup", "lookupAddr", "connect", "connectTimeout", "listen"}},
+		{"Process", []string{"pid", "hostname", "command", "commandArgs", "shell", "run", "exec"}},
+		{"Console", []string{"print", "println", "eprint", "eprintln", "readLine", "writer"}},
+	} {
+		for _, method := range tc.methods {
+			if got := reg.LookupMethodDecl("capability", tc.typeName, method); got == nil {
+				t.Fatalf("LookupMethodDecl(capability, %s, %s) = nil", tc.typeName, method)
+			}
+		}
+	}
+}
+
+func TestCapabilityModuleHelperNamesAreBodied(t *testing.T) {
+	reg := LoadCached()
+	for _, name := range []string{
+		"canonicalNames",
+		"isCanonical",
+		"defaultAmbientNames",
+		"mainAmbientNames",
+		"testAmbientNames",
+		"filesystemEffectFns",
+		"legacyGlobalModules",
+	} {
+		fn := reg.LookupFnDecl("capability", name)
+		if fn == nil {
+			t.Fatalf("LookupFnDecl(capability, %s) = nil", name)
+		}
+		if fn.Body == nil {
+			t.Fatalf("capability.%s body = nil, want Osty helper body", name)
+		}
+	}
+}

--- a/internal/stdlib/modules/capability.osty
+++ b/internal/stdlib/modules/capability.osty
@@ -1,0 +1,102 @@
+// std.capability - v0.6 explicit environment capability protocols.
+//
+// These interfaces are the compile-checked stdlib surface for LANG_SPEC
+// v0.6 §20. They let library APIs state their hidden environment
+// dependencies as ordinary parameters while the compiler-side ambient and
+// reproducibility rules continue to land in later phases.
+use std.io
+use std.net
+use std.os
+use std.process as proc
+use std.time
+pub interface Clock {
+    fn now(self) -> time.Instant
+    fn monotonic(self) -> time.Duration
+    fn sleep(self, duration: time.Duration) -> Result<(), Error>
+}
+pub interface Rng {
+    fn next(self) -> Int
+    fn nextBytes(self, n: Int) -> Bytes
+    fn int(self, min: Int, max: Int) -> Int
+    fn intInclusive(self, min: Int, max: Int) -> Int
+    fn float(self) -> Float
+    fn bool(self) -> Bool
+    fn bytes(self, n: Int) -> Bytes
+}
+pub interface Env {
+    fn args(self) -> List<String>
+    fn get(self, name: String) -> String?
+    fn require(self, name: String) -> Result<String, Error>
+    fn set(self, name: String, value: String) -> Result<(), Error>
+    fn unset(self, name: String) -> Result<(), Error>
+    fn vars(self) -> Map<String, String>
+    fn currentDir(self) -> Result<String, Error>
+    fn setCurrentDir(self, path: String) -> Result<(), Error>
+}
+pub interface Fs {
+    fn read(self, path: String) -> Result<Bytes, Error>
+    fn readToString(self, path: String) -> Result<String, Error>
+    fn write(self, path: String, contents: Bytes) -> Result<(), Error>
+    fn writeString(self, path: String, contents: String) -> Result<(), Error>
+    fn exists(self, path: String) -> Bool
+    fn walk(self, root: String) -> Result<List<String>, Error>
+    fn glob(self, pattern: String) -> Result<List<String>, Error>
+    fn create(self, path: String) -> Result<(), Error>
+    fn remove(self, path: String) -> Result<(), Error>
+    fn rename(self, from: String, to: String) -> Result<(), Error>
+    fn copy(self, from: String, to: String) -> Result<(), Error>
+    fn mkdir(self, path: String) -> Result<(), Error>
+    fn mkdirAll(self, path: String) -> Result<(), Error>
+}
+pub interface Net {
+    fn resolve(self, addr: String) -> Result<net.Addr, Error>
+    fn resolveAll(self, host: String) -> Result<List<net.Addr>, Error>
+    fn lookup(self, host: String) -> Result<List<net.IpAddr>, Error>
+    fn lookupAddr(self, ip: net.IpAddr) -> Result<List<String>, Error>
+    fn connect(self, addr: String) -> Result<net.TcpConn, Error>
+    fn connectTimeout(self, addr: String, timeoutMs: Int) -> Result<net.TcpConn, Error>
+    fn listen(self, addr: String) -> Result<net.TcpListener, Error>
+}
+pub interface Process {
+    fn pid(self) -> Int
+    fn hostname(self) -> Result<String, Error>
+    fn command(self, program: String) -> proc.ProcessCommand
+    fn commandArgs(self, program: String, args: List<String>) -> proc.ProcessCommand
+    fn shell(self, line: String) -> proc.ProcessCommand
+    fn run(self, command: proc.ProcessCommand) -> Result<proc.ProcessOutput, Error>
+    fn exec(self, command: String, args: List<String>) -> Result<os.Output, Error>
+}
+pub interface Console {
+    fn print(self, text: String)
+    fn println(self, text: String)
+    fn eprint(self, text: String)
+    fn eprintln(self, text: String)
+    fn readLine(self) -> String
+    fn writer(self) -> io.Writer
+}
+pub fn canonicalNames() -> List<String> {
+    ["Clock", "Rng", "Env", "Fs", "Net", "Process", "Console"]
+}
+pub fn isCanonical(name: String) -> Bool {
+    for candidate in canonicalNames() {
+        if candidate == name {
+            return true
+        }
+    }
+    false
+}
+pub fn defaultAmbientNames() -> List<String> {
+    ["clock", "rng", "env", "fs"]
+}
+pub fn mainAmbientNames() -> List<String> {
+    ["clock", "rng", "env", "fs", "net", "process", "console"]
+}
+pub fn testAmbientNames() -> List<String> {
+    ["clock", "rng", "env", "fs", "console"]
+}
+pub fn filesystemEffectFns() -> List<String> {
+    ["read", "readToString", "write", "writeString", "exists", "walk", "glob", "create", "remove", "rename", "copy", "mkdir", "mkdirAll"]
+}
+pub fn legacyGlobalModules() -> List<String> {
+    ["time", "random", "env", "fs", "net", "process", "io", "os"]
+}

--- a/internal/stdlib/modules/random.osty
+++ b/internal/stdlib/modules/random.osty
@@ -1,16 +1,21 @@
 // std.random — non-cryptographic pseudorandom numbers (spec §10.14).
 //
-// Constructors and primitive methods are runtime-backed. `choice` and
-// `shuffle` stay as canonical derived helpers over that primitive
-// surface, so their edge-case behavior is visible in the stdlib source.
-
+// Constructors and primitive methods are runtime-backed. `next` /
+// `nextBytes` are v0.6 capability aliases over the existing primitive
+// surface. `choice` and `shuffle` stay as canonical derived helpers so
+// their edge-case behavior is visible in the stdlib source.
 pub struct Rng {
+    pub fn next(self) -> Int {
+        self.int(0, 2147483647)
+    }
+    pub fn nextBytes(self, n: Int) -> Bytes {
+        self.bytes(n)
+    }
     pub fn int(self, min: Int, max: Int) -> Int
     pub fn intInclusive(self, min: Int, max: Int) -> Int
     pub fn float(self) -> Float
     pub fn bool(self) -> Bool
     pub fn bytes(self, n: Int) -> Bytes
-
     pub fn choice<T>(self, items: List<T>) -> T? {
         if items.isEmpty() {
             None
@@ -18,10 +23,6 @@ pub struct Rng {
             Some(items[self.int(0, items.len())])
         }
     }
-
-    /// Shuffle `items` in place with Fisher-Yates. Empty and single-item
-    /// lists are left unchanged; every other permutation is produced by
-    /// the receiver's own random stream.
     pub fn shuffle<T>(self, items: List<T>) {
         let mut i = items.len()
         for i > 1 {
@@ -35,7 +36,5 @@ pub struct Rng {
         }
     }
 }
-
 pub fn default() -> Rng
-
 pub fn seeded(seed: Int64) -> Rng

--- a/internal/stdlib/random_test.go
+++ b/internal/stdlib/random_test.go
@@ -12,7 +12,7 @@ func TestRandomModuleDerivedHelpersAreBodied(t *testing.T) {
 		t.Fatal("stdlib random module missing")
 	}
 
-	for _, name := range []string{"choice", "shuffle"} {
+	for _, name := range []string{"next", "nextBytes", "choice", "shuffle"} {
 		fn := reg.LookupMethodDecl("random", "Rng", name)
 		if fn == nil {
 			t.Fatalf("LookupMethodDecl(random, Rng, %s) = nil, want stdlib helper", name)


### PR DESCRIPTION
## Summary
- add `std.capability` protocol interfaces for v0.6 canonical capability shapes
- add `std.random.Rng.next` / `nextBytes` compatibility aliases
- add a v0.6 capabilities example and update stdlib docs, matrix, and changelog

## Validation
- `go test -count=1 -vet=off ./internal/stdlib`
- `just support-stdlib-fast`
- `.bin/osty check examples/v06_capabilities`
- `go test -count=1 -vet=off ./internal/speccorpus ./internal/resolve ./internal/check ./internal/format`
- `osty fmt --check` on changed Osty files
- `git diff --check`