### PR TITLE
feat(annotations): register v0.6 G36-G46 annotation surface (Phase 1.5)

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -234,6 +234,71 @@ var annotationRules = map[string]AnnotationTarget{
 	// annotation; a checker-level enforcement pass is tracked under
 	// SPEC_GAPS `pure-enforce`. §3.8.12.
 	"pure": TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G36 — Capabilities (LANG_SPEC_v0.6/20-capabilities.md).
+	// `#[ambient(name1, ...)]` injects prelude default capability
+	// instances at the function body's first statement position.
+	// Restricted to entry-point functions (script `main`, `#[test]`,
+	// `#[bench]` etc.). Library functions must receive capabilities
+	// as explicit parameters — `E0780` when applied elsewhere.
+	"ambient": TargetTopLevelDecl,
+	// `#[reproducible_capability]` marks an interface as carrying only
+	// `#[reproducible]` methods, so user-defined deterministic
+	// capabilities can pass `#[reproducible]` checks. v0.6 §20.5.
+	"reproducible_capability": TargetTopLevelDecl,
+
+	// v0.6 G37 — Information flow (LANG_SPEC_v0.6/21-information-flow.md).
+	// Source / sanitizer / sink annotations form a 1-bit + N-tag flow
+	// tracking surface. Targets are widened across function declaration,
+	// parameter, struct field (per `#[taint]`), and method positions to
+	// match the rule table in 00-revision.md §7.6.
+	"taint":              TargetTopLevelDecl | TargetMethod | TargetStructField,
+	"sanitizes":          TargetTopLevelDecl | TargetMethod,
+	// `#[requires("tag")]` on parameters (G37 sink) reuses the v0.5
+	// `requires` annotation name; the parameter-position grammar is a
+	// separate G37 R29 surface added in v0.6 and tracked by the parser
+	// rather than the annotation target table. The existing v0.5
+	// `"requires": TargetMethod` entry above (around line 116) covers
+	// the stdlib trait-bound use; parameter annotations bypass that
+	// table since they live at a different syntactic position.
+	"trusted_declassify": TargetTopLevelDecl | TargetMethod,
+	"taint_field":        TargetStructField,
+
+	// v0.6 G38 — Spec link (LANG_SPEC_v0.6/03-declarations.md §3.10).
+	// `#[spec("§X.Y")]` registers a checked link into the spec corpus.
+	"spec": TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G39 — Reproducibility (§3.11). `#[reproducible(scope=...)]`
+	// asserts environment-independence; checker enforces in Phase 3.
+	"reproducible": TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G40 — Sealed construction (§3.4.5).
+	"sealed_construct":   TargetTopLevelDecl,
+	"trusted_construct":  TargetTopLevelDecl | TargetMethod,
+	"test_construct":     TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G41 — Error contract (§7.5). Catalogues failure modes.
+	"error_contract": TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G42 — Structured intent (§3.12). Machine-readable purpose,
+	// example (auto-checked), fixture (canonical instance).
+	"purpose": TargetTopLevelDecl | TargetMethod,
+	"example": TargetTopLevelDecl | TargetMethod,
+	"fixture": TargetTopLevelDecl,
+
+	// v0.6 G44 — API evolution (§3.14).
+	"since":        TargetTopLevelDecl | TargetMethod | TargetStructField | TargetVariant,
+	"stability":    TargetTopLevelDecl | TargetMethod,
+	"match_compat": TargetTopLevelDecl | TargetMethod,
+
+	// v0.6 G45 — Golden tests (§11.5.2). AST/text/json/diag-aware
+	// snapshot. Implicitly requires `#[reproducible(scope="target")]`.
+	"golden": TargetTopLevelDecl,
+
+	// v0.6 G46 — Performance contract (§3.15). Static keys (allocs,
+	// io_calls, stack_depth, instructions) and runtime keys (time_ms,
+	// p99_ms) coexist on one annotation.
+	"budget": TargetTopLevelDecl | TargetMethod,
 }
 
 // IsAllowedAnnotation reports whether an annotation name is part of the

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2649,6 +2649,41 @@ fn srAnnotAllowedTargets(name: String) -> Int {
     if name == "pure" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
     if name == "target_feature" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
     if name == "noalias" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G36 — Capabilities (LANG_SPEC_v0.6/20-capabilities.md).
+    if name == "ambient" { return srAnnotTargetTopLevel() }
+    if name == "reproducible_capability" { return srAnnotTargetTopLevel() }
+    // v0.6 G37 — Information flow (LANG_SPEC_v0.6/21-information-flow.md).
+    // Note: `#[requires]` on parameters (sink trust tag) reuses the v0.5
+    // annotation name — see the existing entry above. Phase 5 will add
+    // parameter-position parsing (G37 R29).
+    if name == "taint" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField() }
+    if name == "sanitizes" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "trusted_declassify" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "taint_field" { return srAnnotTargetField() }
+    // v0.6 G38 — Spec link (§3.10).
+    if name == "spec" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G39 — Reproducibility (§3.11).
+    if name == "reproducible" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G40 — Sealed construction (§3.4.5).
+    if name == "sealed_construct" { return srAnnotTargetTopLevel() }
+    if name == "trusted_construct" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "test_construct" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G41 — Error contract (§7.5).
+    if name == "error_contract" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G42 — Structured intent (§3.12).
+    if name == "purpose" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "example" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "fixture" { return srAnnotTargetTopLevel() }
+    // v0.6 G44 — API evolution (§3.14).
+    if name == "since" {
+        return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField() | srAnnotTargetVariant()
+    }
+    if name == "stability" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "match_compat" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    // v0.6 G45 — Golden tests (§11.5.2). Test functions only.
+    if name == "golden" { return srAnnotTargetTopLevel() }
+    // v0.6 G46 — Performance contract (§3.15).
+    if name == "budget" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
     0
 }
 
@@ -3790,6 +3825,34 @@ fn srAnnotationNameList() -> List<String> {
         "pure",
         "target_feature",
         "noalias",
+        // v0.6 G36 — Capabilities.
+        "ambient",
+        "reproducible_capability",
+        // v0.6 G37 — Information flow.
+        "taint",
+        "sanitizes",
+        "trusted_declassify",
+        "taint_field",
+        // v0.6 G38 / G39 — Spec link / Reproducibility.
+        "spec",
+        "reproducible",
+        // v0.6 G40 — Sealed construction.
+        "sealed_construct",
+        "trusted_construct",
+        "test_construct",
+        // v0.6 G41 — Error contract.
+        "error_contract",
+        // v0.6 G42 — Structured intent.
+        "purpose",
+        "example",
+        "fixture",
+        // v0.6 G44 — API evolution.
+        "since",
+        "stability",
+        "match_compat",
+        // v0.6 G45 / G46 — Golden / Budget.
+        "golden",
+        "budget",
     ]
 }
 


### PR DESCRIPTION
## Summary

Phase 1 follow-on. PR #1479 가 v0.6 capability protocols (`Clock`/`Rng`/`Env`/`Fs`/`Net`/`Process`/`Console`) 를 stdlib 에 추가. 본 PR 은 그 위에서 **v0.6 spec 이 정의한 20 신규 어노테이션의 *target table 등록*** — 사용자가 v0.6 어노테이션을 작성해도 `E0400` (CodeUnknownAnnotation) 거부 안 됨.

각 어노테이션의 *시맨틱 처리* (실제 검사 / 코드젠 / 진단) 는 Phase 2-5 의 책임. 본 PR 은 *surface 등록만* — Phase 1.5 의 가벼운 인프라.

## 등록된 어노테이션 (20)

| 카테고리 | Annotation | Targets |
|---|---|---|
| **Capabilities (G36)** | `ambient` | top-level fn (entry-point) |
| | `reproducible_capability` | top-level (interface) |
| **Information flow (G37)** | `taint` | fn / method / struct field |
| | `sanitizes` | fn / method |
| | `trusted_declassify` | fn / method |
| | `taint_field` | struct field |
| **Spec / Determinism** | `spec` (G38) | fn / method |
| | `reproducible` (G39) | fn / method |
| **Sealed construction (G40)** | `sealed_construct` | struct |
| | `trusted_construct` | fn / method (stdlib only) |
| | `test_construct` | fn / method (test profile) |
| **Error contract (G41)** | `error_contract` | fn / method |
| **Structured intent (G42)** | `purpose`, `example` | fn / method |
| | `fixture` | fn |
| **API evolution (G44)** | `since` | fn / method / field / variant |
| | `stability` | fn / method |
| | `match_compat` | fn / method |
| **Testing / Perf** | `golden` (G45) | test fn |
| | `budget` (G46) | fn / method |

**Note**: `#[requires]` 은 v0.5 이미 등록 (`TargetMethod` for stdlib trait bound). v0.6 의 *parameter-position* `#[requires("trust_tag")]` (G37 sink) 는 Phase 5 의 parser / check 작업 (G37 R29 grammar surface).

## 동기화

두 source 모두 동일 매핑 (single source of truth):
- `internal/ast/ast.go::annotationRules` — Go-side authority
- `toolchain/resolve.osty::srAnnotAllowedTargets` / `srAnnotationNameList` — self-hosted resolver authority

## Files

- 2 files changed, 128 insertions
- 수정: `internal/ast/ast.go` (+62), `toolchain/resolve.osty` (+66)

## Test plan

- [x] `go build ./internal/ast/...` 통과
- [x] `osty check toolchain/resolve.osty` exit 0
- [x] 기존 annotation 룰 (json/deprecated/op/cfg/test/v0.6 perf hints) 변경 0
- [x] `go test ./internal/ast/... ./internal/check/... ./internal/resolve/...` 통과
- [ ] `TestParseMatchArmAllowsBareAssignmentBody` 실패는 **main 에 이미 존재**하는 별개 회귀 — 본 PR 무관 (확인됨)

## Phase 0 / Phase 1 status

**Phase 0 (LLVM 백엔드 갭)**:
- ✅ A1 (PR #1477)
- ✅ A2 (PR #1470)
- ✅ C1 + diag trace (PR #1480)
- ✅ C1 follow-up safety guards (PR #1481)

**Phase 1 (Capability migration)**:
- ✅ v0.6 capability protocols (PR #1479)
- 🟢 **본 PR — 20 신규 어노테이션 surface 등록 (Phase 1.5)**
- ⚪ stdlib `time.now()` → `clock.now()` migration
- ⚪ `#[ambient]` 시맨틱 (entry-point gating, default instance binding desugar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b2EmHJkX9AuXDT1ooTHUd)_