### PR TITLE
[codex] add v0.6 capability host adapters

### DIFF
--- a/CHANGELOG_v0.6.md
+++ b/CHANGELOG_v0.6.md
@@ -46,10 +46,11 @@ rationale.
 | Item | Status | Notes |
 |---|---|---|
 | `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface | **partial** | `std.capability` 에 7 canonical protocol surface 추가. `std.random.Rng.next/nextBytes` alias와 `examples/v06_capabilities` front-end proof 포함. |
+| Host capability adapter factories | **partial** | `time.systemClock`, `random.host`, `env.host`, `fs.host`, `capability.hostNet`, `capability.hostProcess`, `io.console` 를 추가하고 `examples/v06_capability_adapters` 로 front-end/type-check proof 추가. `net.host` / `process.host` bridge factory 는 cross-module migration helper 로 제공. |
 | `#[ambient(...)]` annotation | **planned** | script / main / test entry 에서만 |
 | `#[reproducible_capability]` annotation | **planned** | 사용자 정의 deterministic capability |
 | `--legacy-globals` 호환 모드 | **planned** | v0.6.x 에서만, v0.7 제거 |
-| stdlib `time.*` → `clock.*` migration | **planned** | 100 PR 분량의 stdlib 순회 |
+| stdlib `time.*` → `clock.*` migration | **partial** | migration catalog (`capability.legacyGlobalRewriteRules`) 와 host-boundary factories가 landing. 전역 호출 warning/desugar 는 compiler phase 후속. |
 
 ### Information flow (G37 — Phase 5)
 

--- a/LANG_SPEC_v0.6/10-standard-library/README.md
+++ b/LANG_SPEC_v0.6/10-standard-library/README.md
@@ -64,3 +64,5 @@ lowering remains implementation backlog.
 Capability protocols (`std.capability`) are specified in
 [§20 Capabilities](../20-capabilities.md) because they govern effect
 typing and ambient injection as well as stdlib shape.
+The current stdlib also exposes host-boundary adapter factories for the
+canonical capability set; see §20 for the exact list and migration status.

--- a/LANG_SPEC_v0.6/20-capabilities.md
+++ b/LANG_SPEC_v0.6/20-capabilities.md
@@ -71,8 +71,11 @@ pub interface Process {
 **Implementation note.** 현재 stdlib 는 이 canonical protocol set 을
 `std.capability` 에 compile-checked interface surface 로 노출한다. 기존
 `std.time`, `std.random`, `std.env`, `std.fs`, `std.net`, `std.process`, `std.io`
-전역 함수는 v0.6.x compatibility surface 로 유지되며, ambient desugar /
-`--legacy-globals` warning 은 별도 compiler phase 에서 닫는다.
+전역 함수는 v0.6.x compatibility surface 로 유지된다. Host-boundary adapter
+factory 는 현재 `time.systemClock()`, `random.host()`, `env.host()`, `fs.host()`,
+`capability.hostNet()`, `capability.hostProcess()`, `io.console()` 로 노출하며,
+`std.net.host()` / `std.process.host()` 는 cross-module bridge helper 로 제공한다.
+Ambient desugar / `--legacy-globals` warning 은 별도 compiler phase 에서 닫는다.
 
 함수는 capability 를 **명시적 파라미터**로 받는다:
 

--- a/STDLIB_MATRIX.md
+++ b/STDLIB_MATRIX.md
@@ -53,12 +53,12 @@ Osty 표준 라이브러리 모듈별 실행 가능성 / 스펙 정합 매트릭
 | encoding | §10.11 | 329 | 8+ | 0% | pure Osty | base64 / hex / url 구현 |
 | crypto | §10.12 | 23 | 8 | 100% | crypto 19 runtime + shim | sha256/512/HMAC/randomBytes/constantTimeEq 백엔드 충족 |
 | math | §10.17 | 42 | 25 | 100% | float 40 runtime | libm 매핑 다 있음 |
-| fs | §10.1 | 51 | 20 | 100% | fs 52 runtime + shim 685 | read/write/exists/remove/mkdir 등 충족 |
-| env | §10.1 | 20 | 8 | 100% | env 15 runtime + shim 624 | args/get/set/vars 충족 |
+| fs | §10.1 / §20 | 76 | 20 + HostFs | 100% | fs 52 runtime + shim 685 | read/write/exists/remove/mkdir 등 충족. v0.6 `HostFs` adapter 추가 |
+| env | §10.1 / §20 | 42 | 8 + HostEnv | 100% | env 15 runtime + shim 624 | args/get/set/vars 충족. v0.6 `HostEnv` adapter 추가 |
 | os | §10.15 | 48 | 8 | 100% | os 37 runtime + shim | exec/exit/pid/hostname 충족 |
-| random | §10.14 | 41 | 9 | 77% | random 17 runtime + shim 524 | Rng default + seeded 충족 |
+| random | §10.14 / §20 | 46 | 11 | 77% | random 17 runtime + shim 524 | Rng default + seeded 충족. `host` / `seededCapability` adapter factory 추가 |
 | compress | §10.19 | 11 | 2 | 100% | compress 4 runtime + shim 199 | gzip만 (spec 명시) |
-| io | §16/§10.1 | 541 | 50 | 0% | io 2 runtime + shim 171 | Reader/Writer 인터페이스 + BytesReader/Buffer 본문 |
+| io | §16/§10.1 / §20 | 517 | 50 + HostConsole | 0% | io 2 runtime + shim 171 | Reader/Writer 인터페이스 + BytesReader/Buffer 본문. v0.6 `HostConsole` / `ConsoleWriter` adapter 추가 |
 | collections (List/Map/Set 메서드) | §10.6 | (above) | (above) | mixed | runtime intrinsics | spec method 정확히 일치 |
 | primitives/int | §10.5 | 84 | 43 | 100% | int runtime ops | checkedAdd/wrappingAdd/saturating/pow/abs 다 있음 |
 | primitives/float | §10.5 | 69 | 40 | 100% | float 40 runtime | sqrt/pow/round/isNaN/isInfinite 충족 |
@@ -105,10 +105,10 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 
 | 모듈 | spec | LOC | 표면 | bodyless | backend | 갭 |
 |---|---|---|---|---|---|---|
-| net | §10.23 | 1084 | 94 | 11% | net 40 runtime | TCP/UDP는 백엔드 풍부, IPv6 zone parsing 등 일부 미검증 |
+| net | §10.23 / §20 | 972 | 94 + HostNet | 11% | net 40 runtime | TCP/UDP는 백엔드 풍부, IPv6 zone parsing 등 일부 미검증. v0.6 bridge `HostNet` adapter 추가 |
 | thread | §8 | 76 | 16 | 50% | thread 16 + chan 10 + select 22 + task 19 | ~~`thread.Duration{}` 빈 struct~~ → commit `23f4568c`에서 제거. 현재는 `use std.time` + `time.Duration` 단일 사용 |
 | sync | §10.2 | 96 | 17 | 17% | mu 5 + rmu 5 + cond 6 + once 3 | spec tier-2 = "Mutex, RwLock, atomics". Once는 spec 외인데 백엔드는 갖춤 |
-| time | §10.20 | 110 | 25 | 64% | monotonic + sleep + format 일부 | ~~`Int.s/ms/h/min/days/ns/us/weeks` 부재~~ → 2026-05-02 재확인 결과 8개 모두 ([primitives/int.osty:76-83](internal/stdlib/primitives/int.osty)) + Float 8개 ([primitives/float.osty:61-68](internal/stdlib/primitives/float.osty)) 선언됨. 체커 등록은 [`primitive_arith_register.go:131`](internal/selfhost/primitive_arith_register.go) (8개 loop), LLVM 백엔드는 [`duration_constructors_test.go`](internal/llvmgen/duration_constructors_test.go) 8개 테스트 통과. spec 이름 `minutes` (≠ `min`, `Int.min(self, other)`와 충돌 회피, [spec §10.20](LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md) line 111-112) |
+| time | §10.20 / §20 | 94 | 25 + HostClock | 64% | monotonic + sleep + format 일부 | `systemClock` adapter 추가. ~~`Int.s/ms/h/min/days/ns/us/weeks` 부재~~ → 2026-05-02 재확인 결과 8개 모두 ([primitives/int.osty:76-83](internal/stdlib/primitives/int.osty)) + Float 8개 ([primitives/float.osty:61-68](internal/stdlib/primitives/float.osty)) 선언됨. 체커 등록은 [`primitive_arith_register.go:131`](internal/selfhost/primitive_arith_register.go) (8개 loop), LLVM 백엔드는 [`duration_constructors_test.go`](internal/llvmgen/duration_constructors_test.go) 8개 테스트 통과. spec 이름 `minutes` (≠ `min`, `Int.min(self, other)`와 충돌 회피, [spec §10.20](LANG_SPEC_v0.5/10-standard-library/20-time-extensions.md) line 111-112) |
 | testing | §11 | 88 | 14 | 100% | bench 7 + test 6 + snapshot 7 + parallel 6 | assertion/benchmark/snapshot 백엔드 인터셉트로 동작. property는 스펙 §11 G33 |
 | testing_gen | §11 | 168 | 18 | 0% | pure Osty | int/intRange/bool/float/string/list 등 generator |
 | term | §10.25 | 320 | 39 | 17% | term 14 runtime + shim | isTerminal/size/write/flush/setRawMode 백엔드. **readKey/pollKey/readEvent는 미구현** (모듈 헤더 자백) |
@@ -116,7 +116,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 | secrets | §10.41 | 20 | 8 | 100% | keychain 위임 | keychain 백엔드 따라감 |
 | cli | §10.1 | 260 | 11 | 0% | env 위임 | flag/option spec/parse 본문 |
 | cmd | unspec | 214 | 24 | 0% | os shim + cmd runtime 8 | command builder + POSIX shell escape |
-| process | §10.1 + unspec | 277 | 32 | 74% | os shim + process runtime 9 | `ProcessCommand` / `ProcessPipeline` facade, stdin text, captured stdout/stderr, shell pipeline composition. abort/todo/unreachable는 backend-owned primitive 유지 |
+| process | §10.1 + unspec / §20 | 235 | 32 + HostProcess | 74% | os shim + process runtime 9 | `ProcessCommand` / `ProcessPipeline` facade, stdin text, captured stdout/stderr, shell pipeline composition. v0.6 bridge `HostProcess` adapter 추가. abort/todo/unreachable는 backend-owned primitive 유지 |
 | path | §10.15 | 191 | 9 | 22% | runtime path 2 | join/split/extension 본문, absolute/canonical은 백엔드 |
 | log | §10.10 | 441 | 33 | 0% | `eprintln` 폰백 (C runtime `osty_rt_log_*` 부재, LLVM shim 부재) | Osty 본문은 spec 동급 (`TextHandler`, `JsonHandler`, `Logger` 체인). 체커/인터프리터 E2E 통과 ([`examples/log_e2e/`](examples/log_e2e/)). **현재 HEAD에는 `internal/llvmgen/` 디렉토리가 없어 LLVM shim 미구현**. |
 | uuid | §10.13 | 22 | 0 | 100% | C runtime 7개 (`osty_rt_uuid_v4/v7/nil/to_string/to_bytes/parse/parse_error`) | declaration-only 모듈. C runtime 백엔드는 충족. 체커/인터프리터 E2E 통과 ([`examples/uuid_e2e/`](examples/uuid_e2e/)). **현재 HEAD에는 LLVM bridge shim 없음**. |
@@ -219,7 +219,7 @@ partial 모듈 3개 (crypto / option / result) 는 **호출 패턴 한정 동작
 
 | 모듈 | spec | LOC | 비고 |
 |---|---|---|---|
-| capability | §20 | 102 | v0.6 canonical `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface surface. `examples/v06_capabilities` front-end/type-check proof. Ambient/legacy-global compiler semantics remain Phase 1 follow-up. |
+| capability | §20 | 177 | v0.6 canonical `Clock` / `Rng` / `Env` / `Fs` / `Net` / `Process` / `Console` interface surface, migration rules, exact `HostNet` / `HostProcess` adapters. `examples/v06_capabilities` + `examples/v06_capability_adapters` front-end/type-check proof. Ambient/legacy-global compiler semantics remain Phase 1 follow-up. |
 | cmp | §10.1 | 27 | Equal / Ordered / Hashable interface 정의. 컴파일러 인지 |
 | error | §10.1 / §7 | 96 | Error interface + BasicError + WrappedError + wrap/chain/rootCause |
 | ref | §10.1 | 9 | `same<T>(a, b)` 단일 함수, declaration-only — 컴파일러 intrinsic 가정 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,8 @@ the compiler evolves.
   and property-based testing.
 - `v06_capabilities`: v0.6-style explicit `Clock` / `Rng` capability
   parameters with deterministic fakes and stdlib protocol helpers.
+- `v06_capability_adapters`: v0.6 host-boundary adapter catalog showing how
+  existing global stdlib modules become explicit capability values.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `gui-webview2-inspector`: Windows WebView2 GUI example using

--- a/examples/v06_capability_adapters/lib.osty
+++ b/examples/v06_capability_adapters/lib.osty
@@ -1,0 +1,48 @@
+use std.capability as cap
+use std.env as hostenv
+use std.fs as hostfs
+use std.io
+use std.random
+use std.time
+pub struct RuntimeCapabilities {
+    pub clock: time.HostClock,
+    pub rng: random.Rng,
+    pub env: hostenv.HostEnv,
+    pub fs: hostfs.HostFs,
+    pub net: cap.HostNet,
+    pub process: cap.HostProcess,
+    pub console: io.HostConsole,
+}
+pub fn hostRuntime() -> RuntimeCapabilities {
+    RuntimeCapabilities {clock: time.systemClock(), rng: random.host(), env: hostenv.host(), fs: hostfs.host(), net: cap.hostNet(), process: cap.hostProcess(), console: io.console()}
+}
+pub fn capabilitySummary() -> String {
+    let protocols = cap.canonicalNames()
+    let factories = cap.hostFactoryNames()
+    let rewrites = cap.legacyGlobalRewriteRules()
+    "{protocols.len()} protocols; {factories.len()} host factories; {rewrites.len()} rewrite rules"
+}
+pub fn describeRuntime(clock: cap.Clock, rng: cap.Rng, env: cap.Env, fs: cap.Fs, net: cap.Net, process: cap.Process, console: cap.Console) -> String {
+    let _ = clock
+    let _ = rng
+    let _ = env
+    let _ = fs
+    let _ = net
+    let _ = process
+    let _ = console
+    capabilitySummary()
+}
+pub fn hostRuntimeSummary() -> String {
+    let runtime = hostRuntime()
+    describeRuntime(runtime.clock, runtime.rng, runtime.env, runtime.fs, runtime.net, runtime.process, runtime.console)
+}
+pub fn legacyRewriteReport() -> List<String> {
+    let mut out: List<String> = []
+    for rule in cap.legacyGlobalRewriteRules() {
+        out.push("{rule.legacy} -> {rule.replacement} [{rule.capability}]")
+    }
+    out
+}
+pub fn ambientBoundaryFactories() -> List<String> {
+    ["clock = time.systemClock()", "rng = random.host()", "env = env.host()", "fs = fs.host()", "net = capability.hostNet()", "process = capability.hostProcess()", "console = io.console()"]
+}

--- a/examples/v06_capability_adapters/lib_test.osty
+++ b/examples/v06_capability_adapters/lib_test.osty
@@ -1,0 +1,14 @@
+use std.testing
+fn testCapabilitySummaryCatalog() {
+    testing.assertEq(capabilitySummary(), "7 protocols; 7 host factories; 8 rewrite rules")
+}
+fn testLegacyRewriteReportShape() {
+    let rows = legacyRewriteReport()
+    testing.assertEq(rows.len(), 8)
+    testing.assertEq(rows[0], "time.now() -> clock.now() [Clock]")
+}
+fn testAmbientBoundaryFactoryCatalog() {
+    let rows = ambientBoundaryFactories()
+    testing.assertEq(rows.len(), 7)
+    testing.assertEq(rows[0], "clock = time.systemClock()")
+}

--- a/examples/v06_capability_adapters/osty.toml
+++ b/examples/v06_capability_adapters/osty.toml
@@ -1,0 +1,7 @@
+[package]
+name = "v06_capability_adapters"
+version = "0.1.0"
+edition = "0.5"
+description = "v0.6 host capability adapter bridge example."
+
+[dependencies]

--- a/internal/stdlib/capability_test.go
+++ b/internal/stdlib/capability_test.go
@@ -20,8 +20,12 @@ func TestCapabilityModuleExposesV06Protocols(t *testing.T) {
 		"pub interface Net",
 		"pub interface Process",
 		"pub interface Console",
+		"pub struct MigrationRule",
+		"pub struct HostNet",
+		"pub struct HostProcess",
 		"pub fn canonicalNames() -> List<String>",
 		"pub fn defaultAmbientNames() -> List<String>",
+		"pub fn hostFactoryNames() -> List<String>",
 		"pub fn legacyGlobalModules() -> List<String>",
 	} {
 		if !strings.Contains(src, want) {
@@ -57,8 +61,15 @@ func TestCapabilityModuleHelperNamesAreBodied(t *testing.T) {
 		"defaultAmbientNames",
 		"mainAmbientNames",
 		"testAmbientNames",
+		"hostFactoryNames",
+		"bridgeFactoryNames",
+		"deterministicCapabilityNames",
+		"nondeterministicCapabilityNames",
 		"filesystemEffectFns",
 		"legacyGlobalModules",
+		"legacyGlobalRewriteRules",
+		"hostNet",
+		"hostProcess",
 	} {
 		fn := reg.LookupFnDecl("capability", name)
 		if fn == nil {
@@ -66,6 +77,53 @@ func TestCapabilityModuleHelperNamesAreBodied(t *testing.T) {
 		}
 		if fn.Body == nil {
 			t.Fatalf("capability.%s body = nil, want Osty helper body", name)
+		}
+	}
+}
+
+func TestCapabilityHostAdaptersExposeInterfaceMethods(t *testing.T) {
+	reg := LoadCached()
+	for _, tc := range []struct {
+		module   string
+		typeName string
+		methods  []string
+	}{
+		{"time", "HostClock", []string{"now", "monotonic", "sleep"}},
+		{"env", "HostEnv", []string{"args", "get", "require", "set", "unset", "vars", "currentDir", "setCurrentDir"}},
+		{"fs", "HostFs", []string{"read", "readToString", "write", "writeString", "exists", "walk", "glob", "create", "remove", "rename", "copy", "mkdir", "mkdirAll"}},
+		{"net", "HostNet", []string{"resolve", "resolveAll", "lookup", "lookupAddr", "connect", "connectTimeout", "listen"}},
+		{"process", "HostProcess", []string{"pid", "hostname", "command", "commandArgs", "shell", "run", "exec"}},
+		{"io", "HostConsole", []string{"print", "println", "eprint", "eprintln", "readLine", "writer"}},
+		{"io", "ConsoleWriter", []string{"write", "flush"}},
+		{"capability", "HostNet", []string{"resolve", "resolveAll", "lookup", "lookupAddr", "connect", "connectTimeout", "listen"}},
+		{"capability", "HostProcess", []string{"pid", "hostname", "command", "commandArgs", "shell", "run", "exec"}},
+	} {
+		for _, method := range tc.methods {
+			if got := reg.LookupMethodDecl(tc.module, tc.typeName, method); got == nil {
+				t.Fatalf("LookupMethodDecl(%s, %s, %s) = nil", tc.module, tc.typeName, method)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		module string
+		name   string
+	}{
+		{"time", "systemClock"},
+		{"random", "host"},
+		{"random", "seededCapability"},
+		{"env", "host"},
+		{"fs", "host"},
+		{"net", "host"},
+		{"process", "host"},
+		{"io", "console"},
+		{"io", "stdoutWriter"},
+		{"io", "stderrWriter"},
+		{"capability", "hostNet"},
+		{"capability", "hostProcess"},
+	} {
+		if got := reg.LookupFnDecl(tc.module, tc.name); got == nil {
+			t.Fatalf("LookupFnDecl(%s, %s) = nil", tc.module, tc.name)
 		}
 	}
 }

--- a/internal/stdlib/modules/capability.osty
+++ b/internal/stdlib/modules/capability.osty
@@ -74,6 +74,66 @@ pub interface Console {
     fn readLine(self) -> String
     fn writer(self) -> io.Writer
 }
+pub struct MigrationRule {
+    pub capability: String,
+    pub legacy: String,
+    pub replacement: String,
+    pub warning: String,
+}
+pub struct HostNet {
+    pub profile: String,
+    pub fn resolve(self, addr: String) -> Result<net.Addr, Error> {
+        net.resolve(addr)
+    }
+    pub fn resolveAll(self, host: String) -> Result<List<net.Addr>, Error> {
+        net.resolveAll(host)
+    }
+    pub fn lookup(self, host: String) -> Result<List<net.IpAddr>, Error> {
+        net.lookup(host)
+    }
+    pub fn lookupAddr(self, ip: net.IpAddr) -> Result<List<String>, Error> {
+        net.lookupAddr(ip)
+    }
+    pub fn connect(self, addr: String) -> Result<net.TcpConn, Error> {
+        net.connect(addr)
+    }
+    pub fn connectTimeout(self, addr: String, timeoutMs: Int) -> Result<net.TcpConn, Error> {
+        net.connectTimeout(addr, timeoutMs)
+    }
+    pub fn listen(self, addr: String) -> Result<net.TcpListener, Error> {
+        net.listen(addr)
+    }
+}
+pub struct HostProcess {
+    pub profile: String,
+    pub fn pid(self) -> Int {
+        os.pid()
+    }
+    pub fn hostname(self) -> Result<String, Error> {
+        os.hostname()
+    }
+    pub fn command(self, program: String) -> proc.ProcessCommand {
+        proc.command(program)
+    }
+    pub fn commandArgs(self, program: String, args: List<String>) -> proc.ProcessCommand {
+        proc.commandArgs(program, args)
+    }
+    pub fn shell(self, line: String) -> proc.ProcessCommand {
+        proc.shell(line)
+    }
+    pub fn run(self, command: proc.ProcessCommand) -> Result<proc.ProcessOutput, Error> {
+        command.run()
+    }
+    pub fn exec(self, command: String, args: List<String>) -> Result<os.Output, Error> {
+        os.exec(command, args)
+    }
+}
+pub fn hostNet() -> HostNet {
+    HostNet {profile: "host"}
+}
+pub fn hostProcess() -> HostProcess {
+    HostProcess {profile: "host"}
+}
 pub fn canonicalNames() -> List<String> {
     ["Clock", "Rng", "Env", "Fs", "Net", "Process", "Console"]
 }
@@ -94,9 +154,24 @@ pub fn mainAmbientNames() -> List<String> {
 pub fn testAmbientNames() -> List<String> {
     ["clock", "rng", "env", "fs", "console"]
 }
+pub fn hostFactoryNames() -> List<String> {
+    ["time.systemClock", "random.host", "env.host", "fs.host", "capability.hostNet", "capability.hostProcess", "io.console"]
+}
+pub fn bridgeFactoryNames() -> List<String> {
+    ["net.host", "process.host"]
+}
+pub fn deterministicCapabilityNames() -> List<String> {
+    ["Console"]
+}
+pub fn nondeterministicCapabilityNames() -> List<String> {
+    ["Clock", "Rng", "Env", "Fs", "Net", "Process"]
+}
 pub fn filesystemEffectFns() -> List<String> {
     ["read", "readToString", "write", "writeString", "exists", "walk", "glob", "create", "remove", "rename", "copy", "mkdir", "mkdirAll"]
 }
 pub fn legacyGlobalModules() -> List<String> {
     ["time", "random", "env", "fs", "net", "process", "io", "os"]
+}
+pub fn legacyGlobalRewriteRules() -> List<MigrationRule> {
+    [MigrationRule {capability: "Clock", legacy: "time.now()", replacement: "clock.now()", warning: "W0750 legacy global time.now; pass cap.Clock explicitly or use time.systemClock at the entry boundary"}, MigrationRule {capability: "Clock", legacy: "time.sleep(d)", replacement: "clock.sleep(d)", warning: "W0750 legacy global time.sleep; pass cap.Clock explicitly"}, MigrationRule {capability: "Rng", legacy: "random.default()", replacement: "rng parameter", warning: "W0750 legacy global random.default; pass cap.Rng explicitly"}, MigrationRule {capability: "Env", legacy: "env.get(k)", replacement: "env.get(k)", warning: "W0750 legacy global env access; pass cap.Env explicitly"}, MigrationRule {capability: "Fs", legacy: "fs.read(p)", replacement: "fs.read(p)", warning: "W0750 legacy global filesystem access; pass cap.Fs explicitly"}, MigrationRule {capability: "Net", legacy: "net.connect(addr)", replacement: "net.connect(addr)", warning: "W0750 legacy global network access; pass cap.Net explicitly"}, MigrationRule {capability: "Process", legacy: "os.exec(cmd, args)", replacement: "process.exec(cmd, args)", warning: "W0750 legacy global process execution; pass cap.Process explicitly"}, MigrationRule {capability: "Console", legacy: "println(text)", replacement: "console.println(text)", warning: "W0750 legacy global console output; pass cap.Console explicitly where reproducibility policy needs it"}]
 }

--- a/internal/stdlib/modules/env.osty
+++ b/internal/stdlib/modules/env.osty
@@ -2,19 +2,41 @@
 //
 // Body-less signature stubs: the backend lowers each call to the OS
 // environment runtime.
-
+pub struct HostEnv {
+    pub profile: String,
+    pub fn args(self) -> List<String> {
+        args()
+    }
+    pub fn get(self, name: String) -> String? {
+        get(name)
+    }
+    pub fn require(self, name: String) -> Result<String, Error> {
+        require(name)
+    }
+    pub fn set(self, name: String, value: String) -> Result<(), Error> {
+        set(name, value)
+    }
+    pub fn unset(self, name: String) -> Result<(), Error> {
+        unset(name)
+    }
+    pub fn vars(self) -> Map<String, String> {
+        vars()
+    }
+    pub fn currentDir(self) -> Result<String, Error> {
+        currentDir()
+    }
+    pub fn setCurrentDir(self, path: String) -> Result<(), Error> {
+        setCurrentDir(path)
+    }
+}
+pub fn host() -> HostEnv {
+    HostEnv {profile: "host"}
+}
 pub fn args() -> List<String>
-
 pub fn get(name: String) -> String?
-
 pub fn require(name: String) -> Result<String, Error>
-
 pub fn set(name: String, value: String) -> Result<(), Error>
-
 pub fn unset(name: String) -> Result<(), Error>
-
 pub fn vars() -> Map<String, String>
-
 pub fn currentDir() -> Result<String, Error>
-
 pub fn setCurrentDir(path: String) -> Result<(), Error>

--- a/internal/stdlib/modules/fs.osty
+++ b/internal/stdlib/modules/fs.osty
@@ -9,43 +9,68 @@
 // `walk` returns sorted descendants; directory paths end in `/`.
 // `glob` supports `*`, `?`, and `**` over slash-normalized paths.
 // `watch` is a polling snapshot: each row is `kind<TAB>size<TAB>mtime<TAB>path`.
-
+pub struct HostFs {
+    pub root: String,
+    pub fn read(self, path: String) -> Result<Bytes, Error> {
+        read(path)
+    }
+    pub fn readToString(self, path: String) -> Result<String, Error> {
+        readToString(path)
+    }
+    pub fn write(self, path: String, contents: Bytes) -> Result<(), Error> {
+        write(path, contents)
+    }
+    pub fn writeString(self, path: String, contents: String) -> Result<(), Error> {
+        writeString(path, contents)
+    }
+    pub fn exists(self, path: String) -> Bool {
+        exists(path)
+    }
+    pub fn walk(self, root: String) -> Result<List<String>, Error> {
+        walk(root)
+    }
+    pub fn glob(self, pattern: String) -> Result<List<String>, Error> {
+        glob(pattern)
+    }
+    pub fn create(self, path: String) -> Result<(), Error> {
+        create(path)
+    }
+    pub fn remove(self, path: String) -> Result<(), Error> {
+        remove(path)
+    }
+    pub fn rename(self, from: String, to: String) -> Result<(), Error> {
+        rename(from, to)
+    }
+    pub fn copy(self, from: String, to: String) -> Result<(), Error> {
+        copy(from, to)
+    }
+    pub fn mkdir(self, path: String) -> Result<(), Error> {
+        mkdir(path)
+    }
+    pub fn mkdirAll(self, path: String) -> Result<(), Error> {
+        mkdirAll(path)
+    }
+}
+pub fn host() -> HostFs {
+    HostFs {root: ""}
+}
 pub fn read(path: String) -> Result<Bytes, Error>
-
 pub fn readToString(path: String) -> Result<String, Error>
-
 pub fn write(path: String, contents: Bytes) -> Result<(), Error>
-
 pub fn writeString(path: String, contents: String) -> Result<(), Error>
-
 pub fn exists(path: String) -> Bool
-
 pub fn walk(root: String) -> Result<List<String>, Error>
-
 pub fn glob(pattern: String) -> Result<List<String>, Error>
-
 pub fn watch(root: String) -> Result<List<String>, Error>
-
 pub fn create(path: String) -> Result<(), Error>
-
 pub fn remove(path: String) -> Result<(), Error>
-
 pub fn rename(from: String, to: String) -> Result<(), Error>
-
 pub fn copy(from: String, to: String) -> Result<(), Error>
-
 pub fn copyDir(from: String, to: String) -> Result<(), Error>
-
 pub fn mkdir(path: String) -> Result<(), Error>
-
 pub fn mkdirAll(path: String) -> Result<(), Error>
-
 pub fn atomicWrite(path: String, contents: Bytes) -> Result<(), Error>
-
 pub fn atomicWriteString(path: String, contents: String) -> Result<(), Error>
-
 pub fn lockFile(path: String) -> Result<(), Error>
-
 pub fn hashFile(path: String) -> Result<String, Error>
-
 pub fn diffFiles(left: String, right: String) -> Result<String, Error>

--- a/internal/stdlib/modules/io.osty
+++ b/internal/stdlib/modules/io.osty
@@ -6,114 +6,139 @@
 // byte readers, short-write-aware writers, in-memory implementations,
 // and helper routines such as `readAll`, `writeAll`, `copy`, and
 // line-oriented text helpers.
-
 use std.bytes
 use std.error
 use std.strings
-
+pub struct ConsoleWriter {
+    pub stderr: Bool,
+    pub fn write(self, data: Bytes) -> Result<Int, Error> {
+        let text = bytes.toString(data)?
+        if self.stderr {
+            eprint(text)
+        } else {
+            print(text)
+        }
+        Ok(data.len())
+    }
+    pub fn flush(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+pub struct HostConsole {
+    pub name: String,
+    pub fn print(self, text: String) {
+        print(text)
+    }
+    pub fn println(self, text: String) {
+        println(text)
+    }
+    pub fn eprint(self, text: String) {
+        eprint(text)
+    }
+    pub fn eprintln(self, text: String) {
+        eprintln(text)
+    }
+    pub fn readLine(self) -> String {
+        readLine()
+    }
+    pub fn writer(self) -> Writer {
+        stdoutWriter()
+    }
+}
+pub fn stdoutWriter() -> ConsoleWriter {
+    ConsoleWriter {stderr: false}
+}
+pub fn stderrWriter() -> ConsoleWriter {
+    ConsoleWriter {stderr: true}
+}
+pub fn console() -> HostConsole {
+    HostConsole {name: "host"}
+}
 pub interface Reader {
     fn read(self, maxBytes: Int) -> Result<Bytes, Error>
 }
-
 pub interface Writer {
     fn write(self, data: Bytes) -> Result<Int, Error>
     fn flush(self) -> Result<(), Error>
 }
-
 pub interface Closer {
     fn close(self) -> Result<(), Error>
 }
-
 pub interface ReadWriter {
     Reader
     Writer
 }
-
 pub interface ReadCloser {
     Reader
     Closer
 }
-
 pub interface WriteCloser {
     Writer
     Closer
 }
-
 pub interface ByteReader {
     Reader
     fn peek(self, maxBytes: Int) -> Result<Bytes, Error>
     fn readByte(self) -> Result<Byte?, Error>
     fn unreadByte(self) -> Result<(), Error>
 }
-
 pub interface LineReader {
     Reader
     fn readLineBytes(self) -> Result<Bytes?, Error>
     fn readLine(self) -> Result<String?, Error>
 }
-
 pub interface ByteWriter {
     Writer
     fn writeByte(self, b: Byte) -> Result<Int, Error>
     fn writeString(self, s: String) -> Result<Int, Error>
     fn writeLine(self, s: String) -> Result<Int, Error>
 }
-
 pub interface ReaderFrom {
     fn readFrom(self, r: Reader) -> Result<Int, Error>
 }
-
 pub interface WriterTo {
     fn writeTo(self, w: Writer) -> Result<Int, Error>
 }
-
 pub interface BufferedReader {
     ByteReader
     LineReader
 }
-
 pub interface BufferedWriter {
     ByteWriter
     ReaderFrom
     WriterTo
 }
-
 fn emptyBytes() -> Bytes {
     bytes.fromString("")
 }
-
 fn newlineBytes() -> Bytes {
     bytes.fromString("\n")
 }
-
 fn carriageReturnByte() -> Byte {
     bytes.fromString("\r")[0]
 }
-
 fn newlineByte() -> Byte {
     bytes.fromString("\n")[0]
 }
-
 fn minInt(a: Int, b: Int) -> Int {
-    if a < b { a } else { b }
+    if a < b {
+        a
+    } else {
+        b
+    }
 }
-
 fn closedError(kind: String) -> Error {
     error.new("io.{kind}: closed")
 }
-
 fn unexpectedEOFError(op: String, want: Int, got: Int) -> Error {
     error.new("io.{op}: unexpected EOF after {got} of {want} bytes")
 }
-
 fn invalidUnreadError() -> Error {
     error.new("io.bytesReader: cannot unread at start")
 }
-
 fn invalidWriteCountError(op: String, n: Int, want: Int) -> Error {
     error.new("io.{op}: writer reported invalid byte count {n} for {want}-byte buffer")
 }
-
 fn trimTrailingCR(data: Bytes) -> Bytes {
     let n = data.len()
     if n > 0 && data[n - 1] == carriageReturnByte() {
@@ -121,7 +146,6 @@ fn trimTrailingCR(data: Bytes) -> Bytes {
     }
     data
 }
-
 fn writeChunk(w: Writer, data: Bytes, op: String) -> Result<(), Error> {
     let total = data.len()
     let mut offset = 0
@@ -135,16 +159,13 @@ fn writeChunk(w: Writer, data: Bytes, op: String) -> Result<(), Error> {
     }
     Ok(())
 }
-
 pub struct BytesReader {
     data: Bytes,
     offset: Int,
     closed: Bool,
-
     pub fn len(self) -> Int {
         self.data.len()
     }
-
     pub fn remaining(self) -> Int {
         let total = self.data.len()
         if self.offset >= total {
@@ -152,15 +173,12 @@ pub struct BytesReader {
         }
         total - self.offset
     }
-
     pub fn isClosed(self) -> Bool {
         self.closed
     }
-
     pub fn rewind(mut self) {
         self.offset = 0
     }
-
     pub fn peek(self, maxBytes: Int) -> Result<Bytes, Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -175,13 +193,15 @@ pub struct BytesReader {
         let start = self.offset
         Ok(bytes.slice(self.data, start, start + take))
     }
-
     pub fn remainingBytes(self) -> Bytes {
         let total = self.data.len()
-        let start = if self.offset < total { self.offset } else { total }
+        let start = if self.offset < total {
+            self.offset
+        } else {
+            total
+        }
         bytes.slice(self.data, start, total)
     }
-
     pub fn readByte(mut self) -> Result<Byte?, Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -193,7 +213,6 @@ pub struct BytesReader {
         self.offset = self.offset + 1
         Ok(Some(out))
     }
-
     pub fn unreadByte(mut self) -> Result<(), Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -204,7 +223,6 @@ pub struct BytesReader {
         self.offset = self.offset - 1
         Ok(())
     }
-
     pub fn skip(mut self, n: Int) -> Result<Int, Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -216,7 +234,6 @@ pub struct BytesReader {
         self.offset = self.offset + skipped
         Ok(skipped)
     }
-
     pub fn readLineBytes(mut self) -> Result<Bytes?, Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -237,14 +254,12 @@ pub struct BytesReader {
         self.offset = total
         Ok(Some(trimTrailingCR(bytes.slice(self.data, start, total))))
     }
-
     pub fn readLine(mut self) -> Result<String?, Error> {
         match self.readLineBytes()? {
             Some(line) -> Ok(Some(line.toString()?)),
-            None       -> Ok(None),
+            None -> Ok(None),
         }
     }
-
     pub fn read(mut self, maxBytes: Int) -> Result<Bytes, Error> {
         if self.closed {
             return Err(closedError("bytesReader"))
@@ -261,46 +276,36 @@ pub struct BytesReader {
         self.offset = end
         Ok(bytes.slice(self.data, start, end))
     }
-
     pub fn close(mut self) -> Result<(), Error> {
         self.closed = true
         Ok(())
     }
 }
-
 pub struct Buffer {
     buf: List<Byte>,
     closed: Bool,
-
     pub fn len(self) -> Int {
         self.buf.len()
     }
-
     pub fn isEmpty(self) -> Bool {
         self.buf.isEmpty()
     }
-
     pub fn isClosed(self) -> Bool {
         self.closed
     }
-
     pub fn bytes(self) -> Bytes {
         bytes.from(self.buf)
     }
-
     pub fn toString(self) -> Result<String, Error> {
         self.bytes().toString()
     }
-
     pub fn clear(mut self) {
         self.buf = []
     }
-
     pub fn reset(mut self) {
         self.buf = []
         self.closed = false
     }
-
     pub fn truncate(mut self, n: Int) {
         let limit = if n <= 0 {
             0
@@ -313,11 +318,9 @@ pub struct Buffer {
             self.buf.removeAt(self.buf.len() - 1)
         }
     }
-
     pub fn reader(self) -> BytesReader {
         bytesReader(self.bytes())
     }
-
     pub fn write(mut self, data: Bytes) -> Result<Int, Error> {
         if self.closed {
             return Err(closedError("buffer"))
@@ -328,7 +331,6 @@ pub struct Buffer {
         }
         Ok(n)
     }
-
     pub fn writeByte(mut self, b: Byte) -> Result<Int, Error> {
         if self.closed {
             return Err(closedError("buffer"))
@@ -336,16 +338,13 @@ pub struct Buffer {
         self.buf.push(b)
         Ok(1)
     }
-
     pub fn writeString(mut self, s: String) -> Result<Int, Error> {
         self.write(bytes.fromString(s))
     }
-
     pub fn writeLine(mut self, s: String) -> Result<Int, Error> {
         let text = "{s}\n"
         self.write(bytes.fromString(text))
     }
-
     pub fn readFrom(mut self, r: Reader) -> Result<Int, Error> {
         if self.closed {
             return Err(closedError("buffer"))
@@ -363,36 +362,29 @@ pub struct Buffer {
             total = total + n
         }
     }
-
     pub fn writeTo(self, w: Writer) -> Result<Int, Error> {
         let data = self.bytes()
         writeChunk(w, data, "buffer.writeTo")?
         w.flush()?
         Ok(data.len())
     }
-
     pub fn flush(self) -> Result<(), Error> {
         Ok(())
     }
-
     pub fn close(mut self) -> Result<(), Error> {
         self.closed = true
         Ok(())
     }
 }
-
 pub fn bytesReader(data: Bytes) -> BytesReader {
-    BytesReader { data: data, offset: 0, closed: false }
+    BytesReader {data: data, offset: 0, closed: false}
 }
-
 pub fn stringReader(s: String) -> BytesReader {
     bytesReader(bytes.fromString(s))
 }
-
 pub fn buffer() -> Buffer {
-    Buffer { buf: [], closed: false }
+    Buffer {buf: [], closed: false}
 }
-
 pub fn copy(dst: Writer, src: Reader) -> Result<Int, Error> {
     let mut total = 0
     for {
@@ -407,7 +399,6 @@ pub fn copy(dst: Writer, src: Reader) -> Result<Int, Error> {
     dst.flush()?
     Ok(total)
 }
-
 pub fn readAll(r: Reader) -> Result<Bytes, Error> {
     let mut out: List<Byte> = []
     for {
@@ -422,13 +413,11 @@ pub fn readAll(r: Reader) -> Result<Bytes, Error> {
     }
     Ok(bytes.from(out))
 }
-
 pub fn writeAll(w: Writer, data: Bytes) -> Result<(), Error> {
     writeChunk(w, data, "writeAll")?
     w.flush()?
     Ok(())
 }
-
 pub fn copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error> {
     if n <= 0 {
         return Ok(0)
@@ -447,7 +436,6 @@ pub fn copyN(dst: Writer, src: Reader, n: Int) -> Result<Int, Error> {
     dst.flush()?
     Ok(total)
 }
-
 pub fn readExact(r: Reader, n: Int) -> Result<Bytes, Error> {
     if n <= 0 {
         return Ok(emptyBytes())
@@ -468,7 +456,6 @@ pub fn readExact(r: Reader, n: Int) -> Result<Bytes, Error> {
     }
     Ok(bytes.from(out))
 }
-
 pub fn discard(r: Reader) -> Result<Int, Error> {
     let mut total = 0
     for {
@@ -480,11 +467,9 @@ pub fn discard(r: Reader) -> Result<Int, Error> {
         total = total + n
     }
 }
-
 pub fn readString(r: Reader) -> Result<String, Error> {
     readAll(r)?.toString()
 }
-
 pub fn readLines(r: Reader) -> Result<List<String>, Error> {
     let text = readString(r)?
     let raw = strings.lines(text)
@@ -502,7 +487,6 @@ pub fn readLines(r: Reader) -> Result<List<String>, Error> {
     }
     Ok(out)
 }
-
 pub fn readAllLines(r: LineReader) -> Result<List<String>, Error> {
     let mut out: List<String> = []
     let mut line = r.readLine()?
@@ -512,15 +496,12 @@ pub fn readAllLines(r: LineReader) -> Result<List<String>, Error> {
     }
     Ok(out)
 }
-
 pub fn writeString(w: Writer, s: String) -> Result<(), Error> {
     writeAll(w, bytes.fromString(s))
 }
-
 pub fn writeLine(w: Writer, s: String) -> Result<(), Error> {
     writeAll(w, bytes.concat(bytes.fromString(s), newlineBytes()))
 }
-
 pub fn writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error> {
     let mut total = 0
     for line in lines {
@@ -529,13 +510,8 @@ pub fn writeLines(w: ByteWriter, lines: List<String>) -> Result<Int, Error> {
     w.flush()?
     Ok(total)
 }
-
 pub fn print(s: String)
-
 pub fn println(s: String)
-
 pub fn eprint(s: String)
-
 pub fn eprintln(s: String)
-
 pub fn readLine() -> String

--- a/internal/stdlib/modules/net.osty
+++ b/internal/stdlib/modules/net.osty
@@ -12,7 +12,6 @@
 //   - UdpSocket                     — UDP datagram socket
 //   - tcpConnect / tcpListen / udpBind
 //   - lookup / lookupAddr           — DNS forward and reverse resolution
-
 use std.strings
 use std.error
 use c "osty_runtime" as rt {
@@ -39,35 +38,54 @@ use c "osty_runtime" as rt {
     fn osty_rt_net_tcp_listener_local_addr(handle: Int64) -> String
     fn osty_rt_net_tcp_listener_close(handle: Int64)
 }
-
+pub struct HostNet {
+    pub profile: String,
+    pub fn resolve(self, addr: String) -> Result<Addr, Error> {
+        resolve(addr)
+    }
+    pub fn resolveAll(self, host: String) -> Result<List<Addr>, Error> {
+        resolveAll(host)
+    }
+    pub fn lookup(self, host: String) -> Result<List<IpAddr>, Error> {
+        lookup(host)
+    }
+    pub fn lookupAddr(self, ip: IpAddr) -> Result<List<String>, Error> {
+        lookupAddr(ip)
+    }
+    pub fn connect(self, addr: String) -> Result<TcpConn, Error> {
+        connect(addr)
+    }
+    pub fn connectTimeout(self, addr: String, timeoutMs: Int) -> Result<TcpConn, Error> {
+        connectTimeout(addr, timeoutMs)
+    }
+    pub fn listen(self, addr: String) -> Result<TcpListener, Error> {
+        listen(addr)
+    }
+}
+pub fn host() -> HostNet {
+    HostNet {profile: "host"}
+}
 // ── IPv4 addresses ────────────────────────────────────────────────────────────
-
 pub struct Ipv4Addr {
     pub a: Int,
     pub b: Int,
     pub c: Int,
     pub d: Int,
-
     pub fn toString(self) -> String {
         "{self.a}.{self.b}.{self.c}.{self.d}"
     }
-
     pub fn toBytes(self) -> List<Int> {
         [self.a, self.b, self.c, self.d]
     }
-
     pub fn toUInt32(self) -> Int {
         ((self.a & 0xFF) << 24) | ((self.b & 0xFF) << 16) | ((self.c & 0xFF) << 8) | (self.d & 0xFF)
     }
-
     pub fn toIp(self) -> IpAddr {
         V4(self)
     }
-
     pub fn isLoopback(self) -> Bool {
         self.a == 127
     }
-
     pub fn isPrivate(self) -> Bool {
         if self.a == 10 {
             return true
@@ -80,23 +98,18 @@ pub struct Ipv4Addr {
         }
         false
     }
-
     pub fn isMulticast(self) -> Bool {
         self.a >= 224 && self.a <= 239
     }
-
     pub fn isLinkLocal(self) -> Bool {
         self.a == 169 && self.b == 254
     }
-
     pub fn isUnspecified(self) -> Bool {
         self.a == 0 && self.b == 0 && self.c == 0 && self.d == 0
     }
-
     pub fn isBroadcast(self) -> Bool {
         self.a == 255 && self.b == 255 && self.c == 255 && self.d == 255
     }
-
     pub fn isDocumentation(self) -> Bool {
         if self.a == 192 && self.b == 0 && self.c == 2 {
             return true
@@ -109,15 +122,12 @@ pub struct Ipv4Addr {
         }
         false
     }
-
     pub fn isShared(self) -> Bool {
         self.a == 100 && self.b >= 64 && self.b <= 127
     }
-
     pub fn isBenchmarking(self) -> Bool {
         self.a == 198 && (self.b == 18 || self.b == 19)
     }
-
     pub fn isReserved(self) -> Bool {
         if self.a == 0 {
             return true
@@ -133,7 +143,6 @@ pub struct Ipv4Addr {
         }
         false
     }
-
     pub fn isGlobalUnicast(self) -> Bool {
         if self.isLoopback() {
             return false
@@ -168,21 +177,12 @@ pub struct Ipv4Addr {
         true
     }
 }
-
 pub fn ipv4FromUInt32(n: Int) -> Ipv4Addr {
-    Ipv4Addr {
-        a: (n >> 24) & 0xFF,
-        b: (n >> 16) & 0xFF,
-        c: (n >> 8) & 0xFF,
-        d: n & 0xFF,
-    }
+    Ipv4Addr {a: (n >> 24) & 0xFF, b: (n >> 16) & 0xFF, c: (n >> 8) & 0xFF, d: n & 0xFF}
 }
-
 // ── IPv6 addresses ────────────────────────────────────────────────────────────
-
 pub struct Ipv6Addr {
     pub groups: List<Int>,
-
     pub fn toString(self) -> String {
         if let Some(addr) = self.toMappedIpv4() {
             return "::ffff:{addr}"
@@ -249,60 +249,42 @@ pub struct Ipv6Addr {
         }
         out
     }
-
     pub fn toIp(self) -> IpAddr {
         V6(self)
     }
-
     pub fn isLoopback(self) -> Bool {
         let g = self.groups
-        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 &&
-        g[4] == 0 && g[5] == 0 && g[6] == 0 && g[7] == 1
+        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 && g[4] == 0 && g[5] == 0 && g[6] == 0 && g[7] == 1
     }
-
     pub fn isUnspecified(self) -> Bool {
         let g = self.groups
-        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 &&
-        g[4] == 0 && g[5] == 0 && g[6] == 0 && g[7] == 0
+        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 && g[4] == 0 && g[5] == 0 && g[6] == 0 && g[7] == 0
     }
-
     pub fn isMulticast(self) -> Bool {
         (self.groups[0] >> 8) == 0xFF
     }
-
     pub fn isLinkLocal(self) -> Bool {
         (self.groups[0] & 0xFFC0) == 0xFE80
     }
-
     pub fn isUniqueLocal(self) -> Bool {
         (self.groups[0] & 0xFE00) == 0xFC00
     }
-
     pub fn isDocumentation(self) -> Bool {
         self.groups[0] == 0x2001 && self.groups[1] == 0x0DB8
     }
-
     pub fn isMappedIpv4(self) -> Bool {
         let g = self.groups
-        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 &&
-        g[4] == 0 && g[5] == 0xFFFF
+        g[0] == 0 && g[1] == 0 && g[2] == 0 && g[3] == 0 && g[4] == 0 && g[5] == 0xFFFF
     }
-
     pub fn toMappedIpv4(self) -> Ipv4Addr? {
         if self.isMappedIpv4() {
             let hi = self.groups[6]
             let lo = self.groups[7]
-            Some(Ipv4Addr {
-                a: (hi >> 8) & 0xFF,
-                b: hi & 0xFF,
-                c: (lo >> 8) & 0xFF,
-                d: lo & 0xFF,
-            })
+            Some(Ipv4Addr {a: (hi >> 8) & 0xFF, b: hi & 0xFF, c: (lo >> 8) & 0xFF, d: lo & 0xFF})
         } else {
             None
         }
     }
-
     pub fn isGlobalUnicast(self) -> Bool {
         if let Some(addr) = self.toMappedIpv4() {
             return addr.isGlobalUnicast()
@@ -328,69 +310,58 @@ pub struct Ipv6Addr {
         true
     }
 }
-
 // ── IpAddr ────────────────────────────────────────────────────────────────────
-
 pub enum IpAddr {
     V4(Ipv4Addr),
     V6(Ipv6Addr),
-
     pub fn toString(self) -> String {
         match self {
             V4(addr) -> addr.toString(),
             V6(addr) -> addr.toString(),
         }
     }
-
     pub fn isLoopback(self) -> Bool {
         match self {
             V4(addr) -> addr.isLoopback(),
             V6(addr) -> addr.isLoopback(),
         }
     }
-
     pub fn isUnspecified(self) -> Bool {
         match self {
             V4(addr) -> addr.isUnspecified(),
             V6(addr) -> addr.isUnspecified(),
         }
     }
-
     pub fn isMulticast(self) -> Bool {
         match self {
             V4(addr) -> addr.isMulticast(),
             V6(addr) -> addr.isMulticast(),
         }
     }
-
     pub fn isGlobalUnicast(self) -> Bool {
         match self {
             V4(addr) -> addr.isGlobalUnicast(),
             V6(addr) -> addr.isGlobalUnicast(),
         }
     }
-
     pub fn isV4(self) -> Bool {
         match self {
             V4(_) -> true,
             V6(_) -> false,
         }
     }
-
     pub fn isV6(self) -> Bool {
         match self {
             V4(_) -> false,
             V6(_) -> true,
         }
     }
-
     pub fn asV4(self) -> Ipv4Addr? {
         match self {
             V4(addr) -> Some(addr),
             V6(_) -> None,
         }
     }
-
     pub fn asV6(self) -> Ipv6Addr? {
         match self {
             V4(_) -> None,
@@ -398,76 +369,64 @@ pub enum IpAddr {
         }
     }
 }
-
 // ── SocketAddr ────────────────────────────────────────────────────────────────
-
 pub struct SocketAddr {
     pub ip: IpAddr,
     pub port: Int,
-
     pub fn toString(self) -> String {
         match self.ip {
             V4(_) -> "{self.ip}:{self.port}",
             V6(_) -> "[{self.ip}]:{self.port}",
         }
     }
-
     pub fn isV4(self) -> Bool {
         self.ip.isV4()
     }
-
     pub fn isV6(self) -> Bool {
         self.ip.isV6()
     }
 }
-
 pub struct Addr {
     pub host: String,
     pub port: Int,
-
     pub fn toString(self) -> String {
         if strings.contains(self.host, ":") {
             return "[{self.host}]:{self.port}"
         }
         "{self.host}:{self.port}"
     }
-
     pub fn toSocketAddr(self) -> Result<SocketAddr, Error> {
         let ip = parseIp(self.host)?
-        Ok(SocketAddr { ip, port: self.port })
+        Ok(SocketAddr {ip, port: self.port})
     }
 }
-
 // ── IPv4 CIDR network blocks ──────────────────────────────────────────────────
-
 pub struct Ipv4Net {
     pub addr: Ipv4Addr,
     pub prefixLen: Int,
-
     pub fn toString(self) -> String {
         "{self.addr}/{self.prefixLen}"
     }
-
     pub fn mask(self) -> Ipv4Addr {
         ipv4FromUInt32(cidrMask(self.prefixLen))
     }
-
     pub fn network(self) -> Ipv4Addr {
         ipv4FromUInt32(self.addr.toUInt32() & cidrMask(self.prefixLen))
     }
-
     pub fn broadcast(self) -> Ipv4Addr {
         let net = self.addr.toUInt32() & cidrMask(self.prefixLen)
         let hostBits = 32 - self.prefixLen
-        let hostMask = if hostBits == 0 { 0 } else { pow2(hostBits) - 1 }
+        let hostMask = if hostBits == 0 {
+            0
+        } else {
+            pow2(hostBits) - 1
+        }
         ipv4FromUInt32(net | hostMask)
     }
-
     pub fn contains(self, addr: Ipv4Addr) -> Bool {
         let m = cidrMask(self.prefixLen)
         (self.addr.toUInt32() & m) == (addr.toUInt32() & m)
     }
-
     pub fn hostCount(self) -> Int {
         if self.prefixLen >= 32 {
             return 1
@@ -478,18 +437,13 @@ pub struct Ipv4Net {
         pow2(32 - self.prefixLen) - 2
     }
 }
-
 // ── Well-known addresses ──────────────────────────────────────────────────────
-
-pub let LOCALHOST_V4: Ipv4Addr = Ipv4Addr { a: 127, b: 0, c: 0, d: 1 }
-pub let UNSPECIFIED_V4: Ipv4Addr = Ipv4Addr { a: 0, b: 0, c: 0, d: 0 }
-pub let BROADCAST_V4: Ipv4Addr = Ipv4Addr { a: 255, b: 255, c: 255, d: 255 }
-
-pub let LOCALHOST_V6: Ipv6Addr = Ipv6Addr { groups: [0, 0, 0, 0, 0, 0, 0, 1] }
-pub let UNSPECIFIED_V6: Ipv6Addr = Ipv6Addr { groups: [0, 0, 0, 0, 0, 0, 0, 0] }
-
+pub let LOCALHOST_V4: Ipv4Addr = Ipv4Addr {a: 127, b: 0, c: 0, d: 1}
+pub let UNSPECIFIED_V4: Ipv4Addr = Ipv4Addr {a: 0, b: 0, c: 0, d: 0}
+pub let BROADCAST_V4: Ipv4Addr = Ipv4Addr {a: 255, b: 255, c: 255, d: 255}
+pub let LOCALHOST_V6: Ipv6Addr = Ipv6Addr {groups: [0, 0, 0, 0, 0, 0, 0, 1]}
+pub let UNSPECIFIED_V6: Ipv6Addr = Ipv6Addr {groups: [0, 0, 0, 0, 0, 0, 0, 0]}
 // ── Parsing ───────────────────────────────────────────────────────────────────
-
 pub fn parseIpv4(text: String) -> Result<Ipv4Addr, Error> {
     let parts = strings.split(text, ".")
     if parts.len() != 4 {
@@ -499,9 +453,8 @@ pub fn parseIpv4(text: String) -> Result<Ipv4Addr, Error> {
     let b = parseOctet(parts[1])?
     let c = parseOctet(parts[2])?
     let d = parseOctet(parts[3])?
-    Ok(Ipv4Addr { a, b, c, d })
+    Ok(Ipv4Addr {a, b, c, d})
 }
-
 pub fn parseIpv6(text: String) -> Result<Ipv6Addr, Error> {
     let dcIdx = findDoubleColon(text)
     if dcIdx != -1 {
@@ -533,15 +486,14 @@ pub fn parseIpv6(text: String) -> Result<Ipv6Addr, Error> {
         for g in rightGroups {
             groups.push(g)
         }
-        return Ok(Ipv6Addr { groups })
+        return Ok(Ipv6Addr {groups})
     }
     let groups = parseHexGroups(text)?
     if groups.len() != 8 {
         return Err(error.new("net: IPv6 address must have 8 groups: {text}"))
     }
-    Ok(Ipv6Addr { groups })
+    Ok(Ipv6Addr {groups})
 }
-
 pub fn parseIp(text: String) -> Result<IpAddr, Error> {
     if strings.contains(text, ":") {
         let addr = parseIpv6(text)?
@@ -550,20 +502,17 @@ pub fn parseIp(text: String) -> Result<IpAddr, Error> {
     let addr = parseIpv4(text)?
     Ok(V4(addr))
 }
-
 pub fn parseSocketAddr(text: String) -> Result<SocketAddr, Error> {
     let (host, portStr) = splitHostPort(text)?
     let port = parsePort(portStr)?
     let ip = parseIp(host)?
-    Ok(SocketAddr { ip, port })
+    Ok(SocketAddr {ip, port})
 }
-
 pub fn parseAddr(text: String) -> Result<Addr, Error> {
     let (host, portStr) = splitHostPort(text)?
     let port = parsePort(portStr)?
-    Ok(Addr { host, port })
+    Ok(Addr {host, port})
 }
-
 pub fn parseCidr(text: String) -> Result<Ipv4Net, Error> {
     let slashIdx = findChar(text, '/')
     if slashIdx == -1 {
@@ -576,9 +525,8 @@ pub fn parseCidr(text: String) -> Result<Ipv4Net, Error> {
     if prefixLen < 0 || prefixLen > 32 {
         return Err(error.new("net: invalid prefix length: {lenPart}"))
     }
-    Ok(Ipv4Net { addr, prefixLen })
+    Ok(Ipv4Net {addr, prefixLen})
 }
-
 pub fn splitHostPort(hostport: String) -> Result<(String, String), Error> {
     if hostport.isEmpty() {
         return Err(error.new("net: empty address"))
@@ -620,37 +568,33 @@ pub fn splitHostPort(hostport: String) -> Result<(String, String), Error> {
     }
     Ok((host, port))
 }
-
 pub fn resolve(addr: String) -> Result<Addr, Error> {
     let parsed = parseAddr(addr)?
     match parseIp(parsed.host) {
-        Ok(ip) -> Ok(Addr { host: ip.toString(), port: parsed.port }),
+        Ok(ip) -> Ok(Addr {host: ip.toString(), port: parsed.port}),
         Err(_) -> {
             let ips = lookup(parsed.host)?
             if ips.isEmpty() {
                 return Err(error.new("net: no addresses found for host: {parsed.host}"))
             }
-            Ok(Addr { host: ips[0].toString(), port: parsed.port })
+            Ok(Addr {host: ips[0].toString(), port: parsed.port})
         },
     }
 }
-
 pub fn resolveAll(host: String) -> Result<List<Addr>, Error> {
     match parseIp(host) {
-        Ok(ip) -> Ok([Addr { host: ip.toString(), port: 0 }]),
+        Ok(ip) -> Ok([Addr {host: ip.toString(), port: 0}]),
         Err(_) -> {
             let ips = lookup(host)?
             let mut out: List<Addr> = []
             for ip in ips {
-                out.push(Addr { host: ip.toString(), port: 0 })
+                out.push(Addr {host: ip.toString(), port: 0})
             }
             Ok(out)
         },
     }
 }
-
 // ── DNS (runtime-bridged) ─────────────────────────────────────────────────────
-
 pub fn lookup(host: String) -> Result<List<IpAddr>, Error> {
     let texts = rt.osty_rt_net_lookup_text(host)
     if rt.osty_rt_net_failed() {
@@ -662,45 +606,34 @@ pub fn lookup(host: String) -> Result<List<IpAddr>, Error> {
     }
     Ok(out)
 }
-
 pub fn lookupAddr(ip: IpAddr) -> Result<List<String>, Error> {
     netStringListResult(rt.osty_rt_net_lookup_addr(ip.toString()))
 }
-
 // ── TCP (runtime-bridged) ─────────────────────────────────────────────────────
-
 pub type TcpConn = TcpStream
-
 pub struct TcpStream {
     rawHandle: Int64,
-
     pub fn read(self, maxBytes: Int) -> Result<Bytes, Error> {
         netBytesResult(rt.osty_rt_net_tcp_read(self.rawHandle, maxBytes))
     }
-
     pub fn readExact(self, n: Int) -> Result<Bytes, Error> {
         netBytesResult(rt.osty_rt_net_tcp_read_exact(self.rawHandle, n))
     }
-
     pub fn write(self, data: Bytes) -> Result<Int, Error> {
         netIntResult(rt.osty_rt_net_tcp_write(self.rawHandle, data))
     }
-
     pub fn writeAll(self, data: Bytes) -> Result<(), Error> {
         rt.osty_rt_net_tcp_write_all(self.rawHandle, data)
         netUnitResult()
     }
-
     pub fn flush(self) -> Result<(), Error> {
         rt.osty_rt_net_tcp_flush(self.rawHandle)
         netUnitResult()
     }
-
     pub fn close(self) -> Result<(), Error> {
         rt.osty_rt_net_tcp_close(self.rawHandle)
         netUnitResult()
     }
-
     pub fn localAddr(self) -> Result<SocketAddr, Error> {
         let text = rt.osty_rt_net_tcp_local_addr(self.rawHandle)
         if rt.osty_rt_net_failed() {
@@ -708,7 +641,6 @@ pub struct TcpStream {
         }
         parseSocketAddr(text)
     }
-
     pub fn peerAddr(self) -> Result<SocketAddr, Error> {
         let text = rt.osty_rt_net_tcp_peer_addr(self.rawHandle)
         if rt.osty_rt_net_failed() {
@@ -716,56 +648,45 @@ pub struct TcpStream {
         }
         parseSocketAddr(text)
     }
-
     pub fn setReadTimeout(self, ms: Int?) -> Result<(), Error> {
         rt.osty_rt_net_tcp_set_read_timeout(self.rawHandle, netTimeoutValue(ms))
         netUnitResult()
     }
-
     pub fn setWriteTimeout(self, ms: Int?) -> Result<(), Error> {
         rt.osty_rt_net_tcp_set_write_timeout(self.rawHandle, netTimeoutValue(ms))
         netUnitResult()
     }
-
     pub fn setNoDelay(self, on: Bool) -> Result<(), Error> {
         rt.osty_rt_net_tcp_set_nodelay(self.rawHandle, on)
         netUnitResult()
     }
-
     pub fn setKeepAlive(self, on: Bool) -> Result<(), Error> {
         rt.osty_rt_net_tcp_set_keepalive(self.rawHandle, on)
         netUnitResult()
     }
-
     pub fn send(self, data: Bytes) -> Result<Int, Error> {
         self.write(data)
     }
-
     pub fn sendAll(self, data: Bytes) -> Result<(), Error> {
         self.writeAll(data)
     }
-
     pub fn recv(self, maxBytes: Int) -> Result<Bytes, Error> {
         self.read(maxBytes)
     }
-
     pub fn remoteAddr(self) -> Result<Addr, Error> {
         let addr = self.peerAddr()?
         Ok(socketAddrToAddr(addr))
     }
 }
-
 pub struct TcpListener {
     rawHandle: Int64,
-
     pub fn accept(self) -> Result<TcpStream, Error> {
         let handle = rt.osty_rt_net_tcp_accept(self.rawHandle)
         if rt.osty_rt_net_failed() {
             return Err(netError())
         }
-        Ok(TcpStream { rawHandle: handle })
+        Ok(TcpStream {rawHandle: handle})
     }
-
     pub fn localAddr(self) -> Result<SocketAddr, Error> {
         let text = rt.osty_rt_net_tcp_listener_local_addr(self.rawHandle)
         if rt.osty_rt_net_failed() {
@@ -773,54 +694,45 @@ pub struct TcpListener {
         }
         parseSocketAddr(text)
     }
-
     pub fn close(self) -> Result<(), Error> {
         rt.osty_rt_net_tcp_listener_close(self.rawHandle)
         netUnitResult()
     }
 }
-
 pub fn tcpConnect(addr: String) -> Result<TcpStream, Error> {
     let parsed = parseAddr(addr)?
     let handle = rt.osty_rt_net_tcp_connect(parsed.host, parsed.port)
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
-    Ok(TcpStream { rawHandle: handle })
+    Ok(TcpStream {rawHandle: handle})
 }
-
 pub fn tcpConnectTimeout(addr: String, timeoutMs: Int) -> Result<TcpStream, Error> {
     let parsed = parseAddr(addr)?
     let handle = rt.osty_rt_net_tcp_connect_timeout(parsed.host, parsed.port, timeoutMs)
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
-    Ok(TcpStream { rawHandle: handle })
+    Ok(TcpStream {rawHandle: handle})
 }
-
 pub fn tcpListen(addr: String) -> Result<TcpListener, Error> {
     let parsed = parseAddr(addr)?
     let handle = rt.osty_rt_net_tcp_listen(parsed.host, parsed.port)
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
-    Ok(TcpListener { rawHandle: handle })
+    Ok(TcpListener {rawHandle: handle})
 }
-
 pub fn connect(addr: String) -> Result<TcpConn, Error> {
     tcpConnect(addr)
 }
-
 pub fn connectTimeout(addr: String, timeoutMs: Int) -> Result<TcpConn, Error> {
     tcpConnectTimeout(addr, timeoutMs)
 }
-
 pub fn listen(addr: String) -> Result<TcpListener, Error> {
     tcpListen(addr)
 }
-
 // ── UDP (runtime-bridged) ─────────────────────────────────────────────────────
-
 pub struct UdpSocket {
     pub fn send(self, data: Bytes, addr: String) -> Result<Int, Error>
     pub fn sendTo(self, data: Bytes, addr: SocketAddr) -> Result<Int, Error>
@@ -833,68 +745,56 @@ pub struct UdpSocket {
     pub fn leaveMulticastV4(self, group: Ipv4Addr, iface: Ipv4Addr) -> Result<(), Error>
     pub fn setMulticastTtl(self, ttl: Int) -> Result<(), Error>
 }
-
 pub fn udpBind(addr: String) -> Result<UdpSocket, Error>
-
 // ── Internal helpers ──────────────────────────────────────────────────────────
-
 fn socketAddrToAddr(addr: SocketAddr) -> Addr {
-    Addr { host: addr.ip.toString(), port: addr.port }
+    Addr {host: addr.ip.toString(), port: addr.port}
 }
-
 fn netError() -> Error {
     error.new(rt.osty_rt_net_last_error())
 }
-
 fn netUnitResult() -> Result<(), Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(())
 }
-
 fn netBytesResult(data: Bytes) -> Result<Bytes, Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(data)
 }
-
 fn netStringResult(text: String) -> Result<String, Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(text)
 }
-
 fn netStringListResult(items: List<String>) -> Result<List<String>, Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(items)
 }
-
 fn netIntResult(n: Int) -> Result<Int, Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(n)
 }
-
 fn netHandleResult(handle: Int64) -> Result<Int64, Error> {
     if rt.osty_rt_net_failed() {
         return Err(netError())
     }
     Ok(handle)
 }
-
 fn netTimeoutValue(ms: Int?) -> Int {
     match ms {
         Some(timeout) -> timeout,
-        None          -> -1,
+        None -> -1,
     }
 }
-
 fn parseOctet(s: String) -> Result<Int, Error> {
     let n = parseDecInt(s)?
     if n < 0 || n > 255 {
@@ -902,7 +802,6 @@ fn parseOctet(s: String) -> Result<Int, Error> {
     }
     Ok(n)
 }
-
 fn parsePort(s: String) -> Result<Int, Error> {
     let port = parseDecInt(s)?
     if port < 0 || port > 65535 {
@@ -910,7 +809,6 @@ fn parsePort(s: String) -> Result<Int, Error> {
     }
     Ok(port)
 }
-
 fn parseDecInt(s: String) -> Result<Int, Error> {
     if s.isEmpty() {
         return Err(error.new("net: empty number string"))
@@ -929,7 +827,6 @@ fn parseDecInt(s: String) -> Result<Int, Error> {
     }
     Ok(result)
 }
-
 fn parseHexGroups(text: String) -> Result<List<Int>, Error> {
     let parts = strings.split(text, ":")
     let mut groups: List<Int> = []
@@ -958,7 +855,6 @@ fn parseHexGroups(text: String) -> Result<List<Int>, Error> {
     }
     Ok(groups)
 }
-
 fn parseHexInt(s: String) -> Result<Int, Error> {
     if s.isEmpty() {
         return Err(error.new("net: empty hex string"))
@@ -973,7 +869,6 @@ fn parseHexInt(s: String) -> Result<Int, Error> {
     }
     Ok(result)
 }
-
 fn hexDigitValue(c: Char) -> Result<Int, Error> {
     if c >= '0' && c <= '9' {
         return Ok(c.toInt() - '0'.toInt())
@@ -986,7 +881,6 @@ fn hexDigitValue(c: Char) -> Result<Int, Error> {
     }
     Err(error.new("net: invalid hex digit: {c}"))
 }
-
 fn intToLowHex(val: Int) -> String {
     if val == 0 {
         return "0"
@@ -1001,7 +895,6 @@ fn intToLowHex(val: Int) -> String {
     }
     result
 }
-
 fn findDoubleColon(s: String) -> Int {
     let chars = s.chars()
     let len = chars.len()
@@ -1017,7 +910,6 @@ fn findDoubleColon(s: String) -> Int {
     }
     -1
 }
-
 fn findChar(s: String, target: Char) -> Int {
     let chars = s.chars()
     let len = chars.len()
@@ -1030,7 +922,6 @@ fn findChar(s: String, target: Char) -> Int {
     }
     -1
 }
-
 fn lastIndexOfChar(s: String, target: Char) -> Int {
     let chars = s.chars()
     let len = chars.len()
@@ -1043,7 +934,6 @@ fn lastIndexOfChar(s: String, target: Char) -> Int {
     }
     -1
 }
-
 fn countChar(s: String, target: Char) -> Int {
     let chars = s.chars()
     let mut count = 0
@@ -1054,7 +944,6 @@ fn countChar(s: String, target: Char) -> Int {
     }
     count
 }
-
 fn cidrMask(prefix: Int) -> Int {
     if prefix == 0 {
         return 0
@@ -1072,7 +961,6 @@ fn cidrMask(prefix: Int) -> Int {
     }
     mask
 }
-
 fn pow2(n: Int) -> Int {
     let mut result = 1
     let mut i = 0

--- a/internal/stdlib/modules/process.osty
+++ b/internal/stdlib/modules/process.osty
@@ -10,37 +10,56 @@
 // can receive stdin text, capture stdout/stderr, and compose shell
 // pipelines where each stage's stdout streams into the next stage's
 // stdin.
-
 use std.error
 use std.os
-
+pub struct HostProcess {
+    pub profile: String,
+    pub fn pid(self) -> Int {
+        os.pid()
+    }
+    pub fn hostname(self) -> Result<String, Error> {
+        os.hostname()
+    }
+    pub fn command(self, program: String) -> ProcessCommand {
+        command(program)
+    }
+    pub fn commandArgs(self, program: String, args: List<String>) -> ProcessCommand {
+        commandArgs(program, args)
+    }
+    pub fn shell(self, line: String) -> ProcessCommand {
+        shell(line)
+    }
+    pub fn run(self, command: ProcessCommand) -> Result<ProcessOutput, Error> {
+        command.run()
+    }
+    pub fn exec(self, command: String, args: List<String>) -> Result<os.Output, Error> {
+        os.exec(command, args)
+    }
+}
+pub fn host() -> HostProcess {
+    HostProcess {profile: "host"}
+}
 pub fn abort(msg: String) -> Never
-
 pub fn unreachable() -> Never
-
 pub fn todo(msg: String) -> Never
-
 pub fn ignoreError<T, E>(result: Result<T, E>) {
     let _ = result
 }
-
 pub fn logError<T>(result: Result<T, Error>, msg: String) {
     match result {
-        Ok(_) -> {},
+        Ok(_) -> {
+        },
         Err(err) -> eprintln("{msg}: {err.message()}"),
     }
 }
-
 pub struct ProcessOutput {
     pub exitCode: Int,
     pub stdout: String,
     pub stderr: String,
     pub timedOut: Bool,
-
     pub fn ok(self) -> Bool {
         self.exitCode == 0 && !self.timedOut
     }
-
     pub fn check(self) -> Result<ProcessOutput, Error> {
         if self.ok() {
             Ok(self)
@@ -51,7 +70,6 @@ pub struct ProcessOutput {
         }
     }
 }
-
 pub struct ProcessCommand {
     pub program: String,
     pub args: List<String>,
@@ -61,47 +79,38 @@ pub struct ProcessCommand {
     pub useShell: Bool,
     pub stdin: String,
     pub hasStdin: Bool,
-
     pub fn arg(mut self, value: String) -> ProcessCommand {
         self.args.push(value)
         self
     }
-
     pub fn withArgs(mut self, values: List<String>) -> ProcessCommand {
         self.args = values
         self
     }
-
     pub fn withCwd(mut self, path: String) -> ProcessCommand {
         self.cwd = path
         self
     }
-
     pub fn withEnv(mut self, name: String, value: String) -> ProcessCommand {
         self.env.insert(name, value)
         self
     }
-
     pub fn withEnvMap(mut self, values: Map<String, String>) -> ProcessCommand {
         self.env = values
         self
     }
-
     pub fn withTimeoutMillis(mut self, millis: Int) -> ProcessCommand {
         self.timeoutMillis = millis
         self
     }
-
     pub fn withStdin(mut self, text: String) -> ProcessCommand {
         self.stdin = text
         self.hasStdin = true
         self
     }
-
     pub fn pipe(self, next: ProcessCommand) -> ProcessPipeline {
         pipe(self, next)
     }
-
     pub fn run(self) -> Result<ProcessOutput, Error> {
         if self.hasStdin && self.useShell {
             return fromOs(os.execShellInputWith(self.program, self.stdin, self.cwd, self.env, self.timeoutMillis))
@@ -115,7 +124,6 @@ pub struct ProcessCommand {
             fromOs(os.execWith(self.program, self.args, self.cwd, self.env, self.timeoutMillis))
         }
     }
-
     pub fn shellLine(self) -> String {
         if self.useShell {
             return self.program
@@ -123,7 +131,6 @@ pub struct ProcessCommand {
         joinEscaped(self.program, self.args)
     }
 }
-
 pub struct ProcessPipeline {
     pub stages: List<ProcessCommand>,
     pub cwd: String,
@@ -131,42 +138,34 @@ pub struct ProcessPipeline {
     pub timeoutMillis: Int,
     pub stdin: String,
     pub hasStdin: Bool,
-
     pub fn stage(mut self, next: ProcessCommand) -> ProcessPipeline {
         self.stages.push(next)
         self
     }
-
     pub fn withCwd(mut self, path: String) -> ProcessPipeline {
         self.cwd = path
         self
     }
-
     pub fn withEnv(mut self, name: String, value: String) -> ProcessPipeline {
         self.env.insert(name, value)
         self
     }
-
     pub fn withEnvMap(mut self, values: Map<String, String>) -> ProcessPipeline {
         self.env = values
         self
     }
-
     pub fn withTimeoutMillis(mut self, millis: Int) -> ProcessPipeline {
         self.timeoutMillis = millis
         self
     }
-
     pub fn withStdin(mut self, text: String) -> ProcessPipeline {
         self.stdin = text
         self.hasStdin = true
         self
     }
-
     pub fn shellLine(self) -> Result<String, Error> {
         renderPipeline(self.stages)
     }
-
     pub fn run(self) -> Result<ProcessOutput, Error> {
         let line = renderPipeline(self.stages)?
         if self.hasStdin {
@@ -176,60 +175,27 @@ pub struct ProcessPipeline {
         }
     }
 }
-
 pub fn command(program: String) -> ProcessCommand {
-    ProcessCommand {
-        program: program,
-        args: [],
-        cwd: "",
-        env: {:},
-        timeoutMillis: 0,
-        useShell: false,
-        stdin: "",
-        hasStdin: false,
-    }
+    ProcessCommand {program: program, args: [], cwd: "", env: {:}, timeoutMillis: 0, useShell: false, stdin: "", hasStdin: false}
 }
-
 pub fn commandArgs(program: String, args: List<String>) -> ProcessCommand {
     command(program).withArgs(args)
 }
-
 pub fn shell(line: String) -> ProcessCommand {
-    ProcessCommand {
-        program: line,
-        args: [],
-        cwd: "",
-        env: {:},
-        timeoutMillis: 0,
-        useShell: true,
-        stdin: "",
-        hasStdin: false,
-    }
+    ProcessCommand {program: line, args: [], cwd: "", env: {:}, timeoutMillis: 0, useShell: true, stdin: "", hasStdin: false}
 }
-
 pub fn pipeline(stages: List<ProcessCommand>) -> ProcessPipeline {
-    ProcessPipeline {
-        stages: stages,
-        cwd: "",
-        env: {:},
-        timeoutMillis: 0,
-        stdin: "",
-        hasStdin: false,
-    }
+    ProcessPipeline {stages: stages, cwd: "", env: {:}, timeoutMillis: 0, stdin: "", hasStdin: false}
 }
-
 pub fn pipe(left: ProcessCommand, right: ProcessCommand) -> ProcessPipeline {
     pipeline([left, right])
 }
-
 pub fn run(program: String, args: List<String> = []) -> Result<ProcessOutput, Error> {
     commandArgs(program, args).run()
 }
-
 pub fn runShell(line: String) -> Result<ProcessOutput, Error> {
     shell(line).run()
 }
-
 pub fn shellEscape(arg: String) -> String {
     if arg.isEmpty() {
         return "''"
@@ -244,7 +210,6 @@ pub fn shellEscape(arg: String) -> String {
     }
     "{out}'"
 }
-
 pub fn joinEscaped(program: String, args: List<String>) -> String {
     let mut parts = [shellEscape(program)]
     for arg in args {
@@ -252,7 +217,6 @@ pub fn joinEscaped(program: String, args: List<String>) -> String {
     }
     " ".join(parts)
 }
-
 fn renderPipeline(stages: List<ProcessCommand>) -> Result<String, Error> {
     if stages.len() == 0 {
         return Err(error.new("process: pipeline requires at least one stage"))
@@ -263,15 +227,9 @@ fn renderPipeline(stages: List<ProcessCommand>) -> Result<String, Error> {
     }
     Ok(" | ".join(parts))
 }
-
 fn fromOs(result: Result<os.ExecOutput, Error>) -> Result<ProcessOutput, Error> {
     match result {
-        Ok(out) -> Ok(ProcessOutput {
-            exitCode: out.exitCode,
-            stdout: out.stdout,
-            stderr: out.stderr,
-            timedOut: out.timedOut,
-        }),
+        Ok(out) -> Ok(ProcessOutput {exitCode: out.exitCode, stdout: out.stdout, stderr: out.stderr, timedOut: out.timedOut}),
         Err(err) -> Err(err),
     }
 }

--- a/internal/stdlib/modules/random.osty
+++ b/internal/stdlib/modules/random.osty
@@ -37,4 +37,10 @@ pub struct Rng {
     }
 }
 pub fn default() -> Rng
+pub fn host() -> Rng {
+    default()
+}
 pub fn seeded(seed: Int64) -> Rng
+pub fn seededCapability(seed: Int64) -> Rng {
+    seeded(seed)
+}

--- a/internal/stdlib/modules/time.osty
+++ b/internal/stdlib/modules/time.osty
@@ -4,64 +4,49 @@
 // formatting are body-less; the backend lowers each call to the time
 // runtime. Pure arithmetic on `Instant` / `Duration` stays as Osty
 // code.
-
 pub let ISO_8601: String = "2006-01-02T15:04:05Z07:00"
 pub let RFC_3339: String = "2006-01-02T15:04:05Z07:00"
 pub let RFC_2822: String = "Mon, 02 Jan 2006 15:04:05 -0700"
-
 pub struct Duration {
     pub nanoseconds: Int64,
-
     pub fn abs(self) -> Duration {
         Duration { nanoseconds: self.nanoseconds.abs() }
     }
-
     pub fn micros(self) -> Int {
         let nanosPerMicro: Int64 = 1000
         self.nanoseconds / nanosPerMicro
     }
-
     pub fn millis(self) -> Int {
         let nanosPerMilli: Int64 = 1000000
         self.nanoseconds / nanosPerMilli
     }
-
     pub fn seconds(self) -> Int {
         let nanosPerSecond: Int64 = 1000000000
         self.nanoseconds / nanosPerSecond
     }
-
     pub fn toString(self) -> String
 }
-
 pub struct Instant {
     pub unixNanos: Int64,
-
     pub fn add(self, duration: Duration) -> Instant {
-        Instant { unixNanos: self.unixNanos + duration.nanoseconds }
+        Instant {unixNanos: self.unixNanos + duration.nanoseconds}
     }
-
     pub fn sub(self, other: Instant) -> Duration {
-        Duration { nanoseconds: self.unixNanos - other.unixNanos }
+        Duration {nanoseconds: self.unixNanos - other.unixNanos}
     }
-
     pub fn since(self, earlier: Instant) -> Duration {
         self.sub(earlier)
     }
-
     pub fn format(self, layout: String) -> String
-
     pub fn inZone(self, zone: Zone) -> ZonedTime {
-        ZonedTime { instant: self, zone: zone }
+        ZonedTime {instant: self, zone: zone}
     }
 }
-
 pub struct Zone {
     pub name: String,
     pub offset: Duration,
     pub isFixed: Bool,
 }
-
 pub enum Weekday {
     Mon,
     Tue,
@@ -71,40 +56,39 @@ pub enum Weekday {
     Sat,
     Sun,
 }
-
 pub struct ZonedTime {
     pub instant: Instant,
     pub zone: Zone,
-
     pub fn year(self) -> Int
-
     pub fn month(self) -> Int
-
     pub fn day(self) -> Int
-
     pub fn hour(self) -> Int
-
     pub fn minute(self) -> Int
-
     pub fn second(self) -> Int
-
     pub fn nanosecond(self) -> Int
-
     pub fn weekday(self) -> Weekday
-
     pub fn format(self, layout: String) -> String {
         self.instant.format(layout)
     }
 }
-
+pub struct HostClock {
+    pub startedAt: Instant,
+    pub fn now(self) -> Instant {
+        now()
+    }
+    pub fn monotonic(self) -> Duration {
+        now().sub(self.startedAt).abs()
+    }
+    pub fn sleep(self, duration: Duration) -> Result<(), Error> {
+        sleep(duration)
+    }
+}
+pub fn systemClock() -> HostClock {
+    HostClock {startedAt: now()}
+}
 pub fn now() -> Instant
-
 pub fn parse(text: String, layout: String) -> Result<Instant, Error>
-
 pub fn sleep(duration: Duration) -> Result<(), Error>
-
 pub fn zone(name: String) -> Result<Zone, Error>
-
 pub fn local() -> Zone
-
 pub fn utc() -> Zone


### PR DESCRIPTION
## Summary
- add v0.6 host-boundary adapter factories for Clock, Rng, Env, Fs, Net, Process, and Console capability migration
- add migration catalog helpers and exact Net/Process adapters in `std.capability`
- add `examples/v06_capability_adapters` and update v0.6 docs / stdlib matrix

## Validation
- `just build`
- `go test -count=1 -vet=off ./internal/stdlib`
- `just support-stdlib-fast`
- `.bin/osty check examples/v06_capability_adapters`
- `.bin/osty check examples/v06_capabilities`
- `go test -count=1 -vet=off ./internal/speccorpus ./internal/resolve ./internal/check ./internal/format`
- `git diff --check HEAD~1 HEAD`